### PR TITLE
feat(agent): surface Codex capability catalog

### DIFF
--- a/apps/desktop/src/renderer/src/features/workspace-agent/services/createDesktopAgentHostApi.test.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-agent/services/createDesktopAgentHostApi.test.ts
@@ -975,7 +975,8 @@ test("desktop agent host api loads composer options through tuttid without creat
               }
             ]
           },
-          skills: []
+          skills: [],
+          capabilityCatalog: []
         };
       }
     })
@@ -2840,7 +2841,8 @@ function createTuttidClient(
           reasoningEffort: settings.reasoningEffort ?? null,
           speed: null
         },
-        skills: []
+        skills: [],
+        capabilityCatalog: []
       };
     },
     async listWorkspaceAgentSessions() {

--- a/apps/desktop/src/renderer/src/features/workspace-agent/services/desktopAgentActivityAdapter.test.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-agent/services/desktopAgentActivityAdapter.test.ts
@@ -302,7 +302,8 @@ test("desktop agent activity adapter normalizes provider composer options", asyn
               }
             ]
           },
-          skills: []
+          skills: [],
+          capabilityCatalog: []
         };
       }
     }),
@@ -446,7 +447,8 @@ test("desktop agent activity adapter normalizes legacy runtime config options", 
               }
             ]
           },
-          skills: []
+          skills: [],
+          capabilityCatalog: []
         };
       }
     }),
@@ -763,7 +765,8 @@ function createTuttidClient(
           options: []
         },
         runtimeContext: {},
-        skills: []
+        skills: [],
+        capabilityCatalog: []
       };
     },
     async submitWorkspaceAgentInteractive() {

--- a/apps/desktop/src/renderer/src/features/workspace-agent/services/desktopAgentActivityAdapter.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-agent/services/desktopAgentActivityAdapter.ts
@@ -1,5 +1,6 @@
 import type {
   AgentActivityAdapter,
+  AgentActivityComposerCapabilityOption,
   AgentActivityComposerOptions,
   AgentActivityComposerPermissionConfig,
   AgentActivityComposerSettingOption,
@@ -468,6 +469,16 @@ export function agentActivityComposerOptionsFromTuttidResult(
   );
   const skillsFromResult = skillOptionsFromValue(result.skills);
   const skillsFromRuntimeContext = skillOptionsFromValue(runtimeContext.skills);
+  const capabilitiesFromResult = capabilityOptionsFromValue(
+    result.capabilityCatalog
+  );
+  const capabilitiesFromRuntimeContext = capabilityOptionsFromValue(
+    runtimeContext.capabilityCatalog
+  );
+  const capabilityCatalog =
+    capabilitiesFromResult.length > 0
+      ? capabilitiesFromResult
+      : capabilitiesFromRuntimeContext;
   return {
     provider: normalizeText(result.provider) ?? provider,
     models:
@@ -494,6 +505,7 @@ export function agentActivityComposerOptionsFromTuttidResult(
     runtimeContext,
     skills:
       skillsFromResult.length > 0 ? skillsFromResult : skillsFromRuntimeContext,
+    capabilityCatalog,
     loadedAtUnixMs: Date.now()
   };
 }
@@ -644,12 +656,16 @@ function skillOptionsFromValue(
     seen.add(trigger);
     const description = normalizeText(record.description);
     const pluginName = normalizeText(record.pluginName);
+    const path = normalizeText(record.path);
+    const kind = normalizeSkillKind(record.kind);
     options.push({
       name,
       trigger,
       sourceKind,
       ...(description ? { description } : {}),
-      ...(pluginName ? { pluginName } : {})
+      ...(pluginName ? { pluginName } : {}),
+      ...(path ? { path } : {}),
+      ...(kind ? { kind } : {})
     });
   }
   return options;
@@ -666,6 +682,120 @@ function normalizeSkillSourceKind(
     case "plugin":
     case "system":
     case "tutti-injected":
+    case "connector":
+      return normalized;
+    default:
+      return null;
+  }
+}
+
+function normalizeSkillKind(
+  value: unknown
+): AgentActivityComposerSkillOption["kind"] | null {
+  const normalized = normalizeText(value);
+  switch (normalized) {
+    case "skill":
+    case "connector":
+      return normalized;
+    default:
+      return null;
+  }
+}
+
+function capabilityOptionsFromValue(
+  value: unknown
+): AgentActivityComposerCapabilityOption[] {
+  if (!Array.isArray(value)) {
+    return [];
+  }
+  const options: AgentActivityComposerCapabilityOption[] = [];
+  const seen = new Set<string>();
+  for (const item of value) {
+    const record = recordValue(item);
+    const id = normalizeText(record.id);
+    const kind = normalizeCapabilityKind(record.kind);
+    const name = normalizeText(record.name);
+    const label = normalizeText(record.label) ?? name;
+    const status = normalizeCapabilityStatus(record.status);
+    const invocation = normalizeCapabilityInvocation(record.invocation);
+    if (
+      !id ||
+      !kind ||
+      !name ||
+      !label ||
+      !status ||
+      !invocation ||
+      seen.has(id)
+    ) {
+      continue;
+    }
+    seen.add(id);
+    const description = normalizeText(record.description);
+    const source = normalizeText(record.source);
+    const pluginName = normalizeText(record.pluginName);
+    const serverName = normalizeText(record.serverName);
+    const toolName = normalizeText(record.toolName);
+    const trigger = normalizeText(record.trigger);
+    const path = normalizeText(record.path);
+    options.push({
+      id,
+      kind,
+      name,
+      label,
+      status,
+      invocation,
+      ...(description ? { description } : {}),
+      ...(source ? { source } : {}),
+      ...(pluginName ? { pluginName } : {}),
+      ...(serverName ? { serverName } : {}),
+      ...(toolName ? { toolName } : {}),
+      ...(trigger ? { trigger } : {}),
+      ...(path ? { path } : {})
+    });
+  }
+  return options;
+}
+
+function normalizeCapabilityKind(
+  value: unknown
+): AgentActivityComposerCapabilityOption["kind"] | null {
+  const normalized = normalizeText(value);
+  switch (normalized) {
+    case "skill":
+    case "plugin":
+    case "connector":
+    case "mcpServer":
+    case "mcpTool":
+      return normalized;
+    default:
+      return null;
+  }
+}
+
+function normalizeCapabilityStatus(
+  value: unknown
+): AgentActivityComposerCapabilityOption["status"] | null {
+  const normalized = normalizeText(value);
+  switch (normalized) {
+    case "available":
+    case "disabled":
+    case "authRequired":
+    case "setupRequired":
+    case "unsupported":
+      return normalized;
+    default:
+      return null;
+  }
+}
+
+function normalizeCapabilityInvocation(
+  value: unknown
+): AgentActivityComposerCapabilityOption["invocation"] | null {
+  const normalized = normalizeText(value);
+  switch (normalized) {
+    case "promptItem":
+    case "textTrigger":
+    case "none":
       return normalized;
     default:
       return null;

--- a/apps/desktop/src/renderer/src/features/workspace-app-center/services/internal/workspaceAppCenterService.test.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-app-center/services/internal/workspaceAppCenterService.test.ts
@@ -976,7 +976,8 @@ test("WorkspaceAppCenterService normalizes provider configuration", async () => 
             ]
           },
           runtimeContext: {},
-          skills: []
+          skills: [],
+          capabilityCatalog: []
         };
       }
     })
@@ -1033,7 +1034,8 @@ test("WorkspaceAppCenterService makes effective permission default visible", asy
             options: []
           },
           runtimeContext: {},
-          skills: []
+          skills: [],
+          capabilityCatalog: []
         };
       }
     })
@@ -1331,7 +1333,8 @@ function createTuttidClient(
           options: []
         },
         runtimeContext: {},
-        skills: []
+        skills: [],
+        capabilityCatalog: []
       };
     },
     ...overrides

--- a/packages/agent/activity-core/src/capabilities.test.ts
+++ b/packages/agent/activity-core/src/capabilities.test.ts
@@ -54,7 +54,9 @@ test("imageInput resolves from the capabilities list only", () => {
 
 test("vocabulary matches the Go side", () => {
   assert.deepEqual([...AGENT_CAPABILITY_KEYS].sort(), [
+    "browserUse",
     "compact",
+    "computerUse",
     "imageInput",
     "interrupt",
     "planMode",

--- a/packages/agent/activity-core/src/controller.ts
+++ b/packages/agent/activity-core/src/controller.ts
@@ -502,6 +502,9 @@ function cloneAgentActivityComposerOptions(
       : (options.permissionConfig ?? null),
     runtimeContext: cloneJSONRecord(options.runtimeContext),
     skills: options.skills.map((skill) => ({ ...skill })),
+    capabilityCatalog: (options.capabilityCatalog ?? []).map((capability) => ({
+      ...capability
+    })),
     loadedAtUnixMs: options.loadedAtUnixMs
   };
 }

--- a/packages/agent/activity-core/src/index.ts
+++ b/packages/agent/activity-core/src/index.ts
@@ -35,6 +35,7 @@ export type {
   AgentActivityCancelReason,
   AgentActivityCancelSessionInput,
   AgentActivityCancelSessionResult,
+  AgentActivityComposerCapabilityOption,
   AgentActivityComposerOptions,
   AgentActivityComposerPermissionConfig,
   AgentActivityComposerPermissionModeOption,

--- a/packages/agent/activity-core/src/types.ts
+++ b/packages/agent/activity-core/src/types.ts
@@ -102,9 +102,33 @@ export interface AgentActivityComposerSkillOption {
     | "bundled"
     | "plugin"
     | "system"
-    | "tutti-injected";
+    | "tutti-injected"
+    | "connector";
   description?: string;
   pluginName?: string;
+  path?: string;
+  kind?: "skill" | "connector";
+}
+
+export interface AgentActivityComposerCapabilityOption {
+  id: string;
+  kind: "skill" | "plugin" | "connector" | "mcpServer" | "mcpTool";
+  name: string;
+  label: string;
+  status:
+    | "available"
+    | "disabled"
+    | "authRequired"
+    | "setupRequired"
+    | "unsupported";
+  invocation: "promptItem" | "textTrigger" | "none";
+  description?: string;
+  source?: string;
+  pluginName?: string;
+  serverName?: string;
+  toolName?: string;
+  trigger?: string;
+  path?: string;
 }
 
 export interface AgentActivityComposerPermissionModeOption {
@@ -143,6 +167,7 @@ export interface AgentActivityComposerOptions {
   permissionConfig?: AgentActivityComposerPermissionConfig | null;
   runtimeContext?: Record<string, unknown>;
   skills: AgentActivityComposerSkillOption[];
+  capabilityCatalog?: AgentActivityComposerCapabilityOption[];
   loadedAtUnixMs: number;
 }
 
@@ -237,12 +262,13 @@ export interface AgentActivitySendInput {
 }
 
 export interface AgentPromptContentBlock {
-  type: "text" | "image";
+  type: "text" | "image" | "skill" | "mention";
   text?: string;
   mimeType?: "image/png" | "image/jpeg" | "image/webp";
   data?: string;
   attachmentId?: string;
   name?: string;
+  path?: string;
 }
 
 export interface AgentActivityCancelSessionInput {

--- a/packages/agent/daemon/runtime/codex_appserver_events.go
+++ b/packages/agent/daemon/runtime/codex_appserver_events.go
@@ -1115,6 +1115,13 @@ func appServerUserInput(content []PromptContentBlock) []map[string]any {
 				"type": "image",
 				"url":  "data:" + firstNonEmpty(block.MimeType, "image/png") + ";base64," + block.Data,
 			})
+		case "skill", "mention":
+			item := map[string]any{
+				"type": block.Type,
+				"name": block.Name,
+				"path": block.Path,
+			}
+			out = append(out, item)
 		}
 	}
 	return out

--- a/packages/agent/daemon/runtime/codex_appserver_events_test.go
+++ b/packages/agent/daemon/runtime/codex_appserver_events_test.go
@@ -79,6 +79,24 @@ func TestAppServerUserInputAnswers(t *testing.T) {
 	}
 }
 
+func TestAppServerUserInputIncludesSkillAndMentionItems(t *testing.T) {
+	t.Parallel()
+
+	got := appServerUserInput([]PromptContentBlock{
+		{Type: "text", Text: "use these"},
+		{Type: "skill", Name: "review", Path: "/tmp/review/SKILL.md"},
+		{Type: "mention", Name: "GitHub", Path: "app://github"},
+	})
+	want := []map[string]any{
+		{"type": "text", "text": "use these"},
+		{"type": "skill", "name": "review", "path": "/tmp/review/SKILL.md"},
+		{"type": "mention", "name": "GitHub", "path": "app://github"},
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("appServerUserInput = %#v, want %#v", got, want)
+	}
+}
+
 // TestCodexAppServerAdapterApplyTokenUsagePrefersLastRequest verifies that
 // usedTokens reflects the most-recent request's context size ("last"), not the
 // running sum across all requests in the thread ("total").  The two diverge

--- a/packages/agent/daemon/runtime/prompt_content.go
+++ b/packages/agent/daemon/runtime/prompt_content.go
@@ -30,6 +30,17 @@ func normalizeRuntimePromptContent(content []PromptContentBlock) []PromptContent
 				AttachmentID: strings.TrimSpace(block.AttachmentID),
 				Name:         strings.TrimSpace(block.Name),
 			})
+		case "skill", "mention":
+			name := strings.TrimSpace(block.Name)
+			path := strings.TrimSpace(block.Path)
+			if name == "" || path == "" {
+				continue
+			}
+			out = append(out, PromptContentBlock{
+				Type: strings.TrimSpace(block.Type),
+				Name: name,
+				Path: path,
+			})
 		}
 	}
 	return out
@@ -57,6 +68,17 @@ func normalizeRuntimePromptContentForValidation(content []PromptContentBlock) []
 				Data:         strings.TrimSpace(block.Data),
 				AttachmentID: strings.TrimSpace(block.AttachmentID),
 				Name:         strings.TrimSpace(block.Name),
+			})
+		case "skill", "mention":
+			name := strings.TrimSpace(block.Name)
+			path := strings.TrimSpace(block.Path)
+			if name == "" || path == "" {
+				continue
+			}
+			out = append(out, PromptContentBlock{
+				Type: strings.TrimSpace(block.Type),
+				Name: name,
+				Path: path,
 			})
 		}
 	}

--- a/packages/agent/daemon/runtime/types.go
+++ b/packages/agent/daemon/runtime/types.go
@@ -148,6 +148,7 @@ type PromptContentBlock struct {
 	Data         string `json:"data,omitempty"`
 	AttachmentID string `json:"attachmentId,omitempty"`
 	Name         string `json:"name,omitempty"`
+	Path         string `json:"path,omitempty"`
 }
 
 type Session struct {

--- a/packages/agent/gui/agent-gui/agentGuiNode/AgentComposer.spec.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/AgentComposer.spec.tsx
@@ -172,15 +172,19 @@ vi.mock("./AgentSlashCommandPalette", () => ({
     onSelectCapability,
     onSelectCapabilitySettings,
     onSelectSkill,
+    connectorsGroupLabel,
+    pluginsGroupLabel,
     skillsGroupLabel
   }: {
     capabilitiesGroupLabel?: string;
     commandsGroupLabel: string;
+    connectorsGroupLabel: string;
     entries: any[];
     onSelect: (command: any) => void;
     onSelectCapability?: (capability: any) => void;
     onSelectCapabilitySettings?: (capability: any) => void;
     onSelectSkill: (skill: any) => void;
+    pluginsGroupLabel: string;
     skillsGroupLabel: string;
   }) => (
     <div data-testid="mock-slash-palette">
@@ -190,8 +194,28 @@ vi.mock("./AgentSlashCommandPalette", () => ({
       {entries.some((entry) => entry.type === "capability") ? (
         <div>{capabilitiesGroupLabel}</div>
       ) : null}
-      {entries.some((entry) => entry.type === "skill") ? (
+      {entries.some(
+        (entry) =>
+          entry.type === "skill" &&
+          entry.skill?.sourceKind !== "plugin" &&
+          entry.skill?.sourceKind !== "connector" &&
+          entry.skill?.kind !== "connector"
+      ) ? (
         <div>{skillsGroupLabel}</div>
+      ) : null}
+      {entries.some(
+        (entry) =>
+          entry.type === "skill" && entry.skill?.sourceKind === "plugin"
+      ) ? (
+        <div>{pluginsGroupLabel}</div>
+      ) : null}
+      {entries.some(
+        (entry) =>
+          entry.type === "skill" &&
+          (entry.skill?.sourceKind === "connector" ||
+            entry.skill?.kind === "connector")
+      ) ? (
+        <div>{connectorsGroupLabel}</div>
       ) : null}
       {entries.map((entry) => (
         <div key={entry.key}>
@@ -2841,6 +2865,9 @@ function createLabels(): Parameters<typeof AgentComposer>[0]["labels"] {
     slashPaletteCommandsGroup: "命令",
     slashPaletteCapabilitiesGroup: "能力",
     slashPaletteSkillsGroup: "技能",
+    slashPalettePluginsGroup: "插件",
+    slashPaletteConnectorsGroup: "连接器",
+    slashPaletteMcpGroup: "MCP",
     slashStatusTitle: "Status",
     slashStatusSession: "Session",
     slashStatusBaseUrl: "Base URL",

--- a/packages/agent/gui/agent-gui/agentGuiNode/AgentComposer.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/AgentComposer.tsx
@@ -241,6 +241,9 @@ export interface AgentComposerProps {
     slashPaletteCommandsGroup: string;
     slashPaletteCapabilitiesGroup: string;
     slashPaletteSkillsGroup: string;
+    slashPalettePluginsGroup: string;
+    slashPaletteConnectorsGroup: string;
+    slashPaletteMcpGroup: string;
     slashStatusTitle: string;
     slashStatusSession: string;
     slashStatusBaseUrl: string;
@@ -2346,6 +2349,9 @@ export function AgentComposer({
                 commandsGroupLabel={labels.slashPaletteCommandsGroup}
                 capabilitiesGroupLabel={labels.slashPaletteCapabilitiesGroup}
                 skillsGroupLabel={labels.slashPaletteSkillsGroup}
+                pluginsGroupLabel={labels.slashPalettePluginsGroup}
+                connectorsGroupLabel={labels.slashPaletteConnectorsGroup}
+                mcpGroupLabel={labels.slashPaletteMcpGroup}
                 onHighlightChange={setHighlightedIndex}
                 onSelect={selectCommand}
                 onSelectCapability={selectCapability}

--- a/packages/agent/gui/agent-gui/agentGuiNode/AgentGUINode.spec.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/AgentGUINode.spec.tsx
@@ -4009,6 +4009,41 @@ describe("AgentGUINode", () => {
     ).toBeTruthy();
   });
 
+  it("groups slash palette plugin and connector entries into separate sections", () => {
+    mockViewModel = createViewModel({
+      activeConversationId: "session-1",
+      draftPrompt: "/",
+      availableCommands: [],
+      availableSkills: [
+        {
+          name: "frontend-design",
+          trigger: "$frontend-design",
+          sourceKind: "plugin",
+          pluginName: "product-design",
+          description: "Design product UI"
+        },
+        {
+          name: "Google Drive",
+          trigger: "$google-drive",
+          sourceKind: "connector",
+          kind: "connector",
+          description: "Reference files from Drive"
+        }
+      ]
+    });
+    renderAgentGUINode();
+
+    expect(
+      screen.getByText("agentHost.agentGui.slashPalettePluginsGroup")
+    ).toBeTruthy();
+    expect(
+      screen.getByText("agentHost.agentGui.slashPaletteConnectorsGroup")
+    ).toBeTruthy();
+    expect(
+      screen.queryByText("agentHost.agentGui.slashPaletteSkillsGroup")
+    ).toBeNull();
+  });
+
   it("hides slash palette group headers when only one section is present", () => {
     mockViewModel = createViewModel({
       activeConversationId: "session-1",

--- a/packages/agent/gui/agent-gui/agentGuiNode/AgentGUINode.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/AgentGUINode.tsx
@@ -1045,6 +1045,13 @@ export const AgentGUINode = memo(function AgentGUINode({
         "agentHost.agentGui.slashPaletteCapabilitiesGroup"
       ),
       slashPaletteSkillsGroup: t("agentHost.agentGui.slashPaletteSkillsGroup"),
+      slashPalettePluginsGroup: t(
+        "agentHost.agentGui.slashPalettePluginsGroup"
+      ),
+      slashPaletteConnectorsGroup: t(
+        "agentHost.agentGui.slashPaletteConnectorsGroup"
+      ),
+      slashPaletteMcpGroup: t("agentHost.agentGui.slashPaletteMcpGroup"),
       browserUseCapabilityLabel: t(
         "agentHost.agentGui.browserUseCapabilityLabel"
       ),

--- a/packages/agent/gui/agent-gui/agentGuiNode/AgentGUINodeView.layout.spec.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/AgentGUINodeView.layout.spec.tsx
@@ -1433,6 +1433,9 @@ function createLabels(): AgentGUIViewLabels {
     slashPaletteCommandsGroup: "slashPaletteCommandsGroup",
     slashPaletteCapabilitiesGroup: "slashPaletteCapabilitiesGroup",
     slashPaletteSkillsGroup: "slashPaletteSkillsGroup",
+    slashPalettePluginsGroup: "slashPalettePluginsGroup",
+    slashPaletteConnectorsGroup: "slashPaletteConnectorsGroup",
+    slashPaletteMcpGroup: "slashPaletteMcpGroup",
     browserUseCapabilityLabel: "browserUseCapabilityLabel",
     browserUseCapabilityDescription: "browserUseCapabilityDescription",
     browserUseCapabilityDescriptionAutoConnect:

--- a/packages/agent/gui/agent-gui/agentGuiNode/AgentGUINodeView.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/AgentGUINodeView.tsx
@@ -318,6 +318,9 @@ export interface AgentGUIViewLabels {
   slashPaletteCommandsGroup: string;
   slashPaletteCapabilitiesGroup: string;
   slashPaletteSkillsGroup: string;
+  slashPalettePluginsGroup: string;
+  slashPaletteConnectorsGroup: string;
+  slashPaletteMcpGroup: string;
   browserUseCapabilityLabel: string;
   browserUseCapabilityDescription: string;
   browserUseCapabilityDescriptionAutoConnect: string;
@@ -1679,6 +1682,9 @@ const AgentGUIDetailPane = memo(function AgentGUIDetailPane({
       slashPaletteCommandsGroup: labels.slashPaletteCommandsGroup,
       slashPaletteCapabilitiesGroup: labels.slashPaletteCapabilitiesGroup,
       slashPaletteSkillsGroup: labels.slashPaletteSkillsGroup,
+      slashPalettePluginsGroup: labels.slashPalettePluginsGroup,
+      slashPaletteConnectorsGroup: labels.slashPaletteConnectorsGroup,
+      slashPaletteMcpGroup: labels.slashPaletteMcpGroup,
       browserUseCapabilityLabel: labels.browserUseCapabilityLabel,
       browserUseCapabilityDescription: labels.browserUseCapabilityDescription,
       browserUseCapabilityDescriptionAutoConnect:
@@ -1798,6 +1804,9 @@ const AgentGUIDetailPane = memo(function AgentGUIDetailPane({
       labels.computerUseCapabilitySettingsLabel,
       labels.slashPaletteCapabilitiesGroup,
       labels.slashPaletteCommandsGroup,
+      labels.slashPaletteConnectorsGroup,
+      labels.slashPaletteMcpGroup,
+      labels.slashPalettePluginsGroup,
       labels.slashPaletteSkillsGroup,
       labels.slashStatusClose,
       labels.slashStatusContext,

--- a/packages/agent/gui/agent-gui/agentGuiNode/AgentSlashCommandPalette.spec.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/AgentSlashCommandPalette.spec.tsx
@@ -11,6 +11,9 @@ describe("AgentSlashCommandPalette", () => {
         commandsGroupLabel="Commands"
         capabilitiesGroupLabel="Capabilities"
         skillsGroupLabel="Skills"
+        pluginsGroupLabel="Plugins"
+        connectorsGroupLabel="Connectors"
+        mcpGroupLabel="MCP"
         highlightedIndex={0}
         entries={[
           {
@@ -78,6 +81,9 @@ describe("AgentSlashCommandPalette", () => {
         commandsGroupLabel="Commands"
         capabilitiesGroupLabel="Capabilities"
         skillsGroupLabel="Skills"
+        pluginsGroupLabel="Plugins"
+        connectorsGroupLabel="Connectors"
+        mcpGroupLabel="MCP"
         highlightedIndex={0}
         entries={[
           {
@@ -119,6 +125,9 @@ describe("AgentSlashCommandPalette", () => {
         commandsGroupLabel="Commands"
         capabilitiesGroupLabel="Capabilities"
         skillsGroupLabel="Skills"
+        pluginsGroupLabel="Plugins"
+        connectorsGroupLabel="Connectors"
+        mcpGroupLabel="MCP"
         highlightedIndex={0}
         entries={[
           {
@@ -161,6 +170,9 @@ describe("AgentSlashCommandPalette", () => {
         commandsGroupLabel="Commands"
         capabilitiesGroupLabel="Capabilities"
         skillsGroupLabel="Skills"
+        pluginsGroupLabel="Plugins"
+        connectorsGroupLabel="Connectors"
+        mcpGroupLabel="MCP"
         highlightedIndex={0}
         entries={[
           {
@@ -195,5 +207,52 @@ describe("AgentSlashCommandPalette", () => {
       "border-t",
       "border-[var(--border-1)]"
     );
+  });
+
+  it("separates plugin and connector skill entries into source groups", () => {
+    render(
+      <AgentSlashCommandPalette
+        label="Slash commands"
+        commandsGroupLabel="Commands"
+        capabilitiesGroupLabel="Capabilities"
+        skillsGroupLabel="Skills"
+        pluginsGroupLabel="Plugins"
+        connectorsGroupLabel="Connectors"
+        mcpGroupLabel="MCP"
+        highlightedIndex={0}
+        entries={[
+          {
+            type: "skill",
+            key: "skill:plugin-review",
+            label: "plugin-review",
+            skill: {
+              name: "plugin-review",
+              trigger: "$plugin-review",
+              sourceKind: "plugin",
+              pluginName: "review-tools"
+            }
+          },
+          {
+            type: "skill",
+            key: "skill:google-drive",
+            label: "google-drive",
+            skill: {
+              name: "Google Drive",
+              trigger: "$google-drive",
+              sourceKind: "connector",
+              kind: "connector"
+            }
+          }
+        ]}
+        onHighlightChange={vi.fn()}
+        onSelect={vi.fn()}
+        onSelectCapability={vi.fn()}
+        onSelectSkill={vi.fn()}
+      />
+    );
+
+    expect(screen.getByText("Plugins")).toBeInTheDocument();
+    expect(screen.getByText("Connectors")).toBeInTheDocument();
+    expect(screen.queryByText("Skills")).toBeNull();
   });
 });

--- a/packages/agent/gui/agent-gui/agentGuiNode/AgentSlashCommandPalette.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/AgentSlashCommandPalette.tsx
@@ -37,6 +37,9 @@ interface AgentSlashCommandPaletteProps {
   commandsGroupLabel: string;
   capabilitiesGroupLabel: string;
   skillsGroupLabel: string;
+  pluginsGroupLabel: string;
+  connectorsGroupLabel: string;
+  mcpGroupLabel: string;
   onHighlightChange: (index: number) => void;
   onSelect: (command: AgentSessionCommand) => void;
   onSelectCapability: (capability: AgentSlashCommandCapability) => void;
@@ -70,6 +73,9 @@ export function AgentSlashCommandPalette({
   commandsGroupLabel,
   capabilitiesGroupLabel,
   skillsGroupLabel,
+  pluginsGroupLabel,
+  connectorsGroupLabel,
+  mcpGroupLabel,
   onHighlightChange,
   onSelect,
   onSelectCapability,
@@ -115,11 +121,14 @@ export function AgentSlashCommandPalette({
                   : paletteStyles.groupHeaderSeparated
               )}
             >
-              {groupType === "command"
-                ? commandsGroupLabel
-                : groupType === "capability"
-                  ? capabilitiesGroupLabel
-                  : skillsGroupLabel}
+              {labelForEntryGroupType(groupType, {
+                commandsGroupLabel,
+                capabilitiesGroupLabel,
+                skillsGroupLabel,
+                pluginsGroupLabel,
+                connectorsGroupLabel,
+                mcpGroupLabel
+              })}
             </div>
           ) : null;
         return (
@@ -188,10 +197,55 @@ export function AgentSlashCommandPalette({
   );
 }
 
-type AgentSlashPaletteEntryGroup = "command" | "capability" | "skill";
+type AgentSlashPaletteEntryGroup =
+  | "command"
+  | "capability"
+  | "skill"
+  | "plugin"
+  | "connector"
+  | "mcp";
 
 function entryGroupType(
   entry: AgentSlashPaletteEntry
 ): AgentSlashPaletteEntryGroup {
-  return entry.type;
+  if (entry.type !== "skill") {
+    return entry.type;
+  }
+  if (
+    entry.skill.sourceKind === "connector" ||
+    entry.skill.kind === "connector"
+  ) {
+    return "connector";
+  }
+  if (entry.skill.sourceKind === "plugin") {
+    return "plugin";
+  }
+  return "skill";
+}
+
+function labelForEntryGroupType(
+  groupType: AgentSlashPaletteEntryGroup,
+  labels: {
+    commandsGroupLabel: string;
+    capabilitiesGroupLabel: string;
+    skillsGroupLabel: string;
+    pluginsGroupLabel: string;
+    connectorsGroupLabel: string;
+    mcpGroupLabel: string;
+  }
+): string {
+  switch (groupType) {
+    case "command":
+      return labels.commandsGroupLabel;
+    case "capability":
+      return labels.capabilitiesGroupLabel;
+    case "plugin":
+      return labels.pluginsGroupLabel;
+    case "connector":
+      return labels.connectorsGroupLabel;
+    case "mcp":
+      return labels.mcpGroupLabel;
+    case "skill":
+      return labels.skillsGroupLabel;
+  }
 }

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/agentGuiController.composerHelpers.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/agentGuiController.composerHelpers.ts
@@ -85,7 +85,37 @@ export function speedSelectionFromComposerOptions(
 export function providerSkillsFromComposerOptions(
   options: AgentActivityComposerOptions | null
 ): AgentGUIProviderSkillOption[] {
-  return options?.skills.map((skill) => ({ ...skill })) ?? [];
+  if (!options) {
+    return [];
+  }
+  return dedupeProviderSkills([
+    ...options.skills.map((skill) => ({ ...skill })),
+    ...(options.capabilityCatalog ?? [])
+      .filter(
+        (capability) =>
+          capability.invocation === "promptItem" &&
+          (capability.kind === "skill" || capability.kind === "connector") &&
+          capability.status === "available" &&
+          Boolean(capability.trigger) &&
+          Boolean(capability.path)
+      )
+      .map((capability): AgentGUIProviderSkillOption => {
+        const isConnector = capability.kind === "connector";
+        return {
+          name: isConnector ? capability.label : capability.name,
+          trigger: capability.trigger!,
+          sourceKind: isConnector ? "connector" : "plugin",
+          kind: isConnector ? "connector" : "skill",
+          ...(capability.description
+            ? { description: capability.description }
+            : {}),
+          ...(capability.pluginName
+            ? { pluginName: capability.pluginName }
+            : {}),
+          ...(capability.path ? { path: capability.path } : {})
+        };
+      })
+  ]);
 }
 
 export function areProviderSkillOptionsEqual(
@@ -97,7 +127,9 @@ export function areProviderSkillOptionsEqual(
     left.trigger === right.trigger &&
     left.sourceKind === right.sourceKind &&
     left.description === right.description &&
-    left.pluginName === right.pluginName
+    left.pluginName === right.pluginName &&
+    left.path === right.path &&
+    left.kind === right.kind
   );
 }
 
@@ -111,6 +143,22 @@ export function areProviderSkillOptionListsEqual(
       areProviderSkillOptionsEqual(skill, right[index]!)
     )
   );
+}
+
+function dedupeProviderSkills(
+  skills: readonly AgentGUIProviderSkillOption[]
+): AgentGUIProviderSkillOption[] {
+  const seen = new Set<string>();
+  const result: AgentGUIProviderSkillOption[] = [];
+  for (const skill of skills) {
+    const key = skill.trigger || `${skill.kind ?? "skill"}:${skill.name}`;
+    if (seen.has(key)) {
+      continue;
+    }
+    seen.add(key);
+    result.push(skill);
+  }
+  return result;
 }
 
 export function permissionConfigFromComposerOptions(

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/agentGuiController.promptHelpers.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/agentGuiController.promptHelpers.ts
@@ -110,6 +110,14 @@ export function normalizePromptContentBlocks(
         data,
         ...(block.name?.trim() ? { name: block.name.trim() } : {})
       });
+      continue;
+    }
+    if (block.type === "skill" || block.type === "mention") {
+      const name = block.name?.trim();
+      const path = block.path?.trim();
+      if (name && path) {
+        result.push({ type: block.type, name, path });
+      }
     }
   }
   return result;

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUINodeController.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUINodeController.ts
@@ -1194,7 +1194,37 @@ function speedSelectionFromComposerOptions(
 function providerSkillsFromComposerOptions(
   options: AgentActivityComposerOptions | null
 ): AgentGUIProviderSkillOption[] {
-  return options?.skills.map((skill) => ({ ...skill })) ?? [];
+  if (!options) {
+    return [];
+  }
+  return dedupeProviderSkills([
+    ...options.skills.map((skill) => ({ ...skill })),
+    ...(options.capabilityCatalog ?? [])
+      .filter(
+        (capability) =>
+          capability.invocation === "promptItem" &&
+          (capability.kind === "skill" || capability.kind === "connector") &&
+          capability.status === "available" &&
+          Boolean(capability.trigger) &&
+          Boolean(capability.path)
+      )
+      .map((capability): AgentGUIProviderSkillOption => {
+        const isConnector = capability.kind === "connector";
+        return {
+          name: isConnector ? capability.label : capability.name,
+          trigger: capability.trigger!,
+          sourceKind: isConnector ? "connector" : "plugin",
+          kind: isConnector ? "connector" : "skill",
+          ...(capability.description
+            ? { description: capability.description }
+            : {}),
+          ...(capability.pluginName
+            ? { pluginName: capability.pluginName }
+            : {}),
+          ...(capability.path ? { path: capability.path } : {})
+        };
+      })
+  ]);
 }
 
 function areProviderSkillOptionsEqual(
@@ -1206,7 +1236,9 @@ function areProviderSkillOptionsEqual(
     left.trigger === right.trigger &&
     left.sourceKind === right.sourceKind &&
     left.description === right.description &&
-    left.pluginName === right.pluginName
+    left.pluginName === right.pluginName &&
+    left.path === right.path &&
+    left.kind === right.kind
   );
 }
 
@@ -1220,6 +1252,22 @@ function areProviderSkillOptionListsEqual(
       areProviderSkillOptionsEqual(skill, right[index]!)
     )
   );
+}
+
+function dedupeProviderSkills(
+  skills: readonly AgentGUIProviderSkillOption[]
+): AgentGUIProviderSkillOption[] {
+  const seen = new Set<string>();
+  const result: AgentGUIProviderSkillOption[] = [];
+  for (const skill of skills) {
+    const key = skill.trigger || `${skill.kind ?? "skill"}:${skill.name}`;
+    if (seen.has(key)) {
+      continue;
+    }
+    seen.add(key);
+    result.push(skill);
+  }
+  return result;
 }
 
 function areComposerSettingOptionsEqual(

--- a/packages/agent/gui/agent-gui/agentGuiNode/model/agentComposerDraft.spec.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/model/agentComposerDraft.spec.ts
@@ -31,6 +31,35 @@ describe("agentComposerDraft", () => {
     ).toEqual([{ type: "text", text: "run tests" }]);
   });
 
+  it("adds codex app-server prompt items for referenced skills and connectors", () => {
+    expect(
+      agentComposerDraftToPromptContent({
+        draft: { prompt: "$review $github check this", images: [] },
+        provider: "codex",
+        skills: [
+          {
+            name: "review",
+            trigger: "$review",
+            sourceKind: "plugin",
+            path: "/tmp/review/SKILL.md",
+            kind: "skill"
+          },
+          {
+            name: "GitHub",
+            trigger: "$github",
+            sourceKind: "connector",
+            path: "app://github",
+            kind: "connector"
+          }
+        ]
+      })
+    ).toEqual([
+      { type: "text", text: "$review $github check this" },
+      { type: "skill", name: "review", path: "/tmp/review/SKILL.md" },
+      { type: "mention", name: "GitHub", path: "app://github" }
+    ]);
+  });
+
   it("converts image-only drafts into prompt content", () => {
     expect(
       agentComposerDraftToPromptContent({

--- a/packages/agent/gui/agent-gui/agentGuiNode/model/agentComposerDraft.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/model/agentComposerDraft.ts
@@ -4,7 +4,10 @@ import type {
   AgentComposerDraftImage,
   AgentGUIProviderSkillOption
 } from "./agentGuiNodeTypes";
-import { promptForProviderSkills } from "./agentSkillOptions";
+import {
+  promptForProviderSkills,
+  skillTriggerForPrefix
+} from "./agentSkillOptions";
 
 export const MAX_AGENT_COMPOSER_DRAFT_IMAGES = 8;
 
@@ -53,6 +56,14 @@ export function normalizeAgentPromptContentBlocks(
         data,
         ...(block.name?.trim() ? { name: block.name.trim() } : {})
       });
+      continue;
+    }
+    if (block.type === "skill" || block.type === "mention") {
+      const name = block.name?.trim();
+      const path = block.path?.trim();
+      if (name && path) {
+        result.push({ type: block.type, name, path });
+      }
     }
   }
   return result;
@@ -105,14 +116,18 @@ export function agentComposerDraftToPromptContent(input: {
   provider: string;
   skills: readonly AgentGUIProviderSkillOption[];
 }): AgentPromptContentBlock[] {
+  const prompt = promptForProviderSkills({
+    prompt: input.draft.prompt,
+    provider: input.provider,
+    skills: input.skills
+  });
   return normalizeAgentPromptContentBlocks([
-    ...textPromptContent(
-      promptForProviderSkills({
-        prompt: input.draft.prompt,
-        provider: input.provider,
-        skills: input.skills
-      })
-    ),
+    ...textPromptContent(prompt),
+    ...promptItemBlocksForProviderSkills({
+      prompt,
+      provider: input.provider,
+      skills: input.skills
+    }),
     ...input.draft.images
       .slice(0, MAX_AGENT_COMPOSER_DRAFT_IMAGES)
       .map((image) => ({
@@ -122,6 +137,41 @@ export function agentComposerDraftToPromptContent(input: {
         name: image.name
       }))
   ]);
+}
+
+function promptItemBlocksForProviderSkills(input: {
+  prompt: string;
+  provider: string;
+  skills: readonly AgentGUIProviderSkillOption[];
+}): AgentPromptContentBlock[] {
+  if (input.provider.trim() !== "codex") {
+    return [];
+  }
+  const result: AgentPromptContentBlock[] = [];
+  for (const skill of input.skills) {
+    const path = skill.path?.trim();
+    if (!path) {
+      continue;
+    }
+    const trigger = skillTriggerForPrefix(skill, "$");
+    if (!trigger || !promptHasTrigger(input.prompt, trigger)) {
+      continue;
+    }
+    result.push({
+      type: skill.kind === "connector" ? "mention" : "skill",
+      name: skill.name,
+      path
+    });
+  }
+  return result;
+}
+
+function promptHasTrigger(prompt: string, trigger: string): boolean {
+  return new RegExp(`(^|\\s)${escapeRegExp(trigger)}(?=$|\\s)`).test(prompt);
+}
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 }
 
 export function textPromptContent(prompt: string): AgentPromptContentBlock[] {

--- a/packages/agent/gui/agent-gui/agentGuiNode/model/agentGuiNodeTypes.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/model/agentGuiNodeTypes.ts
@@ -66,9 +66,12 @@ export interface AgentGUIProviderSkillOption {
     | "bundled"
     | "plugin"
     | "system"
-    | "tutti-injected";
+    | "tutti-injected"
+    | "connector";
   description?: string;
   pluginName?: string;
+  path?: string;
+  kind?: "skill" | "connector";
 }
 
 export interface AgentComposerDraftImage {

--- a/packages/agent/gui/app/renderer/i18n/locales/en.ts
+++ b/packages/agent/gui/app/renderer/i18n/locales/en.ts
@@ -817,6 +817,9 @@ export const en = {
       slashPaletteCommandsGroup: "Commands",
       slashPaletteCapabilitiesGroup: "Capabilities",
       slashPaletteSkillsGroup: "Skills",
+      slashPalettePluginsGroup: "Plugins",
+      slashPaletteConnectorsGroup: "Connectors",
+      slashPaletteMcpGroup: "MCP",
       browserUseCapabilityLabel: "Browser",
       browserUseCapabilityDescription: "Let the agent use a browser.",
       browserUseCapabilityDescriptionAutoConnect:

--- a/packages/agent/gui/app/renderer/i18n/locales/zh-CN.ts
+++ b/packages/agent/gui/app/renderer/i18n/locales/zh-CN.ts
@@ -754,6 +754,9 @@ export const zhCN = {
       slashPaletteCommandsGroup: "命令",
       slashPaletteCapabilitiesGroup: "能力",
       slashPaletteSkillsGroup: "技能",
+      slashPalettePluginsGroup: "插件",
+      slashPaletteConnectorsGroup: "连接器",
+      slashPaletteMcpGroup: "MCP",
       browserUseCapabilityLabel: "浏览器",
       browserUseCapabilityDescription: "让 Agent 使用浏览器。",
       browserUseCapabilityDescriptionAutoConnect:

--- a/packages/agent/gui/shared/contracts/dto/agentSession.ts
+++ b/packages/agent/gui/shared/contracts/dto/agentSession.ts
@@ -175,12 +175,13 @@ export interface AgentHostExecAgentSessionInput {
 }
 
 export interface AgentPromptContentBlock {
-  type: "text" | "image";
+  type: "text" | "image" | "skill" | "mention";
   text?: string;
   mimeType?: "image/png" | "image/jpeg" | "image/webp";
   data?: string;
   attachmentId?: string;
   name?: string;
+  path?: string;
 }
 
 export interface AgentHostExecAgentSessionResult {

--- a/packages/clients/tuttid-ts/src/generated/index.ts
+++ b/packages/clients/tuttid-ts/src/generated/index.ts
@@ -142,6 +142,7 @@ export type {
   AgentProviderAuthStatus,
   AgentProviderAvailability,
   AgentProviderAvailabilityStatus,
+  AgentProviderCapabilityOption,
   AgentProviderCliStatus,
   AgentProviderComposerConfig,
   AgentProviderComposerConfigOptionValue,

--- a/packages/clients/tuttid-ts/src/generated/types.gen.ts
+++ b/packages/clients/tuttid-ts/src/generated/types.gen.ts
@@ -735,6 +735,7 @@ export type AgentProviderComposerOptionsResponse = {
     [key: string]: unknown;
   };
   skills: Array<AgentProviderSkillOption>;
+  capabilityCatalog: Array<AgentProviderCapabilityOption>;
 };
 
 export type AgentProviderSkillOption = {
@@ -749,6 +750,28 @@ export type AgentProviderSkillOption = {
     | "tutti-injected";
   description?: string;
   pluginName?: string;
+  path?: string;
+};
+
+export type AgentProviderCapabilityOption = {
+  id: string;
+  kind: "skill" | "plugin" | "connector" | "mcpServer" | "mcpTool";
+  name: string;
+  label: string;
+  description?: string;
+  status:
+    | "available"
+    | "disabled"
+    | "authRequired"
+    | "setupRequired"
+    | "unsupported";
+  source?: string;
+  pluginName?: string;
+  serverName?: string;
+  toolName?: string;
+  trigger?: string;
+  path?: string;
+  invocation: "promptItem" | "textTrigger" | "none";
 };
 
 export type AgentProviderAvailabilityStatus =
@@ -1033,12 +1056,13 @@ export type SendWorkspaceAgentSessionInputRequest = {
 };
 
 export type AgentPromptContentBlock = {
-  type: "text" | "image";
+  type: "text" | "image" | "skill" | "mention";
   text?: string;
   mimeType?: "image/png" | "image/jpeg" | "image/webp";
   data?: string;
   attachmentId?: string;
   name?: string;
+  path?: string;
 };
 
 export type WorkspaceAgentSessionAttachmentResponse = {

--- a/packages/clients/tuttid-ts/src/index.test.ts
+++ b/packages/clients/tuttid-ts/src/index.test.ts
@@ -599,7 +599,8 @@ test("shared tuttid client loads agent provider composer options", async () => {
               }
             ]
           },
-          skills: []
+          skills: [],
+          capabilityCatalog: []
         } satisfies AgentProviderComposerOptionsResponse),
         {
           status: 200,
@@ -664,7 +665,8 @@ test("shared tuttid client loads agent provider composer options", async () => {
         }
       ]
     },
-    skills: []
+    skills: [],
+    capabilityCatalog: []
   } satisfies AgentProviderComposerOptionsResponse);
 });
 

--- a/services/tuttid/agent_runtime_adapter.go
+++ b/services/tuttid/agent_runtime_adapter.go
@@ -115,6 +115,7 @@ func runtimePromptContentFromService(content []agentservice.PromptContentBlock) 
 			Data:         block.Data,
 			AttachmentID: block.AttachmentID,
 			Name:         block.Name,
+			Path:         block.Path,
 		})
 	}
 	return result

--- a/services/tuttid/api/daemon_agent_composer_options.go
+++ b/services/tuttid/api/daemon_agent_composer_options.go
@@ -1,0 +1,130 @@
+package api
+
+import (
+	"strings"
+
+	tuttigenerated "github.com/tutti-os/tutti/services/tuttid/api/generated"
+	agentservice "github.com/tutti-os/tutti/services/tuttid/service/agent"
+)
+
+func generatedAgentProviderSkillOptions(options []agentservice.ComposerSkillOption) []tuttigenerated.AgentProviderSkillOption {
+	if len(options) == 0 {
+		return []tuttigenerated.AgentProviderSkillOption{}
+	}
+	result := make([]tuttigenerated.AgentProviderSkillOption, 0, len(options))
+	for _, option := range options {
+		name := strings.TrimSpace(option.Name)
+		trigger := strings.TrimSpace(option.Trigger)
+		sourceKind := strings.TrimSpace(option.SourceKind)
+		if name == "" || trigger == "" || sourceKind == "" {
+			continue
+		}
+		generated := tuttigenerated.AgentProviderSkillOption{
+			Name:       name,
+			Trigger:    trigger,
+			SourceKind: tuttigenerated.AgentProviderSkillOptionSourceKind(sourceKind),
+		}
+		if description := strings.TrimSpace(option.Description); description != "" {
+			generated.Description = optionalStringPointer(description)
+		}
+		if pluginName := strings.TrimSpace(option.PluginName); pluginName != "" {
+			generated.PluginName = optionalStringPointer(pluginName)
+		}
+		if path := strings.TrimSpace(option.Path); path != "" {
+			generated.Path = optionalStringPointer(path)
+		}
+		result = append(result, generated)
+	}
+	return result
+}
+
+func generatedAgentProviderCapabilityOptions(options []agentservice.ComposerCapabilityOption) []tuttigenerated.AgentProviderCapabilityOption {
+	if len(options) == 0 {
+		return []tuttigenerated.AgentProviderCapabilityOption{}
+	}
+	result := make([]tuttigenerated.AgentProviderCapabilityOption, 0, len(options))
+	for _, option := range options {
+		id := strings.TrimSpace(option.ID)
+		kind := strings.TrimSpace(option.Kind)
+		name := strings.TrimSpace(option.Name)
+		label := strings.TrimSpace(option.Label)
+		status := strings.TrimSpace(option.Status)
+		invocation := strings.TrimSpace(option.Invocation)
+		if id == "" || kind == "" || name == "" || label == "" || status == "" || invocation == "" {
+			continue
+		}
+		generated := tuttigenerated.AgentProviderCapabilityOption{
+			Id:         id,
+			Kind:       tuttigenerated.AgentProviderCapabilityOptionKind(kind),
+			Name:       name,
+			Label:      label,
+			Status:     tuttigenerated.AgentProviderCapabilityOptionStatus(status),
+			Invocation: tuttigenerated.AgentProviderCapabilityOptionInvocation(invocation),
+		}
+		if description := strings.TrimSpace(option.Description); description != "" {
+			generated.Description = optionalStringPointer(description)
+		}
+		if source := strings.TrimSpace(option.Source); source != "" {
+			generated.Source = optionalStringPointer(source)
+		}
+		if pluginName := strings.TrimSpace(option.PluginName); pluginName != "" {
+			generated.PluginName = optionalStringPointer(pluginName)
+		}
+		if serverName := strings.TrimSpace(option.ServerName); serverName != "" {
+			generated.ServerName = optionalStringPointer(serverName)
+		}
+		if toolName := strings.TrimSpace(option.ToolName); toolName != "" {
+			generated.ToolName = optionalStringPointer(toolName)
+		}
+		if trigger := strings.TrimSpace(option.Trigger); trigger != "" {
+			generated.Trigger = optionalStringPointer(trigger)
+		}
+		if path := strings.TrimSpace(option.Path); path != "" {
+			generated.Path = optionalStringPointer(path)
+		}
+		result = append(result, generated)
+	}
+	return result
+}
+
+// generatedComposerConfigOptionPointer projects an optional composer config
+// (the orthogonal speed dimension) and omits it entirely for providers that do
+// not expose it, so the GUI hides the control.
+func generatedComposerConfigOptionPointer(config agentservice.ComposerConfigOption) *tuttigenerated.AgentProviderComposerConfig {
+	if !config.Configurable && len(config.Options) == 0 {
+		return nil
+	}
+	generated := generatedComposerConfigOption(config)
+	return &generated
+}
+
+func generatedComposerConfigOption(config agentservice.ComposerConfigOption) tuttigenerated.AgentProviderComposerConfig {
+	result := tuttigenerated.AgentProviderComposerConfig{
+		Configurable: config.Configurable,
+		Options:      make([]tuttigenerated.AgentProviderComposerConfigOptionValue, 0, len(config.Options)),
+	}
+	if strings.TrimSpace(config.CurrentValue) != "" {
+		result.CurrentValue = optionalStringPointer(config.CurrentValue)
+	}
+	if strings.TrimSpace(config.DefaultValue) != "" {
+		result.DefaultValue = optionalStringPointer(config.DefaultValue)
+	}
+	for _, option := range config.Options {
+		value := strings.TrimSpace(option.Value)
+		id := strings.TrimSpace(option.ID)
+		label := strings.TrimSpace(option.Label)
+		if value == "" || id == "" || label == "" {
+			continue
+		}
+		resultOption := tuttigenerated.AgentProviderComposerConfigOptionValue{
+			Id:    id,
+			Label: label,
+			Value: value,
+		}
+		if strings.TrimSpace(option.Description) != "" {
+			resultOption.Description = optionalStringPointer(option.Description)
+		}
+		result.Options = append(result.Options, resultOption)
+	}
+	return result
+}

--- a/services/tuttid/api/daemon_agent_sessions.go
+++ b/services/tuttid/api/daemon_agent_sessions.go
@@ -559,6 +559,7 @@ func composerSettingsPatchFromGenerated(settings tuttigenerated.AgentSessionComp
 func generatedAgentProviderComposerOptions(options agentservice.ComposerOptions) tuttigenerated.AgentProviderComposerOptionsResponse {
 	effectiveSettings := generatedAgentSessionComposerSettings(options.EffectiveSettings)
 	return tuttigenerated.AgentProviderComposerOptionsResponse{
+		CapabilityCatalog: generatedAgentProviderCapabilityOptions(options.CapabilityCatalog),
 		EffectiveSettings: effectiveSettings,
 		ModelConfig:       generatedComposerConfigOption(options.ModelConfig),
 		PermissionConfig:  generatedPermissionConfig(options.PermissionConfig),
@@ -568,76 +569,6 @@ func generatedAgentProviderComposerOptions(options agentservice.ComposerOptions)
 		RuntimeContext:    options.RuntimeContext,
 		Skills:            generatedAgentProviderSkillOptions(options.Skills),
 	}
-}
-
-func generatedAgentProviderSkillOptions(options []agentservice.ComposerSkillOption) []tuttigenerated.AgentProviderSkillOption {
-	if len(options) == 0 {
-		return []tuttigenerated.AgentProviderSkillOption{}
-	}
-	result := make([]tuttigenerated.AgentProviderSkillOption, 0, len(options))
-	for _, option := range options {
-		name := strings.TrimSpace(option.Name)
-		trigger := strings.TrimSpace(option.Trigger)
-		sourceKind := strings.TrimSpace(option.SourceKind)
-		if name == "" || trigger == "" || sourceKind == "" {
-			continue
-		}
-		generated := tuttigenerated.AgentProviderSkillOption{
-			Name:       name,
-			Trigger:    trigger,
-			SourceKind: tuttigenerated.AgentProviderSkillOptionSourceKind(sourceKind),
-		}
-		if description := strings.TrimSpace(option.Description); description != "" {
-			generated.Description = optionalStringPointer(description)
-		}
-		if pluginName := strings.TrimSpace(option.PluginName); pluginName != "" {
-			generated.PluginName = optionalStringPointer(pluginName)
-		}
-		result = append(result, generated)
-	}
-	return result
-}
-
-// generatedComposerConfigOptionPointer projects an optional composer config
-// (the orthogonal speed dimension) and omits it entirely for providers that do
-// not expose it, so the GUI hides the control.
-func generatedComposerConfigOptionPointer(config agentservice.ComposerConfigOption) *tuttigenerated.AgentProviderComposerConfig {
-	if !config.Configurable && len(config.Options) == 0 {
-		return nil
-	}
-	generated := generatedComposerConfigOption(config)
-	return &generated
-}
-
-func generatedComposerConfigOption(config agentservice.ComposerConfigOption) tuttigenerated.AgentProviderComposerConfig {
-	result := tuttigenerated.AgentProviderComposerConfig{
-		Configurable: config.Configurable,
-		Options:      make([]tuttigenerated.AgentProviderComposerConfigOptionValue, 0, len(config.Options)),
-	}
-	if strings.TrimSpace(config.CurrentValue) != "" {
-		result.CurrentValue = optionalStringPointer(config.CurrentValue)
-	}
-	if strings.TrimSpace(config.DefaultValue) != "" {
-		result.DefaultValue = optionalStringPointer(config.DefaultValue)
-	}
-	for _, option := range config.Options {
-		value := strings.TrimSpace(option.Value)
-		id := strings.TrimSpace(option.ID)
-		label := strings.TrimSpace(option.Label)
-		if value == "" || id == "" || label == "" {
-			continue
-		}
-		resultOption := tuttigenerated.AgentProviderComposerConfigOptionValue{
-			Id:    id,
-			Label: label,
-			Value: value,
-		}
-		if strings.TrimSpace(option.Description) != "" {
-			resultOption.Description = optionalStringPointer(option.Description)
-		}
-		result.Options = append(result.Options, resultOption)
-	}
-	return result
 }
 
 func generatedAgentSessionComposerSettings(settings agentservice.ComposerSettings) tuttigenerated.AgentSessionComposerSettings {
@@ -769,6 +700,9 @@ func agentPromptContentFromGenerated(content []tuttigenerated.AgentPromptContent
 		}
 		if block.Name != nil {
 			item.Name = *block.Name
+		}
+		if block.Path != nil {
+			item.Path = *block.Path
 		}
 		result = append(result, item)
 	}

--- a/services/tuttid/api/generated/types.gen.go
+++ b/services/tuttid/api/generated/types.gen.go
@@ -39,16 +39,22 @@ func (e AgentPromptContentBlockMimeType) Valid() bool {
 
 // Defines values for AgentPromptContentBlockType.
 const (
-	Image AgentPromptContentBlockType = "image"
-	Text  AgentPromptContentBlockType = "text"
+	AgentPromptContentBlockTypeImage   AgentPromptContentBlockType = "image"
+	AgentPromptContentBlockTypeMention AgentPromptContentBlockType = "mention"
+	AgentPromptContentBlockTypeSkill   AgentPromptContentBlockType = "skill"
+	AgentPromptContentBlockTypeText    AgentPromptContentBlockType = "text"
 )
 
 // Valid indicates whether the value is a known member of the AgentPromptContentBlockType enum.
 func (e AgentPromptContentBlockType) Valid() bool {
 	switch e {
-	case Image:
+	case AgentPromptContentBlockTypeImage:
 		return true
-	case Text:
+	case AgentPromptContentBlockTypeMention:
+		return true
+	case AgentPromptContentBlockTypeSkill:
+		return true
+	case AgentPromptContentBlockTypeText:
 		return true
 	default:
 		return false
@@ -157,6 +163,81 @@ func (e AgentProviderAvailabilityStatus) Valid() bool {
 	case AgentProviderAvailabilityStatusUnknown:
 		return true
 	case AgentProviderAvailabilityStatusUnsupported:
+		return true
+	default:
+		return false
+	}
+}
+
+// Defines values for AgentProviderCapabilityOptionInvocation.
+const (
+	AgentProviderCapabilityOptionInvocationNone        AgentProviderCapabilityOptionInvocation = "none"
+	AgentProviderCapabilityOptionInvocationPromptItem  AgentProviderCapabilityOptionInvocation = "promptItem"
+	AgentProviderCapabilityOptionInvocationTextTrigger AgentProviderCapabilityOptionInvocation = "textTrigger"
+)
+
+// Valid indicates whether the value is a known member of the AgentProviderCapabilityOptionInvocation enum.
+func (e AgentProviderCapabilityOptionInvocation) Valid() bool {
+	switch e {
+	case AgentProviderCapabilityOptionInvocationNone:
+		return true
+	case AgentProviderCapabilityOptionInvocationPromptItem:
+		return true
+	case AgentProviderCapabilityOptionInvocationTextTrigger:
+		return true
+	default:
+		return false
+	}
+}
+
+// Defines values for AgentProviderCapabilityOptionKind.
+const (
+	AgentProviderCapabilityOptionKindConnector AgentProviderCapabilityOptionKind = "connector"
+	AgentProviderCapabilityOptionKindMcpServer AgentProviderCapabilityOptionKind = "mcpServer"
+	AgentProviderCapabilityOptionKindMcpTool   AgentProviderCapabilityOptionKind = "mcpTool"
+	AgentProviderCapabilityOptionKindPlugin    AgentProviderCapabilityOptionKind = "plugin"
+	AgentProviderCapabilityOptionKindSkill     AgentProviderCapabilityOptionKind = "skill"
+)
+
+// Valid indicates whether the value is a known member of the AgentProviderCapabilityOptionKind enum.
+func (e AgentProviderCapabilityOptionKind) Valid() bool {
+	switch e {
+	case AgentProviderCapabilityOptionKindConnector:
+		return true
+	case AgentProviderCapabilityOptionKindMcpServer:
+		return true
+	case AgentProviderCapabilityOptionKindMcpTool:
+		return true
+	case AgentProviderCapabilityOptionKindPlugin:
+		return true
+	case AgentProviderCapabilityOptionKindSkill:
+		return true
+	default:
+		return false
+	}
+}
+
+// Defines values for AgentProviderCapabilityOptionStatus.
+const (
+	AuthRequired  AgentProviderCapabilityOptionStatus = "authRequired"
+	Available     AgentProviderCapabilityOptionStatus = "available"
+	Disabled      AgentProviderCapabilityOptionStatus = "disabled"
+	SetupRequired AgentProviderCapabilityOptionStatus = "setupRequired"
+	Unsupported   AgentProviderCapabilityOptionStatus = "unsupported"
+)
+
+// Valid indicates whether the value is a known member of the AgentProviderCapabilityOptionStatus enum.
+func (e AgentProviderCapabilityOptionStatus) Valid() bool {
+	switch e {
+	case AuthRequired:
+		return true
+	case Available:
+		return true
+	case Disabled:
+		return true
+	case SetupRequired:
+		return true
+	case Unsupported:
 		return true
 	default:
 		return false
@@ -888,25 +969,25 @@ func (e WorkspaceAppCatalogLoadStatus) Valid() bool {
 
 // Defines values for WorkspaceAppCliStatus.
 const (
-	Active  WorkspaceAppCliStatus = "active"
-	Error   WorkspaceAppCliStatus = "error"
-	None    WorkspaceAppCliStatus = "none"
-	Pending WorkspaceAppCliStatus = "pending"
-	Warning WorkspaceAppCliStatus = "warning"
+	WorkspaceAppCliStatusActive  WorkspaceAppCliStatus = "active"
+	WorkspaceAppCliStatusError   WorkspaceAppCliStatus = "error"
+	WorkspaceAppCliStatusNone    WorkspaceAppCliStatus = "none"
+	WorkspaceAppCliStatusPending WorkspaceAppCliStatus = "pending"
+	WorkspaceAppCliStatusWarning WorkspaceAppCliStatus = "warning"
 )
 
 // Valid indicates whether the value is a known member of the WorkspaceAppCliStatus enum.
 func (e WorkspaceAppCliStatus) Valid() bool {
 	switch e {
-	case Active:
+	case WorkspaceAppCliStatusActive:
 		return true
-	case Error:
+	case WorkspaceAppCliStatusError:
 		return true
-	case None:
+	case WorkspaceAppCliStatusNone:
 		return true
-	case Pending:
+	case WorkspaceAppCliStatusPending:
 		return true
-	case Warning:
+	case WorkspaceAppCliStatusWarning:
 		return true
 	default:
 		return false
@@ -1271,6 +1352,7 @@ type AgentPromptContentBlock struct {
 	Data         *string                          `json:"data,omitempty"`
 	MimeType     *AgentPromptContentBlockMimeType `json:"mimeType,omitempty"`
 	Name         *string                          `json:"name,omitempty"`
+	Path         *string                          `json:"path,omitempty"`
 	Text         *string                          `json:"text,omitempty"`
 	Type         AgentPromptContentBlockType      `json:"type"`
 }
@@ -1338,6 +1420,32 @@ type AgentProviderAvailability struct {
 // AgentProviderAvailabilityStatus defines model for AgentProviderAvailabilityStatus.
 type AgentProviderAvailabilityStatus string
 
+// AgentProviderCapabilityOption defines model for AgentProviderCapabilityOption.
+type AgentProviderCapabilityOption struct {
+	Description *string                                 `json:"description,omitempty"`
+	Id          string                                  `json:"id"`
+	Invocation  AgentProviderCapabilityOptionInvocation `json:"invocation"`
+	Kind        AgentProviderCapabilityOptionKind       `json:"kind"`
+	Label       string                                  `json:"label"`
+	Name        string                                  `json:"name"`
+	Path        *string                                 `json:"path,omitempty"`
+	PluginName  *string                                 `json:"pluginName,omitempty"`
+	ServerName  *string                                 `json:"serverName,omitempty"`
+	Source      *string                                 `json:"source,omitempty"`
+	Status      AgentProviderCapabilityOptionStatus     `json:"status"`
+	ToolName    *string                                 `json:"toolName,omitempty"`
+	Trigger     *string                                 `json:"trigger,omitempty"`
+}
+
+// AgentProviderCapabilityOptionInvocation defines model for AgentProviderCapabilityOption.Invocation.
+type AgentProviderCapabilityOptionInvocation string
+
+// AgentProviderCapabilityOptionKind defines model for AgentProviderCapabilityOption.Kind.
+type AgentProviderCapabilityOptionKind string
+
+// AgentProviderCapabilityOptionStatus defines model for AgentProviderCapabilityOption.Status.
+type AgentProviderCapabilityOptionStatus string
+
 // AgentProviderCliStatus defines model for AgentProviderCliStatus.
 type AgentProviderCliStatus struct {
 	BinaryPath *string `json:"binaryPath,omitempty"`
@@ -1363,14 +1471,15 @@ type AgentProviderComposerConfigOptionValue struct {
 
 // AgentProviderComposerOptionsResponse defines model for AgentProviderComposerOptionsResponse.
 type AgentProviderComposerOptionsResponse struct {
-	EffectiveSettings AgentSessionComposerSettings `json:"effectiveSettings"`
-	ModelConfig       AgentProviderComposerConfig  `json:"modelConfig"`
-	PermissionConfig  PermissionConfig             `json:"permissionConfig"`
-	Provider          WorkspaceAgentProvider       `json:"provider"`
-	ReasoningConfig   AgentProviderComposerConfig  `json:"reasoningConfig"`
-	RuntimeContext    map[string]interface{}       `json:"runtimeContext"`
-	Skills            []AgentProviderSkillOption   `json:"skills"`
-	SpeedConfig       *AgentProviderComposerConfig `json:"speedConfig,omitempty"`
+	CapabilityCatalog []AgentProviderCapabilityOption `json:"capabilityCatalog"`
+	EffectiveSettings AgentSessionComposerSettings    `json:"effectiveSettings"`
+	ModelConfig       AgentProviderComposerConfig     `json:"modelConfig"`
+	PermissionConfig  PermissionConfig                `json:"permissionConfig"`
+	Provider          WorkspaceAgentProvider          `json:"provider"`
+	ReasoningConfig   AgentProviderComposerConfig     `json:"reasoningConfig"`
+	RuntimeContext    map[string]interface{}          `json:"runtimeContext"`
+	Skills            []AgentProviderSkillOption      `json:"skills"`
+	SpeedConfig       *AgentProviderComposerConfig    `json:"speedConfig,omitempty"`
 }
 
 // AgentProviderProbeResponse defines model for AgentProviderProbeResponse.
@@ -1391,6 +1500,7 @@ type AgentProviderProbeStatus string
 type AgentProviderSkillOption struct {
 	Description *string                            `json:"description,omitempty"`
 	Name        string                             `json:"name"`
+	Path        *string                            `json:"path,omitempty"`
 	PluginName  *string                            `json:"pluginName,omitempty"`
 	SourceKind  AgentProviderSkillOptionSourceKind `json:"sourceKind"`
 	Trigger     string                             `json:"trigger"`

--- a/services/tuttid/api/openapi/tuttid.v1.yaml
+++ b/services/tuttid/api/openapi/tuttid.v1.yaml
@@ -4616,6 +4616,7 @@ components:
         - effectiveSettings
         - runtimeContext
         - skills
+        - capabilityCatalog
       properties:
         provider:
           $ref: "#/components/schemas/WorkspaceAgentProvider"
@@ -4636,6 +4637,10 @@ components:
           type: array
           items:
             $ref: "#/components/schemas/AgentProviderSkillOption"
+        capabilityCatalog:
+          type: array
+          items:
+            $ref: "#/components/schemas/AgentProviderCapabilityOption"
     AgentProviderSkillOption:
       type: object
       additionalProperties: false
@@ -4661,6 +4666,64 @@ components:
           type: string
         pluginName:
           type: string
+        path:
+          type: string
+    AgentProviderCapabilityOption:
+      type: object
+      additionalProperties: false
+      required:
+        - id
+        - kind
+        - name
+        - label
+        - status
+        - invocation
+      properties:
+        id:
+          type: string
+          minLength: 1
+        kind:
+          type: string
+          enum:
+            - skill
+            - plugin
+            - connector
+            - mcpServer
+            - mcpTool
+        name:
+          type: string
+          minLength: 1
+        label:
+          type: string
+          minLength: 1
+        description:
+          type: string
+        status:
+          type: string
+          enum:
+            - available
+            - disabled
+            - authRequired
+            - setupRequired
+            - unsupported
+        source:
+          type: string
+        pluginName:
+          type: string
+        serverName:
+          type: string
+        toolName:
+          type: string
+        trigger:
+          type: string
+        path:
+          type: string
+        invocation:
+          type: string
+          enum:
+            - promptItem
+            - textTrigger
+            - none
     AgentProviderAvailabilityStatus:
       type: string
       enum:
@@ -5422,6 +5485,8 @@ components:
           enum:
             - text
             - image
+            - skill
+            - mention
         text:
           type: string
         mimeType:
@@ -5435,6 +5500,8 @@ components:
         attachmentId:
           type: string
         name:
+          type: string
+        path:
           type: string
     WorkspaceAgentSessionAttachmentResponse:
       type: object

--- a/services/tuttid/api/workspace/apps.go
+++ b/services/tuttid/api/workspace/apps.go
@@ -293,14 +293,14 @@ func generatedAppCLIIssues(issues []workspacebiz.AppCLIIssue) []tuttigenerated.W
 func generatedAppCLIStatus(status workspacebiz.AppCLIStatus) tuttigenerated.WorkspaceAppCliStatus {
 	switch status {
 	case workspacebiz.AppCLIStatusPending:
-		return tuttigenerated.Pending
+		return tuttigenerated.WorkspaceAppCliStatusPending
 	case workspacebiz.AppCLIStatusActive:
-		return tuttigenerated.Active
+		return tuttigenerated.WorkspaceAppCliStatusActive
 	case workspacebiz.AppCLIStatusWarning:
-		return tuttigenerated.Warning
+		return tuttigenerated.WorkspaceAppCliStatusWarning
 	case workspacebiz.AppCLIStatusError:
-		return tuttigenerated.Error
+		return tuttigenerated.WorkspaceAppCliStatusError
 	default:
-		return tuttigenerated.None
+		return tuttigenerated.WorkspaceAppCliStatusNone
 	}
 }

--- a/services/tuttid/service/agent/codex_capability_catalog.go
+++ b/services/tuttid/service/agent/codex_capability_catalog.go
@@ -1,0 +1,496 @@
+package agent
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os/exec"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/tutti-os/tutti/packages/agentactivity/daemon/runtimecmd"
+	"github.com/tutti-os/tutti/services/tuttid/biz/agentprovider"
+)
+
+const codexAppServerCapabilityListTimeout = 8 * time.Second
+
+type CodexCLICapabilityLister struct {
+	Command          string
+	Args             []string
+	Timeout          time.Duration
+	Environ          func() []string
+	HomeDir          func() (string, error)
+	IsExecutableFile func(string) bool
+	LookPath         func(string) (string, error)
+}
+
+func discoverComposerCapabilityOptions(
+	ctx context.Context,
+	provider string,
+	cwd string,
+	fallbackSkills []ComposerSkillOption,
+) ([]ComposerCapabilityOption, []string) {
+	fallback := composerCapabilityCatalogFromSkills(provider, fallbackSkills)
+	if agentprovider.Normalize(provider) != agentprovider.Codex {
+		return fallback, nil
+	}
+	options, err := (CodexCLICapabilityLister{}).List(ctx, cwd)
+	if err != nil {
+		return fallback, []string{err.Error()}
+	}
+	return mergeComposerCapabilityOptions(fallback, options), nil
+}
+
+func (l CodexCLICapabilityLister) List(ctx context.Context, cwd string) ([]ComposerCapabilityOption, error) {
+	timeout := l.Timeout
+	if timeout <= 0 {
+		timeout = codexAppServerCapabilityListTimeout
+	}
+	processCtx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+
+	command := strings.TrimSpace(l.Command)
+	if command == "" {
+		command = "codex"
+	}
+	resolver := runtimecmd.Resolver{
+		Environ:          l.Environ,
+		HomeDir:          l.HomeDir,
+		IsExecutableFile: l.IsExecutableFile,
+		LookPath:         l.LookPath,
+	}
+	processEnv := resolver.Env(nil)
+	command = resolver.Resolve(command, processEnv)
+	args := append([]string{}, l.Args...)
+	if len(args) == 0 {
+		args = []string{"app-server"}
+	}
+	cmd := exec.CommandContext(processCtx, command, args...)
+	cmd.Env = processEnv
+	cmd.WaitDelay = codexAppServerShutdownWaitDelay
+	stdin, err := cmd.StdinPipe()
+	if err != nil {
+		return nil, fmt.Errorf("open codex app-server stdin: %w", err)
+	}
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		return nil, fmt.Errorf("open codex app-server stdout: %w", err)
+	}
+	stderr, err := cmd.StderrPipe()
+	if err != nil {
+		return nil, fmt.Errorf("open codex app-server stderr: %w", err)
+	}
+	if err := cmd.Start(); err != nil {
+		return nil, fmt.Errorf("start codex app-server: %w", err)
+	}
+
+	stderrBuf := &truncatingBuffer{max: codexModelListMaxStderrBytes}
+	var stderrWG sync.WaitGroup
+	stderrWG.Add(1)
+	go func() {
+		defer stderrWG.Done()
+		_, _ = io.Copy(stderrBuf, stderr)
+	}()
+
+	defer func() {
+		_ = stdin.Close()
+		cancel()
+		_ = cmd.Wait()
+		stderrWG.Wait()
+	}()
+
+	if err := writeCodexCapabilityListRequests(stdin, cwd); err != nil {
+		return nil, err
+	}
+	options, err := readCodexCapabilityListResponses(stdout)
+	if err == nil {
+		return options, nil
+	}
+	if processCtx.Err() != nil {
+		return nil, fmt.Errorf("codex app-server capability discovery timed out: %w", processCtx.Err())
+	}
+	if stderr := strings.TrimSpace(stderrBuf.String()); stderr != "" {
+		return nil, fmt.Errorf("%w: %s", err, stderr)
+	}
+	return nil, err
+}
+
+func writeCodexCapabilityListRequests(stdin io.Writer, cwd string) error {
+	encoder := json.NewEncoder(stdin)
+	if err := encoder.Encode(map[string]any{
+		"id":     "1",
+		"method": "initialize",
+		"params": map[string]any{
+			"clientInfo": map[string]string{
+				"name":    "tuttid",
+				"version": "0.1.0",
+			},
+			"capabilities": map[string]any{
+				"experimentalApi": true,
+			},
+		},
+	}); err != nil {
+		return fmt.Errorf("write codex app-server initialize: %w", err)
+	}
+	if err := encoder.Encode(map[string]any{
+		"method": "initialized",
+		"params": map[string]any{},
+	}); err != nil {
+		return fmt.Errorf("write codex app-server initialized: %w", err)
+	}
+	cwds := []string{}
+	if trimmedCwd := strings.TrimSpace(cwd); trimmedCwd != "" {
+		cwds = append(cwds, trimmedCwd)
+	}
+	requests := []map[string]any{
+		{
+			"id":     "2",
+			"method": "skills/list",
+			"params": map[string]any{
+				"cwds":        cwds,
+				"forceReload": false,
+			},
+		},
+		{
+			"id":     "3",
+			"method": "app/list",
+			"params": map[string]any{
+				"limit":        200,
+				"forceRefetch": false,
+			},
+		},
+		{
+			"id":     "4",
+			"method": "plugin/list",
+			"params": map[string]any{
+				"limit": 200,
+			},
+		},
+		{
+			"id":     "5",
+			"method": "mcpServerStatus/list",
+			"params": map[string]any{
+				"limit":  200,
+				"detail": "toolsAndAuthOnly",
+			},
+		},
+	}
+	for _, request := range requests {
+		if err := encoder.Encode(request); err != nil {
+			return fmt.Errorf("write codex app-server %s: %w", request["method"], err)
+		}
+	}
+	return nil
+}
+
+func readCodexCapabilityListResponses(stdout io.Reader) ([]ComposerCapabilityOption, error) {
+	scanner := bufio.NewScanner(stdout)
+	scanner.Buffer(make([]byte, 0, 64*1024), codexModelListMaxLineBytes)
+	pending := map[string]struct{}{"2": {}, "3": {}, "4": {}, "5": {}}
+	options := make([]ComposerCapabilityOption, 0)
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if line == "" {
+			continue
+		}
+		var payload map[string]json.RawMessage
+		if json.Unmarshal([]byte(line), &payload) != nil {
+			continue
+		}
+		id := codexRPCIDString(payload["id"])
+		if _, ok := pending[id]; !ok {
+			continue
+		}
+		delete(pending, id)
+		if rawError, ok := payload["error"]; ok && string(rawError) != "null" {
+			if len(pending) == 0 {
+				return dedupeComposerCapabilityOptions(options), nil
+			}
+			continue
+		}
+		switch id {
+		case "2":
+			options = append(options, parseCodexSkillCapabilities(payload["result"])...)
+		case "3":
+			options = append(options, parseCodexAppCapabilities(payload["result"])...)
+		case "4":
+			options = append(options, parseCodexPluginCapabilities(payload["result"])...)
+		case "5":
+			options = append(options, parseCodexMCPCapabilities(payload["result"])...)
+		}
+		if len(pending) == 0 {
+			return dedupeComposerCapabilityOptions(options), nil
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		return nil, fmt.Errorf("read codex app-server stdout: %w", err)
+	}
+	if len(options) > 0 {
+		return dedupeComposerCapabilityOptions(options), nil
+	}
+	return nil, fmt.Errorf("codex app-server exited before capability responses")
+}
+
+func codexRPCIDString(raw json.RawMessage) string {
+	var stringID string
+	if err := json.Unmarshal(raw, &stringID); err == nil {
+		return stringID
+	}
+	var numberID int
+	if err := json.Unmarshal(raw, &numberID); err == nil {
+		return fmt.Sprintf("%d", numberID)
+	}
+	return ""
+}
+
+func parseCodexSkillCapabilities(raw json.RawMessage) []ComposerCapabilityOption {
+	var result struct {
+		Data []struct {
+			Skills []map[string]any `json:"skills"`
+		} `json:"data"`
+	}
+	if json.Unmarshal(raw, &result) != nil {
+		return nil
+	}
+	options := make([]ComposerCapabilityOption, 0)
+	for _, group := range result.Data {
+		for _, skill := range group.Skills {
+			name := codexTextValue(skill, "name")
+			if name == "" {
+				continue
+			}
+			label := firstNonEmptyString(codexTextValue(codexNestedMap(skill, "interface"), "displayName"), name)
+			description := firstNonEmptyString(
+				codexTextValue(codexNestedMap(skill, "interface"), "shortDescription"),
+				codexTextValue(skill, "description"),
+			)
+			status := "available"
+			if enabled, ok := codexBoolValue(skill, "enabled"); ok && !enabled {
+				status = "disabled"
+			}
+			path := codexTextValue(skill, "path")
+			options = append(options, ComposerCapabilityOption{
+				ID:          "skill:" + name,
+				Kind:        "skill",
+				Name:        name,
+				Label:       label,
+				Description: description,
+				Status:      status,
+				Trigger:     "$" + name,
+				Path:        path,
+				Invocation:  "promptItem",
+			})
+		}
+	}
+	return options
+}
+
+func parseCodexAppCapabilities(raw json.RawMessage) []ComposerCapabilityOption {
+	var result struct {
+		Data []map[string]any `json:"data"`
+	}
+	if json.Unmarshal(raw, &result) != nil {
+		return nil
+	}
+	options := make([]ComposerCapabilityOption, 0, len(result.Data))
+	for _, app := range result.Data {
+		id := codexTextValue(app, "id")
+		name := firstNonEmptyString(codexTextValue(app, "name"), id)
+		if id == "" || name == "" {
+			continue
+		}
+		status := "available"
+		if enabled, ok := codexBoolValue(app, "isEnabled"); ok && !enabled {
+			status = "disabled"
+		}
+		if accessible, ok := codexBoolValue(app, "isAccessible"); ok && !accessible {
+			status = "authRequired"
+		}
+		options = append(options, ComposerCapabilityOption{
+			ID:          "connector:" + id,
+			Kind:        "connector",
+			Name:        id,
+			Label:       name,
+			Description: codexTextValue(app, "description"),
+			Status:      status,
+			Trigger:     "$" + id,
+			Path:        "app://" + id,
+			Invocation:  "promptItem",
+		})
+	}
+	return options
+}
+
+func parseCodexPluginCapabilities(raw json.RawMessage) []ComposerCapabilityOption {
+	var result struct {
+		Data []map[string]any `json:"data"`
+	}
+	if json.Unmarshal(raw, &result) != nil {
+		return nil
+	}
+	options := make([]ComposerCapabilityOption, 0, len(result.Data))
+	for _, plugin := range result.Data {
+		name := firstNonEmptyString(codexTextValue(plugin, "name"), codexTextValue(plugin, "id"), codexTextValue(plugin, "pluginName"))
+		if name == "" {
+			continue
+		}
+		label := firstNonEmptyString(codexTextValue(plugin, "displayName"), codexTextValue(plugin, "title"), name)
+		options = append(options, ComposerCapabilityOption{
+			ID:          "plugin:" + name,
+			Kind:        "plugin",
+			Name:        name,
+			Label:       label,
+			Description: codexTextValue(plugin, "description"),
+			Status:      "available",
+			Source:      codexPluginSource(plugin),
+			PluginName:  name,
+			Invocation:  "none",
+		})
+	}
+	return options
+}
+
+func parseCodexMCPCapabilities(raw json.RawMessage) []ComposerCapabilityOption {
+	var result struct {
+		Data []map[string]any `json:"data"`
+	}
+	if json.Unmarshal(raw, &result) != nil {
+		return nil
+	}
+	options := make([]ComposerCapabilityOption, 0)
+	for _, server := range result.Data {
+		name := firstNonEmptyString(codexTextValue(server, "name"), codexTextValue(server, "serverName"))
+		if name == "" {
+			continue
+		}
+		status := normalizeCodexMCPStatus(codexTextValue(server, "status"))
+		options = append(options, ComposerCapabilityOption{
+			ID:         "mcpServer:" + name,
+			Kind:       "mcpServer",
+			Name:       name,
+			Label:      name,
+			Status:     status,
+			ServerName: name,
+			Invocation: "none",
+		})
+		for _, tool := range codexSliceOfMaps(server["tools"]) {
+			toolName := firstNonEmptyString(codexTextValue(tool, "name"), codexTextValue(tool, "toolName"))
+			if toolName == "" {
+				continue
+			}
+			options = append(options, ComposerCapabilityOption{
+				ID:          "mcpTool:" + name + "/" + toolName,
+				Kind:        "mcpTool",
+				Name:        toolName,
+				Label:       toolName,
+				Description: codexTextValue(tool, "description"),
+				Status:      status,
+				ServerName:  name,
+				ToolName:    toolName,
+				Invocation:  "none",
+			})
+		}
+	}
+	return options
+}
+
+func normalizeCodexMCPStatus(status string) string {
+	normalized := strings.ToLower(strings.TrimSpace(status))
+	switch {
+	case strings.Contains(normalized, "auth"):
+		return "authRequired"
+	case strings.Contains(normalized, "fail"), strings.Contains(normalized, "error"), strings.Contains(normalized, "disabled"):
+		return "setupRequired"
+	default:
+		return "available"
+	}
+}
+
+func codexPluginSource(plugin map[string]any) string {
+	source := codexNestedMap(plugin, "source")
+	if source == nil {
+		return codexTextValue(plugin, "source")
+	}
+	return firstNonEmptyString(codexTextValue(source, "type"), codexTextValue(source, "url"), codexTextValue(source, "path"))
+}
+
+func codexTextValue(values map[string]any, key string) string {
+	if values == nil {
+		return ""
+	}
+	value, ok := values[key]
+	if !ok {
+		return ""
+	}
+	switch typed := value.(type) {
+	case string:
+		return strings.TrimSpace(typed)
+	case fmt.Stringer:
+		return strings.TrimSpace(typed.String())
+	default:
+		return ""
+	}
+}
+
+func codexBoolValue(values map[string]any, key string) (bool, bool) {
+	if values == nil {
+		return false, false
+	}
+	value, ok := values[key].(bool)
+	return value, ok
+}
+
+func codexNestedMap(values map[string]any, key string) map[string]any {
+	if values == nil {
+		return nil
+	}
+	value, _ := values[key].(map[string]any)
+	return value
+}
+
+func codexSliceOfMaps(value any) []map[string]any {
+	items, ok := value.([]any)
+	if !ok {
+		return nil
+	}
+	result := make([]map[string]any, 0, len(items))
+	for _, item := range items {
+		if record, ok := item.(map[string]any); ok {
+			result = append(result, record)
+		}
+	}
+	return result
+}
+
+func mergeComposerCapabilityOptions(left []ComposerCapabilityOption, right []ComposerCapabilityOption) []ComposerCapabilityOption {
+	if len(left) == 0 {
+		return dedupeComposerCapabilityOptions(right)
+	}
+	if len(right) == 0 {
+		return dedupeComposerCapabilityOptions(left)
+	}
+	return dedupeComposerCapabilityOptions(append(append([]ComposerCapabilityOption{}, left...), right...))
+}
+
+func dedupeComposerCapabilityOptions(options []ComposerCapabilityOption) []ComposerCapabilityOption {
+	if len(options) == 0 {
+		return []ComposerCapabilityOption{}
+	}
+	seen := map[string]struct{}{}
+	result := make([]ComposerCapabilityOption, 0, len(options))
+	for _, option := range options {
+		id := strings.TrimSpace(option.ID)
+		if id == "" {
+			continue
+		}
+		if _, ok := seen[id]; ok {
+			continue
+		}
+		seen[id] = struct{}{}
+		result = append(result, option)
+	}
+	return result
+}

--- a/services/tuttid/service/agent/codex_capability_catalog_test.go
+++ b/services/tuttid/service/agent/codex_capability_catalog_test.go
@@ -1,0 +1,23 @@
+package agent
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestParseCodexCapabilityResponses(t *testing.T) {
+	skills := parseCodexSkillCapabilities(json.RawMessage(`{"data":[{"skills":[{"name":"review","description":"Review code","path":"/tmp/review/SKILL.md","enabled":true}]}]}`))
+	if len(skills) != 1 || skills[0].Kind != "skill" || skills[0].Trigger != "$review" || skills[0].Path == "" {
+		t.Fatalf("parseCodexSkillCapabilities = %#v", skills)
+	}
+
+	apps := parseCodexAppCapabilities(json.RawMessage(`{"data":[{"id":"github","name":"GitHub","description":"GitHub connector","isAccessible":true,"isEnabled":true}]}`))
+	if len(apps) != 1 || apps[0].Kind != "connector" || apps[0].Path != "app://github" || apps[0].Invocation != "promptItem" {
+		t.Fatalf("parseCodexAppCapabilities = %#v", apps)
+	}
+
+	mcp := parseCodexMCPCapabilities(json.RawMessage(`{"data":[{"name":"docs","status":"running","tools":[{"name":"search","description":"Search docs"}]}]}`))
+	if len(mcp) != 2 || mcp[0].Kind != "mcpServer" || mcp[1].Kind != "mcpTool" || mcp[1].ToolName != "search" {
+		t.Fatalf("parseCodexMCPCapabilities = %#v", mcp)
+	}
+}

--- a/services/tuttid/service/agent/composer_options.go
+++ b/services/tuttid/service/agent/composer_options.go
@@ -74,6 +74,23 @@ type ComposerSkillOption struct {
 	SourceKind  string
 	Description string
 	PluginName  string
+	Path        string
+}
+
+type ComposerCapabilityOption struct {
+	ID          string
+	Kind        string
+	Name        string
+	Label       string
+	Description string
+	Status      string
+	Source      string
+	PluginName  string
+	ServerName  string
+	ToolName    string
+	Trigger     string
+	Path        string
+	Invocation  string
 }
 
 type ComposerOptions struct {
@@ -85,6 +102,7 @@ type ComposerOptions struct {
 	EffectiveSettings ComposerSettings
 	RuntimeContext    map[string]any
 	Skills            []ComposerSkillOption
+	CapabilityCatalog []ComposerCapabilityOption
 }
 
 func (s *Service) GetComposerOptions(ctx context.Context, input ComposerOptionsInput) (ComposerOptions, error) {
@@ -122,7 +140,12 @@ func (s *Service) GetComposerOptions(ctx context.Context, input ComposerOptionsI
 		"speed":            nullableString(effectiveSettings.Speed),
 	}
 	skills := s.discoverComposerSkillOptions(provider, input.Cwd, nil)
+	capabilityCatalog, capabilityErrors := discoverComposerCapabilityOptions(ctx, provider, input.Cwd, skills)
 	runtimeContext["skills"] = composerSkillOptionsRuntimeContext(skills)
+	runtimeContext["capabilityCatalog"] = composerCapabilityOptionsRuntimeContext(capabilityCatalog)
+	if len(capabilityErrors) > 0 {
+		runtimeContext["capabilityCatalogErrors"] = capabilityErrors
+	}
 	if composerOptionsProviderUsesModelCatalog(provider) {
 		if catalogOptions, source, ok := composerModelOptionsFromCatalog(ctx, s.ModelCatalog, provider, effectiveSettings.Model); ok {
 			modelOptions = catalogOptions
@@ -139,6 +162,7 @@ func (s *Service) GetComposerOptions(ctx context.Context, input ComposerOptionsI
 		EffectiveSettings: effectiveSettings,
 		RuntimeContext:    runtimeContext,
 		Skills:            skills,
+		CapabilityCatalog: capabilityCatalog,
 	}, nil
 }
 

--- a/services/tuttid/service/agent/prompt_content.go
+++ b/services/tuttid/service/agent/prompt_content.go
@@ -69,6 +69,17 @@ func normalizePromptContent(content []PromptContentBlock) ([]PromptContentBlock,
 				AttachmentID: strings.TrimSpace(block.AttachmentID),
 				Name:         strings.TrimSpace(block.Name),
 			})
+		case "skill", "mention":
+			name := strings.TrimSpace(block.Name)
+			path := strings.TrimSpace(block.Path)
+			if name == "" || path == "" {
+				return nil, "", ErrInvalidArgument
+			}
+			normalized = append(normalized, PromptContentBlock{
+				Type: strings.TrimSpace(block.Type),
+				Name: name,
+				Path: path,
+			})
 		default:
 			return nil, "", ErrInvalidArgument
 		}

--- a/services/tuttid/service/agent/session_types.go
+++ b/services/tuttid/service/agent/session_types.go
@@ -295,6 +295,7 @@ type PromptContentBlock struct {
 	Data         string `json:"data,omitempty"`
 	AttachmentID string `json:"attachmentId,omitempty"`
 	Name         string `json:"name,omitempty"`
+	Path         string `json:"path,omitempty"`
 }
 
 type PromptAttachment struct {

--- a/services/tuttid/service/agent/skill_options.go
+++ b/services/tuttid/service/agent/skill_options.go
@@ -304,6 +304,7 @@ func discoverProviderSkillRoot(
 			SourceKind:  root.sourceKind,
 			Description: metadata.description,
 			PluginName:  root.pluginName,
+			Path:        skillPath,
 		})
 	}
 	return options
@@ -514,6 +515,72 @@ func composerSkillOptionsRuntimeContext(options []ComposerSkillOption) []map[str
 		}
 		if option.PluginName != "" {
 			value["pluginName"] = option.PluginName
+		}
+		if option.Path != "" {
+			value["path"] = option.Path
+		}
+		result = append(result, value)
+	}
+	return result
+}
+
+func composerCapabilityCatalogFromSkills(provider string, skills []ComposerSkillOption) []ComposerCapabilityOption {
+	if len(skills) == 0 {
+		return []ComposerCapabilityOption{}
+	}
+	result := make([]ComposerCapabilityOption, 0, len(skills))
+	for _, skill := range skills {
+		name := strings.TrimSpace(skill.Name)
+		trigger := strings.TrimSpace(skill.Trigger)
+		if name == "" || trigger == "" {
+			continue
+		}
+		invocation := "textTrigger"
+		if agentprovider.Normalize(provider) == agentprovider.Codex && strings.HasPrefix(trigger, "$") {
+			invocation = "promptItem"
+		}
+		result = append(result, ComposerCapabilityOption{
+			ID:          "skill:" + name,
+			Kind:        "skill",
+			Name:        name,
+			Label:       name,
+			Description: strings.TrimSpace(skill.Description),
+			Status:      "available",
+			PluginName:  strings.TrimSpace(skill.PluginName),
+			Trigger:     trigger,
+			Path:        strings.TrimSpace(skill.Path),
+			Invocation:  invocation,
+		})
+	}
+	return result
+}
+
+func composerCapabilityOptionsRuntimeContext(options []ComposerCapabilityOption) []map[string]any {
+	if len(options) == 0 {
+		return []map[string]any{}
+	}
+	result := make([]map[string]any, 0, len(options))
+	for _, option := range options {
+		value := map[string]any{
+			"id":         option.ID,
+			"kind":       option.Kind,
+			"name":       option.Name,
+			"label":      option.Label,
+			"status":     option.Status,
+			"invocation": option.Invocation,
+		}
+		for key, text := range map[string]string{
+			"description": option.Description,
+			"source":      option.Source,
+			"pluginName":  option.PluginName,
+			"serverName":  option.ServerName,
+			"toolName":    option.ToolName,
+			"trigger":     option.Trigger,
+			"path":        option.Path,
+		} {
+			if strings.TrimSpace(text) != "" {
+				value[key] = strings.TrimSpace(text)
+			}
 		}
 		result = append(result, value)
 	}

--- a/services/tuttid/service/agentsidecar/codex.go
+++ b/services/tuttid/service/agentsidecar/codex.go
@@ -99,7 +99,34 @@ func exposeUserCodexFiles(codexHome string) error {
 			}
 		}
 	}
+	if err := exposeUserCodexPluginState(codexHome, userCodexHome); err != nil {
+		return err
+	}
 	return exposeUserCodexConfig(codexHome, userCodexHome)
+}
+
+func exposeUserCodexPluginState(codexHome string, userCodexHome string) error {
+	for _, rel := range []string{
+		filepath.Join("plugins", "cache"),
+		filepath.Join("plugins", "data"),
+		filepath.Join("plugins", ".plugin-appserver"),
+	} {
+		source := filepath.Join(userCodexHome, rel)
+		if _, err := os.Stat(source); err != nil {
+			continue
+		}
+		target := filepath.Join(codexHome, rel)
+		if _, err := os.Lstat(target); err == nil {
+			continue
+		}
+		if err := os.MkdirAll(filepath.Dir(target), 0o700); err != nil {
+			return fmt.Errorf("create codex plugin state parent: %w", err)
+		}
+		if err := os.Symlink(source, target); err != nil {
+			return fmt.Errorf("expose codex plugin state %s: %w", rel, err)
+		}
+	}
+	return nil
 }
 
 func exposeUserCodexConfig(codexHome string, userCodexHome string) error {

--- a/services/tuttid/service/agentsidecar/preparer_test.go
+++ b/services/tuttid/service/agentsidecar/preparer_test.go
@@ -33,6 +33,9 @@ func TestDefaultPreparerCodexWritesInstructionsSkillManifestAndEnv(t *testing.T)
 	if err := os.WriteFile(filepath.Join(userCodexHome, "config.toml"), []byte(userCodexConfig), 0o600); err != nil {
 		t.Fatal(err)
 	}
+	writeSidecarTestFile(t, filepath.Join(userCodexHome, "plugins", "cache", "sample", "plugin.txt"), "plugin cache")
+	writeSidecarTestFile(t, filepath.Join(userCodexHome, "plugins", "data", "sample", "state.txt"), "plugin state")
+	writeSidecarTestFile(t, filepath.Join(userCodexHome, "plugins", ".plugin-appserver", "codex"), "plugin server")
 	writeSidecarTestFile(t, filepath.Join(userCodexHome, "skills", "caveman", "SKILL.md"), "---\nname: caveman\n---\nCaveman mode\n")
 	writeSidecarTestFile(t, filepath.Join(userCodexHome, "skills", "grill-me", "SKILL.md"), "---\nname: grill-me\n---\nGrill me\n")
 	writeSidecarTestFile(t, filepath.Join(userCodexHome, "skills", "broken-frontmatter", "SKILL.md"), "name: broken-frontmatter\n---\nBroken\n")
@@ -99,6 +102,19 @@ func TestDefaultPreparerCodexWritesInstructionsSkillManifestAndEnv(t *testing.T)
 	}
 	if _, err := os.Lstat(filepath.Join(codexHome, "auth.json")); err != nil {
 		t.Fatalf("codex auth not exposed: %v", err)
+	}
+	for _, rel := range []string{
+		filepath.Join("plugins", "cache"),
+		filepath.Join("plugins", "data"),
+		filepath.Join("plugins", ".plugin-appserver"),
+	} {
+		info, err := os.Lstat(filepath.Join(codexHome, rel))
+		if err != nil {
+			t.Fatalf("codex plugin state %s not exposed: %v", rel, err)
+		}
+		if info.Mode()&os.ModeSymlink == 0 {
+			t.Fatalf("codex plugin state %s should be exposed as symlink", rel)
+		}
 	}
 	if _, err := os.Stat(filepath.Join(cwd, ".tutti-codex-root")); !os.IsNotExist(err) {
 		t.Fatalf("codex preparer should not create project root marker in cwd, err = %v", err)


### PR DESCRIPTION
## Summary
- add a Codex app-server capability catalog discovery path for skills, apps/connectors, plugins, and MCP servers/tools
- expose capabilityCatalog through daemon composer options, OpenAPI/generated clients, activity-core types, and Agent GUI composer state
- preserve provider-native skill/mention prompt blocks so selected capabilities can be submitted to agent runtimes

## Notes
This is a stacked PR on top of #135 (`fix/agent-gui-conversation-list-project-storm`) so the capability work is reviewed separately from the conversation project-store fix.

## Validation
- `gofmt` on touched Go files
- `git diff --check` passed
- `pnpm check:changed --tail-lines 80` failed in this new worktree because `node_modules` is not installed, so TS/vitest lanes could not find `oxlint`, `tsgo`, or `vitest`; the Go lane also hit the existing local state path failure `TuttidLogsDir() = "/Users/asdf/.tutti/logs"`.