### PR TITLE
Render Claude Code ACP user prompts in session detail

### DIFF
--- a/packages/agent/gui/shared/workspaceAgentSessionDetailViewModel.spec.ts
+++ b/packages/agent/gui/shared/workspaceAgentSessionDetailViewModel.spec.ts
@@ -759,6 +759,85 @@ describe("buildWorkspaceAgentSessionDetailViewModel", () => {
     expect(view.turns[0]?.hasFailedToolCall).toBe(false);
   });
 
+  it("renders Claude Code user messages delivered as ACP content blocks", () => {
+    const claudeSession: AgentHostWorkspaceAgentSession = {
+      ...session,
+      provider: "claude-code",
+      status: "working",
+      effectiveStatus: "working"
+    };
+
+    const view = buildWorkspaceAgentSessionDetailViewModel({
+      activity: { ...activity, agentProvider: "claude-code" },
+      session: claudeSession,
+      timelineItems: [
+        item({
+          id: 70,
+          seq: 70,
+          turnId: "turn-acp",
+          itemType: "message.user",
+          role: "user",
+          status: "completed",
+          // Durable ACP user prompt: text lives only in the content-block array,
+          // with no `text` mirror or top-level `content`.
+          payload: {
+            content: [{ type: "text", text: "请帮我修复登录页" }],
+            streamState: "completed"
+          }
+        }),
+        item({
+          id: 71,
+          seq: 71,
+          turnId: "turn-acp",
+          itemType: "message.assistant",
+          role: "assistant",
+          status: "completed",
+          payload: { content: "已修复登录页。", streamState: "completed" }
+        })
+      ]
+    });
+
+    expect(view.turns).toHaveLength(1);
+    expect(view.turns[0]?.userMessage?.body).toBe("请帮我修复登录页");
+    expect(view.turns[0]?.agentMessages?.[0]?.body).toBe("已修复登录页。");
+    // The turn completed, so the processing indicator must not linger even
+    // though the session status still lags at "working".
+    expect(view.showProcessingIndicator).toBe(false);
+  });
+
+  it("does not strand the processing indicator when the only message is an ACP content-block user prompt", () => {
+    const claudeSession: AgentHostWorkspaceAgentSession = {
+      ...session,
+      provider: "claude-code",
+      status: "working",
+      effectiveStatus: "working"
+    };
+
+    const view = buildWorkspaceAgentSessionDetailViewModel({
+      activity: { ...activity, agentProvider: "claude-code" },
+      session: claudeSession,
+      timelineItems: [
+        item({
+          id: 80,
+          seq: 80,
+          turnId: "turn-acp-plan",
+          itemType: "message.user",
+          role: "user",
+          status: "completed",
+          payload: {
+            content: [{ type: "text", text: "开始规划这个任务" }],
+            streamState: "completed"
+          }
+        })
+      ]
+    });
+
+    // Before the fix the empty body dropped the user message, leaving zero turns
+    // and a stranded "Planning next moves" spinner with nothing rendered.
+    expect(view.turns).toHaveLength(1);
+    expect(view.turns[0]?.userMessage?.body).toBe("开始规划这个任务");
+  });
+
   it("renders the actual command from failed Codex exec tool payloads instead of raw error JSON", () => {
     const view = buildWorkspaceAgentSessionDetailViewModel({
       activity,

--- a/packages/agent/gui/shared/workspaceAgentTimelineMessageHelpers.ts
+++ b/packages/agent/gui/shared/workspaceAgentTimelineMessageHelpers.ts
@@ -36,6 +36,17 @@ export function messageBody(item: WorkspaceAgentActivityTimelineItem): string {
     return isWorkspaceAgentSyntheticControlMessage(content) ? "" : content;
   }
 
+  // ACP user prompts (and other providers that snapshot structured prompt
+  // content) persist the body as an array of content blocks, e.g.
+  // `[{ type: "text", text: "..." }]`. Live runtime events also mirror the text
+  // into `payload.text`, but durable timeline items can arrive carrying only the
+  // structured `content` array. Extract the text so the message still renders
+  // instead of being dropped as an empty body.
+  const blockText = contentBlocksText(payloadContent);
+  if (blockText) {
+    return isWorkspaceAgentSyntheticControlMessage(blockText) ? "" : blockText;
+  }
+
   const content = item.content?.trim();
   if (content) {
     return isWorkspaceAgentSyntheticControlMessage(content) ? "" : content;
@@ -47,6 +58,27 @@ export function messageBody(item: WorkspaceAgentActivityTimelineItem): string {
   }
   const text = payloadText.trim();
   return isWorkspaceAgentSyntheticControlMessage(text) ? "" : text;
+}
+
+function contentBlocksText(value: unknown): string {
+  if (!Array.isArray(value)) {
+    return "";
+  }
+  const parts: string[] = [];
+  for (const block of value) {
+    if (!block || typeof block !== "object") {
+      continue;
+    }
+    const record = block as Record<string, unknown>;
+    if (record.type !== undefined && record.type !== "text") {
+      continue;
+    }
+    const text = record.text;
+    if (typeof text === "string" && text.trim()) {
+      parts.push(text.trim());
+    }
+  }
+  return parts.join("\n").trim();
 }
 
 export function thinkingStatusKind(


### PR DESCRIPTION
## Summary
- renders Claude Code ACP user prompts persisted as content blocks in agent session detail
- keeps the timeline projection aligned with the stored ACP message shape
- adds coverage for the content-block prompt case

## Validation
- `git status --short --branch` clean
- branch passed local commit-time checks from the agent session
- pre-push `pnpm check:full` was blocked by existing Go test failures in `services/tuttid/service/agentstatus` and `services/tuttid/types`