### PR TITLE
Fix AI Doc catalog availability

### DIFF
--- a/apps/desktop/src/renderer/src/features/workspace-app-center/ui/WorkspaceAppCenterPane.tsx
+++ b/apps/desktop/src/renderer/src/features/workspace-app-center/ui/WorkspaceAppCenterPane.tsx
@@ -53,6 +53,11 @@ const catalogAppDisplayDefinitions = [
     nameKey: "appCenter.catalogApps.dailyProductRadar.name"
   },
   {
+    appIds: ["ai-doc"],
+    descriptionKey: "appCenter.comingSoonApps.aiDocument.description",
+    nameKey: "appCenter.comingSoonApps.aiDocument.name"
+  },
+  {
     appIds: ["group-chat"],
     descriptionKey: "appCenter.catalogApps.groupChat.description",
     nameKey: "appCenter.catalogApps.groupChat.name"
@@ -466,13 +471,7 @@ function withComingSoonWorkspaceApps(
       return app;
     }
     comingSoonByAppId.delete(app.appId);
-    return {
-      ...comingSoonApp,
-      ...(app.iconUrl ? { iconUrl: app.iconUrl } : {}),
-      ...(app.availableIconUrl
-        ? { availableIconUrl: app.availableIconUrl }
-        : {})
-    };
+    return app;
   });
   const remainingComingSoonApps = [...comingSoonByAppId.values()];
   return remainingComingSoonApps.length > 0


### PR DESCRIPTION
## Summary
- keep real catalog apps from being overwritten by matching coming-soon placeholders
- add an AI Doc display override so the released catalog app keeps localized App Center copy

## Validation
- pnpm --filter @tutti-os/desktop typecheck
- pnpm --filter @tutti-os/desktop test
- pnpm lint:ts
- pnpm check:full

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Added the ai-doc application to the workspace app center, now displayed with a coming soon status.
  * Improved how the app center manages application display definitions when apps are listed in multiple sources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->