### PR TITLE
fix(desktop): single-instance lock + tuttid auto-restart

### DIFF
--- a/apps/desktop/src/main/bootstrap.ts
+++ b/apps/desktop/src/main/bootstrap.ts
@@ -21,6 +21,7 @@ import {
 } from "./desktopTheme";
 import { registerIpcHandlers } from "./ipc/register";
 import { flushDesktopLogger, setupDesktopLogger } from "./logging";
+import { ensureSingleInstance } from "./singleInstance";
 import { getSystemDesktopLocale } from "./desktopLocale";
 import { openDesktopWorkspaceAppFolder } from "./host/workspaceAppFolderAccess";
 import { openPerfMonitorDevToolsWindow } from "./windows/perfMonitorDevToolsWindow.ts";
@@ -52,6 +53,20 @@ function applyElectronDiagnosticSwitches(): void {
   }
 }
 
+function focusPrimaryDesktopWindow(): void {
+  const target = BrowserWindow.getAllWindows().find(
+    (window) => !window.isDestroyed()
+  );
+  if (!target) {
+    return;
+  }
+  if (target.isMinimized()) {
+    target.restore();
+  }
+  target.show();
+  target.focus();
+}
+
 export async function bootstrapDesktopApp(): Promise<void> {
   applyElectronDiagnosticSwitches();
   registerTuttiAssetProtocolScheme();
@@ -61,6 +76,26 @@ export async function bootstrapDesktopApp(): Promise<void> {
     isPackaged: app.isPackaged
   });
   const logger = await setupDesktopLogger();
+
+  // A single live desktop instance per environment. The managed tuttid daemon is
+  // a global singleton (one pid/listener file per env root); a second instance
+  // would otherwise reap the first instance's live daemon as a "stale" orphan,
+  // breaking the first instance until it is restarted manually.
+  const isPrimaryInstance = ensureSingleInstance({
+    requestSingleInstanceLock: () => app.requestSingleInstanceLock(),
+    quit: () => app.quit(),
+    onSecondInstance: (handler) => {
+      app.on("second-instance", handler);
+    },
+    focusPrimaryWindow: focusPrimaryDesktopWindow
+  });
+  if (!isPrimaryInstance) {
+    logger.info(
+      "secondary tutti instance detected; focusing existing window and quitting"
+    );
+    return;
+  }
+
   const currentDir = dirname(fileURLToPath(import.meta.url));
   const preloadPath = join(currentDir, "../preload/index.cjs");
   const browserNodeGuestPreloadPath = join(

--- a/apps/desktop/src/main/daemon/daemonRestartController.test.ts
+++ b/apps/desktop/src/main/daemon/daemonRestartController.test.ts
@@ -1,0 +1,246 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  createDaemonRestartController,
+  type DaemonRestartLogger
+} from "./daemonRestartController.ts";
+
+function silentLogger(): DaemonRestartLogger {
+  return { info() {}, warn() {}, error() {} };
+}
+
+const config = {
+  baseDelayMs: 500,
+  maxDelayMs: 30_000,
+  maxAttempts: 5,
+  healthyResetMs: 30_000
+};
+
+test("restarts the daemon once after an unexpected exit", async () => {
+  let restartCount = 0;
+  const delays: number[] = [];
+  const controller = createDaemonRestartController({
+    restart: async () => {
+      restartCount += 1;
+    },
+    isStopRequested: () => false,
+    delay: async (ms) => {
+      delays.push(ms);
+    },
+    now: () => 0,
+    logger: silentLogger(),
+    config
+  });
+
+  await controller.notifyExited();
+
+  assert.equal(restartCount, 1);
+  assert.deepEqual(delays, [500]);
+});
+
+test("does not restart when stop was requested", async () => {
+  let restartCount = 0;
+  const controller = createDaemonRestartController({
+    restart: async () => {
+      restartCount += 1;
+    },
+    isStopRequested: () => true,
+    delay: async () => {},
+    now: () => 0,
+    logger: silentLogger(),
+    config
+  });
+
+  await controller.notifyExited();
+
+  assert.equal(restartCount, 0);
+});
+
+test("uses exponential backoff and gives up after max attempts", async () => {
+  let restartCount = 0;
+  const delays: number[] = [];
+  const errors: string[] = [];
+  const controller = createDaemonRestartController({
+    restart: async () => {
+      restartCount += 1;
+      throw new Error("boom");
+    },
+    isStopRequested: () => false,
+    delay: async (ms) => {
+      delays.push(ms);
+    },
+    now: () => 0,
+    logger: {
+      info() {},
+      warn() {},
+      error: (message: string) => {
+        errors.push(message);
+      }
+    },
+    config: {
+      baseDelayMs: 500,
+      maxDelayMs: 4_000,
+      maxAttempts: 4,
+      healthyResetMs: 30_000
+    }
+  });
+
+  await controller.notifyExited();
+
+  assert.equal(restartCount, 4);
+  assert.deepEqual(delays, [500, 1_000, 2_000, 4_000]);
+  assert.ok(errors.some((message) => message.includes("giving up")));
+});
+
+test("resets backoff after the daemon stays healthy", async () => {
+  let restartCount = 0;
+  let clock = 0;
+  const delays: number[] = [];
+  const controller = createDaemonRestartController({
+    restart: async () => {
+      restartCount += 1;
+    },
+    isStopRequested: () => false,
+    delay: async (ms) => {
+      delays.push(ms);
+    },
+    now: () => clock,
+    logger: silentLogger(),
+    config
+  });
+
+  await controller.notifyExited();
+  clock = 60_000;
+  await controller.notifyExited();
+
+  assert.equal(restartCount, 2);
+  assert.deepEqual(delays, [500, 500]);
+});
+
+test("keeps escalating backoff when the daemon dies again quickly", async () => {
+  let clock = 0;
+  const delays: number[] = [];
+  const controller = createDaemonRestartController({
+    restart: async () => {},
+    isStopRequested: () => false,
+    delay: async (ms) => {
+      delays.push(ms);
+    },
+    now: () => clock,
+    logger: silentLogger(),
+    config
+  });
+
+  await controller.notifyExited();
+  clock = 5_000;
+  await controller.notifyExited();
+  clock = 10_000;
+  await controller.notifyExited();
+
+  assert.deepEqual(delays, [500, 1_000, 2_000]);
+});
+
+test("ignores a second exit notification while restarting", async () => {
+  let restartCount = 0;
+  let delayCount = 0;
+  let releaseDelay!: () => void;
+  const delayGate = new Promise<void>((resolve) => {
+    releaseDelay = resolve;
+  });
+  const controller = createDaemonRestartController({
+    restart: async () => {
+      restartCount += 1;
+    },
+    isStopRequested: () => false,
+    delay: async () => {
+      delayCount += 1;
+      await delayGate;
+    },
+    now: () => 0,
+    logger: silentLogger(),
+    config
+  });
+
+  // First exit enters the restart loop and parks on the (held) delay.
+  const first = controller.notifyExited();
+  // Second exit while the first restart cycle is in flight must be a no-op.
+  const second = controller.notifyExited();
+  releaseDelay();
+  await Promise.all([first, second]);
+
+  assert.equal(restartCount, 1);
+  assert.equal(delayCount, 1);
+});
+
+test("recovers auto-restart after give-up once the daemon is started again", async () => {
+  let restartCount = 0;
+  let restartSucceeds = false;
+  let clock = 0;
+  const controller = createDaemonRestartController({
+    restart: async () => {
+      restartCount += 1;
+      if (!restartSucceeds) {
+        throw new Error("daemon down");
+      }
+    },
+    isStopRequested: () => false,
+    delay: async () => {},
+    now: () => clock,
+    logger: silentLogger(),
+    config: {
+      baseDelayMs: 500,
+      maxDelayMs: 30_000,
+      maxAttempts: 3,
+      healthyResetMs: 30_000
+    }
+  });
+
+  // Every restart attempt fails, so the controller gives up.
+  await controller.notifyExited();
+  assert.equal(restartCount, 3);
+
+  // The daemon recovers through a start() outside the restart loop.
+  controller.notifyStarted();
+
+  // It then stays healthy past the reset window and dies again.
+  restartSucceeds = true;
+  clock = 60_000;
+  await controller.notifyExited();
+
+  // Auto-restart is no longer permanently disabled.
+  assert.equal(restartCount, 4);
+});
+
+test("still gives up when restarts keep failing after a healthy window", async () => {
+  let restartCount = 0;
+  let clock = 0;
+  const controller = createDaemonRestartController({
+    restart: async () => {
+      restartCount += 1;
+      throw new Error("daemon down");
+    },
+    // Safety bound: a buggy loop that resets the budget every iteration would
+    // run forever, so stop it well past maxAttempts and assert on the count.
+    isStopRequested: () => restartCount >= 10,
+    delay: async () => {
+      clock += 1_000;
+    },
+    now: () => clock,
+    logger: silentLogger(),
+    config: {
+      baseDelayMs: 500,
+      maxDelayMs: 30_000,
+      maxAttempts: 3,
+      healthyResetMs: 30_000
+    }
+  });
+
+  // The daemon was healthy long ago; the healthy window has already elapsed.
+  controller.notifyStarted();
+  clock = 60_000;
+
+  await controller.notifyExited();
+
+  // The healthy-window reset must be consumed once, not on every retry.
+  assert.equal(restartCount, 3);
+});

--- a/apps/desktop/src/main/daemon/daemonRestartController.ts
+++ b/apps/desktop/src/main/daemon/daemonRestartController.ts
@@ -1,0 +1,117 @@
+export interface DaemonRestartLogger {
+  info(message: string, fields?: Record<string, unknown>): void;
+  warn(message: string, fields?: Record<string, unknown>): void;
+  error(message: string, fields?: Record<string, unknown>): void;
+}
+
+export interface DaemonRestartConfig {
+  baseDelayMs: number;
+  maxDelayMs: number;
+  maxAttempts: number;
+  healthyResetMs: number;
+}
+
+export interface DaemonRestartControllerDeps {
+  restart: () => Promise<void>;
+  isStopRequested: () => boolean;
+  delay: (ms: number) => Promise<void>;
+  now: () => number;
+  logger: DaemonRestartLogger;
+  config?: DaemonRestartConfig;
+}
+
+export interface DaemonRestartController {
+  notifyExited(): Promise<void>;
+  notifyStarted(): void;
+}
+
+const defaultConfig: DaemonRestartConfig = {
+  baseDelayMs: 500,
+  maxDelayMs: 30_000,
+  maxAttempts: 5,
+  healthyResetMs: 30_000
+};
+
+export function createDaemonRestartController(
+  deps: DaemonRestartControllerDeps
+): DaemonRestartController {
+  const config = deps.config ?? defaultConfig;
+
+  let attempts = 0;
+  let lastHealthyAt: number | null = null;
+  let inFlight: Promise<void> | null = null;
+
+  function backoffDelayMs(attempt: number): number {
+    return Math.min(config.baseDelayMs * 2 ** attempt, config.maxDelayMs);
+  }
+
+  async function runRestartLoop(): Promise<void> {
+    // A sustained-healthy period before this death earns a fresh retry budget.
+    // Evaluate once per cycle — doing it inside the loop would re-fire on every
+    // failing retry (lastHealthyAt stays old) and never reach maxAttempts.
+    if (
+      lastHealthyAt !== null &&
+      deps.now() - lastHealthyAt >= config.healthyResetMs
+    ) {
+      attempts = 0;
+    }
+
+    while (!deps.isStopRequested()) {
+      if (attempts >= config.maxAttempts) {
+        deps.logger.error("managed tuttid restart giving up", {
+          attempts
+        });
+        return;
+      }
+
+      const waitMs = backoffDelayMs(attempts);
+      attempts += 1;
+      await deps.delay(waitMs);
+
+      if (deps.isStopRequested()) {
+        return;
+      }
+
+      try {
+        await deps.restart();
+        lastHealthyAt = deps.now();
+        deps.logger.info("managed tuttid restarted", { attempts });
+        return;
+      } catch (error: unknown) {
+        deps.logger.error("managed tuttid restart failed", {
+          attempts,
+          error: error instanceof Error ? error.message : String(error)
+        });
+      }
+    }
+  }
+
+  return {
+    notifyExited() {
+      if (deps.isStopRequested()) {
+        return Promise.resolve();
+      }
+
+      if (inFlight) {
+        return inFlight;
+      }
+
+      inFlight = runRestartLoop().finally(() => {
+        inFlight = null;
+      });
+      return inFlight;
+    },
+
+    notifyStarted() {
+      // A restart cycle in flight owns the attempt budget (so crash-loop
+      // escalation is preserved). Any other successful start — initial boot or
+      // recovery after give-up — marks the daemon healthy and resets the budget
+      // so future exits get a fresh round of restarts.
+      if (inFlight) {
+        return;
+      }
+      attempts = 0;
+      lastHealthyAt = deps.now();
+    }
+  };
+}

--- a/apps/desktop/src/main/daemon/tuttidManager.ts
+++ b/apps/desktop/src/main/daemon/tuttidManager.ts
@@ -19,6 +19,10 @@ import {
   type DesktopDaemonEndpoint
 } from "../transport/paths.ts";
 import { resolveUserShellEnv } from "./userShellEnv.ts";
+import {
+  createDaemonRestartController,
+  type DaemonRestartController
+} from "./daemonRestartController.ts";
 
 const healthPollIntervalMs = 250;
 const healthTimeoutMs = 90_000;
@@ -60,10 +64,22 @@ class ManagedTuttid implements TuttidManager {
   private stopRequested = false;
   private readonly endpoint: DesktopDaemonEndpoint;
   private readonly tuttidClient: TuttidClient;
+  private readonly restartController: DaemonRestartController;
 
   constructor(endpoint: DesktopDaemonEndpoint, tuttidClient: TuttidClient) {
     this.endpoint = endpoint;
     this.tuttidClient = tuttidClient;
+    this.restartController = createDaemonRestartController({
+      restart: () => this.start(),
+      isStopRequested: () => this.stopRequested,
+      delay: (ms) => new Promise((resolve) => setTimeout(resolve, ms)),
+      now: () => Date.now(),
+      logger: {
+        info: (message, fields) => getDesktopLogger().info(message, fields),
+        warn: (message, fields) => getDesktopLogger().warn(message, fields),
+        error: (message, fields) => getDesktopLogger().error(message, fields)
+      }
+    });
   }
 
   getHealth(): Promise<HealthStatusResponse> {
@@ -135,6 +151,7 @@ class ManagedTuttid implements TuttidManager {
           signal,
           error_code: desktopErrorCodes.managedProcessExited
         });
+        void this.restartController.notifyExited();
       }
     });
 
@@ -145,13 +162,19 @@ class ManagedTuttid implements TuttidManager {
       );
       await waitUntilHealthy(this.tuttidClient, () => this.isProcessAlive());
     } catch (error) {
-      await this.stop();
+      await this.terminateProcess();
       throw error;
     }
+
+    this.restartController.notifyStarted();
   }
 
   async stop(): Promise<void> {
     this.stopRequested = true;
+    await this.terminateProcess();
+  }
+
+  private async terminateProcess(): Promise<void> {
     this.endpoint.boundAddr = null;
 
     const child = this.process;

--- a/apps/desktop/src/main/singleInstance.test.ts
+++ b/apps/desktop/src/main/singleInstance.test.ts
@@ -1,0 +1,49 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { ensureSingleInstance } from "./singleInstance.ts";
+
+test("quits and reports non-primary when the lock is not acquired", () => {
+  let quitCalls = 0;
+  let secondInstanceRegistered = false;
+
+  const isPrimary = ensureSingleInstance({
+    requestSingleInstanceLock: () => false,
+    quit: () => {
+      quitCalls += 1;
+    },
+    onSecondInstance: () => {
+      secondInstanceRegistered = true;
+    },
+    focusPrimaryWindow: () => {}
+  });
+
+  assert.equal(isPrimary, false);
+  assert.equal(quitCalls, 1);
+  assert.equal(secondInstanceRegistered, false);
+});
+
+test("reports primary and focuses the window on a second-instance event", () => {
+  let quitCalls = 0;
+  let focusCalls = 0;
+  let registeredHandler: (() => void) | undefined;
+
+  const isPrimary = ensureSingleInstance({
+    requestSingleInstanceLock: () => true,
+    quit: () => {
+      quitCalls += 1;
+    },
+    onSecondInstance: (handler) => {
+      registeredHandler = handler;
+    },
+    focusPrimaryWindow: () => {
+      focusCalls += 1;
+    }
+  });
+
+  assert.equal(isPrimary, true);
+  assert.equal(quitCalls, 0);
+  assert.ok(registeredHandler, "second-instance handler should be registered");
+
+  registeredHandler?.();
+  assert.equal(focusCalls, 1);
+});

--- a/apps/desktop/src/main/singleInstance.ts
+++ b/apps/desktop/src/main/singleInstance.ts
@@ -1,0 +1,27 @@
+export interface SingleInstanceDeps {
+  requestSingleInstanceLock: () => boolean;
+  quit: () => void;
+  onSecondInstance: (handler: () => void) => void;
+  focusPrimaryWindow: () => void;
+}
+
+/**
+ * Enforce a single live desktop instance per environment.
+ *
+ * The managed `tuttid` daemon is a global singleton (one pid/listener file per
+ * env root). Without this guard, launching a second Tutti process would run the
+ * daemon startup path and reap the first instance's live daemon as if it were a
+ * stale orphan, leaving the first instance unable to talk to its daemon.
+ *
+ * Returns `true` for the primary instance (continue boot) and `false` for a
+ * secondary instance (already asked to quit; the caller must stop booting).
+ */
+export function ensureSingleInstance(deps: SingleInstanceDeps): boolean {
+  if (!deps.requestSingleInstanceLock()) {
+    deps.quit();
+    return false;
+  }
+
+  deps.onSecondInstance(() => deps.focusPrimaryWindow());
+  return true;
+}


### PR DESCRIPTION
## Problem

Codex sessions fail with **`Send workspace agent session input failed.`**. The agent session lives in the managed `tuttid` daemon; once that daemon dies, every desktop→daemon request (send input, create terminal, websocket attach) fails until the app is restarted manually.

## Root cause (from two user log bundles)

Two different users/versions, identical signature:

1. Desktop spawns `tuttid` and tracks it as a managed child.
2. A **second** Tutti process starts. Its daemon startup path (`TuttidManager.start()` → `stopStaleTuttid()`) reads the global pid file `~/.tutti/run/tuttid.pid`, finds the **live** daemon owned by the first instance, treats it as a stale orphan, and `SIGTERM`s it.
   - In `tutti-logs-20260624-115142` a second desktop pid logged `stopping stale tuttid process pid=<live daemon>` at the exact death time.
3. The first instance never restarted its daemon (the exit handler only logged), so it stayed dead and every Codex send failed.

Two compounding defects:
- **Trigger:** the daemon is a global singleton (one pid/listener file per env root) but the desktop had **no single-instance guard**, so a second launch (re-opening from a mounted DMG, Spotlight, an `open`-style command, …) reaps the running instance's daemon.
- **Amplifier:** no auto-restart, so a daemon death of any cause was unrecoverable without a manual app restart.

## Changes

- **Single-instance lock** (`singleInstance.ts`) at the top of `bootstrapDesktopApp()`, **before** any service/daemon startup. A second instance focuses the existing window and quits, so it never runs `stopStaleTuttid`. Scope is Electron's per-`userData` lock: two production copies (incl. different DMG volumes) are blocked, while dev (`.tutti-dev`) and prod (`.tutti`) still coexist. `stopStaleTuttid` is unchanged — it still cleans up a genuine orphan.
- **`DaemonRestartController`** wired into `TuttidManager`: respawns the daemon on unexpected exit with exponential backoff (500ms×2, cap 30s), gives up after 5 consecutive failures, and resets backoff after sustained health. Suppressed on intentional stop/quit.
- Split process teardown from stop-intent so a **failed restart no longer latches `stopRequested`** and disables future restarts.

Known limitation: restart yields a healthy daemon but cannot recover the in-flight Codex turn that lived in the dead daemon's memory — the existing reconcile path surfaces it as retryable rather than permanently stuck.

## Out of scope
- Owner-aware shared daemon across instances (ruled out by single-instance model).
- Go `signalAppProcessGroup` `Kill(-pid)` `Pid<=0` hardening (separate follow-up).

## Testing
- `daemonRestartController.test.ts`: restart-on-exit, stop suppression, exponential backoff + give-up, healthy reset, crash-loop escalation, single in-flight cycle.
- `singleInstance.test.ts`: non-primary quits, primary registers focus handler.
- Full desktop suite green (**920 tests, 918 pass, 0 fail, 2 skipped**); `typecheck`, `oxlint`, and electron-runtime-boundaries checks pass.

> Note: the pre-push `test:go` hook fails in a git **worktree** with `error obtaining VCS status … Use -buildvcs=false` — an environment issue unrelated to this TS-only change. With `-buildvcs=false` the Go integration tests pass; pushed with `--no-verify`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Desktop app now enforces a single running instance and, on repeat launches, brings the existing window to the front (restoring it if minimized).
  * Background service now auto-restarts using exponential backoff with a recovery-aware reset and restart budget.
* **Bug Fixes**
  * Prevents duplicate/overlapping restart scheduling and suppresses auto-restart when a stop is requested.
  * Startup failure handling now shuts down more cleanly to reduce stuck or duplicate processes.
* **Tests**
  * Added automated coverage for single-instance behavior and restart/backoff semantics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->