### PR TITLE
fix(agent): recover from ACP adapter mismatch and refresh provider status

### DIFF
--- a/apps/desktop/src/renderer/src/features/workspace-agent/services/desktopAgentActivityAdapter.test.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-agent/services/desktopAgentActivityAdapter.test.ts
@@ -264,6 +264,39 @@ test("desktop agent activity adapter refreshes provider status and localizes ada
   assert.deepEqual(refreshCalls, [["claude-code"]]);
 });
 
+test("desktop agent activity adapter does not refresh provider status for unrelated create failures", async () => {
+  const refreshCalls: unknown[] = [];
+  const adapter = createDesktopAgentActivityAdapter({
+    agentProviderStatusService: {
+      async refresh(providers) {
+        refreshCalls.push(providers);
+      }
+    },
+    tuttidClient: createTuttidClient({
+      async createWorkspaceAgentSession() {
+        throw new TuttidProtocolError({
+          code: "service_unavailable",
+          developerMessage: "tuttid unavailable",
+          reason: "service_unavailable",
+          statusCode: 503
+        });
+      }
+    }),
+    runtimeApi: createRuntimeApi()
+  });
+
+  await assert.rejects(
+    adapter.createSession({
+      agentSessionId: "agent-session-1",
+      provider: "claude-code",
+      workspaceId
+    }),
+    /service_unavailable|TuttidProtocolError|tuttid unavailable/
+  );
+
+  assert.deepEqual(refreshCalls, []);
+});
+
 test("desktop agent activity adapter requires an injected session event subscription", async () => {
   const diagnostics: unknown[] = [];
   const adapter = createDesktopAgentActivityAdapter({

--- a/apps/desktop/src/renderer/src/features/workspace-agent/services/desktopAgentActivityAdapter.test.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-agent/services/desktopAgentActivityAdapter.test.ts
@@ -6,6 +6,7 @@ import type {
   WorkspaceAgentSession,
   WorkspaceAgentSessionMessage
 } from "@tutti-os/client-tuttid-ts";
+import { TuttidProtocolError } from "@tutti-os/client-tuttid-ts";
 import { createDesktopAgentActivityAdapter } from "./desktopAgentActivityAdapter.ts";
 
 const workspaceId = "workspace-1";
@@ -228,6 +229,39 @@ test("desktop agent activity adapter forwards submit diagnostic metadata", async
       workspaceId
     }
   ]);
+});
+
+test("desktop agent activity adapter refreshes provider status and localizes adapter mismatch create failures", async () => {
+  const refreshCalls: unknown[] = [];
+  const adapter = createDesktopAgentActivityAdapter({
+    agentProviderStatusService: {
+      async refresh(providers) {
+        refreshCalls.push(providers);
+      }
+    },
+    tuttidClient: createTuttidClient({
+      async createWorkspaceAgentSession() {
+        throw new TuttidProtocolError({
+          code: "workspace_operation_failed",
+          developerMessage: "claude-code: ACP adapter not found",
+          reason: "acp_adapter_version_mismatch",
+          statusCode: 502
+        });
+      }
+    }),
+    runtimeApi: createRuntimeApi()
+  });
+
+  await assert.rejects(
+    adapter.createSession({
+      agentSessionId: "agent-session-1",
+      provider: "claude-code",
+      workspaceId
+    }),
+    /Claude Code's local adapter is unavailable or version-mismatched/
+  );
+
+  assert.deepEqual(refreshCalls, [["claude-code"]]);
 });
 
 test("desktop agent activity adapter requires an injected session event subscription", async () => {

--- a/apps/desktop/src/renderer/src/features/workspace-agent/services/desktopAgentActivityAdapter.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-agent/services/desktopAgentActivityAdapter.ts
@@ -16,14 +16,20 @@ import type {
   WorkspaceAgentSession,
   WorkspaceAgentSessionMessage
 } from "@tutti-os/client-tuttid-ts";
+import { normalizeTuttidError } from "@tutti-os/client-tuttid-ts";
 import type { DesktopRuntimeApi } from "@preload/types";
+import type { IAgentProviderStatusService } from "./agentProviderStatusService.interface";
+import { getActiveLocale } from "../../../i18n/runtime.ts";
+import { resolveDesktopErrorMessage } from "../../../lib/desktopErrors.ts";
 
 export interface CreateDesktopAgentActivityAdapterInput {
+  agentProviderStatusService?: Pick<IAgentProviderStatusService, "refresh">;
   tuttidClient: TuttidClient;
   runtimeApi: Pick<DesktopRuntimeApi, "logTerminalDiagnostic">;
 }
 
 export function createDesktopAgentActivityAdapter({
+  agentProviderStatusService,
   tuttidClient,
   runtimeApi
 }: CreateDesktopAgentActivityAdapterInput): AgentActivityAdapter {
@@ -266,79 +272,88 @@ export function createDesktopAgentActivityAdapter({
         provider: input.provider,
         workspaceId: input.workspaceId
       });
-      const promoted = await promoteClaudeDraft(input);
-      if (promoted) {
+      try {
+        const promoted = await promoteClaudeDraft(input);
+        if (promoted) {
+          reportDesktopAgentSubmitTrace(runtimeApi, {
+            agentSessionId: promoted.agentSessionId,
+            event: "renderer_adapter.create.promoted_draft",
+            metadata: input.metadata,
+            provider: promoted.provider,
+            workspaceId: input.workspaceId
+          });
+          return promoted;
+        }
+        if (
+          workspaceAgentProvider(input.provider) === "claude-code" &&
+          (input.initialContent?.length ?? 0) > 0
+        ) {
+          const draft = await ensureClaudeDraft({
+            agentSessionId: input.agentSessionId?.trim() ?? null,
+            cwd: input.cwd ?? null,
+            settings: normalizedClaudeDraftSettings({
+              model: input.model,
+              permissionModeId: input.permissionModeId,
+              planMode: input.planMode,
+              reasoningEffort: input.reasoningEffort,
+              speed: input.speed
+            }),
+            workspaceId: input.workspaceId
+          });
+          const promotedDraft = await promoteClaudeDraft({
+            ...input,
+            agentSessionId: draft.id
+          });
+          if (promotedDraft) {
+            return promotedDraft;
+          }
+        }
+        const agentSessionId =
+          input.agentSessionId?.trim() || createDesktopAgentActivitySessionId();
         reportDesktopAgentSubmitTrace(runtimeApi, {
-          agentSessionId: promoted.agentSessionId,
-          event: "renderer_adapter.create.promoted_draft",
-          metadata: input.metadata,
-          provider: promoted.provider,
-          workspaceId: input.workspaceId
-        });
-        return promoted;
-      }
-      if (
-        workspaceAgentProvider(input.provider) === "claude-code" &&
-        (input.initialContent?.length ?? 0) > 0
-      ) {
-        const draft = await ensureClaudeDraft({
-          agentSessionId: input.agentSessionId?.trim() ?? null,
-          cwd: input.cwd ?? null,
-          settings: normalizedClaudeDraftSettings({
-            model: input.model,
-            permissionModeId: input.permissionModeId,
-            planMode: input.planMode,
-            reasoningEffort: input.reasoningEffort,
-            speed: input.speed
-          }),
-          workspaceId: input.workspaceId
-        });
-        const promotedDraft = await promoteClaudeDraft({
-          ...input,
-          agentSessionId: draft.id
-        });
-        if (promotedDraft) {
-          return promotedDraft;
-        }
-      }
-      const agentSessionId =
-        input.agentSessionId?.trim() || createDesktopAgentActivitySessionId();
-      reportDesktopAgentSubmitTrace(runtimeApi, {
-        agentSessionId,
-        event: "renderer_adapter.create.http_requested",
-        metadata: input.metadata,
-        provider: input.provider,
-        workspaceId: input.workspaceId
-      });
-      const session = await tuttidClient.createWorkspaceAgentSession(
-        input.workspaceId,
-        {
           agentSessionId,
-          cwd: input.cwd ?? null,
-          initialContent: toTuttidPromptContentBlocks(
-            input.initialContent ?? []
-          ),
-          initialDisplayPrompt: input.initialDisplayPrompt ?? null,
-          ...(input.metadata ? { metadata: input.metadata } : {}),
-          model: input.model ?? null,
-          planMode: input.planMode ?? null,
-          permissionModeId: input.permissionModeId ?? null,
-          provider: workspaceAgentProvider(input.provider),
-          reasoningEffort: input.reasoningEffort ?? null,
-          speed: input.speed ?? null,
-          title: input.title ?? null,
-          visible: input.visible ?? null
-        }
-      );
-      reportDesktopAgentSubmitTrace(runtimeApi, {
-        agentSessionId: session.id,
-        event: "renderer_adapter.create.resolved",
-        metadata: input.metadata,
-        provider: session.provider,
-        workspaceId: input.workspaceId,
-        fields: { sessionStatus: session.status }
-      });
-      return agentActivitySessionFromTuttidSession(input.workspaceId, session);
+          event: "renderer_adapter.create.http_requested",
+          metadata: input.metadata,
+          provider: input.provider,
+          workspaceId: input.workspaceId
+        });
+        const session = await tuttidClient.createWorkspaceAgentSession(
+          input.workspaceId,
+          {
+            agentSessionId,
+            cwd: input.cwd ?? null,
+            initialContent: toTuttidPromptContentBlocks(
+              input.initialContent ?? []
+            ),
+            initialDisplayPrompt: input.initialDisplayPrompt ?? null,
+            ...(input.metadata ? { metadata: input.metadata } : {}),
+            model: input.model ?? null,
+            planMode: input.planMode ?? null,
+            permissionModeId: input.permissionModeId ?? null,
+            provider: workspaceAgentProvider(input.provider),
+            reasoningEffort: input.reasoningEffort ?? null,
+            speed: input.speed ?? null,
+            title: input.title ?? null,
+            visible: input.visible ?? null
+          }
+        );
+        reportDesktopAgentSubmitTrace(runtimeApi, {
+          agentSessionId: session.id,
+          event: "renderer_adapter.create.resolved",
+          metadata: input.metadata,
+          provider: session.provider,
+          workspaceId: input.workspaceId,
+          fields: { sessionStatus: session.status }
+        });
+        return agentActivitySessionFromTuttidSession(
+          input.workspaceId,
+          session
+        );
+      } catch (error) {
+        const provider = workspaceAgentProvider(input.provider);
+        void agentProviderStatusService?.refresh([provider]).catch(() => {});
+        throw createAgentSessionCreateError(error);
+      }
     },
     async sendInput(input) {
       reportDesktopAgentSubmitTrace(runtimeApi, {
@@ -461,6 +476,29 @@ function reportDesktopAgentSubmitTrace(
   } catch {
     // Diagnostic logging must not affect agent submission.
   }
+}
+
+function createAgentSessionCreateError(error: unknown): unknown {
+  const normalized = normalizeTuttidError(error);
+  if (
+    normalized?.code !== "workspace_operation_failed" ||
+    normalized.reason !== "acp_adapter_version_mismatch"
+  ) {
+    return error;
+  }
+  const message = resolveDesktopErrorMessage(error, getActiveLocale());
+  const wrapped = new Error(message);
+  wrapped.name = error instanceof Error ? error.name : "TuttidProtocolError";
+  Object.assign(wrapped, {
+    code: normalized.code,
+    correlationId: normalized.correlationId,
+    developerMessage: normalized.developerMessage,
+    params: normalized.params,
+    reason: normalized.reason,
+    retryable: normalized.retryable,
+    statusCode: normalized.statusCode
+  });
+  return wrapped;
 }
 
 function stringMetadata(

--- a/apps/desktop/src/renderer/src/features/workspace-agent/services/desktopAgentActivityAdapter.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-agent/services/desktopAgentActivityAdapter.ts
@@ -16,11 +16,11 @@ import type {
   WorkspaceAgentSession,
   WorkspaceAgentSessionMessage
 } from "@tutti-os/client-tuttid-ts";
-import { normalizeTuttidError } from "@tutti-os/client-tuttid-ts";
 import type { DesktopRuntimeApi } from "@preload/types";
 import type { IAgentProviderStatusService } from "./agentProviderStatusService.interface";
 import { getActiveLocale } from "../../../i18n/runtime.ts";
-import { resolveDesktopErrorMessage } from "../../../lib/desktopErrors.ts";
+import { wrapLocalizedTuttidErrorIfSpecific } from "../../../lib/desktopErrors.ts";
+import { shouldRefreshProviderStatusAfterSessionError } from "./internal/desktopAgentProviderStatusSync.ts";
 
 export interface CreateDesktopAgentActivityAdapterInput {
   agentProviderStatusService?: Pick<IAgentProviderStatusService, "refresh">;
@@ -351,8 +351,10 @@ export function createDesktopAgentActivityAdapter({
         );
       } catch (error) {
         const provider = workspaceAgentProvider(input.provider);
-        void agentProviderStatusService?.refresh([provider]).catch(() => {});
-        throw createAgentSessionCreateError(error);
+        if (shouldRefreshProviderStatusAfterSessionError(error)) {
+          void agentProviderStatusService?.refresh([provider]).catch(() => {});
+        }
+        throw wrapLocalizedTuttidErrorIfSpecific(error, getActiveLocale());
       }
     },
     async sendInput(input) {
@@ -476,29 +478,6 @@ function reportDesktopAgentSubmitTrace(
   } catch {
     // Diagnostic logging must not affect agent submission.
   }
-}
-
-function createAgentSessionCreateError(error: unknown): unknown {
-  const normalized = normalizeTuttidError(error);
-  if (
-    normalized?.code !== "workspace_operation_failed" ||
-    normalized.reason !== "acp_adapter_version_mismatch"
-  ) {
-    return error;
-  }
-  const message = resolveDesktopErrorMessage(error, getActiveLocale());
-  const wrapped = new Error(message);
-  wrapped.name = error instanceof Error ? error.name : "TuttidProtocolError";
-  Object.assign(wrapped, {
-    code: normalized.code,
-    correlationId: normalized.correlationId,
-    developerMessage: normalized.developerMessage,
-    params: normalized.params,
-    reason: normalized.reason,
-    retryable: normalized.retryable,
-    statusCode: normalized.statusCode
-  });
-  return wrapped;
 }
 
 function stringMetadata(

--- a/apps/desktop/src/renderer/src/features/workspace-agent/services/internal/desktopAgentProviderStatusSync.test.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-agent/services/internal/desktopAgentProviderStatusSync.test.ts
@@ -1,0 +1,54 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { TuttidProtocolError } from "@tutti-os/client-tuttid-ts";
+import { shouldRefreshProviderStatusAfterSessionError } from "./desktopAgentProviderStatusSync.ts";
+
+test("shouldRefreshProviderStatusAfterSessionError matches provider availability reasons", () => {
+  assert.equal(
+    shouldRefreshProviderStatusAfterSessionError(
+      new TuttidProtocolError({
+        code: "workspace_operation_failed",
+        reason: "acp_adapter_version_mismatch",
+        statusCode: 502
+      })
+    ),
+    true
+  );
+  assert.equal(
+    shouldRefreshProviderStatusAfterSessionError(
+      new TuttidProtocolError({
+        code: "workspace_operation_failed",
+        reason: "cli_not_found",
+        statusCode: 502
+      })
+    ),
+    true
+  );
+});
+
+test("shouldRefreshProviderStatusAfterSessionError ignores unrelated failures", () => {
+  assert.equal(
+    shouldRefreshProviderStatusAfterSessionError(
+      new TuttidProtocolError({
+        code: "workspace_operation_failed",
+        reason: "workspace_operation_failed",
+        statusCode: 502
+      })
+    ),
+    false
+  );
+  assert.equal(
+    shouldRefreshProviderStatusAfterSessionError(
+      new TuttidProtocolError({
+        code: "service_unavailable",
+        reason: "service_unavailable",
+        statusCode: 503
+      })
+    ),
+    false
+  );
+  assert.equal(
+    shouldRefreshProviderStatusAfterSessionError(new Error("network down")),
+    false
+  );
+});

--- a/apps/desktop/src/renderer/src/features/workspace-agent/services/internal/desktopAgentProviderStatusSync.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-agent/services/internal/desktopAgentProviderStatusSync.ts
@@ -1,0 +1,22 @@
+import { normalizeTuttidError } from "@tutti-os/client-tuttid-ts";
+
+const providerStatusRefreshReasons = new Set([
+  "acp_adapter_not_found",
+  "acp_adapter_launch_failed",
+  "acp_adapter_version_mismatch",
+  "agent_provider_unavailable",
+  "auth_required",
+  "auth_unknown",
+  "cli_not_found"
+]);
+
+export function shouldRefreshProviderStatusAfterSessionError(
+  error: unknown
+): boolean {
+  const normalized = normalizeTuttidError(error);
+  if (!normalized || normalized.code !== "workspace_operation_failed") {
+    return false;
+  }
+  const reason = normalized.reason?.trim() ?? "";
+  return providerStatusRefreshReasons.has(reason);
+}

--- a/apps/desktop/src/renderer/src/features/workspace-agent/services/internal/desktopAgentProviderVisibilityRefresh.test.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-agent/services/internal/desktopAgentProviderVisibilityRefresh.test.ts
@@ -38,9 +38,15 @@ test("bindDesktopManagedAgentProviderVisibilityRefresh refreshes managed provide
       }
     },
     {
-      document: documentStub,
+      document: documentStub as Pick<
+        Document,
+        "addEventListener" | "removeEventListener" | "visibilityState"
+      >,
       minIntervalMs: 0,
-      window: windowStub
+      window: windowStub as Pick<
+        Window,
+        "addEventListener" | "removeEventListener"
+      >
     }
   );
 
@@ -74,7 +80,10 @@ test("bindDesktopManagedAgentProviderVisibilityRefresh skips hidden documents", 
         removeEventListener(type: string, listener: () => void) {
           listeners.get(type)?.delete(listener);
         }
-      },
+      } as Pick<
+        Document,
+        "addEventListener" | "removeEventListener" | "visibilityState"
+      >,
       minIntervalMs: 0,
       window: {
         addEventListener(type: string, listener: () => void) {
@@ -85,7 +94,7 @@ test("bindDesktopManagedAgentProviderVisibilityRefresh skips hidden documents", 
         removeEventListener(type: string, listener: () => void) {
           listeners.get(type)?.delete(listener);
         }
-      }
+      } as Pick<Window, "addEventListener" | "removeEventListener">
     }
   );
 

--- a/apps/desktop/src/renderer/src/features/workspace-agent/services/internal/desktopAgentProviderVisibilityRefresh.test.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-agent/services/internal/desktopAgentProviderVisibilityRefresh.test.ts
@@ -1,0 +1,97 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { bindDesktopManagedAgentProviderVisibilityRefresh } from "./desktopAgentProviderVisibilityRefresh.ts";
+
+test("bindDesktopManagedAgentProviderVisibilityRefresh refreshes managed providers on focus", () => {
+  const refreshCalls: unknown[] = [];
+  let visibilityState: DocumentVisibilityState = "visible";
+  const listeners = new Map<string, Set<() => void>>();
+
+  const documentStub = {
+    get visibilityState() {
+      return visibilityState;
+    },
+    addEventListener(type: string, listener: () => void) {
+      const bucket = listeners.get(type) ?? new Set();
+      bucket.add(listener);
+      listeners.set(type, bucket);
+    },
+    removeEventListener(type: string, listener: () => void) {
+      listeners.get(type)?.delete(listener);
+    }
+  };
+  const windowStub = {
+    addEventListener(type: string, listener: () => void) {
+      const bucket = listeners.get(type) ?? new Set();
+      bucket.add(listener);
+      listeners.set(type, bucket);
+    },
+    removeEventListener(type: string, listener: () => void) {
+      listeners.get(type)?.delete(listener);
+    }
+  };
+
+  bindDesktopManagedAgentProviderVisibilityRefresh(
+    {
+      async refresh(providers) {
+        refreshCalls.push(providers);
+      }
+    },
+    {
+      document: documentStub,
+      minIntervalMs: 0,
+      window: windowStub
+    }
+  );
+
+  for (const listener of listeners.get("focus") ?? []) {
+    listener();
+  }
+
+  assert.deepEqual(refreshCalls, [
+    ["claude-code", "codex", "nexight", "gemini", "hermes", "openclaw"]
+  ]);
+});
+
+test("bindDesktopManagedAgentProviderVisibilityRefresh skips hidden documents", () => {
+  const refreshCalls: unknown[] = [];
+  const listeners = new Map<string, Set<() => void>>();
+
+  bindDesktopManagedAgentProviderVisibilityRefresh(
+    {
+      async refresh(providers) {
+        refreshCalls.push(providers);
+      }
+    },
+    {
+      document: {
+        visibilityState: "hidden",
+        addEventListener(type: string, listener: () => void) {
+          const bucket = listeners.get(type) ?? new Set();
+          bucket.add(listener);
+          listeners.set(type, bucket);
+        },
+        removeEventListener(type: string, listener: () => void) {
+          listeners.get(type)?.delete(listener);
+        }
+      },
+      minIntervalMs: 0,
+      window: {
+        addEventListener(type: string, listener: () => void) {
+          const bucket = listeners.get(type) ?? new Set();
+          bucket.add(listener);
+          listeners.set(type, bucket);
+        },
+        removeEventListener(type: string, listener: () => void) {
+          listeners.get(type)?.delete(listener);
+        }
+      }
+    }
+  );
+
+  for (const listener of listeners.get("focus") ?? []) {
+    listener();
+  }
+
+  assert.deepEqual(refreshCalls, []);
+});

--- a/apps/desktop/src/renderer/src/features/workspace-agent/services/internal/desktopAgentProviderVisibilityRefresh.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-agent/services/internal/desktopAgentProviderVisibilityRefresh.ts
@@ -1,0 +1,47 @@
+import type { IAgentProviderStatusService } from "../agentProviderStatusService.interface.ts";
+import { desktopManagedAgentProviders } from "./desktopManagedAgentProviders.ts";
+
+export interface DesktopAgentProviderVisibilityRefreshOptions {
+  document?: Pick<
+    Document,
+    "addEventListener" | "removeEventListener" | "visibilityState"
+  >;
+  minIntervalMs?: number;
+  window?: Pick<Window, "addEventListener" | "removeEventListener">;
+}
+
+export function bindDesktopManagedAgentProviderVisibilityRefresh(
+  service: Pick<IAgentProviderStatusService, "refresh">,
+  options: DesktopAgentProviderVisibilityRefreshOptions = {}
+): () => void {
+  const windowRef =
+    options.window ?? (typeof window !== "undefined" ? window : null);
+  const documentRef =
+    options.document ?? (typeof document !== "undefined" ? document : null);
+  if (!windowRef || !documentRef) {
+    return () => {};
+  }
+
+  const minIntervalMs = options.minIntervalMs ?? 10_000;
+  const providers = [...desktopManagedAgentProviders];
+  let lastRefreshAt = 0;
+
+  const refreshStatuses = (): void => {
+    if (documentRef.visibilityState !== "visible") {
+      return;
+    }
+    const now = Date.now();
+    if (now - lastRefreshAt < minIntervalMs) {
+      return;
+    }
+    lastRefreshAt = now;
+    void service.refresh(providers).catch(() => {});
+  };
+
+  windowRef.addEventListener("focus", refreshStatuses);
+  documentRef.addEventListener("visibilitychange", refreshStatuses);
+  return () => {
+    windowRef.removeEventListener("focus", refreshStatuses);
+    documentRef.removeEventListener("visibilitychange", refreshStatuses);
+  };
+}

--- a/apps/desktop/src/renderer/src/features/workspace-agent/services/internal/workspaceAgentActivityService.test.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-agent/services/internal/workspaceAgentActivityService.test.ts
@@ -1,6 +1,7 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 import type { TuttidClient } from "@tutti-os/client-tuttid-ts";
+import { TuttidProtocolError } from "@tutti-os/client-tuttid-ts";
 import { WorkspaceAgentActivityService } from "./workspaceAgentActivityService.ts";
 
 function createService(): WorkspaceAgentActivityService {
@@ -128,6 +129,53 @@ test("WorkspaceAgentActivityService.listAgentGeneratedFiles delegates to tuttid 
   ]);
   assert.deepEqual(result.entries, [
     { label: "report.md", path: "/workspace/report.md" }
+  ]);
+});
+
+test("WorkspaceAgentActivityService treats missing reconcile sessions as tombstones", async () => {
+  const diagnostics: unknown[] = [];
+  const service = new WorkspaceAgentActivityService({
+    tuttidClient: {
+      getWorkspaceAgentSession: async () => {
+        throw new TuttidProtocolError({
+          code: "workspace_not_found",
+          developerMessage: "workspace agent session not found",
+          reason: "workspace_agent_session_not_found",
+          statusCode: 404
+        });
+      }
+    } as unknown as TuttidClient,
+    runtimeApi: {
+      logTerminalDiagnostic: async (payload) => {
+        diagnostics.push(payload);
+      }
+    }
+  });
+
+  await (
+    service as unknown as {
+      reconcileAgentActivityUpdate(input: {
+        agentSessionId: string;
+        eventType: string;
+        workspaceId: string;
+      }): Promise<void>;
+    }
+  ).reconcileAgentActivityUpdate({
+    agentSessionId: "ghost-session",
+    eventType: "session_update",
+    workspaceId: "ws-1"
+  });
+
+  assert.deepEqual(diagnostics, [
+    {
+      details: {
+        agentSessionId: "ghost-session",
+        error: "workspace agent session not found"
+      },
+      event: "agent.activity.reconcile_session_missing",
+      level: "info",
+      workspaceId: "ws-1"
+    }
   ]);
 });
 

--- a/apps/desktop/src/renderer/src/features/workspace-agent/services/internal/workspaceAgentActivityService.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-agent/services/internal/workspaceAgentActivityService.ts
@@ -14,6 +14,7 @@ import type {
   TuttidClient,
   TuttidEventStreamClient
 } from "@tutti-os/client-tuttid-ts";
+import { normalizeTuttidError } from "@tutti-os/client-tuttid-ts";
 import type { DesktopHostFilesApi, DesktopRuntimeApi } from "@preload/types";
 import {
   agentActivitySessionFromTuttidSession,
@@ -38,6 +39,7 @@ import type {
   WorkspaceAgentActivityEnsureSessionSynchronizedInput,
   WorkspaceAgentActivityRetainSessionInput
 } from "../workspaceAgentActivityService.interface.ts";
+import type { IAgentProviderStatusService } from "../agentProviderStatusService.interface.ts";
 import { planDecisionOps } from "@tutti-os/agent-gui/plan-decision-ops";
 import type { IWorkspaceUserProjectService } from "../../../workspace-user-project/index.ts";
 
@@ -49,6 +51,7 @@ export interface WorkspaceAgentActivityServiceDependencies {
   >;
   tuttidClient: TuttidClient;
   runtimeApi: Pick<DesktopRuntimeApi, "logTerminalDiagnostic">;
+  agentProviderStatusService?: Pick<IAgentProviderStatusService, "refresh">;
   workspaceUserProjectService?: IWorkspaceUserProjectService;
 }
 
@@ -652,7 +655,8 @@ export class WorkspaceAgentActivityService implements IWorkspaceAgentActivitySer
 
     const adapter = createDesktopAgentActivityAdapter({
       tuttidClient: this.dependencies.tuttidClient,
-      runtimeApi: this.dependencies.runtimeApi
+      runtimeApi: this.dependencies.runtimeApi,
+      agentProviderStatusService: this.dependencies.agentProviderStatusService
     });
     const controller = createAgentActivityController({
       adapter,
@@ -924,6 +928,23 @@ export class WorkspaceAgentActivityService implements IWorkspaceAgentActivitySer
       } while (entry.pending);
     })()
       .catch((error: unknown) => {
+        if (isWorkspaceAgentSessionNotFoundError(error)) {
+          this.markSessionDeleted({
+            agentSessionId,
+            data: { reason: "workspace_agent_session_not_found" },
+            workspaceId
+          });
+          void this.dependencies.runtimeApi.logTerminalDiagnostic({
+            details: {
+              agentSessionId,
+              error: stringifyError(error)
+            },
+            event: "agent.activity.reconcile_session_missing",
+            level: "info",
+            workspaceId
+          });
+          return;
+        }
         void this.dependencies.runtimeApi.logTerminalDiagnostic({
           details: { error: stringifyError(error) },
           event: "agent.activity.reconcile_failed",
@@ -1252,6 +1273,14 @@ function shouldPreserveOptimisticWorkingAfterSend(
 
 function sessionKey(workspaceId: string, agentSessionId: string): string {
   return `${normalizeWorkspaceId(workspaceId)}\n${agentSessionId.trim()}`;
+}
+
+function isWorkspaceAgentSessionNotFoundError(error: unknown): boolean {
+  const normalized = normalizeTuttidError(error);
+  return (
+    normalized?.code === "workspace_not_found" &&
+    normalized.reason === "workspace_agent_session_not_found"
+  );
 }
 
 function deletedAtUnixMsFromData(data: unknown): number | null {

--- a/apps/desktop/src/renderer/src/features/workspace-agent/services/registerWorkspaceAgentServices.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-agent/services/registerWorkspaceAgentServices.ts
@@ -37,22 +37,6 @@ export function registerWorkspaceAgentServices(
   registry: ServiceRegistry,
   input: WorkspaceAgentServiceRegistrationInput
 ): WorkspaceAgentServiceRegistrationResult {
-  const workspaceAgentActivityService = new WorkspaceAgentActivityService(
-    input
-  );
-  registry.registerInstance(
-    IWorkspaceAgentActivityService,
-    workspaceAgentActivityService
-  );
-  registry.registerInstance(
-    IWorkspaceAgentPromptSessionService,
-    new WorkspaceAgentPromptSessionService({
-      reporterService: input.reporterService,
-      workspaceAgentActivityService,
-      workspaceUserProjectService: input.workspaceUserProjectService
-    })
-  );
-
   const agentProviderStatusService = new DesktopAgentProviderStatusService(
     {
       tuttidClient: input.tuttidClient,
@@ -64,6 +48,22 @@ export function registerWorkspaceAgentServices(
   registry.registerInstance(
     IAgentProviderStatusService,
     agentProviderStatusService
+  );
+  const workspaceAgentActivityService = new WorkspaceAgentActivityService({
+    ...input,
+    agentProviderStatusService
+  });
+  registry.registerInstance(
+    IWorkspaceAgentActivityService,
+    workspaceAgentActivityService
+  );
+  registry.registerInstance(
+    IWorkspaceAgentPromptSessionService,
+    new WorkspaceAgentPromptSessionService({
+      reporterService: input.reporterService,
+      workspaceAgentActivityService,
+      workspaceUserProjectService: input.workspaceUserProjectService
+    })
   );
   return { agentProviderStatusService };
 }

--- a/apps/desktop/src/renderer/src/features/workspace-agent/services/registerWorkspaceAgentServices.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-agent/services/registerWorkspaceAgentServices.ts
@@ -9,6 +9,7 @@ import type { IWorkspaceUserProjectService } from "../../workspace-user-project/
 import type { NotificationService } from "@tutti-os/ui-notifications";
 import { IAgentProviderStatusService } from "./agentProviderStatusService.interface";
 import type { AgentProviderTerminalCommandRunner } from "./agentProviderStatusService.interface";
+import { bindDesktopManagedAgentProviderVisibilityRefresh } from "./internal/desktopAgentProviderVisibilityRefresh.ts";
 import { DesktopAgentProviderStatusService } from "./internal/desktopAgentProviderStatusService";
 import { WorkspaceAgentActivityService } from "./internal/workspaceAgentActivityService";
 import { WorkspaceAgentPromptSessionService } from "./internal/workspaceAgentPromptSessionService";
@@ -49,6 +50,7 @@ export function registerWorkspaceAgentServices(
     IAgentProviderStatusService,
     agentProviderStatusService
   );
+  bindDesktopManagedAgentProviderVisibilityRefresh(agentProviderStatusService);
   const workspaceAgentActivityService = new WorkspaceAgentActivityService({
     ...input,
     agentProviderStatusService

--- a/apps/desktop/src/renderer/src/features/workspace-workbench/ui/WorkspaceWorkbench.tsx
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/ui/WorkspaceWorkbench.tsx
@@ -570,27 +570,6 @@ function ReadyWorkspaceWorkbench({
   }, [agentProviderStatusService, runtime.workbenchHostService]);
 
   useEffect(() => {
-    let lastRefreshAt = 0;
-    const refreshClaudeCodeStatus = () => {
-      if (document.visibilityState !== "visible") {
-        return;
-      }
-      const now = Date.now();
-      if (now - lastRefreshAt < 10_000) {
-        return;
-      }
-      lastRefreshAt = now;
-      void agentProviderStatusService.refresh(["claude-code"]);
-    };
-    window.addEventListener("focus", refreshClaudeCodeStatus);
-    document.addEventListener("visibilitychange", refreshClaudeCodeStatus);
-    return () => {
-      window.removeEventListener("focus", refreshClaudeCodeStatus);
-      document.removeEventListener("visibilitychange", refreshClaudeCodeStatus);
-    };
-  }, [agentProviderStatusService]);
-
-  useEffect(() => {
     const missionControlShortcutsEnabled =
       runtime.shortcutsEnabled || runtime.missionControl.isOpen;
     if (!missionControlShortcutsEnabled || !runtime.missionControl.canOpen) {

--- a/apps/desktop/src/renderer/src/features/workspace-workbench/ui/WorkspaceWorkbench.tsx
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/ui/WorkspaceWorkbench.tsx
@@ -570,6 +570,27 @@ function ReadyWorkspaceWorkbench({
   }, [agentProviderStatusService, runtime.workbenchHostService]);
 
   useEffect(() => {
+    let lastRefreshAt = 0;
+    const refreshClaudeCodeStatus = () => {
+      if (document.visibilityState !== "visible") {
+        return;
+      }
+      const now = Date.now();
+      if (now - lastRefreshAt < 10_000) {
+        return;
+      }
+      lastRefreshAt = now;
+      void agentProviderStatusService.refresh(["claude-code"]);
+    };
+    window.addEventListener("focus", refreshClaudeCodeStatus);
+    document.addEventListener("visibilitychange", refreshClaudeCodeStatus);
+    return () => {
+      window.removeEventListener("focus", refreshClaudeCodeStatus);
+      document.removeEventListener("visibilitychange", refreshClaudeCodeStatus);
+    };
+  }, [agentProviderStatusService]);
+
+  useEffect(() => {
     const missionControlShortcutsEnabled =
       runtime.shortcutsEnabled || runtime.missionControl.isOpen;
     if (!missionControlShortcutsEnabled || !runtime.missionControl.canOpen) {

--- a/apps/desktop/src/renderer/src/lib/desktopErrors.test.ts
+++ b/apps/desktop/src/renderer/src/lib/desktopErrors.test.ts
@@ -73,6 +73,22 @@ test("resolveDesktopErrorMessage falls back to grouped default translations", ()
   assert.equal(message, "That request could not be completed.");
 });
 
+test("resolveDesktopErrorMessage localizes workspace operation reason details", () => {
+  const message = resolveDesktopErrorMessage(
+    {
+      code: "workspace_operation_failed",
+      reason: "acp_adapter_version_mismatch",
+      developerMessage: "claude-code: ACP adapter not found"
+    },
+    "zh-CN"
+  );
+
+  assert.equal(
+    message,
+    "Claude Code 本地适配器不可用或版本不匹配。请先在 Dock 中重新连接 Claude Code，然后重试。"
+  );
+});
+
 test("resolveDesktopErrorMessage localizes file-manager invalid path reasons", () => {
   const message = resolveDesktopErrorMessage(
     {

--- a/apps/desktop/src/renderer/src/lib/desktopErrors.test.ts
+++ b/apps/desktop/src/renderer/src/lib/desktopErrors.test.ts
@@ -2,7 +2,10 @@ import assert from "node:assert/strict";
 import test from "node:test";
 import { workspaceProtocolErrorCodes } from "@tutti-os/client-tuttid-ts";
 import { desktopErrorCodes } from "../../../shared/errors/desktopErrors.ts";
-import { resolveDesktopErrorMessage } from "./desktopErrors.ts";
+import {
+  resolveDesktopErrorMessage,
+  wrapLocalizedTuttidErrorIfSpecific
+} from "./desktopErrors.ts";
 
 test("resolveDesktopErrorMessage uses shared protocol-code defaults", () => {
   const message = resolveDesktopErrorMessage({
@@ -71,6 +74,41 @@ test("resolveDesktopErrorMessage falls back to grouped default translations", ()
   );
 
   assert.equal(message, "That request could not be completed.");
+});
+
+test("wrapLocalizedTuttidErrorIfSpecific preserves protocol metadata for reason-specific errors", () => {
+  const source = {
+    code: "workspace_operation_failed",
+    correlationId: "corr-1",
+    developerMessage: "claude-code: ACP adapter not found",
+    reason: "acp_adapter_version_mismatch",
+    retryable: false,
+    statusCode: 502
+  };
+  const wrapped = wrapLocalizedTuttidErrorIfSpecific(source, "en");
+
+  assert.ok(wrapped instanceof Error);
+  assert.match(wrapped.message, /Claude Code's local adapter is unavailable/);
+  assert.equal(
+    (wrapped as { code?: string }).code,
+    "workspace_operation_failed"
+  );
+  assert.equal(
+    (wrapped as { reason?: string }).reason,
+    "acp_adapter_version_mismatch"
+  );
+  assert.equal((wrapped as { correlationId?: string }).correlationId, "corr-1");
+});
+
+test("wrapLocalizedTuttidErrorIfSpecific returns the original error without reason-specific copy", () => {
+  const source = {
+    code: "workspace_operation_failed",
+    developerMessage: "generic failure",
+    reason: "workspace_operation_failed",
+    statusCode: 502
+  };
+
+  assert.equal(wrapLocalizedTuttidErrorIfSpecific(source, "en"), source);
 });
 
 test("resolveDesktopErrorMessage localizes workspace operation reason details", () => {

--- a/apps/desktop/src/renderer/src/lib/desktopErrors.ts
+++ b/apps/desktop/src/renderer/src/lib/desktopErrors.ts
@@ -67,6 +67,36 @@ export function resolveDesktopErrorMessage(
   return unexpectedServiceError();
 }
 
+export function wrapLocalizedTuttidErrorIfSpecific(
+  error: unknown,
+  locale: DesktopLocale = defaultDesktopLocale
+): unknown {
+  const protocolError = normalizeTuttidError(error);
+  if (!protocolError?.reason) {
+    return error;
+  }
+
+  const copy = createDesktopErrorI18nRuntime(locale);
+  const reasonKey = `errors.${protocolError.code}.${protocolError.reason}`;
+  if (!copy.has(reasonKey)) {
+    return error;
+  }
+
+  const message = resolveDesktopErrorMessage(error, locale);
+  const wrapped = new Error(message);
+  wrapped.name = error instanceof Error ? error.name : "TuttidProtocolError";
+  Object.assign(wrapped, {
+    code: protocolError.code,
+    correlationId: protocolError.correlationId,
+    developerMessage: protocolError.developerMessage,
+    params: protocolError.params,
+    reason: protocolError.reason,
+    retryable: protocolError.retryable,
+    statusCode: protocolError.statusCode
+  });
+  return wrapped;
+}
+
 export function getDesktopErrorCode(error: unknown): string | null {
   const protocolError = normalizeTuttidError(error);
   if (protocolError) {

--- a/apps/desktop/src/shared/i18n/locales/en.ts
+++ b/apps/desktop/src/shared/i18n/locales/en.ts
@@ -701,7 +701,10 @@ export const en = {
     workspace_file_not_found:
       "That file or folder could not be found in the workspace.",
     workspace_not_found: "That workspace could not be found.",
-    workspace_operation_failed:
-      "We couldn't finish that workspace action right now."
+    workspace_operation_failed: {
+      default: "We couldn't finish that workspace action right now.",
+      acp_adapter_version_mismatch:
+        "Claude Code's local adapter is unavailable or version-mismatched. Reconnect Claude Code from the dock, then try again."
+    }
   }
 } as const;

--- a/apps/desktop/src/shared/i18n/locales/zh-CN.ts
+++ b/apps/desktop/src/shared/i18n/locales/zh-CN.ts
@@ -662,6 +662,10 @@ export const zhCN = {
       "发布应用前检查失败，请先修复 App Center 里的生成草稿。",
     workspace_file_not_found: "找不到这个工作区里的文件或文件夹。",
     workspace_not_found: "找不到这个工作区。",
-    workspace_operation_failed: "暂时无法完成这个工作区操作。"
+    workspace_operation_failed: {
+      default: "暂时无法完成这个工作区操作。",
+      acp_adapter_version_mismatch:
+        "Claude Code 本地适配器不可用或版本不匹配。请先在 Dock 中重新连接 Claude Code，然后重试。"
+    }
   }
 } as const satisfies TranslationDictionary;

--- a/packages/agent/daemon/runtime/standard_acp_adapter.go
+++ b/packages/agent/daemon/runtime/standard_acp_adapter.go
@@ -1524,6 +1524,9 @@ func (a *standardACPAdapter) ApplySessionSettings(
 	if patch.Speed != nil {
 		speed := strings.TrimSpace(*patch.Speed)
 		if speed != "" {
+			if !a.sessionConfigOptionAdvertisesValue(session.AgentSessionID, "fast", speed) {
+				return nil
+			}
 			if !a.sessionConfigOptionMatches(session.AgentSessionID, "fast", speed) {
 				if err := a.setSessionConfigOption(ctx, acpSession.client, session, "fast", speed); err != nil {
 					return fmt.Errorf("agent session ACP fast configuration failed: %w", err)

--- a/packages/agent/daemon/runtime/standard_acp_adapter_test.go
+++ b/packages/agent/daemon/runtime/standard_acp_adapter_test.go
@@ -2336,6 +2336,77 @@ func TestClaudeCodeAdapterApplySessionSettingsSendsChangedLiveACPConfig(t *testi
 	}
 }
 
+func TestClaudeCodeAdapterApplySessionSettingsSkipsUnsupportedLiveSpeedConfig(t *testing.T) {
+	t.Parallel()
+
+	transport := newStandardACPTransport("Claude Agent", "claude-session-live-speed-unsupported")
+	adapter := NewClaudeCodeAdapter(transport)
+	session := standardTestSession(ProviderClaudeCode)
+
+	if _, err := adapter.Start(context.Background(), session); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+
+	session.Settings = &SessionSettings{Speed: "fast"}
+	if err := adapter.ApplySessionSettings(context.Background(), session, SessionSettingsPatch{
+		Speed: stringPtr("fast"),
+	}); err != nil {
+		t.Fatalf("ApplySessionSettings: %v", err)
+	}
+
+	if calls := transport.conn.setConfigOptionCalls(); len(calls) != 0 {
+		t.Fatalf("config option calls = %#v, want unsupported live speed no-op", calls)
+	}
+}
+
+func TestClaudeCodeAdapterApplySessionSettingsSendsAdvertisedLiveSpeedConfig(t *testing.T) {
+	t.Parallel()
+
+	transport := newStandardACPTransport("Claude Agent", "claude-session-live-speed-supported")
+	adapter := NewClaudeCodeAdapter(transport)
+	session := standardTestSession(ProviderClaudeCode)
+
+	if _, err := adapter.Start(context.Background(), session); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+
+	adapter.applyACPUpdate(session.AgentSessionID, json.RawMessage(`{
+		"update": {
+			"sessionUpdate": "config_option_update",
+			"key": "fast",
+			"value": "standard",
+			"configOptions": [
+				{
+					"id": "fast",
+					"currentValue": "standard",
+					"options": [
+						{"value": "standard", "name": "Standard"},
+						{"value": "fast", "name": "Fast"}
+					]
+				}
+			]
+		}
+	}`))
+
+	session.Settings = &SessionSettings{Speed: "fast"}
+	if err := adapter.ApplySessionSettings(context.Background(), session, SessionSettingsPatch{
+		Speed: stringPtr("fast"),
+	}); err != nil {
+		t.Fatalf("ApplySessionSettings: %v", err)
+	}
+
+	calls := transport.conn.setConfigOptionCalls()
+	if len(calls) != 1 {
+		t.Fatalf("config option calls = %#v, want advertised live speed update", calls)
+	}
+	if got, _ := calls[0]["configId"].(string); got != "fast" {
+		t.Fatalf("config id = %q, want fast", got)
+	}
+	if got, _ := calls[0]["value"].(string); got != "fast" {
+		t.Fatalf("config value = %q, want fast", got)
+	}
+}
+
 func TestClaudeCodeAdapterStartSkipsCustomModelConfigOption(t *testing.T) {
 	t.Parallel()
 

--- a/packages/agent/daemon/runtimecmd/resolver.go
+++ b/packages/agent/daemon/runtimecmd/resolver.go
@@ -142,6 +142,7 @@ func (r Resolver) fallbackExecutableDirs(env []string) []string {
 	home, err := r.homeDir()
 	if err == nil && strings.TrimSpace(home) != "" {
 		homeDirs = []string{
+			filepath.Join(home, ".tutti", "bin"),
 			filepath.Join(home, ".local", "bin"),
 			filepath.Join(home, "bin"),
 			filepath.Join(home, ".npm-global", "bin"),

--- a/packages/agent/daemon/runtimecmd/resolver_test.go
+++ b/packages/agent/daemon/runtimecmd/resolver_test.go
@@ -99,6 +99,36 @@ func TestResolverPrefersExistingPathOverScannedNVMFallback(t *testing.T) {
 	}
 }
 
+func TestResolverFindsTuttiBinFallback(t *testing.T) {
+	home := t.TempDir()
+	tuttiBinDir := filepath.Join(home, ".tutti", "bin")
+	if err := os.MkdirAll(tuttiBinDir, 0o755); err != nil {
+		t.Fatalf("mkdir tutti bin dir: %v", err)
+	}
+	tuttiPath := filepath.Join(tuttiBinDir, "tutti")
+	writeExecutable(t, tuttiPath)
+
+	resolver := Resolver{
+		Environ: func() []string {
+			return []string{"PATH=/usr/bin:/bin"}
+		},
+		HomeDir: func() (string, error) {
+			return home, nil
+		},
+		LookPath: func(string) (string, error) {
+			return "", os.ErrNotExist
+		},
+	}
+
+	env := resolver.Env(nil)
+	if got := resolver.Resolve("tutti", env); got != tuttiPath {
+		t.Fatalf("Resolve() = %q, want %q", got, tuttiPath)
+	}
+	if got := resolver.ResolveBinary([]string{"tutti"}, nil); got != tuttiPath {
+		t.Fatalf("ResolveBinary() = %q, want %q", got, tuttiPath)
+	}
+}
+
 func TestResolverFindsFnmNodeBin(t *testing.T) {
 	home := t.TempDir()
 	fnmDir := filepath.Join(home, "custom-fnm")

--- a/services/tuttid/service/agent/service_test.go
+++ b/services/tuttid/service/agent/service_test.go
@@ -583,6 +583,7 @@ func TestServiceCreateUsesProviderDefaultModelWhenModelOmitted(t *testing.T) {
 }
 
 func TestServiceCreatePassesPlanModeToRuntime(t *testing.T) {
+	t.Setenv("CLAUDE_CONFIG_DIR", t.TempDir())
 	runtime := newFakeRuntime()
 	service := NewService(runtime)
 	planMode := true
@@ -741,6 +742,7 @@ func TestServiceCreateChecksProviderAdapterBeforePreparingRuntime(t *testing.T) 
 }
 
 func TestServiceCreateDoesNotTreatAuthRequiredAsInstallNeeded(t *testing.T) {
+	t.Setenv("CLAUDE_CONFIG_DIR", t.TempDir())
 	runtime := newFakeRuntime()
 	service := NewService(runtime)
 	checker := &fakeProviderAvailabilityChecker{
@@ -904,6 +906,7 @@ func TestServiceCreatePassesInitialDisplayPromptToRuntime(t *testing.T) {
 }
 
 func TestServiceCreateEmptySessionDoesNotExec(t *testing.T) {
+	t.Setenv("CLAUDE_CONFIG_DIR", t.TempDir())
 	runtime := newFakeRuntime()
 	service := NewService(runtime)
 	visible := false
@@ -954,6 +957,7 @@ func TestServiceCreateDoesNotPassDerivedPromptToRuntime(t *testing.T) {
 }
 
 func TestServiceUpdateVisibleUpdatesRuntimeSession(t *testing.T) {
+	t.Setenv("CLAUDE_CONFIG_DIR", t.TempDir())
 	runtime := newFakeRuntime()
 	service := NewService(runtime)
 	visible := false
@@ -1520,6 +1524,7 @@ func TestServiceGetsComposerOptionsSkipsClaudeStaticModelCatalog(t *testing.T) {
 }
 
 func TestGetComposerOptionsClaudeCodeDiscoversLiveModels(t *testing.T) {
+	t.Setenv("CLAUDE_CONFIG_DIR", t.TempDir())
 	runtime := newFakeRuntime()
 	runtime.startHook = func(input RuntimeStartInput, session RuntimeSession) RuntimeSession {
 		if input.Provider != "claude-code" {

--- a/services/tuttid/service/agentstatus/assets/patch-claude-agent-acp.mjs
+++ b/services/tuttid/service/agentstatus/assets/patch-claude-agent-acp.mjs
@@ -15,7 +15,7 @@
 // Why a codemod and not a unified diff: the bridge ships only a bundled
 // `dist/acp-agent.js` and is provisioned from the ACP external agent registry,
 // so there is no source tree to patch. The string anchors below are stable
-// across 0.42.x–0.46.x. The
+// across 0.42.x–0.51.x. The
 // script is idempotent (skips if a `fast` option is already present).
 //
 // Applied automatically after the bridge installs (InstallerPostStep in
@@ -58,17 +58,28 @@ function resolveDistPath() {
   return candidates.find((candidate) => existsSync(candidate)) ?? candidates[0];
 }
 
-const FAST_MODE_EDITS = [
+const FAST_MODE_EDIT_GROUPS = [
   {
     name: "buildConfigOptions signature",
-    find: "function buildConfigOptions(modes, models, modelInfos, currentEffortLevel) {",
-    replace:
-      "function buildConfigOptions(modes, models, modelInfos, currentEffortLevel, currentFastMode) {"
+    variants: [
+      {
+        find: "function buildConfigOptions(modes, models, modelInfos, currentEffortLevel) {",
+        replace:
+          "function buildConfigOptions(modes, models, modelInfos, currentEffortLevel, currentFastMode) {"
+      },
+      {
+        find: "function buildConfigOptions(modes, models, modelInfos, currentEffortLevel, agents = [], currentAgent = DEFAULT_AGENT_ID) {",
+        replace:
+          "function buildConfigOptions(modes, models, modelInfos, currentEffortLevel, currentFastMode, agents = [], currentAgent = DEFAULT_AGENT_ID) {"
+      }
+    ]
   },
   {
     name: "advertise fast config option",
-    find: "    return options;\n}\n// Claude Code CLI persists display strings",
-    replace: `    // tutti patch: orthogonal fast/speed dimension backed by SDK fastMode.
+    variants: [
+      {
+        find: "    return options;\n}\n// Claude Code CLI persists display strings",
+        replace: `    // tutti patch: orthogonal fast/speed dimension backed by SDK fastMode.
     options.push({
         id: "fast",
         name: "Fast",
@@ -84,37 +95,63 @@ const FAST_MODE_EDITS = [
     return options;
 }
 // Claude Code CLI persists display strings`
+      }
+    ]
   },
   {
     name: "seed fast at session creation",
-    find: "const configOptions = buildConfigOptions(modes, models, allowedModels, settingsManager.getSettings().effortLevel);",
-    replace:
-      "const configOptions = buildConfigOptions(modes, models, allowedModels, settingsManager.getSettings().effortLevel, settingsManager.getSettings().fastMode === true);"
+    variants: [
+      {
+        find: "const configOptions = buildConfigOptions(modes, models, allowedModels, settingsManager.getSettings().effortLevel);",
+        replace:
+          "const configOptions = buildConfigOptions(modes, models, allowedModels, settingsManager.getSettings().effortLevel, settingsManager.getSettings().fastMode === true);"
+      },
+      {
+        find: "const configOptions = buildConfigOptions(modes, models, allowedModels, settingsManager.getSettings().effortLevel, agents, currentAgent);",
+        replace:
+          "const configOptions = buildConfigOptions(modes, models, allowedModels, settingsManager.getSettings().effortLevel, settingsManager.getSettings().fastMode === true, agents, currentAgent);"
+      }
+    ]
   },
   {
     name: "apply initial fast mode to the SDK",
-    find: "        this.sessions[sessionId] = {",
-    replace: `        // tutti patch: apply the initial fast mode so the SDK matches the UI.
+    variants: [
+      {
+        find: "        this.sessions[sessionId] = {",
+        replace: `        // tutti patch: apply the initial fast mode so the SDK matches the UI.
         const initialFast = configOptions.find((o) => o.id === "fast");
         if (initialFast && initialFast.currentValue === "fast") {
             await q.applyFlagSettings({ fastMode: true });
         }
         this.sessions[sessionId] = {`
+      }
+    ]
   },
   {
     name: "preserve fast across model switch rebuild",
-    find: "session.configOptions = buildConfigOptions(session.modes, session.models, session.modelInfos, currentEffort);",
-    replace:
-      'session.configOptions = buildConfigOptions(session.modes, session.models, session.modelInfos, currentEffort, session.configOptions.find((o) => o.id === "fast")?.currentValue === "fast");'
+    variants: [
+      {
+        find: "session.configOptions = buildConfigOptions(session.modes, session.models, session.modelInfos, currentEffort);",
+        replace:
+          'session.configOptions = buildConfigOptions(session.modes, session.models, session.modelInfos, currentEffort, session.configOptions.find((o) => o.id === "fast")?.currentValue === "fast");'
+      },
+      {
+        find: "session.configOptions = buildConfigOptions(session.modes, session.models, session.modelInfos, currentEffort, session.agents, session.currentAgent);",
+        replace:
+          'session.configOptions = buildConfigOptions(session.modes, session.models, session.modelInfos, currentEffort, session.configOptions.find((o) => o.id === "fast")?.currentValue === "fast", session.agents, session.currentAgent);'
+      }
+    ]
   },
   {
     name: "route fast config option to applyFlagSettings",
-    find: `            if (configId === "effort") {
+    variants: [
+      {
+        find: `            if (configId === "effort") {
                 await session.query.applyFlagSettings({
                     effortLevel: toSdkEffortLevel(value),
                 });
             }`,
-    replace: `            if (configId === "effort") {
+        replace: `            if (configId === "effort") {
                 await session.query.applyFlagSettings({
                     effortLevel: toSdkEffortLevel(value),
                 });
@@ -122,6 +159,8 @@ const FAST_MODE_EDITS = [
             else if (configId === "fast") {
                 await session.query.applyFlagSettings({ fastMode: value === "fast" });
             }`
+      }
+    ]
   }
 ];
 
@@ -460,6 +499,35 @@ function applyEdits(source, edits) {
   return nextSource;
 }
 
+function applyEditGroups(source, groups) {
+  let nextSource = source;
+  for (const group of groups) {
+    const matches = group.variants
+      .map((variant) => ({
+        variant,
+        occurrences: nextSource.split(variant.find).length - 1
+      }))
+      .filter((match) => match.occurrences > 0);
+    const totalOccurrences = matches.reduce(
+      (sum, match) => sum + match.occurrences,
+      0
+    );
+    if (totalOccurrences !== 1) {
+      throw new Error(
+        `Anchor not uniquely found (${totalOccurrences}x) for "${group.name}".`
+      );
+    }
+    const match = matches[0];
+    if (match.occurrences !== 1) {
+      throw new Error(
+        `Anchor not uniquely found (${match.occurrences}x) for "${group.name}".`
+      );
+    }
+    nextSource = nextSource.replace(match.variant.find, match.variant.replace);
+  }
+  return nextSource;
+}
+
 function hasLifecycleCommandUpdates(source) {
   return (
     source.includes("this.sendAvailableCommandsUpdate(response.sessionId)") &&
@@ -507,12 +575,13 @@ if (/id:\s*"fast"/.test(source)) {
   console.log(`Already patched (fast config option present): ${distPath}`);
 } else {
   try {
-    source = applyEdits(source, FAST_MODE_EDITS);
+    source = applyEditGroups(source, FAST_MODE_EDIT_GROUPS);
     changed = true;
   } catch (error) {
     console.error(
-      `claude-agent-acp fast-mode patch skipped: ${error.message} Bridge layout changed; update services/tuttid/service/agentstatus/assets/patch-claude-agent-acp.mjs.`
+      `claude-agent-acp fast-mode patch failed: ${error.message} Bridge layout changed; update services/tuttid/service/agentstatus/assets/patch-claude-agent-acp.mjs.`
     );
+    process.exit(1);
   }
 }
 

--- a/tools/scripts/dev-web.mjs
+++ b/tools/scripts/dev-web.mjs
@@ -34,6 +34,7 @@ let shutdownStarted = false;
 let exitCode = 0;
 
 installDevCli();
+generateBuiltinApps();
 
 const daemon = spawn(resolveCommand("go"), ["run", "."], {
   cwd: tuttidDir,
@@ -161,6 +162,22 @@ function installDevCli() {
   if (result.status !== 0) {
     throw new Error(
       `install tutti-dev failed with exit code ${result.status ?? "unknown"}`
+    );
+  }
+}
+
+function generateBuiltinApps() {
+  const result = spawnSync(resolveCommand("pnpm"), ["generate:builtin-apps"], {
+    cwd: workspaceRoot,
+    env: {
+      ...process.env,
+      TUTTI_ENV: "development"
+    },
+    stdio: "inherit"
+  });
+  if (result.status !== 0) {
+    throw new Error(
+      `generate builtin apps failed with exit code ${result.status ?? "unknown"}`
     );
   }
 }

--- a/tools/scripts/dev-web.test.mjs
+++ b/tools/scripts/dev-web.test.mjs
@@ -11,3 +11,8 @@ test("dev-web passes the analytics debug flag to tuttid", () => {
   assert.match(source, /TUTTI_ANALYTICS_DEBUG:/);
   assert.match(source, /VITE_TUTTI_ANALYTICS_DEBUG/);
 });
+
+test("dev-web generates builtin apps before starting tuttid", () => {
+  assert.match(source, /installDevCli\(\);\s*generateBuiltinApps\(\);/);
+  assert.match(source, /pnpm"\), \["generate:builtin-apps"\]/);
+});


### PR DESCRIPTION
## Summary
- 在桌面端本地化 ACP adapter mismatch 错误，并在 session 创建失败或窗口重新聚焦时刷新 managed agent provider 状态，帮助用户从 adapter 版本不匹配中恢复。
- 收紧 provider 状态同步逻辑：仅对 availability 相关的 session 创建失败触发刷新，并将 visibility/focus 监听绑定到 service 注册流程。
- 在 agent runtime 中保护 Claude fast config 更新、扩展 `~/.tutti/bin` 可执行文件回退路径，并增强 `patch-claude-agent-acp` 与 `dev-web` 启动流程。

## Test plan
- [x] `pnpm check:full`
- [x] `pnpm --filter @tutti-os/desktop typecheck`
- [x] `go test ./service/agent/... -run 'TestServiceCreatePassesPlanModeToRuntime|TestGetComposerOptionsClaudeCodeDiscoversLiveModels'`
- [ ] 本地触发 Claude Code ACP adapter mismatch，确认错误文案已本地化且 provider 状态会在 focus 后刷新
- [ ] 验证 dev-web 启动前会生成 builtin apps


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved workspace-agent handling with automatic status refreshes for certain provider availability issues.
  * Added support for a visible “fast” mode in compatible Claude sessions.

* **Bug Fixes**
  * Localized clearer error messages when the local adapter is unavailable or mismatched.
  * Better handling when a workspace agent session is missing, with more informative diagnostics.
  * Expanded executable discovery to find tools installed in a user’s `.tutti/bin` folder.

* **Chores**
  * Dev startup now generates built-in apps before launching.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->