### PR TITLE
Fix Codex web search query display and separate failed session group

### DIFF
--- a/packages/agent/daemon/runtime/codex_adapter.go
+++ b/packages/agent/daemon/runtime/codex_adapter.go
@@ -2053,7 +2053,8 @@ func acpToolCallEventWithID(session Session, eventID string, turnID string, upda
 	content := acpSanitizeImagePayload(update["content"])
 	toolName := acpToolName(callID, name, kind, rawInput)
 	eventType := EventCallStarted
-	callBody := acpNormalizeToolInput(rawInput, kind, locations)
+	inputBody := acpNormalizeToolInput(rawInput, kind, locations)
+	callBody := inputBody
 	switch normalizedCallStatus(status) {
 	case messageStreamStateCompleted:
 		eventType = EventCallCompleted
@@ -2089,6 +2090,13 @@ func acpToolCallEventWithID(session Session, eventID string, turnID string, upda
 	}
 	if content != nil {
 		payload["content"] = content
+	}
+	// Some tools (notably Codex web search) stream an empty input on the
+	// `started` event and only populate the real input — the search query — on
+	// the `completed` event. The terminal event must therefore carry the input
+	// too, otherwise the empty start payload wins the merge and the query is lost.
+	if eventType != EventCallStarted && len(inputBody) > 0 {
+		payload["input"] = inputBody
 	}
 	if len(callBody) > 0 {
 		switch eventType {

--- a/packages/agent/daemon/runtime/codex_appserver_events.go
+++ b/packages/agent/daemon/runtime/codex_appserver_events.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"log/slog"
 	"strings"
 
 	activityshared "github.com/tutti-os/tutti/packages/agentactivity/daemon/activity/events"
@@ -319,12 +320,63 @@ func appServerItemToolCallUpdate(item map[string]any, completed bool) (map[strin
 			}
 		}
 	case "webSearch":
-		query := asStringRaw(item["query"])
-		update["title"] = "Searching for: " + query
+		// Per the Codex app-server schema, a webSearch item is {id, query, action?}
+		// and for a `search` action the real query lives in action.query or the
+		// action.queries[] array; the top-level `query` is often empty. Read the
+		// action first and fall back to the top-level field so the query is not
+		// silently dropped (which previously rendered an empty web-search row).
+		action := payloadObject(item["action"])
+		queries := appServerSearchQueries(action["queries"])
+		query := firstNonEmpty(
+			firstAppServerQuery(queries),
+			asString(action["query"]),
+			asString(item["query"]),
+		)
+		url := asString(action["url"])
+		actionType := firstNonEmpty(asString(action["type"]), "search")
+
+		rawInput := map[string]any{}
+		if query != "" {
+			rawInput["query"] = query
+		}
+		if len(queries) > 0 {
+			rawInput["search_query"] = queries
+		}
+		actionOut := map[string]any{"type": actionType}
+		if query != "" {
+			actionOut["query"] = query
+		}
+		if len(queries) > 0 {
+			actionOut["queries"] = queries
+		}
+		if url != "" {
+			actionOut["url"] = url
+		}
+		rawInput["action"] = actionOut
+
+		switch {
+		case query != "":
+			update["title"] = "Searching for: " + query
+		case url != "":
+			update["title"] = "Visiting: " + url
+		default:
+			update["title"] = "WebSearch"
+		}
 		update["kind"] = "fetch"
-		update["rawInput"] = map[string]any{
-			"query":  query,
-			"action": map[string]any{"type": "search", "query": query},
+		update["rawInput"] = rawInput
+
+		if query == "" && url == "" && len(queries) == 0 {
+			// Confirmed via exported logs: the Codex app-server streams web-search
+			// items as {query:"", action:{type:"other"}} for some models (e.g.
+			// gpt-5.x) — it never sends the query or results, so there is nothing
+			// for the daemon or GUI to render. Keep this at debug level (it can fire
+			// once per search) to aid future diagnosis without flooding info logs.
+			slog.Debug(
+				"agent session app-server web search has no query/results from provider",
+				"itemId", itemID,
+				"status", status,
+				"rawItem", appServerItemJSON(item),
+			)
 		}
 	case "dynamicToolCall":
 		update["title"] = firstNonEmpty(asString(item["tool"]), "Tool")
@@ -1457,6 +1509,46 @@ func truthyBool(value any) bool {
 func asStringRaw(value any) string {
 	typed, _ := value.(string)
 	return typed
+}
+
+// appServerSearchQueries reads action.queries[] (Codex app-server webSearch
+// schema) into a []any of non-empty trimmed strings, suitable for the GUI's
+// search_query rendering. Returns nil when absent or empty.
+func appServerSearchQueries(value any) []any {
+	raw, ok := value.([]any)
+	if !ok {
+		return nil
+	}
+	out := make([]any, 0, len(raw))
+	for _, entry := range raw {
+		if text := asString(entry); text != "" {
+			out = append(out, text)
+		}
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
+}
+
+// firstAppServerQuery returns the first non-empty query string from a
+// search_query list produced by appServerSearchQueries.
+func firstAppServerQuery(queries []any) string {
+	for _, q := range queries {
+		if text := asString(q); text != "" {
+			return text
+		}
+	}
+	return ""
+}
+
+// appServerItemJSON renders a raw thread item as compact JSON for diagnostics,
+// falling back to Go formatting if the item is not JSON-serializable.
+func appServerItemJSON(item map[string]any) string {
+	if encoded, err := json.Marshal(item); err == nil {
+		return string(encoded)
+	}
+	return fmt.Sprintf("%+v", item)
 }
 
 // appServerReasoningText pulls the human-readable text out of a completed

--- a/packages/agent/daemon/runtime/codex_appserver_websearch_test.go
+++ b/packages/agent/daemon/runtime/codex_appserver_websearch_test.go
@@ -1,0 +1,105 @@
+package agentruntime
+
+import "testing"
+
+// The Codex app-server webSearch item is {id, query, action?}; for a `search`
+// action the real query lives in action.query or action.queries[], while the
+// top-level `query` is frequently empty. These tests lock in that the daemon
+// reads the action so the GUI does not render an empty web-search row.
+
+func TestAppServerWebSearchReadsActionQuery(t *testing.T) {
+	item := map[string]any{
+		"id":     "ws_1",
+		"type":   "webSearch",
+		"status": "completed",
+		"query":  "",
+		"action": map[string]any{"type": "search", "query": "tutti release notes"},
+	}
+
+	update, ok := appServerItemToolCallUpdate(item, true)
+	if !ok {
+		t.Fatalf("expected webSearch item to produce an update")
+	}
+
+	rawInput, _ := update["rawInput"].(map[string]any)
+	if got := asString(rawInput["query"]); got != "tutti release notes" {
+		t.Fatalf("rawInput.query = %q, want %q", got, "tutti release notes")
+	}
+	action, _ := rawInput["action"].(map[string]any)
+	if got := asString(action["query"]); got != "tutti release notes" {
+		t.Fatalf("action.query = %q, want %q", got, "tutti release notes")
+	}
+}
+
+func TestAppServerWebSearchReadsActionQueriesArray(t *testing.T) {
+	item := map[string]any{
+		"id":     "ws_2",
+		"type":   "webSearch",
+		"status": "completed",
+		"action": map[string]any{
+			"type":    "search",
+			"queries": []any{"first query", "second query"},
+		},
+	}
+
+	update, ok := appServerItemToolCallUpdate(item, true)
+	if !ok {
+		t.Fatalf("expected webSearch item to produce an update")
+	}
+
+	rawInput, _ := update["rawInput"].(map[string]any)
+	if got := asString(rawInput["query"]); got != "first query" {
+		t.Fatalf("rawInput.query = %q, want %q", got, "first query")
+	}
+	searchQuery, _ := rawInput["search_query"].([]any)
+	if len(searchQuery) != 2 {
+		t.Fatalf("rawInput.search_query = %#v, want 2 entries", rawInput["search_query"])
+	}
+}
+
+// The Codex web search streams an empty input on `started` and the real query
+// only on `completed`. The completed activity event must carry that input or the
+// query is dropped when it merges with the empty started payload.
+func TestAcpToolCallEventCompletedCarriesWebSearchInput(t *testing.T) {
+	completed := map[string]any{
+		"sessionUpdate": "tool_call_update",
+		"toolCallId":    "ws_42",
+		"kind":          "fetch",
+		"status":        "completed",
+		"rawInput": map[string]any{
+			"query":  "tutti release notes",
+			"action": map[string]any{"type": "search", "query": "tutti release notes"},
+		},
+	}
+
+	session := Session{Provider: "codex", AgentSessionID: "agent-ws", RoomID: "room-ws"}
+	event, ok := acpToolCallEventWithID(session, "evt-1", "turn-1", completed)
+	if !ok {
+		t.Fatalf("expected completed web search update to produce an event")
+	}
+	if event.Type != EventCallCompleted {
+		t.Fatalf("event.Type = %q, want EventCallCompleted", event.Type)
+	}
+	input, _ := event.Payload.Metadata["input"].(map[string]any)
+	if got := asString(input["query"]); got != "tutti release notes" {
+		t.Fatalf("completed event input.query = %q, want %q (raw=%#v)", got, "tutti release notes", event.Payload.Metadata["input"])
+	}
+}
+
+func TestAppServerWebSearchTopLevelQueryFallback(t *testing.T) {
+	item := map[string]any{
+		"id":    "ws_3",
+		"type":  "webSearch",
+		"query": "legacy top-level query",
+	}
+
+	update, ok := appServerItemToolCallUpdate(item, false)
+	if !ok {
+		t.Fatalf("expected webSearch item to produce an update")
+	}
+
+	rawInput, _ := update["rawInput"].(map[string]any)
+	if got := asString(rawInput["query"]); got != "legacy top-level query" {
+		t.Fatalf("rawInput.query = %q, want %q", got, "legacy top-level query")
+	}
+}

--- a/packages/agent/gui/agent-message-center/WorkspaceAgentMessageCenterPanel.spec.tsx
+++ b/packages/agent/gui/agent-message-center/WorkspaceAgentMessageCenterPanel.spec.tsx
@@ -1493,6 +1493,43 @@ describe("WorkspaceAgentMessageCenterPanel", () => {
     expect(recentSection).not.toHaveTextContent("Finished long ago");
   });
 
+  it("splits failed items out of the needs-attention group in the priority view", () => {
+    render(
+      <WorkspaceAgentMessageCenterPanel
+        open
+        model={createMessageCenterModel([
+          createMessageCenterItem({
+            agentSessionId: "attention-session",
+            title: "Awaiting input",
+            status: "working",
+            needsAttentionKind: "question",
+            needsAttentionSummary: "Needs a decision"
+          }),
+          createMessageCenterItem({
+            agentSessionId: "failed-session",
+            title: "Request failed",
+            status: "failed"
+          })
+        ])}
+        onClose={vi.fn()}
+        onOpenChat={vi.fn()}
+        onSubmitPrompt={vi.fn()}
+      />
+    );
+
+    expect(
+      screen.getByRole("heading", { name: "Needs attention · 1" })
+    ).toBeTruthy();
+    expect(screen.getByRole("heading", { name: "Error · 1" })).toBeTruthy();
+
+    const attentionSection = screen
+      .getByRole("heading", { name: "Needs attention · 1" })
+      .closest("section");
+    expect(attentionSection).not.toBeNull();
+    expect(attentionSection).toHaveTextContent("Awaiting input");
+    expect(attentionSection).not.toHaveTextContent("Request failed");
+  });
+
   it("shows a filtered empty state with a clear filters action", () => {
     render(
       <WorkspaceAgentMessageCenterPanel

--- a/packages/agent/gui/agent-message-center/workspaceAgentMessageCenterViewModel.spec.ts
+++ b/packages/agent/gui/agent-message-center/workspaceAgentMessageCenterViewModel.spec.ts
@@ -137,6 +137,40 @@ describe("groupMessageCenterItems", () => {
       }
     ]);
   });
+
+  it("splits failed items into their own group in the priority view", () => {
+    const groups = groupMessageCenterItems(
+      [
+        item({
+          agentSessionId: "waiting-session",
+          status: "working",
+          needsAttentionKind: "question"
+        }),
+        item({
+          agentSessionId: "failed-session",
+          status: "failed"
+        })
+      ],
+      "priority",
+      (key) => key
+    );
+
+    expect(
+      groups.map((group) => ({
+        id: group.id,
+        sessionIds: group.items.map((entry) => entry.agentSessionId)
+      }))
+    ).toEqual([
+      {
+        id: "needs-attention",
+        sessionIds: ["waiting-session"]
+      },
+      {
+        id: "failed",
+        sessionIds: ["failed-session"]
+      }
+    ]);
+  });
 });
 
 function item(

--- a/packages/agent/gui/agent-message-center/workspaceAgentMessageCenterViewModel.ts
+++ b/packages/agent/gui/agent-message-center/workspaceAgentMessageCenterViewModel.ts
@@ -223,9 +223,12 @@ export function groupMessageCenterItems(
         {
           id: "needs-attention",
           label: t("agentHost.workspaceAgentMessageCenterGroupNeedsAttention"),
-          match: (item) =>
-            messageCenterStatusFilterValue(item) === "waiting" ||
-            messageCenterStatusFilterValue(item) === "failed"
+          match: (item) => messageCenterStatusFilterValue(item) === "waiting"
+        },
+        {
+          id: "failed",
+          label: t("agentHost.workspaceAgentMessageCenterFilterFailed"),
+          match: (item) => messageCenterStatusFilterValue(item) === "failed"
         },
         {
           id: "working",

--- a/packages/agent/gui/shared/agentConversation/components/tool-renderers/AgentExpandedToolContent.spec.tsx
+++ b/packages/agent/gui/shared/agentConversation/components/tool-renderers/AgentExpandedToolContent.spec.tsx
@@ -640,6 +640,51 @@ describe("AgentExpandedToolContent", () => {
     expect(screen.getByText("agent renderer parity")).toBeTruthy();
   });
 
+  it("renders the query when web search carries no results payload", async () => {
+    setAgentGuiI18nTestLocale("en");
+
+    // Mirrors the Codex daemon path (codex_appserver_events.go): web search
+    // events carry only the query under input, never an output/results payload.
+    render(
+      <AgentExpandedToolContent
+        call={projectAgentToolCall(
+          toolCall({
+            toolName: "WebSearch",
+            payload: {
+              input: {
+                query: "agent renderer parity",
+                action: { type: "search", query: "agent renderer parity" }
+              }
+            }
+          })
+        )}
+      />
+    );
+
+    expect(screen.getByText("agent renderer parity")).toBeTruthy();
+  });
+
+  it("does not render an empty body when web search has no results", async () => {
+    setAgentGuiI18nTestLocale("en");
+
+    const { container } = render(
+      <AgentExpandedToolContent
+        call={projectAgentToolCall(
+          toolCall({
+            toolName: "WebSearch",
+            payload: { input: {}, output: {} }
+          })
+        )}
+      />
+    );
+
+    expect(
+      container.querySelector(
+        ".workspace-agents-status-panel__detail-tool-body"
+      )
+    ).toBeNull();
+  });
+
   it("renders web fetch content with truncation notice", async () => {
     setAgentGuiI18nTestLocale("en");
 

--- a/packages/agent/gui/shared/agentConversation/components/tool-renderers/AgentWebSearchContent.tsx
+++ b/packages/agent/gui/shared/agentConversation/components/tool-renderers/AgentWebSearchContent.tsx
@@ -15,14 +15,25 @@ const MAX_SUMMARY_LENGTH = 3000;
 export function AgentWebSearchContent({
   call,
   onLinkClick
-}: AgentToolRendererProps): JSX.Element {
+}: AgentToolRendererProps): JSX.Element | null {
   "use memo";
   const web = getWebSearchRenderData(call);
   const queries = web.queries;
-  const outputText = web.output ?? "";
+  const outputText = web.output;
   const links = normalizeLinks(call.output?.links, outputText);
   const summary = extractSummary(outputText) ?? (call.summary.trim() || null);
   const visibleSummary = summary ? summary.slice(0, MAX_SUMMARY_LENGTH) : null;
+
+  const hasRenderableContent = Boolean(
+    web.query ||
+    queries.length > 0 ||
+    links.length > 0 ||
+    visibleSummary ||
+    web.error
+  );
+  if (!hasRenderableContent) {
+    return null;
+  }
 
   return (
     <div className="workspace-agents-status-panel__detail-tool-body">

--- a/packages/agent/gui/shared/agentConversation/components/tool-renderers/agentToolContentShared.tsx
+++ b/packages/agent/gui/shared/agentConversation/components/tool-renderers/agentToolContentShared.tsx
@@ -8,7 +8,8 @@ import {
   getFileChangeRenderData,
   getImageGenerationRenderData,
   getToolFallbackText,
-  getWebFetchRenderData
+  getWebFetchRenderData,
+  getWebSearchRenderData
 } from "./render-data/agentToolRenderData";
 import { CollapsibleReveal } from "../CollapsibleReveal";
 import { fileRange } from "./AgentReadContent";
@@ -174,8 +175,9 @@ export function hasAgentToolContent(call: AgentToolCallVM): boolean {
       return hasEditContent(call);
     case "bash":
     case "search":
-    case "web-search":
       return hasGenericStructuredContent(call);
+    case "web-search":
+      return hasWebSearchContent(call);
     case "web-fetch":
       return hasWebFetchContent(call) || hasGenericStructuredContent(call);
     case "image-generation": {
@@ -211,6 +213,20 @@ function hasGenericStructuredContent(call: AgentToolCallVM): boolean {
 function hasWebFetchContent(call: AgentToolCallVM): boolean {
   const web = getWebFetchRenderData(call);
   return Boolean(web.url || web.visibleContent);
+}
+
+function hasWebSearchContent(call: AgentToolCallVM): boolean {
+  // Mirror what AgentWebSearchContent can actually render. Web search payloads
+  // (notably the Codex path) often carry only a query and no results, so guard
+  // against treating an empty payload as renderable detail.
+  const web = getWebSearchRenderData(call);
+  return Boolean(
+    web.query ||
+    web.queries.length > 0 ||
+    web.output.trim() ||
+    web.error ||
+    arrayValue(call.output?.links)?.length
+  );
 }
 
 function hasReadContent(call: AgentToolCallVM): boolean {

--- a/packages/agent/gui/shared/agentConversation/components/tool-renderers/render-data/agentToolRenderData.ts
+++ b/packages/agent/gui/shared/agentConversation/components/tool-renderers/render-data/agentToolRenderData.ts
@@ -227,13 +227,13 @@ export function getSearchRenderData(
           : [],
     lines: outputLines,
     output,
-    error: firstString(
-      stringValue(call.error?.aggregated_output),
-      stringValue(call.error?.stdout),
-      stringValue(call.error?.formatted_output),
-      stringValue(call.error?.message),
-      ""
-    )!
+    error:
+      firstString(
+        stringValue(call.error?.aggregated_output),
+        stringValue(call.error?.stdout),
+        stringValue(call.error?.formatted_output),
+        stringValue(call.error?.message)
+      ) ?? ""
   };
 }
 
@@ -257,17 +257,18 @@ export function getWebSearchRenderData(
       stringValue(call.input?.url),
       stringValue(recordValue(call.input?.action)?.url)
     ),
-    output: firstString(
-      stringValue(call.output?.stdout),
-      stringValue(call.output?.output),
-      stringValue(call.output?.content),
-      ""
-    )!,
-    error: firstString(
-      stringValue(call.error?.message),
-      stringValue(call.error?.stdout),
-      ""
-    )!
+    output:
+      firstString(
+        stringValue(call.output?.stdout),
+        stringValue(call.output?.output),
+        stringValue(call.output?.content),
+        contentText(call.output?.content)
+      ) ?? "",
+    error:
+      firstString(
+        stringValue(call.error?.message),
+        stringValue(call.error?.stdout)
+      ) ?? ""
   };
 }
 
@@ -325,12 +326,12 @@ export function getMcpRenderData(call: AgentToolCallVM): AgentMcpRenderData {
     ),
     tool: call.toolName,
     summary: stringValue(call.summary),
-    output: firstString(
-      stringValue(call.output?.content),
-      stringValue(call.output?.output),
-      stringValue(call.output?.stdout),
-      ""
-    )!
+    output:
+      firstString(
+        stringValue(call.output?.content),
+        stringValue(call.output?.output),
+        stringValue(call.output?.stdout)
+      ) ?? ""
   };
 }
 


### PR DESCRIPTION
## Summary

- **[Daemon] Fix web search query being silently dropped**: Codex app-server streams `webSearch` as `{query:"", action:{type:"other"}}` on `started` and only populates the real query on `completed`. `acpToolCallEventWithID` previously only wrote `payload["input"]` on `EventCallStarted`, so the completed-event input was thrown away and the empty started payload won the merge. Terminal events now carry the non-empty input alongside output.
- **[Daemon] Read query from `action.query`/`action.queries[]`**: Per the actual Codex app-server schema, the real query lives in the `action` object, not the top-level `query` field (which is frequently empty). Added proper extraction with `action.queries[]` array support and debug logging when no query is found.
- **[GUI] Guard against empty web search payloads**: `AgentWebSearchContent` now returns `null` when there is nothing renderable, preventing empty gray bars. Added dedicated `hasWebSearchContent()` in `agentToolContentShared` mirroring what the renderer actually shows.
- **[GUI] Eliminate type lies in `agentToolRenderData.ts`**: All `firstString(...)!` non-null assertions replaced with `firstString(...) ?? ""` — the root cause of the `null.trim()` crash that collapsed entire tool groups via the error boundary.
- **[Message center] Split failed sessions into separate group**: In the priority view, `failed` status is now its own group ("Error") rather than being mixed into "Needs attention".

## Test plan

- [ ] Start a Codex agent session and trigger a web search — verify the query renders in the tool call detail panel
- [ ] Verify tool calls can be expanded/collapsed without crashing
- [ ] In the agent message center priority view, confirm failed sessions appear under "Error" and waiting sessions appear under "Needs attention" (not mixed)
- [ ] `go test ./runtime/ ./activity/` in `packages/agent/daemon` — all pass including new `codex_appserver_websearch_test.go`
- [ ] `pnpm --filter ./packages/agent/gui test` — 291+ tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)