### PR TITLE
fix(agent-gui): render structured Message Center replies

### DIFF
--- a/packages/agent/gui/agent-message-center/messageCenterMessageSummary.ts
+++ b/packages/agent/gui/agent-message-center/messageCenterMessageSummary.ts
@@ -1,0 +1,35 @@
+export function messageSummaryText(value: unknown): string | null {
+  const text = structuredTextValue(value);
+  return text && text.trim() ? text.trim() : null;
+}
+
+function structuredTextValue(value: unknown): string | null {
+  if (typeof value === "string") {
+    return value.trim() ? value : null;
+  }
+  if (Array.isArray(value)) {
+    const parts = value
+      .map(structuredTextValue)
+      .filter((part): part is string => Boolean(part?.trim()));
+    return parts.length > 0 ? parts.join("\n") : null;
+  }
+  if (!value || typeof value !== "object") {
+    return null;
+  }
+
+  const record = value as Record<string, unknown>;
+  return firstNonEmptyString(
+    stringValue(record.text),
+    "content" in record ? structuredTextValue(record.content) : null
+  );
+}
+
+function stringValue(value: unknown): string | null {
+  return typeof value === "string" && value.trim() ? value : null;
+}
+
+function firstNonEmptyString(...values: Array<string | null>): string | null {
+  return (
+    values.find((value) => value !== null && value.trim().length > 0) ?? null
+  );
+}

--- a/packages/agent/gui/agent-message-center/workspaceAgentMessageCenterDigest.spec.ts
+++ b/packages/agent/gui/agent-message-center/workspaceAgentMessageCenterDigest.spec.ts
@@ -61,6 +61,37 @@ describe("buildWorkspaceAgentMessageCenterDigest", () => {
     });
   });
 
+  it("uses structured assistant content blocks as message summaries", () => {
+    const digest = buildWorkspaceAgentMessageCenterDigest({
+      fallbackTitle: "Fallback title",
+      messages: [
+        message({
+          messageId: "assistant-1",
+          role: "assistant",
+          payload: {
+            content: [
+              { type: "text", text: "我正在检查消息中心。" },
+              {
+                type: "content",
+                content: { type: "text", text: "会同步修复 issue 状态。" }
+              }
+            ]
+          },
+          occurredAtUnixMs: 10
+        })
+      ],
+      needsAttention: null,
+      pendingPrompt: null,
+      status: "working"
+    });
+
+    expect(digest.primary).toMatchObject({
+      kind: "progress",
+      summary: "我正在检查消息中心。 会同步修复 issue 状态。",
+      occurredAtUnixMs: 10
+    });
+  });
+
   it("prioritizes input-required over terminal-looking message summaries", () => {
     const digest = buildWorkspaceAgentMessageCenterDigest({
       fallbackTitle: "Fallback title",

--- a/packages/agent/gui/agent-message-center/workspaceAgentMessageCenterDigest.ts
+++ b/packages/agent/gui/agent-message-center/workspaceAgentMessageCenterDigest.ts
@@ -5,6 +5,7 @@ import type {
 import type { AgentConversationPromptVM } from "../shared/agentConversation/contracts/agentConversationVM";
 import { extractAgentMcpToolTarget } from "../shared/agentMcpToolTarget";
 import type { WorkspaceAgentActivityStatus } from "../shared/workspaceAgentActivityListViewModel";
+import { messageSummaryText } from "./messageCenterMessageSummary";
 
 export type WorkspaceAgentMessageCenterDigestPrimaryKind =
   | "input-required"
@@ -213,7 +214,7 @@ function summaryCandidate(
   source: MessageSummarySource,
   value: unknown
 ): MessageSummaryCandidate | null {
-  const summary = normalizeSummaryText(stringValue(value));
+  const summary = normalizeSummaryText(messageSummaryText(value));
   return summary ? { source, summary } : null;
 }
 
@@ -230,7 +231,7 @@ function toolErrorSummaryCandidate(
       stringValue(error.message),
       stringValue(error.detail),
       stringValue(error.text),
-      textFromContentValue(error.content),
+      messageSummaryText(error.content),
       stringValue(error.output),
       stringValue(error.stdout),
       stringValue(error.stderr),
@@ -256,7 +257,7 @@ function toolOutputSummaryCandidate(
       stringValue(output.summary),
       stringValue(output.message),
       stringValue(output.text),
-      textFromContentValue(output.content),
+      messageSummaryText(output.content),
       stringValue(output.content),
       stringValue(output.result),
       stringValue(output.output),
@@ -444,27 +445,6 @@ function stringArrayFirstValue(value: unknown): string | null {
   }
   return (
     value.map(stringValue).find((item): item is string => Boolean(item)) ?? null
-  );
-}
-
-function textFromContentValue(value: unknown): string | null {
-  if (typeof value === "string") {
-    return stringValue(value);
-  }
-  if (Array.isArray(value)) {
-    return (
-      value
-        .map(textFromContentValue)
-        .find((item): item is string => Boolean(item)) ?? null
-    );
-  }
-  if (!value || typeof value !== "object") {
-    return null;
-  }
-  const record = value as Record<string, unknown>;
-  return firstNonEmptyString(
-    stringValue(record.text),
-    "content" in record ? textFromContentValue(record.content) : null
   );
 }
 

--- a/packages/agent/gui/agent-message-center/workspaceAgentMessageCenterModel.spec.ts
+++ b/packages/agent/gui/agent-message-center/workspaceAgentMessageCenterModel.spec.ts
@@ -196,6 +196,40 @@ describe("buildWorkspaceAgentMessageCenterModel", () => {
     });
   });
 
+  it("renders structured assistant content blocks as agent replies", () => {
+    const model = buildWorkspaceAgentMessageCenterModel(
+      snapshot({
+        messages: [
+          message({
+            agentSessionId: "session-1",
+            messageId: "assistant-1",
+            role: "assistant",
+            kind: "message.assistant",
+            payload: {
+              content: [
+                { type: "text", text: "我正在检查消息中心。" },
+                {
+                  type: "content",
+                  content: { type: "text", text: "会同步修复 issue 状态。" }
+                }
+              ]
+            },
+            occurredAtUnixMs: 10
+          })
+        ],
+        sessions: [session({ agentSessionId: "session-1", status: "working" })]
+      })
+    );
+
+    expect(model.items[0]?.lastAgentMessageSummary).toBe(
+      "我正在检查消息中心。\n会同步修复 issue 状态。"
+    );
+    expect(model.items[0]?.digest.primary).toMatchObject({
+      kind: "progress",
+      summary: "我正在检查消息中心。 会同步修复 issue 状态。"
+    });
+  });
+
   it("preserves the session user id for message-center stacking", () => {
     const model = buildWorkspaceAgentMessageCenterModel(
       snapshot({

--- a/packages/agent/gui/agent-message-center/workspaceAgentMessageCenterModel.ts
+++ b/packages/agent/gui/agent-message-center/workspaceAgentMessageCenterModel.ts
@@ -19,6 +19,7 @@ import {
   buildWorkspaceAgentMessageCenterDigest,
   type WorkspaceAgentMessageCenterDigest
 } from "./workspaceAgentMessageCenterDigest";
+import { messageSummaryText } from "./messageCenterMessageSummary";
 
 export interface WorkspaceAgentMessageCenterModel {
   waitingCount: number;
@@ -693,13 +694,13 @@ function includesAny(value: string, needles: readonly string[]): boolean {
 
 function messageSummary(message: AgentActivityMessage): string {
   return firstNonEmptyString(
-    stringValue(message.payload.summary),
-    stringValue(message.payload.displayPrompt),
-    stringValue(message.payload.text),
-    stringValue(message.payload.content),
-    stringValue(message.payload.message),
-    stringValue(message.payload.body),
-    stringValue(message.payload.title)
+    messageSummaryText(message.payload.summary),
+    messageSummaryText(message.payload.displayPrompt),
+    messageSummaryText(message.payload.text),
+    messageSummaryText(message.payload.content),
+    messageSummaryText(message.payload.message),
+    messageSummaryText(message.payload.body),
+    messageSummaryText(message.payload.title)
   );
 }
 


### PR DESCRIPTION
## Summary
- Extract structured assistant text blocks into Message Center summaries.
- Reuse the same parsing path for message-center digest and item summaries.
- Add coverage for structured assistant content.

Closes #141

## Validation
- Commit pre-hook passed oxfmt, oxlint, and staged boundary checks.
- Full pre-push hook was attempted separately and hit unrelated Go/environment failures outside this TS-only change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Consolidated message text extraction logic in the agent message center for improved consistency when displaying various message formats and content types.

* **Tests**
  * Added unit tests to validate proper rendering of assistant messages containing structured content blocks and mixed content formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->