### PR TITLE
feat(workspace): expose app toolchain root

### DIFF
--- a/docs/architecture/workspace-app-factory.md
+++ b/docs/architecture/workspace-app-factory.md
@@ -121,6 +121,7 @@ Rules:
 - App data belongs under `TUTTI_APP_DATA_DIR`.
 - Runtime scratch files belong under `TUTTI_APP_RUNTIME_DIR`.
 - Logs belong under `TUTTI_APP_LOG_DIR`.
+- Shared app-managed toolchains belong under `TUTTI_APP_TOOLCHAIN_ROOT`.
 - Package content should treat `TUTTI_APP_PACKAGE_DIR` as read-only at runtime.
 - Workspace root access is allowed, but generated app instructions should avoid
   writing workspace files unless the user request explicitly requires it.

--- a/docs/conventions/local-state-storage.md
+++ b/docs/conventions/local-state-storage.md
@@ -127,6 +127,7 @@ Migrated agent runtime state should derive from the same root:
           runtime/
           data/
           logs/
+  app-toolchains/
 ```
 
 `agent/sessions` stores daemon-created working directories for agent sessions
@@ -169,6 +170,8 @@ Tutti provider startup.
 - local development scripts install or repair `<state-dir>/bin/tutti-dev` as the development CLI command and default it to `TUTTI_ENV=development`
 - workspace app package cache, per-installation runtime/data/log state, and
   app factory job working directories live under `<state-dir>/apps`
+- workspace apps receive `<state-dir>/app-toolchains` as the shared cache root
+  for reusable app-managed binaries
 
 ## Validation
 

--- a/services/tuttid/service/workspace/app_factory.go
+++ b/services/tuttid/service/workspace/app_factory.go
@@ -434,6 +434,7 @@ func prepareAppFactoryJob(ctx context.Context, job workspacebiz.AppFactoryJob) e
 		"TUTTI_APP_RUNTIME_DIR=" + job.RuntimeDir,
 		"TUTTI_APP_DATA_DIR=" + job.DataDir,
 		"TUTTI_APP_LOG_DIR=" + job.LogDir,
+		"TUTTI_APP_TOOLCHAIN_ROOT=" + tuttiAppToolchainRoot(),
 	}
 	envOverrides = append(envOverrides, appRuntime.EnvOverrides...)
 	command.Env = workspaceAppProcessEnv(envOverrides...)

--- a/services/tuttid/service/workspace/app_factory_reference/SKILL.md
+++ b/services/tuttid/service/workspace/app_factory_reference/SKILL.md
@@ -117,6 +117,7 @@ The runtime must:
 - Write durable app data only under `$TUTTI_APP_DATA_DIR`.
 - Write scratch/runtime files only under `$TUTTI_APP_RUNTIME_DIR`.
 - Write logs only under `$TUTTI_APP_LOG_DIR` when backend/server-side file logs are needed.
+- Store reusable app-managed binaries only under `$TUTTI_APP_TOOLCHAIN_ROOT`.
 - Prefer `window.tuttiExternal?.logs?.write?.()` for browser-side diagnostics in Tutti Desktop; reserve `$TUTTI_APP_LOG_DIR` for backend process logs.
 - Read `$TUTTI_WORKSPACE_ROOT` only when the app needs workspace context.
 - Launch Python with `$TUTTI_APP_PYTHON` and Node with `$TUTTI_APP_NODE`; use `$TUTTI_APP_NPM` for npm install/build work.

--- a/services/tuttid/service/workspace/app_factory_reference/references/runtime-env.md
+++ b/services/tuttid/service/workspace/app_factory_reference/references/runtime-env.md
@@ -11,6 +11,7 @@ Use these environment variables:
 - `TUTTI_APP_RUNTIME_DIR`: scratch/runtime files.
 - `TUTTI_APP_DATA_DIR`: durable app data.
 - `TUTTI_APP_LOG_DIR`: app logs.
+- `TUTTI_APP_TOOLCHAIN_ROOT`: shared daemon-owned toolchain cache for app-managed binaries that are safe to reuse across workspace app installations.
 - `TUTTI_APP_PYTHON`: managed Python interpreter path for generated apps.
 - `TUTTI_APP_NODE`: managed Node.js executable path for generated apps.
 - `TUTTI_APP_NPM`: managed npm executable path for generated apps.

--- a/services/tuttid/service/workspace/app_factory_reference/references/validation-checklist.md
+++ b/services/tuttid/service/workspace/app_factory_reference/references/validation-checklist.md
@@ -21,6 +21,7 @@ Before finishing:
 - Durable app data is written only under `TUTTI_APP_DATA_DIR`.
 - Runtime scratch data is written only under `TUTTI_APP_RUNTIME_DIR`.
 - Logs are written only under `TUTTI_APP_LOG_DIR`.
+- Reusable app-managed binaries are written only under `TUTTI_APP_TOOLCHAIN_ROOT`.
 - In-app localization reads optional app context or browser locale APIs, not launch URL query params.
 - Theme rendering uses `prefers-color-scheme`, not launch URL query params.
 - `AGENTS.md` describes package layout, runtime command, endpoints, data storage, and modification guidance.

--- a/services/tuttid/service/workspace/app_factory_test.go
+++ b/services/tuttid/service/workspace/app_factory_test.go
@@ -519,6 +519,49 @@ func TestAppFactoryServiceReconcileInterruptedJobsMarksActiveJobsFailed(t *testi
 	}
 }
 
+func TestPrepareAppFactoryJobInjectsToolchainRoot(t *testing.T) {
+	ctx := context.Background()
+	stateDir := t.TempDir()
+	draftDir := filepath.Join(stateDir, "apps", "factory", "jobs", "job-1", "draft")
+	packageDir := filepath.Join(draftDir, appFactoryPackageRootRelativePath)
+	runtimeDir := filepath.Join(stateDir, "apps", "factory", "jobs", "job-1", "runtime")
+	dataDir := filepath.Join(stateDir, "apps", "factory", "jobs", "job-1", "data")
+	logDir := filepath.Join(stateDir, "apps", "factory", "jobs", "job-1", "logs")
+	for _, dir := range []string{packageDir, runtimeDir, dataDir, logDir} {
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			t.Fatalf("create %s: %v", dir, err)
+		}
+	}
+	t.Setenv("TUTTI_STATE_DIR", stateDir)
+	t.Setenv(tuttiAppRuntimeRootEnv, createManagedAppRuntimeFixture(t, stateDir))
+
+	preparePath := filepath.Join(packageDir, "prepare.sh")
+	if err := os.WriteFile(preparePath, []byte(`#!/bin/sh
+printf '%s\n' "$TUTTI_APP_TOOLCHAIN_ROOT" > "$TUTTI_APP_DATA_DIR/toolchain-root.txt"
+`), 0o755); err != nil {
+		t.Fatalf("write prepare.sh: %v", err)
+	}
+
+	err := prepareAppFactoryJob(ctx, workspacebiz.AppFactoryJob{
+		AppID:      "app_1",
+		DraftDir:   draftDir,
+		RuntimeDir: runtimeDir,
+		DataDir:    dataDir,
+		LogDir:     logDir,
+	})
+	if err != nil {
+		t.Fatalf("prepareAppFactoryJob() error = %v", err)
+	}
+	data, err := os.ReadFile(filepath.Join(dataDir, "toolchain-root.txt"))
+	if err != nil {
+		t.Fatalf("read toolchain root probe: %v", err)
+	}
+	want := filepath.Join(stateDir, "app-toolchains") + "\n"
+	if string(data) != want {
+		t.Fatalf("toolchain root = %q, want %q", data, want)
+	}
+}
+
 func TestAppFactoryServiceReconcileIdleCompletedAgentSessionStartsValidation(t *testing.T) {
 	t.Parallel()
 

--- a/services/tuttid/service/workspace/apps_runner.go
+++ b/services/tuttid/service/workspace/apps_runner.go
@@ -203,6 +203,7 @@ func (r *AppRunner) startProcess(ctx context.Context, key string, input AppStart
 	command.Stderr = logFile
 	tuttiCLIShim := tuttiCLIShimPath()
 	tuttiAPIBaseURL := tuttiAPIBaseURLFromEnv()
+	appToolchainRoot := tuttiAppToolchainRoot()
 	envOverrides := []string{
 		"TUTTI_APP_ID=" + input.AppID,
 		"TUTTI_WORKSPACE_ID=" + input.WorkspaceID,
@@ -213,6 +214,7 @@ func (r *AppRunner) startProcess(ctx context.Context, key string, input AppStart
 		"TUTTI_APP_RUNTIME_DIR=" + input.RuntimeDir,
 		"TUTTI_APP_DATA_DIR=" + input.DataDir,
 		"TUTTI_APP_LOG_DIR=" + input.LogDir,
+		"TUTTI_APP_TOOLCHAIN_ROOT=" + appToolchainRoot,
 		"TUTTI_APP_PORT=" + strconv.Itoa(port),
 		"TUTTI_APP_BASE_URL=http://127.0.0.1:" + strconv.Itoa(port),
 		"TUTTI_API_BASE_URL=" + tuttiAPIBaseURL,
@@ -473,6 +475,7 @@ func writeAppStartupDiagnostic(logFile *os.File, input AppStartInput, bootstrapP
 	_, _ = fmt.Fprintf(logFile, "  packageDir=%s\n", input.PackageDir)
 	_, _ = fmt.Fprintf(logFile, "  dataDir=%s\n", input.DataDir)
 	_, _ = fmt.Fprintf(logFile, "  logDir=%s\n", input.LogDir)
+	_, _ = fmt.Fprintf(logFile, "  toolchainRoot=%s\n", appRuntimeEnvValue(env, "TUTTI_APP_TOOLCHAIN_ROOT"))
 	_, _ = fmt.Fprintf(logFile, "  host=127.0.0.1\n")
 	_, _ = fmt.Fprintf(logFile, "  port=%d\n", port)
 	_, _ = fmt.Fprintf(logFile, "  path=%s\n", appRuntimeEnvValue(env, "PATH"))
@@ -689,6 +692,10 @@ func allocateLoopbackPort() (int, error) {
 
 func tuttiCLIShimPath() string {
 	return tuttiCLIShimPathForPlatform(runtime.GOOS)
+}
+
+func tuttiAppToolchainRoot() string {
+	return filepath.Join(tuttitypes.DefaultStateDir(), "app-toolchains")
 }
 
 func appRuntimePathWithCLIShim(appRuntime ResolvedAppRuntime, cliShimPath string) string {

--- a/services/tuttid/service/workspace/apps_runner_test.go
+++ b/services/tuttid/service/workspace/apps_runner_test.go
@@ -95,6 +95,7 @@ exec "$TUTTI_APP_PYTHON" "$TUTTI_APP_PACKAGE_DIR/server.py"
 		"runtimeDir":    runtimeDir,
 		"dataDir":       dataDir,
 		"logDir":        logDir,
+		"toolchainRoot": filepath.Join(stateRoot, "app-toolchains"),
 		"workspaceRoot": root,
 	} {
 		if probeValues[key] != want {
@@ -730,6 +731,7 @@ func pythonAppReadyServerScript(healthcheckPath string, writeProbe bool) string 
                 "runtimeDir": os.environ["TUTTI_APP_RUNTIME_DIR"],
                 "dataDir": os.environ["TUTTI_APP_DATA_DIR"],
                 "logDir": os.environ["TUTTI_APP_LOG_DIR"],
+                "toolchainRoot": os.environ["TUTTI_APP_TOOLCHAIN_ROOT"],
                 "tuttiCli": os.environ["TUTTI_CLI"],
                 "path": os.environ["PATH"],
             }, f)


### PR DESCRIPTION
## Summary
- inject `TUTTI_APP_TOOLCHAIN_ROOT` into workspace app runtime and factory prepare environments
- document the shared app-managed toolchain cache in workspace app factory and local state docs
- add coverage for runtime and prepare-time env propagation

## Validation
- `go test ./service/workspace`
- `pnpm check:changed --tail-lines 80`
- `pnpm test:go`
- `pnpm lint:go`
- `pnpm build:go`
- `pnpm typecheck`
- `pnpm check:full`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for a shared app toolchain cache path for workspace apps.
  * Workspace app startup now exposes a toolchain-root environment value for app-managed binaries.

* **Documentation**
  * Updated workspace architecture, runtime, and validation docs to describe the new shared toolchain location and usage rules.

* **Tests**
  * Expanded test coverage to verify the toolchain-root value is passed through and reported correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->