### PR TITLE
[codex] Fix external chat import prompt and titles

### DIFF
--- a/apps/desktop/src/renderer/src/features/workspace-workbench/ui/ExternalAgentSessionImportPrompt.tsx
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/ui/ExternalAgentSessionImportPrompt.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useMemo, useRef, useSyncExternalStore } from "react";
 import type { WorkspaceAgentProvider } from "@tutti-os/client-tuttid-ts";
-import { toast } from "@tutti-os/ui-system";
+import { Button, CloseIcon, toast } from "@tutti-os/ui-system";
 import { useService } from "@tutti-os/infra/di";
 import { IAgentProviderStatusService } from "@renderer/features/workspace-agent";
 import { useTranslation } from "@renderer/i18n";
@@ -61,22 +61,56 @@ export function ExternalAgentSessionImportPrompt({
     const providerNames = providers
       .map((provider) => resolveWorkspaceAgentGuiLabel(provider))
       .join(" / ");
-    toast(t("workspace.externalImport.promptTitle"), {
-      action: {
-        label: t("workspace.externalImport.promptImport"),
-        onClick: () => {
-          onOpenImport(providers);
-        }
-      },
-      cancel: {
-        label: t("workspace.externalImport.promptLater"),
-        onClick: () => undefined
-      },
-      description: t("workspace.externalImport.promptDescription", {
-        provider: providerNames
-      }),
-      duration: 16000
-    });
+    toast.custom(
+      (id) => (
+        <article className="relative w-full min-w-0 overflow-visible rounded-[12px] border border-[var(--line-2)] bg-[var(--background-fronted)] p-3.5 shadow-[0_14px_40px_var(--shadow-elevated)]">
+          <button
+            type="button"
+            aria-label={t("common.close")}
+            className="workspace-agent-decision-toast__close absolute top-0 right-0 z-[2] inline-flex size-6 translate-x-[35%] -translate-y-[35%] items-center justify-center rounded-full border border-[var(--line-2)] bg-[var(--background-panel)] text-[var(--text-secondary)] shadow-sm transition-colors hover:bg-[var(--background-fronted)] hover:text-[var(--text-primary)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color-mix(in_srgb,var(--border-focus)_30%,transparent)]"
+            onClick={() => toast.dismiss(id)}
+          >
+            <CloseIcon className="size-4" />
+          </button>
+          <div className="workspace-agent-decision-toast__content relative z-[1] grid min-w-0 gap-3 transition-opacity">
+            <div className="grid min-w-0 gap-1 pr-3">
+              <h3 className="m-0 text-[13px] font-semibold leading-5 text-[var(--text-primary)]">
+                {t("workspace.externalImport.promptTitle")}
+              </h3>
+              <p className="m-0 text-[12px] font-normal leading-5 text-[var(--text-secondary)]">
+                {t("workspace.externalImport.promptDescription", {
+                  provider: providerNames
+                })}
+              </p>
+            </div>
+            <div className="flex justify-end gap-2">
+              <Button
+                size="sm"
+                type="button"
+                variant="ghost"
+                onClick={() => toast.dismiss(id)}
+              >
+                {t("workspace.externalImport.promptLater")}
+              </Button>
+              <Button
+                size="sm"
+                type="button"
+                onClick={() => {
+                  toast.dismiss(id);
+                  onOpenImport(providers);
+                }}
+              >
+                {t("workspace.externalImport.promptImport")}
+              </Button>
+            </div>
+          </div>
+        </article>
+      ),
+      {
+        className: "workspace-agent-decision-toast",
+        duration: 16000
+      }
+    );
   }, [onOpenImport, readyProviders, t, workspaceId]);
 
   return null;

--- a/services/tuttid/service/agent/external_import.go
+++ b/services/tuttid/service/agent/external_import.go
@@ -455,9 +455,6 @@ func (s *Service) importExternalSession(ctx context.Context, workspaceID string,
 			CompletedAtUnixMS: message.OccurredAtUnixMS,
 		})
 	}
-	if len(updates) == 0 && sessionExists {
-		return 0, false, nil
-	}
 	if _, err := s.ExternalImportStore.ReportSessionState(ctx, agentactivitybiz.SessionStateReport{
 		WorkspaceID:       workspaceID,
 		AgentSessionID:    agentSessionID,
@@ -478,6 +475,9 @@ func (s *Service) importExternalSession(ctx context.Context, workspaceID string,
 		EndedAtUnixMS:    session.UpdatedAtUnixMS,
 	}); err != nil {
 		return 0, false, err
+	}
+	if len(updates) == 0 && sessionExists {
+		return 0, false, nil
 	}
 	importedMessages := 0
 	for start := 0; start < len(updates); start += 200 {

--- a/services/tuttid/service/agent/external_import_parse.go
+++ b/services/tuttid/service/agent/external_import_parse.go
@@ -31,6 +31,11 @@ func parseCodexJSONL(path string, reader io.Reader) (externalImportedSession, bo
 			if message.Text != "" {
 				session.Messages = append(session.Messages, message)
 			}
+		case "event_msg":
+			payload := mapField(raw, "payload")
+			if stringField(payload, "type") == "user_message" {
+				session.Title = firstNonEmptyString(session.Title, externalContentText(payload["message"]))
+			}
 		}
 	})
 	if err != nil {
@@ -127,8 +132,20 @@ func normalizeExternalParsedSession(session externalImportedSession) (externalIm
 	session.Messages = messages
 	session.StartedAtUnixMS = firstExternalMessageUnixMS(messages)
 	session.UpdatedAtUnixMS = lastExternalMessageUnixMS(messages)
-	session.Title = externalSessionTitle(messages)
+	session.Title = externalParsedSessionTitle(session.Title, messages)
 	return session, true, nil
+}
+
+func externalParsedSessionTitle(hint string, messages []externalImportedMessage) string {
+	if hint = strings.TrimSpace(hint); hint != "" {
+		return truncateExternalTitle(hint)
+	}
+	for _, message := range messages {
+		if message.Role == "user" && !strings.HasPrefix(message.Text, "<environment_context>") {
+			return truncateExternalTitle(message.Text)
+		}
+	}
+	return externalSessionTitle(messages)
 }
 
 func readJSONLLines(reader io.Reader, handle func(int, map[string]any)) error {

--- a/services/tuttid/service/agent/external_import_parse_test.go
+++ b/services/tuttid/service/agent/external_import_parse_test.go
@@ -1,0 +1,62 @@
+package agent
+
+import (
+	"encoding/json"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestParseCodexJSONLUsesFirstUserEventAsTitle(t *testing.T) {
+	cwd := t.TempDir()
+	session, ok, err := parseCodexJSONL(
+		filepath.Join(cwd, "rollout.jsonl"),
+		strings.NewReader(testAgentJSONL(t,
+			map[string]any{
+				"timestamp": "2026-06-18T00:00:00Z",
+				"type":      "session_meta",
+				"payload":   map[string]any{"id": "codex-title", "cwd": cwd},
+			},
+			map[string]any{
+				"timestamp": "2026-06-18T00:00:01Z",
+				"type":      "response_item",
+				"payload": map[string]any{
+					"type":    "message",
+					"role":    "user",
+					"content": []any{map[string]any{"type": "input_text", "text": "<environment_context>\n</environment_context>"}},
+				},
+			},
+			map[string]any{
+				"timestamp": "2026-06-18T00:00:02Z",
+				"type":      "event_msg",
+				"payload": map[string]any{
+					"type":    "user_message",
+					"message": "Tell me the plan",
+				},
+			},
+		)),
+	)
+	if err != nil {
+		t.Fatalf("parseCodexJSONL error = %v", err)
+	}
+	if !ok {
+		t.Fatal("parseCodexJSONL ok = false")
+	}
+	if session.Title != "Tell me the plan" {
+		t.Fatalf("title = %q, want first user message", session.Title)
+	}
+}
+
+func testAgentJSONL(t *testing.T, items ...map[string]any) string {
+	t.Helper()
+	var builder strings.Builder
+	for _, item := range items {
+		encoded, err := json.Marshal(item)
+		if err != nil {
+			t.Fatalf("marshal jsonl item error = %v", err)
+		}
+		builder.Write(encoded)
+		builder.WriteByte('\n')
+	}
+	return builder.String()
+}

--- a/services/tuttid/service/agent/service_test.go
+++ b/services/tuttid/service/agent/service_test.go
@@ -170,6 +170,13 @@ func TestServiceImportsExternalAgentSessionsByProject(t *testing.T) {
 	if result.ImportedProjects != 1 || result.ImportedSessions != 1 || result.ImportedMessages != 2 {
 		t.Fatalf("import result = %#v, want one project, one session, two messages", result)
 	}
+	importedSession, err := service.Get(ctx, "ws-1", codexAID)
+	if err != nil {
+		t.Fatalf("Get imported session error = %v", err)
+	}
+	if value(importedSession.Title) != "Plan the import" {
+		t.Fatalf("imported session title = %q, want first user message", value(importedSession.Title))
+	}
 	sessions, err := service.List(ctx, "ws-1")
 	if err != nil {
 		t.Fatalf("List error = %v", err)
@@ -209,6 +216,37 @@ func TestServiceImportsExternalAgentSessionsByProject(t *testing.T) {
 	}
 	if finalRerun.ImportedSessions != 0 || finalRerun.ImportedMessages != 0 {
 		t.Fatalf("final rerun import = %#v, want no new sessions or messages", finalRerun)
+	}
+	writeAgentServiceJSONL(t, filepath.Join(codexHome, "sessions", "2026", "codex-a.jsonl"),
+		map[string]any{
+			"timestamp": timestamp(0),
+			"type":      "session_meta",
+			"payload":   map[string]any{"id": "codex-a", "cwd": projectA},
+		},
+		map[string]any{"timestamp": timestamp(time.Second), "type": "response_item", "payload": map[string]any{
+			"type": "message", "id": "codex-a-1", "role": "user",
+			"content": []any{map[string]any{"type": "input_text", "text": "Updated first prompt"}},
+		}},
+		map[string]any{"timestamp": timestamp(2 * time.Second), "type": "response_item", "payload": map[string]any{
+			"type": "message", "id": "codex-a-2", "role": "assistant",
+			"content": []any{map[string]any{"type": "output_text", "text": "Import planned"}},
+		}},
+	)
+	titleRefresh, err := service.ImportExternalSessions(ctx, "ws-1", ExternalImportInput{
+		Projects: []ExternalImportProjectSelection{{Path: projectA, SessionIDs: []string{codexAID}}},
+	})
+	if err != nil {
+		t.Fatalf("ImportExternalSessions title refresh error = %v", err)
+	}
+	if titleRefresh.ImportedSessions != 0 || titleRefresh.ImportedMessages != 0 {
+		t.Fatalf("title refresh import = %#v, want no new sessions or messages", titleRefresh)
+	}
+	refreshedSession, err := service.Get(ctx, "ws-1", codexAID)
+	if err != nil {
+		t.Fatalf("Get refreshed imported session error = %v", err)
+	}
+	if value(refreshedSession.Title) != "Updated first prompt" {
+		t.Fatalf("refreshed title = %q, want updated first user message", value(refreshedSession.Title))
 	}
 }
 


### PR DESCRIPTION
## Summary

- Rework the external AI chat import prompt to use the same custom toast shell as agent decision notifications instead of the generic Sonner action layout.
- Parse Codex `event_msg.user_message` records as the imported session title source and skip environment-context fallback titles.
- Refresh imported session state on re-import so corrected titles can update without duplicating messages.

## Root Cause

The prompt used the generic Sonner title/action API, which does not match the desktop multi-action notification styling. Codex imports also missed the real user-message event shape, so imported titles could fall back to non-user content or opaque identifiers.

## Validation

- `pnpm --filter @tutti-os/desktop typecheck`
- `pnpm check:changed --tail-lines 80`
- `cd services/tuttid && go test ./service/agent`
- pre-push `pnpm check:full`