### PR TITLE
fix(agent): inject macOS system proxy into auth-status & git subprocesses

### DIFF
--- a/services/tuttid/service/agent/git_branches.go
+++ b/services/tuttid/service/agent/git_branches.go
@@ -6,6 +6,8 @@ import (
 	"os/exec"
 	"strings"
 	"time"
+
+	"github.com/tutti-os/tutti/packages/agentactivity/daemon/runtimecmd"
 )
 
 // gitBranchListTimeout bounds the git subprocesses backing the review picker so
@@ -69,7 +71,10 @@ func runGit(ctx context.Context, cwd string, args ...string) (string, error) {
 	// Resolve the repository from cwd, never from an ambient GIT_DIR/GIT_WORK_TREE
 	// in the daemon's environment, so the picker always reflects the session's
 	// working directory.
-	cmd.Env = gitEnvScopedToDir()
+	// Inject the macOS system proxy for parity with the other agent subprocesses.
+	// Branch discovery is local, so this is a no-op today, but keeps the env
+	// consistent if git ever needs to reach a remote here.
+	cmd.Env = runtimecmd.InjectSystemProxyEnv(gitEnvScopedToDir())
 	out, err := cmd.Output()
 	if err != nil {
 		return "", err

--- a/services/tuttid/service/agentstatus/service_helpers.go
+++ b/services/tuttid/service/agentstatus/service_helpers.go
@@ -258,6 +258,11 @@ func runAuthStatusCommand(ctx context.Context, spec ProviderSpec, binaryPath str
 	commandCtx, cancel := context.WithTimeout(ctx, authStatusCommandTimeout)
 	defer cancel()
 	command := exec.CommandContext(commandCtx, binaryPath, spec.AuthStatusCommand...)
+	// Inject the macOS system proxy so the auth-status probe reaches the upstream
+	// API through the same proxy as spawned agents (mirroring agent install &
+	// login), instead of connecting directly and hitting `403 Request not allowed`
+	// from a restricted region.
+	command.Env = runtimecmd.InjectSystemProxyEnv(os.Environ())
 	output, err := command.Output()
 	if err != nil {
 		if exitErr, ok := err.(*exec.ExitError); ok {


### PR DESCRIPTION
## What

补齐 daemon 里两个**自行构建 env、未注入 macOS 系统代理**的子进程启动点,让它们和已有的 agent install / login / 运行时 / terminal 一致地走系统代理。受限网络下,这些子进程之前会直连上游 API 而拿到 `403 Request not allowed`。

| 文件 | 改动 |
|---|---|
| `service/agentstatus/service_helpers.go` (`runAuthStatusCommand`) | 之前**完全没设 `cmd.Env`** → 直接继承裸 daemon 环境。改为 `command.Env = runtimecmd.InjectSystemProxyEnv(os.Environ())`,auth 探活走与 install/login 相同的代理 |
| `service/agent/git_branches.go` (`runGit`) | 改为 `InjectSystemProxyEnv(gitEnvScopedToDir())` 以保持一致。注:分支发现是本地操作,这里实际是 no-op,仅为统一 env |

## Why

系统代理注入的现状梳理:其余起子进程的点(terminal PTY、app bootstrap/prepare、ACP agent 运行时、agentstatus probe/install、codex catalog 等)都已间接走 `Resolver.Env()` 或 `managedruntime.ProcessEnv()`,二者末尾都会调 `InjectSystemProxyEnv`。唯独 `runAuthStatusCommand` 漏注入(真缺口),`runGit` 未统一。本 PR 补齐这两处。

## Behavior

`InjectSystemProxyEnv` 只在 macOS 生效、跳过 SOCKS、**只补不覆盖**用户/会话已设的 `HTTPS_PROXY/HTTP_PROXY/NO_PROXY`,因此对已正确配置代理的环境无副作用。

## Test

- `go build ./service/agent/... ./service/agentstatus/...` ✅
- `go test ./service/agent/... ./service/agentstatus/...` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved macOS system proxy support for Git operations and authentication status checks, ensuring these processes now properly respect system proxy settings for better network connectivity in enterprise environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->