### PR TITLE
[codex] Fix slash command menu surface

### DIFF
--- a/packages/agent/gui/agent-gui/agentGuiNode/AgentComposer.spec.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/AgentComposer.spec.tsx
@@ -29,6 +29,7 @@ const { mockProjectMissingState } = vi.hoisted(() => ({
 
 afterEach(() => {
   mockProjectMissingState.current = false;
+  vi.restoreAllMocks();
 });
 
 const workspaceUserProjectI18n = createWorkspaceUserProjectI18nRuntime(
@@ -1006,6 +1007,9 @@ describe("AgentComposer", () => {
     fireEvent.submit(container.querySelector("form")!);
 
     const panel = screen.getByTestId("agent-gui-slash-status-panel");
+    expect(
+      screen.getByTestId("agent-gui-command-menu-surface")
+    ).toContainElement(panel);
     expect(panel).toHaveTextContent("Status");
     expect(panel).toHaveTextContent("7d limit");
     expect(panel).toHaveTextContent("95% left");
@@ -1013,11 +1017,130 @@ describe("AgentComposer", () => {
     expect(panel).not.toHaveTextContent("Context");
   });
 
-  it("keeps the status panel inset and squared off against the composer input", () => {
+  it("closes the status command menu with Escape", () => {
+    const { container } = render(
+      <AgentComposer
+        workspaceId="workspace-1"
+        currentUserId="user-1"
+        provider="codex"
+        slashStatus={{
+          limits: [
+            {
+              id: "weekly",
+              label: "7d limit",
+              value: "95% left"
+            }
+          ]
+        }}
+        draftContent={createDraft("/status")}
+        availableCommands={[] satisfies readonly AgentHostAgentSessionCommand[]}
+        disabled={false}
+        submitDisabled={false}
+        placeholder="placeholder"
+        composerSettings={createComposerSettings()}
+        queuedPrompts={[]}
+        drainingQueuedPromptId={null}
+        canQueueWhileBusy={false}
+        showStopButton={false}
+        activePrompt={null}
+        isInterrupting={false}
+        isSendingTurn={false}
+        isSubmittingPrompt={false}
+        labels={createLabels()}
+        workspaceUserProjectI18n={workspaceUserProjectI18n}
+        onDraftContentChange={vi.fn()}
+        onSettingsChange={vi.fn()}
+        onSubmit={vi.fn()}
+        onSendQueuedPromptNext={vi.fn()}
+        onRemoveQueuedPrompt={vi.fn()}
+        onEditQueuedPrompt={vi.fn()}
+        onInterruptCurrentTurn={vi.fn()}
+        onSubmitInteractivePrompt={vi.fn()}
+      />
+    );
+
+    fireEvent.submit(container.querySelector("form")!);
+    expect(
+      screen.getByTestId("agent-gui-slash-status-panel")
+    ).toBeInTheDocument();
+
+    fireEvent.keyDown(screen.getByPlaceholderText("placeholder"), {
+      key: "Escape"
+    });
+
+    expect(
+      screen.queryByTestId("agent-gui-slash-status-panel")
+    ).not.toBeInTheDocument();
+  });
+
+  it("closes the status command menu when focus leaves the composer menu", () => {
+    const { container } = render(
+      <>
+        <AgentComposer
+          workspaceId="workspace-1"
+          currentUserId="user-1"
+          provider="codex"
+          slashStatus={{
+            limits: [
+              {
+                id: "weekly",
+                label: "7d limit",
+                value: "95% left"
+              }
+            ]
+          }}
+          draftContent={createDraft("/status")}
+          availableCommands={
+            [] satisfies readonly AgentHostAgentSessionCommand[]
+          }
+          disabled={false}
+          submitDisabled={false}
+          placeholder="placeholder"
+          composerSettings={createComposerSettings()}
+          queuedPrompts={[]}
+          drainingQueuedPromptId={null}
+          canQueueWhileBusy={false}
+          showStopButton={false}
+          activePrompt={null}
+          isInterrupting={false}
+          isSendingTurn={false}
+          isSubmittingPrompt={false}
+          labels={createLabels()}
+          workspaceUserProjectI18n={workspaceUserProjectI18n}
+          onDraftContentChange={vi.fn()}
+          onSettingsChange={vi.fn()}
+          onSubmit={vi.fn()}
+          onSendQueuedPromptNext={vi.fn()}
+          onRemoveQueuedPrompt={vi.fn()}
+          onEditQueuedPrompt={vi.fn()}
+          onInterruptCurrentTurn={vi.fn()}
+          onSubmitInteractivePrompt={vi.fn()}
+        />
+        <button type="button">outside target</button>
+      </>
+    );
+
+    fireEvent.submit(container.querySelector("form")!);
+    expect(
+      screen.getByTestId("agent-gui-command-menu-surface")
+    ).toBeInTheDocument();
+
+    screen.getByText("outside target").focus();
+    fireEvent.focusIn(screen.getByText("outside target"));
+
+    expect(
+      screen.queryByTestId("agent-gui-command-menu-surface")
+    ).not.toBeInTheDocument();
+  });
+
+  it("keeps the status panel styled as floating command menu content", () => {
     const css = readFileSync(resolve("app/renderer/agentactivity.css"), "utf8");
 
     expect(css).toMatch(
-      /\.agent-gui-node__slash-status-panel\s*{[^}]*position:\s*relative[^}]*z-index:\s*1[^}]*margin:\s*0 12px[^}]*border-bottom:\s*0[^}]*border-radius:\s*10px 10px 0 0/s
+      /\.agent-gui-node__slash-status-panel\s*{[^}]*width:\s*100%[^}]*min-width:\s*0[^}]*padding:\s*10px 12px/s
+    );
+    expect(css).not.toMatch(
+      /\.agent-gui-node__slash-status-panel\s*{[^}]*border-bottom:\s*0/s
     );
   });
 
@@ -2124,6 +2247,9 @@ describe("AgentComposer", () => {
       expect(
         screen.getByTestId("agent-gui-review-picker-panel")
       ).toBeInTheDocument();
+      expect(
+        screen.getByTestId("agent-gui-command-menu-surface")
+      ).toContainElement(screen.getByTestId("agent-gui-review-picker-panel"));
       expect(onSubmit).not.toHaveBeenCalled();
 
       // Selecting the "uncommitted changes" scope submits a bare /review.
@@ -2134,6 +2260,58 @@ describe("AgentComposer", () => {
       ]);
     }
   );
+
+  it("lets the review picker handle staged Escape before closing", () => {
+    const { container } = render(
+      <AgentComposer
+        workspaceId="workspace-1"
+        currentUserId="user-1"
+        provider="codex"
+        slashStatus={{ agentSessionId: "agent-session-1", limits: [] }}
+        draftContent={createDraft("/review")}
+        availableCommands={
+          [{ name: "review" }] satisfies readonly AgentHostAgentSessionCommand[]
+        }
+        disabled={false}
+        submitDisabled={false}
+        placeholder="placeholder"
+        composerSettings={createComposerSettings()}
+        queuedPrompts={[]}
+        drainingQueuedPromptId={null}
+        canQueueWhileBusy={false}
+        showStopButton={false}
+        activePrompt={null}
+        isInterrupting={false}
+        isSendingTurn={false}
+        isSubmittingPrompt={false}
+        labels={createLabels()}
+        workspaceUserProjectI18n={workspaceUserProjectI18n}
+        onDraftContentChange={vi.fn()}
+        onSettingsChange={vi.fn()}
+        onSubmit={vi.fn()}
+        onSendQueuedPromptNext={vi.fn()}
+        onRemoveQueuedPrompt={vi.fn()}
+        onEditQueuedPrompt={vi.fn()}
+        onInterruptCurrentTurn={vi.fn()}
+        onSubmitInteractivePrompt={vi.fn()}
+      />
+    );
+
+    fireEvent.submit(container.querySelector("form")!);
+    fireEvent.click(screen.getByText("与分支比较"));
+    const branchSearch = screen.getByPlaceholderText("选择分支");
+
+    fireEvent.keyDown(branchSearch, { key: "Escape" });
+
+    expect(screen.getByText("未提交的更改")).toBeInTheDocument();
+    const rootSearch = screen.getByPlaceholderText("搜索");
+
+    fireEvent.keyDown(rootSearch, { key: "Escape" });
+
+    expect(
+      screen.queryByTestId("agent-gui-review-picker-panel")
+    ).not.toBeInTheDocument();
+  });
 
   it.each(["codex", "claude-code"] as const)(
     "submits %s /review <text> as a custom review without opening the picker",

--- a/packages/agent/gui/agent-gui/agentGuiNode/AgentComposer.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/AgentComposer.tsx
@@ -6,7 +6,6 @@ import {
   useRef,
   useState,
   type CSSProperties,
-  Fragment,
   type FormEvent
 } from "react";
 import { createPortal } from "react-dom";
@@ -31,12 +30,7 @@ import {
 } from "../../app/renderer/components/ui/tooltip";
 import type { AgentConversationPromptVM } from "../../shared/agentConversation/contracts/agentConversationVM";
 import { cn } from "../../app/renderer/lib/utils";
-import {
-  AddIcon,
-  menuItemClassName,
-  Select,
-  SelectTrigger
-} from "@tutti-os/ui-system";
+import { AddIcon, Select, SelectTrigger } from "@tutti-os/ui-system";
 import { X } from "lucide-react";
 import { makeAtPanelKeyDown } from "@tutti-os/ui-rich-text/at-panel";
 import type { WorkspaceFileReference } from "@tutti-os/workspace-file-reference/contracts";
@@ -127,10 +121,11 @@ import {
 } from "../../actions/workspaceLinkActions";
 import type { AgentRichTextAtProvider } from "./agentRichTextAtProvider";
 import { hasWorkspaceFileDropData } from "../terminalNode/workspaceFileDrop";
-import {
-  AgentReviewBranchController,
-  type AgentReviewBranchState
-} from "./AgentReviewBranchController";
+import { AgentSlashStatusPanel } from "./AgentSlashStatusPanel";
+import { AgentReviewPickerPanel } from "./AgentReviewPickerPanel";
+import { ComposerFloatingMenuSurface } from "./composerFloatingMenu/ComposerFloatingMenuSurface";
+
+export { formatSlashStatusTokenCount } from "./AgentSlashStatusPanel";
 
 export interface AgentComposerProps {
   workspaceId: string;
@@ -344,8 +339,7 @@ const composerStyles = {
   footerGroup: styles.composerFooterLeft,
   footerGroupRight: styles.composerFooterRight,
   dropdownSurface:
-    "nodrag isolate rounded-[12px] border border-hairline bg-background-fronted p-[4px] text-foreground shadow-[var(--tsh-shell-shadow)] [-webkit-app-region:no-drag]",
-  slashDropdown: "overflow-hidden"
+    "nodrag isolate rounded-[12px] border border-hairline bg-background-fronted p-[4px] text-foreground shadow-[var(--tsh-shell-shadow)] [-webkit-app-region:no-drag]"
 };
 
 const workspaceReferenceSelectValue = "__tutti_workspace_reference_idle__";
@@ -416,487 +410,6 @@ function hasInlineOverflow(element: HTMLElement | null): boolean {
   }
 
   return element.scrollWidth > element.clientWidth + 1;
-}
-
-export function formatSlashStatusTokenCount(
-  value: number | null | undefined
-): string {
-  if (typeof value !== "number" || !Number.isFinite(value)) {
-    return "";
-  }
-  return Math.max(0, Math.trunc(value)).toLocaleString("en-US");
-}
-
-function slashStatusContextText(
-  status: AgentComposerSlashStatus | null | undefined,
-  labels: Pick<
-    AgentComposerProps["labels"],
-    "slashStatusContextValue" | "slashStatusContextUnavailable"
-  >
-): string {
-  const usedTokens = status?.contextWindow?.usedTokens;
-  const totalTokens = status?.contextWindow?.totalTokens;
-  if (
-    typeof usedTokens !== "number" ||
-    !Number.isFinite(usedTokens) ||
-    typeof totalTokens !== "number" ||
-    !Number.isFinite(totalTokens) ||
-    totalTokens <= 0
-  ) {
-    return labels.slashStatusContextUnavailable;
-  }
-  const used = Math.max(0, Math.trunc(usedTokens));
-  const total = Math.max(0, Math.trunc(totalTokens));
-  const percentLeft = Math.max(
-    0,
-    Math.min(100, Math.round(((total - used) / total) * 100))
-  );
-  return labels.slashStatusContextValue({
-    percentLeft,
-    usedTokens: formatSlashStatusTokenCount(used),
-    totalTokens: formatSlashStatusTokenCount(total)
-  });
-}
-
-function AgentSlashStatusPanel({
-  status,
-  labels,
-  onClose
-}: {
-  status: AgentComposerSlashStatus | null | undefined;
-  labels: Pick<
-    AgentComposerProps["labels"],
-    | "slashStatusTitle"
-    | "slashStatusSession"
-    | "slashStatusBaseUrl"
-    | "slashStatusContext"
-    | "slashStatusLimits"
-    | "slashStatusClose"
-    | "slashStatusContextValue"
-    | "slashStatusContextUnavailable"
-    | "slashStatusLimitsUnavailable"
-  >;
-  onClose: () => void;
-}): React.JSX.Element {
-  const limits = status?.limits ?? [];
-  const agentSessionId = status?.agentSessionId?.trim() ?? "";
-  const baseUrl = status?.baseUrl?.trim() ?? "";
-  const showSessionDetails = agentSessionId.length > 0;
-  return (
-    <section
-      className="agent-gui-node__slash-status-panel"
-      data-testid="agent-gui-slash-status-panel"
-      role="status"
-    >
-      <div className="mb-2 flex items-center justify-between gap-2">
-        <h3 className="truncate text-[11px] font-semibold leading-4">
-          {labels.slashStatusTitle}
-        </h3>
-        <button
-          className="nodrag shrink-0 rounded-[5px] px-1.5 py-0.5 text-[11px] leading-4 text-muted-foreground transition-colors hover:bg-background-hover hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring [-webkit-app-region:no-drag]"
-          type="button"
-          onClick={onClose}
-        >
-          {labels.slashStatusClose}
-        </button>
-      </div>
-      <dl className="grid grid-cols-[max-content_minmax(0,1fr)] gap-x-3 gap-y-1 font-mono text-[11px] leading-4">
-        {showSessionDetails ? (
-          <>
-            <dt className="text-muted-foreground">
-              {labels.slashStatusSession}:
-            </dt>
-            <dd className="min-w-0 truncate">{agentSessionId}</dd>
-            {baseUrl ? (
-              <>
-                <dt className="text-muted-foreground">
-                  {labels.slashStatusBaseUrl}:
-                </dt>
-                <dd className="min-w-0 truncate">{baseUrl}</dd>
-              </>
-            ) : null}
-            <dt className="text-muted-foreground">
-              {labels.slashStatusContext}:
-            </dt>
-            <dd className="min-w-0">
-              {slashStatusContextText(status, labels)}
-            </dd>
-          </>
-        ) : null}
-        {limits.map((limit) => (
-          <Fragment key={limit.id}>
-            <dt className="text-muted-foreground">{limit.label}:</dt>
-            <dd className="min-w-0">
-              <span className="agent-gui-node__slash-status-limit">
-                {typeof limit.percentRemaining === "number" &&
-                Number.isFinite(limit.percentRemaining) ? (
-                  <span
-                    aria-hidden="true"
-                    className="agent-gui-node__slash-status-limit-meter"
-                  >
-                    <span
-                      className="agent-gui-node__slash-status-limit-meter-fill"
-                      style={{
-                        width: `${Math.max(
-                          0,
-                          Math.min(100, limit.percentRemaining)
-                        )}%`
-                      }}
-                    />
-                  </span>
-                ) : null}
-                <span className="agent-gui-node__slash-status-limit-value">
-                  {limit.value}
-                  {limit.reset ? (
-                    <span className="text-muted-foreground">
-                      {" "}
-                      ({limit.reset})
-                    </span>
-                  ) : null}
-                </span>
-              </span>
-            </dd>
-          </Fragment>
-        ))}
-        {limits.length === 0 && status?.limitsLoading ? (
-          <>
-            <dt className="text-muted-foreground">
-              {labels.slashStatusLimits}:
-            </dt>
-            <dd className="min-w-0 text-muted-foreground">
-              {labels.slashStatusLimitsUnavailable}
-            </dd>
-          </>
-        ) : null}
-      </dl>
-    </section>
-  );
-}
-
-type ReviewStage = "root" | "base" | "commit" | "custom";
-
-interface ReviewMenuEntry {
-  key: string;
-  label: string;
-  description?: string;
-  disabled?: boolean;
-  onSelect: () => void;
-}
-
-const reviewMenuStyles = {
-  panel:
-    "agent-gui-node__slash-status-panel nodrag flex max-h-[280px] flex-col gap-1 overflow-hidden [-webkit-app-region:no-drag]",
-  search:
-    "nodrag h-8 w-full shrink-0 rounded-[6px] border-0 bg-transparent px-2.5 text-[11px] leading-4 text-[var(--text-primary)] placeholder:text-[var(--text-secondary)] focus-visible:outline-none [-webkit-app-region:no-drag]",
-  list: "flex min-h-0 flex-1 flex-col gap-1 overflow-y-auto",
-  option: cn(
-    menuItemClassName,
-    "nodrag min-h-9 w-full min-w-0 justify-start overflow-hidden rounded-[6px] border-0 bg-transparent px-2.5 py-2 text-left hover:bg-[var(--transparency-block)] focus:bg-[var(--transparency-block)] focus-visible:outline-none data-[highlighted]:bg-[var(--transparency-block)] active:bg-[var(--transparency-active)] disabled:pointer-events-none disabled:opacity-50"
-  ),
-  copy: "flex min-w-0 flex-1 items-baseline gap-1 overflow-hidden leading-[16px]",
-  name: "min-w-0 shrink-0 truncate text-[11px] font-semibold text-[var(--text-primary)]",
-  description:
-    "min-w-0 flex-1 truncate text-[11px] font-normal text-[var(--text-secondary)]",
-  message:
-    "select-none px-2.5 py-2 text-[11px] leading-4 text-[var(--text-secondary)]"
-};
-
-// A staged, searchable command menu (root scopes -> branch/commit/custom),
-// mirroring the slash-command palette interaction instead of nested dropdowns.
-function AgentReviewPickerPanel({
-  labels,
-  onRequestGitBranches,
-  onSubmitReview,
-  onClose
-}: {
-  labels: AgentComposerProps["labels"]["reviewPicker"];
-  onRequestGitBranches?: (() => Promise<AgentComposerGitBranches>) | null;
-  onSubmitReview: (command: string) => void;
-  onClose: () => void;
-}): React.JSX.Element {
-  const [stage, setStage] = useState<ReviewStage>("root");
-  const [query, setQuery] = useState("");
-  const [highlightedIndex, setHighlightedIndex] = useState(0);
-  const searchInputRef = useRef<HTMLInputElement | null>(null);
-  const highlightedOptionRef = useRef<HTMLButtonElement | null>(null);
-
-  // The controller owns all branch-load orchestration (lazy load, in-flight
-  // de-duplication, caching, loading/error state). It is created inside the
-  // subscribe effect (and held in a ref) rather than in `useState`, mirroring
-  // AgentMentionSearchController: a persisted instance disposed on effect
-  // cleanup would stay permanently disposed after React StrictMode's
-  // mount -> cleanup -> remount cycle, so `ensureLoaded` would never run.
-  const reviewBranchControllerRef = useRef<AgentReviewBranchController | null>(
-    null
-  );
-  const [branchState, setBranchState] = useState<AgentReviewBranchState>({
-    status: "idle",
-    branches: [],
-    currentBranch: null,
-    error: null
-  });
-
-  useEffect(() => {
-    const controller = new AgentReviewBranchController();
-    reviewBranchControllerRef.current = controller;
-    const unsubscribe = controller.subscribe(setBranchState);
-    return () => {
-      unsubscribe();
-      controller.dispose();
-      reviewBranchControllerRef.current = null;
-    };
-  }, []);
-
-  // Keep the controller pointed at the current loader and trigger a lazy load
-  // once the user drills into the base-branch stage.
-  useEffect(() => {
-    const controller = reviewBranchControllerRef.current;
-    if (!controller) {
-      return;
-    }
-    controller.setLoader(onRequestGitBranches ?? null);
-    if (stage === "base") {
-      controller.ensureLoaded();
-    }
-  }, [onRequestGitBranches, stage]);
-
-  // Keep focus in the search field as the user drills between stages.
-  useEffect(() => {
-    searchInputRef.current?.focus();
-  }, [stage]);
-
-  const submit = useCallback(
-    (command: string): void => {
-      onSubmitReview(command);
-    },
-    [onSubmitReview]
-  );
-
-  const goToStage = useCallback((next: ReviewStage): void => {
-    setStage(next);
-    setQuery("");
-    setHighlightedIndex(0);
-  }, []);
-
-  const goBackToRoot = useCallback((): void => {
-    setStage("root");
-    setQuery("");
-    setHighlightedIndex(0);
-  }, []);
-
-  const trimmedQuery = query.trim();
-  const normalizedQuery = trimmedQuery.toLowerCase();
-
-  const entries = useMemo<ReviewMenuEntry[]>(() => {
-    if (stage === "root") {
-      const options: ReviewMenuEntry[] = [
-        {
-          key: "uncommitted",
-          label: labels.uncommitted,
-          onSelect: () => submit("/review")
-        },
-        {
-          key: "base",
-          label: labels.baseBranch,
-          onSelect: () => goToStage("base")
-        },
-        {
-          key: "commit",
-          label: labels.commit,
-          onSelect: () => goToStage("commit")
-        },
-        {
-          key: "custom",
-          label: labels.custom,
-          onSelect: () => goToStage("custom")
-        }
-      ];
-      if (normalizedQuery === "") {
-        return options;
-      }
-      return options.filter((option) =>
-        option.label.toLowerCase().includes(normalizedQuery)
-      );
-    }
-    if (stage === "base") {
-      const branches =
-        normalizedQuery === ""
-          ? branchState.branches
-          : branchState.branches.filter((name) =>
-              name.toLowerCase().includes(normalizedQuery)
-            );
-      return branches.map((name) => ({
-        key: `branch:${name}`,
-        label: name,
-        onSelect: () => submit(`/review base:${name}`)
-      }));
-    }
-    // commit / custom: the search box doubles as the free-text input; the single
-    // confirm entry submits the typed value when non-empty.
-    const prefix = stage === "commit" ? "commit" : "custom";
-    return [
-      {
-        key: `${prefix}-confirm`,
-        label: labels.submit,
-        description: trimmedQuery || undefined,
-        disabled: trimmedQuery === "",
-        onSelect: () => {
-          if (trimmedQuery !== "") {
-            submit(`/review ${prefix}:${trimmedQuery}`);
-          }
-        }
-      }
-    ];
-  }, [
-    stage,
-    normalizedQuery,
-    trimmedQuery,
-    branchState.branches,
-    labels.uncommitted,
-    labels.baseBranch,
-    labels.commit,
-    labels.custom,
-    labels.submit,
-    submit,
-    goToStage
-  ]);
-
-  const safeHighlightedIndex =
-    entries.length === 0 ? -1 : Math.min(highlightedIndex, entries.length - 1);
-
-  // Keep the highlighted entry visible while navigating a long list with the
-  // arrow keys (e.g. many branches).
-  useEffect(() => {
-    highlightedOptionRef.current?.scrollIntoView({ block: "nearest" });
-  }, [safeHighlightedIndex]);
-
-  const searchPlaceholder =
-    stage === "base"
-      ? labels.branchPlaceholder
-      : stage === "commit"
-        ? labels.commitPlaceholder
-        : stage === "custom"
-          ? labels.customPlaceholder
-          : labels.searchPlaceholder;
-
-  // Shown in place of the list when there are no entries (branch loading /
-  // empty repo / no search matches).
-  let emptyMessage = labels.noResults;
-  if (stage === "base") {
-    if (branchState.status === "loading") {
-      emptyMessage = labels.branchLoading;
-    } else if (branchState.branches.length === 0) {
-      emptyMessage = labels.branchEmpty;
-    }
-  }
-
-  const handleKeyDown = useCallback(
-    (event: React.KeyboardEvent<HTMLInputElement>): void => {
-      if (event.key === "ArrowDown") {
-        event.preventDefault();
-        setHighlightedIndex((current) =>
-          entries.length === 0 ? 0 : Math.min(current + 1, entries.length - 1)
-        );
-        return;
-      }
-      if (event.key === "ArrowUp") {
-        event.preventDefault();
-        setHighlightedIndex((current) => Math.max(current - 1, 0));
-        return;
-      }
-      if (event.key === "Enter") {
-        event.preventDefault();
-        event.stopPropagation();
-        const entry = entries[safeHighlightedIndex];
-        if (entry && !entry.disabled) {
-          entry.onSelect();
-        }
-        return;
-      }
-      if (event.key === "Escape") {
-        event.preventDefault();
-        event.stopPropagation();
-        if (stage === "root") {
-          onClose();
-        } else {
-          goBackToRoot();
-        }
-        return;
-      }
-      if (event.key === "Backspace" && query === "" && stage !== "root") {
-        event.preventDefault();
-        goBackToRoot();
-      }
-    },
-    [entries, safeHighlightedIndex, stage, query, onClose, goBackToRoot]
-  );
-
-  return (
-    <section
-      className={reviewMenuStyles.panel}
-      data-testid="agent-gui-review-picker-panel"
-      role="dialog"
-      aria-label={labels.title}
-    >
-      <input
-        ref={searchInputRef}
-        type="search"
-        className={reviewMenuStyles.search}
-        value={query}
-        placeholder={searchPlaceholder}
-        aria-label={searchPlaceholder}
-        onChange={(event) => {
-          setQuery(event.target.value);
-          setHighlightedIndex(0);
-        }}
-        onKeyDown={handleKeyDown}
-      />
-      <div
-        className={reviewMenuStyles.list}
-        role="listbox"
-        aria-label={labels.title}
-      >
-        {entries.length === 0 ? (
-          <div className={reviewMenuStyles.message}>{emptyMessage}</div>
-        ) : (
-          entries.map((entry, index) => {
-            const isHighlighted = index === safeHighlightedIndex;
-            return (
-              <button
-                key={entry.key}
-                ref={isHighlighted ? highlightedOptionRef : null}
-                type="button"
-                className={cn(
-                  reviewMenuStyles.option,
-                  isHighlighted && "bg-[var(--transparency-block)]"
-                )}
-                role="option"
-                aria-selected={isHighlighted}
-                data-highlighted={isHighlighted ? "" : undefined}
-                disabled={entry.disabled}
-                onMouseEnter={() => setHighlightedIndex(index)}
-                onMouseDown={(event) => event.preventDefault()}
-                onClick={() => {
-                  if (!entry.disabled) {
-                    entry.onSelect();
-                  }
-                }}
-              >
-                <span className={reviewMenuStyles.copy}>
-                  <span className={reviewMenuStyles.name}>{entry.label}</span>
-                  {entry.description ? (
-                    <span className={reviewMenuStyles.description}>
-                      {entry.description}
-                    </span>
-                  ) : null}
-                </span>
-              </button>
-            );
-          })
-        )}
-      </div>
-    </section>
-  );
 }
 
 export function AgentComposer({
@@ -991,6 +504,7 @@ export function AgentComposer({
     });
   const composerRef = useRef<HTMLFormElement | null>(null);
   const inputShellRef = useRef<HTMLDivElement | null>(null);
+  const promptInputAreaRef = useRef<HTMLDivElement | null>(null);
   const paletteContentRef = useRef<HTMLDivElement | null>(null);
   const draftPromptRef = useRef(draftPrompt);
   const submittedImagePreviewObservedBusyRef = useRef(false);
@@ -1114,6 +628,8 @@ export function AgentComposer({
         skillQueryMatch !== null &&
         filteredSkills.length > 0));
   const showPalette = showFileMentionPalette || showSlashPalette;
+  const showCommandMenuPanel = isSlashStatusPanelOpen || isReviewPickerOpen;
+  const showFloatingCommandMenu = showSlashPalette || showCommandMenuPanel;
   const activeHighlight = clampSlashCommandHighlight(
     highlightedIndex,
     slashPaletteEntries.length
@@ -1123,8 +639,6 @@ export function AgentComposer({
     [mentionSearchState]
   );
   const [mentionPaletteFrame, setMentionPaletteFrame] =
-    useState<MentionPaletteFrame | null>(null);
-  const [slashPaletteFrame, setSlashPaletteFrame] =
     useState<MentionPaletteFrame | null>(null);
 
   useEffect(() => {
@@ -1211,6 +725,12 @@ export function AgentComposer({
     setIsReviewPickerOpen(false);
   }, []);
 
+  const closeSlashFloatingMenu = useCallback((): void => {
+    setIsSlashStatusPanelOpen(false);
+    setIsReviewPickerOpen(false);
+    setIsPaletteOpen(false);
+  }, []);
+
   const submitReviewCommand = useCallback(
     (command: string): void => {
       setIsReviewPickerOpen(false);
@@ -1252,11 +772,13 @@ export function AgentComposer({
       }
       if (effect.kind === "showStatus") {
         clearSlashCommandDraft();
+        setIsReviewPickerOpen(false);
         setIsSlashStatusPanelOpen((current) => !current);
         return;
       }
       if (effect.kind === "showReviewPicker") {
         clearSlashCommandDraft();
+        setIsSlashStatusPanelOpen(false);
         setIsReviewPickerOpen(true);
         return;
       }
@@ -1462,6 +984,17 @@ export function AgentComposer({
         return true;
       }
       return false;
+    }
+  );
+
+  const handleSlashCommandMenuKeyDown = useStableEventCallback(
+    (event: KeyboardEvent): boolean => {
+      if (!showCommandMenuPanel || event.key !== "Escape") {
+        return false;
+      }
+      event.preventDefault();
+      closeSlashFloatingMenu();
+      return true;
     }
   );
 
@@ -1678,11 +1211,12 @@ export function AgentComposer({
     (event: KeyboardEvent): boolean =>
       handleFileMentionKeyDown(event) ||
       handleSlashPaletteKeyDown(event) ||
+      handleSlashCommandMenuKeyDown(event) ||
       handleModeCycleKeyDown(event)
   );
 
   useEffect(() => {
-    if (!showPalette) {
+    if (!showFileMentionPalette) {
       return;
     }
     const handleDocumentKeyDown = (event: KeyboardEvent): void => {
@@ -1754,7 +1288,7 @@ export function AgentComposer({
   }, [shouldCenterMentionHighlight, showFileMentionPalette]);
 
   useEffect(() => {
-    if (!showPalette) {
+    if (!showFileMentionPalette) {
       return;
     }
 
@@ -1781,7 +1315,7 @@ export function AgentComposer({
       });
       window.removeEventListener("resize", handleWindowResize);
     };
-  }, [closeOpenPalette, showPalette]);
+  }, [closeOpenPalette, showFileMentionPalette]);
 
   const handleDraftChange = useStableEventCallback(
     (nextDraft: string): void => {
@@ -1913,56 +1447,6 @@ export function AgentComposer({
     });
   }, []);
 
-  const syncSlashPaletteFrame = useCallback((): void => {
-    const anchor = inputShellRef.current;
-    if (!anchor || typeof window === "undefined") {
-      setSlashPaletteFrame(null);
-      return;
-    }
-
-    const rect = anchor.getBoundingClientRect();
-    const viewportWidth = window.innerWidth;
-    const viewportHeight = window.innerHeight;
-    const width = Math.max(
-      0,
-      Math.min(
-        rect.width,
-        viewportWidth - MENTION_PALETTE_VIEWPORT_PADDING_PX * 2
-      )
-    );
-    const left = Math.max(
-      MENTION_PALETTE_VIEWPORT_PADDING_PX,
-      Math.min(
-        rect.left,
-        viewportWidth - MENTION_PALETTE_VIEWPORT_PADDING_PX - width
-      )
-    );
-    const availableAbove =
-      rect.top - MENTION_PALETTE_GAP_PX - MENTION_PALETTE_VIEWPORT_PADDING_PX;
-    const height =
-      availableAbove >= SLASH_PALETTE_HEIGHT_PX
-        ? SLASH_PALETTE_HEIGHT_PX
-        : Math.max(
-            MENTION_PALETTE_MIN_HEIGHT_PX,
-            Math.min(SLASH_PALETTE_HEIGHT_PX, availableAbove)
-          );
-
-    setSlashPaletteFrame({
-      height,
-      left,
-      portalTarget: resolveMentionPalettePortalTarget(anchor),
-      top: Math.max(
-        MENTION_PALETTE_VIEWPORT_PADDING_PX,
-        Math.min(
-          rect.top - MENTION_PALETTE_GAP_PX - height,
-          viewportHeight - MENTION_PALETTE_VIEWPORT_PADDING_PX - height
-        )
-      ),
-      width,
-      zIndex: resolveMentionPaletteZIndex(anchor)
-    });
-  }, []);
-
   useLayoutEffect(() => {
     if (!showFileMentionPalette) {
       setMentionPaletteFrame(null);
@@ -1990,33 +1474,6 @@ export function AgentComposer({
     };
   }, [showFileMentionPalette, syncMentionPaletteFrame]);
 
-  useLayoutEffect(() => {
-    if (!showSlashPalette) {
-      setSlashPaletteFrame(null);
-      return;
-    }
-
-    syncSlashPaletteFrame();
-    const anchor = inputShellRef.current;
-    const resizeObserver =
-      typeof ResizeObserver === "undefined"
-        ? null
-        : new ResizeObserver(syncSlashPaletteFrame);
-    if (anchor) {
-      resizeObserver?.observe(anchor);
-    }
-    window.addEventListener("resize", syncSlashPaletteFrame);
-    window.addEventListener("scroll", syncSlashPaletteFrame, {
-      capture: true,
-      passive: true
-    });
-    return () => {
-      resizeObserver?.disconnect();
-      window.removeEventListener("resize", syncSlashPaletteFrame);
-      window.removeEventListener("scroll", syncSlashPaletteFrame, true);
-    };
-  }, [showSlashPalette, syncSlashPaletteFrame]);
-
   const mentionPaletteStyle = useMemo<CSSProperties>(
     () => ({
       position: "fixed",
@@ -2033,21 +1490,6 @@ export function AgentComposer({
   );
   const mentionPaletteHeightPx =
     mentionPaletteFrame?.height ?? MENTION_PALETTE_MIN_HEIGHT_PX;
-  const slashPaletteStyle = useMemo<CSSProperties>(
-    () => ({
-      position: "fixed",
-      left: `${slashPaletteFrame?.left ?? 0}px`,
-      top: `${slashPaletteFrame?.top ?? 0}px`,
-      width: `${slashPaletteFrame?.width ?? 0}px`,
-      maxWidth: `${slashPaletteFrame?.width ?? 0}px`,
-      minHeight: `${MENTION_PALETTE_MIN_HEIGHT_PX}px`,
-      height: `${slashPaletteFrame?.height ?? SLASH_PALETTE_HEIGHT_PX}px`,
-      maxHeight: `${SLASH_PALETTE_HEIGHT_PX}px`,
-      overflow: "hidden",
-      zIndex: composerPaletteZIndex
-    }),
-    [slashPaletteFrame]
-  );
   const composerClassName =
     layoutMode === "hero" ? styles.composerHero : styles.composer;
   const inputShellClassName = cn(
@@ -2229,8 +1671,11 @@ export function AgentComposer({
     };
   }, [activePromptTipId, activePromptTipText, isPromptTipOverflowing]);
   const inputShellStyle = useMemo<CSSProperties | undefined>(
-    () => (showPalette ? { zIndex: composerPaletteZIndex } : undefined),
-    [showPalette]
+    () =>
+      showFileMentionPalette || showFloatingCommandMenu
+        ? { zIndex: composerPaletteZIndex }
+        : undefined,
+    [showFileMentionPalette, showFloatingCommandMenu]
   );
   const hasDraftContent = agentComposerDraftHasContent(draftContent);
   const isQueueMode = canQueueWhileBusy && hasDraftContent;
@@ -2426,35 +1871,10 @@ export function AgentComposer({
             description={labels.projectMissingDescription}
           />
         ) : null}
-        {isSlashStatusPanelOpen ? (
-          <AgentSlashStatusPanel
-            status={slashStatus}
-            labels={{
-              slashStatusTitle: labels.slashStatusTitle,
-              slashStatusSession: labels.slashStatusSession,
-              slashStatusBaseUrl: labels.slashStatusBaseUrl,
-              slashStatusContext: labels.slashStatusContext,
-              slashStatusLimits: labels.slashStatusLimits,
-              slashStatusClose: labels.slashStatusClose,
-              slashStatusContextValue: labels.slashStatusContextValue,
-              slashStatusContextUnavailable:
-                labels.slashStatusContextUnavailable,
-              slashStatusLimitsUnavailable: labels.slashStatusLimitsUnavailable
-            }}
-            onClose={closeSlashStatusPanel}
-          />
-        ) : null}
-        {isReviewPickerOpen ? (
-          <AgentReviewPickerPanel
-            labels={labels.reviewPicker}
-            onRequestGitBranches={reviewBranchLoader}
-            onSubmitReview={submitReviewCommand}
-            onClose={closeReviewPicker}
-          />
-        ) : null}
         <div
           ref={inputShellRef}
           className={cn(inputShellClassName, "relative")}
+          data-testid="agent-gui-composer-input-shell"
           data-input-disabled={inputDisabled ? "true" : undefined}
           title={
             inputDisabled && disabledReasonText ? disabledReasonText : undefined
@@ -2462,12 +1882,12 @@ export function AgentComposer({
           style={inputShellStyle}
         >
           <Popover
-            open={showPalette}
+            open={showFileMentionPalette}
             onOpenChange={setIsPaletteOpen}
             modal={false}
           >
             <PopoverAnchor asChild>
-              <div className="min-w-0 self-start">
+              <div ref={promptInputAreaRef} className="min-w-0 self-start">
                 {visibleDraftImages.length > 0 ? (
                   <div
                     className="mb-2 grid max-w-[320px] grid-cols-[repeat(auto-fill,minmax(56px,1fr))] gap-2"
@@ -2564,40 +1984,82 @@ export function AgentComposer({
                   mentionPaletteFrame.portalTarget
                 )
               : null}
-            {showSlashPalette && slashPaletteFrame
-              ? createPortal(
-                  <div
-                    data-testid="agent-gui-slash-palette-surface"
-                    ref={paletteContentRef}
-                    className={cn(
-                      composerStyles.dropdownSurface,
-                      composerStyles.slashDropdown,
-                      "max-h-[320px] border-0 p-0"
-                    )}
-                    style={slashPaletteStyle}
-                  >
-                    <AgentSlashCommandPalette
-                      entries={slashPaletteEntries}
-                      highlightedIndex={activeHighlight}
-                      label={
-                        slashQuery === null
-                          ? labels.skillPickerPalette
-                          : labels.slashCommandPalette
-                      }
-                      commandsGroupLabel={labels.slashPaletteCommandsGroup}
-                      capabilitiesGroupLabel={
-                        labels.slashPaletteCapabilitiesGroup
-                      }
-                      skillsGroupLabel={labels.slashPaletteSkillsGroup}
-                      onHighlightChange={setHighlightedIndex}
-                      onSelect={selectCommand}
-                      onSelectCapability={selectCapability}
-                      onSelectSkill={selectSkill}
-                    />
-                  </div>,
-                  slashPaletteFrame.portalTarget
-                )
-              : null}
+            <ComposerFloatingMenuSurface
+              anchorRef={inputShellRef}
+              className="max-h-[320px] border-0 p-0"
+              contentClassName="h-full min-h-0"
+              dismissBoundaryRef={promptInputAreaRef}
+              maxHeight={SLASH_PALETTE_HEIGHT_PX}
+              onDismiss={closeSlashFloatingMenu}
+              open={showSlashPalette}
+              placement="fixed-height"
+              surfaceRef={paletteContentRef}
+              testId="agent-gui-slash-palette-surface"
+            >
+              <AgentSlashCommandPalette
+                entries={slashPaletteEntries}
+                highlightedIndex={activeHighlight}
+                label={
+                  slashQuery === null
+                    ? labels.skillPickerPalette
+                    : labels.slashCommandPalette
+                }
+                commandsGroupLabel={labels.slashPaletteCommandsGroup}
+                capabilitiesGroupLabel={labels.slashPaletteCapabilitiesGroup}
+                skillsGroupLabel={labels.slashPaletteSkillsGroup}
+                onHighlightChange={setHighlightedIndex}
+                onSelect={selectCommand}
+                onSelectCapability={selectCapability}
+                onSelectSkill={selectSkill}
+              />
+            </ComposerFloatingMenuSurface>
+            <ComposerFloatingMenuSurface
+              anchorRef={inputShellRef}
+              className="border-0 p-0"
+              dismissBoundaryRef={promptInputAreaRef}
+              maxHeight={SLASH_PALETTE_HEIGHT_PX}
+              onDismiss={closeSlashFloatingMenu}
+              open={isSlashStatusPanelOpen}
+              placement="dynamic-above"
+              surfaceRef={paletteContentRef}
+              testId="agent-gui-command-menu-surface"
+            >
+              <AgentSlashStatusPanel
+                status={slashStatus}
+                labels={{
+                  slashStatusTitle: labels.slashStatusTitle,
+                  slashStatusSession: labels.slashStatusSession,
+                  slashStatusBaseUrl: labels.slashStatusBaseUrl,
+                  slashStatusContext: labels.slashStatusContext,
+                  slashStatusLimits: labels.slashStatusLimits,
+                  slashStatusClose: labels.slashStatusClose,
+                  slashStatusContextValue: labels.slashStatusContextValue,
+                  slashStatusContextUnavailable:
+                    labels.slashStatusContextUnavailable,
+                  slashStatusLimitsUnavailable:
+                    labels.slashStatusLimitsUnavailable
+                }}
+                onClose={closeSlashStatusPanel}
+              />
+            </ComposerFloatingMenuSurface>
+            <ComposerFloatingMenuSurface
+              anchorRef={inputShellRef}
+              className="border-0 p-0"
+              dismissBoundaryRef={promptInputAreaRef}
+              maxHeight={SLASH_PALETTE_HEIGHT_PX}
+              onDismiss={closeSlashFloatingMenu}
+              open={isReviewPickerOpen}
+              placement="dynamic-above"
+              surfaceRef={paletteContentRef}
+              testId="agent-gui-command-menu-surface"
+            >
+              <AgentReviewPickerPanel
+                labels={labels.reviewPicker}
+                onRequestGitBranches={reviewBranchLoader}
+                onSubmitReview={submitReviewCommand}
+                onClose={closeReviewPicker}
+              />
+            </ComposerFloatingMenuSurface>
           </Popover>
           <div className={styles.composerFooter}>
             <div className={composerStyles.footerGroup}>

--- a/packages/agent/gui/agent-gui/agentGuiNode/AgentReviewPickerPanel.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/AgentReviewPickerPanel.tsx
@@ -1,0 +1,337 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { menuItemClassName } from "@tutti-os/ui-system";
+import { cn } from "../../app/renderer/lib/utils";
+import {
+  AgentReviewBranchController,
+  type AgentReviewBranchState
+} from "./AgentReviewBranchController";
+
+type ReviewStage = "root" | "base" | "commit" | "custom";
+
+interface ReviewMenuEntry {
+  key: string;
+  label: string;
+  description?: string;
+  disabled?: boolean;
+  onSelect: () => void;
+}
+
+export interface AgentReviewPickerLabels {
+  title: string;
+  searchPlaceholder: string;
+  noResults: string;
+  uncommitted: string;
+  baseBranch: string;
+  commit: string;
+  custom: string;
+  branchPlaceholder: string;
+  branchLoading: string;
+  branchEmpty: string;
+  commitPlaceholder: string;
+  customPlaceholder: string;
+  submit: string;
+}
+
+export interface AgentReviewPickerGitBranches {
+  branches: readonly string[];
+  currentBranch?: string | null;
+}
+
+const reviewMenuStyles = {
+  panel:
+    "agent-gui-node__slash-status-panel nodrag flex max-h-[280px] flex-col gap-1 overflow-hidden [-webkit-app-region:no-drag]",
+  search:
+    "nodrag h-8 w-full shrink-0 rounded-[6px] border-0 bg-transparent px-2.5 text-[11px] leading-4 text-[var(--text-primary)] placeholder:text-[var(--text-secondary)] focus-visible:outline-none [-webkit-app-region:no-drag]",
+  list: "flex min-h-0 flex-1 flex-col gap-1 overflow-y-auto",
+  option: cn(
+    menuItemClassName,
+    "nodrag min-h-9 w-full min-w-0 justify-start overflow-hidden rounded-[6px] border-0 bg-transparent px-2.5 py-2 text-left hover:bg-[var(--transparency-block)] focus:bg-[var(--transparency-block)] focus-visible:outline-none data-[highlighted]:bg-[var(--transparency-block)] active:bg-[var(--transparency-active)] disabled:pointer-events-none disabled:opacity-50"
+  ),
+  copy: "flex min-w-0 flex-1 items-baseline gap-1 overflow-hidden leading-[16px]",
+  name: "min-w-0 shrink-0 truncate text-[11px] font-semibold text-[var(--text-primary)]",
+  description:
+    "min-w-0 flex-1 truncate text-[11px] font-normal text-[var(--text-secondary)]",
+  message:
+    "select-none px-2.5 py-2 text-[11px] leading-4 text-[var(--text-secondary)]"
+};
+
+export function AgentReviewPickerPanel({
+  labels,
+  onRequestGitBranches,
+  onSubmitReview,
+  onClose
+}: {
+  labels: AgentReviewPickerLabels;
+  onRequestGitBranches?: (() => Promise<AgentReviewPickerGitBranches>) | null;
+  onSubmitReview: (command: string) => void;
+  onClose: () => void;
+}): React.JSX.Element {
+  const [stage, setStage] = useState<ReviewStage>("root");
+  const [query, setQuery] = useState("");
+  const [highlightedIndex, setHighlightedIndex] = useState(0);
+  const searchInputRef = useRef<HTMLInputElement | null>(null);
+  const highlightedOptionRef = useRef<HTMLButtonElement | null>(null);
+
+  const reviewBranchControllerRef = useRef<AgentReviewBranchController | null>(
+    null
+  );
+  const [branchState, setBranchState] = useState<AgentReviewBranchState>({
+    status: "idle",
+    branches: [],
+    currentBranch: null,
+    error: null
+  });
+
+  useEffect(() => {
+    const controller = new AgentReviewBranchController();
+    reviewBranchControllerRef.current = controller;
+    const unsubscribe = controller.subscribe(setBranchState);
+    return () => {
+      unsubscribe();
+      controller.dispose();
+      reviewBranchControllerRef.current = null;
+    };
+  }, []);
+
+  useEffect(() => {
+    const controller = reviewBranchControllerRef.current;
+    if (!controller) {
+      return;
+    }
+    controller.setLoader(onRequestGitBranches ?? null);
+    if (stage === "base") {
+      controller.ensureLoaded();
+    }
+  }, [onRequestGitBranches, stage]);
+
+  useEffect(() => {
+    searchInputRef.current?.focus();
+  }, [stage]);
+
+  const submit = useCallback(
+    (command: string): void => {
+      onSubmitReview(command);
+    },
+    [onSubmitReview]
+  );
+
+  const goToStage = useCallback((next: ReviewStage): void => {
+    setStage(next);
+    setQuery("");
+    setHighlightedIndex(0);
+  }, []);
+
+  const goBackToRoot = useCallback((): void => {
+    setStage("root");
+    setQuery("");
+    setHighlightedIndex(0);
+  }, []);
+
+  const trimmedQuery = query.trim();
+  const normalizedQuery = trimmedQuery.toLowerCase();
+
+  const entries = useMemo<ReviewMenuEntry[]>(() => {
+    if (stage === "root") {
+      const options: ReviewMenuEntry[] = [
+        {
+          key: "uncommitted",
+          label: labels.uncommitted,
+          onSelect: () => submit("/review")
+        },
+        {
+          key: "base",
+          label: labels.baseBranch,
+          onSelect: () => goToStage("base")
+        },
+        {
+          key: "commit",
+          label: labels.commit,
+          onSelect: () => goToStage("commit")
+        },
+        {
+          key: "custom",
+          label: labels.custom,
+          onSelect: () => goToStage("custom")
+        }
+      ];
+      if (normalizedQuery === "") {
+        return options;
+      }
+      return options.filter((option) =>
+        option.label.toLowerCase().includes(normalizedQuery)
+      );
+    }
+    if (stage === "base") {
+      const branches =
+        normalizedQuery === ""
+          ? branchState.branches
+          : branchState.branches.filter((name) =>
+              name.toLowerCase().includes(normalizedQuery)
+            );
+      return branches.map((name) => ({
+        key: `branch:${name}`,
+        label: name,
+        onSelect: () => submit(`/review base:${name}`)
+      }));
+    }
+    const prefix = stage === "commit" ? "commit" : "custom";
+    return [
+      {
+        key: `${prefix}-confirm`,
+        label: labels.submit,
+        description: trimmedQuery || undefined,
+        disabled: trimmedQuery === "",
+        onSelect: () => {
+          if (trimmedQuery !== "") {
+            submit(`/review ${prefix}:${trimmedQuery}`);
+          }
+        }
+      }
+    ];
+  }, [
+    stage,
+    normalizedQuery,
+    trimmedQuery,
+    branchState.branches,
+    labels.uncommitted,
+    labels.baseBranch,
+    labels.commit,
+    labels.custom,
+    labels.submit,
+    submit,
+    goToStage
+  ]);
+
+  const safeHighlightedIndex =
+    entries.length === 0 ? -1 : Math.min(highlightedIndex, entries.length - 1);
+
+  useEffect(() => {
+    highlightedOptionRef.current?.scrollIntoView({ block: "nearest" });
+  }, [safeHighlightedIndex]);
+
+  const searchPlaceholder =
+    stage === "base"
+      ? labels.branchPlaceholder
+      : stage === "commit"
+        ? labels.commitPlaceholder
+        : stage === "custom"
+          ? labels.customPlaceholder
+          : labels.searchPlaceholder;
+
+  let emptyMessage = labels.noResults;
+  if (stage === "base") {
+    if (branchState.status === "loading") {
+      emptyMessage = labels.branchLoading;
+    } else if (branchState.branches.length === 0) {
+      emptyMessage = labels.branchEmpty;
+    }
+  }
+
+  const handleKeyDown = useCallback(
+    (event: React.KeyboardEvent<HTMLInputElement>): void => {
+      if (event.key === "ArrowDown") {
+        event.preventDefault();
+        setHighlightedIndex((current) =>
+          entries.length === 0 ? 0 : Math.min(current + 1, entries.length - 1)
+        );
+        return;
+      }
+      if (event.key === "ArrowUp") {
+        event.preventDefault();
+        setHighlightedIndex((current) => Math.max(current - 1, 0));
+        return;
+      }
+      if (event.key === "Enter") {
+        event.preventDefault();
+        event.stopPropagation();
+        const entry = entries[safeHighlightedIndex];
+        if (entry && !entry.disabled) {
+          entry.onSelect();
+        }
+        return;
+      }
+      if (event.key === "Escape") {
+        event.preventDefault();
+        event.stopPropagation();
+        if (stage === "root") {
+          onClose();
+        } else {
+          goBackToRoot();
+        }
+        return;
+      }
+      if (event.key === "Backspace" && query === "" && stage !== "root") {
+        event.preventDefault();
+        goBackToRoot();
+      }
+    },
+    [entries, safeHighlightedIndex, stage, query, onClose, goBackToRoot]
+  );
+
+  return (
+    <section
+      className={reviewMenuStyles.panel}
+      data-testid="agent-gui-review-picker-panel"
+      role="dialog"
+      aria-label={labels.title}
+    >
+      <input
+        ref={searchInputRef}
+        type="search"
+        className={reviewMenuStyles.search}
+        value={query}
+        placeholder={searchPlaceholder}
+        aria-label={searchPlaceholder}
+        onChange={(event) => {
+          setQuery(event.target.value);
+          setHighlightedIndex(0);
+        }}
+        onKeyDown={handleKeyDown}
+      />
+      <div
+        className={reviewMenuStyles.list}
+        role="listbox"
+        aria-label={labels.title}
+      >
+        {entries.length === 0 ? (
+          <div className={reviewMenuStyles.message}>{emptyMessage}</div>
+        ) : (
+          entries.map((entry, index) => {
+            const isHighlighted = index === safeHighlightedIndex;
+            return (
+              <button
+                key={entry.key}
+                ref={isHighlighted ? highlightedOptionRef : null}
+                type="button"
+                className={cn(
+                  reviewMenuStyles.option,
+                  isHighlighted && "bg-[var(--transparency-block)]"
+                )}
+                role="option"
+                aria-selected={isHighlighted}
+                data-highlighted={isHighlighted ? "" : undefined}
+                disabled={entry.disabled}
+                onMouseEnter={() => setHighlightedIndex(index)}
+                onMouseDown={(event) => event.preventDefault()}
+                onClick={() => {
+                  if (!entry.disabled) {
+                    entry.onSelect();
+                  }
+                }}
+              >
+                <span className={reviewMenuStyles.copy}>
+                  <span className={reviewMenuStyles.name}>{entry.label}</span>
+                  {entry.description ? (
+                    <span className={reviewMenuStyles.description}>
+                      {entry.description}
+                    </span>
+                  ) : null}
+                </span>
+              </button>
+            );
+          })
+        )}
+      </div>
+    </section>
+  );
+}

--- a/packages/agent/gui/agent-gui/agentGuiNode/AgentSlashStatusPanel.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/AgentSlashStatusPanel.tsx
@@ -1,0 +1,180 @@
+import { Fragment } from "react";
+
+export interface AgentSlashStatusPanelStatus {
+  agentSessionId?: string | null;
+  baseUrl?: string | null;
+  contextWindow?: {
+    usedTokens?: number | null;
+    totalTokens?: number | null;
+  } | null;
+  limits?: readonly AgentSlashStatusPanelLimit[];
+  limitsLoading?: boolean;
+}
+
+export interface AgentSlashStatusPanelLimit {
+  id: string;
+  label: string;
+  percentRemaining?: number | null;
+  value: string;
+  reset?: string | null;
+}
+
+export interface AgentSlashStatusPanelLabels {
+  slashStatusTitle: string;
+  slashStatusSession: string;
+  slashStatusBaseUrl: string;
+  slashStatusContext: string;
+  slashStatusLimits: string;
+  slashStatusClose: string;
+  slashStatusContextValue: (input: {
+    percentLeft: number;
+    usedTokens: string;
+    totalTokens: string;
+  }) => string;
+  slashStatusContextUnavailable: string;
+  slashStatusLimitsUnavailable: string;
+}
+
+export function formatSlashStatusTokenCount(
+  value: number | null | undefined
+): string {
+  if (typeof value !== "number" || !Number.isFinite(value)) {
+    return "";
+  }
+  return Math.max(0, Math.trunc(value)).toLocaleString("en-US");
+}
+
+function slashStatusContextText(
+  status: AgentSlashStatusPanelStatus | null | undefined,
+  labels: Pick<
+    AgentSlashStatusPanelLabels,
+    "slashStatusContextValue" | "slashStatusContextUnavailable"
+  >
+): string {
+  const usedTokens = status?.contextWindow?.usedTokens;
+  const totalTokens = status?.contextWindow?.totalTokens;
+  if (
+    typeof usedTokens !== "number" ||
+    !Number.isFinite(usedTokens) ||
+    typeof totalTokens !== "number" ||
+    !Number.isFinite(totalTokens) ||
+    totalTokens <= 0
+  ) {
+    return labels.slashStatusContextUnavailable;
+  }
+  const used = Math.max(0, Math.trunc(usedTokens));
+  const total = Math.max(0, Math.trunc(totalTokens));
+  const percentLeft = Math.max(
+    0,
+    Math.min(100, Math.round(((total - used) / total) * 100))
+  );
+  return labels.slashStatusContextValue({
+    percentLeft,
+    usedTokens: formatSlashStatusTokenCount(used),
+    totalTokens: formatSlashStatusTokenCount(total)
+  });
+}
+
+export function AgentSlashStatusPanel({
+  status,
+  labels,
+  onClose
+}: {
+  status: AgentSlashStatusPanelStatus | null | undefined;
+  labels: AgentSlashStatusPanelLabels;
+  onClose: () => void;
+}): React.JSX.Element {
+  const limits = status?.limits ?? [];
+  const agentSessionId = status?.agentSessionId?.trim() ?? "";
+  const baseUrl = status?.baseUrl?.trim() ?? "";
+  const showSessionDetails = agentSessionId.length > 0;
+  return (
+    <section
+      className="agent-gui-node__slash-status-panel"
+      data-testid="agent-gui-slash-status-panel"
+      role="status"
+    >
+      <div className="mb-2 flex items-center justify-between gap-2">
+        <h3 className="truncate text-[11px] font-semibold leading-4">
+          {labels.slashStatusTitle}
+        </h3>
+        <button
+          className="nodrag shrink-0 rounded-[5px] px-1.5 py-0.5 text-[11px] leading-4 text-muted-foreground transition-colors hover:bg-background-hover hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring [-webkit-app-region:no-drag]"
+          type="button"
+          onClick={onClose}
+        >
+          {labels.slashStatusClose}
+        </button>
+      </div>
+      <dl className="grid grid-cols-[max-content_minmax(0,1fr)] gap-x-3 gap-y-1 font-mono text-[11px] leading-4">
+        {showSessionDetails ? (
+          <>
+            <dt className="text-muted-foreground">
+              {labels.slashStatusSession}:
+            </dt>
+            <dd className="min-w-0 truncate">{agentSessionId}</dd>
+            {baseUrl ? (
+              <>
+                <dt className="text-muted-foreground">
+                  {labels.slashStatusBaseUrl}:
+                </dt>
+                <dd className="min-w-0 truncate">{baseUrl}</dd>
+              </>
+            ) : null}
+            <dt className="text-muted-foreground">
+              {labels.slashStatusContext}:
+            </dt>
+            <dd className="min-w-0">
+              {slashStatusContextText(status, labels)}
+            </dd>
+          </>
+        ) : null}
+        {limits.map((limit) => (
+          <Fragment key={limit.id}>
+            <dt className="text-muted-foreground">{limit.label}:</dt>
+            <dd className="min-w-0">
+              <span className="agent-gui-node__slash-status-limit">
+                {typeof limit.percentRemaining === "number" &&
+                Number.isFinite(limit.percentRemaining) ? (
+                  <span
+                    aria-hidden="true"
+                    className="agent-gui-node__slash-status-limit-meter"
+                  >
+                    <span
+                      className="agent-gui-node__slash-status-limit-meter-fill"
+                      style={{
+                        width: `${Math.max(
+                          0,
+                          Math.min(100, limit.percentRemaining)
+                        )}%`
+                      }}
+                    />
+                  </span>
+                ) : null}
+                <span className="agent-gui-node__slash-status-limit-value">
+                  {limit.value}
+                  {limit.reset ? (
+                    <span className="text-muted-foreground">
+                      {" "}
+                      ({limit.reset})
+                    </span>
+                  ) : null}
+                </span>
+              </span>
+            </dd>
+          </Fragment>
+        ))}
+        {limits.length === 0 && status?.limitsLoading ? (
+          <>
+            <dt className="text-muted-foreground">
+              {labels.slashStatusLimits}:
+            </dt>
+            <dd className="min-w-0 text-muted-foreground">
+              {labels.slashStatusLimitsUnavailable}
+            </dd>
+          </>
+        ) : null}
+      </dl>
+    </section>
+  );
+}

--- a/packages/agent/gui/agent-gui/agentGuiNode/composerFloatingMenu/ComposerFloatingMenuSurface.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/composerFloatingMenu/ComposerFloatingMenuSurface.tsx
@@ -1,0 +1,346 @@
+import {
+  forwardRef,
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+  useState,
+  type CSSProperties,
+  type RefObject
+} from "react";
+import { createPortal } from "react-dom";
+import { cn } from "../../../app/renderer/lib/utils";
+
+const COMPOSER_MENU_GAP_PX = 8;
+const COMPOSER_MENU_VIEWPORT_PADDING_PX = 8;
+const COMPOSER_MENU_MIN_HEIGHT_PX = 280;
+
+export interface ComposerAnchoredMenuFrame {
+  bottom: number;
+  height: number;
+  left: number;
+  portalTarget: Element;
+  top: number;
+  width: number;
+  zIndex: number | string;
+}
+
+export interface UseComposerAnchoredMenuFrameOptions {
+  anchorRef: RefObject<HTMLElement | null>;
+  maxHeight: number;
+  open: boolean;
+}
+
+export type ComposerFloatingMenuPlacement = "fixed-height" | "dynamic-above";
+
+export interface ComposerFloatingMenuSurfaceProps {
+  anchorRef: RefObject<HTMLElement | null>;
+  children: React.ReactNode;
+  className?: string;
+  contentClassName?: string;
+  dismissBoundaryRef?: RefObject<HTMLElement | null>;
+  maxHeight: number;
+  onDismiss?: () => void;
+  open: boolean;
+  placement: ComposerFloatingMenuPlacement;
+  surfaceRef?: RefObject<HTMLDivElement | null>;
+  testId: string;
+}
+
+function resolveComposerMenuPortalTarget(anchor: HTMLElement): Element {
+  return (
+    anchor.closest('[data-slot="viewport-menu-boundary"]') ??
+    anchor.closest(
+      "[data-workbench-window-id], [data-workspace-node-window-root='true']"
+    ) ??
+    document.body
+  );
+}
+
+function resolveComposerMenuZIndex(anchor: HTMLElement): number | string {
+  let current: HTMLElement | null = anchor;
+  while (current) {
+    if (
+      current.matches(
+        "[data-workbench-window-id], [data-workspace-node-window-root='true']"
+      )
+    ) {
+      const windowZIndex = Number.parseInt(
+        window.getComputedStyle(current).zIndex,
+        10
+      );
+      if (Number.isFinite(windowZIndex)) {
+        return windowZIndex + 1;
+      }
+    }
+    current = current.parentElement;
+  }
+  return "var(--z-popover)";
+}
+
+function computeComposerAnchoredMenuFrame(
+  anchor: HTMLElement,
+  maxHeight: number
+): ComposerAnchoredMenuFrame {
+  const rect = anchor.getBoundingClientRect();
+  const viewportWidth = window.innerWidth;
+  const viewportHeight = window.innerHeight;
+  const width = Math.max(
+    0,
+    Math.min(rect.width, viewportWidth - COMPOSER_MENU_VIEWPORT_PADDING_PX * 2)
+  );
+  const left = Math.max(
+    COMPOSER_MENU_VIEWPORT_PADDING_PX,
+    Math.min(
+      rect.left,
+      viewportWidth - COMPOSER_MENU_VIEWPORT_PADDING_PX - width
+    )
+  );
+  const availableAbove =
+    rect.top - COMPOSER_MENU_GAP_PX - COMPOSER_MENU_VIEWPORT_PADDING_PX;
+  const height =
+    availableAbove >= maxHeight
+      ? maxHeight
+      : Math.max(
+          COMPOSER_MENU_MIN_HEIGHT_PX,
+          Math.min(maxHeight, availableAbove)
+        );
+
+  return {
+    bottom: Math.max(
+      COMPOSER_MENU_VIEWPORT_PADDING_PX,
+      viewportHeight - rect.top + COMPOSER_MENU_GAP_PX
+    ),
+    height,
+    left,
+    portalTarget: resolveComposerMenuPortalTarget(anchor),
+    top: Math.max(
+      COMPOSER_MENU_VIEWPORT_PADDING_PX,
+      Math.min(
+        rect.top - COMPOSER_MENU_GAP_PX - height,
+        viewportHeight - COMPOSER_MENU_VIEWPORT_PADDING_PX - height
+      )
+    ),
+    width,
+    zIndex: resolveComposerMenuZIndex(anchor)
+  };
+}
+
+function sameComposerAnchoredMenuFrame(
+  left: ComposerAnchoredMenuFrame | null,
+  right: ComposerAnchoredMenuFrame
+): boolean {
+  return (
+    left !== null &&
+    left.portalTarget === right.portalTarget &&
+    left.zIndex === right.zIndex &&
+    Math.abs(left.left - right.left) < 0.5 &&
+    Math.abs(left.top - right.top) < 0.5 &&
+    Math.abs(left.bottom - right.bottom) < 0.5 &&
+    Math.abs(left.width - right.width) < 0.5 &&
+    Math.abs(left.height - right.height) < 0.5
+  );
+}
+
+export function useComposerAnchoredMenuFrame({
+  anchorRef,
+  maxHeight,
+  open
+}: UseComposerAnchoredMenuFrameOptions): ComposerAnchoredMenuFrame | null {
+  const [frame, setFrame] = useState<ComposerAnchoredMenuFrame | null>(null);
+
+  const syncFrame = useCallback((): void => {
+    const anchor = anchorRef.current;
+    if (!anchor || typeof window === "undefined") {
+      setFrame(null);
+      return;
+    }
+
+    const nextFrame = computeComposerAnchoredMenuFrame(anchor, maxHeight);
+    setFrame((previous) =>
+      sameComposerAnchoredMenuFrame(previous, nextFrame) ? previous : nextFrame
+    );
+  }, [anchorRef, maxHeight]);
+
+  useLayoutEffect(() => {
+    if (!open) {
+      setFrame(null);
+      return;
+    }
+
+    syncFrame();
+    const anchor = anchorRef.current;
+    const resizeObserver =
+      typeof ResizeObserver === "undefined"
+        ? null
+        : new ResizeObserver(syncFrame);
+    if (anchor) {
+      resizeObserver?.observe(anchor);
+    }
+    window.addEventListener("resize", syncFrame);
+    window.addEventListener("scroll", syncFrame, {
+      capture: true,
+      passive: true
+    });
+
+    return () => {
+      resizeObserver?.disconnect();
+      window.removeEventListener("resize", syncFrame);
+      window.removeEventListener("scroll", syncFrame, true);
+    };
+  }, [anchorRef, open, syncFrame]);
+
+  return frame;
+}
+
+function assignRef<T>(ref: RefObject<T | null> | undefined, value: T | null) {
+  if (ref) {
+    ref.current = value;
+  }
+}
+
+export const ComposerFloatingMenuSurface = forwardRef<
+  HTMLDivElement,
+  ComposerFloatingMenuSurfaceProps
+>(function ComposerFloatingMenuSurface(
+  {
+    anchorRef,
+    children,
+    className,
+    contentClassName,
+    dismissBoundaryRef,
+    maxHeight,
+    onDismiss,
+    open,
+    placement,
+    surfaceRef,
+    testId
+  },
+  forwardedRef
+): React.JSX.Element | null {
+  const localSurfaceRef = useRef<HTMLDivElement | null>(null);
+  const frame = useComposerAnchoredMenuFrame({
+    anchorRef,
+    maxHeight,
+    open
+  });
+
+  const setSurfaceRef = useCallback(
+    (node: HTMLDivElement | null): void => {
+      localSurfaceRef.current = node;
+      assignRef(surfaceRef, node);
+      if (typeof forwardedRef === "function") {
+        forwardedRef(node);
+      } else if (forwardedRef) {
+        forwardedRef.current = node;
+      }
+    },
+    [forwardedRef, surfaceRef]
+  );
+
+  useEffect(() => {
+    if (!open || !onDismiss) {
+      return;
+    }
+
+    const isInsideMenu = (target: EventTarget | null): boolean => {
+      if (!(target instanceof Node)) {
+        return false;
+      }
+      const boundaryRef = dismissBoundaryRef ?? anchorRef;
+      return Boolean(
+        boundaryRef.current?.contains(target) ||
+        localSurfaceRef.current?.contains(target)
+      );
+    };
+
+    const handleKeyDown = (event: KeyboardEvent): void => {
+      if (event.key !== "Escape" || event.defaultPrevented) {
+        return;
+      }
+      event.preventDefault();
+      onDismiss();
+    };
+
+    const handlePointerDown = (event: PointerEvent): void => {
+      if (isInsideMenu(event.target)) {
+        return;
+      }
+      onDismiss();
+    };
+
+    const handleFocusIn = (event: FocusEvent): void => {
+      if (isInsideMenu(event.target)) {
+        return;
+      }
+      onDismiss();
+    };
+
+    document.addEventListener("keydown", handleKeyDown);
+    document.addEventListener("pointerdown", handlePointerDown, true);
+    document.addEventListener("focusin", handleFocusIn, true);
+    window.addEventListener("blur", onDismiss);
+    return () => {
+      document.removeEventListener("keydown", handleKeyDown);
+      document.removeEventListener("pointerdown", handlePointerDown, true);
+      document.removeEventListener("focusin", handleFocusIn, true);
+      window.removeEventListener("blur", onDismiss);
+    };
+  }, [anchorRef, dismissBoundaryRef, onDismiss, open]);
+
+  const style = useMemo<CSSProperties>(() => {
+    const baseStyle: CSSProperties = {
+      position: "fixed",
+      left: `${frame?.left ?? 0}px`,
+      width: `${frame?.width ?? 0}px`,
+      maxWidth: `${frame?.width ?? 0}px`,
+      overflow: "hidden",
+      zIndex: frame?.zIndex ?? "var(--z-popover)"
+    };
+    if (placement === "fixed-height") {
+      return {
+        ...baseStyle,
+        top: `${frame?.top ?? 0}px`,
+        minHeight: `${COMPOSER_MENU_MIN_HEIGHT_PX}px`,
+        height: `${frame?.height ?? maxHeight}px`,
+        maxHeight: `${maxHeight}px`
+      };
+    }
+    return {
+      ...baseStyle,
+      bottom: `${frame?.bottom ?? 0}px`,
+      maxHeight: `${frame?.height ?? maxHeight}px`
+    };
+  }, [frame, maxHeight, placement]);
+
+  if (!open || typeof document === "undefined" || !document.body) {
+    return null;
+  }
+
+  const portalTarget =
+    frame?.portalTarget ??
+    (anchorRef.current
+      ? resolveComposerMenuPortalTarget(anchorRef.current)
+      : document.body);
+
+  return createPortal(
+    <div
+      data-testid={testId}
+      ref={setSurfaceRef}
+      className={cn(
+        "nodrag isolate rounded-[12px] border border-hairline bg-background-fronted p-[4px] text-foreground shadow-[var(--tsh-shell-shadow)] [-webkit-app-region:no-drag]",
+        "overflow-hidden",
+        className
+      )}
+      style={style}
+    >
+      {contentClassName ? (
+        <div className={contentClassName}>{children}</div>
+      ) : (
+        children
+      )}
+    </div>,
+    portalTarget
+  );
+});

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/agentGuiController.composerHelpers.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/agentGuiController.composerHelpers.ts
@@ -31,6 +31,12 @@ export function reasoningConfigOptionIdForProvider(
   return provider === "codex" ? "reasoning_effort" : "effort";
 }
 
+export function speedConfigOptionIdForProvider(
+  provider: AgentGUINodeData["provider"]
+): string {
+  return provider === "codex" ? "service_tier" : "fast";
+}
+
 export function composerSettingOptionsFromActivity(
   options: readonly AgentActivityComposerOptions["models"][number][]
 ): AgentGUIComposerSettingOption[] {
@@ -153,6 +159,10 @@ export function resolveEffectiveComposerSettings(input: {
       (normalizeOptionalText(
         input.settings.reasoningEffort
       ) as AgentSessionReasoningEffort | null) ?? null,
+    speed:
+      (normalizeOptionalText(
+        input.settings.speed
+      ) as AgentSessionSpeed | null) ?? null,
     planMode: Boolean(input.settings.planMode),
     // Browser use defaults on; preserve an explicit opt-out, default unset to on.
     browserUse: input.settings.browserUse ?? true,
@@ -162,10 +172,13 @@ export function resolveEffectiveComposerSettings(input: {
 
 export function runtimeConfigKeyForSetting(
   provider: AgentGUINodeData["provider"],
-  setting: "model" | "reasoningEffort" | "permissionModeId"
+  setting: "model" | "reasoningEffort" | "speed" | "permissionModeId"
 ): string {
   if (setting === "reasoningEffort") {
     return reasoningConfigOptionIdForProvider(provider);
+  }
+  if (setting === "speed") {
+    return speedConfigOptionIdForProvider(provider);
   }
   if (setting === "permissionModeId") {
     return "mode";
@@ -176,13 +189,21 @@ export function runtimeConfigKeyForSetting(
 export function shouldUpdateRuntimeConfigOption(
   provider: AgentGUINodeData["provider"],
   id: string | null,
-  setting: "model" | "reasoningEffort" | "permissionModeId"
+  setting: "model" | "reasoningEffort" | "speed" | "permissionModeId"
 ): boolean {
   if (setting === "model") {
     return id === "model";
   }
   if (setting === "permissionModeId") {
     return id === "mode";
+  }
+  if (setting === "speed") {
+    return (
+      id === speedConfigOptionIdForProvider(provider) ||
+      id === "service_tier" ||
+      id === "speed" ||
+      id === "fast"
+    );
   }
   return (
     id === reasoningConfigOptionIdForProvider(provider) ||
@@ -203,7 +224,7 @@ export function mergeRuntimeContextComposerSettings(
   const nextRuntimeContext: Record<string, unknown> = { ...runtimeContext };
   const runtimeConfigPatch: Record<string, unknown> = {};
   const optionPatches: Array<{
-    setting: "model" | "reasoningEffort" | "permissionModeId";
+    setting: "model" | "reasoningEffort" | "speed" | "permissionModeId";
     value: string | null;
   }> = [];
 
@@ -218,6 +239,11 @@ export function mergeRuntimeContextComposerSettings(
       runtimeConfigKeyForSetting(provider, "reasoningEffort")
     ] = value;
     optionPatches.push({ setting: "reasoningEffort", value });
+  }
+  if (settings.speed !== undefined) {
+    const value = normalizeOptionalText(settings.speed);
+    runtimeConfigPatch[runtimeConfigKeyForSetting(provider, "speed")] = value;
+    optionPatches.push({ setting: "speed", value });
   }
   if (settings.permissionModeId !== undefined) {
     const value = normalizeOptionalText(settings.permissionModeId);
@@ -277,6 +303,7 @@ export function sameComposerSettings(
   return (
     (left?.model ?? null) === (right?.model ?? null) &&
     (left?.reasoningEffort ?? null) === (right?.reasoningEffort ?? null) &&
+    (left?.speed ?? null) === (right?.speed ?? null) &&
     Boolean(left?.planMode) === Boolean(right?.planMode) &&
     (left?.browserUse ?? true) === (right?.browserUse ?? true) &&
     (left?.permissionModeId ?? null) === (right?.permissionModeId ?? null)
@@ -287,6 +314,7 @@ export function buildNodeDefaultComposerSettings(
   data: AgentGUINodeData,
   options?: {
     defaultReasoningEffort?: AgentSessionReasoningEffort | null;
+    defaultSpeed?: AgentSessionSpeed | null;
   }
 ): AgentSessionComposerSettings {
   // Generic cleanup only — provider-level clamping is owned by the daemon
@@ -299,6 +327,12 @@ export function buildNodeDefaultComposerSettings(
         composerOverrides.reasoningEffort
       ) as AgentSessionReasoningEffort | null) ??
       options?.defaultReasoningEffort ??
+      null,
+    speed:
+      (normalizeOptionalText(
+        composerOverrides.speed
+      ) as AgentSessionSpeed | null) ??
+      options?.defaultSpeed ??
       null,
     planMode: Boolean(composerOverrides.planMode),
     browserUse: composerOverrides.browserUse ?? true,
@@ -324,6 +358,7 @@ export function composerSupportForProvider(
   model: boolean;
   permission: boolean;
   reasoning: boolean;
+  speed: boolean;
   plan: boolean;
 } {
   if (
@@ -335,6 +370,7 @@ export function composerSupportForProvider(
       model: true,
       permission: provider === "claude-code" || provider === "codex",
       reasoning: true,
+      speed: provider === "claude-code" || provider === "codex",
       plan: false
     };
   }
@@ -342,6 +378,7 @@ export function composerSupportForProvider(
     model: false,
     permission: provider === "nexight",
     reasoning: false,
+    speed: false,
     plan: false
   };
 }
@@ -368,6 +405,7 @@ export function nodeDataFromComposerSettings(
   const composerOverrides = {
     model: normalizeOptionalText(settings.model),
     reasoningEffort: normalizeOptionalText(settings.reasoningEffort),
+    speed: normalizeOptionalText(settings.speed),
     planMode: Boolean(settings.planMode),
     // Raw passthrough (no Boolean coercion): undefined means "default on", so
     // only an explicit false persists as an opt-out.
@@ -468,13 +506,15 @@ export function readNodeDefaultDraftPrompt(input: {
 export function readNodeDefaultDraftSettings(input: {
   data: AgentGUINodeData;
   defaultReasoningEffort?: AgentSessionReasoningEffort | null;
+  defaultSpeed?: AgentSessionSpeed | null;
   drafts: Record<string, AgentSessionComposerSettings>;
 }): AgentSessionComposerSettings {
   return (
     input.drafts[nodeDefaultDraftKey(input.data.provider)] ??
     input.drafts[NODE_DEFAULT_DRAFT_KEY] ??
     buildNodeDefaultComposerSettings(input.data, {
-      defaultReasoningEffort: input.defaultReasoningEffort
+      defaultReasoningEffort: input.defaultReasoningEffort,
+      defaultSpeed: input.defaultSpeed
     })
   );
 }

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUINodeController.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUINodeController.ts
@@ -143,6 +143,17 @@ import {
 import { resolveAgentGUIExplicitConversationTitle } from "../model/agentGuiProviderIdentity";
 import { composerSettingsSupportFromOptions } from "../model/composerSettingsSupport";
 import {
+  buildNodeDefaultComposerSettings,
+  cloneComposerSettings,
+  composerSupportForProvider,
+  mergeRuntimeContextComposerSettings,
+  nodeDataFromComposerSettings,
+  normalizeConfigOptionValue,
+  normalizePermissionModeId,
+  resolveEffectiveComposerSettings,
+  sameComposerSettings
+} from "./agentGuiController.composerHelpers";
+import {
   PLAN_IMPLEMENTATION_ACTION_FEEDBACK,
   PLAN_IMPLEMENTATION_ACTION_IMPLEMENT,
   PLAN_IMPLEMENTATION_ACTION_SKIP,
@@ -1068,22 +1079,6 @@ function recordValue(value: unknown): Record<string, unknown> | null {
     : null;
 }
 
-function normalizeConfigOptionValue(value: unknown): string | null {
-  return typeof value === "string" && value.trim() ? value.trim() : null;
-}
-
-function reasoningConfigOptionIdForProvider(
-  provider: AgentGUINodeData["provider"]
-): string {
-  return provider === "codex" ? "reasoning_effort" : "effort";
-}
-
-function speedConfigOptionIdForProvider(
-  provider: AgentGUINodeData["provider"]
-): string {
-  return provider === "codex" ? "service_tier" : "fast";
-}
-
 function composerSettingOptionsFromActivity(
   options: readonly AgentActivityComposerOptions["models"][number][]
 ): AgentGUIComposerSettingOption[] {
@@ -1220,169 +1215,6 @@ function normalizePermissionModeSemantic(
       return (normalizeOptionalText(value) ??
         "unconfigurable") as AgentSessionPermissionModeOption["semantic"];
   }
-}
-
-function resolveEffectiveComposerSettings(input: {
-  settings: AgentSessionComposerSettings;
-}): AgentSessionComposerSettings {
-  return {
-    model: normalizeOptionalText(input.settings.model) ?? null,
-    reasoningEffort:
-      (normalizeOptionalText(
-        input.settings.reasoningEffort
-      ) as AgentSessionReasoningEffort | null) ?? null,
-    speed:
-      (normalizeOptionalText(
-        input.settings.speed
-      ) as AgentSessionSpeed | null) ?? null,
-    planMode: Boolean(input.settings.planMode),
-    permissionModeId: normalizePermissionModeId(input.settings.permissionModeId)
-  };
-}
-
-type RuntimeConfigSetting =
-  | "model"
-  | "reasoningEffort"
-  | "speed"
-  | "permissionModeId";
-
-function runtimeConfigKeyForSetting(
-  provider: AgentGUINodeData["provider"],
-  setting: RuntimeConfigSetting
-): string {
-  if (setting === "reasoningEffort") {
-    return reasoningConfigOptionIdForProvider(provider);
-  }
-  if (setting === "speed") {
-    return speedConfigOptionIdForProvider(provider);
-  }
-  if (setting === "permissionModeId") {
-    return "mode";
-  }
-  return "model";
-}
-
-function shouldUpdateRuntimeConfigOption(
-  provider: AgentGUINodeData["provider"],
-  id: string | null,
-  setting: RuntimeConfigSetting
-): boolean {
-  if (setting === "model") {
-    return id === "model";
-  }
-  if (setting === "permissionModeId") {
-    return id === "mode";
-  }
-  if (setting === "speed") {
-    return (
-      id === speedConfigOptionIdForProvider(provider) ||
-      id === "service_tier" ||
-      id === "speed" ||
-      id === "fast"
-    );
-  }
-  return (
-    id === reasoningConfigOptionIdForProvider(provider) ||
-    id === "model_reasoning_effort" ||
-    id === "reasoning_effort" ||
-    id === "effort"
-  );
-}
-
-function mergeRuntimeContextComposerSettings(
-  provider: AgentGUINodeData["provider"],
-  runtimeContext: Record<string, unknown> | undefined,
-  settings: AgentSessionComposerSettings
-): Record<string, unknown> | undefined {
-  if (!runtimeContext) {
-    return runtimeContext;
-  }
-  const nextRuntimeContext: Record<string, unknown> = { ...runtimeContext };
-  const runtimeConfigPatch: Record<string, unknown> = {};
-  const optionPatches: Array<{
-    setting: RuntimeConfigSetting;
-    value: string | null;
-  }> = [];
-
-  if (settings.model !== undefined) {
-    const value = normalizeOptionalText(settings.model);
-    runtimeConfigPatch[runtimeConfigKeyForSetting(provider, "model")] = value;
-    optionPatches.push({ setting: "model", value });
-  }
-  if (settings.reasoningEffort !== undefined) {
-    const value = normalizeOptionalText(settings.reasoningEffort);
-    runtimeConfigPatch[
-      runtimeConfigKeyForSetting(provider, "reasoningEffort")
-    ] = value;
-    optionPatches.push({ setting: "reasoningEffort", value });
-  }
-  if (settings.speed !== undefined) {
-    const value = normalizeOptionalText(settings.speed);
-    runtimeConfigPatch[runtimeConfigKeyForSetting(provider, "speed")] = value;
-    optionPatches.push({ setting: "speed", value });
-  }
-  if (settings.permissionModeId !== undefined) {
-    const value = normalizeOptionalText(settings.permissionModeId);
-    runtimeConfigPatch[
-      runtimeConfigKeyForSetting(provider, "permissionModeId")
-    ] = value;
-    optionPatches.push({ setting: "permissionModeId", value });
-  }
-
-  if (Object.keys(runtimeConfigPatch).length > 0) {
-    const currentConfig = recordValue(nextRuntimeContext.config);
-    nextRuntimeContext.config = {
-      ...(currentConfig ?? {}),
-      ...runtimeConfigPatch
-    };
-  }
-  if (
-    optionPatches.length > 0 &&
-    Array.isArray(nextRuntimeContext.configOptions)
-  ) {
-    nextRuntimeContext.configOptions = nextRuntimeContext.configOptions.map(
-      (option) => {
-        const optionRecord = recordValue(option);
-        if (!optionRecord) {
-          return option;
-        }
-        const id = normalizeConfigOptionValue(optionRecord.id);
-        const patch = optionPatches.find((item) =>
-          shouldUpdateRuntimeConfigOption(provider, id, item.setting)
-        );
-        return patch ? { ...optionRecord, currentValue: patch.value } : option;
-      }
-    );
-  }
-  return nextRuntimeContext;
-}
-
-function normalizePermissionModeId(
-  value: string | null | undefined
-): string | null {
-  return normalizeOptionalText(value);
-}
-
-function cloneComposerSettings(
-  settings: AgentSessionComposerSettings | null
-): AgentSessionComposerSettings | null {
-  if (!settings) {
-    return null;
-  }
-  return { ...settings };
-}
-
-function sameComposerSettings(
-  left: AgentSessionComposerSettings | null,
-  right: AgentSessionComposerSettings | null
-): boolean {
-  return (
-    (left?.model ?? null) === (right?.model ?? null) &&
-    (left?.reasoningEffort ?? null) === (right?.reasoningEffort ?? null) &&
-    (left?.speed ?? null) === (right?.speed ?? null) &&
-    Boolean(left?.planMode) === Boolean(right?.planMode) &&
-    (left?.permissionModeId ?? null) === (right?.permissionModeId ?? null)
-  );
 }
 
 function useStableComposerSettings(
@@ -1594,76 +1426,6 @@ function conversationBusyStatusFromAgentActivityDisplayStatus(
   return null;
 }
 
-function buildNodeDefaultComposerSettings(
-  data: AgentGUINodeData,
-  options?: {
-    defaultReasoningEffort?: AgentSessionReasoningEffort | null;
-    defaultSpeed?: AgentSessionSpeed | null;
-  }
-): AgentSessionComposerSettings {
-  // Generic cleanup only — provider-level clamping is owned by the daemon
-  // (normalizeComposerSettingsForProvider and the session create path).
-  const composerOverrides = nodeComposerOverridesForProvider(data) ?? {};
-  return {
-    model: normalizeOptionalText(composerOverrides.model),
-    reasoningEffort:
-      (normalizeOptionalText(
-        composerOverrides.reasoningEffort
-      ) as AgentSessionReasoningEffort | null) ??
-      options?.defaultReasoningEffort ??
-      null,
-    speed:
-      (normalizeOptionalText(
-        composerOverrides.speed
-      ) as AgentSessionSpeed | null) ??
-      options?.defaultSpeed ??
-      null,
-    planMode: Boolean(composerOverrides.planMode),
-    permissionModeId: normalizePermissionModeId(
-      composerOverrides.permissionModeId
-    )
-  };
-}
-
-function nodeComposerOverridesForProvider(
-  data: AgentGUINodeData
-): AgentSessionComposerSettings | null {
-  return (
-    data.composerOverridesByProvider?.[data.provider] ??
-    data.composerOverrides ??
-    null
-  );
-}
-
-function composerSupportForProvider(provider: AgentGUINodeData["provider"]): {
-  model: boolean;
-  permission: boolean;
-  reasoning: boolean;
-  speed: boolean;
-  plan: boolean;
-} {
-  if (
-    provider === "claude-code" ||
-    provider === "codex" ||
-    provider === "gemini"
-  ) {
-    return {
-      model: true,
-      permission: provider === "claude-code" || provider === "codex",
-      reasoning: true,
-      speed: provider === "claude-code" || provider === "codex",
-      plan: false
-    };
-  }
-  return {
-    model: false,
-    permission: provider === "nexight",
-    reasoning: false,
-    speed: false,
-    plan: false
-  };
-}
-
 function permissionModeOptions(
   provider: AgentGUINodeData["provider"],
   permissionConfig: AgentSessionPermissionConfig | null | undefined
@@ -1676,28 +1438,6 @@ function permissionModeOptions(
     label: permissionModeLabel(provider, mode),
     description: permissionModeDescription(provider, mode)
   }));
-}
-
-function nodeDataFromComposerSettings(
-  current: AgentGUINodeData,
-  settings: AgentSessionComposerSettings
-): AgentGUINodeData {
-  // Generic cleanup only — provider-level clamping is owned by the daemon.
-  const composerOverrides = {
-    model: normalizeOptionalText(settings.model),
-    reasoningEffort: normalizeOptionalText(settings.reasoningEffort),
-    speed: normalizeOptionalText(settings.speed),
-    planMode: Boolean(settings.planMode),
-    permissionModeId: normalizePermissionModeId(settings.permissionModeId)
-  };
-  return {
-    ...current,
-    composerOverrides,
-    composerOverridesByProvider: {
-      ...(current.composerOverridesByProvider ?? {}),
-      [current.provider]: composerOverrides
-    }
-  };
 }
 
 function permissionModeLabel(

--- a/packages/agent/gui/app/renderer/agentactivity.css
+++ b/packages/agent/gui/app/renderer/agentactivity.css
@@ -5479,18 +5479,9 @@ button.agent-gui-node__conversation-section-toggle:hover
 }
 
 .agent-gui-node__slash-status-panel {
-  position: relative;
-  z-index: 1;
-  display: grid;
-  justify-self: stretch;
-  width: auto;
-  margin: 0 12px;
-  padding: 6px 12px;
-  border: 1px solid var(--agent-gui-border-subtle, var(--line-2));
-  border-bottom: 0;
-  border-radius: 10px 10px 0 0;
-  background: var(--background-fronted);
-  box-shadow: 0 6px 18px rgb(0 0 0 / 4%);
+  width: 100%;
+  min-width: 0;
+  padding: 10px 12px;
   color: var(--agent-gui-text-primary);
   font-size: 11px;
 }


### PR DESCRIPTION
## Summary

- Move slash command panels (`/status`, `/review`) onto a local composer floating menu surface aligned with the initial `/` palette.
- Extract `/status` and `/review` panel content out of `AgentComposer` and centralize slash menu dismissal behavior.
- Consolidate composer settings helper logic so `speed` and `browserUse` handling do not drift between controller paths.

## Root Cause

The slash menu stack had split rendering and shortcut paths: the initial `/` palette used a floating anchored surface, while `/status` and `/review` rendered inline against the composer. Escape handling was also split between editor key handlers, panel-local handlers, and document listeners, so focus location changed whether a menu could close. Separately, duplicated composer settings helper code drifted and lost part of the persisted settings contract.

## Impact

- `/status` and `/review` now share the same slash floating-menu surface behavior as the initial command palette.
- Slash command panels close on outside focus/click, window blur, and Escape from the editor path.
- Review picker keeps its staged Escape behavior: Escape returns to the root stage before closing.
- `AgentComposer` and controller settings code are smaller and less duplicated.

## Validation

- `pnpm --filter @tutti-os/agent-gui test`
- `pnpm lint:ts`
- `pnpm typecheck`
- `pnpm --filter @tutti-os/desktop build`
- `pnpm lint:go`
- pre-commit staged checks
- pre-push `pnpm check:full`