### PR TITLE
fix(agent-gui): remove host attachment reference path

### DIFF
--- a/packages/agent/gui/agent-gui/agentGuiNode/AgentComposer.spec.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/AgentComposer.spec.tsx
@@ -2582,106 +2582,6 @@ describe("AgentComposer", () => {
     ]);
   });
 
-  it("does not submit host file references before their upload state is reflected in props", async () => {
-    type UploadResult = AgentActivityRuntimeUploadPromptContentResult;
-    let resolveUpload: (result: UploadResult) => void = () => undefined;
-    const uploadPromptContent = vi.fn(
-      () =>
-        new Promise<UploadResult>((resolve) => {
-          resolveUpload = resolve;
-        })
-    );
-    setAgentActivityRuntimeForTests({
-      uploadPromptContent
-    } as unknown as AgentActivityRuntime);
-
-    let draftContent = createDraft("这是个啥图");
-    const onDraftContentChange = vi.fn((nextDraft: AgentComposerDraft) => {
-      draftContent = nextDraft;
-    });
-    const onSubmit = vi.fn();
-    const renderComposer = () => (
-      <AgentComposer
-        workspaceId="workspace-1"
-        currentUserId="user-1"
-        provider="codex"
-        draftContent={draftContent}
-        availableCommands={[] satisfies readonly AgentHostAgentSessionCommand[]}
-        disabled={false}
-        submitDisabled={false}
-        placeholder="placeholder"
-        composerSettings={createComposerSettings()}
-        queuedPrompts={[]}
-        drainingQueuedPromptId={null}
-        canQueueWhileBusy={false}
-        showStopButton={false}
-        activePrompt={null}
-        isInterrupting={false}
-        isSendingTurn={false}
-        isSubmittingPrompt={false}
-        labels={createLabels()}
-        workspaceUserProjectI18n={workspaceUserProjectI18n}
-        onDraftContentChange={onDraftContentChange}
-        onSettingsChange={vi.fn()}
-        onSubmit={onSubmit}
-        onSendQueuedPromptNext={vi.fn()}
-        onRemoveQueuedPrompt={vi.fn()}
-        onEditQueuedPrompt={vi.fn()}
-        onInterruptCurrentTurn={vi.fn()}
-        onSubmitInteractivePrompt={vi.fn()}
-        onRequestWorkspaceReferences={async () => ({
-          files: [],
-          mentionItems: [],
-          hostAttachments: [
-            {
-              hostPath: "/Users/vector/Downloads/1.webp",
-              name: "1.webp",
-              mimeType: "image/webp"
-            }
-          ]
-        })}
-      />
-    );
-    const { container, rerender } = render(renderComposer());
-
-    fireEvent.click(screen.getByRole("combobox", { name: "引用空间文件" }));
-    await waitFor(() => expect(uploadPromptContent).toHaveBeenCalled());
-
-    fireEvent.submit(container.querySelector("form")!);
-    expect(onSubmit).not.toHaveBeenCalled();
-
-    resolveUpload({
-      content: [
-        {
-          type: "file",
-          mimeType: "image/webp",
-          path: "/var/cache/tsh/local-assets/workspace-1/user-1/1.webp",
-          name: "1.webp",
-          kind: "file"
-        }
-      ]
-    });
-    await waitFor(() =>
-      expect(draftContent.files?.[0]).toMatchObject({
-        path: "/var/cache/tsh/local-assets/workspace-1/user-1/1.webp",
-        uploading: false
-      })
-    );
-    rerender(renderComposer());
-
-    fireEvent.submit(container.querySelector("form")!);
-    expect(onSubmit).toHaveBeenCalledWith([
-      { type: "text", text: "这是个啥图" },
-      {
-        type: "file",
-        mimeType: "image/webp",
-        path: "/var/cache/tsh/local-assets/workspace-1/user-1/1.webp",
-        name: "1.webp",
-        kind: "file"
-      }
-    ]);
-  });
-
   it("uploads host-local references before inserting file mention anchors", async () => {
     type UploadResult = AgentActivityRuntimeUploadPromptContentResult;
     let resolveUpload: (result: UploadResult) => void = () => undefined;
@@ -2739,8 +2639,7 @@ describe("AgentComposer", () => {
               sourceId: "host-local-file"
             }
           ],
-          mentionItems: [],
-          hostAttachments: []
+          mentionItems: []
         })}
       />
     );
@@ -2787,74 +2686,6 @@ describe("AgentComposer", () => {
         text: "看下这张图[@首页 (1).jpg](/var/cache/tsh/local-assets/workspace-1/user-1/home.jpg)"
       }
     ]);
-  });
-
-  it("blocks host file drafts when the runtime cannot upload prompt content", async () => {
-    let draftContent = createDraft("");
-    const onDraftContentChange = vi.fn((nextDraft: AgentComposerDraft) => {
-      draftContent = nextDraft;
-    });
-    const onSubmit = vi.fn();
-    const renderComposer = () => (
-      <AgentComposer
-        workspaceId="workspace-1"
-        currentUserId="user-1"
-        provider="codex"
-        draftContent={draftContent}
-        availableCommands={[] satisfies readonly AgentHostAgentSessionCommand[]}
-        disabled={false}
-        submitDisabled={false}
-        placeholder="placeholder"
-        composerSettings={createComposerSettings()}
-        queuedPrompts={[]}
-        drainingQueuedPromptId={null}
-        canQueueWhileBusy={false}
-        showStopButton={false}
-        activePrompt={null}
-        isInterrupting={false}
-        isSendingTurn={false}
-        isSubmittingPrompt={false}
-        labels={createLabels()}
-        workspaceUserProjectI18n={workspaceUserProjectI18n}
-        onDraftContentChange={onDraftContentChange}
-        onSettingsChange={vi.fn()}
-        onSubmit={onSubmit}
-        onSendQueuedPromptNext={vi.fn()}
-        onRemoveQueuedPrompt={vi.fn()}
-        onEditQueuedPrompt={vi.fn()}
-        onInterruptCurrentTurn={vi.fn()}
-        onSubmitInteractivePrompt={vi.fn()}
-        onRequestWorkspaceReferences={async () => ({
-          files: [],
-          mentionItems: [],
-          hostAttachments: [
-            {
-              hostPath: "/Users/vector/Desktop/notes.txt",
-              name: "notes.txt",
-              mimeType: "text/plain"
-            }
-          ]
-        })}
-      />
-    );
-    const { container, rerender } = render(renderComposer());
-
-    fireEvent.click(screen.getByRole("combobox", { name: "引用空间文件" }));
-    await waitFor(() => expect(draftContent.files ?? []).toHaveLength(1));
-    expect(draftContent.files?.[0]).toMatchObject({
-      name: "notes.txt",
-      hostPath: "/Users/vector/Desktop/notes.txt",
-      uploadError:
-        "Prompt file uploads are not supported by this agent runtime."
-    });
-    rerender(renderComposer());
-
-    expect(
-      screen.getByTestId("agent-gui-composer-file-drafts").firstElementChild
-    ).toHaveAttribute("data-upload-error", "true");
-    expect(screen.getByRole("button", { name: "发送" })).toBeDisabled();
-    fireEvent.submit(container.querySelector("form")!);
-    expect(onSubmit).not.toHaveBeenCalled();
   });
 
   it("renders controlled text and image draft content", () => {

--- a/packages/agent/gui/agent-gui/agentGuiNode/AgentComposer.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/AgentComposer.tsx
@@ -151,13 +151,6 @@ export { formatSlashStatusTokenCount };
 export interface WorkspaceReferencePickResult {
   files: readonly WorkspaceFileReference[];
   mentionItems: readonly AgentContextMentionItem[];
-  hostAttachments?: readonly AgentComposerHostAttachment[];
-}
-
-export interface AgentComposerHostAttachment {
-  hostPath: string;
-  name: string;
-  mimeType?: string | null;
 }
 
 export interface AgentComposerProps {
@@ -613,8 +606,6 @@ const MENTION_PALETTE_MIN_HEIGHT_PX = 280;
 const MENTION_PALETTE_MAX_HEIGHT_PX = 320;
 const MENTION_PALETTE_GAP_PX = 8;
 const MENTION_PALETTE_VIEWPORT_PADDING_PX = 8;
-const promptFileUploadUnsupportedError =
-  "Prompt file uploads are not supported by this agent runtime.";
 const EMPTY_CONTEXT_MENTION_PROVIDERS: readonly AgentContextMentionProvider[] =
   [];
 const EMPTY_PROMPT_TIPS: readonly AgentComposerPromptTip[] = [];
@@ -1825,97 +1816,6 @@ export function AgentComposer({
     [onDraftContentChange]
   );
 
-  const addDraftFiles = useCallback(
-    (attachments: readonly AgentComposerHostAttachment[]): void => {
-      if (attachments.length === 0) {
-        return;
-      }
-      const uploadPromptContent = agentActivityRuntime?.uploadPromptContent;
-      const nextFiles = attachments.map((attachment) => ({
-        id: `${Date.now().toString(36)}-${Math.random().toString(36).slice(2)}`,
-        name: attachment.name,
-        mimeType: attachment.mimeType?.trim() || "application/octet-stream",
-        hostPath: attachment.hostPath,
-        uploading: Boolean(uploadPromptContent),
-        ...(uploadPromptContent
-          ? {}
-          : { uploadError: promptFileUploadUnsupportedError })
-      }));
-      const nextDraftFiles = [...draftFilesRef.current, ...nextFiles];
-      draftFilesRef.current = nextDraftFiles;
-      onDraftContentChange({
-        prompt: draftPromptRef.current,
-        images: draftImagesRef.current,
-        files: nextDraftFiles
-      });
-      if (!uploadPromptContent) {
-        return;
-      }
-      for (const draftFile of nextFiles) {
-        void uploadPromptContent({
-          workspaceId,
-          content: [
-            {
-              type: "file",
-              mimeType: draftFile.mimeType,
-              hostPath: draftFile.hostPath,
-              name: draftFile.name,
-              kind: "file"
-            }
-          ]
-        })
-          .then((result) => {
-            const uploadedFile = result.content.find(
-              (block) => block.type === "file"
-            );
-            const uploadedPath = uploadedFile?.path?.trim() ?? "";
-            if (!uploadedPath) {
-              throw new Error("Prompt file upload completed without path.");
-            }
-            const uploadedDraftFiles = draftFilesRef.current.map((file) =>
-              file.id === draftFile.id
-                ? {
-                    id: file.id,
-                    name: uploadedFile?.name ?? file.name,
-                    mimeType: uploadedFile?.mimeType ?? file.mimeType,
-                    path: uploadedPath,
-                    assetId: uploadedFile?.assetId,
-                    sizeBytes: uploadedFile?.sizeBytes,
-                    uploading: false
-                  }
-                : file
-            );
-            draftFilesRef.current = uploadedDraftFiles;
-            onDraftContentChange({
-              prompt: draftPromptRef.current,
-              images: draftImagesRef.current,
-              files: uploadedDraftFiles
-            });
-          })
-          .catch((error: unknown) => {
-            const message =
-              error instanceof Error ? error.message : String(error);
-            const failedDraftFiles = draftFilesRef.current.map((file) =>
-              file.id === draftFile.id
-                ? {
-                    ...file,
-                    uploading: false,
-                    uploadError: message
-                  }
-                : file
-            );
-            draftFilesRef.current = failedDraftFiles;
-            onDraftContentChange({
-              prompt: draftPromptRef.current,
-              images: draftImagesRef.current,
-              files: failedDraftFiles
-            });
-          });
-      }
-    },
-    [agentActivityRuntime, onDraftContentChange, workspaceId]
-  );
-
   const removeDraftFile = useCallback(
     (id: string): void => {
       const nextDraftFiles = draftFilesRef.current.filter(
@@ -1983,11 +1883,8 @@ export function AgentComposer({
       if (result.mentionItems.length > 0) {
         editorHandleRef.current?.insertMentionItems(result.mentionItems);
       }
-      if (result.hostAttachments && result.hostAttachments.length > 0) {
-        addDraftFiles(result.hostAttachments);
-      }
     },
-    [addDraftFiles, agentActivityRuntime, workspaceId]
+    [agentActivityRuntime, workspaceId]
   );
 
   const handleWorkspaceReferencePicker = useCallback(async () => {

--- a/packages/agent/gui/agent-gui/agentGuiNode/AgentGUINode.spec.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/AgentGUINode.spec.tsx
@@ -12,8 +12,15 @@ import { resolve } from "node:path";
 import type { WorkspaceAgentSessionDetailViewModel } from "../../shared/workspaceAgentSessionDetailViewModel";
 import type { AgentHostManagedAgentsState } from "../../shared/contracts/dto";
 import type { WorkspaceFileReferenceAdapter } from "@tutti-os/workspace-file-reference/contracts";
+import type {
+  ReferenceNode,
+  SelectedReference
+} from "@tutti-os/workspace-file-reference/contracts";
+import type { ReferenceSourceAggregator } from "@tutti-os/workspace-file-reference/core";
 import type { WorkspaceLinkAction } from "../../actions/workspaceLinkActions";
 import { MANAGED_AGENT_ICON_URLS } from "../../shared/managedAgentIcons";
+import { AgentActivityHostProvider } from "../../agentActivityHost";
+import type { AgentActivityRuntime } from "../../agentActivityRuntime";
 import { AgentGUINode } from "./AgentGUINode";
 import { resolveAgentGUIHeroIconUrl } from "./AgentGUINodeView";
 import type { AgentContextMentionProvider } from "./agentContextMentionProvider";
@@ -72,6 +79,56 @@ let mockViewModel: AgentGUINodeViewModel;
 
 function createDraft(prompt: string): AgentComposerDraft {
   return { prompt, images: [], files: [] };
+}
+
+function createHostLocalReferenceAggregator(
+  entry: ReferenceNode
+): ReferenceSourceAggregator {
+  return {
+    async listSources() {
+      return [
+        {
+          sourceId: "host-local-file",
+          label: "本地文件",
+          capabilities: {
+            filterable: true,
+            navigable: false,
+            paginated: false,
+            previewable: false,
+            searchable: true
+          }
+        }
+      ];
+    },
+    async listRoot() {
+      return [];
+    },
+    async listChildren() {
+      return { entries: [entry], nextCursor: null };
+    },
+    async search() {
+      return { entries: [], nextCursor: null };
+    },
+    async open() {},
+    async readPreview() {
+      return null;
+    },
+    resolveSelection(node): SelectedReference {
+      return {
+        path: node.ref.nodeId,
+        hostPath: node.ref.nodeId,
+        kind: node.kind,
+        displayName: node.displayName,
+        sourceId: node.ref.sourceId
+      };
+    },
+    async locateTarget() {
+      return null;
+    },
+    getLoadedSource() {
+      return undefined;
+    }
+  };
 }
 
 function textQueuedPrompt(
@@ -4402,6 +4459,81 @@ describe("AgentGUINode", () => {
     );
   });
 
+  it("inserts host-local shared picker selections as uploaded file mention anchors", async () => {
+    const uploadPromptContent = vi.fn(async () => ({
+      content: [
+        {
+          type: "file" as const,
+          path: "/var/cache/tsh/local-assets/room-1/user-1/home.jpg",
+          name: "首页.jpg",
+          kind: "file" as const
+        }
+      ]
+    }));
+    const hostFile: ReferenceNode = {
+      ref: {
+        sourceId: "host-local-file",
+        nodeId: "host-file-handle-1"
+      },
+      kind: "file",
+      displayName: "首页.jpg"
+    };
+    mockViewModel = createViewModel({
+      activeConversationId: "session-1",
+      draftPrompt: "看下 "
+    });
+
+    renderAgentGUINode({
+      workspaceFileReferenceAdapter: null,
+      referenceSourceAggregator: createHostLocalReferenceAggregator(hostFile),
+      agentActivityRuntime: {
+        uploadPromptContent
+      } as unknown as AgentActivityRuntime
+    });
+
+    fireEvent.click(
+      screen.getByRole("combobox", {
+        name: "agentHost.issue.referenceWorkspaceFiles"
+      })
+    );
+    await screen.findByRole("dialog", {
+      name: "agentHost.agentGui.referencePicker.title"
+    });
+    const selectReferenceButton = await screen.findByRole("button", {
+      name: "首页.jpg"
+    });
+    fireEvent.click(selectReferenceButton);
+    fireEvent.click(
+      screen.getByRole("button", {
+        name: "agentHost.agentGui.referencePicker.confirm"
+      })
+    );
+
+    await waitFor(() =>
+      expect(uploadPromptContent).toHaveBeenCalledWith({
+        workspaceId: "room-1",
+        content: [
+          {
+            type: "file",
+            hostPath: "host-file-handle-1",
+            name: "首页.jpg",
+            kind: "file"
+          }
+        ]
+      })
+    );
+    await waitFor(() =>
+      expect(mockUpdateDraftContent).toHaveBeenCalledWith(
+        createDraft(
+          "看下 [@首页.jpg](/var/cache/tsh/local-assets/room-1/user-1/home.jpg) "
+        )
+      )
+    );
+    expect(
+      screen.queryByTestId("agent-gui-composer-file-drafts")
+    ).not.toBeInTheDocument();
+  });
+
   it("opens the shared workspace reference picker with the selected project path revealed", async () => {
     const baseViewModel = createViewModel();
     const loadReferenceTree = vi.fn(
@@ -6887,6 +7019,8 @@ function renderAgentGUINode({
   >(),
   onResize = vi.fn(),
   workspaceFileReferenceAdapter = createWorkspaceFileReferenceAdapter(),
+  referenceSourceAggregator,
+  agentActivityRuntime,
   onShowMessage = vi.fn(),
   onMinimize,
   onToggleMaximize,
@@ -6919,6 +7053,8 @@ function renderAgentGUINode({
   ) => void;
   onResize?: React.ComponentProps<typeof AgentGUINode>["onResize"];
   workspaceFileReferenceAdapter?: WorkspaceFileReferenceAdapter | null;
+  referenceSourceAggregator?: ReferenceSourceAggregator | null;
+  agentActivityRuntime?: AgentActivityRuntime | null;
   onShowMessage?: React.ComponentProps<typeof AgentGUINode>["onShowMessage"];
   onMinimize?: () => void;
   onToggleMaximize?: () => void;
@@ -6950,6 +7086,7 @@ function renderAgentGUINode({
       currentUserId="user-1"
       workspacePath="/workspace"
       workspaceFileReferenceAdapter={workspaceFileReferenceAdapter}
+      referenceSourceAggregator={referenceSourceAggregator}
       agentSettings={{ avoidGroupingEdits: false }}
       title={title}
       state={state}
@@ -6989,8 +7126,20 @@ function renderAgentGUINode({
         {node}
       </section>
     );
+  const nodeWithProviders =
+    agentActivityRuntime === undefined ? (
+      wrappedNode
+    ) : (
+      <AgentActivityHostProvider agentActivityRuntime={agentActivityRuntime}>
+        {wrappedNode}
+      </AgentActivityHostProvider>
+    );
   return render(
-    strictMode ? <StrictMode>{wrappedNode}</StrictMode> : wrappedNode
+    strictMode ? (
+      <StrictMode>{nodeWithProviders}</StrictMode>
+    ) : (
+      nodeWithProviders
+    )
   );
 }
 

--- a/packages/agent/gui/agent-gui/agentGuiNode/AgentGUINodeView.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/AgentGUINodeView.tsx
@@ -837,7 +837,7 @@ export function AgentGUINodeView({
     ((result: WorkspaceReferencePickResult) => void) | null
   >(null);
   const emptyReferencePickResult: WorkspaceReferencePickResult = useMemo(
-    () => ({ files: [], mentionItems: [], hostAttachments: [] }),
+    () => ({ files: [], mentionItems: [] }),
     []
   );
   const hostLocalFileSourceId = "host-local-file";
@@ -913,10 +913,7 @@ export function AgentGUINodeView({
   );
   const confirmWorkspaceReferencePicker = useCallback(
     (refs: WorkspaceFileReference[]) => {
-      settleReferencePicker(
-        { files: refs, mentionItems: [], hostAttachments: [] },
-        refs
-      );
+      settleReferencePicker({ files: refs, mentionItems: [] }, refs);
     },
     [settleReferencePicker]
   );
@@ -925,17 +922,9 @@ export function AgentGUINodeView({
   // mention 插入。agent 收到 `mention://workspace-reference/...` 后经 skill+CLI 按需解析。
   const confirmWorkspaceReferenceBundles = useCallback(
     (result: ReferenceGroupedSelection) => {
-      const hostSourceRefs = result.files.filter(
-        (ref) => ref.sourceId === hostLocalFileSourceId && ref.kind === "file"
-      );
       const workspaceRefs = result.files.filter(
         (ref) => ref.sourceId !== hostLocalFileSourceId
       );
-      const hostAttachments = hostSourceRefs.map((file) => ({
-        hostPath: file.path,
-        name: file.displayName || file.path.split("/").pop() || file.path,
-        mimeType: null
-      }));
       const mentionItems: AgentMentionWorkspaceReferenceItem[] = result.bundles
         .filter((bundle) => bundle.handle != null)
         .map((bundle) => {
@@ -970,7 +959,7 @@ export function AgentGUINodeView({
         });
       // bundle 不再展开文件,仅松散文件计入「最近引用」跟踪。
       settleReferencePicker(
-        { files: workspaceRefs, mentionItems, hostAttachments },
+        { files: result.files, mentionItems },
         workspaceRefs
       );
     },


### PR DESCRIPTION
## What changed
- Removed the `hostAttachments` field from `WorkspaceReferencePickResult`.
- Removed the `AgentComposerHostAttachment` type and `addDraftFiles` flow.
- Kept host-local picker selections in `files` so they upload through `uploadPromptContent` and insert as rich-text file mention anchors with VM paths.
- Added coverage for the shared picker host-local flow and audited that `hostAttachments`, `AgentComposerHostAttachment`, and `addDraftFiles` no longer exist in the repo.

## Why
The host attachment flow rendered picked files as top-of-composer draft attachments. Host-local references should reuse the existing rich-text mention interaction and send VM-readable paths to the agent.

## Risk
Affects agent-gui reference picker confirmation and composer insertion for host-local files. Generic pasted image upload and existing controlled draft file rendering remain in place.

## Verification
- `rg "hostAttachments|AgentComposerHostAttachment|addDraftFiles" -n` returned no matches.
- `npx pnpm@10.11.0 --dir /Users/vector/Documents/CODES/WORK_SPACE_MAIN/tutti --filter @tutti-os/agent-gui exec tsc --noEmit`
- `npx pnpm@10.11.0 --dir /Users/vector/Documents/CODES/WORK_SPACE_MAIN/tutti --filter @tutti-os/agent-gui exec vitest run agent-gui/agentGuiNode/AgentComposer.spec.tsx agent-gui/agentGuiNode/AgentGUINode.spec.tsx`
- `npx pnpm@10.11.0 --dir /Users/vector/Documents/CODES/WORK_SPACE_MAIN/tutti exec oxfmt --check packages/agent/gui/agent-gui/agentGuiNode/AgentComposer.tsx packages/agent/gui/agent-gui/agentGuiNode/AgentGUINodeView.tsx packages/agent/gui/agent-gui/agentGuiNode/AgentComposer.spec.tsx packages/agent/gui/agent-gui/agentGuiNode/AgentGUINode.spec.tsx`
- `npx pnpm@10.11.0 --dir /Users/vector/Documents/CODES/WORK_SPACE_MAIN/tutti --filter @tutti-os/agent-gui exec oxlint agent-gui/agentGuiNode/AgentComposer.tsx agent-gui/agentGuiNode/AgentGUINodeView.tsx agent-gui/agentGuiNode/AgentComposer.spec.tsx agent-gui/agentGuiNode/AgentGUINode.spec.tsx --deny-warnings`
- Pre-commit passed for staged files.

## Known baseline / local pre-push
- `pnpm check:full` during pre-push failed in `test:go`, specifically existing `services/tuttid/service/agent` timeout/model-discovery tests such as `TestServiceCreatePassesPlanModeToRuntime`, `TestServiceCreateDoesNotTreatAuthRequiredAsInstallNeeded`, `TestServiceCreateEmptySessionDoesNotExec`, `TestServiceUpdateVisibleUpdatesRuntimeSession`, and `TestGetComposerOptionsClaudeCodeDiscoversLiveModels`. These are outside the changed agent-gui package surface.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Host-local files picked from the shared reference picker now upload correctly and appear in messages as file mentions.
  * Draft submissions now include the resolved uploaded file reference, instead of leaving host-local selections unhandled.
  * Improved handling when confirming workspace references so selected files and mentions are applied consistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->