### PR TITLE
fix(agent): remove duplicate Codex error warning notice

### DIFF
--- a/packages/agent/daemon/runtime/codex_appserver_events.go
+++ b/packages/agent/daemon/runtime/codex_appserver_events.go
@@ -128,12 +128,13 @@ func (a *CodexAppServerAdapter) appServerNotificationEvents(
 		}
 		return nil
 	case appServerNotifyError:
-		turnError := payloadObject(params["error"])
-		detail := asString(turnError["message"])
 		if willRetry, _ := params["willRetry"].(bool); willRetry {
+			turnError := payloadObject(params["error"])
+			detail := asString(turnError["message"])
 			return []activityshared.Event{appServerSystemNoticeEvent(session, turnID, "transport_retry", "", detail)}
 		}
-		return []activityshared.Event{appServerSystemNoticeEvent(session, turnID, "warning", "Codex reported an error.", detail)}
+		// Terminal turn failures already surface as agent_visible_error in the GUI.
+		return nil
 	case appServerNotifyWarning:
 		return []activityshared.Event{appServerSystemNoticeEvent(session, turnID, "warning", "", asString(params["message"]))}
 	case appServerNotifyDeprecation:

--- a/packages/agent/gui/shared/agentConversation/projection/agentConversationProjection.spec.ts
+++ b/packages/agent/gui/shared/agentConversation/projection/agentConversationProjection.spec.ts
@@ -291,6 +291,70 @@ describe("projectAgentConversationVM", () => {
     );
   });
 
+  it("drops redundant Codex error warning notices when a visible error is present", () => {
+    const conversation = projectAgentConversationVM(
+      detailViewModel({
+        session: {
+          ...detailViewModel().session,
+          status: "failed"
+        },
+        turns: [
+          {
+            id: "turn-1",
+            userMessage: { id: "user-1", body: "Ship it" },
+            userMessages: [{ id: "user-1", body: "Ship it" }],
+            agentMessages: [],
+            toolCalls: [],
+            toolCallCount: 0,
+            hasFailedToolCall: false,
+            agentItems: [
+              {
+                kind: "message",
+                message: {
+                  id: "assistant-warning-1",
+                  body: "Codex reported an error.",
+                  systemNotice: {
+                    noticeKind: "warning",
+                    severity: "warning",
+                    title: "Codex reported an error.",
+                    detail: "stream disconnected",
+                    retryable: false
+                  }
+                }
+              },
+              {
+                kind: "message",
+                message: {
+                  id: "assistant-visible-error-1",
+                  body: "Codex request failed.",
+                  visibleError: {
+                    code: "request_failed",
+                    phase: "turn",
+                    provider: "codex",
+                    detail: "stream disconnected",
+                    retryable: false
+                  }
+                }
+              }
+            ]
+          }
+        ]
+      })
+    );
+
+    const assistantRows = conversation.rows.filter(
+      (
+        row
+      ): row is Extract<
+        (typeof conversation.rows)[number],
+        { kind: "message" }
+      > => row.kind === "message" && row.speaker === "assistant"
+    );
+    expect(assistantRows).toHaveLength(1);
+    expect(assistantRows[0]?.messages[0]?.visibleError?.provider).toBe("codex");
+    expect(assistantRows[0]?.messages[0]?.systemNotice).toBeNull();
+  });
+
   it("groups bridge thinking inside completed tool disclosures", () => {
     const conversation = projectAgentConversationVM(
       detailViewModel({

--- a/packages/agent/gui/shared/agentConversation/projection/agentConversationProjection.ts
+++ b/packages/agent/gui/shared/agentConversation/projection/agentConversationProjection.ts
@@ -71,8 +71,10 @@ export function projectAgentConversationVM(
   }
 
   const normalizedRows = projectMessageCopyText(
-    mergeAdjacentAssistantMessageRows(
-      mergeAdjacentTransportRetryNoticeRows(rows)
+    dropRedundantErrorWarningNotices(
+      mergeAdjacentAssistantMessageRows(
+        mergeAdjacentTransportRetryNoticeRows(rows)
+      )
     ),
     {
       assistantCopyEligibleTurnIds: buildAssistantCopyEligibleTurnIds(detail)
@@ -248,6 +250,60 @@ function mergeAdjacentAssistantMessageRows(
     merged.push(row);
   }
   return merged;
+}
+
+function dropRedundantErrorWarningNotices(
+  rows: readonly AgentTranscriptRowVM[]
+): AgentTranscriptRowVM[] {
+  const turnsWithVisibleError = new Set<string>();
+  for (const row of rows) {
+    if (row.kind !== "message" || row.speaker !== "assistant") {
+      continue;
+    }
+    for (const message of row.messages) {
+      if (message.visibleError) {
+        turnsWithVisibleError.add(row.turnId);
+      }
+    }
+  }
+  if (turnsWithVisibleError.size === 0) {
+    return [...rows];
+  }
+
+  const filteredRows: AgentTranscriptRowVM[] = [];
+  for (const row of rows) {
+    if (row.kind !== "message" || row.speaker !== "assistant") {
+      filteredRows.push(row);
+      continue;
+    }
+    if (!turnsWithVisibleError.has(row.turnId)) {
+      filteredRows.push(row);
+      continue;
+    }
+    const messages = row.messages.filter(
+      (message) => !isRedundantErrorWarningNotice(message)
+    );
+    if (messages.length === 0) {
+      continue;
+    }
+    if (messages.length === row.messages.length) {
+      filteredRows.push(row);
+      continue;
+    }
+    filteredRows.push({ ...row, messages });
+  }
+  return filteredRows;
+}
+
+function isRedundantErrorWarningNotice(
+  message: AgentMessageContentVM
+): boolean {
+  const notice = message.systemNotice;
+  if (!notice || notice.noticeKind !== "warning") {
+    return false;
+  }
+  const title = notice.title?.trim() ?? "";
+  return title === "Codex reported an error.";
 }
 
 function mergeAdjacentTransportRetryNoticeRows(


### PR DESCRIPTION
## Summary
- Stop emitting the yellow "Codex reported an error." system notice for terminal Codex notify errors; turn failure already surfaces as the red visible error card.
- Filter the same redundant warning notice during transcript projection so existing sessions no longer show duplicate error banners.

## Test plan
- [x] `pnpm exec vitest run shared/agentConversation/projection/agentConversationProjection.spec.ts`
- [x] `go test ./runtime/... -run CodexAppServer` in `packages/agent/daemon`
- [ ] Trigger a Codex request failure in Agent GUI and confirm only the red "Codex request failed." banner appears above the composer
- [ ] Confirm transport retry notices and non-error warnings (model reroute, compaction, etc.) still render normally


Made with [Cursor](https://cursor.com)