### PR TITLE
[codex] Handle missing agent session launches

### DIFF
--- a/apps/desktop/src/renderer/src/features/workspace-agent/services/desktopAgentGUIOpenSessionActivation.test.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-agent/services/desktopAgentGUIOpenSessionActivation.test.ts
@@ -129,3 +129,49 @@ test("consumeDesktopAgentGUIOpenSessionActivation activates and selects the requ
     }
   ]);
 });
+
+test("consumeDesktopAgentGUIOpenSessionActivation reports activation errors after selecting the session", async () => {
+  const error = new Error("session not found");
+  const activationErrors: unknown[] = [];
+  let nodeState: DesktopAgentGUINodeState = {
+    provider: "codex",
+    lastActiveAgentSessionId: "session-1"
+  };
+  const agentActivityRuntime = {
+    async activateSession() {
+      throw error;
+    }
+  } as unknown as Pick<AgentActivityRuntime, "activateSession">;
+
+  const consumed = consumeDesktopAgentGUIOpenSessionActivation({
+    activation: {
+      payload: { agentSessionId: "missing-session" },
+      sequence: 12,
+      type: desktopAgentGUIOpenSessionActivationType
+    },
+    agentActivityRuntime,
+    handledSequence: null,
+    markHandled: () => {},
+    nodeId: "node-1",
+    onActivationError: (input) => {
+      activationErrors.push(input);
+    },
+    onStateChange: () => {},
+    provider: "codex",
+    workspaceId: "workspace-1",
+    updateNodeState: (updater) => {
+      nodeState = updater(nodeState);
+    }
+  });
+
+  await Promise.resolve();
+
+  assert.equal(consumed, true);
+  assert.equal(nodeState.lastActiveAgentSessionId, "missing-session");
+  assert.deepEqual(activationErrors, [
+    {
+      agentSessionId: "missing-session",
+      error
+    }
+  ]);
+});

--- a/apps/desktop/src/renderer/src/features/workspace-agent/services/desktopAgentGUIOpenSessionActivation.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-agent/services/desktopAgentGUIOpenSessionActivation.ts
@@ -18,6 +18,10 @@ export interface ConsumeDesktopAgentGUIOpenSessionActivationInput {
   handledSequence: number | null;
   markHandled(this: void, sequence: number): void;
   nodeId: string;
+  onActivationError?(
+    this: void,
+    input: { agentSessionId: string; error: unknown }
+  ): void;
   onStateChange(this: void, state: DesktopAgentGUIWorkbenchState): void;
   provider: DesktopAgentGUIProvider;
   workspaceId: string;
@@ -34,6 +38,7 @@ export function consumeDesktopAgentGUIOpenSessionActivation({
   handledSequence,
   markHandled,
   nodeId,
+  onActivationError,
   onStateChange,
   provider,
   workspaceId,
@@ -52,7 +57,9 @@ export function consumeDesktopAgentGUIOpenSessionActivation({
       agentSessionId: request.agentSessionId,
       mode: "existing"
     })
-    .catch(() => {});
+    .catch((error: unknown) => {
+      onActivationError?.({ agentSessionId: request.agentSessionId, error });
+    });
   updateNodeState((current) => {
     const next = normalizeDesktopAgentGUINodeState(
       {

--- a/apps/desktop/src/renderer/src/features/workspace-agent/ui/DesktopAgentGUIWorkbenchBody.tsx
+++ b/apps/desktop/src/renderer/src/features/workspace-agent/ui/DesktopAgentGUIWorkbenchBody.tsx
@@ -32,6 +32,7 @@ import type {
   IAgentProviderStatusService
 } from "../services/agentProviderStatusService.interface";
 import { useDesktopPreferencesService } from "@renderer/features/desktop-preferences/ui/useDesktopPreferencesService";
+import { Toast } from "@renderer/lib/toast";
 import type { DesktopAgentComposerDefaults } from "@shared/preferences";
 import type { DesktopRuntimeApi } from "@preload/types";
 import {
@@ -382,6 +383,24 @@ export function DesktopAgentGUIWorkbenchBody({
       };
     });
   }, []);
+  const handleOpenSessionActivationError = useCallback(
+    (input: { agentSessionId: string; error: unknown }) => {
+      Toast.Error(
+        i18n.t("workspace.agentGui.openSessionUnavailableTitle"),
+        i18n.t("workspace.agentGui.openSessionUnavailableDescription")
+      );
+      void runtimeApi?.logTerminalDiagnostic({
+        details: {
+          agentSessionId: input.agentSessionId,
+          error: stringifyDiagnosticError(input.error)
+        },
+        event: "agent.gui.open_session_activation_failed",
+        level: "warn",
+        workspaceId
+      });
+    },
+    [i18n, runtimeApi, workspaceId]
+  );
 
   useEffect(() => {
     if (previewMode) {
@@ -473,6 +492,7 @@ export function DesktopAgentGUIWorkbenchBody({
         handledOpenSessionActivationSequenceRef.current = sequence;
       },
       nodeId: context.node.id,
+      onActivationError: handleOpenSessionActivationError,
       onStateChange,
       provider,
       workspaceId,
@@ -483,6 +503,7 @@ export function DesktopAgentGUIWorkbenchBody({
     context.activation,
     context.host,
     context.node.id,
+    handleOpenSessionActivationError,
     onStateChange,
     provider,
     workspaceId

--- a/apps/desktop/src/shared/i18n/locales/en.ts
+++ b/apps/desktop/src/shared/i18n/locales/en.ts
@@ -128,7 +128,10 @@ export const en = {
     agentGui: {
       collapseConversationRail: "Collapse session list",
       expandConversationRail: "Expand session list",
-      fallbackAgentLabel: "Agent"
+      fallbackAgentLabel: "Agent",
+      openSessionUnavailableDescription:
+        "This agent session no longer exists or cannot be opened.",
+      openSessionUnavailableTitle: "Session unavailable"
     },
     agentMessageCenter: {
       openAria: "Open agent messages",
@@ -282,8 +285,7 @@ export const en = {
           "We couldn't update the sleep prevention setting right now.",
         updateChannelSaveFailed:
           "We couldn't update the release channel right now.",
-        updatePolicySaveFailed:
-          "We couldn't update the update mode right now.",
+        updatePolicySaveFailed: "We couldn't update the update mode right now.",
         versionLabel: "Desktop version"
       },
       nav: {

--- a/apps/desktop/src/shared/i18n/locales/zh-CN.ts
+++ b/apps/desktop/src/shared/i18n/locales/zh-CN.ts
@@ -126,7 +126,9 @@ export const zhCN = {
     agentGui: {
       collapseConversationRail: "收起会话列表",
       expandConversationRail: "展开会话列表",
-      fallbackAgentLabel: "Agent"
+      fallbackAgentLabel: "Agent",
+      openSessionUnavailableDescription: "这个 Agent 会话已不存在或无法打开。",
+      openSessionUnavailableTitle: "会话不可用"
     },
     agentMessageCenter: {
       openAria: "打开 Agent 消息",


### PR DESCRIPTION
## Summary
- keep issue-manager open-session activation on the requested missing session id so navigation still lands in the agent GUI
- report activation failures to the workbench and show the existing desktop Toast UI instead of swallowing errors
- add localized copy for the missing/unavailable session message

## Verification
- pnpm --filter @tutti-os/desktop test -- src/renderer/src/features/workspace-agent/services/desktopAgentGUIOpenSessionActivation.test.ts
- pnpm check:i18n
- pnpm --filter @tutti-os/desktop typecheck
- pnpm lint:ts
- pnpm --filter @tutti-os/desktop build
- pnpm check:full (pre-push; first run hit a transient Go model-list timeout, targeted rerun passed, second full run passed)
