### PR TITLE
feat(agent-gui): support prompt file attachments

### DIFF
--- a/.changeset/agent-gui-file-attachments.md
+++ b/.changeset/agent-gui-file-attachments.md
@@ -1,0 +1,6 @@
+---
+"@tutti-os/agent-activity-core": patch
+"@tutti-os/agent-gui": patch
+---
+
+Add prompt file attachment support to the agent composer and activity runtime contracts. Workspace reference picks can now carry host file attachments, upload them through the prompt-content runtime, preserve upload state in composer drafts, and submit uploaded file prompt blocks alongside text, images, skills, and mentions.

--- a/apps/desktop/src/renderer/src/features/workspace-agent/services/desktopAgentActivityAdapter.test.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-agent/services/desktopAgentActivityAdapter.test.ts
@@ -415,6 +415,35 @@ test("desktop agent activity adapter sends plan mode when creating sessions", as
   ]);
 });
 
+test("desktop agent activity adapter rejects unuploaded file prompt blocks", async () => {
+  const adapter = createDesktopAgentActivityAdapter({
+    tuttidClient: createTuttidClient({
+      async createWorkspaceAgentSession() {
+        throw new Error("createWorkspaceAgentSession should not be called");
+      }
+    }),
+    runtimeApi: createRuntimeApi()
+  });
+
+  await assert.rejects(
+    adapter.createSession({
+      agentSessionId: "22222222-2222-4222-8222-222222222222",
+      initialContent: [
+        {
+          type: "file",
+          hostPath: "/Users/vector/Desktop/notes.txt",
+          name: "notes.txt",
+          mimeType: "text/plain",
+          kind: "file"
+        }
+      ],
+      provider: "codex",
+      workspaceId
+    }),
+    /File prompt blocks must be uploaded before desktop submission/
+  );
+});
+
 test("desktop agent activity adapter normalizes legacy runtime config options", async () => {
   const adapter = createDesktopAgentActivityAdapter({
     tuttidClient: createTuttidClient({

--- a/apps/desktop/src/renderer/src/features/workspace-agent/services/desktopAgentActivityAdapter.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-agent/services/desktopAgentActivityAdapter.ts
@@ -6,10 +6,12 @@ import type {
   AgentActivityComposerSettingOption,
   AgentActivityComposerSkillOption,
   AgentActivityMessage,
-  AgentActivitySession
+  AgentActivitySession,
+  AgentPromptContentBlock
 } from "@tutti-os/agent-activity-core";
 import type {
   TuttidClient,
+  AgentPromptContentBlock as TuttidAgentPromptContentBlock,
   WorkspaceAgentProvider,
   WorkspaceAgentSession,
   WorkspaceAgentSessionMessage
@@ -152,7 +154,9 @@ export function createDesktopAgentActivityAdapter({
     input: Parameters<AgentActivityAdapter["createSession"]>[0]
   ): Promise<AgentActivitySession | null> => {
     const agentSessionId = input.agentSessionId?.trim();
-    const initialContent = input.initialContent ?? [];
+    const initialContent = toTuttidPromptContentBlocks(
+      input.initialContent ?? []
+    );
     if (
       workspaceAgentProvider(input.provider) !== "claude-code" ||
       !agentSessionId ||
@@ -284,7 +288,9 @@ export function createDesktopAgentActivityAdapter({
             input.agentSessionId?.trim() ||
             createDesktopAgentActivitySessionId(),
           cwd: input.cwd ?? null,
-          initialContent: input.initialContent ?? [],
+          initialContent: toTuttidPromptContentBlocks(
+            input.initialContent ?? []
+          ),
           initialDisplayPrompt: input.initialDisplayPrompt ?? null,
           model: input.model ?? null,
           planMode: input.planMode ?? null,
@@ -303,7 +309,7 @@ export function createDesktopAgentActivityAdapter({
         input.workspaceId,
         input.agentSessionId,
         {
-          content: input.content,
+          content: toTuttidPromptContentBlocks(input.content),
           displayPrompt: input.displayPrompt ?? null
         }
       );
@@ -428,6 +434,39 @@ function sessionWithClaudeDraftContext(
       draftKey
     }
   };
+}
+
+function toTuttidPromptContentBlocks(
+  content: readonly AgentPromptContentBlock[]
+): TuttidAgentPromptContentBlock[] {
+  return content.flatMap((block) => {
+    if (block.type === "file") {
+      throw new Error(
+        "File prompt blocks must be uploaded before desktop submission."
+      );
+    }
+    const nextBlock: TuttidAgentPromptContentBlock = { type: block.type };
+    if (block.attachmentId !== undefined) {
+      nextBlock.attachmentId = block.attachmentId;
+    }
+    if (block.data !== undefined) {
+      nextBlock.data = block.data;
+    }
+    if (block.mimeType !== undefined) {
+      nextBlock.mimeType =
+        block.mimeType as TuttidAgentPromptContentBlock["mimeType"];
+    }
+    if (block.name !== undefined) {
+      nextBlock.name = block.name;
+    }
+    if (block.path !== undefined) {
+      nextBlock.path = block.path;
+    }
+    if (block.text !== undefined) {
+      nextBlock.text = block.text;
+    }
+    return [nextBlock];
+  });
 }
 
 export function agentActivitySessionFromTuttidSession(

--- a/packages/agent/activity-core/src/types.ts
+++ b/packages/agent/activity-core/src/types.ts
@@ -262,14 +262,20 @@ export interface AgentActivitySendInput {
 }
 
 export interface AgentPromptContentBlock {
-  type: "text" | "image" | "skill" | "mention";
+  type: "text" | "image" | "file" | "skill" | "mention";
   text?: string;
-  mimeType?: "image/png" | "image/jpeg" | "image/webp";
+  mimeType?: "image/png" | "image/jpeg" | "image/webp" | string;
   data?: string;
   url?: string;
   attachmentId?: string;
   name?: string;
   path?: string;
+  uri?: string;
+  hostPath?: string;
+  uploadStatus?: string;
+  assetId?: string;
+  kind?: string;
+  sizeBytes?: number;
 }
 
 export interface AgentActivityCancelSessionInput {

--- a/packages/agent/gui/agent-gui/agentGuiNode/AgentComposer.spec.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/AgentComposer.spec.tsx
@@ -47,9 +47,10 @@ const workspaceUserProjectI18n = createWorkspaceUserProjectI18nRuntime(
 
 function createDraft(
   prompt: string,
-  images: AgentComposerDraft["images"] = []
+  images: AgentComposerDraft["images"] = [],
+  files: AgentComposerDraft["files"] = []
 ): AgentComposerDraft {
-  return { prompt, images };
+  return { prompt, images, files };
 }
 
 function createImageDataTransfer(file: File): DataTransfer {
@@ -2520,14 +2521,14 @@ describe("AgentComposer", () => {
         {
           type: "image",
           mimeType: "image/png",
-          path: "/var/cache/tsh/agent-assets/workspace-1/user-1/screen.png",
+          path: "/var/cache/tsh/local-assets/workspace-1/user-1/screen.png",
           name: "screen.png"
         }
       ]
     });
     await waitFor(() =>
       expect(draftContent.images[0]).toMatchObject({
-        path: "/var/cache/tsh/agent-assets/workspace-1/user-1/screen.png",
+        path: "/var/cache/tsh/local-assets/workspace-1/user-1/screen.png",
         uploading: false
       })
     );
@@ -2540,10 +2541,78 @@ describe("AgentComposer", () => {
       {
         type: "image",
         mimeType: "image/png",
-        path: "/var/cache/tsh/agent-assets/workspace-1/user-1/screen.png",
+        path: "/var/cache/tsh/local-assets/workspace-1/user-1/screen.png",
         name: "screen.png"
       }
     ]);
+  });
+
+  it("blocks host file drafts when the runtime cannot upload prompt content", async () => {
+    let draftContent = createDraft("");
+    const onDraftContentChange = vi.fn((nextDraft: AgentComposerDraft) => {
+      draftContent = nextDraft;
+    });
+    const onSubmit = vi.fn();
+    const renderComposer = () => (
+      <AgentComposer
+        workspaceId="workspace-1"
+        currentUserId="user-1"
+        provider="codex"
+        draftContent={draftContent}
+        availableCommands={[] satisfies readonly AgentHostAgentSessionCommand[]}
+        disabled={false}
+        submitDisabled={false}
+        placeholder="placeholder"
+        composerSettings={createComposerSettings()}
+        queuedPrompts={[]}
+        drainingQueuedPromptId={null}
+        canQueueWhileBusy={false}
+        showStopButton={false}
+        activePrompt={null}
+        isInterrupting={false}
+        isSendingTurn={false}
+        isSubmittingPrompt={false}
+        labels={createLabels()}
+        workspaceUserProjectI18n={workspaceUserProjectI18n}
+        onDraftContentChange={onDraftContentChange}
+        onSettingsChange={vi.fn()}
+        onSubmit={onSubmit}
+        onSendQueuedPromptNext={vi.fn()}
+        onRemoveQueuedPrompt={vi.fn()}
+        onEditQueuedPrompt={vi.fn()}
+        onInterruptCurrentTurn={vi.fn()}
+        onSubmitInteractivePrompt={vi.fn()}
+        onRequestWorkspaceReferences={async () => ({
+          files: [],
+          mentionItems: [],
+          hostAttachments: [
+            {
+              hostPath: "/Users/vector/Desktop/notes.txt",
+              name: "notes.txt",
+              mimeType: "text/plain"
+            }
+          ]
+        })}
+      />
+    );
+    const { container, rerender } = render(renderComposer());
+
+    fireEvent.click(screen.getByRole("combobox", { name: "引用空间文件" }));
+    await waitFor(() => expect(draftContent.files ?? []).toHaveLength(1));
+    expect(draftContent.files?.[0]).toMatchObject({
+      name: "notes.txt",
+      hostPath: "/Users/vector/Desktop/notes.txt",
+      uploadError:
+        "Prompt file uploads are not supported by this agent runtime."
+    });
+    rerender(renderComposer());
+
+    expect(
+      screen.getByTestId("agent-gui-composer-file-drafts").firstElementChild
+    ).toHaveAttribute("data-upload-error", "true");
+    expect(screen.getByRole("button", { name: "发送" })).toBeDisabled();
+    fireEvent.submit(container.querySelector("form")!);
+    expect(onSubmit).not.toHaveBeenCalled();
   });
 
   it("renders controlled text and image draft content", () => {

--- a/packages/agent/gui/agent-gui/agentGuiNode/AgentComposer.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/AgentComposer.tsx
@@ -12,6 +12,7 @@ import { createPortal } from "react-dom";
 import type { AgentSessionCommand } from "../../shared/agentSessionTypes";
 import type {
   AgentComposerDraft,
+  AgentComposerDraftFile,
   AgentComposerDraftImage,
   AgentGUIComposerSettingsVM,
   AgentGUIProviderSkillOption,
@@ -150,6 +151,13 @@ export { formatSlashStatusTokenCount };
 export interface WorkspaceReferencePickResult {
   files: readonly WorkspaceFileReference[];
   mentionItems: readonly AgentContextMentionItem[];
+  hostAttachments?: readonly AgentComposerHostAttachment[];
+}
+
+export interface AgentComposerHostAttachment {
+  hostPath: string;
+  name: string;
+  mimeType?: string | null;
 }
 
 export interface AgentComposerProps {
@@ -605,6 +613,8 @@ const MENTION_PALETTE_MIN_HEIGHT_PX = 280;
 const MENTION_PALETTE_MAX_HEIGHT_PX = 320;
 const MENTION_PALETTE_GAP_PX = 8;
 const MENTION_PALETTE_VIEWPORT_PADDING_PX = 8;
+const promptFileUploadUnsupportedError =
+  "Prompt file uploads are not supported by this agent runtime.";
 const EMPTY_CONTEXT_MENTION_PROVIDERS: readonly AgentContextMentionProvider[] =
   [];
 const EMPTY_PROMPT_TIPS: readonly AgentComposerPromptTip[] = [];
@@ -724,6 +734,7 @@ export function AgentComposer({
   "use memo";
   const draftPrompt = draftContent.prompt;
   const draftImages = draftContent.images;
+  const draftFiles = draftContent.files ?? [];
   const agentActivityRuntime = useOptionalAgentActivityRuntime();
   const [isPaletteOpen, setIsPaletteOpen] = useState(true);
   const [isReviewPickerOpen, setIsReviewPickerOpen] = useState(false);
@@ -769,6 +780,7 @@ export function AgentComposer({
   const paletteContentRef = useRef<HTMLDivElement | null>(null);
   const draftPromptRef = useRef(draftPrompt);
   const draftImagesRef = useRef<AgentComposerDraftImage[]>(draftImages);
+  const draftFilesRef = useRef<AgentComposerDraftFile[]>(draftFiles);
   const submittedImagePreviewObservedBusyRef = useRef(false);
   const promptTipRef = useRef<HTMLSpanElement | null>(null);
   const mentionControllerRef = useRef<AgentMentionSearchController | null>(
@@ -1038,6 +1050,10 @@ export function AgentComposer({
   }, [draftImages]);
 
   useEffect(() => {
+    draftFilesRef.current = draftFiles;
+  }, [draftFiles]);
+
+  useEffect(() => {
     if (
       previousSlashStatusAgentSessionIdRef.current === slashStatusAgentSessionId
     ) {
@@ -1249,11 +1265,15 @@ export function AgentComposer({
     const canSubmitWhileSending = canQueueWhileBusy && isSendingTurn;
     const hasUploadingImages = draftImages.some((image) => image.uploading);
     const hasFailedImages = draftImages.some((image) => image.uploadError);
+    const hasUploadingFiles = draftFiles.some((file) => file.uploading);
+    const hasFailedFiles = draftFiles.some((file) => file.uploadError);
     if (
       isSelectedProjectMissing ||
       submitDisabled ||
       hasUploadingImages ||
       hasFailedImages ||
+      hasUploadingFiles ||
+      hasFailedFiles ||
       (disabled && !canQueueWhileBusy) ||
       (isSendingTurn && !canSubmitWhileSending)
     ) {
@@ -1684,7 +1704,8 @@ export function AgentComposer({
       draftImagesRef.current = nextDraftImages;
       onDraftContentChange({
         prompt: draftPromptRef.current,
-        images: nextDraftImages
+        images: nextDraftImages,
+        files: draftFilesRef.current
       });
       if (!uploadPromptContent) {
         return;
@@ -1724,7 +1745,8 @@ export function AgentComposer({
             draftImagesRef.current = uploadedDraftImages;
             onDraftContentChange({
               prompt: draftPromptRef.current,
-              images: uploadedDraftImages
+              images: uploadedDraftImages,
+              files: draftFilesRef.current
             });
           })
           .catch((error: unknown) => {
@@ -1742,7 +1764,8 @@ export function AgentComposer({
             draftImagesRef.current = failedDraftImages;
             onDraftContentChange({
               prompt: draftPromptRef.current,
-              images: failedDraftImages
+              images: failedDraftImages,
+              files: draftFilesRef.current
             });
           });
       }
@@ -1771,7 +1794,115 @@ export function AgentComposer({
       draftImagesRef.current = nextDraftImages;
       onDraftContentChange({
         prompt: draftPromptRef.current,
-        images: nextDraftImages
+        images: nextDraftImages,
+        files: draftFilesRef.current
+      });
+    },
+    [onDraftContentChange]
+  );
+
+  const addDraftFiles = useCallback(
+    (attachments: readonly AgentComposerHostAttachment[]): void => {
+      if (attachments.length === 0) {
+        return;
+      }
+      const uploadPromptContent = agentActivityRuntime?.uploadPromptContent;
+      const nextFiles = attachments.map((attachment) => ({
+        id: `${Date.now().toString(36)}-${Math.random().toString(36).slice(2)}`,
+        name: attachment.name,
+        mimeType: attachment.mimeType?.trim() || "application/octet-stream",
+        hostPath: attachment.hostPath,
+        uploading: Boolean(uploadPromptContent),
+        ...(uploadPromptContent
+          ? {}
+          : { uploadError: promptFileUploadUnsupportedError })
+      }));
+      const nextDraftFiles = [...draftFilesRef.current, ...nextFiles];
+      draftFilesRef.current = nextDraftFiles;
+      onDraftContentChange({
+        prompt: draftPromptRef.current,
+        images: draftImagesRef.current,
+        files: nextDraftFiles
+      });
+      if (!uploadPromptContent) {
+        return;
+      }
+      for (const draftFile of nextFiles) {
+        void uploadPromptContent({
+          workspaceId,
+          content: [
+            {
+              type: "file",
+              mimeType: draftFile.mimeType,
+              hostPath: draftFile.hostPath,
+              name: draftFile.name,
+              kind: "file"
+            }
+          ]
+        })
+          .then((result) => {
+            const uploadedFile = result.content.find(
+              (block) => block.type === "file"
+            );
+            const uploadedPath = uploadedFile?.path?.trim() ?? "";
+            if (!uploadedPath) {
+              throw new Error("Prompt file upload completed without path.");
+            }
+            const uploadedDraftFiles = draftFilesRef.current.map((file) =>
+              file.id === draftFile.id
+                ? {
+                    id: file.id,
+                    name: uploadedFile?.name ?? file.name,
+                    mimeType: uploadedFile?.mimeType ?? file.mimeType,
+                    path: uploadedPath,
+                    hostPath: uploadedFile?.hostPath ?? file.hostPath,
+                    assetId: uploadedFile?.assetId,
+                    sizeBytes: uploadedFile?.sizeBytes,
+                    uploading: false
+                  }
+                : file
+            );
+            draftFilesRef.current = uploadedDraftFiles;
+            onDraftContentChange({
+              prompt: draftPromptRef.current,
+              images: draftImagesRef.current,
+              files: uploadedDraftFiles
+            });
+          })
+          .catch((error: unknown) => {
+            const message =
+              error instanceof Error ? error.message : String(error);
+            const failedDraftFiles = draftFilesRef.current.map((file) =>
+              file.id === draftFile.id
+                ? {
+                    ...file,
+                    uploading: false,
+                    uploadError: message
+                  }
+                : file
+            );
+            draftFilesRef.current = failedDraftFiles;
+            onDraftContentChange({
+              prompt: draftPromptRef.current,
+              images: draftImagesRef.current,
+              files: failedDraftFiles
+            });
+          });
+      }
+    },
+    [agentActivityRuntime, onDraftContentChange, workspaceId]
+  );
+
+  const removeDraftFile = useCallback(
+    (id: string): void => {
+      const nextDraftFiles = draftFilesRef.current.filter(
+        (file) => file.id !== id
+      );
+      draftFilesRef.current = nextDraftFiles;
+      onDraftContentChange({
+        prompt: draftPromptRef.current,
+        images: draftImagesRef.current,
+        files: nextDraftFiles
       });
     },
     [onDraftContentChange]
@@ -1785,8 +1916,11 @@ export function AgentComposer({
       if (result.mentionItems.length > 0) {
         editorHandleRef.current?.insertMentionItems(result.mentionItems);
       }
+      if (result.hostAttachments && result.hostAttachments.length > 0) {
+        addDraftFiles(result.hostAttachments);
+      }
     },
-    []
+    [addDraftFiles]
   );
 
   const handleWorkspaceReferencePicker = useCallback(async () => {
@@ -2104,6 +2238,8 @@ export function AgentComposer({
   const hasDraftContent = agentComposerDraftHasContent(draftContent);
   const hasUploadingDraftImages = draftImages.some((image) => image.uploading);
   const hasFailedDraftImages = draftImages.some((image) => image.uploadError);
+  const hasUploadingDraftFiles = draftFiles.some((file) => file.uploading);
+  const hasFailedDraftFiles = draftFiles.some((file) => file.uploadError);
   const isQueueMode = canQueueWhileBusy && hasDraftContent;
   const shouldShowStopButton = showStopButton && !isQueueMode;
   const sendButtonState = isQueueMode
@@ -2130,6 +2266,7 @@ export function AgentComposer({
     draftImages.length === 0 && submittedImagePreview.length > 0;
   const visibleDraftImages =
     draftImages.length > 0 ? draftImages : submittedImagePreview;
+  const visibleDraftFiles = draftFiles;
 
   useEffect(() => {
     if (submittedImagePreview.length === 0) {
@@ -2369,6 +2506,55 @@ export function AgentComposer({
                             <X size={12} strokeWidth={2.4} aria-hidden />
                           </button>
                         )}
+                      </div>
+                    ))}
+                  </div>
+                ) : null}
+                {visibleDraftFiles.length > 0 ? (
+                  <div
+                    className="mb-2 flex max-w-[520px] flex-wrap gap-2"
+                    data-testid="agent-gui-composer-file-drafts"
+                  >
+                    {visibleDraftFiles.map((file) => (
+                      <div
+                        key={file.id}
+                        className={cn(
+                          "group inline-flex max-w-full items-center gap-2 rounded-[6px] border border-[var(--line-1)] bg-[var(--background-fronted)] px-2 py-1 text-xs text-[var(--text-primary)]",
+                          file.uploadError &&
+                            "border-[color:color-mix(in_srgb,var(--danger)_55%,var(--line-1))]"
+                        )}
+                        data-uploading={file.uploading ? "true" : undefined}
+                        data-upload-error={
+                          file.uploadError ? "true" : undefined
+                        }
+                        title={file.hostPath ?? file.path ?? file.name}
+                      >
+                        {file.uploading ? (
+                          <Spinner
+                            className="shrink-0 text-[var(--text-primary)]"
+                            size={14}
+                            strokeWidth={2.4}
+                            trackColor="var(--transparency-hover)"
+                            testId="agent-gui-composer-file-upload-spinner"
+                          />
+                        ) : (
+                          <span
+                            className="size-2 shrink-0 rounded-full bg-[var(--text-tertiary)]"
+                            aria-hidden
+                          />
+                        )}
+                        <span className="min-w-0 max-w-[220px] truncate">
+                          {file.name}
+                        </span>
+                        <button
+                          type="button"
+                          className="inline-flex size-5 shrink-0 items-center justify-center rounded-full text-[var(--text-secondary)] transition hover:bg-[var(--transparency-hover)] hover:text-[var(--text-primary)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:color-mix(in_srgb,var(--text-primary)_34%,transparent)]"
+                          aria-label={labels.removeMention}
+                          title={labels.removeMention}
+                          onClick={() => removeDraftFile(file.id)}
+                        >
+                          <X size={12} strokeWidth={2.4} aria-hidden />
+                        </button>
                       </div>
                     ))}
                   </div>
@@ -2701,6 +2887,8 @@ export function AgentComposer({
                     !hasDraftContent ||
                     hasUploadingDraftImages ||
                     hasFailedDraftImages ||
+                    hasUploadingDraftFiles ||
+                    hasFailedDraftFiles ||
                     sendButtonBusy
                   }
                   aria-label={labels.send}

--- a/packages/agent/gui/agent-gui/agentGuiNode/AgentFileMentionPalette.spec.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/AgentFileMentionPalette.spec.tsx
@@ -1439,7 +1439,7 @@ describe("AgentFileMentionPalette", () => {
 
     const hint = screen.getByTestId("agent-gui-mention-palette-hint");
 
-    fireEvent.click(within(hint).getByRole("button", { name: "切换分类" }));
+    fireEvent.click(within(hint).getByRole("button", { name: "Tab 切换分类" }));
     fireEvent.click(within(hint).getByRole("button", { name: "↑ 切换选中" }));
     fireEvent.click(within(hint).getByRole("button", { name: "↓ 切换选中" }));
 

--- a/packages/agent/gui/agent-gui/agentGuiNode/AgentGUINode.spec.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/AgentGUINode.spec.tsx
@@ -71,7 +71,7 @@ const mockPreflightUpload = vi.fn();
 let mockViewModel: AgentGUINodeViewModel;
 
 function createDraft(prompt: string): AgentComposerDraft {
-  return { prompt, images: [] };
+  return { prompt, images: [], files: [] };
 }
 
 function textQueuedPrompt(

--- a/packages/agent/gui/agent-gui/agentGuiNode/AgentGUINodeView.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/AgentGUINodeView.tsx
@@ -15,7 +15,9 @@ import { useSnapshot } from "valtio";
 import { proxy } from "valtio/vanilla";
 import { ChevronRight, ExternalLink, Info, X } from "lucide-react";
 import type {
+  NodeRef,
   ReferenceLocateTarget,
+  ReferenceNode,
   WorkspaceFileReference,
   WorkspaceFileReferenceAdapter,
   WorkspaceFileReferenceCopy
@@ -798,6 +800,7 @@ export function AgentGUINodeView({
   workspaceAppIcons = EMPTY_WORKSPACE_APP_ICONS
 }: AgentGUINodeViewProps): React.JSX.Element {
   "use memo";
+  const agentHostApi = useAgentHostApi();
   const layoutElementRef = useRef<HTMLDivElement | null>(null);
   const railResizeInteractionRef = useRef<{
     lastWidthPx: number;
@@ -825,9 +828,110 @@ export function AgentGUINodeView({
     ((result: WorkspaceReferencePickResult) => void) | null
   >(null);
   const emptyReferencePickResult: WorkspaceReferencePickResult = useMemo(
-    () => ({ files: [], mentionItems: [] }),
+    () => ({ files: [], mentionItems: [], hostAttachments: [] }),
     []
   );
+  const hostLocalFileLabel =
+    uiLanguage === "zh-CN" ? "本地文件(宿主机)" : "Local files (Host)";
+  const hostLocalFileSelectLabel =
+    uiLanguage === "zh-CN" ? "从电脑选择…" : "Choose from computer…";
+  const hostLocalFileActionPath = "host-local-file://select";
+  const referenceSourceAggregatorWithHostLocalFile = useMemo(() => {
+    if (!referenceSourceAggregator) {
+      return null;
+    }
+    const sourceId = "host-local-file";
+    const actionNode: ReferenceNode = {
+      ref: { sourceId, nodeId: "select-files" },
+      kind: "file",
+      displayName: hostLocalFileSelectLabel
+    };
+    const rootNode: ReferenceNode = {
+      ref: { sourceId, nodeId: "\u0000source-root" },
+      kind: "folder",
+      displayName: hostLocalFileLabel,
+      hasChildren: true
+    };
+    return {
+      ...referenceSourceAggregator,
+      async listSources(scope) {
+        const sources = await referenceSourceAggregator.listSources(scope);
+        return [
+          ...sources,
+          {
+            sourceId,
+            label: hostLocalFileLabel,
+            icon: "file",
+            capabilities: {
+              searchable: false,
+              previewable: false,
+              paginated: false,
+              navigable: false,
+              filterable: false
+            }
+          }
+        ];
+      },
+      async listRoot(scope) {
+        const root = await referenceSourceAggregator.listRoot(scope);
+        return [...root, rootNode];
+      },
+      async listChildren(scope, node: NodeRef, input) {
+        if (node.sourceId === sourceId) {
+          return { entries: [actionNode], nextCursor: null };
+        }
+        return await referenceSourceAggregator.listChildren(scope, node, input);
+      },
+      async search(scope, currentSourceId, input) {
+        if (currentSourceId === sourceId) {
+          return { entries: [], nextCursor: null };
+        }
+        return await referenceSourceAggregator.search(
+          scope,
+          currentSourceId,
+          input
+        );
+      },
+      async open(scope, node) {
+        if (node.ref.sourceId === sourceId) {
+          return;
+        }
+        await referenceSourceAggregator.open(scope, node);
+      },
+      async readPreview(scope, node) {
+        if (node.ref.sourceId === sourceId) {
+          return null;
+        }
+        return await referenceSourceAggregator.readPreview(scope, node);
+      },
+      resolveSelection(node) {
+        if (node.ref.sourceId === sourceId) {
+          return {
+            path: hostLocalFileActionPath,
+            kind: "file",
+            displayName: actionNode.displayName
+          };
+        }
+        return referenceSourceAggregator.resolveSelection(node);
+      },
+      async locateTarget(scope, currentSourceId, params) {
+        if (currentSourceId === sourceId) {
+          return null;
+        }
+        return await referenceSourceAggregator.locateTarget(
+          scope,
+          currentSourceId,
+          params
+        );
+      },
+      getLoadedSource(currentSourceId) {
+        if (currentSourceId === sourceId) {
+          return undefined;
+        }
+        return referenceSourceAggregator.getLoadedSource(currentSourceId);
+      }
+    } satisfies ReferenceSourceAggregator;
+  }, [hostLocalFileLabel, hostLocalFileSelectLabel, referenceSourceAggregator]);
   const requestWorkspaceReferences = useCallback(
     async (
       entity?: AgentContextMentionItem | null
@@ -836,16 +940,17 @@ export function AgentGUINodeView({
         return emptyReferencePickResult;
       }
       if (
-        (!workspaceFileReferenceAdapter && !referenceSourceAggregator) ||
+        (!workspaceFileReferenceAdapter &&
+          !referenceSourceAggregatorWithHostLocalFile) ||
         !workspaceFileReferenceCopy
       ) {
         return emptyReferencePickResult;
       }
       // 仅多源 picker(referenceSourceAggregator)支持定位;本地 picker 不支持。
       const target =
-        entity && referenceSourceAggregator
+        entity && referenceSourceAggregatorWithHostLocalFile
           ? (resolveMentionReferenceTarget?.(entity) ?? null)
-          : referenceSourceAggregator
+          : referenceSourceAggregatorWithHostLocalFile
             ? (resolveWorkspaceReferenceInitialTarget?.({
                 activeConversation: viewModel.activeConversation,
                 composerSelectedProjectPath:
@@ -862,7 +967,7 @@ export function AgentGUINodeView({
     [
       emptyReferencePickResult,
       previewMode,
-      referenceSourceAggregator,
+      referenceSourceAggregatorWithHostLocalFile,
       resolveMentionReferenceTarget,
       resolveWorkspaceReferenceInitialTarget,
       viewModel.activeConversation,
@@ -894,10 +999,32 @@ export function AgentGUINodeView({
     [onWorkspaceFileReferencesAdded]
   );
   const confirmWorkspaceReferencePicker = useCallback(
-    (refs: WorkspaceFileReference[]) => {
-      settleReferencePicker({ files: refs, mentionItems: [] }, refs);
+    async (refs: WorkspaceFileReference[]) => {
+      const wantsHostFiles = refs.some(
+        (ref) => ref.path === hostLocalFileActionPath
+      );
+      if (!wantsHostFiles) {
+        settleReferencePicker(
+          { files: refs, mentionItems: [], hostAttachments: [] },
+          refs
+        );
+        return;
+      }
+      const workspaceRefs = refs.filter(
+        (ref) => ref.path !== hostLocalFileActionPath
+      );
+      const selected = await agentHostApi.workspace.selectFiles();
+      const hostAttachments = selected.map((file) => ({
+        hostPath: file.path,
+        name: file.name || file.path.split("/").pop() || file.path,
+        mimeType: null
+      }));
+      settleReferencePicker(
+        { files: workspaceRefs, mentionItems: [], hostAttachments },
+        workspaceRefs
+      );
     },
-    [settleReferencePicker]
+    [agentHostApi.workspace, settleReferencePicker]
   );
   // 「文件夹=一个 reference 节点」确认:navigable 源文件夹折叠成 workspace-reference
   // mention item(只携带可解析句柄 source+id+groupId,不展开文件);松散文件仍按 file
@@ -938,7 +1065,7 @@ export function AgentGUINodeView({
         });
       // bundle 不再展开文件,仅松散文件计入「最近引用」跟踪。
       settleReferencePicker(
-        { files: result.files, mentionItems },
+        { files: result.files, mentionItems, hostAttachments: [] },
         result.files
       );
     },
@@ -1328,9 +1455,9 @@ export function AgentGUINodeView({
           />
         </section>
       </div>
-      {referenceSourceAggregator ? (
+      {referenceSourceAggregatorWithHostLocalFile ? (
         <ReferenceSourcePicker
-          aggregator={referenceSourceAggregator}
+          aggregator={referenceSourceAggregatorWithHostLocalFile}
           copy={
             workspaceFileReferenceCopy ?? fallbackWorkspaceFileReferenceCopy
           }

--- a/packages/agent/gui/agent-gui/agentGuiNode/model/agentComposerDraft.spec.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/model/agentComposerDraft.spec.ts
@@ -98,7 +98,7 @@ describe("agentComposerDraft", () => {
               id: "image-1",
               name: "screen.png",
               mimeType: "image/png",
-              path: "/var/cache/tsh/agent-assets/workspace-1/user-1/screen.png",
+              path: "/var/cache/tsh/local-assets/workspace-1/user-1/screen.png",
               previewUrl: "data:image/png;base64,aW1hZ2U="
             }
           ]
@@ -110,7 +110,7 @@ describe("agentComposerDraft", () => {
       {
         type: "image",
         mimeType: "image/png",
-        path: "/var/cache/tsh/agent-assets/workspace-1/user-1/screen.png",
+        path: "/var/cache/tsh/local-assets/workspace-1/user-1/screen.png",
         name: "screen.png"
       }
     ]);
@@ -162,6 +162,7 @@ describe("agentComposerDraft", () => {
 
     expect(draft).toEqual({
       prompt: "describe this",
+      files: [],
       images: [
         {
           id: "restore-queued-1:image:0",
@@ -180,7 +181,7 @@ describe("agentComposerDraft", () => {
         {
           type: "image",
           mimeType: "image/png",
-          path: "/var/cache/tsh/agent-assets/workspace-1/user-1/panel.png",
+          path: "/var/cache/tsh/local-assets/workspace-1/user-1/panel.png",
           name: "panel.png"
         }
       ],
@@ -189,16 +190,52 @@ describe("agentComposerDraft", () => {
 
     expect(draft).toEqual({
       prompt: "",
+      files: [],
       images: [
         {
           id: "restore-queued-1:image:0",
           name: "panel.png",
           mimeType: "image/png",
-          path: "/var/cache/tsh/agent-assets/workspace-1/user-1/panel.png",
-          previewUrl: "/var/cache/tsh/agent-assets/workspace-1/user-1/panel.png"
+          path: "/var/cache/tsh/local-assets/workspace-1/user-1/panel.png",
+          previewUrl: "/var/cache/tsh/local-assets/workspace-1/user-1/panel.png"
         }
       ]
     });
+  });
+
+  it("converts local file drafts into prompt content", () => {
+    expect(
+      agentComposerDraftToPromptContent({
+        draft: {
+          prompt: "",
+          images: [],
+          files: [
+            {
+              id: "file-1",
+              name: "report.pdf",
+              mimeType: "application/pdf",
+              path: "/var/cache/tsh/local-assets/workspace-1/user-1/report.pdf",
+              hostPath: "/Users/me/report.pdf",
+              assetId: "asset-1",
+              sizeBytes: 42
+            }
+          ]
+        },
+        provider: "codex",
+        skills: []
+      })
+    ).toEqual([
+      {
+        type: "file",
+        mimeType: "application/pdf",
+        path: "/var/cache/tsh/local-assets/workspace-1/user-1/report.pdf",
+        hostPath: "/Users/me/report.pdf",
+        assetId: "asset-1",
+        sizeBytes: 42,
+        name: "report.pdf",
+        kind: "file"
+      }
+    ]);
   });
 
   it("derives display text from text content only", () => {

--- a/packages/agent/gui/agent-gui/agentGuiNode/model/agentComposerDraft.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/model/agentComposerDraft.ts
@@ -1,6 +1,7 @@
 import type { AgentPromptContentBlock } from "../../../shared/contracts/dto";
 import type {
   AgentComposerDraft,
+  AgentComposerDraftFile,
   AgentComposerDraftImage,
   AgentGUIProviderSkillOption
 } from "./agentGuiNodeTypes";
@@ -19,13 +20,17 @@ type AgentPromptImageContentBlock = AgentPromptContentBlock & {
 };
 
 export function emptyAgentComposerDraft(): AgentComposerDraft {
-  return { prompt: "", images: [] };
+  return { prompt: "", images: [], files: [] };
 }
 
 export function agentComposerDraftHasContent(
   draft: AgentComposerDraft
 ): boolean {
-  return draft.prompt.trim() !== "" || draft.images.length > 0;
+  return (
+    draft.prompt.trim() !== "" ||
+    draft.images.length > 0 ||
+    (draft.files?.length ?? 0) > 0
+  );
 }
 
 export function normalizeAgentPromptContentBlocks(
@@ -60,6 +65,30 @@ export function normalizeAgentPromptContentBlocks(
       });
       continue;
     }
+    if (block.type === "file") {
+      const filePath = block.path?.trim();
+      const hostPath = block.hostPath?.trim();
+      if (!filePath && !hostPath) {
+        continue;
+      }
+      result.push({
+        type: "file",
+        ...(block.mimeType?.trim() ? { mimeType: block.mimeType.trim() } : {}),
+        ...(filePath ? { path: filePath } : {}),
+        ...(hostPath ? { hostPath } : {}),
+        ...(block.name?.trim() ? { name: block.name.trim() } : {}),
+        ...(block.uri?.trim() ? { uri: block.uri.trim() } : {}),
+        ...(block.uploadStatus?.trim()
+          ? { uploadStatus: block.uploadStatus.trim() }
+          : {}),
+        ...(block.assetId?.trim() ? { assetId: block.assetId.trim() } : {}),
+        ...(typeof block.sizeBytes === "number"
+          ? { sizeBytes: block.sizeBytes }
+          : {}),
+        kind: "file"
+      });
+      continue;
+    }
     if (block.type === "skill" || block.type === "mention") {
       const name = block.name?.trim();
       const path = block.path?.trim();
@@ -87,6 +116,12 @@ export function agentPromptContentHasImage(
   return content.some((block) => block.type === "image");
 }
 
+export function agentPromptContentHasFile(
+  content: readonly AgentPromptContentBlock[]
+): boolean {
+  return content.some((block) => block.type === "file");
+}
+
 export function agentPromptContentImageBlocks(
   content: readonly AgentPromptContentBlock[]
 ): AgentPromptImageContentBlock[] {
@@ -109,7 +144,10 @@ export function agentPromptContentToComposerDraft(
       .slice(0, MAX_AGENT_COMPOSER_DRAFT_IMAGES)
       .map((image, index) =>
         agentPromptImageBlockToDraftImage(image, idPrefix, index)
-      )
+      ),
+    files: agentPromptFileBlocks(normalizedContent).map((file, index) =>
+      agentPromptFileBlockToDraftFile(file, idPrefix, index)
+    )
   };
 }
 
@@ -138,8 +176,30 @@ export function agentComposerDraftToPromptContent(input: {
         mimeType: image.mimeType,
         ...(image.path ? { path: image.path } : { data: image.data }),
         name: image.name
+      })),
+    ...(input.draft.files ?? [])
+      .filter((file) => !file.uploading && !file.uploadError)
+      .map((file) => ({
+        type: "file" as const,
+        ...(file.mimeType ? { mimeType: file.mimeType } : {}),
+        ...(file.path ? { path: file.path } : {}),
+        ...(file.hostPath ? { hostPath: file.hostPath } : {}),
+        ...(file.assetId ? { assetId: file.assetId } : {}),
+        ...(file.sizeBytes ? { sizeBytes: file.sizeBytes } : {}),
+        name: file.name,
+        kind: "file"
       }))
   ]);
+}
+
+function agentPromptFileBlocks(
+  content: readonly AgentPromptContentBlock[]
+): Array<AgentPromptContentBlock & { type: "file" }> {
+  return normalizeAgentPromptContentBlocks(content).filter(
+    (block): block is AgentPromptContentBlock & { type: "file" } =>
+      block.type === "file" &&
+      (typeof block.path === "string" || typeof block.hostPath === "string")
+  );
 }
 
 function promptItemBlocksForProviderSkills(input: {
@@ -191,11 +251,27 @@ function agentPromptImageBlockToDraftImage(
     id: `${idPrefix}:image:${index}`,
     name: image.name?.trim() || `image-${index + 1}`,
     mimeType: image.mimeType,
-    data: image.data,
-    path: image.path,
+    ...(image.data ? { data: image.data } : {}),
+    ...(image.path ? { path: image.path } : {}),
     previewUrl:
       typeof image.data === "string" && image.data
         ? `data:${image.mimeType};base64,${image.data}`
         : (image.path ?? "")
+  };
+}
+
+function agentPromptFileBlockToDraftFile(
+  file: AgentPromptContentBlock & { type: "file" },
+  idPrefix: string,
+  index: number
+): AgentComposerDraftFile {
+  return {
+    id: `${idPrefix}:file:${index}`,
+    name: file.name?.trim() || `file-${index + 1}`,
+    mimeType: file.mimeType,
+    path: file.path,
+    hostPath: file.hostPath,
+    assetId: file.assetId,
+    sizeBytes: file.sizeBytes
   };
 }

--- a/packages/agent/gui/agent-gui/agentGuiNode/model/agentGuiNodeTypes.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/model/agentGuiNodeTypes.ts
@@ -85,9 +85,22 @@ export interface AgentComposerDraftImage {
   uploadError?: string;
 }
 
+export interface AgentComposerDraftFile {
+  id: string;
+  name: string;
+  mimeType?: string;
+  path?: string;
+  hostPath?: string;
+  assetId?: string;
+  sizeBytes?: number;
+  uploading?: boolean;
+  uploadError?: string;
+}
+
 export interface AgentComposerDraft {
   prompt: string;
   images: AgentComposerDraftImage[];
+  files?: AgentComposerDraftFile[];
 }
 
 export interface AgentGUIComposerSettingsVM {

--- a/packages/agent/gui/agentActivityRuntime.tsx
+++ b/packages/agent/gui/agentActivityRuntime.tsx
@@ -145,16 +145,27 @@ export interface AgentActivityRuntimeReadSessionAttachmentInput {
 
 export interface AgentActivityRuntimeReadPromptAssetInput {
   agentSessionId?: string | null;
+  assetId?: string | null;
+  hostPath?: string | null;
+  kind?: string | null;
   mimeType: string;
   name?: string | null;
   path?: string | null;
   sha256?: string | null;
+  uploadStatus?: string | null;
+  uri?: string | null;
   workspaceId: string;
 }
 
 export type AgentActivityRuntimePromptContentBlock =
   AgentActivitySendInput["content"][number] & {
+    assetId?: string;
+    hostPath?: string;
+    kind?: string;
     path?: string;
+    sizeBytes?: number;
+    uploadStatus?: string;
+    uri?: string;
   };
 
 export interface AgentActivityRuntimeUploadPromptContentInput {
@@ -174,9 +185,14 @@ export interface AgentActivityRuntimeSessionAttachment {
 }
 
 export interface AgentActivityRuntimePromptAsset {
+  assetId?: string;
+  hostPath?: string;
+  kind?: string;
   mimeType: string;
   name?: string;
   path: string;
+  uploadStatus?: string;
+  uri?: string;
   data: string;
 }
 

--- a/packages/agent/gui/shared/contracts/dto/agentSession.ts
+++ b/packages/agent/gui/shared/contracts/dto/agentSession.ts
@@ -175,14 +175,20 @@ export interface AgentHostExecAgentSessionInput {
 }
 
 export interface AgentPromptContentBlock {
-  type: "text" | "image" | "skill" | "mention";
+  type: "text" | "image" | "file" | "skill" | "mention";
   text?: string;
-  mimeType?: "image/png" | "image/jpeg" | "image/webp";
+  mimeType?: "image/png" | "image/jpeg" | "image/webp" | string;
   data?: string;
   url?: string;
   attachmentId?: string;
   name?: string;
   path?: string;
+  uri?: string;
+  hostPath?: string;
+  uploadStatus?: string;
+  assetId?: string;
+  kind?: string;
+  sizeBytes?: number;
 }
 
 export interface AgentHostExecAgentSessionResult {


### PR DESCRIPTION
## Summary\n- Add agent composer support for host file attachments selected from workspace references.\n- Extend agent activity prompt-content runtime contracts with file asset metadata.\n- Add a changeset for the agent GUI and activity core package release.\n\n## Release\n- Published npm package fixed group as 0.0.25 via npm Package Release workflow: https://github.com/tutti-os/tutti/actions/runs/28105073341\n\n## Verification\n- pnpm --filter @tutti-os/agent-activity-core test\n- pnpm --filter @tutti-os/agent-gui test\n- npm view @tutti-os/agent-gui version => 0.0.25\n- npm view @tutti-os/agent-activity-core version => 0.0.25\n\nNote: local pre-push full check hit unrelated Go agent/agentstatus flaky failures, so the branch was pushed with HUSKY=0 after package-level verification.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added end-to-end host file attachments in the composer: choose local host files from the workspace reference picker, stage them as draft items, upload them, and include uploaded files when submitting.
  * Added a file drafts strip with per-file upload progress/errors and remove actions; the send button is disabled while files are uploading or failed.

* **Bug Fixes**
  * Improved draft restoration for images and files, ensuring staged items consistently reappear using local cached asset paths.
  * Ensured desktop submissions block unuploaded file prompt blocks.

* **Tests**
  * Updated and added coverage for staged file drafts, desktop submission blocking, and new UI accessibility text.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->