### PR TITLE
fix(agent-gui): omit reference icon data from prompts

### DIFF
--- a/packages/agent/gui/agent-gui/agentGuiNode/AgentGUINodeView.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/AgentGUINodeView.tsx
@@ -942,7 +942,6 @@ export function AgentGUINodeView({
                 ...(handle.groupId?.trim()
                   ? { groupId: handle.groupId.trim() }
                   : {}),
-                ...(bundleIconUrl ? { icon: bundleIconUrl } : {}),
                 ...(bundle.fileCount > 0
                   ? { count: String(bundle.fileCount) }
                   : {})

--- a/packages/agent/gui/agent-gui/agentGuiNode/agentRichText/agentFileMentionExtension.spec.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/agentRichText/agentFileMentionExtension.spec.ts
@@ -270,11 +270,23 @@ describe("formatAgentMentionMarkdown — workspace reference", () => {
 
   it("renders one chip link (no expansion)", () => {
     expect(formatAgentMentionMarkdown(referenceItem)).toBe(
-      "[@Design](mention://workspace-reference/app-1?source=app&workspaceId=ws-1)"
+      "[@Design](mention://workspace-reference/app-1?count=2&source=app&workspaceId=ws-1)"
     );
   });
 
-  it("round-trips the handle + icon + count through the href (build → parse)", () => {
+  it("omits display icon data from the prompt href", () => {
+    expect(
+      formatAgentMentionMarkdown({
+        ...referenceItem,
+        href: "mention://workspace-reference/app-1?icon=data%3Aimage%2Fpng%3Bbase64%2Cabc&source=app&workspaceId=ws-1",
+        iconUrl: "data:image/png;base64,abc"
+      })
+    ).toBe(
+      "[@Design](mention://workspace-reference/app-1?count=2&source=app&workspaceId=ws-1)"
+    );
+  });
+
+  it("parses legacy href icon data for chip display", () => {
     const href = createRichTextMentionHref({
       providerId: "workspace-reference",
       entityId: "topic-1",

--- a/packages/agent/gui/agent-gui/agentGuiNode/agentRichText/agentFileMentionExtension.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/agentRichText/agentFileMentionExtension.ts
@@ -470,6 +470,19 @@ export function formatAgentMentionMarkdown(
       path: item.href
     });
   }
+  if (item.kind === "workspace-reference") {
+    return createRichTextMentionMarkdown({
+      providerId: "workspace-reference",
+      entityId: item.targetId,
+      label: item.name,
+      scope: {
+        workspaceId: item.workspaceId,
+        source: item.source,
+        ...(item.groupId?.trim() ? { groupId: item.groupId.trim() } : {}),
+        ...(item.fileCount > 0 ? { count: String(item.fileCount) } : {})
+      }
+    });
+  }
   const identity = parseRichTextMentionHref(item.href, item.name);
   return identity ? createRichTextMentionMarkdown(identity) : "";
 }

--- a/packages/workspace/issue-manager/src/core/content.test.ts
+++ b/packages/workspace/issue-manager/src/core/content.test.ts
@@ -267,7 +267,6 @@ test("issue-manager folds a project bundle into a single workspace-reference chi
       scope: {
         count: "7",
         groupId: "project-42",
-        icon: "https://example.com/icon.png",
         source: "app",
         workspaceId: "workspace-1"
       }

--- a/packages/workspace/issue-manager/src/core/content.ts
+++ b/packages/workspace/issue-manager/src/core/content.ts
@@ -64,7 +64,7 @@ export interface IssueManagerWorkspaceReferenceMentionInput {
 
 /**
  * 把一个「项目/分组」折叠成单条 `mention://workspace-reference/...` chip 的 markdown。
- * 句柄(source + id + groupId)随 query 编码,运行时交给 agent 解析;icon/count 仅供展示。
+ * 句柄(source + id + groupId)随 query 编码,运行时交给 agent 解析;count 仅供展示。
  * 与 agent 端 `buildAgentWorkspaceReferenceMentionHref` 的参数名保持一致。
  */
 export function createIssueManagerWorkspaceReferenceMentionMarkdown(
@@ -82,10 +82,6 @@ export function createIssueManagerWorkspaceReferenceMentionMarkdown(
   const groupId = input.groupId?.trim();
   if (groupId) {
     scope.groupId = groupId;
-  }
-  const iconUrl = input.iconUrl?.trim();
-  if (iconUrl) {
-    scope.icon = iconUrl;
   }
   if (input.fileCount != null && input.fileCount > 0) {
     scope.count = String(input.fileCount);


### PR DESCRIPTION
## Summary
- stop writing workspace-reference icon URLs into mention href query params
- rebuild workspace-reference prompt markdown from safe handle fields so legacy icon data does not reach prompts
- keep UI icon data on node attrs only

## Tests
- corepack pnpm --filter @tutti-os/agent-gui test -- agentFileMentionExtension.spec.ts agentRichTextDocument.spec.ts
- corepack pnpm --filter @tutti-os/workspace-issue-manager test -- src/core/content.test.ts
- corepack pnpm --filter @tutti-os/agent-gui typecheck
- corepack pnpm --filter @tutti-os/workspace-issue-manager typecheck

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved workspace reference chip generation to preserve `count` and `groupId` consistently.
  * Removed inclusion of icon data from workspace reference mention hrefs/chips, keeping links cleaner and display behavior consistent.
  * Updated workspace-reference mention markdown formatting to serialize via the proper scope fields across the app.
* **Tests**
  * Extended workspace reference mention formatting and extraction assertions to cover count handling and legacy icon stripping.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->