### PR TITLE
[codex] Normalize model label casing

### DIFF
--- a/packages/agent/gui/agent-gui/agentGuiNode/AgentComposerSettingsMenus.spec.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/AgentComposerSettingsMenus.spec.tsx
@@ -1376,7 +1376,7 @@ describe("AgentModelReasoningDropdown", () => {
 
   it("shows model and reasoning together in the trigger", () => {
     renderModelReasoning();
-    expect(modelReasoningTrigger()).toHaveTextContent(/Gpt-5\.5\s*High/);
+    expect(modelReasoningTrigger()).toHaveTextContent(/GPT-5\.5\s*High/);
   });
 
   it("shows the fast lightning indicator only when speed is fast", () => {
@@ -1405,10 +1405,10 @@ describe("AgentModelReasoningDropdown", () => {
     renderModelReasoning({}, onSettingsChange);
     openModelReasoningMenu();
     const current = await screen.findByRole("menuitem", {
-      name: /Gpt-5\.5/
+      name: /GPT-5\.5/
     });
     expect(current).toBeInTheDocument();
-    fireEvent.click(screen.getByRole("menuitem", { name: /Gpt-5\.4/ }));
+    fireEvent.click(screen.getByRole("menuitem", { name: /GPT-5\.4/ }));
     expect(onSettingsChange).toHaveBeenCalledWith({ model: "gpt-5.4" });
   });
 

--- a/packages/agent/gui/agent-gui/agentGuiNode/AgentGUINode.spec.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/AgentGUINode.spec.tsx
@@ -2671,7 +2671,7 @@ describe("AgentGUINode", () => {
     const modelButton = screen.getByRole("button", {
       name: "agentHost.agentGui.modelLabel / agentHost.agentGui.reasoningLabel"
     });
-    expect(modelButton).toHaveTextContent("Gpt-5");
+    expect(modelButton).toHaveTextContent("GPT-5");
     expect(modelButton).toHaveTextContent(
       "agentHost.agentGui.reasoningOptionHigh"
     );

--- a/packages/agent/gui/agent-gui/agentGuiNode/model/composerSettingsMenuModel.spec.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/model/composerSettingsMenuModel.spec.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import type { AgentGUIComposerSettingsVM } from "./agentGuiNodeTypes";
 import {
   buildComposerModelMenuModel,
+  formatModelDisplayLabel,
   type AgentComposerSettingsMenuLabels
 } from "./composerSettingsMenuModel";
 
@@ -78,17 +79,17 @@ describe("buildComposerModelMenuModel", () => {
     expect(menu.disabled).toBe(false);
     expect(menu.trigger).toMatchObject({
       isFast: false,
-      modelLabel: "Gpt-5.5",
+      modelLabel: "GPT-5.5",
       reasoningLabel: "High",
-      combinedLabel: "Gpt-5.5 High",
+      combinedLabel: "GPT-5.5 High",
       showCombined: false
     });
 
     expect(menu.model.show).toBe(true);
     expect(menu.model.selectedValue).toBe("gpt-5.5");
     expect(menu.model.options).toEqual([
-      { value: "gpt-5.5", label: "Gpt-5.5", description: undefined },
-      { value: "gpt-5.4", label: "Gpt-5.4", description: undefined }
+      { value: "gpt-5.5", label: "GPT-5.5", description: undefined },
+      { value: "gpt-5.4", label: "GPT-5.4", description: undefined }
     ]);
 
     expect(menu.reasoning.show).toBe(true);
@@ -151,9 +152,18 @@ describe("buildComposerModelMenuModel", () => {
     expect(menu.model.selectedValue).toBe("custom-model");
     expect(menu.model.options[0]).toEqual({
       value: "custom-model",
-      label: "Custom-model",
+      label: "Custom-Model",
       description: undefined
     });
+  });
+
+  it("normalizes GPT casing while capitalizing each label segment", () => {
+    expect(formatModelDisplayLabel("gpt-5.5")).toBe("GPT-5.5");
+    expect(formatModelDisplayLabel("gpt-5.3-codex")).toBe("GPT-5.3-Codex");
+    expect(formatModelDisplayLabel("Gpt-5.5-codex")).toBe("GPT-5.5-Codex");
+    expect(formatModelDisplayLabel("vendor/gpt-5.5")).toBe("Vendor/GPT-5.5");
+    expect(formatModelDisplayLabel("codex")).toBe("Codex");
+    expect(formatModelDisplayLabel("custom-model")).toBe("Custom-Model");
   });
 
   it("hides dimensions that are unsupported or unavailable", () => {

--- a/packages/agent/gui/agent-gui/agentGuiNode/model/composerSettingsMenuModel.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/model/composerSettingsMenuModel.ts
@@ -160,7 +160,12 @@ export function formatModelDisplayLabel(label: string): string {
   if (!trimmed) {
     return label;
   }
-  return `${trimmed.charAt(0).toUpperCase()}${trimmed.slice(1)}`;
+  const capitalized = trimmed.replace(
+    /(^|[^A-Za-z0-9])([A-Za-z])/g,
+    (_match, prefix: string, letter: string) =>
+      `${prefix}${letter.toUpperCase()}`
+  );
+  return capitalized.replace(/gpt/gi, "GPT");
 }
 
 export function resolveModelDescription(


### PR DESCRIPTION
## Summary
- capitalize each segment of composer model labels instead of only the first character
- normalize GPT casing so fallback ids like gpt-5.3-codex display as GPT-5.3-Codex
- update model dropdown and node tests for the new display behavior

## Validation
- pnpm --filter @tutti-os/agent-gui exec vitest run --environment jsdom agent-gui/agentGuiNode/model/composerSettingsMenuModel.spec.ts agent-gui/agentGuiNode/AgentComposerSettingsMenus.spec.tsx agent-gui/agentGuiNode/AgentGUINode.spec.tsx
- check:full passed during pre-push