### PR TITLE
fix(agent): repair Codex platform package detection

### DIFF
--- a/services/tuttid/service/agentstatus/codex_platform.go
+++ b/services/tuttid/service/agentstatus/codex_platform.go
@@ -35,29 +35,74 @@ func codexNpmPlatformDir(goos, goarch string) (string, bool) {
 	return "codex-" + nodeOS + "-" + nodeArch, true
 }
 
+func codexPlatformTargetTriple(goos, goarch string) (string, bool) {
+	switch goos {
+	case "darwin":
+		switch goarch {
+		case "arm64":
+			return "aarch64-apple-darwin", true
+		case "amd64":
+			return "x86_64-apple-darwin", true
+		}
+	case "linux":
+		switch goarch {
+		case "arm64":
+			return "aarch64-unknown-linux-musl", true
+		case "amd64":
+			return "x86_64-unknown-linux-musl", true
+		}
+	case "windows":
+		switch goarch {
+		case "arm64":
+			return "aarch64-pc-windows-msvc", true
+		case "amd64":
+			return "x86_64-pc-windows-msvc", true
+		}
+	}
+	return "", false
+}
+
 // codexPlatformBinaryPath returns the absolute path to the platform-specific
 // codex binary inside an installed @openai/codex package directory.
 func codexPlatformBinaryPath(codexPkgDir, goos, goarch string) (string, bool) {
-	dir, ok := codexNpmPlatformDir(goos, goarch)
-	if !ok {
+	paths := codexPlatformBinaryCandidatePaths(codexPkgDir, goos, goarch)
+	if len(paths) == 0 {
 		return "", false
 	}
+	return paths[0], true
+}
+
+func codexPlatformBinaryCandidatePaths(codexPkgDir, goos, goarch string) []string {
 	binName := "codex"
 	if goos == "windows" {
 		binName = "codex.exe"
 	}
-	return filepath.Join(codexPkgDir, "node_modules", "@openai", dir, binName), true
+	dir, dirOK := codexNpmPlatformDir(goos, goarch)
+	if !dirOK {
+		return nil
+	}
+	paths := []string{}
+	if targetTriple, ok := codexPlatformTargetTriple(goos, goarch); ok {
+		paths = append(paths, filepath.Join(codexPkgDir, "node_modules", "@openai", dir, "vendor", targetTriple, "bin", binName))
+	}
+	paths = append(paths, filepath.Join(codexPkgDir, "node_modules", "@openai", dir, binName))
+	return paths
 }
 
 // codexPlatformBinaryComplete reports whether the platform-specific codex
 // binary is present and executable inside the given @openai/codex package
 // directory. It returns the resolved binary path alongside the verdict.
 func (s Service) codexPlatformBinaryComplete(codexPkgDir, goos, goarch string) (string, bool) {
-	path, ok := codexPlatformBinaryPath(codexPkgDir, goos, goarch)
-	if !ok {
+	paths := codexPlatformBinaryCandidatePaths(codexPkgDir, goos, goarch)
+	if len(paths) == 0 {
 		return "", false
 	}
-	return path, s.executableFile(path)
+	for _, path := range paths {
+		if s.executableFile(path) {
+			return path, true
+		}
+	}
+	return paths[0], false
 }
 
 func codexPackageDirForBinary(binaryPath string) string {

--- a/services/tuttid/service/agentstatus/codex_platform_test.go
+++ b/services/tuttid/service/agentstatus/codex_platform_test.go
@@ -31,12 +31,12 @@ func TestCodexNpmPlatformDir(t *testing.T) {
 func TestCodexPlatformBinaryPath(t *testing.T) {
 	pkg := "/home/u/.npm/lib/node_modules/@openai/codex"
 	got, ok := codexPlatformBinaryPath(pkg, "darwin", "arm64")
-	want := filepath.Join(pkg, "node_modules", "@openai", "codex-darwin-arm64", "codex")
+	want := filepath.Join(pkg, "node_modules", "@openai", "codex-darwin-arm64", "vendor", "aarch64-apple-darwin", "bin", "codex")
 	if !ok || got != want {
 		t.Fatalf("codexPlatformBinaryPath darwin/arm64 = (%q,%v), want (%q,true)", got, ok, want)
 	}
 	winGot, ok := codexPlatformBinaryPath(pkg, "windows", "amd64")
-	winWant := filepath.Join(pkg, "node_modules", "@openai", "codex-win32-x64", "codex.exe")
+	winWant := filepath.Join(pkg, "node_modules", "@openai", "codex-win32-x64", "vendor", "x86_64-pc-windows-msvc", "bin", "codex.exe")
 	if !ok || winGot != winWant {
 		t.Fatalf("codexPlatformBinaryPath windows = (%q,%v), want (%q,true)", winGot, ok, winWant)
 	}
@@ -47,7 +47,7 @@ func TestCodexPlatformBinaryPath(t *testing.T) {
 
 func TestServiceCodexPlatformBinaryComplete(t *testing.T) {
 	pkg := t.TempDir()
-	binPath := filepath.Join(pkg, "node_modules", "@openai", "codex-darwin-arm64", "codex")
+	binPath := filepath.Join(pkg, "node_modules", "@openai", "codex-darwin-arm64", "vendor", "aarch64-apple-darwin", "bin", "codex")
 
 	svc := Service{IsExecutableFile: func(p string) bool {
 		info, err := os.Stat(p)
@@ -77,5 +77,25 @@ func TestServiceCodexPlatformBinaryComplete(t *testing.T) {
 	path, complete := svc.codexPlatformBinaryComplete(pkg, "darwin", "arm64")
 	if !complete || path != binPath {
 		t.Fatalf("expected complete with path=%q, got (%q,%v)", binPath, path, complete)
+	}
+}
+
+func TestServiceCodexPlatformBinaryCompleteAcceptsLegacyBinaryPath(t *testing.T) {
+	pkg := t.TempDir()
+	legacyBinPath := filepath.Join(pkg, "node_modules", "@openai", "codex-darwin-arm64", "codex")
+	if err := os.MkdirAll(filepath.Dir(legacyBinPath), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(legacyBinPath, []byte("bin"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	svc := Service{IsExecutableFile: func(p string) bool {
+		info, err := os.Stat(p)
+		return err == nil && !info.IsDir() && info.Mode().Perm()&0o111 != 0
+	}}
+	path, complete := svc.codexPlatformBinaryComplete(pkg, "darwin", "arm64")
+	if !complete || path != legacyBinPath {
+		t.Fatalf("expected complete with legacy path=%q, got (%q,%v)", legacyBinPath, path, complete)
 	}
 }

--- a/services/tuttid/service/agentstatus/installer.go
+++ b/services/tuttid/service/agentstatus/installer.go
@@ -20,6 +20,7 @@ import (
 	"strings"
 
 	"github.com/tutti-os/tutti/packages/agentactivity/daemon/runtimecmd"
+	"github.com/tutti-os/tutti/services/tuttid/biz/agentprovider"
 	managedruntime "github.com/tutti-os/tutti/services/tuttid/service/managedruntime"
 )
 
@@ -173,7 +174,7 @@ func (s Service) installMissingProviderRuntime(
 	attemptedCLI := false
 	attemptedAdapter := false
 	for {
-		installer, missing, installTarget := nextMissingInstaller(spec, current)
+		installer, missing, installTarget := s.nextMissingInstaller(spec, current)
 		if !missing {
 			return summary, current, nil
 		}
@@ -264,8 +265,14 @@ func (s Service) installMissingProviderRuntime(
 	}
 }
 
-func nextMissingInstaller(spec ProviderSpec, runtime providerRuntimeResolution) (InstallerSpec, bool, string) {
+func (s Service) nextMissingInstaller(spec ProviderSpec, runtime providerRuntimeResolution) (InstallerSpec, bool, string) {
 	if strings.TrimSpace(runtime.CLIPath) == "" {
+		if spec.Install.Kind == "" {
+			return InstallerSpec{}, false, ""
+		}
+		return spec.Install, true, "cli"
+	}
+	if s.providerCLIRequiresInstall(spec, runtime) {
 		if spec.Install.Kind == "" {
 			return InstallerSpec{}, false, ""
 		}
@@ -294,6 +301,16 @@ func nextMissingInstaller(spec ProviderSpec, runtime providerRuntimeResolution) 
 		}
 	}
 	return InstallerSpec{}, false, ""
+}
+
+func (s Service) providerCLIRequiresInstall(spec ProviderSpec, runtime providerRuntimeResolution) bool {
+	if spec.Provider != agentprovider.Codex {
+		return false
+	}
+	if !s.codexPlatformBinaryOK(runtime.CLIPath) {
+		return true
+	}
+	return !codexVersionMeetsMinimum(s.cliVersion(context.Background(), runtime.CLIPath))
 }
 
 func adapterPackageRequirementSatisfied(requirement AdapterPackageRequirement, version string) bool {

--- a/services/tuttid/service/agentstatus/service_test.go
+++ b/services/tuttid/service/agentstatus/service_test.go
@@ -358,6 +358,58 @@ func TestServiceProbeReportsCodexPlatformPackageIncomplete(t *testing.T) {
 	assertProviderCheck(t, result.Checks, "platform_binary", false)
 }
 
+func TestServiceRunActionReinstallsCodexWhenPlatformPackageIncomplete(t *testing.T) {
+	home := t.TempDir()
+	binDir := filepath.Join(home, "bin")
+	pkgDir := filepath.Join(home, "lib", "node_modules", "@openai", "codex")
+	writePackageManifest(t, pkgDir, "@openai/codex", MinSupportedCodexVersion)
+	codexPath := filepath.Join(pkgDir, "bin", "codex")
+	writeExecutable(t, codexPath, "#!/bin/sh\nif [ \"$1\" = \"--version\" ]; then echo 'codex "+MinSupportedCodexVersion+"'; exit 0; fi\nsleep 5\n")
+	if err := os.MkdirAll(binDir, 0o755); err != nil {
+		t.Fatalf("mkdir bin dir: %v", err)
+	}
+	if err := os.Symlink(codexPath, filepath.Join(binDir, "codex")); err != nil {
+		t.Fatalf("symlink codex: %v", err)
+	}
+	platformBinary, ok := codexPlatformBinaryPath(pkgDir, runtime.GOOS, runtime.GOARCH)
+	if !ok {
+		t.Skipf("codex platform package is unsupported for %s/%s", runtime.GOOS, runtime.GOARCH)
+	}
+
+	service := probeTestService(home)
+	service.Environ = func() []string {
+		return []string{"PATH=" + binDir, agentNPMRegistryEnv + "=https://registry.example.test"}
+	}
+	service.IsExecutableFile = isTestExecutable
+	service.RunAuthStatusCommand = func(context.Context, ProviderSpec, string) (AuthInfo, bool) {
+		return AuthInfo{Status: AuthAuthenticated}, true
+	}
+	var command InstallCommandInput
+	service.InstallCommand = func(_ context.Context, input InstallCommandInput) (InstallCommandResult, error) {
+		command = input
+		writeExecutable(t, platformBinary, "#!/bin/sh\nexit 0\n")
+		return InstallCommandResult{ExitCode: 0, Stdout: "installed"}, nil
+	}
+
+	result, err := service.RunAction(context.Background(), RunActionInput{
+		Provider: "codex",
+		ActionID: ActionInstall,
+	})
+	if err != nil {
+		t.Fatalf("RunAction() error = %v", err)
+	}
+	if result.Status != RunActionCompleted {
+		t.Fatalf("Status = %q, want %q; result=%#v", result.Status, RunActionCompleted, result)
+	}
+	if !strings.Contains(command.Command, "@openai/codex") ||
+		!strings.Contains(command.Command, "--include=optional") {
+		t.Fatalf("Command = %q, want Codex CLI install with optional dependencies", command.Command)
+	}
+	if result.Probe == nil || result.Probe.Status != ProbeReady {
+		t.Fatalf("Probe = %#v, want ready probe", result.Probe)
+	}
+}
+
 func TestServiceListReportsInstallActionWhenCodexAdapterCommandFails(t *testing.T) {
 	home := t.TempDir()
 	binDir := filepath.Join(home, "bin")


### PR DESCRIPTION
## Summary
- detect Codex's newer vendor target-triple binary layout while keeping the legacy path fallback
- rerun the Codex CLI installer when the wrapper exists but the platform package is incomplete or below the supported version
- add regression coverage for the incomplete platform package install path and new/legacy binary layouts

## Tests
- go test ./service/agentstatus
- pnpm check:changed --tail-lines 40
- pnpm check:full


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Codex binary detection to check multiple platform-specific locations, including newer vendor-style paths and legacy fallbacks.
  * Better handles incomplete installs by triggering a reinstall when the required platform package is missing or outdated.
  * Added coverage for legacy binary locations and reinstall behavior to keep setup more reliable on macOS arm64.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->