### PR TITLE
[codex] remove app factory validate action

### DIFF
--- a/packages/workspace/app-center/src/core/appCenterViewModel.test.ts
+++ b/packages/workspace/app-center/src/core/appCenterViewModel.test.ts
@@ -931,7 +931,7 @@ describe("createAppCenterViewModel", () => {
     assert.equal(builtinApp?.canReplaceIcon, false);
   });
 
-  it("only exposes factory validation retry after failure", () => {
+  it("exposes factory fix after validation failure without a manual validation action", () => {
     const viewModel = createAppCenterViewModel({
       apps: [],
       factoryJobs: [
@@ -950,7 +950,7 @@ describe("createAppCenterViewModel", () => {
       ]
     });
 
-    assert.equal(viewModel.factoryJobs?.[0]?.canRetryValidation, true);
+    assert.equal(viewModel.factoryJobs?.[0]?.canRetryValidation, false);
     assert.equal(viewModel.factoryJobs?.[0]?.canFix, true);
     assert.equal(viewModel.factoryJobs?.[0]?.canCancel, false);
     assert.equal(viewModel.factoryJobs?.[0]?.canDelete, true);

--- a/packages/workspace/app-center/src/core/appCenterViewModel.ts
+++ b/packages/workspace/app-center/src/core/appCenterViewModel.ts
@@ -415,7 +415,7 @@ function createFactoryJobViewModel(
     canFix: canFixValidationFailure,
     canOpenAgentSession: Boolean(agentSessionId),
     canPublish: job.status === "ready",
-    canRetryValidation: canFixValidationFailure,
+    canRetryValidation: false,
     failureReason: job.failureReason,
     updatedAtUnixMs: job.updatedAtUnixMs
   };

--- a/packages/workspace/app-center/src/i18n/appCenterI18n.ts
+++ b/packages/workspace/app-center/src/i18n/appCenterI18n.ts
@@ -78,6 +78,8 @@ export const appCenterEn = {
     },
     messages: {
       factoryJobFailed:
+        "App creation failed. Open the agent session to view details.",
+      factoryJobFailedWithFix:
         "App creation failed. Open the agent session or try Fix to view details.",
       loadingConfiguration: "Loading configuration...",
       loadingProviders: "Loading agent providers...",
@@ -365,7 +367,9 @@ export const appCenterZhCN = {
       templates: "选择起点"
     },
     messages: {
-      factoryJobFailed: "应用创建失败。打开 Agent 会话或使用修复操作查看详情。",
+      factoryJobFailed: "应用创建失败。打开 Agent 会话查看详情。",
+      factoryJobFailedWithFix:
+        "应用创建失败。打开 Agent 会话或使用修复操作查看详情。",
       loadingConfiguration: "正在加载配置...",
       loadingProviders: "正在加载 Agent Provider...",
       noAgentProviders: "暂无可用的 Agent Provider。",

--- a/packages/workspace/app-center/src/ui/AppCenterPanel.tsx
+++ b/packages/workspace/app-center/src/ui/AppCenterPanel.tsx
@@ -549,7 +549,11 @@ export function AppCenterPanel({
                         className="mt-2 truncate text-[11px] leading-4 text-[var(--state-danger)]"
                         title={job.failureReason}
                       >
-                        {copy.t("factory.messages.factoryJobFailed")}
+                        {copy.t(
+                          job.canFix
+                            ? "factory.messages.factoryJobFailedWithFix"
+                            : "factory.messages.factoryJobFailed"
+                        )}
                       </p>
                     ) : (
                       <p className="mt-2 truncate text-[11px] leading-4 text-[var(--text-secondary)]">
@@ -558,19 +562,6 @@ export function AppCenterPanel({
                     )}
                   </div>
                   <div className="flex shrink-0 items-center gap-1">
-                    {job.canRetryValidation ? (
-                      <Button
-                        size="sm"
-                        type="button"
-                        variant="ghost"
-                        onClick={(event) => {
-                          event.stopPropagation();
-                          void actions.retryFactoryValidation?.(job.id);
-                        }}
-                      >
-                        {copy.t("factory.actions.validate")}
-                      </Button>
-                    ) : null}
                     {job.canPublish ? (
                       <Button
                         size="sm"


### PR DESCRIPTION
## Summary
- remove the manual Validate action from App Factory failed job rows
- keep Fix available only for validation failures
- show separate failure copy when Fix is unavailable

## Why
App Factory validation runs automatically when generation completes. The manual Validate button looked inert, and the old failure copy could mention Fix even when no Fix action was available.

## Validation
- pnpm --filter @tutti-os/workspace-app-center test
- pnpm --filter @tutti-os/workspace-app-center typecheck
- pnpm --filter @tutti-os/desktop typecheck
- pnpm lint:ts
- pnpm --filter @tutti-os/desktop build
- pnpm test:ts
- pre-push pnpm check:full passed on retry

Note: the first pre-push attempt hit transient desktop app-center test failures; the failing files passed when rerun directly, `pnpm test:ts` passed, and the later pre-push `check:full` passed.