### PR TITLE
fix(agent-gui): render markdown videos

### DIFF
--- a/packages/agent/gui/actions/workspaceLinkActions.spec.ts
+++ b/packages/agent/gui/actions/workspaceLinkActions.spec.ts
@@ -73,6 +73,32 @@ describe("resolveWorkspaceFileLinkAction", () => {
     ).toBeNull();
   });
 
+  it("allows direct generated video paths under Tutti state outside the workspace root", () => {
+    expect(
+      resolveWorkspaceFileLinkAction({
+        path: "/Users/test/.tutti-dev/agent/runs/session-1/codex-home/generated_videos/dance.mp4",
+        workspaceRoot: "/Users/test/project/tutti",
+        basePath: "/Users/test/project/tutti",
+        source: "agent-markdown"
+      })
+    ).toMatchObject({
+      type: "open-workspace-file",
+      path: "/Users/test/.tutti-dev/agent/runs/session-1/codex-home/generated_videos/dance.mp4",
+      directoryPath:
+        "/Users/test/.tutti-dev/agent/runs/session-1/codex-home/generated_videos",
+      workspaceRoot: "/Users/test/project/tutti"
+    });
+
+    expect(
+      resolveWorkspaceFileLinkAction({
+        path: "/Users/test/.tutti-dev/agent/runs/session-1/codex-home/generated_videos/raw.mov",
+        workspaceRoot: "/Users/test/project/tutti",
+        basePath: "/Users/test/project/tutti",
+        source: "agent-markdown"
+      })
+    ).toBeNull();
+  });
+
   it("allows direct workspace app data paths without a selected project", () => {
     expect(
       resolveWorkspaceFileLinkAction({

--- a/packages/agent/gui/actions/workspaceLinkActions.ts
+++ b/packages/agent/gui/actions/workspaceLinkActions.ts
@@ -371,7 +371,7 @@ function isInsideOrEqual(path: string, root: string): boolean {
   );
 }
 
-function isDirectAgentGeneratedMediaPath(path: string): boolean {
+export function isDirectAgentGeneratedMediaPath(path: string): boolean {
   if (!isAbsoluteLocalPath(path)) {
     return false;
   }

--- a/packages/agent/gui/actions/workspaceLinkActions.ts
+++ b/packages/agent/gui/actions/workspaceLinkActions.ts
@@ -127,7 +127,7 @@ export function resolveWorkspaceFilePathCandidate({
   const normalizedPath = normalizeWorkspaceFilePath(rawPath);
   if (
     isAbsoluteLocalPath(normalizedPath) &&
-    (isDirectAgentGeneratedImagePath(normalizedPath) ||
+    (isDirectAgentGeneratedMediaPath(normalizedPath) ||
       isDirectWorkspaceAppDataPath(normalizedPath))
   ) {
     const directoryPath = dirname(normalizedPath);
@@ -149,7 +149,7 @@ export function resolveWorkspaceFilePathCandidate({
     : normalizeWorkspaceFilePath(`${base}/${normalizedPath}`);
   if (
     !isInsideOrEqual(resolvedPath, root) &&
-    !isDirectAgentGeneratedImagePath(resolvedPath)
+    !isDirectAgentGeneratedMediaPath(resolvedPath)
   ) {
     return null;
   }
@@ -371,7 +371,7 @@ function isInsideOrEqual(path: string, root: string): boolean {
   );
 }
 
-function isDirectAgentGeneratedImagePath(path: string): boolean {
+function isDirectAgentGeneratedMediaPath(path: string): boolean {
   if (!isAbsoluteLocalPath(path)) {
     return false;
   }
@@ -382,11 +382,12 @@ function isDirectAgentGeneratedImagePath(path: string): boolean {
   if (
     statePath[1] !== "agent" ||
     statePath[2] !== "runs" ||
-    !statePath.includes("generated_images")
+    (!statePath.includes("generated_images") &&
+      !statePath.includes("generated_videos"))
   ) {
     return false;
   }
-  return /\.(?:png|jpe?g|gif|webp|bmp)$/i.test(path);
+  return /\.(?:png|jpe?g|gif|webp|bmp|mp4|webm)$/i.test(path);
 }
 
 function isDirectWorkspaceAppDataPath(path: string): boolean {

--- a/packages/agent/gui/shared/AgentMessageMarkdown.spec.tsx
+++ b/packages/agent/gui/shared/AgentMessageMarkdown.spec.tsx
@@ -496,6 +496,32 @@ describe("AgentMessageMarkdown", () => {
     expect(screen.queryByText("Loading preview...")).toBeNull();
   });
 
+  it("does not render arbitrary local absolute markdown video paths when workspace file access is unavailable", () => {
+    const workspace = { ...(window.agentHostApi?.workspace ?? {}) } as Partial<
+      NonNullable<typeof window.agentHostApi>["workspace"]
+    >;
+    delete workspace.readFile;
+
+    window.agentHostApi = {
+      ...(window.agentHostApi ?? {}),
+      workspace: workspace as NonNullable<
+        typeof window.agentHostApi
+      >["workspace"]
+    } as unknown as typeof window.agentHostApi;
+
+    render(
+      <AgentMessageMarkdown
+        content={"![private video](/Users/example/Movies/private.mp4)"}
+      />
+    );
+
+    expect(screen.queryByLabelText("private video")).toBeNull();
+    expect(
+      screen.queryByText("Preview is not available for this file.")
+    ).toBeTruthy();
+    expect(screen.queryByText("Loading preview...")).toBeNull();
+  });
+
   it("keeps image zoom disabled by default outside AgentGui callers", async () => {
     const readFile = vi.fn().mockResolvedValue({
       bytes: new Uint8Array([137, 80, 78, 71])

--- a/packages/agent/gui/shared/AgentMessageMarkdown.spec.tsx
+++ b/packages/agent/gui/shared/AgentMessageMarkdown.spec.tsx
@@ -326,6 +326,43 @@ describe("AgentMessageMarkdown", () => {
     });
   });
 
+  it("renders workspace markdown videos from workspace file bytes", async () => {
+    const readFile = vi.fn().mockResolvedValue({
+      bytes: new Uint8Array([0, 0, 0, 24])
+    });
+    window.agentHostApi = {
+      ...(window.agentHostApi ?? {}),
+      workspace: {
+        ...(window.agentHostApi?.workspace ?? {}),
+        readFile
+      }
+    } as typeof window.agentHostApi;
+    Object.defineProperty(URL, "createObjectURL", {
+      configurable: true,
+      value: vi.fn(() => "blob:tsh-markdown-video")
+    });
+    Object.defineProperty(URL, "revokeObjectURL", {
+      configurable: true,
+      value: vi.fn()
+    });
+
+    render(
+      <AgentMessageMarkdown
+        content={
+          "![generated video](/workspace/output/generated_videos/dance.mp4)"
+        }
+      />
+    );
+
+    const video = await screen.findByLabelText("generated video");
+    expect(video.tagName).toBe("VIDEO");
+    expect(video).toHaveAttribute("src", "blob:tsh-markdown-video");
+    expect(video).toHaveAttribute("controls");
+    expect(readFile).toHaveBeenCalledWith({
+      path: "/workspace/output/generated_videos/dance.mp4"
+    });
+  });
+
   it("shows a loading placeholder while a workspace markdown image is still being read", async () => {
     let resolveRead: ((value: { bytes: Uint8Array }) => void) | undefined;
     const readFile = vi.fn(
@@ -425,6 +462,36 @@ describe("AgentMessageMarkdown", () => {
     ).toHaveAttribute(
       "src",
       "file:///Users/example/Documents/a/output/imagegen/lamb-storybook.png"
+    );
+    expect(screen.queryByText("Loading preview...")).toBeNull();
+  });
+
+  it("falls back to a file URL video for local absolute markdown video paths when workspace file access is unavailable", () => {
+    const workspace = { ...(window.agentHostApi?.workspace ?? {}) } as Partial<
+      NonNullable<typeof window.agentHostApi>["workspace"]
+    >;
+    delete workspace.readFile;
+
+    window.agentHostApi = {
+      ...(window.agentHostApi ?? {}),
+      workspace: workspace as NonNullable<
+        typeof window.agentHostApi
+      >["workspace"]
+    } as unknown as typeof window.agentHostApi;
+
+    render(
+      <AgentMessageMarkdown
+        content={
+          "![generated video](/Users/example/.tutti/agent/runs/session/codex-home/generated_videos/dance.mp4)"
+        }
+      />
+    );
+
+    const video = screen.getByLabelText("generated video");
+    expect(video.tagName).toBe("VIDEO");
+    expect(video).toHaveAttribute(
+      "src",
+      "file:///Users/example/.tutti/agent/runs/session/codex-home/generated_videos/dance.mp4"
     );
     expect(screen.queryByText("Loading preview...")).toBeNull();
   });

--- a/packages/agent/gui/shared/AgentMessageMarkdown.tsx
+++ b/packages/agent/gui/shared/AgentMessageMarkdown.tsx
@@ -47,6 +47,7 @@ import {
   useOptionalAgentHostApi
 } from "../agentActivityHost";
 import {
+  isDirectAgentGeneratedMediaPath,
   resolveWorkspaceFilePathCandidate,
   resolveWorkspaceLinkAction,
   type WorkspaceLinkAction,
@@ -1110,6 +1111,9 @@ function MarkdownMedia({
 
   if (!workspacePath || !readWorkspaceImage) {
     if (fallbackMediaKind === "video") {
+      if (!canRenderMarkdownVideoFallback(src)) {
+        return <UnsupportedMarkdownMediaPreview />;
+      }
       return (
         <video
           src={resolvedSrc}
@@ -1211,6 +1215,15 @@ function MarkdownMedia({
   );
 }
 
+function UnsupportedMarkdownMediaPreview(): JSX.Element {
+  const { t } = useTranslation();
+  return (
+    <span className="flex min-h-[160px] w-full items-center justify-center rounded-[8px] border border-[var(--line-2)] bg-[var(--background-panel)] px-5 py-5 text-center text-[13px] leading-5 text-[var(--text-tertiary)]">
+      {t("agentHost.workspaceFileManager.previewUnsupported")}
+    </span>
+  );
+}
+
 const MARKDOWN_ORDERED_LIST_STYLE: CSSProperties = {
   listStylePosition: "outside",
   margin: "12px 0 8px",
@@ -1307,6 +1320,17 @@ function resolveRenderableMarkdownMediaSrc(src: string): string {
     return src;
   }
   return new URL(trimmed, "file://").toString();
+}
+
+function canRenderMarkdownVideoFallback(src: unknown): boolean {
+  if (typeof src !== "string") {
+    return false;
+  }
+  const trimmed = src.trim();
+  if (!isLocalAbsolutePath(trimmed) || trimmed.startsWith("/workspace/")) {
+    return true;
+  }
+  return isDirectAgentGeneratedMediaPath(trimmed);
 }
 
 function resolveMarkdownMediaKind(

--- a/packages/agent/gui/shared/AgentMessageMarkdown.tsx
+++ b/packages/agent/gui/shared/AgentMessageMarkdown.tsx
@@ -28,6 +28,7 @@ import remarkGfm from "remark-gfm";
 import {
   resolveWorkspaceFileExtension,
   resolveWorkspaceImageMimeType,
+  resolveWorkspaceVideoMimeType,
   workspaceFileName as basenameWorkspacePath
 } from "@tutti-os/workspace-file-manager/services";
 import {
@@ -256,7 +257,7 @@ export function AgentMessageMarkdown({
         />
       ),
       img: (props: MarkdownDomProps<"img">) => (
-        <MarkdownImage {...props} enableZoom={enableImageZoom} />
+        <MarkdownMedia {...props} enableZoom={enableImageZoom} />
       ),
       p: (props: MarkdownDomProps<"p">) => (
         <MarkdownParagraph {...props} inline={inline} />
@@ -967,42 +968,46 @@ function MarkdownCode({
   );
 }
 
-type MarkdownImageState =
+type MarkdownMediaKind = "image" | "video";
+
+type MarkdownMediaState =
   | { status: "loading" }
-  | { status: "ready"; src: string }
+  | { kind: MarkdownMediaKind; status: "ready"; src: string }
   | {
       status: "error";
       reason: "unsupported" | "read-failed";
       detail?: string;
     };
 
-interface CachedMarkdownImage {
+interface CachedMarkdownMedia {
+  kind: MarkdownMediaKind;
   objectUrl: string;
   refCount: number;
   revokeTimer: ReturnType<typeof setTimeout> | null;
 }
 
-const cachedMarkdownImages = new Map<string, CachedMarkdownImage>();
-const CACHED_MARKDOWN_IMAGE_REVOKE_DELAY_MS = 250;
+const cachedMarkdownMedia = new Map<string, CachedMarkdownMedia>();
+const CACHED_MARKDOWN_MEDIA_REVOKE_DELAY_MS = 250;
 
 export function resetCachedMarkdownImagesForTests(): void {
   if (process.env.NODE_ENV !== "test") {
     return;
   }
-  for (const [path, entry] of cachedMarkdownImages) {
+  for (const [path, entry] of cachedMarkdownMedia) {
     if (entry.revokeTimer) {
       clearTimeout(entry.revokeTimer);
     }
     URL.revokeObjectURL(entry.objectUrl);
-    cachedMarkdownImages.delete(path);
+    cachedMarkdownMedia.delete(path);
   }
 }
 
-function MarkdownImage({
+function MarkdownMedia({
   node: _node,
   src,
   alt,
   className,
+  title,
   enableZoom = false,
   ...props
 }: MarkdownDomProps<"img"> & {
@@ -1019,11 +1024,13 @@ function MarkdownImage({
     : undefined;
   const canReadWorkspaceImage = Boolean(workspacePath && readWorkspaceImage);
   const shouldEnableZoom = enableZoom && !isInsideLink;
+  const fallbackMediaKind =
+    typeof src === "string" ? resolveMarkdownMediaKind(src) : null;
   const resolvedSrc =
-    typeof src === "string" ? resolveRenderableMarkdownImageSrc(src) : src;
-  const [state, setState] = useState<MarkdownImageState | null>(() =>
+    typeof src === "string" ? resolveRenderableMarkdownMediaSrc(src) : src;
+  const [state, setState] = useState<MarkdownMediaState | null>(() =>
     canReadWorkspaceImage && workspacePath
-      ? (peekCachedMarkdownImageState(workspacePath) ?? { status: "loading" })
+      ? (peekCachedMarkdownMediaState(workspacePath) ?? { status: "loading" })
       : null
   );
 
@@ -1035,31 +1042,30 @@ function MarkdownImage({
 
     const resolvedWorkspacePath = workspacePath;
     const resolvedReadWorkspaceImage = readWorkspaceImage;
-    const cachedSrc = retainCachedMarkdownImage(resolvedWorkspacePath);
-    if (cachedSrc) {
-      setState({ status: "ready", src: cachedSrc });
+    const cached = retainCachedMarkdownMedia(resolvedWorkspacePath);
+    if (cached) {
+      setState({ kind: cached.kind, status: "ready", src: cached.src });
       return () => {
-        releaseCachedMarkdownImage(resolvedWorkspacePath, cachedSrc);
+        releaseCachedMarkdownMedia(resolvedWorkspacePath, cached.src);
       };
     }
 
-    const resolvedMimeType = resolveWorkspaceImageMimeType(
-      resolvedWorkspacePath
-    );
-    if (!resolvedMimeType) {
+    const mediaType = resolveMarkdownMediaType(resolvedWorkspacePath);
+    if (!mediaType) {
       setState({
         status: "error",
         reason: "unsupported"
       });
       return;
     }
-    const imageMimeType = resolvedMimeType;
+    const mediaKind = mediaType.kind;
+    const mediaMimeType = mediaType.mimeType;
 
     let canceled = false;
     let objectUrl: string | null = null;
     setState({ status: "loading" });
 
-    async function loadWorkspaceImage(): Promise<void> {
+    async function loadWorkspaceMedia(): Promise<void> {
       try {
         const result = await resolvedReadWorkspaceImage({
           path: resolvedWorkspacePath
@@ -1075,11 +1081,12 @@ function MarkdownImage({
           bytes.byteOffset,
           bytes.byteOffset + bytes.byteLength
         ) as ArrayBuffer;
-        objectUrl = cacheMarkdownImage(
+        objectUrl = cacheMarkdownMedia(
           resolvedWorkspacePath,
-          new Blob([arrayBuffer], { type: imageMimeType })
+          mediaKind,
+          new Blob([arrayBuffer], { type: mediaMimeType })
         );
-        setState({ status: "ready", src: objectUrl });
+        setState({ kind: mediaKind, status: "ready", src: objectUrl });
       } catch (error) {
         if (!canceled) {
           setState({
@@ -1091,20 +1098,43 @@ function MarkdownImage({
       }
     }
 
-    void loadWorkspaceImage();
+    void loadWorkspaceMedia();
 
     return () => {
       canceled = true;
       if (objectUrl) {
-        releaseCachedMarkdownImage(resolvedWorkspacePath, objectUrl);
+        releaseCachedMarkdownMedia(resolvedWorkspacePath, objectUrl);
       }
     };
   }, [canReadWorkspaceImage, workspacePath]);
 
   if (!workspacePath || !readWorkspaceImage) {
+    if (fallbackMediaKind === "video") {
+      return (
+        <video
+          src={resolvedSrc}
+          aria-label={alt || undefined}
+          title={typeof title === "string" ? title : undefined}
+          controls
+          playsInline
+          preload="metadata"
+          className={cn(
+            "block max-h-[360px] max-w-full rounded-[8px] border border-[var(--line-2)] bg-[var(--background-panel)]",
+            className
+          )}
+        />
+      );
+    }
+
     if (!shouldEnableZoom) {
       return (
-        <img {...props} src={resolvedSrc} alt={alt} className={className} />
+        <img
+          {...props}
+          src={resolvedSrc}
+          alt={alt}
+          title={title}
+          className={className}
+        />
       );
     }
 
@@ -1113,6 +1143,7 @@ function MarkdownImage({
         {...props}
         src={resolvedSrc}
         alt={alt}
+        title={title}
         className={className}
         wrapElement="span"
       />
@@ -1120,12 +1151,30 @@ function MarkdownImage({
   }
 
   if (state?.status === "ready") {
+    if (state.kind === "video") {
+      return (
+        <video
+          src={state.src}
+          aria-label={alt || undefined}
+          title={typeof title === "string" ? title : undefined}
+          controls
+          playsInline
+          preload="metadata"
+          className={cn(
+            "block max-h-[360px] max-w-full rounded-[8px] border border-[var(--line-2)] bg-[var(--background-panel)]",
+            className
+          )}
+        />
+      );
+    }
+
     if (!shouldEnableZoom) {
       return (
         <img
           {...props}
           src={state.src}
           alt={alt}
+          title={title}
           className={cn(
             "block max-h-[360px] max-w-full rounded-[8px] border border-[var(--line-2)] bg-[var(--background-panel)] object-contain",
             className
@@ -1139,6 +1188,7 @@ function MarkdownImage({
         {...props}
         src={state.src}
         alt={alt}
+        title={title}
         className={cn(
           "block max-h-[360px] max-w-full rounded-[8px] border border-[var(--line-2)] bg-[var(--background-panel)] object-contain",
           className
@@ -1248,7 +1298,7 @@ function isLocalAbsolutePath(path: string): boolean {
   );
 }
 
-function resolveRenderableMarkdownImageSrc(src: string): string {
+function resolveRenderableMarkdownMediaSrc(src: string): string {
   const trimmed = src.trim();
   if (!trimmed) {
     return src;
@@ -1259,13 +1309,37 @@ function resolveRenderableMarkdownImageSrc(src: string): string {
   return new URL(trimmed, "file://").toString();
 }
 
-function peekCachedMarkdownImageState(path: string): MarkdownImageState | null {
-  const src = cachedMarkdownImages.get(path)?.objectUrl ?? null;
-  return src ? { status: "ready", src } : null;
+function resolveMarkdownMediaKind(
+  pathOrName: string
+): MarkdownMediaKind | null {
+  return resolveMarkdownMediaType(pathOrName)?.kind ?? null;
 }
 
-function retainCachedMarkdownImage(path: string): string | null {
-  const entry = cachedMarkdownImages.get(path);
+function resolveMarkdownMediaType(
+  pathOrName: string
+): { kind: MarkdownMediaKind; mimeType: string } | null {
+  const imageMimeType = resolveWorkspaceImageMimeType(pathOrName);
+  if (imageMimeType) {
+    return { kind: "image", mimeType: imageMimeType };
+  }
+  const videoMimeType = resolveWorkspaceVideoMimeType(pathOrName);
+  if (videoMimeType) {
+    return { kind: "video", mimeType: videoMimeType };
+  }
+  return null;
+}
+
+function peekCachedMarkdownMediaState(path: string): MarkdownMediaState | null {
+  const entry = cachedMarkdownMedia.get(path);
+  return entry
+    ? { kind: entry.kind, status: "ready", src: entry.objectUrl }
+    : null;
+}
+
+function retainCachedMarkdownMedia(
+  path: string
+): { kind: MarkdownMediaKind; src: string } | null {
+  const entry = cachedMarkdownMedia.get(path);
   if (!entry) {
     return null;
   }
@@ -1274,11 +1348,15 @@ function retainCachedMarkdownImage(path: string): string | null {
     clearTimeout(entry.revokeTimer);
     entry.revokeTimer = null;
   }
-  return entry.objectUrl;
+  return { kind: entry.kind, src: entry.objectUrl };
 }
 
-function cacheMarkdownImage(path: string, blob: Blob): string {
-  const entry = cachedMarkdownImages.get(path);
+function cacheMarkdownMedia(
+  path: string,
+  kind: MarkdownMediaKind,
+  blob: Blob
+): string {
+  const entry = cachedMarkdownMedia.get(path);
   if (entry) {
     entry.refCount += 1;
     if (entry.revokeTimer) {
@@ -1288,7 +1366,8 @@ function cacheMarkdownImage(path: string, blob: Blob): string {
     return entry.objectUrl;
   }
   const objectUrl = URL.createObjectURL(blob);
-  cachedMarkdownImages.set(path, {
+  cachedMarkdownMedia.set(path, {
+    kind,
     objectUrl,
     refCount: 1,
     revokeTimer: null
@@ -1296,8 +1375,8 @@ function cacheMarkdownImage(path: string, blob: Blob): string {
   return objectUrl;
 }
 
-function releaseCachedMarkdownImage(path: string, objectUrl: string): void {
-  const entry = cachedMarkdownImages.get(path);
+function releaseCachedMarkdownMedia(path: string, objectUrl: string): void {
+  const entry = cachedMarkdownMedia.get(path);
   if (!entry || entry.objectUrl !== objectUrl) {
     URL.revokeObjectURL(objectUrl);
     return;
@@ -1307,13 +1386,13 @@ function releaseCachedMarkdownImage(path: string, objectUrl: string): void {
     return;
   }
   entry.revokeTimer = setTimeout(() => {
-    const current = cachedMarkdownImages.get(path);
+    const current = cachedMarkdownMedia.get(path);
     if (!current || current.objectUrl !== objectUrl || current.refCount > 0) {
       return;
     }
-    cachedMarkdownImages.delete(path);
+    cachedMarkdownMedia.delete(path);
     URL.revokeObjectURL(objectUrl);
-  }, CACHED_MARKDOWN_IMAGE_REVOKE_DELAY_MS);
+  }, CACHED_MARKDOWN_MEDIA_REVOKE_DELAY_MS);
 }
 
 function isHttpUrl(value: string): boolean {

--- a/packages/workspace/file-manager/src/index.ts
+++ b/packages/workspace/file-manager/src/index.ts
@@ -23,6 +23,7 @@ export {
   resolveWorkspaceFileActivationTarget,
   resolveWorkspaceFileExtension,
   resolveWorkspaceImageMimeType,
+  resolveWorkspaceVideoMimeType,
   workspaceFilePreviewMaxBytes,
   workspaceFileTextMaxBytes
 } from "./services/workspaceFileManagerModel.ts";

--- a/packages/workspace/file-manager/src/services/index.ts
+++ b/packages/workspace/file-manager/src/services/index.ts
@@ -46,6 +46,7 @@ export {
   resolveWorkspaceFileExtension,
   resolveWorkspaceFileVisualKind,
   resolveWorkspaceImageMimeType,
+  resolveWorkspaceVideoMimeType,
   workspaceFilePreviewMaxBytes,
   workspaceFileTextMaxBytes,
   type WorkspaceFileVisualKind


### PR DESCRIPTION
## Summary
- Extend AgentGUI Markdown rendering from image-only media to image/video media.
- Render Markdown video references such as `![alt](/path/file.mp4)` with a native `<video controls>` preview.
- Allow safe direct opening of agent-generated `generated_videos/*.mp4` and `*.webm` paths.
- Re-export `resolveWorkspaceVideoMimeType` from workspace-file-manager services and add regression tests.

## Validation
- `pnpm exec vitest run shared/AgentMessageMarkdown.spec.tsx actions/workspaceLinkActions.spec.ts --environment jsdom`
- `pnpm --filter @tutti-os/agent-gui typecheck`
- `pnpm --filter @tutti-os/workspace-file-manager typecheck`
- Pre-push `check:full`: TS, typecheck, lint:ts, lint:go, and test:ts passed; `test:go` failed in unrelated existing Go tests under `services/tuttid/app`, `services/tuttid/service/agentstatus`, `services/tuttid/service/workspace`, and `services/tuttid/types`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Workspace links and markdown previews now support video files (not just images), including local workspace media playback.
  * Video previews can render with playback controls when the media can be loaded.

* **Bug Fixes**
  * Improved acceptance of generated media paths (including generated videos) and more consistent remapping of workspace file link actions.
  * Enhanced markdown video fallback behavior when workspace file access isn’t available.

* **Tests**
  * Added unit coverage for generated workspace link resolution.
  * Added tests for markdown video rendering, fallback states, and “preview unavailable” messaging.

* **Chores**
  * Exported workspace video MIME type resolver for use by the UI.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->