### PR TITLE
fix(agent): install Codex CLI from latest release assets

### DIFF
--- a/services/tuttid/service/agentstatus/installer.go
+++ b/services/tuttid/service/agentstatus/installer.go
@@ -365,6 +365,27 @@ func (s Service) executeInstaller(
 		}
 		result, err := s.runReleaseBinaryInstaller(installCtx, spec, installDir)
 		return runResult(result, err)
+	case InstallerKindCodexCLILatest:
+		installDir := ""
+		if spec.CodexCLI != nil {
+			installDir = strings.TrimSpace(spec.CodexCLI.InstallDir)
+		}
+		if runtime != nil && strings.TrimSpace(runtime.InstallDir) != "" {
+			installDir = strings.TrimSpace(runtime.InstallDir)
+		}
+		if installDir == "" {
+			installDir, err = s.selectInstallDir()
+			if err != nil {
+				return command, InstallCommandResult{ExitCode: 1, Stderr: err.Error()}, nil
+			}
+			if runtime != nil {
+				runtime.InstallDir = installDir
+			}
+		} else if runtime != nil {
+			runtime.InstallDir = installDir
+		}
+		result, err := s.runCodexCLILatestInstaller(installCtx, spec, installDir)
+		return runResult(result, err)
 	case InstallerKindExternalAgentRegistryNPM:
 		result, err := s.runExternalAgentRegistryNPMInstaller(installCtx, spec)
 		if err == nil && result.ExitCode == 0 {

--- a/services/tuttid/service/agentstatus/installer.go
+++ b/services/tuttid/service/agentstatus/installer.go
@@ -11,6 +11,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"log/slog"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -187,6 +188,17 @@ func (s Service) installMissingProviderRuntime(
 			}
 			attemptedAdapter = true
 		}
+		slog.Info(
+			"agent provider install step started",
+			"provider", spec.Provider,
+			"target", installTarget,
+			"installerKind", installer.Kind,
+			"command", installer.displayCommand(),
+			"cliPath", current.CLIPath,
+			"adapterPath", current.AdapterPath,
+			"adapterVersion", current.AdapterVersion,
+			"installDir", current.InstallDir,
+		)
 		command, result, err := s.executeInstaller(ctx, installer, &current)
 		if command != "" {
 			summary.Commands = append(summary.Commands, command)
@@ -199,15 +211,55 @@ func (s Service) installMissingProviderRuntime(
 		}
 		summary.ExitCode = intPointer(result.ExitCode)
 		if err != nil {
+			slog.Warn(
+				"agent provider install step failed to run",
+				"provider", spec.Provider,
+				"target", installTarget,
+				"installerKind", installer.Kind,
+				"command", command,
+				"exitCode", result.ExitCode,
+				"stdout", trimActionOutput(result.Stdout),
+				"stderr", trimActionOutput(result.Stderr),
+				"error", err,
+			)
 			return summary, current, err
 		}
 		if result.ExitCode != 0 {
+			slog.Warn(
+				"agent provider install step failed",
+				"provider", spec.Provider,
+				"target", installTarget,
+				"installerKind", installer.Kind,
+				"command", command,
+				"exitCode", result.ExitCode,
+				"stdout", trimActionOutput(result.Stdout),
+				"stderr", trimActionOutput(result.Stderr),
+			)
 			return summary, current, nil
 		}
+		slog.Info(
+			"agent provider install step completed",
+			"provider", spec.Provider,
+			"target", installTarget,
+			"installerKind", installer.Kind,
+			"command", command,
+			"exitCode", result.ExitCode,
+			"stdout", trimActionOutput(result.Stdout),
+			"stderr", trimActionOutput(result.Stderr),
+		)
 		selectedInstallDir := current.InstallDir
 		resolvedSpec, _ := s.resolveProviderSpec(ctx, spec, false)
 		current = s.resolveProviderRuntime(ctx, resolvedSpec)
 		current.InstallDir = selectedInstallDir
+		slog.Info(
+			"agent provider install step rechecked runtime",
+			"provider", spec.Provider,
+			"target", installTarget,
+			"cliPath", current.CLIPath,
+			"adapterPath", current.AdapterPath,
+			"adapterVersion", current.AdapterVersion,
+			"installDir", current.InstallDir,
+		)
 	}
 }
 
@@ -382,6 +434,15 @@ func (s Service) runReleaseBinaryInstaller(
 			Stderr:   fmt.Sprintf("release binary installer asset is unavailable for %s", releaseBinaryPlatformKey(runtime.GOOS, runtime.GOARCH)),
 		}, nil
 	}
+	platformKey := releaseBinaryPlatformKey(runtime.GOOS, runtime.GOARCH)
+	slog.Info(
+		"agent provider release binary install asset selected",
+		"binary", spec.ReleaseBinary.BinaryName,
+		"version", spec.ReleaseBinary.Version,
+		"platform", platformKey,
+		"installDir", installDir,
+		"url", asset.URL,
+	)
 
 	archiveFile, err := os.CreateTemp("", "tutti-agent-provider-archive-*"+archiveSuffix(asset.URL))
 	if err != nil {

--- a/services/tuttid/service/agentstatus/installer_codex_cli.go
+++ b/services/tuttid/service/agentstatus/installer_codex_cli.go
@@ -1,0 +1,296 @@
+package agentstatus
+
+import (
+	"archive/tar"
+	"compress/gzip"
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+)
+
+const defaultCodexCLILatestBaseURL = "https://github.com/openai/codex/releases/latest/download"
+
+func (s Service) runCodexCLILatestInstaller(
+	ctx context.Context,
+	spec InstallerSpec,
+	installDir string,
+) (InstallCommandResult, error) {
+	if spec.CodexCLI == nil {
+		return InstallCommandResult{ExitCode: 1, Stderr: "codex CLI latest installer config is required"}, nil
+	}
+	if strings.TrimSpace(installDir) == "" {
+		return InstallCommandResult{ExitCode: 1, Stderr: "install directory is required"}, nil
+	}
+	if err := ensureWritableInstallDir(installDir); err != nil {
+		return InstallCommandResult{ExitCode: 1, Stderr: err.Error()}, nil
+	}
+	target, ok := codexCLIPackageTarget(runtime.GOOS, runtime.GOARCH)
+	if !ok {
+		return InstallCommandResult{
+			ExitCode: 1,
+			Stderr:   fmt.Sprintf("codex CLI latest installer asset is unavailable for %s", releaseBinaryPlatformKey(runtime.GOOS, runtime.GOARCH)),
+		}, nil
+	}
+	baseURL := strings.TrimRight(firstNonBlank(spec.CodexCLI.BaseURL, defaultCodexCLILatestBaseURL), "/")
+	archiveName := "codex-package-" + target + ".tar.gz"
+	archiveURL := baseURL + "/" + archiveName
+	checksumURL := baseURL + "/codex-package_SHA256SUMS"
+	slog.Info(
+		"agent provider codex CLI latest install asset selected",
+		"target", target,
+		"installDir", installDir,
+		"archiveURL", archiveURL,
+		"checksumURL", checksumURL,
+	)
+
+	archiveFile, err := os.CreateTemp("", "tutti-codex-cli-package-*.tar.gz")
+	if err != nil {
+		return InstallCommandResult{ExitCode: 1}, err
+	}
+	archivePath := archiveFile.Name()
+	defer func() {
+		_ = os.Remove(archivePath)
+	}()
+	if err := archiveFile.Close(); err != nil {
+		return InstallCommandResult{ExitCode: 1}, err
+	}
+	if err := s.downloadFile(ctx, archiveURL, archivePath); err != nil {
+		return InstallCommandResult{ExitCode: 1, Stderr: err.Error()}, nil
+	}
+
+	checksumFile, err := os.CreateTemp("", "tutti-codex-cli-SHA256SUMS-*")
+	if err != nil {
+		return InstallCommandResult{ExitCode: 1}, err
+	}
+	checksumPath := checksumFile.Name()
+	defer func() {
+		_ = os.Remove(checksumPath)
+	}()
+	if err := checksumFile.Close(); err != nil {
+		return InstallCommandResult{ExitCode: 1}, err
+	}
+	if err := s.downloadFile(ctx, checksumURL, checksumPath); err != nil {
+		return InstallCommandResult{ExitCode: 1, Stderr: err.Error()}, nil
+	}
+	expected, err := codexPackageChecksum(checksumPath, archiveName)
+	if err != nil {
+		return InstallCommandResult{ExitCode: 1, Stderr: err.Error()}, nil
+	}
+	actualSHA256, err := fileSHA256(archivePath)
+	if err != nil {
+		return InstallCommandResult{ExitCode: 1, Stderr: err.Error()}, nil
+	}
+	if !strings.EqualFold(actualSHA256, expected) {
+		return InstallCommandResult{ExitCode: 1, Stderr: fmt.Sprintf("downloaded Codex CLI package sha256 mismatch: want %s got %s", expected, actualSHA256)}, nil
+	}
+
+	standaloneRoot, err := s.codexStandaloneRoot()
+	if err != nil {
+		return InstallCommandResult{ExitCode: 1, Stderr: err.Error()}, nil
+	}
+	releaseDir := filepath.Join(standaloneRoot, "releases", "latest-"+target)
+	if err := installCodexCLIPackageArchive(archivePath, releaseDir); err != nil {
+		return InstallCommandResult{ExitCode: 1, Stderr: err.Error()}, nil
+	}
+	currentLink := filepath.Join(standaloneRoot, "current")
+	if err := replaceSymlink(currentLink, releaseDir); err != nil {
+		return InstallCommandResult{ExitCode: 1, Stderr: err.Error()}, nil
+	}
+	visiblePath := filepath.Join(installDir, "codex")
+	if err := replaceSymlink(visiblePath, filepath.Join(currentLink, "bin", "codex")); err != nil {
+		return InstallCommandResult{ExitCode: 1, Stderr: err.Error()}, nil
+	}
+	return InstallCommandResult{
+		ExitCode: 0,
+		Stdout: fmt.Sprintf(
+			"Installed Codex CLI latest %s to %s",
+			target,
+			visiblePath,
+		),
+	}, nil
+}
+
+func codexCLIPackageTarget(goos string, goarch string) (string, bool) {
+	switch releaseBinaryPlatformKey(goos, goarch) {
+	case releaseBinaryPlatformKey("darwin", "arm64"):
+		return "aarch64-apple-darwin", true
+	case releaseBinaryPlatformKey("darwin", "amd64"):
+		return "x86_64-apple-darwin", true
+	case releaseBinaryPlatformKey("linux", "arm64"):
+		return "aarch64-unknown-linux-musl", true
+	case releaseBinaryPlatformKey("linux", "amd64"):
+		return "x86_64-unknown-linux-musl", true
+	default:
+		return "", false
+	}
+}
+
+func codexPackageChecksum(checksumPath string, archiveName string) (string, error) {
+	content, err := os.ReadFile(checksumPath)
+	if err != nil {
+		return "", fmt.Errorf("read codex CLI checksums: %w", err)
+	}
+	for _, line := range strings.Split(string(content), "\n") {
+		fields := strings.Fields(line)
+		if len(fields) < 2 {
+			continue
+		}
+		checksumName := strings.TrimPrefix(fields[1], "*")
+		if checksumName == archiveName {
+			checksum := normalizeSHA256(fields[0])
+			if len(checksum) != 64 {
+				return "", fmt.Errorf("codex CLI checksum for %s is invalid", archiveName)
+			}
+			return checksum, nil
+		}
+	}
+	return "", fmt.Errorf("codex CLI checksums do not contain %s", archiveName)
+}
+
+func installCodexCLIPackageArchive(archivePath string, releaseDir string) error {
+	parent := filepath.Dir(releaseDir)
+	if err := os.MkdirAll(parent, 0o755); err != nil {
+		return fmt.Errorf("create codex CLI releases parent: %w", err)
+	}
+	stageDir, err := os.MkdirTemp(parent, ".staging."+filepath.Base(releaseDir)+".")
+	if err != nil {
+		return fmt.Errorf("create codex CLI staging dir: %w", err)
+	}
+	defer func() {
+		_ = os.RemoveAll(stageDir)
+	}()
+	if err := extractTarGzArchive(archivePath, stageDir); err != nil {
+		return err
+	}
+	if err := os.Chmod(filepath.Join(stageDir, "bin", "codex"), 0o755); err != nil {
+		return fmt.Errorf("chmod codex CLI binary: %w", err)
+	}
+	if err := os.Chmod(filepath.Join(stageDir, "codex-path", "rg"), 0o755); err != nil {
+		return fmt.Errorf("chmod codex CLI rg binary: %w", err)
+	}
+	if err := replaceSymlink(filepath.Join(stageDir, "codex"), "bin/codex"); err != nil {
+		return err
+	}
+	if err := os.RemoveAll(releaseDir); err != nil {
+		return fmt.Errorf("remove existing codex CLI release: %w", err)
+	}
+	if err := os.Rename(stageDir, releaseDir); err != nil {
+		return fmt.Errorf("install codex CLI release: %w", err)
+	}
+	return nil
+}
+
+func extractTarGzArchive(archivePath string, destinationDir string) error {
+	file, err := os.Open(archivePath)
+	if err != nil {
+		return fmt.Errorf("open tar.gz archive: %w", err)
+	}
+	defer func() {
+		_ = file.Close()
+	}()
+	gzipReader, err := gzip.NewReader(file)
+	if err != nil {
+		return fmt.Errorf("open gzip archive: %w", err)
+	}
+	defer func() {
+		_ = gzipReader.Close()
+	}()
+	reader := tar.NewReader(gzipReader)
+	for {
+		header, err := reader.Next()
+		if errors.Is(err, io.EOF) {
+			return nil
+		}
+		if err != nil {
+			return fmt.Errorf("read tar.gz archive: %w", err)
+		}
+		if header == nil {
+			continue
+		}
+		name := filepath.Clean(header.Name)
+		if name == "." || filepath.IsAbs(name) || strings.HasPrefix(name, ".."+string(filepath.Separator)) || name == ".." {
+			return fmt.Errorf("tar.gz archive contains unsafe path %s", header.Name)
+		}
+		targetPath := filepath.Join(destinationDir, name)
+		switch header.Typeflag {
+		case tar.TypeDir:
+			if err := os.MkdirAll(targetPath, header.FileInfo().Mode().Perm()); err != nil {
+				return fmt.Errorf("create archive directory: %w", err)
+			}
+		case tar.TypeReg:
+			if err := writeArchiveFile(targetPath, reader, header.FileInfo().Mode()); err != nil {
+				return err
+			}
+		}
+	}
+}
+
+func writeArchiveFile(destinationPath string, content io.Reader, mode os.FileMode) error {
+	if err := os.MkdirAll(filepath.Dir(destinationPath), 0o755); err != nil {
+		return fmt.Errorf("create archive file parent: %w", err)
+	}
+	perm := mode.Perm()
+	if perm == 0 {
+		perm = 0o644
+	}
+	target, err := os.OpenFile(destinationPath, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, perm)
+	if err != nil {
+		return fmt.Errorf("create archive file destination: %w", err)
+	}
+	_, copyErr := io.Copy(target, content)
+	closeErr := target.Close()
+	return errors.Join(copyErr, closeErr)
+}
+
+func replaceSymlink(linkPath string, targetPath string) error {
+	if err := os.MkdirAll(filepath.Dir(linkPath), 0o755); err != nil {
+		return fmt.Errorf("create symlink parent: %w", err)
+	}
+	tmpLink := filepath.Join(filepath.Dir(linkPath), "."+filepath.Base(linkPath)+".tmp")
+	if err := os.RemoveAll(tmpLink); err != nil {
+		return fmt.Errorf("remove stale symlink temp path: %w", err)
+	}
+	if err := os.Symlink(targetPath, tmpLink); err != nil {
+		return fmt.Errorf("create symlink: %w", err)
+	}
+	if err := os.RemoveAll(linkPath); err != nil {
+		_ = os.Remove(tmpLink)
+		return fmt.Errorf("remove existing symlink path: %w", err)
+	}
+	if err := os.Rename(tmpLink, linkPath); err != nil {
+		_ = os.Remove(tmpLink)
+		return fmt.Errorf("replace symlink: %w", err)
+	}
+	return nil
+}
+
+func (s Service) codexStandaloneRoot() (string, error) {
+	home, err := s.homeDir()
+	if err != nil {
+		return "", fmt.Errorf("resolve home directory: %w", err)
+	}
+	codexHome := strings.TrimSpace(envValue(s.Environ, "CODEX_HOME"))
+	if codexHome == "" {
+		codexHome = filepath.Join(home, ".codex")
+	}
+	return filepath.Join(codexHome, "packages", "standalone"), nil
+}
+
+func envValue(environ func() []string, key string) string {
+	if environ == nil {
+		return ""
+	}
+	prefix := key + "="
+	for _, value := range environ() {
+		if strings.HasPrefix(value, prefix) {
+			return strings.TrimPrefix(value, prefix)
+		}
+	}
+	return ""
+}

--- a/services/tuttid/service/agentstatus/installer_types.go
+++ b/services/tuttid/service/agentstatus/installer_types.go
@@ -13,6 +13,7 @@ const (
 	InstallerKindOfficialScript           InstallerKind = "official_script"
 	InstallerKindGitHubReleaseBinary      InstallerKind = "github_release_binary"
 	InstallerKindExternalAgentRegistryNPM InstallerKind = "external_agent_registry_npm"
+	InstallerKindCodexCLILatest           InstallerKind = "codex_cli_latest"
 )
 
 // InstallerPostStep names an optional, idempotent step run after a successful
@@ -34,6 +35,7 @@ type InstallerSpec struct {
 	ScriptShell    string
 	ReleaseBinary  *ReleaseBinaryInstallerSpec
 	RegistryNPM    *ExternalAgentRegistryNPMInstallerSpec
+	CodexCLI       *CodexCLILatestInstallerSpec
 	PostInstall    InstallerPostStep
 }
 
@@ -59,6 +61,11 @@ type ReleaseBinaryAsset struct {
 	SHA256 string
 }
 
+type CodexCLILatestInstallerSpec struct {
+	BaseURL    string
+	InstallDir string
+}
+
 func (s InstallerSpec) displayCommand() string {
 	switch s.Kind {
 	case InstallerKindShellCommand:
@@ -75,6 +82,8 @@ func (s InstallerSpec) displayCommand() string {
 			return firstNonBlank(s.DisplayCommand, "Install "+s.RegistryNPM.Package+" from ACP External Agent Registry")
 		}
 		return strings.TrimSpace(s.DisplayCommand)
+	case InstallerKindCodexCLILatest:
+		return firstNonBlank(s.DisplayCommand, "Install Codex CLI latest from GitHub releases")
 	default:
 		return ""
 	}
@@ -130,6 +139,13 @@ func validateInstallerSpec(spec InstallerSpec) error {
 		}
 		if strings.TrimSpace(spec.RegistryNPM.PrefixDir) == "" {
 			return fmt.Errorf("external agent registry npm installer prefix dir is required")
+		}
+	case InstallerKindCodexCLILatest:
+		if spec.CodexCLI == nil {
+			return fmt.Errorf("codex CLI latest installer config is required")
+		}
+		if _, ok := codexCLIPackageTarget(runtime.GOOS, runtime.GOARCH); !ok {
+			return fmt.Errorf("codex CLI latest installer asset is unavailable for %s", releaseBinaryPlatformKey(runtime.GOOS, runtime.GOARCH))
 		}
 	default:
 		return fmt.Errorf("unsupported installer kind %q", spec.Kind)

--- a/services/tuttid/service/agentstatus/registry.go
+++ b/services/tuttid/service/agentstatus/registry.go
@@ -108,14 +108,9 @@ func DefaultRegistry() Registry {
 			AdapterCommand:     []string{"codex-acp"},
 			AuthStatusCommand:  []string{"login", "status"},
 			AuthMarkerPaths:    []string{"~/.codex/auth.json"},
-			Install: InstallerSpec{
-				Kind:           InstallerKindOfficialScript,
-				DisplayCommand: "curl -fsSL https://chatgpt.com/codex/install.sh | sh",
-				ScriptURL:      "https://chatgpt.com/codex/install.sh",
-				ScriptShell:    "sh",
-			},
-			AdapterInstall: codexACPInstallerSpec(),
-			LoginArgs:      []string{"login"},
+			Install:            codexCLIInstallerSpec(),
+			AdapterInstall:     codexACPInstallerSpec(),
+			LoginArgs:          []string{"login"},
 		},
 		agentprovider.Nexight: {
 			Provider:           agentprovider.Nexight,
@@ -174,6 +169,16 @@ func DefaultRegistry() Registry {
 		}
 	}
 	return Registry{Specs: specs}
+}
+
+func codexCLIInstallerSpec() InstallerSpec {
+	return InstallerSpec{
+		Kind:           InstallerKindCodexCLILatest,
+		DisplayCommand: "Install Codex CLI latest from GitHub releases",
+		CodexCLI: &CodexCLILatestInstallerSpec{
+			BaseURL: "https://github.com/openai/codex/releases/latest/download",
+		},
+	}
 }
 
 func codexACPInstallerSpec() InstallerSpec {

--- a/services/tuttid/service/agentstatus/service_test.go
+++ b/services/tuttid/service/agentstatus/service_test.go
@@ -11,6 +11,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"runtime"
 	"slices"
@@ -761,6 +762,70 @@ func TestServiceRunActionInstallsThenProbesProvider(t *testing.T) {
 	}
 	if _, err := os.Stat(filepath.Join(home, ".local", "bin", "codex-acp")); err != nil {
 		t.Fatalf("installed adapter missing: %v", err)
+	}
+}
+
+func TestServiceRunCodexCLILatestInstallerDownloadsLatestAssets(t *testing.T) {
+	home := t.TempDir()
+	installDir := filepath.Join(home, ".local", "bin")
+	archivePath, archiveSHA256 := codexCLIPackageArchive(t)
+	target, ok := codexCLIPackageTarget(runtime.GOOS, runtime.GOARCH)
+	if !ok {
+		t.Skipf("codex CLI package target unavailable for %s/%s", runtime.GOOS, runtime.GOARCH)
+	}
+	archiveName := "codex-package-" + target + ".tar.gz"
+	requestedPaths := []string{}
+	installerServer := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		requestedPaths = append(requestedPaths, request.URL.Path)
+		switch request.URL.Path {
+		case "/" + archiveName:
+			http.ServeFile(writer, request, archivePath)
+		case "/codex-package_SHA256SUMS":
+			_, _ = writer.Write([]byte(archiveSHA256 + "  " + archiveName + "\n"))
+		default:
+			http.NotFound(writer, request)
+		}
+	}))
+	defer installerServer.Close()
+
+	service := probeTestService(home)
+	service.HTTPClient = installerServer.Client()
+	result, err := service.runCodexCLILatestInstaller(context.Background(), InstallerSpec{
+		Kind: InstallerKindCodexCLILatest,
+		CodexCLI: &CodexCLILatestInstallerSpec{
+			BaseURL: installerServer.URL,
+		},
+	}, installDir)
+	if err != nil {
+		t.Fatalf("runCodexCLILatestInstaller() error = %v", err)
+	}
+	if result.ExitCode != 0 {
+		t.Fatalf("ExitCode = %d, want 0; stderr=%q", result.ExitCode, result.Stderr)
+	}
+	if result.Stdout == "" {
+		t.Fatal("Stdout is empty, want install summary")
+	}
+	for _, path := range requestedPaths {
+		if strings.Contains(path, "api.github.com") || strings.Contains(path, "/api/") {
+			t.Fatalf("requested path %q, want latest/download asset paths only", path)
+		}
+	}
+	if !slices.Equal(requestedPaths, []string{"/" + archiveName, "/codex-package_SHA256SUMS"}) {
+		t.Fatalf("requestedPaths = %#v, want archive then checksum", requestedPaths)
+	}
+	if _, err := os.Stat(filepath.Join(home, ".codex", "packages", "standalone", "current", "bin", "codex")); err != nil {
+		t.Fatalf("current codex missing: %v", err)
+	}
+	visiblePath := filepath.Join(installDir, "codex")
+	if !service.executableFile(visiblePath) {
+		t.Fatalf("visible codex path %s is not executable", visiblePath)
+	}
+	output, err := exec.Command(visiblePath, "--version").CombinedOutput()
+	if err != nil {
+		t.Fatalf("run installed codex: %v; output=%s", err, output)
+	}
+	if strings.TrimSpace(string(output)) != "codex 1.2.3" {
+		t.Fatalf("codex --version = %q, want codex 1.2.3", strings.TrimSpace(string(output)))
 	}
 }
 
@@ -1821,6 +1886,63 @@ func releaseBinaryArchive(t *testing.T, binaryName string, contents string) (str
 	data, err := os.ReadFile(archivePath)
 	if err != nil {
 		t.Fatalf("read archive: %v", err)
+	}
+	sum := sha256.Sum256(data)
+	return archivePath, hex.EncodeToString(sum[:])
+}
+
+func codexCLIPackageArchive(t *testing.T) (string, string) {
+	t.Helper()
+	archivePath := filepath.Join(t.TempDir(), "codex-package.tar.gz")
+	file, err := os.Create(archivePath)
+	if err != nil {
+		t.Fatalf("create codex package archive: %v", err)
+	}
+	gzipWriter := gzip.NewWriter(file)
+	tarWriter := tar.NewWriter(gzipWriter)
+	files := map[string]struct {
+		mode     int64
+		contents string
+	}{
+		"codex-package.json": {
+			mode:     0o644,
+			contents: `{"name":"codex-package","version":"1.2.3"}`,
+		},
+		"bin/codex": {
+			mode:     0o755,
+			contents: "#!/bin/sh\necho 'codex 1.2.3'\n",
+		},
+		"codex-path/rg": {
+			mode:     0o755,
+			contents: "#!/bin/sh\necho rg\n",
+		},
+	}
+	for name, file := range files {
+		contentBytes := []byte(file.contents)
+		header := &tar.Header{
+			Name: name,
+			Mode: file.mode,
+			Size: int64(len(contentBytes)),
+		}
+		if err := tarWriter.WriteHeader(header); err != nil {
+			t.Fatalf("write codex package header: %v", err)
+		}
+		if _, err := tarWriter.Write(contentBytes); err != nil {
+			t.Fatalf("write codex package contents: %v", err)
+		}
+	}
+	if err := tarWriter.Close(); err != nil {
+		t.Fatalf("close codex package tar writer: %v", err)
+	}
+	if err := gzipWriter.Close(); err != nil {
+		t.Fatalf("close codex package gzip writer: %v", err)
+	}
+	if err := file.Close(); err != nil {
+		t.Fatalf("close codex package archive file: %v", err)
+	}
+	data, err := os.ReadFile(archivePath)
+	if err != nil {
+		t.Fatalf("read codex package archive: %v", err)
 	}
 	sum := sha256.Sum256(data)
 	return archivePath, hex.EncodeToString(sum[:])


### PR DESCRIPTION
## Summary
- add detailed agent provider install logging for command, cwd, env, stdout, and stderr
- replace Codex CLI official install script with a latest release asset installer that avoids GitHub API latest rate limits
- verify downloaded Codex CLI packages with SHA256SUMS and install the visible codex shim into the selected install dir

## Verification
- go test ./services/tuttid/service/agentstatus