### PR TITLE
fix(agent): support array file change payloads

### DIFF
--- a/packages/agent/gui/shared/agentConversation/components/tool-renderers/render-data/agentToolFileChangeRenderData.ts
+++ b/packages/agent/gui/shared/agentConversation/components/tool-renderers/render-data/agentToolFileChangeRenderData.ts
@@ -3,6 +3,10 @@ import {
   extractAgentPatchPath,
   inferAgentPatchChangeType
 } from "../../../rules/agentPatchMetadata";
+import {
+  fileChangeEntriesFromChanges,
+  fileChangeTypeValue
+} from "../../../../workspaceAgentFileChangePayload";
 
 export interface AgentFileChangeRenderData {
   path: string;
@@ -288,14 +292,10 @@ function fileChangesFiles(value: unknown): AgentFileChangeRenderData[] {
 }
 
 function changeMapFiles(value: unknown): AgentFileChangeRenderData[] {
-  const record = recordValue(value);
-  if (!record) {
-    return [];
-  }
-  return Object.entries(record).flatMap(([path, rawChange]) => {
-    const change = recordValue(rawChange);
-    const normalizedPath = path.trim();
-    if (!normalizedPath || !change) {
+  return fileChangeEntriesFromChanges(value).flatMap((entry) => {
+    const change = entry.change;
+    const normalizedPath = entry.path.trim();
+    if (!normalizedPath) {
       return [];
     }
     const unifiedDiff = firstString(
@@ -305,7 +305,7 @@ function changeMapFiles(value: unknown): AgentFileChangeRenderData[] {
       stringValue(change.patch)
     );
     const explicitContent = stringValue(change.content);
-    const normalizedType = normalizeChangeType(stringValue(change.type));
+    const normalizedType = normalizeChangeType(fileChangeTypeValue(change));
     let oldString = firstString(
       stringValue(change.old_string),
       stringValue(change.oldString)
@@ -389,7 +389,12 @@ function contentDiffFiles(
   if (!items) {
     return [];
   }
-  const changes = recordValue(changesValue);
+  const changesByPath = new Map(
+    fileChangeEntriesFromChanges(changesValue).map((entry) => [
+      entry.path,
+      entry.change
+    ])
+  );
   return items.flatMap((item) => {
     const record = recordValue(item);
     if (!record) {
@@ -403,7 +408,7 @@ function contentDiffFiles(
     if (!path) {
       return [];
     }
-    const relatedChange = recordValue(changes?.[path]);
+    const relatedChange = changesByPath.get(path) ?? null;
     const unifiedDiff = firstString(
       stringValue(record.diff),
       stringValue(record.patch),
@@ -411,7 +416,7 @@ function contentDiffFiles(
       stringValue(relatedChange?.unifiedDiff)
     );
     const normalizedType = normalizeChangeType(
-      stringValue(relatedChange?.type)
+      relatedChange ? fileChangeTypeValue(relatedChange) : null
     );
     let oldString = firstString(
       stringValue(record.oldText),

--- a/packages/agent/gui/shared/agentConversation/components/tool-renderers/render-data/agentToolRenderData.spec.ts
+++ b/packages/agent/gui/shared/agentConversation/components/tool-renderers/render-data/agentToolRenderData.spec.ts
@@ -306,6 +306,41 @@ describe("agentToolRenderData", () => {
     ]);
   });
 
+  it("extracts file changes from Codex array-style changes", () => {
+    const changes = getFileChangeRenderData(
+      makeCall({
+        toolName: "Edit",
+        input: {
+          changes: [
+            {
+              path: "/workspace/deck/slides/02-why-now.html",
+              kind: { type: "add" },
+              diff: "<section>Why now</section>\n"
+            },
+            {
+              path: "/workspace/deck/slides/01-cover.html",
+              kind: { type: "update" },
+              diff: "@@ -1 +1 @@\n-Old\n+New\n"
+            }
+          ]
+        }
+      })
+    );
+
+    expect(changes).toEqual([
+      expect.objectContaining({
+        path: "/workspace/deck/slides/02-why-now.html",
+        changeType: "created",
+        language: "html"
+      }),
+      expect.objectContaining({
+        path: "/workspace/deck/slides/01-cover.html",
+        changeType: "modified",
+        language: "html"
+      })
+    ]);
+  });
+
   it("extracts file changes from ACP diff content blocks backed by change maps", () => {
     const changes = getFileChangeRenderData(
       makeCall({

--- a/packages/agent/gui/shared/agentConversation/projection/agentTurnSummaryProjection.spec.ts
+++ b/packages/agent/gui/shared/agentConversation/projection/agentTurnSummaryProjection.spec.ts
@@ -91,6 +91,71 @@ describe("projectAgentTurnSummaryRowForTurn", () => {
     ]);
   });
 
+  it("extracts Codex array-style Edit changes for summary rows", () => {
+    const rows = projectAgentTurnSummaryRowForTurn(
+      {
+        id: "turn-codex-array-edit",
+        userMessage: null,
+        userMessages: [],
+        agentMessages: [],
+        toolCalls: [
+          {
+            id: "call:edit-array",
+            name: "Edit files",
+            toolName: "Edit",
+            callType: "tool",
+            status: "Completed",
+            statusKind: "completed",
+            summary: "Edited slide deck",
+            occurredAtUnixMs: 14,
+            payload: {
+              input: {
+                file_path: "/workspace/deck/assets/styles.css",
+                changes: [
+                  {
+                    path: "/workspace/deck/slides/02-why-now.html",
+                    kind: { type: "add" },
+                    diff: "<section>Why now</section>\n"
+                  },
+                  {
+                    path: "/workspace/deck/slides/01-cover.html",
+                    kind: { type: "update" },
+                    diff: "@@ -1 +1 @@\n-Old\n+New\n"
+                  }
+                ]
+              }
+            }
+          }
+        ],
+        toolCallCount: 1,
+        hasFailedToolCall: false,
+        agentItems: []
+      } satisfies WorkspaceAgentSessionDetailTurn,
+      { workspaceRoot: "/workspace" }
+    );
+
+    expect(rows).toHaveLength(1);
+    expect(rows[0]).toMatchObject({
+      fileCount: 2,
+      modifiedCount: 1,
+      createdCount: 1
+    });
+    expect(rows[0]?.files).toEqual([
+      expect.objectContaining({
+        path: "/workspace/deck/slides/02-why-now.html",
+        fileName: "02-why-now.html",
+        changeType: "created",
+        toolName: "Edit"
+      }),
+      expect.objectContaining({
+        path: "/workspace/deck/slides/01-cover.html",
+        fileName: "01-cover.html",
+        changeType: "modified",
+        toolName: "Edit"
+      })
+    ]);
+  });
+
   it("extracts nested task step file changes for durable reopen summaries", () => {
     const rows = projectAgentTurnSummaryRowForTurn(
       {
@@ -235,6 +300,51 @@ describe("projectAgentTurnSummaryRowForTurn", () => {
       expect.objectContaining({
         path: "/workspace/docs/spec.md",
         changeType: "created"
+      })
+    ]);
+  });
+
+  it("filters private tmp file paths from summary rows", () => {
+    const rows = projectAgentTurnSummaryRowForTurn(
+      {
+        id: "turn-private-tmp",
+        userMessage: null,
+        userMessages: [],
+        agentMessages: [],
+        toolCalls: [
+          {
+            id: "call:write-private-tmp",
+            name: "Write files",
+            toolName: "Write",
+            callType: "tool",
+            status: "Completed",
+            statusKind: "completed",
+            summary: "Write temp and workspace files",
+            occurredAtUnixMs: 26,
+            payload: {
+              fileChanges: {
+                files: [
+                  {
+                    path: "/private/tmp/workspace/rendered-preview.html",
+                    change: "added"
+                  },
+                  { path: "src/app.ts", change: "modified" }
+                ]
+              }
+            }
+          }
+        ],
+        toolCallCount: 1,
+        hasFailedToolCall: false,
+        agentItems: []
+      } satisfies WorkspaceAgentSessionDetailTurn,
+      { workspaceRoot: "/private/tmp/workspace" }
+    );
+
+    expect(rows[0]?.files).toEqual([
+      expect.objectContaining({
+        path: "src/app.ts",
+        label: "app.ts"
       })
     ]);
   });
@@ -609,6 +719,50 @@ describe("projectAgentTurnSummaryRows", () => {
       expect.objectContaining({
         path: "/repo/docs/spec.md",
         label: "spec.md"
+      })
+    ]);
+  });
+
+  it("filters private tmp paths from activity changed files fallback", () => {
+    const rows = projectAgentTurnSummaryRows({
+      activity: {
+        id: "activity-session-private-tmp",
+        sessionId: "session-private-tmp",
+        userId: "user-a",
+        userName: "Jessica",
+        agentProvider: "gemini",
+        agentName: "Gemini",
+        title: "Completed session",
+        status: "completed",
+        latestActivitySummary: "Completed",
+        changedFiles: [
+          {
+            path: "/private/tmp/workspace/rendered-preview.html",
+            label: "rendered-preview.html"
+          },
+          { path: "src/app.ts", label: "src/app.ts" }
+        ],
+        sortTimeUnixMs: 1_000
+      },
+      session: {
+        id: 1,
+        agentSessionId: "session-private-tmp",
+        presenceId: 1,
+        provider: "gemini",
+        providerSessionId: "provider-1",
+        cwd: "/private/tmp/workspace",
+        status: "completed",
+        updatedAtUnixMs: 1_000
+      },
+      cwd: "/private/tmp/workspace",
+      workspaceRoot: "/private/tmp/workspace",
+      turns: []
+    } satisfies WorkspaceAgentSessionDetailViewModel);
+
+    expect(rows[0]?.files).toEqual([
+      expect.objectContaining({
+        path: "src/app.ts",
+        label: "app.ts"
       })
     ]);
   });

--- a/packages/agent/gui/shared/agentConversation/projection/agentTurnSummaryProjection.ts
+++ b/packages/agent/gui/shared/agentConversation/projection/agentTurnSummaryProjection.ts
@@ -12,6 +12,10 @@ import {
   extractAgentPatchPath,
   inferAgentPatchChangeType
 } from "../rules/agentPatchMetadata";
+import {
+  fileChangeEntriesFromChanges,
+  fileChangeTypeValue
+} from "../../workspaceAgentFileChangePayload";
 
 type AgentTurnSummaryChangeType = AgentTurnSummaryFileVM["changeType"];
 
@@ -76,6 +80,7 @@ function normalizedActivityFilePath(
   const path = value?.trim() ?? "";
   return path &&
     !isStructuredPayloadPath(path) &&
+    !isIgnoredFilePath(path) &&
     resolveWorkspaceFilePathCandidate({
       path,
       workspaceRoot: options.workspaceRoot
@@ -250,11 +255,12 @@ function extractFileChanges(input: {
   if (isFailedToolStatus(input.statusKind)) {
     return [];
   }
-  const changes =
-    objectValue(input.output?.changes) ??
-    objectValue(payload?.changes) ??
-    objectValue(input.input?.changes) ??
-    objectValue(rawInput?.changes);
+  const changes = firstFileChangeValue(
+    input.output?.changes,
+    payload?.changes,
+    input.input?.changes,
+    rawInput?.changes
+  );
 
   const filesFromMetadata = collectMetadataFiles(
     input.id,
@@ -500,19 +506,16 @@ function collectChangeMapFiles(
   messageId: string,
   toolName: string | null,
   occurredAtUnixMs: number | null,
-  changes: Record<string, unknown> | null,
+  changes: unknown,
   options: AgentTurnSummaryProjectionOptions
 ): AgentTurnSummaryFileVM[] {
-  if (!changes) {
-    return [];
-  }
-  return Object.entries(changes).flatMap(([path, rawChange], index) => {
-    const change = objectValue(rawChange);
-    const normalizedPath = normalizedFilePath(path, options);
-    if (!change || !normalizedPath) {
+  return fileChangeEntriesFromChanges(changes).flatMap((entry) => {
+    const change = entry.change;
+    const normalizedPath = normalizedFilePath(entry.path, options);
+    if (!normalizedPath) {
       return [];
     }
-    const normalizedType = normalizeChangeType(stringValue(change.type));
+    const normalizedType = normalizeChangeType(fileChangeTypeValue(change));
     const unifiedDiff = firstNonEmptyString(
       stringValue(change.unified_diff),
       stringValue(change.unifiedDiff),
@@ -568,7 +571,7 @@ function collectChangeMapFiles(
     }
     return [
       buildFileChange({
-        id: `${messageId}:change:${index + 1}`,
+        id: `${messageId}:change:${entry.index + 1}`,
         toolName,
         path: normalizedPath,
         changeType: normalizedType ?? inferAgentPatchChangeType(unifiedDiff),
@@ -587,12 +590,18 @@ function collectContentDiffFiles(
   toolName: string | null,
   occurredAtUnixMs: number | null,
   contentItems: unknown[] | null,
-  changes: Record<string, unknown> | null,
+  changes: unknown,
   options: AgentTurnSummaryProjectionOptions
 ): AgentTurnSummaryFileVM[] {
   if (!contentItems) {
     return [];
   }
+  const changesByPath = new Map(
+    fileChangeEntriesFromChanges(changes).map((entry) => [
+      entry.path,
+      entry.change
+    ])
+  );
   return contentItems.flatMap((value, index) => {
     const item = objectValue(value);
     if (!item) {
@@ -606,9 +615,9 @@ function collectContentDiffFiles(
     if (!path) {
       return [];
     }
-    const relatedChange = objectValue(changes?.[path]);
+    const relatedChange = changesByPath.get(path) ?? null;
     const normalizedType = normalizeChangeType(
-      stringValue(relatedChange?.type)
+      relatedChange ? fileChangeTypeValue(relatedChange) : null
     );
     const unifiedDiff = firstNonEmptyString(
       stringValue(item.diff),
@@ -745,7 +754,13 @@ function normalizedFilePath(
 }
 
 function isIgnoredFilePath(path: string): boolean {
-  return path === "/dev/null" || path === "NUL";
+  const normalizedPath = path.replace(/\\/g, "/").replace(/\/+$/, "");
+  return (
+    normalizedPath === "/dev/null" ||
+    normalizedPath === "NUL" ||
+    normalizedPath === "/private/tmp" ||
+    normalizedPath.startsWith("/private/tmp/")
+  );
 }
 
 function isStructuredPayloadPath(path: string): boolean {
@@ -944,6 +959,15 @@ function objectValue(value: unknown): Record<string, unknown> | null {
   return value && typeof value === "object" && !Array.isArray(value)
     ? (value as Record<string, unknown>)
     : null;
+}
+
+function firstFileChangeValue(...values: unknown[]): unknown {
+  for (const value of values) {
+    if (fileChangeEntriesFromChanges(value).length > 0) {
+      return value;
+    }
+  }
+  return null;
 }
 
 function arrayValue(value: unknown): unknown[] | null {

--- a/packages/agent/gui/shared/workspaceAgentActivityListViewModel.spec.ts
+++ b/packages/agent/gui/shared/workspaceAgentActivityListViewModel.spec.ts
@@ -1194,6 +1194,123 @@ describe("buildWorkspaceAgentActivityListViewModel", () => {
     ]);
   });
 
+  it("keeps changed file keys from lightweight change maps", () => {
+    const snapshot: AgentHostWorkspaceAgentSnapshot = {
+      presences: [],
+      sessions: [
+        {
+          id: 20,
+          agentSessionId: "session-20",
+          presenceId: 0,
+          provider: "codex",
+          providerSessionId: "provider-20",
+          cwd: "/repo",
+          status: "completed",
+          title: "编辑文件"
+        }
+      ]
+    };
+
+    const view = buildWorkspaceAgentActivityListViewModel(snapshot, {
+      sessionMessagesById: {
+        "session-20": [
+          callItem({
+            id: 1,
+            agentSessionId: "session-20",
+            name: "apply_patch",
+            itemType: "call.completed",
+            status: "completed",
+            payload: {
+              toolName: "apply_patch",
+              output: {
+                changes: {
+                  "/workspace/ws-1/src/a.ts": "add",
+                  "/workspace/ws-1/src/b.ts": null
+                }
+              }
+            }
+          })
+        ]
+      }
+    });
+
+    expect(view.activities[0]?.changedFiles).toEqual([
+      {
+        path: "/workspace/ws-1/src/a.ts",
+        label: "a.ts"
+      },
+      {
+        path: "/workspace/ws-1/src/b.ts",
+        label: "b.ts"
+      }
+    ]);
+  });
+
+  it("extracts changed files from Codex Edit changes arrays", () => {
+    const snapshot: AgentHostWorkspaceAgentSnapshot = {
+      presences: [],
+      sessions: [
+        {
+          id: 20,
+          agentSessionId: "session-20",
+          presenceId: 0,
+          provider: "codex",
+          providerSessionId: "provider-20",
+          cwd: "/repo",
+          status: "completed",
+          title: "编辑 html 文件"
+        }
+      ]
+    };
+
+    const view = buildWorkspaceAgentActivityListViewModel(snapshot, {
+      sessionMessagesById: {
+        "session-20": [
+          callItem({
+            id: 1,
+            agentSessionId: "session-20",
+            name: "Edit",
+            itemType: "call.completed",
+            status: "completed",
+            payload: {
+              toolName: "Edit",
+              input: {
+                file_path: "/workspace/deck/assets/styles.css",
+                changes: [
+                  {
+                    path: "/workspace/deck/slides/02-why-now.html",
+                    kind: { type: "add" },
+                    diff: "<section>Why now</section>\n"
+                  },
+                  {
+                    path: "/workspace/deck/slides/01-cover.html",
+                    kind: { type: "update" },
+                    diff: "@@ -1 +1 @@\n-Old\n+New\n"
+                  }
+                ]
+              }
+            }
+          })
+        ]
+      }
+    });
+
+    expect(view.activities[0]?.changedFiles).toEqual([
+      {
+        path: "/workspace/deck/slides/02-why-now.html",
+        label: "02-why-now.html"
+      },
+      {
+        path: "/workspace/deck/slides/01-cover.html",
+        label: "01-cover.html"
+      },
+      {
+        path: "/workspace/deck/assets/styles.css",
+        label: "styles.css"
+      }
+    ]);
+  });
+
   it("does not infer changed files from failed writes without fileChanges metadata", () => {
     const snapshot: AgentHostWorkspaceAgentSnapshot = {
       presences: [],
@@ -1393,6 +1510,125 @@ describe("buildWorkspaceAgentActivityListViewModel", () => {
       {
         path: "/workspace/output/image.png",
         label: "image.png"
+      }
+    ]);
+  });
+
+  it("collects agent-generated files from Codex Edit changes arrays", () => {
+    const snapshot: AgentActivitySnapshot = {
+      workspaceId: "workspace-1",
+      presences: [],
+      sessions: [
+        {
+          agentSessionId: "session-20",
+          cwd: "/Users/demo/project",
+          provider: "codex",
+          status: "completed",
+          title: "Completed session",
+          workspaceId: "workspace-1"
+        }
+      ],
+      sessionMessagesById: {
+        "session-20": [
+          {
+            agentSessionId: "session-20",
+            kind: "tool_call",
+            messageId: "message-1",
+            payload: {
+              toolName: "Edit",
+              input: {
+                file_path: "assets/styles.css",
+                changes: [
+                  {
+                    path: "slides/02-why-now.html",
+                    kind: { type: "add" },
+                    diff: "<section>Why now</section>\n"
+                  },
+                  {
+                    path: "/Users/demo/project/slides/01-cover.html",
+                    kind: { type: "update" },
+                    diff: "@@ -1 +1 @@\n-Old\n+New\n"
+                  }
+                ]
+              }
+            },
+            role: "assistant",
+            status: "completed",
+            version: 1
+          }
+        ]
+      }
+    };
+
+    const files = collectWorkspaceAgentGeneratedFiles(snapshot, {
+      workspaceRoot: "/Users/demo/project"
+    });
+
+    expect(files).toEqual([
+      {
+        path: "/Users/demo/project/slides/02-why-now.html",
+        label: "02-why-now.html"
+      },
+      {
+        path: "/Users/demo/project/slides/01-cover.html",
+        label: "01-cover.html"
+      },
+      {
+        path: "/Users/demo/project/assets/styles.css",
+        label: "styles.css"
+      }
+    ]);
+  });
+
+  it("collects agent-generated files from lightweight change maps", () => {
+    const snapshot: AgentActivitySnapshot = {
+      workspaceId: "workspace-1",
+      presences: [],
+      sessions: [
+        {
+          agentSessionId: "session-20",
+          cwd: "/Users/demo/project",
+          provider: "codex",
+          status: "completed",
+          title: "Completed session",
+          workspaceId: "workspace-1"
+        }
+      ],
+      sessionMessagesById: {
+        "session-20": [
+          {
+            agentSessionId: "session-20",
+            kind: "tool_call",
+            messageId: "message-1",
+            payload: {
+              toolName: "apply_patch",
+              output: {
+                changes: {
+                  "src/a.ts": "add",
+                  "/Users/demo/project/src/b.ts": null
+                }
+              }
+            },
+            role: "assistant",
+            status: "completed",
+            version: 1
+          }
+        ]
+      }
+    };
+
+    const files = collectWorkspaceAgentGeneratedFiles(snapshot, {
+      workspaceRoot: "/Users/demo/project"
+    });
+
+    expect(files).toEqual([
+      {
+        path: "/Users/demo/project/src/a.ts",
+        label: "a.ts"
+      },
+      {
+        path: "/Users/demo/project/src/b.ts",
+        label: "b.ts"
       }
     ]);
   });

--- a/packages/agent/gui/shared/workspaceAgentActivityListViewModel.ts
+++ b/packages/agent/gui/shared/workspaceAgentActivityListViewModel.ts
@@ -1,5 +1,6 @@
 import type { AgentHostUserInfo } from "./contracts/dto";
 import { translate } from "../i18n/index";
+import { fileChangePathsFromChanges } from "./workspaceAgentFileChangePayload";
 import { normalizeAgentTitleText } from "./utils/agentTitleText";
 import { workspaceAgentProviderLabel } from "./workspaceAgentProviderLabel";
 import { normalizeWorkspaceAgentStatus } from "./workspaceAgentStatusNormalizer";
@@ -862,11 +863,7 @@ function changeMapPaths(
   value: unknown,
   normalizePath: ChangedFilePathNormalizer = defaultChangedFilePathNormalizer
 ): string[] {
-  const changes = objectValue(value);
-  if (!changes) {
-    return [];
-  }
-  return Object.keys(changes)
+  return fileChangePathsFromChanges(value)
     .map((path) => normalizePath(path))
     .filter((path): path is string => path !== null);
 }

--- a/packages/agent/gui/shared/workspaceAgentFileChangePayload.ts
+++ b/packages/agent/gui/shared/workspaceAgentFileChangePayload.ts
@@ -1,0 +1,88 @@
+export interface WorkspaceAgentFileChangePayloadEntry {
+  path: string;
+  change: Record<string, unknown>;
+  index: number;
+}
+
+export function fileChangeEntriesFromChanges(
+  value: unknown
+): WorkspaceAgentFileChangePayloadEntry[] {
+  if (Array.isArray(value)) {
+    return value.flatMap((item, index) => {
+      const change = recordValue(item);
+      const path = firstString(
+        stringValue(change?.path),
+        stringValue(change?.filePath),
+        stringValue(change?.file_path)
+      );
+      if (!change || !path) {
+        return [];
+      }
+      return [{ path, change, index }];
+    });
+  }
+
+  const changes = recordValue(value);
+  if (!changes) {
+    return [];
+  }
+  return Object.entries(changes).flatMap(([path, rawChange], index) => {
+    const change = recordValue(rawChange);
+    const normalizedPath = path.trim();
+    if (!change || !normalizedPath) {
+      return [];
+    }
+    return [{ path: normalizedPath, change, index }];
+  });
+}
+
+export function fileChangePathsFromChanges(value: unknown): string[] {
+  if (Array.isArray(value)) {
+    return fileChangeEntriesFromChanges(value).map((entry) => entry.path);
+  }
+
+  const changes = recordValue(value);
+  if (!changes) {
+    return [];
+  }
+  return Object.keys(changes)
+    .map((path) => path.trim())
+    .filter((path) => path.length > 0);
+}
+
+export function fileChangeCountFromChanges(value: unknown): number {
+  return new Set(fileChangePathsFromChanges(value)).size;
+}
+
+export function fileChangeTypeValue(
+  change: Record<string, unknown>
+): string | null {
+  const kind = recordValue(change.kind);
+  return firstString(
+    stringValue(change.type),
+    stringValue(change.change),
+    stringValue(change.kind),
+    stringValue(kind?.type)
+  );
+}
+
+function recordValue(value: unknown): Record<string, unknown> | null {
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : null;
+}
+
+function stringValue(value: unknown): string | null {
+  return typeof value === "string" && value.trim() ? value.trim() : null;
+}
+
+function firstString(
+  ...values: Array<string | null | undefined>
+): string | null {
+  for (const value of values) {
+    if (typeof value === "string" && value.trim()) {
+      return value.trim();
+    }
+  }
+  return null;
+}

--- a/packages/agent/gui/shared/workspaceAgentSessionDetailViewModel.spec.ts
+++ b/packages/agent/gui/shared/workspaceAgentSessionDetailViewModel.spec.ts
@@ -488,6 +488,43 @@ describe("buildWorkspaceAgentSessionDetailViewModel", () => {
     ]);
   });
 
+  it("builds compact summaries for Codex Edit changes arrays", async () => {
+    setAgentGuiI18nTestLocale("en");
+
+    const view = buildWorkspaceAgentSessionDetailViewModel({
+      activity,
+      session,
+      timelineItems: [
+        item({
+          id: 31,
+          turnId: "turn-codex-array-edit",
+          itemType: "call.tool",
+          status: "completed",
+          payload: {
+            toolName: "Edit",
+            input: {
+              file_path: "/workspace/deck/assets/styles.css",
+              changes: [
+                {
+                  path: "/workspace/deck/slides/02-why-now.html",
+                  kind: { type: "add" },
+                  diff: "<section>Why now</section>\n"
+                },
+                {
+                  path: "/workspace/deck/slides/01-cover.html",
+                  kind: { type: "update" },
+                  diff: "@@ -1 +1 @@\n-Old\n+New\n"
+                }
+              ]
+            }
+          }
+        })
+      ]
+    });
+
+    expect(view.turns[0]?.toolCalls[0]?.summary).toBe("2 files");
+  });
+
   it("keeps durable approval items in the transcript as specialized tool calls", async () => {
     setAgentGuiI18nTestLocale("en");
 

--- a/packages/agent/gui/shared/workspaceAgentToolCallDisplay.ts
+++ b/packages/agent/gui/shared/workspaceAgentToolCallDisplay.ts
@@ -4,6 +4,7 @@ import {
   extractImageGenerationPreview,
   resolveImageGenerationCanonicalToolName
 } from "./imageGenerationTool";
+import { fileChangeCountFromChanges } from "./workspaceAgentFileChangePayload";
 import {
   resolveCanonicalToolName,
   resolveLiveCanonicalToolName
@@ -489,7 +490,12 @@ function toolCallDetail(
     summarizeToolInput(payloadInput)
   );
   const normalizedToolName = normalizeToolNameToken(toolName);
-  const multiFileSummary = summarizeFileChangeCount(payloadOutput);
+  const multiFileSummary = summarizeFileChangeCount(
+    payloadOutput,
+    payloadInput,
+    item.payload,
+    metadataInput
+  );
   const todoSummary = summarizeTodoProgress(payloadInput);
   const webDomainSummary = summarizeWebDomain(webTarget);
   const imageGeneration = extractImageGenerationPreview({
@@ -897,18 +903,24 @@ function summarizeToolInput(
 }
 
 function summarizeFileChangeCount(
-  value: Record<string, unknown> | undefined
+  ...values: Array<Record<string, unknown> | undefined>
 ): string | null {
-  const structuredPatch = arrayRecordValue(value, "structuredPatch");
-  if (structuredPatch.length > 1) {
-    return `${structuredPatch.length} files`;
-  }
-  const fileChanges = arrayRecordValue(
-    recordValue(value, "fileChanges"),
-    "files"
-  );
-  if (fileChanges.length > 1) {
-    return `${fileChanges.length} files`;
+  for (const value of values) {
+    const structuredPatch = arrayRecordValue(value, "structuredPatch");
+    if (structuredPatch.length > 1) {
+      return `${structuredPatch.length} files`;
+    }
+    const fileChanges = arrayRecordValue(
+      recordValue(value, "fileChanges"),
+      "files"
+    );
+    if (fileChanges.length > 1) {
+      return `${fileChanges.length} files`;
+    }
+    const changesCount = fileChangeCountFromChanges(value?.changes);
+    if (changesCount > 1) {
+      return `${changesCount} files`;
+    }
   }
   return null;
 }

--- a/services/tuttid/data/workspace/sqlite_agent_generated_files.go
+++ b/services/tuttid/data/workspace/sqlite_agent_generated_files.go
@@ -164,6 +164,15 @@ func appendPathValues(payload map[string]any, appendPath func(any)) {
 			}
 		}
 	}
+	if values, ok := payload["changes"].([]any); ok {
+		for _, value := range values {
+			if valueObject, ok := value.(map[string]any); ok {
+				appendPathValues(valueObject, appendPath)
+				continue
+			}
+			appendPath(value)
+		}
+	}
 }
 
 func objectField(payload map[string]any, key string) (map[string]any, bool) {

--- a/services/tuttid/data/workspace/sqlite_store_test.go
+++ b/services/tuttid/data/workspace/sqlite_store_test.go
@@ -419,20 +419,47 @@ func TestSQLiteStoreListsWorkspaceGeneratedFiles(t *testing.T) {
 		WorkspaceID:    "ws-agent-generated-files",
 		AgentSessionID: "session-1",
 		Origin:         agentsessionstore.WorkspaceAgentSessionOriginRuntime,
-		Messages: []agentactivitybiz.MessageUpdate{{
-			MessageID: "message-1",
-			Role:      "assistant",
-			Kind:      "tool_call",
-			Status:    "completed",
-			Payload: map[string]any{
-				"fileChanges": map[string]any{
-					"files": []any{
-						map[string]any{"path": "report.md"},
+		Messages: []agentactivitybiz.MessageUpdate{
+			{
+				MessageID: "message-1",
+				Role:      "assistant",
+				Kind:      "tool_call",
+				Status:    "completed",
+				Payload: map[string]any{
+					"fileChanges": map[string]any{
+						"files": []any{
+							map[string]any{"path": "report.md"},
+						},
 					},
 				},
+				OccurredAtUnixMS: 110,
 			},
-			OccurredAtUnixMS: 110,
-		}},
+			{
+				MessageID: "message-1b",
+				Role:      "assistant",
+				Kind:      "tool_call",
+				Status:    "completed",
+				Payload: map[string]any{
+					"toolName": "Edit",
+					"input": map[string]any{
+						"file_path": "assets/styles.css",
+						"changes": []any{
+							map[string]any{
+								"path": "slides/02-why-now.html",
+								"kind": map[string]any{"type": "add"},
+								"diff": "<section>Why now</section>\n",
+							},
+							map[string]any{
+								"path": "slides/01-cover.html",
+								"kind": map[string]any{"type": "update"},
+								"diff": "@@ -1 +1 @@\n-Old\n+New\n",
+							},
+						},
+					},
+				},
+				OccurredAtUnixMS: 115,
+			},
+		},
 	}); err != nil {
 		t.Fatalf("ReportSessionMessages(session-1) error = %v", err)
 	}
@@ -473,6 +500,26 @@ func TestSQLiteStoreListsWorkspaceGeneratedFiles(t *testing.T) {
 	}
 	if result.Files[0].Path != "/workspace/report.md" || result.Files[0].Label != "report.md" {
 		t.Fatalf("file = %#v, want /workspace/report.md report.md", result.Files[0])
+	}
+
+	arrayResult, ok, err := store.ListWorkspaceGeneratedFiles(ctx, agentactivitybiz.ListWorkspaceGeneratedFilesInput{
+		WorkspaceID: "ws-agent-generated-files",
+		SessionCwd:  "/workspace",
+		Query:       "slides",
+		Limit:       10,
+	})
+	if err != nil {
+		t.Fatalf("ListWorkspaceGeneratedFiles(array changes) error = %v", err)
+	}
+	if !ok {
+		t.Fatal("ListWorkspaceGeneratedFiles(array changes) ok = false, want true")
+	}
+	if len(arrayResult.Files) != 2 {
+		t.Fatalf("len(array files) = %d, want 2: %#v", len(arrayResult.Files), arrayResult.Files)
+	}
+	if arrayResult.Files[0].Path != "/workspace/slides/02-why-now.html" ||
+		arrayResult.Files[1].Path != "/workspace/slides/01-cover.html" {
+		t.Fatalf("array files = %#v, want Codex Edit changes array paths", arrayResult.Files)
 	}
 }
 


### PR DESCRIPTION
## Summary

- Support Codex Edit `changes` payloads shaped as arrays in agent GUI file-change extraction, activity summaries, compact tool-call summaries, and turn summary projections.
- Share payload normalization through `workspaceAgentFileChangePayload` so map-style and array-style changes use the same path/count/type handling.
- Teach tuttid generated-file extraction to index array-style `changes` entries for workspace generated-files search.

## Verification

- `pnpm check:changed --tail-lines 80`
- `pnpm --filter @tutti-os/agent-gui test -- --run packages/agent/gui/shared/agentConversation/components/tool-renderers/render-data/agentToolRenderData.spec.ts packages/agent/gui/shared/agentConversation/projection/agentTurnSummaryProjection.spec.ts packages/agent/gui/shared/workspaceAgentActivityListViewModel.spec.ts packages/agent/gui/shared/workspaceAgentSessionDetailViewModel.spec.ts`
- `cd services/tuttid && go test ./data/workspace`
- `pnpm lint:go`
- `pnpm check:full`

## Checklist

- [x] I kept the change focused on one concern.
- [x] I updated documentation when behavior, setup, or contributor workflow changed.
- [x] I updated all README/CONTRIBUTING language variants when changing their English source.
- [x] I ran the lowest meaningful local checks for the changed surface.
- [x] My commits are signed off with DCO when required: `git commit -s`.

Docs/translation checklist items are satisfied because this PR does not change docs, setup, contributor workflow, README, or CONTRIBUTING files.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved handling of file-change metadata from tool calls, including array-shaped `changes` payloads.
  * Tool-call summaries more reliably display multi-file counts across multiple input/output shapes.

* **Bug Fixes**
  * File-change rendering and turn summaries now better detect created vs. modified files from varied payload formats.
  * Workspace-generated file lists include paths from structured edit inputs.
  * Summary and file projections now exclude private temporary paths.

* **Tests**
  * Added coverage for array-style edit payloads, private-temp filtering, and generated-file extraction.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->