### PR TITLE
Retry onboarding auto-open launch

### DIFF
--- a/apps/desktop/src/renderer/src/features/workspace-workbench/ui/useWorkspaceOnboardingAutoOpen.test.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/ui/useWorkspaceOnboardingAutoOpen.test.ts
@@ -2,7 +2,45 @@ import assert from "node:assert/strict";
 import test from "node:test";
 import { openWorkspaceOnboardingIfNeeded } from "./useWorkspaceOnboardingAutoOpen.ts";
 
-test("workspace onboarding auto-open marks only after the app opens", async () => {
+test("workspace onboarding auto-open retries when the first open does not launch", async () => {
+  let markCalls = 0;
+  let openCalls = 0;
+  const result = await openWorkspaceOnboardingIfNeeded({
+    appCenterService: {
+      store: {
+        apps: [
+          {
+            appId: "tutti-onboarding",
+            installed: true
+          }
+        ]
+      },
+      async refresh() {},
+      async refreshCatalog() {},
+      async installApp() {},
+      async openApp() {
+        openCalls += 1;
+        return openCalls === 2;
+      }
+    },
+    wait: async () => {},
+    workbenchHostService: {
+      async hasWorkspaceOnboardingAutoOpened() {
+        return false;
+      },
+      async markWorkspaceOnboardingAutoOpened() {
+        markCalls += 1;
+      }
+    },
+    workspaceId: "workspace-1"
+  });
+
+  assert.equal(result, "opened");
+  assert.equal(openCalls, 2);
+  assert.equal(markCalls, 1);
+});
+
+test("workspace onboarding auto-open exhausts retries without marking when the app never opens", async () => {
   let markCalls = 0;
   let openCalls = 0;
   const result = await openWorkspaceOnboardingIfNeeded({
@@ -23,6 +61,7 @@ test("workspace onboarding auto-open marks only after the app opens", async () =
         return false;
       }
     },
+    maxAttempts: 2,
     wait: async () => {},
     workbenchHostService: {
       async hasWorkspaceOnboardingAutoOpened() {
@@ -36,6 +75,6 @@ test("workspace onboarding auto-open marks only after the app opens", async () =
   });
 
   assert.equal(result, "not-opened");
-  assert.equal(openCalls, 1);
+  assert.equal(openCalls, 2);
   assert.equal(markCalls, 0);
 });

--- a/apps/desktop/src/renderer/src/features/workspace-workbench/ui/useWorkspaceOnboardingAutoOpen.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/ui/useWorkspaceOnboardingAutoOpen.ts
@@ -58,6 +58,7 @@ export async function openWorkspaceOnboardingIfNeeded({
 
   await appCenterService.refreshCatalog(workspaceId);
 
+  let openAttempted = false;
   for (let attempt = 0; attempt < maxAttempts; attempt += 1) {
     if (isCanceled()) {
       return "canceled";
@@ -76,9 +77,11 @@ export async function openWorkspaceOnboardingIfNeeded({
       continue;
     }
 
+    openAttempted = true;
     const opened = await appCenterService.openApp({ appId, workspaceId });
     if (!opened) {
-      return "not-opened";
+      await wait(500);
+      continue;
     }
     if (isCanceled()) {
       return "canceled";
@@ -87,7 +90,10 @@ export async function openWorkspaceOnboardingIfNeeded({
     return "opened";
   }
 
-  return isCanceled() ? "canceled" : "not-found";
+  if (isCanceled()) {
+    return "canceled";
+  }
+  return openAttempted ? "not-opened" : "not-found";
 }
 
 export function useWorkspaceOnboardingAutoOpen({


### PR DESCRIPTION
## Summary
- retry onboarding auto-open when the first `openApp` call returns false
- keep `not-opened` only after launch attempts are exhausted
- add regression tests for retry and exhausted-launch behavior

## Test Plan
- node --import ./apps/desktop/test/register-asset-stub.mjs --test --experimental-strip-types apps/desktop/src/renderer/src/features/workspace-workbench/ui/useWorkspaceOnboardingAutoOpen.test.ts
- pnpm --filter @tutti-os/desktop typecheck
- git push pre-push check:full

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved workspace onboarding auto-open reliability with retry logic. When the initial attempt to open the onboarding fails, the system now automatically retries before determining if onboarding could not be opened.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->