### PR TITLE
feat(rich-text): share mention context helpers

### DIFF
--- a/apps/desktop/src/renderer/src/features/workspace-app-center/index.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-app-center/index.ts
@@ -5,6 +5,9 @@ export { findWorkspaceApp } from "./services/internal/workspaceAppCenterLaunchRe
 export {
   createWorkspaceAppCenterContribution,
   createWorkspaceAppCenterDockEntries,
+  readWorkspaceAppIdFromDockEntryId,
+  readWorkspaceAppIdFromInstanceId,
+  readWorkspaceAppIdFromNodeId,
   reportWorkspaceAppOpenedFromDockEntry,
   resolveWorkspaceAppDisplayName,
   workspaceAppBrowserPartitionPrefix,

--- a/apps/desktop/src/renderer/src/features/workspace-app-center/services/internal/workspaceAppCenterContribution.test.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-app-center/services/internal/workspaceAppCenterContribution.test.ts
@@ -10,11 +10,27 @@ import type {
 import { createWorkspaceAppWebviewBrowserLease } from "./workspaceAppWebviewBrowserAnalytics.ts";
 import { resolveWorkspaceAppWebviewUrl } from "./workspaceAppCenterWebviewUrl.ts";
 import {
+  readWorkspaceAppIdFromNodeId,
   reportWorkspaceAppOpenedFromDockEntry,
   resolveWorkspaceAppCenterLaunchRequest,
   workspaceAppDockEntryId,
+  workspaceAppWebviewInstanceId,
   workspaceAppWebviewTypeID
 } from "./workspaceAppCenterLaunchRequest.ts";
+
+test("workspace app node ids resolve app ids from dock and webview node formats", () => {
+  assert.equal(
+    readWorkspaceAppIdFromNodeId(workspaceAppDockEntryId("group-chat")),
+    "group-chat"
+  );
+  assert.equal(
+    readWorkspaceAppIdFromNodeId(
+      `${workspaceAppWebviewTypeID}:${workspaceAppWebviewInstanceId("group-chat")}`
+    ),
+    "group-chat"
+  );
+  assert.equal(readWorkspaceAppIdFromNodeId("browser:browser-1"), null);
+});
 
 test("workspace app contribution reports app open from dock launch requests", async () => {
   const reporterCalls: ReporterEventInput[][] = [];

--- a/apps/desktop/src/renderer/src/features/workspace-app-center/services/internal/workspaceAppCenterContribution.test.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-app-center/services/internal/workspaceAppCenterContribution.test.ts
@@ -8,6 +8,7 @@ import type {
   WorkspaceAppCenterReadableStoreState
 } from "@tutti-os/workspace-app-center";
 import { createWorkspaceAppWebviewBrowserLease } from "./workspaceAppWebviewBrowserAnalytics.ts";
+import { resolveWorkspaceAppWebviewUrl } from "./workspaceAppCenterWebviewUrl.ts";
 import {
   reportWorkspaceAppOpenedFromDockEntry,
   resolveWorkspaceAppCenterLaunchRequest,
@@ -115,6 +116,47 @@ test("workspace app launch request preserves prepared payload previous status", 
         }
       }
     ]
+  );
+});
+
+test("workspace app webview URL prefers the current launch URL over stale activation ports", () => {
+  assert.equal(
+    resolveWorkspaceAppWebviewUrl({
+      activation: {
+        payload: {
+          appId: "group-chat",
+          url: "http://127.0.0.1:4173/rooms/old"
+        },
+        sequence: 1,
+        type: "open-url"
+      },
+      appCanUseExternalState: true,
+      appLaunchUrl: "http://127.0.0.1:51234/",
+      externalNodeState: {
+        title: "Group Chat",
+        url: "http://127.0.0.1:4173/rooms/old"
+      }
+    }),
+    "http://127.0.0.1:51234/"
+  );
+});
+
+test("workspace app webview URL preserves same-origin activation deep links", () => {
+  assert.equal(
+    resolveWorkspaceAppWebviewUrl({
+      activation: {
+        payload: {
+          appId: "group-chat",
+          url: "http://127.0.0.1:51234/rooms/current"
+        },
+        sequence: 1,
+        type: "open-url"
+      },
+      appCanUseExternalState: true,
+      appLaunchUrl: "http://127.0.0.1:51234/",
+      externalNodeState: null
+    }),
+    "http://127.0.0.1:51234/rooms/current"
   );
 });
 

--- a/apps/desktop/src/renderer/src/features/workspace-app-center/services/internal/workspaceAppCenterContribution.tsx
+++ b/apps/desktop/src/renderer/src/features/workspace-app-center/services/internal/workspaceAppCenterContribution.tsx
@@ -39,6 +39,7 @@ import { workspaceAppWebviewFrame } from "./workspaceAppWebviewFrame.ts";
 import {
   findWorkspaceApp,
   readWorkspaceAppIdFromInstanceId,
+  readWorkspaceAppIdFromNodeId,
   resolveWorkspaceAppCenterLaunchRequest,
   resolveWorkspaceAppDisplayName,
   workspaceAppCenterNodeID,
@@ -50,6 +51,9 @@ import { shouldShowWorkspaceApp } from "../workspaceAppVisibility.ts";
 export const workspaceAppBrowserPartitionPrefix = "persist:tutti-app:";
 
 export {
+  readWorkspaceAppIdFromDockEntryId,
+  readWorkspaceAppIdFromInstanceId,
+  readWorkspaceAppIdFromNodeId,
   reportWorkspaceAppOpenedFromDockEntry,
   resolveWorkspaceAppDisplayName,
   workspaceAppCenterNodeID,
@@ -491,11 +495,4 @@ function workspaceAppBrowserSessionPartition(input: {
   return `${workspaceAppBrowserPartitionPrefix}${encodeURIComponent(
     input.workspaceId
   )}:${encodeURIComponent(input.appId)}`;
-}
-
-function readWorkspaceAppIdFromNodeId(value: string): string | null {
-  const prefix = `${workspaceAppWebviewTypeID}:`;
-  return value.startsWith(prefix)
-    ? readWorkspaceAppIdFromInstanceId(value.slice(prefix.length))
-    : null;
 }

--- a/apps/desktop/src/renderer/src/features/workspace-app-center/services/internal/workspaceAppCenterContribution.tsx
+++ b/apps/desktop/src/renderer/src/features/workspace-app-center/services/internal/workspaceAppCenterContribution.tsx
@@ -11,7 +11,6 @@ import { resolveWorkspaceAppStatusPresentation } from "@tutti-os/workspace-app-c
 import { createAppCenterI18nRuntime } from "@tutti-os/workspace-app-center/i18n";
 import type {
   WorkbenchContribution,
-  WorkbenchHostActivation,
   WorkbenchHostDockEntry,
   WorkbenchHostExternalStateLookupInput,
   WorkbenchHostExternalStateSource,
@@ -31,6 +30,11 @@ import {
 } from "./workspaceAppCenterDockOrdering.ts";
 import { projectWorkspaceAppCenterDockApps } from "./workspaceAppCenterDockProjection.ts";
 import { workspaceAppCenterFrame } from "./workspaceAppCenterFrame.ts";
+import {
+  readWorkspaceAppOpenPayload,
+  resolveWorkspaceAppWebviewUrl,
+  type WorkspaceAppWebviewExternalState
+} from "./workspaceAppCenterWebviewUrl.ts";
 import { workspaceAppWebviewFrame } from "./workspaceAppWebviewFrame.ts";
 import {
   findWorkspaceApp,
@@ -359,11 +363,6 @@ function WorkspaceAppWebviewLoadingState({
   );
 }
 
-interface WorkspaceAppWebviewExternalState {
-  title: string | null;
-  url: string | null;
-}
-
 type WorkspaceAppCenterExternalNodeState =
   | WorkspaceAppCenterViewState
   | WorkspaceAppWebviewExternalState
@@ -439,20 +438,6 @@ function readWorkspaceAppExternalState(
     : null;
 }
 
-function resolveWorkspaceAppWebviewUrl(input: {
-  activation: WorkbenchHostActivation | null;
-  appCanUseExternalState: boolean;
-  appLaunchUrl: string | null;
-  externalNodeState: WorkspaceAppWebviewExternalState | null;
-}): string {
-  return (
-    readWorkspaceAppOpenPayload(input.activation)?.url ??
-    normalizeWorkspaceAppUrl(input.appLaunchUrl) ??
-    (input.appCanUseExternalState ? input.externalNodeState?.url : null) ??
-    "about:blank"
-  );
-}
-
 function resolveWorkspaceAppWebviewNavigationPolicy(input: {
   appCenterService: IWorkspaceAppCenterService;
   appId: string;
@@ -497,30 +482,6 @@ function normalizeWorkspaceAppUrl(
 ): string | null {
   const trimmed = value?.trim() ?? "";
   return trimmed.length > 0 ? trimmed : null;
-}
-
-function readWorkspaceAppOpenPayload(
-  activation: WorkbenchHostActivation | null
-): { appId: string; title?: string; url: string } | null {
-  if (
-    activation?.type !== "open-url" ||
-    !activation.payload ||
-    typeof activation.payload !== "object"
-  ) {
-    return null;
-  }
-  const payload = activation.payload as {
-    appId?: unknown;
-    title?: unknown;
-    url?: unknown;
-  };
-  return typeof payload.appId === "string" && typeof payload.url === "string"
-    ? {
-        appId: payload.appId,
-        title: typeof payload.title === "string" ? payload.title : undefined,
-        url: payload.url
-      }
-    : null;
 }
 
 function workspaceAppBrowserSessionPartition(input: {

--- a/apps/desktop/src/renderer/src/features/workspace-app-center/services/internal/workspaceAppCenterLaunchRequest.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-app-center/services/internal/workspaceAppCenterLaunchRequest.ts
@@ -132,6 +132,18 @@ export function readWorkspaceAppIdFromInstanceId(
     : null;
 }
 
+export function readWorkspaceAppIdFromNodeId(
+  value: string | null | undefined
+): string | null {
+  const webviewPrefix = `${workspaceAppWebviewTypeID}:`;
+  return (
+    readWorkspaceAppIdFromDockEntryId(value) ??
+    (value?.startsWith(webviewPrefix)
+      ? readWorkspaceAppIdFromInstanceId(value.slice(webviewPrefix.length))
+      : null)
+  );
+}
+
 export function reportWorkspaceAppOpenedFromDockEntry(input: {
   appCenterService: IWorkspaceAppCenterService;
   entryId: string;

--- a/apps/desktop/src/renderer/src/features/workspace-app-center/services/internal/workspaceAppCenterWebviewUrl.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-app-center/services/internal/workspaceAppCenterWebviewUrl.ts
@@ -1,0 +1,67 @@
+import type { WorkbenchHostActivation } from "@tutti-os/workbench-surface";
+
+export interface WorkspaceAppWebviewExternalState {
+  title: string | null;
+  url: string | null;
+}
+
+export function resolveWorkspaceAppWebviewUrl(input: {
+  activation: WorkbenchHostActivation | null;
+  appCanUseExternalState: boolean;
+  appLaunchUrl: string | null;
+  externalNodeState: WorkspaceAppWebviewExternalState | null;
+}): string {
+  const activationUrl = normalizeWorkspaceAppUrl(
+    readWorkspaceAppOpenPayload(input.activation)?.url
+  );
+  const appLaunchUrl = normalizeWorkspaceAppUrl(input.appLaunchUrl);
+  if (appLaunchUrl) {
+    return activationUrl && hasSameUrlOrigin(activationUrl, appLaunchUrl)
+      ? activationUrl
+      : appLaunchUrl;
+  }
+  return (
+    activationUrl ??
+    (input.appCanUseExternalState ? input.externalNodeState?.url : null) ??
+    "about:blank"
+  );
+}
+
+function normalizeWorkspaceAppUrl(
+  value: string | null | undefined
+): string | null {
+  const trimmed = value?.trim() ?? "";
+  return trimmed.length > 0 ? trimmed : null;
+}
+
+function hasSameUrlOrigin(left: string, right: string): boolean {
+  try {
+    return new URL(left).origin === new URL(right).origin;
+  } catch {
+    return false;
+  }
+}
+
+export function readWorkspaceAppOpenPayload(
+  activation: WorkbenchHostActivation | null
+): { appId: string; title?: string; url: string } | null {
+  if (
+    activation?.type !== "open-url" ||
+    !activation.payload ||
+    typeof activation.payload !== "object"
+  ) {
+    return null;
+  }
+  const payload = activation.payload as {
+    appId?: unknown;
+    title?: unknown;
+    url?: unknown;
+  };
+  return typeof payload.appId === "string" && typeof payload.url === "string"
+    ? {
+        appId: payload.appId,
+        title: typeof payload.title === "string" ? payload.title : undefined,
+        url: payload.url
+      }
+    : null;
+}

--- a/apps/desktop/src/renderer/src/features/workspace-workbench/services/internal/contributions/appCenterWorkbenchContributionFactory.test.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/services/internal/contributions/appCenterWorkbenchContributionFactory.test.ts
@@ -166,6 +166,45 @@ test("workspace app browser feature keeps current app runtime URLs inside the ap
   ]);
 });
 
+test("workspace app browser feature keeps dock entry runtime URLs inside the app webview", async () => {
+  const requests: WorkspaceBrowserLaunchRequest[] = [];
+  let emitBrowserEvent = (_event: BrowserNodeEvent): void => undefined;
+  const browserApi = createBrowserApi({
+    onEvent(listener) {
+      emitBrowserEvent = listener;
+      return () => {
+        emitBrowserEvent = () => undefined;
+      };
+    }
+  });
+  createWorkspaceAppBrowserFeature({
+    browserApi,
+    browserService: createWorkspaceBrowserService({ browserApi }),
+    getAppLaunchUrlForNodeId: (nodeId) =>
+      nodeId === "workspace-app:group-chat" ? "http://127.0.0.1:4173/" : null,
+    runtimeApi: createRuntimeApi(),
+    workspaceId: "workspace-app-dock-entry-open-url"
+  });
+  const disposeLaunchHandler = registerWorkspaceBrowserLaunchHandler(
+    "workspace-app-dock-entry-open-url",
+    (request) => {
+      requests.push(request);
+      return true;
+    }
+  );
+
+  emitBrowserEvent({
+    reuseIfOpen: true,
+    sourceNodeId: "workspace-app:group-chat",
+    type: "open-url",
+    url: "http://127.0.0.1:4173/rooms/123"
+  });
+  await Promise.resolve();
+
+  disposeLaunchHandler();
+  assert.deepEqual(requests, []);
+});
+
 test("workspace app browser feature ignores workspace browser open-url events", async () => {
   const requests: WorkspaceBrowserLaunchRequest[] = [];
   let emitBrowserEvent = (_event: BrowserNodeEvent): void => undefined;

--- a/apps/desktop/src/renderer/src/features/workspace-workbench/services/internal/contributions/appCenterWorkbenchContributionFactory.test.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/services/internal/contributions/appCenterWorkbenchContributionFactory.test.ts
@@ -112,6 +112,60 @@ test("workspace app browser feature launches workspace app window-open events", 
   ]);
 });
 
+test("workspace app browser feature keeps current app runtime URLs inside the app webview", async () => {
+  const requests: WorkspaceBrowserLaunchRequest[] = [];
+  let emitBrowserEvent = (_event: BrowserNodeEvent): void => undefined;
+  const browserApi = createBrowserApi({
+    onEvent(listener) {
+      emitBrowserEvent = listener;
+      return () => {
+        emitBrowserEvent = () => undefined;
+      };
+    }
+  });
+  createWorkspaceAppBrowserFeature({
+    browserApi,
+    browserService: createWorkspaceBrowserService({ browserApi }),
+    getAppLaunchUrlForNodeId: (nodeId) =>
+      nodeId === "workspace-app-webview:app:group-chat"
+        ? "http://127.0.0.1:4173/"
+        : null,
+    runtimeApi: createRuntimeApi(),
+    workspaceId: "workspace-app-runtime-open-url"
+  });
+  const disposeLaunchHandler = registerWorkspaceBrowserLaunchHandler(
+    "workspace-app-runtime-open-url",
+    (request) => {
+      requests.push(request);
+      return true;
+    }
+  );
+
+  emitBrowserEvent({
+    reuseIfOpen: true,
+    sourceNodeId: "workspace-app-webview:app:group-chat",
+    type: "open-url",
+    url: "http://127.0.0.1:4173/rooms/123"
+  });
+  emitBrowserEvent({
+    reuseIfOpen: true,
+    sourceNodeId: "workspace-app-webview:app:group-chat",
+    type: "open-url",
+    url: "http://127.0.0.1:5678/local-preview"
+  });
+  await Promise.resolve();
+
+  disposeLaunchHandler();
+  assert.deepEqual(requests, [
+    {
+      reuseIfOpen: true,
+      source: "workspace_app",
+      url: "http://127.0.0.1:5678/local-preview",
+      workspaceId: "workspace-app-runtime-open-url"
+    }
+  ]);
+});
+
 test("workspace app browser feature ignores workspace browser open-url events", async () => {
   const requests: WorkspaceBrowserLaunchRequest[] = [];
   let emitBrowserEvent = (_event: BrowserNodeEvent): void => undefined;

--- a/apps/desktop/src/renderer/src/features/workspace-workbench/services/internal/contributions/appCenterWorkbenchContributionFactory.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/services/internal/contributions/appCenterWorkbenchContributionFactory.ts
@@ -3,8 +3,7 @@ import type { BrowserNodeFeature } from "@tutti-os/browser-node";
 import type { I18nRuntime } from "@tutti-os/ui-i18n-runtime";
 import {
   createWorkspaceAppCenterContribution,
-  workspaceAppWebviewInstanceId,
-  workspaceAppWebviewTypeID
+  readWorkspaceAppIdFromNodeId
 } from "@renderer/features/workspace-app-center";
 import type { IWorkspaceAppCenterService } from "@renderer/features/workspace-app-center";
 import type { DesktopBrowserApi, DesktopRuntimeApi } from "@preload/types";
@@ -86,11 +85,12 @@ function resolveWorkspaceAppLaunchUrlForNodeId(
   appCenterService: IWorkspaceAppCenterService,
   nodeId: string
 ): string | null {
+  const appId = readWorkspaceAppIdFromNodeId(nodeId);
+  if (!appId) {
+    return null;
+  }
   for (const app of appCenterService.store.apps) {
-    if (
-      nodeId ===
-      `${workspaceAppWebviewTypeID}:${workspaceAppWebviewInstanceId(app.appId)}`
-    ) {
+    if (app.appId === appId) {
       return app.launchUrl ?? null;
     }
   }

--- a/apps/desktop/src/renderer/src/features/workspace-workbench/services/internal/contributions/appCenterWorkbenchContributionFactory.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/services/internal/contributions/appCenterWorkbenchContributionFactory.ts
@@ -1,12 +1,18 @@
 import type { DesktopWorkbenchContributionFactory } from "../workspaceWorkbenchContributionFactory";
 import type { BrowserNodeFeature } from "@tutti-os/browser-node";
 import type { I18nRuntime } from "@tutti-os/ui-i18n-runtime";
-import { createWorkspaceAppCenterContribution } from "@renderer/features/workspace-app-center";
+import {
+  createWorkspaceAppCenterContribution,
+  workspaceAppWebviewInstanceId,
+  workspaceAppWebviewTypeID
+} from "@renderer/features/workspace-app-center";
+import type { IWorkspaceAppCenterService } from "@renderer/features/workspace-app-center";
 import type { DesktopBrowserApi, DesktopRuntimeApi } from "@preload/types";
 import { createWorkspaceAppBrowserFeature } from "./workspaceAppBrowserFeature.ts";
 import type { WorkspaceBrowserService } from "../workspaceBrowserService.ts";
 
 interface CachedWorkspaceAppBrowserFeature {
+  appCenterService: IWorkspaceAppCenterService;
   browserApi: DesktopBrowserApi;
   feature: BrowserNodeFeature;
   runtimeApi: Pick<DesktopRuntimeApi, "logRendererDiagnostic">;
@@ -26,6 +32,7 @@ export const appCenterWorkbenchContributionFactory: DesktopWorkbenchContribution
         ? createWorkspaceAppCenterContribution({
             appCenterService: context.appCenterService,
             browserFeature: resolveWorkspaceAppBrowserFeature({
+              appCenterService: context.appCenterService,
               browserApi: context.browserApi,
               browserService: context.browserService,
               i18n: context.appI18n,
@@ -41,6 +48,7 @@ export const appCenterWorkbenchContributionFactory: DesktopWorkbenchContribution
   };
 
 function resolveWorkspaceAppBrowserFeature(input: {
+  appCenterService: IWorkspaceAppCenterService;
   browserApi: DesktopBrowserApi;
   browserService: WorkspaceBrowserService;
   i18n?: I18nRuntime<string>;
@@ -49,6 +57,7 @@ function resolveWorkspaceAppBrowserFeature(input: {
 }): BrowserNodeFeature {
   const cached = browserFeaturesByWorkspaceId.get(input.workspaceId);
   if (
+    cached?.appCenterService === input.appCenterService &&
     cached?.browserApi === input.browserApi &&
     cached.runtimeApi === input.runtimeApi
   ) {
@@ -58,14 +67,32 @@ function resolveWorkspaceAppBrowserFeature(input: {
   const feature = createWorkspaceAppBrowserFeature({
     browserApi: input.browserApi,
     browserService: input.browserService,
+    getAppLaunchUrlForNodeId: (nodeId) =>
+      resolveWorkspaceAppLaunchUrlForNodeId(input.appCenterService, nodeId),
     i18n: input.i18n,
     runtimeApi: input.runtimeApi,
     workspaceId: input.workspaceId
   });
   browserFeaturesByWorkspaceId.set(input.workspaceId, {
+    appCenterService: input.appCenterService,
     browserApi: input.browserApi,
     feature,
     runtimeApi: input.runtimeApi
   });
   return feature;
+}
+
+function resolveWorkspaceAppLaunchUrlForNodeId(
+  appCenterService: IWorkspaceAppCenterService,
+  nodeId: string
+): string | null {
+  for (const app of appCenterService.store.apps) {
+    if (
+      nodeId ===
+      `${workspaceAppWebviewTypeID}:${workspaceAppWebviewInstanceId(app.appId)}`
+    ) {
+      return app.launchUrl ?? null;
+    }
+  }
+  return null;
 }

--- a/apps/desktop/src/renderer/src/features/workspace-workbench/services/internal/contributions/workspaceAppBrowserFeature.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/services/internal/contributions/workspaceAppBrowserFeature.ts
@@ -11,13 +11,15 @@ import type { WorkspaceBrowserService } from "../workspaceBrowserService.ts";
 export function createWorkspaceAppBrowserFeature(input: {
   browserApi: DesktopBrowserApi;
   browserService: WorkspaceBrowserService;
+  getAppLaunchUrlForNodeId?: (nodeId: string) => string | null | undefined;
   i18n?: I18nRuntime<string>;
   runtimeApi: Pick<DesktopRuntimeApi, "logRendererDiagnostic">;
   workspaceId: string;
 }): BrowserNodeFeature {
   const feature = createBrowserNodeFeature({
     hostApi: input.browserService.createFeatureHostApi({
-      acceptsEvent: isWorkspaceAppBrowserEvent,
+      acceptsEvent: (event) =>
+        isWorkspaceAppBrowserEvent(event, input.getAppLaunchUrlForNodeId),
       source: "workspace_app",
       workspaceId: input.workspaceId
     }),
@@ -38,10 +40,35 @@ export function createWorkspaceAppBrowserFeature(input: {
   return feature;
 }
 
-function isWorkspaceAppBrowserEvent(event: BrowserNodeEvent): boolean {
+function isWorkspaceAppBrowserEvent(
+  event: BrowserNodeEvent,
+  getAppLaunchUrlForNodeId:
+    | ((nodeId: string) => string | null | undefined)
+    | undefined
+): boolean {
   const nodeId = event.type === "open-url" ? event.sourceNodeId : event.nodeId;
-  return (
+  const isWorkspaceAppNode =
     nodeId.startsWith(`${workspaceAppWebviewTypeID}:`) ||
-    nodeId.startsWith("workspace-app:")
-  );
+    nodeId.startsWith("workspace-app:");
+  if (!isWorkspaceAppNode) {
+    return false;
+  }
+  if (
+    event.type === "open-url" &&
+    hasSameUrlOrigin(event.url, getAppLaunchUrlForNodeId?.(nodeId))
+  ) {
+    return false;
+  }
+  return true;
+}
+
+function hasSameUrlOrigin(
+  left: string,
+  right: string | null | undefined
+): boolean {
+  try {
+    return right != null && new URL(left).origin === new URL(right).origin;
+  } catch {
+    return false;
+  }
 }

--- a/packages/ui/rich-text/README.md
+++ b/packages/ui/rich-text/README.md
@@ -160,20 +160,161 @@ Current runtime behavior:
 - mention hydration uses `resolveMention` when the owning trigger provider is
   available and keeps the label-only fallback when it is not
 
-## At-Panel Migration
+## External At-Panel Integration
 
-The `@tutti-os/ui-rich-text/at-panel` subpath now exposes the shared mention
-palette shell through:
+External apps should treat `@tutti-os/ui-rich-text` as the generic trigger and
+palette shell, not as an app-domain data source. The app still owns what can be
+mentioned, how those items are queried, and what gets inserted.
 
-- `MentionPaletteFromState`
-- `createMentionPaletteStateAdapter`
-- `buildMentionPaletteModel`
-- `buildMentionPaletteModelFromTriggerMatches`
-- `richTextTriggerQueryMatchToMentionRowItem`
+Tutti workspace apps that already receive mention candidates from
+`window.tuttiExternal.at.query()` should adapt that bridge through
+`@tutti-os/workspace-external-core/rich-text`:
 
-Older helpers such as `buildMentionPaletteState`, `searchHelpers`, and
-`RichTextAt*` grouping aliases were removed with the legacy flat grouping model.
-Consumers should build category/section config with
-`MentionPaletteCategoryConfig`, derive state with
-`buildMentionPaletteModelFromTriggerMatches`, and keep app-specific copy,
-i18n, provider selection, and insertion behavior in the host application.
+```ts
+import { createTuttiExternalAtRichTextTriggerProviders } from "@tutti-os/workspace-external-core/rich-text";
+
+const providers = createTuttiExternalAtRichTextTriggerProviders({
+  bridge: window.tuttiExternal,
+  providerIds: ["workspace-app", "agent-session"]
+});
+```
+
+Use a custom `RichTextTriggerProvider` only for app-local mention sources or for
+apps that do not use the Tutti external bridge.
+
+Minimum integration checklist:
+
+1. Install the package and load the panel CSS once from the app entry point:
+
+   ```ts
+   import "@tutti-os/ui-rich-text/at-panel/index.css";
+   ```
+
+2. Provide one or more `RichTextTriggerProvider`s for the app's mentionable
+   domains. Host-provided Tutti workspace mentions can come from
+   `createTuttiExternalAtRichTextTriggerProviders`; app-local domains can define
+   providers directly. A provider owns querying, stable keys, visible labels,
+   optional subtitles/icons/keywords, insertion mapping, and optional reverse
+   resolution:
+
+   ```ts
+   import type { RichTextTriggerProvider } from "@tutti-os/ui-rich-text/types";
+
+   const providers: RichTextTriggerProvider[] = [
+     {
+       id: "primary-record",
+       trigger: "@",
+       query: async ({ keyword, context }) => searchRecords(keyword, context),
+       getItemKey: (record) => record.id,
+       getItemLabel: (record) => record.title,
+       getItemSubtitle: (record) => record.subtitle,
+       getItemIconUrl: (record) => record.iconUrl,
+       toInsertResult: (record) => ({
+         kind: "mention",
+         mention: {
+           entityId: record.id,
+           label: record.title,
+           scope: { ownerId: record.ownerId }
+         }
+       })
+     }
+   ];
+   ```
+
+3. Query those providers through the rich-text trigger registry or an
+   equivalent host bridge and keep the results as
+   `RichTextTriggerQueryMatch[]`. Provider ordering remains host-owned. The
+   palette only renders the matches it is given.
+
+4. Define palette categories in the app. A category is the top-level tab/filter;
+   optional `sections` become second-level groups inside the active category.
+   When sections are present, each match is assigned to the first matching
+   section in declaration order. A category without sections renders as a
+   single group:
+
+   ```ts
+   import type { MentionPaletteCategoryConfig } from "@tutti-os/ui-rich-text/at-panel";
+
+   const categories: MentionPaletteCategoryConfig[] = [
+     {
+       id: "primary",
+       label: t("mentions.primary"),
+       providerIds: ["primary-record"],
+       sections: [
+         {
+           id: "recent",
+           label: t("mentions.recent"),
+           matches: (match) => match.item.bucket === "recent"
+         },
+         {
+           id: "all",
+           label: t("mentions.all"),
+           matches: (match) => match.item.bucket !== "recent"
+         }
+       ]
+     },
+     {
+       id: "secondary",
+       label: t("mentions.secondary"),
+       providerIds: ["secondary-record"]
+     }
+   ];
+   ```
+
+5. Convert matches into palette state and render the shared shell:
+
+   ```tsx
+   import {
+     MentionPaletteFromState,
+     buildMentionPaletteModelFromTriggerMatches,
+     renderMentionRow,
+     richTextTriggerQueryMatchToMentionRowItem
+   } from "@tutti-os/ui-rich-text/at-panel";
+
+   const state = buildMentionPaletteModelFromTriggerMatches({
+     activeCategoryId,
+     categories,
+     matches,
+     loading,
+     query
+   });
+
+   <MentionPaletteFromState
+     state={state}
+     highlightedKey={highlightedKey}
+     getItemKey={(match, groupId) => `${match.providerId}:${match.key}`}
+     callbacks={{
+       onActiveCategoryIdChange: setActiveCategoryId,
+       onHighlightChange: setHighlightedKey,
+       onSelectItem: commitMatch
+     }}
+     labels={{
+       empty: t("mentions.empty"),
+       loading: t("mentions.loading")
+     }}
+     hintLabels={{
+       cycleFilter: t("mentions.switchCategory"),
+       moveSelection: t("mentions.switchSelection")
+     }}
+     maxHeightPx={360}
+     renderItem={(match) =>
+       renderMentionRow(
+         richTextTriggerQueryMatchToMentionRowItem(match, {
+           getDescription: (candidate) => candidate.subtitle,
+           renderLeading: (ctx) => renderAppSpecificLeading(ctx)
+         })
+       )
+     }
+   />;
+   ```
+
+6. Wire keyboard handling to the state adapter or to `makeAtPanelKeyDown`.
+   External apps should keep the exact shortcut policy local; the shared shell
+   supports moving selection, cycling categories, expanding groups, and
+   committing the highlighted item.
+
+7. Keep app-owned behavior outside the package. This includes i18n strings,
+   item-specific icons or avatars, domain data fetches, cache refresh policy,
+   app-local bridge calls, and the final insertion side effects. Use
+   `renderLeading`, `getDescription`, status helpers, and category/section
+   config as customization slots instead of forking the panel shell.

--- a/packages/ui/rich-text/package.json
+++ b/packages/ui/rich-text/package.json
@@ -59,32 +59,39 @@
     "exports": {
       ".": {
         "types": "./dist/index.d.ts",
-        "import": "./dist/index.js"
+        "import": "./dist/index.js",
+        "default": "./dist/index.js"
       },
       "./at-panel": {
         "types": "./dist/at-panel/index.d.ts",
-        "import": "./dist/at-panel/index.js"
+        "import": "./dist/at-panel/index.js",
+        "default": "./dist/at-panel/index.js"
       },
       "./at-panel/index.css": "./dist/at-panel/index.css",
       "./at-panel/model": {
         "types": "./dist/at-panel/model.d.ts",
-        "import": "./dist/at-panel/model.js"
+        "import": "./dist/at-panel/model.js",
+        "default": "./dist/at-panel/model.js"
       },
       "./core": {
         "types": "./dist/core/index.d.ts",
-        "import": "./dist/core/index.js"
+        "import": "./dist/core/index.js",
+        "default": "./dist/core/index.js"
       },
       "./editor": {
         "types": "./dist/editor/index.d.ts",
-        "import": "./dist/editor/index.js"
+        "import": "./dist/editor/index.js",
+        "default": "./dist/editor/index.js"
       },
       "./plugins": {
         "types": "./dist/plugins/index.d.ts",
-        "import": "./dist/plugins/index.js"
+        "import": "./dist/plugins/index.js",
+        "default": "./dist/plugins/index.js"
       },
       "./types": {
         "types": "./dist/types/index.d.ts",
-        "import": "./dist/types/index.js"
+        "import": "./dist/types/index.js",
+        "default": "./dist/types/index.js"
       }
     },
     "types": "./dist/index.d.ts",

--- a/packages/ui/rich-text/src/core/richTextDocument.test.ts
+++ b/packages/ui/rich-text/src/core/richTextDocument.test.ts
@@ -12,6 +12,8 @@ import {
   parseRichTextMentionHref,
   removeRichTextLinkFromContent,
   removeRichTextMentionFromContent,
+  sanitizeRichTextMentionForAgentContext,
+  sanitizeRichTextMentionScopeForAgentContext,
   serializeRichTextDocumentToContent
 } from "./richTextDocument.ts";
 import { createRichTextMentionAttrs } from "../plugins/mention.ts";
@@ -74,6 +76,48 @@ test("does not serialize reserved mention scope fields", () => {
   assert.equal(
     createRichTextMentionHref(mention),
     "mention://provider/entity?workspaceId=ws_1"
+  );
+});
+
+test("sanitizes rich text mention scope for agent context", () => {
+  assert.deepEqual(
+    sanitizeRichTextMentionScopeForAgentContext({
+      workspaceId: " ws_1 ",
+      topicId: "topic_1",
+      iconUrl: "data:image/png;base64,weather",
+      thumbnailUrl: "https://example.test/thumb.png",
+      link: "/apps/weather",
+      "meta.source": "presentation",
+      large: "x".repeat(2049),
+      empty: "",
+      objectValue: { id: "not-string" }
+    }),
+    {
+      topicId: "topic_1",
+      workspaceId: "ws_1"
+    }
+  );
+});
+
+test("sanitizes rich text mention identity for agent context", () => {
+  assert.deepEqual(
+    sanitizeRichTextMentionForAgentContext({
+      providerId: " workspace-app ",
+      entityId: " weather ",
+      label: " @Weather ",
+      scope: {
+        workspaceId: "ws_1",
+        iconUrl: "data:image/png;base64,weather"
+      }
+    }),
+    {
+      providerId: "workspace-app",
+      entityId: "weather",
+      label: "Weather",
+      scope: {
+        workspaceId: "ws_1"
+      }
+    }
   );
 });
 

--- a/packages/ui/rich-text/src/core/richTextDocument.test.ts
+++ b/packages/ui/rich-text/src/core/richTextDocument.test.ts
@@ -84,9 +84,10 @@ test("sanitizes rich text mention scope for agent context", () => {
     sanitizeRichTextMentionScopeForAgentContext({
       workspaceId: " ws_1 ",
       topicId: "topic_1",
-      iconUrl: "data:image/png;base64,weather",
+      iconUrl: "DATA:image/png;base64,weather",
       thumbnailUrl: "https://example.test/thumb.png",
       link: "/apps/weather",
+      sourceUrl: "Blob:https://example.test/source",
       "meta.source": "presentation",
       large: "x".repeat(2049),
       empty: "",

--- a/packages/ui/rich-text/src/core/richTextDocument.ts
+++ b/packages/ui/rich-text/src/core/richTextDocument.ts
@@ -40,6 +40,24 @@ const RESERVED_MENTION_SCOPE_KEYS = new Set([
   "v",
   "version"
 ]);
+const PRESENTATION_MENTION_CONTEXT_KEYS = new Set([
+  "agentIconUrl",
+  "iconUrl",
+  "thumbnailUrl",
+  "userAvatarPlaceholderUrl"
+]);
+const DEFAULT_MENTION_CONTEXT_MAX_VALUE_LENGTH = 2048;
+
+export interface RichTextMentionAgentContext {
+  providerId: string;
+  entityId: string;
+  label: string;
+  scope?: Readonly<Record<string, string>>;
+}
+
+export interface SanitizeRichTextMentionContextOptions {
+  maxValueLength?: number;
+}
 
 type LegacyJSONContentNode = {
   type?: string;
@@ -160,6 +178,78 @@ function normalizeMentionLabel(value: string): string {
 
 function isReservedMentionScopeKey(key: string): boolean {
   return RESERVED_MENTION_SCOPE_KEYS.has(key) || key.startsWith("meta.");
+}
+
+function isPresentationMentionContextKey(key: string): boolean {
+  return PRESENTATION_MENTION_CONTEXT_KEYS.has(key);
+}
+
+function isUnsafeMentionContextValue(value: string, maxValueLength: number) {
+  return (
+    value.length > maxValueLength ||
+    value.startsWith("data:") ||
+    value.startsWith("blob:")
+  );
+}
+
+export function sanitizeRichTextMentionScopeForAgentContext(
+  scope?: Readonly<Record<string, unknown>> | null,
+  options: SanitizeRichTextMentionContextOptions = {}
+): Record<string, string> | undefined {
+  if (!scope) {
+    return undefined;
+  }
+  const maxValueLength =
+    options.maxValueLength && options.maxValueLength > 0
+      ? options.maxValueLength
+      : DEFAULT_MENTION_CONTEXT_MAX_VALUE_LENGTH;
+  const nextScope: Record<string, string> = {};
+  for (const [key, value] of Object.entries(scope).sort(([left], [right]) =>
+    left.localeCompare(right)
+  )) {
+    const nextKey = key.trim();
+    if (
+      !nextKey ||
+      isReservedMentionScopeKey(nextKey) ||
+      isPresentationMentionContextKey(nextKey) ||
+      typeof value !== "string"
+    ) {
+      continue;
+    }
+    const nextValue = value.trim();
+    if (!nextValue || isUnsafeMentionContextValue(nextValue, maxValueLength)) {
+      continue;
+    }
+    nextScope[nextKey] = nextValue;
+  }
+  return Object.keys(nextScope).length ? nextScope : undefined;
+}
+
+export function sanitizeRichTextMentionForAgentContext(
+  mention: {
+    providerId?: string | null;
+    entityId?: string | null;
+    label?: string | null;
+    scope?: Readonly<Record<string, unknown>> | null;
+  },
+  options: SanitizeRichTextMentionContextOptions = {}
+): RichTextMentionAgentContext | undefined {
+  const providerId = mention.providerId?.trim() ?? "";
+  const entityId = mention.entityId?.trim() ?? "";
+  const label = normalizeMentionLabel(mention.label ?? "") || entityId;
+  if (!providerId || !entityId || !label) {
+    return undefined;
+  }
+  const scope = sanitizeRichTextMentionScopeForAgentContext(
+    mention.scope,
+    options
+  );
+  return {
+    providerId,
+    entityId,
+    label,
+    ...(scope ? { scope } : {})
+  };
 }
 
 function createMentionQueryParams(

--- a/packages/ui/rich-text/src/core/richTextDocument.ts
+++ b/packages/ui/rich-text/src/core/richTextDocument.ts
@@ -185,10 +185,11 @@ function isPresentationMentionContextKey(key: string): boolean {
 }
 
 function isUnsafeMentionContextValue(value: string, maxValueLength: number) {
+  const normalizedValue = value.toLowerCase();
   return (
     value.length > maxValueLength ||
-    value.startsWith("data:") ||
-    value.startsWith("blob:")
+    normalizedValue.startsWith("data:") ||
+    normalizedValue.startsWith("blob:")
   );
 }
 

--- a/packages/workspace/external-core/README.md
+++ b/packages/workspace/external-core/README.md
@@ -25,3 +25,26 @@ trusted app APIs may read or update host workspace state directly.
   state.
 - `workspace.openFeature()` for user-activated host workspace navigation, such as opening the message center.
 - `logs.write()` for fire-and-forget frontend diagnostics that append to the workspace app `web.log`.
+
+## Rich Text At Providers
+
+Workspace apps that use `@tutti-os/ui-rich-text` can adapt host mention
+candidates from `window.tuttiExternal.at.query()` directly into rich-text trigger
+providers:
+
+```ts
+import { createTuttiExternalAtRichTextTriggerProviders } from "@tutti-os/workspace-external-core/rich-text";
+
+const triggerProviders = createTuttiExternalAtRichTextTriggerProviders({
+  bridge: window.tuttiExternal,
+  providerIds: ["workspace-app", "agent-session", "agent-generated-file"]
+});
+```
+
+Each external at provider becomes one `RichTextTriggerProvider` with the same
+provider id. This keeps rich-text categories and sections aligned with the host
+contract, while the app still owns local-only mention sources, caching policy,
+i18n labels, palette categories, row rendering, and insertion side effects.
+
+See `@tutti-os/ui-rich-text` for the generic trigger-provider and at-panel
+contracts.

--- a/packages/workspace/external-core/package.json
+++ b/packages/workspace/external-core/package.json
@@ -7,7 +7,8 @@
   "exports": {
     ".": "./src/index.ts",
     "./contracts": "./src/contracts/index.ts",
-    "./core": "./src/core/index.ts"
+    "./core": "./src/core/index.ts",
+    "./rich-text": "./src/rich-text/index.ts"
   },
   "files": [
     "dist",
@@ -24,6 +25,7 @@
     "typecheck": "node ../../../tools/scripts/run-tsgo-typecheck.mjs"
   },
   "dependencies": {
+    "@tutti-os/ui-rich-text": "workspace:*",
     "@tutti-os/workspace-file-reference": "workspace:*",
     "@tutti-os/workspace-user-project": "workspace:*"
   },
@@ -46,8 +48,25 @@
       "./core": {
         "types": "./dist/core/index.d.ts",
         "import": "./dist/core/index.js"
+      },
+      "./rich-text": {
+        "types": "./dist/rich-text/index.d.ts",
+        "import": "./dist/rich-text/index.js"
       }
     },
-    "types": "./dist/index.d.ts"
+    "types": "./dist/index.d.ts",
+    "typesVersions": {
+      "*": {
+        "contracts": [
+          "./dist/contracts/index.d.ts"
+        ],
+        "core": [
+          "./dist/core/index.d.ts"
+        ],
+        "rich-text": [
+          "./dist/rich-text/index.d.ts"
+        ]
+      }
+    }
   }
 }

--- a/packages/workspace/external-core/src/index.ts
+++ b/packages/workspace/external-core/src/index.ts
@@ -1,2 +1,3 @@
 export type * from "./contracts/index.ts";
 export * from "./core/index.ts";
+export * from "./rich-text/index.ts";

--- a/packages/workspace/external-core/src/rich-text/index.test.ts
+++ b/packages/workspace/external-core/src/rich-text/index.test.ts
@@ -1,0 +1,159 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  createTuttiExternalAtRichTextTriggerProvider,
+  createTuttiExternalAtRichTextTriggerProviders,
+  queryTuttiExternalAtRichTextTriggerItems
+} from "./index.ts";
+import type {
+  TuttiExternalAtQueryInput,
+  TuttiExternalAtQueryResult
+} from "../contracts/index.ts";
+
+test("creates one rich text provider per requested external at provider", () => {
+  const providers = createTuttiExternalAtRichTextTriggerProviders({
+    bridge: null,
+    providerIds: ["workspace-app", "agent-session"]
+  });
+
+  assert.deepEqual(
+    providers.map((provider) => provider.id),
+    ["workspace-app", "agent-session"]
+  );
+  assert.deepEqual(
+    providers.map((provider) => provider.trigger),
+    ["@", "@"]
+  );
+});
+
+test("queries the external bridge with the provider filter", async () => {
+  const calls: TuttiExternalAtQueryInput[] = [];
+  const provider = createTuttiExternalAtRichTextTriggerProvider({
+    providerId: "workspace-app",
+    bridge: {
+      at: {
+        query(input) {
+          calls.push(input);
+          return [
+            createQueryResult("workspace-app", "apps", "Apps"),
+            createQueryResult("agent-session", "session", "Session")
+          ];
+        }
+      }
+    }
+  });
+
+  const results = await provider.query({
+    keyword: "app",
+    maxResults: 5,
+    context: {},
+    trigger: "@"
+  });
+
+  assert.deepEqual(calls, [
+    {
+      keyword: "app",
+      maxResults: 5,
+      providers: ["workspace-app"]
+    }
+  ]);
+  assert.deepEqual(
+    results.map((item) => item.providerId),
+    ["workspace-app"]
+  );
+});
+
+test("queries multiple external at providers with one bridge call", async () => {
+  const calls: TuttiExternalAtQueryInput[] = [];
+  const results = await queryTuttiExternalAtRichTextTriggerItems({
+    keyword: "a",
+    maxResults: 10,
+    providerIds: ["workspace-app", "agent-session"],
+    bridge: {
+      at: {
+        query(input) {
+          calls.push(input);
+          return [
+            createQueryResult("workspace-app", "apps", "Apps"),
+            createQueryResult("agent-session", "session", "Session"),
+            createQueryResult("file", "README.md", "README.md")
+          ];
+        }
+      }
+    }
+  });
+
+  assert.deepEqual(calls, [
+    {
+      keyword: "a",
+      maxResults: 10,
+      providers: ["workspace-app", "agent-session"]
+    }
+  ]);
+  assert.deepEqual(
+    results.map((item) => item.providerId),
+    ["workspace-app", "agent-session"]
+  );
+});
+
+test("maps query results to the rich text trigger provider shape", () => {
+  const provider = createTuttiExternalAtRichTextTriggerProvider({
+    providerId: "agent-session",
+    bridge: null
+  });
+  const item = createQueryResult("agent-session", "run-1", "Run 1", {
+    subtitle: "created",
+    thumbnailUrl: "https://example.test/run.png"
+  });
+
+  assert.equal(provider.getItemKey(item), "run-1");
+  assert.equal(provider.getItemLabel(item), "Run 1");
+  assert.equal(provider.getItemSubtitle?.(item), "created");
+  assert.equal(provider.getItemIconUrl?.(item), "https://example.test/run.png");
+  assert.deepEqual(provider.toInsertResult(item), item.insert);
+});
+
+test("uses mention presentation icons when thumbnailUrl is absent", () => {
+  const provider = createTuttiExternalAtRichTextTriggerProvider({
+    providerId: "agent-session",
+    bridge: null
+  });
+  const item = createQueryResult("agent-session", "run-1", "Run 1", {
+    insert: {
+      kind: "mention",
+      mention: {
+        entityId: "run-1",
+        label: "Run 1",
+        presentation: {
+          iconUrl: "https://example.test/icon.png"
+        }
+      }
+    }
+  });
+
+  assert.equal(
+    provider.getItemIconUrl?.(item),
+    "https://example.test/icon.png"
+  );
+});
+
+function createQueryResult(
+  providerId: TuttiExternalAtQueryResult["providerId"],
+  itemId: string,
+  label: string,
+  overrides: Partial<TuttiExternalAtQueryResult> = {}
+): TuttiExternalAtQueryResult {
+  return {
+    providerId,
+    itemId,
+    label,
+    insert: {
+      kind: "mention",
+      mention: {
+        entityId: itemId,
+        label
+      }
+    },
+    ...overrides
+  };
+}

--- a/packages/workspace/external-core/src/rich-text/index.test.ts
+++ b/packages/workspace/external-core/src/rich-text/index.test.ts
@@ -96,6 +96,37 @@ test("queries multiple external at providers with one bridge call", async () => 
   );
 });
 
+test("preserves an explicit empty external at provider filter", async () => {
+  const calls: TuttiExternalAtQueryInput[] = [];
+  const results = await queryTuttiExternalAtRichTextTriggerItems({
+    keyword: "a",
+    providerIds: [],
+    bridge: {
+      at: {
+        query(input) {
+          calls.push(input);
+          return [createQueryResult("workspace-app", "apps", "Apps")];
+        }
+      }
+    }
+  });
+
+  assert.deepEqual(calls, [
+    {
+      keyword: "a",
+      providers: []
+    }
+  ]);
+  assert.deepEqual(results, []);
+  assert.deepEqual(
+    createTuttiExternalAtRichTextTriggerProviders({
+      bridge: null,
+      providerIds: []
+    }),
+    []
+  );
+});
+
 test("maps query results to the rich text trigger provider shape", () => {
   const provider = createTuttiExternalAtRichTextTriggerProvider({
     providerId: "agent-session",

--- a/packages/workspace/external-core/src/rich-text/index.ts
+++ b/packages/workspace/external-core/src/rich-text/index.ts
@@ -1,0 +1,100 @@
+import {
+  tuttiExternalAtProviderIds,
+  type TuttiExternalAtProviderId,
+  type TuttiExternalAtQueryInput,
+  type TuttiExternalAtQueryResult
+} from "../contracts/index.ts";
+import type {
+  RichTextTriggerInsertResult,
+  RichTextTriggerProvider
+} from "@tutti-os/ui-rich-text/types";
+
+export interface TuttiExternalAtRichTextBridge {
+  at?: {
+    query(
+      input: TuttiExternalAtQueryInput
+    ):
+      | Promise<readonly TuttiExternalAtQueryResult[]>
+      | readonly TuttiExternalAtQueryResult[];
+  };
+}
+
+export interface CreateTuttiExternalAtRichTextTriggerProviderInput {
+  bridge: TuttiExternalAtRichTextBridge | null | undefined;
+  providerId: TuttiExternalAtProviderId;
+  maxResults?: number;
+}
+
+export interface CreateTuttiExternalAtRichTextTriggerProvidersInput {
+  bridge: TuttiExternalAtRichTextBridge | null | undefined;
+  providerIds?: readonly TuttiExternalAtProviderId[];
+  maxResults?: number;
+}
+
+export interface QueryTuttiExternalAtRichTextTriggerItemsInput {
+  bridge: TuttiExternalAtRichTextBridge | null | undefined;
+  keyword: string;
+  providerIds?: readonly TuttiExternalAtProviderId[];
+  maxResults?: number;
+}
+
+export async function queryTuttiExternalAtRichTextTriggerItems(
+  input: QueryTuttiExternalAtRichTextTriggerItemsInput
+): Promise<readonly TuttiExternalAtQueryResult[]> {
+  const bridge = input.bridge?.at;
+  if (!bridge) return [];
+
+  const providerIds = input.providerIds?.length
+    ? input.providerIds
+    : tuttiExternalAtProviderIds;
+  const results = await bridge.query({
+    keyword: input.keyword,
+    ...(input.maxResults !== undefined ? { maxResults: input.maxResults } : {}),
+    providers: providerIds
+  });
+  const providerSet = new Set<TuttiExternalAtProviderId>(providerIds);
+  return results.filter((item) => providerSet.has(item.providerId));
+}
+
+export function createTuttiExternalAtRichTextTriggerProvider(
+  input: CreateTuttiExternalAtRichTextTriggerProviderInput
+): RichTextTriggerProvider<TuttiExternalAtQueryResult> {
+  return {
+    id: input.providerId,
+    trigger: "@",
+    async query(queryInput) {
+      return queryTuttiExternalAtRichTextTriggerItems({
+        bridge: input.bridge,
+        keyword: queryInput.keyword,
+        maxResults: queryInput.maxResults ?? input.maxResults,
+        providerIds: [input.providerId]
+      });
+    },
+    getItemKey: (item) => item.itemId,
+    getItemLabel: (item) => item.label,
+    getItemSubtitle: (item) => item.subtitle,
+    getItemIconUrl: (item) =>
+      item.thumbnailUrl ??
+      (item.insert.kind === "mention"
+        ? (item.insert.mention.presentation?.iconUrl ??
+          item.insert.mention.presentation?.thumbnailUrl ??
+          item.insert.mention.presentation?.agentIconUrl)
+        : undefined),
+    toInsertResult: (item) => item.insert as RichTextTriggerInsertResult
+  };
+}
+
+export function createTuttiExternalAtRichTextTriggerProviders(
+  input: CreateTuttiExternalAtRichTextTriggerProvidersInput
+): readonly RichTextTriggerProvider<TuttiExternalAtQueryResult>[] {
+  const providerIds = input.providerIds?.length
+    ? input.providerIds
+    : tuttiExternalAtProviderIds;
+  return providerIds.map((providerId) =>
+    createTuttiExternalAtRichTextTriggerProvider({
+      bridge: input.bridge,
+      providerId,
+      maxResults: input.maxResults
+    })
+  );
+}

--- a/packages/workspace/external-core/src/rich-text/index.ts
+++ b/packages/workspace/external-core/src/rich-text/index.ts
@@ -44,9 +44,10 @@ export async function queryTuttiExternalAtRichTextTriggerItems(
   const bridge = input.bridge?.at;
   if (!bridge) return [];
 
-  const providerIds = input.providerIds?.length
-    ? input.providerIds
-    : tuttiExternalAtProviderIds;
+  const providerIds =
+    input.providerIds === undefined
+      ? tuttiExternalAtProviderIds
+      : input.providerIds;
   const results = await bridge.query({
     keyword: input.keyword,
     ...(input.maxResults !== undefined ? { maxResults: input.maxResults } : {}),
@@ -87,9 +88,10 @@ export function createTuttiExternalAtRichTextTriggerProvider(
 export function createTuttiExternalAtRichTextTriggerProviders(
   input: CreateTuttiExternalAtRichTextTriggerProvidersInput
 ): readonly RichTextTriggerProvider<TuttiExternalAtQueryResult>[] {
-  const providerIds = input.providerIds?.length
-    ? input.providerIds
-    : tuttiExternalAtProviderIds;
+  const providerIds =
+    input.providerIds === undefined
+      ? tuttiExternalAtProviderIds
+      : input.providerIds;
   return providerIds.map((providerId) =>
     createTuttiExternalAtRichTextTriggerProvider({
       bridge: input.bridge,

--- a/packages/workspace/external-core/tsup.config.ts
+++ b/packages/workspace/external-core/tsup.config.ts
@@ -6,7 +6,8 @@ export default defineConfig({
   entry: {
     index: "src/index.ts",
     "contracts/index": "src/contracts/index.ts",
-    "core/index": "src/core/index.ts"
+    "core/index": "src/core/index.ts",
+    "rich-text/index": "src/rich-text/index.ts"
   },
   format: ["esm"],
   sourcemap: true

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -681,6 +681,9 @@ importers:
 
   packages/workspace/external-core:
     dependencies:
+      "@tutti-os/ui-rich-text":
+        specifier: workspace:*
+        version: link:../../ui/rich-text
       "@tutti-os/workspace-file-reference":
         specifier: workspace:*
         version: link:../file-reference


### PR DESCRIPTION
## Summary
- keep App Center launches on the current workspace app URL instead of stale activation URLs after updates/restarts
- add shared rich-text mention agent-context sanitizers that drop presentation-only fields such as icon data URLs
- add a workspace external bridge adapter for `@tutti-os/ui-rich-text` trigger providers

## Verification
- `pnpm check:full` (pre-push)
- `pnpm --filter @tutti-os/ui-rich-text test`
- `pnpm --filter @tutti-os/ui-rich-text typecheck`
- `pnpm --filter @tutti-os/workspace-external-core test`
- `pnpm --filter @tutti-os/workspace-external-core typecheck`
- targeted desktop app-center tests from earlier push

AI-assisted change prepared with Codex.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved workspace app launch to resolve the correct webview URL using the latest launch signal and safe same-origin checks.
  * Preserves in-app deep links when activation and launch origins match.
  * Avoids duplicate or unnecessary workspace browser launches on repeated “open” events, and suppresses irrelevant open events for same-origin URLs.
* **New Features**
  * Added support for rich-text “@” external mention querying via rich-text trigger providers.
* **Documentation**
  * Updated external rich-text at-panel integration guide and usage documentation.
* **Tests**
  * Expanded unit coverage for workspace app URL resolution and browser launch handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->