### PR TITLE
fix(agent): bundle Claude Code ACP adapter for offline install

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -27,6 +27,10 @@
       {
         "from": "build/browser-mcp",
         "to": "bin/browser-mcp"
+      },
+      {
+        "from": "build/claude-acp",
+        "to": "bin/claude-acp"
       }
     ],
     "publish": [

--- a/apps/desktop/scripts/vendor-claude-acp.mjs
+++ b/apps/desktop/scripts/vendor-claude-acp.mjs
@@ -22,7 +22,14 @@ const CLAUDE_ACP_VERSION = "0.46.0";
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const desktopDir = join(__dirname, "..");
 const repoRoot = join(desktopDir, "..", "..");
-const outDir = join(desktopDir, "build", "claude-acp");
+// stageDir is the extraResources `from` root (shipped to Resources/bin/claude-acp).
+// We install one level BELOW it, under bridge/, because electron-builder's file
+// matcher hard-excludes a `node_modules` directory that sits at the ROOT of an
+// extraResources `from` dir (app-builder-lib util/filter.js: `relative ===
+// "node_modules"` -> excluded) but KEEPS a nested one. Without this nesting the
+// vendored dependency tree is silently stripped from the packaged app.
+const stageDir = join(desktopDir, "build", "claude-acp");
+const outDir = join(stageDir, "bridge");
 const packageDistDir = join(
   "node_modules",
   "@agentclientprotocol",
@@ -47,7 +54,7 @@ function log(msg) {
   process.stderr.write(`[vendor-claude-acp] ${msg}\n`);
 }
 
-rmSync(outDir, { recursive: true, force: true });
+rmSync(stageDir, { recursive: true, force: true });
 mkdirSync(outDir, { recursive: true });
 
 // A minimal package.json so `npm install` materializes a self-contained tree.

--- a/apps/desktop/scripts/vendor-claude-acp.mjs
+++ b/apps/desktop/scripts/vendor-claude-acp.mjs
@@ -14,7 +14,13 @@
 // Keep CLAUDE_ACP_VERSION in sync with claudeACPPinnedVersion in
 // services/tuttid/service/agentstatus/claude_acp_bundled.go.
 import { execFileSync } from "node:child_process";
-import { existsSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import {
+  existsSync,
+  mkdirSync,
+  readdirSync,
+  rmSync,
+  writeFileSync
+} from "node:fs";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 
@@ -99,5 +105,23 @@ log(`patching bridge at ${patchTarget}`);
 execFileSync("node", [patchScript, "--dist", patchTarget], {
   stdio: "inherit"
 });
+
+// Prune the SDK's bundled Claude Code CLI. @anthropic-ai/claude-agent-sdk ships
+// the full CLI as a ~200MB platform-specific optional dependency
+// (@anthropic-ai/claude-agent-sdk-<os>-<arch>). We must not bundle it:
+//   1. Only the build host's arch is installed, which breaks @electron/universal
+//      packaging (it cannot merge a single-arch native binary across x64/arm64).
+//   2. The daemon points the bridge at Tutti's system-managed `claude` binary
+//      via CLAUDE_CODE_EXECUTABLE (see claude_acp_bundled.go), so the bundled CLI
+//      is never used. The bridge's claudeCliPath() honors that env var first.
+const anthropicScope = join(outDir, "node_modules", "@anthropic-ai");
+if (existsSync(anthropicScope)) {
+  for (const name of readdirSync(anthropicScope)) {
+    if (name.startsWith("claude-agent-sdk-")) {
+      rmSync(join(anthropicScope, name), { recursive: true, force: true });
+      log(`pruned bundled CLI package @anthropic-ai/${name}`);
+    }
+  }
+}
 
 log(`OK: vendored entry at ${runEntry}`);

--- a/apps/desktop/scripts/vendor-claude-acp.mjs
+++ b/apps/desktop/scripts/vendor-claude-acp.mjs
@@ -1,0 +1,96 @@
+#!/usr/bin/env node
+// Vendors a pinned @agentclientprotocol/claude-agent-acp into
+// apps/desktop/build/claude-acp so the packaged app can run Claude Code without
+// fetching the ACP bridge over the network at runtime (which fails on slow or
+// blocked networks during onboarding). electron-builder ships build/claude-acp
+// via extraResources, and the daemon launcher (resolveClaudeAcpDaemonEnv in
+// tuttidManager.ts) points the daemon at the run entry below; the Go side
+// (claude_acp_bundled.go) then runs it directly instead of installing via npm.
+//
+// The bridge is pre-patched here with the same fast-mode/goal codemod the daemon
+// applies post-install, because the bundled path never runs the installer's
+// post-step.
+//
+// Keep CLAUDE_ACP_VERSION in sync with claudeACPPinnedVersion in
+// services/tuttid/service/agentstatus/claude_acp_bundled.go.
+import { execFileSync } from "node:child_process";
+import { existsSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const CLAUDE_ACP_VERSION = "0.46.0";
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const desktopDir = join(__dirname, "..");
+const repoRoot = join(desktopDir, "..", "..");
+const outDir = join(desktopDir, "build", "claude-acp");
+const packageDistDir = join(
+  "node_modules",
+  "@agentclientprotocol",
+  "claude-agent-acp",
+  "dist"
+);
+// The package's `claude-agent-acp` bin is dist/index.js (the run entry). The
+// codemod targets the bundled dist/acp-agent.js that index.js imports.
+const runEntry = join(outDir, packageDistDir, "index.js");
+const patchTarget = join(outDir, packageDistDir, "acp-agent.js");
+const patchScript = join(
+  repoRoot,
+  "services",
+  "tuttid",
+  "service",
+  "agentstatus",
+  "assets",
+  "patch-claude-agent-acp.mjs"
+);
+
+function log(msg) {
+  process.stderr.write(`[vendor-claude-acp] ${msg}\n`);
+}
+
+rmSync(outDir, { recursive: true, force: true });
+mkdirSync(outDir, { recursive: true });
+
+// A minimal package.json so `npm install` materializes a self-contained tree.
+writeFileSync(
+  join(outDir, "package.json"),
+  JSON.stringify(
+    {
+      name: "tutti-vendored-claude-acp",
+      private: true,
+      version: "0.0.0",
+      dependencies: {
+        "@agentclientprotocol/claude-agent-acp": CLAUDE_ACP_VERSION
+      }
+    },
+    null,
+    2
+  ) + "\n"
+);
+
+log(
+  `installing @agentclientprotocol/claude-agent-acp@${CLAUDE_ACP_VERSION} into ${outDir}`
+);
+execFileSync(
+  "npm",
+  ["install", "--omit=dev", "--no-audit", "--no-fund", "--ignore-scripts"],
+  { cwd: outDir, stdio: "inherit" }
+);
+
+if (!existsSync(runEntry)) {
+  log(`ERROR: expected run entry not found: ${runEntry}`);
+  process.exit(1);
+}
+if (!existsSync(patchTarget)) {
+  log(`ERROR: expected patch target not found: ${patchTarget}`);
+  process.exit(1);
+}
+
+// Pre-apply the Tutti bridge codemod (fast mode + /goal forwarding). The script
+// is idempotent and exits non-zero if the bridge layout drifts, which fails the
+// build loudly rather than shipping an unpatched bridge.
+log(`patching bridge at ${patchTarget}`);
+execFileSync("node", [patchScript, "--dist", patchTarget], {
+  stdio: "inherit"
+});
+
+log(`OK: vendored entry at ${runEntry}`);

--- a/apps/desktop/src/main/daemon/tuttidManager.test.ts
+++ b/apps/desktop/src/main/daemon/tuttidManager.test.ts
@@ -190,6 +190,7 @@ test("resolveClaudeAcpDaemonEnv points the daemon at a vendored bridge when pres
       resourcesPath,
       "bin",
       "claude-acp",
+      "bridge",
       "node_modules",
       "@agentclientprotocol",
       "claude-agent-acp",

--- a/apps/desktop/src/main/daemon/tuttidManager.test.ts
+++ b/apps/desktop/src/main/daemon/tuttidManager.test.ts
@@ -16,6 +16,7 @@ import test from "node:test";
 import {
   isLikelyTuttidProcess,
   resolveBrowserMcpDaemonEnv,
+  resolveClaudeAcpDaemonEnv,
   resolveLaunchSpec,
   resolveManagedDaemonProcessEnv
 } from "./tuttidManager.ts";
@@ -132,6 +133,75 @@ test("resolveBrowserMcpDaemonEnv points the daemon at a vendored bundle when pre
     const got = resolveBrowserMcpDaemonEnv({ isPackaged: true, resourcesPath });
     assert.deepEqual(got, {
       TUTTI_BROWSER_MCP_ENTRY_PATH: entry
+    });
+  } finally {
+    restoreEnv(previousEnv);
+  }
+});
+
+test("resolveClaudeAcpDaemonEnv is a no-op in development (daemon uses the ACP registry npm install)", () => {
+  const previousEnv = { ...process.env };
+  try {
+    delete process.env.TUTTI_CLAUDE_ACP_ENTRY_PATH;
+    const got = resolveClaudeAcpDaemonEnv({
+      isPackaged: false,
+      resourcesPath: join(tmpdir(), "tutti-resources")
+    });
+    assert.deepEqual(got, {});
+  } finally {
+    restoreEnv(previousEnv);
+  }
+});
+
+test("resolveClaudeAcpDaemonEnv respects an explicit operator override", () => {
+  const previousEnv = { ...process.env };
+  try {
+    process.env.TUTTI_CLAUDE_ACP_ENTRY_PATH = "/custom/claude-agent-acp.js";
+    const got = resolveClaudeAcpDaemonEnv({
+      isPackaged: true,
+      resourcesPath: join(tmpdir(), "tutti-resources")
+    });
+    assert.deepEqual(got, {});
+  } finally {
+    restoreEnv(previousEnv);
+  }
+});
+
+test("resolveClaudeAcpDaemonEnv falls back to the registry when the vendored bundle is absent", () => {
+  const previousEnv = { ...process.env };
+  try {
+    delete process.env.TUTTI_CLAUDE_ACP_ENTRY_PATH;
+    const got = resolveClaudeAcpDaemonEnv({
+      isPackaged: true,
+      resourcesPath: join(tmpdir(), "tutti-resources-missing")
+    });
+    assert.deepEqual(got, {});
+  } finally {
+    restoreEnv(previousEnv);
+  }
+});
+
+test("resolveClaudeAcpDaemonEnv points the daemon at a vendored bridge when present", async () => {
+  const previousEnv = { ...process.env };
+  try {
+    delete process.env.TUTTI_CLAUDE_ACP_ENTRY_PATH;
+    const resourcesPath = await mkdtemp(join(tmpdir(), "tutti-resources-"));
+    const entry = join(
+      resourcesPath,
+      "bin",
+      "claude-acp",
+      "node_modules",
+      "@agentclientprotocol",
+      "claude-agent-acp",
+      "dist",
+      "index.js"
+    );
+    await mkdir(dirname(entry), { recursive: true });
+    await writeFile(entry, "// stub\n");
+
+    const got = resolveClaudeAcpDaemonEnv({ isPackaged: true, resourcesPath });
+    assert.deepEqual(got, {
+      TUTTI_CLAUDE_ACP_ENTRY_PATH: entry
     });
   } finally {
     restoreEnv(previousEnv);

--- a/apps/desktop/src/main/daemon/tuttidManager.ts
+++ b/apps/desktop/src/main/daemon/tuttidManager.ts
@@ -259,6 +259,10 @@ export function resolveBrowserMcpDaemonEnv(
 const vendoredClaudeAcpRelPath = join(
   "bin",
   "claude-acp",
+  // Nested under bridge/ so the vendored node_modules survives electron-builder
+  // packaging (it strips a node_modules dir at the extraResources `from` root).
+  // Kept in sync with outDir in scripts/vendor-claude-acp.mjs.
+  "bridge",
   "node_modules",
   "@agentclientprotocol",
   "claude-agent-acp",

--- a/apps/desktop/src/main/daemon/tuttidManager.ts
+++ b/apps/desktop/src/main/daemon/tuttidManager.ts
@@ -251,6 +251,50 @@ export function resolveBrowserMcpDaemonEnv(
   };
 }
 
+// Relative path (under the packaged Resources dir) to the vendored, pre-patched
+// claude-agent-acp bridge run entry (the package's `claude-agent-acp` bin, i.e.
+// dist/index.js). Kept in sync with the desktop build's extraResources staging
+// (apps/desktop build/claude-acp) and CLAUDE_ACP_VERSION in
+// scripts/vendor-claude-acp.mjs.
+const vendoredClaudeAcpRelPath = join(
+  "bin",
+  "claude-acp",
+  "node_modules",
+  "@agentclientprotocol",
+  "claude-agent-acp",
+  "dist",
+  "index.js"
+);
+
+// resolveClaudeAcpDaemonEnv points the daemon at the vendored, pre-patched
+// claude-agent-acp bridge in packaged builds so Claude Code never has to install
+// it over the network at runtime. Mirrors resolveBrowserMcpDaemonEnv: it is a
+// no-op in development (the daemon falls back to the ACP external agent registry
+// npm install) and respects an explicit operator override.
+export function resolveClaudeAcpDaemonEnv(
+  runtime?: DesktopElectronAppRuntime
+): Record<string, string> {
+  if (process.env.TUTTI_CLAUDE_ACP_ENTRY_PATH?.trim()) {
+    return {};
+  }
+  let appRuntime: DesktopElectronAppRuntime;
+  try {
+    appRuntime = runtime ?? resolveElectronAppRuntime();
+  } catch {
+    return {};
+  }
+  if (!appRuntime.isPackaged) {
+    return {};
+  }
+  const entry = join(appRuntime.resourcesPath, vendoredClaudeAcpRelPath);
+  if (!existsSync(entry)) {
+    return {};
+  }
+  return {
+    TUTTI_CLAUDE_ACP_ENTRY_PATH: entry
+  };
+}
+
 export function resolveManagedDaemonProcessEnv(
   input: ManagedDaemonProcessEnvInput
 ): NodeJS.ProcessEnv {
@@ -259,6 +303,7 @@ export function resolveManagedDaemonProcessEnv(
     ...(input.userShellEnv ?? {}),
     ...resolveEndpointEnv(input.endpoint),
     ...resolveBrowserMcpDaemonEnv(),
+    ...resolveClaudeAcpDaemonEnv(),
     TUTTI_APP_VERSION: process.env.TUTTI_APP_VERSION?.trim() ?? "",
     TUTTI_DESKTOP_PARENT_PID: String(input.parentPID ?? process.pid),
     TUTTI_LOG_DIR: input.logDir ?? resolveDesktopLogsDir(),

--- a/services/tuttid/service/agentstatus/claude_acp_bundled.go
+++ b/services/tuttid/service/agentstatus/claude_acp_bundled.go
@@ -56,8 +56,16 @@ func (s Service) resolveBundledClaudeACPSpec(
 	if !ok {
 		return spec, false
 	}
+	env := cloneStrings(appRuntime.EnvOverrides)
+	// The vendored bridge has the SDK's bundled Claude Code CLI pruned (see
+	// vendor-claude-acp.mjs), so point it at the system-managed claude binary.
+	// The bridge's claudeCliPath() honors CLAUDE_CODE_EXECUTABLE before falling
+	// back to the (now absent) bundled native package.
+	if claudePath := resolveBinaryWithResolver(s.commandResolver(), spec.BinaryNames, nil); strings.TrimSpace(claudePath) != "" {
+		env = append(env, "CLAUDE_CODE_EXECUTABLE="+claudePath)
+	}
 	spec.AdapterCommand = []string{appRuntime.Node, entry}
-	spec.AdapterEnv = cloneStrings(appRuntime.EnvOverrides)
+	spec.AdapterEnv = env
 	spec.AdapterPackage = AdapterPackageRequirement{
 		Name:    claudeACPPackageName,
 		Version: claudeACPPinnedVersion,

--- a/services/tuttid/service/agentstatus/claude_acp_bundled.go
+++ b/services/tuttid/service/agentstatus/claude_acp_bundled.go
@@ -1,0 +1,83 @@
+package agentstatus
+
+import (
+	"context"
+	"os"
+	"strings"
+)
+
+const (
+	// claudeACPExternalRegistryID is the ACP external agent registry id for the
+	// Claude Code bridge (see DefaultRegistry()).
+	claudeACPExternalRegistryID = "claude-acp"
+
+	// claudeACPPackageName and claudeACPPinnedVersion identify the
+	// @agentclientprotocol/claude-agent-acp bridge that the desktop app vendors
+	// and ships with the package. Keep these in sync with CLAUDE_ACP_VERSION in
+	// apps/desktop/scripts/vendor-claude-acp.mjs.
+	claudeACPPackageName   = "@agentclientprotocol/claude-agent-acp"
+	claudeACPPinnedVersion = "0.46.0"
+
+	// claudeACPEntryPathEnv is set by the packaged desktop app to the vendored,
+	// pre-patched bridge run entry (the package's `claude-agent-acp` bin, i.e.
+	// dist/index.js) so the daemon can run Claude Code offline without a runtime
+	// npm install. Mirrors TUTTI_BROWSER_MCP_ENTRY_PATH.
+	claudeACPEntryPathEnv = "TUTTI_CLAUDE_ACP_ENTRY_PATH"
+)
+
+// bundledClaudeACPEntryPath returns the vendored claude-agent-acp run entry when
+// the packaged desktop app has staged it and the file exists. An empty string
+// means "not bundled" and callers fall back to the external registry / npm
+// install path.
+func (s Service) bundledClaudeACPEntryPath() string {
+	entry := strings.TrimSpace(s.getenv(claudeACPEntryPathEnv))
+	if entry == "" {
+		return ""
+	}
+	if !s.fileExists(entry) {
+		return ""
+	}
+	return entry
+}
+
+// resolveBundledClaudeACPSpec wires the provider spec to run the vendored,
+// pre-patched bridge directly with the managed Node runtime. It deliberately
+// leaves AdapterInstall empty: the bridge is already on disk, so
+// nextMissingInstaller treats the adapter as present and never triggers an
+// install. Returns ok=false when the managed Node runtime is unavailable, so the
+// caller falls back to the external registry path.
+func (s Service) resolveBundledClaudeACPSpec(
+	ctx context.Context,
+	spec ProviderSpec,
+	entry string,
+	requireManagedRuntime bool,
+) (ProviderSpec, bool) {
+	appRuntime, ok := s.resolveManagedRuntimeForProvider(ctx, requireManagedRuntime)
+	if !ok {
+		return spec, false
+	}
+	spec.AdapterCommand = []string{appRuntime.Node, entry}
+	spec.AdapterEnv = cloneStrings(appRuntime.EnvOverrides)
+	spec.AdapterPackage = AdapterPackageRequirement{
+		Name:    claudeACPPackageName,
+		Version: claudeACPPinnedVersion,
+	}
+	spec.AdapterInstall = InstallerSpec{}
+	spec.AdapterUnavailableReasonCode = ""
+	return spec, true
+}
+
+// getenv reads a single environment variable, honoring an injected Environ for
+// testability and falling back to the process environment otherwise.
+func (s Service) getenv(key string) string {
+	if s.Environ == nil {
+		return os.Getenv(key)
+	}
+	prefix := key + "="
+	for _, kv := range s.Environ() {
+		if strings.HasPrefix(kv, prefix) {
+			return kv[len(prefix):]
+		}
+	}
+	return ""
+}

--- a/services/tuttid/service/agentstatus/claude_acp_bundled.go
+++ b/services/tuttid/service/agentstatus/claude_acp_bundled.go
@@ -41,20 +41,36 @@ func (s Service) bundledClaudeACPEntryPath() string {
 }
 
 // resolveBundledClaudeACPSpec wires the provider spec to run the vendored,
-// pre-patched bridge directly with the managed Node runtime. It deliberately
-// leaves AdapterInstall empty: the bridge is already on disk, so
-// nextMissingInstaller treats the adapter as present and never triggers an
-// install. Returns ok=false when the managed Node runtime is unavailable, so the
-// caller falls back to the external registry path.
+// pre-patched bridge directly with the managed Node runtime.
+//
+// Once the bridge is shipped it is authoritative: this never returns a spec that
+// can fall back to the remote registry / npm install. It always clears
+// AdapterInstall (so the installer loop, seeing ExternalRegistryID set, treats
+// the adapter as not-installable and never runs npm) and always pins
+// AdapterPackage to the bundled version. If the managed Node runtime is not yet
+// available (e.g. node-static still materializing at startup), it leaves the run
+// command empty and marks the adapter transiently unavailable — the next resolve
+// fills it in. This avoids a race where an in-flight runtime made the short
+// circuit fall through to the registry, ran an npm install, and then mismatched
+// the registry's required version against the bundled one ("provider adapter is
+// still unavailable after install").
 func (s Service) resolveBundledClaudeACPSpec(
 	ctx context.Context,
 	spec ProviderSpec,
 	entry string,
 	requireManagedRuntime bool,
-) (ProviderSpec, bool) {
+) ProviderSpec {
+	spec.AdapterInstall = InstallerSpec{}
+	spec.AdapterPackage = AdapterPackageRequirement{
+		Name:    claudeACPPackageName,
+		Version: claudeACPPinnedVersion,
+	}
 	appRuntime, ok := s.resolveManagedRuntimeForProvider(ctx, requireManagedRuntime)
 	if !ok {
-		return spec, false
+		spec.AdapterCommand = nil
+		spec.AdapterEnv = nil
+		spec.AdapterUnavailableReasonCode = ReasonManagedRuntimeUnavailable
+		return spec
 	}
 	env := cloneStrings(appRuntime.EnvOverrides)
 	// The vendored bridge has the SDK's bundled Claude Code CLI pruned (see
@@ -66,13 +82,8 @@ func (s Service) resolveBundledClaudeACPSpec(
 	}
 	spec.AdapterCommand = []string{appRuntime.Node, entry}
 	spec.AdapterEnv = env
-	spec.AdapterPackage = AdapterPackageRequirement{
-		Name:    claudeACPPackageName,
-		Version: claudeACPPinnedVersion,
-	}
-	spec.AdapterInstall = InstallerSpec{}
 	spec.AdapterUnavailableReasonCode = ""
-	return spec, true
+	return spec
 }
 
 // getenv reads a single environment variable, honoring an injected Environ for

--- a/services/tuttid/service/agentstatus/claude_acp_bundled_test.go
+++ b/services/tuttid/service/agentstatus/claude_acp_bundled_test.go
@@ -1,0 +1,129 @@
+package agentstatus
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"slices"
+	"testing"
+	"time"
+
+	externalagentregistry "github.com/tutti-os/tutti/services/tuttid/service/externalagentregistry"
+)
+
+// brokenExternalRegistry points at a non-existent source so any attempt to read
+// the ACP external agent registry fails. A passing test that uses it proves the
+// bundled path never touches the network/registry.
+func brokenExternalRegistry(t *testing.T) externalagentregistry.Store {
+	t.Helper()
+	return externalagentregistry.Store{
+		SourceURL: filepath.Join(t.TempDir(), "does-not-exist.json"),
+		CacheRoot: filepath.Join(t.TempDir(), "cache"),
+		Now: func() time.Time {
+			return time.Date(2026, 6, 2, 8, 0, 0, 0, time.UTC)
+		},
+	}
+}
+
+func TestServiceResolveProviderCommandUsesBundledClaudeACP(t *testing.T) {
+	home := t.TempDir()
+	runtimeRoot := fakeManagedRuntimeRoot(t)
+	entry := filepath.Join(t.TempDir(), "claude-acp", "dist", "index.js")
+	if err := os.MkdirAll(filepath.Dir(entry), 0o755); err != nil {
+		t.Fatalf("mkdir entry dir: %v", err)
+	}
+	if err := os.WriteFile(entry, []byte("// vendored bridge\n"), 0o644); err != nil {
+		t.Fatalf("write entry: %v", err)
+	}
+	expectedNode := filepath.Join(runtimeRoot, "node", "bin", nodeBinaryNameForTest())
+
+	service := probeTestService(home)
+	// A deliberately broken registry: success proves we never consult it.
+	service.ExternalAgentRegistry = brokenExternalRegistry(t)
+	service.ManagedRuntime = fakeManagedRuntimeResolver(t, runtimeRoot)
+	service.Environ = func() []string {
+		return []string{"PATH=/usr/bin:/bin", claudeACPEntryPathEnv + "=" + entry}
+	}
+	service.FileExists = func(path string) bool { return path == entry }
+
+	result, err := service.ResolveProviderCommand(context.Background(), "claude-code")
+	if err != nil {
+		t.Fatalf("ResolveProviderCommand() error = %v", err)
+	}
+	want := []string{expectedNode, entry}
+	if !slices.Equal(result.Command, want) {
+		t.Fatalf("Command = %#v, want bundled bridge %#v", result.Command, want)
+	}
+	if slices.Contains(result.Command, "exec") || slices.Contains(result.Command, "install") {
+		t.Fatalf("Command = %#v, want bundled run without npm exec/install", result.Command)
+	}
+}
+
+func TestServiceRunActionSkipsInstallWhenClaudeACPBundled(t *testing.T) {
+	home := t.TempDir()
+	runtimeRoot := fakeManagedRuntimeRoot(t)
+	entry := filepath.Join(t.TempDir(), "claude-acp", "dist", "index.js")
+	if err := os.MkdirAll(filepath.Dir(entry), 0o755); err != nil {
+		t.Fatalf("mkdir entry dir: %v", err)
+	}
+	if err := os.WriteFile(entry, []byte("// vendored bridge\n"), 0o644); err != nil {
+		t.Fatalf("write entry: %v", err)
+	}
+
+	service := probeTestService(home)
+	service.ExternalAgentRegistry = brokenExternalRegistry(t)
+	service.ManagedRuntime = fakeManagedRuntimeResolver(t, runtimeRoot)
+	service.Environ = func() []string {
+		return []string{"PATH=/usr/bin:/bin", claudeACPEntryPathEnv + "=" + entry}
+	}
+	service.FileExists = func(path string) bool { return path == entry }
+	// The Claude CLI is already installed (as in the real onboarding flow), so the
+	// only install that could run is the adapter — which bundling must skip.
+	service.LookPath = func(name string) (string, error) {
+		if name == "claude" {
+			return "/usr/local/bin/claude", nil
+		}
+		return "", errors.New("not found")
+	}
+	installCalled := false
+	service.InstallCommand = func(context.Context, InstallCommandInput) (InstallCommandResult, error) {
+		installCalled = true
+		return InstallCommandResult{ExitCode: 0}, nil
+	}
+
+	if _, err := service.RunAction(context.Background(), RunActionInput{
+		Provider: "claude-code",
+		ActionID: ActionInstall,
+	}); err != nil {
+		t.Fatalf("RunAction() error = %v", err)
+	}
+	if installCalled {
+		t.Fatal("InstallCommand was called, want bundled bridge to skip install")
+	}
+}
+
+func TestServiceResolveProviderSpecFallsBackWhenClaudeACPEntryMissing(t *testing.T) {
+	home := t.TempDir()
+	registryStore, prefixDir := fakeClaudeExternalRegistry(t)
+	runtimeRoot := fakeManagedRuntimeRoot(t)
+
+	service := probeTestService(home)
+	service.ExternalAgentRegistry = registryStore
+	service.ManagedRuntime = fakeManagedRuntimeResolver(t, runtimeRoot)
+	// Entry env points at a path that does not exist: bundled is skipped.
+	missingEntry := filepath.Join(t.TempDir(), "missing", "dist", "index.js")
+	service.Environ = func() []string {
+		return []string{"PATH=/usr/bin:/bin", claudeACPEntryPathEnv + "=" + missingEntry}
+	}
+	service.FileExists = func(string) bool { return false }
+
+	result, err := service.ResolveProviderCommand(context.Background(), "claude-code")
+	if err != nil {
+		t.Fatalf("ResolveProviderCommand() error = %v", err)
+	}
+	// Falls back to the npm-registry exec path against the resolved prefix dir.
+	if !slices.Contains(result.Command, "exec") || !slices.Contains(result.Command, prefixDir) {
+		t.Fatalf("Command = %#v, want npm registry exec fallback under %q", result.Command, prefixDir)
+	}
+}

--- a/services/tuttid/service/agentstatus/claude_acp_bundled_test.go
+++ b/services/tuttid/service/agentstatus/claude_acp_bundled_test.go
@@ -46,6 +46,13 @@ func TestServiceResolveProviderCommandUsesBundledClaudeACP(t *testing.T) {
 		return []string{"PATH=/usr/bin:/bin", claudeACPEntryPathEnv + "=" + entry}
 	}
 	service.FileExists = func(path string) bool { return path == entry }
+	// System claude is installed; the bundled bridge must be pointed at it.
+	service.LookPath = func(name string) (string, error) {
+		if name == "claude" {
+			return "/usr/local/bin/claude", nil
+		}
+		return "", errors.New("not found")
+	}
 
 	result, err := service.ResolveProviderCommand(context.Background(), "claude-code")
 	if err != nil {
@@ -57,6 +64,9 @@ func TestServiceResolveProviderCommandUsesBundledClaudeACP(t *testing.T) {
 	}
 	if slices.Contains(result.Command, "exec") || slices.Contains(result.Command, "install") {
 		t.Fatalf("Command = %#v, want bundled run without npm exec/install", result.Command)
+	}
+	if !slices.Contains(result.Env, "CLAUDE_CODE_EXECUTABLE=/usr/local/bin/claude") {
+		t.Fatalf("Env = %#v, want CLAUDE_CODE_EXECUTABLE pointing at system claude", result.Env)
 	}
 }
 

--- a/services/tuttid/service/agentstatus/claude_acp_bundled_test.go
+++ b/services/tuttid/service/agentstatus/claude_acp_bundled_test.go
@@ -10,7 +10,16 @@ import (
 	"time"
 
 	externalagentregistry "github.com/tutti-os/tutti/services/tuttid/service/externalagentregistry"
+	managedruntime "github.com/tutti-os/tutti/services/tuttid/service/managedruntime"
 )
+
+// unavailableManagedRuntime simulates the managed Node runtime not being ready
+// yet (e.g. node-static still materializing at startup): Resolve errors.
+type unavailableManagedRuntime struct{}
+
+func (unavailableManagedRuntime) Resolve(context.Context) (managedruntime.ResolvedRuntime, error) {
+	return managedruntime.ResolvedRuntime{}, errors.New("managed runtime not ready")
+}
 
 // brokenExternalRegistry points at a non-existent source so any attempt to read
 // the ACP external agent registry fails. A passing test that uses it proves the
@@ -110,6 +119,42 @@ func TestServiceRunActionSkipsInstallWhenClaudeACPBundled(t *testing.T) {
 	}
 	if installCalled {
 		t.Fatal("InstallCommand was called, want bundled bridge to skip install")
+	}
+}
+
+func TestResolveProviderSpecBundledNeverFallsBackToRegistry(t *testing.T) {
+	home := t.TempDir()
+	entry := filepath.Join(t.TempDir(), "claude-acp", "dist", "index.js")
+	if err := os.MkdirAll(filepath.Dir(entry), 0o755); err != nil {
+		t.Fatalf("mkdir entry dir: %v", err)
+	}
+	if err := os.WriteFile(entry, []byte("// vendored bridge\n"), 0o644); err != nil {
+		t.Fatalf("write entry: %v", err)
+	}
+
+	// A valid registry is available: if the bundled path wrongly fell back, the
+	// npm installer would be selected. The managed runtime is NOT ready, which is
+	// exactly the startup race that previously caused a spurious npm install and a
+	// version mismatch ("provider adapter is still unavailable after install").
+	registryStore, _ := fakeClaudeExternalRegistry(t)
+	service := probeTestService(home)
+	service.ExternalAgentRegistry = registryStore
+	service.ManagedRuntime = unavailableManagedRuntime{}
+	service.Environ = func() []string {
+		return []string{"PATH=/usr/bin:/bin", claudeACPEntryPathEnv + "=" + entry}
+	}
+	service.FileExists = func(path string) bool { return path == entry }
+
+	specs, err := service.selectProviderSpecs(context.Background(), []string{"claude-code"}, true)
+	if err != nil {
+		t.Fatalf("selectProviderSpecs() error = %v", err)
+	}
+	spec := specs[0]
+	if spec.AdapterInstall.Kind != "" || spec.AdapterInstall.RegistryNPM != nil {
+		t.Fatalf("AdapterInstall = %#v, want empty (bundle must never fall back to registry npm)", spec.AdapterInstall)
+	}
+	if spec.AdapterPackage.Version != claudeACPPinnedVersion {
+		t.Fatalf("AdapterPackage.Version = %q, want bundled %q", spec.AdapterPackage.Version, claudeACPPinnedVersion)
 	}
 }
 

--- a/services/tuttid/service/agentstatus/provider_resolution.go
+++ b/services/tuttid/service/agentstatus/provider_resolution.go
@@ -61,6 +61,17 @@ func (s Service) resolveProviderSpec(ctx context.Context, spec ProviderSpec, req
 	if strings.TrimSpace(spec.ExternalRegistryID) == "" {
 		return spec, nil
 	}
+	// Prefer the bundled, pre-patched Claude Code bridge shipped with the desktop
+	// app so Claude Code works fully offline: no remote registry fetch and no
+	// runtime npm install. Falls through to the external registry path when the
+	// bridge is not bundled or the managed Node runtime is unavailable.
+	if spec.ExternalRegistryID == claudeACPExternalRegistryID {
+		if entry := s.bundledClaudeACPEntryPath(); entry != "" {
+			if resolved, ok := s.resolveBundledClaudeACPSpec(ctx, spec, entry, requireManagedRuntime); ok {
+				return resolved, nil
+			}
+		}
+	}
 	agent, err := s.externalAgentRegistry().Agent(ctx, spec.ExternalRegistryID)
 	if err != nil {
 		spec.AdapterUnavailableReasonCode = ReasonExternalAgentRegistryUnavailable

--- a/services/tuttid/service/agentstatus/provider_resolution.go
+++ b/services/tuttid/service/agentstatus/provider_resolution.go
@@ -67,9 +67,9 @@ func (s Service) resolveProviderSpec(ctx context.Context, spec ProviderSpec, req
 	// bridge is not bundled or the managed Node runtime is unavailable.
 	if spec.ExternalRegistryID == claudeACPExternalRegistryID {
 		if entry := s.bundledClaudeACPEntryPath(); entry != "" {
-			if resolved, ok := s.resolveBundledClaudeACPSpec(ctx, spec, entry, requireManagedRuntime); ok {
-				return resolved, nil
-			}
+			// The bundled bridge is authoritative — never fall back to the remote
+			// registry / npm install once it is shipped.
+			return s.resolveBundledClaudeACPSpec(ctx, spec, entry, requireManagedRuntime), nil
 		}
 	}
 	agent, err := s.externalAgentRegistry().Agent(ctx, spec.ExternalRegistryID)

--- a/tools/scripts/build-desktop-package.sh
+++ b/tools/scripts/build-desktop-package.sh
@@ -181,6 +181,14 @@ prepare_browser_mcp() {
   node "${ROOT_DIR}/apps/desktop/scripts/vendor-browser-mcp.mjs"
 }
 
+prepare_claude_acp() {
+  # Vendors a pinned, pre-patched @agentclientprotocol/claude-agent-acp into
+  # build/claude-acp so packaged Claude Code never has to npm-install the ACP
+  # bridge over the network at runtime. The daemon launcher
+  # (resolveClaudeAcpDaemonEnv) points the daemon at the bundled run entry.
+  node "${ROOT_DIR}/apps/desktop/scripts/vendor-claude-acp.mjs"
+}
+
 run_pnpm_build() {
   pnpm build
 }
@@ -236,6 +244,7 @@ case "${VARIANT}" in
     run_timed_phase "prepare_builtin_apps" prepare_builtin_apps
     run_timed_phase "prepare_packaged_daemon" prepare_packaged_daemon
     run_timed_phase "prepare_browser_mcp" prepare_browser_mcp
+    run_timed_phase "prepare_claude_acp" prepare_claude_acp
     (
       cd "${APP_DIR}"
       run_timed_phase "resolve_desktop_build_version" resolve_desktop_build_version


### PR DESCRIPTION
## Problem

Installing **Claude Code** could fail during onboarding with:

```
Installation failed — sh: claude-agent-acp: command not found
```

The ACP adapter (`@agentclientprotocol/claude-agent-acp`) is installed on the
user's machine at runtime via `npm install` from the public registry. On
slow/blocked networks the install hangs past the 5‑minute timeout and is killed,
leaving the adapter binary absent; the subsequent launch then reports
`command not found`. (Diagnosed from a user log bundle: `installerKind=external_agent_registry_npm`
→ `error="context deadline exceeded"` at exactly 5 min.)

## Approach

Ship the ACP bridge **with the desktop app** so Claude Code works without a
runtime npm install — mirroring the existing `chrome-devtools-mcp` vendoring:

- **Build time** (`vendor-claude-acp.mjs`): `npm install` the pinned bridge, run
  the existing fast‑mode/`/goal` codemod against it, and ship it via
  electron-builder `extraResources`.
- **Daemon** (`tuttidManager.ts`): in packaged builds, point the daemon at the
  vendored entry with `TUTTI_CLAUDE_ACP_ENTRY_PATH` (no-op in dev / operator
  override, mirroring `resolveBrowserMcpDaemonEnv`).
- **Resolution** (`claude_acp_bundled.go`, `provider_resolution.go`): when the
  bundle is present, `resolveProviderSpec` runs it directly with the managed Node
  runtime and **never** falls back to the registry/npm path.

## Issues found & fixed while verifying (3 rounds of on-device + CI testing)

1. **node_modules stripped from the package.** electron-builder hard-excludes a
   `node_modules` dir at the root of an `extraResources` `from` dir
   (`app-builder-lib util/filter.js`: `relative === "node_modules"` → excluded),
   but keeps a *nested* one. → Install the vendored tree under `bridge/`.
   *(Note: `build/browser-mcp` has the same latent bug — its vendored tree is
   also stripped, so packaged browser-use silently falls back to `npx`. Not
   fixed here; see follow-ups.)*
2. **216 MB bundled CLI broke the universal build.** The SDK pulls in
   `@anthropic-ai/claude-agent-sdk-<os>-<arch>` (the full Claude Code CLI as a
   platform-specific native dep); only the build host's arch is installed, so
   `@electron/universal` can't merge it. → Prune those native packages
   (`build/claude-acp`: ~216 MB → ~43 MB, no Mach-O left) and point the bridge at
   Tutti's system-managed `claude` via `CLAUDE_CODE_EXECUTABLE` (the bridge's
   `claudeCliPath()` honors it first).
3. **Startup race fell back to npm + version mismatch.** At the first resolution
   the managed Node runtime was still materializing, so the short circuit fell
   through to the registry; the npm install ran, then the recheck reported the
   bundled `0.46.0` against the registry's required `0.50.0` →
   `provider adapter is still unavailable after install`. → Once shipped the
   bundle is authoritative: always return the bundled spec (never the registry)
   and keep `AdapterInstall` empty so no npm install can ever be selected; if the
   runtime isn't ready yet, leave the command empty and self-heal on the next
   resolve.

## Verification

- Go (`agentstatus`) + desktop (`tuttidManager`) unit/regression suites green;
  gofmt/vet clean.
- Vendored bridge smoke-tested: answers ACP `initialize` with the bundled CLI
  pruned and `CLAUDE_CODE_EXECUTABLE` set.
- Unsigned dry-run packaging (arm64/x64/universal) verified: shipped app contains
  `bin/claude-acp/bridge/node_modules/.../dist/index.js`, no Mach-O binaries,
  fast-mode patch applied.
- **On-device (rc.274):** enabling Claude Code shows **zero** install steps in
  `tuttid.log`, the bundled `claude-agent-acp` adapter starts, authenticates, and
  runs sessions; SDK init loads the user's own plugins/skills (proving it uses
  the system `claude`).

## Out of scope / follow-ups

- `browser-mcp` has the same `node_modules`-stripping bug (packaged browser-use
  falls back to `npx`); fixable with the same nesting.
- Bundled bridge is pinned to `0.46.0` (registry currently serves `0.50.0`);
  bump separately once patch anchors are confirmed.
- First-run still needs network to download the managed Node runtime (out of
  scope; the eliminated failure was the npm adapter install).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * The desktop app now ships with a pre-packaged Claude ACP bridge, enabling agent integration to work reliably in packaged/offline environments without downloading at runtime.

* **Tests**
  * Added unit and service-level coverage to verify bundled bridge selection, correct environment setup, and expected command-generation behavior, including proper fallback when the bundled entry is unavailable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->