### PR TITLE
Rename issue mention copy to tasks

### DIFF
--- a/packages/agent/gui/agent-gui/agentGuiNode/AgentComposer.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/AgentComposer.tsx
@@ -1533,8 +1533,8 @@ export function AgentComposer({
     insertWorkspaceReferences(await onRequestWorkspaceReferences());
   }, [insertWorkspaceReferences, onRequestWorkspaceReferences]);
 
-  // @ 面板里点事项/应用行的「查看产物文件」图标:关掉面板,打开引用 picker 并定位到该实体;
-  // 选中的文件仍按常规插入,但不会把该事项/应用本身作为 mention 插入。
+  // @ 面板里点任务/应用行的「查看产物文件」图标:关掉面板,打开引用 picker 并定位到该实体;
+  // 选中的文件仍按常规插入,但不会把该任务/应用本身作为 mention 插入。
   const handleOpenReferencesForEntity = useCallback(
     (entity: AgentContextMentionItem): void => {
       closeFileMentionPalette();

--- a/packages/agent/gui/agent-gui/agentGuiNode/AgentFileMentionPalette.spec.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/AgentFileMentionPalette.spec.tsx
@@ -17,9 +17,9 @@ vi.mock("../../i18n/index", async () => {
     "agentHost.agentGui.mentionFilterSession": "Sessions",
     "agentHost.agentGui.mentionGroupApps": "Apps",
     "agentHost.agentGui.mentionEmptyMySessions": "暂无会话",
-    "agentHost.agentGui.mentionGroupIssues": "事项",
-    "agentHost.agentGui.mentionEmptyIssues": "暂无事项",
-    "agentHost.agentGui.mentionFilterIssue": "事项",
+    "agentHost.agentGui.mentionGroupIssues": "任务",
+    "agentHost.agentGui.mentionEmptyIssues": "暂无任务",
+    "agentHost.agentGui.mentionFilterIssue": "任务",
     "agentHost.agentGui.fileMentionSwitchCategory": "切换分类",
     "agentHost.agentGui.fileMentionSwitchSelection": "切换选中",
     "agentHost.agentGui.contextPickerBrowseFileHint":
@@ -1264,12 +1264,12 @@ describe("AgentFileMentionPalette", () => {
       "border-t",
       "border-[var(--line-1)]"
     );
-    expect(screen.getByText("事项")).toHaveClass(
+    expect(screen.getByText("任务")).toHaveClass(
       "text-[13px]",
       "font-normal",
       "text-[var(--text-secondary)]"
     );
-    expect(screen.getByText("暂无事项")).toHaveClass(
+    expect(screen.getByText("暂无任务")).toHaveClass(
       "text-[13px]",
       "font-normal",
       "text-[var(--text-tertiary)]"

--- a/packages/agent/gui/agent-gui/agentGuiNode/AgentGUINode.spec.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/AgentGUINode.spec.tsx
@@ -413,31 +413,31 @@ vi.mock("../../i18n/index", () => ({
       "agentHost.agentGui.mentionFilterFile": "文件",
       "agentHost.agentGui.mentionFilterSession": "会话",
       "agentHost.agentGui.mentionFilterCollab": "协作",
-      "agentHost.agentGui.mentionFilterIssue": "Issue",
+      "agentHost.agentGui.mentionFilterIssue": "Tasks",
       "agentHost.agentGui.mentionGroupApps": "App",
       "agentHost.agentGui.mentionGroupFiles": "文件",
       "agentHost.agentGui.mentionGroupMySessions": "我的会话",
       "agentHost.agentGui.mentionGroupCollabSessions": "协作会话",
-      "agentHost.agentGui.mentionGroupIssues": "Issue",
+      "agentHost.agentGui.mentionGroupIssues": "Tasks",
       "agentHost.agentGui.mentionEmptyMySessions": "暂无会话",
       "agentHost.agentGui.mentionEmptyCollabSessions": "暂无协作会话",
-      "agentHost.agentGui.mentionEmptyIssues": "暂无 Issue",
+      "agentHost.agentGui.mentionEmptyIssues": "No tasks yet",
       "agentHost.agentGui.mentionNoMatchingFiles": "没有匹配到文件",
       "agentHost.agentGui.fileMentionEmpty": "根据你输入的内容搜索工作区文件",
       "agentHost.agentGui.promptTipsPrefix": "Tips：",
       "agentHost.agentGui.promptTips.setWorkspace.label": "指定工作区",
       "agentHost.agentGui.promptTips.setWorkspace.prompt":
         "让 Agent 知道在哪里读文件、运行命令和理解代码",
-      "agentHost.agentGui.promptTips.useIssue.label": "善用Issue",
+      "agentHost.agentGui.promptTips.useIssue.label": "善用任务",
       "agentHost.agentGui.promptTips.useIssue.prompt":
-        "把需求、约束和验收标准写进 Issue，Agent 更容易按目标推进",
+        "把需求、约束和验收标准写进任务，Agent 更容易按目标推进",
       "agentHost.agentGui.promptTips.mapCurrentState.label": "先梳理现状",
       "agentHost.agentGui.promptTips.mapCurrentState.prompt":
         "不确定怎么下手时，让 Agent 先总结当前状态、风险和下一步",
       "agentHost.agentGui.promptTips.continueRecentSession.label":
         "接力最近会话",
       "agentHost.agentGui.promptTips.continueRecentSession.prompt":
-        "延续工作时让 Agent 先回顾最近进展、未完成事项和阻塞点",
+        "延续工作时让 Agent 先回顾最近进展、未完成任务和阻塞点",
       "agentHost.agentGui.promptTips.referenceOtherAgents.label":
         "引用其他 Agent 对话历史",
       "agentHost.agentGui.promptTips.referenceOtherAgents.prompt":
@@ -545,16 +545,16 @@ vi.mock("../../i18n/index", () => ({
         "agentHost.agentGui.promptTips.setWorkspace.label": "指定工作区",
         "agentHost.agentGui.promptTips.setWorkspace.prompt":
           "让 Agent 知道在哪里读文件、运行命令和理解代码",
-        "agentHost.agentGui.promptTips.useIssue.label": "善用Issue",
+        "agentHost.agentGui.promptTips.useIssue.label": "善用任务",
         "agentHost.agentGui.promptTips.useIssue.prompt":
-          "把需求、约束和验收标准写进 Issue，Agent 更容易按目标推进",
+          "把需求、约束和验收标准写进任务，Agent 更容易按目标推进",
         "agentHost.agentGui.promptTips.mapCurrentState.label": "先梳理现状",
         "agentHost.agentGui.promptTips.mapCurrentState.prompt":
           "不确定怎么下手时，让 Agent 先总结当前状态、风险和下一步",
         "agentHost.agentGui.promptTips.continueRecentSession.label":
           "接力最近会话",
         "agentHost.agentGui.promptTips.continueRecentSession.prompt":
-          "延续工作时让 Agent 先回顾最近进展、未完成事项和阻塞点",
+          "延续工作时让 Agent 先回顾最近进展、未完成任务和阻塞点",
         "agentHost.agentGui.promptTips.referenceOtherAgents.label":
           "引用其他 Agent 对话历史",
         "agentHost.agentGui.promptTips.referenceOtherAgents.prompt":
@@ -4515,7 +4515,7 @@ describe("AgentGUINode", () => {
     expect(within(palette).queryByText("暂无会话")).toBeNull();
     expect(within(palette).queryByText("暂无协作会话")).toBeNull();
     expect(within(palette).queryByRole("tab", { name: "协作" })).toBeNull();
-    expect(within(palette).queryByText("暂无 Issue")).toBeNull();
+    expect(within(palette).queryByText("No tasks yet")).toBeNull();
 
     fireEvent.keyDown(getComposerEditor(), { key: "ArrowDown" });
 
@@ -4577,8 +4577,8 @@ describe("AgentGUINode", () => {
     expect(within(palette).queryByText("暂无会话")).toBeNull();
     expect(within(palette).queryByText("协作会话")).toBeNull();
     expect(within(palette).queryByText("暂无协作会话")).toBeNull();
-    expect(within(palette).getAllByText("Issue").length).toBeGreaterThan(0);
-    expect(within(palette).queryByText("暂无 Issue")).toBeNull();
+    expect(within(palette).getAllByText("Tasks").length).toBeGreaterThan(0);
+    expect(within(palette).queryByText("No tasks yet")).toBeNull();
   });
 
   it("shows the loading label when opening @ mentions before any browse data is ready", async () => {
@@ -4661,19 +4661,19 @@ describe("AgentGUINode", () => {
     const palette = await screen.findByRole("listbox", {
       name: "agentHost.agentGui.fileMentionPalette"
     });
-    expect(await within(palette).findByText("暂无 Issue")).toBeTruthy();
+    expect(await within(palette).findByText("No tasks yet")).toBeTruthy();
     const surface = screen.getByTestId("agent-gui-mention-palette-surface");
     const initialSurfaceStyle = surface.getAttribute("style") ?? "";
     const initialSurfaceHeight =
       initialSurfaceStyle.match(/height:[^;]+/)?.[0] ?? "";
     expect(initialSurfaceHeight).toBeTruthy();
 
-    fireEvent.click(within(palette).getByRole("tab", { name: "Issue" }));
+    fireEvent.click(within(palette).getByRole("tab", { name: "Tasks" }));
 
     await waitFor(() =>
       expect(mockListWorkspaceIssues).toHaveBeenCalledTimes(2)
     );
-    expect(within(palette).getByRole("tab", { name: "Issue" })).toHaveAttribute(
+    expect(within(palette).getByRole("tab", { name: "Tasks" })).toHaveAttribute(
       "aria-selected",
       "true"
     );
@@ -4930,7 +4930,7 @@ describe("AgentGUINode", () => {
     const palette = await screen.findByRole("listbox", {
       name: "agentHost.agentGui.fileMentionPalette"
     });
-    fireEvent.click(within(palette).getByRole("tab", { name: "Issue" }));
+    fireEvent.click(within(palette).getByRole("tab", { name: "Tasks" }));
 
     await waitFor(() =>
       expect(mockListWorkspaceIssues).toHaveBeenCalledWith({
@@ -4945,7 +4945,7 @@ describe("AgentGUINode", () => {
     const secondTaskOption = (
       await screen.findByText("整理 agent 输入")
     ).closest("button");
-    const taskOption = within(palette).getByRole("tab", { name: "Issue" });
+    const taskOption = within(palette).getByRole("tab", { name: "Tasks" });
     const allOption = within(palette).getByRole("tab", { name: "全部" });
     const appOption = within(palette).getByRole("tab", { name: "App" });
 
@@ -4970,7 +4970,7 @@ describe("AgentGUINode", () => {
 
     await waitFor(() => {
       expect(
-        within(palette).getByRole("tab", { name: "Issue" })
+        within(palette).getByRole("tab", { name: "Tasks" })
       ).toHaveAttribute("aria-selected", "false");
       expect(within(palette).getByRole("tab", { name: "App" })).toHaveAttribute(
         "aria-selected",

--- a/packages/agent/gui/agent-gui/agentGuiNode/AgentGUINodeView.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/AgentGUINodeView.tsx
@@ -117,7 +117,7 @@ import type { AgentContextMentionProvider } from "./agentContextMentionProvider"
 import type { AgentContextMentionItem } from "./agentRichText/agentFileMentionExtension";
 
 /**
- * 把 @ 面板里的事项/应用 mention 解析为引用 picker 的定位目标(sourceId + 语义 params)。
+ * 把 @ 面板里的任务/应用 mention 解析为引用 picker 的定位目标(sourceId + 语义 params)。
  * 由宿主(desktop)注入 —— 源 id 与 params 形态是宿主侧 reference source 的知识。
  */
 export type AgentMentionReferenceTargetResolver = (
@@ -822,7 +822,7 @@ export function AgentGUINodeView({
   );
   const [workspaceReferencePickerOpen, setWorkspaceReferencePickerOpen] =
     useState(false);
-  // 打开引用 picker 时的定位目标(点事项/应用行的产物图标时设置;「+」按钮则为 null)。
+  // 打开引用 picker 时的定位目标(点任务/应用行的产物图标时设置;「+」按钮则为 null)。
   const [workspaceReferencePickerTarget, setWorkspaceReferencePickerTarget] =
     useState<ReferenceLocateTarget | null>(null);
   const [

--- a/packages/agent/gui/agent-gui/agentGuiNode/AgentMentionLabels.spec.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/AgentMentionLabels.spec.ts
@@ -26,11 +26,11 @@ describe("AgentMentionLabels", () => {
     expect(agentMentionFilterLabel("all")).toBe("全部");
     expect(agentMentionFilterLabel("app")).toBe("应用");
     expect(agentMentionFilterLabel("session")).toBe("会话");
-    expect(agentMentionFilterLabel("issue")).toBe("事项");
+    expect(agentMentionFilterLabel("issue")).toBe("任务");
     expect(agentMentionGroupLabel("apps")).toBe("应用");
-    expect(agentMentionGroupLabel("issues")).toBe("事项");
+    expect(agentMentionGroupLabel("issues")).toBe("任务");
     expect(agentMentionGroupLabel("my_sessions")).toBe("我的会话");
-    expect(agentMentionEmptyGroupLabel("issues", "")).toBe("暂无事项");
+    expect(agentMentionEmptyGroupLabel("issues", "")).toBe("暂无任务");
     expect(agentMentionEmptyGroupLabel("files", "")).toBe(
       "Dock 栏暂无已打开文件，输入关键词可搜索工作区文件"
     );

--- a/packages/agent/gui/agent-gui/agentGuiNode/AgentMentionSearchController.spec.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/AgentMentionSearchController.spec.ts
@@ -378,7 +378,7 @@ describe("AgentMentionSearchController", () => {
 
     expect(labelById.get("app")).toBe("应用");
     expect(labelById.get("session")).toBe("会话");
-    expect(labelById.get("issue")).toBe("事项");
+    expect(labelById.get("issue")).toBe("任务");
     expect(labelById.get("all")).toBe("全部");
   });
 

--- a/packages/agent/gui/agent-gui/agentGuiNode/agentRichText/AgentRichTextEditor.spec.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/agentRichText/AgentRichTextEditor.spec.tsx
@@ -555,7 +555,7 @@ describe("AgentRichTextEditor", () => {
     );
     expect(mentions[1]).toHaveAttribute(
       "aria-label",
-      "事项 修复 room status 批量接口"
+      "任务 修复 room status 批量接口"
     );
   });
 

--- a/packages/agent/gui/app/renderer/i18n/locales/zh-CN.ts
+++ b/packages/agent/gui/app/renderer/i18n/locales/zh-CN.ts
@@ -287,7 +287,7 @@ export const zhCN = {
       sheetTitle: "表格",
       sheetDescription: "整理结构化数据、表格、计算和房间计划清单",
       calendarTitle: "日程",
-      calendarDescription: "规划房间里程碑、跟进事项、评审和共享日程",
+      calendarDescription: "规划房间里程碑、跟进任务、评审和共享日程",
       systemMonitorTitle: "系统监控",
       systemMonitorDescription: "查看运行时健康度、资源信号和工作区活动",
       codeEditorTitle: "代码编辑器",
@@ -311,7 +311,7 @@ export const zhCN = {
       mockSheetPreviewTitle: "数据表格",
       mockSheetPreviewBody: "这里将展示表格、计算、筛选和房间计划数据",
       mockCalendarPreviewTitle: "房间日历",
-      mockCalendarPreviewBody: "这里将展示里程碑、会议、跟进事项和共享日程块",
+      mockCalendarPreviewBody: "这里将展示里程碑、会议、跟进任务和共享日程块",
       mockMonitorPreviewTitle: "运行时信号",
       mockMonitorPreviewBody: "这里将展示 CPU、内存、网络和工作区活动信号",
       mockCodePreviewTitle: "源码工作区",
@@ -324,7 +324,7 @@ export const zhCN = {
     workspaceCenterSearchAria: "打开房间搜索",
     workspaceCenterSearchTitle: "在当前房间搜索节点、分区与便签",
     agentGui: {
-      initialPlaceholder: "输入 @ 引用会话、文件、事项和应用",
+      initialPlaceholder: "输入 @ 引用会话、文件、任务和应用",
       followupPlaceholder: "要求 {{provider}} 继续后续变更",
       installRequiredPlaceholder:
         "请先从 Dock 安装 {{provider}}，然后再发送消息",
@@ -518,8 +518,8 @@ export const zhCN = {
           prompt: "让 Agent 知道在哪里读文件、运行命令和理解代码"
         },
         useIssue: {
-          label: "善用Issue",
-          prompt: "把需求、约束和验收标准写进 Issue，Agent 更容易按目标推进"
+          label: "善用任务",
+          prompt: "把需求、约束和验收标准写进任务，Agent 更容易按目标推进"
         },
         mapCurrentState: {
           label: "先梳理现状",
@@ -527,7 +527,7 @@ export const zhCN = {
         },
         continueRecentSession: {
           label: "接力最近会话",
-          prompt: "延续工作时让 Agent 先回顾最近进展、未完成事项和阻塞点"
+          prompt: "延续工作时让 Agent 先回顾最近进展、未完成任务和阻塞点"
         },
         referenceOtherAgents: {
           label: "引用其他 Agent 对话历史",
@@ -613,7 +613,7 @@ export const zhCN = {
       contextPickerBrowseAppHint: "输入内容以搜索应用",
       contextPickerBrowseSessionHint: "输入内容以搜索我发起的 Agent 会话",
       contextPickerBrowseCollabHint: "输入内容以搜索其他人和 Agent 的会话",
-      contextPickerBrowseIssueHint: "输入内容以搜索当前房间内的 Issue",
+      contextPickerBrowseIssueHint: "输入内容以搜索当前房间内的任务",
       workspaceAppFactoryMentionFallback: "创建应用",
       contextPickerExpandMore: "展开更多 {{count}} 条",
       contextPickerCategoryFileDescription: "搜索工作区文件和目录",
@@ -793,11 +793,11 @@ export const zhCN = {
       mentionFilterApp: "应用",
       mentionFilterSession: "会话",
       mentionFilterCollab: "协作",
-      mentionFilterIssue: "事项",
+      mentionFilterIssue: "任务",
       mentionKindApp: "应用",
       mentionKindAppFactory: "应用工厂",
       mentionKindFile: "文件",
-      mentionKindIssue: "事项",
+      mentionKindIssue: "任务",
       mentionKindSession: "会话",
       mentionGroupFiles: "文件",
       mentionGroupOpenedFiles: "我打开的文件",
@@ -805,11 +805,11 @@ export const zhCN = {
       mentionGroupApps: "应用",
       mentionGroupMySessions: "我的会话",
       mentionGroupCollabSessions: "协作会话",
-      mentionGroupIssues: "事项",
+      mentionGroupIssues: "任务",
       mentionEmptyMySessions: "暂无会话",
       mentionEmptyCollabSessions: "暂无协作会话",
       mentionEmptyApps: "暂无应用",
-      mentionEmptyIssues: "暂无事项",
+      mentionEmptyIssues: "暂无任务",
       mentionEmptyDockFiles:
         "Dock 栏暂无已打开文件，输入关键词可搜索工作区文件",
       mentionEmptyAgentGeneratedFiles: "暂无 Agent 生成的文件",
@@ -820,9 +820,9 @@ export const zhCN = {
       issueRunPrompt: {
         currentWorkingDirectoryLabel: "当前工作目录",
         executionRequirementsLabel: "执行要求",
-        intro: "你正在处理一个任务事项。",
-        issueContentLabel: "事项内容",
-        issueTitleLabel: "事项标题",
+        intro: "你正在处理一个任务。",
+        issueContentLabel: "任务内容",
+        issueTitleLabel: "任务标题",
         missingContent: "（无补充内容）",
         noReferences: "- （无引用资料）",
         referencesLabel: "引用资料",
@@ -1447,7 +1447,7 @@ export const zhCN = {
       titlePlaceholder: "请输入任务标题",
       fieldDescription: "需求描述",
       descriptionPlaceholder: "补充背景、现象、影响范围与期望结果",
-      descriptionPlaceholderLegacy: "描述问题背景、异常表现和期望结果。",
+      descriptionPlaceholderLegacy: "描述任务背景、目标和期望结果。",
       fieldPriority: "优先级",
       priorityOptionMedium: "中",
       priorityOptionHigh: "高",
@@ -2263,7 +2263,7 @@ export const zhCN = {
       sheetTitle: "表格",
       sheetDescription: "整理结构化数据、表格、计算和房间计划清单",
       calendarTitle: "日程",
-      calendarDescription: "规划房间里程碑、跟进事项、评审和共享日程",
+      calendarDescription: "规划房间里程碑、跟进任务、评审和共享日程",
       systemMonitorTitle: "系统监控",
       systemMonitorDescription: "查看运行时健康度、资源信号和工作区活动",
       codeEditorTitle: "代码编辑器",
@@ -2287,7 +2287,7 @@ export const zhCN = {
       mockSheetPreviewTitle: "数据表格",
       mockSheetPreviewBody: "这里将展示表格、计算、筛选和房间计划数据",
       mockCalendarPreviewTitle: "房间日历",
-      mockCalendarPreviewBody: "这里将展示里程碑、会议、跟进事项和共享日程块",
+      mockCalendarPreviewBody: "这里将展示里程碑、会议、跟进任务和共享日程块",
       mockMonitorPreviewTitle: "运行时信号",
       mockMonitorPreviewBody: "这里将展示 CPU、内存、网络和工作区活动信号",
       mockCodePreviewTitle: "源码工作区",


### PR DESCRIPTION
## Summary
- Update Chinese agent mention copy from 事项/Issue wording to 任务
- Align Task/Tasks labels and empty states in mention tests
- Refresh related comments for task/app mention reference handling

## Verification
- pnpm check:i18n
- pnpm --filter @tutti-os/agent-gui typecheck
- pnpm exec vitest run --environment jsdom agent-gui/agentGuiNode/AgentMentionSearchController.spec.ts agent-gui/agentGuiNode/AgentMentionLabels.spec.ts agent-gui/agentGuiNode/AgentFileMentionPalette.spec.tsx agent-gui/agentGuiNode/agentRichText/AgentRichTextEditor.spec.tsx agent-gui/agentGuiNode/agentRichText/agentFileMentionExtension.spec.ts
- pnpm exec vitest run --environment jsdom agent-gui/agentGuiNode/AgentGUINode.spec.tsx -t "empty-state file mention palette|keeps empty non-file groups|mention category tabs|switches browse tabs with Tab|tab switch hint"
- git push pre-push check:full