### PR TITLE
fix(desktop): isolate native file-icon generation in a worker process

### DIFF
--- a/apps/desktop/src/main/host/iconWorker/iconWorkerClient.ts
+++ b/apps/desktop/src/main/host/iconWorker/iconWorkerClient.ts
@@ -1,0 +1,196 @@
+import { type ChildProcess, spawn } from "node:child_process";
+import { createInterface, type Interface } from "node:readline";
+import {
+  ICON_WORKER_ROLE,
+  ICON_WORKER_ROLE_ENV,
+  ICON_WORKER_STDOUT_PREFIX,
+  type IconWorkerMode,
+  type IconWorkerRequestMessage,
+  type IconWorkerResponseMessage
+} from "./iconWorkerProtocol.ts";
+
+const requestTimeoutMs = 10_000;
+
+export interface IconWorkerIconRequest {
+  mode: IconWorkerMode;
+  path: string;
+  sizePx: number;
+}
+
+interface QueuedRequest {
+  key: string;
+  message: IconWorkerRequestMessage;
+  resolve: (bytes: Buffer | null) => void;
+}
+
+interface InFlightRequest extends QueuedRequest {
+  timer: ReturnType<typeof setTimeout>;
+}
+
+let child: ChildProcess | null = null;
+let reader: Interface | null = null;
+let nextRequestId = 1;
+let starting = false;
+const queue: QueuedRequest[] = [];
+let inFlight: InFlightRequest | null = null;
+// Inputs that crashed (or hung) the worker. Skipped for the rest of the session
+// so one malformed file never causes a crash/respawn loop.
+const poisonedKeys = new Set<string>();
+
+// Resolve a single icon by handing the native work to the disposable worker
+// process. Returns the PNG bytes, or `null` when no icon could be produced —
+// including when the worker died on this input — so callers fall back cleanly.
+export function requestWorkerIconPngBytes(
+  request: IconWorkerIconRequest
+): Promise<Buffer | null> {
+  const key = `${request.mode}:${request.path}`;
+  if (poisonedKeys.has(key)) {
+    return Promise.resolve(null);
+  }
+  // A worker would only spawn another worker by mistake; never recurse.
+  if (process.env[ICON_WORKER_ROLE_ENV] === ICON_WORKER_ROLE) {
+    return Promise.resolve(null);
+  }
+
+  return new Promise<Buffer | null>((resolve) => {
+    queue.push({
+      key,
+      message: {
+        id: nextRequestId++,
+        mode: request.mode,
+        path: request.path,
+        sizePx: request.sizePx
+      },
+      resolve
+    });
+    void pump();
+  });
+}
+
+async function pump(): Promise<void> {
+  if (inFlight || starting || queue.length === 0) {
+    return;
+  }
+  starting = true;
+  let worker: ChildProcess | null;
+  try {
+    worker = await ensureWorker();
+  } finally {
+    starting = false;
+  }
+  if (inFlight || queue.length === 0) {
+    return;
+  }
+  if (!worker?.stdin) {
+    // Worker unavailable: drain the queue with fallbacks.
+    for (const queued of queue.splice(0)) {
+      queued.resolve(null);
+    }
+    return;
+  }
+
+  const next = queue.shift();
+  if (!next) {
+    return;
+  }
+  const timer = setTimeout(() => {
+    poisonedKeys.add(next.key);
+    finishInFlight(null);
+    restartWorker();
+  }, requestTimeoutMs);
+  inFlight = { ...next, timer };
+
+  try {
+    worker.stdin.write(`${JSON.stringify(next.message)}\n`);
+  } catch {
+    finishInFlight(null);
+    restartWorker();
+  }
+}
+
+function finishInFlight(bytes: Buffer | null): void {
+  if (!inFlight) {
+    return;
+  }
+  clearTimeout(inFlight.timer);
+  inFlight.resolve(bytes);
+  inFlight = null;
+}
+
+async function ensureWorker(): Promise<ChildProcess | null> {
+  if (child) {
+    return child;
+  }
+  try {
+    // Re-launch this same app binary in worker mode. In dev the app dir must be
+    // passed to the Electron binary; packaged binaries relaunch themselves.
+    const { app } = await import("electron");
+    const args = app.isPackaged ? [] : [app.getAppPath()];
+    const spawned = spawn(process.execPath, args, {
+      env: { ...process.env, [ICON_WORKER_ROLE_ENV]: ICON_WORKER_ROLE },
+      stdio: ["pipe", "pipe", "inherit"]
+    });
+    spawned.on("exit", handleWorkerGone);
+    spawned.on("error", handleWorkerGone);
+
+    if (spawned.stdout) {
+      const lineReader = createInterface({ input: spawned.stdout });
+      lineReader.on("line", handleStdoutLine);
+      reader = lineReader;
+    }
+    child = spawned;
+    return spawned;
+  } catch {
+    child = null;
+    reader = null;
+    return null;
+  }
+}
+
+function handleStdoutLine(line: string): void {
+  if (!line.startsWith(ICON_WORKER_STDOUT_PREFIX)) {
+    return;
+  }
+  let message: IconWorkerResponseMessage;
+  try {
+    message = JSON.parse(
+      line.slice(ICON_WORKER_STDOUT_PREFIX.length)
+    ) as IconWorkerResponseMessage;
+  } catch {
+    return;
+  }
+  if (!inFlight || inFlight.message.id !== message.id) {
+    return;
+  }
+  const bytes = message.pngBase64
+    ? Buffer.from(message.pngBase64, "base64")
+    : null;
+  finishInFlight(bytes);
+  void pump();
+}
+
+function handleWorkerGone(): void {
+  reader?.close();
+  reader = null;
+  child = null;
+  // Whatever request was in flight is the prime suspect for the crash; poison it
+  // so we never feed it back to a fresh worker.
+  if (inFlight) {
+    poisonedKeys.add(inFlight.key);
+    finishInFlight(null);
+  }
+  void pump();
+}
+
+function restartWorker(): void {
+  const dying = child;
+  child = null;
+  reader?.close();
+  reader = null;
+  if (dying) {
+    dying.removeListener("exit", handleWorkerGone);
+    dying.removeListener("error", handleWorkerGone);
+    dying.kill();
+  }
+  void pump();
+}

--- a/apps/desktop/src/main/host/iconWorker/iconWorkerProcess.ts
+++ b/apps/desktop/src/main/host/iconWorker/iconWorkerProcess.ts
@@ -1,0 +1,134 @@
+import { readFile } from "node:fs/promises";
+import { createInterface } from "node:readline";
+import {
+  ICON_WORKER_STDOUT_PREFIX,
+  type IconWorkerRequestMessage,
+  type IconWorkerResponseMessage
+} from "./iconWorkerProtocol.ts";
+
+type ElectronApp = typeof import("electron").app;
+type ElectronNativeImage = typeof import("electron").nativeImage;
+
+// Entry point for the child process spawned with `TUTTI_ROLE=icon-worker`.
+// Reads newline-delimited JSON requests on stdin and replies on stdout. If a
+// native call aborts the process, the parent observes the exit and recovers.
+export function runIconWorkerProcess(): void {
+  void start().catch((error) => {
+    process.stderr.write(
+      `[icon-worker] failed to start: ${error instanceof Error ? (error.stack ?? error.message) : String(error)}\n`
+    );
+    process.exit(1);
+  });
+}
+
+async function start(): Promise<void> {
+  const { app, nativeImage } = await import("electron");
+  // Run headless: no windows, no dock icon, no app-switcher presence.
+  app.dock?.hide();
+  await app.whenReady();
+
+  const reader = createInterface({ input: process.stdin });
+  reader.on("line", (line) => {
+    void handleLine(line, app, nativeImage);
+  });
+  // When the parent goes away its end of the pipe closes; exit with it.
+  reader.on("close", () => {
+    app.quit();
+  });
+}
+
+async function handleLine(
+  line: string,
+  app: ElectronApp,
+  nativeImage: ElectronNativeImage
+): Promise<void> {
+  const trimmed = line.trim();
+  if (!trimmed) {
+    return;
+  }
+
+  let request: IconWorkerRequestMessage;
+  try {
+    request = JSON.parse(trimmed) as IconWorkerRequestMessage;
+  } catch {
+    return;
+  }
+
+  let pngBase64: string | null = null;
+  try {
+    const bytes =
+      request.mode === "fileIcon"
+        ? await readFileIconPng(app, request.path, request.sizePx)
+        : await readImageThumbnailPng(nativeImage, request.path, request.sizePx);
+    pngBase64 = bytes ? bytes.toString("base64") : null;
+  } catch {
+    pngBase64 = null;
+  }
+
+  respond({ id: request.id, pngBase64 });
+}
+
+function respond(message: IconWorkerResponseMessage): void {
+  process.stdout.write(
+    `${ICON_WORKER_STDOUT_PREFIX}${JSON.stringify(message)}\n`
+  );
+}
+
+async function readFileIconPng(
+  app: ElectronApp,
+  targetPath: string,
+  sizePx: number
+): Promise<Buffer | null> {
+  if (process.platform !== "darwin" && process.platform !== "win32") {
+    return null;
+  }
+  const icon = await app.getFileIcon(targetPath, { size: "large" });
+  if (icon.isEmpty()) {
+    return null;
+  }
+  return icon.resize({ height: sizePx, width: sizePx }).toPNG();
+}
+
+async function readImageThumbnailPng(
+  nativeImage: ElectronNativeImage,
+  targetPath: string,
+  maxEdgePx: number
+): Promise<Buffer | null> {
+  let image = nativeImage.createFromPath(targetPath);
+  if (image.isEmpty()) {
+    image = nativeImage.createFromBuffer(await readFile(targetPath));
+  }
+  if (image.isEmpty()) {
+    return null;
+  }
+
+  const sourceSize = image.getSize();
+  if (!isValidImageSize(sourceSize)) {
+    return null;
+  }
+
+  const scale = Math.min(
+    1,
+    maxEdgePx / Math.max(sourceSize.width, sourceSize.height)
+  );
+  const output =
+    scale < 1
+      ? image.resize({
+          height: Math.max(1, Math.round(sourceSize.height * scale)),
+          width: Math.max(1, Math.round(sourceSize.width * scale))
+        })
+      : image;
+  if (output.isEmpty()) {
+    return null;
+  }
+  return output.toPNG();
+}
+
+function isValidImageSize(size: { height: number; width: number }): boolean {
+  return (
+    Number.isFinite(size.height) &&
+    Number.isFinite(size.width) &&
+    size.height > 0 &&
+    size.width > 0
+  );
+}

--- a/apps/desktop/src/main/host/iconWorker/iconWorkerProtocol.ts
+++ b/apps/desktop/src/main/host/iconWorker/iconWorkerProtocol.ts
@@ -1,0 +1,29 @@
+// Shared protocol between the main process and the isolated icon worker process.
+//
+// Native icon/thumbnail generation (`app.getFileIcon`, `nativeImage.*`) can hard
+// abort the process on malformed inputs (e.g. an `.app` bundle whose `.icns`
+// declares a size that mismatches its real image data). Such aborts happen below
+// the JS layer, so a `try/catch` cannot contain them. To keep the main process
+// alive we run all native icon work in a disposable child process and treat its
+// death as "produce a fallback icon" rather than "crash the app".
+
+export const ICON_WORKER_ROLE_ENV = "TUTTI_ROLE";
+export const ICON_WORKER_ROLE = "icon-worker";
+
+// Every worker response line is prefixed with this sentinel so the parent can
+// ignore unrelated stdout noise emitted by Electron/Chromium.
+export const ICON_WORKER_STDOUT_PREFIX = "@@tutti-icon-worker@@ ";
+
+export type IconWorkerMode = "fileIcon" | "imageThumbnail";
+
+export interface IconWorkerRequestMessage {
+  id: number;
+  mode: IconWorkerMode;
+  path: string;
+  sizePx: number;
+}
+
+export interface IconWorkerResponseMessage {
+  id: number;
+  pngBase64: string | null;
+}

--- a/apps/desktop/src/main/host/openWithApplications.ts
+++ b/apps/desktop/src/main/host/openWithApplications.ts
@@ -7,6 +7,7 @@ import path from "node:path";
 import { promisify } from "node:util";
 import type { DesktopOpenWithApplication } from "../../shared/contracts/ipc.ts";
 import { resolveOpenWithApplicationIconOverrideDataUrl } from "../../shared/openWithApplicationIconOverrides.ts";
+import { requestWorkerIconPngBytes } from "./iconWorker/iconWorkerClient.ts";
 
 const execFileAsync = promisify(execFile);
 type ExecFileAsync = (
@@ -508,21 +509,17 @@ export async function readApplicationIconDataUrl(
 
   const iconPath = resolveApplicationIconPath(applicationPath);
   if (iconPath) {
-    try {
-      const { nativeImage } = await import("electron");
-      const image = nativeImage.createFromPath(iconPath);
-      if (!image.isEmpty()) {
-        const iconDataUrl = image
-          .resize({
-            height: applicationIconPixelSize,
-            width: applicationIconPixelSize
-          })
-          .toDataURL();
-        applicationIconDataUrlByPath.set(applicationPath, iconDataUrl);
-        return iconDataUrl;
-      }
-    } catch {
-      // Fall through to NSWorkspace icon lookup.
+    // Decode the bundle icon in the isolated worker process; a malformed
+    // `.icns` can hard-abort native image decoding otherwise.
+    const iconPngBytes = await requestWorkerIconPngBytes({
+      mode: "imageThumbnail",
+      path: iconPath,
+      sizePx: applicationIconPixelSize
+    });
+    if (iconPngBytes) {
+      const iconDataUrl = `data:image/png;base64,${iconPngBytes.toString("base64")}`;
+      applicationIconDataUrlByPath.set(applicationPath, iconDataUrl);
+      return iconDataUrl;
     }
   }
 

--- a/apps/desktop/src/main/host/workspaceFileEntryIcon.ts
+++ b/apps/desktop/src/main/host/workspaceFileEntryIcon.ts
@@ -1,9 +1,10 @@
-import { readFile, stat } from "node:fs/promises";
+import { stat } from "node:fs/promises";
 import { pathToFileURL } from "node:url";
 import {
   resolveWorkspaceFileDefaultApplicationIconExtension,
   resolveWorkspaceFileVisualKind
 } from "@tutti-os/workspace-file-manager/services";
+import { requestWorkerIconPngBytes } from "./iconWorker/iconWorkerClient.ts";
 import {
   readApplicationIconDataUrl,
   resolveDefaultApplicationForFile
@@ -252,71 +253,29 @@ function dataUrlToPngBytes(dataUrl: string | null): Buffer | null {
   return bytes.byteLength > 0 ? bytes : null;
 }
 
+// Native icon generation runs in a disposable worker process: `app.getFileIcon`
+// can hard-abort on malformed bundles, which a try/catch here cannot contain.
 async function readNativeFileIconPngBytes(
   targetPath: string
 ): Promise<Buffer | null> {
   if (process.platform !== "darwin" && process.platform !== "win32") {
     return null;
   }
-
-  try {
-    const { app } = await import("electron");
-    const icon = await app.getFileIcon(targetPath, { size: "large" });
-    if (icon.isEmpty()) {
-      return null;
-    }
-    return icon
-      .resize({ height: entryIconPixelSize, width: entryIconPixelSize })
-      .toPNG();
-  } catch {
-    return null;
-  }
+  return requestWorkerIconPngBytes({
+    mode: "fileIcon",
+    path: targetPath,
+    sizePx: entryIconPixelSize
+  });
 }
 
+// Decoding arbitrary image files is likewise isolated in the worker process.
 async function readImageThumbnailPngBytes(
   targetPath: string,
   maxEdgePx: number
 ): Promise<Buffer | null> {
-  try {
-    const { nativeImage } = await import("electron");
-    let image = nativeImage.createFromPath(targetPath);
-    if (image.isEmpty()) {
-      image = nativeImage.createFromBuffer(await readFile(targetPath));
-    }
-    if (image.isEmpty()) {
-      return null;
-    }
-
-    const sourceSize = image.getSize();
-    if (!isValidImageSize(sourceSize)) {
-      return null;
-    }
-
-    const scale = Math.min(
-      1,
-      maxEdgePx / Math.max(sourceSize.width, sourceSize.height)
-    );
-    const output =
-      scale < 1
-        ? image.resize({
-            height: Math.max(1, Math.round(sourceSize.height * scale)),
-            width: Math.max(1, Math.round(sourceSize.width * scale))
-          })
-        : image;
-    if (output.isEmpty()) {
-      return null;
-    }
-    return output.toPNG();
-  } catch {
-    return null;
-  }
-}
-
-function isValidImageSize(size: { height: number; width: number }): boolean {
-  return (
-    Number.isFinite(size.height) &&
-    Number.isFinite(size.width) &&
-    size.height > 0 &&
-    size.width > 0
-  );
+  return requestWorkerIconPngBytes({
+    mode: "imageThumbnail",
+    path: targetPath,
+    sizePx: maxEdgePx
+  });
 }

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -1,19 +1,34 @@
 import { app } from "electron";
 import { bootstrapDesktopApp } from "./bootstrap";
+import {
+  ICON_WORKER_ROLE,
+  ICON_WORKER_ROLE_ENV
+} from "./host/iconWorker/iconWorkerProtocol.ts";
 import { recordStartupFailureEvent } from "./startupFailureAnalytics.ts";
 
-void bootstrapDesktopApp().catch(async (error) => {
-  await recordStartupFailureEvent({
-    error,
-    name: "app.startup_failed",
-    process: "main"
-  }).catch((recordError) => {
-    process.stderr.write(
-      `[desktop] record startup failure analytics failed: ${recordError instanceof Error ? (recordError.stack ?? recordError.message) : String(recordError)}\n`
-    );
-  });
-  process.stderr.write(
-    `[desktop] bootstrap failed: ${error instanceof Error ? (error.stack ?? error.message) : String(error)}\n`
+if (process.env[ICON_WORKER_ROLE_ENV] === ICON_WORKER_ROLE) {
+  // Disposable child process that owns crash-prone native icon generation.
+  // Bootstrap is never invoked in this role, so privileged-scheme/app-ready
+  // setup stays exclusive to the primary process.
+  void import("./host/iconWorker/iconWorkerProcess.ts").then(
+    ({ runIconWorkerProcess }) => {
+      runIconWorkerProcess();
+    }
   );
-  app.exit(1);
-});
+} else {
+  void bootstrapDesktopApp().catch(async (error) => {
+    await recordStartupFailureEvent({
+      error,
+      name: "app.startup_failed",
+      process: "main"
+    }).catch((recordError) => {
+      process.stderr.write(
+        `[desktop] record startup failure analytics failed: ${recordError instanceof Error ? (recordError.stack ?? recordError.message) : String(recordError)}\n`
+      );
+    });
+    process.stderr.write(
+      `[desktop] bootstrap failed: ${error instanceof Error ? (error.stack ?? error.message) : String(error)}\n`
+    );
+    app.exit(1);
+  });
+}


### PR DESCRIPTION
## Problem

Opening a directory that contains a malformed `.app` bundle crashes the **entire** desktop app (full `闪退`).

Root cause, confirmed by a 20-line standalone repro that uses only Electron APIs (no Tutti code):
- The file manager generates icons for directory entries. For `.app` bundles it calls `app.getFileIcon()` **in the main process**.
- A bundle whose `AppIcon.icns` declares a type tag (`ic12`, nominally 64px) that mismatches its real `1024×1024` image data makes macOS IconServices / Electron **hard-abort** below the JS layer (`EXC_BREAKPOINT`).
- A native abort cannot be caught by `try/catch`, so the whole main process dies — independent of memory or uptime.

## Fix

Run all crash-prone native icon/thumbnail work in a **disposable child Electron process**, re-forked from the same binary via `TUTTI_ROLE=icon-worker`:

- **`host/iconWorker/iconWorkerProtocol.ts`** — shared request/response + role constants.
- **`host/iconWorker/iconWorkerProcess.ts`** — child entry that owns `app.getFileIcon` / `nativeImage.*`; headless (no window/dock), stdin/stdout JSON protocol.
- **`host/iconWorker/iconWorkerClient.ts`** — parent client: lazy spawn, **serialized** dispatch, per-request **timeout**, crash **auto-restart**, and a **poison set** so an input that killed the worker is never retried (no crash loop).
- `workspaceFileEntryIcon.ts` / `openWithApplications.ts` route their native icon calls through the worker; `index.ts` dispatches the worker role before bootstrap.

When the worker dies on a bad input, the main process survives and the entry falls back to a default icon.

## Verification

- `pnpm typecheck`, `oxlint --deny-warnings`, and `node --test` (icon + open-with suites, 20 pass / 0 fail) all green.
- Manual repro in the dev app: before → opening the Desktop folder crashes the whole app; after → only the icon-worker child dies (contained, exactly once), the main process stays alive, the bundle shows a fallback icon, and the directory renders normally.

## Notes

- The triggering bundle (`My Desktop.app`, `com.team-shell.my-desktop`) ships a malformed `.icns`; it now renders a fallback icon. Worth fixing the `.app` packaging toolchain that produces the bad `.icns` separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved application responsiveness by offloading icon processing to a dedicated worker process, reducing main process overhead when extracting file icons and generating image thumbnails.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->