### PR TITLE
[codex] fix workbench minimize preview capture

### DIFF
--- a/apps/desktop/src/renderer/src/features/workspace-workbench/services/internal/workspaceWorkbenchHostService.test.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/services/internal/workspaceWorkbenchHostService.test.ts
@@ -1,4 +1,5 @@
 import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
 import test from "node:test";
 import { TuttidProtocolError } from "@tutti-os/client-tuttid-ts";
 import { createI18nRuntime } from "@tutti-os/ui-i18n-runtime";
@@ -12,6 +13,11 @@ import {
   createTerminalCloseDialogRequest,
   createWindowCloseDialogRequest
 } from "./workspaceCloseDialogRequests.ts";
+
+const workspaceWorkbenchHostServiceSource = readFileSync(
+  new URL("./workspaceWorkbenchHostService.ts", import.meta.url),
+  "utf8"
+);
 
 test("shouldCloseTerminalNodeAfterError closes stale terminal nodes", () => {
   assert.equal(
@@ -138,4 +144,23 @@ test("createWindowCloseDialogRequest summarizes close effects for window close",
     title: "Close this window?",
     variant: "destructive"
   });
+});
+
+test("desktop dock preview capture avoids visible window isolation", () => {
+  assert.match(
+    workspaceWorkbenchHostServiceSource,
+    /isForegroundWorkspaceNodeCaptureTarget\(windowElement\)/
+  );
+  assert.match(
+    workspaceWorkbenchHostServiceSource,
+    /const capturePromise = hostWindowApi\.capturePreview\(\{/
+  );
+  assert.doesNotMatch(
+    workspaceWorkbenchHostServiceSource,
+    new RegExp("data-workbench-" + "preview-capture-" + "active")
+  );
+  assert.doesNotMatch(
+    workspaceWorkbenchHostServiceSource,
+    new RegExp("captureIsolated" + "WorkspaceWindowPreview")
+  );
 });

--- a/apps/desktop/src/renderer/src/features/workspace-workbench/services/internal/workspaceWorkbenchHostService.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/services/internal/workspaceWorkbenchHostService.ts
@@ -98,7 +98,6 @@ import {
 const workspaceDockNativePreviewMaxWidthPx = 260;
 const workspaceDockNativePreviewMaxHeightPx = 170;
 const workspaceDockNativePreviewTimeoutMs = 2_500;
-let isolatedWorkspaceWindowPreviewQueue: Promise<void> = Promise.resolve();
 
 export interface WorkspaceWorkbenchHostServiceDependencies {
   agentProviderStatusService: AgentProviderStatusService;
@@ -773,6 +772,10 @@ function createDesktopWorkspaceNodePreviewCapture(
     }
 
     const { captureTarget, windowElement } = captureContext;
+    if (!isForegroundWorkspaceNodeCaptureTarget(windowElement)) {
+      return null;
+    }
+
     const rect = captureTarget.getBoundingClientRect();
     if (rect.width <= 0 || rect.height <= 0) {
       logDockPreviewCaptureDiagnostic(runtimeApi, workspaceId, {
@@ -828,20 +831,16 @@ function createDesktopWorkspaceNodePreviewCapture(
 
     let captureResult: DockPreviewCaptureResult;
     try {
-      const capturePromise = captureIsolatedWorkspaceWindowPreview(
-        windowElement,
-        () =>
-          hostWindowApi.capturePreview({
-            maxHeight: workspaceDockNativePreviewMaxHeightPx,
-            maxWidth: workspaceDockNativePreviewMaxWidthPx,
-            rect: {
-              height: rect.height,
-              width: rect.width,
-              x: rect.left,
-              y: rect.top
-            }
-          })
-      );
+      const capturePromise = hostWindowApi.capturePreview({
+        maxHeight: workspaceDockNativePreviewMaxHeightPx,
+        maxWidth: workspaceDockNativePreviewMaxWidthPx,
+        rect: {
+          height: rect.height,
+          width: rect.width,
+          x: rect.left,
+          y: rect.top
+        }
+      });
       capturePromise.catch(() => undefined);
       captureResult = await resolveDockPreviewCaptureWithTimeout(
         capturePromise,
@@ -923,73 +922,10 @@ function resolveNativeCaptureBlockReason(
   return null;
 }
 
-function captureIsolatedWorkspaceWindowPreview(
-  windowElement: HTMLElement,
-  capturePreview: () => Promise<string | null>
-): Promise<string | null> {
-  return enqueueIsolatedWorkspaceWindowPreviewCapture(() =>
-    runIsolatedWorkspaceWindowPreviewCapture(windowElement, capturePreview)
-  );
-}
-
-function enqueueIsolatedWorkspaceWindowPreviewCapture(
-  task: () => Promise<string | null>
-): Promise<string | null> {
-  const result = isolatedWorkspaceWindowPreviewQueue.then(task, task);
-  isolatedWorkspaceWindowPreviewQueue = result.then(
-    () => undefined,
-    () => undefined
-  );
-  return result;
-}
-
-function runIsolatedWorkspaceWindowPreviewCapture(
-  windowElement: HTMLElement,
-  capturePreview: () => Promise<string | null>
-): Promise<string | null> {
-  const activeAttribute = "data-workbench-preview-capture-active";
-  const targetAttribute = "data-workbench-preview-capture-target";
-  const styleElement = document.createElement("style");
-  styleElement.textContent = `
-html[${activeAttribute}="true"] [data-workbench-window-id]:not([${targetAttribute}="true"]),
-html[${activeAttribute}="true"] [data-desktop-dock-popup-root],
-html[${activeAttribute}="true"] [data-radix-popper-content-wrapper] {
-  visibility: hidden !important;
-}
-`;
-
-  const previousActiveValue =
-    document.documentElement.getAttribute(activeAttribute);
-  const previousTargetValue = windowElement.getAttribute(targetAttribute);
-  document.head.appendChild(styleElement);
-  windowElement.setAttribute(targetAttribute, "true");
-  document.documentElement.setAttribute(activeAttribute, "true");
-
-  return waitForAnimationFrame()
-    .then(waitForAnimationFrame)
-    .then(capturePreview)
-    .finally(() => {
-      if (previousTargetValue === null) {
-        windowElement.removeAttribute(targetAttribute);
-      } else {
-        windowElement.setAttribute(targetAttribute, previousTargetValue);
-      }
-      if (previousActiveValue === null) {
-        document.documentElement.removeAttribute(activeAttribute);
-      } else {
-        document.documentElement.setAttribute(
-          activeAttribute,
-          previousActiveValue
-        );
-      }
-      styleElement.remove();
-    });
-}
-
-function waitForAnimationFrame(): Promise<void> {
-  return new Promise((resolve) => {
-    window.requestAnimationFrame(() => resolve());
-  });
+function isForegroundWorkspaceNodeCaptureTarget(
+  windowElement: HTMLElement
+): boolean {
+  return windowElement.dataset.focused === "true";
 }
 
 type DockPreviewCaptureResult =

--- a/packages/workbench/surface/src/react/useWorkbenchGenieAnimation.test.ts
+++ b/packages/workbench/surface/src/react/useWorkbenchGenieAnimation.test.ts
@@ -39,3 +39,15 @@ test("genie dock launch does not synchronously flush missing nodes", () => {
     /const shouldAnimate = target\?\.isMinimized === true \|\| !target;/
   );
 });
+
+test("genie minimize foregrounds the target before preview capture", () => {
+  assert.match(source, /function isFocusedWorkbenchNode/);
+  assert.match(
+    source,
+    /controller\.commands\.focusNode\(nodeID\);\s*\}\);\s*await waitForNextAnimationFrame\(\);/
+  );
+  assert.match(
+    source,
+    /const previewImageUrlPromise = Promise\.resolve\(\s*captureNodePreviewImage\?\.\(target\) \?\? null\s*\)/
+  );
+});

--- a/packages/workbench/surface/src/react/useWorkbenchGenieAnimation.tsx
+++ b/packages/workbench/surface/src/react/useWorkbenchGenieAnimation.tsx
@@ -58,6 +58,19 @@ function resolveWorkbenchCaptureElement(
   );
 }
 
+function waitForNextAnimationFrame(): Promise<void> {
+  return new Promise((resolve) => {
+    window.requestAnimationFrame(() => resolve());
+  });
+}
+
+function isFocusedWorkbenchNode<TData>(
+  controller: WorkbenchController<TData>,
+  nodeID: string
+): boolean {
+  return controller.getSnapshot().nodeStack.at(-1) === nodeID;
+}
+
 export interface WorkbenchGenieController {
   genieLayer: ReactNode;
   isNodeGenieHidden: (nodeID: string) => boolean;
@@ -678,9 +691,7 @@ export function useWorkbenchGenieAnimation<TData>({
         return;
       }
 
-      await new Promise<void>((resolve) => {
-        window.requestAnimationFrame(() => resolve());
-      });
+      await waitForNextAnimationFrame();
       if (generation !== animationGenerationRef.current) {
         return;
       }
@@ -806,6 +817,16 @@ export function useWorkbenchGenieAnimation<TData>({
         const runMinimize =
           minimize ?? (() => controller.commands.minimizeNode(nodeID));
         if (shouldReduceMotion()) {
+          const wasFocusedForCapture = isFocusedWorkbenchNode(
+            controller,
+            nodeID
+          );
+          if (!wasFocusedForCapture) {
+            flushSync(() => {
+              controller.commands.focusNode(nodeID);
+            });
+            await waitForNextAnimationFrame();
+          }
           await captureWorkbenchNodePreviewImageForNode(target, {
             captureNodePreviewImage,
             dockPreviewCache,
@@ -830,6 +851,16 @@ export function useWorkbenchGenieAnimation<TData>({
         if (!preparedTexture) {
           runMinimize();
           return;
+        }
+        const wasFocusedForCapture = isFocusedWorkbenchNode(controller, nodeID);
+        if (!wasFocusedForCapture) {
+          flushSync(() => {
+            controller.commands.focusNode(nodeID);
+          });
+          await waitForNextAnimationFrame();
+          if (generation !== animationGenerationRef.current) {
+            return;
+          }
         }
         const previewImageUrlPromise = Promise.resolve(
           captureNodePreviewImage?.(target) ?? null
@@ -884,9 +915,7 @@ export function useWorkbenchGenieAnimation<TData>({
           runMinimize();
         });
 
-        await new Promise<void>((resolve) => {
-          window.requestAnimationFrame(() => resolve());
-        });
+        await waitForNextAnimationFrame();
         if (generation !== animationGenerationRef.current) {
           releaseMinimizedDockEnterAnimation(nodeID);
           return;


### PR DESCRIPTION
## Summary

- Remove the isolated workbench preview capture path that temporarily hid sibling workspace windows.
- Keep desktop native preview capture restricted to the foreground/focused workbench window.
- Foreground the target workbench node before minimize preview capture so background minimize can use the normal native capture path without hiding other windows.
- Add source-level regressions for the foreground guard, removal of the old isolation markers, and focus-before-preview ordering.

## Verification

- `pnpm --filter @tutti-os/workbench-surface exec node --test --experimental-strip-types ./src/react/useWorkbenchGenieAnimation.test.ts`
- `pnpm --filter @tutti-os/desktop exec node --test --experimental-strip-types ./src/renderer/src/features/workspace-workbench/services/internal/workspaceWorkbenchHostService.test.ts`
- `pnpm --filter @tutti-os/workbench-surface typecheck`
- `pnpm --filter @tutti-os/desktop typecheck`
- `pnpm lint:ts`
- `pnpm check:full` via pre-push
