### PR TITLE
fix(agent): stop "Project directory already exists" + infinite loading on rapid new-conversation send

### DIFF
--- a/apps/desktop/src/main/host/workspaceFileHostAccess.test.ts
+++ b/apps/desktop/src/main/host/workspaceFileHostAccess.test.ts
@@ -324,6 +324,26 @@ test("workspace file host access rejects an existing project directory name", as
   );
 });
 
+test("workspace file host access treats an existing directory as success when allowExisting is set", async () => {
+  const documentsRoot = await mkdtemp(path.join(tmpdir(), "tutti-documents-"));
+  const sessionName = "session-cf25318a-0f29-437d-943b-dfb8a478bc64";
+  await mkdir(path.join(documentsRoot, "tutti", sessionName), {
+    recursive: true
+  });
+  const hostAccess = createWorkspaceFileHostAccess({
+    getDocumentsPath: () => documentsRoot
+  });
+
+  const result = await hostAccess.createUserDocumentsProjectDirectory({
+    name: sessionName,
+    allowExisting: true
+  });
+
+  assert.deepEqual(result, {
+    path: path.join(documentsRoot, "tutti", sessionName)
+  });
+});
+
 test("workspace file host access gives project-specific codes for create failures", async () => {
   const documentsRoot = await mkdtemp(path.join(tmpdir(), "tutti-documents-"));
   const hostAccess = createWorkspaceFileHostAccess({

--- a/apps/desktop/src/main/host/workspaceFileHostAccess.ts
+++ b/apps/desktop/src/main/host/workspaceFileHostAccess.ts
@@ -99,6 +99,9 @@ export function createWorkspaceFileHostAccess(
       } catch (error) {
         const code = (error as NodeJS.ErrnoException).code;
         if (code === "EEXIST") {
+          if (payload.allowExisting === true) {
+            return { path: targetPath };
+          }
           throw createProjectDirectoryAlreadyExistsError(targetPath);
         }
         if (code === "EACCES" || code === "EPERM") {

--- a/apps/desktop/src/preload/types.ts
+++ b/apps/desktop/src/preload/types.ts
@@ -116,6 +116,7 @@ export interface DesktopWorkspaceAppExternalHostApi {
 export interface DesktopHostFilesApi {
   createUserDocumentsProjectDirectory(input: {
     name: string;
+    allowExisting?: boolean;
   }): Promise<DesktopCreateUserDocumentsProjectDirectoryResult>;
   selectAppArchive(): Promise<string | null>;
   selectAppArchiveExportPath(input: {

--- a/apps/desktop/src/renderer/src/features/workspace-agent/services/createDesktopAgentHostApi.test.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-agent/services/createDesktopAgentHostApi.test.ts
@@ -1207,6 +1207,7 @@ test("desktop agent host api creates no-project session cwd under user Documents
     {
       args: [
         {
+          allowExisting: true,
           name: "session-44444444-4444-4444-8444-444444444444"
         }
       ],

--- a/apps/desktop/src/renderer/src/features/workspace-agent/services/desktopAgentActivityAdapter.test.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-agent/services/desktopAgentActivityAdapter.test.ts
@@ -715,6 +715,63 @@ test("desktop agent activity adapter promotes Claude draft on first prompt", asy
   assert.equal(session.visible, true);
 });
 
+test("desktop agent activity adapter updates the Claude draft in place when settings change", async () => {
+  const calls: string[] = [];
+  const adapter = createDesktopAgentActivityAdapter({
+    tuttidClient: createTuttidClient({
+      async createWorkspaceAgentSession(_workspaceId, request) {
+        calls.push(`create:${request.planMode === true ? "plan" : "default"}`);
+        return createSession({
+          id: request.agentSessionId,
+          provider: "claude-code",
+          visible: false
+        });
+      },
+      async updateWorkspaceAgentSessionSettings(
+        _workspaceId,
+        agentSessionId,
+        request
+      ) {
+        calls.push(`update:${agentSessionId}:plan=${String(request.planMode)}`);
+        return createSession({
+          id: agentSessionId,
+          provider: "claude-code",
+          visible: false
+        });
+      },
+      async deleteWorkspaceAgentSession(_workspaceId, agentSessionId) {
+        calls.push(`delete:${agentSessionId}`);
+        return { removed: true };
+      }
+    }),
+    runtimeApi: createRuntimeApi()
+  });
+
+  const first = await adapter.loadComposerOptions({
+    provider: "claude-code",
+    settings: { planMode: false },
+    workspaceId
+  });
+  const draftAgentSessionId = String(first.runtimeContext?.draftAgentSessionId);
+
+  const second = await adapter.loadComposerOptions({
+    provider: "claude-code",
+    settings: { planMode: true },
+    workspaceId
+  });
+
+  // The same pre-warm draft is reused and patched in place; no teardown or
+  // second hidden session is created when toggling plan mode.
+  assert.deepEqual(calls, [
+    "create:default",
+    `update:${draftAgentSessionId}:plan=true`
+  ]);
+  assert.equal(
+    String(second.runtimeContext?.draftAgentSessionId),
+    draftAgentSessionId
+  );
+});
+
 function createTuttidClient(
   overrides: Partial<TuttidClient> = {}
 ): TuttidClient {

--- a/apps/desktop/src/renderer/src/features/workspace-agent/services/desktopAgentActivityAdapter.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-agent/services/desktopAgentActivityAdapter.ts
@@ -25,6 +25,9 @@ export function createDesktopAgentActivityAdapter({
   tuttidClient,
   runtimeApi
 }: CreateDesktopAgentActivityAdapterInput): AgentActivityAdapter {
+  // At most one pre-warm draft per workspace. Switching plan/permission/model
+  // updates this draft in place via the ACP protocol instead of tearing it
+  // down and creating a brand new hidden session on every toggle.
   const claudeDrafts = new Map<string, ClaudeDraftSessionEntry>();
 
   const deleteClaudeDraft = (entry: ClaudeDraftSessionEntry): void => {
@@ -32,7 +35,9 @@ export function createDesktopAgentActivityAdapter({
       return;
     }
     entry.status = "disposed";
-    claudeDrafts.delete(entry.key);
+    if (claudeDrafts.get(entry.workspaceId) === entry) {
+      claudeDrafts.delete(entry.workspaceId);
+    }
     void entry.promise
       .then((session) =>
         tuttidClient.deleteWorkspaceAgentSession(entry.workspaceId, session.id)
@@ -40,28 +45,17 @@ export function createDesktopAgentActivityAdapter({
       .catch(() => undefined);
   };
 
-  const ensureClaudeDraft = (
-    input: ClaudeDraftInput
+  const createClaudeDraft = (
+    input: ClaudeDraftInput,
+    cwd: string | null,
+    settingsKey: string
   ): Promise<WorkspaceAgentSession> => {
-    const key = claudeDraftKey(input);
-    const existing = claudeDrafts.get(key);
-    if (
-      existing &&
-      existing.status !== "disposed" &&
-      existing.status !== "failed"
-    ) {
-      return existing.promise;
-    }
-    for (const entry of claudeDrafts.values()) {
-      if (entry.workspaceId === input.workspaceId && entry.key !== key) {
-        deleteClaudeDraft(entry);
-      }
-    }
+    const draftKey = claudeDraftKey({ ...input, cwd });
     const agentSessionId = createDesktopAgentActivitySessionId();
     const promise = tuttidClient
       .createWorkspaceAgentSession(input.workspaceId, {
         agentSessionId,
-        cwd: input.cwd ?? null,
+        cwd,
         initialContent: [],
         model: input.settings.model,
         permissionModeId: input.settings.permissionModeId,
@@ -72,15 +66,16 @@ export function createDesktopAgentActivityAdapter({
         title: null,
         visible: false
       })
-      .then((session) => sessionWithClaudeDraftContext(session, key));
+      .then((session) => sessionWithClaudeDraftContext(session, draftKey));
     const entry: ClaudeDraftSessionEntry = {
-      key,
+      cwd,
       promise,
       sessionId: agentSessionId,
+      settingsKey,
       status: "starting",
       workspaceId: input.workspaceId
     };
-    claudeDrafts.set(key, entry);
+    claudeDrafts.set(input.workspaceId, entry);
     void promise.then(
       (session) => {
         if (entry.status === "starting") {
@@ -90,10 +85,64 @@ export function createDesktopAgentActivityAdapter({
       },
       () => {
         entry.status = "failed";
-        claudeDrafts.delete(key);
+        if (claudeDrafts.get(input.workspaceId) === entry) {
+          claudeDrafts.delete(input.workspaceId);
+        }
       }
     );
     return promise;
+  };
+
+  const ensureClaudeDraft = (
+    input: ClaudeDraftInput
+  ): Promise<WorkspaceAgentSession> => {
+    const cwd = input.cwd ?? null;
+    const settingsKey = JSON.stringify(input.settings);
+    const existing = claudeDrafts.get(input.workspaceId);
+    if (
+      existing &&
+      existing.status !== "disposed" &&
+      existing.status !== "failed" &&
+      existing.cwd === cwd
+    ) {
+      if (existing.settingsKey === settingsKey) {
+        return existing.promise;
+      }
+      // Settings changed (e.g. plan/permission mode toggled): patch the live
+      // draft in place rather than recreating a session. The returned session
+      // carries the refreshed permissionConfig/runtimeContext.
+      const draftKey = claudeDraftKey({ ...input, cwd });
+      existing.settingsKey = settingsKey;
+      const updated = existing.promise.then((session) =>
+        tuttidClient
+          .updateWorkspaceAgentSessionSettings(input.workspaceId, session.id, {
+            model: input.settings.model,
+            permissionModeId: input.settings.permissionModeId,
+            planMode: input.settings.planMode,
+            reasoningEffort: input.settings.reasoningEffort,
+            speed: input.settings.speed
+          })
+          .then((next) => sessionWithClaudeDraftContext(next, draftKey))
+      );
+      existing.promise = updated;
+      void updated.then(
+        (session) => {
+          if (existing.status === "starting" || existing.status === "ready") {
+            existing.status = "ready";
+            existing.sessionId = session.id;
+          }
+        },
+        () => {
+          // Keep the existing draft if the in-place update fails; the final
+          // settings are applied again when the draft is promoted on send.
+        }
+      );
+      return updated;
+    }
+    if (existing) {
+      deleteClaudeDraft(existing);
+    }
+    return createClaudeDraft(input, cwd, settingsKey);
   };
 
   const promoteClaudeDraft = async (
@@ -108,18 +157,17 @@ export function createDesktopAgentActivityAdapter({
     ) {
       return null;
     }
-    const entry = [...claudeDrafts.values()].find(
-      (draft) =>
-        draft.workspaceId === input.workspaceId &&
-        draft.sessionId === agentSessionId &&
-        draft.status !== "disposed" &&
-        draft.status !== "failed"
-    );
-    if (!entry) {
+    const entry = claudeDrafts.get(input.workspaceId);
+    if (
+      !entry ||
+      entry.sessionId !== agentSessionId ||
+      isDeadDraftStatus(entry.status)
+    ) {
       return null;
     }
+    // entry.status can flip to "failed" while awaiting the create promise.
     await entry.promise;
-    if (entry.status === "disposed" || entry.status === "failed") {
+    if (isDeadDraftStatus(entry.status)) {
       return null;
     }
     await tuttidClient.updateWorkspaceAgentSessionVisibility(
@@ -128,7 +176,9 @@ export function createDesktopAgentActivityAdapter({
       { visible: true }
     );
     entry.status = "promoted";
-    claudeDrafts.delete(entry.key);
+    if (claudeDrafts.get(input.workspaceId) === entry) {
+      claudeDrafts.delete(input.workspaceId);
+    }
     const session = await tuttidClient.sendWorkspaceAgentSessionInput(
       input.workspaceId,
       agentSessionId,
@@ -313,7 +363,8 @@ interface ClaudeDraftInput {
 }
 
 interface ClaudeDraftSessionEntry {
-  key: string;
+  cwd: string | null;
+  settingsKey: string;
   promise: Promise<WorkspaceAgentSession>;
   sessionId: string;
   status: ClaudeDraftStatus;
@@ -339,6 +390,10 @@ function normalizedClaudeDraftSettings(
     reasoningEffort: normalizeText(settings?.reasoningEffort) ?? null,
     speed: normalizeText(settings?.speed) ?? null
   };
+}
+
+function isDeadDraftStatus(status: ClaudeDraftStatus): boolean {
+  return status === "disposed" || status === "failed";
 }
 
 function claudeDraftKey(input: ClaudeDraftInput): string {

--- a/apps/desktop/src/renderer/src/features/workspace-agent/services/internal/workspaceAgentActivityService.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-agent/services/internal/workspaceAgentActivityService.ts
@@ -566,7 +566,8 @@ export class WorkspaceAgentActivityService implements IWorkspaceAgentActivitySer
       const directory =
         await this.dependencies.hostFilesApi?.createUserDocumentsProjectDirectory(
           {
-            name: `session-${input.agentSessionId.trim()}`
+            name: `session-${input.agentSessionId.trim()}`,
+            allowExisting: true
           }
         );
       this.dependencies.workspaceUserProjectService?.rememberNoProjectPath(

--- a/apps/desktop/src/shared/contracts/ipc.ts
+++ b/apps/desktop/src/shared/contracts/ipc.ts
@@ -261,6 +261,15 @@ export interface DesktopLocalFileTextResult {
 
 export interface DesktopCreateUserDocumentsProjectDirectoryInput {
   name: string;
+  /**
+   * When true, an already-existing target directory is treated as success
+   * instead of failing with `projectDirectoryAlreadyExists`. Used for
+   * auto-generated `session-<uuid>` working directories, where a name
+   * collision is harmless (the directory belongs to the same session).
+   * User-named project creation must leave this unset to keep the
+   * name-conflict error.
+   */
+  allowExisting?: boolean;
 }
 
 export interface DesktopCreateUserDocumentsProjectDirectoryResult {
@@ -601,8 +610,7 @@ export interface DesktopInvokePayloadByChannel {
   [desktopIpcChannels.appExternal.filesSelect]: TuttiExternalFileSelectInput;
   [desktopIpcChannels.appExternal
     .permissionsRequest]: TuttiExternalPermissionRequestInput;
-  [desktopIpcChannels.appExternal
-    .pdfPrintHtml]: TuttiExternalPdfPrintHtmlInput;
+  [desktopIpcChannels.appExternal.pdfPrintHtml]: TuttiExternalPdfPrintHtmlInput;
   [desktopIpcChannels.appExternal
     .referencesOpen]: TuttiExternalReferenceOpenInput;
   [desktopIpcChannels.appExternal.settingsOpen]: TuttiExternalSettingsOpenInput;

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUINodeController.spec.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUINodeController.spec.tsx
@@ -5290,6 +5290,55 @@ describe("useAgentGUINodeController", () => {
     expect(toast.error).not.toHaveBeenCalled();
   });
 
+  it("clears the per-session messages-loading flag when a new conversation activation fails", async () => {
+    const activate = vi.fn(
+      async (_input: AgentHostActivateAgentSessionInput) => {
+        throw new Error("runtime not connected");
+      }
+    );
+    installAgentHostApi({
+      list: vi.fn(async () => ({ presences: [], sessions: [] })),
+      listSessionTimeline: vi.fn(async () => ({ timelineItems: [] })),
+      subscribeEvents: vi.fn(() => vi.fn()),
+      activate
+    });
+
+    const { result } = renderHook(() =>
+      useAgentGUINodeController({
+        workspaceId: "room-1",
+        currentUserId: "user-1",
+        workspacePath: "/workspace",
+        avoidGroupingEdits: false,
+        data: agentGuiData(null),
+        onDataChange: vi.fn()
+      })
+    );
+
+    act(() => {
+      result.current.actions.submitPrompt(promptBlocks("create one"));
+    });
+
+    await waitFor(() => {
+      expect(result.current.viewModel.isCreatingConversation).toBe(false);
+    });
+
+    const failedId = activate.mock.calls.at(-1)?.[0]?.agentSessionId;
+    expect(failedId).toBeTruthy();
+    // The failure is surfaced and the global loading flag is cleared today.
+    expect(result.current.viewModel.detailError).toBe("runtime not connected");
+    expect(result.current.viewModel.isLoadingMessages).toBe(false);
+    // The per-session messages-loading flag opened before submit must also be
+    // released on failure; otherwise the conversation view spins forever.
+    await waitFor(() => {
+      expect(
+        getAgentSessionView({
+          workspaceId: "room-1",
+          agentSessionId: failedId as string
+        })?.isLoadingMessages
+      ).toBe(false);
+    });
+  });
+
   it("keeps durable history visible and retries attach when explicitly requested again", async () => {
     const activate = vi.fn(
       async (_input: AgentHostActivateAgentSessionInput) => {

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUINodeController.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUINodeController.ts
@@ -4422,9 +4422,22 @@ export function useAgentGUINodeController({
         const snapshotComposerOptions =
           agentActivityRuntime.getSnapshot(workspaceId)
             .composerOptionsByProvider?.[provider] ?? null;
-        const draftAgentSessionId =
+        const snapshotDraftAgentSessionId =
           normalizedInitialContent.length > 0 && provider === "claude-code"
             ? draftAgentSessionIdFromComposerOptions(snapshotComposerOptions)
+            : null;
+        // Only reuse a pre-warmed draft that has not already been consumed by a
+        // previous create. Once a draft is promoted it becomes a real (running)
+        // session, so reusing its id would collide on the server and re-create
+        // the session working directory. The composer-options snapshot can keep
+        // exposing a just-consumed id until it reloads, so guard against it.
+        const draftAgentSessionId =
+          snapshotDraftAgentSessionId &&
+          !activatedConversationIdsRef.current.has(
+            snapshotDraftAgentSessionId
+          ) &&
+          !failedNewConversationIdsRef.current.has(snapshotDraftAgentSessionId)
+            ? snapshotDraftAgentSessionId
             : null;
         const agentSessionId =
           draftAgentSessionId ?? createAgentGUIConversationId();
@@ -4575,8 +4588,12 @@ export function useAgentGUINodeController({
           void syncConversationListProjection(conversation.id);
         })
         .catch((error) => {
+          // Identify the failed create by the id captured when this submission
+          // started, not by re-reading the mutable startingConversationIdRef
+          // (a concurrent create may have overwritten or cleared it, which
+          // would misattribute the failure and skip loading teardown).
           const agentSessionId =
-            startingConversationIdRef.current ?? createAgentGUIConversationId();
+            pendingCreateAgentSessionId ?? createAgentGUIConversationId();
           if (conversationListQuery) {
             clearAgentGUIConversationCreatePending({
               query: conversationListQuery,
@@ -4592,6 +4609,10 @@ export function useAgentGUINodeController({
             !shouldShowFailedConversation &&
             !isCurrentConversation(agentSessionId)
           ) {
+            setAgentSessionViewMessagesLoading(
+              sessionViewRef(agentSessionId),
+              false
+            );
             if (startingConversationIdRef.current === agentSessionId) {
               startingConversationIdRef.current = null;
             }
@@ -4641,6 +4662,10 @@ export function useAgentGUINodeController({
             [agentSessionId]: emptyAgentComposerDraft()
           }));
           setIsLoadingMessages(false);
+          setAgentSessionViewMessagesLoading(
+            sessionViewRef(agentSessionId),
+            false
+          );
           setDetailError(message);
         })
         .finally(() => {


### PR DESCRIPTION
## Problem

切換計畫/權限模式後「立刻新建對話並發送」會出現兩個症狀:
1. 紅色報錯 `Project directory already exists: ~/Documents/tutti/session-<uuid>`
2. 進入無限 loading、看不到自己發送的訊息、也沒有錯誤提示

## Root cause(三顆串連的螺絲)

1. **draft id 複用**:每次切模式都在伺服器 create 一個新隱藏 draft、delete 舊的,並把 `draftAgentSessionId` 寫進 composer 快照。promote 後沒人讓快照失效,下一次「立刻發送」會讀到已被扶正/已用過的舊 id。
2. **mkdir 非冪等**:無專案會話用該 id 建工作目錄,末層 `mkdir` 沒有 `recursive`,撞名直接 EEXIST → 報錯。
3. **catch 身分錯位 + loading 洩漏**:新建會話的 `.catch` 用「可變 ref 當下值」而非送出當下捕捉的穩定 id 辨識失敗會話,併發時錯位、提前 return,跳過 loading 復位;且送出前開的 per-session messages-loading 旗標無人關 → 無限轉圈。

## Fixes

- **冪等 session 目錄**:自動生成的 `~/Documents/tutti/session-<uuid>` 工作目錄改為「已存在即視為成功」(`allowExisting`)。使用者手動命名專案的撞名提示維持不變。
- **穩定 catch 身分 + loading 復位**:`.catch` 改用送出當下捕捉的 `pendingCreateAgentSessionId` 辨識失敗會話,並在每條出口釋放 per-session messages-loading 旗標。
- **單一 Claude draft + 原地更新**:pre-warm draft 改為每 workspace 一個,切 plan/permission/model 時透過 ACP 協定(`set_mode`/`set_config_option`)**原地 `updateWorkspaceAgentSessionSettings`**,不再每次切換都拆掉重建 session。controller 不再重用已扶正的 draft id。

> 註:伺服器(Go)零改動 —— 已驗證 `UpdateSettings → Get → serviceSession` 會用更新後設定即時重算 `PermissionConfig` 並投影 live runtimeContext(真實 model 清單)。

## Tests

新增:host + host-api 目錄冪等、adapter 原地設定更新、controller per-session loading 釋放。

驗證全綠:agent-gui 1478、desktop workspace-agent/host 226;兩 package typecheck 乾淨;`test:go` 全過。

## Follow-up(本 PR 不含)

「新建會話狀態下沉到 vanilla store(移除 controller 的 state+ref 鏡像)」是純架構重構、blast radius 高,另開獨立 PR 處理。本 PR 的兩個 bug 已由上述就地修復根治並有回歸測試。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added an `allowExisting` option for auto-generated project directory creation so already-existing directories are treated as success.

* **Bug Fixes**
  * Improved Claude “draft” session reuse per workspace, including reusing and updating drafts when settings change.
  * Enhanced conversation activation failure handling to clear all relevant loading/error states and correct session ID tracking.

* **Tests**
  * Added/updated unit tests covering `allowExisting`, draft reuse/update behavior, and conversation activation failure scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->