### PR TITLE
fix(tuttid): accept legacy app manifest searchEndpoint alias.

### DIFF
--- a/services/tuttid/biz/workspace/apps.go
+++ b/services/tuttid/biz/workspace/apps.go
@@ -53,7 +53,8 @@ type AppManifestCLI struct {
 }
 
 type AppManifestReferences struct {
-	ListEndpoint string `json:"listEndpoint"`
+	ListEndpoint   string `json:"listEndpoint"`
+	SearchEndpoint string `json:"searchEndpoint,omitempty"`
 }
 
 type AppManifestWindow struct {
@@ -435,6 +436,7 @@ func ParseAppManifestJSON(data []byte) (AppManifest, string, error) {
 	if err := json.Unmarshal(data, &manifest); err != nil {
 		return AppManifest{}, "", fmt.Errorf("parse app manifest json: %w", err)
 	}
+	normalizeAppManifestReferences(&manifest)
 	if err := ValidateAppManifest(manifest); err != nil {
 		return AppManifest{}, "", err
 	}
@@ -458,11 +460,23 @@ func validateAppManifestReferencesJSON(raw map[string]json.RawMessage) error {
 		return errors.New("app manifest references must be an object when provided")
 	}
 	for key := range references {
-		if key != "listEndpoint" {
+		if key != "listEndpoint" && key != "searchEndpoint" {
 			return fmt.Errorf("app manifest references.%s is unsupported", key)
 		}
 	}
 	return nil
+}
+
+func normalizeAppManifestReferences(manifest *AppManifest) {
+	if manifest == nil || manifest.References == nil {
+		return
+	}
+	listEndpoint := strings.TrimSpace(manifest.References.ListEndpoint)
+	searchEndpoint := strings.TrimSpace(manifest.References.SearchEndpoint)
+	if listEndpoint == "" && searchEndpoint != "" {
+		manifest.References.ListEndpoint = searchEndpoint
+	}
+	manifest.References.SearchEndpoint = ""
 }
 
 func ReadAppManifestFile(path string) (AppManifest, string, error) {

--- a/services/tuttid/biz/workspace/apps_test.go
+++ b/services/tuttid/biz/workspace/apps_test.go
@@ -215,17 +215,33 @@ func TestValidateAppManifestRejectsInvalidReferencesListEndpoint(t *testing.T) {
 func TestParseAppManifestJSONRejectsUnsupportedReferencesFields(t *testing.T) {
 	t.Parallel()
 
-	for _, raw := range []string{
+	if _, _, err := ParseAppManifestJSON([]byte(
 		`{"schemaVersion":"tutti.app.manifest.v1","appId":"test-app","version":"0.1.0","name":"Test App","description":"Test app","icon":{"type":"asset","src":"icon.png"},"runtime":{"bootstrap":"bootstrap.sh","healthcheckPath":"/healthz"},"references":null}`,
-		`{"schemaVersion":"tutti.app.manifest.v1","appId":"test-app","version":"0.1.0","name":"Test App","description":"Test app","icon":{"type":"asset","src":"icon.png"},"runtime":{"bootstrap":"bootstrap.sh","healthcheckPath":"/healthz"},"references":{"listEndpoint":"/references/list","searchEndpoint":"/references/search"}}`,
-	} {
-		t.Run(raw, func(t *testing.T) {
-			t.Parallel()
+	)); err == nil {
+		t.Fatal("ParseAppManifestJSON() error = nil, want invalid references error")
+	}
 
-			if _, _, err := ParseAppManifestJSON([]byte(raw)); err == nil {
-				t.Fatal("ParseAppManifestJSON() error = nil, want invalid references error")
-			}
-		})
+	if _, _, err := ParseAppManifestJSON([]byte(
+		`{"schemaVersion":"tutti.app.manifest.v1","appId":"test-app","version":"0.1.0","name":"Test App","description":"Test app","icon":{"type":"asset","src":"icon.png"},"runtime":{"bootstrap":"bootstrap.sh","healthcheckPath":"/healthz"},"references":{"listEndpoint":"/references/list","customEndpoint":"/references/custom"}}`,
+	)); err == nil {
+		t.Fatal("ParseAppManifestJSON() error = nil, want unsupported references field error")
+	}
+}
+
+func TestParseAppManifestJSONAcceptsLegacyReferencesSearchEndpoint(t *testing.T) {
+	t.Parallel()
+
+	manifest, normalized, err := ParseAppManifestJSON([]byte(
+		`{"schemaVersion":"tutti.app.manifest.v1","appId":"test-app","version":"0.1.0","name":"Test App","description":"Test app","icon":{"type":"asset","src":"icon.png"},"runtime":{"bootstrap":"bootstrap.sh","healthcheckPath":"/healthz"},"references":{"searchEndpoint":"/references/search"}}`,
+	))
+	if err != nil {
+		t.Fatalf("ParseAppManifestJSON() error = %v, want legacy searchEndpoint alias accepted", err)
+	}
+	if manifest.References == nil || manifest.References.ListEndpoint != "/references/search" {
+		t.Fatalf("manifest.References = %#v, want listEndpoint /references/search", manifest.References)
+	}
+	if strings.Contains(normalized, "searchEndpoint") {
+		t.Fatalf("normalized manifest = %q, want searchEndpoint removed", normalized)
 	}
 }
 


### PR DESCRIPTION
Apps installed before references.listEndpoint shipped can block app center catalog refresh; map searchEndpoint to listEndpoint during manifest parsing.

## Summary

<!-- What changed and why? -->

## Verification

<!-- Commands run, manual checks, or why verification is not applicable. -->

## Checklist

- [ ] I kept the change focused on one concern.
- [ ] I updated documentation when behavior, setup, or contributor workflow changed.
- [ ] I updated all README/CONTRIBUTING language variants when changing their English source.
- [ ] I ran the lowest meaningful local checks for the changed surface.
- [ ] My commits are signed off with DCO when required: `git commit -s`.
