### PR TITLE
Remove codex-acp; run codex via app-server and install the first-party CLI cleanly

### DIFF
--- a/apps/desktop/src/renderer/src/features/workspace-agent/services/createDesktopAgentHostApi.test.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-agent/services/createDesktopAgentHostApi.test.ts
@@ -1458,7 +1458,7 @@ test("desktop agent host api reports failed activation from tuttid session", asy
       async createWorkspaceAgentSession(_workspaceId, request) {
         return createSession({
           id: request.agentSessionId,
-          lastError: `exec: "codex-acp": executable file not found in $PATH`,
+          lastError: `exec: "codex": executable file not found in $PATH`,
           status: "failed"
         });
       }
@@ -1482,8 +1482,8 @@ test("desktop agent host api reports failed activation from tuttid session", asy
   assert.equal(result.session.status, "failed");
   assert.deepEqual(result.error, {
     code: "agent_session_start_failed",
-    debugMessage: `exec: "codex-acp": executable file not found in $PATH`,
-    message: `exec: "codex-acp": executable file not found in $PATH`
+    debugMessage: `exec: "codex": executable file not found in $PATH`,
+    message: `exec: "codex": executable file not found in $PATH`
   });
   assert.deepEqual(reporterCalls, [
     [

--- a/apps/desktop/src/renderer/src/features/workspace-agent/services/internal/desktopAgentProviderStatusService.test.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-agent/services/internal/desktopAgentProviderStatusService.test.ts
@@ -320,8 +320,7 @@ test("runAction reports daemon install action failures and skips refresh", async
                 {
                   command: {
                     cwd: "/workspace",
-                    input:
-                      "npm install -g @openai/codex @zed-industries/codex-acp\n"
+                    input: "npm install -g @openai/codex\n"
                   },
                   id: "install",
                   kind: "terminal_command"
@@ -1040,7 +1039,7 @@ function createProbeResponse(
 ): AgentProviderProbeResponse {
   return {
     checkedAt: "2026-06-02T08:00:00.000Z",
-    command: ["codex-acp"],
+    command: ["codex"],
     provider,
     status
   };
@@ -1130,7 +1129,7 @@ function createProviderStatus(input: {
   return {
     actions: input.actions,
     adapter: {
-      command: ["codex-acp"],
+      command: ["codex"],
       installed:
         input.adapterInstalled ??
         (input.availability !== "not_installed" &&

--- a/packages/agent/daemon/runtime/codex_adapter.go
+++ b/packages/agent/daemon/runtime/codex_adapter.go
@@ -20,7 +20,6 @@ import (
 )
 
 const (
-	codexACPCommand       = "codex-acp"
 	nexightACPCommand     = "nexight-acp"
 	codexAgentRoutingEnv  = "TUTTI_AGENT_ROUTING=1"
 	codexRoutingPreload   = "LD_PRELOAD=" + runtimepaths.BundlePreloadSOPath
@@ -103,20 +102,6 @@ type pendingACPResponse struct {
 	payload  map[string]any
 	result   map[string]any
 	err      error
-}
-
-func NewCodexAdapter(transport ProcessTransport) *CodexAdapter {
-	return NewCodexAdapterWithHostMetadata(transport, LegacyHostMetadata())
-}
-
-func NewCodexAdapterWithHostMetadata(transport ProcessTransport, host HostMetadata) *CodexAdapter {
-	return newCodexFamilyAdapter(transport, codexAdapterConfig{
-		provider:            ProviderCodex,
-		command:             []string{codexACPCommand},
-		adapterName:         "codex-acp",
-		authRequiredMessage: "Codex ACP requires authentication in the runtime VM. Sync the Codex host credentials, then retry this session.",
-		fallbackTitles:      []string{"", ProviderCodex},
-	}, host)
 }
 
 func NewNexightAdapter(transport ProcessTransport) *CodexAdapter {

--- a/packages/agent/daemon/runtime/codex_adapter_test.go
+++ b/packages/agent/daemon/runtime/codex_adapter_test.go
@@ -38,51 +38,11 @@ func readSessionTestdataJSON(t *testing.T, name string) map[string]any {
 	return body
 }
 
-func TestCodexAdapterStartCreatesRealACPSession(t *testing.T) {
-	t.Parallel()
-
-	transport := newScriptedACPTransport()
-	adapter := NewCodexAdapter(transport)
-
-	events, err := adapter.Start(context.Background(), testSession())
-	if err != nil {
-		t.Fatalf("Start: %v", err)
-	}
-	if len(transport.specs) != 1 {
-		t.Fatalf("process starts = %d, want 1", len(transport.specs))
-	}
-	spec := transport.specs[0]
-	if len(spec.Command) == 0 || spec.Command[0] != codexACPCommand {
-		t.Fatalf("command = %#v, want %q", spec.Command, codexACPCommand)
-	}
-	if len(spec.Command) != 1 {
-		t.Fatalf("command = %#v, want no implicit sandbox config overrides", spec.Command)
-	}
-	if spec.CWD != "/workspace" {
-		t.Fatalf("cwd = %q, want /workspace", spec.CWD)
-	}
-	if !containsString(spec.Env, codexAgentRoutingEnv) {
-		t.Fatalf("env = %#v, want agent routing env", spec.Env)
-	}
-	if !containsString(spec.Env, codexRoutingPreload) {
-		t.Fatalf("env = %#v, want routing preload env", spec.Env)
-	}
-	if len(events) != 1 || events[0].Type != activityshared.EventSessionStarted {
-		t.Fatalf("events = %#v, want session.started", events)
-	}
-	if events[0].ProviderSessionID != "codex-acp-session-1" {
-		t.Fatalf("provider session id = %q", events[0].ProviderSessionID)
-	}
-	if got := acpRequestParamCWD(t, transport.conn, acpMethodNewSession); got != "/workspace" {
-		t.Fatalf("ACP session/new cwd = %q, want /workspace", got)
-	}
-}
-
 func TestCodexAdapterStartAddsConfigOverridesForModelAndReasoning(t *testing.T) {
 	t.Parallel()
 
 	transport := newScriptedACPTransport()
-	adapter := NewCodexAdapter(transport)
+	adapter := NewNexightAdapter(transport)
 	session := testSession()
 	session.Settings = &SessionSettings{
 		Model:            "gpt-5",
@@ -110,7 +70,7 @@ func TestCodexAdapterStartIgnoresUnsupportedPlanMode(t *testing.T) {
 	t.Parallel()
 
 	transport := newScriptedACPTransport()
-	adapter := NewCodexAdapter(transport)
+	adapter := NewNexightAdapter(transport)
 	session := testSession()
 	session.PermissionModeID = "full-access"
 	session.Settings = &SessionSettings{
@@ -131,7 +91,7 @@ func TestCodexAdapterApplySessionSettingsDoesNotApplyUnsupportedPlanMode(t *test
 	t.Parallel()
 
 	transport := newScriptedACPTransport()
-	adapter := NewCodexAdapter(transport)
+	adapter := NewNexightAdapter(transport)
 	session := testSession()
 	session.PermissionModeID = "full-access"
 	session.Settings = &SessionSettings{
@@ -168,7 +128,7 @@ func TestCodexAdapterStartDisablesReasoningSummaryForSparkModel(t *testing.T) {
 	t.Parallel()
 
 	transport := newScriptedACPTransport()
-	adapter := NewCodexAdapter(transport)
+	adapter := NewNexightAdapter(transport)
 	session := testSession()
 	session.Settings = &SessionSettings{
 		Model:            "gpt-5.3-codex-spark",
@@ -211,7 +171,7 @@ func TestCodexAdapterSessionStateIncludesACPConfigOptions(t *testing.T) {
 			map[string]any{"value": "high", "name": "High"},
 		},
 	}}
-	adapter := NewCodexAdapter(transport)
+	adapter := NewNexightAdapter(transport)
 	session := testSession()
 
 	if _, err := adapter.Start(context.Background(), session); err != nil {
@@ -254,7 +214,7 @@ func TestCodexAdapterApplySessionSettingsUpdatesLiveACPConfig(t *testing.T) {
 	t.Parallel()
 
 	transport := newScriptedACPTransport()
-	adapter := NewCodexAdapter(transport)
+	adapter := NewNexightAdapter(transport)
 	session := testSession()
 
 	if _, err := adapter.Start(context.Background(), session); err != nil {
@@ -300,7 +260,7 @@ func TestCodexAdapterApplySessionSettingsSkipsUnchangedLiveACPConfig(t *testing.
 	transport.conn.configOptions = []map[string]any{
 		{"id": "reasoning_effort", "currentValue": "high"},
 	}
-	adapter := NewCodexAdapter(transport)
+	adapter := NewNexightAdapter(transport)
 	session := testSession()
 
 	if _, err := adapter.Start(context.Background(), session); err != nil {
@@ -326,7 +286,7 @@ func TestCodexAdapterApplySessionSettingsSendsChangedLiveACPConfig(t *testing.T)
 	transport.conn.configOptions = []map[string]any{
 		{"id": "reasoning_effort", "currentValue": "high"},
 	}
-	adapter := NewCodexAdapter(transport)
+	adapter := NewNexightAdapter(transport)
 	session := testSession()
 
 	if _, err := adapter.Start(context.Background(), session); err != nil {
@@ -352,7 +312,7 @@ func TestCodexAdapterApplySessionSettingsSendsChangedLiveACPConfig(t *testing.T)
 func TestCodexAdapterRequiresNewSessionWhenReasoningSummarySupportChanges(t *testing.T) {
 	t.Parallel()
 
-	adapter := NewCodexAdapter(newScriptedACPTransport())
+	adapter := NewNexightAdapter(newScriptedACPTransport())
 	session := testSession()
 	session.Settings = &SessionSettings{
 		Model:            "gpt-5.3-codex-spark",
@@ -381,7 +341,7 @@ func TestCodexAdapterRequiresNewSessionWhenReasoningSummarySupportChanges(t *tes
 func TestCodexAdapterApplySessionSettingsRejectsNewSessionOnlyModelChange(t *testing.T) {
 	t.Parallel()
 
-	adapter := NewCodexAdapter(newScriptedACPTransport())
+	adapter := NewNexightAdapter(newScriptedACPTransport())
 	session := testSession()
 	session.Settings = &SessionSettings{
 		Model:            "gpt-5.3-codex",
@@ -401,7 +361,7 @@ func TestCodexAdapterStartPreservesCommandsAdvertisedDuringNewSession(t *testing
 
 	transport := newScriptedACPTransport()
 	transport.conn.commandUpdateOnNewSession = true
-	adapter := NewCodexAdapter(transport)
+	adapter := NewNexightAdapter(transport)
 	session := testSession()
 
 	if _, err := adapter.Start(context.Background(), session); err != nil {
@@ -421,7 +381,7 @@ func TestControllerPublishesIdleCodexCommandUpdatesAfterStart(t *testing.T) {
 	t.Parallel()
 
 	transport := newScriptedACPTransport()
-	adapter := NewCodexAdapter(transport)
+	adapter := NewNexightAdapter(transport)
 	controller := NewController([]Adapter{adapter}, nil)
 	session := testSession()
 
@@ -469,7 +429,7 @@ func TestControllerPublishesIdleCodexConfigOptionsUpdatesAfterStart(t *testing.T
 	t.Parallel()
 
 	transport := newScriptedACPTransport()
-	adapter := NewCodexAdapter(transport)
+	adapter := NewNexightAdapter(transport)
 	controller := NewController([]Adapter{adapter}, nil)
 	session := testSession()
 
@@ -507,7 +467,7 @@ func TestCodexAdapterResumePreservesCommandsAdvertisedDuringLoadSession(t *testi
 
 	transport := newScriptedACPTransport()
 	transport.conn.commandUpdateOnLoadSession = true
-	adapter := NewCodexAdapter(transport)
+	adapter := NewNexightAdapter(transport)
 	session := testSession()
 
 	if err := adapter.Resume(context.Background(), session); err != nil {
@@ -528,7 +488,7 @@ func TestCodexAdapterResumeClassifiesMissingProviderSession(t *testing.T) {
 		Code:    -32002,
 		Message: "Resource not found",
 	}
-	adapter := NewCodexAdapter(transport)
+	adapter := NewNexightAdapter(transport)
 	session := testSession()
 
 	err := adapter.Resume(context.Background(), session)
@@ -549,7 +509,7 @@ func TestCodexAdapterResumeClassifiesUnsupportedRestoreAsProviderSessionNotFound
 
 	transport := newScriptedACPTransport()
 	transport.conn.supportsSessionRestore = false
-	adapter := NewCodexAdapter(transport)
+	adapter := NewNexightAdapter(transport)
 	session := testSession()
 
 	err := adapter.Resume(context.Background(), session)
@@ -566,7 +526,7 @@ func TestCodexAdapterResumeRequiresProviderSessionID(t *testing.T) {
 	t.Parallel()
 
 	transport := newScriptedACPTransport()
-	adapter := NewCodexAdapter(transport)
+	adapter := NewNexightAdapter(transport)
 	session := testSession()
 	session.ProviderSessionID = ""
 
@@ -658,7 +618,7 @@ func TestCodexAdapterStartContinuesWhenSetModeDoesNotRespond(t *testing.T) {
 
 	transport := newScriptedACPTransport()
 	transport.conn.respondSetMode = false
-	adapter := NewCodexAdapter(transport)
+	adapter := NewNexightAdapter(transport)
 	session := testSession()
 	session.PermissionModeID = "full-access"
 
@@ -698,7 +658,7 @@ func TestCodexAdapterStartAuthRequiredCreatesSessionState(t *testing.T) {
 
 	transport := newScriptedACPTransport()
 	transport.conn.authRequiredOnNewSession = true
-	adapter := NewCodexAdapter(transport)
+	adapter := NewNexightAdapter(transport)
 	session := testSession()
 
 	events, err := adapter.Start(context.Background(), session)
@@ -713,7 +673,7 @@ func TestCodexAdapterStartAuthRequiredCreatesSessionState(t *testing.T) {
 	if snapshot.AuthState != "auth_required" {
 		t.Fatalf("auth state = %q, want auth_required", snapshot.AuthState)
 	}
-	if got := asString(snapshot.RuntimeContext["authMessage"]); !strings.Contains(got, "Sync the Codex host credentials") {
+	if got := asString(snapshot.RuntimeContext["authMessage"]); !strings.Contains(got, "Sync the Nexight host credentials") {
 		t.Fatalf("auth message = %q, want credential sync guidance", got)
 	}
 }
@@ -721,7 +681,7 @@ func TestCodexAdapterStartAuthRequiredCreatesSessionState(t *testing.T) {
 func TestCodexAdapterExecStreamsACPUpdates(t *testing.T) {
 	t.Parallel()
 
-	adapter := NewCodexAdapter(newScriptedACPTransport())
+	adapter := NewNexightAdapter(newScriptedACPTransport())
 	session := testSession()
 	if _, err := adapter.Start(context.Background(), session); err != nil {
 		t.Fatalf("Start: %v", err)
@@ -810,7 +770,7 @@ func TestCodexAdapterExecCompletesAssistantMessageFromPromptResult(t *testing.T)
 
 	transport := newScriptedACPTransport()
 	transport.conn.promptFinalContent = "I'll check the repo. Source note."
-	adapter := NewCodexAdapter(transport)
+	adapter := NewNexightAdapter(transport)
 	session := testSession()
 	if _, err := adapter.Start(context.Background(), session); err != nil {
 		t.Fatalf("Start: %v", err)
@@ -855,7 +815,7 @@ func TestCodexAdapterExecPreservesLongAssistantMessageContent(t *testing.T) {
 	longContent := "I'll check the repo." + strings.Repeat("完整回答", 3000)
 	transport := newScriptedACPTransport()
 	transport.conn.promptFinalContent = longContent
-	adapter := NewCodexAdapter(transport)
+	adapter := NewNexightAdapter(transport)
 	session := testSession()
 	if _, err := adapter.Start(context.Background(), session); err != nil {
 		t.Fatalf("Start: %v", err)
@@ -896,7 +856,7 @@ func TestCodexAdapterExecUsesDisplayPromptForUserMessageOnly(t *testing.T) {
 	t.Parallel()
 
 	transport := newScriptedACPTransport()
-	adapter := NewCodexAdapter(transport)
+	adapter := NewNexightAdapter(transport)
 	session := testSession()
 	if _, err := adapter.Start(context.Background(), session); err != nil {
 		t.Fatalf("Start: %v", err)
@@ -949,7 +909,7 @@ func TestCodexAdapterAllowsImagePromptWithoutInitializeCapability(t *testing.T) 
 	t.Parallel()
 
 	transport := newScriptedACPTransport()
-	adapter := NewCodexAdapter(transport)
+	adapter := NewNexightAdapter(transport)
 	session := testSession()
 	if _, err := adapter.Start(context.Background(), session); err != nil {
 		t.Fatalf("Start: %v", err)
@@ -1645,7 +1605,7 @@ func TestACPPermissionEventsCarryCanonicalToolName(t *testing.T) {
 	t.Parallel()
 
 	session := testSession()
-	adapter := NewCodexAdapter(newScriptedACPTransport())
+	adapter := NewNexightAdapter(newScriptedACPTransport())
 
 	approvalEvents, pendingApproval, err := adapter.acpPermissionRequested(
 		session,
@@ -1820,7 +1780,7 @@ func TestCodexAdapterPermissionRequestWaitsForUserSelection(t *testing.T) {
 
 	transport := newScriptedACPTransport()
 	transport.conn.promptPermission = true
-	adapter := NewCodexAdapter(transport)
+	adapter := NewNexightAdapter(transport)
 	session := testSession()
 	if _, err := adapter.Start(context.Background(), session); err != nil {
 		t.Fatalf("Start: %v", err)
@@ -1885,7 +1845,7 @@ func TestCodexAdapterPermissionRequestPreservesAbortInteractiveSelection(t *test
 
 	transport := newScriptedACPTransport()
 	transport.conn.promptPermission = true
-	adapter := NewCodexAdapter(transport)
+	adapter := NewNexightAdapter(transport)
 	session := testSession()
 	if _, err := adapter.Start(context.Background(), session); err != nil {
 		t.Fatalf("Start: %v", err)
@@ -1932,7 +1892,7 @@ func TestCodexAdapterCancelRejectsPendingPermissionRequest(t *testing.T) {
 
 	transport := newScriptedACPTransport()
 	transport.conn.promptPermission = true
-	adapter := NewCodexAdapter(transport)
+	adapter := NewNexightAdapter(transport)
 	session := testSession()
 	if _, err := adapter.Start(context.Background(), session); err != nil {
 		t.Fatalf("Start: %v", err)
@@ -1989,7 +1949,7 @@ func TestCodexAdapterExecTreatsContextCanceledAsInterrupted(t *testing.T) {
 	transport := newScriptedACPTransport()
 	gate := make(chan struct{})
 	transport.conn.pauseBeforePromptResult = gate
-	adapter := NewCodexAdapter(transport)
+	adapter := NewNexightAdapter(transport)
 	session := testSession()
 	if _, err := adapter.Start(context.Background(), session); err != nil {
 		t.Fatalf("Start: %v", err)
@@ -2046,7 +2006,7 @@ func TestCodexAdapterExecTreatsContextCanceledAsInterrupted(t *testing.T) {
 func TestCodexAdapterRejectsPermissionOutsidePromptTurn(t *testing.T) {
 	t.Parallel()
 
-	adapter := NewCodexAdapter(newScriptedACPTransport())
+	adapter := NewNexightAdapter(newScriptedACPTransport())
 	session := testSession()
 	client := newACPClient(newScriptedACPTransport().conn)
 	_, err := adapter.handleACPMessage(
@@ -2079,7 +2039,7 @@ func TestCodexAdapterSessionStateExposesPendingAskUserPromptAndSubmitsPayload(t 
 
 	transport := newScriptedACPTransport()
 	transport.conn.promptKind = "ask-user"
-	adapter := NewCodexAdapter(transport)
+	adapter := NewNexightAdapter(transport)
 	session := testSession()
 	if _, err := adapter.Start(context.Background(), session); err != nil {
 		t.Fatalf("Start: %v", err)
@@ -2142,7 +2102,7 @@ func TestCodexAdapterSessionStateExposesPendingExitPlanPrompt(t *testing.T) {
 
 	transport := newScriptedACPTransport()
 	transport.conn.promptKind = "exit-plan"
-	adapter := NewCodexAdapter(transport)
+	adapter := NewNexightAdapter(transport)
 	session := testSession()
 	if _, err := adapter.Start(context.Background(), session); err != nil {
 		t.Fatalf("Start: %v", err)
@@ -2189,8 +2149,11 @@ func TestCodexAdapterSessionStateExposesPendingExitPlanPrompt(t *testing.T) {
 func TestCodexAdapterSessionStateIncludesModeCommandsAndConfigUpdates(t *testing.T) {
 	t.Parallel()
 
-	adapter := NewCodexAdapter(newScriptedACPTransport())
+	adapter := NewNexightAdapter(newScriptedACPTransport())
 	session := testSession()
+	// providerConfig is derived from session.Provider; exercise the Codex
+	// base-URL path (still used by the app-server adapter) explicitly.
+	session.Provider = ProviderCodex
 	codexHome := t.TempDir()
 	if err := os.WriteFile(filepath.Join(codexHome, "config.toml"), []byte(`
 model_provider = "proxy"
@@ -2616,7 +2579,7 @@ func testSession() Session {
 	return Session{
 		RoomID:            "room-1",
 		AgentSessionID:    "agent-session-1",
-		Provider:          ProviderCodex,
+		Provider:          ProviderNexight,
 		ProviderSessionID: "agent-session-1",
 		CWD:               "/workspace/room-1",
 		Status:            SessionStatusReady,

--- a/packages/clients/tuttid-ts/src/index.test.ts
+++ b/packages/clients/tuttid-ts/src/index.test.ts
@@ -684,7 +684,7 @@ test("shared tuttid client probes agent providers", async () => {
       return new Response(
         JSON.stringify({
           checkedAt: "2026-06-02T08:00:00.000Z",
-          command: ["/usr/local/bin/codex-acp"],
+          command: ["/usr/local/bin/codex"],
           provider: "codex",
           status: "ready"
         }),
@@ -702,7 +702,7 @@ test("shared tuttid client probes agent providers", async () => {
   assert.equal(requestPath, "/v1/agent-providers/codex/probe");
   assert.deepEqual(result, {
     checkedAt: "2026-06-02T08:00:00.000Z",
-    command: ["/usr/local/bin/codex-acp"],
+    command: ["/usr/local/bin/codex"],
     provider: "codex",
     status: "ready"
   });

--- a/services/tuttid/service/agentstatus/installer.go
+++ b/services/tuttid/service/agentstatus/installer.go
@@ -539,6 +539,23 @@ func (s Service) runExternalAgentRegistryNPMInstaller(ctx context.Context, spec 
 
 func (s Service) selectInstallDir() (string, error) {
 	resolver := s.commandResolver()
+	// Prefer a stable, user-global location (~/.local/bin, then ~/bin) so
+	// installed binaries survive toolchain/version-manager churn and never
+	// land in a volatile or app-scoped PATH entry (e.g. a node-version
+	// manager's bin dir that disappears when that version is removed). These
+	// dirs are always searched by the resolver's knownExecutableDirs, so the
+	// binary stays discoverable even when ~/.local/bin is not on PATH.
+	if home, err := s.homeDir(); err == nil && strings.TrimSpace(home) != "" {
+		for _, dir := range []string{
+			filepath.Join(home, ".local", "bin"),
+			filepath.Join(home, "bin"),
+		} {
+			if err := ensureWritableInstallDir(dir); err == nil {
+				return dir, nil
+			}
+		}
+	}
+	// Fall back to the first writable directory already on the user's PATH.
 	for _, dir := range resolver.UserBinInstallDirs(nil) {
 		if err := ensureWritableInstallDir(dir); err == nil {
 			return dir, nil

--- a/services/tuttid/service/agentstatus/registry.go
+++ b/services/tuttid/service/agentstatus/registry.go
@@ -102,15 +102,12 @@ func DefaultRegistry() Registry {
 			LoginArgs: []string{"auth", "login"},
 		},
 		agentprovider.Codex: {
-			Provider:           agentprovider.Codex,
-			BinaryNames:        []string{"codex"},
-			AdapterBinaryNames: []string{"codex-acp"},
-			AdapterCommand:     []string{"codex-acp"},
-			AuthStatusCommand:  []string{"login", "status"},
-			AuthMarkerPaths:    []string{"~/.codex/auth.json"},
-			Install:            codexCLIInstallerSpec(),
-			AdapterInstall:     codexACPInstallerSpec(),
-			LoginArgs:          []string{"login"},
+			Provider:          agentprovider.Codex,
+			BinaryNames:       []string{"codex"},
+			AuthStatusCommand: []string{"login", "status"},
+			AuthMarkerPaths:   []string{"~/.codex/auth.json"},
+			Install:           codexCLIInstallerSpec(),
+			LoginArgs:         []string{"login"},
 		},
 		agentprovider.Nexight: {
 			Provider:           agentprovider.Nexight,
@@ -177,34 +174,5 @@ func codexCLIInstallerSpec() InstallerSpec {
 		DisplayCommand: "curl -fsSL https://chatgpt.com/codex/install.sh | sh",
 		ScriptURL:      "https://chatgpt.com/codex/install.sh",
 		ScriptShell:    "sh",
-	}
-}
-
-func codexACPInstallerSpec() InstallerSpec {
-	return InstallerSpec{
-		Kind:           InstallerKindGitHubReleaseBinary,
-		DisplayCommand: "Install codex-acp v0.15.0 from GitHub releases",
-		ReleaseBinary: &ReleaseBinaryInstallerSpec{
-			BinaryName: "codex-acp",
-			Version:    "v0.15.0",
-			Assets: map[string]ReleaseBinaryAsset{
-				releaseBinaryPlatformKey("darwin", "arm64"): {
-					URL:    "https://github.com/zed-industries/codex-acp/releases/download/v0.15.0/codex-acp-0.15.0-aarch64-apple-darwin.tar.gz",
-					SHA256: "sha256:356b1faf3aa0feb15781d5c8a86c46e1ab623a2bf4908b251acb35df9af2fb79",
-				},
-				releaseBinaryPlatformKey("darwin", "amd64"): {
-					URL:    "https://github.com/zed-industries/codex-acp/releases/download/v0.15.0/codex-acp-0.15.0-x86_64-apple-darwin.tar.gz",
-					SHA256: "sha256:ffbd10e9a5f19fc4a22469b2dfeea6f8860286b50d2c00c906db06d7a03bb145",
-				},
-				releaseBinaryPlatformKey("linux", "arm64"): {
-					URL:    "https://github.com/zed-industries/codex-acp/releases/download/v0.15.0/codex-acp-0.15.0-aarch64-unknown-linux-gnu.tar.gz",
-					SHA256: "sha256:154bbb0e9d8549c6bc89b7c8d75fb745a3baace18a755bfd69cbc8c177458ba0",
-				},
-				releaseBinaryPlatformKey("linux", "amd64"): {
-					URL:    "https://github.com/zed-industries/codex-acp/releases/download/v0.15.0/codex-acp-0.15.0-x86_64-unknown-linux-gnu.tar.gz",
-					SHA256: "sha256:71dcf628a618a82f3b7f3b7383182cdf33dd41c1cbecaf7e3c833f36e44155d1",
-				},
-			},
-		},
 	}
 }

--- a/services/tuttid/service/agentstatus/registry.go
+++ b/services/tuttid/service/agentstatus/registry.go
@@ -168,11 +168,13 @@ func DefaultRegistry() Registry {
 	return Registry{Specs: specs}
 }
 
+// codexCLIInstallerSpec installs the first-party codex binary via the
+// daemon-managed GitHub-release installer. This runs headlessly (HTTP download
+// + checksum + extract + symlink), unlike the official `curl … | sh` script
+// which aborts with "stdin is not a terminal" when run without a TTY.
 func codexCLIInstallerSpec() InstallerSpec {
 	return InstallerSpec{
-		Kind:           InstallerKindOfficialScript,
-		DisplayCommand: "curl -fsSL https://chatgpt.com/codex/install.sh | sh",
-		ScriptURL:      "https://chatgpt.com/codex/install.sh",
-		ScriptShell:    "sh",
+		Kind:     InstallerKindCodexCLILatest,
+		CodexCLI: &CodexCLILatestInstallerSpec{},
 	}
 }

--- a/services/tuttid/service/agentstatus/registry.go
+++ b/services/tuttid/service/agentstatus/registry.go
@@ -102,12 +102,19 @@ func DefaultRegistry() Registry {
 			LoginArgs: []string{"auth", "login"},
 		},
 		agentprovider.Codex: {
-			Provider:          agentprovider.Codex,
-			BinaryNames:       []string{"codex"},
-			AuthStatusCommand: []string{"login", "status"},
-			AuthMarkerPaths:   []string{"~/.codex/auth.json"},
-			Install:           codexCLIInstallerSpec(),
-			LoginArgs:         []string{"login"},
+			Provider:    agentprovider.Codex,
+			BinaryNames: []string{"codex"},
+			// Codex talks to the local codex binary's built-in app-server; there
+			// is no separate ACP adapter. Resolve/probe that command directly so
+			// availability reflects "codex app-server" rather than bare `codex`
+			// (which is an interactive TUI and fails headless with
+			// "stdin is not a terminal").
+			AdapterBinaryNames: []string{"codex"},
+			AdapterCommand:     []string{"codex", "app-server"},
+			AuthStatusCommand:  []string{"login", "status"},
+			AuthMarkerPaths:    []string{"~/.codex/auth.json"},
+			Install:            codexCLIInstallerSpec(),
+			LoginArgs:          []string{"login"},
 		},
 		agentprovider.Nexight: {
 			Provider:           agentprovider.Nexight,

--- a/services/tuttid/service/agentstatus/service_test.go
+++ b/services/tuttid/service/agentstatus/service_test.go
@@ -111,6 +111,37 @@ func TestServiceListReportsLoginAndRefreshActionsWhenAuthMarkerMissing(t *testin
 	}
 }
 
+// specWithSeparateAdapter returns a synthetic provider spec that ships a
+// distinct ACP adapter binary (separate from its CLI). The codex provider no
+// longer has one — it talks to the codex app-server directly — but the
+// separate-adapter machinery is still exercised by other providers (e.g.
+// nexight), so these tests pin a local spec rather than DefaultRegistry's codex.
+func specWithSeparateAdapter() ProviderSpec {
+	return ProviderSpec{
+		Provider:           "codex",
+		BinaryNames:        []string{"codex"},
+		AdapterBinaryNames: []string{"codex-acp"},
+		AdapterCommand:     []string{"codex-acp"},
+		AuthMarkerPaths:    []string{"~/.codex/auth.json"},
+		Install: InstallerSpec{
+			Kind:           InstallerKindOfficialScript,
+			DisplayCommand: "curl -fsSL https://chatgpt.com/codex/install.sh | sh",
+			ScriptURL:      "https://chatgpt.com/codex/install.sh",
+			ScriptShell:    "sh",
+		},
+		AdapterInstall: InstallerSpec{
+			Kind:           InstallerKindGitHubReleaseBinary,
+			DisplayCommand: "Install test adapter from GitHub releases",
+			ReleaseBinary: &ReleaseBinaryInstallerSpec{
+				BinaryName: "codex-acp",
+				Version:    "v0.0.0-test",
+				Assets:     map[string]ReleaseBinaryAsset{},
+			},
+		},
+		LoginArgs: []string{"login"},
+	}
+}
+
 func TestServiceListReportsInstallActionWhenACPAdapterMissing(t *testing.T) {
 	service := testService(func(name string) (string, error) {
 		if name == "codex" {
@@ -118,6 +149,7 @@ func TestServiceListReportsInstallActionWhenACPAdapterMissing(t *testing.T) {
 		}
 		return "", errors.New("not found")
 	}, map[string]bool{"/home/test/.codex/auth.json": true})
+	service.Registry = Registry{Specs: []ProviderSpec{specWithSeparateAdapter()}}
 
 	snapshot, err := service.List(context.Background(), ListInput{Providers: []string{"codex"}})
 	if err != nil {
@@ -252,6 +284,7 @@ func TestServiceListReportsInstallActionWhenCodexAdapterCommandFails(t *testing.
 	writeExecutable(t, adapterPath, "#!/bin/sh\necho 'codex-acp failed to start' >&2\nexit 127\n")
 
 	service := Service{
+		Registry: Registry{Specs: []ProviderSpec{specWithSeparateAdapter()}},
 		Environ: func() []string {
 			return []string{"PATH=" + binDir}
 		},
@@ -585,6 +618,7 @@ func TestServiceListUsesRuntimeCommandResolverForKnownNodeGlobalBin(t *testing.T
 	writeExecutable(t, adapterPath, "#!/bin/sh\nexit 0\n")
 
 	service := Service{
+		Registry: Registry{Specs: []ProviderSpec{specWithSeparateAdapter()}},
 		Environ: func() []string {
 			return []string{"PATH=/usr/bin:/bin"}
 		},
@@ -630,7 +664,9 @@ func TestServiceProbeReportsReadyWhenAdapterStarts(t *testing.T) {
 	adapterPath := filepath.Join(binDir, "codex-acp")
 	writeExecutable(t, adapterPath, "#!/bin/sh\nsleep 5\n")
 
-	result, err := probeTestService(home).Probe(context.Background(), ProbeInput{Provider: "codex"})
+	service := probeTestService(home)
+	service.Registry = Registry{Specs: []ProviderSpec{specWithSeparateAdapter()}}
+	result, err := service.Probe(context.Background(), ProbeInput{Provider: "codex"})
 	if err != nil {
 		t.Fatalf("Probe() error = %v", err)
 	}
@@ -665,8 +701,12 @@ func TestServiceProbeReportsFailureWhenAdapterCommandCannotStart(t *testing.T) {
 			ScriptURL:      "https://chatgpt.com/codex/install.sh",
 			ScriptShell:    "sh",
 		},
-		AdapterInstall: codexACPInstallerSpec(),
-		LoginArgs:      []string{"login"},
+		AdapterInstall: InstallerSpec{
+			Kind:           InstallerKindShellCommand,
+			DisplayCommand: "install adapter",
+			ShellCommand:   "true",
+		},
+		LoginArgs: []string{"login"},
 	}}}
 
 	result, err := service.Probe(context.Background(), ProbeInput{Provider: "codex"})

--- a/services/tuttid/service/agentstatus/service_test.go
+++ b/services/tuttid/service/agentstatus/service_test.go
@@ -1855,8 +1855,10 @@ func TestRegistrySelectNormalizesAndDeduplicatesProviders(t *testing.T) {
 	}
 }
 
-func TestServiceSelectInstallDirPrefersWritablePathDir(t *testing.T) {
+func TestServiceSelectInstallDirPrefersUserLocalBin(t *testing.T) {
 	home := t.TempDir()
+	// A writable directory on PATH must NOT be preferred over the stable
+	// user-global ~/.local/bin (created on demand).
 	pathDir := filepath.Join(home, "custom-bin")
 	if err := os.MkdirAll(pathDir, 0o755); err != nil {
 		t.Fatalf("mkdir path dir: %v", err)
@@ -1874,8 +1876,33 @@ func TestServiceSelectInstallDirPrefersWritablePathDir(t *testing.T) {
 	if err != nil {
 		t.Fatalf("selectInstallDir() error = %v", err)
 	}
+	want := filepath.Join(home, ".local", "bin")
+	if installDir != want {
+		t.Fatalf("installDir = %q, want %q", installDir, want)
+	}
+}
+
+func TestServiceSelectInstallDirFallsBackToPathDirWhenHomeUnavailable(t *testing.T) {
+	root := t.TempDir()
+	pathDir := filepath.Join(root, "custom-bin")
+	if err := os.MkdirAll(pathDir, 0o755); err != nil {
+		t.Fatalf("mkdir path dir: %v", err)
+	}
+	service := Service{
+		Environ: func() []string {
+			return []string{"PATH=" + pathDir}
+		},
+		HomeDir: func() (string, error) {
+			return "", errors.New("home unavailable")
+		},
+	}
+
+	installDir, err := service.selectInstallDir()
+	if err != nil {
+		t.Fatalf("selectInstallDir() error = %v", err)
+	}
 	if installDir != pathDir {
-		t.Fatalf("installDir = %q, want %q", installDir, pathDir)
+		t.Fatalf("installDir = %q, want %q (PATH fallback)", installDir, pathDir)
 	}
 }
 

--- a/services/tuttid/service/agentstatus/service_test.go
+++ b/services/tuttid/service/agentstatus/service_test.go
@@ -60,7 +60,7 @@ func TestServiceListReportsInstallActionWhenCLIMissing(t *testing.T) {
 	}
 }
 
-func TestDefaultRegistryUsesOfficialCodexInstallerScript(t *testing.T) {
+func TestDefaultRegistryUsesCodexCLILatestInstaller(t *testing.T) {
 	specs, err := DefaultRegistry().Select([]string{"codex"})
 	if err != nil {
 		t.Fatalf("Select() error = %v", err)
@@ -69,13 +69,11 @@ func TestDefaultRegistryUsesOfficialCodexInstallerScript(t *testing.T) {
 		t.Fatalf("len(specs) = %d, want 1", len(specs))
 	}
 	install := specs[0].Install
-	if install.Kind != InstallerKindOfficialScript {
-		t.Fatalf("Install.Kind = %q, want %q", install.Kind, InstallerKindOfficialScript)
+	if install.Kind != InstallerKindCodexCLILatest {
+		t.Fatalf("Install.Kind = %q, want %q", install.Kind, InstallerKindCodexCLILatest)
 	}
-	if install.DisplayCommand != "curl -fsSL https://chatgpt.com/codex/install.sh | sh" ||
-		install.ScriptURL != "https://chatgpt.com/codex/install.sh" ||
-		install.ScriptShell != "sh" {
-		t.Fatalf("Install = %#v, want official Codex installer script", install)
+	if install.CodexCLI == nil {
+		t.Fatalf("Install.CodexCLI = nil, want daemon-managed codex CLI installer spec")
 	}
 }
 


### PR DESCRIPTION
## Why

The `codex` provider shipped a legacy ACP integration surface (a separate `codex-acp` binary + GitHub-release download) that the runtime no longer uses — the controller has run the first-party **codex app-server** adapter for some time. This removes that dead surface so codex depends solely on the local `codex` binary / app-server, and fixes the availability + install flows that the removal exposed.

## What changed (4 commits)

**1. Remove codex-acp packages & install logic**
- `registry.go`: dropped the `codex-acp` adapter declaration and the v0.15.0 GitHub download (`codexACPInstallerSpec`).
- `codex_adapter.go`: deleted the codex-specific `NewCodexAdapter` constructors + `codexACPCommand`. The shared `CodexAdapter` ("codex family") machinery stays — it is the **live adapter for the Nexight provider** (`controller.go` → `NewNexightAdapterWithHostMetadata`), so it could not be deleted outright.
- Tests repointed to the Nexight constructor; frontend fixtures that referenced `codex-acp` refreshed.

**2. Install codex via the daemon-managed first-party binary, not `curl | sh`**
Codex's only install action was the OfficialScript `curl … chatgpt.com/codex/install.sh | sh`. Install actions run daemon-side and headless (no PTY), so the script's `[ -t 0 ]` check aborted with "stdin is not a terminal". Switched codex's `Install` to the existing daemon-managed `InstallerKindCodexCLILatest`, which downloads the codex binary from GitHub releases (HTTP + checksum + extract + symlink) with no shell/TTY.

**3. Resolve/probe codex via `codex app-server`, not a separate ACP adapter**
Removing codex's `AdapterCommand` left the status/start gate probing bare `codex` (an interactive TUI that exits 1 headless with "stdin is not a terminal"), surfacing as "codex: ACP adapter not found" and blocking sends. Point codex's adapter command at `codex app-server`, which exits 0 cleanly when probed → `ProbeReady`. Codex availability now means "codex CLI present + authenticated", exactly as the app-server architecture intends — no separate adapter, no extra install.

**4. Install user CLIs to `~/.local/bin`, not the first writable PATH dir**
`selectInstallDir` picked the first writable PATH entry, which can be a volatile, non-global location (e.g. a node-version-manager's `~/.nvm/versions/node/<v>/bin` that disappears when that version is removed). Prefer `~/.local/bin` (then `~/bin`, created on demand), falling back to PATH entries only when no home-global dir is writable. These are already in the resolver's `knownExecutableDirs`, so the binary stays discoverable even when `~/.local/bin` is off PATH. (The codex package itself already extracts under `~/.codex/packages/standalone`; this only fixes where the visible symlink lands.)

## Verification
- Go: `go build` both modules; tests green for runtime, agentstatus, agent service, api.
- TS: `@tutti-os/client-tuttid-ts` and `@tutti-os/desktop` suites green.
- Pre-push `check:full` passed on each push.
- Empirical: `codex app-server </dev/null` exits 0 (probe ready); bare `codex </dev/null` exits 1 with the stdin/terminal error (the old path).
- Manual desktop check recommended: restart the app so it respawns the rebuilt daemon, then open Codex — it should be ready directly (no install link, no "ACP adapter not found").

🤖 Generated with [Claude Code](https://claude.com/claude-code)