### PR TITLE
Serialize external registry npm installs

### DIFF
--- a/services/tuttid/service/agentstatus/install_lock.go
+++ b/services/tuttid/service/agentstatus/install_lock.go
@@ -2,6 +2,8 @@ package agentstatus
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"errors"
 	"fmt"
 	"os"
@@ -33,7 +35,7 @@ type installCommandLock struct {
 func newInstallCommandLock(command string) installCommandLock {
 	return installCommandLock{
 		command:       command,
-		lockPath:      filepath.Join(tuttitypes.TuttidRunDir(), "locks", "npm-global-install.lock"),
+		lockPath:      installCommandLockPath(command),
 		now:           time.Now,
 		pollInterval:  npmGlobalInstallLockPollInterval,
 		processExists: tuttitypes.ProcessExists,
@@ -122,7 +124,18 @@ func (l installCommandLock) Acquire(ctx context.Context) (func(), error) {
 
 func requiresInstallCommandLock(command string) bool {
 	command = strings.TrimSpace(command)
-	return strings.HasPrefix(command, "npm install -g") || strings.HasPrefix(command, "npm i -g")
+	return strings.HasPrefix(command, "npm install -g") ||
+		strings.HasPrefix(command, "npm i -g") ||
+		strings.HasPrefix(command, string(InstallerKindExternalAgentRegistryNPM)+":")
+}
+
+func installCommandLockPath(command string) string {
+	lockFile := "npm-global-install.lock"
+	if strings.HasPrefix(strings.TrimSpace(command), string(InstallerKindExternalAgentRegistryNPM)+":") {
+		sum := sha256.Sum256([]byte(strings.TrimSpace(command)))
+		lockFile = "agent-provider-install-" + hex.EncodeToString(sum[:8]) + ".lock"
+	}
+	return filepath.Join(tuttitypes.TuttidRunDir(), "locks", lockFile)
 }
 
 func RecoverDefaultInstallCommandLock() (InstallCommandLockRecoveryResult, error) {

--- a/services/tuttid/service/agentstatus/installer.go
+++ b/services/tuttid/service/agentstatus/installer.go
@@ -402,7 +402,12 @@ func installerLockCommand(spec InstallerSpec) string {
 		return spec.ShellCommand
 	}
 	if spec.Kind == InstallerKindExternalAgentRegistryNPM && spec.RegistryNPM != nil {
-		return string(spec.Kind) + ":" + spec.RegistryNPM.AgentID + ":" + spec.RegistryNPM.Package
+		return strings.Join([]string{
+			string(spec.Kind),
+			strings.TrimSpace(spec.RegistryNPM.AgentID),
+			strings.TrimSpace(spec.RegistryNPM.Package),
+			strings.TrimSpace(spec.RegistryNPM.PrefixDir),
+		}, ":")
 	}
 	return ""
 }

--- a/services/tuttid/service/agentstatus/service_test.go
+++ b/services/tuttid/service/agentstatus/service_test.go
@@ -1000,6 +1000,110 @@ func TestServiceRunActionUpgradesStaleClaudeACPAdapter(t *testing.T) {
 	}
 }
 
+func TestServiceRunActionSerializesConcurrentExternalRegistryNPMInstalls(t *testing.T) {
+	t.Setenv("TUTTI_STATE_DIR", t.TempDir())
+
+	home := t.TempDir()
+	binDir := filepath.Join(home, ".nvm", "versions", "node", "v24.12.0", "bin")
+	if err := os.MkdirAll(binDir, 0o755); err != nil {
+		t.Fatalf("mkdir bin dir: %v", err)
+	}
+	writeExecutable(t, filepath.Join(binDir, "claude"), "#!/bin/sh\nexit 0\n")
+
+	registryStore, prefixDir := fakeClaudeExternalRegistry(t)
+	runtimeRoot := fakeManagedRuntimeRoot(t)
+	packageDir := npmPackageInstallDir(prefixDir, "@agentclientprotocol/claude-agent-acp")
+	service := probeTestService(home)
+	service.ExternalAgentRegistry = registryStore
+	service.ManagedRuntime = fakeManagedRuntimeResolver(t, runtimeRoot)
+	service.RunAuthStatusCommand = func(context.Context, ProviderSpec, string) (AuthInfo, bool) {
+		return AuthInfo{Status: AuthAuthenticated}, true
+	}
+
+	firstInstallStarted := make(chan struct{})
+	releaseFirstInstall := make(chan struct{})
+	var npmInstallCalls atomic.Int32
+	var activeNPMInstalls atomic.Int32
+	var sawConcurrentInstall atomic.Bool
+	service.InstallCommand = func(ctx context.Context, input InstallCommandInput) (InstallCommandResult, error) {
+		isClaudeACPInstall := strings.Contains(input.Command, " install ") &&
+			strings.Contains(input.Command, "@agentclientprotocol/claude-agent-acp")
+		if !isClaudeACPInstall {
+			return InstallCommandResult{ExitCode: 0, Stdout: "patched"}, nil
+		}
+
+		if active := activeNPMInstalls.Add(1); active != 1 {
+			activeNPMInstalls.Add(-1)
+			sawConcurrentInstall.Store(true)
+			return InstallCommandResult{ExitCode: 90, Stderr: "concurrent npm install"}, nil
+		}
+		defer activeNPMInstalls.Add(-1)
+
+		callIndex := npmInstallCalls.Add(1)
+		if callIndex == 1 {
+			close(firstInstallStarted)
+			select {
+			case <-releaseFirstInstall:
+			case <-ctx.Done():
+				return InstallCommandResult{ExitCode: 1, Stderr: ctx.Err().Error()}, ctx.Err()
+			}
+		}
+
+		writePackageManifest(t, packageDir, "@agentclientprotocol/claude-agent-acp", "0.46.0")
+		return InstallCommandResult{ExitCode: 0, Stdout: "installed"}, nil
+	}
+
+	type runResult struct {
+		result RunActionResult
+		err    error
+	}
+	firstDone := make(chan runResult, 1)
+	go func() {
+		result, err := service.RunAction(context.Background(), RunActionInput{
+			Provider: "claude-code",
+			ActionID: ActionInstall,
+		})
+		firstDone <- runResult{result: result, err: err}
+	}()
+
+	<-firstInstallStarted
+	secondDone := make(chan runResult, 1)
+	go func() {
+		result, err := service.RunAction(context.Background(), RunActionInput{
+			Provider: "claude-code",
+			ActionID: ActionInstall,
+		})
+		secondDone <- runResult{result: result, err: err}
+	}()
+
+	time.Sleep(50 * time.Millisecond)
+	if got := npmInstallCalls.Load(); got != 1 {
+		t.Fatalf("npm install calls before releasing first install = %d, want 1", got)
+	}
+	close(releaseFirstInstall)
+
+	first := <-firstDone
+	if first.err != nil {
+		t.Fatalf("first RunAction() error = %v", first.err)
+	}
+	if first.result.Status != RunActionCompleted {
+		t.Fatalf("first status = %q, want %q; result=%#v", first.result.Status, RunActionCompleted, first.result)
+	}
+	second := <-secondDone
+	if second.err != nil {
+		t.Fatalf("second RunAction() error = %v", second.err)
+	}
+	if second.result.Status != RunActionCompleted {
+		t.Fatalf("second status = %q, want %q; result=%#v", second.result.Status, RunActionCompleted, second.result)
+	}
+	if got := npmInstallCalls.Load(); got != 2 {
+		t.Fatalf("npm install calls = %d, want serialized duplicate installs", got)
+	}
+	if sawConcurrentInstall.Load() {
+		t.Fatal("external registry npm installs overlapped")
+	}
+}
+
 func TestServiceResolveProviderCommandCreatesExternalRegistryNPMPrefix(t *testing.T) {
 	home := t.TempDir()
 	registryStore, prefixDir := fakeClaudeExternalRegistry(t)
@@ -1143,6 +1247,55 @@ func TestInstallCommandLockSerializesConcurrentNPMGlobalInstalls(t *testing.T) {
 	}
 }
 
+func TestInstallCommandLockSerializesConcurrentExternalRegistryNPMInstalls(t *testing.T) {
+	lockPath := filepath.Join(t.TempDir(), "run", "locks", "agent-provider-install.lock")
+	lock := installCommandLock{
+		command:      "external_agent_registry_npm:claude-acp:@agentclientprotocol/claude-agent-acp@0.46.0:/tmp/claude-acp",
+		lockPath:     lockPath,
+		now:          time.Now,
+		pollInterval: 10 * time.Millisecond,
+	}
+	releaseFirst, err := lock.Acquire(context.Background())
+	if err != nil {
+		t.Fatalf("Acquire() first error = %v", err)
+	}
+	defer releaseFirst()
+
+	secondAcquired := make(chan struct{})
+	secondReleased := make(chan struct{})
+	go func() {
+		releaseSecond, acquireErr := lock.Acquire(context.Background())
+		if acquireErr != nil {
+			t.Errorf("Acquire() second error = %v", acquireErr)
+			close(secondAcquired)
+			close(secondReleased)
+			return
+		}
+		close(secondAcquired)
+		releaseSecond()
+		close(secondReleased)
+	}()
+
+	select {
+	case <-secondAcquired:
+		t.Fatal("second install lock acquired before first release")
+	case <-time.After(50 * time.Millisecond):
+	}
+
+	releaseFirst()
+
+	select {
+	case <-secondAcquired:
+	case <-time.After(time.Second):
+		t.Fatal("second install lock did not acquire after first release")
+	}
+	select {
+	case <-secondReleased:
+	case <-time.After(time.Second):
+		t.Fatal("second install lock did not release")
+	}
+}
+
 func TestInstallCommandLockSkipsNonNPMCommands(t *testing.T) {
 	lockPath := filepath.Join(t.TempDir(), "run", "locks", "npm-global-install.lock")
 	var called atomic.Bool
@@ -1166,6 +1319,17 @@ func TestInstallCommandLockSkipsNonNPMCommands(t *testing.T) {
 	}
 	if _, err := os.Stat(lockPath); !errors.Is(err, os.ErrNotExist) {
 		t.Fatalf("lock file exists for non-npm command, err = %v", err)
+	}
+}
+
+func TestInstallCommandLockUsesPackageSpecificPathForExternalRegistryNPM(t *testing.T) {
+	first := installCommandLockPath("external_agent_registry_npm:claude-acp:@agentclientprotocol/claude-agent-acp@0.46.0:/tmp/claude-acp")
+	second := installCommandLockPath("external_agent_registry_npm:other-agent:other-package@1.0.0:/tmp/other-agent")
+	if filepath.Base(first) == "npm-global-install.lock" {
+		t.Fatalf("external registry npm lock path = %q, want package-specific lock", first)
+	}
+	if filepath.Base(first) == filepath.Base(second) {
+		t.Fatalf("lock paths = %q and %q, want distinct package-specific locks", first, second)
 	}
 }
 


### PR DESCRIPTION
## Summary
- add package-specific install locks for external agent registry npm installers
- include agent id, package, and prefix dir in the lock key
- cover concurrent claude-acp install behavior with regression tests

## Tests
- go test ./services/tuttid/service/agentstatus
- check:full via pre-push hook

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced external agent registry npm installation support with improved concurrent operation handling and package-specific installation management.

* **Tests**
  * Added comprehensive test coverage validating concurrent external registry npm installation serialization and distinct package-level installation tracking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->