### PR TITLE
[codex] fix Tutti app release version seed

### DIFF
--- a/.codex/skills/tutti-app-release/SKILL.md
+++ b/.codex/skills/tutti-app-release/SKILL.md
@@ -33,7 +33,7 @@ For catalog publication:
 
 For versioning:
 
-- Production releases should be workflow-driven. Run the production caller workflow with `release_bump` (`patch`, `minor`, or `major`); the reusable workflow calculates the next version from existing release tags and creates the tag after the S3 release verifies.
+- Production releases should be workflow-driven. Run the production caller workflow with `release_bump` (`patch`, `minor`, or `major`); the reusable workflow calculates the next version from the greater of the packaged manifest version and existing release tags, then creates the tag after the S3 release verifies.
 - The workflow never bumps or commits app manifest versions. Do not add caller-side release PRs or manifest bump commits to work around protected branches.
 - Staging releases should leave `release_bump` empty. The workflow uses `manifest.version+<short git sha>` from the packaged manifest and does not create a release tag.
 
@@ -72,9 +72,10 @@ apps/<appId>/latest.json
 
 For production, the workflow derives the next release version by fetching
 existing stable semver tags with the configured `release_tag_prefix` (default
-`<appId>-v`) and applying `release_bump`. It creates the annotated release tag
-after the S3 release has been uploaded and verified. If `release_bump` is empty,
-the workflow uses `manifest.version+<short git sha>` from the packaged manifest,
+`<appId>-v`), reading the packaged manifest version, and applying
+`release_bump` to the greater version. It creates the annotated release tag after
+the S3 release has been uploaded and verified. If `release_bump` is empty, the
+workflow uses `manifest.version+<short git sha>` from the packaged manifest,
 which is intended for staging.
 
 ## Reference Caller Workflow
@@ -183,7 +184,7 @@ Optional catalog inputs:
 
 - `publish_catalog`: after uploading the app release, merge that release into `catalog.json`. Default: `false`.
 - `catalog_only`: skip package build, release metadata generation, and app release upload; merge existing `apps/<appId>/latest.json` into `catalog.json`. Default: `false`.
-- `catalog_cloudfront_distribution_id`: CloudFront distribution id for invalidating `/<s3_prefix>/catalog.json` after catalog upload. Default: empty.
+- `catalog_cloudfront_distribution_id`: CloudFront distribution id for invalidating `/<s3_prefix>/catalog.json` after catalog upload. Default: empty. Caller workflows normally read this from `TUTTI_APP_RELEASES_PRODUCTION_CLOUDFRONT_DISTRIBUTION_ID` or `TUTTI_APP_RELEASES_CLOUDFRONT_DISTRIBUTION_ID`; prefer storing the shared value as an organization variable with selected repository access, and use repository variables only for overrides or when organization variables are unavailable. If neither variable is configured, invalidation is skipped and readers rely on the catalog cache TTL.
 
 Optional runtime/tooling inputs:
 
@@ -218,7 +219,7 @@ Recommended inputs for refresh/repair:
 
 - `catalog_mode`: `merge`
 - `app_ids`: the released remote app id, such as `vibe-design`
-- Leave AWS, S3, prefix, and CloudFront inputs empty unless overriding repository variables.
+- Leave AWS, S3, prefix, and CloudFront inputs empty unless overriding organization or repository variables.
 
 Use `replace` only for deliberate full catalog replacement. Built-in app ids such as `automation` are not published through the remote catalog workflow.
 
@@ -245,7 +246,7 @@ When `publish_catalog` or `catalog_only` is used in the app release workflow, th
 s3://<s3_bucket>/<s3_prefix>/catalog.json
 ```
 
-CloudFront invalidation requires permission for the matching distribution id. Store non-secret configuration such as role ARN and bucket name in GitHub Actions variables when possible.
+CloudFront invalidation requires permission for the matching distribution id. Store shared non-secret configuration such as the CloudFront distribution id in GitHub organization variables with selected repository access when possible; use repository variables only for repository-specific overrides.
 
 ## Local Validation
 

--- a/.github/workflows/publish-tutti-app-release.yml
+++ b/.github/workflows/publish-tutti-app-release.yml
@@ -176,6 +176,20 @@ jobs:
             return process.env.RELEASE_TAG_PREFIX || `${process.env.APP_ID}-v`;
           }
 
+          function parseStableVersion(version, source) {
+            const match = version.match(stableSemverPattern);
+            if (!match) {
+              return null;
+            }
+            return {
+              source,
+              version,
+              major: Number(match[1]),
+              minor: Number(match[2]),
+              patch: Number(match[3])
+            };
+          }
+
           function compareVersions(left, right) {
             for (const key of ["major", "minor", "patch"]) {
               if (left[key] !== right[key]) {
@@ -185,33 +199,30 @@ jobs:
             return 0;
           }
 
-          function nextVersionFromTags(prefix, bump) {
+          function nextVersionFromSources(prefix, bump, manifestVersion) {
             execFileSync("git", ["fetch", "--tags", "--force"], { stdio: "inherit" });
             const tags = execFileSync("git", ["tag", "--list"], { encoding: "utf8" })
               .split("\n")
               .map((tag) => tag.trim())
               .filter((tag) => tag.startsWith(prefix));
-            const versions = tags
-              .map((tag) => tag.slice(prefix.length))
-              .map((version) => {
-                const match = version.match(stableSemverPattern);
-                if (!match) {
-                  return null;
-                }
-                return {
-                  version,
-                  major: Number(match[1]),
-                  minor: Number(match[2]),
-                  patch: Number(match[3])
-                };
-              })
-              .filter(Boolean)
-              .sort(compareVersions);
-            const latest = versions.at(-1) ?? {
+            const manifestSeed = parseStableVersion(
+              manifestVersion,
+              "package manifest"
+            );
+            if (!manifestSeed) {
+              fail(`Package manifest version must be stable semver x.y.z when release_bump is used, got ${manifestVersion}.`);
+            }
+            const tagSeeds = tags
+              .map((tag) => parseStableVersion(tag.slice(prefix.length), `tag ${tag}`))
+              .filter(Boolean);
+            const latest = [manifestSeed, ...tagSeeds].sort(compareVersions).at(-1) ?? {
+              source: "default",
+              version: "0.0.0",
               major: 0,
               minor: 0,
               patch: 0
             };
+            console.log(`Resolved release version seed ${latest.version} from ${latest.source}.`);
 
             if (bump === "major") {
               return `${latest.major + 1}.0.0`;
@@ -230,20 +241,24 @@ jobs:
           }).trim();
           const releaseBump = process.env.RELEASE_BUMP;
           const shouldCreateTag = process.env.CREATE_RELEASE_TAG === "true";
+          const manifest = JSON.parse(
+            fs.readFileSync(`${process.env.PACKAGE_DIR}/tutti.app.json`, "utf8")
+          );
           let releaseVersion = "";
           let tagName = "";
 
           if (releaseBump) {
             const tagPrefix = defaultTagPrefix();
-            releaseVersion = nextVersionFromTags(tagPrefix, releaseBump);
+            releaseVersion = nextVersionFromSources(
+              tagPrefix,
+              releaseBump,
+              manifest.version
+            );
             tagName = `${tagPrefix}${releaseVersion}`;
           } else {
             if (shouldCreateTag) {
               fail("create_release_tag requires release_bump.");
             }
-            const manifest = JSON.parse(
-              fs.readFileSync(`${process.env.PACKAGE_DIR}/tutti.app.json`, "utf8")
-            );
             releaseVersion = `${manifest.version}+${gitSha.slice(0, 12)}`;
           }
 

--- a/docs/conventions/workspace-app-catalog.md
+++ b/docs/conventions/workspace-app-catalog.md
@@ -95,8 +95,9 @@ External app repositories should call `.github/workflows/publish-tutti-app-relea
 Production app releases are manually dispatched from GitHub Actions with a
 `release_bump` value of `patch`, `minor`, or `major`. The reusable workflow
 fetches existing tags with the configured `release_tag_prefix` (default
-`<appId>-v`), calculates the next stable semver version, publishes the S3
-release, verifies the artifact, then creates an annotated release tag such as
+`<appId>-v`), reads the packaged manifest version, calculates the next stable
+semver version from the greater of those sources, publishes the S3 release,
+verifies the artifact, then creates an annotated release tag such as
 `vibe-design-v1.2.4`. The workflow never edits or commits the source manifest.
 
 Staging app releases do not create release tags. When `release_bump` is empty,
@@ -112,6 +113,15 @@ invalidates the catalog path when `catalog_cloudfront_distribution_id` is set.
 The release upload role must be allowed to read and write that `catalog.json`
 object, and must have CloudFront invalidation permissions when invalidation is
 enabled.
+
+Caller workflows usually pass `catalog_cloudfront_distribution_id` from
+`TUTTI_APP_RELEASES_PRODUCTION_CLOUDFRONT_DISTRIBUTION_ID` or the shared
+`TUTTI_APP_RELEASES_CLOUDFRONT_DISTRIBUTION_ID` variable. Prefer configuring
+shared CloudFront distribution ids as organization variables with selected
+repository access, and use repository variables only for repository-specific
+overrides or temporary setup. When neither variable is configured, the input is
+empty, invalidation is skipped, and catalog readers rely on the `catalog.json`
+cache TTL.
 
 The release workflow also supports `catalog_only: true` for catalog repair and
 refresh operations. In catalog-only mode it skips package build, version bump,

--- a/tools/scripts/build-tutti-app-release.test.mjs
+++ b/tools/scripts/build-tutti-app-release.test.mjs
@@ -332,7 +332,14 @@ test("Tutti app release workflow is reusable by external app repositories", asyn
   assert.doesNotMatch(workflow, /github\.ref_type/);
   assert.match(workflow, /`\$\{process\.env\.APP_ID\}-v`/);
   assert.match(workflow, /git", \["fetch", "--tags", "--force"\]/);
-  assert.match(workflow, /nextVersionFromTags/);
+  assert.match(workflow, /parseStableVersion/);
+  assert.match(workflow, /nextVersionFromSources/);
+  assert.match(workflow, /manifest\.version/);
+  assert.match(workflow, /Package manifest version must be stable semver/);
+  assert.match(
+    workflow,
+    /Resolved release version seed \$\{latest\.version\} from \$\{latest\.source\}/
+  );
   assert.match(workflow, /release_bump requires create_release_tag/);
   assert.match(workflow, /create_release_tag requires release_bump/);
   assert.match(


### PR DESCRIPTION
## Summary

Fix the production Tutti app release version resolver so a repo with no historical release tags does not restart from `0.0.1` when its packaged `tutti.app.json` already carries a higher stable version.

## Root cause

The reusable workflow previously derived production versions only from existing `release_tag_prefix` tags. `vibe-design` had no historical `vibe-design-v*` tags, so its first workflow-driven patch release used `0.0.0` as the seed and published `0.0.1`, even though the packaged manifest was already `0.1.45`.

## Changes

- Resolve production release versions from the greater of:
  - stable semver release tags matching `release_tag_prefix`
  - the packaged manifest stable semver version
- Reject production `release_bump` runs when the packaged manifest version is not stable semver.
- Keep staging behavior unchanged: no bump uses `manifest.version+<short git sha>` and does not create release tags.
- Document the CloudFront distribution id variable used for catalog invalidation.
- Update workflow contract coverage for the new version seed behavior.

## Operational notes

I configured `TUTTI_APP_RELEASES_CLOUDFRONT_DISTRIBUTION_ID=E3I3IBVV1C4PH2` on the current release-related repos (`tutti`, `vibe-design`, `ai-media-canvas`, `group-chat`, and `tutti-apps`). AWS IAM simulation confirms the GitHub Actions role can call `cloudfront:CreateInvalidation` on that distribution.

After this lands, rerunning the `vibe-design` production workflow with `release_bump=patch` should seed from the packaged manifest `0.1.45`, so the next published version should be `0.1.46` rather than continuing from `0.0.1`.

## Validation

- `ruby -ryaml -e 'YAML.load_file(".github/workflows/publish-tutti-app-release.yml"); puts "ok"'`
- `pnpm --filter @tutti-os/app-release-tools test`
- `pnpm check:full` via pre-push hook
- `aws iam simulate-principal-policy` for `cloudfront:CreateInvalidation` on `E3I3IBVV1C4PH2`