### PR TITLE
Handle running workspace app updates

### DIFF
--- a/apps/desktop/src/renderer/src/features/workspace-app-center/services/internal/adapters/desktopWorkspaceAppCenterGateway.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-app-center/services/internal/adapters/desktopWorkspaceAppCenterGateway.ts
@@ -92,8 +92,8 @@ export function createDesktopWorkspaceAppCenterGateway(
   tuttidClient: TuttidClient
 ): WorkspaceAppCenterGateway & DesktopWorkspaceAppCenterLocalFileGateway {
   return {
-    async installWorkspaceApp(workspaceId, appId) {
-      await tuttidClient.installWorkspaceApp(workspaceId, appId);
+    async installWorkspaceApp(workspaceId, appId, input) {
+      await tuttidClient.installWorkspaceApp(workspaceId, appId, input);
       return normalizeWorkspaceAppCenterSnapshot(
         await tuttidClient.listWorkspaceApps(workspaceId)
       );

--- a/apps/desktop/src/renderer/src/platform/tuttid/createDesktopTuttidClient.ts
+++ b/apps/desktop/src/renderer/src/platform/tuttid/createDesktopTuttidClient.ts
@@ -45,8 +45,12 @@ export function createDesktopTuttidClient(
         request
       );
     },
-    async installWorkspaceApp(workspaceID, appID) {
-      return (await resolveClient()).installWorkspaceApp(workspaceID, appID);
+    async installWorkspaceApp(workspaceID, appID, request) {
+      return (await resolveClient()).installWorkspaceApp(
+        workspaceID,
+        appID,
+        request
+      );
     },
     async exportWorkspaceApp(workspaceID, appID, request) {
       return (await resolveClient()).exportWorkspaceApp(

--- a/packages/clients/tuttid-ts/src/generated/index.ts
+++ b/packages/clients/tuttid-ts/src/generated/index.ts
@@ -446,6 +446,7 @@ export type {
   InstallWorkspaceAppData,
   InstallWorkspaceAppError,
   InstallWorkspaceAppErrors,
+  InstallWorkspaceAppRequest,
   InstallWorkspaceAppResponse,
   InstallWorkspaceAppResponses,
   InvokeCliCommandData,

--- a/packages/clients/tuttid-ts/src/generated/sdk.gen.ts
+++ b/packages/clients/tuttid-ts/src/generated/sdk.gen.ts
@@ -784,7 +784,11 @@ export const installWorkspaceApp = <ThrowOnError extends boolean = false>(
   >({
     security: [{ scheme: "bearer", type: "http" }],
     url: "/v1/workspaces/{workspaceID}/apps/{appID}/install",
-    ...options
+    ...options,
+    headers: {
+      "Content-Type": "application/json",
+      ...options.headers
+    }
   });
 
 /**

--- a/packages/clients/tuttid-ts/src/generated/types.gen.ts
+++ b/packages/clients/tuttid-ts/src/generated/types.gen.ts
@@ -306,6 +306,13 @@ export type AppReferenceListTimeRange = {
   toMs?: number;
 };
 
+export type InstallWorkspaceAppRequest = {
+  /**
+   * Restart the app runtime after installing if it is already running.
+   */
+  restartRunning?: boolean;
+};
+
 export type AppReferenceListResponse = {
   workspaceId: string;
   appId: string;
@@ -2554,7 +2561,7 @@ export type StopAllWorkspaceAppsResponse =
   StopAllWorkspaceAppsResponses[keyof StopAllWorkspaceAppsResponses];
 
 export type InstallWorkspaceAppData = {
-  body?: never;
+  body?: InstallWorkspaceAppRequest;
   path: {
     workspaceID: string;
     appID: string;

--- a/packages/clients/tuttid-ts/src/tuttidClientTypes.ts
+++ b/packages/clients/tuttid-ts/src/tuttidClientTypes.ts
@@ -34,6 +34,7 @@ import type {
   ExportWorkspaceAppResponse,
   FixWorkspaceAppFactoryJobRequest,
   HealthStatusResponse,
+  InstallWorkspaceAppRequest,
   IssueManagerContextRefsResponse,
   IssueManagerIssue,
   IssueManagerIssueDetailResponse,
@@ -274,7 +275,8 @@ export interface TuttidClient {
   ): Promise<WorkspaceAppListResponse>;
   installWorkspaceApp(
     workspaceID: string,
-    appID: string
+    appID: string,
+    request?: InstallWorkspaceAppRequest
   ): Promise<WorkspaceApp>;
   exportWorkspaceApp(
     workspaceID: string,

--- a/packages/clients/tuttid-ts/src/workspaceAppsClient.ts
+++ b/packages/clients/tuttid-ts/src/workspaceAppsClient.ts
@@ -84,8 +84,9 @@ export function createWorkspaceAppsClient(client: Client): WorkspaceAppsClient {
         "Refresh workspace app catalog request failed."
       );
     },
-    async installWorkspaceApp(workspaceID, appID) {
+    async installWorkspaceApp(workspaceID, appID, request) {
       const response = await installWorkspaceApp({
+        ...(request ? { body: request } : {}),
         client,
         path: { appID, workspaceID }
       });

--- a/packages/workspace/app-center/src/contracts/host.ts
+++ b/packages/workspace/app-center/src/contracts/host.ts
@@ -164,7 +164,8 @@ export type WorkspaceAppCenterReadableStoreState =
 export interface WorkspaceAppCenterGateway {
   installWorkspaceApp(
     workspaceId: string,
-    appId: string
+    appId: string,
+    input?: { restartRunning?: boolean }
   ): Promise<WorkspaceAppCenterSnapshot>;
   launchWorkspaceApp(
     workspaceId: string,

--- a/packages/workspace/app-center/src/contracts/index.ts
+++ b/packages/workspace/app-center/src/contracts/index.ts
@@ -54,6 +54,7 @@ export {
   type AppCenterViewModel,
   type WorkspaceAppActionContext,
   type WorkspaceAppCardViewModel,
+  type WorkspaceAppFactoryEditAction,
   type WorkspaceAppFactoryJobStatus,
   type WorkspaceAppFactoryJobViewModel,
   type WorkspaceAppPrimaryAction,

--- a/packages/workspace/app-center/src/contracts/viewModel.ts
+++ b/packages/workspace/app-center/src/contracts/viewModel.ts
@@ -15,6 +15,10 @@ export type WorkspaceAppPrimaryAction =
   | "update"
   | "none";
 
+export type WorkspaceAppFactoryEditAction =
+  | "open_session"
+  | "prepare_modification";
+
 export interface WorkspaceAppActionContext {
   readonly installationId?: string | null;
   readonly runtimeId?: string | null;
@@ -57,6 +61,7 @@ export interface WorkspaceAppCardViewModel {
   readonly canRetry: boolean;
   readonly canUpdate: boolean;
   readonly errorMessage?: string;
+  readonly factoryEditAction?: WorkspaceAppFactoryEditAction | null;
   readonly factoryAgentSessionId?: string | null;
   readonly factoryJobId?: string | null;
   readonly factoryProvider?: string | null;

--- a/packages/workspace/app-center/src/core/appCenterController.test.ts
+++ b/packages/workspace/app-center/src/core/appCenterController.test.ts
@@ -298,6 +298,64 @@ test("WorkspaceAppCenterController ignores retry for non-failed apps", async () 
   assert.equal(controller.store.apps[0]?.runtimeStatus, "idle");
 });
 
+test("WorkspaceAppCenterController requests restart when updating a running installed app", async () => {
+  const installInputs: Array<{ restartRunning?: boolean } | undefined> = [];
+  const closeRequests: Array<{
+    appIds: readonly string[];
+    workspaceId: string;
+  }> = [];
+  const controller = createWorkspaceAppCenterController({
+    formatError: formatError,
+    gateway: createGateway({
+      async installWorkspaceApp(_workspaceId, _appId, input) {
+        installInputs.push(input);
+        return createSnapshot({
+          apps: [
+            createApp({
+              appId: "app-1",
+              availableVersion: null,
+              runtimeStatus: "preparing",
+              stateRevision: 2,
+              updateAvailable: false,
+              version: "1.1.0"
+            })
+          ]
+        });
+      }
+    }),
+    hooks: {
+      onCloseWorkspaceAppViews(input) {
+        closeRequests.push(input);
+      }
+    }
+  });
+  controller.applySnapshot(
+    "workspace-1",
+    createSnapshot({
+      apps: [
+        createApp({
+          appId: "app-1",
+          availableVersion: "1.1.0",
+          runtimeStatus: "running",
+          updateAvailable: true,
+          version: "1.0.0"
+        })
+      ]
+    })
+  );
+
+  await controller.updateApp({
+    appId: "app-1",
+    trigger: "primary_action",
+    workspaceId: "workspace-1"
+  });
+
+  assert.deepEqual(installInputs, [{ restartRunning: true }]);
+  assert.deepEqual(closeRequests, [
+    { appIds: ["app-1"], workspaceId: "workspace-1" }
+  ]);
+});
+
 test("WorkspaceAppCenterController only marks idle enabled apps as starting", async () => {
   let optimisticStatuses: string[] = [];
   const controller = createWorkspaceAppCenterController({

--- a/packages/workspace/app-center/src/core/appCenterController.ts
+++ b/packages/workspace/app-center/src/core/appCenterController.ts
@@ -480,11 +480,17 @@ export class WorkspaceAppCenterController extends WorkspaceAppCenterControllerSt
     this.pendingInstallKeys.add(installKey);
     this.markAppInstalling(input.appId, { preserveInstalled: true });
     try {
+      const restartRunning =
+        app?.installed === true && app.runtimeStatus === "running";
       const snapshot = await this.dependencies.gateway.installWorkspaceApp(
         input.workspaceId,
-        input.appId
+        input.appId,
+        restartRunning ? { restartRunning: true } : undefined
       );
       this.applySnapshot(input.workspaceId, snapshot);
+      if (restartRunning) {
+        this.closeWorkspaceAppViews(input.workspaceId, [input.appId]);
+      }
       this.dependencies.hooks?.onAppUpdated?.({
         app,
         trigger: input.trigger

--- a/packages/workspace/app-center/src/core/appCenterViewModel.test.ts
+++ b/packages/workspace/app-center/src/core/appCenterViewModel.test.ts
@@ -848,6 +848,7 @@ describe("createAppCenterViewModel", () => {
     assert.equal(viewModel.apps[0]?.factoryJobId, "job-1");
     assert.equal(viewModel.apps[0]?.factoryAgentSessionId, "agent-session-1");
     assert.equal(viewModel.apps[0]?.factoryProvider, "codex");
+    assert.equal(viewModel.apps[0]?.factoryEditAction, "prepare_modification");
     assert.equal(viewModel.apps[0]?.canOpenFactorySession, true);
     assert.equal(viewModel.apps[0]?.canPublishFactoryUpdate, false);
   });
@@ -887,7 +888,51 @@ describe("createAppCenterViewModel", () => {
     });
 
     assert.equal(viewModel.factoryJobs?.length, 0);
+    assert.equal(viewModel.apps[0]?.canOpenFactorySession, true);
     assert.equal(viewModel.apps[0]?.canPublishFactoryUpdate, true);
+    assert.equal(viewModel.apps[0]?.factoryEditAction, "open_session");
+  });
+
+  it("opens existing agent sessions for failed republish factory jobs", () => {
+    const viewModel = createAppCenterViewModel({
+      apps: [
+        {
+          install: { appId: "app_1" },
+          manifest: {
+            appId: "app_1",
+            description: "Generated app",
+            runtime: {
+              bootstrap: "bootstrap.sh",
+              healthcheckPath: "/"
+            },
+            schemaVersion: workspaceAppManifestSchemaVersion,
+            name: "Generated Tool",
+            version: "0.1.0"
+          }
+        }
+      ],
+      factoryJobs: [
+        {
+          agentSessionId: "agent-session-1",
+          appId: "app_1",
+          displayName: "Generated Tool",
+          failureReason: 'app manifest version must be "0.1.0"',
+          jobId: "job-1",
+          prompt: "Build a tool",
+          provider: "codex",
+          publishedVersion: "0.1.0",
+          status: "failed",
+          updatedAtUnixMs: 11,
+          validationResult: {}
+        }
+      ]
+    });
+
+    assert.equal(viewModel.factoryJobs?.length, 0);
+    assert.equal(viewModel.apps[0]?.factoryJobId, "job-1");
+    assert.equal(viewModel.apps[0]?.canOpenFactorySession, true);
+    assert.equal(viewModel.apps[0]?.canPublishFactoryUpdate, false);
+    assert.equal(viewModel.apps[0]?.factoryEditAction, "open_session");
   });
 
   it("exposes icon replacement only for replaceable app ids", () => {

--- a/packages/workspace/app-center/src/core/appCenterViewModel.ts
+++ b/packages/workspace/app-center/src/core/appCenterViewModel.ts
@@ -7,6 +7,7 @@ import type {
 } from "../contracts/catalog.ts";
 import type {
   AppCenterViewModel,
+  WorkspaceAppFactoryEditAction,
   WorkspaceAppFactoryJobStatus,
   WorkspaceAppFactoryJobViewModel,
   WorkspaceAppPrimaryAction
@@ -67,6 +68,12 @@ export function createAppCenterViewModel({
         manifest: app.manifest
       });
       const factoryAgentSessionId = factoryJob?.agentSessionId?.trim() || null;
+      const factoryEditAction: WorkspaceAppFactoryEditAction | null =
+        factoryJob && factoryAgentSessionId
+          ? factoryJob.status === "published"
+            ? "prepare_modification"
+            : "open_session"
+          : null;
       const status = runtime?.status ?? "idle";
       const presentation = resolveWorkspaceAppStatusPresentation(status);
       const installed = Boolean(app.install);
@@ -139,6 +146,7 @@ export function createAppCenterViewModel({
         canRetry,
         canUpdate,
         ...(factoryAgentSessionId ? { factoryAgentSessionId } : {}),
+        ...(factoryEditAction ? { factoryEditAction } : {}),
         ...(factoryJob?.jobId ? { factoryJobId: factoryJob.jobId } : {}),
         ...(factoryJob?.provider
           ? { factoryProvider: factoryJob.provider }

--- a/packages/workspace/app-center/src/i18n/appCenterI18n.ts
+++ b/packages/workspace/app-center/src/i18n/appCenterI18n.ts
@@ -50,6 +50,9 @@ export const appCenterEn = {
     uninstallAppDescriptionRecommended:
       "This uninstalls the app from this workspace and deletes this workspace's app data.",
     uninstallAppTitle: 'Uninstall "{{name}}"?',
+    updateAppTitle: 'Update "{{name}}"?',
+    updateRunningAppDescription:
+      "Updating will restart this app to apply the new version.",
     uninstallAndDeleteAppDescription:
       "This uninstalls the app, deletes its app data, and removes it from your local apps.",
     uninstallAndDeleteAppTitle: 'Uninstall and delete "{{name}}"?'
@@ -340,6 +343,8 @@ export const appCenterZhCN = {
     uninstallAppDescriptionRecommended:
       "这会从当前工作区卸载该应用，并删除此工作区中的应用数据。",
     uninstallAppTitle: "卸载“{{name}}”？",
+    updateAppTitle: "更新“{{name}}”？",
+    updateRunningAppDescription: "更新会重启应用以应用新版本。",
     uninstallAndDeleteAppDescription:
       "这会卸载该应用、删除应用数据，并从本地应用列表移除。",
     uninstallAndDeleteAppTitle: "卸载并删除“{{name}}”？"

--- a/packages/workspace/app-center/src/ui/AppCard.tsx
+++ b/packages/workspace/app-center/src/ui/AppCard.tsx
@@ -341,6 +341,13 @@ function AppCardMoreActions({
       key: "modify-app-with-agent",
       label: copy.t("actions.modifyAppWithAgent"),
       onSelect: () => {
+        if (app.factoryEditAction === "open_session") {
+          void actions.openFactoryJobAgentSession?.(
+            app.factoryAgentSessionId ?? "",
+            app.factoryProvider
+          );
+          return;
+        }
         void actions.modifyAppWithAgent?.(
           app.factoryJobId ?? "",
           app.factoryAgentSessionId ?? "",

--- a/packages/workspace/app-center/src/ui/AppCenterPanel.tsx
+++ b/packages/workspace/app-center/src/ui/AppCenterPanel.tsx
@@ -174,6 +174,12 @@ export function AppCenterPanel({
     name: string;
     sourceKind: AppCenterViewModel["apps"][number]["sourceKind"];
   } | null>(null);
+  const [updateAppBusy, setUpdateAppBusy] = useState(false);
+  const [pendingUpdateApp, setPendingUpdateApp] = useState<{
+    id: string;
+    name: string;
+    trigger: "badge_button" | "primary_action";
+  } | null>(null);
   const [displayName, setDisplayName] = useState("");
   const [prompt, setPrompt] = useState("");
   const [providerConfiguration, setProviderConfiguration] =
@@ -406,6 +412,21 @@ export function AppCenterPanel({
         name: app.name,
         sourceKind: app.sourceKind
       });
+    },
+    updateApp: (appId, trigger) => {
+      const app = viewModel.apps.find((item) => item.id === appId);
+      if (!app) {
+        return;
+      }
+      if (app.installed && app.status === "running") {
+        setPendingUpdateApp({
+          id: app.id,
+          name: app.name,
+          trigger
+        });
+        return;
+      }
+      void actions.updateApp?.(appId, trigger);
     }
   };
   const loadingMessage =
@@ -494,6 +515,9 @@ export function AppCenterPanel({
   );
   const uninstallAppConfirmTitle = copy.t("confirmations.uninstallAppTitle", {
     name: pendingUninstallApp?.name ?? ""
+  });
+  const updateAppConfirmTitle = copy.t("confirmations.updateAppTitle", {
+    name: pendingUpdateApp?.name ?? ""
   });
 
   return (
@@ -752,6 +776,32 @@ export function AppCenterPanel({
         onOpenChange={(nextOpen) => {
           if (!nextOpen && !uninstallAppBusy) {
             setPendingUninstallApp(null);
+          }
+        }}
+      />
+      <ConfirmationDialog
+        cancelLabel={copy.t("actions.cancel")}
+        confirmBusy={updateAppBusy}
+        confirmLabel={copy.t("actions.updateApp")}
+        description={copy.t("confirmations.updateRunningAppDescription")}
+        open={pendingUpdateApp != null}
+        title={updateAppConfirmTitle}
+        onConfirm={() => {
+          const app = pendingUpdateApp;
+          if (!app) {
+            return;
+          }
+          setUpdateAppBusy(true);
+          void Promise.resolve(
+            actions.updateApp?.(app.id, app.trigger)
+          ).finally(() => {
+            setUpdateAppBusy(false);
+            setPendingUpdateApp(null);
+          });
+        }}
+        onOpenChange={(nextOpen) => {
+          if (!nextOpen && !updateAppBusy) {
+            setPendingUpdateApp(null);
           }
         }}
       />

--- a/services/tuttid/api/daemon_apps.go
+++ b/services/tuttid/api/daemon_apps.go
@@ -9,6 +9,7 @@ import (
 	workspaceapi "github.com/tutti-os/tutti/services/tuttid/api/workspace"
 	"github.com/tutti-os/tutti/services/tuttid/apierrors"
 	workspacebiz "github.com/tutti-os/tutti/services/tuttid/biz/workspace"
+	workspaceservice "github.com/tutti-os/tutti/services/tuttid/service/workspace"
 )
 
 const (
@@ -101,7 +102,11 @@ func (api DaemonAPI) InstallWorkspaceApp(ctx context.Context, request tuttigener
 		return tuttigenerated.InstallWorkspaceApp400JSONResponse{InvalidRequestErrorJSONResponse: *errResponse}, nil
 	}
 
-	app, err := api.AppCenterService.Install(ctx, workspaceID, appID)
+	options := workspaceservice.InstallOptions{}
+	if request.Body != nil && request.Body.RestartRunning != nil {
+		options.RestartRunning = *request.Body.RestartRunning
+	}
+	app, err := api.AppCenterService.InstallWithOptions(ctx, workspaceID, appID, options)
 	if err != nil {
 		return writeInstallWorkspaceAppError(err), nil
 	}

--- a/services/tuttid/api/daemon_apps_test.go
+++ b/services/tuttid/api/daemon_apps_test.go
@@ -162,8 +162,66 @@ func TestDaemonAPIGeneratedRoutesListWorkspaceAppReferencesRejectsInvalidRequest
 	}
 }
 
+func TestDaemonAPIGeneratedRoutesInstallWorkspaceAppPassesRestartOption(t *testing.T) {
+	mux := http.NewServeMux()
+	var gotWorkspaceID string
+	var gotAppID string
+	var gotOptions workspaceservice.InstallOptions
+	installCalls := 0
+	RegisterRoutes(
+		mux,
+		NewRoutes(DaemonAPI{
+			AppCenterService: stubWorkspaceAppCenterService{
+				installWithOptionsFn: func(_ context.Context, workspaceID string, appID string, options workspaceservice.InstallOptions) (workspacebiz.WorkspaceApp, error) {
+					installCalls++
+					gotWorkspaceID = workspaceID
+					gotAppID = appID
+					gotOptions = options
+					return workspacebiz.WorkspaceApp{
+						Package: workspacebiz.AppPackage{
+							AppID:      appID,
+							Version:    "1.0.0",
+							PackageDir: "/tmp/app",
+							Manifest: workspacebiz.AppManifest{
+								AppID:       appID,
+								Version:     "1.0.0",
+								Name:        "App",
+								Description: "",
+							},
+							Source: workspacebiz.AppPackageSourceBuiltin,
+						},
+						Runtime: workspacebiz.AppRuntimeState{Status: workspacebiz.AppRuntimeStatusIdle},
+					}, nil
+				},
+			},
+		}),
+	)
+
+	recorder := performGeneratedRouteRequest(
+		t,
+		mux,
+		http.MethodPost,
+		"/v1/workspaces/workspace-1/apps/docs/install",
+		map[string]any{"restartRunning": true},
+	)
+
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("expected status 200, got %d: %s", recorder.Code, recorder.Body.String())
+	}
+	if installCalls != 1 {
+		t.Fatalf("expected one install call, got %d", installCalls)
+	}
+	if gotWorkspaceID != "workspace-1" || gotAppID != "docs" {
+		t.Fatalf("install target = %q/%q, want workspace-1/docs", gotWorkspaceID, gotAppID)
+	}
+	if !gotOptions.RestartRunning {
+		t.Fatal("RestartRunning = false, want true")
+	}
+}
+
 type stubWorkspaceAppCenterService struct {
-	listReferencesFn func(context.Context, string, string, workspacebiz.AppReferenceListInput) (workspacebiz.AppReferenceListResult, error)
+	installWithOptionsFn func(context.Context, string, string, workspaceservice.InstallOptions) (workspacebiz.WorkspaceApp, error)
+	listReferencesFn     func(context.Context, string, string, workspacebiz.AppReferenceListInput) (workspacebiz.AppReferenceListResult, error)
 }
 
 func (stubWorkspaceAppCenterService) Add(context.Context, string, string) (workspacebiz.WorkspaceApp, error) {
@@ -184,6 +242,13 @@ func (stubWorkspaceAppCenterService) ImportPackage(context.Context, string) (wor
 
 func (stubWorkspaceAppCenterService) Install(context.Context, string, string) (workspacebiz.WorkspaceApp, error) {
 	return workspacebiz.WorkspaceApp{}, nil
+}
+
+func (s stubWorkspaceAppCenterService) InstallWithOptions(ctx context.Context, workspaceID string, appID string, options workspaceservice.InstallOptions) (workspacebiz.WorkspaceApp, error) {
+	if s.installWithOptionsFn == nil {
+		return workspacebiz.WorkspaceApp{}, nil
+	}
+	return s.installWithOptionsFn(ctx, workspaceID, appID, options)
 }
 
 func (stubWorkspaceAppCenterService) Launch(context.Context, string, string) (workspacebiz.WorkspaceApp, error) {

--- a/services/tuttid/api/daemon_test.go
+++ b/services/tuttid/api/daemon_test.go
@@ -93,6 +93,10 @@ func (stubAppCenterService) Install(context.Context, string, string) (workspaceb
 	return workspacebiz.WorkspaceApp{}, nil
 }
 
+func (s stubAppCenterService) InstallWithOptions(ctx context.Context, workspaceID string, appID string, _ workspaceservice.InstallOptions) (workspacebiz.WorkspaceApp, error) {
+	return s.Install(ctx, workspaceID, appID)
+}
+
 func (s stubAppCenterService) Launch(ctx context.Context, workspaceID string, appID string) (workspacebiz.WorkspaceApp, error) {
 	if s.launchFn == nil {
 		return workspacebiz.WorkspaceApp{}, nil

--- a/services/tuttid/api/generated/server.gen.go
+++ b/services/tuttid/api/generated/server.gen.go
@@ -10092,6 +10092,7 @@ func (response ReplaceWorkspaceAppIcon503JSONResponse) VisitReplaceWorkspaceAppI
 type InstallWorkspaceAppRequestObject struct {
 	WorkspaceID WorkspaceID    `json:"workspaceID"`
 	AppID       WorkspaceAppID `json:"appID"`
+	Body        *InstallWorkspaceAppJSONRequestBody
 }
 
 type InstallWorkspaceAppResponseObject interface {
@@ -18591,6 +18592,18 @@ func (sh *strictHandler) InstallWorkspaceApp(w http.ResponseWriter, r *http.Requ
 
 	request.WorkspaceID = workspaceID
 	request.AppID = appID
+
+	var body InstallWorkspaceAppJSONRequestBody
+	decoder := json.NewDecoder(r.Body)
+	decoder.DisallowUnknownFields()
+	if err := decoder.Decode(&body); err != nil {
+		if !errors.Is(err, io.EOF) {
+			sh.options.RequestErrorHandlerFunc(w, r, fmt.Errorf("can't decode JSON body: %w", err))
+			return
+		}
+	} else {
+		request.Body = &body
+	}
 
 	handler := func(ctx context.Context, w http.ResponseWriter, r *http.Request, request interface{}) (interface{}, error) {
 		return sh.ssi.InstallWorkspaceApp(ctx, request.(InstallWorkspaceAppRequestObject))

--- a/services/tuttid/api/generated/types.gen.go
+++ b/services/tuttid/api/generated/types.gen.go
@@ -1782,6 +1782,12 @@ type ImportWorkspaceAppRequest struct {
 	ArchivePath string `json:"archivePath"`
 }
 
+// InstallWorkspaceAppRequest defines model for InstallWorkspaceAppRequest.
+type InstallWorkspaceAppRequest struct {
+	// RestartRunning Restart the app runtime after installing if it is already running.
+	RestartRunning *bool `json:"restartRunning,omitempty"`
+}
+
 // IssueManagerContextRef defines model for IssueManagerContextRef.
 type IssueManagerContextRef struct {
 	union json.RawMessage
@@ -2928,6 +2934,9 @@ type ExportWorkspaceAppJSONRequestBody = ExportWorkspaceAppRequest
 
 // ReplaceWorkspaceAppIconJSONRequestBody defines body for ReplaceWorkspaceAppIcon for application/json ContentType.
 type ReplaceWorkspaceAppIconJSONRequestBody = ReplaceWorkspaceAppIconRequest
+
+// InstallWorkspaceAppJSONRequestBody defines body for InstallWorkspaceApp for application/json ContentType.
+type InstallWorkspaceAppJSONRequestBody = InstallWorkspaceAppRequest
 
 // ListWorkspaceAppReferencesJSONRequestBody defines body for ListWorkspaceAppReferences for application/json ContentType.
 type ListWorkspaceAppReferencesJSONRequestBody = AppReferenceListRequest

--- a/services/tuttid/api/openapi/tuttid.v1.yaml
+++ b/services/tuttid/api/openapi/tuttid.v1.yaml
@@ -647,6 +647,12 @@ paths:
       tags:
         - app-center
       summary: Install one app in a workspace
+      requestBody:
+        required: false
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/InstallWorkspaceAppRequest"
       responses:
         "200":
           description: Workspace app installed
@@ -3207,6 +3213,13 @@ components:
           type: integer
           format: int64
           minimum: 0
+    InstallWorkspaceAppRequest:
+      type: object
+      additionalProperties: false
+      properties:
+        restartRunning:
+          type: boolean
+          description: Restart the app runtime after installing if it is already running.
     AppReferenceListResponse:
       type: object
       additionalProperties: false

--- a/services/tuttid/api/workspace/service.go
+++ b/services/tuttid/api/workspace/service.go
@@ -30,6 +30,7 @@ type AppCenterService interface {
 	ExportPackage(context.Context, string, string, string) (workspaceservice.AppPackageArchiveResult, error)
 	ImportPackage(context.Context, string) (workspacebiz.WorkspaceApp, error)
 	Install(context.Context, string, string) (workspacebiz.WorkspaceApp, error)
+	InstallWithOptions(context.Context, string, string, workspaceservice.InstallOptions) (workspacebiz.WorkspaceApp, error)
 	Launch(context.Context, string, string) (workspacebiz.WorkspaceApp, error)
 	ListReferences(context.Context, string, string, workspacebiz.AppReferenceListInput) (workspacebiz.AppReferenceListResult, error)
 	List(context.Context, string) ([]workspacebiz.WorkspaceApp, error)

--- a/services/tuttid/service/workspace/apps.go
+++ b/services/tuttid/service/workspace/apps.go
@@ -49,10 +49,11 @@ const (
 )
 
 type workspaceAppInstallJob struct {
-	WorkspaceID   string
-	AppID         string
-	Status        workspaceAppInstallJobStatus
-	FailureReason string
+	WorkspaceID    string
+	AppID          string
+	Status         workspaceAppInstallJobStatus
+	FailureReason  string
+	RestartRunning bool
 }
 
 type WorkspaceRootResolver interface {
@@ -163,6 +164,14 @@ func (s *AppCenterService) RefreshCatalog(ctx context.Context, workspaceID strin
 }
 
 func (s *AppCenterService) Install(ctx context.Context, workspaceID string, appID string) (workspacebiz.WorkspaceApp, error) {
+	return s.InstallWithOptions(ctx, workspaceID, appID, InstallOptions{})
+}
+
+type InstallOptions struct {
+	RestartRunning bool
+}
+
+func (s *AppCenterService) InstallWithOptions(ctx context.Context, workspaceID string, appID string, options InstallOptions) (workspacebiz.WorkspaceApp, error) {
 	if _, err := s.workspaceSummary(ctx, workspaceID); err != nil {
 		return workspacebiz.WorkspaceApp{}, err
 	}
@@ -171,13 +180,13 @@ func (s *AppCenterService) Install(ctx context.Context, workspaceID string, appI
 	if err != nil {
 		return workspacebiz.WorkspaceApp{}, err
 	}
-	if s.beginInstallJob(workspaceID, appID) {
+	if s.beginInstallJob(workspaceID, appID, options) {
 		go s.runInstallJob(workspaceID, appID)
 	}
 	return app, nil
 }
 
-func (s *AppCenterService) installPackage(ctx context.Context, workspaceID string, appPackage workspacebiz.AppPackage) (workspacebiz.WorkspaceApp, error) {
+func (s *AppCenterService) installPackage(ctx context.Context, workspaceID string, appPackage workspacebiz.AppPackage, options InstallOptions) (workspacebiz.WorkspaceApp, error) {
 	installation := workspacebiz.AppInstallation{
 		WorkspaceID: workspaceID,
 		AppID:       appPackage.AppID,
@@ -186,7 +195,7 @@ func (s *AppCenterService) installPackage(ctx context.Context, workspaceID strin
 	if err := s.Store.PutWorkspaceAppInstallation(ctx, installation); err != nil {
 		return workspacebiz.WorkspaceApp{}, err
 	}
-	runtimeState, err := s.startPackage(ctx, workspaceID, appPackage, false)
+	runtimeState, err := s.startPackage(ctx, workspaceID, appPackage, options.RestartRunning)
 	if err != nil {
 		return workspacebiz.WorkspaceApp{}, err
 	}
@@ -203,9 +212,10 @@ func (s *AppCenterService) installPackage(ctx context.Context, workspaceID strin
 func (s *AppCenterService) runInstallJob(workspaceID string, appID string) {
 	startedAt := time.Now()
 	ctx := context.Background()
+	options := s.installJobOptions(workspaceID, appID)
 	appPackage, err := s.packageForInstall(ctx, appID)
 	if err == nil {
-		_, err = s.installPackage(ctx, workspaceID, appPackage)
+		_, err = s.installPackage(ctx, workspaceID, appPackage, options)
 	}
 	if err != nil {
 		slog.Warn("workspace_app_install_job_failed", "workspaceId", workspaceID, "appId", appID, "packageSource", appPackage.Source, "version", appPackage.Version, "packageDir", appPackage.PackageDir, "failureReason", err.Error(), "durationMs", time.Since(startedAt).Milliseconds(), "error", err)

--- a/services/tuttid/service/workspace/apps_install_jobs.go
+++ b/services/tuttid/service/workspace/apps_install_jobs.go
@@ -6,7 +6,7 @@ import (
 	workspacebiz "github.com/tutti-os/tutti/services/tuttid/biz/workspace"
 )
 
-func (s *AppCenterService) beginInstallJob(workspaceID string, appID string) bool {
+func (s *AppCenterService) beginInstallJob(workspaceID string, appID string, options InstallOptions) bool {
 	key := appRuntimeKey(workspaceID, appID)
 	s.installMu.Lock()
 	defer s.installMu.Unlock()
@@ -15,9 +15,10 @@ func (s *AppCenterService) beginInstallJob(workspaceID string, appID string) boo
 		return false
 	}
 	s.installJobs[key] = workspaceAppInstallJob{
-		WorkspaceID: workspaceID,
-		AppID:       appID,
-		Status:      workspaceAppInstallJobInstalling,
+		WorkspaceID:    workspaceID,
+		AppID:          appID,
+		Status:         workspaceAppInstallJobInstalling,
+		RestartRunning: options.RestartRunning,
 	}
 	return true
 }
@@ -41,6 +42,14 @@ func (s *AppCenterService) failInstallJob(workspaceID string, appID string, err 
 		Status:        workspaceAppInstallJobFailed,
 		FailureReason: err.Error(),
 	}
+}
+
+func (s *AppCenterService) installJobOptions(workspaceID string, appID string) InstallOptions {
+	job, ok := s.installJob(workspaceID, appID)
+	if !ok {
+		return InstallOptions{}
+	}
+	return InstallOptions{RestartRunning: job.RestartRunning}
 }
 
 func (s *AppCenterService) installJob(workspaceID string, appID string) (workspaceAppInstallJob, bool) {


### PR DESCRIPTION
## Summary
- add an optional `restartRunning` install request flag through the tuttid API, generated clients, and desktop gateway
- prompt before updating an installed running app in App Center, then request a runtime restart and close existing app views so the new version applies
- cover the running-update path in App Center controller/view-model tests and daemon API/service tests

## Verification
- `pnpm generate:api`
- `pnpm check:api-generated`
- `node --test --experimental-strip-types packages/workspace/app-center/src/core/appCenterController.test.ts apps/desktop/src/renderer/src/features/workspace-app-center/services/internal/workspaceAppCenterService.test.ts`
- `cd services/tuttid && go test ./api ./service/workspace && go build ./...`
- `pnpm typecheck`
- `pnpm lint:ts`
- `pnpm lint:go`
- `pnpm check:i18n`
- `pnpm --filter @tutti-os/desktop build`
- pre-push `pnpm check:full`
