### PR TITLE
[codex] fix live model discovery cleanup

### DIFF
--- a/services/tuttid/service/agent/composer_live_model_discovery.go
+++ b/services/tuttid/service/agent/composer_live_model_discovery.go
@@ -3,6 +3,7 @@ package agent
 import (
 	"context"
 	"errors"
+	"fmt"
 	"strings"
 	"time"
 
@@ -17,6 +18,8 @@ const (
 )
 
 var liveComposerModelDiscoveryGroup singleflight.Group
+
+var errLiveModelDiscoverySessionFailed = errors.New("live model discovery session failed")
 
 func (s *Service) liveModelDiscoveryTimeout() time.Duration {
 	if s.LiveModelDiscoveryTimeout != 0 {
@@ -115,11 +118,7 @@ func (s *Service) discoverLiveComposerModelsUncached(
 		return nil, normalizeRuntimeError(err)
 	}
 	defer func() {
-		_ = s.controller().Close(context.Background(), RuntimeCloseInput{
-			WorkspaceID:    workspaceID,
-			AgentSessionID: session.ID,
-		})
-		_ = s.cleanupRuntime(context.Background(), workspaceID, session.ID)
+		_, _ = s.Delete(context.Background(), workspaceID, session.ID)
 	}()
 	return s.pollComposerModelOptions(ctx, workspaceID, session)
 }
@@ -139,6 +138,9 @@ func (s *Service) pollComposerModelOptions(
 		if options := extractModelOptionsFromRuntimeContext(current.RuntimeContext); len(options) > 0 {
 			return options, nil
 		}
+		if err := liveModelDiscoverySessionFailureError(current); err != nil {
+			return nil, err
+		}
 		select {
 		case <-pollCtx.Done():
 			return nil, pollCtx.Err()
@@ -149,6 +151,17 @@ func (s *Service) pollComposerModelOptions(
 			}
 		}
 	}
+}
+
+func liveModelDiscoverySessionFailureError(session RuntimeSession) error {
+	if strings.TrimSpace(session.Status) != "failed" {
+		return nil
+	}
+	lastError := strings.TrimSpace(session.LastError)
+	if lastError == "" {
+		return errLiveModelDiscoverySessionFailed
+	}
+	return fmt.Errorf("%w: %s", errLiveModelDiscoverySessionFailed, lastError)
 }
 
 func extractModelOptionsFromRuntimeContext(runtimeContext map[string]any) []ComposerConfigOptionValue {

--- a/services/tuttid/service/agent/service_test.go
+++ b/services/tuttid/service/agent/service_test.go
@@ -1344,6 +1344,50 @@ func TestGetComposerOptionsClaudeCodeDiscoversLiveModels(t *testing.T) {
 	}
 }
 
+func TestGetComposerOptionsClaudeCodeDeletesHiddenDiscoverySession(t *testing.T) {
+	runtime := newFakeRuntime()
+	persisted := fakeSessionReader{sessions: map[string]PersistedSession{}}
+	runtime.startHook = func(input RuntimeStartInput, session RuntimeSession) RuntimeSession {
+		if input.Provider != "claude-code" {
+			return session
+		}
+		session.RuntimeContext = map[string]any{
+			"configOptions": []any{
+				map[string]any{
+					"id":           "model",
+					"currentValue": "default",
+					"options": []any{
+						map[string]any{"name": "Default", "value": "default"},
+					},
+				},
+			},
+		}
+		persisted.sessions[input.WorkspaceID+":"+session.ID] = PersistedSession{
+			ID:          session.ID,
+			WorkspaceID: input.WorkspaceID,
+			Provider:    input.Provider,
+			Visible:     session.Visible,
+		}
+		return session
+	}
+	service := NewService(runtime)
+	service.SessionReader = persisted
+
+	if _, err := service.GetComposerOptions(context.Background(), ComposerOptionsInput{
+		Provider:    "claude-code",
+		WorkspaceID: "ws-1",
+		Cwd:         "/repo",
+	}); err != nil {
+		t.Fatalf("GetComposerOptions returned error: %v", err)
+	}
+	if len(runtime.closeCalls) != 1 {
+		t.Fatalf("close calls = %d, want 1", len(runtime.closeCalls))
+	}
+	if len(persisted.sessions) != 0 {
+		t.Fatalf("persisted sessions = %#v, want hidden discovery session deleted", persisted.sessions)
+	}
+}
+
 func TestGetComposerOptionsClaudeCodeLiveModelsUsesCache(t *testing.T) {
 	runtime := newFakeRuntime()
 	runtime.startHook = func(input RuntimeStartInput, session RuntimeSession) RuntimeSession {
@@ -1380,6 +1424,39 @@ func TestGetComposerOptionsClaudeCodeLiveModelsUsesCache(t *testing.T) {
 	}
 	if len(runtime.closeCalls) != 1 {
 		t.Fatalf("close calls = %d, want 1 with cache", len(runtime.closeCalls))
+	}
+}
+
+func TestGetComposerOptionsClaudeCodeLiveModelsFailedStartupReturnsQuickly(t *testing.T) {
+	runtime := newFakeRuntime()
+	runtime.startHook = func(input RuntimeStartInput, session RuntimeSession) RuntimeSession {
+		if input.Provider != "claude-code" {
+			return session
+		}
+		session.Status = "failed"
+		session.LastError = "auth failed"
+		return session
+	}
+	service := NewService(runtime)
+	service.LiveModelDiscoveryTimeout = time.Second
+	startedAt := time.Now()
+
+	options, err := service.GetComposerOptions(context.Background(), ComposerOptionsInput{
+		Provider:    "claude-code",
+		WorkspaceID: "ws-failed",
+		Cwd:         "/repo",
+	})
+	if err != nil {
+		t.Fatalf("GetComposerOptions returned error: %v", err)
+	}
+	if elapsed := time.Since(startedAt); elapsed >= 400*time.Millisecond {
+		t.Fatalf("GetComposerOptions elapsed = %s, want failed discovery to return before polling timeout", elapsed)
+	}
+	if len(runtime.closeCalls) != 1 {
+		t.Fatalf("close calls = %d, want 1", len(runtime.closeCalls))
+	}
+	if options.ModelConfig.Configurable || len(options.ModelConfig.Options) != 0 {
+		t.Fatalf("modelConfig = %#v, want untouched static fallback after failed discovery", options.ModelConfig)
 	}
 }
 


### PR DESCRIPTION
## Summary
- Delete hidden Claude live model discovery sessions through the service deletion path so persisted activity records are removed.
- Stop live model polling immediately when the discovery session reports `failed`, preserving fallback composer options without waiting for the full timeout.
- Add regression coverage for hidden session deletion and fast failed-startup fallback.

## Root Cause
Live composer model discovery closed the runtime session and cleaned sidecar files, but did not delete the session from the activity projection. The polling loop also ignored failed runtime session status, so auth/runtime startup failures waited for the discovery timeout before falling back.

## Validation
- `go test ./service/agent`
- `pnpm lint:go`
- `cd services/tuttid && go test ./... && go build ./...`
- pre-push `pnpm check:full`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling for model discovery with more detailed failure information.
  * Accelerated failure detection—the system now quickly identifies failed discovery sessions instead of waiting for timeouts.
  * Enhanced cleanup of temporary discovery resources.

* **Tests**
  * Added test coverage for discovery session cleanup and failure scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->