### PR TITLE
Build macOS desktop packages for all architectures

### DIFF
--- a/apps/desktop/scripts/send-release-feishu-card.mjs
+++ b/apps/desktop/scripts/send-release-feishu-card.mjs
@@ -118,9 +118,25 @@ async function loadRelease(repository, tag, githubToken) {
   return response.json();
 }
 
+function findPreferredAssetName(assetNames, pattern) {
+  const matchingAssetNames = assetNames.filter((candidate) => {
+    pattern.lastIndex = 0;
+    return pattern.test(candidate);
+  });
+  return (
+    matchingAssetNames.find((candidate) =>
+      /-mac-universal\.dmg$/i.test(candidate)
+    ) ?? matchingAssetNames[0]
+  );
+}
+
 function findAssetUrl(release, pattern, releaseAssetBaseUrl = "") {
   const assets = Array.isArray(release.assets) ? release.assets : [];
-  const asset = assets.find((candidate) => pattern.test(candidate.name ?? ""));
+  const assetName = findPreferredAssetName(
+    assets.map((candidate) => candidate.name ?? ""),
+    pattern
+  );
+  const asset = assets.find((candidate) => candidate.name === assetName);
   if (!asset?.browser_download_url) {
     return "";
   }
@@ -157,7 +173,7 @@ function resolveMirroredAssetUrl(
     return "";
   }
 
-  const assetName = assetNames.find((candidate) => pattern.test(candidate));
+  const assetName = findPreferredAssetName(assetNames, pattern);
   if (!assetName) {
     return "";
   }
@@ -353,6 +369,7 @@ if (
 
 export {
   buildCardPayload,
+  findPreferredAssetName,
   listAssetNames,
   resolveMirroredAssetUrl,
   resolveIntroText,

--- a/apps/desktop/scripts/upsert-release-download-links.mjs
+++ b/apps/desktop/scripts/upsert-release-download-links.mjs
@@ -24,19 +24,26 @@ function removeManagedSection(body) {
   return body.replace(managedSectionPattern, "\n").trimEnd();
 }
 
+function findPreferredMacDmgAssetName(assetNames) {
+  return (
+    assetNames.find((name) => /-mac-universal\.dmg$/i.test(name)) ??
+    assetNames.find((name) => /\.dmg$/i.test(name))
+  );
+}
+
 function resolveDesktopDownloadLinks(
   assetNames,
   releaseTag,
   releaseAssetBaseUrl
 ) {
   const desktopAssets = [
-    { label: "macOS", matcher: (name) => /\.dmg$/i.test(name) }
+    { label: "macOS", resolveAssetName: findPreferredMacDmgAssetName }
   ];
   const normalizedBaseUrl = normalizeBaseUrl(releaseAssetBaseUrl);
 
   return desktopAssets
-    .map(({ label, matcher }) => {
-      const assetName = assetNames.find(matcher);
+    .map(({ label, resolveAssetName }) => {
+      const assetName = resolveAssetName(assetNames);
       if (!assetName) {
         return null;
       }
@@ -120,6 +127,7 @@ export {
   SECTION_END,
   SECTION_START,
   buildUpdatedReleaseBody,
+  findPreferredMacDmgAssetName,
   removeManagedSection,
   resolveDesktopDownloadLinks
 };

--- a/apps/desktop/scripts/upsert-release-download-links.mjs
+++ b/apps/desktop/scripts/upsert-release-download-links.mjs
@@ -24,11 +24,11 @@ function removeManagedSection(body) {
   return body.replace(managedSectionPattern, "\n").trimEnd();
 }
 
-function findPreferredMacDmgAssetName(assetNames) {
-  return (
-    assetNames.find((name) => /-mac-universal\.dmg$/i.test(name)) ??
-    assetNames.find((name) => /\.dmg$/i.test(name))
-  );
+function findMacDmgAssetName(assetNames, pattern) {
+  return assetNames.find((name) => {
+    pattern.lastIndex = 0;
+    return pattern.test(name);
+  });
 }
 
 function resolveDesktopDownloadLinks(
@@ -37,13 +37,24 @@ function resolveDesktopDownloadLinks(
   releaseAssetBaseUrl
 ) {
   const desktopAssets = [
-    { label: "macOS", resolveAssetName: findPreferredMacDmgAssetName }
+    {
+      label: "macOS Apple Silicon (arm64)",
+      pattern: /-mac-arm64\.dmg$/i
+    },
+    {
+      label: "macOS Intel (x64)",
+      pattern: /-mac-x64\.dmg$/i
+    },
+    {
+      label: "macOS Universal",
+      pattern: /-mac-universal\.dmg$/i
+    }
   ];
   const normalizedBaseUrl = normalizeBaseUrl(releaseAssetBaseUrl);
 
   return desktopAssets
-    .map(({ label, resolveAssetName }) => {
-      const assetName = resolveAssetName(assetNames);
+    .map(({ label, pattern }) => {
+      const assetName = findMacDmgAssetName(assetNames, pattern);
       if (!assetName) {
         return null;
       }
@@ -127,7 +138,7 @@ export {
   SECTION_END,
   SECTION_START,
   buildUpdatedReleaseBody,
-  findPreferredMacDmgAssetName,
+  findMacDmgAssetName,
   removeManagedSection,
   resolveDesktopDownloadLinks
 };

--- a/docs/conventions/desktop-release.md
+++ b/docs/conventions/desktop-release.md
@@ -97,12 +97,14 @@ On Windows the bundled daemon filename is `tuttid.exe`.
 
 Expected release artifacts include:
 
-- macOS universal `.dmg`
-- macOS universal `.zip`
+- macOS x64, arm64, and universal `.dmg`
+- macOS x64, arm64, and universal `.zip`
 - Windows `.exe`
 - Linux `.AppImage`
 - update metadata such as `.yml` and `.blockmap`
 - `SHA256SUMS.txt`
+
+Release notes and Feishu notifications should point the primary macOS download at the universal `.dmg`. The x64 and arm64 artifacts remain attached to the GitHub Release for users or deployment tools that want an architecture-specific installer.
 
 ## Auto Update
 

--- a/docs/conventions/desktop-release.md
+++ b/docs/conventions/desktop-release.md
@@ -85,6 +85,8 @@ Before running `electron-builder`, the script builds `services/tuttid` and place
 apps/desktop/build/tuttid/
 ```
 
+For macOS packages, the bundled `tuttid` daemon and `tutti` CLI must be universal binaries. Build both `darwin/arm64` and `darwin/amd64`, merge them with `lipo`, and verify the resulting binary contains `arm64` and `x86_64` slices before packaging.
+
 `electron-builder` then packages that daemon into the desktop app as:
 
 ```text
@@ -95,8 +97,8 @@ On Windows the bundled daemon filename is `tuttid.exe`.
 
 Expected release artifacts include:
 
-- macOS `.dmg`
-- macOS `.zip`
+- macOS universal `.dmg`
+- macOS universal `.zip`
 - Windows `.exe`
 - Linux `.AppImage`
 - update metadata such as `.yml` and `.blockmap`

--- a/docs/conventions/desktop-release.md
+++ b/docs/conventions/desktop-release.md
@@ -118,6 +118,10 @@ Current updater behavior:
 - scheduled update check interval is six hours
 - macOS update checks are disabled for unsupported unsigned or ad-hoc bundles
 
+macOS auto-update metadata must keep x64, arm64, and universal zip entries in `latest-mac.yml`. The file names must include `${arch}` so `electron-updater` can distinguish `mac-x64`, `mac-arm64`, and `mac-universal` assets.
+
+For automatic updates, electron-updater should download the same-architecture zip first: Intel Macs use `mac-x64.zip`, Apple Silicon Macs use `mac-arm64.zip`, and `mac-universal.zip` remains a fallback and the primary manual download. Do not make universal the only auto-update zip while architecture-specific packages exist.
+
 Policy meanings:
 
 - `off`: update checks are disabled

--- a/services/tuttid/service/workspace/apps_test.go
+++ b/services/tuttid/service/workspace/apps_test.go
@@ -2120,7 +2120,6 @@ func TestAppCenterServiceInstallReturnsWhileRemoteBuiltinDownloadRuns(t *testing
 		t.Fatalf("PutAppPackage() error = %v", err)
 	}
 	fetcher := newBlockingArtifactFetcher()
-	defer close(fetcher.release)
 	service := AppCenterService{
 		Store:           store,
 		WorkspaceStore:  &catalogStoreStub{getWorkspace: workspacebiz.Summary{ID: "ws-1", Name: "Workspace"}},
@@ -2177,6 +2176,13 @@ func TestAppCenterServiceInstallReturnsWhileRemoteBuiltinDownloadRuns(t *testing
 		}
 	case <-time.After(100 * time.Millisecond):
 		t.Fatal("Install() blocked on remote artifact download")
+	}
+
+	close(fetcher.release)
+	select {
+	case <-fetcher.done:
+	case <-time.After(time.Second):
+		t.Fatal("background remote builtin install job did not finish")
 	}
 }
 

--- a/tools/scripts/build-desktop-package.sh
+++ b/tools/scripts/build-desktop-package.sh
@@ -65,12 +65,12 @@ is_macos_package_variant() {
 
 require_macos_packaging_tools() {
   if [[ "$(uname -s)" != "Darwin" ]]; then
-    echo "macOS universal release packaging requires macOS." >&2
+    echo "macOS release packaging requires macOS." >&2
     exit 1
   fi
 
   if ! command -v lipo >/dev/null 2>&1; then
-    echo "macOS universal release packaging requires lipo." >&2
+    echo "macOS release packaging requires lipo." >&2
     exit 1
   fi
 }
@@ -205,11 +205,11 @@ run_electron_builder_mac_unsigned() {
     -u APPLE_TEAM_ID \
     -u APPLE_KEYCHAIN_PROFILE \
     CSC_IDENTITY_AUTO_DISCOVERY=false \
-    pnpm exec electron-builder --mac --universal --publish never -c.mac.notarize=false "-c.extraMetadata.version=${DESKTOP_BUILD_VERSION}"
+    pnpm exec electron-builder --mac --x64 --arm64 --universal --publish never -c.mac.notarize=false "-c.extraMetadata.version=${DESKTOP_BUILD_VERSION}"
 }
 
 run_electron_builder_mac_signed() {
-  pnpm exec electron-builder --mac --universal --publish never -c.mac.notarize=true "-c.extraMetadata.version=${DESKTOP_BUILD_VERSION}"
+  pnpm exec electron-builder --mac --x64 --arm64 --universal --publish never -c.mac.notarize=true "-c.extraMetadata.version=${DESKTOP_BUILD_VERSION}"
 }
 
 run_electron_builder_win() {

--- a/tools/scripts/build-desktop-package.sh
+++ b/tools/scripts/build-desktop-package.sh
@@ -59,6 +59,22 @@ has_signing_identity() {
     security find-identity -p codesigning -v 2>/dev/null | grep -q "Developer ID Application"
 }
 
+is_macos_package_variant() {
+  [[ "${VARIANT}" == "mac" || "${VARIANT}" == "mac-unsigned" || "${VARIANT}" == "mac-signed" ]]
+}
+
+require_macos_packaging_tools() {
+  if [[ "$(uname -s)" != "Darwin" ]]; then
+    echo "macOS universal release packaging requires macOS." >&2
+    exit 1
+  fi
+
+  if ! command -v lipo >/dev/null 2>&1; then
+    echo "macOS universal release packaging requires lipo." >&2
+    exit 1
+  fi
+}
+
 require_signed_macos_release_environment() {
   if [[ "$(uname -s)" != "Darwin" ]]; then
     echo "Signed macOS release packaging requires macOS." >&2
@@ -84,6 +100,37 @@ EOF
   fi
 }
 
+build_macos_universal_go_binary() {
+  local package_dir="$1"
+  local package_path="$2"
+  local output_path="$3"
+  local output_name="$4"
+  local staging_dir
+
+  staging_dir="$(mktemp -d)"
+  (
+    cd "${package_dir}"
+    GOOS=darwin GOARCH=arm64 go build -o "${staging_dir}/${output_name}-arm64" "${package_path}" &&
+      GOOS=darwin GOARCH=amd64 go build -o "${staging_dir}/${output_name}-amd64" "${package_path}"
+  ) || {
+    rm -rf "${staging_dir}"
+    return 1
+  }
+  lipo -create \
+    "${staging_dir}/${output_name}-arm64" \
+    "${staging_dir}/${output_name}-amd64" \
+    -output "${output_path}" || {
+    rm -rf "${staging_dir}"
+    return 1
+  }
+  lipo "${output_path}" -verify_arch arm64 x86_64 || {
+    rm -rf "${staging_dir}"
+    return 1
+  }
+  chmod 755 "${output_path}"
+  rm -rf "${staging_dir}"
+}
+
 prepare_packaged_daemon() {
   rm -rf "${DAEMON_BUNDLE_DIR}" "${CLI_BUNDLE_DIR}"
   mkdir -p "${DAEMON_BUNDLE_DIR}" "${CLI_BUNDLE_DIR}"
@@ -93,6 +140,21 @@ prepare_packaged_daemon() {
   if [[ "${VARIANT}" == "win" ]]; then
     daemon_output_name="tuttid.exe"
     cli_output_name="tutti.exe"
+  fi
+
+  if is_macos_package_variant; then
+    require_macos_packaging_tools
+    build_macos_universal_go_binary \
+      "${ROOT_DIR}/services/tuttid" \
+      "." \
+      "${DAEMON_BUNDLE_DIR}/${daemon_output_name}" \
+      "${daemon_output_name}" || return
+    build_macos_universal_go_binary \
+      "${ROOT_DIR}/apps/cli" \
+      "./cmd/tutti" \
+      "${CLI_BUNDLE_DIR}/${cli_output_name}" \
+      "${cli_output_name}" || return
+    return
   fi
 
   (
@@ -143,11 +205,11 @@ run_electron_builder_mac_unsigned() {
     -u APPLE_TEAM_ID \
     -u APPLE_KEYCHAIN_PROFILE \
     CSC_IDENTITY_AUTO_DISCOVERY=false \
-    pnpm exec electron-builder --mac --publish never -c.mac.notarize=false "-c.extraMetadata.version=${DESKTOP_BUILD_VERSION}"
+    pnpm exec electron-builder --mac --universal --publish never -c.mac.notarize=false "-c.extraMetadata.version=${DESKTOP_BUILD_VERSION}"
 }
 
 run_electron_builder_mac_signed() {
-  pnpm exec electron-builder --mac --publish never -c.mac.notarize=true "-c.extraMetadata.version=${DESKTOP_BUILD_VERSION}"
+  pnpm exec electron-builder --mac --universal --publish never -c.mac.notarize=true "-c.extraMetadata.version=${DESKTOP_BUILD_VERSION}"
 }
 
 run_electron_builder_win() {

--- a/tools/scripts/desktop-dmg-notarization.test.mjs
+++ b/tools/scripts/desktop-dmg-notarization.test.mjs
@@ -39,7 +39,7 @@ test("desktop DMG notarization retries transient notarytool submit failures", as
   });
 
   await notarizeMacDmgArtifacts({
-    artifactPaths: ["/tmp/Tutti-0.0.2-rc.17-mac-arm64.dmg"]
+    artifactPaths: ["/tmp/Tutti-0.0.2-rc.17-mac-universal.dmg"]
   });
 
   const submitCalls = calls.filter(
@@ -86,7 +86,7 @@ test("desktop DMG notarization fetches logs for invalid submissions without retr
 
   await assert.rejects(
     notarizeMacDmgArtifacts({
-      artifactPaths: ["/tmp/Tutti-0.0.2-rc.17-mac-arm64.dmg"]
+      artifactPaths: ["/tmp/Tutti-0.0.2-rc.17-mac-universal.dmg"]
     }),
     /notary submission invalid/
   );

--- a/tools/scripts/desktop-release-config.test.mjs
+++ b/tools/scripts/desktop-release-config.test.mjs
@@ -250,7 +250,7 @@ test("desktop release workflow materializes macOS signing certificate before pac
   );
 });
 
-test("desktop macOS packaging builds universal bundled binaries", async () => {
+test("desktop macOS packaging builds architecture-specific and universal artifacts", async () => {
   const buildScript = await readFile(buildScriptPath, "utf8");
 
   assert.match(buildScript, /GOOS=darwin\s+GOARCH=arm64\s+go build/);
@@ -260,7 +260,7 @@ test("desktop macOS packaging builds universal bundled binaries", async () => {
     buildScript,
     /lipo\s+"\$\{output_path\}"\s+-verify_arch\s+arm64\s+x86_64\s+\|\|\s+\{/
   );
-  assert.match(buildScript, /electron-builder --mac --universal/);
+  assert.match(buildScript, /electron-builder --mac --x64 --arm64 --universal/);
 });
 
 test("desktop release workflow opts JavaScript actions into Node 24", async () => {

--- a/tools/scripts/desktop-release-config.test.mjs
+++ b/tools/scripts/desktop-release-config.test.mjs
@@ -252,7 +252,9 @@ test("desktop release workflow materializes macOS signing certificate before pac
 
 test("desktop macOS packaging builds architecture-specific and universal artifacts", async () => {
   const buildScript = await readFile(buildScriptPath, "utf8");
+  const packageJson = JSON.parse(await readFile(desktopPackagePath, "utf8"));
 
+  assert.match(packageJson.build.artifactName, /\$\{arch\}/);
   assert.match(buildScript, /GOOS=darwin\s+GOARCH=arm64\s+go build/);
   assert.match(buildScript, /GOOS=darwin\s+GOARCH=amd64\s+go build/);
   assert.match(buildScript, /lipo\s+-create/);
@@ -300,6 +302,23 @@ test("desktop package ships ws as a runtime dependency for packaged main-process
     packageJson.devDependencies.ws,
     undefined,
     "ws should not live only in devDependencies or packaged apps will miss it"
+  );
+});
+
+test("desktop release docs describe same-architecture macOS updater preference", async () => {
+  const releaseDocsPath = new URL(
+    "../../docs/conventions/desktop-release.md",
+    import.meta.url
+  );
+  const releaseDocs = await readFile(releaseDocsPath, "utf8");
+
+  assert.match(
+    releaseDocs,
+    /macOS auto-update metadata must keep x64, arm64, and universal zip entries/
+  );
+  assert.match(
+    releaseDocs,
+    /electron-updater should download the same-architecture zip first/
   );
 });
 

--- a/tools/scripts/desktop-release-config.test.mjs
+++ b/tools/scripts/desktop-release-config.test.mjs
@@ -250,6 +250,19 @@ test("desktop release workflow materializes macOS signing certificate before pac
   );
 });
 
+test("desktop macOS packaging builds universal bundled binaries", async () => {
+  const buildScript = await readFile(buildScriptPath, "utf8");
+
+  assert.match(buildScript, /GOOS=darwin\s+GOARCH=arm64\s+go build/);
+  assert.match(buildScript, /GOOS=darwin\s+GOARCH=amd64\s+go build/);
+  assert.match(buildScript, /lipo\s+-create/);
+  assert.match(
+    buildScript,
+    /lipo\s+"\$\{output_path\}"\s+-verify_arch\s+arm64\s+x86_64\s+\|\|\s+\{/
+  );
+  assert.match(buildScript, /electron-builder --mac --universal/);
+});
+
 test("desktop release workflow opts JavaScript actions into Node 24", async () => {
   const workflow = await readFile(workflowPath, "utf8");
 

--- a/tools/scripts/desktop-release-download-links.test.mjs
+++ b/tools/scripts/desktop-release-download-links.test.mjs
@@ -11,7 +11,9 @@ test("desktop release notes append only macOS direct download links for mirrored
   const nextBody = buildUpdatedReleaseBody({
     assetNames: [
       "Tutti-0.1.0-rc.2-linux-x86_64.AppImage",
+      "Tutti-0.1.0-rc.2-mac-arm64.dmg",
       "Tutti-0.1.0-rc.2-mac-universal.dmg",
+      "Tutti-0.1.0-rc.2-mac-x64.dmg",
       "Tutti-0.1.0-rc.2-win-x64.exe"
     ],
     existingBody: "## What's Changed\n- Something",

--- a/tools/scripts/desktop-release-download-links.test.mjs
+++ b/tools/scripts/desktop-release-download-links.test.mjs
@@ -11,7 +11,7 @@ test("desktop release notes append only macOS direct download links for mirrored
   const nextBody = buildUpdatedReleaseBody({
     assetNames: [
       "Tutti-0.1.0-rc.2-linux-x86_64.AppImage",
-      "Tutti-0.1.0-rc.2-mac-arm64.dmg",
+      "Tutti-0.1.0-rc.2-mac-universal.dmg",
       "Tutti-0.1.0-rc.2-win-x64.exe"
     ],
     existingBody: "## What's Changed\n- Something",
@@ -27,7 +27,7 @@ test("desktop release notes append only macOS direct download links for mirrored
   assert.match(nextBody, /### Direct Downloads/);
   assert.match(
     nextBody,
-    /\[macOS\]\(https:\/\/d111111abcdef8\.cloudfront\.net\/desktop-release-assets\/v0\.1\.0-rc\.2\/Tutti-0\.1\.0-rc\.2-mac-arm64\.dmg\)/
+    /\[macOS\]\(https:\/\/d111111abcdef8\.cloudfront\.net\/desktop-release-assets\/v0\.1\.0-rc\.2\/Tutti-0\.1\.0-rc\.2-mac-universal\.dmg\)/
   );
   assert.doesNotMatch(nextBody, /\[Windows\]/);
   assert.doesNotMatch(nextBody, /\[Linux\]/);
@@ -46,7 +46,7 @@ test("desktop release notes replace the managed direct download section in place
   ].join("\n");
 
   const nextBody = buildUpdatedReleaseBody({
-    assetNames: ["Tutti-1.0.0-mac-arm64.dmg"],
+    assetNames: ["Tutti-1.0.0-mac-universal.dmg"],
     existingBody,
     releaseAssetBaseUrl: "https://downloads.example.com/tutti",
     releaseTag: "v1.0.0"
@@ -56,7 +56,7 @@ test("desktop release notes replace the managed direct download section in place
   assert.doesNotMatch(nextBody, /old\.example/);
   assert.match(
     nextBody,
-    /\[macOS\]\(https:\/\/downloads\.example\.com\/tutti\/v1\.0\.0\/Tutti-1\.0\.0-mac-arm64\.dmg\)/
+    /\[macOS\]\(https:\/\/downloads\.example\.com\/tutti\/v1\.0\.0\/Tutti-1\.0\.0-mac-universal\.dmg\)/
   );
 });
 
@@ -73,7 +73,7 @@ test("desktop release notes remove the managed section when no mirrored base URL
   ].join("\n");
 
   const nextBody = buildUpdatedReleaseBody({
-    assetNames: ["Tutti-1.0.0-mac-arm64.dmg"],
+    assetNames: ["Tutti-1.0.0-mac-universal.dmg"],
     existingBody,
     releaseAssetBaseUrl: "",
     releaseTag: "v1.0.0"

--- a/tools/scripts/desktop-release-download-links.test.mjs
+++ b/tools/scripts/desktop-release-download-links.test.mjs
@@ -7,7 +7,7 @@ import {
   buildUpdatedReleaseBody
 } from "../../apps/desktop/scripts/upsert-release-download-links.mjs";
 
-test("desktop release notes append only macOS direct download links for mirrored assets", () => {
+test("desktop release notes append all macOS direct download links for mirrored assets", () => {
   const nextBody = buildUpdatedReleaseBody({
     assetNames: [
       "Tutti-0.1.0-rc.2-linux-x86_64.AppImage",
@@ -29,7 +29,15 @@ test("desktop release notes append only macOS direct download links for mirrored
   assert.match(nextBody, /### Direct Downloads/);
   assert.match(
     nextBody,
-    /\[macOS\]\(https:\/\/d111111abcdef8\.cloudfront\.net\/desktop-release-assets\/v0\.1\.0-rc\.2\/Tutti-0\.1\.0-rc\.2-mac-universal\.dmg\)/
+    /\[macOS Apple Silicon \(arm64\)\]\(https:\/\/d111111abcdef8\.cloudfront\.net\/desktop-release-assets\/v0\.1\.0-rc\.2\/Tutti-0\.1\.0-rc\.2-mac-arm64\.dmg\)/
+  );
+  assert.match(
+    nextBody,
+    /\[macOS Intel \(x64\)\]\(https:\/\/d111111abcdef8\.cloudfront\.net\/desktop-release-assets\/v0\.1\.0-rc\.2\/Tutti-0\.1\.0-rc\.2-mac-x64\.dmg\)/
+  );
+  assert.match(
+    nextBody,
+    /\[macOS Universal\]\(https:\/\/d111111abcdef8\.cloudfront\.net\/desktop-release-assets\/v0\.1\.0-rc\.2\/Tutti-0\.1\.0-rc\.2-mac-universal\.dmg\)/
   );
   assert.doesNotMatch(nextBody, /\[Windows\]/);
   assert.doesNotMatch(nextBody, /\[Linux\]/);
@@ -58,7 +66,7 @@ test("desktop release notes replace the managed direct download section in place
   assert.doesNotMatch(nextBody, /old\.example/);
   assert.match(
     nextBody,
-    /\[macOS\]\(https:\/\/downloads\.example\.com\/tutti\/v1\.0\.0\/Tutti-1\.0\.0-mac-universal\.dmg\)/
+    /\[macOS Universal\]\(https:\/\/downloads\.example\.com\/tutti\/v1\.0\.0\/Tutti-1\.0\.0-mac-universal\.dmg\)/
   );
 });
 

--- a/tools/scripts/desktop-release-feishu-card.test.mjs
+++ b/tools/scripts/desktop-release-feishu-card.test.mjs
@@ -90,7 +90,12 @@ test("release Feishu card can prefer mirrored asset links over GitHub asset URLs
 test("release Feishu card resolves mirrored macOS URLs from local artifact names", () => {
   assert.equal(
     resolveMirroredAssetUrl(
-      ["Tutti-0.1.0-rc.4-mac-universal.dmg", "Tutti-0.1.0-rc.4-win-x64.exe"],
+      [
+        "Tutti-0.1.0-rc.4-mac-arm64.dmg",
+        "Tutti-0.1.0-rc.4-mac-universal.dmg",
+        "Tutti-0.1.0-rc.4-mac-x64.dmg",
+        "Tutti-0.1.0-rc.4-win-x64.exe"
+      ],
       /\.dmg$/i,
       "https://d1x7gb6wqsqmnm.cloudfront.net/tutti-desktop-release-assets",
       "v0.1.0-rc.4"

--- a/tools/scripts/desktop-release-feishu-card.test.mjs
+++ b/tools/scripts/desktop-release-feishu-card.test.mjs
@@ -90,11 +90,11 @@ test("release Feishu card can prefer mirrored asset links over GitHub asset URLs
 test("release Feishu card resolves mirrored macOS URLs from local artifact names", () => {
   assert.equal(
     resolveMirroredAssetUrl(
-      ["Tutti-0.1.0-rc.4-mac-arm64.dmg", "Tutti-0.1.0-rc.4-win-x64.exe"],
+      ["Tutti-0.1.0-rc.4-mac-universal.dmg", "Tutti-0.1.0-rc.4-win-x64.exe"],
       /\.dmg$/i,
       "https://d1x7gb6wqsqmnm.cloudfront.net/tutti-desktop-release-assets",
       "v0.1.0-rc.4"
     ),
-    "https://d1x7gb6wqsqmnm.cloudfront.net/tutti-desktop-release-assets/v0.1.0-rc.4/Tutti-0.1.0-rc.4-mac-arm64.dmg"
+    "https://d1x7gb6wqsqmnm.cloudfront.net/tutti-desktop-release-assets/v0.1.0-rc.4/Tutti-0.1.0-rc.4-mac-universal.dmg"
   );
 });


### PR DESCRIPTION
## Summary
- Build macOS desktop release assets as x64, arm64, and universal packages.
- Keep the manual macOS download link pointed at the universal DMG.
- Document and test that macOS auto-update metadata keeps architecture-specific ZIPs so updater downloads the same-architecture package first.

## Verification
- `pnpm --filter @tutti-os/desktop build:mac:unsigned`
- `pnpm test:tools`
- `pnpm check:full` via pre-push hook
- GitHub Actions unsigned dry run: https://github.com/tutti-os/tutti/actions/runs/27744235142

## Notes
- Local unsigned package sizes: x64 DMG 198.8 MB, arm64 DMG 194.8 MB, universal DMG 284.0 MB.
- The dry-run artifact includes all macOS DMG/ZIP assets and is 1,333,112,751 bytes.
