### PR TITLE
fix(agent-gui): keep new chat on composer home

### DIFF
--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUINodeController.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUINodeController.ts
@@ -3253,8 +3253,9 @@ export function useAgentGUINodeController({
     }
     if (
       !hasExplicitOpenSessionRequest &&
-      suppressedHomeConversationIdRef.current ===
-        effectiveRequestedConversationId
+      (isComposerHomeRef.current ||
+        suppressedHomeConversationIdRef.current ===
+          effectiveRequestedConversationId)
     ) {
       return;
     }


### PR DESCRIPTION
## Summary

- Clicking "new chat" sometimes navigated to a previously visited conversation instead of the blank new-session page.
- Root cause (confirmed with runtime logging): the conversation-restore effect in `useAgentGUINodeController` only suppressed auto-restore when the single tracked id `suppressedHomeConversationIdRef` equaled `data.lastActiveAgentSessionId`. The persisted `lastActiveAgentSessionId` lags behind the in-memory active conversation, so the two diverge (`mismatch:true` in every repro), the suppression check fails, and the effect restores the stale persisted conversation.
- Fix: respect the explicit composer-home intent. When there is no explicit `openSessionRequest` and `isComposerHomeRef.current` is set, suppress automatic restoration regardless of the tracked id. `isComposerHomeRef` is updated synchronously and is unaffected by the persisted-value lag.

The change is a single guard in the restore effect:

```ts
if (
  !hasExplicitOpenSessionRequest &&
  (isComposerHomeRef.current ||
    suppressedHomeConversationIdRef.current ===
      effectiveRequestedConversationId)
) {
  return;
}
```

## Test plan

- [x] `pnpm typecheck`
- [x] `pnpm lint:ts`
- [ ] Open the Agent session UI, visit several past conversations, then repeatedly click "new chat" (especially right after switching) and confirm it always stays on the blank new-session page.
- [ ] Confirm normal restore-on-mount and explicit open-session deep links still work.

Made with [Cursor](https://cursor.com)