### PR TITLE
fix(workspace-files): reveal external absolute paths

### DIFF
--- a/apps/desktop/src/main/host/workspaceFileHostAccess.test.ts
+++ b/apps/desktop/src/main/host/workspaceFileHostAccess.test.ts
@@ -82,6 +82,53 @@ test("workspace file host access resolves and opens workspace files", async () =
   }
 });
 
+test("workspace file host access resolves external absolute workspace file paths", async () => {
+  const homeRoot = await createWorkspaceRootWithFile("home.txt", "home");
+  const externalRoot = await createWorkspaceRootWithFile(
+    "exports/report.txt",
+    "external"
+  );
+  const targetPath = path.join(externalRoot, "exports/report.txt");
+  const restoreHome = installHomeDirectory(homeRoot);
+  try {
+    const openedPaths: string[] = [];
+    let revealedPath = "";
+    const hostAccess = createWorkspaceFileHostAccess({
+      openPath: async (targetPath) => {
+        openedPaths.push(targetPath);
+        return "";
+      },
+      showItemInFolder(targetPath) {
+        revealedPath = targetPath;
+      }
+    });
+
+    await hostAccess.openFile({
+      path: targetPath,
+      workspaceID: "workspace-1"
+    });
+    const fileUrl = await hostAccess.resolveWorkspaceFileFileUrl({
+      path: targetPath,
+      workspaceID: "workspace-1"
+    });
+    const bytes = await hostAccess.readPreviewFile({
+      path: targetPath,
+      workspaceID: "workspace-1"
+    });
+    await hostAccess.revealWorkspaceFile({
+      path: targetPath,
+      workspaceID: "workspace-1"
+    });
+
+    assert.deepEqual(openedPaths, [path.resolve(targetPath)]);
+    assert.equal(fileUrl, pathToFileURL(path.resolve(targetPath)).href);
+    assert.equal(Buffer.from(bytes).toString("utf8"), "external");
+    assert.equal(revealedPath, path.resolve(targetPath));
+  } finally {
+    restoreHome();
+  }
+});
+
 test("workspace file host access treats missing default applications as handled", async () => {
   const workspaceRoot = await createWorkspaceRootWithFile(
     "exports/report.tutti-unknown",

--- a/apps/desktop/src/main/host/workspaceFileHostAccess.ts
+++ b/apps/desktop/src/main/host/workspaceFileHostAccess.ts
@@ -334,11 +334,31 @@ function defaultShowItemInFolder(path: string): void {
 function resolveWorkspaceTargetPath(
   payload: DesktopWorkspaceFilePathPayload
 ): string {
-  return resolveWorkspaceLogicalFilePath({
+  const rootDirectory = resolveWorkspaceTargetRoot(payload.path);
+  const targetPath = resolveWorkspaceLogicalFilePath({
     logicalPath: payload.path,
     logicalRoot: workspaceLogicalRoot,
-    physicalRootDirectory: homedir()
+    physicalRootDirectory: rootDirectory
   });
+  return targetPath;
+}
+
+function resolveWorkspaceTargetRoot(logicalPath: string): string {
+  const normalizedPath = logicalPath.trim().replaceAll("\\", "/");
+  if (
+    isWorkspaceLogicalPath(normalizedPath) ||
+    !path.isAbsolute(normalizedPath)
+  ) {
+    return homedir();
+  }
+  return path.parse(normalizedPath).root || path.resolve(path.sep);
+}
+
+function isWorkspaceLogicalPath(value: string): boolean {
+  return (
+    value === workspaceLogicalRoot ||
+    value.startsWith(`${workspaceLogicalRoot}/`)
+  );
 }
 
 async function shouldTreatSystemOpenFailureAsHandled(

--- a/apps/desktop/src/renderer/src/features/workspace-workbench/services/workspaceFilesLaunchCoordinator.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/services/workspaceFilesLaunchCoordinator.ts
@@ -40,10 +40,7 @@ export async function requestWorkspaceFilesLaunch(
   request: WorkspaceFilesLaunchRequest
 ): Promise<boolean> {
   const normalizedWorkspaceId = request.workspaceId.trim();
-  const normalizedPath = normalizeWorkspaceFilesLaunchPath({
-    homeDirectory: request.homeDirectory,
-    path: request.path
-  });
+  const normalizedPath = normalizeWorkspaceFilesLaunchPath(request.path);
   if (!normalizedWorkspaceId || !normalizedPath) {
     return false;
   }
@@ -61,56 +58,44 @@ export async function requestWorkspaceFilesLaunch(
   });
 }
 
-function normalizeWorkspaceFilesLaunchPath(input: {
-  homeDirectory?: string | null;
-  path: string;
-}): string | null {
-  const normalized = normalizeLocalPath(input.path);
-  if (!normalized) {
-    return null;
-  }
-  const homeRelative = homeRelativeAbsolutePath({
-    homeDirectory: input.homeDirectory,
-    path: normalized
-  });
-  if (homeRelative !== null) {
-    return normalized;
-  }
-  if (isAbsoluteLocalPath(normalized)) {
+function normalizeWorkspaceFilesLaunchPath(path: string): string | null {
+  const normalized = normalizeLocalPath(path);
+  if (
+    !normalized ||
+    isUrlLikeLocalPath(normalized) ||
+    isStructuredPayloadPath(normalized) ||
+    isUnsupportedSpecialPath(normalized)
+  ) {
     return null;
   }
   return normalized;
 }
 
-function homeRelativeAbsolutePath(input: {
-  homeDirectory?: string | null;
-  path: string;
-}): string | null {
-  const homeDirectory = normalizeLocalPath(input.homeDirectory ?? "");
-  if (!homeDirectory) {
-    return null;
+function isUrlLikeLocalPath(path: string): boolean {
+  if (path.startsWith("#")) {
+    return true;
   }
-
-  const comparison = isWindowsAbsolutePath(homeDirectory)
-    ? {
-        homeDirectory: homeDirectory.toLowerCase(),
-        path: input.path.toLowerCase()
-      }
-    : {
-        homeDirectory,
-        path: input.path
-      };
-  if (comparison.path === comparison.homeDirectory) {
-    return "";
+  if (isWindowsAbsolutePath(path)) {
+    return false;
   }
-  if (!comparison.path.startsWith(`${comparison.homeDirectory}/`)) {
-    return null;
-  }
-  return input.path.slice(homeDirectory.length + 1);
+  return /^[A-Za-z][A-Za-z\d+.-]*:/.test(path);
 }
 
-function isAbsoluteLocalPath(path: string): boolean {
-  return path.startsWith("/") || isWindowsAbsolutePath(path);
+function isStructuredPayloadPath(path: string): boolean {
+  if (!path.startsWith("{") && !path.startsWith("[")) {
+    return false;
+  }
+  try {
+    JSON.parse(path);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function isUnsupportedSpecialPath(path: string): boolean {
+  const comparisonPath = cleanLocalPathForComparison(path);
+  return comparisonPath === "/dev/null" || hasWindowsNulSegment(comparisonPath);
 }
 
 function isWindowsAbsolutePath(path: string): boolean {
@@ -119,6 +104,30 @@ function isWindowsAbsolutePath(path: string): boolean {
 
 function normalizeLocalPath(path: string): string {
   return path.trim().replaceAll("\\", "/").replace(/\/+$/, "");
+}
+
+function cleanLocalPathForComparison(path: string): string {
+  const normalized = path.replace(/\/+/g, "/");
+  const parts: string[] = [];
+  for (const part of normalized.split("/")) {
+    if (!part || part === ".") {
+      continue;
+    }
+    if (part === "..") {
+      parts.pop();
+      continue;
+    }
+    parts.push(part);
+  }
+  return normalized.startsWith("/") ? `/${parts.join("/")}` : parts.join("/");
+}
+
+function hasWindowsNulSegment(path: string): boolean {
+  return path.split("/").some((segment) => {
+    const normalized = segment.trim().replace(/[. ]+$/g, "");
+    const deviceName = normalized.split(".", 1)[0]?.toUpperCase();
+    return deviceName === "NUL";
+  });
 }
 
 function noop(): void {}

--- a/apps/desktop/src/renderer/src/features/workspace-workbench/services/workspaceFilesLaunchCoordinator.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/services/workspaceFilesLaunchCoordinator.ts
@@ -59,7 +59,11 @@ export async function requestWorkspaceFilesLaunch(
 }
 
 function normalizeWorkspaceFilesLaunchPath(path: string): string | null {
-  const normalized = normalizeLocalPath(path);
+  const trimmed = path.trim();
+  if (isUncLocalPath(trimmed)) {
+    return null;
+  }
+  const normalized = normalizeLocalPath(trimmed);
   if (
     !normalized ||
     isUrlLikeLocalPath(normalized) ||
@@ -96,6 +100,10 @@ function isStructuredPayloadPath(path: string): boolean {
 function isUnsupportedSpecialPath(path: string): boolean {
   const comparisonPath = cleanLocalPathForComparison(path);
   return comparisonPath === "/dev/null" || hasWindowsNulSegment(comparisonPath);
+}
+
+function isUncLocalPath(path: string): boolean {
+  return /^(?:\\\\|\/\/)[^/\\]+[/\\][^/\\]+/.test(path);
 }
 
 function isWindowsAbsolutePath(path: string): boolean {

--- a/apps/desktop/src/renderer/src/features/workspace-workbench/services/workspaceFilesRevealIntent.test.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/services/workspaceFilesRevealIntent.test.ts
@@ -117,11 +117,13 @@ test("workspace files launch coordinator preserves open directory mode", async (
   ]);
 });
 
-test("workspace files launch coordinator rejects /workspace as an unsupported absolute path", async () => {
+test("workspace files launch coordinator preserves legacy absolute workspace paths", async () => {
+  const requests: Array<{ path: string; workspaceId: string }> = [];
   const dispose = registerWorkspaceFilesLaunchHandler(
     "workspace-legacy",
-    () => {
-      throw new Error("legacy /workspace path should not launch");
+    (request) => {
+      requests.push(request);
+      return true;
     }
   );
 
@@ -131,12 +133,18 @@ test("workspace files launch coordinator rejects /workspace as an unsupported ab
       path: "/workspace/docs/spec.md",
       workspaceId: "workspace-legacy"
     }),
-    false
+    true
   );
   dispose();
+  assert.deepEqual(requests, [
+    {
+      path: "/workspace/docs/spec.md",
+      workspaceId: "workspace-legacy"
+    }
+  ]);
 });
 
-test("workspace files launch coordinator preserves home absolute paths and rejects unsupported absolute paths", async () => {
+test("workspace files launch coordinator preserves local absolute paths outside home", async () => {
   const requests: Array<{ path: string; workspaceId: string }> = [];
   const dispose = registerWorkspaceFilesLaunchHandler(
     "workspace-absolute",
@@ -160,7 +168,7 @@ test("workspace files launch coordinator preserves home absolute paths and rejec
       path: "/Users/other/demo/README.md",
       workspaceId: "workspace-absolute"
     }),
-    false
+    true
   );
   assert.equal(
     await requestWorkspaceFilesLaunch({
@@ -168,15 +176,81 @@ test("workspace files launch coordinator preserves home absolute paths and rejec
       path: "/tmp/README.md",
       workspaceId: "workspace-absolute"
     }),
-    false
+    true
+  );
+  assert.equal(
+    await requestWorkspaceFilesLaunch({
+      homeDirectory: "/Users/example",
+      path: "/var/folders/demo/T/codex-presentations/file.pptx",
+      workspaceId: "workspace-absolute"
+    }),
+    true
+  );
+  assert.equal(
+    await requestWorkspaceFilesLaunch({
+      homeDirectory: "C:\\Users\\example",
+      path: "C:\\tmp\\report.txt",
+      workspaceId: "workspace-absolute"
+    }),
+    true
   );
   dispose();
   assert.deepEqual(requests, [
     {
       path: "/Users/example/demo/README.md",
       workspaceId: "workspace-absolute"
+    },
+    {
+      path: "/Users/other/demo/README.md",
+      workspaceId: "workspace-absolute"
+    },
+    {
+      path: "/tmp/README.md",
+      workspaceId: "workspace-absolute"
+    },
+    {
+      path: "/var/folders/demo/T/codex-presentations/file.pptx",
+      workspaceId: "workspace-absolute"
+    },
+    {
+      path: "C:/tmp/report.txt",
+      workspaceId: "workspace-absolute"
     }
   ]);
+});
+
+test("workspace files launch coordinator rejects non-local and special paths", async () => {
+  const dispose = registerWorkspaceFilesLaunchHandler(
+    "workspace-invalid-paths",
+    () => {
+      throw new Error("invalid path should not launch");
+    }
+  );
+
+  for (const path of [
+    "",
+    "#readme",
+    "https://example.com/file.txt",
+    "file:///tmp/file.txt",
+    '{"path":"/tmp/file.txt"}',
+    '["/tmp/file.txt"]',
+    "/dev/null",
+    "/dev/./null",
+    "/dev//null",
+    "NUL",
+    "NUL.txt",
+    "C:\\tmp\\NUL"
+  ]) {
+    assert.equal(
+      await requestWorkspaceFilesLaunch({
+        path,
+        workspaceId: "workspace-invalid-paths"
+      }),
+      false,
+      path
+    );
+  }
+  dispose();
 });
 
 test("workspace files launch coordinator preserves hidden internal state paths under home", async () => {

--- a/apps/desktop/src/renderer/src/features/workspace-workbench/services/workspaceFilesRevealIntent.test.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/services/workspaceFilesRevealIntent.test.ts
@@ -239,7 +239,9 @@ test("workspace files launch coordinator rejects non-local and special paths", a
     "/dev//null",
     "NUL",
     "NUL.txt",
-    "C:\\tmp\\NUL"
+    "C:\\tmp\\NUL",
+    "\\\\server\\share\\file.txt",
+    "//server/share/file.txt"
   ]) {
     assert.equal(
       await requestWorkspaceFilesLaunch({

--- a/docs/conventions/troubleshooting.md
+++ b/docs/conventions/troubleshooting.md
@@ -931,3 +931,23 @@ information is not available yet`, but `ps` or `lsof` still shows an older
   [webviewSecurity.ts](../../packages/browser/workbench-node/src/electron-main/webviewSecurity.ts)
   [workspaceApp.ts](../../apps/desktop/src/preload/entries/workspaceApp.ts)
   [workspaceAppInteractionForwarding.ts](../../apps/desktop/src/preload/entries/workspaceAppInteractionForwarding.ts)
+
+### Agent generated files under system temp do not open
+
+- Symptom:
+  Agent GUI shows a generated or changed file under a path such as
+  `/var/folders/.../T/codex-presentations/...`, but clicking the file does not
+  reveal it in FileManager.
+- Quick checks:
+  Confirm the desktop workspace files launch coordinator accepts the path, then
+  confirm `tuttid` resolves the workspace file root for the requested absolute
+  path instead of forcing the user home root.
+- Root cause:
+  Some agent tools write durable-looking outputs to system temporary
+  directories. FileManager can reveal a precise local path, but both the
+  renderer launch filter and daemon workspace root resolution must allow that
+  external absolute path.
+- Fix:
+  Treat explicitly launched local absolute paths like direct hidden-file reveal:
+  do not add them as projects or default locations, but allow FileManager to
+  load the parent directory and apply normal local-file operations.

--- a/packages/agent/gui/actions/workspaceLinkActions.spec.ts
+++ b/packages/agent/gui/actions/workspaceLinkActions.spec.ts
@@ -47,6 +47,56 @@ describe("resolveWorkspaceFileLinkAction", () => {
     });
   });
 
+  it("allows explicit local absolute paths outside the selected workspace root", () => {
+    expect(
+      resolveWorkspaceFileLinkAction({
+        path: "/var/folders/17/demo/T/codex-presentations/test-note.md",
+        workspaceRoot: "/Users/test/project/tutti",
+        basePath: "/Users/test/project/tutti",
+        source: "agent-file-change"
+      })
+    ).toMatchObject({
+      type: "open-workspace-file",
+      path: "/var/folders/17/demo/T/codex-presentations/test-note.md",
+      directoryPath: "/var/folders/17/demo/T/codex-presentations",
+      workspaceRoot: "/Users/test/project/tutti"
+    });
+
+    expect(
+      resolveWorkspaceFileLinkAction({
+        path: "/tmp/report.txt",
+        workspaceRoot: "/Users/test/project/tutti",
+        basePath: "/Users/test/project/tutti",
+        source: "agent-file-change"
+      })
+    ).toMatchObject({
+      type: "open-workspace-file",
+      path: "/tmp/report.txt",
+      directoryPath: "/tmp",
+      workspaceRoot: "/Users/test/project/tutti"
+    });
+  });
+
+  it("rejects special local device paths before launch", () => {
+    for (const path of [
+      "/dev/null",
+      "/dev/./null",
+      "/dev//null",
+      "NUL",
+      "NUL.txt",
+      "C:\\tmp\\NUL"
+    ]) {
+      expect(
+        resolveWorkspaceFileLinkAction({
+          path,
+          workspaceRoot: "/",
+          basePath: "/",
+          source: "agent-file-change"
+        })
+      ).toBeNull();
+    }
+  });
+
   it("allows direct generated image paths under Tutti state outside the workspace root", () => {
     expect(
       resolveWorkspaceFileLinkAction({
@@ -70,7 +120,12 @@ describe("resolveWorkspaceFileLinkAction", () => {
         basePath: "/Users/test/project/tutti",
         source: "agent-markdown"
       })
-    ).toBeNull();
+    ).toMatchObject({
+      type: "open-workspace-file",
+      path: "/Users/test/.tutti-dev/agent/runs/session-1/codex-home/secrets.txt",
+      directoryPath: "/Users/test/.tutti-dev/agent/runs/session-1/codex-home",
+      workspaceRoot: "/Users/test/project/tutti"
+    });
   });
 
   it("allows direct generated video paths under Tutti state outside the workspace root", () => {
@@ -96,7 +151,13 @@ describe("resolveWorkspaceFileLinkAction", () => {
         basePath: "/Users/test/project/tutti",
         source: "agent-markdown"
       })
-    ).toBeNull();
+    ).toMatchObject({
+      type: "open-workspace-file",
+      path: "/Users/test/.tutti-dev/agent/runs/session-1/codex-home/generated_videos/raw.mov",
+      directoryPath:
+        "/Users/test/.tutti-dev/agent/runs/session-1/codex-home/generated_videos",
+      workspaceRoot: "/Users/test/project/tutti"
+    });
   });
 
   it("allows direct workspace app data paths without a selected project", () => {

--- a/packages/agent/gui/actions/workspaceLinkActions.spec.ts
+++ b/packages/agent/gui/actions/workspaceLinkActions.spec.ts
@@ -28,7 +28,12 @@ describe("resolveWorkspaceFileLinkAction", () => {
         basePath: "/Users/test/project/tutti",
         source: "agent-markdown"
       })
-    ).toBeNull();
+    ).toMatchObject({
+      type: "open-workspace-file",
+      path: "/workspace/src/App.tsx",
+      directoryPath: "/workspace/src",
+      workspaceRoot: "/Users/test/project/tutti"
+    });
   });
 
   it("allows local absolute paths when the workspace root is the filesystem root", () => {
@@ -77,14 +82,16 @@ describe("resolveWorkspaceFileLinkAction", () => {
     });
   });
 
-  it("rejects special local device paths before launch", () => {
+  it("rejects special local device and network share paths before launch", () => {
     for (const path of [
       "/dev/null",
       "/dev/./null",
       "/dev//null",
       "NUL",
       "NUL.txt",
-      "C:\\tmp\\NUL"
+      "C:\\tmp\\NUL",
+      "\\\\server\\share\\file.txt",
+      "//server/share/file.txt"
     ]) {
       expect(
         resolveWorkspaceFileLinkAction({

--- a/packages/agent/gui/actions/workspaceLinkActions.ts
+++ b/packages/agent/gui/actions/workspaceLinkActions.ts
@@ -125,6 +125,9 @@ export function resolveWorkspaceFilePathCandidate({
   }
 
   const normalizedPath = normalizeWorkspaceFilePath(rawPath);
+  if (isUnsupportedSpecialWorkspaceFilePath(normalizedPath)) {
+    return null;
+  }
   if (
     isAbsoluteLocalPath(normalizedPath) &&
     (isDirectAgentGeneratedMediaPath(normalizedPath) ||
@@ -142,6 +145,17 @@ export function resolveWorkspaceFilePathCandidate({
   const root = normalizeWorkspaceFilePath(workspaceRoot?.trim() ?? "");
   if (!root) {
     return null;
+  }
+  if (
+    isAbsoluteLocalPath(normalizedPath) &&
+    !isSyntheticWorkspacePathOutsideRoot(normalizedPath, root)
+  ) {
+    const directoryPath = dirname(normalizedPath);
+    return {
+      path: normalizedPath,
+      directoryPath,
+      workspaceRoot: root
+    };
   }
   const base = normalizeWorkspaceFilePath(basePath?.trim() || root);
   const resolvedPath = isAbsoluteLocalPath(normalizedPath)
@@ -336,6 +350,43 @@ function isAbsoluteLocalPath(path: string): boolean {
 
 function isWindowsAbsolutePath(path: string): boolean {
   return /^[A-Za-z]:\//.test(path);
+}
+
+function isSyntheticWorkspacePathOutsideRoot(
+  path: string,
+  root: string
+): boolean {
+  return (
+    root !== "/" && (path === "/workspace" || path.startsWith("/workspace/"))
+  );
+}
+
+function isUnsupportedSpecialWorkspaceFilePath(path: string): boolean {
+  const comparisonPath = cleanWorkspaceFilePathForComparison(path);
+  return (
+    comparisonPath === "/dev/null" ||
+    comparisonPath.split("/").some((segment) => {
+      const normalized = segment.trim().replace(/[. ]+$/g, "");
+      const deviceName = normalized.split(".", 1)[0]?.toUpperCase();
+      return deviceName === "NUL";
+    })
+  );
+}
+
+function cleanWorkspaceFilePathForComparison(path: string): string {
+  const normalized = path.replace(/\/+/g, "/");
+  const parts: string[] = [];
+  for (const part of normalized.split("/")) {
+    if (!part || part === ".") {
+      continue;
+    }
+    if (part === "..") {
+      parts.pop();
+      continue;
+    }
+    parts.push(part);
+  }
+  return normalized.startsWith("/") ? `/${parts.join("/")}` : parts.join("/");
 }
 
 function decodeWorkspaceLinkPath(path: string): string {

--- a/packages/agent/gui/actions/workspaceLinkActions.ts
+++ b/packages/agent/gui/actions/workspaceLinkActions.ts
@@ -120,7 +120,11 @@ export function resolveWorkspaceFilePathCandidate({
   basePath
 }: ResolveWorkspaceFilePathCandidateInput): ResolvedWorkspaceFilePathCandidate | null {
   const rawPath = decodeWorkspaceLinkPath(path.trim());
-  if (!rawPath || isUrlLikeWorkspaceFilePath(rawPath)) {
+  if (
+    !rawPath ||
+    isUrlLikeWorkspaceFilePath(rawPath) ||
+    isUncWorkspaceFilePath(rawPath)
+  ) {
     return null;
   }
 
@@ -146,10 +150,7 @@ export function resolveWorkspaceFilePathCandidate({
   if (!root) {
     return null;
   }
-  if (
-    isAbsoluteLocalPath(normalizedPath) &&
-    !isSyntheticWorkspacePathOutsideRoot(normalizedPath, root)
-  ) {
+  if (isAbsoluteLocalPath(normalizedPath)) {
     const directoryPath = dirname(normalizedPath);
     return {
       path: normalizedPath,
@@ -352,13 +353,8 @@ function isWindowsAbsolutePath(path: string): boolean {
   return /^[A-Za-z]:\//.test(path);
 }
 
-function isSyntheticWorkspacePathOutsideRoot(
-  path: string,
-  root: string
-): boolean {
-  return (
-    root !== "/" && (path === "/workspace" || path.startsWith("/workspace/"))
-  );
+function isUncWorkspaceFilePath(path: string): boolean {
+  return /^(?:\\\\|\/\/)[^/\\]+[/\\][^/\\]+/.test(path);
 }
 
 function isUnsupportedSpecialWorkspaceFilePath(path: string): boolean {

--- a/packages/agent/gui/shared/agentConversation/components/AgentTurnSummaryRow.spec.tsx
+++ b/packages/agent/gui/shared/agentConversation/components/AgentTurnSummaryRow.spec.tsx
@@ -250,6 +250,60 @@ describe("AgentTurnSummaryRow", () => {
     ).toBeTruthy();
   });
 
+  it("dispatches workspace actions for external absolute file changes", async () => {
+    const onLinkAction = vi.fn();
+    const externalPath =
+      "/var/folders/17/demo/T/codex-presentations/test-note.md";
+    render(
+      <AgentTurnSummaryRow
+        row={{
+          kind: "turn-summary",
+          id: "turn-summary:external",
+          turnId: "turn-external",
+          fileCount: 1,
+          modifiedCount: 0,
+          createdCount: 1,
+          occurredAtUnixMs: 25,
+          files: [
+            {
+              label: externalPath,
+              path: externalPath,
+              fileName: "test-note.md",
+              directory: "/var/folders/17/demo/T/codex-presentations",
+              changeType: "created",
+              toolName: "write_file",
+              messageId: "call:external",
+              content: "# Test note",
+              newString: "# Test note",
+              occurredAtUnixMs: 25
+            }
+          ]
+        }}
+        workspaceRoot="/Users/demo/project"
+        label="Changed files"
+        onLinkAction={onLinkAction}
+      />
+    );
+
+    fireEvent.click(
+      screen.getAllByRole("button", {
+        name: /test-note\.md/i
+      })[0]!
+    );
+
+    const openFileButton = await screen.findByRole("button", {
+      name: /agentHost\.workspaceAgentSessionDetailOpenFile:\/var\/folders\/17\/demo\/T\/codex-presentations\/test-note\.md/i
+    });
+    fireEvent.click(openFileButton);
+
+    expect(onLinkAction).toHaveBeenCalledWith(
+      expect.objectContaining({
+        path: externalPath,
+        type: "open-workspace-file"
+      })
+    );
+  });
+
   it("renders created edit-file content without falling back to monaco loading", async () => {
     render(
       <AgentTurnSummaryRow

--- a/packages/agent/gui/shared/agentConversation/projection/agentTurnSummaryProjection.spec.ts
+++ b/packages/agent/gui/shared/agentConversation/projection/agentTurnSummaryProjection.spec.ts
@@ -252,6 +252,11 @@ describe("projectAgentTurnSummaryRowForTurn", () => {
         path: "/Users/example/tsh-project/tutti/src/routes.ts",
         label: "routes.ts",
         changeType: "created"
+      }),
+      expect.objectContaining({
+        path: "/tmp/outside.txt",
+        label: "outside.txt",
+        changeType: "created"
       })
     ]);
   });
@@ -903,6 +908,10 @@ describe("projectAgentTurnSummaryRows", () => {
     );
 
     expect(rows[0]?.files).toEqual([
+      expect.objectContaining({
+        path: "/tmp/outside.txt",
+        label: "outside.txt"
+      }),
       expect.objectContaining({
         path: "ppt_news/generate_news_ppt.py",
         label: "generate_news_ppt.py"

--- a/packages/workspace/file-manager/src/services/internal/model/paths.ts
+++ b/packages/workspace/file-manager/src/services/internal/model/paths.ts
@@ -61,6 +61,9 @@ export function workspaceFileDirectory(
   rootPath?: string | null
 ): string {
   const root = normalizeWorkspaceFilePath(rootPath);
+  const rawPath = String(path ?? "")
+    .trim()
+    .replaceAll("\\", "/");
   const normalized = normalizeWorkspaceFilePath(path, root);
   if (normalized === root) {
     return root;
@@ -73,7 +76,10 @@ export function workspaceFileDirectory(
   }
   const directory = `/${parts.join("/")}`;
   if (root !== workspaceFileManagerLogicalRoot) {
-    return isWorkspaceFilePathWithinRoot(directory, root) ? directory : root;
+    if (isWorkspaceFilePathWithinRoot(directory, root)) {
+      return directory;
+    }
+    return rawPath.startsWith("/") ? directory : root;
   }
   return directory;
 }

--- a/packages/workspace/file-manager/src/services/internal/model/paths.ts
+++ b/packages/workspace/file-manager/src/services/internal/model/paths.ts
@@ -15,7 +15,7 @@ export function normalizeWorkspaceFilePath(
     return root;
   }
 
-  if (!raw.startsWith("/") && root) {
+  if (!isWorkspaceFileAbsolutePath(raw) && root) {
     return normalizeWorkspaceFileAbsolutePath(`${root}/${raw}`);
   }
 
@@ -30,7 +30,14 @@ function normalizeWorkspaceFileAbsolutePath(value?: string | null): string {
     return workspaceFileManagerLogicalRoot;
   }
 
-  const segments = raw
+  const drive = readWindowsDrive(raw);
+  const startsWithSlash = raw.startsWith("/");
+  const body = drive
+    ? raw.slice(drive.length).replace(/^\/+/, "")
+    : startsWithSlash
+      ? raw.slice(1)
+      : raw;
+  const segments = body
     .split("/")
     .filter(Boolean)
     .filter((segment) => segment !== ".");
@@ -44,7 +51,10 @@ function normalizeWorkspaceFileAbsolutePath(value?: string | null): string {
   }
 
   if (result.length === 0) {
-    return workspaceFileManagerLogicalRoot;
+    return drive ? `${drive}/` : workspaceFileManagerLogicalRoot;
+  }
+  if (drive) {
+    return `${drive}/${result.join("/")}`;
   }
   return `/${result.join("/")}`;
 }
@@ -69,17 +79,22 @@ export function workspaceFileDirectory(
     return root;
   }
 
-  const parts = normalized.split("/").filter(Boolean);
+  const drive = readWindowsDrive(normalized);
+  const body = drive ? normalized.slice(drive.length) : normalized;
+  const parts = body.split("/").filter(Boolean);
   parts.pop();
-  if (parts.length === 0) {
-    return root;
-  }
-  const directory = `/${parts.join("/")}`;
+  const directory = drive
+    ? parts.length === 0
+      ? `${drive}/`
+      : `${drive}/${parts.join("/")}`
+    : parts.length === 0
+      ? workspaceFileManagerLogicalRoot
+      : `/${parts.join("/")}`;
   if (root !== workspaceFileManagerLogicalRoot) {
     if (isWorkspaceFilePathWithinRoot(directory, root)) {
       return directory;
     }
-    return rawPath.startsWith("/") ? directory : root;
+    return isWorkspaceFileAbsolutePath(rawPath) ? directory : root;
   }
   return directory;
 }
@@ -142,9 +157,21 @@ export function isWorkspaceFilePathWithinRoot(
 ): boolean {
   const root = normalizeWorkspaceFilePath(rootPath);
   const normalized = normalizeWorkspaceFilePath(path, root);
+  const comparison =
+    readWindowsDrive(root) || readWindowsDrive(normalized)
+      ? { normalized: normalized.toLowerCase(), root: root.toLowerCase() }
+      : { normalized, root };
   return (
-    root === workspaceFileManagerLogicalRoot ||
-    normalized === root ||
-    normalized.startsWith(`${root}/`)
+    comparison.root === workspaceFileManagerLogicalRoot ||
+    comparison.normalized === comparison.root ||
+    comparison.normalized.startsWith(`${comparison.root}/`)
   );
+}
+
+function isWorkspaceFileAbsolutePath(path: string): boolean {
+  return path.startsWith("/") || readWindowsDrive(path) !== "";
+}
+
+function readWindowsDrive(path: string): string {
+  return /^[A-Za-z]:/.exec(path)?.[0] ?? "";
 }

--- a/packages/workspace/file-manager/src/services/internal/workspaceFileManagerNavigationController.test.ts
+++ b/packages/workspace/file-manager/src/services/internal/workspaceFileManagerNavigationController.test.ts
@@ -133,6 +133,34 @@ test("revealPath loads the parent directory and selects the requested file", asy
   assert.equal(store.isLoading, false);
 });
 
+test("revealPath loads external absolute parent directories outside the current root", async () => {
+  const store = createTestStore();
+  store.root = "/Users/demo";
+  store.currentDirectoryPath = "/Users/demo";
+  const controller = new WorkspaceFileManagerNavigationController({
+    host: {
+      async listDirectory(input) {
+        assert.equal(input.path, "/tmp");
+        return {
+          directoryPath: input.path,
+          entries: [createFileEntry("/tmp/hello_world.md")],
+          root: "/",
+          workspaceID: input.workspaceID
+        };
+      }
+    },
+    resolveErrorMessage: defaultResolveErrorMessage,
+    store
+  });
+
+  await controller.revealPath("/tmp/hello_world.md");
+
+  assert.equal(store.root, "/");
+  assert.equal(store.currentDirectoryPath, "/tmp");
+  assert.equal(store.selectedPath, "/tmp/hello_world.md");
+  assert.equal(store.isLoading, false);
+});
+
 test("revealPath includes hidden entries when parent path contains a hidden segment", async () => {
   const store = createTestStore();
   store.root = "/Users/demo";

--- a/packages/workspace/file-manager/src/services/internal/workspaceFileManagerNavigationController.test.ts
+++ b/packages/workspace/file-manager/src/services/internal/workspaceFileManagerNavigationController.test.ts
@@ -161,6 +161,34 @@ test("revealPath loads external absolute parent directories outside the current 
   assert.equal(store.isLoading, false);
 });
 
+test("revealPath handles Windows drive paths outside the current root", async () => {
+  const store = createTestStore();
+  store.root = "C:/Users/demo";
+  store.currentDirectoryPath = "C:/Users/demo";
+  const controller = new WorkspaceFileManagerNavigationController({
+    host: {
+      async listDirectory(input) {
+        assert.equal(input.path, "C:/tmp");
+        return {
+          directoryPath: input.path,
+          entries: [createFileEntry("C:/tmp/hello_world.md")],
+          root: "C:/",
+          workspaceID: input.workspaceID
+        };
+      }
+    },
+    resolveErrorMessage: defaultResolveErrorMessage,
+    store
+  });
+
+  await controller.revealPath("C:\\tmp\\hello_world.md");
+
+  assert.equal(store.root, "C:/");
+  assert.equal(store.currentDirectoryPath, "C:/tmp");
+  assert.equal(store.selectedPath, "C:/tmp/hello_world.md");
+  assert.equal(store.isLoading, false);
+});
+
 test("revealPath includes hidden entries when parent path contains a hidden segment", async () => {
   const store = createTestStore();
   store.root = "/Users/demo";

--- a/packages/workspace/file-manager/src/services/workspaceFileManagerModel.test.ts
+++ b/packages/workspace/file-manager/src/services/workspaceFileManagerModel.test.ts
@@ -62,6 +62,24 @@ test("derives logical parent directory", () => {
   );
 });
 
+test("derives external absolute parent directories outside the current root", () => {
+  assert.equal(
+    workspaceFileDirectory("/tmp/hello_world.md", "/Users/demo"),
+    "/tmp"
+  );
+  assert.equal(
+    workspaceFileDirectory(
+      "/var/folders/demo/T/codex-presentations/slides.pptx",
+      "/Users/demo"
+    ),
+    "/var/folders/demo/T/codex-presentations"
+  );
+  assert.equal(
+    workspaceFileDirectory("../../tmp/file.txt", "/Users/demo"),
+    "/Users/demo"
+  );
+});
+
 test("filters hidden directories and sorts directories first", () => {
   const entries: WorkspaceFileEntry[] = [
     entry("zeta.txt", "file"),

--- a/packages/workspace/file-manager/src/services/workspaceFileManagerModel.test.ts
+++ b/packages/workspace/file-manager/src/services/workspaceFileManagerModel.test.ts
@@ -30,6 +30,20 @@ test("normalizes paths under the logical workspace root", () => {
   assert.equal(normalizeWorkspaceFilePath(""), "/");
 });
 
+test("normalizes Windows drive paths without treating them as relative", () => {
+  assert.equal(
+    normalizeWorkspaceFilePath("src\\main.ts", "C:\\Users\\demo\\project"),
+    "C:/Users/demo/project/src/main.ts"
+  );
+  assert.equal(
+    normalizeWorkspaceFilePath(
+      "C:\\tmp\\report.txt",
+      "C:\\Users\\demo\\project"
+    ),
+    "C:/tmp/report.txt"
+  );
+});
+
 test("formatWorkspaceFileModifiedTime uses the shared English short date-time format", () => {
   const timestamp = new Date(2026, 4, 23, 11, 39).getTime();
 
@@ -67,6 +81,7 @@ test("derives external absolute parent directories outside the current root", ()
     workspaceFileDirectory("/tmp/hello_world.md", "/Users/demo"),
     "/tmp"
   );
+  assert.equal(workspaceFileDirectory("/hello_world.md", "/Users/demo"), "/");
   assert.equal(
     workspaceFileDirectory(
       "/var/folders/demo/T/codex-presentations/slides.pptx",
@@ -77,6 +92,17 @@ test("derives external absolute parent directories outside the current root", ()
   assert.equal(
     workspaceFileDirectory("../../tmp/file.txt", "/Users/demo"),
     "/Users/demo"
+  );
+});
+
+test("derives Windows drive parent directories outside the current root", () => {
+  assert.equal(
+    workspaceFileDirectory("C:\\tmp\\hello_world.md", "C:\\Users\\demo"),
+    "C:/tmp"
+  );
+  assert.equal(
+    workspaceFileDirectory("C:\\hello_world.md", "C:\\Users\\demo"),
+    "C:/"
   );
 });
 

--- a/packages/workspace/file-manager/src/services/workspaceFileManagerSession.test.ts
+++ b/packages/workspace/file-manager/src/services/workspaceFileManagerSession.test.ts
@@ -1534,6 +1534,58 @@ test("applyRevealIntent opens target directories directly when requested", async
   session.dispose();
 });
 
+test("applyRevealIntent reveals external absolute file paths", async () => {
+  const session = createWorkspaceFileManagerService().createSession({
+    host: {
+      async listDirectory(input) {
+        assert.equal(input.path, "/var/folders/demo/T/codex-presentations");
+        assert.equal(input.includeHidden, false);
+        return {
+          directoryPath: input.path,
+          entries: [
+            {
+              hasChildren: false,
+              kind: "file",
+              mtimeMs: null,
+              name: "slides.pptx",
+              path: "/var/folders/demo/T/codex-presentations/slides.pptx",
+              sizeBytes: 42
+            }
+          ],
+          root: "/",
+          workspaceID: input.workspaceID
+        };
+      }
+    },
+    i18n: createTestI18nRuntime(),
+    persistedState: {
+      currentDirectoryPath: "/Users/demo",
+      navigationBackStack: [],
+      navigationForwardStack: [],
+      selectedLocationId: null,
+      schemaVersion: 3
+    },
+    workspaceID: "workspace-1"
+  });
+  session.store.root = "/Users/demo";
+
+  await session.applyRevealIntent({
+    path: "/var/folders/demo/T/codex-presentations/slides.pptx",
+    requestID: "external-reveal-1"
+  });
+
+  assert.equal(session.store.root, "/");
+  assert.equal(
+    session.store.currentDirectoryPath,
+    "/var/folders/demo/T/codex-presentations"
+  );
+  assert.equal(
+    session.store.selectedPath,
+    "/var/folders/demo/T/codex-presentations/slides.pptx"
+  );
+  session.dispose();
+});
+
 test("initialize preserves directory state already loaded by a reveal intent", async () => {
   const listedPaths: string[] = [];
   const session = createWorkspaceFileManagerService().createSession({

--- a/packages/workspace/files/adapter.go
+++ b/packages/workspace/files/adapter.go
@@ -6,6 +6,10 @@ type WorkspaceResolver interface {
 	ResolveWorkspaceRoot(ctx context.Context, workspaceID string) (WorkspaceRoot, error)
 }
 
+type PathAwareWorkspaceResolver interface {
+	ResolveWorkspaceRootForPath(ctx context.Context, workspaceID string, path string) (WorkspaceRoot, error)
+}
+
 type FileAdapter interface {
 	ListDirectory(ctx context.Context, root WorkspaceRoot, path LogicalPath, includeHidden bool) (DirectoryListing, error)
 	CreateFile(ctx context.Context, root WorkspaceRoot, path LogicalPath) (FileEntry, error)

--- a/packages/workspace/files/service.go
+++ b/packages/workspace/files/service.go
@@ -12,11 +12,7 @@ type Service struct {
 }
 
 func (s Service) ListDirectory(ctx context.Context, workspaceID string, input DirectoryListInput) (DirectoryListing, error) {
-	root, err := s.resolve(ctx, workspaceID)
-	if err != nil {
-		return DirectoryListing{}, err
-	}
-	logicalPath, err := NormalizeLogicalPathWithinRoot(input.Path, root.LogicalRoot)
+	root, logicalPath, err := s.resolvePath(ctx, workspaceID, input.Path)
 	if err != nil {
 		return DirectoryListing{}, err
 	}
@@ -98,14 +94,22 @@ func (s Service) DeleteEntry(ctx context.Context, workspaceID string, value stri
 }
 
 func (s Service) MoveEntry(ctx context.Context, workspaceID string, value string, targetDirectoryValue string) (FileEntry, error) {
-	root, logicalPath, err := s.resolvePath(ctx, workspaceID, value)
+	defaultRoot, err := s.resolve(ctx, workspaceID)
+	if err != nil {
+		return FileEntry{}, err
+	}
+	root, err := s.resolveRootForPathsFromDefault(ctx, workspaceID, defaultRoot, value, targetDirectoryValue)
+	if err != nil {
+		return FileEntry{}, err
+	}
+	logicalPath, err := NormalizeLogicalPathWithinRoot(pathValueForRoot(value, defaultRoot, root), root.LogicalRoot)
 	if err != nil {
 		return FileEntry{}, err
 	}
 	if IsLogicalRoot(logicalPath, root.LogicalRoot) {
 		return FileEntry{}, ErrRootDeleteForbidden
 	}
-	targetDirectoryPath, err := NormalizeLogicalPathWithinRoot(targetDirectoryValue, root.LogicalRoot)
+	targetDirectoryPath, err := NormalizeLogicalPathWithinRoot(pathValueForRoot(targetDirectoryValue, defaultRoot, root), root.LogicalRoot)
 	if err != nil {
 		return FileEntry{}, err
 	}
@@ -154,12 +158,7 @@ func (s Service) CopyEntry(ctx context.Context, workspaceID string, value string
 }
 
 func (s Service) UploadFiles(ctx context.Context, workspaceID string, input UploadInput) (UploadResult, error) {
-	root, err := s.resolve(ctx, workspaceID)
-	if err != nil {
-		return UploadResult{}, err
-	}
-
-	targetDirectoryPath, err := NormalizeLogicalPathWithinRoot(input.TargetDirectoryPath, root.LogicalRoot)
+	root, targetDirectoryPath, err := s.resolvePath(ctx, workspaceID, input.TargetDirectoryPath)
 	if err != nil {
 		return UploadResult{}, err
 	}
@@ -193,12 +192,7 @@ func (s Service) UploadFiles(ctx context.Context, workspaceID string, input Uplo
 }
 
 func (s Service) PreflightUploadFiles(ctx context.Context, workspaceID string, input PreflightUploadInput) (PreflightUploadResult, error) {
-	root, err := s.resolve(ctx, workspaceID)
-	if err != nil {
-		return PreflightUploadResult{}, err
-	}
-
-	targetDirectoryPath, err := NormalizeLogicalPathWithinRoot(input.TargetDirectoryPath, root.LogicalRoot)
+	root, targetDirectoryPath, err := s.resolvePath(ctx, workspaceID, input.TargetDirectoryPath)
 	if err != nil {
 		return PreflightUploadResult{}, err
 	}
@@ -232,7 +226,7 @@ func (s Service) PreflightUploadFiles(ctx context.Context, workspaceID string, i
 }
 
 func (s Service) Search(ctx context.Context, workspaceID string, input SearchInput) (SearchResult, error) {
-	root, err := s.resolve(ctx, workspaceID)
+	root, err := s.resolveRootForPaths(ctx, workspaceID, input.Within)
 	if err != nil {
 		return SearchResult{}, err
 	}
@@ -299,7 +293,7 @@ func (s Service) ListRecent(ctx context.Context, workspaceID string, input Recen
 }
 
 func (s Service) resolvePath(ctx context.Context, workspaceID string, value string) (WorkspaceRoot, LogicalPath, error) {
-	root, err := s.resolve(ctx, workspaceID)
+	root, err := s.resolveRootForPaths(ctx, workspaceID, value)
 	if err != nil {
 		return WorkspaceRoot{}, "", err
 	}
@@ -308,6 +302,49 @@ func (s Service) resolvePath(ctx context.Context, workspaceID string, value stri
 		return WorkspaceRoot{}, "", err
 	}
 	return root, logicalPath, nil
+}
+
+func (s Service) resolveRootForPaths(ctx context.Context, workspaceID string, values ...string) (WorkspaceRoot, error) {
+	root, err := s.resolve(ctx, workspaceID)
+	if err != nil {
+		return WorkspaceRoot{}, err
+	}
+	return s.resolveRootForPathsFromDefault(ctx, workspaceID, root, values...)
+}
+
+func (s Service) resolveRootForPathsFromDefault(ctx context.Context, workspaceID string, root WorkspaceRoot, values ...string) (WorkspaceRoot, error) {
+	pathResolver, ok := s.Resolver.(PathAwareWorkspaceResolver)
+	if !ok {
+		return root, nil
+	}
+	for _, value := range values {
+		pathRoot, err := pathResolver.ResolveWorkspaceRootForPath(ctx, workspaceID, value)
+		if err != nil {
+			return WorkspaceRoot{}, err
+		}
+		pathRoot = normalizeResolvedRoot(pathRoot, workspaceID)
+		if pathRoot.LogicalRoot != root.LogicalRoot || strings.TrimSpace(pathRoot.PhysicalRoot) != strings.TrimSpace(root.PhysicalRoot) {
+			return pathRoot, nil
+		}
+	}
+	return root, nil
+}
+
+func pathValueForRoot(value string, defaultRoot WorkspaceRoot, root WorkspaceRoot) string {
+	raw := strings.TrimSpace(strings.ReplaceAll(value, "\\", "/"))
+	if raw == "" || strings.HasPrefix(raw, "/") || sameWorkspaceRoot(defaultRoot, root) {
+		return value
+	}
+	defaultLogicalPath, err := NormalizeLogicalPathWithinRoot(value, defaultRoot.LogicalRoot)
+	if err != nil {
+		return value
+	}
+	return defaultLogicalPath.String()
+}
+
+func sameWorkspaceRoot(left WorkspaceRoot, right WorkspaceRoot) bool {
+	return NormalizeLogicalRoot(left.LogicalRoot) == NormalizeLogicalRoot(right.LogicalRoot) &&
+		strings.TrimSpace(left.PhysicalRoot) == strings.TrimSpace(right.PhysicalRoot)
 }
 
 func (s Service) resolve(ctx context.Context, workspaceID string) (WorkspaceRoot, error) {
@@ -321,16 +358,20 @@ func (s Service) resolve(ctx context.Context, workspaceID string) (WorkspaceRoot
 	if err != nil {
 		return WorkspaceRoot{}, err
 	}
+	return normalizeResolvedRoot(root, workspaceID), nil
+}
+
+func (s Service) adapter() FileAdapter {
+	return s.Adapter
+}
+
+func normalizeResolvedRoot(root WorkspaceRoot, workspaceID string) WorkspaceRoot {
 	root.WorkspaceID = strings.TrimSpace(root.WorkspaceID)
 	if root.WorkspaceID == "" {
 		root.WorkspaceID = strings.TrimSpace(workspaceID)
 	}
 	root.LogicalRoot = NormalizeLogicalRoot(root.LogicalRoot).String()
-	return root, nil
-}
-
-func (s Service) adapter() FileAdapter {
-	return s.Adapter
+	return root
 }
 
 func normalizeDirectoryListing(root WorkspaceRoot, requested LogicalPath, listing DirectoryListing) DirectoryListing {

--- a/packages/workspace/files/service.go
+++ b/packages/workspace/files/service.go
@@ -102,6 +102,10 @@ func (s Service) MoveEntry(ctx context.Context, workspaceID string, value string
 	if err != nil {
 		return FileEntry{}, err
 	}
+	if defaultLogicalPath, err := NormalizeLogicalPathWithinRoot(value, defaultRoot.LogicalRoot); err == nil &&
+		IsLogicalRoot(defaultLogicalPath, defaultRoot.LogicalRoot) {
+		return FileEntry{}, ErrRootDeleteForbidden
+	}
 	logicalPath, err := NormalizeLogicalPathWithinRoot(pathValueForRoot(value, defaultRoot, root), root.LogicalRoot)
 	if err != nil {
 		return FileEntry{}, err

--- a/packages/workspace/files/service_test.go
+++ b/packages/workspace/files/service_test.go
@@ -23,11 +23,27 @@ func (r fakeResolver) ResolveWorkspaceRoot(_ context.Context, workspaceID string
 	return root, nil
 }
 
+type fakePathAwareResolver struct {
+	fakeResolver
+	rootByPath map[string]WorkspaceRoot
+}
+
+func (r fakePathAwareResolver) ResolveWorkspaceRootForPath(ctx context.Context, workspaceID string, path string) (WorkspaceRoot, error) {
+	if root, ok := r.rootByPath[path]; ok {
+		if root.WorkspaceID == "" {
+			root.WorkspaceID = workspaceID
+		}
+		return root, nil
+	}
+	return r.ResolveWorkspaceRoot(ctx, workspaceID)
+}
+
 type fakeAdapter struct {
 	directoryListingByPath   map[LogicalPath]DirectoryListing
 	listDirectoryCallsByPath map[LogicalPath]int
 	listDirectoryDelayByPath map[LogicalPath]time.Duration
 	listDirectoryErrByPath   map[LogicalPath]error
+	listRoot                 WorkspaceRoot
 	listPath                 LogicalPath
 	listIncludeHidden        bool
 	createFile               LogicalPath
@@ -38,6 +54,12 @@ type fakeAdapter struct {
 	createDir                LogicalPath
 	deletePath               LogicalPath
 	deleteKind               EntryKind
+	moveRoot                 WorkspaceRoot
+	movePath                 LogicalPath
+	moveTargetDirectory      LogicalPath
+	renameRoot               WorkspaceRoot
+	renamePath               LogicalPath
+	renameName               string
 	conflicts                []UploadConflict
 	uploadDir                LogicalPath
 	uploadPaths              []string
@@ -46,6 +68,7 @@ type fakeAdapter struct {
 }
 
 func (a *fakeAdapter) ListDirectory(ctx context.Context, root WorkspaceRoot, logicalPath LogicalPath, includeHidden bool) (DirectoryListing, error) {
+	a.listRoot = root
 	a.listPath = logicalPath
 	a.listIncludeHidden = includeHidden
 	if a.listDirectoryCallsByPath != nil {
@@ -117,14 +140,20 @@ func (a *fakeAdapter) DeleteEntry(_ context.Context, _ WorkspaceRoot, logicalPat
 	return nil
 }
 
-func (*fakeAdapter) MoveEntry(_ context.Context, _ WorkspaceRoot, logicalPath LogicalPath, targetDirectoryPath LogicalPath) (FileEntry, error) {
+func (a *fakeAdapter) MoveEntry(_ context.Context, root WorkspaceRoot, logicalPath LogicalPath, targetDirectoryPath LogicalPath) (FileEntry, error) {
+	a.moveRoot = root
+	a.movePath = logicalPath
+	a.moveTargetDirectory = targetDirectoryPath
 	return FileEntry{
 		Path: LogicalPath(targetDirectoryPath.String() + "/" + LogicalPathBase(logicalPath)),
 		Kind: EntryKindFile,
 	}, nil
 }
 
-func (*fakeAdapter) RenameEntry(_ context.Context, _ WorkspaceRoot, logicalPath LogicalPath, newName string) (FileEntry, error) {
+func (a *fakeAdapter) RenameEntry(_ context.Context, root WorkspaceRoot, logicalPath LogicalPath, newName string) (FileEntry, error) {
+	a.renameRoot = root
+	a.renamePath = logicalPath
+	a.renameName = newName
 	parentDirectoryPath := LogicalPathDir(logicalPath)
 	return FileEntry{
 		Path: LogicalPath(parentDirectoryPath.String() + "/" + newName),
@@ -188,6 +217,164 @@ func TestServiceListDirectoryNormalizesPath(t *testing.T) {
 	}
 	if len(listing.Entries) != 1 {
 		t.Fatalf("entries length = %d", len(listing.Entries))
+	}
+}
+
+func TestServiceListDirectoryUsesPathAwareRootForExternalAbsolutePath(t *testing.T) {
+	adapter := &fakeAdapter{}
+	service := Service{
+		Resolver: fakePathAwareResolver{
+			fakeResolver: fakeResolver{
+				root: WorkspaceRoot{
+					LogicalRoot:  "/Users/example",
+					PhysicalRoot: "/Users/example",
+				},
+			},
+			rootByPath: map[string]WorkspaceRoot{
+				"/var/folders/demo/T/codex-presentations": {
+					LogicalRoot:  "/",
+					PhysicalRoot: "/",
+				},
+			},
+		},
+		Adapter: adapter,
+	}
+
+	_, err := service.ListDirectory(context.Background(), "ws-1", DirectoryListInput{
+		Path: "/var/folders/demo/T/codex-presentations",
+	})
+	if err != nil {
+		t.Fatalf("ListDirectory() error = %v", err)
+	}
+	if adapter.listRoot.LogicalRoot != "/" || adapter.listRoot.PhysicalRoot != "/" {
+		t.Fatalf("list root = %+v, want filesystem root", adapter.listRoot)
+	}
+	if adapter.listPath != "/var/folders/demo/T/codex-presentations" {
+		t.Fatalf("list path = %q", adapter.listPath)
+	}
+}
+
+func TestServiceRenameEntryUsesPathAwareRootForExternalAbsolutePath(t *testing.T) {
+	adapter := &fakeAdapter{}
+	service := Service{
+		Resolver: fakePathAwareResolver{
+			fakeResolver: fakeResolver{
+				root: WorkspaceRoot{
+					LogicalRoot:  "/Users/example",
+					PhysicalRoot: "/Users/example",
+				},
+			},
+			rootByPath: map[string]WorkspaceRoot{
+				"/tmp/report.txt": {
+					LogicalRoot:  "/",
+					PhysicalRoot: "/",
+				},
+			},
+		},
+		Adapter: adapter,
+	}
+
+	entry, err := service.RenameEntry(context.Background(), "ws-1", "/tmp/report.txt", "renamed.txt")
+	if err != nil {
+		t.Fatalf("RenameEntry() error = %v", err)
+	}
+	if adapter.renameRoot.LogicalRoot != "/" || adapter.renameRoot.PhysicalRoot != "/" {
+		t.Fatalf("rename root = %+v, want filesystem root", adapter.renameRoot)
+	}
+	if adapter.renamePath != "/tmp/report.txt" {
+		t.Fatalf("rename path = %q", adapter.renamePath)
+	}
+	if adapter.renameName != "renamed.txt" {
+		t.Fatalf("rename name = %q", adapter.renameName)
+	}
+	if entry.Path != "/tmp/renamed.txt" {
+		t.Fatalf("renamed entry path = %q", entry.Path)
+	}
+}
+
+func TestServiceMoveEntryUsesPathAwareRootWhenTargetIsExternal(t *testing.T) {
+	adapter := &fakeAdapter{}
+	service := Service{
+		Resolver: fakePathAwareResolver{
+			fakeResolver: fakeResolver{
+				root: WorkspaceRoot{
+					LogicalRoot:  "/Users/example",
+					PhysicalRoot: "/Users/example",
+				},
+			},
+			rootByPath: map[string]WorkspaceRoot{
+				"/tmp/output": {
+					LogicalRoot:  "/",
+					PhysicalRoot: "/",
+				},
+			},
+		},
+		Adapter: adapter,
+	}
+
+	entry, err := service.MoveEntry(
+		context.Background(),
+		"ws-1",
+		"/Users/example/project/report.txt",
+		"/tmp/output",
+	)
+	if err != nil {
+		t.Fatalf("MoveEntry() error = %v", err)
+	}
+	if adapter.moveRoot.LogicalRoot != "/" || adapter.moveRoot.PhysicalRoot != "/" {
+		t.Fatalf("move root = %+v, want filesystem root", adapter.moveRoot)
+	}
+	if adapter.movePath != "/Users/example/project/report.txt" {
+		t.Fatalf("move path = %q", adapter.movePath)
+	}
+	if adapter.moveTargetDirectory != "/tmp/output" {
+		t.Fatalf("move target = %q", adapter.moveTargetDirectory)
+	}
+	if entry.Path != "/tmp/output/report.txt" {
+		t.Fatalf("moved entry path = %q", entry.Path)
+	}
+}
+
+func TestServiceMoveEntryKeepsRelativeSourceUnderDefaultRootWhenTargetIsExternal(t *testing.T) {
+	adapter := &fakeAdapter{}
+	service := Service{
+		Resolver: fakePathAwareResolver{
+			fakeResolver: fakeResolver{
+				root: WorkspaceRoot{
+					LogicalRoot:  "/Users/example",
+					PhysicalRoot: "/Users/example",
+				},
+			},
+			rootByPath: map[string]WorkspaceRoot{
+				"/tmp/output": {
+					LogicalRoot:  "/",
+					PhysicalRoot: "/",
+				},
+			},
+		},
+		Adapter: adapter,
+	}
+
+	entry, err := service.MoveEntry(
+		context.Background(),
+		"ws-1",
+		"project/report.txt",
+		"/tmp/output",
+	)
+	if err != nil {
+		t.Fatalf("MoveEntry() error = %v", err)
+	}
+	if adapter.moveRoot.LogicalRoot != "/" || adapter.moveRoot.PhysicalRoot != "/" {
+		t.Fatalf("move root = %+v, want filesystem root", adapter.moveRoot)
+	}
+	if adapter.movePath != "/Users/example/project/report.txt" {
+		t.Fatalf("move path = %q", adapter.movePath)
+	}
+	if adapter.moveTargetDirectory != "/tmp/output" {
+		t.Fatalf("move target = %q", adapter.moveTargetDirectory)
+	}
+	if entry.Path != "/tmp/output/report.txt" {
+		t.Fatalf("moved entry path = %q", entry.Path)
 	}
 }
 

--- a/packages/workspace/files/service_test.go
+++ b/packages/workspace/files/service_test.go
@@ -335,6 +335,42 @@ func TestServiceMoveEntryUsesPathAwareRootWhenTargetIsExternal(t *testing.T) {
 	}
 }
 
+func TestServiceMoveEntryRejectsDefaultRootWhenTargetIsExternal(t *testing.T) {
+	adapter := &fakeAdapter{}
+	service := Service{
+		Resolver: fakePathAwareResolver{
+			fakeResolver: fakeResolver{
+				root: WorkspaceRoot{
+					LogicalRoot:  "/Users/example",
+					PhysicalRoot: "/Users/example",
+				},
+			},
+			rootByPath: map[string]WorkspaceRoot{
+				"/tmp/output": {
+					LogicalRoot:  "/",
+					PhysicalRoot: "/",
+				},
+			},
+		},
+		Adapter: adapter,
+	}
+
+	for _, value := range []string{"/Users/example", ""} {
+		_, err := service.MoveEntry(
+			context.Background(),
+			"ws-1",
+			value,
+			"/tmp/output",
+		)
+		if !errors.Is(err, ErrRootDeleteForbidden) {
+			t.Fatalf("MoveEntry(%q) error = %v, want ErrRootDeleteForbidden", value, err)
+		}
+		if adapter.movePath != "" {
+			t.Fatalf("adapter move path = %q, want no call", adapter.movePath)
+		}
+	}
+}
+
 func TestServiceMoveEntryKeepsRelativeSourceUnderDefaultRootWhenTargetIsExternal(t *testing.T) {
 	adapter := &fakeAdapter{}
 	service := Service{

--- a/packages/workspace/files/tree.go
+++ b/packages/workspace/files/tree.go
@@ -13,12 +13,7 @@ func (s Service) GetDirectoryTreeSnapshot(
 	workspaceID string,
 	input DirectoryTreeSnapshotInput,
 ) (DirectoryTreeSnapshot, error) {
-	root, err := s.resolve(ctx, workspaceID)
-	if err != nil {
-		return DirectoryTreeSnapshot{}, err
-	}
-
-	logicalPath, err := NormalizeLogicalPathWithinRoot(input.Path, root.LogicalRoot)
+	root, logicalPath, err := s.resolvePath(ctx, workspaceID, input.Path)
 	if err != nil {
 		return DirectoryTreeSnapshot{}, err
 	}

--- a/services/tuttid/api/daemon_files.go
+++ b/services/tuttid/api/daemon_files.go
@@ -12,6 +12,10 @@ import (
 	"github.com/tutti-os/tutti/services/tuttid/apierrors"
 )
 
+type pathAwareWorkspaceFileResponseRootResolver interface {
+	ResolveWorkspaceRootForPath(context.Context, string, string) (workspacefiles.WorkspaceRoot, error)
+}
+
 func (api DaemonAPI) ListWorkspaceFileDirectory(
 	ctx context.Context,
 	request tuttigenerated.ListWorkspaceFileDirectoryRequestObject,
@@ -92,7 +96,7 @@ func (api DaemonAPI) CreateWorkspaceFileDirectory(
 	if err != nil {
 		return writeCreateWorkspaceFileDirectoryError(err), nil
 	}
-	root, err := api.workspaceFileResponseRoot(ctx, workspaceID)
+	root, err := api.workspaceFileResponseRootForPath(ctx, workspaceID, entry.Path.String())
 	if err != nil {
 		return writeCreateWorkspaceFileDirectoryError(err), nil
 	}
@@ -298,7 +302,7 @@ func (api DaemonAPI) CreateWorkspaceFile(
 	if err != nil {
 		return writeCreateWorkspaceFileError(err), nil
 	}
-	root, err := api.workspaceFileResponseRoot(ctx, workspaceID)
+	root, err := api.workspaceFileResponseRootForPath(ctx, workspaceID, entry.Path.String())
 	if err != nil {
 		return writeCreateWorkspaceFileError(err), nil
 	}
@@ -344,7 +348,7 @@ func (api DaemonAPI) ReadWorkspaceFilePreview(
 	if err != nil {
 		return writeReadWorkspaceFilePreviewError(err), nil
 	}
-	root, err := api.workspaceFileResponseRoot(ctx, workspaceID)
+	root, err := api.workspaceFileResponseRootForPath(ctx, workspaceID, content.Path.String())
 	if err != nil {
 		return writeReadWorkspaceFilePreviewError(err), nil
 	}
@@ -394,7 +398,7 @@ func (api DaemonAPI) WriteWorkspaceFileText(
 	if err != nil {
 		return writeWriteWorkspaceFileTextError(err), nil
 	}
-	root, err := api.workspaceFileResponseRoot(ctx, workspaceID)
+	root, err := api.workspaceFileResponseRootForPath(ctx, workspaceID, entry.Path.String())
 	if err != nil {
 		return writeWriteWorkspaceFileTextError(err), nil
 	}
@@ -499,7 +503,7 @@ func (api DaemonAPI) MoveWorkspaceFileEntry(
 	if err != nil {
 		return writeMoveWorkspaceFileEntryError(err), nil
 	}
-	root, err := api.workspaceFileResponseRoot(ctx, workspaceID)
+	root, err := api.workspaceFileResponseRootForPath(ctx, workspaceID, entry.Path.String())
 	if err != nil {
 		return writeMoveWorkspaceFileEntryError(err), nil
 	}
@@ -553,7 +557,7 @@ func (api DaemonAPI) RenameWorkspaceFileEntry(
 	if err != nil {
 		return writeRenameWorkspaceFileEntryError(err), nil
 	}
-	root, err := api.workspaceFileResponseRoot(ctx, workspaceID)
+	root, err := api.workspaceFileResponseRootForPath(ctx, workspaceID, entry.Path.String())
 	if err != nil {
 		return writeRenameWorkspaceFileEntryError(err), nil
 	}
@@ -602,7 +606,7 @@ func (api DaemonAPI) CopyWorkspaceFileEntry(
 	if err != nil {
 		return writeCopyWorkspaceFileEntryError(err), nil
 	}
-	root, err := api.workspaceFileResponseRoot(ctx, workspaceID)
+	root, err := api.workspaceFileResponseRootForPath(ctx, workspaceID, entry.Path.String())
 	if err != nil {
 		return writeCopyWorkspaceFileEntryError(err), nil
 	}
@@ -621,6 +625,22 @@ func (api DaemonAPI) workspaceFileResponseRoot(
 	workspaceID string,
 ) (workspacefiles.LogicalPath, error) {
 	root, err := api.FileService.ResolveWorkspaceRoot(ctx, workspaceID)
+	if err != nil {
+		return "", err
+	}
+	return workspacefiles.NormalizeLogicalRoot(root.LogicalRoot), nil
+}
+
+func (api DaemonAPI) workspaceFileResponseRootForPath(
+	ctx context.Context,
+	workspaceID string,
+	path string,
+) (workspacefiles.LogicalPath, error) {
+	pathResolver, ok := api.FileService.(pathAwareWorkspaceFileResponseRootResolver)
+	if !ok {
+		return api.workspaceFileResponseRoot(ctx, workspaceID)
+	}
+	root, err := pathResolver.ResolveWorkspaceRootForPath(ctx, workspaceID, path)
 	if err != nil {
 		return "", err
 	}

--- a/services/tuttid/api/daemon_test.go
+++ b/services/tuttid/api/daemon_test.go
@@ -47,8 +47,10 @@ type stubFileService struct {
 	listDirectoryFn        func(context.Context, string, workspacefiles.DirectoryListInput) (workspacefiles.DirectoryListing, error)
 	listRecentFn           func(context.Context, string, workspacefiles.RecentListInput) (workspacefiles.DirectoryListing, error)
 	moveEntryFn            func(context.Context, string, string, string) (workspacefiles.FileEntry, error)
+	renameEntryFn          func(context.Context, string, string, string) (workspacefiles.FileEntry, error)
 	preflightUploadFilesFn func(context.Context, string, workspacefiles.PreflightUploadInput) (workspacefiles.PreflightUploadResult, error)
 	resolveRootFn          func(context.Context, string) (workspacefiles.WorkspaceRoot, error)
+	resolveRootForPathFn   func(context.Context, string, string) (workspacefiles.WorkspaceRoot, error)
 	searchFn               func(context.Context, string, workspacefiles.SearchInput) (workspacefiles.SearchResult, error)
 	uploadFilesFn          func(context.Context, string, workspacefiles.UploadInput) (workspacefiles.UploadResult, error)
 }
@@ -347,6 +349,17 @@ func (s stubFileService) ResolveWorkspaceRoot(
 	return s.resolveRootFn(ctx, workspaceID)
 }
 
+func (s stubFileService) ResolveWorkspaceRootForPath(
+	ctx context.Context,
+	workspaceID string,
+	path string,
+) (workspacefiles.WorkspaceRoot, error) {
+	if s.resolveRootForPathFn == nil {
+		return s.ResolveWorkspaceRoot(ctx, workspaceID)
+	}
+	return s.resolveRootForPathFn(ctx, workspaceID, path)
+}
+
 func (s stubFileService) ListDirectory(
 	ctx context.Context,
 	workspaceID string,
@@ -450,12 +463,15 @@ func (s stubFileService) MoveEntry(
 	return s.moveEntryFn(ctx, workspaceID, path, targetDirectoryPath)
 }
 
-func (stubFileService) RenameEntry(
-	_ context.Context,
-	_ string,
+func (s stubFileService) RenameEntry(
+	ctx context.Context,
+	workspaceID string,
 	path string,
-	_ string,
+	newName string,
 ) (workspacefiles.FileEntry, error) {
+	if s.renameEntryFn != nil {
+		return s.renameEntryFn(ctx, workspaceID, path, newName)
+	}
 	return workspacefiles.FileEntry{Path: workspacefiles.LogicalPath(path)}, nil
 }
 
@@ -2431,6 +2447,67 @@ func TestDaemonAPIGeneratedRoutesReadWorkspaceFilePreview(t *testing.T) {
 	}
 }
 
+func TestDaemonAPIGeneratedRoutesReadWorkspaceFilePreviewUsesPathAwareRoot(t *testing.T) {
+	mux := http.NewServeMux()
+	RegisterRoutes(
+		mux,
+		NewRoutes(DaemonAPI{
+			FileService: stubFileService{
+				readFileFn: func(_ context.Context, workspaceID string, path string, _ int64) (workspacefiles.FileContent, error) {
+					if workspaceID != "ws-1" {
+						t.Fatalf("workspaceID = %q, want ws-1", workspaceID)
+					}
+					if path != "/tmp/report.md" {
+						t.Fatalf("path = %q, want /tmp/report.md", path)
+					}
+					return workspacefiles.FileContent{
+						Bytes:     []byte("hello"),
+						Name:      "report.md",
+						Path:      "/tmp/report.md",
+						SizeBytes: 5,
+					}, nil
+				},
+				resolveRootForPathFn: func(_ context.Context, workspaceID string, path string) (workspacefiles.WorkspaceRoot, error) {
+					if workspaceID != "ws-1" {
+						t.Fatalf("workspaceID = %q, want ws-1", workspaceID)
+					}
+					if path != "/tmp/report.md" {
+						t.Fatalf("root path = %q, want /tmp/report.md", path)
+					}
+					return workspacefiles.WorkspaceRoot{
+						WorkspaceID:  workspaceID,
+						LogicalRoot:  "/",
+						PhysicalRoot: "/",
+					}, nil
+				},
+			},
+		}),
+	)
+
+	request, err := http.NewRequest(
+		http.MethodGet,
+		"/v1/workspaces/ws-1/files/file/preview?path=%2Ftmp%2Freport.md",
+		nil,
+	)
+	if err != nil {
+		t.Fatalf("NewRequest() error = %v", err)
+	}
+	recorder := httptest.NewRecorder()
+	mux.ServeHTTP(recorder, request)
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d; body: %s", recorder.Code, http.StatusOK, recorder.Body.String())
+	}
+
+	var response tuttigenerated.WorkspaceFilePreviewResponse
+	decodeGeneratedRouteResponse(t, recorder, &response)
+	if response.Root != "/" {
+		t.Fatalf("root = %q, want /", response.Root)
+	}
+	if response.Path != "/tmp/report.md" {
+		t.Fatalf("path = %q, want /tmp/report.md", response.Path)
+	}
+}
+
 func TestDaemonAPIGeneratedRoutesWriteWorkspaceFileText(t *testing.T) {
 	mux := http.NewServeMux()
 	RegisterRoutes(
@@ -2477,6 +2554,66 @@ func TestDaemonAPIGeneratedRoutesWriteWorkspaceFileText(t *testing.T) {
 	}
 	if response.Entry.SizeBytes == nil || *response.Entry.SizeBytes != int64(len("updated")) {
 		t.Fatalf("entry size = %#v", response.Entry.SizeBytes)
+	}
+}
+
+func TestDaemonAPIGeneratedRoutesRenameWorkspaceFileEntryUsesPathAwareRoot(t *testing.T) {
+	mux := http.NewServeMux()
+	RegisterRoutes(
+		mux,
+		NewRoutes(DaemonAPI{
+			FileService: stubFileService{
+				renameEntryFn: func(_ context.Context, workspaceID string, path string, newName string) (workspacefiles.FileEntry, error) {
+					if workspaceID != "ws-1" {
+						t.Fatalf("workspaceID = %q, want ws-1", workspaceID)
+					}
+					if path != "/tmp/report.md" {
+						t.Fatalf("path = %q, want /tmp/report.md", path)
+					}
+					if newName != "renamed.md" {
+						t.Fatalf("newName = %q, want renamed.md", newName)
+					}
+					return workspacefiles.FileEntry{
+						Path: "/tmp/renamed.md",
+						Name: "renamed.md",
+						Kind: workspacefiles.EntryKindFile,
+					}, nil
+				},
+				resolveRootForPathFn: func(_ context.Context, workspaceID string, path string) (workspacefiles.WorkspaceRoot, error) {
+					if workspaceID != "ws-1" {
+						t.Fatalf("workspaceID = %q, want ws-1", workspaceID)
+					}
+					if path != "/tmp/renamed.md" {
+						t.Fatalf("root path = %q, want /tmp/renamed.md", path)
+					}
+					return workspacefiles.WorkspaceRoot{
+						WorkspaceID:  workspaceID,
+						LogicalRoot:  "/",
+						PhysicalRoot: "/",
+					}, nil
+				},
+			},
+		}),
+	)
+
+	recorder := performGeneratedRouteRequest(
+		t,
+		mux,
+		http.MethodPost,
+		"/v1/workspaces/ws-1/files/entry/rename",
+		map[string]any{"newName": "renamed.md", "path": "/tmp/report.md"},
+	)
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d; body: %s", recorder.Code, http.StatusOK, recorder.Body.String())
+	}
+
+	var response tuttigenerated.WorkspaceFileEntryResponse
+	decodeGeneratedRouteResponse(t, recorder, &response)
+	if response.Root != "/" {
+		t.Fatalf("root = %q, want /", response.Root)
+	}
+	if response.Entry.Path != "/tmp/renamed.md" {
+		t.Fatalf("entry path = %q, want /tmp/renamed.md", response.Entry.Path)
 	}
 }
 

--- a/services/tuttid/data/workspace/local_files_test.go
+++ b/services/tuttid/data/workspace/local_files_test.go
@@ -49,6 +49,52 @@ func TestLocalFilesAdapterListsLogicalChildren(t *testing.T) {
 	}
 }
 
+func TestLocalFilesAdapterReadsExternalAbsolutePathsFromFilesystemRoot(t *testing.T) {
+	t.Parallel()
+
+	targetDir := t.TempDir()
+	targetPath := filepath.Join(targetDir, "test-note.md")
+	if err := os.WriteFile(targetPath, []byte("# Test note\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	root := workspacefiles.WorkspaceRoot{
+		WorkspaceID:  "ws-1",
+		LogicalRoot:  filepath.ToSlash(string(filepath.Separator)),
+		PhysicalRoot: string(filepath.Separator),
+	}
+	adapter := LocalFilesAdapter{}
+	listing, err := adapter.ListDirectory(
+		context.Background(),
+		root,
+		workspacefiles.LogicalPath(filepath.ToSlash(targetDir)),
+		false,
+	)
+	if err != nil {
+		t.Fatalf("ListDirectory() error = %v", err)
+	}
+
+	if listing.DirectoryPath.String() != filepath.ToSlash(targetDir) {
+		t.Fatalf("directoryPath = %q, want %q", listing.DirectoryPath, filepath.ToSlash(targetDir))
+	}
+	if len(listing.Entries) != 1 || listing.Entries[0].Path.String() != filepath.ToSlash(targetPath) {
+		t.Fatalf("entries = %#v, want test note", listing.Entries)
+	}
+
+	content, err := adapter.ReadFile(
+		context.Background(),
+		root,
+		workspacefiles.LogicalPath(filepath.ToSlash(targetPath)),
+		workspacefiles.DefaultReadFileMaxBytes,
+	)
+	if err != nil {
+		t.Fatalf("ReadFile() error = %v", err)
+	}
+	if string(content.Bytes) != "# Test note\n" {
+		t.Fatalf("content = %q", string(content.Bytes))
+	}
+}
+
 func TestLocalFilesAdapterRejectsSymlinkEscape(t *testing.T) {
 	t.Parallel()
 

--- a/services/tuttid/service/workspace/files.go
+++ b/services/tuttid/service/workspace/files.go
@@ -167,6 +167,43 @@ func (FileService) ResolveWorkspaceRoot(
 	}, nil
 }
 
+func (s FileService) ResolveWorkspaceRootForPath(
+	ctx context.Context,
+	workspaceID string,
+	path string,
+) (workspacefiles.WorkspaceRoot, error) {
+	root, err := s.ResolveWorkspaceRoot(ctx, workspaceID)
+	if err != nil {
+		return workspacefiles.WorkspaceRoot{}, err
+	}
+	trimmedPath := strings.TrimSpace(path)
+	if trimmedPath == "" || !filepath.IsAbs(trimmedPath) {
+		return root, nil
+	}
+	absolutePath, err := filepath.Abs(trimmedPath)
+	if err != nil {
+		return workspacefiles.WorkspaceRoot{}, err
+	}
+	if workspacefiles.IsPhysicalPathWithinRoot(root.PhysicalRoot, absolutePath) {
+		return root, nil
+	}
+
+	physicalRoot := filesystemRootForPath(absolutePath)
+	return workspacefiles.WorkspaceRoot{
+		WorkspaceID:  root.WorkspaceID,
+		LogicalRoot:  filepath.ToSlash(physicalRoot),
+		PhysicalRoot: physicalRoot,
+	}, nil
+}
+
+func filesystemRootForPath(path string) string {
+	volume := filepath.VolumeName(path)
+	if volume != "" {
+		return filepath.Clean(volume + string(filepath.Separator))
+	}
+	return string(filepath.Separator)
+}
+
 func (s FileService) domainService() workspacefiles.Service {
 	return workspacefiles.Service{
 		Resolver: s,

--- a/services/tuttid/service/workspace/files.go
+++ b/services/tuttid/service/workspace/files.go
@@ -3,7 +3,9 @@ package workspace
 import (
 	"context"
 	"errors"
+	"fmt"
 	"os"
+	pathpkg "path"
 	"path/filepath"
 	"strings"
 	"time"
@@ -177,6 +179,9 @@ func (s FileService) ResolveWorkspaceRootForPath(
 		return workspacefiles.WorkspaceRoot{}, err
 	}
 	trimmedPath := strings.TrimSpace(path)
+	if isUnsupportedSpecialWorkspaceFilePath(trimmedPath) {
+		return workspacefiles.WorkspaceRoot{}, fmt.Errorf("%w: unsupported special path %q", workspacefiles.ErrInvalidPath, path)
+	}
 	if trimmedPath == "" || !filepath.IsAbs(trimmedPath) {
 		return root, nil
 	}
@@ -202,6 +207,25 @@ func filesystemRootForPath(path string) string {
 		return filepath.Clean(volume + string(filepath.Separator))
 	}
 	return string(filepath.Separator)
+}
+
+func isUnsupportedSpecialWorkspaceFilePath(value string) bool {
+	normalized := strings.ReplaceAll(strings.TrimSpace(value), "\\", "/")
+	if normalized == "" {
+		return false
+	}
+	comparisonPath := pathpkg.Clean(normalized)
+	if comparisonPath == "/dev/null" {
+		return true
+	}
+	for _, segment := range strings.Split(comparisonPath, "/") {
+		trimmedSegment := strings.TrimRight(strings.TrimSpace(segment), ". ")
+		deviceName := strings.ToUpper(strings.SplitN(trimmedSegment, ".", 2)[0])
+		if deviceName == "NUL" {
+			return true
+		}
+	}
+	return false
 }
 
 func (s FileService) domainService() workspacefiles.Service {

--- a/services/tuttid/service/workspace/files_test.go
+++ b/services/tuttid/service/workspace/files_test.go
@@ -57,6 +57,85 @@ func TestFileServiceListDirectoryAcceptsHomeAbsolutePaths(t *testing.T) {
 	}
 }
 
+func TestFileServiceListDirectoryAcceptsExternalAbsolutePaths(t *testing.T) {
+	homeDir := t.TempDir()
+	t.Setenv("HOME", homeDir)
+	adapter := &fileSearchDeadlineAdapter{}
+	service := FileService{Adapter: adapter}
+	targetPath := filepath.Join(t.TempDir(), "codex-presentations")
+
+	_, err := service.ListDirectory(context.Background(), "ws-1", workspacefiles.DirectoryListInput{
+		IncludeHidden: true,
+		Path:          targetPath,
+	})
+	if err != nil {
+		t.Fatalf("ListDirectory() error = %v", err)
+	}
+
+	wantRoot := filesystemRootForPath(targetPath)
+	if adapter.listRoot.LogicalRoot != filepath.ToSlash(wantRoot) {
+		t.Fatalf("logical root = %q, want %q", adapter.listRoot.LogicalRoot, filepath.ToSlash(wantRoot))
+	}
+	if adapter.listRoot.PhysicalRoot != wantRoot {
+		t.Fatalf("physical root = %q, want %q", adapter.listRoot.PhysicalRoot, wantRoot)
+	}
+	if adapter.listPath.String() != filepath.ToSlash(filepath.Clean(targetPath)) {
+		t.Fatalf("list path = %q, want %q", adapter.listPath, filepath.ToSlash(filepath.Clean(targetPath)))
+	}
+	if !adapter.listIncludeHidden {
+		t.Fatal("include hidden = false, want true")
+	}
+}
+
+func TestFileServiceRenameEntryAcceptsExternalAbsolutePaths(t *testing.T) {
+	homeDir := t.TempDir()
+	t.Setenv("HOME", homeDir)
+	adapter := &fileSearchDeadlineAdapter{}
+	service := FileService{Adapter: adapter}
+	targetPath := filepath.Join(t.TempDir(), "report.txt")
+
+	_, err := service.RenameEntry(context.Background(), "ws-1", targetPath, "renamed.txt")
+	if err != nil {
+		t.Fatalf("RenameEntry() error = %v", err)
+	}
+
+	wantRoot := filesystemRootForPath(targetPath)
+	if adapter.renameRoot.PhysicalRoot != wantRoot {
+		t.Fatalf("rename physical root = %q, want %q", adapter.renameRoot.PhysicalRoot, wantRoot)
+	}
+	if adapter.renamePath.String() != filepath.ToSlash(filepath.Clean(targetPath)) {
+		t.Fatalf("rename path = %q, want %q", adapter.renamePath, filepath.ToSlash(filepath.Clean(targetPath)))
+	}
+	if adapter.renameName != "renamed.txt" {
+		t.Fatalf("rename name = %q", adapter.renameName)
+	}
+}
+
+func TestFileServiceMoveEntryUsesExternalRootWhenTargetIsExternal(t *testing.T) {
+	homeDir := t.TempDir()
+	t.Setenv("HOME", homeDir)
+	adapter := &fileSearchDeadlineAdapter{}
+	service := FileService{Adapter: adapter}
+	sourcePath := filepath.Join(homeDir, "project", "report.txt")
+	targetDirectoryPath := filepath.Join(t.TempDir(), "output")
+
+	_, err := service.MoveEntry(context.Background(), "ws-1", sourcePath, targetDirectoryPath)
+	if err != nil {
+		t.Fatalf("MoveEntry() error = %v", err)
+	}
+
+	wantRoot := filesystemRootForPath(targetDirectoryPath)
+	if adapter.moveRoot.PhysicalRoot != wantRoot {
+		t.Fatalf("move physical root = %q, want %q", adapter.moveRoot.PhysicalRoot, wantRoot)
+	}
+	if adapter.movePath.String() != filepath.ToSlash(filepath.Clean(sourcePath)) {
+		t.Fatalf("move path = %q, want %q", adapter.movePath, filepath.ToSlash(filepath.Clean(sourcePath)))
+	}
+	if adapter.moveTargetDirectory.String() != filepath.ToSlash(filepath.Clean(targetDirectoryPath)) {
+		t.Fatalf("move target = %q, want %q", adapter.moveTargetDirectory, filepath.ToSlash(filepath.Clean(targetDirectoryPath)))
+	}
+}
+
 func TestFileServiceSearchSetsDefaultDeadline(t *testing.T) {
 	homeDir := t.TempDir()
 	t.Setenv("HOME", homeDir)
@@ -103,10 +182,16 @@ func TestFileServiceSearchPreservesExplicitDeadline(t *testing.T) {
 }
 
 type fileSearchDeadlineAdapter struct {
-	input             workspacefiles.SearchInput
-	listIncludeHidden bool
-	listPath          workspacefiles.LogicalPath
-	listRoot          workspacefiles.WorkspaceRoot
+	input               workspacefiles.SearchInput
+	listIncludeHidden   bool
+	listPath            workspacefiles.LogicalPath
+	listRoot            workspacefiles.WorkspaceRoot
+	moveRoot            workspacefiles.WorkspaceRoot
+	movePath            workspacefiles.LogicalPath
+	moveTargetDirectory workspacefiles.LogicalPath
+	renameRoot          workspacefiles.WorkspaceRoot
+	renamePath          workspacefiles.LogicalPath
+	renameName          string
 }
 
 func (a *fileSearchDeadlineAdapter) Search(
@@ -164,22 +249,28 @@ func (*fileSearchDeadlineAdapter) DeleteEntry(
 	return nil
 }
 
-func (*fileSearchDeadlineAdapter) MoveEntry(
-	context.Context,
-	workspacefiles.WorkspaceRoot,
-	workspacefiles.LogicalPath,
-	workspacefiles.LogicalPath,
+func (a *fileSearchDeadlineAdapter) MoveEntry(
+	_ context.Context,
+	workspaceRoot workspacefiles.WorkspaceRoot,
+	logicalPath workspacefiles.LogicalPath,
+	targetDirectoryPath workspacefiles.LogicalPath,
 ) (workspacefiles.FileEntry, error) {
-	return workspacefiles.FileEntry{}, nil
+	a.moveRoot = workspaceRoot
+	a.movePath = logicalPath
+	a.moveTargetDirectory = targetDirectoryPath
+	return workspacefiles.FileEntry{Path: targetDirectoryPath, Kind: workspacefiles.EntryKindFile}, nil
 }
 
-func (*fileSearchDeadlineAdapter) RenameEntry(
-	context.Context,
-	workspacefiles.WorkspaceRoot,
-	workspacefiles.LogicalPath,
-	string,
+func (a *fileSearchDeadlineAdapter) RenameEntry(
+	_ context.Context,
+	workspaceRoot workspacefiles.WorkspaceRoot,
+	logicalPath workspacefiles.LogicalPath,
+	newName string,
 ) (workspacefiles.FileEntry, error) {
-	return workspacefiles.FileEntry{}, nil
+	a.renameRoot = workspaceRoot
+	a.renamePath = logicalPath
+	a.renameName = newName
+	return workspacefiles.FileEntry{Path: logicalPath, Kind: workspacefiles.EntryKindFile}, nil
 }
 
 func (*fileSearchDeadlineAdapter) CopyEntry(

--- a/services/tuttid/service/workspace/files_test.go
+++ b/services/tuttid/service/workspace/files_test.go
@@ -2,6 +2,7 @@ package workspace
 
 import (
 	"context"
+	"errors"
 	"path/filepath"
 	"testing"
 	"time"
@@ -84,6 +85,26 @@ func TestFileServiceListDirectoryAcceptsExternalAbsolutePaths(t *testing.T) {
 	}
 	if !adapter.listIncludeHidden {
 		t.Fatal("include hidden = false, want true")
+	}
+}
+
+func TestFileServiceResolveWorkspaceRootForPathRejectsUnsupportedSpecialPaths(t *testing.T) {
+	homeDir := t.TempDir()
+	t.Setenv("HOME", homeDir)
+	service := FileService{}
+
+	for _, path := range []string{
+		"/dev/null",
+		"/dev/./null",
+		"/dev//null",
+		"NUL",
+		"NUL.txt",
+		"C:\\tmp\\NUL",
+	} {
+		_, err := service.ResolveWorkspaceRootForPath(context.Background(), "ws-1", path)
+		if !errors.Is(err, workspacefiles.ErrInvalidPath) {
+			t.Fatalf("ResolveWorkspaceRootForPath(%q) error = %v, want ErrInvalidPath", path, err)
+		}
 	}
 }
 


### PR DESCRIPTION
## Summary
- Allow workspace file reveal and daemon file operations to resolve explicit absolute paths outside the workspace root, including agent-generated files under system temp directories.
- Keep unsupported special targets such as /dev/null and Windows NUL filtered out.
- Update desktop, agent GUI, file manager, daemon/workspace file tests, and troubleshooting guidance.

## Testing
- git diff --check
- pnpm check:changed --tail-lines 80 (initial run hit a transient parallel golangci-lint lock)
- pnpm check:changed -- --failed-only
- pnpm check:full
- git push pre-push check:full


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Workspace files can now open, preview, reveal, move, rename, and list valid files located outside the default workspace when provided as absolute local paths.
  * File links and launch/reveal flows now support external absolute paths (including common temp/system directories) with correct parent-folder handling.

* **Bug Fixes**
  * Improved resolution so external paths map to the correct directory/file location instead of defaulting to the workspace home root.
  * Rejected unsupported special/device-like paths (e.g., `/dev/null`, `NUL` variants, UNC-like inputs) to prevent invalid launches.

* **Documentation**
  * Added troubleshooting guidance for agent-generated temp files not revealing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->