### PR TITLE
fix(ci): centralize external review refresh

### DIFF
--- a/.github/workflows/external-pr-review-gate-review-refresh.yml
+++ b/.github/workflows/external-pr-review-gate-review-refresh.yml
@@ -8,67 +8,19 @@ on:
       - completed
 
 permissions:
+  actions: read
   contents: read
   pull-requests: write
   statuses: write
 
 jobs:
-  resolve-pr:
+  external-pr-review-refresh:
     if: ${{ github.event.workflow_run.conclusion == 'success' }}
-    runs-on: ubuntu-latest
-    outputs:
-      pr_number: ${{ steps.resolve.outputs.pr_number }}
-      pr_author: ${{ steps.resolve.outputs.pr_author }}
-      pr_head_sha: ${{ steps.resolve.outputs.pr_head_sha }}
-      pr_is_draft: ${{ steps.resolve.outputs.pr_is_draft }}
-      should_refresh: ${{ steps.resolve.outputs.should_refresh }}
-    steps:
-      - name: Resolve reviewed pull request
-        id: resolve
-        uses: actions/github-script@v8
-        with:
-          script: |
-            const run = context.payload.workflow_run;
-            let pr = run.pull_requests?.find((item) => item.base?.repo?.full_name === context.payload.repository.full_name);
-
-            if (!pr) {
-              const associated = await github.paginate(github.rest.repos.listPullRequestsAssociatedWithCommit, {
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                commit_sha: run.head_sha,
-                per_page: 100,
-              });
-              pr = associated.find((item) => item.state === 'open');
-            }
-
-            if (!pr) {
-              core.info(`No open pull request found for review signal ${run.id} at ${run.head_sha}.`);
-              core.setOutput('should_refresh', 'false');
-              return;
-            }
-
-            const { data: pull } = await github.rest.pulls.get({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              pull_number: pr.number,
-            });
-
-            core.setOutput('pr_number', String(pull.number));
-            core.setOutput('pr_author', pull.user.login);
-            core.setOutput('pr_head_sha', pull.head.sha);
-            core.setOutput('pr_is_draft', String(pull.draft));
-            core.setOutput('should_refresh', 'true');
-
-  external-pr-review-gate:
-    needs: resolve-pr
-    if: ${{ needs.resolve-pr.outputs.should_refresh == 'true' }}
-    uses: ./.github/workflows/reusable-external-pr-review-gate.yml
+    uses: ./.github/workflows/reusable-external-pr-review-refresh.yml
     secrets: inherit
     with:
-      pr_number: ${{ fromJSON(needs.resolve-pr.outputs.pr_number) }}
-      pr_author: ${{ needs.resolve-pr.outputs.pr_author }}
-      pr_head_sha: ${{ needs.resolve-pr.outputs.pr_head_sha }}
-      pr_is_draft: ${{ fromJSON(needs.resolve-pr.outputs.pr_is_draft) }}
+      review_signal_run_id: ${{ github.event.workflow_run.id }}
+      review_signal_head_sha: ${{ github.event.workflow_run.head_sha }}
       review_team_slug: tutti-rd
       official_member_logins: ${{ vars.TUTTI_RD_MEMBERS }}
       status_context: external-pr-review-gate

--- a/.github/workflows/external-pr-review-gate-review-signal.yml
+++ b/.github/workflows/external-pr-review-gate-review-signal.yml
@@ -12,7 +12,11 @@ permissions:
 
 jobs:
   review-signal:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Record review event
-        run: echo "External PR review gate refresh requested."
+    uses: ./.github/workflows/reusable-external-pr-review-signal.yml
+    with:
+      pr_number: ${{ github.event.pull_request.number }}
+      pr_author: ${{ github.event.pull_request.user.login }}
+      pr_head_sha: ${{ github.event.pull_request.head.sha }}
+      pr_is_draft: ${{ github.event.pull_request.draft }}
+      review_commit_id: ${{ github.event.review.commit_id }}
+      review_state: ${{ github.event.review.state }}

--- a/.github/workflows/reusable-external-pr-review-refresh.yml
+++ b/.github/workflows/reusable-external-pr-review-refresh.yml
@@ -1,0 +1,117 @@
+name: Reusable External PR Review Refresh
+
+on:
+  workflow_call:
+    inputs:
+      review_signal_run_id:
+        description: Workflow run id that uploaded the review signal artifact.
+        required: true
+        type: number
+      review_signal_head_sha:
+        description: Head SHA from the review signal workflow run.
+        required: true
+        type: string
+      review_team_slug:
+        description: Organization team slug that owns external contribution review.
+        required: false
+        type: string
+        default: tutti-rd
+      official_member_logins:
+        description: Comma or whitespace separated logins that count as internal authors and reviewers.
+        required: false
+        type: string
+        default: ""
+      status_context:
+        description: Commit status context used by branch protection.
+        required: false
+        type: string
+        default: external-pr-review-gate
+
+permissions:
+  actions: read
+  contents: read
+  pull-requests: write
+  statuses: write
+
+jobs:
+  resolve-pr:
+    runs-on: ubuntu-latest
+    outputs:
+      pr_number: ${{ steps.resolve.outputs.pr_number }}
+      pr_author: ${{ steps.resolve.outputs.pr_author }}
+      pr_head_sha: ${{ steps.resolve.outputs.pr_head_sha }}
+      pr_is_draft: ${{ steps.resolve.outputs.pr_is_draft }}
+      should_refresh: ${{ steps.resolve.outputs.should_refresh }}
+    steps:
+      - name: Download review event payload
+        uses: actions/download-artifact@v4
+        with:
+          name: external-pr-review-gate-review
+          path: ${{ runner.temp }}/review-signal
+          run-id: ${{ inputs.review_signal_run_id }}
+          github-token: ${{ github.token }}
+
+      - name: Resolve reviewed pull request
+        id: resolve
+        uses: actions/github-script@v8
+        with:
+          script: |
+            const fs = require('fs');
+            const expectedHeadSha = '${{ inputs.review_signal_head_sha }}';
+            const payloadPath = `${process.env.RUNNER_TEMP}/review-signal/review-event.json`;
+
+            if (!fs.existsSync(payloadPath)) {
+              throw new Error(`Review signal artifact is missing ${payloadPath}.`);
+            }
+
+            const payload = JSON.parse(fs.readFileSync(payloadPath, 'utf8'));
+            const pullNumber = Number(payload.pr_number);
+            if (!Number.isInteger(pullNumber) || pullNumber <= 0) {
+              throw new Error(`Invalid PR number in review signal artifact: ${JSON.stringify(payload.pr_number)}`);
+            }
+
+            if (payload.pr_head_sha !== expectedHeadSha) {
+              throw new Error(
+                `Review signal head SHA ${payload.pr_head_sha} does not match triggering workflow head SHA ${expectedHeadSha}.`,
+              );
+            }
+
+            core.info(`Resolved PR #${pullNumber} from review signal artifact.`);
+
+            const { data: pull } = await github.rest.pulls.get({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: pullNumber,
+            });
+
+            if (pull.state !== 'open') {
+              core.info(`PR #${pull.number} is ${pull.state}; review gate refresh is skipped.`);
+              core.setOutput('should_refresh', 'false');
+              return;
+            }
+
+            if (pull.head.sha !== expectedHeadSha) {
+              throw new Error(
+                `PR #${pull.number} head SHA ${pull.head.sha} does not match triggering workflow head SHA ${expectedHeadSha}.`,
+              );
+            }
+
+            core.setOutput('pr_number', String(pull.number));
+            core.setOutput('pr_author', pull.user.login);
+            core.setOutput('pr_head_sha', pull.head.sha);
+            core.setOutput('pr_is_draft', String(pull.draft));
+            core.setOutput('should_refresh', 'true');
+
+  external-pr-review-gate:
+    needs: resolve-pr
+    if: ${{ needs.resolve-pr.outputs.should_refresh == 'true' }}
+    uses: tutti-os/tutti/.github/workflows/reusable-external-pr-review-gate.yml@main
+    secrets: inherit
+    with:
+      pr_number: ${{ fromJSON(needs.resolve-pr.outputs.pr_number) }}
+      pr_author: ${{ needs.resolve-pr.outputs.pr_author }}
+      pr_head_sha: ${{ needs.resolve-pr.outputs.pr_head_sha }}
+      pr_is_draft: ${{ fromJSON(needs.resolve-pr.outputs.pr_is_draft) }}
+      review_team_slug: ${{ inputs.review_team_slug }}
+      official_member_logins: ${{ inputs.official_member_logins }}
+      status_context: ${{ inputs.status_context }}

--- a/.github/workflows/reusable-external-pr-review-signal.yml
+++ b/.github/workflows/reusable-external-pr-review-signal.yml
@@ -1,0 +1,67 @@
+name: Reusable External PR Review Signal
+
+on:
+  workflow_call:
+    inputs:
+      pr_number:
+        description: Pull request number that received a review event.
+        required: true
+        type: number
+      pr_author:
+        description: Pull request author login.
+        required: true
+        type: string
+      pr_head_sha:
+        description: Pull request head commit SHA at review event time.
+        required: true
+        type: string
+      pr_is_draft:
+        description: Whether the pull request is currently a draft.
+        required: true
+        type: boolean
+      review_commit_id:
+        description: Commit SHA attached to the review event.
+        required: true
+        type: string
+      review_state:
+        description: Review state from the review event.
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+jobs:
+  review-signal:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Record review event
+        uses: actions/github-script@v8
+        with:
+          script: |
+            const fs = require('fs');
+
+            const payload = {
+              pr_number: Number('${{ inputs.pr_number }}'),
+              pr_author: '${{ inputs.pr_author }}',
+              pr_head_sha: '${{ inputs.pr_head_sha }}',
+              pr_is_draft: '${{ inputs.pr_is_draft }}' === 'true',
+              review_commit_id: '${{ inputs.review_commit_id }}',
+              review_state: '${{ inputs.review_state }}',
+            };
+
+            fs.mkdirSync('review-signal', { recursive: true });
+            fs.writeFileSync(
+              'review-signal/review-event.json',
+              `${JSON.stringify(payload, null, 2)}\n`,
+            );
+
+            core.info(`External PR review gate refresh requested for PR #${payload.pr_number} at ${payload.pr_head_sha}.`);
+
+      - name: Upload review event payload
+        uses: actions/upload-artifact@v4
+        with:
+          name: external-pr-review-gate-review
+          path: review-signal/review-event.json
+          if-no-files-found: error
+          retention-days: 1

--- a/docs/conventions/troubleshooting.md
+++ b/docs/conventions/troubleshooting.md
@@ -89,8 +89,10 @@ Use this shape for new entries:
   Keep the status-writing gate on trusted `pull_request_target` or
   `workflow_run` execution. If approvals must refresh the gate automatically,
   use a low-privilege `pull_request_review` signal workflow and a trusted
-  `workflow_run` refresh workflow that resolves the PR and calls the reusable
-  gate.
+  `workflow_run` refresh workflow. The signal workflow should call the reusable
+  signal workflow so it uploads the standard review artifact, and the refresh
+  workflow should call the reusable refresh workflow so PR identity resolution,
+  head-SHA validation, and the final reusable gate call stay centralized.
 - Validation:
   Confirm the old caller workflow no longer directly invokes the gate from
   `pull_request_review`. After an internal approval, expect a signal run and a


### PR DESCRIPTION
## Summary

- Add a reusable low-privilege external review signal workflow that uploads the PR identity artifact.
- Add a reusable trusted review refresh workflow that downloads the artifact, validates the PR/head SHA, and calls the existing external review gate.
- Keep the existing reusable gate focused on enforcing review status from normalized PR facts.
- Convert this repository's review signal and refresh workflows into thin callers of the reusable workflows.

## Verification

- `go run github.com/rhysd/actionlint/cmd/actionlint@latest .github/workflows/external-pr-review-gate.yml .github/workflows/external-pr-review-gate-review-signal.yml .github/workflows/external-pr-review-gate-review-refresh.yml .github/workflows/reusable-external-pr-review-gate.yml .github/workflows/reusable-external-pr-review-signal.yml .github/workflows/reusable-external-pr-review-refresh.yml`
- `git diff --check`
- YAML parse check for changed workflow files

## Notes

This cannot fix already-copied child repository signal workflows without a small caller update, because their current `pull_request_review` workflow only echoes and uploads no PR identity artifact. After this lands, child repositories can use thin callers instead of copying resolver JavaScript.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added reusable workflows for external PR review signaling and refresh, streamlining how review events are captured and processed.
  * The review signal flow now records standardized PR review details and uploads them as an artifact for later use.
  * The refresh flow now validates the latest PR state before updating review status.

* **Bug Fixes**
  * Improved reliability of review gate refreshes when PR review approvals change.

* **Documentation**
  * Updated troubleshooting guidance to match the new review signal and refresh workflow flow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->