### PR TITLE
feat(workbench): add generic node launch requests

### DIFF
--- a/apps/cli/internal/app/run.go
+++ b/apps/cli/internal/app/run.go
@@ -243,6 +243,17 @@ func parseCommandInput(command daemon.Capability, args []string) (map[string]any
 		if strings.TrimSpace(name) == "" {
 			return nil, fmt.Errorf("invalid flag %q", arg)
 		}
+		if existing, ok := input[name]; ok {
+			switch typed := existing.(type) {
+			case []string:
+				input[name] = append(typed, value)
+			case string:
+				input[name] = []string{typed, value}
+			default:
+				input[name] = value
+			}
+			continue
+		}
 		input[name] = value
 	}
 	return input, nil

--- a/apps/cli/internal/app/run_test.go
+++ b/apps/cli/internal/app/run_test.go
@@ -210,6 +210,39 @@ func TestRunDynamicCommandMatchesMultiSegmentPath(t *testing.T) {
 	}
 }
 
+func TestRunDynamicCommandAggregatesRepeatedFlags(t *testing.T) {
+	var invokedBody map[string]any
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/v1/cli/capabilities":
+			_, _ = w.Write([]byte(`{"commands":[{"id":"workspace-apps.app.open","path":["app","open"],"summary":"Open app","inputSchema":{"type":"object","required":["app-id"],"properties":{"app-id":{"type":"string"},"param":{"type":"string"},"route":{"type":"string"}}},"output":{"defaultMode":"json","json":true}}]}`))
+		case "/v1/cli/commands/workspace-apps.app.open/invoke":
+			if err := json.NewDecoder(r.Body).Decode(&invokedBody); err != nil {
+				t.Fatalf("decode body: %v", err)
+			}
+			_, _ = w.Write([]byte(`{"ok":true,"output":{"kind":"json","value":{"ok":true}}}`))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	writeEndpoint(t, server.URL, "token-1")
+
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	code := Run(t.Context(), []string{"app", "open", "--app-id", "docs", "--route", "/files", "--param", "path=/tmp/a", "--param", "mode=preview"}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("code = %d, stderr = %s", code, stderr.String())
+	}
+	input := invokedBody["input"].(map[string]any)
+	params, ok := input["param"].([]any)
+	if !ok || len(params) != 2 || params[0] != "path=/tmp/a" || params[1] != "mode=preview" {
+		t.Fatalf("param input = %#v", input["param"])
+	}
+}
+
 func TestRunDynamicCommandHelpRendersInputSchema(t *testing.T) {
 	invoked := false
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/apps/desktop/src/main/ipc/workspaceAppContext.ts
+++ b/apps/desktop/src/main/ipc/workspaceAppContext.ts
@@ -47,7 +47,8 @@ import type {
   TuttiExternalPdfPrintHtmlResult,
   TuttiExternalPermissionRequestInput,
   TuttiExternalPermissionRequestResult,
-  TuttiExternalUploadedFile
+  TuttiExternalUploadedFile,
+  TuttiExternalWorkspaceOpenRouteIntent
 } from "@tutti-os/workspace-external-core/contracts";
 import { isTuttiExternalManagedAiModelProviderId } from "@tutti-os/workspace-external-core/core";
 import type { DesktopLocale } from "../../shared/i18n";
@@ -71,6 +72,10 @@ import { resolveWorkspaceAppOpenFilePayload } from "../host/workspaceAppFileOpen
 
 const workspaceAppGuestWebContents = new Set<WebContents>();
 const workspaceAppGuestContexts = new Map<number, WorkspaceAppGuestContext>();
+const workspaceAppInitialLaunchIntents = new Map<
+  string,
+  TuttiExternalWorkspaceOpenRouteIntent
+>();
 let workspaceAppFrontendLogWriter: WorkspaceAppFrontendLogWriter | null = null;
 let workspaceAppGuestLogRateLimiter: WorkspaceAppGuestLogRateLimiter | null =
   null;
@@ -78,6 +83,7 @@ type WorkspaceAppPrintLoadListener = (...args: unknown[]) => void;
 
 interface WorkspaceAppGuestContext {
   appID: string;
+  launchIntent?: TuttiExternalWorkspaceOpenRouteIntent;
   ownerWindow: BrowserWindow;
   workspaceID: string;
 }
@@ -678,8 +684,17 @@ function forwardWorkspaceAppExternalRendererEvent(
   ownerContents: WebContents,
   rendererEvent: DesktopWorkspaceAppExternalRendererEvent
 ): void {
+  if (rendererEvent.type === "workspace.launchIntent") {
+    persistWorkspaceAppInitialLaunchIntent(ownerContents.id, rendererEvent);
+  }
   for (const [guestWebContentsId, context] of workspaceAppGuestContexts) {
     if (context.workspaceID !== rendererEvent.workspaceId) {
+      continue;
+    }
+    if (
+      rendererEvent.type === "workspace.launchIntent" &&
+      context.appID !== rendererEvent.appId
+    ) {
       continue;
     }
     if (context.ownerWindow.webContents.id !== ownerContents.id) {
@@ -697,6 +712,33 @@ function forwardWorkspaceAppExternalRendererEvent(
       desktopIpcChannels.appExternal.guestEvent,
       rendererEvent
     );
+  }
+}
+
+function persistWorkspaceAppInitialLaunchIntent(
+  ownerWebContentsId: number,
+  event: Extract<
+    DesktopWorkspaceAppExternalRendererEvent,
+    { type: "workspace.launchIntent" }
+  >
+): void {
+  const key = workspaceAppInitialLaunchIntentKey({
+    appID: event.appId,
+    ownerWebContentsId,
+    workspaceID: event.workspaceId
+  });
+  let matchedGuest = false;
+  for (const context of workspaceAppGuestContexts.values()) {
+    if (
+      context.appID === event.appId &&
+      context.workspaceID === event.workspaceId &&
+      context.ownerWindow.webContents.id === ownerWebContentsId
+    ) {
+      matchedGuest = true;
+    }
+  }
+  if (!matchedGuest) {
+    workspaceAppInitialLaunchIntents.set(key, event.intent);
   }
 }
 
@@ -1173,6 +1215,8 @@ function createWorkspaceAppContext(
   }
   const issuer = new URL(resolveDesktopDaemonBaseUrl(endpoint)).origin;
   const installationId = `${context.workspaceID}:${context.appID}`;
+  const launchIntent = context.launchIntent;
+  delete context.launchIntent;
   return {
     appId: context.appID,
     capabilities: [
@@ -1188,6 +1232,7 @@ function createWorkspaceAppContext(
     }),
     installationId,
     issuer,
+    ...(launchIntent ? { launchIntent } : {}),
     locale,
     workspaceId: context.workspaceID
   };
@@ -1249,11 +1294,33 @@ function readWorkspaceAppGuestContext(
   if (separator <= 0 || separator >= value.length - 1) {
     return null;
   }
+  const workspaceID = decodeURIComponent(value.slice(0, separator));
+  const appID = decodeURIComponent(value.slice(separator + 1));
+  const intentKey = workspaceAppInitialLaunchIntentKey({
+    appID,
+    ownerWebContentsId: ownerWindow.webContents.id,
+    workspaceID
+  });
+  const launchIntent = workspaceAppInitialLaunchIntents.get(intentKey);
+  workspaceAppInitialLaunchIntents.delete(intentKey);
   return {
-    appID: decodeURIComponent(value.slice(separator + 1)),
+    ...(launchIntent ? { launchIntent } : {}),
+    appID,
     ownerWindow,
-    workspaceID: decodeURIComponent(value.slice(0, separator))
+    workspaceID
   };
+}
+
+function workspaceAppInitialLaunchIntentKey(input: {
+  appID: string;
+  ownerWebContentsId: number;
+  workspaceID: string;
+}): string {
+  return [
+    String(input.ownerWebContentsId),
+    encodeURIComponent(input.workspaceID),
+    encodeURIComponent(input.appID)
+  ].join(":");
 }
 
 function isWorkspaceAppDiagnosticPayload(
@@ -1268,10 +1335,16 @@ function isWorkspaceAppExternalRendererEvent(
   if (!isRecord(value)) {
     return false;
   }
-  if (value.type !== "userProjects.changed") {
+  if (typeof value.workspaceId !== "string") {
     return false;
   }
-  if (typeof value.workspaceId !== "string") {
+  if (value.type === "workspace.launchIntent") {
+    return (
+      typeof value.appId === "string" &&
+      isWorkspaceAppOpenRouteIntent(value.intent)
+    );
+  }
+  if (value.type !== "userProjects.changed") {
     return false;
   }
   if (!isRecord(value.snapshot)) {
@@ -1285,6 +1358,37 @@ function isWorkspaceAppExternalRendererEvent(
     Array.isArray(snapshot.projects) &&
     typeof snapshot.revision === "number"
   );
+}
+
+function isWorkspaceAppOpenRouteIntent(value: unknown): boolean {
+  if (!isRecord(value)) {
+    return false;
+  }
+  if (value.kind !== "open-route" || typeof value.route !== "string") {
+    return false;
+  }
+  const route = value.route.trim();
+  if (
+    !route.startsWith("/") ||
+    route.startsWith("//") ||
+    route.includes("://")
+  ) {
+    return false;
+  }
+  if (value.params !== undefined && !isStringRecord(value.params)) {
+    return false;
+  }
+  if (value.state !== undefined && !isRecord(value.state)) {
+    return false;
+  }
+  return true;
+}
+
+function isStringRecord(value: unknown): value is Record<string, string> {
+  if (!isRecord(value)) {
+    return false;
+  }
+  return Object.values(value).every((entry) => typeof entry === "string");
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {

--- a/apps/desktop/src/preload/entries/workspaceApp.ts
+++ b/apps/desktop/src/preload/entries/workspaceApp.ts
@@ -4,6 +4,7 @@ import type {
   DesktopWorkspaceAppContext,
   DesktopWorkspaceAppExternalRendererEvent
 } from "../../shared/contracts/ipc";
+import type { TuttiExternalWorkspaceOpenRouteIntent } from "@tutti-os/workspace-external-core/contracts";
 import { createWorkspaceAppExternalBridge } from "./workspaceAppExternalBridge.ts";
 import { installWorkspaceAppLinkInterception } from "./workspaceAppLinks.ts";
 import { createWorkspaceAppUserProjectSnapshotBridge } from "./workspaceAppUserProjectSnapshots.ts";
@@ -40,6 +41,9 @@ export interface WorkspaceAppHostContext {
 
 const contextListeners = new Set<
   (context: DesktopWorkspaceAppContext) => void
+>();
+const launchIntentListeners = new Set<
+  (intent: TuttiExternalWorkspaceOpenRouteIntent) => void
 >();
 const userProjectSnapshots = createWorkspaceAppUserProjectSnapshotBridge();
 let cachedContext: DesktopWorkspaceAppContext | null = null;
@@ -92,6 +96,12 @@ const tuttiExternal = createWorkspaceAppExternalBridge({
   send(channel, payload) {
     ipcRenderer.send(channel, payload);
   },
+  subscribeToWorkspaceLaunchIntents(listener) {
+    launchIntentListeners.add(listener);
+    return () => {
+      launchIntentListeners.delete(listener);
+    };
+  },
   subscribeToUserProjects(listener) {
     return userProjectSnapshots.subscribe(listener);
   }
@@ -117,6 +127,12 @@ ipcRenderer.on(
     }
     if (payload.type === "userProjects.changed") {
       userProjectSnapshots.publish(payload.snapshot);
+      return;
+    }
+    if (payload.type === "workspace.launchIntent") {
+      for (const listener of launchIntentListeners) {
+        listener(payload.intent);
+      }
     }
   }
 );
@@ -176,7 +192,12 @@ function isWorkspaceAppExternalRendererEvent(
   }
   const record = value as Record<string, unknown>;
   if (record.type !== "userProjects.changed") {
-    return false;
+    return (
+      record.type === "workspace.launchIntent" &&
+      typeof record.workspaceId === "string" &&
+      typeof record.appId === "string" &&
+      isWorkspaceAppOpenRouteIntent(record.intent)
+    );
   }
   if (typeof record.workspaceId !== "string") {
     return false;
@@ -194,6 +215,45 @@ function isWorkspaceAppExternalRendererEvent(
     Array.isArray(snapshotRecord.projects) &&
     typeof snapshotRecord.revision === "number"
   );
+}
+
+function isWorkspaceAppOpenRouteIntent(
+  value: unknown
+): value is TuttiExternalWorkspaceOpenRouteIntent {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    return false;
+  }
+  const record = value as Record<string, unknown>;
+  if (record.kind !== "open-route" || typeof record.route !== "string") {
+    return false;
+  }
+  const route = record.route.trim();
+  if (
+    !route.startsWith("/") ||
+    route.startsWith("//") ||
+    route.includes("://")
+  ) {
+    return false;
+  }
+  if (record.params !== undefined && !isStringRecord(record.params)) {
+    return false;
+  }
+  if (
+    record.state !== undefined &&
+    (!record.state ||
+      typeof record.state !== "object" ||
+      Array.isArray(record.state))
+  ) {
+    return false;
+  }
+  return true;
+}
+
+function isStringRecord(value: unknown): value is Record<string, string> {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    return false;
+  }
+  return Object.values(value).every((entry) => typeof entry === "string");
 }
 
 contextBridge.exposeInMainWorld("tuttiExternal", tuttiExternal);

--- a/apps/desktop/src/preload/entries/workspaceAppExternalBridge.test.ts
+++ b/apps/desktop/src/preload/entries/workspaceAppExternalBridge.test.ts
@@ -67,6 +67,53 @@ test("workspace app external bridge subscribes to app context", () => {
   assert.deepEqual(contexts, [context]);
 });
 
+test("workspace app external bridge replays initial launch intent from app context", async () => {
+  const intent = {
+    kind: "open-route" as const,
+    params: { mode: "preview" },
+    route: "/files",
+    state: { selectedPath: "/tmp/a.md" }
+  };
+  const bridge = createWorkspaceAppExternalBridge({
+    appContext: {
+      async get() {
+        return {
+          appId: "docs",
+          launchIntent: intent,
+          locale: "en",
+          workspaceId: "workspace-1"
+        };
+      },
+      subscribe() {
+        throw new Error("unexpected subscribe");
+      }
+    },
+    isUserActivationActive: () => true,
+    send: unexpectedSend,
+    subscribeToWorkspaceLaunchIntents() {
+      return () => undefined;
+    },
+    async invoke() {
+      throw new Error("unexpected invoke");
+    }
+  });
+  const intents: unknown[] = [];
+
+  const unsubscribe = bridge.workspace.onLaunchIntent((nextIntent) => {
+    intents.push(nextIntent);
+  });
+  await new Promise((resolve) => setImmediate(resolve));
+
+  unsubscribe();
+  const unsubscribeAgain = bridge.workspace.onLaunchIntent((nextIntent) => {
+    intents.push(nextIntent);
+  });
+  await new Promise((resolve) => setImmediate(resolve));
+
+  unsubscribeAgain();
+  assert.deepEqual(intents, [intent]);
+});
+
 test("workspace app external bridge invokes at query without user activation", async () => {
   const calls: Array<{ channel: string; payload?: unknown }> = [];
   const bridge = createWorkspaceAppExternalBridge({

--- a/apps/desktop/src/preload/entries/workspaceAppExternalBridge.ts
+++ b/apps/desktop/src/preload/entries/workspaceAppExternalBridge.ts
@@ -24,6 +24,7 @@ import type {
   TuttiExternalUserProjectCreateInput,
   TuttiExternalUserProjectPathInput,
   TuttiExternalUserProjectRememberDefaultSelectionInput,
+  TuttiExternalWorkspaceOpenRouteIntent,
   TuttiExternalWorkspaceOpenFeatureInput
 } from "@tutti-os/workspace-external-core/contracts";
 import {
@@ -53,6 +54,9 @@ export interface WorkspaceAppExternalBridgeDependencies {
   send(channel: string, payload?: unknown): void;
   subscribeToUserProjects?(
     listener: (snapshot: WorkspaceUserProjectServiceSnapshot) => void
+  ): () => void;
+  subscribeToWorkspaceLaunchIntents?(
+    listener: (intent: TuttiExternalWorkspaceOpenRouteIntent) => void
   ): () => void;
 }
 
@@ -103,9 +107,12 @@ export const workspaceAppExternalChannels = {
   workspaceFeatureOpen: "workspace-app-feature:open"
 } as const;
 
+const noop = () => {};
+
 export function createWorkspaceAppExternalBridge(
   dependencies: WorkspaceAppExternalBridgeDependencies
 ): TuttiExternalBridge {
+  let initialLaunchIntentConsumed = false;
   return {
     app: {
       getContext() {
@@ -294,6 +301,28 @@ export function createWorkspaceAppExternalBridge(
       }
     },
     workspace: {
+      onLaunchIntent(listener) {
+        let active = true;
+        const unsubscribe =
+          dependencies.subscribeToWorkspaceLaunchIntents?.(listener) ?? noop;
+        void dependencies.appContext
+          .get()
+          .then((context) => {
+            if (
+              active &&
+              context.launchIntent &&
+              !initialLaunchIntentConsumed
+            ) {
+              initialLaunchIntentConsumed = true;
+              listener(context.launchIntent);
+            }
+          })
+          .catch(() => {});
+        return () => {
+          active = false;
+          unsubscribe();
+        };
+      },
       openFeature(input: TuttiExternalWorkspaceOpenFeatureInput) {
         requireUserActivation(
           dependencies.isUserActivationActive(),

--- a/apps/desktop/src/renderer/src/features/workspace-agent/services/internal/workspaceAgentActivityService.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-agent/services/internal/workspaceAgentActivityService.ts
@@ -16,10 +16,6 @@ import type {
 } from "@tutti-os/client-tuttid-ts";
 import type { DesktopHostFilesApi, DesktopRuntimeApi } from "@preload/types";
 import {
-  isDesktopAgentGUIProvider,
-  normalizeDesktopAgentGUIProvider
-} from "../../desktopAgentGUINodeState.ts";
-import {
   agentActivitySessionFromTuttidSession,
   createDesktopAgentActivityAdapter
 } from "../desktopAgentActivityAdapter.ts";
@@ -36,7 +32,6 @@ import {
   rememberAgentSessionVisibility
 } from "./desktopAgentHostWorkspaceState.ts";
 import { loadWorkspaceAgentSessionControlState } from "./workspaceAgentSessionControlState.ts";
-import { requestWorkspaceAgentGuiLaunch } from "../workspaceAgentGuiLaunchCoordinator.ts";
 import type {
   IWorkspaceAgentActivityService,
   WorkspaceAgentActivityListMessagesInput,
@@ -676,39 +671,6 @@ export class WorkspaceAgentActivityService implements IWorkspaceAgentActivitySer
           data: payload.data,
           eventType: payload.eventType,
           workspaceId
-        });
-      },
-      { scope: { workspaceId } }
-    );
-    eventStreamClient.subscribe(
-      "agent.gui.launch.requested",
-      (event) => {
-        const payload = event.payload;
-        if (payload.workspaceId.trim() !== workspaceId) {
-          return;
-        }
-        const rawProvider = payload.provider.trim();
-        if (!isDesktopAgentGUIProvider(rawProvider)) {
-          void this.dependencies.runtimeApi.logTerminalDiagnostic({
-            details: { provider: payload.provider },
-            event: "agent.gui.launch.unsupported_provider",
-            level: "warn",
-            workspaceId
-          });
-          return;
-        }
-        const provider = normalizeDesktopAgentGUIProvider(rawProvider);
-        void requestWorkspaceAgentGuiLaunch({
-          agentSessionId: payload.agentSessionId,
-          provider,
-          workspaceId
-        }).catch((error: unknown) => {
-          void this.dependencies.runtimeApi.logTerminalDiagnostic({
-            details: { error: stringifyError(error) },
-            event: "agent.gui.launch.request_failed",
-            level: "warn",
-            workspaceId
-          });
         });
       },
       { scope: { workspaceId } }

--- a/apps/desktop/src/renderer/src/features/workspace-app-center/services/internal/workspaceAppCenterContribution.test.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-app-center/services/internal/workspaceAppCenterContribution.test.ts
@@ -167,6 +167,54 @@ test("workspace app launch request restarts pending app from dock", async () => 
   ]);
 });
 
+test("workspace app launch request preserves open-route intent across pending restart", async () => {
+  const app = createApp({
+    appId: "docs",
+    runtimeStatus: "installed_pending_restart",
+    launchUrl: "http://127.0.0.1:3000"
+  });
+  const restartCalls: Array<
+    Parameters<IWorkspaceAppCenterService["restartAndOpenApp"]>[0]
+  > = [];
+  const result = await resolveWorkspaceAppCenterLaunchRequest({
+    appCenterService: createAppCenterService([app], {
+      restartAndOpenApp: async (input) => {
+        restartCalls.push(input);
+        return true;
+      }
+    }),
+    request: {
+      ...createLaunchRequestContext(),
+      payload: {
+        appId: "docs",
+        intent: {
+          kind: "open-route",
+          params: { mode: "preview" },
+          route: "/files",
+          state: { selectedPath: "/tmp/a.md" }
+        }
+      },
+      reason: "host",
+      typeId: workspaceAppWebviewTypeID,
+      workspaceId: "workspace-1"
+    }
+  });
+
+  assert.equal(result, null);
+  assert.deepEqual(restartCalls, [
+    {
+      appId: "docs",
+      intent: {
+        kind: "open-route",
+        params: { mode: "preview" },
+        route: "/files",
+        state: { selectedPath: "/tmp/a.md" }
+      },
+      workspaceId: "workspace-1"
+    }
+  ]);
+});
+
 test("workspace app webview URL prefers the current launch URL over stale activation ports", () => {
   assert.equal(
     resolveWorkspaceAppWebviewUrl({
@@ -206,6 +254,100 @@ test("workspace app webview URL preserves same-origin activation deep links", ()
     }),
     "http://127.0.0.1:51234/rooms/current"
   );
+});
+
+test("workspace app webview URL supports open-route activation payloads", () => {
+  assert.equal(
+    resolveWorkspaceAppWebviewUrl({
+      activation: {
+        payload: {
+          appId: "docs",
+          intent: {
+            kind: "open-route",
+            params: { mode: "preview" },
+            route: "/files"
+          },
+          url: "http://127.0.0.1:51234/files?mode=preview"
+        },
+        sequence: 1,
+        type: "workspace-app:open"
+      },
+      appCanUseExternalState: true,
+      appLaunchUrl: "http://127.0.0.1:51234/",
+      externalNodeState: null
+    }),
+    "http://127.0.0.1:51234/files?mode=preview"
+  );
+});
+
+test("workspace app open-route resolves from the app origin root", async () => {
+  const app = createApp({
+    appId: "docs",
+    runtimeStatus: "running",
+    launchUrl: "http://127.0.0.1:51234/app-shell/"
+  });
+
+  const result = await resolveWorkspaceAppCenterLaunchRequest({
+    appCenterService: createAppCenterService([app]),
+    request: {
+      ...createLaunchRequestContext(),
+      payload: {
+        appId: "docs",
+        intent: {
+          kind: "open-route",
+          params: { mode: "preview" },
+          route: "/files"
+        }
+      },
+      reason: "host",
+      typeId: workspaceAppWebviewTypeID,
+      workspaceId: "workspace-1"
+    }
+  });
+
+  assert.equal(result?.activation?.type, "workspace-app:open");
+  assert.deepEqual(result?.activation?.payload, {
+    appId: "docs",
+    intent: {
+      kind: "open-route",
+      params: { mode: "preview" },
+      route: "/files"
+    },
+    title: "Ready",
+    url: "http://127.0.0.1:51234/files?mode=preview"
+  });
+});
+
+test("workspace app open-route rejects protocol-relative routes", async () => {
+  const app = createApp({
+    appId: "docs",
+    runtimeStatus: "running",
+    launchUrl: "http://127.0.0.1:51234/app-shell/"
+  });
+
+  const result = await resolveWorkspaceAppCenterLaunchRequest({
+    appCenterService: createAppCenterService([app]),
+    request: {
+      ...createLaunchRequestContext(),
+      payload: {
+        appId: "docs",
+        intent: {
+          kind: "open-route",
+          route: "//example.com/files"
+        }
+      },
+      reason: "host",
+      typeId: workspaceAppWebviewTypeID,
+      workspaceId: "workspace-1"
+    }
+  });
+
+  assert.equal(result?.activation?.type, "open-url");
+  assert.deepEqual(result?.activation?.payload, {
+    appId: "docs",
+    title: "Ready",
+    url: "http://127.0.0.1:51234/app-shell/"
+  });
 });
 
 test("workspace app dock entry focus reports app open from the dock entry id", () => {

--- a/apps/desktop/src/renderer/src/features/workspace-app-center/services/internal/workspaceAppCenterLaunchRequest.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-app-center/services/internal/workspaceAppCenterLaunchRequest.ts
@@ -15,6 +15,7 @@ import {
   workspaceAppWebviewTypeID
 } from "../workspaceAppCenterLaunchIds.ts";
 import { workspaceAppWebviewFrame } from "./workspaceAppWebviewFrame.ts";
+import type { WorkspaceAppOpenRouteIntent } from "./workspaceAppCenterWebviewUrl.ts";
 
 export { workspaceAppCenterNodeID, workspaceAppWebviewTypeID };
 
@@ -49,6 +50,7 @@ export async function resolveWorkspaceAppCenterLaunchRequest(input: {
   ) {
     await input.appCenterService.restartAndOpenApp({
       appId,
+      ...(payload?.intent ? { intent: payload.intent } : {}),
       workspaceId: input.request.workspaceId
     });
     return null;
@@ -70,15 +72,17 @@ export async function resolveWorkspaceAppCenterLaunchRequest(input: {
     reporterService: input.reporterService
   });
   const appTitle = resolveWorkspaceAppDisplayName(app);
+  const url = resolveWorkspaceAppOpenUrl(app.launchUrl, payload?.intent);
 
   return {
     activation: {
       payload: {
         appId: app.appId,
+        ...(payload?.intent ? { intent: payload.intent } : {}),
         title: appTitle,
-        url: app.launchUrl
+        url
       },
-      type: "open-url"
+      type: payload?.intent ? "workspace-app:open" : "open-url"
     },
     defaultFrame: workspaceAppWebviewFrame,
     dockEntryId: workspaceAppDockEntryId(app.appId),
@@ -173,6 +177,7 @@ export function reportWorkspaceAppOpenedFromDockEntry(input: {
 
 function readWorkspaceAppLaunchPayload(request: WorkbenchHostLaunchRequest): {
   appId: string;
+  intent?: WorkspaceAppOpenRouteIntent;
   prepared: boolean;
   prevStatus?: AppCenterAppOpenedParams["prevStatus"];
 } | null {
@@ -180,6 +185,7 @@ function readWorkspaceAppLaunchPayload(request: WorkbenchHostLaunchRequest): {
     request.payload && typeof request.payload === "object"
       ? (request.payload as {
           appId?: unknown;
+          intent?: unknown;
           prepared?: unknown;
           prevStatus?: unknown;
         })
@@ -193,11 +199,70 @@ function readWorkspaceAppLaunchPayload(request: WorkbenchHostLaunchRequest): {
     isWorkspaceAppOpenPrevStatus(payload.prevStatus)
       ? payload.prevStatus
       : undefined;
+  const intent = readWorkspaceAppOpenRouteIntent(payload?.intent);
   return {
     appId,
+    ...(intent ? { intent } : {}),
     prepared: payload?.prepared === true,
     prevStatus
   };
+}
+
+function readWorkspaceAppOpenRouteIntent(
+  value: unknown
+): WorkspaceAppOpenRouteIntent | null {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    return null;
+  }
+  const record = value as Record<string, unknown>;
+  if (record.kind !== "open-route" || typeof record.route !== "string") {
+    return null;
+  }
+  const route = record.route.trim();
+  if (
+    !route.startsWith("/") ||
+    route.startsWith("//") ||
+    route.includes("://")
+  ) {
+    return null;
+  }
+  return {
+    kind: "open-route",
+    ...(isStringRecord(record.params) ? { params: record.params } : {}),
+    route,
+    ...(isRecord(record.state) ? { state: record.state } : {})
+  };
+}
+
+function resolveWorkspaceAppOpenUrl(
+  launchUrl: string,
+  intent: WorkspaceAppOpenRouteIntent | undefined
+): string {
+  if (!intent) {
+    return launchUrl;
+  }
+  try {
+    const url = new URL(launchUrl);
+    url.pathname = intent.route;
+    url.search = "";
+    for (const [key, value] of Object.entries(intent.params ?? {})) {
+      url.searchParams.append(key, value);
+    }
+    return url.toString();
+  } catch {
+    return launchUrl;
+  }
+}
+
+function isStringRecord(value: unknown): value is Record<string, string> {
+  if (!isRecord(value)) {
+    return false;
+  }
+  return Object.values(value).every((entry) => typeof entry === "string");
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
 }
 
 function isWorkspaceAppOpenPrevStatus(

--- a/apps/desktop/src/renderer/src/features/workspace-app-center/services/internal/workspaceAppCenterService.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-app-center/services/internal/workspaceAppCenterService.ts
@@ -40,6 +40,7 @@ import { AppCenterCatalogRefreshedReporter } from "../../../analytics/reporters/
 import { AppCenterFactoryJobCreatedReporter } from "../../../analytics/reporters/app-center-factory-job-created/appCenterFactoryJobCreatedReporter.ts";
 import { ErrorAppRuntimeFailedReporter } from "../../../analytics/reporters/error-app-runtime-failed/errorAppRuntimeFailedReporter.ts";
 import type { IReporterService } from "../../../analytics/services/reporterService.interface.ts";
+import type { TuttiExternalWorkspaceOpenRouteIntent } from "@tutti-os/workspace-external-core/contracts";
 import type { IWorkspaceAppCenterService } from "../workspaceAppCenterService.interface";
 import {
   normalizeWorkspaceAppCenterApp,
@@ -78,6 +79,7 @@ export interface WorkspaceAppCenterServiceDependencies {
 
 type WorkspaceAppLauncher = (input: {
   appId: string;
+  intent?: TuttiExternalWorkspaceOpenRouteIntent;
   prepared: boolean;
   prevStatus?: WorkspaceAppCenterRuntimeStatus;
   workspaceId: string;
@@ -603,6 +605,7 @@ export class WorkspaceAppCenterService implements IWorkspaceAppCenterService {
 
   async restartAndOpenApp(input: {
     appId: string;
+    intent?: TuttiExternalWorkspaceOpenRouteIntent;
     workspaceId: string;
   }): Promise<boolean> {
     const previousApp = this.store.apps.find(
@@ -616,6 +619,7 @@ export class WorkspaceAppCenterService implements IWorkspaceAppCenterService {
     return (
       (await this.workspaceAppLauncher?.({
         appId: launchableApp.appId,
+        ...(input.intent ? { intent: input.intent } : {}),
         prepared: true,
         prevStatus: previousApp?.runtimeStatus ?? launchableApp.runtimeStatus,
         workspaceId: input.workspaceId

--- a/apps/desktop/src/renderer/src/features/workspace-app-center/services/internal/workspaceAppCenterWebviewUrl.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-app-center/services/internal/workspaceAppCenterWebviewUrl.ts
@@ -5,6 +5,20 @@ export interface WorkspaceAppWebviewExternalState {
   url: string | null;
 }
 
+export interface WorkspaceAppOpenRouteIntent {
+  kind: "open-route";
+  params?: Record<string, string>;
+  route: string;
+  state?: Record<string, unknown>;
+}
+
+export interface WorkspaceAppOpenPayload {
+  appId: string;
+  intent?: WorkspaceAppOpenRouteIntent;
+  title?: string;
+  url: string;
+}
+
 export function resolveWorkspaceAppWebviewUrl(input: {
   activation: WorkbenchHostActivation | null;
   appCanUseExternalState: boolean;
@@ -44,24 +58,67 @@ function hasSameUrlOrigin(left: string, right: string): boolean {
 
 export function readWorkspaceAppOpenPayload(
   activation: WorkbenchHostActivation | null
-): { appId: string; title?: string; url: string } | null {
+): WorkspaceAppOpenPayload | null {
   if (
-    activation?.type !== "open-url" ||
-    !activation.payload ||
-    typeof activation.payload !== "object"
+    activation?.type !== "open-url" &&
+    activation?.type !== "workspace-app:open"
   ) {
+    return null;
+  }
+  if (!activation.payload || typeof activation.payload !== "object") {
     return null;
   }
   const payload = activation.payload as {
     appId?: unknown;
     title?: unknown;
     url?: unknown;
+    intent?: unknown;
   };
-  return typeof payload.appId === "string" && typeof payload.url === "string"
-    ? {
-        appId: payload.appId,
-        title: typeof payload.title === "string" ? payload.title : undefined,
-        url: payload.url
-      }
-    : null;
+  if (typeof payload.appId !== "string" || typeof payload.url !== "string") {
+    return null;
+  }
+  const intent = readWorkspaceAppOpenRouteIntent(payload.intent);
+  return {
+    appId: payload.appId,
+    ...(intent ? { intent } : {}),
+    ...(typeof payload.title === "string" ? { title: payload.title } : {}),
+    url: payload.url
+  };
+}
+
+function readWorkspaceAppOpenRouteIntent(
+  value: unknown
+): WorkspaceAppOpenRouteIntent | null {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    return null;
+  }
+  const record = value as Record<string, unknown>;
+  if (record.kind !== "open-route" || typeof record.route !== "string") {
+    return null;
+  }
+  const route = record.route.trim();
+  if (
+    !route.startsWith("/") ||
+    route.startsWith("//") ||
+    route.includes("://")
+  ) {
+    return null;
+  }
+  return {
+    kind: "open-route",
+    ...(isStringRecord(record.params) ? { params: record.params } : {}),
+    route,
+    ...(isRecord(record.state) ? { state: record.state } : {})
+  };
+}
+
+function isStringRecord(value: unknown): value is Record<string, string> {
+  if (!isRecord(value)) {
+    return false;
+  }
+  return Object.values(value).every((entry) => typeof entry === "string");
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
 }

--- a/apps/desktop/src/renderer/src/features/workspace-app-center/services/workspaceAppCenterService.interface.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-app-center/services/workspaceAppCenterService.interface.ts
@@ -7,6 +7,7 @@ import type {
   WorkspaceAppCenterReadableStoreState,
   WorkspaceAppCenterViewState
 } from "@tutti-os/workspace-app-center";
+import type { TuttiExternalWorkspaceOpenRouteIntent } from "@tutti-os/workspace-external-core/contracts";
 
 export interface IWorkspaceAppCenterService {
   readonly _serviceBrand: undefined;
@@ -73,6 +74,7 @@ export interface IWorkspaceAppCenterService {
   replaceAppIcon(input: { appId: string; workspaceId: string }): Promise<void>;
   restartAndOpenApp(input: {
     appId: string;
+    intent?: TuttiExternalWorkspaceOpenRouteIntent;
     workspaceId: string;
   }): Promise<boolean>;
   retryFactoryValidation(input: {
@@ -88,6 +90,7 @@ export interface IWorkspaceAppCenterService {
     launcher:
       | ((input: {
           appId: string;
+          intent?: TuttiExternalWorkspaceOpenRouteIntent;
           prepared: boolean;
           prevStatus?: WorkspaceAppCenterApp["runtimeStatus"];
           workspaceId: string;

--- a/apps/desktop/src/renderer/src/features/workspace-workbench/services/internal/workspaceWorkbenchHostService.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/services/internal/workspaceWorkbenchHostService.ts
@@ -114,6 +114,7 @@ import type {
 import type { WorkspaceFileReferenceAdapter } from "@tutti-os/workspace-file-reference/contracts";
 import type { WorkspaceUserProjectApi } from "@tutti-os/workspace-user-project/contracts";
 import { serializeWorkspaceAppExternalAtMatch } from "./workspaceAppExternalAtSerialization.ts";
+import { requestWorkspaceWorkbenchNodeLaunch } from "../workspaceWorkbenchNodeLaunchCoordinator.ts";
 
 const workspaceDockNativePreviewMaxWidthPx = 260;
 const workspaceDockNativePreviewMaxHeightPx = 170;
@@ -244,6 +245,7 @@ export class WorkspaceWorkbenchHostService implements IWorkspaceWorkbenchHostSer
     this.dependencies.repository.subscribe(() => {
       this.notifyWallpaperListeners();
     });
+    this.subscribeWorkbenchNodeLaunchRequests();
     void this.loadCustomWallpaper();
   }
 
@@ -610,6 +612,43 @@ export class WorkspaceWorkbenchHostService implements IWorkspaceWorkbenchHostSer
     this.dependencies.hostWorkspaceApi.broadcastAgentStatus(payload);
   }
 
+  private subscribeWorkbenchNodeLaunchRequests(): void {
+    const eventStreamClient = this.dependencies.eventStreamClient;
+    if (!eventStreamClient) {
+      return;
+    }
+    eventStreamClient.subscribe(
+      "workspace.workbench.node.launch.requested",
+      (event) => {
+        const payload = event.payload;
+        void requestWorkspaceWorkbenchNodeLaunch({
+          ...(payload.dockEntryId ? { dockEntryId: payload.dockEntryId } : {}),
+          ...(payload.launchSource
+            ? { launchSource: payload.launchSource }
+            : {}),
+          payload: payload.payload,
+          typeId: payload.typeId,
+          workspaceId: payload.workspaceId
+        }).catch((error: unknown) => {
+          void this.dependencies.runtimeApi.logTerminalDiagnostic({
+            details: { error: formatDiagnosticError(error) },
+            event: "workbench.node.launch.request_failed",
+            level: "warn",
+            workspaceId: payload.workspaceId
+          });
+        });
+      }
+    );
+    void eventStreamClient.connect().catch((error: unknown) => {
+      void this.dependencies.runtimeApi.logTerminalDiagnostic({
+        details: { error: formatDiagnosticError(error) },
+        event: "workbench.node.launch.event_stream_connect_failed",
+        level: "warn",
+        workspaceId: null
+      });
+    });
+  }
+
   private async persistPendingWallpaperSettings(
     workspaceId: string
   ): Promise<void> {
@@ -897,6 +936,10 @@ export class WorkspaceWorkbenchHostService implements IWorkspaceWorkbenchHostSer
     }
     return dynamicHostInput;
   }
+}
+
+function formatDiagnosticError(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
 }
 
 function createDesktopWorkspaceNodePreviewCapture(

--- a/apps/desktop/src/renderer/src/features/workspace-workbench/services/workspaceWorkbenchNodeLaunchCoordinator.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/services/workspaceWorkbenchNodeLaunchCoordinator.ts
@@ -1,0 +1,61 @@
+export interface WorkspaceWorkbenchNodeLaunchRequest {
+  dockEntryId?: string;
+  launchSource?: string;
+  payload?: unknown;
+  typeId: string;
+  workspaceId: string;
+}
+
+export type WorkspaceWorkbenchNodeLaunchHandler = (
+  request: WorkspaceWorkbenchNodeLaunchRequest
+) => Promise<boolean> | boolean;
+
+const launchHandlersByWorkspaceId = new Map<
+  string,
+  WorkspaceWorkbenchNodeLaunchHandler
+>();
+
+export function registerWorkspaceWorkbenchNodeLaunchHandler(
+  workspaceId: string,
+  handler: WorkspaceWorkbenchNodeLaunchHandler
+): () => void {
+  const normalizedWorkspaceId = workspaceId.trim();
+  if (!normalizedWorkspaceId) {
+    return noop;
+  }
+
+  launchHandlersByWorkspaceId.set(normalizedWorkspaceId, handler);
+  return () => {
+    if (launchHandlersByWorkspaceId.get(normalizedWorkspaceId) === handler) {
+      launchHandlersByWorkspaceId.delete(normalizedWorkspaceId);
+    }
+  };
+}
+
+export async function requestWorkspaceWorkbenchNodeLaunch(
+  request: WorkspaceWorkbenchNodeLaunchRequest
+): Promise<boolean> {
+  const normalizedWorkspaceId = request.workspaceId.trim();
+  const normalizedTypeId = request.typeId.trim();
+  if (!normalizedWorkspaceId || !normalizedTypeId) {
+    return false;
+  }
+  const handler = launchHandlersByWorkspaceId.get(normalizedWorkspaceId);
+  if (!handler) {
+    return false;
+  }
+
+  return handler({
+    ...(request.dockEntryId?.trim()
+      ? { dockEntryId: request.dockEntryId.trim() }
+      : {}),
+    ...(request.launchSource?.trim()
+      ? { launchSource: request.launchSource.trim() }
+      : {}),
+    payload: request.payload,
+    typeId: normalizedTypeId,
+    workspaceId: normalizedWorkspaceId
+  });
+}
+
+function noop(): void {}

--- a/apps/desktop/src/renderer/src/features/workspace-workbench/ui/WorkspaceWorkbench.tsx
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/ui/WorkspaceWorkbench.tsx
@@ -63,6 +63,7 @@ import {
   registerWorkspaceIssueManagerLaunchHandler,
   type WorkspaceIssueManagerLaunchRequest
 } from "../services/workspaceIssueManagerLaunchCoordinator.ts";
+import { registerWorkspaceWorkbenchNodeLaunchHandler } from "../services/workspaceWorkbenchNodeLaunchCoordinator.ts";
 import {
   buildGroupChatDeepLinkUrl,
   registerGroupChatLaunchHandler,
@@ -89,7 +90,11 @@ import { useWorkspaceWorkbenchShellRuntime } from "./useWorkspaceWorkbenchShellR
 import { useWorkspaceOnboardingAutoOpen } from "./useWorkspaceOnboardingAutoOpen.ts";
 import { resolveWorkspaceWorkbenchLayoutConstraints } from "./workspaceWorkbenchLayoutConstraints.ts";
 import type { DesktopWorkspaceAppExternalHostApi } from "@preload/types";
-import type { TuttiExternalFileOpenInput } from "@tutti-os/workspace-external-core/contracts";
+import type { DesktopWorkspaceAppExternalRendererEvent } from "@shared/contracts/ipc";
+import type {
+  TuttiExternalFileOpenInput,
+  TuttiExternalWorkspaceOpenRouteIntent
+} from "@tutti-os/workspace-external-core/contracts";
 
 const temporaryWorkspaceAppDockRetentionActionPrefix =
   "temporary-workspace-app-dock-retention:";
@@ -185,6 +190,7 @@ function ReadyWorkspaceWorkbench({
   const unregisterFilesLaunchRef = useRef<(() => void) | null>(null);
   const unregisterIssueManagerLaunchRef = useRef<(() => void) | null>(null);
   const unregisterGroupChatLaunchRef = useRef<(() => void) | null>(null);
+  const unregisterWorkbenchNodeLaunchRef = useRef<(() => void) | null>(null);
   const closeLaunchpad = useCallback(() => {
     setLaunchpadOpen(false);
   }, []);
@@ -288,6 +294,8 @@ function ReadyWorkspaceWorkbench({
       unregisterIssueManagerLaunchRef.current = null;
       unregisterGroupChatLaunchRef.current?.();
       unregisterGroupChatLaunchRef.current = null;
+      unregisterWorkbenchNodeLaunchRef.current?.();
+      unregisterWorkbenchNodeLaunchRef.current = null;
 
       if (!host) {
         return;
@@ -345,8 +353,48 @@ function ReadyWorkspaceWorkbench({
             return openWorkspaceBrowserNode(host, request);
           }
         );
+      unregisterWorkbenchNodeLaunchRef.current =
+        registerWorkspaceWorkbenchNodeLaunchHandler(
+          state.workspace.id,
+          async (request) => {
+            const shouldPrepublishIntent =
+              shouldPublishWorkspaceAppLaunchIntentBeforeLaunch({
+                appCenterService,
+                payload: request.payload,
+                typeId: request.typeId
+              });
+            if (shouldPrepublishIntent) {
+              publishWorkspaceAppLaunchIntent({
+                api: workspaceAppExternalApi,
+                payload: request.payload,
+                typeId: request.typeId,
+                workspaceId: state.workspace.id
+              });
+            }
+            const nodeId = await host.launchNode({
+              ...(request.dockEntryId
+                ? { dockEntryId: request.dockEntryId }
+                : {}),
+              ...(request.launchSource
+                ? { launchSource: request.launchSource }
+                : {}),
+              payload: request.payload,
+              reason: "host",
+              typeId: request.typeId
+            });
+            if (nodeId && !shouldPrepublishIntent) {
+              publishWorkspaceAppLaunchIntent({
+                api: workspaceAppExternalApi,
+                payload: request.payload,
+                typeId: request.typeId,
+                workspaceId: state.workspace.id
+              });
+            }
+            return nodeId !== null;
+          }
+        );
     },
-    [appCenterService, runtime, state.workspace.id]
+    [appCenterService, runtime, state.workspace.id, workspaceAppExternalApi]
   );
   const windowManagement = useMemo<WorkbenchWindowManagementConfig>(
     () => ({
@@ -370,6 +418,8 @@ function ReadyWorkspaceWorkbench({
       unregisterIssueManagerLaunchRef.current = null;
       unregisterGroupChatLaunchRef.current?.();
       unregisterGroupChatLaunchRef.current = null;
+      unregisterWorkbenchNodeLaunchRef.current?.();
+      unregisterWorkbenchNodeLaunchRef.current = null;
     };
   }, []);
 
@@ -716,6 +766,99 @@ function readWorkspaceAppIdFromDockEntryId(
   return value?.startsWith(prefix)
     ? decodeURIComponent(value.slice(prefix.length))
     : null;
+}
+
+function publishWorkspaceAppLaunchIntent(input: {
+  api: DesktopWorkspaceAppExternalHostApi | undefined;
+  payload: unknown;
+  typeId: string;
+  workspaceId: string;
+}): void {
+  if (!input.api || input.typeId !== workspaceAppWebviewTypeID) {
+    return;
+  }
+  const event = readWorkspaceAppLaunchIntentEvent(
+    input.payload,
+    input.workspaceId
+  );
+  if (!event) {
+    return;
+  }
+  input.api.sendEvent(event);
+}
+
+function readWorkspaceAppLaunchIntentEvent(
+  payload: unknown,
+  workspaceId: string
+): DesktopWorkspaceAppExternalRendererEvent | null {
+  if (!payload || typeof payload !== "object" || Array.isArray(payload)) {
+    return null;
+  }
+  const record = payload as Record<string, unknown>;
+  const appId = typeof record.appId === "string" ? record.appId.trim() : "";
+  const intent = readWorkspaceAppOpenRouteIntent(record.intent);
+  if (!appId || !intent) {
+    return null;
+  }
+  return {
+    appId,
+    intent,
+    type: "workspace.launchIntent",
+    workspaceId
+  };
+}
+
+function readWorkspaceAppOpenRouteIntent(
+  value: unknown
+): TuttiExternalWorkspaceOpenRouteIntent | null {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    return null;
+  }
+  const record = value as Record<string, unknown>;
+  if (record.kind !== "open-route" || typeof record.route !== "string") {
+    return null;
+  }
+  const route = record.route.trim();
+  if (
+    !route.startsWith("/") ||
+    route.startsWith("//") ||
+    route.includes("://")
+  ) {
+    return null;
+  }
+  return {
+    kind: "open-route",
+    ...(isStringRecord(record.params) ? { params: record.params } : {}),
+    route,
+    ...(isRecord(record.state) ? { state: record.state } : {})
+  };
+}
+
+function isStringRecord(value: unknown): value is Record<string, string> {
+  if (!isRecord(value)) {
+    return false;
+  }
+  return Object.values(value).every((entry) => typeof entry === "string");
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function shouldPublishWorkspaceAppLaunchIntentBeforeLaunch(input: {
+  appCenterService: IWorkspaceAppCenterService;
+  payload: unknown;
+  typeId: string;
+}): boolean {
+  if (input.typeId !== workspaceAppWebviewTypeID) {
+    return false;
+  }
+  const event = readWorkspaceAppLaunchIntentEvent(input.payload, "workspace");
+  const app =
+    event?.type === "workspace.launchIntent"
+      ? findWorkspaceApp(input.appCenterService, event.appId)
+      : null;
+  return app?.runtimeStatus === "installed_pending_restart";
 }
 
 async function openWorkspaceFilesNode(

--- a/apps/desktop/src/renderer/src/features/workspace-workbench/ui/useWorkspaceWorkbenchShellRuntime.tsx
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/ui/useWorkspaceWorkbenchShellRuntime.tsx
@@ -368,10 +368,15 @@ export function useWorkspaceWorkbenchShellRuntime({
       );
       appCenterService.setWorkspaceAppLauncher(
         host
-          ? async ({ appId, prepared, prevStatus }) => {
+          ? async ({ appId, intent, prepared, prevStatus }) => {
               return (
                 (await host.launchNode({
-                  payload: { appId, prepared, prevStatus },
+                  payload: {
+                    appId,
+                    ...(intent ? { intent } : {}),
+                    prepared,
+                    prevStatus
+                  },
                   reason: "host",
                   typeId: workspaceAppWebviewTypeID,
                   // 让 onboarding 应用打开时播放“从底部进入并展开”的动画。

--- a/apps/desktop/src/shared/contracts/ipc.ts
+++ b/apps/desktop/src/shared/contracts/ipc.ts
@@ -44,6 +44,7 @@ import type {
   TuttiExternalUserProjectCreateInput,
   TuttiExternalUserProjectPathInput,
   TuttiExternalUserProjectRememberDefaultSelectionInput,
+  TuttiExternalWorkspaceOpenRouteIntent,
   TuttiExternalWorkspaceOpenFeatureInput
 } from "@tutti-os/workspace-external-core/contracts";
 import type {
@@ -365,6 +366,7 @@ export interface DesktopWorkspaceAppContext {
   contextToken?: string;
   installationId?: string;
   issuer?: string;
+  launchIntent?: TuttiExternalWorkspaceOpenRouteIntent;
   locale: DesktopLocale;
   workspaceId?: string;
 }
@@ -526,11 +528,18 @@ export interface DesktopWorkspaceAppExternalRendererResponse {
   result: DesktopIpcResult<DesktopWorkspaceAppExternalRendererResult>;
 }
 
-export type DesktopWorkspaceAppExternalRendererEvent = {
-  snapshot: WorkspaceUserProjectServiceSnapshot;
-  type: "userProjects.changed";
-  workspaceId: string;
-};
+export type DesktopWorkspaceAppExternalRendererEvent =
+  | {
+      snapshot: WorkspaceUserProjectServiceSnapshot;
+      type: "userProjects.changed";
+      workspaceId: string;
+    }
+  | {
+      appId: string;
+      intent: TuttiExternalWorkspaceOpenRouteIntent;
+      type: "workspace.launchIntent";
+      workspaceId: string;
+    };
 
 export type DesktopWorkspaceAppExternalRendererRequest =
   TuttiExternalRendererRequest;

--- a/packages/clients/tuttid-ts/src/index.ts
+++ b/packages/clients/tuttid-ts/src/index.ts
@@ -15,7 +15,7 @@ export {
 } from "./eventStreamClient.ts";
 export type {
   AgentActivityUpdatedEventV1,
-  AgentGuiLaunchRequestedEventV1,
+  WorkspaceWorkbenchNodeLaunchRequestedEventV1,
   WorkspaceIssueUpdatedEventV1
 } from "@tutti-os/event-protocol";
 export {

--- a/packages/events/protocol/definitions/workspace/workbench.node.launch.requested.event.json
+++ b/packages/events/protocol/definitions/workspace/workbench.node.launch.requested.event.json
@@ -1,24 +1,20 @@
 {
   "$schema": "../../schemas/core/event-definition.schema.json",
-  "topic": "agent.gui.launch.requested",
+  "topic": "workspace.workbench.node.launch.requested",
   "version": 1,
   "direction": "server->client",
-  "owner": "agent",
+  "owner": "core",
   "scope": "workspace",
   "payloadSchema": {
     "type": "object",
     "additionalProperties": false,
-    "required": ["workspaceId", "agentSessionId", "provider", "source"],
+    "required": ["workspaceId", "typeId", "source"],
     "properties": {
       "workspaceId": {
         "type": "string",
         "minLength": 1
       },
-      "agentSessionId": {
-        "type": "string",
-        "minLength": 1
-      },
-      "provider": {
+      "typeId": {
         "type": "string",
         "minLength": 1
       },
@@ -26,14 +22,19 @@
         "type": "string",
         "minLength": 1
       },
-      "reason": {
+      "launchSource": {
+        "type": "string",
+        "minLength": 1
+      },
+      "dockEntryId": {
         "type": "string",
         "minLength": 1
       },
       "requestId": {
         "type": "string",
         "minLength": 1
-      }
+      },
+      "payload": true
     }
   }
 }

--- a/packages/events/protocol/src/generated/contracts.ts
+++ b/packages/events/protocol/src/generated/contracts.ts
@@ -8,13 +8,13 @@ export type BusinessEventScopeName = "global" | "desktop" | "workspace";
 
 export type BusinessEventTopic =
   | "agent.activity.updated"
-  | "agent.gui.launch.requested"
   | "analytics.debug.reported"
   | "preferences.desktop.update.requested"
   | "preferences.desktop.updated"
   | "workspace.app.updated"
   | "workspace.appfactory.job.updated"
-  | "workspace.issue.updated";
+  | "workspace.issue.updated"
+  | "workspace.workbench.node.launch.requested";
 
 export interface BusinessEventScopeV1 {
   workspaceId?: string;
@@ -258,15 +258,6 @@ export type AgentActivityUpdatedPayloadV1 =
       };
     };
 
-export interface AgentGuiLaunchRequestedPayloadV1 {
-  workspaceId: string;
-  agentSessionId: string;
-  provider: string;
-  source: string;
-  reason?: string;
-  requestId?: string;
-}
-
 export interface AnalyticsDebugReportedPayloadV1 {
   events: readonly {
     name: string;
@@ -310,15 +301,19 @@ export interface WorkspaceIssueUpdatedPayloadV1 {
     | "run_completed";
 }
 
+export interface WorkspaceWorkbenchNodeLaunchRequestedPayloadV1 {
+  workspaceId: string;
+  typeId: string;
+  source: string;
+  launchSource?: string;
+  dockEntryId?: string;
+  requestId?: string;
+  payload?: unknown;
+}
+
 export type AgentActivityUpdatedEventV1 = BusinessEventEnvelopeV1<
   "agent.activity.updated",
   AgentActivityUpdatedPayloadV1,
-  1
->;
-
-export type AgentGuiLaunchRequestedEventV1 = BusinessEventEnvelopeV1<
-  "agent.gui.launch.requested",
-  AgentGuiLaunchRequestedPayloadV1,
   1
 >;
 
@@ -358,27 +353,34 @@ export type WorkspaceIssueUpdatedEventV1 = BusinessEventEnvelopeV1<
   1
 >;
 
+export type WorkspaceWorkbenchNodeLaunchRequestedEventV1 =
+  BusinessEventEnvelopeV1<
+    "workspace.workbench.node.launch.requested",
+    WorkspaceWorkbenchNodeLaunchRequestedPayloadV1,
+    1
+  >;
+
 export type ClientToServerEventTopic = "preferences.desktop.update.requested";
 
 export type ServerToClientEventTopic =
   | "agent.activity.updated"
-  | "agent.gui.launch.requested"
   | "analytics.debug.reported"
   | "preferences.desktop.updated"
   | "workspace.app.updated"
   | "workspace.appfactory.job.updated"
-  | "workspace.issue.updated";
+  | "workspace.issue.updated"
+  | "workspace.workbench.node.launch.requested";
 
 export type ClientToServerEventV1 = PreferencesDesktopUpdateRequestedEventV1;
 
 export type ServerToClientEventV1 =
   | AgentActivityUpdatedEventV1
-  | AgentGuiLaunchRequestedEventV1
   | AnalyticsDebugReportedEventV1
   | PreferencesDesktopUpdatedEventV1
   | WorkspaceAppUpdatedEventV1
   | WorkspaceAppfactoryJobUpdatedEventV1
-  | WorkspaceIssueUpdatedEventV1;
+  | WorkspaceIssueUpdatedEventV1
+  | WorkspaceWorkbenchNodeLaunchRequestedEventV1;
 
 export type BusinessEventV1 = ClientToServerEventV1 | ServerToClientEventV1;
 

--- a/packages/events/protocol/src/generated/registry.ts
+++ b/packages/events/protocol/src/generated/registry.ts
@@ -10,8 +10,6 @@ import type {
 
 export const businessEventTopicAgentActivityUpdated =
   "agent.activity.updated" as const;
-export const businessEventTopicAgentGuiLaunchRequested =
-  "agent.gui.launch.requested" as const;
 export const businessEventTopicAnalyticsDebugReported =
   "analytics.debug.reported" as const;
 export const businessEventTopicPreferencesDesktopUpdateRequested =
@@ -24,6 +22,8 @@ export const businessEventTopicWorkspaceAppfactoryJobUpdated =
   "workspace.appfactory.job.updated" as const;
 export const businessEventTopicWorkspaceIssueUpdated =
   "workspace.issue.updated" as const;
+export const businessEventTopicWorkspaceWorkbenchNodeLaunchRequested =
+  "workspace.workbench.node.launch.requested" as const;
 
 export interface BusinessEventDefinition {
   topic: BusinessEventTopic;
@@ -33,18 +33,11 @@ export interface BusinessEventDefinition {
   scope: BusinessEventScopeName;
 }
 
-export const businessEventCatalogRevision = "sha256:1f4baa742a2dbf19" as const;
+export const businessEventCatalogRevision = "sha256:7de58350911c2aa6" as const;
 
 export const businessEventDefinitions = [
   {
     topic: "agent.activity.updated",
-    version: 1,
-    direction: "server->client",
-    owner: "agent",
-    scope: "workspace"
-  },
-  {
-    topic: "agent.gui.launch.requested",
     version: 1,
     direction: "server->client",
     owner: "agent",
@@ -91,19 +84,19 @@ export const businessEventDefinitions = [
     direction: "server->client",
     owner: "workspace",
     scope: "workspace"
+  },
+  {
+    topic: "workspace.workbench.node.launch.requested",
+    version: 1,
+    direction: "server->client",
+    owner: "core",
+    scope: "workspace"
   }
 ] as const satisfies readonly BusinessEventDefinition[];
 
 export const businessEventDefinitionByTopic = {
   "agent.activity.updated": {
     topic: "agent.activity.updated",
-    version: 1,
-    direction: "server->client",
-    owner: "agent",
-    scope: "workspace"
-  },
-  "agent.gui.launch.requested": {
-    topic: "agent.gui.launch.requested",
     version: 1,
     direction: "server->client",
     owner: "agent",
@@ -149,6 +142,13 @@ export const businessEventDefinitionByTopic = {
     version: 1,
     direction: "server->client",
     owner: "workspace",
+    scope: "workspace"
+  },
+  "workspace.workbench.node.launch.requested": {
+    topic: "workspace.workbench.node.launch.requested",
+    version: 1,
+    direction: "server->client",
+    owner: "core",
     scope: "workspace"
   }
 } as const satisfies Record<BusinessEventTopic, BusinessEventDefinition>;

--- a/packages/events/protocol/src/generated/schemas.ts
+++ b/packages/events/protocol/src/generated/schemas.ts
@@ -863,38 +863,6 @@ export const agentActivityUpdatedPayloadSchema = {
   }
 } as const;
 
-export const agentGuiLaunchRequestedPayloadSchema = {
-  type: "object",
-  additionalProperties: false,
-  required: ["workspaceId", "agentSessionId", "provider", "source"],
-  properties: {
-    workspaceId: {
-      type: "string",
-      minLength: 1
-    },
-    agentSessionId: {
-      type: "string",
-      minLength: 1
-    },
-    provider: {
-      type: "string",
-      minLength: 1
-    },
-    source: {
-      type: "string",
-      minLength: 1
-    },
-    reason: {
-      type: "string",
-      minLength: 1
-    },
-    requestId: {
-      type: "string",
-      minLength: 1
-    }
-  }
-} as const;
-
 export const analyticsDebugReportedPayloadSchema = {
   type: "object",
   additionalProperties: false,
@@ -1754,6 +1722,39 @@ export const workspaceIssueUpdatedPayloadSchema = {
   }
 } as const;
 
+export const workspaceWorkbenchNodeLaunchRequestedPayloadSchema = {
+  type: "object",
+  additionalProperties: false,
+  required: ["workspaceId", "typeId", "source"],
+  properties: {
+    workspaceId: {
+      type: "string",
+      minLength: 1
+    },
+    typeId: {
+      type: "string",
+      minLength: 1
+    },
+    source: {
+      type: "string",
+      minLength: 1
+    },
+    launchSource: {
+      type: "string",
+      minLength: 1
+    },
+    dockEntryId: {
+      type: "string",
+      minLength: 1
+    },
+    requestId: {
+      type: "string",
+      minLength: 1
+    },
+    payload: true
+  }
+} as const;
+
 export const businessEventEnvelopeSchema = {
   $schema: "https://json-schema.org/draft/2020-12/schema",
   $id: "https://tutti.dev/schemas/events/event-envelope.schema.json",
@@ -2080,7 +2081,6 @@ export const businessEventServerFrameSchema = {
 
 export const businessEventPayloadSchemas = {
   "agent.activity.updated": agentActivityUpdatedPayloadSchema,
-  "agent.gui.launch.requested": agentGuiLaunchRequestedPayloadSchema,
   "analytics.debug.reported": analyticsDebugReportedPayloadSchema,
   "preferences.desktop.update.requested":
     preferencesDesktopUpdateRequestedPayloadSchema,
@@ -2088,5 +2088,7 @@ export const businessEventPayloadSchemas = {
   "workspace.app.updated": workspaceAppUpdatedPayloadSchema,
   "workspace.appfactory.job.updated":
     workspaceAppfactoryJobUpdatedPayloadSchema,
-  "workspace.issue.updated": workspaceIssueUpdatedPayloadSchema
+  "workspace.issue.updated": workspaceIssueUpdatedPayloadSchema,
+  "workspace.workbench.node.launch.requested":
+    workspaceWorkbenchNodeLaunchRequestedPayloadSchema
 } as const;

--- a/packages/workspace/external-core/src/contracts/index.ts
+++ b/packages/workspace/external-core/src/contracts/index.ts
@@ -175,6 +175,16 @@ export interface TuttiExternalWorkspaceOpenFeatureInput {
   provider?: TuttiExternalWorkspaceAgentProvider;
 }
 
+export interface TuttiExternalWorkspaceOpenRouteIntent {
+  kind: "open-route";
+  params?: Record<string, string>;
+  /**
+   * Origin-root path for the app launch origin. It must start with "/".
+   */
+  route: string;
+  state?: Record<string, unknown>;
+}
+
 export interface TuttiExternalReferenceOpenInput {
   href: string;
 }
@@ -264,6 +274,9 @@ export interface TuttiExternalBridge {
     open(input?: TuttiExternalSettingsOpenInput): Promise<void>;
   };
   workspace: {
+    onLaunchIntent(
+      listener: (intent: TuttiExternalWorkspaceOpenRouteIntent) => void
+    ): () => void;
     openFeature(input: TuttiExternalWorkspaceOpenFeatureInput): Promise<void>;
   };
   references: {

--- a/services/tuttid/api/events/generated/protocol.gen.go
+++ b/services/tuttid/api/events/generated/protocol.gen.go
@@ -6,20 +6,20 @@ import "encoding/json"
 
 const (
 	BusinessEventProtocolVersion = 1
-	BusinessEventCatalogRevision = "sha256:1f4baa742a2dbf19"
+	BusinessEventCatalogRevision = "sha256:7de58350911c2aa6"
 )
 
 type Topic string
 
 const (
-	TopicAgentActivityUpdated              Topic = "agent.activity.updated"
-	TopicAgentGuiLaunchRequested           Topic = "agent.gui.launch.requested"
-	TopicAnalyticsDebugReported            Topic = "analytics.debug.reported"
-	TopicPreferencesDesktopUpdateRequested Topic = "preferences.desktop.update.requested"
-	TopicPreferencesDesktopUpdated         Topic = "preferences.desktop.updated"
-	TopicWorkspaceAppUpdated               Topic = "workspace.app.updated"
-	TopicWorkspaceAppfactoryJobUpdated     Topic = "workspace.appfactory.job.updated"
-	TopicWorkspaceIssueUpdated             Topic = "workspace.issue.updated"
+	TopicAgentActivityUpdated                  Topic = "agent.activity.updated"
+	TopicAnalyticsDebugReported                Topic = "analytics.debug.reported"
+	TopicPreferencesDesktopUpdateRequested     Topic = "preferences.desktop.update.requested"
+	TopicPreferencesDesktopUpdated             Topic = "preferences.desktop.updated"
+	TopicWorkspaceAppUpdated                   Topic = "workspace.app.updated"
+	TopicWorkspaceAppfactoryJobUpdated         Topic = "workspace.appfactory.job.updated"
+	TopicWorkspaceIssueUpdated                 Topic = "workspace.issue.updated"
+	TopicWorkspaceWorkbenchNodeLaunchRequested Topic = "workspace.workbench.node.launch.requested"
 )
 
 type Direction string
@@ -184,15 +184,6 @@ type AgentActivityUpdatedPayload struct {
 	Data           any    `json:"data"`
 }
 
-type AgentGuiLaunchRequestedPayload struct {
-	WorkspaceId    string  `json:"workspaceId"`
-	AgentSessionId string  `json:"agentSessionId"`
-	Provider       string  `json:"provider"`
-	Source         string  `json:"source"`
-	Reason         *string `json:"reason,omitempty"`
-	RequestId      *string `json:"requestId,omitempty"`
-}
-
 type AnalyticsDebugReportedPayload struct {
 	Events []struct {
 		Name     string         `json:"name"`
@@ -226,6 +217,16 @@ type WorkspaceIssueUpdatedPayload struct {
 	ChangeKind  string  `json:"changeKind"`
 }
 
+type WorkspaceWorkbenchNodeLaunchRequestedPayload struct {
+	WorkspaceId  string  `json:"workspaceId"`
+	TypeId       string  `json:"typeId"`
+	Source       string  `json:"source"`
+	LaunchSource *string `json:"launchSource,omitempty"`
+	DockEntryId  *string `json:"dockEntryId,omitempty"`
+	RequestId    *string `json:"requestId,omitempty"`
+	Payload      any     `json:"payload,omitempty"`
+}
+
 type AgentActivityUpdatedEvent struct {
 	ID        string                      `json:"id"`
 	Topic     Topic                       `json:"topic"`
@@ -233,15 +234,6 @@ type AgentActivityUpdatedEvent struct {
 	EmittedAt string                      `json:"emittedAt"`
 	Scope     *EventScope                 `json:"scope,omitempty"`
 	Payload   AgentActivityUpdatedPayload `json:"payload"`
-}
-
-type AgentGuiLaunchRequestedEvent struct {
-	ID        string                         `json:"id"`
-	Topic     Topic                          `json:"topic"`
-	Version   int                            `json:"version"`
-	EmittedAt string                         `json:"emittedAt"`
-	Scope     *EventScope                    `json:"scope,omitempty"`
-	Payload   AgentGuiLaunchRequestedPayload `json:"payload"`
 }
 
 type AnalyticsDebugReportedEvent struct {
@@ -296,6 +288,15 @@ type WorkspaceIssueUpdatedEvent struct {
 	EmittedAt string                       `json:"emittedAt"`
 	Scope     *EventScope                  `json:"scope,omitempty"`
 	Payload   WorkspaceIssueUpdatedPayload `json:"payload"`
+}
+
+type WorkspaceWorkbenchNodeLaunchRequestedEvent struct {
+	ID        string                                       `json:"id"`
+	Topic     Topic                                        `json:"topic"`
+	Version   int                                          `json:"version"`
+	EmittedAt string                                       `json:"emittedAt"`
+	Scope     *EventScope                                  `json:"scope,omitempty"`
+	Payload   WorkspaceWorkbenchNodeLaunchRequestedPayload `json:"payload"`
 }
 
 type ClientSubscribeFrame struct {
@@ -365,13 +366,6 @@ var BusinessEventDefinitions = []EventDefinition{
 		Scope:     ScopeNameWorkspace,
 	},
 	{
-		Topic:     TopicAgentGuiLaunchRequested,
-		Version:   1,
-		Direction: DirectionServerToClient,
-		Owner:     "agent",
-		Scope:     ScopeNameWorkspace,
-	},
-	{
 		Topic:     TopicAnalyticsDebugReported,
 		Version:   1,
 		Direction: DirectionServerToClient,
@@ -413,17 +407,24 @@ var BusinessEventDefinitions = []EventDefinition{
 		Owner:     "workspace",
 		Scope:     ScopeNameWorkspace,
 	},
+	{
+		Topic:     TopicWorkspaceWorkbenchNodeLaunchRequested,
+		Version:   1,
+		Direction: DirectionServerToClient,
+		Owner:     "core",
+		Scope:     ScopeNameWorkspace,
+	},
 }
 
 var businessEventDefinitionByTopic = map[Topic]EventDefinition{
-	TopicAgentActivityUpdated:              BusinessEventDefinitions[0],
-	TopicAgentGuiLaunchRequested:           BusinessEventDefinitions[1],
-	TopicAnalyticsDebugReported:            BusinessEventDefinitions[2],
-	TopicPreferencesDesktopUpdateRequested: BusinessEventDefinitions[3],
-	TopicPreferencesDesktopUpdated:         BusinessEventDefinitions[4],
-	TopicWorkspaceAppUpdated:               BusinessEventDefinitions[5],
-	TopicWorkspaceAppfactoryJobUpdated:     BusinessEventDefinitions[6],
-	TopicWorkspaceIssueUpdated:             BusinessEventDefinitions[7],
+	TopicAgentActivityUpdated:                  BusinessEventDefinitions[0],
+	TopicAnalyticsDebugReported:                BusinessEventDefinitions[1],
+	TopicPreferencesDesktopUpdateRequested:     BusinessEventDefinitions[2],
+	TopicPreferencesDesktopUpdated:             BusinessEventDefinitions[3],
+	TopicWorkspaceAppUpdated:                   BusinessEventDefinitions[4],
+	TopicWorkspaceAppfactoryJobUpdated:         BusinessEventDefinitions[5],
+	TopicWorkspaceIssueUpdated:                 BusinessEventDefinitions[6],
+	TopicWorkspaceWorkbenchNodeLaunchRequested: BusinessEventDefinitions[7],
 }
 
 var ClientToServerTopics = []Topic{
@@ -432,12 +433,12 @@ var ClientToServerTopics = []Topic{
 
 var ServerToClientTopics = []Topic{
 	TopicAgentActivityUpdated,
-	TopicAgentGuiLaunchRequested,
 	TopicAnalyticsDebugReported,
 	TopicPreferencesDesktopUpdated,
 	TopicWorkspaceAppUpdated,
 	TopicWorkspaceAppfactoryJobUpdated,
 	TopicWorkspaceIssueUpdated,
+	TopicWorkspaceWorkbenchNodeLaunchRequested,
 }
 
 func LookupEventDefinition(topic Topic) (EventDefinition, bool) {
@@ -463,8 +464,6 @@ func IsServerToClientTopic(topic Topic) bool {
 	switch topic {
 	case TopicAgentActivityUpdated:
 		return true
-	case TopicAgentGuiLaunchRequested:
-		return true
 	case TopicAnalyticsDebugReported:
 		return true
 	case TopicPreferencesDesktopUpdated:
@@ -475,6 +474,8 @@ func IsServerToClientTopic(topic Topic) bool {
 		return true
 	case TopicWorkspaceIssueUpdated:
 		return true
+	case TopicWorkspaceWorkbenchNodeLaunchRequested:
+		return true
 	default:
 		return false
 	}
@@ -484,8 +485,6 @@ func PayloadPrototypeForTopic(topic Topic) (any, bool) {
 	switch topic {
 	case TopicAgentActivityUpdated:
 		return &AgentActivityUpdatedPayload{}, true
-	case TopicAgentGuiLaunchRequested:
-		return &AgentGuiLaunchRequestedPayload{}, true
 	case TopicAnalyticsDebugReported:
 		return &AnalyticsDebugReportedPayload{}, true
 	case TopicPreferencesDesktopUpdateRequested:
@@ -498,6 +497,8 @@ func PayloadPrototypeForTopic(topic Topic) (any, bool) {
 		return &WorkspaceAppfactoryJobUpdatedPayload{}, true
 	case TopicWorkspaceIssueUpdated:
 		return &WorkspaceIssueUpdatedPayload{}, true
+	case TopicWorkspaceWorkbenchNodeLaunchRequested:
+		return &WorkspaceWorkbenchNodeLaunchRequestedPayload{}, true
 	default:
 		return nil, false
 	}
@@ -507,8 +508,6 @@ func EventPrototypeForTopic(topic Topic) (any, bool) {
 	switch topic {
 	case TopicAgentActivityUpdated:
 		return &AgentActivityUpdatedEvent{}, true
-	case TopicAgentGuiLaunchRequested:
-		return &AgentGuiLaunchRequestedEvent{}, true
 	case TopicAnalyticsDebugReported:
 		return &AnalyticsDebugReportedEvent{}, true
 	case TopicPreferencesDesktopUpdateRequested:
@@ -521,6 +520,8 @@ func EventPrototypeForTopic(topic Topic) (any, bool) {
 		return &WorkspaceAppfactoryJobUpdatedEvent{}, true
 	case TopicWorkspaceIssueUpdated:
 		return &WorkspaceIssueUpdatedEvent{}, true
+	case TopicWorkspaceWorkbenchNodeLaunchRequested:
+		return &WorkspaceWorkbenchNodeLaunchRequestedEvent{}, true
 	default:
 		return nil, false
 	}

--- a/services/tuttid/biz/workbench/launch.go
+++ b/services/tuttid/biz/workbench/launch.go
@@ -1,0 +1,32 @@
+package workbench
+
+import (
+	"encoding/json"
+	"strings"
+)
+
+type NodeLaunchRequest struct {
+	WorkspaceID  string
+	TypeID       string
+	Source       string
+	LaunchSource string
+	DockEntryID  string
+	RequestID    string
+	Payload      json.RawMessage
+}
+
+func NormalizeNodeLaunchRequest(input NodeLaunchRequest) NodeLaunchRequest {
+	source := strings.TrimSpace(input.Source)
+	if source == "" {
+		source = "cli"
+	}
+	return NodeLaunchRequest{
+		WorkspaceID:  strings.TrimSpace(input.WorkspaceID),
+		TypeID:       strings.TrimSpace(input.TypeID),
+		Source:       source,
+		LaunchSource: strings.TrimSpace(input.LaunchSource),
+		DockEntryID:  strings.TrimSpace(input.DockEntryID),
+		RequestID:    strings.TrimSpace(input.RequestID),
+		Payload:      input.Payload,
+	}
+}

--- a/services/tuttid/service/cli/providers/workbenchapps/provider.go
+++ b/services/tuttid/service/cli/providers/workbenchapps/provider.go
@@ -1,0 +1,283 @@
+package workbenchapps
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	workbenchbiz "github.com/tutti-os/tutti/services/tuttid/biz/workbench"
+	workspacebiz "github.com/tutti-os/tutti/services/tuttid/biz/workspace"
+	cliservice "github.com/tutti-os/tutti/services/tuttid/service/cli"
+)
+
+const (
+	appID              = "workspace-apps"
+	workspaceAppTypeID = "workspace-app-webview"
+	maxStateJSONBytes  = 16 * 1024
+)
+
+type AppLauncher interface {
+	Launch(context.Context, string, string) (workspacebiz.WorkspaceApp, error)
+}
+
+type WorkbenchNodeLaunchPublisher interface {
+	PublishWorkbenchNodeLaunchRequested(context.Context, workbenchbiz.NodeLaunchRequest) error
+}
+
+type Provider struct {
+	workspaces      cliservice.WorkspaceCatalog
+	apps            AppLauncher
+	launchPublisher WorkbenchNodeLaunchPublisher
+}
+
+func NewProvider(
+	workspaces cliservice.WorkspaceCatalog,
+	apps AppLauncher,
+	launchPublisher WorkbenchNodeLaunchPublisher,
+) Provider {
+	return Provider{workspaces: workspaces, apps: apps, launchPublisher: launchPublisher}
+}
+
+func (Provider) AppID() string {
+	return appID
+}
+
+func (p Provider) Commands() []cliservice.Command {
+	return []cliservice.Command{p.newOpenCommand()}
+}
+
+func (p Provider) newOpenCommand() cliservice.Command {
+	return cliservice.Command{
+		Capability: cliservice.Capability{
+			ID:          appID + ".app.open",
+			Path:        []string{"app", "open"},
+			Summary:     "Open a workspace app",
+			Description: "Launch or activate an installed workspace app. Use --route to pass an origin-root route intent.",
+			InputSchema: map[string]any{
+				"type": "object",
+				"required": []string{
+					"app-id",
+				},
+				"properties": map[string]any{
+					"app-id": map[string]any{
+						"type":        "string",
+						"description": "Workspace app id.",
+					},
+					"route": map[string]any{
+						"type":        "string",
+						"description": "Origin-root route path. Must start with /.",
+					},
+					"param": map[string]any{
+						"oneOf": []map[string]any{
+							{"type": "string"},
+							{
+								"type":  "array",
+								"items": map[string]any{"type": "string"},
+							},
+						},
+						"description": "Route parameter in key=value form. May be passed multiple times.",
+					},
+					"state-json": map[string]any{
+						"type":        "string",
+						"description": "Optional JSON object passed as route state. Maximum 16KiB.",
+					},
+				},
+			},
+			Output: cliservice.CapabilityOutput{
+				DefaultMode: cliservice.OutputModeTable,
+				JSON:        true,
+				Table: &cliservice.TableOutput{
+					Columns: []cliservice.TableColumn{
+						{Key: "appId", Label: "App ID"},
+						{Key: "status", Label: "Status"},
+						{Key: "launchRequested", Label: "Launch Requested"},
+					},
+				},
+			},
+		},
+		Handler: p.runOpen,
+	}
+}
+
+func (p Provider) runOpen(ctx context.Context, request cliservice.InvokeRequest) (cliservice.CommandOutput, error) {
+	if p.apps == nil {
+		return cliservice.CommandOutput{}, cliservice.ServiceUnavailableError("workspace_apps_unavailable", fmt.Errorf("workspace apps service is unavailable"))
+	}
+	workspaceID, err := cliservice.ResolveWorkspaceID(ctx, p.workspaces, request.Context.WorkspaceID)
+	if err != nil {
+		return cliservice.CommandOutput{}, err
+	}
+	appID, err := cliservice.RequiredStringInput(request.Input, "app-id")
+	if err != nil {
+		return cliservice.CommandOutput{}, err
+	}
+	route, _, err := cliservice.StringInput(request.Input, "route")
+	if err != nil {
+		return cliservice.CommandOutput{}, err
+	}
+	intent, err := appOpenRouteIntent(request.Input, route)
+	if err != nil {
+		return cliservice.CommandOutput{}, err
+	}
+	app, err := p.apps.Launch(ctx, workspaceID, appID)
+	if err != nil {
+		return cliservice.CommandOutput{}, err
+	}
+	payload, err := json.Marshal(workspaceAppWorkbenchLaunchPayload{
+		AppID:  app.Package.AppID,
+		Intent: intent,
+	})
+	if err != nil {
+		return cliservice.CommandOutput{}, fmt.Errorf("marshal workspace app launch payload: %w", err)
+	}
+	launchRequested := false
+	if p.launchPublisher != nil {
+		if err := p.launchPublisher.PublishWorkbenchNodeLaunchRequested(ctx, workbenchbiz.NodeLaunchRequest{
+			WorkspaceID:  workspaceID,
+			TypeID:       workspaceAppTypeID,
+			Source:       request.Context.Source,
+			LaunchSource: firstNonEmptyString(request.Context.Source, "cli"),
+			Payload:      payload,
+		}); err != nil {
+			return cliservice.CommandOutput{}, err
+		}
+		launchRequested = true
+	}
+	row := map[string]any{
+		"appId":           app.Package.AppID,
+		"status":          string(app.Runtime.Status),
+		"launchRequested": launchRequested,
+	}
+	return cliservice.CommandOutput{
+		Kind: cliservice.OutputModeTable,
+		Columns: []cliservice.TableColumn{
+			{Key: "appId", Label: "App ID"},
+			{Key: "status", Label: "Status"},
+			{Key: "launchRequested", Label: "Launch Requested"},
+		},
+		Rows: []map[string]any{row},
+		Value: map[string]any{
+			"app": map[string]any{
+				"appId":  app.Package.AppID,
+				"status": string(app.Runtime.Status),
+			},
+			"launchRequested": launchRequested,
+		},
+	}, nil
+}
+
+type workspaceAppWorkbenchLaunchPayload struct {
+	AppID  string              `json:"appId"`
+	Intent *workspaceAppIntent `json:"intent,omitempty"`
+}
+
+type workspaceAppIntent struct {
+	Kind   string            `json:"kind"`
+	Route  string            `json:"route"`
+	Params map[string]string `json:"params,omitempty"`
+	State  json.RawMessage   `json:"state,omitempty"`
+}
+
+func appOpenRouteIntent(input map[string]any, route string) (*workspaceAppIntent, error) {
+	if route == "" {
+		if len(inputStringValues(input["param"])) > 0 {
+			return nil, cliservice.InvalidInputKeyError("param")
+		}
+		if len(inputStringValues(input["state-json"])) > 0 {
+			return nil, cliservice.InvalidInputKeyError("state-json")
+		}
+		return nil, nil
+	}
+	if !strings.HasPrefix(route, "/") || strings.HasPrefix(route, "//") || strings.Contains(route, "://") {
+		return nil, cliservice.InvalidInputKeyError("route")
+	}
+	params, err := parseRouteParams(input["param"])
+	if err != nil {
+		return nil, err
+	}
+	state, err := parseStateJSON(input["state-json"])
+	if err != nil {
+		return nil, err
+	}
+	return &workspaceAppIntent{
+		Kind:   "open-route",
+		Route:  route,
+		Params: params,
+		State:  state,
+	}, nil
+}
+
+func parseRouteParams(raw any) (map[string]string, error) {
+	values := inputStringValues(raw)
+	if len(values) == 0 {
+		return nil, nil
+	}
+	params := map[string]string{}
+	for _, value := range values {
+		key, val, ok := strings.Cut(value, "=")
+		key = strings.TrimSpace(key)
+		if !ok || key == "" {
+			return nil, cliservice.InvalidInputKeyError("param")
+		}
+		params[key] = strings.TrimSpace(val)
+	}
+	return params, nil
+}
+
+func parseStateJSON(raw any) (json.RawMessage, error) {
+	values := inputStringValues(raw)
+	if len(values) == 0 || strings.TrimSpace(values[0]) == "" {
+		return nil, nil
+	}
+	if len(values) > 1 {
+		return nil, cliservice.InvalidInputKeyError("state-json")
+	}
+	rawJSON := strings.TrimSpace(values[0])
+	if len(rawJSON) > maxStateJSONBytes {
+		return nil, cliservice.InvalidInputKeyError("state-json")
+	}
+	var decoded map[string]any
+	if err := json.Unmarshal([]byte(rawJSON), &decoded); err != nil {
+		return nil, cliservice.InvalidInputKeyError("state-json")
+	}
+	encoded, err := json.Marshal(decoded)
+	if err != nil {
+		return nil, fmt.Errorf("marshal state json: %w", err)
+	}
+	return encoded, nil
+}
+
+func inputStringValues(raw any) []string {
+	switch value := raw.(type) {
+	case nil:
+		return nil
+	case string:
+		return []string{strings.TrimSpace(value)}
+	case []string:
+		result := make([]string, 0, len(value))
+		for _, item := range value {
+			result = append(result, strings.TrimSpace(item))
+		}
+		return result
+	case []any:
+		result := make([]string, 0, len(value))
+		for _, item := range value {
+			if text, ok := item.(string); ok {
+				result = append(result, strings.TrimSpace(text))
+			}
+		}
+		return result
+	default:
+		return nil
+	}
+}
+
+func firstNonEmptyString(values ...string) string {
+	for _, value := range values {
+		if trimmed := strings.TrimSpace(value); trimmed != "" {
+			return trimmed
+		}
+	}
+	return ""
+}

--- a/services/tuttid/service/cli/providers/workbenchapps/provider_test.go
+++ b/services/tuttid/service/cli/providers/workbenchapps/provider_test.go
@@ -1,0 +1,177 @@
+package workbenchapps
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"strings"
+	"testing"
+
+	workbenchbiz "github.com/tutti-os/tutti/services/tuttid/biz/workbench"
+	workspacebiz "github.com/tutti-os/tutti/services/tuttid/biz/workspace"
+	cliservice "github.com/tutti-os/tutti/services/tuttid/service/cli"
+)
+
+func TestOpenPublishesWorkspaceAppWorkbenchLaunch(t *testing.T) {
+	workspaces := fakeWorkspaceCatalog{startupID: "ws-1"}
+	apps := &fakeAppLauncher{
+		app: workspacebiz.WorkspaceApp{
+			Package: workspacebiz.AppPackage{AppID: "docs"},
+			Runtime: workspacebiz.AppRuntimeState{
+				Status: workspacebiz.AppRuntimeStatusRunning,
+			},
+		},
+	}
+	publisher := &fakeWorkbenchLaunchPublisher{}
+	provider := NewProvider(workspaces, apps, publisher)
+
+	output, err := provider.newOpenCommand().Handler(t.Context(), cliservice.InvokeRequest{
+		Context: cliservice.InvokeContext{Source: "cli"},
+		Input: map[string]any{
+			"app-id":     "docs",
+			"param":      []any{"path=/tmp/a", "mode=preview"},
+			"route":      "/files",
+			"state-json": `{"selected":true}`,
+		},
+	})
+	if err != nil {
+		t.Fatalf("run open: %v", err)
+	}
+
+	if output.Rows[0]["appId"] != "docs" || output.Rows[0]["launchRequested"] != true {
+		t.Fatalf("output = %#v", output)
+	}
+	if apps.workspaceID != "ws-1" || apps.appID != "docs" {
+		t.Fatalf("launch input = %q %q", apps.workspaceID, apps.appID)
+	}
+	if len(publisher.requests) != 1 {
+		t.Fatalf("published requests = %#v", publisher.requests)
+	}
+	request := publisher.requests[0]
+	if request.WorkspaceID != "ws-1" || request.TypeID != workspaceAppTypeID || request.Source != "cli" {
+		t.Fatalf("request = %#v", request)
+	}
+	var payload struct {
+		AppID  string `json:"appId"`
+		Intent struct {
+			Kind   string            `json:"kind"`
+			Params map[string]string `json:"params"`
+			Route  string            `json:"route"`
+			State  map[string]bool   `json:"state"`
+		} `json:"intent"`
+	}
+	if err := json.Unmarshal(request.Payload, &payload); err != nil {
+		t.Fatalf("unmarshal payload: %v", err)
+	}
+	if payload.AppID != "docs" ||
+		payload.Intent.Kind != "open-route" ||
+		payload.Intent.Route != "/files" ||
+		payload.Intent.Params["path"] != "/tmp/a" ||
+		payload.Intent.Params["mode"] != "preview" ||
+		!payload.Intent.State["selected"] {
+		t.Fatalf("payload = %#v", payload)
+	}
+}
+
+func TestOpenCommandAdvertisesRepeatableParamSchema(t *testing.T) {
+	command := NewProvider(fakeWorkspaceCatalog{}, &fakeAppLauncher{}, nil).newOpenCommand()
+	properties := command.Capability.InputSchema["properties"].(map[string]any)
+	param := properties["param"].(map[string]any)
+	oneOf := param["oneOf"].([]map[string]any)
+	if len(oneOf) != 2 || oneOf[0]["type"] != "string" || oneOf[1]["type"] != "array" {
+		t.Fatalf("param schema = %#v", param)
+	}
+	items := oneOf[1]["items"].(map[string]any)
+	if items["type"] != "string" {
+		t.Fatalf("param array items schema = %#v", items)
+	}
+	route := properties["route"].(map[string]any)
+	if !strings.Contains(route["description"].(string), "Origin-root") {
+		t.Fatalf("route schema = %#v", route)
+	}
+}
+
+func TestOpenPublishesAppWithoutRouteIntent(t *testing.T) {
+	provider := NewProvider(
+		fakeWorkspaceCatalog{startupID: "ws-1"},
+		&fakeAppLauncher{
+			app: workspacebiz.WorkspaceApp{
+				Package: workspacebiz.AppPackage{AppID: "docs"},
+				Runtime: workspacebiz.AppRuntimeState{
+					Status: workspacebiz.AppRuntimeStatusRunning,
+				},
+			},
+		},
+		&fakeWorkbenchLaunchPublisher{},
+	)
+
+	output, err := provider.newOpenCommand().Handler(t.Context(), cliservice.InvokeRequest{
+		Context: cliservice.InvokeContext{WorkspaceID: "ws-1"},
+		Input:   map[string]any{"app-id": "docs"},
+	})
+	if err != nil {
+		t.Fatalf("run open: %v", err)
+	}
+	if output.Rows[0]["launchRequested"] != true {
+		t.Fatalf("output = %#v", output)
+	}
+}
+
+func TestOpenRejectsInvalidRouteInputs(t *testing.T) {
+	provider := NewProvider(
+		fakeWorkspaceCatalog{startupID: "ws-1"},
+		&fakeAppLauncher{},
+		&fakeWorkbenchLaunchPublisher{},
+	)
+	tests := []map[string]any{
+		{"app-id": "docs", "route": "https://example.com/path"},
+		{"app-id": "docs", "route": "//example.com/path"},
+		{"app-id": "docs", "route": "files"},
+		{"app-id": "docs", "route": "/files", "state-json": "[]"},
+		{"app-id": "docs", "param": "path=/tmp/a"},
+	}
+	for _, input := range tests {
+		_, err := provider.newOpenCommand().Handler(t.Context(), cliservice.InvokeRequest{
+			Input: input,
+		})
+		if !errors.Is(err, cliservice.ErrInvalidInput) {
+			t.Fatalf("input = %#v err = %v, want ErrInvalidInput", input, err)
+		}
+	}
+}
+
+type fakeWorkspaceCatalog struct {
+	startupID string
+}
+
+func (f fakeWorkspaceCatalog) Startup(context.Context) (*workspacebiz.Summary, error) {
+	return &workspacebiz.Summary{ID: f.startupID}, nil
+}
+
+func (fakeWorkspaceCatalog) Get(_ context.Context, id string) (workspacebiz.Summary, error) {
+	return workspacebiz.Summary{ID: strings.TrimSpace(id)}, nil
+}
+
+type fakeAppLauncher struct {
+	app         workspacebiz.WorkspaceApp
+	appID       string
+	workspaceID string
+}
+
+func (f *fakeAppLauncher) Launch(_ context.Context, workspaceID string, appID string) (workspacebiz.WorkspaceApp, error) {
+	f.workspaceID = workspaceID
+	f.appID = appID
+	if f.app.Package.AppID == "" {
+		f.app.Package.AppID = appID
+	}
+	return f.app, nil
+}
+
+type fakeWorkbenchLaunchPublisher struct {
+	requests []workbenchbiz.NodeLaunchRequest
+}
+
+func (f *fakeWorkbenchLaunchPublisher) PublishWorkbenchNodeLaunchRequested(_ context.Context, request workbenchbiz.NodeLaunchRequest) error {
+	f.requests = append(f.requests, request)
+	return nil
+}

--- a/services/tuttid/service/eventstream/agent_gui.go
+++ b/services/tuttid/service/eventstream/agent_gui.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"github.com/tutti-os/tutti/services/tuttid/biz/agentgui"
+	workbenchbiz "github.com/tutti-os/tutti/services/tuttid/biz/workbench"
 )
 
 type AgentGUILaunchPublisher struct {
@@ -24,24 +25,26 @@ func (p AgentGUILaunchPublisher) PublishAgentGUILaunchRequested(
 	if request.WorkspaceID == "" || request.AgentSessionID == "" || request.Provider == "" {
 		return fmt.Errorf("agent gui launch request requires workspaceId, agentSessionId, and provider")
 	}
-	payload := agentGUILaunchRequestedPayload{
-		WorkspaceID:    request.WorkspaceID,
+	payload, err := json.Marshal(agentGUIWorkbenchLaunchPayload{
 		AgentSessionID: request.AgentSessionID,
 		Provider:       request.Provider,
-		Source:         firstNonEmptyString(request.Source, "cli"),
-		Reason:         strings.TrimSpace(request.Reason),
-		RequestID:      strings.TrimSpace(request.RequestID),
-	}
-	encoded, err := json.Marshal(payload)
+	})
 	if err != nil {
-		return fmt.Errorf("marshal agent gui launch requested payload: %w", err)
+		return fmt.Errorf("marshal agent gui workbench launch payload: %w", err)
 	}
-	return p.Service.PublishFromServerScoped(
-		ctx,
-		TopicAgentGUILaunchRequested,
-		encoded,
-		EventScope{WorkspaceID: request.WorkspaceID},
-	)
+	return WorkbenchNodeLaunchPublisher(p).PublishWorkbenchNodeLaunchRequested(ctx, workbenchbiz.NodeLaunchRequest{
+		WorkspaceID:  request.WorkspaceID,
+		TypeID:       "agent-gui",
+		Source:       firstNonEmptyString(request.Source, "cli"),
+		LaunchSource: firstNonEmptyString(request.Source, "cli"),
+		RequestID:    strings.TrimSpace(request.RequestID),
+		Payload:      payload,
+	})
+}
+
+type agentGUIWorkbenchLaunchPayload struct {
+	AgentSessionID string `json:"agentSessionId"`
+	Provider       string `json:"provider"`
 }
 
 func firstNonEmptyString(values ...string) string {

--- a/services/tuttid/service/eventstream/agent_gui_test.go
+++ b/services/tuttid/service/eventstream/agent_gui_test.go
@@ -1,0 +1,69 @@
+package eventstream
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/tutti-os/tutti/services/tuttid/biz/agentgui"
+)
+
+func TestAgentGUILaunchPublisherPublishesWorkbenchNodeLaunch(t *testing.T) {
+	t.Parallel()
+
+	service := NewService(DefaultCatalog(), nil)
+	session := service.OpenSession()
+	t.Cleanup(func() {
+		service.CloseSession(session)
+	})
+	if err := service.Subscribe(session, []string{TopicWorkspaceWorkbenchNodeLaunchRequested}, EventScope{
+		WorkspaceID: "workspace-1",
+	}); err != nil {
+		t.Fatalf("Subscribe() error = %v", err)
+	}
+
+	publisher := AgentGUILaunchPublisher{Service: service}
+	if err := publisher.PublishAgentGUILaunchRequested(context.Background(), agentgui.LaunchRequest{
+		AgentSessionID: "session-1",
+		Provider:       "codex",
+		RequestID:      "request-1",
+		Source:         "cli",
+		WorkspaceID:    "workspace-1",
+	}); err != nil {
+		t.Fatalf("PublishAgentGUILaunchRequested() error = %v", err)
+	}
+
+	event := receiveEvent(t, session)
+	if event.Topic != TopicWorkspaceWorkbenchNodeLaunchRequested {
+		t.Fatalf("event topic = %q, want %q", event.Topic, TopicWorkspaceWorkbenchNodeLaunchRequested)
+	}
+	if event.Scope.WorkspaceID != "workspace-1" {
+		t.Fatalf("event scope workspace = %q, want workspace-1", event.Scope.WorkspaceID)
+	}
+
+	var payload struct {
+		LaunchSource string `json:"launchSource"`
+		Payload      struct {
+			AgentSessionID string `json:"agentSessionId"`
+			Provider       string `json:"provider"`
+		} `json:"payload"`
+		RequestID string `json:"requestId"`
+		Source    string `json:"source"`
+		TypeID    string `json:"typeId"`
+	}
+	if err := json.Unmarshal(event.Payload, &payload); err != nil {
+		t.Fatalf("json.Unmarshal(event.Payload) error = %v", err)
+	}
+	if payload.TypeID != "agent-gui" {
+		t.Fatalf("payload typeId = %q, want agent-gui", payload.TypeID)
+	}
+	if payload.Source != "cli" || payload.LaunchSource != "cli" {
+		t.Fatalf("payload source = (%q, %q), want cli", payload.Source, payload.LaunchSource)
+	}
+	if payload.RequestID != "request-1" {
+		t.Fatalf("payload requestId = %q, want request-1", payload.RequestID)
+	}
+	if payload.Payload.AgentSessionID != "session-1" || payload.Payload.Provider != "codex" {
+		t.Fatalf("payload nested launch = %#v, want session/provider", payload.Payload)
+	}
+}

--- a/services/tuttid/service/eventstream/catalog.go
+++ b/services/tuttid/service/eventstream/catalog.go
@@ -14,14 +14,14 @@ import (
 )
 
 const (
-	TopicAnalyticsDebugReported            = "analytics.debug.reported"
-	TopicAgentActivityUpdated              = "agent.activity.updated"
-	TopicAgentGUILaunchRequested           = "agent.gui.launch.requested"
-	TopicPreferencesDesktopUpdateRequested = "preferences.desktop.update.requested"
-	TopicPreferencesDesktopUpdated         = "preferences.desktop.updated"
-	TopicWorkspaceIssueUpdated             = "workspace.issue.updated"
-	TopicWorkspaceAppFactoryJobUpdated     = "workspace.appfactory.job.updated"
-	TopicWorkspaceAppUpdated               = "workspace.app.updated"
+	TopicAnalyticsDebugReported                = "analytics.debug.reported"
+	TopicAgentActivityUpdated                  = "agent.activity.updated"
+	TopicPreferencesDesktopUpdateRequested     = "preferences.desktop.update.requested"
+	TopicPreferencesDesktopUpdated             = "preferences.desktop.updated"
+	TopicWorkspaceIssueUpdated                 = "workspace.issue.updated"
+	TopicWorkspaceAppFactoryJobUpdated         = "workspace.appfactory.job.updated"
+	TopicWorkspaceAppUpdated                   = "workspace.app.updated"
+	TopicWorkspaceWorkbenchNodeLaunchRequested = "workspace.workbench.node.launch.requested"
 )
 
 type Direction string
@@ -116,16 +116,6 @@ func DefaultCatalog() StaticCatalog {
 			},
 		},
 		{
-			Name:               TopicAgentGUILaunchRequested,
-			ClientCanPublish:   false,
-			ClientCanSubscribe: true,
-			Version:            1,
-			directions:         []Direction{DirectionServerToClient},
-			validators: map[Direction]PayloadValidator{
-				DirectionServerToClient: validateAgentGUILaunchRequestedPayload,
-			},
-		},
-		{
 			Name:               TopicPreferencesDesktopUpdateRequested,
 			ClientCanPublish:   true,
 			ClientCanSubscribe: false,
@@ -173,6 +163,16 @@ func DefaultCatalog() StaticCatalog {
 			directions:         []Direction{DirectionServerToClient},
 			validators: map[Direction]PayloadValidator{
 				DirectionServerToClient: validateWorkspaceAppFactoryJobUpdatedPayload,
+			},
+		},
+		{
+			Name:               TopicWorkspaceWorkbenchNodeLaunchRequested,
+			ClientCanPublish:   false,
+			ClientCanSubscribe: true,
+			Version:            1,
+			directions:         []Direction{DirectionServerToClient},
+			validators: map[Direction]PayloadValidator{
+				DirectionServerToClient: validateWorkspaceWorkbenchNodeLaunchRequestedPayload,
 			},
 		},
 	})
@@ -339,13 +339,14 @@ type agentActivityStateTurnData struct {
 	CompletedAtUnixMS *int64 `json:"completedAtUnixMs,omitempty"`
 }
 
-type agentGUILaunchRequestedPayload struct {
-	WorkspaceID    string `json:"workspaceId"`
-	AgentSessionID string `json:"agentSessionId"`
-	Provider       string `json:"provider"`
-	Source         string `json:"source"`
-	Reason         string `json:"reason,omitempty"`
-	RequestID      string `json:"requestId,omitempty"`
+type workbenchNodeLaunchRequestedPayload struct {
+	WorkspaceID  string          `json:"workspaceId"`
+	TypeID       string          `json:"typeId"`
+	Source       string          `json:"source"`
+	LaunchSource string          `json:"launchSource,omitempty"`
+	DockEntryID  string          `json:"dockEntryId,omitempty"`
+	RequestID    string          `json:"requestId,omitempty"`
+	Payload      json.RawMessage `json:"payload,omitempty"`
 }
 
 type workspaceIssueUpdatedPayload struct {
@@ -658,25 +659,25 @@ func validateAgentActivityUpdatedData(decoded agentActivityUpdatedPayload) error
 	return nil
 }
 
-func validateAgentGUILaunchRequestedPayload(payload []byte) error {
-	var decoded agentGUILaunchRequestedPayload
+func validateWorkspaceWorkbenchNodeLaunchRequestedPayload(payload []byte) error {
+	var decoded workbenchNodeLaunchRequestedPayload
 	if err := json.Unmarshal(payload, &decoded); err != nil {
 		return fmt.Errorf("decode payload: %w", err)
 	}
 	if strings.TrimSpace(decoded.WorkspaceID) == "" {
 		return fmt.Errorf("workspaceId is required")
 	}
-	if strings.TrimSpace(decoded.AgentSessionID) == "" {
-		return fmt.Errorf("agentSessionId is required")
-	}
-	if strings.TrimSpace(decoded.Provider) == "" {
-		return fmt.Errorf("provider is required")
+	if strings.TrimSpace(decoded.TypeID) == "" {
+		return fmt.Errorf("typeId is required")
 	}
 	if strings.TrimSpace(decoded.Source) == "" {
 		return fmt.Errorf("source is required")
 	}
-	if decoded.Reason != "" && strings.TrimSpace(decoded.Reason) == "" {
-		return fmt.Errorf("reason must not be blank")
+	if decoded.LaunchSource != "" && strings.TrimSpace(decoded.LaunchSource) == "" {
+		return fmt.Errorf("launchSource must not be blank")
+	}
+	if decoded.DockEntryID != "" && strings.TrimSpace(decoded.DockEntryID) == "" {
+		return fmt.Errorf("dockEntryId must not be blank")
 	}
 	if decoded.RequestID != "" && strings.TrimSpace(decoded.RequestID) == "" {
 		return fmt.Errorf("requestId must not be blank")

--- a/services/tuttid/service/eventstream/workbench.go
+++ b/services/tuttid/service/eventstream/workbench.go
@@ -1,0 +1,45 @@
+package eventstream
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	workbenchbiz "github.com/tutti-os/tutti/services/tuttid/biz/workbench"
+)
+
+type WorkbenchNodeLaunchPublisher struct {
+	Service *Service
+}
+
+func (p WorkbenchNodeLaunchPublisher) PublishWorkbenchNodeLaunchRequested(
+	ctx context.Context,
+	request workbenchbiz.NodeLaunchRequest,
+) error {
+	if p.Service == nil {
+		return nil
+	}
+	request = workbenchbiz.NormalizeNodeLaunchRequest(request)
+	if request.WorkspaceID == "" || request.TypeID == "" || request.Source == "" {
+		return fmt.Errorf("workbench node launch request requires workspaceId, typeId, and source")
+	}
+	payload := workbenchNodeLaunchRequestedPayload{
+		WorkspaceID:  request.WorkspaceID,
+		TypeID:       request.TypeID,
+		Source:       request.Source,
+		LaunchSource: request.LaunchSource,
+		DockEntryID:  request.DockEntryID,
+		RequestID:    request.RequestID,
+		Payload:      request.Payload,
+	}
+	encoded, err := json.Marshal(payload)
+	if err != nil {
+		return fmt.Errorf("marshal workbench node launch requested payload: %w", err)
+	}
+	return p.Service.PublishFromServerScoped(
+		ctx,
+		TopicWorkspaceWorkbenchNodeLaunchRequested,
+		encoded,
+		EventScope{WorkspaceID: request.WorkspaceID},
+	)
+}

--- a/services/tuttid/wiring.go
+++ b/services/tuttid/wiring.go
@@ -26,6 +26,7 @@ import (
 	diagnosticscli "github.com/tutti-os/tutti/services/tuttid/service/cli/providers/diagnostics"
 	issuemanagercli "github.com/tutti-os/tutti/services/tuttid/service/cli/providers/issuemanager"
 	referencescli "github.com/tutti-os/tutti/services/tuttid/service/cli/providers/references"
+	workbenchappscli "github.com/tutti-os/tutti/services/tuttid/service/cli/providers/workbenchapps"
 	computersvc "github.com/tutti-os/tutti/services/tuttid/service/computer"
 	eventstreamservice "github.com/tutti-os/tutti/services/tuttid/service/eventstream"
 	managedcredentialsservice "github.com/tutti-os/tutti/services/tuttid/service/managedcredentials"
@@ -322,6 +323,11 @@ func buildDaemonAPI(ctx context.Context, store workspacedata.CatalogStore, analy
 		diagnosticscli.NewProvider(),
 		issuemanagercli.NewProvider(workspaceService, issueService, appCenterService),
 		referencescli.NewProvider(workspaceService, appCenterService, issueService),
+		workbenchappscli.NewProvider(
+			workspaceService,
+			appCenterService,
+			eventstreamservice.WorkbenchNodeLaunchPublisher{Service: events},
+		),
 		agentcontextcli.NewProviderWithLaunchPublisher(
 			workspaceService,
 			agentSessionService,


### PR DESCRIPTION
## Summary
- replace the AgentGUI-specific launch event with a generic workspace workbench node launch request event
- add `tutti app open` with origin-root `open-route` intent, params, and JSON state for workspace app webviews
- route AgentGUI, workspace app webviews, and external app launch-intent delivery through the unified workbench launch path

## Validation
- `pnpm check:event-protocol-generated`
- `pnpm lint:ts`
- `pnpm --filter @tutti-os/desktop typecheck`
- `cd services/tuttid && go test ./service/eventstream ./service/cli/providers/agentcontext ./service/cli/providers/workbenchapps`
- `pnpm --filter @tutti-os/workbench-surface test -- src/host/session.test.ts`
- `pnpm --filter @tutti-os/desktop test -- src/renderer/src/features/workspace-app-center/services/internal/workspaceAppCenterContribution.test.ts src/renderer/src/features/workspace-workbench/services/internal/workspaceWorkbenchComposition.test.ts`
- isolated dev GUI smoke test with `tutti-dev app open --app-id tutti-onboarding --route / --param source=selftest --state-json '{"from":"codex-dev-gui"}' --json`
- `pnpm check:full` via pre-push hook


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added route-aware workspace app launch intents with optional parameters and state, including route-based webview URL resolution and restart-and-open preservation.
  * Added a CLI workspace app open command supporting route intents and repeatable `--param` entries.
  * Desktop now exposes a subscription API for launch-intent events.
* **Bug Fixes**
  * Repeated CLI flags are now aggregated instead of overwritten.
  * Launch intents are now delivered only to the correct matching guest/app context.
  * Workbench node launches now use the unified workbench node launch event flow (including agent GUI).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->