### PR TITLE
Return grant context token to workspace apps

### DIFF
--- a/apps/desktop/src/main/ipc/workspaceAppContext.ts
+++ b/apps/desktop/src/main/ipc/workspaceAppContext.ts
@@ -757,7 +757,10 @@ async function requestManagedAiModelPermission(
     throw new Error(message);
   }
   const payload: unknown = await response.json();
-  return normalizeManagedAiModelPermissionResponse(payload);
+  return {
+    ...normalizeManagedAiModelPermissionResponse(payload),
+    contextToken
+  };
 }
 
 async function readManagedAiModelGrantError(
@@ -785,6 +788,9 @@ function normalizeManagedAiModelPermissionResponse(
   }
   return {
     code: value.grantCode,
+    ...(typeof value.contextToken === "string"
+      ? { contextToken: value.contextToken }
+      : {}),
     ...(typeof value.expiresAt === "string"
       ? { expiresAt: value.expiresAt }
       : {}),

--- a/apps/desktop/src/preload/entries/workspaceAppExternalBridge.test.ts
+++ b/apps/desktop/src/preload/entries/workspaceAppExternalBridge.test.ts
@@ -389,7 +389,10 @@ test("workspace app external bridge invokes permission request with activation",
     send: unexpectedSend,
     async invoke<TResult>(channel: string, payload?: unknown) {
       calls.push({ channel, payload });
-      return { code: "grant-code-1" } as TResult;
+      return {
+        code: "grant-code-1",
+        contextToken: "context-token-1"
+      } as TResult;
     }
   });
 
@@ -401,7 +404,7 @@ test("workspace app external bridge invokes permission request with activation",
       scopes: ["model:invoke"],
       state: "state-1"
     }),
-    { code: "grant-code-1" }
+    { code: "grant-code-1", contextToken: "context-token-1" }
   );
   assert.deepEqual(calls, [
     {

--- a/packages/workspace/external-core/src/contracts/index.ts
+++ b/packages/workspace/external-core/src/contracts/index.ts
@@ -116,6 +116,7 @@ export interface TuttiExternalPermissionRequestInput {
 
 export interface TuttiExternalPermissionRequestResult {
   code: string;
+  contextToken?: string;
   expiresAt?: string;
   models?: readonly TuttiExternalManagedAiModel[];
   providers?: readonly TuttiExternalManagedAiModelProviderId[];


### PR DESCRIPTION
## Summary
- Add contextToken to the workspace external permission request result contract.
- Return the exact context token used to create a Tutti Managed grant from the desktop host.
- Cover permission request bridge passthrough for the returned context token.

## Test Plan
- pnpm --filter @tutti-os/desktop test -- workspaceAppExternalBridge.test.ts
- pnpm --filter @tutti-os/desktop typecheck
- pnpm --filter @tutti-os/workspace-external-core typecheck
- git push pre-push check:full passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced permission request handling to optionally carry additional context information for improved tracking and management of permission states throughout the application lifecycle.

* **Tests**
  * Updated permission request tests to verify that permission responses now properly include contextual information alongside existing request identifiers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->