### PR TITLE
[codex] Request members read for review app token

### DIFF
--- a/.github/workflows/reusable-external-pr-review-gate.yml
+++ b/.github/workflows/reusable-external-pr-review-gate.yml
@@ -53,6 +53,7 @@ jobs:
           private-key: ${{ secrets.TUTTI_REVIEW_APP_PRIVATE_KEY }}
           owner: ${{ github.repository_owner }}
           repositories: ${{ github.event.repository.name }}
+          permission-members: read
           permission-pull-requests: write
 
       - name: Request official review for external PRs


### PR DESCRIPTION
## Summary

- Request `permission-members: read` when creating the review GitHub App token
- This is needed so the App token can resolve the `tutti-rd` team when requesting team reviewers

## Validation

- git diff --check
- pre-commit hooks
- pnpm check:full

## Follow-up before merge

Update the `tutti-pr-review-bot` GitHub App settings to grant Organization permissions -> Members: Read-only, then approve the updated installation permissions.