### PR TITLE
fix(agent): preserve tutti bin in process PATH

### DIFF
--- a/packages/agent/daemon/runtime/process_transport.go
+++ b/packages/agent/daemon/runtime/process_transport.go
@@ -4,7 +4,10 @@ import (
 	"context"
 	"errors"
 	"io"
+	"log/slog"
 	"os/exec"
+	"path/filepath"
+	"strings"
 	"sync"
 
 	"github.com/tutti-os/tutti/packages/agentactivity/daemon/runtimecmd"
@@ -42,7 +45,9 @@ func (localProcessTransport) Start(ctx context.Context, spec ProcessSpec) (Proce
 	processCtx, cancel := context.WithCancel(context.Background())
 	resolver := runtimecmd.Resolver{}
 	env := resolver.Env(spec.Env)
-	cmd := exec.CommandContext(processCtx, resolver.Resolve(spec.Command[0], env), spec.Command[1:]...)
+	resolvedCommand := resolver.Resolve(spec.Command[0], env)
+	logProcessStartEnvDiagnostics(spec, env, resolvedCommand)
+	cmd := exec.CommandContext(processCtx, resolvedCommand, spec.Command[1:]...)
 	cmd.Env = env
 
 	stdin, err := cmd.StdinPipe()
@@ -81,6 +86,111 @@ func (localProcessTransport) Start(ctx context.Context, spec ProcessSpec) (Proce
 	go conn.readPipe(&readers, stderr, false)
 	go conn.wait(&readers)
 	return conn, nil
+}
+
+func logProcessStartEnvDiagnostics(spec ProcessSpec, env []string, resolvedCommand string) {
+	diag := processStartEnvDiagnostics(spec, env)
+	slog.Info("agent session process start env diagnostics",
+		"event", "agent_session.process_start.env_diagnostics",
+		"provider", spec.Provider,
+		"room_id", spec.RoomID,
+		"agent_session_id", spec.AgentSessionID,
+		"cwd", spec.CWD,
+		"command", commandNameForLog(spec.Command),
+		"resolved_command", resolvedCommand,
+		"path_override_count", diag["path_override_count"],
+		"path_entry_count", diag["path_entry_count"],
+		"path_head", diag["path_head"],
+		"path_contains_tutti_bin", diag["path_contains_tutti_bin"],
+		"path_contains_app_node_bin", diag["path_contains_app_node_bin"],
+		"path_contains_app_npm_bin", diag["path_contains_app_npm_bin"],
+		"workspace_env_present", diag["workspace_env_present"],
+		"agent_session_env_present", diag["agent_session_env_present"],
+	)
+}
+
+func processStartEnvDiagnostics(spec ProcessSpec, env []string) map[string]any {
+	pathValue := envValueFromList(env, "PATH")
+	pathDirs := filepath.SplitList(pathValue)
+	appNodeBin := filepath.Dir(envValueFromList(env, "TUTTI_APP_NODE"))
+	appNPMBin := filepath.Dir(envValueFromList(env, "TUTTI_APP_NPM"))
+	return map[string]any{
+		"path_override_count":        envKeyCount(spec.Env, "PATH"),
+		"path_entry_count":           len(pathDirs),
+		"path_head":                  pathHeadForLog(pathDirs, 6),
+		"path_contains_tutti_bin":    pathContainsTuttiBin(pathDirs),
+		"path_contains_app_node_bin": appNodeBin != "." && pathContainsDir(pathDirs, appNodeBin),
+		"path_contains_app_npm_bin":  appNPMBin != "." && pathContainsDir(pathDirs, appNPMBin),
+		"workspace_env_present":      envHasKey(env, "TUTTI_WORKSPACE_ID"),
+		"agent_session_env_present":  envHasKey(env, "TUTTI_AGENT_SESSION_ID"),
+	}
+}
+
+func commandNameForLog(command []string) string {
+	if len(command) == 0 {
+		return ""
+	}
+	return command[0]
+}
+
+func pathHeadForLog(dirs []string, limit int) []string {
+	if limit <= 0 || len(dirs) == 0 {
+		return nil
+	}
+	if len(dirs) < limit {
+		limit = len(dirs)
+	}
+	head := make([]string, 0, limit)
+	for _, dir := range dirs[:limit] {
+		if dir = filepath.Clean(dir); dir != "." {
+			head = append(head, dir)
+		}
+	}
+	return head
+}
+
+func pathContainsTuttiBin(dirs []string) bool {
+	for _, dir := range dirs {
+		if filepath.Base(filepath.Clean(dir)) == "bin" && filepath.Base(filepath.Dir(filepath.Clean(dir))) == ".tutti" {
+			return true
+		}
+	}
+	return false
+}
+
+func pathContainsDir(dirs []string, want string) bool {
+	want = filepath.Clean(want)
+	for _, dir := range dirs {
+		if filepath.Clean(dir) == want {
+			return true
+		}
+	}
+	return false
+}
+
+func envHasKey(env []string, key string) bool {
+	return envValueFromList(env, key) != ""
+}
+
+func envKeyCount(env []string, key string) int {
+	count := 0
+	for _, item := range env {
+		candidateKey, _, ok := strings.Cut(item, "=")
+		if ok && strings.EqualFold(candidateKey, key) {
+			count++
+		}
+	}
+	return count
+}
+
+func envValueFromList(env []string, key string) string {
+	for i := len(env) - 1; i >= 0; i-- {
+		candidateKey, value, ok := strings.Cut(env[i], "=")
+		if ok && strings.EqualFold(candidateKey, key) {
+			return value
+		}
+	}
+	return ""
 }
 
 func (c *localProcessConnection) Send(data []byte) error {

--- a/packages/agent/daemon/runtime/process_transport_test.go
+++ b/packages/agent/daemon/runtime/process_transport_test.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"reflect"
 	"testing"
 	"time"
 )
@@ -78,6 +79,41 @@ func TestLocalProcessTransportFindsKnownNodeGlobalBin(t *testing.T) {
 	frame := receiveRuntimeStdoutFrame(t, conn)
 	if string(frame.Stdout) != "nested-ok\n" {
 		t.Fatalf("stdout = %q, want nested-ok", string(frame.Stdout))
+	}
+}
+
+func TestProcessStartEnvDiagnosticsSummarizesFinalPath(t *testing.T) {
+	tuttiBin := filepath.Join(string(os.PathSeparator), "Users", "Sun", ".tutti", "bin")
+	managedBin := filepath.Join(string(os.PathSeparator), "managed", "node", "bin")
+	env := []string{
+		"PATH=" + managedBin + string(os.PathListSeparator) + tuttiBin + string(os.PathListSeparator) + "/usr/bin",
+		"TUTTI_APP_NODE=" + filepath.Join(managedBin, "node"),
+		"TUTTI_AGENT_SESSION_ID=agent-session-1",
+	}
+	diag := processStartEnvDiagnostics(ProcessSpec{
+		Provider:       ProviderClaudeCode,
+		AgentSessionID: "agent-session-1",
+		Env: []string{
+			"PATH=" + tuttiBin + string(os.PathListSeparator) + "/usr/bin",
+			"PATH=" + managedBin + string(os.PathListSeparator) + "/usr/bin",
+		},
+	}, env)
+
+	if got := diag["path_override_count"]; got != 2 {
+		t.Fatalf("path_override_count = %v, want 2", got)
+	}
+	if got := diag["path_contains_tutti_bin"]; got != true {
+		t.Fatalf("path_contains_tutti_bin = %v, want true", got)
+	}
+	if got := diag["path_contains_app_node_bin"]; got != true {
+		t.Fatalf("path_contains_app_node_bin = %v, want true", got)
+	}
+	if got := diag["agent_session_env_present"]; got != true {
+		t.Fatalf("agent_session_env_present = %v, want true", got)
+	}
+	wantHead := []string{managedBin, tuttiBin, "/usr/bin"}
+	if got := diag["path_head"]; !reflect.DeepEqual(got, wantHead) {
+		t.Fatalf("path_head = %#v, want %#v", got, wantHead)
 	}
 }
 

--- a/packages/agent/daemon/runtimecmd/resolver.go
+++ b/packages/agent/daemon/runtimecmd/resolver.go
@@ -39,8 +39,8 @@ func (r Resolver) Env(overrides []string) []string {
 	env := append(baseEnv, overrides...)
 	pathKey := pathEnvKey(env)
 	pathGroups := [][]string{}
-	if overridePath, ok := envValueFrom(overrides, pathKey); ok {
-		pathGroups = append(pathGroups, filepath.SplitList(overridePath))
+	if overridePathGroups := pathGroupsFromEnv(overrides, pathKey, envValue(baseEnv, pathKey)); len(overridePathGroups) > 0 {
+		pathGroups = append(pathGroups, overridePathGroups...)
 		pathGroups = append(pathGroups, r.preferredExecutableDirs(env))
 		pathGroups = append(pathGroups, r.fallbackExecutableDirs(env))
 	} else {
@@ -259,10 +259,7 @@ func mergePathDirs(groups ...[]string) []string {
 			if normalized == "" {
 				continue
 			}
-			key := filepath.Clean(normalized)
-			if runtime.GOOS == "windows" {
-				key = strings.ToLower(key)
-			}
+			key := pathDirKey(normalized)
 			if seen[key] {
 				continue
 			}
@@ -271,6 +268,14 @@ func mergePathDirs(groups ...[]string) []string {
 		}
 	}
 	return result
+}
+
+func pathDirKey(dir string) string {
+	key := filepath.Clean(strings.TrimSpace(dir))
+	if runtime.GOOS == "windows" {
+		key = strings.ToLower(key)
+	}
+	return key
 }
 
 func pathEnvKey(env []string) string {
@@ -296,6 +301,54 @@ func envValueFrom(env []string, key string) (string, bool) {
 		}
 	}
 	return "", false
+}
+
+func pathGroupsFromEnv(env []string, key string, basePath string) [][]string {
+	groups := [][]string{}
+	baseDirs := filepath.SplitList(basePath)
+	inheritedBaseDirs := []string{}
+	for i := len(env) - 1; i >= 0; i-- {
+		candidateKey, value, ok := strings.Cut(env[i], "=")
+		if ok && strings.EqualFold(candidateKey, key) {
+			dirs := filepath.SplitList(value)
+			if prefix, inherited, ok := splitInheritedPath(dirs, baseDirs); ok {
+				groups = append(groups, prefix)
+				if len(inheritedBaseDirs) == 0 {
+					inheritedBaseDirs = inherited
+				}
+				continue
+			}
+			groups = append(groups, dirs)
+		}
+	}
+	if len(inheritedBaseDirs) > 0 {
+		groups = append(groups, inheritedBaseDirs)
+	}
+	return groups
+}
+
+func splitInheritedPath(dirs []string, baseDirs []string) ([]string, []string, bool) {
+	if len(baseDirs) == 0 || len(dirs) < len(baseDirs) {
+		return nil, nil, false
+	}
+	for i := 0; i+len(baseDirs) <= len(dirs); i++ {
+		if pathDirSlicesEqual(dirs[i:i+len(baseDirs)], baseDirs) {
+			return dirs[:i], dirs[i:], true
+		}
+	}
+	return nil, nil, false
+}
+
+func pathDirSlicesEqual(a []string, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if pathDirKey(a[i]) != pathDirKey(b[i]) {
+			return false
+		}
+	}
+	return true
 }
 
 func stripEnvKeys(env []string, keys []string) []string {

--- a/packages/agent/daemon/runtimecmd/resolver_test.go
+++ b/packages/agent/daemon/runtimecmd/resolver_test.go
@@ -193,6 +193,42 @@ func TestResolverReplacesPathEnv(t *testing.T) {
 	}
 }
 
+func TestResolverMergesMultiplePathOverrides(t *testing.T) {
+	resolver := Resolver{
+		Environ: func() []string {
+			return []string{"PATH=/usr/bin:/bin"}
+		},
+		HomeDir: func() (string, error) {
+			return "", os.ErrNotExist
+		},
+	}
+
+	env := resolver.Env([]string{
+		"PATH=/state/bin:/usr/bin:/bin",
+		"PATH=/managed/node/bin:/usr/bin:/bin",
+	})
+	pathCount := 0
+	pathValue := ""
+	for _, item := range env {
+		key, value, ok := strings.Cut(item, "=")
+		if ok && key == "PATH" {
+			pathCount++
+			pathValue = value
+		}
+	}
+	if pathCount != 1 {
+		t.Fatalf("PATH entry count = %d, want 1 in %#v", pathCount, env)
+	}
+	pathDirs := filepath.SplitList(pathValue)
+	if len(pathDirs) < 4 ||
+		pathDirs[0] != "/managed/node/bin" ||
+		pathDirs[1] != "/state/bin" ||
+		pathDirs[2] != "/usr/bin" ||
+		pathDirs[3] != "/bin" {
+		t.Fatalf("PATH = %q, want override prefixes before inherited base path", pathValue)
+	}
+}
+
 func TestResolverEnvStripsClaudeCodeNestingGuards(t *testing.T) {
 	resolver := Resolver{
 		Environ: func() []string {


### PR DESCRIPTION
## Summary
- Preserve earlier PATH overrides when managed runtime PATH is appended, so `~/.tutti/bin` stays discoverable for agent processes.
- Add safe process-start PATH diagnostics for future log triage without dumping full env.
- Add regression tests for PATH merge ordering and diagnostic summaries.

## Test Plan
- `go test ./runtime ./runtimecmd -count=1` from `packages/agent/daemon`
- `go test ./... -count=1` from `packages/agent/daemon`

## Notes
- `git push` pre-push full check ran most lanes but failed at `typecheck` due existing unrelated TypeScript errors in `packages/workspace/external-core/src/rich-text/*`; this PR only changes Go runtime files.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved handling of command environment setup so overridden path entries are merged more predictably with inherited paths.
  * Added richer runtime diagnostics when launching local processes, making startup behavior easier to inspect.

* **Bug Fixes**
  * Fixed path merging so multiple path overrides are preserved in the correct order instead of being lost or duplicated.
  * Improved path normalization to avoid inconsistent executable lookup across platforms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->