### PR TITLE
Add Claude Code live composer model discovery for CLI and Agent GUI

### DIFF
--- a/apps/desktop/src/renderer/src/features/workspace-agent/services/createDesktopAgentHostApi.test.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-agent/services/createDesktopAgentHostApi.test.ts
@@ -1014,6 +1014,7 @@ test("desktop agent host api loads composer options through tuttid without creat
       args: [
         "codex",
         {
+          workspaceId,
           settings: {
             model: "gpt-5",
             permissionModeId: "auto",

--- a/apps/desktop/src/renderer/src/features/workspace-agent/services/desktopAgentActivityAdapter.test.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-agent/services/desktopAgentActivityAdapter.test.ts
@@ -322,6 +322,7 @@ test("desktop agent activity adapter normalizes provider composer options", asyn
       "codex",
       {
         cwd: "/repo",
+        workspaceId,
         settings: { model: "gpt-5.4" }
       }
     ]
@@ -471,34 +472,38 @@ test("desktop agent activity adapter normalizes legacy runtime config options", 
 });
 
 test("desktop agent activity adapter uses Claude draft live model list", async () => {
+  const calls: unknown[] = [];
   const adapter = createDesktopAgentActivityAdapter({
     tuttidClient: createTuttidClient({
-      async createWorkspaceAgentSession(_workspaceId, request) {
-        return createSession({
-          id: request.agentSessionId,
-          provider: "claude-code",
-          runtimeContext: {
-            configOptions: [
+      async getAgentProviderComposerOptions(provider, request) {
+        calls.push([provider, request]);
+        return {
+          provider,
+          effectiveSettings: {},
+          modelConfig: {
+            configurable: true,
+            currentValue: "default",
+            options: [
               {
-                id: "model",
-                currentValue: "default",
-                options: [
-                  {
-                    value: "default",
-                    name: "Default",
-                    description: "Opus 4.8 with 1M context"
-                  },
-                  {
-                    value: "claude-opus-4-6",
-                    name: "Opus 4.6",
-                    description: "Most capable for complex work"
-                  }
-                ]
+                id: "default",
+                value: "default",
+                label: "Default",
+                description: "Opus 4.8 with 1M context"
+              },
+              {
+                id: "claude-opus-4-6",
+                value: "claude-opus-4-6",
+                label: "Opus 4.6",
+                description: "Most capable for complex work"
               }
             ]
           },
-          visible: false
-        });
+          permissionConfig: { configurable: false, modes: [] },
+          reasoningConfig: { configurable: false, options: [] },
+          runtimeContext: {},
+          skills: [],
+          capabilityCatalog: []
+        };
       }
     }),
     runtimeApi: createRuntimeApi()
@@ -521,15 +526,23 @@ test("desktop agent activity adapter uses Claude draft live model list", async (
       description: "Most capable for complex work"
     }
   ]);
+  assert.deepEqual(calls, [["claude-code", { settings: {}, workspaceId }]]);
 });
 
 test("desktop agent activity adapter flattens grouped runtime config options", async () => {
   const adapter = createDesktopAgentActivityAdapter({
     tuttidClient: createTuttidClient({
-      async createWorkspaceAgentSession(_workspaceId, request) {
-        return createSession({
-          id: request.agentSessionId,
-          provider: "claude-code",
+      async getAgentProviderComposerOptions(provider) {
+        return {
+          provider,
+          effectiveSettings: {},
+          modelConfig: {
+            configurable: true,
+            currentValue: "sonnet",
+            options: []
+          },
+          permissionConfig: { configurable: false, modes: [] },
+          reasoningConfig: { configurable: false, options: [] },
           runtimeContext: {
             configOptions: [
               {
@@ -551,8 +564,9 @@ test("desktop agent activity adapter flattens grouped runtime config options", a
               }
             ]
           },
-          visible: false
-        });
+          skills: [],
+          capabilityCatalog: []
+        };
       }
     }),
     runtimeApi: createRuntimeApi()
@@ -572,37 +586,39 @@ test("desktop agent activity adapter flattens grouped runtime config options", a
   ]);
 });
 
-test("desktop agent activity adapter loads Claude models from draft session", async () => {
-  const createCalls: unknown[] = [];
+test("desktop agent activity adapter loads Claude models via composer options request", async () => {
+  const composerOptionsCalls: unknown[] = [];
   const adapter = createDesktopAgentActivityAdapter({
     tuttidClient: createTuttidClient({
-      async createWorkspaceAgentSession(requestWorkspaceId, request) {
-        createCalls.push({ request, workspaceId: requestWorkspaceId });
-        return createSession({
-          id: request.agentSessionId,
-          provider: "claude-code",
-          runtimeContext: {
-            configOptions: [
+      async getAgentProviderComposerOptions(provider, request) {
+        composerOptionsCalls.push({ provider, request });
+        return {
+          provider,
+          effectiveSettings: {},
+          modelConfig: {
+            configurable: true,
+            currentValue: "default",
+            options: [
               {
-                id: "model",
-                currentValue: "default",
-                options: [
-                  {
-                    value: "default",
-                    name: "Default",
-                    description: "Opus 4.8 with 1M context"
-                  },
-                  {
-                    value: "opus",
-                    name: "Opus",
-                    description: "Most capable"
-                  }
-                ]
+                id: "default",
+                value: "default",
+                label: "Default",
+                description: "Opus 4.8 with 1M context"
+              },
+              {
+                id: "opus",
+                value: "opus",
+                label: "Opus",
+                description: "Most capable"
               }
             ]
           },
-          visible: false
-        });
+          permissionConfig: { configurable: false, modes: [] },
+          reasoningConfig: { configurable: false, options: [] },
+          runtimeContext: {},
+          skills: [],
+          capabilityCatalog: []
+        };
       }
     }),
     runtimeApi: createRuntimeApi()
@@ -614,19 +630,12 @@ test("desktop agent activity adapter loads Claude models from draft session", as
     workspaceId
   });
 
-  assert.equal(createCalls.length, 1);
-  assert.deepEqual(
-    (
-      createCalls[0] as {
-        request: { initialContent: unknown[]; visible: boolean };
-      }
-    ).request.initialContent,
-    []
-  );
-  assert.equal(
-    (createCalls[0] as { request: { visible: boolean } }).request.visible,
-    false
-  );
+  assert.deepEqual(composerOptionsCalls, [
+    {
+      provider: "claude-code",
+      request: { cwd: "/repo", settings: {}, workspaceId }
+    }
+  ]);
   assert.equal(options.modelConfigurable, true);
   assert.deepEqual(options.models, [
     {
@@ -636,7 +645,6 @@ test("desktop agent activity adapter loads Claude models from draft session", as
     },
     { value: "opus", label: "Opus", description: "Most capable" }
   ]);
-  assert.equal(typeof options.runtimeContext?.draftAgentSessionId, "string");
 });
 
 test("desktop agent activity adapter promotes Claude draft on first prompt", async () => {
@@ -715,10 +723,25 @@ test("desktop agent activity adapter promotes Claude draft on first prompt", asy
   assert.equal(session.visible, true);
 });
 
-test("desktop agent activity adapter updates the Claude draft in place when settings change", async () => {
+test("desktop agent activity adapter loads Claude options without mutating draft sessions", async () => {
   const calls: string[] = [];
   const adapter = createDesktopAgentActivityAdapter({
     tuttidClient: createTuttidClient({
+      async getAgentProviderComposerOptions(provider, request) {
+        calls.push(
+          `options:${provider}:${String(request?.settings?.planMode)}`
+        );
+        return {
+          provider,
+          effectiveSettings: request?.settings ?? {},
+          modelConfig: { configurable: true, options: [] },
+          permissionConfig: { configurable: false, modes: [] },
+          reasoningConfig: { configurable: true, options: [] },
+          runtimeContext: {},
+          skills: [],
+          capabilityCatalog: []
+        };
+      },
       async createWorkspaceAgentSession(_workspaceId, request) {
         calls.push(`create:${request.planMode === true ? "plan" : "default"}`);
         return createSession({
@@ -747,29 +770,22 @@ test("desktop agent activity adapter updates the Claude draft in place when sett
     runtimeApi: createRuntimeApi()
   });
 
-  const first = await adapter.loadComposerOptions({
+  await adapter.loadComposerOptions({
     provider: "claude-code",
     settings: { planMode: false },
     workspaceId
   });
-  const draftAgentSessionId = String(first.runtimeContext?.draftAgentSessionId);
 
-  const second = await adapter.loadComposerOptions({
+  await adapter.loadComposerOptions({
     provider: "claude-code",
     settings: { planMode: true },
     workspaceId
   });
 
-  // The same pre-warm draft is reused and patched in place; no teardown or
-  // second hidden session is created when toggling plan mode.
   assert.deepEqual(calls, [
-    "create:default",
-    `update:${draftAgentSessionId}:plan=true`
+    "options:claude-code:false",
+    "options:claude-code:true"
   ]);
-  assert.equal(
-    String(second.runtimeContext?.draftAgentSessionId),
-    draftAgentSessionId
-  );
 });
 
 function createTuttidClient(

--- a/apps/desktop/src/renderer/src/features/workspace-agent/services/desktopAgentActivityAdapter.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-agent/services/desktopAgentActivityAdapter.ts
@@ -51,7 +51,9 @@ export function createDesktopAgentActivityAdapter({
     settingsKey: string
   ): Promise<WorkspaceAgentSession> => {
     const draftKey = claudeDraftKey({ ...input, cwd });
-    const agentSessionId = createDesktopAgentActivitySessionId();
+    const agentSessionId =
+      normalizeText(input.agentSessionId) ??
+      createDesktopAgentActivitySessionId();
     const promise = tuttidClient
       .createWorkspaceAgentSession(input.workspaceId, {
         agentSessionId,
@@ -103,7 +105,8 @@ export function createDesktopAgentActivityAdapter({
       existing &&
       existing.status !== "disposed" &&
       existing.status !== "failed" &&
-      existing.cwd === cwd
+      existing.cwd === cwd &&
+      (!input.agentSessionId || existing.sessionId === input.agentSessionId)
     ) {
       if (existing.settingsKey === settingsKey) {
         return existing.promise;
@@ -219,27 +222,11 @@ export function createDesktopAgentActivityAdapter({
     },
     async loadComposerOptions(input) {
       const cwd = input.cwd?.trim();
-      if (workspaceAgentProvider(input.provider) === "claude-code") {
-        try {
-          const session = await ensureClaudeDraft({
-            cwd: cwd || null,
-            settings: normalizedClaudeDraftSettings(input.settings),
-            workspaceId: input.workspaceId
-          });
-          return agentActivityComposerOptionsFromTuttidResult(input.provider, {
-            permissionConfig: session.permissionConfig,
-            provider: session.provider,
-            runtimeContext: session.runtimeContext
-          });
-        } catch {
-          // Fall through to daemon composer options. Claude no longer gets a
-          // static model list there; this only preserves capabilities/skills.
-        }
-      }
       const result = await tuttidClient.getAgentProviderComposerOptions(
         workspaceAgentProvider(input.provider),
         {
           ...(cwd ? { cwd } : {}),
+          workspaceId: input.workspaceId,
           settings: input.settings ?? {}
         }
       );
@@ -265,6 +252,30 @@ export function createDesktopAgentActivityAdapter({
       const promoted = await promoteClaudeDraft(input);
       if (promoted) {
         return promoted;
+      }
+      if (
+        workspaceAgentProvider(input.provider) === "claude-code" &&
+        (input.initialContent?.length ?? 0) > 0
+      ) {
+        const draft = await ensureClaudeDraft({
+          agentSessionId: input.agentSessionId?.trim() ?? null,
+          cwd: input.cwd ?? null,
+          settings: normalizedClaudeDraftSettings({
+            model: input.model,
+            permissionModeId: input.permissionModeId,
+            planMode: input.planMode,
+            reasoningEffort: input.reasoningEffort,
+            speed: input.speed
+          }),
+          workspaceId: input.workspaceId
+        });
+        const promotedDraft = await promoteClaudeDraft({
+          ...input,
+          agentSessionId: draft.id
+        });
+        if (promotedDraft) {
+          return promotedDraft;
+        }
       }
       const session = await tuttidClient.createWorkspaceAgentSession(
         input.workspaceId,
@@ -357,6 +368,7 @@ interface ClaudeDraftSettings {
 }
 
 interface ClaudeDraftInput {
+  agentSessionId?: string | null;
   cwd: string | null;
   settings: ClaudeDraftSettings;
   workspaceId: string;

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUINodeController.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUINodeController.ts
@@ -3832,17 +3832,19 @@ export function useAgentGUINodeController({
         defaultReasoningEffort,
         drafts: draftSettingsBySessionIdRef.current
       });
+      const composerOptionsCwd =
+        selectedProjectPathRef.current?.trim() || workspacePath.trim() || "";
       void Promise.resolve(
         agentActivityRuntime.getComposerOptions({
           workspaceId,
-          cwd: selectedProjectPathRef.current ?? "",
+          cwd: composerOptionsCwd,
           force: options?.force,
           provider,
           settings
         })
       ).catch(() => undefined);
     },
-    [agentActivityRuntime, defaultReasoningEffort, workspaceId]
+    [agentActivityRuntime, defaultReasoningEffort, workspaceId, workspacePath]
   );
 
   useEffect(() => {

--- a/packages/clients/tuttid-ts/src/generated/sdk.gen.ts
+++ b/packages/clients/tuttid-ts/src/generated/sdk.gen.ts
@@ -1288,7 +1288,7 @@ export const importWorkspaceExternalAgentSessions = <
   });
 
 /**
- * Get provider composer options without creating an agent session
+ * Get provider composer options with short-lived Claude Code discovery
  */
 export const getAgentProviderComposerOptions = <
   ThrowOnError extends boolean = false

--- a/packages/clients/tuttid-ts/src/generated/types.gen.ts
+++ b/packages/clients/tuttid-ts/src/generated/types.gen.ts
@@ -752,6 +752,10 @@ export type AgentProviderComposerConfig = {
 
 export type GetAgentProviderComposerOptionsRequest = {
   cwd?: string;
+  /**
+   * Workspace used for Claude Code live model discovery.
+   */
+  workspaceId?: string;
   locale?: DesktopLocale;
   settings?: AgentSessionComposerSettings;
 };
@@ -4130,7 +4134,7 @@ export type GetAgentProviderComposerOptionsError =
 
 export type GetAgentProviderComposerOptionsResponses = {
   /**
-   * Agent provider composer options
+   * Agent provider composer options with short-lived Claude Code discovery when needed
    */
   200: AgentProviderComposerOptionsResponse;
 };

--- a/services/tuttid/api/daemon_agent_sessions.go
+++ b/services/tuttid/api/daemon_agent_sessions.go
@@ -102,6 +102,7 @@ func (api DaemonAPI) GetAgentProviderComposerOptions(ctx context.Context, reques
 	}
 	if request.Body != nil {
 		input.Cwd = optionalStringValue(request.Body.Cwd)
+		input.WorkspaceID = optionalStringValue(request.Body.WorkspaceId)
 	}
 	input.Settings = api.composerDefaultsForProvider(ctx, input.Provider)
 	if request.Body != nil && request.Body.Settings != nil {

--- a/services/tuttid/api/generated/server.gen.go
+++ b/services/tuttid/api/generated/server.gen.go
@@ -25,7 +25,7 @@ type ServerInterface interface {
 	// Run a local agent provider action owned by tuttid
 	// (POST /v1/agent-providers/{provider}/actions/{actionID}/run)
 	RunAgentProviderAction(w http.ResponseWriter, r *http.Request, provider WorkspaceAgentProvider, actionID AgentProviderActionID)
-	// Get provider composer options without creating an agent session
+	// Get provider composer options with short-lived Claude Code discovery
 	// (POST /v1/agent-providers/{provider}/composer-options)
 	GetAgentProviderComposerOptions(w http.ResponseWriter, r *http.Request, provider WorkspaceAgentProvider)
 	// Probe whether tuttid can start a local agent provider runtime command
@@ -18621,7 +18621,7 @@ type StrictServerInterface interface {
 	// Run a local agent provider action owned by tuttid
 	// (POST /v1/agent-providers/{provider}/actions/{actionID}/run)
 	RunAgentProviderAction(ctx context.Context, request RunAgentProviderActionRequestObject) (RunAgentProviderActionResponseObject, error)
-	// Get provider composer options without creating an agent session
+	// Get provider composer options with short-lived Claude Code discovery
 	// (POST /v1/agent-providers/{provider}/composer-options)
 	GetAgentProviderComposerOptions(ctx context.Context, request GetAgentProviderComposerOptionsRequestObject) (GetAgentProviderComposerOptionsResponseObject, error)
 	// Probe whether tuttid can start a local agent provider runtime command

--- a/services/tuttid/api/generated/types.gen.go
+++ b/services/tuttid/api/generated/types.gen.go
@@ -2158,6 +2158,9 @@ type GetAgentProviderComposerOptionsRequest struct {
 	Cwd      *string                       `json:"cwd,omitempty"`
 	Locale   *DesktopLocale                `json:"locale,omitempty"`
 	Settings *AgentSessionComposerSettings `json:"settings,omitempty"`
+
+	// WorkspaceId Workspace used for Claude Code live model discovery.
+	WorkspaceId *string `json:"workspaceId,omitempty"`
 }
 
 // HealthStatusResponse defines model for HealthStatusResponse.

--- a/services/tuttid/api/openapi/tuttid.v1.yaml
+++ b/services/tuttid/api/openapi/tuttid.v1.yaml
@@ -1438,7 +1438,7 @@ paths:
       operationId: getAgentProviderComposerOptions
       tags:
         - agent-session
-      summary: Get provider composer options without creating an agent session
+      summary: Get provider composer options with short-lived Claude Code discovery
       requestBody:
         required: false
         content:
@@ -1447,7 +1447,7 @@ paths:
               $ref: "#/components/schemas/GetAgentProviderComposerOptionsRequest"
       responses:
         "200":
-          description: Agent provider composer options
+          description: Agent provider composer options with short-lived Claude Code discovery when needed
           content:
             application/json:
               schema:
@@ -4742,6 +4742,9 @@ components:
       properties:
         cwd:
           type: string
+        workspaceId:
+          type: string
+          description: Workspace used for Claude Code live model discovery.
         locale:
           $ref: "#/components/schemas/DesktopLocale"
         settings:

--- a/services/tuttid/service/agent/composer_live_model_cache.go
+++ b/services/tuttid/service/agent/composer_live_model_cache.go
@@ -1,0 +1,97 @@
+package agent
+
+import (
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/tutti-os/tutti/services/tuttid/biz/agentprovider"
+)
+
+const defaultLiveModelCacheTTL = 10 * time.Minute
+
+type composerLiveModelCache struct {
+	mu      sync.Mutex
+	entries map[string]composerLiveModelCacheEntry
+}
+
+type composerLiveModelCacheEntry struct {
+	cachedAt time.Time
+	options  []ComposerConfigOptionValue
+}
+
+func newComposerLiveModelCache() *composerLiveModelCache {
+	return &composerLiveModelCache{
+		entries: make(map[string]composerLiveModelCacheEntry),
+	}
+}
+
+func (c *composerLiveModelCache) get(key string, now time.Time, ttl time.Duration) ([]ComposerConfigOptionValue, bool) {
+	if c == nil || ttl <= 0 {
+		return nil, false
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	entry, ok := c.entries[key]
+	if !ok {
+		return nil, false
+	}
+	if now.Sub(entry.cachedAt) > ttl {
+		delete(c.entries, key)
+		return nil, false
+	}
+	return cloneComposerConfigOptionValues(entry.options), true
+}
+
+func (c *composerLiveModelCache) set(key string, now time.Time, options []ComposerConfigOptionValue) {
+	if c == nil {
+		return
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.entries[key] = composerLiveModelCacheEntry{
+		cachedAt: now,
+		options:  cloneComposerConfigOptionValues(options),
+	}
+}
+
+func (s *Service) liveModelCacheTTL() time.Duration {
+	if s.LiveModelCacheTTL != 0 {
+		return s.LiveModelCacheTTL
+	}
+	return defaultLiveModelCacheTTL
+}
+
+func (s *Service) liveComposerModelCache() *composerLiveModelCache {
+	if s.liveModelCache == nil {
+		s.liveModelCache = newComposerLiveModelCache()
+	}
+	return s.liveModelCache
+}
+
+func (s *Service) getLiveComposerModelOptions(provider, workspaceID, cwd string, now time.Time) ([]ComposerConfigOptionValue, bool) {
+	key := composerLiveModelCacheKey(provider, workspaceID, cwd)
+	return s.liveComposerModelCache().get(key, now, s.liveModelCacheTTL())
+}
+
+func (s *Service) setLiveComposerModelOptions(provider, workspaceID, cwd string, now time.Time, options []ComposerConfigOptionValue) {
+	if len(options) == 0 {
+		return
+	}
+	key := composerLiveModelCacheKey(provider, workspaceID, cwd)
+	s.liveComposerModelCache().set(key, now, options)
+}
+
+func composerLiveModelCacheKey(provider, workspaceID, cwd string) string {
+	return "live-model:" +
+		agentprovider.Normalize(provider) + ":" +
+		strings.TrimSpace(workspaceID) + ":" +
+		strings.TrimSpace(cwd)
+}
+
+func cloneComposerConfigOptionValues(options []ComposerConfigOptionValue) []ComposerConfigOptionValue {
+	if len(options) == 0 {
+		return nil
+	}
+	return append([]ComposerConfigOptionValue(nil), options...)
+}

--- a/services/tuttid/service/agent/composer_live_model_discovery.go
+++ b/services/tuttid/service/agent/composer_live_model_discovery.go
@@ -1,0 +1,375 @@
+package agent
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/tutti-os/tutti/services/tuttid/biz/agentprovider"
+	"golang.org/x/sync/singleflight"
+)
+
+const (
+	defaultLiveModelDiscoveryTimeout = 8 * time.Second
+	liveModelDiscoveryPollInterval   = 100 * time.Millisecond
+)
+
+var liveComposerModelDiscoveryGroup singleflight.Group
+
+func (s *Service) liveModelDiscoveryTimeout() time.Duration {
+	if s.LiveModelDiscoveryTimeout != 0 {
+		return s.LiveModelDiscoveryTimeout
+	}
+	return defaultLiveModelDiscoveryTimeout
+}
+
+func (s *Service) discoverLiveComposerModels(
+	ctx context.Context,
+	workspaceID string,
+	cwd string,
+	settings ComposerSettings,
+) ([]ComposerConfigOptionValue, error) {
+	workspaceID = strings.TrimSpace(workspaceID)
+	if workspaceID == "" {
+		return nil, ErrInvalidArgument
+	}
+	provider := agentprovider.ClaudeCode
+	cacheKey := composerLiveModelCacheKey(provider, workspaceID, cwd)
+	result, err, _ := liveComposerModelDiscoveryGroup.Do(cacheKey, func() (any, error) {
+		now := time.Now().UTC()
+		if cached, ok := s.getLiveComposerModelOptions(provider, workspaceID, cwd, now); ok && len(cached) > 0 {
+			return cached, nil
+		}
+		discovered, discoverErr := s.discoverLiveComposerModelsUncached(ctx, workspaceID, cwd, settings)
+		if discoverErr != nil {
+			return nil, discoverErr
+		}
+		s.setLiveComposerModelOptions(provider, workspaceID, cwd, now, discovered)
+		return discovered, nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	models, _ := result.([]ComposerConfigOptionValue)
+	return cloneComposerConfigOptionValues(models), nil
+}
+
+func (s *Service) discoverLiveComposerModelsUncached(
+	ctx context.Context,
+	workspaceID string,
+	cwd string,
+	settings ComposerSettings,
+) ([]ComposerConfigOptionValue, error) {
+	provider := agentprovider.ClaudeCode
+	if err := s.ensureProviderRuntimeInstalled(ctx, provider); err != nil {
+		return nil, err
+	}
+	resolvedCwd := strings.TrimSpace(cwd)
+	if resolvedCwd != "" {
+		resolved, err := s.resolveCwd(ctx, &resolvedCwd)
+		if err != nil {
+			return nil, err
+		}
+		resolvedCwd = resolved
+	}
+	visible := false
+	startInput := CreateSessionInput{
+		AgentSessionID:   uuid.NewString(),
+		Provider:         provider,
+		Cwd:              &resolvedCwd,
+		PermissionModeID: stringPointer(strings.TrimSpace(settings.PermissionModeID)),
+		Model:            stringPointer(strings.TrimSpace(settings.Model)),
+		PlanMode:         boolPointer(settings.PlanMode),
+		BrowserUse:       settings.BrowserUse,
+		ComputerUse:      settings.ComputerUse,
+		ReasoningEffort:  stringPointer(strings.TrimSpace(settings.ReasoningEffort)),
+		Speed:            stringPointer(strings.TrimSpace(settings.Speed)),
+		Visible:          &visible,
+	}
+	prepared, err := s.prepareRuntime(ctx, workspaceID, resolvedCwd, startInput)
+	if err != nil {
+		return nil, err
+	}
+	session, err := s.controller().Start(ctx, RuntimeStartInput{
+		WorkspaceID:      workspaceID,
+		AgentSessionID:   startInput.AgentSessionID,
+		Provider:         provider,
+		Cwd:              prepared.Cwd,
+		Env:              prepared.Env,
+		PermissionModeID: value(startInput.PermissionModeID),
+		Model:            clampComposerModelForProvider(provider, value(startInput.Model)),
+		PlanMode:         clampComposerPlanModeForProvider(provider, valueBool(startInput.PlanMode)),
+		BrowserUse:       startInput.BrowserUse,
+		ComputerUse:      startInput.ComputerUse,
+		ReasoningEffort:  normalizeReasoningEffortForProvider(provider, value(startInput.ReasoningEffort)),
+		Speed:            normalizeSpeedForProvider(provider, value(startInput.Speed)),
+		Visible:          startInput.Visible,
+	})
+	if err != nil {
+		cleanupErr := s.cleanupRuntime(ctx, workspaceID, startInput.AgentSessionID)
+		if cleanupErr != nil {
+			return nil, errors.Join(normalizeRuntimeError(err), cleanupErr)
+		}
+		return nil, normalizeRuntimeError(err)
+	}
+	defer func() {
+		_ = s.controller().Close(context.Background(), RuntimeCloseInput{
+			WorkspaceID:    workspaceID,
+			AgentSessionID: session.ID,
+		})
+		_ = s.cleanupRuntime(context.Background(), workspaceID, session.ID)
+	}()
+	return s.pollComposerModelOptions(ctx, workspaceID, session)
+}
+
+func (s *Service) pollComposerModelOptions(
+	ctx context.Context,
+	workspaceID string,
+	session RuntimeSession,
+) ([]ComposerConfigOptionValue, error) {
+	timeout := s.liveModelDiscoveryTimeout()
+	pollCtx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+	ticker := time.NewTicker(liveModelDiscoveryPollInterval)
+	defer ticker.Stop()
+	current := session
+	for {
+		if options := extractModelOptionsFromRuntimeContext(current.RuntimeContext); len(options) > 0 {
+			return options, nil
+		}
+		select {
+		case <-pollCtx.Done():
+			return nil, pollCtx.Err()
+		case <-ticker.C:
+			refreshed, ok := s.controller().Session(workspaceID, current.ID)
+			if ok {
+				current = refreshed
+			}
+		}
+	}
+}
+
+func extractModelOptionsFromRuntimeContext(runtimeContext map[string]any) []ComposerConfigOptionValue {
+	if len(runtimeContext) == 0 {
+		return nil
+	}
+	configOptions, ok := runtimeContext["configOptions"].([]any)
+	if !ok {
+		if typed, typedOK := runtimeContext["configOptions"].([]map[string]any); typedOK {
+			configOptions = make([]any, 0, len(typed))
+			for _, item := range typed {
+				configOptions = append(configOptions, item)
+			}
+		}
+	}
+	if len(configOptions) == 0 {
+		return nil
+	}
+	for _, optionRaw := range configOptions {
+		optionMap, ok := optionRaw.(map[string]any)
+		if !ok || strings.TrimSpace(stringFromAny(optionMap["id"])) != "model" {
+			continue
+		}
+		return composerConfigOptionValuesFromAny(optionMap["options"])
+	}
+	return nil
+}
+
+func composerConfigOptionValuesFromAny(input any) []ComposerConfigOptionValue {
+	rawOptions, ok := input.([]any)
+	if !ok {
+		if typed, typedOK := input.([]map[string]string); typedOK {
+			rawOptions = make([]any, 0, len(typed))
+			for _, item := range typed {
+				rawOptions = append(rawOptions, item)
+			}
+		}
+	}
+	if len(rawOptions) == 0 {
+		return nil
+	}
+	options := make([]ComposerConfigOptionValue, 0, len(rawOptions))
+	for _, raw := range rawOptions {
+		optionMap, ok := raw.(map[string]any)
+		if !ok {
+			if typed, typedOK := raw.(map[string]string); typedOK {
+				optionMap = map[string]any{
+					"id":    typed["id"],
+					"name":  typed["name"],
+					"label": typed["label"],
+					"value": typed["value"],
+				}
+			} else {
+				continue
+			}
+		}
+		value := strings.TrimSpace(stringFromAny(optionMap["value"]))
+		if value == "" {
+			continue
+		}
+		label := strings.TrimSpace(stringFromAny(optionMap["label"]))
+		if label == "" {
+			label = strings.TrimSpace(stringFromAny(optionMap["name"]))
+		}
+		if label == "" {
+			label = value
+		}
+		id := strings.TrimSpace(stringFromAny(optionMap["id"]))
+		if id == "" {
+			id = value
+		}
+		options = append(options, ComposerConfigOptionValue{
+			ID:          id,
+			Label:       label,
+			Value:       value,
+			Description: strings.TrimSpace(stringFromAny(optionMap["description"])),
+		})
+	}
+	return options
+}
+
+func stringFromAny(input any) string {
+	if value, ok := input.(string); ok {
+		return value
+	}
+	return ""
+}
+
+func mergeLiveModelsIntoComposerOptions(options ComposerOptions, liveModels []ComposerConfigOptionValue) ComposerOptions {
+	normalized := normalizeLiveComposerModelOptions(liveModels, options.EffectiveSettings.Model)
+	if len(normalized) == 0 {
+		return options
+	}
+	selected := strings.TrimSpace(options.EffectiveSettings.Model)
+	options.ModelConfig = ComposerConfigOption{
+		Configurable: true,
+		CurrentValue: selected,
+		DefaultValue: selected,
+		Options:      cloneComposerConfigOptionValues(normalized),
+	}
+	options.RuntimeContext = mergeLiveModelsIntoRuntimeContext(options.RuntimeContext, selected, normalized)
+	return options
+}
+
+func normalizeLiveComposerModelOptions(
+	options []ComposerConfigOptionValue,
+	selectedModel string,
+) []ComposerConfigOptionValue {
+	if len(options) == 0 {
+		return nil
+	}
+	normalized := make([]ComposerConfigOptionValue, 0, len(options)+1)
+	seen := make(map[string]struct{}, len(options)+1)
+	for _, option := range options {
+		value := strings.TrimSpace(option.Value)
+		if value == "" {
+			continue
+		}
+		if _, ok := seen[value]; ok {
+			continue
+		}
+		seen[value] = struct{}{}
+		label := strings.TrimSpace(option.Label)
+		if label == "" {
+			label = value
+		}
+		id := strings.TrimSpace(option.ID)
+		if id == "" {
+			id = value
+		}
+		normalized = append(normalized, ComposerConfigOptionValue{
+			ID:          id,
+			Label:       label,
+			Value:       value,
+			Description: strings.TrimSpace(option.Description),
+		})
+	}
+	selectedModel = strings.TrimSpace(selectedModel)
+	if selectedModel != "" {
+		if _, ok := seen[selectedModel]; !ok {
+			normalized = append(normalized, ComposerConfigOptionValue{
+				ID:    selectedModel,
+				Label: selectedModel,
+				Value: selectedModel,
+			})
+		}
+	}
+	return normalized
+}
+
+func mergeLiveModelsIntoRuntimeContext(
+	runtimeContext map[string]any,
+	selectedModel string,
+	liveModels []ComposerConfigOptionValue,
+) map[string]any {
+	if runtimeContext == nil {
+		runtimeContext = map[string]any{}
+	}
+	modelOption := map[string]any{
+		"id":           "model",
+		"currentValue": nullableString(selectedModel),
+		"options":      composerConfigOptionValuesToRuntimeModelOptions(liveModels),
+	}
+	configOptions := make([]map[string]any, 0, 4)
+	configOptions = append(configOptions, modelOption)
+	for _, option := range runtimeConfigOptionsAsMapSlice(runtimeContext["configOptions"]) {
+		if strings.TrimSpace(stringFromAny(option["id"])) == "model" {
+			continue
+		}
+		configOptions = append(configOptions, option)
+	}
+	runtimeContext["configOptions"] = configOptions
+	runtimeContext["modelCatalogSource"] = "acp-live-discovery"
+	return runtimeContext
+}
+
+func composerConfigOptionValuesToRuntimeModelOptions(options []ComposerConfigOptionValue) []map[string]string {
+	if len(options) == 0 {
+		return []map[string]string{}
+	}
+	result := make([]map[string]string, 0, len(options))
+	for _, option := range options {
+		value := strings.TrimSpace(option.Value)
+		if value == "" {
+			continue
+		}
+		label := strings.TrimSpace(option.Label)
+		if label == "" {
+			label = value
+		}
+		result = append(result, map[string]string{
+			"name":  label,
+			"value": value,
+		})
+	}
+	return result
+}
+
+func runtimeConfigOptionsAsMapSlice(input any) []map[string]any {
+	switch typed := input.(type) {
+	case []map[string]any:
+		return append([]map[string]any(nil), typed...)
+	case []any:
+		result := make([]map[string]any, 0, len(typed))
+		for _, item := range typed {
+			entry, ok := item.(map[string]any)
+			if !ok {
+				continue
+			}
+			result = append(result, entry)
+		}
+		return result
+	default:
+		return nil
+	}
+}
+
+func nullableString(value string) any {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return nil
+	}
+	return value
+}

--- a/services/tuttid/service/agent/composer_live_model_discovery_test.go
+++ b/services/tuttid/service/agent/composer_live_model_discovery_test.go
@@ -1,0 +1,57 @@
+package agent
+
+import "testing"
+
+func TestExtractModelOptionsFromRuntimeContext(t *testing.T) {
+	options := extractModelOptionsFromRuntimeContext(map[string]any{
+		"configOptions": []any{
+			map[string]any{
+				"id":           "model",
+				"currentValue": "default",
+				"options": []any{
+					map[string]any{"name": "Default", "value": "default"},
+					map[string]any{"name": "Sonnet", "value": "sonnet"},
+				},
+			},
+			map[string]any{
+				"id": "effort",
+			},
+		},
+	})
+	if len(options) != 2 {
+		t.Fatalf("len(options) = %d, want 2", len(options))
+	}
+	if options[0].Value != "default" || options[1].Value != "sonnet" {
+		t.Fatalf("options = %#v, want default and sonnet", options)
+	}
+}
+
+func TestMergeLiveModelsIntoComposerOptionsUpdatesRuntimeContext(t *testing.T) {
+	merged := mergeLiveModelsIntoComposerOptions(ComposerOptions{
+		Provider: "claude-code",
+		EffectiveSettings: ComposerSettings{
+			Model: "default",
+		},
+		RuntimeContext: map[string]any{
+			"configOptions": []map[string]any{
+				{
+					"id":           "effort",
+					"currentValue": "high",
+				},
+			},
+		},
+	}, []ComposerConfigOptionValue{
+		{ID: "default", Label: "Default", Value: "default"},
+		{ID: "sonnet", Label: "Sonnet", Value: "sonnet"},
+	})
+	if !merged.ModelConfig.Configurable || len(merged.ModelConfig.Options) != 2 {
+		t.Fatalf("modelConfig = %#v", merged.ModelConfig)
+	}
+	if merged.RuntimeContext["modelCatalogSource"] != "acp-live-discovery" {
+		t.Fatalf("modelCatalogSource = %#v, want acp-live-discovery", merged.RuntimeContext["modelCatalogSource"])
+	}
+	configOptions, ok := merged.RuntimeContext["configOptions"].([]map[string]any)
+	if !ok || len(configOptions) != 2 || configOptions[0]["id"] != "model" {
+		t.Fatalf("configOptions = %#v, want model + effort", merged.RuntimeContext["configOptions"])
+	}
+}

--- a/services/tuttid/service/agent/composer_options.go
+++ b/services/tuttid/service/agent/composer_options.go
@@ -3,6 +3,7 @@ package agent
 import (
 	"context"
 	"strings"
+	"time"
 
 	"github.com/tutti-os/tutti/services/tuttid/biz/agentprovider"
 	preferencesbiz "github.com/tutti-os/tutti/services/tuttid/biz/preferences"
@@ -65,6 +66,7 @@ type ComposerOptionsInput struct {
 	Cwd                      string
 	Locale                   string
 	Provider                 string
+	WorkspaceID              string
 	Settings                 ComposerSettings
 	IncludeCapabilityCatalog *bool
 }
@@ -158,7 +160,7 @@ func (s *Service) GetComposerOptions(ctx context.Context, input ComposerOptionsI
 			runtimeContext["modelCatalogSource"] = source
 		}
 	}
-	return ComposerOptions{
+	options := ComposerOptions{
 		Provider:          provider,
 		ModelConfig:       composerModelConfig(provider, effectiveSettings.Model, modelOptions),
 		PermissionConfig:  permissionConfig,
@@ -168,7 +170,22 @@ func (s *Service) GetComposerOptions(ctx context.Context, input ComposerOptionsI
 		RuntimeContext:    runtimeContext,
 		Skills:            skills,
 		CapabilityCatalog: capabilityCatalog,
-	}, nil
+	}
+	if provider == agentprovider.ClaudeCode && strings.TrimSpace(input.WorkspaceID) != "" {
+		now := time.Now().UTC()
+		liveModels, ok := s.getLiveComposerModelOptions(provider, input.WorkspaceID, input.Cwd, now)
+		if !ok {
+			discovered, err := s.discoverLiveComposerModels(ctx, input.WorkspaceID, input.Cwd, effectiveSettings)
+			if err == nil && len(discovered) > 0 {
+				liveModels = discovered
+				s.setLiveComposerModelOptions(provider, input.WorkspaceID, input.Cwd, now, discovered)
+			}
+		}
+		if len(liveModels) > 0 {
+			options = mergeLiveModelsIntoComposerOptions(options, liveModels)
+		}
+	}
+	return options, nil
 }
 
 func composerOptionsIncludeCapabilityCatalog(input ComposerOptionsInput) bool {
@@ -774,12 +791,4 @@ func normalizeReasoningEffortForProvider(provider string, value string) string {
 		return "high"
 	}
 	return normalized
-}
-
-func nullableString(value string) any {
-	value = strings.TrimSpace(value)
-	if value == "" {
-		return nil
-	}
-	return value
 }

--- a/services/tuttid/service/agent/service.go
+++ b/services/tuttid/service/agent/service.go
@@ -28,6 +28,7 @@ func NewService(runtime RuntimeController) *Service {
 		skillOptionsCache:         newComposerSkillOptionsCache(),
 		providerAvailabilityCache: newProviderAvailabilityCache(),
 		capabilityCatalogCache:    newComposerCapabilityCatalogCache(),
+		liveModelCache:            newComposerLiveModelCache(),
 	}
 }
 

--- a/services/tuttid/service/agent/service_test.go
+++ b/services/tuttid/service/agent/service_test.go
@@ -1289,6 +1289,124 @@ func TestServiceGetsComposerOptionsSkipsClaudeStaticModelCatalog(t *testing.T) {
 	}
 }
 
+func TestGetComposerOptionsClaudeCodeDiscoversLiveModels(t *testing.T) {
+	runtime := newFakeRuntime()
+	runtime.startHook = func(input RuntimeStartInput, session RuntimeSession) RuntimeSession {
+		if input.Provider != "claude-code" {
+			return session
+		}
+		session.RuntimeContext = map[string]any{
+			"configOptions": []any{
+				map[string]any{
+					"id":           "model",
+					"currentValue": "default",
+					"options": []any{
+						map[string]any{"name": "Default", "value": "default"},
+						map[string]any{"name": "Sonnet", "value": "sonnet"},
+					},
+				},
+				map[string]any{
+					"id":           "effort",
+					"currentValue": "high",
+					"options": []any{
+						map[string]any{"name": "High", "value": "high"},
+					},
+				},
+			},
+		}
+		return session
+	}
+	service := NewService(runtime)
+
+	options, err := service.GetComposerOptions(context.Background(), ComposerOptionsInput{
+		Provider:    "claude-code",
+		WorkspaceID: "ws-1",
+		Cwd:         "/repo",
+	})
+	if err != nil {
+		t.Fatalf("GetComposerOptions returned error: %v", err)
+	}
+	if len(runtime.startCalls) != 1 {
+		t.Fatalf("start calls = %d, want 1", len(runtime.startCalls))
+	}
+	if len(runtime.closeCalls) != 1 {
+		t.Fatalf("close calls = %d, want 1", len(runtime.closeCalls))
+	}
+	if !options.ModelConfig.Configurable || len(options.ModelConfig.Options) != 2 {
+		t.Fatalf("modelConfig = %#v, want discovered model options", options.ModelConfig)
+	}
+	if options.RuntimeContext["modelCatalogSource"] != "acp-live-discovery" {
+		t.Fatalf("modelCatalogSource = %#v, want acp-live-discovery", options.RuntimeContext["modelCatalogSource"])
+	}
+	configOptions, ok := options.RuntimeContext["configOptions"].([]map[string]any)
+	if !ok || len(configOptions) == 0 || configOptions[0]["id"] != "model" {
+		t.Fatalf("configOptions = %#v, want model option merged into runtime context", options.RuntimeContext["configOptions"])
+	}
+}
+
+func TestGetComposerOptionsClaudeCodeLiveModelsUsesCache(t *testing.T) {
+	runtime := newFakeRuntime()
+	runtime.startHook = func(input RuntimeStartInput, session RuntimeSession) RuntimeSession {
+		if input.Provider != "claude-code" {
+			return session
+		}
+		session.RuntimeContext = map[string]any{
+			"configOptions": []any{
+				map[string]any{
+					"id":           "model",
+					"currentValue": "default",
+					"options": []any{
+						map[string]any{"name": "Default", "value": "default"},
+					},
+				},
+			},
+		}
+		return session
+	}
+	service := NewService(runtime)
+
+	for range 2 {
+		_, err := service.GetComposerOptions(context.Background(), ComposerOptionsInput{
+			Provider:    "claude-code",
+			WorkspaceID: "ws-1",
+			Cwd:         "/repo",
+		})
+		if err != nil {
+			t.Fatalf("GetComposerOptions returned error: %v", err)
+		}
+	}
+	if len(runtime.startCalls) != 1 {
+		t.Fatalf("start calls = %d, want 1 with cache", len(runtime.startCalls))
+	}
+	if len(runtime.closeCalls) != 1 {
+		t.Fatalf("close calls = %d, want 1 with cache", len(runtime.closeCalls))
+	}
+}
+
+func TestGetComposerOptionsClaudeCodeLiveModelsTimeoutDegradesGracefully(t *testing.T) {
+	runtime := newFakeRuntime()
+	service := NewService(runtime)
+	service.LiveModelDiscoveryTimeout = 250 * time.Millisecond
+
+	options, err := service.GetComposerOptions(context.Background(), ComposerOptionsInput{
+		Provider:    "claude-code",
+		WorkspaceID: "ws-timeout",
+		Cwd:         "/repo",
+	})
+	if err != nil {
+		t.Fatalf("GetComposerOptions returned error: %v", err)
+	}
+	if len(runtime.startCalls) != 1 {
+		t.Fatalf("start calls = %d, want 1", len(runtime.startCalls))
+	}
+	if len(runtime.closeCalls) != 1 {
+		t.Fatalf("close calls = %d, want 1 even on timeout", len(runtime.closeCalls))
+	}
+	if options.ModelConfig.Configurable || len(options.ModelConfig.Options) != 0 {
+		t.Fatalf("modelConfig = %#v, want untouched static fallback after timeout", options.ModelConfig)
+	}
+}
+
 func TestServiceGetsComposerOptionsLeavesUnresolvedProviderModelUnset(t *testing.T) {
 	runtime := newFakeRuntime()
 	service := NewService(runtime)
@@ -2569,6 +2687,7 @@ type fakeRuntime struct {
 	submitInteractiveCalls []RuntimeSubmitInteractiveInput
 	startErr               error
 	startCalls             []RuntimeStartInput
+	startHook              func(RuntimeStartInput, RuntimeSession) RuntimeSession
 	validateErr            error
 	validateCalls          []RuntimeExecInput
 }
@@ -2882,6 +3001,9 @@ func (f *fakeRuntime) Start(_ context.Context, input RuntimeStartInput) (Runtime
 		WorkspaceID:     input.WorkspaceID,
 		CreatedAtUnixMS: now,
 		UpdatedAtUnixMS: now,
+	}
+	if f.startHook != nil {
+		session = f.startHook(input, session)
 	}
 	f.sessions[input.WorkspaceID+":"+session.ID] = session
 	return session, nil

--- a/services/tuttid/service/agent/session_types.go
+++ b/services/tuttid/service/agent/session_types.go
@@ -21,9 +21,12 @@ type Service struct {
 	CapabilityLister             ComposerCapabilityLister
 	ProviderAvailabilityCacheTTL time.Duration
 	CapabilityCatalogCacheTTL    time.Duration
+	LiveModelCacheTTL            time.Duration
+	LiveModelDiscoveryTimeout    time.Duration
 	skillOptionsCache            *composerSkillOptionsCache
 	providerAvailabilityCache    *providerAvailabilityCache
 	capabilityCatalogCache       *composerCapabilityCatalogCache
+	liveModelCache               *composerLiveModelCache
 }
 
 type StaleTurnResumeReconciler interface {

--- a/services/tuttid/service/agentsidecar/claude.go
+++ b/services/tuttid/service/agentsidecar/claude.go
@@ -5,7 +5,9 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"os/exec"
 	"path/filepath"
+	"strings"
 )
 
 const claudeSystemPromptFileEnv = "TUTTI_CLAUDE_SYSTEM_PROMPT_FILE"
@@ -39,6 +41,9 @@ func (ClaudeCodePreparer) Prepare(_ context.Context, input ProviderPrepareInput)
 		claudeSystemPromptFileEnv + "=" + systemPromptPath,
 		claudePluginDirEnv + "=" + pluginDir,
 		claudeSkillListingBudgetEnv + "=" + claudeSkillListingBudgetChars,
+	}
+	if claudeExecutableEnv := claudeCodeExecutableEnv(); claudeExecutableEnv != "" {
+		env = append(env, claudeExecutableEnv)
 	}
 	// Plan mode is enabled exclusively through the ACP `set_mode("plan")` call
 	// (see effectiveModeID in the daemon runtime). We intentionally do NOT set
@@ -78,4 +83,15 @@ func installClaudeTuttiPlugin(pluginDir string, input PrepareInput) error {
 		return fmt.Errorf("install claude tutti skill plugin: %w", err)
 	}
 	return nil
+}
+
+func claudeCodeExecutableEnv() string {
+	if configured := strings.TrimSpace(os.Getenv("CLAUDE_CODE_EXECUTABLE")); configured != "" {
+		return "CLAUDE_CODE_EXECUTABLE=" + configured
+	}
+	claudePath, err := exec.LookPath("claude")
+	if err != nil {
+		return ""
+	}
+	return "CLAUDE_CODE_EXECUTABLE=" + claudePath
 }

--- a/services/tuttid/service/agentsidecar/preparer_test.go
+++ b/services/tuttid/service/agentsidecar/preparer_test.go
@@ -757,6 +757,29 @@ func TestDefaultPreparerClaudeCodeUsesSessionScopedSystemPrompt(t *testing.T) {
 	}
 }
 
+func TestDefaultPreparerClaudeCodeSetsClaudeCodeExecutableFromPath(t *testing.T) {
+	binDir := t.TempDir()
+	claudePath := filepath.Join(binDir, "claude")
+	if err := os.WriteFile(claudePath, []byte("#!/bin/sh\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", binDir)
+	t.Setenv("CLAUDE_CODE_EXECUTABLE", "")
+
+	prepared, err := NewDefaultPreparer(t.TempDir()).Prepare(t.Context(), PrepareInput{
+		WorkspaceID:    "workspace-1",
+		AgentSessionID: "session-1",
+		Provider:       "claude-code",
+		Cwd:            t.TempDir(),
+	})
+	if err != nil {
+		t.Fatalf("Prepare() error = %v", err)
+	}
+	if got := envValue(prepared.Env, "CLAUDE_CODE_EXECUTABLE"); got != claudePath {
+		t.Fatalf("CLAUDE_CODE_EXECUTABLE = %q, want %q", got, claudePath)
+	}
+}
+
 // Plan mode must NOT override CLAUDE_CONFIG_DIR. Doing so points the CLI at a
 // fresh config directory without the user's credentials, which made plan turns
 // fail with "Not logged in · Please run /login" (-32000) for OAuth users while

--- a/services/tuttid/service/cli/providers/agentcontext/composer_options.go
+++ b/services/tuttid/service/cli/providers/agentcontext/composer_options.go
@@ -11,6 +11,7 @@ import (
 
 type composerOptionsInput struct {
 	Provider                 string `cli:"provider" validate:"required"`
+	Cwd                      string `cli:"cwd"`
 	Locale                   string `cli:"locale"`
 	Model                    string `cli:"model"`
 	PermissionMode           string `cli:"permission-mode"`
@@ -23,7 +24,7 @@ func (p Provider) newComposerOptionsCommand() cliservice.Command {
 		ID:          appID + ".agent.composer-options",
 		Path:        []string{"agent", "composer-options"},
 		Summary:     "Get agent composer options",
-		Description: "Get provider-specific model and reasoning options without starting an agent session.",
+		Description: "Get provider-specific model and reasoning options without starting an agent session. Claude Code may spin up a short-lived hidden discovery session.",
 		Kind:        framework.KindGet,
 		Workspace:   framework.WorkspaceOptional,
 		Inputs:      framework.FromStruct[composerOptionsInput](),
@@ -41,7 +42,7 @@ func (p Provider) newComposerOptionsCommand() cliservice.Command {
 	})
 }
 
-func (p Provider) runComposerOptions(ctx context.Context, _ framework.InvokeContext, input composerOptionsInput) (any, error) {
+func (p Provider) runComposerOptions(ctx context.Context, invoke framework.InvokeContext, input composerOptionsInput) (any, error) {
 	if err := p.requireSessions(); err != nil {
 		return nil, err
 	}
@@ -63,8 +64,10 @@ func (p Provider) runComposerOptions(ctx context.Context, _ framework.InvokeCont
 		reasoningEffort = defaults.ReasoningEffort
 	}
 	return p.sessions.GetComposerOptions(ctx, agentservice.ComposerOptionsInput{
+		Cwd:                      input.Cwd,
 		Locale:                   locale,
 		Provider:                 input.Provider,
+		WorkspaceID:              invoke.WorkspaceID,
 		IncludeCapabilityCatalog: input.IncludeCapabilityCatalog,
 		Settings: agentservice.ComposerSettings{
 			Model:            model,


### PR DESCRIPTION
## Summary
- Add live ACP model discovery for Claude Code in tuttid `GetComposerOptions`, with caching and a hidden-session poll path.
- Extend CLI `agent composer-options` with `--cwd` and OpenAPI `workspaceId` so callers can supply the workspace context required for discovery.
- Auto-resolve `CLAUDE_CODE_EXECUTABLE` from PATH in the agentsidecar when the bundled binary is unavailable.
- Fix Agent GUI composer-options requests to fall back to workspace path when no project is selected, and route Desktop through the unified HTTP composer-options flow.

## Test plan
- [x] `go test ./services/tuttid/service/agent/...`
- [x] `go test ./services/tuttid/service/agentsidecar/...`
- [x] `go test ./services/tuttid/service/cli/providers/agentcontext/...`
- [x] pre-push checks (lint, typecheck, tests)
- [ ] In Tutti Desktop Agent GUI, select Claude Code without a project path and confirm models load
- [ ] `tutti-dev --json agent composer-options --provider claude-code --cwd "$HOME"` returns model options with `TUTTI_WORKSPACE_ID` set


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added live model discovery for Claude Code, dynamically discovering available models during runtime instead of relying on static configurations.
  * Implemented intelligent caching of discovered models to optimize performance and reduce redundant discovery operations.
  * Enhanced workspace context awareness for model discovery operations.
  * Added automatic Claude executable discovery from system PATH.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->