### PR TITLE
fix(browser-node): open local file URLs in the external browser

### DIFF
--- a/apps/desktop/src/main/ipc/browser.ts
+++ b/apps/desktop/src/main/ipc/browser.ts
@@ -164,11 +164,9 @@ async function openBrowserNodeExternalUrl(
     try {
       filePath = fileURLToPath(trimmedUrl);
     } catch (error) {
-      throw new Error(
-        error instanceof Error
-          ? error.message
-          : "Browser Node rejected external file URL"
-      );
+      throw new Error("Browser Node rejected external file URL", {
+        cause: error
+      });
     }
 
     if (process.platform === "darwin") {
@@ -196,12 +194,7 @@ async function openBrowserNodeExternalUrl(
     });
   }
 
-  const opened = await shell.openExternal(trimmedUrl);
-  if (!opened) {
-    throw new Error(
-      `Browser Node openExternal returned false for ${trimmedUrl}`
-    );
-  }
+  await shell.openExternal(trimmedUrl);
 }
 
 function logRejectedGuest(

--- a/apps/desktop/src/main/ipc/browser.ts
+++ b/apps/desktop/src/main/ipc/browser.ts
@@ -1,4 +1,5 @@
 import { ipcMain, nativeTheme, shell, webContents } from "electron";
+import { fileURLToPath } from "node:url";
 import { registerBrowserNodeElectronMain } from "@tutti-os/browser-node/electron-main";
 import type { BrowserNodeElectronLogger } from "@tutti-os/browser-node/electron-main";
 import {
@@ -18,6 +19,7 @@ import {
   type BrowserPreferredColorScheme
 } from "./browserPreferredColorScheme.ts";
 import { resolveOwnerWindowFromEvent } from "./ownerWindow.ts";
+import { openFileWithDefaultBrowser } from "../host/openWithApplications.ts";
 
 type BrowserInvokeChannel = Exclude<
   (typeof desktopIpcChannels.browser)[keyof typeof desktopIpcChannels.browser],
@@ -55,7 +57,7 @@ export function registerBrowserIpc(
     },
     getPreferredColorScheme: () => getPreferredColorScheme(preferences),
     logger,
-    openExternal: (url) => shell.openExternal(url),
+    openExternal: (url) => openBrowserNodeExternalUrl(url, logger),
     registerHandler(channel, handler) {
       registerDesktopIpcHandler(
         channel as BrowserInvokeChannel & DesktopInvokeChannel,
@@ -146,6 +148,60 @@ function isBrowserDevToolsEnabled(): boolean {
     tuttiEnv: process.env.TUTTI_ENV,
     nodeEnv: process.env.NODE_ENV
   });
+}
+
+async function openBrowserNodeExternalUrl(
+  url: string,
+  logger: BrowserNodeElectronLogger
+): Promise<void> {
+  const trimmedUrl = url.trim();
+  if (trimmedUrl.length === 0) {
+    throw new Error("Browser Node rejected empty external URL");
+  }
+
+  if (trimmedUrl.startsWith("file://")) {
+    let filePath: string;
+    try {
+      filePath = fileURLToPath(trimmedUrl);
+    } catch (error) {
+      throw new Error(
+        error instanceof Error
+          ? error.message
+          : "Browser Node rejected external file URL"
+      );
+    }
+
+    if (process.platform === "darwin") {
+      try {
+        await openFileWithDefaultBrowser(filePath);
+        return;
+      } catch (error) {
+        logger.warn?.("Browser Node openFileWithDefaultBrowser failed", {
+          error: error instanceof Error ? error.message : String(error),
+          filePath,
+          url: trimmedUrl
+        });
+      }
+    }
+
+    const openPathError = await shell.openPath(filePath);
+    if (openPathError.length === 0) {
+      return;
+    }
+
+    logger.warn?.("Browser Node shell.openPath failed", {
+      error: openPathError,
+      filePath,
+      url: trimmedUrl
+    });
+  }
+
+  const opened = await shell.openExternal(trimmedUrl);
+  if (!opened) {
+    throw new Error(
+      `Browser Node openExternal returned false for ${trimmedUrl}`
+    );
+  }
 }
 
 function logRejectedGuest(

--- a/packages/browser/workbench-node/src/core/feature.ts
+++ b/packages/browser/workbench-node/src/core/feature.ts
@@ -8,7 +8,9 @@ import {
 } from "./runtimeStore.ts";
 import {
   resolveBrowserAddressInput,
+  resolveBrowserOpenExternalUrl,
   type BrowserAddressInputResolution,
+  type BrowserNavigationUrlResolution,
   type BrowserSearchUrlResolver
 } from "./url.ts";
 
@@ -17,6 +19,7 @@ export interface BrowserNodeFeature {
   i18n: BrowserNodeI18nRuntime;
   reportDiagnostic?: BrowserNodeDiagnosticReporter;
   resolveAddressInput(rawInput: string): BrowserAddressInputResolution;
+  resolveOpenExternalUrl(rawInput: string): BrowserNavigationUrlResolution;
   runtimeStore: BrowserNodeRuntimeStore;
   connect(): () => void;
 }
@@ -71,6 +74,9 @@ export function createBrowserNodeFeature({
     reportDiagnostic,
     resolveAddressInput(rawInput) {
       return resolveBrowserAddressInput(rawInput, { resolveSearchUrl });
+    },
+    resolveOpenExternalUrl(rawInput) {
+      return resolveBrowserOpenExternalUrl(rawInput);
     },
     runtimeStore
   };

--- a/packages/browser/workbench-node/src/core/index.ts
+++ b/packages/browser/workbench-node/src/core/index.ts
@@ -11,6 +11,7 @@ export {
   resolveBrowserAddressInput,
   normalizeHostBrowserComparableUrl,
   resolveBrowserNavigationUrl,
+  resolveBrowserOpenExternalUrl,
   resolveHostBrowserNavigationUrl,
   type BrowserAddressInputResolution,
   type BrowserNavigationUrlErrorCode,

--- a/packages/browser/workbench-node/src/core/url.test.ts
+++ b/packages/browser/workbench-node/src/core/url.test.ts
@@ -4,6 +4,7 @@ import {
   normalizeBrowserComparableUrl,
   resolveBrowserAddressInput,
   resolveBrowserNavigationUrl,
+  resolveBrowserOpenExternalUrl,
   resolveHostBrowserNavigationUrl
 } from "./url.ts";
 
@@ -38,6 +39,23 @@ test("allows host browser navigation for workspace file URLs", () => {
       url: "file:///Users/local/project/index.html"
     }
   );
+});
+
+test("keeps file URLs for external browser open instead of search fallback", () => {
+  const fileUrl = "file:///Users/local/project/memory.md";
+  assert.deepEqual(resolveBrowserOpenExternalUrl(fileUrl), {
+    errorCode: null,
+    url: fileUrl
+  });
+
+  const searchFallback = resolveBrowserAddressInput(fileUrl, {
+    resolveSearchUrl(query) {
+      const searchUrl = new URL("https://www.google.com/search");
+      searchUrl.searchParams.set("q", query);
+      return searchUrl.toString();
+    }
+  });
+  assert.match(searchFallback.url ?? "", /^https:\/\/www\.google\.com\/search/);
 });
 
 test("keeps non-URL address input policy host-provided", () => {

--- a/packages/browser/workbench-node/src/core/url.ts
+++ b/packages/browser/workbench-node/src/core/url.ts
@@ -91,6 +91,12 @@ export function normalizeBrowserComparableUrl(rawUrl: string): string | null {
   return resolved.errorCode === null ? resolved.url : null;
 }
 
+export function resolveBrowserOpenExternalUrl(
+  rawUrl: string
+): BrowserNavigationUrlResolution {
+  return resolveHostBrowserNavigationUrl(rawUrl);
+}
+
 export function resolveHostBrowserNavigationUrl(
   rawUrl: string
 ): BrowserNavigationUrlResolution {

--- a/packages/browser/workbench-node/src/electron-main/electronMain.test.ts
+++ b/packages/browser/workbench-node/src/electron-main/electronMain.test.ts
@@ -608,10 +608,11 @@ test("opens Browser Node URLs externally after validation", async () => {
   await manager.openExternal({ url: "example.com/docs" });
 
   assert.deepEqual(openedExternalUrls, ["https://example.com/docs"]);
-  await assert.rejects(
-    manager.openExternal({ url: "file:///tmp/blocked" }),
-    /rejected external URL/
-  );
+  await manager.openExternal({ url: "file:///tmp/local.html" });
+  assert.deepEqual(openedExternalUrls, [
+    "https://example.com/docs",
+    "file:///tmp/local.html"
+  ]);
 });
 
 test("converts guest preload open-url requests into Browser Node open-url events", async () => {

--- a/packages/browser/workbench-node/src/electron-main/guestManager.ts
+++ b/packages/browser/workbench-node/src/electron-main/guestManager.ts
@@ -664,7 +664,7 @@ export function createBrowserGuestManager({
       await loadDesiredUrl(session);
     },
     async openExternal(input) {
-      const resolved = resolveBrowserNavigationUrl(input.url);
+      const resolved = resolveHostBrowserNavigationUrl(input.url);
       if (!resolved.url) {
         throw new Error("Browser Node rejected external URL");
       }

--- a/packages/browser/workbench-node/src/react/BrowserNode.tsx
+++ b/packages/browser/workbench-node/src/react/BrowserNode.tsx
@@ -15,6 +15,7 @@ import {
 import { useEffect, useRef, useState } from "react";
 import type { HTMLAttributes, JSX, ReactNode } from "react";
 import type { BrowserNodeFeature } from "../core/feature.ts";
+import type { BrowserNodeControllerState } from "../core/nodeController.ts";
 import type {
   BrowserNodeNavigationPolicy,
   BrowserNodeRuntimeError,
@@ -74,9 +75,7 @@ export function BrowserNode({
     ? formatBrowserNodeErrorStatus(feature, runtime.error)
     : null;
   const isShowingLoadError = errorMessage !== null;
-  const openExternalUrl = feature.hostApi.openExternal
-    ? feature.resolveAddressInput(state.displayUrl).url
-    : null;
+  const openExternalUrl = resolveBrowserNodeOpenExternalUrl(feature, state);
   const {
     devToolsContextMenu,
     dismissDevToolsContextMenu,
@@ -138,9 +137,7 @@ export function BrowserNode({
           onOpenExternal={
             openExternalUrl
               ? () => {
-                  void feature.hostApi
-                    .openExternal?.({ url: openExternalUrl })
-                    .catch(() => undefined);
+                  void openBrowserNodeExternal(feature, openExternalUrl);
                 }
               : undefined
           }
@@ -198,9 +195,7 @@ export function BrowserNode({
                     type="button"
                     variant="outline"
                     onClick={() => {
-                      void feature.hostApi
-                        .openExternal?.({ url: openExternalUrl })
-                        .catch(() => undefined);
+                      void openBrowserNodeExternal(feature, openExternalUrl);
                     }}
                   >
                     <LaunchIcon className="size-3.5" />
@@ -272,9 +267,7 @@ export function BrowserNodeWorkbenchHeader({
     nodeId
   });
   const runtime = state.runtime;
-  const openExternalUrl = feature.hostApi.openExternal
-    ? feature.resolveAddressInput(state.displayUrl).url
-    : null;
+  const openExternalUrl = resolveBrowserNodeOpenExternalUrl(feature, state);
 
   return (
     <BrowserNodeHeader
@@ -296,9 +289,7 @@ export function BrowserNodeWorkbenchHeader({
       onOpenExternal={
         openExternalUrl
           ? () => {
-              void feature.hostApi
-                .openExternal?.({ url: openExternalUrl })
-                .catch(() => undefined);
+              void openBrowserNodeExternal(feature, openExternalUrl);
             }
           : undefined
       }
@@ -475,6 +466,40 @@ export function BrowserNodeHeader({
       ) : null}
     </div>
   );
+}
+
+function resolveBrowserNodeOpenExternalUrl(
+  feature: BrowserNodeFeature,
+  state: BrowserNodeControllerState
+): string | null {
+  if (!feature.hostApi.openExternal) {
+    return null;
+  }
+
+  const sourceUrl = state.runtime.url?.trim() || state.displayUrl.trim();
+  if (sourceUrl.length === 0 || sourceUrl === "about:blank") {
+    return null;
+  }
+
+  return feature.resolveOpenExternalUrl(sourceUrl).url;
+}
+
+async function openBrowserNodeExternal(
+  feature: BrowserNodeFeature,
+  url: string
+): Promise<void> {
+  try {
+    await feature.hostApi.openExternal?.({ url });
+  } catch (error) {
+    feature.reportDiagnostic?.({
+      details: {
+        error: error instanceof Error ? error.message : String(error),
+        url
+      },
+      event: "open-external-failed",
+      level: "warn"
+    });
+  }
 }
 
 function formatBrowserNodeErrorMessage(


### PR DESCRIPTION
## Summary

- 修复内置浏览器打开 `file://` 本地文件后，点击「在浏览器中打开」被误当成 Google 搜索的问题
- 为外部打开动作使用独立的 URL 解析（`resolveOpenExternalUrl`），支持 `file://`，不再走地址栏搜索 fallback
- 主进程在 macOS 上优先通过 `openFileWithDefaultBrowser` 用系统默认浏览器打开本地文件，失败时回退到 `shell.openPath` / `shell.openExternal`

## Test plan

- [ ] 在内置浏览器中打开本地 `.md` / `.html` 文件
- [ ] 点击工具栏「在浏览器中打开」，应在系统默认浏览器中打开同一文件
- [ ] 打开普通 `https://` 页面后点击「在浏览器中打开」，仍能在系统浏览器中正常打开
- [ ] 地址栏输入非 URL 文本并搜索的行为不受影响


Made with [Cursor](https://cursor.com)