### PR TITLE
[codex] Preserve settings titlebar drag

### DIFF
--- a/apps/desktop/src/renderer/src/features/workspace-workbench/ui/WorkspaceSettingsPanel.test.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/ui/WorkspaceSettingsPanel.test.ts
@@ -27,6 +27,17 @@ test("workspace settings panel lists appearance below general", () => {
   );
 });
 
+test("workspace settings backdrop preserves titlebar dragging", () => {
+  assert.match(source, /data-workspace-settings-backdrop="true"/);
+  assert.match(source, /data-workspace-settings-window-drag-region="true"/);
+  assert.match(
+    source,
+    /pointer-events-auto absolute inset-x-0 top-0 z-0 h-\[52px\] \[-webkit-app-region:drag\]/
+  );
+  assert.match(source, /data-workspace-settings-panel="true"/);
+  assert.match(source, /\[-webkit-app-region:no-drag\]/);
+});
+
 test("workspace settings agent panel lists agent controls", () => {
   assert.match(
     source,

--- a/apps/desktop/src/renderer/src/features/workspace-workbench/ui/WorkspaceSettingsPanel.tsx
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/ui/WorkspaceSettingsPanel.tsx
@@ -189,7 +189,7 @@ export function WorkspaceSettingsPanel({
       <section
         aria-labelledby="workspace-settings-title"
         aria-modal="true"
-        className="grid h-[min(500px,calc(100vh-40px))] w-[min(760px,calc(100vw-40px))] origin-center grid-cols-[160px_minmax(0,1fr)] grid-rows-[auto_minmax(0,1fr)] overflow-hidden rounded-2xl border border-[var(--border-1)] bg-[var(--background-fronted)] text-[var(--text-primary)] shadow-panel transition-[background,opacity] duration-[180ms] ease-[cubic-bezier(0.22,1,0.36,1)] [-webkit-app-region:no-drag] motion-safe:animate-in motion-safe:fade-in-0 motion-safe:zoom-in-[0.96] motion-safe:duration-[250ms] motion-safe:ease-[cubic-bezier(0.22,1,0.36,1)] motion-reduce:animate-none max-[760px]:h-[min(100vh-24px,520px)] max-[760px]:w-[min(calc(100vw-24px),640px)] max-[760px]:grid-cols-1 max-[760px]:grid-rows-[auto_auto_minmax(0,1fr)]"
+        className="relative z-[1] grid h-[min(500px,calc(100vh-40px))] w-[min(760px,calc(100vw-40px))] origin-center grid-cols-[160px_minmax(0,1fr)] grid-rows-[auto_minmax(0,1fr)] overflow-hidden rounded-2xl border border-[var(--border-1)] bg-[var(--background-fronted)] text-[var(--text-primary)] shadow-panel transition-[background,opacity] duration-[180ms] ease-[cubic-bezier(0.22,1,0.36,1)] [-webkit-app-region:no-drag] motion-safe:animate-in motion-safe:fade-in-0 motion-safe:zoom-in-[0.96] motion-safe:duration-[250ms] motion-safe:ease-[cubic-bezier(0.22,1,0.36,1)] motion-reduce:animate-none max-[760px]:h-[min(100vh-24px,520px)] max-[760px]:w-[min(calc(100vw-24px),640px)] max-[760px]:grid-cols-1 max-[760px]:grid-rows-[auto_auto_minmax(0,1fr)]"
         data-workspace-settings-panel="true"
         role="dialog"
         onClick={(event) => event.stopPropagation()}
@@ -1806,6 +1806,11 @@ function WorkspaceSettingsPanelPortal({
       style={{ zIndex: "var(--z-panel)" }}
       onClick={onClose}
     >
+      <div
+        aria-hidden="true"
+        className="pointer-events-auto absolute inset-x-0 top-0 z-0 h-[52px] [-webkit-app-region:drag]"
+        data-workspace-settings-window-drag-region="true"
+      />
       {children}
     </div>
   );


### PR DESCRIPTION
## Summary

- Adds a top-window drag region above the settings backdrop so the frameless desktop window can still be dragged while settings is open.
- Keeps the settings panel itself on a higher no-drag layer so panel controls remain clickable and the backdrop still closes the panel.
- Adds a source-level regression test covering the backdrop drag region.

## Root Cause

The settings backdrop covered the full window with `-webkit-app-region: no-drag`, which swallowed the normal titlebar drag area whenever the settings modal was visible.

## Validation

- `node --import ./test/register-asset-stub.mjs --test --experimental-strip-types src/renderer/src/features/workspace-workbench/ui/WorkspaceSettingsPanel.test.ts`
- `pnpm --filter @tutti-os/desktop typecheck`
- `pnpm lint:ts`
- `pnpm --filter @tutti-os/desktop build`
- `pnpm lint:go` with Go 1.24 and pinned golangci-lint v2.12.0
- `pnpm check:full` via pre-push hook


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved workspace settings window behavior so the title bar drag area remains usable while keeping the panel content interactive.
  * Adjusted layering and drag-region handling to preserve expected window dragging on the settings screen.
* **Tests**
  * Added coverage for the workspace settings drag region behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->