### PR TITLE
fix(workspace-terminal): preserve IME composition input

### DIFF
--- a/packages/workspace/terminal/src/react/terminalImeInputGuard.test.ts
+++ b/packages/workspace/terminal/src/react/terminalImeInputGuard.test.ts
@@ -1,0 +1,77 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  createTerminalImeInputGuard,
+  type TerminalImeKeyEvent
+} from "./terminalImeInputGuard.ts";
+
+test("terminal IME guard suppresses terminal input while composition is active", () => {
+  const guard = createTerminalImeInputGuard({});
+
+  guard.handleCompositionStart();
+
+  assert.equal(guard.shouldProcessKeyEvent(keyEvent({ key: "z" })), false);
+  assert.equal(guard.shouldProcessKeyEvent(keyEvent({ key: " " })), false);
+  assert.equal(guard.shouldProcessKeyEvent(keyEvent({ key: "Enter" })), false);
+  assert.equal(
+    guard.shouldProcessKeyEvent(keyEvent({ key: "ArrowDown" })),
+    false
+  );
+  assert.equal(guard.shouldProcessKeyEvent(keyEvent({ key: "Shift" })), true);
+});
+
+test("terminal IME guard allows regular input outside composition", () => {
+  const guard = createTerminalImeInputGuard({});
+
+  assert.equal(guard.shouldProcessKeyEvent(keyEvent({ key: "a" })), true);
+  assert.equal(guard.shouldProcessKeyEvent(keyEvent({ key: "Enter" })), true);
+});
+
+test("terminal IME guard suppresses the key that commits composition", () => {
+  let now = 1_000;
+  const guard = createTerminalImeInputGuard({ now: () => now });
+
+  guard.handleCompositionStart();
+  guard.handleCompositionEnd();
+
+  assert.equal(guard.shouldProcessKeyEvent(keyEvent({ key: "Enter" })), false);
+  assert.equal(guard.shouldProcessKeyEvent(keyEvent({ key: "a" })), true);
+});
+
+test("terminal IME guard does not suppress delayed input after composition", () => {
+  let now = 1_000;
+  const guard = createTerminalImeInputGuard({ now: () => now });
+
+  guard.handleCompositionStart();
+  guard.handleCompositionEnd();
+  now += 100;
+
+  assert.equal(guard.shouldProcessKeyEvent(keyEvent({ key: "a" })), true);
+});
+
+test("terminal IME guard consumes post-composition state for shortcuts", () => {
+  const guard = createTerminalImeInputGuard({});
+
+  guard.handleCompositionStart();
+  guard.handleCompositionEnd();
+
+  assert.equal(
+    guard.shouldProcessKeyEvent(keyEvent({ ctrlKey: true, key: "c" })),
+    true
+  );
+  assert.equal(guard.shouldProcessKeyEvent(keyEvent({ key: "a" })), true);
+});
+
+function keyEvent(
+  overrides: Partial<TerminalImeKeyEvent>
+): TerminalImeKeyEvent {
+  return {
+    altKey: false,
+    ctrlKey: false,
+    isComposing: false,
+    key: "a",
+    metaKey: false,
+    type: "keydown",
+    ...overrides
+  };
+}

--- a/packages/workspace/terminal/src/react/terminalImeInputGuard.ts
+++ b/packages/workspace/terminal/src/react/terminalImeInputGuard.ts
@@ -1,0 +1,100 @@
+const postCompositionSuppressMs = 80;
+
+export interface TerminalImeKeyEvent {
+  altKey: boolean;
+  ctrlKey: boolean;
+  isComposing: boolean;
+  key: string;
+  metaKey: boolean;
+  type: string;
+}
+
+export interface TerminalImeInputGuard {
+  dispose(): void;
+  handleCompositionEnd(): void;
+  handleCompositionStart(): void;
+  shouldProcessKeyEvent(event: TerminalImeKeyEvent): boolean;
+}
+
+export function createTerminalImeInputGuard(input: {
+  now?: () => number;
+  textarea?: HTMLTextAreaElement;
+}): TerminalImeInputGuard {
+  const now = input.now ?? (() => Date.now());
+  let composing = false;
+  let compositionEndedAt: number | null = null;
+
+  const guard: TerminalImeInputGuard = {
+    dispose() {
+      input.textarea?.removeEventListener(
+        "compositionstart",
+        guard.handleCompositionStart
+      );
+      input.textarea?.removeEventListener(
+        "compositionend",
+        guard.handleCompositionEnd
+      );
+    },
+    handleCompositionEnd() {
+      composing = false;
+      compositionEndedAt = now();
+    },
+    handleCompositionStart() {
+      composing = true;
+      compositionEndedAt = null;
+    },
+    shouldProcessKeyEvent(event) {
+      if (!isKeyInputEvent(event)) {
+        return true;
+      }
+      if (isModifierOnlyKey(event.key)) {
+        return true;
+      }
+      if (composing || event.isComposing) {
+        return false;
+      }
+      if (compositionEndedAt === null) {
+        return true;
+      }
+      if (now() - compositionEndedAt > postCompositionSuppressMs) {
+        compositionEndedAt = null;
+        return true;
+      }
+      if (!isPlainKeyEvent(event)) {
+        compositionEndedAt = null;
+        return true;
+      }
+      compositionEndedAt = null;
+      return false;
+    }
+  };
+
+  input.textarea?.addEventListener(
+    "compositionstart",
+    guard.handleCompositionStart
+  );
+  input.textarea?.addEventListener(
+    "compositionend",
+    guard.handleCompositionEnd
+  );
+
+  return guard;
+}
+
+function isKeyInputEvent(event: TerminalImeKeyEvent): boolean {
+  return event.type === "keydown" || event.type === "keypress";
+}
+
+function isPlainKeyEvent(event: TerminalImeKeyEvent): boolean {
+  return !event.altKey && !event.ctrlKey && !event.metaKey;
+}
+
+function isModifierOnlyKey(key: string): boolean {
+  return (
+    key === "Alt" ||
+    key === "AltGraph" ||
+    key === "Control" ||
+    key === "Meta" ||
+    key === "Shift"
+  );
+}

--- a/packages/workspace/terminal/src/react/terminalSurfaceRuntime.ts
+++ b/packages/workspace/terminal/src/react/terminalSurfaceRuntime.ts
@@ -16,6 +16,7 @@ import type { TerminalNodeFeature } from "../core/feature.ts";
 import { createTerminalScreenStateCache } from "../core/index.ts";
 import type { TerminalSurfaceDiagnostics } from "../core/sessionDiagnostics.ts";
 import { createTerminalFileLinkProvider } from "./terminalFileLinkProvider.ts";
+import { createTerminalImeInputGuard } from "./terminalImeInputGuard.ts";
 import { resolveTerminalSurfaceOutputPlan } from "./terminalSurfaceOutputPlan.ts";
 import { resolveTerminalSurfaceResizePlan } from "./terminalSurfaceResizePlan.ts";
 import { resolveTerminalSurfaceScreenCachePlan } from "./terminalSurfaceScreenCachePlan.ts";
@@ -113,6 +114,12 @@ export function createTerminalSurfaceRuntime(input: {
     })
   );
   terminal.open(input.container);
+  const imeInputGuard = createTerminalImeInputGuard({
+    textarea: terminal.textarea
+  });
+  terminal.attachCustomKeyEventHandler((event) =>
+    imeInputGuard.shouldProcessKeyEvent(event)
+  );
 
   const dataSubscription = terminal.onData((data) => {
     input.onUserInput(data);
@@ -188,6 +195,7 @@ export function createTerminalSurfaceRuntime(input: {
       binarySubscription.dispose();
       writeParsedSubscription.dispose();
       fileLinkDisposable.dispose();
+      imeInputGuard.dispose();
       clearInitialLayoutSync();
       clearPendingReveal();
       const hasPendingWrites =


### PR DESCRIPTION
## Summary
- add an IME input guard around the xterm surface to keep composition keystrokes from being sent as terminal input
- wire the guard into terminal runtime disposal and xterm custom key handling
- cover active composition, commit-key suppression, delayed input, and shortcut behavior

## Test plan
- pnpm --filter @tutti-os/workspace-terminal test
- pnpm --filter @tutti-os/workspace-terminal typecheck
- pnpm exec oxlint packages/workspace/terminal/src/react/terminalSurfaceRuntime.ts packages/workspace/terminal/src/react/terminalImeInputGuard.ts packages/workspace/terminal/src/react/terminalImeInputGuard.test.ts --deny-warnings
- pnpm exec oxfmt --check packages/workspace/terminal/src/react/terminalSurfaceRuntime.ts packages/workspace/terminal/src/react/terminalImeInputGuard.ts packages/workspace/terminal/src/react/terminalImeInputGuard.test.ts
- pnpm check:changed --tail-lines 80
- pnpm check:full

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved terminal text input handling for IME users, making composition-based typing behave more reliably.
  * Added support for smoother transitions after composition ends, helping prevent accidental duplicate or missed input.

* **Bug Fixes**
  * Reduced cases where keyboard shortcuts or rapid follow-up keystrokes could be incorrectly processed during IME input.
  * Added coverage for key input behavior to help keep terminal typing consistent across composition states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->