### PR TITLE
fix(agent-gui): prioritize local asset preview over workspace file links

### DIFF
--- a/packages/agent/gui/actions/workspaceLinkActions.spec.ts
+++ b/packages/agent/gui/actions/workspaceLinkActions.spec.ts
@@ -222,6 +222,15 @@ describe("resolveWorkspaceFileLinkAction", () => {
     });
   });
 
+  it("rejects staged local asset paths from workspace file candidates", () => {
+    expect(
+      resolveWorkspaceFilePathCandidate({
+        path: "/var/cache/tsh/local-assets/room-1/user-1/photo.png",
+        workspaceRoot: "/workspace/project-a"
+      })
+    ).toBeNull();
+  });
+
   it("resolves relative paths through the same workspace file candidate contract", () => {
     expect(
       resolveWorkspaceFilePathCandidate({

--- a/packages/agent/gui/actions/workspaceLinkActions.ts
+++ b/packages/agent/gui/actions/workspaceLinkActions.ts
@@ -141,6 +141,9 @@ export function resolveWorkspaceFilePathCandidate({
   if (isUnsupportedSpecialWorkspaceFilePath(normalizedPath)) {
     return null;
   }
+  if (isStagedLocalAssetPath(normalizedPath)) {
+    return null;
+  }
   if (
     isAbsoluteLocalPath(normalizedPath) &&
     (isDirectAgentGeneratedMediaPath(normalizedPath) ||
@@ -336,14 +339,14 @@ export function resolveWorkspaceLinkAction({
 }: ResolveWorkspaceLinkActionInput): WorkspaceLinkAction | null {
   return (
     resolveWorkspaceMentionLinkAction({ href, source }) ??
+    resolveLocalAssetPreviewLinkAction({
+      path: href,
+      source
+    }) ??
     resolveWorkspaceFileLinkAction({
       path: href,
       workspaceRoot,
       basePath,
-      source
-    }) ??
-    resolveLocalAssetPreviewLinkAction({
-      path: href,
       source
     }) ??
     resolveWorkspaceUrlLinkAction({ url: href, source })
@@ -464,6 +467,10 @@ function isInsideOrEqual(path: string, root: string): boolean {
     comparison.path === comparison.root ||
     comparison.path.startsWith(`${comparison.root}/`)
   );
+}
+
+function isStagedLocalAssetPath(path: string): boolean {
+  return path !== LOCAL_ASSET_ROOT && isInsideOrEqual(path, LOCAL_ASSET_ROOT);
 }
 
 export function isDirectAgentGeneratedMediaPath(path: string): boolean {

--- a/services/tuttid/service/agentstatus/network_probe_test.go
+++ b/services/tuttid/service/agentstatus/network_probe_test.go
@@ -18,15 +18,18 @@ func (f networkRoundTripFunc) RoundTrip(r *http.Request) (*http.Response, error)
 	return f(r)
 }
 
-func networkProbeService(rt networkRoundTripFunc) Service {
+func networkProbeService(t *testing.T, rt networkRoundTripFunc) Service {
+	t.Helper()
+	home := t.TempDir()
 	return Service{
 		Environ:    func() []string { return nil },
 		HTTPClient: &http.Client{Transport: rt},
+		HomeDir:    func() (string, error) { return home, nil },
 	}
 }
 
 func TestProbeRegistryReachableReturnsOfficial(t *testing.T) {
-	svc := networkProbeService(func(r *http.Request) (*http.Response, error) {
+	svc := networkProbeService(t, func(r *http.Request) (*http.Response, error) {
 		if r.Method != http.MethodHead {
 			t.Fatalf("expected HEAD, got %s", r.Method)
 		}
@@ -40,7 +43,7 @@ func TestProbeRegistryReachableReturnsOfficial(t *testing.T) {
 
 func TestProbeRegistryReachableEvenOnHTTPError(t *testing.T) {
 	// A 405/404 still proves the host was reached — connectivity is fine.
-	svc := networkProbeService(func(*http.Request) (*http.Response, error) {
+	svc := networkProbeService(t, func(*http.Request) (*http.Response, error) {
 		return &http.Response{StatusCode: http.StatusMethodNotAllowed, Body: http.NoBody}, nil
 	})
 	if got := svc.probeRegistry(context.Background()); !got.Reachable {
@@ -49,7 +52,7 @@ func TestProbeRegistryReachableEvenOnHTTPError(t *testing.T) {
 }
 
 func TestProbeRegistryUnreachableReportsNetworkError(t *testing.T) {
-	svc := networkProbeService(func(*http.Request) (*http.Response, error) {
+	svc := networkProbeService(t, func(*http.Request) (*http.Response, error) {
 		return nil, errors.New("dial tcp: connect: connection refused")
 	})
 	got := svc.probeRegistry(context.Background())
@@ -62,7 +65,7 @@ func TestProbeRegistryUnreachableReportsNetworkError(t *testing.T) {
 }
 
 func TestProbeRegistryFallsBackToMirror(t *testing.T) {
-	svc := networkProbeService(func(r *http.Request) (*http.Response, error) {
+	svc := networkProbeService(t, func(r *http.Request) (*http.Response, error) {
 		if strings.Contains(r.URL.Host, "registry.npmjs.org") {
 			return nil, errors.New("connection refused")
 		}
@@ -76,7 +79,7 @@ func TestProbeRegistryFallsBackToMirror(t *testing.T) {
 
 func TestProbeProviderAPIChecksCodexChatGPTEndpointFirst(t *testing.T) {
 	var probed string
-	svc := networkProbeService(func(r *http.Request) (*http.Response, error) {
+	svc := networkProbeService(t, func(r *http.Request) (*http.Response, error) {
 		probed = r.URL.String()
 		return &http.Response{StatusCode: http.StatusOK, Body: http.NoBody}, nil
 	})
@@ -92,7 +95,7 @@ func TestProbeProviderAPIChecksCodexChatGPTEndpointFirst(t *testing.T) {
 
 func TestProbeProviderAPICodexReachableViaOpenAIWhenChatGPTBlocked(t *testing.T) {
 	// chatgpt.com blocked but api.openai.com reachable → still reachable (either).
-	svc := networkProbeService(func(r *http.Request) (*http.Response, error) {
+	svc := networkProbeService(t, func(r *http.Request) (*http.Response, error) {
 		if strings.Contains(r.URL.Host, "chatgpt.com") {
 			return nil, errors.New("connection refused")
 		}
@@ -105,7 +108,7 @@ func TestProbeProviderAPICodexReachableViaOpenAIWhenChatGPTBlocked(t *testing.T)
 }
 
 func TestProbeProviderAPIUnreachableReportsNetworkError(t *testing.T) {
-	svc := networkProbeService(func(*http.Request) (*http.Response, error) {
+	svc := networkProbeService(t, func(*http.Request) (*http.Response, error) {
 		return nil, errors.New("getaddrinfo ENOTFOUND api.anthropic.com")
 	})
 	got := svc.probeProviderAPI(context.Background(), agentprovider.ClaudeCode)
@@ -115,7 +118,7 @@ func TestProbeProviderAPIUnreachableReportsNetworkError(t *testing.T) {
 }
 
 func TestProbeProviderAPISkippedForUnknownProvider(t *testing.T) {
-	svc := networkProbeService(func(*http.Request) (*http.Response, error) {
+	svc := networkProbeService(t, func(*http.Request) (*http.Response, error) {
 		t.Fatal("should not probe a provider with no known endpoint")
 		return nil, nil
 	})
@@ -125,7 +128,7 @@ func TestProbeProviderAPISkippedForUnknownProvider(t *testing.T) {
 }
 
 func TestProbeProviderAPISkippedWhenCustomAPIKeyConfigured(t *testing.T) {
-	svc := networkProbeService(func(*http.Request) (*http.Response, error) {
+	svc := networkProbeService(t, func(*http.Request) (*http.Response, error) {
 		t.Fatal("should not probe the default endpoint when a custom key is set")
 		return nil, nil
 	})


### PR DESCRIPTION
## Summary

- 将 `/var/cache/tsh/local-assets/...` 从 `resolveWorkspaceFilePathCandidate` 中排除，避免被 `8ddc9e2d` 引入的外部绝对路径解析误匹配
- 调整 `resolveWorkspaceLinkAction` 顺序：local-asset preview 优先于 `open-workspace-file`
- 附带修复 `network_probe_test` 在开发者机器存在 `~/.claude` 配置时被跳过导致 pre-push 失败

## Why

`ceb1aa22` 新增的 local-asset preview 与 `fix(workspace-files): reveal external absolute paths` 在主干上冲突：消息流图片链接被解析为 `open-workspace-file`，tsh host 打开 Files 面板而非 preview。主干单测 `opens staged local asset links with the preview action` 已失败。

## Risks / affected surfaces

- `@tutti-os/agent-gui` link action 解析（Agent GUI、Message Center markdown 锚点）
- 外部绝对路径 reveal 行为（非 local-asset 路径不受影响）

## Test plan

- [x] `pnpm test -- actions/workspaceLinkActions.spec.ts`
- [x] `go test ./services/tuttid/service/agentstatus -run TestProbeProviderAPIUnreachableReportsNetworkError`
- [x] pre-push validation suite
- [ ] tsh 联调：消息流点击 local-asset 图片 → workbench preview-only 预览


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved link resolution so staged local asset paths are no longer treated as workspace files.
  * Refined fallback handling for links and mentions to better resolve local asset previews before file links.

* **Tests**
  * Added coverage for rejecting staged local asset paths during workspace file resolution.
  * Updated service tests to use isolated temporary home directories for more reliable runs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->