### PR TITLE
[codex] limit desktop release assets to macos

### DIFF
--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -302,134 +302,9 @@ jobs:
           if-no-files-found: error
           retention-days: 7
 
-  build-windows:
-    name: Build Windows
-    needs: resolve
-    runs-on: windows-latest
-    env:
-      TUTTI_DESKTOP_RELEASE_TAG: ${{ needs.resolve.outputs.release_tag }}
-      TUTTI_DESKTOP_RELEASE_TARGET: ${{ needs.resolve.outputs.release_target }}
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v6
-        with:
-          ref: ${{ env.TUTTI_DESKTOP_RELEASE_TARGET }}
-          fetch-depth: 0
-
-      - name: Setup pnpm
-        uses: pnpm/action-setup@v6
-        with:
-          version: 10.11.0
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v6
-        with:
-          node-version-file: .node-version
-          cache: pnpm
-          cache-dependency-path: pnpm-lock.yaml
-
-      - name: Setup Go
-        uses: actions/setup-go@v6
-        with:
-          go-version: "1.24.5"
-          cache-dependency-path: |
-            go.work
-            go.work.sum
-            packages/workbench/service/go.mod
-            packages/workspace/files/go.mod
-            packages/workspace/issues/go.mod
-            services/tuttid/go.mod
-            services/tuttid/go.sum
-
-      - name: Install dependencies
-        run: pnpm install --frozen-lockfile
-
-      - name: Align package version with release tag
-        working-directory: apps/desktop
-        run: node scripts/apply-ci-release-version.mjs "$env:TUTTI_DESKTOP_RELEASE_TAG"
-
-      - name: Build release artifacts
-        shell: bash
-        run: pnpm --filter @tutti-os/desktop build:win
-
-      - name: Upload release artifacts
-        uses: actions/upload-artifact@v7
-        with:
-          name: tutti-desktop-release-assets-windows
-          compression-level: 0
-          path: |
-            apps/desktop/dist/*.blockmap
-            apps/desktop/dist/*.exe
-            apps/desktop/dist/*.yml
-          if-no-files-found: error
-          retention-days: 7
-
-  build-linux:
-    name: Build Linux
-    needs: resolve
-    runs-on: ubuntu-latest
-    env:
-      TUTTI_DESKTOP_RELEASE_TAG: ${{ needs.resolve.outputs.release_tag }}
-      TUTTI_DESKTOP_RELEASE_TARGET: ${{ needs.resolve.outputs.release_target }}
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v6
-        with:
-          ref: ${{ env.TUTTI_DESKTOP_RELEASE_TARGET }}
-          fetch-depth: 0
-
-      - name: Setup pnpm
-        uses: pnpm/action-setup@v6
-        with:
-          version: 10.11.0
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v6
-        with:
-          node-version-file: .node-version
-          cache: pnpm
-          cache-dependency-path: pnpm-lock.yaml
-
-      - name: Setup Go
-        uses: actions/setup-go@v6
-        with:
-          go-version: "1.24.5"
-          cache-dependency-path: |
-            go.work
-            go.work.sum
-            packages/workbench/service/go.mod
-            packages/workspace/files/go.mod
-            packages/workspace/issues/go.mod
-            services/tuttid/go.mod
-            services/tuttid/go.sum
-
-      - name: Install dependencies
-        run: pnpm install --frozen-lockfile
-
-      - name: Align package version with release tag
-        working-directory: apps/desktop
-        run: node scripts/apply-ci-release-version.mjs "${TUTTI_DESKTOP_RELEASE_TAG}"
-
-      - name: Build release artifacts
-        run: pnpm --filter @tutti-os/desktop build:linux
-
-      - name: Upload release artifacts
-        uses: actions/upload-artifact@v7
-        with:
-          name: tutti-desktop-release-assets-linux
-          compression-level: 0
-          path: |
-            apps/desktop/dist/*.AppImage
-            apps/desktop/dist/*.blockmap
-            apps/desktop/dist/*.yml
-          if-no-files-found: error
-          retention-days: 7
-
   publish:
     name: Publish Release
-    needs: [resolve, build-macos, build-windows, build-linux]
+    needs: [resolve, build-macos]
     if: ${{ github.event_name == 'push' || needs.resolve.outputs.release_dry_run != 'true' }}
     runs-on: ubuntu-latest
     env:
@@ -456,7 +331,7 @@ jobs:
       - name: Download built artifacts
         uses: actions/download-artifact@v4
         with:
-          pattern: tutti-desktop-release-assets-*
+          pattern: tutti-desktop-release-assets-macos
           merge-multiple: true
           path: release-assets
 
@@ -579,7 +454,7 @@ jobs:
         if: env.FEISHU_WEBHOOK_URL != ''
         uses: actions/download-artifact@v4
         with:
-          pattern: tutti-desktop-release-assets-*
+          pattern: tutti-desktop-release-assets-macos
           merge-multiple: true
           path: release-assets
 

--- a/apps/desktop/scripts/upsert-release-download-links.mjs
+++ b/apps/desktop/scripts/upsert-release-download-links.mjs
@@ -30,9 +30,7 @@ function resolveDesktopDownloadLinks(
   releaseAssetBaseUrl
 ) {
   const desktopAssets = [
-    { label: "macOS", matcher: (name) => /\.dmg$/i.test(name) },
-    { label: "Windows", matcher: (name) => /\.exe$/i.test(name) },
-    { label: "Linux", matcher: (name) => /\.AppImage$/i.test(name) }
+    { label: "macOS", matcher: (name) => /\.dmg$/i.test(name) }
   ];
   const normalizedBaseUrl = normalizeBaseUrl(releaseAssetBaseUrl);
 

--- a/tools/scripts/desktop-release-config.test.mjs
+++ b/tools/scripts/desktop-release-config.test.mjs
@@ -119,7 +119,7 @@ test("desktop release workflow passes tsh-aligned Feishu card context", async ()
 
   assert.match(
     workflow,
-    /name:\s+Download built artifacts[\s\S]*pattern:\s+tutti-desktop-release-assets-\*/
+    /name:\s+Download built artifacts[\s\S]*pattern:\s+tutti-desktop-release-assets-macos/
   );
   assert.match(
     workflow,
@@ -192,6 +192,39 @@ test("desktop release workflow can mirror release assets to S3 and upsert direct
   assert.match(
     workflow,
     /apps\/desktop\/scripts\/upsert-release-download-links\.mjs/
+  );
+});
+
+test("desktop release workflow publishes only macOS release assets for now", async () => {
+  const workflow = await readFile(workflowPath, "utf8");
+  const publishJobMatch = workflow.match(
+    /publish:[\s\S]*?(?=\n\s{2}[a-z][a-z0-9_-]+:\n|$)/
+  );
+  const notifyJobMatch = workflow.match(
+    /notify-feishu:[\s\S]*?(?=\n\s{2}[a-z][a-z0-9_-]+:\n|$)/
+  );
+
+  assert.ok(publishJobMatch, "publish job should exist");
+  assert.ok(notifyJobMatch, "notify-feishu job should exist");
+  assert.doesNotMatch(workflow, /\n\s{2}build-windows:\n/);
+  assert.doesNotMatch(workflow, /\n\s{2}build-linux:\n/);
+  assert.match(publishJobMatch[0], /needs:\s+\[resolve, build-macos\]/);
+  assert.doesNotMatch(publishJobMatch[0], /build-windows|build-linux/);
+  assert.match(
+    publishJobMatch[0],
+    /pattern:\s+tutti-desktop-release-assets-macos/
+  );
+  assert.doesNotMatch(
+    publishJobMatch[0],
+    /pattern:\s+tutti-desktop-release-assets-\*/
+  );
+  assert.match(
+    notifyJobMatch[0],
+    /pattern:\s+tutti-desktop-release-assets-macos/
+  );
+  assert.doesNotMatch(
+    notifyJobMatch[0],
+    /pattern:\s+tutti-desktop-release-assets-\*/
   );
 });
 

--- a/tools/scripts/desktop-release-download-links.test.mjs
+++ b/tools/scripts/desktop-release-download-links.test.mjs
@@ -7,7 +7,7 @@ import {
   buildUpdatedReleaseBody
 } from "../../apps/desktop/scripts/upsert-release-download-links.mjs";
 
-test("desktop release notes append direct download links for mirrored assets", () => {
+test("desktop release notes append only macOS direct download links for mirrored assets", () => {
   const nextBody = buildUpdatedReleaseBody({
     assetNames: [
       "Tutti-0.1.0-rc.2-linux-x86_64.AppImage",
@@ -29,14 +29,8 @@ test("desktop release notes append direct download links for mirrored assets", (
     nextBody,
     /\[macOS\]\(https:\/\/d111111abcdef8\.cloudfront\.net\/desktop-release-assets\/v0\.1\.0-rc\.2\/Tutti-0\.1\.0-rc\.2-mac-arm64\.dmg\)/
   );
-  assert.match(
-    nextBody,
-    /\[Windows\]\(https:\/\/d111111abcdef8\.cloudfront\.net\/desktop-release-assets\/v0\.1\.0-rc\.2\/Tutti-0\.1\.0-rc\.2-win-x64\.exe\)/
-  );
-  assert.match(
-    nextBody,
-    /\[Linux\]\(https:\/\/d111111abcdef8\.cloudfront\.net\/desktop-release-assets\/v0\.1\.0-rc\.2\/Tutti-0\.1\.0-rc\.2-linux-x86_64\.AppImage\)/
-  );
+  assert.doesNotMatch(nextBody, /\[Windows\]/);
+  assert.doesNotMatch(nextBody, /\[Linux\]/);
 });
 
 test("desktop release notes replace the managed direct download section in place", () => {


### PR DESCRIPTION
## Summary
- Limit the desktop release workflow to macOS build artifacts for now.
- Restrict mirrored direct download links to macOS assets.
- Add/update tests that lock the macOS-only release behavior.

## Validation
- node --test ./tools/scripts/desktop-release-config.test.mjs ./tools/scripts/desktop-release-download-links.test.mjs
- pnpm check:full (passed during pre-push; initial push SSH connection then closed, branch was pushed after skipping the already-passed hook)