### PR TITLE
Add workspace app HTML PDF printing

### DIFF
--- a/apps/desktop/src/main/ipc/workspaceAppContext.ts
+++ b/apps/desktop/src/main/ipc/workspaceAppContext.ts
@@ -1,6 +1,6 @@
 import {
+  BrowserWindow,
   ipcMain,
-  type BrowserWindow,
   type IpcMainEvent,
   type WebContents
 } from "electron";
@@ -19,6 +19,7 @@ import {
   normalizeTuttiExternalFileOpenInput,
   normalizeTuttiExternalFileSelectInput,
   normalizeTuttiExternalLogInput,
+  normalizeTuttiExternalPdfPrintHtmlInput,
   normalizeTuttiExternalPermissionRequestInput,
   normalizeTuttiExternalReferenceOpenInput,
   normalizeTuttiExternalSettingsOpenInput,
@@ -30,6 +31,9 @@ import type {
   TuttiExternalFileSelectResult,
   TuttiExternalManagedAiModel,
   TuttiExternalManagedAiModelProviderId,
+  TuttiExternalPdfMargin,
+  TuttiExternalPdfPrintHtmlInput,
+  TuttiExternalPdfPrintHtmlResult,
   TuttiExternalPermissionRequestInput,
   TuttiExternalPermissionRequestResult
 } from "@tutti-os/workspace-external-core/contracts";
@@ -58,11 +62,18 @@ const workspaceAppGuestContexts = new Map<number, WorkspaceAppGuestContext>();
 let workspaceAppFrontendLogWriter: WorkspaceAppFrontendLogWriter | null = null;
 let workspaceAppGuestLogRateLimiter: WorkspaceAppGuestLogRateLimiter | null =
   null;
+type WorkspaceAppPrintLoadListener = (...args: unknown[]) => void;
 
 interface WorkspaceAppGuestContext {
   appID: string;
   ownerWindow: BrowserWindow;
   workspaceID: string;
+}
+
+interface WorkspaceAppPrintWebContents {
+  loadURL(url: string): Promise<void>;
+  off(event: string, listener: WorkspaceAppPrintLoadListener): unknown;
+  once(event: string, listener: WorkspaceAppPrintLoadListener): unknown;
 }
 
 export function registerWorkspaceAppGuestWebContents(
@@ -179,6 +190,14 @@ export function registerWorkspaceAppContextIpc(
     }
   );
   registerDesktopIpcHandler(
+    desktopIpcChannels.appExternal.pdfPrintHtml,
+    async (event, payload) => {
+      const context = requireWorkspaceAppGuestContext(event.sender);
+      const input = normalizeTuttiExternalPdfPrintHtmlInput(payload);
+      return printWorkspaceAppHtmlToPdf(context, input);
+    }
+  );
+  registerDesktopIpcHandler(
     desktopIpcChannels.appExternal.settingsOpen,
     async (event, payload) => {
       const context = requireWorkspaceAppGuestContext(event.sender);
@@ -289,6 +308,137 @@ export function registerWorkspaceAppContextIpc(
       locale: preferences.getLocale()
     });
   });
+}
+
+async function printWorkspaceAppHtmlToPdf(
+  context: WorkspaceAppGuestContext,
+  input: TuttiExternalPdfPrintHtmlInput
+): Promise<TuttiExternalPdfPrintHtmlResult> {
+  const printWindow = new BrowserWindow({
+    height: 900,
+    parent: context.ownerWindow,
+    show: false,
+    webPreferences: {
+      contextIsolation: true,
+      nodeIntegration: false,
+      sandbox: true,
+      session: context.ownerWindow.webContents.session
+    },
+    width: 720
+  });
+
+  try {
+    await loadPrintHtml(printWindow.webContents, input);
+    const pdf = await printWindow.webContents.printToPDF({
+      margins: printMargins(input.margin),
+      pageSize: input.pageSize ?? "A4",
+      printBackground: input.printBackground !== false
+    });
+    return { bytes: new Uint8Array(pdf) };
+  } finally {
+    if (!printWindow.isDestroyed()) {
+      printWindow.destroy();
+    }
+  }
+}
+
+function loadPrintHtml(
+  contents: WorkspaceAppPrintWebContents,
+  input: TuttiExternalPdfPrintHtmlInput
+): Promise<void> {
+  const html = preparePrintHtml(input);
+  const url = `data:text/html;charset=utf-8;base64,${Buffer.from(html, "utf8").toString("base64")}`;
+  return new Promise((resolve, reject) => {
+    const timeout = setTimeout(() => {
+      cleanup();
+      reject(new Error("PDF print HTML load timed out."));
+    }, 30_000);
+    const cleanup = (): void => {
+      clearTimeout(timeout);
+      contents.off("did-finish-load", handleLoaded);
+      contents.off("did-fail-load", handleFailed);
+    };
+    const handleLoaded = (): void => {
+      cleanup();
+      resolve();
+    };
+    const handleFailed: WorkspaceAppPrintLoadListener = (...args) => {
+      const errorDescription =
+        typeof args[2] === "string" ? args[2] : "PDF print HTML failed to load.";
+      cleanup();
+      reject(new Error(errorDescription));
+    };
+    contents.once("did-finish-load", handleLoaded);
+    contents.once("did-fail-load", handleFailed);
+    void contents.loadURL(url).catch((error: unknown) => {
+      cleanup();
+      reject(error instanceof Error ? error : new Error(String(error)));
+    });
+  });
+}
+
+function preparePrintHtml(input: TuttiExternalPdfPrintHtmlInput): string {
+  const base = input.baseUrl ? `<base href="${escapeHtml(input.baseUrl)}">` : "";
+  const title = input.title ? `<title>${escapeHtml(input.title)}</title>` : "";
+  const printHead = `${base}${title}`;
+  if (!printHead) {
+    return input.html;
+  }
+  if (/<head[^>]*>/iu.test(input.html)) {
+    return input.html.replace(/<head([^>]*)>/iu, `<head$1>${printHead}`);
+  }
+  if (/<html[^>]*>/iu.test(input.html)) {
+    return input.html.replace(
+      /<html([^>]*)>/iu,
+      `<html$1><head>${printHead}</head>`
+    );
+  }
+  return `<!DOCTYPE html><html><head>${printHead}</head><body>${input.html}</body></html>`;
+}
+
+function printMargins(
+  margin: TuttiExternalPdfMargin | undefined
+): Electron.Margins | undefined {
+  if (!margin) {
+    return undefined;
+  }
+  return {
+    marginType: "custom",
+    bottom: marginToPixels(margin.bottom),
+    left: marginToPixels(margin.left),
+    right: marginToPixels(margin.right),
+    top: marginToPixels(margin.top)
+  };
+}
+
+function marginToPixels(value: string | undefined): number {
+  if (!value) {
+    return 0;
+  }
+  const match = value.match(/^(\d+(?:\.\d+)?)(px|in|cm|mm)$/u);
+  if (!match) {
+    return 0;
+  }
+  const amount = Number(match[1]);
+  const unit = match[2];
+  if (unit === "px") {
+    return amount;
+  }
+  if (unit === "in") {
+    return amount * 96;
+  }
+  if (unit === "cm") {
+    return (amount / 2.54) * 96;
+  }
+  return (amount / 25.4) * 96;
+}
+
+function escapeHtml(value: string): string {
+  return value
+    .replace(/&/gu, "&amp;")
+    .replace(/</gu, "&lt;")
+    .replace(/>/gu, "&gt;")
+    .replace(/"/gu, "&quot;");
 }
 
 function writeWorkspaceAppDiagnosticLog(
@@ -523,7 +673,11 @@ function createWorkspaceAppContext(
   const installationId = `${context.workspaceID}:${context.appID}`;
   return {
     appId: context.appID,
-    capabilities: ["files.open@1", "workspace.openFeature@1"],
+    capabilities: [
+      "files.open@1",
+      "pdf.printHtmlToPdf@1",
+      "workspace.openFeature@1"
+    ],
     contextToken: createWorkspaceAppContextToken(endpoint, context, {
       installationId,
       issuer

--- a/apps/desktop/src/preload/entries/workspaceAppExternalBridge.test.ts
+++ b/apps/desktop/src/preload/entries/workspaceAppExternalBridge.test.ts
@@ -289,6 +289,62 @@ test("workspace app external bridge invokes file open with activation", async ()
   ]);
 });
 
+test("workspace app external bridge invokes PDF print with activation", async () => {
+  const calls: Array<{ channel: string; payload?: unknown }> = [];
+  const bridge = createWorkspaceAppExternalBridge({
+    appContext: {
+      async get() {
+        return { locale: "en" };
+      },
+      subscribe() {
+        throw new Error("unexpected subscribe");
+      }
+    },
+    isUserActivationActive: () => true,
+    send: unexpectedSend,
+    async invoke<TResult>(channel: string, payload?: unknown) {
+      calls.push({ channel, payload });
+      return { bytes: new Uint8Array([37, 80, 68, 70]) } as TResult;
+    }
+  });
+
+  assert.deepEqual(
+    await bridge.pdf.printHtmlToPdf({ html: "<h1>Hello</h1>" }),
+    {
+      bytes: new Uint8Array([37, 80, 68, 70])
+    }
+  );
+  assert.deepEqual(calls, [
+    {
+      channel: workspaceAppExternalChannels.pdfPrintHtml,
+      payload: { html: "<h1>Hello</h1>" }
+    }
+  ]);
+});
+
+test("workspace app external bridge requires activation for PDF print", () => {
+  const bridge = createWorkspaceAppExternalBridge({
+    appContext: {
+      async get() {
+        return { locale: "en" };
+      },
+      subscribe() {
+        throw new Error("unexpected subscribe");
+      }
+    },
+    isUserActivationActive: () => false,
+    send: unexpectedSend,
+    async invoke() {
+      throw new Error("unexpected invoke");
+    }
+  });
+
+  assert.throws(
+    () => bridge.pdf.printHtmlToPdf({ html: "<h1>Hello</h1>" }),
+    /pdf\.printHtmlToPdf requires a user action/
+  );
+});
+
 test("workspace app external bridge requires activation for permission request", () => {
   const bridge = createWorkspaceAppExternalBridge({
     appContext: {

--- a/apps/desktop/src/preload/entries/workspaceAppExternalBridge.ts
+++ b/apps/desktop/src/preload/entries/workspaceAppExternalBridge.ts
@@ -9,6 +9,8 @@ import type {
   TuttiExternalLogInput,
   TuttiExternalPermissionRequestInput,
   TuttiExternalPermissionRequestResult,
+  TuttiExternalPdfPrintHtmlInput,
+  TuttiExternalPdfPrintHtmlResult,
   TuttiExternalReferenceOpenInput,
   TuttiExternalSettingsOpenInput,
   TuttiExternalWorkspaceOpenFeatureInput
@@ -33,6 +35,7 @@ export const workspaceAppExternalChannels = {
   filesSelect: "workspace-app-files:select",
   logsWrite: "workspace-app-logs:write",
   permissionsRequest: "workspace-app-permissions:request",
+  pdfPrintHtml: "workspace-app-pdf:print-html",
   referencesOpen: "workspace-app-references:open",
   settingsOpen: "workspace-app-settings:open",
   workspaceFeatureOpen: "workspace-app-feature:open"
@@ -124,6 +127,18 @@ export function createWorkspaceAppExternalBridge(
         );
         return dependencies.invoke<void>(
           workspaceAppExternalChannels.workspaceFeatureOpen,
+          input
+        );
+      }
+    },
+    pdf: {
+      printHtmlToPdf(input: TuttiExternalPdfPrintHtmlInput) {
+        requireUserActivation(
+          dependencies.isUserActivationActive(),
+          "pdf.printHtmlToPdf"
+        );
+        return dependencies.invoke<TuttiExternalPdfPrintHtmlResult>(
+          workspaceAppExternalChannels.pdfPrintHtml,
           input
         );
       }

--- a/apps/desktop/src/shared/contracts/ipc.ts
+++ b/apps/desktop/src/shared/contracts/ipc.ts
@@ -35,6 +35,8 @@ import type {
   TuttiExternalLogInput,
   TuttiExternalPermissionRequestInput,
   TuttiExternalPermissionRequestResult,
+  TuttiExternalPdfPrintHtmlInput,
+  TuttiExternalPdfPrintHtmlResult,
   TuttiExternalReferenceOpenInput,
   TuttiExternalRendererRequest,
   TuttiExternalSettingsOpenInput,
@@ -62,6 +64,7 @@ export const desktopIpcChannels = {
     filesSelect: "workspace-app-files:select",
     logsWrite: "workspace-app-logs:write",
     permissionsRequest: "workspace-app-permissions:request",
+    pdfPrintHtml: "workspace-app-pdf:print-html",
     referencesOpen: "workspace-app-references:open",
     rendererRequest: "workspace-app-external:renderer-request",
     rendererResponse: "workspace-app-external:renderer-response",
@@ -557,6 +560,8 @@ export interface DesktopInvokePayloadByChannel {
   [desktopIpcChannels.appExternal
     .permissionsRequest]: TuttiExternalPermissionRequestInput;
   [desktopIpcChannels.appExternal
+    .pdfPrintHtml]: TuttiExternalPdfPrintHtmlInput;
+  [desktopIpcChannels.appExternal
     .referencesOpen]: TuttiExternalReferenceOpenInput;
   [desktopIpcChannels.appExternal.settingsOpen]: TuttiExternalSettingsOpenInput;
   [desktopIpcChannels.appExternal
@@ -653,6 +658,8 @@ export interface DesktopInvokeResultByChannel {
   [desktopIpcChannels.appExternal.filesSelect]: TuttiExternalFileSelectResult;
   [desktopIpcChannels.appExternal
     .permissionsRequest]: TuttiExternalPermissionRequestResult;
+  [desktopIpcChannels.appExternal
+    .pdfPrintHtml]: TuttiExternalPdfPrintHtmlResult;
   [desktopIpcChannels.appExternal.referencesOpen]: void;
   [desktopIpcChannels.appExternal.settingsOpen]: void;
   [desktopIpcChannels.appExternal.workspaceFeatureOpen]: void;

--- a/packages/workspace/external-core/README.md
+++ b/packages/workspace/external-core/README.md
@@ -9,6 +9,7 @@ Contracts and host-agnostic helpers for the workspace app external bridge.
 - `files.select()` for user-activated workspace file picking.
 - `files.open()` for user-activated host opening/revealing of a known workspace file path.
 - `permissions.request()` for user-activated host permission grants such as managed AI model access.
+- `pdf.printHtmlToPdf()` for user-activated host PDF generation from print-ready HTML.
 - `settings.open()` for user-activated host settings navigation, including the managed models tab.
 - `workspace.openFeature()` for user-activated host workspace navigation, such as opening the message center.
 - `logs.write()` for fire-and-forget frontend diagnostics that append to the workspace app `web.log`.

--- a/packages/workspace/external-core/src/contracts/index.ts
+++ b/packages/workspace/external-core/src/contracts/index.ts
@@ -163,6 +163,26 @@ export interface TuttiExternalLogInput {
   level?: TuttiExternalLogLevel;
 }
 
+export interface TuttiExternalPdfMargin {
+  bottom?: string;
+  left?: string;
+  right?: string;
+  top?: string;
+}
+
+export interface TuttiExternalPdfPrintHtmlInput {
+  baseUrl?: string;
+  html: string;
+  margin?: TuttiExternalPdfMargin;
+  pageSize?: "A4" | "Letter";
+  printBackground?: boolean;
+  title?: string;
+}
+
+export interface TuttiExternalPdfPrintHtmlResult {
+  bytes: Uint8Array;
+}
+
 export interface TuttiExternalBridge {
   app: {
     getContext(): Promise<unknown>;
@@ -192,6 +212,11 @@ export interface TuttiExternalBridge {
   };
   references: {
     open(input: TuttiExternalReferenceOpenInput): Promise<void>;
+  };
+  pdf: {
+    printHtmlToPdf(
+      input: TuttiExternalPdfPrintHtmlInput
+    ): Promise<TuttiExternalPdfPrintHtmlResult>;
   };
   logs: {
     write(input: TuttiExternalLogInput): void;

--- a/packages/workspace/external-core/src/core/index.test.ts
+++ b/packages/workspace/external-core/src/core/index.test.ts
@@ -5,6 +5,7 @@ import {
   normalizeTuttiExternalFileOpenInput,
   normalizeTuttiExternalFileSelectInput,
   normalizeTuttiExternalLogInput,
+  normalizeTuttiExternalPdfPrintHtmlInput,
   normalizeTuttiExternalPermissionRequestInput,
   normalizeTuttiExternalReferenceOpenInput,
   normalizeTuttiExternalSettingsOpenInput,
@@ -175,6 +176,60 @@ test("rejects invalid settings open input", () => {
   assert.throws(
     () => normalizeTuttiExternalSettingsOpenInput({ provider: "codex" }),
     /provider is unsupported/
+  );
+});
+
+test("normalizes PDF print HTML input", () => {
+  assert.deepEqual(
+    normalizeTuttiExternalPdfPrintHtmlInput({
+      baseUrl: " http://127.0.0.1:8790/project/ ",
+      html: " <h1>Doc</h1> ",
+      margin: {
+        bottom: "14mm",
+        left: " 10mm ",
+        right: "10mm",
+        top: "12mm"
+      },
+      pageSize: "A4",
+      printBackground: false,
+      title: " Report "
+    }),
+    {
+      baseUrl: "http://127.0.0.1:8790/project/",
+      html: "<h1>Doc</h1>",
+      margin: {
+        bottom: "14mm",
+        left: "10mm",
+        right: "10mm",
+        top: "12mm"
+      },
+      pageSize: "A4",
+      printBackground: false,
+      title: "Report"
+    }
+  );
+});
+
+test("rejects invalid PDF print HTML input", () => {
+  assert.throws(
+    () => normalizeTuttiExternalPdfPrintHtmlInput({ html: "" }),
+    /html is required/
+  );
+  assert.throws(
+    () =>
+      normalizeTuttiExternalPdfPrintHtmlInput({
+        baseUrl: "file:///tmp/doc.html",
+        html: "<h1>Doc</h1>"
+      }),
+    /baseUrl protocol is unsupported/
+  );
+  assert.throws(
+    () =>
+      normalizeTuttiExternalPdfPrintHtmlInput({
+        html: "<h1>Doc</h1>",
+        margin: { top: "12pt" }
+      }),
+    /margin top unit is unsupported/
   );
 });
 

--- a/packages/workspace/external-core/src/core/index.ts
+++ b/packages/workspace/external-core/src/core/index.ts
@@ -10,6 +10,8 @@ import {
   type TuttiExternalLogLevel,
   type TuttiExternalManagedAiModelProviderId,
   type TuttiExternalPermissionRequestInput,
+  type TuttiExternalPdfMargin,
+  type TuttiExternalPdfPrintHtmlInput,
   type TuttiExternalReferenceOpenInput,
   type TuttiExternalSettingsOpenInput,
   type TuttiExternalWorkspaceAgentProvider,
@@ -225,6 +227,35 @@ export function normalizeTuttiExternalReferenceOpenInput(
   return { href };
 }
 
+export function normalizeTuttiExternalPdfPrintHtmlInput(
+  input: unknown
+): TuttiExternalPdfPrintHtmlInput {
+  if (!isRecord(input)) {
+    throw new Error("pdf.printHtmlToPdf input must be an object.");
+  }
+  const html = normalizeRequiredString(input.html, "pdf.printHtmlToPdf html");
+  const title =
+    typeof input.title === "string" && input.title.trim() !== ""
+      ? input.title.trim().slice(0, 200)
+      : undefined;
+  const baseUrl =
+    typeof input.baseUrl === "string" && input.baseUrl.trim() !== ""
+      ? normalizePdfBaseUrl(input.baseUrl)
+      : undefined;
+  return {
+    html,
+    ...(baseUrl ? { baseUrl } : {}),
+    ...(title ? { title } : {}),
+    ...(input.printBackground === false ? { printBackground: false } : {}),
+    ...(input.pageSize !== undefined && input.pageSize !== null
+      ? { pageSize: normalizePdfPageSize(input.pageSize) }
+      : {}),
+    ...(input.margin !== undefined && input.margin !== null
+      ? { margin: normalizePdfMargin(input.margin) }
+      : {})
+  };
+}
+
 export function isTuttiExternalAtProviderId(
   value: unknown
 ): value is TuttiExternalAtProviderId {
@@ -384,6 +415,55 @@ function normalizeManagedAiModelProvider(
     throw new Error("managed AI model provider is unsupported.");
   }
   return value;
+}
+
+function normalizePdfBaseUrl(value: string): string {
+  let url: URL;
+  try {
+    url = new URL(value.trim());
+  } catch {
+    throw new Error("pdf.printHtmlToPdf baseUrl must be a valid URL.");
+  }
+  if (url.protocol !== "http:" && url.protocol !== "https:") {
+    throw new Error("pdf.printHtmlToPdf baseUrl protocol is unsupported.");
+  }
+  return url.toString();
+}
+
+function normalizePdfPageSize(value: unknown): "A4" | "Letter" {
+  if (value === "A4" || value === "Letter") {
+    return value;
+  }
+  throw new Error("pdf.printHtmlToPdf pageSize is unsupported.");
+}
+
+function normalizePdfMargin(value: unknown): TuttiExternalPdfMargin {
+  if (!isRecord(value)) {
+    throw new Error("pdf.printHtmlToPdf margin must be an object.");
+  }
+  return {
+    ...normalizePdfMarginSide(value.top, "top"),
+    ...normalizePdfMarginSide(value.right, "right"),
+    ...normalizePdfMarginSide(value.bottom, "bottom"),
+    ...normalizePdfMarginSide(value.left, "left")
+  };
+}
+
+function normalizePdfMarginSide(
+  value: unknown,
+  side: keyof TuttiExternalPdfMargin
+): TuttiExternalPdfMargin {
+  if (value === undefined || value === null || value === "") {
+    return {};
+  }
+  if (typeof value !== "string" || value.trim() === "") {
+    throw new Error(`pdf.printHtmlToPdf margin ${side} must be a string.`);
+  }
+  const normalized = value.trim();
+  if (!/^\d+(?:\.\d+)?(?:px|in|cm|mm)$/u.test(normalized)) {
+    throw new Error(`pdf.printHtmlToPdf margin ${side} unit is unsupported.`);
+  }
+  return { [side]: normalized };
 }
 
 function normalizeFileOpenMode(


### PR DESCRIPTION
## Summary
- add a `pdf.printHtmlToPdf()` external bridge capability for workspace apps
- route the new preload IPC channel through desktop main and render print-ready HTML in a hidden sandboxed `BrowserWindow`
- add input normalization, public contract types, README mention, and tests for PDF print activation/validation

## Validation
- `git diff --check`
- `pnpm --filter @tutti-os/workspace-external-core test`
- `pnpm --filter @tutti-os/workspace-external-core typecheck`
- `pnpm --filter @tutti-os/desktop test`
- `pnpm --filter @tutti-os/desktop typecheck`
- `pnpm check:electron-runtime-boundaries`
- `pnpm --filter @tutti-os/desktop build`

## Notes
- Local pre-push `pnpm check:full` was attempted. It passed the preflight checks, `lint:ts`, `typecheck`, and TS tests, but failed in unrelated Go tests under `services/tuttid/service/agentstatus` where this machine reports Codex/external adapters as `ready` instead of the tests' expected `not_installed` state.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added PDF printing capability to generate PDFs from HTML with customizable options including page size, margins, and titles. User activation required for security.

* **Tests**
  * Added comprehensive test coverage for PDF printing functionality, including user activation validation and input normalization scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->