### PR TITLE
[codex] Optimize app center renders

### DIFF
--- a/apps/desktop/src/renderer/src/features/workspace-app-center/ui/WorkspaceAppCenterPane.tsx
+++ b/apps/desktop/src/renderer/src/features/workspace-app-center/ui/WorkspaceAppCenterPane.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useSyncExternalStore } from "react";
+import { useCallback, useEffect, useMemo, useSyncExternalStore } from "react";
 import type {
   WorkspaceAppCenterApp,
   WorkspaceAppCenterViewState,
@@ -14,7 +14,8 @@ import { createAppCenterI18nRuntime } from "@tutti-os/workspace-app-center/i18n"
 import type {
   AppCenterAppTab,
   AppCenterFactoryProviderConfiguration,
-  AppCenterFactoryProviderOption
+  AppCenterFactoryProviderOption,
+  AppCenterHostActions
 } from "@tutti-os/workspace-app-center/ui";
 import { AppCenterPanel } from "@tutti-os/workspace-app-center/ui";
 import { agentGuiDockIconUrls } from "@tutti-os/agent-gui";
@@ -166,15 +167,6 @@ export function WorkspaceAppCenterPane({
       providers: [...workspaceAgentGuiProviders]
     });
   }, [agentProviderStatusService]);
-  useEffect(() => {
-    if (!state.error) {
-      return;
-    }
-    const error = service.consumeError();
-    if (error) {
-      Toast.Error(error);
-    }
-  }, [service, state.error]);
   const factoryProviderOptions = useMemo(
     () =>
       resolveAppCenterReadyAgentProviderOptions(agentProviderSnapshot.statuses),
@@ -200,6 +192,69 @@ export function WorkspaceAppCenterPane({
         return service.getFactoryProviderConfiguration(provider);
       },
     [service]
+  );
+  const appCenterActions = useMemo<AppCenterHostActions>(
+    () => ({
+      cancelFactoryJob: (jobId) =>
+        service.cancelFactoryJob({ jobId, workspaceId }),
+      createFactoryJob: (input) =>
+        service.createFactoryJob({ ...input, workspaceId }),
+      deleteFactoryJob: (jobId) =>
+        service.deleteFactoryJob({ jobId, workspaceId }),
+      deleteApp: (appId) => service.deleteApp({ appId, workspaceId }),
+      exportApp: (appId) => service.exportApp({ appId, workspaceId }),
+      fixFactoryJob: (jobId, prompt) =>
+        service.fixFactoryJob({ jobId, prompt, workspaceId }),
+      importApp: () => service.importApp({ workspaceId }),
+      installApp: (appId) => service.installApp({ appId, workspaceId }),
+      openApp: (appId) => service.openApp({ appId, workspaceId }),
+      openAppFolder: (appId) => service.openAppFolder({ appId, workspaceId }),
+      openAppPackageFolder: (appId) =>
+        service.openAppPackageFolder({ appId, workspaceId }),
+      openFactoryJobAgentSession: async (agentSessionId, provider) => {
+        await requestWorkspaceAgentGuiLaunch({
+          agentSessionId,
+          provider: normalizeDesktopAgentGUIProvider(provider),
+          workspaceId
+        });
+      },
+      modifyAppWithAgent: async (jobId, agentSessionId, provider) => {
+        const preparedJob = await service.prepareFactoryJobModification({
+          jobId,
+          workspaceId
+        });
+        if (!preparedJob) {
+          return;
+        }
+        await requestWorkspaceAgentGuiLaunch({
+          agentSessionId: preparedJob.agentSessionId ?? agentSessionId,
+          provider: normalizeDesktopAgentGUIProvider(
+            preparedJob.provider ?? provider
+          ),
+          workspaceId
+        });
+      },
+      publishFactoryJob: (jobId) =>
+        service.publishFactoryJob({ jobId, workspaceId }),
+      refreshCatalog: () => service.refreshCatalog(workspaceId),
+      retryFactoryValidation: (jobId) =>
+        service.retryFactoryValidation({ jobId, workspaceId }),
+      retryApp: (appId) => service.retryApp({ appId, workspaceId }),
+      replaceAppIcon: (appId) => service.replaceAppIcon({ appId, workspaceId }),
+      updateApp: (appId, trigger) =>
+        service.updateApp({ appId, trigger, workspaceId }),
+      uninstallApp: (appId) => service.uninstallApp({ appId, workspaceId })
+    }),
+    [service, workspaceId]
+  );
+  const handleActiveAppTabChange = useCallback(
+    (activeAppTab: AppCenterAppTab) => {
+      service.setViewState({
+        state: { activeAppTab },
+        workspaceId
+      });
+    },
+    [service, workspaceId]
   );
   const viewModel = useMemo(() => {
     const recommendedApps = withComingSoonWorkspaceApps(
@@ -250,76 +305,39 @@ export function WorkspaceAppCenterPane({
   ]);
 
   return (
-    <AppCenterPanel
-      actions={{
-        cancelFactoryJob: (jobId) =>
-          service.cancelFactoryJob({ jobId, workspaceId }),
-        createFactoryJob: (input) =>
-          service.createFactoryJob({ ...input, workspaceId }),
-        deleteFactoryJob: (jobId) =>
-          service.deleteFactoryJob({ jobId, workspaceId }),
-        deleteApp: (appId) => service.deleteApp({ appId, workspaceId }),
-        exportApp: (appId) => service.exportApp({ appId, workspaceId }),
-        fixFactoryJob: (jobId, prompt) =>
-          service.fixFactoryJob({ jobId, prompt, workspaceId }),
-        importApp: () => service.importApp({ workspaceId }),
-        installApp: (appId) => service.installApp({ appId, workspaceId }),
-        openApp: (appId) => service.openApp({ appId, workspaceId }),
-        openAppFolder: (appId) => service.openAppFolder({ appId, workspaceId }),
-        openAppPackageFolder: (appId) =>
-          service.openAppPackageFolder({ appId, workspaceId }),
-        openFactoryJobAgentSession: async (agentSessionId, provider) => {
-          await requestWorkspaceAgentGuiLaunch({
-            agentSessionId,
-            provider: normalizeDesktopAgentGUIProvider(provider),
-            workspaceId
-          });
-        },
-        modifyAppWithAgent: async (jobId, agentSessionId, provider) => {
-          const preparedJob = await service.prepareFactoryJobModification({
-            jobId,
-            workspaceId
-          });
-          if (!preparedJob) {
-            return;
-          }
-          await requestWorkspaceAgentGuiLaunch({
-            agentSessionId: preparedJob.agentSessionId ?? agentSessionId,
-            provider: normalizeDesktopAgentGUIProvider(
-              preparedJob.provider ?? provider
-            ),
-            workspaceId
-          });
-        },
-        publishFactoryJob: (jobId) =>
-          service.publishFactoryJob({ jobId, workspaceId }),
-        refreshCatalog: () => service.refreshCatalog(workspaceId),
-        retryFactoryValidation: (jobId) =>
-          service.retryFactoryValidation({ jobId, workspaceId }),
-        retryApp: (appId) => service.retryApp({ appId, workspaceId }),
-        replaceAppIcon: (appId) =>
-          service.replaceAppIcon({ appId, workspaceId }),
-        updateApp: (appId, trigger) =>
-          service.updateApp({ appId, trigger, workspaceId }),
-        uninstallApp: (appId) => service.uninstallApp({ appId, workspaceId })
-      }}
-      activeAppTab={viewState.activeAppTab}
-      catalogStatus={catalogPanelStatus}
-      copy={copy}
-      defaultAgentProvider={agentProviderSnapshot.defaultProvider}
-      loadProviderConfiguration={loadFactoryProviderConfiguration}
-      onActiveAppTabChange={(activeAppTab: AppCenterAppTab) => {
-        service.setViewState({
-          state: { activeAppTab },
-          workspaceId
-        });
-      }}
-      providerErrorMessage={agentProviderSnapshot.error}
-      providerLoading={agentProviderSnapshot.isLoading}
-      providerOptions={factoryProviderOptions}
-      viewModel={viewModel}
-    />
+    <>
+      <WorkspaceAppCenterErrorToast />
+      <AppCenterPanel
+        actions={appCenterActions}
+        activeAppTab={viewState.activeAppTab}
+        catalogStatus={catalogPanelStatus}
+        copy={copy}
+        defaultAgentProvider={agentProviderSnapshot.defaultProvider}
+        loadProviderConfiguration={loadFactoryProviderConfiguration}
+        onActiveAppTabChange={handleActiveAppTabChange}
+        providerErrorMessage={agentProviderSnapshot.error}
+        providerLoading={agentProviderSnapshot.isLoading}
+        providerOptions={factoryProviderOptions}
+        viewModel={viewModel}
+      />
+    </>
   );
+}
+
+function WorkspaceAppCenterErrorToast() {
+  const { service, state } = useWorkspaceAppCenterService();
+
+  useEffect(() => {
+    if (!state.error) {
+      return;
+    }
+    const error = service.consumeError();
+    if (error) {
+      Toast.Error(error);
+    }
+  }, [service, state.error]);
+
+  return null;
 }
 
 function createComingSoonWorkspaceApps(

--- a/packages/workspace/app-center/src/ui/AppCard.tsx
+++ b/packages/workspace/app-center/src/ui/AppCard.tsx
@@ -1,4 +1,5 @@
-import type { ReactElement } from "react";
+import type { KeyboardEvent, ReactElement } from "react";
+import { memo, useCallback, useMemo } from "react";
 import {
   Button,
   ChatIcon,
@@ -109,7 +110,7 @@ export interface AppCardProps {
   readonly copy: AppCenterI18nRuntime;
 }
 
-export function AppCard({
+export const AppCard = memo(function AppCard({
   actions,
   app,
   className,
@@ -141,7 +142,10 @@ export function AppCard({
     app.canOpenFactorySession &&
     !!app.factoryAgentSessionId &&
     !!app.factoryJobId;
-  const actionContext = createWorkspaceAppActionContext(app);
+  const actionContext = useMemo(
+    () => createWorkspaceAppActionContext(app),
+    [app]
+  );
   const hasMoreActions =
     canPublishFactoryUpdate ||
     canOpenFactorySession ||
@@ -151,7 +155,7 @@ export function AppCard({
     app.canOpenFolder ||
     app.canOpenPackageFolder ||
     app.canUninstall;
-  const executePrimaryAction = (): void => {
+  const executePrimaryAction = useCallback((): void => {
     if (app.primaryAction === "retry") {
       void actions.retryApp?.(app.id);
       return;
@@ -167,12 +171,25 @@ export function AppCard({
     if (app.primaryAction === "open") {
       void actions.openApp?.(app.id, actionContext);
     }
-  };
-  const executeCardAction = (): void => {
+  }, [actionContext, actions, app.id, app.primaryAction]);
+  const executeCardAction = useCallback((): void => {
     if (canOpenFromCard) {
       void actions.openApp?.(app.id, actionContext);
     }
-  };
+  }, [actionContext, actions, app.id, canOpenFromCard]);
+  const handleCardKeyDown = useCallback(
+    (event: KeyboardEvent<HTMLElement>): void => {
+      if (!canOpenFromCard || (event.key !== "Enter" && event.key !== " ")) {
+        return;
+      }
+      event.preventDefault();
+      executeCardAction();
+    },
+    [canOpenFromCard, executeCardAction]
+  );
+  const handleReplaceIcon = useCallback((): void => {
+    void actions.replaceAppIcon?.(app.id);
+  }, [actions, app.id]);
 
   return (
     <article
@@ -186,21 +203,13 @@ export function AppCard({
       role="listitem"
       tabIndex={canOpenFromCard ? 0 : -1}
       onClick={executeCardAction}
-      onKeyDown={(event) => {
-        if (!canOpenFromCard || (event.key !== "Enter" && event.key !== " ")) {
-          return;
-        }
-        event.preventDefault();
-        executeCardAction();
-      }}
+      onKeyDown={handleCardKeyDown}
     >
       <div className="flex items-start justify-between gap-3">
         <AppIcon
           app={app}
           replaceIconLabel={copy.t("actions.replaceIcon")}
-          onReplaceIcon={() => {
-            void actions.replaceAppIcon?.(app.id);
-          }}
+          onReplaceIcon={handleReplaceIcon}
         />
         <div className="flex shrink-0 items-center gap-1">
           <div className="flex size-8 shrink-0 items-center justify-center">
@@ -303,7 +312,7 @@ export function AppCard({
       </div>
     </article>
   );
-}
+});
 
 function createWorkspaceAppActionContext(
   app: WorkspaceAppCardViewModel

--- a/packages/workspace/app-center/src/ui/AppCenterPanel.tsx
+++ b/packages/workspace/app-center/src/ui/AppCenterPanel.tsx
@@ -392,43 +392,46 @@ export function AppCenterPanel({
     }
     void actions.openFactoryJobAgentSession?.(agentSessionId, job.provider);
   };
-  const cardActions: AppCenterHostActions = {
-    ...actions,
-    deleteApp: (appId, appName) => {
-      setPendingDeleteApp({
-        id: appId,
-        installed:
-          viewModel.apps.find((app) => app.id === appId)?.installed ?? false,
-        name: appName
-      });
-    },
-    uninstallApp: (appId) => {
-      const app = viewModel.apps.find((item) => item.id === appId);
-      if (!app) {
-        return;
-      }
-      setPendingUninstallApp({
-        id: app.id,
-        name: app.name,
-        sourceKind: app.sourceKind
-      });
-    },
-    updateApp: (appId, trigger) => {
-      const app = viewModel.apps.find((item) => item.id === appId);
-      if (!app) {
-        return;
-      }
-      if (app.installed && app.status === "running") {
-        setPendingUpdateApp({
+  const cardActions = useMemo<AppCenterHostActions>(
+    () => ({
+      ...actions,
+      deleteApp: (appId, appName) => {
+        setPendingDeleteApp({
+          id: appId,
+          installed:
+            viewModel.apps.find((app) => app.id === appId)?.installed ?? false,
+          name: appName
+        });
+      },
+      uninstallApp: (appId) => {
+        const app = viewModel.apps.find((item) => item.id === appId);
+        if (!app) {
+          return;
+        }
+        setPendingUninstallApp({
           id: app.id,
           name: app.name,
-          trigger
+          sourceKind: app.sourceKind
         });
-        return;
+      },
+      updateApp: (appId, trigger) => {
+        const app = viewModel.apps.find((item) => item.id === appId);
+        if (!app) {
+          return;
+        }
+        if (app.installed && app.status === "running") {
+          setPendingUpdateApp({
+            id: app.id,
+            name: app.name,
+            trigger
+          });
+          return;
+        }
+        void actions.updateApp?.(appId, trigger);
       }
-      void actions.updateApp?.(appId, trigger);
-    }
-  };
+    }),
+    [actions, viewModel.apps]
+  );
   const loadingMessage =
     catalogStatus === "loading" ? copy.t("messages.catalogLoading") : null;
   const catalogLoading = catalogStatus === "loading";


### PR DESCRIPTION
## Summary
- stabilize App Center host action props so card renders are not invalidated by parent renders
- memoize the AppCard boundary and its primary handlers
- keep AppCenterPanel card action overrides stable while preserving confirmation-dialog behavior
- move App Center error toast handling into a narrow subscriber component

## Why
A DevTools trace showed AppCard and Radix tooltip/menu trees re-rendering frequently because action objects and handlers were recreated across App Center renders. This keeps the existing Valtio store model but avoids broad prop churn through the card grid.

## Validation
- pnpm --filter @tutti-os/workspace-app-center typecheck
- pnpm --filter @tutti-os/desktop typecheck
- pnpm lint:ts
- pnpm --filter @tutti-os/desktop build
- pnpm check:full (pre-push)

## Notes
- Did not re-record a DevTools trace after the change.