### PR TITLE
fix(workspace-apps): stop list-triggered runtime preload

### DIFF
--- a/apps/desktop/src/renderer/src/features/agent-reference-sources/appReferenceListBackend.ts
+++ b/apps/desktop/src/renderer/src/features/agent-reference-sources/appReferenceListBackend.ts
@@ -22,10 +22,23 @@ import type {
 const APP_REFERENCE_PAGE_LIMIT = 200;
 const APP_MARKER = "app:";
 const GROUP_MARKER = "|grp:";
+const REFERENCE_SUPPORTING_APPS_CACHE_TTL_MS = 2_000;
 
 type AppReferenceListItem = Awaited<
   ReturnType<TuttidClient["listWorkspaceAppReferences"]>
 >["items"][number];
+type ReferenceSupportingApp = Awaited<
+  ReturnType<TuttidClient["listWorkspaceApps"]>
+>["apps"][number];
+type ReferenceSupportingAppsCacheEntry = {
+  expiresAt: number;
+  promise: Promise<ReferenceSupportingApp[]>;
+};
+
+const referenceSupportingAppsCache = new WeakMap<
+  TuttidClient,
+  Map<string, ReferenceSupportingAppsCacheEntry>
+>();
 
 export function createAppReferenceListBackend(
   tuttidClient: TuttidClient
@@ -203,10 +216,35 @@ export async function listReferenceSupportingApps(
   tuttidClient: TuttidClient,
   scope: ReferenceScope
 ) {
-  const response = await tuttidClient.listWorkspaceApps(scope.workspaceId);
-  return response.apps.filter(
-    (app) => app.references.listSupported && app.installed && app.enabled
-  );
+  const workspaceID = scope.workspaceId;
+  let clientCache = referenceSupportingAppsCache.get(tuttidClient);
+  if (!clientCache) {
+    clientCache = new Map();
+    referenceSupportingAppsCache.set(tuttidClient, clientCache);
+  }
+  const now = Date.now();
+  const cached = clientCache.get(workspaceID);
+  if (cached && cached.expiresAt > now) {
+    return cached.promise;
+  }
+
+  const promise = tuttidClient
+    .listWorkspaceApps(workspaceID)
+    .then((response) =>
+      response.apps.filter(
+        (app) => app.references.listSupported && app.installed && app.enabled
+      )
+    );
+  clientCache.set(workspaceID, {
+    expiresAt: now + REFERENCE_SUPPORTING_APPS_CACHE_TTL_MS,
+    promise
+  });
+  void promise.catch(() => {
+    if (clientCache.get(workspaceID)?.promise === promise) {
+      clientCache.delete(workspaceID);
+    }
+  });
+  return promise;
 }
 
 function appItemToProtocol(

--- a/apps/desktop/src/renderer/src/features/agent-reference-sources/referenceHandle.test.ts
+++ b/apps/desktop/src/renderer/src/features/agent-reference-sources/referenceHandle.test.ts
@@ -4,7 +4,10 @@ import type { TuttidClient } from "@tutti-os/client-tuttid-ts";
 import type { ReferenceScope } from "@tutti-os/workspace-file-reference/contracts";
 import type { ReferenceListItem } from "@tutti-os/workspace-file-reference/core";
 import { createIssueReferenceListBackend } from "./issueReferenceListBackend.ts";
-import { createAppReferenceListBackend } from "./appReferenceListBackend.ts";
+import {
+  createAppReferenceListBackend,
+  listReferenceSupportingApps
+} from "./appReferenceListBackend.ts";
 
 const scope: ReferenceScope = { workspaceId: "workspace-1" };
 
@@ -113,6 +116,46 @@ test("app backend labels child groups with app and project names", async () => {
       ? childGroup.parentLabel
       : undefined,
     "Prototype Design / 23232"
+  );
+});
+
+test("app reference app discovery caches repeated workspace app listing", async () => {
+  let listCalls = 0;
+  const tuttidClient = {
+    listWorkspaceApps: async () => {
+      listCalls += 1;
+      return {
+        apps: [
+          {
+            appId: "ready-app",
+            displayName: "Ready",
+            installed: true,
+            enabled: true,
+            references: { listSupported: true, searchSupported: false }
+          },
+          {
+            appId: "disabled-app",
+            displayName: "Disabled",
+            installed: true,
+            enabled: false,
+            references: { listSupported: true, searchSupported: false }
+          }
+        ]
+      };
+    }
+  } as unknown as TuttidClient;
+
+  const first = await listReferenceSupportingApps(tuttidClient, scope);
+  const second = await listReferenceSupportingApps(tuttidClient, scope);
+
+  assert.equal(listCalls, 1);
+  assert.deepEqual(
+    first.map((app) => app.appId),
+    ["ready-app"]
+  );
+  assert.deepEqual(
+    second.map((app) => app.appId),
+    ["ready-app"]
   );
 });
 

--- a/docs/conventions/troubleshooting.md
+++ b/docs/conventions/troubleshooting.md
@@ -43,6 +43,32 @@ Use this shape for new entries:
 
 ## Current Entries
 
+### App Center list requests repeatedly log runtime preload
+
+- Symptom:
+  `tuttid` logs repeated `workspace app runtime preload started` and
+  `workspace app runtime preload completed` lines while App Center is merely
+  open or refreshing, even when the user is not installing an app.
+- Quick checks:
+  Trace the call path from `ListWorkspaceApps` to
+  `AppCenterService.List`. A list or catalog refresh request should not call
+  `AppRunner.PreloadRuntimeForProfile` or the managed runtime resolver.
+- Root cause:
+  Treating App Center list/read requests as an opportunity to prepare runtimes
+  gives a pure read operation hidden background side effects. Frequent renderer
+  refreshes then turn a fast idempotent runtime check into noisy repeated logs.
+- Fix:
+  Keep passive runtime preloading in daemon startup or another explicit
+  runtime-preparation workflow. Install, launch, retry, and enabled-app start
+  paths may still resolve runtimes because they actually need executable app
+  runtimes.
+- Validation:
+  Add or run service coverage that `AppCenterService.List` returns visible
+  uninstalled apps without invoking the runtime resolver.
+- References:
+  [apps.go](../../services/tuttid/service/workspace/apps.go)
+  [apps_test.go](../../services/tuttid/service/workspace/apps_test.go)
+
 ### Load unpacked project roots with source manifests
 
 - Symptom:

--- a/docs/conventions/workspace-app-runtime.md
+++ b/docs/conventions/workspace-app-runtime.md
@@ -114,12 +114,14 @@ The runtime catalog consumed by tuttid has this shape:
 ```
 
 tuttid resolves the `baseline` profile by default when launching apps, and may
-preload smaller profiles such as `node-static` in the background before first
-launch. App manifests must not declare a runtime kind. Apps that only need Node
-may declare `runtime.profile: "node-static"` so launch does not require the
-Python component. If runtime requirements need to become more selective later,
-add a capability list such as runtime component requirements rather than
-restoring a single-kind manifest field.
+preload smaller profiles such as `node-static` during daemon startup or an
+explicit runtime-preparation workflow before first launch. Listing App Center
+apps must not preload runtimes as a side effect. App manifests must not declare
+a runtime kind. Apps that only need Node may declare
+`runtime.profile: "node-static"` so launch does not require the Python
+component. If runtime requirements need to become more selective later, add a
+capability list such as runtime component requirements rather than restoring a
+single-kind manifest field.
 
 ## Runtime Overrides
 

--- a/services/tuttid/service/workspace/app_factory_reference/references/runtime-env.md
+++ b/services/tuttid/service/workspace/app_factory_reference/references/runtime-env.md
@@ -25,7 +25,7 @@ For local Tutti capabilities, use `TUTTI_CLI`.
 
 Tutti keeps the managed runtime baseline outside app packages under daemon-owned state. Operators can override the cache with `TUTTI_APP_RUNTIME_CACHE_ROOT`, point at an exact prepared runtime with `TUTTI_APP_RUNTIME_ROOT`, or override first-use runtime downloads with `TUTTI_APP_RUNTIME_CATALOG`. App packages must not set these variables themselves.
 
-Opening App Center may silently preload the managed runtime when uninstalled apps are visible. If the runtime is still missing when an installed app starts, Tutti reports the app as `preparing` while it resolves or downloads the runtime, then moves to `starting` only when `bootstrap.sh` is about to launch.
+tuttid may preload the managed runtime during daemon startup or an explicit runtime-preparation workflow, but listing App Center apps does not preload runtimes as a side effect. If the runtime is still missing when an installed app starts, Tutti reports the app as `preparing` while it resolves or downloads the runtime, then moves to `starting` only when `bootstrap.sh` is about to launch.
 
 Prefer a small local server with Python standard library or Node built-ins. Avoid startup-time dependency installation. If build or install steps are necessary, put them in executable `prepare.sh`, not `bootstrap.sh`. `prepare.sh` may use the managed runtime variables for dependency installation and build commands. `bootstrap.sh` should only launch the already prepared app server.
 

--- a/services/tuttid/service/workspace/app_references_test.go
+++ b/services/tuttid/service/workspace/app_references_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http/httptest"
 	"path/filepath"
 	"testing"
+	"time"
 
 	workspacebiz "github.com/tutti-os/tutti/services/tuttid/biz/workspace"
 )
@@ -492,9 +493,11 @@ func assertRuntimeResolverNotCalled(t *testing.T, resolver *appRuntimeResolverSt
 	if resolver == nil {
 		return
 	}
+	timer := time.NewTimer(50 * time.Millisecond)
+	defer timer.Stop()
 	select {
 	case <-resolver.called:
 		t.Fatal("runtime resolver was called")
-	default:
+	case <-timer.C:
 	}
 }

--- a/services/tuttid/service/workspace/apps.go
+++ b/services/tuttid/service/workspace/apps.go
@@ -32,10 +32,9 @@ type AppCenterService struct {
 	ArtifactFetcher        AppArtifactFetcher
 	RemoteCatalogRefresher func(context.Context, string) (builtinapps.CatalogSnapshot, error)
 
-	mu                     sync.Mutex
-	stateRevisions         map[string]int64
-	appProjectionKeys      map[string]workspaceAppProjectionKey
-	runtimePreloadInFlight bool
+	mu                sync.Mutex
+	stateRevisions    map[string]int64
+	appProjectionKeys map[string]workspaceAppProjectionKey
 
 	installMu             sync.Mutex
 	installJobs           map[string]workspaceAppInstallJob
@@ -169,7 +168,6 @@ func (s *AppCenterService) listWithBuiltins(ctx context.Context, workspaceID str
 	if err != nil {
 		return nil, err
 	}
-	s.maybePreloadRuntimeForUninstalledApps(apps)
 	apps = s.withInstallJobProjections(apps, workspaceID)
 	return apps, nil
 }
@@ -499,43 +497,6 @@ func (s *AppCenterService) runner() *AppRunner {
 		s.Runner.OnStateChanged = s.handleRunnerStateChanged
 	}
 	return s.Runner
-}
-
-func (s *AppCenterService) maybePreloadRuntimeForUninstalledApps(apps []workspacebiz.WorkspaceApp) {
-	for _, app := range apps {
-		if app.Installation == nil && !appRuntimeProfileIsStandalone(appRuntimeProfileForPackage(app.Package)) {
-			s.startRuntimePreload()
-			return
-		}
-	}
-}
-
-func (s *AppCenterService) startRuntimePreload() {
-	s.mu.Lock()
-	if s.runtimePreloadInFlight {
-		s.mu.Unlock()
-		return
-	}
-	s.runtimePreloadInFlight = true
-	runner := s.runner()
-	s.mu.Unlock()
-
-	go func() {
-		startedAt := time.Now()
-		slog.Info("workspace app runtime preload started", "profile", workspaceAppNodeRuntimePreloadProfile)
-		defer func() {
-			s.mu.Lock()
-			s.runtimePreloadInFlight = false
-			s.mu.Unlock()
-		}()
-		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Minute)
-		defer cancel()
-		if err := runner.PreloadRuntimeForProfile(ctx, workspaceAppNodeRuntimePreloadProfile); err != nil {
-			slog.Warn("workspace app runtime preload failed", "profile", workspaceAppNodeRuntimePreloadProfile, "durationMs", time.Since(startedAt).Milliseconds(), "error", err)
-			return
-		}
-		slog.Info("workspace app runtime preload completed", "profile", workspaceAppNodeRuntimePreloadProfile, "durationMs", time.Since(startedAt).Milliseconds())
-	}()
 }
 
 func (s *AppCenterService) handleRunnerStateChanged(workspaceID string, appID string, state workspacebiz.AppRuntimeState) {

--- a/services/tuttid/service/workspace/apps_runtime.go
+++ b/services/tuttid/service/workspace/apps_runtime.go
@@ -103,7 +103,6 @@ func (s *AppCenterService) StartEnabled(ctx context.Context, workspaceID string)
 	}
 	remoteBuiltins := remoteBuiltinByAppID(builtins)
 
-	remoteBuiltinInstallStarted := false
 	for _, installation := range installations {
 		if !installation.Enabled {
 			continue
@@ -118,13 +117,11 @@ func (s *AppCenterService) StartEnabled(ctx context.Context, workspaceID string)
 				return nil, err
 			}
 			s.startRemoteBuiltinInstallJob(workspaceID, remoteBuiltin)
-			remoteBuiltinInstallStarted = true
 			slog.Warn("workspace app start enabled deferred app; package unavailable locally", "workspaceId", workspaceID, "appId", installation.AppID)
 			continue
 		}
 		if remoteBuiltin, ok := remoteBuiltins[installation.AppID]; ok && shouldMaterializeRemoteBuiltin(appPackage, remoteBuiltin) {
 			s.startRemoteBuiltinInstallJob(workspaceID, remoteBuiltin)
-			remoteBuiltinInstallStarted = true
 			slog.Info(
 				"workspace app start enabled deferred app; remote builtin update available",
 				"workspaceId", workspaceID,
@@ -161,9 +158,6 @@ func (s *AppCenterService) StartEnabled(ctx context.Context, workspaceID string)
 		}
 	}
 	slog.Info("workspace app start enabled completed", "workspaceId", workspaceID, "enabledAppCount", len(enabledAppIDs), "duration", time.Since(startedAt), "durationMs", time.Since(startedAt).Milliseconds())
-	if !remoteBuiltinInstallStarted {
-		s.startRuntimePreload()
-	}
 
 	if len(enabledAppIDs) > 0 {
 		return s.listWithBuiltins(ctx, workspaceID, builtins)

--- a/services/tuttid/service/workspace/apps_test.go
+++ b/services/tuttid/service/workspace/apps_test.go
@@ -409,7 +409,7 @@ func (s *appStoreStub) ListWorkspaceAppInstallationsByApp(_ context.Context, app
 	return result, nil
 }
 
-func TestAppCenterServiceListPreloadsRuntimeForUninstalledApps(t *testing.T) {
+func TestAppCenterServiceListDoesNotPreloadRuntimeForUninstalledApps(t *testing.T) {
 	t.Parallel()
 
 	store := newAppStoreStub()
@@ -449,11 +449,50 @@ func TestAppCenterServiceListPreloadsRuntimeForUninstalledApps(t *testing.T) {
 	if len(apps) != 1 || apps[0].Installation != nil {
 		t.Fatalf("List() apps = %#v", apps)
 	}
-	select {
-	case <-resolver.called:
-	case <-time.After(time.Second):
-		t.Fatalf("List() did not preload runtime for uninstalled app")
+	assertRuntimeResolverNotCalled(t, resolver)
+}
+
+func TestAppCenterServiceRefreshCatalogDoesNotPreloadRuntimeForUninstalledApps(t *testing.T) {
+	t.Parallel()
+
+	store := newAppStoreStub()
+	appPackage := workspacebiz.AppPackage{
+		AppID:   "local-app",
+		Version: "1.0.0",
+		Manifest: workspacebiz.AppManifest{
+			SchemaVersion: workspacebiz.AppManifestSchemaVersionV1,
+			AppID:         "local-app",
+			Version:       "1.0.0",
+			Name:          "Local App",
+			Runtime: workspacebiz.AppManifestRuntime{
+				Bootstrap:       "bootstrap.sh",
+				HealthcheckPath: "/",
+			},
+		},
+		Source: workspacebiz.AppPackageSourceGenerated,
 	}
+	if err := store.PutAppPackage(context.Background(), appPackage); err != nil {
+		t.Fatalf("PutAppPackage() error = %v", err)
+	}
+	resolver := &appRuntimeResolverStub{called: make(chan struct{})}
+	service := AppCenterService{
+		Store:          store,
+		WorkspaceStore: &catalogStoreStub{getWorkspace: workspacebiz.Summary{ID: "ws-1", Name: "Workspace"}},
+		Runner:         &AppRunner{RuntimeResolver: resolver},
+		StateDir:       t.TempDir(),
+		BuiltinCatalog: func() ([]builtinapps.App, error) {
+			return nil, nil
+		},
+	}
+
+	apps, err := service.RefreshCatalog(context.Background(), "ws-1")
+	if err != nil {
+		t.Fatalf("RefreshCatalog() error = %v", err)
+	}
+	if len(apps) != 1 || apps[0].Installation != nil {
+		t.Fatalf("RefreshCatalog() apps = %#v", apps)
+	}
+	assertRuntimeResolverNotCalled(t, resolver)
 }
 
 func TestAppCenterServiceListSkipsRuntimePreloadForUninstalledStandaloneApp(t *testing.T) {
@@ -497,11 +536,7 @@ func TestAppCenterServiceListSkipsRuntimePreloadForUninstalledStandaloneApp(t *t
 	if len(apps) != 1 || apps[0].Installation != nil {
 		t.Fatalf("List() apps = %#v", apps)
 	}
-	select {
-	case <-resolver.called:
-		t.Fatalf("List() preloaded runtime for uninstalled standalone app")
-	default:
-	}
+	assertRuntimeResolverNotCalled(t, resolver)
 }
 
 func TestAppCenterServiceListSkipsRuntimePreloadWhenAllAppsInstalled(t *testing.T) {
@@ -551,11 +586,7 @@ func TestAppCenterServiceListSkipsRuntimePreloadWhenAllAppsInstalled(t *testing.
 	if len(apps) != 1 || apps[0].Installation == nil {
 		t.Fatalf("List() apps = %#v", apps)
 	}
-	select {
-	case <-resolver.called:
-		t.Fatalf("List() preloaded runtime when all apps are installed")
-	default:
-	}
+	assertRuntimeResolverNotCalled(t, resolver)
 }
 
 func TestAppCenterServiceInstallNodeStaticPackageSkipsBaselineRuntimePreload(t *testing.T) {
@@ -1653,11 +1684,7 @@ func TestAppCenterServiceStartEnabledDoesNotWaitForRemoteCatalogWhenNoAppsAreEna
 	case <-time.After(time.Second):
 		t.Fatal("StartEnabled() did not return after catalog refresh completed")
 	}
-	select {
-	case <-resolver.called:
-	case <-time.After(time.Second):
-		t.Fatal("runtime preload did not start")
-	}
+	assertRuntimeResolverNotCalled(t, resolver)
 
 	select {
 	case <-catalogRequested:
@@ -1667,8 +1694,8 @@ func TestAppCenterServiceStartEnabledDoesNotWaitForRemoteCatalogWhenNoAppsAreEna
 	resolver.mu.Lock()
 	preloadedProfile := resolver.profile
 	resolver.mu.Unlock()
-	if preloadedProfile != workspaceAppNodeRuntimePreloadProfile {
-		t.Fatalf("runtime preload profile = %q, want %q", preloadedProfile, workspaceAppNodeRuntimePreloadProfile)
+	if preloadedProfile != "" {
+		t.Fatalf("runtime preload profile = %q, want empty", preloadedProfile)
 	}
 }
 


### PR DESCRIPTION
## Summary
- Remove App Center list/refresh runtime preload side effects from tuttid
- Keep runtime preparation on install/start paths and cover list/refresh with negative tests
- Cache reference-supporting app discovery during webview mention queries to avoid per-keystroke app listing

## Validation
- go test ./service/workspace -timeout=60s
- pnpm --filter @tutti-os/desktop typecheck
- pnpm --filter @tutti-os/desktop test -- src/renderer/src/features/agent-reference-sources/referenceHandle.test.ts
- pnpm check:changed --tail-lines 20
- pnpm check:full

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved app list performance by reusing recent results briefly, reducing repeated loading when the same workspace is queried.
  * App listing and catalog refreshes no longer trigger unnecessary background runtime loading.
  * Starting enabled apps now avoids extra runtime loading when no additional setup is needed.

* **Documentation**
  * Clarified runtime and App Center behavior, including when runtimes may be prepared and when they are not.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->