### PR TITLE
Inject macOS system proxy into spawned ACP agents

### DIFF
--- a/packages/agent/daemon/runtimecmd/proxy.go
+++ b/packages/agent/daemon/runtimecmd/proxy.go
@@ -1,10 +1,12 @@
 package runtimecmd
 
 import (
+	"context"
 	"net"
 	"os/exec"
 	"runtime"
 	"strings"
+	"time"
 )
 
 // System proxy injection.
@@ -67,7 +69,9 @@ func runScutilProxy() (string, bool) {
 	if runtime.GOOS != "darwin" {
 		return "", false
 	}
-	out, err := exec.Command("scutil", "--proxy").Output()
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	out, err := exec.CommandContext(ctx, "scutil", "--proxy").Output()
 	if err != nil {
 		return "", false
 	}

--- a/packages/agent/daemon/runtimecmd/proxy.go
+++ b/packages/agent/daemon/runtimecmd/proxy.go
@@ -1,0 +1,129 @@
+package runtimecmd
+
+import (
+	"net"
+	"os/exec"
+	"runtime"
+	"strings"
+)
+
+// System proxy injection.
+//
+// The standalone ACP agents we spawn (e.g. `claude`) only honor the
+// HTTP(S)_PROXY environment variables — they do NOT read the macOS system proxy.
+// The Claude desktop app works around this by resolving the OS proxy via
+// Electron's session.resolveProxy() (Chromium/SystemConfiguration) and injecting
+// HTTPS_PROXY/HTTP_PROXY into the spawned process. Without it, a child agent
+// connects directly and, from a restricted region, gets `403 Request not
+// allowed` from the upstream API while the app keeps working.
+//
+// We mirror that behavior here by reading the same SystemConfiguration data via
+// `scutil --proxy` and injecting equivalent env vars. To stay faithful to the
+// app we: skip SOCKS entries (downstream HTTP agents don't speak SOCKS), use the
+// same default NO_PROXY, and never override a proxy the user/session already set.
+
+// noProxyDefault matches the value the Claude desktop app injects.
+const noProxyDefault = "localhost,127.0.0.1,::1,.local"
+
+// injectSystemProxyEnv appends HTTPS_PROXY/HTTP_PROXY/NO_PROXY derived from the
+// macOS system proxy, but only for keys not already present (case-insensitive)
+// in env, so explicit user/session settings always win.
+func (r Resolver) injectSystemProxyEnv(env []string) []string {
+	proxyEnv := r.systemProxyEnv()
+	if len(proxyEnv) == 0 {
+		return env
+	}
+	for _, key := range []string{"HTTPS_PROXY", "HTTP_PROXY", "NO_PROXY"} {
+		value, ok := proxyEnv[key]
+		if !ok || strings.TrimSpace(value) == "" {
+			continue
+		}
+		if _, exists := envValueFrom(env, key); exists {
+			continue
+		}
+		env = append(env, key+"="+value)
+	}
+	return env
+}
+
+func (r Resolver) systemProxyEnv() map[string]string {
+	output, ok := r.scutilProxy()
+	if !ok {
+		return nil
+	}
+	return parseScutilProxy(output)
+}
+
+func (r Resolver) scutilProxy() (string, bool) {
+	if r.ScutilProxy != nil {
+		return r.ScutilProxy()
+	}
+	return runScutilProxy()
+}
+
+// runScutilProxy reads the macOS system proxy configuration. It is a no-op on
+// non-macOS platforms, where proxies are conventionally driven by env vars.
+func runScutilProxy() (string, bool) {
+	if runtime.GOOS != "darwin" {
+		return "", false
+	}
+	out, err := exec.Command("scutil", "--proxy").Output()
+	if err != nil {
+		return "", false
+	}
+	return string(out), true
+}
+
+// parseScutilProxy turns `scutil --proxy` output into proxy env vars.
+//
+// Example input:
+//
+//	<dictionary> {
+//	  HTTPSEnable : 1
+//	  HTTPSProxy : 127.0.0.1
+//	  HTTPSPort : 7890
+//	  ...
+//	}
+//
+// SOCKS entries are intentionally ignored, and PAC (ProxyAutoConfig) is not
+// resolved — scutil only exposes the PAC URL, not the per-URL result, so we
+// leave those to the user's explicit env. Returns nil when no usable proxy is
+// configured (direct connection).
+func parseScutilProxy(output string) map[string]string {
+	fields := map[string]string{}
+	for _, line := range strings.Split(output, "\n") {
+		key, value, ok := strings.Cut(line, ":")
+		if !ok {
+			continue
+		}
+		fields[strings.TrimSpace(key)] = strings.TrimSpace(value)
+	}
+
+	proxyURL := func(enableKey, hostKey, portKey string) string {
+		if fields[enableKey] != "1" {
+			return ""
+		}
+		host := fields[hostKey]
+		port := fields[portKey]
+		if host == "" || port == "" {
+			return ""
+		}
+		return "http://" + net.JoinHostPort(host, port)
+	}
+
+	// Prefer the HTTPS entry (the upstream API is HTTPS); fall back to HTTP.
+	// Both env vars point at the same proxy, mirroring the Claude app.
+	url := proxyURL("HTTPSEnable", "HTTPSProxy", "HTTPSPort")
+	if url == "" {
+		url = proxyURL("HTTPEnable", "HTTPProxy", "HTTPPort")
+	}
+	if url == "" {
+		return nil
+	}
+
+	return map[string]string{
+		"HTTPS_PROXY": url,
+		"HTTP_PROXY":  url,
+		"NO_PROXY":    noProxyDefault,
+	}
+}

--- a/packages/agent/daemon/runtimecmd/proxy_test.go
+++ b/packages/agent/daemon/runtimecmd/proxy_test.go
@@ -1,0 +1,139 @@
+package runtimecmd
+
+import (
+	"strings"
+	"testing"
+)
+
+// Real-world `scutil --proxy` output with Clash Verge system proxy enabled
+// (HTTP/HTTPS/SOCKS all pointing at 127.0.0.1:7890).
+const scutilProxyEnabled = `<dictionary> {
+  ExceptionsList : <array> {
+    0 : 127.0.0.1
+    1 : localhost
+    2 : *.local
+  }
+  HTTPEnable : 1
+  HTTPPort : 7890
+  HTTPProxy : 127.0.0.1
+  HTTPSEnable : 1
+  HTTPSPort : 7890
+  HTTPSProxy : 127.0.0.1
+  ProxyAutoConfigEnable : 0
+  SOCKSEnable : 1
+  SOCKSPort : 7890
+  SOCKSProxy : 127.0.0.1
+}`
+
+const scutilProxyDisabled = `<dictionary> {
+  ExceptionsList : <array> {
+    0 : 127.0.0.1
+    1 : localhost
+  }
+  HTTPEnable : 0
+  HTTPSEnable : 0
+  ProxyAutoConfigEnable : 0
+  SOCKSEnable : 0
+}`
+
+func TestParseScutilProxyEnabled(t *testing.T) {
+	got := parseScutilProxy(scutilProxyEnabled)
+	want := map[string]string{
+		"HTTPS_PROXY": "http://127.0.0.1:7890",
+		"HTTP_PROXY":  "http://127.0.0.1:7890",
+		"NO_PROXY":    noProxyDefault,
+	}
+	for k, v := range want {
+		if got[k] != v {
+			t.Fatalf("parseScutilProxy()[%q] = %q, want %q", k, got[k], v)
+		}
+	}
+}
+
+func TestParseScutilProxyDisabledReturnsNil(t *testing.T) {
+	if got := parseScutilProxy(scutilProxyDisabled); got != nil {
+		t.Fatalf("parseScutilProxy() = %v, want nil", got)
+	}
+}
+
+func TestParseScutilProxyHTTPOnly(t *testing.T) {
+	out := `<dictionary> {
+  HTTPEnable : 1
+  HTTPProxy : 10.0.0.2
+  HTTPPort : 3128
+  HTTPSEnable : 0
+  SOCKSEnable : 0
+}`
+	got := parseScutilProxy(out)
+	if got["HTTP_PROXY"] != "http://10.0.0.2:3128" || got["HTTPS_PROXY"] != "http://10.0.0.2:3128" {
+		t.Fatalf("parseScutilProxy() = %v, want HTTP(S)_PROXY=http://10.0.0.2:3128", got)
+	}
+}
+
+func TestParseScutilProxySOCKSOnlyIgnored(t *testing.T) {
+	out := `<dictionary> {
+  HTTPEnable : 0
+  HTTPSEnable : 0
+  SOCKSEnable : 1
+  SOCKSProxy : 127.0.0.1
+  SOCKSPort : 7890
+}`
+	if got := parseScutilProxy(out); got != nil {
+		t.Fatalf("parseScutilProxy() with SOCKS only = %v, want nil (SOCKS skipped)", got)
+	}
+}
+
+func TestEnvInjectsSystemProxy(t *testing.T) {
+	resolver := Resolver{
+		Environ:     func() []string { return []string{"PATH=/usr/bin:/bin"} },
+		HomeDir:     func() (string, error) { return t.TempDir(), nil },
+		ScutilProxy: func() (string, bool) { return scutilProxyEnabled, true },
+	}
+	env := resolver.Env(nil)
+	if got := envValue(env, "HTTPS_PROXY"); got != "http://127.0.0.1:7890" {
+		t.Fatalf("HTTPS_PROXY = %q, want http://127.0.0.1:7890", got)
+	}
+	if got := envValue(env, "HTTP_PROXY"); got != "http://127.0.0.1:7890" {
+		t.Fatalf("HTTP_PROXY = %q, want http://127.0.0.1:7890", got)
+	}
+	if got := envValue(env, "NO_PROXY"); got != noProxyDefault {
+		t.Fatalf("NO_PROXY = %q, want %q", got, noProxyDefault)
+	}
+}
+
+func TestEnvDoesNotOverrideExplicitProxy(t *testing.T) {
+	resolver := Resolver{
+		// User already exported a (lowercase) proxy — must be preserved.
+		Environ: func() []string {
+			return []string{"PATH=/usr/bin:/bin", "https_proxy=http://user-set:1080"}
+		},
+		HomeDir:     func() (string, error) { return t.TempDir(), nil },
+		ScutilProxy: func() (string, bool) { return scutilProxyEnabled, true },
+	}
+	env := resolver.Env(nil)
+	if got := envValue(env, "https_proxy"); got != "http://user-set:1080" {
+		t.Fatalf("https_proxy = %q, want it preserved as http://user-set:1080", got)
+	}
+	// And we must not have appended a conflicting upper-case HTTPS_PROXY.
+	count := 0
+	for _, item := range env {
+		if k, _, _ := strings.Cut(item, "="); strings.EqualFold(k, "HTTPS_PROXY") {
+			count++
+		}
+	}
+	if count != 1 {
+		t.Fatalf("found %d HTTPS_PROXY entries, want exactly 1 (no override)", count)
+	}
+}
+
+func TestEnvNoProxyWhenScutilUnavailable(t *testing.T) {
+	resolver := Resolver{
+		Environ:     func() []string { return []string{"PATH=/usr/bin:/bin"} },
+		HomeDir:     func() (string, error) { return t.TempDir(), nil },
+		ScutilProxy: func() (string, bool) { return "", false },
+	}
+	env := resolver.Env(nil)
+	if got := envValue(env, "HTTPS_PROXY"); got != "" {
+		t.Fatalf("HTTPS_PROXY = %q, want empty when scutil unavailable", got)
+	}
+}

--- a/packages/agent/daemon/runtimecmd/resolver.go
+++ b/packages/agent/daemon/runtimecmd/resolver.go
@@ -13,6 +13,10 @@ type Resolver struct {
 	HomeDir          func() (string, error)
 	IsExecutableFile func(string) bool
 	LookPath         func(string) (string, error)
+	// ScutilProxy returns the raw output of `scutil --proxy` (and whether it is
+	// available). It is injectable for tests; the default reads the macOS system
+	// proxy and is a no-op on other platforms. See proxy.go.
+	ScutilProxy func() (string, bool)
 }
 
 // nestingGuardEnvKeys are the environment variables a parent Claude Code
@@ -41,10 +45,10 @@ func (r Resolver) Env(overrides []string) []string {
 		pathGroups = append(pathGroups, filepath.SplitList(envValue(baseEnv, pathKey)))
 	}
 	pathDirs := mergePathDirs(pathGroups...)
-	if len(pathDirs) == 0 {
-		return env
+	if len(pathDirs) > 0 {
+		env = setEnvValue(env, pathKey, strings.Join(pathDirs, string(os.PathListSeparator)))
 	}
-	return setEnvValue(env, pathKey, strings.Join(pathDirs, string(os.PathListSeparator)))
+	return r.injectSystemProxyEnv(env)
 }
 
 func (r Resolver) Resolve(command string, env []string) string {


### PR DESCRIPTION
## Problem

Standalone ACP agents (e.g. `claude`) only honor the `HTTP(S)_PROXY` env vars — they do **not** read the macOS system proxy. When `tuttid` is launched without proxy env (the GUI/launchd norm), a spawned agent connects **directly**. From a restricted region this surfaces as:

```
API Error: 403 {"error":{"type":"forbidden","message":"Request not allowed"}}
```

…while the **Claude desktop app keeps working**, because it resolves the OS proxy (Electron `session.resolveProxy()` → SystemConfiguration) and injects it into its child process.

## Fix

Mirror the app's behavior in `Resolver.Env()`: read the **same SystemConfiguration data** via `scutil --proxy` and inject `HTTPS_PROXY` / `HTTP_PROXY` / `NO_PROXY` into the spawned ACP process env.

Faithful to the app:
- **Skip SOCKS** entries (downstream HTTP agents don't speak SOCKS).
- Same default `NO_PROXY` = `localhost,127.0.0.1,::1,.local`.
- **Never override** a proxy the user/session already set (case-insensitive).
- Returns nothing when no proxy is configured (direct) and is a **no-op on non-macOS**.

Injection lives in `Env()`, the single chokepoint already used by `process_transport.go` to build the child env, so callers need no change.

## Why scutil (not CGO)

`scutil --proxy` reads the exact same SystemConfiguration source the app uses. It's **runtime-only and arch-independent**, so both arm64 and amd64 binaries get this with **no `build-desktop-package.sh` / CGO_ENABLED change**. (CGO would only buy faithful PAC resolution, which isn't used here — system proxy is static.)

## Changed files

- `packages/agent/daemon/runtimecmd/resolver.go` — injectable `ScutilProxy` field; `Env()` calls `injectSystemProxyEnv`.
- `packages/agent/daemon/runtimecmd/proxy.go` — scutil read + parse + inject.
- `packages/agent/daemon/runtimecmd/proxy_test.go` — parse / disabled / HTTP-only / SOCKS-skipped / inject / no-override / unavailable.

## Verification

- `go build ./...`, `go test ./runtimecmd ./runtime` pass.
- golangci-lint (shared config) **0 issues**, gofmt clean.
- Live `scutil` on macOS resolves `HTTPS_PROXY=http://127.0.0.1:7890` from a real Clash Verge system proxy.

## Note (out of scope)

`packages/agent/daemon` is **not** in the CI `go-tests` / `go-lint` module roots (only `workbench/service`, `workspace/files`, `services/tuttid`), so these new tests won't run in CI yet. Happy to add it in a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * On macOS, the app now automatically detects the system proxy settings (when enabled) and injects the appropriate `HTTP_PROXY`, `HTTPS_PROXY`, and `NO_PROXY` values into spawned agent environments.

* **Bug Fixes**
  * Proxy environment injection now runs even in cases where no PATH changes are required.

* **Tests**
  * Added unit tests covering proxy parsing, disabled/HTTP-only/SOCKS-only scenarios, and ensuring existing user-provided proxy settings aren’t overridden.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->