### PR TITLE
docs: link contributing guide from agent instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,6 +23,12 @@ Read the closest `AGENTS.md` before editing:
 
 Use this root file for repository-wide defaults only. Area-specific files win.
 
+## Contribution Workflow
+
+Before preparing commits or pull requests, read `CONTRIBUTING.md` and follow it
+for repository-wide contribution requirements, including Conventional Commits,
+DCO sign-off, PR workflow, review gates, and multilingual documentation updates.
+
 ## Hard Rules
 
 - Published workspace packages use `@tutti-os/*`; keep manifests, imports, docs, and release config aligned.


### PR DESCRIPTION
## Summary

- add a contribution workflow section to AGENTS.md
- direct agents to read CONTRIBUTING.md before preparing commits or pull requests
- call out Conventional Commits, DCO, PR workflow, review gates, and multilingual docs

## Verification

- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated contribution workflow guidelines in AGENTS.md, outlining requirements contributors should review before submitting commits or pull requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->