### PR TITLE
feat(cli): add integration-only command visibility

### DIFF
--- a/apps/cli/internal/app/run.go
+++ b/apps/cli/internal/app/run.go
@@ -107,7 +107,9 @@ func runDynamic(ctx context.Context, commandName string, opts options, args []st
 		return 1
 	}
 	invokeContext := cliInvokeContextFromEnv()
-	capabilities, err := client.ListCapabilitiesForWorkspace(ctx, invokeContext.WorkspaceID)
+	capabilities, err := client.ListCapabilitiesForWorkspaceWithOptions(ctx, invokeContext.WorkspaceID, daemon.CapabilityListOptions{
+		IncludeIntegration: includeIntegrationCapabilitiesFromEnv(),
+	})
 	if err != nil {
 		fmt.Fprintf(stderr, "%s %s: %v\n", commandName, strings.Join(args, " "), err)
 		return 1
@@ -158,13 +160,20 @@ func runHelp(ctx context.Context, commandName string, stdout io.Writer) int {
 	client, err := discoverClient()
 	if err == nil {
 		invokeContext := cliInvokeContextFromEnv()
-		capabilities, listErr := client.ListCapabilitiesForWorkspace(ctx, invokeContext.WorkspaceID)
+		capabilities, listErr := client.ListCapabilitiesForWorkspaceWithOptions(ctx, invokeContext.WorkspaceID, daemon.CapabilityListOptions{
+			IncludeIntegration: includeIntegrationCapabilitiesFromEnv(),
+		})
 		if listErr == nil {
 			commands = capabilities.Commands
 		}
 	}
 	printHelp(stdout, commandName, commands)
 	return 0
+}
+
+func includeIntegrationCapabilitiesFromEnv() bool {
+	return strings.TrimSpace(os.Getenv("TUTTI_APP_ID")) != "" &&
+		strings.TrimSpace(os.Getenv("TUTTI_CLI")) != ""
 }
 
 func cliInvokeContextFromEnv() daemon.InvokeContext {
@@ -396,6 +405,7 @@ func printHelp(stdout io.Writer, commandName string, commands []daemon.Capabilit
 	rows := []helpCommandRow{{Name: "status", Summary: "Show local tuttid status"}}
 	rows = append(rows, rootHelpRows(commands)...)
 	printHelpRows(stdout, rows)
+	printIntegrationOnlyNotice(stdout, commands)
 }
 
 func printCommandPrefixHelp(stdout io.Writer, commandName string, prefix []string, commands []daemon.Capability) bool {
@@ -407,6 +417,7 @@ func printCommandPrefixHelp(stdout io.Writer, commandName string, prefix []strin
 	fmt.Fprintln(stdout)
 	fmt.Fprintln(stdout, "Commands:")
 	printHelpRows(stdout, prefixHelpRows(prefix, matches))
+	printIntegrationOnlyNotice(stdout, matches)
 	fmt.Fprintln(stdout)
 	fmt.Fprintf(stdout, "Use \"%s %s <command> --help\" for command details.\n", commandName, strings.Join(prefix, " "))
 	printDocumentationHints(stdout, matches)
@@ -434,6 +445,7 @@ func printDynamicCommandHelp(stdout io.Writer, commandName string, command daemo
 		}
 		fmt.Fprintln(stdout, command.Description)
 	}
+	printIntegrationOnlyNotice(stdout, []daemon.Capability{command})
 	if len(flags) == 0 {
 		printDocumentationHints(stdout, []daemon.Capability{command})
 		return
@@ -461,15 +473,18 @@ func printDynamicCommandHelp(stdout io.Writer, commandName string, command daemo
 }
 
 type helpCommandRow struct {
-	Name    string
-	Summary string
+	Name                    string
+	Summary                 string
+	IntegrationOnly         bool
+	IncludesIntegrationOnly bool
 }
 
 func rootHelpRows(commands []daemon.Capability) []helpCommandRow {
 	type group struct {
-		count       int
-		summary     string
-		description string
+		count            int
+		integrationCount int
+		summary          string
+		description      string
 	}
 	groups := map[string]group{}
 	for _, command := range commands {
@@ -482,6 +497,9 @@ func rootHelpRows(commands []daemon.Capability) []helpCommandRow {
 		}
 		current := groups[name]
 		current.count++
+		if isIntegrationCapability(command) {
+			current.integrationCount++
+		}
 		if len(command.Path) == 1 && current.summary == "" {
 			current.summary = command.Summary
 		}
@@ -505,7 +523,12 @@ func rootHelpRows(commands []daemon.Capability) []helpCommandRow {
 		if item.description != "" && item.count > 0 {
 			summary = fmt.Sprintf("%s  %d commands", item.description, item.count)
 		}
-		rows = append(rows, helpCommandRow{Name: name, Summary: summary})
+		rows = append(rows, helpCommandRow{
+			Name:                    name,
+			Summary:                 summary,
+			IntegrationOnly:         item.count > 0 && item.integrationCount == item.count,
+			IncludesIntegrationOnly: item.integrationCount > 0 && item.integrationCount < item.count,
+		})
 	}
 	return rows
 }
@@ -543,8 +566,9 @@ func matchingPrefixCommands(commands []daemon.Capability, prefix []string) []dae
 
 func prefixHelpRows(prefix []string, commands []daemon.Capability) []helpCommandRow {
 	type group struct {
-		count   int
-		summary string
+		count            int
+		integrationCount int
+		summary          string
 	}
 	groups := map[string]group{}
 	for _, command := range commands {
@@ -555,6 +579,9 @@ func prefixHelpRows(prefix []string, commands []daemon.Capability) []helpCommand
 		name := remaining[0]
 		current := groups[name]
 		current.count++
+		if isIntegrationCapability(command) {
+			current.integrationCount++
+		}
 		if len(remaining) == 1 && current.summary == "" {
 			current.summary = command.Summary
 		}
@@ -572,7 +599,12 @@ func prefixHelpRows(prefix []string, commands []daemon.Capability) []helpCommand
 		if summary == "" {
 			summary = fmt.Sprintf("%d commands", item.count)
 		}
-		rows = append(rows, helpCommandRow{Name: name, Summary: summary})
+		rows = append(rows, helpCommandRow{
+			Name:                    name,
+			Summary:                 summary,
+			IntegrationOnly:         item.count > 0 && item.integrationCount == item.count,
+			IncludesIntegrationOnly: item.integrationCount > 0 && item.integrationCount < item.count,
+		})
 	}
 	return rows
 }
@@ -585,8 +617,36 @@ func printHelpRows(stdout io.Writer, rows []helpCommandRow) {
 		}
 	}
 	for _, row := range rows {
-		fmt.Fprintf(stdout, "  %-*s  %s\n", width, row.Name, row.Summary)
+		summary := row.Summary
+		switch {
+		case row.IntegrationOnly:
+			summary += " [integration-only]"
+		case row.IncludesIntegrationOnly:
+			summary += " [includes integration-only]"
+		}
+		fmt.Fprintf(stdout, "  %-*s  %s\n", width, row.Name, summary)
 	}
+}
+
+func printIntegrationOnlyNotice(stdout io.Writer, commands []daemon.Capability) {
+	if !hasIntegrationCapability(commands) {
+		return
+	}
+	fmt.Fprintln(stdout)
+	fmt.Fprintln(stdout, "Integration-only commands are app-runtime plumbing. Do not expose or forward them as ordinary user or Agent actions; prefer public app commands.")
+}
+
+func hasIntegrationCapability(commands []daemon.Capability) bool {
+	for _, command := range commands {
+		if isIntegrationCapability(command) {
+			return true
+		}
+	}
+	return false
+}
+
+func isIntegrationCapability(command daemon.Capability) bool {
+	return strings.TrimSpace(command.Visibility) == "integration"
 }
 
 func printDocumentationHints(stdout io.Writer, commands []daemon.Capability) {

--- a/apps/cli/internal/app/run_test.go
+++ b/apps/cli/internal/app/run_test.go
@@ -72,6 +72,73 @@ func TestCliInvokeContextFromEnvIncludesAgentSessionID(t *testing.T) {
 	}
 }
 
+func TestRunHelpIncludesIntegrationCapabilitiesInsideAppRuntime(t *testing.T) {
+	var sawCapabilitiesRequest bool
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if r.URL.Path != "/v1/cli/capabilities" {
+			http.NotFound(w, r)
+			return
+		}
+		sawCapabilitiesRequest = true
+		if r.URL.Query().Get("workspaceID") != "ws-1" {
+			t.Fatalf("workspaceID query = %q", r.URL.RawQuery)
+		}
+		if r.URL.Query().Get("includeIntegration") != "true" {
+			t.Fatalf("includeIntegration query = %q", r.URL.RawQuery)
+		}
+		if r.URL.Query().Get("includeHidden") != "" {
+			t.Fatalf("includeHidden query = %q", r.URL.RawQuery)
+		}
+		_, _ = w.Write([]byte(`{"commands":[{"id":"workspace-apps.app.open","path":["app","open"],"summary":"Open app","visibility":"integration","output":{"defaultMode":"json","json":true},"source":{"kind":"builtin"}}]}`))
+	}))
+	defer server.Close()
+
+	writeEndpoint(t, server.URL, "token-1")
+	t.Setenv("TUTTI_APP_ID", "automation-app")
+	t.Setenv("TUTTI_CLI", "/tmp/tutti")
+	t.Setenv("TUTTI_WORKSPACE_ID", "ws-1")
+
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	if code := Run(t.Context(), []string{"--help"}, &stdout, &stderr); code != 0 {
+		t.Fatalf("code = %d, stderr = %s", code, stderr.String())
+	}
+	if !sawCapabilitiesRequest {
+		t.Fatal("capabilities request was not sent")
+	}
+	if !strings.Contains(stdout.String(), "integration-only") || !strings.Contains(stdout.String(), "Do not expose or forward") {
+		t.Fatalf("stdout = %q", stdout.String())
+	}
+}
+
+func TestRunHelpDoesNotIncludeIntegrationCapabilitiesWithoutAppCLIContract(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if r.URL.Path != "/v1/cli/capabilities" {
+			http.NotFound(w, r)
+			return
+		}
+		if r.URL.Query().Get("includeIntegration") != "" {
+			t.Fatalf("includeIntegration query = %q", r.URL.RawQuery)
+		}
+		if r.URL.Query().Get("includeHidden") != "" {
+			t.Fatalf("includeHidden query = %q", r.URL.RawQuery)
+		}
+		_, _ = w.Write([]byte(`{"commands":[]}`))
+	}))
+	defer server.Close()
+
+	writeEndpoint(t, server.URL, "token-1")
+	t.Setenv("TUTTI_APP_ID", "draft-app")
+
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	if code := Run(t.Context(), []string{"--help"}, &stdout, &stderr); code != 0 {
+		t.Fatalf("code = %d, stderr = %s", code, stderr.String())
+	}
+}
+
 func TestRunStatusJSON(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path != "/v1/health" {

--- a/apps/cli/internal/daemon/client.go
+++ b/apps/cli/internal/daemon/client.go
@@ -44,9 +44,15 @@ type Capability struct {
 	Path        []string         `json:"path"`
 	Summary     string           `json:"summary"`
 	Description string           `json:"description,omitempty"`
+	Visibility  string           `json:"visibility,omitempty"`
 	InputSchema map[string]any   `json:"inputSchema,omitempty"`
 	Output      CapabilityOutput `json:"output"`
 	Source      CapabilitySource `json:"source"`
+}
+
+type CapabilityListOptions struct {
+	IncludeHidden      bool
+	IncludeIntegration bool
 }
 
 type CapabilitySource struct {
@@ -125,11 +131,27 @@ func (client *Client) ListCapabilities(ctx context.Context) (CapabilityList, err
 }
 
 func (client *Client) ListCapabilitiesForWorkspace(ctx context.Context, workspaceID string) (CapabilityList, error) {
+	return client.ListCapabilitiesForWorkspaceWithHidden(ctx, workspaceID, false)
+}
+
+func (client *Client) ListCapabilitiesForWorkspaceWithHidden(ctx context.Context, workspaceID string, includeHidden bool) (CapabilityList, error) {
+	return client.ListCapabilitiesForWorkspaceWithOptions(ctx, workspaceID, CapabilityListOptions{IncludeHidden: includeHidden})
+}
+
+func (client *Client) ListCapabilitiesForWorkspaceWithOptions(ctx context.Context, workspaceID string, options CapabilityListOptions) (CapabilityList, error) {
 	var result CapabilityList
 	path := cliCapabilitiesPath
+	query := url.Values{}
 	if strings.TrimSpace(workspaceID) != "" {
-		query := url.Values{}
 		query.Set("workspaceID", strings.TrimSpace(workspaceID))
+	}
+	if options.IncludeHidden {
+		query.Set("includeHidden", "true")
+	}
+	if options.IncludeIntegration {
+		query.Set("includeIntegration", "true")
+	}
+	if len(query) > 0 {
 		path += "?" + query.Encode()
 	}
 	if err := client.DoJSON(ctx, http.MethodGet, path, nil, &result); err != nil {

--- a/docs/conventions/tutti-cli-contract.md
+++ b/docs/conventions/tutti-cli-contract.md
@@ -41,9 +41,23 @@ Keep these semantics stable unless the app CLI manifest version changes:
 - app handlers receive HTTP `POST` requests under `/tutti/cli/*`
 - app handlers return the existing `CliCommandOutput` shape
 - app command output is validated against the manifest-declared output contract
+- app commands may declare optional `visibility: "integration"` to stay out of
+  ordinary user and Agent discovery while remaining available to app-runtime
+  integrations; omitted visibility is `public`
 
 Do not require migration for existing app manifests when changing builtin CLI
 implementation internals.
+
+`visibility` is a discovery hint, not an authorization boundary. Use it to keep
+integration-only commands out of `tutti --help`, Agent command guides, and
+ordinary command matching. Do not use it for secrets, privileged actions, or
+operations that must be blocked when a user already knows the command.
+
+App-runtime CLI discovery should request integration-only commands without
+skipping provider availability filters. Use the CLI capabilities
+`includeIntegration` query for that path. Reserve `includeHidden` for metadata
+or debugging paths that intentionally need both provider-filtered and
+visibility-filtered capabilities.
 
 ## Builtin Command Source Of Truth
 
@@ -67,6 +81,12 @@ it from the spec.
 
 The framework must return the existing `cliservice.Command` type. The registry,
 OpenAPI route shape, and app CLI registry remain separate.
+
+Builtin capabilities may declare `Capability.Visibility` as `integration` when
+the command is intended for app-runtime integrations rather than ordinary user
+or Agent discovery. Omitted visibility defaults to `public`. For example,
+`workspace-apps.app.open` is integration-only so the model does not discover it
+as a normal user-facing command.
 
 ## Command Kinds
 

--- a/packages/appcli/core/capability.go
+++ b/packages/appcli/core/capability.go
@@ -14,6 +14,7 @@ func BuildCommands(manifest Manifest, options CommandBuildOptions) []Command {
 				Path:        append([]string{manifest.Scope}, command.Path...),
 				Summary:     strings.TrimSpace(command.Summary),
 				Description: strings.TrimSpace(command.Description),
+				Visibility:  NormalizeVisibility(command.Visibility),
 				InputSchema: CloneSchema(command.InputSchema),
 				Output: CapabilityOutput{
 					DefaultMode: command.Output.DefaultMode,

--- a/packages/appcli/core/manifest.go
+++ b/packages/appcli/core/manifest.go
@@ -18,6 +18,11 @@ const (
 	MaxTimeoutMs          = 600000
 )
 
+const (
+	CommandVisibilityPublic      CommandVisibility = "public"
+	CommandVisibilityIntegration CommandVisibility = "integration"
+)
+
 var segmentPattern = regexp.MustCompile(`^[a-z0-9](?:[a-z0-9-]*[a-z0-9])?$`)
 
 type Manifest struct {
@@ -36,6 +41,7 @@ type ManifestCommand struct {
 	Path        []string               `json:"path"`
 	Summary     string                 `json:"summary"`
 	Description string                 `json:"description,omitempty"`
+	Visibility  CommandVisibility      `json:"visibility,omitempty"`
 	InputSchema map[string]any         `json:"inputSchema,omitempty"`
 	Output      ManifestCommandOutput  `json:"output"`
 	Handler     ManifestCommandHandler `json:"handler"`
@@ -125,6 +131,9 @@ func ValidateManifest(manifest Manifest) error {
 		if strings.TrimSpace(command.Summary) == "" {
 			return fmt.Errorf("cli manifest %s.summary is required", location)
 		}
+		if err := validateVisibility(command.Visibility, location+".visibility"); err != nil {
+			return err
+		}
 		if err := validateInputSchema(command.InputSchema, location+".inputSchema"); err != nil {
 			return err
 		}
@@ -136,6 +145,26 @@ func ValidateManifest(manifest Manifest) error {
 		}
 	}
 	return nil
+}
+
+func NormalizeVisibility(visibility CommandVisibility) CommandVisibility {
+	switch CommandVisibility(strings.TrimSpace(string(visibility))) {
+	case "", CommandVisibilityPublic:
+		return CommandVisibilityPublic
+	case CommandVisibilityIntegration:
+		return CommandVisibilityIntegration
+	default:
+		return visibility
+	}
+}
+
+func validateVisibility(visibility CommandVisibility, location string) error {
+	switch NormalizeVisibility(visibility) {
+	case CommandVisibilityPublic, CommandVisibilityIntegration:
+		return nil
+	default:
+		return fmt.Errorf("cli manifest %s must be public or integration", location)
+	}
 }
 
 func isSupportedManifestSchemaVersion(schemaVersion string) bool {

--- a/packages/appcli/core/manifest_test.go
+++ b/packages/appcli/core/manifest_test.go
@@ -18,6 +18,23 @@ func TestValidateManifestRejectsReservedHandlerPath(t *testing.T) {
 	}
 }
 
+func TestValidateManifestRejectsUnknownVisibility(t *testing.T) {
+	err := ValidateManifest(Manifest{
+		SchemaVersion: ManifestSchemaVersion,
+		Scope:         "automation",
+		Commands: []ManifestCommand{{
+			Path:       []string{"run"},
+			Summary:    "Run automation",
+			Visibility: "private",
+			Output:     ManifestCommandOutput{DefaultMode: OutputModeJSON, JSON: true},
+			Handler:    ManifestCommandHandler{Kind: "http", Method: "POST", Path: "/tutti/cli/run"},
+		}},
+	})
+	if err == nil {
+		t.Fatal("ValidateManifest() error = nil, want visibility error")
+	}
+}
+
 func TestBuildCommandsBuildsAppCapability(t *testing.T) {
 	manifest := Manifest{
 		SchemaVersion: ManifestSchemaVersion,
@@ -27,6 +44,7 @@ func TestBuildCommandsBuildsAppCapability(t *testing.T) {
 			Path:        []string{"run"},
 			Summary:     "Run automation",
 			Description: "Runs a job",
+			Visibility:  CommandVisibilityIntegration,
 			InputSchema: map[string]any{"type": "object", "properties": map[string]any{"name": map[string]any{"type": "string"}}},
 			Output:      ManifestCommandOutput{DefaultMode: OutputModeJSON, JSON: true},
 			Handler:     ManifestCommandHandler{Kind: "http", Method: "POST", Path: "/tutti/cli/run"},
@@ -51,5 +69,25 @@ func TestBuildCommandsBuildsAppCapability(t *testing.T) {
 	}
 	if capability.Source.AppID != "automation-app" || capability.Source.CLIDescription != "Automation commands" {
 		t.Fatalf("capability source = %#v", capability.Source)
+	}
+	if capability.Visibility != CommandVisibilityIntegration {
+		t.Fatalf("capability visibility = %q", capability.Visibility)
+	}
+}
+
+func TestBuildCommandsDefaultsVisibilityToPublic(t *testing.T) {
+	commands := BuildCommands(Manifest{
+		SchemaVersion: ManifestSchemaVersion,
+		Scope:         "automation",
+		Commands: []ManifestCommand{{
+			Path:    []string{"run"},
+			Summary: "Run automation",
+			Output:  ManifestCommandOutput{DefaultMode: OutputModeJSON, JSON: true},
+			Handler: ManifestCommandHandler{Kind: "http", Method: "POST", Path: "/tutti/cli/run"},
+		}},
+	}, CommandBuildOptions{AppID: "automation-app"})
+
+	if len(commands) != 1 || commands[0].Capability.Visibility != CommandVisibilityPublic {
+		t.Fatalf("commands = %#v", commands)
 	}
 }

--- a/packages/appcli/core/scope.go
+++ b/packages/appcli/core/scope.go
@@ -44,6 +44,10 @@ type RegisteredApp struct {
 	Commands []Command
 }
 
+type CapabilityListOptions struct {
+	IncludeIntegration bool
+}
+
 type CommandRef struct {
 	AppID     string
 	CommandID string
@@ -123,9 +127,13 @@ func (s *ScopeSet) Remove(appID string) {
 	s.recompute()
 }
 
-func (s *ScopeSet) Capabilities() []Capability {
+func (s *ScopeSet) Capabilities(options ...CapabilityListOptions) []Capability {
 	if s == nil || len(s.entries) == 0 {
 		return []Capability{}
+	}
+	includeIntegration := false
+	if len(options) > 0 {
+		includeIntegration = options[0].IncludeIntegration
 	}
 	appIDs := make([]string, 0, len(s.entries))
 	for appID := range s.entries {
@@ -139,6 +147,9 @@ func (s *ScopeSet) Capabilities() []Capability {
 			continue
 		}
 		for _, command := range entry.Commands {
+			if !includeIntegration && NormalizeVisibility(command.Capability.Visibility) == CommandVisibilityIntegration {
+				continue
+			}
 			result = append(result, command.Capability)
 		}
 	}

--- a/packages/appcli/core/scope_test.go
+++ b/packages/appcli/core/scope_test.go
@@ -45,3 +45,28 @@ func TestScopeSetReservedScopeWarningsDoNotExposeCommands(t *testing.T) {
 		t.Fatalf("capabilities = %#v", capabilities)
 	}
 }
+
+func TestScopeSetHidesIntegrationCommandsFromDefaultCapabilities(t *testing.T) {
+	scopeSet := NewScopeSet(ScopeSetOptions{})
+	scopeSet.Upsert(RegisteredApp{
+		AppID: "automation-app",
+		Scope: "automation",
+		Commands: []Command{
+			{Capability: Capability{ID: "app.automation.automation.list", Visibility: CommandVisibilityPublic}},
+			{Capability: Capability{ID: "app.automation.automation.internal-sync", Visibility: CommandVisibilityIntegration}},
+		},
+	})
+
+	capabilities := scopeSet.Capabilities()
+	if len(capabilities) != 1 || capabilities[0].ID != "app.automation.automation.list" {
+		t.Fatalf("capabilities = %#v", capabilities)
+	}
+
+	capabilities = scopeSet.Capabilities(CapabilityListOptions{IncludeIntegration: true})
+	if len(capabilities) != 2 {
+		t.Fatalf("capabilities with integration = %#v", capabilities)
+	}
+	if _, command, ok := scopeSet.Command("app.automation.automation.internal-sync"); !ok || command.Capability.ID == "" {
+		t.Fatalf("integration command lookup failed: %#v", command)
+	}
+}

--- a/packages/appcli/core/types.go
+++ b/packages/appcli/core/types.go
@@ -9,6 +9,8 @@ const (
 	OutputModeJSON  OutputMode = "json"
 )
 
+type CommandVisibility string
+
 type TableColumn struct {
 	Key   string
 	Label string
@@ -46,6 +48,7 @@ type Capability struct {
 	Path        []string
 	Summary     string
 	Description string
+	Visibility  CommandVisibility
 	InputSchema map[string]any
 	Output      CapabilityOutput
 	Source      CapabilitySource

--- a/packages/clients/tuttid-ts/src/generated/index.ts
+++ b/packages/clients/tuttid-ts/src/generated/index.ts
@@ -221,6 +221,7 @@ export type {
   CliCapabilityOutput,
   CliCapabilitySource,
   CliCapabilitySourceKind,
+  CliCapabilityVisibility,
   CliCommandId,
   CliCommandOutput,
   ClientOptions,

--- a/packages/clients/tuttid-ts/src/generated/types.gen.ts
+++ b/packages/clients/tuttid-ts/src/generated/types.gen.ts
@@ -72,6 +72,8 @@ export type CliCapabilitySource = {
   documentationPath?: string | null;
 };
 
+export type CliCapabilityVisibility = "public" | "integration";
+
 /**
  * Stable command metadata exposed by the local CLI capability protocol.
  */
@@ -92,6 +94,7 @@ export type CliCapability = {
    * Optional longer human-readable command description.
    */
   description?: string | null;
+  visibility?: CliCapabilityVisibility;
   /**
    * Optional JSON Schema fragment describing accepted command input.
    */
@@ -1986,9 +1989,13 @@ export type ListCliCapabilitiesData = {
      */
     workspaceID?: string;
     /**
-     * Include capabilities hidden from CLI command discovery by provider availability filters. Intended for metadata consumers, not command routing.
+     * Include capabilities hidden from ordinary CLI command discovery by provider availability filters and command visibility. Intended for metadata consumers, not ordinary user command routing.
      */
     includeHidden?: boolean;
+    /**
+     * Include integration-only commands while preserving provider availability filters. Intended for app-runtime integrations.
+     */
+    includeIntegration?: boolean;
   };
   url: "/v1/cli/capabilities";
 };

--- a/packages/clients/tuttid-ts/src/index.test.ts
+++ b/packages/clients/tuttid-ts/src/index.test.ts
@@ -13,6 +13,7 @@ import {
   type ApiErrorResponse,
   type AgentProviderComposerOptionsResponse,
   type AppReferenceListResponse,
+  type CliCapabilitiesResponse,
   type IssueManagerReferenceSearchResponse,
   type ListWorkspacesResponse,
   type WorkspaceFilePreviewResponse
@@ -135,6 +136,64 @@ test("shared tuttid client forwards bearer auth tokens", async () => {
 
   await client.getHealth();
   assert.equal(authorizationHeader, "Bearer desktop-session-token");
+});
+
+test("shared tuttid client lists CLI capabilities with discovery options", async () => {
+  let requestPath = "";
+  let requestQueryEntries: Record<string, string> = {};
+
+  const client = createTuttidClient({
+    fetch: async (input, init) => {
+      const request =
+        input instanceof Request ? input : new Request(input, init);
+      const url = new URL(request.url);
+      requestPath = url.pathname;
+      requestQueryEntries = Object.fromEntries(url.searchParams.entries());
+
+      return new Response(
+        JSON.stringify({
+          commands: [
+            {
+              id: "workspace-apps.app.open",
+              path: ["app", "open"],
+              summary: "Open app",
+              visibility: "integration",
+              output: { defaultMode: "json", json: true },
+              source: { kind: "builtin" }
+            }
+          ]
+        }),
+        {
+          status: 200,
+          headers: { "content-type": "application/json" }
+        }
+      );
+    }
+  });
+
+  const response = await client.listCliCapabilities("ws-1", {
+    includeHidden: true,
+    includeIntegration: true
+  });
+
+  assert.equal(requestPath, "/v1/cli/capabilities");
+  assert.deepEqual(requestQueryEntries, {
+    includeHidden: "true",
+    includeIntegration: "true",
+    workspaceID: "ws-1"
+  });
+  assert.deepEqual(response, {
+    commands: [
+      {
+        id: "workspace-apps.app.open",
+        path: ["app", "open"],
+        summary: "Open app",
+        visibility: "integration",
+        output: { defaultMode: "json", json: true },
+        source: { kind: "builtin" }
+      }
+    ]
+  } satisfies CliCapabilitiesResponse);
 });
 
 test("shared tuttid client creates workspace agent sessions with bearer auth", async () => {

--- a/packages/clients/tuttid-ts/src/tuttidClient.ts
+++ b/packages/clients/tuttid-ts/src/tuttidClient.ts
@@ -119,7 +119,8 @@ export function createTuttidClient(
         client,
         query: {
           ...(workspaceID ? { workspaceID } : {}),
-          ...(options?.includeHidden ? { includeHidden: true } : {})
+          ...(options?.includeHidden ? { includeHidden: true } : {}),
+          ...(options?.includeIntegration ? { includeIntegration: true } : {})
         }
       });
       return unwrapData(response, "CLI capabilities request failed.");

--- a/packages/clients/tuttid-ts/src/tuttidClientTypes.ts
+++ b/packages/clients/tuttid-ts/src/tuttidClientTypes.ts
@@ -126,7 +126,7 @@ export type TuttidTrackEventsRequest = TrackEventsRequest;
 export interface TuttidClient {
   listCliCapabilities(
     workspaceID?: string,
-    options?: { includeHidden?: boolean }
+    options?: { includeHidden?: boolean; includeIntegration?: boolean }
   ): Promise<CliCapabilitiesResponse>;
   listWorkspaceAppMentionCandidates(
     workspaceID: string

--- a/packages/workspace/app-release-tools/bin/build-tutti-app-release.mjs
+++ b/packages/workspace/app-release-tools/bin/build-tutti-app-release.mjs
@@ -254,9 +254,19 @@ function validateCLICommand(command, label, scope, seenPaths) {
   }
   seenPaths.add(pathKey);
   requireNonEmpty(command.summary, `${label}.summary`);
+  validateCLIVisibility(command.visibility, `${label}.visibility`);
   validateCLIInputSchema(command.inputSchema, `${label}.inputSchema`);
   validateCLIOutput(command.output, `${label}.output`);
   validateCLIHandler(command.handler, `${label}.handler`);
+}
+
+function validateCLIVisibility(visibility, label) {
+  if (visibility === undefined) {
+    return;
+  }
+  if (!["public", "integration"].includes(visibility)) {
+    throw new Error(`${label} must be public or integration`);
+  }
 }
 
 function validateCLIInputSchema(schema, label) {

--- a/services/tuttid/api/daemon_app_mentions_test.go
+++ b/services/tuttid/api/daemon_app_mentions_test.go
@@ -96,6 +96,32 @@ func TestDaemonAPIGeneratedRoutesListWorkspaceAppMentionCandidates(t *testing.T)
 	}
 }
 
+func TestWorkspaceAppMentionCLIAppsExcludeIntegrationCapabilities(t *testing.T) {
+	appCommands := &workspaceAppMentionDynamicCommands{}
+	registry := &cliservice.Registry{AppCommands: appCommands}
+
+	appsByID := workspaceAppMentionCLIAppsByID(context.Background(), registry, "workspace-1")
+
+	if len(appCommands.contexts) != 1 {
+		t.Fatalf("contexts = %#v, want one call", appCommands.contexts)
+	}
+	contextValue := appCommands.contexts[0]
+	if !contextValue.SkipCapabilityFilters {
+		t.Fatalf("SkipCapabilityFilters = false, want true for metadata path")
+	}
+	if contextValue.IncludeIntegrationCapabilities {
+		t.Fatalf("IncludeIntegrationCapabilities = true, want false for mention metadata")
+	}
+
+	app := appsByID["automation-app"]
+	if app.metadata.CommandCount != 1 {
+		t.Fatalf("command count = %d, want only public command", app.metadata.CommandCount)
+	}
+	if len(app.metadata.CommandPaths) != 1 || app.metadata.CommandPaths[0] != "automation list" {
+		t.Fatalf("command paths = %#v, want only public list command", app.metadata.CommandPaths)
+	}
+}
+
 type workspaceAppMentionTestCLIProvider struct {
 	capabilities []cliservice.Capability
 	filterCalls  int
@@ -167,5 +193,39 @@ func workspaceAppMentionTestApp(appID string, name string, description string, i
 		Installation: installation,
 		IconURL:      &iconURL,
 		Runtime:      workspacebiz.AppRuntimeState{Status: workspacebiz.AppRuntimeStatusIdle},
+	}
+}
+
+type workspaceAppMentionDynamicCommands struct {
+	contexts []cliservice.InvokeContext
+}
+
+func (f *workspaceAppMentionDynamicCommands) Capabilities(_ context.Context, contextValue cliservice.InvokeContext) []cliservice.Capability {
+	f.contexts = append(f.contexts, contextValue)
+	capabilities := []cliservice.Capability{
+		workspaceAppMentionAppCapability("app.automation-app.automation.list", "automation-app", []string{"automation", "list"}, "List automations"),
+	}
+	if contextValue.IncludeIntegrationCapabilities {
+		capabilities = append(capabilities,
+			workspaceAppMentionAppCapability("app.automation-app.automation.internal-sync", "automation-app", []string{"automation", "internal-sync"}, "Sync internal automation state"),
+		)
+	}
+	return capabilities
+}
+
+func (*workspaceAppMentionDynamicCommands) Invoke(context.Context, cliservice.InvokeRequest) (cliservice.CommandOutput, error) {
+	return cliservice.CommandOutput{}, cliservice.ErrCommandNotFound
+}
+
+func workspaceAppMentionAppCapability(id string, appID string, path []string, summary string) cliservice.Capability {
+	return cliservice.Capability{
+		ID:      id,
+		Path:    path,
+		Summary: summary,
+		Source: cliservice.CapabilitySource{
+			Kind:    cliservice.CapabilitySourceApp,
+			AppID:   appID,
+			AppName: "Automation",
+		},
 	}
 }

--- a/services/tuttid/api/daemon_cli.go
+++ b/services/tuttid/api/daemon_cli.go
@@ -23,10 +23,12 @@ func (api DaemonAPI) ListCliCapabilities(ctx context.Context, request tuttigener
 		workspaceID = *request.Params.WorkspaceID
 	}
 	includeHidden := request.Params.IncludeHidden != nil && *request.Params.IncludeHidden
+	includeIntegration := request.Params.IncludeIntegration != nil && *request.Params.IncludeIntegration
 	capabilities := api.CLIRegistry.Capabilities(ctx, cliservice.InvokeContext{
-		Source:                "cli",
-		WorkspaceID:           workspaceID,
-		SkipCapabilityFilters: includeHidden,
+		Source:                         "cli",
+		WorkspaceID:                    workspaceID,
+		SkipCapabilityFilters:          includeHidden,
+		IncludeIntegrationCapabilities: includeHidden || includeIntegration,
 	})
 	return tuttigenerated.ListCliCapabilities200JSONResponse{
 		Commands: generatedCliCapabilities(capabilities),
@@ -139,10 +141,19 @@ func generatedCliCapability(capability cliservice.Capability) tuttigenerated.Cli
 		Path:        capability.Path,
 		Summary:     capability.Summary,
 		Description: description,
+		Visibility:  generatedCliCapabilityVisibility(capability.Visibility),
 		InputSchema: inputSchema,
 		Output:      generatedCliCapabilityOutput(capability.Output),
 		Source:      generatedCliCapabilitySource(capability.Source),
 	}
+}
+
+func generatedCliCapabilityVisibility(visibility cliservice.CapabilityVisibility) *tuttigenerated.CliCapabilityVisibility {
+	result := tuttigenerated.Public
+	if cliservice.NormalizeCapabilityVisibility(visibility) == cliservice.CapabilityVisibilityIntegration {
+		result = tuttigenerated.Integration
+	}
+	return &result
 }
 
 func generatedCliCapabilitySource(source cliservice.CapabilitySource) tuttigenerated.CliCapabilitySource {

--- a/services/tuttid/api/daemon_cli_test.go
+++ b/services/tuttid/api/daemon_cli_test.go
@@ -38,8 +38,43 @@ func TestListCliCapabilitiesCanIncludeHiddenCapabilities(t *testing.T) {
 	}
 
 	commands := response.(tuttigenerated.ListCliCapabilities200JSONResponse).Commands
-	if got, want := generatedCommandIDs(commands), []string{"diagnostics.hidden", "diagnostics.visible"}; !equalStringSlices(got, want) {
+	if got, want := generatedCommandIDs(commands), []string{"diagnostics.hidden", "diagnostics.visible", "diagnostics.internal"}; !equalStringSlices(got, want) {
 		t.Fatalf("command ids = %#v, want %#v", got, want)
+	}
+}
+
+func TestListCliCapabilitiesCanIncludeIntegrationCapabilities(t *testing.T) {
+	includeIntegration := true
+	api := DaemonAPI{CLIRegistry: newTestFilteredCLIRegistry(t)}
+
+	response, err := api.ListCliCapabilities(context.Background(), tuttigenerated.ListCliCapabilitiesRequestObject{
+		Params: tuttigenerated.ListCliCapabilitiesParams{},
+	})
+	if err != nil {
+		t.Fatalf("ListCliCapabilities: %v", err)
+	}
+	commands := response.(tuttigenerated.ListCliCapabilities200JSONResponse).Commands
+	if got, want := generatedCommandIDs(commands), []string{"diagnostics.visible"}; !equalStringSlices(got, want) {
+		t.Fatalf("command ids = %#v, want %#v", got, want)
+	}
+	if commands[0].Visibility == nil || *commands[0].Visibility != tuttigenerated.Public {
+		t.Fatalf("visibility = %#v, want public", commands[0].Visibility)
+	}
+
+	response, err = api.ListCliCapabilities(context.Background(), tuttigenerated.ListCliCapabilitiesRequestObject{
+		Params: tuttigenerated.ListCliCapabilitiesParams{
+			IncludeIntegration: &includeIntegration,
+		},
+	})
+	if err != nil {
+		t.Fatalf("ListCliCapabilities include integration: %v", err)
+	}
+	commands = response.(tuttigenerated.ListCliCapabilities200JSONResponse).Commands
+	if got, want := generatedCommandIDs(commands), []string{"diagnostics.visible", "diagnostics.internal"}; !equalStringSlices(got, want) {
+		t.Fatalf("command ids with integration = %#v, want %#v", got, want)
+	}
+	if commands[1].Visibility == nil || *commands[1].Visibility != tuttigenerated.Integration {
+		t.Fatalf("integration visibility = %#v", commands[1].Visibility)
 	}
 }
 
@@ -50,16 +85,19 @@ func (testFilteringCLIProvider) AppID() string {
 }
 
 func (testFilteringCLIProvider) Commands() []cliservice.Command {
+	internal := testCLICommand("diagnostics.internal", []string{"internal"})
+	internal.Capability.Visibility = cliservice.CapabilityVisibilityIntegration
 	return []cliservice.Command{
 		testCLICommand("diagnostics.hidden", []string{"hidden"}),
 		testCLICommand("diagnostics.visible", []string{"visible"}),
+		internal,
 	}
 }
 
 func (testFilteringCLIProvider) FilterCapabilities(_ context.Context, _ cliservice.InvokeContext, capabilities []cliservice.Capability) []cliservice.Capability {
 	result := make([]cliservice.Capability, 0, len(capabilities))
 	for _, capability := range capabilities {
-		if capability.ID == "diagnostics.visible" {
+		if capability.ID != "diagnostics.hidden" {
 			result = append(result, capability)
 		}
 	}

--- a/services/tuttid/api/generated/server.gen.go
+++ b/services/tuttid/api/generated/server.gen.go
@@ -581,6 +581,19 @@ func (siw *ServerInterfaceWrapper) ListCliCapabilities(w http.ResponseWriter, r 
 		return
 	}
 
+	// ------------- Optional query parameter "includeIntegration" -------------
+
+	err = runtime.BindQueryParameterWithOptions("form", true, false, "includeIntegration", r.URL.Query(), &params.IncludeIntegration, runtime.BindQueryParameterOptions{Type: "boolean", Format: ""})
+	if err != nil {
+		var requiredError *runtime.RequiredParameterError
+		if errors.As(err, &requiredError) {
+			siw.ErrorHandlerFunc(w, r, &RequiredParamError{ParamName: "includeIntegration"})
+		} else {
+			siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "includeIntegration", Err: err})
+		}
+		return
+	}
+
 	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		siw.Handler.ListCliCapabilities(w, r, params)
 	}))

--- a/services/tuttid/api/generated/types.gen.go
+++ b/services/tuttid/api/generated/types.gen.go
@@ -421,6 +421,24 @@ func (e CliCapabilitySourceKind) Valid() bool {
 	}
 }
 
+// Defines values for CliCapabilityVisibility.
+const (
+	Integration CliCapabilityVisibility = "integration"
+	Public      CliCapabilityVisibility = "public"
+)
+
+// Valid indicates whether the value is a known member of the CliCapabilityVisibility enum.
+func (e CliCapabilityVisibility) Valid() bool {
+	switch e {
+	case Integration:
+		return true
+	case Public:
+		return true
+	default:
+		return false
+	}
+}
+
 // Defines values for CliOutputMode.
 const (
 	Json     CliOutputMode = "json"
@@ -1822,7 +1840,8 @@ type CliCapability struct {
 	Source CliCapabilitySource `json:"source"`
 
 	// Summary Short human-readable summary for help surfaces.
-	Summary string `json:"summary"`
+	Summary    string                   `json:"summary"`
+	Visibility *CliCapabilityVisibility `json:"visibility,omitempty"`
 }
 
 // CliCapabilityOutput defines model for CliCapabilityOutput.
@@ -1855,6 +1874,9 @@ type CliCapabilitySource struct {
 
 // CliCapabilitySourceKind defines model for CliCapabilitySourceKind.
 type CliCapabilitySourceKind string
+
+// CliCapabilityVisibility defines model for CliCapabilityVisibility.
+type CliCapabilityVisibility string
 
 // CliCommandOutput defines model for CliCommandOutput.
 type CliCommandOutput struct {
@@ -3487,8 +3509,11 @@ type ListCliCapabilitiesParams struct {
 	// WorkspaceID Optional workspace context. When omitted, the daemon uses the startup workspace.
 	WorkspaceID *string `form:"workspaceID,omitempty" json:"workspaceID,omitempty"`
 
-	// IncludeHidden Include capabilities hidden from CLI command discovery by provider availability filters. Intended for metadata consumers, not command routing.
+	// IncludeHidden Include capabilities hidden from ordinary CLI command discovery by provider availability filters and command visibility. Intended for metadata consumers, not ordinary user command routing.
 	IncludeHidden *bool `form:"includeHidden,omitempty" json:"includeHidden,omitempty"`
+
+	// IncludeIntegration Include integration-only commands while preserving provider availability filters. Intended for app-runtime integrations.
+	IncludeIntegration *bool `form:"includeIntegration,omitempty" json:"includeIntegration,omitempty"`
 }
 
 // ListWorkspaceAgentGeneratedFilesParams defines parameters for ListWorkspaceAgentGeneratedFiles.

--- a/services/tuttid/api/openapi/tuttid.v1.yaml
+++ b/services/tuttid/api/openapi/tuttid.v1.yaml
@@ -84,7 +84,14 @@ paths:
           schema:
             type: boolean
             default: false
-          description: Include capabilities hidden from CLI command discovery by provider availability filters. Intended for metadata consumers, not command routing.
+          description: Include capabilities hidden from ordinary CLI command discovery by provider availability filters and command visibility. Intended for metadata consumers, not ordinary user command routing.
+        - name: includeIntegration
+          in: query
+          required: false
+          schema:
+            type: boolean
+            default: false
+          description: Include integration-only commands while preserving provider availability filters. Intended for app-runtime integrations.
       responses:
         "200":
           description: Visible CLI capabilities
@@ -3337,6 +3344,11 @@ components:
           type: string
           description: Absolute command documentation path resolved from the installed app package.
           nullable: true
+    CliCapabilityVisibility:
+      type: string
+      enum:
+        - public
+        - integration
     CliCapability:
       type: object
       description: Stable command metadata exposed by the local CLI capability protocol.
@@ -3367,6 +3379,9 @@ components:
           type: string
           description: Optional longer human-readable command description.
           nullable: true
+        visibility:
+          $ref: "#/components/schemas/CliCapabilityVisibility"
+          description: Command discovery visibility. Public commands are user-facing; integration commands are app-runtime plumbing and should not be exposed as ordinary user or Agent actions.
         inputSchema:
           type: object
           description: Optional JSON Schema fragment describing accepted command input.

--- a/services/tuttid/builtin-apps/tutti-onboarding/scripts/package-builtin.mjs
+++ b/services/tuttid/builtin-apps/tutti-onboarding/scripts/package-builtin.mjs
@@ -435,6 +435,15 @@ function validateCliInputSchema(schema, label) {
   }
 }
 
+function validateCliVisibility(visibility, label) {
+  if (visibility === undefined) {
+    return;
+  }
+  if (!["public", "integration"].includes(visibility)) {
+    throw new Error(`tutti.cli.json ${label} must be public or integration.`);
+  }
+}
+
 function validateCliOutput(output, label) {
   if (!output || !["json", "table"].includes(output.defaultMode)) {
     throw new Error(
@@ -522,6 +531,7 @@ function validateCliManifest(cliManifest) {
       throw new Error(`tutti.cli.json command path ${pathKey} is duplicated.`);
     }
     seenPaths.add(pathKey);
+    validateCliVisibility(command.visibility, `${label}.visibility`);
     validateCliInputSchema(command.inputSchema, `${label}.inputSchema`);
     validateCliOutput(command.output, `${label}.output`);
     validateCliHandler(command.handler, `${label}.handler`);

--- a/services/tuttid/service/cli/appcli/registry.go
+++ b/services/tuttid/service/cli/appcli/registry.go
@@ -163,7 +163,9 @@ func (r *Registry) Capabilities(ctx context.Context, invokeContext cliservice.In
 		r.mu.RUnlock()
 		return []cliservice.Capability{}
 	}
-	capabilities := scopeSet.Capabilities()
+	capabilities := scopeSet.Capabilities(appclicore.CapabilityListOptions{
+		IncludeIntegration: invokeContext.IncludeIntegrationCapabilities,
+	})
 	r.mu.RUnlock()
 	return serviceCapabilities(capabilities)
 }
@@ -387,9 +389,19 @@ func serviceCapability(capability appclicore.Capability) cliservice.Capability {
 		Path:        append([]string(nil), capability.Path...),
 		Summary:     capability.Summary,
 		Description: capability.Description,
+		Visibility:  serviceCapabilityVisibility(capability.Visibility),
 		InputSchema: appclicore.CloneSchema(capability.InputSchema),
 		Output:      serviceCapabilityOutput(capability.Output),
 		Source:      serviceCapabilitySource(capability.Source),
+	}
+}
+
+func serviceCapabilityVisibility(visibility appclicore.CommandVisibility) cliservice.CapabilityVisibility {
+	switch appclicore.NormalizeVisibility(visibility) {
+	case appclicore.CommandVisibilityIntegration:
+		return cliservice.CapabilityVisibilityIntegration
+	default:
+		return cliservice.CapabilityVisibilityPublic
 	}
 }
 

--- a/services/tuttid/service/cli/appcli/registry_test.go
+++ b/services/tuttid/service/cli/appcli/registry_test.go
@@ -56,6 +56,91 @@ func TestRegistryActivateExposesAppCapabilities(t *testing.T) {
 	}
 }
 
+func TestRegistryActivateHidesIntegrationCommandsFromDefaultCapabilities(t *testing.T) {
+	registry := NewRegistry(fakeWorkspaceCatalog{workspaceID: "ws-1"}, nil)
+	appPackage := writeTestPackage(t, "automation-app", "automation", `[
+    {
+      "path": ["list"],
+      "summary": "List automations",
+      "output": {"defaultMode":"json","json":true},
+      "handler": {"kind":"http","method":"POST","path":"/tutti/cli/list"}
+    },
+    {
+      "path": ["internal-sync"],
+      "summary": "Sync internal automation state",
+      "visibility": "integration",
+      "output": {"defaultMode":"json","json":true},
+      "handler": {"kind":"http","method":"POST","path":"/tutti/cli/internal-sync"}
+    }
+  ]`)
+
+	state := registry.Activate(context.Background(), Activation{
+		WorkspaceID: "ws-1",
+		AppPackage:  appPackage,
+		BaseURL:     "http://127.0.0.1:1",
+	})
+	if state.Status != workspacebiz.AppCLIStatusActive {
+		t.Fatalf("Activate() state = %#v", state)
+	}
+
+	capabilities := registry.Capabilities(context.Background(), cliservice.InvokeContext{Source: "cli", WorkspaceID: "ws-1"})
+	if got, want := capabilityIDs(capabilities), []string{"app.automation-app.automation.list"}; !stringSlicesEqual(got, want) {
+		t.Fatalf("capability ids = %#v, want %#v", got, want)
+	}
+
+	capabilities = registry.Capabilities(context.Background(), cliservice.InvokeContext{
+		Source:                "agent-context",
+		WorkspaceID:           "ws-1",
+		SkipCapabilityFilters: true,
+	})
+	if got, want := capabilityIDs(capabilities), []string{"app.automation-app.automation.list"}; !stringSlicesEqual(got, want) {
+		t.Fatalf("capability ids with provider filters skipped = %#v, want %#v", got, want)
+	}
+
+	capabilities = registry.Capabilities(context.Background(), cliservice.InvokeContext{
+		Source:                         "cli",
+		WorkspaceID:                    "ws-1",
+		IncludeIntegrationCapabilities: true,
+	})
+	if got, want := capabilityIDs(capabilities), []string{"app.automation-app.automation.list", "app.automation-app.automation.internal-sync"}; !stringSlicesEqual(got, want) {
+		t.Fatalf("capability ids with hidden = %#v, want %#v", got, want)
+	}
+}
+
+func TestRegistryInvokeAllowsIntegrationCommandsByID(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost || r.URL.Path != "/tutti/cli/internal-sync" {
+			t.Fatalf("request = %s %s", r.Method, r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"kind":"json","value":{"ok":true}}`))
+	}))
+	defer server.Close()
+
+	registry := NewRegistry(fakeWorkspaceCatalog{workspaceID: "ws-1"}, fakeRuntime{baseURL: server.URL})
+	appPackage := writeTestPackage(t, "automation-app", "automation", `[
+    {
+      "path": ["internal-sync"],
+      "summary": "Sync internal automation state",
+      "visibility": "integration",
+      "output": {"defaultMode":"json","json":true},
+      "handler": {"kind":"http","method":"POST","path":"/tutti/cli/internal-sync"}
+    }
+  ]`)
+	registry.Activate(context.Background(), Activation{WorkspaceID: "ws-1", AppPackage: appPackage, BaseURL: server.URL})
+
+	output, err := registry.Invoke(context.Background(), cliservice.InvokeRequest{
+		CommandID: "app.automation-app.automation.internal-sync",
+		Context:   cliservice.InvokeContext{WorkspaceID: "ws-1"},
+	})
+	if err != nil {
+		t.Fatalf("Invoke() error = %v", err)
+	}
+	if output.Kind != cliservice.OutputModeJSON || output.Value["ok"] != true {
+		t.Fatalf("output = %#v", output)
+	}
+}
+
 func TestRegistryActivateExposesDocumentationFile(t *testing.T) {
 	registry := NewRegistry(fakeWorkspaceCatalog{workspaceID: "ws-1"}, nil)
 	appPackage := writeTestPackageWithDocumentation(t, "automation-app", "automation", "COMMANDS.md", testJSONCommand())
@@ -311,4 +396,24 @@ func testJSONCommand() string {
       "handler": {"kind":"http","method":"POST","path":"/tutti/cli/run"}
     }
   ]`
+}
+
+func capabilityIDs(capabilities []cliservice.Capability) []string {
+	ids := make([]string, 0, len(capabilities))
+	for _, capability := range capabilities {
+		ids = append(ids, capability.ID)
+	}
+	return ids
+}
+
+func stringSlicesEqual(left []string, right []string) bool {
+	if len(left) != len(right) {
+		return false
+	}
+	for index := range left {
+		if left[index] != right[index] {
+			return false
+		}
+	}
+	return true
 }

--- a/services/tuttid/service/cli/providers/workbenchapps/provider.go
+++ b/services/tuttid/service/cli/providers/workbenchapps/provider.go
@@ -54,6 +54,7 @@ func (p Provider) newOpenCommand() cliservice.Command {
 			Path:        []string{"app", "open"},
 			Summary:     "Open a workspace app",
 			Description: "Launch or activate an installed workspace app. Use --route to pass an origin-root route intent.",
+			Visibility:  cliservice.CapabilityVisibilityIntegration,
 			InputSchema: map[string]any{
 				"type": "object",
 				"required": []string{

--- a/services/tuttid/service/cli/providers/workbenchapps/provider_test.go
+++ b/services/tuttid/service/cli/providers/workbenchapps/provider_test.go
@@ -75,6 +75,9 @@ func TestOpenPublishesWorkspaceAppWorkbenchLaunch(t *testing.T) {
 
 func TestOpenCommandAdvertisesRepeatableParamSchema(t *testing.T) {
 	command := NewProvider(fakeWorkspaceCatalog{}, &fakeAppLauncher{}, nil).newOpenCommand()
+	if command.Capability.Visibility != cliservice.CapabilityVisibilityIntegration {
+		t.Fatalf("visibility = %q, want integration", command.Capability.Visibility)
+	}
 	properties := command.Capability.InputSchema["properties"].(map[string]any)
 	param := properties["param"].(map[string]any)
 	oneOf := param["oneOf"].([]map[string]any)

--- a/services/tuttid/service/cli/registry.go
+++ b/services/tuttid/service/cli/registry.go
@@ -183,6 +183,9 @@ func (r *Registry) Capabilities(ctx context.Context, invokeContext InvokeContext
 			if !r.capabilityVisible(id, allowedByProvider) {
 				continue
 			}
+			if !capabilityDiscoverable(command.Capability, invokeContext) {
+				continue
+			}
 			result = append(result, command.Capability)
 		}
 	}
@@ -240,6 +243,24 @@ func (r *Registry) capabilityVisible(id string, allowedByProvider map[string]map
 	}
 	_, visible := allowed[id]
 	return visible
+}
+
+func capabilityDiscoverable(capability Capability, invokeContext InvokeContext) bool {
+	if invokeContext.IncludeIntegrationCapabilities {
+		return true
+	}
+	return NormalizeCapabilityVisibility(capability.Visibility) != CapabilityVisibilityIntegration
+}
+
+func NormalizeCapabilityVisibility(visibility CapabilityVisibility) CapabilityVisibility {
+	switch CapabilityVisibility(strings.TrimSpace(string(visibility))) {
+	case "", CapabilityVisibilityPublic:
+		return CapabilityVisibilityPublic
+	case CapabilityVisibilityIntegration:
+		return CapabilityVisibilityIntegration
+	default:
+		return visibility
+	}
 }
 
 func (r *Registry) Invoke(ctx context.Context, request InvokeRequest) (CommandOutput, error) {

--- a/services/tuttid/service/cli/registry_test.go
+++ b/services/tuttid/service/cli/registry_test.go
@@ -179,6 +179,54 @@ func TestRegistryCapabilitiesCanSkipProviderFilters(t *testing.T) {
 	}
 }
 
+func TestRegistryHidesIntegrationCapabilitiesFromDefaultList(t *testing.T) {
+	registry, err := NewRegistry(
+		testCommandWithPath("diagnostics.visible", []string{"visible"}),
+		Command{
+			Capability: Capability{
+				ID:         "diagnostics.internal",
+				Path:       []string{"internal"},
+				Summary:    "Run internal command",
+				Visibility: CapabilityVisibilityIntegration,
+				Output: CapabilityOutput{
+					DefaultMode: OutputModePlain,
+					JSON:        true,
+				},
+			},
+			Handler: func(context.Context, InvokeRequest) (CommandOutput, error) {
+				return CommandOutput{
+					Kind: OutputModePlain,
+					Text: "internal ok",
+				}, nil
+			},
+		},
+	)
+	if err != nil {
+		t.Fatalf("NewRegistry: %v", err)
+	}
+
+	capabilities := registry.Capabilities(context.Background(), InvokeContext{Source: "cli"})
+	if got, want := capabilityIDs(capabilities), []string{"diagnostics.visible"}; !stringSlicesEqual(got, want) {
+		t.Fatalf("capability ids = %#v, want %#v", got, want)
+	}
+
+	capabilities = registry.Capabilities(context.Background(), InvokeContext{
+		Source:                         "cli",
+		IncludeIntegrationCapabilities: true,
+	})
+	if got, want := capabilityIDs(capabilities), []string{"diagnostics.visible", "diagnostics.internal"}; !stringSlicesEqual(got, want) {
+		t.Fatalf("capability ids with integration = %#v, want %#v", got, want)
+	}
+
+	output, err := registry.Invoke(context.Background(), InvokeRequest{CommandID: "diagnostics.internal"})
+	if err != nil {
+		t.Fatalf("Invoke integration command: %v", err)
+	}
+	if output.Text != "internal ok" {
+		t.Fatalf("output = %#v", output)
+	}
+}
+
 type filteringTestProvider struct {
 	testProvider
 	visibleIDs map[string]bool

--- a/services/tuttid/service/cli/types.go
+++ b/services/tuttid/service/cli/types.go
@@ -11,6 +11,13 @@ const (
 	OutputModeMarkdown OutputMode = "markdown"
 )
 
+type CapabilityVisibility string
+
+const (
+	CapabilityVisibilityPublic      CapabilityVisibility = "public"
+	CapabilityVisibilityIntegration CapabilityVisibility = "integration"
+)
+
 type TableColumn struct {
 	Key   string
 	Label string
@@ -49,17 +56,19 @@ type Capability struct {
 	Path        []string
 	Summary     string
 	Description string
+	Visibility  CapabilityVisibility
 	InputSchema map[string]any
 	Output      CapabilityOutput
 	Source      CapabilitySource
 }
 
 type InvokeContext struct {
-	Source                string
-	WorkspaceID           string
-	ParentCommandID       string
-	AgentSessionID        string
-	SkipCapabilityFilters bool
+	Source                         string
+	WorkspaceID                    string
+	ParentCommandID                string
+	AgentSessionID                 string
+	SkipCapabilityFilters          bool
+	IncludeIntegrationCapabilities bool
 }
 
 type InvokeRequest struct {

--- a/services/tuttid/service/workspace/app_factory_reference/references/cli-manifest-contract.md
+++ b/services/tuttid/service/workspace/app_factory_reference/references/cli-manifest-contract.md
@@ -25,6 +25,7 @@ Shape:
       "path": ["run"],
       "summary": "Run an automation",
       "description": "Run one named automation.",
+      "visibility": "public",
       "inputSchema": {
         "type": "object",
         "properties": {
@@ -55,6 +56,10 @@ Rules:
 - `scope` and every command path segment must use lowercase letters, numbers, and hyphen only.
 - `description` is optional. When present, it describes the CLI scope as a whole for app-level discovery surfaces such as `tutti --help` and `@app` mentions.
 - Command `path` must not repeat `scope`.
+- Command `visibility` is optional. It may be `public` or `integration`; when omitted, it defaults to `public`.
+- `public` commands appear in ordinary Tutti CLI help, Agent command guides, and command discovery.
+- `integration` commands are hidden from ordinary user and Agent discovery, but are still available to app-runtime integrations that call local capabilities through `$TUTTI_CLI`.
+- `visibility` is not an authorization boundary. Do not use `integration` for secrets, privileged operations, or commands that must be blocked from a user who already knows the command.
 - `documentation` is optional. When present, `documentation.file` must be a relative package path to app-owned command documentation, usually `COMMANDS.md`. CLI capabilities expose the resolved absolute documentation path for help output.
 - Handler `kind` must be `http`, `method` must be `POST`, and `path` must start with `/tutti/cli/`.
 - Do not declare host, port, or full URLs; Tutti routes to the app runtime port.

--- a/services/tuttid/service/workspace/app_factory_reference/references/tutti-cli-commands.md
+++ b/services/tuttid/service/workspace/app_factory_reference/references/tutti-cli-commands.md
@@ -31,6 +31,7 @@ def run_tutti(args, timeout=15):
 ## Discovery
 
 The CLI command set is dynamic. It includes daemon-owned commands plus commands exposed by installed workspace apps through `tutti.cli.json`.
+When `TUTTI_CLI` runs inside a workspace app runtime, command discovery includes commands marked integration-only, including app commands with `visibility: "integration"`. Ordinary user CLI help and Agent command guides do not include those integration-only commands. App-runtime help labels integration-only commands and tells models not to expose or forward them as user or Agent actions.
 
 Generated apps that integrate with another app should probe commands before depending on them:
 

--- a/services/tuttid/service/workspace/app_factory_reference/scripts/check_local_dev_app.py
+++ b/services/tuttid/service/workspace/app_factory_reference/scripts/check_local_dev_app.py
@@ -216,6 +216,8 @@ def validate_cli_manifest(
             )
         ):
             errors.append(f"CLI manifest commands[{index}].path must be non-empty lowercase path segments")
+        if "visibility" in command and command.get("visibility") not in {"public", "integration"}:
+            errors.append(f"CLI manifest commands[{index}].visibility must be public or integration")
         handler = command.get("handler")
         if not isinstance(handler, dict):
             errors.append(f"CLI manifest commands[{index}] requires a handler")

--- a/services/tuttid/service/workspace/app_factory_reference/scripts/validate_tutti_app_package.py
+++ b/services/tuttid/service/workspace/app_factory_reference/scripts/validate_tutti_app_package.py
@@ -155,6 +155,9 @@ def validate_cli_manifest(root: Path, manifest: dict[str, Any], errors: list[str
         if not isinstance(command, dict):
             errors.append(f"CLI command {index} must be an object")
             continue
+        visibility = command.get("visibility")
+        if visibility is not None and visibility not in {"public", "integration"}:
+            errors.append(f"CLI command {command.get('name', index)} visibility must be public or integration")
         handler = command.get("handler")
         if not isinstance(handler, dict):
             errors.append(f"CLI command {command.get('name', index)} requires a handler")

--- a/tools/scripts/build-tutti-app-release.test.mjs
+++ b/tools/scripts/build-tutti-app-release.test.mjs
@@ -342,6 +342,16 @@ test("validateCLIManifest accepts the app CLI HTTP bridge contract", () => {
   );
 });
 
+test("validateCLIManifest rejects invalid command visibility", () => {
+  const manifest = cliManifestForTest();
+  manifest.commands[0].visibility = "private";
+
+  assert.throws(
+    () => validateCLIManifest(manifest, "tutti.cli.json"),
+    /visibility must be public or integration/
+  );
+});
+
 test("buildTuttiAppRelease validates declared CLI manifests", async () => {
   const packageDir = await createPackageForTest("cli-app");
   const manifest = manifestForTest("cli-app");


### PR DESCRIPTION
## Summary
- add CLI command visibility for public vs integration-only capabilities
- hide integration-only commands from ordinary discovery while allowing app-runtime discovery with help warnings
- mark workspace app open as integration-only and validate app CLI manifest visibility across tooling

## Validation
- pnpm check:full

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * CLI help and command discovery now distinguish integration-only commands and can include them when appropriate.
  * API requests for CLI capabilities support an option to include integration-scoped commands.

* **Bug Fixes**
  * Hidden integration commands are no longer shown in standard command listings.
  * Integration-only commands remain callable in runtime contexts while staying out of обычный help output.

* **Documentation**
  * Updated CLI manifest and command discovery guidance to explain command visibility and default behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->