### PR TITLE
Remove Calendar placeholder from App Center

### DIFF
--- a/apps/desktop/src/renderer/src/features/workspace-app-center/ui/WorkspaceAppCenterPane.tsx
+++ b/apps/desktop/src/renderer/src/features/workspace-app-center/ui/WorkspaceAppCenterPane.tsx
@@ -113,10 +113,6 @@ const designReviewAppIconUrl = new URL(
   "../../../assets/workspace-canvas/dock/default/apps/design-review.png",
   import.meta.url
 ).href;
-const calendarAppIconUrl = new URL(
-  "../../../assets/workspace-canvas/dock/default/apps/calendar.png",
-  import.meta.url
-).href;
 const documentSummarizerAppIconUrl = new URL(
   "../../../assets/workspace-canvas/dock/default/apps/aisummary.png",
   import.meta.url
@@ -164,13 +160,6 @@ const comingSoonWorkspaceAppDefinitions = [
     iconUrl: designReviewAppIconUrl,
     nameKey: "appCenter.comingSoonApps.designReview.name",
     tags: ["coming-soon", "product", "design"]
-  },
-  {
-    appId: "calendar",
-    descriptionKey: "appCenter.comingSoonApps.calendar.description",
-    iconUrl: calendarAppIconUrl,
-    nameKey: "appCenter.comingSoonApps.calendar.name",
-    tags: ["coming-soon", "productivity", "calendar", "schedule"]
   },
   {
     appId: "document-summarizer",
@@ -523,7 +512,6 @@ function resolveWorkspaceAppCategory(
     case "issue-manager":
     case "workspace-issue":
     case "workspace-issue-manager":
-    case "calendar":
     case "document-summarizer":
       return labels.tools;
     default:

--- a/packages/workspace/app-center/src/core/appCenterAppOrdering.ts
+++ b/packages/workspace/app-center/src/core/appCenterAppOrdering.ts
@@ -15,7 +15,6 @@ const comingSoonRecommendedAppIds = [
   "open-cut",
   "product-competition",
   "design-review",
-  "calendar",
   "document-summarizer"
 ] as const;
 

--- a/packages/workspace/app-center/src/i18n/appCenterI18n.ts
+++ b/packages/workspace/app-center/src/i18n/appCenterI18n.ts
@@ -241,11 +241,6 @@ export const appCenterEn = {
         "Open-source video editor with media arrangement and timeline editing.",
       name: "Open Cut"
     },
-    calendar: {
-      category: "Other tools",
-      description: "Manage schedules, meetings, and to-dos.",
-      name: "Calendar"
-    },
     documentSummarizer: {
       category: "Other tools",
       description:
@@ -516,11 +511,6 @@ export const appCenterZhCN = {
       category: "内容创作",
       description: "开源视频剪辑工具，支持素材编排和时间线编辑",
       name: "Open Cut"
-    },
-    calendar: {
-      category: "其他工具",
-      description: "管理日程、会议和待办事项",
-      name: "Calendar"
     },
     documentSummarizer: {
       category: "其他工具",


### PR DESCRIPTION
## Summary
- remove the static Calendar coming-soon placeholder from App Center
- remove Calendar from recommended app ordering and App Center i18n defaults

## Verification
- pnpm --filter @tutti-os/workspace-app-center test
- pnpm --filter @tutti-os/workspace-app-center typecheck
- pnpm --filter @tutti-os/desktop typecheck
- pnpm --filter @tutti-os/desktop exec node --import ./test/register-asset-stub.mjs --test --experimental-strip-types ./src/main/ipc/workspaceAppFrontendLogging.test.ts

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added new coming-soon applications to the workspace app center: Open Cut, Product Competition, Design Review, and Document Summarizer.
  * Removed Calendar from the coming-soon applications list.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->