### PR TITLE
[codex] Use installation-wide review app token

### DIFF
--- a/.github/workflows/reusable-external-pr-review-gate.yml
+++ b/.github/workflows/reusable-external-pr-review-gate.yml
@@ -52,7 +52,6 @@ jobs:
           app-id: ${{ vars.TUTTI_REVIEW_APP_ID }}
           private-key: ${{ secrets.TUTTI_REVIEW_APP_PRIVATE_KEY }}
           owner: ${{ github.repository_owner }}
-          repositories: ${{ github.event.repository.name }}
           permission-members: read
           permission-pull-requests: write
 


### PR DESCRIPTION
## What changed

- Create the review bot token at the installation owner scope instead of narrowing it to the current repository.

## Why

The previous repository-scoped token could authenticate, but GitHub still could not resolve the organization team node when requesting `@tutti-os/tutti-rd` as a reviewer. The app installation already has `members: read` and `pull_requests: write`; using the installation owner scope lets the token see the org team while keeping the requested token permissions minimal.

## Validation

- `pnpm check:full`
