### PR TITLE
fix: onboarding agent binding UX improvements

### DIFF
--- a/apps/desktop/src/main/ipc/workspaceAppContext.ts
+++ b/apps/desktop/src/main/ipc/workspaceAppContext.ts
@@ -456,6 +456,20 @@ export function registerWorkspaceAppContextIpc(
       );
     }
   );
+  ipcMain.on(
+    desktopIpcChannels.appContext.agentStatusBroadcast,
+    (_event, payload: unknown) => {
+      if (
+        typeof payload === "object" &&
+        payload !== null &&
+        typeof (payload as { agentBound?: unknown }).agentBound === "boolean"
+      ) {
+        broadcastWorkspaceAppContext({
+          agentBound: (payload as { agentBound: boolean }).agentBound
+        });
+      }
+    }
+  );
   preferences.subscribe(() => {
     broadcastWorkspaceAppContext({
       locale: preferences.getLocale()
@@ -991,7 +1005,7 @@ function normalizeWorkspaceAppOpenUrlLogPayload(
   };
 }
 
-function broadcastWorkspaceAppContext(payload: { locale: string }): void {
+function broadcastWorkspaceAppContext(payload: Partial<DesktopWorkspaceAppContext>): void {
   for (const contents of [...workspaceAppGuestWebContents]) {
     if (contents.isDestroyed()) {
       workspaceAppGuestWebContents.delete(contents);

--- a/apps/desktop/src/preload/api/host.ts
+++ b/apps/desktop/src/preload/api/host.ts
@@ -211,6 +211,12 @@ export function createHostDesktopApi(): DesktopHostApi {
       }
     },
     workspace: {
+      broadcastAgentStatus(payload: { agentBound: boolean }): void {
+        ipcRenderer.send(
+          desktopIpcChannels.appContext.agentStatusBroadcast,
+          payload
+        );
+      },
       onOpenFeatureRequest(listener): () => void {
         const handler = (_event: IpcRendererEvent, payload: unknown) =>
           listener(payload as Parameters<typeof listener>[0]);

--- a/apps/desktop/src/preload/types.ts
+++ b/apps/desktop/src/preload/types.ts
@@ -66,6 +66,7 @@ export interface DesktopPlatformApi {
 }
 
 export interface DesktopHostWorkspaceApi {
+  broadcastAgentStatus(payload: { agentBound: boolean }): void;
   onOpenFeatureRequest(
     listener: (request: DesktopWorkspaceOpenFeatureRequest) => void
   ): () => void;

--- a/apps/desktop/src/renderer/src/features/workspace-workbench/services/internal/workspaceWorkbenchHostService.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/services/internal/workspaceWorkbenchHostService.ts
@@ -130,7 +130,7 @@ export interface WorkspaceWorkbenchHostServiceDependencies {
   hostWindowApi: DesktopHostWindowApi;
   hostWorkspaceApi: Pick<
     DesktopHostWorkspaceApi,
-    "onOpenFeatureRequest" | "onOpenFileRequest"
+    "broadcastAgentStatus" | "onOpenFeatureRequest" | "onOpenFileRequest"
   >;
   workspaceFileManagerService: IWorkspaceFileManagerService;
   workspaceUserProjectService: IWorkspaceUserProjectService;
@@ -159,7 +159,7 @@ export interface WorkspaceWorkbenchHostExternalDependencies {
   hostWindowApi: DesktopHostWindowApi;
   hostWorkspaceApi: Pick<
     DesktopHostWorkspaceApi,
-    "onOpenFeatureRequest" | "onOpenFileRequest"
+    "broadcastAgentStatus" | "onOpenFeatureRequest" | "onOpenFileRequest"
   >;
   tuttidClient: TuttidClient;
   platformApi: Pick<
@@ -571,6 +571,10 @@ export class WorkspaceWorkbenchHostService implements IWorkspaceWorkbenchHostSer
     return () => {
       this.wallpaperListeners.delete(listener);
     };
+  }
+
+  broadcastAgentStatus(payload: { agentBound: boolean }): void {
+    this.dependencies.hostWorkspaceApi.broadcastAgentStatus(payload);
   }
 
   private async persistPendingWallpaperSettings(

--- a/apps/desktop/src/renderer/src/features/workspace-workbench/services/registerWorkspaceWorkbenchServices.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/services/registerWorkspaceWorkbenchServices.ts
@@ -34,7 +34,7 @@ export interface WorkspaceWorkbenchServiceRegistrationInput {
   hostWindowApi: DesktopHostWindowApi;
   hostWorkspaceApi: Pick<
     DesktopHostWorkspaceApi,
-    "onOpenFeatureRequest" | "onOpenFileRequest"
+    "broadcastAgentStatus" | "onOpenFeatureRequest" | "onOpenFileRequest"
   >;
   tuttidClient: TuttidClient;
   platformApi: Pick<

--- a/apps/desktop/src/renderer/src/features/workspace-workbench/services/workspaceWorkbenchHostService.interface.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/services/workspaceWorkbenchHostService.interface.ts
@@ -162,6 +162,7 @@ export interface IWorkspaceWorkbenchHostService {
     wallpaperId: WorkspaceWallpaperId
   ): void;
   subscribeWallpaperChanges(listener: () => void): () => void;
+  broadcastAgentStatus(payload: { agentBound: boolean }): void;
 }
 
 export const IWorkspaceWorkbenchHostService =

--- a/apps/desktop/src/renderer/src/features/workspace-workbench/ui/WorkspaceWorkbench.tsx
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/ui/WorkspaceWorkbench.tsx
@@ -1,5 +1,12 @@
 import type * as React from "react";
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  useSyncExternalStore
+} from "react";
 import type { WorkspaceSummary } from "@tutti-os/client-tuttid-ts";
 import {
   defaultIssueManagerWorkbenchTypeId,
@@ -416,11 +423,11 @@ function ReadyWorkspaceWorkbench({
       const agentBound = snapshot.statuses.some(
         (s) => s.availability.status === "ready"
       );
-      window.tutti?.host?.workspace?.broadcastAgentStatus({ agentBound });
+      runtime.workbenchHostService.broadcastAgentStatus({ agentBound });
     };
     broadcastAgentBound();
     return agentProviderStatusService.subscribe(broadcastAgentBound);
-  }, [agentProviderStatusService]);
+  }, [agentProviderStatusService, runtime.workbenchHostService]);
 
   useEffect(() => {
     const missionControlShortcutsEnabled =

--- a/apps/desktop/src/renderer/src/features/workspace-workbench/ui/WorkspaceWorkbench.tsx
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/ui/WorkspaceWorkbench.tsx
@@ -72,6 +72,7 @@ import {
 } from "@renderer/features/workspace-app-center";
 import { workspaceLaunchpadDockActionId } from "../services/workspaceLaunchpadModel.ts";
 import { requestWorkspaceMessageCenterOpen } from "../services/workspaceMessageCenterCoordinator.ts";
+import { resolveWorkspaceAgentGuiLabel } from "../services/workspaceAgentProviderCatalog.ts";
 import { workspaceBrowserNodeID } from "../services/workspaceWorkbenchNodeIds.ts";
 import { WorkspaceChrome } from "./WorkspaceChrome";
 import { WorkspaceAppExternalBridge } from "./WorkspaceAppExternalBridge";
@@ -410,6 +411,18 @@ function ReadyWorkspaceWorkbench({
   });
 
   useEffect(() => {
+    const broadcastAgentBound = () => {
+      const snapshot = agentProviderStatusService.getSnapshot();
+      const agentBound = snapshot.statuses.some(
+        (s) => s.availability.status === "ready"
+      );
+      window.tutti?.host?.workspace?.broadcastAgentStatus({ agentBound });
+    };
+    broadcastAgentBound();
+    return agentProviderStatusService.subscribe(broadcastAgentBound);
+  }, [agentProviderStatusService]);
+
+  useEffect(() => {
     const missionControlShortcutsEnabled =
       runtime.shortcutsEnabled || runtime.missionControl.isOpen;
     if (!missionControlShortcutsEnabled || !runtime.missionControl.canOpen) {
@@ -513,6 +526,7 @@ function ReadyWorkspaceWorkbench({
         workspaceId={state.workspace.id}
         onClose={closeLaunchpad}
       />
+      <WorkspaceAgentConnectingCard service={agentProviderStatusService} />
       <WorkspaceCloseGuardDialog
         request={runtime.closeDialog.request}
         onCancel={runtime.closeDialog.onCancel}
@@ -522,6 +536,39 @@ function ReadyWorkspaceWorkbench({
   );
 }
 
+function WorkspaceAgentConnectingCard({
+  service
+}: {
+  service: IAgentProviderStatusService;
+}) {
+  const { t } = useTranslation();
+  const snapshot = useSyncExternalStore(
+    (listener) => service.subscribe(listener),
+    () => service.getSnapshot(),
+    () => service.getSnapshot()
+  );
+  const pending = snapshot.pendingActions.find(
+    (action) =>
+      action.actionId === "install" || action.actionId === "login"
+  );
+  if (!pending) {
+    return null;
+  }
+  const label = resolveWorkspaceAgentGuiLabel(
+    normalizeDesktopAgentGUIProvider(pending.provider)
+  );
+  return (
+    <div className="pointer-events-none fixed inset-x-0 bottom-28 z-50 flex justify-center">
+      <div className="pointer-events-auto flex w-64 flex-col items-center gap-3 rounded-2xl border border-border bg-background px-6 py-5 text-center shadow-xl">
+        <div className="text-[15px] font-semibold text-foreground">{label}</div>
+        <div className="text-[12.5px] leading-relaxed text-muted-foreground">
+          {t("workspace.workbenchDesktop.agentProviders.installing")}
+        </div>
+        <LoadingIcon className="size-5 animate-spin text-muted-foreground" />
+      </div>
+    </div>
+  );
+}
 async function openWorkspaceFilesNode(
   host: WorkbenchHostHandle,
   request: WorkspaceFilesLaunchRequest

--- a/apps/desktop/src/renderer/src/platform/desktop/web/createWebDesktopApi.ts
+++ b/apps/desktop/src/renderer/src/platform/desktop/web/createWebDesktopApi.ts
@@ -298,6 +298,7 @@ function createWebHostApi(): DesktopHostApi {
       }
     },
     workspace: {
+      broadcastAgentStatus() {},
       onOpenFeatureRequest() {
         return () => {};
       },

--- a/apps/desktop/src/shared/contracts/ipc.ts
+++ b/apps/desktop/src/shared/contracts/ipc.ts
@@ -62,6 +62,7 @@ export const desktopIpcChannels = {
     grantPermissions: "computerUse:grantPermissions"
   },
   appContext: {
+    agentStatusBroadcast: "workspace-app-context:agent-status-broadcast",
     changed: "workspace-app-context:changed",
     diagnostic: "workspace-app-context:diagnostic",
     get: "workspace-app-context:get",
@@ -310,6 +311,7 @@ export interface DesktopHostPreferencesSyncPayload {
 }
 
 export interface DesktopWorkspaceAppContext {
+  agentBound?: boolean;
   appId?: string;
   capabilities?: string[];
   contextToken?: string;


### PR DESCRIPTION
## Summary
- **Issue 2**: Show the agent connecting loading bubble when user clicks bind buttons and the agent is in "login" (direct binding) state, not just "install" state
- **Issue 3**: Add IPC broadcast mechanism so the onboarding workspace app receives real-time agent bound status, enabling conditional footer button display (bound → "已绑定，去使用" / unbound → "绑定 Agent，开始使用")

### Changes
- `ipc.ts`: Added `agentStatusBroadcast` IPC channel and `agentBound` field to `DesktopWorkspaceAppContext`
- `types.ts` + `host.ts`: Added `broadcastAgentStatus` to preload workspace API
- `workspaceAppContext.ts`: Added main-process IPC listener that broadcasts agent status to workspace app guests; widened `broadcastWorkspaceAppContext` signature to `Partial<DesktopWorkspaceAppContext>`
- `WorkspaceWorkbench.tsx`: Added `WorkspaceAgentConnectingCard` with extended pending action filter to include `login`; added `useEffect` to subscribe to agent status changes and broadcast to workspace apps

## Test plan
- [ ] Open onboarding app, verify connecting bubble appears when agent is in login/direct-bind state
- [ ] Verify footer shows "已绑定，去使用" when any agent is bound
- [ ] Verify footer shows "绑定 Agent，开始使用" when no agent is bound
- [ ] Verify bubble still appears during install state (no regression)

Supersedes #263 (rebased on main to resolve conflicts).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Agent provider connection status is now tracked and displayed to users. A new “connecting/installing” status card appears in the workspace workbench when an agent provider is pending installation or login, including a loading indicator and a resolved provider label.
  * The desktop workspace now broadcasts agent-bound status through the host/workbench pipeline so the UI can stay in sync with connection state.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->