### PR TITLE
fix(app-center): sync factory job failures and refine app ordering

### DIFF
--- a/apps/desktop/src/renderer/src/features/workspace-app-center/ui/WorkspaceAppCenterPane.tsx
+++ b/apps/desktop/src/renderer/src/features/workspace-app-center/ui/WorkspaceAppCenterPane.tsx
@@ -37,34 +37,9 @@ import { useWorkspaceAppCenterService } from "./useWorkspaceAppCenterService.ts"
 
 const comingSoonWorkspaceAppDefinitions = [
   {
-    appId: "product-competition",
-    displayTagKeys: [
-      "appCenter.comingSoonTags.productCompetition.primary",
-      "appCenter.comingSoonTags.productCompetition.secondary",
-      "appCenter.comingSoonTags.productCompetition.tertiary"
-    ],
-    tags: ["coming-soon", "product", "design"]
-  },
-  {
-    appId: "design-review",
-    displayTagKeys: [
-      "appCenter.comingSoonTags.designReview.primary",
-      "appCenter.comingSoonTags.designReview.secondary",
-      "appCenter.comingSoonTags.designReview.tertiary"
-    ],
-    tags: ["coming-soon", "product", "design"]
-  },
-  {
-    appId: "group-chat",
-    displayTagKeys: [
-      "appCenter.comingSoonTags.groupChat.primary",
-      "appCenter.comingSoonTags.groupChat.secondary",
-      "appCenter.comingSoonTags.groupChat.tertiary"
-    ],
-    tags: ["coming-soon", "productivity", "chat", "team"]
-  },
-  {
     appId: "ai-ppt",
+    descriptionKey: "appCenter.comingSoonApps.aiPpt.description",
+    nameKey: "appCenter.comingSoonApps.aiPpt.name",
     displayTagKeys: [
       "appCenter.comingSoonTags.aiPpt.primary",
       "appCenter.comingSoonTags.aiPpt.secondary",
@@ -74,6 +49,8 @@ const comingSoonWorkspaceAppDefinitions = [
   },
   {
     appId: "ai-document",
+    descriptionKey: "appCenter.comingSoonApps.aiDocument.description",
+    nameKey: "appCenter.comingSoonApps.aiDocument.name",
     displayTagKeys: [
       "appCenter.comingSoonTags.aiDocument.primary",
       "appCenter.comingSoonTags.aiDocument.secondary",
@@ -83,6 +60,8 @@ const comingSoonWorkspaceAppDefinitions = [
   },
   {
     appId: "ai-sheet",
+    descriptionKey: "appCenter.comingSoonApps.aiSheet.description",
+    nameKey: "appCenter.comingSoonApps.aiSheet.name",
     displayTagKeys: [
       "appCenter.comingSoonTags.aiSheet.primary",
       "appCenter.comingSoonTags.aiSheet.secondary",
@@ -92,6 +71,8 @@ const comingSoonWorkspaceAppDefinitions = [
   },
   {
     appId: "open-cut",
+    descriptionKey: "appCenter.comingSoonApps.openCut.description",
+    nameKey: "appCenter.comingSoonApps.openCut.name",
     displayTagKeys: [
       "appCenter.comingSoonTags.openCut.primary",
       "appCenter.comingSoonTags.openCut.secondary",
@@ -100,7 +81,31 @@ const comingSoonWorkspaceAppDefinitions = [
     tags: ["coming-soon", "content", "creation", "video", "timeline", "editor"]
   },
   {
+    appId: "product-competition",
+    descriptionKey: "appCenter.comingSoonApps.productCompetition.description",
+    nameKey: "appCenter.comingSoonApps.productCompetition.name",
+    displayTagKeys: [
+      "appCenter.comingSoonTags.productCompetition.primary",
+      "appCenter.comingSoonTags.productCompetition.secondary",
+      "appCenter.comingSoonTags.productCompetition.tertiary"
+    ],
+    tags: ["coming-soon", "product", "design"]
+  },
+  {
+    appId: "design-review",
+    descriptionKey: "appCenter.comingSoonApps.designReview.description",
+    nameKey: "appCenter.comingSoonApps.designReview.name",
+    displayTagKeys: [
+      "appCenter.comingSoonTags.designReview.primary",
+      "appCenter.comingSoonTags.designReview.secondary",
+      "appCenter.comingSoonTags.designReview.tertiary"
+    ],
+    tags: ["coming-soon", "product", "design"]
+  },
+  {
     appId: "calendar",
+    descriptionKey: "appCenter.comingSoonApps.calendar.description",
+    nameKey: "appCenter.comingSoonApps.calendar.name",
     displayTagKeys: [
       "appCenter.comingSoonTags.calendar.primary",
       "appCenter.comingSoonTags.calendar.secondary",
@@ -110,6 +115,8 @@ const comingSoonWorkspaceAppDefinitions = [
   },
   {
     appId: "document-summarizer",
+    descriptionKey: "appCenter.comingSoonApps.documentSummarizer.description",
+    nameKey: "appCenter.comingSoonApps.documentSummarizer.name",
     displayTagKeys: [
       "appCenter.comingSoonTags.documentSummarizer.primary",
       "appCenter.comingSoonTags.documentSummarizer.secondary",
@@ -309,75 +316,15 @@ function createComingSoonWorkspaceApps(
   i18n: { readonly t: (key: string) => string },
   locale: string
 ): readonly WorkspaceAppCenterApp[] {
-  return [
+  return comingSoonWorkspaceAppDefinitions.map((definition) =>
     createComingSoonWorkspaceApp({
-      description: i18n.t(
-        "appCenter.comingSoonApps.productCompetition.description"
-      ),
-      definition: comingSoonWorkspaceAppDefinitions[0],
+      description: i18n.t(definition.descriptionKey),
+      definition,
       locale,
-      name: i18n.t("appCenter.comingSoonApps.productCompetition.name"),
-      t: i18n.t
-    }),
-    createComingSoonWorkspaceApp({
-      description: i18n.t("appCenter.comingSoonApps.designReview.description"),
-      definition: comingSoonWorkspaceAppDefinitions[1],
-      locale,
-      name: i18n.t("appCenter.comingSoonApps.designReview.name"),
-      t: i18n.t
-    }),
-    createComingSoonWorkspaceApp({
-      description: i18n.t("appCenter.comingSoonApps.groupChat.description"),
-      definition: comingSoonWorkspaceAppDefinitions[2],
-      locale,
-      name: i18n.t("appCenter.comingSoonApps.groupChat.name"),
-      t: i18n.t
-    }),
-    createComingSoonWorkspaceApp({
-      description: i18n.t("appCenter.comingSoonApps.aiPpt.description"),
-      definition: comingSoonWorkspaceAppDefinitions[3],
-      locale,
-      name: i18n.t("appCenter.comingSoonApps.aiPpt.name"),
-      t: i18n.t
-    }),
-    createComingSoonWorkspaceApp({
-      description: i18n.t("appCenter.comingSoonApps.aiDocument.description"),
-      definition: comingSoonWorkspaceAppDefinitions[4],
-      locale,
-      name: i18n.t("appCenter.comingSoonApps.aiDocument.name"),
-      t: i18n.t
-    }),
-    createComingSoonWorkspaceApp({
-      description: i18n.t("appCenter.comingSoonApps.aiSheet.description"),
-      definition: comingSoonWorkspaceAppDefinitions[5],
-      locale,
-      name: i18n.t("appCenter.comingSoonApps.aiSheet.name"),
-      t: i18n.t
-    }),
-    createComingSoonWorkspaceApp({
-      description: i18n.t("appCenter.comingSoonApps.openCut.description"),
-      definition: comingSoonWorkspaceAppDefinitions[6],
-      locale,
-      name: i18n.t("appCenter.comingSoonApps.openCut.name"),
-      t: i18n.t
-    }),
-    createComingSoonWorkspaceApp({
-      description: i18n.t("appCenter.comingSoonApps.calendar.description"),
-      definition: comingSoonWorkspaceAppDefinitions[7],
-      locale,
-      name: i18n.t("appCenter.comingSoonApps.calendar.name"),
-      t: i18n.t
-    }),
-    createComingSoonWorkspaceApp({
-      description: i18n.t(
-        "appCenter.comingSoonApps.documentSummarizer.description"
-      ),
-      definition: comingSoonWorkspaceAppDefinitions[8],
-      locale,
-      name: i18n.t("appCenter.comingSoonApps.documentSummarizer.name"),
+      name: i18n.t(definition.nameKey),
       t: i18n.t
     })
-  ];
+  );
 }
 
 function createComingSoonWorkspaceApp(input: {
@@ -417,13 +364,27 @@ function withComingSoonWorkspaceApps(
   apps: readonly WorkspaceAppCenterApp[],
   comingSoonApps: readonly WorkspaceAppCenterApp[]
 ): readonly WorkspaceAppCenterApp[] {
-  const existingAppIds = new Set(apps.map((app) => app.appId));
-  const missingComingSoonApps = comingSoonApps.filter(
-    (app) => !existingAppIds.has(app.appId)
+  const comingSoonByAppId = new Map(
+    comingSoonApps.map((app) => [app.appId, app] as const)
   );
-  return missingComingSoonApps.length > 0
-    ? [...apps, ...missingComingSoonApps]
-    : apps;
+  const mergedApps = apps.map((app) => {
+    const comingSoonApp = comingSoonByAppId.get(app.appId);
+    if (!comingSoonApp) {
+      return app;
+    }
+    comingSoonByAppId.delete(app.appId);
+    return {
+      ...comingSoonApp,
+      ...(app.iconUrl ? { iconUrl: app.iconUrl } : {}),
+      ...(app.availableIconUrl
+        ? { availableIconUrl: app.availableIconUrl }
+        : {})
+    };
+  });
+  const remainingComingSoonApps = [...comingSoonByAppId.values()];
+  return remainingComingSoonApps.length > 0
+    ? [...mergedApps, ...remainingComingSoonApps]
+    : mergedApps;
 }
 
 function withWorkspaceAppIconOverride(

--- a/packages/workspace/app-center/src/core/appCenterAppOrdering.test.ts
+++ b/packages/workspace/app-center/src/core/appCenterAppOrdering.test.ts
@@ -25,88 +25,123 @@ describe("sortMyAppsByCreatedDesc", () => {
 });
 
 describe("sortRecommendedApps", () => {
-  it("orders recommended apps by configured category sections", () => {
+  it("orders recommended apps by the configured display list", () => {
     const apps = [
-      createApp({ category: "内容创作", id: "media", name: "Media" }),
-      createApp({ category: "工具", id: "automation", name: "Automation" }),
-      createApp({ category: "办公", id: "chat", name: "Chat" }),
       createApp({
-        category: "产品与设计",
-        id: "design",
-        name: "Design"
+        id: "automation",
+        name: "Automation",
+        sourceKind: "bundled"
+      }),
+      createApp({
+        id: "ai-ppt",
+        name: "AI PPT",
+        sourceKind: "bundled",
+        tags: ["coming-soon"]
+      }),
+      createApp({
+        id: "vibe-design",
+        name: "Vibe Design",
+        sourceKind: "bundled"
+      }),
+      createApp({
+        id: "ai-media-canvas",
+        name: "AI Media Canvas",
+        sourceKind: "bundled"
+      }),
+      createApp({
+        id: "daily-product-radar",
+        name: "Daily Product Radar",
+        sourceKind: "bundled"
       })
     ];
 
     assert.deepEqual(
       sortRecommendedApps(apps).map((app) => app.id),
-      ["design", "chat", "automation", "media"]
+      [
+        "ai-media-canvas",
+        "vibe-design",
+        "automation",
+        "daily-product-radar",
+        "ai-ppt"
+      ]
     );
   });
 
-  it("places coming soon apps at the end of each category", () => {
+  it("places unlisted apps after configured apps and keeps coming soon after ready", () => {
     const apps = [
       createApp({
-        category: "产品与设计",
-        id: "soon-a",
-        name: "Alpha coming soon",
+        id: "unknown-soon",
+        name: "Unknown soon",
+        sourceKind: "bundled",
         statusLabelKey: "status.comingSoon"
       }),
       createApp({
-        category: "产品与设计",
-        id: "ready-b",
-        name: "Zeta ready"
+        id: "unknown-ready",
+        name: "Unknown ready",
+        sourceKind: "bundled"
       }),
-      createApp({
-        category: "产品与设计",
-        id: "ready-a",
-        name: "Alpha ready"
-      }),
-      createApp({
-        category: "产品与设计",
-        id: "soon-b",
-        name: "Beta coming soon",
-        tags: ["coming-soon"]
-      }),
-      createApp({ category: "办公", id: "office", name: "Office" })
+      createApp({ id: "automation", name: "Automation", sourceKind: "bundled" })
     ];
 
     assert.deepEqual(
       sortRecommendedApps(apps).map((app) => app.id),
-      ["ready-a", "ready-b", "soon-a", "soon-b", "office"]
+      ["automation", "unknown-ready", "unknown-soon"]
     );
   });
 });
 
 describe("sortRecommendedAppsForAllTab", () => {
-  it("places all coming soon apps after ready apps across categories", () => {
+  it("uses the same configured display order as category tabs", () => {
     const apps = [
       createApp({
-        category: "产品与设计",
-        id: "design-soon",
-        name: "Design soon",
+        id: "document-summarizer",
+        name: "Document Summarizer",
+        sourceKind: "bundled",
         tags: ["coming-soon"]
       }),
       createApp({
-        category: "内容创作",
-        id: "media-ready",
-        name: "Media ready"
+        id: "group-chat",
+        name: "Group Chat",
+        sourceKind: "bundled"
       }),
       createApp({
-        category: "办公",
-        id: "office-soon",
-        name: "Office soon",
-        statusLabelKey: "status.comingSoon"
+        id: "open-cut",
+        name: "Open Cut",
+        sourceKind: "bundled",
+        tags: ["coming-soon"]
       }),
       createApp({
-        category: "工具",
-        id: "tool-ready",
-        name: "Tool ready"
+        id: "ai-media-canvas",
+        name: "AI Media Canvas",
+        sourceKind: "bundled"
       })
     ];
 
     assert.deepEqual(
       sortRecommendedAppsForAllTab(apps).map((app) => app.id),
-      ["tool-ready", "media-ready", "design-soon", "office-soon"]
+      ["ai-media-canvas", "group-chat", "open-cut", "document-summarizer"]
+    );
+  });
+
+  it("orders radar aliases with other installable apps before coming soon apps", () => {
+    const apps = [
+      createApp({
+        id: "ai-ppt",
+        name: "AI PPT",
+        sourceKind: "bundled",
+        tags: ["coming-soon"]
+      }),
+      createApp({
+        id: "daily-tech-radar",
+        name: "每日产品雷达",
+        sourceKind: "bundled"
+      }),
+      createApp({ id: "automation", name: "Automation", sourceKind: "bundled" })
+    ];
+
+    assert.deepEqual(
+      sortRecommendedAppsForAllTab(apps).map((app) => app.id),
+      ["automation", "daily-tech-radar", "ai-ppt"]
     );
   });
 });
@@ -116,7 +151,11 @@ function createApp(
     Partial<
       Pick<
         AppCenterViewModel["apps"][number],
-        "category" | "createdAtUnixMs" | "statusLabelKey" | "tags"
+        | "category"
+        | "createdAtUnixMs"
+        | "sourceKind"
+        | "statusLabelKey"
+        | "tags"
       >
     >
 ): AppCenterViewModel["apps"][number] {

--- a/packages/workspace/app-center/src/core/appCenterAppOrdering.ts
+++ b/packages/workspace/app-center/src/core/appCenterAppOrdering.ts
@@ -1,5 +1,26 @@
 import type { AppCenterViewModel } from "../contracts/viewModel.ts";
 
+const installableRecommendedAppIds = [
+  ["ai-media-canvas", "media-canvas"],
+  ["vibe-design"],
+  ["group-chat"],
+  ["automation"],
+  ["daily-product-radar", "daily-tech-radar", "radar"]
+] as const;
+
+const comingSoonRecommendedAppIds = [
+  "ai-ppt",
+  "ai-document",
+  "ai-sheet",
+  "open-cut",
+  "product-competition",
+  "design-review",
+  "calendar",
+  "document-summarizer"
+] as const;
+
+const recommendedAppDisplayRankById = buildRecommendedAppDisplayRankById();
+
 export function sortMyAppsByCreatedDesc(
   apps: readonly AppCenterViewModel["apps"][number][]
 ): AppCenterViewModel["apps"] {
@@ -20,41 +41,83 @@ export function sortMyAppsByCreatedDesc(
 export function sortRecommendedApps(
   apps: readonly AppCenterViewModel["apps"][number][]
 ): AppCenterViewModel["apps"] {
-  return [...apps].sort((left, right) => {
-    const categoryOrder =
-      getRecommendedAppCategoryRank(left) -
-      getRecommendedAppCategoryRank(right);
-    if (categoryOrder !== 0) {
-      return categoryOrder;
-    }
-    const comingSoonOrder =
-      getRecommendedAppComingSoonRank(left) -
-      getRecommendedAppComingSoonRank(right);
-    if (comingSoonOrder !== 0) {
-      return comingSoonOrder;
-    }
-    return left.name.localeCompare(right.name);
-  });
+  return [...apps].sort(compareRecommendedApps);
 }
 
 export function sortRecommendedAppsForAllTab(
   apps: readonly AppCenterViewModel["apps"][number][]
 ): AppCenterViewModel["apps"] {
-  return [...apps].sort((left, right) => {
-    const comingSoonOrder =
-      getRecommendedAppComingSoonRank(left) -
-      getRecommendedAppComingSoonRank(right);
-    if (comingSoonOrder !== 0) {
-      return comingSoonOrder;
+  return [...apps].sort(compareRecommendedApps);
+}
+
+function compareRecommendedApps(
+  left: AppCenterViewModel["apps"][number],
+  right: AppCenterViewModel["apps"][number]
+): number {
+  const sectionOrder =
+    getRecommendedAppSectionRank(left) - getRecommendedAppSectionRank(right);
+  if (sectionOrder !== 0) {
+    return sectionOrder;
+  }
+
+  const displayOrder =
+    getRecommendedAppDisplayRank(left.id) -
+    getRecommendedAppDisplayRank(right.id);
+  if (displayOrder !== 0) {
+    return displayOrder;
+  }
+
+  const comingSoonOrder =
+    getRecommendedAppComingSoonRank(left) -
+    getRecommendedAppComingSoonRank(right);
+  if (comingSoonOrder !== 0) {
+    return comingSoonOrder;
+  }
+
+  return left.name.localeCompare(right.name);
+}
+
+function buildRecommendedAppDisplayRankById(): Map<string, number> {
+  const rankById = new Map<string, number>();
+  let rank = 0;
+
+  for (const aliases of installableRecommendedAppIds) {
+    for (const appId of aliases) {
+      rankById.set(appId, rank);
     }
-    const categoryOrder =
-      getRecommendedAppCategoryRank(left) -
-      getRecommendedAppCategoryRank(right);
-    if (categoryOrder !== 0) {
-      return categoryOrder;
-    }
-    return left.name.localeCompare(right.name);
-  });
+    rank += 1;
+  }
+
+  for (const appId of comingSoonRecommendedAppIds) {
+    rankById.set(appId, rank);
+    rank += 1;
+  }
+
+  return rankById;
+}
+
+function getRecommendedAppDisplayRank(appId: string): number {
+  return (
+    recommendedAppDisplayRankById.get(appId.trim().toLowerCase()) ??
+    Number.MAX_SAFE_INTEGER
+  );
+}
+
+function getRecommendedAppSectionRank(
+  app: AppCenterViewModel["apps"][number]
+): number {
+  const normalizedAppId = app.id.trim().toLowerCase();
+  if (recommendedAppDisplayRankById.has(normalizedAppId)) {
+    return isConfiguredComingSoonApp(normalizedAppId) ? 1 : 0;
+  }
+
+  return getRecommendedAppComingSoonRank(app);
+}
+
+function isConfiguredComingSoonApp(appId: string): boolean {
+  return comingSoonRecommendedAppIds.some(
+    (configuredAppId) => configuredAppId === appId
+  );
 }
 
 function getRecommendedAppComingSoonRank(
@@ -64,49 +127,4 @@ function getRecommendedAppComingSoonRank(
     app.tags.some((tag) => tag.trim().toLowerCase() === "coming-soon")
     ? 1
     : 0;
-}
-
-function getRecommendedAppCategoryRank(
-  app: AppCenterViewModel["apps"][number]
-): number {
-  const category = app.category?.trim().toLowerCase() ?? "";
-  if (category === "产品与设计" || category === "product and design") {
-    return 0;
-  }
-  if (category === "办公" || category === "office") {
-    return 1;
-  }
-  if (
-    category === "工具" ||
-    category === "tools" ||
-    category === "productivity"
-  ) {
-    return 2;
-  }
-  if (category === "内容创作" || category === "content creation") {
-    return 3;
-  }
-
-  const searchableText = [app.id, app.name, app.description, ...app.tags]
-    .filter(Boolean)
-    .join(" ")
-    .toLowerCase();
-
-  if (
-    /\b(automation|schedule|recurring|productivity|efficiency|workflow|task)\b/.test(
-      searchableText
-    )
-  ) {
-    return 0;
-  }
-
-  if (
-    /\b(media|canvas|video|edit|design|prototype|creative|creation)\b/.test(
-      searchableText
-    )
-  ) {
-    return 1;
-  }
-
-  return 2;
 }

--- a/packages/workspace/app-center/src/ui/AppCenterPanel.tsx
+++ b/packages/workspace/app-center/src/ui/AppCenterPanel.tsx
@@ -506,129 +506,6 @@ export function AppCenterPanel({
     >
       {statusToast ? <AppCenterStatusToast toast={statusToast} /> : null}
       <div className="flex min-h-0 flex-1 flex-col gap-5 overflow-auto px-6 pb-6 pt-5 [container-type:inline-size]">
-        {hasFactoryJobs ? (
-          <section className="min-w-0">
-            <h2 className="mb-3 text-[15px] font-semibold leading-5 tracking-[0] text-[var(--text-primary)]">
-              {copy.t("factory.labels.jobs")}
-            </h2>
-            <div className="flex min-w-0 flex-col gap-2">
-              {factoryJobs.map((job) => (
-                <article
-                  aria-disabled={job.canOpenAgentSession ? undefined : true}
-                  className={cn(
-                    "group flex min-w-0 items-center justify-between gap-3 rounded-[8px] border border-[color:var(--line-2)] bg-[var(--background-fronted)] p-[12px] text-left transition-colors duration-150 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--border-focus)]",
-                    job.canOpenAgentSession
-                      ? "cursor-pointer hover:bg-[var(--transparency-block)]"
-                      : "cursor-default"
-                  )}
-                  key={job.id}
-                  role="button"
-                  tabIndex={job.canOpenAgentSession ? 0 : -1}
-                  onClick={() => openFactoryJobAgentSession(job)}
-                  onKeyDown={(event) => {
-                    if (
-                      !job.canOpenAgentSession ||
-                      event.currentTarget !== event.target ||
-                      (event.key !== "Enter" && event.key !== " ")
-                    ) {
-                      return;
-                    }
-                    event.preventDefault();
-                    openFactoryJobAgentSession(job);
-                  }}
-                >
-                  <div className="min-w-0">
-                    <div className="flex min-w-0 items-center gap-2">
-                      <h3 className="truncate text-[13px] font-semibold leading-5 text-[var(--text-primary)]">
-                        {job.title}
-                      </h3>
-                      <FactoryJobStatusIndicator copy={copy} job={job} />
-                    </div>
-                    {job.failureReason ? (
-                      <p
-                        className="mt-2 truncate text-[11px] leading-4 text-[var(--state-danger)]"
-                        title={job.failureReason}
-                      >
-                        {copy.t(
-                          job.canFix
-                            ? "factory.messages.factoryJobFailedWithFix"
-                            : "factory.messages.factoryJobFailed"
-                        )}
-                      </p>
-                    ) : (
-                      <p className="mt-2 truncate text-[11px] leading-4 text-[var(--text-secondary)]">
-                        {job.prompt}
-                      </p>
-                    )}
-                  </div>
-                  <div className="flex shrink-0 items-center gap-1">
-                    {job.canPublish ? (
-                      <Button
-                        size="sm"
-                        type="button"
-                        variant="ghost"
-                        onClick={(event) => {
-                          event.stopPropagation();
-                          void actions.publishFactoryJob?.(job.id);
-                        }}
-                      >
-                        {copy.t("factory.actions.publish")}
-                      </Button>
-                    ) : null}
-                    {job.canFix ? (
-                      <Button
-                        size="sm"
-                        type="button"
-                        variant="ghost"
-                        onClick={(event) => {
-                          event.stopPropagation();
-                          void actions.fixFactoryJob?.(
-                            job.id,
-                            copy.t("factory.prompts.fixDefault")
-                          );
-                        }}
-                      >
-                        {copy.t("factory.actions.fix")}
-                      </Button>
-                    ) : null}
-                    {job.canCancel ? (
-                      <Button
-                        aria-label={copy.t("factory.actions.cancel")}
-                        className="opacity-0 transition-opacity duration-150 group-hover:opacity-100 group-focus-within:opacity-100"
-                        size="icon-sm"
-                        title={copy.t("factory.actions.cancel")}
-                        type="button"
-                        variant="ghost"
-                        onClick={(event) => {
-                          event.stopPropagation();
-                          void actions.cancelFactoryJob?.(job.id);
-                        }}
-                      >
-                        <CloseIcon />
-                      </Button>
-                    ) : null}
-                    {job.canDelete ? (
-                      <BareIconButton
-                        aria-label={copy.t("factory.actions.delete")}
-                        className="text-[var(--text-secondary)]"
-                        size="md"
-                        title={copy.t("factory.actions.delete")}
-                        type="button"
-                        onClick={(event) => {
-                          event.stopPropagation();
-                          void actions.deleteFactoryJob?.(job.id);
-                        }}
-                      >
-                        <DeleteIcon />
-                      </BareIconButton>
-                    ) : null}
-                  </div>
-                </article>
-              ))}
-            </div>
-          </section>
-        ) : null}
-
         <section className="flex min-w-0 flex-col gap-3">
           <div className="flex h-8 min-w-0 items-center justify-between gap-3">
             <SectionTabs
@@ -669,6 +546,141 @@ export function AppCenterPanel({
               )}
             </div>
           </div>
+          {activeAppTab === "my" && hasFactoryJobs ? (
+            <section className="min-w-0">
+              <h2 className="mb-3 text-[15px] font-semibold leading-5 tracking-[0] text-[var(--text-primary)]">
+                {copy.t("factory.labels.jobs")}
+              </h2>
+              <div className="flex min-w-0 flex-col gap-2">
+                {factoryJobs.map((job) => (
+                  <article
+                    aria-disabled={job.canOpenAgentSession ? undefined : true}
+                    className={cn(
+                      "group flex min-w-0 items-center justify-between gap-3 rounded-[8px] border border-[color:var(--line-2)] bg-[var(--background-fronted)] p-[12px] text-left transition-colors duration-150 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--border-focus)]",
+                      job.canOpenAgentSession
+                        ? "cursor-pointer hover:bg-[var(--transparency-block)]"
+                        : "cursor-default"
+                    )}
+                    key={job.id}
+                    role="button"
+                    tabIndex={job.canOpenAgentSession ? 0 : -1}
+                    onClick={() => openFactoryJobAgentSession(job)}
+                    onKeyDown={(event) => {
+                      if (
+                        !job.canOpenAgentSession ||
+                        event.currentTarget !== event.target ||
+                        (event.key !== "Enter" && event.key !== " ")
+                      ) {
+                        return;
+                      }
+                      event.preventDefault();
+                      openFactoryJobAgentSession(job);
+                    }}
+                  >
+                    <div className="min-w-0">
+                      <div className="flex min-w-0 items-center gap-2">
+                        <h3 className="truncate text-[13px] font-semibold leading-5 text-[var(--text-primary)]">
+                          {job.title}
+                        </h3>
+                        <FactoryJobStatusIndicator copy={copy} job={job} />
+                      </div>
+                      {job.failureReason ? (
+                        <p
+                          className="mt-2 truncate text-[11px] leading-4 text-[var(--state-danger)]"
+                          title={job.failureReason}
+                        >
+                          {copy.t(
+                            job.canFix
+                              ? "factory.messages.factoryJobFailedWithFix"
+                              : "factory.messages.factoryJobFailed"
+                          )}
+                        </p>
+                      ) : (
+                        <p className="mt-2 truncate text-[11px] leading-4 text-[var(--text-secondary)]">
+                          {job.prompt}
+                        </p>
+                      )}
+                    </div>
+                    <div className="flex shrink-0 items-center gap-1">
+                      {job.canRetryValidation ? (
+                        <Button
+                          size="sm"
+                          type="button"
+                          variant="ghost"
+                          onClick={(event) => {
+                            event.stopPropagation();
+                            void actions.retryFactoryValidation?.(job.id);
+                          }}
+                        >
+                          {copy.t("factory.actions.validate")}
+                        </Button>
+                      ) : null}
+                      {job.canPublish ? (
+                        <Button
+                          size="sm"
+                          type="button"
+                          variant="ghost"
+                          onClick={(event) => {
+                            event.stopPropagation();
+                            void actions.publishFactoryJob?.(job.id);
+                          }}
+                        >
+                          {copy.t("factory.actions.publish")}
+                        </Button>
+                      ) : null}
+                      {job.canFix ? (
+                        <Button
+                          size="sm"
+                          type="button"
+                          variant="ghost"
+                          onClick={(event) => {
+                            event.stopPropagation();
+                            void actions.fixFactoryJob?.(
+                              job.id,
+                              copy.t("factory.prompts.fixDefault")
+                            );
+                          }}
+                        >
+                          {copy.t("factory.actions.fix")}
+                        </Button>
+                      ) : null}
+                      {job.canCancel ? (
+                        <Button
+                          aria-label={copy.t("factory.actions.cancel")}
+                          className="opacity-0 transition-opacity duration-150 group-hover:opacity-100 group-focus-within:opacity-100"
+                          size="icon-sm"
+                          title={copy.t("factory.actions.cancel")}
+                          type="button"
+                          variant="ghost"
+                          onClick={(event) => {
+                            event.stopPropagation();
+                            void actions.cancelFactoryJob?.(job.id);
+                          }}
+                        >
+                          <CloseIcon />
+                        </Button>
+                      ) : null}
+                      {job.canDelete ? (
+                        <BareIconButton
+                          aria-label={copy.t("factory.actions.delete")}
+                          className="text-[var(--text-secondary)]"
+                          size="md"
+                          title={copy.t("factory.actions.delete")}
+                          type="button"
+                          onClick={(event) => {
+                            event.stopPropagation();
+                            void actions.deleteFactoryJob?.(job.id);
+                          }}
+                        >
+                          <DeleteIcon />
+                        </BareIconButton>
+                      ) : null}
+                    </div>
+                  </article>
+                ))}
+              </div>
+            </section>
+          ) : null}
           {viewModel.empty ? (
             <p className="text-[13px] leading-5 text-[var(--text-secondary)]">
               {copy.t("messages.empty")}

--- a/services/tuttid/service/workspace/app_factory.go
+++ b/services/tuttid/service/workspace/app_factory.go
@@ -121,7 +121,29 @@ func (s *AppFactoryService) List(ctx context.Context, workspaceID string) ([]wor
 	if _, err := s.workspaceSummary(ctx, workspaceID); err != nil {
 		return nil, err
 	}
-	return s.store().ListAppFactoryJobs(ctx, workspaceID)
+	jobs, err := s.store().ListAppFactoryJobs(ctx, workspaceID)
+	if err != nil {
+		return nil, err
+	}
+	for index, job := range jobs {
+		if !isActiveAppFactoryJobStatus(job.Status) &&
+			!isRecoverablePreValidationAgentFailure(job) {
+			continue
+		}
+		handled, reconcileErr := s.reconcileFromPersistedAgentSession(ctx, workspaceID, job)
+		if reconcileErr != nil {
+			return nil, reconcileErr
+		}
+		if !handled {
+			continue
+		}
+		updated, getErr := s.store().GetAppFactoryJob(ctx, workspaceID, job.JobID)
+		if getErr != nil {
+			return nil, getErr
+		}
+		jobs[index] = updated
+	}
+	return jobs, nil
 }
 
 func (s *AppFactoryService) ReconcileInterruptedJobs(ctx context.Context) (int, error) {

--- a/services/tuttid/service/workspace/app_factory_agent_state.go
+++ b/services/tuttid/service/workspace/app_factory_agent_state.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	agentsessionstore "github.com/tutti-os/tutti/packages/agentactivity/daemon/activity"
+	agentactivityprojection "github.com/tutti-os/tutti/packages/agentactivity/daemon/activity/projection"
 	agentactivitybiz "github.com/tutti-os/tutti/services/tuttid/biz/agentactivity"
 	workspacebiz "github.com/tutti-os/tutti/services/tuttid/biz/workspace"
 )
@@ -122,7 +123,9 @@ func (s *AppFactoryService) reconcileFromPersistedAgentSession(ctx context.Conte
 	if !ok {
 		return false, nil
 	}
-	status := normalizePersistedFactoryAgentSessionStatus(session.Status)
+	status := normalizeFactoryAgentSessionStatus(
+		agentactivityprojection.CanonicalSessionStatus(session.Status, session.CurrentPhase),
+	)
 	if status == "" {
 		return s.reconcileCompletedAgentSessionMessages(ctx, workspaceID, job)
 	}
@@ -290,12 +293,17 @@ func factoryAgentTerminalStatus(state agentsessionstore.WorkspaceAgentSessionSta
 	if status := normalizeFactoryAgentSessionStatus(state.LifecycleStatus); status != "" {
 		return status
 	}
+	if strings.ToLower(strings.TrimSpace(state.CurrentPhase)) == "failed" {
+		return "failed"
+	}
 	if state.Turn == nil {
 		return ""
 	}
 	switch strings.ToLower(strings.TrimSpace(state.Turn.Outcome)) {
 	case "completed", "complete", "succeeded", "success":
 		return "completed"
+	case "failed", "failure", "error", "errored":
+		return "failed"
 	default:
 		return ""
 	}

--- a/services/tuttid/service/workspace/app_factory_test.go
+++ b/services/tuttid/service/workspace/app_factory_test.go
@@ -1255,6 +1255,96 @@ func TestAppFactoryServicePublishReturnsPublishedJobIdempotently(t *testing.T) {
 	}
 }
 
+func TestAppFactoryServiceFailedTurnOutcomeFailsGeneratingJob(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	store := newAppFactoryStoreStub()
+	if err := store.PutAppFactoryJob(ctx, workspacebiz.AppFactoryJob{
+		AgentSessionID: "session-1",
+		AppID:          "app_1",
+		JobID:          "job-1",
+		Status:         workspacebiz.AppFactoryJobStatusGenerating,
+		WorkspaceID:    "ws-1",
+	}); err != nil {
+		t.Fatalf("PutAppFactoryJob() error = %v", err)
+	}
+	service := AppFactoryService{Store: store}
+	state := agentsessionstore.WorkspaceAgentSessionStateUpdate{
+		CurrentPhase:    "failed",
+		LastError:       "Codex request failed because a quota or rate limit was reached.",
+		LifecycleStatus: "active",
+		Turn: &agentsessionstore.WorkspaceAgentTurnStateUpdate{
+			Outcome: "failed",
+			TurnID:  "turn-1",
+		},
+	}
+	status := factoryAgentTerminalStatus(state)
+	if status != "failed" {
+		t.Fatalf("terminal status = %q, want failed", status)
+	}
+	if err := service.handleAgentSessionTerminalState(ctx, "ws-1", "session-1", status, state.LastError); err != nil {
+		t.Fatalf("handleAgentSessionTerminalState() error = %v", err)
+	}
+	job, err := store.GetAppFactoryJob(ctx, "ws-1", "job-1")
+	if err != nil {
+		t.Fatalf("GetAppFactoryJob() error = %v", err)
+	}
+	if job.Status != workspacebiz.AppFactoryJobStatusFailed {
+		t.Fatalf("status = %q, want failed", job.Status)
+	}
+	if job.FailureReason != state.LastError {
+		t.Fatalf("failure reason = %q, want %q", job.FailureReason, state.LastError)
+	}
+}
+
+func TestAppFactoryServiceListReconcilesFailedAgentSession(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	store := newAppFactoryStoreStub()
+	if err := store.PutAppFactoryJob(ctx, workspacebiz.AppFactoryJob{
+		AgentSessionID: "session-1",
+		AppID:          "app_1",
+		JobID:          "job-1",
+		Status:         workspacebiz.AppFactoryJobStatusGenerating,
+		WorkspaceID:    "ws-1",
+	}); err != nil {
+		t.Fatalf("PutAppFactoryJob() error = %v", err)
+	}
+	service := AppFactoryService{
+		Store: store,
+		WorkspaceStore: &catalogStoreStub{
+			getWorkspace: workspacebiz.Summary{ID: "ws-1", Name: "Workspace"},
+		},
+		AgentSessionReader: factoryAgentSessionReaderStub{
+			sessions: map[string]agentservice.PersistedSession{
+				appFactoryJobStoreKey("ws-1", "session-1"): {
+					ID:           "session-1",
+					WorkspaceID:  "ws-1",
+					Status:       "active",
+					CurrentPhase: "failed",
+					LastError:    "Codex request failed because a quota or rate limit was reached.",
+				},
+			},
+		},
+	}
+
+	jobs, err := service.List(ctx, "ws-1")
+	if err != nil {
+		t.Fatalf("List() error = %v", err)
+	}
+	if len(jobs) != 1 {
+		t.Fatalf("jobs = %d, want 1", len(jobs))
+	}
+	if jobs[0].Status != workspacebiz.AppFactoryJobStatusFailed {
+		t.Fatalf("status = %q, want failed", jobs[0].Status)
+	}
+	if jobs[0].FailureReason != "Codex request failed because a quota or rate limit was reached." {
+		t.Fatalf("failure reason = %q, want quota failure message", jobs[0].FailureReason)
+	}
+}
+
 func TestAppFactoryServiceFailedAgentSessionFailsGeneratingJob(t *testing.T) {
 	t.Parallel()
 
@@ -1336,7 +1426,33 @@ func TestFactoryAgentTerminalStatusUsesTurnOutcomeWhenSessionStaysActive(t *test
 	}
 }
 
-func TestFactoryAgentTerminalStatusIgnoresFailedTurnOutcomeWhenSessionStaysActive(t *testing.T) {
+func TestFactoryAgentTerminalStatusUsesFailedTurnOutcomeWhenSessionStaysActive(t *testing.T) {
+	t.Parallel()
+
+	status := factoryAgentTerminalStatus(agentsessionstore.WorkspaceAgentSessionStateUpdate{
+		LifecycleStatus: "active",
+		Turn: &agentsessionstore.WorkspaceAgentTurnStateUpdate{
+			Outcome: "failed",
+		},
+	})
+	if status != "failed" {
+		t.Fatalf("status = %q, want failed", status)
+	}
+}
+
+func TestFactoryAgentTerminalStatusUsesFailedPhaseWhenSessionStaysActive(t *testing.T) {
+	t.Parallel()
+
+	status := factoryAgentTerminalStatus(agentsessionstore.WorkspaceAgentSessionStateUpdate{
+		LifecycleStatus: "active",
+		CurrentPhase:    "failed",
+	})
+	if status != "failed" {
+		t.Fatalf("status = %q, want failed", status)
+	}
+}
+
+func TestFactoryAgentTerminalStatusIgnoresInterruptedTurnOutcomeWhenSessionStaysActive(t *testing.T) {
 	t.Parallel()
 
 	status := factoryAgentTerminalStatus(agentsessionstore.WorkspaceAgentSessionStateUpdate{


### PR DESCRIPTION
## Summary
- 修复 Codex turn 失败时创建队列仍显示 loading 的问题，将 factory job 同步为 failed 状态
- 列表拉取时 reconcile 卡住的 factory job，避免状态长期不一致
- 将创建队列移到「我的应用」Tab 标题下方，仅在「我的应用」中展示
- 调整推荐应用排序，修复敬请期待应用 i18n 显示

## Test plan
- [ ] 触发 Codex 创建失败（如 usage limit），确认创建队列显示「失败」及错误信息
- [ ] 重新打开「我的应用」Tab，确认已失败任务状态被正确 reconcile
- [ ] 确认「推荐应用」Tab 不显示创建队列
- [ ] 确认 office 类敬请期待应用名称正常（AI PPT / AI 文档 / AI 表格）
- [ ] 确认推荐应用排序符合预期

Made with [Cursor](https://cursor.com)