### PR TITLE
docs(readme): align Tutti Cloud intro with runs-on table copy

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ Whatever your role, Tutti helps you find the lowest-friction way to combine the 
 - Use all apps inside Tutti with your existing agent subscriptions.
 - Describe a goal, let agents break it into subtasks, then assign each task to the right agent.
 
-**In Tutti · Cloud** (Runs locally. Outputs live in the cloud.)
+**In Tutti · Cloud** (Agents run locally. Outputs live in the cloud.)
 
 Everything in the local version, plus:
 


### PR DESCRIPTION
## Summary

- Update the Tutti · Cloud section intro to say "Agents run locally. Outputs live in the cloud." so it matches the comparison table wording updated in d5848f4b.

## Test plan

- [ ] Read README Tutti · Cloud section and comparison table; confirm both use the same phrasing.


Made with [Cursor](https://cursor.com)