### PR TITLE
docs(app-skills): clarify managed agent migration checklist

### DIFF
--- a/services/tuttid/service/workspace/agent_workspace_app_reference/SKILL.md
+++ b/services/tuttid/service/workspace/agent_workspace_app_reference/SKILL.md
@@ -41,11 +41,28 @@ Also read `$tutti-workspace-app-factory` before changing final package files or 
 2. Choose the smallest architecture that can stay maintainable: do not add local agents, WebSocket, MCP, CLI, or background workers unless the product needs them.
 3. Define shared contracts before wiring web/server calls. Keep domain DTOs, WebSocket messages, CLI-visible shapes, and runtime profile types in `packages/shared`.
 4. Build the web UI as the primary development surface. Keep the server as local API/static host and app orchestration layer.
-5. If agents are needed, add `@tutti-os/agent-acp-kit`, provider detection, runtime provider abstraction, event normalization, and a run-scoped tool gateway.
+5. If agents are needed, add `@tutti-os/agent-acp-kit`, provider detection, runtime provider abstraction, event normalization, and a run-scoped tool gateway. For apps that must run both locally and in cloud/managed Tutti, follow `references/agent-acp-kit.md` exactly: managed credentials come from request headers on the server, never from browser JSB fallback or request body fields.
 6. Add package generation only after the local dev app runs. Package the built web assets, bundled server, `tutti.app.json`, optional `tutti.cli.json`, executable `bootstrap.sh`, assets, locales, and package-local `AGENTS.md`.
 7. If the user asks to connect to the Tutti app ecosystem, treat ecosystem integration as required: expose app capabilities through `tutti.cli.json`, make the app callable by other Tutti apps and agents, and use `TUTTI_CLI` for any calls to other installed Tutti apps.
 8. For GitHub-hosted app repositories that should publish releases, add staging and production release workflows after the package builder is stable.
 9. Verify with the repo's targeted checks first, then package checks.
+
+## Cloud-Compatible Local Agent Checklist
+
+When adapting an existing local-first agent app for cloud/managed Tutti, the app must keep the local path working while removing app-owned credential plumbing:
+
+1. Upgrade `@tutti-os/agent-acp-kit` to a version that exports managed-agent header context helpers.
+2. In server-side detect/model endpoints, call `createManagedAgentDetectContextFromHeaders(req.headers)` and pass the returned context to `localAgentRuntime.detect(...)`.
+3. In server-side run creation, call `createManagedAgentRunContextFromHeaders(req.headers, { providerId, runId })`.
+4. Pass only `cwd: runContext.cwd` and `managedAgentInvocation: runContext.managedAgentInvocation` into `localAgentRuntime.run(...)`.
+5. Delete browser JSB credential fallback code.
+6. Delete request body credential fields and client-side credential forwarding.
+7. Never persist managed credentials.
+8. Never expose managed cwd or credentials through frontend events, logs, status APIs, or stored app state.
+9. Do not hard-code `/workspace`, `.agent-runs`, or `CODEX_HOME` policy in the app business layer. Let the kit derive managed run context from headers and runtime env.
+10. If agent instructions are sent over WebSocket, confirm the Tutti/TSH host injects the managed credential into that WebSocket route too; do not invent a second credential channel inside the app.
+11. Add or update the cloud zip/package script so the packaged app contains the built server, web assets, MCP/tool entrypoints, and runtime metadata needed by Tutti.
+12. Add tests covering SSR/server detect, model detect, run context creation, credential non-leakage, and local no-header fallback behavior.
 
 ## Validation
 

--- a/services/tuttid/service/workspace/agent_workspace_app_reference/references/agent-acp-kit.md
+++ b/services/tuttid/service/workspace/agent_workspace_app_reference/references/agent-acp-kit.md
@@ -6,6 +6,8 @@ Use this reference only when the app needs local Codex/Claude execution or a loc
 
 If the app involves local agents, depend on `@tutti-os/agent-acp-kit`. Do not hand-roll provider detection, ACP stream parsing, or local-agent adapters unless the kit lacks a required capability and the gap is documented.
 
+For apps that must work in both local Tutti and cloud/managed Tutti, use an `@tutti-os/agent-acp-kit` version that provides managed-agent header context helpers. The app server should derive managed context from request headers and pass it directly to the kit runtime. The browser, request body, app state, and logs must not carry managed credentials.
+
 ## Runtime Shape
 
 Keep app domain logic independent from providers:
@@ -22,10 +24,11 @@ Use provider IDs from the kit or an explicit allowlist such as `codex` and `clau
 
 ## Provider Detection
 
-Create a small discovery wrapper:
+Create a small discovery wrapper. Server detect/model endpoints should derive a context from request headers:
 
 ```ts
 import {
+  createManagedAgentDetectContextFromHeaders,
   createDefaultLocalAgentProviderPlugins,
   createLocalAgentRuntime
 } from "@tutti-os/agent-acp-kit";
@@ -34,33 +37,46 @@ const localAgentRuntime = createLocalAgentRuntime({
   providers: createDefaultLocalAgentProviderPlugins()
 });
 
-export async function detectLocalAgents() {
-  return localAgentRuntime.detect();
+export async function detectLocalAgents(
+  headers: Headers | Record<string, string | string[] | undefined>
+) {
+  const context = createManagedAgentDetectContextFromHeaders(headers);
+  return localAgentRuntime.detect(context);
 }
 ```
 
 Map detected provider models to app model IDs with a provider prefix, such as `codex:gpt-5.1` or `claude:sonnet`.
 
+Do not call a browser JSB API to fetch credentials for detection. Do not accept a credential field in the request body. If no managed credential header is present, the helper returns a local-compatible context and detection continues through the normal local path.
+
 ## Runtime Execution
 
 For each agent run:
 
-1. Create a temporary run directory.
-2. Materialize any app or workspace skills under that directory using relative paths.
-3. Build a prompt envelope with conversation identity, current user turn, attachments, current app state, collaboration rules, and tool gateway guidance.
-4. Create a run-scoped tool gateway session and MCP config.
-5. Call `localAgentRuntime.run(...)`.
-6. Normalize ACP events into app stream events.
-7. Persist provider session/resume metadata when the kit returns it.
-8. Always revoke the gateway token and remove the temporary run directory in `finally`.
+1. Generate a stable app run ID.
+2. Derive managed run context on the server from request headers with `createManagedAgentRunContextFromHeaders(...)`.
+3. Materialize app or workspace skills only when the app needs them, using paths under the returned `runContext.cwd` or app-owned runtime/data paths. Do not invent a separate managed cwd policy.
+4. Build a prompt envelope with conversation identity, current user turn, attachments, current app state, collaboration rules, and tool gateway guidance.
+5. Create a run-scoped tool gateway session and MCP config.
+6. Call `localAgentRuntime.run(...)` with the returned managed invocation context.
+7. Normalize ACP events into app stream events.
+8. Persist provider session/resume metadata when the kit returns it, but never persist managed credentials.
+9. Always revoke the gateway token and clean up app-owned temporary files in `finally`.
 
 Skeleton:
 
 ```ts
+import { createManagedAgentRunContextFromHeaders } from "@tutti-os/agent-acp-kit";
+
+const runContext = createManagedAgentRunContextFromHeaders(req.headers, {
+  providerId: provider,
+  runId
+});
+
 for await (const event of localAgentRuntime.run({
   runId,
   provider,
-  cwd: runDir,
+  cwd: runContext.cwd,
   prompt,
   systemPrompt,
   model,
@@ -70,13 +86,24 @@ for await (const event of localAgentRuntime.run({
   resume,
   signal,
   skillManifest,
-  timeoutMs
+  timeoutMs,
+  managedAgentInvocation: runContext.managedAgentInvocation
 })) {
   yield adaptLocalAgentEvent(event);
 }
 ```
 
 Do not claim a file write, canvas edit, image generation, or other side effect happened unless the corresponding tool event succeeded.
+
+Do not add these managed-agent anti-patterns:
+
+- Browser-side JSB credential fallback.
+- Request body fields such as `credential` or `managedAgentCredential`.
+- Persisted credential state.
+- Frontend events, logs, status APIs, or stored run metadata that expose managed credentials or managed cwd.
+- Business-layer hard-coding of `/workspace`, `.agent-runs`, or `CODEX_HOME` strategy. The kit owns managed run context and Codex home behavior.
+
+If the app sends agent instructions over WebSocket instead of HTTP POST, verify the Tutti/TSH host injects the managed credential header into that WebSocket route. The app should still read the credential from headers; it should not create a parallel credential transport.
 
 ## Event Mapping
 
@@ -146,6 +173,11 @@ Package builders should bundle the MCP entrypoint and expose its path through an
 Add tests for:
 
 - provider filtering and model mapping
+- SSR/server provider detection using `createManagedAgentDetectContextFromHeaders(...)`
+- model-list detection using request-header managed context
+- run creation using `createManagedAgentRunContextFromHeaders(...)`
+- local no-header fallback behavior
+- credential non-leakage in response DTOs, logs, frontend events, and persisted run state
 - event normalization
 - MCP config env and packaged path
 - tool gateway token validation and revocation

--- a/services/tuttid/service/workspace/agent_workspace_app_reference/references/package-builder.md
+++ b/services/tuttid/service/workspace/agent_workspace_app_reference/references/package-builder.md
@@ -19,6 +19,7 @@ The package builder should:
 - Include package-local `AGENTS.md`, optional `COMMANDS.md`, icons, locales, docs needed by agents, built web assets, and server bundle.
 - Reject symlinks and missing required files.
 - Validate package manifest, CLI manifest linkage, references endpoint linkage, and bootstrap executability.
+- For cloud-compatible agent apps, include the same server routes that call `@tutti-os/agent-acp-kit` managed header context helpers. The package script should package those routes; it must not add separate credential body fields, browser JSB fallback, managed cwd remapping, or `CODEX_HOME` setup.
 
 ## Bootstrap
 
@@ -30,6 +31,7 @@ Generated `bootstrap.sh` should:
 - Use `TUTTI_APP_DATA_DIR`, `TUTTI_APP_RUNTIME_DIR`, and `TUTTI_APP_LOG_DIR` for mutable files.
 - Set a package-local path for bundled MCP tools when local agents need them.
 - Start all required child processes and clean them up on `INT`/`TERM`.
+- Leave managed-agent credential, managed run cwd, and Codex home policy to `@tutti-os/agent-acp-kit` server calls. Do not export credentials or synthesize `CODEX_HOME` in `bootstrap.sh`.
 
 Pattern:
 

--- a/services/tuttid/service/workspace/app_factory_reference/SKILL.md
+++ b/services/tuttid/service/workspace/app_factory_reference/SKILL.md
@@ -12,7 +12,7 @@ Use this skill to create, convert, or repair one Tutti workspace app. Choose one
 
 When the user selected a directory in App Center and Tutti reports that it cannot be loaded, treat the task as local debug repair. Adapt the selected project by creating or fixing `.tutti/dev-app/`; do not create a zip wrapper or copy the repository into `package/` unless the user explicitly asks for release packaging.
 
-For a full agent-enabled Tutti app repository with `apps/web`, `apps/server`, `packages/shared`, `@tutti-os/agent-acp-kit`, local Codex/Claude runtimes, MCP tool gateways, and an app-owned package builder, use `$tutti-agent-workspace-app` first. Return to this skill for the final package contract and validation.
+For a full agent-enabled Tutti app repository with `apps/web`, `apps/server`, `packages/shared`, `@tutti-os/agent-acp-kit`, local Codex/Claude runtimes, MCP tool gateways, and an app-owned package builder, use `$tutti-agent-workspace-app` first. Return to this skill for the final package contract and validation. Do not invent managed-agent credential, cwd, JSB fallback, request-body credential, or `CODEX_HOME` behavior in this factory skill; the agent app skill owns that migration checklist and should keep those concerns in server-side kit calls.
 
 ## Version Check And Update Reminder
 


### PR DESCRIPTION
## Summary
- Replaced the earlier broad guidance with a concrete cloud/managed Tutti migration checklist for local-first agent apps.
- Updated the agent app skill to require server-side `@tutti-os/agent-acp-kit` header context helpers for detect/model and run creation.
- Documented the exact runtime handoff: pass `cwd: runContext.cwd` and `managedAgentInvocation: runContext.managedAgentInvocation` into `localAgentRuntime.run(...)`.
- Explicitly forbid app-owned JSB credential fallback, request-body credentials, credential persistence/leakage, `/workspace` / `.agent-runs` / `CODEX_HOME` business-layer policy, and parallel WS credential channels.
- Clarified package builder/factory boundaries: cloud package scripts should package the agent server routes, while managed credential/cwd/Codex home policy stays in the SDK layer.

## Validation
- `git diff --check HEAD~1..HEAD`
- `python3 /Users/wwcome/.codex/skills/.system/skill-creator/scripts/quick_validate.py services/tuttid/service/workspace/agent_workspace_app_reference`
- `python3 /Users/wwcome/.codex/skills/.system/skill-creator/scripts/quick_validate.py services/tuttid/service/workspace/app_factory_reference`
- pre-commit staged checks passed during commit
- subagent review: no Critical/Important/Minor issues; confirmed the 12 requested migration points are covered in tracked skill source files


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified guidance for agent-enabled app repositories to use the cloud-compatible agent workflow first.
  * Added a checklist for managing local and cloud agent behavior, including safer handling of credentials and run context.
  * Updated integration and packaging guidance with clearer rules for header-based context, local fallback behavior, and test coverage expectations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->