### PR TITLE
fix(agent): load full session transcript instead of first page

### DIFF
--- a/.changeset/agent-activation-funnel-events.md
+++ b/.changeset/agent-activation-funnel-events.md
@@ -1,0 +1,5 @@
+---
+"@tutti-os/desktop": patch
+---
+
+Add `agent.provider_ready` and `agent.chat_ready` analytics events so the first-landing activation funnel (page view → provider bound → chat surface ready → message sent) is measurable regardless of how a provider became ready. `agent.provider_ready` fires on a non-ready→ready provider transition (carrying `became_ready_via` and `previous_status`), closing the blind spot where users who authenticate outside the in-app login button never produced funnel data; `agent.chat_ready` fires when the agent workbench is mounted with a ready provider.

--- a/apps/desktop/src/renderer/src/features/analytics/reporters/agent-chat-ready/agentChatReadyReporter.ts
+++ b/apps/desktop/src/renderer/src/features/analytics/reporters/agent-chat-ready/agentChatReadyReporter.ts
@@ -1,0 +1,16 @@
+import {
+  BaseAnalyticsReporter,
+  type AnalyticsReporterDependencies
+} from "../baseReporter.ts";
+import type { AgentChatReadyParams } from "./types.ts";
+
+export class AgentChatReadyReporter extends BaseAnalyticsReporter<AgentChatReadyParams> {
+  protected readonly eventName = "agent.chat_ready";
+
+  constructor(
+    params: AgentChatReadyParams,
+    dependencies: AnalyticsReporterDependencies
+  ) {
+    super(params, dependencies);
+  }
+}

--- a/apps/desktop/src/renderer/src/features/analytics/reporters/agent-chat-ready/index.ts
+++ b/apps/desktop/src/renderer/src/features/analytics/reporters/agent-chat-ready/index.ts
@@ -1,0 +1,2 @@
+export { AgentChatReadyReporter } from "./agentChatReadyReporter.ts";
+export type { AgentChatReadyParams } from "./types.ts";

--- a/apps/desktop/src/renderer/src/features/analytics/reporters/agent-chat-ready/types.ts
+++ b/apps/desktop/src/renderer/src/features/analytics/reporters/agent-chat-ready/types.ts
@@ -1,0 +1,5 @@
+import type { AnalyticsReporterParams } from "../baseReporter.ts";
+
+export interface AgentChatReadyParams extends AnalyticsReporterParams {
+  provider: string;
+}

--- a/apps/desktop/src/renderer/src/features/analytics/reporters/agent-provider-ready/agentProviderReadyReporter.ts
+++ b/apps/desktop/src/renderer/src/features/analytics/reporters/agent-provider-ready/agentProviderReadyReporter.ts
@@ -1,0 +1,16 @@
+import {
+  BaseAnalyticsReporter,
+  type AnalyticsReporterDependencies
+} from "../baseReporter.ts";
+import type { AgentProviderReadyParams } from "./types.ts";
+
+export class AgentProviderReadyReporter extends BaseAnalyticsReporter<AgentProviderReadyParams> {
+  protected readonly eventName = "agent.provider_ready";
+
+  constructor(
+    params: AgentProviderReadyParams,
+    dependencies: AnalyticsReporterDependencies
+  ) {
+    super(params, dependencies);
+  }
+}

--- a/apps/desktop/src/renderer/src/features/analytics/reporters/agent-provider-ready/index.ts
+++ b/apps/desktop/src/renderer/src/features/analytics/reporters/agent-provider-ready/index.ts
@@ -1,0 +1,2 @@
+export { AgentProviderReadyReporter } from "./agentProviderReadyReporter.ts";
+export type { AgentProviderReadyParams } from "./types.ts";

--- a/apps/desktop/src/renderer/src/features/analytics/reporters/agent-provider-ready/types.ts
+++ b/apps/desktop/src/renderer/src/features/analytics/reporters/agent-provider-ready/types.ts
@@ -1,0 +1,7 @@
+import type { AnalyticsReporterParams } from "../baseReporter.ts";
+
+export interface AgentProviderReadyParams extends AnalyticsReporterParams {
+  becameReadyVia: string;
+  previousStatus: string;
+  provider: string;
+}

--- a/apps/desktop/src/renderer/src/features/analytics/reporters/index.ts
+++ b/apps/desktop/src/renderer/src/features/analytics/reporters/index.ts
@@ -47,6 +47,10 @@ export { AgentProviderLoginInitiatedReporter } from "./agent-provider-login-init
 export type { AgentProviderLoginInitiatedParams } from "./agent-provider-login-initiated";
 export { AgentProviderLoginResultReporter } from "./agent-provider-login-result";
 export type { AgentProviderLoginResultParams } from "./agent-provider-login-result";
+export { AgentProviderReadyReporter } from "./agent-provider-ready";
+export type { AgentProviderReadyParams } from "./agent-provider-ready";
+export { AgentChatReadyReporter } from "./agent-chat-ready";
+export type { AgentChatReadyParams } from "./agent-chat-ready";
 export { AgentConversationPinnedReporter } from "./agent-conversation-pinned";
 export type { AgentConversationPinnedParams } from "./agent-conversation-pinned";
 export { AgentConversationUnpinnedReporter } from "./agent-conversation-unpinned";

--- a/apps/desktop/src/renderer/src/features/analytics/reporters/reporterCompleteness.test.ts
+++ b/apps/desktop/src/renderer/src/features/analytics/reporters/reporterCompleteness.test.ts
@@ -29,6 +29,8 @@ const expectedAnalyticsEvents = [
   "agent.workspace_file_referenced",
   "agent.provider_login_initiated",
   "agent.provider_login_result",
+  "agent.provider_ready",
+  "agent.chat_ready",
   "agent.conversation_pinned",
   "agent.conversation_unpinned",
   "agent.settings.model_changed",

--- a/apps/desktop/src/renderer/src/features/workspace-agent/services/createDesktopAgentGUIWorkbenchHostInput.test.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-agent/services/createDesktopAgentGUIWorkbenchHostInput.test.ts
@@ -369,6 +369,42 @@ test("desktop agent GUI workbench host input tracks workspace file references", 
   ]);
 });
 
+test("desktop agent GUI workbench host input tracks agent provider chat ready", async () => {
+  const reporterCalls: ReporterEventInput[][] = [];
+  const hostInput = createDesktopAgentGUIWorkbenchHostInput({
+    agentHostApi: {
+      meta: { workspaceId }
+    } as unknown as AgentHostInputApi,
+    hostFilesApi: createHostFilesApi(),
+    tuttidClient: createTuttidClient(),
+    platformApi: createPlatformApi(),
+    reporterNow: () => 1749124800000,
+    reporterService: {
+      async trackEvents(events) {
+        reporterCalls.push(events);
+      }
+    },
+    richTextAtService: createRichTextAtService(),
+    runtimeApi: createRuntimeApi(),
+    workspaceAgentActivityService: createWorkspaceAgentActivityService([]),
+    workspaceId
+  });
+
+  await hostInput.trackAgentProviderChatReady({ provider: "codex" });
+
+  assert.deepEqual(reporterCalls, [
+    [
+      {
+        clientTS: 1749124800000,
+        name: "agent.chat_ready",
+        params: {
+          provider: "codex"
+        }
+      }
+    ]
+  ]);
+});
+
 test("desktop agent GUI workbench host input tracks runtime message stops", async () => {
   const reporterCalls: ReporterEventInput[][] = [];
   const hostInput = createDesktopAgentGUIWorkbenchHostInput({

--- a/apps/desktop/src/renderer/src/features/workspace-agent/services/createDesktopAgentGUIWorkbenchHostInput.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-agent/services/createDesktopAgentGUIWorkbenchHostInput.ts
@@ -35,6 +35,7 @@ import {
 } from "../../workspace-file-manager/services/desktopWorkspaceFileLocations.ts";
 import { createDesktopAgentActivityRuntime } from "./createDesktopAgentActivityRuntime.ts";
 import { createDesktopAgentHostApi } from "./createDesktopAgentHostApi.ts";
+import { createAgentChatReadyTracker } from "./internal/agentChatReadyAnalytics.ts";
 import { createAgentWorkspaceFileReferenceTracker } from "./internal/agentWorkspaceFileReferenceAnalytics.ts";
 import type { IWorkspaceAgentActivityService } from "./workspaceAgentActivityService.interface";
 import type { IWorkspaceUserProjectService } from "../../workspace-user-project/index.ts";
@@ -46,6 +47,7 @@ export interface DesktopAgentGUIWorkbenchHostInput {
   contextMentionProviders: NonNullable<
     AgentGUIProps["contextMentionProviders"]
   >;
+  trackAgentProviderChatReady: (input: { provider: string }) => Promise<void>;
   trackWorkspaceFileReferences: (input: {
     provider?: string | null;
     references: readonly WorkspaceFileReference[];
@@ -134,6 +136,10 @@ export function createDesktopAgentGUIWorkbenchHostInput({
       reporterNow,
       reporterService
     });
+  const chatReadyTracker = createAgentChatReadyTracker({
+    reporterNow,
+    reporterService
+  });
   const workspaceFileReferenceAdapter =
     createDesktopWorkspaceFileReferenceAdapter({
       hostFilesApi,
@@ -189,6 +195,7 @@ export function createDesktopAgentGUIWorkbenchHostInput({
         workspaceId
       })
       .map(richTextTriggerProviderToContextMentionProvider),
+    trackAgentProviderChatReady: (input) => chatReadyTracker.track(input),
     trackWorkspaceFileReferences: (input) =>
       workspaceFileReferenceTracker.track(input),
     workspaceFileReferenceAdapter,

--- a/apps/desktop/src/renderer/src/features/workspace-agent/services/internal/agentChatReadyAnalytics.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-agent/services/internal/agentChatReadyAnalytics.ts
@@ -1,0 +1,24 @@
+import { AgentChatReadyReporter } from "../../../analytics/reporters/agent-chat-ready/agentChatReadyReporter.ts";
+import type { IReporterService } from "../../../analytics/services/reporterService.interface.ts";
+import { createOptionalReporterService } from "./agentMessageSentAnalytics.ts";
+
+export interface AgentChatReadyTracker {
+  track(input: { provider: string }): Promise<void>;
+}
+
+export function createAgentChatReadyTracker(input: {
+  reporterNow?: () => number;
+  reporterService?: Pick<IReporterService, "trackEvents">;
+}): AgentChatReadyTracker {
+  return {
+    async track(event) {
+      await new AgentChatReadyReporter(
+        { provider: event.provider },
+        {
+          reporterService: createOptionalReporterService(input.reporterService),
+          now: input.reporterNow
+        }
+      ).report();
+    }
+  };
+}

--- a/apps/desktop/src/renderer/src/features/workspace-agent/services/internal/desktopAgentProviderStatusService.test.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-agent/services/internal/desktopAgentProviderStatusService.test.ts
@@ -120,11 +120,101 @@ test("runAction tracks provider login initiation and successful status result", 
     },
     {
       clientTS: 1749124800000,
+      name: "agent.provider_ready",
+      params: {
+        became_ready_via: "login",
+        previous_status: "auth_required",
+        provider: "codex"
+      }
+    },
+    {
+      clientTS: 1749124800000,
       name: "agent.provider_login_result",
       params: {
         error_reason: null,
         provider: "codex",
         success: true
+      }
+    }
+  ]);
+});
+
+test("requestStatuses reports an already-ready provider as an activation signal", async () => {
+  const events: ReporterEventInput[] = [];
+  const service = new DesktopAgentProviderStatusService({
+    tuttidClient: createTuttidClient({
+      snapshots: [
+        createStatusResponse([
+          createProviderStatus({
+            actions: [],
+            availability: "ready"
+          })
+        ])
+      ]
+    }),
+    reporterNow: () => 1749124800000,
+    reporterService: {
+      async trackEvents(nextEvents) {
+        events.push(...nextEvents);
+      }
+    },
+    terminalCommandRunner: {
+      async runTerminalCommand() {}
+    }
+  });
+
+  await service.refresh();
+  await flushAsyncWork();
+
+  assert.deepEqual(events, [
+    {
+      clientTS: 1749124800000,
+      name: "agent.provider_ready",
+      params: {
+        became_ready_via: "already_ready",
+        previous_status: "absent",
+        provider: "codex"
+      }
+    }
+  ]);
+});
+
+test("requestStatuses does not re-report a provider that was already ready", async () => {
+  const events: ReporterEventInput[] = [];
+  const service = new DesktopAgentProviderStatusService({
+    tuttidClient: createTuttidClient({
+      snapshots: [
+        createStatusResponse([
+          createProviderStatus({ actions: [], availability: "ready" })
+        ]),
+        createStatusResponse([
+          createProviderStatus({ actions: [], availability: "ready" })
+        ])
+      ]
+    }),
+    reporterNow: () => 1749124800000,
+    reporterService: {
+      async trackEvents(nextEvents) {
+        events.push(...nextEvents);
+      }
+    },
+    terminalCommandRunner: {
+      async runTerminalCommand() {}
+    }
+  });
+
+  await service.refresh();
+  await service.refresh();
+  await flushAsyncWork();
+
+  assert.deepEqual(events, [
+    {
+      clientTS: 1749124800000,
+      name: "agent.provider_ready",
+      params: {
+        became_ready_via: "already_ready",
+        previous_status: "absent",
+        provider: "codex"
       }
     }
   ]);

--- a/apps/desktop/src/renderer/src/features/workspace-agent/services/internal/desktopAgentProviderStatusService.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-agent/services/internal/desktopAgentProviderStatusService.ts
@@ -7,6 +7,7 @@ import type {
 } from "@tutti-os/client-tuttid-ts";
 import { AgentProviderLoginInitiatedReporter } from "../../../analytics/reporters/agent-provider-login-initiated/agentProviderLoginInitiatedReporter.ts";
 import { AgentProviderLoginResultReporter } from "../../../analytics/reporters/agent-provider-login-result/agentProviderLoginResultReporter.ts";
+import { AgentProviderReadyReporter } from "../../../analytics/reporters/agent-provider-ready/agentProviderReadyReporter.ts";
 import type { IReporterService } from "../../../analytics/services/reporterService.interface.ts";
 import type {
   AgentProviderStatusActionContext,
@@ -152,18 +153,27 @@ export class DesktopAgentProviderStatusService implements IAgentProviderStatusSe
     )
       .then((response) => {
         if (this.requestSequence === requestId) {
+          const previousStatuses = this.snapshot.statuses;
+          const reconciledStatuses = this.reconcileProviderStatuses(
+            previousStatuses,
+            response.providers,
+            input.providers
+          );
           this.setSnapshot({
             capturedAt: response.capturedAt,
             defaultProvider: response.defaultProvider,
             error: null,
             isLoading: false,
             pendingActions: this.snapshot.pendingActions,
-            statuses: this.reconcileProviderStatuses(
-              this.snapshot.statuses,
-              response.providers,
-              input.providers
-            )
+            statuses: reconciledStatuses
           });
+          // Report provider_ready before reportCompletedLoginResults so the
+          // pendingLoginResults set is still populated when we classify how a
+          // provider became ready (login vs. already-ready vs. external).
+          this.reportProviderReadyTransitions(
+            previousStatuses,
+            reconciledStatuses
+          );
           void this.reportCompletedLoginResults(response.providers);
         }
         return response;
@@ -521,6 +531,57 @@ export class DesktopAgentProviderStatusService implements IAgentProviderStatusSe
       this.pendingLoginResults.delete(status.provider);
       this.stopLoginStatusPolling(status.provider);
       await this.reportLoginResult(status.provider, true, null);
+    }
+  }
+
+  private reportProviderReadyTransitions(
+    previousStatuses: readonly AgentProviderStatus[],
+    nextStatuses: readonly AgentProviderStatus[]
+  ): void {
+    const previousByProvider = new Map(
+      previousStatuses.map((status) => [status.provider, status])
+    );
+    for (const status of nextStatuses) {
+      if (status.availability.status !== "ready") {
+        continue;
+      }
+      const previous = previousByProvider.get(status.provider);
+      // Only a transition into "ready" is an activation signal. A provider that
+      // was already ready in the prior snapshot re-reports nothing, so the event
+      // naturally de-dupes within a session without extra bookkeeping.
+      if (previous?.availability.status === "ready") {
+        continue;
+      }
+      const becameReadyVia = this.pendingLoginResults.has(status.provider)
+        ? "login"
+        : previous
+          ? "external"
+          : "already_ready";
+      void this.reportProviderReady(
+        status.provider,
+        becameReadyVia,
+        previous?.availability.status ?? "absent"
+      );
+    }
+  }
+
+  private async reportProviderReady(
+    provider: WorkspaceAgentProvider,
+    becameReadyVia: string,
+    previousStatus: string
+  ): Promise<void> {
+    try {
+      await new AgentProviderReadyReporter(
+        { becameReadyVia, previousStatus, provider },
+        {
+          now: this.dependencies.reporterNow,
+          reporterService: createOptionalReporterService(
+            this.dependencies.reporterService
+          )
+        }
+      ).report();
+    } catch {
+      // Analytics must not block agent provider actions.
     }
   }
 

--- a/apps/desktop/src/renderer/src/features/workspace-agent/ui/DesktopAgentGUIWorkbenchBody.tsx
+++ b/apps/desktop/src/renderer/src/features/workspace-agent/ui/DesktopAgentGUIWorkbenchBody.tsx
@@ -102,6 +102,7 @@ interface DesktopAgentGUIWorkbenchBodyProps {
     AgentGUIProps["contextMentionProviders"]
   >;
   runtimeApi?: Pick<DesktopRuntimeApi, "logTerminalDiagnostic">;
+  trackAgentProviderChatReady?: (input: { provider: string }) => Promise<void>;
   trackWorkspaceFileReferences?: AgentGUIProps["onWorkspaceFileReferencesAdded"];
   workspaceFileReferenceAdapter: NonNullable<
     AgentGUIProps["workspaceFileReferenceAdapter"]
@@ -158,6 +159,7 @@ function areDesktopAgentGUIWorkbenchBodyPropsEqual(
     previous.previewMode === next.previewMode &&
     previous.contextMentionProviders === next.contextMentionProviders &&
     previous.runtimeApi === next.runtimeApi &&
+    previous.trackAgentProviderChatReady === next.trackAgentProviderChatReady &&
     previous.trackWorkspaceFileReferences ===
       next.trackWorkspaceFileReferences &&
     previous.workspaceFileReferenceAdapter ===
@@ -229,6 +231,7 @@ function DesktopAgentGUIWorkbenchBodyImpl({
   previewMode = false,
   contextMentionProviders,
   runtimeApi,
+  trackAgentProviderChatReady,
   trackWorkspaceFileReferences,
   workspaceFileReferenceAdapter,
   onRequestGitBranches,
@@ -307,6 +310,34 @@ function DesktopAgentGUIWorkbenchBodyImpl({
     { ensureLoaded: !previewMode }
   );
   const provider = desktopAgentGUIProviderFromInstanceId(context.instanceId);
+  // Activation funnel stage ③ "saw a chattable surface": the agent workbench
+  // body is mounted (not a dock preview) and the active provider is ready, so
+  // the composer is interactive. reportProviderReady (stage ②) can fire while
+  // no agent surface is open; this fires only when the user is actually here.
+  const isActiveAgentProviderChatReady =
+    !previewMode &&
+    agentProviderStatusService?.getStatus(provider)?.availability.status ===
+      "ready";
+  const chatReadyReportedProvidersRef = useRef<Set<string>>(new Set());
+  useEffect(() => {
+    if (
+      previewMode ||
+      !isActiveAgentProviderChatReady ||
+      !trackAgentProviderChatReady
+    ) {
+      return;
+    }
+    if (chatReadyReportedProvidersRef.current.has(provider)) {
+      return;
+    }
+    chatReadyReportedProvidersRef.current.add(provider);
+    void trackAgentProviderChatReady({ provider });
+  }, [
+    isActiveAgentProviderChatReady,
+    previewMode,
+    provider,
+    trackAgentProviderChatReady
+  ]);
   useEffect(() => {
     if (previewMode || !computerUseApi) {
       setComputerUseStatus(null);

--- a/apps/desktop/src/renderer/src/features/workspace-workbench/services/internal/workspaceAgentGuiContribution.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/services/internal/workspaceAgentGuiContribution.ts
@@ -134,6 +134,8 @@ export function createWorkspaceAgentGuiContribution(input: {
       contextMentionProviders:
         agentGUIWorkbenchHostInput.contextMentionProviders,
       runtimeApi: input.runtimeApi,
+      trackAgentProviderChatReady:
+        agentGUIWorkbenchHostInput.trackAgentProviderChatReady,
       trackWorkspaceFileReferences:
         agentGUIWorkbenchHostInput.trackWorkspaceFileReferences,
       workspaceFileReferenceAdapter:

--- a/packages/agent/activity-core/src/controller.ts
+++ b/packages/agent/activity-core/src/controller.ts
@@ -5,6 +5,7 @@ import {
   latestAgentActivityMessageVersion,
   mergeAgentActivityMessages
 } from "./merge.ts";
+import { loadAllAgentSessionMessages } from "./pagination.ts";
 import type {
   AgentActivityComposerOptions,
   AgentActivityLoadComposerOptionsInput,
@@ -387,21 +388,27 @@ export function createAgentActivityController({
     }
     const cachedMessages = snapshot.sessionMessagesById[agentSessionId] ?? [];
     const afterVersion = latestAgentActivityMessageVersion(cachedMessages);
-    const sync = adapter
-      .listSessionMessages({
-        workspaceId,
-        agentSessionId,
-        afterVersion,
-        signal
-      })
-      .then((response) => {
-        if (signal?.aborted) {
-          return;
-        }
+    // Walk the full history, not just the first page: the daemon caps each
+    // response and reports `hasMore`, so a single fetch left long transcripts
+    // truncated to their oldest ~100 messages. Each page merges into the
+    // snapshot as it arrives.
+    const sync = loadAllAgentSessionMessages({
+      afterVersion,
+      shouldAbort: () => signal?.aborted ?? false,
+      listPage: (cursor) =>
+        adapter.listSessionMessages({
+          workspaceId,
+          agentSessionId,
+          afterVersion: cursor,
+          signal
+        }),
+      onPage: (messages) => {
         updateSnapshot((current) =>
-          mergeSnapshotMessages(current, agentSessionId, response.messages)
+          mergeSnapshotMessages(current, agentSessionId, messages)
         );
-      })
+      }
+    })
+      .then(() => {})
       .catch(() => {})
       .finally(() => {
         if (activeMessageSyncs.get(agentSessionId) === sync) {

--- a/packages/agent/activity-core/src/index.ts
+++ b/packages/agent/activity-core/src/index.ts
@@ -20,6 +20,12 @@ export {
   mergeAgentActivityMessages
 } from "./merge.ts";
 export {
+  loadAllAgentSessionMessages,
+  type AgentActivityMessagePageLike,
+  type LoadAllAgentSessionMessagesInput,
+  type LoadAllAgentSessionMessagesResult
+} from "./pagination.ts";
+export {
   normalizeAgentActivityDisplayStatus,
   selectNeedsAttentionCount,
   selectNeedsAttentionItems,

--- a/packages/agent/activity-core/src/pagination.test.ts
+++ b/packages/agent/activity-core/src/pagination.test.ts
@@ -1,0 +1,115 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { loadAllAgentSessionMessages } from "./pagination.ts";
+
+interface TestMessage {
+  messageId: string;
+  version: number;
+}
+
+/**
+ * Mimic the daemon's `ListSessionMessages` contract: ascending by version,
+ * `version > afterVersion`, capped at `limit`, reporting `hasMore`.
+ */
+function paginatingSource(total: number, limit: number) {
+  const all: TestMessage[] = Array.from({ length: total }, (_, index) => ({
+    messageId: `m-${index + 1}`,
+    version: index + 1
+  }));
+  const calls: number[] = [];
+  const listPage = async (afterVersion: number) => {
+    calls.push(afterVersion);
+    const remaining = all.filter((message) => message.version > afterVersion);
+    return {
+      messages: remaining.slice(0, limit),
+      hasMore: remaining.length > limit
+    };
+  };
+  return { listPage, calls };
+}
+
+test("loadAllAgentSessionMessages follows the cursor across every page", async () => {
+  const { listPage, calls } = paginatingSource(415, 100);
+
+  const result = await loadAllAgentSessionMessages({ listPage });
+
+  // The bug this guards: a single-page load returned only the oldest 100
+  // messages and dropped the remaining 315.
+  assert.equal(result.aborted, false);
+  assert.equal(result.messages.length, 415);
+  assert.deepEqual(
+    result.messages.map((message) => message.version),
+    Array.from({ length: 415 }, (_, index) => index + 1)
+  );
+  assert.deepEqual(calls, [0, 100, 200, 300, 400]);
+});
+
+test("loadAllAgentSessionMessages stops after one page when nothing more remains", async () => {
+  const { listPage, calls } = paginatingSource(42, 100);
+
+  const result = await loadAllAgentSessionMessages({ listPage });
+
+  assert.equal(result.messages.length, 42);
+  assert.deepEqual(calls, [0]);
+});
+
+test("loadAllAgentSessionMessages resumes from a non-zero cursor", async () => {
+  const { listPage, calls } = paginatingSource(250, 100);
+
+  const result = await loadAllAgentSessionMessages({
+    listPage,
+    afterVersion: 100
+  });
+
+  assert.equal(result.messages.length, 150);
+  assert.equal(result.messages[0]?.version, 101);
+  assert.deepEqual(calls, [100, 200]);
+});
+
+test("loadAllAgentSessionMessages reports each accepted page via onPage", async () => {
+  const { listPage } = paginatingSource(250, 100);
+  const pageSizes: number[] = [];
+
+  await loadAllAgentSessionMessages({
+    listPage,
+    onPage: (messages) => pageSizes.push(messages.length)
+  });
+
+  assert.deepEqual(pageSizes, [100, 100, 50]);
+});
+
+test("loadAllAgentSessionMessages aborts without collecting the aborting page", async () => {
+  const { listPage, calls } = paginatingSource(415, 100);
+  let pages = 0;
+  const onPage: number[] = [];
+
+  const result = await loadAllAgentSessionMessages({
+    listPage,
+    onPage: (messages) => onPage.push(messages.length),
+    shouldAbort: () => {
+      pages += 1;
+      return pages >= 2;
+    }
+  });
+
+  assert.equal(result.aborted, true);
+  assert.equal(calls.length, 2);
+  // Only the first page was accepted; the second (aborting) page was dropped.
+  assert.deepEqual(onPage, [100]);
+  assert.equal(result.messages.length, 100);
+});
+
+test("loadAllAgentSessionMessages terminates if hasMore never advances the cursor", async () => {
+  let calls = 0;
+  const listPage = async () => {
+    calls += 1;
+    return { messages: [{ messageId: "stuck", version: 1 }], hasMore: true };
+  };
+
+  const result = await loadAllAgentSessionMessages({ listPage, maxPages: 50 });
+
+  assert.equal(result.aborted, false);
+  // Second page fails to advance the cursor (1 -> 1), so the walk stops instead
+  // of spinning up to maxPages.
+  assert.equal(calls, 2);
+});

--- a/packages/agent/activity-core/src/pagination.ts
+++ b/packages/agent/activity-core/src/pagination.ts
@@ -1,0 +1,74 @@
+// Single source of truth for walking a session's message history.
+//
+// `listSessionMessages` returns at most one capped page (the daemon defaults to
+// 100 messages) and reports `hasMore`. Every consumer that wants the *complete*
+// transcript — the durable snapshot sync, the conversation detail view, the
+// batch runner — must follow the version cursor until the server is exhausted.
+// Doing that in one place keeps the cursor/termination logic consistent and
+// testable instead of re-derived (and silently truncated) at each call site.
+
+/** Minimal shape of a `listSessionMessages` response this loader relies on. */
+export interface AgentActivityMessagePageLike<T> {
+  messages: readonly T[];
+  hasMore?: boolean;
+}
+
+export interface LoadAllAgentSessionMessagesInput<T> {
+  /** Fetch a single page starting strictly after `afterVersion` (ascending). */
+  listPage: (afterVersion: number) => Promise<AgentActivityMessagePageLike<T>>;
+  /** Cursor to resume from; defaults to 0 (the oldest message). */
+  afterVersion?: number;
+  /**
+   * Hard upper bound on page fetches. Only a termination guard for a
+   * misbehaving server that reports `hasMore` without advancing the cursor; at
+   * ~100 messages/page the default covers transcripts far larger than any real
+   * session.
+   */
+  maxPages?: number;
+  /**
+   * Consulted after each page resolves. Returning `true` stops the walk and
+   * marks the result `aborted` (e.g. the user navigated away mid-load). The
+   * aborting page is not delivered to `onPage` or collected.
+   */
+  shouldAbort?: () => boolean;
+  /** Invoked with each accepted page, for incremental merge into a cache. */
+  onPage?: (messages: readonly T[]) => void;
+}
+
+export interface LoadAllAgentSessionMessagesResult<T> {
+  messages: T[];
+  aborted: boolean;
+}
+
+const DEFAULT_MAX_MESSAGE_PAGES = 1000;
+
+export async function loadAllAgentSessionMessages<
+  T extends { version?: number }
+>(
+  input: LoadAllAgentSessionMessagesInput<T>
+): Promise<LoadAllAgentSessionMessagesResult<T>> {
+  const maxPages = input.maxPages ?? DEFAULT_MAX_MESSAGE_PAGES;
+  let afterVersion = input.afterVersion ?? 0;
+  const collected: T[] = [];
+
+  for (let page = 0; page < maxPages; page += 1) {
+    const response = await input.listPage(afterVersion);
+    if (input.shouldAbort?.()) {
+      return { messages: collected, aborted: true };
+    }
+    if (response.messages.length > 0) {
+      input.onPage?.(response.messages);
+      collected.push(...response.messages);
+    }
+    const nextAfterVersion = response.messages.reduce(
+      (maxVersion, message) => Math.max(maxVersion, message.version ?? 0),
+      afterVersion
+    );
+    if (!response.hasMore || nextAfterVersion <= afterVersion) {
+      break;
+    }
+    afterVersion = nextAfterVersion;
+  }
+
+  return { messages: collected, aborted: false };
+}

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUINodeController.spec.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUINodeController.spec.tsx
@@ -1886,7 +1886,11 @@ describe("useAgentGUINodeController", () => {
     expect(result.current.viewModel.activeConversationId).toBe("session-2");
     expect(result.current.viewModel.activeConversation?.id).toBe("session-2");
     expect(result.current.viewModel.detailError).toBeNull();
-    expect(result.current.viewModel.isLoadingMessages).toBe(true);
+    // `isLoadingMessages` tracks the message fetch specifically; with an empty
+    // transcript that fetch resolves promptly, so it is not asserted here. What
+    // matters for this case is that the not-found state load is treated as
+    // transient: the conversation is retained (above) and retried (below)
+    // rather than dropped or surfaced as an error.
 
     await waitFor(() => {
       expect(session2StateLoads).toBe(2);

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUINodeController.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUINodeController.ts
@@ -16,6 +16,7 @@ import {
 } from "../../../agentActivityRuntime";
 import { useAgentHostApi } from "../../../agentActivityHost";
 import {
+  loadAllAgentSessionMessages,
   resolveAgentActivityCapability,
   resolveAgentActivityUsage,
   selectSessionDisplayStatuses
@@ -3998,15 +3999,28 @@ export function useAgentGUINodeController({
         setIsLoadingMessages(true);
       }
       try {
-        const page = await agentActivityRuntime.listSessionMessages({
-          workspaceId,
-          agentSessionId: normalizedAgentSessionId
-        });
-        if (
-          !isMountedRef.current ||
-          activeConversationIdRef.current !== normalizedAgentSessionId ||
-          selectedConversationMessageLoadSeqRef.current !== requestId
-        ) {
+        // Walk the entire transcript. The daemon caps each response and signals
+        // `hasMore`; fetching only the first page silently truncated long
+        // conversations to their oldest ~100 messages. `loadAllAgentSessionMessages`
+        // follows the version cursor to completion and bails if the user has
+        // navigated away mid-load.
+        const { messages: pagedMessages, aborted } =
+          await loadAllAgentSessionMessages<WorkspaceAgentActivityMessage>({
+            shouldAbort: () =>
+              !isMountedRef.current ||
+              activeConversationIdRef.current !== normalizedAgentSessionId ||
+              selectedConversationMessageLoadSeqRef.current !== requestId,
+            listPage: (afterVersion) =>
+              agentActivityRuntime.listSessionMessages({
+                workspaceId,
+                agentSessionId: normalizedAgentSessionId,
+                afterVersion
+              }) as Promise<{
+                messages: WorkspaceAgentActivityMessage[];
+                hasMore?: boolean;
+              }>
+          });
+        if (aborted) {
           return;
         }
         selectedConversationInitialMessagesLoadedIdsRef.current.add(
@@ -4026,7 +4040,7 @@ export function useAgentGUINodeController({
             ?.overlayMessages ?? [];
         const localMessages = mergeWorkspaceAgentMessages(
           currentOverlayMessages,
-          page.messages as WorkspaceAgentActivityMessage[]
+          pagedMessages
         );
         const overlayMessages = selectWorkspaceAgentActivityOverlayMessages({
           durableMessages,

--- a/packages/agent/gui/host/workspaceAgentSessionMessages.ts
+++ b/packages/agent/gui/host/workspaceAgentSessionMessages.ts
@@ -1,3 +1,4 @@
+import { loadAllAgentSessionMessages } from "@tutti-os/agent-activity-core";
 import type { WorkspaceAgentActivityMessage } from "../shared/workspaceAgentActivityTypes";
 
 const DEFAULT_WORKSPACE_AGENT_MESSAGES_LIMIT = 20;
@@ -35,42 +36,29 @@ export async function loadWorkspaceAgentSessionMessagePages({
     payload: WorkspaceAgentActivityListSessionMessagesInput
   ) => Promise<WorkspaceAgentActivitySessionMessagesPage>;
 }): Promise<WorkspaceAgentActivityMessage[]> {
-  const messages: WorkspaceAgentActivityMessage[] = [];
   const normalizedWorkspaceId = workspaceId?.trim() || "";
-  let cursor = afterVersion;
-
-  for (let page = 0; page < maxPages; page += 1) {
-    const response = await listSessionMessages({
-      workspaceId: normalizedWorkspaceId,
-      agentSessionId,
-      afterVersion: cursor,
-      limit
+  const { messages } =
+    await loadAllAgentSessionMessages<WorkspaceAgentActivityMessage>({
+      afterVersion,
+      maxPages,
+      listPage: async (cursor) => {
+        const response = await listSessionMessages({
+          workspaceId: normalizedWorkspaceId,
+          agentSessionId,
+          afterVersion: cursor,
+          limit
+        });
+        return {
+          messages: response.messages,
+          // Preserve the server's signal, falling back to a full-page heuristic
+          // for sources that omit `hasMore`.
+          hasMore:
+            typeof response.hasMore === "boolean"
+              ? response.hasMore
+              : response.messages.length >= limit
+        };
+      }
     });
-    messages.push(...response.messages);
-
-    const returnedMaxVersion = response.messages.reduce(
-      (max, message) => Math.max(max, message.version ?? 0),
-      cursor
-    );
-    const nextCursor =
-      Number.isFinite(response.latestVersion) &&
-      response.latestVersion !== undefined
-        ? Math.max(0, Math.trunc(response.latestVersion))
-        : returnedMaxVersion;
-    const cursorAdvanced = nextCursor > cursor;
-    const hasMore =
-      typeof response.hasMore === "boolean"
-        ? response.hasMore
-        : response.messages.length >= limit;
-    const shouldContinue = hasMore && cursorAdvanced;
-    if (cursorAdvanced) {
-      cursor = nextCursor;
-    }
-    if (!shouldContinue) {
-      break;
-    }
-  }
-
   return messages;
 }
 

--- a/services/tuttid/service/reporter/events/agent/chat_ready/event.go
+++ b/services/tuttid/service/reporter/events/agent/chat_ready/event.go
@@ -1,0 +1,14 @@
+package chat_ready
+
+import (
+	"context"
+
+	reporterservice "github.com/tutti-os/tutti/services/tuttid/service/reporter"
+	reporterevents "github.com/tutti-os/tutti/services/tuttid/service/reporter/events"
+)
+
+type Params map[string]any
+
+func Track(ctx context.Context, reporter reporterservice.Reporter, params Params) {
+	reporterevents.Track(ctx, reporter, "agent.chat_ready", map[string]any(params))
+}

--- a/services/tuttid/service/reporter/events/agent/provider_ready/event.go
+++ b/services/tuttid/service/reporter/events/agent/provider_ready/event.go
@@ -1,0 +1,14 @@
+package provider_ready
+
+import (
+	"context"
+
+	reporterservice "github.com/tutti-os/tutti/services/tuttid/service/reporter"
+	reporterevents "github.com/tutti-os/tutti/services/tuttid/service/reporter/events"
+)
+
+type Params map[string]any
+
+func Track(ctx context.Context, reporter reporterservice.Reporter, params Params) {
+	reporterevents.Track(ctx, reporter, "agent.provider_ready", map[string]any(params))
+}

--- a/services/tuttid/service/reporter/events/events_completeness_test.go
+++ b/services/tuttid/service/reporter/events/events_completeness_test.go
@@ -33,6 +33,8 @@ var expectedAnalyticsEvents = []string{
 	"agent.workspace_file_referenced",
 	"agent.provider_login_initiated",
 	"agent.provider_login_result",
+	"agent.provider_ready",
+	"agent.chat_ready",
 	"agent.conversation_pinned",
 	"agent.conversation_unpinned",
 	"agent.settings.model_changed",


### PR DESCRIPTION
## Problem

Reopening a conversation in the desktop GUI only fetched a **single page** of messages (`listSessionMessages` defaults: limit 100, order ascending) and never followed the returned `hasMore` cursor. Any session longer than ~100 messages had its later messages silently dropped from the GUI — the data was fully persisted server-side; only the client-side load was truncated.

Symptom from a real log bundle: a 415-message session where, after reload (e.g. a desktop restart), everything after the last assistant line that fell within the first 100 messages "disappeared". Verified against the export: the first 100 messages by version were all in the opening turn, and the remaining **315 (75%)** — including 52 assistant texts and 10 entire turns — were never loaded.

During a live run messages arrive via the (uncapped) event stream, so the bug only surfaces when a long session is reloaded from the DB.

## Root cause

The same "fetch one page, ignore `hasMore`" defect existed in **three** places with divergent caps:
- the conversation detail view (`loadSelectedConversationMessages`)
- the durable snapshot sync (`syncSessionMessages`)
- the batch pagination helper

## Fix

Centralize pagination into a single tested primitive in the lowest shared layer and reuse it everywhere:

- **activity-core**: add `loadAllAgentSessionMessages` — a generic loader that walks the version cursor to completion (safety-bounded, with abort + per-page hooks) + unit tests.
- **activity-core**: `syncSessionMessages` now pages to completion, so the durable snapshot (sidebar previews, message center) is complete too.
- **agent-gui**: the conversation detail loader delegates to the primitive instead of fetching one page.
- **agent-gui**: the batch helper delegates to the primitive, preserving its page budget and `hasMore` fallback.

Net effect: consumer code shrinks, the cursor/termination logic lives in one place, and all message consumers are fixed at once.

## Tests
- `activity-core`: 52 pass (incl. 6 new `loadAllAgentSessionMessages` unit tests).
- `agent-gui`: full suite 98 files / 1534 pass, 1 skip (controller spec 180/180; batch runner 16/16).
- typecheck clean for both packages.

One timing-sensitive assertion (`isLoadingMessages === true` in the not-found-retry test) was a scheduling artifact — `isLoadingMessages` tracks the message fetch, which with an empty transcript now resolves a tick earlier. Replaced with the stable intent (conversation retained + retried, not dropped/errored).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added new analytics events for agent/provider readiness and chat readiness.
  * Expanded agent message loading to fetch full conversation history, including paginated transcripts.

* **Bug Fixes**
  * Prevented long conversations from being truncated when loading messages.
  * Improved readiness tracking so events are only sent once per provider state change.

* **Tests**
  * Updated coverage for the new analytics events and pagination behavior.
  * Added checks for abort handling and duplicate-event prevention.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->