### PR TITLE
fix(ui): polish workspace chrome surfaces

### DIFF
--- a/apps/ui-storyboard/src/foundation/colors.json
+++ b/apps/ui-storyboard/src/foundation/colors.json
@@ -281,25 +281,25 @@
         },
         {
           "label": "--state-danger",
-          "dark": "rgb(239, 68, 68)",
+          "dark": "rgb(244, 91, 91)",
           "light": "rgb(220, 38, 38)",
           "usage": "错误、危险、删除"
         },
         {
           "label": "--state-danger-hover",
-          "dark": "color-mix(in srgb, rgb(239, 68, 68) 90%, transparent)",
+          "dark": "color-mix(in srgb, rgb(244, 91, 91) 90%, transparent)",
           "light": "color-mix(in srgb, rgb(220, 38, 38) 90%, transparent)",
           "usage": "Destructive 按钮 hover 底色"
         },
         {
           "label": "--on-danger",
-          "dark": "rgba(239, 68, 68, 0.08)",
+          "dark": "rgba(248, 113, 113, 0.10)",
           "light": "rgb(255, 238, 242)",
           "usage": "Destructive 实心按钮文字"
         },
         {
           "label": "--on-danger-hover",
-          "dark": "color-mix(in srgb, rgba(239, 68, 68, 0.08) 82%, rgb(239, 68, 68))",
+          "dark": "color-mix(in srgb, rgba(248, 113, 113, 0.10) 82%, rgb(244, 91, 91))",
           "light": "color-mix(in srgb, rgb(255, 238, 242) 92%, rgb(220, 38, 38))",
           "usage": "二级警示按钮 hover 底色"
         },

--- a/apps/ui-storyboard/src/storyboardTheme.ts
+++ b/apps/ui-storyboard/src/storyboardTheme.ts
@@ -111,11 +111,11 @@ const storyboardDarkThemeVars = {
   "--transparency-block": "rgba(255, 255, 255, 0.1)",
   "--transparency-hover": "rgba(255, 255, 255, 0.14)",
   "--transparency-active": "rgba(255, 255, 255, 0.16)",
-  "--state-danger": "rgb(239, 68, 68)",
+  "--state-danger": "rgb(244, 91, 91)",
   "--state-danger-hover":
     "color-mix(in srgb, var(--state-danger) 90%, transparent)",
   "--state-success": "rgb(74, 222, 128)",
-  "--on-danger": "rgba(239, 68, 68, 0.08)",
+  "--on-danger": "rgba(248, 113, 113, 0.10)",
   "--on-danger-hover":
     "color-mix(in srgb, var(--on-danger) 82%, var(--state-danger))",
   "--backdrop": "rgba(0, 0, 0, 0.60)",

--- a/packages/agent/gui/agent-gui/agentGuiNode/AgentFileMentionPalette.spec.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/AgentFileMentionPalette.spec.tsx
@@ -366,17 +366,24 @@ describe("AgentFileMentionPalette", () => {
       "green",
       "red"
     ]);
-    expect(statusTags[0]).toHaveClass("bg-sky-500/10", "text-sky-700");
+    expect(statusTags[0]).toHaveClass(
+      "bg-transparent",
+      "px-0",
+      "text-[var(--status-running)]"
+    );
     expect(statusTags[1]).toHaveClass(
-      "bg-[color:color-mix(in_srgb,var(--color-amber-500)_12%,transparent)]",
-      "text-[var(--color-amber-500)]"
+      "bg-transparent",
+      "px-0",
+      "text-[var(--state-warning)]"
     );
     expect(statusTags[2]).toHaveClass(
-      "bg-[var(--tsh-ui-pill-success-bg)]",
-      "text-[var(--tsh-ui-pill-success-fg)]"
+      "bg-transparent",
+      "px-0",
+      "text-[var(--state-success)]"
     );
     expect(statusTags[8]).toHaveClass(
-      "bg-[var(--on-danger)]",
+      "bg-transparent",
+      "px-0",
       "text-[var(--state-danger)]"
     );
     const selectedOption = screen.getByRole("option", { selected: true });
@@ -1771,17 +1778,17 @@ describe("AgentFileMentionPalette", () => {
     );
   });
 
-  it("uses package-owned status tokens for agent gui chrome", () => {
+  it("uses shared semantic status tokens for agent gui chrome", () => {
     const css = readFileSync(resolve("app/renderer/agentactivity.css"), "utf8");
 
     expect(css).toMatch(
-      /\.agent-gui-node__shell\s*{[^}]*--agent-gui-package-success:\s*rgb\(34 197 94\)[^}]*--agent-gui-package-warning:\s*rgb\(234 121 8\)[^}]*--agent-gui-package-danger:\s*rgb\(220 38 38\)[^}]*--agent-gui-success:\s*var\(--agent-gui-package-success\)[^}]*--agent-gui-warning:\s*var\(--agent-gui-package-warning\)[^}]*--agent-gui-danger:\s*var\(--agent-gui-package-danger\)/s
+      /\.agent-gui-node__shell\s*{[^}]*--agent-gui-package-success:\s*var\(--state-success\)[^}]*--agent-gui-package-warning:\s*var\(--state-warning\)[^}]*--agent-gui-package-danger:\s*var\(--state-danger\)[^}]*--agent-gui-success:\s*var\(--agent-gui-package-success\)[^}]*--agent-gui-warning:\s*var\(--agent-gui-package-warning\)[^}]*--agent-gui-danger:\s*var\(--agent-gui-package-danger\)/s
     );
     expect(css).toMatch(
-      /\[data-testid="workspace-agent-message-center"\]\s*{[^}]*--agent-gui-package-success:\s*rgb\(34 197 94\)[^}]*--agent-gui-package-warning:\s*rgb\(234 121 8\)[^}]*--agent-gui-package-danger:\s*rgb\(220 38 38\)[^}]*--agent-gui-success:\s*var\(--agent-gui-package-success\)[^}]*--agent-gui-warning:\s*var\(--agent-gui-package-warning\)[^}]*--agent-gui-danger:\s*var\(--agent-gui-package-danger\)/s
+      /\[data-testid="workspace-agent-message-center"\]\s*{[^}]*--agent-gui-package-success:\s*var\(--state-success\)[^}]*--agent-gui-package-warning:\s*var\(--state-warning\)[^}]*--agent-gui-package-danger:\s*var\(--state-danger\)[^}]*--agent-gui-success:\s*var\(--agent-gui-package-success\)[^}]*--agent-gui-warning:\s*var\(--agent-gui-package-warning\)[^}]*--agent-gui-danger:\s*var\(--agent-gui-package-danger\)/s
     );
     expect(css).toMatch(
-      /\.agent-gui-node__composer-menu-content\s*{[^}]*--agent-gui-surface-raised:\s*var\(--background-fronted\)[^}]*--agent-gui-border-subtle:\s*var\(--line-2\)[^}]*--agent-gui-package-success:\s*rgb\(34 197 94\)[^}]*--agent-gui-success:\s*var\(--agent-gui-package-success\)/s
+      /\.agent-gui-node__composer-menu-content\s*{[^}]*--agent-gui-surface-raised:\s*var\(--background-fronted\)[^}]*--agent-gui-border-subtle:\s*var\(--line-2\)[^}]*--agent-gui-package-success:\s*var\(--state-success\)[^}]*--agent-gui-success:\s*var\(--agent-gui-package-success\)/s
     );
   });
 
@@ -1846,7 +1853,10 @@ describe("AgentFileMentionPalette", () => {
       /\.agent-gui-node__layout\s+\[data-slot="status-dot"\]\[data-size="md"\],\s*\[data-testid="workspace-agent-message-center"\]\s+\[data-slot="status-dot"\]\[data-size="md"\]\s*{[^}]*width:\s*10px[^}]*height:\s*10px/s
     );
     expect(css).toMatch(
-      /\.agent-gui-node__layout\s+\[data-slot="status-dot"\]\[data-tone="green"\],\s*\[data-testid="workspace-agent-message-center"\]\s+\[data-slot="status-dot"\]\[data-tone="green"\]\s*{[^}]*--agent-gui-status-dot-color:\s*var\(--agent-gui-success,\s*var\(--state-success\)\)/s
+      /\.agent-gui-node__layout\s+\[data-slot="status-dot"\]\[data-tone="green"\],\s*\[data-testid="workspace-agent-message-center"\]\s+\[data-slot="status-dot"\]\[data-tone="green"\]\s*{[^}]*--agent-gui-status-dot-color:\s*var\(--state-success\)/s
+    );
+    expect(css).toMatch(
+      /\.agent-gui-node__layout\s+\[data-slot="status-dot"\]\[data-tone="red"\],\s*\[data-testid="workspace-agent-message-center"\]\s+\[data-slot="status-dot"\]\[data-tone="red"\]\s*{[^}]*--agent-gui-status-dot-color:\s*var\(--state-danger\)/s
     );
     expect(css).toMatch(
       /\.agent-gui-node__layout\s+\[data-slot="status-dot"\]\[data-pulse="true"\],\s*\[data-testid="workspace-agent-message-center"\]\s+\[data-slot="status-dot"\]\[data-pulse="true"\]\s*{[^}]*animation:\s*agent-gui-status-dot-pulse\s+1\.8s\s+ease-in-out\s+infinite/s

--- a/packages/agent/gui/agent-gui/agentGuiNode/AgentGUINode.spec.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/AgentGUINode.spec.tsx
@@ -2543,6 +2543,29 @@ describe("AgentGUINode", () => {
     expect(screen.queryByTestId("agent-gui-composer-send-spinner")).toBeNull();
   });
 
+  it("keeps the composer ready while managed agent install state is still loading", () => {
+    mockViewModel = createViewModel({
+      data: {
+        provider: "codex",
+        lastActiveAgentSessionId: null,
+        conversationRailWidthPx: null
+      },
+      activeConversationId: "session-1",
+      draftPrompt: "@请处理这个任务引用。",
+      canQueueWhileBusy: true
+    });
+
+    renderAgentGUINode({
+      managedAgentsState: null
+    });
+
+    expect(getComposerEditor()).not.toHaveAttribute("aria-disabled", "true");
+    expect(screen.queryByTestId("agent-gui-provider-setup-notice")).toBeNull();
+    expect(
+      screen.getByRole("button", { name: "agentHost.agentGui.send" })
+    ).not.toBeDisabled();
+  });
+
   it("shows a provider setup notice while keeping the disabled composer reason on the input placeholder", () => {
     mockViewModel = createViewModel({
       data: {

--- a/packages/agent/gui/agent-gui/agentGuiNode/AgentGUINode.styles.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/AgentGUINode.styles.ts
@@ -94,8 +94,6 @@ const styles = {
   usageAlertActions: "agent-gui-node__usage-alert-actions",
   usageAlertDismiss: "agent-gui-node__usage-alert-dismiss",
   providerSetupNotice: "agent-gui-node__provider-setup-notice",
-  providerSetupNoticeIcon: "agent-gui-node__provider-setup-notice-icon",
-  providerSetupNoticeText: "agent-gui-node__provider-setup-notice-text",
   detailHeaderTitle: "agent-gui-node__detail-header-title",
   detailHeaderTitleGroup: "agent-gui-node__detail-header-title-group",
   detail: "agent-gui-node__detail",

--- a/packages/agent/gui/agent-gui/agentGuiNode/AgentGUINode.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/AgentGUINode.tsx
@@ -1186,10 +1186,13 @@ export const AgentGUINode = memo(function AgentGUINode({
     if (!managedAgent) {
       return true;
     }
+    if (!managedAgentsState) {
+      return true;
+    }
     return (
       resolveAgentHostManagedToolchainAgentAction(
         managedAgent,
-        managedAgentsState ?? null
+        managedAgentsState
       ) === "installed"
     );
   }, [activeProbeProvider, managedAgentsState]);

--- a/packages/agent/gui/agent-gui/agentGuiNode/AgentGUINodeView.layout.spec.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/AgentGUINodeView.layout.spec.tsx
@@ -1364,6 +1364,7 @@ describe("AgentGUINodeView provider setup notice", () => {
     const notice = screen.getByTestId("agent-gui-provider-setup-notice");
     expect(notice).toHaveTextContent("installRequiredPlaceholder");
     expect(notice).toHaveAttribute("role", "status");
+    expect(notice).toHaveAttribute("data-slot", "toast");
   });
 
   it("floats the setup notice above the detail content without affecting layout", () => {
@@ -1373,12 +1374,21 @@ describe("AgentGUINodeView provider setup notice", () => {
     )?.[0];
 
     expect(setupNoticeRule).toContain("position: absolute;");
-    expect(setupNoticeRule).toContain("top: 16px;");
+    expect(setupNoticeRule).toContain("top: 8px;");
+    expect(setupNoticeRule).toContain(
+      "left: var(--agent-gui-detail-padding-x);"
+    );
     expect(setupNoticeRule).toContain("z-index: 2;");
+    expect(setupNoticeRule).toContain("width: max-content;");
+    expect(setupNoticeRule).toMatch(
+      /max-width:\s*min\(\s*calc\(100% - \(var\(--agent-gui-detail-padding-x\) \* 2\)\),\s*420px\s*\);/s
+    );
     expect(setupNoticeRule).toContain("margin: 0;");
+    expect(setupNoticeRule).not.toContain("background:");
     expect(css).toContain(
       ".agent-gui-node__detail-header + .agent-gui-node__provider-setup-notice"
     );
+    expect(css).toContain("top: calc(64px + 4px);");
   });
 
   it("hides the setup notice when the provider is ready", () => {

--- a/packages/agent/gui/agent-gui/agentGuiNode/AgentGUINodeView.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/AgentGUINodeView.tsx
@@ -34,6 +34,7 @@ import {
   TooltipTrigger,
   NewWorkspaceLinedIcon,
   ConfirmationDialog,
+  toastVariants,
   cn
 } from "@tutti-os/ui-system";
 import { WorkspaceUserProjectSelect } from "@tutti-os/workspace-user-project/ui";
@@ -2323,18 +2324,18 @@ const AgentGUIDetailPane = memo(function AgentGUIDetailPane({
       />
       {showProviderSetupNotice ? (
         <div
-          className={styles.providerSetupNotice}
+          className={cn(
+            toastVariants({ variant: "default" }),
+            styles.providerSetupNotice
+          )}
+          data-slot="toast"
           data-testid="agent-gui-provider-setup-notice"
           role="status"
         >
-          <Info
-            aria-hidden="true"
-            className={styles.providerSetupNoticeIcon}
-            size={15}
-            strokeWidth={2}
-          />
-          <span className={styles.providerSetupNoticeText}>
-            {labels.installRequiredPlaceholder}
+          <span className="inline-flex max-w-full items-center justify-center gap-[6px] text-center text-[13px] font-normal leading-normal">
+            <span className="min-w-0 break-words">
+              {labels.installRequiredPlaceholder}
+            </span>
           </span>
         </div>
       ) : null}

--- a/packages/agent/gui/agent-message-center/WorkspaceAgentMessageCenterCard.tsx
+++ b/packages/agent/gui/agent-message-center/WorkspaceAgentMessageCenterCard.tsx
@@ -94,6 +94,7 @@ export const WorkspaceAgentMessageCenterCard = memo(
     const displayTitle = normalizeAgentTitleText(item.title);
     const summary = messageCenterVisibleSummary(item);
     const displayStatus = statusClass(item);
+    const statusTone = messageCenterStatusTone(item);
     const statusLabel = workspaceAgentActivityStatusLabel(displayStatus, t);
 
     return (
@@ -130,12 +131,15 @@ export const WorkspaceAgentMessageCenterCard = memo(
             {item.cwd ? <ProjectPathInfo path={item.cwd} /> : null}
           </div>
           <span
-            className="workspace-agent-message-center__status inline-flex shrink-0 items-center gap-1.5 text-[11px] font-semibold leading-4 text-[var(--text-secondary)]"
+            className={cn(
+              "workspace-agent-message-center__status inline-flex shrink-0 items-center gap-1.5 text-[11px] font-semibold leading-4",
+              messageCenterStatusToneClass(statusTone)
+            )}
             data-status={displayStatus}
             title={statusLabel}
           >
             <StatusDot
-              tone={messageCenterStatusTone(item)}
+              tone={statusTone}
               pulse={
                 isWaitingMessageCenterItem(item) || item.status === "working"
               }
@@ -1122,9 +1126,16 @@ function statusClass(item: WorkspaceAgentMessageCenterItem): string {
   return item.status;
 }
 
+export type MessageCenterStatusTone =
+  | "amber"
+  | "blue"
+  | "green"
+  | "neutral"
+  | "red";
+
 function messageCenterStatusTone(
   item: WorkspaceAgentMessageCenterItem
-): "amber" | "blue" | "green" | "neutral" | "red" {
+): MessageCenterStatusTone {
   if (isWaitingMessageCenterItem(item)) {
     return "amber";
   }
@@ -1141,4 +1152,21 @@ function messageCenterStatusTone(
     return "blue";
   }
   return "neutral";
+}
+
+export function messageCenterStatusToneClass(
+  tone: MessageCenterStatusTone
+): string {
+  switch (tone) {
+    case "amber":
+      return "text-[var(--state-warning)]";
+    case "blue":
+      return "text-[var(--status-running)]";
+    case "green":
+      return "text-[var(--state-success)]";
+    case "red":
+      return "text-[var(--state-danger)]";
+    case "neutral":
+      return "text-[var(--text-secondary)]";
+  }
 }

--- a/packages/agent/gui/agent-message-center/WorkspaceAgentMessageCenterPanel.spec.tsx
+++ b/packages/agent/gui/agent-message-center/WorkspaceAgentMessageCenterPanel.spec.tsx
@@ -674,6 +674,9 @@ describe("WorkspaceAgentMessageCenterCard", () => {
     expect(screen.getByText("Completed").parentElement).toHaveClass(
       "workspace-agent-message-center__status"
     );
+    expect(screen.getByText("Completed").parentElement).toHaveClass(
+      "text-[var(--state-success)]"
+    );
     expect(screen.getByRole("button", { name: "Open session" })).toHaveClass(
       "workspace-agent-message-center__open-chat-button"
     );
@@ -899,6 +902,9 @@ describe("WorkspaceAgentMessageCenterPanel", () => {
     expect(errorHeading).toHaveClass("font-normal");
     expect(runningHeading).toHaveClass("font-normal");
     expect(completedHeading).toHaveClass("font-normal");
+    expect(errorHeading).toHaveClass("text-[var(--state-danger)]");
+    expect(runningHeading).toHaveClass("text-[var(--status-running)]");
+    expect(completedHeading).toHaveClass("text-[var(--state-success)]");
     expect(
       errorHeading.querySelector('[data-slot="status-dot"]')
     ).toHaveAttribute("data-tone", "red");

--- a/packages/agent/gui/agent-message-center/WorkspaceAgentMessageCenterPanel.tsx
+++ b/packages/agent/gui/agent-message-center/WorkspaceAgentMessageCenterPanel.tsx
@@ -35,9 +35,11 @@ import { MessageCenterViewMenu } from "./WorkspaceAgentMessageCenterViewControls
 import {
   MessageCenterIdentityAvatarMark,
   MessageCenterIdentityLabel,
+  messageCenterStatusToneClass,
   resolveMessageCenterNotificationAction,
   WorkspaceAgentMessageCenterStack,
   WorkspaceAgentMessageCenterCard,
+  type MessageCenterStatusTone,
   type WorkspaceAgentMessageCenterCardProps
 } from "./WorkspaceAgentMessageCenterCard";
 import {
@@ -723,7 +725,12 @@ function MessageCenterGroupHeading({
 
   return (
     <h3
-      className="flex min-w-0 items-center gap-1.5 text-[11px] font-normal leading-4 text-[var(--text-tertiary)]"
+      className={cn(
+        "flex min-w-0 items-center gap-1.5 text-[11px] font-normal leading-4",
+        statusSignal
+          ? messageCenterStatusToneClass(statusSignal.tone)
+          : "text-[var(--text-tertiary)]"
+      )}
       title={`${group.label} · ${group.items.length}`}
     >
       {statusSignal ? (
@@ -743,7 +750,10 @@ function MessageCenterGroupHeading({
 
 function messageCenterGroupStatusSignal(
   groupId: string
-): { pulse: boolean; tone: "amber" | "blue" | "green" | "red" } | null {
+): {
+  pulse: boolean;
+  tone: Exclude<MessageCenterStatusTone, "neutral">;
+} | null {
   switch (groupId) {
     case "needs-attention":
     case "waiting":

--- a/packages/agent/gui/app/renderer/agentactivity.css
+++ b/packages/agent/gui/app/renderer/agentactivity.css
@@ -162,9 +162,9 @@
 [data-testid="workspace-agent-message-center"] {
   --agent-gui-package-accent: var(--accent-codex);
   --agent-gui-package-accent-strong: var(--accent-codex);
-  --agent-gui-package-success: rgb(34 197 94);
-  --agent-gui-package-warning: rgb(234 121 8);
-  --agent-gui-package-danger: rgb(220 38 38);
+  --agent-gui-package-success: var(--state-success);
+  --agent-gui-package-warning: var(--state-warning);
+  --agent-gui-package-danger: var(--state-danger);
   --agent-gui-accent: var(--agent-gui-package-accent);
   --agent-gui-accent-strong: var(--agent-gui-package-accent-strong);
   --agent-gui-success: var(--agent-gui-package-success);
@@ -3808,9 +3808,9 @@ aside.workspace-agents-status-panel
     var(--agent-gui-package-accent) 12%
   );
   --agent-gui-package-border-focus: var(--accent-codex-border);
-  --agent-gui-package-success: rgb(34 197 94);
-  --agent-gui-package-warning: rgb(234 121 8);
-  --agent-gui-package-danger: rgb(220 38 38);
+  --agent-gui-package-success: var(--state-success);
+  --agent-gui-package-warning: var(--state-warning);
+  --agent-gui-package-danger: var(--state-danger);
   --agent-gui-accent: var(--agent-gui-package-accent);
   --agent-gui-accent-strong: var(--agent-gui-package-accent-strong);
   --agent-gui-accent-bg: var(--agent-gui-package-accent-bg);
@@ -5486,46 +5486,18 @@ button.agent-gui-node__conversation-section-toggle:hover
 
 .agent-gui-node__provider-setup-notice {
   position: absolute;
-  top: 16px;
-  right: var(--agent-gui-detail-padding-x);
+  top: 8px;
   left: var(--agent-gui-detail-padding-x);
   z-index: 2;
-  display: flex;
-  align-items: center;
-  gap: 8px;
   box-sizing: border-box;
+  width: max-content;
+  max-width: min(calc(100% - (var(--agent-gui-detail-padding-x) * 2)), 420px);
   margin: 0;
-  border: 1px solid
-    color-mix(
-      in srgb,
-      var(--agent-gui-warning, var(--state-warning)) 26%,
-      transparent
-    );
-  border-radius: 8px;
-  padding: 8px 10px;
-  color: var(--agent-gui-warning, var(--state-warning));
-  background: color-mix(
-    in srgb,
-    var(--agent-gui-warning, var(--state-warning)) 9%,
-    transparent
-  );
-  font-size: 13px;
-  line-height: 18px;
   pointer-events: auto;
 }
 
 .agent-gui-node__detail-header + .agent-gui-node__provider-setup-notice {
-  top: calc(64px + 8px);
-}
-
-.agent-gui-node__provider-setup-notice-icon {
-  flex: 0 0 auto;
-  color: currentColor;
-}
-
-.agent-gui-node__provider-setup-notice-text {
-  min-width: 0;
-  overflow-wrap: anywhere;
+  top: calc(64px + 4px);
 }
 
 .agent-gui-node__layout [data-slot="status-dot"],
@@ -5573,25 +5545,25 @@ button.agent-gui-node__conversation-section-toggle:hover
 .agent-gui-node__layout [data-slot="status-dot"][data-tone="green"],
 [data-testid="workspace-agent-message-center"]
   [data-slot="status-dot"][data-tone="green"] {
-  --agent-gui-status-dot-color: var(--agent-gui-success, var(--state-success));
+  --agent-gui-status-dot-color: var(--state-success);
 }
 
 .agent-gui-node__layout [data-slot="status-dot"][data-tone="blue"],
 [data-testid="workspace-agent-message-center"]
   [data-slot="status-dot"][data-tone="blue"] {
-  --agent-gui-status-dot-color: var(--agent-gui-accent);
+  --agent-gui-status-dot-color: var(--status-running);
 }
 
 .agent-gui-node__layout [data-slot="status-dot"][data-tone="amber"],
 [data-testid="workspace-agent-message-center"]
   [data-slot="status-dot"][data-tone="amber"] {
-  --agent-gui-status-dot-color: var(--agent-gui-warning, var(--state-warning));
+  --agent-gui-status-dot-color: var(--state-warning);
 }
 
 .agent-gui-node__layout [data-slot="status-dot"][data-tone="red"],
 [data-testid="workspace-agent-message-center"]
   [data-slot="status-dot"][data-tone="red"] {
-  --agent-gui-status-dot-color: var(--agent-gui-danger, var(--state-danger));
+  --agent-gui-status-dot-color: var(--state-danger);
 }
 
 .agent-gui-node__layout [data-slot="status-dot"][data-pulse="true"],
@@ -6821,9 +6793,9 @@ html[data-theme="light"] [data-message-center-item-id].agent-gui-edge-glow {
   --agent-gui-border-subtle: var(--line-2);
   --agent-gui-package-accent: var(--tutti-purple);
   --agent-gui-package-accent-strong: var(--tutti-purple);
-  --agent-gui-package-success: rgb(34 197 94);
-  --agent-gui-package-warning: rgb(234 121 8);
-  --agent-gui-package-danger: rgb(220 38 38);
+  --agent-gui-package-success: var(--state-success);
+  --agent-gui-package-warning: var(--state-warning);
+  --agent-gui-package-danger: var(--state-danger);
   --agent-gui-accent: var(--agent-gui-package-accent);
   --agent-gui-accent-strong: var(--agent-gui-package-accent-strong);
   --agent-gui-success: var(--agent-gui-package-success);

--- a/packages/ui/rich-text/src/at-panel/mentionPalette.css
+++ b/packages/ui/rich-text/src/at-panel/mentionPalette.css
@@ -775,6 +775,15 @@
   color: var(--rich-text-at-mention-text-secondary);
 }
 
+.rich-text-at-mention-status--activity {
+  padding-inline: 0;
+  background: transparent;
+}
+
+.rich-text-at-mention-status--activity[data-tone] {
+  background: transparent;
+}
+
 .rich-text-at-mention-status [data-slot="status-dot"] {
   display: inline-flex;
   width: 6px;

--- a/packages/ui/rich-text/src/at-panel/mentionStatusTone.ts
+++ b/packages/ui/rich-text/src/at-panel/mentionStatusTone.ts
@@ -15,24 +15,23 @@ export type MentionRowStatusTone =
 export type MentionRowStatusVariant = "activity" | "issue";
 
 /**
- * Background/text classes for the agent activity status badge. Ported verbatim
- * from the agent's `mentionStatusBadgeClassName` so the rendered DOM is
- * unchanged.
+ * Text classes for agent activity status signals. Activity rows already include
+ * a status dot, so they render as plain signal text instead of a filled badge.
  */
 export function activityMentionStatusBadgeClassName(
   tone: MentionRowStatusTone
 ): string {
   switch (tone) {
     case "blue":
-      return "bg-sky-500/10 text-sky-700";
+      return "bg-transparent px-0 text-[var(--status-running)]";
     case "amber":
-      return "bg-[color:color-mix(in_srgb,var(--color-amber-500)_12%,transparent)] text-[var(--color-amber-500)]";
+      return "bg-transparent px-0 text-[var(--state-warning)]";
     case "green":
-      return "bg-[var(--tsh-ui-pill-success-bg)] text-[var(--tsh-ui-pill-success-fg)]";
+      return "bg-transparent px-0 text-[var(--state-success)]";
     case "red":
-      return "bg-[var(--on-danger)] text-[var(--state-danger)]";
+      return "bg-transparent px-0 text-[var(--state-danger)]";
     default:
-      return "bg-[var(--transparency-block)] text-[var(--text-secondary)]";
+      return "bg-transparent px-0 text-[var(--text-secondary)]";
   }
 }
 

--- a/packages/ui/system/src/components/promoted-advanced-components.test.ts
+++ b/packages/ui/system/src/components/promoted-advanced-components.test.ts
@@ -74,6 +74,14 @@ test("promoted advanced primitive sources preserve their core interaction contra
   const statusDotSource = readComponentSource("status-dot.tsx");
   assert.match(statusDotSource, /data-tone=/);
   assert.match(statusDotSource, /data-size=/);
+  assert.match(statusDotSource, /bg-\[var\(--status-running\)\]/);
+  assert.match(statusDotSource, /bg-\[var\(--state-warning\)\]/);
+  assert.match(statusDotSource, /bg-\[var\(--state-danger\)\]/);
+  assert.match(statusDotSource, /bg-\[var\(--state-success\)\]/);
+  assert.doesNotMatch(statusDotSource, /bg-blue-/);
+  assert.doesNotMatch(statusDotSource, /bg-amber-/);
+  assert.doesNotMatch(statusDotSource, /bg-destructive/);
+  assert.doesNotMatch(statusDotSource, /bg-emerald-500/);
 
   const viewportMenuSurfaceSource = readComponentSource(
     "viewport-menu-surface.tsx"

--- a/packages/ui/system/src/components/status-dot/status-dot.tsx
+++ b/packages/ui/system/src/components/status-dot/status-dot.tsx
@@ -5,11 +5,11 @@ import { cn } from "#lib/utils";
 const statusDotVariants = cva("inline-flex shrink-0 rounded-full", {
   variants: {
     tone: {
-      neutral: "bg-muted-foreground/70",
-      green: "bg-emerald-500",
-      blue: "bg-sky-500",
-      amber: "bg-amber-500",
-      red: "bg-destructive"
+      neutral: "bg-[var(--text-tertiary)]",
+      green: "bg-[var(--state-success)]",
+      blue: "bg-[var(--status-running)]",
+      amber: "bg-[var(--state-warning)]",
+      red: "bg-[var(--state-danger)]"
     },
     size: {
       xs: "size-1.5",

--- a/packages/ui/system/src/components/style-contracts.test.ts
+++ b/packages/ui/system/src/components/style-contracts.test.ts
@@ -223,7 +223,9 @@ test("Chinese language contexts use the CJK font stack and medium weights", () =
   );
   assert.match(themeSource, /--state-warning:\s*rgb\(234 121 8\)/);
   assert.match(themeSource, /--state-warning:\s*rgb\(251 146 60\)/);
+  assert.match(themeSource, /--state-danger:\s*rgb\(244 91 91\)/);
   assert.match(themeSource, /--on-danger:\s*rgb\(220 38 38 \/ 8%\)/);
+  assert.match(themeSource, /--on-danger:\s*rgb\(248 113 113 \/ 10%\)/);
   assert.match(baseSource, /:lang\(zh\)/);
   assert.match(baseSource, /--font-sans-system:\s*var\(--font-sans-cjk\)/);
   assert.match(baseSource, /--font-sans:\s*var\(--font-sans-cjk\)/);

--- a/packages/ui/system/src/styles/theme.css
+++ b/packages/ui/system/src/styles/theme.css
@@ -262,7 +262,7 @@
   --accent-foreground: var(--foreground);
   --destructive: oklch(0.672 0.172 25);
   --destructive-foreground: oklch(0.19 0.01 25);
-  --state-danger: rgb(239 68 68);
+  --state-danger: rgb(244 91 91);
   --state-danger-hover: color-mix(
     in srgb,
     var(--state-danger) 90%,
@@ -270,7 +270,7 @@
   );
   --state-success: rgb(74 222 128);
   --state-warning: rgb(251 146 60);
-  --on-danger: rgb(239 68 68 / 8%);
+  --on-danger: rgb(248 113 113 / 10%);
   --on-danger-hover: color-mix(
     in srgb,
     var(--on-danger) 82%,

--- a/packages/workbench/surface/src/host/types.ts
+++ b/packages/workbench/surface/src/host/types.ts
@@ -299,7 +299,7 @@ export interface WorkbenchHostDockEntryStateSource {
 export interface WorkbenchHostNodeWindowCapabilities {
   closable?: boolean;
   defaultOpen?: boolean;
-  fullscreenHeaderMode?: "persistent" | "reveal";
+  fullscreenHeaderMode?: "persistent";
   fullscreenable?: boolean;
   keepMountedWhenMinimized?:
     | boolean

--- a/packages/workbench/surface/src/react/WorkbenchWindowFrame.test.ts
+++ b/packages/workbench/surface/src/react/WorkbenchWindowFrame.test.ts
@@ -13,40 +13,27 @@ test("workbench windows define viewport menu boundaries for local floating menus
   assert.match(source, /data-slot="viewport-menu-boundary"/);
 });
 
-test("fullscreen windows default to reveal header mode", () => {
+test("fullscreen windows always keep their own header visible", () => {
   const source = readFileSync(
     resolve("src/react/WorkbenchWindowFrame.tsx"),
     "utf8"
   );
+  const styleSource = readFileSync(resolve("src/styles/workbench.css"), "utf8");
 
   assert.match(
     source,
-    /const resolvedFullscreenHeaderMode = fullscreenHeaderMode \?\? "reveal";/
+    /const resolvedFullscreenHeaderMode: WorkbenchFullscreenHeaderMode =\s*"persistent";/
+  );
+  assert.doesNotMatch(source, /fullscreenHeaderMode \?\? "reveal"/);
+  assert.doesNotMatch(source, /workbench-window__header-reveal-zone/);
+  assert.doesNotMatch(styleSource, /workbench-window__header-reveal-zone/);
+  assert.doesNotMatch(
+    styleSource,
+    /\.workbench-window\[data-display-mode="fullscreen"\]\s+\.workbench-window__header\s*\{[^}]*opacity:\s*0;/s
   );
   assert.doesNotMatch(
-    source,
-    /const resolvedFullscreenHeaderMode = fullscreenHeaderMode \?\? "persistent";/
-  );
-});
-
-test("fullscreen reveal header hover zone is generous and immediate", () => {
-  const source = readFileSync(resolve("src/styles/workbench.css"), "utf8");
-
-  assert.match(
-    source,
-    /\.workbench-window__header-reveal-zone\s*\{[^}]*height:\s*16px;/
-  );
-  assert.doesNotMatch(
-    source,
-    /\.workbench-window__header-reveal-zone\s*\{[^}]*height:\s*8px;/
-  );
-  assert.match(
-    source,
-    /\.workbench-window\[data-display-mode="fullscreen"\]:has\(\s*\.workbench-window__header-reveal-zone:hover\s*\)\s*\.workbench-window__header\s*\{[^}]*opacity\s+0\.16s\s+ease,[^}]*transform\s+0\.2s\s+cubic-bezier\(0\.4,\s*0,\s*0\.2,\s*1\);/
-  );
-  assert.doesNotMatch(
-    source,
-    /\.workbench-window\[data-display-mode="fullscreen"\]:has\(\s*\.workbench-window__header-reveal-zone:hover\s*\)\s*\.workbench-window__header\s*\{[^}]*0\.5s;/
+    styleSource,
+    /\.workbench-window\[data-display-mode="fullscreen"\]\s+\.workbench-window__body\s*\{[^}]*grid-row:\s*1;/s
   );
 });
 
@@ -63,16 +50,20 @@ test("fullscreen toggle releases button focus when entering fullscreen", () => {
   );
 });
 
-test("layout selection chrome uses shared accent and stationary check tokens", () => {
+test("layout selection chrome uses tutti purple and stationary check tokens", () => {
   const source = readFileSync(
     resolve("src/react/WorkbenchWindowFrame.tsx"),
     "utf8"
   );
 
-  assert.match(source, /border-2 border-\[var\(--accent\)\]/);
-  assert.match(source, /data-\[state=checked\]:border-\[var\(--accent\)\]/);
-  assert.match(source, /data-\[state=checked\]:bg-\[var\(--accent\)\]/);
+  assert.match(source, /border-2 border-\[var\(--tutti-purple\)\]/);
+  assert.match(
+    source,
+    /data-\[state=checked\]:border-\[var\(--tutti-purple\)\]/
+  );
+  assert.match(source, /data-\[state=checked\]:bg-\[var\(--tutti-purple\)\]/);
   assert.match(source, /text-\[var\(--white-stationary\)\]/);
+  assert.doesNotMatch(source, /border-2 border-\[var\(--accent\)\]/);
   assert.doesNotMatch(source, /border-2 border-\[var\(--border-focus\)\]/);
 });
 

--- a/packages/workbench/surface/src/react/WorkbenchWindowFrame.tsx
+++ b/packages/workbench/surface/src/react/WorkbenchWindowFrame.tsx
@@ -87,7 +87,6 @@ function resolveWorkbenchNodeTypeId(data: unknown): string | undefined {
 export function WorkbenchWindowFrame<TData>({
   children,
   edgeSnapEnabled = false,
-  fullscreenHeaderMode,
   genie,
   hiddenMounted = false,
   interactive = true,
@@ -160,7 +159,8 @@ export function WorkbenchWindowFrame<TData>({
   });
   const shouldRenderCustomHeader =
     resolvedHeader.windowChromeMode === "custom-header";
-  const resolvedFullscreenHeaderMode = fullscreenHeaderMode ?? "reveal";
+  const resolvedFullscreenHeaderMode: WorkbenchFullscreenHeaderMode =
+    "persistent";
   const presentationMode = presentation?.mode ?? null;
   const presentationFrame = presentation?.frameByNodeId.get(node.id) ?? null;
   const isPresentationHidden =
@@ -249,10 +249,6 @@ export function WorkbenchWindowFrame<TData>({
           data-window-drag-state={isDragging ? "dragging" : "idle"}
           data-window-resize-state={isResizing ? "resizing" : "idle"}
         >
-          {node.displayMode === "fullscreen" &&
-          resolvedFullscreenHeaderMode === "reveal" ? (
-            <div className="workbench-window__header-reveal-zone" aria-hidden />
-          ) : null}
           <div
             className={[
               "workbench-window__header",
@@ -310,7 +306,7 @@ export function WorkbenchWindowFrame<TData>({
         >
           {presentationInteraction.mode === "layout" &&
           isMissionControlSelected ? (
-            <div className="pointer-events-none absolute inset-0 rounded-lg border-2 border-[var(--accent)] transition-[border-color,transform] duration-150 ease-out" />
+            <div className="pointer-events-none absolute inset-0 rounded-lg border-2 border-[var(--tutti-purple)] transition-[border-color,transform] duration-150 ease-out" />
           ) : null}
         </button>
       ) : null}
@@ -319,7 +315,7 @@ export function WorkbenchWindowFrame<TData>({
         <Checkbox
           aria-hidden="true"
           checked
-          className="pointer-events-none absolute right-3 bottom-3 z-20 size-6 rounded-md text-[var(--white-stationary)] shadow-[0_2px_8px_rgb(0_0_0_/_0.18)] data-[state=checked]:border-[var(--accent)] data-[state=checked]:bg-[var(--accent)] [&_[data-slot=checkbox-indicator]>svg]:size-4"
+          className="pointer-events-none absolute right-3 bottom-3 z-20 size-6 rounded-md text-[var(--white-stationary)] shadow-[0_2px_8px_rgb(0_0_0_/_0.18)] data-[state=checked]:border-[var(--tutti-purple)] data-[state=checked]:bg-[var(--tutti-purple)] [&_[data-slot=checkbox-indicator]>svg]:size-4"
           tabIndex={-1}
         />
       ) : null}

--- a/packages/workbench/surface/src/react/types.ts
+++ b/packages/workbench/surface/src/react/types.ts
@@ -64,7 +64,7 @@ export interface WorkbenchWindowActionContext<TData = unknown> {
 
 export type WorkbenchWindowChromeMode = "system" | "custom-header";
 
-export type WorkbenchFullscreenHeaderMode = "persistent" | "reveal";
+export type WorkbenchFullscreenHeaderMode = "persistent";
 
 export interface WorkbenchResolveWindowChromeModeContext<TData = unknown> {
   node: WorkbenchNode<TData>;

--- a/packages/workbench/surface/src/styles/workbench.css
+++ b/packages/workbench/surface/src/styles/workbench.css
@@ -173,16 +173,8 @@
     box-shadow 0.16s ease;
 }
 
-.workbench-window[data-display-mode="fullscreen"] {
-  grid-template-rows: minmax(0, 1fr);
-}
-
 .workbench-window[data-display-mode="floating"] {
   background: var(--background-panel);
-}
-
-.workbench-window[data-display-mode="fullscreen"][data-fullscreen-header-mode="persistent"] {
-  grid-template-rows: var(--workbench-header-height) minmax(0, 1fr);
 }
 
 .workbench-window[data-focused="true"] {
@@ -218,66 +210,6 @@
   cursor: default;
 }
 
-.workbench-window[data-display-mode="fullscreen"] .workbench-window__header {
-  position: absolute;
-  top: 0;
-  right: 0;
-  left: 0;
-  z-index: 3;
-  backdrop-filter: var(--workbench-window-backdrop-filter);
-  -webkit-backdrop-filter: var(--workbench-window-backdrop-filter);
-  opacity: 0;
-  transform: translateY(calc(-100% - 8px));
-  pointer-events: none;
-  transition:
-    opacity 0.16s ease,
-    transform 0.2s cubic-bezier(0.4, 0, 0.2, 1);
-}
-
-.workbench-window[data-display-mode="fullscreen"][data-fullscreen-header-mode="persistent"]
-  .workbench-window__header {
-  position: relative;
-  opacity: 1;
-  transform: none;
-  pointer-events: auto;
-}
-
-.workbench-window[data-display-mode="fullscreen"]:has(
-    .workbench-window__header-reveal-zone:hover
-  )
-  .workbench-window__header {
-  opacity: 1;
-  transform: translateY(0);
-  pointer-events: auto;
-  transition:
-    opacity 0.16s ease,
-    transform 0.2s cubic-bezier(0.4, 0, 0.2, 1);
-}
-
-.workbench-window[data-display-mode="fullscreen"]:has(
-    .workbench-window__header:hover
-  )
-  .workbench-window__header,
-.workbench-window[data-display-mode="fullscreen"]:has(
-    .workbench-window__header:focus-within
-  )
-  .workbench-window__header {
-  opacity: 1;
-  transform: translateY(0);
-  pointer-events: auto;
-  transition: none;
-}
-
-.workbench-window__header-reveal-zone {
-  position: absolute;
-  top: 0;
-  right: 0;
-  left: 0;
-  z-index: 2;
-  height: 16px;
-  pointer-events: auto;
-}
-
 [data-workbench-drag-handle="true"] {
   cursor: grab;
   user-select: none;
@@ -292,15 +224,6 @@
   min-height: 0;
   overflow: auto;
   background: var(--background-panel);
-}
-
-.workbench-window[data-display-mode="fullscreen"] .workbench-window__body {
-  grid-row: 1;
-}
-
-.workbench-window[data-display-mode="fullscreen"][data-fullscreen-header-mode="persistent"]
-  .workbench-window__body {
-  grid-row: 2;
 }
 
 .workbench-window__resize-handle {
@@ -1376,10 +1299,14 @@
   cursor: default;
 }
 
-.desktop-dock__icon-shell {
+.desktop-dock__icon-shell,
+.desktop-dock__minimized-stack-icon {
   --desktop-dock-loading-badge-offset: -3.6px;
   --desktop-dock-loading-badge-size: 16.2px;
   --desktop-dock-loading-spinner-size: 9px;
+}
+
+.desktop-dock__icon-shell {
   position: relative;
   box-sizing: border-box;
   display: inline-flex;
@@ -1413,7 +1340,7 @@
   align-items: center;
   justify-content: center;
   padding: 0 4.5px;
-  border: 1px solid color-mix(in srgb, var(--workbench-panel) 72%, white);
+  border: 1px solid var(--text-inverted);
   border-radius: 999px;
   background: var(--workbench-foreground);
   box-shadow: 0 1px 4px rgb(0 0 0 / 0.2);
@@ -1493,8 +1420,8 @@
 }
 
 .desktop-dock__count-badge {
-  color: var(--workbench-panel);
-  font-size: 10px;
+  color: var(--text-inverted);
+  font-size: 11px;
   font-weight: 700;
   line-height: 1;
 }
@@ -1515,7 +1442,7 @@
   bottom: -1.8px;
   width: 10.8px;
   height: 10.8px;
-  border: 1.8px solid color-mix(in srgb, var(--workbench-panel) 82%, white);
+  border: 1.8px solid var(--text-inverted);
   border-radius: 999px;
   box-shadow: 0 1px 4px rgb(0 0 0 / 0.18);
 }
@@ -1785,7 +1712,8 @@
 }
 
 .desktop-dock__slot--minimized .desktop-dock__count-badge {
-  right: -10.8px;
+  right: -12px;
+  bottom: var(--desktop-dock-loading-badge-offset);
   z-index: 8;
 }
 

--- a/packages/workbench/surface/src/styles/workbenchStyle.test.ts
+++ b/packages/workbench/surface/src/styles/workbenchStyle.test.ts
@@ -50,6 +50,31 @@ test("dock retained entry removal animates width and icon exit", () => {
   assert.match(css, /@keyframes desktop-dock-separator-collapse-left/);
 });
 
+test("dock badge chrome uses inverted outlines and 11px count text", () => {
+  const css = readFileSync(resolve("src/styles/workbench.css"), "utf8");
+
+  assert.match(
+    css,
+    /\.desktop-dock__icon-shell,\s*\.desktop-dock__minimized-stack-icon\s*{[^}]*--desktop-dock-loading-badge-offset:\s*-3\.6px;[^}]*--desktop-dock-loading-badge-size:\s*16\.2px;/s
+  );
+  assert.match(
+    css,
+    /\.desktop-dock__icon-shell\[data-entry-state="loading"\]::before,\s*\.desktop-dock__count-badge\s*{[^}]*border:\s*1px solid var\(--text-inverted\);/s
+  );
+  assert.match(
+    css,
+    /\.desktop-dock__count-badge\s*{[^}]*color:\s*var\(--text-inverted\);[^}]*font-size:\s*11px;/s
+  );
+  assert.match(
+    css,
+    /\.desktop-dock__status-badge\s*{[^}]*border:\s*1\.8px solid var\(--text-inverted\);/s
+  );
+  assert.match(
+    css,
+    /\.desktop-dock__slot--minimized\s+\.desktop-dock__count-badge\s*{[^}]*right:\s*-12px;[^}]*bottom:\s*var\(--desktop-dock-loading-badge-offset\);/s
+  );
+});
+
 test("left dock placement owns vertical frame and popup placement styles", () => {
   const css = readFileSync(resolve("src/styles/workbench.css"), "utf8");
 

--- a/packages/workspace/issue-manager/src/i18n/issueManagerI18n.test.ts
+++ b/packages/workspace/issue-manager/src/i18n/issueManagerI18n.test.ts
@@ -44,7 +44,7 @@ test("zh-CN task terminology and status labels use requested copy", () => {
   assert.equal(copy.t("labels.searchIssues"), "搜索任务");
   assert.equal(copy.t("labels.subtasks"), "子任务");
   assert.equal(copy.t("labels.taskAcceptance"), "任务待验收");
-  assert.equal(copy.t("labels.taskCount", { count: 7 }), "7子任务");
+  assert.equal(copy.t("labels.taskCount", { count: 7 }), "7 个子任务");
   assert.equal(copy.t("labels.taskDetails"), "任务详情");
   assert.equal(copy.t("labels.taskList"), "任务");
   assert.equal(copy.t("messages.noIssues"), "还没有任务");

--- a/packages/workspace/issue-manager/src/i18n/issueManagerI18n.ts
+++ b/packages/workspace/issue-manager/src/i18n/issueManagerI18n.ts
@@ -347,7 +347,7 @@ const issueManagerZhCN = {
     editTopicDialogTitle: "编辑主题",
     title: "标题",
     updatedAt: "更新时间",
-    taskCount: "{{count}}子任务",
+    taskCount: "{{count}} 个子任务",
     taskDetails: "任务详情",
     taskList: "任务",
     temporaryExecutionDirectory: "临时目录"

--- a/packages/workspace/issue-manager/src/ui/internal/panel/IssueManagerPanelSurface.test.ts
+++ b/packages/workspace/issue-manager/src/ui/internal/panel/IssueManagerPanelSurface.test.ts
@@ -1,0 +1,20 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import test from "node:test";
+
+const panelSurfaceSource = readFileSync(
+  new URL("./IssueManagerPanelSurface.tsx", import.meta.url),
+  "utf8"
+);
+
+test("task center loading skeletons use transparency block surfaces", () => {
+  assert.match(panelSurfaceSource, /bg-\[var\(--transparency-block\)\]/);
+  assert.doesNotMatch(panelSurfaceSource, /bg-muted/);
+});
+
+test("task center loading skeletons use compact uniform bones", () => {
+  assert.match(panelSurfaceSource, /h-4 rounded-\[4px\]/);
+  assert.doesNotMatch(panelSurfaceSource, /rounded-full/);
+  assert.doesNotMatch(panelSurfaceSource, /rounded-\[(?:24|28)px\]/);
+  assert.doesNotMatch(panelSurfaceSource, /h-(?:3\.5|6|10|12)\b/);
+});

--- a/packages/workspace/issue-manager/src/ui/internal/panel/IssueManagerPanelSurface.tsx
+++ b/packages/workspace/issue-manager/src/ui/internal/panel/IssueManagerPanelSurface.tsx
@@ -1,5 +1,8 @@
 import { type JSX, type ReactNode } from "react";
-import { Button, FileCreateIcon } from "@tutti-os/ui-system";
+import { Button, FileCreateIcon, cn } from "@tutti-os/ui-system";
+
+const issueManagerLoadingBoneClassName =
+  "h-4 rounded-[4px] bg-[var(--transparency-block)]";
 
 export function IssueManagerEmptyIllustration({
   src
@@ -59,20 +62,20 @@ export function IssueManagerPaneLoadingState(): JSX.Element {
   return (
     <div
       aria-hidden="true"
-      className="mx-auto flex w-full max-w-4xl flex-col gap-6"
+      className="mx-auto flex w-full max-w-4xl flex-col gap-9"
     >
-      <div className="h-6 w-28 rounded-full bg-muted" />
-      <div className="h-12 w-2/3 rounded-full bg-muted" />
-      <div className="rounded-[28px] border border-border/70 bg-transparent px-5 py-5">
-        <div className="h-4 w-24 rounded-full bg-muted" />
-        <div className="mt-5 h-4 w-full rounded-full bg-muted" />
-        <div className="mt-3 h-4 w-11/12 rounded-full bg-muted" />
-        <div className="mt-3 h-4 w-10/12 rounded-full bg-muted" />
+      <div className={cn(issueManagerLoadingBoneClassName, "w-28")} />
+      <div className={cn(issueManagerLoadingBoneClassName, "w-2/3")} />
+      <div className="grid gap-3">
+        <div className={cn(issueManagerLoadingBoneClassName, "w-24")} />
+        <div className={cn(issueManagerLoadingBoneClassName, "w-full")} />
+        <div className={cn(issueManagerLoadingBoneClassName, "w-11/12")} />
+        <div className={cn(issueManagerLoadingBoneClassName, "w-10/12")} />
       </div>
-      <div className="rounded-[24px] border border-border/70 bg-transparent px-5 py-5">
-        <div className="h-4 w-32 rounded-full bg-muted" />
-        <div className="mt-5 h-4 w-full rounded-full bg-muted" />
-        <div className="mt-3 h-4 w-9/12 rounded-full bg-muted" />
+      <div className="grid gap-3">
+        <div className={cn(issueManagerLoadingBoneClassName, "w-32")} />
+        <div className={cn(issueManagerLoadingBoneClassName, "w-full")} />
+        <div className={cn(issueManagerLoadingBoneClassName, "w-9/12")} />
       </div>
     </div>
   );
@@ -80,21 +83,20 @@ export function IssueManagerPaneLoadingState(): JSX.Element {
 
 export function IssueManagerTaskListLoadingState(): JSX.Element {
   return (
-    <div
-      aria-hidden="true"
-      className="overflow-hidden rounded-lg border border-border/70 bg-transparent"
-    >
+    <div aria-hidden="true" className="overflow-hidden bg-transparent">
       {Array.from({ length: 3 }, (_, index) => (
         <div
           className="border-b border-border/70 px-3.5 py-3.5 last:border-b-0"
           key={index}
         >
           <div className="flex items-center justify-between gap-3">
-            <div className="h-4 w-2/5 rounded-full bg-muted" />
-            <div className="h-3.5 w-20 rounded-full bg-muted" />
+            <div className={cn(issueManagerLoadingBoneClassName, "w-2/5")} />
+            <div className={cn(issueManagerLoadingBoneClassName, "w-20")} />
           </div>
-          <div className="mt-3 h-3.5 w-full rounded-full bg-muted" />
-          <div className="mt-2 h-3.5 w-4/5 rounded-full bg-muted" />
+          <div
+            className={cn(issueManagerLoadingBoneClassName, "mt-3 w-full")}
+          />
+          <div className={cn(issueManagerLoadingBoneClassName, "mt-2 w-4/5")} />
         </div>
       ))}
     </div>
@@ -104,16 +106,16 @@ export function IssueManagerTaskListLoadingState(): JSX.Element {
 export function IssueManagerTaskDrawerLoadingState(): JSX.Element {
   return (
     <div aria-hidden="true" className="grid gap-5">
-      <div className="h-12 w-full rounded-2xl bg-muted" />
+      <div className={cn(issueManagerLoadingBoneClassName, "w-full")} />
       <div className="grid grid-cols-2 gap-3">
-        <div className="h-10 rounded-xl bg-muted" />
-        <div className="h-10 rounded-xl bg-muted" />
+        <div className={issueManagerLoadingBoneClassName} />
+        <div className={issueManagerLoadingBoneClassName} />
       </div>
-      <div className="rounded-[24px] border border-border/70 bg-transparent px-4 py-4">
-        <div className="h-4 w-24 rounded-full bg-muted" />
-        <div className="mt-4 h-4 w-full rounded-full bg-muted" />
-        <div className="mt-3 h-4 w-11/12 rounded-full bg-muted" />
-        <div className="mt-3 h-4 w-9/12 rounded-full bg-muted" />
+      <div className="grid gap-3">
+        <div className={cn(issueManagerLoadingBoneClassName, "w-24")} />
+        <div className={cn(issueManagerLoadingBoneClassName, "w-full")} />
+        <div className={cn(issueManagerLoadingBoneClassName, "w-11/12")} />
+        <div className={cn(issueManagerLoadingBoneClassName, "w-9/12")} />
       </div>
     </div>
   );

--- a/packages/workspace/terminal/src/react/terminalHeaderStyle.test.ts
+++ b/packages/workspace/terminal/src/react/terminalHeaderStyle.test.ts
@@ -1,0 +1,30 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import test from "node:test";
+
+test("terminal header status tag renders without badge background", () => {
+  const css = readFileSync(resolve("src/styles/terminal.css"), "utf8");
+
+  assert.match(
+    css,
+    /\.workspace-terminal__status-tag\s*\{[^}]*padding-inline:\s*0;[^}]*background:\s*transparent;/s
+  );
+});
+
+test("terminal header status dot uses ui-system semantic status colors", () => {
+  const css = readFileSync(resolve("src/styles/terminal.css"), "utf8");
+  const source = readFileSync(resolve("src/react/TerminalNode.tsx"), "utf8");
+
+  assert.match(
+    source,
+    /import \{ Badge, StatusDot \} from "@tutti-os\/ui-system";/
+  );
+  assert.match(source, /tone=\{resolveTerminalStatusTone\(status\)\}/);
+  assert.doesNotMatch(css, /workspace-terminal__status-tag[\s\S]*status-dot/);
+  assert.doesNotMatch(css, /--workspace-terminal-status/);
+  assert.doesNotMatch(css, /--status-running/);
+  assert.doesNotMatch(css, /--state-warning/);
+  assert.doesNotMatch(css, /--state-success/);
+  assert.doesNotMatch(css, /--state-danger/);
+});

--- a/packages/workspace/terminal/src/styles/terminal.css
+++ b/packages/workspace/terminal/src/styles/terminal.css
@@ -50,6 +50,8 @@
 
 .workspace-terminal__status-tag {
   flex: none;
+  padding-inline: 0;
+  background: transparent;
 }
 
 .workspace-terminal__actions {


### PR DESCRIPTION
## Summary

- Polish workspace chrome/status tone surfaces across agent UI, mentions, status dot tokens, terminal header, and issue manager loading skeletons.
- Convert the provider setup warning to ui-system toast styling with adaptive width and adjusted vertical placement.
- Keep all maximized/fullscreen workbench windows on a persistent self-owned topbar and remove hidden-header reveal behavior.

## Validation

- `pnpm check:changed --tail-lines 80`
- `pnpm --filter @tutti-os/agent-gui test -- agent-gui/agentGuiNode/AgentGUINodeView.layout.spec.tsx`
- `pnpm --filter @tutti-os/agent-gui typecheck`
- `pnpm --filter @tutti-os/workbench-surface test`
- `pnpm --filter @tutti-os/workbench-surface typecheck`
- `pnpm lint:go` with Node 24, Go 1.24, and pinned golangci-lint on PATH
- `go test ./service/agentstatus -run TestServiceRunActionSerializesConcurrentExternalRegistryNPMInstalls -count=1`
- pre-push `pnpm check:full`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Status indicators and notice styling now use a more consistent, transparent text-based look across the app.
  * Fullscreen workbench windows now keep their header visible by default.

* **Bug Fixes**
  * Improved loading and enabled-state behavior in the agent composer while setup details are still loading.
  * Updated destructive/error color treatments for better dark-mode readability.
  * Refined issue manager loading placeholders and Chinese task-count wording.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->