### PR TITLE
fix(agent-gui): keep generated no-project sessions ungrouped

### DIFF
--- a/apps/desktop/src/renderer/src/features/workspace-user-project/services/internal/desktopWorkspaceUserProjectService.test.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-user-project/services/internal/desktopWorkspaceUserProjectService.test.ts
@@ -224,6 +224,29 @@ test("workspace user project service remembers generated no-project cwd values",
   assert.equal(service.isNoProjectPath("/tmp/other"), false);
 });
 
+test("workspace user project service lets an explicit project override generated no-project paths", async () => {
+  const generatedLikePath =
+    "/Users/local/Documents/tutti/session-44444444-4444-4444-8444-444444444444";
+  const service = createService({
+    tuttidClient: createTuttidClient({
+      async useUserProject(input) {
+        return createProject({
+          id: "odd-project",
+          label: "Odd project",
+          path: input.path
+        });
+      }
+    })
+  });
+
+  service.rememberNoProjectPath(generatedLikePath);
+  assert.equal(service.isNoProjectPath(generatedLikePath), true);
+
+  await service.registerProjectPath(generatedLikePath);
+
+  assert.equal(service.isNoProjectPath(generatedLikePath), false);
+});
+
 test("workspace user project service creates a documents directory before registering project", async () => {
   const calls: Array<{ method: string; path?: string; name?: string }> = [];
   const service = createService({

--- a/apps/desktop/src/renderer/src/features/workspace-user-project/services/internal/desktopWorkspaceUserProjectService.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-user-project/services/internal/desktopWorkspaceUserProjectService.ts
@@ -36,6 +36,7 @@ export interface DesktopWorkspaceUserProjectServiceDependencies {
 
 interface DesktopWorkspaceUserProjectWorkspaceState {
   defaultSelection: WorkspaceUserProjectDefaultSelection | null;
+  explicitProjectPaths: Set<string>;
   noProjectPaths: Set<string>;
   removedProjectPaths: Set<string>;
 }
@@ -105,6 +106,13 @@ export class DesktopWorkspaceUserProjectService implements IWorkspaceUserProject
 
   isNoProjectPath(path: string): boolean {
     const normalizedPath = path.trim();
+    if (
+      !normalizedPath ||
+      hasProjectPath(this.store.projects, normalizedPath) ||
+      this.workspaceState.explicitProjectPaths.has(normalizedPath)
+    ) {
+      return false;
+    }
     return (
       this.workspaceState.noProjectPaths.has(normalizedPath) ||
       isGeneratedNoProjectCwd({
@@ -203,6 +211,8 @@ export class DesktopWorkspaceUserProjectService implements IWorkspaceUserProject
       path
     });
     this.loadSequence += 1;
+    this.workspaceState.explicitProjectPaths.add(project.path);
+    this.workspaceState.noProjectPaths.delete(project.path);
     this.workspaceState.removedProjectPaths.delete(project.path);
     this.store.projects = upsertWorkspaceUserProject(
       this.store.projects,
@@ -225,6 +235,7 @@ export class DesktopWorkspaceUserProjectService implements IWorkspaceUserProject
       path: normalizedPath
     });
     const previousProjectCount = this.store.projects.length;
+    this.workspaceState.explicitProjectPaths.delete(normalizedPath);
     this.workspaceState.removedProjectPaths.add(normalizedPath);
     this.store.projects = this.store.projects.filter(
       (project) => project.path !== normalizedPath
@@ -318,6 +329,7 @@ function workspaceUserProjectState(
   if (!state) {
     state = {
       defaultSelection: null,
+      explicitProjectPaths: new Set(),
       noProjectPaths: new Set(),
       removedProjectPaths: new Set()
     };

--- a/docs/conventions/troubleshooting.md
+++ b/docs/conventions/troubleshooting.md
@@ -380,14 +380,17 @@ delimited by ---`, and the composer skill picker may show partial or
   Conversation project grouping is a view-model join of `cwd x userProjects`.
   If a generated no-project cwd is not recognized before prefix/parent project
   matching, the longest-parent project match can assign the session to a broad
-  project such as `$HOME`. Do not rely only on a host callback for this guard;
-  the Agent GUI resolver itself needs to exclude the generated
-  `Documents/tutti/session-<uuid>` cwd before project lookup.
+  project such as `$HOME`. Keep generated-path recognition in the host
+  `isNoProjectPath` callback because it has the user home-directory context;
+  a package-level suffix check would misclassify real projects that contain a
+  `Documents/tutti/session-<uuid>` subdirectory.
 - Fix:
-  Treat exact user-project path matches as explicit user intent, then treat
-  generated `Documents/tutti/session-<uuid>` cwd values as no-project before
-  parent project matching. Keep the project field derived in the Agent GUI
-  view-model rather than writing it back into the conversation store.
+  Treat exact user-project path matches as explicit user intent, then call the
+  host no-project resolver before parent project matching. The desktop resolver
+  should recognize generated `$HOME/Documents/tutti/session-<uuid>` cwd values
+  while allowing explicit registered projects to override them. Keep the project
+  field derived in the Agent GUI view-model rather than writing it back into the
+  conversation store.
 - Validation:
   Run
   `pnpm --filter @tutti-os/agent-gui test -- agent-gui/agentGuiNode/model/agentGuiConversationModel.spec.ts`,

--- a/docs/conventions/troubleshooting.md
+++ b/docs/conventions/troubleshooting.md
@@ -366,6 +366,38 @@ delimited by ---`, and the composer skill picker may show partial or
   [desktopRichTextAtService.ts](../../apps/desktop/src/renderer/src/features/rich-text-at/services/internal/desktopRichTextAtService.ts)
   [desktopAgentProviderStatusService.ts](../../apps/desktop/src/renderer/src/features/workspace-agent/services/internal/desktopAgentProviderStatusService.ts)
 
+### Agent GUI no-project sessions appear under a user project
+
+- Symptom:
+  A conversation started with the "No project" selection appears in the Agent
+  GUI rail under a parent user-project group such as the user's home directory.
+- Quick checks:
+  Inspect the session `cwd` from the activity snapshot. Generated no-project
+  sessions should resolve as no-project before `cwd` is matched against parent
+  user-project paths. Check both the in-memory `rememberNoProjectPath` path and
+  the restart fallback that recognizes `Documents/tutti/session-<uuid>`.
+- Root cause:
+  Conversation project grouping is a view-model join of `cwd x userProjects`.
+  If a generated no-project cwd is not recognized before prefix/parent project
+  matching, the longest-parent project match can assign the session to a broad
+  project such as `$HOME`. Do not rely only on a host callback for this guard;
+  the Agent GUI resolver itself needs to exclude the generated
+  `Documents/tutti/session-<uuid>` cwd before project lookup.
+- Fix:
+  Treat exact user-project path matches as explicit user intent, then treat
+  generated `Documents/tutti/session-<uuid>` cwd values as no-project before
+  parent project matching. Keep the project field derived in the Agent GUI
+  view-model rather than writing it back into the conversation store.
+- Validation:
+  Run
+  `pnpm --filter @tutti-os/agent-gui test -- agent-gui/agentGuiNode/model/agentGuiConversationModel.spec.ts`,
+  `node --import ./test/register-asset-stub.mjs --test --experimental-strip-types ./src/renderer/src/features/workspace-user-project/services/internal/desktopWorkspaceUserProjectService.test.ts`
+  from `apps/desktop`, then run `pnpm check:changed`.
+- References:
+  [desktopWorkspaceUserProjectService.ts](../../apps/desktop/src/renderer/src/features/workspace-user-project/services/internal/desktopWorkspaceUserProjectService.ts)
+  [agentGuiConversationProjectResolver.ts](../../packages/agent/gui/agent-gui/agentGuiNode/model/agentGuiConversationProjectResolver.ts)
+  [agentGuiConversationListStore.ts](../../packages/agent/gui/contexts/workspace/presentation/renderer/agentGuiConversationList/agentGuiConversationListStore.ts)
+
 ### Electron main/preload crashes on a workspace package `.ts` export
 
 - Symptom:

--- a/packages/agent/gui/agent-gui/agentGuiNode/model/agentGuiConversationModel.spec.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/model/agentGuiConversationModel.spec.ts
@@ -105,13 +105,17 @@ describe("agentGuiConversationModel", () => {
     ).toBeNull();
   });
 
-  it("does not assign generated no-project cwd to a home parent project", () => {
+  it("keeps generated-looking cwd values grouped under real parent projects without host no-project context", () => {
     expect(
       resolveAgentGUIConversationProject(
-        "/Users/local/Documents/tutti/session-44444444-4444-4444-8444-444444444444",
-        [userProject("home", "/Users/local", "Home")]
+        "/repo/Documents/tutti/session-44444444-4444-4444-8444-444444444444",
+        [userProject("repo", "/repo", "Repo")]
       )
-    ).toBeNull();
+    ).toEqual({
+      id: "repo",
+      path: "/repo",
+      label: "Repo"
+    });
   });
 
   it("keeps an explicit project whose path looks like a generated no-project cwd", () => {

--- a/packages/agent/gui/agent-gui/agentGuiNode/model/agentGuiConversationModel.spec.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/model/agentGuiConversationModel.spec.ts
@@ -105,6 +105,35 @@ describe("agentGuiConversationModel", () => {
     ).toBeNull();
   });
 
+  it("does not assign generated no-project cwd to a home parent project", () => {
+    expect(
+      resolveAgentGUIConversationProject(
+        "/Users/local/Documents/tutti/session-44444444-4444-4444-8444-444444444444",
+        [userProject("home", "/Users/local", "Home")]
+      )
+    ).toBeNull();
+  });
+
+  it("keeps an explicit project whose path looks like a generated no-project cwd", () => {
+    expect(
+      resolveAgentGUIConversationProject(
+        "/Users/local/Documents/tutti/session-44444444-4444-4444-8444-444444444444",
+        [
+          userProject("home", "/Users/local", "Home"),
+          userProject(
+            "odd",
+            "/Users/local/Documents/tutti/session-44444444-4444-4444-8444-444444444444",
+            "Odd project"
+          )
+        ]
+      )
+    ).toEqual({
+      id: "odd",
+      path: "/Users/local/Documents/tutti/session-44444444-4444-4444-8444-444444444444",
+      label: "Odd project"
+    });
+  });
+
   it("builds no-project runtime sessions without parent project assignment", () => {
     const noProjectPath =
       "/Users/local/Documents/tutti/session-44444444-4444-4444-8444-444444444444";

--- a/packages/agent/gui/agent-gui/agentGuiNode/model/agentGuiConversationProjectResolver.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/model/agentGuiConversationProjectResolver.ts
@@ -108,10 +108,7 @@ function resolveAgentGUIConversationProjectFromIndex(
   if (exactProject) {
     return agentGUIConversationProjectSummaryFromProject(exactProject);
   }
-  if (
-    isGeneratedAgentGUINoProjectCwd(normalizedCwd) ||
-    options.isNoProjectPath?.({ path: normalizedCwd })
-  ) {
+  if (options.isNoProjectPath?.({ path: normalizedCwd })) {
     return null;
   }
   const matchedProject = lookupAgentGUIConversationProject(
@@ -172,20 +169,6 @@ function normalizeAgentGUIProjectPath(path: string | null | undefined): string {
     return "";
   }
   return normalized.replace(/\/+$/, "") || "/";
-}
-
-function isGeneratedAgentGUINoProjectCwd(normalizedCwd: string): boolean {
-  const segments = normalizedCwd.split("/").filter(Boolean);
-  const leaf = segments.at(-1) ?? "";
-  const projectRoot = segments.at(-2) ?? "";
-  const documentsRoot = segments.at(-3) ?? "";
-  return (
-    /^session-[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/iu.test(
-      leaf
-    ) &&
-    projectRoot.toLowerCase() === "tutti" &&
-    documentsRoot.toLowerCase() === "documents"
-  );
 }
 
 function cachedAgentGUIConversationProjectSummary(

--- a/packages/agent/gui/agent-gui/agentGuiNode/model/agentGuiConversationProjectResolver.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/model/agentGuiConversationProjectResolver.ts
@@ -104,7 +104,14 @@ function resolveAgentGUIConversationProjectFromIndex(
   projectByNormalizedPath: ReadonlyMap<string, AgentGUIConversationUserProject>,
   options: AgentGUIConversationProjectResolutionOptions
 ): AgentGUIConversationProjectSummary | null {
-  if (options.isNoProjectPath?.({ path: normalizedCwd })) {
+  const exactProject = projectByNormalizedPath.get(normalizedCwd);
+  if (exactProject) {
+    return agentGUIConversationProjectSummaryFromProject(exactProject);
+  }
+  if (
+    isGeneratedAgentGUINoProjectCwd(normalizedCwd) ||
+    options.isNoProjectPath?.({ path: normalizedCwd })
+  ) {
     return null;
   }
   const matchedProject = lookupAgentGUIConversationProject(
@@ -114,6 +121,12 @@ function resolveAgentGUIConversationProjectFromIndex(
   if (!matchedProject) {
     return null;
   }
+  return agentGUIConversationProjectSummaryFromProject(matchedProject);
+}
+
+function agentGUIConversationProjectSummaryFromProject(
+  matchedProject: AgentGUIConversationUserProject
+): AgentGUIConversationProjectSummary {
   const summary: AgentGUIConversationProjectSummary = {
     id: matchedProject.id,
     path: matchedProject.path,
@@ -159,6 +172,20 @@ function normalizeAgentGUIProjectPath(path: string | null | undefined): string {
     return "";
   }
   return normalized.replace(/\/+$/, "") || "/";
+}
+
+function isGeneratedAgentGUINoProjectCwd(normalizedCwd: string): boolean {
+  const segments = normalizedCwd.split("/").filter(Boolean);
+  const leaf = segments.at(-1) ?? "";
+  const projectRoot = segments.at(-2) ?? "";
+  const documentsRoot = segments.at(-3) ?? "";
+  return (
+    /^session-[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/iu.test(
+      leaf
+    ) &&
+    projectRoot.toLowerCase() === "tutti" &&
+    documentsRoot.toLowerCase() === "documents"
+  );
 }
 
 function cachedAgentGUIConversationProjectSummary(


### PR DESCRIPTION
## Summary

- keep exact user-project path matches ahead of host no-project detection
- prevent generated `$HOME/Documents/tutti/session-<uuid>` cwd values from falling through to parent project grouping via the desktop `isNoProjectPath` resolver
- let explicit registered projects override generated no-project paths, and document the troubleshooting pattern
- keep generated-path detection out of the package-level resolver so real projects containing `Documents/tutti/session-<uuid>` subdirectories still group by parent project

## Verification

- `node --import ./test/register-asset-stub.mjs --test --experimental-strip-types ./src/renderer/src/features/workspace-user-project/services/internal/desktopWorkspaceUserProjectService.test.ts`
- `pnpm --dir packages/agent/gui exec vitest run --environment jsdom agent-gui/agentGuiNode/model/agentGuiConversationModel.spec.ts`
- `pnpm check:changed --tail-lines 80`
- `pnpm check:full` via pre-push hook

## Checklist

- [x] I kept the change focused on one concern.
- [x] I updated documentation when behavior, setup, or contributor workflow changed.
- [x] I updated all README/CONTRIBUTING language variants when changing their English source.
- [x] I ran the lowest meaningful local checks for the changed surface.
- [x] My commits are signed off with DCO when required: `git commit -s`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Conversations and workspace project resolution now respects explicitly registered project paths, preventing them from being overridden by previously stored “no-project” state.
  * Generated-looking “no-project” session paths are no longer incorrectly grouped under broader parent projects.
  * Removing a project now fully clears its explicit path status to restore correct future matching.
* **Tests**
  * Added unit tests for exact-match and generated-no-project `cwd` handling, including a regression for restoring a path after it was marked “no-project.”
* **Documentation**
  * Expanded troubleshooting guidance for “no-project” sessions appearing under a user project, with validation steps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->