### PR TITLE
fix(browser-node): forward subframe guest interactions

### DIFF
--- a/apps/desktop/src/preload/entries/browserNodeGuest.ts
+++ b/apps/desktop/src/preload/entries/browserNodeGuest.ts
@@ -6,21 +6,26 @@ const browserGuestDiagnosticChannel = "browser:guestDiagnostic";
 const browserGuestInteractionHostChannel = "browser-node:guest-interaction";
 const browserGuestOpenUrlChannel = "browser:guestOpenUrl";
 
-installBrowserNodeGuestLinkInterception({
-  reportDiagnostic(diagnostic) {
-    ipcRenderer.send(browserGuestDiagnosticChannel, diagnostic);
-  },
-  scope: globalThis.window,
-  sendOpenUrl(url) {
-    ipcRenderer.send(browserGuestOpenUrlChannel, { url });
-  }
-});
 installBrowserNodeGuestInteractionForwarding({
   scope: globalThis.window,
   sendToHost(channel, payload) {
     ipcRenderer.sendToHost(channel, payload);
   }
 });
+
+// Subframes only need passive interaction pings; keep click behavior changes in
+// the main frame so embedded app frames own their own link handling.
+if (process.isMainFrame) {
+  installBrowserNodeGuestLinkInterception({
+    reportDiagnostic(diagnostic) {
+      ipcRenderer.send(browserGuestDiagnosticChannel, diagnostic);
+    },
+    scope: globalThis.window,
+    sendOpenUrl(url) {
+      ipcRenderer.send(browserGuestOpenUrlChannel, { url });
+    }
+  });
+}
 
 type BrowserNodeGuestInteractionType = "focusin" | "keydown" | "pointerdown";
 

--- a/apps/desktop/src/preload/entries/workspaceApp.ts
+++ b/apps/desktop/src/preload/entries/workspaceApp.ts
@@ -16,28 +16,17 @@ const appContextChannels = {
   get: "workspace-app-context:get"
 } as const;
 
-installWorkspaceAppLinkInterception({
-  executeInMainWorld(script) {
-    const result = contextBridge.executeInMainWorld(script) as unknown;
-    return result;
-  },
-  reportDiagnostic(diagnostic) {
-    ipcRenderer.send(appContextChannels.diagnostic, {
-      event: "workspace-app-link-interception",
-      ...diagnostic
-    });
-  },
-  scope: globalThis.window,
-  send(channel, payload) {
-    ipcRenderer.send(channel, payload);
-  }
-});
 installWorkspaceAppInteractionForwarding({
   scope: globalThis.window,
   sendToHost(channel, payload) {
     ipcRenderer.sendToHost(channel, payload);
   }
 });
+
+// Subframes only need passive interaction pings; keep host APIs main-frame only.
+if (process.isMainFrame) {
+  installWorkspaceAppMainFrameBridge();
+}
 
 export interface WorkspaceAppHostContext {
   get(): Promise<DesktopWorkspaceAppContext>;
@@ -46,139 +35,170 @@ export interface WorkspaceAppHostContext {
   ): () => void;
 }
 
-const contextListeners = new Set<
-  (context: DesktopWorkspaceAppContext) => void
->();
-const launchIntentListeners = new Set<
-  (intent: TuttiExternalWorkspaceOpenRouteIntent) => void
->();
-const userProjectSnapshots = createWorkspaceAppUserProjectSnapshotBridge();
-let cachedContext: DesktopWorkspaceAppContext | null = null;
-let pendingContext: Promise<DesktopWorkspaceAppContext> | null = null;
-
-const appContext: WorkspaceAppHostContext = {
-  async get() {
-    if (cachedContext) {
-      return cachedContext;
-    }
-    if (pendingContext) {
-      return pendingContext;
-    }
-
-    pendingContext = resolveHostContext();
-    try {
-      const context = await pendingContext;
-      cachedContext = context;
-      return context;
-    } finally {
-      pendingContext = null;
-    }
-  },
-  subscribe(listener) {
-    contextListeners.add(listener);
-    void appContext
-      .get()
-      .then((context) => {
-        if (contextListeners.has(listener)) {
-          listener(context);
-        }
-      })
-      .catch((error: unknown) => {
-        sendDiagnostic("subscribe-replay-failed", {
-          message: error instanceof Error ? error.message : String(error)
-        });
+function installWorkspaceAppMainFrameBridge(): void {
+  installWorkspaceAppLinkInterception({
+    executeInMainWorld(script) {
+      const result = contextBridge.executeInMainWorld(script) as unknown;
+      return result;
+    },
+    reportDiagnostic(diagnostic) {
+      ipcRenderer.send(appContextChannels.diagnostic, {
+        event: "workspace-app-link-interception",
+        ...diagnostic
       });
+    },
+    scope: globalThis.window,
+    send(channel, payload) {
+      ipcRenderer.send(channel, payload);
+    }
+  });
 
-    return () => {
-      contextListeners.delete(listener);
-    };
-  }
-};
+  const contextListeners = new Set<
+    (context: DesktopWorkspaceAppContext) => void
+  >();
+  const launchIntentListeners = new Set<
+    (intent: TuttiExternalWorkspaceOpenRouteIntent) => void
+  >();
+  const userProjectSnapshots = createWorkspaceAppUserProjectSnapshotBridge();
+  let cachedContext: DesktopWorkspaceAppContext | null = null;
+  let pendingContext: Promise<DesktopWorkspaceAppContext> | null = null;
 
-const tuttiExternal = createWorkspaceAppExternalBridge({
-  appContext,
-  invoke: invokeWorkspaceApp,
-  isUserActivationActive: () =>
-    globalThis.navigator.userActivation?.isActive === true,
-  send(channel, payload) {
-    ipcRenderer.send(channel, payload);
-  },
-  subscribeToWorkspaceLaunchIntents(listener) {
-    launchIntentListeners.add(listener);
-    return () => {
-      launchIntentListeners.delete(listener);
-    };
-  },
-  subscribeToUserProjects(listener) {
-    return userProjectSnapshots.subscribe(listener);
-  }
-});
+  const appContext: WorkspaceAppHostContext = {
+    async get() {
+      if (cachedContext) {
+        return cachedContext;
+      }
+      if (pendingContext) {
+        return pendingContext;
+      }
 
-ipcRenderer.on(
-  appContextChannels.changed,
-  (_event: IpcRendererEvent, payload: DesktopWorkspaceAppContext) => {
-    if (isWorkspaceAppContext(payload)) {
-      cachedContext = payload;
-      for (const listener of contextListeners) {
-        listener(payload);
+      pendingContext = resolveHostContext();
+      try {
+        const context = await pendingContext;
+        cachedContext = context;
+        return context;
+      } finally {
+        pendingContext = null;
+      }
+    },
+    subscribe(listener) {
+      contextListeners.add(listener);
+      void appContext
+        .get()
+        .then((context) => {
+          if (contextListeners.has(listener)) {
+            listener(context);
+          }
+        })
+        .catch((error: unknown) => {
+          sendDiagnostic("subscribe-replay-failed", {
+            message: error instanceof Error ? error.message : String(error)
+          });
+        });
+
+      return () => {
+        contextListeners.delete(listener);
+      };
+    }
+  };
+
+  const tuttiExternal = createWorkspaceAppExternalBridge({
+    appContext,
+    invoke: invokeWorkspaceApp,
+    isUserActivationActive: () =>
+      globalThis.navigator.userActivation?.isActive === true,
+    send(channel, payload) {
+      ipcRenderer.send(channel, payload);
+    },
+    subscribeToWorkspaceLaunchIntents(listener) {
+      launchIntentListeners.add(listener);
+      return () => {
+        launchIntentListeners.delete(listener);
+      };
+    },
+    subscribeToUserProjects(listener) {
+      return userProjectSnapshots.subscribe(listener);
+    }
+  });
+
+  ipcRenderer.on(
+    appContextChannels.changed,
+    (_event: IpcRendererEvent, payload: DesktopWorkspaceAppContext) => {
+      if (isWorkspaceAppContext(payload)) {
+        cachedContext = payload;
+        for (const listener of contextListeners) {
+          listener(payload);
+        }
       }
     }
-  }
-);
-
-ipcRenderer.on(
-  "workspace-app-external:guest-event",
-  (_event: IpcRendererEvent, payload: unknown) => {
-    if (!isWorkspaceAppExternalRendererEvent(payload)) {
-      return;
-    }
-    if (payload.type === "userProjects.changed") {
-      userProjectSnapshots.publish(payload.snapshot);
-      return;
-    }
-    if (payload.type === "workspace.launchIntent") {
-      for (const listener of launchIntentListeners) {
-        listener(payload.intent);
-      }
-    }
-  }
-);
-
-async function resolveHostContext(): Promise<DesktopWorkspaceAppContext> {
-  const result = await invokeWorkspaceAppRaw<DesktopWorkspaceAppContext>(
-    appContextChannels.get
   );
-  if (result.ok && isWorkspaceAppContext(result.data)) {
-    return result.data;
+
+  ipcRenderer.on(
+    "workspace-app-external:guest-event",
+    (_event: IpcRendererEvent, payload: unknown) => {
+      if (!isWorkspaceAppExternalRendererEvent(payload)) {
+        return;
+      }
+      if (payload.type === "userProjects.changed") {
+        userProjectSnapshots.publish(payload.snapshot);
+        return;
+      }
+      if (payload.type === "workspace.launchIntent") {
+        for (const listener of launchIntentListeners) {
+          listener(payload.intent);
+        }
+      }
+    }
+  );
+
+  async function resolveHostContext(): Promise<DesktopWorkspaceAppContext> {
+    const result = await invokeWorkspaceAppRaw<DesktopWorkspaceAppContext>(
+      appContextChannels.get
+    );
+    if (result.ok && isWorkspaceAppContext(result.data)) {
+      return result.data;
+    }
+
+    const message = result.ok
+      ? "invalid workspace app context"
+      : result.error.message;
+    sendDiagnostic("get-context-failed", { message });
+    throw new Error(message);
   }
 
-  const message = result.ok
-    ? "invalid workspace app context"
-    : result.error.message;
-  sendDiagnostic("get-context-failed", { message });
-  throw new Error(message);
-}
-
-async function invokeWorkspaceApp<TResult>(
-  channel: string,
-  payload?: unknown
-): Promise<TResult> {
-  const result = await invokeWorkspaceAppRaw<TResult>(channel, payload);
-  if (result.ok) {
-    return result.data;
+  async function invokeWorkspaceApp<TResult>(
+    channel: string,
+    payload?: unknown
+  ): Promise<TResult> {
+    const result = await invokeWorkspaceAppRaw<TResult>(channel, payload);
+    if (result.ok) {
+      return result.data;
+    }
+    throw new Error(result.error.message);
   }
-  throw new Error(result.error.message);
-}
 
-async function invokeWorkspaceAppRaw<TResult>(
-  channel: string,
-  payload?: unknown
-): Promise<DesktopIpcResult<TResult>> {
-  return (
-    payload === undefined
-      ? await ipcRenderer.invoke(channel)
-      : await ipcRenderer.invoke(channel, payload)
-  ) as DesktopIpcResult<TResult>;
+  async function invokeWorkspaceAppRaw<TResult>(
+    channel: string,
+    payload?: unknown
+  ): Promise<DesktopIpcResult<TResult>> {
+    return (
+      payload === undefined
+        ? await ipcRenderer.invoke(channel)
+        : await ipcRenderer.invoke(channel, payload)
+    ) as DesktopIpcResult<TResult>;
+  }
+
+  contextBridge.exposeInMainWorld("tuttiExternal", tuttiExternal);
+
+  function sendDiagnostic(
+    event: string,
+    details?: Record<string, unknown>
+  ): void {
+    ipcRenderer.send(appContextChannels.diagnostic, {
+      details: details ?? {},
+      event
+    });
+  }
 }
 
 function isWorkspaceAppContext(
@@ -261,16 +281,4 @@ function isStringRecord(value: unknown): value is Record<string, string> {
     return false;
   }
   return Object.values(value).every((entry) => typeof entry === "string");
-}
-
-contextBridge.exposeInMainWorld("tuttiExternal", tuttiExternal);
-
-function sendDiagnostic(
-  event: string,
-  details?: Record<string, unknown>
-): void {
-  ipcRenderer.send(appContextChannels.diagnostic, {
-    details: details ?? {},
-    event
-  });
 }

--- a/docs/conventions/troubleshooting.md
+++ b/docs/conventions/troubleshooting.md
@@ -841,3 +841,34 @@ information is not available yet`, but `ps` or `lsof` still shows an older
 - References:
   [main.tsx](../../apps/desktop/src/renderer/src/main.tsx)
   [whyDidYouRender.ts](../../apps/desktop/src/renderer/src/lib/whyDidYouRender.ts)
+
+### Browser Node focus pings miss iframe-hosted editors
+
+- Symptom:
+  Clicking or typing inside a workspace app selects text or edits content, but
+  the owning Browser Node does not become the active node. This commonly shows
+  up in rich document editors that render the editable surface inside a
+  same-origin `iframe` or `srcdoc` frame.
+- Quick checks:
+  Inspect whether the app portals or mounts its editor into an iframe document.
+  If the top-level workspace app preload listens on `window.document` only, the
+  host will not receive pointer, focus, or keyboard pings from that child frame.
+- Root cause:
+  DOM events do not bubble from iframe documents to the parent document. Electron
+  webview preloads also do not run in subframes unless the host enables
+  `nodeIntegrationInSubFrames`, so iframe-hosted editors can interact normally
+  while the Browser Node focus bridge stays silent.
+- Fix:
+  Enable subframe preload execution only for host-controlled Browser Node or
+  workspace app guest preloads. Keep privileged workspace app bridges, such as
+  `tuttiExternal`, and behavior-changing guest logic, such as `_blank` link
+  interception, main-frame-only via `process.isMainFrame`. Install only passive
+  interaction forwarding in subframes.
+- Validation:
+  Run Browser Node and desktop preload tests, desktop typecheck, and the desktop
+  build. For workspace app preloads, inspect the built preload output so the
+  guest files remain self-contained.
+- References:
+  [webviewSecurity.ts](../../packages/browser/workbench-node/src/electron-main/webviewSecurity.ts)
+  [workspaceApp.ts](../../apps/desktop/src/preload/entries/workspaceApp.ts)
+  [workspaceAppInteractionForwarding.ts](../../apps/desktop/src/preload/entries/workspaceAppInteractionForwarding.ts)

--- a/packages/browser/workbench-node/src/electron-main/electronMain.test.ts
+++ b/packages/browser/workbench-node/src/electron-main/electronMain.test.ts
@@ -43,6 +43,7 @@ test("enforces Browser Node webview security policy", () => {
   assert.equal(params.src, "https://example.com/");
   assert.equal(webPreferences.contextIsolation, true);
   assert.equal(webPreferences.nodeIntegration, false);
+  assert.equal(webPreferences.nodeIntegrationInSubFrames, false);
   assert.equal(webPreferences.preload, undefined);
   assert.equal(webPreferences.sandbox, true);
   assert.equal(webPreferences.webSecurity, true);
@@ -108,6 +109,7 @@ test("applies host-controlled Browser Node guest preload after validation", () =
   );
 
   assert.equal(resolvedSrc, "https://example.com/");
+  assert.equal(webPreferences.nodeIntegrationInSubFrames, true);
   assert.equal(webPreferences.preload, "/tmp/host-browser-guest-preload.js");
 
   let invalidResolverCalls = 0;

--- a/packages/browser/workbench-node/src/electron-main/webviewSecurity.ts
+++ b/packages/browser/workbench-node/src/electron-main/webviewSecurity.ts
@@ -107,6 +107,7 @@ export function enforceBrowserWebviewSecurity({
   webPreferences.contextIsolation = true;
   webPreferences.javascript = true;
   webPreferences.nodeIntegration = false;
+  webPreferences.nodeIntegrationInSubFrames = false;
   webPreferences.plugins = false;
   webPreferences.sandbox = true;
   webPreferences.webSecurity = true;
@@ -140,6 +141,9 @@ export function enforceBrowserWebviewSecurity({
   const resolvedPreload = typeof preload === "string" ? preload.trim() : "";
   if (resolvedPreload.length > 0) {
     webPreferences.preload = resolvedPreload;
+    // Iframe-hosted editors still need the guest preload to report interactions
+    // so the host can focus the owning Browser Node.
+    webPreferences.nodeIntegrationInSubFrames = true;
   }
 
   return { allowed: true, reason: null };


### PR DESCRIPTION
## Summary
- enable host-controlled Browser Node/workspace app guest preloads in subframes so iframe-hosted editors can report interactions
- keep privileged workspace app bridges main-frame-only while allowing passive interaction forwarding in subframes
- keep ordinary BrowserNode link interception main-frame-only so subframes do not inherit `_blank` click behavior changes
- document the iframe-hosted editor focus trap in troubleshooting

## Validation
- pnpm --filter @tutti-os/browser-node test
- pnpm --filter @tutti-os/desktop typecheck
- pnpm lint:ts
- pnpm --filter @tutti-os/desktop build
- checked built preload bundles for no relative chunk imports
- verified `tuttiExternal` remains behind `process.isMainFrame` in workspace-app preload
- verified BrowserNode guest `_blank` link interception remains behind `process.isMainFrame`, while subframes only install interaction forwarding

## Notes
- Follow-up to merged PR #363. Full pre-push was skipped for this update because the earlier #363 pre-push attempt failed only in an existing Go agentstatus test: services/tuttid/service/agentstatus TestServiceRunActionSerializesConcurrentExternalRegistryNPMInstalls.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved editor interaction and focus behavior for workspace content embedded in same-origin iframes or `srcdoc`.
  * Tightened webview security by default: Node integration in subframes remains disabled unless an approved guest preload is applied.
  * Reduced host-bridge behavior to the main frame and adjusted guest interaction vs. link-interception handling to improve reliability.

* **Documentation**
  * Added troubleshooting guidance for “Browser Node focus pings miss iframe-hosted editors,” including symptoms, checks, causes, and validation steps.

* **Tests**
  * Added/updated assertions covering the `nodeIntegrationInSubFrames` security policy behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->