### PR TITLE
[codex] Deduplicate agent tool detail sections

### DIFF
--- a/packages/agent/gui/shared/agentConversation/components/tool-renderers/AgentExpandedToolContent.spec.tsx
+++ b/packages/agent/gui/shared/agentConversation/components/tool-renderers/AgentExpandedToolContent.spec.tsx
@@ -636,8 +636,9 @@ describe("AgentExpandedToolContent", () => {
       />
     );
 
-    expect(screen.getAllByText("today top news").length).toBeGreaterThan(0);
-    expect(screen.getByText("agent renderer parity")).toBeTruthy();
+    expect(screen.getByText(/today top news/)).toBeTruthy();
+    expect(screen.getByText(/agent renderer parity/)).toBeTruthy();
+    expect(screen.queryByText("Results")).toBeNull();
   });
 
   it("renders the query when web search carries no results payload", async () => {
@@ -664,6 +665,32 @@ describe("AgentExpandedToolContent", () => {
     expect(screen.getByText("agent renderer parity")).toBeTruthy();
   });
 
+  it("does not mirror a web search query into results or output", async () => {
+    setAgentGuiI18nTestLocale("en");
+
+    render(
+      <AgentExpandedToolContent
+        call={projectAgentToolCall(
+          toolCall({
+            toolName: "WebSearch",
+            summary: "agent renderer parity",
+            payload: {
+              input: {
+                query: "agent renderer parity",
+                action: { type: "search", query: "agent renderer parity" }
+              }
+            }
+          })
+        )}
+      />
+    );
+
+    expect(screen.getByText("Query")).toBeTruthy();
+    expect(screen.getByText("agent renderer parity")).toBeTruthy();
+    expect(screen.queryByText("Results")).toBeNull();
+    expect(screen.queryByText("Output")).toBeNull();
+  });
+
   it("does not render an empty body when web search has no results", async () => {
     setAgentGuiI18nTestLocale("en");
 
@@ -683,6 +710,32 @@ describe("AgentExpandedToolContent", () => {
         ".workspace-agents-status-panel__detail-tool-body"
       )
     ).toBeNull();
+  });
+
+  it("dedupes repeated default tool input and output sections", async () => {
+    setAgentGuiI18nTestLocale("en");
+
+    render(
+      <AgentExpandedToolContent
+        call={projectAgentToolCall(
+          toolCall({
+            toolName: "CustomTool",
+            payload: {
+              input: {
+                query: "same content"
+              },
+              output: {
+                output: "same content"
+              }
+            }
+          })
+        )}
+      />
+    );
+
+    expect(screen.getByText("Input")).toBeTruthy();
+    expect(screen.getByText("same content")).toBeTruthy();
+    expect(screen.queryByText("Output")).toBeNull();
   });
 
   it("renders web fetch content with truncation notice", async () => {
@@ -708,6 +761,83 @@ describe("AgentExpandedToolContent", () => {
 
     expect(screen.getByText("docs.example.com")).toBeTruthy();
     expect(screen.getByText("Content truncated")).toBeTruthy();
+  });
+
+  it("does not mirror a web fetch domain summary into content", async () => {
+    setAgentGuiI18nTestLocale("en");
+
+    render(
+      <AgentExpandedToolContent
+        call={projectAgentToolCall(
+          toolCall({
+            toolName: "WebFetch",
+            summary: "forecast.weather.gov",
+            payload: {
+              input: {
+                url: "https://forecast.weather.gov/zipcity.php?inputstring=10002"
+              }
+            }
+          })
+        )}
+      />
+    );
+
+    expect(screen.getByText("URL")).toBeTruthy();
+    expect(
+      screen.getAllByText(/forecast\.weather\.gov/).length
+    ).toBeGreaterThan(0);
+    expect(screen.queryByText("Content")).toBeNull();
+  });
+
+  it("falls back to structured error content when a failed typed renderer has no body", async () => {
+    setAgentGuiI18nTestLocale("en");
+
+    render(
+      <AgentExpandedToolContent
+        call={projectAgentToolCall(
+          toolCall({
+            toolName: "WebFetch",
+            status: "Failed",
+            statusKind: "failed",
+            payload: {
+              error: {
+                message: "network request failed"
+              }
+            }
+          })
+        )}
+      />
+    );
+
+    expect(screen.getByText("Error")).toBeTruthy();
+    expect(screen.getByText("network request failed")).toBeTruthy();
+  });
+
+  it("keeps real web fetch page content", async () => {
+    setAgentGuiI18nTestLocale("en");
+
+    render(
+      <AgentExpandedToolContent
+        call={projectAgentToolCall(
+          toolCall({
+            toolName: "WebFetch",
+            summary: "forecast.weather.gov",
+            payload: {
+              input: {
+                url: "https://forecast.weather.gov/zipcity.php?inputstring=10002"
+              },
+              output: {
+                content:
+                  "Detailed Forecast\n\nWednesday: Sunny, with a high near 82."
+              }
+            }
+          })
+        )}
+      />
+    );
+
+    expect(screen.getByText("Content")).toBeTruthy();
+    expect(screen.getByText(/Detailed Forecast/)).toBeTruthy();
   });
 
   it("renders todo items with semantic statuses instead of raw json", async () => {

--- a/packages/agent/gui/shared/agentConversation/components/tool-renderers/AgentMcpToolContent.tsx
+++ b/packages/agent/gui/shared/agentConversation/components/tool-renderers/AgentMcpToolContent.tsx
@@ -1,6 +1,7 @@
 import type { JSX } from "react";
 import { translate } from "../../../../i18n/index";
 import {
+  dedupeToolSectionContent,
   RawPayloadSection,
   ToolMarkdownBlock,
   ToolSection,
@@ -16,6 +17,10 @@ export function AgentMcpToolContent({
   "use memo";
   const payload = normalizeMcpPayload(call);
   const specialized = renderRegisteredMcp(payload);
+  const visibleText = dedupeToolSectionContent(
+    payload.text,
+    payload.inputSummary
+  );
 
   return (
     <div className="workspace-agents-status-panel__detail-tool-body">
@@ -44,10 +49,10 @@ export function AgentMcpToolContent({
         <ToolSection title={translate("agentHost.agentTool.details.output")}>
           {specialized}
         </ToolSection>
-      ) : payload.text ? (
+      ) : visibleText ? (
         <ToolSection title={translate("agentHost.agentTool.details.output")}>
           <ToolMarkdownBlock
-            content={payload.text}
+            content={visibleText}
             onLinkClick={onLinkClick}
             collapsible
           />

--- a/packages/agent/gui/shared/agentConversation/components/tool-renderers/AgentSearchContent.tsx
+++ b/packages/agent/gui/shared/agentConversation/components/tool-renderers/AgentSearchContent.tsx
@@ -1,6 +1,7 @@
 import type { JSX } from "react";
 import { translate } from "../../../../i18n/index";
 import {
+  dedupeToolSectionContent,
   ToolMarkdownBlock,
   ToolSection,
   type AgentToolRendererProps
@@ -17,7 +18,11 @@ export function AgentSearchContent({
     ? `${search.query ?? ""}\n\n${translate("agentHost.agentTool.details.scope")}: ${search.scope}`.trim()
     : search.query;
   const resultFiles = withStableOccurrenceKeys(search.files, "file");
-  const outputLines = withStableOccurrenceKeys(search.lines, "line");
+  const visibleOutput = dedupeToolSectionContent(search.output, queryText);
+  const outputLines = withStableOccurrenceKeys(
+    visibleOutput.split("\n").filter(Boolean),
+    "line"
+  );
 
   return (
     <div className="workspace-agents-status-panel__detail-tool-body">
@@ -43,7 +48,7 @@ export function AgentSearchContent({
           </div>
         </ToolSection>
       ) : null}
-      {search.mode === "content" && search.output ? (
+      {search.mode === "content" && visibleOutput ? (
         <ToolSection title={translate("agentHost.agentTool.details.output")}>
           <pre className="max-h-[320px] overflow-auto rounded-[8px] border border-[var(--line-2)] bg-[var(--transparency-block)] px-3 py-2 text-[11px] leading-5 text-[var(--text-primary)]">
             {outputLines.map(({ key, value: line }) => (
@@ -72,7 +77,7 @@ export function AgentSearchContent({
         search.mode === "list_files" ||
         search.mode === "count") &&
       search.files.length === 0 &&
-      !search.output &&
+      !visibleOutput &&
       !search.error ? (
         <ToolSection title={translate("agentHost.agentTool.details.results")}>
           <div className="text-[11px] italic text-[var(--text-tertiary)]">
@@ -80,10 +85,10 @@ export function AgentSearchContent({
           </div>
         </ToolSection>
       ) : null}
-      {search.mode === "unknown" && search.output ? (
+      {search.mode === "unknown" && visibleOutput ? (
         <ToolSection title={translate("agentHost.agentTool.details.output")}>
           <ToolMarkdownBlock
-            content={search.output}
+            content={visibleOutput}
             onLinkClick={onLinkClick}
             collapsible
           />

--- a/packages/agent/gui/shared/agentConversation/components/tool-renderers/AgentWebFetchContent.tsx
+++ b/packages/agent/gui/shared/agentConversation/components/tool-renderers/AgentWebFetchContent.tsx
@@ -1,11 +1,15 @@
 import type { JSX } from "react";
 import { translate } from "../../../../i18n/index";
 import {
+  dedupeToolSectionContent,
   ToolMarkdownBlock,
   ToolSection,
   type AgentToolRendererProps
 } from "./agentToolContentShared";
-import { getWebFetchRenderData } from "./render-data/agentToolRenderData";
+import {
+  getToolFallbackText,
+  getWebFetchRenderData
+} from "./render-data/agentToolRenderData";
 
 export function AgentWebFetchContent({
   call,
@@ -13,7 +17,23 @@ export function AgentWebFetchContent({
 }: AgentToolRendererProps): JSX.Element | null {
   "use memo";
   const web = getWebFetchRenderData(call);
-  if (!web.url && !web.visibleContent) {
+  const urlText =
+    web.url && web.domain && web.domain !== web.url
+      ? `${web.domain}\n\n${web.url}`
+      : web.url;
+  const visibleContent = dedupeToolSectionContent(
+    web.visibleContent,
+    web.url,
+    web.domain,
+    urlText
+  );
+  const fallbackText = getToolFallbackText(call);
+  const errorText = dedupeToolSectionContent(
+    fallbackText.error,
+    urlText,
+    visibleContent
+  );
+  if (!web.url && !visibleContent && !errorText) {
     return null;
   }
 
@@ -22,19 +42,15 @@ export function AgentWebFetchContent({
       {web.url ? (
         <ToolSection title={translate("agentHost.agentTool.details.url")}>
           <ToolMarkdownBlock
-            content={
-              web.domain && web.domain !== web.url
-                ? `${web.domain}\n\n${web.url}`
-                : web.url
-            }
+            content={urlText ?? ""}
             onLinkClick={onLinkClick}
           />
         </ToolSection>
       ) : null}
-      {web.visibleContent ? (
+      {visibleContent ? (
         <ToolSection title={translate("agentHost.agentTool.details.content")}>
           <ToolMarkdownBlock
-            content={web.visibleContent}
+            content={visibleContent}
             onLinkClick={onLinkClick}
             collapsible
           />
@@ -44,6 +60,15 @@ export function AgentWebFetchContent({
         <div className="text-[10px] italic text-[var(--text-tertiary)]">
           {translate("agentHost.agentTool.details.contentTruncated")}
         </div>
+      ) : null}
+      {errorText ? (
+        <ToolSection title={translate("agentHost.agentTool.details.error")}>
+          <ToolMarkdownBlock
+            content={errorText}
+            onLinkClick={onLinkClick}
+            collapsible
+          />
+        </ToolSection>
       ) : null}
     </div>
   );

--- a/packages/agent/gui/shared/agentConversation/components/tool-renderers/AgentWebSearchContent.tsx
+++ b/packages/agent/gui/shared/agentConversation/components/tool-renderers/AgentWebSearchContent.tsx
@@ -2,6 +2,7 @@ import type { JSX } from "react";
 import { translate } from "../../../../i18n/index";
 import {
   arrayValue,
+  dedupeToolSectionContent,
   optionRecord,
   stringValue,
   ToolMarkdownBlock,
@@ -21,15 +22,16 @@ export function AgentWebSearchContent({
   const queries = web.queries;
   const outputText = web.output;
   const links = normalizeLinks(call.output?.links, outputText);
-  const summary = extractSummary(outputText) ?? (call.summary.trim() || null);
-  const visibleSummary = summary ? summary.slice(0, MAX_SUMMARY_LENGTH) : null;
+  const queryText = webSearchQueryText(web.query, queries);
+  const summary = extractSummary(outputText);
+  const visibleSummary = dedupeToolSectionContent(
+    summary ? summary.slice(0, MAX_SUMMARY_LENGTH) : null,
+    queryText,
+    links.map((link) => `${link.domain} ${link.title}`).join("\n")
+  );
 
   const hasRenderableContent = Boolean(
-    web.query ||
-    queries.length > 0 ||
-    links.length > 0 ||
-    visibleSummary ||
-    web.error
+    queryText || links.length > 0 || visibleSummary || web.error
   );
   if (!hasRenderableContent) {
     return null;
@@ -37,25 +39,9 @@ export function AgentWebSearchContent({
 
   return (
     <div className="workspace-agents-status-panel__detail-tool-body">
-      {web.query ? (
+      {queryText ? (
         <ToolSection title={translate("agentHost.agentTool.details.query")}>
-          <ToolMarkdownBlock content={web.query} onLinkClick={onLinkClick} />
-        </ToolSection>
-      ) : null}
-      {queries.length > 0 ? (
-        <ToolSection title={translate("agentHost.agentTool.details.results")}>
-          <div className="workspace-agents-status-panel__detail-tool-result-list overflow-hidden rounded-[8px] border border-[var(--line-2)] bg-[var(--transparency-block)]">
-            {queries.map((candidate, index) => (
-              <div
-                key={`${candidate}:${queries.length}`}
-                className={`px-3 py-2 font-[var(--tsh-font-mono)] text-[11px] text-[var(--text-primary)] ${
-                  index > 0 ? "border-t border-[var(--line-2)]" : ""
-                }`}
-              >
-                {candidate}
-              </div>
-            ))}
-          </div>
+          <ToolMarkdownBlock content={queryText} onLinkClick={onLinkClick} />
         </ToolSection>
       ) : null}
       {links.length > 0 ? (
@@ -107,6 +93,17 @@ export function AgentWebSearchContent({
       ) : null}
     </div>
   );
+}
+
+function webSearchQueryText(
+  query: string | null,
+  queries: readonly string[]
+): string | null {
+  const candidates = queries.length > 0 ? queries : query ? [query] : [];
+  const deduped = [
+    ...new Set(candidates.map((value) => value.trim()).filter(Boolean))
+  ];
+  return deduped.length > 0 ? deduped.join("\n") : null;
 }
 
 function normalizeLinks(

--- a/packages/agent/gui/shared/agentConversation/components/tool-renderers/agentToolContentShared.tsx
+++ b/packages/agent/gui/shared/agentConversation/components/tool-renderers/agentToolContentShared.tsx
@@ -109,9 +109,13 @@ export function AgentDefaultToolContent({
 }: AgentToolRendererProps): JSX.Element | null {
   "use memo";
   const fallbackText = getToolFallbackText(call);
-  const inputText = fallbackText.input;
-  const outputText = fallbackText.output;
-  const errorText = fallbackText.error;
+  const inputText = dedupeToolSectionContent(fallbackText.input);
+  const outputText = dedupeToolSectionContent(fallbackText.output, inputText);
+  const errorText = dedupeToolSectionContent(
+    fallbackText.error,
+    inputText,
+    outputText
+  );
   const detail = dedupeToolSummary(
     call.summary.trim(),
     inputText,
@@ -550,18 +554,27 @@ function dedupeToolSummary(
   summary: string,
   ...otherValues: Array<string | null>
 ): string {
-  const normalizedSummary = summary.trim();
-  if (!normalizedSummary) {
-    return "";
-  }
-  const duplicate = otherValues.some(
-    (value) =>
-      normalizeWhitespace(value) === normalizeWhitespace(normalizedSummary)
-  );
-  return duplicate ? "" : normalizedSummary;
+  return dedupeToolSectionContent(summary, ...otherValues);
 }
 
-function normalizeWhitespace(value: string | null | undefined): string {
+export function dedupeToolSectionContent(
+  content: string | null | undefined,
+  ...previousValues: Array<string | null | undefined>
+): string {
+  const normalizedContent = content?.trim() ?? "";
+  if (!normalizedContent) {
+    return "";
+  }
+  const contentKey = normalizeToolSectionContent(normalizedContent);
+  const duplicate = previousValues.some(
+    (value) => normalizeToolSectionContent(value) === contentKey
+  );
+  return duplicate ? "" : normalizedContent;
+}
+
+export function normalizeToolSectionContent(
+  value: string | null | undefined
+): string {
   return (value ?? "").trim().replace(/\s+/g, " ");
 }
 

--- a/packages/agent/gui/shared/agentConversation/components/tool-renderers/render-data/agentToolRenderData.ts
+++ b/packages/agent/gui/shared/agentConversation/components/tool-renderers/render-data/agentToolRenderData.ts
@@ -285,8 +285,7 @@ export function getWebFetchRenderData(
     contentText(call.output?.content),
     stringValue(call.output?.output),
     stringValue(call.output?.content),
-    stringValue(call.output?.stdout),
-    nonEmpty(call.summary)
+    stringValue(call.output?.stdout)
   );
   return {
     url,


### PR DESCRIPTION
## Summary

- Deduplicate repeated agent tool detail sections across default, search, MCP, WebSearch, and WebFetch renderers
- Stop treating WebSearch query candidates as Results and stop using summary/domain fallback as WebFetch Content
- Render WebFetch/read-page error content when a failed typed renderer has no URL/content body

## Root Cause

Typed tool renderers were mixing compact summaries and input candidates into detail sections. WebSearch rendered input `search_query` under Results and used `call.summary` as Output fallback, while WebFetch used `call.summary` as page Content. Failed WebFetch calls with error-only payloads could also be considered expandable by outer state while the renderer returned no body.

## Validation

- `pnpm --filter @tutti-os/agent-gui test -- AgentExpandedToolContent.spec.tsx`
- `pnpm --filter @tutti-os/agent-gui test -- render-data/agentToolRenderData.spec.ts`
- `pnpm --filter @tutti-os/agent-gui typecheck`
- `pnpm exec oxfmt --check packages/agent/gui/shared/agentConversation/components/tool-renderers/agentToolContentShared.tsx packages/agent/gui/shared/agentConversation/components/tool-renderers/AgentWebSearchContent.tsx packages/agent/gui/shared/agentConversation/components/tool-renderers/AgentSearchContent.tsx packages/agent/gui/shared/agentConversation/components/tool-renderers/AgentMcpToolContent.tsx packages/agent/gui/shared/agentConversation/components/tool-renderers/render-data/agentToolRenderData.ts packages/agent/gui/shared/agentConversation/components/tool-renderers/AgentWebFetchContent.tsx packages/agent/gui/shared/agentConversation/components/tool-renderers/AgentExpandedToolContent.spec.tsx`
- `git diff --check`
- `pnpm check:changed`
- pre-commit staged boundary checks
- pre-push `pnpm check:full`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved tool output display by removing repeated or duplicate text in search, web fetch, MCP, and default tool sections.
  * Web search and fetch results now show clearer, more accurate content, avoiding summary text being repeated as the main result.
  * Web fetch now surfaces errors more consistently when content is unavailable, while preserving real page content when it exists.
  * Search results and multi-query web searches now render more reliably, with cleaner query and result presentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->