### PR TITLE
fix(agent-gui): keep permission menu options aligned

### DIFF
--- a/packages/agent/gui/agent-gui/agentGuiNode/AgentComposerSettingsMenus.spec.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/AgentComposerSettingsMenus.spec.tsx
@@ -1177,6 +1177,29 @@ describe("AgentPermissionModeDropdown", () => {
       })
     ).closest('[data-slot="select-content"]');
     expect(menu).toHaveClass("data-[side=top]:!translate-y-0");
+    expect(menu).toHaveAttribute(
+      "data-agent-composer-settings-layout",
+      "permission"
+    );
+  });
+
+  it("keeps permission select sizing tied to the Select collision bounds", () => {
+    const css = readFileSync(resolve("app/renderer/agentactivity.css"), "utf8");
+
+    renderPermissionModeDropdown("auto");
+
+    expect(
+      screen.getByRole("combobox", { name: "Run permissions" })
+    ).toHaveAttribute("data-agent-permission-mode-trigger", "true");
+    expect(css).toMatch(
+      /\.agent-gui-node__composer-menu-trigger\[data-agent-permission-mode-trigger="true"\]\s*{[^}]*flex:\s*0 0 auto[^}]*max-width:\s*min\(100%, 180px\)/s
+    );
+    expect(css).toMatch(
+      /\.agent-gui-node__composer-menu-content\s*{[^}]*max-height:\s*min\([^}]*--radix-select-content-available-height[\s\S]*?--radix-dropdown-menu-content-available-height/s
+    );
+    expect(css).toMatch(
+      /\.agent-gui-node__composer-menu-content\[data-agent-composer-settings-layout="permission"\]\s*{[^}]*--radix-select-content-available-width/s
+    );
   });
 
   it("shows permission descriptions in an info tooltip", async () => {

--- a/packages/agent/gui/agent-gui/agentGuiNode/AgentComposerSettingsMenus.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/AgentComposerSettingsMenus.tsx
@@ -205,6 +205,7 @@ export function AgentPermissionModeDropdown({
           composerSettings.isSettingsLoading && "animate-pulse"
         )}
         aria-label={labels.permissionLabel}
+        data-agent-permission-mode-trigger="true"
         data-permission-tone={triggerTone}
       >
         <span className="flex min-w-0 flex-1 items-center">
@@ -221,6 +222,7 @@ export function AgentPermissionModeDropdown({
             styles.composerMenuContent,
             "w-max min-w-[220px] max-w-[calc(100vw-32px)] data-[side=top]:!translate-y-0"
           )}
+          data-agent-composer-settings-layout="permission"
         >
           {permissionOptions.map((option) => (
             <SelectItem

--- a/packages/agent/gui/app/renderer/agentactivity.css
+++ b/packages/agent/gui/app/renderer/agentactivity.css
@@ -6618,6 +6618,11 @@ html[data-theme="light"] [data-message-center-item-id].agent-gui-edge-glow {
   transform: rotate(180deg);
 }
 
+.agent-gui-node__composer-menu-trigger[data-agent-permission-mode-trigger="true"] {
+  flex: 0 0 auto;
+  max-width: min(100%, 180px);
+}
+
 .agent-gui-node__composer-menu-trigger[data-permission-tone="accent"],
 .agent-gui-node__composer-menu-trigger[data-permission-tone="accent"]:hover:not(
     :disabled
@@ -6686,10 +6691,20 @@ html[data-theme="light"] [data-message-center-item-id].agent-gui-edge-glow {
   color: var(--agent-gui-text-primary);
   max-height: min(
     360px,
-    var(--radix-dropdown-menu-content-available-height, 360px)
+    var(
+      --radix-select-content-available-height,
+      var(--radix-dropdown-menu-content-available-height, 360px)
+    )
   );
   overflow-y: auto;
   overscroll-behavior: contain;
+}
+
+.agent-gui-node__composer-menu-content[data-agent-composer-settings-layout="permission"] {
+  max-width: min(
+    calc(100vw - 32px),
+    var(--radix-select-content-available-width, calc(100vw - 32px))
+  );
 }
 
 .agent-gui-node__composer-menu-label {


### PR DESCRIPTION
## Summary
- Mark the permission-mode trigger and menu with stable layout attributes.
- Constrain the select menu to Radix collision bounds so options stay aligned and visible.
- Add CSS-backed coverage for the sizing behavior.

Closes #140

## Validation
- Commit pre-hook passed oxfmt, oxlint, prettier, and staged boundary checks.
- Full pre-push hook was attempted separately and hit unrelated Go/environment failures outside this TS/CSS-only change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced test coverage for the permission dropdown component.

* **Style**
  * Improved permission dropdown menu styling and sizing to better adapt to available viewport space.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->