### PR TITLE
[codex] Fix window close and launchpad wheel navigation

### DIFF
--- a/apps/desktop/src/main/applicationMenu.test.ts
+++ b/apps/desktop/src/main/applicationMenu.test.ts
@@ -186,6 +186,32 @@ test("application menu routes Command-Q through the shortcut quit handler", () =
   assert.equal(shortcutQuitRequested, 1);
 });
 
+test("application menu routes Command-W through the shortcut close handler", () => {
+  const ownerWindow = {};
+  let receivedOwnerWindow: unknown;
+  const menu = createApplicationMenuTemplate({
+    closeFromCommandShortcut(nextOwnerWindow) {
+      receivedOwnerWindow = nextOwnerWindow;
+    },
+    platform: "darwin"
+  });
+
+  const fileMenu = menu.find((item) => item.label === "File");
+  assert.ok(fileMenu);
+  assert.ok(Array.isArray(fileMenu.submenu));
+  const closeItem = fileMenu.submenu.find((item) => item.label === "Close");
+  assert.ok(closeItem);
+  assert.equal(closeItem.accelerator, "Command+W");
+
+  closeItem.click?.(
+    {} as Parameters<NonNullable<typeof closeItem.click>>[0],
+    ownerWindow as Parameters<NonNullable<typeof closeItem.click>>[1],
+    undefined as unknown as Parameters<NonNullable<typeof closeItem.click>>[2]
+  );
+
+  assert.equal(receivedOwnerWindow, ownerWindow);
+});
+
 test("application menu exposes Perf Monitor DevTools when configured", () => {
   const ownerWindow = {};
   let receivedOwnerWindow: unknown;

--- a/apps/desktop/src/main/applicationMenu.ts
+++ b/apps/desktop/src/main/applicationMenu.ts
@@ -18,6 +18,7 @@ export interface ApplicationMenuOptions {
   clearDeveloperLogs?: () =>
     | ClearDeveloperLogsResult
     | Promise<ClearDeveloperLogsResult>;
+  closeFromCommandShortcut?: (ownerWindow?: BaseWindow | null) => void;
   exportDeveloperLogs?: () => unknown;
   getLocale?: () => DesktopLocale;
   logger?: DesktopLogger;
@@ -149,6 +150,7 @@ export function createApplicationMenuTemplate({
   allowDeveloperTools = process.env.NODE_ENV === "development",
   checkForUpdates,
   clearDeveloperLogs,
+  closeFromCommandShortcut,
   exportDeveloperLogs,
   getLocale = () => "en",
   logger,
@@ -200,7 +202,18 @@ export function createApplicationMenuTemplate({
   template.push(
     {
       label: translator.t("desktop.menu.file"),
-      submenu: isMac ? [{ role: "close" }] : [{ role: "quit" }]
+      submenu: isMac
+        ? [
+            closeFromCommandShortcut
+              ? {
+                  accelerator: "Command+W",
+                  label: translator.t("common.close"),
+                  click: (_menuItem, browserWindow) =>
+                    closeFromCommandShortcut(browserWindow)
+                }
+              : { role: "close" }
+          ]
+        : [{ role: "quit" }]
     },
     {
       label: translator.t("desktop.menu.edit"),
@@ -335,6 +348,15 @@ export async function configureApplicationMenu(
               }
             }
           }),
+        closeFromCommandShortcut: (ownerWindow) => {
+          if (ownerWindow instanceof BrowserWindow) {
+            void import("./windows/workspaceWindow.ts").then(
+              ({ requestWorkspaceWindowCloseFromCommandShortcut }) => {
+                requestWorkspaceWindowCloseFromCommandShortcut(ownerWindow);
+              }
+            );
+          }
+        },
         ...options
       })
     )

--- a/apps/desktop/src/main/windows/workspaceWindow.ts
+++ b/apps/desktop/src/main/windows/workspaceWindow.ts
@@ -125,7 +125,6 @@ export function createWorkspaceWindow(
     }
   });
 
-  installWorkspaceWindowCloseRequest(workspaceWindow);
   installWorkspaceWindowDevelopmentReloadShortcut(workspaceWindow, {
     enabled: options.enableDevelopmentReloadShortcut === true
   });
@@ -208,23 +207,10 @@ export function loadWorkspaceWindowContent(
   );
 }
 
-function installWorkspaceWindowCloseRequest(
+export function requestWorkspaceWindowCloseFromCommandShortcut(
   workspaceWindow: BrowserWindow
 ): void {
-  workspaceWindow.on("close", (event) => {
-    if (
-      workspaceWindow.isDestroyed() ||
-      workspaceWindow.webContents.isDestroyed()
-    ) {
-      return;
-    }
-
-    event.preventDefault();
-    workspaceWindow.webContents.send(
-      desktopIpcChannels.host.window.closeRequest,
-      { reason: "window-close" } satisfies DesktopHostWindowCloseRequestPayload
-    );
-  });
+  sendWorkspaceWindowCloseRequest(workspaceWindow, { reason: "window-close" });
 }
 
 export async function requestWorkspaceWindowsClose(
@@ -294,14 +280,28 @@ function requestWorkspaceWindowClose(
       }
       finish(payload.reason === "quit" ? "blocked" : "approved");
     }, workspaceWindowQuitCloseTimeoutMs);
-    workspaceWindow.webContents.send(
-      desktopIpcChannels.host.window.closeRequest,
-      {
-        ...payload,
-        requestId
-      } satisfies DesktopHostWindowCloseRequestPayload
-    );
+    sendWorkspaceWindowCloseRequest(workspaceWindow, {
+      ...payload,
+      requestId
+    });
   });
+}
+
+function sendWorkspaceWindowCloseRequest(
+  workspaceWindow: BrowserWindow,
+  payload: DesktopHostWindowCloseRequestPayload
+): void {
+  if (
+    workspaceWindow.isDestroyed() ||
+    workspaceWindow.webContents.isDestroyed()
+  ) {
+    return;
+  }
+
+  workspaceWindow.webContents.send(
+    desktopIpcChannels.host.window.closeRequest,
+    payload
+  );
 }
 
 function createWorkspaceWindowQuitCloseRequestId(): string {

--- a/apps/desktop/src/renderer/src/features/workspace-workbench/services/internal/workspaceLaunchpadWheelNavigation.test.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/services/internal/workspaceLaunchpadWheelNavigation.test.ts
@@ -1,0 +1,131 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  createWorkspaceLaunchpadWheelNavigationState,
+  resolveWorkspaceLaunchpadWheelNavigation
+} from "./workspaceLaunchpadWheelNavigation.ts";
+
+test("launchpad wheel navigation accumulates horizontal trackpad deltas before paging", () => {
+  let state = createWorkspaceLaunchpadWheelNavigationState();
+
+  const first = resolveWorkspaceLaunchpadWheelNavigation({
+    currentPage: 0,
+    deltaX: 24,
+    deltaY: 2,
+    pageCount: 2,
+    state,
+    timestamp: 500
+  });
+  state = first.state;
+
+  assert.equal(first.nextPageIndex, null);
+  assert.equal(first.shouldPreventDefault, true);
+
+  const second = resolveWorkspaceLaunchpadWheelNavigation({
+    currentPage: 0,
+    deltaX: 48,
+    deltaY: 3,
+    pageCount: 2,
+    state,
+    timestamp: 560
+  });
+
+  assert.equal(second.nextPageIndex, 1);
+  assert.equal(second.shouldPreventDefault, true);
+  assert.deepEqual(second.state, {
+    accumulatedDeltaX: 0,
+    lastNavigationAt: 560
+  });
+});
+
+test("launchpad wheel navigation ignores vertical scroll intent", () => {
+  const state = {
+    accumulatedDeltaX: 32,
+    lastNavigationAt: 100
+  };
+
+  assert.deepEqual(
+    resolveWorkspaceLaunchpadWheelNavigation({
+      currentPage: 0,
+      deltaX: 12,
+      deltaY: 40,
+      pageCount: 2,
+      state,
+      timestamp: 500
+    }),
+    {
+      nextPageIndex: null,
+      shouldPreventDefault: false,
+      state: {
+        accumulatedDeltaX: 0,
+        lastNavigationAt: 100
+      }
+    }
+  );
+});
+
+test("launchpad wheel navigation moves to the previous page for negative horizontal deltas", () => {
+  const result = resolveWorkspaceLaunchpadWheelNavigation({
+    currentPage: 1,
+    deltaX: -80,
+    deltaY: 0,
+    pageCount: 2,
+    state: createWorkspaceLaunchpadWheelNavigationState(),
+    timestamp: 500
+  });
+
+  assert.equal(result.nextPageIndex, 0);
+  assert.equal(result.shouldPreventDefault, true);
+});
+
+test("launchpad wheel navigation absorbs horizontal overscroll at page boundaries", () => {
+  const result = resolveWorkspaceLaunchpadWheelNavigation({
+    currentPage: 1,
+    deltaX: 90,
+    deltaY: 0,
+    pageCount: 2,
+    state: createWorkspaceLaunchpadWheelNavigationState(),
+    timestamp: 500
+  });
+
+  assert.equal(result.nextPageIndex, null);
+  assert.equal(result.shouldPreventDefault, true);
+});
+
+test("launchpad wheel navigation throttles repeated page changes in one gesture", () => {
+  const result = resolveWorkspaceLaunchpadWheelNavigation({
+    currentPage: 1,
+    deltaX: -90,
+    deltaY: 0,
+    pageCount: 3,
+    state: {
+      accumulatedDeltaX: 0,
+      lastNavigationAt: 500
+    },
+    timestamp: 700
+  });
+
+  assert.deepEqual(result, {
+    nextPageIndex: null,
+    shouldPreventDefault: true,
+    state: {
+      accumulatedDeltaX: 0,
+      lastNavigationAt: 500
+    }
+  });
+});
+
+test("launchpad wheel navigation normalizes line-based wheel deltas", () => {
+  const result = resolveWorkspaceLaunchpadWheelNavigation({
+    currentPage: 0,
+    deltaMode: 1,
+    deltaX: 5,
+    deltaY: 0,
+    pageCount: 2,
+    state: createWorkspaceLaunchpadWheelNavigationState(),
+    timestamp: 500
+  });
+
+  assert.equal(result.nextPageIndex, 1);
+  assert.equal(result.shouldPreventDefault, true);
+});

--- a/apps/desktop/src/renderer/src/features/workspace-workbench/services/internal/workspaceLaunchpadWheelNavigation.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/services/internal/workspaceLaunchpadWheelNavigation.ts
@@ -1,0 +1,129 @@
+const wheelDeltaLinePx = 16;
+const wheelDeltaPagePx = 360;
+const launchpadWheelNavigationThresholdPx = 64;
+const launchpadWheelNavigationCooldownMs = 420;
+const launchpadWheelHorizontalIntentRatio = 1.2;
+
+export interface WorkspaceLaunchpadWheelNavigationState {
+  accumulatedDeltaX: number;
+  lastNavigationAt: number;
+}
+
+export interface WorkspaceLaunchpadWheelNavigationResult {
+  nextPageIndex: number | null;
+  shouldPreventDefault: boolean;
+  state: WorkspaceLaunchpadWheelNavigationState;
+}
+
+export function createWorkspaceLaunchpadWheelNavigationState(): WorkspaceLaunchpadWheelNavigationState {
+  return {
+    accumulatedDeltaX: 0,
+    lastNavigationAt: 0
+  };
+}
+
+export function resolveWorkspaceLaunchpadWheelNavigation(input: {
+  currentPage: number;
+  deltaMode?: number;
+  deltaX: number;
+  deltaY: number;
+  pageCount: number;
+  state: WorkspaceLaunchpadWheelNavigationState;
+  timestamp: number;
+}): WorkspaceLaunchpadWheelNavigationResult {
+  if (input.pageCount <= 1) {
+    return {
+      nextPageIndex: null,
+      shouldPreventDefault: false,
+      state: createWorkspaceLaunchpadWheelNavigationState()
+    };
+  }
+
+  const delta = normalizeWorkspaceLaunchpadWheelDelta(input);
+  const absDeltaX = Math.abs(delta.x);
+  const absDeltaY = Math.abs(delta.y);
+  const isHorizontalIntent =
+    absDeltaX > 0 &&
+    absDeltaX >= absDeltaY * launchpadWheelHorizontalIntentRatio;
+
+  if (!isHorizontalIntent) {
+    return {
+      nextPageIndex: null,
+      shouldPreventDefault: false,
+      state: {
+        accumulatedDeltaX: 0,
+        lastNavigationAt: input.state.lastNavigationAt
+      }
+    };
+  }
+
+  const direction = delta.x > 0 ? 1 : -1;
+  const previousDirection = input.state.accumulatedDeltaX > 0 ? 1 : -1;
+  const accumulatedDeltaX =
+    input.state.accumulatedDeltaX !== 0 && previousDirection === direction
+      ? input.state.accumulatedDeltaX + delta.x
+      : delta.x;
+
+  if (
+    input.timestamp - input.state.lastNavigationAt <
+    launchpadWheelNavigationCooldownMs
+  ) {
+    return {
+      nextPageIndex: null,
+      shouldPreventDefault: true,
+      state: {
+        accumulatedDeltaX: 0,
+        lastNavigationAt: input.state.lastNavigationAt
+      }
+    };
+  }
+
+  if (Math.abs(accumulatedDeltaX) < launchpadWheelNavigationThresholdPx) {
+    return {
+      nextPageIndex: null,
+      shouldPreventDefault: true,
+      state: {
+        accumulatedDeltaX,
+        lastNavigationAt: input.state.lastNavigationAt
+      }
+    };
+  }
+
+  const nextPageIndex = input.currentPage + direction;
+  if (nextPageIndex < 0 || nextPageIndex >= input.pageCount) {
+    return {
+      nextPageIndex: null,
+      shouldPreventDefault: true,
+      state: {
+        accumulatedDeltaX: 0,
+        lastNavigationAt: input.timestamp
+      }
+    };
+  }
+
+  return {
+    nextPageIndex,
+    shouldPreventDefault: true,
+    state: {
+      accumulatedDeltaX: 0,
+      lastNavigationAt: input.timestamp
+    }
+  };
+}
+
+function normalizeWorkspaceLaunchpadWheelDelta(input: {
+  deltaMode?: number;
+  deltaX: number;
+  deltaY: number;
+}): { x: number; y: number } {
+  const unit =
+    input.deltaMode === 1
+      ? wheelDeltaLinePx
+      : input.deltaMode === 2
+        ? wheelDeltaPagePx
+        : 1;
+  return {
+    x: input.deltaX * unit,
+    y: input.deltaY * unit
+  };
+}

--- a/apps/desktop/src/renderer/src/features/workspace-workbench/services/internal/workspaceWindowCloseCoordinator.test.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/services/internal/workspaceWindowCloseCoordinator.test.ts
@@ -5,9 +5,10 @@ import { createWindowCloseRequestTracker } from "../windowCloseRequestTracker.ts
 import type { WorkspaceWorkbenchHostInput } from "../workspaceWorkbenchHostService.interface.ts";
 import { confirmWorkspaceWindowClose } from "./workspaceWindowCloseCoordinator.ts";
 
-test("confirmWorkspaceWindowClose approves native window close without close guard", async () => {
+test("confirmWorkspaceWindowClose minimizes focused workbench node before window close", async () => {
   let approvedCloseCount = 0;
   let closeGuardCount = 0;
+  const events: string[] = [];
   const hostInput: WorkspaceWorkbenchHostInput = {
     createWindowCloseDialogRequest: () => ({
       cancelLabel: "Cancel",
@@ -24,7 +25,7 @@ test("confirmWorkspaceWindowClose approves native window close without close gua
     workspaceId: "workspace-1"
   };
 
-  await confirmWorkspaceWindowClose({
+  const outcome = await confirmWorkspaceWindowClose({
     confirmCloseGuard: async () => {
       closeGuardCount += 1;
       return false;
@@ -33,8 +34,9 @@ test("confirmWorkspaceWindowClose approves native window close without close gua
       focusedNodeId: "workspace-app-1",
       nodeIds: ["workspace-app-1"],
       onCloseNode: () => assert.fail("window close should not close nodes"),
-      onMinimizeNode: () =>
-        assert.fail("window close should not minimize nodes")
+      onMinimizeNode: (nodeId) => {
+        events.push(`node-minimize:${nodeId}`);
+      }
     }),
     hostInput,
     reason: "window-close",
@@ -45,7 +47,9 @@ test("confirmWorkspaceWindowClose approves native window close without close gua
   });
 
   assert.equal(closeGuardCount, 0);
-  assert.equal(approvedCloseCount, 1);
+  assert.equal(approvedCloseCount, 0);
+  assert.deepEqual(events, ["node-minimize:workspace-app-1"]);
+  assert.equal(outcome, "blocked");
 });
 
 test("confirmWorkspaceWindowClose does not prepare host close before approving window close", async () => {
@@ -108,6 +112,61 @@ test("confirmWorkspaceWindowClose approves window close without stopping workspa
   });
 
   assert.deepEqual(events, ["approve"]);
+});
+
+test("confirmWorkspaceWindowClose falls back to visible node when focused id is stale", async () => {
+  const events: string[] = [];
+  const hostInput: WorkspaceWorkbenchHostInput = {
+    snapshotRepository: {} as never,
+    workspaceId: "workspace-5"
+  };
+
+  const outcome = await confirmWorkspaceWindowClose({
+    confirmCloseGuard: async () => true,
+    host: createWorkbenchHostHandleStub({
+      focusedNodeId: "stale-node",
+      nodeIds: ["live-node"],
+      onMinimizeNode: (nodeId) => {
+        events.push(`node-minimize:${nodeId}`);
+      }
+    }),
+    hostInput,
+    reason: "window-close",
+    requestApprovedClose: async () => {
+      events.push("approve");
+    },
+    tracker: createWindowCloseRequestTracker()
+  });
+
+  assert.deepEqual(events, ["node-minimize:live-node"]);
+  assert.equal(outcome, "blocked");
+});
+
+test("confirmWorkspaceWindowClose minimizes last visible node when focus stack is empty", async () => {
+  const events: string[] = [];
+  const hostInput: WorkspaceWorkbenchHostInput = {
+    snapshotRepository: {} as never,
+    workspaceId: "workspace-6"
+  };
+
+  const outcome = await confirmWorkspaceWindowClose({
+    confirmCloseGuard: async () => true,
+    host: createWorkbenchHostHandleStub({
+      nodeIds: ["workspace-files", "workspace-app-1"],
+      onMinimizeNode: (nodeId) => {
+        events.push(`node-minimize:${nodeId}`);
+      }
+    }),
+    hostInput,
+    reason: "window-close",
+    requestApprovedClose: async () => {
+      events.push("approve");
+    },
+    tracker: createWindowCloseRequestTracker()
+  });
+
+  assert.deepEqual(events, ["node-minimize:workspace-app-1"]);
+  assert.equal(outcome, "blocked");
 });
 
 test("confirmWorkspaceWindowClose approves host close when every node is minimized", async () => {

--- a/apps/desktop/src/renderer/src/features/workspace-workbench/services/internal/workspaceWindowCloseCoordinator.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/services/internal/workspaceWindowCloseCoordinator.ts
@@ -17,6 +17,15 @@ export async function confirmWorkspaceWindowClose(input: {
   tracker: WindowCloseRequestTracker;
 }): Promise<"approved" | "blocked"> {
   if (input.reason === "window-close") {
+    const host = input.host;
+    if (host) {
+      const focusedNodeId = resolveFocusedVisibleNodeId(host);
+      if (focusedNodeId) {
+        host.minimizeNode(focusedNodeId);
+        return "blocked";
+      }
+    }
+
     return requestWorkspaceWindowClose({
       requestApprovedClose: () => input.requestApprovedClose(),
       tracker: input.tracker
@@ -64,6 +73,20 @@ async function requestWorkspaceWindowClose(input: {
   } finally {
     input.tracker.finish();
   }
+}
+
+function resolveFocusedVisibleNodeId(host: WorkbenchHostHandle): string | null {
+  const snapshot = host.getSnapshot();
+  const focusedNodeId = snapshot.nodeStack.at(-1);
+  const visibleNodes = snapshot.nodes.filter((node) => !node.isMinimized);
+  if (focusedNodeId) {
+    const focusedNode = visibleNodes.find((node) => node.id === focusedNodeId);
+    if (focusedNode) {
+      return focusedNode.id;
+    }
+  }
+
+  return visibleNodes.at(-1)?.id ?? null;
 }
 
 function resolveQuitCloseNodeId(

--- a/apps/desktop/src/renderer/src/features/workspace-workbench/ui/WorkspaceLaunchpadOverlay.tsx
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/ui/WorkspaceLaunchpadOverlay.tsx
@@ -51,6 +51,10 @@ import {
   type WorkspaceLaunchpadOpenTrigger
 } from "../services/workspaceLaunchpadAnalytics.ts";
 import {
+  createWorkspaceLaunchpadWheelNavigationState,
+  resolveWorkspaceLaunchpadWheelNavigation
+} from "../services/internal/workspaceLaunchpadWheelNavigation.ts";
+import {
   buildWorkspaceLaunchpadItems,
   filterWorkspaceLaunchpadItems,
   paginateWorkspaceLaunchpadItems,
@@ -112,6 +116,9 @@ export function WorkspaceLaunchpadOverlay({
   const [shouldRender, setShouldRender] = useState(open);
   const searchInputRef = useRef<HTMLInputElement | null>(null);
   const wasOpenRef = useRef(false);
+  const wheelNavigationRef = useRef(
+    createWorkspaceLaunchpadWheelNavigationState()
+  );
   const { grid, ref: gridViewportRef } = useLaunchpadGridMetrics(open);
   const isClosing = shouldRender && !open;
   const launchpadAnalytics = useMemo(
@@ -247,6 +254,8 @@ export function WorkspaceLaunchpadOverlay({
   useEffect(() => {
     if (!open) {
       wasOpenRef.current = false;
+      wheelNavigationRef.current =
+        createWorkspaceLaunchpadWheelNavigationState();
       return;
     }
     if (!wasOpenRef.current) {
@@ -263,6 +272,7 @@ export function WorkspaceLaunchpadOverlay({
 
   useEffect(() => {
     setPageIndex(0);
+    wheelNavigationRef.current = createWorkspaceLaunchpadWheelNavigationState();
   }, [query]);
 
   useEffect(() => {
@@ -396,6 +406,31 @@ export function WorkspaceLaunchpadOverlay({
     },
     [closeLaunchpad, isClosing]
   );
+  const handleOverlayWheel = useCallback(
+    (event: React.WheelEvent<HTMLDivElement>) => {
+      if (!open || isClosing || isLaunchpadWheelIgnoredTarget(event.target)) {
+        return;
+      }
+
+      const result = resolveWorkspaceLaunchpadWheelNavigation({
+        currentPage: page.currentPage,
+        deltaMode: event.deltaMode,
+        deltaX: event.deltaX,
+        deltaY: event.deltaY,
+        pageCount: page.pageCount,
+        state: wheelNavigationRef.current,
+        timestamp: event.timeStamp
+      });
+      wheelNavigationRef.current = result.state;
+      if (result.shouldPreventDefault) {
+        event.preventDefault();
+      }
+      if (result.nextPageIndex !== null) {
+        changePage(result.nextPageIndex);
+      }
+    },
+    [changePage, isClosing, open, page.currentPage, page.pageCount]
+  );
 
   if (!shouldRender) {
     return null;
@@ -411,6 +446,7 @@ export function WorkspaceLaunchpadOverlay({
       )}
       role="dialog"
       onClick={handleOverlayClick}
+      onWheel={handleOverlayWheel}
     >
       <button
         aria-hidden="true"
@@ -916,6 +952,18 @@ function isLaunchpadInteractiveTarget(target: EventTarget | null): boolean {
         ".workspace-launchpad-overlay__topbar, .workspace-launchpad-search, .workspace-launchpad-item, .desktop-dock__hover-panel, .workspace-launchpad-pages"
       )
     )
+  );
+}
+
+function isLaunchpadWheelIgnoredTarget(target: EventTarget | null): boolean {
+  return (
+    isTextInputTarget(target) ||
+    (target instanceof HTMLElement &&
+      Boolean(
+        target.closest(
+          ".workspace-launchpad-overlay__topbar, .workspace-launchpad-search, .desktop-dock__hover-panel, .workspace-launchpad-pages"
+        )
+      ))
   );
 }
 


### PR DESCRIPTION
## Summary
- separate native red-window close from Command-W so Command-W minimizes workbench nodes first while native close can close the Electron window directly
- add Launchpad horizontal wheel navigation with gesture accumulation, boundary absorption, and cooldown handling
- cover the menu shortcut, window close coordinator, and Launchpad wheel navigation with tests

## Root Cause
Command-W and native window close were both flowing through the same Electron close path, so they could not express different semantics. Launchpad page navigation also did not have a dedicated wheel gesture resolver, making horizontal trackpad paging unavailable.

## Validation
- PATH=/Users/zoezyu/.nvm/versions/node/v24.17.0/bin:$PATH pnpm --filter @tutti-os/desktop typecheck
- PATH=/Users/zoezyu/.nvm/versions/node/v24.17.0/bin:$PATH pnpm --filter @tutti-os/desktop test
- PATH=/Users/zoezyu/.nvm/versions/node/v24.17.0/bin:$PATH pnpm check:renderer-boundaries
- PATH=/Users/zoezyu/.nvm/versions/node/v24.17.0/bin:$PATH pnpm check:electron-runtime-boundaries
- PATH=/Users/zoezyu/.nvm/versions/node/v24.17.0/bin:/Users/zoezyu/go/bin:$PATH pnpm lint:go
- pre-push: PATH=/Users/zoezyu/.nvm/versions/node/v24.17.0/bin:/Users/zoezyu/go/bin:$PATH git push -u origin codex/window-close-launchpad-wheel (runs pnpm check:full)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Command-W keyboard shortcut support for closing windows on macOS.
  * Implemented mouse wheel navigation for the workspace launchpad with throttling and boundary detection.
  * Workspace launchpad now minimizes the current panel when closed via Command-W instead of closing entirely.

* **Tests**
  * Added comprehensive test coverage for keyboard shortcut handling, wheel navigation, and close request coordination.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->