### PR TITLE
[codex] Fix workbench minimize Genie anchors

### DIFF
--- a/packages/workbench/surface/src/host/WorkbenchHostDock.tsx
+++ b/packages/workbench/surface/src/host/WorkbenchHostDock.tsx
@@ -3209,6 +3209,100 @@ function resolveNextDockItemPresence(
   return previousPresence ?? "entering";
 }
 
+function resolveDockPresenceItems(input: {
+  current: readonly WorkbenchHostPresentDockItem[];
+  initialized: boolean;
+  nextSourceItems: readonly WorkbenchHostDockItem[];
+  shouldAnimateMinimizedDockEnter: (nodeId: string) => boolean;
+}): WorkbenchHostPresentDockItem[] {
+  const currentByKey = new Map(input.current.map((item) => [item.key, item]));
+  const currentIndexByKey = new Map(
+    input.current.map((item, index) => [item.key, index])
+  );
+  const nextByKey = new Map(
+    input.nextSourceItems.map((item) => [item.key, item])
+  );
+  const nextKeys = new Set(input.nextSourceItems.map((item) => item.key));
+  const currentVisibleItemCount = input.current.filter(
+    (item) => item.presence !== "exiting"
+  ).length;
+  const shouldRetainExitingItems =
+    input.nextSourceItems.length < currentVisibleItemCount;
+  const emittedKeys = new Set<string>();
+  const nextItems: WorkbenchHostPresentDockItem[] = [];
+  let currentIndex = 0;
+
+  const emitExitingUntil = (nextCurrentIndex: number) => {
+    while (currentIndex < nextCurrentIndex) {
+      const currentItem = input.current[currentIndex];
+      currentIndex += 1;
+      if (
+        shouldRetainExitingItems &&
+        currentItem &&
+        !nextKeys.has(currentItem.key) &&
+        !emittedKeys.has(currentItem.key)
+      ) {
+        emittedKeys.add(currentItem.key);
+        nextItems.push({
+          ...currentItem,
+          presence: "exiting"
+        });
+      }
+    }
+  };
+
+  for (const item of input.nextSourceItems) {
+    const previousIndex = currentIndexByKey.get(item.key);
+    if (previousIndex !== undefined) {
+      emitExitingUntil(previousIndex);
+      currentIndex = Math.max(currentIndex, previousIndex + 1);
+    }
+    emittedKeys.add(item.key);
+    nextItems.push({
+      item,
+      key: item.key,
+      presence: resolveNextDockItemPresence(
+        item,
+        input.initialized,
+        currentByKey.get(item.key)?.presence,
+        input.shouldAnimateMinimizedDockEnter
+      )
+    });
+  }
+
+  for (const currentItem of input.current) {
+    if (shouldRetainExitingItems && !nextKeys.has(currentItem.key)) {
+      if (emittedKeys.has(currentItem.key)) {
+        continue;
+      }
+      emittedKeys.add(currentItem.key);
+      nextItems.push({
+        ...currentItem,
+        presence: "exiting"
+      });
+    }
+  }
+
+  return nextItems.filter(
+    (item) => nextByKey.has(item.key) || item.presence === "exiting"
+  );
+}
+
+function resolveDockPresenceSettleMs(
+  items: readonly WorkbenchHostPresentDockItem[]
+): number {
+  if (
+    items.some(
+      (item) =>
+        item.item.kind === "minimized" &&
+        (item.presence === "entering" || item.presence === "exiting")
+    )
+  ) {
+    return minimizedDockSlotLayoutAnimationMs;
+  }
+  return dockPresenceAnimationMs;
+}
+
 function useDockPresenceItems(
   items: readonly WorkbenchHostDockItem[],
   shouldAnimateMinimizedDockEnter: (nodeId: string) => boolean
@@ -3235,87 +3329,14 @@ function useDockPresenceItems(
     let nextSettleMs = dockPresenceAnimationMs;
 
     setPresentItems((current) => {
-      const nextSourceItems = [...latestItemsByKey.current.values()];
-      const currentByKey = new Map(current.map((item) => [item.key, item]));
-      const currentIndexByKey = new Map(
-        current.map((item, index) => [item.key, index])
-      );
-      const nextByKey = new Map(
-        nextSourceItems.map((item) => [item.key, item])
-      );
-      const nextKeys = new Set(nextSourceItems.map((item) => item.key));
-      const currentVisibleItemCount = current.filter(
-        (item) => item.presence !== "exiting"
-      ).length;
-      const shouldRetainExitingItems =
-        nextSourceItems.length < currentVisibleItemCount;
-      const emittedKeys = new Set<string>();
-      const nextItems: WorkbenchHostPresentDockItem[] = [];
-      let currentIndex = 0;
-
-      const emitExitingUntil = (nextCurrentIndex: number) => {
-        while (currentIndex < nextCurrentIndex) {
-          const currentItem = current[currentIndex];
-          currentIndex += 1;
-          if (
-            shouldRetainExitingItems &&
-            currentItem &&
-            !nextKeys.has(currentItem.key) &&
-            !emittedKeys.has(currentItem.key)
-          ) {
-            emittedKeys.add(currentItem.key);
-            nextItems.push({
-              ...currentItem,
-              presence: "exiting"
-            });
-          }
-        }
-      };
-
-      for (const item of nextSourceItems) {
-        const previousIndex = currentIndexByKey.get(item.key);
-        if (previousIndex !== undefined) {
-          emitExitingUntil(previousIndex);
-          currentIndex = Math.max(currentIndex, previousIndex + 1);
-        }
-        emittedKeys.add(item.key);
-        nextItems.push({
-          item,
-          key: item.key,
-          presence: resolveNextDockItemPresence(
-            item,
-            initialized.current,
-            currentByKey.get(item.key)?.presence,
-            shouldAnimateMinimizedDockEnterRef.current
-          )
-        });
-      }
-
-      for (const currentItem of current) {
-        if (shouldRetainExitingItems && !nextKeys.has(currentItem.key)) {
-          if (emittedKeys.has(currentItem.key)) {
-            continue;
-          }
-          emittedKeys.add(currentItem.key);
-          nextItems.push({
-            ...currentItem,
-            presence: "exiting"
-          });
-        }
-      }
-
-      const filteredItems = nextItems.filter(
-        (item) => nextByKey.has(item.key) || item.presence === "exiting"
-      );
-      if (
-        filteredItems.some(
-          (item) =>
-            item.item.kind === "minimized" &&
-            (item.presence === "entering" || item.presence === "exiting")
-        )
-      ) {
-        nextSettleMs = minimizedDockSlotLayoutAnimationMs;
-      }
+      const filteredItems = resolveDockPresenceItems({
+        current,
+        initialized: initialized.current,
+        nextSourceItems: [...latestItemsByKey.current.values()],
+        shouldAnimateMinimizedDockEnter:
+          shouldAnimateMinimizedDockEnterRef.current
+      });
+      nextSettleMs = resolveDockPresenceSettleMs(filteredItems);
       return filteredItems;
     });
     initialized.current = true;
@@ -3335,7 +3356,14 @@ function useDockPresenceItems(
     return () => globalThis.clearTimeout(timeout);
   }, [itemKeys]);
 
-  return presentItems.map((presentItem) => {
+  const renderedPresentItems = resolveDockPresenceItems({
+    current: presentItems,
+    initialized: initialized.current,
+    nextSourceItems: [...latestItemsByKey.current.values()],
+    shouldAnimateMinimizedDockEnter
+  });
+
+  return renderedPresentItems.map((presentItem) => {
     const latestItem = latestItemsByKey.current.get(presentItem.key);
     return latestItem ? { ...presentItem, item: latestItem } : presentItem;
   });

--- a/packages/workbench/surface/src/react/WorkbenchSurface.tsx
+++ b/packages/workbench/surface/src/react/WorkbenchSurface.tsx
@@ -92,6 +92,7 @@ export function WorkbenchSurface<TData>({
   captureNodePreviewImage,
   className,
   controller,
+  debugDiagnostics,
   dockPreviewCache,
   dockPlacement,
   interactive,
@@ -123,6 +124,7 @@ export function WorkbenchSurface<TData>({
       <WorkbenchSurfaceInner
         captureNodePreviewImage={captureNodePreviewImage}
         className={className}
+        debugDiagnostics={debugDiagnostics}
         dockPreviewCache={dockPreviewCache}
         dockPlacement={dockPlacement}
         interactive={interactive}
@@ -156,6 +158,7 @@ export function WorkbenchSurface<TData>({
 function WorkbenchSurfaceInner<TData>({
   captureNodePreviewImage,
   className,
+  debugDiagnostics,
   dockPreviewCache,
   dockPlacement,
   interactive = true,
@@ -193,6 +196,7 @@ function WorkbenchSurfaceInner<TData>({
   const genie = useWorkbenchGenieAnimation({
     captureNodePreviewImage,
     controller,
+    debugDiagnostics,
     dockPreviewCache,
     minimizeAnimation,
     renderNodeGeniePreview,

--- a/packages/workbench/surface/src/react/useWorkbenchGenieAnimation.tsx
+++ b/packages/workbench/surface/src/react/useWorkbenchGenieAnimation.tsx
@@ -6,7 +6,10 @@ import {
   type ReactNode
 } from "react";
 import { createPortal, flushSync } from "react-dom";
-import type { WorkbenchController } from "../store/types.ts";
+import type {
+  WorkbenchController,
+  WorkbenchDebugDiagnostics
+} from "../store/types.ts";
 import type { WorkbenchNode } from "../core/types.ts";
 import type { WorkbenchMinimizeAnimation } from "./types.ts";
 import type {
@@ -31,6 +34,7 @@ const genieMaxDevicePixelRatio = 2;
 const genieSnapshotScale = 1;
 const renderedGeniePreviewHeaderOffsetPx = 40;
 const minimizedDockSlotEnterAnimationMs = 720;
+const dockAnchorResolveMaxAnimationFrames = 3;
 const dockPreviewMaxWidth = 260;
 const dockPreviewMaxHeight = 170;
 const dockPreviewImageCacheMaxEntries = 96;
@@ -86,6 +90,46 @@ function isFocusedWorkbenchNode<TData>(
 
 function isEmptyGeniePreview(preview: ReactNode): boolean {
   return preview === null || preview === undefined || preview === false;
+}
+
+function logWorkbenchGenieDiagnostic(
+  debugDiagnostics: WorkbenchDebugDiagnostics | undefined,
+  event: string,
+  details: Record<string, unknown>,
+  level: "debug" | "info" | "warn" = "info"
+): void {
+  if (!debugDiagnostics?.isEnabled() || !debugDiagnostics.log) {
+    return;
+  }
+  void Promise.resolve(
+    debugDiagnostics.log({
+      details,
+      event,
+      level,
+      source: "workbench-genie"
+    })
+  ).catch(() => undefined);
+}
+
+function describeGenieNode<TData>(
+  node: WorkbenchNode<TData> | null | undefined
+): Record<string, unknown> {
+  if (!node) {
+    return {};
+  }
+  const data =
+    node.data && typeof node.data === "object"
+      ? (node.data as Record<string, unknown>)
+      : {};
+  return {
+    displayMode: node.displayMode,
+    instanceId: typeof data.instanceId === "string" ? data.instanceId : null,
+    isMinimized: node.isMinimized,
+    minimizedAtUnixMs: node.minimizedAtUnixMs,
+    nodeId: node.id,
+    title: node.title,
+    typeId: typeof data.typeId === "string" ? data.typeId : null
+  };
 }
 
 export interface WorkbenchGenieController<TData = unknown> {
@@ -585,6 +629,7 @@ function createGenieSvgTexture(
 export function useWorkbenchGenieAnimation<TData>({
   captureNodePreviewImage,
   controller,
+  debugDiagnostics,
   dockPreviewCache,
   minimizeAnimation = "genie",
   renderNodeGeniePreview,
@@ -594,6 +639,7 @@ export function useWorkbenchGenieAnimation<TData>({
 }: {
   captureNodePreviewImage?: WorkbenchNodePreviewImageCapture<TData>;
   controller: WorkbenchController<TData>;
+  debugDiagnostics?: WorkbenchDebugDiagnostics;
   dockPreviewCache?: WorkbenchDockPreviewCache;
   minimizeAnimation?: WorkbenchMinimizeAnimation;
   renderNodeGeniePreview?: WorkbenchNodeGeniePreviewRenderer<TData>;
@@ -639,8 +685,31 @@ export function useWorkbenchGenieAnimation<TData>({
 
   const resolveDockAnchorRect = useCallback((anchorKey: string) => {
     const element = dockAnchorElementsRef.current.get(anchorKey) ?? null;
-    return element ? resolveDockAnchorViewportRect(element) : null;
+    if (!element) {
+      return null;
+    }
+    return resolveDockAnchorViewportRect(element);
   }, []);
+
+  const resolveDockAnchorRectAfterRender = useCallback(
+    async (anchorKey: string, isCurrent: () => boolean) => {
+      let dockRect = resolveDockAnchorRect(anchorKey);
+      for (
+        let frame = 0;
+        (!dockRect || !isUsableGenieRect(dockRect)) &&
+        frame < dockAnchorResolveMaxAnimationFrames;
+        frame += 1
+      ) {
+        await waitForNextAnimationFrame();
+        if (!isCurrent()) {
+          return null;
+        }
+        dockRect = resolveDockAnchorRect(anchorKey);
+      }
+      return dockRect;
+    },
+    [resolveDockAnchorRect]
+  );
 
   const resolveNodeElement = useCallback((nodeID: string) => {
     return (
@@ -1321,6 +1390,15 @@ export function useWorkbenchGenieAnimation<TData>({
           .getSnapshot()
           .nodes.find((node) => node.id === nodeID);
         if (!target) {
+          logWorkbenchGenieDiagnostic(
+            debugDiagnostics,
+            "workbench.genie.minimize.skipped",
+            {
+              nodeId: nodeID,
+              reason: "target_missing"
+            },
+            "warn"
+          );
           return;
         }
         clearMinimizedGenieTexture(nodeID);
@@ -1389,6 +1467,16 @@ export function useWorkbenchGenieAnimation<TData>({
           const generation = animationGenerationRef.current;
           const nodeElement = resolveNodeElement(nodeID);
           if (!nodeElement) {
+            logWorkbenchGenieDiagnostic(
+              debugDiagnostics,
+              "workbench.genie.minimize.skipped",
+              {
+                ...describeGenieNode(target),
+                mode: "scale",
+                reason: "node_element_missing"
+              },
+              "warn"
+            );
             runMinimize();
             return;
           }
@@ -1445,12 +1533,34 @@ export function useWorkbenchGenieAnimation<TData>({
           }
 
           const anchorKey = resolveAnchorKeyForNode(pendingMinimizedNode);
-          const dockRect = resolveDockAnchorRect(anchorKey);
+          const dockRect = await resolveDockAnchorRectAfterRender(
+            anchorKey,
+            () => generation === animationGenerationRef.current
+          );
+          if (generation !== animationGenerationRef.current) {
+            return;
+          }
           if (
             !nodeElement.isConnected ||
             !dockRect ||
             !isUsableGenieRect(dockRect)
           ) {
+            logWorkbenchGenieDiagnostic(
+              debugDiagnostics,
+              "workbench.genie.minimize.skipped",
+              {
+                ...describeGenieNode(target),
+                anchorKey,
+                dockRect,
+                mode: "scale",
+                nodeElementConnected: nodeElement.isConnected,
+                registeredDockAnchorKeys: Array.from(
+                  dockAnchorElementsRef.current.keys()
+                ).filter((key) => key.startsWith("minimized:")),
+                reason: "dock_rect_unusable"
+              },
+              "warn"
+            );
             cleanupPendingMinimize();
             return;
           }
@@ -1479,11 +1589,32 @@ export function useWorkbenchGenieAnimation<TData>({
         const generation = animationGenerationRef.current;
         const nodeElement = resolveNodeElement(nodeID);
         if (!nodeElement) {
+          logWorkbenchGenieDiagnostic(
+            debugDiagnostics,
+            "workbench.genie.minimize.skipped",
+            {
+              ...describeGenieNode(target),
+              mode: "genie",
+              reason: "node_element_missing"
+            },
+            "warn"
+          );
           runMinimize();
           return;
         }
         const windowRect = viewportRectFromElement(nodeElement);
         if (!isUsableGenieRect(windowRect)) {
+          logWorkbenchGenieDiagnostic(
+            debugDiagnostics,
+            "workbench.genie.minimize.skipped",
+            {
+              ...describeGenieNode(target),
+              mode: "genie",
+              reason: "window_rect_unusable",
+              windowRect
+            },
+            "warn"
+          );
           runMinimize();
           return;
         }
@@ -1503,6 +1634,18 @@ export function useWorkbenchGenieAnimation<TData>({
         }
         if (!shouldCapturePreview) {
           if (!componentPreviewTexture) {
+            logWorkbenchGenieDiagnostic(
+              debugDiagnostics,
+              "workbench.genie.texture.missing",
+              {
+                ...describeGenieNode(target),
+                mode: "genie",
+                reason: "component_preview_texture_missing",
+                shouldCapturePreview,
+                windowRect
+              },
+              "warn"
+            );
             runMinimize();
             return;
           }
@@ -1514,6 +1657,17 @@ export function useWorkbenchGenieAnimation<TData>({
           : null;
         if (!preparedTexture) {
           if (!componentPreviewTexture) {
+            logWorkbenchGenieDiagnostic(
+              debugDiagnostics,
+              "workbench.genie.minimize.skipped",
+              {
+                ...describeGenieNode(target),
+                mode: "genie",
+                reason: "prepared_texture_missing",
+                shouldCapturePreview
+              },
+              "warn"
+            );
             runMinimize();
             return;
           }
@@ -1553,6 +1707,20 @@ export function useWorkbenchGenieAnimation<TData>({
           return;
         }
         if (!texture) {
+          logWorkbenchGenieDiagnostic(
+            debugDiagnostics,
+            "workbench.genie.minimize.skipped",
+            {
+              ...describeGenieNode(target),
+              hasComponentPreviewTexture: Boolean(componentPreviewTexture),
+              hasPreparedDomTexture: Boolean(preparedTexture),
+              hasPreviewImageTexture: Boolean(previewImageTexture),
+              mode: "genie",
+              reason: "texture_missing",
+              shouldCapturePreview
+            },
+            "warn"
+          );
           if (previewImageUrl) {
             writeCachedWorkbenchNodePreviewImage(nodeID, previewImageUrl);
             persistWorkbenchNodePreviewImage(target, previewImageUrl, {
@@ -1613,8 +1781,29 @@ export function useWorkbenchGenieAnimation<TData>({
         }
 
         const anchorKey = resolveAnchorKeyForNode(pendingMinimizedNode);
-        const dockRect = resolveDockAnchorRect(anchorKey);
+        const dockRect = await resolveDockAnchorRectAfterRender(
+          anchorKey,
+          () => generation === animationGenerationRef.current
+        );
+        if (generation !== animationGenerationRef.current) {
+          return;
+        }
         if (!dockRect || !isUsableGenieRect(dockRect)) {
+          logWorkbenchGenieDiagnostic(
+            debugDiagnostics,
+            "workbench.genie.minimize.skipped",
+            {
+              ...describeGenieNode(target),
+              anchorKey,
+              dockRect,
+              mode: "genie",
+              registeredDockAnchorKeys: Array.from(
+                dockAnchorElementsRef.current.keys()
+              ).filter((key) => key.startsWith("minimized:")),
+              reason: "dock_rect_unusable"
+            },
+            "warn"
+          );
           animationCleanupRef.current = null;
           cleanupPendingGenieMinimize();
           return;
@@ -1649,6 +1838,7 @@ export function useWorkbenchGenieAnimation<TData>({
       controller,
       captureNodePreviewImage,
       clearPendingMinimizedNode,
+      debugDiagnostics,
       dockPreviewCache,
       hideNodeForGenie,
       minimizeAnimation,

--- a/packages/workbench/surface/src/styles/workbench.css
+++ b/packages/workbench/surface/src/styles/workbench.css
@@ -1114,9 +1114,7 @@
 }
 
 .desktop-dock__slot--minimized[data-presence="entering"] {
-  min-width: 0;
-  animation: desktop-dock-minimized-slot-expand 720ms
-    cubic-bezier(0.16, 1, 0.3, 1) both;
+  animation: none;
 }
 
 .desktop-dock__slot--minimized[data-promoted-from-stack="true"][data-presence="entering"] {
@@ -1158,8 +1156,7 @@
 
 .desktop-dock[data-dock-placement="left"]
   .desktop-dock__slot--minimized[data-presence="entering"] {
-  min-height: 0;
-  animation-name: desktop-dock-minimized-slot-expand-left;
+  animation: none;
 }
 
 .desktop-dock__slot--minimized[data-presence="entering"]
@@ -1177,6 +1174,13 @@
   .desktop-dock__slot--minimized[data-presence="entering"]
   .desktop-dock__minimized-stack-icon {
   animation-name: desktop-dock-minimized-icon-appear-left;
+}
+
+.desktop-dock__slot--minimized[data-pending-minimize="true"][data-presence="entering"]
+  .desktop-dock__minimized-preview,
+.desktop-dock__slot--minimized[data-pending-minimize="true"][data-presence="entering"]
+  .desktop-dock__minimized-stack-icon {
+  animation: none;
 }
 
 .desktop-dock__slot[data-presence="exiting"] {

--- a/packages/workbench/surface/src/styles/workbenchStyle.test.ts
+++ b/packages/workbench/surface/src/styles/workbenchStyle.test.ts
@@ -328,7 +328,7 @@ test("dock overflow keeps scroll controls viewport-bound", () => {
   );
   assert.match(
     css,
-    /\.desktop-dock__slot--minimized\[data-presence="entering"\]\s*{[^}]*animation:\s*desktop-dock-minimized-slot-expand 720ms/s
+    /\.desktop-dock__slot--minimized\[data-presence="entering"\]\s*{[^}]*animation:\s*none;/s
   );
   assert.match(
     css,
@@ -344,11 +344,15 @@ test("dock overflow keeps scroll controls viewport-bound", () => {
   );
   assert.match(
     css,
-    /\.desktop-dock\[data-dock-placement="left"\]\s+\.desktop-dock__slot--minimized\[data-presence="entering"\]\s*{[^}]*animation-name:\s*desktop-dock-minimized-slot-expand-left;/s
+    /\.desktop-dock\[data-dock-placement="left"\]\s+\.desktop-dock__slot--minimized\[data-presence="entering"\]\s*{[^}]*animation:\s*none;/s
   );
   assert.match(
     css,
-    /@keyframes desktop-dock-minimized-slot-expand\s*{[\s\S]*?width:\s*0;[\s\S]*?margin-inline:\s*calc\(var\(--desktop-dock-gap\) \/ -2\);[\s\S]*?width:\s*var\(--desktop-dock-size\);/
+    /\.desktop-dock__slot--minimized\[data-presence="entering"\]\s+\.desktop-dock__minimized-preview,[\s\S]*?\.desktop-dock__slot--minimized\[data-presence="entering"\]\s+\.desktop-dock__minimized-stack-icon\s*{[^}]*animation:\s*desktop-dock-minimized-icon-appear 640ms/s
+  );
+  assert.match(
+    css,
+    /\.desktop-dock__slot--minimized\[data-pending-minimize="true"\]\[data-presence="entering"\]\s+\.desktop-dock__minimized-preview,[\s\S]*?\.desktop-dock__slot--minimized\[data-pending-minimize="true"\]\[data-presence="entering"\]\s+\.desktop-dock__minimized-stack-icon\s*{[^}]*animation:\s*none;/s
   );
   assert.match(
     css,


### PR DESCRIPTION
## Summary
- render newly minimized dock slots synchronously so Genie can resolve their anchor before starting minimize animation
- wait briefly for dock anchor registration before falling back from Genie/scale minimize
- keep pending minimized dock slots visually stable and remove temporary high-volume diagnostics while retaining low-frequency failure warnings

## Root cause
WebView and some app windows captured minimize previews successfully, but Genie read the minimized dock anchor before the slot ref was registered. The missing anchor caused `dock_rect_unusable` skips. Terminal also showed a dock blink because the pending minimized slot animated its outer layout from zero size.

## Validation
- pnpm --filter @tutti-os/workbench-surface typecheck
- pnpm --filter @tutti-os/workbench-surface test -- src/react/useWorkbenchGenieAnimation.test.ts src/host/WorkbenchHostDock.test.ts src/styles/workbenchStyle.test.ts
- pnpm check:changed --tail-lines 80
- pnpm check:full

Ready PR, not draft.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved dock presence lifecycle handling to keep departing items visible for smoother transitions and to better match animation settling behavior during minimized dock activity.
* **Bug Fixes**
  * Improved “minimize/genie” layout reliability by rechecking dock anchor measurements after render to reduce skipped or incorrect animations.
  * Added more detailed diagnostics when minimize prerequisites can’t be satisfied (where debugging is enabled).
* **Style**
  * Disabled minimized dock slot animations during entering to prevent unwanted expand effects; refined behavior for pending-minimize states.
* **Tests**
  * Updated CSS assertions to reflect the new minimized dock animation rules.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->