### PR TITLE
fix: preserve Tutti runtime artifact layout

### DIFF
--- a/.github/workflows/publish-tutti-app-runtime.yml
+++ b/.github/workflows/publish-tutti-app-runtime.yml
@@ -259,8 +259,27 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           pattern: tutti-app-runtime-*
-          path: tutti-app-runtime
-          merge-multiple: true
+          path: downloaded-tutti-app-runtime
+          merge-multiple: false
+
+      - name: Restore runtime artifact layout
+        shell: bash
+        run: |
+          rm -rf tutti-app-runtime
+          mkdir -p tutti-app-runtime
+          while IFS= read -r metadata_file; do
+            runtime_version="$(node -e "process.stdout.write(JSON.parse(require('fs').readFileSync(process.argv[1], 'utf8')).runtimeVersion)" "${metadata_file}")"
+            platform="$(node -e "process.stdout.write(JSON.parse(require('fs').readFileSync(process.argv[1], 'utf8')).platform)" "${metadata_file}")"
+            target_dir="tutti-app-runtime/${runtime_version}/${platform}"
+            mkdir -p "${target_dir}"
+            cp -R "$(dirname "${metadata_file}")/." "${target_dir}/"
+          done < <(find downloaded-tutti-app-runtime -name metadata.json -type f | sort)
+          metadata_count="$(find tutti-app-runtime -name metadata.json -type f | wc -l | tr -d ' ')"
+          if [ "${metadata_count}" -eq 0 ]; then
+            echo "No runtime metadata files were downloaded" >&2
+            exit 1
+          fi
+          echo "Restored ${metadata_count} runtime artifact metadata files."
 
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v4

--- a/tools/scripts/build-tutti-app-runtime-catalog.test.mjs
+++ b/tools/scripts/build-tutti-app-runtime-catalog.test.mjs
@@ -119,6 +119,13 @@ test("Tutti app runtime workflow publishes immutable artifacts and mutable catal
   assert.match(workflow, /npx-cli\.js/);
   assert.match(workflow, /\$\{node_staging\}\/node\/bin\/npm" --version/);
   assert.match(workflow, /\$\{node_staging\}\/node\/bin\/npx" --version/);
+  assert.match(workflow, /path: downloaded-tutti-app-runtime/);
+  assert.match(workflow, /merge-multiple: false/);
+  assert.match(workflow, /Restore runtime artifact layout/);
+  assert.match(
+    workflow,
+    /target_dir="tutti-app-runtime\/\$\{runtime_version\}\/\$\{platform\}"/
+  );
   assert.match(workflow, /build-tutti-app-runtime-catalog\.mjs/);
   assert.match(workflow, /max-age=31536000, immutable/);
   assert.match(workflow, /max-age=60/);


### PR DESCRIPTION
## Summary
- keep downloaded runtime artifacts separated by GitHub artifact name
- restore the expected tutti-app-runtime/<version>/<platform> layout before catalog generation and S3 upload
- add workflow assertions so runtime artifacts are not flattened again

## Verification
- node --test tools/scripts/build-tutti-app-runtime-catalog.test.mjs
- pre-push check:full