### PR TITLE
[codex] Increase recent reference list limit

### DIFF
--- a/apps/desktop/src/renderer/src/features/agent-reference-sources/workspaceFileLocationReferenceSources.test.ts
+++ b/apps/desktop/src/renderer/src/features/agent-reference-sources/workspaceFileLocationReferenceSources.test.ts
@@ -109,6 +109,40 @@ test("location reference source searches recent from recent references", async (
   );
 });
 
+test("location reference source lists up to 100 recent references", async () => {
+  let observedRecentLimit: number | undefined;
+  const adapter: WorkspaceFileReferenceAdapter = {
+    async listRecentReferences(input) {
+      observedRecentLimit = input.limit;
+      return [
+        {
+          displayName: "notes.txt",
+          kind: "file",
+          path: "/Users/local/notes.txt"
+        }
+      ];
+    }
+  };
+  const [, localSource] = createWorkspaceFileLocationReferenceSources({
+    adapter,
+    getLocationSections: () => locationSections,
+    localLabel: "Local",
+    projectLabel: "Project"
+  });
+
+  await localSource?.listChildren?.(
+    { workspaceId: "workspace-1" },
+    {
+      node: {
+        sourceId: WORKSPACE_FILE_SOURCE_ID,
+        nodeId: "__recent__"
+      }
+    }
+  );
+
+  assert.equal(observedRecentLimit, 100);
+});
+
 test("location reference source recent search only matches file names", async () => {
   const adapter: WorkspaceFileReferenceAdapter = {
     async listRecentReferences() {

--- a/apps/desktop/src/renderer/src/features/agent-reference-sources/workspaceFileLocationReferenceSources.ts
+++ b/apps/desktop/src/renderer/src/features/agent-reference-sources/workspaceFileLocationReferenceSources.ts
@@ -30,7 +30,7 @@ export const WORKSPACE_FILE_SOURCE_ID = "workspace-file";
 export const USER_PROJECT_REFERENCE_SOURCE_ID = "user-project";
 
 const RECENT_GROUP_NODE_ID = "__recent__";
-const RECENT_SEARCH_CANDIDATE_LIMIT = 100;
+const RECENT_REFERENCE_LIMIT = 100;
 
 export function createWorkspaceFileLocationReferenceSources(input: {
   adapter: WorkspaceFileReferenceAdapter;
@@ -145,6 +145,7 @@ function createLocationReferenceSource(input: {
         }
         const refs = await adapter.listRecentReferences({
           workspaceId: scope.workspaceId,
+          limit: RECENT_REFERENCE_LIMIT,
           ...(signal ? { signal } : {})
         });
         return {
@@ -204,7 +205,7 @@ function createLocationReferenceSource(input: {
         const normalizedQuery = query.trim().toLowerCase();
         const refs = await adapter.listRecentReferences({
           workspaceId: scope.workspaceId,
-          limit: RECENT_SEARCH_CANDIDATE_LIMIT,
+          limit: RECENT_REFERENCE_LIMIT,
           ...(signal ? { signal } : {})
         });
         const filteredRefs = refs.filter((ref) =>

--- a/apps/desktop/src/renderer/src/features/agent-reference-sources/workspaceFileReferenceSource.test.ts
+++ b/apps/desktop/src/renderer/src/features/agent-reference-sources/workspaceFileReferenceSource.test.ts
@@ -67,6 +67,29 @@ test("local source searches recent from the recent reference list", async () => 
   );
 });
 
+test("local source lists up to 100 recent references", async () => {
+  let observedRecentLimit: number | undefined;
+  const adapter: WorkspaceFileReferenceAdapter = {
+    async listRecentReferences(input) {
+      observedRecentLimit = input.limit;
+      return [{ kind: "file", path: "/workspace/notes.txt" }];
+    }
+  };
+  const source = createWorkspaceFileReferenceSource({
+    adapter,
+    label: "Local"
+  });
+
+  await source.listChildren?.(scope, {
+    node: {
+      sourceId: "workspace-file",
+      nodeId: "__recent__"
+    }
+  });
+
+  assert.equal(observedRecentLimit, 100);
+});
+
 test("local source recent search only matches file names", async () => {
   const adapter: WorkspaceFileReferenceAdapter = {
     async listRecentReferences() {

--- a/apps/desktop/src/renderer/src/features/agent-reference-sources/workspaceFileReferenceSource.ts
+++ b/apps/desktop/src/renderer/src/features/agent-reference-sources/workspaceFileReferenceSource.ts
@@ -23,7 +23,7 @@ export const WORKSPACE_FILE_SOURCE_ID = "workspace-file";
 
 /** 「最近访问」二级分组的 nodeId 哨兵。listChildren 据此走 recent 取数链路。 */
 const RECENT_GROUP_NODE_ID = "__recent__";
-const RECENT_SEARCH_CANDIDATE_LIMIT = 100;
+const RECENT_REFERENCE_LIMIT = 100;
 
 /**
  * 本地源左栏固定「位置」(顺序即展示顺序),复刻 macOS Finder 边栏收藏:
@@ -119,6 +119,7 @@ export function createWorkspaceFileReferenceSource(input: {
         }
         const refs = await adapter.listRecentReferences({
           workspaceId: scope.workspaceId,
+          limit: RECENT_REFERENCE_LIMIT,
           ...(signal ? { signal } : {})
         });
         return {
@@ -151,7 +152,7 @@ export function createWorkspaceFileReferenceSource(input: {
         const normalizedQuery = query.trim().toLowerCase();
         const refs = await adapter.listRecentReferences({
           workspaceId: scope.workspaceId,
-          limit: RECENT_SEARCH_CANDIDATE_LIMIT,
+          limit: RECENT_REFERENCE_LIMIT,
           ...(signal ? { signal } : {})
         });
         const filteredRefs = refs.filter((ref) =>


### PR DESCRIPTION
## Summary

- Increase the recent reference list fetch size from the implicit default of 30 to 100.
- Reuse the same 100-item limit for recent-list search candidates.
- Add regression coverage for both workspace file reference source implementations.

## Why

The artifact reference panel did not paginate the recent file list. Without a search query, users only saw the first 30 recent files even though the backend supports up to 100 recent entries.

## Validation

- `pnpm --filter @tutti-os/desktop test -- src/renderer/src/features/agent-reference-sources/workspaceFileLocationReferenceSources.test.ts src/renderer/src/features/agent-reference-sources/workspaceFileReferenceSource.test.ts`
- `pnpm exec oxfmt --check apps/desktop/src/renderer/src/features/agent-reference-sources/workspaceFileLocationReferenceSources.ts apps/desktop/src/renderer/src/features/agent-reference-sources/workspaceFileReferenceSource.ts apps/desktop/src/renderer/src/features/agent-reference-sources/workspaceFileLocationReferenceSources.test.ts apps/desktop/src/renderer/src/features/agent-reference-sources/workspaceFileReferenceSource.test.ts`
- `git diff --check`
- `env -u TUTTI_LOG_DIR git push -u origin codex/workspace-reference-source-updates` (ran pre-push `check:full`, passed)
