### PR TITLE
fix(agent): drive Claude Code model selection from the live agent

### DIFF
--- a/apps/desktop/src/renderer/src/features/workspace-agent/services/createDesktopAgentHostApi.test.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-agent/services/createDesktopAgentHostApi.test.ts
@@ -981,7 +981,9 @@ test("desktop agent host api loads composer options through tuttid without creat
     }
   });
 
-  assert.deepEqual(options.models, [{ value: "gpt-5", label: "gpt-5" }]);
+  // The live agent's advertised model list takes precedence over the static
+  // catalog, so the display name comes from runtimeContext.configOptions.
+  assert.deepEqual(options.models, [{ value: "gpt-5", label: "GPT-5" }]);
   assert.deepEqual(options.reasoningEfforts, [
     { value: "high", label: "high" }
   ]);

--- a/apps/desktop/src/renderer/src/features/workspace-agent/services/desktopAgentActivityAdapter.test.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-agent/services/desktopAgentActivityAdapter.test.ts
@@ -465,6 +465,59 @@ test("desktop agent activity adapter normalizes legacy runtime config options", 
   ]);
 });
 
+test("desktop agent activity adapter prefers live model list over static catalog", async () => {
+  const adapter = createDesktopAgentActivityAdapter({
+    tuttidClient: createTuttidClient({
+      async getAgentProviderComposerOptions(provider) {
+        return {
+          provider,
+          effectiveSettings: {},
+          modelConfig: {
+            configurable: true,
+            currentValue: "default",
+            options: [
+              { id: "default", value: "default", label: "default" },
+              { id: "opus", value: "opus", label: "opus" }
+            ]
+          },
+          permissionConfig: {
+            configurable: false,
+            modes: []
+          },
+          reasoningConfig: {
+            configurable: true,
+            options: []
+          },
+          runtimeContext: {
+            configOptions: [
+              {
+                id: "model",
+                currentValue: "default",
+                options: [
+                  { value: "default", name: "Default" },
+                  { value: "claude-opus-4-6", name: "Opus 4.6" }
+                ]
+              }
+            ]
+          },
+          skills: []
+        };
+      }
+    }),
+    runtimeApi: createRuntimeApi()
+  });
+
+  const options = await adapter.loadComposerOptions({
+    workspaceId,
+    provider: "claude-code"
+  });
+
+  assert.deepEqual(options.models, [
+    { value: "default", label: "Default" },
+    { value: "claude-opus-4-6", label: "Opus 4.6" }
+  ]);
+});
+
 function createTuttidClient(
   overrides: Partial<TuttidClient> = {}
 ): TuttidClient {

--- a/apps/desktop/src/renderer/src/features/workspace-agent/services/desktopAgentActivityAdapter.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-agent/services/desktopAgentActivityAdapter.ts
@@ -237,6 +237,13 @@ function agentActivityComposerOptionsFromTuttidResult(
   const modelConfig = recordValue(result.modelConfig);
   const reasoningConfig = recordValue(result.reasoningConfig);
   const modelsFromConfig = settingOptionsFromComposerConfig(modelConfig);
+  // The live agent's advertised model list reflects the models the running
+  // session can actually use (e.g. concrete ids like Opus 4.6), so it takes
+  // precedence over the pre-session static catalog when present. The static
+  // list remains the fallback before a session has advertised its options.
+  const modelsFromLiveConfig = settingOptionsFromConfigOption(rawConfigOptions, [
+    "model"
+  ]);
   const reasoningEffortsFromConfig =
     settingOptionsFromComposerConfig(reasoningConfig);
   const skillsFromResult = skillOptionsFromValue(result.skills);
@@ -244,9 +251,9 @@ function agentActivityComposerOptionsFromTuttidResult(
   return {
     provider: normalizeText(result.provider) ?? provider,
     models:
-      modelsFromConfig.length > 0
-        ? modelsFromConfig
-        : settingOptionsFromConfigOption(rawConfigOptions, ["model"]),
+      modelsFromLiveConfig.length > 0
+        ? modelsFromLiveConfig
+        : modelsFromConfig,
     reasoningEfforts:
       reasoningEffortsFromConfig.length > 0
         ? reasoningEffortsFromConfig

--- a/packages/agent/daemon/runtime/acp_live_state.go
+++ b/packages/agent/daemon/runtime/acp_live_state.go
@@ -474,6 +474,46 @@ func acpConfigOptionMatches(state acpLiveState, configID string, value string) b
 	return ok && strings.TrimSpace(asString(got)) == strings.TrimSpace(value)
 }
 
+// acpConfigOptionAdvertisesValue reports whether the live agent has advertised
+// value as a selectable option for configID (e.g. a concrete model id in the
+// "model" option). It lets callers accept any value the running agent will
+// actually honor, instead of relying on a hardcoded alias list.
+func acpConfigOptionAdvertisesValue(state acpLiveState, configID string, value string) bool {
+	configID = strings.TrimSpace(configID)
+	value = strings.TrimSpace(value)
+	if configID == "" || value == "" {
+		return false
+	}
+	for _, descriptor := range state.configOptionDescriptors {
+		if strings.TrimSpace(asString(descriptor["id"])) != configID {
+			continue
+		}
+		for _, option := range configOptionEntries(descriptor["options"]) {
+			if strings.TrimSpace(asString(option["value"])) == value {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func configOptionEntries(options any) []map[string]any {
+	switch items := options.(type) {
+	case []map[string]any:
+		return items
+	case []any:
+		out := make([]map[string]any, 0, len(items))
+		for _, item := range items {
+			if option, ok := item.(map[string]any); ok {
+				out = append(out, option)
+			}
+		}
+		return out
+	default:
+		return nil
+	}
+}
+
 func cloneConfigOptionDescriptors(descriptors []map[string]any) []map[string]any {
 	if len(descriptors) == 0 {
 		return nil

--- a/packages/agent/daemon/runtime/standard_acp_adapter.go
+++ b/packages/agent/daemon/runtime/standard_acp_adapter.go
@@ -1038,17 +1038,23 @@ func (a *standardACPAdapter) applySessionConfigOptions(
 		"model_requested":      strings.TrimSpace(settings.Model) != "",
 		"effort_requested":     strings.TrimSpace(settings.ReasoningEffort) != "",
 	})
+	// Startup config options are applied best-effort: a value the agent
+	// rejects (e.g. a model alias the signed-in account cannot access) must
+	// not abort the whole session. The session stays usable on the agent's
+	// default, and the user can pick a supported value from the live list.
 	if model := strings.TrimSpace(settings.Model); model != "" && a.shouldApplyACPModelConfigOption(model, supported) {
 		if err := a.setSessionConfigOption(ctx, client, session, "model", model); err != nil {
-			return fmt.Errorf("agent session ACP model configuration failed: %w", err)
+			a.logStartupConfigOptionRejected(session, "model", model, err)
+		} else {
+			a.updateSessionConfigOption(session.AgentSessionID, "model", model)
 		}
-		a.updateSessionConfigOption(session.AgentSessionID, "model", model)
 	}
 	if reasoning := strings.TrimSpace(settings.ReasoningEffort); reasoning != "" && supported["effort"] {
 		if err := a.setSessionConfigOption(ctx, client, session, "effort", reasoning); err != nil {
-			return fmt.Errorf("agent session ACP effort configuration failed: %w", err)
+			a.logStartupConfigOptionRejected(session, "effort", reasoning, err)
+		} else {
+			a.updateSessionConfigOption(session.AgentSessionID, "effort", reasoning)
 		}
-		a.updateSessionConfigOption(session.AgentSessionID, "effort", reasoning)
 	}
 	a.logHermesStartupDiagnostics("config_options.succeeded", map[string]any{
 		"room_id":             session.RoomID,
@@ -1056,6 +1062,25 @@ func (a *standardACPAdapter) applySessionConfigOptions(
 		"provider_session_id": session.ProviderSessionID,
 	})
 	return nil
+}
+
+func (a *standardACPAdapter) logStartupConfigOptionRejected(
+	session Session,
+	configID string,
+	value string,
+	err error,
+) {
+	slog.Warn("agent session ACP startup config option rejected; continuing on agent default",
+		"event", "agent_session.acp.config_option.rejected",
+		"provider", a.config.provider,
+		"adapter", a.config.adapterName,
+		"room_id", session.RoomID,
+		"agent_session_id", session.AgentSessionID,
+		"provider_session_id", session.ProviderSessionID,
+		"config_id", configID,
+		"value", value,
+		"error", err.Error(),
+	)
 }
 
 func (a *standardACPAdapter) shouldApplyACPModelConfigOption(model string, supported map[string]bool) bool {
@@ -1172,11 +1197,16 @@ func (a *standardACPAdapter) ApplySessionSettings(
 
 	if patch.Model != nil {
 		model := strings.TrimSpace(*patch.Model)
-		if a.config.provider == ProviderClaudeCode && model != "" && !claudeCodeACPModelAliases[model] {
+		// A model the live agent advertises as a selectable option can be
+		// switched in place via set_config_option, even if it is a concrete id
+		// (e.g. Opus 4.6) rather than one of the static aliases. Only models the
+		// running agent has not advertised still require a fresh session.
+		advertised := a.sessionConfigOptionAdvertisesValue(session.AgentSessionID, "model", model)
+		if a.config.provider == ProviderClaudeCode && model != "" && !claudeCodeACPModelAliases[model] && !advertised {
 			return errors.New("claude code custom model changes require a new session")
 		}
 		supported := map[string]bool{"model": true}
-		if a.shouldApplyACPModelConfigOption(model, supported) {
+		if advertised || a.shouldApplyACPModelConfigOption(model, supported) {
 			if !a.sessionConfigOptionMatches(session.AgentSessionID, "model", model) {
 				if err := a.setSessionConfigOption(ctx, acpSession.client, session, "model", model); err != nil {
 					return fmt.Errorf("agent session ACP model configuration failed: %w", err)
@@ -1700,6 +1730,19 @@ func (a *standardACPAdapter) sessionConfigOptionMatches(agentSessionID string, c
 		return false
 	}
 	return acpConfigOptionMatches(session.acpLiveState, configID, value)
+}
+
+func (a *standardACPAdapter) sessionConfigOptionAdvertisesValue(agentSessionID string, configID string, value string) bool {
+	if a == nil {
+		return false
+	}
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	session := a.sessions[strings.TrimSpace(agentSessionID)]
+	if session == nil {
+		return false
+	}
+	return acpConfigOptionAdvertisesValue(session.acpLiveState, configID, value)
 }
 
 func (a *standardACPAdapter) removeSession(agentSessionID string) {

--- a/packages/agent/daemon/runtime/standard_acp_adapter_test.go
+++ b/packages/agent/daemon/runtime/standard_acp_adapter_test.go
@@ -2173,6 +2173,87 @@ func TestClaudeCodeAdapterApplySessionSettingsRejectsCustomModel(t *testing.T) {
 	}
 }
 
+func TestClaudeCodeAdapterApplySessionSettingsSwitchesToAdvertisedModel(t *testing.T) {
+	t.Parallel()
+
+	transport := newStandardACPTransport("Claude Agent", "claude-session-advertised-model")
+	adapter := NewClaudeCodeAdapter(transport)
+	session := standardTestSession(ProviderClaudeCode)
+	session.Settings = &SessionSettings{
+		Model: "sonnet",
+	}
+
+	if _, err := adapter.Start(context.Background(), session); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+
+	// The live agent advertises a concrete model id (e.g. Opus 4.6) that is
+	// not one of the static aliases.
+	adapter.applyACPUpdate(session.AgentSessionID, json.RawMessage(`{
+		"update": {
+			"sessionUpdate": "config_option_update",
+			"key": "model",
+			"value": "default",
+			"configOptions": [
+				{
+					"id": "model",
+					"currentValue": "default",
+					"options": [
+						{"value": "default", "name": "Default"},
+						{"value": "claude-opus-4-6", "name": "Opus 4.6"}
+					]
+				}
+			]
+		}
+	}`))
+
+	if err := adapter.ApplySessionSettings(context.Background(), session, SessionSettingsPatch{
+		Model: stringPtr("claude-opus-4-6"),
+	}); err != nil {
+		t.Fatalf("ApplySessionSettings should switch to an advertised model, got: %v", err)
+	}
+
+	calls := transport.conn.setConfigOptionCalls()
+	if len(calls) == 0 {
+		t.Fatal("config option calls = none, want an advertised model switch call")
+	}
+	last := calls[len(calls)-1]
+	if got, _ := last["configId"].(string); got != "model" {
+		t.Fatalf("config id = %q, want model", got)
+	}
+	if got, _ := last["value"].(string); got != "claude-opus-4-6" {
+		t.Fatalf("config value = %q, want claude-opus-4-6", got)
+	}
+}
+
+func TestClaudeCodeAdapterStartToleratesRejectedModelConfig(t *testing.T) {
+	t.Parallel()
+
+	transport := newStandardACPTransport("Claude Agent", "claude-session-reject-model")
+	transport.conn.rejectModelValue = "opus"
+	adapter := NewClaudeCodeAdapter(transport)
+	session := standardTestSession(ProviderClaudeCode)
+	session.Settings = &SessionSettings{
+		Model: "opus",
+	}
+
+	if _, err := adapter.Start(context.Background(), session); err != nil {
+		t.Fatalf("Start should tolerate a rejected model config option, got: %v", err)
+	}
+
+	if adapter.getSession(session.AgentSessionID) == nil {
+		t.Fatal("session should remain live after a tolerated model rejection")
+	}
+
+	calls := transport.conn.setConfigOptionCalls()
+	if len(calls) != 1 {
+		t.Fatalf("config option calls = %#v, want one rejected model attempt", calls)
+	}
+	if got, _ := calls[0]["value"].(string); got != "opus" {
+		t.Fatalf("config value = %q, want opus", got)
+	}
+}
+
 func configOptionDescriptorValues(descriptors []map[string]any, configID string) []string {
 	for _, descriptor := range descriptors {
 		if strings.TrimSpace(asString(descriptor["id"])) != configID {
@@ -2519,6 +2600,7 @@ type standardACPConnection struct {
 	lastAuthenticatedMethodID    string
 	setModeError                 *acpError
 	loadSessionError             *acpError
+	rejectModelValue             string
 	supportsLoadSession          bool
 	isClosed                     bool
 	lastNewSessionParams         map[string]any
@@ -2670,7 +2752,24 @@ func (c *standardACPConnection) Send(data []byte) error {
 			if request.Params != nil {
 				c.setConfigOptionSnapshots = append(c.setConfigOptionSnapshots, maps.Clone(request.Params))
 			}
+			rejectModelValue := c.rejectModelValue
 			c.mu.Unlock()
+			if rejectModelValue != "" && request.Params != nil {
+				configID, _ := request.Params["configId"].(string)
+				value, _ := request.Params["value"].(string)
+				if configID == "model" && value == rejectModelValue {
+					c.sendJSON(map[string]any{
+						"jsonrpc": "2.0",
+						"id":      message.ID,
+						"error": &acpError{
+							Code:    -32603,
+							Message: "Internal error",
+							Data:    json.RawMessage(`{"details":"Invalid value for config option model: ` + value + `"}`),
+						},
+					})
+					return nil
+				}
+			}
 			c.sendJSON(map[string]any{
 				"jsonrpc": "2.0",
 				"id":      message.ID,

--- a/services/tuttid/service/agent/claude_model_catalog.go
+++ b/services/tuttid/service/agent/claude_model_catalog.go
@@ -41,12 +41,3 @@ func listClaudeCodeModels() []AgentModelOption {
 		"Claude Code model alias",
 	)
 }
-
-func claudeCodeStaticModelExists(model string) bool {
-	for _, option := range claudeCodeStaticModels {
-		if option.ID == model {
-			return true
-		}
-	}
-	return false
-}

--- a/services/tuttid/service/agent/model_config.go
+++ b/services/tuttid/service/agent/model_config.go
@@ -34,11 +34,10 @@ func readClaudeCodeConfiguredDefaultModel() string {
 		claudeConfigDir = filepath.Join(home, ".claude")
 	}
 	settings := readJSONRecord(filepath.Join(claudeConfigDir, "settings.json"))
-	model := normalizeModelID(settings["model"])
-	if model == "" || !claudeCodeStaticModelExists(model) {
-		return ""
-	}
-	return model
+	// Keep whatever model the user configured, including a concrete id
+	// (e.g. claude-opus-4-6) that is not one of the static aliases. Dropping it
+	// here is what hid the user's chosen model from the composer catalog.
+	return normalizeModelID(settings["model"])
 }
 
 func readGeminiConfiguredDefaultModel() string {

--- a/services/tuttid/service/agent/model_config_test.go
+++ b/services/tuttid/service/agent/model_config_test.go
@@ -1,0 +1,43 @@
+package agent
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestReadClaudeCodeConfiguredDefaultModelKeepsConcreteModel(t *testing.T) {
+	configDir := t.TempDir()
+	settingsPath := filepath.Join(configDir, "settings.json")
+	if err := os.WriteFile(settingsPath, []byte(`{"model":"claude-opus-4-6"}`), 0o600); err != nil {
+		t.Fatalf("write settings.json: %v", err)
+	}
+	t.Setenv("CLAUDE_CONFIG_DIR", configDir)
+
+	if got := readClaudeCodeConfiguredDefaultModel(); got != "claude-opus-4-6" {
+		t.Fatalf("readClaudeCodeConfiguredDefaultModel() = %q, want claude-opus-4-6", got)
+	}
+}
+
+func TestReadClaudeCodeConfiguredDefaultModelSurfacesInCatalog(t *testing.T) {
+	configDir := t.TempDir()
+	settingsPath := filepath.Join(configDir, "settings.json")
+	if err := os.WriteFile(settingsPath, []byte(`{"model":"claude-opus-4-6"}`), 0o600); err != nil {
+		t.Fatalf("write settings.json: %v", err)
+	}
+	t.Setenv("CLAUDE_CONFIG_DIR", configDir)
+
+	models := listClaudeCodeModels()
+	var found bool
+	for _, model := range models {
+		if model.ID == "claude-opus-4-6" {
+			found = true
+			if !model.IsDefault {
+				t.Fatalf("model %q should be marked default", model.ID)
+			}
+		}
+	}
+	if !found {
+		t.Fatalf("listClaudeCodeModels() = %#v, want it to include configured default claude-opus-4-6", models)
+	}
+}


### PR DESCRIPTION
## 问题

结合两份 P0 工单的报错截图与定位，二者实为**同一根因**：Claude Code 的模型列表是一份硬编码的静态别名目录（`claude-static`），与运行中的 `claude-agent-acp` 会话真实支持的模型解耦。

- **P0 #1 「claudecode 切换为非默认模型时报错无法使用」**（启动失败截图）
  切换到非默认别名（如 `opus`）后，启动阶段通过 `session/set_config_option` 下发该别名；当登录账号无法解析该别名时，agent 返回 `Invalid value for config option model: opus`，而该错误在启动阶段是**致命的**，导致整个会话「启动失败」。
- **P0 #2 「输入指令时无法查看/切换具体模型名（如 opus4.6）」**
  静态目录遮蔽了 live `configOptions`，具体版本模型从不出现在选单；即使可见，切换也会被「require a new session」拒绝。

## 改动

| 修复 | 文件 |
|---|---|
| 启动期 model/effort 配置改为**尽力而为**：被拒则记日志并回退到 agent 默认，不再中断会话 | `standard_acp_adapter.go` |
| `ApplySessionSettings` 允许切换到 live 会话**已广播**的任意模型（不再只限静态别名）；仅未广播的值才需新会话。新增 `acpConfigOptionAdvertisesValue` | `standard_acp_adapter.go`, `acp_live_state.go` |
| 桌面 composer 在 live 模型列表存在时优先采用它，具体模型（Opus 4.6）得以显示 | `desktopAgentActivityAdapter.ts` |
| `readClaudeCodeConfiguredDefaultModel` 不再丢弃用户在 `~/.claude/settings.json` 配置的、不在静态别名表内的具体模型；删除已无用的 `claudeCodeStaticModelExists` | `model_config.go`, `claude_model_catalog.go` |

设计前提：concrete 模型经 `ANTHROPIC_MODEL` env 在启动时固定（已有逻辑），alias 经 `set_config_option` 实时切换。本 PR 让 live 广播的模型也能实时切换，并让 alias 被拒时不再致命。

## 测试（全部 TDD：先红后绿）

- `TestClaudeCodeAdapterStartToleratesRejectedModelConfig` — 模型被拒后会话仍存活（#1）
- `TestClaudeCodeAdapterApplySessionSettingsSwitchesToAdvertisedModel` — 可切换到 live 广播的具体模型（#2）
- `TestReadClaudeCodeConfiguredDefaultModelKeepsConcreteModel` / `...SurfacesInCatalog` — 配置的具体模型不被丢弃且进入目录（#2）
- `desktop ... prefers live model list over static catalog` — 前端优先 live（#2）
- 既有 `RejectsCustomModel` / `HidesDirectCustomModelOption` 等仍通过（未广播的值仍要求新会话）

### 验证结果
- `go build ./...`（daemon + tuttid 两模块）exit 0；`go vet` 干净；`gofmt -l` 无输出
- `go test ./service/agent/`、runtime 模型相关测试全绿
- `node --test` 桌面 adapter 测试 8/8

### 说明
- runtime 包内 `TestControllerCancelStopsBackgroundTurn` 与 `TestClaudeCodeAdapterExecTreatsContextCanceledAsInterrupted` 为**既有的计时型 flaky 测试**（在干净 `origin/main` 上同样 ~3/6 概率失败，与本改动无关，单独运行均稳定通过）。
- 隔离 worktree 内无 `node_modules`，无法跑完整 `tsc`；但改动文件本身无类型错误，且逻辑由通过的 `node --test` 用例覆盖，完整 typecheck 交由 CI。
- 未做端到端真机验证（需真实 claude-agent-acp 账号环境）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)