### PR TITLE
[codex] Refresh app updates before download

### DIFF
--- a/apps/desktop/src/main/update/appUpdateService.test.ts
+++ b/apps/desktop/src/main/update/appUpdateService.test.ts
@@ -179,6 +179,76 @@ test("createAppUpdateService skips downloading state when cached update is alrea
   }
 });
 
+test("createAppUpdateService refreshes update availability before downloading", async () => {
+  const listeners: {
+    checking?: () => void;
+    available?: (info: UpdateInfo) => void;
+    downloaded?: (info: UpdateDownloadedEvent) => void;
+  } = {};
+  const emittedStatuses: string[] = [];
+  let checkCallCount = 0;
+  let emitFreshAvailability = false;
+  let latestAvailableVersion = "1.1.0";
+  let downloadedVersion: string | null = null;
+  const driver = createFakeDriver({
+    async checkForUpdates() {
+      checkCallCount += 1;
+      listeners.checking?.();
+      if (!emitFreshAvailability) {
+        return;
+      }
+      latestAvailableVersion = "1.2.0";
+      listeners.available?.(createUpdateInfoFixture(latestAvailableVersion));
+    },
+    async downloadUpdate() {
+      downloadedVersion = latestAvailableVersion;
+      listeners.downloaded?.(
+        createUpdateDownloadedInfoFixture(latestAvailableVersion)
+      );
+    },
+    onUpdateAvailable(listener) {
+      listeners.available = listener;
+      return noop;
+    },
+    onCheckingForUpdate(listener) {
+      listeners.checking = listener;
+      return noop;
+    },
+    onUpdateDownloaded(listener) {
+      listeners.downloaded = listener;
+      return noop;
+    }
+  });
+  const service = createAppUpdateService(driver, {
+    supportsUpdates: true
+  });
+
+  try {
+    service.onStateChanged((state) => {
+      emittedStatuses.push(state.status);
+    });
+    await service.configure({
+      channel: "stable",
+      policy: "prompt"
+    });
+    await service.checkForUpdates();
+    listeners.available?.(createUpdateInfoFixture("1.1.0"));
+    emittedStatuses.length = 0;
+
+    const checksBeforeDownload = checkCallCount;
+    emitFreshAvailability = true;
+    const state = await service.downloadUpdate();
+
+    assert.equal(checkCallCount, checksBeforeDownload + 1);
+    assert.equal(downloadedVersion, "1.2.0");
+    assert.equal(state.latestVersion, "1.2.0");
+    assert.equal(state.status, "downloaded");
+    assert.deepEqual(emittedStatuses, ["available", "downloaded"]);
+  } finally {
+    service.dispose();
+  }
+});
+
 test("createElectronUpdaterLogger defers no published versions errors during prefixed fallback", () => {
   const calls: Array<{ level: string; message: string }> = [];
   const logger = createElectronUpdaterLogger({

--- a/apps/desktop/src/main/update/appUpdateService.ts
+++ b/apps/desktop/src/main/update/appUpdateService.ts
@@ -28,7 +28,7 @@ import {
 
 const { app, BrowserWindow } = electron;
 
-const updateCheckIntervalMs = 1000 * 60 * 60 * 6;
+const updateCheckIntervalMs = 1000 * 60 * 60 * 3;
 
 type DriverDisposer = () => void;
 
@@ -471,6 +471,7 @@ export function createAppUpdateService(
   let intervalId: ReturnType<typeof setInterval> | null = null;
   let activeCheckPromise: Promise<void> | null = null;
   let activeDownloadPromise: Promise<void> | null = null;
+  let preserveAvailableStateDuringCheck = false;
   const stateChangedListeners = new Set<
     (state: AppUpdateState, previousState: AppUpdateState) => void
   >();
@@ -534,6 +535,9 @@ export function createAppUpdateService(
         channel: state.channel,
         policy: state.policy
       });
+      if (preserveAvailableStateDuringCheck && state.status === "available") {
+        return;
+      }
       applyState({
         ...buildBaseState(
           currentVersion,
@@ -720,12 +724,26 @@ export function createAppUpdateService(
       }
     },
     async downloadUpdate() {
-      if (!supportsUpdates || state.status !== "available") {
+      if (!supportsUpdates) {
         return state;
       }
 
       if (activeDownloadPromise) {
         await activeDownloadPromise;
+        return state;
+      }
+
+      if (state.status !== "available") {
+        return state;
+      }
+
+      preserveAvailableStateDuringCheck = true;
+      try {
+        await service.checkForUpdates();
+      } finally {
+        preserveAvailableStateDuringCheck = false;
+      }
+      if (state.status !== "available") {
         return state;
       }
 

--- a/docs/conventions/desktop-release.md
+++ b/docs/conventions/desktop-release.md
@@ -115,7 +115,7 @@ Current updater behavior:
 - stable channel only
 - packaged builds only
 - default policy is `prompt`
-- scheduled update check interval is six hours
+- scheduled update check interval is three hours
 - macOS update checks are disabled for unsupported unsigned or ad-hoc bundles
 
 macOS auto-update metadata must keep x64, arm64, and universal zip entries in `latest-mac.yml`. The file names must include `${arch}` so `electron-updater` can distinguish `mac-x64`, `mac-arm64`, and `mac-universal` assets.


### PR DESCRIPTION
## Summary
- Reduce the scheduled desktop update check interval from six hours to three hours.
- Refresh update availability before starting a download so the latest available version is selected at click time.
- Add a regression test for the stale A -> fresh B download scenario and update the release convention docs.

## Test Plan
- `node --import ./test/register-asset-stub.mjs --test --experimental-strip-types ./src/main/update/appUpdateService.test.ts`
- `pnpm exec oxfmt --check apps/desktop/src/main/update/appUpdateService.ts apps/desktop/src/main/update/appUpdateService.test.ts`
- `pnpm --filter @tutti-os/desktop test -- src/main/update/appUpdateService.test.ts`

## Notes
- Local pre-push `pnpm check:full` reached an unrelated existing Go failure in `services/tuttid/service/agentstatus`: `TestServiceRunActionSerializesConcurrentExternalRegistryNPMInstalls` reports `npm install calls = 1, want serialized duplicate installs`. The branch changes only desktop updater files and docs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved state management during update availability refresh and download process.

* **Tests**
  * Added test for update availability check and download flow validation.

* **Documentation**
  * Updated scheduled update check interval from 6 hours to 3 hours.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->