### PR TITLE
Fix Codex CLI resolution with nvm versions

### DIFF
--- a/docs/conventions/troubleshooting.md
+++ b/docs/conventions/troubleshooting.md
@@ -110,6 +110,41 @@ Use this shape for new entries:
   [session.go](../../services/tuttid/service/browser/session.go)
   [command.go](../../services/tuttid/service/browser/command.go)
 
+### macOS Gatekeeper dialogs appear during Codex provider probing
+
+- Symptom:
+  Opening an app or surface that reads agent composer options, provider status,
+  or capability catalog triggers repeated macOS warnings that `codex` may harm
+  the computer.
+- Quick checks:
+  Resolve the active Codex binary from `tuttid` logs or by running with the
+  same daemon environment. Then inspect the native binary behind the npm shim
+  with `spctl --assess --type execute -vv <native-codex-path>`. If it reports
+  `CSSMERR_TP_CERT_REVOKED`, remove or reinstall that specific Codex package.
+- Root cause:
+  Provider status and composer capability discovery intentionally start Codex
+  commands such as `codex login status` and `codex app-server`. If the daemon
+  resolves an older nvm global Codex package whose Developer ID certificate has
+  been revoked, each otherwise harmless background probe can become a
+  Gatekeeper dialog. This can happen even when `which codex` in the user's shell
+  points at a newer working Codex if the daemon command resolver places scanned
+  nvm fallback directories before the real PATH.
+- Fix:
+  Respect the daemon PATH before scanned nvm fallback directories, and sort nvm
+  fallback directories by Node version so fallback resolution does not pick the
+  oldest installed Node first. Do not automatically remove attributes or delete
+  arbitrary user-managed Codex binaries from Tutti; user repair scripts should
+  only move Codex packages that `spctl` explicitly reports as certificate
+  revoked, and should keep a backup.
+- Validation:
+  Run `go test ./runtimecmd` and `go test ./runtime` from
+  `packages/agent/daemon`, plus `go test ./service/agentstatus` from
+  `services/tuttid`. Verify provider status logs resolve `codex` to the same
+  npm shim the user expects from PATH, unless PATH lacks Codex and the resolver
+  intentionally falls back to a scanned nvm install.
+- References:
+  [resolver.go](../../packages/agent/daemon/runtimecmd/resolver.go)
+
 ### Malformed user skill frontmatter breaks skill discovery
 
 - Symptom:

--- a/packages/agent/daemon/runtimecmd/resolver.go
+++ b/packages/agent/daemon/runtimecmd/resolver.go
@@ -5,6 +5,8 @@ import (
 	"os/exec"
 	"path/filepath"
 	"runtime"
+	"sort"
+	"strconv"
 	"strings"
 )
 
@@ -39,10 +41,12 @@ func (r Resolver) Env(overrides []string) []string {
 	pathGroups := [][]string{}
 	if overridePath, ok := envValueFrom(overrides, pathKey); ok {
 		pathGroups = append(pathGroups, filepath.SplitList(overridePath))
-		pathGroups = append(pathGroups, r.knownExecutableDirs(env))
+		pathGroups = append(pathGroups, r.preferredExecutableDirs(env))
+		pathGroups = append(pathGroups, r.fallbackExecutableDirs(env))
 	} else {
-		pathGroups = append(pathGroups, r.knownExecutableDirs(env))
+		pathGroups = append(pathGroups, r.preferredExecutableDirs(env))
 		pathGroups = append(pathGroups, filepath.SplitList(envValue(baseEnv, pathKey)))
+		pathGroups = append(pathGroups, r.fallbackExecutableDirs(env))
 	}
 	pathDirs := mergePathDirs(pathGroups...)
 	if len(pathDirs) > 0 {
@@ -104,31 +108,35 @@ func (r Resolver) UserBinInstallDirs(overrides []string) []string {
 	return mergePathDirs(candidates...)
 }
 
-func (r Resolver) knownExecutableDirs(env []string) []string {
+func (r Resolver) preferredExecutableDirs(env []string) []string {
+	dirs := []string{}
+	if nPrefix := strings.TrimSpace(envValue(env, "N_PREFIX")); nPrefix != "" {
+		dirs = append([]string{filepath.Join(nPrefix, "bin")}, dirs...)
+	}
+	if pnpmHome := strings.TrimSpace(envValue(env, "PNPM_HOME")); pnpmHome != "" {
+		dirs = append([]string{pnpmHome}, dirs...)
+	}
+	if voltaHome := strings.TrimSpace(envValue(env, "VOLTA_HOME")); voltaHome != "" {
+		dirs = append([]string{filepath.Join(voltaHome, "bin")}, dirs...)
+	}
+	if asdfDataDir := strings.TrimSpace(envValue(env, "ASDF_DATA_DIR")); asdfDataDir != "" {
+		dirs = append([]string{filepath.Join(asdfDataDir, "shims")}, dirs...)
+	}
+	if miseDataDir := strings.TrimSpace(envValue(env, "MISE_DATA_DIR")); miseDataDir != "" {
+		dirs = append([]string{filepath.Join(miseDataDir, "shims")}, dirs...)
+	}
+	if fnmDir := strings.TrimSpace(envValue(env, "FNM_DIR")); fnmDir != "" {
+		dirs = append(fnmNodeBinDirs(fnmDir), dirs...)
+	}
+	return dirs
+}
+
+func (r Resolver) fallbackExecutableDirs(env []string) []string {
 	dirs := []string{
 		"/opt/homebrew/bin",
 		"/usr/local/bin",
 		"/usr/bin",
 		"/bin",
-	}
-	explicitDirs := []string{}
-	if nPrefix := strings.TrimSpace(envValue(env, "N_PREFIX")); nPrefix != "" {
-		explicitDirs = append([]string{filepath.Join(nPrefix, "bin")}, explicitDirs...)
-	}
-	if pnpmHome := strings.TrimSpace(envValue(env, "PNPM_HOME")); pnpmHome != "" {
-		explicitDirs = append([]string{pnpmHome}, explicitDirs...)
-	}
-	if voltaHome := strings.TrimSpace(envValue(env, "VOLTA_HOME")); voltaHome != "" {
-		explicitDirs = append([]string{filepath.Join(voltaHome, "bin")}, explicitDirs...)
-	}
-	if asdfDataDir := strings.TrimSpace(envValue(env, "ASDF_DATA_DIR")); asdfDataDir != "" {
-		explicitDirs = append([]string{filepath.Join(asdfDataDir, "shims")}, explicitDirs...)
-	}
-	if miseDataDir := strings.TrimSpace(envValue(env, "MISE_DATA_DIR")); miseDataDir != "" {
-		explicitDirs = append([]string{filepath.Join(miseDataDir, "shims")}, explicitDirs...)
-	}
-	if fnmDir := strings.TrimSpace(envValue(env, "FNM_DIR")); fnmDir != "" {
-		explicitDirs = append(fnmNodeBinDirs(fnmDir), explicitDirs...)
 	}
 	homeDirs := []string{}
 	home, err := r.homeDir()
@@ -148,7 +156,7 @@ func (r Resolver) knownExecutableDirs(env []string) []string {
 		homeDirs = append(homeDirs, nvmNodeBinDirs(home)...)
 		homeDirs = append(homeDirs, fnmNodeBinDirs(filepath.Join(home, ".fnm"))...)
 	}
-	return append(append(explicitDirs, homeDirs...), dirs...)
+	return append(homeDirs, dirs...)
 }
 
 func (r Resolver) environ() []string {
@@ -190,7 +198,48 @@ func nvmNodeBinDirs(home string) []string {
 	if err != nil {
 		return nil
 	}
+	sort.SliceStable(matches, func(i, j int) bool {
+		return compareNVMNodeBinDirs(matches[i], matches[j]) > 0
+	})
 	return matches
+}
+
+func compareNVMNodeBinDirs(left string, right string) int {
+	leftVersion := nvmNodeVersion(left)
+	rightVersion := nvmNodeVersion(right)
+	for i := 0; i < max(len(leftVersion), len(rightVersion)); i++ {
+		leftPart := versionPart(leftVersion, i)
+		rightPart := versionPart(rightVersion, i)
+		if leftPart > rightPart {
+			return 1
+		}
+		if leftPart < rightPart {
+			return -1
+		}
+	}
+	return strings.Compare(left, right)
+}
+
+func nvmNodeVersion(binDir string) []int {
+	versionDir := filepath.Base(filepath.Dir(binDir))
+	version := strings.TrimPrefix(versionDir, "v")
+	parts := strings.Split(version, ".")
+	result := make([]int, 0, len(parts))
+	for _, part := range parts {
+		value, err := strconv.Atoi(part)
+		if err != nil {
+			return nil
+		}
+		result = append(result, value)
+	}
+	return result
+}
+
+func versionPart(version []int, index int) int {
+	if index < 0 || index >= len(version) {
+		return 0
+	}
+	return version[index]
 }
 
 func fnmNodeBinDirs(fnmDir string) []string {

--- a/packages/agent/daemon/runtimecmd/resolver_test.go
+++ b/packages/agent/daemon/runtimecmd/resolver_test.go
@@ -37,6 +37,68 @@ func TestResolverFindsKnownNodeGlobalBin(t *testing.T) {
 	}
 }
 
+func TestResolverPrefersNewestNVMNodeBin(t *testing.T) {
+	home := t.TempDir()
+	oldBinDir := filepath.Join(home, ".nvm", "versions", "node", "v20.19.4", "bin")
+	newBinDir := filepath.Join(home, ".nvm", "versions", "node", "v24.16.0", "bin")
+	for _, dir := range []string{oldBinDir, newBinDir} {
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			t.Fatalf("mkdir bin dir: %v", err)
+		}
+		writeExecutable(t, filepath.Join(dir, "codex"))
+	}
+
+	resolver := Resolver{
+		Environ: func() []string {
+			return []string{"PATH=/usr/bin:/bin"}
+		},
+		HomeDir: func() (string, error) {
+			return home, nil
+		},
+		LookPath: func(string) (string, error) {
+			return "", os.ErrNotExist
+		},
+	}
+
+	env := resolver.Env(nil)
+	want := filepath.Join(newBinDir, "codex")
+	if got := resolver.Resolve("codex", env); got != want {
+		t.Fatalf("Resolve() = %q, want newest NVM codex %q", got, want)
+	}
+}
+
+func TestResolverPrefersExistingPathOverScannedNVMFallback(t *testing.T) {
+	home := t.TempDir()
+	activeBinDir := filepath.Join(home, ".nvm", "versions", "node", "v20.19.4", "bin")
+	newerBinDir := filepath.Join(home, ".nvm", "versions", "node", "v24.16.0", "bin")
+	for _, dir := range []string{activeBinDir, newerBinDir} {
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			t.Fatalf("mkdir bin dir: %v", err)
+		}
+		writeExecutable(t, filepath.Join(dir, "codex"))
+	}
+
+	resolver := Resolver{
+		Environ: func() []string {
+			return []string{
+				"PATH=" + activeBinDir + string(os.PathListSeparator) + "/usr/bin:/bin",
+			}
+		},
+		HomeDir: func() (string, error) {
+			return home, nil
+		},
+		LookPath: func(string) (string, error) {
+			return "", os.ErrNotExist
+		},
+	}
+
+	env := resolver.Env(nil)
+	want := filepath.Join(activeBinDir, "codex")
+	if got := resolver.Resolve("codex", env); got != want {
+		t.Fatalf("Resolve() = %q, want active PATH codex %q", got, want)
+	}
+}
+
 func TestResolverFindsFnmNodeBin(t *testing.T) {
 	home := t.TempDir()
 	fnmDir := filepath.Join(home, "custom-fnm")


### PR DESCRIPTION
## Summary
- respect the daemon PATH before scanned nvm fallback directories when resolving agent runtime commands
- sort scanned nvm Node bin fallbacks by Node version so fallback resolution avoids older global CLIs
- document the macOS Gatekeeper/Codex revoked certificate debugging path

## Tests
- go test ./runtimecmd ./runtime (packages/agent/daemon)
- go test ./service/agentstatus (services/tuttid)
- pnpm check:full (pre-push)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added troubleshooting guide for macOS Gatekeeper dialogs appearing during Codex provider probing.

* **Bug Fixes**
  * Fixed daemon PATH resolution to prefer newer Node versions, preventing repeated Gatekeeper warnings from revoked certificates.

* **Tests**
  * Added test coverage for Node binary resolution precedence handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->