### PR TITLE
Speed up macOS DMG notarization

### DIFF
--- a/apps/desktop/scripts/notarize-mac-dmg-artifacts.mjs
+++ b/apps/desktop/scripts/notarize-mac-dmg-artifacts.mjs
@@ -179,9 +179,7 @@ export function createDmgArtifactNotarizer({
       return [];
     }
 
-    for (const dmgPath of resolveDmgArtifactPaths(buildResult)) {
-      await notarizeDmg(dmgPath);
-    }
+    await Promise.all(resolveDmgArtifactPaths(buildResult).map(notarizeDmg));
 
     return [];
   };

--- a/tools/scripts/desktop-dmg-notarization.test.mjs
+++ b/tools/scripts/desktop-dmg-notarization.test.mjs
@@ -102,3 +102,55 @@ test("desktop DMG notarization fetches logs for invalid submissions without retr
   assert.equal(logCalls.length, 1);
   assert.equal(logCalls[0][1][2], "submission-id");
 });
+
+test("desktop DMG notarization submits multiple artifacts concurrently", async () => {
+  let activeSubmits = 0;
+  let maxConcurrentSubmits = 0;
+  const calls = [];
+  const notarizeMacDmgArtifacts = createDmgArtifactNotarizer({
+    env: {
+      APPLE_API_KEY: "/tmp/AuthKey_TEST.p8",
+      APPLE_API_KEY_ID: "TESTKEY",
+      APPLE_API_ISSUER: "TESTISSUER"
+    },
+    logger: {
+      error() {},
+      log() {}
+    },
+    platform: "darwin",
+    runCommand: async (command, args) => {
+      calls.push([command, args]);
+
+      if (args[0] === "notarytool" && args[1] === "submit") {
+        activeSubmits += 1;
+        maxConcurrentSubmits = Math.max(maxConcurrentSubmits, activeSubmits);
+        await new Promise((resolve) => setTimeout(resolve, 10));
+        activeSubmits -= 1;
+      }
+
+      return { stderr: "", stdout: "" };
+    }
+  });
+
+  await notarizeMacDmgArtifacts({
+    artifactPaths: [
+      "/tmp/Tutti-0.0.2-rc.17-mac-x64.dmg",
+      "/tmp/Tutti-0.0.2-rc.17-mac-arm64.dmg",
+      "/tmp/Tutti-0.0.2-rc.17-mac-universal.dmg"
+    ]
+  });
+
+  const submitCalls = calls.filter(
+    ([, args]) => args[0] === "notarytool" && args[1] === "submit"
+  );
+  const stapleCalls = calls.filter(
+    ([, args]) => args[0] === "stapler" && args[1] === "staple"
+  );
+
+  assert.equal(submitCalls.length, 3);
+  assert.equal(stapleCalls.length, 3);
+  assert.ok(
+    maxConcurrentSubmits > 1,
+    `expected concurrent notary submissions, got max concurrency ${maxConcurrentSubmits}`
+  );
+});


### PR DESCRIPTION
## Summary
- Run macOS DMG artifact notarization concurrently instead of serially after Electron Builder emits all DMGs.
- Add a regression test proving multiple DMG submissions overlap while preserving existing retry and invalid-submission behavior.

## Test Plan
- `pnpm exec node --test ./tools/scripts/desktop-dmg-notarization.test.mjs`
- `pnpm exec oxfmt --check apps/desktop/scripts/notarize-mac-dmg-artifacts.mjs tools/scripts/desktop-dmg-notarization.test.mjs`
- `pnpm test:tools`
- `pnpm --filter @tutti-os/desktop exec node --test --experimental-strip-types ./src/main/ipc/workspaceAppFrontendLogging.test.ts`

## Notes
- A pre-push `check:full` run was blocked by an unrelated flaky desktop test: `workspace app frontend log writer appends to web.log` expected `page.ready` but saw `page.loaded`. The same test file passed when rerun directly.
