### PR TITLE
Filter agent-generated file mentions by composer work directory

### DIFF
--- a/apps/desktop/src/renderer/src/features/workspace-agent/services/internal/createDesktopAgentGeneratedFileMentionProvider.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-agent/services/internal/createDesktopAgentGeneratedFileMentionProvider.ts
@@ -46,7 +46,14 @@ export function createDesktopAgentGeneratedFileMentionProvider(input: {
       }
       const refreshedSnapshot =
         input.agentActivityRuntime.getSnapshot(workspaceId);
-      const files = collectWorkspaceAgentGeneratedFiles(refreshedSnapshot);
+      const sessionCwd = metadataString(
+        searchInput.context.metadata,
+        "sessionCwd",
+        ""
+      );
+      const files = collectWorkspaceAgentGeneratedFiles(refreshedSnapshot, {
+        ...(sessionCwd ? { sessionCwd } : {})
+      });
       const keyword = searchInput.keyword.trim().toLowerCase();
       const filtered = keyword
         ? files.filter((file) =>

--- a/packages/agent/gui/agent-gui/agentGuiNode/AgentComposer.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/AgentComposer.tsx
@@ -1294,10 +1294,11 @@ export function AgentComposer({
       mentionControllerRef.current?.updateQuery({
         workspaceId,
         currentUserId,
-        query: state.query
+        query: state.query,
+        sessionCwd: selectedProjectPath || null
       });
     },
-    [currentUserId, workspaceId]
+    [currentUserId, selectedProjectPath, workspaceId]
   );
 
   const handleLinkClick = useCallback(
@@ -1834,7 +1835,16 @@ export function AgentComposer({
     }
     previousSelectedProjectPathRef.current = selectedProjectPath;
     setIsSelectedProjectMissing(false);
-  }, [selectedProjectPath]);
+    if (!fileMentionSuggestion) {
+      return;
+    }
+    mentionControllerRef.current?.updateQuery({
+      workspaceId,
+      currentUserId,
+      query: fileMentionSuggestion.query,
+      sessionCwd: selectedProjectPath || null
+    });
+  }, [currentUserId, fileMentionSuggestion, selectedProjectPath, workspaceId]);
 
   useEffect(() => {
     setDismissedPromptRequestId(null);

--- a/packages/agent/gui/agent-gui/agentGuiNode/AgentMentionSearchController.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/AgentMentionSearchController.ts
@@ -130,6 +130,7 @@ export class AgentMentionSearchController {
   private currentUserId = "";
   private currentFilter: AgentMentionFilterId = "all";
   private currentQuery = "";
+  private currentSessionCwd = "";
   private currentFileSearchLimit: number;
   private currentIssueSearchLimit: number;
   private agentGeneratedBrowsePath: string | null = null;
@@ -180,12 +181,14 @@ export class AgentMentionSearchController {
     workspaceId: string;
     currentUserId?: string | null;
     query: string;
+    sessionCwd?: string | null;
   }): void {
     if (this.disposed) {
       return;
     }
     this.activeWorkspaceId = input.workspaceId.trim();
     this.currentUserId = input.currentUserId?.trim() ?? "";
+    this.currentSessionCwd = input.sessionCwd?.trim() ?? "";
     this.currentQuery = normalizeQuery(input.query);
     this.clearTimer();
     const requestId = ++this.requestId;
@@ -795,6 +798,7 @@ export class AgentMentionSearchController {
       context: {
         metadata: {
           currentUserId: input.currentUserId,
+          sessionCwd: this.currentSessionCwd || undefined,
           target: "agent-gui",
           workspaceId: input.workspaceId
         }

--- a/packages/agent/gui/shared/workspaceAgentActivityListViewModel.spec.ts
+++ b/packages/agent/gui/shared/workspaceAgentActivityListViewModel.spec.ts
@@ -1397,6 +1397,78 @@ describe("buildWorkspaceAgentActivityListViewModel", () => {
     ]);
   });
 
+  it("filters agent-generated files to the selected session work directory", () => {
+    const snapshot: AgentActivitySnapshot = {
+      workspaceId: "workspace-1",
+      presences: [],
+      sessions: [
+        {
+          agentSessionId: "session-web",
+          cwd: "/Users/demo/project/apps/web",
+          provider: "codex",
+          status: "completed",
+          title: "Web session",
+          workspaceId: "workspace-1"
+        },
+        {
+          agentSessionId: "session-api",
+          cwd: "/Users/demo/project/apps/api",
+          provider: "codex",
+          status: "completed",
+          title: "API session",
+          workspaceId: "workspace-1"
+        }
+      ],
+      sessionMessagesById: {
+        "session-web": [
+          {
+            agentSessionId: "session-web",
+            kind: "tool_call",
+            messageId: "message-web",
+            payload: {
+              toolName: "Write",
+              status: "completed",
+              fileChanges: {
+                files: [{ path: "/Users/demo/project/apps/web/index.html" }]
+              }
+            },
+            role: "assistant",
+            status: "completed",
+            version: 1
+          }
+        ],
+        "session-api": [
+          {
+            agentSessionId: "session-api",
+            kind: "tool_call",
+            messageId: "message-api",
+            payload: {
+              toolName: "Write",
+              status: "completed",
+              fileChanges: {
+                files: [{ path: "/Users/demo/project/apps/api/server.go" }]
+              }
+            },
+            role: "assistant",
+            status: "completed",
+            version: 1
+          }
+        ]
+      }
+    };
+
+    expect(
+      collectWorkspaceAgentGeneratedFiles(snapshot, {
+        sessionCwd: "/Users/demo/project/apps/web"
+      })
+    ).toEqual([
+      {
+        path: "/Users/demo/project/apps/web/index.html",
+        label: "index.html"
+      }
+    ]);
+  });
+
   it("collects Codex edit tool file paths from structured tool payloads", () => {
     const snapshot: AgentActivitySnapshot = {
       workspaceId: "workspace-1",

--- a/packages/agent/gui/shared/workspaceAgentActivityListViewModel.ts
+++ b/packages/agent/gui/shared/workspaceAgentActivityListViewModel.ts
@@ -58,17 +58,32 @@ export interface BuildWorkspaceAgentActivityListOptions {
   fallbackMembers?: RoomShareMemberView[];
 }
 
+export interface CollectWorkspaceAgentGeneratedFilesOptions {
+  workspaceRoot?: string | null;
+  /** When set, only include files from sessions whose cwd matches this path. */
+  sessionCwd?: string | null;
+}
+
 export function collectWorkspaceAgentGeneratedFiles(
   snapshot: WorkspaceAgentActivitySnapshot,
-  options: { workspaceRoot?: string | null } = {}
+  options: CollectWorkspaceAgentGeneratedFilesOptions = {}
 ): WorkspaceAgentChangedFile[] {
+  const sessionCwdFilter = normalizeComparablePath(options.sessionCwd ?? "");
   const workspaceRoot =
-    options.workspaceRoot?.trim().replace(/\/+$/, "") ||
+    sessionCwdFilter ||
+    normalizeComparablePath(options.workspaceRoot ?? "") ||
     resolveWorkspaceRootFromSessions(snapshot.sessions);
+  const sessions = sessionCwdFilter
+    ? snapshot.sessions.filter(
+        (session) =>
+          normalizeComparablePath(session.cwd ?? "") === sessionCwdFilter
+      )
+    : snapshot.sessions;
   const filesByPath = new Map<string, WorkspaceAgentChangedFile>();
 
-  for (const session of snapshot.sessions) {
-    const sessionCwd = session.cwd?.trim().replace(/\/+$/, "") || workspaceRoot;
+  for (const session of sessions) {
+    const sessionCwd =
+      normalizeComparablePath(session.cwd ?? "") || workspaceRoot;
     const normalizePath = createAgentGeneratedFilePathNormalizer({
       sessionCwd,
       workspaceRoot
@@ -516,12 +531,16 @@ function resolveWorkspaceRootFromSessions(
   sessions: readonly WorkspaceAgentActivitySession[]
 ): string {
   for (const session of sessions) {
-    const cwd = session.cwd?.trim().replace(/\/+$/, "") ?? "";
+    const cwd = normalizeComparablePath(session.cwd ?? "");
     if (cwd) {
       return cwd;
     }
   }
   return "";
+}
+
+function normalizeComparablePath(path: string): string {
+  return path.trim().replace(/\\/g, "/").replace(/\/+$/, "");
 }
 
 function createAgentGeneratedFilePathNormalizer(input: {


### PR DESCRIPTION
## Summary
- Scope `@` mention **Agent generated files** to agent sessions whose `cwd` matches the composer-selected project path.
- Pass `sessionCwd` through mention search metadata from `AgentComposer` to the desktop agent-generated-file provider.
- Refresh the mention palette when the selected project changes while `@` is open.

## Test plan
- [x] `pnpm exec vitest run shared/workspaceAgentActivityListViewModel.spec.ts agent-gui/agentGuiNode/AgentMentionSearchController.spec.ts` in `packages/agent/gui`
- [x] `pnpm --filter @tutti-os/agent-gui typecheck`
- [ ] In Agent GUI, create two projects with separate agent sessions that write files; verify each project only shows its own generated files under `@` → Files → Agent generated files
- [ ] Switch project while the mention palette is open and confirm the list refreshes
- [ ] With no project selected, verify workspace-wide agent-generated files still appear


Made with [Cursor](https://cursor.com)