### PR TITLE
fix(agent-gui): open conversations in separate GUI windows

### DIFF
--- a/apps/desktop/src/renderer/src/features/workspace-agent/ui/DesktopAgentGUIWorkbenchBody.tsx
+++ b/apps/desktop/src/renderer/src/features/workspace-agent/ui/DesktopAgentGUIWorkbenchBody.tsx
@@ -89,6 +89,11 @@ interface DesktopAgentGUIWorkbenchBodyProps {
   dockPreviewCache: WorkbenchDockPreviewCache;
   onLinkAction?: (action: WorkspaceLinkAction) => void;
   onCapabilitySettingsRequest?: AgentGUIProps["onCapabilitySettingsRequest"];
+  onOpenAgentConversationWindow?: (input: {
+    agentSessionId: string;
+    provider: DesktopAgentGUINodeState["provider"];
+    workspaceId: string;
+  }) => Promise<void> | void;
   onStateChange: (state: DesktopAgentGUIWorkbenchState) => void;
   previewMode?: boolean;
   contextMentionProviders: NonNullable<
@@ -158,6 +163,7 @@ export function DesktopAgentGUIWorkbenchBody({
   dockPreviewCache,
   onLinkAction,
   onCapabilitySettingsRequest,
+  onOpenAgentConversationWindow,
   onStateChange,
   previewMode = false,
   contextMentionProviders,
@@ -655,6 +661,24 @@ export function DesktopAgentGUIWorkbenchBody({
     };
   }, [context.instanceId, previewMode]);
 
+  const handleOpenConversationWindow = useCallback(
+    (agentSessionId: string) => {
+      if (previewMode || !onOpenAgentConversationWindow) {
+        return;
+      }
+      const trimmedAgentSessionId = agentSessionId.trim();
+      if (!trimmedAgentSessionId) {
+        return;
+      }
+      void onOpenAgentConversationWindow({
+        agentSessionId: trimmedAgentSessionId,
+        provider,
+        workspaceId
+      });
+    },
+    [onOpenAgentConversationWindow, previewMode, provider, workspaceId]
+  );
+
   useEffect(() => {
     if (
       previewMode ||
@@ -814,6 +838,11 @@ export function DesktopAgentGUIWorkbenchBody({
       onResize={DESKTOP_AGENT_GUI_NOOP}
       onShowMessage={DESKTOP_AGENT_GUI_NOOP}
       onUpdateNode={handleUpdateNode}
+      onOpenConversationWindow={
+        previewMode || !onOpenAgentConversationWindow
+          ? undefined
+          : handleOpenConversationWindow
+      }
       onWorkspaceFileReferencesAdded={trackWorkspaceFileReferences}
       position={DESKTOP_AGENT_GUI_POSITION}
       previewMode={previewMode}

--- a/apps/desktop/src/renderer/src/features/workspace-workbench/services/internal/contributions/agentGuiWorkbenchContributionFactory.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/services/internal/contributions/agentGuiWorkbenchContributionFactory.ts
@@ -14,6 +14,7 @@ export const agentGuiWorkbenchContributionFactory: DesktopWorkbenchContributionF
         dockIconUrls: context.dockIcons.agents,
         dockPreviewCache: context.dockPreviewCache,
         hostFilesApi: context.hostFilesApi,
+        hostWindowApi: context.hostWindowApi,
         i18n: context.i18n,
         onCapabilitySettingsRequest: context.onCapabilitySettingsRequest,
         tuttidClient: context.tuttidClient,

--- a/apps/desktop/src/renderer/src/features/workspace-workbench/services/internal/contributions/agentGuiWorkbenchContributionFactory.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/services/internal/contributions/agentGuiWorkbenchContributionFactory.ts
@@ -14,7 +14,6 @@ export const agentGuiWorkbenchContributionFactory: DesktopWorkbenchContributionF
         dockIconUrls: context.dockIcons.agents,
         dockPreviewCache: context.dockPreviewCache,
         hostFilesApi: context.hostFilesApi,
-        hostWindowApi: context.hostWindowApi,
         i18n: context.i18n,
         onCapabilitySettingsRequest: context.onCapabilitySettingsRequest,
         tuttidClient: context.tuttidClient,

--- a/apps/desktop/src/renderer/src/features/workspace-workbench/services/internal/workspaceAgentGuiContribution.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/services/internal/workspaceAgentGuiContribution.ts
@@ -18,6 +18,7 @@ import type {
 import type {
   DesktopComputerUseApi,
   DesktopHostFilesApi,
+  DesktopHostWindowApi,
   DesktopPlatformApi,
   DesktopRuntimeApi
 } from "@preload/types";
@@ -54,6 +55,7 @@ export function createWorkspaceAgentGuiContribution(input: {
     typeof createAgentGuiWorkbenchContribution
   >[0]["dockIconUrls"];
   hostFilesApi: DesktopHostFilesApi;
+  hostWindowApi: DesktopHostWindowApi;
   i18n: WorkspaceWorkbenchDesktopI18nRuntime;
   onCapabilitySettingsRequest?: Parameters<
     typeof DesktopAgentGUIWorkbenchBody
@@ -117,6 +119,9 @@ export function createWorkspaceAgentGuiContribution(input: {
       dockPreviewCache: input.dockPreviewCache,
       onCapabilitySettingsRequest: input.onCapabilitySettingsRequest,
       onLinkAction: handleLinkAction,
+      onOpenAgentConversationWindow: async (request) => {
+        await requestWorkspaceAgentGuiLaunch(request);
+      },
       onStateChange: (...args) => helpers.onStateChange(...args),
       previewMode: options?.previewMode,
       contextMentionProviders:

--- a/apps/desktop/src/renderer/src/features/workspace-workbench/services/internal/workspaceAgentGuiContribution.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/services/internal/workspaceAgentGuiContribution.ts
@@ -18,7 +18,6 @@ import type {
 import type {
   DesktopComputerUseApi,
   DesktopHostFilesApi,
-  DesktopHostWindowApi,
   DesktopPlatformApi,
   DesktopRuntimeApi
 } from "@preload/types";
@@ -55,7 +54,6 @@ export function createWorkspaceAgentGuiContribution(input: {
     typeof createAgentGuiWorkbenchContribution
   >[0]["dockIconUrls"];
   hostFilesApi: DesktopHostFilesApi;
-  hostWindowApi: DesktopHostWindowApi;
   i18n: WorkspaceWorkbenchDesktopI18nRuntime;
   onCapabilitySettingsRequest?: Parameters<
     typeof DesktopAgentGUIWorkbenchBody

--- a/apps/desktop/src/renderer/src/features/workspace-workbench/services/internal/workspaceWorkbenchComposition.test.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/services/internal/workspaceWorkbenchComposition.test.ts
@@ -138,7 +138,7 @@ test("workspace agent GUI session launches target exact session instances", () =
   assert.equal(descriptor.targetAgentSessionId, "session-2");
   assert.equal(descriptor.dockEntryId, "agent-gui");
   assert.equal(descriptor.instanceId, "agent-gui:codex:session:session-2");
-  assert.equal(descriptor.reuseDockEntryNode, true);
+  assert.equal(descriptor.reuseDockEntryNode, false);
   assert.deepEqual(descriptor.activation, {
     payload: {
       agentSessionId: "session-2"

--- a/packages/agent/gui/agent-gui/agentGuiNode/AgentFileMentionPalette.spec.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/AgentFileMentionPalette.spec.tsx
@@ -1766,7 +1766,7 @@ describe("AgentFileMentionPalette", () => {
       /\.agent-gui-node__conversation-title\s*{[^}]*overflow:\s*hidden[^}]*color:\s*var\(--text-primary\)[^}]*font-size:\s*13px[^}]*font-weight:\s*400[^}]*text-overflow:\s*ellipsis[^}]*white-space:\s*nowrap/s
     );
     expect(css).toMatch(
-      /\.agent-gui-node__conversation-item:hover\s+\.agent-gui-node__conversation-select[\s\S]*?grid-template-columns:\s*minmax\(0,\s*1fr\)\s*0[\s\S]*?padding-right:\s*72px/s
+      /\.agent-gui-node__conversation-item:hover\s+\.agent-gui-node__conversation-select[\s\S]*?grid-template-columns:\s*minmax\(0,\s*1fr\)\s*0[\s\S]*?padding-right:\s*96px/s
     );
     expect(css).not.toMatch(
       /\.agent-gui-node__conversation-item:focus-within\s+\.agent-gui-node__conversation-select[\s\S]*?grid-template-columns/s
@@ -1778,16 +1778,16 @@ describe("AgentFileMentionPalette", () => {
       /\.agent-gui-node__conversation-item\[data-pinned="true"\]\s+\.agent-gui-node__conversation-actions,\s*\.agent-gui-node__conversation-item:hover/s
     );
     expect(css).toMatch(
-      /\.agent-gui-node__conversation-actions\s*{[^}]*right:\s*4px[^}]*justify-content:\s*flex-start[^}]*gap:\s*0[^}]*min-width:\s*48px/s
+      /\.agent-gui-node__conversation-actions\s*{[^}]*right:\s*4px[^}]*justify-content:\s*flex-start[^}]*gap:\s*0[^}]*min-width:\s*72px/s
     );
     expect(css).toMatch(
-      /\.agent-gui-node__conversation-delete-button,\s*\.agent-gui-node__conversation-pin-button\s*{[^}]*background:\s*transparent[^}]*background-color:\s*transparent[^}]*color:\s*var\(--text-tertiary\)/s
+      /\.agent-gui-node__conversation-delete-button,\s*\.agent-gui-node__conversation-open-window-button,\s*\.agent-gui-node__conversation-pin-button\s*{[^}]*background:\s*transparent[^}]*background-color:\s*transparent[^}]*color:\s*var\(--text-tertiary\)/s
     );
     expect(css).not.toMatch(
       /\.agent-gui-node__conversation-delete-button,\s*\.agent-gui-node__conversation-pin-button\s*{[^}]*width:\s*28px/s
     );
     expect(nodeViewSource).toMatch(
-      /<BareIconButton[\s\S]*className=\{styles\.conversationPinButton\}[\s\S]*size="md"[\s\S]*<BareIconButton[\s\S]*className=\{[\s\S]*?styles\.conversationDeleteButton[\s\S]*?\}[\s\S]*size="md"/
+      /<BareIconButton[\s\S]*className=\{styles\.conversationOpenWindowButton\}[\s\S]*size="md"[\s\S]*<BareIconButton[\s\S]*className=\{styles\.conversationPinButton\}[\s\S]*size="md"[\s\S]*<BareIconButton[\s\S]*className=\{styles\.conversationDeleteButton\}[\s\S]*size="md"/
     );
     expect(css).toMatch(
       /\.agent-gui-node__conversation-actions\s+>\s+button\.agent-gui-node__conversation-pin-button:not\(:disabled\):hover,\s*\.agent-gui-node__conversation-actions\s+>\s+button\.agent-gui-node__conversation-pin-button:not\(:disabled\):focus-visible,\s*\.agent-gui-node__conversation-actions\s+>\s+button\.agent-gui-node__conversation-pin-button:not\(:disabled\):active\s*{[^}]*background:\s*transparent[^}]*background-color:\s*transparent/s

--- a/packages/agent/gui/agent-gui/agentGuiNode/AgentFileMentionPalette.spec.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/AgentFileMentionPalette.spec.tsx
@@ -1798,6 +1798,15 @@ describe("AgentFileMentionPalette", () => {
     expect(css).toMatch(
       /\.agent-gui-node__conversation-actions\s+>\s+button\.agent-gui-node__conversation-pin-button:not\(:disabled\):hover,\s*\.agent-gui-node__conversation-actions\s+>\s+button\.agent-gui-node__conversation-pin-button:not\(:disabled\):focus-visible,\s*\.agent-gui-node__conversation-actions\s+>\s+button\.agent-gui-node__conversation-pin-button:not\(:disabled\):active\s*{[^}]*color:\s*var\(--agent-gui-accent\)/s
     );
+    const openWindowIconHoverRule = css.match(
+      /\.agent-gui-node__conversation-actions\s+>\s+button\.agent-gui-node__conversation-open-window-button:not\(:disabled\):hover\s+svg,[\s\S]*?\.agent-gui-node__conversation-actions\s+>\s+button\.agent-gui-node__conversation-open-window-button:not\(:disabled\):active\s+svg\s*{(?<body>[^}]*)}/
+    );
+    expect(openWindowIconHoverRule?.groups?.body).toMatch(
+      /color:\s*var\(--text-primary\)/
+    );
+    expect(openWindowIconHoverRule?.groups?.body).not.toMatch(
+      /fill:\s*currentColor/
+    );
     expect(css).toMatch(
       /\.agent-gui-node__conversation-actions\s+>\s+button\.agent-gui-node__conversation-pin-button:not\(:disabled\):hover\s+svg,\s*\.agent-gui-node__conversation-actions\s+>\s+button\.agent-gui-node__conversation-pin-button:not\(:disabled\):focus-visible\s+svg,\s*\.agent-gui-node__conversation-actions\s+>\s+button\.agent-gui-node__conversation-pin-button:not\(:disabled\):active\s+svg\s*{[^}]*color:\s*var\(--agent-gui-accent\)[^}]*fill:\s*currentColor/s
     );

--- a/packages/agent/gui/agent-gui/agentGuiNode/AgentGUINode.spec.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/AgentGUINode.spec.tsx
@@ -1921,6 +1921,38 @@ describe("AgentGUINode", () => {
     expect(mockSelectConversation).not.toHaveBeenCalled();
   });
 
+  it("opens a conversation in a new window from the rail action without selecting", () => {
+    const onOpenConversationWindow =
+      vi.fn<
+        NonNullable<
+          React.ComponentProps<typeof AgentGUINode>["onOpenConversationWindow"]
+        >
+      >();
+    mockViewModel = createViewModel({
+      conversations: [
+        {
+          id: "session-1",
+          provider: "codex",
+          title: "Session 1",
+          status: "ready",
+          cwd: "/workspace",
+          updatedAtUnixMs: 1
+        }
+      ],
+      activeConversationId: "session-1"
+    });
+    renderAgentGUINode({ onOpenConversationWindow });
+
+    fireEvent.click(
+      screen.getByRole("button", {
+        name: "agentHost.agentGui.openConversationWindow"
+      })
+    );
+
+    expect(onOpenConversationWindow).toHaveBeenCalledWith("session-1");
+    expect(mockSelectConversation).not.toHaveBeenCalled();
+  });
+
   it("renders inline delete confirmation and dispatches confirm without a dialog", () => {
     mockViewModel = createViewModel({
       conversations: [
@@ -6715,6 +6747,7 @@ function renderAgentGUINode({
   onLinkAction,
   onAgentProviderLogin,
   onWorkspaceFileReferencesAdded,
+  onOpenConversationWindow,
   state = {
     provider: "codex",
     lastActiveAgentSessionId: null,
@@ -6748,6 +6781,9 @@ function renderAgentGUINode({
   onWorkspaceFileReferencesAdded?: React.ComponentProps<
     typeof AgentGUINode
   >["onWorkspaceFileReferencesAdded"];
+  onOpenConversationWindow?: React.ComponentProps<
+    typeof AgentGUINode
+  >["onOpenConversationWindow"];
   state?: AgentGUINodeData;
   onUpdateNode?: (
     updater: (current: AgentGUINodeData) => AgentGUINodeData
@@ -6795,6 +6831,7 @@ function renderAgentGUINode({
       onLinkAction={onLinkAction}
       onAgentProviderLogin={onAgentProviderLogin}
       onWorkspaceFileReferencesAdded={onWorkspaceFileReferencesAdded}
+      onOpenConversationWindow={onOpenConversationWindow}
       onClose={vi.fn()}
       onResize={onResize}
       onUpdateNode={onUpdateNode}

--- a/packages/agent/gui/agent-gui/agentGuiNode/AgentGUINode.styles.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/AgentGUINode.styles.ts
@@ -57,6 +57,8 @@ const styles = {
   conversationItem: "agent-gui-node__conversation-item",
   conversationList: "agent-gui-node__conversation-list",
   conversationMeta: "agent-gui-node__conversation-meta",
+  conversationOpenWindowButton:
+    "agent-gui-node__conversation-open-window-button",
   conversationPinButton: "agent-gui-node__conversation-pin-button",
   conversationSection: "agent-gui-node__conversation-section",
   conversationSectionActions: "agent-gui-node__conversation-section-actions",

--- a/packages/agent/gui/agent-gui/agentGuiNode/AgentGUINode.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/AgentGUINode.tsx
@@ -170,6 +170,7 @@ export interface AgentGUINodeProps {
     provider: AgentProvider;
     references: readonly WorkspaceFileReference[];
   }) => void | Promise<void>;
+  onOpenConversationWindow?: (agentSessionId: string) => void;
   onClose: () => void;
   onResize: (frame: NodeFrame) => void;
   onUpdateNode: (
@@ -474,6 +475,7 @@ function areAgentGUINodePropsEqual(
     previous.onClose === next.onClose &&
     previous.onResize === next.onResize &&
     previous.onUpdateNode === next.onUpdateNode &&
+    previous.onOpenConversationWindow === next.onOpenConversationWindow &&
     previous.isMaximized === next.isMaximized &&
     previous.isMuted === next.isMuted &&
     previous.onMinimize === next.onMinimize &&
@@ -522,6 +524,7 @@ export const AgentGUINode = memo(function AgentGUINode({
   onCapabilitySettingsRequest,
   onAgentProviderLogin,
   onWorkspaceFileReferencesAdded,
+  onOpenConversationWindow,
   onClose,
   onResize,
   onUpdateNode,
@@ -944,6 +947,7 @@ export const AgentGUINode = memo(function AgentGUINode({
       thinkingLabel: t("agentHost.workspaceAgentSessionDetailThinking"),
       toolCallsLabel: (count: number) =>
         t("agentHost.workspaceAgentSessionDetailToolCalls", { count }),
+      openConversationWindow: t("agentHost.agentGui.openConversationWindow"),
       deleteSession: t("agentHost.agentGui.deleteSession"),
       pinSession: t("agentHost.agentGui.pinSession"),
       unpinSession: t("agentHost.agentGui.unpinSession"),
@@ -1335,6 +1339,7 @@ export const AgentGUINode = memo(function AgentGUINode({
             labels={labels}
             workspaceUserProjectI18n={workspaceUserProjectI18n}
             workspaceFileReferenceAdapter={workspaceFileReferenceAdapter}
+            onOpenConversationWindow={onOpenConversationWindow}
             onRequestGitBranches={onRequestGitBranches}
             referenceSourceAggregator={referenceSourceAggregator}
             resolveMentionReferenceTarget={resolveMentionReferenceTarget}

--- a/packages/agent/gui/agent-gui/agentGuiNode/AgentGUINodeView.layout.spec.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/AgentGUINodeView.layout.spec.tsx
@@ -1414,6 +1414,7 @@ function createLabels(): AgentGUIViewLabels {
     waitingForAnswer: "waitingForAnswer",
     thinkingLabel: "thinkingLabel",
     toolCallsLabel: (count: number) => `toolCalls:${count}`,
+    openConversationWindow: "openConversationWindow",
     deleteSession: "deleteSession",
     pinSession: "pinSession",
     unpinSession: "unpinSession",

--- a/packages/agent/gui/agent-gui/agentGuiNode/AgentGUINodeView.layout.spec.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/AgentGUINodeView.layout.spec.tsx
@@ -1,6 +1,6 @@
 import { readFileSync } from "node:fs";
 import { resolve } from "node:path";
-import { fireEvent, render, screen } from "@testing-library/react";
+import { fireEvent, render, screen, within } from "@testing-library/react";
 import { createDefaultWorkspaceUserProjectI18nRuntime } from "@tutti-os/workspace-user-project/i18n";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { WorkspaceAgentSessionDetailViewModel } from "../../shared/workspaceAgentSessionDetailViewModel";
@@ -389,6 +389,39 @@ describe("AgentGUINodeView layout persistence", () => {
       screen.getByTestId("agent-gui-conversation-list-loading-skeleton")
     ).toHaveAccessibleName("loadingConversations");
     expect(screen.queryByText("loadingConversations")).not.toBeInTheDocument();
+  });
+
+  it("opens a conversation from the rail with the external-link action", () => {
+    const actions = createActions();
+    const onOpenConversationWindow = vi.fn();
+
+    renderAgentGUINodeView({
+      actions,
+      onOpenConversationWindow,
+      viewModel: {
+        ...createViewModel(),
+        activeConversationId: "session-1",
+        conversations: [
+          createConversationSummary("session-1"),
+          createConversationSummary("session-2")
+        ]
+      }
+    });
+
+    const row = screen.getByTestId("agent-gui-conversation-item-session-2");
+    const openWindowButton = within(row).getByRole("button", {
+      name: "openConversationWindow"
+    });
+
+    expect(
+      openWindowButton.querySelector("svg.lucide-external-link")
+    ).toBeInTheDocument();
+
+    fireEvent.click(openWindowButton);
+
+    expect(onOpenConversationWindow).toHaveBeenCalledTimes(1);
+    expect(onOpenConversationWindow).toHaveBeenCalledWith("session-2");
+    expect(actions.selectConversation).not.toHaveBeenCalled();
   });
 
   it("scrolls the active conversation item into view", () => {
@@ -1069,6 +1102,7 @@ interface RenderAgentGUINodeViewOptions {
   viewModel?: AgentGUINodeViewModel;
   actions?: AgentGUINodeViewProps["actions"];
   labels?: AgentGUIViewLabels;
+  onOpenConversationWindow?: AgentGUINodeViewProps["onOpenConversationWindow"];
   slashStatusLimits?: AgentGUINodeViewProps["slashStatusLimits"];
   showProjectSelector?: boolean;
 }
@@ -1081,6 +1115,7 @@ function buildAgentGUINodeViewElement({
   viewModel = createViewModel(),
   actions = createActions(),
   labels = createLabels(),
+  onOpenConversationWindow,
   slashStatusLimits = [],
   showProjectSelector = true
 }: RenderAgentGUINodeViewOptions = {}) {
@@ -1098,6 +1133,7 @@ function buildAgentGUINodeViewElement({
       detailMinWidthPx={220}
       uiLanguage="en"
       showProjectSelector={showProjectSelector}
+      onOpenConversationWindow={onOpenConversationWindow}
       onConversationRailWidthChanged={onConversationRailWidthChanged}
       labels={labels}
     />

--- a/packages/agent/gui/agent-gui/agentGuiNode/AgentGUINodeView.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/AgentGUINodeView.tsx
@@ -12,7 +12,7 @@ import {
   useState
 } from "react";
 import { useSnapshot } from "valtio";
-import { ChevronRight, Info, X } from "lucide-react";
+import { ChevronRight, ExternalLink, Info, X } from "lucide-react";
 import type {
   ReferenceLocateTarget,
   WorkspaceFileReference,
@@ -39,7 +39,6 @@ import type { WorkspaceUserProjectI18nRuntime } from "@tutti-os/workspace-user-p
 import { BareIconButton, ScrollArea } from "@tutti-os/ui-system/components";
 import { Button } from "../../app/renderer/components/ui/button";
 import {
-  AppWindowIcon,
   EditIcon,
   FolderIcon,
   MoreHorizontalIcon
@@ -3418,7 +3417,7 @@ const AgentGUIConversationRailItem = memo(
                     handleOpenConversationWindow();
                   }}
                 >
-                  <AppWindowIcon aria-hidden="true" />
+                  <ExternalLink aria-hidden="true" />
                 </BareIconButton>
               ) : null}
               <BareIconButton

--- a/packages/agent/gui/agent-gui/agentGuiNode/AgentGUINodeView.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/AgentGUINodeView.tsx
@@ -39,6 +39,7 @@ import type { WorkspaceUserProjectI18nRuntime } from "@tutti-os/workspace-user-p
 import { BareIconButton, ScrollArea } from "@tutti-os/ui-system/components";
 import { Button } from "../../app/renderer/components/ui/button";
 import {
+  AppWindowIcon,
   EditIcon,
   FolderIcon,
   MoreHorizontalIcon
@@ -299,6 +300,7 @@ export interface AgentGUIViewLabels {
   waitingForAnswer: string;
   thinkingLabel: string;
   toolCallsLabel: (count: number) => string;
+  openConversationWindow: string;
   deleteSession: string;
   pinSession: string;
   unpinSession: string;
@@ -446,6 +448,7 @@ interface AgentGUINodeViewProps {
   labels: AgentGUIViewLabels;
   workspaceUserProjectI18n: WorkspaceUserProjectI18nRuntime;
   workspaceFileReferenceAdapter?: WorkspaceFileReferenceAdapter | null;
+  onOpenConversationWindow?: (agentSessionId: string) => void;
   onRequestGitBranches?: AgentComposerGitBranchLoader | null;
   workspaceFileReferenceCopy?: WorkspaceFileReferenceCopy | null;
   contextMentionProviders?: readonly AgentContextMentionProvider[];
@@ -766,6 +769,7 @@ export function AgentGUINodeView({
   labels,
   workspaceUserProjectI18n,
   workspaceFileReferenceAdapter = null,
+  onOpenConversationWindow,
   workspaceFileReferenceCopy = null,
   onRequestGitBranches = null,
   contextMentionProviders,
@@ -1141,6 +1145,7 @@ export function AgentGUINodeView({
             onRequestDeleteConversation={actions.requestDeleteConversation}
             onCancelDeleteConversation={actions.cancelDeleteConversation}
             onConfirmDeleteConversation={actions.confirmDeleteConversation}
+            onOpenConversationWindow={onOpenConversationWindow}
           />
         </aside>
         <div
@@ -2761,6 +2766,7 @@ interface AgentGUIConversationRailPaneProps {
   onRetryOpenclawGateway: () => void;
   onSelectConversation: (agentSessionId: string) => void;
   onToggleConversationPinned: (agentSessionId: string, pinned: boolean) => void;
+  onOpenConversationWindow?: (agentSessionId: string) => void;
   onRemoveProject: (path: string) => void;
   onConfirmDeleteProjectConversations: (path?: string) => void;
   onRequestDeleteConversation: (agentSessionId: string) => void;
@@ -2818,6 +2824,7 @@ const AgentGUIConversationRailPane = memo(
     onRetryOpenclawGateway,
     onSelectConversation,
     onToggleConversationPinned,
+    onOpenConversationWindow,
     onRemoveProject,
     onConfirmDeleteProjectConversations,
     onRequestDeleteConversation,
@@ -3045,6 +3052,7 @@ const AgentGUIConversationRailPane = memo(
                     onSelectConversation={onSelectConversation}
                     setPendingProjectAction={setPendingProjectAction}
                     onToggleConversationPinned={onToggleConversationPinned}
+                    onOpenConversationWindow={onOpenConversationWindow}
                     onToggleProjectSectionCollapsed={
                       toggleProjectSectionCollapsed
                     }
@@ -3129,6 +3137,7 @@ interface AgentGUIConversationRailSectionProps {
   setPendingProjectAction: (action: AgentGUIProjectActionDialog | null) => void;
   onSelectConversation: (agentSessionId: string) => void;
   onToggleConversationPinned: (agentSessionId: string, pinned: boolean) => void;
+  onOpenConversationWindow?: (agentSessionId: string) => void;
   onRequestDeleteConversation: (agentSessionId: string) => void;
   onCancelDeleteConversation: () => void;
   onConfirmDeleteConversation: () => void;
@@ -3154,6 +3163,7 @@ const AgentGUIConversationRailSection = memo(
     onSelectConversation,
     setPendingProjectAction,
     onToggleConversationPinned,
+    onOpenConversationWindow,
     onRequestDeleteConversation,
     onCancelDeleteConversation,
     onConfirmDeleteConversation
@@ -3282,6 +3292,7 @@ const AgentGUIConversationRailSection = memo(
                 onRequestDeleteConversation={onRequestDeleteConversation}
                 onSelectConversation={onSelectConversation}
                 onToggleConversationPinned={onToggleConversationPinned}
+                onOpenConversationWindow={onOpenConversationWindow}
               />
             ))}
           </div>
@@ -3302,6 +3313,7 @@ interface AgentGUIConversationRailItemProps {
   registerItemElement: (itemId: string, element: HTMLDivElement | null) => void;
   onSelectConversation: (agentSessionId: string) => void;
   onToggleConversationPinned: (agentSessionId: string, pinned: boolean) => void;
+  onOpenConversationWindow?: (agentSessionId: string) => void;
   onRequestDeleteConversation: (agentSessionId: string) => void;
   onCancelDeleteConversation: () => void;
   onConfirmDeleteConversation: () => void;
@@ -3319,6 +3331,7 @@ const AgentGUIConversationRailItem = memo(
     registerItemElement,
     onSelectConversation,
     onToggleConversationPinned,
+    onOpenConversationWindow,
     onRequestDeleteConversation,
     onCancelDeleteConversation,
     onConfirmDeleteConversation
@@ -3342,6 +3355,9 @@ const AgentGUIConversationRailItem = memo(
     const handleTogglePinned = useCallback(() => {
       onToggleConversationPinned(item.id, !pinned);
     }, [item.id, onToggleConversationPinned, pinned]);
+    const handleOpenConversationWindow = useCallback(() => {
+      onOpenConversationWindow?.(item.id);
+    }, [item.id, onOpenConversationWindow]);
     const handleRequestDelete = useCallback(() => {
       onRequestDeleteConversation(item.id);
     }, [item.id, onRequestDeleteConversation]);
@@ -3385,6 +3401,26 @@ const AgentGUIConversationRailItem = memo(
             </button>
           ) : (
             <>
+              {onOpenConversationWindow ? (
+                <BareIconButton
+                  className={styles.conversationOpenWindowButton}
+                  aria-label={labels.openConversationWindow}
+                  title={labels.openConversationWindow}
+                  size="md"
+                  onPointerDown={(event) => {
+                    event.stopPropagation();
+                  }}
+                  onMouseDown={(event) => {
+                    event.stopPropagation();
+                  }}
+                  onClick={(event) => {
+                    event.stopPropagation();
+                    handleOpenConversationWindow();
+                  }}
+                >
+                  <AppWindowIcon aria-hidden="true" />
+                </BareIconButton>
+              ) : null}
               <BareIconButton
                 className={styles.conversationPinButton}
                 aria-label={pinned ? labels.unpinSession : labels.pinSession}

--- a/packages/agent/gui/app/renderer/agentactivity.css
+++ b/packages/agent/gui/app/renderer/agentactivity.css
@@ -4654,7 +4654,7 @@ button.agent-gui-node__conversation-section-toggle:hover
 
 .agent-gui-node__conversation-item:hover .agent-gui-node__conversation-select {
   grid-template-columns: minmax(0, 1fr) 0;
-  padding-right: 72px;
+  padding-right: 96px;
 }
 
 .agent-gui-node__conversation-item[data-pending-delete="true"]
@@ -4696,7 +4696,7 @@ button.agent-gui-node__conversation-section-toggle:hover
   justify-content: flex-start;
   gap: 0;
   box-sizing: border-box;
-  min-width: 48px;
+  min-width: 72px;
   max-width: calc(100% - 20px);
   opacity: 0;
   transform: translateY(-50%);
@@ -4704,6 +4704,7 @@ button.agent-gui-node__conversation-section-toggle:hover
 }
 
 .agent-gui-node__conversation-delete-button,
+.agent-gui-node__conversation-open-window-button,
 .agent-gui-node__conversation-pin-button {
   background: transparent;
   background-color: transparent;
@@ -4711,6 +4712,7 @@ button.agent-gui-node__conversation-section-toggle:hover
 }
 
 .agent-gui-node__conversation-pin-button svg,
+.agent-gui-node__conversation-open-window-button svg,
 .agent-gui-node__conversation-delete-button svg {
   width: 14px;
   height: 14px;
@@ -4762,6 +4764,36 @@ button.agent-gui-node__conversation-section-toggle:hover
   margin-right: 0;
   overflow: hidden;
   opacity: 0;
+}
+
+.agent-gui-node__conversation-actions
+  > button.agent-gui-node__conversation-open-window-button:not(:disabled):hover,
+.agent-gui-node__conversation-actions
+  > button.agent-gui-node__conversation-open-window-button:not(
+    :disabled
+  ):focus-visible,
+.agent-gui-node__conversation-actions
+  > button.agent-gui-node__conversation-open-window-button:not(
+    :disabled
+  ):active {
+  background: transparent;
+  background-color: transparent;
+  color: var(--text-primary);
+}
+
+.agent-gui-node__conversation-actions
+  > button.agent-gui-node__conversation-open-window-button:not(:disabled):hover
+  svg,
+.agent-gui-node__conversation-actions
+  > button.agent-gui-node__conversation-open-window-button:not(
+    :disabled
+  ):focus-visible
+  svg,
+.agent-gui-node__conversation-actions
+  > button.agent-gui-node__conversation-open-window-button:not(:disabled):active
+  svg {
+  color: var(--text-primary);
+  fill: currentColor;
 }
 
 .agent-gui-node__conversation-actions
@@ -4817,6 +4849,7 @@ button.agent-gui-node__conversation-section-toggle:hover
 }
 
 .agent-gui-node__conversation-delete-button:disabled,
+.agent-gui-node__conversation-open-window-button:disabled,
 .agent-gui-node__conversation-pin-button:disabled {
   cursor: not-allowed;
   opacity: 0.4;

--- a/packages/agent/gui/app/renderer/agentactivity.css
+++ b/packages/agent/gui/app/renderer/agentactivity.css
@@ -4793,7 +4793,6 @@ button.agent-gui-node__conversation-section-toggle:hover
   > button.agent-gui-node__conversation-open-window-button:not(:disabled):active
   svg {
   color: var(--text-primary);
-  fill: currentColor;
 }
 
 .agent-gui-node__conversation-actions

--- a/packages/agent/gui/app/renderer/i18n/locales/en.ts
+++ b/packages/agent/gui/app/renderer/i18n/locales/en.ts
@@ -796,6 +796,7 @@ export const en = {
       shortcutEnter: "Enter",
       shortcutCmdEnter: "Cmd + Enter",
       shortcutCtrEnter: "Ctr + Enter",
+      openConversationWindow: "Open session in new window",
       deleteSession: "Delete session",
       pinSession: "Pin session",
       unpinSession: "Unpin session",

--- a/packages/agent/gui/app/renderer/i18n/locales/zh-CN.ts
+++ b/packages/agent/gui/app/renderer/i18n/locales/zh-CN.ts
@@ -733,6 +733,7 @@ export const zhCN = {
       shortcutEnter: "Enter",
       shortcutCmdEnter: "Cmd + Enter",
       shortcutCtrEnter: "Ctr + Enter",
+      openConversationWindow: "在新窗口打开会话",
       deleteSession: "删除会话",
       pinSession: "置顶会话",
       unpinSession: "取消置顶",

--- a/packages/agent/gui/workbench/launch.test.ts
+++ b/packages/agent/gui/workbench/launch.test.ts
@@ -78,7 +78,7 @@ describe("agent gui workbench launch contract", () => {
       dockEntryId: "agent-gui",
       instanceId: "agent-gui:codex:session:session-2",
       provider: "codex",
-      reuseDockEntryNode: true,
+      reuseDockEntryNode: false,
       targetAgentSessionId: "session-2"
     });
   });

--- a/packages/agent/gui/workbench/launch.ts
+++ b/packages/agent/gui/workbench/launch.ts
@@ -190,7 +190,7 @@ export function createAgentGuiWorkbenchLaunchDescriptor(
     dockEntryId: request.dockEntryId ?? agentGuiWorkbenchDockEntryId(provider),
     instanceId,
     provider,
-    reuseDockEntryNode: Boolean(targetAgentSessionId),
+    reuseDockEntryNode: false,
     targetAgentSessionId
   };
 }


### PR DESCRIPTION
## Summary
- Add a conversation rail hover action for opening a session in its own Agent GUI workbench window.
- Launch target sessions with a distinct workbench instance instead of reusing the existing dock entry node.
- Keep the action out of the header and preserve the existing pin/delete ordering.

Closes #158

## Validation
- Verified this split branch no longer contains the file-entry or permission-menu hunks from the prerelease aggregate branch.
- Temporary worktree package-local tests could not resolve workspace dependencies because the worktree has no installed package-local node_modules layout.
- The prerelease aggregate branch containing this final diff was user-accepted before PR splitting.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an “Open session in new window” action for agent conversations that launches the selected session in a separate window.
* **Design**
  * Refreshed the conversation action rail/button layout and updated hover/focus/active + disabled styling for the new action.
* **Bug Fixes**
  * Updated agent GUI workbench launch behavior to avoid reusing the existing dock entry node when opening exact session instances.
* **Translations**
  * Added English and Simplified Chinese strings for the new “open in new window” label/action.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->