### PR TITLE
[codex] fix app install progress and stale agent turns

### DIFF
--- a/apps/desktop/src/renderer/src/features/workspace-app-center/services/internal/adapters/desktopWorkspaceAppCenterGateway.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-app-center/services/internal/adapters/desktopWorkspaceAppCenterGateway.ts
@@ -77,6 +77,10 @@ export interface WorkspaceAppLike {
   readonly updatedAtUnixMs?: number | null;
   readonly updateAvailable?: boolean;
   readonly version: string;
+  readonly installProgress?:
+    | WorkspaceApp["installProgress"]
+    | Record<string, unknown>
+    | null;
   readonly windowMinHeight?: number | null;
   readonly windowMinWidth?: number | null;
 }
@@ -315,6 +319,7 @@ export function normalizeWorkspaceAppCenterApp(
     exportable: app.exportable,
     failureReason: app.failureReason ?? null,
     iconUrl: app.iconUrl,
+    installProgress: normalizeWorkspaceAppInstallProgress(app.installProgress),
     installed: app.installed,
     installationId: app.installationId ?? null,
     lastError: app.lastError ?? null,
@@ -339,6 +344,54 @@ export function normalizeWorkspaceAppCenterApp(
     windowMinHeight: normalizeWorkspaceAppWindowMinimum(app.windowMinHeight),
     windowMinWidth: normalizeWorkspaceAppWindowMinimum(app.windowMinWidth)
   };
+}
+
+function normalizeWorkspaceAppInstallProgress(
+  progress: WorkspaceAppLike["installProgress"]
+): WorkspaceAppCenterApp["installProgress"] {
+  if (!isWorkspaceAppInstallProgressLike(progress)) {
+    return null;
+  }
+  return {
+    downloadedBytes: normalizeOptionalProgressNumber(progress.downloadedBytes),
+    indeterminate: progress.indeterminate,
+    overallPercent: progress.overallPercent,
+    totalBytes: normalizeOptionalProgressNumber(progress.totalBytes),
+    userPhase: progress.userPhase
+  };
+}
+
+function isWorkspaceAppInstallProgressLike(
+  value: WorkspaceAppLike["installProgress"]
+): value is NonNullable<WorkspaceApp["installProgress"]> {
+  if (value == null || typeof value !== "object") {
+    return false;
+  }
+  const candidate = value as Record<string, unknown>;
+  return (
+    isWorkspaceAppInstallUserPhase(candidate.userPhase) &&
+    typeof candidate.overallPercent === "number" &&
+    Number.isFinite(candidate.overallPercent) &&
+    typeof candidate.indeterminate === "boolean" &&
+    isOptionalProgressNumber(candidate.downloadedBytes) &&
+    isOptionalProgressNumber(candidate.totalBytes)
+  );
+}
+
+function isWorkspaceAppInstallUserPhase(
+  value: unknown
+): value is NonNullable<WorkspaceApp["installProgress"]>["userPhase"] {
+  return (
+    value === "downloading" || value === "installing" || value === "starting"
+  );
+}
+
+function isOptionalProgressNumber(value: unknown): value is number | null {
+  return value == null || (typeof value === "number" && Number.isFinite(value));
+}
+
+function normalizeOptionalProgressNumber(value: number | null | undefined) {
+  return typeof value === "number" ? value : null;
 }
 
 function normalizeWorkspaceAppWindowMinimum(

--- a/apps/desktop/src/renderer/src/features/workspace-app-center/ui/WorkspaceAppCenterPane.tsx
+++ b/apps/desktop/src/renderer/src/features/workspace-app-center/ui/WorkspaceAppCenterPane.tsx
@@ -583,6 +583,7 @@ function toWorkspaceAppRuntimeState(
       : {}),
     appId: app.appId,
     launchUrl: app.launchUrl ?? null,
+    ...(app.installProgress ? { installProgress: app.installProgress } : {}),
     ...(cliIssue
       ? {
           error: {
@@ -591,6 +592,9 @@ function toWorkspaceAppRuntimeState(
           }
         }
       : {}),
-    status: app.runtimeStatus
+    status:
+      app.installProgress != null || app.runtimeStatus === "installing"
+        ? "installing"
+        : app.runtimeStatus
   };
 }

--- a/packages/clients/tuttid-ts/src/generated/index.ts
+++ b/packages/clients/tuttid-ts/src/generated/index.ts
@@ -810,6 +810,8 @@ export type {
   WorkspaceAppFactoryJobResponse,
   WorkspaceAppFactoryJobStatus,
   WorkspaceAppId,
+  WorkspaceAppInstallProgress,
+  WorkspaceAppInstallUserPhase,
   WorkspaceAppListResponse,
   WorkspaceAppLocalization,
   WorkspaceAppMinimizeBehavior,

--- a/packages/clients/tuttid-ts/src/generated/types.gen.ts
+++ b/packages/clients/tuttid-ts/src/generated/types.gen.ts
@@ -246,6 +246,19 @@ export type DeleteWorkspaceResponse = {
   workspaceId: string;
 };
 
+export type WorkspaceAppInstallUserPhase =
+  | "downloading"
+  | "installing"
+  | "starting";
+
+export type WorkspaceAppInstallProgress = {
+  userPhase: WorkspaceAppInstallUserPhase;
+  overallPercent: number;
+  downloadedBytes: number | null;
+  totalBytes: number | null;
+  indeterminate: boolean;
+};
+
 export type WorkspaceAppRuntimeStatus =
   | "idle"
   | "preparing"
@@ -379,6 +392,7 @@ export type WorkspaceApp = {
   version: string;
   description: string;
   createdAtUnixMs: number;
+  installProgress?: WorkspaceAppInstallProgress;
   iconUrl: string | null;
   availableVersion: string | null;
   availableIconUrl: string | null;

--- a/packages/events/protocol/schemas/topics/workspace/workspace-app.schema.json
+++ b/packages/events/protocol/schemas/topics/workspace/workspace-app.schema.json
@@ -147,6 +147,39 @@
           "type": "boolean"
         }
       }
+    },
+    "installProgress": {
+      "type": ["object", "null"],
+      "additionalProperties": false,
+      "required": [
+        "userPhase",
+        "overallPercent",
+        "downloadedBytes",
+        "totalBytes",
+        "indeterminate"
+      ],
+      "properties": {
+        "userPhase": {
+          "type": "string",
+          "enum": ["downloading", "installing", "starting"]
+        },
+        "overallPercent": {
+          "type": "number",
+          "minimum": 0,
+          "maximum": 100
+        },
+        "downloadedBytes": {
+          "type": ["integer", "null"],
+          "format": "int64"
+        },
+        "totalBytes": {
+          "type": ["integer", "null"],
+          "format": "int64"
+        },
+        "indeterminate": {
+          "type": "boolean"
+        }
+      }
     }
   }
 }

--- a/packages/events/protocol/src/generated/contracts.ts
+++ b/packages/events/protocol/src/generated/contracts.ts
@@ -146,6 +146,7 @@ export interface WorkspaceWorkspaceAppV1 {
   references: {
     listSupported: boolean;
   };
+  installProgress?: Record<string, unknown> | null;
 }
 
 export type AgentActivityUpdatedPayloadV1 =

--- a/packages/events/protocol/src/generated/registry.ts
+++ b/packages/events/protocol/src/generated/registry.ts
@@ -33,7 +33,7 @@ export interface BusinessEventDefinition {
   scope: BusinessEventScopeName;
 }
 
-export const businessEventCatalogRevision = "sha256:3b800f900e63f4ae" as const;
+export const businessEventCatalogRevision = "sha256:4596ff7f0fab3db3" as const;
 
 export const businessEventDefinitions = [
   {

--- a/packages/events/protocol/src/generated/schemas.ts
+++ b/packages/events/protocol/src/generated/schemas.ts
@@ -407,6 +407,39 @@ export const workspaceWorkspaceAppSchema = {
           type: "boolean"
         }
       }
+    },
+    installProgress: {
+      type: ["object", "null"],
+      additionalProperties: false,
+      required: [
+        "userPhase",
+        "overallPercent",
+        "downloadedBytes",
+        "totalBytes",
+        "indeterminate"
+      ],
+      properties: {
+        userPhase: {
+          type: "string",
+          enum: ["downloading", "installing", "starting"]
+        },
+        overallPercent: {
+          type: "number",
+          minimum: 0,
+          maximum: 100
+        },
+        downloadedBytes: {
+          type: ["integer", "null"],
+          format: "int64"
+        },
+        totalBytes: {
+          type: ["integer", "null"],
+          format: "int64"
+        },
+        indeterminate: {
+          type: "boolean"
+        }
+      }
     }
   }
 } as const;
@@ -1343,6 +1376,39 @@ export const workspaceAppUpdatedPayloadSchema = {
           required: ["listSupported"],
           properties: {
             listSupported: {
+              type: "boolean"
+            }
+          }
+        },
+        installProgress: {
+          type: ["object", "null"],
+          additionalProperties: false,
+          required: [
+            "userPhase",
+            "overallPercent",
+            "downloadedBytes",
+            "totalBytes",
+            "indeterminate"
+          ],
+          properties: {
+            userPhase: {
+              type: "string",
+              enum: ["downloading", "installing", "starting"]
+            },
+            overallPercent: {
+              type: "number",
+              minimum: 0,
+              maximum: 100
+            },
+            downloadedBytes: {
+              type: ["integer", "null"],
+              format: "int64"
+            },
+            totalBytes: {
+              type: ["integer", "null"],
+              format: "int64"
+            },
+            indeterminate: {
               type: "boolean"
             }
           }

--- a/packages/workspace/app-center/src/contracts/host.ts
+++ b/packages/workspace/app-center/src/contracts/host.ts
@@ -1,7 +1,13 @@
-import type { WorkspaceAppRuntimeStatus } from "./runtime.ts";
+import type {
+  WorkspaceAppInstallProgress,
+  WorkspaceAppInstallUserPhase,
+  WorkspaceAppRuntimeStatus
+} from "./runtime.ts";
 import type { WorkspaceAppFactoryJobStatus } from "./viewModel.ts";
 
 export type WorkspaceAppCenterRuntimeStatus = WorkspaceAppRuntimeStatus;
+
+export type { WorkspaceAppInstallProgress, WorkspaceAppInstallUserPhase };
 
 export type WorkspaceAppCenterSource = "builtin" | "generated" | "imported";
 
@@ -48,6 +54,7 @@ export interface WorkspaceAppCenterApp {
   exportable: boolean;
   failureReason?: string | null;
   iconUrl?: string | null;
+  installProgress?: WorkspaceAppInstallProgress | null;
   installed: boolean;
   lastError?: string | null;
   cli?: WorkspaceAppCenterCliState;

--- a/packages/workspace/app-center/src/contracts/runtime.ts
+++ b/packages/workspace/app-center/src/contracts/runtime.ts
@@ -17,12 +17,26 @@ export interface WorkspaceAppRuntimeError {
   readonly message: string;
 }
 
+export type WorkspaceAppInstallUserPhase =
+  | "downloading"
+  | "installing"
+  | "starting";
+
+export interface WorkspaceAppInstallProgress {
+  readonly userPhase: WorkspaceAppInstallUserPhase;
+  readonly overallPercent: number;
+  readonly downloadedBytes?: number | null;
+  readonly totalBytes?: number | null;
+  readonly indeterminate: boolean;
+}
+
 export interface WorkspaceAppRuntimeState {
   readonly runtimeId?: string;
   readonly installationId?: string;
   readonly appId: string;
   readonly status: WorkspaceAppRuntimeStatus;
   readonly launchUrl?: string | null;
+  readonly installProgress?: WorkspaceAppInstallProgress | null;
   readonly error?: WorkspaceAppRuntimeError | null;
   readonly startedAt?: string | null;
   readonly updatedAt?: string | null;

--- a/packages/workspace/app-center/src/contracts/viewModel.ts
+++ b/packages/workspace/app-center/src/contracts/viewModel.ts
@@ -1,5 +1,6 @@
 import type { WorkspaceAppRuntimeStatus } from "./runtime.ts";
 import type { WorkspaceAppCatalogSourceKind } from "./catalog.ts";
+import type { WorkspaceAppInstallProgress } from "./runtime.ts";
 
 export type WorkspaceAppStatusTone =
   | "neutral"
@@ -61,6 +62,7 @@ export interface WorkspaceAppCardViewModel {
   readonly canRetry: boolean;
   readonly canUpdate: boolean;
   readonly errorMessage?: string;
+  readonly installProgress?: WorkspaceAppInstallProgress | null;
   readonly factoryEditAction?: WorkspaceAppFactoryEditAction | null;
   readonly factoryAgentSessionId?: string | null;
   readonly factoryJobId?: string | null;

--- a/packages/workspace/app-center/src/core/appCenterController.test.ts
+++ b/packages/workspace/app-center/src/core/appCenterController.test.ts
@@ -356,6 +356,169 @@ test("WorkspaceAppCenterController requests restart when updating a running inst
   ]);
 });
 
+test("WorkspaceAppCenterController preserves install progress during pending install app updates", async () => {
+  const controller = createWorkspaceAppCenterController({
+    formatError: formatError,
+    gateway: createGateway({
+      async installWorkspaceApp() {
+        return createSnapshot({
+          apps: [
+            createApp({
+              appId: "app-1",
+              installProgress: {
+                downloadedBytes: 1024,
+                indeterminate: false,
+                overallPercent: 72,
+                totalBytes: 2048,
+                userPhase: "downloading"
+              },
+              installed: false,
+              runtimeStatus: "installing",
+              stateRevision: 2
+            })
+          ]
+        });
+      }
+    })
+  });
+  controller.applySnapshot(
+    "workspace-1",
+    createSnapshot({
+      apps: [
+        createApp({
+          appId: "app-1",
+          installed: false,
+          runtimeStatus: "idle"
+        })
+      ]
+    })
+  );
+
+  await controller.installApp({
+    appId: "app-1",
+    workspaceId: "workspace-1"
+  });
+
+  controller.applyAppUpdate({
+    app: createApp({
+      appId: "app-1",
+      installed: true,
+      runtimeStatus: "starting",
+      stateRevision: 3
+    }),
+    workspaceId: "workspace-1"
+  });
+
+  const app = controller.store.apps.find(
+    (candidate) => candidate.appId === "app-1"
+  );
+  assert.equal(app?.runtimeStatus, "starting");
+  assert.equal(app?.installProgress?.userPhase, "starting");
+  assert.equal(app?.installProgress?.overallPercent, 96);
+  assert.equal(app?.installProgress?.downloadedBytes, null);
+
+  controller.applyAppUpdate({
+    app: createApp({
+      appId: "app-1",
+      installed: true,
+      runtimeStatus: "running",
+      stateRevision: 4
+    }),
+    workspaceId: "workspace-1"
+  });
+});
+
+test("WorkspaceAppCenterController clears pending install when backend job disappears", async () => {
+  let installCalls = 0;
+  const installFailures: unknown[] = [];
+  const controller = createWorkspaceAppCenterController({
+    formatError: formatError,
+    gateway: createGateway({
+      async installWorkspaceApp() {
+        installCalls += 1;
+        return createSnapshot({
+          apps: [
+            createApp({
+              appId: "app-1",
+              installProgress: {
+                downloadedBytes: null,
+                indeterminate: true,
+                overallPercent: 0,
+                totalBytes: null,
+                userPhase: "downloading"
+              },
+              installed: false,
+              runtimeStatus: "installing",
+              stateRevision: installCalls + 1
+            })
+          ]
+        });
+      }
+    }),
+    hooks: {
+      onAppInstallFailed(input) {
+        installFailures.push(input);
+      }
+    }
+  });
+  controller.applySnapshot(
+    "workspace-1",
+    createSnapshot({
+      apps: [
+        createApp({
+          appId: "app-1",
+          installed: false,
+          runtimeStatus: "idle"
+        })
+      ]
+    })
+  );
+
+  await controller.installApp({
+    appId: "app-1",
+    workspaceId: "workspace-1"
+  });
+  controller.applySnapshot(
+    "workspace-1",
+    createSnapshot({
+      apps: [
+        createApp({
+          appId: "app-1",
+          installed: false,
+          installProgress: null,
+          runtimeStatus: "idle",
+          stateRevision: 4
+        })
+      ]
+    })
+  );
+
+  assert.equal(controller.store.apps[0]?.runtimeStatus, "idle");
+  assert.equal(controller.store.apps[0]?.installProgress, null);
+  assert.deepEqual(installFailures, []);
+
+  await controller.installApp({
+    appId: "app-1",
+    workspaceId: "workspace-1"
+  });
+  assert.equal(installCalls, 2);
+
+  controller.applySnapshot(
+    "workspace-1",
+    createSnapshot({
+      apps: [
+        createApp({
+          appId: "app-1",
+          installed: false,
+          installProgress: null,
+          runtimeStatus: "idle",
+          stateRevision: 5
+        })
+      ]
+    })
+  );
+});
+
 test("WorkspaceAppCenterController only marks idle enabled apps as starting", async () => {
   let optimisticStatuses: string[] = [];
   const controller = createWorkspaceAppCenterController({

--- a/packages/workspace/app-center/src/core/appCenterControllerHelpers.ts
+++ b/packages/workspace/app-center/src/core/appCenterControllerHelpers.ts
@@ -47,6 +47,25 @@ export function mergeWorkspaceAppCatalogFields(
   };
 }
 
+function areWorkspaceAppInstallProgressEqual(
+  left: WorkspaceAppCenterApp["installProgress"],
+  right: WorkspaceAppCenterApp["installProgress"]
+): boolean {
+  if (left == null && right == null) {
+    return true;
+  }
+  if (left == null || right == null) {
+    return false;
+  }
+  return (
+    left.userPhase === right.userPhase &&
+    left.overallPercent === right.overallPercent &&
+    left.downloadedBytes === right.downloadedBytes &&
+    left.totalBytes === right.totalBytes &&
+    left.indeterminate === right.indeterminate
+  );
+}
+
 export function areWorkspaceAppCenterAppsEqual(
   left: readonly WorkspaceAppCenterApp[],
   right: readonly WorkspaceAppCenterApp[]
@@ -67,6 +86,10 @@ export function areWorkspaceAppCenterAppsEqual(
       leftApp.exportable === rightApp.exportable &&
       leftApp.iconUrl === rightApp.iconUrl &&
       leftApp.installed === rightApp.installed &&
+      areWorkspaceAppInstallProgressEqual(
+        leftApp.installProgress,
+        rightApp.installProgress
+      ) &&
       leftApp.installationId === rightApp.installationId &&
       areWorkspaceAppCenterLocalizationsEqual(
         leftApp.localizations ?? [],

--- a/packages/workspace/app-center/src/core/appCenterControllerState.ts
+++ b/packages/workspace/app-center/src/core/appCenterControllerState.ts
@@ -19,6 +19,7 @@ import {
   defaultCatalogLoadingRefreshDelayMs,
   defaultInstallRefreshDelayMs
 } from "./appCenterControllerTypes.ts";
+import { reconcilePendingInstallProgress } from "./installProgressMerge.ts";
 
 export abstract class WorkspaceAppCenterControllerState extends WorkspaceAppCenterControllerBase {
   abstract refresh(workspaceId: string): Promise<void>;
@@ -161,12 +162,17 @@ export abstract class WorkspaceAppCenterControllerState extends WorkspaceAppCent
       currentApp?.installed === true && !nextApp.installed
         ? [nextApp.appId]
         : [];
+    const mergedApp = this.mergeActiveInstallAppState(
+      workspaceId,
+      nextApp,
+      currentApp
+    );
 
     const nextApps = sortWorkspaceAppCenterApps([
       ...this.store.apps.filter(
         (candidate) => candidate.appId !== nextApp.appId
       ),
-      nextApp
+      mergedApp
     ]);
     if (areWorkspaceAppCenterAppsEqual(this.store.apps, nextApps)) {
       return;
@@ -176,11 +182,11 @@ export abstract class WorkspaceAppCenterControllerState extends WorkspaceAppCent
     this.store.loadStatus = "ready";
     this.bumpRevision();
     this.settlePendingInstallReport({
-      app: nextApp,
+      app: mergedApp,
       failureReason:
         options.installFailureReason ??
-        nextApp.failureReason ??
-        nextApp.lastError ??
+        mergedApp.failureReason ??
+        mergedApp.lastError ??
         null,
       workspaceId
     });
@@ -323,15 +329,32 @@ export abstract class WorkspaceAppCenterControllerState extends WorkspaceAppCent
 
   protected isPendingInstallSettled(
     installKey: string,
-    app: WorkspaceAppCenterApp
+    app: WorkspaceAppCenterApp,
+    previousApp?: WorkspaceAppCenterApp
   ): boolean {
+    if (this.isPendingInstallAbandoned(installKey, app, previousApp)) {
+      return true;
+    }
     if (app.runtimeStatus === "failed") {
       return true;
+    }
+    if (this.isRuntimeInstallBusy(app.runtimeStatus)) {
+      return false;
     }
     if (this.pendingInstallReportKeys.has(installKey)) {
       return app.installed;
     }
     return app.installed && !app.updateAvailable && !app.availableVersion;
+  }
+
+  protected isRuntimeInstallBusy(
+    runtimeStatus: WorkspaceAppCenterApp["runtimeStatus"]
+  ): boolean {
+    return (
+      runtimeStatus === "installing" ||
+      runtimeStatus === "preparing" ||
+      runtimeStatus === "starting"
+    );
   }
 
   private mergeSnapshotAppsByStateRevision(
@@ -353,7 +376,8 @@ export abstract class WorkspaceAppCenterControllerState extends WorkspaceAppCent
       if (this.pendingInstallKeys.has(installKey)) {
         const pendingSettled = this.isPendingInstallSettled(
           installKey,
-          snapshotApp
+          snapshotApp,
+          currentApp
         );
         if (
           pendingSettled &&
@@ -389,27 +413,87 @@ export abstract class WorkspaceAppCenterControllerState extends WorkspaceAppCent
     }, this.dependencies.catalogLoadingRefreshDelayMs ?? defaultCatalogLoadingRefreshDelayMs);
   }
 
+  protected mergeActiveInstallAppState(
+    workspaceId: string,
+    app: WorkspaceAppCenterApp,
+    previousApp?: WorkspaceAppCenterApp
+  ): WorkspaceAppCenterApp {
+    const installKey = appRuntimeKey(workspaceId, app.appId);
+    if (!this.pendingInstallKeys.has(installKey)) {
+      return app;
+    }
+    if (this.isPendingInstallSettled(installKey, app, previousApp)) {
+      return app;
+    }
+    const incomingRuntimeStatus = app.runtimeStatus;
+    const runtimeStatus = this.isRuntimeInstallLifecycleStatus(
+      incomingRuntimeStatus
+    )
+      ? incomingRuntimeStatus
+      : "installing";
+    return {
+      ...app,
+      enabled: true,
+      installed: this.pendingInstallReportKeys.has(installKey)
+        ? false
+        : app.installed,
+      installProgress: reconcilePendingInstallProgress({
+        incoming: app.installProgress,
+        previous: previousApp?.installProgress ?? null,
+        runtimeStatus: incomingRuntimeStatus
+      }),
+      runtimeStatus
+    };
+  }
+
+  private isRuntimeInstallLifecycleStatus(
+    runtimeStatus: WorkspaceAppCenterApp["runtimeStatus"]
+  ): boolean {
+    return (
+      runtimeStatus === "installing" ||
+      runtimeStatus === "preparing" ||
+      runtimeStatus === "starting"
+    );
+  }
+
+  private isPendingInstallAbandoned(
+    installKey: string,
+    app: WorkspaceAppCenterApp,
+    previousApp?: WorkspaceAppCenterApp
+  ): boolean {
+    return (
+      this.pendingInstallReportKeys.has(installKey) &&
+      !app.installed &&
+      app.runtimeStatus === "idle" &&
+      app.installProgress == null &&
+      this.hasObservedInstallActivity(previousApp)
+    );
+  }
+
+  private hasObservedInstallActivity(
+    app: WorkspaceAppCenterApp | undefined
+  ): boolean {
+    return (
+      app?.installProgress != null ||
+      app?.runtimeStatus === "preparing" ||
+      app?.runtimeStatus === "starting"
+    );
+  }
+
   private withPendingInstallState(
     workspaceId: string,
     apps: readonly WorkspaceAppCenterApp[]
   ): WorkspaceAppCenterApp[] {
-    return apps.map((app) => {
-      const installKey = appRuntimeKey(workspaceId, app.appId);
-      if (!this.pendingInstallKeys.has(installKey)) {
-        return app;
-      }
-      if (this.isPendingInstallSettled(installKey, app)) {
-        return app;
-      }
-      return {
-        ...app,
-        enabled: true,
-        installed: this.pendingInstallReportKeys.has(installKey)
-          ? false
-          : app.installed,
-        runtimeStatus: "installing"
-      };
-    });
+    const previousAppsById = new Map(
+      this.store.apps.map((app) => [app.appId, app])
+    );
+    return apps.map((app) =>
+      this.mergeActiveInstallAppState(
+        workspaceId,
+        app,
+        previousAppsById.get(app.appId)
+      )
+    );
   }
 
   private async refreshInstallState(
@@ -453,6 +537,15 @@ export abstract class WorkspaceAppCenterControllerState extends WorkspaceAppCent
     }
     if (input.app.installed) {
       this.dependencies.hooks?.onAppInstalled?.(input.app);
+      return;
+    }
+    if (
+      input.app.runtimeStatus === "idle" &&
+      input.app.installProgress == null &&
+      input.failureReason == null &&
+      input.app.failureReason == null &&
+      input.app.lastError == null
+    ) {
       return;
     }
     this.dependencies.hooks?.onAppInstallFailed?.({

--- a/packages/workspace/app-center/src/core/appCenterViewModel.test.ts
+++ b/packages/workspace/app-center/src/core/appCenterViewModel.test.ts
@@ -457,6 +457,64 @@ describe("createAppCenterViewModel", () => {
     assert.equal(viewModel.apps[0]?.primaryAction, "none");
   });
 
+  it("preserves runtime phases while install progress is active", () => {
+    const viewModel = createAppCenterViewModel({
+      apps: [
+        {
+          catalog: {
+            manifest: {
+              appId: "remote",
+              description: "Remote app",
+              runtime: {
+                bootstrap: "bootstrap.sh",
+                healthcheckPath: "/"
+              },
+              schemaVersion: workspaceAppManifestSchemaVersion,
+              name: "Remote",
+              version: "0.1.0"
+            },
+            source: {
+              kind: "local"
+            }
+          },
+          install: { appId: "remote" },
+          manifest: {
+            appId: "remote",
+            description: "Remote app",
+            runtime: {
+              bootstrap: "bootstrap.sh",
+              healthcheckPath: "/"
+            },
+            schemaVersion: workspaceAppManifestSchemaVersion,
+            name: "Remote",
+            version: "0.1.0"
+          }
+        }
+      ],
+      runtimeStates: [
+        {
+          appId: "remote",
+          installProgress: {
+            downloadedBytes: null,
+            indeterminate: false,
+            overallPercent: 96,
+            totalBytes: null,
+            userPhase: "starting"
+          },
+          status: "starting"
+        }
+      ]
+    });
+
+    assert.equal(viewModel.apps[0]?.status, "starting");
+    assert.equal(viewModel.apps[0]?.statusLabelKey, "status.starting");
+    assert.equal(viewModel.apps[0]?.primaryAction, "none");
+    assert.equal(viewModel.apps[0]?.canOpenFolder, false);
+    assert.equal(viewModel.apps[0]?.canOpenPackageFolder, false);
+    assert.equal(viewModel.apps[0]?.canUninstall, false);
+    assert.equal(viewModel.apps[0]?.installProgress?.overallPercent, 96);
+  });
+
   it("keeps catalog source kind for recommended and user-owned grouping", () => {
     const viewModel = createAppCenterViewModel({
       apps: [

--- a/packages/workspace/app-center/src/core/appCenterViewModel.ts
+++ b/packages/workspace/app-center/src/core/appCenterViewModel.ts
@@ -74,9 +74,11 @@ export function createAppCenterViewModel({
             ? "prepare_modification"
             : "open_session"
           : null;
-      const status = runtime?.status ?? "idle";
+      const status = resolveRuntimeStatusForViewModel(runtime);
       const presentation = resolveWorkspaceAppStatusPresentation(status);
       const installed = Boolean(app.install);
+      const installBusy =
+        runtime?.installProgress != null || status === "installing";
       const sourceKind = resolveCatalogSourceKind(app.catalog);
       const localApp = sourceKind === "local";
       const runtimeId = normalizeOptionalString(runtime?.runtimeId);
@@ -128,21 +130,22 @@ export function createAppCenterViewModel({
           ? "status.comingSoon"
           : resolvePrimaryActionLabelKey(primaryAction, presentation.labelKey),
         statusTone: presentation.tone,
-        statusPulse: presentation.pulse,
+        statusPulse: runtime?.installProgress ? false : presentation.pulse,
         primaryAction,
         sourceKind,
         canOpen,
         canExport: localApp,
         canDelete: localApp,
         canReplaceIcon: replaceableIconAppIdSet.has(app.manifest.appId),
-        canOpenFolder: installed,
-        canOpenPackageFolder: installed && localApp && Boolean(displayVersion),
+        canOpenFolder: installed && !installBusy,
+        canOpenPackageFolder:
+          installed && localApp && Boolean(displayVersion) && !installBusy,
         canOpenFactorySession: Boolean(factoryAgentSessionId),
         canPublishFactoryUpdate:
           installed &&
           factoryJob?.status === "ready" &&
           Boolean(factoryJob.publishedVersion?.trim()),
-        canUninstall: installed,
+        canUninstall: installed && !installBusy,
         canRetry,
         canUpdate,
         ...(factoryAgentSessionId ? { factoryAgentSessionId } : {}),
@@ -153,6 +156,9 @@ export function createAppCenterViewModel({
           : {}),
         ...(runtime?.error?.message
           ? { errorMessage: runtime.error.message }
+          : {}),
+        ...(runtime?.installProgress
+          ? { installProgress: runtime.installProgress }
           : {})
       };
     })
@@ -184,7 +190,8 @@ function createRuntimeStateMaps(
   for (const state of runtimeStates) {
     const runtime = {
       ...state,
-      status: mapWorkspaceAppRuntimeStatus(state.status)
+      status: mapWorkspaceAppRuntimeStatus(state.status),
+      installProgress: state.installProgress ?? null
     };
     const installationId = normalizeOptionalString(runtime.installationId);
     if (installationId) {
@@ -217,6 +224,18 @@ function findRuntimeStateForApp(
   }
 
   return maps.fallbackByAppId.get(appId);
+}
+
+function resolveRuntimeStatusForViewModel(
+  runtime: WorkspaceAppRuntimeState | undefined
+): WorkspaceAppRuntimeState["status"] {
+  if (!runtime) {
+    return "idle";
+  }
+  if (runtime.installProgress != null && runtime.status === "idle") {
+    return "installing";
+  }
+  return runtime.status;
 }
 
 function resolveCatalogSourceKind(

--- a/packages/workspace/app-center/src/core/installProgressMerge.test.ts
+++ b/packages/workspace/app-center/src/core/installProgressMerge.test.ts
@@ -1,0 +1,58 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { reconcilePendingInstallProgress } from "./installProgressMerge.ts";
+
+test("reconcilePendingInstallProgress advances stale downloading progress during starting", () => {
+  const progress = reconcilePendingInstallProgress({
+    incoming: null,
+    previous: {
+      downloadedBytes: 1024,
+      indeterminate: false,
+      overallPercent: 72,
+      totalBytes: 2048,
+      userPhase: "downloading"
+    },
+    runtimeStatus: "starting"
+  });
+
+  assert.equal(progress?.userPhase, "starting");
+  assert.equal(progress?.overallPercent, 96);
+  assert.equal(progress?.downloadedBytes, null);
+  assert.equal(progress?.totalBytes, null);
+});
+
+test("reconcilePendingInstallProgress keeps fresher server progress", () => {
+  const progress = reconcilePendingInstallProgress({
+    incoming: {
+      downloadedBytes: null,
+      indeterminate: false,
+      overallPercent: 98,
+      totalBytes: null,
+      userPhase: "starting"
+    },
+    previous: {
+      downloadedBytes: 1024,
+      indeterminate: false,
+      overallPercent: 72,
+      totalBytes: 2048,
+      userPhase: "downloading"
+    },
+    runtimeStatus: "starting"
+  });
+
+  assert.equal(progress?.userPhase, "starting");
+  assert.equal(progress?.overallPercent, 98);
+});
+
+test("reconcilePendingInstallProgress creates progress from runtime phase when none was reported", () => {
+  const progress = reconcilePendingInstallProgress({
+    incoming: null,
+    previous: null,
+    runtimeStatus: "starting"
+  });
+
+  assert.equal(progress?.userPhase, "starting");
+  assert.equal(progress?.overallPercent, 96);
+  assert.equal(progress?.downloadedBytes, null);
+  assert.equal(progress?.totalBytes, null);
+});

--- a/packages/workspace/app-center/src/core/installProgressMerge.ts
+++ b/packages/workspace/app-center/src/core/installProgressMerge.ts
@@ -1,0 +1,116 @@
+import type {
+  WorkspaceAppInstallProgress,
+  WorkspaceAppInstallUserPhase,
+  WorkspaceAppRuntimeStatus
+} from "../contracts/runtime.ts";
+
+const installUserPhaseOrder: Record<WorkspaceAppInstallUserPhase, number> = {
+  downloading: 0,
+  installing: 1,
+  starting: 2
+};
+
+// Default install progress weights from tuttid: 40 + 30 + 20 + 10.
+const defaultDownloadCompletePercent = 70;
+const defaultInstallingPartialPercent = 79;
+const defaultStartingPartialPercent = 96;
+
+export function reconcilePendingInstallProgress(input: {
+  readonly incoming: WorkspaceAppInstallProgress | null | undefined;
+  readonly previous: WorkspaceAppInstallProgress | null | undefined;
+  readonly runtimeStatus: WorkspaceAppRuntimeStatus;
+}): WorkspaceAppInstallProgress | null {
+  const runtimePhase = runtimeStatusToInstallUserPhase(input.runtimeStatus);
+  const progress =
+    input.incoming ??
+    input.previous ??
+    (runtimePhase == null ? null : createProgressForRuntimePhase(runtimePhase));
+  if (progress == null) {
+    return null;
+  }
+
+  if (runtimePhase == null) {
+    return clearDownloadBytesUnlessDownloading(progress);
+  }
+
+  if (compareInstallUserPhase(progress.userPhase, runtimePhase) >= 0) {
+    return clearDownloadBytesUnlessDownloading(progress);
+  }
+
+  return advanceInstallProgressToPhase(progress, runtimePhase);
+}
+
+function runtimeStatusToInstallUserPhase(
+  runtimeStatus: WorkspaceAppRuntimeStatus
+): WorkspaceAppInstallUserPhase | null {
+  switch (runtimeStatus) {
+    case "preparing":
+      return "installing";
+    case "starting":
+      return "starting";
+    default:
+      return null;
+  }
+}
+
+function compareInstallUserPhase(
+  left: WorkspaceAppInstallUserPhase,
+  right: WorkspaceAppInstallUserPhase
+): number {
+  return installUserPhaseOrder[left] - installUserPhaseOrder[right];
+}
+
+function advanceInstallProgressToPhase(
+  progress: WorkspaceAppInstallProgress,
+  targetPhase: WorkspaceAppInstallUserPhase
+): WorkspaceAppInstallProgress {
+  let overallPercent = progress.overallPercent;
+  let userPhase = progress.userPhase;
+
+  if (targetPhase === "installing" || targetPhase === "starting") {
+    overallPercent = Math.max(overallPercent, defaultDownloadCompletePercent);
+    userPhase = "installing";
+  }
+
+  if (targetPhase === "starting") {
+    overallPercent = Math.max(overallPercent, defaultStartingPartialPercent);
+    userPhase = "starting";
+  } else if (targetPhase === "installing") {
+    overallPercent = Math.max(overallPercent, defaultInstallingPartialPercent);
+  }
+
+  return clearDownloadBytesUnlessDownloading({
+    ...progress,
+    indeterminate: false,
+    overallPercent,
+    userPhase
+  });
+}
+
+function createProgressForRuntimePhase(
+  userPhase: WorkspaceAppInstallUserPhase
+): WorkspaceAppInstallProgress {
+  return advanceInstallProgressToPhase(
+    {
+      downloadedBytes: null,
+      indeterminate: false,
+      overallPercent: 0,
+      totalBytes: null,
+      userPhase: "downloading"
+    },
+    userPhase
+  );
+}
+
+function clearDownloadBytesUnlessDownloading(
+  progress: WorkspaceAppInstallProgress
+): WorkspaceAppInstallProgress {
+  if (progress.userPhase === "downloading") {
+    return progress;
+  }
+  return {
+    ...progress,
+    downloadedBytes: null,
+    totalBytes: null
+  };
+}

--- a/packages/workspace/app-center/src/i18n/appCenterI18n.ts
+++ b/packages/workspace/app-center/src/i18n/appCenterI18n.ts
@@ -275,6 +275,13 @@ export const appCenterEn = {
   status: {
     comingSoon: "Coming soon",
     failed: "Failed",
+    installProgress: {
+      downloadedOfTotal: "{{downloaded}} / {{total}}",
+      downloading: "Downloading…",
+      installing: "Installing…",
+      progressAria: "App install progress",
+      starting: "Starting…"
+    },
     installing: "Installing",
     preparing: "Preparing",
     running: "Running",
@@ -530,6 +537,13 @@ export const appCenterZhCN = {
   status: {
     comingSoon: "敬请期待",
     failed: "失败",
+    installProgress: {
+      downloadedOfTotal: "{{downloaded}} / {{total}}",
+      downloading: "正在下载…",
+      installing: "正在安装…",
+      progressAria: "应用安装进度",
+      starting: "正在启动…"
+    },
     installing: "安装中",
     preparing: "准备中",
     running: "运行中",

--- a/packages/workspace/app-center/src/ui/AppCard.tsx
+++ b/packages/workspace/app-center/src/ui/AppCard.tsx
@@ -20,6 +20,7 @@ import type {
   WorkspaceAppActionContext,
   WorkspaceAppCardViewModel
 } from "../contracts/viewModel.ts";
+import type { WorkspaceAppInstallProgress } from "../contracts/runtime.ts";
 import type { AppCenterI18nRuntime } from "../i18n/appCenterI18n.ts";
 
 export interface AppCenterFactoryProviderOption {
@@ -115,6 +116,15 @@ export function AppCard({
   copy
 }: AppCardProps): ReactElement {
   const statusLabel = copy.t(app.statusLabelKey);
+  const installBusy =
+    app.installProgress != null || app.status === "installing";
+  const busyStatusLabel = installBusy
+    ? copy.t("status.installing")
+    : statusLabel;
+  const showInstallProgressRing = installBusy;
+  const statusButtonTitle = app.installProgress
+    ? resolveInstallProgressTitle(copy, app.installProgress, busyStatusLabel)
+    : statusLabel;
   const primaryActionLabel =
     app.primaryAction === "install"
       ? copy.t("actions.installApp")
@@ -193,37 +203,48 @@ export function AppCard({
           }}
         />
         <div className="flex shrink-0 items-center gap-1">
-          {hasMoreActions ? (
-            <AppCardMoreActions
-              actions={actions}
-              app={app}
-              canOpenFactorySession={canOpenFactorySession}
-              canPublishFactoryUpdate={canPublishFactoryUpdate}
-              copy={copy}
-            />
-          ) : null}
-          <Button
-            className={cn(
-              "min-w-[56px]",
-              !canExecutePrimaryAction ? "cursor-default" : null,
-              canExecutePrimaryAction
-                ? app.primaryAction === "retry"
-                  ? statusClassName(app.status)
-                  : "text-[var(--text-primary)]"
-                : statusClassName(app.status)
-            )}
-            disabled={!canExecutePrimaryAction}
-            size="default"
-            title={statusLabel}
-            type="button"
-            variant="ghost"
-            onClick={(event) => {
-              event.stopPropagation();
-              executePrimaryAction();
-            }}
-          >
-            {canExecutePrimaryAction ? primaryActionLabel : statusLabel}
-          </Button>
+          <div className="flex size-8 shrink-0 items-center justify-center">
+            {hasMoreActions ? (
+              <AppCardMoreActions
+                actions={actions}
+                app={app}
+                canOpenFactorySession={canOpenFactorySession}
+                canPublishFactoryUpdate={canPublishFactoryUpdate}
+                copy={copy}
+              />
+            ) : null}
+          </div>
+          <div className="flex items-center gap-1.5">
+            <Button
+              className={cn(
+                "min-w-[56px] shrink-0",
+                !canExecutePrimaryAction ? "cursor-default" : null,
+                canExecutePrimaryAction
+                  ? app.primaryAction === "retry"
+                    ? statusClassName(app.status)
+                    : "text-[var(--text-primary)]"
+                  : statusClassName(app.status)
+              )}
+              disabled={!canExecutePrimaryAction}
+              size="default"
+              title={statusButtonTitle}
+              type="button"
+              variant="ghost"
+              onClick={(event) => {
+                event.stopPropagation();
+                executePrimaryAction();
+              }}
+            >
+              {canExecutePrimaryAction ? primaryActionLabel : busyStatusLabel}
+            </Button>
+            {showInstallProgressRing ? (
+              <AppInstallProgressRing
+                ariaLabel={copy.t("status.installProgress.progressAria")}
+                fallbackPercent={0}
+                progress={app.installProgress}
+              />
+            ) : null}
+          </div>
         </div>
       </div>
 
@@ -555,6 +576,91 @@ function AppIcon({
       ) : null}
     </span>
   );
+}
+
+function AppInstallProgressRing({
+  ariaLabel,
+  fallbackPercent,
+  progress
+}: {
+  readonly ariaLabel: string;
+  readonly fallbackPercent: number;
+  readonly progress: WorkspaceAppInstallProgress | null | undefined;
+}): ReactElement {
+  const percent =
+    progress == null
+      ? Math.max(0, Math.min(100, Math.round(fallbackPercent)))
+      : Math.max(0, Math.min(100, Math.round(progress.overallPercent)));
+
+  return (
+    <span
+      aria-label={ariaLabel}
+      aria-valuemax={100}
+      aria-valuemin={0}
+      aria-valuenow={percent}
+      className="relative inline-flex size-[14px] shrink-0 items-center justify-center rounded-full"
+      role="progressbar"
+      style={{
+        background: `conic-gradient(var(--text-secondary) ${percent}%, color-mix(in srgb, var(--text-secondary) 24%, transparent) 0)`
+      }}
+    >
+      <span
+        aria-hidden="true"
+        className="absolute inset-[2px] rounded-full bg-[var(--surface-panel)]"
+      />
+    </span>
+  );
+}
+
+function resolveInstallProgressTitle(
+  copy: AppCenterI18nRuntime,
+  progress: WorkspaceAppInstallProgress,
+  statusLabel: string
+): string {
+  const byteLabel = formatInstallProgressBytes(copy, progress);
+  const percent = Math.max(
+    0,
+    Math.min(100, Math.round(progress.overallPercent))
+  );
+  if (byteLabel) {
+    return `${statusLabel} · ${byteLabel} · ${percent}%`;
+  }
+  return `${statusLabel} · ${percent}%`;
+}
+
+function formatInstallProgressBytes(
+  copy: AppCenterI18nRuntime,
+  progress: WorkspaceAppInstallProgress
+): string | null {
+  if (
+    progress.userPhase !== "downloading" ||
+    progress.downloadedBytes == null
+  ) {
+    return null;
+  }
+  const downloaded = formatByteSize(progress.downloadedBytes);
+  if (progress.totalBytes == null || progress.totalBytes <= 0) {
+    return downloaded;
+  }
+  return copy.t("status.installProgress.downloadedOfTotal", {
+    downloaded,
+    total: formatByteSize(progress.totalBytes)
+  });
+}
+
+function formatByteSize(value: number): string {
+  if (!Number.isFinite(value) || value <= 0) {
+    return "0 B";
+  }
+  const units = ["B", "KB", "MB", "GB"] as const;
+  let size = value;
+  let unitIndex = 0;
+  while (size >= 1024 && unitIndex < units.length - 1) {
+    size /= 1024;
+    unitIndex += 1;
+  }
+  const precision = size >= 10 || unitIndex === 0 ? 0 : 1;
+  return `${size.toFixed(precision)} ${units[unitIndex]}`;
 }
 
 function statusClassName(status: WorkspaceAppCardViewModel["status"]): string {

--- a/services/tuttid/api/events/generated/protocol.gen.go
+++ b/services/tuttid/api/events/generated/protocol.gen.go
@@ -6,7 +6,7 @@ import "encoding/json"
 
 const (
 	BusinessEventProtocolVersion = 1
-	BusinessEventCatalogRevision = "sha256:3b800f900e63f4ae"
+	BusinessEventCatalogRevision = "sha256:4596ff7f0fab3db3"
 )
 
 type Topic string
@@ -151,6 +151,13 @@ type WorkspaceWorkspaceApp struct {
 	References       struct {
 		ListSupported bool `json:"listSupported"`
 	} `json:"references"`
+	InstallProgress *struct {
+		UserPhase       string  `json:"userPhase"`
+		OverallPercent  float64 `json:"overallPercent"`
+		DownloadedBytes *int64  `json:"downloadedBytes"`
+		TotalBytes      *int64  `json:"totalBytes"`
+		Indeterminate   bool    `json:"indeterminate"`
+	} `json:"installProgress,omitempty"`
 }
 
 type AgentActivityUpdatedPayload struct {

--- a/services/tuttid/api/generated/types.gen.go
+++ b/services/tuttid/api/generated/types.gen.go
@@ -907,6 +907,27 @@ func (e WorkspaceAppFactoryJobStatus) Valid() bool {
 	}
 }
 
+// Defines values for WorkspaceAppInstallUserPhase.
+const (
+	WorkspaceAppInstallUserPhaseDownloading WorkspaceAppInstallUserPhase = "downloading"
+	WorkspaceAppInstallUserPhaseInstalling  WorkspaceAppInstallUserPhase = "installing"
+	WorkspaceAppInstallUserPhaseStarting    WorkspaceAppInstallUserPhase = "starting"
+)
+
+// Valid indicates whether the value is a known member of the WorkspaceAppInstallUserPhase enum.
+func (e WorkspaceAppInstallUserPhase) Valid() bool {
+	switch e {
+	case WorkspaceAppInstallUserPhaseDownloading:
+		return true
+	case WorkspaceAppInstallUserPhaseInstalling:
+		return true
+	case WorkspaceAppInstallUserPhaseStarting:
+		return true
+	default:
+		return false
+	}
+}
+
 // Defines values for WorkspaceAppMinimizeBehavior.
 const (
 	Hibernate   WorkspaceAppMinimizeBehavior = "hibernate"
@@ -2411,6 +2432,7 @@ type WorkspaceApp struct {
 	Exportable       bool                         `json:"exportable"`
 	FailureReason    *string                      `json:"failureReason"`
 	IconUrl          *string                      `json:"iconUrl"`
+	InstallProgress  *WorkspaceAppInstallProgress `json:"installProgress,omitempty"`
 	Installed        bool                         `json:"installed"`
 	LastError        *string                      `json:"lastError"`
 	LaunchUrl        *string                      `json:"launchUrl"`
@@ -2492,6 +2514,18 @@ type WorkspaceAppFactoryJobResponse struct {
 
 // WorkspaceAppFactoryJobStatus defines model for WorkspaceAppFactoryJobStatus.
 type WorkspaceAppFactoryJobStatus string
+
+// WorkspaceAppInstallProgress defines model for WorkspaceAppInstallProgress.
+type WorkspaceAppInstallProgress struct {
+	DownloadedBytes *int64                       `json:"downloadedBytes"`
+	Indeterminate   bool                         `json:"indeterminate"`
+	OverallPercent  float32                      `json:"overallPercent"`
+	TotalBytes      *int64                       `json:"totalBytes"`
+	UserPhase       WorkspaceAppInstallUserPhase `json:"userPhase"`
+}
+
+// WorkspaceAppInstallUserPhase defines model for WorkspaceAppInstallUserPhase.
+type WorkspaceAppInstallUserPhase string
 
 // WorkspaceAppListResponse defines model for WorkspaceAppListResponse.
 type WorkspaceAppListResponse struct {

--- a/services/tuttid/api/openapi/tuttid.v1.yaml
+++ b/services/tuttid/api/openapi/tuttid.v1.yaml
@@ -3077,6 +3077,42 @@ components:
       properties:
         workspaceId:
           type: string
+    WorkspaceAppInstallUserPhase:
+      type: string
+      enum:
+        - downloading
+        - installing
+        - starting
+      x-enum-varnames:
+        - WorkspaceAppInstallUserPhaseDownloading
+        - WorkspaceAppInstallUserPhaseInstalling
+        - WorkspaceAppInstallUserPhaseStarting
+    WorkspaceAppInstallProgress:
+      type: object
+      additionalProperties: false
+      required:
+        - userPhase
+        - overallPercent
+        - downloadedBytes
+        - totalBytes
+        - indeterminate
+      properties:
+        userPhase:
+          $ref: "#/components/schemas/WorkspaceAppInstallUserPhase"
+        overallPercent:
+          type: number
+          minimum: 0
+          maximum: 100
+        downloadedBytes:
+          type: integer
+          format: int64
+          nullable: true
+        totalBytes:
+          type: integer
+          format: int64
+          nullable: true
+        indeterminate:
+          type: boolean
     WorkspaceAppRuntimeStatus:
       type: string
       enum:
@@ -3445,6 +3481,9 @@ components:
           type: integer
           format: int64
           minimum: 0
+        installProgress:
+          $ref: "#/components/schemas/WorkspaceAppInstallProgress"
+          nullable: true
         iconUrl:
           type: string
           nullable: true

--- a/services/tuttid/api/workspace/apps.go
+++ b/services/tuttid/api/workspace/apps.go
@@ -35,6 +35,31 @@ func GeneratedAppFromBiz(app workspacebiz.WorkspaceApp) tuttigenerated.Workspace
 		WindowMinHeight:  app.Package.WindowMinHeight(),
 		Cli:              generatedAppCLIState(app.CLI),
 		References:       generatedAppReferencesStateFromBiz(app),
+		InstallProgress:  generatedAppInstallProgressFromBiz(app.InstallProgress),
+	}
+}
+
+func generatedAppInstallProgressFromBiz(progress *workspacebiz.AppInstallProgress) *tuttigenerated.WorkspaceAppInstallProgress {
+	if progress == nil {
+		return nil
+	}
+	return &tuttigenerated.WorkspaceAppInstallProgress{
+		UserPhase:       generatedAppInstallUserPhase(progress.UserPhase),
+		OverallPercent:  float32(progress.OverallPercent),
+		DownloadedBytes: progress.DownloadedBytes,
+		TotalBytes:      progress.TotalBytes,
+		Indeterminate:   progress.Indeterminate,
+	}
+}
+
+func generatedAppInstallUserPhase(phase workspacebiz.AppInstallUserPhase) tuttigenerated.WorkspaceAppInstallUserPhase {
+	switch phase {
+	case workspacebiz.AppInstallUserPhaseInstalling:
+		return tuttigenerated.WorkspaceAppInstallUserPhaseInstalling
+	case workspacebiz.AppInstallUserPhaseStarting:
+		return tuttigenerated.WorkspaceAppInstallUserPhaseStarting
+	default:
+		return tuttigenerated.WorkspaceAppInstallUserPhaseDownloading
 	}
 }
 

--- a/services/tuttid/biz/workspace/apps.go
+++ b/services/tuttid/biz/workspace/apps.go
@@ -237,6 +237,23 @@ type AppRuntimeState struct {
 	UpdatedAtUnixMs *int64
 }
 
+type AppInstallUserPhase string
+
+const (
+	AppInstallUserPhaseDownloading AppInstallUserPhase = "downloading"
+	AppInstallUserPhaseInstalling  AppInstallUserPhase = "installing"
+	AppInstallUserPhaseStarting    AppInstallUserPhase = "starting"
+)
+
+type AppInstallProgress struct {
+	UserPhase       AppInstallUserPhase
+	OverallPercent  float64
+	DownloadedBytes *int64
+	TotalBytes      *int64
+	Indeterminate   bool
+	UpdatedAtUnixMs int64
+}
+
 type AppCLIStatus string
 
 const (
@@ -268,6 +285,7 @@ type WorkspaceApp struct {
 	AvailableIconURL *string
 	UpdateAvailable  bool
 	Runtime          AppRuntimeState
+	InstallProgress  *AppInstallProgress
 	CLI              AppCLIState
 	References       AppReferencesState
 	StateRevision    int64

--- a/services/tuttid/data/workspace/sqlite_apps.go
+++ b/services/tuttid/data/workspace/sqlite_apps.go
@@ -397,6 +397,43 @@ ORDER BY app_id ASC
 	return result, nil
 }
 
+func (s *SQLiteStore) ListWorkspaceAppInstallationsByApp(ctx context.Context, appID string) ([]workspacebiz.AppInstallation, error) {
+	if s == nil || s.db == nil {
+		return nil, errors.New("workspace database is not initialized")
+	}
+
+	appID = strings.TrimSpace(appID)
+	if appID == "" {
+		return nil, errors.New("workspace app id is required")
+	}
+
+	rows, err := s.db.QueryContext(ctx, `
+SELECT workspace_id, app_id, enabled
+FROM workspace_app_installations
+WHERE app_id = ?
+ORDER BY workspace_id ASC
+`, appID)
+	if err != nil {
+		return nil, fmt.Errorf("list workspace app installations by app: %w", err)
+	}
+	defer rows.Close()
+
+	var result []workspacebiz.AppInstallation
+	for rows.Next() {
+		var installation workspacebiz.AppInstallation
+		var enabled int
+		if err := rows.Scan(&installation.WorkspaceID, &installation.AppID, &enabled); err != nil {
+			return nil, fmt.Errorf("scan workspace app installation by app: %w", err)
+		}
+		installation.Enabled = enabled != 0
+		result = append(result, installation)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate workspace app installations by app: %w", err)
+	}
+	return result, nil
+}
+
 type appPackageScanner interface {
 	Scan(dest ...any) error
 }

--- a/services/tuttid/data/workspace/sqlite_apps.go
+++ b/services/tuttid/data/workspace/sqlite_apps.go
@@ -14,6 +14,14 @@ import (
 )
 
 func (s *SQLiteStore) PutAppPackage(ctx context.Context, appPackage workspacebiz.AppPackage) error {
+	return s.putAppPackage(ctx, appPackage, true)
+}
+
+func (s *SQLiteStore) PutAppPackageVersion(ctx context.Context, appPackage workspacebiz.AppPackage) error {
+	return s.putAppPackage(ctx, appPackage, false)
+}
+
+func (s *SQLiteStore) putAppPackage(ctx context.Context, appPackage workspacebiz.AppPackage, activate bool) error {
 	if s == nil || s.db == nil {
 		return errors.New("workspace database is not initialized")
 	}
@@ -75,7 +83,8 @@ ON CONFLICT(app_id, version) DO UPDATE SET
 		return fmt.Errorf("put workspace app package: %w", err)
 	}
 
-	if _, err := tx.ExecContext(ctx, `
+	if activate {
+		if _, err := tx.ExecContext(ctx, `
 INSERT INTO app_catalog_entries (
   app_id, active_version, source, created_in_workspace_id, created_at_unix_ms, updated_at_unix_ms
 )
@@ -86,7 +95,18 @@ ON CONFLICT(app_id) DO UPDATE SET
   created_in_workspace_id = excluded.created_in_workspace_id,
   updated_at_unix_ms = excluded.updated_at_unix_ms
 `, appID, version, source, strings.TrimSpace(appPackage.CreatedInWorkspaceID), now, now); err != nil {
-		return fmt.Errorf("put workspace app catalog entry: %w", err)
+			return fmt.Errorf("put workspace app catalog entry: %w", err)
+		}
+	} else {
+		if _, err := tx.ExecContext(ctx, `
+INSERT INTO app_catalog_entries (
+  app_id, active_version, source, created_in_workspace_id, created_at_unix_ms, updated_at_unix_ms
+)
+VALUES (?, ?, ?, ?, ?, ?)
+ON CONFLICT(app_id) DO NOTHING
+`, appID, version, source, strings.TrimSpace(appPackage.CreatedInWorkspaceID), now, now); err != nil {
+			return fmt.Errorf("put inactive workspace app catalog entry: %w", err)
+		}
 	}
 
 	if err := tx.Commit(); err != nil {

--- a/services/tuttid/data/workspace/sqlite_apps_test.go
+++ b/services/tuttid/data/workspace/sqlite_apps_test.go
@@ -66,6 +66,13 @@ func TestSQLiteStoreWorkspaceAppsPersistPackagesAndInstallations(t *testing.T) {
 	if len(installations) != 1 || installations[0].AppID != "hello" || !installations[0].Enabled {
 		t.Fatalf("ListWorkspaceAppInstallations() = %#v", installations)
 	}
+	installationsByApp, err := store.ListWorkspaceAppInstallationsByApp(ctx, "hello")
+	if err != nil {
+		t.Fatalf("ListWorkspaceAppInstallationsByApp() error = %v", err)
+	}
+	if len(installationsByApp) != 1 || installationsByApp[0].WorkspaceID != "ws-apps" || !installationsByApp[0].Enabled {
+		t.Fatalf("ListWorkspaceAppInstallationsByApp() = %#v", installationsByApp)
+	}
 
 	if err := store.DeleteWorkspaceAppInstallation(ctx, "ws-apps", "hello"); err != nil {
 		t.Fatalf("DeleteWorkspaceAppInstallation() error = %v", err)

--- a/services/tuttid/data/workspace/sqlite_apps_test.go
+++ b/services/tuttid/data/workspace/sqlite_apps_test.go
@@ -157,3 +157,100 @@ func TestSQLiteStoreDeleteAppPackageRemovesCatalogVersionsAndInstallations(t *te
 		t.Fatalf("installations after delete = %#v, want empty", installations)
 	}
 }
+
+func TestSQLiteStorePutAppPackageVersionDoesNotActivateVersion(t *testing.T) {
+	t.Parallel()
+
+	store := openTestSQLiteStore(t)
+	ctx := context.Background()
+	manifest := workspacebiz.AppManifest{
+		SchemaVersion: workspacebiz.AppManifestSchemaVersionV1,
+		AppID:         "remote-app",
+		Version:       "1.0.0",
+		Name:          "Remote App v1",
+		Description:   "Remote app",
+		Runtime: workspacebiz.AppManifestRuntime{
+			Bootstrap:       "start.sh",
+			HealthcheckPath: "/ready",
+		},
+	}
+	if err := store.PutAppPackage(ctx, workspacebiz.AppPackage{
+		AppID:      manifest.AppID,
+		Version:    manifest.Version,
+		PackageDir: "/tmp/remote-app-1.0.0",
+		Manifest:   manifest,
+		Source:     workspacebiz.AppPackageSourceBuiltin,
+	}); err != nil {
+		t.Fatalf("PutAppPackage() error = %v", err)
+	}
+	manifest.Version = "1.1.0"
+	manifest.Name = "Remote App v2"
+	if err := store.PutAppPackageVersion(ctx, workspacebiz.AppPackage{
+		AppID:      manifest.AppID,
+		Version:    manifest.Version,
+		PackageDir: "/tmp/remote-app-1.1.0",
+		Manifest:   manifest,
+		Source:     workspacebiz.AppPackageSourceBuiltin,
+	}); err != nil {
+		t.Fatalf("PutAppPackageVersion() error = %v", err)
+	}
+
+	active, err := store.GetAppPackage(ctx, "remote-app")
+	if err != nil {
+		t.Fatalf("GetAppPackage() error = %v", err)
+	}
+	if active.Version != "1.0.0" {
+		t.Fatalf("active version = %q, want 1.0.0", active.Version)
+	}
+	versions, err := store.ListAppPackageVersions(ctx, "remote-app")
+	if err != nil {
+		t.Fatalf("ListAppPackageVersions() error = %v", err)
+	}
+	if len(versions) != 2 {
+		t.Fatalf("versions length = %d, want 2: %#v", len(versions), versions)
+	}
+	if err := store.SetActiveAppPackageVersion(ctx, "remote-app", "1.1.0"); err != nil {
+		t.Fatalf("SetActiveAppPackageVersion() error = %v", err)
+	}
+	active, err = store.GetAppPackage(ctx, "remote-app")
+	if err != nil {
+		t.Fatalf("GetAppPackage() after activate error = %v", err)
+	}
+	if active.Version != "1.1.0" {
+		t.Fatalf("active version after activate = %q, want 1.1.0", active.Version)
+	}
+}
+
+func TestSQLiteStorePutAppPackageVersionCreatesInitialCatalogEntry(t *testing.T) {
+	t.Parallel()
+
+	store := openTestSQLiteStore(t)
+	ctx := context.Background()
+	manifest := workspacebiz.AppManifest{
+		SchemaVersion: workspacebiz.AppManifestSchemaVersionV1,
+		AppID:         "remote-app",
+		Version:       "1.0.0",
+		Name:          "Remote App",
+		Description:   "Remote app",
+		Runtime: workspacebiz.AppManifestRuntime{
+			Bootstrap:       "start.sh",
+			HealthcheckPath: "/ready",
+		},
+	}
+	if err := store.PutAppPackageVersion(ctx, workspacebiz.AppPackage{
+		AppID:      manifest.AppID,
+		Version:    manifest.Version,
+		PackageDir: "/tmp/remote-app-1.0.0",
+		Manifest:   manifest,
+		Source:     workspacebiz.AppPackageSourceBuiltin,
+	}); err != nil {
+		t.Fatalf("PutAppPackageVersion() error = %v", err)
+	}
+	active, err := store.GetAppPackage(ctx, "remote-app")
+	if err != nil {
+		t.Fatalf("GetAppPackage() error = %v", err)
+	}
+	if active.Version != "1.0.0" {
+		t.Fatalf("active version = %q, want 1.0.0", active.Version)
+	}
+}

--- a/services/tuttid/data/workspace/store.go
+++ b/services/tuttid/data/workspace/store.go
@@ -68,6 +68,7 @@ type AppStore interface {
 	ListWorkspaceAppInstallationsByApp(context.Context, string) ([]workspacebiz.AppInstallation, error)
 	ListWorkspaceAppInstallations(context.Context, string) ([]workspacebiz.AppInstallation, error)
 	PutAppPackage(context.Context, workspacebiz.AppPackage) error
+	PutAppPackageVersion(context.Context, workspacebiz.AppPackage) error
 	SetActiveAppPackageVersion(context.Context, string, string) error
 	PutWorkspaceAppInstallation(context.Context, workspacebiz.AppInstallation) error
 }

--- a/services/tuttid/data/workspace/store.go
+++ b/services/tuttid/data/workspace/store.go
@@ -65,6 +65,7 @@ type AppStore interface {
 	GetAppPackageVersion(context.Context, string, string) (workspacebiz.AppPackage, error)
 	ListAppPackageVersions(context.Context, string) ([]workspacebiz.AppPackage, error)
 	ListAppPackages(context.Context) ([]workspacebiz.AppPackage, error)
+	ListWorkspaceAppInstallationsByApp(context.Context, string) ([]workspacebiz.AppInstallation, error)
 	ListWorkspaceAppInstallations(context.Context, string) ([]workspacebiz.AppInstallation, error)
 	PutAppPackage(context.Context, workspacebiz.AppPackage) error
 	SetActiveAppPackageVersion(context.Context, string, string) error

--- a/services/tuttid/service/agent/service.go
+++ b/services/tuttid/service/agent/service.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	"github.com/google/uuid"
+	agentactivitybiz "github.com/tutti-os/tutti/services/tuttid/biz/agentactivity"
 	agentsidecarservice "github.com/tutti-os/tutti/services/tuttid/service/agentsidecar"
 )
 
@@ -692,7 +693,11 @@ func (s *Service) reconcilePersistedStaleTurn(ctx context.Context, workspaceID s
 }
 
 func (s *Service) reconcileStaleTurnOnResume(ctx context.Context, session PersistedSession) (bool, error) {
-	if !isResumeStaleTurnStatus(session.Status) {
+	shouldReconcile, err := s.shouldReconcileStaleTurn(session)
+	if err != nil {
+		return false, err
+	}
+	if !shouldReconcile {
 		return false, nil
 	}
 	reconciler, ok := s.SessionReader.(StaleTurnResumeReconciler)
@@ -703,6 +708,34 @@ func (s *Service) reconcileStaleTurnOnResume(ctx context.Context, session Persis
 		return false, err
 	}
 	return true, nil
+}
+
+func (s *Service) shouldReconcileStaleTurn(session PersistedSession) (bool, error) {
+	if isResumeStaleTurnStatus(session.Status) || isResumeStaleTurnStatus(session.CurrentPhase) {
+		return true, nil
+	}
+	if s == nil || s.MessageReader == nil {
+		return false, nil
+	}
+	page, ok := s.MessageReader.ListSessionMessages(agentactivitybiz.ListSessionMessagesInput{
+		WorkspaceID:    strings.TrimSpace(session.WorkspaceID),
+		AgentSessionID: strings.TrimSpace(session.ID),
+		Limit:          100,
+		Order:          agentactivitybiz.MessageOrderDesc,
+	})
+	if !ok {
+		return false, nil
+	}
+	return hasStaleResumeOpenToolCall(page.Messages), nil
+}
+
+func hasStaleResumeOpenToolCall(messages []SessionMessage) bool {
+	for _, message := range messages {
+		if isStaleResumeOpenToolCall(message) {
+			return true
+		}
+	}
+	return false
 }
 
 func isResumeStaleTurnStatus(status string) bool {

--- a/services/tuttid/service/agent/service_test.go
+++ b/services/tuttid/service/agent/service_test.go
@@ -1071,6 +1071,33 @@ func TestStaleResumeMessageUpdatesFailOpenToolCallsForLatestTurn(t *testing.T) {
 	}
 }
 
+func TestHasStaleResumeOpenToolCall(t *testing.T) {
+	if hasStaleResumeOpenToolCall([]SessionMessage{{
+		MessageID: "text-1",
+		TurnID:    "turn-1",
+		Kind:      "text",
+		Status:    "waiting_approval",
+	}}) {
+		t.Fatal("text message reported as open tool call")
+	}
+	if hasStaleResumeOpenToolCall([]SessionMessage{{
+		MessageID: "approval-1",
+		TurnID:    "turn-1",
+		Kind:      "tool_call",
+		Status:    "completed",
+	}}) {
+		t.Fatal("completed tool call reported as open")
+	}
+	if !hasStaleResumeOpenToolCall([]SessionMessage{{
+		MessageID: "approval-2",
+		TurnID:    "turn-2",
+		Kind:      "tool_call",
+		Status:    "waiting_approval",
+	}}) {
+		t.Fatal("waiting approval tool call was not reported as open")
+	}
+}
+
 func TestServiceListsSessionMessages(t *testing.T) {
 	service := NewService(newFakeRuntime())
 	lastLimit := 0
@@ -1471,6 +1498,62 @@ func TestServiceReconcilesStalePersistedTurnBeforeSubmittingInteractive(t *testi
 	}
 	if len(reconciled) != 1 || reconciled[0].ID != "session-1" {
 		t.Fatalf("reconciled = %#v, want stale persisted session", reconciled)
+	}
+	if len(runtime.submitInteractiveCalls) != 0 {
+		t.Fatalf("submit interactive calls = %#v, want skipped stale live request", runtime.submitInteractiveCalls)
+	}
+}
+
+func TestServiceReconcilesOpenToolCallBeforeSubmittingInteractive(t *testing.T) {
+	runtime := newFakeRuntime()
+	reconciled := make([]PersistedSession, 0)
+	service := NewService(runtime)
+	service.SessionReader = fakeSessionReader{
+		reconciled: &reconciled,
+		sessions: map[string]PersistedSession{
+			"ws-1:session-1": {
+				ID:                "session-1",
+				WorkspaceID:       "ws-1",
+				Provider:          "codex",
+				ProviderSessionID: "provider-session-1",
+				Cwd:               "/workspace",
+				Status:            "created",
+				Title:             "Created",
+			},
+		},
+	}
+	service.MessageReader = fakeMessageReader{
+		page: SessionMessagesPage{
+			AgentSessionID: "session-1",
+			Messages: []SessionMessage{{
+				MessageID: "approval-1",
+				TurnID:    "turn-1",
+				Role:      "assistant",
+				Kind:      "tool_call",
+				Status:    "waiting_approval",
+				Payload: map[string]any{
+					"input":  map[string]any{"requestId": "permission-1"},
+					"status": "waiting_approval",
+				},
+			}},
+		},
+	}
+
+	session, err := service.SubmitInteractive(
+		context.Background(),
+		"ws-1",
+		"session-1",
+		"permission-1",
+		SubmitInteractiveInput{OptionID: stringRef("approve")},
+	)
+	if err != nil {
+		t.Fatalf("SubmitInteractive returned error: %v", err)
+	}
+	if session.ID != "session-1" {
+		t.Fatalf("session ID = %q, want session-1", session.ID)
+	}
+	if len(reconciled) != 1 || reconciled[0].ID != "session-1" {
+		t.Fatalf("reconciled = %#v, want open tool call session", reconciled)
 	}
 	if len(runtime.submitInteractiveCalls) != 0 {
 		t.Fatalf("submit interactive calls = %#v, want skipped stale live request", runtime.submitInteractiveCalls)

--- a/services/tuttid/service/eventstream/workspace_apps.go
+++ b/services/tuttid/service/eventstream/workspace_apps.go
@@ -66,6 +66,7 @@ func (p WorkspaceAppPublisher) PublishWorkspaceAppUpdated(ctx context.Context, w
 			}{
 				ListSupported: app.Package.ReferenceListSupported(),
 			},
+			InstallProgress: generatedEventInstallProgress(app.InstallProgress),
 		},
 	})
 	if err != nil {
@@ -88,4 +89,29 @@ func nonNilStrings(values []string) []string {
 		return []string{}
 	}
 	return values
+}
+
+func generatedEventInstallProgress(progress *workspacebiz.AppInstallProgress) *struct {
+	UserPhase       string  `json:"userPhase"`
+	OverallPercent  float64 `json:"overallPercent"`
+	DownloadedBytes *int64  `json:"downloadedBytes"`
+	TotalBytes      *int64  `json:"totalBytes"`
+	Indeterminate   bool    `json:"indeterminate"`
+} {
+	if progress == nil {
+		return nil
+	}
+	return &struct {
+		UserPhase       string  `json:"userPhase"`
+		OverallPercent  float64 `json:"overallPercent"`
+		DownloadedBytes *int64  `json:"downloadedBytes"`
+		TotalBytes      *int64  `json:"totalBytes"`
+		Indeterminate   bool    `json:"indeterminate"`
+	}{
+		UserPhase:       string(progress.UserPhase),
+		OverallPercent:  progress.OverallPercent,
+		DownloadedBytes: progress.DownloadedBytes,
+		TotalBytes:      progress.TotalBytes,
+		Indeterminate:   progress.Indeterminate,
+	}
 }

--- a/services/tuttid/service/workspace/app_archives.go
+++ b/services/tuttid/service/workspace/app_archives.go
@@ -167,8 +167,11 @@ func downloadAppArtifactOnce(ctx context.Context, client *http.Client, artifactU
 	body := appArtifactProgressReader{
 		reader:               response.Body,
 		lastProgressUnixNano: &lastProgressUnixNano,
+		onProgress:           appArtifactDownloadProgressFromContext(requestCtx),
+		totalBytes:           response.ContentLength,
+		bytesWritten:         0,
 	}
-	bytesWritten, err := io.Copy(target, io.LimitReader(body, maxWorkspaceAppArtifactBytes+1))
+	bytesWritten, err := io.Copy(target, io.LimitReader(&body, maxWorkspaceAppArtifactBytes+1))
 	if err != nil {
 		return bytesWritten, wrapAppArtifactDownloadError("write app artifact", err, idleTimedOut.Load())
 	}
@@ -207,12 +210,22 @@ func isRetryableAppArtifactDownloadError(err error) bool {
 type appArtifactProgressReader struct {
 	reader               io.Reader
 	lastProgressUnixNano *atomic.Int64
+	onProgress           func(AppArtifactDownloadProgress)
+	totalBytes           int64
+	bytesWritten         int64
 }
 
-func (r appArtifactProgressReader) Read(p []byte) (int, error) {
+func (r *appArtifactProgressReader) Read(p []byte) (int, error) {
 	n, err := r.reader.Read(p)
 	if n > 0 {
 		r.lastProgressUnixNano.Store(time.Now().UnixNano())
+		r.bytesWritten += int64(n)
+		if r.onProgress != nil {
+			r.onProgress(AppArtifactDownloadProgress{
+				DownloadedBytes: r.bytesWritten,
+				TotalBytes:      r.totalBytes,
+			})
+		}
 	}
 	return n, err
 }

--- a/services/tuttid/service/workspace/app_packages.go
+++ b/services/tuttid/service/workspace/app_packages.go
@@ -175,6 +175,54 @@ func (s *AppCenterService) DeletePackage(ctx context.Context, workspaceID string
 	return s.Store.DeleteAppPackage(ctx, appPackage.AppID)
 }
 
+func (s *AppCenterService) shouldDeleteRemoteBuiltinPackageAfterUninstall(ctx context.Context, workspaceID string, appPackage workspacebiz.AppPackage) (bool, error) {
+	if appPackage.Source != workspacebiz.AppPackageSourceBuiltin {
+		return false, nil
+	}
+	_, ok, err := s.remoteBuiltinForAppID(appPackage.AppID)
+	if err != nil {
+		return false, err
+	}
+	if !ok {
+		return false, nil
+	}
+
+	installations, err := s.Store.ListWorkspaceAppInstallationsByApp(ctx, appPackage.AppID)
+	if err != nil {
+		return false, err
+	}
+	if len(installations) != 1 {
+		return false, nil
+	}
+	installation := installations[0]
+	return installation.WorkspaceID == workspaceID && installation.AppID == appPackage.AppID, nil
+}
+
+func (s *AppCenterService) deleteRemoteBuiltinPackageFilesAndRecord(ctx context.Context, appPackage workspacebiz.AppPackage) error {
+	versions, err := s.Store.ListAppPackageVersions(ctx, appPackage.AppID)
+	if err != nil {
+		return err
+	}
+	packageDirs := make(map[string]struct{}, len(versions)+1)
+	if dir := strings.TrimSpace(appPackage.PackageDir); dir != "" {
+		packageDirs[dir] = struct{}{}
+	}
+	for _, versionPackage := range versions {
+		if dir := strings.TrimSpace(versionPackage.PackageDir); dir != "" {
+			packageDirs[dir] = struct{}{}
+		}
+	}
+	for packageDir := range packageDirs {
+		if err := os.RemoveAll(packageDir); err != nil {
+			return fmt.Errorf("delete remote builtin workspace app package dir: %w", err)
+		}
+		if err := s.pruneEmptyPackageCacheParents(packageDir); err != nil {
+			return err
+		}
+	}
+	return s.Store.DeleteAppPackage(ctx, appPackage.AppID)
+}
+
 func (s *AppCenterService) removeFactoryJobFilesForPackage(ctx context.Context, workspaceID string, appPackage workspacebiz.AppPackage) error {
 	if s.AppFactoryStore == nil || strings.TrimSpace(appPackage.FactoryJobID) == "" {
 		return nil

--- a/services/tuttid/service/workspace/app_projection_revision.go
+++ b/services/tuttid/service/workspace/app_projection_revision.go
@@ -12,38 +12,46 @@ func (s *AppCenterService) ensureRevisionStateLocked() {
 }
 
 type workspaceAppProjectionKey struct {
-	appID            string
-	description      string
-	displayName      string
-	enabled          bool
-	failureReason    string
-	hasFailureReason bool
-	hasIconURL       bool
-	hasLastError     bool
-	hasLaunchURL     bool
-	hasPort          bool
-	iconURL          string
-	hasStartedAt     bool
-	hasUpdatedAt     bool
-	installed        bool
-	lastError        string
-	launchURL        string
-	manifestJSON     string
-	port             int
-	startedAtUnixMs  int64
-	status           workspacebiz.AppRuntimeStatus
-	updateAvailable  bool
-	availableIconURL string
-	availableVersion string
-	cliActive        bool
-	cliIssueCount    int
-	cliIssueCode     string
-	cliIssueMessage  string
-	cliIssuePath     string
-	cliScope         string
-	cliStatus        workspacebiz.AppCLIStatus
-	updatedAtUnixMs  int64
-	version          string
+	appID                string
+	description          string
+	displayName          string
+	enabled              bool
+	failureReason        string
+	hasFailureReason     bool
+	hasIconURL           bool
+	hasLastError         bool
+	hasLaunchURL         bool
+	hasPort              bool
+	iconURL              string
+	hasStartedAt         bool
+	hasUpdatedAt         bool
+	installed            bool
+	lastError            string
+	launchURL            string
+	manifestJSON         string
+	port                 int
+	startedAtUnixMs      int64
+	status               workspacebiz.AppRuntimeStatus
+	updateAvailable      bool
+	availableIconURL     string
+	availableVersion     string
+	cliActive            bool
+	cliIssueCount        int
+	cliIssueCode         string
+	cliIssueMessage      string
+	cliIssuePath         string
+	cliScope             string
+	cliStatus            workspacebiz.AppCLIStatus
+	updatedAtUnixMs      int64
+	version              string
+	installPhase         string
+	installPercent       float64
+	hasInstallProgress   bool
+	installIndeterminate bool
+	installDownloaded    int64
+	installTotal         int64
+	hasInstallDownloaded bool
+	hasInstallTotal      bool
 }
 
 func projectionKeyFromWorkspaceApp(app workspacebiz.WorkspaceApp) workspaceAppProjectionKey {
@@ -96,6 +104,20 @@ func projectionKeyFromWorkspaceApp(app workspacebiz.WorkspaceApp) workspaceAppPr
 	if app.Runtime.UpdatedAtUnixMs != nil {
 		key.hasUpdatedAt = true
 		key.updatedAtUnixMs = *app.Runtime.UpdatedAtUnixMs
+	}
+	if app.InstallProgress != nil {
+		key.hasInstallProgress = true
+		key.installPhase = string(app.InstallProgress.UserPhase)
+		key.installPercent = app.InstallProgress.OverallPercent
+		key.installIndeterminate = app.InstallProgress.Indeterminate
+		if app.InstallProgress.DownloadedBytes != nil {
+			key.hasInstallDownloaded = true
+			key.installDownloaded = *app.InstallProgress.DownloadedBytes
+		}
+		if app.InstallProgress.TotalBytes != nil {
+			key.hasInstallTotal = true
+			key.installTotal = *app.InstallProgress.TotalBytes
+		}
 	}
 	return key
 }

--- a/services/tuttid/service/workspace/app_runtime_env.go
+++ b/services/tuttid/service/workspace/app_runtime_env.go
@@ -297,7 +297,14 @@ func (r DefaultManagedAppRuntimeResolver) downloadRuntimeComponents(
 		waitGroup.Add(1)
 		go func() {
 			defer waitGroup.Done()
-			download, err := r.downloadRuntimeComponent(downloadCtx, downloadsDir, name, component)
+			componentReport := appArtifactRuntimeComponentProgressFromContext(downloadCtx)
+			componentCtx := downloadCtx
+			if componentReport != nil {
+				componentCtx = ContextWithAppArtifactDownloadProgress(downloadCtx, func(progress AppArtifactDownloadProgress) {
+					componentReport(name, progress)
+				})
+			}
+			download, err := r.downloadRuntimeComponent(componentCtx, downloadsDir, name, component)
 			if err != nil {
 				cancel()
 			}

--- a/services/tuttid/service/workspace/apps.go
+++ b/services/tuttid/service/workspace/apps.go
@@ -173,6 +173,8 @@ type InstallOptions struct {
 	RestartRunning bool
 }
 
+type appInstallPackageResolver func(context.Context) (workspacebiz.AppPackage, error)
+
 func (s *AppCenterService) InstallWithOptions(ctx context.Context, workspaceID string, appID string, options InstallOptions) (workspacebiz.WorkspaceApp, error) {
 	if _, err := s.workspaceSummary(ctx, workspaceID); err != nil {
 		return workspacebiz.WorkspaceApp{}, err
@@ -182,10 +184,18 @@ func (s *AppCenterService) InstallWithOptions(ctx context.Context, workspaceID s
 	if err != nil {
 		return workspacebiz.WorkspaceApp{}, err
 	}
-	if s.beginInstallJob(workspaceID, appID, options) {
-		go s.runInstallJob(workspaceID, appID)
-	}
+	s.startInstallJob(workspaceID, appID, options, func(ctx context.Context) (workspacebiz.AppPackage, error) {
+		return s.packageForInstall(ctx, appID)
+	})
 	return app, nil
+}
+
+func (s *AppCenterService) startInstallJob(workspaceID string, appID string, options InstallOptions, resolvePackage appInstallPackageResolver) bool {
+	if !s.beginInstallJob(workspaceID, appID, options) {
+		return false
+	}
+	go s.runInstallJob(workspaceID, appID, resolvePackage)
+	return true
 }
 
 func (s *AppCenterService) installPackage(ctx context.Context, workspaceID string, appPackage workspacebiz.AppPackage, options InstallOptions) (workspacebiz.WorkspaceApp, error) {
@@ -211,7 +221,7 @@ func (s *AppCenterService) installPackage(ctx context.Context, workspaceID strin
 	return s.publishAppIfChanged(ctx, workspaceID, appPackage.AppID, app), nil
 }
 
-func (s *AppCenterService) runInstallJob(workspaceID string, appID string) {
+func (s *AppCenterService) runInstallJob(workspaceID string, appID string, resolvePackage appInstallPackageResolver) {
 	startedAt := time.Now()
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -240,7 +250,7 @@ func (s *AppCenterService) runInstallJob(workspaceID string, appID string) {
 	wg.Add(1)
 	go func() {
 		defer wg.Done()
-		pkg, err := s.packageForInstall(tracker.packageProgressContext(ctx), appID)
+		pkg, err := resolvePackage(tracker.packageProgressContext(ctx))
 		results <- installJobResult{
 			appPackage: pkg,
 			err:        err,
@@ -616,12 +626,18 @@ func (s *AppCenterService) workspaceAppProjectionForInstall(ctx context.Context,
 		}
 		return workspacebiz.WorkspaceApp{}, workspacedata.ErrWorkspaceAppNotFound
 	}
-	if remoteErr == nil && hasRemoteBuiltin && shouldUseRemoteBuiltin(appPackage, remoteBuiltin) {
-		return s.remoteBuiltinWorkspaceApp(remoteBuiltin, workspaceID)
-	}
 	installation, installed, err := s.workspaceAppInstallation(ctx, workspaceID, appID)
 	if err != nil {
 		return workspacebiz.WorkspaceApp{}, err
+	}
+	if remoteErr == nil && hasRemoteBuiltin && shouldUseRemoteBuiltin(appPackage, remoteBuiltin) {
+		if installed {
+			return workspaceAppWithRemoteBuiltinUpdate(
+				s.workspaceAppFromPackage(appPackage, installation, installed, workspaceID),
+				remoteBuiltin,
+			)
+		}
+		return s.remoteBuiltinWorkspaceApp(remoteBuiltin, workspaceID)
 	}
 	return s.workspaceAppFromPackage(appPackage, installation, installed, workspaceID), nil
 }

--- a/services/tuttid/service/workspace/apps.go
+++ b/services/tuttid/service/workspace/apps.go
@@ -35,8 +35,9 @@ type AppCenterService struct {
 	appProjectionKeys      map[string]workspaceAppProjectionKey
 	runtimePreloadInFlight bool
 
-	installMu   sync.Mutex
-	installJobs map[string]workspaceAppInstallJob
+	installMu             sync.Mutex
+	installJobs           map[string]workspaceAppInstallJob
+	activeInstallTrackers map[string]*installProgressTracker
 
 	remoteBuiltinInstallLocks keyedOperationLocks
 }
@@ -54,6 +55,7 @@ type workspaceAppInstallJob struct {
 	Status         workspaceAppInstallJobStatus
 	FailureReason  string
 	RestartRunning bool
+	Progress       *workspacebiz.AppInstallProgress
 }
 
 type WorkspaceRootResolver interface {
@@ -211,24 +213,97 @@ func (s *AppCenterService) installPackage(ctx context.Context, workspaceID strin
 
 func (s *AppCenterService) runInstallJob(workspaceID string, appID string) {
 	startedAt := time.Now()
-	ctx := context.Background()
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
 	options := s.installJobOptions(workspaceID, appID)
-	appPackage, err := s.packageForInstall(ctx, appID)
-	if err == nil {
-		_, err = s.installPackage(ctx, workspaceID, appPackage, options)
+	plan := s.buildInstallProgressPlan(ctx, appID)
+	tracker := s.newInstallProgressTracker(workspaceID, appID, plan)
+	s.registerActiveInstallTracker(workspaceID, appID, tracker)
+	defer func() {
+		s.unregisterActiveInstallTracker(workspaceID, appID)
+		tracker.clear()
+	}()
+
+	var (
+		appPackage workspacebiz.AppPackage
+		packageErr error
+		runtimeErr error
+	)
+	type installJobResult struct {
+		appPackage workspacebiz.AppPackage
+		err        error
+		kind       string
 	}
-	if err != nil {
-		slog.Warn("workspace_app_install_job_failed", "workspaceId", workspaceID, "appId", appID, "packageSource", appPackage.Source, "version", appPackage.Version, "packageDir", appPackage.PackageDir, "failureReason", err.Error(), "durationMs", time.Since(startedAt).Milliseconds(), "error", err)
-		s.failInstallJob(workspaceID, appID, err)
-		if failedApp, projectionErr := s.failedInstallAppProjection(ctx, workspaceID, appID, err); projectionErr == nil {
-			_ = s.publishAppIfChanged(ctx, workspaceID, appID, failedApp)
-		} else {
-			slog.Warn("workspace app install failure projection failed", "workspaceId", workspaceID, "appId", appID, "error", projectionErr)
+	results := make(chan installJobResult, 2)
+	var wg sync.WaitGroup
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		pkg, err := s.packageForInstall(tracker.packageProgressContext(ctx), appID)
+		results <- installJobResult{
+			appPackage: pkg,
+			err:        err,
+			kind:       "package",
 		}
+	}()
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		err := s.runner().PreloadRuntime(tracker.runtimeProgressContext(ctx))
+		results <- installJobResult{
+			err:  err,
+			kind: "runtime",
+		}
+	}()
+
+	for completed := 0; completed < 2; completed += 1 {
+		result := <-results
+		if result.kind == "package" {
+			appPackage = result.appPackage
+			packageErr = result.err
+		} else {
+			runtimeErr = result.err
+		}
+		if result.err != nil {
+			cancel()
+			wg.Wait()
+			s.handleInstallJobFailure(context.Background(), workspaceID, appID, appPackage, result.err, startedAt)
+			return
+		}
+	}
+	wg.Wait()
+
+	if packageErr != nil {
+		s.handleInstallJobFailure(ctx, workspaceID, appID, appPackage, packageErr, startedAt)
 		return
 	}
+	if runtimeErr != nil {
+		s.handleInstallJobFailure(ctx, workspaceID, appID, appPackage, runtimeErr, startedAt)
+		return
+	}
+
+	tracker.beginInstalling()
+	if _, err := s.installPackage(ctx, workspaceID, appPackage, options); err != nil {
+		s.handleInstallJobFailure(ctx, workspaceID, appID, appPackage, err, startedAt)
+		return
+	}
+	tracker.finishInstalling()
+	tracker.finishStarting()
+
 	s.finishInstallJob(workspaceID, appID)
 	slog.Info("workspace_app_install_job_succeeded", "workspaceId", workspaceID, "appId", appID, "packageSource", appPackage.Source, "version", appPackage.Version, "packageDir", appPackage.PackageDir, "durationMs", time.Since(startedAt).Milliseconds())
+}
+
+func (s *AppCenterService) handleInstallJobFailure(ctx context.Context, workspaceID string, appID string, appPackage workspacebiz.AppPackage, err error, startedAt time.Time) {
+	slog.Warn("workspace_app_install_job_failed", "workspaceId", workspaceID, "appId", appID, "packageSource", appPackage.Source, "version", appPackage.Version, "packageDir", appPackage.PackageDir, "failureReason", err.Error(), "durationMs", time.Since(startedAt).Milliseconds(), "error", err)
+	s.failInstallJob(workspaceID, appID, err)
+	if failedApp, projectionErr := s.failedInstallAppProjection(ctx, workspaceID, appID, err); projectionErr == nil {
+		_ = s.publishAppIfChanged(ctx, workspaceID, appID, failedApp)
+	} else {
+		slog.Warn("workspace app install failure projection failed", "workspaceId", workspaceID, "appId", appID, "error", projectionErr)
+	}
 }
 
 func (s *AppCenterService) packageForInstall(ctx context.Context, appID string) (workspacebiz.AppPackage, error) {
@@ -269,8 +344,18 @@ func (s *AppCenterService) Uninstall(ctx context.Context, workspaceID string, ap
 	if err := s.removeWorkspaceAppStateRoot(workspaceID, appPackage.AppID); err != nil {
 		return workspacebiz.WorkspaceApp{}, err
 	}
-	if err := s.Store.DeleteWorkspaceAppInstallation(ctx, workspaceID, appPackage.AppID); err != nil {
+	deletePackage, err := s.shouldDeleteRemoteBuiltinPackageAfterUninstall(ctx, workspaceID, appPackage)
+	if err != nil {
 		return workspacebiz.WorkspaceApp{}, err
+	}
+	if deletePackage {
+		if err := s.deleteRemoteBuiltinPackageFilesAndRecord(ctx, appPackage); err != nil {
+			return workspacebiz.WorkspaceApp{}, err
+		}
+	} else {
+		if err := s.Store.DeleteWorkspaceAppInstallation(ctx, workspaceID, appPackage.AppID); err != nil {
+			return workspacebiz.WorkspaceApp{}, err
+		}
 	}
 
 	app := workspacebiz.WorkspaceApp{
@@ -405,6 +490,7 @@ func (s *AppCenterService) handleRunnerStateChanged(workspaceID string, appID st
 	if s.Store == nil {
 		return
 	}
+	s.syncInstallProgressFromRuntimeStatus(workspaceID, appID, state.Status)
 	ctx := context.Background()
 	appPackage, err := s.Store.GetAppPackage(ctx, appID)
 	if err != nil {
@@ -440,6 +526,7 @@ func (s *AppCenterService) handleRunnerStateChanged(workspaceID string, appID st
 }
 
 func (s *AppCenterService) publishAppIfChanged(ctx context.Context, workspaceID string, appID string, app workspacebiz.WorkspaceApp) workspacebiz.WorkspaceApp {
+	app = s.withActiveInstallJobProgress(app, workspaceID, appID)
 	app, changed := s.withChangedRevision(app, workspaceID, appID)
 	if !changed {
 		return app

--- a/services/tuttid/service/workspace/apps.go
+++ b/services/tuttid/service/workspace/apps.go
@@ -150,7 +150,8 @@ func (s *AppCenterService) List(ctx context.Context, workspaceID string) ([]work
 		return nil, err
 	}
 	s.maybePreloadRuntimeForUninstalledApps(apps)
-	return s.withInstallJobProjections(apps, workspaceID), nil
+	apps = s.withInstallJobProjections(apps, workspaceID)
+	return apps, nil
 }
 
 func (s *AppCenterService) RefreshCatalog(ctx context.Context, workspaceID string) ([]workspacebiz.WorkspaceApp, error) {
@@ -209,6 +210,9 @@ func (s *AppCenterService) installPackage(ctx context.Context, workspaceID strin
 	}
 	runtimeState, err := s.startPackage(ctx, workspaceID, appPackage, options.RestartRunning)
 	if err != nil {
+		return workspacebiz.WorkspaceApp{}, err
+	}
+	if err := s.Store.SetActiveAppPackageVersion(ctx, appPackage.AppID, appPackage.Version); err != nil {
 		return workspacebiz.WorkspaceApp{}, err
 	}
 

--- a/services/tuttid/service/workspace/apps_install_jobs.go
+++ b/services/tuttid/service/workspace/apps_install_jobs.go
@@ -67,22 +67,58 @@ func (s *AppCenterService) ensureInstallJobsLocked() {
 	}
 }
 
+func (s *AppCenterService) setInstallJobProgress(workspaceID string, appID string, progress workspacebiz.AppInstallProgress) {
+	key := appRuntimeKey(workspaceID, appID)
+	s.installMu.Lock()
+	defer s.installMu.Unlock()
+	s.ensureInstallJobsLocked()
+	job, ok := s.installJobs[key]
+	if !ok || job.Status != workspaceAppInstallJobInstalling {
+		return
+	}
+	progressCopy := progress
+	job.Progress = &progressCopy
+	s.installJobs[key] = job
+}
+
+func (s *AppCenterService) clearInstallJobProgress(workspaceID string, appID string) {
+	key := appRuntimeKey(workspaceID, appID)
+	s.installMu.Lock()
+	defer s.installMu.Unlock()
+	s.ensureInstallJobsLocked()
+	job, ok := s.installJobs[key]
+	if !ok {
+		return
+	}
+	job.Progress = nil
+	s.installJobs[key] = job
+}
+
 func (s *AppCenterService) withInstallJobProjections(apps []workspacebiz.WorkspaceApp, workspaceID string) []workspacebiz.WorkspaceApp {
 	result := make([]workspacebiz.WorkspaceApp, len(apps))
 	copy(result, apps)
 	for index, app := range result {
 		job, ok := s.installJob(workspaceID, app.Package.AppID)
-		if !ok || job.Status != workspaceAppInstallJobFailed {
+		if !ok {
 			continue
 		}
-		failureReason := job.FailureReason
-		app.Installation = nil
-		app.Runtime = workspacebiz.AppRuntimeState{
-			Status:        workspacebiz.AppRuntimeStatusFailed,
-			FailureReason: &failureReason,
-			LastError:     &failureReason,
+		if job.Status == workspaceAppInstallJobFailed {
+			failureReason := job.FailureReason
+			app.Installation = nil
+			app.InstallProgress = nil
+			app.Runtime = workspacebiz.AppRuntimeState{
+				Status:        workspacebiz.AppRuntimeStatusFailed,
+				FailureReason: &failureReason,
+				LastError:     &failureReason,
+			}
+			result[index] = s.withCurrentRevision(app, workspaceID, app.Package.AppID)
+			continue
 		}
-		result[index] = s.withCurrentRevision(app, workspaceID, app.Package.AppID)
+		if job.Status == workspaceAppInstallJobInstalling && job.Progress != nil {
+			progressCopy := *job.Progress
+			app.InstallProgress = &progressCopy
+			result[index] = s.withCurrentRevision(app, workspaceID, app.Package.AppID)
+		}
 	}
 	return result
 }
@@ -94,6 +130,7 @@ func (s *AppCenterService) failedInstallAppProjection(ctx context.Context, works
 	}
 	failureReason := installErr.Error()
 	app.Installation = nil
+	app.InstallProgress = nil
 	app.Runtime = workspacebiz.AppRuntimeState{
 		Status:        workspacebiz.AppRuntimeStatusFailed,
 		FailureReason: &failureReason,

--- a/services/tuttid/service/workspace/apps_install_progress.go
+++ b/services/tuttid/service/workspace/apps_install_progress.go
@@ -1,0 +1,499 @@
+package workspace
+
+import (
+	"context"
+	"errors"
+	"math"
+	"sync"
+	"time"
+
+	workspacebiz "github.com/tutti-os/tutti/services/tuttid/biz/workspace"
+	workspacedata "github.com/tutti-os/tutti/services/tuttid/data/workspace"
+)
+
+const (
+	installProgressWeightPackageDownload = 40.0
+	installProgressWeightRuntimeDownload = 30.0
+	installProgressWeightInstalling      = 20.0
+	installProgressWeightStarting        = 10.0
+	installProgressPublishInterval       = 300 * time.Millisecond
+)
+
+type appArtifactDownloadProgressKey struct{}
+type appArtifactRuntimeComponentProgressKey struct{}
+
+type AppArtifactDownloadProgress struct {
+	DownloadedBytes int64
+	TotalBytes      int64
+}
+
+type installProgressPlan struct {
+	packageDownloadWeight float64
+	runtimeDownloadWeight float64
+	installingWeight      float64
+	startingWeight        float64
+}
+
+type installProgressTracker struct {
+	service     *AppCenterService
+	workspaceID string
+	appID       string
+	plan        installProgressPlan
+
+	mu              sync.Mutex
+	userPhase       workspacebiz.AppInstallUserPhase
+	packageDone     int64
+	packageTotal    int64
+	runtimeStreams  map[string]streamDownloadProgress
+	installingDone  float64
+	startingDone    float64
+	overallPercent  float64
+	indeterminate   bool
+	lastPublished   float64
+	lastPublishTime time.Time
+}
+
+type streamDownloadProgress struct {
+	done  int64
+	total int64
+}
+
+func (s *AppCenterService) newInstallProgressTracker(workspaceID string, appID string, plan installProgressPlan) *installProgressTracker {
+	tracker := &installProgressTracker{
+		service:     s,
+		workspaceID: workspaceID,
+		appID:       appID,
+		plan:        plan,
+		userPhase:   workspacebiz.AppInstallUserPhaseDownloading,
+	}
+	tracker.publish(true)
+	return tracker
+}
+
+func (s *AppCenterService) buildInstallProgressPlan(ctx context.Context, appID string) installProgressPlan {
+	plan := installProgressPlan{
+		packageDownloadWeight: installProgressWeightPackageDownload,
+		runtimeDownloadWeight: installProgressWeightRuntimeDownload,
+		installingWeight:      installProgressWeightInstalling,
+		startingWeight:        installProgressWeightStarting,
+	}
+	if !s.installNeedsPackageDownload(ctx, appID) {
+		plan.packageDownloadWeight = 0
+	}
+	if !s.installNeedsRuntimeDownload() {
+		plan.runtimeDownloadWeight = 0
+	}
+	if plan.packageDownloadWeight == 0 && plan.runtimeDownloadWeight == 0 {
+		plan.installingWeight = 70
+		plan.startingWeight = 30
+	}
+	return plan
+}
+
+func (s *AppCenterService) installNeedsPackageDownload(ctx context.Context, appID string) bool {
+	appPackage, err := s.Store.GetAppPackage(ctx, appID)
+	if err != nil {
+		if errors.Is(err, workspacedata.ErrWorkspaceAppNotFound) {
+			_, ok, remoteErr := s.remoteBuiltinForAppID(appID)
+			return remoteErr == nil && ok
+		}
+		return false
+	}
+	remoteBuiltin, ok, remoteErr := s.remoteBuiltinForAppID(appID)
+	if remoteErr != nil || !ok {
+		return false
+	}
+	return shouldMaterializeRemoteBuiltin(appPackage, remoteBuiltin)
+}
+
+func (s *AppCenterService) installNeedsRuntimeDownload() bool {
+	resolver := s.runner().runtimeResolver()
+	managed, ok := resolver.(DefaultManagedAppRuntimeResolver)
+	if !ok {
+		return false
+	}
+	root := defaultManagedAppRuntimeRoot(managed.environ())
+	return !managedAppRuntimeRootReady(root)
+}
+
+func ContextWithAppArtifactDownloadProgress(ctx context.Context, report func(AppArtifactDownloadProgress)) context.Context {
+	if report == nil {
+		return ctx
+	}
+	return context.WithValue(ctx, appArtifactDownloadProgressKey{}, report)
+}
+
+func ContextWithAppArtifactRuntimeComponentProgress(ctx context.Context, report func(string, AppArtifactDownloadProgress)) context.Context {
+	if report == nil {
+		return ctx
+	}
+	return context.WithValue(ctx, appArtifactRuntimeComponentProgressKey{}, report)
+}
+
+func appArtifactDownloadProgressFromContext(ctx context.Context) func(AppArtifactDownloadProgress) {
+	if ctx == nil {
+		return nil
+	}
+	report, _ := ctx.Value(appArtifactDownloadProgressKey{}).(func(AppArtifactDownloadProgress))
+	return report
+}
+
+func appArtifactRuntimeComponentProgressFromContext(ctx context.Context) func(string, AppArtifactDownloadProgress) {
+	if ctx == nil {
+		return nil
+	}
+	report, _ := ctx.Value(appArtifactRuntimeComponentProgressKey{}).(func(string, AppArtifactDownloadProgress))
+	return report
+}
+
+func (t *installProgressTracker) packageProgressContext(ctx context.Context) context.Context {
+	if t.plan.packageDownloadWeight <= 0 {
+		return ctx
+	}
+	return ContextWithAppArtifactDownloadProgress(ctx, func(progress AppArtifactDownloadProgress) {
+		t.updatePackageDownload(progress.DownloadedBytes, progress.TotalBytes)
+	})
+}
+
+func (t *installProgressTracker) runtimeProgressContext(ctx context.Context) context.Context {
+	if t.plan.runtimeDownloadWeight <= 0 {
+		return ctx
+	}
+	return ContextWithAppArtifactRuntimeComponentProgress(ctx, func(component string, progress AppArtifactDownloadProgress) {
+		t.updateRuntimeStreamDownload(component, progress.DownloadedBytes, progress.TotalBytes)
+	})
+}
+
+func (t *installProgressTracker) updatePackageDownload(downloaded int64, total int64) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	if downloaded > t.packageDone {
+		t.packageDone = downloaded
+	}
+	if total > t.packageTotal {
+		t.packageTotal = total
+	}
+	t.userPhase = workspacebiz.AppInstallUserPhaseDownloading
+	t.recalculateLocked()
+	t.publishLocked(false)
+}
+
+func (t *installProgressTracker) updateRuntimeStreamDownload(stream string, downloaded int64, total int64) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	if t.runtimeStreams == nil {
+		t.runtimeStreams = make(map[string]streamDownloadProgress)
+	}
+	current := t.runtimeStreams[stream]
+	if downloaded > current.done {
+		current.done = downloaded
+	}
+	if total > current.total {
+		current.total = total
+	}
+	t.runtimeStreams[stream] = current
+	t.userPhase = workspacebiz.AppInstallUserPhaseDownloading
+	t.recalculateLocked()
+	t.publishLocked(false)
+}
+
+func (t *installProgressTracker) runtimeDownloadTotalsLocked() (int64, int64) {
+	downloaded := int64(0)
+	total := int64(0)
+	for _, stream := range t.runtimeStreams {
+		downloaded += stream.done
+		if stream.total > 0 {
+			total += stream.total
+		}
+	}
+	return downloaded, total
+}
+
+func (t *installProgressTracker) beginInstalling() {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	t.userPhase = workspacebiz.AppInstallUserPhaseInstalling
+	if t.plan.packageDownloadWeight > 0 {
+		t.packageDone = maxInt64(t.packageDone, t.packageTotal)
+	}
+	if t.plan.runtimeDownloadWeight > 0 {
+		for stream, progress := range t.runtimeStreams {
+			if progress.total > 0 {
+				progress.done = progress.total
+				t.runtimeStreams[stream] = progress
+			}
+		}
+	}
+	t.installingDone = 0
+	t.recalculateLocked()
+	t.publishLocked(true)
+}
+
+func (t *installProgressTracker) advanceInstalling(fraction float64) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	if fraction > t.installingDone {
+		t.installingDone = fraction
+	}
+	t.userPhase = workspacebiz.AppInstallUserPhaseInstalling
+	t.recalculateLocked()
+	t.publishLocked(false)
+}
+
+func (t *installProgressTracker) finishInstalling() {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	t.installingDone = 1
+	t.userPhase = workspacebiz.AppInstallUserPhaseStarting
+	t.recalculateLocked()
+	t.publishLocked(true)
+}
+
+func (t *installProgressTracker) advanceStarting(fraction float64) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	if fraction > t.startingDone {
+		t.startingDone = fraction
+	}
+	t.userPhase = workspacebiz.AppInstallUserPhaseStarting
+	t.recalculateLocked()
+	t.publishLocked(false)
+}
+
+func (t *installProgressTracker) finishStarting() {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	t.startingDone = 1
+	t.recalculateLocked()
+	t.publishLocked(true)
+}
+
+func (t *installProgressTracker) clear() {
+	t.service.clearInstallProgress(t.workspaceID, t.appID)
+}
+
+func (t *installProgressTracker) recalculateLocked() {
+	downloadWeight := t.plan.packageDownloadWeight + t.plan.runtimeDownloadWeight
+	downloadFraction := 0.0
+	downloaded := int64(0)
+	total := int64(0)
+	if t.plan.packageDownloadWeight > 0 {
+		downloaded += t.packageDone
+		if t.packageTotal > 0 {
+			total += t.packageTotal
+		}
+	}
+	if t.plan.runtimeDownloadWeight > 0 {
+		runtimeDownloaded, runtimeTotal := t.runtimeDownloadTotalsLocked()
+		downloaded += runtimeDownloaded
+		if runtimeTotal > 0 {
+			total += runtimeTotal
+		}
+	}
+	if total > 0 {
+		downloadFraction = float64(downloaded) / float64(total)
+		if downloadFraction > 1 {
+			downloadFraction = 1
+		}
+	} else if downloadWeight > 0 && t.userPhase == workspacebiz.AppInstallUserPhaseDownloading && downloaded > 0 {
+		downloadFraction = estimateUnknownDownloadFraction(downloaded)
+	}
+
+	if t.overallPercent > 0 || downloadFraction > 0 || t.userPhase != workspacebiz.AppInstallUserPhaseDownloading {
+		t.indeterminate = false
+	} else if downloadWeight > 0 && t.userPhase == workspacebiz.AppInstallUserPhaseDownloading {
+		t.indeterminate = true
+	} else {
+		t.indeterminate = false
+	}
+
+	overall := downloadFraction * downloadWeight
+	if t.plan.installingWeight > 0 {
+		overall += t.installingDone * t.plan.installingWeight
+	}
+	if t.plan.startingWeight > 0 {
+		overall += t.startingDone * t.plan.startingWeight
+	}
+	if overall > 100 {
+		overall = 100
+	}
+	if overall < t.overallPercent {
+		overall = t.overallPercent
+	}
+	t.overallPercent = overall
+}
+
+func estimateUnknownDownloadFraction(downloaded int64) float64 {
+	if downloaded <= 0 {
+		return 0
+	}
+	const referenceBytes = 50 * 1024 * 1024
+	fraction := 0.05 + 0.8*(float64(downloaded)/float64(referenceBytes))
+	if fraction > 0.85 {
+		return 0.85
+	}
+	return fraction
+}
+
+func (t *installProgressTracker) snapshotLocked() workspacebiz.AppInstallProgress {
+	var downloadedBytes *int64
+	var totalBytes *int64
+	if t.userPhase == workspacebiz.AppInstallUserPhaseDownloading &&
+		(t.plan.packageDownloadWeight > 0 || t.plan.runtimeDownloadWeight > 0) {
+		downloaded := int64(0)
+		total := int64(0)
+		if t.plan.packageDownloadWeight > 0 {
+			downloaded += t.packageDone
+			if t.packageTotal > 0 {
+				total += t.packageTotal
+			}
+		}
+		if t.plan.runtimeDownloadWeight > 0 {
+			runtimeDownloaded, runtimeTotal := t.runtimeDownloadTotalsLocked()
+			downloaded += runtimeDownloaded
+			if runtimeTotal > 0 {
+				total += runtimeTotal
+			}
+		}
+		if downloaded > 0 || total > 0 {
+			downloadedCopy := downloaded
+			downloadedBytes = &downloadedCopy
+			if total > 0 {
+				totalCopy := total
+				totalBytes = &totalCopy
+			}
+		}
+	}
+	return workspacebiz.AppInstallProgress{
+		UserPhase:       t.userPhase,
+		OverallPercent:  roundInstallProgressPercent(t.overallPercent),
+		DownloadedBytes: downloadedBytes,
+		TotalBytes:      totalBytes,
+		Indeterminate:   t.indeterminate,
+		UpdatedAtUnixMs: time.Now().UnixMilli(),
+	}
+}
+
+func (t *installProgressTracker) publish(force bool) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	t.publishLocked(force)
+}
+
+func (t *installProgressTracker) publishLocked(force bool) {
+	if !force {
+		if time.Since(t.lastPublishTime) < installProgressPublishInterval &&
+			math.Abs(t.overallPercent-t.lastPublished) < 0.5 &&
+			t.overallPercent < 100 {
+			return
+		}
+	}
+	t.lastPublishTime = time.Now()
+	t.lastPublished = t.overallPercent
+	progress := t.snapshotLocked()
+	t.service.publishInstallProgress(context.Background(), t.workspaceID, t.appID, progress)
+}
+
+func roundInstallProgressPercent(value float64) float64 {
+	if value <= 0 {
+		return 0
+	}
+	if value >= 100 {
+		return 100
+	}
+	return math.Round(value*10) / 10
+}
+
+func maxInt64(left int64, right int64) int64 {
+	if left > right {
+		return left
+	}
+	return right
+}
+
+func (s *AppCenterService) publishInstallProgress(ctx context.Context, workspaceID string, appID string, progress workspacebiz.AppInstallProgress) {
+	s.setInstallJobProgress(workspaceID, appID, progress)
+	app, err := s.workspaceAppProjectionForInstall(ctx, workspaceID, appID)
+	if err != nil {
+		return
+	}
+	progressCopy := progress
+	app.InstallProgress = &progressCopy
+	_ = s.publishAppIfChanged(ctx, workspaceID, appID, app)
+}
+
+func (s *AppCenterService) clearInstallProgress(workspaceID string, appID string) {
+	s.clearInstallJobProgress(workspaceID, appID)
+	ctx := context.Background()
+	app, err := s.workspaceAppProjectionForInstall(ctx, workspaceID, appID)
+	if err != nil {
+		return
+	}
+	if app.InstallProgress == nil {
+		return
+	}
+	app.InstallProgress = nil
+	_ = s.publishAppIfChanged(ctx, workspaceID, appID, app)
+}
+
+func (s *AppCenterService) registerActiveInstallTracker(workspaceID string, appID string, tracker *installProgressTracker) {
+	key := appRuntimeKey(workspaceID, appID)
+	s.installMu.Lock()
+	defer s.installMu.Unlock()
+	if s.activeInstallTrackers == nil {
+		s.activeInstallTrackers = make(map[string]*installProgressTracker)
+	}
+	s.activeInstallTrackers[key] = tracker
+}
+
+func (s *AppCenterService) unregisterActiveInstallTracker(workspaceID string, appID string) {
+	key := appRuntimeKey(workspaceID, appID)
+	s.installMu.Lock()
+	defer s.installMu.Unlock()
+	delete(s.activeInstallTrackers, key)
+}
+
+func (s *AppCenterService) activeInstallTracker(workspaceID string, appID string) *installProgressTracker {
+	key := appRuntimeKey(workspaceID, appID)
+	s.installMu.Lock()
+	defer s.installMu.Unlock()
+	return s.activeInstallTrackers[key]
+}
+
+func (s *AppCenterService) syncInstallProgressFromRuntimeStatus(workspaceID string, appID string, status workspacebiz.AppRuntimeStatus) {
+	tracker := s.activeInstallTracker(workspaceID, appID)
+	if tracker == nil {
+		return
+	}
+	switch status {
+	case workspacebiz.AppRuntimeStatusPreparing:
+		tracker.advanceInstalling(0.45)
+	case workspacebiz.AppRuntimeStatusStarting:
+		tracker.finishInstalling()
+		tracker.advanceStarting(0.6)
+		tracker.publish(true)
+	case workspacebiz.AppRuntimeStatusRunning:
+		tracker.finishInstalling()
+		tracker.finishStarting()
+	default:
+		return
+	}
+}
+
+func (s *AppCenterService) withActiveInstallJobProgress(app workspacebiz.WorkspaceApp, workspaceID string, appID string) workspacebiz.WorkspaceApp {
+	job, ok := s.installJob(workspaceID, appID)
+	if !ok ||
+		job.Status != workspaceAppInstallJobInstalling ||
+		job.Progress == nil ||
+		!shouldAttachActiveInstallProgress(app.Runtime.Status) {
+		return app
+	}
+	progressCopy := *job.Progress
+	app.InstallProgress = &progressCopy
+	return app
+}
+
+func shouldAttachActiveInstallProgress(status workspacebiz.AppRuntimeStatus) bool {
+	return status == workspacebiz.AppRuntimeStatusPreparing ||
+		status == workspacebiz.AppRuntimeStatusStarting
+}

--- a/services/tuttid/service/workspace/apps_install_progress_test.go
+++ b/services/tuttid/service/workspace/apps_install_progress_test.go
@@ -1,0 +1,131 @@
+package workspace
+
+import (
+	"testing"
+
+	workspacebiz "github.com/tutti-os/tutti/services/tuttid/biz/workspace"
+)
+
+func TestInstallProgressTrackerAggregatesParallelRuntimeDownloads(t *testing.T) {
+	tracker := &installProgressTracker{
+		plan: installProgressPlan{
+			packageDownloadWeight: 0,
+			runtimeDownloadWeight: 30,
+			installingWeight:      20,
+			startingWeight:        10,
+		},
+		userPhase:      workspacebiz.AppInstallUserPhaseDownloading,
+		runtimeStreams: make(map[string]streamDownloadProgress),
+	}
+
+	tracker.mu.Lock()
+	tracker.runtimeStreams["python"] = streamDownloadProgress{done: 50, total: 100}
+	tracker.runtimeStreams["node"] = streamDownloadProgress{done: 25, total: 50}
+	tracker.recalculateLocked()
+	tracker.mu.Unlock()
+
+	if tracker.overallPercent <= 0 {
+		t.Fatalf("overallPercent = %v, want > 0", tracker.overallPercent)
+	}
+
+	progress := tracker.snapshotLocked()
+	if progress.DownloadedBytes == nil || *progress.DownloadedBytes != 75 {
+		t.Fatalf("DownloadedBytes = %v, want 75", progress.DownloadedBytes)
+	}
+	if progress.TotalBytes == nil || *progress.TotalBytes != 150 {
+		t.Fatalf("TotalBytes = %v, want 150", progress.TotalBytes)
+	}
+}
+
+func TestInstallProgressTrackerIsMonotonic(t *testing.T) {
+	tracker := &installProgressTracker{
+		plan: installProgressPlan{
+			packageDownloadWeight: 40,
+			runtimeDownloadWeight: 0,
+			installingWeight:      20,
+			startingWeight:        10,
+		},
+		userPhase: workspacebiz.AppInstallUserPhaseDownloading,
+	}
+
+	tracker.mu.Lock()
+	tracker.packageDone = 10
+	tracker.packageTotal = 100
+	tracker.recalculateLocked()
+	first := tracker.overallPercent
+	tracker.packageDone = 5
+	tracker.recalculateLocked()
+	if tracker.overallPercent < first {
+		t.Fatalf("overallPercent regressed from %v to %v", first, tracker.overallPercent)
+	}
+	tracker.mu.Unlock()
+}
+
+func TestInstallProgressTrackerEstimatesUnknownDownloadFraction(t *testing.T) {
+	tracker := &installProgressTracker{
+		plan: installProgressPlan{
+			packageDownloadWeight: 40,
+			runtimeDownloadWeight: 0,
+			installingWeight:      20,
+			startingWeight:        10,
+		},
+		userPhase: workspacebiz.AppInstallUserPhaseDownloading,
+	}
+
+	tracker.mu.Lock()
+	tracker.packageDone = 1024 * 1024
+	tracker.recalculateLocked()
+	if tracker.indeterminate {
+		t.Fatal("indeterminate = true, want false when bytes are known")
+	}
+	if tracker.overallPercent <= 0 {
+		t.Fatalf("overallPercent = %v, want > 0", tracker.overallPercent)
+	}
+	progress := tracker.snapshotLocked()
+	if progress.DownloadedBytes == nil {
+		t.Fatalf("DownloadedBytes = nil, want non-nil during downloading")
+	}
+	if progress.TotalBytes != nil {
+		t.Fatalf("TotalBytes = %v, want nil without known total", progress.TotalBytes)
+	}
+	tracker.mu.Unlock()
+}
+
+func TestWithActiveInstallJobProgressOnlyAttachesToInstallRuntimeStates(t *testing.T) {
+	service := &AppCenterService{}
+	progress := workspacebiz.AppInstallProgress{
+		UserPhase:      workspacebiz.AppInstallUserPhaseStarting,
+		OverallPercent: 95,
+	}
+	service.beginInstallJob("ws-1", "app-1", InstallOptions{})
+	service.setInstallJobProgress("ws-1", "app-1", progress)
+
+	for _, status := range []workspacebiz.AppRuntimeStatus{
+		workspacebiz.AppRuntimeStatusPreparing,
+		workspacebiz.AppRuntimeStatusStarting,
+	} {
+		app := service.withActiveInstallJobProgress(workspacebiz.WorkspaceApp{
+			Runtime: workspacebiz.AppRuntimeState{Status: status},
+		}, "ws-1", "app-1")
+		if app.InstallProgress == nil {
+			t.Fatalf("InstallProgress = nil for status %q, want active progress", status)
+		}
+		if app.InstallProgress.OverallPercent != progress.OverallPercent {
+			t.Fatalf("InstallProgress.OverallPercent = %v, want %v", app.InstallProgress.OverallPercent, progress.OverallPercent)
+		}
+	}
+
+	for _, status := range []workspacebiz.AppRuntimeStatus{
+		workspacebiz.AppRuntimeStatusIdle,
+		workspacebiz.AppRuntimeStatusRunning,
+		workspacebiz.AppRuntimeStatusFailed,
+		workspacebiz.AppRuntimeStatusStopping,
+	} {
+		app := service.withActiveInstallJobProgress(workspacebiz.WorkspaceApp{
+			Runtime: workspacebiz.AppRuntimeState{Status: status},
+		}, "ws-1", "app-1")
+		if app.InstallProgress != nil {
+			t.Fatalf("InstallProgress = %#v for status %q, want nil", app.InstallProgress, status)
+		}
+	}
+}

--- a/services/tuttid/service/workspace/apps_remote_builtin.go
+++ b/services/tuttid/service/workspace/apps_remote_builtin.go
@@ -167,7 +167,7 @@ func (s *AppCenterService) downloadRemoteBuiltinPackage(ctx context.Context, bui
 		ManifestJSON: manifestJSON,
 		Source:       workspacebiz.AppPackageSourceBuiltin,
 	}
-	if err := s.Store.PutAppPackage(ctx, appPackage); err != nil {
+	if err := s.Store.PutAppPackageVersion(ctx, appPackage); err != nil {
 		return workspacebiz.AppPackage{}, err
 	}
 	return appPackage, nil

--- a/services/tuttid/service/workspace/apps_runtime.go
+++ b/services/tuttid/service/workspace/apps_runtime.go
@@ -101,12 +101,12 @@ func (s *AppCenterService) StartEnabled(ctx context.Context, workspaceID string)
 			if !ok {
 				return nil, err
 			}
-			s.startRemoteBuiltinPackage(workspaceID, remoteBuiltin, "missing")
+			s.startRemoteBuiltinInstallJob(workspaceID, remoteBuiltin)
 			slog.Warn("workspace app start enabled deferred app; package unavailable locally", "workspaceId", workspaceID, "appId", installation.AppID)
 			continue
 		}
 		if remoteBuiltin, ok := remoteBuiltins[installation.AppID]; ok && shouldMaterializeRemoteBuiltin(appPackage, remoteBuiltin) {
-			s.startRemoteBuiltinPackage(workspaceID, remoteBuiltin, "update")
+			s.startRemoteBuiltinInstallJob(workspaceID, remoteBuiltin)
 			slog.Info(
 				"workspace app start enabled deferred app; remote builtin update available",
 				"workspaceId", workspaceID,
@@ -171,54 +171,14 @@ func (s *AppCenterService) publishInstalledAppRuntime(ctx context.Context, works
 	return s.publishAppIfChanged(ctx, workspaceID, appPackage.AppID, app)
 }
 
-func (s *AppCenterService) startRemoteBuiltinPackage(workspaceID string, builtin builtinapps.App, reason string) {
-	go func() {
-		startedAt := time.Now()
-		appID := strings.TrimSpace(builtin.Manifest.AppID)
-		slog.Info(
-			"workspace app remote builtin update and start started",
-			"workspaceId", workspaceID,
-			"appId", appID,
-			"version", builtin.Manifest.Version,
-			"reason", reason,
-		)
-		appPackage, err := s.packageForRemoteBuiltinStart(context.Background(), builtin)
-		if err != nil {
-			slog.Warn(
-				"workspace app remote builtin update and start failed",
-				"workspaceId", workspaceID,
-				"appId", appID,
-				"version", builtin.Manifest.Version,
-				"reason", reason,
-				"duration", time.Since(startedAt),
-				"error", err,
-			)
-			return
-		}
-		if _, err := s.startPackage(context.Background(), workspaceID, appPackage, false); err != nil {
-			slog.Warn(
-				"workspace app remote builtin start failed",
-				"workspaceId", workspaceID,
-				"appId", appID,
-				"version", appPackage.Version,
-				"reason", reason,
-				"duration", time.Since(startedAt),
-				"error", err,
-			)
-			return
-		}
-		slog.Info(
-			"workspace app remote builtin updated and started",
-			"workspaceId", workspaceID,
-			"appId", appID,
-			"version", appPackage.Version,
-			"reason", reason,
-			"duration", time.Since(startedAt),
-		)
-	}()
+func (s *AppCenterService) startRemoteBuiltinInstallJob(workspaceID string, builtin builtinapps.App) bool {
+	appID := strings.TrimSpace(builtin.Manifest.AppID)
+	return s.startInstallJob(workspaceID, appID, InstallOptions{}, func(ctx context.Context) (workspacebiz.AppPackage, error) {
+		return s.packageForRemoteBuiltinInstall(ctx, builtin)
+	})
 }
 
-func (s *AppCenterService) packageForRemoteBuiltinStart(ctx context.Context, builtin builtinapps.App) (workspacebiz.AppPackage, error) {
+func (s *AppCenterService) packageForRemoteBuiltinInstall(ctx context.Context, builtin builtinapps.App) (workspacebiz.AppPackage, error) {
 	appID := strings.TrimSpace(builtin.Manifest.AppID)
 	version := strings.TrimSpace(builtin.Manifest.Version)
 	if appID == "" || version == "" {

--- a/services/tuttid/service/workspace/apps_runtime.go
+++ b/services/tuttid/service/workspace/apps_runtime.go
@@ -189,9 +189,6 @@ func (s *AppCenterService) packageForRemoteBuiltinInstall(ctx context.Context, b
 		if shouldMaterializeRemoteBuiltin(existing, builtin) {
 			return s.downloadRemoteBuiltinPackage(ctx, builtin)
 		}
-		if err := s.Store.SetActiveAppPackageVersion(ctx, appID, version); err != nil {
-			return workspacebiz.AppPackage{}, err
-		}
 		return existing, nil
 	}
 	if err != nil && !errors.Is(err, workspacedata.ErrWorkspaceAppNotFound) {

--- a/services/tuttid/service/workspace/apps_test.go
+++ b/services/tuttid/service/workspace/apps_test.go
@@ -39,6 +39,14 @@ type appRuntimeResolverStub struct {
 	err    error
 }
 
+type preloadThenFailRuntimeResolver struct {
+	called   chan struct{}
+	once     sync.Once
+	mu       sync.Mutex
+	calls    int
+	startErr error
+}
+
 type waitingAppRuntimeResolver struct {
 	waitForFetch <-chan int
 	called       chan struct{}
@@ -169,6 +177,19 @@ func (r *appRuntimeResolverStub) Resolve(context.Context) (ResolvedAppRuntime, e
 	})
 	if r.err != nil {
 		return ResolvedAppRuntime{}, r.err
+	}
+	return ResolvedAppRuntime{}, nil
+}
+
+func (r *preloadThenFailRuntimeResolver) Resolve(context.Context) (ResolvedAppRuntime, error) {
+	r.once.Do(func() {
+		close(r.called)
+	})
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.calls += 1
+	if r.calls > 1 && r.startErr != nil {
+		return ResolvedAppRuntime{}, r.startErr
 	}
 	return ResolvedAppRuntime{}, nil
 }
@@ -702,7 +723,7 @@ func TestAppCenterServiceListKeepsCachedBuiltinWhenCatalogNotReady(t *testing.T)
 	}
 }
 
-func TestAppCenterServiceRemoteBuiltinStartActivatesUpdate(t *testing.T) {
+func TestAppCenterServiceRemoteBuiltinInstallActivatesUpdate(t *testing.T) {
 	t.Parallel()
 
 	ctx := context.Background()
@@ -777,12 +798,12 @@ func TestAppCenterServiceRemoteBuiltinStartActivatesUpdate(t *testing.T) {
 		},
 	}
 
-	appPackage, err := service.packageForRemoteBuiltinStart(ctx, remoteBuiltin)
+	appPackage, err := service.packageForRemoteBuiltinInstall(ctx, remoteBuiltin)
 	if err != nil {
-		t.Fatalf("packageForRemoteBuiltinStart() error = %v", err)
+		t.Fatalf("packageForRemoteBuiltinInstall() error = %v", err)
 	}
 	if appPackage.Version != "1.1.0" {
-		t.Fatalf("packageForRemoteBuiltinStart() version = %q, want 1.1.0", appPackage.Version)
+		t.Fatalf("packageForRemoteBuiltinInstall() version = %q, want 1.1.0", appPackage.Version)
 	}
 	stored, err := store.GetAppPackage(ctx, "large-builtin")
 	if err != nil {
@@ -868,6 +889,70 @@ func TestAppCenterServiceStartEnabledSkipsUninstalledRemoteBuiltinUpdate(t *test
 	}
 }
 
+func TestAppCenterServiceInstallProjectionPreservesInstalledRemoteBuiltinUpdate(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	oldDir := createWorkspaceAppPackageForTest(t, t.TempDir(), workspacebiz.AppManifest{
+		SchemaVersion: workspacebiz.AppManifestSchemaVersionV1,
+		AppID:         "large-builtin",
+		Version:       "1.0.0",
+		Name:          "Large Builtin",
+		Description:   "Old large app",
+		Runtime: workspacebiz.AppManifestRuntime{
+			Bootstrap:       "bootstrap.sh",
+			HealthcheckPath: "/",
+		},
+	})
+	remoteManifest := mustReadManifestForTest(t, oldDir)
+	remoteManifest.Version = "1.1.0"
+	store := newAppStoreStub()
+	if err := store.PutAppPackage(ctx, workspacebiz.AppPackage{
+		AppID:      "large-builtin",
+		Version:    "1.0.0",
+		PackageDir: oldDir,
+		Manifest:   mustReadManifestForTest(t, oldDir),
+		Source:     workspacebiz.AppPackageSourceBuiltin,
+	}); err != nil {
+		t.Fatalf("PutAppPackage() error = %v", err)
+	}
+	if err := store.PutWorkspaceAppInstallation(ctx, workspacebiz.AppInstallation{
+		WorkspaceID: "ws-1",
+		AppID:       "large-builtin",
+		Enabled:     true,
+	}); err != nil {
+		t.Fatalf("PutWorkspaceAppInstallation() error = %v", err)
+	}
+	service := AppCenterService{
+		Store:          store,
+		WorkspaceStore: &catalogStoreStub{getWorkspace: workspacebiz.Summary{ID: "ws-1", Name: "Workspace"}},
+		Runner:         &AppRunner{},
+		StateDir:       t.TempDir(),
+		BuiltinCatalog: func() ([]builtinapps.App, error) {
+			return []builtinapps.App{{
+				Manifest: remoteManifest,
+				Distribution: builtinapps.Distribution{
+					Kind:           builtinapps.DistributionRemote,
+					ArtifactURL:    "https://cdn.example.test/large-builtin.zip",
+					ArtifactSHA256: "sha256",
+					IconURL:        "https://cdn.example.test/large-builtin.png",
+				},
+			}}, nil
+		},
+	}
+
+	app, err := service.workspaceAppProjectionForInstall(ctx, "ws-1", "large-builtin")
+	if err != nil {
+		t.Fatalf("workspaceAppProjectionForInstall() error = %v", err)
+	}
+	if app.Installation == nil || !app.Installation.Enabled {
+		t.Fatalf("projection installation = %#v, want installed app", app.Installation)
+	}
+	if app.Package.Version != "1.0.0" || !app.UpdateAvailable || app.AvailableVersion == nil || *app.AvailableVersion != "1.1.0" {
+		t.Fatalf("projection app = %#v, want installed old package with available update", app)
+	}
+}
+
 func TestAppCenterServiceStartEnabledDoesNotBlockOnRemoteBuiltinUpdate(t *testing.T) {
 	t.Parallel()
 
@@ -904,7 +989,7 @@ func TestAppCenterServiceStartEnabledDoesNotBlockOnRemoteBuiltinUpdate(t *testin
 		t.Fatalf("PutWorkspaceAppInstallation() error = %v", err)
 	}
 	fetcher := newBlockingArtifactFetcher()
-	resolver := &appRuntimeResolverStub{called: make(chan struct{}), err: errors.New("skip runtime")}
+	resolver := &preloadThenFailRuntimeResolver{called: make(chan struct{}), startErr: errors.New("skip runtime")}
 	service := AppCenterService{
 		Store:           store,
 		WorkspaceStore:  &catalogStoreStub{getWorkspace: workspacebiz.Summary{ID: "ws-1", Name: "Workspace"}},
@@ -965,6 +1050,11 @@ func TestAppCenterServiceStartEnabledDoesNotBlockOnRemoteBuiltinUpdate(t *testin
 	case <-time.After(time.Second):
 		close(fetcher.release)
 		t.Fatal("background remote builtin sync did not start")
+	}
+	progress := waitForInstallJobProgressForTest(t, &service, "ws-1", "large-builtin")
+	if progress.UserPhase != workspacebiz.AppInstallUserPhaseDownloading {
+		close(fetcher.release)
+		t.Fatalf("auto update install progress user phase = %q, want downloading", progress.UserPhase)
 	}
 	close(fetcher.release)
 	select {
@@ -1032,7 +1122,7 @@ func TestAppCenterServiceStartEnabledUpdatesRemoteBuiltinBeforeStartingIt(t *tes
 		t.Fatalf("PutWorkspaceAppInstallation() error = %v", err)
 	}
 	fetcher := newCopyingArtifactFetcher(archivePath)
-	runner := &AppRunner{RuntimeResolver: &appRuntimeResolverStub{called: make(chan struct{}), err: errors.New("skip runtime")}}
+	runner := &AppRunner{RuntimeResolver: &preloadThenFailRuntimeResolver{called: make(chan struct{}), startErr: errors.New("skip runtime")}}
 	service := AppCenterService{
 		Store:           store,
 		WorkspaceStore:  &catalogStoreStub{getWorkspace: workspacebiz.Summary{ID: "ws-1", Name: "Workspace"}},
@@ -1120,7 +1210,7 @@ func TestAppCenterServiceStartEnabledRepairsMissingRemoteBuiltinCacheBeforeStart
 		t.Fatalf("PutWorkspaceAppInstallation() error = %v", err)
 	}
 	fetcher := newCopyingArtifactFetcher(archivePath)
-	runner := &AppRunner{RuntimeResolver: &appRuntimeResolverStub{called: make(chan struct{}), err: errors.New("skip runtime")}}
+	runner := &AppRunner{RuntimeResolver: &preloadThenFailRuntimeResolver{called: make(chan struct{}), startErr: errors.New("skip runtime")}}
 	service := AppCenterService{
 		Store:           store,
 		WorkspaceStore:  &catalogStoreStub{getWorkspace: workspacebiz.Summary{ID: "ws-1", Name: "Workspace"}},
@@ -1378,7 +1468,7 @@ func TestAppCenterServiceStartEnabledDoesNotBlockOtherAppsWhenRemoteBuiltinPacka
 		}
 	}
 	fetcher := newBlockingArtifactFetcher()
-	resolver := &appRuntimeResolverStub{called: make(chan struct{}), err: errors.New("skip runtime")}
+	resolver := &preloadThenFailRuntimeResolver{called: make(chan struct{}), startErr: errors.New("skip runtime")}
 	runner := &AppRunner{RuntimeResolver: resolver}
 	service := AppCenterService{
 		Store:           store,
@@ -1438,13 +1528,13 @@ func TestAppCenterServiceStartEnabledDoesNotBlockOtherAppsWhenRemoteBuiltinPacka
 	case <-fetcher.started:
 	case <-time.After(time.Second):
 		close(fetcher.release)
-		t.Fatal("missing remote builtin update and start did not start")
+		t.Fatal("missing remote builtin install job did not start")
 	}
 	close(fetcher.release)
 	select {
 	case <-fetcher.done:
 	case <-time.After(time.Second):
-		t.Fatal("missing remote builtin update and start did not finish")
+		t.Fatal("missing remote builtin install job did not finish")
 	}
 	waitForRunnerStatus(t, runner, "ws-1", "local-app", workspacebiz.AppRuntimeStatusFailed)
 }
@@ -3085,6 +3175,21 @@ func waitForActiveAppPackageDirChangeForTest(t *testing.T, store *appStoreStub, 
 		}
 		if time.Now().After(deadline) {
 			t.Fatalf("GetAppPackage(%s) packageDir = %q, error = %v, want different from %q", appID, appPackage.PackageDir, err, previousPackageDir)
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+}
+
+func waitForInstallJobProgressForTest(t *testing.T, service *AppCenterService, workspaceID string, appID string) workspacebiz.AppInstallProgress {
+	t.Helper()
+	deadline := time.Now().Add(time.Second)
+	for {
+		job, ok := service.installJob(workspaceID, appID)
+		if ok && job.Progress != nil {
+			return *job.Progress
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("install job progress for %s/%s was not published", workspaceID, appID)
 		}
 		time.Sleep(10 * time.Millisecond)
 	}

--- a/services/tuttid/service/workspace/apps_test.go
+++ b/services/tuttid/service/workspace/apps_test.go
@@ -229,6 +229,14 @@ func (s *appStoreStub) PutAppPackage(_ context.Context, appPackage workspacebiz.
 	return nil
 }
 
+func (s *appStoreStub) PutAppPackageVersion(_ context.Context, appPackage workspacebiz.AppPackage) error {
+	if s.packageVersions[appPackage.AppID] == nil {
+		s.packageVersions[appPackage.AppID] = make(map[string]workspacebiz.AppPackage)
+	}
+	s.packageVersions[appPackage.AppID][appPackage.Version] = appPackage
+	return nil
+}
+
 func (s *appStoreStub) DeleteAppPackage(_ context.Context, appID string) error {
 	if _, ok := s.packages[appID]; !ok {
 		return workspacedata.ErrWorkspaceAppNotFound
@@ -723,7 +731,7 @@ func TestAppCenterServiceListKeepsCachedBuiltinWhenCatalogNotReady(t *testing.T)
 	}
 }
 
-func TestAppCenterServiceRemoteBuiltinInstallActivatesUpdate(t *testing.T) {
+func TestAppCenterServiceRemoteBuiltinInstallCachesUpdateWithoutActivating(t *testing.T) {
 	t.Parallel()
 
 	ctx := context.Background()
@@ -809,10 +817,17 @@ func TestAppCenterServiceRemoteBuiltinInstallActivatesUpdate(t *testing.T) {
 	if err != nil {
 		t.Fatalf("GetAppPackage() error = %v", err)
 	}
-	if stored.Version != "1.1.0" || stored.PackageDir == oldDir {
-		t.Fatalf("stored package after update = %#v", stored)
+	if stored.Version != "1.0.0" || stored.PackageDir != oldDir {
+		t.Fatalf("active package after cache = %#v, want old active package", stored)
 	}
-	if actualIconURL := stored.IconDataURL(); actualIconURL == nil || !strings.HasPrefix(*actualIconURL, "data:image/png;base64,") {
+	cached, err := store.GetAppPackageVersion(ctx, "large-builtin", "1.1.0")
+	if err != nil {
+		t.Fatalf("GetAppPackageVersion(1.1.0) error = %v", err)
+	}
+	if cached.PackageDir == oldDir {
+		t.Fatalf("cached package dir = %q, want new package dir", cached.PackageDir)
+	}
+	if actualIconURL := cached.IconDataURL(); actualIconURL == nil || !strings.HasPrefix(*actualIconURL, "data:image/png;base64,") {
 		t.Fatalf("synced remote builtin icon url = %v", actualIconURL)
 	}
 }
@@ -1613,6 +1628,130 @@ func TestAppCenterServiceListExposesInstalledRemoteBuiltinUpdate(t *testing.T) {
 	}
 }
 
+func TestAppCenterServiceCachedRemoteBuiltinUpdateDoesNotReplaceActiveInstall(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	oldDir := createWorkspaceAppPackageForTest(t, t.TempDir(), workspacebiz.AppManifest{
+		SchemaVersion: workspacebiz.AppManifestSchemaVersionV1,
+		AppID:         "large-builtin",
+		Version:       "1.0.0",
+		Name:          "Large Builtin v1",
+		Description:   "Old large app",
+		Icon: workspacebiz.AppManifestIcon{
+			Type: "asset",
+			Src:  "icon.png",
+		},
+		Runtime: workspacebiz.AppManifestRuntime{
+			Bootstrap:       "bootstrap.sh",
+			HealthcheckPath: "/",
+		},
+	})
+	newDir := createWorkspaceAppPackageForTest(t, t.TempDir(), workspacebiz.AppManifest{
+		SchemaVersion: workspacebiz.AppManifestSchemaVersionV1,
+		AppID:         "large-builtin",
+		Version:       "1.1.0",
+		Name:          "Large Builtin v2",
+		Description:   "New large app",
+		Icon: workspacebiz.AppManifestIcon{
+			Type: "asset",
+			Src:  "icon.png",
+		},
+		Runtime: workspacebiz.AppManifestRuntime{
+			Bootstrap:       "bootstrap.sh",
+			HealthcheckPath: "/",
+		},
+	})
+	archivePath := filepath.Join(t.TempDir(), "large-builtin.zip")
+	if err := createAppPackageZip(newDir, archivePath); err != nil {
+		t.Fatalf("createAppPackageZip() error = %v", err)
+	}
+	archiveSHA256, _, err := fileSHA256AndSize(archivePath)
+	if err != nil {
+		t.Fatalf("fileSHA256AndSize() error = %v", err)
+	}
+	store := newAppStoreStub()
+	if err := store.PutAppPackage(ctx, workspacebiz.AppPackage{
+		AppID:      "large-builtin",
+		Version:    "1.0.0",
+		PackageDir: oldDir,
+		Manifest:   mustReadManifestForTest(t, oldDir),
+		Source:     workspacebiz.AppPackageSourceBuiltin,
+	}); err != nil {
+		t.Fatalf("PutAppPackage() error = %v", err)
+	}
+	if err := store.PutWorkspaceAppInstallation(ctx, workspacebiz.AppInstallation{
+		WorkspaceID: "ws-1",
+		AppID:       "large-builtin",
+		Enabled:     true,
+	}); err != nil {
+		t.Fatalf("PutWorkspaceAppInstallation() error = %v", err)
+	}
+	service := AppCenterService{
+		Store:          store,
+		WorkspaceStore: &catalogStoreStub{getWorkspace: workspacebiz.Summary{ID: "ws-1", Name: "Workspace"}},
+		Runner:         &AppRunner{},
+		StateDir:       t.TempDir(),
+		ArtifactFetcher: newCopyingArtifactFetcher(
+			archivePath,
+		),
+		BuiltinCatalog: func() ([]builtinapps.App, error) {
+			return []builtinapps.App{{
+				Manifest: mustReadManifestForTest(t, newDir),
+				Distribution: builtinapps.Distribution{
+					Kind:           builtinapps.DistributionRemote,
+					ArtifactURL:    "https://cdn.example.test/large-builtin.zip",
+					ArtifactSHA256: archiveSHA256,
+					IconURL:        "https://cdn.example.test/large-builtin.png",
+				},
+			}}, nil
+		},
+	}
+
+	builtins, err := service.BuiltinCatalog()
+	if err != nil {
+		t.Fatalf("BuiltinCatalog() error = %v", err)
+	}
+	if _, err := service.packageForRemoteBuiltinInstall(ctx, builtins[0]); err != nil {
+		t.Fatalf("packageForRemoteBuiltinInstall() error = %v", err)
+	}
+	active, err := store.GetAppPackage(ctx, "large-builtin")
+	if err != nil {
+		t.Fatalf("GetAppPackage() error = %v", err)
+	}
+	if active.Version != "1.0.0" {
+		t.Fatalf("active package version = %q, want 1.0.0", active.Version)
+	}
+	if _, err := store.GetAppPackageVersion(ctx, "large-builtin", "1.1.0"); err != nil {
+		t.Fatalf("cached update package missing: %v", err)
+	}
+	if _, err := service.packageForRemoteBuiltinInstall(ctx, builtins[0]); err != nil {
+		t.Fatalf("packageForRemoteBuiltinInstall(cached) error = %v", err)
+	}
+	active, err = store.GetAppPackage(ctx, "large-builtin")
+	if err != nil {
+		t.Fatalf("GetAppPackage() after cached resolve error = %v", err)
+	}
+	if active.Version != "1.0.0" {
+		t.Fatalf("active package after cached resolve = %q, want 1.0.0", active.Version)
+	}
+
+	apps, err := service.List(ctx, "ws-1")
+	if err != nil {
+		t.Fatalf("List() error = %v", err)
+	}
+	app := findWorkspaceAppForTest(apps, "large-builtin")
+	if app == nil {
+		t.Fatalf("large-builtin missing: %#v", apps)
+	}
+	if app.Package.Version != "1.0.0" || app.Package.DisplayName() != "Large Builtin v1" {
+		t.Fatalf("projected active package = version %q name %q, want v1", app.Package.Version, app.Package.DisplayName())
+	}
+	if !app.UpdateAvailable || app.AvailableVersion == nil || *app.AvailableVersion != "1.1.0" {
+		t.Fatalf("projected update fields = updateAvailable %v availableVersion %v, want v2 update", app.UpdateAvailable, app.AvailableVersion)
+	}
+}
+
 func TestAppCenterServiceListsRemoteBuiltinWhenOlderLocalPackageExists(t *testing.T) {
 	t.Parallel()
 
@@ -1917,8 +2056,15 @@ func TestAppCenterServiceResolvesRemoteBuiltinForInstallWhenOlderLocalPackageExi
 	if err != nil {
 		t.Fatalf("GetAppPackage() error = %v", err)
 	}
-	if activePackage.Version != "0.1.0+abc123" || activePackage.PackageDir == "" {
-		t.Fatalf("active package = %#v", activePackage)
+	if activePackage.Version != "0.1.0" {
+		t.Fatalf("active package = %#v, want old active package", activePackage)
+	}
+	cachedPackage, err := store.GetAppPackageVersion(ctx, "design-app", "0.1.0+abc123")
+	if err != nil {
+		t.Fatalf("GetAppPackageVersion(remote) error = %v", err)
+	}
+	if cachedPackage.PackageDir == "" {
+		t.Fatalf("cached package = %#v", cachedPackage)
 	}
 }
 

--- a/services/tuttid/service/workspace/apps_test.go
+++ b/services/tuttid/service/workspace/apps_test.go
@@ -39,6 +39,13 @@ type appRuntimeResolverStub struct {
 	err    error
 }
 
+type waitingAppRuntimeResolver struct {
+	waitForFetch <-chan int
+	called       chan struct{}
+	once         sync.Once
+	err          error
+}
+
 func (f *appArtifactFetcherStub) FetchAppArtifact(_ context.Context, artifactURL string, _ string) error {
 	f.calls = append(f.calls, artifactURL)
 	if f.err != nil {
@@ -166,6 +173,18 @@ func (r *appRuntimeResolverStub) Resolve(context.Context) (ResolvedAppRuntime, e
 	return ResolvedAppRuntime{}, nil
 }
 
+func (r *waitingAppRuntimeResolver) Resolve(ctx context.Context) (ResolvedAppRuntime, error) {
+	r.once.Do(func() {
+		close(r.called)
+	})
+	select {
+	case <-r.waitForFetch:
+		return ResolvedAppRuntime{}, r.err
+	case <-ctx.Done():
+		return ResolvedAppRuntime{}, ctx.Err()
+	}
+}
+
 func (s *workspaceAppPublisherStub) PublishWorkspaceAppUpdated(_ context.Context, workspaceID string, app workspacebiz.WorkspaceApp) error {
 	s.workspaces = append(s.workspaces, workspaceID)
 	s.published = append(s.published, app)
@@ -270,6 +289,16 @@ func (s *appStoreStub) ListWorkspaceAppInstallations(_ context.Context, workspac
 	var result []workspacebiz.AppInstallation
 	for _, installation := range s.installations {
 		if installation.WorkspaceID == workspaceID {
+			result = append(result, installation)
+		}
+	}
+	return result, nil
+}
+
+func (s *appStoreStub) ListWorkspaceAppInstallationsByApp(_ context.Context, appID string) ([]workspacebiz.AppInstallation, error) {
+	var result []workspacebiz.AppInstallation
+	for _, installation := range s.installations {
+		if installation.AppID == appID {
 			result = append(result, installation)
 		}
 	}
@@ -1929,6 +1958,84 @@ func TestAppCenterServiceInstallReturnsWhileRemoteBuiltinDownloadRuns(t *testing
 	}
 }
 
+func TestAppCenterServiceInstallCancelsPackageDownloadAfterRuntimePreloadFailure(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	stateDir := t.TempDir()
+	remoteDir := createWorkspaceAppPackageForTest(t, t.TempDir(), workspacebiz.AppManifest{
+		SchemaVersion: workspacebiz.AppManifestSchemaVersionV1,
+		AppID:         "design-app",
+		Version:       "0.1.0+abc123",
+		Name:          "Design App",
+		Description:   "Remote design app",
+		Runtime: workspacebiz.AppManifestRuntime{
+			Bootstrap:       "bootstrap.sh",
+			HealthcheckPath: "/",
+		},
+	})
+	archivePath := filepath.Join(t.TempDir(), "design-app.zip")
+	if err := createAppPackageZip(remoteDir, archivePath); err != nil {
+		t.Fatalf("createAppPackageZip() error = %v", err)
+	}
+	artifactSHA256, _, err := fileSHA256AndSize(archivePath)
+	if err != nil {
+		t.Fatalf("fileSHA256AndSize() error = %v", err)
+	}
+
+	fetcher := newTrackingArtifactFetcher(archivePath)
+	defer close(fetcher.release)
+	runtimeErr := errors.New("runtime unavailable")
+	resolver := &waitingAppRuntimeResolver{
+		waitForFetch: fetcher.entered,
+		called:       make(chan struct{}),
+		err:          runtimeErr,
+	}
+	service := AppCenterService{
+		Store:           newAppStoreStub(),
+		WorkspaceStore:  &catalogStoreStub{getWorkspace: workspacebiz.Summary{ID: "ws-1", Name: "Workspace"}},
+		Runner:          &AppRunner{RuntimeResolver: resolver},
+		StateDir:        stateDir,
+		ArtifactFetcher: fetcher,
+		BuiltinCatalog: func() ([]builtinapps.App, error) {
+			return []builtinapps.App{{
+				Manifest: mustReadManifestForTest(t, remoteDir),
+				Distribution: builtinapps.Distribution{
+					Kind:           builtinapps.DistributionRemote,
+					ArtifactURL:    "https://cdn.example.test/design-app.zip",
+					ArtifactSHA256: artifactSHA256,
+					IconURL:        "https://cdn.example.test/design-app.png",
+				},
+			}}, nil
+		},
+	}
+
+	if _, err := service.Install(ctx, "ws-1", "design-app"); err != nil {
+		t.Fatalf("Install() error = %v", err)
+	}
+	select {
+	case <-resolver.called:
+	case <-time.After(time.Second):
+		t.Fatal("runtime preload did not start")
+	}
+
+	deadline := time.After(time.Second)
+	for {
+		job, ok := service.installJob("ws-1", "design-app")
+		if ok && job.Status == workspaceAppInstallJobFailed {
+			if !strings.Contains(job.FailureReason, runtimeErr.Error()) {
+				t.Fatalf("FailureReason = %q, want runtime preload error", job.FailureReason)
+			}
+			return
+		}
+		select {
+		case <-deadline:
+			t.Fatal("install job did not fail after runtime preload error; package download was not canceled")
+		case <-time.After(10 * time.Millisecond):
+		}
+	}
+}
+
 func TestAppCenterServiceImportsAndExportsUserPackageArchives(t *testing.T) {
 	t.Parallel()
 
@@ -2071,6 +2178,140 @@ func TestAppCenterServiceRemoveDeletesWorkspaceAppState(t *testing.T) {
 	}
 	if _, err := os.Stat(stateRoot); !errors.Is(err, os.ErrNotExist) {
 		t.Fatalf("removed app state root stat error = %v, want not exist", err)
+	}
+}
+
+func TestAppCenterServiceRemoveDeletesUnusedRemoteBuiltinPackage(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	store := newAppStoreStub()
+	packageDir := filepath.Join(t.TempDir(), "packages", "remote-builtin", "1.0.0")
+	if err := os.MkdirAll(packageDir, 0o755); err != nil {
+		t.Fatalf("create package dir: %v", err)
+	}
+	appPackage := workspacebiz.AppPackage{
+		AppID:      "remote-builtin",
+		Version:    "1.0.0",
+		PackageDir: packageDir,
+		Source:     workspacebiz.AppPackageSourceBuiltin,
+		Manifest: workspacebiz.AppManifest{
+			AppID:       "remote-builtin",
+			Version:     "1.0.0",
+			Name:        "Remote Builtin",
+			Description: "Remote builtin",
+		},
+	}
+	if err := store.PutAppPackage(ctx, appPackage); err != nil {
+		t.Fatalf("PutAppPackage() error = %v", err)
+	}
+	if err := store.PutWorkspaceAppInstallation(ctx, workspacebiz.AppInstallation{
+		WorkspaceID: "ws-1",
+		AppID:       "remote-builtin",
+		Enabled:     true,
+	}); err != nil {
+		t.Fatalf("PutWorkspaceAppInstallation() error = %v", err)
+	}
+	service := AppCenterService{
+		Store:          store,
+		WorkspaceStore: &catalogStoreStub{getWorkspace: workspacebiz.Summary{ID: "ws-1", Name: "Workspace"}},
+		Runner:         &AppRunner{},
+		StateDir:       t.TempDir(),
+		BuiltinCatalog: func() ([]builtinapps.App, error) {
+			return []builtinapps.App{
+				{
+					Manifest: appPackage.Manifest,
+					Distribution: builtinapps.Distribution{
+						Kind: builtinapps.DistributionRemote,
+					},
+				},
+			}, nil
+		},
+	}
+
+	if _, err := service.Remove(ctx, "ws-1", "remote-builtin"); err != nil {
+		t.Fatalf("Remove() error = %v", err)
+	}
+	if _, err := store.GetAppPackage(ctx, "remote-builtin"); !errors.Is(err, workspacedata.ErrWorkspaceAppNotFound) {
+		t.Fatalf("GetAppPackage() after remove error = %v, want ErrWorkspaceAppNotFound", err)
+	}
+	if _, err := os.Stat(packageDir); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("removed package dir stat error = %v, want not exist", err)
+	}
+	installations, err := store.ListWorkspaceAppInstallationsByApp(ctx, "remote-builtin")
+	if err != nil {
+		t.Fatalf("ListWorkspaceAppInstallationsByApp() error = %v", err)
+	}
+	if len(installations) != 0 {
+		t.Fatalf("installations after remove = %#v, want empty", installations)
+	}
+}
+
+func TestAppCenterServiceRemoveKeepsRemoteBuiltinPackageUsedByAnotherWorkspace(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	store := newAppStoreStub()
+	packageDir := filepath.Join(t.TempDir(), "packages", "remote-builtin", "1.0.0")
+	if err := os.MkdirAll(packageDir, 0o755); err != nil {
+		t.Fatalf("create package dir: %v", err)
+	}
+	appPackage := workspacebiz.AppPackage{
+		AppID:      "remote-builtin",
+		Version:    "1.0.0",
+		PackageDir: packageDir,
+		Source:     workspacebiz.AppPackageSourceBuiltin,
+		Manifest: workspacebiz.AppManifest{
+			AppID:       "remote-builtin",
+			Version:     "1.0.0",
+			Name:        "Remote Builtin",
+			Description: "Remote builtin",
+		},
+	}
+	if err := store.PutAppPackage(ctx, appPackage); err != nil {
+		t.Fatalf("PutAppPackage() error = %v", err)
+	}
+	for _, workspaceID := range []string{"ws-1", "ws-2"} {
+		if err := store.PutWorkspaceAppInstallation(ctx, workspacebiz.AppInstallation{
+			WorkspaceID: workspaceID,
+			AppID:       "remote-builtin",
+			Enabled:     true,
+		}); err != nil {
+			t.Fatalf("PutWorkspaceAppInstallation(%s) error = %v", workspaceID, err)
+		}
+	}
+	service := AppCenterService{
+		Store:          store,
+		WorkspaceStore: &catalogStoreStub{getWorkspace: workspacebiz.Summary{ID: "ws-1", Name: "Workspace"}},
+		Runner:         &AppRunner{},
+		StateDir:       t.TempDir(),
+		BuiltinCatalog: func() ([]builtinapps.App, error) {
+			return []builtinapps.App{
+				{
+					Manifest: appPackage.Manifest,
+					Distribution: builtinapps.Distribution{
+						Kind: builtinapps.DistributionRemote,
+					},
+				},
+			}, nil
+		},
+	}
+
+	if _, err := service.Remove(ctx, "ws-1", "remote-builtin"); err != nil {
+		t.Fatalf("Remove() error = %v", err)
+	}
+	if _, err := store.GetAppPackage(ctx, "remote-builtin"); err != nil {
+		t.Fatalf("GetAppPackage() after remove error = %v", err)
+	}
+	if _, err := os.Stat(packageDir); err != nil {
+		t.Fatalf("package dir after remove stat error = %v", err)
+	}
+	installations, err := store.ListWorkspaceAppInstallationsByApp(ctx, "remote-builtin")
+	if err != nil {
+		t.Fatalf("ListWorkspaceAppInstallationsByApp() error = %v", err)
+	}
+	if len(installations) != 1 || installations[0].WorkspaceID != "ws-2" {
+		t.Fatalf("installations after remove = %#v, want ws-2 only", installations)
 	}
 }
 


### PR DESCRIPTION
## Summary

- Add daemon-side install progress tracking for workspace app installs, including package/runtime download aggregation and install/start phases.
- Surface install progress through API and workspace app update events, and keep the app center UI showing a single "安装中" label with a progress ring.
- Fix install races by canceling parallel install work after the first failure and avoiding terminal runtime projections that still carry active install progress.
- Delete remote builtin package files and records when uninstalling the last workspace installation, while preserving packages still used by another workspace.
- Reconcile stale agent turns when a persisted session looks idle/created but still has an open tool call waiting in recent messages.
- Reuse the unified install job runner for startup remote builtin repairs/auto-updates, keeping `start-enabled` non-blocking while giving automatic updates the same progress and failure behavior as manual installs/updates.

## Root Cause

The install workflow mixed runtime status updates with install-progress state. A running projection could still carry active install progress, causing the renderer to keep treating the app as installing. Parallel install work also waited for both branches, so a fast runtime preload failure could be delayed by an unrelated package download.

Startup auto-update for remote builtin apps used a separate background path that downloaded and started the app directly. That bypassed install jobs, progress tracking, failure projection, and cancellation behavior. The refactor removes that path and schedules the same install job with a package resolver specific to the discovered remote builtin.

For agent sessions, stale-turn recovery only looked at persisted session status/phase. If the session record no longer looked active but the latest messages still contained an open tool call, resume/interactive handling could skip reconciliation and try to submit against stale live state.

## Validation

- `go test ./service/workspace -run 'TestWithActiveInstallJobProgressOnlyAttachesToInstallRuntimeStates|TestAppCenterServiceInstallCancelsPackageDownloadAfterRuntimePreloadFailure'`
- `go test ./service/workspace -run 'TestAppCenterService(InstallProjectionPreservesInstalledRemoteBuiltinUpdate|StartEnabledDoesNotBlockOnRemoteBuiltinUpdate|StartEnabledUpdatesRemoteBuiltinBeforeStartingIt|StartEnabledRepairsMissingRemoteBuiltinCacheBeforeStarting|StartEnabledDoesNotBlockOtherAppsWhenRemoteBuiltinPackageIsMissing)'`
- `go test ./service/workspace`
- `go test ./service/agent -run 'TestHasStaleResumeOpenToolCall|TestServiceReconcilesOpenToolCallBeforeSubmittingInteractive|TestServiceReconcilesStalePersistedTurnBeforeSubmittingInteractive'`
- `go test ./service/agent`
- `cd services/tuttid && go test ./...`
- `cd services/tuttid && go build ./...`
- `pnpm lint:go`
- `pnpm lint:ts`
- `pnpm --filter @tutti-os/workspace-app-center typecheck`
- `pnpm --filter @tutti-os/desktop typecheck`
- `pnpm typecheck`
- `pnpm --filter @tutti-os/desktop build`
- `pnpm check:ui-boundaries:staged`
- pre-push `pnpm check:full`
