### PR TITLE
chore: schedule desktop release at Beijing 08:15

### DIFF
--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -5,7 +5,7 @@ on:
     tags:
       - "v*"
   schedule:
-    - cron: "23 1 * * *"
+    - cron: "15 0 * * *"
   workflow_dispatch:
     inputs:
       release_mode:

--- a/docs/conventions/desktop-release.md
+++ b/docs/conventions/desktop-release.md
@@ -43,7 +43,7 @@ The release workflow file is `.github/workflows/desktop-release.yml`.
 Supported triggers:
 
 - pushing a tag matching `tutti-desktop-v*`
-- scheduled run at `01:30 UTC` every day
+- scheduled run at `00:15 UTC` every day (`08:15` Beijing time)
 - manual `workflow_dispatch`
 
 Supported manual modes:

--- a/tools/scripts/desktop-release-config.test.mjs
+++ b/tools/scripts/desktop-release-config.test.mjs
@@ -80,10 +80,10 @@ test("desktop release workflow publishes rc tags as prereleases and keeps stable
   );
 });
 
-test("desktop release workflow schedules a daily Beijing 9:23am rc release", async () => {
+test("desktop release workflow schedules a daily Beijing 8:15am rc release", async () => {
   const workflow = await readFile(workflowPath, "utf8");
 
-  assert.match(workflow, /schedule:\s*\n\s*-\s*cron:\s*"23 1 \* \* \*"/);
+  assert.match(workflow, /schedule:\s*\n\s*-\s*cron:\s*"15 0 \* \* \*"/);
   assert.doesNotMatch(workflow, /timezone:\s*"Asia\/Shanghai"/);
   assert.match(
     workflow,


### PR DESCRIPTION
## Summary
- move the Desktop Release scheduled cron from Beijing 09:23 to Beijing 08:15
- update the desktop release config test expectation
- update the release convention docs with the UTC/Beijing time mapping

## Validation
- PASS: node --test tools/scripts/desktop-release-config.test.mjs
- PASS: git diff --check
- PASS: commit hooks for staged files
- NOTE: pre-push check:full failed in unrelated Go test services/tuttid/service/agentstatus TestServiceRunActionSerializesConcurrentExternalRegistryNPMInstalls; the same test fails when run directly with go test ./services/tuttid/service/agentstatus -run TestServiceRunActionSerializesConcurrentExternalRegistryNPMInstalls -count=1

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Rescheduled the daily desktop release workflow to run at a new time.

* **Documentation**
  * Updated documentation and test suites to reflect the adjusted desktop release schedule.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->