### PR TITLE
[codex] preserve agent display prompts and fix electron install

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
   },
   "pnpm": {
     "overrides": {
-      "@radix-ui/react-slot": "1.2.5"
+      "@radix-ui/react-slot": "1.2.5",
+      "yauzl": "3.4.0"
     }
   },
   "scripts": {

--- a/packages/agent/activity-core/src/selectors.test.ts
+++ b/packages/agent/activity-core/src/selectors.test.ts
@@ -302,6 +302,14 @@ test("needs-attention selectors use summary and timestamp fallbacks", () => {
   const items = selectNeedsAttentionItems(
     snapshotWithMessages([
       message({
+        messageId: "display-prompt",
+        payload: {
+          displayPrompt: "Display prompt wins",
+          summary: "Summary loses"
+        },
+        occurredAtUnixMs: 60
+      }),
+      message({
         messageId: "summary",
         payload: { summary: "Summary wins", title: "Title loses" },
         occurredAtUnixMs: 50
@@ -313,7 +321,7 @@ test("needs-attention selectors use summary and timestamp fallbacks", () => {
       }),
       message({
         messageId: "content",
-        payload: { content: "Content wins", text: "Text loses" },
+        payload: { content: "Content loses", text: "Text wins" },
         completedAtUnixMs: 30
       }),
       message({
@@ -330,9 +338,10 @@ test("needs-attention selectors use summary and timestamp fallbacks", () => {
   assert.deepEqual(
     items.map((item) => [item.id, item.summary, item.occurredAtUnixMs]),
     [
+      ["session-1:display-prompt", "Display prompt wins", 60],
       ["session-1:summary", "Summary wins", 50],
       ["session-1:title", "Title wins", 40],
-      ["session-1:content", "Content wins", 30],
+      ["session-1:content", "Text wins", 30],
       ["session-1:kind", "message.assistant", 1],
       ["session-1:text", "Text wins", 1]
     ]

--- a/packages/agent/activity-core/src/selectors.ts
+++ b/packages/agent/activity-core/src/selectors.ts
@@ -235,10 +235,11 @@ function needsAttentionItemFromMessage(
 
 function messageSummary(message: AgentActivityMessage): string {
   return (
+    stringValue(message.payload.displayPrompt) ||
     stringValue(message.payload.summary) ||
     stringValue(message.payload.title) ||
-    stringValue(message.payload.content) ||
     stringValue(message.payload.text) ||
+    stringValue(message.payload.content) ||
     message.kind
   );
 }

--- a/packages/agent/daemon/activity/runtime_projection.go
+++ b/packages/agent/daemon/activity/runtime_projection.go
@@ -676,11 +676,14 @@ func timelineDisplayMessageRole(item WorkspaceAgentTimelineItem) string {
 
 func timelineDisplayMessageContent(item WorkspaceAgentTimelineItem) string {
 	if item.Payload != nil {
-		if content, ok := item.Payload["content"].(string); ok && strings.TrimSpace(content) != "" {
-			return content
+		if displayPrompt, ok := item.Payload["displayPrompt"].(string); ok && strings.TrimSpace(displayPrompt) != "" {
+			return displayPrompt
 		}
 		if text, ok := item.Payload["text"].(string); ok && strings.TrimSpace(text) != "" {
 			return text
+		}
+		if content, ok := item.Payload["content"].(string); ok && strings.TrimSpace(content) != "" {
+			return content
 		}
 	}
 	return ""

--- a/packages/agent/daemon/runtime/codex_adapter.go
+++ b/packages/agent/daemon/runtime/codex_adapter.go
@@ -507,10 +507,7 @@ func (a *CodexAdapter) Exec(
 		return nil, ErrSessionDisconnected
 	}
 	session.ProviderSessionID = acpSession.providerSessionID
-	trimmedDisplayPrompt := strings.TrimSpace(displayPrompt)
-	if trimmedDisplayPrompt == "" {
-		trimmedDisplayPrompt = promptDisplayText(content)
-	}
+	explicitDisplayPrompt, visibleText := explicitAndVisiblePromptText(content, displayPrompt)
 	normalizer := newACPTurnNormalizer()
 	var events []activityshared.Event
 	emitEvents := func(next []activityshared.Event) {
@@ -523,14 +520,12 @@ func (a *CodexAdapter) Exec(
 		}
 	}
 	startEvents := make([]activityshared.Event, 0, 3)
-	if fallbackTitle := fallbackACPFamilySessionTitle(session.Title, trimmedDisplayPrompt, a.config.fallbackTitles...); fallbackTitle != "" {
+	if fallbackTitle := fallbackACPFamilySessionTitle(session.Title, visibleText, a.config.fallbackTitles...); fallbackTitle != "" {
 		startEvents = append(startEvents, newSessionTitleActivityEvent(session, fallbackTitle))
 		session.Title = fallbackTitle
 	}
 	startEvents = append(startEvents,
-		newTurnActivityEvent(session, EventMessage, turnID, "", RoleUser, trimmedDisplayPrompt, map[string]any{
-			"content": promptContentForActivity(content),
-		}),
+		newTurnActivityEvent(session, EventMessage, turnID, "", RoleUser, visibleText, userPromptActivityPayload(content, explicitDisplayPrompt, nil)),
 		newTurnActivityEvent(session, EventTurnStarted, turnID, SessionStatusWorking, "", "", nil),
 	)
 	emitEvents(startEvents)

--- a/packages/agent/daemon/runtime/codex_adapter_test.go
+++ b/packages/agent/daemon/runtime/codex_adapter_test.go
@@ -922,6 +922,10 @@ func TestCodexAdapterExecUsesDisplayPromptForUserMessageOnly(t *testing.T) {
 	if !hasActivityMessage(emittedActivity, activityshared.MessageRoleUser, "Run Automation") {
 		t.Fatalf("emitted events = %#v, missing display prompt user message", emittedActivity)
 	}
+	userMessages := activityMessagesWithRole(emittedActivity, activityshared.MessageRoleUser)
+	if len(userMessages) == 0 || userMessages[0].Payload.Metadata["displayPrompt"] != "Run Automation" {
+		t.Fatalf("user message metadata = %#v, want display prompt", userMessages)
+	}
 	if hasActivityMessage(emittedActivity, activityshared.MessageRoleUser, "real automation prompt") {
 		t.Fatalf("emitted events = %#v, leaked provider prompt as user message", emittedActivity)
 	}

--- a/packages/agent/daemon/runtime/codex_appserver_adapter.go
+++ b/packages/agent/daemon/runtime/codex_appserver_adapter.go
@@ -601,13 +601,10 @@ func (a *CodexAppServerAdapter) Exec(
 		return nil, ErrSessionDisconnected
 	}
 	session.ProviderSessionID = appSession.threadID
-	trimmedDisplayPrompt := strings.TrimSpace(displayPrompt)
-	if trimmedDisplayPrompt == "" {
-		trimmedDisplayPrompt = promptDisplayText(content)
-	}
+	explicitDisplayPrompt, visibleText := explicitAndVisiblePromptText(content, displayPrompt)
 
 	if activeTurnID := a.sessionActiveTurnID(session.AgentSessionID); activeTurnID != "" {
-		return a.steerActiveTurn(ctx, appSession, session, content, trimmedDisplayPrompt, turnID, activeTurnID, emit)
+		return a.steerActiveTurn(ctx, appSession, session, content, explicitDisplayPrompt, visibleText, turnID, activeTurnID, emit)
 	}
 
 	normalizer := newACPTurnNormalizer()
@@ -654,14 +651,12 @@ func (a *CodexAppServerAdapter) Exec(
 		return append([]activityshared.Event(nil), events...)
 	}
 	startEvents := make([]activityshared.Event, 0, 3)
-	if fallbackTitle := fallbackACPFamilySessionTitle(session.Title, trimmedDisplayPrompt, "", ProviderCodex); fallbackTitle != "" {
+	if fallbackTitle := fallbackACPFamilySessionTitle(session.Title, visibleText, "", ProviderCodex); fallbackTitle != "" {
 		startEvents = append(startEvents, newSessionTitleActivityEvent(session, fallbackTitle))
 		session.Title = fallbackTitle
 	}
 	startEvents = append(startEvents,
-		newTurnActivityEvent(session, EventMessage, turnID, "", RoleUser, trimmedDisplayPrompt, map[string]any{
-			"content": promptContentForActivity(content),
-		}),
+		newTurnActivityEvent(session, EventMessage, turnID, "", RoleUser, visibleText, userPromptActivityPayload(content, explicitDisplayPrompt, nil)),
 		newTurnActivityEvent(session, EventTurnStarted, turnID, SessionStatusWorking, "", "", nil),
 	)
 	emitEvents(startEvents)
@@ -680,7 +675,7 @@ func (a *CodexAppServerAdapter) Exec(
 	}
 	defer a.endActiveTurn(session.AgentSessionID, appTurn)
 
-	if handled, err := a.execSlashCommand(ctx, appSession, session, trimmedDisplayPrompt, turnID, appTurn, normalizer, emitEvents, emitTerminal, emitCommands); handled {
+	if handled, err := a.execSlashCommand(ctx, appSession, session, visibleText, turnID, appTurn, normalizer, emitEvents, emitTerminal, emitCommands); handled {
 		return snapshotEvents(), err
 	}
 
@@ -808,6 +803,7 @@ func (a *CodexAppServerAdapter) steerActiveTurn(
 	appSession *codexAppServerSession,
 	session Session,
 	content []PromptContentBlock,
+	explicitDisplayPrompt string,
 	displayPrompt string,
 	turnID string,
 	activeTurnID string,
@@ -822,10 +818,9 @@ func (a *CodexAppServerAdapter) steerActiveTurn(
 		return nil, err
 	}
 	events := []activityshared.Event{
-		newTurnActivityEvent(session, EventMessage, turnID, "", RoleUser, displayPrompt, map[string]any{
-			"content": promptContentForActivity(content),
+		newTurnActivityEvent(session, EventMessage, turnID, "", RoleUser, displayPrompt, userPromptActivityPayload(content, explicitDisplayPrompt, map[string]any{
 			"steered": true,
-		}),
+		})),
 	}
 	if emit != nil {
 		emit(events)

--- a/packages/agent/daemon/runtime/controller.go
+++ b/packages/agent/daemon/runtime/controller.go
@@ -449,9 +449,6 @@ func (c *Controller) Exec(_ context.Context, input ExecInput) (ExecResult, error
 		return ExecResult{}, fmt.Errorf("prompt is required")
 	}
 	displayPrompt := strings.TrimSpace(input.DisplayPrompt)
-	if displayPrompt == "" {
-		displayPrompt = promptDisplayText(content)
-	}
 	if promptAdapter, ok := adapter.(PromptContentAdapter); ok {
 		if err := promptAdapter.ValidatePromptContent(session, content); err != nil {
 			return ExecResult{}, err

--- a/packages/agent/daemon/runtime/controller_test.go
+++ b/packages/agent/daemon/runtime/controller_test.go
@@ -441,6 +441,35 @@ func TestControllerExecTurnContextHasNoDeadline(t *testing.T) {
 	waitForSessionStatus(t, controller, "room-1", started.Session.AgentSessionID, SessionStatusReady)
 }
 
+func TestControllerExecPassesOnlyExplicitDisplayPrompt(t *testing.T) {
+	t.Parallel()
+
+	adapter := newBlockingExecAdapter()
+	controller := NewController([]Adapter{adapter}, nil)
+	started, err := controller.Start(context.Background(), StartInput{
+		RoomID:   "room-1",
+		Provider: ProviderCodex,
+		CWD:      "/workspace",
+		Title:    "Codex",
+	})
+	if err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	if _, err := controller.Exec(context.Background(), ExecInput{
+		RoomID:         started.Session.RoomID,
+		AgentSessionID: started.Session.AgentSessionID,
+		Content:        textPrompt("ordinary prompt"),
+	}); err != nil {
+		t.Fatalf("Exec: %v", err)
+	}
+	adapter.waitForPrompt(t, "ordinary prompt")
+	if displays := adapter.displayPrompts(); len(displays) != 1 || displays[0] != "" {
+		t.Fatalf("display prompts = %#v, want one empty explicit prompt", displays)
+	}
+	adapter.releaseNext()
+	waitForSessionStatus(t, controller, "room-1", started.Session.AgentSessionID, SessionStatusReady)
+}
+
 func TestControllerExecRejectsPromptDuringActiveTurn(t *testing.T) {
 	t.Parallel()
 
@@ -1459,6 +1488,7 @@ func (workingOnlyAdapter) Cancel(context.Context, Session, string) ([]activitysh
 type blockingExecAdapter struct {
 	mu       sync.Mutex
 	seen     []string
+	displays []string
 	contexts chan context.Context
 	started  chan string
 	releases chan struct{}
@@ -1482,10 +1512,11 @@ func (*blockingExecAdapter) Resume(context.Context, Session) error { return nil 
 
 func (*blockingExecAdapter) Close(context.Context, Session) error { return nil }
 
-func (a *blockingExecAdapter) Exec(ctx context.Context, session Session, content []PromptContentBlock, _ string, turnID string, emit EventSink, _ CommandSnapshotSink) ([]activityshared.Event, error) {
+func (a *blockingExecAdapter) Exec(ctx context.Context, session Session, content []PromptContentBlock, displayPrompt string, turnID string, emit EventSink, _ CommandSnapshotSink) ([]activityshared.Event, error) {
 	prompt := promptDisplayText(content)
 	a.mu.Lock()
 	a.seen = append(a.seen, prompt)
+	a.displays = append(a.displays, displayPrompt)
 	a.mu.Unlock()
 	a.contexts <- ctx
 	emit([]activityshared.Event{
@@ -1534,6 +1565,12 @@ func (a *blockingExecAdapter) prompts() []string {
 	a.mu.Lock()
 	defer a.mu.Unlock()
 	return append([]string(nil), a.seen...)
+}
+
+func (a *blockingExecAdapter) displayPrompts() []string {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	return append([]string(nil), a.displays...)
 }
 
 type deferredRemoteCancelAdapter struct {

--- a/packages/agent/daemon/runtime/prompt_content.go
+++ b/packages/agent/daemon/runtime/prompt_content.go
@@ -95,6 +95,27 @@ func promptDisplayText(content []PromptContentBlock) string {
 	return ""
 }
 
+func explicitAndVisiblePromptText(content []PromptContentBlock, displayPrompt string) (string, string) {
+	explicitDisplayPrompt := strings.TrimSpace(displayPrompt)
+	if explicitDisplayPrompt != "" {
+		return explicitDisplayPrompt, explicitDisplayPrompt
+	}
+	return "", promptDisplayText(content)
+}
+
+func userPromptActivityPayload(content []PromptContentBlock, displayPrompt string, extra map[string]any) map[string]any {
+	payload := map[string]any{
+		"content": promptContentForActivity(content),
+	}
+	for key, value := range extra {
+		payload[key] = value
+	}
+	if explicitDisplayPrompt := strings.TrimSpace(displayPrompt); explicitDisplayPrompt != "" {
+		payload["displayPrompt"] = explicitDisplayPrompt
+	}
+	return payload
+}
+
 func promptContentForACP(content []PromptContentBlock) []map[string]any {
 	out := make([]map[string]any, 0, len(content))
 	for _, block := range content {

--- a/packages/agent/daemon/runtime/reporter.go
+++ b/packages/agent/daemon/runtime/reporter.go
@@ -356,6 +356,9 @@ func textMessageUpdateFromSessionEvent(
 	if content, ok := event.Payload.Metadata["content"]; ok {
 		payload["content"] = acpSanitizeImagePayload(content)
 	}
+	if displayPrompt := stringFromPayload(event.Payload.Metadata, "displayPrompt"); displayPrompt != "" {
+		payload["displayPrompt"] = displayPrompt
+	}
 	update := agentsessionstore.WorkspaceAgentMessageUpdate{
 		AgentSessionID:   strings.TrimSpace(sessionID),
 		MessageID:        messageID,

--- a/packages/agent/daemon/runtime/reporter_test.go
+++ b/packages/agent/daemon/runtime/reporter_test.go
@@ -384,6 +384,45 @@ func TestReportActivityInputProjectsRuntimeMessagesToMessageUpdates(t *testing.T
 	}
 }
 
+func TestReportActivityInputProjectsDisplayPromptAndRichContent(t *testing.T) {
+	t.Parallel()
+
+	session := reportTestSession()
+	userEvent := newTurnActivityEventWithID(session, "user-event-1", EventMessage, "turn-1", messageStreamStateCompleted, RoleUser, "Run Automation", map[string]any{
+		"messageId":     "user-message-1",
+		"displayPrompt": "Run Automation",
+		"content": []any{map[string]any{
+			"type": "text",
+			"text": "real automation prompt",
+		}, map[string]any{
+			"type":         "image",
+			"mimeType":     "image/png",
+			"attachmentId": "attachment-1",
+			"data":         "base64-image-bytes",
+		}},
+	})
+	userEvent.OccurredAtUnixMS = 101
+
+	report := reportActivityInput(session, []activityshared.Event{userEvent})
+
+	if len(report.MessageUpdates) != 1 {
+		t.Fatalf("message updates = %#v, want one user update", report.MessageUpdates)
+	}
+	user := report.MessageUpdates[0]
+	if user.Payload["text"] != "Run Automation" ||
+		user.Payload["displayPrompt"] != "Run Automation" {
+		t.Fatalf("user message payload = %#v, want text and displayPrompt", user.Payload)
+	}
+	content := payloadArray(user.Payload["content"])
+	if len(content) != 2 {
+		t.Fatalf("user message content = %#v, want rich content blocks", user.Payload["content"])
+	}
+	imageBlock := payloadObject(content[1])
+	if _, exists := imageBlock["data"]; exists {
+		t.Fatalf("user message image block retained data bytes: %#v", imageBlock)
+	}
+}
+
 func TestReportActivityInputForwardsMessageKindToPayload(t *testing.T) {
 	t.Parallel()
 

--- a/packages/agent/daemon/runtime/standard_acp_adapter.go
+++ b/packages/agent/daemon/runtime/standard_acp_adapter.go
@@ -676,10 +676,7 @@ func (a *standardACPAdapter) Exec(
 		return nil, ErrSessionDisconnected
 	}
 	session.ProviderSessionID = acpSession.providerSessionID
-	trimmedDisplayPrompt := strings.TrimSpace(displayPrompt)
-	if trimmedDisplayPrompt == "" {
-		trimmedDisplayPrompt = promptDisplayText(content)
-	}
+	explicitDisplayPrompt, visibleText := explicitAndVisiblePromptText(content, displayPrompt)
 	normalizer := newACPTurnNormalizer()
 	var events []activityshared.Event
 	emitEvents := func(next []activityshared.Event) {
@@ -693,14 +690,12 @@ func (a *standardACPAdapter) Exec(
 	}
 
 	startEvents := make([]activityshared.Event, 0, 3)
-	if fallbackTitle := fallbackStandardSessionTitle(a.config, session.Title, trimmedDisplayPrompt); fallbackTitle != "" {
+	if fallbackTitle := fallbackStandardSessionTitle(a.config, session.Title, visibleText); fallbackTitle != "" {
 		startEvents = append(startEvents, newSessionTitleActivityEvent(session, fallbackTitle))
 		session.Title = fallbackTitle
 	}
 	startEvents = append(startEvents,
-		newTurnActivityEvent(session, EventMessage, turnID, "", RoleUser, trimmedDisplayPrompt, map[string]any{
-			"content": promptContentForActivity(content),
-		}),
+		newTurnActivityEvent(session, EventMessage, turnID, "", RoleUser, visibleText, userPromptActivityPayload(content, explicitDisplayPrompt, nil)),
 		newTurnActivityEvent(session, EventTurnStarted, turnID, SessionStatusWorking, "", "", nil),
 	)
 	emitEvents(startEvents)
@@ -712,7 +707,7 @@ func (a *standardACPAdapter) Exec(
 		"agent_session_id", session.AgentSessionID,
 		"provider_session_id", session.ProviderSessionID,
 		"turn_id", turnID,
-		"prompt_length", len(trimmedDisplayPrompt),
+		"prompt_length", len(visibleText),
 	)
 
 	result, err := acpSession.client.Call(ctx, acpMethodPrompt, map[string]any{

--- a/packages/agent/gui/agent-gui/agentGuiNode/model/agentGuiConversationModel.spec.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/model/agentGuiConversationModel.spec.ts
@@ -561,13 +561,17 @@ describe("agentGuiConversationModel", () => {
             actorId: "user-1",
             itemType: "message.user",
             role: "user",
-            payload: { text: "AAA" },
+            payload: {
+              displayPrompt: "Run Automation",
+              text: "long automation prompt",
+              content: "long automation prompt"
+            },
             occurredAtUnixMs: 10
           })
         ]
       })
     ).toEqual({
-      title: "AAA",
+      title: "Run Automation",
       titleFallback: null
     });
   });
@@ -1238,7 +1242,11 @@ describe("agentGuiConversationModel", () => {
           },
           options: [
             { kind: "allow_once", name: "Yes", optionId: "default" },
-            { kind: "reject_once", name: "No, keep planning", optionId: "plan" }
+            {
+              kind: "reject_once",
+              name: "No, keep planning",
+              optionId: "plan"
+            }
           ]
         }
       },

--- a/packages/agent/gui/agent-gui/agentGuiNode/model/agentGuiConversationModel.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/model/agentGuiConversationModel.ts
@@ -927,11 +927,17 @@ function messageRole(
 }
 
 function messageText(message: WorkspaceAgentActivityMessage): string {
+  const payloadDisplayPrompt =
+    typeof message.payload?.displayPrompt === "string"
+      ? message.payload.displayPrompt
+      : "";
   const payloadContent =
     typeof message.payload?.content === "string" ? message.payload.content : "";
   const payloadText =
     typeof message.payload?.text === "string" ? message.payload.text : "";
-  return (payloadContent || payloadText).replace(/\s+/g, " ").trim();
+  return (payloadDisplayPrompt || payloadText || payloadContent)
+    .replace(/\s+/g, " ")
+    .trim();
 }
 
 function compareMessagesAscending(
@@ -979,11 +985,15 @@ function timelineItemRole(
 }
 
 function timelineItemText(item: WorkspaceAgentActivityTimelineItem): string {
+  const payloadDisplayPrompt =
+    typeof item.payload?.displayPrompt === "string"
+      ? item.payload.displayPrompt
+      : "";
   const payloadContent =
     typeof item.payload?.content === "string" ? item.payload.content : "";
   const payloadText =
     typeof item.payload?.text === "string" ? item.payload.text : "";
-  return (payloadContent || item.content || payloadText)
+  return (payloadDisplayPrompt || payloadText || item.content || payloadContent)
     .replace(/\s+/g, " ")
     .trim();
 }
@@ -1498,13 +1508,17 @@ function normalizedTimelineItemBody(
   item: WorkspaceAgentActivityTimelineItem
 ): string {
   const content =
-    typeof item.content === "string" && item.content.trim()
-      ? item.content
-      : typeof item.payload?.content === "string" && item.payload.content.trim()
-        ? item.payload.content
-        : typeof item.payload?.text === "string"
-          ? item.payload.text
-          : "";
+    typeof item.payload?.displayPrompt === "string" &&
+    item.payload.displayPrompt.trim()
+      ? item.payload.displayPrompt
+      : typeof item.payload?.text === "string" && item.payload.text.trim()
+        ? item.payload.text
+        : typeof item.payload?.content === "string" &&
+            item.payload.content.trim()
+          ? item.payload.content
+          : typeof item.content === "string"
+            ? item.content
+            : "";
   return content.trim();
 }
 

--- a/packages/agent/gui/agent-message-center/workspaceAgentMessageCenterDigest.spec.ts
+++ b/packages/agent/gui/agent-message-center/workspaceAgentMessageCenterDigest.spec.ts
@@ -36,6 +36,31 @@ describe("buildWorkspaceAgentMessageCenterDigest", () => {
     });
   });
 
+  it("prefers displayPrompt for message summaries", () => {
+    const digest = buildWorkspaceAgentMessageCenterDigest({
+      fallbackTitle: "Fallback title",
+      messages: [
+        message({
+          messageId: "assistant-1",
+          role: "assistant",
+          payload: {
+            displayPrompt: "Run Automation",
+            text: "long automation prompt",
+            content: "long automation prompt"
+          },
+          occurredAtUnixMs: 10
+        })
+      ],
+      needsAttention: null,
+      pendingPrompt: null,
+      status: "idle"
+    });
+
+    expect(digest.primary).toMatchObject({
+      summary: "Run Automation"
+    });
+  });
+
   it("prioritizes input-required over terminal-looking message summaries", () => {
     const digest = buildWorkspaceAgentMessageCenterDigest({
       fallbackTitle: "Fallback title",

--- a/packages/agent/gui/agent-message-center/workspaceAgentMessageCenterDigest.ts
+++ b/packages/agent/gui/agent-message-center/workspaceAgentMessageCenterDigest.ts
@@ -155,6 +155,7 @@ function isAgentMessageRole(role: string): boolean {
 
 type MessageSummarySource =
   | "payload.summary"
+  | "payload.displayPrompt"
   | "payload.text"
   | "payload.content"
   | "payload.message"
@@ -183,6 +184,7 @@ function messageSummaryCandidates(
 ): MessageSummaryCandidate[] {
   const explicitCandidates = [
     summaryCandidate("payload.summary", message.payload.summary),
+    summaryCandidate("payload.displayPrompt", message.payload.displayPrompt),
     summaryCandidate("payload.text", message.payload.text),
     summaryCandidate("payload.content", message.payload.content),
     summaryCandidate("payload.message", message.payload.message),

--- a/packages/agent/gui/agent-message-center/workspaceAgentMessageCenterModel.spec.ts
+++ b/packages/agent/gui/agent-message-center/workspaceAgentMessageCenterModel.spec.ts
@@ -169,6 +169,33 @@ describe("buildWorkspaceAgentMessageCenterModel", () => {
     });
   });
 
+  it("prefers displayPrompt for message-center model summaries", () => {
+    const model = buildWorkspaceAgentMessageCenterModel(
+      snapshot({
+        messages: [
+          message({
+            agentSessionId: "session-1",
+            messageId: "assistant-1",
+            role: "assistant",
+            kind: "text",
+            payload: {
+              displayPrompt: "Run Automation",
+              text: "long automation prompt",
+              content: "long automation prompt"
+            },
+            occurredAtUnixMs: 10
+          })
+        ],
+        sessions: [session({ agentSessionId: "session-1" })]
+      })
+    );
+
+    expect(model.items[0]?.lastAgentMessageSummary).toBe("Run Automation");
+    expect(model.items[0]?.digest.primary).toMatchObject({
+      summary: "Run Automation"
+    });
+  });
+
   it("preserves the session user id for message-center stacking", () => {
     const model = buildWorkspaceAgentMessageCenterModel(
       snapshot({

--- a/packages/agent/gui/agent-message-center/workspaceAgentMessageCenterModel.ts
+++ b/packages/agent/gui/agent-message-center/workspaceAgentMessageCenterModel.ts
@@ -694,6 +694,7 @@ function includesAny(value: string, needles: readonly string[]): boolean {
 function messageSummary(message: AgentActivityMessage): string {
   return firstNonEmptyString(
     stringValue(message.payload.summary),
+    stringValue(message.payload.displayPrompt),
     stringValue(message.payload.text),
     stringValue(message.payload.content),
     stringValue(message.payload.message),

--- a/packages/agent/gui/shared/agentConversation/projection/agentConversationProjection.spec.ts
+++ b/packages/agent/gui/shared/agentConversation/projection/agentConversationProjection.spec.ts
@@ -654,6 +654,79 @@ describe("projectAgentConversationVM", () => {
     });
   });
 
+  it("replaces rich user prompt text blocks with displayPrompt while preserving images", () => {
+    const conversation = projectAgentConversationVM(
+      detailViewModel({
+        session: {
+          ...detailViewModel().session,
+          workspaceId: "room-1"
+        },
+        turns: [
+          {
+            id: "turn-1",
+            userMessage: null,
+            userMessages: [
+              {
+                id: "user-1",
+                body: "Run Automation",
+                sourceTimelineItems: [
+                  {
+                    id: 1,
+                    agentSessionId: "session-1",
+                    eventId: "event-1",
+                    actorType: "user",
+                    actorId: "user",
+                    itemType: "message",
+                    role: "user",
+                    payload: {
+                      displayPrompt: "Run Automation",
+                      content: [
+                        { type: "text", text: "long automation prompt" },
+                        {
+                          type: "image",
+                          mimeType: "image/png",
+                          attachmentId: "attachment-1",
+                          name: "screen.png"
+                        }
+                      ]
+                    }
+                  }
+                ]
+              }
+            ],
+            agentMessages: [],
+            toolCalls: [],
+            toolCallCount: 0,
+            hasFailedToolCall: false,
+            agentItems: []
+          }
+        ],
+        showProcessingIndicator: false
+      })
+    );
+
+    const userRow = conversation.rows.find(
+      (
+        row
+      ): row is Extract<
+        (typeof conversation.rows)[number],
+        { kind: "message" }
+      > => row.kind === "message" && row.speaker === "user"
+    );
+
+    expect(userRow?.messages.map((message) => message.contentKind)).toEqual([
+      "image-grid",
+      "text"
+    ]);
+    expect(userRow?.messages[0]?.images?.[0]?.attachmentId).toBe(
+      "attachment-1"
+    );
+    expect(userRow?.messages[1]?.body).toBe("Run Automation");
+    expect(userRow?.messages.map((message) => message.body)).not.toContain(
+      "long automation prompt"
+    );
+  });
+
   it("reuses unchanged transcript row references across incremental updates", () => {
     const firstTurn = detailViewModel().turns[0]!;
     const secondTurn = {

--- a/packages/agent/gui/shared/agentConversation/projection/agentConversationProjection.ts
+++ b/packages/agent/gui/shared/agentConversation/projection/agentConversationProjection.ts
@@ -576,7 +576,14 @@ function userPromptContentBlocks(
   if (!content) {
     return [];
   }
-  return content.flatMap((raw): UserPromptContentBlock[] => {
+  const displayPrompt = firstString(
+    message.sourceTimelineItems?.map((candidate) =>
+      typeof candidate.payload?.displayPrompt === "string"
+        ? candidate.payload.displayPrompt
+        : ""
+    ) ?? []
+  );
+  const blocks = content.flatMap((raw): UserPromptContentBlock[] => {
     const block =
       raw && typeof raw === "object" && !Array.isArray(raw)
         ? (raw as Record<string, unknown>)
@@ -585,6 +592,9 @@ function userPromptContentBlocks(
       return [];
     }
     if (block.type === "text" && typeof block.text === "string") {
+      if (displayPrompt) {
+        return [];
+      }
       return [{ type: "text", text: block.text }];
     }
     if (block.type !== "image") {
@@ -618,6 +628,20 @@ function userPromptContentBlocks(
       }
     ];
   });
+  if (!displayPrompt) {
+    return blocks;
+  }
+  return [{ type: "text", text: displayPrompt }, ...blocks];
+}
+
+function firstString(values: readonly string[]): string {
+  for (const value of values) {
+    const trimmed = value.trim();
+    if (trimmed) {
+      return trimmed;
+    }
+  }
+  return "";
 }
 
 function projectTurnAgentRows(

--- a/packages/agent/gui/shared/agentConversation/projection/workspaceAgentMessageProjection.spec.ts
+++ b/packages/agent/gui/shared/agentConversation/projection/workspaceAgentMessageProjection.spec.ts
@@ -381,6 +381,52 @@ describe("projectWorkspaceAgentMessagesToConversationVM", () => {
     );
     expect(toolRows[0]?.calls[0]?.toolName).toBe("Agent");
   });
+
+  it("renders displayPrompt instead of rich content text while preserving prompt images", () => {
+    const conversation = projectWorkspaceAgentMessagesToConversationVM({
+      activity: activity(),
+      session: session(),
+      workspaceRoot: "/workspace/demo",
+      messages: [
+        message({
+          messageId: "user-1",
+          id: 1,
+          role: "user",
+          kind: "text",
+          payload: {
+            displayPrompt: "Run Automation",
+            text: "Run Automation",
+            content: [
+              { type: "text", text: "long automation prompt" },
+              {
+                type: "image",
+                mimeType: "image/png",
+                attachmentId: "attachment-1",
+                name: "screen.png"
+              }
+            ]
+          }
+        })
+      ]
+    });
+
+    const userRow = conversation.rows.find(
+      (row) => row.kind === "message" && row.speaker === "user"
+    );
+
+    expect(
+      userRow?.kind === "message" ? userRow.messages[0]?.contentKind : null
+    ).toBe("image-grid");
+    expect(
+      userRow?.kind === "message" ? userRow.messages[0]?.images?.[0] : null
+    ).toMatchObject({
+      attachmentId: "attachment-1",
+      mimeType: "image/png"
+    });
+    expect(userRow?.kind === "message" ? userRow.messages[1]?.body : null).toBe(
+      "Run Automation"
+    );
+  });
 });
 
 function activity(

--- a/packages/agent/gui/shared/agentConversation/projection/workspaceAgentMessageProjection.ts
+++ b/packages/agent/gui/shared/agentConversation/projection/workspaceAgentMessageProjection.ts
@@ -326,6 +326,7 @@ function messageText(message: WorkspaceAgentActivityMessage): string {
   const payload = normalizedPayload(message.payload);
   const title = messagePayloadString(message, "title");
   return firstNonEmptyString(
+    stringValue(payload.displayPrompt),
     stringValue(payload.text),
     stringValue(payload.content),
     stringValue(payload.message),

--- a/packages/agent/gui/shared/workspaceAgentActivityListViewModel.spec.ts
+++ b/packages/agent/gui/shared/workspaceAgentActivityListViewModel.spec.ts
@@ -465,6 +465,47 @@ describe("buildWorkspaceAgentActivityListViewModel", () => {
     });
   });
 
+  it("prefers displayPrompt for activity titles and latest summaries", () => {
+    const snapshot: AgentHostWorkspaceAgentSnapshot = {
+      presences: [],
+      sessions: [
+        {
+          id: 10,
+          agentSessionId: "session-10",
+          presenceId: 1,
+          provider: "codex",
+          providerSessionId: "provider-10",
+          cwd: "/repo",
+          status: "working",
+          updatedAtUnixMs: 2000,
+          createdAtUnixMs: 2000,
+          title: "Codex"
+        }
+      ]
+    };
+
+    const view = buildWorkspaceAgentActivityListViewModel(snapshot, {
+      sessionMessagesById: {
+        "session-10": [
+          messageItem({
+            id: 1,
+            content: "long automation prompt",
+            payload: {
+              displayPrompt: "Run Automation",
+              text: "long automation prompt",
+              content: "long automation prompt"
+            }
+          })
+        ]
+      }
+    });
+
+    expect(view.activities[0]).toMatchObject({
+      title: "Run Automation",
+      latestActivitySummary: "Run Automation"
+    });
+  });
+
   it("treats resumed active sessions without a running turn as idle", () => {
     const snapshot: AgentHostWorkspaceAgentSnapshot = {
       presences: [],

--- a/packages/agent/gui/shared/workspaceAgentActivityListViewModel.ts
+++ b/packages/agent/gui/shared/workspaceAgentActivityListViewModel.ts
@@ -1007,8 +1007,9 @@ function messageDisplayText(message: WorkspaceAgentActivityMessage): string {
   const payload = message.payload ?? {};
   const text = normalizeAgentTitleText(
     compactText(
-      stringValue(payload.content) ||
+      stringValue(payload.displayPrompt) ||
         stringValue(payload.text) ||
+        stringValue(payload.content) ||
         stringValue(payload.message) ||
         stringValue(payload.body) ||
         stringValue(payload.title) ||

--- a/packages/agent/gui/shared/workspaceAgentLatestActivitySummary.ts
+++ b/packages/agent/gui/shared/workspaceAgentLatestActivitySummary.ts
@@ -157,9 +157,10 @@ function latestUserMessageText(
   }
 
   return firstPresentText(
+    stringPayloadValue(latestUserMessage, "displayPrompt"),
+    stringPayloadValue(latestUserMessage, "text"),
     stringPayloadValue(latestUserMessage, "content"),
-    latestUserMessage.content,
-    stringPayloadValue(latestUserMessage, "text")
+    latestUserMessage.content
   );
 }
 
@@ -236,16 +237,17 @@ function messageRole(
 
 function messageContent(item: WorkspaceAgentActivityTimelineItem): string {
   const content = firstPresentText(
+    stringPayloadValue(item, "displayPrompt"),
+    stringPayloadValue(item, "text"),
     stringPayloadValue(item, "content"),
-    item.content,
-    stringPayloadValue(item, "text")
+    item.content
   );
   return isWorkspaceAgentSyntheticControlMessage(content) ? "" : content;
 }
 
 function stringPayloadValue(
   item: WorkspaceAgentActivityTimelineItem,
-  key: "content" | "summary" | "text"
+  key: "content" | "displayPrompt" | "summary" | "text"
 ): string {
   const value = item.payload?.[key];
   return typeof value === "string" ? value : "";

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,6 +6,7 @@ settings:
 
 overrides:
   "@radix-ui/react-slot": 1.2.5
+  yauzl: 3.4.0
 
 importers:
   .:
@@ -8957,11 +8958,12 @@ packages:
       }
     engines: { node: ">=12" }
 
-  yauzl@2.10.0:
+  yauzl@3.4.0:
     resolution:
       {
-        integrity: sha512-p4a9I6X6nu6IhoGmBqAcbJy1mlC4j27vEPZX9F4L4/vZT3Lyq1VkFHw/V/PUcB9Buo+DG3iHkT0x3Qya58zc3g==
+        integrity: sha512-jIH9yLR9wqr0wOS0TpBvo/g/2UgZH5qePVbjgRliiF0BYvOZyaBknKsF+x9Iht0O6sqgnB93rCICdOZFecJuDw==
       }
+    engines: { node: ">=12" }
 
   yazl@3.3.1:
     resolution:
@@ -12092,7 +12094,7 @@ snapshots:
     dependencies:
       debug: 4.4.3
       get-stream: 5.2.0
-      yauzl: 2.10.0
+      yauzl: 3.4.0
     optionalDependencies:
       "@types/yauzl": 2.10.3
     transitivePeerDependencies:
@@ -14282,10 +14284,9 @@ snapshots:
       y18n: 5.0.8
       yargs-parser: 21.1.1
 
-  yauzl@2.10.0:
+  yauzl@3.4.0:
     dependencies:
-      buffer-crc32: 0.2.13
-      fd-slicer: 1.1.0
+      pend: 1.2.0
 
   yazl@3.3.1:
     dependencies:

--- a/services/tuttid/service/agent/service.go
+++ b/services/tuttid/service/agent/service.go
@@ -95,7 +95,7 @@ func (s *Service) Create(ctx context.Context, workspaceID string, input CreateSe
 		input.PermissionModeID = nil
 	}
 	input.AgentSessionID = agentSessionIDOrNew(input.AgentSessionID)
-	normalizedContent, displayPrompt, err := normalizePromptContent(input.InitialContent)
+	normalizedContent, _, err := normalizePromptContent(input.InitialContent)
 	if err != nil {
 		return Session{}, err
 	}
@@ -140,7 +140,7 @@ func (s *Service) Create(ctx context.Context, workspaceID string, input CreateSe
 		})
 		return Session{}, cleanupPrepared(errors.Join(err, closeErr))
 	}
-	content, displayPrompt, err := s.prepareNormalizedPromptContentForExec(workspaceID, session.ID, normalizedContent, displayPrompt)
+	content, _, err := s.prepareNormalizedPromptContentForExec(workspaceID, session.ID, normalizedContent, "")
 	if err != nil {
 		closeErr := s.controller().Close(ctx, RuntimeCloseInput{
 			WorkspaceID:    workspaceID,
@@ -148,9 +148,7 @@ func (s *Service) Create(ctx context.Context, workspaceID string, input CreateSe
 		})
 		return Session{}, cleanupPrepared(errors.Join(err, closeErr))
 	}
-	if strings.TrimSpace(input.InitialDisplayPrompt) != "" {
-		displayPrompt = input.InitialDisplayPrompt
-	}
+	displayPrompt := strings.TrimSpace(input.InitialDisplayPrompt)
 	if _, err := s.controller().Exec(ctx, RuntimeExecInput{
 		WorkspaceID:    workspaceID,
 		AgentSessionID: session.ID,
@@ -474,20 +472,18 @@ func (s *Service) SendInput(ctx context.Context, workspaceID string, agentSessio
 	if _, err := s.ensureRuntimeSession(ctx, workspaceID, agentSessionID); err != nil {
 		return Session{}, err
 	}
-	normalizedContent, displayPrompt, err := normalizePromptContent(input.Content)
+	normalizedContent, _, err := normalizePromptContent(input.Content)
 	if err != nil {
 		return Session{}, err
 	}
 	if err := s.validatePromptContentForExec(ctx, workspaceID, agentSessionID, normalizedContent); err != nil {
 		return Session{}, err
 	}
-	content, displayPrompt, err := s.prepareNormalizedPromptContentForExec(workspaceID, agentSessionID, normalizedContent, displayPrompt)
+	content, _, err := s.prepareNormalizedPromptContentForExec(workspaceID, agentSessionID, normalizedContent, "")
 	if err != nil {
 		return Session{}, err
 	}
-	if strings.TrimSpace(input.DisplayPrompt) != "" {
-		displayPrompt = input.DisplayPrompt
-	}
+	displayPrompt := strings.TrimSpace(input.DisplayPrompt)
 	result, err := s.controller().Exec(ctx, RuntimeExecInput{
 		WorkspaceID:    workspaceID,
 		AgentSessionID: agentSessionID,

--- a/services/tuttid/service/agent/service_test.go
+++ b/services/tuttid/service/agent/service_test.go
@@ -283,6 +283,26 @@ func TestServiceCreatePassesInitialDisplayPromptToRuntime(t *testing.T) {
 	}
 }
 
+func TestServiceCreateDoesNotPassDerivedPromptToRuntime(t *testing.T) {
+	runtime := newFakeRuntime()
+	service := NewService(runtime)
+
+	_, err := service.Create(context.Background(), "ws-1", CreateSessionInput{
+		AgentSessionID: "session-1",
+		Provider:       "codex",
+		InitialContent: TextPromptContent("ordinary prompt"),
+	})
+	if err != nil {
+		t.Fatalf("Create error = %v", err)
+	}
+	if len(runtime.execCalls) != 1 {
+		t.Fatalf("exec calls = %d, want 1", len(runtime.execCalls))
+	}
+	if runtime.execCalls[0].DisplayPrompt != "" {
+		t.Fatalf("runtime display prompt = %q, want empty explicit display prompt", runtime.execCalls[0].DisplayPrompt)
+	}
+}
+
 func TestServiceSendInputPassesDisplayPromptToRuntime(t *testing.T) {
 	runtime := newFakeRuntime()
 	service := NewService(runtime)


### PR DESCRIPTION
## Summary

- Preserve explicit agent display prompts separately from the visible prompt text used for titles and message rendering.
- Carry `displayPrompt` through runtime activity payloads and Agent GUI projections so explicit user-facing prompts survive message normalization.
- Add regression coverage across the daemon runtime, tuttid agent service, activity selectors, and Agent GUI view models/projections.
- Override `yauzl` to `3.4.0` so Electron postinstall no longer uses the old `fd-slicer@1.1.0` stream path that can leave a partial macOS Electron.app extraction.

## Root cause

The agent changes keep the explicit display prompt from being replaced by derived prompt text when prompt content is normalized for runtime execution. Without that separation, the UI and activity projections can lose the caller-provided display prompt and fall back to content-derived text.

Separately, Electron's postinstall downloads a valid Electron zip, then uses `extract-zip`, which previously resolved to `yauzl@2.10.0` and `fd-slicer@1.1.0`. On macOS, that stack can hang while streaming the compressed `Electron.app/Contents/Resources/electron.icns` entry into zlib, leaving a partial `Electron.app` without `Contents/Frameworks`. `yauzl@3.4.0` preserves the callback API used by `extract-zip@2.0.1` and avoids the old `fd-slicer` stream path.

## Verification

- `pnpm install --frozen-lockfile`
- Verified `extract-zip@2.0.1` resolves `yauzl@3.4.0`
- Removed Electron `dist`/`path.txt`, reran `electron/install.js`, and verified `Electron.app/Contents/Frameworks`, `Info.plist`, and `PkgInfo` are present
- `pnpm --filter @tutti-os/desktop exec electron --version`
- `pnpm --filter @tutti-os/agent-activity-core test`
- `pnpm --filter @tutti-os/agent-activity-core typecheck`
- `pnpm --filter @tutti-os/agent-gui test -- --runInBand`
- `pnpm --filter @tutti-os/agent-gui typecheck`
- `cd packages/agent/daemon && go test ./...`
- `cd services/tuttid && go test ./service/agent -count=1`
- `pnpm check:full` via pre-push
