### PR TITLE
fix(workspace-apps): stabilize webview update handoff

### DIFF
--- a/apps/desktop/src/renderer/src/features/workspace-app-center/services/internal/workspaceAppCenterContribution.test.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-app-center/services/internal/workspaceAppCenterContribution.test.ts
@@ -523,6 +523,34 @@ test("workspace app webview does not preserve idle app without recent handoff", 
   );
 });
 
+test("workspace app webview does not bridge terminal idle or failed handoff states", () => {
+  for (const runtimeStatus of ["idle", "failed"] as const) {
+    const app = createApp({
+      installed: true,
+      installProgress: null,
+      launchUrl: null,
+      runtimeStatus
+    });
+    const handoffOptions = {
+      externalNodeUrl: "http://127.0.0.1:58028/",
+      hadRecentHandoff: true
+    };
+
+    assert.equal(
+      shouldPreserveWorkspaceAppWebviewDuringHandoff(app, handoffOptions),
+      false
+    );
+    assert.equal(
+      shouldRenderWorkspaceAppBrowserNode(
+        app,
+        "http://127.0.0.1:58028/",
+        handoffOptions
+      ),
+      false
+    );
+  }
+});
+
 test("workspace app webview resumes default URL sync outside update handoff", () => {
   const runningApp = createApp({
     installed: true,

--- a/apps/desktop/src/renderer/src/features/workspace-app-center/services/internal/workspaceAppCenterContribution.test.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-app-center/services/internal/workspaceAppCenterContribution.test.ts
@@ -8,6 +8,11 @@ import type {
   WorkspaceAppCenterReadableStoreState
 } from "@tutti-os/workspace-app-center";
 import { createWorkspaceAppWebviewBrowserLease } from "./workspaceAppWebviewBrowserAnalytics.ts";
+import {
+  shouldPreserveWorkspaceAppWebviewDuringHandoff,
+  shouldRenderWorkspaceAppBrowserNode,
+  shouldSyncWorkspaceAppWebviewDefaultUrl
+} from "./workspaceAppCenterWebviewHandoff.ts";
 import { resolveWorkspaceAppWebviewUrl } from "./workspaceAppCenterWebviewUrl.ts";
 import {
   readWorkspaceAppIdFromNodeId,
@@ -237,6 +242,29 @@ test("workspace app webview URL prefers the current launch URL over stale activa
   );
 });
 
+test("workspace app webview URL preserves external runtime URL during update handoff", () => {
+  assert.equal(
+    resolveWorkspaceAppWebviewUrl({
+      activation: {
+        payload: {
+          appId: "group-chat",
+          url: "http://127.0.0.1:4173/rooms/old"
+        },
+        sequence: 1,
+        type: "open-url"
+      },
+      appCanUseExternalState: true,
+      appLaunchUrl: "http://127.0.0.1:51234/",
+      externalNodeState: {
+        title: "Group Chat",
+        url: "http://127.0.0.1:4173/rooms/old"
+      },
+      preferExternalState: true
+    }),
+    "http://127.0.0.1:4173/rooms/old"
+  );
+});
+
 test("workspace app webview URL preserves same-origin activation deep links", () => {
   assert.equal(
     resolveWorkspaceAppWebviewUrl({
@@ -348,6 +376,210 @@ test("workspace app open-route rejects protocol-relative routes", async () => {
     title: "Ready",
     url: "http://127.0.0.1:51234/app-shell/"
   });
+});
+
+test("workspace app webview stays mounted during running app update handoff", () => {
+  const installingApp = createApp({
+    installed: true,
+    launchUrl: "http://127.0.0.1:51234/",
+    runtimeStatus: "installing"
+  });
+
+  assert.equal(
+    shouldPreserveWorkspaceAppWebviewDuringHandoff(installingApp),
+    true
+  );
+  assert.equal(
+    shouldRenderWorkspaceAppBrowserNode(
+      installingApp,
+      "http://127.0.0.1:51234/"
+    ),
+    true
+  );
+});
+
+test("workspace app webview shows update handoff while progress is published for a running app", () => {
+  const downloadingApp = createApp({
+    installed: true,
+    installProgress: {
+      downloadedBytes: null,
+      indeterminate: false,
+      overallPercent: 0,
+      totalBytes: null,
+      userPhase: "downloading"
+    },
+    launchUrl: "http://127.0.0.1:51234/",
+    runtimeStatus: "running"
+  });
+
+  assert.equal(
+    shouldPreserveWorkspaceAppWebviewDuringHandoff(downloadingApp),
+    true
+  );
+  assert.equal(
+    shouldRenderWorkspaceAppBrowserNode(
+      downloadingApp,
+      "http://127.0.0.1:51234/"
+    ),
+    true
+  );
+  assert.equal(shouldSyncWorkspaceAppWebviewDefaultUrl(downloadingApp), false);
+});
+
+test("workspace app webview handoff does not mount without a usable URL", () => {
+  const installingApp = createApp({
+    installed: true,
+    launchUrl: null,
+    runtimeStatus: "installing"
+  });
+
+  assert.equal(
+    shouldRenderWorkspaceAppBrowserNode(installingApp, "about:blank"),
+    false
+  );
+});
+
+test("workspace app webview stays mounted while installed package is waiting for restart", () => {
+  const pendingRestartApp = createApp({
+    installed: true,
+    installProgress: null,
+    launchUrl: "http://127.0.0.1:51234/",
+    runtimeStatus: "installed_pending_restart"
+  });
+
+  assert.equal(
+    shouldPreserveWorkspaceAppWebviewDuringHandoff(pendingRestartApp),
+    true
+  );
+  assert.equal(
+    shouldRenderWorkspaceAppBrowserNode(
+      pendingRestartApp,
+      "http://127.0.0.1:51234/"
+    ),
+    true
+  );
+  assert.equal(
+    shouldSyncWorkspaceAppWebviewDefaultUrl(pendingRestartApp),
+    false
+  );
+});
+
+test("workspace app webview bridges transient stopping during update handoff", () => {
+  const stoppingApp = createApp({
+    installed: true,
+    installProgress: null,
+    launchUrl: null,
+    runtimeStatus: "stopping"
+  });
+
+  assert.equal(
+    shouldPreserveWorkspaceAppWebviewDuringHandoff(stoppingApp, {
+      externalNodeUrl: "http://127.0.0.1:58028/",
+      hadRecentHandoff: true
+    }),
+    true
+  );
+  assert.equal(
+    shouldRenderWorkspaceAppBrowserNode(
+      stoppingApp,
+      "http://127.0.0.1:58028/",
+      {
+        externalNodeUrl: "http://127.0.0.1:58028/",
+        hadRecentHandoff: true
+      }
+    ),
+    true
+  );
+  assert.equal(
+    shouldSyncWorkspaceAppWebviewDefaultUrl(stoppingApp, {
+      externalNodeUrl: "http://127.0.0.1:58028/",
+      hadRecentHandoff: true
+    }),
+    false
+  );
+});
+
+test("workspace app webview does not preserve idle app without recent handoff", () => {
+  const idleApp = createApp({
+    installed: true,
+    installProgress: null,
+    launchUrl: null,
+    runtimeStatus: "idle"
+  });
+
+  assert.equal(
+    shouldPreserveWorkspaceAppWebviewDuringHandoff(idleApp, {
+      externalNodeUrl: "http://127.0.0.1:58028/",
+      hadRecentHandoff: false
+    }),
+    false
+  );
+  assert.equal(
+    shouldRenderWorkspaceAppBrowserNode(idleApp, "http://127.0.0.1:58028/", {
+      externalNodeUrl: "http://127.0.0.1:58028/",
+      hadRecentHandoff: false
+    }),
+    false
+  );
+});
+
+test("workspace app webview resumes default URL sync outside update handoff", () => {
+  const runningApp = createApp({
+    installed: true,
+    installProgress: null,
+    launchUrl: "http://127.0.0.1:51234/",
+    runtimeStatus: "running"
+  });
+
+  assert.equal(shouldSyncWorkspaceAppWebviewDefaultUrl(runningApp), true);
+});
+
+test("workspace app webview keeps handoff cover while syncing to the restarted runtime URL", () => {
+  const runningApp = createApp({
+    installed: true,
+    installProgress: null,
+    launchUrl: "http://127.0.0.1:59636",
+    runtimeStatus: "running"
+  });
+  const handoffOptions = {
+    externalNodeUrl: "http://127.0.0.1:59586/",
+    hadRecentHandoff: true
+  };
+
+  assert.equal(
+    shouldPreserveWorkspaceAppWebviewDuringHandoff(runningApp, handoffOptions),
+    true
+  );
+  assert.equal(
+    shouldRenderWorkspaceAppBrowserNode(
+      runningApp,
+      "http://127.0.0.1:59636",
+      handoffOptions
+    ),
+    true
+  );
+  assert.equal(
+    shouldSyncWorkspaceAppWebviewDefaultUrl(runningApp, handoffOptions),
+    true
+  );
+  assert.equal(
+    resolveWorkspaceAppWebviewUrl({
+      activation: null,
+      appCanUseExternalState: true,
+      appLaunchUrl: runningApp.launchUrl ?? null,
+      externalNodeState: {
+        title: "Group Chat",
+        url: handoffOptions.externalNodeUrl
+      },
+      preferExternalState:
+        shouldPreserveWorkspaceAppWebviewDuringHandoff(
+          runningApp,
+          handoffOptions
+        ) &&
+        !shouldSyncWorkspaceAppWebviewDefaultUrl(runningApp, handoffOptions)
+    }),
+    "http://127.0.0.1:59636"
+  );
 });
 
 test("workspace app dock entry focus reports app open from the dock entry id", () => {

--- a/apps/desktop/src/renderer/src/features/workspace-app-center/services/internal/workspaceAppCenterContribution.tsx
+++ b/apps/desktop/src/renderer/src/features/workspace-app-center/services/internal/workspaceAppCenterContribution.tsx
@@ -376,6 +376,10 @@ function WorkspaceAppWebviewBody({
       recentHandoffAppIdRef.current = null;
       return;
     }
+    if (app?.runtimeStatus === "idle" || app?.runtimeStatus === "failed") {
+      recentHandoffAppIdRef.current = null;
+      return;
+    }
     if (!app || recentHandoffAppIdRef.current !== appId) {
       recentHandoffAppIdRef.current = null;
     }

--- a/apps/desktop/src/renderer/src/features/workspace-app-center/services/internal/workspaceAppCenterContribution.tsx
+++ b/apps/desktop/src/renderer/src/features/workspace-app-center/services/internal/workspaceAppCenterContribution.tsx
@@ -1,4 +1,4 @@
-import { createElement, type ReactNode } from "react";
+import { createElement, useEffect, useRef, type ReactNode } from "react";
 import {
   type BrowserNodeNavigationPolicy,
   type BrowserNodeRuntimeState,
@@ -14,6 +14,7 @@ import type {
   WorkbenchHostDockEntry,
   WorkbenchHostExternalStateLookupInput,
   WorkbenchHostExternalStateSource,
+  WorkbenchHostNodeBodyContext,
   WorkbenchHostNodeDefinition
 } from "@tutti-os/workbench-surface";
 import { WorkspaceAppCenterPane } from "../../ui/WorkspaceAppCenterPane.tsx";
@@ -36,6 +37,11 @@ import {
   type WorkspaceAppWebviewExternalState
 } from "./workspaceAppCenterWebviewUrl.ts";
 import { workspaceAppWebviewFrame } from "./workspaceAppWebviewFrame.ts";
+import {
+  shouldPreserveWorkspaceAppWebviewDuringHandoff,
+  shouldRenderWorkspaceAppBrowserNode,
+  shouldSyncWorkspaceAppWebviewDefaultUrl
+} from "./workspaceAppCenterWebviewHandoff.ts";
 import {
   findWorkspaceApp,
   readWorkspaceAppIdFromInstanceId,
@@ -272,48 +278,16 @@ function createWorkspaceAppWebviewNodeDefinition(input: {
     instance: {
       mode: "multi"
     },
-    renderBody: (context) => {
-      const appId =
-        readWorkspaceAppIdFromInstanceId(context.node.data.instanceId) ??
-        readWorkspaceAppOpenPayload(context.activation)?.appId ??
-        "unknown";
-      const app = findWorkspaceApp(input.appCenterService, appId);
-      const defaultUrl = resolveWorkspaceAppWebviewUrl({
-        activation: context.activation,
-        appCanUseExternalState: app ? app.runtimeStatus === "running" : false,
-        appLaunchUrl: app?.launchUrl ?? null,
-        externalNodeState: context.externalNodeState
-      });
-      const navigationPolicy = resolveWorkspaceAppWebviewNavigationPolicy({
-        appCenterService: input.appCenterService,
-        appId,
-        fallbackUrl: defaultUrl
-      });
-      if (!isWorkspaceAppWebviewReady(app, defaultUrl)) {
-        return (
-          <WorkspaceAppWebviewLoadingState
-            app={app}
-            copy={appCenterCopy}
-            fallbackLabel={input.i18n.t("common.loading")}
-          />
-        );
-      }
-      return (
-        <BrowserNode
-          defaultUrl={defaultUrl}
-          feature={input.browserFeature}
-          navigationPolicy={navigationPolicy}
-          nodeId={context.node.id}
-          onFocusRequest={context.isFocused ? undefined : () => context.focus()}
-          sessionPartition={workspaceAppBrowserSessionPartition({
-            appId,
-            workspaceId: input.workspaceId
-          })}
-          showHeader={false}
-          syncDefaultUrl={true}
-        />
-      );
-    },
+    renderBody: (context) => (
+      <WorkspaceAppWebviewBody
+        appCenterCopy={appCenterCopy}
+        appCenterService={input.appCenterService}
+        browserFeature={input.browserFeature}
+        context={context}
+        fallbackLabel={input.i18n.t("common.loading")}
+        workspaceId={input.workspaceId}
+      />
+    ),
     title: input.i18n.t("workspace.workbenchDesktop.nodes.appWebview"),
     typeId: workspaceAppWebviewTypeID,
     window: {
@@ -334,6 +308,114 @@ function createWorkspaceAppWebviewNodeDefinition(input: {
       restoreOnLoad: true
     }
   };
+}
+
+function WorkspaceAppWebviewBody({
+  appCenterCopy,
+  appCenterService,
+  browserFeature,
+  context,
+  fallbackLabel,
+  workspaceId
+}: {
+  appCenterCopy: ReturnType<typeof createAppCenterI18nRuntime>;
+  appCenterService: IWorkspaceAppCenterService;
+  browserFeature: BrowserNodeFeature;
+  context: WorkbenchHostNodeBodyContext<
+    WorkspaceAppWebviewExternalState | null,
+    unknown
+  >;
+  fallbackLabel: string;
+  workspaceId: string;
+}): ReactNode {
+  const recentHandoffAppIdRef = useRef<string | null>(null);
+  const appId =
+    readWorkspaceAppIdFromInstanceId(context.node.data.instanceId) ??
+    readWorkspaceAppOpenPayload(context.activation)?.appId ??
+    "unknown";
+  const app = findWorkspaceApp(appCenterService, appId);
+  const externalNodeUrl = context.externalNodeState?.url ?? null;
+  const handoffOptions = {
+    externalNodeUrl,
+    hadRecentHandoff: recentHandoffAppIdRef.current === appId
+  };
+  const hasDirectHandoffState =
+    shouldPreserveWorkspaceAppWebviewDuringHandoff(app);
+  const preserveWebviewDuringHandoff =
+    shouldPreserveWorkspaceAppWebviewDuringHandoff(app, handoffOptions);
+  const shouldSyncDefaultUrl = shouldSyncWorkspaceAppWebviewDefaultUrl(
+    app,
+    handoffOptions
+  );
+  const defaultUrl = resolveWorkspaceAppWebviewUrl({
+    activation: context.activation,
+    appCanUseExternalState: app
+      ? app.runtimeStatus === "running" || preserveWebviewDuringHandoff
+      : false,
+    appLaunchUrl: app?.launchUrl ?? null,
+    externalNodeState: context.externalNodeState,
+    preferExternalState: preserveWebviewDuringHandoff && !shouldSyncDefaultUrl
+  });
+  const shouldRenderBrowserNode = shouldRenderWorkspaceAppBrowserNode(
+    app,
+    defaultUrl,
+    handoffOptions
+  );
+  const navigationPolicy = resolveWorkspaceAppWebviewNavigationPolicy({
+    appCenterService,
+    appId,
+    fallbackUrl: defaultUrl
+  });
+
+  useEffect(() => {
+    if (hasDirectHandoffState) {
+      recentHandoffAppIdRef.current = appId;
+      return;
+    }
+    if (app?.runtimeStatus === "running" && app.installProgress == null) {
+      recentHandoffAppIdRef.current = null;
+      return;
+    }
+    if (!app || recentHandoffAppIdRef.current !== appId) {
+      recentHandoffAppIdRef.current = null;
+    }
+  }, [app, appId, hasDirectHandoffState]);
+
+  if (!shouldRenderBrowserNode) {
+    return (
+      <WorkspaceAppWebviewLoadingState
+        app={app}
+        copy={appCenterCopy}
+        fallbackLabel={fallbackLabel}
+      />
+    );
+  }
+  return (
+    <div className="relative h-full min-h-0 w-full overflow-hidden bg-[var(--background-panel)]">
+      <BrowserNode
+        defaultUrl={defaultUrl}
+        feature={browserFeature}
+        navigationPolicy={navigationPolicy}
+        nodeId={context.node.id}
+        onFocusRequest={context.isFocused ? undefined : () => context.focus()}
+        sessionPartition={workspaceAppBrowserSessionPartition({
+          appId,
+          workspaceId
+        })}
+        showHeader={false}
+        syncDefaultUrl={shouldSyncDefaultUrl}
+      />
+      {preserveWebviewDuringHandoff ? (
+        <div className="pointer-events-auto absolute inset-0 z-20">
+          <WorkspaceAppWebviewLoadingState
+            app={app}
+            copy={appCenterCopy}
+            fallbackLabel={fallbackLabel}
+          />
+        </div>
+      ) : null}
+    </div>
+  );
 }
 
 function WorkspaceAppWebviewLoadingState({
@@ -462,16 +544,6 @@ function resolveWorkspaceAppWebviewNavigationPolicy(input: {
   };
 }
 
-function isWorkspaceAppWebviewReady(
-  app: WorkspaceAppCenterApp | null,
-  defaultUrl: string
-): boolean {
-  const url = normalizeWorkspaceAppUrl(defaultUrl);
-  return (
-    app?.runtimeStatus === "running" && url !== null && url !== "about:blank"
-  );
-}
-
 function shouldKeepWorkspaceAppWebviewMountedWhenMinimized(input: {
   appCenterService: IWorkspaceAppCenterService;
   instanceId: string;
@@ -479,13 +551,6 @@ function shouldKeepWorkspaceAppWebviewMountedWhenMinimized(input: {
   const appId = readWorkspaceAppIdFromInstanceId(input.instanceId);
   const app = appId ? findWorkspaceApp(input.appCenterService, appId) : null;
   return app?.minimizeBehavior !== "hibernate";
-}
-
-function normalizeWorkspaceAppUrl(
-  value: string | null | undefined
-): string | null {
-  const trimmed = value?.trim() ?? "";
-  return trimmed.length > 0 ? trimmed : null;
 }
 
 function workspaceAppBrowserSessionPartition(input: {

--- a/apps/desktop/src/renderer/src/features/workspace-app-center/services/internal/workspaceAppCenterService.test.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-app-center/services/internal/workspaceAppCenterService.test.ts
@@ -405,6 +405,93 @@ test("WorkspaceAppCenterService keeps update disabled while update install is pe
   assert.equal(service.store.apps[0]?.version, "1.1.0");
 });
 
+test("WorkspaceAppCenterService records low-volume diagnostics for running app update handoff", async () => {
+  const diagnostics: DesktopRendererDiagnosticPayload[] = [];
+  const service = new WorkspaceAppCenterService({
+    eventStreamClient: createEventStreamClient(),
+    gateway: createGateway({
+      installWorkspaceApp: async () =>
+        createSnapshot({
+          apps: [
+            createApp({
+              appId: "app-1",
+              availableVersion: null,
+              installed: true,
+              launchUrl: "http://127.0.0.1:51234/",
+              runtimeStatus: "running",
+              source: "builtin",
+              stateRevision: 4,
+              updateAvailable: false,
+              version: "1.1.0"
+            })
+          ]
+        }),
+      listWorkspaceApps: async () =>
+        createSnapshot({
+          apps: [
+            createApp({
+              appId: "app-1",
+              availableVersion: "1.1.0",
+              installed: true,
+              launchUrl: "http://127.0.0.1:50405/",
+              runtimeStatus: "running",
+              source: "builtin",
+              stateRevision: 3,
+              updateAvailable: true,
+              version: "1.0.0"
+            })
+          ]
+        })
+    }),
+    hostFilesApi: createHostFilesApi(),
+    hostWorkspaceApi: createHostWorkspaceApi(),
+    runtimeApi: {
+      async logRendererDiagnostic(payload) {
+        diagnostics.push(payload);
+      }
+    }
+  });
+
+  await service.refresh("workspace-1");
+  await service.updateApp({
+    appId: "app-1",
+    trigger: "primary_action",
+    workspaceId: "workspace-1"
+  });
+
+  assert.deepEqual(
+    diagnostics.map((entry) => {
+      const details = entry.details ?? {};
+      return {
+        event: entry.event,
+        launchUrlOrigin: details.launchUrlOrigin,
+        level: entry.level,
+        phase: details.phase,
+        runtimeStatus: details.runtimeStatus,
+        version: details.version
+      };
+    }),
+    [
+      {
+        event: "workspace_app_center_update_handoff",
+        launchUrlOrigin: "http://127.0.0.1:50405",
+        level: "debug",
+        phase: "started",
+        runtimeStatus: "running",
+        version: "1.0.0"
+      },
+      {
+        event: "workspace_app_center_update_handoff",
+        launchUrlOrigin: "http://127.0.0.1:51234",
+        level: "debug",
+        phase: "completed",
+        runtimeStatus: "running",
+        version: "1.1.0"
+      }
+    ]
+  );
+});
+
 test("WorkspaceAppCenterService waits for async install completion before tracking app install", async () => {
   const reporterCalls: ReporterEventInput[][] = [];
   let listCalls = 0;

--- a/apps/desktop/src/renderer/src/features/workspace-app-center/services/internal/workspaceAppCenterService.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-app-center/services/internal/workspaceAppCenterService.ts
@@ -596,7 +596,54 @@ export class WorkspaceAppCenterService implements IWorkspaceAppCenterService {
     trigger: "badge_button" | "primary_action";
     workspaceId: string;
   }): Promise<void> {
-    await this.controller.updateApp(input);
+    const previousApp = this.store.apps.find(
+      (candidate) => candidate.appId === input.appId
+    );
+    const shouldRecordHandoff =
+      previousApp?.installed === true &&
+      previousApp.runtimeStatus === "running";
+    const startedAt = shouldRecordHandoff ? Date.now() : 0;
+
+    if (shouldRecordHandoff) {
+      this.recordWorkspaceAppUpdateHandoff({
+        app: previousApp,
+        phase: "started",
+        trigger: input.trigger,
+        workspaceId: input.workspaceId
+      });
+    }
+
+    try {
+      await this.controller.updateApp(input);
+    } catch (error) {
+      if (shouldRecordHandoff) {
+        this.recordWorkspaceAppUpdateHandoff({
+          app:
+            this.store.apps.find(
+              (candidate) => candidate.appId === input.appId
+            ) ?? null,
+          durationMs: Date.now() - startedAt,
+          error,
+          phase: "failed",
+          trigger: input.trigger,
+          workspaceId: input.workspaceId
+        });
+      }
+      throw error;
+    }
+
+    if (shouldRecordHandoff) {
+      this.recordWorkspaceAppUpdateHandoff({
+        app:
+          this.store.apps.find(
+            (candidate) => candidate.appId === input.appId
+          ) ?? null,
+        durationMs: Date.now() - startedAt,
+        phase: "completed",
+        trigger: input.trigger,
+        workspaceId: input.workspaceId
+      });
+    }
   }
 
   async retryApp(input: { appId: string; workspaceId: string }): Promise<void> {
@@ -785,6 +832,33 @@ export class WorkspaceAppCenterService implements IWorkspaceAppCenterService {
         workspaceId: input.workspaceId
       })
       .catch(() => undefined);
+  }
+
+  private recordWorkspaceAppUpdateHandoff(input: {
+    app: WorkspaceAppCenterApp | null;
+    durationMs?: number;
+    error?: unknown;
+    phase: "started" | "completed" | "failed";
+    trigger: "badge_button" | "primary_action";
+    workspaceId: string;
+  }): void {
+    this.recordRendererDiagnostic({
+      details: {
+        appId: input.app?.appId ?? null,
+        durationMs: input.durationMs ?? null,
+        errorCode: input.error ? getDesktopErrorCode(input.error) : null,
+        errorMessage: input.error instanceof Error ? input.error.message : null,
+        launchUrlOrigin: resolveUrlOriginForDiagnostic(input.app?.launchUrl),
+        operation: "app_center.update.running_handoff",
+        phase: input.phase,
+        runtimeStatus: input.app?.runtimeStatus ?? null,
+        trigger: input.trigger,
+        version: input.app?.version ?? null
+      },
+      event: "workspace_app_center_update_handoff",
+      level: input.phase === "failed" ? "warn" : "debug",
+      workspaceId: input.workspaceId
+    });
   }
 
   private closeWorkspaceAppViews(
@@ -1347,6 +1421,20 @@ function summarizeFactoryJobsForDiagnostic(
     status: job.status,
     updatedAtUnixMs: job.updatedAtUnixMs
   }));
+}
+
+function resolveUrlOriginForDiagnostic(
+  value: string | null | undefined
+): string | null {
+  const trimmed = value?.trim() ?? "";
+  if (!trimmed) {
+    return null;
+  }
+  try {
+    return new URL(trimmed).origin;
+  } catch {
+    return null;
+  }
 }
 
 function noop(): void {}

--- a/apps/desktop/src/renderer/src/features/workspace-app-center/services/internal/workspaceAppCenterWebviewHandoff.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-app-center/services/internal/workspaceAppCenterWebviewHandoff.ts
@@ -64,7 +64,7 @@ function shouldBridgeWorkspaceAppWebviewHandoffGap(
   return (
     options.hadRecentHandoff === true &&
     normalizeWorkspaceAppUrl(options.externalNodeUrl) !== null &&
-    (app.runtimeStatus === "stopping" || app.runtimeStatus === "idle")
+    app.runtimeStatus === "stopping"
   );
 }
 

--- a/apps/desktop/src/renderer/src/features/workspace-app-center/services/internal/workspaceAppCenterWebviewHandoff.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-app-center/services/internal/workspaceAppCenterWebviewHandoff.ts
@@ -1,0 +1,106 @@
+import type {
+  WorkspaceAppCenterApp,
+  WorkspaceAppCenterRuntimeStatus
+} from "@tutti-os/workspace-app-center";
+
+export function shouldRenderWorkspaceAppBrowserNode(
+  app: WorkspaceAppCenterApp | null,
+  defaultUrl: string,
+  options: WorkspaceAppWebviewHandoffOptions = {}
+): boolean {
+  const url = normalizeWorkspaceAppUrl(defaultUrl);
+  if (url === null || url === "about:blank") {
+    return false;
+  }
+  return (
+    app?.runtimeStatus === "running" ||
+    shouldPreserveWorkspaceAppWebviewDuringHandoff(app, options)
+  );
+}
+
+export function shouldPreserveWorkspaceAppWebviewDuringHandoff(
+  app: WorkspaceAppCenterApp | null,
+  options: WorkspaceAppWebviewHandoffOptions = {}
+): boolean {
+  return (
+    app?.installed === true &&
+    (app.installProgress != null ||
+      isWorkspaceAppWebviewHandoffRuntimeStatus(app.runtimeStatus) ||
+      shouldCoverWorkspaceAppWebviewRuntimeUrlSync(app, options) ||
+      shouldBridgeWorkspaceAppWebviewHandoffGap(app, options))
+  );
+}
+
+export function shouldSyncWorkspaceAppWebviewDefaultUrl(
+  app: WorkspaceAppCenterApp | null,
+  options: WorkspaceAppWebviewHandoffOptions = {}
+): boolean {
+  if (shouldCoverWorkspaceAppWebviewRuntimeUrlSync(app, options)) {
+    return true;
+  }
+  return !shouldPreserveWorkspaceAppWebviewDuringHandoff(app, options);
+}
+
+export interface WorkspaceAppWebviewHandoffOptions {
+  externalNodeUrl?: string | null;
+  hadRecentHandoff?: boolean;
+}
+
+function isWorkspaceAppWebviewHandoffRuntimeStatus(
+  status: WorkspaceAppCenterRuntimeStatus
+): boolean {
+  return (
+    status === "installing" ||
+    status === "preparing" ||
+    status === "starting" ||
+    status === "installed_pending_restart"
+  );
+}
+
+function shouldBridgeWorkspaceAppWebviewHandoffGap(
+  app: WorkspaceAppCenterApp,
+  options: WorkspaceAppWebviewHandoffOptions
+): boolean {
+  return (
+    options.hadRecentHandoff === true &&
+    normalizeWorkspaceAppUrl(options.externalNodeUrl) !== null &&
+    (app.runtimeStatus === "stopping" || app.runtimeStatus === "idle")
+  );
+}
+
+function shouldCoverWorkspaceAppWebviewRuntimeUrlSync(
+  app: WorkspaceAppCenterApp | null,
+  options: WorkspaceAppWebviewHandoffOptions
+): boolean {
+  if (
+    app?.installed !== true ||
+    app.runtimeStatus !== "running" ||
+    app.installProgress != null ||
+    options.hadRecentHandoff !== true
+  ) {
+    return false;
+  }
+  const launchUrl = normalizeWorkspaceAppUrl(app.launchUrl);
+  const externalUrl = normalizeWorkspaceAppUrl(options.externalNodeUrl);
+  return (
+    launchUrl !== null &&
+    externalUrl !== null &&
+    comparableWorkspaceAppUrl(launchUrl) !==
+      comparableWorkspaceAppUrl(externalUrl)
+  );
+}
+
+function normalizeWorkspaceAppUrl(
+  value: string | null | undefined
+): string | null {
+  const trimmed = value?.trim() ?? "";
+  return trimmed.length > 0 ? trimmed : null;
+}
+
+function comparableWorkspaceAppUrl(value: string): string {
+  try {
+    return new URL(value).href;
+  } catch {
+    return value;
+  }
+}

--- a/apps/desktop/src/renderer/src/features/workspace-app-center/services/internal/workspaceAppCenterWebviewUrl.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-app-center/services/internal/workspaceAppCenterWebviewUrl.ts
@@ -24,21 +24,26 @@ export function resolveWorkspaceAppWebviewUrl(input: {
   appCanUseExternalState: boolean;
   appLaunchUrl: string | null;
   externalNodeState: WorkspaceAppWebviewExternalState | null;
+  preferExternalState?: boolean;
 }): string {
   const activationUrl = normalizeWorkspaceAppUrl(
     readWorkspaceAppOpenPayload(input.activation)?.url
   );
   const appLaunchUrl = normalizeWorkspaceAppUrl(input.appLaunchUrl);
+  const externalNodeUrl = input.appCanUseExternalState
+    ? normalizeWorkspaceAppUrl(input.externalNodeState?.url)
+    : null;
+  if (input.preferExternalState === true && externalNodeUrl) {
+    return activationUrl && hasSameUrlOrigin(activationUrl, externalNodeUrl)
+      ? activationUrl
+      : externalNodeUrl;
+  }
   if (appLaunchUrl) {
     return activationUrl && hasSameUrlOrigin(activationUrl, appLaunchUrl)
       ? activationUrl
       : appLaunchUrl;
   }
-  return (
-    activationUrl ??
-    (input.appCanUseExternalState ? input.externalNodeState?.url : null) ??
-    "about:blank"
-  );
+  return activationUrl ?? externalNodeUrl ?? "about:blank";
 }
 
 function normalizeWorkspaceAppUrl(

--- a/apps/desktop/src/renderer/src/features/workspace-workbench/services/internal/contributions/appCenterWorkbenchContributionFactory.test.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/services/internal/contributions/appCenterWorkbenchContributionFactory.test.ts
@@ -166,6 +166,59 @@ test("workspace app browser feature keeps current app runtime URLs inside the ap
   ]);
 });
 
+test("workspace app browser feature keeps runtime-origin open-url inside the app during launch url handoff", async () => {
+  const requests: WorkspaceBrowserLaunchRequest[] = [];
+  let emitBrowserEvent = (_event: BrowserNodeEvent): void => undefined;
+  const browserApi = createBrowserApi({
+    onEvent(listener) {
+      emitBrowserEvent = listener;
+      return () => {
+        emitBrowserEvent = () => undefined;
+      };
+    }
+  });
+  createWorkspaceAppBrowserFeature({
+    browserApi,
+    browserService: createWorkspaceBrowserService({ browserApi }),
+    getAppLaunchUrlForNodeId: (nodeId) =>
+      nodeId === "workspace-app-webview:app:group-chat"
+        ? "http://127.0.0.1:4173/"
+        : null,
+    runtimeApi: createRuntimeApi(),
+    workspaceId: "workspace-app-runtime-handoff-open-url"
+  });
+  const disposeLaunchHandler = registerWorkspaceBrowserLaunchHandler(
+    "workspace-app-runtime-handoff-open-url",
+    (request) => {
+      requests.push(request);
+      return true;
+    }
+  );
+
+  emitBrowserEvent({
+    canGoBack: false,
+    canGoForward: false,
+    isAttachedToWindow: true,
+    isLoading: false,
+    isOccluded: false,
+    lifecycle: "active",
+    nodeId: "workspace-app-webview:app:group-chat",
+    title: null,
+    type: "state",
+    url: "http://127.0.0.1:55765/"
+  });
+  emitBrowserEvent({
+    reuseIfOpen: true,
+    sourceNodeId: "workspace-app-webview:app:group-chat",
+    type: "open-url",
+    url: "http://127.0.0.1:55765/"
+  });
+  await Promise.resolve();
+
+  disposeLaunchHandler();
+  assert.deepEqual(requests, []);
+});
+
 test("workspace app browser feature keeps dock entry runtime URLs inside the app webview", async () => {
   const requests: WorkspaceBrowserLaunchRequest[] = [];
   let emitBrowserEvent = (_event: BrowserNodeEvent): void => undefined;

--- a/apps/desktop/src/renderer/src/features/workspace-workbench/services/internal/contributions/workspaceAppBrowserFeature.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/services/internal/contributions/workspaceAppBrowserFeature.ts
@@ -16,10 +16,15 @@ export function createWorkspaceAppBrowserFeature(input: {
   runtimeApi: Pick<DesktopRuntimeApi, "logRendererDiagnostic">;
   workspaceId: string;
 }): BrowserNodeFeature {
-  const feature = createBrowserNodeFeature({
+  let feature: BrowserNodeFeature | null = null;
+  feature = createBrowserNodeFeature({
     hostApi: input.browserService.createFeatureHostApi({
       acceptsEvent: (event) =>
-        isWorkspaceAppBrowserEvent(event, input.getAppLaunchUrlForNodeId),
+        isWorkspaceAppBrowserEvent(event, {
+          getAppLaunchUrlForNodeId: input.getAppLaunchUrlForNodeId,
+          getCurrentUrlForNodeId: (nodeId) =>
+            feature?.runtimeStore.getNodeState(nodeId).url
+        }),
       source: "workspace_app",
       workspaceId: input.workspaceId
     }),
@@ -42,9 +47,12 @@ export function createWorkspaceAppBrowserFeature(input: {
 
 function isWorkspaceAppBrowserEvent(
   event: BrowserNodeEvent,
-  getAppLaunchUrlForNodeId:
-    | ((nodeId: string) => string | null | undefined)
-    | undefined
+  input: {
+    getAppLaunchUrlForNodeId?:
+      | ((nodeId: string) => string | null | undefined)
+      | undefined;
+    getCurrentUrlForNodeId: (nodeId: string) => string | null | undefined;
+  }
 ): boolean {
   const nodeId = event.type === "open-url" ? event.sourceNodeId : event.nodeId;
   const isWorkspaceAppNode =
@@ -55,11 +63,25 @@ function isWorkspaceAppBrowserEvent(
   }
   if (
     event.type === "open-url" &&
-    hasSameUrlOrigin(event.url, getAppLaunchUrlForNodeId?.(nodeId))
+    shouldKeepWorkspaceAppOpenUrlInsideApp({
+      currentUrl: input.getCurrentUrlForNodeId(nodeId),
+      event,
+      launchUrl: input.getAppLaunchUrlForNodeId?.(nodeId)
+    })
   ) {
     return false;
   }
   return true;
+}
+
+function shouldKeepWorkspaceAppOpenUrlInsideApp(input: {
+  currentUrl: string | null | undefined;
+  event: Extract<BrowserNodeEvent, { type: "open-url" }>;
+  launchUrl: string | null | undefined;
+}): boolean {
+  const sameAsLaunchUrl = hasSameUrlOrigin(input.event.url, input.launchUrl);
+  const sameAsCurrentUrl = hasSameUrlOrigin(input.event.url, input.currentUrl);
+  return sameAsLaunchUrl || sameAsCurrentUrl;
 }
 
 function hasSameUrlOrigin(

--- a/packages/browser/workbench-node/src/core/types.ts
+++ b/packages/browser/workbench-node/src/core/types.ts
@@ -93,6 +93,7 @@ export interface BrowserNodePrepareSessionInput {
   profileId: string | null;
   sessionMode: BrowserNodeSessionMode;
   sessionPartition?: string | null;
+  url?: string;
 }
 
 export interface BrowserNodeRegisterGuestInput {
@@ -101,6 +102,7 @@ export interface BrowserNodeRegisterGuestInput {
   profileId: string | null;
   sessionMode: BrowserNodeSessionMode;
   sessionPartition?: string | null;
+  url?: string;
   webContentsId: number;
 }
 

--- a/packages/browser/workbench-node/src/core/webviewController.test.ts
+++ b/packages/browser/workbench-node/src/core/webviewController.test.ts
@@ -96,6 +96,95 @@ test("Browser Node webview controller unregisters guests after release", async (
   assert.deepEqual(unregisterCalls, [17]);
 });
 
+test("Browser Node webview controller tolerates webviews before dom-ready exposes webContentsId", async () => {
+  const registerCalls: number[] = [];
+  const feature = createBrowserNodeFeature({
+    hostApi: createBrowserNodeHostApi({
+      registerGuest(payload) {
+        registerCalls.push(payload.webContentsId);
+        return Promise.resolve();
+      }
+    })
+  });
+
+  const controller = acquireBrowserNodeWebviewController({
+    feature,
+    initialUrl: "https://example.com/",
+    lifecycle: "active",
+    nodeId: "browser-dom-ready-late",
+    profileId: null,
+    sessionMode: "shared"
+  });
+
+  const webview = new MockBrowserNodeWebviewTag(18);
+  webview.throwWhenReadingWebContentsId = true;
+  controller.setWebview(webview as unknown as BrowserNodeWebviewTag);
+  assert.doesNotThrow(() => controller.retain());
+  webview.emit("did-attach");
+  await Promise.resolve();
+  await Promise.resolve();
+  assert.deepEqual(registerCalls, []);
+
+  webview.throwWhenReadingWebContentsId = false;
+  webview.emit("dom-ready");
+  await Promise.resolve();
+  await Promise.resolve();
+  assert.deepEqual(registerCalls, [18]);
+  controller.release();
+});
+
+test("Browser Node webview controller keeps a pending guest alive when the node is retained again", async () => {
+  const registerCalls: number[] = [];
+  const unregisterCalls: number[] = [];
+  const feature = createBrowserNodeFeature({
+    hostApi: createBrowserNodeHostApi({
+      registerGuest(payload) {
+        registerCalls.push(payload.webContentsId);
+        return Promise.resolve();
+      },
+      unregisterGuest(payload) {
+        unregisterCalls.push(payload.webContentsId);
+        return Promise.resolve();
+      }
+    })
+  });
+
+  const first = acquireBrowserNodeWebviewController({
+    feature,
+    initialUrl: "https://example.com/",
+    lifecycle: "active",
+    nodeId: "browser-retained-again",
+    profileId: null,
+    sessionMode: "shared"
+  });
+
+  const webview = new MockBrowserNodeWebviewTag(19);
+  first.retain();
+  first.setWebview(webview as unknown as BrowserNodeWebviewTag);
+  webview.emit("did-attach");
+  await Promise.resolve();
+  await Promise.resolve();
+
+  first.release();
+  const second = acquireBrowserNodeWebviewController({
+    feature,
+    initialUrl: "https://example.com/",
+    lifecycle: "active",
+    nodeId: "browser-retained-again",
+    profileId: null,
+    sessionMode: "shared"
+  });
+  second.retain();
+
+  await waitForTimers();
+  assert.deepEqual(registerCalls, [19]);
+  assert.deepEqual(unregisterCalls, []);
+
+  second.release();
+  await waitForTimers();
+  assert.deepEqual(unregisterCalls, [19]);
+});
+
 test("Browser Node webview controller keeps shared guest registration alive until the last consumer releases", async () => {
   const registerCalls: number[] = [];
   const unregisterCalls: number[] = [];
@@ -152,6 +241,7 @@ test("Browser Node webview controller resyncs webview state when context changes
     nodeId: string;
     profileId: string | null;
     sessionMode: string;
+    url: string | undefined;
   }> = [];
   const feature = createBrowserNodeFeature({
     hostApi: createBrowserNodeHostApi({
@@ -159,7 +249,8 @@ test("Browser Node webview controller resyncs webview state when context changes
         prepareCalls.push({
           nodeId: payload.nodeId,
           profileId: payload.profileId,
-          sessionMode: payload.sessionMode
+          sessionMode: payload.sessionMode,
+          url: payload.url
         });
         return Promise.resolve();
       }
@@ -200,7 +291,50 @@ test("Browser Node webview controller resyncs webview state when context changes
   );
   assert.equal(prepareCalls.at(-1)?.profileId, "profile-1");
   assert.equal(prepareCalls.at(-1)?.sessionMode, "profile");
+  assert.equal(prepareCalls.at(-1)?.url, "https://openai.com/");
   second.release();
+});
+
+test("Browser Node webview controller passes the current URL when registering guests", async () => {
+  const registerCalls: Array<{
+    url: string | undefined;
+    webContentsId: number;
+  }> = [];
+  const feature = createBrowserNodeFeature({
+    hostApi: createBrowserNodeHostApi({
+      registerGuest(payload) {
+        registerCalls.push({
+          url: payload.url,
+          webContentsId: payload.webContentsId
+        });
+        return Promise.resolve();
+      }
+    })
+  });
+
+  const controller = acquireBrowserNodeWebviewController({
+    feature,
+    initialUrl: "https://openai.com/",
+    lifecycle: "active",
+    nodeId: "browser-register-url",
+    profileId: null,
+    sessionMode: "shared"
+  });
+
+  const webview = new MockBrowserNodeWebviewTag(31);
+  controller.retain();
+  controller.setWebview(webview as unknown as BrowserNodeWebviewTag);
+  webview.emit("did-attach");
+  await Promise.resolve();
+  await Promise.resolve();
+
+  assert.deepEqual(registerCalls, [
+    {
+      url: "https://openai.com/",
+      webContentsId: 31
+    }
+  ]);
+  controller.release();
 });
 
 test("Browser Node webview controller opens a devtools context menu before opening devtools", async () => {
@@ -350,6 +484,7 @@ class MockBrowserNodeWebviewTag extends EventTarget {
     y: 200,
     toJSON: () => ({})
   };
+  throwWhenReadingWebContentsId = false;
 
   constructor(webContentsId: number) {
     super();
@@ -357,6 +492,9 @@ class MockBrowserNodeWebviewTag extends EventTarget {
   }
 
   getWebContentsId(): number {
+    if (this.throwWhenReadingWebContentsId) {
+      throw new Error("The WebView must be attached to the DOM");
+    }
     return this.webContentsId;
   }
 

--- a/packages/browser/workbench-node/src/core/webviewController.ts
+++ b/packages/browser/workbench-node/src/core/webviewController.ts
@@ -240,14 +240,20 @@ function reconcileBrowserNodeWebviewControllerState(
     if (entry.context.lifecycle === "cold") {
       scheduleBrowserNodeGuestUnregister(entry);
     } else {
-      clearPendingBrowserNodeGuestUnregister(entry.context.nodeId);
+      const pendingGuestId = clearPendingBrowserNodeGuestUnregister(
+        entry.context.nodeId
+      );
+      if (entry.registeredGuestId === null && pendingGuestId !== null) {
+        entry.registeredGuestId = pendingGuestId;
+      }
       void entry.context.feature.hostApi
         .prepareSession({
           navigationPolicy: entry.context.navigationPolicy,
           nodeId: entry.context.nodeId,
           profileId: entry.context.profileId,
           sessionMode: entry.context.sessionMode,
-          sessionPartition: entry.context.sessionPartition
+          sessionPartition: entry.context.sessionPartition,
+          url: entry.context.initialUrl
         })
         .catch(() => undefined);
     }
@@ -297,13 +303,17 @@ function notifyBrowserNodeWebviewControllerListeners(
   }
 }
 
-function clearPendingBrowserNodeGuestUnregister(nodeId: string): void {
+function clearPendingBrowserNodeGuestUnregister(nodeId: string): number | null {
   const timerId = pendingUnregisterTimersByNodeId.get(nodeId);
   if (timerId !== undefined) {
     globalThis.clearTimeout(timerId);
     pendingUnregisterTimersByNodeId.delete(nodeId);
   }
+  const pendingGuestId = pendingGuestIdsByNodeId.get(nodeId);
   pendingGuestIdsByNodeId.delete(nodeId);
+  return typeof pendingGuestId === "number" && Number.isFinite(pendingGuestId)
+    ? pendingGuestId
+    : null;
 }
 
 function scheduleBrowserNodeGuestUnregister(
@@ -328,6 +338,17 @@ function scheduleBrowserNodeGuestUnregister(
       typeof pendingGuestId !== "number" ||
       !Number.isFinite(pendingGuestId)
     ) {
+      return;
+    }
+    const currentEntry = webviewControllerRegistry.get(nodeId);
+    if (
+      currentEntry &&
+      currentEntry.refCount > 0 &&
+      currentEntry.state.shouldRenderWebview
+    ) {
+      if (currentEntry.registeredGuestId === null) {
+        currentEntry.registeredGuestId = pendingGuestId;
+      }
       return;
     }
 
@@ -363,7 +384,7 @@ function attachBrowserNodeWebview(
   }
 
   const registerGuest = async (): Promise<void> => {
-    const guestId = webview.getWebContentsId?.();
+    const guestId = readBrowserNodeWebContentsId(webview);
     if (
       typeof guestId !== "number" ||
       !Number.isFinite(guestId) ||
@@ -383,6 +404,7 @@ function attachBrowserNodeWebview(
         profileId: entry.context.profileId,
         sessionMode: entry.context.sessionMode,
         sessionPartition: entry.context.sessionPartition,
+        url: entry.context.initialUrl,
         webContentsId: guestId
       });
       entry.registeredGuestId = guestId;
@@ -485,7 +507,12 @@ function readFiniteNumber(value: unknown): number | null {
 function readBrowserNodeWebContentsId(
   webview: BrowserNodeWebviewTag | null
 ): number | null {
-  const webContentsId = webview?.getWebContentsId?.();
+  let webContentsId: number | undefined;
+  try {
+    webContentsId = webview?.getWebContentsId?.();
+  } catch {
+    return null;
+  }
   return typeof webContentsId === "number" && Number.isFinite(webContentsId)
     ? webContentsId
     : null;
@@ -497,12 +524,16 @@ function reportBrowserNodeWebviewDiagnostic(
   details: Record<string, unknown>,
   level: "debug" | "info" | "warn" | "error" = "info"
 ): void {
-  entry.context.feature.reportDiagnostic?.({
-    details: {
-      ...details,
-      nodeId: entry.context.nodeId
-    },
-    event,
-    level
-  });
+  try {
+    entry.context.feature.reportDiagnostic?.({
+      details: {
+        ...details,
+        nodeId: entry.context.nodeId
+      },
+      event,
+      level
+    });
+  } catch {
+    // Diagnostics must never affect BrowserNode lifecycle.
+  }
 }

--- a/packages/browser/workbench-node/src/electron-main/electronMain.test.ts
+++ b/packages/browser/workbench-node/src/electron-main/electronMain.test.ts
@@ -1096,6 +1096,36 @@ test("keeps Browser Node navigation failures as the final emitted event", async 
   );
 });
 
+test("uses registerGuest URL before loading a newly attached guest", async () => {
+  const contents = new MockBrowserGuestWebContents(21);
+  const manager = createBrowserGuestManager({
+    emit: () => undefined,
+    openExternal: () => undefined,
+    resolveWebContents: (id) => (id === contents.id ? contents : null)
+  });
+
+  await manager.prepareSession({
+    nodeId: "browser-stale-desired",
+    profileId: null,
+    sessionMode: "shared",
+    url: "http://127.0.0.1:50158/"
+  });
+
+  await manager.registerGuest({
+    nodeId: "browser-stale-desired",
+    profileId: null,
+    sessionMode: "shared",
+    url: "http://127.0.0.1:51103/",
+    webContentsId: 21
+  });
+
+  assert.deepEqual(contents.loadedUrls, ["http://127.0.0.1:51103/"]);
+  assert.equal(
+    manager.debugDump({ nodeId: "browser-stale-desired" })?.desiredUrl,
+    "http://127.0.0.1:51103/"
+  );
+});
+
 test("deduplicates Browser Node did-fail-load and loadURL rejection errors", async () => {
   const events: BrowserNodeEvent[] = [];
   const contents = new MockBrowserGuestWebContents(20);

--- a/packages/browser/workbench-node/src/electron-main/guestManager.ts
+++ b/packages/browser/workbench-node/src/electron-main/guestManager.ts
@@ -549,6 +549,15 @@ export function createBrowserGuestManager({
     return { action: "deny" };
   };
 
+  const resolveOptionalDesiredUrl = (
+    url: string | undefined
+  ): string | undefined => {
+    if (url === undefined) {
+      return undefined;
+    }
+    return resolveHostBrowserNavigationUrl(url).url ?? undefined;
+  };
+
   return {
     async activate(input) {
       const resolved = resolveHostBrowserNavigationUrl(input.url);
@@ -693,7 +702,8 @@ export function createBrowserGuestManager({
         navigationPolicy: input.navigationPolicy,
         profileId: input.profileId,
         sessionMode: input.sessionMode,
-        sessionPartition: input.sessionPartition
+        sessionPartition: input.sessionPartition,
+        url: resolveOptionalDesiredUrl(input.url)
       });
     },
     async registerGuest(input) {
@@ -722,7 +732,8 @@ export function createBrowserGuestManager({
         navigationPolicy: input.navigationPolicy,
         profileId: input.profileId,
         sessionMode: input.sessionMode,
-        sessionPartition: input.sessionPartition
+        sessionPartition: input.sessionPartition,
+        url: resolveOptionalDesiredUrl(input.url)
       });
       if (
         session.webContentsId === input.webContentsId &&
@@ -738,11 +749,6 @@ export function createBrowserGuestManager({
       session.webContentsId = input.webContentsId;
       nodeIdByWebContentsId.set(input.webContentsId, input.nodeId);
       session.lifecycle = "active";
-      logger?.info?.("Browser Node registered guest owner", {
-        nodeId: input.nodeId,
-        sessionPartition: session.sessionPartition,
-        webContentsId: input.webContentsId
-      });
       contents.setWindowOpenHandler?.(({ url }) => {
         if (isGoogleGisOAuthPopupUrl(url)) {
           logger?.info?.("Browser Node allowing Google GIS OAuth popup", {

--- a/packages/workspace/app-center/src/i18n/appCenterI18n.ts
+++ b/packages/workspace/app-center/src/i18n/appCenterI18n.ts
@@ -251,7 +251,7 @@ export const appCenterEn = {
     myApps: "My apps",
     recommendedApps: "Recommended apps",
     runningCount: "{{count}} running",
-    updateAvailable: "Update {{version}} available",
+    updateAvailable: "Update to {{version}}",
     version: "Version {{version}}"
   },
   localDev: {
@@ -517,7 +517,7 @@ export const appCenterZhCN = {
     myApps: "我的应用",
     recommendedApps: "推荐应用",
     runningCount: "{{count}} 个运行中",
-    updateAvailable: "可更新到 {{version}}",
+    updateAvailable: "更新到 {{version}}",
     version: "版本 {{version}}"
   },
   localDev: {

--- a/packages/workspace/app-center/src/ui/AppCard.tsx
+++ b/packages/workspace/app-center/src/ui/AppCard.tsx
@@ -252,7 +252,7 @@ export const AppCard = memo(function AppCard({
           <div className="flex items-center gap-1.5">
             <Button
               className={cn(
-                "min-w-[56px] shrink-0",
+                "min-w-[56px] max-w-[140px] shrink-0 overflow-hidden",
                 !canExecutePrimaryAction ? "cursor-default" : null,
                 canExecutePrimaryAction
                   ? app.primaryAction === "retry"
@@ -270,7 +270,9 @@ export const AppCard = memo(function AppCard({
                 executePrimaryAction();
               }}
             >
-              {canExecutePrimaryAction ? primaryActionLabel : busyStatusLabel}
+              <span className="block min-w-0 max-w-full truncate">
+                {canExecutePrimaryAction ? primaryActionLabel : busyStatusLabel}
+              </span>
             </Button>
             {showInstallProgressRing ? (
               <AppInstallProgressRing

--- a/services/tuttid/service/workspace/apps.go
+++ b/services/tuttid/service/workspace/apps.go
@@ -19,17 +19,18 @@ import (
 )
 
 type AppCenterService struct {
-	Store                 workspacedata.AppStore
-	AppFactoryStore       workspacedata.AppFactoryStore
-	WorkspaceRootResolver WorkspaceRootResolver
-	WorkspaceStore        workspacedata.CatalogStore
-	PreferencesStore      workspacedata.PreferencesStore
-	Runner                *AppRunner
-	AppCLIRegistry        *appcliservice.Registry
-	StateDir              string
-	Publisher             WorkspaceAppEventPublisher
-	BuiltinCatalog        func() ([]builtinapps.App, error)
-	ArtifactFetcher       AppArtifactFetcher
+	Store                  workspacedata.AppStore
+	AppFactoryStore        workspacedata.AppFactoryStore
+	WorkspaceRootResolver  WorkspaceRootResolver
+	WorkspaceStore         workspacedata.CatalogStore
+	PreferencesStore       workspacedata.PreferencesStore
+	Runner                 *AppRunner
+	AppCLIRegistry         *appcliservice.Registry
+	StateDir               string
+	Publisher              WorkspaceAppEventPublisher
+	BuiltinCatalog         func() ([]builtinapps.App, error)
+	ArtifactFetcher        AppArtifactFetcher
+	RemoteCatalogRefresher func(context.Context, string) (builtinapps.CatalogSnapshot, error)
 
 	mu                     sync.Mutex
 	stateRevisions         map[string]int64
@@ -145,6 +146,10 @@ func (s *AppCenterService) List(ctx context.Context, workspaceID string) ([]work
 	if err != nil {
 		return nil, err
 	}
+	return s.listWithBuiltins(ctx, workspaceID, builtins)
+}
+
+func (s *AppCenterService) listWithBuiltins(ctx context.Context, workspaceID string, builtins []builtinapps.App) ([]workspacebiz.WorkspaceApp, error) {
 	packages, err := s.Store.ListAppPackages(ctx)
 	if err != nil {
 		return nil, err

--- a/services/tuttid/service/workspace/apps_remote_builtin.go
+++ b/services/tuttid/service/workspace/apps_remote_builtin.go
@@ -248,7 +248,11 @@ func (s *AppCenterService) refreshBuiltinCatalogAndWait(ctx context.Context) (bu
 	if builtinapps.RemoteCatalogEnvOverrideActive() {
 		return builtinapps.RefreshRemoteCatalogAndWait(ctx)
 	}
-	return builtinapps.RefreshRemoteCatalogAndWaitForRemoteURL(ctx, s.appCatalogRemoteURL(ctx))
+	catalogURL := s.appCatalogRemoteURL(ctx)
+	if s.RemoteCatalogRefresher != nil {
+		return s.RemoteCatalogRefresher(ctx, catalogURL)
+	}
+	return builtinapps.RefreshRemoteCatalogAndWaitForRemoteURL(ctx, catalogURL)
 }
 
 func (s *AppCenterService) appCatalogRemoteURL(ctx context.Context) string {

--- a/services/tuttid/service/workspace/apps_runner.go
+++ b/services/tuttid/service/workspace/apps_runner.go
@@ -414,12 +414,21 @@ func (r *AppRunner) StopAll(ctx context.Context) {
 
 func (r *AppRunner) stopProcess(ctx context.Context, key string, process *appProcess) (workspacebiz.AppRuntimeState, error) {
 	r.mu.Lock()
+	currentProcess := r.processes[key]
+	current := r.states[key]
+	if currentProcess != nil && currentProcess != process {
+		r.mu.Unlock()
+		return currentRuntimeStateOrIdle(current), nil
+	}
+	if currentProcess == nil {
+		r.mu.Unlock()
+		return currentRuntimeStateOrIdle(current), nil
+	}
 	if process.stopRequested {
 		r.mu.Unlock()
-		return r.State(appRuntimeWorkspaceIDFromKey(key), appRuntimeAppIDFromKey(key)), nil
+		return currentRuntimeStateOrIdle(current), nil
 	}
 	process.stopRequested = true
-	current := r.states[key]
 	stoppingState := withRuntimeUpdated(workspacebiz.AppRuntimeState{
 		Status:          workspacebiz.AppRuntimeStatusStopping,
 		LaunchURL:       current.LaunchURL,
@@ -427,6 +436,7 @@ func (r *AppRunner) stopProcess(ctx context.Context, key string, process *appPro
 		FailureReason:   current.FailureReason,
 		LastError:       current.LastError,
 		StartedAtUnixMs: current.StartedAtUnixMs,
+		PackageDir:      current.PackageDir,
 	})
 	r.states[key] = stoppingState
 	r.mu.Unlock()
@@ -439,22 +449,59 @@ func (r *AppRunner) stopProcess(ctx context.Context, key string, process *appPro
 	select {
 	case <-process.done:
 	case <-ctx.Done():
-		return r.setFailed(key, "stop", ctx.Err()), ctx.Err()
+		return r.setStoppedProcessFailed(key, process, "stop", ctx.Err()), ctx.Err()
 	case <-time.After(2 * time.Second):
 		_ = killAppProcess(process.command)
 		select {
 		case <-process.done:
-			return r.setState(key, workspacebiz.AppRuntimeState{
-				Status: workspacebiz.AppRuntimeStatusIdle,
-			}), nil
+			return r.setStoppedProcessIdle(key, process), nil
 		case <-time.After(500 * time.Millisecond):
 		}
-		return r.setFailed(key, "stop", errors.New("timed out stopping app process")), nil
+		return r.setStoppedProcessFailed(key, process, "stop", errors.New("timed out stopping app process")), nil
 	}
 
-	return r.setState(key, workspacebiz.AppRuntimeState{
+	return r.setStoppedProcessIdle(key, process), nil
+}
+
+func (r *AppRunner) setStoppedProcessIdle(key string, process *appProcess) workspacebiz.AppRuntimeState {
+	return r.setStoppedProcessTerminalState(key, process, workspacebiz.AppRuntimeState{
 		Status: workspacebiz.AppRuntimeStatusIdle,
-	}), nil
+	})
+}
+
+func (r *AppRunner) setStoppedProcessFailed(key string, process *appProcess, failureReason string, err error) workspacebiz.AppRuntimeState {
+	message := err.Error()
+	return r.setStoppedProcessTerminalState(key, process, workspacebiz.AppRuntimeState{
+		Status:        workspacebiz.AppRuntimeStatusFailed,
+		FailureReason: &failureReason,
+		LastError:     &message,
+	})
+}
+
+func (r *AppRunner) setStoppedProcessTerminalState(key string, process *appProcess, next workspacebiz.AppRuntimeState) workspacebiz.AppRuntimeState {
+	r.mu.Lock()
+	currentProcess := r.processes[key]
+	current := r.states[key]
+	if currentProcess != nil && currentProcess != process {
+		r.mu.Unlock()
+		return currentRuntimeStateOrIdle(current)
+	}
+	if currentProcess == nil && current.Status != workspacebiz.AppRuntimeStatusStopping {
+		r.mu.Unlock()
+		return currentRuntimeStateOrIdle(current)
+	}
+	state := withRuntimeUpdated(next)
+	r.states[key] = state
+	r.mu.Unlock()
+	r.notifyStateChanged(key, state)
+	return state
+}
+
+func currentRuntimeStateOrIdle(state workspacebiz.AppRuntimeState) workspacebiz.AppRuntimeState {
+	if state.Status == "" {
+		return workspacebiz.AppRuntimeState{Status: workspacebiz.AppRuntimeStatusIdle}
+	}
+	return state
 }
 
 func writeAppStartupDiagnostic(logFile *os.File, input AppStartInput, bootstrapPath string, port int, appRuntime ResolvedAppRuntime, env []string) {

--- a/services/tuttid/service/workspace/apps_runner.go
+++ b/services/tuttid/service/workspace/apps_runner.go
@@ -449,6 +449,11 @@ func (r *AppRunner) stopProcess(ctx context.Context, key string, process *appPro
 	select {
 	case <-process.done:
 	case <-ctx.Done():
+		_ = killAppProcess(process.command)
+		select {
+		case <-process.done:
+		case <-time.After(500 * time.Millisecond):
+		}
 		return r.setStoppedProcessFailed(key, process, "stop", ctx.Err()), ctx.Err()
 	case <-time.After(2 * time.Second):
 		_ = killAppProcess(process.command)

--- a/services/tuttid/service/workspace/apps_runner_test.go
+++ b/services/tuttid/service/workspace/apps_runner_test.go
@@ -362,6 +362,49 @@ func TestAppRunnerStopProcessDoesNotOverwriteReplacementRuntime(t *testing.T) {
 	}
 }
 
+func TestAppRunnerStopProcessWaitsForProcessDoneWhenContextIsCanceled(t *testing.T) {
+	runner := &AppRunner{}
+	runner.ensure()
+	key := appRuntimeKey("ws-runner", "hello")
+	process := &appProcess{done: make(chan error)}
+	runner.mu.Lock()
+	runner.processes[key] = process
+	runner.states[key] = workspacebiz.AppRuntimeState{
+		Status: workspacebiz.AppRuntimeStatusRunning,
+	}
+	runner.mu.Unlock()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	type stopResult struct {
+		state workspacebiz.AppRuntimeState
+		err   error
+	}
+	stopped := make(chan stopResult, 1)
+	go func() {
+		state, err := runner.stopProcess(ctx, key, process)
+		stopped <- stopResult{state: state, err: err}
+	}()
+
+	select {
+	case result := <-stopped:
+		t.Fatalf("stopProcess() returned before process done: %#v", result)
+	case <-time.After(50 * time.Millisecond):
+	}
+	process.done <- nil
+	select {
+	case result := <-stopped:
+		if !errors.Is(result.err, context.Canceled) {
+			t.Fatalf("stopProcess() error = %v, want context.Canceled", result.err)
+		}
+		if result.state.Status != workspacebiz.AppRuntimeStatusFailed {
+			t.Fatalf("stopProcess() status = %q, want failed", result.state.Status)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for stopProcess")
+	}
+}
+
 func TestAppRunnerStartWithoutRestartReusesQueuedStart(t *testing.T) {
 	root := t.TempDir()
 	packageDir := filepath.Join(root, "package")

--- a/services/tuttid/service/workspace/apps_runner_test.go
+++ b/services/tuttid/service/workspace/apps_runner_test.go
@@ -295,6 +295,73 @@ exec "$TUTTI_APP_PYTHON" "$TUTTI_APP_PACKAGE_DIR/server.py"
 	}
 }
 
+func TestAppRunnerStopProcessDoesNotOverwriteReplacementRuntime(t *testing.T) {
+	runner := &AppRunner{}
+	runner.ensure()
+	key := appRuntimeKey("ws-runner", "hello")
+	oldURL := "http://127.0.0.1:41001"
+	newURL := "http://127.0.0.1:41002"
+	oldPort := 41001
+	newPort := 41002
+	oldProcess := &appProcess{done: make(chan error, 1)}
+	newProcess := &appProcess{done: make(chan error, 1)}
+
+	runner.mu.Lock()
+	runner.processes[key] = oldProcess
+	runner.states[key] = workspacebiz.AppRuntimeState{
+		Status:    workspacebiz.AppRuntimeStatusRunning,
+		LaunchURL: &oldURL,
+		Port:      &oldPort,
+	}
+	runner.mu.Unlock()
+
+	type stopResult struct {
+		state workspacebiz.AppRuntimeState
+		err   error
+	}
+	stopped := make(chan stopResult, 1)
+	go func() {
+		state, err := runner.stopProcess(context.Background(), key, oldProcess)
+		stopped <- stopResult{state: state, err: err}
+	}()
+
+	waitForRunnerStatus(t, runner, "ws-runner", "hello", workspacebiz.AppRuntimeStatusStopping)
+
+	runner.mu.Lock()
+	runner.processes[key] = newProcess
+	runner.states[key] = workspacebiz.AppRuntimeState{
+		Status:    workspacebiz.AppRuntimeStatusRunning,
+		LaunchURL: &newURL,
+		Port:      &newPort,
+	}
+	runner.mu.Unlock()
+
+	oldProcess.done <- nil
+
+	select {
+	case result := <-stopped:
+		if result.err != nil {
+			t.Fatalf("stopProcess() error = %v", result.err)
+		}
+		if result.state.Status != workspacebiz.AppRuntimeStatusRunning {
+			t.Fatalf("stopProcess() status = %q, want running", result.state.Status)
+		}
+		if result.state.LaunchURL == nil || *result.state.LaunchURL != newURL {
+			t.Fatalf("stopProcess() launchURL = %v, want %q", result.state.LaunchURL, newURL)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for stopProcess")
+	}
+
+	state := runner.State("ws-runner", "hello")
+	if state.Status != workspacebiz.AppRuntimeStatusRunning {
+		t.Fatalf("runner state = %q, want running", state.Status)
+	}
+	if state.LaunchURL == nil || *state.LaunchURL != newURL {
+		t.Fatalf("runner launchURL = %v, want %q", state.LaunchURL, newURL)
+	}
+}
+
 func TestAppRunnerStartWithoutRestartReusesQueuedStart(t *testing.T) {
 	root := t.TempDir()
 	packageDir := filepath.Join(root, "package")

--- a/services/tuttid/service/workspace/apps_runtime.go
+++ b/services/tuttid/service/workspace/apps_runtime.go
@@ -87,7 +87,15 @@ func (s *AppCenterService) StartEnabled(ctx context.Context, workspaceID string)
 		var err error
 		builtins, err = s.refreshBuiltinCatalogForStartEnabled(ctx, workspaceID)
 		if err != nil {
-			return nil, err
+			slog.Warn(
+				"workspace app start enabled remote catalog refresh failed; continuing with cached builtin catalog",
+				"workspaceId", workspaceID,
+				"error", err,
+			)
+			builtins, err = s.builtinCatalog(ctx)
+			if err != nil {
+				return nil, err
+			}
 		}
 		slog.Info("workspace app start enabled remote catalog refresh completed", "workspaceId", workspaceID, "enabledAppCount", len(enabledAppIDs), "durationMs", time.Since(refreshStartedAt).Milliseconds())
 	} else {

--- a/services/tuttid/service/workspace/apps_runtime.go
+++ b/services/tuttid/service/workspace/apps_runtime.go
@@ -84,14 +84,12 @@ func (s *AppCenterService) StartEnabled(ctx context.Context, workspaceID string)
 	slog.Info("workspace app start enabled started", "workspaceId", workspaceID, "enabledAppCount", len(enabledAppIDs))
 	if len(enabledAppIDs) > 0 {
 		refreshStartedAt := time.Now()
-		if err := s.refreshBuiltinCatalogForStartEnabled(ctx, workspaceID); err != nil {
+		var err error
+		builtins, err = s.refreshBuiltinCatalogForStartEnabled(ctx, workspaceID)
+		if err != nil {
 			return nil, err
 		}
 		slog.Info("workspace app start enabled remote catalog refresh completed", "workspaceId", workspaceID, "enabledAppCount", len(enabledAppIDs), "durationMs", time.Since(refreshStartedAt).Milliseconds())
-		builtins, err = s.builtinCatalog(ctx)
-		if err != nil {
-			slog.Warn("workspace app start remote builtin sync skipped; builtin catalog unavailable", "workspaceId", workspaceID, "error", err)
-		}
 	} else {
 		slog.Info("workspace app start enabled remote catalog refresh skipped", "workspaceId", workspaceID, "enabledAppCount", len(enabledAppIDs), "reason", "no-enabled-apps")
 	}
@@ -159,20 +157,19 @@ func (s *AppCenterService) StartEnabled(ctx context.Context, workspaceID string)
 		s.startRuntimePreload()
 	}
 
-	apps, err := s.List(ctx, workspaceID)
-	if err != nil {
-		return nil, err
+	if len(enabledAppIDs) > 0 {
+		return s.listWithBuiltins(ctx, workspaceID, builtins)
 	}
-	return apps, nil
+	return s.List(ctx, workspaceID)
 }
 
-func (s *AppCenterService) refreshBuiltinCatalogForStartEnabled(ctx context.Context, workspaceID string) error {
+func (s *AppCenterService) refreshBuiltinCatalogForStartEnabled(ctx context.Context, workspaceID string) ([]builtinapps.App, error) {
 	if s.BuiltinCatalog != nil {
-		return nil
+		return s.BuiltinCatalog()
 	}
-	snapshot, err := builtinapps.RefreshRemoteCatalogAndWait(ctx)
+	snapshot, err := s.refreshBuiltinCatalogAndWait(ctx)
 	if err != nil {
-		return err
+		return nil, err
 	}
 	if snapshot.RemoteCatalog.Status == builtinapps.RemoteCatalogLoadStatusFailed {
 		slog.Warn(
@@ -181,7 +178,7 @@ func (s *AppCenterService) refreshBuiltinCatalogForStartEnabled(ctx context.Cont
 			"error", snapshot.RemoteCatalog.LastError,
 		)
 	}
-	return nil
+	return snapshot.Apps, nil
 }
 
 func (s *AppCenterService) StopAll(ctx context.Context, workspaceID string) ([]workspacebiz.WorkspaceApp, error) {

--- a/services/tuttid/service/workspace/apps_test.go
+++ b/services/tuttid/service/workspace/apps_test.go
@@ -1534,6 +1534,75 @@ func TestAppCenterServiceStartEnabledRefreshesPreferredCatalogChannel(t *testing
 	}
 }
 
+func TestAppCenterServiceStartEnabledFallsBackToCachedCatalogWhenRefreshFails(t *testing.T) {
+	ctx := context.Background()
+	t.Setenv("TUTTI_APP_CATALOG_FILE", "")
+	packageDir := createWorkspaceAppPackageForTest(t, t.TempDir(), workspacebiz.AppManifest{
+		SchemaVersion: workspacebiz.AppManifestSchemaVersionV1,
+		AppID:         "tutti-onboarding",
+		Version:       "0.1.0",
+		Name:          "Getting Started",
+		Description:   "Learn Tutti and Agent collaboration",
+		Runtime: workspacebiz.AppManifestRuntime{
+			Bootstrap:       "bootstrap.sh",
+			HealthcheckPath: "/healthz",
+			Profile:         "standalone",
+		},
+	})
+
+	store := newAppStoreStub()
+	if err := store.PutAppPackage(ctx, workspacebiz.AppPackage{
+		AppID:      "tutti-onboarding",
+		Version:    "0.1.0",
+		PackageDir: packageDir,
+		Manifest:   mustReadManifestForTest(t, packageDir),
+		Source:     workspacebiz.AppPackageSourceBuiltin,
+	}); err != nil {
+		t.Fatalf("PutAppPackage() error = %v", err)
+	}
+	if err := store.PutWorkspaceAppInstallation(ctx, workspacebiz.AppInstallation{
+		WorkspaceID: "ws-1",
+		AppID:       "tutti-onboarding",
+		Enabled:     true,
+	}); err != nil {
+		t.Fatalf("PutWorkspaceAppInstallation() error = %v", err)
+	}
+
+	launchURL := "http://127.0.0.1:41001"
+	runner := &AppRunner{}
+	runner.ensure()
+	runner.mu.Lock()
+	runner.states[appRuntimeKey("ws-1", "tutti-onboarding")] = workspacebiz.AppRuntimeState{
+		Status:    workspacebiz.AppRuntimeStatusRunning,
+		LaunchURL: &launchURL,
+	}
+	runner.mu.Unlock()
+
+	refreshCalls := 0
+	service := AppCenterService{
+		Store:          store,
+		WorkspaceStore: &catalogStoreStub{getWorkspace: workspacebiz.Summary{ID: "ws-1", Name: "Workspace"}},
+		Runner:         runner,
+		StateDir:       t.TempDir(),
+		RemoteCatalogRefresher: func(context.Context, string) (builtinapps.CatalogSnapshot, error) {
+			refreshCalls += 1
+			return builtinapps.CatalogSnapshot{}, errors.New("catalog unavailable")
+		},
+	}
+
+	apps, err := service.StartEnabled(ctx, "ws-1")
+	if err != nil {
+		t.Fatalf("StartEnabled() error = %v", err)
+	}
+	if refreshCalls != 1 {
+		t.Fatalf("remote catalog refresh calls = %d, want 1", refreshCalls)
+	}
+	app := findWorkspaceAppForTest(apps, "tutti-onboarding")
+	if app == nil || app.Runtime.Status != workspacebiz.AppRuntimeStatusRunning {
+		t.Fatalf("StartEnabled() app = %#v", app)
+	}
+}
+
 func TestAppCenterServiceStartEnabledDoesNotWaitForRemoteCatalogWhenNoAppsAreEnabled(t *testing.T) {
 	ctx := context.Background()
 	t.Setenv("TUTTI_APP_CATALOG_FILE", "")

--- a/services/tuttid/service/workspace/apps_test.go
+++ b/services/tuttid/service/workspace/apps_test.go
@@ -1440,6 +1440,100 @@ func TestAppCenterServiceStartEnabledWaitsForRemoteCatalogRefresh(t *testing.T) 
 	}
 }
 
+func TestAppCenterServiceStartEnabledRefreshesPreferredCatalogChannel(t *testing.T) {
+	ctx := context.Background()
+	t.Setenv("TUTTI_APP_CATALOG_FILE", "")
+	oldDir := createWorkspaceAppPackageForTest(t, t.TempDir(), workspacebiz.AppManifest{
+		SchemaVersion: workspacebiz.AppManifestSchemaVersionV1,
+		AppID:         "large-builtin",
+		Version:       "1.0.0",
+		Name:          "Large Builtin",
+		Description:   "Old large app",
+		Runtime: workspacebiz.AppManifestRuntime{
+			Bootstrap:       "bootstrap.sh",
+			HealthcheckPath: "/",
+		},
+	})
+
+	store := newAppStoreStub()
+	if err := store.PutAppPackage(ctx, workspacebiz.AppPackage{
+		AppID:      "large-builtin",
+		Version:    "1.0.0",
+		PackageDir: oldDir,
+		Manifest:   mustReadManifestForTest(t, oldDir),
+		Source:     workspacebiz.AppPackageSourceBuiltin,
+	}); err != nil {
+		t.Fatalf("PutAppPackage() error = %v", err)
+	}
+	if err := store.PutWorkspaceAppInstallation(ctx, workspacebiz.AppInstallation{
+		WorkspaceID: "ws-1",
+		AppID:       "large-builtin",
+		Enabled:     true,
+	}); err != nil {
+		t.Fatalf("PutWorkspaceAppInstallation() error = %v", err)
+	}
+
+	fetcher := newBlockingArtifactFetcher()
+	close(fetcher.release)
+	refreshedURLs := make([]string, 0, 1)
+	service := AppCenterService{
+		Store:           store,
+		WorkspaceStore:  &catalogStoreStub{getWorkspace: workspacebiz.Summary{ID: "ws-1", Name: "Workspace"}},
+		Runner:          &AppRunner{RuntimeResolver: &preloadThenFailRuntimeResolver{called: make(chan struct{}), startErr: errors.New("skip runtime")}},
+		StateDir:        t.TempDir(),
+		ArtifactFetcher: fetcher,
+		PreferencesStore: appCenterPreferencesStoreStub{
+			preferences: preferencesbiz.DesktopPreferences{
+				AppCatalogChannel: "staging",
+			},
+		},
+		RemoteCatalogRefresher: func(_ context.Context, catalogURL string) (builtinapps.CatalogSnapshot, error) {
+			refreshedURLs = append(refreshedURLs, catalogURL)
+			return builtinapps.CatalogSnapshot{
+				Apps: []builtinapps.App{
+					{
+						Manifest: workspacebiz.AppManifest{
+							SchemaVersion: workspacebiz.AppManifestSchemaVersionV1,
+							AppID:         "large-builtin",
+							Version:       "1.1.0",
+							Name:          "Large Builtin",
+							Description:   "New large app",
+							Runtime: workspacebiz.AppManifestRuntime{
+								Bootstrap:       "bootstrap.sh",
+								HealthcheckPath: "/",
+							},
+						},
+						Distribution: builtinapps.Distribution{
+							Kind:           builtinapps.DistributionRemote,
+							ArtifactURL:    "https://cdn.example.test/large-builtin.zip",
+							ArtifactSHA256: "sha256",
+							IconURL:        "https://cdn.example.test/large-builtin.png",
+						},
+					},
+				},
+				RemoteCatalog: builtinapps.RemoteCatalogLoadState{Status: builtinapps.RemoteCatalogLoadStatusReady},
+			}, nil
+		},
+	}
+
+	apps, err := service.StartEnabled(ctx, "ws-1")
+	if err != nil {
+		t.Fatalf("StartEnabled() error = %v", err)
+	}
+	if len(refreshedURLs) != 1 || refreshedURLs[0] != builtinapps.StagingRemoteCatalogURL {
+		t.Fatalf("refreshed catalog URLs = %#v, want %#v", refreshedURLs, []string{builtinapps.StagingRemoteCatalogURL})
+	}
+	app := findWorkspaceAppForTest(apps, "large-builtin")
+	if app == nil || !app.UpdateAvailable || app.AvailableVersion == nil || *app.AvailableVersion != "1.1.0" {
+		t.Fatalf("StartEnabled() app = %#v", app)
+	}
+	select {
+	case <-fetcher.started:
+	case <-time.After(time.Second):
+		t.Fatal("background staging remote builtin update did not start")
+	}
+}
+
 func TestAppCenterServiceStartEnabledDoesNotWaitForRemoteCatalogWhenNoAppsAreEnabled(t *testing.T) {
 	ctx := context.Background()
 	t.Setenv("TUTTI_APP_CATALOG_FILE", "")


### PR DESCRIPTION
## Summary
- keep workspace app webviews mounted behind a loading cover during update/restart handoff instead of tearing down the existing guest immediately
- retain Browser Node guest ownership across brief release/reacquire windows and avoid old runtime stop completion overwriting replacement runtime state
- refresh start-enabled remote builtins from the selected app catalog channel and add low-volume update handoff diagnostics

## Testing
- pnpm check:full
- pnpm --filter @tutti-os/desktop typecheck
- pnpm --filter @tutti-os/browser-node test
- cd services/tuttid && go test ./service/workspace

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved Workspace app-center webview handoff so the webview can stay visible across running updates, restart gaps, and transitional loading states.
  * Smarter webview URL selection to preserve the current page origin where possible during handoff.

* **Bug Fixes**
  * Fixed webview mounting/rendering and default URL syncing so it doesn’t incorrectly mount when no usable URL is available.
  * Improved reliability of browser guest registration and URL propagation for smoother app loading.

* **UI / Localization**
  * Updated App Center “Update” label text and improved app card primary button label truncation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->