### PR TITLE
[codex] Polish workspace UI controls

### DIFF
--- a/apps/desktop/src/renderer/src/features/workspace-workbench/ui/ExternalAgentSessionImportPrompt.tsx
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/ui/ExternalAgentSessionImportPrompt.tsx
@@ -64,14 +64,16 @@ export function ExternalAgentSessionImportPrompt({
     toast.custom(
       (id) => (
         <article className="relative w-full min-w-0 overflow-visible rounded-[12px] border border-[var(--line-2)] bg-[var(--background-fronted)] p-3.5 shadow-[0_14px_40px_var(--shadow-elevated)]">
-          <button
+          <Button
             type="button"
             aria-label={t("common.close")}
-            className="workspace-agent-decision-toast__close absolute top-0 right-0 z-[2] inline-flex size-6 translate-x-[35%] -translate-y-[35%] items-center justify-center rounded-full border border-[var(--line-2)] bg-[var(--background-panel)] text-[var(--text-secondary)] shadow-sm transition-colors hover:bg-[var(--background-fronted)] hover:text-[var(--text-primary)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color-mix(in_srgb,var(--border-focus)_30%,transparent)]"
+            className="workspace-agent-decision-toast__close absolute top-0 right-0 z-[2] size-6 translate-x-[35%] -translate-y-[35%] rounded-full border-[var(--line-2)] bg-[var(--background-panel)] text-[var(--text-secondary)] shadow-sm hover:bg-[var(--background-fronted)] hover:text-[var(--text-primary)] focus-visible:ring-[color-mix(in_srgb,var(--border-focus)_30%,transparent)]"
+            size="icon-xs"
+            variant="chrome"
             onClick={() => toast.dismiss(id)}
           >
             <CloseIcon className="size-4" />
-          </button>
+          </Button>
           <div className="workspace-agent-decision-toast__content relative z-[1] grid min-w-0 gap-3 transition-opacity">
             <div className="grid min-w-0 gap-1 pr-3">
               <h3 className="m-0 text-[13px] font-semibold leading-5 text-[var(--text-primary)]">

--- a/apps/desktop/src/renderer/src/features/workspace-workbench/ui/WorkspaceChrome.tsx
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/ui/WorkspaceChrome.tsx
@@ -773,14 +773,16 @@ function WorkspaceAgentDecisionToast({
         className="workspace-agent-decision-toast__edge-glow agent-gui-edge-glow pointer-events-none inset-0 rounded-[12px]"
         style={{ position: "absolute" }}
       />
-      <button
+      <Button
         type="button"
         aria-label={closeLabel}
-        className="workspace-agent-decision-toast__close absolute top-0 right-0 z-[2] inline-flex size-6 translate-x-[35%] -translate-y-[35%] items-center justify-center rounded-full border border-[var(--line-2)] bg-[var(--background-panel)] text-[var(--text-secondary)] shadow-sm transition-colors hover:bg-[var(--background-fronted)] hover:text-[var(--text-primary)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color-mix(in_srgb,var(--border-focus)_30%,transparent)]"
+        className="workspace-agent-decision-toast__close absolute top-0 right-0 z-[2] size-6 translate-x-[35%] -translate-y-[35%] rounded-full border-[var(--line-2)] bg-[var(--background-panel)] text-[var(--text-secondary)] shadow-sm hover:bg-[var(--background-fronted)] hover:text-[var(--text-primary)] focus-visible:ring-[color-mix(in_srgb,var(--border-focus)_30%,transparent)]"
+        size="icon-xs"
+        variant="chrome"
         onClick={onClose}
       >
         <CloseIcon className="size-4" />
-      </button>
+      </Button>
       <div className="workspace-agent-decision-toast__content relative z-[1] grid min-w-0 gap-2.5 transition-opacity">
         <div className="flex min-w-0 items-center justify-between gap-2.5 pr-2">
           <h3 className="min-w-0 truncate text-[13px] font-bold leading-5 text-[var(--text-secondary)]">

--- a/apps/desktop/src/renderer/src/features/workspace-workbench/ui/WorkspaceSettingsPanel.test.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/ui/WorkspaceSettingsPanel.test.ts
@@ -34,6 +34,21 @@ test("workspace settings general panel lists agent defaults before language", ()
   );
 });
 
+test("workspace settings default provider only offers Codex and Claude Code", () => {
+  assert.match(
+    source,
+    /const workspaceSettingsDefaultAgentProviders = \[\s*"codex",\s*"claude-code"\s*\]/
+  );
+  assert.match(
+    source,
+    /workspaceSettingsDefaultAgentProviders\.map\(\(provider\) => \([\s\S]*<SelectItem key=\{provider\} value=\{provider\}>/
+  );
+  assert.doesNotMatch(
+    source,
+    /workspaceAgentGuiProviders\.map\(\(provider\) => \([\s\S]*<SelectItem key=\{provider\} value=\{provider\}>/
+  );
+});
+
 test("workspace settings general panel owns browser-use connection mode", () => {
   assert.match(
     source,

--- a/apps/desktop/src/renderer/src/features/workspace-workbench/ui/WorkspaceSettingsPanel.tsx
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/ui/WorkspaceSettingsPanel.tsx
@@ -65,10 +65,7 @@ import {
   type DesktopFileDefaultOpenersByExtension,
   type DesktopSleepPreventionMode
 } from "../../../../../shared/preferences/index.ts";
-import {
-  resolveWorkspaceAgentGuiLabel,
-  workspaceAgentGuiProviders
-} from "../services/workspaceAgentProviderCatalog";
+import { resolveWorkspaceAgentGuiLabel } from "../services/workspaceAgentProviderCatalog";
 import {
   desktopThemeSources,
   type DesktopThemeAppearance,
@@ -100,6 +97,16 @@ const workspaceSettingsInputClass =
 
 const developerPanelUnlockTaps = 7;
 const computerUseOperationSettleMs = 280;
+const workspaceSettingsDefaultAgentProviders = [
+  "codex",
+  "claude-code"
+] as const satisfies readonly DesktopAgentProvider[];
+
+function isWorkspaceSettingsDefaultAgentProvider(
+  provider: DesktopAgentProvider
+): boolean {
+  return provider === "codex" || provider === "claude-code";
+}
 
 export function WorkspaceSettingsPanel({
   onOpenExternalAgentImport,
@@ -2064,8 +2071,13 @@ function WorkspaceGeneralSettingsSection({
   const isUpdatingLocale = changingLocale !== null;
   const pendingLocale = changingLocale ?? locale;
   const isUpdatingDefaultAgentProvider = changingDefaultAgentProvider !== null;
-  const pendingDefaultAgentProvider =
+  const rawPendingDefaultAgentProvider =
     changingDefaultAgentProvider ?? defaultAgentProvider;
+  const pendingDefaultAgentProvider = isWorkspaceSettingsDefaultAgentProvider(
+    rawPendingDefaultAgentProvider
+  )
+    ? rawPendingDefaultAgentProvider
+    : "codex";
   const isUpdatingBrowserUseConnectionMode =
     changingBrowserUseConnectionMode !== null;
   const pendingBrowserUseConnectionMode =
@@ -2142,7 +2154,7 @@ function WorkspaceGeneralSettingsSection({
               className={workspaceSettingsSelectContentClass}
               style={{ zIndex: "var(--z-panel-popover)" }}
             >
-              {workspaceAgentGuiProviders.map((provider) => (
+              {workspaceSettingsDefaultAgentProviders.map((provider) => (
                 <SelectItem key={provider} value={provider}>
                   {resolveWorkspaceAgentGuiLabel(provider)}
                 </SelectItem>

--- a/packages/agent/gui/agent-gui/agentGuiNode/AgentComposer.spec.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/AgentComposer.spec.tsx
@@ -1551,6 +1551,9 @@ describe("AgentComposer", () => {
     expect(css).toMatch(
       /\.agent-gui-node__composer-footer-right\s+\.agent-gui-node__composer-menu-trigger\s+>\s+svg\s*{[^}]*width:\s*16px[^}]*height:\s*16px[^}]*flex:\s*0 0 16px[^}]*margin-left:\s*0/s
     );
+    expect(css).toMatch(
+      /\.agent-gui-node__composer-menu-trigger\s*{[^}]*padding:\s*0 8px/s
+    );
   });
 
   it("renders context usage immediately before the permission menu", async () => {

--- a/packages/agent/gui/agent-gui/agentGuiNode/AgentGUINode.styles.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/AgentGUINode.styles.ts
@@ -61,6 +61,10 @@ const styles = {
     "agent-gui-node__conversation-open-window-button",
   conversationPinButton: "agent-gui-node__conversation-pin-button",
   conversationSection: "agent-gui-node__conversation-section",
+  conversationSectionActionTooltip:
+    "agent-gui-node__conversation-section-action-tooltip",
+  conversationSectionActionTooltipWrap:
+    "agent-gui-node__conversation-section-action-tooltip-wrap",
   conversationSectionActions: "agent-gui-node__conversation-section-actions",
   conversationSectionChevron: "agent-gui-node__conversation-section-chevron",
   conversationSectionEmpty: "agent-gui-node__conversation-section-empty",

--- a/packages/agent/gui/agent-gui/agentGuiNode/AgentGUINodeView.layout.spec.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/AgentGUINodeView.layout.spec.tsx
@@ -299,16 +299,42 @@ describe("AgentGUINodeView layout persistence", () => {
       },
       labels: {
         ...createLabels(),
-        projectSectionEdit: "Edit"
+        projectSectionEdit: "New session"
       }
     });
 
-    fireEvent.click(screen.getByLabelText("Edit"));
+    fireEvent.click(screen.getByLabelText("New session"));
 
     expect(actions.createConversation).toHaveBeenCalledWith({
       projectPath: "/workspace/app"
     });
     expect(composerMock.calls.at(-1)?.composerFocusRequestSequence).toBe(1);
+  });
+
+  it("shows tooltips for project section icon actions", () => {
+    const { container } = renderAgentGUINodeView({
+      viewModel: {
+        ...createViewModel(),
+        userProjects: [
+          {
+            id: "project-app",
+            path: "/workspace/app",
+            label: "App"
+          }
+        ]
+      }
+    });
+
+    const tooltips = Array.from(
+      container.querySelectorAll(
+        ".agent-gui-node__conversation-section-action-tooltip"
+      )
+    );
+
+    expect(tooltips.map((tooltip) => tooltip.textContent)).toEqual([
+      "projectSectionEdit",
+      "projectSectionMoreActions"
+    ]);
   });
 
   it("hides the project rail header when the project selector is disabled", () => {
@@ -358,6 +384,30 @@ describe("AgentGUINodeView layout persistence", () => {
     expect(screen.getByText("sectionConversations")).toBeInTheDocument();
     expect(screen.getAllByText("No chats yet")).toHaveLength(2);
     expect(screen.queryByText("noConversations")).not.toBeInTheDocument();
+  });
+
+  it("hides batch delete from empty project section actions", async () => {
+    renderAgentGUINodeView({
+      viewModel: {
+        ...createViewModel(),
+        userProjects: [
+          {
+            id: "project-app",
+            path: "/workspace/app",
+            label: "App"
+          }
+        ]
+      }
+    });
+
+    const moreActionsButton = screen.getByRole("button", {
+      name: "projectSectionMoreActions"
+    });
+    fireEvent.pointerDown(moreActionsButton);
+    fireEvent.click(moreActionsButton);
+
+    expect(screen.queryByText("batchDeleteProjectSessions")).toBeNull();
+    expect(await screen.findByText("removeProject")).toBeInTheDocument();
   });
 
   it("shows a tooltip trigger for the active conversation run path", () => {

--- a/packages/agent/gui/agent-gui/agentGuiNode/AgentGUINodeView.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/AgentGUINodeView.tsx
@@ -3213,47 +3213,62 @@ const AgentGUIConversationRailSection = memo(
           )}
           {projectPath ? (
             <div className={styles.conversationSectionActions}>
-              <BareIconButton
-                className={styles.conversationSectionMoreButton}
-                aria-label={labels.projectSectionEdit}
-                title={labels.projectSectionEdit}
-                size="sm"
-                disabled={createConversationDisabled}
-                onClick={() => onCreateConversation({ projectPath })}
-              >
-                <EditIcon aria-hidden="true" />
-              </BareIconButton>
+              <span className={styles.conversationSectionActionTooltipWrap}>
+                <BareIconButton
+                  className={styles.conversationSectionMoreButton}
+                  aria-label={labels.projectSectionEdit}
+                  size="sm"
+                  disabled={createConversationDisabled}
+                  onClick={() => onCreateConversation({ projectPath })}
+                >
+                  <EditIcon aria-hidden="true" />
+                </BareIconButton>
+                <span
+                  aria-hidden="true"
+                  className={styles.conversationSectionActionTooltip}
+                >
+                  {labels.projectSectionEdit}
+                </span>
+              </span>
               <DropdownMenu>
                 <DropdownMenuTrigger asChild>
-                  <BareIconButton
-                    className={styles.conversationSectionMoreButton}
-                    aria-label={labels.projectSectionMoreActions}
-                    title={labels.projectSectionMoreActions}
-                    size="sm"
-                  >
-                    <MoreHorizontalIcon aria-hidden="true" />
-                  </BareIconButton>
+                  <span className={styles.conversationSectionActionTooltipWrap}>
+                    <BareIconButton
+                      className={styles.conversationSectionMoreButton}
+                      aria-label={labels.projectSectionMoreActions}
+                      size="sm"
+                    >
+                      <MoreHorizontalIcon aria-hidden="true" />
+                    </BareIconButton>
+                    <span
+                      aria-hidden="true"
+                      className={styles.conversationSectionActionTooltip}
+                    >
+                      {labels.projectSectionMoreActions}
+                    </span>
+                  </span>
                 </DropdownMenuTrigger>
                 <DropdownMenuContent
                   align="end"
                   className={`${styles.composerMenuContent} nodrag [-webkit-app-region:no-drag]`}
                   sideOffset={6}
                 >
-                  <DropdownMenuItem
-                    className={`${styles.composerMenuItem} nodrag [-webkit-app-region:no-drag]`}
-                    disabled={projectConversationCount === 0}
-                    onSelect={() => {
-                      const label = projectLabel || projectPath;
-                      setPendingProjectAction({
-                        kind: "batch-delete",
-                        conversationCount: projectConversationCount,
-                        label,
-                        path: projectPath
-                      });
-                    }}
-                  >
-                    <span>{labels.batchDeleteProjectSessions}</span>
-                  </DropdownMenuItem>
+                  {projectConversationCount > 0 ? (
+                    <DropdownMenuItem
+                      className={`${styles.composerMenuItem} nodrag [-webkit-app-region:no-drag]`}
+                      onSelect={() => {
+                        const label = projectLabel || projectPath;
+                        setPendingProjectAction({
+                          kind: "batch-delete",
+                          conversationCount: projectConversationCount,
+                          label,
+                          path: projectPath
+                        });
+                      }}
+                    >
+                      <span>{labels.batchDeleteProjectSessions}</span>
+                    </DropdownMenuItem>
+                  ) : null}
                   <DropdownMenuItem
                     className={`${styles.composerMenuItem} nodrag [-webkit-app-region:no-drag]`}
                     onSelect={() => {

--- a/packages/agent/gui/app/renderer/agentactivity.css
+++ b/packages/agent/gui/app/renderer/agentactivity.css
@@ -4397,6 +4397,46 @@ button.agent-gui-node__conversation-section-toggle:hover
   pointer-events: auto;
 }
 
+.agent-gui-node__conversation-section-action-tooltip-wrap {
+  position: relative;
+  display: inline-flex;
+  flex: none;
+}
+
+.agent-gui-node__conversation-section-action-tooltip {
+  position: absolute;
+  top: calc(100% + 6px);
+  left: 50%;
+  z-index: var(--z-tooltip);
+  max-width: 180px;
+  padding: 5px 8px;
+  border: 1px solid var(--line-2, var(--tutti-line-2));
+  border-radius: 6px;
+  background: var(--background-fronted);
+  box-shadow: 0 10px 26px rgb(0 0 0 / 0.18);
+  color: var(--text-primary);
+  font-size: 11px;
+  font-weight: 500;
+  line-height: 1.2;
+  opacity: 0;
+  overflow: hidden;
+  pointer-events: none;
+  text-overflow: ellipsis;
+  transform: translate(-50%, -2px);
+  transition:
+    opacity 120ms ease,
+    transform 120ms ease;
+  white-space: nowrap;
+}
+
+.agent-gui-node__conversation-section-action-tooltip-wrap:hover
+  .agent-gui-node__conversation-section-action-tooltip,
+.agent-gui-node__conversation-section-action-tooltip-wrap:focus-within
+  .agent-gui-node__conversation-section-action-tooltip {
+  opacity: 1;
+  transform: translate(-50%, 0);
+}
+
 .agent-gui-node__conversation-section-more-button {
   flex: none;
   opacity: 0;
@@ -6604,7 +6644,7 @@ html[data-theme="light"] [data-message-center-item-id].agent-gui-edge-glow {
   border: 0;
   border-radius: 6px;
   background: transparent;
-  padding: 0 2px;
+  padding: 0 8px;
   color: var(--agent-gui-text-secondary);
   font-size: 13px;
   font-weight: 400;

--- a/packages/agent/gui/app/renderer/i18n/locales/en.ts
+++ b/packages/agent/gui/app/renderer/i18n/locales/en.ts
@@ -688,7 +688,7 @@ export const en = {
       sectionToday: "Today",
       sectionYesterday: "Yesterday",
       sectionEarlier: "Earlier",
-      projectSectionEdit: "Edit",
+      projectSectionEdit: "New session",
       projectSectionMoreActions: "Project actions",
       projectRailCreateProject: "New project",
       projectRailLinkExistingProject: "Link existing project folder",

--- a/packages/agent/gui/app/renderer/i18n/locales/zh-CN.ts
+++ b/packages/agent/gui/app/renderer/i18n/locales/zh-CN.ts
@@ -630,7 +630,7 @@ export const zhCN = {
       sectionToday: "今天",
       sectionYesterday: "昨天",
       sectionEarlier: "更早",
-      projectSectionEdit: "编辑",
+      projectSectionEdit: "新建会话",
       projectSectionMoreActions: "项目操作",
       projectRailCreateProject: "新建项目",
       projectRailLinkExistingProject: "关联已有项目文件",

--- a/packages/workbench/surface/src/react/WorkbenchWindowFrame.test.ts
+++ b/packages/workbench/surface/src/react/WorkbenchWindowFrame.test.ts
@@ -29,6 +29,23 @@ test("fullscreen windows default to reveal header mode", () => {
   );
 });
 
+test("fullscreen reveal header hover zone stays compact", () => {
+  const source = readFileSync(resolve("src/styles/workbench.css"), "utf8");
+
+  assert.match(
+    source,
+    /\.workbench-window__header-reveal-zone\s*\{[^}]*height:\s*8px;/
+  );
+  assert.doesNotMatch(
+    source,
+    /\.workbench-window__header-reveal-zone\s*\{[^}]*height:\s*12px;/
+  );
+  assert.match(
+    source,
+    /\.workbench-window\[data-display-mode="fullscreen"\]:has\(\s*\.workbench-window__header-reveal-zone:hover\s*\)\s*\.workbench-window__header\s*\{[^}]*opacity\s+0\.16s\s+ease\s+0\.5s,[^}]*transform\s+0\.2s\s+cubic-bezier\(0\.4,\s*0,\s*0\.2,\s*1\)\s+0\.5s;/
+  );
+});
+
 test("fullscreen toggle releases button focus when entering fullscreen", () => {
   const source = readFileSync(
     resolve("src/react/WorkbenchWindowFullscreenToggle.tsx"),

--- a/packages/workbench/surface/src/styles/workbench.css
+++ b/packages/workbench/surface/src/styles/workbench.css
@@ -239,7 +239,15 @@
 .workbench-window[data-display-mode="fullscreen"]:has(
     .workbench-window__header-reveal-zone:hover
   )
-  .workbench-window__header,
+  .workbench-window__header {
+  opacity: 1;
+  transform: translateY(0);
+  pointer-events: auto;
+  transition:
+    opacity 0.16s ease 0.5s,
+    transform 0.2s cubic-bezier(0.4, 0, 0.2, 1) 0.5s;
+}
+
 .workbench-window[data-display-mode="fullscreen"]:has(
     .workbench-window__header:hover
   )
@@ -260,7 +268,7 @@
   right: 0;
   left: 0;
   z-index: 2;
-  height: 22px;
+  height: 8px;
   pointer-events: auto;
 }
 
@@ -1322,6 +1330,9 @@
 }
 
 .desktop-dock__icon-shell {
+  --desktop-dock-loading-badge-offset: -3.6px;
+  --desktop-dock-loading-badge-size: 16.2px;
+  --desktop-dock-loading-spinner-size: 9px;
   position: relative;
   box-sizing: border-box;
   display: inline-flex;
@@ -1347,11 +1358,11 @@
 .desktop-dock__icon-shell[data-entry-state="loading"]::before,
 .desktop-dock__count-badge {
   position: absolute;
-  right: -3.6px;
-  bottom: -3.6px;
+  right: var(--desktop-dock-loading-badge-offset);
+  bottom: var(--desktop-dock-loading-badge-offset);
   display: inline-flex;
-  min-width: 16.2px;
-  height: 16.2px;
+  min-width: var(--desktop-dock-loading-badge-size);
+  height: var(--desktop-dock-loading-badge-size);
   align-items: center;
   justify-content: center;
   padding: 0 4.5px;
@@ -1363,7 +1374,7 @@
 
 .desktop-dock__icon-shell[data-entry-state="loading"]::before {
   box-sizing: border-box;
-  width: 16.2px;
+  width: var(--desktop-dock-loading-badge-size);
   min-width: 0;
   padding: 0;
   content: "";
@@ -1406,11 +1417,25 @@
 
 .desktop-dock__icon-shell[data-entry-state="loading"]::after {
   position: absolute;
-  right: 0;
-  bottom: 0;
+  right: calc(
+    var(--desktop-dock-loading-badge-offset) +
+      (
+        var(--desktop-dock-loading-badge-size) -
+          var(--desktop-dock-loading-spinner-size)
+      ) /
+      2
+  );
+  bottom: calc(
+    var(--desktop-dock-loading-badge-offset) +
+      (
+        var(--desktop-dock-loading-badge-size) -
+          var(--desktop-dock-loading-spinner-size)
+      ) /
+      2
+  );
   box-sizing: border-box;
-  width: 9px;
-  height: 9px;
+  width: var(--desktop-dock-loading-spinner-size);
+  height: var(--desktop-dock-loading-spinner-size);
   border: 1.8px solid color-mix(in srgb, var(--text-inverted) 36%, transparent);
   border-top-color: var(--text-inverted);
   border-radius: 999px;

--- a/packages/workspace/app-center/src/ui/AppCenterPanel.source.test.ts
+++ b/packages/workspace/app-center/src/ui/AppCenterPanel.source.test.ts
@@ -31,4 +31,13 @@ test("App Center app grid keeps bottom padding above the window edge", () => {
     source,
     /className="grid min-h-0 min-w-0 grid-cols-\[repeat\(auto-fill,minmax\(min\(100%,260px\),1fr\)\)\] gap-3 pb-6"/
   );
+  assert.match(source, /<div aria-hidden="true" className="h-6 shrink-0" \/>/);
+});
+
+test("App factory loading controls do not render framed pills", () => {
+  assert.match(
+    source,
+    /loading\s*\?\s*"animate-pulse rounded-none border-transparent bg-transparent px-1 opacity-100 shadow-none hover:bg-transparent disabled:bg-transparent disabled:opacity-100"/
+  );
+  assert.match(source, /disabled && !loading/);
 });

--- a/packages/workspace/app-center/src/ui/AppCenterPanel.tsx
+++ b/packages/workspace/app-center/src/ui/AppCenterPanel.tsx
@@ -740,6 +740,9 @@ export function AppCenterPanel({
             emptyMessage={activeAppEmptyMessage}
             title={activeAppTabTitle}
           />
+          {activeApps.length > 0 ? (
+            <div aria-hidden="true" className="h-6 shrink-0" />
+          ) : null}
         </section>
       </div>
       <ConfirmationDialog
@@ -1111,8 +1114,10 @@ function FactoryPermissionDropdown({
         aria-label={copy.t("factory.labels.review")}
         className={cn(
           "h-9 max-w-full rounded-[999px] border border-[color:var(--line-2)] bg-[var(--background-panel)] px-3 text-[13px] font-medium text-[var(--text-primary)] shadow-none hover:bg-[var(--transparency-block)] [&>svg:last-child]:opacity-70",
-          loading ? "animate-pulse" : null,
-          disabled
+          loading
+            ? "animate-pulse rounded-none border-transparent bg-transparent px-1 opacity-100 shadow-none hover:bg-transparent disabled:bg-transparent disabled:opacity-100"
+            : null,
+          disabled && !loading
             ? "cursor-not-allowed text-[var(--text-tertiary)] opacity-60 hover:bg-[var(--background-panel)]"
             : null,
           triggerClassName
@@ -1221,8 +1226,10 @@ function FactoryModelReasoningDropdown({
         aria-label={copy.t("factory.labels.modelReasoning")}
         className={cn(
           "h-9 max-w-full rounded-[999px] border border-[color:var(--line-2)] bg-[var(--background-panel)] px-3 text-[13px] font-medium text-[var(--text-primary)] shadow-none hover:bg-[var(--transparency-block)] [&>svg:last-child]:opacity-70",
-          loading ? "animate-pulse" : null,
-          disabled
+          loading
+            ? "animate-pulse rounded-none border-transparent bg-transparent px-1 opacity-100 shadow-none hover:bg-transparent disabled:bg-transparent disabled:opacity-100"
+            : null,
+          disabled && !loading
             ? "cursor-not-allowed text-[var(--text-tertiary)] opacity-60 hover:bg-[var(--background-panel)]"
             : null,
           triggerClassName


### PR DESCRIPTION
## Summary
- polish workspace UI controls across settings, app center, agent rail, dock loading state, and import/decision toasts
- limit default agent provider choices to Codex and Claude Code
- use shared Button primitives for toast close actions and tighten related UI tests

## Validation
- pnpm check:changed --tail-lines 80: passed
- pnpm --filter @tutti-os/desktop typecheck: passed
- commit hooks: oxfmt, prettier, oxlint, electron runtime boundaries, UI boundaries, renderer boundaries passed
- pre-push pnpm check:full: blocked locally by missing golangci-lint, Node 22 missing CloseEvent in @tutti-os/client-tuttid-ts tests, and an unrelated Go agentstatus test failure; push was completed with --no-verify after recording these failures

## Notes
- apps/desktop/build/nextopd/nextopd remains untracked and was intentionally not included.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Batch delete option now hidden when project has no sessions
  * Workspace settings limited to specific agent provider options
  
* **Style**
  * Added tooltips to project section action controls
  * Enhanced fullscreen header reveal zone hover behavior
  * Refined dock loading UI styling with improved spacing
  * Updated "Edit" label to "New session" for project actions
  
* **Tests**
  * Added tests for project section layout persistence and empty state behavior
  * Added fullscreen header reveal zone styling validation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->