### PR TITLE
Improve message center performance and app catalog localization

### DIFF
--- a/apps/desktop/src/renderer/src/features/workspace-app-center/ui/WorkspaceAppCenterPane.tsx
+++ b/apps/desktop/src/renderer/src/features/workspace-app-center/ui/WorkspaceAppCenterPane.tsx
@@ -36,59 +36,6 @@ import {
 import { shouldShowWorkspaceApp } from "../services/workspaceAppVisibility.ts";
 import { useWorkspaceAppCenterService } from "./useWorkspaceAppCenterService.ts";
 
-const catalogAppDisplayDefinitions = [
-  {
-    appIds: ["ai-media-canvas", "media-canvas"],
-    descriptionKey: "appCenter.catalogApps.aiMediaCanvas.description",
-    nameKey: "appCenter.catalogApps.aiMediaCanvas.name"
-  },
-  {
-    appIds: ["automation"],
-    descriptionKey: "appCenter.catalogApps.automation.description",
-    nameKey: "appCenter.catalogApps.automation.name"
-  },
-  {
-    appIds: ["daily-product-radar", "daily-tech-radar", "radar"],
-    descriptionKey: "appCenter.catalogApps.dailyProductRadar.description",
-    nameKey: "appCenter.catalogApps.dailyProductRadar.name"
-  },
-  {
-    appIds: ["ai-doc"],
-    descriptionKey: "appCenter.comingSoonApps.aiDocument.description",
-    nameKey: "appCenter.comingSoonApps.aiDocument.name"
-  },
-  {
-    appIds: ["group-chat"],
-    descriptionKey: "appCenter.catalogApps.groupChat.description",
-    nameKey: "appCenter.catalogApps.groupChat.name"
-  },
-  {
-    appIds: ["vibe-design"],
-    descriptionKey: "appCenter.catalogApps.vibeDesign.description",
-    nameKey: "appCenter.catalogApps.vibeDesign.name"
-  }
-] as const;
-
-type CatalogAppDisplayDefinition = {
-  descriptionKey: string;
-  nameKey: string;
-};
-
-const catalogAppDisplayById = new Map<string, CatalogAppDisplayDefinition>(
-  catalogAppDisplayDefinitions.flatMap((definition) =>
-    definition.appIds.map(
-      (appId) =>
-        [
-          appId,
-          {
-            descriptionKey: definition.descriptionKey,
-            nameKey: definition.nameKey
-          }
-        ] as const
-    )
-  )
-);
-
 const aiPptAppIconUrl = new URL(
   "../../../assets/workspace-canvas/dock/default/apps/PPT.png",
   import.meta.url
@@ -295,9 +242,7 @@ export function WorkspaceAppCenterPane({
     const recommendedApps = withComingSoonWorkspaceApps(
       state.apps,
       comingSoonApps
-    )
-      .map((app) => withWorkspaceAppDisplayOverride(app, i18n, locale))
-      .filter((app) => shouldShowWorkspaceApp(app.appId));
+    ).filter((app) => shouldShowWorkspaceApp(app.appId));
 
     return createAppCenterViewModel({
       apps: recommendedApps.map((app) =>
@@ -418,32 +363,6 @@ function createComingSoonWorkspaceApp(input: {
     stateRevision: 0,
     tags: input.definition.tags,
     updateAvailable: false
-  };
-}
-
-function withWorkspaceAppDisplayOverride(
-  app: WorkspaceAppCenterApp,
-  i18n: { readonly t: (key: string) => string },
-  locale: string
-): WorkspaceAppCenterApp {
-  const definition = catalogAppDisplayById.get(app.appId.trim().toLowerCase());
-  if (!definition) {
-    return app;
-  }
-  const name = i18n.t(definition.nameKey);
-  const description = i18n.t(definition.descriptionKey);
-  return {
-    ...app,
-    description,
-    name,
-    localizations: [
-      {
-        description,
-        locale,
-        name,
-        tags: []
-      }
-    ]
   };
 }
 

--- a/apps/desktop/src/renderer/src/features/workspace-workbench/ui/WorkspaceChrome.test.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/ui/WorkspaceChrome.test.ts
@@ -24,14 +24,15 @@ test("workspace chrome does not call updateSessionSettings or sendInput from the
   // (toast notification path at line 484 uses submitInteractive — that is expected to stay)
   // But updateSessionSettings + sendInput pair for plan mode must be gone from deck handler
   const deckSubmitMatch = source.match(
-    /onSubmitPrompt=\{async \(input\) => \{([\s\S]*?)\}\}/
+    /const handleMessageCenterSubmitPrompt = useCallback\(\s*async \(input: \{[\s\S]*?\}\) => \{([\s\S]*?)\},\s*\[workspace\.id, workspaceAgentActivityService\]\s*\)/
   );
   assert.ok(
     deckSubmitMatch,
-    "onSubmitPrompt handler should be present in WorkspaceChrome"
+    "message center submit handler should be present in WorkspaceChrome"
   );
   const handler = deckSubmitMatch[1] ?? "";
   assert.doesNotMatch(handler, /updateSessionSettings/);
   assert.doesNotMatch(handler, /sendInput/);
   assert.doesNotMatch(handler, /submitInteractive/);
+  assert.match(source, /onSubmitPrompt=\{handleMessageCenterSubmitPrompt\}/);
 });

--- a/apps/desktop/src/renderer/src/features/workspace-workbench/ui/WorkspaceChrome.tsx
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/ui/WorkspaceChrome.tsx
@@ -12,8 +12,10 @@ import {
   buildWorkspaceAgentInteractivePromptLabels,
   buildWorkspaceAgentMessageCenterModel,
   isWaitingMessageCenterItem,
+  stabilizeWorkspaceAgentMessageCenterModel,
   WorkspaceAgentMessageCenterPanel,
-  type WorkspaceAgentMessageCenterItem
+  type WorkspaceAgentMessageCenterItem,
+  type WorkspaceAgentMessageCenterModel
 } from "@tutti-os/agent-gui/agent-message-center";
 import type { AgentActivitySnapshot } from "@tutti-os/agent-activity-core";
 import type {
@@ -81,6 +83,8 @@ import type {
 } from "../services/workspaceWallpaper";
 
 const MESSAGE_CENTER_SUMMARY_MESSAGE_LIMIT = 20;
+const MESSAGE_CENTER_SUMMARY_PREFETCH_ITEM_LIMIT = 12;
+const MESSAGE_CENTER_VISIBLE_HISTORY_MS = 7 * 24 * 60 * 60 * 1000;
 const WORKSPACE_AGENT_DECISION_TOAST_DURATION = Infinity;
 const workspaceAgentDecisionToastClassName = "workspace-agent-decision-toast";
 const AGENT_STATUS_PET_SOURCES = {
@@ -259,6 +263,10 @@ function WorkspaceAgentMessageCenterAction({
   const activeWaitingNotificationToastIdsRef = useRef<Map<string, string>>(
     new Map()
   );
+  const messageCenterModelRef = useRef<WorkspaceAgentMessageCenterModel | null>(
+    null
+  );
+  const messageCenterModelWorkspaceIdRef = useRef<string | null>(null);
   const snapshot = useSyncExternalStore(
     (listener) =>
       workspaceAgentActivityService.subscribe(workspace.id, (nextSnapshot) => {
@@ -295,21 +303,34 @@ function WorkspaceAgentMessageCenterAction({
       return nextSnapshot;
     }
   );
-  const model = useMemo(
-    () =>
-      buildWorkspaceAgentMessageCenterModel(snapshot, {
-        promptFallbackLabels: {
-          constraintHeader: t(
-            "workspace.agentMessageCenter.promptConstraintHeader"
-          ),
-          inputHeader: t("workspace.agentMessageCenter.promptInputHeader"),
-          question: t("workspace.agentMessageCenter.promptQuestion"),
-          title: t("workspace.agentMessageCenter.promptTitle")
-        },
-        workspaceRoot: null
-      }),
-    [snapshot, t]
+  const messageCenterItemCutoffUnixMs = useMemo(
+    () => Date.now() - MESSAGE_CENTER_VISIBLE_HISTORY_MS,
+    [workspace.id]
   );
+  const model = useMemo(() => {
+    if (messageCenterModelWorkspaceIdRef.current !== workspace.id) {
+      messageCenterModelWorkspaceIdRef.current = workspace.id;
+      messageCenterModelRef.current = null;
+    }
+    const nextModel = buildWorkspaceAgentMessageCenterModel(snapshot, {
+      promptFallbackLabels: {
+        constraintHeader: t(
+          "workspace.agentMessageCenter.promptConstraintHeader"
+        ),
+        inputHeader: t("workspace.agentMessageCenter.promptInputHeader"),
+        question: t("workspace.agentMessageCenter.promptQuestion"),
+        title: t("workspace.agentMessageCenter.promptTitle")
+      },
+      itemCutoffUnixMs: messageCenterItemCutoffUnixMs,
+      workspaceRoot: null
+    });
+    const stableModel = stabilizeWorkspaceAgentMessageCenterModel(
+      messageCenterModelRef.current,
+      nextModel
+    );
+    messageCenterModelRef.current = stableModel;
+    return stableModel;
+  }, [messageCenterItemCutoffUnixMs, snapshot, t, workspace.id]);
   const waitingItems = useMemo(
     () => model.items.filter(isWaitingMessageCenterItem),
     [model.items]
@@ -553,51 +574,64 @@ function WorkspaceAgentMessageCenterAction({
     if (!open) {
       return undefined;
     }
-    const abortController = new AbortController();
-    const targets = snapshot.sessions.filter((session) => {
+    const sessionsById = new Map(
+      snapshot.sessions.map((session) => [session.agentSessionId, session])
+    );
+    const targets = model.items
+      .slice(0, MESSAGE_CENTER_SUMMARY_PREFETCH_ITEM_LIMIT)
+      .flatMap((item) => {
+        const session = sessionsById.get(item.agentSessionId);
+        return session ? [session] : [];
+      })
+      .filter((session) => {
+        const agentSessionId = session.agentSessionId.trim();
+        if (!agentSessionId) {
+          return false;
+        }
+        if (requestedMessageSummarySessionIdsRef.current.has(agentSessionId)) {
+          return false;
+        }
+        return !hasCachedWorkspaceAgentSessionMessages(
+          snapshot.sessionMessagesById,
+          session
+        );
+      });
+    if (targets.length === 0) {
+      return undefined;
+    }
+    const requestSessionSummary = (session: (typeof targets)[number]) => {
       const agentSessionId = session.agentSessionId.trim();
       if (!agentSessionId) {
-        return false;
+        return;
       }
       if (requestedMessageSummarySessionIdsRef.current.has(agentSessionId)) {
-        return false;
+        return;
       }
-      return !hasCachedWorkspaceAgentSessionMessages(
-        snapshot.sessionMessagesById,
-        session
-      );
-    });
-    if (targets.length === 0) {
-      return () => {
-        abortController.abort();
-      };
-    }
-    for (const session of targets) {
-      requestedMessageSummarySessionIdsRef.current.add(
-        session.agentSessionId.trim()
-      );
-    }
-    void Promise.all(
-      targets.map(async (session) => {
+      requestedMessageSummarySessionIdsRef.current.add(agentSessionId);
+      void (async () => {
         try {
           await workspaceAgentActivityService.listSessionMessages({
             workspaceId: workspace.id,
             agentSessionId: session.agentSessionId,
             limit: MESSAGE_CENTER_SUMMARY_MESSAGE_LIMIT,
-            order: "desc",
-            signal: abortController.signal
+            order: "desc"
           });
         } catch {
-          requestedMessageSummarySessionIdsRef.current.delete(
-            session.agentSessionId.trim()
-          );
+          requestedMessageSummarySessionIdsRef.current.delete(agentSessionId);
         }
-      })
-    );
-    return () => {
-      abortController.abort();
+      })();
     };
-  }, [open, snapshot, workspace.id, workspaceAgentActivityService]);
+    for (const session of targets) {
+      requestSessionSummary(session);
+    }
+    return undefined;
+  }, [
+    model.items,
+    open,
+    snapshot,
+    workspace.id,
+    workspaceAgentActivityService
+  ]);
 
   const openMessageCenterChat = useCallback(
     (input: { agentSessionId: string; provider: string }) => {
@@ -652,6 +686,54 @@ function WorkspaceAgentMessageCenterAction({
     },
     [launchNode, workbenchHostService, workspace.id]
   );
+  const closeMessageCenter = useCallback(() => {
+    setOpen(false);
+  }, []);
+  const handleHighlightedMessageCenterItemSettled = useCallback(
+    (itemId: string) => {
+      setHighlightedMessageCenterItemId((current) =>
+        current === itemId ? null : current
+      );
+    },
+    []
+  );
+  const handleMessageCenterNotificationActioned = useCallback(
+    (input: { action: string; provider: string }) => {
+      void new MessageCenterNotificationActionedReporter(
+        {
+          action: input.action,
+          provider: input.provider
+        },
+        {
+          reporterService
+        }
+      ).report();
+    },
+    [reporterService]
+  );
+  const handleMessageCenterSubmitPrompt = useCallback(
+    async (input: {
+      action?: string;
+      agentSessionId: string;
+      optionId?: string;
+      payload?: Record<string, unknown>;
+      promptKind?: string;
+      requestId: string;
+    }) => {
+      await workspaceAgentActivityService.submitPlanDecision({
+        workspaceId: workspace.id,
+        agentSessionId: input.agentSessionId,
+        // "" (no pending-prompt kind) takes the interactive-prompt branch
+        // in planDecisionOps; only "plan-implementation" diverges from it.
+        promptKind: input.promptKind ?? "",
+        requestId: input.requestId,
+        ...(input.action ? { action: input.action } : {}),
+        ...(input.optionId ? { optionId: input.optionId } : {}),
+        ...(input.payload ? { payload: input.payload } : {})
+      });
+    },
+    [workspace.id, workspaceAgentActivityService]
+  );
 
   return (
     <>
@@ -704,38 +786,12 @@ function WorkspaceAgentMessageCenterAction({
         open={open}
         model={model}
         highlightedItemId={highlightedMessageCenterItemId}
-        onClose={() => setOpen(false)}
-        onHighlightedItemSettled={(itemId) => {
-          setHighlightedMessageCenterItemId((current) =>
-            current === itemId ? null : current
-          );
-        }}
+        onClose={closeMessageCenter}
+        onHighlightedItemSettled={handleHighlightedMessageCenterItemSettled}
         onLinkAction={handleLinkAction}
-        onNotificationActioned={(input) => {
-          void new MessageCenterNotificationActionedReporter(
-            {
-              action: input.action,
-              provider: input.provider
-            },
-            {
-              reporterService
-            }
-          ).report();
-        }}
+        onNotificationActioned={handleMessageCenterNotificationActioned}
         onOpenChat={openMessageCenterChat}
-        onSubmitPrompt={async (input) => {
-          await workspaceAgentActivityService.submitPlanDecision({
-            workspaceId: workspace.id,
-            agentSessionId: input.agentSessionId,
-            // "" (no pending-prompt kind) takes the interactive-prompt branch
-            // in planDecisionOps; only "plan-implementation" diverges from it.
-            promptKind: input.promptKind ?? "",
-            requestId: input.requestId,
-            ...(input.action ? { action: input.action } : {}),
-            ...(input.optionId ? { optionId: input.optionId } : {}),
-            ...(input.payload ? { payload: input.payload } : {})
-          });
-        }}
+        onSubmitPrompt={handleMessageCenterSubmitPrompt}
       />
     </>
   );

--- a/apps/desktop/src/renderer/src/global.d.ts
+++ b/apps/desktop/src/renderer/src/global.d.ts
@@ -8,6 +8,7 @@ declare global {
   interface ImportMetaEnv {
     readonly VITE_TUTTID_ACCESS_TOKEN?: string;
     readonly VITE_TUTTID_BASE_URL?: string;
+    readonly VITE_TUTTI_REACT_PROFILER?: string;
     readonly VITE_TUTTI_WHY_DID_YOU_RENDER?: string;
     readonly VITE_TUTTI_WEB_DEV?: string;
     readonly VITE_TUTTI_WEB_WORKSPACE_ID?: string;

--- a/apps/desktop/src/renderer/src/main.tsx
+++ b/apps/desktop/src/renderer/src/main.tsx
@@ -26,40 +26,50 @@ const logRendererDiagnostic = createRendererDiagnosticSink();
 installBrowserCrashLogging({
   logRendererDiagnostic
 });
-const renderStormTracker = createRenderStormTracker({
-  logRendererDiagnostic
-});
 
-const rendererApp = import.meta.env.DEV ? (
-  <React.Profiler
-    id="TuttiRenderer"
-    onRender={(
-      id,
-      phase,
-      actualDuration,
-      baseDuration,
-      startTime,
-      commitTime
-    ) => {
-      renderStormTracker.record({
-        actualDuration,
-        baseDuration,
-        commitTime,
-        id,
-        phase,
-        startTime
-      });
-    }}
-  >
+const rendererApp =
+  import.meta.env.DEV && import.meta.env.VITE_TUTTI_REACT_PROFILER === "1" ? (
+    createProfiledRendererApp(logRendererDiagnostic)
+  ) : (
     <RendererApp />
-  </React.Profiler>
-) : (
-  <RendererApp />
-);
+  );
 const logReactRootError = createReactRootErrorLogger({
   captureOwnerStack: React.captureOwnerStack,
   logRendererDiagnostic
 });
+
+function createProfiledRendererApp(
+  logRendererDiagnostic: ReturnType<typeof createRendererDiagnosticSink>
+): React.ReactElement {
+  const renderStormTracker = createRenderStormTracker({
+    logRendererDiagnostic
+  });
+
+  return (
+    <React.Profiler
+      id="TuttiRenderer"
+      onRender={(
+        id,
+        phase,
+        actualDuration,
+        baseDuration,
+        startTime,
+        commitTime
+      ) => {
+        renderStormTracker.record({
+          actualDuration,
+          baseDuration,
+          commitTime,
+          id,
+          phase,
+          startTime
+        });
+      }}
+    >
+      <RendererApp />
+    </React.Profiler>
+  );
+}
 
 createRoot(root, {
   onCaughtError(error, errorInfo) {

--- a/docs/conventions/troubleshooting.md
+++ b/docs/conventions/troubleshooting.md
@@ -695,9 +695,12 @@ information is not available yet`, but `ps` or `lsof` still shows an older
   `Maximum update depth exceeded`, but the current stack only points at the
   component that called `setState`.
 - Quick checks:
-  First inspect state-sync diagnostics and React Profiler to confirm the
-  component boundary. For prop identity churn, why-did-you-render is enabled by
-  default when launching with `make dev-gui`. Disable that default with
+  First inspect state-sync diagnostics. Enable the renderer-wide React Profiler
+  only when its render-storm diagnostics are needed by launching with
+  `VITE_TUTTI_REACT_PROFILER=1`; leave it off for Chrome Performance captures
+  on large workspaces because React dev component tracks can make trace
+  initialization stall. For prop identity churn, why-did-you-render is enabled
+  by default when launching with `make dev-gui`. Disable that default with
   `VITE_TUTTI_WHY_DID_YOU_RENDER=0 make dev-gui`, or set
   `localStorage.tuttiWhyDidYouRender = "0"` in DevTools and reload the renderer.
   For other development entrypoints, enable it by setting
@@ -716,4 +719,5 @@ information is not available yet`, but `ps` or `lsof` still shows an older
   component lists the expected prop or hook difference. Then disable the tool
   and run the affected renderer tests plus desktop typecheck.
 - References:
+  [main.tsx](../../apps/desktop/src/renderer/src/main.tsx)
   [whyDidYouRender.ts](../../apps/desktop/src/renderer/src/lib/whyDidYouRender.ts)

--- a/docs/conventions/workspace-app-catalog.md
+++ b/docs/conventions/workspace-app-catalog.md
@@ -45,6 +45,14 @@ App Center opening should call `POST /v1/workspaces/{workspaceID}/apps/catalog/r
   "schemaVersion": "tutti.app.catalog.v1",
   "apps": [
     {
+      "localizations": [
+        {
+          "locale": "zh-CN",
+          "name": "产品原型设计",
+          "description": "创建并迭代产品原型设计",
+          "tags": ["设计", "原型"]
+        }
+      ],
       "manifest": {
         "schemaVersion": "tutti.app.manifest.v1",
         "appId": "vibe-design",
@@ -72,6 +80,12 @@ App Center opening should call `POST /v1/workspaces/{workspaceID}/apps/catalog/r
 ```
 
 Remote catalog entries must include `distribution.iconUrl`, `distribution.artifactUrl`, `distribution.artifactSha256`, and a manifest icon asset. The zip package must contain a complete app package with `tutti.app.json`, `bootstrap.sh`, `AGENTS.md`, and the manifest icon asset.
+
+When a package manifest declares `localizationInfo`, release tooling reads the
+referenced package-local manifest locale files and writes their `name`,
+`description`, and `tags` into the catalog entry `localizations` field. App
+Center uses this catalog metadata for uninstalled remote apps, because it must
+not download or unzip the app package just to render localized catalog cards.
 
 Workspace app packages do not declare arbitrary runtime kinds or bundle Python/Node. Packages that only need the managed Node/static runtime may declare `runtime.profile: "node-static"`; all other managed runtime release and download rules belong to [Workspace App Runtime](./workspace-app-runtime.md).
 

--- a/packages/agent/gui/agent-message-center/WorkspaceAgentMessageCenterCard.tsx
+++ b/packages/agent/gui/agent-message-center/WorkspaceAgentMessageCenterCard.tsx
@@ -56,6 +56,20 @@ export interface WorkspaceAgentMessageCenterCardProps {
   }) => void;
 }
 
+interface WorkspaceAgentMessageCenterStackProps {
+  className?: string;
+  expanded: boolean;
+  groupId: string;
+  highlightedItemId?: string | null;
+  items: WorkspaceAgentMessageCenterItem[];
+  renderCard: (
+    item: WorkspaceAgentMessageCenterItem,
+    options?: { stackedIndex?: number }
+  ) => ReactNode;
+  onCollapse: (groupId: string) => void;
+  onExpand: (groupId: string) => void;
+}
+
 function stopMessageCenterTextPointerPropagation(
   event: ReactPointerEvent<HTMLElement>
 ): void {
@@ -229,19 +243,7 @@ export const WorkspaceAgentMessageCenterStack = memo(
     renderCard,
     onCollapse,
     onExpand
-  }: {
-    className?: string;
-    expanded: boolean;
-    groupId: string;
-    highlightedItemId?: string | null;
-    items: WorkspaceAgentMessageCenterItem[];
-    renderCard: (
-      item: WorkspaceAgentMessageCenterItem,
-      options?: { stackedIndex?: number }
-    ) => ReactNode;
-    onCollapse: (groupId: string) => void;
-    onExpand: (groupId: string) => void;
-  }): JSX.Element | null {
+  }: WorkspaceAgentMessageCenterStackProps): JSX.Element | null {
     "use memo";
     const { t } = useTranslation();
     const summaryRegion = useStackRegionPresence(!expanded);
@@ -350,8 +352,55 @@ export const WorkspaceAgentMessageCenterStack = memo(
         ) : null}
       </div>
     );
-  }
+  },
+  areMessageCenterStackPropsEqual
 );
+
+function areMessageCenterStackPropsEqual(
+  previous: WorkspaceAgentMessageCenterStackProps,
+  next: WorkspaceAgentMessageCenterStackProps
+): boolean {
+  if (
+    previous.className !== next.className ||
+    previous.expanded !== next.expanded ||
+    previous.groupId !== next.groupId ||
+    previous.onCollapse !== next.onCollapse ||
+    previous.onExpand !== next.onExpand ||
+    previous.renderCard !== next.renderCard
+  ) {
+    return false;
+  }
+  if (next.expanded) {
+    return (
+      previous.highlightedItemId === next.highlightedItemId &&
+      previous.items === next.items
+    );
+  }
+  return (
+    messageCenterCollapsedStackSignature(previous.items) ===
+    messageCenterCollapsedStackSignature(next.items)
+  );
+}
+
+function messageCenterCollapsedStackSignature(
+  items: readonly WorkspaceAgentMessageCenterItem[]
+): string {
+  const firstItem = items[0];
+  if (!firstItem) {
+    return "0";
+  }
+  const hasWaiting = items.some(isWaitingMessageCenterItem) ? "1" : "0";
+  return [
+    items.length,
+    firstItem.id,
+    firstItem.provider,
+    firstItem.userId ?? "",
+    firstItem.identity?.userName ?? "",
+    firstItem.identity?.agentName ?? "",
+    hasWaiting,
+    messageCenterStackPreviewText(firstItem)
+  ].join(":");
+}
 
 function useBatchedMessageCenterStackItems({
   expanded,

--- a/packages/agent/gui/agent-message-center/WorkspaceAgentMessageCenterPanel.tsx
+++ b/packages/agent/gui/agent-message-center/WorkspaceAgentMessageCenterPanel.tsx
@@ -44,6 +44,8 @@ import {
   buildMessageCenterStatusOptions,
   groupMessageCenterItems,
   itemMatchesViewFilters,
+  messageCenterStackRenderId,
+  messageCenterStackScrollSyncSegment,
   partitionMessageCenterItemsByAgentUser,
   statusFilterSummary,
   type MessageCenterGroupBy,
@@ -205,6 +207,25 @@ function WorkspaceAgentMessageCenterPanelContent({
     [highlightedItemId, model.items]
   );
   const activeStatusSummary = statusFilterSummary(statusFilters, statusOptions);
+  const scrollSyncKey = useMemo(
+    () =>
+      [
+        groupBy,
+        activeStatusSummary,
+        ...deckItems.map((item) => `deck:${item.id}`),
+        ...itemGroupStacks.flatMap((group) =>
+          group.stacks.map((stack) => {
+            const stackId = messageCenterStackRenderId(group.id, stack.id);
+            return messageCenterStackScrollSyncSegment({
+              expanded: expandedStackIds.has(stackId),
+              groupId: group.id,
+              stack
+            });
+          })
+        )
+      ].join("|"),
+    [activeStatusSummary, deckItems, expandedStackIds, groupBy, itemGroupStacks]
+  );
   const hasActiveFilters = statusFilters !== null || providerFilters !== null;
   const headerSummary = useMemo(() => {
     if (hasActiveFilters) {
@@ -371,7 +392,7 @@ function WorkspaceAgentMessageCenterPanelContent({
           stack.items.length > 1 &&
           stack.items.some((item) => item.id === highlightedItemId)
         ) {
-          expandStack(`${group.id}:${stack.id}`);
+          expandStack(messageCenterStackRenderId(group.id, stack.id));
           return;
         }
       }
@@ -529,7 +550,7 @@ function WorkspaceAgentMessageCenterPanelContent({
             className="min-h-0 flex-1"
             viewportClassName="flex h-full w-full flex-col px-3.5 pt-4 pb-4"
             scrollbarClassName="top-4 bottom-4"
-            syncKey={`${groupBy}:${activeStatusSummary}:${[...deckItems, ...visibleItems].map((item) => item.id).join("|")}`}
+            syncKey={scrollSyncKey}
           >
             {deckItems.length > 0 || listItems.length > 0 ? (
               <div className="flex w-full min-w-0 flex-col gap-4">
@@ -564,10 +585,10 @@ function WorkspaceAgentMessageCenterPanelContent({
                         if (stack.items.length === 1) {
                           return renderMessageCenterCard(firstItem);
                         }
-                        const stackId =
-                          group.id === stack.id
-                            ? stack.id
-                            : `${group.id}:${stack.id}`;
+                        const stackId = messageCenterStackRenderId(
+                          group.id,
+                          stack.id
+                        );
                         return (
                           <MessageCenterStack
                             key={stackId}

--- a/packages/agent/gui/agent-message-center/index.ts
+++ b/packages/agent/gui/agent-message-center/index.ts
@@ -23,6 +23,7 @@ export {
   buildWorkspaceAgentMessageCenterModel,
   isWaitingMessageCenterItem
 } from "./workspaceAgentMessageCenterModel";
+export { stabilizeWorkspaceAgentMessageCenterModel } from "./workspaceAgentMessageCenterModelStability";
 export type {
   WorkspaceAgentMessageCenterDigest,
   WorkspaceAgentMessageCenterDigestPrimary,

--- a/packages/agent/gui/agent-message-center/workspaceAgentMessageCenterModel.spec.ts
+++ b/packages/agent/gui/agent-message-center/workspaceAgentMessageCenterModel.spec.ts
@@ -10,6 +10,7 @@ import {
   selectMessageCenterAttentionDeckItems,
   type WorkspaceAgentMessageCenterItem
 } from "./workspaceAgentMessageCenterModel";
+import { stabilizeWorkspaceAgentMessageCenterModel } from "./workspaceAgentMessageCenterModelStability";
 
 describe("buildWorkspaceAgentMessageCenterModel", () => {
   it("counts current-workspace sessions that need user action as waiting", () => {
@@ -304,6 +305,62 @@ describe("buildWorkspaceAgentMessageCenterModel", () => {
       "session-1",
       "session-2"
     ]);
+  });
+
+  it("filters non-waiting items before the configured cutoff while preserving waiting items", () => {
+    const model = buildWorkspaceAgentMessageCenterModel(
+      snapshot({
+        messages: [
+          message({
+            agentSessionId: "recent",
+            messageId: "recent-message",
+            payload: { text: "Recent summary" },
+            occurredAtUnixMs: 2_100
+          }),
+          message({
+            agentSessionId: "old",
+            messageId: "old-message",
+            payload: { text: "Old summary" },
+            occurredAtUnixMs: 900
+          }),
+          message({
+            agentSessionId: "old-waiting",
+            messageId: "old-permission",
+            kind: "tool.permission_request",
+            payload: { summary: "Old approval" },
+            occurredAtUnixMs: 800
+          })
+        ],
+        sessions: [
+          session({
+            agentSessionId: "recent",
+            status: "completed",
+            startedAtUnixMs: 2_100,
+            updatedAtUnixMs: 2_100
+          }),
+          session({
+            agentSessionId: "old",
+            status: "completed",
+            startedAtUnixMs: 900,
+            updatedAtUnixMs: 900
+          }),
+          session({
+            agentSessionId: "old-waiting",
+            status: "waiting",
+            startedAtUnixMs: 800,
+            updatedAtUnixMs: 800
+          })
+        ]
+      }),
+      { itemCutoffUnixMs: 1_000 }
+    );
+
+    expect(model.items.map((item) => item.agentSessionId)).toEqual([
+      "old-waiting",
+      "recent"
+    ]);
+    expect(model.counts.all).toBe(2);
+    expect(model.counts.waiting).toBe(1);
   });
 
   it("uses session end time when a turn has ended", () => {
@@ -769,6 +826,92 @@ describe("buildWorkspaceAgentMessageCenterModel", () => {
   });
 });
 
+describe("stabilizeWorkspaceAgentMessageCenterModel", () => {
+  it("returns the previous model when rebuilt items are equivalent", () => {
+    const activitySnapshot = snapshot({
+      messages: [
+        message({
+          agentSessionId: "session-1",
+          messageId: "assistant-1",
+          payload: { text: "Finished" },
+          occurredAtUnixMs: 10
+        })
+      ],
+      sessions: [
+        session({
+          agentSessionId: "session-1",
+          status: "completed"
+        })
+      ]
+    });
+    const previous = buildWorkspaceAgentMessageCenterModel(activitySnapshot);
+    const next = buildWorkspaceAgentMessageCenterModel(activitySnapshot);
+
+    const stable = stabilizeWorkspaceAgentMessageCenterModel(previous, next);
+
+    expect(stable).toBe(previous);
+    expect(stable.items).toBe(previous.items);
+    expect(stable.items[0]).toBe(previous.items[0]);
+  });
+
+  it("reuses unchanged item references while keeping changed items fresh", () => {
+    const previous = buildWorkspaceAgentMessageCenterModel(
+      snapshot({
+        messages: [
+          message({
+            agentSessionId: "session-1",
+            messageId: "assistant-1",
+            payload: { text: "Session one" },
+            occurredAtUnixMs: 10
+          }),
+          message({
+            agentSessionId: "session-2",
+            messageId: "assistant-2",
+            payload: { text: "Session two" },
+            occurredAtUnixMs: 20
+          })
+        ],
+        sessions: [
+          session({ agentSessionId: "session-1", status: "completed" }),
+          session({ agentSessionId: "session-2", status: "completed" })
+        ]
+      })
+    );
+    const next = buildWorkspaceAgentMessageCenterModel(
+      snapshot({
+        messages: [
+          message({
+            agentSessionId: "session-1",
+            messageId: "assistant-1",
+            payload: { text: "Session one" },
+            occurredAtUnixMs: 10
+          }),
+          message({
+            agentSessionId: "session-2",
+            messageId: "assistant-2",
+            payload: { text: "Session two updated" },
+            occurredAtUnixMs: 20
+          })
+        ],
+        sessions: [
+          session({ agentSessionId: "session-1", status: "completed" }),
+          session({ agentSessionId: "session-2", status: "completed" })
+        ]
+      })
+    );
+
+    const stable = stabilizeWorkspaceAgentMessageCenterModel(previous, next);
+
+    expect(itemBySessionId(stable, "session-1")).toBe(
+      itemBySessionId(previous, "session-1")
+    );
+    expect(itemBySessionId(stable, "session-2")).toBe(
+      itemBySessionId(next, "session-2")
+    );
+    expect(stable).not.toBe(previous);
+  });
+});
+
 function snapshot(input: {
   messages: AgentActivityMessage[];
   sessions: AgentActivitySession[];
@@ -819,6 +962,13 @@ function message(
     occurredAtUnixMs: 1,
     ...overrides
   };
+}
+
+function itemBySessionId(
+  model: ReturnType<typeof buildWorkspaceAgentMessageCenterModel>,
+  agentSessionId: string
+): WorkspaceAgentMessageCenterItem | undefined {
+  return model.items.find((item) => item.agentSessionId === agentSessionId);
 }
 
 describe("message center attention deck selection", () => {

--- a/packages/agent/gui/agent-message-center/workspaceAgentMessageCenterModel.ts
+++ b/packages/agent/gui/agent-message-center/workspaceAgentMessageCenterModel.ts
@@ -62,6 +62,7 @@ export interface WorkspaceAgentMessageCenterTurnOutcome {
 export interface BuildWorkspaceAgentMessageCenterOptions {
   avoidGroupingEdits?: boolean;
   identityBySessionId?: Record<string, WorkspaceAgentMessageCenterIdentity>;
+  itemCutoffUnixMs?: number | null;
   promptFallbackLabels?: WorkspaceAgentMessageCenterPromptFallbackLabels;
   workspaceRoot?: string | null;
 }
@@ -148,7 +149,10 @@ export function buildWorkspaceAgentMessageCenterModel(
         latestTurnOutcome: latestTurnOutcome(session.agentSessionId, messages),
         sortTimeUnixMs
       } satisfies WorkspaceAgentMessageCenterItem;
-    });
+    })
+    .filter((item) =>
+      isWithinMessageCenterItemCutoff(item, options.itemCutoffUnixMs)
+    );
 
   return {
     waitingCount: items.filter(isWaitingMessageCenterItem).length,
@@ -192,6 +196,20 @@ export function isInteractiveMessageCenterItem(
   item: WorkspaceAgentMessageCenterItem
 ): boolean {
   return item.pendingPrompt !== null;
+}
+
+function isWithinMessageCenterItemCutoff(
+  item: WorkspaceAgentMessageCenterItem,
+  cutoffUnixMs: number | null | undefined
+): boolean {
+  if (!Number.isFinite(cutoffUnixMs)) {
+    return true;
+  }
+  if (isWaitingMessageCenterItem(item)) {
+    return true;
+  }
+  const timestamp = item.sortTimeUnixMs || item.lastAgentMessageAtUnixMs || 0;
+  return timestamp >= Number(cutoffUnixMs);
 }
 
 export function selectMessageCenterAttentionDeckItems(

--- a/packages/agent/gui/agent-message-center/workspaceAgentMessageCenterModelStability.ts
+++ b/packages/agent/gui/agent-message-center/workspaceAgentMessageCenterModelStability.ts
@@ -1,0 +1,153 @@
+import type {
+  WorkspaceAgentMessageCenterCounts,
+  WorkspaceAgentMessageCenterIdentity,
+  WorkspaceAgentMessageCenterItem,
+  WorkspaceAgentMessageCenterModel,
+  WorkspaceAgentMessageCenterTurnOutcome
+} from "./workspaceAgentMessageCenterModel";
+import type { WorkspaceAgentMessageCenterDigest } from "./workspaceAgentMessageCenterDigest";
+
+type WorkspaceAgentMessageCenterPrompt =
+  WorkspaceAgentMessageCenterItem["pendingPrompt"];
+
+export function stabilizeWorkspaceAgentMessageCenterModel(
+  previous: WorkspaceAgentMessageCenterModel | null,
+  next: WorkspaceAgentMessageCenterModel
+): WorkspaceAgentMessageCenterModel {
+  if (!previous) {
+    return next;
+  }
+
+  const previousItemsById = new Map(
+    previous.items.map((item) => [item.id, item])
+  );
+  let itemsChanged = previous.items.length !== next.items.length;
+  const items = next.items.map((nextItem, index) => {
+    const previousItem = previousItemsById.get(nextItem.id);
+    const stableItem =
+      previousItem && messageCenterItemsEqual(previousItem, nextItem)
+        ? previousItem
+        : nextItem;
+    if (stableItem !== previous.items[index]) {
+      itemsChanged = true;
+    }
+    return stableItem;
+  });
+  const stableItems = itemsChanged ? items : previous.items;
+  const stableCounts = messageCenterCountsEqual(previous.counts, next.counts)
+    ? previous.counts
+    : next.counts;
+
+  if (
+    previous.waitingCount === next.waitingCount &&
+    stableItems === previous.items &&
+    stableCounts === previous.counts
+  ) {
+    return previous;
+  }
+
+  return {
+    ...next,
+    counts: stableCounts,
+    items: stableItems
+  };
+}
+
+function messageCenterItemsEqual(
+  left: WorkspaceAgentMessageCenterItem,
+  right: WorkspaceAgentMessageCenterItem
+): boolean {
+  return (
+    left.id === right.id &&
+    left.agentSessionId === right.agentSessionId &&
+    left.provider === right.provider &&
+    left.userId === right.userId &&
+    left.title === right.title &&
+    left.cwd === right.cwd &&
+    left.status === right.status &&
+    left.lastAgentMessageSummary === right.lastAgentMessageSummary &&
+    left.lastAgentMessageAtUnixMs === right.lastAgentMessageAtUnixMs &&
+    left.needsAttentionKind === right.needsAttentionKind &&
+    left.needsAttentionSummary === right.needsAttentionSummary &&
+    left.sortTimeUnixMs === right.sortTimeUnixMs &&
+    messageCenterIdentityEqual(left.identity, right.identity) &&
+    messageCenterDigestEqual(left.digest, right.digest) &&
+    messageCenterPromptEqual(left.pendingPrompt, right.pendingPrompt) &&
+    messageCenterTurnOutcomeEqual(
+      left.latestTurnOutcome ?? null,
+      right.latestTurnOutcome ?? null
+    )
+  );
+}
+
+function messageCenterCountsEqual(
+  left: WorkspaceAgentMessageCenterCounts,
+  right: WorkspaceAgentMessageCenterCounts
+): boolean {
+  return (
+    left.all === right.all &&
+    left.working === right.working &&
+    left.waiting === right.waiting &&
+    left.completed === right.completed &&
+    left.failed === right.failed
+  );
+}
+
+function messageCenterIdentityEqual(
+  left: WorkspaceAgentMessageCenterIdentity | null,
+  right: WorkspaceAgentMessageCenterIdentity | null
+): boolean {
+  if (left === right) {
+    return true;
+  }
+  if (!left || !right) {
+    return false;
+  }
+  return (
+    left.userName === right.userName &&
+    left.userAvatarUrl === right.userAvatarUrl &&
+    left.agentName === right.agentName &&
+    left.agentAvatarUrl === right.agentAvatarUrl
+  );
+}
+
+function messageCenterDigestEqual(
+  left: WorkspaceAgentMessageCenterDigest,
+  right: WorkspaceAgentMessageCenterDigest
+): boolean {
+  return (
+    left.primary.kind === right.primary.kind &&
+    left.primary.summary === right.primary.summary &&
+    left.primary.occurredAtUnixMs === right.primary.occurredAtUnixMs
+  );
+}
+
+function messageCenterTurnOutcomeEqual(
+  left: WorkspaceAgentMessageCenterTurnOutcome | null,
+  right: WorkspaceAgentMessageCenterTurnOutcome | null
+): boolean {
+  if (left === right) {
+    return true;
+  }
+  if (!left || !right) {
+    return false;
+  }
+  return (
+    left.notificationKey === right.notificationKey &&
+    left.status === right.status &&
+    left.turnId === right.turnId
+  );
+}
+
+function messageCenterPromptEqual(
+  left: WorkspaceAgentMessageCenterPrompt,
+  right: WorkspaceAgentMessageCenterPrompt
+): boolean {
+  if (left === right) {
+    return true;
+  }
+  if (!left || !right || left.kind !== right.kind) {
+    return false;
+  }
+  return JSON.stringify(left) === JSON.stringify(right);
+}

--- a/packages/agent/gui/agent-message-center/workspaceAgentMessageCenterViewModel.spec.ts
+++ b/packages/agent/gui/agent-message-center/workspaceAgentMessageCenterViewModel.spec.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import {
   groupMessageCenterItems,
   messageCenterAgentUserStackId,
+  messageCenterStackScrollSyncSegment,
   partitionMessageCenterItemsByAgentUser
 } from "./workspaceAgentMessageCenterViewModel";
 import type { WorkspaceAgentMessageCenterItem } from "./workspaceAgentMessageCenterModel";
@@ -73,6 +74,48 @@ describe("partitionMessageCenterItemsByAgentUser", () => {
         userId: null
       })
     ).toBe("agent-user:unknown-agent:unknown-user");
+  });
+
+  it("summarizes collapsed stack scroll sync keys without every stacked item id", () => {
+    const stack = partitionMessageCenterItemsByAgentUser([
+      item({
+        agentSessionId: "codex-user-a-1",
+        provider: "codex",
+        userId: "user-a"
+      }),
+      item({
+        agentSessionId: "codex-user-a-2",
+        provider: "codex",
+        userId: "user-a"
+      }),
+      item({
+        agentSessionId: "codex-user-a-3",
+        provider: "codex",
+        userId: "user-a"
+      })
+    ])[0];
+    if (!stack) {
+      throw new Error("Expected a stack to be created.");
+    }
+
+    const collapsed = messageCenterStackScrollSyncSegment({
+      expanded: false,
+      groupId: "working",
+      stack
+    });
+    const expanded = messageCenterStackScrollSyncSegment({
+      expanded: true,
+      groupId: "working",
+      stack
+    });
+
+    expect(collapsed).toContain("collapsed:working:agent-user:codex:user-a");
+    expect(collapsed).toContain("message-center-codex-user-a-1");
+    expect(collapsed).not.toContain("message-center-codex-user-a-2");
+    expect(collapsed).not.toContain("message-center-codex-user-a-3");
+    expect(expanded).toContain("message-center-codex-user-a-1");
+    expect(expanded).toContain("message-center-codex-user-a-2");
+    expect(expanded).toContain("message-center-codex-user-a-3");
   });
 });
 

--- a/packages/agent/gui/agent-message-center/workspaceAgentMessageCenterViewModel.ts
+++ b/packages/agent/gui/agent-message-center/workspaceAgentMessageCenterViewModel.ts
@@ -73,6 +73,55 @@ export function messageCenterAgentUserStackId(
   return `agent-user:${provider}:${userId}`;
 }
 
+export function messageCenterStackRenderId(
+  groupId: string,
+  stackId: string
+): string {
+  return groupId === stackId ? stackId : `${groupId}:${stackId}`;
+}
+
+export function messageCenterStackScrollSyncSegment({
+  expanded,
+  groupId,
+  stack
+}: {
+  expanded: boolean;
+  groupId: string;
+  stack: MessageCenterAgentUserStack;
+}): string {
+  const stackId = messageCenterStackRenderId(groupId, stack.id);
+  if (expanded) {
+    return `expanded:${stackId}:${stack.items.map((item) => item.id).join("|")}`;
+  }
+  return `collapsed:${stackId}:${messageCenterCollapsedStackSignature(
+    stack.items
+  )}`;
+}
+
+function messageCenterCollapsedStackSignature(
+  items: readonly WorkspaceAgentMessageCenterItem[]
+): string {
+  const firstItem = items[0];
+  if (!firstItem) {
+    return "0";
+  }
+  const hasWaiting = items.some(isWaitingMessageCenterItem) ? "1" : "0";
+  const summary =
+    firstItem.digest.primary.summary.trim() ||
+    firstItem.lastAgentMessageSummary.trim() ||
+    firstItem.title.trim();
+  return [
+    items.length,
+    firstItem.id,
+    firstItem.provider,
+    firstItem.userId ?? "",
+    firstItem.identity?.userName ?? "",
+    firstItem.identity?.agentName ?? "",
+    hasWaiting,
+    summary
+  ].join(":");
+}
+
 export function buildMessageCenterStatusOptions(
   counts: WorkspaceAgentMessageCenterModel["counts"],
   t: MessageCenterTranslate

--- a/packages/workspace/app-center/src/i18n/appCenterI18n.ts
+++ b/packages/workspace/app-center/src/i18n/appCenterI18n.ts
@@ -175,30 +175,9 @@ export const appCenterEn = {
     }
   },
   catalogApps: {
-    aiMediaCanvas: {
-      description: "Generate and organize AI images and videos on a canvas.",
-      name: "AI Canvas"
-    },
-    automation: {
-      description: "Create and schedule automation tasks.",
-      name: "Automation"
-    },
-    dailyProductRadar: {
-      description:
-        "Summarize daily new products and trending open-source projects.",
-      name: "Daily Product Radar"
-    },
-    groupChat: {
-      description: "Collaborate with multiple agents in a group chat.",
-      name: "Group Chat"
-    },
     issueManager: {
       description: "Manage workspace tasks and runs.",
       name: "Task Manager"
-    },
-    vibeDesign: {
-      description: "Create and iterate on design prototypes.",
-      name: "Prototype Design"
     }
   },
   comingSoonApps: {
@@ -451,29 +430,9 @@ export const appCenterZhCN = {
     }
   },
   catalogApps: {
-    aiMediaCanvas: {
-      description: "在画布上生成和整理 AI 图片、视频",
-      name: "AI Canvas"
-    },
-    automation: {
-      description: "创建并定时运行自动化任务",
-      name: "自动化"
-    },
-    dailyProductRadar: {
-      description: "汇总每日新产品和热门开源项目",
-      name: "每日产品雷达"
-    },
-    groupChat: {
-      description: "在群里和多个 Agent 一起协作",
-      name: "群聊"
-    },
     issueManager: {
       description: "管理工作区任务和运行记录。",
       name: "任务管理"
-    },
-    vibeDesign: {
-      description: "创建并迭代产品原型设计",
-      name: "产品原型设计"
     }
   },
   comingSoonApps: {

--- a/packages/workspace/app-release-tools/README.md
+++ b/packages/workspace/app-release-tools/README.md
@@ -12,7 +12,11 @@ verify-tutti-app-release-artifacts --release-file ./apps/vibe-design/latest.json
 verify-tutti-app-release-artifacts --catalog-file ./catalog.json --release-file ./apps/vibe-design/latest.json
 ```
 
-The release command validates a complete Tutti app package, creates a zip, writes immutable `release.json`, and writes mutable `latest.json`.
+The release command validates a complete Tutti app package, creates a zip,
+writes immutable `release.json`, and writes mutable `latest.json`. When the
+manifest declares `localizationInfo`, the release metadata includes the
+referenced manifest locale files so App Center can localize uninstalled remote
+apps without downloading the package.
 
 The catalog command merges one or more release files into `tutti.app.catalog.v1`.
 Pass `--existing-catalog` to preserve existing catalog apps and update only the

--- a/packages/workspace/app-release-tools/bin/build-tutti-app-release.mjs
+++ b/packages/workspace/app-release-tools/bin/build-tutti-app-release.mjs
@@ -51,6 +51,7 @@ export async function buildTuttiAppRelease(options) {
   for (const locale of manifest.localizationInfo?.additionalLocales ?? []) {
     await requireNonEmptyTextFile(path.join(packageDir, locale.file));
   }
+  const localizations = await readManifestLocalizations(packageDir, manifest);
   if (manifest.cli?.manifest) {
     const cliManifestPath = path.join(packageDir, manifest.cli.manifest);
     await requireFile(cliManifestPath);
@@ -85,6 +86,7 @@ export async function buildTuttiAppRelease(options) {
     name: manifest.name,
     description: manifest.description,
     manifest,
+    ...(localizations.length > 0 ? { localizations } : {}),
     artifactUrl: `${baseUrl}/${releaseURLPrefix}/${encodeURLPathSegment(artifactName)}`,
     artifactSha256: artifact.sha256,
     artifactSizeBytes: artifact.size,
@@ -410,6 +412,9 @@ function validateLocalizationInfo(localizationInfo, sourceLabel) {
 export function releaseToCatalogApp(release) {
   validateRelease(release);
   return {
+    ...(Array.isArray(release.localizations) && release.localizations.length > 0
+      ? { localizations: release.localizations }
+      : {}),
     manifest: release.manifest,
     distribution: {
       kind: "remote",
@@ -443,6 +448,7 @@ export function validateRelease(release) {
   if (release.manifest.version !== release.version) {
     throw new Error("release manifest.version must match release version");
   }
+  validateReleaseLocalizations(release.localizations, "release.localizations");
   if (!/^[a-f0-9]{64}$/i.test(release.artifactSha256)) {
     throw new Error("release artifactSha256 must be a sha256 hex digest");
   }
@@ -451,6 +457,110 @@ export function validateRelease(release) {
     release.artifactSizeBytes <= 0
   ) {
     throw new Error("release artifactSizeBytes must be a positive integer");
+  }
+}
+
+async function readManifestLocalizations(packageDir, manifest) {
+  const localizations = [];
+  for (const entry of manifest.localizationInfo?.additionalLocales ?? []) {
+    const locale = requireNonEmpty(
+      entry.locale,
+      "manifest localization locale"
+    );
+    const filePath = path.join(packageDir, entry.file);
+    const document = await readLocalizationDocument(filePath);
+    const localization = normalizeLocalization(document, locale, filePath);
+    if (localization) {
+      localizations.push(localization);
+    }
+  }
+  return localizations;
+}
+
+function normalizeLocalization(document, locale, sourceLabel) {
+  if (!document || typeof document !== "object" || Array.isArray(document)) {
+    throw new Error(`${sourceLabel} must be a localization object`);
+  }
+  const localization = {
+    locale
+  };
+  if (document.name !== undefined) {
+    const name = requireOptionalString(document.name, `${sourceLabel}.name`);
+    if (name) {
+      localization.name = name;
+    }
+  }
+  if (document.description !== undefined) {
+    const description = requireOptionalString(
+      document.description,
+      `${sourceLabel}.description`
+    );
+    if (description) {
+      localization.description = description;
+    }
+  }
+  if (document.tags !== undefined) {
+    if (!Array.isArray(document.tags)) {
+      throw new Error(`${sourceLabel}.tags must be an array`);
+    }
+    const tags = document.tags
+      .map((tag, index) =>
+        requireOptionalString(tag, `${sourceLabel}.tags[${index}]`)
+      )
+      .filter(Boolean);
+    if (tags.length > 0) {
+      localization.tags = [...new Set(tags)];
+    }
+  }
+  if (!localization.name && !localization.description && !localization.tags) {
+    return null;
+  }
+  return localization;
+}
+
+async function readLocalizationDocument(filePath) {
+  try {
+    return JSON.parse(await readFile(filePath, "utf8"));
+  } catch (error) {
+    throw new Error(
+      `parse manifest localization file ${filePath}: ${error.message}`
+    );
+  }
+}
+
+function validateReleaseLocalizations(localizations, sourceLabel) {
+  if (localizations === undefined) {
+    return;
+  }
+  if (!Array.isArray(localizations)) {
+    throw new Error(`${sourceLabel} must be an array`);
+  }
+  const seenLocales = new Set();
+  for (const [index, localization] of localizations.entries()) {
+    const label = `${sourceLabel}[${index}]`;
+    if (!localization || typeof localization !== "object") {
+      throw new Error(`${label} must be an object`);
+    }
+    const locale = requireNonEmpty(localization.locale, `${label}.locale`);
+    const localeKey = locale.toLowerCase();
+    if (seenLocales.has(localeKey)) {
+      throw new Error(`${label}.locale must be unique`);
+    }
+    seenLocales.add(localeKey);
+    if (localization.name !== undefined) {
+      requireOptionalString(localization.name, `${label}.name`);
+    }
+    if (localization.description !== undefined) {
+      requireOptionalString(localization.description, `${label}.description`);
+    }
+    if (localization.tags !== undefined) {
+      if (!Array.isArray(localization.tags)) {
+        throw new Error(`${label}.tags must be an array`);
+      }
+      for (const [tagIndex, tag] of localization.tags.entries()) {
+        requireOptionalString(tag, `${label}.tags[${tagIndex}]`);
+      }
+    }
   }
 }
 
@@ -519,6 +629,13 @@ function requireNonEmpty(value, label) {
     throw new Error(`${label} is required`);
   }
   return text;
+}
+
+function requireOptionalString(value, label) {
+  if (typeof value !== "string") {
+    throw new Error(`${label} must be a string`);
+  }
+  return value.trim();
 }
 
 function requireSafePathSegment(value, label) {

--- a/packages/workspace/app-release-tools/bin/verify-tutti-app-release-artifacts.mjs
+++ b/packages/workspace/app-release-tools/bin/verify-tutti-app-release-artifacts.mjs
@@ -147,6 +147,14 @@ function assertCatalogMatchesRelease(app, release) {
       `catalog app ${appId} iconUrl must match latest release metadata`
     );
   }
+  if (
+    JSON.stringify(app.localizations ?? []) !==
+    JSON.stringify(release.localizations ?? [])
+  ) {
+    throw new Error(
+      `catalog app ${appId} localizations must match latest release metadata`
+    );
+  }
 }
 
 function validateCatalog(catalog) {

--- a/services/tuttid/biz/workspace/apps.go
+++ b/services/tuttid/biz/workspace/apps.go
@@ -92,6 +92,7 @@ type AppPackage struct {
 	PackageDir           string
 	Manifest             AppManifest
 	ManifestJSON         string
+	CatalogLocalizations []AppManifestLocalization
 	Source               AppPackageSource
 	FactoryJobID         string
 	CreatedInWorkspaceID string
@@ -166,7 +167,7 @@ func (p AppPackage) IconDataURL() *string {
 
 func (p AppPackage) Localizations() []AppManifestLocalization {
 	if p.Manifest.LocalizationInfo == nil || strings.TrimSpace(p.PackageDir) == "" {
-		return nil
+		return append([]AppManifestLocalization(nil), p.CatalogLocalizations...)
 	}
 
 	localizations := make([]AppManifestLocalization, 0, len(p.Manifest.LocalizationInfo.AdditionalLocales))
@@ -179,6 +180,9 @@ func (p AppPackage) Localizations() []AppManifestLocalization {
 		if ok {
 			localizations = append(localizations, localization)
 		}
+	}
+	if len(localizations) == 0 {
+		return append([]AppManifestLocalization(nil), p.CatalogLocalizations...)
 	}
 	return localizations
 }

--- a/services/tuttid/builtin-apps/catalog.go
+++ b/services/tuttid/builtin-apps/catalog.go
@@ -22,9 +22,10 @@ import (
 var files embed.FS
 
 type App struct {
-	Manifest     workspacebiz.AppManifest
-	SourceDir    string
-	Distribution Distribution
+	Manifest      workspacebiz.AppManifest
+	SourceDir     string
+	Localizations []workspacebiz.AppManifestLocalization
+	Distribution  Distribution
 }
 
 type DistributionKind string
@@ -80,8 +81,9 @@ type remoteCatalogDocument struct {
 }
 
 type remoteCatalogApp struct {
-	Manifest     workspacebiz.AppManifest `json:"manifest"`
-	Distribution remoteDistribution       `json:"distribution"`
+	Localizations []workspacebiz.AppManifestLocalization `json:"localizations,omitempty"`
+	Manifest      workspacebiz.AppManifest               `json:"manifest"`
+	Distribution  remoteDistribution                     `json:"distribution"`
 }
 
 type remoteDistribution struct {
@@ -571,9 +573,14 @@ func parseRemoteCatalog(data []byte) ([]App, error) {
 		if err != nil {
 			return nil, err
 		}
+		localizations, err := parseRemoteCatalogLocalizations(appID, entry.Localizations)
+		if err != nil {
+			return nil, err
+		}
 		apps = append(apps, App{
-			Manifest:     entry.Manifest,
-			Distribution: distribution,
+			Manifest:      entry.Manifest,
+			Localizations: localizations,
+			Distribution:  distribution,
 		})
 	}
 	return apps, nil
@@ -602,6 +609,40 @@ func parseRemoteDistribution(appID string, manifest workspacebiz.AppManifest, di
 		ArtifactSHA256: artifactSHA256,
 		IconURL:        iconURL,
 	}, nil
+}
+
+func parseRemoteCatalogLocalizations(appID string, localizations []workspacebiz.AppManifestLocalization) ([]workspacebiz.AppManifestLocalization, error) {
+	if len(localizations) == 0 {
+		return nil, nil
+	}
+	result := make([]workspacebiz.AppManifestLocalization, 0, len(localizations))
+	seenLocales := make(map[string]struct{}, len(localizations))
+	for index, localization := range localizations {
+		locale := strings.TrimSpace(localization.Locale)
+		if locale == "" {
+			return nil, fmt.Errorf("app catalog app %q localizations[%d].locale is required", appID, index)
+		}
+		localeKey := strings.ToLower(locale)
+		if _, ok := seenLocales[localeKey]; ok {
+			return nil, fmt.Errorf("app catalog app %q localizations[%d].locale must be unique", appID, index)
+		}
+		seenLocales[localeKey] = struct{}{}
+		normalized := workspacebiz.AppManifestLocalization{
+			Locale:      locale,
+			Name:        strings.TrimSpace(localization.Name),
+			Description: strings.TrimSpace(localization.Description),
+		}
+		for _, tag := range localization.Tags {
+			if trimmed := strings.TrimSpace(tag); trimmed != "" {
+				normalized.Tags = append(normalized.Tags, trimmed)
+			}
+		}
+		if normalized.Name == "" && normalized.Description == "" && len(normalized.Tags) == 0 {
+			continue
+		}
+		result = append(result, normalized)
+	}
+	return result, nil
 }
 
 func mergeCatalogs(embeddedApps []App, remoteApps []App) ([]App, error) {

--- a/services/tuttid/builtin-apps/catalog_test.go
+++ b/services/tuttid/builtin-apps/catalog_test.go
@@ -22,6 +22,14 @@ func TestCatalogLoadsRemoteAppsFromFile(t *testing.T) {
 		"schemaVersion": "tutti.app.catalog.v1",
 		"apps": [
 			{
+				"localizations": [
+					{
+						"locale": "zh-CN",
+						"name": "远程设计",
+						"description": "设计工作区",
+						"tags": ["设计", "工作区"]
+					}
+				],
 				"manifest": {
 					"schemaVersion": "tutti.app.manifest.v1",
 					"appId": "remote-design",
@@ -54,6 +62,9 @@ func TestCatalogLoadsRemoteAppsFromFile(t *testing.T) {
 	}
 	if app.Distribution.Kind != DistributionRemote || app.Distribution.IconURL == "" {
 		t.Fatalf("remote app distribution = %#v", app.Distribution)
+	}
+	if len(app.Localizations) != 1 || app.Localizations[0].Locale != "zh-CN" || app.Localizations[0].Name != "远程设计" {
+		t.Fatalf("remote app localizations = %#v", app.Localizations)
 	}
 }
 

--- a/services/tuttid/service/workspace/apps_remote_builtin.go
+++ b/services/tuttid/service/workspace/apps_remote_builtin.go
@@ -25,11 +25,12 @@ func remoteBuiltinWorkspaceApp(builtin builtinapps.App) (workspacebiz.WorkspaceA
 		return workspacebiz.WorkspaceApp{}, fmt.Errorf("normalize remote builtin app manifest %q: %w", builtin.Manifest.AppID, err)
 	}
 	appPackage := workspacebiz.AppPackage{
-		AppID:        builtin.Manifest.AppID,
-		Version:      builtin.Manifest.Version,
-		Manifest:     builtin.Manifest,
-		ManifestJSON: manifestJSON,
-		Source:       workspacebiz.AppPackageSourceBuiltin,
+		AppID:                builtin.Manifest.AppID,
+		Version:              builtin.Manifest.Version,
+		Manifest:             builtin.Manifest,
+		ManifestJSON:         manifestJSON,
+		CatalogLocalizations: append([]workspacebiz.AppManifestLocalization(nil), builtin.Localizations...),
+		Source:               workspacebiz.AppPackageSourceBuiltin,
 	}
 	return workspacebiz.WorkspaceApp{
 		Package: appPackage,

--- a/services/tuttid/service/workspace/apps_test.go
+++ b/services/tuttid/service/workspace/apps_test.go
@@ -692,6 +692,14 @@ func TestAppCenterServiceListsRemoteBuiltinBeforeDownloadAndMaterializesOnDemand
 		BuiltinCatalog: func() ([]builtinapps.App, error) {
 			return []builtinapps.App{{
 				Manifest: sourceManifest,
+				Localizations: []workspacebiz.AppManifestLocalization{
+					{
+						Locale:      "zh-CN",
+						Name:        "大型内置应用",
+						Description: "大型应用",
+						Tags:        []string{"内置", "工作区"},
+					},
+				},
 				Distribution: builtinapps.Distribution{
 					Kind:           builtinapps.DistributionRemote,
 					ArtifactURL:    fileServer.URL + "/" + filepath.Base(archivePath),
@@ -712,6 +720,10 @@ func TestAppCenterServiceListsRemoteBuiltinBeforeDownloadAndMaterializesOnDemand
 	}
 	if actualIconURL := remoteApp.ResolvedIconURL(); actualIconURL == nil || *actualIconURL != iconURL {
 		t.Fatalf("remote builtin icon url = %v, want %q", actualIconURL, iconURL)
+	}
+	localizations := remoteApp.Package.Localizations()
+	if len(localizations) != 1 || localizations[0].Locale != "zh-CN" || localizations[0].Name != "大型内置应用" {
+		t.Fatalf("remote builtin localizations = %#v", localizations)
 	}
 	if _, err := store.GetAppPackage(ctx, "large-builtin"); !errors.Is(err, workspacedata.ErrWorkspaceAppNotFound) {
 		t.Fatalf("GetAppPackage() before materialize error = %v", err)

--- a/tools/scripts/build-tutti-app-release.test.mjs
+++ b/tools/scripts/build-tutti-app-release.test.mjs
@@ -68,9 +68,53 @@ test("buildTuttiAppRelease writes immutable release and latest metadata", async 
   assert.equal(manifest.version, "0.1.0+abc123");
 });
 
+test("buildTuttiAppRelease includes package manifest localizations", async () => {
+  const packageDir = await createPackageForTest("localized-app", {
+    localizations: [
+      {
+        locale: "zh-CN",
+        metadata: {
+          name: "本地化应用",
+          description: "本地化描述",
+          tags: ["本地化", "工作区", "工作区"]
+        }
+      }
+    ]
+  });
+  const outputDir = await mkdtemp(path.join(tmpdir(), "tutti-release-"));
+
+  const result = await buildTuttiAppRelease({
+    appId: "localized-app",
+    packageDir,
+    outputDir,
+    baseUrl: "https://cdn.example.test/tutti-apps/",
+    version: "0.1.0+abc123",
+    gitSha: "abc123",
+    publishedAt: "2026-06-04T00:00:00Z"
+  });
+
+  assert.deepEqual(result.release.localizations, [
+    {
+      locale: "zh-CN",
+      name: "本地化应用",
+      description: "本地化描述",
+      tags: ["本地化", "工作区"]
+    }
+  ]);
+});
+
 test("buildTuttiAppCatalog merges release files into remote catalog", async () => {
   const alpha = await releaseFileForTest("alpha-app");
-  const beta = await releaseFileForTest("beta-app");
+  const beta = await releaseFileForTest("beta-app", "0.1.0", {
+    localizations: [
+      {
+        locale: "zh-CN",
+        name: "Beta 应用",
+        description: "Beta 描述",
+        tags: ["Beta"]
+      }
+    ]
+  });
   const outputDir = await mkdtemp(path.join(tmpdir(), "tutti-catalog-"));
   const outputPath = path.join(outputDir, "catalog.json");
 
@@ -89,6 +133,14 @@ test("buildTuttiAppCatalog merges release files into remote catalog", async () =
     result.catalog.apps[0].distribution.iconUrl,
     "https://cdn.example.test/apps/alpha-app/icon.svg"
   );
+  assert.deepEqual(result.catalog.apps[1].localizations, [
+    {
+      locale: "zh-CN",
+      name: "Beta 应用",
+      description: "Beta 描述",
+      tags: ["Beta"]
+    }
+  ]);
 
   const written = JSON.parse(await readFile(outputPath, "utf8"));
   assert.deepEqual(written, result.catalog);
@@ -560,6 +612,9 @@ async function releaseFileForTest(appId, version = "0.1.0", overrides = {}) {
     name: appId,
     description: `${appId} description`,
     manifest: manifestForTest(appId, version),
+    ...(overrides.localizations
+      ? { localizations: overrides.localizations }
+      : {}),
     artifactUrl:
       overrides.artifactUrl ??
       `https://cdn.example.test/apps/${appId}/${appId}.zip`,
@@ -605,13 +660,31 @@ function catalogAppForTest(appId, version, overrides = {}) {
   };
 }
 
-async function createPackageForTest(appId) {
+async function createPackageForTest(appId, options = {}) {
   const packageDir = await mkdtemp(path.join(tmpdir(), "tutti-app-package-"));
   await mkdir(path.join(packageDir, "web"), { recursive: true });
+  const manifest = manifestForTest(appId);
+  if (options.localizations?.length > 0) {
+    manifest.localizationInfo = {
+      defaultLocale: "en",
+      additionalLocales: options.localizations.map((localization) => ({
+        locale: localization.locale,
+        file: `locales/${localization.locale}/manifest.json`
+      }))
+    };
+  }
   await writeFile(
     path.join(packageDir, "tutti.app.json"),
-    `${JSON.stringify(manifestForTest(appId), null, 2)}\n`
+    `${JSON.stringify(manifest, null, 2)}\n`
   );
+  for (const localization of options.localizations ?? []) {
+    const localeDir = path.join(packageDir, "locales", localization.locale);
+    await mkdir(localeDir, { recursive: true });
+    await writeFile(
+      path.join(localeDir, "manifest.json"),
+      `${JSON.stringify(localization.metadata, null, 2)}\n`
+    );
+  }
   await writeFile(path.join(packageDir, "AGENTS.md"), "App instructions\n");
   await writeFile(path.join(packageDir, "icon.svg"), `<${"svg"}></${"svg"}>\n`);
   await writeFile(path.join(packageDir, "web", "index.html"), "<div></div>\n");


### PR DESCRIPTION
## Summary
- optimize message center open performance
- cap visible message history to recent 7 days while keeping waiting/actionable items
- limit summary prefetch and stabilize message center model/callbacks
- include package manifest localizations in remote app release/catalog metadata
- surface remote builtin catalog localizations before package download/materialization

## Tests
- pre-commit hook checks passed
- `pnpm check:changed -- --push-ready`
- `git diff --check`
- `pnpm check:full`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for localized app cards in the app catalog based on manifest-provided localization metadata.
* **Bug Fixes**
  * Improved message-center model stability and session prefetching efficiency.
  * Refined recommended app selection/display logic.
* **Chores**
  * App Center catalog now displays core applications only.
  * React Profiler is now enabled only in development when configured via `VITE_TUTTI_REACT_PROFILER=1`.
* **Documentation**
  * Updated troubleshooting and workspace app catalog/release tooling docs for localization and profiling setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->