### PR TITLE
[codex] Add reusable external PR review gate

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,0 @@
-# Current repository members own all paths.
-* @rhinoc @vorshen @SingleMai @hugozhou-ai @jomeswang @devRickyyy @copper6666 @chovy-ai @svenzeng1021-boop @rv4no

--- a/.github/workflows/external-pr-review-gate.yml
+++ b/.github/workflows/external-pr-review-gate.yml
@@ -1,0 +1,30 @@
+name: External PR Review Gate
+
+on:
+  pull_request_target:
+    types:
+      - opened
+      - reopened
+      - ready_for_review
+      - synchronize
+  pull_request_review:
+    types:
+      - submitted
+      - edited
+      - dismissed
+
+permissions:
+  contents: read
+  pull-requests: write
+  statuses: write
+
+jobs:
+  external-pr-review-gate:
+    uses: tutti-os/tutti/.github/workflows/reusable-external-pr-review-gate.yml@main
+    with:
+      pr_number: ${{ github.event.pull_request.number }}
+      pr_author: ${{ github.event.pull_request.user.login }}
+      pr_head_sha: ${{ github.event.pull_request.head.sha }}
+      pr_is_draft: ${{ github.event.pull_request.draft }}
+      review_team_slug: tutti-rd
+      status_context: external-pr-review-gate

--- a/.github/workflows/reusable-external-pr-review-gate.yml
+++ b/.github/workflows/reusable-external-pr-review-gate.yml
@@ -1,0 +1,153 @@
+name: Reusable External PR Review Gate
+
+on:
+  workflow_call:
+    inputs:
+      pr_number:
+        description: Pull request number to evaluate.
+        required: true
+        type: number
+      pr_author:
+        description: Pull request author login.
+        required: true
+        type: string
+      pr_head_sha:
+        description: Pull request current head commit SHA.
+        required: true
+        type: string
+      pr_is_draft:
+        description: Whether the pull request is currently a draft.
+        required: true
+        type: boolean
+      review_team_slug:
+        description: Organization team slug that owns external contribution review.
+        required: false
+        type: string
+        default: tutti-rd
+      status_context:
+        description: Commit status context used by branch protection.
+        required: false
+        type: string
+        default: external-pr-review-gate
+
+permissions:
+  contents: read
+  pull-requests: write
+  statuses: write
+
+jobs:
+  external-pr-review-gate:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Enforce official review for external PRs
+        uses: actions/github-script@v8
+        with:
+          script: |
+            const org = context.repo.owner;
+            const repo = context.repo.repo;
+            const teamSlug = '${{ inputs.review_team_slug }}';
+            const statusContext = '${{ inputs.status_context }}';
+            const prNumber = Number('${{ inputs.pr_number }}');
+            const author = '${{ inputs.pr_author }}';
+            const headSha = '${{ inputs.pr_head_sha }}';
+            const isDraft = '${{ inputs.pr_is_draft }}' === 'true';
+            const runUrl = `${process.env.GITHUB_SERVER_URL}/${org}/${repo}/actions/runs/${process.env.GITHUB_RUN_ID}`;
+
+            async function setGateStatus(state, description) {
+              await github.rest.repos.createCommitStatus({
+                owner: org,
+                repo,
+                sha: headSha,
+                state,
+                context: statusContext,
+                description,
+                target_url: runUrl,
+              });
+            }
+
+            if (isDraft) {
+              await setGateStatus('success', 'Draft PRs are not gated until ready for review.');
+              core.info('Draft PR; review gate is not enforced yet.');
+              return;
+            }
+
+            let isOfficial = false;
+            try {
+              const membership = await github.rest.teams.getMembershipForUserInOrg({
+                org,
+                team_slug: teamSlug,
+                username: author,
+              });
+              isOfficial = membership.data.state === 'active';
+            } catch (error) {
+              if (error.status !== 404) {
+                throw error;
+              }
+            }
+
+            if (isOfficial) {
+              await setGateStatus('success', `${author} is in ${org}/${teamSlug}.`);
+              core.info(`${author} is in ${org}/${teamSlug}; no review request needed.`);
+              return;
+            }
+
+            try {
+              await github.rest.pulls.requestReviewers({
+                owner: org,
+                repo,
+                pull_number: prNumber,
+                team_reviewers: [teamSlug],
+              });
+              core.info(`Requested ${org}/${teamSlug} review for PR from ${author}.`);
+            } catch (error) {
+              if (error.status === 422) {
+                core.info(`Review request already exists or cannot be added: ${error.message}`);
+              } else {
+                throw error;
+              }
+            }
+
+            const teamMembers = await github.paginate(github.rest.teams.listMembersInOrg, {
+              org,
+              team_slug: teamSlug,
+              per_page: 100,
+            });
+            const officialLogins = new Set(teamMembers.map((member) => member.login));
+            const reviews = await github.paginate(github.rest.pulls.listReviews, {
+              owner: org,
+              repo,
+              pull_number: prNumber,
+              per_page: 100,
+            });
+
+            const latestDecisionByReviewer = new Map();
+            for (const review of reviews) {
+              const reviewer = review.user?.login;
+              if (!reviewer || !officialLogins.has(reviewer)) {
+                continue;
+              }
+              if (review.commit_id !== headSha) {
+                continue;
+              }
+              if (!['APPROVED', 'CHANGES_REQUESTED', 'DISMISSED'].includes(review.state)) {
+                continue;
+              }
+              latestDecisionByReviewer.set(reviewer, review.state);
+            }
+
+            const latestDecisions = Array.from(latestDecisionByReviewer.values());
+            if (latestDecisions.includes('CHANGES_REQUESTED')) {
+              await setGateStatus('failure', `External PR has changes requested by ${teamSlug}.`);
+              core.setFailed(`External PR #${prNumber} has changes requested by ${org}/${teamSlug}.`);
+              return;
+            }
+
+            if (latestDecisions.includes('APPROVED')) {
+              await setGateStatus('success', `External PR approved by ${teamSlug}.`);
+              core.info(`External PR #${prNumber} has ${org}/${teamSlug} approval for ${headSha}.`);
+              return;
+            }
+
+            await setGateStatus('failure', `External PR requires ${teamSlug} approval.`);
+            core.setFailed(`External PR #${prNumber} requires approval from ${org}/${teamSlug}.`);


### PR DESCRIPTION
## Summary

- Add a reusable external PR review gate workflow owned by `tutti-os/tutti`.
- Add a thin caller workflow for the `tutti` repo itself.
- Remove catch-all CODEOWNERS so internal RD PRs do not automatically request reviewers.

## Behavior

- Authors in `tutti-os/tutti-rd` pass `external-pr-review-gate` automatically.
- Authors outside `tutti-rd` automatically request `@tutti-os/tutti-rd` review and fail the gate until the current head commit has an approval from that team.
- `CHANGES_REQUESTED` by a `tutti-rd` reviewer fails the gate.

## Validation

- Parsed all `.github/workflows/*.yml` with Ruby `YAML.load_file`.
- `git diff --check`
- `pnpm check:full` via pre-push hook