### PR TITLE
fix(cli): raise daemon client request timeout to 360s

### DIFF
--- a/apps/cli/internal/daemon/client.go
+++ b/apps/cli/internal/daemon/client.go
@@ -21,7 +21,10 @@ type Client struct {
 }
 
 const (
-	defaultClientTimeout    = 60 * time.Second
+	// 覆盖最长的命令预算(如 vibe-design session-start 声明 timeoutMs=300000),
+	// 留出网络/排队余量,避免长命令在客户端侧误报 "daemon request timed out"。
+	// TODO: 改为按命令的 timeoutMs 透传后,此全局值可回落。
+	defaultClientTimeout    = 360 * time.Second
 	healthPath              = "/v1/health"
 	cliCapabilitiesPath     = "/v1/cli/capabilities"
 	cliCommandInvokePattern = "/v1/cli/commands/{commandID}/invoke"


### PR DESCRIPTION
## 背景

`tutti(-dev) vibe-design session-start` 在本地报 `daemon request timed out`。排查发现 daemon 与 app runtime 其实仍在正常工作 —— 超时是 **CLI 客户端这一跳**误报的。

## 根因

CLI 客户端对每次 daemon invoke 用写死的 **60s** `http.Client` 超时(`apps/cli/internal/daemon/client.go`),且**不读命令声明的 `timeoutMs`**(`daemon.Capability` 结构体里没有该字段)。像 `vibe-design session-start`(manifest 声明 `timeoutMs=300000`,即 5 分钟预算)这类长命令一旦实际耗时超过 60s,就会触发 `context.DeadlineExceeded` → `daemon request timed out`,而 daemon/app 仍在跑。

之前已合并的 #120 修的是 **daemon → app** 那一跳(appcli registry 按 `timeoutMs` 转发);本 PR 补的是 **client → daemon** 那一跳,二者互补。

## 改动

把客户端全局超时从 60s 抬到 **360s**,覆盖最长命令预算(5 min)加网络/排队余量。

## 局限 / 后续

这是临时止血:对所有命令一刀切 360s,仍未读 per-command `timeoutMs`。代码里留了 `TODO`——正解是把命令的 `timeoutMs` 经 capability DTO 透传到客户端、按命令用 context deadline 控制,届时这个全局值可回落。

## 测试

`go test ./internal/daemon/...`(改动所在包)通过。

> 注:pre-push 的 `test:go` 在本机失败的是 `services/tuttid` 的终端/PTY/WebSocket 测试(依赖真实 TTY 的环境性失败)以及 `test:go` 脚本里一个已失效的 `workbench/service` 路径,均与本改动无关。

🤖 Generated with [Claude Code](https://claude.com/claude-code)