### PR TITLE
Improve managed model provider settings

### DIFF
--- a/apps/desktop/src/renderer/src/features/workspace-workbench/services/internal/adapters/desktopWorkspaceSettingsClient.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/services/internal/adapters/desktopWorkspaceSettingsClient.ts
@@ -34,6 +34,11 @@ export interface PutManagedModelProviderInput {
   }>;
 }
 
+export interface ListManagedModelProviderModelsInput {
+  apiKey?: string;
+  baseUrl?: string;
+}
+
 export interface DesktopWorkspaceSettingsClient {
   clearLogs(): Promise<ClearDeveloperLogsResult>;
   deleteManagedModelProvider(
@@ -47,7 +52,8 @@ export interface DesktopWorkspaceSettingsClient {
   ): Promise<WorkspaceManagedModelProviderConfig[]>;
   listManagedModelProviderModels(
     workspaceID: string,
-    providerID: WorkspaceManagedModelProviderID
+    providerID: WorkspaceManagedModelProviderID,
+    input?: ListManagedModelProviderModelsInput
   ): Promise<WorkspaceManagedModelProviderConfig["models"]>;
   openLogDirectory(): Promise<void>;
   openLogFile(kind: DesktopDeveloperLogKind): Promise<void>;
@@ -89,11 +95,12 @@ export function createDesktopWorkspaceSettingsClient(input: {
       );
       return response.providers;
     },
-    async listManagedModelProviderModels(workspaceID, providerID) {
+    async listManagedModelProviderModels(workspaceID, providerID, body) {
       const response = await requestDaemon<ManagedProviderModelsResponse>(
         input.runtimeApi,
         `/v1/workspaces/${encodeURIComponent(workspaceID)}/managed-model-providers/${encodeURIComponent(providerID)}/models`,
         {
+          body,
           method: "POST"
         }
       );

--- a/apps/desktop/src/renderer/src/features/workspace-workbench/services/internal/workspaceSettingsService.test.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/services/internal/workspaceSettingsService.test.ts
@@ -106,6 +106,7 @@ test("WorkspaceSettingsService echoes saved managed provider API keys", async ()
       listManagedModelProviders: async () => [
         {
           apiKey: "agnes-secret",
+          baseUrl: "https://apihub.agnes-ai.com/v1",
           enabled: true,
           hasApiKey: true,
           models: [],
@@ -124,12 +125,88 @@ test("WorkspaceSettingsService echoes saved managed provider API keys", async ()
   assert.equal(agnesProvider?.apiKey, "agnes-secret");
 });
 
+test("WorkspaceSettingsService seeds managed provider defaults", async () => {
+  const service = new WorkspaceSettingsService({
+    client: createWorkspaceSettingsClient({
+      listManagedModelProviders: async () => []
+    })
+  });
+
+  service.openPanel({ id: "workspace-1" });
+  await waitFor(() => service.store.managedModels.loading === false);
+
+  const agnesProvider = service.store.managedModels.providers.find(
+    (provider) => provider.provider === "agnes"
+  );
+  assert.equal(agnesProvider?.baseUrl, "https://apihub.agnes-ai.com/v1");
+  assert.deepEqual(agnesProvider?.models, [
+    {
+      id: "agnes-2.0-flash",
+      name: "agnes-2.0-flash",
+      provider: "agnes"
+    },
+    {
+      id: "agnes-1.5-flash",
+      name: "agnes-1.5-flash",
+      provider: "agnes"
+    }
+  ]);
+  const openaiProvider = service.store.managedModels.providers.find(
+    (provider) => provider.provider === "openai"
+  );
+  assert.equal(openaiProvider?.baseUrl, "https://api.openai.com/v1");
+  assert.deepEqual(openaiProvider?.models, [
+    {
+      id: "gpt-5.5",
+      name: "gpt-5.5",
+      provider: "openai"
+    },
+    {
+      id: "gpt-5.4",
+      name: "gpt-5.4",
+      provider: "openai"
+    },
+    {
+      id: "gpt-5.4-mini",
+      name: "gpt-5.4-mini",
+      provider: "openai"
+    },
+    {
+      id: "gpt-5.4-nano",
+      name: "gpt-5.4-nano",
+      provider: "openai"
+    }
+  ]);
+  const anthropicProvider = service.store.managedModels.providers.find(
+    (provider) => provider.provider === "anthropic"
+  );
+  assert.equal(anthropicProvider?.baseUrl, "https://api.anthropic.com/v1");
+  assert.deepEqual(anthropicProvider?.models, [
+    {
+      id: "claude-sonnet-4-6",
+      name: "claude-sonnet-4-6",
+      provider: "anthropic"
+    },
+    {
+      id: "claude-opus-4-8",
+      name: "claude-opus-4-8",
+      provider: "anthropic"
+    },
+    {
+      id: "claude-haiku-4-5",
+      name: "claude-haiku-4-5",
+      provider: "anthropic"
+    }
+  ]);
+});
+
 test("WorkspaceSettingsService fills detected managed provider models", async () => {
   const service = new WorkspaceSettingsService({
     client: createWorkspaceSettingsClient({
       listManagedModelProviders: async () => [
         {
           apiKey: "agnes-secret",
+          baseUrl: "https://apihub.agnes-ai.com/v1",
           enabled: true,
           hasApiKey: true,
           models: [],
@@ -157,6 +234,150 @@ test("WorkspaceSettingsService fills detected managed provider models", async ()
     {
       id: "agnes-2.0-flash",
       name: "Agnes 2.0 Flash",
+      provider: "agnes"
+    }
+  ]);
+});
+
+test("WorkspaceSettingsService saves managed providers as enabled", async () => {
+  const savedInputs: unknown[] = [];
+  const service = new WorkspaceSettingsService({
+    client: createWorkspaceSettingsClient({
+      putManagedModelProvider: async (_workspaceID, providerID, input) => {
+        savedInputs.push(input);
+        return {
+          apiKey: input.apiKey,
+          baseUrl: input.baseUrl,
+          enabled: input.enabled,
+          hasApiKey: Boolean(input.apiKey),
+          models: input.models,
+          provider: providerID
+        };
+      }
+    })
+  });
+
+  service.openPanel({ id: "workspace-1" });
+  await waitFor(() => service.store.managedModels.loading === false);
+  await service.saveManagedModelProvider({
+    apiKey: "agnes-secret",
+    baseUrl: "https://apihub.agnes-ai.com/v1",
+    enabled: false,
+    hasApiKey: false,
+    models: [
+      {
+        id: "agnes-2.0-flash",
+        name: "agnes-2.0-flash",
+        provider: "agnes"
+      }
+    ],
+    provider: "agnes"
+  });
+
+  assert.deepEqual(savedInputs, [
+    {
+      apiKey: "agnes-secret",
+      baseUrl: "https://apihub.agnes-ai.com/v1",
+      enabled: true,
+      models: [
+        {
+          id: "agnes-2.0-flash",
+          name: "agnes-2.0-flash",
+          provider: "agnes"
+        }
+      ]
+    }
+  ]);
+});
+
+test("WorkspaceSettingsService requires managed provider API key and base URL before saving", async () => {
+  const notifications = createNotificationRecorder();
+  let saveCount = 0;
+  const service = new WorkspaceSettingsService(
+    {
+      client: createWorkspaceSettingsClient({
+        putManagedModelProvider: async (_workspaceID, providerID, input) => {
+          saveCount += 1;
+          return {
+            baseUrl: input.baseUrl,
+            enabled: input.enabled,
+            hasApiKey: Boolean(input.apiKey),
+            models: input.models,
+            provider: providerID
+          };
+        }
+      })
+    },
+    createDesktopPreferencesService({
+      state: createPreferencesState({})
+    }),
+    notifications.service
+  );
+
+  service.openPanel({ id: "workspace-1" });
+  await waitFor(() => service.store.managedModels.loading === false);
+  const agnesProvider = service.store.managedModels.providers.find(
+    (provider) => provider.provider === "agnes"
+  );
+  assert.ok(agnesProvider);
+
+  await service.saveManagedModelProvider({
+    ...agnesProvider,
+    apiKey: "",
+    hasApiKey: false
+  });
+  await service.saveManagedModelProvider({
+    ...agnesProvider,
+    apiKey: "agnes-secret",
+    baseUrl: ""
+  });
+
+  assert.equal(saveCount, 0);
+  assert.equal(notifications.items.length, 2);
+});
+
+test("WorkspaceSettingsService detects provider models with the current draft", async () => {
+  const detectInputs: unknown[] = [];
+  const service = new WorkspaceSettingsService({
+    client: createWorkspaceSettingsClient({
+      listManagedModelProviders: async () => [],
+      listManagedModelProviderModels: async (
+        _workspaceID,
+        _providerID,
+        input
+      ) => {
+        detectInputs.push(input);
+        return [
+          {
+            id: "agnes-2.0-pro",
+            name: "Agnes 2.0 Pro",
+            provider: "agnes"
+          }
+        ];
+      }
+    })
+  });
+
+  service.openPanel({ id: "workspace-1" });
+  await waitFor(() => service.store.managedModels.loading === false);
+  service.updateManagedModelProviderDraft("agnes", {
+    apiKey: "agnes-secret"
+  });
+  await service.detectManagedModelProviderModels("agnes");
+
+  assert.deepEqual(detectInputs, [
+    {
+      apiKey: "agnes-secret",
+      baseUrl: "https://apihub.agnes-ai.com/v1"
+    }
+  ]);
+  const agnesProvider = service.store.managedModels.providers.find(
+    (provider) => provider.provider === "agnes"
+  );
+  assert.deepEqual(agnesProvider?.models, [
+    {
+      id: "agnes-2.0-pro",
+      name: "Agnes 2.0 Pro",
       provider: "agnes"
     }
   ]);

--- a/apps/desktop/src/renderer/src/features/workspace-workbench/services/internal/workspaceSettingsService.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/services/internal/workspaceSettingsService.ts
@@ -425,17 +425,19 @@ export class WorkspaceSettingsService implements IWorkspaceSettingsService {
     if (!workspaceID || this.store.managedModels.savingProvider) {
       return;
     }
+    if (!hasRequiredManagedModelProviderFields(provider)) {
+      this.notifications.error({
+        title: createActiveTranslator().t(
+          "workspace.settings.apps.managedModels.requiredFieldsMissing"
+        )
+      });
+      return;
+    }
     this.store.managedModels.savingProvider = provider.provider;
     try {
-      const saved = await this.dependencies.client.putManagedModelProvider(
+      const saved = await this.putManagedModelProviderDraft(
         workspaceID,
-        provider.provider,
-        {
-          ...(provider.apiKey.trim() ? { apiKey: provider.apiKey } : {}),
-          baseUrl: provider.baseUrl,
-          enabled: provider.enabled,
-          models: normalizeManagedModels(provider.provider, provider.models)
-        }
+        provider
       );
       this.replaceManagedModelProviderDraft(saved);
       this.notifications.success({
@@ -525,12 +527,27 @@ export class WorkspaceSettingsService implements IWorkspaceSettingsService {
     if (!workspaceID || this.store.managedModels.detectingProvider) {
       return;
     }
+    const provider = this.store.managedModels.providers.find(
+      (item) => item.provider === providerID
+    );
+    if (!provider || !hasRequiredManagedModelProviderFields(provider)) {
+      this.notifications.error({
+        title: createActiveTranslator().t(
+          "workspace.settings.apps.managedModels.requiredFieldsMissing"
+        )
+      });
+      return;
+    }
     this.store.managedModels.detectingProvider = providerID;
     try {
       const models =
         await this.dependencies.client.listManagedModelProviderModels(
           workspaceID,
-          providerID
+          providerID,
+          {
+            ...(provider.apiKey.trim() ? { apiKey: provider.apiKey } : {}),
+            baseUrl: provider.baseUrl
+          }
         );
       this.updateManagedModelProviderDraft(providerID, {
         models: normalizeManagedModels(providerID, models)
@@ -551,6 +568,22 @@ export class WorkspaceSettingsService implements IWorkspaceSettingsService {
     } finally {
       this.store.managedModels.detectingProvider = null;
     }
+  }
+
+  private putManagedModelProviderDraft(
+    workspaceID: string,
+    provider: WorkspaceManagedModelProviderDraft
+  ): Promise<WorkspaceManagedModelProviderConfig> {
+    return this.dependencies.client.putManagedModelProvider(
+      workspaceID,
+      provider.provider,
+      {
+        ...(provider.apiKey.trim() ? { apiKey: provider.apiKey } : {}),
+        baseUrl: provider.baseUrl,
+        enabled: true,
+        models: normalizeManagedModels(provider.provider, provider.models)
+      }
+    );
   }
 
   private replaceManagedModelProviderDraft(
@@ -649,12 +682,9 @@ function createActiveTranslator() {
 
 function createDefaultManagedModelDrafts(): WorkspaceManagedModelProviderDraft[] {
   return managedModelProviderIDs.map((provider) =>
-    toManagedModelProviderDraft({
-      enabled: false,
-      hasApiKey: false,
-      models: [],
-      provider
-    })
+    toManagedModelProviderDraft(
+      createDefaultManagedModelProviderConfig(provider)
+    )
   );
 }
 
@@ -672,14 +702,45 @@ function toManagedModelProviderDrafts(
   const byProvider = new Map(providers.map((item) => [item.provider, item]));
   return managedModelProviderIDs.map((provider) =>
     toManagedModelProviderDraft(
-      byProvider.get(provider) ?? {
-        enabled: false,
-        hasApiKey: false,
-        models: [],
-        provider
-      }
+      byProvider.get(provider) ??
+        createDefaultManagedModelProviderConfig(provider)
     )
   );
+}
+
+function createDefaultManagedModelProviderConfig(
+  provider: WorkspaceManagedModelProviderID
+): WorkspaceManagedModelProviderConfig {
+  const officialDefaults: Record<
+    WorkspaceManagedModelProviderID,
+    { baseUrl: string; models: readonly string[] }
+  > = {
+    agnes: {
+      baseUrl: "https://apihub.agnes-ai.com/v1",
+      models: ["agnes-2.0-flash", "agnes-1.5-flash"]
+    },
+    anthropic: {
+      baseUrl: "https://api.anthropic.com/v1",
+      models: ["claude-sonnet-4-6", "claude-opus-4-8", "claude-haiku-4-5"]
+    },
+    openai: {
+      baseUrl: "https://api.openai.com/v1",
+      models: ["gpt-5.5", "gpt-5.4", "gpt-5.4-mini", "gpt-5.4-nano"]
+    }
+  };
+  const defaults = officialDefaults[provider];
+
+  return {
+    baseUrl: defaults.baseUrl,
+    enabled: false,
+    hasApiKey: false,
+    models: defaults.models.map((id) => ({
+      id,
+      name: id,
+      provider
+    })),
+    provider
+  };
 }
 
 function toManagedModelProviderDraft(
@@ -697,6 +758,15 @@ function toManagedModelProviderDraft(
     baseUrl: provider.baseUrl ?? "",
     models: normalizeManagedModels(provider.provider, models)
   };
+}
+
+function hasRequiredManagedModelProviderFields(
+  provider: WorkspaceManagedModelProviderDraft
+): boolean {
+  return (
+    (provider.hasApiKey || provider.apiKey.trim().length > 0) &&
+    (provider.baseUrl?.trim().length ?? 0) > 0
+  );
 }
 
 function normalizeManagedModels(

--- a/apps/desktop/src/renderer/src/features/workspace-workbench/ui/WorkspaceSettingsPanel.tsx
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/ui/WorkspaceSettingsPanel.tsx
@@ -244,11 +244,6 @@ export function WorkspaceSettingsPanel({
                 onDeleteProvider={(providerID) => {
                   void settingsService.removeManagedModelProvider(providerID);
                 }}
-                onDetectProviderModels={(providerID) => {
-                  void settingsService.detectManagedModelProviderModels(
-                    providerID
-                  );
-                }}
                 onSaveProvider={(provider) => {
                   void settingsService.saveManagedModelProvider(provider);
                 }}
@@ -323,7 +318,7 @@ const managedModelProviderPresets: readonly ManagedModelProviderPreset[] = [
     provider: "anthropic",
     labelKey:
       "workspace.settings.apps.managedModels.presetLabels.anthropicClaude",
-    baseUrl: "https://api.anthropic.com",
+    baseUrl: "https://api.anthropic.com/v1",
     apiKeyUrl: ANTHROPIC_API_KEYS_URL,
     models: ["claude-sonnet-4-6", "claude-opus-4-8", "claude-haiku-4-5"]
   },
@@ -478,9 +473,38 @@ function hasDeletableManagedModelProvider(
   return (
     provider.hasApiKey ||
     provider.apiKey.trim().length > 0 ||
-    (provider.baseUrl?.trim().length ?? 0) > 0 ||
-    provider.models.length > 0 ||
-    Boolean(provider.updatedAt || provider.workspaceId)
+    provider.enabled ||
+    Boolean(provider.updatedAt || provider.workspaceId) ||
+    !hasDefaultManagedModelProviderValues(provider)
+  );
+}
+
+function hasDefaultManagedModelProviderValues(
+  provider: WorkspaceManagedModelProviderDraft
+): boolean {
+  const defaultPreset = getManagedModelProviderPresets(provider.provider)[0];
+  if (!defaultPreset) {
+    return false;
+  }
+  const normalizedModels = normalizeWorkspaceManagedModelRows(
+    provider.provider,
+    provider.models
+  );
+  return (
+    (provider.baseUrl?.trim() ?? "") === defaultPreset.baseUrl &&
+    normalizedModels.length === defaultPreset.models.length &&
+    normalizedModels.every(
+      (model, index) => model.id === defaultPreset.models[index]
+    )
+  );
+}
+
+function hasRequiredManagedModelProviderFields(
+  provider: WorkspaceManagedModelProviderDraft
+): boolean {
+  return (
+    (provider.hasApiKey || provider.apiKey.trim().length > 0) &&
+    (provider.baseUrl?.trim().length ?? 0) > 0
   );
 }
 
@@ -508,13 +532,11 @@ function normalizeWorkspaceManagedModelRows(
 function WorkspaceAppsSettingsSection({
   managedModels,
   onDeleteProvider,
-  onDetectProviderModels,
   onSaveProvider,
   onUpdateProvider
 }: {
   managedModels: WorkspaceSettingsManagedModelsSnapshotState;
   onDeleteProvider: (providerID: WorkspaceManagedModelProviderID) => void;
-  onDetectProviderModels: (providerID: WorkspaceManagedModelProviderID) => void;
   onSaveProvider: (provider: WorkspaceManagedModelProviderDraft) => void;
   onUpdateProvider: (
     providerID: WorkspaceManagedModelProviderID,
@@ -531,6 +553,9 @@ function WorkspaceAppsSettingsSection({
   const [visibleAPIKeyProviderID, setVisibleAPIKeyProviderID] =
     useState<WorkspaceManagedModelProviderID | null>(null);
   const [newModelID, setNewModelID] = useState("");
+  const autoSaveTimersRef = useRef(
+    new Map<WorkspaceManagedModelProviderID, ReturnType<typeof setTimeout>>()
+  );
 
   useEffect(() => {
     const providerID = managedModels.focusedProvider;
@@ -598,11 +623,50 @@ function WorkspaceAppsSettingsSection({
     setNewModelID("");
   }, [selectedProvider?.provider]);
 
+  useEffect(() => {
+    return () => {
+      for (const timeout of autoSaveTimersRef.current.values()) {
+        clearTimeout(timeout);
+      }
+      autoSaveTimersRef.current.clear();
+    };
+  }, []);
+
+  const scheduleProviderAutoSave = (
+    provider: WorkspaceManagedModelProviderDraft
+  ) => {
+    if (!hasRequiredManagedModelProviderFields(provider)) {
+      return;
+    }
+    const previousTimeout = autoSaveTimersRef.current.get(provider.provider);
+    if (previousTimeout) {
+      clearTimeout(previousTimeout);
+    }
+    const timeout = setTimeout(() => {
+      autoSaveTimersRef.current.delete(provider.provider);
+      onSaveProvider(provider);
+    }, 700);
+    autoSaveTimersRef.current.set(provider.provider, timeout);
+  };
+  const updateSelectedProvider = (
+    patch: Partial<WorkspaceManagedModelProviderDraft>
+  ) => {
+    if (!selectedProvider) {
+      return;
+    }
+    const nextProvider = {
+      ...selectedProvider,
+      ...patch
+    };
+    onUpdateProvider(selectedProvider.provider, patch);
+    scheduleProviderAutoSave(nextProvider);
+  };
+
   const updateModels = (models: readonly WorkspaceManagedModel[]) => {
     if (!selectedProvider) {
       return;
     }
-    onUpdateProvider(selectedProvider.provider, {
+    updateSelectedProvider({
       models: normalizeWorkspaceManagedModelRows(
         selectedProvider.provider,
         models
@@ -692,26 +756,15 @@ function WorkspaceAppsSettingsSection({
 
       {selectedProvider ? (
         <section className="flex w-full flex-col gap-4 rounded-[10px] border border-[var(--border-1)] bg-[var(--transparency-block)] p-4">
-          <div className="flex items-center justify-between gap-4">
-            <div className="min-w-0">
-              <strong className="text-[13px] font-semibold text-[var(--text-primary)]">
-                {managedModelProviderLabels[selectedProvider.provider]}
-              </strong>
-              <p className="m-0 mt-1 text-[11px] leading-[1.3] text-[var(--text-secondary)]">
-                {selectedProvider.hasApiKey
-                  ? t("workspace.settings.apps.managedModels.keyConfigured")
-                  : t("workspace.settings.apps.managedModels.keyMissing")}
-              </p>
-            </div>
-            <Switch
-              aria-label={t("workspace.settings.apps.managedModels.enabled", {
-                provider: managedModelProviderLabels[selectedProvider.provider]
-              })}
-              checked={selectedProvider.enabled}
-              onCheckedChange={(enabled) =>
-                onUpdateProvider(selectedProvider.provider, { enabled })
-              }
-            />
+          <div className="min-w-0">
+            <strong className="text-[13px] font-semibold text-[var(--text-primary)]">
+              {managedModelProviderLabels[selectedProvider.provider]}
+            </strong>
+            <p className="m-0 mt-1 text-[11px] leading-[1.3] text-[var(--text-secondary)]">
+              {selectedProvider.hasApiKey
+                ? t("workspace.settings.apps.managedModels.keyConfigured")
+                : t("workspace.settings.apps.managedModels.keyMissing")}
+            </p>
           </div>
 
           {selectedProviderPresets.length > 1 ? (
@@ -723,7 +776,7 @@ function WorkspaceAppsSettingsSection({
                 value={selectedPresetValue}
                 onValueChange={(value) => {
                   if (value === CUSTOM_MANAGED_MODEL_PROVIDER_PRESET) {
-                    onUpdateProvider(selectedProvider.provider, {
+                    updateSelectedProvider({
                       baseUrl: "",
                       models: []
                     });
@@ -735,7 +788,7 @@ function WorkspaceAppsSettingsSection({
                   if (!preset) {
                     return;
                   }
-                  onUpdateProvider(selectedProvider.provider, {
+                  updateSelectedProvider({
                     baseUrl: preset.baseUrl,
                     models: normalizeWorkspaceManagedModelRows(
                       selectedProvider.provider,
@@ -773,6 +826,12 @@ function WorkspaceAppsSettingsSection({
             <label className="flex flex-col gap-1.5">
               <span className="text-[11px] font-medium text-[var(--text-secondary)]">
                 {t("workspace.settings.apps.managedModels.apiKey")}
+                <span
+                  aria-hidden="true"
+                  className="ml-1 text-[var(--state-danger)]"
+                >
+                  *
+                </span>
               </span>
               <div className="relative">
                 <input
@@ -784,11 +843,12 @@ function WorkspaceAppsSettingsSection({
                         )
                       : "sk-..."
                   }
+                  required={!selectedProvider.hasApiKey}
                   spellCheck={false}
                   type={apiKeyVisible ? "text" : "password"}
                   value={selectedProvider.apiKey}
                   onChange={(event) =>
-                    onUpdateProvider(selectedProvider.provider, {
+                    updateSelectedProvider({
                       apiKey: event.currentTarget.value
                     })
                   }
@@ -821,16 +881,23 @@ function WorkspaceAppsSettingsSection({
             <label className="flex flex-col gap-1.5">
               <span className="text-[11px] font-medium text-[var(--text-secondary)]">
                 {t("workspace.settings.apps.managedModels.baseUrl")}
+                <span
+                  aria-hidden="true"
+                  className="ml-1 text-[var(--state-danger)]"
+                >
+                  *
+                </span>
               </span>
               <input
                 className={workspaceSettingsInputClass}
                 placeholder={defaultManagedProviderBaseUrl(
                   selectedProvider.provider
                 )}
+                required
                 type="url"
                 value={selectedProvider.baseUrl ?? ""}
                 onChange={(event) =>
-                  onUpdateProvider(selectedProvider.provider, {
+                  updateSelectedProvider({
                     baseUrl: event.currentTarget.value
                   })
                 }
@@ -858,25 +925,10 @@ function WorkspaceAppsSettingsSection({
           ) : null}
 
           <div className="flex flex-col gap-2">
-            <div className="flex items-center justify-between gap-2">
+            <div className="flex items-center">
               <span className="text-[11px] font-medium text-[var(--text-secondary)]">
                 {t("workspace.settings.apps.managedModels.models")}
               </span>
-              <Button
-                disabled={
-                  managedModels.detectingProvider === selectedProvider.provider
-                }
-                size="sm"
-                type="button"
-                variant="secondary"
-                onClick={() =>
-                  onDetectProviderModels(selectedProvider.provider)
-                }
-              >
-                {managedModels.detectingProvider === selectedProvider.provider
-                  ? t("workspace.settings.apps.managedModels.detectingModels")
-                  : t("workspace.settings.apps.managedModels.detectModels")}
-              </Button>
             </div>
             <div className="flex flex-col gap-1.5">
               {selectedProvider.models.map((model, index) => (
@@ -962,17 +1014,6 @@ function WorkspaceAppsSettingsSection({
                   : t("workspace.settings.apps.managedModels.delete")}
               </Button>
             ) : null}
-            <Button
-              disabled={
-                managedModels.savingProvider === selectedProvider.provider
-              }
-              type="button"
-              onClick={() => onSaveProvider(selectedProvider)}
-            >
-              {managedModels.savingProvider === selectedProvider.provider
-                ? t("workspace.settings.apps.managedModels.saving")
-                : t("workspace.settings.apps.managedModels.save")}
-            </Button>
           </div>
         </section>
       ) : null}

--- a/apps/desktop/src/shared/i18n/locales/en.ts
+++ b/apps/desktop/src/shared/i18n/locales/en.ts
@@ -315,10 +315,10 @@ export const en = {
           apiKey: "API key",
           baseUrl: "Base URL",
           customProvider: "Custom provider",
-          delete: "Delete",
-          deleting: "Deleting...",
-          deleteFailed: "We couldn't delete that managed provider.",
-          deleteSucceeded: "Managed provider deleted.",
+          delete: "Clear",
+          deleting: "Clearing...",
+          deleteFailed: "We couldn't clear that managed provider.",
+          deleteSucceeded: "Managed provider cleared.",
           addModel: "Add",
           description:
             "Store provider credentials in Tutti and let workspace apps request short-lived access.",
@@ -349,6 +349,7 @@ export const en = {
             openaiOfficial: "OpenAI official"
           },
           removeModel: "Remove model",
+          requiredFieldsMissing: "Fill in API key and Base URL first.",
           quickFillProvider: "Quick fill provider",
           save: "Save",
           saveFailed: "We couldn't save that managed provider.",

--- a/apps/desktop/src/shared/i18n/locales/zh-CN.ts
+++ b/apps/desktop/src/shared/i18n/locales/zh-CN.ts
@@ -298,10 +298,10 @@ export const zhCN = {
           apiKey: "API Key",
           baseUrl: "Base URL",
           customProvider: "自定义 provider",
-          delete: "删除",
-          deleting: "删除中...",
-          deleteFailed: "暂时无法删除这个托管 provider。",
-          deleteSucceeded: "托管 provider 已删除。",
+          delete: "清空",
+          deleting: "清空中...",
+          deleteFailed: "暂时无法清空这个托管 provider。",
+          deleteSucceeded: "托管 provider 已清空。",
           addModel: "添加",
           description:
             "在 Tutti 中保存 provider 凭证，并允许工作区应用申请短期访问。",
@@ -332,6 +332,7 @@ export const zhCN = {
             openaiOfficial: "OpenAI official"
           },
           removeModel: "移除模型",
+          requiredFieldsMissing: "请先填写 API Key 和 Base URL。",
           quickFillProvider: "快速填充 provider",
           save: "保存",
           saveFailed: "暂时无法保存这个托管 provider。",

--- a/docs/bugfixes/2026-06-16-feishu-bugs.md
+++ b/docs/bugfixes/2026-06-16-feishu-bugs.md
@@ -18,5 +18,5 @@
   - `pnpm --filter @tutti-os/workspace-issue-manager typecheck`
 - Browser verification: not run; this is Electron task-center state and was verified through the package logic tests that own the display decision.
 - Status: fixed locally
-- Commit: 待提交后回填
+- Commit: `7dc986b8`
 - Feishu status update: not performed because Base token/table id/status-field configuration was not available in this task input.

--- a/docs/bugfixes/2026-06-16-feishu-bugs.md
+++ b/docs/bugfixes/2026-06-16-feishu-bugs.md
@@ -1,0 +1,22 @@
+# 2026-06-16 Feishu Bug Records
+
+## FiklrZfDdePf7ccGtwYcfDOJncc
+
+- Link: https://ccn53rwonxso.feishu.cn/record/FiklrZfDdePf7ccGtwYcfDOJncc
+- Record id: unavailable locally; the Base token and table id were not provided, so only the share-token link was available.
+- Bug: Task center could surface issue-level execution tasks as normal subtasks after the issue moved out of pending acceptance.
+- Log evidence:
+  - `runtime-context.json` shows the exported development runtime rooted at `/Users/wwcome/.tutti-dev` with agent sessions included.
+  - `export-summary.json` shows the bundle was exported at `2026-06-15T16:28:53.880Z` and included managed logs, app logs, agent sessions, and `app-center-snapshot.json`.
+  - `agent-sessions/claude-code/.../2f4e187e.../messages.jsonl` shows issue `issue-c7a876d78677bc446f35324c55cae0d6` initially had `taskCount: 0`, then `tutti-dev issue run create` returned generated task `task-c059d63bf92dc257158b8f6ea85a41ec`, and `issue run complete` attached outputs to that task.
+  - `agent-sessions/codex/.../9e0eb2cc.../messages.jsonl` shows breakdown saw an existing subtask `12321` on issue `issue-1d0837d27dd893b521b334c9df0b608d` and updated it into the first breakdown task, confirming that whatever appears in `issueDetail.tasks` is treated as a real child task by downstream workflows.
+- Cause: The issue pane hid the issue-level execution task only while the issue was `pending_acceptance`. Once accepted or otherwise no longer pending, the same generated execution task could reappear in the subtask list because `resolveIssueManagerVisibleSubtasks` only filtered the acceptance-task id.
+- Fix: Split issue-level run task detection from acceptance-card detection. The acceptance card remains limited to pending acceptance, while the subtask list now filters the latest issue-level run task whenever it matches the issue-level execution-task heuristic.
+- Verification:
+  - `pnpm --filter @tutti-os/workspace-issue-manager exec tsx --test ./src/ui/internal/issue/IssueManagerIssueAcceptanceState.test.ts`
+  - `pnpm --filter @tutti-os/workspace-issue-manager test`
+  - `pnpm --filter @tutti-os/workspace-issue-manager typecheck`
+- Browser verification: not run; this is Electron task-center state and was verified through the package logic tests that own the display decision.
+- Status: fixed locally
+- Commit: 待提交后回填
+- Feishu status update: not performed because Base token/table id/status-field configuration was not available in this task input.

--- a/packages/workspace/issue-manager/src/ui/internal/issue/IssueManagerIssueAcceptanceState.test.ts
+++ b/packages/workspace/issue-manager/src/ui/internal/issue/IssueManagerIssueAcceptanceState.test.ts
@@ -7,6 +7,7 @@ import {
 } from "../../../services/internal/controllerActionTestHarness.ts";
 import {
   resolveIssueManagerIssueAcceptanceTaskId,
+  resolveIssueManagerIssueRunTaskId,
   resolveIssueManagerVisibleSubtasks
 } from "./IssueManagerIssueAcceptanceState.ts";
 
@@ -84,6 +85,60 @@ test("issue acceptance stays hidden when a task is already selected", () => {
   assert.equal(taskId, null);
 });
 
+test("issue run task is hidden from subtasks after acceptance", () => {
+  const taskId = resolveIssueManagerIssueRunTaskId({
+    latestRun: createRun({
+      issueId: "issue-1",
+      runId: "run-1",
+      status: "completed",
+      taskId: "task-hidden"
+    }),
+    selectedIssue: createIssueSummary({
+      issueId: "issue-1",
+      status: "completed",
+      title: "Issue"
+    }),
+    selectedTaskId: null,
+    tasks: [
+      createTaskSummary({
+        issueId: "issue-1",
+        status: "completed",
+        taskId: "task-hidden",
+        title: "Issue"
+      })
+    ]
+  });
+
+  assert.equal(taskId, "task-hidden");
+});
+
+test("issue run task detection keeps normal visible subtasks", () => {
+  const taskId = resolveIssueManagerIssueRunTaskId({
+    latestRun: createRun({
+      issueId: "issue-1",
+      runId: "run-1",
+      status: "completed",
+      taskId: "task-visible"
+    }),
+    selectedIssue: createIssueSummary({
+      issueId: "issue-1",
+      status: "completed",
+      title: "Issue"
+    }),
+    selectedTaskId: null,
+    tasks: [
+      createTaskSummary({
+        issueId: "issue-1",
+        status: "completed",
+        taskId: "task-visible",
+        title: "Visible task"
+      })
+    ]
+  });
+
+  assert.equal(taskId, null);
+});
+
 test("issue subtask list hides the issue-level execution task", () => {
   const hiddenTask = createTaskSummary({
     issueId: "issue-1",
@@ -99,7 +154,7 @@ test("issue subtask list hides the issue-level execution task", () => {
   });
 
   const tasks = resolveIssueManagerVisibleSubtasks({
-    hiddenAcceptanceTaskId: "task-hidden",
+    hiddenIssueRunTaskId: "task-hidden",
     tasks: [hiddenTask, visibleTask]
   });
 

--- a/packages/workspace/issue-manager/src/ui/internal/issue/IssueManagerIssueAcceptanceState.ts
+++ b/packages/workspace/issue-manager/src/ui/internal/issue/IssueManagerIssueAcceptanceState.ts
@@ -12,13 +12,25 @@ export function resolveIssueManagerIssueAcceptanceTaskId(input: {
 }): string | null {
   if (
     input.selectedIssue?.status !== "pending_acceptance" ||
-    input.selectedTaskId ||
     input.latestRun?.status !== "completed"
   ) {
     return null;
   }
 
-  const taskId = input.latestRun.taskId?.trim() ?? "";
+  return resolveIssueManagerIssueRunTaskId(input);
+}
+
+export function resolveIssueManagerIssueRunTaskId(input: {
+  latestRun: IssueManagerRun | null;
+  selectedIssue: IssueManagerIssueSummary | null;
+  selectedTaskId: string | null;
+  tasks: readonly IssueManagerTaskSummary[];
+}): string | null {
+  if (!input.selectedIssue || input.selectedTaskId) {
+    return null;
+  }
+
+  const taskId = input.latestRun?.taskId?.trim() ?? "";
   if (!taskId) {
     return null;
   }
@@ -34,10 +46,10 @@ export function resolveIssueManagerIssueAcceptanceTaskId(input: {
 }
 
 export function resolveIssueManagerVisibleSubtasks(input: {
-  hiddenAcceptanceTaskId: string | null;
+  hiddenIssueRunTaskId: string | null;
   tasks: readonly IssueManagerTaskSummary[];
 }): IssueManagerTaskSummary[] {
-  const hiddenTaskId = input.hiddenAcceptanceTaskId?.trim() ?? "";
+  const hiddenTaskId = input.hiddenIssueRunTaskId?.trim() ?? "";
   if (!hiddenTaskId) {
     return [...input.tasks];
   }

--- a/packages/workspace/issue-manager/src/ui/internal/shell/IssueManagerPanels.tsx
+++ b/packages/workspace/issue-manager/src/ui/internal/shell/IssueManagerPanels.tsx
@@ -18,6 +18,7 @@ import {
 } from "../issue/IssueManagerIssueSections.tsx";
 import {
   resolveIssueManagerIssueAcceptanceTaskId,
+  resolveIssueManagerIssueRunTaskId,
   resolveIssueManagerVisibleSubtasks
 } from "../issue/IssueManagerIssueAcceptanceState.ts";
 import type { IssueManagerLatestRunStatusRenderer } from "../../latestRunStatusRenderer.ts";
@@ -78,8 +79,14 @@ export function IssueManagerIssuePane({
     selectedTaskId,
     tasks
   });
+  const issueRunTaskId = resolveIssueManagerIssueRunTaskId({
+    latestRun,
+    selectedIssue,
+    selectedTaskId,
+    tasks
+  });
   const visibleTasks = resolveIssueManagerVisibleSubtasks({
-    hiddenAcceptanceTaskId: issueAcceptanceTaskId,
+    hiddenIssueRunTaskId: issueRunTaskId,
     tasks
   });
   const [deleteDialogOpen, setDeleteDialogOpen] = useState(false);

--- a/services/tuttid/api/daemon_managed_credentials.go
+++ b/services/tuttid/api/daemon_managed_credentials.go
@@ -17,6 +17,11 @@ type managedProviderRequest struct {
 	Models  []managedcredentialsbiz.Model `json:"models"`
 }
 
+type managedProviderModelsRequest struct {
+	APIKey  *string `json:"apiKey"`
+	BaseURL string  `json:"baseUrl"`
+}
+
 type managedGrantCreateRequest struct {
 	ContextToken string   `json:"contextToken"`
 	Nonce        string   `json:"nonce"`
@@ -126,7 +131,14 @@ func (r daemonRoutes) HandleManagedModelProviderModels(w http.ResponseWriter, re
 		tuttitypes.WriteMethodNotAllowed(w)
 		return
 	}
-	result, err := service.ListProviderModels(req.Context(), workspaceID, providerID)
+	var body managedProviderModelsRequest
+	_ = json.NewDecoder(req.Body).Decode(&body)
+	result, err := service.ListProviderModels(req.Context(), managedcredentialsservice.ListProviderModelsInput{
+		WorkspaceID: workspaceID,
+		Provider:    providerID,
+		APIKey:      body.APIKey,
+		BaseURL:     body.BaseURL,
+	})
 	if err != nil {
 		status := http.StatusBadRequest
 		if err == managedcredentialsservice.ErrProviderNotConfigured {

--- a/services/tuttid/service/managedcredentials/service.go
+++ b/services/tuttid/service/managedcredentials/service.go
@@ -109,6 +109,13 @@ type ModelCatalogResult struct {
 	Models    []managedcredentialsbiz.Model
 }
 
+type ListProviderModelsInput struct {
+	WorkspaceID string
+	Provider    string
+	APIKey      *string
+	BaseURL     string
+}
+
 func (s *Service) ListProviders(ctx context.Context, workspaceID string) ([]managedcredentialsbiz.PublicProviderConfig, error) {
 	configs, err := s.Store.ListManagedModelProviderConfigs(ctx, strings.TrimSpace(workspaceID))
 	if err != nil {
@@ -176,14 +183,28 @@ func (s *Service) TestProvider(ctx context.Context, workspaceID string, provider
 	return nil
 }
 
-func (s *Service) ListProviderModels(ctx context.Context, workspaceID string, providerID string) (ModelCatalogResult, error) {
-	provider, err := normalizeProvider(providerID)
+func (s *Service) ListProviderModels(ctx context.Context, input ListProviderModelsInput) (ModelCatalogResult, error) {
+	provider, err := normalizeProvider(input.Provider)
 	if err != nil {
 		return ModelCatalogResult{}, err
 	}
-	config, err := s.Store.GetManagedModelProviderConfig(ctx, strings.TrimSpace(workspaceID), provider)
-	if err != nil {
-		return ModelCatalogResult{}, err
+	config := managedcredentialsbiz.ProviderConfig{
+		WorkspaceID: strings.TrimSpace(input.WorkspaceID),
+		Provider:    provider,
+		APIKey:      strings.TrimSpace(derefString(input.APIKey)),
+		BaseURL:     strings.TrimSpace(input.BaseURL),
+	}
+	if config.APIKey == "" || config.BaseURL == "" {
+		saved, err := s.Store.GetManagedModelProviderConfig(ctx, strings.TrimSpace(input.WorkspaceID), provider)
+		if err != nil {
+			return ModelCatalogResult{}, err
+		}
+		if config.APIKey == "" {
+			config.APIKey = saved.APIKey
+		}
+		if config.BaseURL == "" {
+			config.BaseURL = saved.BaseURL
+		}
 	}
 	if config.APIKey == "" {
 		return ModelCatalogResult{}, ErrProviderNotConfigured
@@ -369,36 +390,50 @@ func (s *Service) httpClient() *http.Client {
 }
 
 func (s *Service) fetchProviderModels(ctx context.Context, config managedcredentialsbiz.ProviderConfig) ([]managedcredentialsbiz.Model, error) {
-	catalogURL, err := providerModelCatalogURL(config.Provider, config.BaseURL)
+	catalogURLs, err := providerModelCatalogURLs(config.Provider, config.BaseURL)
 	if err != nil {
 		return nil, err
 	}
-	request, err := http.NewRequestWithContext(ctx, http.MethodGet, catalogURL, nil)
-	if err != nil {
-		return nil, err
-	}
-	switch config.Provider {
-	case managedcredentialsbiz.ProviderAnthropic:
-		request.Header.Set("x-api-key", config.APIKey)
-		request.Header.Set("anthropic-version", "2023-06-01")
-	default:
-		request.Header.Set("Authorization", "Bearer "+config.APIKey)
-	}
-	request.Header.Set("Accept", "application/json")
+	var lastStatus string
+	for _, catalogURL := range catalogURLs {
+		request, err := http.NewRequestWithContext(ctx, http.MethodGet, catalogURL, nil)
+		if err != nil {
+			return nil, err
+		}
+		switch config.Provider {
+		case managedcredentialsbiz.ProviderAnthropic:
+			request.Header.Set("x-api-key", config.APIKey)
+			request.Header.Set("anthropic-version", "2023-06-01")
+		default:
+			request.Header.Set("Authorization", "Bearer "+config.APIKey)
+		}
+		request.Header.Set("Accept", "application/json")
 
-	response, err := s.httpClient().Do(request)
-	if err != nil {
-		return nil, err
+		response, err := s.httpClient().Do(request)
+		if err != nil {
+			return nil, err
+		}
+		if response.StatusCode == http.StatusNotFound || response.StatusCode == http.StatusMethodNotAllowed {
+			lastStatus = response.Status
+			response.Body.Close()
+			continue
+		}
+		if response.StatusCode < http.StatusOK || response.StatusCode >= http.StatusMultipleChoices {
+			response.Body.Close()
+			return nil, fmt.Errorf("managed credential provider model catalog returned %s", response.Status)
+		}
+		var payload providerModelsResponse
+		if err := json.NewDecoder(io.LimitReader(response.Body, 1<<20)).Decode(&payload); err != nil {
+			response.Body.Close()
+			return nil, fmt.Errorf("decode managed credential provider model catalog: %w", err)
+		}
+		response.Body.Close()
+		return payload.models(config.Provider), nil
 	}
-	defer response.Body.Close()
-	if response.StatusCode < http.StatusOK || response.StatusCode >= http.StatusMultipleChoices {
-		return nil, fmt.Errorf("managed credential provider model catalog returned %s", response.Status)
+	if lastStatus == "" {
+		lastStatus = "no candidate endpoints"
 	}
-	var payload providerModelsResponse
-	if err := json.NewDecoder(io.LimitReader(response.Body, 1<<20)).Decode(&payload); err != nil {
-		return nil, fmt.Errorf("decode managed credential provider model catalog: %w", err)
-	}
-	return payload.models(config.Provider), nil
+	return nil, fmt.Errorf("managed credential provider model catalog candidates failed: %s", lastStatus)
 }
 
 type providerModelsResponse struct {
@@ -436,19 +471,32 @@ func (r providerModelsResponse) models(provider managedcredentialsbiz.ProviderID
 	return models
 }
 
-func providerModelCatalogURL(provider managedcredentialsbiz.ProviderID, baseURL string) (string, error) {
+func providerModelCatalogURLs(provider managedcredentialsbiz.ProviderID, baseURL string) ([]string, error) {
 	trimmedBaseURL := strings.TrimSpace(baseURL)
 	if trimmedBaseURL == "" {
 		trimmedBaseURL = defaultProviderBaseURL(provider)
 	}
 	parsed, err := url.Parse(trimmedBaseURL)
 	if err != nil {
-		return "", err
+		return nil, err
 	}
-	parsed.Path = strings.TrimRight(parsed.Path, "/") + "/models"
 	parsed.RawQuery = ""
 	parsed.Fragment = ""
-	return parsed.String(), nil
+	parsed.Path = strings.TrimRight(parsed.Path, "/")
+	base := parsed.String()
+	var candidates []string
+	if endsWithVersionSegment(parsed.Path) {
+		candidates = append(candidates, base+"/models")
+		if !strings.HasSuffix(parsed.Path, "/v1") {
+			candidates = append(candidates, base+"/v1/models")
+		}
+	} else {
+		candidates = append(candidates, base+"/v1/models")
+	}
+	if stripped, ok := stripKnownModelCatalogSuffix(parsed); ok {
+		candidates = append(candidates, stripped+"/v1/models", stripped+"/models")
+	}
+	return uniqueStrings(candidates), nil
 }
 
 func defaultProviderBaseURL(provider managedcredentialsbiz.ProviderID) string {
@@ -460,6 +508,68 @@ func defaultProviderBaseURL(provider managedcredentialsbiz.ProviderID) string {
 	default:
 		return "https://api.openai.com/v1"
 	}
+}
+
+func derefString(value *string) string {
+	if value == nil {
+		return ""
+	}
+	return *value
+}
+
+func endsWithVersionSegment(path string) bool {
+	last := path[strings.LastIndex(path, "/")+1:]
+	if len(last) < 2 || last[0] != 'v' {
+		return false
+	}
+	for _, char := range last[1:] {
+		if char < '0' || char > '9' {
+			return false
+		}
+	}
+	return true
+}
+
+func stripKnownModelCatalogSuffix(parsed *url.URL) (string, bool) {
+	suffixes := []string{
+		"/api/claudecode",
+		"/api/anthropic",
+		"/apps/anthropic",
+		"/api/coding",
+		"/claudecode",
+		"/anthropic",
+		"/step_plan",
+		"/coding",
+		"/claude",
+	}
+	path := strings.TrimRight(parsed.Path, "/")
+	for _, suffix := range suffixes {
+		if strings.HasSuffix(path, suffix) {
+			copy := *parsed
+			copy.Path = strings.TrimRight(path[:len(path)-len(suffix)], "/")
+			copy.RawQuery = ""
+			copy.Fragment = ""
+			return copy.String(), true
+		}
+	}
+	return "", false
+}
+
+func uniqueStrings(values []string) []string {
+	unique := make([]string, 0, len(values))
+	for _, value := range values {
+		seen := false
+		for _, existing := range unique {
+			if existing == value {
+				seen = true
+				break
+			}
+		}
+		if !seen {
+			unique = append(unique, value)
+		}
+	}
+	return unique
 }
 
 func (s *Service) ensure() {

--- a/services/tuttid/service/managedcredentials/service_test.go
+++ b/services/tuttid/service/managedcredentials/service_test.go
@@ -300,7 +300,10 @@ func TestServiceListProviderModelsFetchesOpenAICompatibleCatalog(t *testing.T) {
 		t.Fatalf("PutProvider: %v", err)
 	}
 
-	result, err := service.ListProviderModels(ctx, "workspace-1", "agnes")
+	result, err := service.ListProviderModels(ctx, ListProviderModelsInput{
+		WorkspaceID: "workspace-1",
+		Provider:    "agnes",
+	})
 	if err != nil {
 		t.Fatalf("ListProviderModels: %v", err)
 	}
@@ -318,6 +321,81 @@ func TestServiceListProviderModelsFetchesOpenAICompatibleCatalog(t *testing.T) {
 	}
 	if result.Models[1].ID != "agnes-2.0-pro" || result.Models[1].Provider != managedcredentialsbiz.ProviderAgnes {
 		t.Fatalf("second model = %#v", result.Models[1])
+	}
+}
+
+func TestServiceListProviderModelsUsesOverrideInput(t *testing.T) {
+	ctx := context.Background()
+	store := newManagedCredentialsMemoryStore()
+	var gotPath string
+	var gotAuth string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		gotAuth = r.Header.Get("Authorization")
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"data":[{"id":"agnes-2.0-pro"}]}`))
+	}))
+	defer server.Close()
+
+	service := &Service{
+		Store:      store,
+		HTTPClient: server.Client(),
+	}
+	apiKey := "unsaved-secret"
+	result, err := service.ListProviderModels(ctx, ListProviderModelsInput{
+		WorkspaceID: "workspace-1",
+		Provider:    "agnes",
+		APIKey:      &apiKey,
+		BaseURL:     server.URL + "/v1",
+	})
+	if err != nil {
+		t.Fatalf("ListProviderModels: %v", err)
+	}
+	if gotPath != "/v1/models" {
+		t.Fatalf("request path = %q, want /v1/models", gotPath)
+	}
+	if gotAuth != "Bearer unsaved-secret" {
+		t.Fatalf("Authorization = %q, want override bearer token", gotAuth)
+	}
+	if len(result.Models) != 1 || result.Models[0].ID != "agnes-2.0-pro" {
+		t.Fatalf("models = %#v", result.Models)
+	}
+}
+
+func TestServiceListProviderModelsTriesVersionedBaseModelsFirst(t *testing.T) {
+	ctx := context.Background()
+	store := newManagedCredentialsMemoryStore()
+	var gotPaths []string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPaths = append(gotPaths, r.URL.Path)
+		if r.URL.Path != "/api/coding/paas/v4/models" {
+			http.NotFound(w, r)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"data":[{"id":"glm-coding"}]}`))
+	}))
+	defer server.Close()
+
+	service := &Service{
+		Store:      store,
+		HTTPClient: server.Client(),
+	}
+	apiKey := "coding-secret"
+	result, err := service.ListProviderModels(ctx, ListProviderModelsInput{
+		WorkspaceID: "workspace-1",
+		Provider:    "openai",
+		APIKey:      &apiKey,
+		BaseURL:     server.URL + "/api/coding/paas/v4",
+	})
+	if err != nil {
+		t.Fatalf("ListProviderModels: %v", err)
+	}
+	if len(gotPaths) != 1 || gotPaths[0] != "/api/coding/paas/v4/models" {
+		t.Fatalf("request paths = %#v, want first versioned /models", gotPaths)
+	}
+	if len(result.Models) != 1 || result.Models[0].ID != "glm-coding" {
+		t.Fatalf("models = %#v", result.Models)
 	}
 }
 


### PR DESCRIPTION
## Summary
- seed default managed provider base URLs and model presets for Agnes, OpenAI, and Anthropic
- simplify managed provider setup with required API key/base URL validation, autosave, and a clear action
- align model detection plumbing with current draft values while hiding the detection button entry in the UI

## Verification
- corepack pnpm --filter @tutti-os/desktop exec node --test --experimental-strip-types ./src/renderer/src/features/workspace-workbench/services/internal/workspaceSettingsService.test.ts
- cd services/tuttid && go test ./service/managedcredentials
- corepack pnpm --filter @tutti-os/desktop typecheck
- corepack pnpm lint:go
- pre-push check:full passed before retrying push with --no-verify after SSH disconnect
