### PR TITLE
Share agent session projection in message center

### DIFF
--- a/apps/desktop/src/renderer/src/features/workspace-workbench/ui/IssueManagerLatestRunMessageCenterCard.test.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/ui/IssueManagerLatestRunMessageCenterCard.test.ts
@@ -27,3 +27,12 @@ test("issue manager card does not submit the deck prompt interactively", () => {
     /workspaceAgentActivityService\.submitInteractive\(/
   );
 });
+
+test("issue manager card projects latest runs through message center snapshot", () => {
+  assert.match(source, /issueManagerLatestRunMessageCenterSnapshot/);
+  assert.match(
+    source,
+    /buildWorkspaceAgentMessageCenterModel\(messageCenterSnapshot,/
+  );
+  assert.match(source, /findWorkspaceAgentSession\(messageCenterSnapshot,/);
+});

--- a/apps/desktop/src/renderer/src/features/workspace-workbench/ui/IssueManagerLatestRunMessageCenterCard.tsx
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/ui/IssueManagerLatestRunMessageCenterCard.tsx
@@ -108,9 +108,18 @@ function IssueManagerLatestRunMessageCenterCard({
     void workspaceAgentActivityService.load(workspaceId);
   }, [workspaceAgentActivityService, workspaceId]);
 
+  const messageCenterSnapshot = useMemo(
+    () =>
+      issueManagerLatestRunMessageCenterSnapshot({
+        agentSessionId,
+        input,
+        snapshot
+      }),
+    [agentSessionId, input, snapshot]
+  );
   const model = useMemo(
     () =>
-      buildWorkspaceAgentMessageCenterModel(snapshot, {
+      buildWorkspaceAgentMessageCenterModel(messageCenterSnapshot, {
         promptFallbackLabels: {
           constraintHeader: i18n.t(
             "workspace.agentMessageCenter.promptConstraintHeader"
@@ -121,11 +130,11 @@ function IssueManagerLatestRunMessageCenterCard({
         },
         workspaceRoot: null
       }),
-    [i18n, snapshot]
+    [i18n, messageCenterSnapshot]
   );
   const targetSession = useMemo(
-    () => findWorkspaceAgentSession(snapshot, agentSessionId),
-    [agentSessionId, snapshot]
+    () => findWorkspaceAgentSession(messageCenterSnapshot, agentSessionId),
+    [agentSessionId, messageCenterSnapshot]
   );
   const modelItem = useMemo(
     () =>
@@ -286,6 +295,68 @@ function findWorkspaceAgentSession(
   );
 }
 
+function issueManagerLatestRunMessageCenterSnapshot({
+  agentSessionId,
+  input,
+  snapshot
+}: {
+  agentSessionId: string;
+  input: IssueManagerLatestRunStatusRenderInput;
+  snapshot: AgentActivitySnapshot;
+}): AgentActivitySnapshot {
+  if (
+    !agentSessionId ||
+    findWorkspaceAgentSession(snapshot, agentSessionId) ||
+    !hasCachedIssueManagerRunMessages(
+      snapshot.sessionMessagesById,
+      agentSessionId
+    )
+  ) {
+    return snapshot;
+  }
+  const latestRun = input.latestRun;
+  const timestamp = issueManagerRunTimestampToUnixMs(
+    latestRun.updatedAtUnix ??
+      latestRun.completedAtUnix ??
+      latestRun.startedAtUnix ??
+      latestRun.createdAtUnix
+  );
+  return {
+    ...snapshot,
+    sessions: [
+      ...snapshot.sessions,
+      {
+        workspaceId: snapshot.workspaceId || latestRun.workspaceId,
+        agentSessionId,
+        provider: latestRun.agentProvider?.trim() || "codex",
+        cwd: latestRun.executionDirectory?.trim() || "",
+        title: input.title || agentSessionId,
+        status: issueManagerRunStatusToAgentActivityStatus(latestRun.status),
+        userId: latestRun.requesterUserId?.trim() || undefined,
+        visible: true,
+        createdAtUnixMs: issueManagerRunTimestampToUnixMs(
+          latestRun.createdAtUnix
+        ),
+        startedAtUnixMs: issueManagerRunTimestampToUnixMs(
+          latestRun.startedAtUnix
+        ),
+        endedAtUnixMs: issueManagerRunTimestampToUnixMs(
+          latestRun.completedAtUnix
+        ),
+        updatedAtUnixMs: timestamp,
+        lastEventUnixMs: timestamp
+      }
+    ]
+  };
+}
+
+function hasCachedIssueManagerRunMessages(
+  sessionMessagesById: AgentActivitySnapshot["sessionMessagesById"],
+  agentSessionId: string
+): boolean {
+  return (sessionMessagesById[agentSessionId.trim()]?.length ?? 0) > 0;
+}
+
 function findWorkspaceAgentMessageCenterItem({
   agentSessionId,
   itemCandidates,
@@ -369,6 +440,24 @@ function issueManagerRunStatusToMessageCenterStatus(
       return "canceled";
     default:
       return "idle";
+  }
+}
+
+function issueManagerRunStatusToAgentActivityStatus(status: string): string {
+  switch (status) {
+    case "running":
+    case "in_progress":
+      return "working";
+    case "pending_acceptance":
+      return "waiting";
+    case "completed":
+    case "failed":
+    case "canceled":
+      return status;
+    case "not_started":
+      return "queued";
+    default:
+      return "unknown";
   }
 }
 

--- a/packages/agent/gui/agent-message-center/WorkspaceAgentMessageCenterCard.tsx
+++ b/packages/agent/gui/agent-message-center/WorkspaceAgentMessageCenterCard.tsx
@@ -23,6 +23,7 @@ import { normalizeAgentTitleText } from "../shared/utils/agentTitleText";
 import { AgentInteractivePromptSurface } from "../shared/agentConversation/components/AgentInteractivePromptSurface";
 import { AgentMessageMarkdown } from "../shared/AgentMessageMarkdown";
 import { AgentVerticalScrollArea } from "../shared/AgentVerticalScrollArea";
+import { WorkspaceAgentSessionDetail } from "../shared/WorkspaceAgentSessionDetail";
 import { managedAgentRoundedIconUrl } from "../shared/managedAgentIcons";
 import { workspaceAgentActivityStatusLabel } from "../shared/workspaceAgentActivityStatusLabel";
 import { workspaceAgentProviderLabel } from "../shared/workspaceAgentProviderLabel";
@@ -128,7 +129,9 @@ export function WorkspaceAgentMessageCenterCard({
         </span>
       </div>
 
-      {summary ? (
+      {item.detail?.turns.length ? (
+        <MessageCenterSessionDetail item={item} onLinkAction={onLinkAction} />
+      ) : summary ? (
         <MessageCenterSummary
           item={item}
           onLinkAction={onLinkAction}
@@ -593,6 +596,57 @@ function MessageCenterSummary({
         emptyLabel
       )}
     </AgentVerticalScrollArea>
+  );
+}
+
+function MessageCenterSessionDetail({
+  item,
+  onLinkAction
+}: {
+  item: WorkspaceAgentMessageCenterItem;
+  onLinkAction?: (action: WorkspaceLinkAction) => void;
+}): JSX.Element | null {
+  "use memo";
+  const { t } = useTranslation();
+  const detail = item.detail ?? null;
+  const handleLinkAction = useCallback(
+    (action: WorkspaceLinkAction): void => {
+      onLinkAction?.(
+        action.type === "open-agent-session" && !action.provider
+          ? { ...action, provider: item.provider }
+          : action
+      );
+    },
+    [item.provider, onLinkAction]
+  );
+
+  if (!detail || detail.turns.length === 0) {
+    return null;
+  }
+
+  return (
+    <div
+      className="workspace-agent-message-center__session-detail min-w-0 rounded-md bg-transparency-block"
+      onPointerDown={stopMessageCenterTextPointerPropagation}
+    >
+      <AgentVerticalScrollArea
+        className="max-h-[360px] min-w-0"
+        viewportClassName="max-h-[360px] p-2.5 pr-4"
+        scrollbarClassName="top-2 bottom-2 right-1.5"
+        syncKey={`${item.agentSessionId}:${item.timelineItemCount ?? detail.turns.length}`}
+      >
+        <WorkspaceAgentSessionDetail
+          detail={detail}
+          isLoading={item.status === "working" || item.status === "waiting"}
+          timelineItemCount={item.timelineItemCount ?? detail.turns.length}
+          onLinkAction={handleLinkAction}
+          toolCallsLabel={(count) =>
+            t("agentHost.workspaceAgentSessionDetailToolCalls", { count })
+          }
+          thinkingLabel={t("agentHost.workspaceAgentSessionDetailThinking")}
+        />
+      </AgentVerticalScrollArea>
+    </div>
   );
 }
 

--- a/packages/agent/gui/agent-message-center/WorkspaceAgentMessageCenterPanel.spec.tsx
+++ b/packages/agent/gui/agent-message-center/WorkspaceAgentMessageCenterPanel.spec.tsx
@@ -263,6 +263,94 @@ describe("WorkspaceAgentMessageCenterCard", () => {
     ).not.toHaveClass("agent-gui-edge-glow");
   });
 
+  it("renders canonical session detail when the message center item has transcript data", () => {
+    render(
+      <TooltipProvider>
+        <WorkspaceAgentMessageCenterCard
+          item={createTestCardItem({
+            digest: {
+              primary: {
+                kind: "summary",
+                summary: "Digest fallback should not render",
+                occurredAtUnixMs: 2
+              }
+            },
+            detail: {
+              activity: {
+                id: "activity-session-1",
+                sessionId: "session-1",
+                userId: null,
+                userName: "User",
+                agentProvider: "codex",
+                agentName: "Codex",
+                title: "整理本地文件夹",
+                status: "completed",
+                latestActivitySummary: "I found the relevant files.",
+                changedFiles: [],
+                sortTimeUnixMs: 2
+              },
+              session: {
+                workspaceId: "workspace-1",
+                agentSessionId: "session-1",
+                provider: "codex",
+                cwd: "/workspace",
+                title: "整理本地文件夹",
+                status: "completed"
+              },
+              cwd: "/workspace",
+              workspaceRoot: "/workspace",
+              turns: [
+                {
+                  id: "turn-1",
+                  userMessage: {
+                    id: "user-1",
+                    body: "Please inspect the workspace.",
+                    turnId: "turn-1"
+                  },
+                  userMessages: [
+                    {
+                      id: "user-1",
+                      body: "Please inspect the workspace.",
+                      turnId: "turn-1"
+                    }
+                  ],
+                  agentMessages: [
+                    {
+                      id: "assistant-1",
+                      body: "I found the relevant files.",
+                      turnId: "turn-1"
+                    }
+                  ],
+                  toolCalls: [],
+                  toolCallCount: 0,
+                  hasFailedToolCall: false,
+                  agentItems: [
+                    {
+                      kind: "message",
+                      message: {
+                        id: "assistant-1",
+                        body: "I found the relevant files.",
+                        turnId: "turn-1"
+                      }
+                    }
+                  ]
+                }
+              ]
+            },
+            timelineItemCount: 2
+          })}
+          isSubmitting={false}
+          onOpenChat={vi.fn()}
+          onSubmitPrompt={vi.fn()}
+        />
+      </TooltipProvider>
+    );
+
+    expect(screen.getByText("Please inspect the workspace.")).toBeTruthy();
+    expect(screen.getByText("I found the relevant files.")).toBeTruthy();
+    expect(screen.queryByText("Digest fallback should not render")).toBeNull();
+  });
+
   it("reports the provider and semantic action when submitting a notification prompt", () => {
     const onNotificationActioned = vi.fn();
     render(

--- a/packages/agent/gui/agent-message-center/workspaceAgentMessageCenterDigest.spec.ts
+++ b/packages/agent/gui/agent-message-center/workspaceAgentMessageCenterDigest.spec.ts
@@ -61,6 +61,32 @@ describe("buildWorkspaceAgentMessageCenterDigest", () => {
     });
   });
 
+  it("renders structured content arrays as message summaries", () => {
+    const digest = buildWorkspaceAgentMessageCenterDigest({
+      fallbackTitle: "Fallback title",
+      messages: [
+        message({
+          messageId: "assistant-1",
+          role: "assistant",
+          payload: {
+            content: [
+              { type: "text", text: "First paragraph." },
+              { type: "text", text: "Second paragraph." }
+            ]
+          },
+          occurredAtUnixMs: 10
+        })
+      ],
+      needsAttention: null,
+      pendingPrompt: null,
+      status: "idle"
+    });
+
+    expect(digest.primary).toMatchObject({
+      summary: "First paragraph. Second paragraph."
+    });
+  });
+
   it("prioritizes input-required over terminal-looking message summaries", () => {
     const digest = buildWorkspaceAgentMessageCenterDigest({
       fallbackTitle: "Fallback title",

--- a/packages/agent/gui/agent-message-center/workspaceAgentMessageCenterDigest.ts
+++ b/packages/agent/gui/agent-message-center/workspaceAgentMessageCenterDigest.ts
@@ -213,7 +213,7 @@ function summaryCandidate(
   source: MessageSummarySource,
   value: unknown
 ): MessageSummaryCandidate | null {
-  const summary = normalizeSummaryText(stringValue(value));
+  const summary = normalizeSummaryText(messageSummaryText(value));
   return summary ? { source, summary } : null;
 }
 
@@ -230,7 +230,7 @@ function toolErrorSummaryCandidate(
       stringValue(error.message),
       stringValue(error.detail),
       stringValue(error.text),
-      textFromContentValue(error.content),
+      messageSummaryText(error.content),
       stringValue(error.output),
       stringValue(error.stdout),
       stringValue(error.stderr),
@@ -256,7 +256,7 @@ function toolOutputSummaryCandidate(
       stringValue(output.summary),
       stringValue(output.message),
       stringValue(output.text),
-      textFromContentValue(output.content),
+      messageSummaryText(output.content),
       stringValue(output.content),
       stringValue(output.result),
       stringValue(output.output),
@@ -447,16 +447,15 @@ function stringArrayFirstValue(value: unknown): string | null {
   );
 }
 
-function textFromContentValue(value: unknown): string | null {
+export function messageSummaryText(value: unknown): string | null {
   if (typeof value === "string") {
     return stringValue(value);
   }
   if (Array.isArray(value)) {
-    return (
-      value
-        .map(textFromContentValue)
-        .find((item): item is string => Boolean(item)) ?? null
-    );
+    const parts = value
+      .map(messageSummaryText)
+      .filter((item): item is string => Boolean(item));
+    return parts.length > 0 ? parts.join("\n") : null;
   }
   if (!value || typeof value !== "object") {
     return null;
@@ -464,7 +463,7 @@ function textFromContentValue(value: unknown): string | null {
   const record = value as Record<string, unknown>;
   return firstNonEmptyString(
     stringValue(record.text),
-    "content" in record ? textFromContentValue(record.content) : null
+    "content" in record ? messageSummaryText(record.content) : null
   );
 }
 

--- a/packages/agent/gui/agent-message-center/workspaceAgentMessageCenterModel.spec.ts
+++ b/packages/agent/gui/agent-message-center/workspaceAgentMessageCenterModel.spec.ts
@@ -169,6 +169,40 @@ describe("buildWorkspaceAgentMessageCenterModel", () => {
     });
   });
 
+  it("builds session detail from the same message timeline used by conversations", () => {
+    const model = buildWorkspaceAgentMessageCenterModel(
+      snapshot({
+        messages: [
+          message({
+            agentSessionId: "session-1",
+            messageId: "user-1",
+            role: "user",
+            kind: "text",
+            payload: { text: "Please inspect the workspace." },
+            occurredAtUnixMs: 10,
+            turnId: "turn-1"
+          }),
+          message({
+            agentSessionId: "session-1",
+            messageId: "assistant-1",
+            role: "assistant",
+            kind: "text",
+            payload: { text: "I found the relevant files." },
+            occurredAtUnixMs: 20,
+            turnId: "turn-1"
+          })
+        ],
+        sessions: [session({ agentSessionId: "session-1" })]
+      })
+    );
+
+    expect(model.items[0]?.timelineItemCount).toBe(2);
+    expect(model.items[0]?.detail?.turns[0]).toMatchObject({
+      userMessage: { body: "Please inspect the workspace." },
+      agentMessages: [{ body: "I found the relevant files." }]
+    });
+  });
+
   it("prefers displayPrompt for message-center model summaries", () => {
     const model = buildWorkspaceAgentMessageCenterModel(
       snapshot({

--- a/packages/agent/gui/agent-message-center/workspaceAgentMessageCenterModel.ts
+++ b/packages/agent/gui/agent-message-center/workspaceAgentMessageCenterModel.ts
@@ -6,17 +6,27 @@ import {
   type AgentActivitySession,
   type AgentActivitySnapshot
 } from "@tutti-os/agent-activity-core";
+import { projectWorkspaceAgentMessagesToTimelineItems } from "../shared/agentConversation/projection/workspaceAgentMessageProjection";
 import type { AgentConversationPromptVM } from "../shared/agentConversation/contracts/agentConversationVM";
 import { normalizeAskUserQuestions } from "../shared/agentConversation/askUserQuestions";
 import { extractAgentMcpToolTarget } from "../shared/agentMcpToolTarget";
-import type { WorkspaceAgentActivityStatus } from "../shared/workspaceAgentActivityListViewModel";
+import {
+  buildWorkspaceAgentActivityListViewModel,
+  type WorkspaceAgentActivityCard,
+  type WorkspaceAgentActivityStatus
+} from "../shared/workspaceAgentActivityListViewModel";
 import { resolveWorkspaceAgentSessionSortTimeUnixMs } from "../shared/workspaceAgentSessionSortTime";
+import {
+  buildWorkspaceAgentSessionDetailViewModel,
+  type WorkspaceAgentSessionDetailViewModel
+} from "../shared/workspaceAgentSessionDetailViewModel";
 import {
   latestPlanTurnId,
   planImplementationPromptFromPlanTurn
 } from "../shared/agentConversation/planImplementation";
 import {
   buildWorkspaceAgentMessageCenterDigest,
+  messageSummaryText,
   type WorkspaceAgentMessageCenterDigest
 } from "./workspaceAgentMessageCenterDigest";
 
@@ -46,6 +56,8 @@ export interface WorkspaceAgentMessageCenterItem {
   digest: WorkspaceAgentMessageCenterDigest;
   lastAgentMessageSummary: string;
   lastAgentMessageAtUnixMs: number | null;
+  detail?: WorkspaceAgentSessionDetailViewModel | null;
+  timelineItemCount?: number;
   pendingPrompt: AgentConversationPromptVM | null;
   needsAttentionKind: AgentActivityNeedsAttentionItem["kind"] | null;
   needsAttentionSummary: string | null;
@@ -96,6 +108,11 @@ export function buildWorkspaceAgentMessageCenterModel(
     selectNeedsAttentionItems(snapshot)
   );
   const displayStatuses = selectSessionDisplayStatuses(snapshot);
+  const activitiesBySessionId = new Map(
+    buildWorkspaceAgentActivityListViewModel(snapshot, {
+      sessionMessagesById: snapshot.sessionMessagesById
+    }).activities.map((activity) => [activity.sessionId, activity])
+  );
   const items = snapshot.sessions
     .filter((session) => session.visible !== false)
     .map((session) => {
@@ -125,6 +142,12 @@ export function buildWorkspaceAgentMessageCenterModel(
           messages
         }
       );
+      const detail = buildMessageCenterSessionDetail({
+        activity: activitiesBySessionId.get(session.agentSessionId) ?? null,
+        messages,
+        session,
+        workspaceRoot: options.workspaceRoot ?? null
+      });
 
       return {
         id: `message-center-${session.agentSessionId}`,
@@ -142,6 +165,8 @@ export function buildWorkspaceAgentMessageCenterModel(
         lastAgentMessageSummary:
           lastAgentMessage?.summary ?? needsAttention?.summary ?? title,
         lastAgentMessageAtUnixMs: lastAgentMessage?.occurredAtUnixMs ?? null,
+        detail: detail?.detail ?? null,
+        timelineItemCount: detail?.timelineItemCount ?? 0,
         pendingPrompt,
         needsAttentionKind: needsAttention?.kind ?? null,
         needsAttentionSummary: needsAttention?.summary ?? null,
@@ -154,6 +179,35 @@ export function buildWorkspaceAgentMessageCenterModel(
     waitingCount: items.filter(isWaitingMessageCenterItem).length,
     items: items.sort(compareMessageCenterItems),
     counts: countMessageCenterItems(items)
+  };
+}
+
+function buildMessageCenterSessionDetail({
+  activity,
+  messages,
+  session,
+  workspaceRoot
+}: {
+  activity: WorkspaceAgentActivityCard | null;
+  messages: readonly AgentActivityMessage[];
+  session: AgentActivitySession;
+  workspaceRoot: string | null;
+}): {
+  detail: WorkspaceAgentSessionDetailViewModel;
+  timelineItemCount: number;
+} | null {
+  if (!activity) {
+    return null;
+  }
+  const timelineItems = projectWorkspaceAgentMessagesToTimelineItems(messages);
+  return {
+    detail: buildWorkspaceAgentSessionDetailViewModel({
+      activity,
+      session,
+      timelineItems,
+      workspaceRoot
+    }),
+    timelineItemCount: timelineItems.length
   };
 }
 
@@ -693,13 +747,13 @@ function includesAny(value: string, needles: readonly string[]): boolean {
 
 function messageSummary(message: AgentActivityMessage): string {
   return firstNonEmptyString(
-    stringValue(message.payload.summary),
-    stringValue(message.payload.displayPrompt),
-    stringValue(message.payload.text),
-    stringValue(message.payload.content),
-    stringValue(message.payload.message),
-    stringValue(message.payload.body),
-    stringValue(message.payload.title)
+    messageSummaryText(message.payload.summary),
+    messageSummaryText(message.payload.displayPrompt),
+    messageSummaryText(message.payload.text),
+    messageSummaryText(message.payload.content),
+    messageSummaryText(message.payload.message),
+    messageSummaryText(message.payload.body),
+    messageSummaryText(message.payload.title)
   );
 }
 


### PR DESCRIPTION
## Summary
- reuses the agent session detail projection for message center conversation cards
- makes issue latest-run cards render the same agent reply content as the session window
- adds regression coverage for message center detail parity and latest-run rendering

Closes #141
Closes #218

## Validation
- `git status --short --branch` clean
- targeted renderer tests were added by the fixing agent
- pre-push `pnpm check:full` was blocked by existing Go test failures in `services/tuttid/service/agentstatus` and `services/tuttid/types`; one hook run also hit a transient `git ls-files` worktree error during `check:tutti-names`