### PR TITLE
Add Tutti agent skills sync workflows

### DIFF
--- a/.github/workflows/sync-tutti-agent-skills.yml
+++ b/.github/workflows/sync-tutti-agent-skills.yml
@@ -1,0 +1,268 @@
+name: Sync Tutti Agent Skills
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - "services/tuttid/service/workspace/app_factory_reference/**"
+  workflow_dispatch:
+    inputs:
+      source_ref:
+        description: "Source ref to mirror, usually main or a commit SHA."
+        required: false
+        default: main
+
+permissions:
+  contents: read
+  issues: write
+  pull-requests: write
+
+concurrency:
+  group: sync-tutti-agent-skills
+  cancel-in-progress: false
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+
+    env:
+      SKILLS_REPO: tutti-os/tutti-agent-skills
+      SYNC_BRANCH: sync/workspace-app-factory-skill
+
+    steps:
+      - name: Checkout Tutti main repository
+        uses: actions/checkout@v4
+        with:
+          path: source-repository
+          ref: ${{ github.event.inputs.source_ref || github.sha }}
+
+      - name: Checkout skills repository
+        uses: actions/checkout@v4
+        with:
+          repository: ${{ env.SKILLS_REPO }}
+          token: ${{ secrets.TUTTI_AGENT_SKILLS_SYNC_TOKEN }}
+          path: tutti-agent-skills
+
+      - name: Sync built-in skill
+        run: |
+          rsync -a --delete \
+            source-repository/services/tuttid/service/workspace/app_factory_reference/ \
+            tutti-agent-skills/skills/tutti-workspace-app-factory/
+          rsync -a --delete \
+            source-repository/services/tuttid/service/workspace/app_factory_reference/ \
+            tutti-agent-skills/plugins/tutti/skills/tutti-workspace-app-factory/
+
+      - name: Detect mirrored changes
+        id: changes
+        working-directory: tutti-agent-skills
+        run: |
+          if git diff --quiet -- skills/tutti-workspace-app-factory plugins/tutti/skills/tutti-workspace-app-factory; then
+            echo "has_changes=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "has_changes=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Bump plugin cachebuster
+        if: steps.changes.outputs.has_changes == 'true'
+        working-directory: tutti-agent-skills
+        run: |
+          python3 - <<'PY'
+          import json
+          import os
+          import pathlib
+
+          sha = os.environ["GITHUB_SHA"][:12]
+          for manifest_path in [
+              pathlib.Path(".codex-plugin/plugin.json"),
+              pathlib.Path("plugins/tutti/.codex-plugin/plugin.json"),
+          ]:
+              manifest = json.loads(manifest_path.read_text())
+              version = str(manifest.get("version", "0.1.0"))
+              base = version.split("+", 1)[0]
+              manifest["version"] = f"{base}+codex.source-{sha}"
+              manifest_path.write_text(json.dumps(manifest, indent=2) + "\n")
+          PY
+
+      - name: Validate allowed changed paths
+        if: steps.changes.outputs.has_changes == 'true'
+        working-directory: tutti-agent-skills
+        run: |
+          git diff --name-only > /tmp/tutti-agent-skills-changed-files.txt
+          while IFS= read -r path; do
+            case "$path" in
+              skills/tutti-workspace-app-factory/*|skills/tutti-workspace-app-factory/**|plugins/tutti/skills/tutti-workspace-app-factory/*|plugins/tutti/skills/tutti-workspace-app-factory/**|.codex-plugin/plugin.json|plugins/tutti/.codex-plugin/plugin.json)
+                ;;
+              *)
+                echo "Unexpected changed path: $path" >&2
+                exit 1
+                ;;
+            esac
+          done < /tmp/tutti-agent-skills-changed-files.txt
+
+      - name: Validate skill discovery
+        if: steps.changes.outputs.has_changes == 'true'
+        working-directory: tutti-agent-skills
+        run: |
+          npx --yes skills add . --list
+          npx --yes skills add ./skills/tutti-workspace-app-factory --list
+
+      - name: Validate marketplace layout
+        if: steps.changes.outputs.has_changes == 'true'
+        working-directory: tutti-agent-skills
+        run: |
+          python3 - <<'PY'
+          import json
+          import pathlib
+          import sys
+
+          marketplace = json.loads(pathlib.Path(".agents/plugins/marketplace.json").read_text())
+          plugins = marketplace.get("plugins")
+          if not isinstance(plugins, list) or not plugins:
+              sys.exit("marketplace must contain at least one plugin")
+          entry = plugins[0]
+          if entry.get("name") != "tutti":
+              sys.exit("marketplace plugin name must be tutti")
+          if entry.get("source", {}).get("path") != "./plugins/tutti":
+              sys.exit("marketplace plugin source path must be ./plugins/tutti")
+          for root in (pathlib.Path("."), pathlib.Path("plugins/tutti")):
+              manifest = json.loads((root / ".codex-plugin/plugin.json").read_text())
+              if manifest.get("name") != "tutti":
+                  sys.exit(f"{root} plugin name must be tutti")
+              if manifest.get("skills") != "./skills/":
+                  sys.exit(f"{root} skills path must be ./skills/")
+              if manifest.get("interface", {}).get("websiteURL") != "https://tutti.sh/":
+                  sys.exit(f"{root} websiteURL must be https://tutti.sh/")
+              if not (root / "skills/tutti-workspace-app-factory/SKILL.md").exists():
+                  sys.exit(f"{root} is missing the workspace app factory skill")
+          PY
+
+      - name: Validate skill frontmatter
+        if: steps.changes.outputs.has_changes == 'true'
+        working-directory: tutti-agent-skills
+        run: |
+          python3 - <<'PY'
+          import pathlib
+          import re
+          import sys
+
+          skill = pathlib.Path("skills/tutti-workspace-app-factory/SKILL.md")
+          text = skill.read_text()
+          if not text.startswith("---\n"):
+              sys.exit("SKILL.md must start with YAML frontmatter")
+          end = text.find("\n---\n", 4)
+          if end < 0:
+              sys.exit("SKILL.md must close YAML frontmatter")
+          frontmatter = text[4:end]
+          if not re.search(r"^name:\s*tutti-workspace-app-factory\s*$", frontmatter, re.M):
+              sys.exit("SKILL.md missing expected name")
+          if not re.search(r"^description:\s*.+", frontmatter, re.M):
+              sys.exit("SKILL.md missing description")
+          allowed = {"name", "description"}
+          keys = {
+              line.split(":", 1)[0].strip()
+              for line in frontmatter.splitlines()
+              if ":" in line and not line.startswith(" ")
+          }
+          extra = keys - allowed
+          if extra:
+              sys.exit(f"SKILL.md frontmatter has unsupported keys: {sorted(extra)}")
+          PY
+
+      - name: Commit and push sync branch
+        if: steps.changes.outputs.has_changes == 'true'
+        working-directory: tutti-agent-skills
+        env:
+          TOKEN: ${{ secrets.TUTTI_AGENT_SKILLS_SYNC_TOKEN }}
+        run: |
+          git config user.name "tutti-agent-skills-sync"
+          git config user.email "tutti-agent-skills-sync@users.noreply.github.com"
+          git checkout -B "$SYNC_BRANCH"
+          git add skills/tutti-workspace-app-factory plugins/tutti/skills/tutti-workspace-app-factory .codex-plugin/plugin.json plugins/tutti/.codex-plugin/plugin.json
+          git commit -m "Sync workspace app factory skill from Tutti main repository"
+          git push "https://x-access-token:${TOKEN}@github.com/${SKILLS_REPO}.git" "$SYNC_BRANCH" --force
+
+      - name: Open or update sync pull request
+        if: steps.changes.outputs.has_changes == 'true'
+        id: sync_pr
+        working-directory: tutti-agent-skills
+        env:
+          GH_TOKEN: ${{ secrets.TUTTI_AGENT_SKILLS_SYNC_TOKEN }}
+        run: |
+          pr_number="$(gh pr list \
+            --repo "$SKILLS_REPO" \
+            --head "$SYNC_BRANCH" \
+            --json number \
+            --jq '.[0].number // ""')"
+          if [ -z "$pr_number" ]; then
+            pr_url="$(gh pr create \
+              --repo "$SKILLS_REPO" \
+              --base main \
+              --head "$SYNC_BRANCH" \
+              --title "Sync workspace app factory skill" \
+              --body "Mirrors Tutti main repository services/tuttid/service/workspace/app_factory_reference.\n\nSource commit: ${GITHUB_SHA}")"
+            pr_number="${pr_url##*/}"
+          else
+            gh pr edit "$pr_number" \
+              --repo "$SKILLS_REPO" \
+              --title "Sync workspace app factory skill" \
+              --body "Mirrors Tutti main repository services/tuttid/service/workspace/app_factory_reference.\n\nSource commit: ${GITHUB_SHA}"
+            pr_url="https://github.com/${SKILLS_REPO}/pull/${pr_number}"
+          fi
+          echo "number=$pr_number" >> "$GITHUB_OUTPUT"
+          echo "url=https://github.com/${SKILLS_REPO}/pull/${pr_number}" >> "$GITHUB_OUTPUT"
+
+      - name: Enable auto-merge
+        if: steps.changes.outputs.has_changes == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.TUTTI_AGENT_SKILLS_SYNC_TOKEN }}
+        run: |
+          gh pr merge \
+            "${{ steps.sync_pr.outputs.number }}" \
+            --repo "$SKILLS_REPO" \
+            --squash \
+            --auto
+
+      - name: Find source pull request
+        if: always()
+        id: source_pr
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          pr_number="$(gh api \
+            -H "Accept: application/vnd.github+json" \
+            "repos/${GITHUB_REPOSITORY}/commits/${GITHUB_SHA}/pulls" \
+            --jq '.[0].number // ""')"
+          echo "number=$pr_number" >> "$GITHUB_OUTPUT"
+
+      - name: Comment sync result on source pull request
+        if: always() && steps.source_pr.outputs.number != ''
+        uses: actions/github-script@v8
+        with:
+          script: |
+            const prNumber = Number("${{ steps.source_pr.outputs.number }}");
+            const hasChanges = "${{ steps.changes.outputs.has_changes }}" === "true";
+            const syncUrl = "${{ steps.sync_pr.outputs.url }}";
+            const status = "${{ job.status }}";
+            const body = hasChanges
+              ? `Tutti skills sync ${status}.\n\nExternal repository:\n  tutti-os/tutti-agent-skills\n\nSync PR:\n  ${syncUrl}\n\nAuto-merge:\n  enabled after required checks pass\n\nSource commit:\n  ${context.sha}`
+              : `Tutti skills sync skipped.\n\nNo mirrored skill changes were detected for source commit ${context.sha}.`;
+
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: prNumber,
+              body,
+            });
+
+      - name: Summarize sync
+        if: always()
+        run: |
+          {
+            echo "## Tutti Skills Sync"
+            echo
+            echo "- Source commit: \`${GITHUB_SHA}\`"
+            echo "- Mirrored changes: \`${{ steps.changes.outputs.has_changes || 'unknown' }}\`"
+            echo "- Sync PR: ${{ steps.sync_pr.outputs.url || 'not created' }}"
+            echo "- Job status: \`${{ job.status }}\`"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/sync-tutti-agent-skills.yml
+++ b/.github/workflows/sync-tutti-agent-skills.yml
@@ -6,6 +6,7 @@ on:
       - main
     paths:
       - "services/tuttid/service/workspace/app_factory_reference/**"
+      - "services/tuttid/service/workspace/agent_workspace_app_reference/**"
   workflow_dispatch:
     inputs:
       source_ref:
@@ -44,7 +45,7 @@ jobs:
           token: ${{ secrets.TUTTI_AGENT_SKILLS_SYNC_TOKEN }}
           path: tutti-agent-skills
 
-      - name: Sync built-in skill
+      - name: Sync built-in skills
         run: |
           rsync -a --delete \
             source-repository/services/tuttid/service/workspace/app_factory_reference/ \
@@ -52,12 +53,22 @@ jobs:
           rsync -a --delete \
             source-repository/services/tuttid/service/workspace/app_factory_reference/ \
             tutti-agent-skills/plugins/tutti/skills/tutti-workspace-app-factory/
+          rsync -a --delete \
+            source-repository/services/tuttid/service/workspace/agent_workspace_app_reference/ \
+            tutti-agent-skills/skills/tutti-agent-workspace-app/
+          rsync -a --delete \
+            source-repository/services/tuttid/service/workspace/agent_workspace_app_reference/ \
+            tutti-agent-skills/plugins/tutti/skills/tutti-agent-workspace-app/
 
       - name: Detect mirrored changes
         id: changes
         working-directory: tutti-agent-skills
         run: |
-          if git diff --quiet -- skills/tutti-workspace-app-factory plugins/tutti/skills/tutti-workspace-app-factory; then
+          if git diff --quiet -- \
+            skills/tutti-workspace-app-factory \
+            skills/tutti-agent-workspace-app \
+            plugins/tutti/skills/tutti-workspace-app-factory \
+            plugins/tutti/skills/tutti-agent-workspace-app; then
             echo "has_changes=false" >> "$GITHUB_OUTPUT"
           else
             echo "has_changes=true" >> "$GITHUB_OUTPUT"
@@ -91,7 +102,7 @@ jobs:
           git diff --name-only > /tmp/tutti-agent-skills-changed-files.txt
           while IFS= read -r path; do
             case "$path" in
-              skills/tutti-workspace-app-factory/*|skills/tutti-workspace-app-factory/**|plugins/tutti/skills/tutti-workspace-app-factory/*|plugins/tutti/skills/tutti-workspace-app-factory/**|.codex-plugin/plugin.json|plugins/tutti/.codex-plugin/plugin.json)
+              skills/tutti-workspace-app-factory/*|skills/tutti-workspace-app-factory/**|skills/tutti-agent-workspace-app/*|skills/tutti-agent-workspace-app/**|plugins/tutti/skills/tutti-workspace-app-factory/*|plugins/tutti/skills/tutti-workspace-app-factory/**|plugins/tutti/skills/tutti-agent-workspace-app/*|plugins/tutti/skills/tutti-agent-workspace-app/**|.codex-plugin/plugin.json|plugins/tutti/.codex-plugin/plugin.json)
                 ;;
               *)
                 echo "Unexpected changed path: $path" >&2
@@ -106,6 +117,7 @@ jobs:
         run: |
           npx --yes skills add . --list
           npx --yes skills add ./skills/tutti-workspace-app-factory --list
+          npx --yes skills add ./skills/tutti-agent-workspace-app --list
 
       - name: Validate marketplace layout
         if: steps.changes.outputs.has_changes == 'true'
@@ -133,8 +145,9 @@ jobs:
                   sys.exit(f"{root} skills path must be ./skills/")
               if manifest.get("interface", {}).get("websiteURL") != "https://tutti.sh/":
                   sys.exit(f"{root} websiteURL must be https://tutti.sh/")
-              if not (root / "skills/tutti-workspace-app-factory/SKILL.md").exists():
-                  sys.exit(f"{root} is missing the workspace app factory skill")
+              for skill_name in ["tutti-workspace-app-factory", "tutti-agent-workspace-app"]:
+                  if not (root / f"skills/{skill_name}/SKILL.md").exists():
+                      sys.exit(f"{root} is missing {skill_name}")
           PY
 
       - name: Validate skill frontmatter
@@ -146,27 +159,28 @@ jobs:
           import re
           import sys
 
-          skill = pathlib.Path("skills/tutti-workspace-app-factory/SKILL.md")
-          text = skill.read_text()
-          if not text.startswith("---\n"):
-              sys.exit("SKILL.md must start with YAML frontmatter")
-          end = text.find("\n---\n", 4)
-          if end < 0:
-              sys.exit("SKILL.md must close YAML frontmatter")
-          frontmatter = text[4:end]
-          if not re.search(r"^name:\s*tutti-workspace-app-factory\s*$", frontmatter, re.M):
-              sys.exit("SKILL.md missing expected name")
-          if not re.search(r"^description:\s*.+", frontmatter, re.M):
-              sys.exit("SKILL.md missing description")
-          allowed = {"name", "description"}
-          keys = {
-              line.split(":", 1)[0].strip()
-              for line in frontmatter.splitlines()
-              if ":" in line and not line.startswith(" ")
-          }
-          extra = keys - allowed
-          if extra:
-              sys.exit(f"SKILL.md frontmatter has unsupported keys: {sorted(extra)}")
+          for expected_name in ["tutti-workspace-app-factory", "tutti-agent-workspace-app"]:
+              skill = pathlib.Path(f"skills/{expected_name}/SKILL.md")
+              text = skill.read_text()
+              if not text.startswith("---\n"):
+                  sys.exit(f"{skill} must start with YAML frontmatter")
+              end = text.find("\n---\n", 4)
+              if end < 0:
+                  sys.exit(f"{skill} must close YAML frontmatter")
+              frontmatter = text[4:end]
+              if not re.search(rf"^name:\s*{re.escape(expected_name)}\s*$", frontmatter, re.M):
+                  sys.exit(f"{skill} missing expected name")
+              if not re.search(r"^description:\s*.+", frontmatter, re.M):
+                  sys.exit(f"{skill} missing description")
+              allowed = {"name", "description"}
+              keys = {
+                  line.split(":", 1)[0].strip()
+                  for line in frontmatter.splitlines()
+                  if ":" in line and not line.startswith(" ")
+              }
+              extra = keys - allowed
+              if extra:
+                  sys.exit(f"{skill} frontmatter has unsupported keys: {sorted(extra)}")
           PY
 
       - name: Commit and push sync branch
@@ -178,8 +192,14 @@ jobs:
           git config user.name "tutti-agent-skills-sync"
           git config user.email "tutti-agent-skills-sync@users.noreply.github.com"
           git checkout -B "$SYNC_BRANCH"
-          git add skills/tutti-workspace-app-factory plugins/tutti/skills/tutti-workspace-app-factory .codex-plugin/plugin.json plugins/tutti/.codex-plugin/plugin.json
-          git commit -m "Sync workspace app factory skill from Tutti main repository"
+          git add \
+            skills/tutti-workspace-app-factory \
+            skills/tutti-agent-workspace-app \
+            plugins/tutti/skills/tutti-workspace-app-factory \
+            plugins/tutti/skills/tutti-agent-workspace-app \
+            .codex-plugin/plugin.json \
+            plugins/tutti/.codex-plugin/plugin.json
+          git commit -m "Sync Tutti agent skills from Tutti main repository"
           git push "https://x-access-token:${TOKEN}@github.com/${SKILLS_REPO}.git" "$SYNC_BRANCH" --force
 
       - name: Open or update sync pull request
@@ -199,14 +219,14 @@ jobs:
               --repo "$SKILLS_REPO" \
               --base main \
               --head "$SYNC_BRANCH" \
-              --title "Sync workspace app factory skill" \
-              --body "Mirrors Tutti main repository services/tuttid/service/workspace/app_factory_reference.\n\nSource commit: ${GITHUB_SHA}")"
+              --title "Sync Tutti agent skills" \
+              --body "Mirrors Tutti main repository workspace app skills.\n\nSource commit: ${GITHUB_SHA}")"
             pr_number="${pr_url##*/}"
           else
             gh pr edit "$pr_number" \
               --repo "$SKILLS_REPO" \
-              --title "Sync workspace app factory skill" \
-              --body "Mirrors Tutti main repository services/tuttid/service/workspace/app_factory_reference.\n\nSource commit: ${GITHUB_SHA}"
+              --title "Sync Tutti agent skills" \
+              --body "Mirrors Tutti main repository workspace app skills.\n\nSource commit: ${GITHUB_SHA}"
             pr_url="https://github.com/${SKILLS_REPO}/pull/${pr_number}"
           fi
           echo "number=$pr_number" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/tutti-agent-skills-preview.yml
+++ b/.github/workflows/tutti-agent-skills-preview.yml
@@ -1,0 +1,221 @@
+name: Preview Tutti Skills Sync
+
+on:
+  pull_request:
+    paths:
+      - "services/tuttid/service/workspace/app_factory_reference/**"
+
+permissions:
+  contents: read
+  issues: write
+  pull-requests: write
+
+concurrency:
+  group: tutti-agent-skills-preview-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  preview:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout Tutti main repository
+        uses: actions/checkout@v4
+
+      - name: Build temporary skills repository layout
+        run: |
+          mkdir -p /tmp/tutti-agent-skills/skills/tutti-workspace-app-factory
+          mkdir -p /tmp/tutti-agent-skills/plugins/tutti/skills/tutti-workspace-app-factory
+          rsync -a --delete \
+            services/tuttid/service/workspace/app_factory_reference/ \
+            /tmp/tutti-agent-skills/skills/tutti-workspace-app-factory/
+          rsync -a --delete \
+            services/tuttid/service/workspace/app_factory_reference/ \
+            /tmp/tutti-agent-skills/plugins/tutti/skills/tutti-workspace-app-factory/
+          mkdir -p /tmp/tutti-agent-skills/.agents/plugins
+          mkdir -p /tmp/tutti-agent-skills/.codex-plugin
+          mkdir -p /tmp/tutti-agent-skills/plugins/tutti/.codex-plugin
+
+      - name: Write temporary marketplace manifest
+        run: |
+          cat > /tmp/tutti-agent-skills/.agents/plugins/marketplace.json <<'JSON'
+          {
+            "name": "tutti-agent-skills",
+            "interface": {
+              "displayName": "Tutti Agent Skills"
+            },
+            "plugins": [
+              {
+                "name": "tutti",
+                "source": {
+                  "source": "local",
+                  "path": "./plugins/tutti"
+                },
+                "policy": {
+                  "installation": "AVAILABLE",
+                  "authentication": "ON_INSTALL"
+                },
+                "category": "Developer Tools"
+              }
+            ]
+          }
+          JSON
+
+      - name: Write temporary plugin manifest
+        run: |
+          tee /tmp/tutti-agent-skills/.codex-plugin/plugin.json \
+            /tmp/tutti-agent-skills/plugins/tutti/.codex-plugin/plugin.json > /dev/null <<'JSON'
+          {
+            "name": "tutti",
+            "version": "0.1.0",
+            "description": "Tutti workspace app authoring tools for agent runtimes.",
+            "author": { "name": "Tutti" },
+            "repository": "https://github.com/tutti-os/tutti-agent-skills",
+            "license": "MIT",
+            "keywords": ["tutti", "workspace-apps", "agent-skills"],
+            "skills": "./skills/",
+            "interface": {
+              "displayName": "Tutti",
+              "shortDescription": "Create and repair Tutti workspace apps",
+              "longDescription": "Skills for generating, validating, and repairing self-contained Tutti workspace app packages.",
+              "developerName": "Tutti",
+              "category": "Developer Tools",
+              "capabilities": ["Write"],
+              "websiteURL": "https://tutti.sh/",
+              "defaultPrompt": [
+                "Create a Tutti workspace app package.",
+                "Repair this Tutti workspace app package.",
+                "Validate a Tutti workspace app manifest."
+              ]
+            }
+          }
+          JSON
+
+      - name: Validate skill discovery
+        working-directory: /tmp/tutti-agent-skills
+        run: |
+          npx --yes skills add . --list
+          npx --yes skills add ./skills/tutti-workspace-app-factory --list
+
+      - name: Validate marketplace layout
+        working-directory: /tmp/tutti-agent-skills
+        run: |
+          python3 - <<'PY'
+          import json
+          import pathlib
+          import sys
+
+          marketplace = json.loads(pathlib.Path(".agents/plugins/marketplace.json").read_text())
+          plugins = marketplace.get("plugins")
+          if not isinstance(plugins, list) or not plugins:
+              sys.exit("marketplace must contain at least one plugin")
+          entry = plugins[0]
+          if entry.get("name") != "tutti":
+              sys.exit("marketplace plugin name must be tutti")
+          if entry.get("source", {}).get("path") != "./plugins/tutti":
+              sys.exit("marketplace plugin source path must be ./plugins/tutti")
+          for root in (pathlib.Path("."), pathlib.Path("plugins/tutti")):
+              manifest = json.loads((root / ".codex-plugin/plugin.json").read_text())
+              if manifest.get("name") != "tutti":
+                  sys.exit(f"{root} plugin name must be tutti")
+              if manifest.get("skills") != "./skills/":
+                  sys.exit(f"{root} skills path must be ./skills/")
+              if manifest.get("interface", {}).get("websiteURL") != "https://tutti.sh/":
+                  sys.exit(f"{root} websiteURL must be https://tutti.sh/")
+              if not (root / "skills/tutti-workspace-app-factory/SKILL.md").exists():
+                  sys.exit(f"{root} is missing the workspace app factory skill")
+          PY
+
+      - name: Validate skill frontmatter
+        working-directory: /tmp/tutti-agent-skills
+        run: |
+          python3 - <<'PY'
+          import pathlib
+          import re
+          import sys
+
+          skill = pathlib.Path("skills/tutti-workspace-app-factory/SKILL.md")
+          text = skill.read_text()
+          if not text.startswith("---\n"):
+              sys.exit("SKILL.md must start with YAML frontmatter")
+          end = text.find("\n---\n", 4)
+          if end < 0:
+              sys.exit("SKILL.md must close YAML frontmatter")
+          frontmatter = text[4:end]
+          if not re.search(r"^name:\s*tutti-workspace-app-factory\s*$", frontmatter, re.M):
+              sys.exit("SKILL.md missing expected name")
+          if not re.search(r"^description:\s*.+", frontmatter, re.M):
+              sys.exit("SKILL.md missing description")
+          allowed = {"name", "description"}
+          keys = {
+              line.split(":", 1)[0].strip()
+              for line in frontmatter.splitlines()
+              if ":" in line and not line.startswith(" ")
+          }
+          extra = keys - allowed
+          if extra:
+              sys.exit(f"SKILL.md frontmatter has unsupported keys: {sorted(extra)}")
+          PY
+
+      - name: Upload preview artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: tutti-agent-skills-preview
+          path: /tmp/tutti-agent-skills
+
+      - name: Summarize preview
+        run: |
+          {
+            echo "## Tutti Skills Preview"
+            echo
+            echo "This PR changes the built-in Tutti workspace app factory skill."
+            echo
+            echo "- External repository target: \`skills/tutti-workspace-app-factory/\`"
+            echo "- Plugin marketplace target: \`plugins/tutti/skills/tutti-workspace-app-factory/\`"
+            echo "- Preview artifact: \`tutti-agent-skills-preview\`"
+            echo "- This workflow did not push to the external repository."
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Comment on pull request
+        uses: actions/github-script@v8
+        with:
+          script: |
+            const marker = "<!-- tutti-agent-skills-preview -->";
+            const body = `${marker}
+            This PR changes the built-in Tutti workspace app factory skill.
+
+            External repository target:
+            \`skills/tutti-workspace-app-factory/\`
+
+            Plugin marketplace target:
+            \`plugins/tutti/skills/tutti-workspace-app-factory/\`
+
+            Preview artifact:
+            \`tutti-agent-skills-preview\`
+
+            This workflow did not push to the external repository. After this PR lands, the main-branch sync workflow will update \`tutti-os/tutti-agent-skills\` and enable auto-merge when checks pass.`;
+
+            const {owner, repo} = context.repo;
+            const issue_number = context.issue.number;
+            const comments = await github.rest.issues.listComments({
+              owner,
+              repo,
+              issue_number,
+              per_page: 100,
+            });
+            const previous = comments.data.find((comment) => comment.body?.includes(marker));
+            if (previous) {
+              await github.rest.issues.updateComment({
+                owner,
+                repo,
+                comment_id: previous.id,
+                body,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner,
+                repo,
+                issue_number,
+                body,
+              });
+            }

--- a/.github/workflows/tutti-agent-skills-preview.yml
+++ b/.github/workflows/tutti-agent-skills-preview.yml
@@ -80,7 +80,7 @@ jobs:
             "description": "Tutti workspace app authoring and agent app architecture tools.",
             "author": { "name": "Tutti" },
             "repository": "https://github.com/tutti-os/tutti-agent-skills",
-            "license": "MIT",
+            "license": "Apache-2.0",
             "keywords": ["tutti", "workspace-apps", "agent-skills"],
             "skills": "./skills/",
             "interface": {

--- a/.github/workflows/tutti-agent-skills-preview.yml
+++ b/.github/workflows/tutti-agent-skills-preview.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
     paths:
       - "services/tuttid/service/workspace/app_factory_reference/**"
+      - "services/tuttid/service/workspace/agent_workspace_app_reference/**"
 
 permissions:
   contents: read
@@ -25,13 +26,21 @@ jobs:
       - name: Build temporary skills repository layout
         run: |
           mkdir -p /tmp/tutti-agent-skills/skills/tutti-workspace-app-factory
+          mkdir -p /tmp/tutti-agent-skills/skills/tutti-agent-workspace-app
           mkdir -p /tmp/tutti-agent-skills/plugins/tutti/skills/tutti-workspace-app-factory
+          mkdir -p /tmp/tutti-agent-skills/plugins/tutti/skills/tutti-agent-workspace-app
           rsync -a --delete \
             services/tuttid/service/workspace/app_factory_reference/ \
             /tmp/tutti-agent-skills/skills/tutti-workspace-app-factory/
           rsync -a --delete \
             services/tuttid/service/workspace/app_factory_reference/ \
             /tmp/tutti-agent-skills/plugins/tutti/skills/tutti-workspace-app-factory/
+          rsync -a --delete \
+            services/tuttid/service/workspace/agent_workspace_app_reference/ \
+            /tmp/tutti-agent-skills/skills/tutti-agent-workspace-app/
+          rsync -a --delete \
+            services/tuttid/service/workspace/agent_workspace_app_reference/ \
+            /tmp/tutti-agent-skills/plugins/tutti/skills/tutti-agent-workspace-app/
           mkdir -p /tmp/tutti-agent-skills/.agents/plugins
           mkdir -p /tmp/tutti-agent-skills/.codex-plugin
           mkdir -p /tmp/tutti-agent-skills/plugins/tutti/.codex-plugin
@@ -68,7 +77,7 @@ jobs:
           {
             "name": "tutti",
             "version": "0.1.0",
-            "description": "Tutti workspace app authoring tools for agent runtimes.",
+            "description": "Tutti workspace app authoring and agent app architecture tools.",
             "author": { "name": "Tutti" },
             "repository": "https://github.com/tutti-os/tutti-agent-skills",
             "license": "MIT",
@@ -76,14 +85,15 @@ jobs:
             "skills": "./skills/",
             "interface": {
               "displayName": "Tutti",
-              "shortDescription": "Create and repair Tutti workspace apps",
-              "longDescription": "Skills for generating, validating, and repairing self-contained Tutti workspace app packages.",
+              "shortDescription": "Create Tutti workspace and agent apps",
+              "longDescription": "Skills for generating, converting, validating, localizing, and repairing Tutti workspace apps and agent-enabled app repositories.",
               "developerName": "Tutti",
               "category": "Developer Tools",
               "capabilities": ["Write"],
               "websiteURL": "https://tutti.sh/",
               "defaultPrompt": [
                 "Create a Tutti workspace app package.",
+                "Create an agent-enabled Tutti workspace app repository.",
                 "Repair this Tutti workspace app package.",
                 "Validate a Tutti workspace app manifest."
               ]
@@ -96,6 +106,7 @@ jobs:
         run: |
           npx --yes skills add . --list
           npx --yes skills add ./skills/tutti-workspace-app-factory --list
+          npx --yes skills add ./skills/tutti-agent-workspace-app --list
 
       - name: Validate marketplace layout
         working-directory: /tmp/tutti-agent-skills
@@ -122,8 +133,9 @@ jobs:
                   sys.exit(f"{root} skills path must be ./skills/")
               if manifest.get("interface", {}).get("websiteURL") != "https://tutti.sh/":
                   sys.exit(f"{root} websiteURL must be https://tutti.sh/")
-              if not (root / "skills/tutti-workspace-app-factory/SKILL.md").exists():
-                  sys.exit(f"{root} is missing the workspace app factory skill")
+              for skill_name in ["tutti-workspace-app-factory", "tutti-agent-workspace-app"]:
+                  if not (root / f"skills/{skill_name}/SKILL.md").exists():
+                      sys.exit(f"{root} is missing {skill_name}")
           PY
 
       - name: Validate skill frontmatter
@@ -134,27 +146,28 @@ jobs:
           import re
           import sys
 
-          skill = pathlib.Path("skills/tutti-workspace-app-factory/SKILL.md")
-          text = skill.read_text()
-          if not text.startswith("---\n"):
-              sys.exit("SKILL.md must start with YAML frontmatter")
-          end = text.find("\n---\n", 4)
-          if end < 0:
-              sys.exit("SKILL.md must close YAML frontmatter")
-          frontmatter = text[4:end]
-          if not re.search(r"^name:\s*tutti-workspace-app-factory\s*$", frontmatter, re.M):
-              sys.exit("SKILL.md missing expected name")
-          if not re.search(r"^description:\s*.+", frontmatter, re.M):
-              sys.exit("SKILL.md missing description")
-          allowed = {"name", "description"}
-          keys = {
-              line.split(":", 1)[0].strip()
-              for line in frontmatter.splitlines()
-              if ":" in line and not line.startswith(" ")
-          }
-          extra = keys - allowed
-          if extra:
-              sys.exit(f"SKILL.md frontmatter has unsupported keys: {sorted(extra)}")
+          for expected_name in ["tutti-workspace-app-factory", "tutti-agent-workspace-app"]:
+              skill = pathlib.Path(f"skills/{expected_name}/SKILL.md")
+              text = skill.read_text()
+              if not text.startswith("---\n"):
+                  sys.exit(f"{skill} must start with YAML frontmatter")
+              end = text.find("\n---\n", 4)
+              if end < 0:
+                  sys.exit(f"{skill} must close YAML frontmatter")
+              frontmatter = text[4:end]
+              if not re.search(rf"^name:\s*{re.escape(expected_name)}\s*$", frontmatter, re.M):
+                  sys.exit(f"{skill} missing expected name")
+              if not re.search(r"^description:\s*.+", frontmatter, re.M):
+                  sys.exit(f"{skill} missing description")
+              allowed = {"name", "description"}
+              keys = {
+                  line.split(":", 1)[0].strip()
+                  for line in frontmatter.splitlines()
+                  if ":" in line and not line.startswith(" ")
+              }
+              extra = keys - allowed
+              if extra:
+                  sys.exit(f"{skill} frontmatter has unsupported keys: {sorted(extra)}")
           PY
 
       - name: Upload preview artifact
@@ -168,10 +181,12 @@ jobs:
           {
             echo "## Tutti Skills Preview"
             echo
-            echo "This PR changes the built-in Tutti workspace app factory skill."
+            echo "This PR changes built-in Tutti workspace app skills."
             echo
             echo "- External repository target: \`skills/tutti-workspace-app-factory/\`"
+            echo "- External repository target: \`skills/tutti-agent-workspace-app/\`"
             echo "- Plugin marketplace target: \`plugins/tutti/skills/tutti-workspace-app-factory/\`"
+            echo "- Plugin marketplace target: \`plugins/tutti/skills/tutti-agent-workspace-app/\`"
             echo "- Preview artifact: \`tutti-agent-skills-preview\`"
             echo "- This workflow did not push to the external repository."
           } >> "$GITHUB_STEP_SUMMARY"
@@ -182,13 +197,15 @@ jobs:
           script: |
             const marker = "<!-- tutti-agent-skills-preview -->";
             const body = `${marker}
-            This PR changes the built-in Tutti workspace app factory skill.
+            This PR changes built-in Tutti workspace app skills.
 
             External repository target:
             \`skills/tutti-workspace-app-factory/\`
+            \`skills/tutti-agent-workspace-app/\`
 
             Plugin marketplace target:
             \`plugins/tutti/skills/tutti-workspace-app-factory/\`
+            \`plugins/tutti/skills/tutti-agent-workspace-app/\`
 
             Preview artifact:
             \`tutti-agent-skills-preview\`

--- a/docs/conventions/tutti-agent-skills-repository.md
+++ b/docs/conventions/tutti-agent-skills-repository.md
@@ -1,0 +1,610 @@
+# Tutti Agent Skills Repository
+
+This document defines the proposed external repository shape for publishing the
+Tutti workspace app factory skill as both:
+
+- an agent plugin
+- a skill repository installable with `npx skills add`
+
+The goal is to publish one external package that is easy for outside users to
+install while preserving the current built-in App Factory flow in this
+repository.
+
+## Current State
+
+The built-in App Factory skill currently lives at:
+
+```text
+services/tuttid/service/workspace/app_factory_reference/
+```
+
+That directory contains:
+
+```text
+SKILL.md
+references/
+  manifest-contract.md
+  cli-manifest-contract.md
+  runtime-env.md
+  tutti-cli-commands.md
+  validation-checklist.md
+  demos/simple-python-static-app/
+```
+
+The App Factory service embeds this directory with Go `embed`, then passes it to
+agent sessions as an extra provider-native skill. The skill is copied into the
+session-scoped provider skill root. It is not installed into the user's global
+skill directory.
+
+For Codex sessions, the runtime preparer writes the skill under:
+
+```text
+<runtimeRoot>/codex-home/skills/app-factory/
+```
+
+and sets:
+
+```text
+CODEX_HOME=<runtimeRoot>/codex-home
+```
+
+For Claude Code sessions, the runtime preparer writes the skill under the
+session-scoped Tutti plugin directory:
+
+```text
+<runtimeRoot>/claude-plugin/tutti-cli/skills/app-factory/
+```
+
+Because this internal path is deep inside the Tutti main repository,
+`npx skills add <repository-root> --list` does not reliably expose it as a public
+installable skill. Directly pointing `npx skills add` at the skill directory does
+work, but that is not a good public installation contract.
+
+## Proposed External Repository
+
+Use one external repository that is both a plugin repository and a skills
+repository. The repository name should not be tied to one agent provider.
+
+Recommended repository name:
+
+```text
+tutti-agent-skills
+```
+
+Recommended structure:
+
+```text
+tutti-agent-skills/
+  .agents/
+    plugins/
+      marketplace.json
+  .codex-plugin/
+    plugin.json
+  plugins/
+    tutti/
+      .codex-plugin/
+        plugin.json
+      skills/
+        tutti-workspace-app-factory/
+          SKILL.md
+          agents/
+            openai.yaml
+          references/
+            ...
+  skills/
+    tutti-workspace-app-factory/
+      SKILL.md
+      agents/
+        openai.yaml
+      references/
+        manifest-contract.md
+        cli-manifest-contract.md
+        runtime-env.md
+        tutti-cli-commands.md
+        validation-checklist.md
+        demos/
+          simple-python-static-app/
+  scripts/
+    pull-from-tutti-main.sh
+    check-tutti-main-sync.sh
+```
+
+This layout has two intended consumers:
+
+- Codex marketplace import reads `.agents/plugins/marketplace.json`, then loads the
+  `tutti` plugin from `plugins/tutti/`.
+- Direct plugin ingestion reads `.codex-plugin/plugin.json` and the `skills` pointer.
+- `npx skills add` discovers the skill under `skills/tutti-workspace-app-factory`.
+
+Keep the skill name stable:
+
+```yaml
+name: tutti-workspace-app-factory
+```
+
+## Plugin Manifest
+
+Create `.codex-plugin/plugin.json` with a minimal plugin manifest. Do not declare
+`apps`, `mcpServers`, or `hooks` until those companion files actually exist.
+
+Initial manifest:
+
+```json
+{
+  "name": "tutti",
+  "version": "0.1.0",
+  "description": "Tutti workspace app authoring tools for agent runtimes.",
+  "author": {
+    "name": "Tutti"
+  },
+  "repository": "https://github.com/tutti-os/tutti-agent-skills",
+  "license": "MIT",
+  "keywords": ["tutti", "workspace-apps", "agent-skills"],
+  "skills": "./skills/",
+  "interface": {
+    "displayName": "Tutti",
+    "shortDescription": "Create and repair Tutti workspace apps",
+    "longDescription": "Skills for generating, validating, and repairing self-contained Tutti workspace app packages.",
+    "developerName": "Tutti",
+    "category": "Developer Tools",
+    "capabilities": ["Write"],
+    "websiteURL": "https://tutti.sh/",
+    "defaultPrompt": [
+      "Create a Tutti workspace app package.",
+      "Repair this Tutti workspace app package.",
+      "Validate a Tutti workspace app manifest."
+    ]
+  }
+}
+```
+
+Before publishing, validate whether the plugin registry accepts the selected
+`interface.capabilities` values. If validation rejects `Write`, replace it with
+an accepted capability value or omit optional capability metadata.
+
+## Skill Metadata
+
+The skill directory should include `agents/openai.yaml` for UI metadata:
+
+```yaml
+interface:
+  display_name: "Tutti Workspace App Factory"
+  short_description: "Create Tutti workspace app packages"
+  default_prompt: "Use $tutti-workspace-app-factory to create or repair a self-contained Tutti workspace app package."
+
+policy:
+  allow_implicit_invocation: true
+```
+
+The `SKILL.md` frontmatter must contain only `name` and `description`.
+
+Example:
+
+```yaml
+---
+name: tutti-workspace-app-factory
+description: "Create or repair a self-contained Tutti workspace app package from a user request. Use for mention://workspace-app-factory/create handoffs, mention://workspace-app-factory handoffs, Tutti workspace app generation, repair, validation, manifests, bootstrap scripts, package-local AGENTS.md, local HTTP runtimes, healthchecks, app assets, optional app-runtime Tutti CLI integration, and TUTTI_APP_* storage rules."
+---
+```
+
+## Skill Runtime Modes
+
+The current built-in skill assumes the Tutti App Factory handoff always provides
+`context.json`. External users may install the skill directly and run it outside
+that handoff. The public skill must support both modes.
+
+Add this rule near the top of `SKILL.md`:
+
+```markdown
+## Required Context
+
+If the current working directory contains `context.json`, or the task includes
+`mention://workspace-app-factory/create` or `mention://workspace-app-factory`,
+operate in Tutti factory handoff mode. Read `context.json` before writing files,
+then follow its metadata, output rules, workspace context, and constraints
+exactly.
+
+If `context.json` is absent, operate in standalone mode. Treat the current
+working directory as the app authoring workspace, create the app package under
+`package/`, and infer missing metadata conservatively from the user request.
+```
+
+Handoff mode must preserve the existing behavior:
+
+- read `context.json` before writing files
+- use `output.packageRoot` as the package root
+- do not copy `context.json` into generated app outputs
+- follow all manifest, runtime, storage, CLI, and validation references
+
+Standalone mode should keep the same generated package contract, but with
+default output:
+
+```text
+package/
+  tutti.app.json
+  bootstrap.sh
+  AGENTS.md
+  ...
+```
+
+## Sync Direction
+
+Short term, keep the Tutti main repository built-in directory as the source of truth because
+that is where the runtime integration is currently tested.
+
+Sync direction:
+
+```text
+tutti-main/services/tuttid/service/workspace/app_factory_reference/
+  -> tutti-agent-skills/skills/tutti-workspace-app-factory/
+  -> tutti-agent-skills/plugins/tutti/skills/tutti-workspace-app-factory/
+```
+
+Put this script in the external repository as `scripts/pull-from-tutti-main.sh`:
+
+```bash
+#!/usr/bin/env bash
+set -euo pipefail
+
+SOURCE_REPO="${1:?usage: $0 /path/to/tutti-main}"
+SRC_DIR="$SOURCE_REPO/services/tuttid/service/workspace/app_factory_reference/"
+DST_DIR="skills/tutti-workspace-app-factory/"
+PLUGIN_DST_DIR="plugins/tutti/skills/tutti-workspace-app-factory/"
+
+rsync -a --delete "$SRC_DIR" "$DST_DIR"
+rsync -a --delete "$SRC_DIR" "$PLUGIN_DST_DIR"
+```
+
+Use it from the external repository:
+
+```bash
+./scripts/pull-from-tutti-main.sh /path/to/tutti-main
+```
+
+Add a drift check script as `scripts/check-tutti-main-sync.sh`:
+
+```bash
+#!/usr/bin/env bash
+set -euo pipefail
+
+SOURCE_REPO="${1:?usage: $0 /path/to/tutti-main}"
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+mkdir -p "$TMP_DIR/skills/tutti-workspace-app-factory"
+rsync -a --delete \
+  "$SOURCE_REPO/services/tuttid/service/workspace/app_factory_reference/" \
+  "$TMP_DIR/skills/tutti-workspace-app-factory/"
+
+diff -ru "$TMP_DIR/skills/tutti-workspace-app-factory" \
+  "skills/tutti-workspace-app-factory"
+
+diff -ru "$TMP_DIR/skills/tutti-workspace-app-factory" \
+  "plugins/tutti/skills/tutti-workspace-app-factory"
+```
+
+Run the drift check in CI when the external repository is updated. If the
+external repository becomes the source of truth later, reverse the sync
+direction and add a Tutti main repository-side check that compares the embedded copy to the
+external repository content.
+
+Avoid casual two-way sync. Pick one source of truth for each phase.
+
+## Tutti Repository Pull Request Workflow
+
+Use a pull-request-stage workflow first. The workflow should run when a Tutti main repository
+PR changes the built-in App Factory skill directory:
+
+```yaml
+on:
+  pull_request:
+    paths:
+      - "services/tuttid/service/workspace/app_factory_reference/**"
+```
+
+This workflow must not push to `tutti-agent-skills` and must not open or update
+external repository pull requests. A Tutti main repository PR is still review content, not a
+published source of truth.
+
+The pull request workflow should:
+
+1. check out Tutti main repository
+2. create a temporary `tutti-agent-skills` repository layout in the workflow
+   workspace
+3. copy `services/tuttid/service/workspace/app_factory_reference/` into
+   `skills/tutti-workspace-app-factory/`
+4. validate the temporary plugin and skill layout
+5. upload the temporary repository layout as an artifact
+6. comment on the Tutti main repository PR with validation results and the intended external
+   repository paths
+
+Example workflow:
+
+```yaml
+name: Preview Tutti Agent Skills Sync
+
+on:
+  pull_request:
+    paths:
+      - "services/tuttid/service/workspace/app_factory_reference/**"
+
+jobs:
+  preview:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Tutti main repository
+        uses: actions/checkout@v4
+
+      - name: Build temporary skills repository layout
+        run: |
+          mkdir -p /tmp/tutti-agent-skills/skills/tutti-workspace-app-factory
+          rsync -a --delete \
+            services/tuttid/service/workspace/app_factory_reference/ \
+            /tmp/tutti-agent-skills/skills/tutti-workspace-app-factory/
+          mkdir -p /tmp/tutti-agent-skills/.codex-plugin
+
+      - name: Write temporary plugin manifest
+        run: |
+          cat > /tmp/tutti-agent-skills/.codex-plugin/plugin.json <<'JSON'
+          {
+            "name": "tutti",
+            "version": "0.1.0",
+            "description": "Tutti workspace app authoring tools for agent runtimes.",
+            "author": { "name": "Tutti" },
+            "repository": "https://github.com/tutti-os/tutti-agent-skills",
+            "license": "MIT",
+            "keywords": ["tutti", "workspace-apps", "agent-skills"],
+            "skills": "./skills/",
+            "interface": {
+              "displayName": "Tutti",
+              "shortDescription": "Create and repair Tutti workspace apps",
+              "longDescription": "Skills for generating, validating, and repairing self-contained Tutti workspace app packages.",
+              "developerName": "Tutti",
+              "category": "Developer Tools",
+              "capabilities": ["Write"],
+              "websiteURL": "https://tutti.sh/",
+              "defaultPrompt": [
+                "Create a Tutti workspace app package.",
+                "Repair this Tutti workspace app package.",
+                "Validate a Tutti workspace app manifest."
+              ]
+            }
+          }
+          JSON
+
+      - name: Upload preview artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: tutti-agent-skills-preview
+          path: /tmp/tutti-agent-skills
+```
+
+The temporary manifest in this workflow is only for preview validation. The real
+manifest must live in the external `tutti-agent-skills` repository.
+
+The PR comment should communicate:
+
+```text
+This PR changes the built-in Tutti workspace app factory skill.
+
+External repository target:
+  skills/tutti-workspace-app-factory/
+
+Preview artifact:
+  tutti-agent-skills-preview
+
+This workflow did not push to the external repository. After this PR lands,
+sync the external repository through the release/update process.
+```
+
+This keeps Tutti main repository PR feedback fast while preventing unmerged Tutti main repository changes from
+appearing in the public skills repository.
+
+## External Repository Update Workflow
+
+After a Tutti main repository PR lands, update the external repository automatically from the
+Tutti main repository `main` branch. This keeps the external repository in sync without asking
+a human to remember a second manual workflow.
+
+```yaml
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - "services/tuttid/service/workspace/app_factory_reference/**"
+```
+
+The update workflow should:
+
+1. check out Tutti main repository at the pushed `main` commit
+2. check out `tutti-agent-skills`
+3. copy the built-in skill into `skills/tutti-workspace-app-factory/`
+4. bump the plugin cachebuster or version metadata when needed
+5. run plugin and skill validation
+6. open or update a pull request in `tutti-agent-skills`
+7. enable auto-merge on that pull request when all protection checks pass
+8. notify the original Tutti main repository PR or commit with the external PR and merge status
+
+Auto-merge is allowed only for generated sync pull requests that satisfy all of
+these conditions:
+
+- the PR author is the sync bot or GitHub Actions bot
+- the PR branch name matches the reserved sync prefix, for example
+  `sync/workspace-app-factory-skill`
+- the changed files are limited to:
+  - `skills/tutti-workspace-app-factory/**`
+  - `.codex-plugin/plugin.json` when the workflow bumps plugin metadata
+- plugin and skill validation passed
+- repository branch protection checks passed
+
+Do not auto-merge if the sync PR changes workflow files, scripts, marketplace
+configuration, repository settings, or any path outside the generated mirror
+surface. Those changes require human review.
+
+Example update workflow shape:
+
+```yaml
+name: Sync Tutti Agent Skills
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - "services/tuttid/service/workspace/app_factory_reference/**"
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Tutti main repository
+        uses: actions/checkout@v4
+        with:
+          path: source-repository
+
+      - name: Checkout skills repository
+        uses: actions/checkout@v4
+        with:
+          repository: tutti-os/tutti-agent-skills
+          token: ${{ secrets.TUTTI_AGENT_SKILLS_SYNC_TOKEN }}
+          path: tutti-agent-skills
+
+      - name: Sync built-in skill
+        run: |
+          rsync -a --delete \
+            tutti-main/services/tuttid/service/workspace/app_factory_reference/ \
+            tutti-agent-skills/skills/tutti-workspace-app-factory/
+
+      - name: Create sync pull request
+        id: sync-pr
+        uses: peter-evans/create-pull-request@v6
+        with:
+          path: tutti-agent-skills
+          token: ${{ secrets.TUTTI_AGENT_SKILLS_SYNC_TOKEN }}
+          branch: sync/workspace-app-factory-skill
+          delete-branch: true
+          title: "Sync workspace app factory skill"
+          commit-message: "Sync workspace app factory skill from Tutti main repository"
+          body: |
+            Mirrors Tutti main repository services/tuttid/service/workspace/app_factory_reference.
+
+            Source commit: ${{ github.sha }}
+
+      - name: Enable auto-merge
+        if: steps.sync-pr.outputs.pull-request-number != ''
+        env:
+          GH_TOKEN: ${{ secrets.TUTTI_AGENT_SKILLS_SYNC_TOKEN }}
+        run: |
+          gh pr merge \
+            "${{ steps.sync-pr.outputs.pull-request-number }}" \
+            --repo tutti-os/tutti-agent-skills \
+            --squash \
+            --auto
+```
+
+Keep the token narrowly scoped to the external skills repository. It needs
+permission to push the sync branch, open the sync PR, and enable auto-merge.
+
+## Notifications
+
+The automation must leave a notification trail in Tutti main repository so the sync does not
+become invisible.
+
+At minimum, the workflow should publish a GitHub Actions job summary containing:
+
+- source repository commit
+- whether a sync PR was created, updated, auto-merge-enabled, or skipped
+- external sync PR URL
+- validation result
+
+When the source commit belongs to a merged Tutti main repository PR, the workflow should also
+comment back on that Tutti main repository PR:
+
+```text
+Tutti agent skills sync started.
+
+External repository:
+  tutti-os/tutti-agent-skills
+
+Sync PR:
+  <external PR URL>
+
+Auto-merge:
+  enabled after required checks pass
+
+Source commit:
+  <Tutti main repository commit SHA>
+```
+
+If the sync fails, the comment should include the failing workflow URL and the
+manual recovery command:
+
+```bash
+./scripts/pull-from-tutti-main.sh /path/to/tutti-main
+```
+
+Team chat notifications are optional. If they are added later, send them only on
+sync failure or when auto-merge is blocked; successful syncs can rely on the
+Tutti main repository PR comment and workflow summary.
+
+## Validation
+
+Run these checks in the external repository:
+
+```bash
+npx --yes skills add . --list
+npx --yes skills add ./skills/tutti-workspace-app-factory --list
+python3 /Users/wwcome/.codex/skills/.system/plugin-creator/scripts/validate_plugin.py .
+python3 /Users/wwcome/.codex/skills/.system/plugin-creator/scripts/validate_plugin.py ./plugins/tutti
+python3 /Users/wwcome/.codex/skills/.system/skill-creator/scripts/quick_validate.py ./skills/tutti-workspace-app-factory
+```
+
+The root-level `npx skills add . --list` discovery must be tested with the real
+external repository. If root discovery does not find `skills/tutti-workspace-app-factory`,
+document this fallback installation command:
+
+```bash
+npx --yes skills add ./skills/tutti-workspace-app-factory --skill tutti-workspace-app-factory
+```
+
+Also test the public GitHub form before announcing the repository:
+
+```bash
+npx --yes skills add tutti-os/tutti-agent-skills
+npx --yes skills add tutti-os/tutti-agent-skills --list
+npx --yes skills add tutti-os/tutti-agent-skills --skill tutti-workspace-app-factory
+```
+
+The first command is the preferred public installation path. It installs every
+skill discovered under the repository's `skills/` directory. The `--skill`
+command is only for users who want a single skill.
+
+Also test the Codex marketplace form with an empty sparse path so the importer
+discovers `.agents/plugins/marketplace.json` from the repository root.
+
+## Open Questions
+
+These require real install validation rather than assumptions:
+
+- whether `npx skills add . --list` always scans a root-level `skills/` directory
+- whether plugin ingestion imports `skills: "./skills/"` exactly as expected
+- whether `interface.capabilities: ["Write"]` is accepted by the plugin validator
+- whether the external repository should eventually become the source of truth
+  for the embedded Tutti main repository copy
+
+## Rollout Plan
+
+1. Create `tutti-agent-skills` with `.codex-plugin/plugin.json`.
+2. Copy the current built-in App Factory skill to
+   `skills/tutti-workspace-app-factory/`.
+3. Add `agents/openai.yaml`.
+4. Update `SKILL.md` to support handoff mode and standalone mode.
+5. Add sync and drift-check scripts.
+6. Add the Tutti main repository pull-request preview workflow.
+7. Add the post-merge external sync workflow with guarded auto-merge.
+8. Add Tutti main repository PR comments or workflow summaries for sync notifications.
+9. Run local skill discovery and plugin validation.
+10. Run public GitHub `npx skills add` validation.
+11. Keep Tutti main repository embedding the built-in copy until there is a deliberate decision
+    to reverse the source-of-truth direction.

--- a/services/tuttid/service/workspace/agent_workspace_app_reference/SKILL.md
+++ b/services/tuttid/service/workspace/agent_workspace_app_reference/SKILL.md
@@ -1,0 +1,64 @@
+---
+name: tutti-agent-workspace-app
+description: "Build or evolve a complex agent-enabled Tutti workspace app repository. Use for Tutti apps with web/server/shared monorepos, @tutti-os/agent-acp-kit local agent runtimes, Codex or Claude provider detection, run-scoped MCP tool gateways, app-owned package builders, Tutti CLI/reference surfaces, web-first debugging, i18n harnesses, and production package validation. For simple package creation or repair, use tutti-workspace-app-factory instead."
+---
+
+# Tutti Agent Workspace App
+
+Use this skill when the task is to create or evolve a full Tutti app repository, not just a final package directory. The target app is usually a local-first web app with a server, shared contracts, optional local agent runtime, and an app-owned `scripts/package-tutti-app.mjs`.
+
+For the final package contract, defer to `$tutti-workspace-app-factory` and its references. This skill owns app architecture patterns; the factory skill owns `tutti.app.json`, `tutti.cli.json`, `bootstrap.sh`, runtime env, storage, i18n harness, and static package validation rules.
+
+## When To Use
+
+Use this skill for:
+
+- New agent-enabled Tutti app repositories.
+- Existing web/server apps being converted into maintainable Tutti app repos.
+- Apps that need `@tutti-os/agent-acp-kit` for local Codex or Claude runtime execution.
+- App-specific MCP or command gateways that expose domain tools to local agents.
+- Multi-package `pnpm` workspaces with `apps/web`, `apps/server`, and `packages/shared`.
+- App-owned packaging, smoke tests, i18n enforcement, and CLI/reference endpoints.
+
+Use `$tutti-workspace-app-factory` instead for a small standalone package, package repair, or manifest-only validation.
+
+## Required References
+
+Read only the references needed for the task:
+
+- `references/app-architecture.md` for repository layout, web/server/shared boundaries, and dependency choices.
+- `references/agent-acp-kit.md` when implementing local agent providers, provider detection, ACP event mapping, or run-scoped MCP tools.
+- `references/package-builder.md` when adding `scripts/package-tutti-app.mjs`, `bootstrap.sh`, Tutti CLI output docs, or package validation.
+- `references/i18n-and-web-debugging.md` when changing UI copy, language handling, web-first debug flow, or smoke/e2e checks.
+
+Also read `$tutti-workspace-app-factory` before changing final package files or package runtime behavior.
+
+## Workflow
+
+1. Inspect the existing app shape, scripts, runtime dependencies, build output, storage, i18n, and agent surfaces.
+2. Choose the smallest architecture that can stay maintainable: do not add local agents, WebSocket, MCP, CLI, or background workers unless the product needs them.
+3. Define shared contracts before wiring web/server calls. Keep domain DTOs, WebSocket messages, CLI-visible shapes, and runtime profile types in `packages/shared`.
+4. Build the web UI as the primary development surface. Keep the server as local API/static host and app orchestration layer.
+5. If agents are needed, add `@tutti-os/agent-acp-kit`, provider detection, runtime provider abstraction, event normalization, and a run-scoped tool gateway.
+6. Add package generation only after the local dev app runs. Package the built web assets, bundled server, `tutti.app.json`, optional `tutti.cli.json`, executable `bootstrap.sh`, assets, locales, and package-local `AGENTS.md`.
+7. Verify with the repo's targeted checks first, then package checks.
+
+## Validation
+
+Prefer app-local scripts when they exist:
+
+```bash
+pnpm check
+pnpm test
+pnpm typecheck
+pnpm check:i18n
+pnpm package:tutti
+```
+
+For final package validation, run the validator from `$tutti-workspace-app-factory` when available:
+
+```bash
+python3 <factory-skill>/scripts/validate_tutti_app_package.py <generated-package-root>
+```
+
+If the app includes real local agent execution, add or run a smoke check that starts with provider detection before launching a real turn.

--- a/services/tuttid/service/workspace/agent_workspace_app_reference/SKILL.md
+++ b/services/tuttid/service/workspace/agent_workspace_app_reference/SKILL.md
@@ -19,6 +19,7 @@ Use this skill for:
 - App-specific MCP or command gateways that expose domain tools to local agents.
 - Multi-package `pnpm` workspaces with `apps/web`, `apps/server`, and `packages/shared`.
 - App-owned packaging, smoke tests, i18n enforcement, and CLI/reference endpoints.
+- GitHub Actions release workflows for publishing Tutti app releases and staging/production catalogs.
 
 Use `$tutti-workspace-app-factory` instead for a small standalone package, package repair, or manifest-only validation.
 
@@ -29,6 +30,7 @@ Read only the references needed for the task:
 - `references/app-architecture.md` for repository layout, web/server/shared boundaries, and dependency choices.
 - `references/agent-acp-kit.md` when implementing local agent providers, provider detection, ACP event mapping, or run-scoped MCP tools.
 - `references/package-builder.md` when adding `scripts/package-tutti-app.mjs`, `bootstrap.sh`, Tutti CLI output docs, or package validation.
+- `references/github-actions-release.md` when creating or changing `.github/workflows/publish-tutti-app.yml`, `.github/workflows/publish-tutti-app-staging.yml`, release variables, or catalog publishing.
 - `references/i18n-and-web-debugging.md` when changing UI copy, language handling, web-first debug flow, or smoke/e2e checks.
 
 Also read `$tutti-workspace-app-factory` before changing final package files or package runtime behavior.
@@ -41,7 +43,8 @@ Also read `$tutti-workspace-app-factory` before changing final package files or 
 4. Build the web UI as the primary development surface. Keep the server as local API/static host and app orchestration layer.
 5. If agents are needed, add `@tutti-os/agent-acp-kit`, provider detection, runtime provider abstraction, event normalization, and a run-scoped tool gateway.
 6. Add package generation only after the local dev app runs. Package the built web assets, bundled server, `tutti.app.json`, optional `tutti.cli.json`, executable `bootstrap.sh`, assets, locales, and package-local `AGENTS.md`.
-7. Verify with the repo's targeted checks first, then package checks.
+7. For GitHub-hosted app repositories that should publish releases, add staging and production release workflows after the package builder is stable.
+8. Verify with the repo's targeted checks first, then package checks.
 
 ## Validation
 

--- a/services/tuttid/service/workspace/agent_workspace_app_reference/SKILL.md
+++ b/services/tuttid/service/workspace/agent_workspace_app_reference/SKILL.md
@@ -43,8 +43,9 @@ Also read `$tutti-workspace-app-factory` before changing final package files or 
 4. Build the web UI as the primary development surface. Keep the server as local API/static host and app orchestration layer.
 5. If agents are needed, add `@tutti-os/agent-acp-kit`, provider detection, runtime provider abstraction, event normalization, and a run-scoped tool gateway.
 6. Add package generation only after the local dev app runs. Package the built web assets, bundled server, `tutti.app.json`, optional `tutti.cli.json`, executable `bootstrap.sh`, assets, locales, and package-local `AGENTS.md`.
-7. For GitHub-hosted app repositories that should publish releases, add staging and production release workflows after the package builder is stable.
-8. Verify with the repo's targeted checks first, then package checks.
+7. If the user asks to connect to the Tutti app ecosystem, treat ecosystem integration as required: expose app capabilities through `tutti.cli.json`, make the app callable by other Tutti apps and agents, and use `TUTTI_CLI` for any calls to other installed Tutti apps.
+8. For GitHub-hosted app repositories that should publish releases, add staging and production release workflows after the package builder is stable.
+9. Verify with the repo's targeted checks first, then package checks.
 
 ## Validation
 

--- a/services/tuttid/service/workspace/agent_workspace_app_reference/agents/openai.yaml
+++ b/services/tuttid/service/workspace/agent_workspace_app_reference/agents/openai.yaml
@@ -1,0 +1,7 @@
+interface:
+  display_name: "Tutti Agent Workspace App"
+  short_description: "Build agent-enabled Tutti apps"
+  default_prompt: "Use $tutti-agent-workspace-app to create an agent-enabled Tutti workspace app repository."
+
+policy:
+  allow_implicit_invocation: true

--- a/services/tuttid/service/workspace/agent_workspace_app_reference/references/agent-acp-kit.md
+++ b/services/tuttid/service/workspace/agent_workspace_app_reference/references/agent-acp-kit.md
@@ -1,0 +1,155 @@
+# Agent ACP Kit Integration
+
+Use this reference only when the app needs local Codex/Claude execution or a local agent runtime.
+
+## Rule
+
+If the app involves local agents, depend on `@tutti-os/agent-acp-kit`. Do not hand-roll provider detection, ACP stream parsing, or local-agent adapters unless the kit lacks a required capability and the gap is documented.
+
+## Runtime Shape
+
+Keep app domain logic independent from providers:
+
+```text
+Application use-case
+  -> Agent run service/orchestrator
+    -> Runtime provider interface
+      -> local-agent provider using @tutti-os/agent-acp-kit
+        -> run-scoped MCP/tool gateway
+```
+
+Use provider IDs from the kit or an explicit allowlist such as `codex` and `claude`. Detect providers before showing them as available.
+
+## Provider Detection
+
+Create a small discovery wrapper:
+
+```ts
+import {
+  createDefaultLocalAgentProviderPlugins,
+  createLocalAgentRuntime
+} from "@tutti-os/agent-acp-kit";
+
+const localAgentRuntime = createLocalAgentRuntime({
+  providers: createDefaultLocalAgentProviderPlugins()
+});
+
+export async function detectLocalAgents() {
+  return localAgentRuntime.detect();
+}
+```
+
+Map detected provider models to app model IDs with a provider prefix, such as `codex:gpt-5.1` or `claude:sonnet`.
+
+## Runtime Execution
+
+For each agent run:
+
+1. Create a temporary run directory.
+2. Materialize any app or workspace skills under that directory using relative paths.
+3. Build a prompt envelope with conversation identity, current user turn, attachments, current app state, collaboration rules, and tool gateway guidance.
+4. Create a run-scoped tool gateway session and MCP config.
+5. Call `localAgentRuntime.run(...)`.
+6. Normalize ACP events into app stream events.
+7. Persist provider session/resume metadata when the kit returns it.
+8. Always revoke the gateway token and remove the temporary run directory in `finally`.
+
+Skeleton:
+
+```ts
+for await (const event of localAgentRuntime.run({
+  runId,
+  provider,
+  cwd: runDir,
+  prompt,
+  systemPrompt,
+  model,
+  runtimeKind: "local-agent",
+  runtimeProvider: provider,
+  mcpServers,
+  resume,
+  signal,
+  skillManifest,
+  timeoutMs
+})) {
+  yield adaptLocalAgentEvent(event);
+}
+```
+
+Do not claim a file write, canvas edit, image generation, or other side effect happened unless the corresponding tool event succeeded.
+
+## Event Mapping
+
+Normalize at least:
+
+- text deltas and final assistant text
+- thinking/reasoning text
+- tool calls and tool results
+- status/progress updates
+- file writes
+- stderr/log events
+- done, canceled, and error terminal events
+- provider session ID or resume token
+
+If a provider emits raw events differently, add a provider-specific compatibility adapter near provider setup, not in UI code.
+
+## Tool Gateway
+
+Expose app abilities through a run-scoped gateway:
+
+- Mint one token per run.
+- Pass the token only to the MCP server process or command bridge.
+- Validate token, run, participant/session, tool name, and schema on every call.
+- Revoke the token when the run completes, fails, or is canceled.
+- Keep tools app-level: read context, inspect state, mutate app artifacts, start app jobs, persist outputs, read app-owned files.
+
+MCP config pattern:
+
+```ts
+import type { LocalAgentMcpServerConfig } from "@tutti-os/agent-acp-kit";
+
+export function createAppToolsMcpServerConfig(input: {
+  gatewayBaseUrl: string;
+  gatewayToken: string;
+  packagedMcpPath?: string;
+}): LocalAgentMcpServerConfig {
+  if (input.packagedMcpPath) {
+    return {
+      name: "app-tools",
+      type: "stdio",
+      command: process.execPath,
+      args: [input.packagedMcpPath],
+      env: {
+        APP_TOOL_GATEWAY_URL: input.gatewayBaseUrl,
+        APP_TOOL_TOKEN: input.gatewayToken
+      }
+    };
+  }
+
+  return {
+    name: "app-tools",
+    type: "stdio",
+    command: "pnpm",
+    args: ["exec", "tsx", "src/agent/local-agent-host/tools-mcp.ts"],
+    env: {
+      APP_TOOL_GATEWAY_URL: input.gatewayBaseUrl,
+      APP_TOOL_TOKEN: input.gatewayToken
+    }
+  };
+}
+```
+
+Package builders should bundle the MCP entrypoint and expose its path through an app-specific env var such as `AIMC_TOOLS_MCP_PATH`.
+
+## Verification
+
+Add tests for:
+
+- provider filtering and model mapping
+- event normalization
+- MCP config env and packaged path
+- tool gateway token validation and revocation
+- run cancellation cleanup
+- resume metadata persistence
+
+For real-agent smoke tests, start with detection, then run a narrow prompt with no irreversible side effects.

--- a/services/tuttid/service/workspace/agent_workspace_app_reference/references/app-architecture.md
+++ b/services/tuttid/service/workspace/agent_workspace_app_reference/references/app-architecture.md
@@ -1,0 +1,114 @@
+# App Architecture
+
+Use this reference for full app repositories. Keep the final package contract in `$tutti-workspace-app-factory`.
+
+## Repository Shape
+
+Prefer this shape for agent-enabled apps:
+
+```text
+app-name/
+  apps/
+    web/
+      src/
+      package.json
+    server/
+      src/
+      package.json
+  packages/
+    shared/
+      src/
+      package.json
+  docs/
+  locales/
+  scripts/
+    package-tutti-app.mjs
+  COMMANDS.md
+  package.json
+  pnpm-workspace.yaml
+  tsconfig.base.json
+  tutti.app.json
+  tutti.cli.json
+```
+
+For a multi-app catalog repository, use `apps/<app-id>/` with each app owning its source, i18n config, and `tutti-package/` inputs. Keep shared repository scripts under root `scripts/`.
+
+## Boundaries
+
+- `apps/web`: React/Next/Vite UI, UI state, API/WS client, host bridge wrappers. Do not place core orchestration here.
+- `apps/server`: local HTTP runtime, static asset hosting, WebSocket, storage, domain use-cases, local agent runtime providers, tool gateway, Tutti CLI/reference endpoints.
+- `packages/shared`: stable contracts consumed by web and server: DTOs, WebSocket messages, command output envelopes, runtime profile types, and schema helpers.
+- `scripts`: deterministic build, validation, and package generation.
+- `docs`: plans and architecture notes. Keep executable contracts in code and package manifests.
+
+## Dependency Defaults
+
+Use `pnpm` workspaces by default. Common choices:
+
+- Server: Fastify, `@fastify/static`, `@fastify/websocket`, zod or ajv for schemas.
+- Web: React with Vite, Next, or TanStack Start, matching the repo's current stack.
+- Agent runtime: `@tutti-os/agent-acp-kit` when local Codex/Claude execution is required.
+- I18n: `i18next`, `react-i18next`, and `i18next-cli` for larger web apps.
+- Tests: Vitest or Node test runner for packages, Playwright only for cross-boundary UI flows.
+
+Avoid introducing monorepo tooling, background workers, WebSocket, local agents, or MCP gateways unless the app workflow needs them.
+
+## Server Runtime Conventions
+
+Local development:
+
+- Root `pnpm dev` should build `packages/shared` first, then run `apps/server` and `apps/web`.
+- Keep the app server bound to `127.0.0.1`.
+- Provide a health endpoint such as `/api/health`.
+- Provide a bootstrap/snapshot endpoint when the web UI needs initial state.
+- Add `/api/ws` only when real-time state or streaming is required.
+- Add `/tutti/cli/*` and `/tutti/references/*` only for external agent or CLI surfaces.
+
+Tutti package startup:
+
+- `bootstrap.sh` takes no arguments.
+- Bind to `$TUTTI_APP_HOST:$TUTTI_APP_PORT`.
+- Use `$TUTTI_APP_NODE`, `$TUTTI_APP_PYTHON`, and `$TUTTI_APP_NPM`; do not rely on system runtime names.
+- Treat `$TUTTI_APP_PACKAGE_DIR` as read-only after startup.
+- Store durable data under `$TUTTI_APP_DATA_DIR`.
+- Store scratch files under `$TUTTI_APP_RUNTIME_DIR`.
+- Write file logs under `$TUTTI_APP_LOG_DIR` only when needed.
+- Read `$TUTTI_WORKSPACE_ROOT` only for explicit workspace features.
+
+## Host Bridge
+
+Use one narrow browser wrapper for Tutti host calls. The web app must continue to run in a normal browser.
+
+```ts
+export interface TuttiWorkspaceAppBridge {
+  files?: {
+    open(input: {
+      path: string;
+      name?: string;
+      mode?: "auto" | "preview" | "reveal";
+    }): Promise<void>;
+  };
+  appContext?: {
+    get(): Promise<{ workspaceId?: string; locale?: string }>;
+    subscribe?(
+      listener: (context: { workspaceId?: string; locale?: string }) => void
+    ): () => void;
+  };
+}
+
+declare global {
+  interface Window {
+    tutti?: TuttiWorkspaceAppBridge;
+    tuttiExternal?: {
+      app?: {
+        getContext?: () => Promise<{ locale?: string; language?: string }>;
+        subscribe?: (
+          listener: (context: { locale?: string; language?: string }) => void
+        ) => () => void;
+      };
+    };
+  }
+}
+```
+
+Host-only actions should fail softly or fall back to a local browser behavior.

--- a/services/tuttid/service/workspace/agent_workspace_app_reference/references/github-actions-release.md
+++ b/services/tuttid/service/workspace/agent_workspace_app_reference/references/github-actions-release.md
@@ -1,0 +1,166 @@
+# GitHub Actions Release Workflows
+
+Use this reference when creating or updating GitHub Actions that publish a Tutti app package to the Tutti App Center release bucket and catalog.
+
+## When To Add
+
+Add release workflows when the target repository is expected to publish a Tutti app from GitHub. Do not add them for local-only prototypes, throwaway demos, or repositories that cannot use GitHub OIDC to assume the Tutti release AWS role.
+
+Create both files for app repositories that need normal staging/production publishing:
+
+- `.github/workflows/publish-tutti-app-staging.yml`
+- `.github/workflows/publish-tutti-app.yml`
+
+Keep PR checks separate from publishing. PR workflows should build, test, run i18n checks, and run `pnpm package:tutti`; only manual dispatch or protected release flows should upload release artifacts or catalogs.
+
+## Shared Workflow
+
+Use the reusable Tutti release workflow instead of reimplementing S3/catalog logic:
+
+```yaml
+uses: tutti-os/tutti/.github/workflows/publish-tutti-app-release.yml@main
+```
+
+This reusable workflow builds the app package, generates release metadata, uploads immutable app release artifacts to S3, updates `latest.json`, verifies the published release, optionally creates a release tag, and optionally refreshes the app catalog.
+
+## Production Workflow Template
+
+Fill `app_id`, `package_command`, `package_dir`, `icon_path`, `release_tag_prefix`, `runner`, and `pnpm_version` from the app repository.
+
+```yaml
+name: Publish Tutti App Production
+
+on:
+  workflow_dispatch:
+    inputs:
+      release_bump:
+        description: Semver bump to publish.
+        required: true
+        type: choice
+        default: patch
+        options:
+          - patch
+          - minor
+          - major
+      publish_catalog:
+        description: Whether to publish the production App Center catalog after this release.
+        required: false
+        type: boolean
+        default: true
+      catalog_only:
+        description: Whether to skip app release upload and only publish the existing latest release to catalog.
+        required: false
+        type: boolean
+        default: false
+
+permissions:
+  contents: write
+  id-token: write
+
+jobs:
+  publish:
+    uses: tutti-os/tutti/.github/workflows/publish-tutti-app-release.yml@main
+    with:
+      app_id: <app-id>
+      package_command: pnpm package:tutti
+      package_dir: build/tutti-app/package
+      icon_path: build/tutti-app/package/icon.png
+      release_tag_prefix: <app-id>-v
+      release_bump: ${{ inputs.release_bump }}
+      create_release_tag: ${{ !inputs.catalog_only }}
+      runner: ubuntu-latest
+      pnpm_version: 10.26.2
+      aws_region: ${{ vars.TUTTI_APP_RELEASES_PRODUCTION_AWS_REGION || vars.TUTTI_APP_RELEASES_AWS_REGION }}
+      aws_role_arn: ${{ vars.TUTTI_APP_RELEASES_PRODUCTION_AWS_ROLE_ARN || vars.TUTTI_APP_RELEASES_AWS_ROLE_ARN }}
+      s3_bucket: ${{ vars.TUTTI_APP_RELEASES_PRODUCTION_S3_BUCKET || vars.TUTTI_APP_RELEASES_S3_BUCKET }}
+      s3_prefix: ${{ vars.TUTTI_APP_RELEASES_PRODUCTION_S3_PREFIX || vars.TUTTI_APP_RELEASES_S3_PREFIX }}
+      release_assets_base_url: ${{ vars.TUTTI_APP_RELEASES_PRODUCTION_BASE_URL || vars.TUTTI_APP_RELEASES_BASE_URL }}
+      publish_catalog: ${{ inputs.publish_catalog }}
+      catalog_only: ${{ inputs.catalog_only }}
+      catalog_cloudfront_distribution_id: ${{ vars.TUTTI_APP_RELEASES_PRODUCTION_CLOUDFRONT_DISTRIBUTION_ID || vars.TUTTI_APP_RELEASES_CLOUDFRONT_DISTRIBUTION_ID || '' }}
+```
+
+Use `macos-latest` only when packaging depends on macOS-only tooling. Prefer `ubuntu-latest` for web/server-only apps.
+
+## Staging Workflow Template
+
+Staging should not require semver bump or tag creation. It can publish a build-addressed release and optionally refresh the staging catalog.
+
+```yaml
+name: Publish Tutti App Staging
+
+on:
+  workflow_dispatch:
+    inputs:
+      publish_catalog:
+        description: Whether to publish the staging App Center catalog after this release.
+        required: false
+        type: boolean
+        default: false
+      catalog_only:
+        description: Whether to skip app release upload and only publish the existing latest release to staging catalog.
+        required: false
+        type: boolean
+        default: false
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  publish:
+    uses: tutti-os/tutti/.github/workflows/publish-tutti-app-release.yml@main
+    with:
+      app_id: <app-id>
+      package_command: pnpm package:tutti
+      package_dir: build/tutti-app/package
+      icon_path: build/tutti-app/package/icon.png
+      runner: ubuntu-latest
+      pnpm_version: 10.26.2
+      aws_region: ${{ vars.TUTTI_APP_RELEASES_STAGING_AWS_REGION || vars.TUTTI_APP_RELEASES_AWS_REGION }}
+      aws_role_arn: ${{ vars.TUTTI_APP_RELEASES_STAGING_AWS_ROLE_ARN || vars.TUTTI_APP_RELEASES_AWS_ROLE_ARN }}
+      s3_bucket: ${{ vars.TUTTI_APP_RELEASES_STAGING_S3_BUCKET || vars.TUTTI_APP_RELEASES_S3_BUCKET }}
+      s3_prefix: ${{ vars.TUTTI_APP_RELEASES_STAGING_S3_PREFIX || 'tutti-app-releases-staging' }}
+      release_assets_base_url: ${{ vars.TUTTI_APP_RELEASES_STAGING_BASE_URL || vars.TUTTI_APP_RELEASES_BASE_URL }}
+      publish_catalog: ${{ inputs.publish_catalog }}
+      catalog_only: ${{ inputs.catalog_only }}
+      catalog_cloudfront_distribution_id: ${{ vars.TUTTI_APP_RELEASES_STAGING_CLOUDFRONT_DISTRIBUTION_ID || vars.TUTTI_APP_RELEASES_CLOUDFRONT_DISTRIBUTION_ID || '' }}
+```
+
+## Variables
+
+Prefer organization-level GitHub Actions variables for shared Tutti release infrastructure so new app repositories can reuse the same workflows without copying repo-local configuration. Grant the organization variables only to repositories that are allowed to publish Tutti apps.
+
+Recommended organization variables:
+
+- `TUTTI_APP_RELEASES_AWS_REGION`
+- `TUTTI_APP_RELEASES_AWS_ROLE_ARN`
+- `TUTTI_APP_RELEASES_S3_BUCKET`
+- `TUTTI_APP_RELEASES_S3_PREFIX`
+- `TUTTI_APP_RELEASES_BASE_URL`
+- `TUTTI_APP_RELEASES_CLOUDFRONT_DISTRIBUTION_ID`
+- `TUTTI_APP_RELEASES_STAGING_AWS_REGION`
+- `TUTTI_APP_RELEASES_STAGING_AWS_ROLE_ARN`
+- `TUTTI_APP_RELEASES_STAGING_S3_BUCKET`
+- `TUTTI_APP_RELEASES_STAGING_S3_PREFIX`
+- `TUTTI_APP_RELEASES_STAGING_BASE_URL`
+- `TUTTI_APP_RELEASES_STAGING_CLOUDFRONT_DISTRIBUTION_ID`
+- `TUTTI_APP_RELEASES_PRODUCTION_AWS_REGION`
+- `TUTTI_APP_RELEASES_PRODUCTION_AWS_ROLE_ARN`
+- `TUTTI_APP_RELEASES_PRODUCTION_S3_BUCKET`
+- `TUTTI_APP_RELEASES_PRODUCTION_S3_PREFIX`
+- `TUTTI_APP_RELEASES_PRODUCTION_BASE_URL`
+- `TUTTI_APP_RELEASES_PRODUCTION_CLOUDFRONT_DISTRIBUTION_ID`
+
+Use repository-level variables only for app-specific overrides, migration periods, or repositories that publish to a separate bucket, prefix, base URL, or role. Do not create long-lived AWS secrets for this flow; the release workflow uses GitHub OIDC with `id-token: write` and an AWS role ARN.
+
+## Validation
+
+Before considering the release workflows ready:
+
+- Run `pnpm package:tutti` locally or in CI.
+- Confirm `package_dir` contains `tutti.app.json`, `bootstrap.sh`, icon assets, built web assets, server bundle, and locales.
+- Confirm the app id in `tutti.app.json`, `app_id`, and `release_tag_prefix` are consistent.
+- Confirm the selected runner can build the app package.
+- Confirm the organization or repository variables are visible to the app repository.
+- Run the staging workflow first, then production only after the staging release and optional staging catalog are verified.

--- a/services/tuttid/service/workspace/agent_workspace_app_reference/references/i18n-and-web-debugging.md
+++ b/services/tuttid/service/workspace/agent_workspace_app_reference/references/i18n-and-web-debugging.md
@@ -1,0 +1,62 @@
+# I18n And Web Debugging
+
+Use this reference for UI copy, language behavior, and web-first validation.
+
+## I18n Rules
+
+For larger React apps, prefer `i18next`, `react-i18next`, and `i18next-cli`.
+
+- All user-visible web copy should use `t(...)`, `i18n.t(...)`, or a translated data source.
+- Update every supported locale when adding or changing a key.
+- Keep interpolation inside i18n resources.
+- Allowlist only product names, provider/model labels, technical identifiers, file extensions, keyboard shortcuts, route names, and user-generated content.
+- Do not introduce locale-prefixed routes or server-cookie rendering dependencies unless the app already uses them.
+- App-local language switching must not mutate the host application's global language.
+
+For app package manifest metadata, use `tutti.app.json` `localizationInfo` and package-local `locales/<locale>/manifest.json` files per `$tutti-workspace-app-factory`.
+
+For smaller generated apps, use the factory skill's `references/i18n-harness.md`. For larger repos, add an app-level check similar to:
+
+```bash
+pnpm check:i18n
+```
+
+The check should verify:
+
+- each locale has the same flattened key set
+- every `t("key")` reference exists in every locale
+- TSX/JSX visible copy is translated or allowlisted
+- extracted keys do not leave unstaged translation drift in CI
+
+## Locale Source
+
+Locale may come from the app's own route or language switcher. When no app-local locale is set, read optional Tutti host app context and then fall back to browser locale APIs.
+
+Do not read host locale from launch URL query parameters.
+
+## Web-First Debugging
+
+Prioritize web scenarios:
+
+1. Run the local dev app.
+2. Open the web UI and exercise the workflow there first.
+3. Keep browser-visible state aligned with `packages/shared` contracts.
+4. Add Playwright tests only for user flows that cross web/server boundaries.
+5. Use server smoke tests for storage, runtime providers, local agents, CLI routes, and package generation.
+
+Useful checks:
+
+```bash
+pnpm check
+pnpm typecheck
+pnpm test
+pnpm check:i18n
+pnpm package:tutti
+```
+
+When local agents are involved:
+
+1. Run provider detection.
+2. Verify the web settings/runtime panel or equivalent status UI.
+3. Run isolated smoke tests for real Codex/Claude turns.
+4. Inspect run events, tool calls, generated files, and package-local data writes.

--- a/services/tuttid/service/workspace/agent_workspace_app_reference/references/package-builder.md
+++ b/services/tuttid/service/workspace/agent_workspace_app_reference/references/package-builder.md
@@ -57,6 +57,8 @@ Keep install/build work out of `bootstrap.sh`; use `prepare.sh` only when prepar
 
 ## CLI Surface
 
+If the user asks to connect the app to the Tutti ecosystem, the app must expose a `tutti.cli.json` surface and declare it from `tutti.app.json`. Do not skip CLI integration as optional in that case. If the app has no obvious domain action yet, expose a small useful command such as `status`, `summary`, or `open-context` that proves the app is discoverable and callable.
+
 If the app exposes `tutti.cli.json`:
 
 - Use `schemaVersion: "tutti.app.cli.v1"`.

--- a/services/tuttid/service/workspace/agent_workspace_app_reference/references/package-builder.md
+++ b/services/tuttid/service/workspace/agent_workspace_app_reference/references/package-builder.md
@@ -1,0 +1,87 @@
+# Package Builder
+
+Use this reference when adding or changing an app-owned `scripts/package-tutti-app.mjs`.
+
+## Role
+
+The app repository owns build orchestration. `$tutti-workspace-app-factory` owns the final package contract. Do not fork manifest/runtime rules; read the factory skill before changing package outputs.
+
+## Builder Responsibilities
+
+The package builder should:
+
+- Run or depend on app build outputs for shared, web, and server code.
+- Bundle server code for the managed Node runtime.
+- Bundle worker and MCP entrypoints when the app needs background jobs or local agent tools.
+- Generate or copy `tutti.app.json`.
+- Generate or copy `tutti.cli.json` only when the app manifest declares `cli.manifest`.
+- Generate executable `bootstrap.sh`.
+- Include package-local `AGENTS.md`, optional `COMMANDS.md`, icons, locales, docs needed by agents, built web assets, and server bundle.
+- Reject symlinks and missing required files.
+- Validate package manifest, CLI manifest linkage, references endpoint linkage, and bootstrap executability.
+
+## Bootstrap
+
+Generated `bootstrap.sh` should:
+
+- Resolve `TUTTI_APP_PACKAGE_DIR`, defaulting to its own directory for local direct startup.
+- Export app-specific env vars from Tutti runtime env vars.
+- Use `TUTTI_APP_NODE` instead of bare `node`.
+- Use `TUTTI_APP_DATA_DIR`, `TUTTI_APP_RUNTIME_DIR`, and `TUTTI_APP_LOG_DIR` for mutable files.
+- Set a package-local path for bundled MCP tools when local agents need them.
+- Start all required child processes and clean them up on `INT`/`TERM`.
+
+Pattern:
+
+```sh
+#!/bin/sh
+set -eu
+
+script_dir=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+package_dir="${TUTTI_APP_PACKAGE_DIR:-$script_dir}"
+
+export HOST="${TUTTI_APP_HOST:-127.0.0.1}"
+export APP_PORT="${TUTTI_APP_PORT:-3001}"
+export APP_DATA_ROOT="${TUTTI_APP_DATA_DIR:-$package_dir/.data}"
+export APP_RUNTIME_ROOT="${TUTTI_APP_RUNTIME_DIR:-$APP_DATA_ROOT/.runtime}"
+export APP_WEB_DIST="$package_dir/dist"
+export APP_TOOLS_MCP_PATH="$package_dir/server/tools-mcp.js"
+
+node_bin="${TUTTI_APP_NODE:-node}"
+mkdir -p "$APP_DATA_ROOT" "$APP_RUNTIME_ROOT"
+
+"$node_bin" "$package_dir/server/server.js"
+```
+
+Keep install/build work out of `bootstrap.sh`; use `prepare.sh` only when preparation is required.
+
+## CLI Surface
+
+If the app exposes `tutti.cli.json`:
+
+- Use `schemaVersion: "tutti.app.cli.v1"`.
+- Keep `scope` lowercase letters, numbers, and hyphen.
+- Every command path must be non-empty and not repeat the scope.
+- Every command needs `summary`, `description`, object `inputSchema`, and HTTP `POST` handler.
+- Handler paths should be deterministic: `/tutti/cli/${command.path.join("/")}`.
+- Route handlers must call shared use-case helpers, not duplicate business logic from `/api/*`.
+- Add `COMMANDS.md` or equivalent documentation when the app has many commands.
+
+## Validation
+
+Package tests should assert:
+
+- Required package files exist.
+- `bootstrap.sh` is executable.
+- `tutti.app.json` does not declare `runtime.kind`.
+- CLI manifest exists when declared.
+- CLI command handler paths start with `/tutti/cli/` and match command paths.
+- Manifest localization files exist.
+- No symlinks are present.
+- Packaged server starts and `/api/health` or the manifest healthcheck path returns 2xx.
+
+Run the factory validator against the generated package:
+
+```bash
+python3 <factory-skill>/scripts/validate_tutti_app_package.py build/tutti-app/package
+```

--- a/services/tuttid/service/workspace/app_factory_reference/SKILL.md
+++ b/services/tuttid/service/workspace/app_factory_reference/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: tutti-workspace-app-factory
-description: "Create or repair a self-contained Tutti workspace app package from a user request. Use for mention://workspace-app-factory/create handoffs, mention://workspace-app-factory handoffs, standalone Tutti workspace app generation, repair, validation, manifests, bootstrap scripts, package-local AGENTS.md, local HTTP runtimes, healthchecks, app assets, optional app-runtime Tutti CLI integration, and TUTTI_APP_* storage rules."
+description: "Create, convert, or repair a self-contained Tutti workspace app package from a user request or existing repository. Use for mention://workspace-app-factory/create handoffs, mention://workspace-app-factory handoffs, standalone Tutti workspace app generation, adapting existing projects into Tutti packages, repair, validation, manifests, bootstrap scripts, package-local AGENTS.md, local HTTP runtimes, healthchecks, app assets, optional app-runtime Tutti CLI integration, and TUTTI_APP_* storage rules."
 ---
 
 # Tutti Workspace App Factory
 
-Use this skill to create or repair one Tutti workspace app package. The app package must be self-contained, runnable by the Tutti custom app runtime, and safe to copy into a workspace app archive.
+Use this skill to create, convert, or repair one Tutti workspace app package. The app package must be self-contained, runnable by the Tutti custom app runtime, and safe to copy into a workspace app archive.
 
 ## Version Check And Update Reminder
 
@@ -43,7 +43,7 @@ Before generating, repairing, or validating an app package, perform a best-effor
 
 If the current working directory contains `context.json`, or the task includes `mention://workspace-app-factory/create` or `mention://workspace-app-factory`, operate in Tutti factory handoff mode. Read `context.json` before writing files, then follow its metadata, output rules, workspace context, and constraints exactly. Do not copy the context file into generated app outputs.
 
-If `context.json` is absent, operate in standalone mode. Treat the current working directory as the app authoring workspace, create the app package under `package/`, and infer missing metadata conservatively from the user request.
+If `context.json` is absent, operate in standalone mode. Treat the current working directory as the app authoring workspace. If the directory already contains an app or repository, adapt it into a Tutti package under `package/`; otherwise create a new package under `package/`. Infer missing metadata conservatively from the user request.
 
 The package root is the only generated app output directory; files outside it are scratch or coordination files and will not be published.
 
@@ -111,6 +111,19 @@ Avoid startup-time package installation. If dependencies or build artifacts are 
 Generated apps must not rely on system `python`, `python3`, `node`, or `npm` commands. Use the explicit managed runtime environment variables instead.
 
 Keep generated apps small and inspectable. Do not add frameworks, background workers, databases, or network services unless they are required by the user request.
+
+## Conversion Workflow
+
+When converting an existing repository into a Tutti workspace app package:
+
+1. Inspect the repository shape first: package manifests, lockfiles, source directories, existing start/build scripts, ports, static assets, storage paths, and localization files.
+2. Prefer a wrapper package under `package/` that copies or references the smallest runnable subset of the existing project. Do not rewrite the original repository outside `package/` unless the user explicitly asks.
+3. Translate the existing start command into `bootstrap.sh`. If the project needs install or build work, put that in executable `prepare.sh` and keep `bootstrap.sh` launch-only.
+4. Replace hard-coded host, port, data, runtime, and log paths with the Tutti runtime environment variables from `references/runtime-env.md`.
+5. If the project already exposes commands, convert the stable user-facing commands into `tutti.cli.json`; otherwise omit `cli`.
+6. If the project already has localized metadata or UI copy, preserve it using `localizationInfo` for manifest metadata and app-owned locale files or dictionaries for in-app copy.
+7. Document the adapted layout, original project entrypoints, runtime command, storage ownership, and any unsupported original features in package `AGENTS.md`.
+8. Validate the converted package against `references/validation-checklist.md`.
 
 ## Implementation Workflow
 

--- a/services/tuttid/service/workspace/app_factory_reference/SKILL.md
+++ b/services/tuttid/service/workspace/app_factory_reference/SKILL.md
@@ -56,6 +56,7 @@ Before writing files, read these bundled references:
 - `references/manifest-contract.md` for `tutti.app.json`.
 - `references/cli-manifest-contract.md` for optional `tutti.cli.json`.
 - `references/runtime-env.md` for runtime environment variables and storage ownership.
+- `references/i18n-harness.md` when the app has localized metadata, user-facing in-app copy, or an existing localization system.
 - `references/tutti-cli-commands.md` when the generated app runtime should call, combine, or expose local Tutti CLI capabilities.
 - `references/validation-checklist.md` for completion checks.
 
@@ -70,6 +71,7 @@ Create or update these files under `output.packageRoot` from the context in hand
 - `bootstrap.sh`: executable shell entrypoint that starts the app server with no arguments.
 - `AGENTS.md`: package-local guidance describing layout, runtime command, endpoints, data storage, and modification rules.
 - `locales/<locale>/manifest.json`: manifest metadata localization files, only when the user asks for localized app metadata.
+- App-owned locale dictionaries or an i18n helper/harness when the app has user-facing in-app copy in more than one language.
 - App implementation files and assets needed for the requested behavior.
 
 If the task supplies exact metadata such as `appId`, version, display name, or description, copy those values exactly into `tutti.app.json`. If metadata is missing, choose conservative defaults:
@@ -99,6 +101,7 @@ The runtime must:
 - Launch Python with `$TUTTI_APP_PYTHON` and Node with `$TUTTI_APP_NODE`; use `$TUTTI_APP_NPM` for npm install/build work.
 - When the generated app calls another local Tutti capability at runtime, use `$TUTTI_CLI` and follow `references/tutti-cli-commands.md`.
 - Read the current UI locale from the optional host-injected app context when localized in-app copy is needed. Do not pass locale in the launch URL query.
+- Keep localized in-app copy behind stable keys and use the harness pattern in `references/i18n-harness.md` so future edits can check locale parity.
 - Use CSS `prefers-color-scheme` / `matchMedia("(prefers-color-scheme: dark)")` for dark/light rendering. Do not pass theme in the launch URL query.
 - When exposing app-owned files through references or generated content, return reference-list `location` objects scoped to `app-data-relative` or `app-package-relative`. Do not emit, persist, or instruct clients to open direct `.tutti` / `.tutti-dev` app state paths such as `$TUTTI_STATE_DIR/apps/...`; the daemon resolves valid locations before desktop clients open files.
 
@@ -121,7 +124,7 @@ When converting an existing repository into a Tutti workspace app package:
 3. Translate the existing start command into `bootstrap.sh`. If the project needs install or build work, put that in executable `prepare.sh` and keep `bootstrap.sh` launch-only.
 4. Replace hard-coded host, port, data, runtime, and log paths with the Tutti runtime environment variables from `references/runtime-env.md`.
 5. If the project already exposes commands, convert the stable user-facing commands into `tutti.cli.json`; otherwise omit `cli`.
-6. If the project already has localized metadata or UI copy, preserve it using `localizationInfo` for manifest metadata and app-owned locale files or dictionaries for in-app copy.
+6. If the project already has localized metadata or UI copy, preserve it using `localizationInfo` for manifest metadata and the i18n harness from `references/i18n-harness.md` for in-app copy.
 7. Document the adapted layout, original project entrypoints, runtime command, storage ownership, and any unsupported original features in package `AGENTS.md`.
 8. Validate the converted package against `references/validation-checklist.md`.
 
@@ -131,7 +134,7 @@ When converting an existing repository into a Tutti workspace app package:
 2. Decide the smallest runtime shape that satisfies the requested behavior.
 3. Write the manifest, bootstrap script, package guidance, and app files.
 4. Make `bootstrap.sh` executable.
-5. Validate against `references/validation-checklist.md`.
+5. Run `scripts/validate_tutti_app_package.py <package-root>` when available, then validate remaining runtime behavior against `references/validation-checklist.md`.
 6. Fix any validation failure before finishing.
 
 ## Repair Workflow

--- a/services/tuttid/service/workspace/app_factory_reference/SKILL.md
+++ b/services/tuttid/service/workspace/app_factory_reference/SKILL.md
@@ -56,7 +56,7 @@ Treat a `mention://workspace-app-factory/create` or `mention://workspace-app-fac
 Before writing files, read these bundled references:
 
 - `references/manifest-contract.md` for `tutti.app.json`.
-- `references/cli-manifest-contract.md` for optional `tutti.cli.json`.
+- `references/cli-manifest-contract.md` for `tutti.cli.json` when exposing app capabilities to the Tutti ecosystem.
 - `references/runtime-env.md` for runtime environment variables and storage ownership.
 - `references/i18n-harness.md` when the app has localized metadata, user-facing in-app copy, or an existing localization system.
 - `references/tutti-cli-commands.md` when the generated app runtime should call, combine, or expose local Tutti CLI capabilities.
@@ -69,7 +69,7 @@ Read `references/demos/simple-python-static-app/` only when you need a concrete 
 Create or update these files under `output.packageRoot` from the context in handoff mode, or under `package/` in standalone mode:
 
 - `tutti.app.json`: valid JSON manifest matching `references/manifest-contract.md`.
-- `tutti.cli.json`: optional CLI manifest matching `references/cli-manifest-contract.md`, only when `tutti.app.json` declares `cli.manifest`.
+- `tutti.cli.json`: CLI manifest matching `references/cli-manifest-contract.md`, required when the user asks to connect the app to the Tutti ecosystem; otherwise create it only when `tutti.app.json` declares `cli.manifest`.
 - `bootstrap.sh`: executable shell entrypoint that starts the app server with no arguments.
 - `AGENTS.md`: package-local guidance describing layout, runtime command, endpoints, data storage, and modification rules.
 - `locales/<locale>/manifest.json`: manifest metadata localization files, only when the user asks for localized app metadata.
@@ -86,6 +86,8 @@ If the task supplies exact metadata such as `appId`, version, display name, or d
 - `runtime.bootstrap`: `bootstrap.sh`
 - `runtime.healthcheckPath`: `/healthz`
 - `localizationInfo`: omit unless the user asks for localized app metadata; when needed, follow `references/manifest-contract.md` and create each referenced locale file.
+
+If the user asks to connect the app to the Tutti ecosystem, expose at least one app capability through `tutti.cli.json` and declare it from `tutti.app.json`. If the app has no obvious domain command yet, add a small useful command such as `status`, `summary`, or `open-context` so other Tutti apps and agents can discover and call it.
 
 ## Runtime Rules
 
@@ -125,7 +127,7 @@ When converting an existing repository into a Tutti workspace app package:
 2. Prefer a wrapper package under `package/` that copies or references the smallest runnable subset of the existing project. Do not rewrite the original repository outside `package/` unless the user explicitly asks.
 3. Translate the existing start command into `bootstrap.sh`. If the project needs install or build work, put that in executable `prepare.sh` and keep `bootstrap.sh` launch-only.
 4. Replace hard-coded host, port, data, runtime, and log paths with the Tutti runtime environment variables from `references/runtime-env.md`.
-5. If the project already exposes commands, convert the stable user-facing commands into `tutti.cli.json`; otherwise omit `cli`.
+5. If the user asks to connect the app to the Tutti ecosystem, expose stable app capabilities through `tutti.cli.json`; otherwise, if the project already exposes commands, convert the stable user-facing commands into `tutti.cli.json`.
 6. If the project already has localized metadata or UI copy, preserve it using `localizationInfo` for manifest metadata and the i18n harness from `references/i18n-harness.md` for in-app copy.
 7. Document the adapted layout, original project entrypoints, runtime command, storage ownership, and any unsupported original features in package `AGENTS.md`.
 8. Validate the converted package against `references/validation-checklist.md`.

--- a/services/tuttid/service/workspace/app_factory_reference/SKILL.md
+++ b/services/tuttid/service/workspace/app_factory_reference/SKILL.md
@@ -7,6 +7,8 @@ description: "Create, convert, or repair a self-contained Tutti workspace app pa
 
 Use this skill to create, convert, or repair one Tutti workspace app package. The app package must be self-contained, runnable by the Tutti custom app runtime, and safe to copy into a workspace app archive.
 
+For a full agent-enabled Tutti app repository with `apps/web`, `apps/server`, `packages/shared`, `@tutti-os/agent-acp-kit`, local Codex/Claude runtimes, MCP tool gateways, and an app-owned package builder, use `$tutti-agent-workspace-app` first. Return to this skill for the final package contract and validation.
+
 ## Version Check And Update Reminder
 
 Before generating, repairing, or validating an app package, perform a best-effort freshness check unless the user asks to skip network access or the environment is offline.

--- a/services/tuttid/service/workspace/app_factory_reference/SKILL.md
+++ b/services/tuttid/service/workspace/app_factory_reference/SKILL.md
@@ -1,19 +1,55 @@
 ---
 name: tutti-workspace-app-factory
-description: "Create or repair a self-contained Tutti workspace app package from a user request. Use for mention://workspace-app-factory/create handoffs, Tutti workspace app generation, repair, validation, manifests, bootstrap scripts, package-local AGENTS.md, local HTTP runtimes, healthchecks, app assets, optional app-runtime Tutti CLI integration, and TUTTI_APP_* storage rules."
+description: "Create or repair a self-contained Tutti workspace app package from a user request. Use for mention://workspace-app-factory/create handoffs, mention://workspace-app-factory handoffs, standalone Tutti workspace app generation, repair, validation, manifests, bootstrap scripts, package-local AGENTS.md, local HTTP runtimes, healthchecks, app assets, optional app-runtime Tutti CLI integration, and TUTTI_APP_* storage rules."
 ---
 
 # Tutti Workspace App Factory
 
 Use this skill to create or repair one Tutti workspace app package. The app package must be self-contained, runnable by the Tutti custom app runtime, and safe to copy into a workspace app archive.
 
+## Version Check And Update Reminder
+
+Before generating, repairing, or validating an app package, perform a best-effort freshness check unless the user asks to skip network access or the environment is offline.
+
+1. Fetch the current published skill body:
+
+   ```text
+   https://raw.githubusercontent.com/tutti-os/tutti-agent-skills/main/skills/tutti-workspace-app-factory/SKILL.md
+   ```
+
+2. Compare the fetched content with the local `SKILL.md` that loaded this skill. Prefer a content hash comparison when filesystem access is available. If the local skill path is unavailable, fetch the latest repository commit instead:
+
+   ```text
+   https://api.github.com/repos/tutti-os/tutti-agent-skills/commits?per_page=1
+   ```
+
+3. If the published skill differs from the local copy, state this at the start of the reply before doing other work:
+
+   ```text
+   This Tutti skill has a newer version available. I can continue with the currently loaded copy, but updating first is recommended so the latest manifest rules and runtime guidance are used.
+
+   Update the Codex plugin marketplace:
+   codex plugin marketplace upgrade tutti-agent-skills
+
+   Update the direct skill install:
+   npx --yes skills add tutti-os/tutti-agent-skills
+   ```
+
+4. If the user has explicitly asked to update local installs, or if the current task is itself about keeping the skill current, run the update commands that are available in the environment before continuing. Tell the user that newly installed skill content may take effect only after the next skill reload or new session.
+
+5. If the freshness check fails because network access, GitHub, `codex`, or `npx` is unavailable, mention the check was skipped or failed briefly and continue the requested Tutti app work.
+
 ## Required Context
 
-Treat the current working directory as the factory job workspace. The app package must be created under the package root named by the mention context `output.packageRoot`, normally `package/`. The package root is the only generated app output directory; files outside it are scratch or coordination files and will not be published.
+If the current working directory contains `context.json`, or the task includes `mention://workspace-app-factory/create` or `mention://workspace-app-factory`, operate in Tutti factory handoff mode. Read `context.json` before writing files, then follow its metadata, output rules, workspace context, and constraints exactly. Do not copy the context file into generated app outputs.
+
+If `context.json` is absent, operate in standalone mode. Treat the current working directory as the app authoring workspace, create the app package under `package/`, and infer missing metadata conservatively from the user request.
+
+The package root is the only generated app output directory; files outside it are scratch or coordination files and will not be published.
 
 ## Mention Contract
 
-Treat a `mention://workspace-app-factory/create` link as the factory handoff. Before writing files, read `context.json` from the current working directory. Use its exact metadata, output rules, workspace context, and constraints as authoritative. Do not copy the context file into generated app outputs.
+Treat a `mention://workspace-app-factory/create` or `mention://workspace-app-factory` link as the factory handoff. In handoff mode, use the exact metadata, output rules, workspace context, and constraints from `context.json` as authoritative.
 
 Before writing files, read these bundled references:
 
@@ -27,7 +63,7 @@ Read `references/demos/simple-python-static-app/` only when you need a concrete 
 
 ## Output Contract
 
-Create or update these files under `output.packageRoot` from the context, normally `package/`:
+Create or update these files under `output.packageRoot` from the context in handoff mode, or under `package/` in standalone mode:
 
 - `tutti.app.json`: valid JSON manifest matching `references/manifest-contract.md`.
 - `tutti.cli.json`: optional CLI manifest matching `references/cli-manifest-contract.md`, only when `tutti.app.json` declares `cli.manifest`.

--- a/services/tuttid/service/workspace/app_factory_reference/agents/openai.yaml
+++ b/services/tuttid/service/workspace/app_factory_reference/agents/openai.yaml
@@ -1,0 +1,7 @@
+interface:
+  display_name: "Tutti Workspace App Factory"
+  short_description: "Create Tutti workspace app packages"
+  default_prompt: "Use $tutti-workspace-app-factory to create or repair a self-contained Tutti workspace app package."
+
+policy:
+  allow_implicit_invocation: true

--- a/services/tuttid/service/workspace/app_factory_reference/agents/openai.yaml
+++ b/services/tuttid/service/workspace/app_factory_reference/agents/openai.yaml
@@ -1,7 +1,7 @@
 interface:
   display_name: "Tutti Workspace App Factory"
-  short_description: "Create Tutti workspace app packages"
-  default_prompt: "Use $tutti-workspace-app-factory to create or repair a self-contained Tutti workspace app package."
+  short_description: "Create or convert Tutti workspace app packages"
+  default_prompt: "Use $tutti-workspace-app-factory to convert this repository into a Tutti workspace app package."
 
 policy:
   allow_implicit_invocation: true

--- a/services/tuttid/service/workspace/app_factory_reference/references/cli-manifest-contract.md
+++ b/services/tuttid/service/workspace/app_factory_reference/references/cli-manifest-contract.md
@@ -1,6 +1,6 @@
 # Tutti App CLI Manifest Contract
 
-Create `tutti.cli.json` only when `tutti.app.json` declares:
+Create `tutti.cli.json` when the app exposes capabilities to the Tutti ecosystem. The app manifest must declare:
 
 ```json
 {
@@ -51,6 +51,7 @@ Shape:
 Rules:
 
 - `scope` is required and may differ from `appId`.
+- If the user asks to connect the app to the Tutti ecosystem, `tutti.cli.json` is required and must expose at least one useful command.
 - `scope` and every command path segment must use lowercase letters, numbers, and hyphen only.
 - `description` is optional. When present, it describes the CLI scope as a whole for app-level discovery surfaces such as `tutti --help` and `@app` mentions.
 - Command `path` must not repeat `scope`.

--- a/services/tuttid/service/workspace/app_factory_reference/references/i18n-harness.md
+++ b/services/tuttid/service/workspace/app_factory_reference/references/i18n-harness.md
@@ -1,0 +1,117 @@
+# I18n Harness
+
+Use this reference when an app has localized manifest metadata, user-facing in-app copy, or an existing localization system being converted into a Tutti package.
+
+## Goals
+
+- Keep all user-facing in-app copy behind stable keys.
+- Preserve a default locale and every requested or existing non-default locale.
+- Make missing or extra locale keys easy to detect during future edits.
+- Read the current locale from the optional Tutti browser context or browser locale APIs, never from launch URL query parameters.
+
+## Package Pattern
+
+Prefer package-local JSON dictionaries when creating new apps:
+
+```text
+package/
+  locales/
+    en/
+      manifest.json
+      app.json
+    zh-CN/
+      manifest.json
+      app.json
+  static/
+    i18n.js
+```
+
+Use `locales/<locale>/manifest.json` only for manifest metadata referenced by `tutti.app.json` `localizationInfo`. Use `locales/<locale>/app.json` or an equivalent app-owned dictionary for browser UI copy.
+
+For converted projects, keep the existing framework i18n layout if it already has reliable key parity checks. Otherwise normalize the adapted package to the JSON dictionary pattern above.
+
+## Browser Harness
+
+The app should have one small helper that:
+
+1. Defines the supported locales and default locale.
+2. Normalizes language tags such as `zh-CN`, `zh_Hans`, and `en-US`.
+3. Reads locale from `window.tuttiExternal?.app?.getContext()`.
+4. Subscribes to `window.tuttiExternal?.app?.subscribe()` for later locale changes.
+5. Falls back to `document.documentElement.lang`, `navigator.languages`, and `navigator.language`.
+6. Resolves copy through keyed dictionaries with default-locale fallback.
+7. Exposes a small development/test function that checks every locale has the same flattened key set as the default locale.
+
+Minimal helper shape:
+
+```js
+const defaultLocale = "en";
+const supportedLocales = ["en", "zh-CN"];
+const messages = {
+  en: {
+    "app.title": "Display name",
+    "app.empty": "No items yet."
+  },
+  "zh-CN": {
+    "app.title": "显示名称",
+    "app.empty": "暂无项目。"
+  }
+};
+
+function normalizeLocale(value) {
+  const tag = String(value || "")
+    .trim()
+    .replace(/_/g, "-");
+  if (!tag) return defaultLocale;
+  const exact = supportedLocales.find(
+    (locale) => locale.toLowerCase() === tag.toLowerCase()
+  );
+  if (exact) return exact;
+  const language = tag.split("-")[0].toLowerCase();
+  return (
+    supportedLocales.find(
+      (locale) => locale.split("-")[0].toLowerCase() === language
+    ) || defaultLocale
+  );
+}
+
+function t(key) {
+  const locale = normalizeLocale(document.documentElement.lang);
+  return messages[locale]?.[key] || messages[defaultLocale]?.[key] || key;
+}
+
+function assertI18nParity() {
+  const baseKeys = Object.keys(messages[defaultLocale]).sort();
+  for (const locale of supportedLocales) {
+    const keys = Object.keys(messages[locale] || {}).sort();
+    const missing = baseKeys.filter((key) => !keys.includes(key));
+    const extra = keys.filter((key) => !baseKeys.includes(key));
+    if (missing.length || extra.length) {
+      throw new Error(
+        `${locale} i18n mismatch: missing=${missing.join(",")} extra=${extra.join(",")}`
+      );
+    }
+  }
+}
+```
+
+For JSON dictionaries, `scripts/validate_tutti_app_package.py` performs a static key-parity check for matching dictionary files under `locales/<locale>/`.
+
+## AGENTS.md Guidance
+
+Document the app's i18n harness in package `AGENTS.md`:
+
+- Default locale and supported locales.
+- Where manifest metadata translations live.
+- Where in-app copy dictionaries live.
+- How to add or rename a copy key.
+- The command to run the package validator.
+
+## Validation
+
+Before finishing:
+
+- All localized manifest files referenced by `localizationInfo` exist.
+- All app-owned locale dictionaries have the same flattened key set as the default locale.
+- No UI text that should be localized is introduced outside the dictionary/helper pattern.
+- Locale is read from Tutti app context or browser locale APIs, not URL query params.

--- a/services/tuttid/service/workspace/app_factory_reference/references/validation-checklist.md
+++ b/services/tuttid/service/workspace/app_factory_reference/references/validation-checklist.md
@@ -2,10 +2,13 @@
 
 Before finishing:
 
+- Run `scripts/validate_tutti_app_package.py <package-root>` from this skill when filesystem access is available.
 - `tutti.app.json` is valid JSON and matches the manifest contract.
 - If `tutti.app.json` declares `cli.manifest`, the referenced CLI manifest exists and matches the CLI manifest contract.
 - The manifest icon `src` points to an existing package-local asset.
 - If `localizationInfo` is present, every `additionalLocales[].file` points to an existing package-local JSON file with localized manifest metadata.
+- If the app has localized in-app copy, app-owned locale dictionaries use stable keys and each locale has the same flattened key set as the default locale.
+- The package `AGENTS.md` explains how future maintainers add or rename localized copy keys.
 - `bootstrap.sh` is executable.
 - `bootstrap.sh` starts a server with no arguments.
 - `bootstrap.sh` launches the prepared app and does not install dependencies.

--- a/services/tuttid/service/workspace/app_factory_reference/scripts/validate_tutti_app_package.py
+++ b/services/tuttid/service/workspace/app_factory_reference/scripts/validate_tutti_app_package.py
@@ -1,0 +1,257 @@
+#!/usr/bin/env python3
+"""Static validator for Tutti workspace app packages."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import stat
+import sys
+from pathlib import Path
+from typing import Any
+
+
+BARE_RUNTIME_RE = re.compile(r"(^|[;&|`(]\s*|\s)(python3?|node|npm)(\s|$)")
+URL_SETTING_RE = re.compile(
+    r"(URLSearchParams|searchParams).*?(locale|lang|theme)|(locale|lang|theme).*?(URLSearchParams|searchParams)",
+    re.IGNORECASE,
+)
+
+
+def load_json(path: Path, errors: list[str]) -> Any:
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except FileNotFoundError:
+        errors.append(f"Missing file: {path}")
+    except json.JSONDecodeError as exc:
+        errors.append(f"Invalid JSON in {path}: {exc}")
+    return None
+
+
+def is_safe_relative_path(value: Any) -> bool:
+    if not isinstance(value, str) or not value:
+        return False
+    path = Path(value)
+    if path.is_absolute():
+        return False
+    if "://" in value or "\x00" in value:
+        return False
+    return ".." not in path.parts
+
+
+def flatten_keys(value: Any, prefix: str = "") -> set[str]:
+    if isinstance(value, dict):
+        keys: set[str] = set()
+        for key, nested in value.items():
+            next_prefix = f"{prefix}.{key}" if prefix else str(key)
+            keys.update(flatten_keys(nested, next_prefix))
+        return keys
+    return {prefix}
+
+
+def validate_manifest(root: Path, errors: list[str]) -> dict[str, Any] | None:
+    manifest_path = root / "tutti.app.json"
+    manifest = load_json(manifest_path, errors)
+    if not isinstance(manifest, dict):
+        errors.append("tutti.app.json must be a JSON object")
+        return None
+
+    if manifest.get("schemaVersion") != "tutti.app.manifest.v1":
+        errors.append("tutti.app.json schemaVersion must be tutti.app.manifest.v1")
+    for field in ("appId", "version", "name", "description"):
+        if not isinstance(manifest.get(field), str) or not manifest.get(field):
+            errors.append(f"tutti.app.json requires non-empty string field: {field}")
+
+    icon = manifest.get("icon")
+    if not isinstance(icon, dict) or icon.get("type") != "asset" or not is_safe_relative_path(icon.get("src")):
+        errors.append("tutti.app.json icon must be an asset with a safe package-relative src")
+    elif not (root / icon["src"]).is_file():
+        errors.append(f"Manifest icon asset does not exist: {icon['src']}")
+
+    runtime = manifest.get("runtime")
+    if not isinstance(runtime, dict):
+        errors.append("tutti.app.json requires runtime object")
+    else:
+        if "kind" in runtime:
+            errors.append("runtime.kind is not supported; Tutti manages the runtime baseline")
+        bootstrap = runtime.get("bootstrap")
+        if not is_safe_relative_path(bootstrap):
+            errors.append("runtime.bootstrap must be a safe package-relative path")
+        elif not (root / bootstrap).is_file():
+            errors.append(f"runtime.bootstrap file does not exist: {bootstrap}")
+        healthcheck = runtime.get("healthcheckPath")
+        if not isinstance(healthcheck, str) or not healthcheck.startswith("/"):
+            errors.append("runtime.healthcheckPath must start with /")
+
+    cli = manifest.get("cli")
+    if cli is not None:
+        if not isinstance(cli, dict) or not is_safe_relative_path(cli.get("manifest")):
+            errors.append("cli.manifest must be a safe package-relative path")
+        elif not (root / cli["manifest"]).is_file():
+            errors.append(f"CLI manifest does not exist: {cli['manifest']}")
+
+    references = manifest.get("references")
+    if references is not None:
+        endpoint = references.get("listEndpoint") if isinstance(references, dict) else None
+        if not isinstance(endpoint, str) or not endpoint.startswith("/") or any(char in endpoint for char in "?#%"):
+            errors.append("references.listEndpoint must be a relative URL path without query, hash, or percent encoding")
+
+    localization = manifest.get("localizationInfo")
+    if localization is not None:
+        validate_localization_info(root, localization, errors)
+
+    return manifest
+
+
+def validate_localization_info(root: Path, localization: Any, errors: list[str]) -> None:
+    if not isinstance(localization, dict):
+        errors.append("localizationInfo must be an object")
+        return
+    if not isinstance(localization.get("defaultLocale"), str) or not localization.get("defaultLocale"):
+        errors.append("localizationInfo.defaultLocale must be a non-empty string")
+    locales = localization.get("additionalLocales")
+    if not isinstance(locales, list):
+        errors.append("localizationInfo.additionalLocales must be an array")
+        return
+    for entry in locales:
+        if not isinstance(entry, dict):
+            errors.append("Each localizationInfo.additionalLocales entry must be an object")
+            continue
+        locale = entry.get("locale")
+        file_name = entry.get("file")
+        if not isinstance(locale, str) or not locale:
+            errors.append("Each additional locale needs a locale string")
+        if not is_safe_relative_path(file_name):
+            errors.append(f"Locale {locale or '<unknown>'} file must be package-relative")
+            continue
+        locale_path = root / file_name
+        data = load_json(locale_path, errors)
+        if isinstance(data, dict):
+            for key in data:
+                if key not in {"name", "description", "tags"}:
+                    errors.append(f"{file_name} contains unsupported manifest localization key: {key}")
+
+
+def validate_cli_manifest(root: Path, manifest: dict[str, Any], errors: list[str]) -> None:
+    cli = manifest.get("cli")
+    if not isinstance(cli, dict) or not is_safe_relative_path(cli.get("manifest")):
+        return
+    cli_manifest = load_json(root / cli["manifest"], errors)
+    if not isinstance(cli_manifest, dict):
+        errors.append("CLI manifest must be a JSON object")
+        return
+    if cli_manifest.get("schemaVersion") != "tutti.app.cli.v1":
+        errors.append("CLI manifest schemaVersion must be tutti.app.cli.v1")
+    commands = cli_manifest.get("commands")
+    if not isinstance(commands, list):
+        errors.append("CLI manifest commands must be an array")
+        return
+    for index, command in enumerate(commands):
+        if not isinstance(command, dict):
+            errors.append(f"CLI command {index} must be an object")
+            continue
+        handler = command.get("handler")
+        if not isinstance(handler, dict):
+            errors.append(f"CLI command {command.get('name', index)} requires a handler")
+            continue
+        if handler.get("kind") != "http" or handler.get("method") != "POST":
+            errors.append(f"CLI command {command.get('name', index)} handler must be HTTP POST")
+        path = handler.get("path")
+        if not isinstance(path, str) or not path.startswith("/tutti/cli/"):
+            errors.append(f"CLI command {command.get('name', index)} handler path must start with /tutti/cli/")
+
+
+def validate_scripts(root: Path, manifest: dict[str, Any] | None, errors: list[str]) -> None:
+    script_names = {"bootstrap.sh", "prepare.sh"}
+    runtime = manifest.get("runtime") if isinstance(manifest, dict) else None
+    if isinstance(runtime, dict) and isinstance(runtime.get("bootstrap"), str):
+        script_names.add(runtime["bootstrap"])
+
+    for name in script_names:
+        path = root / name
+        if not path.exists():
+            if name == "bootstrap.sh":
+                errors.append("Missing bootstrap.sh")
+            continue
+        mode = path.stat().st_mode
+        if not mode & stat.S_IXUSR:
+            errors.append(f"{name} must be executable")
+        text = path.read_text(encoding="utf-8", errors="ignore")
+        for line_number, line in enumerate(text.splitlines(), start=1):
+            stripped = line.strip()
+            if not stripped or stripped.startswith("#"):
+                continue
+            if BARE_RUNTIME_RE.search(stripped) and "TUTTI_APP_" not in stripped:
+                errors.append(f"{name}:{line_number} uses bare runtime command; use TUTTI_APP_* variables")
+        if name == "bootstrap.sh" and re.search(r"\b(install|npm\s+i|npm\s+install|pip\s+install)\b", text):
+            errors.append("bootstrap.sh should launch only; move install/build work to prepare.sh")
+
+
+def validate_i18n_dictionaries(root: Path, errors: list[str]) -> None:
+    locales_dir = root / "locales"
+    if not locales_dir.is_dir():
+        return
+
+    by_file: dict[str, dict[str, set[str]]] = {}
+    for locale_dir in sorted(path for path in locales_dir.iterdir() if path.is_dir()):
+        for json_path in sorted(locale_dir.glob("*.json")):
+            if json_path.name == "manifest.json":
+                continue
+            data = load_json(json_path, errors)
+            if isinstance(data, dict):
+                by_file.setdefault(json_path.name, {})[locale_dir.name] = flatten_keys(data)
+
+    for file_name, locale_keys in by_file.items():
+        if len(locale_keys) < 2:
+            continue
+        default_locale = "en" if "en" in locale_keys else sorted(locale_keys)[0]
+        base = locale_keys[default_locale]
+        for locale, keys in sorted(locale_keys.items()):
+            missing = sorted(base - keys)
+            extra = sorted(keys - base)
+            if missing or extra:
+                errors.append(
+                    f"i18n key mismatch in {file_name} for {locale}: "
+                    f"missing={','.join(missing) or '-'} extra={','.join(extra) or '-'}"
+                )
+
+
+def validate_no_url_settings(root: Path, errors: list[str]) -> None:
+    for path in root.rglob("*"):
+        if path.is_dir() or path.suffix.lower() not in {".js", ".jsx", ".ts", ".tsx", ".html"}:
+            continue
+        text = path.read_text(encoding="utf-8", errors="ignore")
+        if URL_SETTING_RE.search(text):
+            errors.append(f"{path.relative_to(root)} appears to read locale/theme from URL search params")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("package_root", nargs="?", default="package")
+    args = parser.parse_args()
+
+    root = Path(args.package_root).resolve()
+    errors: list[str] = []
+    if not root.is_dir():
+        errors.append(f"Package root does not exist or is not a directory: {root}")
+    else:
+        manifest = validate_manifest(root, errors)
+        if manifest:
+            validate_cli_manifest(root, manifest, errors)
+        validate_scripts(root, manifest, errors)
+        validate_i18n_dictionaries(root, errors)
+        validate_no_url_settings(root, errors)
+
+    if errors:
+        print("Tutti app package validation failed:", file=sys.stderr)
+        for error in errors:
+            print(f"- {error}", file=sys.stderr)
+        return 1
+    print("Tutti app package validation passed.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

- add a PR preview workflow for `services/tuttid/service/workspace/app_factory_reference/**`
- add a post-merge sync workflow that opens/updates an external `tutti-os/tutti-agent-skills` PR and enables guarded auto-merge
- document the standalone skills + plugin repository plan
- align the workspace app factory skill with standalone `npx skills add` usage and add plugin agent metadata

External repository created: https://github.com/tutti-os/tutti-agent-skills

## Sync model

PR phase in this repository:
- validate and preview the extracted skill repository
- upload the generated repository as an artifact
- comment on the source PR with install/test hints

After merge to `main`:
- workflow syncs the checked-in skill source to `tutti-os/tutti-agent-skills`
- opens or updates an external repository PR
- requests guarded auto-merge so GitHub merges only after external checks pass

## Required setup

The post-merge workflow needs repository secret `TUTTI_AGENT_SKILLS_SYNC_TOKEN` on `tutti-os/tutti`. The token needs permission to push branches and create/update/auto-merge PRs in `tutti-os/tutti-agent-skills`.

## Verification

- `ruby -e 'require "yaml"; ARGV.each { |path| YAML.load_file(path); puts "ok #{path}" }' .github/workflows/tutti-agent-skills-preview.yml .github/workflows/sync-tutti-agent-skills.yml`
- local preview simulation with `npx --yes skills add . --list`
- local preview simulation with `npx --yes skills add ./skills/tutti-workspace-app-factory --list`
- external repo `npx --yes skills add tutti-os/tutti-agent-skills --list`
- app factory skill `quick_validate.py`
- external repo `scripts/check-tutti-main-sync.sh /Users/wwcome/work/nextop-os/nextop`
- `pnpm check:tutti-names`
- GitHub PR preview workflow passed on this PR and posted a PR comment
- pre-push `pnpm check:full` partially passed: lint, typecheck, Go tests passed; TS tests had one local environment failure in `apps/desktop/src/main/daemon/tuttidManager.test.ts` where the dev `tuttid` binary path was not selected and `go` was selected instead.
