### PR TITLE
[codex] Fix agent GUI composer input state

### DIFF
--- a/packages/agent/gui/agent-gui/agentGuiNode/AgentComposer.spec.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/AgentComposer.spec.tsx
@@ -541,6 +541,53 @@ describe("AgentComposer", () => {
     expect(onSubmit).not.toHaveBeenCalled();
   });
 
+  it("clears the visible draft immediately after a normal prompt submit", () => {
+    const onDraftChange = vi.fn();
+    const onSubmit = vi.fn();
+    const { container } = render(
+      <AgentComposer
+        workspaceId="workspace-1"
+        currentUserId="user-1"
+        provider="codex"
+        draftPrompt="run the tests"
+        availableCommands={[] satisfies readonly AgentHostAgentSessionCommand[]}
+        disabled={false}
+        submitDisabled={false}
+        placeholder="placeholder"
+        composerSettings={createComposerSettings()}
+        queuedPrompts={[]}
+        drainingQueuedPromptId={null}
+        canQueueWhileBusy={false}
+        showStopButton={false}
+        activePrompt={null}
+        isInterrupting={false}
+        isSendingTurn={false}
+        isSubmittingPrompt={false}
+        labels={createLabels()}
+        workspaceUserProjectI18n={workspaceUserProjectI18n}
+        onDraftChange={onDraftChange}
+        onSettingsChange={vi.fn()}
+        onSubmit={onSubmit}
+        onSendQueuedPromptNext={vi.fn()}
+        onRemoveQueuedPrompt={vi.fn()}
+        onEditQueuedPrompt={vi.fn()}
+        onInterruptCurrentTurn={vi.fn()}
+        onSubmitInteractivePrompt={vi.fn()}
+      />
+    );
+
+    const editor = screen.getByPlaceholderText("placeholder");
+    expect(editor).toHaveValue("run the tests");
+
+    fireEvent.submit(container.querySelector("form")!);
+
+    expect(onSubmit).toHaveBeenCalledWith([
+      { type: "text", text: "run the tests" }
+    ]);
+    expect(onDraftChange).toHaveBeenCalledWith("");
+    expect(editor).toHaveValue("");
+  });
+
   it("toggles a persistent status panel for the local status slash command", () => {
     const { container, rerender } = render(
       <AgentComposer
@@ -1405,6 +1452,15 @@ describe("AgentComposer", () => {
     const css = readFileSync(resolve("app/renderer/agentactivity.css"), "utf8");
     expect(css).toMatch(
       /\.agent-gui-node__composer-textarea\s*{[^}]*font-size:\s*13px/s
+    );
+    expect(css).toMatch(
+      /\.agent-gui-node__composer-textarea\s*{[^}]*max-height:\s*72px;[^}]*overflow-y:\s*auto;[^}]*scrollbar-width:\s*thin;[^}]*scrollbar-gutter:\s*stable/s
+    );
+    expect(css).toMatch(
+      /\.agent-gui-node__composer-textarea::-webkit-scrollbar\s*{[^}]*display:\s*block;[^}]*width:\s*4px/s
+    );
+    expect(css).toMatch(
+      /\.agent-gui-node__composer-textarea::-webkit-scrollbar-thumb\s*{[^}]*background:\s*var\(--transparency-hover\)/s
     );
     expect(css).toMatch(
       /\.agent-gui-node__composer-textarea p\s*{[^}]*font-size:\s*13px/s

--- a/packages/agent/gui/agent-gui/agentGuiNode/AgentComposer.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/AgentComposer.tsx
@@ -930,6 +930,9 @@ export function AgentComposer({
       setSubmittedImagePreview([]);
       submittedImagePreviewObservedBusyRef.current = false;
     }
+    draftPromptRef.current = "";
+    setPaletteDraftPrompt("");
+    onDraftChange("");
     setDraftImages([]);
   };
 

--- a/packages/agent/gui/agent-gui/agentGuiNode/AgentGUINode.spec.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/AgentGUINode.spec.tsx
@@ -3457,7 +3457,7 @@ describe("AgentGUINode", () => {
 
     expect(mockUpdateComposerSettings).not.toHaveBeenCalled();
     expect(mockSubmitPrompt).toHaveBeenCalledWith(promptBlocks("/pla"));
-    expect(mockUpdateDraftPrompt).not.toHaveBeenCalledWith("");
+    expect(mockUpdateDraftPrompt).toHaveBeenCalledWith("");
   });
 
   it("blocks manual Codex plan text", () => {
@@ -3715,8 +3715,8 @@ describe("AgentGUINode", () => {
       key: "Enter"
     });
 
-    expect(mockUpdateDraftPrompt).not.toHaveBeenCalled();
     expect(mockSubmitPrompt).toHaveBeenCalledWith(promptBlocks("/web query"));
+    expect(mockUpdateDraftPrompt).toHaveBeenCalledWith("");
   });
 
   it("does not match slash commands after non-command text", () => {
@@ -3747,10 +3747,12 @@ describe("AgentGUINode", () => {
 
     const editor = getComposerEditor();
     fireEvent.keyDown(editor, { key: "Escape" });
+    expect(mockUpdateDraftPrompt).not.toHaveBeenCalled();
+
     fireEvent.keyDown(editor, { key: "Enter" });
 
-    expect(mockUpdateDraftPrompt).not.toHaveBeenCalled();
     expect(mockSubmitPrompt).toHaveBeenCalledWith(promptBlocks("/"));
+    expect(mockUpdateDraftPrompt).toHaveBeenCalledWith("");
   });
 
   it("filters slash commands and closes the palette after the command token", () => {

--- a/packages/agent/gui/app/renderer/agentactivity.css
+++ b/packages/agent/gui/app/renderer/agentactivity.css
@@ -6241,6 +6241,7 @@ html[data-theme="light"] [data-message-center-item-id].agent-gui-edge-glow {
   min-width: 0;
   min-height: 46px;
   max-height: 72px;
+  overflow-y: auto;
   border: 0;
   background: transparent;
   color: var(--agent-gui-text-primary);
@@ -6250,6 +6251,30 @@ html[data-theme="light"] [data-message-center-item-id].agent-gui-edge-glow {
   outline: 0;
   padding: 0;
   resize: none;
+  scrollbar-width: thin;
+  scrollbar-color: var(--transparency-hover) transparent;
+  scrollbar-gutter: stable;
+  -ms-overflow-style: auto;
+}
+
+.agent-gui-node__composer textarea::-webkit-scrollbar,
+.agent-gui-node__composer-textarea::-webkit-scrollbar {
+  display: block;
+  width: 4px;
+  height: 4px;
+}
+
+.agent-gui-node__composer textarea::-webkit-scrollbar-track,
+.agent-gui-node__composer textarea::-webkit-scrollbar-corner,
+.agent-gui-node__composer-textarea::-webkit-scrollbar-track,
+.agent-gui-node__composer-textarea::-webkit-scrollbar-corner {
+  background: transparent;
+}
+
+.agent-gui-node__composer textarea::-webkit-scrollbar-thumb,
+.agent-gui-node__composer-textarea::-webkit-scrollbar-thumb {
+  border-radius: 999px;
+  background: var(--transparency-hover);
 }
 
 .agent-gui-node__composer-input-shell[data-input-disabled="true"],


### PR DESCRIPTION
## Summary
- Show a stable visible scrollbar for the agent GUI composer when multi-line input exceeds the composer height.
- Clear the visible composer draft immediately after a normal prompt submit instead of waiting for parent state to catch up.
- Update AgentComposer and AgentGUINode tests for the new draft-clearing behavior.

## Root cause
- The rich text composer had a height cap and overflow behavior, but no explicit visible scrollbar styling, so repeated Shift+Enter could produce scrollable content without an obvious scrollbar.
- The normal submit path sent the prompt but did not clear the local composer draft or notify the parent draft state immediately, leaving submitted text visible until an async state update arrived.

## Validation
- pnpm --filter @tutti-os/agent-gui typecheck
- pnpm --filter @tutti-os/agent-gui test -- agent-gui/agentGuiNode/AgentComposer.spec.tsx
- pnpm --filter @tutti-os/desktop build
- pre-push check:full