### PR TITLE
[codex] Add readable issue timestamps

### DIFF
--- a/services/tuttid/service/cli/providers/issuemanager/output.go
+++ b/services/tuttid/service/cli/providers/issuemanager/output.go
@@ -2,6 +2,7 @@ package issuemanager
 
 import (
 	"strings"
+	"time"
 
 	workspaceissues "github.com/tutti-os/tutti/packages/workspace/issues"
 	cliservice "github.com/tutti-os/tutti/services/tuttid/service/cli"
@@ -133,7 +134,9 @@ func issueDetailValue(item workspaceissues.Issue) map[string]any {
 		"creatorUserId":          item.CreatorUserID,
 		"creatorDisplayName":     item.CreatorDisplayName,
 		"creatorAvatarUrl":       item.CreatorAvatarURL,
+		"createdAt":              unixMillisTimestamp(item.CreatedAtUnixMS),
 		"createdAtUnixMs":        item.CreatedAtUnixMS,
+		"updatedAt":              unixMillisTimestamp(item.UpdatedAtUnixMS),
 		"updatedAtUnixMs":        item.UpdatedAtUnixMS,
 	}
 }
@@ -175,7 +178,9 @@ func taskDetailValue(item workspaceissues.Task) map[string]any {
 		"creatorDisplayName": item.CreatorDisplayName,
 		"creatorAvatarUrl":   item.CreatorAvatarURL,
 		"latestRunId":        item.LatestRunID,
+		"createdAt":          unixMillisTimestamp(item.CreatedAtUnixMS),
 		"createdAtUnixMs":    item.CreatedAtUnixMS,
+		"updatedAt":          unixMillisTimestamp(item.UpdatedAtUnixMS),
 		"updatedAtUnixMs":    item.UpdatedAtUnixMS,
 	}
 }
@@ -206,9 +211,13 @@ func runDetailValue(item workspaceissues.Run) map[string]any {
 		"errorMessage":       item.ErrorMessage,
 		"outputDir":          item.OutputDir,
 		"executionDirectory": item.ExecutionDirectory,
+		"createdAt":          unixMillisTimestamp(item.CreatedAtUnixMS),
 		"createdAtUnixMs":    item.CreatedAtUnixMS,
+		"startedAt":          unixMillisTimestamp(item.StartedAtUnixMS),
 		"startedAtUnixMs":    item.StartedAtUnixMS,
+		"completedAt":        unixMillisTimestamp(item.CompletedAtUnixMS),
 		"completedAtUnixMs":  item.CompletedAtUnixMS,
+		"updatedAt":          unixMillisTimestamp(item.UpdatedAtUnixMS),
 		"updatedAtUnixMs":    item.UpdatedAtUnixMS,
 	}
 }
@@ -231,6 +240,7 @@ func runOutputValue(item workspaceissues.RunOutput) map[string]any {
 		"displayName":     item.DisplayName,
 		"mediaType":       item.MediaType,
 		"sizeBytes":       item.SizeBytes,
+		"createdAt":       unixMillisTimestamp(item.CreatedAtUnixMS),
 		"createdAtUnixMs": item.CreatedAtUnixMS,
 	}
 }
@@ -299,4 +309,11 @@ func maybeAddNextPageToken(value map[string]any, token string) {
 	if token = strings.TrimSpace(token); token != "" {
 		value["nextPageToken"] = token
 	}
+}
+
+func unixMillisTimestamp(value int64) string {
+	if value <= 0 {
+		return ""
+	}
+	return time.UnixMilli(value).UTC().Format(time.RFC3339)
 }

--- a/services/tuttid/service/cli/providers/issuemanager/provider_test.go
+++ b/services/tuttid/service/cli/providers/issuemanager/provider_test.go
@@ -79,7 +79,12 @@ func (*fakeIssueManager) CreateIssue(context.Context, string, workspaceservice.C
 
 func (*fakeIssueManager) GetIssueDetail(context.Context, string, string) (workspaceissues.IssueDetail, error) {
 	return workspaceissues.IssueDetail{
-		Issue: workspaceissues.Issue{IssueID: "ISS-1", Title: "Issue"},
+		Issue: workspaceissues.Issue{
+			IssueID:         "ISS-1",
+			Title:           "Issue",
+			CreatedAtUnixMS: 1700000000000,
+			UpdatedAtUnixMS: 1700000060000,
+		},
 		Tasks: []workspaceissues.Task{{TaskID: "TASK-1", IssueID: "ISS-1", Title: "Task"}},
 	}, nil
 }
@@ -123,12 +128,32 @@ func (*fakeIssueManager) CreateTask(context.Context, string, string, workspacese
 }
 
 func (*fakeIssueManager) GetTaskDetail(context.Context, string, string, string) (workspaceissues.TaskDetail, error) {
-	run := workspaceissues.Run{RunID: "RUN-1", TaskID: "TASK-1", IssueID: "ISS-1", AgentSessionID: "SESSION-1"}
+	run := workspaceissues.Run{
+		RunID:           "RUN-1",
+		TaskID:          "TASK-1",
+		IssueID:         "ISS-1",
+		AgentSessionID:  "SESSION-1",
+		CreatedAtUnixMS: 1700000120000,
+		UpdatedAtUnixMS: 1700000180000,
+	}
 	return workspaceissues.TaskDetail{
-		Task:          workspaceissues.Task{TaskID: "TASK-1", IssueID: "ISS-1", Title: "Task", Content: "visible content", LatestRunID: "RUN-1"},
-		LatestRun:     &run,
-		RecentRuns:    []workspaceissues.Run{run},
-		LatestOutputs: []workspaceissues.RunOutput{{OutputID: "OUT-1", Path: "/tmp/report.md", DisplayName: "report.md"}},
+		Task: workspaceissues.Task{
+			TaskID:          "TASK-1",
+			IssueID:         "ISS-1",
+			Title:           "Task",
+			Content:         "visible content",
+			LatestRunID:     "RUN-1",
+			CreatedAtUnixMS: 1700000000000,
+			UpdatedAtUnixMS: 1700000060000,
+		},
+		LatestRun:  &run,
+		RecentRuns: []workspaceissues.Run{run},
+		LatestOutputs: []workspaceissues.RunOutput{{
+			OutputID:        "OUT-1",
+			Path:            "/tmp/report.md",
+			DisplayName:     "report.md",
+			CreatedAtUnixMS: 1700000240000,
+		}},
 	}, nil
 }
 
@@ -286,8 +311,36 @@ func TestTaskGetIncludesLatestRunAndOutputs(t *testing.T) {
 	if detail["task"].(map[string]any)["content"] != "visible content" {
 		t.Fatalf("detail = %#v", detail)
 	}
-	if len(detail["latestOutputs"].([]any)) != 1 {
+	task := detail["task"].(map[string]any)
+	if task["createdAt"] != "2023-11-14T22:13:20Z" || task["createdAtUnixMs"] != int64(1700000000000) {
+		t.Fatalf("task timestamps = %#v", task)
+	}
+	outputs := detail["latestOutputs"].([]any)
+	if len(outputs) != 1 {
 		t.Fatalf("detail = %#v", detail)
+	}
+	outputItem := outputs[0].(map[string]any)
+	if outputItem["createdAt"] != "2023-11-14T22:17:20Z" || outputItem["createdAtUnixMs"] != int64(1700000240000) {
+		t.Fatalf("output timestamps = %#v", outputItem)
+	}
+}
+
+func TestIssueGetIncludesReadableTimestamps(t *testing.T) {
+	command := NewProvider(fakeWorkspaceCatalog{startup: workspacebiz.Summary{ID: "workspace-1"}}, &fakeIssueManager{}, nil).newIssueGetCommand()
+
+	output, err := command.Handler(context.Background(), cliservice.InvokeRequest{
+		Input: map[string]any{"issue-id": "ISS-1"},
+	})
+	if err != nil {
+		t.Fatalf("Handler: %v", err)
+	}
+	detail := output.Value["detail"].(map[string]any)
+	issue := detail["issue"].(map[string]any)
+	if issue["createdAt"] != "2023-11-14T22:13:20Z" || issue["createdAtUnixMs"] != int64(1700000000000) {
+		t.Fatalf("issue timestamps = %#v", issue)
+	}
+	if issue["updatedAt"] != "2023-11-14T22:14:20Z" || issue["updatedAtUnixMs"] != int64(1700000060000) {
+		t.Fatalf("issue update timestamps = %#v", issue)
 	}
 }
 


### PR DESCRIPTION
## Summary
- add RFC3339 timestamp fields alongside existing Unix millisecond issue manager CLI output fields
- include readable timestamps for issue, task, run, and run output details
- cover issue and task detail timestamp output in provider tests

## Validation
- cd services/tuttid && go test ./service/cli/providers/issuemanager
- git push pre-push hook: pnpm check:full