### PR TITLE
fix(agent-gui): stop hiding completed Codex tool calls during streaming

### DIFF
--- a/packages/agent/gui/shared/agentConversation/projection/agentConversationProjection.spec.ts
+++ b/packages/agent/gui/shared/agentConversation/projection/agentConversationProjection.spec.ts
@@ -131,16 +131,25 @@ describe("projectAgentConversationVM", () => {
     expect(toolRows.every((row) => row.grouped === false)).toBe(true);
   });
 
-  it("collapses the tail to a single live row while the latest tail tool runs", () => {
-    // The latest tail tool is still active: keep showing only the live row.
+  it("keeps completed tail tools visible while the latest tail tool runs", () => {
+    // Regression for the Codex tool-rendering flicker: Codex emits long runs of
+    // short, sequential tool calls. Previously, while the newest tail tool was
+    // still active every already-completed predecessor was collapsed into a
+    // single live row, so the transcript jumped between showing one tool and
+    // many as the burst advanced (and again when interleaved reasoning broke the
+    // trailing run). Completed tools must stay visible alongside the live one so
+    // the streaming transcript only grows instead of toggling.
     const toolRows = tailChainConversation({
       status: "Running",
       statusKind: "working"
     });
 
-    expect(toolRows).toHaveLength(1);
-    expect(toolRows[0]?.grouped).toBe(false);
-    expect(toolRows[0]?.calls[0]?.id).toBe("call:3");
+    expect(toolRows.map((row) => row.calls[0]?.id)).toEqual([
+      "call:1",
+      "call:2",
+      "call:3"
+    ]);
+    expect(toolRows.every((row) => row.grouped === false)).toBe(true);
   });
 
   it("keeps Codex transport retry notices out of the working processing label", () => {

--- a/packages/agent/gui/shared/agentConversation/projection/agentToolGroupingProjection.ts
+++ b/packages/agent/gui/shared/agentConversation/projection/agentToolGroupingProjection.ts
@@ -95,9 +95,16 @@ export function computeAgentToolGroups(
 ): AgentComputedToolGroupInfoVM {
   const groups = new Map<number, AgentComputedToolGroupVM>();
   const groupedIndices = new Set<number>();
-  const suppressedIndices = allowTrailingFinalization
-    ? new Set<number>()
-    : findActiveTailSuppressedToolIndices(sequence);
+  // Nothing is hidden anymore. While a session streams a burst of sequential
+  // tool calls (e.g. Codex), the trailing run whose newest tool is still active
+  // is rendered as individual, always-visible rows instead of grouping or
+  // collapsing it. Grouping that run while the tail tool kept changing was what
+  // made the transcript flicker between "one tool" and "many" as the burst
+  // advanced. Items before the active trailing run still group as usual.
+  const suppressedIndices = new Set<number>();
+  const splitFromIndex = allowTrailingFinalization
+    ? -1
+    : findActiveTailRunStartIndex(sequence);
 
   let currentCalls: AgentToolCallVM[] = [];
   let currentEntries: AgentToolGroupEntryVM[] = [];
@@ -134,7 +141,11 @@ export function computeAgentToolGroups(
     if (!item) {
       continue;
     }
-    if (suppressedIndices.has(index)) {
+    // Once we reach the still-streaming trailing run, stop grouping: close any
+    // open group and let every remaining item fall through to its own visible
+    // row so the live view only ever appends.
+    if (splitFromIndex >= 0 && index >= splitFromIndex) {
+      finalizeGroup();
       continue;
     }
     if (item.kind === "tool-call" && isGroupableToolCall(item.call)) {
@@ -179,11 +190,56 @@ export function computeAgentToolGroups(
     finalizeGroup();
   }
 
+  debugLogToolGrouping(sequence, {
+    allowTrailingFinalization,
+    splitFromIndex,
+    groups
+  });
+
   return {
     groups,
     groupedIndices,
     suppressedIndices
   };
+}
+
+/**
+ * Opt-in diagnostic for the Codex tool-rendering flicker. Off by default so the
+ * hot streaming projection path stays allocation-free; enable it from the
+ * renderer devtools console with
+ * `globalThis.__TUTTI_DEBUG_TOOL_GROUPING = true` and reproduce the burst to see,
+ * per projection pass, the tool statuses, the active trailing-run boundary, and
+ * the groups produced. A stable boundary / row count across passes confirms the
+ * jump is gone.
+ */
+function debugLogToolGrouping(
+  sequence: readonly AgentTurnSequenceItemVM[],
+  info: {
+    allowTrailingFinalization: boolean;
+    splitFromIndex: number;
+    groups: ReadonlyMap<number, AgentComputedToolGroupVM>;
+  }
+): void {
+  const flag = (globalThis as { __TUTTI_DEBUG_TOOL_GROUPING?: unknown })
+    .__TUTTI_DEBUG_TOOL_GROUPING;
+  if (flag !== true || typeof console === "undefined") {
+    return;
+  }
+  const tools = sequence
+    .map((item, index) =>
+      item?.kind === "tool-call"
+        ? `${index}:${item.call.id}:${item.call.statusKind ?? "?"}`
+        : null
+    )
+    .filter((entry): entry is string => entry !== null);
+  // eslint-disable-next-line no-console
+  console.debug("[tool-grouping]", {
+    sequenceLength: sequence.length,
+    tools,
+    allowTrailingFinalization: info.allowTrailingFinalization,
+    splitFromIndex: info.splitFromIndex,
+    groupStartIndices: [...info.groups.keys()]
+  });
 }
 
 export function projectAgentToolGroupRowFromGroup(
@@ -287,32 +343,31 @@ function isGroupableToolCall(call: AgentToolCallVM): boolean {
   }
 }
 
-function findActiveTailSuppressedToolIndices(
+/**
+ * Index where the still-streaming trailing tool run begins, or -1 when there
+ * is none. The run is the contiguous block of tool calls at the end of the
+ * sequence whose newest (tail) tool is still active. Returning its start lets
+ * the projection keep that whole run as individual, always-visible rows while
+ * the burst is in flight, instead of grouping (and previously hiding) it.
+ */
+function findActiveTailRunStartIndex(
   sequence: readonly AgentTurnSequenceItemVM[]
-): Set<number> {
-  const suppressedIndices = new Set<number>();
-  let latestTailToolIndex = -1;
+): number {
+  let tailIndex = -1;
   for (let index = sequence.length - 1; index >= 0; index -= 1) {
     const item = sequence[index];
     if (!item) {
       continue;
     }
-    if (item.kind !== "tool-call") {
-      break;
-    }
-    latestTailToolIndex = Math.max(latestTailToolIndex, index);
+    tailIndex = index;
+    break;
   }
-  if (latestTailToolIndex < 0) {
-    return suppressedIndices;
+  const tailItem = tailIndex >= 0 ? sequence[tailIndex] : undefined;
+  if (tailItem?.kind !== "tool-call" || !isActiveTailTool(tailItem.call)) {
+    return -1;
   }
-  const latestTailTool = sequence[latestTailToolIndex];
-  if (
-    latestTailTool?.kind !== "tool-call" ||
-    !isSuppressingActiveTailTool(latestTailTool.call)
-  ) {
-    return suppressedIndices;
-  }
-  for (let index = latestTailToolIndex - 1; index >= 0; index -= 1) {
+  let startIndex = tailIndex;
+  for (let index = tailIndex - 1; index >= 0; index -= 1) {
     const item = sequence[index];
     if (!item) {
       continue;
@@ -320,15 +375,15 @@ function findActiveTailSuppressedToolIndices(
     if (item.kind !== "tool-call") {
       break;
     }
-    suppressedIndices.add(index);
+    startIndex = index;
   }
-  return suppressedIndices;
+  return startIndex;
 }
 
-function isSuppressingActiveTailTool(call: AgentToolCallVM): boolean {
-  // Only an actively running tail tool collapses the tools before it into a
-  // single live row. Once the latest tail tool has finished, the completed
-  // tools stay visible instead of vanishing behind it.
+function isActiveTailTool(call: AgentToolCallVM): boolean {
+  // Only an actively running tail tool keeps its trailing run in the live,
+  // ungrouped state. Once the latest tail tool has finished, the run finalizes
+  // and groups like any other completed run.
   if (call.statusKind !== "working" && call.statusKind !== "waiting") {
     return false;
   }

--- a/packages/agent/gui/shared/agentConversation/projection/agentToolGroupingProjection.ts
+++ b/packages/agent/gui/shared/agentConversation/projection/agentToolGroupingProjection.ts
@@ -190,56 +190,11 @@ export function computeAgentToolGroups(
     finalizeGroup();
   }
 
-  debugLogToolGrouping(sequence, {
-    allowTrailingFinalization,
-    splitFromIndex,
-    groups
-  });
-
   return {
     groups,
     groupedIndices,
     suppressedIndices
   };
-}
-
-/**
- * Opt-in diagnostic for the Codex tool-rendering flicker. Off by default so the
- * hot streaming projection path stays allocation-free; enable it from the
- * renderer devtools console with
- * `globalThis.__TUTTI_DEBUG_TOOL_GROUPING = true` and reproduce the burst to see,
- * per projection pass, the tool statuses, the active trailing-run boundary, and
- * the groups produced. A stable boundary / row count across passes confirms the
- * jump is gone.
- */
-function debugLogToolGrouping(
-  sequence: readonly AgentTurnSequenceItemVM[],
-  info: {
-    allowTrailingFinalization: boolean;
-    splitFromIndex: number;
-    groups: ReadonlyMap<number, AgentComputedToolGroupVM>;
-  }
-): void {
-  const flag = (globalThis as { __TUTTI_DEBUG_TOOL_GROUPING?: unknown })
-    .__TUTTI_DEBUG_TOOL_GROUPING;
-  if (flag !== true || typeof console === "undefined") {
-    return;
-  }
-  const tools = sequence
-    .map((item, index) =>
-      item?.kind === "tool-call"
-        ? `${index}:${item.call.id}:${item.call.statusKind ?? "?"}`
-        : null
-    )
-    .filter((entry): entry is string => entry !== null);
-  // eslint-disable-next-line no-console
-  console.debug("[tool-grouping]", {
-    sequenceLength: sequence.length,
-    tools,
-    allowTrailingFinalization: info.allowTrailingFinalization,
-    splitFromIndex: info.splitFromIndex,
-    groupStartIndices: [...info.groups.keys()]
-  });
 }
 
 export function projectAgentToolGroupRowFromGroup(


### PR DESCRIPTION
## Problem

Codex tool rendering kept jumping during streaming: in a burst of consecutive tool calls the transcript would show **only one tool**, then **suddenly many**, flickering throughout.

## Root cause

The transcript projection's *active-tail suppression* (`findActiveTailSuppressedToolIndices` / `isSuppressingActiveTailTool` in `agentToolGroupingProjection.ts`) collapsed **every already-completed tool call before the newest active tail tool into that single live row**. Codex emits long runs of short sequential tool calls interleaved with brief reasoning, so:

- while a tool was active, its completed predecessors were hidden → only one tool shown;
- when the burst ended (or interleaved reasoning broke the trailing run), suppression lifted and all of them re-appeared at once → "suddenly many".

The captured logs confirm the scenario — one Codex turn fired **17 back-to-back tool calls**. Persisted message data is fully consistent (stable `version` ordering, 0 time inversions across all 19 sessions), so the defect is purely in the **live streaming projection**, which is the render path (`useProjectedAgentConversation` → `projectAgentConversationVM`).

## Fix

Replace the hide-predecessors suppression with `findActiveTailRunStartIndex`: the still-streaming trailing tool run is rendered as **individual, always-visible rows** (the active tail tool stays a live row; completed tools remain visible). The live transcript now only ever appends instead of toggling 1↔many. Items before the active trailing run still group as before. This makes the active-tail case consistent with the already-accepted completed-tail behavior (tools stay visible while the session works).

## Tests

- Updated the tail-chain test in `agentConversationProjection.spec.ts`: while the latest tail tool runs, completed tools stay visible (was: collapse to a single live row).
- Logic projection specs pass (`agentConversationProjection`, `agentTurnRowProjection` — 38 tests). Component specs needing `@testing-library/react` should be run in CI.

## Deferred follow-ups (not in this PR)

Reviewed but intentionally out of scope:
- **Live ordering key**: `compareTimelineItemsForMerge` orders by completion-time `occurredAtUnixMs` while the durable path uses stable monotonic `version` — items can still reorder as tools complete.
- **Tool-group row identity**: the group row `id` concatenates all callIds, so it churns as a group grows and `reconcileProjectedAgentConversationVM` can't reuse the row (remount).
- **Boy-Scout**: vestigial always-empty `suppressedIndices`; duplicated `summarizeToolCallGroup`; the dead innermost `avoidGroupingEdits` branch (kept — the setting is fully plumbed/persisted).

🤖 Generated with [Claude Code](https://claude.com/claude-code)