### PR TITLE
fix(codex): retain context usage replayed during thread/resume

### DIFF
--- a/packages/agent/daemon/runtime/codex_appserver_adapter.go
+++ b/packages/agent/daemon/runtime/codex_appserver_adapter.go
@@ -352,8 +352,23 @@ func (a *CodexAppServerAdapter) Resume(ctx context.Context, session Session) err
 
 	params := appServerThreadStartParams(session, a.sessionCWD(session))
 	params["threadId"] = strings.TrimSpace(session.ProviderSessionID)
+	// codex replays thread/tokenUsage/updated during thread/resume so the GUI
+	// can show context fill before a new turn runs. The resumed session is not
+	// stored yet, so applyTokenUsage cannot reach it; capture the replayed
+	// usage here and fold it into the live state below.
+	var replayedUsage acpUsageState
+	replayedUsageKnown := false
 	threadResult, err := client.CallWithTimeout(ctx, acpStartCallTimeout, appServerMethodThreadResume, params,
 		func(ctx context.Context, message acpMessage) error {
+			if message.Method == appServerNotifyTokenUsage && len(message.Params) > 0 {
+				tokenParams := map[string]any{}
+				if json.Unmarshal(message.Params, &tokenParams) == nil {
+					if usage, ok := appServerTokenUsageState(tokenParams); ok {
+						replayedUsage = usage
+						replayedUsageKnown = true
+					}
+				}
+			}
 			_, err := a.handleAppServerMessage(ctx, client, session, "", message, nil, nil, nil)
 			return err
 		})
@@ -367,6 +382,9 @@ func (a *CodexAppServerAdapter) Resume(ctx context.Context, session Session) err
 	applyACPConfigOptionDescriptors(&liveState, codexAppServerConfigOptionDescriptors(models, session, threadResult))
 	if quotas := appServerRateLimitQuotas(rateLimits); len(quotas) > 0 {
 		liveState.usage = mergeACPUsageState(liveState.usage, acpUsageState{quotas: quotas})
+	}
+	if replayedUsageKnown {
+		liveState.usage = mergeACPUsageState(liveState.usage, replayedUsage)
 	}
 
 	started = true

--- a/packages/agent/daemon/runtime/codex_appserver_adapter_test.go
+++ b/packages/agent/daemon/runtime/codex_appserver_adapter_test.go
@@ -72,6 +72,7 @@ type scriptedAppServerConnection struct {
 	goal                         map[string]any
 	goalStartsTurn               bool
 	goalCleared                  bool
+	replayTokenUsageOnResume     bool // mirror real codex: emit token usage during thread/resume
 	closeOnce                    sync.Once
 }
 
@@ -249,6 +250,21 @@ func (c *scriptedAppServerConnection) Send(data []byte) error {
 			c.notify(appServerNotifyThreadStarted, map[string]any{
 				"thread": map[string]any{"id": "codex-thread-1"},
 			})
+			c.mu.Lock()
+			replayTokenUsage := c.replayTokenUsageOnResume && message.Method == appServerMethodThreadResume
+			c.mu.Unlock()
+			if replayTokenUsage {
+				// Real codex 0.140.0 replays thread/tokenUsage/updated during
+				// thread/resume so the GUI can show context fill before a new
+				// turn runs (modelContextWindow at top level, last.inputTokens).
+				c.notify(appServerNotifyTokenUsage, map[string]any{
+					"tokenUsage": map[string]any{
+						"modelContextWindow": 258400,
+						"last":               map[string]any{"inputTokens": 20453, "totalTokens": 20473},
+						"total":              map[string]any{"totalTokens": 20473},
+					},
+				})
+			}
 			c.sendJSON(map[string]any{
 				"id": message.ID,
 				"result": map[string]any{
@@ -793,6 +809,34 @@ func TestCodexAppServerAdapterResumeEmitsCommandSnapshot(t *testing.T) {
 		if !containsString(names, want) {
 			t.Fatalf("resume snapshot commands = %#v, want %q", names, want)
 		}
+	}
+}
+
+func TestCodexAppServerAdapterResumeRetainsReplayedContextUsage(t *testing.T) {
+	t.Parallel()
+
+	transport := newScriptedAppServerTransport()
+	transport.conn.replayTokenUsageOnResume = true
+	adapter := NewCodexAppServerAdapter(transport)
+	session := testAppServerSession()
+	session.ProviderSessionID = "codex-thread-1"
+
+	if err := adapter.Resume(context.Background(), session); err != nil {
+		t.Fatalf("Resume: %v", err)
+	}
+
+	state := adapter.SessionState(session)
+	usage, _ := state.RuntimeContext["usage"].(map[string]any)
+	contextWindow, _ := usage["contextWindow"].(map[string]any)
+
+	if contextWindow == nil {
+		t.Fatalf("resume dropped replayed token usage: usage=%#v", usage)
+	}
+	if got, _ := acpInt64Value(contextWindow["usedTokens"]); got != 20453 {
+		t.Fatalf("usedTokens = %d, want 20453", got)
+	}
+	if got, _ := acpInt64Value(contextWindow["totalTokens"]); got != 258400 {
+		t.Fatalf("totalTokens = %d, want 258400", got)
 	}
 }
 

--- a/packages/agent/daemon/runtime/codex_appserver_events.go
+++ b/packages/agent/daemon/runtime/codex_appserver_events.go
@@ -422,19 +422,37 @@ func appServerPlanStepStatus(status string) string {
 }
 
 func (a *CodexAppServerAdapter) applyTokenUsage(agentSessionID string, params map[string]any) {
-	tokenUsage := payloadObject(params["tokenUsage"])
-	if len(tokenUsage) == 0 {
+	usage, ok := appServerTokenUsageState(params)
+	if !ok {
 		return
 	}
-	// ThreadTokenUsage schema: "last" = most-recent API call breakdown,
-	// "total" = cumulative thread totals.  Use last.inputTokens (context fill
-	// sent to the model) as the most accurate indicator of how full the window
-	// is.  Fall back to last.totalTokens (includes response tokens — slightly
-	// high but still per-request), then total.totalTokens only when "last" is
-	// absent entirely.  Using total.totalTokens as primary causes a false
-	// compact alert: after 10 calls of 27 K tokens each the cumulative reaches
-	// 270 K and exceeds the 258 K per-request window even though each call
-	// individually used only ~10 %.
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	appSession := a.sessions[strings.TrimSpace(agentSessionID)]
+	if appSession == nil {
+		return
+	}
+	appSession.usage = mergeACPUsageState(appSession.usage, usage)
+}
+
+// appServerTokenUsageState parses a thread/tokenUsage/updated payload into the
+// context-window portion of acpUsageState. It is shared between the live
+// notification path (applyTokenUsage) and the resume handshake, where codex
+// replays token usage before the session is stored.
+//
+// ThreadTokenUsage schema: "last" = most-recent API call breakdown, "total" =
+// cumulative thread totals. Use last.inputTokens (context fill sent to the
+// model) as the most accurate indicator of how full the window is. Fall back to
+// last.totalTokens (includes response tokens — slightly high but still
+// per-request), then total.totalTokens only when "last" is absent entirely.
+// Using total.totalTokens as primary causes a false compact alert: after 10
+// calls of 27 K tokens each the cumulative reaches 270 K and exceeds the 258 K
+// per-request window even though each call individually used only ~10 %.
+func appServerTokenUsageState(params map[string]any) (acpUsageState, bool) {
+	tokenUsage := payloadObject(params["tokenUsage"])
+	if len(tokenUsage) == 0 {
+		return acpUsageState{}, false
+	}
 	last := payloadObject(tokenUsage["last"])
 	used, usedOK := firstACPInt64(last, "inputTokens")
 	if !usedOK {
@@ -445,19 +463,13 @@ func (a *CodexAppServerAdapter) applyTokenUsage(agentSessionID string, params ma
 	}
 	window, windowOK := firstACPInt64(tokenUsage, "modelContextWindow")
 	if !usedOK || !windowOK {
-		return
+		return acpUsageState{}, false
 	}
-	a.mu.Lock()
-	defer a.mu.Unlock()
-	appSession := a.sessions[strings.TrimSpace(agentSessionID)]
-	if appSession == nil {
-		return
-	}
-	appSession.usage = mergeACPUsageState(appSession.usage, acpUsageState{
+	return acpUsageState{
 		contextUsedTokens:   used,
 		contextWindowTokens: window,
 		contextKnown:        true,
-	})
+	}, true
 }
 
 func (a *CodexAppServerAdapter) applyRateLimits(agentSessionID string, snapshot map[string]any) {


### PR DESCRIPTION
## Summary

- Reopened Codex conversations showed **"上下文用量不可用"** (context usage unavailable) even though rate limits displayed, until a new turn was run.
- Root cause: codex replays a `thread/tokenUsage/updated` notification during `thread/resume`, but the resumed session was not yet stored when `applyTokenUsage` ran, so the replayed usage hit a nil session and was dropped. `Resume` then overwrote `liveState` with only the proactively-fetched rate-limit quotas.
- Fix: capture the token usage replayed during the resume handshake and fold it into `liveState` before storing the session. Extracted a shared `appServerTokenUsageState` parser used by both the live `applyTokenUsage` path and resume.

## Root cause evidence

- Driving the real `codex app-server` (0.140.0) confirmed it emits `thread/tokenUsage/updated` with `modelContextWindow` at top level and `last.inputTokens`, and **replays it on `thread/resume`** without a new turn.
- A daemon-level reproduction proved the drop: after resume, `SessionState.usage` contained only `quotas` (no `contextWindow`). After the fix it contains `usedTokens`/`totalTokens`.

## Test plan

- [x] `cd packages/agent/daemon && go test ./runtime/ -run TestCodexAppServerAdapterResume` (new `TestCodexAppServerAdapterResumeRetainsReplayedContextUsage` passes)
- [x] `go build ./...`
- [x] `pnpm --filter @tutti-os/agent-gui typecheck`
- [x] `check:full` (test:go, typecheck, lint:ts) passed on push
- [x] Manually verified in the desktop app: reopening a Codex conversation now shows context usage without sending a new message.

Made with [Cursor](https://cursor.com)