### PR TITLE
fix(agent-gui): keep settled sessions from appearing busy

### DIFF
--- a/packages/agent/gui/agent-gui/agentGuiNode/AgentGUINode.spec.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/AgentGUINode.spec.tsx
@@ -2785,6 +2785,90 @@ describe("AgentGUINode", () => {
     expect(mockSubmitPrompt).not.toHaveBeenCalled();
   });
 
+  it("does not keep completed conversations busy when old transcript rows still contain running calls", () => {
+    const completedConversation = {
+      id: "session-1",
+      provider: "codex" as const,
+      title: "Session 1",
+      status: "completed" as const,
+      cwd: "/workspace",
+      updatedAtUnixMs: 1
+    };
+    const completedDetail = detailViewModel({
+      activity: {
+        ...detailViewModel().activity,
+        status: "completed" as const
+      },
+      session: {
+        ...detailViewModel().session,
+        lifecycleStatus: "ended",
+        turnPhase: "idle",
+        effectiveStatus: "completed"
+      }
+    });
+    mockViewModel = createViewModel({
+      activeConversationId: "session-1",
+      activeConversation: completedConversation,
+      conversations: [completedConversation],
+      conversationDetail: completedDetail,
+      conversation: {
+        activity: completedDetail.activity,
+        workspaceRoot: "/workspace",
+        sourceDetail: completedDetail,
+        rows: [
+          {
+            kind: "tool-group",
+            id: "tools-running",
+            turnId: "turn-1",
+            grouped: true,
+            calls: [
+              {
+                kind: "tool-call",
+                id: "call-running",
+                turnId: "turn-1",
+                name: "Read file",
+                toolName: "read_file",
+                callType: "tool",
+                status: "Running",
+                statusKind: "working",
+                summary: "/workspace/README.md",
+                compactSummary: null,
+                payload: null,
+                toolState: null,
+                input: null,
+                output: null,
+                error: null,
+                metadata: null,
+                content: null,
+                locations: null,
+                rendererKind: "default",
+                approval: null,
+                planMode: null,
+                askUserQuestion: null,
+                task: null,
+                occurredAtUnixMs: 1
+              }
+            ],
+            entries: [],
+            occurredAtUnixMs: 1
+          }
+        ],
+        pendingApproval: null,
+        pendingInteractivePrompt: null
+      },
+      canSubmit: false,
+      draftPrompt: "hello"
+    });
+    renderAgentGUINode();
+
+    expect(
+      screen.getAllByText("agentHost.workspaceAgentStatusCompleted").length
+    ).toBeGreaterThan(0);
+    expect(
+      screen.queryByRole("button", { name: "agentHost.agentGui.stop" })
+    ).toBeNull();
+  });
+
   it("keeps the send button in a loading state before switching to Stop", () => {
     mockViewModel = createViewModel({
       activeConversationId: "session-1",

--- a/packages/agent/gui/agent-gui/agentGuiNode/AgentGUINodeView.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/AgentGUINodeView.tsx
@@ -585,6 +585,15 @@ function conversationHasActiveWork(
   );
 }
 
+function isSettledConversationStatus(
+  status:
+    | AgentGUINodeViewModel["conversations"][number]["status"]
+    | null
+    | undefined
+): boolean {
+  return status === "completed" || status === "failed" || status === "canceled";
+}
+
 function resolveActiveConversationBusyStatus(input: {
   conversationStatus:
     | AgentGUINodeViewModel["conversations"][number]["status"]
@@ -603,6 +612,12 @@ function resolveActiveConversationBusyStatus(input: {
     input.detailStatus === "working"
   ) {
     return "working";
+  }
+  if (
+    isSettledConversationStatus(input.conversationStatus) ||
+    isSettledConversationStatus(input.detailStatus)
+  ) {
+    return null;
   }
   if (conversationHasActiveWork(input.conversation)) {
     return "working";


### PR DESCRIPTION
## What changed
- Treat completed, failed, and canceled Agent GUI conversations as settled before deriving busy state from transcript rows.
- Add a regression test for completed historical conversations that still contain a stale running tool-call row.

## Why
Historical shared conversations can contain orphan `call.started` / running rows even after the authoritative conversation detail is terminal. The GUI previously let those stale transcript rows keep the opened session in a loading/busy state, while the message center used the terminal session status and appeared normal.

## Risks / affected surfaces
- Affects Agent GUI busy/loading derivation for historical conversation detail views.
- Active conversations still derive waiting/working state from explicit pending/streaming status before settled-state suppression applies.

## Verification
- `pnpm --dir packages/agent/gui typecheck`
- `pnpm --dir packages/agent/gui test -- agent-gui/agentGuiNode/AgentGUINode.spec.tsx -t "does not keep completed conversations busy"`
- `git diff --check`
- pre-push `pnpm check:full`
