### PR TITLE
fix(agent): inject macOS system proxy into agent install & login

### DIFF
--- a/packages/agent/daemon/runtimecmd/proxy.go
+++ b/packages/agent/daemon/runtimecmd/proxy.go
@@ -3,6 +3,8 @@ package runtimecmd
 import (
 	"context"
 	"net"
+	"net/http"
+	"net/url"
 	"os/exec"
 	"runtime"
 	"strings"
@@ -46,6 +48,74 @@ func (r Resolver) injectSystemProxyEnv(env []string) []string {
 		env = append(env, key+"="+value)
 	}
 	return env
+}
+
+// InjectSystemProxyEnv appends the macOS system proxy variables
+// (HTTPS_PROXY/HTTP_PROXY/NO_PROXY) to env for any key not already present,
+// reading the same SystemConfiguration source as Resolver.Env(). It exists so
+// the spawn paths that build their own environment instead of going through
+// Resolver.Env() — managed-runtime installs, agent logins, workspace terminals —
+// get identical proxy treatment. No-op on non-macOS or when no system proxy is
+// configured; never overrides a user/session-set value.
+func InjectSystemProxyEnv(env []string) []string {
+	return Resolver{}.injectSystemProxyEnv(env)
+}
+
+// SystemProxyURL returns the macOS system proxy (HTTPS preferred, then HTTP) as
+// a URL, if one is configured. In-process HTTP clients (e.g. installer
+// downloads) cannot inherit a spawned child's injected env, so they consult this
+// directly. Returns (nil, false) on non-macOS or when no proxy is set.
+func SystemProxyURL() (*url.URL, bool) {
+	return systemProxyURLFrom(Resolver{}.systemProxyEnv())
+}
+
+// systemProxyURLFrom parses the HTTPS (preferred) or HTTP proxy URL out of a
+// proxy env map. Split out so the URL-selection logic is testable without
+// invoking scutil.
+func systemProxyURLFrom(proxyEnv map[string]string) (*url.URL, bool) {
+	raw := strings.TrimSpace(proxyEnv["HTTPS_PROXY"])
+	if raw == "" {
+		raw = strings.TrimSpace(proxyEnv["HTTP_PROXY"])
+	}
+	if raw == "" {
+		return nil, false
+	}
+	parsed, err := url.Parse(raw)
+	if err != nil || parsed == nil {
+		return nil, false
+	}
+	return parsed, true
+}
+
+// HTTPProxyFunc returns an http.Transport.Proxy function that prefers an
+// explicit proxy from the process environment (honoring NO_PROXY) and falls back
+// to the macOS system proxy. It mirrors InjectSystemProxyEnv for in-process
+// downloads so installs from a restricted region don't connect directly and hit
+// `403 Request not allowed`. The system-proxy fallback is resolved once, when
+// the function is built.
+func HTTPProxyFunc() func(*http.Request) (*url.URL, error) {
+	systemURL, hasSystem := SystemProxyURL()
+	return httpProxyFunc(http.ProxyFromEnvironment, systemURL, hasSystem)
+}
+
+// httpProxyFunc builds the proxy selector from its dependencies so the
+// env-first / system-fallback precedence is testable without touching the real
+// process environment or scutil.
+func httpProxyFunc(
+	envProxy func(*http.Request) (*url.URL, error),
+	systemURL *url.URL,
+	hasSystem bool,
+) func(*http.Request) (*url.URL, error) {
+	return func(req *http.Request) (*url.URL, error) {
+		envURL, err := envProxy(req)
+		if err != nil || envURL != nil {
+			return envURL, err
+		}
+		if hasSystem {
+			return systemURL, nil
+		}
+		return nil, nil
+	}
 }
 
 func (r Resolver) systemProxyEnv() map[string]string {

--- a/packages/agent/daemon/runtimecmd/proxy_test.go
+++ b/packages/agent/daemon/runtimecmd/proxy_test.go
@@ -1,6 +1,8 @@
 package runtimecmd
 
 import (
+	"net/http"
+	"net/url"
 	"strings"
 	"testing"
 )
@@ -135,5 +137,108 @@ func TestEnvNoProxyWhenScutilUnavailable(t *testing.T) {
 	env := resolver.Env(nil)
 	if got := envValue(env, "HTTPS_PROXY"); got != "" {
 		t.Fatalf("HTTPS_PROXY = %q, want empty when scutil unavailable", got)
+	}
+}
+
+func TestSystemProxyURLFromPrefersHTTPS(t *testing.T) {
+	got, ok := systemProxyURLFrom(map[string]string{
+		"HTTPS_PROXY": "http://127.0.0.1:7890",
+		"HTTP_PROXY":  "http://127.0.0.1:1080",
+	})
+	if !ok {
+		t.Fatalf("systemProxyURLFrom() ok = false, want true")
+	}
+	if got.String() != "http://127.0.0.1:7890" {
+		t.Fatalf("systemProxyURLFrom() = %q, want HTTPS entry http://127.0.0.1:7890", got)
+	}
+}
+
+func TestSystemProxyURLFromFallsBackToHTTP(t *testing.T) {
+	got, ok := systemProxyURLFrom(map[string]string{
+		"HTTP_PROXY": "http://10.0.0.2:3128",
+	})
+	if !ok {
+		t.Fatalf("systemProxyURLFrom() ok = false, want true")
+	}
+	if got.String() != "http://10.0.0.2:3128" {
+		t.Fatalf("systemProxyURLFrom() = %q, want http://10.0.0.2:3128", got)
+	}
+}
+
+func TestSystemProxyURLFromEmptyReturnsFalse(t *testing.T) {
+	if got, ok := systemProxyURLFrom(nil); ok {
+		t.Fatalf("systemProxyURLFrom(nil) = (%v, true), want (nil, false)", got)
+	}
+	if got, ok := systemProxyURLFrom(map[string]string{"HTTPS_PROXY": "  "}); ok {
+		t.Fatalf("systemProxyURLFrom(blank) = (%v, true), want (nil, false)", got)
+	}
+}
+
+func mustParseURL(t *testing.T, raw string) *url.URL {
+	t.Helper()
+	parsed, err := url.Parse(raw)
+	if err != nil {
+		t.Fatalf("url.Parse(%q): %v", raw, err)
+	}
+	return parsed
+}
+
+func TestHTTPProxyFuncPrefersEnvProxy(t *testing.T) {
+	envURL := mustParseURL(t, "http://env-proxy:8080")
+	systemURL := mustParseURL(t, "http://system-proxy:7890")
+	fn := httpProxyFunc(
+		func(*http.Request) (*url.URL, error) { return envURL, nil },
+		systemURL, true,
+	)
+	got, err := fn(&http.Request{})
+	if err != nil {
+		t.Fatalf("proxy func err = %v", err)
+	}
+	if got != envURL {
+		t.Fatalf("proxy = %v, want env proxy %v (env wins over system)", got, envURL)
+	}
+}
+
+func TestHTTPProxyFuncFallsBackToSystem(t *testing.T) {
+	systemURL := mustParseURL(t, "http://system-proxy:7890")
+	fn := httpProxyFunc(
+		func(*http.Request) (*url.URL, error) { return nil, nil },
+		systemURL, true,
+	)
+	got, err := fn(&http.Request{})
+	if err != nil {
+		t.Fatalf("proxy func err = %v", err)
+	}
+	if got != systemURL {
+		t.Fatalf("proxy = %v, want system proxy %v when env has none", got, systemURL)
+	}
+}
+
+func TestHTTPProxyFuncDirectWhenNoneConfigured(t *testing.T) {
+	fn := httpProxyFunc(
+		func(*http.Request) (*url.URL, error) { return nil, nil },
+		nil, false,
+	)
+	got, err := fn(&http.Request{})
+	if err != nil {
+		t.Fatalf("proxy func err = %v", err)
+	}
+	if got != nil {
+		t.Fatalf("proxy = %v, want nil (direct) when nothing configured", got)
+	}
+}
+
+func TestHTTPProxyFuncPropagatesEnvError(t *testing.T) {
+	wantErr := http.ErrNoCookie
+	fn := httpProxyFunc(
+		func(*http.Request) (*url.URL, error) { return nil, wantErr },
+		mustParseURL(t, "http://system-proxy:7890"), true,
+	)
+	got, err := fn(&http.Request{})
+	if err != wantErr {
+		t.Fatalf("err = %v, want %v (env error surfaces, no system fallback)", err, wantErr)
+	}
+	if got != nil {
+		t.Fatalf("proxy = %v, want nil on env error", got)
 	}
 }

--- a/services/tuttid/service/agentstatus/installer.go
+++ b/services/tuttid/service/agentstatus/installer.go
@@ -739,7 +739,13 @@ func (s Service) httpClient() *http.Client {
 	if s.HTTPClient != nil {
 		return s.HTTPClient
 	}
-	return http.DefaultClient
+	// Route downloads (codex CLI package, claude install.sh, release binaries)
+	// through the macOS system proxy. This is an in-process HTTP call, so it
+	// cannot inherit the proxy env we inject into spawned children — resolve it
+	// directly. Prefers an explicit env proxy, falls back to the system proxy.
+	transport := http.DefaultTransport.(*http.Transport).Clone()
+	transport.Proxy = runtimecmd.HTTPProxyFunc()
+	return &http.Client{Transport: transport}
 }
 
 func joinShellCommand(parts []string) string {

--- a/services/tuttid/service/managedruntime/runtime.go
+++ b/services/tuttid/service/managedruntime/runtime.go
@@ -14,6 +14,7 @@ import (
 	"sync"
 	"unicode"
 
+	"github.com/tutti-os/tutti/packages/agentactivity/daemon/runtimecmd"
 	tuttitypes "github.com/tutti-os/tutti/services/tuttid/types"
 )
 
@@ -607,7 +608,11 @@ func ProcessEnv(overrides ...string) []string {
 		}
 		env = append(next, override)
 	}
-	return env
+	// Inject the macOS system proxy so processes spawned with this env (agent
+	// installs, workspace apps) reach the upstream API through the same proxy as
+	// Resolver.Env()-spawned agents. Without it, an install from a restricted
+	// region connects directly and gets `403 Request not allowed`.
+	return runtimecmd.InjectSystemProxyEnv(env)
 }
 
 func EnvValue(env []string, key string) string {

--- a/services/tuttid/service/workspace/terminal_helpers.go
+++ b/services/tuttid/service/workspace/terminal_helpers.go
@@ -8,6 +8,8 @@ import (
 	"runtime"
 	"strings"
 	"time"
+
+	"github.com/tutti-os/tutti/packages/agentactivity/daemon/runtimecmd"
 )
 
 func defaultTerminalHomeDir() (string, error) {
@@ -75,11 +77,15 @@ func resolveTerminalShellInvocation(shell string) []string {
 }
 
 func terminalProcessEnv(cwd string) []string {
-	return append(os.Environ(),
+	// Inject the macOS system proxy so commands run in the workspace terminal —
+	// notably agent `login` flows — reach the upstream API through the same proxy
+	// as spawned agents, instead of connecting directly and hitting `403 Request
+	// not allowed` from a restricted region.
+	return runtimecmd.InjectSystemProxyEnv(append(os.Environ(),
 		"PWD="+cwd,
 		"TERM=xterm-256color",
 		"COLORTERM=truecolor",
-	)
+	))
 }
 
 func normalizeTerminalDimension(value *int, fallback int) int {


### PR DESCRIPTION
## Problem

When only the macOS **system proxy** is enabled (no `HTTP(S)_PROXY` env var exported), installing or logging in to **codex / claude** from a restricted region fails with `403 Request not allowed` — even though *running* an already-installed agent works fine.

Root cause: system-proxy injection was wired into **`Resolver.Env()` only**, which feeds spawned ACP agents. The paths that build their own environment never got it:

| Path | Used by | Proxy before |
|---|---|---|
| `managedruntime.ProcessEnv()` | claude-agent-acp **npm install**, acp patch, workspace apps | ❌ raw `os.Environ()` |
| `terminalProcessEnv()` | **agent `login`** (terminal action) + all workspace terminals | ❌ raw `os.Environ()` |
| `installer.httpClient()` → `http.DefaultClient` | **codex CLI download**, **claude `install.sh`**, release binaries | ❌ ignores macOS system proxy |

The install-via-`Resolver.Env()` paths (gemini/openclaw `ShellCommand`, claude `OfficialScript` bash subprocess) already had the proxy and are unchanged.

## Fix

- Export the existing injection as `runtimecmd.InjectSystemProxyEnv(env)`, and add `SystemProxyURL()` / `HTTPProxyFunc()` for in-process HTTP clients (which can't inherit a spawned child's env).
- Apply them in `ProcessEnv`, `terminalProcessEnv`, and the installer's `httpClient` so **install and login get the same proxy treatment as spawned agents**.
- Behavior preserved: prefers an explicit user/session-set proxy, never overrides it; no-op on non-macOS and when no system proxy is configured.

## Tests

- New unit tests for `systemProxyURLFrom` (HTTPS-preferred / HTTP-fallback / empty) and `httpProxyFunc` (env-wins / system-fallback / direct / error-propagation).
- `go build` + `go vet` pass for `runtimecmd`, `managedruntime`, `workspace`, `agentstatus`; full `runtimecmd` test suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * HTTP downloads and terminal processes now automatically respect macOS system proxy settings, preventing connection failures in restricted regions.
  * System proxy configuration is automatically applied to package installations and CLI tool downloads.

* **Tests**
  * Added comprehensive test coverage for proxy selection and fallback behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->