### PR TITLE
[codex] include speed config in CLI composer options

### DIFF
--- a/services/tuttid/service/cli/providers/agentcontext/composer_options.go
+++ b/services/tuttid/service/cli/providers/agentcontext/composer_options.go
@@ -111,6 +111,7 @@ func composerOptionsValue(options agentservice.ComposerOptions) map[string]any {
 		"modelConfig":       composerConfigOptionValue(options.ModelConfig),
 		"permissionConfig":  permissionConfigValue(options.PermissionConfig),
 		"reasoningConfig":   composerConfigOptionValue(options.ReasoningConfig),
+		"speedConfig":       composerConfigOptionValue(options.SpeedConfig),
 	}
 }
 

--- a/services/tuttid/service/cli/providers/agentcontext/provider_test.go
+++ b/services/tuttid/service/cli/providers/agentcontext/provider_test.go
@@ -638,6 +638,7 @@ func TestStartCommandPassesComposerSettings(t *testing.T) {
 			"prompt":           "do work",
 			"provider":         "codex",
 			"reasoning-effort": "high",
+			"speed":            "fast",
 		},
 	}); err != nil {
 		t.Fatalf("Handler: %v", err)
@@ -650,6 +651,9 @@ func TestStartCommandPassesComposerSettings(t *testing.T) {
 	}
 	if sessions.createInput.ReasoningEffort == nil || *sessions.createInput.ReasoningEffort != "high" {
 		t.Fatalf("ReasoningEffort = %#v", sessions.createInput.ReasoningEffort)
+	}
+	if sessions.createInput.Speed == nil || *sessions.createInput.Speed != "fast" {
+		t.Fatalf("Speed = %#v", sessions.createInput.Speed)
 	}
 }
 
@@ -929,12 +933,16 @@ func TestProviderHiddenAgentAppCapabilityRemainsInvokable(t *testing.T) {
 		Input: map[string]any{
 			"model":  "gpt-5",
 			"prompt": "do work",
+			"speed":  "fast",
 		},
 	}); err != nil {
 		t.Fatalf("Invoke hidden codex command: %v", err)
 	}
 	if sessions.createInput.Provider != "codex" {
 		t.Fatalf("created provider = %q, want codex", sessions.createInput.Provider)
+	}
+	if sessions.createInput.Speed == nil || *sessions.createInput.Speed != "fast" {
+		t.Fatalf("created speed = %#v, want fast", sessions.createInput.Speed)
 	}
 }
 

--- a/services/tuttid/service/cli/providers/agentcontext/provider_test.go
+++ b/services/tuttid/service/cli/providers/agentcontext/provider_test.go
@@ -134,6 +134,20 @@ func (f *fakeAgentSessions) GetComposerOptions(_ context.Context, input agentser
 				Value: input.Settings.ReasoningEffort,
 			}},
 		},
+		SpeedConfig: agentservice.ComposerConfigOption{
+			Configurable: true,
+			CurrentValue: "standard",
+			DefaultValue: "standard",
+			Options: []agentservice.ComposerConfigOptionValue{{
+				ID:    "standard",
+				Label: "标准",
+				Value: "standard",
+			}, {
+				ID:    "fast",
+				Label: "快速",
+				Value: "fast",
+			}},
+		},
 		RuntimeContext: map[string]any{
 			"configOptions": []map[string]any{{
 				"currentValue": input.Settings.Model,
@@ -506,6 +520,14 @@ func TestComposerOptionsCommandReturnsProviderOptions(t *testing.T) {
 	modes := permissionConfig["modes"].([]any)
 	if modes[0].(map[string]any)["label"] != "替我审批" {
 		t.Fatalf("permission modes = %#v", modes)
+	}
+	speedConfig := output.Value["speedConfig"].(map[string]any)
+	if speedConfig["currentValue"] != "standard" || speedConfig["defaultValue"] != "standard" {
+		t.Fatalf("speedConfig = %#v", speedConfig)
+	}
+	speedOptions := speedConfig["options"].([]any)
+	if len(speedOptions) != 2 || speedOptions[0].(map[string]any)["value"] != "standard" || speedOptions[1].(map[string]any)["value"] != "fast" {
+		t.Fatalf("speed options = %#v", speedOptions)
 	}
 }
 

--- a/services/tuttid/service/cli/providers/agentcontext/session_commands.go
+++ b/services/tuttid/service/cli/providers/agentcontext/session_commands.go
@@ -27,6 +27,7 @@ type startInput struct {
 	Prompt          string `cli:"prompt" validate:"required"`
 	ReasoningEffort string `cli:"reasoning-effort"`
 	Show            bool   `cli:"show"`
+	Speed           string `cli:"speed"`
 	Title           string `cli:"title"`
 	Visible         bool   `cli:"visible"`
 }
@@ -39,6 +40,7 @@ type providerStartInput struct {
 	Prompt          string `cli:"prompt" validate:"required"`
 	ReasoningEffort string `cli:"reasoning-effort"`
 	Show            bool   `cli:"show"`
+	Speed           string `cli:"speed"`
 	Title           string `cli:"title"`
 	Visible         bool   `cli:"visible"`
 }
@@ -77,6 +79,7 @@ func (p Provider) newStartCommand() cliservice.Command {
 				Prompt:          input.Prompt,
 				ReasoningEffort: input.ReasoningEffort,
 				Show:            input.Show,
+				Speed:           input.Speed,
 				Title:           input.Title,
 				Visible:         input.Visible,
 			})
@@ -125,6 +128,7 @@ type startFields struct {
 	Prompt          string
 	ReasoningEffort string
 	Show            bool
+	Speed           string
 	Title           string
 	Visible         bool
 }
@@ -146,6 +150,7 @@ func (p Provider) runStart(ctx context.Context, invoke framework.InvokeContext, 
 		Model:                optionalStringPointer(input.Model),
 		PermissionModeID:     optionalStringPointer(input.PermissionMode),
 		ReasoningEffort:      optionalStringPointer(input.ReasoningEffort),
+		Speed:                optionalStringPointer(input.Speed),
 		Title:                optionalStringPointer(input.Title),
 		Visible:              boolPointer(visible),
 	})


### PR DESCRIPTION
## Summary

- Include `speedConfig` in the `agent composer-options` CLI JSON output.
- Add CLI provider test coverage for the standard/fast speed options.

## Why

The daemon already computes provider speed options for supported providers, but the CLI JSON projection omitted `speedConfig`. Consumers could see `effectiveSettings.speed` but could not discover the selectable standard/fast modes from the CLI output.

## Validation

- `go test -count=1 ./services/tuttid/service/cli/providers/agentcontext`
- `pnpm check:changed --tail-lines 80`
- End-to-end CLI self-test against an isolated source-built `tuttid` confirmed `speedConfig.options` includes `standard` and `fast`.

## Notes

`git push` pre-push ran `pnpm check:full`, but the full `test:go` lane failed in an unrelated existing test: `services/tuttid/service/agentstatus` `TestServiceRunActionSerializesConcurrentExternalRegistryNPMInstalls` (`npm install calls = 1, want serialized duplicate installs`). Re-running that single test reproduced the same failure. The changed package checks listed above pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Composer options now include speed settings, exposing speed choices in the CLI output.
  * The agent session start flow now accepts a `--speed` option and forwards the selected speed into session creation.
* **Tests**
  * Updated composer-options and start-command tests to validate speed propagation and the new CLI output fields.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->