### PR TITLE
Polish task status and subtask progress UI

### DIFF
--- a/packages/workspace/issue-manager/src/i18n/issueManagerI18n.test.ts
+++ b/packages/workspace/issue-manager/src/i18n/issueManagerI18n.test.ts
@@ -104,7 +104,7 @@ test("en task terminology and status labels use requested copy", () => {
   assert.equal(copy.t("labels.taskList"), "Tasks");
   assert.equal(copy.t("messages.noIssues"), "No tasks yet");
   assert.equal(copy.t("messages.noTasks"), "No tasks yet");
-  assert.equal(copy.t("status.notStarted"), "To do");
+  assert.equal(copy.t("status.notStarted"), "Todo");
   assert.equal(copy.t("status.running"), "Running");
   assert.equal(copy.t("status.inProgress"), "Running");
   assert.equal(copy.t("status.pendingAcceptance"), "In review");

--- a/packages/workspace/issue-manager/src/i18n/issueManagerI18n.ts
+++ b/packages/workspace/issue-manager/src/i18n/issueManagerI18n.ts
@@ -140,7 +140,7 @@ const issueManagerEn = {
     noOutputs: "No outputs yet",
     noRecentRuns: "No runs yet",
     taskContentEmpty: "No task description yet",
-    taskAcceptanceHint: "Accept to complete; reject to return to To do.",
+    taskAcceptanceHint: "Accept to complete; reject to return to Todo.",
     noTaskReferences: "No task references yet",
     noTasksForIssueBody:
       "Create the first subtask for this task and let an agent or yourself execute it",
@@ -224,7 +224,7 @@ const issueManagerEn = {
     completed: "Done",
     failed: "Failed",
     inProgress: "Running",
-    notStarted: "To do",
+    notStarted: "Todo",
     pendingAcceptance: "In review",
     running: "Running",
     unknown: "Unknown"

--- a/packages/workspace/issue-manager/src/services/internal/controllerRuntime.test.ts
+++ b/packages/workspace/issue-manager/src/services/internal/controllerRuntime.test.ts
@@ -193,6 +193,68 @@ test("controllerRuntime reloads issues when deferred search input changes", asyn
   runtime.release();
 });
 
+test("controllerRuntime includes legacy in-progress issues in the running filter", async () => {
+  const statusFilters: string[] = [];
+  const runtime = createIssueManagerControllerRuntime({
+    feature: createFeature({
+      async listIssues(input) {
+        statusFilters.push(input.statusFilter ?? "");
+        if (input.statusFilter === "running") {
+          return {
+            issues: [
+              {
+                ...createIssueSummary({
+                  issueId: "issue-running",
+                  title: "Running task"
+                }),
+                status: "running"
+              }
+            ]
+          };
+        }
+        if (input.statusFilter === "in_progress") {
+          return {
+            issues: [
+              {
+                ...createIssueSummary({
+                  issueId: "issue-legacy",
+                  title: "Legacy running task"
+                }),
+                status: "in_progress"
+              }
+            ]
+          };
+        }
+        return {
+          issues: []
+        };
+      }
+    }),
+    state: {
+      activeTopicId: "topic-1",
+      issueStatusFilter: "running"
+    },
+    workspaceId: "workspace-1"
+  });
+
+  runtime.retain();
+  await flushAsyncWork();
+  await flushAsyncWork();
+
+  assert.deepEqual(statusFilters, ["running", "in_progress"]);
+  assert.deepEqual(
+    runtime
+      .getSnapshot()
+      .issues.value.map((issue) => [issue.issueId, issue.status]),
+    [
+      ["issue-running", "running"],
+      ["issue-legacy", "in_progress"]
+    ]
+  );
+
+  runtime.release();
+});
+
 test("controllerRuntime reports task search analytics only for explicit search usage", async () => {
   const searches: string[] = [];
   const analyticsEvents: IssueManagerAnalyticsEvent[] = [];

--- a/packages/workspace/issue-manager/src/services/internal/controllerRuntime.ts
+++ b/packages/workspace/issue-manager/src/services/internal/controllerRuntime.ts
@@ -2,6 +2,7 @@ import type { SetStateAction } from "react";
 import { proxy } from "valtio/vanilla";
 import type {
   IssueManagerIssueDetail,
+  IssueManagerListIssuesResult,
   IssueManagerIssueSummary,
   IssueManagerNodeState,
   IssueManagerOpenSource,
@@ -70,6 +71,33 @@ function createIssueManagerOpenedParams(source: IssueManagerOpenSource): {
       source === "restore" || source === "agent_command"
         ? "automatic"
         : "manual"
+  };
+}
+
+function mergeIssueManagerRunningListResults(
+  results: readonly [IssueManagerListIssuesResult, IssueManagerListIssuesResult]
+): IssueManagerListIssuesResult {
+  const [runningResult, legacyResult] = results;
+  const issueIds = new Set<string>();
+  const issues: IssueManagerIssueSummary[] = [];
+
+  for (const issue of [...runningResult.issues, ...legacyResult.issues]) {
+    if (issueIds.has(issue.issueId)) {
+      continue;
+    }
+    issueIds.add(issue.issueId);
+    issues.push(issue);
+  }
+
+  return {
+    issues,
+    nextPageToken: runningResult.nextPageToken ?? legacyResult.nextPageToken,
+    statusCounts: runningResult.statusCounts ?? legacyResult.statusCounts,
+    totalCount:
+      runningResult.totalCount !== undefined ||
+      legacyResult.totalCount !== undefined
+        ? issues.length
+        : undefined
   };
 }
 
@@ -371,12 +399,24 @@ export function createIssueManagerControllerRuntime(
     }));
 
     try {
-      const result = await input.feature.backend.listIssues({
-        searchQuery: searchQuery || undefined,
-        statusFilter: snapshot.nodeState.issueStatusFilter,
-        topicId: activeTopicId,
-        workspaceId: input.workspaceId
-      });
+      const listIssues = (
+        statusFilter: IssueManagerNodeState["issueStatusFilter"]
+      ) =>
+        input.feature.backend.listIssues({
+          searchQuery: searchQuery || undefined,
+          statusFilter,
+          topicId: activeTopicId,
+          workspaceId: input.workspaceId
+        });
+      const result =
+        snapshot.nodeState.issueStatusFilter === "running"
+          ? mergeIssueManagerRunningListResults(
+              await Promise.all([
+                listIssues("running"),
+                listIssues("in_progress")
+              ])
+            )
+          : await listIssues(snapshot.nodeState.issueStatusFilter);
       if (!retained || sequence !== issueListSequence) {
         return;
       }

--- a/packages/workspace/issue-manager/src/ui/internal/shell/IssueManagerShellState.test.ts
+++ b/packages/workspace/issue-manager/src/ui/internal/shell/IssueManagerShellState.test.ts
@@ -10,6 +10,7 @@ import {
   resolveIssueManagerStatusCounts,
   resolveIssueManagerShellContentViewState,
   resolveIssueManagerSubtaskProgress,
+  resolveIssueManagerSubtaskProgressByIssueId,
   resolveIssueManagerSubtaskProgressFromTasks,
   resolveIssueManagerSidebarViewState
 } from "./IssueManagerShellState.ts";
@@ -275,6 +276,28 @@ test("subtask progress from visible tasks counts only visible completed subtasks
       percent: 50,
       total: 2
     }
+  );
+});
+
+test("subtask progress override hides summary progress when visible subtasks are empty", () => {
+  assert.deepEqual(
+    resolveIssueManagerSubtaskProgressByIssueId({
+      issueId: "issue-1",
+      visibleTasks: []
+    }),
+    {
+      "issue-1": null
+    }
+  );
+});
+
+test("subtask progress override is omitted when no issue detail is available", () => {
+  assert.deepEqual(
+    resolveIssueManagerSubtaskProgressByIssueId({
+      issueId: null,
+      visibleTasks: null
+    }),
+    {}
   );
 });
 

--- a/packages/workspace/issue-manager/src/ui/internal/shell/IssueManagerShellState.test.ts
+++ b/packages/workspace/issue-manager/src/ui/internal/shell/IssueManagerShellState.test.ts
@@ -265,16 +265,17 @@ test("subtask progress from visible tasks is hidden when all subtasks are filter
   assert.equal(resolveIssueManagerSubtaskProgressFromTasks([]), null);
 });
 
-test("subtask progress from visible tasks counts only visible completed subtasks", () => {
+test("subtask progress from visible tasks counts review-ready subtasks as completed", () => {
   assert.deepEqual(
     resolveIssueManagerSubtaskProgressFromTasks([
       createTaskSummary({ status: "completed", taskId: "task-1" }),
-      createTaskSummary({ status: "running", taskId: "task-2" })
+      createTaskSummary({ status: "pending_acceptance", taskId: "task-2" }),
+      createTaskSummary({ status: "running", taskId: "task-3" })
     ]),
     {
-      completed: 1,
-      percent: 50,
-      total: 2
+      completed: 2,
+      percent: 66.66666666666666,
+      total: 3
     }
   );
 });

--- a/packages/workspace/issue-manager/src/ui/internal/shell/IssueManagerShellState.test.ts
+++ b/packages/workspace/issue-manager/src/ui/internal/shell/IssueManagerShellState.test.ts
@@ -1,12 +1,16 @@
 import assert from "node:assert/strict";
 import test from "node:test";
-import type { IssueManagerIssueSummary } from "../../../contracts/index.ts";
+import type {
+  IssueManagerIssueSummary,
+  IssueManagerTaskSummary
+} from "../../../contracts/index.ts";
 import type { IssueManagerI18nRuntime } from "../../../i18n/issueManagerI18n.ts";
 import {
   buildIssueManagerStatusCounts,
   resolveIssueManagerStatusCounts,
   resolveIssueManagerShellContentViewState,
   resolveIssueManagerSubtaskProgress,
+  resolveIssueManagerSubtaskProgressFromTasks,
   resolveIssueManagerSidebarViewState
 } from "./IssueManagerShellState.ts";
 
@@ -256,6 +260,24 @@ test("subtask progress uses completed subtasks over total subtasks", () => {
   );
 });
 
+test("subtask progress from visible tasks is hidden when all subtasks are filtered out", () => {
+  assert.equal(resolveIssueManagerSubtaskProgressFromTasks([]), null);
+});
+
+test("subtask progress from visible tasks counts only visible completed subtasks", () => {
+  assert.deepEqual(
+    resolveIssueManagerSubtaskProgressFromTasks([
+      createTaskSummary({ status: "completed", taskId: "task-1" }),
+      createTaskSummary({ status: "running", taskId: "task-2" })
+    ]),
+    {
+      completed: 1,
+      percent: 50,
+      total: 2
+    }
+  );
+});
+
 test("shell content view state prefers issue editing over task flows", () => {
   assert.deepEqual(
     resolveIssueManagerShellContentViewState({
@@ -339,6 +361,20 @@ function createIssueSummary(
     taskCount: input.taskCount,
     title: input.title ?? "Task",
     topicId: "topic-1",
+    workspaceId: "workspace-1"
+  };
+}
+
+function createTaskSummary(
+  input: Pick<IssueManagerTaskSummary, "status" | "taskId">
+): IssueManagerTaskSummary {
+  return {
+    creatorUserId: "local",
+    issueId: "issue-1",
+    priority: "medium",
+    status: input.status,
+    taskId: input.taskId,
+    title: "Task",
     workspaceId: "workspace-1"
   };
 }

--- a/packages/workspace/issue-manager/src/ui/internal/shell/IssueManagerShellState.ts
+++ b/packages/workspace/issue-manager/src/ui/internal/shell/IssueManagerShellState.ts
@@ -160,6 +160,21 @@ export function resolveIssueManagerSubtaskProgressFromTasks(
   };
 }
 
+export function resolveIssueManagerSubtaskProgressByIssueId(input: {
+  issueId: string | null;
+  visibleTasks: readonly Pick<IssueManagerTaskSummary, "status">[] | null;
+}): Record<string, IssueManagerSubtaskProgressViewState | null> {
+  if (!input.issueId || !input.visibleTasks) {
+    return {};
+  }
+
+  return {
+    [input.issueId]: resolveIssueManagerSubtaskProgressFromTasks(
+      input.visibleTasks
+    )
+  };
+}
+
 export interface IssueManagerShellContentViewState {
   isIssueEditing: boolean;
   isTaskCreating: boolean;

--- a/packages/workspace/issue-manager/src/ui/internal/shell/IssueManagerShellState.ts
+++ b/packages/workspace/issue-manager/src/ui/internal/shell/IssueManagerShellState.ts
@@ -151,7 +151,10 @@ export function resolveIssueManagerSubtaskProgressFromTasks(
     return null;
   }
 
-  const completed = tasks.filter((task) => task.status === "completed").length;
+  const completed = tasks.filter(
+    (task) =>
+      task.status === "completed" || task.status === "pending_acceptance"
+  ).length;
 
   return {
     completed,

--- a/packages/workspace/issue-manager/src/ui/internal/shell/IssueManagerShellState.ts
+++ b/packages/workspace/issue-manager/src/ui/internal/shell/IssueManagerShellState.ts
@@ -1,6 +1,7 @@
 import type {
   IssueManagerIssueSummary,
-  IssueManagerStatusCounts
+  IssueManagerStatusCounts,
+  IssueManagerTaskSummary
 } from "../../../contracts/index.ts";
 import type { IssueManagerI18nRuntime } from "../../../i18n/issueManagerI18n.ts";
 import type { AsyncCollectionState } from "../../../services/controllerTypes.ts";
@@ -134,6 +135,23 @@ export function resolveIssueManagerSubtaskProgress(
     total,
     Math.max(0, Math.trunc(issue.completedCount ?? 0))
   );
+
+  return {
+    completed,
+    percent: (completed / total) * 100,
+    total
+  };
+}
+
+export function resolveIssueManagerSubtaskProgressFromTasks(
+  tasks: readonly Pick<IssueManagerTaskSummary, "status">[]
+): IssueManagerSubtaskProgressViewState | null {
+  const total = tasks.length;
+  if (total <= 0) {
+    return null;
+  }
+
+  const completed = tasks.filter((task) => task.status === "completed").length;
 
   return {
     completed,

--- a/packages/workspace/issue-manager/src/ui/internal/shell/IssueManagerSidebar.tsx
+++ b/packages/workspace/issue-manager/src/ui/internal/shell/IssueManagerSidebar.tsx
@@ -8,10 +8,9 @@ import {
 } from "./IssueManagerSidebarSections.tsx";
 import { resolveIssueManagerSidebarPresentationState } from "./IssueManagerSidebarState.ts";
 import type { IssueManagerController } from "../../react/index.ts";
-import { resolveIssueManagerSubtaskProgressFromTasks } from "./IssueManagerShellState.ts";
+import { resolveIssueManagerSubtaskProgressByIssueId } from "./IssueManagerShellState.ts";
 import type {
   issueManagerStatusFilters,
-  IssueManagerSubtaskProgressViewState,
   IssueManagerSidebarViewState
 } from "./IssueManagerShellState.ts";
 import {
@@ -62,18 +61,10 @@ export function IssueManagerSidebar({
         tasks: currentIssueDetail.tasks
       })
     : [];
-  const visibleSubtaskProgress = currentIssueDetail
-    ? resolveIssueManagerSubtaskProgressFromTasks(visibleTasks)
-    : null;
-  const subtaskProgressByIssueId: Record<
-    string,
-    IssueManagerSubtaskProgressViewState | null
-  > =
-    currentIssueDetail && visibleSubtaskProgress
-      ? {
-          [currentIssueDetail.issue.issueId]: visibleSubtaskProgress
-        }
-      : {};
+  const subtaskProgressByIssueId = resolveIssueManagerSubtaskProgressByIssueId({
+    issueId: currentIssueDetail?.issue.issueId ?? null,
+    visibleTasks: currentIssueDetail ? visibleTasks : null
+  });
 
   return (
     <aside

--- a/packages/workspace/issue-manager/src/ui/internal/shell/IssueManagerSidebar.tsx
+++ b/packages/workspace/issue-manager/src/ui/internal/shell/IssueManagerSidebar.tsx
@@ -8,10 +8,16 @@ import {
 } from "./IssueManagerSidebarSections.tsx";
 import { resolveIssueManagerSidebarPresentationState } from "./IssueManagerSidebarState.ts";
 import type { IssueManagerController } from "../../react/index.ts";
+import { resolveIssueManagerSubtaskProgressFromTasks } from "./IssueManagerShellState.ts";
 import type {
   issueManagerStatusFilters,
+  IssueManagerSubtaskProgressViewState,
   IssueManagerSidebarViewState
 } from "./IssueManagerShellState.ts";
+import {
+  resolveIssueManagerIssueRunTaskId,
+  resolveIssueManagerVisibleSubtasks
+} from "../issue/IssueManagerIssueAcceptanceState.ts";
 
 export interface IssueManagerSidebarProps {
   controller: IssueManagerController;
@@ -35,6 +41,36 @@ export function IssueManagerSidebar({
     showStandaloneState,
     sidebarViewState
   });
+  const currentIssueDetail =
+    controller.issueDetail.value?.issue.issueId ===
+    controller.nodeState.selectedIssueId
+      ? controller.issueDetail.value
+      : null;
+  const issueRunTaskId = currentIssueDetail
+    ? resolveIssueManagerIssueRunTaskId({
+        latestRun:
+          currentIssueDetail.latestRun ??
+          currentIssueDetail.recentRuns[0] ??
+          null,
+        selectedIssue: currentIssueDetail.issue,
+        tasks: currentIssueDetail.tasks
+      })
+    : null;
+  const visibleTasks = currentIssueDetail
+    ? resolveIssueManagerVisibleSubtasks({
+        hiddenIssueRunTaskId: issueRunTaskId,
+        tasks: currentIssueDetail.tasks
+      })
+    : [];
+  const subtaskProgressByIssueId: Record<
+    string,
+    IssueManagerSubtaskProgressViewState | null
+  > = currentIssueDetail
+    ? {
+        [currentIssueDetail.issue.issueId]:
+          resolveIssueManagerSubtaskProgressFromTasks(visibleTasks)
+      }
+    : {};
 
   return (
     <aside
@@ -95,6 +131,7 @@ export function IssueManagerSidebar({
             isNarrowLayout={isNarrowLayout}
             selectedIssueId={controller.nodeState.selectedIssueId}
             sidebarViewState={sidebarViewState}
+            subtaskProgressByIssueId={subtaskProgressByIssueId}
             onRetry={() => controller.refreshAll()}
             onSelectIssue={controller.selectIssue}
           />

--- a/packages/workspace/issue-manager/src/ui/internal/shell/IssueManagerSidebar.tsx
+++ b/packages/workspace/issue-manager/src/ui/internal/shell/IssueManagerSidebar.tsx
@@ -62,15 +62,18 @@ export function IssueManagerSidebar({
         tasks: currentIssueDetail.tasks
       })
     : [];
+  const visibleSubtaskProgress = currentIssueDetail
+    ? resolveIssueManagerSubtaskProgressFromTasks(visibleTasks)
+    : null;
   const subtaskProgressByIssueId: Record<
     string,
     IssueManagerSubtaskProgressViewState | null
-  > = currentIssueDetail
-    ? {
-        [currentIssueDetail.issue.issueId]:
-          resolveIssueManagerSubtaskProgressFromTasks(visibleTasks)
-      }
-    : {};
+  > =
+    currentIssueDetail && visibleSubtaskProgress
+      ? {
+          [currentIssueDetail.issue.issueId]: visibleSubtaskProgress
+        }
+      : {};
 
   return (
     <aside

--- a/packages/workspace/issue-manager/src/ui/internal/shell/IssueManagerSidebarSections.tsx
+++ b/packages/workspace/issue-manager/src/ui/internal/shell/IssueManagerSidebarSections.tsx
@@ -1,4 +1,4 @@
-import { type CSSProperties, type JSX } from "react";
+import { type JSX } from "react";
 import { useComposedInputValue } from "@tutti-os/ui-react-hooks";
 import {
   Badge,
@@ -342,30 +342,26 @@ function IssueManagerSidebarItem({
         </p>
       </div>
       {subtaskProgress ? (
-        <div className="mt-3 flex items-center">
+        <div
+          aria-label={`${copy.t("labels.taskCount", {
+            count: subtaskProgress.total
+          })}, ${subtaskProgress.completed}/${subtaskProgress.total}`}
+          className="mt-3 flex min-w-0 items-center gap-2 text-[11px] font-semibold leading-none text-[var(--text-secondary)]"
+        >
+          <span className="shrink-0">
+            {copy.t("labels.taskCount", { count: subtaskProgress.total })}
+          </span>
           <span
-            aria-label={`${copy.t("labels.taskCount", {
-              count: subtaskProgress.total
-            })}, ${subtaskProgress.completed}/${subtaskProgress.total}`}
-            className="inline-flex h-8 items-center gap-2 rounded-full border border-[var(--border-1)] bg-[var(--background-fronted)] px-2.5 text-[13px] font-semibold leading-none text-[var(--text-primary)]"
+            aria-hidden="true"
+            className="h-0.5 w-14 shrink-0 overflow-hidden rounded-full bg-[var(--transparency-block)]"
           >
             <span
-              aria-hidden="true"
-              className="relative h-5 w-5 shrink-0 rounded-full bg-[conic-gradient(var(--status-running)_var(--issue-manager-subtask-progress),var(--transparency-block)_0)]"
-              style={
-                {
-                  "--issue-manager-subtask-progress": `${Math.max(
-                    subtaskProgress.percent,
-                    1.5
-                  )}%`
-                } as CSSProperties
-              }
-            >
-              <span className="absolute inset-[3px] rounded-full bg-[var(--background-fronted)]" />
-            </span>
-            <span>
-              {subtaskProgress.completed}/{subtaskProgress.total}
-            </span>
+              className="block h-full rounded-full bg-[var(--status-running)]"
+              style={{ width: `${subtaskProgress.percent}%` }}
+            />
+          </span>
+          <span className="shrink-0 text-[var(--text-primary)]">
+            {subtaskProgress.completed}/{subtaskProgress.total}
           </span>
         </div>
       ) : null}

--- a/packages/workspace/issue-manager/src/ui/internal/shell/IssueManagerSidebarSections.tsx
+++ b/packages/workspace/issue-manager/src/ui/internal/shell/IssueManagerSidebarSections.tsx
@@ -1,4 +1,4 @@
-import { type JSX } from "react";
+import { type CSSProperties, type JSX } from "react";
 import { useComposedInputValue } from "@tutti-os/ui-react-hooks";
 import {
   Badge,
@@ -320,26 +320,31 @@ function IssueManagerSidebarItem({
         </p>
       </div>
       {subtaskProgress ? (
-        <div className="mt-3 space-y-1.5">
-          <div className="flex items-center justify-between gap-3 text-[11px] leading-[1.55] text-[var(--text-secondary)]">
-            <span>
-              {copy.t("labels.taskCount", { count: subtaskProgress.total })}
-            </span>
+        <div className="mt-3 flex items-center">
+          <span
+            aria-label={`${copy.t("labels.taskCount", {
+              count: subtaskProgress.total
+            })}, ${subtaskProgress.completed}/${subtaskProgress.total}`}
+            className="inline-flex h-8 items-center gap-2 rounded-full border border-[var(--border-1)] bg-[var(--background-fronted)] px-2.5 text-[13px] font-semibold leading-none text-[var(--text-primary)]"
+          >
             <span
-              aria-label={`${subtaskProgress.completed}/${subtaskProgress.total}`}
+              aria-hidden="true"
+              className="relative h-5 w-5 shrink-0 rounded-full bg-[conic-gradient(var(--status-running)_var(--issue-manager-subtask-progress),var(--transparency-block)_0)]"
+              style={
+                {
+                  "--issue-manager-subtask-progress": `${Math.max(
+                    subtaskProgress.percent,
+                    1.5
+                  )}%`
+                } as CSSProperties
+              }
             >
+              <span className="absolute inset-[3px] rounded-full bg-[var(--background-fronted)]" />
+            </span>
+            <span>
               {subtaskProgress.completed}/{subtaskProgress.total}
             </span>
-          </div>
-          <div
-            aria-hidden="true"
-            className="h-1 overflow-hidden rounded-full bg-[var(--transparency-block)]"
-          >
-            <div
-              className="h-full rounded-full bg-[var(--status-running)]"
-              style={{ width: `${subtaskProgress.percent}%` }}
-            />
-          </div>
+          </span>
         </div>
       ) : null}
     </button>

--- a/packages/workspace/issue-manager/src/ui/internal/shell/IssueManagerSidebarSections.tsx
+++ b/packages/workspace/issue-manager/src/ui/internal/shell/IssueManagerSidebarSections.tsx
@@ -22,6 +22,7 @@ import {
 import {
   issueManagerStatusFilters,
   resolveIssueManagerSubtaskProgress,
+  type IssueManagerSubtaskProgressViewState,
   type IssueManagerSidebarViewState
 } from "./IssueManagerShellState.ts";
 import { issueManagerStatusBadgeVariant } from "../status/IssueManagerStatusBadge.ts";
@@ -102,6 +103,7 @@ export function IssueManagerSidebarBody({
   isNarrowLayout,
   selectedIssueId,
   sidebarViewState,
+  subtaskProgressByIssueId,
   onRetry,
   onSelectIssue
 }: {
@@ -109,6 +111,10 @@ export function IssueManagerSidebarBody({
   isNarrowLayout: boolean;
   selectedIssueId: string | null;
   sidebarViewState: IssueManagerSidebarViewState;
+  subtaskProgressByIssueId: Record<
+    string,
+    IssueManagerSubtaskProgressViewState | null
+  >;
   onRetry: () => void;
   onSelectIssue: (issueId: string | null) => void;
 }): JSX.Element {
@@ -144,6 +150,7 @@ export function IssueManagerSidebarBody({
             isNarrowLayout={isNarrowLayout}
             issues={sidebarViewState.issues}
             selectedIssueId={selectedIssueId}
+            subtaskProgressByIssueId={subtaskProgressByIssueId}
             onSelectIssue={onSelectIssue}
           />
         )}
@@ -245,12 +252,17 @@ function IssueManagerSidebarIssueList({
   isNarrowLayout,
   issues,
   selectedIssueId,
+  subtaskProgressByIssueId,
   onSelectIssue
 }: {
   copy: IssueManagerI18nRuntime;
   isNarrowLayout: boolean;
   issues: readonly IssueManagerIssueSummary[];
   selectedIssueId: string | null;
+  subtaskProgressByIssueId: Record<
+    string,
+    IssueManagerSubtaskProgressViewState | null
+  >;
   onSelectIssue: (issueId: string | null) => void;
 }): JSX.Element {
   return (
@@ -269,6 +281,11 @@ function IssueManagerSidebarIssueList({
           issue={issue}
           key={issue.issueId}
           selected={selectedIssueId === issue.issueId}
+          subtaskProgress={
+            issue.issueId in subtaskProgressByIssueId
+              ? subtaskProgressByIssueId[issue.issueId]
+              : undefined
+          }
           onSelect={onSelectIssue}
         />
       ))}
@@ -281,15 +298,20 @@ function IssueManagerSidebarItem({
   isNarrowLayout,
   issue,
   onSelect,
-  selected
+  selected,
+  subtaskProgress: subtaskProgressOverride
 }: {
   copy: IssueManagerI18nRuntime;
   isNarrowLayout: boolean;
   issue: IssueManagerIssueSummary;
   onSelect: (issueId: string | null) => void;
   selected: boolean;
+  subtaskProgress?: IssueManagerSubtaskProgressViewState | null;
 }): JSX.Element {
-  const subtaskProgress = resolveIssueManagerSubtaskProgress(issue);
+  const subtaskProgress =
+    subtaskProgressOverride === undefined
+      ? resolveIssueManagerSubtaskProgress(issue)
+      : subtaskProgressOverride;
 
   return (
     <button

--- a/services/tuttid/service/workspace/issues.go
+++ b/services/tuttid/service/workspace/issues.go
@@ -113,7 +113,7 @@ func (s IssueManagerService) ListIssues(ctx context.Context, workspaceID string,
 	if err != nil {
 		return workspaceissues.IssueList{}, err
 	}
-	return service.ListIssues(ctx, workspaceissues.IssueListFilter{
+	list, err := service.ListIssues(ctx, workspaceissues.IssueListFilter{
 		WorkspaceID:  workspaceID,
 		TopicID:      input.TopicID,
 		PageSize:     input.PageSize,
@@ -122,6 +122,13 @@ func (s IssueManagerService) ListIssues(ctx context.Context, workspaceID string,
 		SearchQuery:  input.SearchQuery,
 		ReturnAll:    false,
 	})
+	if err != nil {
+		return workspaceissues.IssueList{}, err
+	}
+	if err := s.applyVisibleIssueSubtaskCounts(ctx, &list); err != nil {
+		return workspaceissues.IssueList{}, err
+	}
+	return list, nil
 }
 
 func (s IssueManagerService) ListTopics(ctx context.Context, workspaceID string) (workspaceissues.TopicList, error) {
@@ -178,7 +185,12 @@ func (s IssueManagerService) CreateIssue(ctx context.Context, workspaceID string
 
 func (s IssueManagerService) GetIssueDetail(ctx context.Context, workspaceID string, issueID string) (workspaceissues.IssueDetail, error) {
 	s.reconcileWorkspaceRunsBestEffort(ctx, workspaceID)
-	return s.domainService().GetIssueDetail(ctx, workspaceID, issueID)
+	detail, err := s.domainService().GetIssueDetail(ctx, workspaceID, issueID)
+	if err != nil {
+		return workspaceissues.IssueDetail{}, err
+	}
+	applyVisibleIssueSubtaskCount(&detail.Issue, detail.Tasks, detail.LatestRun)
+	return detail, nil
 }
 
 func (s IssueManagerService) UpdateIssue(ctx context.Context, workspaceID string, issueID string, input UpdateIssueManagerIssueInput) (workspaceissues.Issue, error) {
@@ -413,6 +425,105 @@ func (s IssueManagerService) CompleteRun(ctx context.Context, workspaceID string
 		ChangeKind:  eventstreamservice.WorkspaceIssueChangeRunCompleted,
 	})
 	return workspaceissues.RunDetail{Run: run, Outputs: outputs}, nil
+}
+
+func (s IssueManagerService) applyVisibleIssueSubtaskCounts(ctx context.Context, list *workspaceissues.IssueList) error {
+	if list == nil || len(list.Items) == 0 {
+		return nil
+	}
+
+	service := s.domainService()
+	for index := range list.Items {
+		issue := &list.Items[index]
+		tasks, err := service.ListTasks(ctx, workspaceissues.TaskListFilter{
+			WorkspaceID: issue.WorkspaceID,
+			IssueID:     issue.IssueID,
+			ReturnAll:   true,
+		})
+		if err != nil {
+			return err
+		}
+		runs, err := service.ListRuns(ctx, issue.WorkspaceID, issue.IssueID, "")
+		if err != nil {
+			return err
+		}
+		var latestRun *workspaceissues.Run
+		if len(runs) > 0 {
+			latestRun = &runs[0]
+		}
+		applyVisibleIssueSubtaskCount(issue, tasks.Items, latestRun)
+	}
+	return nil
+}
+
+func applyVisibleIssueSubtaskCount(issue *workspaceissues.Issue, tasks []workspaceissues.Task, latestRun *workspaceissues.Run) {
+	if issue == nil {
+		return
+	}
+	counts := countVisibleIssueSubtaskStatuses(*issue, tasks, latestRun)
+	issue.TaskCount = counts.All
+	issue.NotStartedCount = counts.NotStarted
+	issue.RunningCount = counts.Running
+	issue.PendingAcceptanceCount = counts.PendingAcceptance
+	issue.CompletedCount = counts.Completed
+	issue.FailedCount = counts.Failed
+	issue.CanceledCount = counts.Canceled
+}
+
+func countVisibleIssueSubtaskStatuses(issue workspaceissues.Issue, tasks []workspaceissues.Task, latestRun *workspaceissues.Run) workspaceissues.StatusCounts {
+	hiddenTaskID := hiddenIssueRunTaskID(issue, tasks, latestRun)
+	var counts workspaceissues.StatusCounts
+	for _, task := range tasks {
+		if task.TaskID == hiddenTaskID {
+			continue
+		}
+		incrementIssueManagerStatusCount(&counts, task.Status)
+	}
+	return counts
+}
+
+func hiddenIssueRunTaskID(issue workspaceissues.Issue, tasks []workspaceissues.Task, latestRun *workspaceissues.Run) string {
+	if latestRun == nil {
+		return ""
+	}
+	taskID := strings.TrimSpace(latestRun.TaskID)
+	if taskID == "" {
+		return ""
+	}
+	issueTitle := strings.TrimSpace(issue.Title)
+	for _, task := range tasks {
+		if task.TaskID != taskID {
+			continue
+		}
+		taskTitle := strings.TrimSpace(task.Title)
+		if taskTitle != "" && taskTitle != issueTitle {
+			return ""
+		}
+		return taskID
+	}
+	return ""
+}
+
+func incrementIssueManagerStatusCount(counts *workspaceissues.StatusCounts, status workspaceissues.Status) {
+	counts.All++
+	switch status {
+	case workspaceissues.StatusNotStarted:
+		counts.NotStarted++
+	case workspaceissues.StatusRunning:
+		counts.Running++
+	case workspaceissues.StatusPendingAcceptance:
+		counts.PendingAcceptance++
+	case workspaceissues.StatusCompleted:
+		counts.Completed++
+	case workspaceissues.StatusFailed:
+		counts.Failed++
+	case workspaceissues.StatusCanceled:
+		counts.Canceled++
+	case workspaceissues.StatusInProgress:
+		counts.InProgress++
+	default:
+		counts.NotStarted++
+	}
 }
 
 func (s IssueManagerService) RemoveIssueContextRef(ctx context.Context, workspaceID string, issueID string, contextRefID string) (bool, error) {

--- a/services/tuttid/service/workspace/issues.go
+++ b/services/tuttid/service/workspace/issues.go
@@ -465,7 +465,7 @@ func applyVisibleIssueSubtaskCount(issue *workspaceissues.Issue, tasks []workspa
 	issue.NotStartedCount = counts.NotStarted
 	issue.RunningCount = counts.Running
 	issue.PendingAcceptanceCount = counts.PendingAcceptance
-	issue.CompletedCount = counts.Completed
+	issue.CompletedCount = counts.Completed + counts.PendingAcceptance
 	issue.FailedCount = counts.Failed
 	issue.CanceledCount = counts.Canceled
 }

--- a/services/tuttid/service/workspace/issues_test.go
+++ b/services/tuttid/service/workspace/issues_test.go
@@ -219,6 +219,67 @@ func TestIssueManagerServiceReconcilesRunningRunsFromBatchAgentSessions(t *testi
 	}
 }
 
+func TestIssueManagerServiceHidesIssueRunTaskFromVisibleSubtaskCounts(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	store := openIssueServiceStore(t)
+	if err := store.Create(ctx, workspacebiz.Summary{
+		ID:   "workspace-1",
+		Name: "Workspace One",
+	}); err != nil {
+		t.Fatalf("Create() workspace error = %v", err)
+	}
+
+	service := IssueManagerService{Store: store}
+	if _, err := service.CreateIssue(ctx, "workspace-1", CreateIssueManagerIssueInput{
+		IssueID: "issue-1",
+		TopicID: workspaceissues.DefaultTopicID,
+		Title:   "Issue One",
+	}); err != nil {
+		t.Fatalf("CreateIssue() error = %v", err)
+	}
+	run, err := service.CreateRun(ctx, "workspace-1", "issue-1", "", CreateIssueManagerRunInput{
+		AgentProvider: "codex",
+		RunID:         "run-1",
+	})
+	if err != nil {
+		t.Fatalf("CreateRun() error = %v", err)
+	}
+	if _, err := service.CompleteRun(ctx, "workspace-1", "issue-1", run.TaskID, run.RunID, CompleteIssueManagerRunInput{
+		Status: string(workspaceissues.StatusCompleted),
+	}); err != nil {
+		t.Fatalf("CompleteRun() error = %v", err)
+	}
+
+	detail, err := service.GetIssueDetail(ctx, "workspace-1", "issue-1")
+	if err != nil {
+		t.Fatalf("GetIssueDetail() error = %v", err)
+	}
+	if detail.Issue.Status != workspaceissues.StatusPendingAcceptance {
+		t.Fatalf("detail issue status = %q, want %q", detail.Issue.Status, workspaceissues.StatusPendingAcceptance)
+	}
+	if detail.Issue.TaskCount != 0 || detail.Issue.CompletedCount != 0 {
+		t.Fatalf("detail issue visible subtask counts = %+v, want zero visible subtasks", detail.Issue)
+	}
+
+	list, err := service.ListIssues(ctx, "workspace-1", ListIssueManagerItemsInput{
+		TopicID: workspaceissues.DefaultTopicID,
+	})
+	if err != nil {
+		t.Fatalf("ListIssues() error = %v", err)
+	}
+	if len(list.Items) != 1 {
+		t.Fatalf("list items len = %d, want 1", len(list.Items))
+	}
+	if list.Items[0].Status != workspaceissues.StatusPendingAcceptance {
+		t.Fatalf("list issue status = %q, want %q", list.Items[0].Status, workspaceissues.StatusPendingAcceptance)
+	}
+	if list.Items[0].TaskCount != 0 || list.Items[0].CompletedCount != 0 {
+		t.Fatalf("list issue visible subtask counts = %+v, want zero visible subtasks", list.Items[0])
+	}
+}
+
 func TestIssueRunReconcileCompletionWaitsGraceBeforeFailedSessionCompletion(t *testing.T) {
 	now := time.Now().UnixMilli()
 	run := workspaceissues.Run{

--- a/services/tuttid/service/workspace/issues_test.go
+++ b/services/tuttid/service/workspace/issues_test.go
@@ -280,6 +280,67 @@ func TestIssueManagerServiceHidesIssueRunTaskFromVisibleSubtaskCounts(t *testing
 	}
 }
 
+func TestIssueManagerServiceCountsPendingAcceptanceSubtasksAsCompletedProgress(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	store := openIssueServiceStore(t)
+	if err := store.Create(ctx, workspacebiz.Summary{
+		ID:   "workspace-1",
+		Name: "Workspace One",
+	}); err != nil {
+		t.Fatalf("Create() workspace error = %v", err)
+	}
+
+	service := IssueManagerService{Store: store}
+	if _, err := service.CreateIssue(ctx, "workspace-1", CreateIssueManagerIssueInput{
+		IssueID: "issue-1",
+		TopicID: workspaceissues.DefaultTopicID,
+		Title:   "Issue One",
+	}); err != nil {
+		t.Fatalf("CreateIssue() error = %v", err)
+	}
+	if _, err := service.CreateTask(ctx, "workspace-1", "issue-1", CreateIssueManagerTaskInput{
+		TaskID: "task-1",
+		Title:  "Task One",
+	}); err != nil {
+		t.Fatalf("CreateTask() error = %v", err)
+	}
+	run, err := service.CreateRun(ctx, "workspace-1", "issue-1", "task-1", CreateIssueManagerRunInput{
+		AgentProvider: "codex",
+		RunID:         "run-1",
+	})
+	if err != nil {
+		t.Fatalf("CreateRun() error = %v", err)
+	}
+	if _, err := service.CompleteRun(ctx, "workspace-1", "issue-1", run.TaskID, run.RunID, CompleteIssueManagerRunInput{
+		Status: string(workspaceissues.StatusCompleted),
+	}); err != nil {
+		t.Fatalf("CompleteRun() error = %v", err)
+	}
+
+	detail, err := service.GetIssueDetail(ctx, "workspace-1", "issue-1")
+	if err != nil {
+		t.Fatalf("GetIssueDetail() error = %v", err)
+	}
+	if detail.Issue.TaskCount != 1 || detail.Issue.PendingAcceptanceCount != 1 || detail.Issue.CompletedCount != 1 {
+		t.Fatalf("detail issue visible subtask counts = %+v, want pending acceptance counted as completed progress", detail.Issue)
+	}
+
+	list, err := service.ListIssues(ctx, "workspace-1", ListIssueManagerItemsInput{
+		TopicID: workspaceissues.DefaultTopicID,
+	})
+	if err != nil {
+		t.Fatalf("ListIssues() error = %v", err)
+	}
+	if len(list.Items) != 1 {
+		t.Fatalf("list items len = %d, want 1", len(list.Items))
+	}
+	if list.Items[0].TaskCount != 1 || list.Items[0].PendingAcceptanceCount != 1 || list.Items[0].CompletedCount != 1 {
+		t.Fatalf("list issue visible subtask counts = %+v, want pending acceptance counted as completed progress", list.Items[0])
+	}
+}
+
 func TestIssueRunReconcileCompletionWaitsGraceBeforeFailedSessionCompletion(t *testing.T) {
 	now := time.Now().UnixMilli()
 	run := workspaceissues.Run{


### PR DESCRIPTION
## Summary
- Change the English not-started task status label from `To do` to `Todo` so the status tab reads as one compact label.
- Update the related task acceptance hint copy and i18n test expectation.
- Show task card subtask progress as a lightweight inline row: task count, short progress bar, and `completed/total` ratio.
- Align sidebar subtask progress with the detail body filtering logic by using the visible-subtasks list for the currently loaded issue detail when available.
- Use the detail-derived visible subtask result for the selected sidebar item even when it is empty, so filtered-out execution tasks do not appear as `1 subtasks 0/1` in the left list.
- Normalize service-layer list/detail responses so issue-level execution tasks are excluded from returned subtask count fields while issue status still reflects the execution state.
- Count review-ready subtasks (`pending_acceptance` / In review) as completed progress for subtask progress bars while preserving their status bucket.
- Include legacy `in_progress` tasks in the `Running` filter results so the tab count and list contents stay consistent.

## Test Plan
- pnpm --filter @tutti-os/workspace-issue-manager exec tsx --test src/ui/internal/shell/IssueManagerShellState.test.ts
- pnpm --filter @tutti-os/workspace-issue-manager exec tsx --test src/ui/internal/shell/IssueManagerShellState.test.ts src/ui/internal/issue/IssueManagerIssueAcceptanceState.test.ts src/services/internal/controllerRuntime.test.ts
- pnpm --filter @tutti-os/workspace-issue-manager typecheck
- go test ./services/tuttid/service/workspace
- pnpm lint:go
- git diff --check
