### PR TITLE
fix(agent-gui): stabilize session list updates

### DIFF
--- a/apps/desktop/src/renderer/src/features/workspace-agent/desktopAgentGUINodeState.test.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-agent/desktopAgentGUINodeState.test.ts
@@ -190,7 +190,7 @@ test("desktop agent gui provider derives from workbench instance id", () => {
   );
 });
 
-test("desktop agent gui node state source keeps workbench rail state in memory", (t) => {
+test("desktop agent gui node state source consumes instance launch state after node state is written", (t) => {
   const source = createDesktopAgentGUINodeStateSource({
     workspaceId: "workspace-1"
   });
@@ -228,6 +228,44 @@ test("desktop agent gui node state source keeps workbench rail state in memory",
       conversationRailWidthPx: 360,
       lastActiveAgentSessionId: "session-1"
     }
+  );
+
+  source.writeNodeState({
+    instanceId: "agent-gui:gemini",
+    nodeId: "node-1",
+    state: {
+      composerOverrides: { permissionModeId: "read-only" },
+      conversationRailCollapsed: false,
+      conversationRailWidthPx: 420,
+      lastActiveAgentSessionId: "session-2",
+      lastActiveConversationTitle: "Node title"
+    },
+    typeId: "agent-gui"
+  });
+
+  assert.equal(notified, 2);
+  assert.deepEqual(
+    source.externalStateSource.getNodeState({
+      instanceId: "agent-gui:gemini",
+      nodeId: "node-1",
+      typeId: "agent-gui",
+      workspaceId: "workspace-1"
+    }),
+    {
+      composerOverrides: { permissionModeId: "read-only" },
+      composerOverridesByProvider: null,
+      conversationRailCollapsed: false,
+      conversationRailWidthPx: 420,
+      lastActiveAgentSessionId: "session-2",
+      lastActiveConversationTitle: "Node title"
+    }
+  );
+  assert.equal(
+    source.readNodeState({
+      instanceId: "agent-gui:gemini",
+      typeId: "agent-gui"
+    }),
+    null
   );
   assert.equal(
     source.externalStateSource.getNodeState({

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUINodeController.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUINodeController.ts
@@ -1426,6 +1426,21 @@ function conversationBusyStatusFromAgentActivityDisplayStatus(
   return null;
 }
 
+function reuseAgentActivityDisplayStatusesIfUnchanged(
+  previous: ReadonlyMap<string, AgentActivityDisplayStatus> | null,
+  next: Map<string, AgentActivityDisplayStatus>
+): Map<string, AgentActivityDisplayStatus> {
+  if (!previous || previous.size !== next.size) {
+    return next;
+  }
+  for (const [sessionId, status] of next) {
+    if (previous.get(sessionId) !== status) {
+      return next;
+    }
+  }
+  return previous as Map<string, AgentActivityDisplayStatus>;
+}
+
 function permissionModeOptions(
   provider: AgentGUINodeData["provider"],
   permissionConfig: AgentSessionPermissionConfig | null | undefined
@@ -1930,10 +1945,19 @@ export function useAgentGUINodeController({
   const agentActivityRuntime = useAgentActivityRuntime();
   const agentHostApi = useAgentHostApi();
   const agentActivitySnapshot = useAgentActivitySnapshot(workspaceId);
-  const agentActivityDisplayStatuses = useMemo(
-    () => selectSessionDisplayStatuses(agentActivitySnapshot),
-    [agentActivitySnapshot]
-  );
+  const agentActivityDisplayStatusesRef = useRef<Map<
+    string,
+    AgentActivityDisplayStatus
+  > | null>(null);
+  const agentActivityDisplayStatuses = useMemo(() => {
+    const next = selectSessionDisplayStatuses(agentActivitySnapshot);
+    const stable = reuseAgentActivityDisplayStatusesIfUnchanged(
+      agentActivityDisplayStatusesRef.current,
+      next
+    );
+    agentActivityDisplayStatusesRef.current = stable;
+    return stable;
+  }, [agentActivitySnapshot]);
   const generatedControllerOwnerKey = useId();
   const conversationListQuery =
     useMemo<AgentGUIConversationListQuery | null>(() => {

--- a/packages/agent/gui/contexts/workspace/presentation/renderer/agentGuiConversationList/agentGuiConversationListStore.spec.ts
+++ b/packages/agent/gui/contexts/workspace/presentation/renderer/agentGuiConversationList/agentGuiConversationListStore.spec.ts
@@ -81,6 +81,71 @@ describe("agentGuiConversationListStore", () => {
     });
   });
 
+  it("keeps existing conversations during incremental runtime updates that omit one session", async () => {
+    const query: AgentGUIConversationListQuery = {
+      workspaceId: "workspace-1",
+      userId: "user-1",
+      provider: "codex",
+      sessionOrigin: "WORKSPACE_AGENT_SESSION_ORIGIN_RUNTIME"
+    };
+    let snapshot: WorkspaceAgentActivitySnapshot = {
+      ...emptySnapshot(),
+      sessions: [
+        runtimeSession("a", 3_000),
+        runtimeSession("z", 2_000),
+        runtimeSession("b", 1_000)
+      ]
+    };
+    let loadCount = 0;
+    let runtimeListener: (() => void) | undefined;
+    setAgentActivityRuntimeForTests({
+      getSnapshot: () => snapshot,
+      load: async () => {
+        loadCount += 1;
+        return snapshot;
+      },
+      subscribe: (_workspaceId, listener) => {
+        runtimeListener = () => listener(snapshot as AgentActivitySnapshot);
+        return () => {};
+      }
+    } as Partial<AgentActivityRuntime> as AgentActivityRuntime);
+
+    ensureAgentGUIConversationListQuery(query);
+    scheduleAgentGUIConversationListProjection(query, "projection-sync");
+    await waitFor(() => {
+      expect(
+        getAgentGUIConversationListQuerySnapshot(query)?.conversations.map(
+          (item) => item.id
+        )
+      ).toEqual(["a", "z", "b"]);
+    });
+
+    snapshot = {
+      ...snapshot,
+      sessions: [runtimeSession("a", 3_500), runtimeSession("b", 1_000)]
+    };
+    runtimeListener?.();
+
+    await waitFor(() => {
+      expect(loadCount).toBe(1);
+      expect(
+        getAgentGUIConversationListQuerySnapshot(query)?.conversations.map(
+          (item) => item.id
+        )
+      ).toEqual(["a", "z", "b"]);
+    });
+
+    scheduleAgentGUIConversationListProjection(query, "projection-sync");
+    await waitFor(() => {
+      expect(loadCount).toBe(2);
+      expect(
+        getAgentGUIConversationListQuerySnapshot(query)?.conversations.map(
+          (item) => item.id
+        )
+      ).toEqual(["a", "b"]);
+    });
+  });
+
   it("sorts conversations by stable sort time before update time", () => {
     const query: AgentGUIConversationListQuery = {
       workspaceId: "workspace-1",
@@ -232,6 +297,22 @@ function emptySnapshot(): WorkspaceAgentActivitySnapshot {
     presences: [],
     sessions: [],
     sessionMessagesById: {}
+  };
+}
+
+function runtimeSession(
+  agentSessionId: string,
+  updatedAtUnixMs: number
+): WorkspaceAgentActivitySnapshot["sessions"][number] {
+  return {
+    workspaceId: "workspace-1",
+    agentSessionId,
+    provider: "codex",
+    cwd: "/repo",
+    title: agentSessionId,
+    status: "ready",
+    updatedAtUnixMs,
+    sessionOrigin: "WORKSPACE_AGENT_SESSION_ORIGIN_RUNTIME"
   };
 }
 

--- a/packages/agent/gui/contexts/workspace/presentation/renderer/agentGuiConversationList/agentGuiConversationListStore.ts
+++ b/packages/agent/gui/contexts/workspace/presentation/renderer/agentGuiConversationList/agentGuiConversationListStore.ts
@@ -724,7 +724,15 @@ async function refreshAgentGUIConversationListQuery(
       queryKey,
       localCreatedConversationIds
     );
+    const currentConversations = getQueryState(query)?.conversations ?? [];
     const retainedSessionIds = new Set(retainedSnapshotSessionIds);
+    if (reason === "workspace-agent-update") {
+      for (const conversation of currentConversations) {
+        if (!nextDeletedConversationIds.has(conversation.id)) {
+          retainedSessionIds.add(conversation.id);
+        }
+      }
+    }
     if (retainedSnapshotSessionIds.size > 0) {
       for (const agentSessionId of localCreatedConversationIds) {
         if (!nextDeletedConversationIds.has(agentSessionId)) {
@@ -733,7 +741,6 @@ async function refreshAgentGUIConversationListQuery(
       }
     }
 
-    const currentConversations = getQueryState(query)?.conversations ?? [];
     const nextConversations = sortConversationsByRecency(
       mergeLoadedConversations(
         currentConversations,

--- a/packages/agent/gui/workbench/state.test.ts
+++ b/packages/agent/gui/workbench/state.test.ts
@@ -112,7 +112,7 @@ describe("agent gui workbench state", () => {
     ).toBe("codex");
   });
 
-  it("keeps node state in memory for workbench external state", () => {
+  it("uses instance launch state only until node state is written", () => {
     const source = createAgentGuiWorkbenchNodeStateSource({
       workspaceId: "workspace-1"
     });
@@ -136,7 +136,6 @@ describe("agent gui workbench state", () => {
       },
       typeId: "agent-gui"
     });
-    unsubscribe();
 
     expect(notified).toBe(1);
     expect(
@@ -155,6 +154,54 @@ describe("agent gui workbench state", () => {
       conversationRailWidthPx: 360,
       lastActiveAgentSessionId: "session-1"
     });
+
+    source.writeNodeState({
+      instanceId: "agent-gui:gemini",
+      nodeId: "node-1",
+      state: {
+        composerOverrides: { permissionModeId: "read-only" },
+        conversationRailCollapsed: false,
+        conversationRailWidthPx: 420,
+        lastActiveAgentSessionId: "session-2",
+        lastActiveConversationTitle: "Node title"
+      },
+      typeId: "agent-gui"
+    });
+    unsubscribe();
+
+    expect(notified).toBe(2);
+    expect(
+      source.externalStateSource.getNodeState({
+        instanceId: "agent-gui:gemini",
+        nodeId: "node-1",
+        typeId: "agent-gui",
+        workspaceId: "workspace-1"
+      })
+    ).toEqual({
+      composerOverrides: { permissionModeId: "read-only" },
+      composerOverridesByProvider: null,
+      conversationRailCollapsed: false,
+      conversationRailWidthPx: 420,
+      lastActiveAgentSessionId: "session-2",
+      lastActiveConversationTitle: "Node title"
+    });
+    expect(
+      source.externalStateSource.getSnapshotNodeState?.({
+        instanceId: "agent-gui:gemini",
+        nodeId: "node-1",
+        typeId: "agent-gui",
+        workspaceId: "workspace-1"
+      })
+    ).toMatchObject({
+      lastActiveAgentSessionId: "session-2",
+      lastActiveConversationTitle: "Node title"
+    });
+    expect(
+      source.readNodeState({
+        instanceId: "agent-gui:gemini",
+        typeId: "agent-gui"
+      })
+    ).toBeNull();
   });
 
   it("isolates multi-instance node state by workbench node id", () => {

--- a/packages/agent/gui/workbench/state.ts
+++ b/packages/agent/gui/workbench/state.ts
@@ -183,6 +183,16 @@ export function createAgentGuiWorkbenchNodeStateSource(input: {
   const nodeStateByKey = new Map<string, AgentGuiWorkbenchState>();
   const listeners = new Set<() => void>();
 
+  const lookupState = (request: AgentGuiWorkbenchStateLookupRequest) => {
+    const nodeState = request.nodeId
+      ? nodeStateByKey.get(agentGuiWorkbenchNodeStateKey(request))
+      : null;
+    const state =
+      nodeState ??
+      nodeStateByKey.get(agentGuiWorkbenchInstanceStateKey(request));
+    return state ? { ...state } : null;
+  };
+
   const notify = () => {
     for (const listener of listeners) {
       listener();
@@ -195,19 +205,13 @@ export function createAgentGuiWorkbenchNodeStateSource(input: {
         if (request.typeId !== typeId) {
           return null;
         }
-        const state =
-          nodeStateByKey.get(agentGuiWorkbenchNodeStateKey(request)) ??
-          nodeStateByKey.get(agentGuiWorkbenchInstanceStateKey(request));
-        return state ? { ...state } : null;
+        return lookupState(request);
       },
       getSnapshotNodeState(request) {
         if (request.typeId !== typeId) {
           return null;
         }
-        const state =
-          nodeStateByKey.get(agentGuiWorkbenchNodeStateKey(request)) ??
-          nodeStateByKey.get(agentGuiWorkbenchInstanceStateKey(request));
-        return state ? { ...state } : null;
+        return lookupState(request);
       },
       getWorkspaceState() {
         return {
@@ -225,10 +229,7 @@ export function createAgentGuiWorkbenchNodeStateSource(input: {
       if (request.typeId !== typeId) {
         return null;
       }
-      const state =
-        nodeStateByKey.get(agentGuiWorkbenchNodeStateKey(request)) ??
-        nodeStateByKey.get(agentGuiWorkbenchInstanceStateKey(request));
-      return state ? { ...state } : null;
+      return lookupState(request);
     },
     writeNodeState(request) {
       if (request.typeId !== typeId) {
@@ -236,6 +237,9 @@ export function createAgentGuiWorkbenchNodeStateSource(input: {
       }
       const key = agentGuiWorkbenchNodeStateKey(request);
       const previous = nodeStateByKey.get(key);
+      const clearedInstanceSeed = request.nodeId
+        ? nodeStateByKey.delete(agentGuiWorkbenchInstanceStateKey(request))
+        : false;
       const next = {
         ...normalizeAgentGuiWorkbenchState(request.state)
       };
@@ -247,7 +251,11 @@ export function createAgentGuiWorkbenchNodeStateSource(input: {
           request.state.lastActiveConversationTitle;
       }
       nodeStateByKey.set(key, next);
-      if (previous && areAgentGuiWorkbenchMemoryStatesEqual(previous, next)) {
+      if (
+        !clearedInstanceSeed &&
+        previous &&
+        areAgentGuiWorkbenchMemoryStatesEqual(previous, next)
+      ) {
         return;
       }
       notify();


### PR DESCRIPTION
## Summary
- consume instance-scoped agent-gui launch state once node state is written
- keep conversation list entries stable during incremental runtime updates
- reuse unchanged activity display status maps to reduce session-stream rerenders

## Tests
- `pnpm --dir packages/agent/gui exec vitest run --environment jsdom workbench/state.test.ts contexts/workspace/presentation/renderer/agentGuiConversationList/agentGuiConversationListStore.spec.ts agent-gui/agentGuiNode/controller/useAgentGUINodeController.spec.tsx`
- `pnpm --filter @tutti-os/desktop test -- src/renderer/src/features/workspace-agent/desktopAgentGUINodeState.test.ts`
- `pnpm --filter @tutti-os/agent-gui typecheck`
- `pnpm --filter @tutti-os/desktop typecheck`
- `git diff --check`
- `pnpm check:full` (pre-push hook)

## Notes
- `pnpm check:changed -- --push-ready` still hits existing `@tutti-os/agent-gui:test` failures in unrelated slash-command/composer-settings specs. The targeted tests covering this change pass.
- Compared DevTools traces before/after the render-stability change; main-thread task time per second dropped from ~256.5ms/s to ~138.1ms/s and React >16.7ms render frequency dropped from ~0.652/s to ~0.243/s in the captured scenario.