### PR TITLE
Optimize agent conversation rail rendering

### DIFF
--- a/packages/agent/gui/agent-gui/agentGuiNode/AgentGUINode.styles.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/AgentGUINode.styles.ts
@@ -77,6 +77,10 @@ const styles = {
     "agent-gui-node__conversation-section-label-icon",
   conversationSectionMoreButton:
     "agent-gui-node__conversation-section-more-button",
+  conversationSectionPagination:
+    "agent-gui-node__conversation-section-pagination",
+  conversationSectionPaginationButton:
+    "agent-gui-node__conversation-section-pagination-button",
   conversationSectionToggle: "agent-gui-node__conversation-section-toggle",
   conversationSelect: "agent-gui-node__conversation-select",
   conversationStatusGlyph: "agent-gui-node__conversation-status-glyph",

--- a/packages/agent/gui/agent-gui/agentGuiNode/AgentGUINode.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/AgentGUINode.tsx
@@ -948,6 +948,8 @@ export const AgentGUINode = memo(function AgentGUINode({
       toolCallsLabel: (count: number) =>
         t("agentHost.workspaceAgentSessionDetailToolCalls", { count }),
       openConversationWindow: t("agentHost.agentGui.openConversationWindow"),
+      showMoreConversations: t("agentHost.agentGui.showMoreConversations"),
+      showLessConversations: t("agentHost.agentGui.showLessConversations"),
       deleteSession: t("agentHost.agentGui.deleteSession"),
       pinSession: t("agentHost.agentGui.pinSession"),
       unpinSession: t("agentHost.agentGui.unpinSession"),

--- a/packages/agent/gui/agent-gui/agentGuiNode/AgentGUINodeView.layout.spec.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/AgentGUINodeView.layout.spec.tsx
@@ -11,6 +11,10 @@ const conversationFlowMock = vi.hoisted(() => ({
   calls: [] as Array<{ conversation: unknown; labels: unknown }>
 }));
 
+const conversationMetaMock = vi.hoisted(() => ({
+  calls: [] as string[]
+}));
+
 const composerMock = vi.hoisted(() => ({
   calls: [] as Array<{
     composerFocusRequestSequence?: number | null;
@@ -84,9 +88,24 @@ vi.mock("../../app/renderer/components/StatusDot", () => ({
   }
 }));
 
+vi.mock("./agentGuiNodeViewConversation", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("./agentGuiNodeViewConversation")>();
+  return {
+    ...actual,
+    ConversationMeta: (
+      props: Parameters<typeof actual.ConversationMeta>[0]
+    ): React.JSX.Element => {
+      conversationMetaMock.calls.push(props.item.id);
+      return actual.ConversationMeta(props);
+    }
+  };
+});
+
 describe("AgentGUINodeView layout persistence", () => {
   afterEach(() => {
     conversationFlowMock.calls = [];
+    conversationMetaMock.calls = [];
     composerMock.calls = [];
     statusDotMock.calls = [];
   });
@@ -472,6 +491,37 @@ describe("AgentGUINodeView layout persistence", () => {
     expect(onOpenConversationWindow).toHaveBeenCalledTimes(1);
     expect(onOpenConversationWindow).toHaveBeenCalledWith("session-2");
     expect(actions.selectConversation).not.toHaveBeenCalled();
+  });
+
+  it("does not rerender the conversation rail when only the active detail state changes", () => {
+    const actions = createActions();
+    const labels = createLabels();
+    const viewModel = {
+      ...createViewModel(),
+      conversations: Array.from({ length: 20 }, (_, index) =>
+        createConversationSummary(`session-${index + 1}`)
+      )
+    };
+    const initialOptions = {
+      actions,
+      isActive: true,
+      labels,
+      viewModel
+    };
+
+    const { rerender } = renderAgentGUINodeView(initialOptions);
+
+    expect(conversationMetaMock.calls).toHaveLength(20);
+    conversationMetaMock.calls = [];
+
+    rerender(
+      buildAgentGUINodeViewElement({
+        ...initialOptions,
+        isActive: false
+      })
+    );
+
+    expect(conversationMetaMock.calls).toHaveLength(0);
   });
 
   it("scrolls the active conversation item into view", () => {
@@ -1147,6 +1197,7 @@ describe("AgentGUINodeView usage alert banner", () => {
 interface RenderAgentGUINodeViewOptions {
   conversationRailCollapsed?: boolean;
   conversationRailWidthPx?: number;
+  isActive?: boolean;
   isAgentProviderReady?: boolean;
   onConversationRailWidthChanged?: (widthPx: number) => void;
   viewModel?: AgentGUINodeViewModel;
@@ -1160,6 +1211,7 @@ interface RenderAgentGUINodeViewOptions {
 function buildAgentGUINodeViewElement({
   conversationRailCollapsed = false,
   conversationRailWidthPx = 240,
+  isActive = true,
   isAgentProviderReady = true,
   onConversationRailWidthChanged = vi.fn(),
   viewModel = createViewModel(),
@@ -1172,6 +1224,7 @@ function buildAgentGUINodeViewElement({
   return (
     <AgentGUINodeView
       viewModel={viewModel}
+      isActive={isActive}
       isAgentProviderReady={isAgentProviderReady}
       slashStatusLimits={slashStatusLimits}
       actions={actions}

--- a/packages/agent/gui/agent-gui/agentGuiNode/AgentGUINodeView.layout.spec.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/AgentGUINodeView.layout.spec.tsx
@@ -493,6 +493,72 @@ describe("AgentGUINodeView layout persistence", () => {
     expect(actions.selectConversation).not.toHaveBeenCalled();
   });
 
+  it("pages each conversation rail section five sessions at a time", () => {
+    renderAgentGUINodeView({
+      labels: {
+        ...createLabels(),
+        showMoreConversations: "Show more",
+        showLessConversations: "Show less"
+      },
+      viewModel: {
+        ...createViewModel(),
+        conversations: Array.from({ length: 12 }, (_, index) =>
+          createConversationSummary(`session-${index + 1}`)
+        )
+      }
+    });
+
+    expect(
+      screen.getByTestId("agent-gui-conversation-item-session-5")
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByTestId("agent-gui-conversation-item-session-6")
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: "Show less" })
+    ).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "Show more" }));
+
+    expect(
+      screen.getByTestId("agent-gui-conversation-item-session-10")
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByTestId("agent-gui-conversation-item-session-11")
+    ).not.toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "Show more" })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "Show less" })
+    ).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "Show less" }));
+
+    expect(
+      screen.getByTestId("agent-gui-conversation-item-session-5")
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByTestId("agent-gui-conversation-item-session-6")
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: "Show less" })
+    ).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "Show more" }));
+    fireEvent.click(screen.getByRole("button", { name: "Show more" }));
+
+    expect(
+      screen.getByTestId("agent-gui-conversation-item-session-12")
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: "Show more" })
+    ).not.toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "Show less" })
+    ).toBeInTheDocument();
+  });
+
   it("does not rerender the conversation rail when only the active detail state changes", () => {
     const actions = createActions();
     const labels = createLabels();
@@ -511,7 +577,7 @@ describe("AgentGUINodeView layout persistence", () => {
 
     const { rerender } = renderAgentGUINodeView(initialOptions);
 
-    expect(conversationMetaMock.calls).toHaveLength(20);
+    expect(conversationMetaMock.calls).toHaveLength(5);
     conversationMetaMock.calls = [];
 
     rerender(
@@ -1554,6 +1620,8 @@ function createLabels(): AgentGUIViewLabels {
     thinkingLabel: "thinkingLabel",
     toolCallsLabel: (count: number) => `toolCalls:${count}`,
     openConversationWindow: "openConversationWindow",
+    showMoreConversations: "showMoreConversations",
+    showLessConversations: "showLessConversations",
     deleteSession: "deleteSession",
     pinSession: "pinSession",
     unpinSession: "unpinSession",

--- a/packages/agent/gui/agent-gui/agentGuiNode/AgentGUINodeView.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/AgentGUINodeView.tsx
@@ -130,6 +130,7 @@ export type AgentMentionReferenceTargetResolver = (
 ) => ReferenceLocateTarget | null;
 
 const AGENT_GUI_STICK_TO_BOTTOM_THRESHOLD_PX = 24;
+const AGENT_GUI_CONVERSATION_RAIL_SECTION_PAGE_SIZE = 5;
 
 const AGENT_GUI_TIMELINE_SCROLL_AREA_CONTENT_STYLE: CSSProperties = {
   width: "100%",
@@ -301,6 +302,8 @@ export interface AgentGUIViewLabels {
   thinkingLabel: string;
   toolCallsLabel: (count: number) => string;
   openConversationWindow: string;
+  showMoreConversations: string;
+  showLessConversations: string;
   deleteSession: string;
   pinSession: string;
   unpinSession: string;
@@ -3320,6 +3323,26 @@ const AgentGUIConversationRailSection = memo(
   }: AgentGUIConversationRailSectionProps): React.JSX.Element {
     "use memo";
     const isProjectSection = section.kind === "project";
+    const [visibleItemLimit, setVisibleItemLimit] = useState(
+      AGENT_GUI_CONVERSATION_RAIL_SECTION_PAGE_SIZE
+    );
+    const visibleItemCount = Math.min(visibleItemLimit, section.items.length);
+    const visibleItems = section.items.slice(0, visibleItemCount);
+    const canShowMore = visibleItemCount < section.items.length;
+    const canShowLess =
+      visibleItemCount > AGENT_GUI_CONVERSATION_RAIL_SECTION_PAGE_SIZE;
+    const showMoreConversations = useCallback(() => {
+      setVisibleItemLimit((current) =>
+        Math.min(
+          section.items.length,
+          current + AGENT_GUI_CONVERSATION_RAIL_SECTION_PAGE_SIZE
+        )
+      );
+    }, [section.items.length]);
+    const showLessConversations = useCallback(() => {
+      setVisibleItemLimit(AGENT_GUI_CONVERSATION_RAIL_SECTION_PAGE_SIZE);
+    }, []);
+
     return (
       <section
         className={styles.conversationSection}
@@ -3439,7 +3462,7 @@ const AgentGUIConversationRailSection = memo(
                 {labels.emptyProjectConversations}
               </div>
             ) : null}
-            {section.items.map((item) => (
+            {visibleItems.map((item) => (
               <AgentGUIConversationRailItem
                 key={item.id}
                 active={item.id === activeConversationId}
@@ -3460,6 +3483,28 @@ const AgentGUIConversationRailSection = memo(
                 onOpenConversationWindow={onOpenConversationWindow}
               />
             ))}
+            {canShowMore || canShowLess ? (
+              <div className={styles.conversationSectionPagination}>
+                {canShowMore ? (
+                  <button
+                    type="button"
+                    className={styles.conversationSectionPaginationButton}
+                    onClick={showMoreConversations}
+                  >
+                    {labels.showMoreConversations}
+                  </button>
+                ) : null}
+                {canShowLess ? (
+                  <button
+                    type="button"
+                    className={styles.conversationSectionPaginationButton}
+                    onClick={showLessConversations}
+                  >
+                    {labels.showLessConversations}
+                  </button>
+                ) : null}
+              </div>
+            ) : null}
           </div>
         </div>
       </section>

--- a/packages/agent/gui/agent-gui/agentGuiNode/AgentGUINodeView.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/AgentGUINodeView.tsx
@@ -12,6 +12,7 @@ import {
   useState
 } from "react";
 import { useSnapshot } from "valtio";
+import { proxy } from "valtio/vanilla";
 import { ChevronRight, ExternalLink, Info, X } from "lucide-react";
 import type {
   ReferenceLocateTarget,
@@ -904,15 +905,44 @@ export function AgentGUINodeView({
     },
     [settleReferencePicker, viewModel.workspaceId]
   );
-  const openclawGateway =
-    viewModel.openclawGateway ??
-    (viewModel.data.provider === "openclaw"
-      ? { status: "starting" as const, error: null }
-      : null);
+  const openclawGateway = useMemo(
+    () =>
+      viewModel.openclawGateway ??
+      (viewModel.data.provider === "openclaw"
+        ? { status: "starting" as const, error: null }
+        : null),
+    [viewModel.data.provider, viewModel.openclawGateway]
+  );
   const isOpenclawGatewayBlocking =
     openclawGateway !== null && openclawGateway.status !== "ready";
   const createConversationDisabled =
     viewModel.isCreatingConversation || isOpenclawGatewayBlocking;
+  const createConversationAction = useStableEventCallback(
+    actions.createConversation
+  );
+  const retryOpenclawGateway = useStableEventCallback(
+    actions.retryOpenclawGateway
+  );
+  const selectConversation = useStableEventCallback(actions.selectConversation);
+  const toggleConversationPinned = useStableEventCallback(
+    actions.toggleConversationPinned
+  );
+  const removeProject = useStableEventCallback(actions.removeProject);
+  const confirmDeleteProjectConversations = useStableEventCallback(
+    actions.confirmDeleteProjectConversations
+  );
+  const requestDeleteConversation = useStableEventCallback(
+    actions.requestDeleteConversation
+  );
+  const cancelDeleteConversation = useStableEventCallback(
+    actions.cancelDeleteConversation
+  );
+  const confirmDeleteConversation = useStableEventCallback(
+    actions.confirmDeleteConversation
+  );
+  const openConversationWindow = useOptionalStableEventCallback(
+    onOpenConversationWindow
+  );
   const detailComposerFocusRequestSequence =
     localComposerFocusRequestSequence === 0
       ? composerFocusRequestSequence
@@ -923,13 +953,13 @@ export function AgentGUINodeView({
         return;
       }
       if (options) {
-        actions.createConversation(options);
+        createConversationAction(options);
       } else {
-        actions.createConversation();
+        createConversationAction();
       }
       setLocalComposerFocusRequestSequence((current) => current + 1);
     },
-    [actions, previewMode]
+    [createConversationAction, previewMode]
   );
   useEffect(() => {
     if (
@@ -1098,6 +1128,76 @@ export function AgentGUINodeView({
       ? "0 minmax(var(--agent-gui-detail-min-width), 1fr)"
       : "var(--agent-gui-conversation-rail-width) minmax(var(--agent-gui-detail-min-width), 1fr)"
   } as CSSProperties;
+  const conversationRailStoreState =
+    useMemo<AgentGUIConversationRailStoreSnapshot>(
+      () => ({
+        conversations: viewModel.conversations,
+        userProjects: viewModel.userProjects,
+        activeConversationId: viewModel.activeConversationId,
+        pendingDeleteConversationId:
+          viewModel.pendingDeleteConversation?.id ?? null,
+        isLoadingConversations: viewModel.isLoadingConversations,
+        isDeletingConversation: viewModel.isDeletingConversation,
+        isDeletingProjectConversations:
+          viewModel.isDeletingProjectConversations,
+        labels,
+        workspaceUserProjectI18n,
+        uiLanguage,
+        showProjectSelector,
+        createConversationDisabled,
+        openclawGateway,
+        isCollapsed: conversationRailCollapsed,
+        onCreateConversation: requestCreateConversation,
+        onRetryOpenclawGateway: retryOpenclawGateway,
+        onSelectConversation: selectConversation,
+        onToggleConversationPinned: toggleConversationPinned,
+        onRemoveProject: removeProject,
+        onConfirmDeleteProjectConversations: confirmDeleteProjectConversations,
+        onRequestDeleteConversation: requestDeleteConversation,
+        onCancelDeleteConversation: cancelDeleteConversation,
+        onConfirmDeleteConversation: confirmDeleteConversation,
+        onOpenConversationWindow: openConversationWindow
+      }),
+      [
+        cancelDeleteConversation,
+        confirmDeleteConversation,
+        confirmDeleteProjectConversations,
+        conversationRailCollapsed,
+        createConversationDisabled,
+        labels,
+        openConversationWindow,
+        openclawGateway,
+        removeProject,
+        requestCreateConversation,
+        requestDeleteConversation,
+        retryOpenclawGateway,
+        selectConversation,
+        showProjectSelector,
+        toggleConversationPinned,
+        uiLanguage,
+        viewModel.activeConversationId,
+        viewModel.conversations,
+        viewModel.isDeletingConversation,
+        viewModel.isDeletingProjectConversations,
+        viewModel.isLoadingConversations,
+        viewModel.pendingDeleteConversation?.id,
+        viewModel.userProjects,
+        workspaceUserProjectI18n
+      ]
+    );
+  const conversationRailStoreRef = useRef<AgentGUIConversationRailStore | null>(
+    null
+  );
+  if (conversationRailStoreRef.current === null) {
+    conversationRailStoreRef.current = createAgentGUIConversationRailStore(
+      conversationRailStoreState
+    );
+  }
+  const conversationRailStore = conversationRailStoreRef.current;
+  syncAgentGUIConversationRailStore(
+    conversationRailStore,
+    conversationRailStoreState
+  );
 
   return (
     <TooltipProvider>
@@ -1117,37 +1217,9 @@ export function AgentGUINodeView({
           aria-hidden={conversationRailCollapsed ? "true" : undefined}
           inert={conversationRailCollapsed ? true : undefined}
         >
-          <AgentGUIConversationRailPane
-            conversations={viewModel.conversations}
-            userProjects={viewModel.userProjects}
-            activeConversationId={viewModel.activeConversationId}
-            pendingDeleteConversationId={
-              viewModel.pendingDeleteConversation?.id ?? null
-            }
-            isLoadingConversations={viewModel.isLoadingConversations}
-            isDeletingConversation={viewModel.isDeletingConversation}
-            isDeletingProjectConversations={
-              viewModel.isDeletingProjectConversations
-            }
-            labels={labels}
-            workspaceUserProjectI18n={workspaceUserProjectI18n}
-            uiLanguage={uiLanguage}
-            showProjectSelector={showProjectSelector}
-            createConversationDisabled={createConversationDisabled}
-            openclawGateway={openclawGateway}
-            isCollapsed={conversationRailCollapsed}
-            onCreateConversation={requestCreateConversation}
-            onRetryOpenclawGateway={actions.retryOpenclawGateway}
-            onSelectConversation={actions.selectConversation}
-            onToggleConversationPinned={actions.toggleConversationPinned}
-            onRemoveProject={actions.removeProject}
-            onConfirmDeleteProjectConversations={
-              actions.confirmDeleteProjectConversations
-            }
-            onRequestDeleteConversation={actions.requestDeleteConversation}
-            onCancelDeleteConversation={actions.cancelDeleteConversation}
-            onConfirmDeleteConversation={actions.confirmDeleteConversation}
-            onOpenConversationWindow={onOpenConversationWindow}
+          <AgentGUIConversationRailStorePane
+            store={conversationRailStore}
+            storeState={conversationRailStoreState}
           />
         </aside>
         <div
@@ -2801,6 +2873,76 @@ type OpenclawGatewayViewModel =
       status: "starting";
       error: null;
     };
+
+type AgentGUIConversationRailStoreSnapshot = AgentGUIConversationRailPaneProps;
+
+type AgentGUIConversationRailStore = AgentGUIConversationRailStoreSnapshot;
+
+function createAgentGUIConversationRailStore(
+  initialState: AgentGUIConversationRailStoreSnapshot
+): AgentGUIConversationRailStore {
+  return proxy<AgentGUIConversationRailStoreSnapshot>(initialState);
+}
+
+function syncAgentGUIConversationRailStore(
+  store: AgentGUIConversationRailStore,
+  next: AgentGUIConversationRailStoreSnapshot
+): void {
+  if (agentGUIConversationRailStoreSnapshotsEqual(store, next)) {
+    return;
+  }
+  Object.assign(store, next);
+}
+
+function agentGUIConversationRailStoreSnapshotsEqual(
+  current: AgentGUIConversationRailStoreSnapshot,
+  next: AgentGUIConversationRailStoreSnapshot
+): boolean {
+  return (
+    current.conversations === next.conversations &&
+    current.userProjects === next.userProjects &&
+    current.activeConversationId === next.activeConversationId &&
+    current.pendingDeleteConversationId === next.pendingDeleteConversationId &&
+    current.isLoadingConversations === next.isLoadingConversations &&
+    current.isDeletingConversation === next.isDeletingConversation &&
+    current.isDeletingProjectConversations ===
+      next.isDeletingProjectConversations &&
+    current.labels === next.labels &&
+    current.workspaceUserProjectI18n === next.workspaceUserProjectI18n &&
+    current.uiLanguage === next.uiLanguage &&
+    current.showProjectSelector === next.showProjectSelector &&
+    current.createConversationDisabled === next.createConversationDisabled &&
+    current.openclawGateway === next.openclawGateway &&
+    current.isCollapsed === next.isCollapsed &&
+    current.onCreateConversation === next.onCreateConversation &&
+    current.onRetryOpenclawGateway === next.onRetryOpenclawGateway &&
+    current.onSelectConversation === next.onSelectConversation &&
+    current.onToggleConversationPinned === next.onToggleConversationPinned &&
+    current.onOpenConversationWindow === next.onOpenConversationWindow &&
+    current.onRemoveProject === next.onRemoveProject &&
+    current.onConfirmDeleteProjectConversations ===
+      next.onConfirmDeleteProjectConversations &&
+    current.onRequestDeleteConversation === next.onRequestDeleteConversation &&
+    current.onCancelDeleteConversation === next.onCancelDeleteConversation &&
+    current.onConfirmDeleteConversation === next.onConfirmDeleteConversation
+  );
+}
+
+interface AgentGUIConversationRailStorePaneProps {
+  store: AgentGUIConversationRailStore;
+  storeState: AgentGUIConversationRailStoreSnapshot;
+}
+
+const AgentGUIConversationRailStorePane = memo(
+  function AgentGUIConversationRailStorePane({
+    store,
+    storeState: _storeState
+  }: AgentGUIConversationRailStorePaneProps): React.JSX.Element {
+    "use memo";
+    const state = useSnapshot(store) as AgentGUIConversationRailStoreSnapshot;
+    return <AgentGUIConversationRailPane {...state} />;
+  }
+);
 
 function normalizeConversationRailProjectPath(
   path: string | null | undefined

--- a/packages/agent/gui/agent-message-center/WorkspaceAgentMessageCenterPanel.spec.tsx
+++ b/packages/agent/gui/agent-message-center/WorkspaceAgentMessageCenterPanel.spec.tsx
@@ -1411,11 +1411,14 @@ describe("WorkspaceAgentMessageCenterPanel", () => {
       stack.querySelectorAll("[data-message-center-item-id]").length
     ).toBeLessThan(100);
 
-    await waitFor(() => {
-      expect(
-        stack.querySelectorAll("[data-message-center-item-id]")
-      ).toHaveLength(127);
-    });
+    await waitFor(
+      () => {
+        expect(
+          stack.querySelectorAll("[data-message-center-item-id]")
+        ).toHaveLength(127);
+      },
+      { timeout: 5000 }
+    );
 
     expect(screen.getByText("Running task 127")).toBeTruthy();
     expect(

--- a/packages/agent/gui/app/renderer/agentactivity.css
+++ b/packages/agent/gui/app/renderer/agentactivity.css
@@ -4517,6 +4517,38 @@ button.agent-gui-node__conversation-section-toggle:hover
   gap: 2px;
 }
 
+.agent-gui-node__conversation-section-pagination {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  align-items: center;
+  min-width: 0;
+  padding: 2px 6px 0 22px;
+}
+
+.agent-gui-node__conversation-section-pagination-button {
+  min-width: 0;
+  border: 0;
+  border-radius: 4px;
+  background: transparent;
+  color: var(--text-tertiary);
+  cursor: pointer;
+  font: inherit;
+  font-size: 12px;
+  line-height: 18px;
+  padding: 1px 4px;
+  text-align: left;
+  transition:
+    background-color 140ms ease,
+    color 140ms ease;
+}
+
+.agent-gui-node__conversation-section-pagination-button:hover,
+.agent-gui-node__conversation-section-pagination-button:focus-visible {
+  background-color: var(--agent-gui-surface-hover);
+  color: var(--text-primary);
+}
+
 @media (prefers-reduced-motion: reduce) {
   .agent-gui-node__conversation-section-items {
     transition: none;

--- a/packages/agent/gui/app/renderer/i18n/locales/en.ts
+++ b/packages/agent/gui/app/renderer/i18n/locales/en.ts
@@ -796,6 +796,8 @@ export const en = {
       shortcutCmdEnter: "Cmd + Enter",
       shortcutCtrEnter: "Ctr + Enter",
       openConversationWindow: "Open session in new window",
+      showMoreConversations: "Show more",
+      showLessConversations: "Show less",
       deleteSession: "Delete session",
       pinSession: "Pin session",
       unpinSession: "Unpin session",

--- a/packages/agent/gui/app/renderer/i18n/locales/zh-CN.ts
+++ b/packages/agent/gui/app/renderer/i18n/locales/zh-CN.ts
@@ -733,6 +733,8 @@ export const zhCN = {
       shortcutCmdEnter: "Cmd + Enter",
       shortcutCtrEnter: "Ctr + Enter",
       openConversationWindow: "在新窗口打开会话",
+      showMoreConversations: "显示更多",
+      showLessConversations: "收起",
       deleteSession: "删除会话",
       pinSession: "置顶会话",
       unpinSession: "取消置顶",

--- a/services/tuttid/service/agentstatus/service_test.go
+++ b/services/tuttid/service/agentstatus/service_test.go
@@ -256,6 +256,8 @@ func TestServiceListReportsInstallActionWhenCodexAdapterCommandFails(t *testing.
 		Now: func() time.Time {
 			return time.Date(2026, 6, 2, 8, 0, 0, 0, time.UTC)
 		},
+		ProbeReadyAfter: 10 * time.Second,
+		ProbeTimeout:    15 * time.Second,
 		RunAuthStatusCommand: func(context.Context, ProviderSpec, string) (AuthInfo, bool) {
 			return AuthInfo{Status: AuthAuthenticated}, true
 		},


### PR DESCRIPTION
## Summary
- isolate the Agent GUI conversation rail behind stable props/local Valtio state so active/detail changes do not rerender all rail rows
- page each conversation rail section in groups of five with localized Show more / Show less controls aligned with session titles
- stabilize related high-load tests for expanded message-center stack batching and Codex adapter launch-failure probing

## Tests
- `pnpm check:changed -- --push-ready`
- `pnpm check:full` (pre-push)
- `pnpm --filter @tutti-os/agent-gui test -- agent-message-center/WorkspaceAgentMessageCenterPanel.spec.tsx`
- `cd services/tuttid && go test ./service/agentstatus -run TestServiceListReportsInstallActionWhenCodexAdapterCommandFails -count=20 && go test ./service/agentstatus -count=3`
- GitHub PR Checks: all passing

## Notes
- I did not re-record a Chrome performance trace after these UI changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Conversation rail now supports pagination with "Show more" and "Show less" buttons to expand/collapse conversation lists by section.
  * Pagination controls are available in English and Chinese.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->