### PR TITLE
[codex] Fix workspace onboarding provider flow

### DIFF
--- a/apps/desktop/src/renderer/src/features/workspace-workbench/services/internal/workspaceWorkbenchHostService.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/services/internal/workspaceWorkbenchHostService.ts
@@ -74,6 +74,10 @@ import {
   writeWorkspaceWallpaperDisplayModeToSnapshot,
   writeWorkspaceWallpaperIdToSnapshot
 } from "../workspaceWallpaper";
+import {
+  hasWorkspaceOnboardingAutoOpened,
+  writeWorkspaceOnboardingAutoOpenedToSnapshot
+} from "../workspaceOnboarding.ts";
 import { createWorkspaceAgentProviderDockStateSource } from "./workspaceAgentProviderDockStateSource.ts";
 import { createWindowCloseRequestTracker } from "../windowCloseRequestTracker";
 import { runWorkspaceAgentProviderDockAction } from "./workspaceAgentProviderDockActions.ts";
@@ -324,6 +328,27 @@ export class WorkspaceWorkbenchHostService implements IWorkspaceWorkbenchHostSer
     listener: (request: DesktopWorkspaceAppOpenFileResolvedPayload) => void
   ): () => void {
     return this.dependencies.hostWorkspaceApi.onOpenFileRequest(listener);
+  }
+
+  async hasWorkspaceOnboardingAutoOpened(
+    workspaceId: string
+  ): Promise<boolean> {
+    const cachedSnapshot = this.dependencies.repository.readCached(workspaceId);
+    const snapshot = cachedSnapshot
+      ? cachedSnapshot
+      : await this.dependencies.repository.load(workspaceId);
+    return hasWorkspaceOnboardingAutoOpened(snapshot);
+  }
+
+  async markWorkspaceOnboardingAutoOpened(workspaceId: string): Promise<void> {
+    const cachedSnapshot = this.dependencies.repository.readCached(workspaceId);
+    const snapshot = cachedSnapshot
+      ? cachedSnapshot
+      : await this.dependencies.repository.load(workspaceId);
+    await this.dependencies.repository.save(
+      workspaceId,
+      writeWorkspaceOnboardingAutoOpenedToSnapshot(snapshot)
+    );
   }
 
   readWallpaperDisplayMode(workspaceId: string) {

--- a/apps/desktop/src/renderer/src/features/workspace-workbench/services/workspaceOnboarding.test.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/services/workspaceOnboarding.test.ts
@@ -1,0 +1,82 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  workbenchSnapshotSchemaVersion,
+  type WorkbenchSnapshot
+} from "@tutti-os/workbench-snapshot";
+import {
+  hasWorkspaceOnboardingAutoOpened,
+  writeWorkspaceOnboardingAutoOpenedToSnapshot
+} from "./workspaceOnboarding.ts";
+
+test("workspace onboarding reads missing or invalid metadata as not auto-opened", () => {
+  assert.equal(hasWorkspaceOnboardingAutoOpened(null), false);
+  assert.equal(
+    hasWorkspaceOnboardingAutoOpened({
+      ...createSnapshot(),
+      metadata: {
+        workspaceOnboarding: {
+          autoOpened: "yes",
+          schemaVersion: 1
+        }
+      }
+    }),
+    false
+  );
+});
+
+test("workspace onboarding auto-open state round-trips through snapshot metadata", () => {
+  const snapshot = writeWorkspaceOnboardingAutoOpenedToSnapshot(
+    {
+      ...createSnapshot(),
+      metadata: {
+        anotherFeature: {
+          enabled: true
+        }
+      }
+    },
+    "2026-06-18T00:00:00.000Z"
+  );
+
+  assert.equal(hasWorkspaceOnboardingAutoOpened(snapshot), true);
+  assert.deepEqual(snapshot.metadata, {
+    anotherFeature: {
+      enabled: true
+    },
+    workspaceOnboarding: {
+      autoOpened: true,
+      autoOpenedAt: "2026-06-18T00:00:00.000Z",
+      schemaVersion: 1
+    }
+  });
+});
+
+test("workspace onboarding state does not access localStorage", () => {
+  const original = Object.getOwnPropertyDescriptor(globalThis, "localStorage");
+  Object.defineProperty(globalThis, "localStorage", {
+    configurable: true,
+    get() {
+      throw new Error("localStorage should not be accessed");
+    }
+  });
+  try {
+    const snapshot =
+      writeWorkspaceOnboardingAutoOpenedToSnapshot(createSnapshot());
+    assert.equal(hasWorkspaceOnboardingAutoOpened(snapshot), true);
+  } finally {
+    if (original) {
+      Object.defineProperty(globalThis, "localStorage", original);
+    } else {
+      Reflect.deleteProperty(globalThis, "localStorage");
+    }
+  }
+});
+
+function createSnapshot(): WorkbenchSnapshot {
+  return {
+    schemaVersion: workbenchSnapshotSchemaVersion,
+    nodes: [],
+    nodeStack: [],
+    activeNodeId: null
+  };
+}

--- a/apps/desktop/src/renderer/src/features/workspace-workbench/services/workspaceOnboarding.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/services/workspaceOnboarding.ts
@@ -1,0 +1,55 @@
+import type { WorkbenchSnapshot } from "@tutti-os/workbench-snapshot";
+
+const workspaceOnboardingMetadataKey = "workspaceOnboarding";
+const workspaceOnboardingMetadataSchemaVersion = 1;
+
+interface WorkspaceOnboardingSnapshotMetadata {
+  autoOpened: boolean;
+  autoOpenedAt: string;
+  schemaVersion: typeof workspaceOnboardingMetadataSchemaVersion;
+}
+
+export function hasWorkspaceOnboardingAutoOpened(
+  snapshot: WorkbenchSnapshot | null | undefined
+): boolean {
+  const metadata = readWorkspaceOnboardingMetadata(snapshot);
+  return metadata?.autoOpened === true;
+}
+
+export function writeWorkspaceOnboardingAutoOpenedToSnapshot(
+  snapshot: WorkbenchSnapshot,
+  autoOpenedAt = new Date().toISOString()
+): WorkbenchSnapshot {
+  return {
+    ...snapshot,
+    metadata: {
+      ...snapshot.metadata,
+      [workspaceOnboardingMetadataKey]: {
+        autoOpened: true,
+        autoOpenedAt,
+        schemaVersion: workspaceOnboardingMetadataSchemaVersion
+      } satisfies WorkspaceOnboardingSnapshotMetadata
+    }
+  };
+}
+
+function readWorkspaceOnboardingMetadata(
+  snapshot: WorkbenchSnapshot | null | undefined
+): WorkspaceOnboardingSnapshotMetadata | null {
+  const value = snapshot?.metadata?.[workspaceOnboardingMetadataKey];
+  if (
+    typeof value !== "object" ||
+    value === null ||
+    Array.isArray(value) ||
+    !("schemaVersion" in value) ||
+    value.schemaVersion !== workspaceOnboardingMetadataSchemaVersion ||
+    !("autoOpened" in value) ||
+    value.autoOpened !== true ||
+    !("autoOpenedAt" in value) ||
+    typeof value.autoOpenedAt !== "string"
+  ) {
+    return null;
+  }
+
+  return value as WorkspaceOnboardingSnapshotMetadata;
+}

--- a/apps/desktop/src/renderer/src/features/workspace-workbench/services/workspaceOpenFeatureRequest.test.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/services/workspaceOpenFeatureRequest.test.ts
@@ -1,0 +1,22 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { resolveWorkspaceAgentChatProvider } from "./workspaceOpenFeatureRequest.ts";
+
+test("workspace agent chat uses the requested provider before the workspace default", () => {
+  assert.equal(
+    resolveWorkspaceAgentChatProvider({
+      defaultProvider: "codex",
+      requestedProvider: "claude-code"
+    }),
+    "claude-code"
+  );
+});
+
+test("workspace agent chat falls back to the workspace default provider", () => {
+  assert.equal(
+    resolveWorkspaceAgentChatProvider({
+      defaultProvider: "gemini"
+    }),
+    "gemini"
+  );
+});

--- a/apps/desktop/src/renderer/src/features/workspace-workbench/services/workspaceOpenFeatureRequest.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/services/workspaceOpenFeatureRequest.ts
@@ -1,0 +1,11 @@
+import { normalizeAgentGuiWorkbenchProvider } from "@tutti-os/agent-gui/workbench/providerCatalog";
+import type { AgentGuiWorkbenchProvider } from "@tutti-os/agent-gui/workbench/types";
+
+export function resolveWorkspaceAgentChatProvider(input: {
+  defaultProvider?: string | null;
+  requestedProvider?: string | null;
+}): AgentGuiWorkbenchProvider {
+  return normalizeAgentGuiWorkbenchProvider(
+    input.requestedProvider ?? input.defaultProvider
+  );
+}

--- a/apps/desktop/src/renderer/src/features/workspace-workbench/services/workspaceWorkbenchHostService.interface.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/services/workspaceWorkbenchHostService.interface.ts
@@ -133,6 +133,8 @@ export interface IWorkspaceWorkbenchHostService {
   onOpenFileRequest(
     listener: (request: DesktopWorkspaceAppOpenFileResolvedPayload) => void
   ): () => void;
+  hasWorkspaceOnboardingAutoOpened(workspaceId: string): Promise<boolean>;
+  markWorkspaceOnboardingAutoOpened(workspaceId: string): Promise<void>;
   readWallpaperDisplayMode(workspaceId: string): WorkspaceWallpaperDisplayMode;
   readWallpaperId(workspaceId: string): WorkspaceWallpaperId;
   ensureAgentProviderStatusesLoaded(): Promise<void>;

--- a/apps/desktop/src/renderer/src/features/workspace-workbench/ui/WorkspaceWorkbench.source.test.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/ui/WorkspaceWorkbench.source.test.ts
@@ -1,0 +1,19 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import test from "node:test";
+
+const source = readFileSync(
+  resolve(
+    "src/renderer/src/features/workspace-workbench/ui/WorkspaceWorkbench.tsx"
+  ),
+  "utf8"
+);
+
+test("WorkspaceWorkbench does not render a global agent install pending overlay", () => {
+  assert.doesNotMatch(source, /WorkspaceAgentConnectingCard/);
+  assert.doesNotMatch(
+    source,
+    /pendingActions\.find\(\s*\(action\) => action\.actionId === "install"/s
+  );
+});

--- a/apps/desktop/src/renderer/src/features/workspace-workbench/ui/WorkspaceWorkbench.tsx
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/ui/WorkspaceWorkbench.tsx
@@ -1,12 +1,5 @@
 import type * as React from "react";
-import {
-  useCallback,
-  useEffect,
-  useMemo,
-  useRef,
-  useState,
-  useSyncExternalStore
-} from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import type { WorkspaceSummary } from "@tutti-os/client-tuttid-ts";
 import {
   defaultIssueManagerWorkbenchTypeId,
@@ -45,6 +38,7 @@ import {
   createWorkspaceAgentGuiDraftLaunchRequest,
   createWorkspaceAgentGuiSessionLaunchRequest
 } from "../services/workspaceAgentGuiLaunch.ts";
+import { resolveWorkspaceAgentChatProvider } from "../services/workspaceOpenFeatureRequest.ts";
 import type { WorkspaceLaunchpadOpenTrigger } from "../services/workspaceLaunchpadAnalytics.ts";
 import {
   registerWorkspaceBrowserLaunchHandler,
@@ -65,7 +59,6 @@ import {
 } from "../services/workspaceIssueManagerLaunchCoordinator.ts";
 import { workspaceLaunchpadDockActionId } from "../services/workspaceLaunchpadModel.ts";
 import { requestWorkspaceMessageCenterOpen } from "../services/workspaceMessageCenterCoordinator.ts";
-import { resolveWorkspaceAgentGuiLabel } from "../services/workspaceAgentProviderCatalog.ts";
 import { workspaceBrowserNodeID } from "../services/workspaceWorkbenchNodeIds.ts";
 import { WorkspaceChrome } from "./WorkspaceChrome";
 import { WorkspaceAppExternalBridge } from "./WorkspaceAppExternalBridge";
@@ -308,11 +301,12 @@ function ReadyWorkspaceWorkbench({
         return;
       }
       if (request.feature === "agent-chat") {
-        // “已绑定，去使用”：打开已绑定（默认）provider 的对话框。
+        // “已绑定，去使用”：优先打开请求指定的 provider，再回退到默认 provider。
         const snapshot = agentProviderStatusService.getSnapshot();
-        const preferred = normalizeDesktopAgentGUIProvider(
-          snapshot.defaultProvider ?? request.provider
-        );
+        const preferred = resolveWorkspaceAgentChatProvider({
+          defaultProvider: snapshot.defaultProvider,
+          requestedProvider: request.provider
+        });
         void requestWorkspaceAgentGuiLaunch({
           provider: preferred,
           workspaceId
@@ -379,6 +373,13 @@ function ReadyWorkspaceWorkbench({
 
     let canceled = false;
     const openOnboarding = async () => {
+      if (
+        await runtime.workbenchHostService.hasWorkspaceOnboardingAutoOpened(
+          workspaceId
+        )
+      ) {
+        return;
+      }
       for (let attempt = 0; attempt < 20 && !canceled; attempt += 1) {
         await appCenterService.refresh(workspaceId);
         const app = appCenterService.store.apps.find(
@@ -400,6 +401,9 @@ function ReadyWorkspaceWorkbench({
             appId: onboardingAppId,
             workspaceId
           });
+          await runtime.workbenchHostService.markWorkspaceOnboardingAutoOpened(
+            workspaceId
+          );
           return;
         }
         await new Promise((resolve) => setTimeout(resolve, 500));
@@ -411,7 +415,12 @@ function ReadyWorkspaceWorkbench({
     return () => {
       canceled = true;
     };
-  }, [appCenterService, state.workspace.id, workbenchHost]);
+  }, [
+    appCenterService,
+    runtime.workbenchHostService,
+    state.workspace.id,
+    workbenchHost
+  ]);
 
   useEffect(() => {
     const missionControlShortcutsEnabled =
@@ -517,46 +526,12 @@ function ReadyWorkspaceWorkbench({
         workspaceId={state.workspace.id}
         onClose={closeLaunchpad}
       />
-      <WorkspaceAgentConnectingCard service={agentProviderStatusService} />
       <WorkspaceCloseGuardDialog
         request={runtime.closeDialog.request}
         onCancel={runtime.closeDialog.onCancel}
         onConfirm={runtime.closeDialog.onConfirm}
       />
     </main>
-  );
-}
-
-function WorkspaceAgentConnectingCard({
-  service
-}: {
-  service: IAgentProviderStatusService;
-}) {
-  const { t } = useTranslation();
-  const snapshot = useSyncExternalStore(
-    (listener) => service.subscribe(listener),
-    () => service.getSnapshot(),
-    () => service.getSnapshot()
-  );
-  const pending = snapshot.pendingActions.find(
-    (action) => action.actionId === "install"
-  );
-  if (!pending) {
-    return null;
-  }
-  const label = resolveWorkspaceAgentGuiLabel(
-    normalizeDesktopAgentGUIProvider(pending.provider)
-  );
-  return (
-    <div className="pointer-events-none fixed inset-x-0 bottom-28 z-50 flex justify-center">
-      <div className="pointer-events-auto flex w-64 flex-col items-center gap-3 rounded-2xl border border-border bg-background px-6 py-5 text-center shadow-xl">
-        <div className="text-[15px] font-semibold text-foreground">{label}</div>
-        <div className="text-[12.5px] leading-relaxed text-muted-foreground">
-          {t("workspace.workbenchDesktop.agentProviders.installing")}
-        </div>
-        <LoadingIcon className="size-5 animate-spin text-muted-foreground" />
-      </div>
-    </div>
   );
 }
 

--- a/docs/conventions/runtime-overrides.md
+++ b/docs/conventions/runtime-overrides.md
@@ -87,6 +87,7 @@ Use the owner documents linked below for detailed behavior. This file exists to 
 | `TUTTI_AGENT_SESSION_ID`     | This document                                   | Identifies the caller agent session for CLI invoke context and agent runtime logs.      |
 | `TUTTI_AGENT_ROUTING`        | This document                                   | Marks provider subprocesses launched through the migrated agent routing path.           |
 | `TUTTI_ACP_TOOL_DEBUG`       | This document                                   | Enables verbose migrated ACP tool-call normalization diagnostics.                       |
+| `TUTTI_MOCK_AGENT_UNBOUND`   | This document                                   | Forces Codex unbound and Claude Code auth-required for onboarding diagnostics.          |
 | `TUTTI_WORKSPACE_ID`         | This document                                   | Supplies a workspace id to migrated agent context readers when no input id is provided. |
 
 ## Desktop Renderer Diagnostics

--- a/packages/workspace/external-core/src/contracts/index.ts
+++ b/packages/workspace/external-core/src/contracts/index.ts
@@ -125,9 +125,21 @@ export type TuttiExternalWorkspaceFeature =
   | "agent-connect"
   | "agent-chat";
 
+export const tuttiExternalWorkspaceAgentProviders = [
+  "claude-code",
+  "codex",
+  "nexight",
+  "hermes",
+  "gemini",
+  "openclaw"
+] as const;
+
+export type TuttiExternalWorkspaceAgentProvider =
+  (typeof tuttiExternalWorkspaceAgentProviders)[number];
+
 export interface TuttiExternalWorkspaceOpenFeatureInput {
   feature: TuttiExternalWorkspaceFeature;
-  provider?: string;
+  provider?: TuttiExternalWorkspaceAgentProvider;
 }
 
 export const tuttiExternalLogLevels = [

--- a/packages/workspace/external-core/src/core/index.test.ts
+++ b/packages/workspace/external-core/src/core/index.test.ts
@@ -11,6 +11,7 @@ import {
   tuttiExternalAtDefaultMaxResults,
   tuttiExternalAtMaxResultsLimit,
   tuttiExternalAtProviderIds,
+  tuttiExternalWorkspaceAgentProviders,
   tuttiExternalManagedAiModelProviderIds
 } from "./index.ts";
 
@@ -201,6 +202,25 @@ test("rejects invalid workspace feature open input", () => {
       }),
     /feature is unsupported/
   );
+  assert.throws(
+    () =>
+      normalizeTuttiExternalWorkspaceOpenFeatureInput({
+        feature: "agent-chat",
+        provider: "unknown-agent"
+      }),
+    /provider is unsupported/
+  );
+});
+
+test("keeps the workspace agent provider set explicit", () => {
+  assert.deepEqual(tuttiExternalWorkspaceAgentProviders, [
+    "claude-code",
+    "codex",
+    "nexight",
+    "hermes",
+    "gemini",
+    "openclaw"
+  ]);
 });
 
 test("keeps the managed AI model provider set explicit", () => {

--- a/packages/workspace/external-core/src/core/index.ts
+++ b/packages/workspace/external-core/src/core/index.ts
@@ -1,6 +1,7 @@
 import {
   tuttiExternalManagedAiModelProviderIds,
   tuttiExternalAtProviderIds,
+  tuttiExternalWorkspaceAgentProviders,
   type TuttiExternalAtProviderId,
   type TuttiExternalAtQueryInput,
   type TuttiExternalFileOpenInput,
@@ -10,13 +11,15 @@ import {
   type TuttiExternalManagedAiModelProviderId,
   type TuttiExternalPermissionRequestInput,
   type TuttiExternalSettingsOpenInput,
+  type TuttiExternalWorkspaceAgentProvider,
   type TuttiExternalWorkspaceFeature,
   type TuttiExternalWorkspaceOpenFeatureInput
 } from "../contracts/index.ts";
 
 export {
   tuttiExternalAtProviderIds,
-  tuttiExternalManagedAiModelProviderIds
+  tuttiExternalManagedAiModelProviderIds,
+  tuttiExternalWorkspaceAgentProviders
 } from "../contracts/index.ts";
 
 export const tuttiExternalAtMaxResultsLimit = 50;
@@ -197,7 +200,9 @@ export function normalizeTuttiExternalWorkspaceOpenFeatureInput(
   return {
     feature,
     ...(typeof input.provider === "string" && input.provider.trim() !== ""
-      ? { provider: input.provider.trim() }
+      ? {
+          provider: normalizeTuttiExternalWorkspaceAgentProvider(input.provider)
+        }
       : {})
   };
 }
@@ -231,6 +236,27 @@ export function isTuttiExternalWorkspaceFeature(
       value as TuttiExternalWorkspaceFeature
     )
   );
+}
+
+export function isTuttiExternalWorkspaceAgentProvider(
+  value: unknown
+): value is TuttiExternalWorkspaceAgentProvider {
+  return (
+    typeof value === "string" &&
+    tuttiExternalWorkspaceAgentProviders.includes(
+      value as TuttiExternalWorkspaceAgentProvider
+    )
+  );
+}
+
+function normalizeTuttiExternalWorkspaceAgentProvider(
+  value: unknown
+): TuttiExternalWorkspaceAgentProvider {
+  const provider = typeof value === "string" ? value.trim() : value;
+  if (!isTuttiExternalWorkspaceAgentProvider(provider)) {
+    throw new Error("workspace.openFeature provider is unsupported.");
+  }
+  return provider;
 }
 
 function normalizeTuttiExternalLogLevel(value: unknown): TuttiExternalLogLevel {


### PR DESCRIPTION
## Summary
- Remove the global agent install pending overlay from the workspace workbench.
- Validate workspace openFeature agent providers and prefer requested providers for agent-chat launches.
- Persist onboarding auto-open state in workbench snapshot metadata and document the mock unbound agent override.

## Why
The onboarding workspace app MR introduced global provider install UI and loose provider fallback behavior. This keeps provider actions scoped to their launch path and avoids reopening onboarding after it has already been shown.

## Validation
- pnpm --filter @tutti-os/workspace-external-core test
- pnpm --filter @tutti-os/desktop exec node --import ./test/register-asset-stub.mjs --test --experimental-strip-types ./src/renderer/src/features/workspace-workbench/services/workspaceOpenFeatureRequest.test.ts ./src/renderer/src/features/workspace-workbench/services/workspaceOnboarding.test.ts ./src/renderer/src/features/workspace-workbench/ui/WorkspaceWorkbench.source.test.ts
- pnpm exec oxfmt --check ...
- pnpm exec oxlint ... --deny-warnings
- pnpm --filter @tutti-os/workspace-external-core typecheck
- pnpm --filter @tutti-os/desktop typecheck
- pre-push pnpm check:full passed on retry; first run hit a transient unrelated workspaceAppFrontendLogging.test.ts ENOENT, and that test passed when rerun directly.