### PR TITLE
[codex] sync app update and workspace agent workflows

### DIFF
--- a/apps/desktop/src/main/developerLogs.test.ts
+++ b/apps/desktop/src/main/developerLogs.test.ts
@@ -705,9 +705,7 @@ test("developer logs service does not clear generated diagnostics", async () => 
 
   assert.equal(exportResult.fileCount, 6);
   assert.ok(exportResult.filePath !== null);
-  const zipText = (await readFile(exportResult.filePath, "utf8")).toString(
-    "utf8"
-  );
+  const zipText = await readFile(exportResult.filePath, "utf8");
   assert.equal(
     zipText.includes(
       "agent-sessions/codex/workspace-1/agent-codex/manifest.json"

--- a/apps/desktop/src/main/developerLogs.test.ts
+++ b/apps/desktop/src/main/developerLogs.test.ts
@@ -704,7 +704,10 @@ test("developer logs service does not clear generated diagnostics", async () => 
   await assert.rejects(() => stat(appLogPath));
 
   assert.equal(exportResult.fileCount, 6);
-  const zipText = (await readFile(exportResult.filePath)).toString("utf8");
+  assert.ok(exportResult.filePath !== null);
+  const zipText = (await readFile(exportResult.filePath, "utf8")).toString(
+    "utf8"
+  );
   assert.equal(
     zipText.includes(
       "agent-sessions/codex/workspace-1/agent-codex/manifest.json"

--- a/apps/desktop/src/main/developerLogs.test.ts
+++ b/apps/desktop/src/main/developerLogs.test.ts
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
-import { mkdir, readFile, writeFile } from "node:fs/promises";
-import { join } from "node:path";
+import { mkdir, readFile, stat, writeFile } from "node:fs/promises";
+import { dirname, join } from "node:path";
 import { tmpdir } from "node:os";
 import test from "node:test";
 import { createDeveloperLogsService } from "./developerLogs.ts";
@@ -53,7 +53,7 @@ test("developer logs service summarizes managed desktop and daemon logs", async 
   );
 });
 
-test("developer logs service truncates active logs and removes rotated logs", async () => {
+test("developer logs service truncates active logs, removes rotated logs, and clears app and factory logs", async () => {
   const root = join(tmpdir(), `tutti-developer-clear-${Date.now()}`);
   await mkdir(root, { recursive: true });
   const logsDir = join(root, "logs");
@@ -62,9 +62,31 @@ test("developer logs service truncates active logs and removes rotated logs", as
   const daemonPath = join(logsDir, "tuttid.log");
   const desktopPath = join(logsDir, "tutti-desktop.log");
   const rotatedPath = join(logsDir, "tutti-desktop.2026-05-23.log");
+  const appLogPath = join(
+    root,
+    "apps",
+    "workspaces",
+    "workspace-1",
+    "app.alpha",
+    "logs",
+    "runtime.log"
+  );
+  const factoryLogPath = join(
+    root,
+    "apps",
+    "factory",
+    "jobs",
+    "job-1",
+    "logs",
+    "factory.log"
+  );
+  await mkdir(dirname(appLogPath), { recursive: true });
+  await mkdir(dirname(factoryLogPath), { recursive: true });
   await writeFile(daemonPath, "daemon-live");
   await writeFile(desktopPath, "desktop-live");
   await writeFile(rotatedPath, "rotated-history");
+  await writeFile(appLogPath, "app-runtime");
+  await writeFile(factoryLogPath, "factory-runtime");
 
   const service = createDeveloperLogsService({
     defaults: {
@@ -88,7 +110,7 @@ test("developer logs service truncates active logs and removes rotated logs", as
   const result = await service.clearLogs();
   const after = await service.getLogsState();
 
-  assert.equal(result.clearedFiles, 3);
+  assert.equal(result.clearedFiles, 5);
   assert.equal(after.totalFiles, 2);
   assert.equal(after.totalSizeBytes, 0);
   assert.deepEqual(
@@ -589,4 +611,105 @@ test("developer logs service treats .LOG files as managed logs", async () => {
     state.totalSizeBytes,
     "daemon-upper".length + "desktop-rotated-upper".length
   );
+});
+
+test("developer logs service does not clear generated diagnostics", async () => {
+  const root = join(tmpdir(), `tutti-developer-clear-generated-${Date.now()}`);
+  await mkdir(root, { recursive: true });
+  const logsDir = join(root, "logs");
+  const downloadsDir = join(root, "downloads");
+  const appLogPath = join(
+    root,
+    "apps",
+    "workspaces",
+    "workspace-1",
+    "app.alpha",
+    "logs",
+    "events.jsonl"
+  );
+  await mkdir(logsDir, { recursive: true });
+  await mkdir(downloadsDir, { recursive: true });
+  await mkdir(dirname(appLogPath), { recursive: true });
+
+  const daemonPath = join(logsDir, "tuttid.log");
+  const desktopPath = join(logsDir, "tutti-desktop.log");
+  await writeFile(daemonPath, "daemon-live");
+  await writeFile(desktopPath, "desktop-live");
+  await writeFile(appLogPath, "app-events");
+
+  const workspaceID = "workspace-1";
+  const service = createDeveloperLogsService({
+    agentSessionsProvider: async () => [
+      {
+        agentSessionID: "agent-codex",
+        hasMoreMessages: false,
+        latestMessageVersion: 1,
+        messages: [
+          {
+            agentSessionId: "agent-codex",
+            id: 1,
+            kind: "text",
+            messageId: "codex-message",
+            role: "assistant",
+            version: 1
+          }
+        ],
+        provider: "codex",
+        providerSessionID: "provider-codex",
+        session: {
+          id: "agent-codex",
+          provider: "codex",
+          providerSessionId: "provider-codex",
+          createdAt: "2026-06-10T00:00:00Z",
+          updatedAt: "2026-06-10T00:00:20Z"
+        },
+        updatedAtUnixMS: 20,
+        workspaceID
+      }
+    ],
+    appCenterSnapshotProvider: async () => ({
+      workspaces: [
+        {
+          appFactoryJobsResponse: { jobs: [], workspaceId: workspaceID },
+          appsResponse: { apps: [], workspaceId: workspaceID },
+          workspaceId: workspaceID
+        }
+      ]
+    }),
+    defaults: {
+      state: {
+        desktopLogPath: desktopPath,
+        logsDir,
+        tuttidDBPath: "",
+        tuttidListenerInfoPath: "",
+        tuttidLogPath: daemonPath,
+        tuttidPIDPath: "",
+        rootDir: root,
+        runDir: ""
+      }
+    },
+    desktopVersion: "1.2.3",
+    getDownloadsPath: () => downloadsDir,
+    preferredSystemLanguages: ["en-US"],
+    systemLocale: "en",
+    transportSnapshot: { kind: "unix", socketPath: "/tmp/tutti.sock" }
+  });
+
+  const clearResult = await service.clearLogs();
+  const exportResult = await service.exportLogs();
+
+  assert.equal(clearResult.clearedFiles, 3);
+  assert.equal(await readFile(daemonPath, "utf8"), "");
+  assert.equal(await readFile(desktopPath, "utf8"), "");
+  await assert.rejects(() => stat(appLogPath));
+
+  assert.equal(exportResult.fileCount, 6);
+  const zipText = (await readFile(exportResult.filePath)).toString("utf8");
+  assert.equal(
+    zipText.includes(
+      "agent-sessions/codex/workspace-1/agent-codex/manifest.json"
+    ),
+    true
+  );
+  assert.equal(zipText.includes("app-center-snapshot.json"), true);
 });

--- a/apps/desktop/src/main/developerLogs.ts
+++ b/apps/desktop/src/main/developerLogs.ts
@@ -49,6 +49,37 @@ export interface DeveloperLogsAppCenterSnapshot {
 const managedDesktopLogPrefixes = ["tutti-desktop"];
 const managedDaemonLogPrefixes = ["tuttid"];
 
+type DeveloperDiagnosticsArtifact =
+  | {
+      kind: "file";
+      category: "managed-log" | "workspace-app-log" | "app-factory-log";
+      path: string;
+      archivePath: string;
+      sizeBytes: number;
+      clearable: true;
+      clearMode: "truncate" | "remove";
+    }
+  | {
+      kind: "generated";
+      category: "agent-session";
+      archivePath: string;
+      content: Buffer;
+      sizeBytes: number;
+      clearable: false;
+      agentSessionID: string;
+      path: string;
+      provider: "claude-code" | "codex";
+      workspaceID: string;
+    }
+  | {
+      kind: "generated";
+      category: "app-center-snapshot";
+      archivePath: string;
+      content: Buffer;
+      sizeBytes: number;
+      clearable: false;
+    };
+
 export function createDeveloperLogsService(
   deps: DeveloperLogsDependencies
 ): DeveloperLogsService {
@@ -80,26 +111,24 @@ export class DeveloperLogsService {
   }
 
   async clearLogs(): Promise<ClearDeveloperLogsResult> {
-    const managedFiles = await listManagedLogFiles(
-      this.deps.defaults.state.logsDir
-    );
+    const artifacts = await discoverDeveloperDiagnosticsArtifacts(this.deps);
     let clearedFiles = 0;
     let clearedSizeBytes = 0;
     const clearedPaths: string[] = [];
-    const activePaths = new Set([
-      this.deps.defaults.state.tuttidLogPath,
-      this.deps.defaults.state.desktopLogPath
-    ]);
 
-    for (const file of managedFiles) {
-      if (activePaths.has(file.path)) {
-        await truncate(file.path, 0);
+    for (const artifact of artifacts) {
+      if (!artifact.clearable) {
+        continue;
+      }
+
+      if (artifact.clearMode === "truncate") {
+        await truncate(artifact.path, 0);
       } else {
-        await rm(file.path, { force: true });
+        await rm(artifact.path, { force: true });
       }
       clearedFiles += 1;
-      clearedSizeBytes += file.sizeBytes;
-      clearedPaths.push(file.path);
+      clearedSizeBytes += artifact.sizeBytes;
+      clearedPaths.push(artifact.path);
     }
 
     return {
@@ -111,36 +140,34 @@ export class DeveloperLogsService {
 
   async exportLogs(savePath?: string): Promise<ExportDeveloperLogsResult> {
     await this.deps.flushLogs?.();
-    const managedFiles = await listManagedLogFiles(
-      this.deps.defaults.state.logsDir
+    const artifacts = await discoverDeveloperDiagnosticsArtifacts(this.deps);
+    const fileArtifacts = artifacts.filter(
+      (
+        artifact
+      ): artifact is Extract<DeveloperDiagnosticsArtifact, { kind: "file" }> =>
+        artifact.kind === "file"
     );
-    const appLogFiles = await listWorkspaceAppLogFiles(
-      this.deps.defaults.state.rootDir
+    const generatedArtifacts = artifacts.filter(
+      (
+        artifact
+      ): artifact is Extract<
+        DeveloperDiagnosticsArtifact,
+        { kind: "generated" }
+      > => artifact.kind === "generated"
     );
-    const appFactoryLogFiles = await listAppFactoryLogFiles(
-      this.deps.defaults.state.rootDir
+    const agentSessionArtifacts = generatedArtifacts.filter(
+      (
+        artifact
+      ): artifact is Extract<
+        DeveloperDiagnosticsArtifact,
+        { category: "agent-session" }
+      > => artifact.category === "agent-session"
     );
-    const agentSessions = await this.deps
-      .agentSessionsProvider?.()
-      .catch(() => []);
-    const agentSessionFiles = buildProviderAgentSessionRecordFiles(
-      agentSessions ?? []
+    const appCenterSnapshotIncluded = generatedArtifacts.some(
+      (artifact) => artifact.category === "app-center-snapshot"
     );
-    const appCenterSnapshot = await this.deps
-      .appCenterSnapshotProvider?.()
-      .catch(() => null);
-    const logFiles = [
-      ...managedFiles.map((file) => ({
-        ...file,
-        archivePath: joinZipPath("logs", basename(file.path))
-      })),
-      ...appLogFiles,
-      ...appFactoryLogFiles
-    ];
-    if (
-      logFiles.length + agentSessionFiles.length === 0 &&
-      !appCenterSnapshot
-    ) {
+
+    if (artifacts.length === 0) {
       return {
         canceled: false,
         fileCount: 0,
@@ -169,25 +196,31 @@ export class DeveloperLogsService {
 
     zipFile.outputStream.pipe(output);
 
-    for (const file of logFiles) {
-      const content = await readFile(file.path);
-      zipFile.addBuffer(content, file.archivePath);
+    for (const artifact of fileArtifacts) {
+      const content = await readFile(artifact.path);
+      zipFile.addBuffer(content, artifact.archivePath);
     }
-    for (const file of agentSessionFiles) {
-      zipFile.addBuffer(file.content, file.archivePath);
-    }
-    if (appCenterSnapshot) {
-      zipFile.addBuffer(
-        Buffer.from(JSON.stringify(appCenterSnapshot, null, 2), "utf8"),
-        "app-center-snapshot.json"
-      );
+    for (const artifact of generatedArtifacts) {
+      zipFile.addBuffer(artifact.content, artifact.archivePath);
     }
 
     const runtimeContext = buildRuntimeContext({
       defaults: this.deps.defaults,
       desktopVersion: this.deps.desktopVersion,
-      agentSessionFiles,
-      logFiles,
+      agentSessionFiles: agentSessionArtifacts.map((artifact) => ({
+        agentSessionID: artifact.agentSessionID,
+        archivePath: artifact.archivePath,
+        content: artifact.content,
+        path: artifact.path,
+        provider: artifact.provider,
+        sizeBytes: artifact.sizeBytes,
+        workspaceID: artifact.workspaceID
+      })),
+      logFiles: fileArtifacts.map((artifact) => ({
+        archivePath: artifact.archivePath,
+        path: artifact.path,
+        sizeBytes: artifact.sizeBytes
+      })),
       persistedLocale: this.deps.persistedLocale ?? null,
       preferredSystemLanguages: this.deps.preferredSystemLanguages ?? null,
       systemLocale: this.deps.systemLocale ?? null,
@@ -206,15 +239,22 @@ export class DeveloperLogsService {
             desktopVersion: this.deps.desktopVersion,
             exportedAt: new Date().toISOString(),
             logsDir: this.deps.defaults.state.logsDir,
-            agentSessionFileCount: agentSessionFiles.length,
-            appCenterSnapshotIncluded: appCenterSnapshot !== null,
-            appFactoryLogFileCount: appFactoryLogFiles.length,
-            appLogFileCount: appLogFiles.length,
-            fileCount: logFiles.length + agentSessionFiles.length,
-            managedLogFileCount: managedFiles.length,
-            totalSizeBytes:
-              logFiles.reduce((sum, file) => sum + file.sizeBytes, 0) +
-              agentSessionFiles.reduce((sum, file) => sum + file.sizeBytes, 0)
+            agentSessionFileCount: agentSessionArtifacts.length,
+            appCenterSnapshotIncluded,
+            appFactoryLogFileCount: fileArtifacts.filter(
+              (artifact) => artifact.category === "app-factory-log"
+            ).length,
+            appLogFileCount: fileArtifacts.filter(
+              (artifact) => artifact.category === "workspace-app-log"
+            ).length,
+            fileCount: fileArtifacts.length + generatedArtifacts.length,
+            managedLogFileCount: fileArtifacts.filter(
+              (artifact) => artifact.category === "managed-log"
+            ).length,
+            totalSizeBytes: artifacts.reduce(
+              (sum, artifact) => sum + artifact.sizeBytes,
+              0
+            )
           },
           null,
           2
@@ -229,7 +269,7 @@ export class DeveloperLogsService {
 
     return {
       canceled: false,
-      fileCount: logFiles.length + agentSessionFiles.length,
+      fileCount: fileArtifacts.length + generatedArtifacts.length,
       filePath: targetPath
     };
   }
@@ -295,8 +335,98 @@ interface ManagedLogFile {
   sizeBytes: number;
 }
 
-interface ExportedLogFile extends ManagedLogFile {
+interface DiscoveredLogFile extends ManagedLogFile {
   archivePath: string;
+}
+
+async function discoverDeveloperDiagnosticsArtifacts(
+  deps: DeveloperLogsDependencies
+): Promise<DeveloperDiagnosticsArtifact[]> {
+  const activeManagedLogPaths = new Set([
+    deps.defaults.state.tuttidLogPath,
+    deps.defaults.state.desktopLogPath
+  ]);
+  const managedFiles = await listManagedLogFiles(deps.defaults.state.logsDir);
+  const appLogFiles = await listWorkspaceAppLogFiles(
+    deps.defaults.state.rootDir
+  );
+  const appFactoryLogFiles = await listAppFactoryLogFiles(
+    deps.defaults.state.rootDir
+  );
+  const agentSessions = await deps.agentSessionsProvider?.().catch(() => []);
+  const agentSessionFiles = buildProviderAgentSessionRecordFiles(
+    agentSessions ?? []
+  );
+  const appCenterSnapshot = await deps
+    .appCenterSnapshotProvider?.()
+    .catch(() => null);
+
+  const artifacts: DeveloperDiagnosticsArtifact[] = [
+    ...managedFiles.map(
+      (file): DeveloperDiagnosticsArtifact => ({
+        kind: "file",
+        category: "managed-log",
+        path: file.path,
+        archivePath: joinZipPath("logs", basename(file.path)),
+        sizeBytes: file.sizeBytes,
+        clearable: true,
+        clearMode: activeManagedLogPaths.has(file.path) ? "truncate" : "remove"
+      })
+    ),
+    ...appLogFiles.map(
+      (file): DeveloperDiagnosticsArtifact => ({
+        kind: "file",
+        category: "workspace-app-log",
+        path: file.path,
+        archivePath: file.archivePath,
+        sizeBytes: file.sizeBytes,
+        clearable: true,
+        clearMode: "remove"
+      })
+    ),
+    ...appFactoryLogFiles.map(
+      (file): DeveloperDiagnosticsArtifact => ({
+        kind: "file",
+        category: "app-factory-log",
+        path: file.path,
+        archivePath: file.archivePath,
+        sizeBytes: file.sizeBytes,
+        clearable: true,
+        clearMode: "remove"
+      })
+    ),
+    ...agentSessionFiles.map(
+      (file): DeveloperDiagnosticsArtifact => ({
+        kind: "generated",
+        category: "agent-session",
+        archivePath: file.archivePath,
+        content: file.content,
+        sizeBytes: file.sizeBytes,
+        clearable: false,
+        agentSessionID: file.agentSessionID,
+        path: file.path,
+        provider: file.provider,
+        workspaceID: file.workspaceID
+      })
+    )
+  ];
+
+  if (appCenterSnapshot) {
+    const content = Buffer.from(
+      JSON.stringify(appCenterSnapshot, null, 2),
+      "utf8"
+    );
+    artifacts.push({
+      kind: "generated",
+      category: "app-center-snapshot",
+      archivePath: "app-center-snapshot.json",
+      content,
+      sizeBytes: content.byteLength,
+      clearable: false
+    });
+  }
+
+  return artifacts;
 }
 
 export function createDefaultDeveloperLogsExportFileName(
@@ -313,7 +443,7 @@ interface BuildRuntimeContextInput {
   defaults: Pick<DesktopResolvedDefaults, "state">;
   desktopVersion: string;
   agentSessionFiles: ExportedAgentSessionFile[];
-  logFiles: ExportedLogFile[];
+  logFiles: DiscoveredLogFile[];
   persistedLocale: string | null;
   preferredSystemLanguages: readonly string[] | null;
   systemLocale: string | null;
@@ -478,7 +608,7 @@ async function listManagedLogFiles(logsDir: string): Promise<ManagedLogFile[]> {
 
 async function listWorkspaceAppLogFiles(
   stateRootDir: string
-): Promise<ExportedLogFile[]> {
+): Promise<DiscoveredLogFile[]> {
   const appWorkspacesDir = join(stateRootDir, "apps", "workspaces");
   let workspaceEntries: Dirent[];
   try {
@@ -522,8 +652,8 @@ async function listWorkspaceAppLogDirFiles(input: {
   appID: string;
   logsDir: string;
   workspaceID: string;
-}): Promise<ExportedLogFile[]> {
-  const files: ExportedLogFile[] = [];
+}): Promise<DiscoveredLogFile[]> {
+  const files: DiscoveredLogFile[] = [];
   const pending = [input.logsDir];
 
   while (pending.length > 0) {
@@ -578,7 +708,7 @@ async function listWorkspaceAppLogDirFiles(input: {
 
 async function listAppFactoryLogFiles(
   stateRootDir: string
-): Promise<ExportedLogFile[]> {
+): Promise<DiscoveredLogFile[]> {
   const factoryJobsDir = join(stateRootDir, "apps", "factory", "jobs");
   let jobEntries: Dirent[];
   try {
@@ -604,8 +734,8 @@ async function listAppFactoryLogFiles(
 async function listAppFactoryJobLogDirFiles(input: {
   jobID: string;
   logsDir: string;
-}): Promise<ExportedLogFile[]> {
-  const files: ExportedLogFile[] = [];
+}): Promise<DiscoveredLogFile[]> {
+  const files: DiscoveredLogFile[] = [];
   const pending = [input.logsDir];
 
   while (pending.length > 0) {

--- a/apps/desktop/src/main/update/appUpdateService.test.ts
+++ b/apps/desktop/src/main/update/appUpdateService.test.ts
@@ -1,5 +1,6 @@
 import assert from "node:assert/strict";
 import test from "node:test";
+import type { ProgressInfo } from "electron-updater";
 import type { UpdateDownloadedEvent, UpdateInfo } from "electron-updater";
 import {
   createAppUpdateService,
@@ -199,6 +200,61 @@ test("createElectronUpdaterLogger defers no published versions errors during pre
         "electron updater error deferred for prefixed GitHub release fallback"
     }
   ]);
+});
+
+test("createAppUpdateService skips identical consecutive download progress states", async () => {
+  const progressListeners = new Set<(progress: ProgressInfo) => void>();
+  let stateChangeCount = 0;
+  const driver = createFakeDriver({
+    onDownloadProgress(listener) {
+      progressListeners.add(listener);
+      return () => progressListeners.delete(listener);
+    }
+  });
+  const service = createAppUpdateService(driver, {
+    supportsUpdates: true
+  });
+
+  try {
+    service.onStateChanged(() => {
+      stateChangeCount += 1;
+    });
+    await service.configure({
+      channel: "stable",
+      policy: "prompt"
+    });
+
+    const progress: ProgressInfo = {
+      bytesPerSecond: 1_000,
+      delta: 100,
+      percent: 10,
+      total: 1_000,
+      transferred: 100
+    };
+    for (const listener of progressListeners) {
+      listener(progress);
+    }
+    stateChangeCount = 0;
+
+    for (const listener of progressListeners) {
+      listener(progress);
+      listener(progress);
+    }
+    assert.equal(stateChangeCount, 0);
+
+    const nextProgress: ProgressInfo = {
+      ...progress,
+      delta: 100,
+      percent: 20,
+      transferred: 200
+    };
+    for (const listener of progressListeners) {
+      listener(nextProgress);
+    }
+    assert.equal(stateChangeCount, 1);
+  } finally {
+    service.dispose();
+  }
 });
 
 function createUpdateInfoFixture(version: string): UpdateInfo {

--- a/apps/desktop/src/main/update/appUpdateService.ts
+++ b/apps/desktop/src/main/update/appUpdateService.ts
@@ -5,6 +5,7 @@ import electronUpdater, {
   type UpdateDownloadedEvent,
   type UpdateInfo
 } from "electron-updater";
+import { isSameAppUpdateState } from "../../shared/contracts/appUpdateState.ts";
 import {
   desktopIpcChannels,
   type AppUpdateChannel,
@@ -481,6 +482,10 @@ export function createAppUpdateService(
   };
 
   const applyState = (nextState: AppUpdateState): AppUpdateState => {
+    if (isSameAppUpdateState(state, nextState)) {
+      return state;
+    }
+
     const previousState = state;
     state = nextState;
     emitState();

--- a/apps/desktop/src/renderer/src/features/app-update/services/internal/appUpdateService.test.ts
+++ b/apps/desktop/src/renderer/src/features/app-update/services/internal/appUpdateService.test.ts
@@ -84,6 +84,53 @@ test("AppUpdateService keeps install action pending after IPC succeeds", async (
   assert.equal(service.store.view.busy, true);
 });
 
+test("AppUpdateService skips redundant subscription states", async () => {
+  const diagnosticEvents: string[] = [];
+  let emitState: ((state: AppUpdateState) => void) | null = null;
+  const service = new AppUpdateService(
+    createClient({
+      getState: async () =>
+        createState({
+          downloadPercent: 5,
+          downloadedBytes: 50,
+          status: "downloading"
+        }),
+      onState(listener) {
+        emitState = listener;
+        return () => {};
+      }
+    }),
+    null,
+    undefined,
+    {
+      async logRendererDiagnostic(input) {
+        diagnosticEvents.push(input.event);
+      }
+    }
+  );
+
+  await service.load();
+  diagnosticEvents.length = 0;
+
+  const nextState = createState({
+    downloadPercent: 10,
+    downloadedBytes: 100,
+    status: "downloading"
+  });
+  const emit = emitState as ((state: AppUpdateState) => void) | null;
+  assert.ok(emit);
+  emit(nextState);
+  emit(nextState);
+
+  assert.deepEqual(
+    diagnosticEvents.filter((event) => event === "app_update.state_applied"),
+    ["app_update.state_applied"]
+  );
+  assert.ok(
+    !diagnosticEvents.includes("app_update.subscription_state_received")
+  );
+});
+
 test("AppUpdateService reports when load state is skipped after disposal", async () => {
   const diagnosticEvents: string[] = [];
   let resolveGetState: ((state: AppUpdateState) => void) | null = null;

--- a/apps/desktop/src/renderer/src/features/app-update/services/internal/appUpdateService.ts
+++ b/apps/desktop/src/renderer/src/features/app-update/services/internal/appUpdateService.ts
@@ -2,6 +2,7 @@ import { getActiveLocale } from "../../../../i18n/runtime.ts";
 import { AppUpdateActionClickedReporter } from "../../../analytics/reporters/app-update-action-clicked/appUpdateActionClickedReporter.ts";
 import type { IReporterService } from "../../../analytics/services/reporterService.interface.ts";
 import { resolveDesktopErrorMessage } from "../../../../lib/desktopErrors.ts";
+import { isSameAppUpdateState } from "../../../../../../shared/contracts/appUpdateState.ts";
 import type { AppUpdateState } from "@shared/contracts/ipc";
 import type { DesktopRuntimeApi } from "@preload/types";
 import type { IAppUpdateService } from "../appUpdateService.interface";
@@ -192,9 +193,7 @@ export class AppUpdateService implements IAppUpdateService {
 
     this.recordDiagnostic("app_update.subscription_started");
     this.unsubscribe = this.updateClient.onState((updateState) => {
-      if (this.applyUpdateState(updateState)) {
-        this.recordDiagnostic("app_update.subscription_state_received");
-      }
+      this.applyUpdateState(updateState);
     });
   }
 
@@ -210,6 +209,13 @@ export class AppUpdateService implements IAppUpdateService {
         },
         "warn"
       );
+      return false;
+    }
+
+    if (
+      this.store.updateState &&
+      isSameAppUpdateState(this.store.updateState, updateState)
+    ) {
       return false;
     }
 

--- a/apps/desktop/src/renderer/src/features/app-update/services/registerAppUpdateServices.test.ts
+++ b/apps/desktop/src/renderer/src/features/app-update/services/registerAppUpdateServices.test.ts
@@ -50,7 +50,6 @@ test("registerAppUpdateServices hydrates update state immediately", async () => 
     "app_update.service_registered",
     "app_update.load_started",
     "app_update.subscription_started",
-    "app_update.state_normalized",
     "app_update.state_applied",
     "app_update.load_succeeded"
   ]);

--- a/apps/desktop/src/renderer/src/features/app-update/services/registerAppUpdateServices.ts
+++ b/apps/desktop/src/renderer/src/features/app-update/services/registerAppUpdateServices.ts
@@ -24,17 +24,7 @@ export function registerAppUpdateServices(
     .catch(() => undefined);
 
   const service = new AppUpdateService(
-    createDesktopAppUpdateClient(desktopApi.update, {
-      logStateNormalized(details) {
-        void desktopApi.runtime
-          ?.logRendererDiagnostic({
-            details,
-            event: "app_update.state_normalized",
-            source: "app-update"
-          })
-          .catch(() => undefined);
-      }
-    }),
+    createDesktopAppUpdateClient(desktopApi.update),
     input.reporterService ?? null,
     undefined,
     desktopApi.runtime

--- a/apps/desktop/src/renderer/src/features/app-update/ui/AppUpdateStatus.tsx
+++ b/apps/desktop/src/renderer/src/features/app-update/ui/AppUpdateStatus.tsx
@@ -15,10 +15,6 @@ export function AppUpdateStatus({
   const { t } = useTranslation();
   const { service, state } = useAppUpdateService();
 
-  useEffect(() => {
-    void service.load();
-  }, [service]);
-
   const view = state.view;
 
   if (!view.visible || !view.titleKey) {

--- a/apps/desktop/src/renderer/src/features/workspace-agent/services/desktopAgentGUIOpenSessionActivation.test.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-agent/services/desktopAgentGUIOpenSessionActivation.test.ts
@@ -38,6 +38,7 @@ test("consumeDesktopAgentGUIOpenSessionActivation activates and selects the requ
   const activated: unknown[] = [];
   const cleared: unknown[] = [];
   const handled: number[] = [];
+  const openSessionRequests: unknown[] = [];
   const stateChanges: DesktopAgentGUIWorkbenchState[] = [];
   let nodeState: DesktopAgentGUINodeState = {
     provider: "codex",
@@ -65,6 +66,9 @@ test("consumeDesktopAgentGUIOpenSessionActivation activates and selects the requ
       handled.push(sequence);
     },
     nodeId: "node-1",
+    onOpenSessionRequest: (request) => {
+      openSessionRequests.push(request);
+    },
     onStateChange: (state) => {
       stateChanges.push(state);
     },
@@ -80,6 +84,12 @@ test("consumeDesktopAgentGUIOpenSessionActivation activates and selects the requ
   assert.equal(consumed, true);
   assert.deepEqual(handled, [11]);
   assert.deepEqual(cleared, [{ nodeId: "node-1", sequence: 11 }]);
+  assert.deepEqual(openSessionRequests, [
+    {
+      agentSessionId: "session-2",
+      sequence: 11
+    }
+  ]);
   assert.deepEqual(activated, [
     {
       workspaceId: "workspace-1",
@@ -128,11 +138,18 @@ test("consumeDesktopAgentGUIOpenSessionActivation activates and selects the requ
       mode: "existing"
     }
   ]);
+  assert.deepEqual(openSessionRequests, [
+    {
+      agentSessionId: "session-2",
+      sequence: 11
+    }
+  ]);
 });
 
 test("consumeDesktopAgentGUIOpenSessionActivation reports activation errors after selecting the session", async () => {
   const error = new Error("session not found");
   const activationErrors: unknown[] = [];
+  const openSessionRequests: unknown[] = [];
   let nodeState: DesktopAgentGUINodeState = {
     provider: "codex",
     lastActiveAgentSessionId: "session-1"
@@ -156,6 +173,9 @@ test("consumeDesktopAgentGUIOpenSessionActivation reports activation errors afte
     onActivationError: (input) => {
       activationErrors.push(input);
     },
+    onOpenSessionRequest: (request) => {
+      openSessionRequests.push(request);
+    },
     onStateChange: () => {},
     provider: "codex",
     workspaceId: "workspace-1",
@@ -167,6 +187,12 @@ test("consumeDesktopAgentGUIOpenSessionActivation reports activation errors afte
   await Promise.resolve();
 
   assert.equal(consumed, true);
+  assert.deepEqual(openSessionRequests, [
+    {
+      agentSessionId: "missing-session",
+      sequence: 12
+    }
+  ]);
   assert.equal(nodeState.lastActiveAgentSessionId, "missing-session");
   assert.deepEqual(activationErrors, [
     {

--- a/apps/desktop/src/renderer/src/features/workspace-agent/services/desktopAgentGUIOpenSessionActivation.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-agent/services/desktopAgentGUIOpenSessionActivation.ts
@@ -22,6 +22,10 @@ export interface ConsumeDesktopAgentGUIOpenSessionActivationInput {
     this: void,
     input: { agentSessionId: string; error: unknown }
   ): void;
+  onOpenSessionRequest?(
+    this: void,
+    request: { agentSessionId: string; sequence: number }
+  ): void;
   onStateChange(this: void, state: DesktopAgentGUIWorkbenchState): void;
   provider: DesktopAgentGUIProvider;
   workspaceId: string;
@@ -39,6 +43,7 @@ export function consumeDesktopAgentGUIOpenSessionActivation({
   markHandled,
   nodeId,
   onActivationError,
+  onOpenSessionRequest,
   onStateChange,
   provider,
   workspaceId,
@@ -51,6 +56,7 @@ export function consumeDesktopAgentGUIOpenSessionActivation({
 
   markHandled(request.sequence);
   clearNodeActivation?.(nodeId, request.sequence);
+  onOpenSessionRequest?.(request);
   void agentActivityRuntime
     .activateSession({
       workspaceId,

--- a/apps/desktop/src/renderer/src/features/workspace-agent/ui/DesktopAgentGUIWorkbenchBody.tsx
+++ b/apps/desktop/src/renderer/src/features/workspace-agent/ui/DesktopAgentGUIWorkbenchBody.tsx
@@ -349,6 +349,9 @@ export function DesktopAgentGUIWorkbenchBody({
   >({});
   const [workspaceAgentProbes, setWorkspaceAgentProbes] =
     useState<DesktopAgentProbeState | null>(null);
+  const [openSessionRequest, setOpenSessionRequest] = useState<NonNullable<
+    AgentGUIProps["openSessionRequest"]
+  > | null>(null);
   const [prefillPromptRequest, setPrefillPromptRequest] =
     useState<DesktopAgentGUIPrefillPromptRequest | null>(null);
   const lastRequestedWorkbenchStateRef =
@@ -493,6 +496,7 @@ export function DesktopAgentGUIWorkbenchBody({
       },
       nodeId: context.node.id,
       onActivationError: handleOpenSessionActivationError,
+      onOpenSessionRequest: setOpenSessionRequest,
       onStateChange,
       provider,
       workspaceId,
@@ -710,6 +714,7 @@ export function DesktopAgentGUIWorkbenchBody({
       isMaximized={context.displayMode === "fullscreen"}
       isActive={context.isFocused}
       composerFocusRequestSequence={composerFocusRequestSequence}
+      openSessionRequest={openSessionRequest}
       prefillPromptRequest={prefillPromptRequest}
       managedAgentsState={managedAgentsState}
       nodeId={context.node.id}

--- a/apps/desktop/src/renderer/src/features/workspace-workbench/services/internal/workspaceAgentGuiContribution.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/services/internal/workspaceAgentGuiContribution.ts
@@ -97,7 +97,7 @@ export function createWorkspaceAgentGuiContribution(input: {
       context,
       dockPreviewCache: input.dockPreviewCache,
       onLinkAction: handleLinkAction,
-      onStateChange: helpers.onStateChange,
+      onStateChange: (...args) => helpers.onStateChange(...args),
       previewMode: options?.previewMode,
       richTextAtProviders: agentGUIWorkbenchHostInput.richTextAtProviders,
       resolveAppIconUrl: input.resolveAppIconUrl,

--- a/apps/desktop/src/renderer/src/features/workspace-workbench/services/internal/workspaceAgentGuiContribution.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/services/internal/workspaceAgentGuiContribution.ts
@@ -68,6 +68,18 @@ export function createWorkspaceAgentGuiContribution(input: {
     workspaceUserProjectService: input.workspaceUserProjectService,
     workspaceId: input.workspaceId
   });
+  const handleLinkAction: NonNullable<
+    Parameters<typeof DesktopAgentGUIWorkbenchBody>[0]["onLinkAction"]
+  > = (action) => {
+    void runDesktopAgentGUILinkAction(action, {
+      homeDirectory: input.platformApi.homeDirectory,
+      launchAgentGui: requestWorkspaceAgentGuiLaunch,
+      launchWorkspaceIssueManager: requestWorkspaceIssueManagerLaunch,
+      launchWorkspaceFiles: requestWorkspaceFilesLaunch,
+      openBrowserUrl: requestWorkspaceBrowserLaunch,
+      workspaceId: input.workspaceId
+    });
+  };
   const renderAgentGuiWorkbenchBody = (
     context: Parameters<
       Parameters<typeof createAgentGuiWorkbenchContribution>[0]["renderBody"]
@@ -84,23 +96,14 @@ export function createWorkspaceAgentGuiContribution(input: {
       agentProviderStatusService: input.agentProviderStatusService,
       context,
       dockPreviewCache: input.dockPreviewCache,
-      onLinkAction: (action) => {
-        void runDesktopAgentGUILinkAction(action, {
-          homeDirectory: input.platformApi.homeDirectory,
-          launchAgentGui: requestWorkspaceAgentGuiLaunch,
-          launchWorkspaceIssueManager: requestWorkspaceIssueManagerLaunch,
-          launchWorkspaceFiles: requestWorkspaceFilesLaunch,
-          openBrowserUrl: requestWorkspaceBrowserLaunch,
-          workspaceId: input.workspaceId
-        });
-      },
-      onStateChange: (state) => helpers.onStateChange(state),
+      onLinkAction: handleLinkAction,
+      onStateChange: helpers.onStateChange,
       previewMode: options?.previewMode,
       richTextAtProviders: agentGUIWorkbenchHostInput.richTextAtProviders,
       resolveAppIconUrl: input.resolveAppIconUrl,
       runtimeApi: input.runtimeApi,
-      trackWorkspaceFileReferences: (referenceInput) =>
-        agentGUIWorkbenchHostInput.trackWorkspaceFileReferences(referenceInput),
+      trackWorkspaceFileReferences:
+        agentGUIWorkbenchHostInput.trackWorkspaceFileReferences,
       workspaceFileReferenceAdapter:
         agentGUIWorkbenchHostInput.workspaceFileReferenceAdapter,
       workspaceId: input.workspaceId

--- a/apps/desktop/src/shared/contracts/appUpdateState.test.ts
+++ b/apps/desktop/src/shared/contracts/appUpdateState.test.ts
@@ -1,0 +1,40 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import type { AppUpdateState } from "./ipc.ts";
+import { isSameAppUpdateState } from "./appUpdateState.ts";
+
+test("isSameAppUpdateState compares all AppUpdateState fields", () => {
+  const base = createState();
+  assert.equal(isSameAppUpdateState(base, { ...base }), true);
+  assert.equal(
+    isSameAppUpdateState(base, createState({ downloadPercent: 42 })),
+    false
+  );
+  assert.equal(
+    isSameAppUpdateState(base, createState({ downloadedBytes: 1024 })),
+    false
+  );
+  assert.equal(
+    isSameAppUpdateState(base, createState({ status: "downloading" })),
+    false
+  );
+});
+
+function createState(overrides: Partial<AppUpdateState> = {}): AppUpdateState {
+  return {
+    channel: "stable",
+    checkedAt: null,
+    currentVersion: "1.0.0",
+    downloadedBytes: null,
+    downloadPercent: null,
+    latestVersion: "1.1.0",
+    message: null,
+    policy: "prompt",
+    releaseDate: null,
+    releaseName: null,
+    releaseNotesUrl: null,
+    status: "available",
+    totalBytes: null,
+    ...overrides
+  };
+}

--- a/apps/desktop/src/shared/contracts/appUpdateState.ts
+++ b/apps/desktop/src/shared/contracts/appUpdateState.ts
@@ -1,0 +1,22 @@
+import type { AppUpdateState } from "./ipc.ts";
+
+export function isSameAppUpdateState(
+  left: AppUpdateState,
+  right: AppUpdateState
+): boolean {
+  return (
+    left.channel === right.channel &&
+    left.checkedAt === right.checkedAt &&
+    left.currentVersion === right.currentVersion &&
+    left.downloadedBytes === right.downloadedBytes &&
+    left.downloadPercent === right.downloadPercent &&
+    left.latestVersion === right.latestVersion &&
+    left.message === right.message &&
+    left.policy === right.policy &&
+    left.releaseDate === right.releaseDate &&
+    left.releaseName === right.releaseName &&
+    left.releaseNotesUrl === right.releaseNotesUrl &&
+    left.status === right.status &&
+    left.totalBytes === right.totalBytes
+  );
+}

--- a/docs/conventions/troubleshooting.md
+++ b/docs/conventions/troubleshooting.md
@@ -567,3 +567,30 @@ information is not available yet`, but `ps` or `lsof` still shows an older
 - References:
   [workspaceFilePreviewNodeController.ts](../../apps/desktop/src/renderer/src/features/workspace-workbench/services/internal/workspaceFilePreviewNodeController.ts)
   [WorkspaceFilePreviewNodeBody.tsx](../../apps/desktop/src/renderer/src/features/workspace-workbench/ui/WorkspaceFilePreviewNodeBody.tsx)
+
+### App update diagnostics flood with identical download progress states
+
+- Symptom:
+  Renderer diagnostics show hundreds of
+  `app_update.state_applied` events per minute during update downloads, often
+  with identical payloads. `AppUpdateStatus` may re-render without visible UI
+  changes.
+- Quick checks:
+  Compare consecutive diagnostic payloads for `status`, `downloadPercent`, and
+  `downloadedBytes`. Inspect whether main-process `applyState` and renderer
+  `applyUpdateState` both commit every IPC event.
+- Root cause:
+  `electron-updater` can emit high-frequency download progress callbacks. Without
+  a shared `AppUpdateState` equality guard at the commit boundary, identical
+  states still emit IPC, write the valtio store, and log diagnostics.
+- Fix:
+  Compare incoming state with the current snapshot via
+  `isSameAppUpdateState()` before committing in both main `applyState` and
+  renderer `applyUpdateState`. Keep diagnostics on successful commits only.
+- Validation:
+  Run desktop app-update tests and confirm repeated identical progress events
+  produce a single state change.
+- References:
+  [appUpdateState.ts](../../apps/desktop/src/shared/contracts/appUpdateState.ts)
+  [appUpdateService.ts](../../apps/desktop/src/main/update/appUpdateService.ts)
+  [appUpdateService.ts](../../apps/desktop/src/renderer/src/features/app-update/services/internal/appUpdateService.ts)

--- a/packages/agent/gui/agent-gui/agentGuiNode/AgentComposer.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/AgentComposer.tsx
@@ -879,7 +879,7 @@ export function AgentComposer({
     [draftContent, onDraftContentChange, promptBeforeSelection, skillQueryMatch]
   );
 
-  const submitCurrentPrompt = (): void => {
+  const submitCurrentPrompt = useStableEventCallback((): void => {
     const canSubmitWhileSending = canQueueWhileBusy && isSendingTurn;
     if (
       isSelectedProjectMissing ||
@@ -925,14 +925,17 @@ export function AgentComposer({
     draftPromptRef.current = "";
     setPaletteDraftPrompt("");
     onDraftContentChange(emptyAgentComposerDraft());
-  };
+  });
 
-  const submit = (event: FormEvent<HTMLFormElement>): void => {
-    event.preventDefault();
-    submitCurrentPrompt();
-  };
+  const submit = useCallback(
+    (event: FormEvent<HTMLFormElement>): void => {
+      event.preventDefault();
+      submitCurrentPrompt();
+    },
+    [submitCurrentPrompt]
+  );
 
-  const handleSlashPaletteKeyDown = useCallback(
+  const handleSlashPaletteKeyDown = useStableEventCallback(
     (event: KeyboardEvent): boolean => {
       if (!showSlashPalette) {
         return false;
@@ -967,14 +970,7 @@ export function AgentComposer({
         return true;
       }
       return false;
-    },
-    [
-      activeHighlight,
-      selectCommand,
-      selectSkill,
-      showSlashPalette,
-      slashPaletteEntries
-    ]
+    }
   );
 
   const selectFileMention = useCallback(
@@ -1205,16 +1201,11 @@ export function AgentComposer({
     ]
   );
 
-  const handlePaletteKeyDown = useCallback(
+  const handlePaletteKeyDown = useStableEventCallback(
     (event: KeyboardEvent): boolean =>
       handleFileMentionKeyDown(event) ||
       handleSlashPaletteKeyDown(event) ||
-      handleModeCycleKeyDown(event),
-    [
-      handleFileMentionKeyDown,
-      handleSlashPaletteKeyDown,
-      handleModeCycleKeyDown
-    ]
+      handleModeCycleKeyDown(event)
   );
 
   useEffect(() => {
@@ -1319,14 +1310,16 @@ export function AgentComposer({
     };
   }, [closeOpenPalette, showPalette]);
 
-  const handleDraftChange = (nextDraft: string): void => {
-    draftPromptRef.current = nextDraft;
-    setPaletteDraftPrompt(nextDraft);
-    setIsPaletteOpen(true);
-    setSubmittedImagePreview([]);
-    submittedImagePreviewObservedBusyRef.current = false;
-    onDraftContentChange({ ...draftContent, prompt: nextDraft });
-  };
+  const handleDraftChange = useStableEventCallback(
+    (nextDraft: string): void => {
+      draftPromptRef.current = nextDraft;
+      setPaletteDraftPrompt(nextDraft);
+      setIsPaletteOpen(true);
+      setSubmittedImagePreview([]);
+      submittedImagePreviewObservedBusyRef.current = false;
+      onDraftContentChange({ ...draftContent, prompt: nextDraft });
+    }
+  );
 
   const addDraftImages = useCallback(
     (images: AgentRichTextPastedImage[]): void => {
@@ -2303,6 +2296,14 @@ export function AgentComposer({
       </div>
     </form>
   );
+}
+
+function useStableEventCallback<Args extends unknown[], Result>(
+  callback: (...args: Args) => Result
+): (...args: Args) => Result {
+  const callbackRef = useRef(callback);
+  callbackRef.current = callback;
+  return useCallback((...args: Args) => callbackRef.current(...args), []);
 }
 
 function SendFilledIcon(): React.JSX.Element {

--- a/packages/agent/gui/agent-gui/agentGuiNode/AgentGUINode.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/AgentGUINode.tsx
@@ -27,7 +27,10 @@ import { WorkspaceNodeWindow } from "../shared/WorkspaceNodeWindow";
 import { CanvasNodeGhostIconButton } from "../shared/CanvasNodeGhostIconButton";
 import { CanvasNodePanelLinedIcon } from "../shared/canvasNodeChromeIcons";
 import { useAgentGUINodeController } from "./controller/useAgentGUINodeController";
-import type { AgentGUIPrefillPromptRequest } from "./controller/useAgentGUINodeController";
+import type {
+  AgentGUIOpenSessionRequest,
+  AgentGUIPrefillPromptRequest
+} from "./controller/useAgentGUINodeController";
 import { AgentGUINodeView, type AgentGUIViewLabels } from "./AgentGUINodeView";
 import {
   normalizeAgentGUIProviderIdentity,
@@ -119,6 +122,7 @@ export interface AgentGUINodeProps {
   isMaximized?: boolean;
   isActive: boolean;
   composerFocusRequestSequence?: number | null;
+  openSessionRequest?: AgentGUIOpenSessionRequest | null;
   prefillPromptRequest?: AgentGUIPrefillPromptRequest | null;
   showProjectSelector?: boolean;
   isMuted?: boolean;
@@ -430,6 +434,7 @@ function areAgentGUINodePropsEqual(
     previous.showProjectSelector === next.showProjectSelector &&
     previous.composerFocusRequestSequence ===
       next.composerFocusRequestSequence &&
+    previous.openSessionRequest === next.openSessionRequest &&
     previous.prefillPromptRequest === next.prefillPromptRequest
   );
 }
@@ -456,6 +461,7 @@ export const AgentGUINode = memo(function AgentGUINode({
   isMaximized = false,
   isActive,
   composerFocusRequestSequence = null,
+  openSessionRequest = null,
   prefillPromptRequest = null,
   showProjectSelector = true,
   isMuted = false,
@@ -604,6 +610,7 @@ export const AgentGUINode = memo(function AgentGUINode({
     workspacePath,
     avoidGroupingEdits: agentSettings.avoidGroupingEdits,
     data: state,
+    openSessionRequest,
     prefillPromptRequest,
     previewMode,
     onDataChange: handleDataChange,

--- a/packages/agent/gui/agent-gui/agentGuiNode/AgentGUINodeView.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/AgentGUINodeView.tsx
@@ -593,6 +593,56 @@ function resolveSlashStatus({
   };
 }
 
+function slashStatusLimitsEqual(
+  left: readonly AgentComposerSlashStatusLimit[] | null | undefined,
+  right: readonly AgentComposerSlashStatusLimit[] | null | undefined
+): boolean {
+  const leftLimits = left ?? [];
+  const rightLimits = right ?? [];
+  return (
+    leftLimits.length === rightLimits.length &&
+    leftLimits.every((limit, index) => {
+      const rightLimit = rightLimits[index]!;
+      return (
+        limit.id === rightLimit.id &&
+        limit.label === rightLimit.label &&
+        (limit.percentRemaining ?? null) ===
+          (rightLimit.percentRemaining ?? null) &&
+        limit.value === rightLimit.value
+      );
+    })
+  );
+}
+
+function slashStatusesEqual(
+  left: AgentComposerSlashStatus,
+  right: AgentComposerSlashStatus
+): boolean {
+  return (
+    (left.agentSessionId ?? null) === (right.agentSessionId ?? null) &&
+    (left.baseUrl ?? null) === (right.baseUrl ?? null) &&
+    (left.contextWindow?.usedTokens ?? null) ===
+      (right.contextWindow?.usedTokens ?? null) &&
+    (left.contextWindow?.totalTokens ?? null) ===
+      (right.contextWindow?.totalTokens ?? null) &&
+    slashStatusLimitsEqual(left.limits, right.limits) &&
+    Boolean(left.limitsLoading) === Boolean(right.limitsLoading)
+  );
+}
+
+function useStableSlashStatus(
+  status: AgentComposerSlashStatus
+): AgentComposerSlashStatus {
+  const statusRef = useRef<AgentComposerSlashStatus | null>(null);
+  if (
+    statusRef.current === null ||
+    !slashStatusesEqual(statusRef.current, status)
+  ) {
+    statusRef.current = status;
+  }
+  return statusRef.current;
+}
+
 function conversationHasActiveWork(
   conversation: AgentConversationVM | null | undefined
 ): boolean {
@@ -1138,7 +1188,7 @@ const AgentGUIDetailPane = memo(function AgentGUIDetailPane({
     () => ({ ...viewModel.sessionChrome, approval: null }),
     [viewModel.sessionChrome]
   );
-  const slashStatus = useMemo(
+  const rawSlashStatus = useMemo(
     () =>
       resolveSlashStatus({
         rawState: viewModel.sessionChrome.rawState,
@@ -1151,6 +1201,7 @@ const AgentGUIDetailPane = memo(function AgentGUIDetailPane({
       viewModel.sessionChrome.rawState
     ]
   );
+  const slashStatus = useStableSlashStatus(rawSlashStatus);
   const displayedInlineNotice = useMemo(() => {
     const inlineNotice = viewModel.inlineNotice;
     const inlineNoticeMessage = inlineNotice?.message.trim() ?? "";

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUINodeController.spec.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUINodeController.spec.tsx
@@ -1282,6 +1282,66 @@ describe("useAgentGUINodeController", () => {
     expect(onDataChange).toHaveBeenCalled();
   });
 
+  it("honors an explicit open-session request after a local conversation switch", async () => {
+    installAgentHostApi({
+      list: vi.fn(async () => ({
+        presences: [],
+        sessions: [
+          workspaceAgentSession("session-1"),
+          workspaceAgentSession("session-2")
+        ]
+      })),
+      listSessionTimeline: vi.fn(async () => ({ timelineItems: [] })),
+      subscribeEvents: vi.fn(() => vi.fn())
+    });
+
+    const { result, rerender } = renderHook(
+      (props) =>
+        useAgentGUINodeController({
+          workspaceId: "room-1",
+          currentUserId: "user-1",
+          workspacePath: "/workspace",
+          avoidGroupingEdits: false,
+          ...props
+        }),
+      {
+        initialProps: {
+          data: agentGuiData("session-1"),
+          onDataChange: vi.fn(),
+          openSessionRequest: null as {
+            agentSessionId: string;
+            sequence: number;
+          } | null
+        }
+      }
+    );
+
+    await waitFor(() => {
+      expect(result.current.viewModel.activeConversationId).toBe("session-1");
+    });
+
+    act(() => {
+      result.current.actions.selectConversation("session-2");
+    });
+
+    await waitFor(() => {
+      expect(result.current.viewModel.activeConversationId).toBe("session-2");
+    });
+
+    rerender({
+      data: agentGuiData("session-1"),
+      onDataChange: vi.fn(),
+      openSessionRequest: {
+        agentSessionId: "session-1",
+        sequence: 1
+      }
+    });
+
+    await waitFor(() => {
+      expect(result.current.viewModel.activeConversationId).toBe("session-1");
+    });
+  });
+
   it("keeps a switched conversation loading while its timeline request is pending", async () => {
     const session2TimelineResolvers: Array<
       (value: { timelineItems: AgentHostWorkspaceAgentTimelineItem[] }) => void

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUINodeController.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUINodeController.ts
@@ -1049,6 +1049,19 @@ function normalizeOptionalPrompt(value: unknown): string {
   return typeof value === "string" ? value.trim() : "";
 }
 
+function normalizeAgentGUIOpenSessionRequest(
+  request: AgentGUIOpenSessionRequest | null | undefined
+): AgentGUIOpenSessionRequest | null {
+  const agentSessionId = request?.agentSessionId.trim() ?? "";
+  if (!agentSessionId || typeof request?.sequence !== "number") {
+    return null;
+  }
+  return {
+    agentSessionId,
+    sequence: request.sequence
+  };
+}
+
 function recordValue(value: unknown): Record<string, unknown> | null {
   return value !== null && typeof value === "object" && !Array.isArray(value)
     ? (value as Record<string, unknown>)
@@ -1143,6 +1156,31 @@ function areProviderSkillOptionListsEqual(
     left.length === right.length &&
     left.every((skill, index) =>
       areProviderSkillOptionsEqual(skill, right[index]!)
+    )
+  );
+}
+
+function areComposerSettingOptionsEqual(
+  left: AgentGUIComposerSettingOption,
+  right: AgentGUIComposerSettingOption
+): boolean {
+  return (
+    left.value === right.value &&
+    left.label === right.label &&
+    left.description === right.description
+  );
+}
+
+function areComposerSettingOptionListsEqual(
+  left: readonly AgentGUIComposerSettingOption[] | null | undefined,
+  right: readonly AgentGUIComposerSettingOption[] | null | undefined
+): boolean {
+  const leftOptions = left ?? [];
+  const rightOptions = right ?? [];
+  return (
+    leftOptions.length === rightOptions.length &&
+    leftOptions.every((option, index) =>
+      areComposerSettingOptionsEqual(option, rightOptions[index]!)
     )
   );
 }
@@ -1379,6 +1417,111 @@ function useStableProviderSkillOptions(
     skillsRef.current = skills;
   }
   return skillsRef.current;
+}
+
+function areComposerSettingsDraftsEqual(
+  left: AgentGUIComposerSettingsVM["draftSettings"],
+  right: AgentGUIComposerSettingsVM["draftSettings"]
+): boolean {
+  return (
+    left.model === right.model &&
+    left.reasoningEffort === right.reasoningEffort &&
+    left.speed === right.speed &&
+    left.planMode === right.planMode &&
+    (left.permissionModeId ?? null) === (right.permissionModeId ?? null)
+  );
+}
+
+function arePermissionModeOptionsEqual(
+  left: AgentSessionPermissionModeOption,
+  right: AgentSessionPermissionModeOption
+): boolean {
+  return (
+    left.id === right.id &&
+    left.label === right.label &&
+    left.description === right.description &&
+    left.semantic === right.semantic
+  );
+}
+
+function arePermissionConfigsEqual(
+  left: AgentSessionPermissionConfig | null | undefined,
+  right: AgentSessionPermissionConfig | null | undefined
+): boolean {
+  if (!left || !right) {
+    return left === right;
+  }
+  return (
+    left.configurable === right.configurable &&
+    (left.defaultValue ?? null) === (right.defaultValue ?? null) &&
+    left.modes.length === right.modes.length &&
+    left.modes.every((mode, index) =>
+      arePermissionModeOptionsEqual(mode, right.modes[index]!)
+    )
+  );
+}
+
+function areComposerSettingsVMsEqual(
+  left: AgentGUIComposerSettingsVM,
+  right: AgentGUIComposerSettingsVM
+): boolean {
+  return (
+    left.sessionSettings === right.sessionSettings &&
+    areComposerSettingsDraftsEqual(left.draftSettings, right.draftSettings) &&
+    (left.effectivePlanMode ?? false) === (right.effectivePlanMode ?? false) &&
+    left.supportsModel === right.supportsModel &&
+    left.supportsReasoningEffort === right.supportsReasoningEffort &&
+    left.supportsSpeed === right.supportsSpeed &&
+    (left.supportsPermissionMode ?? false) ===
+      (right.supportsPermissionMode ?? false) &&
+    left.supportsPlanMode === right.supportsPlanMode &&
+    left.isSettingsLoading === right.isSettingsLoading &&
+    left.modelUnavailable === right.modelUnavailable &&
+    left.reasoningUnavailable === right.reasoningUnavailable &&
+    left.speedUnavailable === right.speedUnavailable &&
+    (left.permissionModeUnavailable ?? false) ===
+      (right.permissionModeUnavailable ?? false) &&
+    left.planUnavailable === right.planUnavailable &&
+    (left.selectedModelValue ?? null) === (right.selectedModelValue ?? null) &&
+    (left.selectedReasoningEffortValue ?? null) ===
+      (right.selectedReasoningEffortValue ?? null) &&
+    (left.selectedSpeedValue ?? null) === (right.selectedSpeedValue ?? null) &&
+    (left.selectedPermissionModeValue ?? null) ===
+      (right.selectedPermissionModeValue ?? null) &&
+    arePermissionConfigsEqual(left.permissionConfig, right.permissionConfig) &&
+    (left.selectedProjectPath ?? null) ===
+      (right.selectedProjectPath ?? null) &&
+    Boolean(left.projectLocked) === Boolean(right.projectLocked) &&
+    areComposerSettingOptionListsEqual(
+      left.availableModels,
+      right.availableModels
+    ) &&
+    areComposerSettingOptionListsEqual(
+      left.availableReasoningEfforts,
+      right.availableReasoningEfforts
+    ) &&
+    areComposerSettingOptionListsEqual(
+      left.availableSpeeds,
+      right.availableSpeeds
+    ) &&
+    areComposerSettingOptionListsEqual(
+      left.availablePermissionModes,
+      right.availablePermissionModes
+    )
+  );
+}
+
+function useStableComposerSettingsVM(
+  settings: AgentGUIComposerSettingsVM
+): AgentGUIComposerSettingsVM {
+  const settingsRef = useRef<AgentGUIComposerSettingsVM | null>(null);
+  if (
+    settingsRef.current === null ||
+    !areComposerSettingsVMsEqual(settingsRef.current, settings)
+  ) {
+    settingsRef.current = settings;
+  }
+  return settingsRef.current;
 }
 
 function useStableControllerEventCallback<Args extends unknown[], Result>(
@@ -1635,7 +1778,7 @@ function readNodeDefaultDraftContent(input: {
   return (
     input.drafts[nodeDefaultDraftContentKey(input.data.provider)] ??
     input.drafts[NODE_DEFAULT_DRAFT_KEY] ??
-    emptyAgentComposerDraft()
+    EMPTY_AGENT_COMPOSER_DRAFT
   );
 }
 
@@ -2008,6 +2151,7 @@ interface UseAgentGUINodeControllerInput {
   workspacePath: string;
   avoidGroupingEdits: boolean;
   data: AgentGUINodeData;
+  openSessionRequest?: AgentGUIOpenSessionRequest | null;
   prefillPromptRequest?: AgentGUIPrefillPromptRequest | null;
   previewMode?: boolean;
   onDataChange: (
@@ -2017,6 +2161,11 @@ interface UseAgentGUINodeControllerInput {
     message: string,
     tone?: "info" | "warning" | "error"
   ) => void;
+}
+
+export interface AgentGUIOpenSessionRequest {
+  agentSessionId: string;
+  sequence: number;
 }
 
 export interface AgentGUIPrefillPromptRequest {
@@ -2032,6 +2181,7 @@ export function useAgentGUINodeController({
   workspacePath,
   avoidGroupingEdits,
   data,
+  openSessionRequest = null,
   prefillPromptRequest = null,
   previewMode = false,
   onDataChange,
@@ -2542,6 +2692,9 @@ export function useAgentGUINodeController({
   const selectedConversationInitialMessagesLoadedIdsRef = useRef(
     new Set<string>()
   );
+  const handledOpenSessionSequenceRef = useRef<number | null>(null);
+  const pendingOpenSessionRequestRef =
+    useRef<AgentGUIOpenSessionRequest | null>(null);
   const stateReloadCauseRef = useRef<{
     source: "activity-stream";
     eventType?: string;
@@ -3315,45 +3468,80 @@ export function useAgentGUINodeController({
   );
 
   useEffect(() => {
+    const normalizedOpenSessionRequest =
+      normalizeAgentGUIOpenSessionRequest(openSessionRequest);
+    if (
+      !previewMode &&
+      normalizedOpenSessionRequest &&
+      handledOpenSessionSequenceRef.current !==
+        normalizedOpenSessionRequest.sequence
+    ) {
+      handledOpenSessionSequenceRef.current =
+        normalizedOpenSessionRequest.sequence;
+      pendingOpenSessionRequestRef.current = normalizedOpenSessionRequest;
+    }
+    const pendingOpenSessionRequest = pendingOpenSessionRequestRef.current;
     const requestedConversationId = data.lastActiveAgentSessionId?.trim() ?? "";
+    const explicitRequestedConversationId =
+      pendingOpenSessionRequest?.agentSessionId.trim() ?? "";
+    const effectiveRequestedConversationId =
+      explicitRequestedConversationId || requestedConversationId;
+    const hasExplicitOpenSessionRequest =
+      explicitRequestedConversationId !== "";
     const requestedConversationExists =
-      requestedConversationId !== ""
+      effectiveRequestedConversationId !== ""
         ? resolveConversationSummaryById(
             conversations,
-            requestedConversationId,
+            effectiveRequestedConversationId,
             transientConversationRef.current
           ) !== null
         : false;
-    if (!requestedConversationId) {
+    if (!effectiveRequestedConversationId) {
       externalConversationReloadAttemptRef.current = null;
       suppressedHomeConversationIdRef.current = null;
       return;
     }
     if (
-      requestedConversationId === activeConversationIdRef.current &&
+      effectiveRequestedConversationId === activeConversationIdRef.current &&
       (!hasLoadedConversations || requestedConversationExists)
     ) {
       externalConversationReloadAttemptRef.current = null;
-      return;
-    }
-    if (suppressedHomeConversationIdRef.current === requestedConversationId) {
+      if (hasExplicitOpenSessionRequest) {
+        pendingOpenSessionRequestRef.current = null;
+      }
       return;
     }
     if (
-      pendingLocalActiveConversationIdRef.current !== null &&
-      requestedConversationId !== pendingLocalActiveConversationIdRef.current &&
-      externalConversationReloadAttemptRef.current !== requestedConversationId
+      !hasExplicitOpenSessionRequest &&
+      suppressedHomeConversationIdRef.current ===
+        effectiveRequestedConversationId
     ) {
       return;
+    }
+    if (
+      !hasExplicitOpenSessionRequest &&
+      pendingLocalActiveConversationIdRef.current !== null &&
+      effectiveRequestedConversationId !==
+        pendingLocalActiveConversationIdRef.current &&
+      externalConversationReloadAttemptRef.current !==
+        effectiveRequestedConversationId
+    ) {
+      return;
+    }
+    if (hasExplicitOpenSessionRequest) {
+      pendingLocalActiveConversationIdRef.current = null;
     }
 
     if (!requestedConversationExists) {
       if (
-        requestedConversationId === activeConversationIdRef.current &&
+        effectiveRequestedConversationId === activeConversationIdRef.current &&
         hasLoadedConversations &&
         conversations.length > 0
       ) {
         externalConversationReloadAttemptRef.current = null;
+        if (hasExplicitOpenSessionRequest) {
+          pendingOpenSessionRequestRef.current = null;
+        }
         const fallbackConversationId = selectAgentGUIConversationId(
           conversations,
           activeConversationIdRef.current
@@ -3367,20 +3555,26 @@ export function useAgentGUINodeController({
       }
       if (
         hasLoadedConversations &&
-        externalConversationReloadAttemptRef.current !== requestedConversationId
+        externalConversationReloadAttemptRef.current !==
+          effectiveRequestedConversationId
       ) {
-        externalConversationReloadAttemptRef.current = requestedConversationId;
-        void syncConversationListProjection(requestedConversationId);
+        externalConversationReloadAttemptRef.current =
+          effectiveRequestedConversationId;
+        void syncConversationListProjection(effectiveRequestedConversationId);
         return;
       }
       if (
         hasLoadedConversations &&
         !isLoadingConversations &&
-        externalConversationReloadAttemptRef.current === requestedConversationId
+        externalConversationReloadAttemptRef.current ===
+          effectiveRequestedConversationId
       ) {
         externalConversationReloadAttemptRef.current = null;
+        if (hasExplicitOpenSessionRequest) {
+          pendingOpenSessionRequestRef.current = null;
+        }
         const fallbackConversationId =
-          isComposerHomeRef.current && !requestedConversationId
+          isComposerHomeRef.current && !effectiveRequestedConversationId
             ? null
             : selectAgentGUIConversationId(
                 conversations,
@@ -3396,12 +3590,18 @@ export function useAgentGUINodeController({
     }
 
     externalConversationReloadAttemptRef.current = null;
-    selectConversation(requestedConversationId, { reloadConversations: false });
+    if (hasExplicitOpenSessionRequest) {
+      pendingOpenSessionRequestRef.current = null;
+    }
+    selectConversation(effectiveRequestedConversationId, {
+      reloadConversations: false
+    });
   }, [
     conversations,
     data.lastActiveAgentSessionId,
     hasLoadedConversations,
     isLoadingConversations,
+    openSessionRequest,
     syncConversationListProjection,
     selectConversation,
     transientConversation
@@ -7552,6 +7752,7 @@ export function useAgentGUINodeController({
     draftReasoningEffort,
     draftSpeed
   ]);
+  const stableComposerSettings = useStableComposerSettingsVM(composerSettings);
 
   const stableCreateConversation =
     useStableControllerEventCallback(createConversation);
@@ -7709,7 +7910,7 @@ export function useAgentGUINodeController({
         activationError,
         openclawGateway,
         canSubmit,
-        composerSettings,
+        composerSettings: stableComposerSettings,
         queuedPrompts,
         drainingQueuedPromptId,
         canQueueWhileBusy,
@@ -7740,7 +7941,6 @@ export function useAgentGUINodeController({
       availableSkills,
       canSubmit,
       canQueueWhileBusy,
-      composerSettings,
       conversation,
       conversationDetail,
       controllerActions,
@@ -7773,6 +7973,7 @@ export function useAgentGUINodeController({
       currentUserId,
       workspaceId,
       workspacePath,
+      stableComposerSettings,
       sessionChrome,
       userProjects,
       visibleConversations

--- a/packages/workbench/surface/src/host/WorkbenchHost.tsx
+++ b/packages/workbench/surface/src/host/WorkbenchHost.tsx
@@ -75,6 +75,7 @@ export function WorkbenchHost({
     missionControlMode !== null || onMissionControlAdapterReady !== undefined;
   const {
     chromeContext,
+    externalStateRevision,
     hostI18n,
     hostSession,
     isHydrating,
@@ -105,6 +106,7 @@ export function WorkbenchHost({
     dockStateSource,
     dockEntries: hostDockEntries,
     externalStateSource: hostRuntimeConfig.externalStateSource,
+    externalStateRevision,
     hostI18n,
     hostSession,
     nodeDefinitionByType,

--- a/packages/workbench/surface/src/host/externalStateRender.test.ts
+++ b/packages/workbench/surface/src/host/externalStateRender.test.ts
@@ -1,0 +1,32 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import test from "node:test";
+
+const runtimeSource = readFileSync(
+  resolve("src/host/useWorkbenchHostRuntime.ts"),
+  "utf8"
+);
+const renderersSource = readFileSync(
+  resolve("src/host/useWorkbenchHostSurfaceRenderers.tsx"),
+  "utf8"
+);
+const hostSource = readFileSync(resolve("src/host/WorkbenchHost.tsx"), "utf8");
+
+test("external state notifications invalidate host node body renderers", () => {
+  assert.match(
+    runtimeSource,
+    /const \[externalStateRevision, bumpExternalStateRevision\] = useState\(0\);/
+  );
+  assert.match(runtimeSource, /externalStateRevision,/);
+  assert.match(hostSource, /externalStateRevision,/);
+  assert.match(renderersSource, /externalStateRevision: number;/);
+  assert.match(
+    renderersSource,
+    /const renderNode = useCallback\([\s\S]*?input\.externalStateRevision,[\s\S]*?input\.hostSession/
+  );
+  assert.match(
+    renderersSource,
+    /const renderWindowHeader = useCallback\([\s\S]*?input\.externalStateRevision,[\s\S]*?input\.hostSession/
+  );
+});

--- a/packages/workbench/surface/src/host/useWorkbenchHostRuntime.ts
+++ b/packages/workbench/surface/src/host/useWorkbenchHostRuntime.ts
@@ -41,7 +41,7 @@ export function useWorkbenchHostRuntime({
   > & {
     missionControlEnabled: boolean;
   }) {
-  const [, bumpExternalStateRevision] = useState(0);
+  const [externalStateRevision, bumpExternalStateRevision] = useState(0);
   const [, bumpHydrationRevision] = useState(0);
   const hostSession = useMemo(() => {
     logWorkbenchHostDebug("create-session", debugDiagnostics, {
@@ -160,6 +160,7 @@ export function useWorkbenchHostRuntime({
 
   return {
     chromeContext,
+    externalStateRevision,
     hostI18n,
     isHydrating,
     hostSession,

--- a/packages/workbench/surface/src/host/useWorkbenchHostSurfaceRenderers.tsx
+++ b/packages/workbench/surface/src/host/useWorkbenchHostSurfaceRenderers.tsx
@@ -44,6 +44,7 @@ export function useWorkbenchHostSurfaceRenderers(input: {
   dockEntries: readonly WorkbenchHostDockEntry[];
   dockStateSource?: WorkbenchHostProps["dockStateSource"];
   externalStateSource?: WorkbenchHostExternalStateSource;
+  externalStateRevision: number;
   hostI18n: WorkbenchHostI18nRuntime;
   hostSession: WorkbenchHostRuntimeHandle;
   nodeDefinitionByType: Map<string, WorkbenchHostNodeDefinition>;
@@ -225,6 +226,7 @@ export function useWorkbenchHostSurfaceRenderers(input: {
     [
       input.debugDiagnostics,
       input.externalStateSource,
+      input.externalStateRevision,
       input.hostSession,
       input.nodeDefinitionByType,
       input.workspaceId
@@ -266,6 +268,7 @@ export function useWorkbenchHostSurfaceRenderers(input: {
     },
     [
       input.externalStateSource,
+      input.externalStateRevision,
       input.hostSession,
       input.nodeDefinitionByType,
       input.workspaceId

--- a/services/tuttid/builtin-apps/automation/server.py
+++ b/services/tuttid/builtin-apps/automation/server.py
@@ -726,9 +726,65 @@ def tutti_cli_command():
     return configured
 
 
+AGENT_GET_POLL_LOG_FIELDS = ("id", "status", "taskStatus", "updatedAt", "lastError")
+AGENT_GET_LOG_OMIT_FIELDS = (
+    "runtimeContext",
+    "messages",
+    "skills",
+    "configOptions",
+    "settings",
+    "permissionConfig",
+)
+
+
+def is_agent_get_poll_args(args):
+    return (
+        len(args) >= 3
+        and args[0] == "agent"
+        and args[1] == "get"
+        and args[2] == "--session-id"
+    )
+
+
+def compact_agent_get_log_stdout(stdout_text):
+    original_bytes = len(stdout_text.encode("utf-8"))
+    try:
+        payload = json.loads(stdout_text)
+    except json.JSONDecodeError:
+        return stdout_text, None
+
+    session = payload.get("session") if isinstance(payload, dict) else None
+    if not isinstance(session, dict):
+        return stdout_text, None
+
+    omitted = [field for field in AGENT_GET_LOG_OMIT_FIELDS if field in session]
+    summary = {field: session.get(field) for field in AGENT_GET_POLL_LOG_FIELDS}
+    compact_json = json.dumps(summary, ensure_ascii=False, indent=2)
+    omitted_text = ",".join(omitted) if omitted else "none"
+    meta_line = (
+        f"[automation] stdout compacted: originalBytes={original_bytes} "
+        f"omitted={omitted_text}\n"
+    )
+    return compact_json + "\n" + meta_line, {
+        "originalBytes": original_bytes,
+        "omitted": omitted,
+    }
+
+
+def write_cli_log_output(log_file, stdout_text, *, compact_stdout=False):
+    if stdout_text:
+        text_to_log = stdout_text
+        if compact_stdout:
+            text_to_log, _meta = compact_agent_get_log_stdout(stdout_text)
+        log_file.write(text_to_log.encode("utf-8"))
+        if not text_to_log.endswith("\n"):
+            log_file.write(b"\n")
+
+
 def run_tutti_cli(args, timeout=60, log_file=None):
     command_path = tutti_cli_command()
     command = [command_path, "--json", *args]
+    compact_stdout = is_agent_get_poll_args(args)
     if log_file:
         log_file.write(("Command: " + " ".join(command) + "\n").encode("utf-8"))
         log_file.flush()
@@ -743,9 +799,11 @@ def run_tutti_cli(args, timeout=60, log_file=None):
         raise RuntimeError(f"TUTTI_CLI executable was not found: {command_path}") from exc
     if log_file:
         if result.stdout:
-            log_file.write(result.stdout.encode("utf-8"))
-            if not result.stdout.endswith("\n"):
-                log_file.write(b"\n")
+            write_cli_log_output(
+                log_file,
+                result.stdout,
+                compact_stdout=compact_stdout and result.returncode == 0,
+            )
         if result.stderr:
             log_file.write(result.stderr.encode("utf-8"))
             if not result.stderr.endswith("\n"):

--- a/services/tuttid/builtin-apps/automation/server_test.py
+++ b/services/tuttid/builtin-apps/automation/server_test.py
@@ -1,5 +1,7 @@
 import importlib.util
+import json
 import os
+import subprocess
 import tempfile
 import unittest
 from pathlib import Path
@@ -286,6 +288,111 @@ def fake_interval_automation(module, next_run_at):
         "schedule": {"intervalMinutes": 15},
         "nextRunAt": next_run_at.isoformat(),
     }
+
+
+class AgentGetLogCompactionTest(unittest.TestCase):
+    def test_compact_agent_get_log_stdout_keeps_poll_summary_only(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            module = load_server_module(Path(temp_dir))
+            stdout = json.dumps(
+                {
+                    "session": {
+                        "id": "agent-session-1",
+                        "status": "running",
+                        "updatedAt": "2026-06-16T12:00:00+00:00",
+                        "lastError": None,
+                        "provider": "codex",
+                        "runtimeContext": {
+                            "skills": [{"name": "skill-a", "description": "x" * 5000}],
+                            "configOptions": [{"id": "model", "currentValue": "gpt-5"}],
+                        },
+                        "messages": [{"role": "assistant", "payload": {"text": "hello"}}],
+                    }
+                }
+            )
+
+            compacted, meta = module.compact_agent_get_log_stdout(stdout)
+
+            self.assertEqual(
+                meta,
+                {
+                    "originalBytes": len(stdout.encode("utf-8")),
+                    "omitted": ["runtimeContext", "messages"],
+                },
+            )
+            self.assertIn('"id": "agent-session-1"', compacted)
+            self.assertIn('"status": "running"', compacted)
+            self.assertIn('"updatedAt": "2026-06-16T12:00:00+00:00"', compacted)
+            self.assertIn('"lastError": null', compacted)
+            self.assertNotIn("skill-a", compacted)
+            summary_json = compacted.split("[automation] stdout compacted:", 1)[0]
+            self.assertNotIn("runtimeContext", summary_json)
+            self.assertNotIn("messages", summary_json)
+            self.assertIn("[automation] stdout compacted:", compacted)
+            self.assertIn("omitted=runtimeContext,messages", compacted)
+
+    def test_run_tutti_cli_compacts_agent_get_poll_stdout_only(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            module = load_server_module(Path(temp_dir))
+            large_stdout = json.dumps(
+                {
+                    "session": {
+                        "id": "agent-session-1",
+                        "status": "running",
+                        "runtimeContext": {"skills": [{"name": "skill-a"}]},
+                    }
+                }
+            )
+            completed = subprocess.CompletedProcess(
+                args=[],
+                returncode=0,
+                stdout=large_stdout,
+                stderr="",
+            )
+
+            with tempfile.NamedTemporaryFile(mode="w+b") as log_file:
+                with mock.patch.object(module.subprocess, "run", return_value=completed):
+                    module.run_tutti_cli(
+                        ["agent", "get", "--session-id", "agent-session-1"],
+                        log_file=log_file,
+                    )
+                log_file.seek(0)
+                log_text = log_file.read().decode("utf-8")
+
+            self.assertIn("Command: /usr/local/bin/tutti --json agent get --session-id agent-session-1", log_text)
+            summary_json = log_text.split("[automation] stdout compacted:", 1)[0]
+            self.assertNotIn("runtimeContext", summary_json)
+            self.assertIn("[automation] stdout compacted:", log_text)
+
+    def test_run_tutti_cli_keeps_full_stdout_for_non_poll_commands(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            module = load_server_module(Path(temp_dir))
+            large_stdout = json.dumps(
+                {
+                    "session": {
+                        "id": "agent-session-1",
+                        "runtimeContext": {"skills": [{"name": "skill-a"}]},
+                    }
+                }
+            )
+            completed = subprocess.CompletedProcess(
+                args=[],
+                returncode=0,
+                stdout=large_stdout,
+                stderr="",
+            )
+
+            with tempfile.NamedTemporaryFile(mode="w+b") as log_file:
+                with mock.patch.object(module.subprocess, "run", return_value=completed):
+                    module.run_tutti_cli(
+                        ["agent", "start", "--provider", "codex"],
+                        log_file=log_file,
+                    )
+                log_file.seek(0)
+                log_text = log_file.read().decode("utf-8")
+
+            self.assertIn("runtimeContext", log_text)
+            self.assertNotIn("[automation] stdout compacted:", log_text)
 
 
 class RunCompletionTest(unittest.TestCase):

--- a/services/tuttid/service/agent/composer_options.go
+++ b/services/tuttid/service/agent/composer_options.go
@@ -109,7 +109,7 @@ func (s *Service) GetComposerOptions(ctx context.Context, input ComposerOptionsI
 		"reasoningEffort":  nullableString(effectiveSettings.ReasoningEffort),
 		"speed":            nullableString(effectiveSettings.Speed),
 	}
-	skills := discoverComposerSkillOptions(provider, input.Cwd, nil)
+	skills := s.discoverComposerSkillOptions(provider, input.Cwd, nil)
 	runtimeContext["skills"] = composerSkillOptionsRuntimeContext(skills)
 	if composerOptionsProviderSupportsSettings(provider) {
 		if catalogOptions, source, ok := composerModelOptionsFromCatalog(ctx, s.ModelCatalog, provider, effectiveSettings.Model); ok {

--- a/services/tuttid/service/agent/service.go
+++ b/services/tuttid/service/agent/service.go
@@ -23,7 +23,10 @@ func NewService(runtime RuntimeController) *Service {
 	if runtime == nil {
 		panic("agent service requires a runtime")
 	}
-	return &Service{Runtime: runtime}
+	return &Service{
+		Runtime:           runtime,
+		skillOptionsCache: newComposerSkillOptionsCache(),
+	}
 }
 
 func (s *Service) List(ctx context.Context, workspaceID string) ([]Session, error) {
@@ -169,9 +172,10 @@ func (s *Service) Create(ctx context.Context, workspaceID string, input CreateSe
 	if refreshed, ok := s.controller().Session(workspaceID, session.ID); ok {
 		session = refreshed
 	}
-	return serviceSession(
+	return serviceSessionWithComposerSkillOptions(
 		session,
 		s.controller().CanResume(runtimeResumeInputFromRuntimeSession(session)),
+		s.discoverComposerSkillOptions(session.Provider, session.Cwd, session.Env),
 	), nil
 }
 

--- a/services/tuttid/service/agent/service_session.go
+++ b/services/tuttid/service/agent/service_session.go
@@ -56,10 +56,6 @@ func serviceSession(session RuntimeSession, resumable bool) Session {
 		normalizedSettings,
 		session.RuntimeContext,
 	)
-	runtimeContext = withComposerSkillOptionsRuntimeContext(
-		runtimeContext,
-		discoverComposerSkillOptions(normalizedProvider, session.Cwd, session.Env),
-	)
 	return Session{
 		ID:                strings.TrimSpace(session.ID),
 		Provider:          normalizedProvider,
@@ -78,6 +74,19 @@ func serviceSession(session RuntimeSession, resumable bool) Session {
 		EndedAt:           endedAt,
 		LastError:         stringPointer(strings.TrimSpace(session.LastError)),
 	}
+}
+
+func serviceSessionWithComposerSkillOptions(
+	session RuntimeSession,
+	resumable bool,
+	options []ComposerSkillOption,
+) Session {
+	result := serviceSession(session, resumable)
+	result.RuntimeContext = withFallbackComposerSkillOptionsRuntimeContext(
+		result.RuntimeContext,
+		options,
+	)
+	return result
 }
 
 func sessionFromPersisted(session PersistedSession, resumable bool) Session {

--- a/services/tuttid/service/agent/service_test.go
+++ b/services/tuttid/service/agent/service_test.go
@@ -799,6 +799,35 @@ func TestServiceMapsRuntimeSessionLastError(t *testing.T) {
 	}
 }
 
+func TestServiceGetDoesNotDiscoverComposerSkills(t *testing.T) {
+	tempDir := t.TempDir()
+	homeDir := filepath.Join(tempDir, "home")
+	cwd := filepath.Join(tempDir, "repo")
+	t.Setenv("HOME", homeDir)
+	t.Setenv("USERPROFILE", homeDir)
+	writeSkill(t, filepath.Join(cwd, ".codex", "skills", "project-skill", "SKILL.md"), `---
+description: Project skill.
+---
+`)
+	runtime := newFakeRuntime()
+	runtime.sessions["ws-1:session-1"] = RuntimeSession{
+		ID:          "session-1",
+		Provider:    "codex",
+		WorkspaceID: "ws-1",
+		Cwd:         cwd,
+		Status:      "working",
+	}
+	service := NewService(runtime)
+
+	session, err := service.Get(context.Background(), "ws-1", "session-1")
+	if err != nil {
+		t.Fatalf("Get returned error: %v", err)
+	}
+	if _, ok := session.RuntimeContext["skills"]; ok {
+		t.Fatalf("runtime context skills = %#v, want not discovered on get", session.RuntimeContext["skills"])
+	}
+}
+
 func TestServiceSessionNormalizesReasoningRuntimeConfigOptions(t *testing.T) {
 	session := serviceSession(RuntimeSession{
 		ID:          "session-1",

--- a/services/tuttid/service/agent/session_types.go
+++ b/services/tuttid/service/agent/session_types.go
@@ -16,6 +16,7 @@ type Service struct {
 	SessionDirectoryAllocator SessionDirectoryAllocator
 	PromptAttachmentStore     PromptAttachmentStore
 	RuntimePreparer           agentsidecarservice.Preparer
+	skillOptionsCache         *composerSkillOptionsCache
 }
 
 type StaleTurnResumeReconciler interface {

--- a/services/tuttid/service/agent/skill_options.go
+++ b/services/tuttid/service/agent/skill_options.go
@@ -6,7 +6,9 @@ import (
 	"os"
 	"path/filepath"
 	"sort"
+	"strconv"
 	"strings"
+	"sync"
 
 	"github.com/tutti-os/tutti/services/tuttid/biz/agentprovider"
 )
@@ -26,17 +28,47 @@ var hiddenTuttiProviderSkills = map[string]struct{}{
 }
 
 func discoverComposerSkillOptions(provider string, cwd string, env []string) []ComposerSkillOption {
+	roots, triggerFor := composerSkillDiscoveryPlan(provider, cwd, env)
+	if triggerFor == nil {
+		return nil
+	}
+	return discoverComposerSkillOptionsFromRoots(roots, triggerFor)
+}
+
+func (s *Service) discoverComposerSkillOptions(provider string, cwd string, env []string) []ComposerSkillOption {
+	roots, triggerFor := composerSkillDiscoveryPlan(provider, cwd, env)
+	if triggerFor == nil {
+		return nil
+	}
+	cache := s.skillOptionsCache
+	if cache == nil {
+		return discoverComposerSkillOptionsFromRoots(roots, triggerFor)
+	}
+	key := composerSkillOptionsCacheKey(provider, roots)
+	if cached, ok := cache.get(key); ok {
+		return cloneComposerSkillOptions(cached)
+	}
+	options := discoverComposerSkillOptionsFromRoots(roots, triggerFor)
+	cache.set(key, options)
+	return cloneComposerSkillOptions(options)
+}
+
+func composerSkillDiscoveryPlan(provider string, cwd string, env []string) ([]composerSkillRoot, skillTriggerFunc) {
 	switch agentprovider.Normalize(provider) {
 	case agentprovider.Codex:
-		return discoverCodexComposerSkills(cwd, env)
+		return codexComposerSkillRoots(cwd, env), codexSkillTrigger
 	case agentprovider.ClaudeCode:
-		return discoverClaudeCodeComposerSkills(cwd, env)
+		return claudeCodeComposerSkillRoots(cwd, env), claudeCodeSkillTrigger
 	default:
-		return nil
+		return nil, nil
 	}
 }
 
 func discoverCodexComposerSkills(cwd string, env []string) []ComposerSkillOption {
+	return discoverComposerSkillOptionsFromRoots(codexComposerSkillRoots(cwd, env), codexSkillTrigger)
+}
+
+func codexComposerSkillRoots(cwd string, env []string) []composerSkillRoot {
 	roots := make([]composerSkillRoot, 0)
 	roots = append(roots, ancestorSkillRoots(cwd, ".codex", "skills", composerSkillSourceProject)...)
 	if userHome, err := os.UserHomeDir(); err == nil && strings.TrimSpace(userHome) != "" {
@@ -59,10 +91,14 @@ func discoverCodexComposerSkills(cwd string, env []string) []ComposerSkillOption
 			sourceKind: composerSkillSourceTuttiInjected,
 		})
 	}
-	return discoverProviderSkillRoots(roots, codexSkillTrigger)
+	return roots
 }
 
 func discoverClaudeCodeComposerSkills(cwd string, env []string) []ComposerSkillOption {
+	return discoverComposerSkillOptionsFromRoots(claudeCodeComposerSkillRoots(cwd, env), claudeCodeSkillTrigger)
+}
+
+func claudeCodeComposerSkillRoots(cwd string, env []string) []composerSkillRoot {
 	roots := make([]composerSkillRoot, 0)
 	roots = append(roots, ancestorSkillRoots(cwd, ".claude", "skills", composerSkillSourceProject)...)
 	if userHome, err := os.UserHomeDir(); err == nil && strings.TrimSpace(userHome) != "" {
@@ -78,7 +114,7 @@ func discoverClaudeCodeComposerSkills(cwd string, env []string) []ComposerSkillO
 			pluginName: claudePluginName(pluginDir),
 		})
 	}
-	return discoverProviderSkillRoots(roots, claudeCodeSkillTrigger)
+	return roots
 }
 
 type composerSkillRoot struct {
@@ -88,6 +124,105 @@ type composerSkillRoot struct {
 }
 
 type skillTriggerFunc func(composerSkillRoot, string) string
+
+type composerSkillOptionsCache struct {
+	mu      sync.Mutex
+	entries map[string][]ComposerSkillOption
+}
+
+func newComposerSkillOptionsCache() *composerSkillOptionsCache {
+	return &composerSkillOptionsCache{
+		entries: make(map[string][]ComposerSkillOption),
+	}
+}
+
+func (c *composerSkillOptionsCache) get(key string) ([]ComposerSkillOption, bool) {
+	if c == nil {
+		return nil, false
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	options, ok := c.entries[key]
+	if !ok {
+		return nil, false
+	}
+	return cloneComposerSkillOptions(options), true
+}
+
+func (c *composerSkillOptionsCache) set(key string, options []ComposerSkillOption) {
+	if c == nil {
+		return
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.entries[key] = cloneComposerSkillOptions(options)
+}
+
+func composerSkillOptionsCacheKey(provider string, roots []composerSkillRoot) string {
+	var builder strings.Builder
+	builder.WriteString(agentprovider.Normalize(provider))
+	for _, root := range roots {
+		builder.WriteByte('\n')
+		builder.WriteString(root.path)
+		builder.WriteByte('|')
+		builder.WriteString(root.sourceKind)
+		builder.WriteByte('|')
+		builder.WriteString(root.pluginName)
+		writeFileSignature(&builder, root.path)
+		entries, err := os.ReadDir(root.path)
+		if err != nil {
+			builder.WriteString("|missing")
+			continue
+		}
+		for _, entry := range entries {
+			name := strings.TrimSpace(entry.Name())
+			if name == "" || strings.HasPrefix(name, ".") {
+				continue
+			}
+			sourcePath := filepath.Join(root.path, name)
+			sourceInfo, err := os.Stat(sourcePath)
+			if err != nil || !sourceInfo.IsDir() {
+				continue
+			}
+			builder.WriteByte('\n')
+			builder.WriteString(filepath.Join(sourcePath, "SKILL.md"))
+			writeFileSignature(&builder, filepath.Join(sourcePath, "SKILL.md"))
+		}
+	}
+	return builder.String()
+}
+
+func writeFileSignature(builder *strings.Builder, path string) {
+	info, err := os.Stat(path)
+	if err != nil {
+		builder.WriteString("|missing")
+		return
+	}
+	builder.WriteByte('|')
+	builder.WriteString(strconv.FormatInt(info.Size(), 10))
+	builder.WriteByte('|')
+	builder.WriteString(strconv.FormatInt(info.ModTime().UnixNano(), 10))
+	builder.WriteByte('|')
+	if info.IsDir() {
+		builder.WriteString("dir")
+	} else {
+		builder.WriteString("file")
+	}
+}
+
+func cloneComposerSkillOptions(options []ComposerSkillOption) []ComposerSkillOption {
+	if len(options) == 0 {
+		return nil
+	}
+	return append([]ComposerSkillOption(nil), options...)
+}
+
+func discoverComposerSkillOptionsFromRoots(
+	roots []composerSkillRoot,
+	triggerFor skillTriggerFunc,
+) []ComposerSkillOption {
+	return discoverProviderSkillRoots(roots, triggerFor)
+}
 
 func discoverProviderSkillRoots(
 	roots []composerSkillRoot,
@@ -147,16 +282,18 @@ func discoverProviderSkillRoot(
 		if err != nil || info.IsDir() {
 			continue
 		}
-		metadata, ok := readSkillMetadata(skillPath)
+		metadata, ok, shouldWarn := readSkillMetadataForDiscovery(skillPath)
 		if !ok {
-			slog.Warn(
-				"composer skill skipped; invalid frontmatter",
-				"error_code", "skill_frontmatter_invalid",
-				"skillName", name,
-				"skillPath", skillPath,
-				"sourceKind", root.sourceKind,
-				"reason", "missing_delimited_yaml_frontmatter",
-			)
+			if shouldWarn {
+				slog.Warn(
+					"composer skill skipped; invalid frontmatter",
+					"error_code", "skill_frontmatter_invalid",
+					"skillName", name,
+					"skillPath", skillPath,
+					"sourceKind", root.sourceKind,
+					"reason", "missing_delimited_yaml_frontmatter",
+				)
+			}
 			continue
 		}
 		if metadata.name != "" {
@@ -211,6 +348,62 @@ func ancestorSkillRoots(cwd string, parent string, child string, sourceKind stri
 type skillMetadata struct {
 	name        string
 	description string
+}
+
+type skillMetadataCacheEntry struct {
+	size          int64
+	modTimeUnixNS int64
+	metadata      skillMetadata
+	ok            bool
+	warnedInvalid bool
+}
+
+var skillMetadataCache = struct {
+	mu      sync.Mutex
+	entries map[string]skillMetadataCacheEntry
+}{
+	entries: make(map[string]skillMetadataCacheEntry),
+}
+
+func readSkillMetadataForDiscovery(path string) (skillMetadata, bool, bool) {
+	info, err := os.Stat(path)
+	if err != nil || info.IsDir() {
+		return skillMetadata{}, false, false
+	}
+	size := info.Size()
+	modTimeUnixNS := info.ModTime().UnixNano()
+	skillMetadataCache.mu.Lock()
+	if entry, ok := skillMetadataCache.entries[path]; ok &&
+		entry.size == size &&
+		entry.modTimeUnixNS == modTimeUnixNS {
+		if entry.ok {
+			metadata := entry.metadata
+			skillMetadataCache.mu.Unlock()
+			return metadata, true, false
+		}
+		if !entry.warnedInvalid {
+			entry.warnedInvalid = true
+			skillMetadataCache.entries[path] = entry
+			skillMetadataCache.mu.Unlock()
+			return skillMetadata{}, false, true
+		}
+		skillMetadataCache.mu.Unlock()
+		return skillMetadata{}, false, false
+	}
+	skillMetadataCache.mu.Unlock()
+
+	metadata, ok := readSkillMetadata(path)
+	entry := skillMetadataCacheEntry{
+		size:          size,
+		modTimeUnixNS: modTimeUnixNS,
+		metadata:      metadata,
+		ok:            ok,
+		warnedInvalid: !ok,
+	}
+	skillMetadataCache.mu.Lock()
+	skillMetadataCache.entries[path] = entry
+	skillMetadataCache.mu.Unlock()
+	return metadata, ok, !ok
 }
 
 func readSkillMetadata(path string) (skillMetadata, bool) {
@@ -347,6 +540,21 @@ func withComposerSkillOptionsRuntimeContext(
 	}
 	runtimeContext["skills"] = composerSkillOptionsRuntimeContext(options)
 	return runtimeContext
+}
+
+func withFallbackComposerSkillOptionsRuntimeContext(
+	runtimeContext map[string]any,
+	options []ComposerSkillOption,
+) map[string]any {
+	if len(options) == 0 {
+		return runtimeContext
+	}
+	if runtimeContext != nil {
+		if _, ok := runtimeContext["skills"]; ok {
+			return runtimeContext
+		}
+	}
+	return withComposerSkillOptionsRuntimeContext(runtimeContext, options)
 }
 
 func skillSourceRank(sourceKind string) int {

--- a/services/tuttid/service/agent/skill_options.go
+++ b/services/tuttid/service/agent/skill_options.go
@@ -64,10 +64,6 @@ func composerSkillDiscoveryPlan(provider string, cwd string, env []string) ([]co
 	}
 }
 
-func discoverCodexComposerSkills(cwd string, env []string) []ComposerSkillOption {
-	return discoverComposerSkillOptionsFromRoots(codexComposerSkillRoots(cwd, env), codexSkillTrigger)
-}
-
 func codexComposerSkillRoots(cwd string, env []string) []composerSkillRoot {
 	roots := make([]composerSkillRoot, 0)
 	roots = append(roots, ancestorSkillRoots(cwd, ".codex", "skills", composerSkillSourceProject)...)
@@ -92,10 +88,6 @@ func codexComposerSkillRoots(cwd string, env []string) []composerSkillRoot {
 		})
 	}
 	return roots
-}
-
-func discoverClaudeCodeComposerSkills(cwd string, env []string) []ComposerSkillOption {
-	return discoverComposerSkillOptionsFromRoots(claudeCodeComposerSkillRoots(cwd, env), claudeCodeSkillTrigger)
 }
 
 func claudeCodeComposerSkillRoots(cwd string, env []string) []composerSkillRoot {

--- a/services/tuttid/service/agent/skill_options_test.go
+++ b/services/tuttid/service/agent/skill_options_test.go
@@ -1,9 +1,13 @@
 package agent
 
 import (
+	"bytes"
+	"log/slog"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
+	"time"
 )
 
 func TestDiscoverComposerSkillOptionsCodexUsesProviderNativeTriggers(t *testing.T) {
@@ -109,6 +113,47 @@ description: Internal Tutti CLI.
 	}
 	if options[2].PluginName != "product-design" || options[2].SourceKind != "plugin" {
 		t.Fatalf("plugin option = %#v", options[2])
+	}
+}
+
+func TestDiscoverComposerSkillOptionsWarnsOnceForUnchangedInvalidSkill(t *testing.T) {
+	tempDir := t.TempDir()
+	homeDir := filepath.Join(tempDir, "home")
+	cwd := filepath.Join(tempDir, "repo")
+	t.Setenv("HOME", homeDir)
+	t.Setenv("USERPROFILE", homeDir)
+	skillPath := filepath.Join(homeDir, ".codex", "skills", "broken", "SKILL.md")
+	writeSkill(t, skillPath, `description: Missing frontmatter delimiter.
+---
+`)
+	skillMetadataCache.mu.Lock()
+	skillMetadataCache.entries = make(map[string]skillMetadataCacheEntry)
+	skillMetadataCache.mu.Unlock()
+	var output bytes.Buffer
+	previousLogger := slog.Default()
+	slog.SetDefault(slog.New(slog.NewTextHandler(&output, nil)))
+	t.Cleanup(func() {
+		slog.SetDefault(previousLogger)
+	})
+
+	_ = discoverComposerSkillOptions("codex", cwd, nil)
+	_ = discoverComposerSkillOptions("codex", cwd, nil)
+
+	if count := strings.Count(output.String(), "skill_frontmatter_invalid"); count != 1 {
+		t.Fatalf("invalid frontmatter warnings = %d, want 1; output:\n%s", count, output.String())
+	}
+
+	writeSkill(t, skillPath, `description: Still missing frontmatter delimiter.
+---
+`)
+	modTime := time.Now().Add(2 * time.Second)
+	if err := os.Chtimes(skillPath, modTime, modTime); err != nil {
+		t.Fatalf("Chtimes: %v", err)
+	}
+	_ = discoverComposerSkillOptions("codex", cwd, nil)
+
+	if count := strings.Count(output.String(), "skill_frontmatter_invalid"); count != 2 {
+		t.Fatalf("invalid frontmatter warnings after modification = %d, want 2; output:\n%s", count, output.String())
 	}
 }
 


### PR DESCRIPTION
## Summary
- Sync app-update state contract and telemetry flow between desktop main and renderer.
- Improve developer logs export/cleanup behavior and related coverage.
- Update workspace agent GUI/workbench activation and contribution hooks for updated state handling.
- Expand automation/server tests and workspace agent option discovery behavior.
- Consolidate app update/agent option contracts and update shared schema tests.

## Validation
- `pnpm check:full` passed.

## Notes
- Multiple refactors landed across UI, desktop main process, and daemon.
