### PR TITLE
docs(rich-text): document external at-panel integration

### DIFF
--- a/packages/ui/rich-text/README.md
+++ b/packages/ui/rich-text/README.md
@@ -16,37 +16,6 @@ path policy, workspace-file markdown meaning, host file lookup, or product
 workflow-specific reference rules. Those stay with the owning workspace-domain
 package or host adapter.
 
-Current migration status:
-
-- `src/internal/ported-source/*` is a direct snapshot of the old top-level
-  `richText/` directory so we can refactor from the current code instead of
-  redesigning from memory.
-- `src/core/richTextDocument.ts` is the first promoted, host-agnostic surface
-  extracted from that snapshot.
-- editor wrappers and current node extensions are intentionally not public yet
-  because they still depend on app-specific imports and legacy host seams.
-- the package root export is intentionally narrow; `core`, `editor`, `plugins`,
-  and `types` remain the explicit public subpaths
-
-Known transitional seam:
-
-- current editor and readonly surfaces still embed workspace-reference semantics
-  such as `/workspace/...` link handling and workspace reference presentation
-- treat that behavior as transitional implementation, not as the intended
-  public contract of `@tutti-os/ui-rich-text`
-- before adding another host-specific inline reference protocol here, stop and
-  re-evaluate the generic rich-text reference seam across real consumers
-
-Current refactor plan:
-
-1. Promote host-agnostic document helpers from `ported-source` into `core`.
-2. Define a stable plugin contract for `@`, `#`, and future inline token
-   triggers.
-3. Rebuild editor wrappers around injected host adapters instead of app-local
-   imports.
-4. Keep domain-specific reference protocols in their owning packages and only
-   promote the generic rich-text seam here when it is truly host-agnostic.
-
 ## Mention Protocol
 
 The stable `@` mention storage protocol is provider-agnostic:
@@ -160,20 +129,143 @@ Current runtime behavior:
 - mention hydration uses `resolveMention` when the owning trigger provider is
   available and keeps the label-only fallback when it is not
 
-## At-Panel Migration
+## External At-Panel Integration
 
-The `@tutti-os/ui-rich-text/at-panel` subpath now exposes the shared mention
-palette shell through:
+External apps should treat `@tutti-os/ui-rich-text` as the generic trigger and
+palette shell, not as an app-domain data source. The app still owns what can be
+mentioned, how those items are queried, and what gets inserted.
 
-- `MentionPaletteFromState`
-- `createMentionPaletteStateAdapter`
-- `buildMentionPaletteModel`
-- `buildMentionPaletteModelFromTriggerMatches`
-- `richTextTriggerQueryMatchToMentionRowItem`
+Minimum integration checklist:
 
-Older helpers such as `buildMentionPaletteState`, `searchHelpers`, and
-`RichTextAt*` grouping aliases were removed with the legacy flat grouping model.
-Consumers should build category/section config with
-`MentionPaletteCategoryConfig`, derive state with
-`buildMentionPaletteModelFromTriggerMatches`, and keep app-specific copy,
-i18n, provider selection, and insertion behavior in the host application.
+1. Install the package and load the panel CSS once from the app entry point:
+
+   ```ts
+   import "@tutti-os/ui-rich-text/at-panel/index.css";
+   ```
+
+2. Provide one or more `RichTextTriggerProvider`s for the app's mentionable
+   domains. A provider owns querying, stable keys, visible labels, optional
+   subtitles/icons/keywords, insertion mapping, and optional reverse
+   resolution:
+
+   ```ts
+   import type { RichTextTriggerProvider } from "@tutti-os/ui-rich-text/types";
+
+   const providers: RichTextTriggerProvider[] = [
+     {
+       id: "primary-record",
+       trigger: "@",
+       query: async ({ keyword, context }) => searchRecords(keyword, context),
+       getItemKey: (record) => record.id,
+       getItemLabel: (record) => record.title,
+       getItemSubtitle: (record) => record.subtitle,
+       getItemIconUrl: (record) => record.iconUrl,
+       toInsertResult: (record) => ({
+         kind: "mention",
+         mention: {
+           entityId: record.id,
+           label: record.title,
+           scope: { ownerId: record.ownerId }
+         }
+       })
+     }
+   ];
+   ```
+
+3. Query those providers through the rich-text trigger registry or an
+   equivalent host bridge and keep the results as
+   `RichTextTriggerQueryMatch[]`. Provider ordering remains host-owned. The
+   palette only renders the matches it is given.
+
+4. Define palette categories in the app. A category is the top-level tab/filter;
+   optional `sections` become second-level groups inside the active category.
+   When sections are present, each match is assigned to the first matching
+   section in declaration order. A category without sections renders as a
+   single group:
+
+   ```ts
+   import type { MentionPaletteCategoryConfig } from "@tutti-os/ui-rich-text/at-panel";
+
+   const categories: MentionPaletteCategoryConfig[] = [
+     {
+       id: "primary",
+       label: t("mentions.primary"),
+       providerIds: ["primary-record"],
+       sections: [
+         {
+           id: "recent",
+           label: t("mentions.recent"),
+           matches: (match) => match.item.bucket === "recent"
+         },
+         {
+           id: "all",
+           label: t("mentions.all"),
+           matches: (match) => match.item.bucket !== "recent"
+         }
+       ]
+     },
+     {
+       id: "secondary",
+       label: t("mentions.secondary"),
+       providerIds: ["secondary-record"]
+     }
+   ];
+   ```
+
+5. Convert matches into palette state and render the shared shell:
+
+   ```tsx
+   import {
+     MentionPaletteFromState,
+     buildMentionPaletteModelFromTriggerMatches,
+     renderMentionRow,
+     richTextTriggerQueryMatchToMentionRowItem
+   } from "@tutti-os/ui-rich-text/at-panel";
+
+   const state = buildMentionPaletteModelFromTriggerMatches({
+     activeCategoryId,
+     categories,
+     matches,
+     loading,
+     query
+   });
+
+   <MentionPaletteFromState
+     state={state}
+     highlightedKey={highlightedKey}
+     getItemKey={(match, groupId) => `${match.providerId}:${match.key}`}
+     callbacks={{
+       onActiveCategoryIdChange: setActiveCategoryId,
+       onHighlightChange: setHighlightedKey,
+       onSelectItem: commitMatch
+     }}
+     labels={{
+       empty: t("mentions.empty"),
+       loading: t("mentions.loading")
+     }}
+     hintLabels={{
+       cycleFilter: t("mentions.switchCategory"),
+       moveSelection: t("mentions.switchSelection")
+     }}
+     maxHeightPx={360}
+     renderItem={(match) =>
+       renderMentionRow(
+         richTextTriggerQueryMatchToMentionRowItem(match, {
+           getDescription: (candidate) => candidate.subtitle,
+           renderLeading: (ctx) => renderAppSpecificLeading(ctx)
+         })
+       )
+     }
+   />;
+   ```
+
+6. Wire keyboard handling to the state adapter or to `makeAtPanelKeyDown`.
+   External apps should keep the exact shortcut policy local; the shared shell
+   supports moving selection, cycling categories, expanding groups, and
+   committing the highlighted item.
+
+7. Keep app-owned behavior outside the package. This includes i18n strings,
+   item-specific icons or avatars, domain data fetches, cache refresh policy,
+   host bridge calls, and the final insertion side effects. Use
+   `renderLeading`, `getDescription`, status helpers, and category/section
+   config as customization slots instead of forking the panel shell.


### PR DESCRIPTION
## Summary
- document the generic external at-panel integration path for apps using @tutti-os/ui-rich-text
- remove internal migration/history notes and legacy at-panel migration wording from the package README
- keep the examples neutral so they describe provider/category/section integration rather than a specific app domain

## Verification
- pnpm exec prettier --check --config packages/configs/prettier/base.mjs packages/ui/rich-text/README.md

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the rich-text integration guide with a clearer, step-by-step setup flow for host apps.
  * Replaced the old migration guidance with a new external integration section covering styling, provider setup, palette configuration, keyboard handling, and customization options.
  * Clarified how to keep app-specific behavior outside the package while using the available extension points.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->