### PR TITLE
[codex] fix ask-user prompt selection feedback

### DIFF
--- a/packages/agent/gui/agent-gui/agentGuiNode/AgentInteractivePromptSurface.spec.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/AgentInteractivePromptSurface.spec.tsx
@@ -1135,9 +1135,19 @@ describe("AgentInteractivePromptSurface", () => {
       />
     );
 
-    fireEvent.click(
-      screen.getByRole("button", { name: "Small Minimal change" })
-    );
+    const smallOption = screen.getByRole("button", {
+      name: "Small Minimal change"
+    });
+    const largeOption = screen.getByRole("button", {
+      name: "Large Broader cleanup"
+    });
+
+    expect(smallOption.getAttribute("aria-pressed")).toBe("false");
+    fireEvent.click(smallOption);
+    expect(smallOption.getAttribute("aria-pressed")).toBe("true");
+    expect(largeOption.getAttribute("aria-pressed")).toBe("false");
+    expect(onSubmit).not.toHaveBeenCalled();
+
     fireEvent.click(screen.getByRole("button", { name: labels.nextQuestion }));
     fireEvent.change(screen.getByPlaceholderText(labels.answerPlaceholder), {
       target: { value: "Include API docs parity." }

--- a/packages/agent/gui/app/renderer/agentactivity.css
+++ b/packages/agent/gui/app/renderer/agentactivity.css
@@ -2826,12 +2826,18 @@ aside.workspace-agents-status-panel
   text-align: left;
   transition:
     background-color 150ms ease,
+    box-shadow 150ms ease,
     color 150ms ease;
 }
 
 .agent-gui-conversation__interactive-option-button:hover:not(:disabled),
 .agent-gui-conversation__interactive-option-button[data-active="true"] {
   background: var(--transparency-hover);
+}
+
+.agent-gui-conversation__interactive-option-button[data-active="true"] {
+  box-shadow: inset 0 0 0 1px
+    color-mix(in srgb, var(--text-primary) 24%, transparent);
 }
 
 .agent-gui-conversation__interactive-option-display {
@@ -3065,6 +3071,13 @@ aside.workspace-agents-status-panel
   font-size: 11px;
   font-weight: 560;
   padding: 6px 12px;
+}
+
+.agent-gui-conversation__interactive-prompt-actions button:disabled {
+  cursor: not-allowed;
+  background: var(--transparency-block);
+  color: var(--text-disabled);
+  opacity: 0.58;
 }
 
 .agent-gui-conversation__user-message-flow,

--- a/packages/agent/gui/shared/agentConversation/components/AgentInteractivePromptSurface.tsx
+++ b/packages/agent/gui/shared/agentConversation/components/AgentInteractivePromptSurface.tsx
@@ -806,6 +806,7 @@ function FullAskUserPromptSurface({
                   type="button"
                   className={styles.interactiveOptionButton}
                   data-active={active}
+                  aria-pressed={active}
                   aria-label={interactiveOptionLabel(
                     option.label,
                     option.description


### PR DESCRIPTION
## What changed

- Mark ask-user option buttons with `aria-pressed` when selected.
- Add a visible selected outline for ask-user options.
- Add disabled styling for ask-user prompt action buttons.
- Extend the prompt surface test to verify that option selection updates state without submitting immediately.

## Why

The ask-user prompt option click only selected an answer locally; the user still had to press Submit answers. The selected state only reused the hover-like background, so clicking an option looked like it did nothing.

## Impact

Users now get clear visual and accessibility feedback after choosing an answer, while the existing submit flow and optional free-text details remain unchanged.

## Validation

Passed:

- `pnpm --filter @tutti-os/agent-gui test -- AgentInteractivePromptSurface.spec.tsx`
- `pnpm --filter @tutti-os/agent-gui typecheck`
- `pnpm exec oxfmt --check packages/agent/gui/shared/agentConversation/components/AgentInteractivePromptSurface.tsx packages/agent/gui/agent-gui/agentGuiNode/AgentInteractivePromptSurface.spec.tsx`
- `pnpm exec prettier --check --config packages/configs/prettier/base.mjs packages/agent/gui/app/renderer/agentactivity.css`
- pre-commit staged checks: electron runtime boundaries, UI boundaries, renderer boundaries

Pre-push `pnpm check:full` was run and failed in unrelated Go tests:

- `services/tuttid/service/agentstatus`: `TestServiceListReportsInstallActionWhenCodexAdapterCommandFails`, `TestServiceListReportsInstallActionWhenExternalAdapterCommandFails`
- `services/tuttid/service/computer`: `TestAdaptToolCallIntegration`

This PR only changes `packages/agent/gui` TSX/CSS/test files.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test for interactive prompt selections to validate UI state changes and confirm options don't immediately submit.

* **Style**
  * Enhanced visual feedback for option buttons with smooth transitions and clearer active/disabled states.

* **Accessibility**
  * Improved keyboard navigation and screen reader support for selection prompts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->