### PR TITLE
fix(agent-gui): close Message Center on outside press

### DIFF
--- a/packages/agent/gui/agent-message-center/WorkspaceAgentMessageCenterPanel.spec.tsx
+++ b/packages/agent/gui/agent-message-center/WorkspaceAgentMessageCenterPanel.spec.tsx
@@ -837,6 +837,30 @@ describe("WorkspaceAgentMessageCenterCard", () => {
 });
 
 describe("WorkspaceAgentMessageCenterPanel", () => {
+  it("closes immediately when the user presses outside the panel", async () => {
+    const onClose = vi.fn();
+    render(
+      <WorkspaceAgentMessageCenterPanel
+        open
+        model={emptyModel}
+        onClose={onClose}
+        onOpenChat={vi.fn()}
+        onSubmitPrompt={vi.fn()}
+      />
+    );
+    await new Promise<void>((resolve) => {
+      window.setTimeout(resolve, 0);
+    });
+
+    fireEvent.pointerDown(document.body, {
+      button: 0,
+      ctrlKey: false,
+      pointerType: "mouse"
+    });
+
+    expect(onClose).toHaveBeenCalledOnce();
+  });
+
   it("groups visible message center items by status when selected", () => {
     render(
       <WorkspaceAgentMessageCenterPanel

--- a/packages/agent/gui/agent-message-center/WorkspaceAgentMessageCenterPanel.tsx
+++ b/packages/agent/gui/agent-message-center/WorkspaceAgentMessageCenterPanel.tsx
@@ -431,6 +431,10 @@ function WorkspaceAgentMessageCenterPanelContent({
         portalContainer={portalContainer ?? undefined}
         showOverlay={false}
         aria-label={t("agentHost.workspaceAgentMessageCenterTitle")}
+        onPointerDownOutside={(event) => {
+          event.preventDefault();
+          onClose();
+        }}
       >
         <TooltipProvider delayDuration={MESSAGE_CENTER_TOOLTIP_DELAY_MS}>
           <div className="flex-none border-b border-[var(--border-1)] px-3.5 pt-3 pb-3">


### PR DESCRIPTION
## Summary
- Close the Message Center immediately when pointer-down happens outside the panel.
- Add coverage for outside-press dismissal.

Closes #219

## Validation
- Commit pre-hook passed oxfmt, oxlint, and staged boundary checks.
- Full pre-push hook was attempted separately and hit unrelated Go/environment failures outside this TS-only change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Message center panel now closes when users click or touch outside of it, providing a more intuitive interaction experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->