### PR TITLE
feat: upgrade /compact UX — spinner/icon system notices instead of raw text

### DIFF
--- a/packages/agent/daemon/runtime/codex_adapter.go
+++ b/packages/agent/daemon/runtime/codex_adapter.go
@@ -1887,6 +1887,16 @@ func acpSystemNoticeFromAgentText(text string) (map[string]any, bool) {
 			"source":     "agent_message_chunk",
 		}, true
 	}
+	// ponytail: strings owned by @agentclientprotocol/claude-agent-acp binary
+	if strings.HasPrefix(normalized, "compacting...") {
+		return map[string]any{"kind": "agent_system_notice", "noticeKind": "context_compaction_in_progress", "title": "Compacting context…"}, true
+	}
+	if strings.Contains(normalized, "compacting completed") {
+		return map[string]any{"kind": "agent_system_notice", "noticeKind": "context_compaction_completed", "title": "Context compacted"}, true
+	}
+	if strings.HasPrefix(normalized, "compacting failed") {
+		return map[string]any{"kind": "agent_system_notice", "noticeKind": "context_compaction_failed", "title": "Compacting failed"}, true
+	}
 	return nil, false
 }
 

--- a/packages/agent/daemon/runtime/codex_appserver_adapter.go
+++ b/packages/agent/daemon/runtime/codex_appserver_adapter.go
@@ -883,6 +883,7 @@ func (a *CodexAppServerAdapter) execSlashCommand(
 	command, args := splitSlashCommand(displayPrompt)
 	switch command {
 	case appServerSlashCompact:
+		emitEvents([]activityshared.Event{appServerSystemNoticeEvent(session, turnID, "context_compaction_in_progress", "Compacting context…", "")})
 		_, err := appSession.client.Call(ctx, appServerMethodThreadCompact, map[string]any{
 			"threadId": appSession.threadID,
 		}, a.appServerMessageHandler(appSession, session, turnID, normalizer, emitEvents, emitCommands))
@@ -892,7 +893,6 @@ func (a *CodexAppServerAdapter) execSlashCommand(
 		}
 		emitTerminal(append(
 			normalizer.FinishCompleted(session, turnID),
-			appServerSystemNoticeEvent(session, turnID, "system_notice", "Context compaction started.", ""),
 			newTurnActivityEvent(session, EventTurnCompleted, turnID, SessionStatusReady, "", "", map[string]any{
 				"stopReason": "end_turn",
 			}),

--- a/packages/agent/daemon/runtime/codex_appserver_events.go
+++ b/packages/agent/daemon/runtime/codex_appserver_events.go
@@ -143,7 +143,7 @@ func (a *CodexAppServerAdapter) appServerNotificationEvents(
 			asString(params["fromModel"]), asString(params["toModel"]))
 		return []activityshared.Event{appServerSystemNoticeEvent(session, turnID, "system_notice", title, asString(params["reason"]))}
 	case appServerNotifyThreadCompacted:
-		return []activityshared.Event{appServerSystemNoticeEvent(session, turnID, "system_notice", "Context compacted.", "")}
+		return []activityshared.Event{appServerSystemNoticeEvent(session, turnID, "context_compaction_completed", "Context compacted.", "")}
 	case appServerNotifyThreadGoalUpdated:
 		a.applyGoalUpdate(session.AgentSessionID, payloadObject(params["goal"]))
 		return nil
@@ -164,11 +164,12 @@ func (a *CodexAppServerAdapter) appServerNotificationEvents(
 // exitedReviewMode and contextCompaction ride the authoritative item/completed.
 var appServerNoticeItems = map[string]struct {
 	message         string
+	noticeKind      string
 	emitOnCompleted bool
 }{
 	"enteredReviewMode": {message: "Code review started.", emitOnCompleted: false},
 	"exitedReviewMode":  {message: "Code review finished.", emitOnCompleted: true},
-	"contextCompaction": {message: "Context compacted.", emitOnCompleted: true},
+	"contextCompaction": {message: "Context compacted.", noticeKind: "context_compaction_completed", emitOnCompleted: true},
 }
 
 func (a *CodexAppServerAdapter) appServerItemEvents(
@@ -188,7 +189,7 @@ func (a *CodexAppServerAdapter) appServerItemEvents(
 		if notice.emitOnCompleted != completed {
 			return nil
 		}
-		return []activityshared.Event{appServerSystemNoticeEvent(session, turnID, "system_notice", notice.message, "")}
+		return []activityshared.Event{appServerSystemNoticeEvent(session, turnID, firstNonEmpty(notice.noticeKind, "system_notice"), notice.message, "")}
 	}
 	switch itemType {
 	case "agentMessage":

--- a/packages/agent/daemon/runtime/standard_acp_adapter.go
+++ b/packages/agent/daemon/runtime/standard_acp_adapter.go
@@ -2246,7 +2246,7 @@ func standardACPUpdateEvents(config standardACPConfig, session Session, turnID s
 	case "user_message_chunk":
 		return nil
 	case "agent_message_chunk":
-		if events, ok := acpSystemNoticeEvents(session, turnID, params.Update, normalizer, "agent_message_chunk", config.provider == ProviderCodex); ok {
+		if events, ok := acpSystemNoticeEvents(session, turnID, params.Update, normalizer, "agent_message_chunk", config.provider == ProviderCodex || config.provider == ProviderClaudeCode); ok {
 			return events
 		}
 		content := acpTextContent(params.Update["content"])

--- a/packages/agent/gui/shared/agentConversation/components/AgentMessageBlock.tsx
+++ b/packages/agent/gui/shared/agentConversation/components/AgentMessageBlock.tsx
@@ -7,7 +7,7 @@ import {
   type JSX,
   type ReactNode
 } from "react";
-import { AlertTriangle, ChevronRight, Info } from "lucide-react";
+import { AlertTriangle, CheckCircle2, ChevronRight, Info, Loader2 } from "lucide-react";
 import { CheckIcon, CopyIcon } from "@tutti-os/ui-system/icons";
 import { Button } from "../../../app/renderer/components/ui/button";
 import { AgentPlanCard } from "./AgentPlanCard";
@@ -391,9 +391,23 @@ function AgentSystemNoticeMessage({
   "use memo";
   const notice = message.systemNotice;
   const detail = notice?.detail?.trim() ?? "";
+  const noticeKind = notice?.noticeKind ?? "";
   const isWarning =
     notice?.severity === "warning" || notice?.severity === "error";
-  const Icon = isWarning ? AlertTriangle : Info;
+  const Icon =
+    noticeKind === "context_compaction_in_progress"
+      ? Loader2
+      : noticeKind === "context_compaction_completed"
+        ? CheckCircle2
+        : isWarning
+          ? AlertTriangle
+          : Info;
+  const iconClass =
+    noticeKind === "context_compaction_in_progress"
+      ? "mt-0.5 shrink-0 animate-spin text-[var(--text-secondary)]"
+      : noticeKind === "context_compaction_completed"
+        ? "mt-0.5 shrink-0 text-[var(--state-success)]"
+        : "mt-0.5 shrink-0 text-[var(--state-warning)]";
   return (
     <section
       role={isWarning ? "status" : undefined}
@@ -404,7 +418,7 @@ function AgentSystemNoticeMessage({
           size={15}
           strokeWidth={2.1}
           aria-hidden="true"
-          className="mt-0.5 shrink-0 text-[var(--state-warning)]"
+          className={iconClass}
         />
         <div className="min-w-0 flex-1">
           <div className="font-medium text-[var(--text-primary)]">
@@ -465,6 +479,12 @@ function systemNoticeTitle(message: AgentMessageContentVM): string {
       return (
         notice.title || translate("agentHost.agentGui.systemNoticeWarning")
       );
+    case "context_compaction_in_progress":
+      return "Compacting context…";
+    case "context_compaction_completed":
+      return "Context compacted";
+    case "context_compaction_failed":
+      return notice?.title || "Compacting failed";
     default:
       return (
         notice?.title ||

--- a/packages/agent/gui/shared/agentConversation/projection/agentProcessingProjection.ts
+++ b/packages/agent/gui/shared/agentConversation/projection/agentProcessingProjection.ts
@@ -16,10 +16,13 @@ export function projectAgentProcessingRow(
   if (hasSpecificProgressRow(rows)) {
     return null;
   }
+  // ponytail: detect compact turn to suppress generic "processing" label
+  const lastPrompt = detail.turns.at(-1)?.userMessage?.body?.trim().toLowerCase() ?? "";
   return {
     kind: "processing",
     id: "processing",
     turnId: detail.turns.at(-1)?.id ?? null,
+    label: lastPrompt === "/compact" ? "Compacting context…" : null,
     occurredAtUnixMs:
       detail.session.updatedAtUnixMs ?? detail.session.createdAtUnixMs ?? null
   };


### PR DESCRIPTION
## Summary

- **Claude Code**: converts `agent_message_chunk` text from the `claude-agent-acp` binary (`Compacting...` / `Compacting completed.` / `Compacting failed`) into typed `agent_system_notice` events with `context_compaction_in_progress/completed/failed` noticeKind, instead of rendering as plain chat text. Gate also enabled for `ProviderClaudeCode` alongside existing `ProviderCodex`.
- **Codex app-server**: emits `context_compaction_in_progress` notice *before* the blocking `thread/compact/start` RPC; upgrades `thread/compacted` notification and `contextCompaction` item to `context_compaction_completed` noticeKind; removes the wrong-ordered "Context compaction started." text that fired after completion.
- **Processing indicator**: `/compact` turns display `"Compacting context…"` instead of the generic `"正在規劃下一步"` label.
- **AgentMessageBlock**: renders a spinning `Loader2` icon for in-progress, green `CheckCircle2` for completed, and `AlertTriangle` for failed — instead of the generic `Info` icon.

## Test plan

- [ ] Claude Code `/compact`: no "正在規劃下一步" during compaction; no raw "Compacting..." text in chat; system notice shows spinner → green checkmark on completion
- [ ] Codex `/compact`: same — in-progress notice fires before the blocking RPC, completed notice fires after
- [ ] Compaction failure (Claude Code): system notice shows warning icon + "Compacting failed"
- [ ] Normal turns: "正在規劃下一步" processing indicator still appears as before
- [ ] Go tests pass: `go test ./packages/agent/daemon/runtime/...`

🤖 Generated with [Claude Code](https://claude.ai/claude-code)