### PR TITLE
[codex] Document external PR review gate

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -134,13 +134,13 @@ Local hooks use `husky`:
 
 ## Pull Request Review Gate
 
-Tutti uses the `external-pr-review-gate` workflow to separate internal team changes from external contributions. Internal authors are defined by the `tutti-rd` GitHub team and the matching organization variable `TUTTI_RD_MEMBERS`.
+Tutti uses the `external-pr-review-gate` workflow to separate internal team changes from external contributions. Internal authors are defined by the organization variable `TUTTI_RD_MEMBERS`; the `tutti-rd` GitHub team is the review target for external PRs.
 
 - PRs opened by `tutti-rd` members do not automatically request reviewers and can pass the review gate without a separate official approval
 - PRs opened by non-`tutti-rd` authors automatically request review from `@tutti-os/tutti-rd`
 - External PRs can merge only after a `tutti-rd` member approves the current head commit
 - Pushing a new commit refreshes the gate; the new head commit needs a fresh passing review
-- Maintainers must update both the `tutti-rd` team and `TUTTI_RD_MEMBERS` when official team membership changes
+- Maintainers must update both `TUTTI_RD_MEMBERS` and the `tutti-rd` team when official team membership changes
 
 ```mermaid
 ---
@@ -150,7 +150,7 @@ config:
   look: neo
 ---
 flowchart TB
-    A["PR opened / reopened / marked ready for review / new commit pushed"] --> B{"Is the PR author in the tutti-rd team?"}
+    A["PR opened / reopened / marked ready for review / new commit pushed"] --> B{"Is the PR author in the official member list?"}
     B -- Yes --> C["Do not automatically request reviewers"]
     C --> P["✅ Passed"]
     P --> M["Can merge"]

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -132,6 +132,38 @@ Local hooks use `husky`:
 - `pre-commit` runs staged formatting and UI-boundary checks
 - `pre-push` runs `pnpm check:full`
 
+## Pull Request Review Gate
+
+Tutti uses the `external-pr-review-gate` workflow to separate internal team changes from external contributions. Internal authors are defined by the `tutti-rd` GitHub team and the matching organization variable `TUTTI_RD_MEMBERS`.
+
+- PRs opened by `tutti-rd` members do not automatically request reviewers and can pass the review gate without a separate official approval
+- PRs opened by non-`tutti-rd` authors automatically request review from `@tutti-os/tutti-rd`
+- External PRs can merge only after a `tutti-rd` member approves the current head commit
+- Pushing a new commit refreshes the gate; the new head commit needs a fresh passing review
+- Maintainers must update both the `tutti-rd` team and `TUTTI_RD_MEMBERS` when official team membership changes
+
+```mermaid
+---
+config:
+  layout: dagre
+  theme: redux
+  look: neo
+---
+flowchart TB
+    A["PR opened / reopened / marked ready for review / new commit pushed"] --> B{"Is the PR author in the tutti-rd team?"}
+    B -- Yes --> C["Do not automatically request reviewers"]
+    C --> P["✅ Passed"]
+    P --> M["Can merge"]
+    B -- No --> D["Automatically request @tutti-os/tutti-rd review"]
+    D --> E{"Does the current head commit have an official review?"}
+    E -- Approved --> P
+    E -- No passing review --> F["❌ Failed"]
+    F --> N["Cannot merge"]
+    G["External contributor pushes a new commit"] --> A
+
+    G@{ shape: rounded}
+```
+
 ## Documentation Language Policy
 
 - `README.*` and `CONTRIBUTING.*` are maintained in English, Simplified Chinese, and Traditional Chinese

--- a/CONTRIBUTING.zh-CN.md
+++ b/CONTRIBUTING.zh-CN.md
@@ -134,13 +134,13 @@ git commit -s -m "feat(scope): add something"
 
 ## Pull Request 评审门禁
 
-Tutti 使用 `external-pr-review-gate` workflow 区分内部团队改动和外部贡献。官方团队成员由 GitHub 团队 `tutti-rd` 以及配套的组织变量 `TUTTI_RD_MEMBERS` 定义。
+Tutti 使用 `external-pr-review-gate` workflow 区分内部团队改动和外部贡献。官方作者由组织变量 `TUTTI_RD_MEMBERS` 定义；GitHub 团队 `tutti-rd` 是外部 PR 的 review 请求目标。
 
 - `tutti-rd` 成员发起的 PR 不会自动请求 reviewer，也不需要额外官方 approve 即可通过评审门禁
 - 非 `tutti-rd` 作者发起的 PR 会自动请求 `@tutti-os/tutti-rd` review
 - 外部 PR 只有在当前 head commit 获得 `tutti-rd` 成员 approve 后才能合并
 - 推送新提交会刷新门禁；新的 head commit 需要重新获得通过评审
-- 官方团队成员变化时，维护者必须同时更新 `tutti-rd` 团队和 `TUTTI_RD_MEMBERS`
+- 官方团队成员变化时，维护者必须同时更新 `TUTTI_RD_MEMBERS` 和 `tutti-rd` 团队
 
 ```mermaid
 ---
@@ -150,7 +150,7 @@ config:
   look: neo
 ---
 flowchart TB
-    A["PR 打开 / 重新打开 / 标记为可评审 / 推送新提交"] --> B{"PR 作者是否在 tutti-rd 团队？"}
+    A["PR 打开 / 重新打开 / 标记为可评审 / 推送新提交"] --> B{"PR 作者是否在官方成员名单？"}
     B -- 是 --> C["不自动请求 Reviewer"]
     C --> P["✅ 通过"]
     P --> M["可以合并"]

--- a/CONTRIBUTING.zh-CN.md
+++ b/CONTRIBUTING.zh-CN.md
@@ -132,6 +132,38 @@ git commit -s -m "feat(scope): add something"
 - `pre-commit` 运行暂存区格式化和 UI 边界检查
 - `pre-push` 运行 `pnpm check:full`
 
+## Pull Request 评审门禁
+
+Tutti 使用 `external-pr-review-gate` workflow 区分内部团队改动和外部贡献。官方团队成员由 GitHub 团队 `tutti-rd` 以及配套的组织变量 `TUTTI_RD_MEMBERS` 定义。
+
+- `tutti-rd` 成员发起的 PR 不会自动请求 reviewer，也不需要额外官方 approve 即可通过评审门禁
+- 非 `tutti-rd` 作者发起的 PR 会自动请求 `@tutti-os/tutti-rd` review
+- 外部 PR 只有在当前 head commit 获得 `tutti-rd` 成员 approve 后才能合并
+- 推送新提交会刷新门禁；新的 head commit 需要重新获得通过评审
+- 官方团队成员变化时，维护者必须同时更新 `tutti-rd` 团队和 `TUTTI_RD_MEMBERS`
+
+```mermaid
+---
+config:
+  layout: dagre
+  theme: redux
+  look: neo
+---
+flowchart TB
+    A["PR 打开 / 重新打开 / 标记为可评审 / 推送新提交"] --> B{"PR 作者是否在 tutti-rd 团队？"}
+    B -- 是 --> C["不自动请求 Reviewer"]
+    C --> P["✅ 通过"]
+    P --> M["可以合并"]
+    B -- 否 --> D["自动请求 @tutti-os/tutti-rd Review"]
+    D --> E{"当前 head commit 是否有官方 Review？"}
+    E -- 已 Approve --> P
+    E -- 没有通过评审 --> F["❌ 未通过"]
+    F --> N["不能合并"]
+    G["外部贡献者推送新提交"] --> A
+
+    G@{ shape: rounded}
+```
+
 ## 文档语言策略
 
 - `README.*` 和 `CONTRIBUTING.*` 以英文、简体中文、繁体中文三语维护

--- a/CONTRIBUTING.zh-TW.md
+++ b/CONTRIBUTING.zh-TW.md
@@ -134,13 +134,13 @@ git commit -s -m "feat(scope): add something"
 
 ## Pull Request 評審門禁
 
-Tutti 使用 `external-pr-review-gate` workflow 區分內部團隊變更和外部貢獻。官方團隊成員由 GitHub 團隊 `tutti-rd` 以及配套的組織變數 `TUTTI_RD_MEMBERS` 定義。
+Tutti 使用 `external-pr-review-gate` workflow 區分內部團隊變更和外部貢獻。官方作者由組織變數 `TUTTI_RD_MEMBERS` 定義；GitHub 團隊 `tutti-rd` 是外部 PR 的 review 請求目標。
 
 - `tutti-rd` 成員發起的 PR 不會自動請求 reviewer，也不需要額外官方 approve 即可通過評審門禁
 - 非 `tutti-rd` 作者發起的 PR 會自動請求 `@tutti-os/tutti-rd` review
 - 外部 PR 只有在目前 head commit 獲得 `tutti-rd` 成員 approve 後才能合併
 - 推送新提交會刷新門禁；新的 head commit 需要重新獲得通過評審
-- 官方團隊成員變更時，維護者必須同時更新 `tutti-rd` 團隊和 `TUTTI_RD_MEMBERS`
+- 官方團隊成員變更時，維護者必須同時更新 `TUTTI_RD_MEMBERS` 和 `tutti-rd` 團隊
 
 ```mermaid
 ---
@@ -150,7 +150,7 @@ config:
   look: neo
 ---
 flowchart TB
-    A["PR 開啟 / 重新開啟 / 標記為可評審 / 推送新提交"] --> B{"PR 作者是否在 tutti-rd 團隊？"}
+    A["PR 開啟 / 重新開啟 / 標記為可評審 / 推送新提交"] --> B{"PR 作者是否在官方成員名單？"}
     B -- 是 --> C["不自動請求 Reviewer"]
     C --> P["✅ 通過"]
     P --> M["可以合併"]

--- a/CONTRIBUTING.zh-TW.md
+++ b/CONTRIBUTING.zh-TW.md
@@ -132,6 +132,38 @@ git commit -s -m "feat(scope): add something"
 - `pre-commit` 執行暫存區格式化和 UI 邊界檢查
 - `pre-push` 執行 `pnpm check:full`
 
+## Pull Request 評審門禁
+
+Tutti 使用 `external-pr-review-gate` workflow 區分內部團隊變更和外部貢獻。官方團隊成員由 GitHub 團隊 `tutti-rd` 以及配套的組織變數 `TUTTI_RD_MEMBERS` 定義。
+
+- `tutti-rd` 成員發起的 PR 不會自動請求 reviewer，也不需要額外官方 approve 即可通過評審門禁
+- 非 `tutti-rd` 作者發起的 PR 會自動請求 `@tutti-os/tutti-rd` review
+- 外部 PR 只有在目前 head commit 獲得 `tutti-rd` 成員 approve 後才能合併
+- 推送新提交會刷新門禁；新的 head commit 需要重新獲得通過評審
+- 官方團隊成員變更時，維護者必須同時更新 `tutti-rd` 團隊和 `TUTTI_RD_MEMBERS`
+
+```mermaid
+---
+config:
+  layout: dagre
+  theme: redux
+  look: neo
+---
+flowchart TB
+    A["PR 開啟 / 重新開啟 / 標記為可評審 / 推送新提交"] --> B{"PR 作者是否在 tutti-rd 團隊？"}
+    B -- 是 --> C["不自動請求 Reviewer"]
+    C --> P["✅ 通過"]
+    P --> M["可以合併"]
+    B -- 否 --> D["自動請求 @tutti-os/tutti-rd Review"]
+    D --> E{"目前 head commit 是否有官方 Review？"}
+    E -- 已 Approve --> P
+    E -- 沒有通過評審 --> F["❌ 未通過"]
+    F --> N["不能合併"]
+    G["外部貢獻者推送新提交"] --> A
+
+    G@{ shape: rounded}
+```
+
 ## 文件語言策略
 
 - `README.*` 和 `CONTRIBUTING.*` 以英文、簡體中文、繁體中文三種語言維護


### PR DESCRIPTION
## Summary

- Add the external PR review gate rules to the main contributing guide
- Keep English, Simplified Chinese, and Traditional Chinese contributing docs in sync
- Include the requested Mermaid flowchart for the tutti-rd review gate
- Clarify that `TUTTI_RD_MEMBERS` is the official-author source of truth, while `tutti-rd` is the review request target

## Validation

- `git diff --check`
- pre-commit hooks
- `pnpm check:full`

Note: opened as a draft PR for review; not merged yet.
