### PR TITLE
feat(agent): expose dynamic skill bundle

### DIFF
--- a/services/tuttid/service/agent/service.go
+++ b/services/tuttid/service/agent/service.go
@@ -15,6 +15,7 @@ var (
 	ErrInvalidArgument                  = errors.New("invalid agent session request")
 	ErrPromptImageUnsupported           = errors.New("agent prompt image input is unsupported")
 	ErrSessionNotFound                  = errors.New("workspace agent session not found")
+	ErrSkillBundleUnavailable           = errors.New("agent skill bundle renderer is unavailable")
 	ErrSessionSettingsRequireNewSession = errors.New("agent session settings update requires a new session to preserve context")
 )
 

--- a/services/tuttid/service/agent/service_test.go
+++ b/services/tuttid/service/agent/service_test.go
@@ -1100,6 +1100,60 @@ func TestServiceCreatePassesExtraSkillsToRuntimePreparer(t *testing.T) {
 	}
 }
 
+func TestServiceGetSkillBundleUsesRuntimeRenderer(t *testing.T) {
+	runtime := newFakeRuntime()
+	var renderInput agentsidecarservice.PrepareInput
+	service := NewService(runtime)
+	service.RuntimePreparer = fakeSkillBundleRenderer{
+		input: &renderInput,
+		bundle: agentsidecarservice.SkillBundle{
+			SchemaVersion:  1,
+			Provider:       "codex",
+			AgentSessionID: "run-1",
+			CLICommand:     "tutti-dev",
+			Skills: []agentsidecarservice.SkillMaterializationRecord{
+				{SkillID: "tutti/tutti-cli", Slug: "tutti-cli", DeliveryMode: "materialized-files"},
+			},
+		},
+	}
+
+	bundle, err := service.GetSkillBundle(context.Background(), "ws-1", SkillBundleInput{
+		AgentSessionID: "run-1",
+		BrowserUse:     true,
+		Provider:       " codex ",
+	})
+	if err != nil {
+		t.Fatalf("GetSkillBundle returned error: %v", err)
+	}
+	if renderInput.WorkspaceID != "ws-1" ||
+		renderInput.AgentSessionID != "run-1" ||
+		renderInput.Provider != "codex" ||
+		!renderInput.BrowserUse ||
+		renderInput.ComputerUse {
+		t.Fatalf("render input = %#v", renderInput)
+	}
+	if bundle.CLICommand != "tutti-dev" || len(bundle.Skills) != 1 || bundle.Skills[0].SkillID != "tutti/tutti-cli" {
+		t.Fatalf("bundle = %#v", bundle)
+	}
+	if len(runtime.startCalls) != 0 {
+		t.Fatalf("runtime start calls = %d, want 0", len(runtime.startCalls))
+	}
+}
+
+func TestServiceGetSkillBundleRequiresRenderer(t *testing.T) {
+	runtime := newFakeRuntime()
+	service := NewService(runtime)
+	service.RuntimePreparer = fakeRuntimePreparer{}
+
+	_, err := service.GetSkillBundle(context.Background(), "ws-1", SkillBundleInput{Provider: "codex"})
+	if !errors.Is(err, ErrSkillBundleUnavailable) {
+		t.Fatalf("GetSkillBundle error = %v, want ErrSkillBundleUnavailable", err)
+	}
+	if len(runtime.startCalls) != 0 {
+		t.Fatalf("runtime start calls = %d, want 0", len(runtime.startCalls))
+	}
+}
+
 func TestServiceDeleteCleansPreparedRuntime(t *testing.T) {
 	runtime := newFakeRuntime()
 	service := NewService(runtime)
@@ -3020,6 +3074,20 @@ func (f fakeRuntimePreparer) Cleanup(_ context.Context, input agentsidecarservic
 		*f.cleanupCalls = append(*f.cleanupCalls, input)
 	}
 	return nil
+}
+
+type fakeSkillBundleRenderer struct {
+	fakeRuntimePreparer
+	bundle agentsidecarservice.SkillBundle
+	err    error
+	input  *agentsidecarservice.PrepareInput
+}
+
+func (f fakeSkillBundleRenderer) RenderSkillBundle(_ context.Context, input agentsidecarservice.PrepareInput) (agentsidecarservice.SkillBundle, error) {
+	if f.input != nil {
+		*f.input = input
+	}
+	return f.bundle, f.err
 }
 
 type fakeModelCatalog struct {

--- a/services/tuttid/service/agent/skill_bundle.go
+++ b/services/tuttid/service/agent/skill_bundle.go
@@ -1,0 +1,39 @@
+package agent
+
+import (
+	"context"
+	"strings"
+
+	agentsidecarservice "github.com/tutti-os/tutti/services/tuttid/service/agentsidecar"
+)
+
+type SkillBundleInput struct {
+	AgentSessionID string
+	Provider       string
+	BrowserUse     bool
+	ComputerUse    bool
+}
+
+type SkillBundle = agentsidecarservice.SkillBundle
+type SkillMaterializationFile = agentsidecarservice.SkillMaterializationFile
+type SkillMaterializationRecord = agentsidecarservice.SkillMaterializationRecord
+type RecommendedSystemPrompt = agentsidecarservice.RecommendedSystemPrompt
+
+func (s *Service) GetSkillBundle(ctx context.Context, workspaceID string, input SkillBundleInput) (SkillBundle, error) {
+	workspaceID = strings.TrimSpace(workspaceID)
+	provider := strings.TrimSpace(input.Provider)
+	if workspaceID == "" || provider == "" {
+		return SkillBundle{}, ErrInvalidArgument
+	}
+	renderer, ok := s.RuntimePreparer.(agentsidecarservice.SkillBundleRenderer)
+	if s.RuntimePreparer == nil || !ok {
+		return SkillBundle{}, ErrSkillBundleUnavailable
+	}
+	return renderer.RenderSkillBundle(ctx, agentsidecarservice.PrepareInput{
+		WorkspaceID:    workspaceID,
+		AgentSessionID: strings.TrimSpace(input.AgentSessionID),
+		Provider:       provider,
+		BrowserUse:     input.BrowserUse,
+		ComputerUse:    input.ComputerUse,
+	})
+}

--- a/services/tuttid/service/agentsidecar/command_catalog.go
+++ b/services/tuttid/service/agentsidecar/command_catalog.go
@@ -68,6 +68,9 @@ func relevantRuntimeCommands(cliName string, capabilities []cliservice.Capabilit
 
 func runtimeCommandFromCapability(cliName string, capability cliservice.Capability) (runtimeCommand, bool) {
 	id := strings.TrimSpace(capability.ID)
+	if id == "agent-context.agent.skill-bundle" || id == "agent-context.agent.tutti-cli-skill-bundle" {
+		return runtimeCommand{}, false
+	}
 	if capability.Source.Kind != cliservice.CapabilitySourceApp && !strings.HasPrefix(id, "issue-manager.") && !strings.HasPrefix(id, "agent-context.") && !strings.HasPrefix(id, "browser.") {
 		return runtimeCommand{}, false
 	}

--- a/services/tuttid/service/agentsidecar/command_catalog_test.go
+++ b/services/tuttid/service/agentsidecar/command_catalog_test.go
@@ -77,6 +77,12 @@ func TestCommandGuideFromCapabilitiesUsesRelevantRegistryCommands(t *testing.T) 
 			Summary:     "List agent sessions",
 			Description: "List agent sessions.",
 		},
+		{
+			ID:          "agent-context.agent.tutti-cli-skill-bundle",
+			Path:        []string{"agent", "tutti-cli-skill-bundle"},
+			Summary:     "Get Tutti CLI skill bundle",
+			Description: "Get a host integration skill bundle.",
+		},
 	})
 
 	if !strings.Contains(guide, "tutti issue get --issue-id <issue-id>") {
@@ -106,6 +112,9 @@ func TestCommandGuideFromCapabilitiesUsesRelevantRegistryCommands(t *testing.T) 
 	}
 	if !strings.Contains(guide, "tutti agent sessions") {
 		t.Fatalf("guide missing agent sessions: %q", guide)
+	}
+	if strings.Contains(guide, "skill-bundle") {
+		t.Fatalf("guide included host integration command: %q", guide)
 	}
 	if strings.Contains(guide, "diagnostics") {
 		t.Fatalf("guide included irrelevant command: %q", guide)

--- a/services/tuttid/service/agentsidecar/policy_templates/skill-bundle-routing.md
+++ b/services/tuttid/service/agentsidecar/policy_templates/skill-bundle-routing.md
@@ -1,0 +1,54 @@
+# Tutti Dynamic Skill Routing
+
+The host application has provided a Tutti dynamic skill bundle for this run.
+
+Available Tutti skills:
+
+- `tutti-cli`: global CLI reference for workspace-wide issues, tasks, topics, and `mention://agent-session/<sessionId>?workspaceId=...` session inspection.
+- `issue-manager`: workspace issue execution, inspection, and breakdown workflow guidance built on top of `tutti-cli`.
+- `workspace-app`: workspace app mention discovery, inspection, and invocation guidance built on top of `tutti-cli`.
+- `reference`: workspace reference resolution guidance built on top of `tutti-cli`.
+  {{BROWSER_USE_SKILL_LINES}}{{COMPUTER_USE_SKILL_LINES}}
+  Required mention routing:
+
+- If the current request contains any `mention://...` URI, route it by URI type before reading files, searching the repository, calling Bash, using browser or web tools, calling MCP tools, or treating the URI as plain text.
+- `mention://workspace-issue/<issueId>?workspaceId=...` -> use `issue-manager`.
+- `mention://workspace-app/<appId>?workspaceId=...` -> use `workspace-app`.
+- `mention://workspace-reference/<id>?source=...&workspaceId=...` -> use `reference`.
+- `mention://agent-session/<sessionId>?workspaceId=...` -> use `tutti-cli`.
+- For `mention://workspace-app/<appId>`, `<appId>` is the workspace app id, not a skill name. For example, `mention://workspace-app/group-chat?...` means app id `group-chat`; do not look for a `group-chat` skill. Use the `workspace-app` skill.
+- Treat `mention://...` links as internal Tutti references, not web URLs, browser URLs, filesystem paths, or directories.
+
+How to use the matching skill:
+
+- If provider-native Skill tools are available, call the matching skill first.
+- If skills are materialized as files, first read the materialized `SKILL.md` for the matching skill slug from the workspace skills prompt section, then follow that skill's instructions.
+- Do not read app `AGENTS.md`, `COMMANDS.md`, source files, or run shell commands before following the matching Tutti skill.
+- A matching skill means the routing-table skill slug (`issue-manager`, `workspace-app`, `reference`, or `tutti-cli`), not the issue id, app id, reference id, or session id inside the URI.
+
+{{PROVIDER_SPECIFIC_MENTION_ROUTING}}
+
+Execution environment:
+
+- The Tutti CLI communicates with the local Tutti daemon over localhost/IPC.
+- Run Tutti CLI commands in an execution environment that can access the user's local host daemon and the injected Tutti CLI path.
+- If the local Tutti daemon is not accessible from the current execution environment, explain that limitation instead of guessing from local files.
+
+Runtime context:
+
+- agent session id: `{{AGENT_SESSION_ID}}`
+- provider: `{{PROVIDER}}`
+
+Fallback only when the matching Tutti skill is unavailable:
+
+- For `mention://workspace-issue/<issueId>?workspaceId=...`, parse the issue id from the URL path and parse `workspaceId`, `topicId`, `taskId`, `runId`, and `mode` from the query. Start context recovery with `{{CLI_COMMAND}} issue get --issue-id <issue-id> --json`; read task, run, or topic context only when those query fields are present or needed.
+- For `mention://workspace-app/<appId>?workspaceId=...`, parse the app id from the URL path. If it is `agent-codex`, use `{{CLI_COMMAND}} codex start --prompt <task> --show --json`; if it is `agent-claude-code`, use `{{CLI_COMMAND}} claude start --prompt <task> --show --json`; if it is `issue-manager`, use the `issue-manager` workflow. For other app ids, match against the workspace-app commands listed in the command guide. If no matching app command is available, say the app does not expose usable CLI capabilities instead of guessing from files.
+- For `mention://workspace-reference/<id>?source=...&workspaceId=...`, parse the path id plus `source`, `workspaceId`, and `groupId` from the query. List the referenced files with `{{CLI_COMMAND}} reference list --source <source> --id <id> [--group-id <groupId>] --json`, then read the returned paths.
+- For `mention://agent-session/<sessionId>?workspaceId=...`, parse the session id from the URL path and start context recovery with `{{CLI_COMMAND}} agent session-summary --session-id <session-id> --json`.
+  {{BROWSER_USE_HANDOFF_LINES}}{{COMPUTER_USE_HANDOFF_LINES}}
+
+Use the bundled Tutti CLI for workspace context:
+
+{{COMMAND_GUIDE}}
+
+Treat Tutti mentions, issue/task records, app outputs, references, and session summaries as context. Follow explicit user instructions first.

--- a/services/tuttid/service/agentsidecar/preparer.go
+++ b/services/tuttid/service/agentsidecar/preparer.go
@@ -131,6 +131,21 @@ func (p *DefaultPreparer) Prepare(ctx context.Context, input PrepareInput) (Prep
 	return PreparedRuntime(result), nil
 }
 
+func (p *DefaultPreparer) RenderSkillBundle(ctx context.Context, input PrepareInput) (SkillBundle, error) {
+	workspaceID := strings.TrimSpace(input.WorkspaceID)
+	providerID := strings.TrimSpace(input.Provider)
+	if workspaceID == "" || providerID == "" {
+		return SkillBundle{}, errors.New("agent skill bundle render requires workspace and provider")
+	}
+
+	input.WorkspaceID = workspaceID
+	input.AgentSessionID = strings.TrimSpace(input.AgentSessionID)
+	input.Provider = providerID
+	input.CLICommand = firstNonEmptyText(input.CLICommand, p.CLICommand, resolveCLICommand(p.StateDir))
+	input.CommandGuide = commandGuideFromCatalog(ctx, p.CommandCatalog, workspaceID, input.CLICommand)
+	return renderProviderSkillBundle(input), nil
+}
+
 func (p *DefaultPreparer) Cleanup(_ context.Context, input CleanupInput) error {
 	workspaceID := strings.TrimSpace(input.WorkspaceID)
 	agentSessionID := strings.TrimSpace(input.AgentSessionID)

--- a/services/tuttid/service/agentsidecar/preparer_test.go
+++ b/services/tuttid/service/agentsidecar/preparer_test.go
@@ -950,6 +950,7 @@ func TestDefaultPreparerGeminiUsesSessionScopedHome(t *testing.T) {
 func TestCodexPreparerSkipsUserBrowserSkillWhenBrowserUseEnabled(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)
+	t.Setenv(browserUseSwitchEnv, "")
 	userCodexHome := filepath.Join(home, ".codex")
 	if err := os.MkdirAll(userCodexHome, 0o700); err != nil {
 		t.Fatal(err)

--- a/services/tuttid/service/agentsidecar/provider_skill.go
+++ b/services/tuttid/service/agentsidecar/provider_skill.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 )
 
@@ -62,17 +63,21 @@ func referenceSkill(input PrepareInput) string {
 	)
 }
 
-func browserUseSkill(_ PrepareInput) string {
+func browserUseSkill(input PrepareInput) string {
 	return renderProviderSkillTemplate(
 		"skill_templates/browser-use.md",
-		map[string]string{},
+		map[string]string{
+			"{{CLI_COMMAND}}": normalizeCLICommandName(input.CLICommand),
+		},
 	)
 }
 
-func computerUseSkill(_ PrepareInput) string {
+func computerUseSkill(input PrepareInput) string {
 	return renderProviderSkillTemplate(
 		"skill_templates/computer-use.md",
-		map[string]string{},
+		map[string]string{
+			"{{CLI_COMMAND}}": normalizeCLICommandName(input.CLICommand),
+		},
 	)
 }
 
@@ -138,6 +143,58 @@ func providerSkills(input PrepareInput) []providerSkillSpec {
 
 func installProviderNativeSkills(root string, input PrepareInput) ([]string, error) {
 	return installProviderNativeSkillSpecs(root, providerSkills(input))
+}
+
+func renderProviderSkillBundle(input PrepareInput) SkillBundle {
+	skills := providerSkills(input)
+	records := make([]SkillMaterializationRecord, 0, len(skills))
+	for _, skill := range skills {
+		records = append(records, providerSkillSpecRecord(skill))
+	}
+	return SkillBundle{
+		SchemaVersion:           1,
+		Provider:                strings.TrimSpace(input.Provider),
+		AgentSessionID:          strings.TrimSpace(input.AgentSessionID),
+		CLICommand:              normalizeCLICommandName(input.CLICommand),
+		RecommendedSystemPrompt: recommendedSystemPrompt(input),
+		Skills:                  records,
+	}
+}
+
+func recommendedSystemPrompt(input PrepareInput) *RecommendedSystemPrompt {
+	content := strings.TrimSpace(tuttiSkillBundleRecommendedPolicy(input))
+	if content == "" {
+		return nil
+	}
+	return &RecommendedSystemPrompt{
+		Format:  "text/markdown",
+		Content: content,
+	}
+}
+
+func providerSkillSpecRecord(spec providerSkillSpec) SkillMaterializationRecord {
+	files := make([]SkillMaterializationFile, 0, len(spec.files))
+	paths := make([]string, 0, len(spec.files))
+	for path := range spec.files {
+		if path == "SKILL.md" {
+			continue
+		}
+		paths = append(paths, path)
+	}
+	sort.Strings(paths)
+	for _, path := range paths {
+		files = append(files, SkillMaterializationFile{
+			Content: spec.files[path],
+			Path:    path,
+		})
+	}
+	return SkillMaterializationRecord{
+		Content:      spec.files["SKILL.md"],
+		Files:        files,
+		SkillID:      "tutti/" + spec.baseName,
+		Slug:         spec.baseName,
+		DeliveryMode: "materialized-files",
+	}
 }
 
 func installProviderNativeSkillSpecs(root string, skills []providerSkillSpec) ([]string, error) {

--- a/services/tuttid/service/agentsidecar/provider_skill_test.go
+++ b/services/tuttid/service/agentsidecar/provider_skill_test.go
@@ -55,6 +55,10 @@ func TestTuttiCLIPolicyUsesPreparedCLICommandForAgentLauncherFallback(t *testing
 		strings.Contains(policy, "claude start --model <model>") {
 		t.Fatalf("tutti CLI policy still requires model: %q", policy)
 	}
+	if !strings.Contains(policy, "# Host App Context") ||
+		!strings.Contains(policy, "The app displays images and videos using standard Markdown syntax") {
+		t.Fatalf("tutti CLI policy missing host app context: %q", policy)
+	}
 }
 
 func TestProviderSkillRootDoesNotExposeClaudeCodeProjectSkills(t *testing.T) {
@@ -66,4 +70,149 @@ func TestProviderSkillRootDoesNotExposeClaudeCodeProjectSkills(t *testing.T) {
 	if root := providerSkillRoot(cwd, "gemini"); root != filepath.Join(cwd, ".gemini", "skills") {
 		t.Fatalf("providerSkillRoot() for gemini = %q, want project skill root", root)
 	}
+}
+
+func TestDefaultPreparerRenderSkillBundleUsesDynamicGuide(t *testing.T) {
+	catalog := fakeCommandCatalog{}
+	preparer := NewDefaultPreparer(t.TempDir())
+	preparer.CLICommand = "tutti-dev"
+	preparer.CommandCatalog = &catalog
+
+	bundle, err := preparer.RenderSkillBundle(t.Context(), PrepareInput{
+		WorkspaceID:    "workspace-1",
+		AgentSessionID: "run-1",
+		Provider:       "codex",
+	})
+	if err != nil {
+		t.Fatalf("RenderSkillBundle() error = %v", err)
+	}
+	if catalog.context.Source != "agent-runtime" || catalog.context.WorkspaceID != "workspace-1" {
+		t.Fatalf("catalog context = %#v", catalog.context)
+	}
+	if bundle.SchemaVersion != 1 ||
+		bundle.Provider != "codex" ||
+		bundle.AgentSessionID != "run-1" ||
+		bundle.CLICommand != "tutti-dev" {
+		t.Fatalf("bundle metadata = %#v", bundle)
+	}
+	if got := skillBundleSlugs(bundle.Skills); strings.Join(got, ",") != "tutti-cli,issue-manager,workspace-app,reference" {
+		t.Fatalf("skill slugs = %#v", got)
+	}
+	if bundle.RecommendedSystemPrompt == nil ||
+		bundle.RecommendedSystemPrompt.Format != "text/markdown" {
+		t.Fatalf("recommended system prompt = %#v", bundle.RecommendedSystemPrompt)
+	}
+	for _, want := range []string{
+		"agent session id: `run-1`",
+		"provider: `codex`",
+		"tutti-dev issue list --topic-id <topic-id>",
+		"`mention://workspace-app/<appId>?workspaceId=...` -> use `workspace-app`.",
+		"`group-chat`; do not look for a `group-chat` skill",
+		"first read the materialized `SKILL.md` for the matching skill slug",
+		"Do not read app `AGENTS.md`, `COMMANDS.md`, source files, or run shell commands before following the matching Tutti skill.",
+	} {
+		if !strings.Contains(bundle.RecommendedSystemPrompt.Content, want) {
+			t.Fatalf("recommended system prompt missing %q: %q", want, bundle.RecommendedSystemPrompt.Content)
+		}
+	}
+	if strings.Contains(bundle.RecommendedSystemPrompt.Content, "# Host App Context") ||
+		strings.Contains(bundle.RecommendedSystemPrompt.Content, "The app displays images and videos using standard Markdown syntax") {
+		t.Fatalf("recommended system prompt should not include host app context: %q", bundle.RecommendedSystemPrompt.Content)
+	}
+	if strings.Contains(bundle.RecommendedSystemPrompt.Content, "{{") {
+		t.Fatalf("recommended system prompt has unresolved placeholder: %q", bundle.RecommendedSystemPrompt.Content)
+	}
+	tuttiSkill := skillBundleRecord(bundle.Skills, "tutti-cli")
+	if tuttiSkill.SkillID != "tutti/tutti-cli" ||
+		tuttiSkill.DeliveryMode != "materialized-files" ||
+		tuttiSkill.MaterializedPath != "" {
+		t.Fatalf("tutti skill record = %#v", tuttiSkill)
+	}
+	for _, want := range []string{
+		"tutti-dev issue list --topic-id <topic-id>",
+		"The current AgentGUI session is `run-1`.",
+		"The current AgentGUI provider is `codex`.",
+	} {
+		if !strings.Contains(tuttiSkill.Content, want) {
+			t.Fatalf("tutti skill content missing %q: %q", want, tuttiSkill.Content)
+		}
+	}
+	if strings.Contains(tuttiSkill.Content, "{{") {
+		t.Fatalf("tutti skill content has unresolved placeholder: %q", tuttiSkill.Content)
+	}
+}
+
+func TestRenderProviderSkillBundleGatesOptionalSkills(t *testing.T) {
+	t.Setenv(browserUseSwitchEnv, "")
+	t.Setenv(computerUseSwitchEnv, "")
+
+	withoutOptional := renderProviderSkillBundle(PrepareInput{
+		AgentSessionID: "run-1",
+		CLICommand:     "tutti-dev",
+		Provider:       "codex",
+	})
+	if got := strings.Join(skillBundleSlugs(withoutOptional.Skills), ","); got != "tutti-cli,issue-manager,workspace-app,reference" {
+		t.Fatalf("skill slugs without optional = %q", got)
+	}
+
+	withOptional := renderProviderSkillBundle(PrepareInput{
+		AgentSessionID: "run-1",
+		BrowserUse:     true,
+		CLICommand:     "tutti-dev",
+		ComputerUse:    true,
+		Provider:       "codex",
+	})
+	if got := strings.Join(skillBundleSlugs(withOptional.Skills), ","); got != "tutti-cli,issue-manager,workspace-app,reference,browser-use,computer-use" {
+		t.Fatalf("skill slugs with optional = %q", got)
+	}
+	if withOptional.RecommendedSystemPrompt == nil ||
+		!strings.Contains(withOptional.RecommendedSystemPrompt.Content, "tutti-dev browser") ||
+		!strings.Contains(withOptional.RecommendedSystemPrompt.Content, "tutti-dev computer") {
+		t.Fatalf("recommended system prompt = %#v", withOptional.RecommendedSystemPrompt)
+	}
+	browserSkill := skillBundleRecord(withOptional.Skills, "browser-use")
+	if !strings.Contains(browserSkill.Content, "tutti-dev browser navigate") ||
+		strings.Contains(browserSkill.Content, "{{CLI_COMMAND}}") ||
+		strings.Contains(browserSkill.Content, "tutti browser") {
+		t.Fatalf("browser skill content = %q", browserSkill.Content)
+	}
+	computerSkill := skillBundleRecord(withOptional.Skills, "computer-use")
+	if !strings.Contains(computerSkill.Content, "tutti-dev computer screenshot") ||
+		strings.Contains(computerSkill.Content, "{{CLI_COMMAND}}") ||
+		strings.Contains(computerSkill.Content, "tutti computer") {
+		t.Fatalf("computer skill content = %q", computerSkill.Content)
+	}
+}
+
+func TestRenderProviderSkillBundleIncludesClaudeRoutingForAlias(t *testing.T) {
+	bundle := renderProviderSkillBundle(PrepareInput{
+		AgentSessionID: "run-1",
+		CLICommand:     "tutti-dev",
+		Provider:       "claude",
+	})
+	if bundle.Provider != "claude" {
+		t.Fatalf("bundle provider = %q, want claude", bundle.Provider)
+	}
+	if bundle.RecommendedSystemPrompt == nil ||
+		!strings.Contains(bundle.RecommendedSystemPrompt.Content, "Claude Code mention routing") ||
+		!strings.Contains(bundle.RecommendedSystemPrompt.Content, `Skill(skill="workspace-app", args="<full mention URI>")`) {
+		t.Fatalf("recommended system prompt = %#v", bundle.RecommendedSystemPrompt)
+	}
+}
+
+func skillBundleSlugs(skills []SkillMaterializationRecord) []string {
+	slugs := make([]string, 0, len(skills))
+	for _, skill := range skills {
+		slugs = append(slugs, skill.Slug)
+	}
+	return slugs
+}
+
+func skillBundleRecord(skills []SkillMaterializationRecord, slug string) SkillMaterializationRecord {
+	for _, skill := range skills {
+		if skill.Slug == slug {
+			return skill
+		}
+	}
+	return SkillMaterializationRecord{}
 }

--- a/services/tuttid/service/agentsidecar/skill_templates/browser-use.md
+++ b/services/tuttid/service/agentsidecar/skill_templates/browser-use.md
@@ -7,14 +7,14 @@ description: Use to operate a web browser — open URLs, read page content, clic
 
 Use this skill for browser tasks: open URLs, read pages, click, fill forms, run page JS, or capture screenshots.
 
-Drive the browser only through `tutti browser`. The Tutti daemon owns the browser session. Do not launch `open`, `xdg-open`, `start`, `google-chrome`, `chromium`, or direct browser automation; those are outside the managed session.
+Drive the browser only through `{{CLI_COMMAND}} browser`. The Tutti daemon owns the browser session. Do not launch `open`, `xdg-open`, `start`, `google-chrome`, `chromium`, or direct browser automation; those are outside the managed session.
 
 ## Protocol
 
-1. Navigate when needed: `tutti browser navigate --url <url>`.
-2. Read the current page with `tutti browser snapshot`; use returned `uid` values for interactions.
-3. Act with `tutti browser click --uid <uid>` or `tutti browser fill --uid <uid> --value <text>`.
-4. Use `tutti browser eval --script '() => document.title'` for page JS, `tutti browser screenshot` for a PNG path, and `tutti browser list-pages` to inspect open pages.
+1. Navigate when needed: `{{CLI_COMMAND}} browser navigate --url <url>`.
+2. Read the current page with `{{CLI_COMMAND}} browser snapshot`; use returned `uid` values for interactions.
+3. Act with `{{CLI_COMMAND}} browser click --uid <uid>` or `{{CLI_COMMAND}} browser fill --uid <uid> --value <text>`.
+4. Use `{{CLI_COMMAND}} browser eval --script '() => document.title'` for page JS, `{{CLI_COMMAND}} browser screenshot` for a PNG path, and `{{CLI_COMMAND}} browser list-pages` to inspect open pages.
 5. Re-run `snapshot` after navigation or UI-changing actions because `uid` values can change.
 
 ## Guardrails

--- a/services/tuttid/service/agentsidecar/skill_templates/computer-use.md
+++ b/services/tuttid/service/agentsidecar/skill_templates/computer-use.md
@@ -7,21 +7,21 @@ description: Use to operate the macOS desktop — take screenshots, click, type,
 
 Use this skill for macOS desktop automation: screenshot, click, type, press keys, scroll, or move the cursor.
 
-Drive the desktop only through `tutti computer`. The Tutti daemon owns the cua-driver session. Do not use AppleScript, `osascript`, `xdotool`, or direct accessibility APIs; those are outside the managed session.
+Drive the desktop only through `{{CLI_COMMAND}} computer`. The Tutti daemon owns the cua-driver session. Do not use AppleScript, `osascript`, `xdotool`, or direct accessibility APIs; those are outside the managed session.
 
 ## Protocol
 
-1. Start with `tutti computer screenshot` to read screen state.
+1. Start with `{{CLI_COMMAND}} computer screenshot` to read screen state.
 2. Choose coordinates from that screenshot; coordinates are logical screen points.
 3. Act with `click`, `double-click`, `right-click`, `type`, `press-key`, `scroll`, or `move-cursor`.
 4. Re-run `screenshot` after actions that change the UI because coordinates can shift.
 
 Common forms:
 
-- `tutti computer click --x <n> --y <n>`
-- `tutti computer type --text <text>`
-- `tutti computer press-key --key <key>`
-- `tutti computer scroll --x <n> --y <n> --direction <up|down|left|right> --amount <n>`
+- `{{CLI_COMMAND}} computer click --x <n> --y <n>`
+- `{{CLI_COMMAND}} computer type --text <text>`
+- `{{CLI_COMMAND}} computer press-key --key <key>`
+- `{{CLI_COMMAND}} computer scroll --x <n> --y <n> --direction <up|down|left|right> --amount <n>`
 
 ## Guardrails
 

--- a/services/tuttid/service/agentsidecar/tutti_cli_policy.go
+++ b/services/tuttid/service/agentsidecar/tutti_cli_policy.go
@@ -5,6 +5,10 @@ import (
 )
 
 func tuttiCLIPolicy(input PrepareInput) string {
+	return tuttiRuntimePolicy(input) + "\n\n" + strings.TrimSpace(renderProviderSkillTemplate("policy_templates/host-app-context.md", nil))
+}
+
+func tuttiRuntimePolicy(input PrepareInput) string {
 	return strings.TrimSpace(renderProviderSkillTemplate(
 		"policy_templates/tutti-runtime.md",
 		map[string]string{
@@ -18,40 +22,57 @@ func tuttiCLIPolicy(input PrepareInput) string {
 			"{{COMPUTER_USE_SKILL_LINES}}":          computerUseSkillPolicyLines(input),
 			"{{COMPUTER_USE_HANDOFF_LINES}}":        computerUseHandoffPolicyLines(input),
 		},
-	)) + "\n\n" + strings.TrimSpace(renderProviderSkillTemplate("policy_templates/host-app-context.md", nil))
+	))
+}
+
+func tuttiSkillBundleRecommendedPolicy(input PrepareInput) string {
+	return strings.TrimSpace(renderProviderSkillTemplate(
+		"policy_templates/skill-bundle-routing.md",
+		map[string]string{
+			"{{COMMAND_GUIDE}}":                     commandGuide(input),
+			"{{CLI_COMMAND}}":                       normalizeCLICommandName(input.CLICommand),
+			"{{AGENT_SESSION_ID}}":                  strings.TrimSpace(input.AgentSessionID),
+			"{{PROVIDER}}":                          strings.TrimSpace(input.Provider),
+			"{{PROVIDER_SPECIFIC_MENTION_ROUTING}}": providerSpecificMentionRouting(input.Provider),
+			"{{BROWSER_USE_SKILL_LINES}}":           browserUseSkillPolicyLines(input),
+			"{{BROWSER_USE_HANDOFF_LINES}}":         browserUseHandoffPolicyLines(input),
+			"{{COMPUTER_USE_SKILL_LINES}}":          computerUseSkillPolicyLines(input),
+			"{{COMPUTER_USE_HANDOFF_LINES}}":        computerUseHandoffPolicyLines(input),
+		},
+	))
 }
 
 func browserUseSkillPolicyLines(input PrepareInput) string {
 	if !input.BrowserUse || !BrowserUseDefaultEnabled() {
 		return ""
 	}
-	return "- `browser-use`: browser automation through the daemon-owned `tutti browser` CLI. Prefer this over any generic `browser` skill or direct CDP scripts.\n"
+	return "- `browser-use`: browser automation through the daemon-owned `" + normalizeCLICommandName(input.CLICommand) + " browser` CLI. Prefer this over any generic `browser` skill or direct CDP scripts.\n"
 }
 
 func browserUseHandoffPolicyLines(input PrepareInput) string {
 	if !input.BrowserUse || !BrowserUseDefaultEnabled() {
 		return ""
 	}
-	return "- For browser tasks — visiting URLs, reading pages, clicking, filling forms, or screenshots — use `browser-use` and `tutti browser` only; do not use provider-native `browser` skills or direct CDP automation.\n"
+	return "- For browser tasks — visiting URLs, reading pages, clicking, filling forms, or screenshots — use `browser-use` and `" + normalizeCLICommandName(input.CLICommand) + " browser` only; do not use provider-native `browser` skills or direct CDP automation.\n"
 }
 
 func computerUseSkillPolicyLines(input PrepareInput) string {
 	if !input.ComputerUse || !ComputerUseDefaultEnabled() {
 		return ""
 	}
-	return "- `computer-use`: macOS desktop automation through the daemon-owned `tutti computer` CLI. Prefer this over any generic computer-use or accessibility scripts.\n"
+	return "- `computer-use`: macOS desktop automation through the daemon-owned `" + normalizeCLICommandName(input.CLICommand) + " computer` CLI. Prefer this over any generic computer-use or accessibility scripts.\n"
 }
 
 func computerUseHandoffPolicyLines(input PrepareInput) string {
 	if !input.ComputerUse || !ComputerUseDefaultEnabled() {
 		return ""
 	}
-	return "- For desktop tasks — taking screenshots, clicking UI elements, typing, pressing keys, or scrolling on the macOS desktop — use `computer-use` and `tutti computer` only; do not use provider-native computer-use tools or accessibility scripts.\n"
+	return "- For desktop tasks — taking screenshots, clicking UI elements, typing, pressing keys, or scrolling on the macOS desktop — use `computer-use` and `" + normalizeCLICommandName(input.CLICommand) + " computer` only; do not use provider-native computer-use tools or accessibility scripts.\n"
 }
 
 func providerSpecificMentionRouting(provider string) string {
 	switch strings.TrimSpace(provider) {
-	case "claude-code":
+	case "claude", "claude-code":
 		return strings.TrimSpace(`
 Claude Code mention routing:
 

--- a/services/tuttid/service/agentsidecar/types.go
+++ b/services/tuttid/service/agentsidecar/types.go
@@ -11,6 +11,10 @@ type Preparer interface {
 	Cleanup(context.Context, CleanupInput) error
 }
 
+type SkillBundleRenderer interface {
+	RenderSkillBundle(context.Context, PrepareInput) (SkillBundle, error)
+}
+
 type PrepareInput struct {
 	WorkspaceID      string
 	AgentSessionID   string
@@ -37,6 +41,34 @@ type PreparedRuntime struct {
 type ProviderSkillBundle struct {
 	Name  string
 	Files map[string]string
+}
+
+type SkillBundle struct {
+	SchemaVersion           int                          `json:"schemaVersion"`
+	Provider                string                       `json:"provider"`
+	AgentSessionID          string                       `json:"agentSessionId"`
+	CLICommand              string                       `json:"cliCommand"`
+	RecommendedSystemPrompt *RecommendedSystemPrompt     `json:"recommendedSystemPrompt,omitempty"`
+	Skills                  []SkillMaterializationRecord `json:"skills"`
+}
+
+type RecommendedSystemPrompt struct {
+	Format  string `json:"format"`
+	Content string `json:"content"`
+}
+
+type SkillMaterializationRecord struct {
+	Content          string                     `json:"content,omitempty"`
+	Files            []SkillMaterializationFile `json:"files,omitempty"`
+	SkillID          string                     `json:"skillId"`
+	Slug             string                     `json:"slug"`
+	DeliveryMode     string                     `json:"deliveryMode"`
+	MaterializedPath string                     `json:"materializedPath,omitempty"`
+}
+
+type SkillMaterializationFile struct {
+	Content string `json:"content"`
+	Path    string `json:"path"`
 }
 
 type CleanupInput struct {

--- a/services/tuttid/service/cli/framework/register.go
+++ b/services/tuttid/service/cli/framework/register.go
@@ -18,6 +18,7 @@ func Register[T any](spec CommandSpec[T]) cliservice.Command {
 			Path:        spec.Path,
 			Summary:     strings.TrimSpace(spec.Summary),
 			Description: strings.TrimSpace(spec.Description),
+			Visibility:  spec.Visibility,
 			InputSchema: Schema(spec.Inputs),
 			Output: cliservice.CapabilityOutput{
 				DefaultMode: spec.Output.DefaultMode,

--- a/services/tuttid/service/cli/framework/spec.go
+++ b/services/tuttid/service/cli/framework/spec.go
@@ -40,6 +40,7 @@ type CommandSpec[T any] struct {
 	Summary     string
 	Description string
 	Kind        CommandKind
+	Visibility  cliservice.CapabilityVisibility
 	Workspace   WorkspacePolicy
 	Workspaces  cliservice.WorkspaceCatalog
 	Inputs      InputSpec

--- a/services/tuttid/service/cli/providers/agentcontext/provider.go
+++ b/services/tuttid/service/cli/providers/agentcontext/provider.go
@@ -23,6 +23,7 @@ type AgentSessions interface {
 	Create(context.Context, string, agentservice.CreateSessionInput) (agentservice.Session, error)
 	Get(context.Context, string, string) (agentservice.Session, error)
 	GetComposerOptions(context.Context, agentservice.ComposerOptionsInput) (agentservice.ComposerOptions, error)
+	GetSkillBundle(context.Context, string, agentservice.SkillBundleInput) (agentservice.SkillBundle, error)
 	List(context.Context, string) ([]agentservice.Session, error)
 	ListActivePeers(context.Context, string) (agentservice.ActivePeers, error)
 	ListMessages(context.Context, string, string, agentservice.ListMessagesInput) (agentservice.SessionMessagesPage, error)
@@ -75,6 +76,7 @@ func (p Provider) Commands() []cliservice.Command {
 	return []cliservice.Command{
 		p.newProvidersCommand(),
 		p.newComposerOptionsCommand(),
+		p.newSkillBundleCommand(),
 		p.newProviderStartCommand(providerStartCommandSpec{
 			AppID:       codexAgentAppID,
 			AppName:     "Codex",

--- a/services/tuttid/service/cli/providers/agentcontext/provider_test.go
+++ b/services/tuttid/service/cli/providers/agentcontext/provider_test.go
@@ -619,6 +619,9 @@ func TestSkillBundleCommandReturnsAgentACPKitShape(t *testing.T) {
 		strings.Join(command.Capability.Path, " ") != "agent tutti-cli-skill-bundle" {
 		t.Fatalf("command capability = %#v", command.Capability)
 	}
+	if command.Capability.Visibility != cliservice.CapabilityVisibilityIntegration {
+		t.Fatalf("visibility = %q, want integration", command.Capability.Visibility)
+	}
 
 	output, err := command.Handler(context.Background(), cliservice.InvokeRequest{
 		Input: map[string]any{

--- a/services/tuttid/service/cli/providers/agentcontext/provider_test.go
+++ b/services/tuttid/service/cli/providers/agentcontext/provider_test.go
@@ -48,6 +48,7 @@ type fakeAgentSessions struct {
 	createCallCount int
 	createInput     agentservice.CreateSessionInput
 	composerInput   agentservice.ComposerOptionsInput
+	skillBundleIn   agentservice.SkillBundleInput
 	sendInput       agentservice.SendInput
 	getSession      agentservice.Session
 	getErr          error
@@ -157,6 +158,29 @@ func (f *fakeAgentSessions) GetComposerOptions(_ context.Context, input agentser
 					"value": "gpt-5",
 				}},
 			}},
+		},
+	}, nil
+}
+
+func (f *fakeAgentSessions) GetSkillBundle(_ context.Context, workspaceID string, input agentservice.SkillBundleInput) (agentservice.SkillBundle, error) {
+	f.workspaceID = workspaceID
+	f.skillBundleIn = input
+	return agentservice.SkillBundle{
+		SchemaVersion:  1,
+		Provider:       input.Provider,
+		AgentSessionID: input.AgentSessionID,
+		CLICommand:     "tutti-dev",
+		RecommendedSystemPrompt: &agentservice.RecommendedSystemPrompt{
+			Format:  "text/markdown",
+			Content: "Use Tutti skills for mention routing.",
+		},
+		Skills: []agentservice.SkillMaterializationRecord{
+			{
+				Content:      "---\nname: tutti-cli\n---\nUse tutti.\n",
+				SkillID:      "tutti/tutti-cli",
+				Slug:         "tutti-cli",
+				DeliveryMode: "materialized-files",
+			},
 		},
 	}, nil
 }
@@ -585,6 +609,81 @@ func TestComposerOptionsCommandUsesComposerDefaultsFromPreferences(t *testing.T)
 		sessions.composerInput.Settings.PermissionModeID != "full-access" ||
 		sessions.composerInput.Settings.ReasoningEffort != "high" {
 		t.Fatalf("composer input = %#v", sessions.composerInput)
+	}
+}
+
+func TestSkillBundleCommandReturnsAgentACPKitShape(t *testing.T) {
+	sessions := &fakeAgentSessions{}
+	command := NewProvider(fakeWorkspaceCatalog{startup: workspacebiz.Summary{ID: "workspace-1"}}, sessions).newSkillBundleCommand()
+	if command.Capability.ID != appID+".agent.tutti-cli-skill-bundle" ||
+		strings.Join(command.Capability.Path, " ") != "agent tutti-cli-skill-bundle" {
+		t.Fatalf("command capability = %#v", command.Capability)
+	}
+
+	output, err := command.Handler(context.Background(), cliservice.InvokeRequest{
+		Input: map[string]any{
+			"agent-session-id": "run-1",
+			"browser-use":      "true",
+			"provider":         "codex",
+		},
+	})
+	if err != nil {
+		t.Fatalf("Handler: %v", err)
+	}
+	if sessions.workspaceID != "workspace-1" {
+		t.Fatalf("workspaceID = %q, want workspace-1", sessions.workspaceID)
+	}
+	if sessions.skillBundleIn.Provider != "codex" ||
+		sessions.skillBundleIn.AgentSessionID != "run-1" ||
+		!sessions.skillBundleIn.BrowserUse ||
+		sessions.skillBundleIn.ComputerUse {
+		t.Fatalf("skill bundle input = %#v", sessions.skillBundleIn)
+	}
+	if output.Kind != cliservice.OutputModeJSON {
+		t.Fatalf("output kind = %q, want json", output.Kind)
+	}
+	skills, ok := output.Value["skills"].([]any)
+	if !ok || len(skills) != 1 {
+		t.Fatalf("skills output = %#v", output.Value["skills"])
+	}
+	first, ok := skills[0].(map[string]any)
+	if !ok {
+		t.Fatalf("first skill = %#v", skills[0])
+	}
+	recommended, ok := output.Value["recommendedSystemPrompt"].(map[string]any)
+	if !ok {
+		t.Fatalf("recommendedSystemPrompt = %#v", output.Value["recommendedSystemPrompt"])
+	}
+	if output.Value["schemaVersion"] != 1 ||
+		output.Value["provider"] != "codex" ||
+		output.Value["agentSessionId"] != "run-1" ||
+		output.Value["cliCommand"] != "tutti-dev" ||
+		recommended["format"] != "text/markdown" ||
+		recommended["content"] != "Use Tutti skills for mention routing." ||
+		first["skillId"] != "tutti/tutti-cli" ||
+		first["slug"] != "tutti-cli" ||
+		first["deliveryMode"] != "materialized-files" ||
+		first["materializedPath"] != nil {
+		t.Fatalf("skill bundle output = %#v", output.Value)
+	}
+}
+
+func TestSkillBundleSkillsValuePreservesMaterializedPathWhenPresent(t *testing.T) {
+	values := skillBundleSkillsValue([]agentservice.SkillMaterializationRecord{
+		{
+			SkillID:          "app/custom",
+			Slug:             "custom",
+			DeliveryMode:     "materialized-files",
+			MaterializedPath: "/workspace/.local-agent/runs/run-1/skills/custom",
+		},
+	})
+
+	first, ok := values[0].(map[string]any)
+	if !ok {
+		t.Fatalf("first skill = %#v", values[0])
+	}
+	if first["materializedPath"] != "/workspace/.local-agent/runs/run-1/skills/custom" {
+		t.Fatalf("skill value = %#v", first)
 	}
 }
 

--- a/services/tuttid/service/cli/providers/agentcontext/skill_bundle.go
+++ b/services/tuttid/service/cli/providers/agentcontext/skill_bundle.go
@@ -22,6 +22,7 @@ func (p Provider) newSkillBundleCommand() cliservice.Command {
 		Summary:     "Get Tutti CLI skill bundle",
 		Description: "Get a dynamically rendered Tutti skill bundle for an external agent runtime.",
 		Kind:        framework.KindGet,
+		Visibility:  cliservice.CapabilityVisibilityIntegration,
 		Workspace:   framework.WorkspaceRequired,
 		Workspaces:  p.workspaces,
 		Inputs:      framework.FromStruct[skillBundleInput](),

--- a/services/tuttid/service/cli/providers/agentcontext/skill_bundle.go
+++ b/services/tuttid/service/cli/providers/agentcontext/skill_bundle.go
@@ -1,0 +1,102 @@
+package agentcontext
+
+import (
+	"context"
+
+	agentservice "github.com/tutti-os/tutti/services/tuttid/service/agent"
+	cliservice "github.com/tutti-os/tutti/services/tuttid/service/cli"
+	"github.com/tutti-os/tutti/services/tuttid/service/cli/framework"
+)
+
+type skillBundleInput struct {
+	AgentSessionID string `cli:"agent-session-id"`
+	BrowserUse     bool   `cli:"browser-use"`
+	ComputerUse    bool   `cli:"computer-use"`
+	Provider       string `cli:"provider" validate:"required"`
+}
+
+func (p Provider) newSkillBundleCommand() cliservice.Command {
+	return framework.Register(framework.CommandSpec[skillBundleInput]{
+		ID:          appID + ".agent.tutti-cli-skill-bundle",
+		Path:        []string{"agent", "tutti-cli-skill-bundle"},
+		Summary:     "Get Tutti CLI skill bundle",
+		Description: "Get a dynamically rendered Tutti skill bundle for an external agent runtime.",
+		Kind:        framework.KindGet,
+		Workspace:   framework.WorkspaceRequired,
+		Workspaces:  p.workspaces,
+		Inputs:      framework.FromStruct[skillBundleInput](),
+		Output: framework.OutputSpec{
+			DefaultMode: cliservice.OutputModeJSON,
+			DefaultView: framework.ViewDetail,
+			JSON:        true,
+			JSONViews: map[framework.OutputView]func(any) map[string]any{
+				framework.ViewDetail: func(result any) map[string]any {
+					return skillBundleValue(result.(agentservice.SkillBundle))
+				},
+			},
+		},
+		Run: p.runSkillBundle,
+	})
+}
+
+func (p Provider) runSkillBundle(ctx context.Context, invoke framework.InvokeContext, input skillBundleInput) (any, error) {
+	if err := p.requireSessions(); err != nil {
+		return nil, err
+	}
+	return p.sessions.GetSkillBundle(ctx, invoke.WorkspaceID, agentservice.SkillBundleInput{
+		AgentSessionID: input.AgentSessionID,
+		BrowserUse:     input.BrowserUse,
+		ComputerUse:    input.ComputerUse,
+		Provider:       input.Provider,
+	})
+}
+
+func skillBundleValue(bundle agentservice.SkillBundle) map[string]any {
+	value := map[string]any{
+		"schemaVersion":  bundle.SchemaVersion,
+		"provider":       bundle.Provider,
+		"agentSessionId": bundle.AgentSessionID,
+		"cliCommand":     bundle.CLICommand,
+		"skills":         skillBundleSkillsValue(bundle.Skills),
+	}
+	if bundle.RecommendedSystemPrompt != nil {
+		value["recommendedSystemPrompt"] = map[string]any{
+			"format":  bundle.RecommendedSystemPrompt.Format,
+			"content": bundle.RecommendedSystemPrompt.Content,
+		}
+	}
+	return value
+}
+
+func skillBundleSkillsValue(skills []agentservice.SkillMaterializationRecord) []any {
+	values := make([]any, 0, len(skills))
+	for _, skill := range skills {
+		value := map[string]any{
+			"skillId":      skill.SkillID,
+			"slug":         skill.Slug,
+			"deliveryMode": skill.DeliveryMode,
+		}
+		if skill.Content != "" {
+			value["content"] = skill.Content
+		}
+		if len(skill.Files) > 0 {
+			value["files"] = skillBundleFilesValue(skill.Files)
+		}
+		if skill.MaterializedPath != "" {
+			value["materializedPath"] = skill.MaterializedPath
+		}
+		values = append(values, value)
+	}
+	return values
+}
+
+func skillBundleFilesValue(files []agentservice.SkillMaterializationFile) []any {
+	values := make([]any, 0, len(files))
+	for _, file := range files {
+		values = append(values, map[string]any{
+			"path":    file.Path,
+			"content": file.Content,
+		})
+	}
+	return values
+}

--- a/services/tuttid/service/workspace/agent_workspace_app_reference/references/agent-acp-kit.md
+++ b/services/tuttid/service/workspace/agent_workspace_app_reference/references/agent-acp-kit.md
@@ -46,13 +46,32 @@ Map detected provider models to app model IDs with a provider prefix, such as `c
 For each agent run:
 
 1. Create a temporary run directory.
-2. Materialize any app or workspace skills under that directory using relative paths.
+2. Materialize any app-owned skills under that directory using relative paths.
 3. Build a prompt envelope with conversation identity, current user turn, attachments, current app state, collaboration rules, and tool gateway guidance.
-4. Create a run-scoped tool gateway session and MCP config.
-5. Call `localAgentRuntime.run(...)`.
-6. Normalize ACP events into app stream events.
-7. Persist provider session/resume metadata when the kit returns it.
-8. Always revoke the gateway token and remove the temporary run directory in `finally`.
+4. Load Tutti dynamic skill context through `@tutti-os/agent-acp-kit/tutti` when the app runs inside Tutti and needs platform CLI skills.
+5. Create a run-scoped tool gateway session and MCP config.
+6. Call `localAgentRuntime.run(...)`.
+7. Normalize ACP events into app stream events.
+8. Persist provider session/resume metadata when the kit returns it.
+9. Always revoke the gateway token and remove the temporary run directory in `finally`.
+
+Tutti dynamic CLI skills should use the kit helper, not per-app subprocess and JSON parsing code:
+
+```ts
+import { loadTuttiAgentSkillContext } from "@tutti-os/agent-acp-kit/tutti";
+
+const tuttiContext = await loadTuttiAgentSkillContext({
+  provider,
+  agentSessionId: runId,
+  cwd: workspaceCwd,
+  systemPrompt: appSystemPrompt,
+  systemPromptMode: "append-recommended"
+});
+
+const skillManifest = [...appSkillManifest, ...tuttiContext.skillManifest];
+```
+
+The app still owns policy. Use `systemPromptMode: "append-recommended"` only when the app intentionally wants Tutti's recommended prompt appended; otherwise omit it or use `"ignore"`. Do not silently append the recommended prompt, and do not hand-roll `$TUTTI_CLI agent tutti-cli-skill-bundle --json` parsing unless the installed `@tutti-os/agent-acp-kit` version lacks the helper.
 
 Skeleton:
 
@@ -62,7 +81,7 @@ for await (const event of localAgentRuntime.run({
   provider,
   cwd: runDir,
   prompt,
-  systemPrompt,
+  systemPrompt: tuttiContext.systemPrompt,
   model,
   runtimeKind: "local-agent",
   runtimeProvider: provider,

--- a/services/tuttid/service/workspace/agent_workspace_app_reference/references/agent-acp-kit.md
+++ b/services/tuttid/service/workspace/agent_workspace_app_reference/references/agent-acp-kit.md
@@ -63,15 +63,20 @@ import { loadTuttiAgentSkillContext } from "@tutti-os/agent-acp-kit/tutti";
 const tuttiContext = await loadTuttiAgentSkillContext({
   provider,
   agentSessionId: runId,
-  cwd: workspaceCwd,
-  systemPrompt: appSystemPrompt,
-  systemPromptMode: "append-recommended"
+  cwd: workspaceCwd
 });
+
+const systemPrompt = [
+  appSystemPrompt,
+  tuttiContext.recommendedSystemPrompt?.content
+]
+  .filter(Boolean)
+  .join("\n\n");
 
 const skillManifest = [...appSkillManifest, ...tuttiContext.skillManifest];
 ```
 
-The app still owns policy. Use `systemPromptMode: "append-recommended"` only when the app intentionally wants Tutti's recommended prompt appended; otherwise omit it or use `"ignore"`. Do not silently append the recommended prompt, and do not hand-roll `$TUTTI_CLI agent tutti-cli-skill-bundle --json` parsing unless the installed `@tutti-os/agent-acp-kit` version lacks the helper.
+The app still owns policy. `tuttiContext.recommendedSystemPrompt?.content` is raw advisory prompt content: merge it, edit it, place it elsewhere, or ignore it according to the app's prompt strategy. Do not silently append the recommended prompt, and do not hand-roll `$TUTTI_CLI agent tutti-cli-skill-bundle --json` parsing unless the installed `@tutti-os/agent-acp-kit` version lacks the helper.
 
 Skeleton:
 
@@ -81,7 +86,7 @@ for await (const event of localAgentRuntime.run({
   provider,
   cwd: runDir,
   prompt,
-  systemPrompt: tuttiContext.systemPrompt,
+  systemPrompt,
   model,
   runtimeKind: "local-agent",
   runtimeProvider: provider,

--- a/services/tuttid/service/workspace/app_factory_reference/SKILL.md
+++ b/services/tuttid/service/workspace/app_factory_reference/SKILL.md
@@ -132,10 +132,11 @@ The runtime must:
 
 For a full agent-enabled app repository, prefer `$tutti-agent-workspace-app` first. When this skill still needs to package or repair an app that already uses `@tutti-os/agent-acp-kit`, keep the app in control of agent policy:
 
-- Do not make `@tutti-os/agent-acp-kit` product-specific. The app should pass selected skills, MCP servers, and `systemPrompt` explicitly through `runtime.run(...)`.
-- To give the app's local Codex or Claude run access to Tutti's dynamic CLI skills, call `$TUTTI_CLI agent tutti-cli-skill-bundle --provider <provider> --agent-session-id <runId> --json` from the app host process when `$TUTTI_CLI` is available.
-- Parse the command output as the Tutti dynamic skill bundle. Pass `bundle.skills` to `runtime.run({ ..., skillManifest: bundle.skills })`.
-- Treat `bundle.recommendedSystemPrompt?.content` as advisory. The app may merge it into its own `systemPrompt`, edit it, or ignore it; do not inject it silently and do not hide this control inside a generic helper.
+- Keep the generic `@tutti-os/agent-acp-kit` runtime path product-neutral. Tutti-specific behavior should stay behind the explicit `@tutti-os/agent-acp-kit/tutti` subpath and app-owned policy.
+- To give the app's local Codex or Claude run access to Tutti's dynamic CLI skills, prefer the `@tutti-os/agent-acp-kit/tutti` helper instead of hand-writing `$TUTTI_CLI agent tutti-cli-skill-bundle` execution and response parsing in each app.
+- Use `loadTuttiAgentSkillContext(...)` from the app host process. Pass the selected provider, run id, workspace cwd, the app-owned system prompt, and an explicit `systemPromptMode` such as `"append-recommended"` only when the app wants Tutti's recommended prompt appended.
+- Pass `tuttiContext.skillManifest` into `runtime.run({ ..., skillManifest })`, merging it with app-owned skills when needed. Pass `tuttiContext.systemPrompt` as the run system prompt when using the helper to compose the prompt.
+- Treat the helper's prompt composition mode as an app policy choice. Do not silently append Tutti's recommended prompt, and do not reintroduce duplicated CLI parsing unless the installed kit lacks the helper.
 - Keep run-scoped app tools and MCP credentials app-owned. Do not pass broad Tutti daemon credentials or app secrets directly to the agent process.
 
 Do not assume a Tutti API token, browser extension, daemon internals, or broad desktop APIs. The only browser-side host surface a generated app may optionally consume is the app context described in `references/runtime-env.md`.

--- a/services/tuttid/service/workspace/app_factory_reference/SKILL.md
+++ b/services/tuttid/service/workspace/app_factory_reference/SKILL.md
@@ -128,6 +128,16 @@ The runtime must:
 - Use CSS `prefers-color-scheme` / `matchMedia("(prefers-color-scheme: dark)")` for dark/light rendering. Do not pass theme in the launch URL query.
 - When exposing app-owned files through references or generated content, return reference-list `location` objects scoped to `app-data-relative` or `app-package-relative`. Do not emit, persist, or instruct clients to open direct `.tutti` / `.tutti-dev` app state paths such as `$TUTTI_STATE_DIR/apps/...`; the daemon resolves valid locations before desktop clients open files.
 
+## Agent Runtime Integration
+
+For a full agent-enabled app repository, prefer `$tutti-agent-workspace-app` first. When this skill still needs to package or repair an app that already uses `@tutti-os/agent-acp-kit`, keep the app in control of agent policy:
+
+- Do not make `@tutti-os/agent-acp-kit` product-specific. The app should pass selected skills, MCP servers, and `systemPrompt` explicitly through `runtime.run(...)`.
+- To give the app's local Codex or Claude run access to Tutti's dynamic CLI skills, call `$TUTTI_CLI agent tutti-cli-skill-bundle --provider <provider> --agent-session-id <runId> --json` from the app host process when `$TUTTI_CLI` is available.
+- Parse the command output as the Tutti dynamic skill bundle. Pass `bundle.skills` to `runtime.run({ ..., skillManifest: bundle.skills })`.
+- Treat `bundle.recommendedSystemPrompt?.content` as advisory. The app may merge it into its own `systemPrompt`, edit it, or ignore it; do not inject it silently and do not hide this control inside a generic helper.
+- Keep run-scoped app tools and MCP credentials app-owned. Do not pass broad Tutti daemon credentials or app secrets directly to the agent process.
+
 Do not assume a Tutti API token, browser extension, daemon internals, or broad desktop APIs. The only browser-side host surface a generated app may optionally consume is the app context described in `references/runtime-env.md`.
 
 ## Dependency Rules

--- a/services/tuttid/service/workspace/app_factory_reference/SKILL.md
+++ b/services/tuttid/service/workspace/app_factory_reference/SKILL.md
@@ -134,9 +134,9 @@ For a full agent-enabled app repository, prefer `$tutti-agent-workspace-app` fir
 
 - Keep the generic `@tutti-os/agent-acp-kit` runtime path product-neutral. Tutti-specific behavior should stay behind the explicit `@tutti-os/agent-acp-kit/tutti` subpath and app-owned policy.
 - To give the app's local Codex or Claude run access to Tutti's dynamic CLI skills, prefer the `@tutti-os/agent-acp-kit/tutti` helper instead of hand-writing `$TUTTI_CLI agent tutti-cli-skill-bundle` execution and response parsing in each app.
-- Use `loadTuttiAgentSkillContext(...)` from the app host process. Pass the selected provider, run id, workspace cwd, the app-owned system prompt, and an explicit `systemPromptMode` such as `"append-recommended"` only when the app wants Tutti's recommended prompt appended.
-- Pass `tuttiContext.skillManifest` into `runtime.run({ ..., skillManifest })`, merging it with app-owned skills when needed. Pass `tuttiContext.systemPrompt` as the run system prompt when using the helper to compose the prompt.
-- Treat the helper's prompt composition mode as an app policy choice. Do not silently append Tutti's recommended prompt, and do not reintroduce duplicated CLI parsing unless the installed kit lacks the helper.
+- Use `loadTuttiAgentSkillContext(...)` from the app host process. Pass the selected provider, run id, workspace cwd, and optional Tutti CLI command configuration such as `commandEnvNames`.
+- Pass `tuttiContext.skillManifest` into `runtime.run({ ..., skillManifest })`, merging it with app-owned skills when needed.
+- Treat `tuttiContext.recommendedSystemPrompt?.content` as advisory raw prompt content. The app may merge it into its own `systemPrompt`, edit it, place it elsewhere, or ignore it. Do not inject it silently, and do not reintroduce duplicated CLI parsing unless the installed kit lacks the helper.
 - Keep run-scoped app tools and MCP credentials app-owned. Do not pass broad Tutti daemon credentials or app secrets directly to the agent process.
 
 Do not assume a Tutti API token, browser extension, daemon internals, or broad desktop APIs. The only browser-side host surface a generated app may optionally consume is the app context described in `references/runtime-env.md`.


### PR DESCRIPTION
## Summary
- add a daemon-rendered Tutti dynamic skill bundle for external agent runtimes
- expose `agent tutti-cli-skill-bundle` through the agent-context CLI provider
- add routing policy, optional browser/computer skill CLI command templating, and coverage for bundle output shape
- document app factory guidance for consuming `@tutti-os/agent-acp-kit` with the Tutti bundle

## Validation
- `pnpm check:changed --tail-lines 80`
- `pnpm lint:go`
- `pnpm test:go`
- `pnpm build:go`
- pre-push `pnpm check:full`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new agent CLI command to fetch a dynamically rendered skill bundle, including optional browser/computer guidance and an optional recommended system prompt.
  * Introduced a new skill-bundle retrieval capability for agent sessions.
  * Skill-bundle execution/policy text is now generated with the active CLI command name.
* **Bug Fixes**
  * Skill-bundle capability handling now excludes specific skill-bundle capability IDs from command guidance.
  * Skill-bundle requests now trim/validate inputs and return a clear “bundle unavailable” error when no renderer is available.
  * Command capability visibility is now respected from command specs.
* **Documentation**
  * Updated skill-routing policy docs and revised browser/computer skill templates and runtime integration guidance.
* **Tests**
  * Added coverage for rendering, optional-skill gating, and JSON output shape.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->