### PR TITLE
Speed up onboarding auto-open startup

### DIFF
--- a/apps/desktop/src/renderer/src/features/workspace-app-center/services/internal/workspaceAppCenterService.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-app-center/services/internal/workspaceAppCenterService.ts
@@ -551,17 +551,45 @@ export class WorkspaceAppCenterService implements IWorkspaceAppCenterService {
     markConnected: () => void,
     markStartupRefreshSettled: () => void
   ): Promise<void> {
+    const startedAt = Date.now();
+    this.logStartupDiagnostic("app_center.start_workspace_updates.started", {
+      workspaceId
+    });
     try {
+      const connectStartedAt = Date.now();
       await this.dependencies.eventStreamClient.connect();
+      this.logStartupDiagnostic(
+        "app_center.start_workspace_updates.event_stream_connected",
+        {
+          durationMs: Date.now() - connectStartedAt,
+          workspaceId
+        }
+      );
       if (isDisposed()) {
         return;
       }
+      const refreshStartedAt = Date.now();
       await this.controller.refresh(workspaceId);
+      this.logStartupDiagnostic(
+        "app_center.start_workspace_updates.initial_refreshed",
+        {
+          durationMs: Date.now() - refreshStartedAt,
+          workspaceId
+        }
+      );
       if (isDisposed()) {
         return;
       }
       markConnected();
+      const startEnabledStartedAt = Date.now();
       await this.controller.startEnabledApps(workspaceId);
+      this.logStartupDiagnostic(
+        "app_center.start_workspace_updates.start_enabled_completed",
+        {
+          durationMs: Date.now() - startEnabledStartedAt,
+          workspaceId
+        }
+      );
     } catch (error) {
       if (isDisposed()) {
         return;
@@ -571,8 +599,30 @@ export class WorkspaceAppCenterService implements IWorkspaceAppCenterService {
         workspaceId
       });
     } finally {
+      this.logStartupDiagnostic("app_center.start_workspace_updates.settled", {
+        durationMs: Date.now() - startedAt,
+        workspaceId
+      });
       markStartupRefreshSettled();
     }
+  }
+
+  private logStartupDiagnostic(
+    event: string,
+    details: Record<string, unknown>
+  ): void {
+    void this.dependencies.runtimeApi
+      ?.logRendererDiagnostic({
+        details,
+        event,
+        level: "debug",
+        source: "workspace-app-center",
+        workspaceId:
+          typeof details.workspaceId === "string"
+            ? details.workspaceId
+            : undefined
+      })
+      .catch(() => undefined);
   }
 
   private recordOperationFailure(

--- a/apps/desktop/src/renderer/src/features/workspace-workbench/ui/useWorkspaceOnboardingAutoOpen.test.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/ui/useWorkspaceOnboardingAutoOpen.test.ts
@@ -2,6 +2,66 @@ import assert from "node:assert/strict";
 import test from "node:test";
 import { openWorkspaceOnboardingIfNeeded } from "./useWorkspaceOnboardingAutoOpen.ts";
 
+test("workspace onboarding auto-open uses local app list before refreshing remote catalog", async () => {
+  let catalogRefreshCalls = 0;
+  const result = await openWorkspaceOnboardingIfNeeded({
+    appCenterService: {
+      store: {
+        apps: [
+          {
+            appId: "tutti-onboarding",
+            installed: true
+          }
+        ]
+      },
+      async refresh() {},
+      async refreshCatalog() {
+        catalogRefreshCalls += 1;
+      },
+      async installApp() {},
+      async openApp() {
+        return true;
+      }
+    },
+    wait: async () => {},
+    workbenchHostService: createWorkbenchHostService(),
+    workspaceId: "workspace-1"
+  });
+
+  assert.equal(result, "opened");
+  assert.equal(catalogRefreshCalls, 0);
+});
+
+test("workspace onboarding auto-open falls back to remote catalog when app is missing locally", async () => {
+  let catalogRefreshCalls = 0;
+  const apps: { appId: string; installed?: boolean }[] = [];
+  const result = await openWorkspaceOnboardingIfNeeded({
+    appCenterService: {
+      store: {
+        apps
+      },
+      async refresh() {},
+      async refreshCatalog() {
+        catalogRefreshCalls += 1;
+        apps.push({
+          appId: "tutti-onboarding",
+          installed: true
+        });
+      },
+      async installApp() {},
+      async openApp() {
+        return true;
+      }
+    },
+    wait: async () => {},
+    workbenchHostService: createWorkbenchHostService(),
+    workspaceId: "workspace-1"
+  });
+
+  assert.equal(result, "opened");
+  assert.equal(catalogRefreshCalls, 1);
+});
+
 test("workspace onboarding auto-open retries when the first open does not launch", async () => {
   let markCalls = 0;
   let openCalls = 0;

--- a/apps/desktop/src/renderer/src/features/workspace-workbench/ui/useWorkspaceOnboardingAutoOpen.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/ui/useWorkspaceOnboardingAutoOpen.ts
@@ -64,14 +64,17 @@ export async function openWorkspaceOnboardingIfNeeded({
     appId,
     event: "workspace-onboarding.auto-open.started",
     level: "info",
+    catalogStrategy: "local-first",
     maxAttempts,
     workspaceId
   });
+  const markerCheckStartedAt = Date.now();
   if (
     await workbenchHostService.hasWorkspaceOnboardingAutoOpened(workspaceId)
   ) {
     logAutoOpenDiagnostic(workbenchHostService, {
       appId,
+      durationMs: Date.now() - markerCheckStartedAt,
       event: "workspace-onboarding.auto-open.already-opened",
       level: "info",
       maxAttempts,
@@ -79,17 +82,17 @@ export async function openWorkspaceOnboardingIfNeeded({
     });
     return "already-opened";
   }
-
-  await appCenterService.refreshCatalog(workspaceId);
   logAutoOpenDiagnostic(workbenchHostService, {
     appId,
-    event: "workspace-onboarding.auto-open.catalog-refreshed",
+    durationMs: Date.now() - markerCheckStartedAt,
+    event: "workspace-onboarding.auto-open.marker-checked",
     level: "debug",
     maxAttempts,
     workspaceId
   });
 
   let openAttempted = false;
+  let catalogFallbackAttempted = false;
   for (let attempt = 0; attempt < maxAttempts; attempt += 1) {
     const attemptNumber = attempt + 1;
     if (isCanceled()) {
@@ -104,7 +107,17 @@ export async function openWorkspaceOnboardingIfNeeded({
       });
       return "canceled";
     }
+    const refreshStartedAt = Date.now();
     await appCenterService.refresh(workspaceId);
+    logAutoOpenDiagnostic(workbenchHostService, {
+      appId,
+      attempt: attemptNumber,
+      durationMs: Date.now() - refreshStartedAt,
+      event: "workspace-onboarding.auto-open.local-refreshed",
+      level: "debug",
+      maxAttempts,
+      workspaceId
+    });
     const app = appCenterService.store.apps.find(
       (candidate) => candidate.appId === appId
     );
@@ -117,7 +130,23 @@ export async function openWorkspaceOnboardingIfNeeded({
         maxAttempts,
         workspaceId
       });
-      await wait(500);
+      if (!catalogFallbackAttempted) {
+        catalogFallbackAttempted = true;
+        const catalogRefreshStartedAt = Date.now();
+        await appCenterService.refreshCatalog(workspaceId);
+        logAutoOpenDiagnostic(workbenchHostService, {
+          appId,
+          attempt: attemptNumber,
+          durationMs: Date.now() - catalogRefreshStartedAt,
+          event: "workspace-onboarding.auto-open.catalog-refreshed",
+          level: "debug",
+          maxAttempts,
+          reason: "app-missing-fallback",
+          workspaceId
+        });
+        continue;
+      }
+      await wait(250);
       continue;
     }
     if (!app.installed) {
@@ -129,31 +158,35 @@ export async function openWorkspaceOnboardingIfNeeded({
         maxAttempts,
         workspaceId
       });
+      const installStartedAt = Date.now();
       await appCenterService.installApp({ appId, workspaceId });
       logAutoOpenDiagnostic(workbenchHostService, {
         appId,
         attempt: attemptNumber,
+        durationMs: Date.now() - installStartedAt,
         event: "workspace-onboarding.auto-open.install-completed",
         level: "info",
         maxAttempts,
         workspaceId
       });
-      await wait(500);
+      await wait(250);
       continue;
     }
 
     openAttempted = true;
+    const openStartedAt = Date.now();
     const opened = await appCenterService.openApp({ appId, workspaceId });
     if (!opened) {
       logAutoOpenDiagnostic(workbenchHostService, {
         appId,
         attempt: attemptNumber,
+        durationMs: Date.now() - openStartedAt,
         event: "workspace-onboarding.auto-open.launch-not-ready",
         level: "warn",
         maxAttempts,
         workspaceId
       });
-      await wait(500);
+      await wait(250);
       continue;
     }
     if (isCanceled()) {
@@ -172,6 +205,7 @@ export async function openWorkspaceOnboardingIfNeeded({
     logAutoOpenDiagnostic(workbenchHostService, {
       appId,
       attempt: attemptNumber,
+      durationMs: Date.now() - openStartedAt,
       event: "workspace-onboarding.auto-open.opened",
       level: "info",
       maxAttempts,
@@ -219,14 +253,35 @@ export function useWorkspaceOnboardingAutoOpen({
   useEffect(() => {
     const normalizedWorkspaceId = workspaceId.trim();
     if (!workbenchHost || !normalizedWorkspaceId) {
+      if (normalizedWorkspaceId) {
+        logAutoOpenDiagnostic(workbenchHostService, {
+          event: "workspace-onboarding.auto-open.effect-waiting",
+          level: "debug",
+          reason: !workbenchHost
+            ? "workbench-host-missing"
+            : "workspace-id-missing",
+          workspaceId: normalizedWorkspaceId
+        });
+      }
       return;
     }
     if (activeWorkspaceIdsRef.current.has(normalizedWorkspaceId)) {
+      logAutoOpenDiagnostic(workbenchHostService, {
+        event: "workspace-onboarding.auto-open.effect-skipped",
+        level: "debug",
+        reason: "workspace-already-active",
+        workspaceId: normalizedWorkspaceId
+      });
       return;
     }
 
     let canceled = false;
     activeWorkspaceIdsRef.current.add(normalizedWorkspaceId);
+    logAutoOpenDiagnostic(workbenchHostService, {
+      event: "workspace-onboarding.auto-open.effect-ready",
+      level: "debug",
+      workspaceId: normalizedWorkspaceId
+    });
     void openWorkspaceOnboardingIfNeeded({
       appCenterService,
       isCanceled: () => canceled,
@@ -264,6 +319,8 @@ function logAutoOpenDiagnostic(
   input: {
     appId?: string;
     attempt?: number;
+    catalogStrategy?: string;
+    durationMs?: number;
     event: string;
     level: "debug" | "info" | "warn" | "error";
     maxAttempts?: number;

--- a/services/tuttid/service/workspace/apps_runtime.go
+++ b/services/tuttid/service/workspace/apps_runtime.go
@@ -70,9 +70,6 @@ func (s *AppCenterService) StartEnabled(ctx context.Context, workspaceID string)
 	if _, err := s.workspaceSummary(ctx, workspaceID); err != nil {
 		return nil, err
 	}
-	if err := s.refreshBuiltinCatalogForStartEnabled(ctx, workspaceID); err != nil {
-		return nil, err
-	}
 	installations, err := s.Store.ListWorkspaceAppInstallations(ctx, workspaceID)
 	if err != nil {
 		return nil, err
@@ -84,12 +81,21 @@ func (s *AppCenterService) StartEnabled(ctx context.Context, workspaceID string)
 		}
 	}
 	var builtins []builtinapps.App
-	builtins, err = s.builtinCatalog(ctx)
-	if err != nil {
-		slog.Warn("workspace app start remote builtin sync skipped; builtin catalog unavailable", "workspaceId", workspaceID, "error", err)
+	slog.Info("workspace app start enabled started", "workspaceId", workspaceID, "enabledAppCount", len(enabledAppIDs))
+	if len(enabledAppIDs) > 0 {
+		refreshStartedAt := time.Now()
+		if err := s.refreshBuiltinCatalogForStartEnabled(ctx, workspaceID); err != nil {
+			return nil, err
+		}
+		slog.Info("workspace app start enabled remote catalog refresh completed", "workspaceId", workspaceID, "enabledAppCount", len(enabledAppIDs), "durationMs", time.Since(refreshStartedAt).Milliseconds())
+		builtins, err = s.builtinCatalog(ctx)
+		if err != nil {
+			slog.Warn("workspace app start remote builtin sync skipped; builtin catalog unavailable", "workspaceId", workspaceID, "error", err)
+		}
+	} else {
+		slog.Info("workspace app start enabled remote catalog refresh skipped", "workspaceId", workspaceID, "enabledAppCount", len(enabledAppIDs), "reason", "no-enabled-apps")
 	}
 	remoteBuiltins := remoteBuiltinByAppID(builtins)
-	slog.Info("workspace app start enabled started", "workspaceId", workspaceID, "enabledAppCount", len(enabledAppIDs))
 
 	remoteBuiltinInstallStarted := false
 	for _, installation := range installations {
@@ -148,7 +154,7 @@ func (s *AppCenterService) StartEnabled(ctx context.Context, workspaceID string)
 			return nil, err
 		}
 	}
-	slog.Info("workspace app start enabled completed", "workspaceId", workspaceID, "enabledAppCount", len(enabledAppIDs), "duration", time.Since(startedAt))
+	slog.Info("workspace app start enabled completed", "workspaceId", workspaceID, "enabledAppCount", len(enabledAppIDs), "duration", time.Since(startedAt), "durationMs", time.Since(startedAt).Milliseconds())
 	if !remoteBuiltinInstallStarted {
 		s.startRuntimePreload()
 	}

--- a/services/tuttid/service/workspace/apps_test.go
+++ b/services/tuttid/service/workspace/apps_test.go
@@ -1440,7 +1440,7 @@ func TestAppCenterServiceStartEnabledWaitsForRemoteCatalogRefresh(t *testing.T) 
 	}
 }
 
-func TestAppCenterServiceStartEnabledPreloadsRuntimeAfterRemoteCatalogRefresh(t *testing.T) {
+func TestAppCenterServiceStartEnabledDoesNotWaitForRemoteCatalogWhenNoAppsAreEnabled(t *testing.T) {
 	ctx := context.Background()
 	t.Setenv("TUTTI_APP_CATALOG_FILE", "")
 
@@ -1483,20 +1483,6 @@ func TestAppCenterServiceStartEnabledPreloadsRuntimeAfterRemoteCatalogRefresh(t 
 	}()
 
 	select {
-	case <-catalogRequested:
-	case err := <-resultCh:
-		t.Fatalf("StartEnabled() returned before catalog request completed: %v", err)
-	case <-time.After(time.Second):
-		t.Fatal("remote catalog was not requested")
-	}
-	select {
-	case <-resolver.called:
-		t.Fatal("runtime preload started before catalog refresh completed")
-	case <-time.After(50 * time.Millisecond):
-	}
-
-	releaseCatalogResponse()
-	select {
 	case err := <-resultCh:
 		if err != nil {
 			t.Fatalf("StartEnabled() error = %v", err)
@@ -1507,8 +1493,14 @@ func TestAppCenterServiceStartEnabledPreloadsRuntimeAfterRemoteCatalogRefresh(t 
 	select {
 	case <-resolver.called:
 	case <-time.After(time.Second):
-		t.Fatal("runtime preload did not start after catalog refresh")
+		t.Fatal("runtime preload did not start")
 	}
+
+	select {
+	case <-catalogRequested:
+	case <-time.After(50 * time.Millisecond):
+	}
+	releaseCatalogResponse()
 	resolver.mu.Lock()
 	preloadedProfile := resolver.profile
 	resolver.mu.Unlock()


### PR DESCRIPTION
## Summary
- Make onboarding auto-open use local app state first and only refresh the remote catalog as a fallback.
- Skip blocking remote catalog refresh in StartEnabled when no workspace apps are enabled.
- Add renderer and daemon timing diagnostics for onboarding/App Center startup.

## Test Plan
- pnpm check:full
- go test ./services/tuttid/service/workspace
- node --import ./apps/desktop/test/register-asset-stub.mjs --test --experimental-strip-types ./apps/desktop/src/renderer/src/features/workspace-workbench/ui/useWorkspaceOnboardingAutoOpen.test.ts
- pnpm exec oxlint apps/desktop/src/renderer/src/features/workspace-app-center/services/internal/workspaceAppCenterService.ts apps/desktop/src/renderer/src/features/workspace-workbench/ui/useWorkspaceOnboardingAutoOpen.ts apps/desktop/src/renderer/src/features/workspace-workbench/ui/useWorkspaceOnboardingAutoOpen.test.ts --deny-warnings

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added comprehensive diagnostics logging for workspace startup and app auto-open processes to improve observability.

* **Performance**
  * Optimized catalog refresh logic to skip unnecessary remote updates when no enabled apps exist.
  * Improved retry timing for faster app open responsiveness.

* **Bug Fixes**
  * Enhanced app discovery with conditional catalog refresh fallback when apps are missing from the local catalog.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->