### PR TITLE
Dedupe Codex reply snapshots

### DIFF
--- a/packages/agent/daemon/runtime/acp_turn_normalizer.go
+++ b/packages/agent/daemon/runtime/acp_turn_normalizer.go
@@ -82,10 +82,13 @@ func (n *acpTurnNormalizer) ApplyAssistantFinalText(finalText string) {
 	if finalText == "" {
 		return
 	}
-	if n.assistantMessageID == "" || n.assistantSegmentCompleted {
-		n.assistantMessageID = newID()
-		n.assistantSegmentCompleted = false
+	if n.assistantSegmentCompleted && strings.TrimSpace(n.assistantContent.String()) == finalText {
+		return
 	}
+	if n.assistantMessageID == "" {
+		n.assistantMessageID = newID()
+	}
+	n.assistantSegmentCompleted = false
 	n.assistantContent.Reset()
 	_, _ = n.assistantContent.WriteString(finalText)
 }

--- a/packages/agent/daemon/runtime/codex_appserver_events_test.go
+++ b/packages/agent/daemon/runtime/codex_appserver_events_test.go
@@ -3,6 +3,8 @@ package agentruntime
 import (
 	"reflect"
 	"testing"
+
+	activityshared "github.com/tutti-os/tutti/packages/agentactivity/daemon/activity/events"
 )
 
 // appServerUserInputAnswers is the codex-specific translation of the GUI's
@@ -94,6 +96,36 @@ func TestAppServerUserInputIncludesSkillAndMentionItems(t *testing.T) {
 	}
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("appServerUserInput = %#v, want %#v", got, want)
+	}
+}
+
+func TestAppServerAgentMessageCompletedAndFinalTurnDoNotDuplicateReply(t *testing.T) {
+	t.Parallel()
+
+	session := testSession()
+	normalizer := newACPTurnNormalizer()
+	var events []activityshared.Event
+	events = append(events, normalizer.AppendAssistantChunk(session, "turn-1", "Done.")...)
+	events = append(events, (&CodexAppServerAdapter{}).appServerItemEvents(
+		session,
+		"turn-1",
+		map[string]any{"type": "agentMessage", "text": "Done."},
+		true,
+		normalizer,
+	)...)
+	finalTurn := map[string]any{
+		"status": "completed",
+		"items":  []any{map[string]any{"type": "agentMessage", "text": "Done."}},
+	}
+	normalizer.ApplyAssistantFinalText(appServerTurnFinalAssistantText(finalTurn))
+	events = append(events, appServerTurnTerminalEvents(session, "turn-1", finalTurn, normalizer)...)
+
+	assistantMessages := activityMessagesWithRole(events, activityshared.MessageRoleAssistant)
+	if len(assistantMessages) != 2 {
+		t.Fatalf("assistant message events = %d, want streaming+completed only", len(assistantMessages))
+	}
+	if assistantMessages[0].EventID == "" || assistantMessages[1].EventID != assistantMessages[0].EventID {
+		t.Fatalf("assistant event IDs = %#v, want one stable message id", assistantMessages)
 	}
 }
 

--- a/packages/agent/gui/shared/agentConversation/projection/workspaceAgentMessageProjection.spec.ts
+++ b/packages/agent/gui/shared/agentConversation/projection/workspaceAgentMessageProjection.spec.ts
@@ -239,6 +239,44 @@ describe("projectWorkspaceAgentMessagesToConversationVM", () => {
     expect(bodies).toEqual(["I'll check the repo.Distinct message."]);
   });
 
+  it("dedupes Codex streaming and final snapshots with different message ids", () => {
+    const conversation = projectWorkspaceAgentMessagesToConversationVM({
+      activity: activity(),
+      session: session(),
+      workspaceRoot: "/workspace/demo",
+      messages: [
+        message({
+          messageId: "assistant-stream-1",
+          id: 1,
+          version: 1,
+          role: "assistant",
+          kind: "text",
+          payload: { source: "runtime", text: "Done." }
+        }),
+        message({
+          messageId: "assistant-final-1",
+          id: 2,
+          version: 2,
+          role: "assistant",
+          kind: "text",
+          payload: { source: "runtime", text: "Done." }
+        })
+      ]
+    });
+
+    const bodies = conversation.rows
+      .filter(
+        (
+          row
+        ): row is Extract<
+          (typeof conversation.rows)[number],
+          { kind: "message" }
+        > => row.kind === "message"
+      )
+      .flatMap((row) => row.messages.map((item) => item.body));
+    expect(bodies).toEqual(["Done."]);
+  });
+
   it("projects only the latest reasoning snapshot for a stable message id", () => {
     const conversation = projectWorkspaceAgentMessagesToConversationVM({
       activity: activity(),

--- a/packages/agent/gui/shared/agentConversation/projection/workspaceAgentMessageProjection.ts
+++ b/packages/agent/gui/shared/agentConversation/projection/workspaceAgentMessageProjection.ts
@@ -1,5 +1,6 @@
 import type { BuildWorkspaceAgentSessionDetailInput } from "../../workspaceAgentSessionDetailViewModel";
 import { buildCanonicalWorkspaceAgentDetailView } from "../../workspaceAgentTimelineCanonical";
+import { normalizedMessageBody } from "../../workspaceAgentTimelineMessageHelpers";
 import type { AgentConversationVM } from "../contracts/agentConversationVM";
 import {
   projectAgentConversationVM,
@@ -36,8 +37,8 @@ export function projectWorkspaceAgentMessagesToConversationVM(
 export function projectWorkspaceAgentMessagesToTimelineItems(
   messages: readonly WorkspaceAgentActivityMessage[]
 ): WorkspaceAgentActivityTimelineItem[] {
-  const sortedMessages = latestMessageSnapshots(messages).sort(
-    compareMessagesByDisplayOrder
+  const sortedMessages = dedupeAdjacentAssistantTextSnapshots(
+    latestMessageSnapshots(messages).sort(compareMessagesByDisplayOrder)
   );
   const mergedToolPayloadByKey = new Map<string, Record<string, unknown>>();
 
@@ -157,6 +158,52 @@ export function projectWorkspaceAgentMessagesToTimelineItems(
       occurredAtUnixMs
     });
   });
+}
+
+function dedupeAdjacentAssistantTextSnapshots(
+  messages: readonly WorkspaceAgentActivityMessage[]
+): WorkspaceAgentActivityMessage[] {
+  const deduped: WorkspaceAgentActivityMessage[] = [];
+  for (const message of messages) {
+    const previous = deduped.at(-1);
+    if (previous && isDuplicateAssistantTextSnapshot(previous, message)) {
+      continue;
+    }
+    deduped.push(message);
+  }
+  return deduped;
+}
+
+function isDuplicateAssistantTextSnapshot(
+  previous: WorkspaceAgentActivityMessage,
+  next: WorkspaceAgentActivityMessage
+): boolean {
+  if (
+    !isRuntimeAssistantTextSnapshot(previous) ||
+    !isRuntimeAssistantTextSnapshot(next)
+  ) {
+    return false;
+  }
+  if ((previous.turnId?.trim() || "") !== (next.turnId?.trim() || "")) {
+    return false;
+  }
+  return (
+    normalizedMessageBody(messageText(previous)) ===
+    normalizedMessageBody(messageText(next))
+  );
+}
+
+function isRuntimeAssistantTextSnapshot(
+  message: WorkspaceAgentActivityMessage
+): boolean {
+  const payload = normalizedPayload(message.payload);
+  const role = normalizeToken(message.role);
+  return (
+    normalizeToken(message.kind) === "text" &&
+    (role === "assistant" || role === "agent") &&
+    stringValue(payload.source) === "runtime" &&
+    messageText(message).trim() !== ""
+  );
 }
 
 function latestMessageSnapshots(


### PR DESCRIPTION
## Summary
- dedupes Codex reply snapshots during ACP turn normalization and message projection
- prevents repeated assistant reply rendering when the same final snapshot is seen more than once
- adds daemon and renderer projection coverage

## Validation
- `git status --short --branch` clean
- targeted tests were added by the fixing agent
- pre-push `pnpm check:full` was blocked by existing Go test failures in `services/tuttid/service/agentstatus` and `services/tuttid/types`