### PR TITLE
Add onboarding auto-open diagnostics

### DIFF
--- a/apps/desktop/src/renderer/src/features/workspace-workbench/services/internal/workspaceWorkbenchHostService.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/services/internal/workspaceWorkbenchHostService.ts
@@ -14,6 +14,7 @@ import type {
 import { resolveWorkbenchHostPrepareClose } from "@tutti-os/workbench-surface";
 import type {
   IWorkspaceWorkbenchHostService,
+  WorkspaceOnboardingAutoOpenDiagnostic,
   WorkspaceCustomWallpaperSnapshot,
   WorkspaceCustomWallpaperStatus,
   WorkspaceWorkbenchBodyRendererContext,
@@ -349,6 +350,20 @@ export class WorkspaceWorkbenchHostService implements IWorkspaceWorkbenchHostSer
       ? cachedSnapshot
       : await this.dependencies.repository.load(workspaceId);
     return hasWorkspaceOnboardingAutoOpened(snapshot);
+  }
+
+  logWorkspaceOnboardingAutoOpenDiagnostic(
+    diagnostic: WorkspaceOnboardingAutoOpenDiagnostic
+  ): void {
+    void this.dependencies.runtimeApi
+      .logRendererDiagnostic({
+        details: diagnostic.details ?? {},
+        event: diagnostic.event,
+        level: diagnostic.level,
+        source: "workspace-workbench",
+        workspaceId: diagnostic.workspaceId
+      })
+      .catch(() => undefined);
   }
 
   async markWorkspaceOnboardingAutoOpened(workspaceId: string): Promise<void> {

--- a/apps/desktop/src/renderer/src/features/workspace-workbench/services/workspaceWorkbenchHostService.interface.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/services/workspaceWorkbenchHostService.interface.ts
@@ -50,6 +50,13 @@ export interface WorkspaceCustomWallpaperSnapshot {
   thumbnailUrl: string | null;
 }
 
+export interface WorkspaceOnboardingAutoOpenDiagnostic {
+  details?: Record<string, unknown>;
+  event: string;
+  level: "debug" | "info" | "warn" | "error";
+  workspaceId: string;
+}
+
 export interface WorkspaceFilesNodeActivationPayload {
   path: string;
 }
@@ -137,6 +144,9 @@ export interface IWorkspaceWorkbenchHostService {
     listener: (request: DesktopWorkspaceAppOpenFileResolvedPayload) => void
   ): () => void;
   hasWorkspaceOnboardingAutoOpened(workspaceId: string): Promise<boolean>;
+  logWorkspaceOnboardingAutoOpenDiagnostic(
+    diagnostic: WorkspaceOnboardingAutoOpenDiagnostic
+  ): void;
   markWorkspaceOnboardingAutoOpened(workspaceId: string): Promise<void>;
   readWallpaperDisplayMode(workspaceId: string): WorkspaceWallpaperDisplayMode;
   readWallpaperId(workspaceId: string): WorkspaceWallpaperId;

--- a/apps/desktop/src/renderer/src/features/workspace-workbench/ui/useWorkspaceOnboardingAutoOpen.test.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/ui/useWorkspaceOnboardingAutoOpen.test.ts
@@ -24,14 +24,11 @@ test("workspace onboarding auto-open retries when the first open does not launch
       }
     },
     wait: async () => {},
-    workbenchHostService: {
-      async hasWorkspaceOnboardingAutoOpened() {
-        return false;
-      },
-      async markWorkspaceOnboardingAutoOpened() {
+    workbenchHostService: createWorkbenchHostService({
+      markWorkspaceOnboardingAutoOpened: () => {
         markCalls += 1;
       }
-    },
+    }),
     workspaceId: "workspace-1"
   });
 
@@ -63,14 +60,11 @@ test("workspace onboarding auto-open exhausts retries without marking when the a
     },
     maxAttempts: 2,
     wait: async () => {},
-    workbenchHostService: {
-      async hasWorkspaceOnboardingAutoOpened() {
-        return false;
-      },
-      async markWorkspaceOnboardingAutoOpened() {
+    workbenchHostService: createWorkbenchHostService({
+      markWorkspaceOnboardingAutoOpened: () => {
         markCalls += 1;
       }
-    },
+    }),
     workspaceId: "workspace-1"
   });
 
@@ -78,3 +72,96 @@ test("workspace onboarding auto-open exhausts retries without marking when the a
   assert.equal(openCalls, 2);
   assert.equal(markCalls, 0);
 });
+
+test("workspace onboarding auto-open records launch retry diagnostics", async () => {
+  let openCalls = 0;
+  const diagnostics: WorkspaceOnboardingDiagnostic[] = [];
+  const result = await openWorkspaceOnboardingIfNeeded({
+    appCenterService: {
+      store: {
+        apps: [
+          {
+            appId: "tutti-onboarding",
+            installed: true
+          }
+        ]
+      },
+      async refresh() {},
+      async refreshCatalog() {},
+      async installApp() {},
+      async openApp() {
+        openCalls += 1;
+        return openCalls === 2;
+      }
+    },
+    wait: async () => {},
+    workbenchHostService: createWorkbenchHostService({
+      logWorkspaceOnboardingAutoOpenDiagnostic: (diagnostic) => {
+        diagnostics.push(diagnostic);
+      }
+    }),
+    workspaceId: "workspace-1"
+  });
+
+  assert.equal(result, "opened");
+  assert.deepEqual(
+    diagnostics
+      .filter((diagnostic) =>
+        [
+          "workspace-onboarding.auto-open.launch-not-ready",
+          "workspace-onboarding.auto-open.opened"
+        ].includes(diagnostic.event)
+      )
+      .map((diagnostic) => ({
+        appId: diagnostic.details?.appId,
+        attempt: diagnostic.details?.attempt,
+        event: diagnostic.event,
+        level: diagnostic.level,
+        maxAttempts: diagnostic.details?.maxAttempts
+      })),
+    [
+      {
+        appId: "tutti-onboarding",
+        attempt: 1,
+        event: "workspace-onboarding.auto-open.launch-not-ready",
+        level: "warn",
+        maxAttempts: 20
+      },
+      {
+        appId: "tutti-onboarding",
+        attempt: 2,
+        event: "workspace-onboarding.auto-open.opened",
+        level: "info",
+        maxAttempts: 20
+      }
+    ]
+  );
+});
+
+type WorkspaceOnboardingDiagnostic = {
+  details?: Record<string, unknown>;
+  event: string;
+  level: "debug" | "info" | "warn" | "error";
+  workspaceId: string;
+};
+
+function createWorkbenchHostService(input?: {
+  logWorkspaceOnboardingAutoOpenDiagnostic?: (
+    diagnostic: WorkspaceOnboardingDiagnostic
+  ) => void;
+  markWorkspaceOnboardingAutoOpened?: () => void;
+}) {
+  return {
+    async hasWorkspaceOnboardingAutoOpened() {
+      return false;
+    },
+    logWorkspaceOnboardingAutoOpenDiagnostic(
+      diagnostic: WorkspaceOnboardingDiagnostic
+    ) {
+      input?.logWorkspaceOnboardingAutoOpenDiagnostic?.(diagnostic);
+    },
+    async markWorkspaceOnboardingAutoOpened() {
+      input?.markWorkspaceOnboardingAutoOpened?.();
+    }
+  };
+}

--- a/apps/desktop/src/renderer/src/features/workspace-workbench/ui/useWorkspaceOnboardingAutoOpen.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/ui/useWorkspaceOnboardingAutoOpen.ts
@@ -33,7 +33,9 @@ interface OpenWorkspaceOnboardingInput {
   wait?: (delayMs: number) => Promise<void>;
   workbenchHostService: Pick<
     IWorkspaceWorkbenchHostService,
-    "hasWorkspaceOnboardingAutoOpened" | "markWorkspaceOnboardingAutoOpened"
+    | "hasWorkspaceOnboardingAutoOpened"
+    | "logWorkspaceOnboardingAutoOpenDiagnostic"
+    | "markWorkspaceOnboardingAutoOpened"
   >;
   workspaceId: string;
 }
@@ -48,19 +50,58 @@ export async function openWorkspaceOnboardingIfNeeded({
   workspaceId
 }: OpenWorkspaceOnboardingInput): Promise<WorkspaceOnboardingAutoOpenResult> {
   if (isCanceled()) {
+    logAutoOpenDiagnostic(workbenchHostService, {
+      appId,
+      event: "workspace-onboarding.auto-open.canceled",
+      level: "info",
+      maxAttempts,
+      reason: "before-start",
+      workspaceId
+    });
     return "canceled";
   }
+  logAutoOpenDiagnostic(workbenchHostService, {
+    appId,
+    event: "workspace-onboarding.auto-open.started",
+    level: "info",
+    maxAttempts,
+    workspaceId
+  });
   if (
     await workbenchHostService.hasWorkspaceOnboardingAutoOpened(workspaceId)
   ) {
+    logAutoOpenDiagnostic(workbenchHostService, {
+      appId,
+      event: "workspace-onboarding.auto-open.already-opened",
+      level: "info",
+      maxAttempts,
+      workspaceId
+    });
     return "already-opened";
   }
 
   await appCenterService.refreshCatalog(workspaceId);
+  logAutoOpenDiagnostic(workbenchHostService, {
+    appId,
+    event: "workspace-onboarding.auto-open.catalog-refreshed",
+    level: "debug",
+    maxAttempts,
+    workspaceId
+  });
 
   let openAttempted = false;
   for (let attempt = 0; attempt < maxAttempts; attempt += 1) {
+    const attemptNumber = attempt + 1;
     if (isCanceled()) {
+      logAutoOpenDiagnostic(workbenchHostService, {
+        appId,
+        attempt: attemptNumber,
+        event: "workspace-onboarding.auto-open.canceled",
+        level: "info",
+        maxAttempts,
+        reason: "during-attempt",
+        workspaceId
+      });
       return "canceled";
     }
     await appCenterService.refresh(workspaceId);
@@ -68,11 +109,35 @@ export async function openWorkspaceOnboardingIfNeeded({
       (candidate) => candidate.appId === appId
     );
     if (!app) {
+      logAutoOpenDiagnostic(workbenchHostService, {
+        appId,
+        attempt: attemptNumber,
+        event: "workspace-onboarding.auto-open.app-missing",
+        level: "debug",
+        maxAttempts,
+        workspaceId
+      });
       await wait(500);
       continue;
     }
     if (!app.installed) {
+      logAutoOpenDiagnostic(workbenchHostService, {
+        appId,
+        attempt: attemptNumber,
+        event: "workspace-onboarding.auto-open.install-requested",
+        level: "info",
+        maxAttempts,
+        workspaceId
+      });
       await appCenterService.installApp({ appId, workspaceId });
+      logAutoOpenDiagnostic(workbenchHostService, {
+        appId,
+        attempt: attemptNumber,
+        event: "workspace-onboarding.auto-open.install-completed",
+        level: "info",
+        maxAttempts,
+        workspaceId
+      });
       await wait(500);
       continue;
     }
@@ -80,19 +145,61 @@ export async function openWorkspaceOnboardingIfNeeded({
     openAttempted = true;
     const opened = await appCenterService.openApp({ appId, workspaceId });
     if (!opened) {
+      logAutoOpenDiagnostic(workbenchHostService, {
+        appId,
+        attempt: attemptNumber,
+        event: "workspace-onboarding.auto-open.launch-not-ready",
+        level: "warn",
+        maxAttempts,
+        workspaceId
+      });
       await wait(500);
       continue;
     }
     if (isCanceled()) {
+      logAutoOpenDiagnostic(workbenchHostService, {
+        appId,
+        attempt: attemptNumber,
+        event: "workspace-onboarding.auto-open.canceled",
+        level: "info",
+        maxAttempts,
+        reason: "after-open",
+        workspaceId
+      });
       return "canceled";
     }
     await workbenchHostService.markWorkspaceOnboardingAutoOpened(workspaceId);
+    logAutoOpenDiagnostic(workbenchHostService, {
+      appId,
+      attempt: attemptNumber,
+      event: "workspace-onboarding.auto-open.opened",
+      level: "info",
+      maxAttempts,
+      workspaceId
+    });
     return "opened";
   }
 
   if (isCanceled()) {
+    logAutoOpenDiagnostic(workbenchHostService, {
+      appId,
+      event: "workspace-onboarding.auto-open.canceled",
+      level: "info",
+      maxAttempts,
+      reason: "after-attempts",
+      workspaceId
+    });
     return "canceled";
   }
+  logAutoOpenDiagnostic(workbenchHostService, {
+    appId,
+    event: openAttempted
+      ? "workspace-onboarding.auto-open.not-opened"
+      : "workspace-onboarding.auto-open.not-found",
+    level: "warn",
+    maxAttempts,
+    workspaceId
+  });
   return openAttempted ? "not-opened" : "not-found";
 }
 
@@ -126,7 +233,14 @@ export function useWorkspaceOnboardingAutoOpen({
       workbenchHostService,
       workspaceId: normalizedWorkspaceId
     })
-      .catch(() => {})
+      .catch((error: unknown) => {
+        logAutoOpenDiagnostic(workbenchHostService, {
+          event: "workspace-onboarding.auto-open.failed",
+          level: "error",
+          reason: stringifyDiagnosticError(error),
+          workspaceId: normalizedWorkspaceId
+        });
+      })
       .finally(() => {
         activeWorkspaceIdsRef.current.delete(normalizedWorkspaceId);
       });
@@ -140,4 +254,35 @@ export function useWorkspaceOnboardingAutoOpen({
 
 function defaultWait(delayMs: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, delayMs));
+}
+
+function logAutoOpenDiagnostic(
+  workbenchHostService: Pick<
+    IWorkspaceWorkbenchHostService,
+    "logWorkspaceOnboardingAutoOpenDiagnostic"
+  >,
+  input: {
+    appId?: string;
+    attempt?: number;
+    event: string;
+    level: "debug" | "info" | "warn" | "error";
+    maxAttempts?: number;
+    reason?: string;
+    workspaceId: string;
+  }
+): void {
+  const { event, level, workspaceId, ...details } = input;
+  workbenchHostService.logWorkspaceOnboardingAutoOpenDiagnostic({
+    details,
+    event,
+    level,
+    workspaceId
+  });
+}
+
+function stringifyDiagnosticError(error: unknown): string {
+  if (error instanceof Error) {
+    return error.message;
+  }
+  return String(error);
 }


### PR DESCRIPTION
## Summary
- log structured renderer diagnostics across the onboarding auto-open flow
- include attempt/maxAttempts/appId details for install, retry, open, and terminal outcomes
- add a regression test that verifies launch retry diagnostics are emitted

## Test Plan
- node --import ./apps/desktop/test/register-asset-stub.mjs --test --experimental-strip-types apps/desktop/src/renderer/src/features/workspace-workbench/ui/useWorkspaceOnboardingAutoOpen.test.ts
- pnpm exec oxfmt --write apps/desktop/src/renderer/src/features/workspace-workbench/ui/useWorkspaceOnboardingAutoOpen.ts apps/desktop/src/renderer/src/features/workspace-workbench/ui/useWorkspaceOnboardingAutoOpen.test.ts apps/desktop/src/renderer/src/features/workspace-workbench/services/workspaceWorkbenchHostService.interface.ts apps/desktop/src/renderer/src/features/workspace-workbench/services/internal/workspaceWorkbenchHostService.ts
- pnpm exec oxlint apps/desktop/src/renderer/src/features/workspace-workbench/ui/useWorkspaceOnboardingAutoOpen.ts apps/desktop/src/renderer/src/features/workspace-workbench/ui/useWorkspaceOnboardingAutoOpen.test.ts apps/desktop/src/renderer/src/features/workspace-workbench/services/workspaceWorkbenchHostService.interface.ts apps/desktop/src/renderer/src/features/workspace-workbench/services/internal/workspaceWorkbenchHostService.ts --deny-warnings

Note: local `pnpm --filter @tutti-os/desktop typecheck` is currently blocked by unrelated dirty app-center changes in this worktree (`restartAndOpenApp` test without implementation). CI should validate this branch from a clean checkout.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced diagnostic logging for workspace initialization to track auto-open attempts, outcomes, and error states throughout the process.

* **Tests**
  * Significantly expanded test coverage with new diagnostic logging verification tests and enhanced mock service utilities for workspace initialization scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->