### PR TITLE
Embed standalone onboarding app package in tuttid

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,6 +33,7 @@ __pycache__/
 *.mobileprovision
 
 *.zip
+!services/tuttid/builtin-apps/apps/**/*.zip
 *.tar
 *.tgz
 *.dmg

--- a/services/tuttid/biz/workspace/apps.go
+++ b/services/tuttid/biz/workspace/apps.go
@@ -541,8 +541,8 @@ func ValidateAppManifest(manifest AppManifest) error {
 	if !strings.HasPrefix(manifest.Runtime.HealthcheckPath, "/") {
 		return errors.New("app manifest runtime.healthcheckPath must start with /")
 	}
-	if profile := strings.TrimSpace(manifest.Runtime.Profile); profile != "" && profile != "node-static" {
-		return errors.New("app manifest runtime.profile must be node-static when set")
+	if profile := strings.TrimSpace(manifest.Runtime.Profile); profile != "" && profile != "node-static" && profile != "standalone" {
+		return errors.New("app manifest runtime.profile must be node-static or standalone when set")
 	}
 	if manifest.Window != nil {
 		minimizeBehavior := strings.TrimSpace(manifest.Window.MinimizeBehavior)

--- a/services/tuttid/biz/workspace/apps_test.go
+++ b/services/tuttid/biz/workspace/apps_test.go
@@ -252,6 +252,20 @@ func TestParseAppManifestJSONAcceptsRuntimeProfile(t *testing.T) {
 	}
 }
 
+func TestParseAppManifestJSONAcceptsStandaloneRuntimeProfile(t *testing.T) {
+	t.Parallel()
+
+	manifest, _, err := ParseAppManifestJSON([]byte(
+		`{"schemaVersion":"tutti.app.manifest.v1","appId":"test-app","version":"0.1.0","name":"Test App","description":"Test app","icon":{"type":"asset","src":"icon.png"},"runtime":{"bootstrap":"bootstrap.sh","healthcheckPath":"/healthz","profile":"standalone"}}`,
+	))
+	if err != nil {
+		t.Fatalf("ParseAppManifestJSON() error = %v, want nil for runtime.profile", err)
+	}
+	if manifest.Runtime.Profile != "standalone" {
+		t.Fatalf("Runtime.Profile = %q, want standalone", manifest.Runtime.Profile)
+	}
+}
+
 func TestParseAppManifestJSONRejectsUnsupportedRuntimeProfile(t *testing.T) {
 	t.Parallel()
 

--- a/services/tuttid/builtin-apps/catalog.go
+++ b/services/tuttid/builtin-apps/catalog.go
@@ -19,6 +19,7 @@ import (
 	workspacebiz "github.com/tutti-os/tutti/services/tuttid/biz/workspace"
 )
 
+//go:embed apps/**
 var files embed.FS
 
 type App struct {
@@ -31,15 +32,17 @@ type App struct {
 type DistributionKind string
 
 const (
-	DistributionEmbedded DistributionKind = "embedded"
-	DistributionRemote   DistributionKind = "remote"
+	DistributionEmbedded        DistributionKind = "embedded"
+	DistributionEmbeddedArchive DistributionKind = "embedded-archive"
+	DistributionRemote          DistributionKind = "remote"
 )
 
 type Distribution struct {
-	Kind           DistributionKind
-	ArtifactURL    string
-	ArtifactSHA256 string
-	IconURL        string
+	Kind                 DistributionKind
+	ArtifactURL          string
+	ArtifactSHA256       string
+	EmbeddedArtifactPath string
+	IconURL              string
 }
 
 const (
@@ -134,12 +137,69 @@ func RemoteCatalogEnvOverrideActive() bool {
 	return ok
 }
 
+func embeddedCatalog() []App {
+	minWidth := 520
+	minHeight := 640
+	return []App{
+		{
+			Manifest: workspacebiz.AppManifest{
+				SchemaVersion: workspacebiz.AppManifestSchemaVersionV1,
+				AppID:         "tutti-onboarding",
+				Version:       "0.1.0",
+				Name:          "Getting Started",
+				Description:   "Learn Tutti and Agent collaboration",
+				Icon: workspacebiz.AppManifestIcon{
+					Type: "asset",
+					Src:  "icon.webp",
+				},
+				Runtime: workspacebiz.AppManifestRuntime{
+					Bootstrap:       "bootstrap.sh",
+					HealthcheckPath: "/healthz",
+					Profile:         "standalone",
+				},
+				CLI: &workspacebiz.AppManifestCLI{
+					Manifest: "tutti.cli.json",
+				},
+				Window: &workspacebiz.AppManifestWindow{
+					MinWidth:  &minWidth,
+					MinHeight: &minHeight,
+				},
+				LocalizationInfo: &workspacebiz.AppManifestLocalizationInfo{
+					DefaultLocale: "en",
+					AdditionalLocales: []workspacebiz.AppManifestLocalizationFile{
+						{
+							Locale: "zh-CN",
+							File:   "locales/zh-CN/manifest.json",
+						},
+					},
+				},
+				Author: &workspacebiz.AppManifestAuthor{
+					Name: "Tutti",
+				},
+				Tags: []string{"onboarding", "getting-started", "workspace"},
+			},
+			Localizations: []workspacebiz.AppManifestLocalization{
+				{
+					Locale:      "zh-CN",
+					Name:        "新手指引",
+					Description: "带你快速上手 Tutti 和 Agent 协作",
+					Tags:        []string{"入门", "引导", "工作区"},
+				},
+			},
+			Distribution: Distribution{
+				Kind:                 DistributionEmbeddedArchive,
+				EmbeddedArtifactPath: "apps/tutti-onboarding/tutti-onboarding-0.1.0.zip",
+			},
+		},
+	}
+}
+
 func snapshot(refreshRemote bool) (CatalogSnapshot, error) {
 	return snapshotWithSource(currentRemoteCatalogSource(), refreshRemote)
 }
 
 func snapshotWithSource(source remoteCatalogSource, refreshRemote bool) (CatalogSnapshot, error) {
-	apps := []App{}
+	apps := embeddedCatalog()
 
 	remote, err := remoteCatalogSnapshot(source, refreshRemote)
 	if err != nil {
@@ -165,7 +225,7 @@ func snapshotAndWait(ctx context.Context) (CatalogSnapshot, error) {
 }
 
 func snapshotAndWaitWithSource(ctx context.Context, source remoteCatalogSource) (CatalogSnapshot, error) {
-	apps := []App{}
+	apps := embeddedCatalog()
 
 	remote, err := remoteCatalogSnapshotAndWait(ctx, source)
 	if err != nil {
@@ -239,6 +299,38 @@ func CopyTo(app App, destinationDir string) error {
 		}
 		return nil
 	})
+}
+
+func CopyArchiveTo(app App, destinationPath string) error {
+	if app.Distribution.Kind != DistributionEmbeddedArchive {
+		return fmt.Errorf("builtin app %q is not an embedded archive", app.Manifest.AppID)
+	}
+	if strings.TrimSpace(app.Distribution.EmbeddedArtifactPath) == "" {
+		return errors.New("builtin app embedded artifact path is required")
+	}
+	if strings.TrimSpace(destinationPath) == "" {
+		return errors.New("builtin app archive destination path is required")
+	}
+	if err := os.MkdirAll(filepath.Dir(destinationPath), 0o755); err != nil {
+		return fmt.Errorf("create builtin app archive destination parent: %w", err)
+	}
+
+	sourceFile, err := files.Open(app.Distribution.EmbeddedArtifactPath)
+	if err != nil {
+		return fmt.Errorf("open builtin app archive: %w", err)
+	}
+	defer sourceFile.Close()
+
+	targetFile, err := os.OpenFile(destinationPath, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0o644)
+	if err != nil {
+		return fmt.Errorf("open builtin app archive destination: %w", err)
+	}
+	defer targetFile.Close()
+
+	if _, err := io.Copy(targetFile, sourceFile); err != nil {
+		return fmt.Errorf("copy builtin app archive: %w", err)
+	}
+	return nil
 }
 
 func modeForBuiltinFile(relativePath string) os.FileMode {

--- a/services/tuttid/builtin-apps/catalog_test.go
+++ b/services/tuttid/builtin-apps/catalog_test.go
@@ -274,7 +274,7 @@ func TestRefreshRemoteCatalogAndWaitReturnsFailedCatalog(t *testing.T) {
 	}
 }
 
-func TestCatalogReturnsEmptyEmbeddedCatalogWhenRemoteURLFails(t *testing.T) {
+func TestCatalogReturnsEmbeddedCatalogWhenRemoteURLFails(t *testing.T) {
 	disableRemoteCatalogRetrySleepForTest(t)
 	t.Setenv(remoteCatalogFileEnv, "")
 	server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, _ *http.Request) {
@@ -287,16 +287,16 @@ func TestCatalogReturnsEmptyEmbeddedCatalogWhenRemoteURLFails(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Catalog() error = %v", err)
 	}
-	if len(apps) != 0 {
-		t.Fatalf("Catalog() apps = %#v, want empty embedded catalog", apps)
+	if app := findCatalogAppForTest(apps, "tutti-onboarding"); app == nil {
+		t.Fatalf("Catalog() apps = %#v, want embedded onboarding", apps)
 	}
 
 	snapshot := waitForCatalogStatusForTest(t, RemoteCatalogLoadStatusFailed)
 	if snapshot.RemoteCatalog.LastError == "" {
 		t.Fatal("remote catalog last error is empty, want failure details")
 	}
-	if len(snapshot.Apps) != 0 {
-		t.Fatalf("failed snapshot apps = %#v, want empty embedded catalog", snapshot.Apps)
+	if app := findCatalogAppForTest(snapshot.Apps, "tutti-onboarding"); app == nil {
+		t.Fatalf("failed snapshot apps = %#v, want embedded onboarding", snapshot.Apps)
 	}
 }
 
@@ -324,6 +324,37 @@ func TestRemoteCatalogURLDefaultsToPublishedCatalog(t *testing.T) {
 	_ = os.Setenv(remoteCatalogURLEnv, override)
 	if got := remoteCatalogURL(); got != override {
 		t.Fatalf("remoteCatalogURL() with override = %q, want %q", got, override)
+	}
+}
+
+func TestMergeCatalogsKeepsEmbeddedAppBeforeRemoteAppWithSameID(t *testing.T) {
+	embedded := embeddedCatalog()
+	if len(embedded) == 0 {
+		t.Fatal("embedded catalog is empty")
+	}
+	remoteManifest := embedded[0].Manifest
+	remoteManifest.Version = "9.9.9"
+
+	apps, err := mergeCatalogs(embedded, []App{
+		{
+			Manifest: remoteManifest,
+			Distribution: Distribution{
+				Kind:           DistributionRemote,
+				ArtifactURL:    "https://cdn.example.test/tutti-onboarding.zip",
+				ArtifactSHA256: "abc123",
+				IconURL:        "https://cdn.example.test/tutti-onboarding.webp",
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("mergeCatalogs() error = %v", err)
+	}
+	app := findCatalogAppForTest(apps, "tutti-onboarding")
+	if app == nil {
+		t.Fatalf("merged apps = %#v, want embedded onboarding", apps)
+	}
+	if app.Manifest.Version != "0.1.0" || app.Distribution.Kind != DistributionEmbeddedArchive {
+		t.Fatalf("merged onboarding = %#v, want embedded version", app)
 	}
 }
 

--- a/services/tuttid/service/workspace/app_factory_reference/references/manifest-contract.md
+++ b/services/tuttid/service/workspace/app_factory_reference/references/manifest-contract.md
@@ -44,7 +44,7 @@ Rules:
 - Do not include `runtime.kind`; Tutti manages the runtime baseline outside the app package.
 - `runtime.bootstrap` must be a relative package path.
 - `runtime.healthcheckPath` must start with `/`.
-- `runtime.profile` is optional. Use `"node-static"` only for apps whose bootstrap launches a Node/static server and does not need Python. Omit it for the default baseline runtime.
+- `runtime.profile` is optional. Use `"node-static"` only for apps whose bootstrap launches a Node/static server and does not need Python. Use `"standalone"` only for apps whose package includes its own executable server and does not need the managed Python or Node runtime. Omit it for the default baseline runtime.
 - `cli` is optional. Include it only when the app exposes commands through the Tutti CLI.
 - `cli.manifest` must be a relative package path to a `tutti.app.cli.v1` manifest, usually `tutti.cli.json`.
 - `references` is optional. Include it only when the app exposes browsable file references.

--- a/services/tuttid/service/workspace/app_factory_reference/scripts/validate_tutti_app_package.py
+++ b/services/tuttid/service/workspace/app_factory_reference/scripts/validate_tutti_app_package.py
@@ -85,8 +85,8 @@ def validate_manifest(root: Path, errors: list[str]) -> dict[str, Any] | None:
         if not isinstance(healthcheck, str) or not healthcheck.startswith("/"):
             errors.append("runtime.healthcheckPath must start with /")
         profile = runtime.get("profile")
-        if profile is not None and profile != "node-static":
-            errors.append("runtime.profile must be node-static when set")
+        if profile is not None and profile not in {"node-static", "standalone"}:
+            errors.append("runtime.profile must be node-static or standalone when set")
 
     cli = manifest.get("cli")
     if cli is not None:

--- a/services/tuttid/service/workspace/app_runtime_env.go
+++ b/services/tuttid/service/workspace/app_runtime_env.go
@@ -11,6 +11,7 @@ import (
 
 const tuttiAppRuntimeRootEnv = "TUTTI_APP_RUNTIME_ROOT"
 const workspaceAppNodeRuntimePreloadProfile = managedruntime.NodeStaticProfile
+const workspaceAppStandaloneRuntimeProfile = "standalone"
 
 type AppRuntimeResolver = managedruntime.Resolver
 type AppRuntimeProfilePreloader = managedruntime.ProfilePreloader
@@ -28,6 +29,10 @@ func appRuntimeProfileForPackage(appPackage workspacebiz.AppPackage) string {
 
 func appRuntimeProfileForManifest(manifest workspacebiz.AppManifest) string {
 	return strings.TrimSpace(manifest.Runtime.Profile)
+}
+
+func appRuntimeProfileIsStandalone(profile string) bool {
+	return strings.TrimSpace(profile) == workspaceAppStandaloneRuntimeProfile
 }
 
 func appRuntimeEnvValue(env []string, key string) string {

--- a/services/tuttid/service/workspace/apps.go
+++ b/services/tuttid/service/workspace/apps.go
@@ -93,9 +93,16 @@ func (s *AppCenterService) InitBuiltinPackages(ctx context.Context) error {
 		return err
 	}
 	for _, builtin := range builtins {
-		if builtin.Distribution.Kind == builtinapps.DistributionRemote {
+		switch builtin.Distribution.Kind {
+		case builtinapps.DistributionRemote:
+			continue
+		case builtinapps.DistributionEmbeddedArchive:
+			if _, err := s.materializeEmbeddedArchiveBuiltinPackage(ctx, builtin); err != nil {
+				return fmt.Errorf("initialize embedded builtin app archive %q: %w", builtin.Manifest.AppID, err)
+			}
 			continue
 		}
+
 		packageDir := s.packageCacheDir(builtin.Manifest.AppID, builtin.Manifest.Version)
 		if err := builtinapps.CopyTo(builtin, packageDir); err != nil {
 			return fmt.Errorf("initialize builtin app package %q: %w", builtin.Manifest.AppID, err)
@@ -281,7 +288,9 @@ func (s *AppCenterService) runInstallJob(workspaceID string, appID string, runti
 	go func() {
 		defer wg.Done()
 		var err error
-		if strings.TrimSpace(runtimeProfileHint) == workspaceAppNodeRuntimePreloadProfile {
+		if appRuntimeProfileIsStandalone(runtimeProfileHint) {
+			err = nil
+		} else if strings.TrimSpace(runtimeProfileHint) == workspaceAppNodeRuntimePreloadProfile {
 			err = s.runner().PreloadRuntimeForProfile(tracker.runtimeProgressContext(ctx), workspaceAppNodeRuntimePreloadProfile)
 		} else {
 			err = s.runner().PreloadRuntime(tracker.runtimeProgressContext(ctx))
@@ -481,7 +490,7 @@ func (s *AppCenterService) runner() *AppRunner {
 
 func (s *AppCenterService) maybePreloadRuntimeForUninstalledApps(apps []workspacebiz.WorkspaceApp) {
 	for _, app := range apps {
-		if app.Installation == nil {
+		if app.Installation == nil && !appRuntimeProfileIsStandalone(appRuntimeProfileForPackage(app.Package)) {
 			s.startRuntimePreload()
 			return
 		}

--- a/services/tuttid/service/workspace/apps_remote_builtin.go
+++ b/services/tuttid/service/workspace/apps_remote_builtin.go
@@ -64,6 +64,51 @@ func shouldMaterializeRemoteBuiltin(appPackage workspacebiz.AppPackage, builtin 
 	return validateExtractedAppPackage(appPackage.PackageDir, appPackage.Manifest) != nil
 }
 
+func (s *AppCenterService) materializeEmbeddedArchiveBuiltinPackage(ctx context.Context, builtin builtinapps.App) (workspacebiz.AppPackage, error) {
+	unlock := s.remoteBuiltinInstallLocks.Lock(builtin.Manifest.AppID + "@" + builtin.Manifest.Version)
+	defer unlock()
+
+	downloadParent := filepath.Join(s.stateDir(), "apps", "downloads")
+	if err := os.MkdirAll(downloadParent, 0o755); err != nil {
+		return workspacebiz.AppPackage{}, fmt.Errorf("create app download dir: %w", err)
+	}
+	archiveFile, err := os.CreateTemp(downloadParent, safeAppPathSegment(builtin.Manifest.AppID)+"-embedded-*.zip")
+	if err != nil {
+		return workspacebiz.AppPackage{}, fmt.Errorf("create embedded app archive file: %w", err)
+	}
+	archivePath := archiveFile.Name()
+	if err := archiveFile.Close(); err != nil {
+		return workspacebiz.AppPackage{}, fmt.Errorf("close embedded app archive file: %w", err)
+	}
+	defer func() {
+		_ = os.Remove(archivePath)
+	}()
+
+	startedAt := time.Now()
+	slog.Info(
+		"embedded builtin app package materialize started",
+		"appId", builtin.Manifest.AppID,
+		"version", builtin.Manifest.Version,
+		"artifactPath", builtin.Distribution.EmbeddedArtifactPath,
+		"archivePath", archivePath,
+	)
+	if err := builtinapps.CopyArchiveTo(builtin, archivePath); err != nil {
+		return workspacebiz.AppPackage{}, err
+	}
+	appPackage, err := s.materializeBuiltinArchivePackage(ctx, builtin, archivePath, true)
+	if err != nil {
+		return workspacebiz.AppPackage{}, err
+	}
+	slog.Info(
+		"embedded builtin app package materialize completed",
+		"appId", builtin.Manifest.AppID,
+		"version", builtin.Manifest.Version,
+		"artifactPath", builtin.Distribution.EmbeddedArtifactPath,
+		"duration", time.Since(startedAt),
+	)
+	return appPackage, nil
+}
+
 func (s *AppCenterService) downloadRemoteBuiltinPackage(ctx context.Context, builtin builtinapps.App) (workspacebiz.AppPackage, error) {
 	artifactURL := strings.TrimSpace(builtin.Distribution.ArtifactURL)
 	artifactSHA256 := strings.TrimSpace(builtin.Distribution.ArtifactSHA256)
@@ -125,10 +170,14 @@ func (s *AppCenterService) downloadRemoteBuiltinPackage(ctx context.Context, bui
 		return workspacebiz.AppPackage{}, fmt.Errorf("remote builtin app %q artifact sha256 mismatch", builtin.Manifest.AppID)
 	}
 
+	return s.materializeBuiltinArchivePackage(ctx, builtin, archivePath, false)
+}
+
+func (s *AppCenterService) materializeBuiltinArchivePackage(ctx context.Context, builtin builtinapps.App, archivePath string, activate bool) (workspacebiz.AppPackage, error) {
 	stagingParent := filepath.Join(s.stateDir(), "apps")
 	stagingDir, err := os.MkdirTemp(stagingParent, "remote-builtin-*")
 	if err != nil {
-		return workspacebiz.AppPackage{}, fmt.Errorf("create remote builtin staging dir: %w", err)
+		return workspacebiz.AppPackage{}, fmt.Errorf("create builtin app staging dir: %w", err)
 	}
 	defer func() {
 		_ = os.RemoveAll(stagingDir)
@@ -153,13 +202,13 @@ func (s *AppCenterService) downloadRemoteBuiltinPackage(ctx context.Context, bui
 
 	packageDir := s.packageCacheDir(manifest.AppID, manifest.Version)
 	if err := os.RemoveAll(packageDir); err != nil {
-		return workspacebiz.AppPackage{}, fmt.Errorf("replace remote builtin app package dir: %w", err)
+		return workspacebiz.AppPackage{}, fmt.Errorf("replace builtin app package dir: %w", err)
 	}
 	if err := copyDirectory(packageRoot, packageDir); err != nil {
-		return workspacebiz.AppPackage{}, fmt.Errorf("copy remote builtin app package: %w", err)
+		return workspacebiz.AppPackage{}, fmt.Errorf("copy builtin app package: %w", err)
 	}
 	if err := validateExtractedAppPackage(packageDir, manifest); err != nil {
-		return workspacebiz.AppPackage{}, fmt.Errorf("validate copied remote builtin app package: %w", err)
+		return workspacebiz.AppPackage{}, fmt.Errorf("validate copied builtin app package: %w", err)
 	}
 	appPackage := workspacebiz.AppPackage{
 		AppID:        manifest.AppID,
@@ -169,8 +218,14 @@ func (s *AppCenterService) downloadRemoteBuiltinPackage(ctx context.Context, bui
 		ManifestJSON: manifestJSON,
 		Source:       workspacebiz.AppPackageSourceBuiltin,
 	}
-	if err := s.Store.PutAppPackageVersion(ctx, appPackage); err != nil {
-		return workspacebiz.AppPackage{}, err
+	if activate {
+		if err := s.Store.PutAppPackage(ctx, appPackage); err != nil {
+			return workspacebiz.AppPackage{}, err
+		}
+	} else {
+		if err := s.Store.PutAppPackageVersion(ctx, appPackage); err != nil {
+			return workspacebiz.AppPackage{}, err
+		}
 	}
 	return appPackage, nil
 }

--- a/services/tuttid/service/workspace/apps_runner.go
+++ b/services/tuttid/service/workspace/apps_runner.go
@@ -126,6 +126,9 @@ func (r *AppRunner) PreloadRuntime(ctx context.Context) error {
 
 func (r *AppRunner) PreloadRuntimeForProfile(ctx context.Context, profile string) error {
 	r.ensure()
+	if appRuntimeProfileIsStandalone(profile) {
+		return nil
+	}
 	resolver := r.runtimeResolver()
 	if preloader, ok := resolver.(AppRuntimeProfilePreloader); ok {
 		return preloader.PreloadProfile(ctx, profile)
@@ -611,6 +614,9 @@ func (r *AppRunner) runtimeResolver() AppRuntimeResolver {
 
 func (r *AppRunner) resolveRuntime(ctx context.Context, profile string) (ResolvedAppRuntime, error) {
 	profile = strings.TrimSpace(profile)
+	if appRuntimeProfileIsStandalone(profile) {
+		return ResolvedAppRuntime{}, nil
+	}
 	resolver := r.runtimeResolver()
 	if profile != "" {
 		if profileResolver, ok := resolver.(AppRuntimeProfileResolver); ok {
@@ -684,7 +690,11 @@ func tuttiCLIShimPath() string {
 
 func appRuntimePathWithCLIShim(appRuntime ResolvedAppRuntime, cliShimPath string) string {
 	pathKey := pathEnvKey(appRuntime.EnvOverrides)
-	pathDirs := filepath.SplitList(envValue(appRuntime.EnvOverrides, pathKey))
+	pathValue := envValue(appRuntime.EnvOverrides, pathKey)
+	if strings.TrimSpace(pathValue) == "" {
+		pathValue = os.Getenv(pathKey)
+	}
+	pathDirs := filepath.SplitList(pathValue)
 	pathDirs = mergeAppPathDirs(append([]string{filepath.Dir(cliShimPath)}, pathDirs...))
 	return pathKey + "=" + strings.Join(pathDirs, string(os.PathListSeparator))
 }

--- a/services/tuttid/service/workspace/apps_runner_test.go
+++ b/services/tuttid/service/workspace/apps_runner_test.go
@@ -144,6 +144,71 @@ exec "$TUTTI_APP_PYTHON" "$TUTTI_APP_PACKAGE_DIR/server.py"
 	}
 }
 
+func TestAppRunnerStartsStandaloneAppWithoutResolvingManagedRuntime(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("bootstrap.sh runner test is POSIX-only")
+	}
+	if _, err := exec.LookPath("python3"); err != nil {
+		t.Skip("python3 is required for runner standalone test")
+	}
+
+	root := t.TempDir()
+	packageDir := filepath.Join(root, "package")
+	runtimeDir := filepath.Join(root, "runtime")
+	dataDir := filepath.Join(root, "data")
+	logDir := filepath.Join(root, "logs")
+	if err := os.MkdirAll(packageDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll(packageDir) error = %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(packageDir, "bootstrap.sh"), []byte(`#!/bin/sh
+set -eu
+exec python3 "$TUTTI_APP_PACKAGE_DIR/server.py"
+`), 0o755); err != nil {
+		t.Fatalf("WriteFile(bootstrap.sh) error = %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(packageDir, "server.py"), []byte(pythonAppReadyServerScript("/healthz", false)), 0o644); err != nil {
+		t.Fatalf("WriteFile(server.py) error = %v", err)
+	}
+
+	resolver := &appRuntimeResolverStub{called: make(chan struct{})}
+	runner := &AppRunner{
+		HealthcheckTimeout: 10 * time.Second,
+		RuntimeResolver:    resolver,
+	}
+	state, err := runner.Start(context.Background(), AppStartInput{
+		WorkspaceID:     "ws-runner",
+		WorkspaceName:   "Runner Workspace",
+		WorkspaceRoot:   root,
+		AppID:           "standalone",
+		PackageDir:      packageDir,
+		Bootstrap:       "bootstrap.sh",
+		HealthcheckPath: "/healthz",
+		RuntimeProfile:  workspaceAppStandaloneRuntimeProfile,
+		RuntimeDir:      runtimeDir,
+		DataDir:         dataDir,
+		LogDir:          logDir,
+	})
+	if err != nil {
+		t.Fatalf("Start() error = %v", err)
+	}
+	t.Cleanup(func() {
+		_, _ = runner.Stop(context.Background(), "ws-runner", "standalone")
+	})
+	if state.Status != workspacebiz.AppRuntimeStatusPreparing {
+		t.Fatalf("Start() status = %q, want preparing, lastError=%v", state.Status, state.LastError)
+	}
+	state = waitForRunnerStatus(t, runner, "ws-runner", "standalone", workspacebiz.AppRuntimeStatusRunning)
+	if state.LaunchURL == nil || !strings.HasPrefix(*state.LaunchURL, "http://127.0.0.1:") {
+		t.Fatalf("LaunchURL = %v", state.LaunchURL)
+	}
+
+	select {
+	case <-resolver.called:
+		t.Fatal("standalone app resolved managed runtime")
+	default:
+	}
+}
+
 func TestAppRunnerRestartStartsFreshProcessAndWritesStartupDiagnostic(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("bootstrap.sh runner test is POSIX-only")

--- a/services/tuttid/service/workspace/apps_test.go
+++ b/services/tuttid/service/workspace/apps_test.go
@@ -456,6 +456,54 @@ func TestAppCenterServiceListPreloadsRuntimeForUninstalledApps(t *testing.T) {
 	}
 }
 
+func TestAppCenterServiceListSkipsRuntimePreloadForUninstalledStandaloneApp(t *testing.T) {
+	t.Parallel()
+
+	store := newAppStoreStub()
+	appPackage := workspacebiz.AppPackage{
+		AppID:   "standalone-app",
+		Version: "1.0.0",
+		Manifest: workspacebiz.AppManifest{
+			SchemaVersion: workspacebiz.AppManifestSchemaVersionV1,
+			AppID:         "standalone-app",
+			Version:       "1.0.0",
+			Name:          "Standalone App",
+			Runtime: workspacebiz.AppManifestRuntime{
+				Bootstrap:       "bootstrap.sh",
+				HealthcheckPath: "/",
+				Profile:         workspaceAppStandaloneRuntimeProfile,
+			},
+		},
+		Source: workspacebiz.AppPackageSourceGenerated,
+	}
+	if err := store.PutAppPackage(context.Background(), appPackage); err != nil {
+		t.Fatalf("PutAppPackage() error = %v", err)
+	}
+	resolver := &appRuntimeResolverStub{called: make(chan struct{})}
+	service := AppCenterService{
+		Store:          store,
+		WorkspaceStore: &catalogStoreStub{getWorkspace: workspacebiz.Summary{ID: "ws-1", Name: "Workspace"}},
+		Runner:         &AppRunner{RuntimeResolver: resolver},
+		StateDir:       t.TempDir(),
+		BuiltinCatalog: func() ([]builtinapps.App, error) {
+			return nil, nil
+		},
+	}
+
+	apps, err := service.List(context.Background(), "ws-1")
+	if err != nil {
+		t.Fatalf("List() error = %v", err)
+	}
+	if len(apps) != 1 || apps[0].Installation != nil {
+		t.Fatalf("List() apps = %#v", apps)
+	}
+	select {
+	case <-resolver.called:
+		t.Fatalf("List() preloaded runtime for uninstalled standalone app")
+	default:
+	}
+}
+
 func TestAppCenterServiceListSkipsRuntimePreloadWhenAllAppsInstalled(t *testing.T) {
 	t.Parallel()
 
@@ -591,8 +639,15 @@ func TestAppCenterServiceInitializesBuiltinCatalogAndInstallState(t *testing.T) 
 	if err != nil {
 		t.Fatalf("List() error = %v", err)
 	}
-	if len(apps) != 0 {
-		t.Fatalf("List() = %#v, want no embedded apps", apps)
+	onboarding := findWorkspaceAppForTest(apps, "tutti-onboarding")
+	if onboarding == nil {
+		t.Fatalf("List() = %#v, want embedded onboarding", apps)
+	}
+	if onboarding.Package.Manifest.Runtime.Profile != workspaceAppStandaloneRuntimeProfile {
+		t.Fatalf("onboarding runtime profile = %q, want standalone", onboarding.Package.Manifest.Runtime.Profile)
+	}
+	if _, err := os.Stat(filepath.Join(onboarding.Package.PackageDir, "bin", "darwin-arm64", "tutti-onboarding-server")); err != nil {
+		t.Fatalf("onboarding embedded server missing: %v", err)
 	}
 }
 
@@ -617,8 +672,8 @@ func TestAppCenterServiceInitializesBuiltinPackagesWhenRemoteCatalogFails(t *tes
 	}
 	if packages, err := store.ListAppPackages(context.Background()); err != nil {
 		t.Fatalf("ListAppPackages() error = %v", err)
-	} else if len(packages) != 0 {
-		t.Fatalf("ListAppPackages() = %#v, want no embedded packages", packages)
+	} else if len(packages) != 1 || packages[0].AppID != "tutti-onboarding" {
+		t.Fatalf("ListAppPackages() = %#v, want embedded onboarding package", packages)
 	}
 	state := service.CatalogLoadState()
 	if state.Status != workspacebiz.AppCatalogLoadStatusLoading && state.Status != workspacebiz.AppCatalogLoadStatusFailed {


### PR DESCRIPTION
## Summary\n- add standalone runtime profile support for workspace apps\n- embed the generated tutti-onboarding package zip in tuttid builtin apps\n- initialize embedded archive packages locally and skip Node runtime preload for standalone apps\n\n## Tests\n- go test ./services/tuttid/biz/workspace ./services/tuttid/builtin-apps ./services/tuttid/service/workspace\n- pnpm check:full

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for standalone app runtime profiles, allowing apps to run without managed runtime dependencies
  * Built-in applications can now be distributed as embedded archives
  * Embedded onboarding application included and installed by default

* **Improvements**
  * Runtime preload skipped for standalone apps for faster startup
  * Embedded apps persist even when remote catalog fetch fails

<!-- end of auto-generated comment: release notes by coderabbit.ai -->