### PR TITLE
[codex] Polish agent GUI notices and relative time

### DIFF
--- a/packages/agent/gui/app/renderer/shell/utils/format.test.ts
+++ b/packages/agent/gui/app/renderer/shell/utils/format.test.ts
@@ -1,0 +1,30 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { setCurrentAgentGuiI18nLocaleForTests } from "../../../../i18n/runtime";
+import { toRelativeTime } from "./format";
+
+describe("toRelativeTime", () => {
+  afterEach(() => {
+    setCurrentAgentGuiI18nLocaleForTests("en");
+    vi.useRealTimers();
+  });
+
+  it("formats relative timestamps for English locale", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-06-24T12:00:00Z"));
+    setCurrentAgentGuiI18nLocaleForTests("en");
+
+    expect(toRelativeTime("2026-06-14T12:00:00Z")).toBe("10 days ago");
+    expect(toRelativeTime("2026-04-24T12:00:00Z")).toBe("2 months ago");
+    expect(toRelativeTime("2024-06-24T12:00:00Z")).toBe("2 years ago");
+  });
+
+  it("formats relative timestamps for Chinese locale with readable digit spacing", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-06-24T12:00:00Z"));
+    setCurrentAgentGuiI18nLocaleForTests("zh-CN");
+
+    expect(toRelativeTime("2026-06-14T12:00:00Z")).toBe("10 天前");
+    expect(toRelativeTime("2026-04-24T12:00:00Z")).toBe("2 个月前");
+    expect(toRelativeTime("2024-06-24T12:00:00Z")).toBe("2 年前");
+  });
+});

--- a/packages/agent/gui/app/renderer/shell/utils/format.ts
+++ b/packages/agent/gui/app/renderer/shell/utils/format.ts
@@ -191,7 +191,17 @@ export function toRelativeTime(iso: string | null): string {
     );
   }
 
+  const deltaDays = Math.floor(deltaSeconds / 86400);
+  if (deltaDays < 30) {
+    return addSpacesAroundDigits(formatter.format(-deltaDays, "day"));
+  }
+
+  const deltaMonths = Math.floor(deltaDays / 30);
+  if (deltaMonths < 12) {
+    return addSpacesAroundDigits(formatter.format(-deltaMonths, "month"));
+  }
+
   return addSpacesAroundDigits(
-    formatter.format(-Math.floor(deltaSeconds / 86400), "day")
+    formatter.format(-Math.floor(deltaDays / 365), "year")
   );
 }

--- a/packages/agent/gui/shared/agentConversation/components/AgentMessageBlock.tsx
+++ b/packages/agent/gui/shared/agentConversation/components/AgentMessageBlock.tsx
@@ -7,7 +7,7 @@ import {
   type JSX,
   type ReactNode
 } from "react";
-import { AlertTriangle, ChevronRight, Info } from "lucide-react";
+import { ChevronRight } from "lucide-react";
 import { CheckIcon, CopyIcon } from "@tutti-os/ui-system/icons";
 import { Button } from "../../../app/renderer/components/ui/button";
 import { AgentPlanCard } from "./AgentPlanCard";
@@ -398,27 +398,18 @@ function AgentSystemNoticeMessage({
   const detail = notice?.detail?.trim() ?? "";
   const isWarning =
     notice?.severity === "warning" || notice?.severity === "error";
-  const Icon = isWarning ? AlertTriangle : Info;
   return (
     <section
       role={isWarning ? "status" : undefined}
       className="box-border w-full min-w-0 rounded-[8px] border border-[color-mix(in_srgb,var(--state-warning)_14%,transparent)] bg-[color-mix(in_srgb,var(--background-fronted)_100%,var(--state-warning)_6%)] p-3 text-[13px] leading-5 text-[var(--text-primary)]"
     >
-      <div className="flex min-w-0 items-start gap-2">
-        <Icon
-          size={15}
-          strokeWidth={2.1}
-          aria-hidden="true"
-          className="mt-0.5 shrink-0 text-[var(--state-warning)]"
-        />
-        <div className="min-w-0 flex-1">
-          <div className="font-medium text-[var(--text-primary)]">
-            {systemNoticeTitle(message)}
-          </div>
-          {detail ? (
-            <AgentMessageDetailsDisclosure detail={detail} className="mt-1" />
-          ) : null}
+      <div className="min-w-0">
+        <div className="font-medium text-[var(--text-primary)]">
+          {systemNoticeTitle(message)}
         </div>
+        {detail ? (
+          <AgentMessageDetailsDisclosure detail={detail} className="mt-1" />
+        ) : null}
       </div>
     </section>
   );

--- a/packages/agent/gui/shared/agentConversation/components/AgentTranscriptItemView.spec.tsx
+++ b/packages/agent/gui/shared/agentConversation/components/AgentTranscriptItemView.spec.tsx
@@ -529,6 +529,10 @@ describe("AgentTranscriptItemView render stability", () => {
     expect(
       getByText("agentHost.agentGui.systemNoticeTransportRetry")
     ).toBeTruthy();
+    const notice = getByText(
+      "agentHost.agentGui.systemNoticeTransportRetry"
+    ).closest("section");
+    expect(notice?.firstElementChild?.firstElementChild?.tagName).toBe("DIV");
     expect(getByText("agentHost.agentGui.visibleErrorDetails")).toBeTruthy();
     expect(
       queryByText("Codex connection interrupted. Reconnecting...")


### PR DESCRIPTION
## What changed

- Format relative times in the agent GUI as days, months, and years instead of showing every older timestamp as days.
- Add coverage for English and Chinese relative-time output.
- Remove the leading icon from agent system notice cards while preserving the title, details disclosure, and status styling.

## Why

Older timestamps were hard to scan when expressed only as large day counts. The system notice card also duplicated the warning state with a leading icon that made the notice feel heavier than the surrounding agent UI.

## Validation

- `pnpm --filter @tutti-os/agent-gui test -- app/renderer/shell/utils/format.test.ts shared/agentConversation/components/AgentTranscriptItemView.spec.tsx`
- `pnpm --filter @tutti-os/agent-gui typecheck`
- pre-commit staged checks passed: `oxfmt`, `oxlint --fix --deny-warnings`, electron runtime boundaries, UI boundaries, renderer boundaries
- pre-push `check:full` was rerun with Node 24 and `golangci-lint` installed; `test:ts`, `typecheck`, `lint:ts`, and `lint:go` passed. The full hook still returned a `test:go` failure while running lanes concurrently, but the failing Go suites passed when rerun separately: `cd services/tuttid && go test ./service/agentstatus -count=1`, `cd services/tuttid && go test ./...`, and `cd apps/cli && go test ./... -count=1 -v`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved relative-time wording for longer intervals so day, month, and year values display more accurately.
  * Simplified system notice display in chat messages by removing extra severity icons and keeping the content easier to read.
  * Transport retry notices now render with more consistent layout handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->