### PR TITLE
[codex] fix reference picker task reveal

### DIFF
--- a/apps/desktop/src/renderer/src/features/agent-reference-sources/workspaceFileLocationReferenceSources.test.ts
+++ b/apps/desktop/src/renderer/src/features/agent-reference-sources/workspaceFileLocationReferenceSources.test.ts
@@ -109,6 +109,40 @@ test("location reference source searches recent from recent references", async (
   );
 });
 
+test("location reference source lists up to 100 recent references", async () => {
+  let observedRecentLimit: number | undefined;
+  const adapter: WorkspaceFileReferenceAdapter = {
+    async listRecentReferences(input) {
+      observedRecentLimit = input.limit;
+      return [
+        {
+          displayName: "notes.txt",
+          kind: "file",
+          path: "/Users/local/notes.txt"
+        }
+      ];
+    }
+  };
+  const [, localSource] = createWorkspaceFileLocationReferenceSources({
+    adapter,
+    getLocationSections: () => locationSections,
+    localLabel: "Local",
+    projectLabel: "Project"
+  });
+
+  await localSource?.listChildren?.(
+    { workspaceId: "workspace-1" },
+    {
+      node: {
+        sourceId: WORKSPACE_FILE_SOURCE_ID,
+        nodeId: "__recent__"
+      }
+    }
+  );
+
+  assert.equal(observedRecentLimit, 100);
+});
+
 test("location reference source recent search only matches file names", async () => {
   const adapter: WorkspaceFileReferenceAdapter = {
     async listRecentReferences() {

--- a/apps/desktop/src/renderer/src/features/agent-reference-sources/workspaceFileLocationReferenceSources.ts
+++ b/apps/desktop/src/renderer/src/features/agent-reference-sources/workspaceFileLocationReferenceSources.ts
@@ -30,7 +30,7 @@ export const WORKSPACE_FILE_SOURCE_ID = "workspace-file";
 export const USER_PROJECT_REFERENCE_SOURCE_ID = "user-project";
 
 const RECENT_GROUP_NODE_ID = "__recent__";
-const RECENT_SEARCH_CANDIDATE_LIMIT = 100;
+const RECENT_REFERENCE_LIMIT = 100;
 
 export function createWorkspaceFileLocationReferenceSources(input: {
   adapter: WorkspaceFileReferenceAdapter;
@@ -145,6 +145,7 @@ function createLocationReferenceSource(input: {
         }
         const refs = await adapter.listRecentReferences({
           workspaceId: scope.workspaceId,
+          limit: RECENT_REFERENCE_LIMIT,
           ...(signal ? { signal } : {})
         });
         return {
@@ -204,7 +205,7 @@ function createLocationReferenceSource(input: {
         const normalizedQuery = query.trim().toLowerCase();
         const refs = await adapter.listRecentReferences({
           workspaceId: scope.workspaceId,
-          limit: RECENT_SEARCH_CANDIDATE_LIMIT,
+          limit: RECENT_REFERENCE_LIMIT,
           ...(signal ? { signal } : {})
         });
         const filteredRefs = refs.filter((ref) =>

--- a/apps/desktop/src/renderer/src/features/agent-reference-sources/workspaceFileReferenceSource.test.ts
+++ b/apps/desktop/src/renderer/src/features/agent-reference-sources/workspaceFileReferenceSource.test.ts
@@ -67,6 +67,29 @@ test("local source searches recent from the recent reference list", async () => 
   );
 });
 
+test("local source lists up to 100 recent references", async () => {
+  let observedRecentLimit: number | undefined;
+  const adapter: WorkspaceFileReferenceAdapter = {
+    async listRecentReferences(input) {
+      observedRecentLimit = input.limit;
+      return [{ kind: "file", path: "/workspace/notes.txt" }];
+    }
+  };
+  const source = createWorkspaceFileReferenceSource({
+    adapter,
+    label: "Local"
+  });
+
+  await source.listChildren?.(scope, {
+    node: {
+      sourceId: "workspace-file",
+      nodeId: "__recent__"
+    }
+  });
+
+  assert.equal(observedRecentLimit, 100);
+});
+
 test("local source recent search only matches file names", async () => {
   const adapter: WorkspaceFileReferenceAdapter = {
     async listRecentReferences() {

--- a/apps/desktop/src/renderer/src/features/agent-reference-sources/workspaceFileReferenceSource.ts
+++ b/apps/desktop/src/renderer/src/features/agent-reference-sources/workspaceFileReferenceSource.ts
@@ -23,7 +23,7 @@ export const WORKSPACE_FILE_SOURCE_ID = "workspace-file";
 
 /** 「最近访问」二级分组的 nodeId 哨兵。listChildren 据此走 recent 取数链路。 */
 const RECENT_GROUP_NODE_ID = "__recent__";
-const RECENT_SEARCH_CANDIDATE_LIMIT = 100;
+const RECENT_REFERENCE_LIMIT = 100;
 
 /**
  * 本地源左栏固定「位置」(顺序即展示顺序),复刻 macOS Finder 边栏收藏:
@@ -119,6 +119,7 @@ export function createWorkspaceFileReferenceSource(input: {
         }
         const refs = await adapter.listRecentReferences({
           workspaceId: scope.workspaceId,
+          limit: RECENT_REFERENCE_LIMIT,
           ...(signal ? { signal } : {})
         });
         return {
@@ -151,7 +152,7 @@ export function createWorkspaceFileReferenceSource(input: {
         const normalizedQuery = query.trim().toLowerCase();
         const refs = await adapter.listRecentReferences({
           workspaceId: scope.workspaceId,
-          limit: RECENT_SEARCH_CANDIDATE_LIMIT,
+          limit: RECENT_REFERENCE_LIMIT,
           ...(signal ? { signal } : {})
         });
         const filteredRefs = refs.filter((ref) =>

--- a/packages/workspace/file-manager/src/services/internal/workspaceFileManagerPreviewController.ts
+++ b/packages/workspace/file-manager/src/services/internal/workspaceFileManagerPreviewController.ts
@@ -9,6 +9,7 @@ import {
 import type { WorkspaceFileManagerI18nRuntime } from "../../i18n/workspaceFileManagerI18n.ts";
 import type { WorkspaceFileManagerHost } from "../workspaceFileManagerHost.interface.ts";
 import type { WorkspaceFileManagerState } from "../workspaceFileManagerTypes.ts";
+import { findWorkspaceFileEntry } from "./model/entryLookup.ts";
 
 export interface WorkspaceFileManagerPreviewControllerInput {
   copy: () => WorkspaceFileManagerI18nRuntime;
@@ -51,10 +52,10 @@ export class WorkspaceFileManagerPreviewController {
     this.previewRequestSeq = requestID;
     this.revokePreviewObjectUrl();
 
-    const selectedEntry =
-      this.store.entries.find(
-        (entry) => entry.path === this.store.selectedPath
-      ) ?? null;
+    const selectedEntry = findWorkspaceFileEntry(
+      this.store,
+      this.store.selectedPath
+    );
     const copy = this.copy();
 
     if (!selectedEntry) {

--- a/packages/workspace/file-manager/src/services/internal/workspaceFileManagerSession.ts
+++ b/packages/workspace/file-manager/src/services/internal/workspaceFileManagerSession.ts
@@ -712,6 +712,12 @@ export class DefaultWorkspaceFileManagerSession implements WorkspaceFileManagerS
       ? normalizeWorkspaceFilePath(path, this.store.root)
       : null;
     if (this.store.selectedPath === nextSelectedPath) {
+      if (
+        nextSelectedPath !== null &&
+        !isPreviewStateForPath(this.store.previewState, nextSelectedPath)
+      ) {
+        void this.previewController.syncPreviewState();
+      }
       return;
     }
     this.store.selectedPath = nextSelectedPath;
@@ -1158,6 +1164,13 @@ export class DefaultWorkspaceFileManagerSession implements WorkspaceFileManagerS
 
     return this.copy.t("unknownErrorMessage");
   }
+}
+
+function isPreviewStateForPath(
+  previewState: WorkspaceFileManagerState["previewState"],
+  path: string
+): boolean {
+  return "entry" in previewState && previewState.entry.path === path;
 }
 
 function serializePersistedState(

--- a/packages/workspace/file-manager/src/services/workspaceFileManagerSession.test.ts
+++ b/packages/workspace/file-manager/src/services/workspaceFileManagerSession.test.ts
@@ -171,6 +171,102 @@ test("preview state is stable across repeated selection and same i18n runtime", 
   session.dispose();
 });
 
+test("reselecting the same entry repairs an empty preview state", async () => {
+  const entry: WorkspaceFileEntry = {
+    hasChildren: false,
+    kind: "file",
+    mtimeMs: null,
+    name: "notes.txt",
+    path: "/Users/demo/project/notes.txt",
+    sizeBytes: 5
+  };
+  const session = createWorkspaceFileManagerService().createSession({
+    i18n: createTestI18nRuntime(),
+    host: {
+      async listDirectory(input) {
+        return {
+          directoryPath: input.path,
+          entries: [entry],
+          root: "/Users/demo/project",
+          workspaceID: input.workspaceID
+        };
+      },
+      async readPreviewFile() {
+        return new TextEncoder().encode("hello");
+      }
+    },
+    workspaceID: "workspace-1"
+  });
+
+  await session.initialize();
+  session.store.selectedPath = entry.path;
+  await flushMicrotasks();
+  session.store.previewState = { status: "empty" };
+  await flushMicrotasks();
+
+  session.select(entry.path);
+  await flushMicrotasks();
+  await flushMicrotasks();
+
+  assert.equal(previewStatus(session), "text");
+
+  session.dispose();
+});
+
+test("preview follows selected entries inside expanded directories", async () => {
+  const downloadsEntry: WorkspaceFileEntry = {
+    hasChildren: true,
+    kind: "directory",
+    mtimeMs: null,
+    name: "Downloads",
+    path: "/Users/demo/Downloads",
+    sizeBytes: null
+  };
+  const nestedEntry: WorkspaceFileEntry = {
+    hasChildren: false,
+    kind: "file",
+    mtimeMs: null,
+    name: "notes.txt",
+    path: "/Users/demo/Downloads/notes.txt",
+    sizeBytes: 5
+  };
+  const previewReads: string[] = [];
+  const session = createWorkspaceFileManagerService().createSession({
+    i18n: createTestI18nRuntime(),
+    host: {
+      async listDirectory(input) {
+        const directoryPath = input.path || "/Users/demo";
+        return {
+          directoryPath,
+          entries:
+            directoryPath === downloadsEntry.path
+              ? [nestedEntry]
+              : [downloadsEntry],
+          root: "/Users/demo",
+          workspaceID: input.workspaceID
+        };
+      },
+      async readPreviewFile(_workspaceID, path) {
+        previewReads.push(path);
+        return new TextEncoder().encode("hello");
+      }
+    },
+    workspaceID: "workspace-1"
+  });
+
+  await session.initialize();
+  await session.toggleDirectoryExpanded(downloadsEntry);
+
+  session.select(nestedEntry.path);
+  await flushMicrotasks();
+  await flushMicrotasks();
+
+  assert.equal(previewStatus(session), "text");
+  assert.deepEqual(previewReads, [nestedEntry.path]);
+
+  session.dispose();
+});
+
 test("openEntry enters directories and records navigation history", async () => {
   const srcEntry: WorkspaceFileEntry = {
     hasChildren: true,

--- a/packages/workspace/file-reference/src/react/internal/reference/referenceSourcePickerController.test.ts
+++ b/packages/workspace/file-reference/src/react/internal/reference/referenceSourcePickerController.test.ts
@@ -159,6 +159,52 @@ test("toggleNode 展开 folder 并懒加载子节点", async () => {
   );
 });
 
+test("refreshChildren reloads an already loaded app group", async () => {
+  let appGroupFiles = [file("app-artifact", "old.png")];
+  let appGroupLoadCount = 0;
+  const appGroup = folder("app-artifact", "app:vibe-design", "Vibe Design");
+  const controller = createReferenceSourcePickerController({
+    aggregator: {
+      ...fakeAggregator({
+        tabs: [tabsTwo[1]!],
+        children: {}
+      }),
+      async listChildren(_scope, ref: NodeRef): Promise<ListChildrenResult> {
+        if (ref.nodeId === SOURCE_ROOT_NODE_ID) {
+          return { entries: [appGroup], nextCursor: null };
+        }
+        if (ref.nodeId === appGroup.ref.nodeId) {
+          appGroupLoadCount += 1;
+          return { entries: appGroupFiles, nextCursor: null };
+        }
+        return { entries: [], nextCursor: null };
+      }
+    },
+    scope,
+    searchDebounceMs: 0
+  });
+
+  controller.open();
+  await flush();
+  controller.ensureChildren(appGroup);
+  await flush();
+  assert.equal(appGroupLoadCount, 1);
+
+  appGroupFiles = [file("app-artifact", "new.png")];
+  controller.refreshChildren(appGroup);
+  await flush();
+
+  const key = nodeRefKey(appGroup.ref);
+  const entries =
+    controller.getSnapshot().bySource["app-artifact"]?.childrenByKey[key]
+      ?.entries ?? [];
+  assert.equal(appGroupLoadCount, 2);
+  assert.deepEqual(
+    entries.map((node) => node.ref.nodeId),
+    ["new.png"]
+  );
+});
+
 test("toggleSingleSelectionAndExpand single-selects and expands folders", async () => {
   const controller = createReferenceSourcePickerController({
     aggregator: fakeAggregator({

--- a/packages/workspace/file-reference/src/react/internal/reference/referenceSourcePickerController.test.ts
+++ b/packages/workspace/file-reference/src/react/internal/reference/referenceSourcePickerController.test.ts
@@ -923,6 +923,76 @@ test("locatePath follows pagination while resolving the target path", async () =
   );
 });
 
+test("locatePath keeps paged parent children so the located target can render", async () => {
+  const controller = createReferenceSourcePickerController({
+    aggregator: {
+      ...fakeAggregator({
+        tabs: tabsTwo,
+        children: {
+          [`app-artifact:${SOURCE_ROOT_NODE_ID}`]: {
+            entries: [folder("app-artifact", "topic-1", "主题一")],
+            nextCursor: null
+          },
+          "app-artifact:topic-1": {
+            entries: [folder("app-artifact", "issue-old", "旧事项")],
+            nextCursor: "page-2"
+          }
+        },
+        locate: {
+          "app-artifact": [
+            { sourceId: "app-artifact", nodeId: "topic-1" },
+            { sourceId: "app-artifact", nodeId: "issue-target" }
+          ]
+        }
+      }),
+      async listChildren(_scope, ref, input): Promise<ListChildrenResult> {
+        if (ref.sourceId === "app-artifact" && ref.nodeId === "topic-1") {
+          return input?.cursor === "page-2"
+            ? {
+                entries: [folder("app-artifact", "issue-target", "目标事项")],
+                nextCursor: null
+              }
+            : {
+                entries: [folder("app-artifact", "issue-old", "旧事项")],
+                nextCursor: "page-2"
+              };
+        }
+        return fakeAggregator({
+          tabs: tabsTwo,
+          children: {
+            [`app-artifact:${SOURCE_ROOT_NODE_ID}`]: {
+              entries: [folder("app-artifact", "topic-1", "主题一")],
+              nextCursor: null
+            }
+          }
+        }).listChildren(_scope, ref, input);
+      }
+    },
+    scope,
+    searchDebounceMs: 0
+  });
+  controller.open();
+  await flush();
+
+  await controller.locatePath({
+    sourceId: "app-artifact",
+    params: { issueId: "issue-target", topicId: "topic-1" }
+  });
+
+  const topicKey = nodeRefKey({
+    sourceId: "app-artifact",
+    nodeId: "topic-1"
+  });
+  assert.deepEqual(
+    controller
+      .getSnapshot()
+      .bySource["app-artifact"]?.childrenByKey[topicKey]?.entries.map(
+        (node) => node.ref.nodeId
+      ),
+    ["issue-old", "issue-target"]
+  );
+});
+
 test("locatePath 源不支持定位 / 未找到时返回空路径", async () => {
   const controller = createReferenceSourcePickerController({
     aggregator: fakeAggregator({ tabs: tabsTwo, children: {} }),

--- a/packages/workspace/file-reference/src/react/internal/reference/referenceSourcePickerController.ts
+++ b/packages/workspace/file-reference/src/react/internal/reference/referenceSourcePickerController.ts
@@ -668,6 +668,11 @@ export function createReferenceSourcePickerController(
       };
       for (const ref of refs) {
         const targetKey = nodeRefKey(ref);
+        const parentKey =
+          parent.nodeId === SOURCE_ROOT_NODE_ID
+            ? ROOT_CHILDREN_KEY
+            : nodeRefKey(parent);
+        let locatedEntries: ReferenceNode[] = [];
         let cursor: string | null = null;
         let node: ReferenceNode | undefined;
         do {
@@ -676,9 +681,22 @@ export function createReferenceSourcePickerController(
             parent,
             { cursor }
           );
+          locatedEntries = appendReferencePage(locatedEntries, entries);
           node = entries.find((entry) => nodeRefKey(entry.ref) === targetKey);
           cursor = nextCursor ?? null;
         } while (!node && cursor);
+        if (locatedEntries.length > 0) {
+          const current =
+            snapshot.bySource[parent.sourceId]?.childrenByKey[parentKey]
+              ?.entries ?? [];
+          setChildrenState(parent.sourceId, parentKey, {
+            entries: appendReferencePage(current, locatedEntries),
+            nextCursor: cursor,
+            loaded: true,
+            loading: false,
+            error: null
+          });
+        }
         if (!node) {
           break;
         }

--- a/packages/workspace/file-reference/src/react/internal/reference/referenceSourcePickerController.ts
+++ b/packages/workspace/file-reference/src/react/internal/reference/referenceSourcePickerController.ts
@@ -108,6 +108,8 @@ export interface ReferenceSourcePickerController {
   locatePath(target: ReferenceLocateTarget): Promise<ReferenceNode[]>;
   /** 确保某节点(null=当前源根)的子节点已加载(抽屉式导航进入用,不切换展开态)。 */
   ensureChildren(node: ReferenceNode | null): void;
+  /** 重新拉取某节点(null=当前源根)的子节点第一页,用于应用/议题等动态源刷新已加载分组。 */
+  refreshChildren(node: ReferenceNode | null): void;
   /** 确保指定源的根层级已加载(左栏可同时展开多源时,为非 active 源预载分组)。 */
   ensureSourceRoot(sourceId: string): void;
   /** 幂等展开某 folder 并确保其子节点已加载(定位目标默认展开用)。 */
@@ -715,6 +717,13 @@ export function createReferenceSourcePickerController(
       if (!childState?.loaded && !childState?.loading) {
         void loadChildren(sourceId, node, { append: false });
       }
+    },
+    refreshChildren(node) {
+      const sourceId = node ? node.ref.sourceId : snapshot.activeSourceId;
+      if (!sourceId) {
+        return;
+      }
+      void loadChildren(sourceId, node, { append: false });
     },
     ensureSourceRoot(sourceId) {
       if (

--- a/packages/workspace/file-reference/src/react/internal/reference/useReferenceSourcePickerView.ts
+++ b/packages/workspace/file-reference/src/react/internal/reference/useReferenceSourcePickerView.ts
@@ -384,6 +384,13 @@ export function useReferenceSourcePickerView({
     [controller]
   );
 
+  const shouldRefreshChildrenOnEnter = useCallback(
+    (sourceId: string) =>
+      snapshot.tabs.find((tab) => tab.sourceId === sourceId)?.capabilities
+        .navigable ?? false,
+    [snapshot.tabs]
+  );
+
   const enterFolder = useCallback(
     (node: ReferenceNode) => {
       const sourceId = node.ref.sourceId;
@@ -394,7 +401,11 @@ export function useReferenceSourcePickerView({
       ) {
         return;
       }
-      controller.ensureChildren(node);
+      if (shouldRefreshChildrenOnEnter(sourceId)) {
+        controller.refreshChildren(node);
+      } else {
+        controller.ensureChildren(node);
+      }
       setBreadcrumbBySource((current) => {
         const stack = current[sourceId] ?? [];
         const index = stack.findIndex(
@@ -406,7 +417,7 @@ export function useReferenceSourcePickerView({
       });
       setFocusedNode(null);
     },
-    [controller]
+    [controller, shouldRefreshChildrenOnEnter]
   );
 
   // 进入某源时默认选中它的第一个二级分组,而非停在根列表:
@@ -459,10 +470,19 @@ export function useReferenceSourcePickerView({
         return { ...current, [activeSourceId]: stack.slice(0, index + 1) };
       });
       const target = (breadcrumbBySource[activeSourceId] ?? [])[index] ?? null;
-      controller.ensureChildren(target);
+      if (target && shouldRefreshChildrenOnEnter(target.ref.sourceId)) {
+        controller.refreshChildren(target);
+      } else {
+        controller.ensureChildren(target);
+      }
       setFocusedNode(null);
     },
-    [activeSourceId, breadcrumbBySource, controller]
+    [
+      activeSourceId,
+      breadcrumbBySource,
+      controller,
+      shouldRefreshChildrenOnEnter
+    ]
   );
 
   const navigateToRoot = useCallback(
@@ -501,12 +521,21 @@ export function useReferenceSourcePickerView({
         navigateToRoot(sourceId);
         return;
       }
-      controller.ensureChildren(node);
+      if (shouldRefreshChildrenOnEnter(sourceId)) {
+        controller.refreshChildren(node);
+      } else {
+        controller.ensureChildren(node);
+      }
       controller.setSearchScope(nextScopeNodeId);
       setBreadcrumbBySource((current) => ({ ...current, [sourceId]: [node] }));
       setFocusedNode(null);
     },
-    [controller, snapshot.activeSourceId, navigateToRoot]
+    [
+      controller,
+      snapshot.activeSourceId,
+      navigateToRoot,
+      shouldRefreshChildrenOnEnter
+    ]
   );
 
   const isSelected = useCallback(

--- a/packages/workspace/file-reference/src/ui/internal/reference/ReferenceSourcePicker.source.test.ts
+++ b/packages/workspace/file-reference/src/ui/internal/reference/ReferenceSourcePicker.source.test.ts
@@ -130,3 +130,15 @@ test("preview group path uses readable hierarchy labels instead of opaque node i
   assert.match(source, /formatReferenceNodePathText\(node, hierarchy\)/);
   assert.match(source, /hierarchy=\{view\.breadcrumb\}/);
 });
+
+test("focused middle tree row scrolls into view after initial target reveal", () => {
+  assert.match(
+    source,
+    /const focusedRowRef = useRef<HTMLDivElement \| null>\(null\);/
+  );
+  assert.match(
+    source,
+    /focusedRowRef\.current\?\.scrollIntoView\(\{ block: "nearest" \}\);/
+  );
+  assert.match(source, /ref=\{focused \? focusedRowRef : undefined\}/);
+});

--- a/packages/workspace/file-reference/src/ui/internal/reference/ReferenceSourcePicker.tsx
+++ b/packages/workspace/file-reference/src/ui/internal/reference/ReferenceSourcePicker.tsx
@@ -1212,9 +1212,16 @@ function TreeNodeRow({
   const selectable = view.isSelectable(node);
   const focused = isFocused(view.focusedNode, node);
   const active = selected || (focused && selectable);
+  const focusedRowRef = useRef<HTMLDivElement | null>(null);
 
   const [shouldRenderChildContent, setShouldRenderChildContent] =
     useState(expanded);
+
+  useEffect(() => {
+    if (focused) {
+      focusedRowRef.current?.scrollIntoView({ block: "nearest" });
+    }
+  }, [focused]);
 
   useEffect(() => {
     if (expanded) {
@@ -1264,6 +1271,7 @@ function TreeNodeRow({
       {/* 整行可点:点击监听挂在父级行 div 上,使可点热区与 hover 高亮区一致;
           内层箭头/选中按钮 stopPropagation 各管各的,避免冒泡到行点击。 */}
       <div
+        ref={focused ? focusedRowRef : undefined}
         className={cn(
           "flex cursor-pointer items-center gap-2 rounded-[6px] py-1.5 pr-1 transition-colors",
           active ? "bg-transparency-block" : "hover:bg-transparency-block"


### PR DESCRIPTION
## Summary

- keep the reference picker parent children populated when locating a target through paginated results
- scroll the focused middle tree row into view after an initial target reveal
- preserve the existing recent reference list limit change already present on the rebased branch

## Root Cause

When the @ mention panel opened the reference picker for a task with many siblings, `locatePath` could page through backend children to find the target, but it did not store the paged parent entries in picker state. The middle column could therefore render only the initially loaded page, leaving the located task absent from the visible tree. Even when the target was rendered, the middle tree did not scroll the focused row into view.

## Validation

- `pnpm --filter @tutti-os/workspace-file-reference test`
- `pnpm --filter @tutti-os/workspace-file-reference typecheck`
- `pnpm check:changed --tail-lines 80`
- `cd services/tuttid && go test ./service/cli ./service/cli/providers/issuemanager ./service/workspace`
- `pnpm check:full`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Recent reference lists now consistently load up to 100 items.
  * Path lookup in the reference picker now preserves already-loaded parent children, keeping tree context visible.
  * Focused rows in the reference picker now scroll into view more reliably after reveal/navigation.
  * Preview state synchronization during reselection is now more accurate, reducing unnecessary preview updates.
* **Tests**
  * Added coverage for recent-reference limits, paged path lookup behavior, refresh/reload behavior, focus scrolling, and preview-state transitions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->