### PR TITLE
[codex] align claude code review picker

### DIFF
--- a/packages/agent/daemon/runtime/capabilities.go
+++ b/packages/agent/daemon/runtime/capabilities.go
@@ -27,6 +27,7 @@ func standardACPCapabilities(provider string, promptImage bool, state acpLiveSta
 			CapabilityRateLimits,
 			CapabilityPlanMode,
 			CapabilityInterrupt,
+			"review",
 		}
 		if promptImage {
 			capabilities = append([]string{CapabilityImageInput}, capabilities...)

--- a/packages/agent/daemon/runtime/codex_appserver_adapter_test.go
+++ b/packages/agent/daemon/runtime/codex_appserver_adapter_test.go
@@ -1380,6 +1380,17 @@ func TestAppServerReasoningText(t *testing.T) {
 	}
 }
 
+func TestAppServerReasoningDeltaTextPreservesWhitespace(t *testing.T) {
+	t.Parallel()
+
+	if got := appServerReasoningDeltaText(map[string]any{"delta": "Need "}); got != "Need " {
+		t.Fatalf("delta text = %q, want trailing space preserved", got)
+	}
+	if got := appServerReasoningDeltaText(map[string]any{"text": " more"}); got != " more" {
+		t.Fatalf("text fallback = %q, want leading space preserved", got)
+	}
+}
+
 func TestCodexAppServerAdapterSlashReviewInlineReasoningSummaryDelta(t *testing.T) {
 	t.Parallel()
 

--- a/packages/agent/daemon/runtime/codex_appserver_events.go
+++ b/packages/agent/daemon/runtime/codex_appserver_events.go
@@ -1339,7 +1339,10 @@ func appServerReasoningText(item map[string]any) string {
 // appServerReasoningDeltaText reads a reasoning delta payload. Most app-server
 // versions use `delta`, but some event shapes expose the chunk as `text`.
 func appServerReasoningDeltaText(params map[string]any) string {
-	return firstNonEmpty(asStringRaw(params["delta"]), asStringRaw(params["text"]))
+	if delta := asStringRaw(params["delta"]); delta != "" {
+		return delta
+	}
+	return asStringRaw(params["text"])
 }
 
 // reasoningSectionsText joins the non-empty sections of a reasoning

--- a/packages/agent/daemon/runtime/standard_acp_adapter.go
+++ b/packages/agent/daemon/runtime/standard_acp_adapter.go
@@ -302,6 +302,29 @@ func claudeCodeACPModeID(mode string) string {
 	}
 }
 
+func claudeCodeACPCommands() []AgentSessionCommand {
+	return []AgentSessionCommand{
+		{Name: "review"},
+		{Name: "compact"},
+	}
+}
+
+func standardACPInitialLiveState(provider string) acpLiveState {
+	state := newACPLiveState()
+	seedStandardACPInitialCommands(&state, provider)
+	return state
+}
+
+func seedStandardACPInitialCommands(state *acpLiveState, provider string) {
+	if state == nil || state.commandsKnown {
+		return
+	}
+	if strings.TrimSpace(provider) == ProviderClaudeCode {
+		state.availableCommands = claudeCodeACPCommands()
+		state.commandsKnown = true
+	}
+}
+
 func NewClaudeCodeAdapter(transport ProcessTransport) *standardACPAdapter {
 	return NewClaudeCodeAdapterWithHostMetadata(transport, LegacyHostMetadata())
 }
@@ -373,7 +396,7 @@ func (a *standardACPAdapter) Start(ctx context.Context, session Session) ([]acti
 		client:           client,
 		agentInfo:        acpAgentInfo(initializeResult),
 		promptImage:      standardACPProviderPromptImageSupported(a.config.provider, initializeResult),
-		acpLiveState:     newACPLiveState(),
+		acpLiveState:     standardACPInitialLiveState(a.config.provider),
 		pendingApprovals: make(map[string]*pendingACPApproval),
 	}
 	a.storeSession(session.AgentSessionID, acpSession)
@@ -492,11 +515,12 @@ func (a *standardACPAdapter) Resume(ctx context.Context, session Session) error 
 		providerSessionID: session.ProviderSessionID,
 		agentInfo:         acpAgentInfo(initializeResult),
 		promptImage:       standardACPProviderPromptImageSupported(a.config.provider, initializeResult),
-		acpLiveState:      newACPLiveState(),
+		acpLiveState:      standardACPInitialLiveState(a.config.provider),
 		pendingApprovals:  make(map[string]*pendingACPApproval),
 	}
 	if previousSession != nil {
 		acpSession.acpLiveState = cloneACPLiveState(previousSession.acpLiveState)
+		seedStandardACPInitialCommands(&acpSession.acpLiveState, a.config.provider)
 	}
 	a.storeSession(session.AgentSessionID, acpSession)
 

--- a/packages/agent/daemon/runtime/standard_acp_adapter_test.go
+++ b/packages/agent/daemon/runtime/standard_acp_adapter_test.go
@@ -1556,6 +1556,65 @@ func TestClaudeCodeAdapterStartAppliesDefaultMode(t *testing.T) {
 	}
 }
 
+func TestClaudeCodeAdapterStartExposesReviewCommandBaseline(t *testing.T) {
+	t.Parallel()
+
+	transport := newStandardACPTransport("Claude Agent", "claude-session-review")
+	adapter := NewClaudeCodeAdapter(transport)
+	session := standardTestSession(ProviderClaudeCode)
+
+	if _, err := adapter.Start(context.Background(), session); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+
+	snapshot, ok := adapter.SessionCommandSnapshot(session)
+	if !ok {
+		t.Fatal("SessionCommandSnapshot ok=false, want Claude Code review baseline")
+	}
+	names := agentSessionCommandNames(snapshot.Commands)
+	for _, want := range []string{"review", "compact"} {
+		if !containsString(names, want) {
+			t.Fatalf("commands = %#v, want %q", names, want)
+		}
+	}
+
+	state := adapter.SessionState(session)
+	commands, _ := state.RuntimeContext["commands"].([]string)
+	for _, want := range []string{"review", "compact"} {
+		if !containsString(commands, want) {
+			t.Fatalf("runtime context commands = %#v, want %q", commands, want)
+		}
+	}
+	capabilities, _ := state.RuntimeContext["capabilities"].([]string)
+	if !containsString(capabilities, "review") {
+		t.Fatalf("capabilities = %#v, want review", capabilities)
+	}
+}
+
+func TestClaudeCodeAdapterResumeExposesReviewCommandBaseline(t *testing.T) {
+	t.Parallel()
+
+	transport := newStandardACPTransport("Claude Agent", "claude-session-review-resume")
+	adapter := NewClaudeCodeAdapter(transport)
+	session := standardTestSession(ProviderClaudeCode)
+	session.ProviderSessionID = "persisted-claude-session-id"
+
+	if err := adapter.Resume(context.Background(), session); err != nil {
+		t.Fatalf("Resume: %v", err)
+	}
+
+	snapshot, ok := adapter.SessionCommandSnapshot(session)
+	if !ok {
+		t.Fatal("SessionCommandSnapshot ok=false, want Claude Code review baseline")
+	}
+	names := agentSessionCommandNames(snapshot.Commands)
+	for _, want := range []string{"review", "compact"} {
+		if !containsString(names, want) {
+			t.Fatalf("commands = %#v, want %q", names, want)
+		}
+	}
+}
+
 func TestClaudeCodeAdapterStartAppliesPlanMode(t *testing.T) {
 	t.Parallel()
 
@@ -2449,10 +2508,9 @@ func TestControllerPublishesIdleStandardACPCommandUpdatesAfterStart(t *testing.T
 			if !ok {
 				t.Fatalf("event data = %#v, want AgentSessionCommandSnapshot", event.Data)
 			}
-			if len(snapshot.Commands) != 1 || snapshot.Commands[0].Name != "web" {
-				t.Fatalf("command snapshot = %#v, want web command", snapshot)
+			if len(snapshot.Commands) == 1 && snapshot.Commands[0].Name == "web" {
+				return
 			}
-			return
 		case <-deadline:
 			t.Fatal("idle available_commands_update was not published")
 		}

--- a/packages/agent/gui/agent-gui/agentGuiNode/AgentComposer.spec.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/AgentComposer.spec.tsx
@@ -1786,100 +1786,110 @@ describe("AgentComposer", () => {
     expect(onSubmit).not.toHaveBeenCalled();
   });
 
-  it("opens the codex review picker and submits the chosen target", () => {
-    const onSubmit = vi.fn();
-    const { container } = render(
-      <AgentComposer
-        workspaceId="workspace-1"
-        currentUserId="user-1"
-        provider="codex"
-        slashStatus={{ agentSessionId: "agent-session-1", limits: [] }}
-        draftContent={createDraft("/review")}
-        availableCommands={
-          [{ name: "review" }] satisfies readonly AgentHostAgentSessionCommand[]
-        }
-        disabled={false}
-        submitDisabled={false}
-        placeholder="placeholder"
-        composerSettings={createComposerSettings()}
-        queuedPrompts={[]}
-        drainingQueuedPromptId={null}
-        canQueueWhileBusy={false}
-        showStopButton={false}
-        activePrompt={null}
-        isInterrupting={false}
-        isSendingTurn={false}
-        isSubmittingPrompt={false}
-        labels={createLabels()}
-        workspaceUserProjectI18n={workspaceUserProjectI18n}
-        onDraftContentChange={vi.fn()}
-        onSettingsChange={vi.fn()}
-        onSubmit={onSubmit}
-        onSendQueuedPromptNext={vi.fn()}
-        onRemoveQueuedPrompt={vi.fn()}
-        onEditQueuedPrompt={vi.fn()}
-        onInterruptCurrentTurn={vi.fn()}
-        onSubmitInteractivePrompt={vi.fn()}
-      />
-    );
+  it.each(["codex", "claude-code"] as const)(
+    "opens the %s review picker and submits the chosen target",
+    (provider) => {
+      const onSubmit = vi.fn();
+      const { container } = render(
+        <AgentComposer
+          workspaceId="workspace-1"
+          currentUserId="user-1"
+          provider={provider}
+          slashStatus={{ agentSessionId: "agent-session-1", limits: [] }}
+          draftContent={createDraft("/review")}
+          availableCommands={
+            [
+              { name: "review" }
+            ] satisfies readonly AgentHostAgentSessionCommand[]
+          }
+          disabled={false}
+          submitDisabled={false}
+          placeholder="placeholder"
+          composerSettings={createComposerSettings()}
+          queuedPrompts={[]}
+          drainingQueuedPromptId={null}
+          canQueueWhileBusy={false}
+          showStopButton={false}
+          activePrompt={null}
+          isInterrupting={false}
+          isSendingTurn={false}
+          isSubmittingPrompt={false}
+          labels={createLabels()}
+          workspaceUserProjectI18n={workspaceUserProjectI18n}
+          onDraftContentChange={vi.fn()}
+          onSettingsChange={vi.fn()}
+          onSubmit={onSubmit}
+          onSendQueuedPromptNext={vi.fn()}
+          onRemoveQueuedPrompt={vi.fn()}
+          onEditQueuedPrompt={vi.fn()}
+          onInterruptCurrentTurn={vi.fn()}
+          onSubmitInteractivePrompt={vi.fn()}
+        />
+      );
 
-    fireEvent.submit(container.querySelector("form")!);
-    expect(
-      screen.getByTestId("agent-gui-review-picker-panel")
-    ).toBeInTheDocument();
-    expect(onSubmit).not.toHaveBeenCalled();
+      fireEvent.submit(container.querySelector("form")!);
+      expect(
+        screen.getByTestId("agent-gui-review-picker-panel")
+      ).toBeInTheDocument();
+      expect(onSubmit).not.toHaveBeenCalled();
 
-    // Selecting the "uncommitted changes" scope submits a bare /review.
-    fireEvent.click(screen.getByText("未提交的更改"));
-    expect(onSubmit).toHaveBeenCalledTimes(1);
-    expect(onSubmit.mock.calls[0]?.[0]).toEqual([
-      { type: "text", text: "/review" }
-    ]);
-  });
+      // Selecting the "uncommitted changes" scope submits a bare /review.
+      fireEvent.click(screen.getByText("未提交的更改"));
+      expect(onSubmit).toHaveBeenCalledTimes(1);
+      expect(onSubmit.mock.calls[0]?.[0]).toEqual([
+        { type: "text", text: "/review" }
+      ]);
+    }
+  );
 
-  it("submits /review <text> as a custom review without opening the picker", () => {
-    const onSubmit = vi.fn();
-    const { container } = render(
-      <AgentComposer
-        workspaceId="workspace-1"
-        currentUserId="user-1"
-        provider="codex"
-        slashStatus={{ agentSessionId: "agent-session-1", limits: [] }}
-        draftContent={createDraft("/review check the auth flow")}
-        availableCommands={
-          [{ name: "review" }] satisfies readonly AgentHostAgentSessionCommand[]
-        }
-        disabled={false}
-        submitDisabled={false}
-        placeholder="placeholder"
-        composerSettings={createComposerSettings()}
-        queuedPrompts={[]}
-        drainingQueuedPromptId={null}
-        canQueueWhileBusy={false}
-        showStopButton={false}
-        activePrompt={null}
-        isInterrupting={false}
-        isSendingTurn={false}
-        isSubmittingPrompt={false}
-        labels={createLabels()}
-        workspaceUserProjectI18n={workspaceUserProjectI18n}
-        onDraftContentChange={vi.fn()}
-        onSettingsChange={vi.fn()}
-        onSubmit={onSubmit}
-        onSendQueuedPromptNext={vi.fn()}
-        onRemoveQueuedPrompt={vi.fn()}
-        onEditQueuedPrompt={vi.fn()}
-        onInterruptCurrentTurn={vi.fn()}
-        onSubmitInteractivePrompt={vi.fn()}
-      />
-    );
+  it.each(["codex", "claude-code"] as const)(
+    "submits %s /review <text> as a custom review without opening the picker",
+    (provider) => {
+      const onSubmit = vi.fn();
+      const { container } = render(
+        <AgentComposer
+          workspaceId="workspace-1"
+          currentUserId="user-1"
+          provider={provider}
+          slashStatus={{ agentSessionId: "agent-session-1", limits: [] }}
+          draftContent={createDraft("/review check the auth flow")}
+          availableCommands={
+            [
+              { name: "review" }
+            ] satisfies readonly AgentHostAgentSessionCommand[]
+          }
+          disabled={false}
+          submitDisabled={false}
+          placeholder="placeholder"
+          composerSettings={createComposerSettings()}
+          queuedPrompts={[]}
+          drainingQueuedPromptId={null}
+          canQueueWhileBusy={false}
+          showStopButton={false}
+          activePrompt={null}
+          isInterrupting={false}
+          isSendingTurn={false}
+          isSubmittingPrompt={false}
+          labels={createLabels()}
+          workspaceUserProjectI18n={workspaceUserProjectI18n}
+          onDraftContentChange={vi.fn()}
+          onSettingsChange={vi.fn()}
+          onSubmit={onSubmit}
+          onSendQueuedPromptNext={vi.fn()}
+          onRemoveQueuedPrompt={vi.fn()}
+          onEditQueuedPrompt={vi.fn()}
+          onInterruptCurrentTurn={vi.fn()}
+          onSubmitInteractivePrompt={vi.fn()}
+        />
+      );
 
-    fireEvent.submit(container.querySelector("form")!);
-    expect(
-      screen.queryByTestId("agent-gui-review-picker-panel")
-    ).not.toBeInTheDocument();
-    expect(onSubmit).toHaveBeenCalledTimes(1);
-  });
+      fireEvent.submit(container.querySelector("form")!);
+      expect(
+        screen.queryByTestId("agent-gui-review-picker-panel")
+      ).not.toBeInTheDocument();
+      expect(onSubmit).toHaveBeenCalledTimes(1);
+    }
+  );
 });
 
 function createComposerSettings(

--- a/packages/agent/gui/agent-gui/agentGuiNode/model/agentSlashCommandProviderPolicy.spec.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/model/agentSlashCommandProviderPolicy.spec.ts
@@ -6,6 +6,8 @@ import {
 } from "./agentSlashCommandProviderPolicy";
 
 describe("agentSlashCommandProviderPolicy", () => {
+  const reviewPickerProviders = ["codex", "claude-code"] as const;
+
   it("adds Codex compact, status, fast, and review fallback commands after provider commands", () => {
     expect(
       resolveSlashCommandsForProvider({
@@ -27,7 +29,7 @@ describe("agentSlashCommandProviderPolicy", () => {
         provider: "claude-code",
         commands: []
       }).map((command) => command.name)
-    ).toEqual(["compact", "status", "fast"]);
+    ).toEqual(["compact", "status", "fast", "review"]);
   });
 
   it("filters compact when the session has no compactable context", () => {
@@ -46,7 +48,12 @@ describe("agentSlashCommandProviderPolicy", () => {
         provider: "claude-code",
         commands: [{ name: "plan", description: "provider plan" }]
       })
-    ).toEqual([{ name: "compact" }, { name: "status" }, { name: "fast" }]);
+    ).toEqual([
+      { name: "compact" },
+      { name: "status" },
+      { name: "fast" },
+      { name: "review" }
+    ]);
   });
 
   it("submits Codex init and compact commands immediately", () => {
@@ -197,64 +204,76 @@ describe("agentSlashCommandProviderPolicy", () => {
     ).toBeNull();
   });
 
-  it("opens the review picker when picking codex /review from the palette", () => {
+  it.each(reviewPickerProviders)(
+    "opens the review picker when picking %s /review from the palette",
+    (provider) => {
+      expect(
+        resolveSlashCommandSelectionEffect({
+          provider,
+          command: { name: "review", description: "Review code changes" },
+          currentDraft: "/rev"
+        })
+      ).toEqual({ kind: "showReviewPicker" });
+    }
+  );
+
+  it.each(reviewPickerProviders)(
+    "opens the review picker when submitting bare /review on %s",
+    (provider) => {
+      const commands = resolveSlashCommandsForProvider({
+        provider,
+        commands: [{ name: "review", description: "Review code changes" }]
+      });
+      expect(
+        resolveSlashCommandSubmitEffect({
+          provider,
+          commands,
+          draft: "/review"
+        })
+      ).toEqual({ kind: "showReviewPicker" });
+    }
+  );
+
+  it.each(reviewPickerProviders)(
+    "opens the review picker from %s fallback /review before provider commands arrive",
+    (provider) => {
+      const commands = resolveSlashCommandsForProvider({
+        provider,
+        commands: [],
+        hasCompactableContext: false
+      });
+      expect(commands.map((command) => command.name)).toContain("review");
+      expect(
+        resolveSlashCommandSubmitEffect({
+          provider,
+          commands,
+          draft: "/review"
+        })
+      ).toEqual({ kind: "showReviewPicker" });
+    }
+  );
+
+  it.each(reviewPickerProviders)(
+    "submits /review <text> straight through as a %s custom review",
+    (provider) => {
+      const commands = resolveSlashCommandsForProvider({
+        provider,
+        commands: [{ name: "review", description: "Review code changes" }]
+      });
+      expect(
+        resolveSlashCommandSubmitEffect({
+          provider,
+          commands,
+          draft: "/review check the auth flow"
+        })
+      ).toBeNull();
+    }
+  );
+
+  it("does not open the review picker for unknown providers", () => {
     expect(
       resolveSlashCommandSelectionEffect({
-        provider: "codex",
-        command: { name: "review", description: "Review code changes" },
-        currentDraft: "/rev"
-      })
-    ).toEqual({ kind: "showReviewPicker" });
-  });
-
-  it("opens the review picker when submitting bare /review on codex", () => {
-    const commands = resolveSlashCommandsForProvider({
-      provider: "codex",
-      commands: [{ name: "review", description: "Review code changes" }]
-    });
-    expect(
-      resolveSlashCommandSubmitEffect({
-        provider: "codex",
-        commands,
-        draft: "/review"
-      })
-    ).toEqual({ kind: "showReviewPicker" });
-  });
-
-  it("opens the review picker for Codex fallback /review before provider commands arrive", () => {
-    const commands = resolveSlashCommandsForProvider({
-      provider: "codex",
-      commands: [],
-      hasCompactableContext: false
-    });
-    expect(commands.map((command) => command.name)).toContain("review");
-    expect(
-      resolveSlashCommandSubmitEffect({
-        provider: "codex",
-        commands,
-        draft: "/review"
-      })
-    ).toEqual({ kind: "showReviewPicker" });
-  });
-
-  it("submits /review <text> straight through as a custom review", () => {
-    const commands = resolveSlashCommandsForProvider({
-      provider: "codex",
-      commands: [{ name: "review", description: "Review code changes" }]
-    });
-    expect(
-      resolveSlashCommandSubmitEffect({
-        provider: "codex",
-        commands,
-        draft: "/review check the auth flow"
-      })
-    ).toBeNull();
-  });
-
-  it("does not open the review picker for non-codex providers", () => {
-    expect(
-      resolveSlashCommandSelectionEffect({
-        provider: "claude-code",
+        provider: "other-provider",
         command: { name: "review", description: "Review" },
         currentDraft: "/rev"
       })

--- a/packages/agent/gui/agent-gui/agentGuiNode/model/agentSlashCommandProviderPolicy.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/model/agentSlashCommandProviderPolicy.ts
@@ -48,6 +48,8 @@ interface ResolveSlashCommandSubmitEffectInput {
 interface ProviderSlashPolicy {
   /** Commands submitted immediately on selection instead of filling a draft. */
   immediateCommands: ReadonlySet<string>;
+  /** Commands that open the shared review target picker when invoked bare. */
+  reviewPickerCommands: ReadonlySet<string>;
   /** Commands surfaced when the agent advertises none of its own. */
   fallbackCommands: readonly AgentSessionCommand[];
 }
@@ -70,6 +72,10 @@ const CODEX_FALLBACK_COMMANDS: readonly AgentSessionCommand[] = [
   ...ACP_FALLBACK_COMMANDS,
   { name: REVIEW_COMMAND }
 ];
+const CLAUDE_CODE_FALLBACK_COMMANDS: readonly AgentSessionCommand[] = [
+  ...ACP_FALLBACK_COMMANDS,
+  { name: REVIEW_COMMAND }
+];
 
 const PROVIDER_SLASH_POLICY: Record<
   "codex" | "claude-code",
@@ -77,11 +83,13 @@ const PROVIDER_SLASH_POLICY: Record<
 > = {
   codex: {
     immediateCommands: new Set(["init", "compact"]),
+    reviewPickerCommands: new Set([REVIEW_COMMAND]),
     fallbackCommands: CODEX_FALLBACK_COMMANDS
   },
   "claude-code": {
     immediateCommands: new Set(["compact", "context", "usage"]),
-    fallbackCommands: ACP_FALLBACK_COMMANDS
+    reviewPickerCommands: new Set([REVIEW_COMMAND]),
+    fallbackCommands: CLAUDE_CODE_FALLBACK_COMMANDS
   }
 };
 
@@ -214,7 +222,10 @@ function isReviewPickerCommand(
   provider: AgentSlashCommandProvider,
   commandName: string
 ): boolean {
-  return provider === "codex" && commandName === REVIEW_COMMAND;
+  return (
+    providerSlashPolicy(provider)?.reviewPickerCommands.has(commandName) ??
+    false
+  );
 }
 
 function fallbackCommandsForProvider(


### PR DESCRIPTION
## Summary
- align claude-code slash policy with Codex for the shared `/review` picker contract
- seed claude-code start/resume command snapshots with `review`/`compact` until provider commands arrive
- preserve Codex app-server reasoning delta whitespace so streamed thinking remains readable

## Validation
- `pnpm --filter @tutti-os/agent-gui test -- agentGuiNode/model/agentSlashCommandProviderPolicy.spec.ts agentGuiNode/AgentComposer.spec.tsx`
- `pnpm --filter @tutti-os/agent-gui typecheck`
- `pnpm lint:ts`
- `pnpm typecheck`
- `go test ./packages/agent/daemon/runtime`
- `PATH="/Users/asdf/go/bin:$PATH" pnpm lint:go`
- `PATH="/Users/asdf/go/bin:$PATH" git push -u origin codex/claude-code-review-picker-parity` (pre-push `check:full` passed)