### PR TITLE
fix(agent-gui): quiet Codex transport retry notices

### DIFF
--- a/packages/agent/gui/shared/agentConversation/components/AgentMessageBlock.tsx
+++ b/packages/agent/gui/shared/agentConversation/components/AgentMessageBlock.tsx
@@ -37,6 +37,8 @@ import { CanvasNodeGhostIconButton } from "../../../contexts/workspace/presentat
 
 const MESSAGE_COPY_FEEDBACK_MS = 1400;
 const CONTEXT_COMPACTION_NOTICE_TITLE = "Context compacted.";
+const TRANSPORT_RETRY_PROGRESS_PATTERN =
+  /\b(reconnect(?:ing)?(?:\s*(?:\.\.\.|…|[.。]+|:|-))?\s*\(?\d+\s*\/\s*\d+\)?)/i;
 
 interface AgentMessageBlockProps {
   workspaceRoot: string | null;
@@ -448,6 +450,17 @@ function AgentSystemNoticeMessage({
   const notice = message.systemNotice;
   const detail = notice?.detail?.trim() ?? "";
   const title = systemNoticeTitle(message);
+  if (notice?.noticeKind === "transport_retry") {
+    const retryText = transportRetryNoticeText(message);
+    return (
+      <div
+        role="status"
+        className="box-border w-full min-w-0 py-1 text-[13px] leading-5 text-[var(--text-primary)]"
+      >
+        {retryText}
+      </div>
+    );
+  }
   if (isContextCompactionNotice(message, title)) {
     return (
       <div
@@ -481,6 +494,28 @@ function AgentSystemNoticeMessage({
       </div>
     </section>
   );
+}
+
+function transportRetryNoticeText(message: AgentMessageContentVM): string {
+  const notice = message.systemNotice;
+  const detail = notice?.detail?.trim() ?? "";
+  const progressText =
+    transportRetryProgressText(detail) ??
+    transportRetryProgressText(notice?.title ?? "") ??
+    transportRetryProgressText(message.body);
+  if (progressText) {
+    return progressText;
+  }
+  return (
+    notice?.title?.trim() ||
+    message.body.trim() ||
+    translate("agentHost.agentGui.systemNoticeTransportRetry")
+  );
+}
+
+function transportRetryProgressText(value: string): string | null {
+  const match = TRANSPORT_RETRY_PROGRESS_PATTERN.exec(value.trim());
+  return match?.[1]?.replace(/\s+/g, " ").trim() || null;
 }
 
 function isContextCompactionNotice(

--- a/packages/agent/gui/shared/agentConversation/components/AgentTranscriptItemView.spec.tsx
+++ b/packages/agent/gui/shared/agentConversation/components/AgentTranscriptItemView.spec.tsx
@@ -584,7 +584,7 @@ describe("AgentTranscriptItemView render stability", () => {
     expect(onAuthLogin).toHaveBeenCalledWith("claude-code");
   });
 
-  it("shows transport retry notices separately from markdown answers", () => {
+  it("renders transport retry notices as quiet text", () => {
     const { getByText, queryByText } = render(
       <AgentMessageBlock
         workspaceRoot="/workspace/demo"
@@ -600,7 +600,7 @@ describe("AgentTranscriptItemView render stability", () => {
             severity: "warning",
             title: "Codex connection interrupted. Reconnecting...",
             detail:
-              "ResponseStreamDisconnected: websocket IO error: Broken pipe",
+              "Handled error during turn: Reconnecting... 1/5 Some(ResponseStreamDisconnected { http_status_code: None })",
             retryable: true
           }
         })}
@@ -608,16 +608,17 @@ describe("AgentTranscriptItemView render stability", () => {
       />
     );
 
-    expect(
-      getByText("agentHost.agentGui.systemNoticeTransportRetry")
-    ).toBeTruthy();
-    const notice = getByText(
-      "agentHost.agentGui.systemNoticeTransportRetry"
-    ).closest("section");
-    expect(notice?.firstElementChild?.firstElementChild?.tagName).toBe("DIV");
-    expect(getByText("agentHost.agentGui.visibleErrorDetails")).toBeTruthy();
+    expect(getByText("Reconnecting... 1/5")).toBeTruthy();
+    const notice = getByText("Reconnecting... 1/5");
+    expect(notice.tagName).toBe("DIV");
+    expect(notice.className).toContain("text-[var(--text-primary)]");
+    expect(notice.className).not.toContain("rounded-[8px]");
+    expect(queryByText("agentHost.agentGui.visibleErrorDetails")).toBeNull();
     expect(
       queryByText("Codex connection interrupted. Reconnecting...")
+    ).toBeNull();
+    expect(
+      queryByText("agentHost.agentGui.systemNoticeTransportRetry")
     ).toBeNull();
   });
 

--- a/packages/agent/gui/shared/agentConversation/projection/agentConversationProjection.spec.ts
+++ b/packages/agent/gui/shared/agentConversation/projection/agentConversationProjection.spec.ts
@@ -186,6 +186,111 @@ describe("projectAgentConversationVM", () => {
     expect(processing).not.toHaveProperty("noticeKind");
   });
 
+  it("merges only adjacent Codex transport retry notice rows", () => {
+    const retryNotice = (id: string, detail: string, sourceId: number) => ({
+      id,
+      body: "Codex connection interrupted. Reconnecting...",
+      occurredAtUnixMs: sourceId,
+      sourceTimelineItems: [
+        {
+          id: sourceId,
+          agentSessionId: "session-1",
+          eventId: `event-${sourceId}`,
+          actorType: "agent",
+          actorId: "codex",
+          itemType: "message",
+          role: "assistant",
+          payload: {
+            kind: "agent_system_notice",
+            noticeKind: "transport_retry"
+          }
+        }
+      ],
+      systemNotice: {
+        noticeKind: "transport_retry",
+        severity: "warning",
+        title: "Codex connection interrupted. Reconnecting...",
+        detail,
+        retryable: true
+      }
+    });
+    const conversation = projectAgentConversationVM(
+      detailViewModel({
+        session: {
+          ...detailViewModel().session,
+          status: "completed"
+        },
+        turns: [
+          {
+            id: "turn-1",
+            userMessage: { id: "user-1", body: "Ship it" },
+            userMessages: [{ id: "user-1", body: "Ship it" }],
+            agentMessages: [],
+            toolCalls: [],
+            toolCallCount: 0,
+            hasFailedToolCall: false,
+            agentItems: [
+              {
+                kind: "message",
+                message: retryNotice(
+                  "assistant-retry-1",
+                  "Handled error during turn: Reconnecting... 1/5",
+                  11
+                )
+              },
+              {
+                kind: "message",
+                message: retryNotice(
+                  "assistant-retry-2",
+                  "Handled error during turn: Reconnecting... 2/5",
+                  12
+                )
+              },
+              {
+                kind: "message",
+                message: { id: "assistant-1", body: "Still working" }
+              },
+              {
+                kind: "message",
+                message: retryNotice(
+                  "assistant-retry-3",
+                  "Handled error during turn: Reconnecting... 3/5",
+                  13
+                )
+              }
+            ]
+          }
+        ],
+        showProcessingIndicator: false
+      })
+    );
+
+    const assistantRows = conversation.rows.filter(
+      (
+        row
+      ): row is Extract<
+        (typeof conversation.rows)[number],
+        { kind: "message" }
+      > => row.kind === "message" && row.speaker === "assistant"
+    );
+
+    expect(assistantRows).toHaveLength(3);
+    expect(assistantRows.map((row) => row.messages[0]?.id)).toEqual([
+      "assistant-retry-1",
+      "assistant-1",
+      "assistant-retry-3"
+    ]);
+    expect(
+      assistantRows[0]?.messages[0]?.sourceTimelineItems?.map((item) => item.id)
+    ).toEqual([11, 12]);
+    expect(assistantRows[0]?.messages[0]?.systemNotice?.detail).toBe(
+      "Handled error during turn: Reconnecting... 2/5"
+    );
+    expect(assistantRows[2]?.messages[0]?.sourceTimelineItems?.[0]?.id).toBe(
+      13
+    );
+  });
+
   it("groups bridge thinking inside completed tool disclosures", () => {
     const conversation = projectAgentConversationVM(
       detailViewModel({

--- a/packages/agent/gui/shared/agentConversation/projection/agentConversationProjection.ts
+++ b/packages/agent/gui/shared/agentConversation/projection/agentConversationProjection.ts
@@ -71,7 +71,9 @@ export function projectAgentConversationVM(
   }
 
   const normalizedRows = projectMessageCopyText(
-    mergeAdjacentAssistantMessageRows(rows),
+    mergeAdjacentAssistantMessageRows(
+      mergeAdjacentTransportRetryNoticeRows(rows)
+    ),
     {
       assistantCopyEligibleTurnIds: buildAssistantCopyEligibleTurnIds(detail)
     }
@@ -246,6 +248,74 @@ function mergeAdjacentAssistantMessageRows(
     merged.push(row);
   }
   return merged;
+}
+
+function mergeAdjacentTransportRetryNoticeRows(
+  rows: readonly AgentTranscriptRowVM[]
+): AgentTranscriptRowVM[] {
+  const merged: AgentTranscriptRowVM[] = [];
+  for (const row of rows) {
+    const previous = merged.at(-1);
+    if (
+      isSingleTransportRetryNoticeRow(previous) &&
+      isSingleTransportRetryNoticeRow(row) &&
+      previous.turnId === row.turnId
+    ) {
+      const previousMessage = previous.messages[0];
+      const nextMessage = row.messages[0];
+      if (!previousMessage || !nextMessage) {
+        merged.push(row);
+        continue;
+      }
+      const sourceTimelineItems = mergeSourceTimelineItems(
+        previousMessage.sourceTimelineItems,
+        nextMessage.sourceTimelineItems
+      );
+      previous.messages[0] = {
+        ...previousMessage,
+        body: nextMessage.body || previousMessage.body,
+        systemNotice: nextMessage.systemNotice ?? previousMessage.systemNotice,
+        statusKind:
+          nextMessage.statusKind ?? previousMessage.statusKind ?? null,
+        occurredAtUnixMs:
+          nextMessage.occurredAtUnixMs ?? previousMessage.occurredAtUnixMs,
+        ...(sourceTimelineItems ? { sourceTimelineItems } : {})
+      };
+      previous.occurredAtUnixMs =
+        row.occurredAtUnixMs ?? previous.occurredAtUnixMs;
+      continue;
+    }
+    merged.push(row);
+  }
+  return merged;
+}
+
+function isSingleTransportRetryNoticeRow(
+  row: AgentTranscriptRowVM | undefined
+): row is AgentMessageRowVM {
+  if (
+    !row ||
+    row.kind !== "message" ||
+    row.speaker !== "assistant" ||
+    row.thinking.length > 0 ||
+    row.messages.length !== 1
+  ) {
+    return false;
+  }
+  return row.messages[0]?.systemNotice?.noticeKind === "transport_retry";
+}
+
+function mergeSourceTimelineItems(
+  previous: AgentMessageContentVM["sourceTimelineItems"],
+  next: AgentMessageContentVM["sourceTimelineItems"]
+): AgentMessageContentVM["sourceTimelineItems"] {
+  if (!previous || previous.length === 0) {
+    return next;
+  }
+  if (!next || next.length === 0) {
+    return previous;
+  }
+  return [...previous, ...next];
 }
 
 function projectMessageCopyText(


### PR DESCRIPTION
## Summary
- Render Codex transport retry system notices as plain transcript text instead of warning cards
- Preserve retry progress text such as `Reconnecting... 2/5` and merge only adjacent retry notices within the same turn
- Add projection and rendering coverage for the quiet retry behavior

## Validation
- `pnpm --filter @tutti-os/agent-gui test -- shared/agentConversation/projection/agentConversationProjection.spec.ts shared/agentConversation/components/AgentTranscriptItemView.spec.tsx`
- `pnpm --filter @tutti-os/agent-gui typecheck`
- `pnpm exec oxlint --deny-warnings packages/agent/gui/shared/agentConversation/projection/agentConversationProjection.ts packages/agent/gui/shared/agentConversation/projection/agentConversationProjection.spec.ts packages/agent/gui/shared/agentConversation/components/AgentMessageBlock.tsx packages/agent/gui/shared/agentConversation/components/AgentTranscriptItemView.spec.tsx`
- `pnpm lint:go`
- `pnpm check:full` (via pre-push)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved how retry status messages appear in conversation views, making them render as a compact inline notice with clearer progress text.
  * Consolidated consecutive retry notices so repeated retry updates now display as a single combined message instead of separate entries.
  * Updated related behavior so retry notices no longer show extra error-detail sections in the transcript.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->