### PR TITLE
Support node-static workspace app runtime profile

### DIFF
--- a/apps/desktop/src/renderer/src/features/workspace-workbench/ui/WorkspaceWorkbench.tsx
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/ui/WorkspaceWorkbench.tsx
@@ -4,8 +4,7 @@ import {
   useEffect,
   useMemo,
   useRef,
-  useState,
-  useSyncExternalStore
+  useState
 } from "react";
 import type { WorkspaceSummary } from "@tutti-os/client-tuttid-ts";
 import {
@@ -79,7 +78,6 @@ import {
 } from "@renderer/features/workspace-app-center";
 import { workspaceLaunchpadDockActionId } from "../services/workspaceLaunchpadModel.ts";
 import { requestWorkspaceMessageCenterOpen } from "../services/workspaceMessageCenterCoordinator.ts";
-import { resolveWorkspaceAgentGuiLabel } from "../services/workspaceAgentProviderCatalog.ts";
 import { workspaceBrowserNodeID } from "../services/workspaceWorkbenchNodeIds.ts";
 import { WorkspaceChrome } from "./WorkspaceChrome";
 import { WorkspaceAppExternalBridge } from "./WorkspaceAppExternalBridge";
@@ -533,7 +531,6 @@ function ReadyWorkspaceWorkbench({
         workspaceId={state.workspace.id}
         onClose={closeLaunchpad}
       />
-      <WorkspaceAgentConnectingCard service={agentProviderStatusService} />
       <WorkspaceCloseGuardDialog
         request={runtime.closeDialog.request}
         onCancel={runtime.closeDialog.onCancel}
@@ -543,39 +540,6 @@ function ReadyWorkspaceWorkbench({
   );
 }
 
-function WorkspaceAgentConnectingCard({
-  service
-}: {
-  service: IAgentProviderStatusService;
-}) {
-  const { t } = useTranslation();
-  const snapshot = useSyncExternalStore(
-    (listener) => service.subscribe(listener),
-    () => service.getSnapshot(),
-    () => service.getSnapshot()
-  );
-  const pending = snapshot.pendingActions.find(
-    (action) =>
-      action.actionId === "install" || action.actionId === "login"
-  );
-  if (!pending) {
-    return null;
-  }
-  const label = resolveWorkspaceAgentGuiLabel(
-    normalizeDesktopAgentGUIProvider(pending.provider)
-  );
-  return (
-    <div className="pointer-events-none fixed inset-x-0 bottom-28 z-50 flex justify-center">
-      <div className="pointer-events-auto flex w-64 flex-col items-center gap-3 rounded-2xl border border-border bg-background px-6 py-5 text-center shadow-xl">
-        <div className="text-[15px] font-semibold text-foreground">{label}</div>
-        <div className="text-[12.5px] leading-relaxed text-muted-foreground">
-          {t("workspace.workbenchDesktop.agentProviders.installing")}
-        </div>
-        <LoadingIcon className="size-5 animate-spin text-muted-foreground" />
-      </div>
-    </div>
-  );
-}
 async function openWorkspaceFilesNode(
   host: WorkbenchHostHandle,
   request: WorkspaceFilesLaunchRequest

--- a/docs/conventions/workspace-app-catalog.md
+++ b/docs/conventions/workspace-app-catalog.md
@@ -73,7 +73,7 @@ App Center opening should call `POST /v1/workspaces/{workspaceID}/apps/catalog/r
 
 Remote catalog entries must include `distribution.iconUrl`, `distribution.artifactUrl`, `distribution.artifactSha256`, and a manifest icon asset. The zip package must contain a complete app package with `tutti.app.json`, `bootstrap.sh`, `AGENTS.md`, and the manifest icon asset.
 
-Workspace app packages do not declare runtime kind or bundle Python/Node. Managed runtime release and download rules belong to [Workspace App Runtime](./workspace-app-runtime.md).
+Workspace app packages do not declare arbitrary runtime kinds or bundle Python/Node. Packages that only need the managed Node/static runtime may declare `runtime.profile: "node-static"`; all other managed runtime release and download rules belong to [Workspace App Runtime](./workspace-app-runtime.md).
 
 ## Release Flow
 

--- a/docs/conventions/workspace-app-runtime.md
+++ b/docs/conventions/workspace-app-runtime.md
@@ -113,11 +113,13 @@ The runtime catalog consumed by tuttid has this shape:
 }
 ```
 
-tuttid resolves the `baseline` profile when launching apps, and may preload
-smaller profiles such as `node-static` in the background before first launch. App
-manifests must not declare a runtime kind. If runtime requirements need to
-become more selective later, add a capability list such as runtime component
-requirements rather than restoring a single-kind manifest field.
+tuttid resolves the `baseline` profile by default when launching apps, and may
+preload smaller profiles such as `node-static` in the background before first
+launch. App manifests must not declare a runtime kind. Apps that only need Node
+may declare `runtime.profile: "node-static"` so launch does not require the
+Python component. If runtime requirements need to become more selective later,
+add a capability list such as runtime component requirements rather than
+restoring a single-kind manifest field.
 
 ## Runtime Overrides
 

--- a/packages/workspace/app-center/src/contracts/manifest.ts
+++ b/packages/workspace/app-center/src/contracts/manifest.ts
@@ -11,6 +11,7 @@ export interface WorkspaceAppManifestIcon {
 export interface WorkspaceAppManifestRuntime {
   readonly bootstrap: string;
   readonly healthcheckPath: string;
+  readonly profile?: "node-static";
 }
 
 export interface WorkspaceAppManifestReferences {

--- a/packages/workspace/app-center/src/core/manifestValidation.test.ts
+++ b/packages/workspace/app-center/src/core/manifestValidation.test.ts
@@ -48,6 +48,45 @@ describe("validateWorkspaceAppManifest", () => {
     assert.equal(result.manifest?.window?.minimizeBehavior, "hibernate");
   });
 
+  it("normalizes supported runtime profile", () => {
+    const result = validateWorkspaceAppManifest({
+      schemaVersion: workspaceAppManifestSchemaVersion,
+      appId: "demo",
+      name: "Demo",
+      description: "Demo app",
+      runtime: {
+        bootstrap: "bootstrap.sh",
+        healthcheckPath: "/",
+        profile: "node-static"
+      },
+      version: "1.0.0"
+    });
+
+    assert.equal(result.valid, true);
+    assert.equal(result.manifest?.runtime.profile, "node-static");
+  });
+
+  it("rejects unsupported runtime profile", () => {
+    const result = validateWorkspaceAppManifest({
+      schemaVersion: workspaceAppManifestSchemaVersion,
+      appId: "demo",
+      name: "Demo",
+      description: "Demo app",
+      runtime: {
+        bootstrap: "bootstrap.sh",
+        healthcheckPath: "/",
+        profile: "python"
+      },
+      version: "1.0.0"
+    });
+
+    assert.equal(result.valid, false);
+    assert.deepEqual(
+      result.issues.map((issue) => issue.path),
+      ["$.runtime.profile"]
+    );
+  });
+
   it("normalizes supported window minimum size", () => {
     const result = validateWorkspaceAppManifest({
       schemaVersion: workspaceAppManifestSchemaVersion,

--- a/packages/workspace/app-center/src/core/manifestValidation.ts
+++ b/packages/workspace/app-center/src/core/manifestValidation.ts
@@ -193,6 +193,7 @@ function validateRuntime(
 
   const bootstrap = readOptionalString(value.bootstrap);
   const healthcheckPath = readOptionalString(value.healthcheckPath);
+  const profile = readOptionalString(value.profile);
   if (!bootstrap || !isRelativePackagePath(bootstrap)) {
     issues.push({
       code: "manifest.runtime",
@@ -207,18 +208,27 @@ function validateRuntime(
       path: "$.runtime.healthcheckPath"
     });
   }
+  if (profile && profile !== "node-static") {
+    issues.push({
+      code: "manifest.runtime",
+      message: "runtime.profile must be node-static when set.",
+      path: "$.runtime.profile"
+    });
+  }
   if (
     !bootstrap ||
     !healthcheckPath ||
     !isRelativePackagePath(bootstrap) ||
-    !healthcheckPath.startsWith("/")
+    !healthcheckPath.startsWith("/") ||
+    (profile !== undefined && profile !== "node-static")
   ) {
     return undefined;
   }
 
   return {
     bootstrap,
-    healthcheckPath
+    healthcheckPath,
+    ...(profile ? { profile } : {})
   };
 }
 

--- a/services/tuttid/biz/workspace/apps.go
+++ b/services/tuttid/biz/workspace/apps.go
@@ -46,6 +46,7 @@ type AppManifestIcon struct {
 type AppManifestRuntime struct {
 	Bootstrap       string `json:"bootstrap"`
 	HealthcheckPath string `json:"healthcheckPath"`
+	Profile         string `json:"profile,omitempty"`
 }
 
 type AppManifestCLI struct {
@@ -535,6 +536,9 @@ func ValidateAppManifest(manifest AppManifest) error {
 	}
 	if !strings.HasPrefix(manifest.Runtime.HealthcheckPath, "/") {
 		return errors.New("app manifest runtime.healthcheckPath must start with /")
+	}
+	if profile := strings.TrimSpace(manifest.Runtime.Profile); profile != "" && profile != "node-static" {
+		return errors.New("app manifest runtime.profile must be node-static when set")
 	}
 	if manifest.Window != nil {
 		minimizeBehavior := strings.TrimSpace(manifest.Window.MinimizeBehavior)

--- a/services/tuttid/biz/workspace/apps_test.go
+++ b/services/tuttid/biz/workspace/apps_test.go
@@ -238,6 +238,30 @@ func TestParseAppManifestJSONAcceptsReferencesSearchEndpoint(t *testing.T) {
 	}
 }
 
+func TestParseAppManifestJSONAcceptsRuntimeProfile(t *testing.T) {
+	t.Parallel()
+
+	manifest, _, err := ParseAppManifestJSON([]byte(
+		`{"schemaVersion":"tutti.app.manifest.v1","appId":"test-app","version":"0.1.0","name":"Test App","description":"Test app","icon":{"type":"asset","src":"icon.png"},"runtime":{"bootstrap":"bootstrap.sh","healthcheckPath":"/healthz","profile":"node-static"}}`,
+	))
+	if err != nil {
+		t.Fatalf("ParseAppManifestJSON() error = %v, want nil for runtime.profile", err)
+	}
+	if manifest.Runtime.Profile != "node-static" {
+		t.Fatalf("Runtime.Profile = %q, want node-static", manifest.Runtime.Profile)
+	}
+}
+
+func TestParseAppManifestJSONRejectsUnsupportedRuntimeProfile(t *testing.T) {
+	t.Parallel()
+
+	if _, _, err := ParseAppManifestJSON([]byte(
+		`{"schemaVersion":"tutti.app.manifest.v1","appId":"test-app","version":"0.1.0","name":"Test App","description":"Test app","icon":{"type":"asset","src":"icon.png"},"runtime":{"bootstrap":"bootstrap.sh","healthcheckPath":"/healthz","profile":"python"}}`,
+	)); err == nil {
+		t.Fatal("ParseAppManifestJSON() error = nil, want invalid runtime.profile error")
+	}
+}
+
 func validTestAppManifest() AppManifest {
 	return AppManifest{
 		SchemaVersion: AppManifestSchemaVersionV1,

--- a/services/tuttid/service/managedruntime/runtime.go
+++ b/services/tuttid/service/managedruntime/runtime.go
@@ -38,6 +38,10 @@ type ProfilePreloader interface {
 	PreloadProfile(context.Context, string) error
 }
 
+type ProfileResolver interface {
+	ResolveProfile(context.Context, string) (ResolvedRuntime, error)
+}
+
 type ResolvedRuntime struct {
 	Root         string
 	Python       string
@@ -86,11 +90,30 @@ func (r DefaultResolver) Resolve(ctx context.Context) (ResolvedRuntime, error) {
 	if err := r.ensureRuntime(ctx, root); err != nil {
 		return ResolvedRuntime{}, err
 	}
-	return r.resolvedRuntime(root)
+	return r.resolvedRuntimeForComponents(root, []string{"python", "node"})
 }
 
 func (r DefaultResolver) PreloadProfile(ctx context.Context, profile string) error {
 	return r.ensureRuntimeProfile(ctx, r.runtimeRoot(), profile)
+}
+
+func (r DefaultResolver) ResolveProfile(ctx context.Context, profile string) (ResolvedRuntime, error) {
+	profile = strings.TrimSpace(profile)
+	if profile == "" || profile == appRuntimeBaselineProfile {
+		return r.Resolve(ctx)
+	}
+	root := r.runtimeRoot()
+	if err := r.ensureRuntimeProfile(ctx, root, profile); err != nil {
+		return ResolvedRuntime{}, err
+	}
+	if profile == appRuntimeNodeStaticProfile {
+		return r.resolvedRuntimeForComponents(root, []string{"node"})
+	}
+	componentNames, err := r.runtimeProfileComponentNames(ctx, profile)
+	if err != nil {
+		return ResolvedRuntime{}, err
+	}
+	return r.resolvedRuntimeForComponents(root, componentNames)
 }
 
 func (r DefaultResolver) runtimeRoot() string {
@@ -105,38 +128,58 @@ func (r DefaultResolver) runtimeRoot() string {
 }
 
 func (r DefaultResolver) resolvedRuntime(root string) (ResolvedRuntime, error) {
+	return r.resolvedRuntimeForComponents(root, []string{"python", "node"})
+}
+
+func (r DefaultResolver) resolvedRuntimeForComponents(root string, components []string) (ResolvedRuntime, error) {
 	pythonBinDir := filepath.Join(root, "python", "bin")
 	nodeBinDir := filepath.Join(root, "node", "bin")
 	python := filepath.Join(pythonBinDir, pythonBinaryName())
 	node := filepath.Join(nodeBinDir, nodeBinaryName())
 	npm := filepath.Join(nodeBinDir, npmBinaryName())
 
-	for name, path := range map[string]string{
-		"python": python,
-		"node":   node,
-		"npm":    npm,
-	} {
-		if !isExecutableFile(path) {
-			return ResolvedRuntime{}, fmt.Errorf("managed app runtime %s executable is unavailable at %s", name, path)
+	var (
+		binDirs      []string
+		envOverrides []string
+		resolved     ResolvedRuntime
+	)
+	for _, component := range components {
+		switch strings.TrimSpace(component) {
+		case "python":
+			if !isExecutableFile(python) {
+				return ResolvedRuntime{}, fmt.Errorf("managed app runtime python executable is unavailable at %s", python)
+			}
+			resolved.Python = python
+			binDirs = append(binDirs, pythonBinDir)
+			envOverrides = append(envOverrides, "TUTTI_APP_PYTHON="+python)
+		case "node":
+			for name, path := range map[string]string{
+				"node": node,
+				"npm":  npm,
+			} {
+				if !isExecutableFile(path) {
+					return ResolvedRuntime{}, fmt.Errorf("managed app runtime %s executable is unavailable at %s", name, path)
+				}
+			}
+			resolved.Node = node
+			resolved.NPM = npm
+			binDirs = append(binDirs, nodeBinDir)
+			envOverrides = append(envOverrides, "TUTTI_APP_NODE="+node, "TUTTI_APP_NPM="+npm)
 		}
 	}
 
-	binDirs := mergeAppPathDirs([]string{pythonBinDir, nodeBinDir})
-	envOverrides := []string{
-		tuttiAppRuntimeRootEnv + "=" + root,
-		"TUTTI_APP_PYTHON=" + python,
-		"TUTTI_APP_NODE=" + node,
-		"TUTTI_APP_NPM=" + npm,
-		"PATH=" + strings.Join(append(binDirs, filepath.SplitList(envValue(r.environ(), pathEnvKey(r.environ())))...), string(os.PathListSeparator)),
-	}
-	return ResolvedRuntime{
-		Root:         root,
-		Python:       python,
-		Node:         node,
-		NPM:          npm,
-		BinDirs:      binDirs,
-		EnvOverrides: envOverrides,
-	}, nil
+	binDirs = mergeAppPathDirs(binDirs)
+	resolved.Root = root
+	resolved.BinDirs = binDirs
+	resolved.EnvOverrides = append(
+		[]string{tuttiAppRuntimeRootEnv + "=" + root},
+		envOverrides...,
+	)
+	resolved.EnvOverrides = append(
+		resolved.EnvOverrides,
+		"PATH="+strings.Join(append(binDirs, filepath.SplitList(envValue(r.environ(), pathEnvKey(r.environ())))...), string(os.PathListSeparator)),
+	)
+	return resolved, nil
 }
 
 func (r DefaultResolver) ensureRuntime(ctx context.Context, root string) error {
@@ -192,6 +235,23 @@ func (r DefaultResolver) ensureRuntimeProfile(ctx context.Context, root string, 
 		return nil
 	}
 	return r.downloadRuntime(ctx, root, entry, missing)
+}
+
+func (r DefaultResolver) runtimeProfileComponentNames(ctx context.Context, profile string) ([]string, error) {
+	catalogSource := r.runtimeCatalogSource()
+	if catalogSource == "" {
+		return nil, fmt.Errorf("managed app runtime catalog is unavailable and %s is not configured", tuttiAppRuntimeCatalogEnv)
+	}
+	platformArch := appRuntimePlatformArch(runtime.GOOS, runtime.GOARCH)
+	catalog, err := r.loadCatalog(ctx, catalogSource)
+	if err != nil {
+		return nil, err
+	}
+	entry, ok := catalog.Runtimes[platformArch]
+	if !ok {
+		return nil, fmt.Errorf("managed app runtime catalog does not contain platform %q", platformArch)
+	}
+	return appRuntimeProfileComponentNames(entry, profile)
 }
 
 func RootReady(root string) bool {

--- a/services/tuttid/service/managedruntime/runtime_test.go
+++ b/services/tuttid/service/managedruntime/runtime_test.go
@@ -230,6 +230,20 @@ func TestDefaultResolverPreloadsRuntimeProfileComponents(t *testing.T) {
 		t.Fatal("node profile preload installed python")
 	}
 
+	nodeRuntime, err := resolver.ResolveProfile(context.Background(), "node-static")
+	if err != nil {
+		t.Fatalf("ResolveProfile(node-static) error = %v", err)
+	}
+	if nodeRuntime.Python != "" {
+		t.Fatalf("ResolveProfile(node-static) Python = %q, want empty", nodeRuntime.Python)
+	}
+	if !isExecutableFile(nodeRuntime.Node) || !isExecutableFile(nodeRuntime.NPM) {
+		t.Fatalf("ResolveProfile(node-static) did not resolve node runtime: %#v", nodeRuntime)
+	}
+	if isExecutableFile(filepath.Join(root, "python", "bin", pythonBinaryName())) {
+		t.Fatal("node profile resolve installed python")
+	}
+
 	resolved, err := resolver.Resolve(context.Background())
 	if err != nil {
 		t.Fatalf("Resolve() error = %v", err)

--- a/services/tuttid/service/workspace/app_factory.go
+++ b/services/tuttid/service/workspace/app_factory.go
@@ -498,6 +498,7 @@ func (s *AppFactoryService) validatePackage(ctx context.Context, workspaceID str
 		PackageDir:      draftPackageDir,
 		Bootstrap:       manifest.Runtime.Bootstrap,
 		HealthcheckPath: manifest.Runtime.HealthcheckPath,
+		RuntimeProfile:  strings.TrimSpace(manifest.Runtime.Profile),
 		RuntimeDir:      job.RuntimeDir,
 		DataDir:         job.DataDir,
 		LogDir:          job.LogDir,

--- a/services/tuttid/service/workspace/app_factory_reference/references/manifest-contract.md
+++ b/services/tuttid/service/workspace/app_factory_reference/references/manifest-contract.md
@@ -44,6 +44,7 @@ Rules:
 - Do not include `runtime.kind`; Tutti manages the runtime baseline outside the app package.
 - `runtime.bootstrap` must be a relative package path.
 - `runtime.healthcheckPath` must start with `/`.
+- `runtime.profile` is optional. Use `"node-static"` only for apps whose bootstrap launches a Node/static server and does not need Python. Omit it for the default baseline runtime.
 - `cli` is optional. Include it only when the app exposes commands through the Tutti CLI.
 - `cli.manifest` must be a relative package path to a `tutti.app.cli.v1` manifest, usually `tutti.cli.json`.
 - `references` is optional. Include it only when the app exposes browsable file references.

--- a/services/tuttid/service/workspace/app_factory_reference/scripts/validate_tutti_app_package.py
+++ b/services/tuttid/service/workspace/app_factory_reference/scripts/validate_tutti_app_package.py
@@ -84,6 +84,9 @@ def validate_manifest(root: Path, errors: list[str]) -> dict[str, Any] | None:
         healthcheck = runtime.get("healthcheckPath")
         if not isinstance(healthcheck, str) or not healthcheck.startswith("/"):
             errors.append("runtime.healthcheckPath must start with /")
+        profile = runtime.get("profile")
+        if profile is not None and profile != "node-static":
+            errors.append("runtime.profile must be node-static when set")
 
     cli = manifest.get("cli")
     if cli is not None:

--- a/services/tuttid/service/workspace/app_runtime_env.go
+++ b/services/tuttid/service/workspace/app_runtime_env.go
@@ -5,6 +5,7 @@ import (
 	"runtime"
 	"strings"
 
+	workspacebiz "github.com/tutti-os/tutti/services/tuttid/biz/workspace"
 	managedruntime "github.com/tutti-os/tutti/services/tuttid/service/managedruntime"
 )
 
@@ -13,11 +14,20 @@ const workspaceAppNodeRuntimePreloadProfile = managedruntime.NodeStaticProfile
 
 type AppRuntimeResolver = managedruntime.Resolver
 type AppRuntimeProfilePreloader = managedruntime.ProfilePreloader
+type AppRuntimeProfileResolver = managedruntime.ProfileResolver
 type ResolvedAppRuntime = managedruntime.ResolvedRuntime
 type DefaultManagedAppRuntimeResolver = managedruntime.DefaultResolver
 
 func workspaceAppProcessEnv(overrides ...string) []string {
 	return managedruntime.ProcessEnv(overrides...)
+}
+
+func appRuntimeProfileForPackage(appPackage workspacebiz.AppPackage) string {
+	return appRuntimeProfileForManifest(appPackage.Manifest)
+}
+
+func appRuntimeProfileForManifest(manifest workspacebiz.AppManifest) string {
+	return strings.TrimSpace(manifest.Runtime.Profile)
 }
 
 func appRuntimeEnvValue(env []string, key string) string {

--- a/services/tuttid/service/workspace/apps.go
+++ b/services/tuttid/service/workspace/apps.go
@@ -185,18 +185,27 @@ func (s *AppCenterService) InstallWithOptions(ctx context.Context, workspaceID s
 	if err != nil {
 		return workspacebiz.WorkspaceApp{}, err
 	}
-	s.startInstallJob(workspaceID, appID, options, func(ctx context.Context) (workspacebiz.AppPackage, error) {
+	runtimeProfileHint := s.installRuntimeProfileHint(appID, app)
+	s.startInstallJob(workspaceID, appID, options, runtimeProfileHint, func(ctx context.Context) (workspacebiz.AppPackage, error) {
 		return s.packageForInstall(ctx, appID)
 	})
 	return app, nil
 }
 
-func (s *AppCenterService) startInstallJob(workspaceID string, appID string, options InstallOptions, resolvePackage appInstallPackageResolver) bool {
+func (s *AppCenterService) startInstallJob(workspaceID string, appID string, options InstallOptions, runtimeProfileHint string, resolvePackage appInstallPackageResolver) bool {
 	if !s.beginInstallJob(workspaceID, appID, options) {
 		return false
 	}
-	go s.runInstallJob(workspaceID, appID, resolvePackage)
+	go s.runInstallJob(workspaceID, appID, runtimeProfileHint, resolvePackage)
 	return true
+}
+
+func (s *AppCenterService) installRuntimeProfileHint(appID string, app workspacebiz.WorkspaceApp) string {
+	remoteBuiltin, ok, err := s.remoteBuiltinForAppID(appID)
+	if err == nil && ok && shouldUseRemoteBuiltin(app.Package, remoteBuiltin) {
+		return appRuntimeProfileForManifest(remoteBuiltin.Manifest)
+	}
+	return appRuntimeProfileForPackage(app.Package)
 }
 
 func (s *AppCenterService) installPackage(ctx context.Context, workspaceID string, appPackage workspacebiz.AppPackage, options InstallOptions) (workspacebiz.WorkspaceApp, error) {
@@ -234,7 +243,7 @@ func (s *AppCenterService) installPackage(ctx context.Context, workspaceID strin
 	return s.publishAppIfChanged(ctx, workspaceID, appPackage.AppID, app), nil
 }
 
-func (s *AppCenterService) runInstallJob(workspaceID string, appID string, resolvePackage appInstallPackageResolver) {
+func (s *AppCenterService) runInstallJob(workspaceID string, appID string, runtimeProfileHint string, resolvePackage appInstallPackageResolver) {
 	startedAt := time.Now()
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -247,11 +256,7 @@ func (s *AppCenterService) runInstallJob(workspaceID string, appID string, resol
 		tracker.clear()
 	}()
 
-	var (
-		appPackage workspacebiz.AppPackage
-		packageErr error
-		runtimeErr error
-	)
+	var appPackage workspacebiz.AppPackage
 	type installJobResult struct {
 		appPackage workspacebiz.AppPackage
 		err        error
@@ -274,7 +279,12 @@ func (s *AppCenterService) runInstallJob(workspaceID string, appID string, resol
 	wg.Add(1)
 	go func() {
 		defer wg.Done()
-		err := s.runner().PreloadRuntime(tracker.runtimeProgressContext(ctx))
+		var err error
+		if strings.TrimSpace(runtimeProfileHint) == workspaceAppNodeRuntimePreloadProfile {
+			err = s.runner().PreloadRuntimeForProfile(tracker.runtimeProgressContext(ctx), workspaceAppNodeRuntimePreloadProfile)
+		} else {
+			err = s.runner().PreloadRuntime(tracker.runtimeProgressContext(ctx))
+		}
 		results <- installJobResult{
 			err:  err,
 			kind: "runtime",
@@ -285,9 +295,6 @@ func (s *AppCenterService) runInstallJob(workspaceID string, appID string, resol
 		result := <-results
 		if result.kind == "package" {
 			appPackage = result.appPackage
-			packageErr = result.err
-		} else {
-			runtimeErr = result.err
 		}
 		if result.err != nil {
 			cancel()
@@ -297,13 +304,8 @@ func (s *AppCenterService) runInstallJob(workspaceID string, appID string, resol
 		}
 	}
 	wg.Wait()
-
-	if packageErr != nil {
-		s.handleInstallJobFailure(ctx, workspaceID, appID, appPackage, packageErr, startedAt)
-		return
-	}
-	if runtimeErr != nil {
-		s.handleInstallJobFailure(ctx, workspaceID, appID, appPackage, runtimeErr, startedAt)
+	if err := ctx.Err(); err != nil {
+		s.handleInstallJobFailure(ctx, workspaceID, appID, appPackage, err, startedAt)
 		return
 	}
 

--- a/services/tuttid/service/workspace/apps_runner.go
+++ b/services/tuttid/service/workspace/apps_runner.go
@@ -47,6 +47,7 @@ type AppStartInput struct {
 	PackageDir      string
 	Bootstrap       string
 	HealthcheckPath string
+	RuntimeProfile  string
 	RuntimeDir      string
 	DataDir         string
 	LogDir          string
@@ -172,7 +173,7 @@ func (r *AppRunner) startProcess(ctx context.Context, key string, input AppStart
 		r.setFailed(key, "startup", fmt.Errorf("create app log dir: %w", err))
 		return
 	}
-	appRuntime, err := r.runtimeResolver().Resolve(ctx)
+	appRuntime, err := r.resolveRuntime(ctx, input.RuntimeProfile)
 	if err != nil {
 		logAppRuntimeControl("workspace_app_runtime_start_failed", input, port, "runtime_unavailable", err)
 		r.setFailed(key, "runtime_unavailable", err)
@@ -517,6 +518,9 @@ func logAppRuntimeControl(event string, input AppStartInput, port int, failureRe
 		"bootstrap", input.Bootstrap,
 		"healthcheckPath", input.HealthcheckPath,
 	}
+	if strings.TrimSpace(input.RuntimeProfile) != "" {
+		fields = append(fields, "runtimeProfile", strings.TrimSpace(input.RuntimeProfile))
+	}
 	if port != 0 {
 		fields = append(fields, "port", port)
 	}
@@ -603,6 +607,17 @@ func (r *AppRunner) runtimeResolver() AppRuntimeResolver {
 		return r.RuntimeResolver
 	}
 	return DefaultManagedAppRuntimeResolver{}
+}
+
+func (r *AppRunner) resolveRuntime(ctx context.Context, profile string) (ResolvedAppRuntime, error) {
+	profile = strings.TrimSpace(profile)
+	resolver := r.runtimeResolver()
+	if profile != "" {
+		if profileResolver, ok := resolver.(AppRuntimeProfileResolver); ok {
+			return profileResolver.ResolveProfile(ctx, profile)
+		}
+	}
+	return resolver.Resolve(ctx)
 }
 
 func (r *AppRunner) setFailed(key string, reason string, err error) workspacebiz.AppRuntimeState {

--- a/services/tuttid/service/workspace/apps_runtime.go
+++ b/services/tuttid/service/workspace/apps_runtime.go
@@ -200,7 +200,7 @@ func (s *AppCenterService) publishInstalledAppRuntime(ctx context.Context, works
 
 func (s *AppCenterService) startRemoteBuiltinInstallJob(workspaceID string, builtin builtinapps.App) bool {
 	appID := strings.TrimSpace(builtin.Manifest.AppID)
-	return s.startInstallJob(workspaceID, appID, InstallOptions{}, func(ctx context.Context) (workspacebiz.AppPackage, error) {
+	return s.startInstallJob(workspaceID, appID, InstallOptions{}, appRuntimeProfileForManifest(builtin.Manifest), func(ctx context.Context) (workspacebiz.AppPackage, error) {
 		return s.packageForRemoteBuiltinInstall(ctx, builtin)
 	})
 }
@@ -275,6 +275,7 @@ func (s *AppCenterService) startPackage(ctx context.Context, workspaceID string,
 		PackageDir:      appPackage.PackageDir,
 		Bootstrap:       appPackage.Manifest.Runtime.Bootstrap,
 		HealthcheckPath: appPackage.Manifest.Runtime.HealthcheckPath,
+		RuntimeProfile:  appRuntimeProfileForPackage(appPackage),
 		RuntimeDir:      filepath.Join(root, "runtime"),
 		DataDir:         filepath.Join(root, "data"),
 		LogDir:          filepath.Join(root, "logs"),

--- a/services/tuttid/service/workspace/apps_test.go
+++ b/services/tuttid/service/workspace/apps_test.go
@@ -35,11 +35,13 @@ type appArtifactFetcherStub struct {
 }
 
 type appRuntimeResolverStub struct {
-	called  chan struct{}
-	once    sync.Once
-	mu      sync.Mutex
-	profile string
-	err     error
+	called         chan struct{}
+	once           sync.Once
+	mu             sync.Mutex
+	profile        string
+	resolveProfile string
+	resolveCalls   int
+	err            error
 }
 
 type preloadThenFailRuntimeResolver struct {
@@ -178,6 +180,9 @@ func (r *appRuntimeResolverStub) Resolve(context.Context) (ResolvedAppRuntime, e
 	r.once.Do(func() {
 		close(r.called)
 	})
+	r.mu.Lock()
+	r.resolveCalls += 1
+	r.mu.Unlock()
 	if r.err != nil {
 		return ResolvedAppRuntime{}, r.err
 	}
@@ -192,6 +197,19 @@ func (r *appRuntimeResolverStub) PreloadProfile(_ context.Context, profile strin
 	r.profile = profile
 	r.mu.Unlock()
 	return r.err
+}
+
+func (r *appRuntimeResolverStub) ResolveProfile(_ context.Context, profile string) (ResolvedAppRuntime, error) {
+	r.once.Do(func() {
+		close(r.called)
+	})
+	r.mu.Lock()
+	r.resolveProfile = profile
+	r.mu.Unlock()
+	if r.err != nil {
+		return ResolvedAppRuntime{}, r.err
+	}
+	return ResolvedAppRuntime{}, nil
 }
 
 func (r *preloadThenFailRuntimeResolver) Resolve(context.Context) (ResolvedAppRuntime, error) {
@@ -469,6 +487,68 @@ func TestAppCenterServiceListSkipsRuntimePreloadWhenAllAppsInstalled(t *testing.
 	case <-resolver.called:
 		t.Fatalf("List() preloaded runtime when all apps are installed")
 	default:
+	}
+}
+
+func TestAppCenterServiceInstallNodeStaticPackageSkipsBaselineRuntimePreload(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	store := newAppStoreStub()
+	manifest := workspacebiz.AppManifest{
+		SchemaVersion: workspacebiz.AppManifestSchemaVersionV1,
+		AppID:         "node-app",
+		Version:       "1.0.0",
+		Name:          "Node App",
+		Description:   "Node-only app",
+		Runtime: workspacebiz.AppManifestRuntime{
+			Bootstrap:       "bootstrap.sh",
+			HealthcheckPath: "/",
+			Profile:         workspaceAppNodeRuntimePreloadProfile,
+		},
+	}
+	packageDir := createWorkspaceAppPackageForTest(t, t.TempDir(), manifest)
+	if err := store.PutAppPackage(ctx, workspacebiz.AppPackage{
+		AppID:      manifest.AppID,
+		Version:    manifest.Version,
+		PackageDir: packageDir,
+		Manifest:   manifest,
+		Source:     workspacebiz.AppPackageSourceGenerated,
+	}); err != nil {
+		t.Fatalf("PutAppPackage() error = %v", err)
+	}
+	resolver := &appRuntimeResolverStub{called: make(chan struct{})}
+	service := AppCenterService{
+		Store:          store,
+		WorkspaceStore: &catalogStoreStub{getWorkspace: workspacebiz.Summary{ID: "ws-1", Name: "Workspace"}},
+		Runner:         &AppRunner{RuntimeResolver: resolver},
+		StateDir:       t.TempDir(),
+		BuiltinCatalog: func() ([]builtinapps.App, error) {
+			return nil, nil
+		},
+	}
+
+	if _, err := service.Install(ctx, "ws-1", manifest.AppID); err != nil {
+		t.Fatalf("Install() error = %v", err)
+	}
+
+	deadline := time.After(time.Second)
+	for {
+		resolver.mu.Lock()
+		profile := resolver.profile
+		resolveCalls := resolver.resolveCalls
+		resolver.mu.Unlock()
+		if profile == workspaceAppNodeRuntimePreloadProfile {
+			if resolveCalls != 0 {
+				t.Fatalf("baseline Resolve() calls = %d, want 0", resolveCalls)
+			}
+			return
+		}
+		select {
+		case <-deadline:
+			t.Fatal("node-static runtime preload did not run")
+		case <-time.After(10 * time.Millisecond):
+		}
 	}
 }
 


### PR DESCRIPTION
## Summary
- add manifest/runtime support for the node-static profile
- resolve and preload node-static apps without requiring Python
- document and test the profile across daemon, app center, and app factory validation
- remove the stale global agent pending overlay that current source guards already disallow

## Tests
- go test ./service/managedruntime ./biz/workspace ./service/workspace
- pnpm --filter @tutti-os/workspace-app-center test
- node --test --experimental-strip-types src/renderer/src/features/workspace-workbench/ui/WorkspaceWorkbench.source.test.ts

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Workspace apps can now declare an optional `runtime.profile: "node-static"` in their manifest to use a Node-only runtime during installation and launch.
* **Bug Fixes**
  * Validation now rejects unsupported `runtime.profile` values and reports issues at `$.runtime.profile`.
* **Behavior Changes**
  * Runtime preloading and app start runtime resolution now respect the declared runtime profile, avoiding baseline Python runtime when `node-static` is used.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->