### PR TITLE
Fix agent GUI conversation list projection

### DIFF
--- a/apps/desktop/src/renderer/src/features/workspace-agent/services/createDesktopAgentHostApi.test.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-agent/services/createDesktopAgentHostApi.test.ts
@@ -2409,6 +2409,36 @@ test("desktop agent host api keeps canonical sessions across adapter recreation"
   );
 });
 
+test("desktop agent host api excludes invisible persisted sessions from workspace agent list", async () => {
+  const api = createAgentHostApi({
+    workspaceId: "workspace-invisible",
+    tuttidClient: createTuttidClient({
+      async listWorkspaceAgentSessions() {
+        return {
+          sessions: [
+            createSession({
+              id: "visible-session",
+              visible: true
+            }),
+            createSession({
+              id: "invisible-session",
+              visible: false
+            })
+          ],
+          workspaceId: "workspace-invisible"
+        };
+      }
+    })
+  });
+
+  const snapshot = await api.workspaceAgents.list();
+
+  assert.deepEqual(
+    snapshot.sessions.map((session) => session.agentSessionId),
+    ["visible-session"]
+  );
+});
+
 test("desktop agent host api reuses desktop host file operations", async () => {
   const usedProjectPaths: string[] = [];
   const writtenFiles: Array<{

--- a/apps/desktop/src/renderer/src/features/workspace-agent/services/internal/createDesktopAgentHostWorkspaceAgentsApi.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-agent/services/internal/createDesktopAgentHostWorkspaceAgentsApi.ts
@@ -57,7 +57,9 @@ export function createDesktopAgentHostWorkspaceAgentsApi({
     list: async (_payload) => {
       const activitySnapshot = await agentActivityService.load(workspaceId);
       const visibleSessions = activitySnapshot.sessions.filter(
-        (session) => !isHiddenAgentSession(workspaceState, session)
+        (session) =>
+          session.visible !== false &&
+          !isHiddenAgentSession(workspaceState, session)
       );
       return {
         presences: desktopAgentGUIPresenceProviders.map((provider, index) => ({

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUINodeController.spec.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUINodeController.spec.tsx
@@ -2130,12 +2130,14 @@ describe("useAgentGUINodeController", () => {
     await waitFor(() => {
       expect(list).toHaveBeenCalledTimes(2);
     });
-    expect(result.current.viewModel.conversations[0]).toEqual(
-      expect.objectContaining({
-        id: createdSessionId,
-        title: "start a fresh chat"
-      })
-    );
+    await waitFor(() => {
+      expect(result.current.viewModel.conversations[0]).toEqual(
+        expect.objectContaining({
+          id: createdSessionId,
+          title: "start a fresh chat"
+        })
+      );
+    });
   });
 
   it("keeps the hero draft visible while activation is pending, then clears it after switching to the new session", async () => {
@@ -4255,84 +4257,6 @@ describe("useAgentGUINodeController", () => {
         "session-1": "AAA",
         "session-2": "BBB"
       });
-    });
-  });
-
-  it("marks background completed conversations unread until they are selected", async () => {
-    let activityListener:
-      | ((event: AgentHostAgentActivityStreamEvent) => void)
-      | undefined;
-    const subscribeEvents = vi.fn((_payload, listener) => {
-      activityListener = listener;
-      return vi.fn();
-    });
-    installAgentHostApi({
-      list: vi.fn(async () => ({
-        presences: [],
-        sessions: [
-          workspaceAgentSession("session-1"),
-          workspaceAgentSession("session-2")
-        ]
-      })),
-      listSessionTimeline: vi.fn(async () => ({ timelineItems: [] })),
-      subscribeEvents
-    });
-
-    const { result } = renderHook(() =>
-      useAgentGUINodeController({
-        workspaceId: "room-1",
-        currentUserId: "user-1",
-        workspacePath: "/workspace",
-        avoidGroupingEdits: false,
-        data: agentGuiData("session-1"),
-        onDataChange: vi.fn()
-      })
-    );
-
-    act(() => {
-      result.current.actions.retryActivation();
-    });
-
-    await waitFor(() => {
-      expect(activityListener).toBeDefined();
-    });
-
-    act(() => {
-      activityListener?.({
-        eventType: "state_patch",
-        data: {
-          agentSessionId: "session-2",
-          lifecycleStatus: "completed",
-          occurredAtUnixMs: 20
-        }
-      });
-    });
-
-    await waitFor(() => {
-      expect(result.current.viewModel.conversations).toEqual(
-        expect.arrayContaining([
-          expect.objectContaining({
-            id: "session-2",
-            status: "completed",
-            hasUnreadCompletion: true
-          })
-        ])
-      );
-    });
-
-    act(() => {
-      result.current.actions.selectConversation("session-2");
-    });
-
-    await waitFor(() => {
-      expect(result.current.viewModel.conversations).toEqual(
-        expect.arrayContaining([
-          expect.objectContaining({
-            id: "session-2",
-            hasUnreadCompletion: false
-          })
-        ])
-      );
     });
   });
 
@@ -12172,14 +12096,18 @@ function installAgentActivityRuntimeForHostMocks({
         userId: "user-1"
       });
       const next = agentActivitySnapshotFromHostSnapshot(snapshot, workspaceId);
-      setSnapshot(workspaceId, (current) => ({
+      const merged = setSnapshot(workspaceId, (current) => ({
         ...next,
         composerOptionsByProvider:
           current.composerOptionsByProvider ??
           next.composerOptionsByProvider ??
-          {}
+          {},
+        sessionMessagesById: {
+          ...next.sessionMessagesById,
+          ...current.sessionMessagesById
+        }
       }));
-      return cloneAgentActivitySnapshot(next);
+      return cloneAgentActivitySnapshot(merged);
     },
     ensureSessionSynchronized: synchronizeSession,
     retainSessionEvents: synchronizeSession,

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUINodeController.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUINodeController.ts
@@ -46,7 +46,6 @@ import { AGENT_PROVIDER_LABEL } from "../../../contexts/settings/domain/agentSet
 import type { AgentGUINodeData } from "../../../types";
 import {
   AGENT_GUI_RUNTIME_SESSION_ORIGIN,
-  buildAgentGUIConversationSummaries,
   buildAgentGUIConversationDetail,
   buildAgentGUIConversationVM,
   conversationSummaryFromAgentSession,
@@ -133,10 +132,8 @@ import {
   upsertLocalCreatedAgentGUIConversation,
   updateAgentGUIConversationListConversations,
   isAgentGUIConversationListRefreshing,
-  getDeletedAgentGUIConversationIds,
   type AgentGUIConversationListQuery
 } from "../../../contexts/workspace/presentation/renderer/agentGuiConversationList/agentGuiConversationListStore";
-import { workspaceAgentSnapshotForConversations } from "../../../contexts/workspace/presentation/renderer/agentGuiConversationList/agentGuiConversationListSnapshot";
 import { useAgentGuiConversationList } from "../../../contexts/workspace/presentation/renderer/agentGuiConversationList/useAgentGuiConversationList";
 import { useAgentGUIActivation } from "./useAgentGUIActivation";
 import {
@@ -763,116 +760,6 @@ function sessionHasRenderableMessages(input: {
   }
   return (
     (input.snapshotMessagesById[normalizedAgentSessionId]?.length ?? 0) > 0
-  );
-}
-
-function maxOptionalTimeUnixMs(
-  left: number | null | undefined,
-  right: number | null | undefined
-): number | undefined {
-  const leftTime =
-    typeof left === "number" && Number.isFinite(left) ? left : undefined;
-  const rightTime =
-    typeof right === "number" && Number.isFinite(right) ? right : undefined;
-  if (leftTime === undefined) {
-    return rightTime;
-  }
-  if (rightTime === undefined) {
-    return leftTime;
-  }
-  return Math.max(leftTime, rightTime);
-}
-
-function mergeSnapshotConversationSummary(
-  existing: AgentGUIConversationSummary | undefined,
-  incoming: AgentGUIConversationSummary,
-  provider: AgentProviderId,
-  completedConversationIds: Set<string>
-): AgentGUIConversationSummary {
-  if (!existing) {
-    return {
-      ...incoming,
-      hasUnreadCompletion: incoming.hasUnreadCompletion ?? false
-    };
-  }
-  const titleFields =
-    hasPromptConversationTitle(existing) &&
-    (isWorkspaceAgentUntitledTask(incoming.title) ||
-      shouldPreserveExistingConversationTitle(
-        existing,
-        incoming.title,
-        provider
-      ))
-      ? {
-          title: existing.title,
-          titleFallback: existing.titleFallback
-        }
-      : mergeConversationTitleUpdateFields(existing, incoming.title, provider);
-  const incomingWouldSettleBusyStatus =
-    conversationBusyStatus(existing.status) &&
-    !conversationBusyStatus(incoming.status);
-  const shouldKeepExistingStatus =
-    existing.updatedAtUnixMs > incoming.updatedAtUnixMs &&
-    incomingWouldSettleBusyStatus;
-  const status = shouldKeepExistingStatus ? existing.status : incoming.status;
-  if (status === "completed" && existing.status !== "completed") {
-    completedConversationIds.add(incoming.id);
-  }
-  const syncState =
-    incoming.syncState &&
-    shouldApplySyncState(existing.syncState, incoming.syncState) &&
-    !syncStateRenderFieldsEqual(existing.syncState, incoming.syncState)
-      ? incoming.syncState
-      : existing.syncState;
-  const hasUnreadCompletion =
-    incoming.status === "completed"
-      ? (existing.hasUnreadCompletion ?? incoming.hasUnreadCompletion ?? false)
-      : false;
-  const merged: AgentGUIConversationSummary = {
-    ...existing,
-    ...incoming,
-    ...titleFields,
-    status,
-    syncState,
-    sortTimeUnixMs: maxOptionalTimeUnixMs(
-      existing.sortTimeUnixMs,
-      incoming.sortTimeUnixMs
-    ),
-    updatedAtUnixMs: shouldKeepExistingStatus
-      ? existing.updatedAtUnixMs
-      : titleFields.title === existing.title &&
-          titleFields.titleFallback === existing.titleFallback &&
-          status === existing.status &&
-          syncState === existing.syncState
-        ? existing.updatedAtUnixMs
-        : incoming.updatedAtUnixMs,
-    hasUnreadCompletion
-  };
-  return areAgentGUIConversationSummariesEqual(existing, merged)
-    ? existing
-    : merged;
-}
-
-function areAgentGUIConversationSummariesEqual(
-  left: AgentGUIConversationSummary,
-  right: AgentGUIConversationSummary
-): boolean {
-  return (
-    left.id === right.id &&
-    left.userId === right.userId &&
-    left.provider === right.provider &&
-    left.title === right.title &&
-    left.titleFallback === right.titleFallback &&
-    left.status === right.status &&
-    left.cwd === right.cwd &&
-    (left.project?.id ?? null) === (right.project?.id ?? null) &&
-    (left.project?.path ?? null) === (right.project?.path ?? null) &&
-    (left.project?.label ?? null) === (right.project?.label ?? null) &&
-    left.sortTimeUnixMs === right.sortTimeUnixMs &&
-    left.updatedAtUnixMs === right.updatedAtUnixMs &&
-    (left.pinnedAtUnixMs ?? 0) === (right.pinnedAtUnixMs ?? 0) &&
-    left.hasUnreadCompletion === right.hasUnreadCompletion &&
-    left.syncState === right.syncState
   );
 }
 
@@ -2752,156 +2639,6 @@ export function useAgentGUINodeController({
     };
   }, [agentHostApi.userProjects, previewMode, setUserProjectsSnapshot]);
 
-  useEffect(() => {
-    if (previewMode) {
-      return;
-    }
-    const filteredSnapshot = workspaceAgentSnapshotForConversations(
-      agentActivitySnapshot
-    );
-    if (!conversationListQuery || filteredSnapshot.sessions.length === 0) {
-      return;
-    }
-    const snapshotConversations = buildAgentGUIConversationSummaries({
-      isNoProjectPath,
-      snapshot: filteredSnapshot,
-      provider: data.provider,
-      sessionMessagesById: agentActivitySnapshot.sessionMessagesById,
-      userProjects
-    });
-    if (snapshotConversations.length === 0) {
-      return;
-    }
-    const completedConversationIds = new Set<string>();
-    updateConversationList((current) => {
-      const snapshotById = new Map(
-        snapshotConversations.map((conversation) => [
-          conversation.id,
-          conversation
-        ])
-      );
-      if (hasLoadedConversations && current.length > 0) {
-        let changed = false;
-        const patched = current.map((existing) => {
-          const incoming = snapshotById.get(existing.id);
-          if (!incoming) {
-            return existing;
-          }
-          const merged = mergeSnapshotConversationSummary(
-            existing,
-            incoming,
-            data.provider,
-            completedConversationIds
-          );
-          if (merged !== existing) {
-            changed = true;
-          }
-          return merged;
-        });
-        const activeConversationId =
-          activeConversationIdRef.current?.trim() ?? "";
-        if (
-          activeConversationId &&
-          !patched.some(
-            (conversation) => conversation.id === activeConversationId
-          )
-        ) {
-          const incoming = snapshotById.get(activeConversationId);
-          if (incoming) {
-            patched.unshift(
-              mergeSnapshotConversationSummary(
-                undefined,
-                incoming,
-                data.provider,
-                completedConversationIds
-              )
-            );
-            changed = true;
-          }
-        }
-        const transientConversation = transientConversationRef.current;
-        if (
-          transientConversation &&
-          !patched.some(
-            (conversation) => conversation.id === transientConversation.id
-          )
-        ) {
-          const snapshotVersion = snapshotById.get(transientConversation.id);
-          patched.unshift(
-            snapshotVersion
-              ? mergeSnapshotConversationSummary(
-                  undefined,
-                  snapshotVersion,
-                  data.provider,
-                  completedConversationIds
-                )
-              : transientConversation
-          );
-          changed = true;
-        }
-        if (!changed) {
-          return current;
-        }
-        const next = applyAgentGUIConversationProjects(patched, userProjects, {
-          isNoProjectPath
-        });
-        if (
-          next.length === current.length &&
-          next.every((conversation, index) => conversation === current[index])
-        ) {
-          return current;
-        }
-        return next;
-      }
-
-      const currentById = new Map(
-        current.map((conversation) => [conversation.id, conversation])
-      );
-      const deletedIds = getDeletedAgentGUIConversationIds(
-        conversationListQuery
-      );
-      const filteredSnapshotConversations =
-        deletedIds.size > 0
-          ? snapshotConversations.filter((c) => !deletedIds.has(c.id))
-          : snapshotConversations;
-      const snapshotIds = new Set(
-        filteredSnapshotConversations.map((conversation) => conversation.id)
-      );
-      const merged: AgentGUIConversationSummary[] =
-        filteredSnapshotConversations.map((conversation) =>
-          mergeSnapshotConversationSummary(
-            currentById.get(conversation.id),
-            conversation,
-            data.provider,
-            completedConversationIds
-          )
-        );
-      for (const conversation of current) {
-        if (!snapshotIds.has(conversation.id)) {
-          merged.push(conversation);
-        }
-      }
-      return applyAgentGUIConversationProjects(merged, userProjects, {
-        isNoProjectPath
-      });
-    });
-    for (const conversationId of completedConversationIds) {
-      markAgentGUIConversationCompletionObserved({
-        query: conversationListQuery,
-        conversationId
-      });
-    }
-  }, [
-    agentActivitySnapshot,
-    conversationListQuery,
-    data.provider,
-    hasLoadedConversations,
-    isNoProjectPath,
-    previewMode,
-    updateConversationList,
-    userProjects
-  ]);
-
   const setTransientConversation = useCallback(
     (
       value:
@@ -2946,6 +2683,7 @@ export function useAgentGUINodeController({
     );
   }, [
     isNoProjectPath,
+    conversations,
     previewMode,
     setTransientConversation,
     updateConversationList,

--- a/packages/agent/gui/contexts/workspace/presentation/renderer/agentGuiConversationList/agentGuiConversationListStore.spec.ts
+++ b/packages/agent/gui/contexts/workspace/presentation/renderer/agentGuiConversationList/agentGuiConversationListStore.spec.ts
@@ -146,6 +146,60 @@ describe("agentGuiConversationListStore", () => {
     });
   });
 
+  it("marks background completed runtime updates unread during projection", async () => {
+    const query: AgentGUIConversationListQuery = {
+      workspaceId: "workspace-1",
+      userId: "user-1",
+      provider: "codex",
+      sessionOrigin: "WORKSPACE_AGENT_SESSION_ORIGIN_RUNTIME"
+    };
+    let snapshot: WorkspaceAgentActivitySnapshot = {
+      ...emptySnapshot(),
+      sessions: [runtimeSession("session-1", 1_000)]
+    };
+    let runtimeListener: (() => void) | undefined;
+    setAgentActivityRuntimeForTests({
+      getSnapshot: () => snapshot,
+      load: async () => snapshot,
+      subscribe: (_workspaceId, listener) => {
+        runtimeListener = () => listener(snapshot as AgentActivitySnapshot);
+        return () => {};
+      }
+    } as Partial<AgentActivityRuntime> as AgentActivityRuntime);
+
+    ensureAgentGUIConversationListQuery(query);
+    scheduleAgentGUIConversationListProjection(query, "projection-sync");
+    await waitFor(() => {
+      expect(
+        getAgentGUIConversationListQuerySnapshot(query)?.conversations[0]
+          ?.status
+      ).toBe("ready");
+    });
+
+    snapshot = {
+      ...snapshot,
+      sessions: [
+        {
+          ...runtimeSession("session-1", 2_000),
+          status: "completed"
+        }
+      ]
+    };
+    runtimeListener?.();
+
+    await waitFor(() => {
+      expect(
+        getAgentGUIConversationListQuerySnapshot(query)?.conversations[0]
+      ).toEqual(
+        expect.objectContaining({
+          id: "session-1",
+          status: "completed",
+          hasUnreadCompletion: true
+        })
+      );
+    });
+  });
+
   it("sorts conversations by stable sort time before update time", () => {
     const query: AgentGUIConversationListQuery = {
       workspaceId: "workspace-1",

--- a/packages/agent/gui/contexts/workspace/presentation/renderer/agentGuiConversationList/agentGuiConversationListStore.ts
+++ b/packages/agent/gui/contexts/workspace/presentation/renderer/agentGuiConversationList/agentGuiConversationListStore.ts
@@ -64,6 +64,14 @@ type RefreshReason =
   | "local-create"
   | "local-delete"
   | "workspace-agent-update";
+type ConversationListUpdateReason =
+  | RefreshReason
+  | "active-conversation"
+  | "completion-observed"
+  | "external-update"
+  | "local-created"
+  | "pin-changed"
+  | "submit-pending";
 
 const EMPTY_SNAPSHOT: AgentGUIConversationListStoreSnapshot = {
   statesByQueryKey: {}
@@ -725,6 +733,12 @@ async function refreshAgentGUIConversationListQuery(
       localCreatedConversationIds
     );
     const currentConversations = getQueryState(query)?.conversations ?? [];
+    const currentConversationById = new Map(
+      currentConversations.map((conversation) => [
+        conversation.id,
+        conversation
+      ])
+    );
     const retainedSessionIds = new Set(retainedSnapshotSessionIds);
     if (reason === "workspace-agent-update") {
       for (const conversation of currentConversations) {
@@ -751,6 +765,7 @@ async function refreshAgentGUIConversationListQuery(
       ),
       createConversationOrderIndex(currentConversations)
     ).map((conversation) => {
+      const currentConversation = currentConversationById.get(conversation.id);
       const sessionViewData = sessionViewDataById[conversation.id];
       const mergedMessages =
         sessionMessagesByIdForSummaries[conversation.id] ??
@@ -768,6 +783,13 @@ async function refreshAgentGUIConversationListQuery(
         ...(title
           ? { title: title.title, titleFallback: title.titleFallback }
           : {}),
+        hasUnreadCompletion:
+          conversation.status === "completed"
+            ? currentConversation?.status !== "completed" &&
+              !hasActiveConversationOwner(queryKey, conversation.id)
+              ? true
+              : (conversation.hasUnreadCompletion ?? false)
+            : false,
         status: conversation.status,
         updatedAtUnixMs: conversation.updatedAtUnixMs,
         pinnedAtUnixMs: conversation.pinnedAtUnixMs
@@ -948,7 +970,8 @@ export function updateAgentGUIConversationListConversations(
   query: AgentGUIConversationListQuery,
   updater: (
     current: AgentGUIConversationSummary[]
-  ) => AgentGUIConversationSummary[]
+  ) => AgentGUIConversationSummary[],
+  _reason: ConversationListUpdateReason = "external-update"
 ): void {
   updateQueryState(query, (current) => {
     const nextConversations = updater(current.conversations);
@@ -1021,23 +1044,27 @@ export function clearAgentGUIConversationUnreadCompletion(input: {
   if (!conversationId) {
     return;
   }
-  updateAgentGUIConversationListConversations(input.query, (current) => {
-    let changed = false;
-    const next = current.map((conversation) => {
-      if (
-        conversation.id !== conversationId ||
-        conversation.hasUnreadCompletion !== true
-      ) {
-        return conversation;
-      }
-      changed = true;
-      return {
-        ...conversation,
-        hasUnreadCompletion: false
-      };
-    });
-    return changed ? next : current;
-  });
+  updateAgentGUIConversationListConversations(
+    input.query,
+    (current) => {
+      let changed = false;
+      const next = current.map((conversation) => {
+        if (
+          conversation.id !== conversationId ||
+          conversation.hasUnreadCompletion !== true
+        ) {
+          return conversation;
+        }
+        changed = true;
+        return {
+          ...conversation,
+          hasUnreadCompletion: false
+        };
+      });
+      return changed ? next : current;
+    },
+    "active-conversation"
+  );
 }
 
 export function markAgentGUIConversationCompletionObserved(input: {
@@ -1056,25 +1083,29 @@ export function markAgentGUIConversationCompletionObserved(input: {
     queryState.queryKey,
     conversationId
   );
-  updateAgentGUIConversationListConversations(input.query, (current) => {
-    let changed = false;
-    const next = current.map((conversation) => {
-      if (conversation.id !== conversationId) {
-        return conversation;
-      }
-      const hasUnreadCompletion =
-        conversation.status === "completed" && shouldMarkUnread;
-      if (conversation.hasUnreadCompletion === hasUnreadCompletion) {
-        return conversation;
-      }
-      changed = true;
-      return {
-        ...conversation,
-        hasUnreadCompletion
-      };
-    });
-    return changed ? next : current;
-  });
+  updateAgentGUIConversationListConversations(
+    input.query,
+    (current) => {
+      let changed = false;
+      const next = current.map((conversation) => {
+        if (conversation.id !== conversationId) {
+          return conversation;
+        }
+        const hasUnreadCompletion =
+          conversation.status === "completed" && shouldMarkUnread;
+        if (conversation.hasUnreadCompletion === hasUnreadCompletion) {
+          return conversation;
+        }
+        changed = true;
+        return {
+          ...conversation,
+          hasUnreadCompletion
+        };
+      });
+      return changed ? next : current;
+    },
+    "completion-observed"
+  );
 }
 
 export function upsertLocalCreatedAgentGUIConversation(input: {
@@ -1096,8 +1127,10 @@ export function upsertLocalCreatedAgentGUIConversation(input: {
     queryState.queryKey,
     localCreatedIds
   );
-  updateAgentGUIConversationListConversations(input.query, (current) =>
-    upsertConversationOverlay(current, input.conversation)
+  updateAgentGUIConversationListConversations(
+    input.query,
+    (current) => upsertConversationOverlay(current, input.conversation),
+    "local-created"
   );
 }
 
@@ -1110,21 +1143,24 @@ export function setAgentGUIConversationPinned(input: {
   if (!conversationId) {
     return;
   }
-  updateAgentGUIConversationListConversations(input.query, (current) =>
-    current.some((conversation) => conversation.id === conversationId)
-      ? current.map((conversation) => {
-          if (conversation.id !== conversationId) {
-            return conversation;
-          }
-          const pinnedAtUnixMs = Math.max(0, input.pinnedAtUnixMs);
-          return (conversation.pinnedAtUnixMs ?? 0) === pinnedAtUnixMs
-            ? conversation
-            : {
-                ...conversation,
-                pinnedAtUnixMs
-              };
-        })
-      : current
+  updateAgentGUIConversationListConversations(
+    input.query,
+    (current) =>
+      current.some((conversation) => conversation.id === conversationId)
+        ? current.map((conversation) => {
+            if (conversation.id !== conversationId) {
+              return conversation;
+            }
+            const pinnedAtUnixMs = Math.max(0, input.pinnedAtUnixMs);
+            return (conversation.pinnedAtUnixMs ?? 0) === pinnedAtUnixMs
+              ? conversation
+              : {
+                  ...conversation,
+                  pinnedAtUnixMs
+                };
+          })
+        : current,
+    "pin-changed"
   );
 }
 
@@ -1180,16 +1216,19 @@ export function markAgentGUIConversationSubmitPending(input: {
       conversationId: input.conversationId
     })
   ) {
-    updateAgentGUIConversationListConversations(input.query, (current) =>
-      current.map((conversation) =>
-        conversation.id === input.conversationId.trim()
-          ? {
-              ...conversation,
-              status: "working",
-              updatedAtUnixMs: Date.now()
-            }
-          : conversation
-      )
+    updateAgentGUIConversationListConversations(
+      input.query,
+      (current) =>
+        current.map((conversation) =>
+          conversation.id === input.conversationId.trim()
+            ? {
+                ...conversation,
+                status: "working",
+                updatedAtUnixMs: Date.now()
+              }
+            : conversation
+        ),
+      "submit-pending"
     );
     emitChange();
   }
@@ -1240,8 +1279,13 @@ export function markLocalDeletedAgentGUIConversation(input: {
     queryState.queryKey,
     localCreatedIds
   );
-  updateAgentGUIConversationListConversations(input.query, (current) =>
-    current.filter((conversation) => conversation.id !== input.agentSessionId)
+  updateAgentGUIConversationListConversations(
+    input.query,
+    (current) =>
+      current.filter(
+        (conversation) => conversation.id !== input.agentSessionId
+      ),
+    "local-delete"
   );
 }
 


### PR DESCRIPTION
## Summary
- route durable Agent GUI conversation-list projection through the conversation list store instead of the node controller
- filter invisible persisted sessions before they enter desktop workspace agent lists
- keep incremental runtime updates from dropping active list entries, and mark background completions unread in the store projection

## Tests
- `pnpm exec oxlint packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUINodeController.ts packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUINodeController.spec.tsx packages/agent/gui/contexts/workspace/presentation/renderer/agentGuiConversationList/agentGuiConversationListStore.ts packages/agent/gui/contexts/workspace/presentation/renderer/agentGuiConversationList/agentGuiConversationListStore.spec.ts apps/desktop/src/renderer/src/features/workspace-agent/services/internal/createDesktopAgentHostWorkspaceAgentsApi.ts apps/desktop/src/renderer/src/features/workspace-agent/services/createDesktopAgentHostApi.test.ts --deny-warnings`
- `git diff --cached --check`

## Notes
- Draft because targeted typecheck/test could not be completed in the temporary clean worktree: package-level workspace dependencies were missing from that isolated worktree.
