### PR TITLE
[codex] Sync app package icons

### DIFF
--- a/apps/desktop/src/renderer/src/features/workspace-workbench/services/workspaceAppIconStyle.test.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/services/workspaceAppIconStyle.test.ts
@@ -10,6 +10,10 @@ test("default workspace app icon resolver includes built-in agent launcher apps"
     resolveIconUrl("agent-claude-code") ?? "",
     /\/claudecode\.png$/u
   );
-  assert.match(resolveIconUrl("automation") ?? "", /\/automation\.png$/u);
+  assert.equal(resolveIconUrl("automation"), null);
+  assert.equal(resolveIconUrl("ai-media-canvas"), null);
+  assert.equal(resolveIconUrl("daily-tech-radar"), null);
+  assert.equal(resolveIconUrl("group-chat"), null);
+  assert.equal(resolveIconUrl("vibe-design"), null);
   assert.equal(resolveIconUrl("missing-app"), null);
 });

--- a/apps/desktop/src/renderer/src/features/workspace-workbench/services/workspaceAppIconStyle.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/services/workspaceAppIconStyle.ts
@@ -6,10 +6,6 @@ const defaultCodexIconUrl = new URL(
   "../../../assets/workspace-canvas/dock/default/codex.png",
   import.meta.url
 ).href;
-const defaultAutomationIconUrl = new URL(
-  "../../../assets/workspace-canvas/dock/default/apps/automation.png",
-  import.meta.url
-).href;
 const defaultAiPptIconUrl = new URL(
   "../../../assets/workspace-canvas/dock/default/apps/PPT.png",
   import.meta.url
@@ -20,10 +16,6 @@ const defaultAiSummaryIconUrl = new URL(
 ).href;
 const defaultCalendarIconUrl = new URL(
   "../../../assets/workspace-canvas/dock/default/apps/calendar.png",
-  import.meta.url
-).href;
-const defaultChatIconUrl = new URL(
-  "../../../assets/workspace-canvas/dock/default/apps/chat.png",
   import.meta.url
 ).href;
 const defaultDesignReviewIconUrl = new URL(
@@ -54,10 +46,6 @@ const defaultSheetIconUrl = new URL(
   "../../../assets/workspace-canvas/dock/default/apps/sheet.png",
   import.meta.url
 ).href;
-const defaultVibeDesignIconUrl = new URL(
-  "../../../assets/workspace-canvas/dock/default/apps/vibedesign.png",
-  import.meta.url
-).href;
 
 export type WorkspaceAppIconResolver = (appId: string) => string | null;
 
@@ -65,22 +53,17 @@ export function createDefaultWorkspaceAppIconResolver(): WorkspaceAppIconResolve
   const iconsByAppId = new Map<string, string>([
     ["agent-claude-code", defaultClaudeCodeIconUrl],
     ["agent-codex", defaultCodexIconUrl],
-    ["automation", defaultAutomationIconUrl],
     ["ai-ppt", defaultAiPptIconUrl],
     ["ai-document", defaultDocumentIconUrl],
     ["ai-sheet", defaultSheetIconUrl],
     ["calendar", defaultCalendarIconUrl],
-    ["group-chat", defaultChatIconUrl],
-    ["ai-media-canvas", defaultMediaCanvasIconUrl],
     ["design-review", defaultDesignReviewIconUrl],
     ["daily-product-radar", defaultRadarIconUrl],
-    ["daily-tech-radar", defaultRadarIconUrl],
     ["document-summarizer", defaultAiSummaryIconUrl],
     ["media-canvas", defaultMediaCanvasIconUrl],
     ["open-cut", defaultOpenCutIconUrl],
     ["product-competition", defaultProductCompetitionIconUrl],
-    ["radar", defaultRadarIconUrl],
-    ["vibe-design", defaultVibeDesignIconUrl]
+    ["radar", defaultRadarIconUrl]
   ]);
   return (appId) => iconsByAppId.get(appId) ?? null;
 }


### PR DESCRIPTION
## What changed

- Removed desktop-side local icon resolver entries for external package-owned apps: automation, ai-media-canvas, daily-tech-radar, group-chat, and vibe-design.
- Kept the resolver for built-in/default desktop apps.

## Why

- These external app icons now belong in each app package/catalog, so mention resolver and other workspace icon surfaces resolve the released package icon instead of a desktop override.

## Validation

- pnpm --filter @tutti-os/desktop test -- workspaceAppIconStyle.test.ts
- pnpm check:full
