### PR TITLE
feat(tuttid): improve external agent session import titles and skip empty projects

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -2,3 +2,32 @@ Tutti
 Copyright 2026 Nexight
 
 This product includes software developed at Nexight (https://tutti.sh).
+
+----------------------------------------------------------------------
+
+This product contains code adapted from cc-switch
+(https://github.com/farion1231/cc-switch), used under the MIT License.
+The adapted code is the external agent session title extraction logic in
+services/tuttid/service/agent/external_import_parse.go.
+
+  MIT License
+
+  Copyright (c) 2025 Jason Young
+
+  Permission is hereby granted, free of charge, to any person obtaining a copy
+  of this software and associated documentation files (the "Software"), to deal
+  in the Software without restriction, including without limitation the rights
+  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  copies of the Software, and to permit persons to whom the Software is
+  furnished to do so, subject to the following conditions:
+
+  The above copyright notice and this permission notice shall be included in all
+  copies or substantial portions of the Software.
+
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+  SOFTWARE.

--- a/services/tuttid/api/daemon_agent_sessions.go
+++ b/services/tuttid/api/daemon_agent_sessions.go
@@ -20,6 +20,7 @@ type AgentSessionService interface {
 	ListMessages(context.Context, string, string, agentservice.ListMessagesInput) (agentservice.SessionMessagesPage, error)
 	ScanExternalImports(context.Context, agentservice.ExternalImportScanInput) (agentservice.ExternalImportScanResult, error)
 	ImportExternalSessions(context.Context, string, agentservice.ExternalImportInput) (agentservice.ExternalImportResult, error)
+	ExternalImportValidProjectPaths(context.Context, agentservice.ExternalImportInput) ([]string, error)
 	Create(context.Context, string, agentservice.CreateSessionInput) (agentservice.Session, error)
 	Get(context.Context, string, string) (agentservice.Session, error)
 	ReadAttachment(context.Context, string, string, string) (agentservice.PromptAttachment, error)

--- a/services/tuttid/api/daemon_agent_sessions_external_import.go
+++ b/services/tuttid/api/daemon_agent_sessions_external_import.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"context"
+	"path/filepath"
 	"strings"
 
 	tuttigenerated "github.com/tutti-os/tutti/services/tuttid/api/generated"
@@ -43,30 +44,94 @@ func (api DaemonAPI) ImportWorkspaceExternalAgentSessions(ctx context.Context, r
 	projects := externalImportProjectSelectionsFromGenerated(request.Body.Projects)
 	register := request.Body.RegisterUserProjects == nil || *request.Body.RegisterUserProjects
 	importSessions := request.Body.ImportSessions == nil || *request.Body.ImportSessions
-	projects, registrationErrors := api.registerExternalImportUserProjects(ctx, projects, register)
-	if len(projects) == 0 {
-		return tuttigenerated.ImportWorkspaceExternalAgentSessions200JSONResponse(
-			generatedExternalImportResult(agentservice.ExternalImportResult{Errors: registrationErrors}),
-		), nil
+
+	// Import sessions first, then register only the projects that actually
+	// matched at least one valid session so empty projects never get surfaced.
+	var result agentservice.ExternalImportResult
+	var validPaths map[string]struct{}
+	if importSessions {
+		var err error
+		result, err = api.AgentSessionService.ImportExternalSessions(ctx, string(request.WorkspaceID), agentservice.ExternalImportInput{
+			Projects: projects,
+		})
+		if err != nil {
+			return writeImportWorkspaceExternalAgentSessionsError(err), nil
+		}
+		validPaths = stringSet(result.ProjectPaths)
+	} else {
+		scan, err := api.AgentSessionService.ScanExternalImports(ctx, agentservice.ExternalImportScanInput{})
+		if err != nil {
+			return writeImportWorkspaceExternalAgentSessionsError(err), nil
+		}
+		validPaths = externalImportSelectionPathsWithSessions(projects, scan)
 	}
-	if !importSessions {
-		return tuttigenerated.ImportWorkspaceExternalAgentSessions200JSONResponse(
-			generatedExternalImportResult(agentservice.ExternalImportResult{
-				ImportedProjects: len(projects),
-				Errors:           registrationErrors,
-			}),
-		), nil
-	}
-	result, err := api.AgentSessionService.ImportExternalSessions(ctx, string(request.WorkspaceID), agentservice.ExternalImportInput{
-		Projects: projects,
-	})
-	if err != nil {
-		return writeImportWorkspaceExternalAgentSessionsError(err), nil
-	}
+
+	validSelections := filterExternalImportSelectionsByPaths(projects, validPaths)
+	registeredSelections, registrationErrors := api.registerExternalImportUserProjects(ctx, validSelections, register)
+	result.ImportedProjects = len(registeredSelections)
 	result.Errors = append(registrationErrors, result.Errors...)
 	return tuttigenerated.ImportWorkspaceExternalAgentSessions200JSONResponse(
 		generatedExternalImportResult(result),
 	), nil
+}
+
+func stringSet(values []string) map[string]struct{} {
+	set := make(map[string]struct{}, len(values))
+	for _, value := range values {
+		if trimmed := strings.TrimSpace(value); trimmed != "" {
+			set[trimmed] = struct{}{}
+		}
+	}
+	return set
+}
+
+func filterExternalImportSelectionsByPaths(
+	selections []agentservice.ExternalImportProjectSelection,
+	validPaths map[string]struct{},
+) []agentservice.ExternalImportProjectSelection {
+	filtered := make([]agentservice.ExternalImportProjectSelection, 0, len(selections))
+	for _, selection := range selections {
+		if _, ok := validPaths[strings.TrimSpace(selection.Path)]; ok {
+			filtered = append(filtered, selection)
+		}
+	}
+	return filtered
+}
+
+// externalImportSelectionPathsWithSessions returns the set of selected project
+// paths that contain at least one scanned session, used by the register-only
+// path to avoid surfacing empty projects.
+func externalImportSelectionPathsWithSessions(
+	selections []agentservice.ExternalImportProjectSelection,
+	scan agentservice.ExternalImportScanResult,
+) map[string]struct{} {
+	valid := make(map[string]struct{})
+	for _, selection := range selections {
+		selectionPath := strings.TrimSpace(selection.Path)
+		if selectionPath == "" {
+			continue
+		}
+		for _, project := range scan.Projects {
+			if externalImportPathContains(selectionPath, project.Path) {
+				valid[selectionPath] = struct{}{}
+				break
+			}
+		}
+	}
+	return valid
+}
+
+func externalImportPathContains(parent string, child string) bool {
+	parent = filepath.Clean(parent)
+	child = filepath.Clean(child)
+	if parent == child {
+		return true
+	}
+	rel, err := filepath.Rel(parent, child)
+	if err != nil {
+		return false
+	}
+	return rel != "." && rel != ".." && !strings.HasPrefix(rel, ".."+string(filepath.Separator))
 }
 
 func externalImportProvidersFromGenerated(input *[]tuttigenerated.WorkspaceAgentProvider) []string {

--- a/services/tuttid/api/daemon_agent_sessions_external_import.go
+++ b/services/tuttid/api/daemon_agent_sessions_external_import.go
@@ -2,7 +2,6 @@ package api
 
 import (
 	"context"
-	"path/filepath"
 	"strings"
 
 	tuttigenerated "github.com/tutti-os/tutti/services/tuttid/api/generated"
@@ -47,8 +46,10 @@ func (api DaemonAPI) ImportWorkspaceExternalAgentSessions(ctx context.Context, r
 
 	// Import sessions first, then register only the projects that actually
 	// matched at least one valid session so empty projects never get surfaced.
+	// validPaths are canonical project paths (see the agent service), so register
+	// them directly instead of mapping back to the raw request selections.
 	var result agentservice.ExternalImportResult
-	var validPaths map[string]struct{}
+	var validPaths []string
 	if importSessions {
 		var err error
 		result, err = api.AgentSessionService.ImportExternalSessions(ctx, string(request.WorkspaceID), agentservice.ExternalImportInput{
@@ -57,17 +58,18 @@ func (api DaemonAPI) ImportWorkspaceExternalAgentSessions(ctx context.Context, r
 		if err != nil {
 			return writeImportWorkspaceExternalAgentSessionsError(err), nil
 		}
-		validPaths = stringSet(result.ProjectPaths)
+		validPaths = result.ProjectPaths
 	} else {
-		scan, err := api.AgentSessionService.ScanExternalImports(ctx, agentservice.ExternalImportScanInput{})
+		var err error
+		validPaths, err = api.AgentSessionService.ExternalImportValidProjectPaths(ctx, agentservice.ExternalImportInput{
+			Projects: projects,
+		})
 		if err != nil {
 			return writeImportWorkspaceExternalAgentSessionsError(err), nil
 		}
-		validPaths = externalImportSelectionPathsWithSessions(projects, scan)
 	}
 
-	validSelections := filterExternalImportSelectionsByPaths(projects, validPaths)
-	registeredSelections, registrationErrors := api.registerExternalImportUserProjects(ctx, validSelections, register)
+	registeredSelections, registrationErrors := api.registerExternalImportUserProjects(ctx, externalImportSelectionsFromPaths(validPaths), register)
 	result.ImportedProjects = len(registeredSelections)
 	result.Errors = append(registrationErrors, result.Errors...)
 	return tuttigenerated.ImportWorkspaceExternalAgentSessions200JSONResponse(
@@ -75,63 +77,14 @@ func (api DaemonAPI) ImportWorkspaceExternalAgentSessions(ctx context.Context, r
 	), nil
 }
 
-func stringSet(values []string) map[string]struct{} {
-	set := make(map[string]struct{}, len(values))
-	for _, value := range values {
-		if trimmed := strings.TrimSpace(value); trimmed != "" {
-			set[trimmed] = struct{}{}
+func externalImportSelectionsFromPaths(paths []string) []agentservice.ExternalImportProjectSelection {
+	selections := make([]agentservice.ExternalImportProjectSelection, 0, len(paths))
+	for _, path := range paths {
+		if trimmed := strings.TrimSpace(path); trimmed != "" {
+			selections = append(selections, agentservice.ExternalImportProjectSelection{Path: trimmed})
 		}
 	}
-	return set
-}
-
-func filterExternalImportSelectionsByPaths(
-	selections []agentservice.ExternalImportProjectSelection,
-	validPaths map[string]struct{},
-) []agentservice.ExternalImportProjectSelection {
-	filtered := make([]agentservice.ExternalImportProjectSelection, 0, len(selections))
-	for _, selection := range selections {
-		if _, ok := validPaths[strings.TrimSpace(selection.Path)]; ok {
-			filtered = append(filtered, selection)
-		}
-	}
-	return filtered
-}
-
-// externalImportSelectionPathsWithSessions returns the set of selected project
-// paths that contain at least one scanned session, used by the register-only
-// path to avoid surfacing empty projects.
-func externalImportSelectionPathsWithSessions(
-	selections []agentservice.ExternalImportProjectSelection,
-	scan agentservice.ExternalImportScanResult,
-) map[string]struct{} {
-	valid := make(map[string]struct{})
-	for _, selection := range selections {
-		selectionPath := strings.TrimSpace(selection.Path)
-		if selectionPath == "" {
-			continue
-		}
-		for _, project := range scan.Projects {
-			if externalImportPathContains(selectionPath, project.Path) {
-				valid[selectionPath] = struct{}{}
-				break
-			}
-		}
-	}
-	return valid
-}
-
-func externalImportPathContains(parent string, child string) bool {
-	parent = filepath.Clean(parent)
-	child = filepath.Clean(child)
-	if parent == child {
-		return true
-	}
-	rel, err := filepath.Rel(parent, child)
-	if err != nil {
-		return false
-	}
-	return rel != "." && rel != ".." && !strings.HasPrefix(rel, ".."+string(filepath.Separator))
+	return selections
 }
 
 func externalImportProvidersFromGenerated(input *[]tuttigenerated.WorkspaceAgentProvider) []string {

--- a/services/tuttid/api/daemon_test.go
+++ b/services/tuttid/api/daemon_test.go
@@ -69,6 +69,7 @@ type stubAgentSessionService struct {
 	createFn                 func(context.Context, string, agentservice.CreateSessionInput) (agentservice.Session, error)
 	deleteFn                 func(context.Context, string, string) (bool, error)
 	importExternalFn         func(context.Context, string, agentservice.ExternalImportInput) (agentservice.ExternalImportResult, error)
+	validImportPathsFn       func(context.Context, agentservice.ExternalImportInput) ([]string, error)
 	listFn                   func(context.Context, string, agentservice.ListSessionsInput) ([]agentservice.Session, error)
 	listGeneratedFilesFn     func(context.Context, string, agentservice.ListGeneratedFilesInput) (agentservice.GeneratedFileList, error)
 	listMessagesFn           func(context.Context, string, string, agentservice.ListMessagesInput) (agentservice.SessionMessagesPage, error)
@@ -217,6 +218,13 @@ func (s stubAgentSessionService) ImportExternalSessions(ctx context.Context, wor
 		return agentservice.ExternalImportResult{}, nil
 	}
 	return s.importExternalFn(ctx, workspaceID, input)
+}
+
+func (s stubAgentSessionService) ExternalImportValidProjectPaths(ctx context.Context, input agentservice.ExternalImportInput) ([]string, error) {
+	if s.validImportPathsFn == nil {
+		return nil, nil
+	}
+	return s.validImportPathsFn(ctx, input)
 }
 
 func (s stubAgentSessionService) Create(ctx context.Context, workspaceID string, input agentservice.CreateSessionInput) (agentservice.Session, error) {

--- a/services/tuttid/service/agent/external_import.go
+++ b/services/tuttid/service/agent/external_import.go
@@ -82,6 +82,10 @@ type ExternalImportResult struct {
 	ImportedMessages int
 	SkippedSessions  int
 	Errors           []ExternalImportError
+	// ProjectPaths lists the selected project paths that matched at least one
+	// valid imported session. Callers use it to avoid registering user projects
+	// that would surface with no sessions underneath them.
+	ProjectPaths []string
 }
 
 type externalImportedSession struct {
@@ -90,9 +94,14 @@ type externalImportedSession struct {
 	SourcePath        string
 	Cwd               string
 	Title             string
-	StartedAtUnixMS   int64
-	UpdatedAtUnixMS   int64
-	Messages          []externalImportedMessage
+	// SummaryTitle holds an authoritative, provider-supplied conversation title
+	// (e.g. Claude `custom-title`/`summary` transcript lines or the Codex
+	// app-server `threads.title`). When present it wins over message-derived
+	// titles.
+	SummaryTitle    string
+	StartedAtUnixMS int64
+	UpdatedAtUnixMS int64
+	Messages        []externalImportedMessage
 }
 
 type externalImportedMessage struct {
@@ -136,6 +145,7 @@ func (s *Service) ImportExternalSessions(ctx context.Context, workspaceID string
 		Errors:          append([]ExternalImportError(nil), data.result.Errors...),
 	}
 	importedProjectPaths := map[string]struct{}{}
+	validProjectPaths := map[string]struct{}{}
 	for _, session := range data.sessions {
 		if ctx.Err() != nil {
 			return result, ctx.Err()
@@ -144,6 +154,7 @@ func (s *Service) ImportExternalSessions(ctx context.Context, workspaceID string
 		if !selected {
 			continue
 		}
+		validProjectPaths[projectPath] = struct{}{}
 		importedMessages, imported, err := s.importExternalSession(ctx, workspaceID, session)
 		if err != nil {
 			result.Errors = append(result.Errors, ExternalImportError{
@@ -162,7 +173,17 @@ func (s *Service) ImportExternalSessions(ctx context.Context, workspaceID string
 		}
 	}
 	result.ImportedProjects = len(importedProjectPaths)
+	result.ProjectPaths = sortedStringSet(validProjectPaths)
 	return result, nil
+}
+
+func sortedStringSet(values map[string]struct{}) []string {
+	out := make([]string, 0, len(values))
+	for value := range values {
+		out = append(out, value)
+	}
+	sort.Strings(out)
+	return out
 }
 
 func normalizeExternalImportProviders(input []string) []string {
@@ -341,6 +362,13 @@ func scanExternalProviderSessions(provider string, cutoffUnixMS int64) ([]extern
 		summary.Error = err.Error()
 		return nil, summary, []ExternalImportError{{Provider: provider, Message: err.Error()}}
 	}
+	// Codex stores the generated conversation title in its app-server SQLite
+	// state DB rather than in the rollout transcript, so resolve it up front and
+	// let it override the message-derived title.
+	var codexTitles map[string]string
+	if provider == agentproviderbiz.Codex {
+		codexTitles = codexThreadTitles(root)
+	}
 	sessions := make([]externalImportedSession, 0, len(files))
 	errors := make([]ExternalImportError, 0)
 	for _, file := range files {
@@ -354,6 +382,9 @@ func scanExternalProviderSessions(provider string, cutoffUnixMS int64) ([]extern
 		}
 		if session.UpdatedAtUnixMS < cutoffUnixMS {
 			continue
+		}
+		if title := strings.TrimSpace(codexTitles[session.ProviderSessionID]); title != "" {
+			session.Title = truncateExternalTitle(title)
 		}
 		sessions = append(sessions, session)
 		summary.SessionCount++

--- a/services/tuttid/service/agent/external_import.go
+++ b/services/tuttid/service/agent/external_import.go
@@ -177,15 +177,6 @@ func (s *Service) ImportExternalSessions(ctx context.Context, workspaceID string
 	return result, nil
 }
 
-func sortedStringSet(values map[string]struct{}) []string {
-	out := make([]string, 0, len(values))
-	for value := range values {
-		out = append(out, value)
-	}
-	sort.Strings(out)
-	return out
-}
-
 func normalizeExternalImportProviders(input []string) []string {
 	if len(input) == 0 {
 		return []string{agentproviderbiz.Codex, agentproviderbiz.ClaudeCode}
@@ -683,10 +674,12 @@ func externalSessionTitle(messages []externalImportedMessage) string {
 
 func truncateExternalTitle(input string) string {
 	input = strings.Join(strings.Fields(input), " ")
-	if len(input) <= 80 {
+	const maxTitleRunes = 80
+	runes := []rune(input)
+	if len(runes) <= maxTitleRunes {
 		return input
 	}
-	return strings.TrimSpace(input[:80])
+	return strings.TrimSpace(string(runes[:maxTitleRunes]))
 }
 
 func firstExternalMessageUnixMS(messages []externalImportedMessage) int64 {

--- a/services/tuttid/service/agent/external_import_codex_titles.go
+++ b/services/tuttid/service/agent/external_import_codex_titles.go
@@ -1,0 +1,88 @@
+package agent
+
+import (
+	"context"
+	"database/sql"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"time"
+
+	_ "modernc.org/sqlite"
+)
+
+// codexThreadTitles reads the Codex app-server state database and returns a map
+// of thread id (the rollout session id) to its generated conversation title.
+//
+// Codex keeps the human-readable title in `state_<n>.sqlite` (table `threads`,
+// column `title`) rather than in the rollout transcript, so importing the title
+// requires reading that DB. The schema is versioned and undocumented, so every
+// failure path degrades gracefully to an empty map and the caller falls back to
+// the message-derived title.
+func codexThreadTitles(codexHome string) map[string]string {
+	titles := map[string]string{}
+	codexHome = strings.TrimSpace(codexHome)
+	if codexHome == "" {
+		return titles
+	}
+	dbPath := codexStateDBPath(codexHome)
+	if dbPath == "" {
+		return titles
+	}
+
+	// Open read-only with a short busy timeout so a live Codex process holding
+	// the write lock never blocks the import scan.
+	db, err := sql.Open("sqlite", "file:"+dbPath+"?mode=ro&_pragma=busy_timeout(2000)")
+	if err != nil {
+		return titles
+	}
+	defer db.Close()
+	db.SetMaxOpenConns(1)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+
+	rows, err := db.QueryContext(ctx, "SELECT id, title FROM threads WHERE title IS NOT NULL AND title != ''")
+	if err != nil {
+		return titles
+	}
+	defer rows.Close()
+	for rows.Next() {
+		var id, title string
+		if err := rows.Scan(&id, &title); err != nil {
+			continue
+		}
+		id = strings.TrimSpace(id)
+		title = strings.TrimSpace(title)
+		if id != "" && title != "" {
+			titles[id] = title
+		}
+	}
+	return titles
+}
+
+// codexStateDBPath returns the highest-versioned state_<n>.sqlite under codexHome.
+func codexStateDBPath(codexHome string) string {
+	matches, err := filepath.Glob(filepath.Join(codexHome, "state_*.sqlite"))
+	if err != nil {
+		return ""
+	}
+	best := ""
+	bestVersion := -1
+	for _, match := range matches {
+		if info, err := os.Stat(match); err != nil || info.IsDir() {
+			continue
+		}
+		name := strings.TrimSuffix(strings.TrimPrefix(filepath.Base(match), "state_"), ".sqlite")
+		version, err := strconv.Atoi(name)
+		if err != nil {
+			continue
+		}
+		if version > bestVersion {
+			bestVersion = version
+			best = match
+		}
+	}
+	return best
+}

--- a/services/tuttid/service/agent/external_import_codex_titles.go
+++ b/services/tuttid/service/agent/external_import_codex_titles.go
@@ -3,6 +3,7 @@ package agent
 import (
 	"context"
 	"database/sql"
+	"net/url"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -32,8 +33,11 @@ func codexThreadTitles(codexHome string) map[string]string {
 	}
 
 	// Open read-only with a short busy timeout so a live Codex process holding
-	// the write lock never blocks the import scan.
-	db, err := sql.Open("sqlite", "file:"+dbPath+"?mode=ro&_pragma=busy_timeout(2000)")
+	// the write lock never blocks the import scan. Build the file: URI via
+	// url.URL so paths containing spaces or other reserved characters are
+	// percent-encoded rather than corrupting the DSN.
+	dsn := (&url.URL{Scheme: "file", Path: dbPath, RawQuery: "mode=ro&_pragma=busy_timeout(2000)"}).String()
+	db, err := sql.Open("sqlite", dsn)
 	if err != nil {
 		return titles
 	}

--- a/services/tuttid/service/agent/external_import_codex_titles_test.go
+++ b/services/tuttid/service/agent/external_import_codex_titles_test.go
@@ -1,0 +1,91 @@
+package agent
+
+import (
+	"context"
+	"database/sql"
+	"os"
+	"path/filepath"
+	"slices"
+	"testing"
+
+	_ "modernc.org/sqlite"
+)
+
+func TestScanExternalImportsAppliesCodexSQLiteTitle(t *testing.T) {
+	root := t.TempDir()
+	codexHome := filepath.Join(root, "codex-home")
+	project := filepath.Join(root, "project-x")
+	if err := os.MkdirAll(project, 0o755); err != nil {
+		t.Fatalf("create project error = %v", err)
+	}
+	t.Setenv("CODEX_HOME", codexHome)
+	t.Setenv("CLAUDE_CONFIG_DIR", filepath.Join(root, "claude-home"))
+
+	writeAgentServiceJSONL(t, filepath.Join(codexHome, "sessions", "codex-x.jsonl"),
+		map[string]any{
+			"timestamp": "2026-06-18T00:00:00Z",
+			"type":      "session_meta",
+			"payload":   map[string]any{"id": "codex-x", "cwd": project},
+		},
+		map[string]any{"timestamp": "2026-06-18T00:00:01Z", "type": "response_item", "payload": map[string]any{
+			"type": "message", "id": "codex-x-1", "role": "user",
+			"content": []any{map[string]any{"type": "input_text", "text": "First raw prompt"}},
+		}},
+	)
+	writeCodexThreadsDB(t, filepath.Join(codexHome, "state_5.sqlite"), map[string]string{
+		"codex-x": "Generated summary title",
+	})
+
+	service := NewService(newFakeRuntime())
+	scan, err := service.ScanExternalImports(context.Background(), ExternalImportScanInput{Providers: []string{"codex"}})
+	if err != nil {
+		t.Fatalf("ScanExternalImports error = %v", err)
+	}
+	if !slices.ContainsFunc(scan.Sessions, func(session ExternalImportSession) bool {
+		return session.Provider == "codex" && session.Title == "Generated summary title"
+	}) {
+		t.Fatalf("scan sessions = %#v, want SQLite-derived title", scan.Sessions)
+	}
+}
+
+func TestCodexThreadTitlesReadsStateDB(t *testing.T) {
+	codexHome := t.TempDir()
+	writeCodexThreadsDB(t, filepath.Join(codexHome, "state_5.sqlite"), map[string]string{
+		"thread-a": "Summarize user persona prompts",
+		"thread-b": "",
+	})
+
+	titles := codexThreadTitles(codexHome)
+	if titles["thread-a"] != "Summarize user persona prompts" {
+		t.Fatalf("title = %q, want stored thread title", titles["thread-a"])
+	}
+	if _, ok := titles["thread-b"]; ok {
+		t.Fatalf("empty title should be skipped, got %#v", titles)
+	}
+}
+
+func TestCodexThreadTitlesMissingDB(t *testing.T) {
+	if titles := codexThreadTitles(t.TempDir()); len(titles) != 0 {
+		t.Fatalf("titles = %#v, want empty for missing DB", titles)
+	}
+	if titles := codexThreadTitles(""); len(titles) != 0 {
+		t.Fatalf("titles = %#v, want empty for empty home", titles)
+	}
+}
+
+func writeCodexThreadsDB(t *testing.T, path string, rows map[string]string) {
+	t.Helper()
+	db, err := sql.Open("sqlite", path)
+	if err != nil {
+		t.Fatalf("open sqlite error = %v", err)
+	}
+	defer db.Close()
+	if _, err := db.Exec("CREATE TABLE threads (id TEXT PRIMARY KEY, title TEXT NOT NULL)"); err != nil {
+		t.Fatalf("create table error = %v", err)
+	}
+	for id, title := range rows {
+		if _, err := db.Exec("INSERT INTO threads (id, title) VALUES (?, ?)", id, title); err != nil {
+			t.Fatalf("insert error = %v", err)
+		}
+	}
+}

--- a/services/tuttid/service/agent/external_import_codex_titles_test.go
+++ b/services/tuttid/service/agent/external_import_codex_titles_test.go
@@ -64,6 +64,20 @@ func TestCodexThreadTitlesReadsStateDB(t *testing.T) {
 	}
 }
 
+func TestCodexThreadTitlesReadsFromPathWithSpaces(t *testing.T) {
+	codexHome := filepath.Join(t.TempDir(), "code x home")
+	if err := os.MkdirAll(codexHome, 0o755); err != nil {
+		t.Fatalf("create codex home error = %v", err)
+	}
+	writeCodexThreadsDB(t, filepath.Join(codexHome, "state_5.sqlite"), map[string]string{
+		"thread-a": "Title in spaced dir",
+	})
+	titles := codexThreadTitles(codexHome)
+	if titles["thread-a"] != "Title in spaced dir" {
+		t.Fatalf("title = %q, want title read from a path containing spaces", titles["thread-a"])
+	}
+}
+
 func TestCodexThreadTitlesMissingDB(t *testing.T) {
 	if titles := codexThreadTitles(t.TempDir()); len(titles) != 0 {
 		t.Fatalf("titles = %#v, want empty for missing DB", titles)

--- a/services/tuttid/service/agent/external_import_parse.go
+++ b/services/tuttid/service/agent/external_import_parse.go
@@ -158,6 +158,19 @@ func parseClaudeCodeJSONL(path string, reader io.Reader) (externalImportedSessio
 	err := readJSONLLines(reader, func(index int, raw map[string]any) {
 		session.ProviderSessionID = firstNonEmptyString(session.ProviderSessionID, stringField(raw, "sessionId"), stringField(raw, "session_id"))
 		session.Cwd = firstNonEmptyString(session.Cwd, stringField(raw, "cwd"))
+		// Claude Code records the human/auto-generated conversation title inline.
+		// `custom-title` is the canonical rename; the older `summary` line is a
+		// fallback. The last occurrence wins.
+		switch stringField(raw, "type") {
+		case "custom-title":
+			if title := strings.TrimSpace(stringField(raw, "customTitle")); title != "" {
+				session.SummaryTitle = title
+			}
+		case "summary":
+			if title := strings.TrimSpace(stringField(raw, "summary")); title != "" {
+				session.SummaryTitle = title
+			}
+		}
 		messageMap := mapField(raw, "message")
 		if len(messageMap) == 0 {
 			return
@@ -225,7 +238,7 @@ func normalizeExternalParsedSession(session externalImportedSession) (externalIm
 	session.Messages = messages
 	session.StartedAtUnixMS = firstExternalMessageUnixMS(messages)
 	session.UpdatedAtUnixMS = lastExternalMessageUnixMS(messages)
-	session.Title = externalParsedSessionTitle(session.Title, messages)
+	session.Title = resolveExternalSessionTitle(session.Provider, session.SummaryTitle, session.Title, messages)
 	return session, true, nil
 }
 
@@ -236,16 +249,106 @@ func externalImportedMessageHasContent(message externalImportedMessage) bool {
 	return strings.TrimSpace(message.Kind) == "tool_call" && len(message.Payload) > 0
 }
 
-func externalParsedSessionTitle(hint string, messages []externalImportedMessage) string {
-	if hint = strings.TrimSpace(hint); hint != "" {
-		return truncateExternalTitle(hint)
+// resolveExternalSessionTitle picks the best conversation title using the
+// priority: provider-supplied summary title -> first real user message (with
+// system preambles skipped) -> raw first message text.
+func resolveExternalSessionTitle(provider string, summaryTitle string, hint string, messages []externalImportedMessage) string {
+	if title := strings.TrimSpace(summaryTitle); title != "" {
+		return truncateExternalTitle(title)
+	}
+	if title, ok := externalImportTitleCandidate(provider, hint); ok {
+		return truncateExternalTitle(title)
 	}
 	for _, message := range messages {
-		if message.Role == "user" && !strings.HasPrefix(message.Text, "<environment_context>") {
-			return truncateExternalTitle(message.Text)
+		if message.Role != "user" {
+			continue
+		}
+		if title, ok := externalImportTitleCandidate(provider, message.Text); ok {
+			return truncateExternalTitle(title)
 		}
 	}
 	return externalSessionTitle(messages)
+}
+
+// VS Code injects IDE context ahead of the real Codex prompt; the actual
+// request lives under the final "## My request for Codex:" heading.
+const (
+	codexIDEContextPrefix = "# Context from my IDE setup:"
+	codexRequestMarker    = "my request for codex"
+)
+
+// externalImportTitleCandidate cleans a user message for use as a session title,
+// returning false when the text is a system-injected preamble that should not be
+// surfaced. The Codex/Claude preamble rules are ported from cc-switch (MIT, see
+// NOTICE).
+func externalImportTitleCandidate(provider string, text string) (string, bool) {
+	trimmed := strings.TrimSpace(text)
+	if trimmed == "" {
+		return "", false
+	}
+	switch provider {
+	case agentproviderbiz.ClaudeCode:
+		if strings.Contains(trimmed, "<local-command-caveat>") || strings.HasPrefix(trimmed, "<command-name>") {
+			return "", false
+		}
+		return trimmed, true
+	default:
+		if strings.HasPrefix(trimmed, "# AGENTS.md") || strings.HasPrefix(trimmed, "<environment_context>") {
+			return "", false
+		}
+		if strings.HasPrefix(trimmed, codexIDEContextPrefix) {
+			return extractCodexPromptFromIDEContext(trimmed)
+		}
+		return trimmed, true
+	}
+}
+
+func extractCodexPromptFromIDEContext(text string) (string, bool) {
+	normalized := strings.ReplaceAll(text, "\r\n", "\n")
+	lines := strings.Split(normalized, "\n")
+	prompt := ""
+	found := false
+	for index, line := range lines {
+		inline, ok := codexRequestHeadingPayload(line)
+		if !ok {
+			continue
+		}
+		if inline != "" {
+			prompt = inline
+			found = true
+			continue
+		}
+		following := strings.TrimSpace(strings.Join(lines[index+1:], "\n"))
+		prompt = following
+		found = following != ""
+	}
+	if !found || strings.TrimSpace(prompt) == "" {
+		return "", false
+	}
+	return strings.TrimSpace(prompt), true
+}
+
+func codexRequestHeadingPayload(line string) (string, bool) {
+	trimmed := strings.TrimSpace(line)
+	if !strings.HasPrefix(trimmed, "#") {
+		return "", false
+	}
+	heading := strings.TrimLeft(trimmed, "#")
+	heading = strings.TrimLeft(heading, " \t")
+	if !strings.HasPrefix(strings.ToLower(heading), codexRequestMarker) {
+		return "", false
+	}
+	suffix := strings.TrimLeft(heading[len(codexRequestMarker):], " \t")
+	if suffix == "" {
+		return "", true
+	}
+	separator := []rune(suffix)[0]
+	switch separator {
+	case ':', '：', '-', '—':
+	default:
+		return "", false
+	}
+	return strings.TrimSpace(strings.TrimLeft(suffix, ":：-— \t")), true
 }
 
 func readJSONLLines(reader io.Reader, handle func(int, map[string]any)) error {

--- a/services/tuttid/service/agent/external_import_parse_test.go
+++ b/services/tuttid/service/agent/external_import_parse_test.go
@@ -125,6 +125,103 @@ func TestParseCodexJSONLPreservesToolCallStructure(t *testing.T) {
 	}
 }
 
+func TestParseCodexJSONLExtractsPromptFromIDEContext(t *testing.T) {
+	cwd := t.TempDir()
+	ideMessage := "# Context from my IDE setup:\n" +
+		"The user is in file foo.go\n\n" +
+		"## My request for Codex: Refactor the parser\n"
+	session, ok, err := parseCodexJSONL(
+		filepath.Join(cwd, "rollout.jsonl"),
+		strings.NewReader(testAgentJSONL(t,
+			map[string]any{
+				"timestamp": "2026-06-18T00:00:00Z",
+				"type":      "session_meta",
+				"payload":   map[string]any{"id": "codex-ide", "cwd": cwd},
+			},
+			map[string]any{
+				"timestamp": "2026-06-18T00:00:01Z",
+				"type":      "response_item",
+				"payload": map[string]any{
+					"type":    "message",
+					"role":    "user",
+					"content": []any{map[string]any{"type": "input_text", "text": ideMessage}},
+				},
+			},
+		)),
+	)
+	if err != nil || !ok {
+		t.Fatalf("parseCodexJSONL ok=%v err=%v", ok, err)
+	}
+	if session.Title != "Refactor the parser" {
+		t.Fatalf("title = %q, want IDE request payload", session.Title)
+	}
+}
+
+func TestParseCodexJSONLSkipsAgentsAndEnvironmentPreamble(t *testing.T) {
+	cwd := t.TempDir()
+	session, ok, err := parseCodexJSONL(
+		filepath.Join(cwd, "rollout.jsonl"),
+		strings.NewReader(testAgentJSONL(t,
+			map[string]any{
+				"timestamp": "2026-06-18T00:00:00Z",
+				"type":      "session_meta",
+				"payload":   map[string]any{"id": "codex-preamble", "cwd": cwd},
+			},
+			map[string]any{
+				"timestamp": "2026-06-18T00:00:01Z",
+				"type":      "response_item",
+				"payload": map[string]any{
+					"type":    "message",
+					"role":    "user",
+					"content": []any{map[string]any{"type": "input_text", "text": "# AGENTS.md\nrules"}},
+				},
+			},
+			map[string]any{
+				"timestamp": "2026-06-18T00:00:02Z",
+				"type":      "response_item",
+				"payload": map[string]any{
+					"type":    "message",
+					"role":    "user",
+					"content": []any{map[string]any{"type": "input_text", "text": "Real question here"}},
+				},
+			},
+		)),
+	)
+	if err != nil || !ok {
+		t.Fatalf("parseCodexJSONL ok=%v err=%v", ok, err)
+	}
+	if session.Title != "Real question here" {
+		t.Fatalf("title = %q, want first non-preamble user message", session.Title)
+	}
+}
+
+func TestParseClaudeCodeJSONLPrefersCustomTitle(t *testing.T) {
+	cwd := t.TempDir()
+	session, ok, err := parseClaudeCodeJSONL(
+		filepath.Join(cwd, "claude.jsonl"),
+		strings.NewReader(testAgentJSONL(t,
+			map[string]any{
+				"timestamp": "2026-06-18T00:00:00Z",
+				"sessionId": "claude-title",
+				"cwd":       cwd,
+				"uuid":      "claude-1",
+				"message":   map[string]any{"role": "user", "content": []any{map[string]any{"type": "text", "text": "Some long first prompt"}}},
+			},
+			map[string]any{
+				"type":        "custom-title",
+				"customTitle": "Summarize user persona prompts",
+				"sessionId":   "claude-title",
+			},
+		)),
+	)
+	if err != nil || !ok {
+		t.Fatalf("parseClaudeCodeJSONL ok=%v err=%v", ok, err)
+	}
+	if session.Title != "Summarize user persona prompts" {
+		t.Fatalf("title = %q, want custom-title", session.Title)
+	}
+}
+
 func testAgentJSONL(t *testing.T, items ...map[string]any) string {
 	t.Helper()
 	var builder strings.Builder

--- a/services/tuttid/service/agent/external_import_parse_test.go
+++ b/services/tuttid/service/agent/external_import_parse_test.go
@@ -5,6 +5,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"unicode/utf8"
 )
 
 func TestParseCodexJSONLUsesFirstUserEventAsTitle(t *testing.T) {
@@ -219,6 +220,19 @@ func TestParseClaudeCodeJSONLPrefersCustomTitle(t *testing.T) {
 	}
 	if session.Title != "Summarize user persona prompts" {
 		t.Fatalf("title = %q, want custom-title", session.Title)
+	}
+}
+
+func TestTruncateExternalTitleKeepsMultibyteRunesIntact(t *testing.T) {
+	// 120 CJK runes (360 bytes) — must truncate by rune, not byte, so the
+	// result stays valid UTF-8 instead of being cut mid-character.
+	long := strings.Repeat("测", 120)
+	got := truncateExternalTitle(long)
+	if !utf8.ValidString(got) {
+		t.Fatalf("truncated title = %q is not valid UTF-8", got)
+	}
+	if runes := utf8.RuneCountInString(got); runes != 80 {
+		t.Fatalf("truncated rune count = %d, want 80", runes)
 	}
 }
 

--- a/services/tuttid/service/agent/external_import_projects.go
+++ b/services/tuttid/service/agent/external_import_projects.go
@@ -1,0 +1,38 @@
+package agent
+
+import (
+	"context"
+	"sort"
+)
+
+// ExternalImportValidProjectPaths returns the canonical paths of the selected
+// projects that contain at least one valid importable session, without importing
+// anything. The register-only import path uses it to avoid surfacing empty
+// projects. Returned paths are canonical (see canonicalExistingDir), matching
+// ImportExternalSessions.ProjectPaths so callers can register them directly.
+func (*Service) ExternalImportValidProjectPaths(ctx context.Context, input ExternalImportInput) ([]string, error) {
+	selections := normalizeExternalImportSelections(input.Projects)
+	if len(selections) == 0 {
+		return nil, nil
+	}
+	data := scanExternalAgentSessions(ctx, providersFromExternalImportSelections(selections))
+	valid := map[string]struct{}{}
+	for _, session := range data.sessions {
+		if ctx.Err() != nil {
+			return nil, ctx.Err()
+		}
+		if projectPath, ok := matchingExternalImportProject(session, selections); ok {
+			valid[projectPath] = struct{}{}
+		}
+	}
+	return sortedStringSet(valid), nil
+}
+
+func sortedStringSet(values map[string]struct{}) []string {
+	out := make([]string, 0, len(values))
+	for value := range values {
+		out = append(out, value)
+	}
+	sort.Strings(out)
+	return out
+}

--- a/services/tuttid/service/agent/service_test.go
+++ b/services/tuttid/service/agent/service_test.go
@@ -61,6 +61,45 @@ func TestServiceCreatesAndListsSessions(t *testing.T) {
 	}
 }
 
+func TestServiceImportExternalSessionsOmitsProjectsWithoutValidSessions(t *testing.T) {
+	ctx := context.Background()
+	store := openAgentServiceSQLiteStore(t)
+	if err := store.Create(ctx, workspacebiz.Summary{ID: "ws-1", Name: "Workspace One"}); err != nil {
+		t.Fatalf("Create workspace error = %v", err)
+	}
+	root := t.TempDir()
+	emptyProject := filepath.Join(root, "empty-project")
+	if err := os.MkdirAll(emptyProject, 0o755); err != nil {
+		t.Fatalf("create empty project error = %v", err)
+	}
+	if canonical, ok := canonicalExistingDir(emptyProject); ok {
+		emptyProject = canonical
+	}
+	// No Codex/Claude history exists under these homes, so the selected project
+	// has no valid session.
+	t.Setenv("CODEX_HOME", filepath.Join(root, "codex-home"))
+	t.Setenv("CLAUDE_CONFIG_DIR", filepath.Join(root, "claude-home"))
+
+	service := NewService(newFakeRuntime())
+	projection := NewActivityProjection(store)
+	service.SessionReader = projection
+	service.MessageReader = projection
+	service.ExternalImportStore = store
+
+	result, err := service.ImportExternalSessions(ctx, "ws-1", ExternalImportInput{
+		Projects: []ExternalImportProjectSelection{{Path: emptyProject}},
+	})
+	if err != nil {
+		t.Fatalf("ImportExternalSessions error = %v", err)
+	}
+	if len(result.ProjectPaths) != 0 {
+		t.Fatalf("project paths = %#v, want none for project without valid sessions", result.ProjectPaths)
+	}
+	if result.ImportedSessions != 0 || result.ImportedProjects != 0 {
+		t.Fatalf("import result = %#v, want nothing imported", result)
+	}
+}
+
 func TestServiceImportsExternalAgentSessionsByProject(t *testing.T) {
 	ctx := context.Background()
 	store := openAgentServiceSQLiteStore(t)
@@ -181,6 +220,9 @@ func TestServiceImportsExternalAgentSessionsByProject(t *testing.T) {
 	}
 	if result.ImportedProjects != 1 || result.ImportedSessions != 1 || result.ImportedMessages != 4 {
 		t.Fatalf("import result = %#v, want one project, one session, four message updates", result)
+	}
+	if len(result.ProjectPaths) != 1 || result.ProjectPaths[0] != projectA {
+		t.Fatalf("project paths = %#v, want [%s]", result.ProjectPaths, projectA)
 	}
 	importedSession, err := service.Get(ctx, "ws-1", codexAID)
 	if err != nil {

--- a/services/tuttid/service/agent/service_test.go
+++ b/services/tuttid/service/agent/service_test.go
@@ -100,6 +100,46 @@ func TestServiceImportExternalSessionsOmitsProjectsWithoutValidSessions(t *testi
 	}
 }
 
+func TestServiceExternalImportValidProjectPaths(t *testing.T) {
+	ctx := context.Background()
+	root := t.TempDir()
+	project := filepath.Join(root, "project-a")
+	empty := filepath.Join(root, "empty-project")
+	for _, dir := range []string{project, empty} {
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			t.Fatalf("create dir error = %v", err)
+		}
+	}
+	if canonical, ok := canonicalExistingDir(project); ok {
+		project = canonical
+	}
+	codexHome := filepath.Join(root, "codex-home")
+	t.Setenv("CODEX_HOME", codexHome)
+	t.Setenv("CLAUDE_CONFIG_DIR", filepath.Join(root, "claude-home"))
+	writeAgentServiceJSONL(t, filepath.Join(codexHome, "sessions", "codex-a.jsonl"),
+		map[string]any{
+			"timestamp": time.Now().Add(-time.Hour).Format(time.RFC3339),
+			"type":      "session_meta",
+			"payload":   map[string]any{"id": "codex-a", "cwd": project},
+		},
+		map[string]any{"timestamp": time.Now().Add(-time.Hour).Format(time.RFC3339), "type": "response_item", "payload": map[string]any{
+			"type": "message", "id": "codex-a-1", "role": "user",
+			"content": []any{map[string]any{"type": "input_text", "text": "A prompt"}},
+		}},
+	)
+
+	service := NewService(newFakeRuntime())
+	paths, err := service.ExternalImportValidProjectPaths(ctx, ExternalImportInput{
+		Projects: []ExternalImportProjectSelection{{Path: project}, {Path: empty}},
+	})
+	if err != nil {
+		t.Fatalf("ExternalImportValidProjectPaths error = %v", err)
+	}
+	if len(paths) != 1 || paths[0] != project {
+		t.Fatalf("valid paths = %#v, want only the project with a session (%s)", paths, project)
+	}
+}
+
 func TestServiceImportsExternalAgentSessionsByProject(t *testing.T) {
 	ctx := context.Background()
 	store := openAgentServiceSQLiteStore(t)


### PR DESCRIPTION
## 背景

導入外部 agent session（`~/.codex/sessions`、`~/.claude/projects`）時：
1. 標題只取「首句用戶訊息」，拿不到 Codex app / Claude 那種總結標題；
2. 每個 cwd 都會被註冊成 user-project，連沒有有效 session 的空項目也會出現。

## 改動

### 1. 標題：總結優先 + cc-switch 兜底
取標題優先級改為 **provider 總結標題 → 清洗後首句 → `basename(cwd)`**：
- **Codex**：唯讀讀取 app-server 狀態庫 `~/.codex/state_<n>.sqlite` 的 `threads.title`（用 `provider_session_id` 對應），掃描時覆蓋訊息推導標題。schema 帶版本號且未公開，故全程容錯：DB/表/查詢任一失敗都優雅回退，不阻塞導入。
- **Claude Code**：解析 transcript 內的 `custom-title` / `summary` 行作為權威標題。
- **首句清洗（移植自 cc-switch）**：跳過 `# AGENTS.md`、`<environment_context>`、`<local-command-caveat>`、`<command-name>`，並從 VS Code IDE context 抽取 `## My request for Codex:` 正文。

### 2. 空項目不再註冊
- `ImportExternalSessions` 新增回傳 `ProjectPaths`（只含實際匹配到有效 session 的項目）。
- daemon 改為**先導入 session → 只註冊非空項目**；register-only 模式用掃描結果判定。沒有有效 session 的項目不再 `Use` 註冊、不再出現。

> 註：本次未處理「導入時把每個 cwd 註冊成 user-project」這個產生大量 UUID/隨機串項目的根因，也未做「避免循環導入自有歷史」（按需求暫緩），僅讓空項目不再冒出。

## 協議合規
- **cc-switch = MIT** → 與 Tutti 的 Apache-2.0 相容，已在 `NOTICE` 加上 MIT 版權聲明並標明改編位置。
- **zed = GPL-3.0**（agent crates）→ 不可移植，本次完全未使用其程式碼。

## 驗證
- `gofmt` / `go vet` / `go build ./...` / `go test ./...` 全綠，`golangci-lint` 0 issues。
- 新增 7 個測試：Codex SQLite 標題讀取／缺庫容錯／掃描覆蓋、IDE context 抽取、AGENTS/env 前導跳過、Claude custom-title、空項目不註冊。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * External imports now use improved, provider-aware conversation titles (including Codex titles from state DB and IDE/request parsing) with safer UTF-8 truncation.
  * External import results now expose the specific imported project paths.
* **Bug Fixes**
  * Project registration and imported project reporting now only include projects with valid imported external sessions.
* **Tests**
  * Added/expanded coverage for Codex/Claude title parsing, encoding-safe truncation, and valid project path selection.
* **Documentation**
  * Updated attribution for adapted third-party code.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->