### PR TITLE
Support custom PDF page sizes for workspace apps

### DIFF
--- a/apps/desktop/src/main/ipc/workspaceAppContext.ts
+++ b/apps/desktop/src/main/ipc/workspaceAppContext.ts
@@ -485,6 +485,7 @@ async function printWorkspaceAppHtmlToPdf(
     const pdf = await printWindow.webContents.printToPDF({
       margins: printMargins(input.margin),
       pageSize: input.pageSize ?? "A4",
+      preferCSSPageSize: input.preferCSSPageSize === true,
       printBackground: input.printBackground !== false
     });
     return { bytes: new Uint8Array(pdf) };
@@ -517,7 +518,9 @@ function loadPrintHtml(
     };
     const handleFailed: WorkspaceAppPrintLoadListener = (...args) => {
       const errorDescription =
-        typeof args[2] === "string" ? args[2] : "PDF print HTML failed to load.";
+        typeof args[2] === "string"
+          ? args[2]
+          : "PDF print HTML failed to load.";
       cleanup();
       reject(new Error(errorDescription));
     };
@@ -531,7 +534,9 @@ function loadPrintHtml(
 }
 
 function preparePrintHtml(input: TuttiExternalPdfPrintHtmlInput): string {
-  const base = input.baseUrl ? `<base href="${escapeHtml(input.baseUrl)}">` : "";
+  const base = input.baseUrl
+    ? `<base href="${escapeHtml(input.baseUrl)}">`
+    : "";
   const title = input.title ? `<title>${escapeHtml(input.title)}</title>` : "";
   const printHead = `${base}${title}`;
   if (!printHead) {

--- a/packages/workspace/external-core/src/contracts/index.ts
+++ b/packages/workspace/external-core/src/contracts/index.ts
@@ -190,11 +190,20 @@ export interface TuttiExternalPdfMargin {
   top?: string;
 }
 
+export type TuttiExternalPdfPageSize =
+  | "A4"
+  | "Letter"
+  | {
+      height: number;
+      width: number;
+    };
+
 export interface TuttiExternalPdfPrintHtmlInput {
   baseUrl?: string;
   html: string;
   margin?: TuttiExternalPdfMargin;
-  pageSize?: "A4" | "Letter";
+  pageSize?: TuttiExternalPdfPageSize;
+  preferCSSPageSize?: boolean;
   printBackground?: boolean;
   title?: string;
 }

--- a/packages/workspace/external-core/src/core/index.test.ts
+++ b/packages/workspace/external-core/src/core/index.test.ts
@@ -194,7 +194,8 @@ test("normalizes PDF print HTML input", () => {
         right: "10mm",
         top: "12mm"
       },
-      pageSize: "A4",
+      pageSize: { width: 13.333333, height: 7.5 },
+      preferCSSPageSize: true,
       printBackground: false,
       title: " Report "
     }),
@@ -207,7 +208,8 @@ test("normalizes PDF print HTML input", () => {
         right: "10mm",
         top: "12mm"
       },
-      pageSize: "A4",
+      pageSize: { width: 13.333333, height: 7.5 },
+      preferCSSPageSize: true,
       printBackground: false,
       title: "Report"
     }
@@ -234,6 +236,14 @@ test("rejects invalid PDF print HTML input", () => {
         margin: { top: "12pt" }
       }),
     /margin top unit is unsupported/
+  );
+  assert.throws(
+    () =>
+      normalizeTuttiExternalPdfPrintHtmlInput({
+        html: "<h1>Doc</h1>",
+        pageSize: { width: 13.333333, height: 0 }
+      }),
+    /pageSize height must be a positive number/
   );
 });
 

--- a/packages/workspace/external-core/src/core/index.ts
+++ b/packages/workspace/external-core/src/core/index.ts
@@ -254,6 +254,7 @@ export function normalizeTuttiExternalPdfPrintHtmlInput(
     ...(input.pageSize !== undefined && input.pageSize !== null
       ? { pageSize: normalizePdfPageSize(input.pageSize) }
       : {}),
+    ...(input.preferCSSPageSize === true ? { preferCSSPageSize: true } : {}),
     ...(input.margin !== undefined && input.margin !== null
       ? { margin: normalizePdfMargin(input.margin) }
       : {})
@@ -486,11 +487,30 @@ function normalizePdfBaseUrl(value: string): string {
   return url.toString();
 }
 
-function normalizePdfPageSize(value: unknown): "A4" | "Letter" {
+function normalizePdfPageSize(
+  value: unknown
+): TuttiExternalPdfPrintHtmlInput["pageSize"] {
   if (value === "A4" || value === "Letter") {
     return value;
   }
+  if (isRecord(value)) {
+    const width = normalizePdfPageSizeSide(value.width, "width");
+    const height = normalizePdfPageSizeSide(value.height, "height");
+    return { width, height };
+  }
   throw new Error("pdf.printHtmlToPdf pageSize is unsupported.");
+}
+
+function normalizePdfPageSizeSide(
+  value: unknown,
+  side: "height" | "width"
+): number {
+  if (typeof value !== "number" || !Number.isFinite(value) || value <= 0) {
+    throw new Error(
+      `pdf.printHtmlToPdf pageSize ${side} must be a positive number.`
+    );
+  }
+  return value;
 }
 
 function normalizePdfMargin(value: unknown): TuttiExternalPdfMargin {


### PR DESCRIPTION
## Summary
- extend workspace app PDF bridge contracts to accept custom pageSize objects
- normalize positive width/height values and pass preferCSSPageSize through
- forward preferCSSPageSize to Electron printToPDF

## Tests
- pnpm --filter @tutti-os/workspace-external-core test
- pnpm --filter @tutti-os/desktop typecheck
- git push hook: check:full passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * PDF printing now accepts custom page dimensions (width/height) alongside standard sizes (A4, Letter)
  * Added CSS page size preference option to control how CSS-defined sizing is applied to PDF output

<!-- end of auto-generated comment: release notes by coderabbit.ai -->