### PR TITLE
fix(agent-gui): render full Message Center session details

### DIFF
--- a/packages/agent/gui/agent-message-center/WorkspaceAgentMessageCenterCard.tsx
+++ b/packages/agent/gui/agent-message-center/WorkspaceAgentMessageCenterCard.tsx
@@ -23,6 +23,7 @@ import { normalizeAgentTitleText } from "../shared/utils/agentTitleText";
 import { AgentInteractivePromptSurface } from "../shared/agentConversation/components/AgentInteractivePromptSurface";
 import { AgentMessageMarkdown } from "../shared/AgentMessageMarkdown";
 import { AgentVerticalScrollArea } from "../shared/AgentVerticalScrollArea";
+import { WorkspaceAgentSessionDetail } from "../shared/WorkspaceAgentSessionDetail";
 import { managedAgentRoundedIconUrl } from "../shared/managedAgentIcons";
 import { workspaceAgentActivityStatusLabel } from "../shared/workspaceAgentActivityStatusLabel";
 import { workspaceAgentProviderLabel } from "../shared/workspaceAgentProviderLabel";
@@ -128,7 +129,9 @@ export function WorkspaceAgentMessageCenterCard({
         </span>
       </div>
 
-      {summary ? (
+      {item.detail?.turns.length ? (
+        <MessageCenterSessionDetail item={item} onLinkAction={onLinkAction} />
+      ) : summary ? (
         <MessageCenterSummary
           item={item}
           onLinkAction={onLinkAction}
@@ -593,6 +596,57 @@ function MessageCenterSummary({
         emptyLabel
       )}
     </AgentVerticalScrollArea>
+  );
+}
+
+function MessageCenterSessionDetail({
+  item,
+  onLinkAction
+}: {
+  item: WorkspaceAgentMessageCenterItem;
+  onLinkAction?: (action: WorkspaceLinkAction) => void;
+}): JSX.Element | null {
+  "use memo";
+  const { t } = useTranslation();
+  const detail = item.detail ?? null;
+  const handleLinkAction = useCallback(
+    (action: WorkspaceLinkAction): void => {
+      onLinkAction?.(
+        action.type === "open-agent-session" && !action.provider
+          ? { ...action, provider: item.provider }
+          : action
+      );
+    },
+    [item.provider, onLinkAction]
+  );
+
+  if (!detail || detail.turns.length === 0) {
+    return null;
+  }
+
+  return (
+    <div
+      className="workspace-agent-message-center__session-detail min-w-0 rounded-md bg-transparency-block"
+      onPointerDown={stopMessageCenterTextPointerPropagation}
+    >
+      <AgentVerticalScrollArea
+        className="max-h-[360px] min-w-0"
+        viewportClassName="max-h-[360px] p-2.5 pr-4"
+        scrollbarClassName="top-2 bottom-2 right-1.5"
+        syncKey={`${item.agentSessionId}:${item.timelineItemCount ?? detail.turns.length}`}
+      >
+        <WorkspaceAgentSessionDetail
+          detail={detail}
+          isLoading={item.status === "working" || item.status === "waiting"}
+          timelineItemCount={item.timelineItemCount ?? detail.turns.length}
+          onLinkAction={handleLinkAction}
+          toolCallsLabel={(count) =>
+            t("agentHost.workspaceAgentSessionDetailToolCalls", { count })
+          }
+          thinkingLabel={t("agentHost.workspaceAgentSessionDetailThinking")}
+        />
+      </AgentVerticalScrollArea>
+    </div>
   );
 }
 

--- a/packages/agent/gui/agent-message-center/WorkspaceAgentMessageCenterPanel.spec.tsx
+++ b/packages/agent/gui/agent-message-center/WorkspaceAgentMessageCenterPanel.spec.tsx
@@ -263,6 +263,94 @@ describe("WorkspaceAgentMessageCenterCard", () => {
     ).not.toHaveClass("agent-gui-edge-glow");
   });
 
+  it("renders canonical session detail when the message center item has transcript data", () => {
+    render(
+      <TooltipProvider>
+        <WorkspaceAgentMessageCenterCard
+          item={createTestCardItem({
+            digest: {
+              primary: {
+                kind: "summary",
+                summary: "Digest fallback should not render",
+                occurredAtUnixMs: 2
+              }
+            },
+            detail: {
+              activity: {
+                id: "activity-session-1",
+                sessionId: "session-1",
+                userId: null,
+                userName: "User",
+                agentProvider: "codex",
+                agentName: "Codex",
+                title: "整理本地文件夹",
+                status: "completed",
+                latestActivitySummary: "I found the relevant files.",
+                changedFiles: [],
+                sortTimeUnixMs: 2
+              },
+              session: {
+                workspaceId: "workspace-1",
+                agentSessionId: "session-1",
+                provider: "codex",
+                cwd: "/workspace",
+                title: "整理本地文件夹",
+                status: "completed"
+              },
+              cwd: "/workspace",
+              workspaceRoot: "/workspace",
+              turns: [
+                {
+                  id: "turn-1",
+                  userMessage: {
+                    id: "user-1",
+                    body: "Please inspect the workspace.",
+                    turnId: "turn-1"
+                  },
+                  userMessages: [
+                    {
+                      id: "user-1",
+                      body: "Please inspect the workspace.",
+                      turnId: "turn-1"
+                    }
+                  ],
+                  agentMessages: [
+                    {
+                      id: "assistant-1",
+                      body: "I found the relevant files.",
+                      turnId: "turn-1"
+                    }
+                  ],
+                  toolCalls: [],
+                  toolCallCount: 0,
+                  hasFailedToolCall: false,
+                  agentItems: [
+                    {
+                      kind: "message",
+                      message: {
+                        id: "assistant-1",
+                        body: "I found the relevant files.",
+                        turnId: "turn-1"
+                      }
+                    }
+                  ]
+                }
+              ]
+            },
+            timelineItemCount: 2
+          })}
+          isSubmitting={false}
+          onOpenChat={vi.fn()}
+          onSubmitPrompt={vi.fn()}
+        />
+      </TooltipProvider>
+    );
+
+    expect(screen.getByText("Please inspect the workspace.")).toBeTruthy();
+    expect(screen.getByText("I found the relevant files.")).toBeTruthy();
+    expect(screen.queryByText("Digest fallback should not render")).toBeNull();
+  });
+
   it("reports the provider and semantic action when submitting a notification prompt", () => {
     const onNotificationActioned = vi.fn();
     render(

--- a/packages/agent/gui/agent-message-center/workspaceAgentMessageCenterModel.spec.ts
+++ b/packages/agent/gui/agent-message-center/workspaceAgentMessageCenterModel.spec.ts
@@ -169,6 +169,40 @@ describe("buildWorkspaceAgentMessageCenterModel", () => {
     });
   });
 
+  it("builds session detail from the same message timeline used by conversations", () => {
+    const model = buildWorkspaceAgentMessageCenterModel(
+      snapshot({
+        messages: [
+          message({
+            agentSessionId: "session-1",
+            messageId: "user-1",
+            role: "user",
+            kind: "text",
+            payload: { text: "Please inspect the workspace." },
+            occurredAtUnixMs: 10,
+            turnId: "turn-1"
+          }),
+          message({
+            agentSessionId: "session-1",
+            messageId: "assistant-1",
+            role: "assistant",
+            kind: "text",
+            payload: { text: "I found the relevant files." },
+            occurredAtUnixMs: 20,
+            turnId: "turn-1"
+          })
+        ],
+        sessions: [session({ agentSessionId: "session-1" })]
+      })
+    );
+
+    expect(model.items[0]?.timelineItemCount).toBe(2);
+    expect(model.items[0]?.detail?.turns[0]).toMatchObject({
+      userMessage: { body: "Please inspect the workspace." },
+      agentMessages: [{ body: "I found the relevant files." }]
+    });
+  });
+
   it("prefers displayPrompt for message-center model summaries", () => {
     const model = buildWorkspaceAgentMessageCenterModel(
       snapshot({

--- a/packages/agent/gui/agent-message-center/workspaceAgentMessageCenterModel.ts
+++ b/packages/agent/gui/agent-message-center/workspaceAgentMessageCenterModel.ts
@@ -6,11 +6,20 @@ import {
   type AgentActivitySession,
   type AgentActivitySnapshot
 } from "@tutti-os/agent-activity-core";
+import { projectWorkspaceAgentMessagesToTimelineItems } from "../shared/agentConversation/projection/workspaceAgentMessageProjection";
 import type { AgentConversationPromptVM } from "../shared/agentConversation/contracts/agentConversationVM";
 import { normalizeAskUserQuestions } from "../shared/agentConversation/askUserQuestions";
 import { extractAgentMcpToolTarget } from "../shared/agentMcpToolTarget";
-import type { WorkspaceAgentActivityStatus } from "../shared/workspaceAgentActivityListViewModel";
+import {
+  buildWorkspaceAgentActivityListViewModel,
+  type WorkspaceAgentActivityCard,
+  type WorkspaceAgentActivityStatus
+} from "../shared/workspaceAgentActivityListViewModel";
 import { resolveWorkspaceAgentSessionSortTimeUnixMs } from "../shared/workspaceAgentSessionSortTime";
+import {
+  buildWorkspaceAgentSessionDetailViewModel,
+  type WorkspaceAgentSessionDetailViewModel
+} from "../shared/workspaceAgentSessionDetailViewModel";
 import {
   latestPlanTurnId,
   planImplementationPromptFromPlanTurn
@@ -46,6 +55,8 @@ export interface WorkspaceAgentMessageCenterItem {
   digest: WorkspaceAgentMessageCenterDigest;
   lastAgentMessageSummary: string;
   lastAgentMessageAtUnixMs: number | null;
+  detail?: WorkspaceAgentSessionDetailViewModel | null;
+  timelineItemCount?: number;
   pendingPrompt: AgentConversationPromptVM | null;
   needsAttentionKind: AgentActivityNeedsAttentionItem["kind"] | null;
   needsAttentionSummary: string | null;
@@ -96,6 +107,11 @@ export function buildWorkspaceAgentMessageCenterModel(
     selectNeedsAttentionItems(snapshot)
   );
   const displayStatuses = selectSessionDisplayStatuses(snapshot);
+  const activitiesBySessionId = new Map(
+    buildWorkspaceAgentActivityListViewModel(snapshot, {
+      sessionMessagesById: snapshot.sessionMessagesById
+    }).activities.map((activity) => [activity.sessionId, activity])
+  );
   const items = snapshot.sessions
     .filter((session) => session.visible !== false)
     .map((session) => {
@@ -125,6 +141,12 @@ export function buildWorkspaceAgentMessageCenterModel(
           messages
         }
       );
+      const detail = buildMessageCenterSessionDetail({
+        activity: activitiesBySessionId.get(session.agentSessionId) ?? null,
+        messages,
+        session,
+        workspaceRoot: options.workspaceRoot ?? null
+      });
 
       return {
         id: `message-center-${session.agentSessionId}`,
@@ -142,6 +164,8 @@ export function buildWorkspaceAgentMessageCenterModel(
         lastAgentMessageSummary:
           lastAgentMessage?.summary ?? needsAttention?.summary ?? title,
         lastAgentMessageAtUnixMs: lastAgentMessage?.occurredAtUnixMs ?? null,
+        detail: detail?.detail ?? null,
+        timelineItemCount: detail?.timelineItemCount ?? 0,
         pendingPrompt,
         needsAttentionKind: needsAttention?.kind ?? null,
         needsAttentionSummary: needsAttention?.summary ?? null,
@@ -154,6 +178,35 @@ export function buildWorkspaceAgentMessageCenterModel(
     waitingCount: items.filter(isWaitingMessageCenterItem).length,
     items: items.sort(compareMessageCenterItems),
     counts: countMessageCenterItems(items)
+  };
+}
+
+function buildMessageCenterSessionDetail({
+  activity,
+  messages,
+  session,
+  workspaceRoot
+}: {
+  activity: WorkspaceAgentActivityCard | null;
+  messages: readonly AgentActivityMessage[];
+  session: AgentActivitySession;
+  workspaceRoot: string | null;
+}): {
+  detail: WorkspaceAgentSessionDetailViewModel;
+  timelineItemCount: number;
+} | null {
+  if (!activity) {
+    return null;
+  }
+  const timelineItems = projectWorkspaceAgentMessagesToTimelineItems(messages);
+  return {
+    detail: buildWorkspaceAgentSessionDetailViewModel({
+      activity,
+      session,
+      timelineItems,
+      workspaceRoot
+    }),
+    timelineItemCount: timelineItems.length
   };
 }
 


### PR DESCRIPTION
## Summary
- Build Message Center detail data from the canonical conversation timeline.
- Render session details with the shared conversation detail component when transcript data is available.
- Preserve provider context when links are opened from the Message Center.

Closes #218

## Validation
- Commit pre-hook passed oxfmt, oxlint, and staged boundary checks.
- Full pre-push hook was attempted separately and hit unrelated Go/environment failures outside this TS-only change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Agent message center now displays detailed session information and message transcripts when available, replacing the summary-only view.

* **Tests**
  * Added test coverage for session detail rendering and transcript visibility in the message center.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->