### PR TITLE
docs(readme): simplify header to banner-only with text fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,6 @@
 
 <img src="docs/assets/banner.jpg" alt="Tutti — where people and agents build in tune" width="720" />
 
-<img src="docs/assets/tutti-logo.png" alt="Tutti logo" width="120" />
-
 # Tutti
 
 **Where people and agents build in tune.**

--- a/README.md
+++ b/README.md
@@ -1,8 +1,6 @@
 <div align="center">
 
-<img src="docs/assets/banner.jpg" alt="Tutti — where people and agents build in tune" width="720" />
-
-# Tutti
+<img src="docs/assets/banner.jpg" alt="Tutti" width="720" />
 
 **Where people and agents build in tune.**
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -2,8 +2,6 @@
 
 <img src="docs/assets/banner.jpg" alt="Tutti —— 人与 Agent 同频协作的地方" width="720" />
 
-<img src="docs/assets/tutti-logo.png" alt="Tutti logo" width="120" />
-
 # Tutti
 
 **人与 Agent「同频」协作的地方。**

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -1,8 +1,6 @@
 <div align="center">
 
-<img src="docs/assets/banner.jpg" alt="Tutti —— 人与 Agent 同频协作的地方" width="720" />
-
-# Tutti
+<img src="docs/assets/banner.jpg" alt="Tutti" width="720" />
 
 **人与 Agent「同频」协作的地方。**
 

--- a/README.zh-TW.md
+++ b/README.zh-TW.md
@@ -2,8 +2,6 @@
 
 <img src="docs/assets/banner.jpg" alt="Tutti —— 人與 Agent 同頻協作的地方" width="720" />
 
-<img src="docs/assets/tutti-logo.png" alt="Tutti logo" width="120" />
-
 # Tutti
 
 **人與 Agent「同步協作」的工作空間。**

--- a/README.zh-TW.md
+++ b/README.zh-TW.md
@@ -1,8 +1,6 @@
 <div align="center">
 
-<img src="docs/assets/banner.jpg" alt="Tutti —— 人與 Agent 同頻協作的地方" width="720" />
-
-# Tutti
+<img src="docs/assets/banner.jpg" alt="Tutti" width="720" />
 
 **人與 Agent「同步協作」的工作空間。**
 


### PR DESCRIPTION
## Summary

The hero banner already contains the Tutti logo and wordmark, so the separate logo image and the `# Tutti` heading below it were both visual duplicates. This PR trims the header in all three READMEs (EN / zh-CN / zh-TW) down to just the banner.

**Changes**
- Removed the redundant `tutti-logo.png` `<img>` from the header.
- Removed the redundant `# Tutti` heading.
- Set the banner's `alt="Tutti"` so the brand name still appears as a text fallback if the image fails to load.

**Header before → after**

```
banner            banner
logo icon    →    tagline
# Tutti           links / badges
tagline
links / badges
```

## Note

`docs/assets/tutti-logo.png` is now unreferenced in the repo but left in place to avoid breaking any external links to it. It can be removed in a follow-up if preferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)