### PR TITLE
fix(agent): show real post-compaction context size instead of 0

### DIFF
--- a/packages/agent/daemon/runtime/codex_appserver_events.go
+++ b/packages/agent/daemon/runtime/codex_appserver_events.go
@@ -500,6 +500,11 @@ func (a *CodexAppServerAdapter) applyTokenUsage(agentSessionID string, params ma
 // Using total.totalTokens as primary causes a false compact alert: after 10
 // calls of 27 K tokens each the cumulative reaches 270 K and exceeds the 258 K
 // per-request window even though each call individually used only ~10 %.
+//
+// A non-positive last.inputTokens also triggers the fallback chain: the
+// post-compaction frame reports last.inputTokens=0 while last.totalTokens holds
+// the real compacted context size. Treating that literal 0 as the context fill
+// would display "0" right after a compaction instead of the compacted size.
 func appServerTokenUsageState(params map[string]any) (acpUsageState, bool) {
 	tokenUsage := payloadObject(params["tokenUsage"])
 	if len(tokenUsage) == 0 {
@@ -507,10 +512,10 @@ func appServerTokenUsageState(params map[string]any) (acpUsageState, bool) {
 	}
 	last := payloadObject(tokenUsage["last"])
 	used, usedOK := firstACPInt64(last, "inputTokens")
-	if !usedOK {
+	if !usedOK || used <= 0 {
 		used, usedOK = firstACPInt64(last, "totalTokens")
 	}
-	if !usedOK {
+	if !usedOK || used <= 0 {
 		used, usedOK = firstACPInt64(payloadObject(tokenUsage["total"]), "totalTokens")
 	}
 	window, windowOK := firstACPInt64(tokenUsage, "modelContextWindow")

--- a/packages/agent/daemon/runtime/codex_appserver_events_test.go
+++ b/packages/agent/daemon/runtime/codex_appserver_events_test.go
@@ -155,6 +155,43 @@ func TestCodexAppServerAdapterApplyTokenUsageFallsBackToLastTotalTokens(t *testi
 	}
 }
 
+// TestCodexAppServerAdapterApplyTokenUsageCompactFrameUsesLastTotalTokens
+// reproduces the post-compaction frame Codex app-server emits: last.inputTokens
+// is explicitly 0 while last.totalTokens carries the real compacted context size
+// (summary). The display must show the compacted size, not 0. (Captured live:
+// seed last.inputTokens=26017 -> compact last.inputTokens=0/totalTokens=5763.)
+func TestCodexAppServerAdapterApplyTokenUsageCompactFrameUsesLastTotalTokens(t *testing.T) {
+	t.Parallel()
+
+	adapter, _, session := startedAppServerAdapter(t)
+
+	// Seed turn: window is full at 26017.
+	adapter.applyTokenUsage(session.AgentSessionID, map[string]any{
+		"tokenUsage": map[string]any{
+			"last":               map[string]any{"inputTokens": int64(26017), "totalTokens": int64(26049)},
+			"total":              map[string]any{"totalTokens": int64(26049)},
+			"modelContextWindow": int64(258400),
+		},
+	})
+
+	// Compact frame: inputTokens is explicitly 0, totalTokens=5763 is the real
+	// post-compaction context size.
+	adapter.applyTokenUsage(session.AgentSessionID, map[string]any{
+		"tokenUsage": map[string]any{
+			"last":               map[string]any{"inputTokens": int64(0), "totalTokens": int64(5763)},
+			"total":              map[string]any{"totalTokens": int64(26049)},
+			"modelContextWindow": int64(258400),
+		},
+	})
+
+	state := adapter.SessionState(session)
+	usage, _ := state.RuntimeContext["usage"].(map[string]any)
+	contextWindow, _ := usage["contextWindow"].(map[string]any)
+	if used, _ := acpInt64Value(contextWindow["usedTokens"]); used != 5763 {
+		t.Fatalf("usedTokens = %v, want post-compact last.totalTokens (5763); a literal 0 inputTokens must not be shown as the context fill", used)
+	}
+}
+
 // TestCodexAppServerAdapterApplyTokenUsageNoCumulativeFalsePositive verifies
 // that repeated calls with the same per-request size do not inflate usedTokens
 // beyond the context window, which would falsely trigger the compact alert.


### PR DESCRIPTION
## Problem

After a Codex compaction, the AgentGUI context-usage indicator reset to **0** instead of showing the real (much smaller) compacted context size.

## Root cause

The post-compaction `thread/tokenUsage/updated` frame reports `last.inputTokens=0` while `last.totalTokens` carries the real compacted context size (the summary). `appServerTokenUsageState` picked `last.inputTokens` first and only fell back to `last.totalTokens` when the field was **absent** — but `firstACPInt64` returns `(0, true)` for a present literal `0`. The fallback chain never ran, so a literal `0` was shown as the context fill.

This was confirmed empirically with a live probe: seed turn `last.inputTokens=26017` → compact frame `last.inputTokens=0 / last.totalTokens=5763`.

## Fix

Treat a non-positive `last.inputTokens` the same as a missing one, so the fallback chain reaches `last.totalTokens` (then `total.totalTokens`). The display now shows the real compacted size (e.g. 5763) immediately after compaction.

```go
used, usedOK := firstACPInt64(last, "inputTokens")
if !usedOK || used <= 0 {   // was: if !usedOK
    used, usedOK = firstACPInt64(last, "totalTokens")
}
if !usedOK || used <= 0 {   // was: if !usedOK
    used, usedOK = firstACPInt64(payloadObject(tokenUsage["total"]), "totalTokens")
}
```

## Tests

- New `TestCodexAppServerAdapterApplyTokenUsageCompactFrameUsesLastTotalTokens` reproduces the captured live frame and asserts the display shows 5763, not 0 (RED→GREEN verified).
- Existing token-usage tests (prefers-input, falls-back, no-cumulative) still pass.
- Full `packages/agent/daemon/runtime` package + `go vet` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed token usage reporting to correctly display actual token consumption in scenarios involving context compaction, ensuring accurate usage metrics are shown to users.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
