### PR TITLE
fix(workbench): stabilize dock hover and rail resize

### DIFF
--- a/packages/agent/gui/agent-gui/agentGuiNode/AgentGUINodeView.layout.spec.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/AgentGUINodeView.layout.spec.tsx
@@ -151,6 +151,42 @@ describe("AgentGUINodeView layout persistence", () => {
     expect(onConversationRailWidthChanged).toHaveBeenCalledWith(360);
   });
 
+  it("keeps the in-flight rail width across parent rerenders", () => {
+    const onConversationRailWidthChanged = vi.fn();
+    const initialOptions = {
+      conversationRailWidthPx: 240,
+      onConversationRailWidthChanged
+    };
+
+    const { container, rerender } = renderAgentGUINodeView(initialOptions);
+    const layout = container.querySelector(".agent-gui-node__layout");
+    const resizeHandle = screen.getByTestId(
+      "agent-gui-conversation-rail-resize-handle"
+    );
+
+    fireEvent.pointerDown(resizeHandle, {
+      button: 0,
+      clientX: 0,
+      pointerId: 1
+    });
+    fireEvent.pointerMove(resizeHandle, { clientX: 120, pointerId: 1 });
+    expect(layout).toHaveStyle({
+      "--agent-gui-conversation-rail-width": "360px"
+    });
+
+    rerender(buildAgentGUINodeViewElement(initialOptions));
+
+    expect(layout).toHaveStyle({
+      "--agent-gui-conversation-rail-width": "360px"
+    });
+
+    fireEvent.pointerUp(resizeHandle, { pointerId: 1 });
+    expect(onConversationRailWidthChanged).toHaveBeenCalledWith(360);
+    expect(layout).toHaveStyle({
+      "--agent-gui-conversation-rail-width": "360px"
+    });
+  });
+
   it("keeps the rail resize affordance active while dragging", () => {
     const { container } = renderAgentGUINodeView();
 

--- a/packages/agent/gui/agent-gui/agentGuiNode/AgentGUINodeView.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/AgentGUINodeView.tsx
@@ -781,6 +781,9 @@ export function AgentGUINodeView({
     startWidthPx: number;
   } | null>(null);
   const [isRailResizing, setIsRailResizing] = useState(false);
+  const [railResizeWidthPx, setRailResizeWidthPx] = useState<number | null>(
+    null
+  );
   const [workspaceReferencePickerOpen, setWorkspaceReferencePickerOpen] =
     useState(false);
   const [
@@ -881,6 +884,7 @@ export function AgentGUINodeView({
         startClientX: event.clientX,
         startWidthPx: conversationRailWidthPx
       };
+      setRailResizeWidthPx(conversationRailWidthPx);
       setIsRailResizing(true);
     },
     [conversationRailCollapsed, conversationRailWidthPx, previewMode]
@@ -923,12 +927,33 @@ export function AgentGUINodeView({
       }
       railResizeInteractionRef.current = null;
       if (resizeState) {
-        onConversationRailWidthChanged(resizeState.lastWidthPx);
+        const nextWidthPx = resizeState.lastWidthPx;
+        setRailResizeWidthPx(nextWidthPx);
+        onConversationRailWidthChanged(nextWidthPx);
+      } else {
+        setRailResizeWidthPx(null);
       }
       setIsRailResizing(false);
     },
     [onConversationRailWidthChanged]
   );
+
+  useEffect(() => {
+    if (isRailResizing || railResizeWidthPx === null) {
+      return;
+    }
+    if (
+      conversationRailCollapsed ||
+      conversationRailWidthPx === railResizeWidthPx
+    ) {
+      setRailResizeWidthPx(null);
+    }
+  }, [
+    conversationRailCollapsed,
+    conversationRailWidthPx,
+    isRailResizing,
+    railResizeWidthPx
+  ]);
 
   const handleConversationRailResizeKeyDown = useCallback(
     (event: KeyboardEvent<HTMLDivElement>): void => {
@@ -960,8 +985,12 @@ export function AgentGUINodeView({
     ]
   );
 
+  const visualConversationRailWidthPx = isRailResizing
+    ? (railResizeInteractionRef.current?.lastWidthPx ?? conversationRailWidthPx)
+    : (railResizeWidthPx ?? conversationRailWidthPx);
+
   const layoutStyle = {
-    "--agent-gui-conversation-rail-width": `${conversationRailWidthPx}px`,
+    "--agent-gui-conversation-rail-width": `${visualConversationRailWidthPx}px`,
     "--agent-gui-detail-min-width": `${detailMinWidthPx}px`,
     gridTemplateColumns: conversationRailCollapsed
       ? "0 minmax(var(--agent-gui-detail-min-width), 1fr)"
@@ -1032,7 +1061,9 @@ export function AgentGUINodeView({
           aria-valuemin={conversationRailMinWidthPx}
           aria-valuemax={conversationRailMaxWidthPx}
           aria-valuenow={
-            conversationRailCollapsed ? undefined : conversationRailWidthPx
+            conversationRailCollapsed
+              ? undefined
+              : visualConversationRailWidthPx
           }
           data-resizing={isRailResizing ? "true" : undefined}
           data-testid="agent-gui-conversation-rail-resize-handle"

--- a/packages/workbench/surface/src/host/WorkbenchHostDock.test.ts
+++ b/packages/workbench/surface/src/host/WorkbenchHostDock.test.ts
@@ -5,13 +5,11 @@ import test from "node:test";
 
 const source = readFileSync(resolve("src/host/WorkbenchHostDock.tsx"), "utf8");
 
-test("dock hover panels survive pointer travel from slot to panel", () => {
-  assert.match(source, /TooltipTrigger asChild/);
-  assert.equal(source.match(/<TooltipTrigger asChild>/g)?.length, 3);
-  assert.equal(
-    source.match(/sideOffset=\{DOCK_MAGNIFIED_TOOLTIP_SIDE_OFFSET\}/g)?.length,
-    3
-  );
+test("dock hover labels avoid tooltip portals while preserving native titles", () => {
+  assert.doesNotMatch(source, /TooltipProvider/);
+  assert.doesNotMatch(source, /TooltipTrigger/);
+  assert.doesNotMatch(source, /TooltipContent/);
+  assert.doesNotMatch(source, /DOCK_MAGNIFIED_TOOLTIP_SIDE_OFFSET/);
   assert.match(source, /title=\{entry\.label\}/);
   assert.match(source, /title=\{i18n\.t\("minimizedWindows"\)\}/);
   assert.match(source, /title=\{node\.title\}/);

--- a/packages/workbench/surface/src/host/WorkbenchHostDock.tsx
+++ b/packages/workbench/surface/src/host/WorkbenchHostDock.tsx
@@ -17,11 +17,7 @@ import {
   ArrowRightIcon,
   Button,
   ChevronDownIcon,
-  ChevronUpIcon,
-  Tooltip,
-  TooltipContent,
-  TooltipProvider,
-  TooltipTrigger
+  ChevronUpIcon
 } from "@tutti-os/ui-system";
 import type { WorkbenchDockContext } from "../react/types.ts";
 import {
@@ -1044,493 +1040,386 @@ export function WorkbenchHostDock({
               } as WorkbenchHostDockPlateStyle)
         }
       >
-        <TooltipProvider delayDuration={500}>
-          <div
-            ref={dockMeasureRef}
-            aria-label={i18n.t("dockLabel")}
-            className="desktop-dock"
-            data-dock-placement={dockPlacement}
-            data-desktop-dock-root="true"
-            data-scroll-overflow={
-              dockScrollState.hasOverflow ? "true" : undefined
-            }
-            data-scroll-backward={
-              dockScrollState.canScrollBackward ? "true" : undefined
-            }
-            data-scroll-forward={
-              dockScrollState.canScrollForward ? "true" : undefined
-            }
-            onPointerLeave={() => {
-              hoverPanelRestTargetRef.current = null;
-              clearHoverPanelOpenTimer();
-              closeHoverPanelImmediate();
-              handleDockPointerLeave();
-              flushPendingDockStateRefresh();
-            }}
-            onPointerMoveCapture={(event) => {
-              handleDockPointerTravel(event.clientX, event.clientY);
-            }}
-            role="toolbar"
-            style={
-              dockPlacement === "left"
-                ? { height: dockWidth }
-                : { width: dockWidth }
-            }
+        <div
+          ref={dockMeasureRef}
+          aria-label={i18n.t("dockLabel")}
+          className="desktop-dock"
+          data-dock-placement={dockPlacement}
+          data-desktop-dock-root="true"
+          data-scroll-overflow={
+            dockScrollState.hasOverflow ? "true" : undefined
+          }
+          data-scroll-backward={
+            dockScrollState.canScrollBackward ? "true" : undefined
+          }
+          data-scroll-forward={
+            dockScrollState.canScrollForward ? "true" : undefined
+          }
+          onPointerLeave={() => {
+            hoverPanelRestTargetRef.current = null;
+            clearHoverPanelOpenTimer();
+            closeHoverPanelImmediate();
+            handleDockPointerLeave();
+            flushPendingDockStateRefresh();
+          }}
+          onPointerMoveCapture={(event) => {
+            handleDockPointerTravel(event.clientX, event.clientY);
+          }}
+          role="toolbar"
+          style={
+            dockPlacement === "left"
+              ? { height: dockWidth }
+              : { width: dockWidth }
+          }
+        >
+          <span
+            className="desktop-dock__pointer-rail"
+            data-desktop-dock-pointer-rail="true"
+            aria-hidden
+          />
+          <button
+            aria-label={i18n.t(
+              dockPlacement === "left" ? "scrollDockUp" : "scrollDockLeft"
+            )}
+            className="desktop-dock__scroll-button desktop-dock__scroll-button--backward"
+            data-scroll-button="backward"
+            disabled={!dockScrollState.canScrollBackward}
+            onClick={() => scrollDockItems("backward")}
+            type="button"
           >
-            <span
-              className="desktop-dock__pointer-rail"
-              data-desktop-dock-pointer-rail="true"
-              aria-hidden
-            />
-            <button
-              aria-label={i18n.t(
-                dockPlacement === "left" ? "scrollDockUp" : "scrollDockLeft"
-              )}
-              className="desktop-dock__scroll-button desktop-dock__scroll-button--backward"
-              data-scroll-button="backward"
-              disabled={!dockScrollState.canScrollBackward}
-              onClick={() => scrollDockItems("backward")}
-              type="button"
-            >
-              {dockPlacement === "left" ? (
-                <ChevronUpIcon size={16} />
-              ) : (
-                <ArrowLeftIcon size={16} />
-              )}
-            </button>
-            <div ref={dockItemsRef} className="desktop-dock__items">
-              {presentDockItems.map((dockItem) => {
-                if (dockItem.item.kind === "separator") {
-                  return (
-                    <span
-                      ref={registerWallpaperToneElement(dockItem.key)}
-                      className="desktop-dock__separator"
-                      aria-hidden="true"
-                      data-presence={dockItem.presence}
-                      data-wallpaper-tone={wallpaperTones.get(dockItem.key)}
-                      key={dockItem.key}
-                    />
-                  );
-                }
+            {dockPlacement === "left" ? (
+              <ChevronUpIcon size={16} />
+            ) : (
+              <ArrowLeftIcon size={16} />
+            )}
+          </button>
+          <div ref={dockItemsRef} className="desktop-dock__items">
+            {presentDockItems.map((dockItem) => {
+              if (dockItem.item.kind === "separator") {
+                return (
+                  <span
+                    ref={registerWallpaperToneElement(dockItem.key)}
+                    className="desktop-dock__separator"
+                    aria-hidden="true"
+                    data-presence={dockItem.presence}
+                    data-wallpaper-tone={wallpaperTones.get(dockItem.key)}
+                    key={dockItem.key}
+                  />
+                );
+              }
 
-                if (dockItem.item.kind === "entry") {
-                  const resolvedEntry = dockItem.item.resolvedEntry;
-                  const { anchorKey, entry } = resolvedEntry;
-                  const currentPopup =
-                    activePopup?.entryId === entry.id ? activePopup : null;
-                  const instanceMode = resolveDockEntryInstanceMode(
-                    entry,
-                    nodeDefinitions
-                  );
-                  const clickResolution = resolveWorkbenchDockEntryClick({
-                    entry,
-                    instanceMode,
-                    matchedNodes: resolvedEntry.matchedNodes
-                  });
-                  const hasHoverPanel = dockEntryHasHoverPanel(entry);
-                  const dockButton = (
-                    <button
-                      aria-expanded={currentPopup ? true : undefined}
-                      aria-haspopup={
-                        clickResolution.kind === "open-popup"
-                          ? "dialog"
-                          : undefined
-                      }
-                      aria-label={i18n.t("launch", { title: entry.label })}
-                      aria-disabled={
-                        clickResolution.kind === "blocked" &&
-                        !resolvedEntry.hasMatchingNodes
-                      }
-                      className="desktop-dock__btn"
-                      data-interactive={
-                        clickResolution.kind === "blocked" &&
-                        !resolvedEntry.hasMatchingNodes
-                          ? "false"
-                          : "true"
-                      }
-                      title={entry.label}
-                      type="button"
-                      onPointerDown={() => {
-                        if (
-                          clickResolution.kind === "blocked" &&
-                          !resolvedEntry.hasMatchingNodes
-                        ) {
-                          return;
-                        }
-                        beginDockIconInteraction(anchorKey);
-                      }}
-                      onClick={(event) => {
-                        logWorkbenchDockDebug("dock.click", debugDiagnostics, {
-                          anchorKey,
-                          clickResolution,
-                          dockNodeState: resolvedEntry.dockNodeState,
-                          entryId: entry.id,
-                          instanceMode: instanceMode ?? null,
-                          matchedNodeCount: resolvedEntry.matchedNodes.length,
-                          matchedNodeIds: resolvedEntry.matchedNodes.map(
-                            (node) => node.id
-                          ),
-                          typeId: entry.typeId,
-                          workspaceId
-                        });
-                        switch (clickResolution.kind) {
-                          case "focus-node":
-                            closePopup();
-                            void Promise.resolve(
-                              onDockEntryClick?.({
-                                entryId: entry.id,
-                                host,
-                                nodeId: clickResolution.nodeId
-                              })
-                            ).catch(() => {});
-                            context.genie.launchNodeFromAnchor(
-                              anchorKey,
-                              clickResolution.nodeId,
-                              () => {
-                                host.focusNode(clickResolution.nodeId);
-                              }
-                            );
-                            return;
-                          case "open-popup": {
-                            const rect =
-                              event.currentTarget.getBoundingClientRect();
-                            logWorkbenchDockDebug(
-                              "dock.popup.toggle",
-                              debugDiagnostics,
-                              {
-                                anchorKey,
-                                entryId: entry.id,
-                                matchedNodeCount:
-                                  resolvedEntry.matchedNodes.length,
-                                nextOpen: currentPopup === null,
-                                typeId: entry.typeId,
-                                workspaceId
-                              }
-                            );
-                            setActivePopup((current) =>
-                              current?.entryId === entry.id
-                                ? null
-                                : {
-                                    anchorRect: {
-                                      height: rect.height,
-                                      left: rect.left,
-                                      top: rect.top,
-                                      width: rect.width
-                                    },
-                                    entryId: entry.id
-                                  }
-                            );
-                            return;
-                          }
-                          case "action":
-                            closePopup();
-                            void Promise.resolve(
-                              onDockEntryAction?.({
-                                actionId: clickResolution.actionId,
-                                entryId: entry.id,
-                                host
-                              })
-                            ).catch(() => {});
-                            return;
-                          case "launch":
-                            closePopup();
-                            context.genie.launchNodeFromAnchor(
-                              anchorKey,
-                              entry.id,
-                              () =>
-                                host.launchNode({
-                                  dockEntryId: entry.id,
-                                  payload: entry.launchPayload,
-                                  reason: "dock",
-                                  typeId: entry.typeId
-                                })
-                            );
-                            return;
-                          case "blocked":
-                            return;
-                        }
-                      }}
-                    >
-                      <span
-                        className="desktop-dock__icon-shell"
-                        data-desktop-dock-icon-shell="true"
-                        data-entry-state={entry.state?.kind ?? "enabled"}
-                        aria-hidden
-                      >
-                        <span className="desktop-dock__icon-content">
-                          {entry.icon}
-                        </span>
-                        {renderDockBadge(
-                          entry,
-                          resolvedEntry.matchedNodes.length
-                        )}
-                      </span>
-                    </button>
-                  );
-
-                  return (
-                    <span
-                      key={dockItem.key}
-                      ref={registerDockSlot(anchorKey)}
-                      className="desktop-dock__slot"
-                      data-attention-active={
-                        activeAttentionEntryIds.has(entry.id)
-                          ? "true"
-                          : undefined
-                      }
-                      data-desktop-dock-anchor-key={anchorKey}
-                      data-desktop-dock-slot="true"
-                      data-entry-state={entry.state?.kind ?? "enabled"}
-                      data-dock-hover-panel-entry-id={
-                        hasHoverPanel ? entry.id : undefined
-                      }
-                      data-icon-size={entry.iconSize ?? "default"}
-                      data-node-state={resolvedEntry.dockNodeState}
-                      data-popup-active={currentPopup ? "true" : undefined}
-                      data-presence={dockItem.presence}
-                      data-section-id={entry.sectionId}
-                      data-wallpaper-tone={wallpaperTones.get(anchorKey)}
-                      onBlur={(event) => {
-                        if (
-                          hasHoverPanel &&
-                          !event.currentTarget.contains(event.relatedTarget)
-                        ) {
-                          closeHoverPanelImmediate(entry.id);
-                        }
-                      }}
-                      onFocus={(event) => {
-                        if (hasHoverPanel) {
-                          showHoverPanel(
-                            entry.id,
-                            anchorKey,
-                            event.currentTarget
-                          );
-                        }
-                      }}
-                      onPointerEnter={() => {
-                        if (hasHoverPanel) {
-                          scheduleHoverPanelAfterRest(entry.id, anchorKey);
-                        }
-                      }}
-                      onPointerLeave={(event) => {
-                        if (!hasHoverPanel) {
-                          return;
-                        }
-                        const relatedTarget = event.relatedTarget;
-                        if (
-                          relatedTarget instanceof Node &&
-                          hoverPanelRef.current?.contains(relatedTarget)
-                        ) {
-                          return;
-                        }
-                        if (
-                          relatedTarget instanceof Node &&
-                          dockMeasureRef.current?.contains(relatedTarget)
-                        ) {
-                          scheduleHoverPanelAtPointAfterRest(
-                            event.clientX,
-                            event.clientY
-                          );
-                          return;
-                        }
-                        if (
-                          hoverPanelRestTargetRef.current?.anchorKey ===
-                          anchorKey
-                        ) {
-                          hoverPanelRestTargetRef.current = null;
-                        }
-                        clearHoverPanelOpenTimer();
-                        closeHoverPanelImmediate(entry.id);
-                        handleDockPointerLeave();
-                      }}
-                    >
-                      {hasHoverPanel ? (
-                        dockButton
-                      ) : (
-                        <Tooltip>
-                          <TooltipTrigger asChild>{dockButton}</TooltipTrigger>
-                          <TooltipContent
-                            side={dockPlacement === "left" ? "right" : "top"}
-                            sideOffset={DOCK_MAGNIFIED_TOOLTIP_SIDE_OFFSET}
-                          >
-                            {entry.label}
-                          </TooltipContent>
-                        </Tooltip>
-                      )}
-                    </span>
-                  );
-                }
-
-                const slot = dockItem.item.slot;
-                if (slot.kind === "stack") {
-                  const stackPopupActive =
-                    activeMinimizedStackPopup !== null ? true : undefined;
-                  const stackButton = (
-                    <button
-                      aria-expanded={stackPopupActive}
-                      aria-haspopup="dialog"
-                      aria-label={i18n.t("minimizedWindows")}
-                      className="desktop-dock__btn desktop-dock__minimized-btn"
-                      data-interactive="true"
-                      title={i18n.t("minimizedWindows")}
-                      type="button"
-                      onPointerDown={() => {
-                        beginDockMinimizedInteraction();
-                      }}
-                      onClick={(event) => {
-                        setActivePopup(null);
-                        const rect =
-                          event.currentTarget.getBoundingClientRect();
-                        const dockRect =
-                          dockMeasureRef.current?.getBoundingClientRect();
-                        setActiveMinimizedStackPopup((current) =>
-                          current
-                            ? null
-                            : {
-                                dockRight: Math.max(
-                                  rect.right,
-                                  dockRect?.right ?? rect.right
-                                ),
-                                height: rect.height,
-                                left: rect.left,
-                                top: rect.top,
-                                width: rect.width
-                              }
-                        );
-                      }}
-                    >
-                      <span
-                        className="desktop-dock__minimized-stack-icon"
-                        data-desktop-dock-icon-shell="true"
-                        data-stack-folded={
-                          slot.nodes.length > 1 ? "true" : undefined
-                        }
-                        aria-hidden
-                      >
-                        {Array.from(
-                          {
-                            length:
-                              slot.nodes.length > 1
-                                ? 3
-                                : Math.min(slot.nodes.length, 1)
-                          },
-                          (_, index) => {
-                            const node = slot.nodes[index];
-                            if (index === 0 && node) {
-                              return (
-                                <WorkbenchHostDockMinimizedNodePreview
-                                  key={node.id}
-                                  capturePreview={captureMinimizedNodePreview}
-                                  className={`desktop-dock__minimized-stack-layer desktop-dock__minimized-stack-layer--${index}`}
-                                  dockPreviewCache={dockPreviewCache}
-                                  node={node}
-                                  workspaceId={workspaceId}
-                                />
-                              );
-                            }
-                            return (
-                              <span
-                                key={`${slot.anchorKey}-stack-back-${index}`}
-                                aria-hidden="true"
-                                className={`desktop-dock__minimized-preview desktop-dock__minimized-stack-layer desktop-dock__minimized-stack-layer--${index} desktop-dock__minimized-stack-layer-back`}
-                              />
-                            );
-                          }
-                        )}
-                        <span className="desktop-dock__count-badge">
-                          {slot.nodes.length}
-                        </span>
-                      </span>
-                    </button>
-                  );
-
-                  return (
-                    <span
-                      key={dockItem.key}
-                      ref={registerDockSlot(slot.anchorKey)}
-                      className="desktop-dock__slot desktop-dock__slot--minimized"
-                      data-desktop-dock-anchor-key={slot.anchorKey}
-                      data-desktop-dock-slot="true"
-                      data-node-state="minimized"
-                      data-popup-active={stackPopupActive}
-                      data-presence={dockItem.presence}
-                      data-section-id="minimized"
-                      data-stack-dispatching={
-                        stackDispatching ? "true" : undefined
-                      }
-                    >
-                      <Tooltip>
-                        <TooltipTrigger asChild>{stackButton}</TooltipTrigger>
-                        <TooltipContent
-                          side={dockPlacement === "left" ? "right" : "top"}
-                          sideOffset={DOCK_MAGNIFIED_TOOLTIP_SIDE_OFFSET}
-                        >
-                          {i18n.t("minimizedWindows")}
-                        </TooltipContent>
-                      </Tooltip>
-                    </span>
-                  );
-                }
-
-                const node = slot.node;
+              if (dockItem.item.kind === "entry") {
+                const resolvedEntry = dockItem.item.resolvedEntry;
+                const { anchorKey, entry } = resolvedEntry;
+                const currentPopup =
+                  activePopup?.entryId === entry.id ? activePopup : null;
+                const instanceMode = resolveDockEntryInstanceMode(
+                  entry,
+                  nodeDefinitions
+                );
+                const clickResolution = resolveWorkbenchDockEntryClick({
+                  entry,
+                  instanceMode,
+                  matchedNodes: resolvedEntry.matchedNodes
+                });
+                const hasHoverPanel = dockEntryHasHoverPanel(entry);
                 const dockButton = (
                   <button
-                    aria-label={i18n.t("launch", { title: node.title })}
-                    className="desktop-dock__btn desktop-dock__minimized-btn"
-                    data-interactive="true"
-                    title={node.title}
+                    aria-expanded={currentPopup ? true : undefined}
+                    aria-haspopup={
+                      clickResolution.kind === "open-popup"
+                        ? "dialog"
+                        : undefined
+                    }
+                    aria-label={i18n.t("launch", { title: entry.label })}
+                    aria-disabled={
+                      clickResolution.kind === "blocked" &&
+                      !resolvedEntry.hasMatchingNodes
+                    }
+                    className="desktop-dock__btn"
+                    data-interactive={
+                      clickResolution.kind === "blocked" &&
+                      !resolvedEntry.hasMatchingNodes
+                        ? "false"
+                        : "true"
+                    }
+                    title={entry.label}
                     type="button"
                     onPointerDown={() => {
-                      const restoreIntent =
-                        resolveWorkbenchMinimizedDockRestoreIntent({
-                          nodeId: node.id,
-                          slots: minimizedDockSlots,
-                          source: {
-                            anchorKey: slot.anchorKey,
-                            kind: "node-slot"
-                          }
-                        });
-                      if (restoreIntent?.kind !== "node-slot") {
-                        clearCollapsingMinimizedLaunch(slot.anchorKey);
+                      if (
+                        clickResolution.kind === "blocked" &&
+                        !resolvedEntry.hasMatchingNodes
+                      ) {
                         return;
                       }
-                      beginDockMinimizedInteraction();
+                      beginDockIconInteraction(anchorKey);
                     }}
-                    onClick={() => {
-                      const restoreIntent =
-                        resolveWorkbenchMinimizedDockRestoreIntent({
-                          nodeId: node.id,
-                          slots: minimizedDockSlots,
-                          source: {
-                            anchorKey: slot.anchorKey,
-                            kind: "node-slot"
-                          }
-                        });
-                      if (restoreIntent?.kind !== "node-slot") {
-                        clearCollapsingMinimizedLaunch(slot.anchorKey);
-                        return;
-                      }
-                      closePopup();
-                      runDockMinimizedLaunchAfterCollapse(
-                        restoreIntent,
-                        (intent) => {
+                    onClick={(event) => {
+                      logWorkbenchDockDebug("dock.click", debugDiagnostics, {
+                        anchorKey,
+                        clickResolution,
+                        dockNodeState: resolvedEntry.dockNodeState,
+                        entryId: entry.id,
+                        instanceMode: instanceMode ?? null,
+                        matchedNodeCount: resolvedEntry.matchedNodes.length,
+                        matchedNodeIds: resolvedEntry.matchedNodes.map(
+                          (node) => node.id
+                        ),
+                        typeId: entry.typeId,
+                        workspaceId
+                      });
+                      switch (clickResolution.kind) {
+                        case "focus-node":
+                          closePopup();
+                          void Promise.resolve(
+                            onDockEntryClick?.({
+                              entryId: entry.id,
+                              host,
+                              nodeId: clickResolution.nodeId
+                            })
+                          ).catch(() => {});
                           context.genie.launchNodeFromAnchor(
-                            intent.anchorKey,
-                            intent.nodeId,
+                            anchorKey,
+                            clickResolution.nodeId,
                             () => {
-                              host.focusNode(intent.nodeId);
+                              host.focusNode(clickResolution.nodeId);
                             }
                           );
+                          return;
+                        case "open-popup": {
+                          const rect =
+                            event.currentTarget.getBoundingClientRect();
+                          logWorkbenchDockDebug(
+                            "dock.popup.toggle",
+                            debugDiagnostics,
+                            {
+                              anchorKey,
+                              entryId: entry.id,
+                              matchedNodeCount:
+                                resolvedEntry.matchedNodes.length,
+                              nextOpen: currentPopup === null,
+                              typeId: entry.typeId,
+                              workspaceId
+                            }
+                          );
+                          setActivePopup((current) =>
+                            current?.entryId === entry.id
+                              ? null
+                              : {
+                                  anchorRect: {
+                                    height: rect.height,
+                                    left: rect.left,
+                                    top: rect.top,
+                                    width: rect.width
+                                  },
+                                  entryId: entry.id
+                                }
+                          );
+                          return;
                         }
+                        case "action":
+                          closePopup();
+                          void Promise.resolve(
+                            onDockEntryAction?.({
+                              actionId: clickResolution.actionId,
+                              entryId: entry.id,
+                              host
+                            })
+                          ).catch(() => {});
+                          return;
+                        case "launch":
+                          closePopup();
+                          context.genie.launchNodeFromAnchor(
+                            anchorKey,
+                            entry.id,
+                            () =>
+                              host.launchNode({
+                                dockEntryId: entry.id,
+                                payload: entry.launchPayload,
+                                reason: "dock",
+                                typeId: entry.typeId
+                              })
+                          );
+                          return;
+                        case "blocked":
+                          return;
+                      }
+                    }}
+                  >
+                    <span
+                      className="desktop-dock__icon-shell"
+                      data-desktop-dock-icon-shell="true"
+                      data-entry-state={entry.state?.kind ?? "enabled"}
+                      aria-hidden
+                    >
+                      <span className="desktop-dock__icon-content">
+                        {entry.icon}
+                      </span>
+                      {renderDockBadge(
+                        entry,
+                        resolvedEntry.matchedNodes.length
+                      )}
+                    </span>
+                  </button>
+                );
+
+                return (
+                  <span
+                    key={dockItem.key}
+                    ref={registerDockSlot(anchorKey)}
+                    className="desktop-dock__slot"
+                    data-attention-active={
+                      activeAttentionEntryIds.has(entry.id) ? "true" : undefined
+                    }
+                    data-desktop-dock-anchor-key={anchorKey}
+                    data-desktop-dock-slot="true"
+                    data-entry-state={entry.state?.kind ?? "enabled"}
+                    data-dock-hover-panel-entry-id={
+                      hasHoverPanel ? entry.id : undefined
+                    }
+                    data-icon-size={entry.iconSize ?? "default"}
+                    data-node-state={resolvedEntry.dockNodeState}
+                    data-popup-active={currentPopup ? "true" : undefined}
+                    data-presence={dockItem.presence}
+                    data-section-id={entry.sectionId}
+                    data-wallpaper-tone={wallpaperTones.get(anchorKey)}
+                    onBlur={(event) => {
+                      if (
+                        hasHoverPanel &&
+                        !event.currentTarget.contains(event.relatedTarget)
+                      ) {
+                        closeHoverPanelImmediate(entry.id);
+                      }
+                    }}
+                    onFocus={(event) => {
+                      if (hasHoverPanel) {
+                        showHoverPanel(
+                          entry.id,
+                          anchorKey,
+                          event.currentTarget
+                        );
+                      }
+                    }}
+                    onPointerEnter={() => {
+                      if (hasHoverPanel) {
+                        scheduleHoverPanelAfterRest(entry.id, anchorKey);
+                      }
+                    }}
+                    onPointerLeave={(event) => {
+                      if (!hasHoverPanel) {
+                        return;
+                      }
+                      const relatedTarget = event.relatedTarget;
+                      if (
+                        relatedTarget instanceof Node &&
+                        hoverPanelRef.current?.contains(relatedTarget)
+                      ) {
+                        return;
+                      }
+                      if (
+                        relatedTarget instanceof Node &&
+                        dockMeasureRef.current?.contains(relatedTarget)
+                      ) {
+                        scheduleHoverPanelAtPointAfterRest(
+                          event.clientX,
+                          event.clientY
+                        );
+                        return;
+                      }
+                      if (
+                        hoverPanelRestTargetRef.current?.anchorKey === anchorKey
+                      ) {
+                        hoverPanelRestTargetRef.current = null;
+                      }
+                      clearHoverPanelOpenTimer();
+                      closeHoverPanelImmediate(entry.id);
+                      handleDockPointerLeave();
+                    }}
+                  >
+                    {dockButton}
+                  </span>
+                );
+              }
+
+              const slot = dockItem.item.slot;
+              if (slot.kind === "stack") {
+                const stackPopupActive =
+                  activeMinimizedStackPopup !== null ? true : undefined;
+                const stackButton = (
+                  <button
+                    aria-expanded={stackPopupActive}
+                    aria-haspopup="dialog"
+                    aria-label={i18n.t("minimizedWindows")}
+                    className="desktop-dock__btn desktop-dock__minimized-btn"
+                    data-interactive="true"
+                    title={i18n.t("minimizedWindows")}
+                    type="button"
+                    onPointerDown={() => {
+                      beginDockMinimizedInteraction();
+                    }}
+                    onClick={(event) => {
+                      setActivePopup(null);
+                      const rect = event.currentTarget.getBoundingClientRect();
+                      const dockRect =
+                        dockMeasureRef.current?.getBoundingClientRect();
+                      setActiveMinimizedStackPopup((current) =>
+                        current
+                          ? null
+                          : {
+                              dockRight: Math.max(
+                                rect.right,
+                                dockRect?.right ?? rect.right
+                              ),
+                              height: rect.height,
+                              left: rect.left,
+                              top: rect.top,
+                              width: rect.width
+                            }
                       );
                     }}
                   >
-                    <WorkbenchHostDockMinimizedNodePreview
-                      capturePreview={captureMinimizedNodePreview}
-                      dockPreviewCache={dockPreviewCache}
-                      node={node}
-                      workspaceId={workspaceId}
-                    />
+                    <span
+                      className="desktop-dock__minimized-stack-icon"
+                      data-desktop-dock-icon-shell="true"
+                      data-stack-folded={
+                        slot.nodes.length > 1 ? "true" : undefined
+                      }
+                      aria-hidden
+                    >
+                      {Array.from(
+                        {
+                          length:
+                            slot.nodes.length > 1
+                              ? 3
+                              : Math.min(slot.nodes.length, 1)
+                        },
+                        (_, index) => {
+                          const node = slot.nodes[index];
+                          if (index === 0 && node) {
+                            return (
+                              <WorkbenchHostDockMinimizedNodePreview
+                                key={node.id}
+                                capturePreview={captureMinimizedNodePreview}
+                                className={`desktop-dock__minimized-stack-layer desktop-dock__minimized-stack-layer--${index}`}
+                                dockPreviewCache={dockPreviewCache}
+                                node={node}
+                                workspaceId={workspaceId}
+                              />
+                            );
+                          }
+                          return (
+                            <span
+                              key={`${slot.anchorKey}-stack-back-${index}`}
+                              aria-hidden="true"
+                              className={`desktop-dock__minimized-preview desktop-dock__minimized-stack-layer desktop-dock__minimized-stack-layer--${index} desktop-dock__minimized-stack-layer-back`}
+                            />
+                          );
+                        }
+                      )}
+                      <span className="desktop-dock__count-badge">
+                        {slot.nodes.length}
+                      </span>
+                    </span>
                   </button>
                 );
 
@@ -1539,88 +1428,161 @@ export function WorkbenchHostDock({
                     key={dockItem.key}
                     ref={registerDockSlot(slot.anchorKey)}
                     className="desktop-dock__slot desktop-dock__slot--minimized"
-                    data-collapsing={
-                      collapsingMinimizedLaunchAnchorKeys.has(slot.anchorKey)
-                        ? "true"
-                        : undefined
-                    }
                     data-desktop-dock-anchor-key={slot.anchorKey}
                     data-desktop-dock-slot="true"
                     data-node-state="minimized"
+                    data-popup-active={stackPopupActive}
                     data-presence={dockItem.presence}
-                    data-promoted-from-stack={
-                      promotedNodeId === node.id ? "true" : undefined
-                    }
                     data-section-id="minimized"
+                    data-stack-dispatching={
+                      stackDispatching ? "true" : undefined
+                    }
                   >
-                    <Tooltip>
-                      <TooltipTrigger asChild>{dockButton}</TooltipTrigger>
-                      <TooltipContent
-                        side={dockPlacement === "left" ? "right" : "top"}
-                        sideOffset={DOCK_MAGNIFIED_TOOLTIP_SIDE_OFFSET}
-                      >
-                        {node.title}
-                      </TooltipContent>
-                    </Tooltip>
+                    {stackButton}
                   </span>
                 );
-              })}
-            </div>
-            <button
-              aria-label={i18n.t(
-                dockPlacement === "left" ? "scrollDockDown" : "scrollDockRight"
-              )}
-              className="desktop-dock__scroll-button desktop-dock__scroll-button--forward"
-              data-scroll-button="forward"
-              disabled={!dockScrollState.canScrollForward}
-              onClick={() => scrollDockItems("forward")}
-              type="button"
-            >
-              {dockPlacement === "left" ? (
-                <ChevronDownIcon size={16} />
-              ) : (
-                <ArrowRightIcon size={16} />
-              )}
-            </button>
-            {activeHoverPanel ? (
-              <WorkbenchHostDockHoverPanel
-                entry={
-                  resolvedEntries.find(
-                    (entry) => entry.entry.id === activeHoverPanel.entryId
-                  )?.entry ?? null
-                }
-                host={host}
-                onDockEntryAction={onDockEntryAction}
-                pendingActionKeys={pendingActionKeys}
-                placement={dockPlacement}
-                hoverPanelRef={hoverPanelRef}
-                setPendingActionKeys={setPendingActionKeys}
-                state={activeHoverPanel}
-                onBlur={(event) => {
-                  if (!event.currentTarget.contains(event.relatedTarget)) {
-                    closeHoverPanelImmediate(activeHoverPanel.entryId);
+              }
+
+              const node = slot.node;
+              const dockButton = (
+                <button
+                  aria-label={i18n.t("launch", { title: node.title })}
+                  className="desktop-dock__btn desktop-dock__minimized-btn"
+                  data-interactive="true"
+                  title={node.title}
+                  type="button"
+                  onPointerDown={() => {
+                    const restoreIntent =
+                      resolveWorkbenchMinimizedDockRestoreIntent({
+                        nodeId: node.id,
+                        slots: minimizedDockSlots,
+                        source: {
+                          anchorKey: slot.anchorKey,
+                          kind: "node-slot"
+                        }
+                      });
+                    if (restoreIntent?.kind !== "node-slot") {
+                      clearCollapsingMinimizedLaunch(slot.anchorKey);
+                      return;
+                    }
+                    beginDockMinimizedInteraction();
+                  }}
+                  onClick={() => {
+                    const restoreIntent =
+                      resolveWorkbenchMinimizedDockRestoreIntent({
+                        nodeId: node.id,
+                        slots: minimizedDockSlots,
+                        source: {
+                          anchorKey: slot.anchorKey,
+                          kind: "node-slot"
+                        }
+                      });
+                    if (restoreIntent?.kind !== "node-slot") {
+                      clearCollapsingMinimizedLaunch(slot.anchorKey);
+                      return;
+                    }
+                    closePopup();
+                    runDockMinimizedLaunchAfterCollapse(
+                      restoreIntent,
+                      (intent) => {
+                        context.genie.launchNodeFromAnchor(
+                          intent.anchorKey,
+                          intent.nodeId,
+                          () => {
+                            host.focusNode(intent.nodeId);
+                          }
+                        );
+                      }
+                    );
+                  }}
+                >
+                  <WorkbenchHostDockMinimizedNodePreview
+                    capturePreview={captureMinimizedNodePreview}
+                    dockPreviewCache={dockPreviewCache}
+                    node={node}
+                    workspaceId={workspaceId}
+                  />
+                </button>
+              );
+
+              return (
+                <span
+                  key={dockItem.key}
+                  ref={registerDockSlot(slot.anchorKey)}
+                  className="desktop-dock__slot desktop-dock__slot--minimized"
+                  data-collapsing={
+                    collapsingMinimizedLaunchAnchorKeys.has(slot.anchorKey)
+                      ? "true"
+                      : undefined
                   }
-                }}
-                onFocus={clearHoverPanelCloseTimer}
-                onPointerEnter={clearHoverPanelCloseTimer}
-                onPointerLeave={(event) => {
-                  const relatedTarget = event.relatedTarget;
-                  const anchorSlot = slotRefs.current.get(
-                    activeHoverPanel.anchorKey
-                  );
-                  if (
-                    relatedTarget instanceof Node &&
-                    anchorSlot?.contains(relatedTarget)
-                  ) {
-                    return;
+                  data-desktop-dock-anchor-key={slot.anchorKey}
+                  data-desktop-dock-slot="true"
+                  data-node-state="minimized"
+                  data-presence={dockItem.presence}
+                  data-promoted-from-stack={
+                    promotedNodeId === node.id ? "true" : undefined
                   }
-                  scheduleHoverPanelClose(activeHoverPanel.entryId);
-                  handleDockPointerLeave();
-                }}
-              />
-            ) : null}
+                  data-section-id="minimized"
+                >
+                  {dockButton}
+                </span>
+              );
+            })}
           </div>
-        </TooltipProvider>
+          <button
+            aria-label={i18n.t(
+              dockPlacement === "left" ? "scrollDockDown" : "scrollDockRight"
+            )}
+            className="desktop-dock__scroll-button desktop-dock__scroll-button--forward"
+            data-scroll-button="forward"
+            disabled={!dockScrollState.canScrollForward}
+            onClick={() => scrollDockItems("forward")}
+            type="button"
+          >
+            {dockPlacement === "left" ? (
+              <ChevronDownIcon size={16} />
+            ) : (
+              <ArrowRightIcon size={16} />
+            )}
+          </button>
+          {activeHoverPanel ? (
+            <WorkbenchHostDockHoverPanel
+              entry={
+                resolvedEntries.find(
+                  (entry) => entry.entry.id === activeHoverPanel.entryId
+                )?.entry ?? null
+              }
+              host={host}
+              onDockEntryAction={onDockEntryAction}
+              pendingActionKeys={pendingActionKeys}
+              placement={dockPlacement}
+              hoverPanelRef={hoverPanelRef}
+              setPendingActionKeys={setPendingActionKeys}
+              state={activeHoverPanel}
+              onBlur={(event) => {
+                if (!event.currentTarget.contains(event.relatedTarget)) {
+                  closeHoverPanelImmediate(activeHoverPanel.entryId);
+                }
+              }}
+              onFocus={clearHoverPanelCloseTimer}
+              onPointerEnter={clearHoverPanelCloseTimer}
+              onPointerLeave={(event) => {
+                const relatedTarget = event.relatedTarget;
+                const anchorSlot = slotRefs.current.get(
+                  activeHoverPanel.anchorKey
+                );
+                if (
+                  relatedTarget instanceof Node &&
+                  anchorSlot?.contains(relatedTarget)
+                ) {
+                  return;
+                }
+                scheduleHoverPanelClose(activeHoverPanel.entryId);
+                handleDockPointerLeave();
+              }}
+            />
+          ) : null}
+        </div>
       </div>
       {popupEntry && activePopup ? (
         <WorkbenchHostDockPopup
@@ -2835,7 +2797,6 @@ const dockHoverPanelCloseDelayMs = 160;
 const dockHoverPanelHitSlopPx = 12;
 const dockHoverPanelBridgeSlopPx = 6;
 const dockHoverPanelPointerRestTolerancePx = 4;
-const DOCK_MAGNIFIED_TOOLTIP_SIDE_OFFSET = 40;
 const dockWallpaperSampleCanvasMaxSizePx = 192;
 const dockWallpaperToneSampleCount = 7;
 const dockWallpaperDarkLuminanceThreshold = 132;


### PR DESCRIPTION
## Summary
- avoid the dock Radix tooltip portal path that was triggering React #185 on hover, while keeping native dock titles and existing explicit hover panels
- keep Agent GUI rail resize width stable during an in-flight drag even if the parent rerenders with the old controlled width
- add regression coverage for both dock tooltip behavior and rail resize rerender stability

## Verification
- pnpm --dir packages/agent/gui exec vitest run --environment jsdom agent-gui/agentGuiNode/AgentGUINodeView.layout.spec.tsx
- pnpm --filter @tutti-os/agent-gui typecheck
- pnpm --dir packages/workbench/surface exec node --test --experimental-strip-types ./src/host/WorkbenchHostDock.test.ts
- pnpm check:full passed twice via pre-push; final push used --no-verify only because GitHub SSH closed the idle connection after the successful hook run
