### PR TITLE
fix(agent-gui): tighten message copy button hit area

### DIFF
--- a/packages/agent/gui/app/renderer/agentactivity.css
+++ b/packages/agent/gui/app/renderer/agentactivity.css
@@ -3113,20 +3113,25 @@ aside.workspace-agents-status-panel
   top: 100%;
   right: 0;
   left: 0;
-  height: 10px;
+  height: 4px;
   content: "";
 }
 
 .agent-gui-conversation__message-group:has(
   > .agent-gui-conversation__message-copy-button
 ) {
-  margin-bottom: 36px;
+  margin-bottom: 26px;
 }
 
 .agent-gui-conversation__message-copy-button {
   position: absolute;
-  top: calc(100% + 8px);
+  top: calc(100% + 4px);
   z-index: 1;
+  width: 22px;
+  min-width: 22px;
+  height: 22px;
+  min-height: 22px;
+  border-radius: 5px;
   opacity: 0;
   pointer-events: none;
   transform: translateY(-2px);

--- a/packages/agent/gui/app/renderer/agentactivity.css
+++ b/packages/agent/gui/app/renderer/agentactivity.css
@@ -3113,7 +3113,7 @@ aside.workspace-agents-status-panel
   top: 100%;
   right: 0;
   left: 0;
-  height: 4px;
+  height: 26px;
   content: "";
 }
 

--- a/packages/agent/gui/shared/agentConversation/components/AgentTranscriptItemView.spec.tsx
+++ b/packages/agent/gui/shared/agentConversation/components/AgentTranscriptItemView.spec.tsx
@@ -259,6 +259,35 @@ describe("AgentTranscriptItemView render stability", () => {
     });
   });
 
+  it("keeps the message copy action compact and close to message content", () => {
+    const css = readFileSync(resolve("app/renderer/agentactivity.css"), "utf8");
+
+    expect(css).toMatch(
+      /\.agent-gui-conversation__message-copy-button\s*{[^}]*width:\s*22px[^}]*min-width:\s*22px[^}]*height:\s*22px[^}]*min-height:\s*22px[^}]*border-radius:\s*5px/s
+    );
+    expect(css).toMatch(
+      /\.agent-gui-conversation__message-copy-button\s*{[^}]*top:\s*calc\(100% \+ 4px\)/s
+    );
+    expect(css).toMatch(
+      /\.agent-gui-conversation__message-group::after\s*{[^}]*height:\s*4px/s
+    );
+    expect(css).toMatch(
+      /\.agent-gui-conversation__message-group:has\(\s*> \.agent-gui-conversation__message-copy-button\s*\)\s*{[^}]*margin-bottom:\s*26px/s
+    );
+    expect(css).not.toMatch(
+      /\.agent-gui-conversation__message-copy-button\s*{[^}]*width:\s*28px/s
+    );
+    expect(css).not.toMatch(
+      /\.agent-gui-conversation__message-copy-button\s*{[^}]*top:\s*calc\(100% \+ 8px\)/s
+    );
+    expect(css).not.toMatch(
+      /\.agent-gui-conversation__message-group:has\(\s*> \.agent-gui-conversation__message-copy-button\s*\)\s*{[^}]*margin-bottom:\s*36px/s
+    );
+    expect(css).not.toMatch(
+      /\.agent-gui-conversation__message-group::after\s*{[^}]*height:\s*10px/s
+    );
+  });
+
   it("loads user prompt image attachments from the activity runtime", async () => {
     const readSessionAttachment = vi.fn(async () => ({
       attachmentId: "attachment-1",

--- a/packages/agent/gui/shared/agentConversation/components/AgentTranscriptItemView.spec.tsx
+++ b/packages/agent/gui/shared/agentConversation/components/AgentTranscriptItemView.spec.tsx
@@ -259,20 +259,28 @@ describe("AgentTranscriptItemView render stability", () => {
     });
   });
 
-  it("keeps the message copy action compact and close to message content", () => {
+  it("shows the message copy action when hovering the bottom action row", () => {
     const css = readFileSync(resolve("app/renderer/agentactivity.css"), "utf8");
 
     expect(css).toMatch(
-      /\.agent-gui-conversation__message-copy-button\s*{[^}]*width:\s*22px[^}]*min-width:\s*22px[^}]*height:\s*22px[^}]*min-height:\s*22px[^}]*border-radius:\s*5px/s
-    );
-    expect(css).toMatch(
-      /\.agent-gui-conversation__message-copy-button\s*{[^}]*top:\s*calc\(100% \+ 4px\)/s
-    );
-    expect(css).toMatch(
-      /\.agent-gui-conversation__message-group::after\s*{[^}]*height:\s*4px/s
+      /\.agent-gui-conversation__message-group::after\s*{[^}]*top:\s*100%[^}]*right:\s*0[^}]*left:\s*0[^}]*height:\s*26px/s
     );
     expect(css).toMatch(
       /\.agent-gui-conversation__message-group:has\(\s*> \.agent-gui-conversation__message-copy-button\s*\)\s*{[^}]*margin-bottom:\s*26px/s
+    );
+    expect(css).toMatch(
+      /\.agent-gui-conversation__message-group:hover[\s\S]*?> \.agent-gui-conversation__message-copy-button,[\s\S]*?\.agent-gui-conversation__message-group:focus-within[\s\S]*?> \.agent-gui-conversation__message-copy-button\s*{[^}]*opacity:\s*1[^}]*pointer-events:\s*auto/s
+    );
+    expect(css).not.toMatch(
+      /\.agent-gui-conversation__message-group::after\s*{[^}]*height:\s*10px/s
+    );
+  });
+
+  it("keeps the message copy button compact within the action row", () => {
+    const css = readFileSync(resolve("app/renderer/agentactivity.css"), "utf8");
+
+    expect(css).toMatch(
+      /\.agent-gui-conversation__message-copy-button\s*{[^}]*top:\s*calc\(100% \+ 4px\)[^}]*width:\s*22px[^}]*min-width:\s*22px[^}]*height:\s*22px[^}]*min-height:\s*22px[^}]*border-radius:\s*5px/s
     );
     expect(css).not.toMatch(
       /\.agent-gui-conversation__message-copy-button\s*{[^}]*width:\s*28px/s
@@ -282,9 +290,6 @@ describe("AgentTranscriptItemView render stability", () => {
     );
     expect(css).not.toMatch(
       /\.agent-gui-conversation__message-group:has\(\s*> \.agent-gui-conversation__message-copy-button\s*\)\s*{[^}]*margin-bottom:\s*36px/s
-    );
-    expect(css).not.toMatch(
-      /\.agent-gui-conversation__message-group::after\s*{[^}]*height:\s*10px/s
     );
   });
 


### PR DESCRIPTION
## Summary
- reduce the agent message copy action visual footprint and click target to match the inline control
- keep the copy button accessible without creating an oversized floating block below messages
- add a regression test for the copy button sizing contract

## Validation
- `git diff --check HEAD~1..HEAD`
- Targeted vitest could not run in this worktree because the available node_modules does not include a vitest binary.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Refined copy button positioning and sizing for conversation messages
  * Improved button spacing and alignment for better visual clarity

* **Tests**
  * Added test coverage for message copy button visibility and interaction behavior (hover/focus states)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->