### PR TITLE
[codex] Expose workspace browser open bridge

### DIFF
--- a/apps/desktop/src/main/ipc/workspaceAppContext.ts
+++ b/apps/desktop/src/main/ipc/workspaceAppContext.ts
@@ -878,6 +878,7 @@ function createWorkspaceAppContext(
   return {
     appId: context.appID,
     capabilities: [
+      "browser.openUrl@1",
       "files.open@1",
       "pdf.printHtmlToPdf@1",
       "userProjects@1",

--- a/apps/desktop/src/preload/entries/workspaceAppExternalBridge.test.ts
+++ b/apps/desktop/src/preload/entries/workspaceAppExternalBridge.test.ts
@@ -146,6 +146,59 @@ test("workspace app external bridge invokes workspace feature open", async () =>
   ]);
 });
 
+test("workspace app external bridge sends browser open URL requests", async () => {
+  const calls: Array<{ channel: string; payload?: unknown }> = [];
+  const bridge = createWorkspaceAppExternalBridge({
+    appContext: {
+      async get() {
+        return { locale: "en" };
+      },
+      subscribe() {
+        throw new Error("unexpected subscribe");
+      }
+    },
+    isUserActivationActive: () => true,
+    send(channel: string, payload?: unknown) {
+      calls.push({ channel, payload });
+    },
+    async invoke() {
+      throw new Error("unexpected invoke");
+    }
+  });
+
+  await bridge.browser.openUrl({ url: "https://example.com/design" });
+
+  assert.deepEqual(calls, [
+    {
+      channel: workspaceAppExternalChannels.browserOpenUrl,
+      payload: { url: "https://example.com/design" }
+    }
+  ]);
+});
+
+test("workspace app external bridge requires activation for browser open URL", () => {
+  const bridge = createWorkspaceAppExternalBridge({
+    appContext: {
+      async get() {
+        return { locale: "en" };
+      },
+      subscribe() {
+        throw new Error("unexpected subscribe");
+      }
+    },
+    isUserActivationActive: () => false,
+    send: unexpectedSend,
+    async invoke() {
+      throw new Error("unexpected invoke");
+    }
+  });
+
+  assert.throws(
+    () => bridge.browser.openUrl({ url: "https://example.com/design" }),
+    /browser\.openUrl requires a user action/
+  );
+});
+
 test("workspace app external bridge requires activation for workspace feature open", () => {
   const bridge = createWorkspaceAppExternalBridge({
     appContext: {

--- a/apps/desktop/src/preload/entries/workspaceAppExternalBridge.ts
+++ b/apps/desktop/src/preload/entries/workspaceAppExternalBridge.ts
@@ -45,6 +45,7 @@ export interface WorkspaceAppExternalBridgeDependencies {
 
 export const workspaceAppExternalChannels = {
   atQuery: "workspace-app-at:query",
+  browserOpenUrl: "workspace-app:open-url",
   filesOpen: "workspace-app-files:open",
   filesSelect: "workspace-app-files:select",
   logsWrite: "workspace-app-logs:write",
@@ -77,6 +78,16 @@ export function createWorkspaceAppExternalBridge(
       },
       subscribe(listener) {
         return dependencies.appContext.subscribe(listener);
+      }
+    },
+    browser: {
+      openUrl(input) {
+        requireUserActivation(
+          dependencies.isUserActivationActive(),
+          "browser.openUrl"
+        );
+        dependencies.send(workspaceAppExternalChannels.browserOpenUrl, input);
+        return Promise.resolve();
       }
     },
     at: {

--- a/packages/workspace/external-core/src/contracts/index.ts
+++ b/packages/workspace/external-core/src/contracts/index.ts
@@ -127,6 +127,10 @@ export interface TuttiExternalSettingsOpenInput {
   tab?: "models";
 }
 
+export interface TuttiExternalBrowserOpenUrlInput {
+  url: string;
+}
+
 export type TuttiExternalWorkspaceFeature =
   | "app-center"
   | "issue-manager"
@@ -217,6 +221,9 @@ export interface TuttiExternalBridge {
   app: {
     getContext(): Promise<unknown>;
     subscribe(listener: (context: unknown) => void): () => void;
+  };
+  browser: {
+    openUrl(input: TuttiExternalBrowserOpenUrlInput): Promise<void>;
   };
   at: {
     query(

--- a/packages/workspace/external-core/src/core/index.test.ts
+++ b/packages/workspace/external-core/src/core/index.test.ts
@@ -2,6 +2,7 @@ import assert from "node:assert/strict";
 import test from "node:test";
 import {
   normalizeTuttiExternalAtQueryInput,
+  normalizeTuttiExternalBrowserOpenUrlInput,
   normalizeTuttiExternalFileOpenInput,
   normalizeTuttiExternalFileSelectInput,
   normalizeTuttiExternalLogInput,
@@ -63,6 +64,29 @@ test("keeps the default provider set explicit", () => {
     "agent-session",
     "agent-generated-file"
   ]);
+});
+
+test("normalizes browser open URL input", () => {
+  assert.deepEqual(
+    normalizeTuttiExternalBrowserOpenUrlInput({
+      url: " https://example.com/design "
+    }),
+    {
+      url: "https://example.com/design"
+    }
+  );
+});
+
+test("rejects invalid browser open URL input", () => {
+  assert.throws(
+    () => normalizeTuttiExternalBrowserOpenUrlInput({ url: "" }),
+    /browser\.openUrl url is required/
+  );
+  assert.throws(
+    () =>
+      normalizeTuttiExternalBrowserOpenUrlInput({ url: "file:///tmp/a.html" }),
+    /browser\.openUrl protocol is unsupported/
+  );
 });
 
 test("normalizes file select input", () => {

--- a/packages/workspace/external-core/src/core/index.ts
+++ b/packages/workspace/external-core/src/core/index.ts
@@ -4,6 +4,7 @@ import {
   tuttiExternalWorkspaceAgentProviders,
   type TuttiExternalAtProviderId,
   type TuttiExternalAtQueryInput,
+  type TuttiExternalBrowserOpenUrlInput,
   type TuttiExternalFileOpenInput,
   type TuttiExternalFileSelectInput,
   type TuttiExternalLogInput,
@@ -94,6 +95,27 @@ export function normalizeTuttiExternalAtQueryInput(
     maxResults: normalizeMaxResults(input.maxResults),
     providers: normalizeProviders(input.providers)
   };
+}
+
+export function normalizeTuttiExternalBrowserOpenUrlInput(
+  input: unknown
+): TuttiExternalBrowserOpenUrlInput {
+  if (!isRecord(input)) {
+    throw new Error("browser.openUrl input must be an object.");
+  }
+  const url = normalizeRequiredString(input.url, "browser.openUrl url");
+  try {
+    const parsed = new URL(url);
+    if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
+      throw new Error("browser.openUrl protocol is unsupported.");
+    }
+    return { url: parsed.toString() };
+  } catch (error) {
+    if (error instanceof Error && error.message.includes("unsupported")) {
+      throw error;
+    }
+    throw new Error("browser.openUrl url is invalid.");
+  }
 }
 
 export function normalizeTuttiExternalFileSelectInput(


### PR DESCRIPTION
## What changed

- Exposes a typed `tuttiExternal.browser.openUrl({ url })` bridge for workspace apps.
- Reuses the existing `workspace-app:open-url` IPC path so approved app requests dispatch to the Tutti browser node.
- Advertises the new capability as `browser.openUrl@1` in workspace app context.
- Adds URL normalization and validation for http/https URLs plus bridge/preload tests.

## Why

Workspace apps such as vibe-design need an explicit, user-activated way to open iframe preview URLs in the outer Tutti browser instead of relying on ad hoc iframe/window behavior.

## Validation

Passed on latest `origin/main` in `/Users/chovy/Desktop/workspace/tutti-browser-open-pr`:

- `pnpm --filter @tutti-os/workspace-external-core test -- src/core/index.test.ts`
- `pnpm --filter @tutti-os/workspace-external-core typecheck`
- `pnpm --filter @tutti-os/desktop test -- src/preload/entries/workspaceAppExternalBridge.test.ts`
- `pnpm --filter @tutti-os/desktop typecheck`

Pre-push full check was also attempted. It was blocked by unrelated Go-side failures outside this diff:

- `lint:go`: missing generated `builtin-apps/generated/tutti-onboarding/tutti-onboarding-0.1.0.zip`
- `test:go`: two `services/tuttid/service/agentstatus` expectations reported `ready` instead of `not_installed`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a new `browser.openUrl` capability allowing applications to open URLs with built-in security measures
  * Implemented user-activation gating to ensure URL operations occur only during user interactions

* **Tests**
  * Added comprehensive test coverage for the new URL opening functionality
  * Tests verify proper behavior with user activation and validate error handling for invalid requests

<!-- end of auto-generated comment: release notes by coderabbit.ai -->