### PR TITLE
refactor(agent-gui): move new-conversation bookkeeping into a creation store

### DIFF
--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/agentGuiConversationCreationStore.spec.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/agentGuiConversationCreationStore.spec.ts
@@ -1,0 +1,66 @@
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  clearConversationCreationOwner,
+  clearFailedNewConversation,
+  getStartingConversationId,
+  isActivatedConversation,
+  isFailedNewConversation,
+  markActivatedConversation,
+  markFailedNewConversation,
+  resetConversationCreationStoreForTests,
+  setStartingConversationId,
+  unmarkActivatedConversation
+} from "./agentGuiConversationCreationStore.ts";
+
+afterEach(() => {
+  resetConversationCreationStoreForTests();
+});
+
+describe("agentGuiConversationCreationStore", () => {
+  it("tracks the starting conversation id per owner", () => {
+    expect(getStartingConversationId("owner-a")).toBeNull();
+    setStartingConversationId("owner-a", "conv-1");
+    expect(getStartingConversationId("owner-a")).toBe("conv-1");
+    // Owners are isolated from one another.
+    expect(getStartingConversationId("owner-b")).toBeNull();
+    setStartingConversationId("owner-a", null);
+    expect(getStartingConversationId("owner-a")).toBeNull();
+  });
+
+  it("tracks activated conversations per owner", () => {
+    expect(isActivatedConversation("owner-a", "conv-1")).toBe(false);
+    markActivatedConversation("owner-a", "conv-1");
+    expect(isActivatedConversation("owner-a", "conv-1")).toBe(true);
+    expect(isActivatedConversation("owner-b", "conv-1")).toBe(false);
+    unmarkActivatedConversation("owner-a", "conv-1");
+    expect(isActivatedConversation("owner-a", "conv-1")).toBe(false);
+  });
+
+  it("tracks failed new conversations per owner", () => {
+    expect(isFailedNewConversation("owner-a", "conv-1")).toBe(false);
+    markFailedNewConversation("owner-a", "conv-1");
+    expect(isFailedNewConversation("owner-a", "conv-1")).toBe(true);
+    clearFailedNewConversation("owner-a", "conv-1");
+    expect(isFailedNewConversation("owner-a", "conv-1")).toBe(false);
+  });
+
+  it("clears all bookkeeping for an owner on unmount", () => {
+    setStartingConversationId("owner-a", "conv-1");
+    markActivatedConversation("owner-a", "conv-2");
+    markFailedNewConversation("owner-a", "conv-3");
+
+    clearConversationCreationOwner("owner-a");
+
+    expect(getStartingConversationId("owner-a")).toBeNull();
+    expect(isActivatedConversation("owner-a", "conv-2")).toBe(false);
+    expect(isFailedNewConversation("owner-a", "conv-3")).toBe(false);
+  });
+
+  it("ignores clears for unknown ids and owners", () => {
+    // Should not throw when the owner has no state yet.
+    clearFailedNewConversation("missing", "conv-1");
+    unmarkActivatedConversation("missing", "conv-1");
+    setStartingConversationId("missing-null", null);
+    expect(getStartingConversationId("missing-null")).toBeNull();
+  });
+});

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/agentGuiConversationCreationStore.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/agentGuiConversationCreationStore.ts
@@ -1,0 +1,121 @@
+// Module-level store owning the per-controller "new conversation" lifecycle
+// bookkeeping that previously lived as scattered refs inside
+// useAgentGUINodeController (startingConversationId, the activated/failed id
+// sets). These values are read synchronously inside async callbacks and are
+// never rendered, so this is a plain keyed store rather than a
+// useSyncExternalStore source — which is exactly why the controller used refs
+// for them. Moving them here removes the ref bookkeeping from the controller
+// and makes the creation lifecycle testable in isolation.
+//
+// Keyed by a stable controller owner key (the node id, or a generated id for
+// detached controllers). The owner entry is cleared when the controller
+// unmounts so semantics match the previous per-instance refs.
+
+interface ConversationCreationOwnerState {
+  startingConversationId: string | null;
+  activatedConversationIds: Set<string>;
+  failedNewConversationIds: Set<string>;
+}
+
+const ownerStatesByKey = new Map<string, ConversationCreationOwnerState>();
+
+function ensureOwnerState(ownerKey: string): ConversationCreationOwnerState {
+  let state = ownerStatesByKey.get(ownerKey);
+  if (!state) {
+    state = {
+      startingConversationId: null,
+      activatedConversationIds: new Set<string>(),
+      failedNewConversationIds: new Set<string>()
+    };
+    ownerStatesByKey.set(ownerKey, state);
+  }
+  return state;
+}
+
+// --- starting conversation id (the create currently in flight) ---
+
+export function setStartingConversationId(
+  ownerKey: string,
+  conversationId: string | null
+): void {
+  if (conversationId === null) {
+    const state = ownerStatesByKey.get(ownerKey);
+    if (state) {
+      state.startingConversationId = null;
+    }
+    return;
+  }
+  ensureOwnerState(ownerKey).startingConversationId = conversationId;
+}
+
+export function getStartingConversationId(ownerKey: string): string | null {
+  return ownerStatesByKey.get(ownerKey)?.startingConversationId ?? null;
+}
+
+// --- activated conversations (successfully attached) ---
+
+export function markActivatedConversation(
+  ownerKey: string,
+  conversationId: string
+): void {
+  ensureOwnerState(ownerKey).activatedConversationIds.add(conversationId);
+}
+
+export function unmarkActivatedConversation(
+  ownerKey: string,
+  conversationId: string
+): void {
+  ownerStatesByKey
+    .get(ownerKey)
+    ?.activatedConversationIds.delete(conversationId);
+}
+
+export function isActivatedConversation(
+  ownerKey: string,
+  conversationId: string
+): boolean {
+  return (
+    ownerStatesByKey
+      .get(ownerKey)
+      ?.activatedConversationIds.has(conversationId) ?? false
+  );
+}
+
+// --- failed new conversations (creation rejected) ---
+
+export function markFailedNewConversation(
+  ownerKey: string,
+  conversationId: string
+): void {
+  ensureOwnerState(ownerKey).failedNewConversationIds.add(conversationId);
+}
+
+export function clearFailedNewConversation(
+  ownerKey: string,
+  conversationId: string
+): void {
+  ownerStatesByKey
+    .get(ownerKey)
+    ?.failedNewConversationIds.delete(conversationId);
+}
+
+export function isFailedNewConversation(
+  ownerKey: string,
+  conversationId: string
+): boolean {
+  return (
+    ownerStatesByKey
+      .get(ownerKey)
+      ?.failedNewConversationIds.has(conversationId) ?? false
+  );
+}
+
+// --- lifecycle ---
+
+export function clearConversationCreationOwner(ownerKey: string): void {
+  ownerStatesByKey.delete(ownerKey);
+}
+
+export function resetConversationCreationStoreForTests(): void {
+  ownerStatesByKey.clear();
+}

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUINodeController.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUINodeController.ts
@@ -139,6 +139,12 @@ import {
 import { useAgentGuiConversationList } from "../../../contexts/workspace/presentation/renderer/agentGuiConversationList/useAgentGuiConversationList";
 import { useAgentGUIActivation } from "./useAgentGUIActivation";
 import {
+  clearConversationCreationOwner,
+  clearFailedNewConversation,
+  isFailedNewConversation,
+  markFailedNewConversation
+} from "./agentGuiConversationCreationStore";
+import {
   buildAgentSessionMentionHref,
   formatAgentMentionMarkdown,
   normalizeAgentSessionMentionTitle
@@ -2433,7 +2439,12 @@ export function useAgentGUINodeController({
   );
   const startingConversationIdRef = useRef<string | null>(null);
   const activatedConversationIdsRef = useRef(new Set<string>());
-  const failedNewConversationIdsRef = useRef(new Set<string>());
+  // Stable owner key for the conversation-creation store, read inside async
+  // callbacks without threading it through dependency arrays.
+  const conversationCreationOwnerKeyRef = useRef(
+    conversationListActiveOwnerKey
+  );
+  conversationCreationOwnerKeyRef.current = conversationListActiveOwnerKey;
   const pendingTurnIdBySessionIdRef = useRef<Record<string, string>>({});
   const conversationIdsRef = useRef(
     new Set(conversations.map((conversation) => conversation.id))
@@ -3782,7 +3793,12 @@ export function useAgentGUINodeController({
       if (!agentSessionId) {
         return;
       }
-      if (failedNewConversationIdsRef.current.has(agentSessionId)) {
+      if (
+        isFailedNewConversation(
+          conversationCreationOwnerKeyRef.current,
+          agentSessionId
+        )
+      ) {
         return;
       }
       if (startingConversationIdRef.current === agentSessionId) {
@@ -4301,7 +4317,12 @@ export function useAgentGUINodeController({
       setDetailError(null);
       return;
     }
-    if (failedNewConversationIdsRef.current.has(activeConversationId)) {
+    if (
+      isFailedNewConversation(
+        conversationCreationOwnerKeyRef.current,
+        activeConversationId
+      )
+    ) {
       return;
     }
     if (startingConversationIdRef.current === activeConversationId) {
@@ -4375,6 +4396,7 @@ export function useAgentGUINodeController({
         activatedConversationIdsRef.current.delete(pendingNewConversationId);
         void unactivateRef.current(pendingNewConversationId);
       }
+      clearConversationCreationOwner(conversationCreationOwnerKeyRef.current);
     };
   }, [
     scheduleActivityStreamStateReload,
@@ -4436,7 +4458,10 @@ export function useAgentGUINodeController({
           !activatedConversationIdsRef.current.has(
             snapshotDraftAgentSessionId
           ) &&
-          !failedNewConversationIdsRef.current.has(snapshotDraftAgentSessionId)
+          !isFailedNewConversation(
+            conversationCreationOwnerKeyRef.current,
+            snapshotDraftAgentSessionId
+          )
             ? snapshotDraftAgentSessionId
             : null;
         const agentSessionId =
@@ -4523,7 +4548,10 @@ export function useAgentGUINodeController({
               optimisticSortTimeUnixMs ?? 0
             )
           };
-          failedNewConversationIdsRef.current.delete(conversation.id);
+          clearFailedNewConversation(
+            conversationCreationOwnerKeyRef.current,
+            conversation.id
+          );
           if (startingConversationIdRef.current === agentSessionId) {
             startingConversationIdRef.current = null;
           }
@@ -4577,7 +4605,10 @@ export function useAgentGUINodeController({
           }));
           persistActiveConversation(conversation.id);
           if (activationFailed) {
-            failedNewConversationIdsRef.current.add(conversation.id);
+            markFailedNewConversation(
+              conversationCreationOwnerKeyRef.current,
+              conversation.id
+            );
             setIsLoadingMessages(false);
             void refreshMessagesFromSnapshot(conversation.id);
             void syncConversationListProjection(conversation.id);
@@ -4646,7 +4677,10 @@ export function useAgentGUINodeController({
             sortTimeUnixMs: failedAtUnixMs,
             updatedAtUnixMs: failedAtUnixMs
           };
-          failedNewConversationIdsRef.current.add(agentSessionId);
+          markFailedNewConversation(
+            conversationCreationOwnerKeyRef.current,
+            agentSessionId
+          );
           setTransientConversation(failedConversation);
           if (startingConversationIdRef.current === agentSessionId) {
             startingConversationIdRef.current = null;
@@ -4852,7 +4886,10 @@ export function useAgentGUINodeController({
     if (isNonRetryableResumeErrorCode(activation.codeFor(agentSessionId))) {
       return;
     }
-    failedNewConversationIdsRef.current.delete(agentSessionId);
+    clearFailedNewConversation(
+      conversationCreationOwnerKeyRef.current,
+      agentSessionId
+    );
     setDetailError(null);
     const existingMessages = resolveSessionMessages(agentSessionId);
     if (existingMessages.length === 0) {


### PR DESCRIPTION
> **Draft / WIP.** Stacked on #271 — base is `codex/misc-bugs-20260622`, rebase onto `main` after #271 merges.

## Why

Follow-up to #271. The new-conversation flow in `useAgentGUINodeController` keeps its lifecycle state as scattered `useRef`s (and `state + ref` mirrors). The user asked to move this complex state out of the 7800-line hook into a store, following the repo's existing vanilla-store convention (`agentGuiConversationListStore` / `agentSessionViewStore`) — **not** a state machine.

## Approach

A plain module-level store keyed by the controller owner key. The migrated values are read synchronously inside async callbacks and never rendered, so the store is a simple owner-keyed module (no `useSyncExternalStore`) — exactly why the controller used refs — and is unit-testable without React.

## Progress

- [x] `agentGuiConversationCreationStore.ts` + unit tests (foundation)
- [x] Migrate `failedNewConversationIds` (guards/marks read/write the store; owner cleared on unmount)
- [ ] Migrate `startingConversationId` (intertwined with unmount cleanup)
- [ ] Migrate `activatedConversationIds` (intertwined with unmount cleanup)
- [ ] Evaluate moving `transientConversation` render-state (heavier; may stay as the legitimate state+ref render mirror)
- [ ] Remove now-dead refs; final full-suite pass

## Verification (current)

agent-gui 1488 + store unit tests green; typecheck clean; oxlint/oxfmt/boundary clean. No behaviour change — pure refactor guarded by the existing controller suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)