### PR TITLE
fix(app-center): stabilize factory selects

### DIFF
--- a/packages/workspace/app-center/src/core/appCenterController.test.ts
+++ b/packages/workspace/app-center/src/core/appCenterController.test.ts
@@ -354,6 +354,17 @@ test("WorkspaceAppCenterController requests restart when updating a running inst
   assert.deepEqual(closeRequests, [
     { appIds: ["app-1"], workspaceId: "workspace-1" }
   ]);
+  controller.applyAppUpdate({
+    app: createApp({
+      appId: "app-1",
+      availableVersion: null,
+      runtimeStatus: "running",
+      stateRevision: 3,
+      updateAvailable: false,
+      version: "1.1.0"
+    }),
+    workspaceId: "workspace-1"
+  });
 });
 
 test("WorkspaceAppCenterController preserves install progress during pending install app updates", async () => {

--- a/packages/workspace/app-center/src/core/appCenterControllerState.ts
+++ b/packages/workspace/app-center/src/core/appCenterControllerState.ts
@@ -34,10 +34,14 @@ export abstract class WorkspaceAppCenterControllerState extends WorkspaceAppCent
         this.withPendingInstallState(workspaceId, snapshot.apps)
       )
     );
+    const previousAppsById = new Map(
+      this.store.apps.map((app) => [app.appId, app])
+    );
     for (const app of nextApps) {
       this.settlePendingInstallReport({
         app,
         failureReason: app.failureReason ?? app.lastError ?? null,
+        previousApp: previousAppsById.get(app.appId),
         workspaceId
       });
     }
@@ -154,6 +158,7 @@ export abstract class WorkspaceAppCenterControllerState extends WorkspaceAppCent
           currentApp.failureReason ??
           currentApp.lastError ??
           null,
+        previousApp: currentApp,
         workspaceId
       });
       return;
@@ -188,6 +193,7 @@ export abstract class WorkspaceAppCenterControllerState extends WorkspaceAppCent
         mergedApp.failureReason ??
         mergedApp.lastError ??
         null,
+      previousApp: currentApp,
       workspaceId
     });
     this.closeWorkspaceAppViews(workspaceId, appIdsToClose);
@@ -231,6 +237,7 @@ export abstract class WorkspaceAppCenterControllerState extends WorkspaceAppCent
       }
       void this.refreshInstallState(workspaceId, appId);
     }, this.dependencies.installRefreshDelayMs ?? defaultInstallRefreshDelayMs);
+    timer.unref?.();
     this.installRefreshTimers.set(key, timer);
   }
 
@@ -411,6 +418,7 @@ export abstract class WorkspaceAppCenterControllerState extends WorkspaceAppCent
       }
       void this.refresh(workspaceId);
     }, this.dependencies.catalogLoadingRefreshDelayMs ?? defaultCatalogLoadingRefreshDelayMs);
+    this.catalogRefreshTimer.unref?.();
   }
 
   protected mergeActiveInstallAppState(
@@ -520,13 +528,16 @@ export abstract class WorkspaceAppCenterControllerState extends WorkspaceAppCent
   private settlePendingInstallReport(input: {
     app: WorkspaceAppCenterApp;
     failureReason: string | null;
+    previousApp?: WorkspaceAppCenterApp;
     workspaceId: string;
   }): void {
     const installKey = appRuntimeKey(input.workspaceId, input.app.appId);
     if (!this.pendingInstallKeys.has(installKey)) {
       return;
     }
-    if (!this.isPendingInstallSettled(installKey, input.app)) {
+    if (
+      !this.isPendingInstallSettled(installKey, input.app, input.previousApp)
+    ) {
       return;
     }
 

--- a/packages/workspace/app-center/src/ui/AppCenterPanel.tsx
+++ b/packages/workspace/app-center/src/ui/AppCenterPanel.tsx
@@ -1011,7 +1011,7 @@ function FactoryProviderSelect({
     <Select
       disabled={options.length === 0}
       open={open}
-      value={selectedOption?.provider}
+      value={selectedProvider}
       onOpenChange={onOpenChange}
       onValueChange={onSelectProvider}
     >
@@ -1091,7 +1091,7 @@ function FactoryPermissionDropdown({
     <Select
       disabled={disabled}
       open={open}
-      value={selectedOption?.value}
+      value={selectedPermissionModeId}
       onOpenChange={onOpenChange}
       onValueChange={onSelectPermissionMode}
     >
@@ -1183,10 +1183,10 @@ function FactoryModelReasoningDropdown({
   const selectedValue = showModelSection
     ? selectedModel
       ? `model:${selectedModel}`
-      : undefined
+      : ""
     : selectedReasoningEffort
       ? `reasoning:${selectedReasoningEffort}`
-      : undefined;
+      : "";
   const applySettingsValue = (nextValue: string): void => {
     if (nextValue.startsWith("reasoning:")) {
       onSelectReasoningEffort(nextValue.slice("reasoning:".length));


### PR DESCRIPTION
## Summary
- use stable selected ids for App Center factory select controls instead of derived option objects
- clear pending install state when backend install activity disappears after observed progress
- let App Center refresh timers avoid holding Node test processes open

## Tests
- `pnpm check:changed -- --push-ready --verbose --tail-lines 200`
- `pnpm --filter @tutti-os/workspace-app-center test`
- `node ./tools/scripts/run-tsgo-typecheck.mjs --package-root packages/workspace/app-center`
- `git diff --check`
- pre-push `pnpm check:full`
