### PR TITLE
fix(codex-compact): wait for turn/completed before closing compact turn

### DIFF
--- a/packages/agent/daemon/runtime/codex_appserver_adapter.go
+++ b/packages/agent/daemon/runtime/codex_appserver_adapter.go
@@ -890,9 +890,30 @@ func (a *CodexAppServerAdapter) execSlashCommand(
 			emitTerminal([]activityshared.Event{newTurnActivityEvent(session, EventTurnFailed, turnID, SessionStatusFailed, "", "", acpFailureMetadata(err))})
 			return true, nil
 		}
+		// Block until the App Server signals turn/completed. The session-level
+		// handler keeps activeTurn alive during this wait, so the
+		// contextCompaction item/completed notification fires appServerItemEvents
+		// and emits the "Context compacted." banner through emitEvents before we
+		// close the turn.
+		_, finishErr := a.awaitTurnCompletion(ctx, appSession, appTurn, nil)
+		if finishErr != nil {
+			if errors.Is(finishErr, context.Canceled) || errors.Is(finishErr, errPermissionRequestCanceled) {
+				emitTerminal(append(
+					normalizer.FinishInterrupted(session, turnID, "interrupted"),
+					newTurnActivityEvent(session, EventTurnCanceled, turnID, SessionStatusCanceled, "", "", map[string]any{
+						"error": finishErr.Error(),
+					}),
+				))
+			} else {
+				emitTerminal(append(
+					normalizer.FinishFailed(session, turnID),
+					newTurnActivityEvent(session, EventTurnFailed, turnID, SessionStatusFailed, "", "", acpFailureMetadata(finishErr)),
+				))
+			}
+			return true, nil
+		}
 		emitTerminal(append(
 			normalizer.FinishCompleted(session, turnID),
-			appServerSystemNoticeEvent(session, turnID, "system_notice", "Context compaction started.", ""),
 			newTurnActivityEvent(session, EventTurnCompleted, turnID, SessionStatusReady, "", "", map[string]any{
 				"stopReason": "end_turn",
 			}),

--- a/packages/agent/daemon/runtime/codex_appserver_adapter_test.go
+++ b/packages/agent/daemon/runtime/codex_appserver_adapter_test.go
@@ -410,6 +410,24 @@ func (c *scriptedAppServerConnection) Send(data []byte) error {
 			c.sendJSON(map[string]any{"id": message.ID, "result": map[string]any{"turnId": "turn-1"}})
 		case appServerMethodThreadCompact:
 			c.sendJSON(map[string]any{"id": message.ID, "result": map[string]any{}})
+			// The real app-server runs compaction as a full turn and streams
+			// turn/started → item/started → item/completed → turn/completed.
+			c.notify(appServerNotifyTurnStarted, map[string]any{
+				"threadId": "codex-thread-1",
+				"turn":     map[string]any{"id": "turn-compact", "status": "inProgress", "items": []any{}},
+			})
+			c.notify(appServerNotifyItemStarted, map[string]any{
+				"threadId": "codex-thread-1", "turnId": "turn-compact",
+				"item": map[string]any{"type": "contextCompaction", "id": "item-compact", "status": "inProgress"},
+			})
+			c.notify(appServerNotifyItemCompleted, map[string]any{
+				"threadId": "codex-thread-1", "turnId": "turn-compact",
+				"item": map[string]any{"type": "contextCompaction", "id": "item-compact", "status": "completed"},
+			})
+			c.notify(appServerNotifyTurnCompleted, map[string]any{
+				"threadId": "codex-thread-1",
+				"turn":     map[string]any{"id": "turn-compact", "status": "completed", "items": []any{}},
+			})
 		case appServerMethodThreadRollback:
 			c.sendJSON(map[string]any{
 				"id":     message.ID,
@@ -1354,6 +1372,17 @@ func TestCodexAppServerAdapterSlashCompact(t *testing.T) {
 	}
 	if requests := appServerRequestParamsList(t, transport.conn, appServerMethodTurnStart); len(requests) != 0 {
 		t.Fatalf("turn/start should not run for /compact")
+	}
+	// "Context compacted." must arrive via item/completed through the
+	// session-level handler — not as a locally-emitted terminal message.
+	var gotCompactedBanner bool
+	for _, event := range events {
+		if event.Payload.Content == "Context compacted." {
+			gotCompactedBanner = true
+		}
+	}
+	if !gotCompactedBanner {
+		t.Fatalf("expected 'Context compacted.' banner in compact events; got %#v", events)
 	}
 	if completed := eventsOfType(events, activityshared.EventTurnCompleted); len(completed) != 1 {
 		t.Fatalf("compact turn completed events = %d, want 1", len(completed))


### PR DESCRIPTION
## Summary

- **Bug 1 (UI stuck)**: After `/compact`, the UI never showed "Context compacted." — the `thread/compact/start` RPC returns immediately, so `emitTerminal` was called right away and `endActiveTurn` cleared the active turn. When the actual compaction finished ~15s later, `item/completed(contextCompaction)` arrived at the session-level handler with `activeTurn == nil`, causing `appServerItemEvents` to early-return nil and the banner to be silently dropped.
- **Bug 2 (unnecessary block)**: A "Context compaction started." notice was emitted as a terminal message block before compaction actually completed, diverging from Claude Code's single-result-after-completion pattern.

**Fix**: Call `awaitTurnCompletion` after the compact RPC (mirroring `execReviewSlashCommand`). This keeps `activeTurn` alive during compaction so the session-level handler correctly routes `item/completed(contextCompaction)` through `appServerItemEvents` and emits "Context compacted." via `emitEvents`. The premature "Context compaction started." notice is removed — only "Context compacted." appears, after the operation actually completes.

Also updates the test mock to stream the full `turn/started → item/started → item/completed → turn/completed` sequence matching real App Server behavior, and asserts the "Context compacted." banner is present in collected events.

## Test plan

- [ ] Trigger `/compact` in Codex session — UI should show a loading indicator for ~15s, then "Context compacted." appears and session returns to ready state
- [ ] Verify no "Context compaction started." block appears (only the single "Context compacted." notice)
- [ ] `go test ./packages/agent/daemon/runtime/... -run TestCodexAppServerAdapterSlashCompact` passes
- [ ] Full runtime test suite passes: `go test ./packages/agent/daemon/runtime/...`

🤖 Generated with [Claude Code](https://claude.com/claude-code)