### PR TITLE
[codex] Fix agent composer notice spacing

### DIFF
--- a/packages/agent/gui/agent-gui/agentGuiNode/AgentFileMentionPalette.spec.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/AgentFileMentionPalette.spec.tsx
@@ -1824,11 +1824,33 @@ describe("AgentFileMentionPalette", () => {
     );
   });
 
-  it("keeps composer chrome notices inset by 12px", () => {
+  it("keeps composer chrome notices inset by 24px", () => {
     const css = readFileSync(resolve("app/renderer/agentactivity.css"), "utf8");
 
     expect(css).toMatch(
-      /\.agent-gui-node__composer-input-group\s*>\s*\.agent-gui-chrome__session-chrome\s*{[^}]*margin-right:\s*12px[^}]*margin-left:\s*12px/s
+      /\.agent-gui-node__composer-input-group\s*>\s*\.agent-gui-chrome__session-chrome\s*{[^}]*margin-right:\s*24px[^}]*margin-left:\s*24px/s
+    );
+  });
+
+  it("keeps hero inline notices flush with the composer and inset by 24px", () => {
+    const css = readFileSync(resolve("app/renderer/agentactivity.css"), "utf8");
+
+    expect(css).toMatch(
+      /\.agent-gui-node__empty-hero-body\s*{[^}]*--agent-gui-empty-hero-gap:\s*24px[^}]*gap:\s*var\(--agent-gui-empty-hero-gap\)/s
+    );
+    expect(css).toMatch(
+      /\.agent-gui-node__empty-hero-body\s*>\s*\.agent-gui-chrome__session-chrome\s*>\s*\.agent-gui-chrome__card\s*{[^}]*margin-right:\s*24px[^}]*margin-left:\s*24px/s
+    );
+    expect(css).toMatch(
+      /\.agent-gui-node__empty-hero-body\s*>\s*\.agent-gui-chrome__session-chrome\s*\+\s*\.agent-gui-node__composer-hero\s*{[^}]*margin-top:\s*calc\(var\(--agent-gui-empty-hero-gap,\s*24px\)\s*\*\s*-1\)/s
+    );
+  });
+
+  it("keeps composer danger chrome outlined through the bottom edge", () => {
+    const css = readFileSync(resolve("app/renderer/agentactivity.css"), "utf8");
+
+    expect(css).toMatch(
+      /\.agent-gui-node__empty-hero-body\s*>\s*\.agent-gui-chrome__session-chrome\s*>\s*\.agent-gui-chrome__card--danger,[\s\S]*?\.agent-gui-node__composer-input-group\s*>\s*\.agent-gui-chrome__session-chrome\s*>\s*\.agent-gui-chrome__card--danger,[\s\S]*?\.agent-gui-node__bottom-dock\s*>\s*\.agent-gui-chrome__session-chrome:has\(\s*\+\s*\.agent-gui-node__composer\s*\)\s*>\s*\.agent-gui-chrome__card--danger\s*{[^}]*border-bottom:\s*1px solid\s+color-mix\(\s*in srgb,\s*var\(--status-danger,\s*var\(--state-danger\)\)\s*16%,\s*transparent\s*\)/s
     );
   });
 
@@ -1842,7 +1864,7 @@ describe("AgentFileMentionPalette", () => {
       /\.agent-gui-node__bottom-dock\s*>\s*\.agent-gui-chrome__session-chrome:has\(\s*\+\s*\.agent-gui-node__composer\s+\.agent-gui-node__composer-input-group\s*>\s*\.agent-gui-chrome__session-chrome\s*\)\s*{[^}]*margin-right:\s*36px[^}]*margin-left:\s*36px/s
     );
     expect(css).toMatch(
-      /\.agent-gui-node__bottom-dock\s*>\s*\.agent-gui-chrome__session-chrome:has\(\s*\+\s*\.agent-gui-node__composer\s+\.agent-gui-node__composer-input-group\s*>\s*\.agent-gui-chrome__session-chrome\s*\)\s*\+\s*\.agent-gui-node__composer\s+\.agent-gui-node__composer-input-group\s*>\s*\.agent-gui-chrome__session-chrome\s*{[^}]*margin-right:\s*12px[^}]*margin-left:\s*12px/s
+      /\.agent-gui-node__bottom-dock\s*>\s*\.agent-gui-chrome__session-chrome:has\(\s*\+\s*\.agent-gui-node__composer\s+\.agent-gui-node__composer-input-group\s*>\s*\.agent-gui-chrome__session-chrome\s*\)\s*\+\s*\.agent-gui-node__composer\s+\.agent-gui-node__composer-input-group\s*>\s*\.agent-gui-chrome__session-chrome\s*{[^}]*margin-right:\s*24px[^}]*margin-left:\s*24px/s
     );
   });
 

--- a/packages/agent/gui/app/renderer/agentactivity.css
+++ b/packages/agent/gui/app/renderer/agentactivity.css
@@ -2303,14 +2303,27 @@ aside.workspace-agents-status-panel
   margin: 0 auto;
 }
 
+.agent-gui-node__empty-hero-body
+  > .agent-gui-chrome__session-chrome
+  > .agent-gui-chrome__card {
+  margin-right: 24px;
+  margin-left: 24px;
+}
+
+.agent-gui-node__empty-hero-body
+  > .agent-gui-chrome__session-chrome
+  + .agent-gui-node__composer-hero {
+  margin-top: calc(var(--agent-gui-empty-hero-gap, 24px) * -1);
+}
+
 .agent-gui-chrome__session-chrome:has(+ .agent-gui-chrome__session-chrome) {
   margin-right: 36px;
   margin-left: 36px;
 }
 
 .agent-gui-node__composer-input-group > .agent-gui-chrome__session-chrome {
-  margin-right: 12px;
-  margin-left: 12px;
+  margin-right: 24px;
+  margin-left: 24px;
 }
 
 .agent-gui-node__bottom-dock
@@ -2332,8 +2345,8 @@ aside.workspace-agents-status-panel
   + .agent-gui-node__composer
   .agent-gui-node__composer-input-group
   > .agent-gui-chrome__session-chrome {
-  margin-right: 12px;
-  margin-left: 12px;
+  margin-right: 24px;
+  margin-left: 24px;
 }
 
 .agent-gui-chrome__card {
@@ -2505,6 +2518,23 @@ aside.workspace-agents-status-panel
   min-height: 36px;
   padding: 4px 16px;
   cursor: pointer;
+}
+
+.agent-gui-node__empty-hero-body
+  > .agent-gui-chrome__session-chrome
+  > .agent-gui-chrome__card--danger,
+.agent-gui-node__composer-input-group
+  > .agent-gui-chrome__session-chrome
+  > .agent-gui-chrome__card--danger,
+.agent-gui-node__bottom-dock
+  > .agent-gui-chrome__session-chrome:has(+ .agent-gui-node__composer)
+  > .agent-gui-chrome__card--danger {
+  border-bottom: 1px solid
+    color-mix(
+      in srgb,
+      var(--status-danger, var(--state-danger)) 16%,
+      transparent
+    );
 }
 
 .agent-gui-chrome__card[data-has-inline-actions="true"] {
@@ -6906,9 +6936,11 @@ html[data-theme="light"] [data-message-center-item-id].agent-gui-edge-glow {
 }
 
 .agent-gui-node__empty-hero-body {
+  --agent-gui-empty-hero-gap: 24px;
+
   display: grid;
   width: min(820px, 100%);
-  gap: 24px;
+  gap: var(--agent-gui-empty-hero-gap);
   justify-items: center;
 }
 


### PR DESCRIPTION
## Summary
- Keep the Agent GUI error notice flush against the composer/input surface.
- Apply 24px left/right notice insets in the empty hero, composer input group, and docked composer contexts.
- Restore the danger notice bottom border where it attaches to the composer so the outline reaches the bottom edge.

## Checks
- PATH="/opt/homebrew/opt/node@24/bin:$PATH" pnpm --filter @tutti-os/agent-gui test -- AgentFileMentionPalette.spec.tsx AgentGUINode.spec.tsx AgentComposer.spec.tsx
- PATH="/opt/homebrew/opt/node@24/bin:$PATH" pnpm check:changed
- git diff --check
- PATH="/opt/homebrew/opt/node@24:$HOME/go/bin:/opt/homebrew/opt/node@24/bin:$PATH" git push -u origin feat/dashboard-ui-update (pre-push pnpm check:full passed)

## Notes
- Left unrelated untracked apps/desktop/build/nextopd/ untouched.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Adjusted spacing in the agent activity view so composer and notice layouts now align consistently at 24px.
  * Improved hero and bottom-dock notice positioning for cleaner spacing when stacked with composer content.
  * Ensured danger-styled cards continue cleanly to the bottom edge in nested layouts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->