### PR TITLE
feat(desktop): add tuttiExternal.logs.write for workspace app web.log

### DIFF
--- a/apps/desktop/src/main/ipc/register.ts
+++ b/apps/desktop/src/main/ipc/register.ts
@@ -12,7 +12,8 @@ import type { DesktopDaemonEndpoint } from "../transport/paths";
 import { registerBrowserIpc } from "./browser";
 import { registerComputerUseIpc } from "./computerUse";
 import { registerDockPreviewCacheIpc } from "./dockPreviewCache";
-import type { DesktopLogger } from "../logging";
+import { getDesktopLogSessionID, type DesktopLogger } from "../logging";
+import { resolveDesktopDefaultsFromEnv } from "../defaults";
 import type { WorkspaceFileIconCacheStore } from "../host/workspaceFileIconCacheStore.ts";
 import type { DesktopWorkspaceAppPayload } from "../../shared/contracts/ipc";
 import type { TuttidClient } from "@tutti-os/client-tuttid-ts";
@@ -46,11 +47,11 @@ export interface IpcRegistrationDependencies {
 }
 
 export function registerIpcHandlers(deps: IpcRegistrationDependencies): void {
-  registerWorkspaceAppContextIpc(
-    deps.daemonEndpoint,
-    deps.preferences,
-    deps.logger
-  );
+  registerWorkspaceAppContextIpc(deps.daemonEndpoint, deps.preferences, {
+    logger: deps.logger,
+    sessionID: getDesktopLogSessionID(),
+    stateRootDir: resolveDesktopDefaultsFromEnv().state.rootDir
+  });
   registerBrowserIpc(deps.preferences);
   registerComputerUseIpc();
   registerDockPreviewCacheIpc();

--- a/apps/desktop/src/main/ipc/workspaceAppContext.ts
+++ b/apps/desktop/src/main/ipc/workspaceAppContext.ts
@@ -14,10 +14,10 @@ import {
   type DesktopWorkspaceAppContext
 } from "../../shared/contracts/ipc";
 import {
-  isTuttiExternalManagedAiModelProviderId,
   normalizeTuttiExternalAtQueryInput,
   normalizeTuttiExternalFileOpenInput,
   normalizeTuttiExternalFileSelectInput,
+  normalizeTuttiExternalLogInput,
   normalizeTuttiExternalPermissionRequestInput,
   normalizeTuttiExternalSettingsOpenInput
 } from "@tutti-os/workspace-external-core/core";
@@ -29,6 +29,7 @@ import type {
   TuttiExternalPermissionRequestInput,
   TuttiExternalPermissionRequestResult
 } from "@tutti-os/workspace-external-core/contracts";
+import { isTuttiExternalManagedAiModelProviderId } from "@tutti-os/workspace-external-core/core";
 import type { DesktopLocale } from "../../shared/i18n";
 import type { DesktopHostPreferencesState } from "../desktopHostPreferences";
 import type { DesktopLogger } from "../logging";
@@ -41,9 +42,17 @@ import {
   dispatchWorkspaceAppOpenUrl,
   installWorkspaceAppWindowOpenHandler
 } from "./workspaceAppWindowOpen.ts";
+import {
+  normalizeWorkspaceAppDiagnosticLogRecord,
+  WorkspaceAppFrontendLogWriter,
+  WorkspaceAppGuestLogRateLimiter
+} from "./workspaceAppFrontendLogging.ts";
 
 const workspaceAppGuestWebContents = new Set<WebContents>();
 const workspaceAppGuestContexts = new Map<number, WorkspaceAppGuestContext>();
+let workspaceAppFrontendLogWriter: WorkspaceAppFrontendLogWriter | null = null;
+let workspaceAppGuestLogRateLimiter: WorkspaceAppGuestLogRateLimiter | null =
+  null;
 
 interface WorkspaceAppGuestContext {
   appID: string;
@@ -78,14 +87,26 @@ export function registerWorkspaceAppGuestWebContents(
   contents.once("destroyed", () => {
     workspaceAppGuestWebContents.delete(contents);
     workspaceAppGuestContexts.delete(contents.id);
+    workspaceAppGuestLogRateLimiter?.forget(contents.id);
   });
 }
 
 export function registerWorkspaceAppContextIpc(
   endpoint: DesktopDaemonEndpoint,
   preferences: DesktopHostPreferencesState,
-  logger?: DesktopLogger
+  options: {
+    logger?: DesktopLogger;
+    sessionID: string;
+    stateRootDir: string;
+  }
 ): void {
+  const { logger, sessionID, stateRootDir } = options;
+  workspaceAppGuestLogRateLimiter ??= new WorkspaceAppGuestLogRateLimiter();
+  workspaceAppFrontendLogWriter ??= new WorkspaceAppFrontendLogWriter(
+    stateRootDir,
+    sessionID,
+    workspaceAppGuestLogRateLimiter
+  );
   registerDesktopIpcHandler(desktopIpcChannels.appContext.get, (event) =>
     createWorkspaceAppContext(
       endpoint,
@@ -165,25 +186,46 @@ export function registerWorkspaceAppContextIpc(
   );
   ipcMain.on(
     desktopIpcChannels.appContext.diagnostic,
-    (_event, payload: unknown) => {
+    (event, payload: unknown) => {
       const normalizedPayload = isWorkspaceAppDiagnosticPayload(payload)
         ? payload
         : null;
-      const event =
+      writeWorkspaceAppDiagnosticLog(event.sender.id, normalizedPayload);
+      const diagnosticEvent =
         typeof normalizedPayload?.event === "string"
           ? normalizedPayload.event
           : "";
-      if (event === "workspace-app-link-interception") {
+      if (diagnosticEvent === "workspace-app-link-interception") {
         logger?.info("workspace app link interception diagnostic", {
           payload: normalizedPayload,
-          webContentsId: _event.sender.id
+          webContentsId: event.sender.id
         });
         return;
       }
-      if (event.includes("failed")) {
+      if (diagnosticEvent.includes("failed")) {
         logger?.warn("workspace app context preload diagnostic", {
           payload: normalizedPayload
         });
+      }
+    }
+  );
+  ipcMain.on(
+    desktopIpcChannels.appExternal.logsWrite,
+    (event, payload: unknown) => {
+      const context = workspaceAppGuestContexts.get(event.sender.id);
+      if (
+        !context ||
+        !workspaceAppGuestWebContents.has(event.sender) ||
+        event.sender.isDestroyed()
+      ) {
+        return;
+      }
+
+      try {
+        const input = normalizeTuttiExternalLogInput(payload);
+        workspaceAppFrontendLogWriter?.write(event.sender.id, context, input);
+      } catch {
+        // Fire-and-forget: invalid app payloads are silently ignored.
       }
     }
   );
@@ -214,6 +256,23 @@ export function registerWorkspaceAppContextIpc(
       locale: preferences.getLocale()
     });
   });
+}
+
+function writeWorkspaceAppDiagnosticLog(
+  guestWebContentsId: number,
+  payload: Record<string, unknown> | null
+): void {
+  if (!payload) {
+    return;
+  }
+
+  const context = workspaceAppGuestContexts.get(guestWebContentsId);
+  const record = normalizeWorkspaceAppDiagnosticLogRecord(payload);
+  if (!context || !record) {
+    return;
+  }
+
+  workspaceAppFrontendLogWriter?.write(guestWebContentsId, context, record);
 }
 
 function requireWorkspaceAppGuestContext(

--- a/apps/desktop/src/main/ipc/workspaceAppFrontendLogging.test.ts
+++ b/apps/desktop/src/main/ipc/workspaceAppFrontendLogging.test.ts
@@ -1,0 +1,123 @@
+import assert from "node:assert/strict";
+import { mkdir, readFile, rm } from "node:fs/promises";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import test from "node:test";
+import {
+  WorkspaceAppFrontendLogWriter,
+  WorkspaceAppGuestLogRateLimiter,
+  formatWorkspaceAppWebLogLine,
+  normalizeWorkspaceAppDiagnosticLogRecord,
+  resolveWorkspaceAppWebLogPath
+} from "./workspaceAppFrontendLogging.ts";
+
+test("formats workspace app web log lines with injected context", () => {
+  const line = formatWorkspaceAppWebLogLine(
+    {
+      event: "page.loaded",
+      level: "info",
+      details: { route: "/home" }
+    },
+    {
+      appID: "demo-app",
+      workspaceID: "workspace-1"
+    },
+    "session-123"
+  );
+
+  assert.match(line, /^time=/);
+  assert.match(line, /level=info/);
+  assert.match(line, /session_id="session-123"/);
+  assert.match(line, /workspace_id="workspace-1"/);
+  assert.match(line, /app_id="demo-app"/);
+  assert.match(line, /web_event="page.loaded"/);
+  assert.match(line, /web_details=\{"route":"\/home"\}/);
+  assert.match(line, /\n$/);
+});
+
+test("resolves workspace app web log path under app logs dir", () => {
+  const path = resolveWorkspaceAppWebLogPath("/tmp/tutti-state", {
+    appID: "demo-app",
+    workspaceID: "workspace-1"
+  });
+
+  assert.equal(
+    path,
+    join(
+      "/tmp/tutti-state",
+      "apps",
+      "workspaces",
+      "workspace-1",
+      "demo-app",
+      "logs",
+      "web.log"
+    )
+  );
+});
+
+test("workspace app frontend log writer appends to web.log", async () => {
+  const root = join(tmpdir(), `tutti-web-log-${Date.now()}`);
+  await mkdir(root, { recursive: true });
+
+  const writer = new WorkspaceAppFrontendLogWriter(
+    root,
+    "session-abc",
+    new WorkspaceAppGuestLogRateLimiter()
+  );
+
+  writer.write(
+    1,
+    { appID: "demo-app", workspaceID: "workspace-1" },
+    { event: "page.loaded", details: { ok: true } }
+  );
+  writer.write(
+    1,
+    { appID: "demo-app", workspaceID: "workspace-1" },
+    { event: "page.ready" }
+  );
+
+  await new Promise((resolve) => setTimeout(resolve, 50));
+
+  const logPath = resolveWorkspaceAppWebLogPath(root, {
+    appID: "demo-app",
+    workspaceID: "workspace-1"
+  });
+  const content = await readFile(logPath, "utf8");
+
+  assert.match(content, /web_event="page.loaded"/);
+  assert.match(content, /web_event="page.ready"/);
+
+  await rm(root, { recursive: true, force: true });
+});
+
+test("workspace app guest log rate limiter silently drops excess entries", () => {
+  const limiter = new WorkspaceAppGuestLogRateLimiter();
+  let allowed = 0;
+
+  for (let index = 0; index < 60; index += 1) {
+    if (limiter.allow(42)) {
+      allowed += 1;
+    }
+  }
+
+  assert.equal(allowed, 50);
+});
+
+test("normalizes workspace app preload diagnostic payloads", () => {
+  assert.deepEqual(
+    normalizeWorkspaceAppDiagnosticLogRecord({
+      event: "get-context-failed",
+      details: { message: "invalid workspace app context" }
+    }),
+    {
+      event: "get-context-failed",
+      level: "warn",
+      details: { message: "invalid workspace app context" },
+      webSource: "preload"
+    }
+  );
+  assert.equal(
+    normalizeWorkspaceAppDiagnosticLogRecord({ details: { message: "x" } }),
+    null
+  );
+});

--- a/apps/desktop/src/main/ipc/workspaceAppFrontendLogging.ts
+++ b/apps/desktop/src/main/ipc/workspaceAppFrontendLogging.ts
@@ -1,0 +1,152 @@
+import { appendFile, mkdir } from "node:fs/promises";
+import { dirname, join } from "node:path";
+import type { TuttiExternalLogInput } from "@tutti-os/workspace-external-core/contracts";
+import type { DesktopRuntimeLogLevel } from "../../shared/contracts/ipc";
+import { resolveWorkspaceAppFolderPath } from "../host/workspaceAppFolderPaths.ts";
+
+export interface WorkspaceAppFrontendLogContext {
+  appID: string;
+  workspaceID: string;
+}
+
+export interface WorkspaceAppFrontendLogRecord extends TuttiExternalLogInput {
+  webSource?: string;
+}
+
+export const workspaceAppFrontendLogRateLimitPerSecond = 50;
+
+export function resolveWorkspaceAppWebLogPath(
+  stateRootDir: string,
+  context: WorkspaceAppFrontendLogContext
+): string {
+  return join(
+    resolveWorkspaceAppFolderPath(stateRootDir, {
+      appId: context.appID,
+      folderKind: "logs",
+      workspaceId: context.workspaceID
+    }),
+    "web.log"
+  );
+}
+
+export function formatWorkspaceAppWebLogLine(
+  input: WorkspaceAppFrontendLogRecord,
+  context: WorkspaceAppFrontendLogContext,
+  sessionID: string
+): string {
+  const level = input.level ?? "info";
+  const fields = [
+    `time=${new Date().toISOString()}`,
+    `level=${level}`,
+    `component=${JSON.stringify("tutti-workspace-app-web")}`,
+    `pid=${process.pid}`,
+    `session_id=${JSON.stringify(sessionID)}`,
+    `workspace_id=${JSON.stringify(context.workspaceID)}`,
+    `app_id=${JSON.stringify(context.appID)}`,
+    `msg=${JSON.stringify("web diagnostic")}`,
+    `web_event=${JSON.stringify(input.event)}`,
+    `web_details=${JSON.stringify(input.details ?? {})}`
+  ];
+
+  if (input.webSource) {
+    fields.push(`web_source=${JSON.stringify(input.webSource)}`);
+  }
+
+  return `${fields.join(" ")}\n`;
+}
+
+export class WorkspaceAppGuestLogRateLimiter {
+  private readonly timestampsByGuest = new Map<number, number[]>();
+
+  allow(
+    guestWebContentsId: number,
+    limit = workspaceAppFrontendLogRateLimitPerSecond,
+    windowMs = 1_000
+  ): boolean {
+    const now = Date.now();
+    const recent = (
+      this.timestampsByGuest.get(guestWebContentsId) ?? []
+    ).filter((timestamp) => now - timestamp < windowMs);
+    if (recent.length >= limit) {
+      this.timestampsByGuest.set(guestWebContentsId, recent);
+      return false;
+    }
+
+    recent.push(now);
+    this.timestampsByGuest.set(guestWebContentsId, recent);
+    return true;
+  }
+
+  forget(guestWebContentsId: number): void {
+    this.timestampsByGuest.delete(guestWebContentsId);
+  }
+}
+
+export class WorkspaceAppFrontendLogWriter {
+  private readonly pendingWrites = new Map<string, Promise<void>>();
+  private readonly stateRootDir: string;
+  private readonly sessionID: string;
+  private readonly rateLimiter: WorkspaceAppGuestLogRateLimiter;
+
+  constructor(
+    stateRootDir: string,
+    sessionID: string,
+    rateLimiter: WorkspaceAppGuestLogRateLimiter
+  ) {
+    this.stateRootDir = stateRootDir;
+    this.sessionID = sessionID;
+    this.rateLimiter = rateLimiter;
+  }
+
+  write(
+    guestWebContentsId: number,
+    context: WorkspaceAppFrontendLogContext,
+    input: WorkspaceAppFrontendLogRecord
+  ): void {
+    if (!this.rateLimiter.allow(guestWebContentsId)) {
+      return;
+    }
+
+    const path = resolveWorkspaceAppWebLogPath(this.stateRootDir, context);
+    const line = formatWorkspaceAppWebLogLine(input, context, this.sessionID);
+    const pending = (this.pendingWrites.get(path) ?? Promise.resolve())
+      .then(() => appendWorkspaceAppWebLogLine(path, line))
+      .catch(() => undefined);
+    this.pendingWrites.set(path, pending);
+  }
+}
+
+export function resolveWorkspaceAppFrontendLogLevel(
+  event: string
+): DesktopRuntimeLogLevel {
+  return event.includes("failed") ? "warn" : "info";
+}
+
+export function normalizeWorkspaceAppDiagnosticLogRecord(
+  payload: Record<string, unknown>
+): WorkspaceAppFrontendLogRecord | null {
+  const event = typeof payload.event === "string" ? payload.event.trim() : "";
+  if (!event) {
+    return null;
+  }
+
+  const details = isRecord(payload.details) ? payload.details : undefined;
+  return {
+    event,
+    level: resolveWorkspaceAppFrontendLogLevel(event),
+    ...(details ? { details } : {}),
+    webSource: "preload"
+  };
+}
+
+async function appendWorkspaceAppWebLogLine(
+  path: string,
+  line: string
+): Promise<void> {
+  await mkdir(dirname(path), { recursive: true });
+  await appendFile(path, line, { encoding: "utf8", flag: "a" });
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}

--- a/apps/desktop/src/preload/entries/workspaceApp.ts
+++ b/apps/desktop/src/preload/entries/workspaceApp.ts
@@ -85,7 +85,10 @@ const tuttiExternal = createWorkspaceAppExternalBridge({
   appContext,
   invoke: invokeWorkspaceApp,
   isUserActivationActive: () =>
-    globalThis.navigator.userActivation?.isActive === true
+    globalThis.navigator.userActivation?.isActive === true,
+  send(channel, payload) {
+    ipcRenderer.send(channel, payload);
+  }
 });
 
 ipcRenderer.on(

--- a/apps/desktop/src/preload/entries/workspaceAppExternalBridge.test.ts
+++ b/apps/desktop/src/preload/entries/workspaceAppExternalBridge.test.ts
@@ -7,6 +7,10 @@ import {
 } from "./workspaceAppExternalBridge.ts";
 import type { DesktopWorkspaceAppContext } from "../../shared/contracts/ipc.ts";
 
+function unexpectedSend(): void {
+  throw new Error("unexpected send");
+}
+
 test("workspace app external bridge proxies app context", async () => {
   const context: DesktopWorkspaceAppContext = {
     appId: "automation",
@@ -23,6 +27,7 @@ test("workspace app external bridge proxies app context", async () => {
       }
     },
     isUserActivationActive: () => true,
+    send: unexpectedSend,
     async invoke() {
       throw new Error("unexpected invoke");
     }
@@ -48,6 +53,7 @@ test("workspace app external bridge subscribes to app context", () => {
       }
     },
     isUserActivationActive: () => true,
+    send: unexpectedSend,
     async invoke() {
       throw new Error("unexpected invoke");
     }
@@ -73,6 +79,7 @@ test("workspace app external bridge invokes at query without user activation", a
       }
     },
     isUserActivationActive: () => false,
+    send: unexpectedSend,
     async invoke<TResult>(channel: string, payload?: unknown) {
       calls.push({ channel, payload });
       return [
@@ -121,6 +128,7 @@ test("workspace app external bridge requires activation for file select", async 
       }
     },
     isUserActivationActive: () => false,
+    send: unexpectedSend,
     async invoke() {
       throw new Error("unexpected invoke");
     }
@@ -143,6 +151,7 @@ test("workspace app external bridge requires activation for file open", async ()
       }
     },
     isUserActivationActive: () => false,
+    send: unexpectedSend,
     async invoke() {
       throw new Error("unexpected invoke");
     }
@@ -166,6 +175,7 @@ test("workspace app external bridge invokes file select with activation", async 
       }
     },
     isUserActivationActive: () => true,
+    send: unexpectedSend,
     async invoke<TResult>(channel: string, payload?: unknown) {
       calls.push({ channel, payload });
       return [
@@ -203,6 +213,7 @@ test("workspace app external bridge invokes file open with activation", async ()
       }
     },
     isUserActivationActive: () => true,
+    send: unexpectedSend,
     async invoke<TResult>(channel: string, payload?: unknown) {
       calls.push({ channel, payload });
       return undefined as TResult;
@@ -237,6 +248,7 @@ test("workspace app external bridge requires activation for permission request",
       }
     },
     isUserActivationActive: () => false,
+    send: unexpectedSend,
     async invoke() {
       throw new Error("unexpected invoke");
     }
@@ -266,6 +278,7 @@ test("workspace app external bridge invokes permission request with activation",
       }
     },
     isUserActivationActive: () => true,
+    send: unexpectedSend,
     async invoke<TResult>(channel: string, payload?: unknown) {
       calls.push({ channel, payload });
       return { code: "grant-code-1" } as TResult;
@@ -307,6 +320,7 @@ test("workspace app external bridge requires activation for settings open", () =
       }
     },
     isUserActivationActive: () => false,
+    send: unexpectedSend,
     async invoke() {
       throw new Error("unexpected invoke");
     }
@@ -330,6 +344,7 @@ test("workspace app external bridge invokes settings open with activation", asyn
       }
     },
     isUserActivationActive: () => true,
+    send: unexpectedSend,
     async invoke<TResult>(channel: string, payload?: unknown) {
       calls.push({ channel, payload });
       return undefined as TResult;
@@ -343,6 +358,68 @@ test("workspace app external bridge invokes settings open with activation", asyn
       payload: { provider: "openai", tab: "models" }
     }
   ]);
+});
+
+test("workspace app external bridge sends logs without user activation", () => {
+  const calls: Array<{ channel: string; payload?: unknown }> = [];
+  const bridge = createWorkspaceAppExternalBridge({
+    appContext: {
+      async get() {
+        return { locale: "en" };
+      },
+      subscribe() {
+        throw new Error("unexpected subscribe");
+      }
+    },
+    isUserActivationActive: () => false,
+    send(channel, payload) {
+      calls.push({ channel, payload });
+    },
+    async invoke() {
+      throw new Error("unexpected invoke");
+    }
+  });
+
+  bridge.logs.write({
+    event: "page.loaded",
+    level: "info",
+    details: { route: "/home" }
+  });
+
+  assert.deepEqual(calls, [
+    {
+      channel: workspaceAppExternalChannels.logsWrite,
+      payload: {
+        event: "page.loaded",
+        level: "info",
+        details: { route: "/home" }
+      }
+    }
+  ]);
+});
+
+test("workspace app external bridge ignores invalid log payloads", () => {
+  const calls: Array<{ channel: string; payload?: unknown }> = [];
+  const bridge = createWorkspaceAppExternalBridge({
+    appContext: {
+      async get() {
+        return { locale: "en" };
+      },
+      subscribe() {
+        throw new Error("unexpected subscribe");
+      }
+    },
+    isUserActivationActive: () => false,
+    send(channel, payload) {
+      calls.push({ channel, payload });
+    },
+    async invoke() {
+      throw new Error("unexpected invoke");
+    }
+  });
+
+  assert.doesNotThrow(() => bridge.logs.write({ event: "" } as never));
+  assert.deepEqual(calls, []);
 });
 
 test("requireUserActivation throws only when inactive", () => {

--- a/apps/desktop/src/preload/entries/workspaceAppExternalBridge.ts
+++ b/apps/desktop/src/preload/entries/workspaceAppExternalBridge.ts
@@ -6,10 +6,12 @@ import type {
   TuttiExternalFileOpenInput,
   TuttiExternalFileSelectInput,
   TuttiExternalFileSelectResult,
+  TuttiExternalLogInput,
   TuttiExternalPermissionRequestInput,
   TuttiExternalPermissionRequestResult,
   TuttiExternalSettingsOpenInput
 } from "@tutti-os/workspace-external-core/contracts";
+import { normalizeTuttiExternalLogInput } from "@tutti-os/workspace-external-core/core";
 
 export interface WorkspaceAppExternalBridgeDependencies {
   appContext: {
@@ -20,12 +22,14 @@ export interface WorkspaceAppExternalBridgeDependencies {
   };
   invoke<TResult>(channel: string, payload?: unknown): Promise<TResult>;
   isUserActivationActive(): boolean;
+  send(channel: string, payload?: unknown): void;
 }
 
 export const workspaceAppExternalChannels = {
   atQuery: "workspace-app-at:query",
   filesOpen: "workspace-app-files:open",
   filesSelect: "workspace-app-files:select",
+  logsWrite: "workspace-app-logs:write",
   permissionsRequest: "workspace-app-permissions:request",
   settingsOpen: "workspace-app-settings:open"
 } as const;
@@ -94,6 +98,18 @@ export function createWorkspaceAppExternalBridge(
           workspaceAppExternalChannels.settingsOpen,
           input ?? {}
         );
+      }
+    },
+    logs: {
+      write(input: TuttiExternalLogInput) {
+        try {
+          dependencies.send(
+            workspaceAppExternalChannels.logsWrite,
+            normalizeTuttiExternalLogInput(input)
+          );
+        } catch {
+          // Fire-and-forget: invalid app payloads are silently ignored.
+        }
       }
     }
   };

--- a/apps/desktop/src/shared/contracts/ipc.ts
+++ b/apps/desktop/src/shared/contracts/ipc.ts
@@ -30,6 +30,7 @@ import type {
   TuttiExternalFileOpenInput,
   TuttiExternalFileSelectInput,
   TuttiExternalFileSelectResult,
+  TuttiExternalLogInput,
   TuttiExternalPermissionRequestInput,
   TuttiExternalPermissionRequestResult,
   TuttiExternalRendererRequest,
@@ -53,6 +54,7 @@ export const desktopIpcChannels = {
     atQuery: "workspace-app-at:query",
     filesOpen: "workspace-app-files:open",
     filesSelect: "workspace-app-files:select",
+    logsWrite: "workspace-app-logs:write",
     permissionsRequest: "workspace-app-permissions:request",
     rendererRequest: "workspace-app-external:renderer-request",
     rendererResponse: "workspace-app-external:renderer-response",
@@ -276,6 +278,8 @@ export interface DesktopWorkspaceAppContext {
   locale: DesktopLocale;
   workspaceId?: string;
 }
+
+export type DesktopWorkspaceAppFrontendLogPayload = TuttiExternalLogInput;
 
 export interface DesktopBackendConfig {
   accessToken: string;

--- a/packages/workspace/external-core/README.md
+++ b/packages/workspace/external-core/README.md
@@ -10,3 +10,4 @@ Contracts and host-agnostic helpers for the workspace app external bridge.
 - `files.open()` for user-activated host opening/revealing of a known workspace file path.
 - `permissions.request()` for user-activated host permission grants such as managed AI model access.
 - `settings.open()` for user-activated host settings navigation, including the managed models tab.
+- `logs.write()` for fire-and-forget frontend diagnostics that append to the workspace app `web.log`.

--- a/packages/workspace/external-core/src/contracts/index.ts
+++ b/packages/workspace/external-core/src/contracts/index.ts
@@ -118,6 +118,21 @@ export interface TuttiExternalSettingsOpenInput {
   tab?: "models";
 }
 
+export const tuttiExternalLogLevels = [
+  "debug",
+  "info",
+  "warn",
+  "error"
+] as const;
+
+export type TuttiExternalLogLevel = (typeof tuttiExternalLogLevels)[number];
+
+export interface TuttiExternalLogInput {
+  details?: Record<string, unknown>;
+  event: string;
+  level?: TuttiExternalLogLevel;
+}
+
 export interface TuttiExternalBridge {
   app: {
     getContext(): Promise<unknown>;
@@ -141,6 +156,9 @@ export interface TuttiExternalBridge {
   };
   settings: {
     open(input?: TuttiExternalSettingsOpenInput): Promise<void>;
+  };
+  logs: {
+    write(input: TuttiExternalLogInput): void;
   };
 }
 

--- a/packages/workspace/external-core/src/core/index.test.ts
+++ b/packages/workspace/external-core/src/core/index.test.ts
@@ -4,6 +4,7 @@ import {
   normalizeTuttiExternalAtQueryInput,
   normalizeTuttiExternalFileOpenInput,
   normalizeTuttiExternalFileSelectInput,
+  normalizeTuttiExternalLogInput,
   normalizeTuttiExternalPermissionRequestInput,
   normalizeTuttiExternalSettingsOpenInput,
   tuttiExternalAtDefaultMaxResults,
@@ -180,4 +181,70 @@ test("keeps the managed AI model provider set explicit", () => {
     "openai",
     "anthropic"
   ]);
+});
+
+test("normalizes external log input defaults", () => {
+  assert.deepEqual(normalizeTuttiExternalLogInput({ event: "page.loaded" }), {
+    event: "page.loaded"
+  });
+});
+
+test("normalizes external log input with level and details", () => {
+  assert.deepEqual(
+    normalizeTuttiExternalLogInput({
+      event: " request.failed ",
+      level: "warn",
+      details: {
+        route: "/home",
+        retryCount: 2
+      }
+    }),
+    {
+      event: "request.failed",
+      level: "warn",
+      details: {
+        route: "/home",
+        retryCount: 2
+      }
+    }
+  );
+});
+
+test("truncates long external log detail strings", () => {
+  const longValue = "x".repeat(8_500);
+  const normalized = normalizeTuttiExternalLogInput({
+    event: "payload.large",
+    details: {
+      message: longValue
+    }
+  });
+
+  assert.equal(normalized.details?.message, `${"x".repeat(8_000)}...`);
+});
+
+test("rejects invalid external log input", () => {
+  assert.throws(
+    () => normalizeTuttiExternalLogInput(null),
+    /input must be an object/
+  );
+  assert.throws(
+    () => normalizeTuttiExternalLogInput({ event: "" }),
+    /event is required/
+  );
+  assert.throws(
+    () =>
+      normalizeTuttiExternalLogInput({
+        event: "page.loaded",
+        level: "trace"
+      }),
+    /level is unsupported/
+  );
+  assert.throws(
+    () =>
+      normalizeTuttiExternalLogInput({
+        event: "page.loaded",
+        details: "invalid"
+      }),
+    /details must be an object/
+  );
 });

--- a/packages/workspace/external-core/src/core/index.ts
+++ b/packages/workspace/external-core/src/core/index.ts
@@ -5,6 +5,8 @@ import {
   type TuttiExternalAtQueryInput,
   type TuttiExternalFileOpenInput,
   type TuttiExternalFileSelectInput,
+  type TuttiExternalLogInput,
+  type TuttiExternalLogLevel,
   type TuttiExternalManagedAiModelProviderId,
   type TuttiExternalPermissionRequestInput,
   type TuttiExternalSettingsOpenInput
@@ -17,6 +19,44 @@ export {
 
 export const tuttiExternalAtMaxResultsLimit = 50;
 export const tuttiExternalAtDefaultMaxResults = 20;
+export const tuttiExternalLogDiagnosticTextLimit = 8_000;
+
+export function limitDiagnosticText(
+  value: string | undefined
+): string | undefined {
+  const trimmed = value?.trim();
+  if (!trimmed) {
+    return undefined;
+  }
+  return trimmed.length > tuttiExternalLogDiagnosticTextLimit
+    ? `${trimmed.slice(0, tuttiExternalLogDiagnosticTextLimit)}...`
+    : trimmed;
+}
+
+export function normalizeTuttiExternalLogInput(
+  input: unknown
+): TuttiExternalLogInput {
+  if (!isRecord(input)) {
+    throw new Error("logs.write input must be an object.");
+  }
+
+  const event = limitDiagnosticText(
+    normalizeRequiredString(input.event, "logs.write event")
+  );
+  if (!event) {
+    throw new Error("logs.write event is required.");
+  }
+
+  return {
+    event,
+    ...(input.level !== undefined && input.level !== null
+      ? { level: normalizeTuttiExternalLogLevel(input.level) }
+      : {}),
+    ...(input.details !== undefined && input.details !== null
+      ? { details: normalizeTuttiExternalLogDetails(input.details) }
+      : {})
+  };
+}
 
 export function normalizeTuttiExternalAtQueryInput(
   input: unknown
@@ -153,6 +193,52 @@ export function isTuttiExternalManagedAiModelProviderId(
       value as TuttiExternalManagedAiModelProviderId
     )
   );
+}
+
+function normalizeTuttiExternalLogLevel(value: unknown): TuttiExternalLogLevel {
+  if (
+    value === "debug" ||
+    value === "info" ||
+    value === "warn" ||
+    value === "error"
+  ) {
+    return value;
+  }
+  throw new Error("logs.write level is unsupported.");
+}
+
+function normalizeTuttiExternalLogDetails(
+  value: unknown
+): Record<string, unknown> {
+  if (!isRecord(value)) {
+    throw new Error("logs.write details must be an object.");
+  }
+
+  const details: Record<string, unknown> = {};
+  for (const [key, entry] of Object.entries(value)) {
+    details[key] = normalizeTuttiExternalLogDetailValue(entry);
+  }
+  return details;
+}
+
+function normalizeTuttiExternalLogDetailValue(value: unknown): unknown {
+  if (typeof value === "string") {
+    return limitDiagnosticText(value) ?? "";
+  }
+  if (value instanceof Error) {
+    return {
+      message: limitDiagnosticText(value.message) ?? "",
+      name: value.name,
+      stack: limitDiagnosticText(value.stack)
+    };
+  }
+  if (Array.isArray(value)) {
+    return value.map((entry) => normalizeTuttiExternalLogDetailValue(entry));
+  }
+  if (isRecord(value)) {
+    return normalizeTuttiExternalLogDetails(value);
+  }
+  return value;
 }
 
 function normalizeMaxResults(value: unknown): number {

--- a/services/tuttid/service/workspace/app_factory_reference/SKILL.md
+++ b/services/tuttid/service/workspace/app_factory_reference/SKILL.md
@@ -58,7 +58,8 @@ The runtime must:
 - Treat `$TUTTI_APP_PACKAGE_DIR` as read-only after startup.
 - Write durable app data only under `$TUTTI_APP_DATA_DIR`.
 - Write scratch/runtime files only under `$TUTTI_APP_RUNTIME_DIR`.
-- Write logs only under `$TUTTI_APP_LOG_DIR` when file logs are needed.
+- Write logs only under `$TUTTI_APP_LOG_DIR` when backend/server-side file logs are needed.
+- Prefer `window.tuttiExternal?.logs?.write?.()` for browser-side diagnostics in Tutti Desktop; reserve `$TUTTI_APP_LOG_DIR` for backend process logs.
 - Read `$TUTTI_WORKSPACE_ROOT` only when the app needs workspace context.
 - Launch Python with `$TUTTI_APP_PYTHON` and Node with `$TUTTI_APP_NODE`; use `$TUTTI_APP_NPM` for npm install/build work.
 - When the generated app calls another local Tutti capability at runtime, use `$TUTTI_CLI` and follow `references/tutti-cli-commands.md`.

--- a/services/tuttid/service/workspace/app_factory_reference/references/runtime-env.md
+++ b/services/tuttid/service/workspace/app_factory_reference/references/runtime-env.md
@@ -75,3 +75,19 @@ const isDark = window.matchMedia?.("(prefers-color-scheme: dark)").matches;
 ```
 
 Do not read `theme`, `themeSource`, `locale`, or `lang` from URL search params for host settings.
+
+## Browser Frontend Diagnostics
+
+When a workspace app runs inside Tutti Desktop, prefer writing browser-side diagnostics through the optional host bridge instead of posting to an app-owned `/api/log` route:
+
+```js
+window.tuttiExternal?.logs?.write?.({
+  event: "page.loaded",
+  level: "info",
+  details: { route: location.pathname }
+});
+```
+
+`logs.write()` is fire-and-forget. Invalid payloads and write failures are ignored in the app. Use optional chaining so the same frontend keeps working when opened directly in a normal browser.
+
+Tutti Desktop appends these entries to the workspace app log directory as `web.log`, alongside `runtime.log`. Reserve `$TUTTI_APP_LOG_DIR` for backend/server-side logs written by the app process itself.


### PR DESCRIPTION
## Summary
- Add `tuttiExternal.logs.write({ event, level?, details? })` to workspace app external bridge; preload normalizes input (8000-char truncation) and sends `workspace-app-logs:write` guest→main.
- Desktop main appends structured lines to `{stateRoot}/apps/workspaces/{ws}/{app}/logs/web.log` with guest-derived `workspace_id` / `app_id` / `session_id`, plus 50/s/guest rate limiting.
- Route existing preload `workspace-app-context:diagnostic` events to the same `web.log` sink; document the API in app factory references.

## Tests
- `pnpm --filter @tutti-os/workspace-external-core test`
- `pnpm --filter @tutti-os/desktop test -- src/main/ipc/workspaceAppFrontendLogging.test.ts src/preload/entries/workspaceAppExternalBridge.test.ts`
- `pnpm check:changed -- --push-ready`
- Pre-push `check:full` (second attempt; first failed on flaky `TestCodexCLIModelListerReadsModelListFromAppServer`)

## Notes
- Fire-and-forget semantics: invalid payloads and write failures are silently ignored in the app.
- Developer Export Logs already discovers app log dirs recursively, so `web.log` is included in diagnostics bundles.

Made with [Cursor](https://cursor.com)