### PR TITLE
fix(tuttid): app CLI client timeout honors per-command budget

### DIFF
--- a/services/tuttid/service/cli/appcli/registry.go
+++ b/services/tuttid/service/cli/appcli/registry.go
@@ -499,7 +499,12 @@ func (r *Registry) httpClient() *http.Client {
 	if r.HTTPClient != nil {
 		return r.HTTPClient
 	}
-	return &http.Client{Timeout: 35 * time.Second}
+	// Cover the largest command budget the manifest allows (maxTimeoutMs) plus a
+	// small buffer; the per-command context.WithTimeout(command.timeout) still
+	// enforces the real deadline. A shorter client timeout would cut long
+	// synchronous commands (e.g. vibe-design session-start at 300s) short and
+	// surface them as app_cli_runtime_unavailable.
+	return &http.Client{Timeout: maxTimeoutMs*time.Millisecond + 30*time.Second}
 }
 
 func (r *Registry) ensureLocked() {


### PR DESCRIPTION
## Problem

`tutti-dev vibe-design session-start` failed with:

```
app_cli_runtime_unavailable: Post "http://127.0.0.1:57654/tutti/cli/session-start":
context deadline exceeded (Client.Timeout exceeded while awaiting headers)
```

The error code implies the app runtime was down, but it was healthy — the request was killed by the daemon's own HTTP client.

The app CLI registry's shared HTTP client hardcoded a **35s** timeout (`registry.go` `httpClient()`), which capped *every* command regardless of its declared `timeoutMs`. Long synchronous commands such as vibe-design `session-start` (declared **300s** budget in `tutti.cli.json`, runs the agent to completion) reliably exceed 35s. Worse, the resulting `net.Error` timeout is matched by `isConnectionUnavailable(...)`, so it surfaces as `app_cli_runtime_unavailable` instead of a timeout.

## Fix

Raise the default client timeout to cover the largest manifest-allowed budget (`maxTimeoutMs` = 600s) plus a 30s buffer. The per-command `context.WithTimeout(command.timeout)` still enforces the real deadline, so no command runs longer than its declared `timeoutMs`.

## Test

- `go build ./service/cli/appcli/...` ✅
- `go test ./service/cli/appcli/...` ✅

Note: pre-push `test:go` flags pre-existing, environment-dependent failures in `services/tuttid/integration` (terminal PTY tests: `start terminal pty: device not configured`) unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)