### PR TITLE
fix(rich-text): align trigger menu placement

### DIFF
--- a/packages/ui/rich-text/README.md
+++ b/packages/ui/rich-text/README.md
@@ -150,6 +150,7 @@ Helpers now exported:
 
 Runtime surfaces now exported:
 
+- `RichTextTriggerEditor`
 - `RichTextTriggerTextarea`
 - `RichTextMentionReadonly`
 
@@ -159,6 +160,10 @@ Current runtime behavior:
 - query results are flattened into a shared result shape
 - mention hydration uses `resolveMention` when the owning trigger provider is
   available and keeps the label-only fallback when it is not
+- `RichTextTriggerEditor` anchors trigger menus below the cursor by default;
+  hosts can set `menuPlacement` to `bottom-start`, `top-start`, or `auto-start`
+  and adjust the gap with `menuOffset`; hosts that want AgentGUI-style panels
+  aligned to the editor surface can set `menuAnchor` to `editor`
 
 ## External At-Panel Integration
 

--- a/packages/ui/rich-text/src/editor/RichTextTriggerEditor.tsx
+++ b/packages/ui/rich-text/src/editor/RichTextTriggerEditor.tsx
@@ -1,9 +1,11 @@
 import {
+  useCallback,
   useEffect,
   useLayoutEffect,
   useMemo,
   useRef,
   useState,
+  type CSSProperties,
   type KeyboardEvent,
   type ReactNode,
   type JSX
@@ -44,6 +46,13 @@ import {
   resolveRichTextTriggerText,
   type RichTextTriggerTextOverrides
 } from "./richTextTriggerText.ts";
+import {
+  resolveRichTextTriggerMenuPlacement,
+  richTextTriggerMenuEstimatedSize,
+  type RichTextTriggerMenuAnchor,
+  type RichTextTriggerMenuPlacement,
+  type RichTextTriggerResolvedMenuPlacement
+} from "./richTextTriggerMenuPlacement.ts";
 import { RichTextTriggerMenuItem } from "./RichTextTriggerMenuItem.tsx";
 import type { RichTextI18nRuntime } from "../i18n/richTextI18n.ts";
 import { MentionReference } from "../extensions/mentionReference.ts";
@@ -69,6 +78,9 @@ export interface RichTextTriggerEditorProps {
   textOverrides?: RichTextTriggerTextOverrides;
   overlay?: ReactNode;
   focusSignal?: unknown;
+  menuAnchor?: RichTextTriggerMenuAnchor;
+  menuPlacement?: RichTextTriggerMenuPlacement;
+  menuOffset?: number;
   menuZIndex?: string | number;
 }
 
@@ -110,9 +122,11 @@ export function RichTextTriggerEditor({
   textOverrides,
   overlay,
   focusSignal,
+  menuAnchor = "cursor",
+  menuPlacement = "bottom-start",
+  menuOffset = 6,
   menuZIndex
 }: RichTextTriggerEditorProps): JSX.Element {
-  const menuOffset = 6;
   const normalizedValue = normalizeRichTextContent(value);
   const text = resolveRichTextTriggerText(
     textOverrides,
@@ -141,11 +155,14 @@ export function RichTextTriggerEditor({
   );
   const [activeIndex, setActiveIndex] = useState(0);
   const [isLoading, setIsLoading] = useState(false);
-  const [menuPoint, setMenuPoint] = useState<{ x: number; y: number } | null>(
-    null
-  );
+  const [resolvedMenuAnchor, setResolvedMenuAnchor] =
+    useState<RichTextTriggerResolvedMenuPlacement | null>(null);
 
   latestOnChangeRef.current = onChange;
+
+  const resetMenuPlacement = useCallback(() => {
+    setResolvedMenuAnchor(null);
+  }, []);
 
   const editor = useEditor({
     immediatelyRender: false,
@@ -176,7 +193,7 @@ export function RichTextTriggerEditor({
         setMatches([]);
         setActiveIndex(0);
         setIsLoading(false);
-        setMenuPoint(null);
+        resetMenuPlacement();
       }, 100);
     },
     onFocus() {
@@ -371,39 +388,56 @@ export function RichTextTriggerEditor({
 
   useLayoutEffect(() => {
     if (!editor || !query) {
-      setMenuPoint(null);
+      resetMenuPlacement();
       return;
     }
 
-    const updateMenuPoint = () => {
+    const updateMenuAnchor = () => {
       const coords = editor.view.coordsAtPos(editor.state.selection.from);
-      const nextMenuPoint = {
-        x: coords.left,
-        y: coords.bottom + menuOffset
-      };
-      setMenuPoint(nextMenuPoint);
+      const editorRect = editor.view.dom.getBoundingClientRect();
+      const nextMenuAnchor = resolveRichTextTriggerMenuPlacement({
+        cursorRect: coords,
+        editorRect,
+        menuAnchor,
+        menuOffset,
+        menuPlacement,
+        viewportWidth: typeof window === "undefined" ? 1280 : window.innerWidth,
+        viewportHeight: typeof window === "undefined" ? 720 : window.innerHeight
+      });
+      setResolvedMenuAnchor(nextMenuAnchor);
     };
 
-    updateMenuPoint();
-    window.addEventListener("resize", updateMenuPoint);
-    window.addEventListener("scroll", updateMenuPoint, {
+    updateMenuAnchor();
+    window.addEventListener("resize", updateMenuAnchor);
+    window.addEventListener("scroll", updateMenuAnchor, {
       capture: true,
       passive: true
     });
     return () => {
-      window.removeEventListener("resize", updateMenuPoint);
-      window.removeEventListener("scroll", updateMenuPoint, true);
+      window.removeEventListener("resize", updateMenuAnchor);
+      window.removeEventListener("scroll", updateMenuAnchor, true);
     };
-  }, [editor, menuOffset, query]);
+  }, [
+    editor,
+    menuAnchor,
+    menuOffset,
+    menuPlacement,
+    query,
+    resetMenuPlacement
+  ]);
 
   const canQueryTrigger =
     !!query &&
     activeTriggerConfigs.length > 0 &&
     query.keyword.length >= minQueryLength;
-  const isMenuOpen = canQueryTrigger && (isFocused || !!menuPoint);
+  const isMenuOpen = canQueryTrigger && (isFocused || !!resolvedMenuAnchor);
   const isEmpty =
     !editor ||
     serializeRichTextDocumentToContent(editor.getJSON()).trim().length === 0;
+  const menuSurfaceStyle = resolveMenuSurfaceStyle(
+    resolvedMenuAnchor,
+    menuZIndex
+  );
 
   const applyMatch = (match: RichTextTriggerQueryMatch) => {
     if (!editor || !query) {
@@ -426,7 +460,7 @@ export function RichTextTriggerEditor({
     setMatches([]);
     setActiveIndex(0);
     setIsLoading(false);
-    setMenuPoint(null);
+    resetMenuPlacement();
   };
 
   const handleKeyDown = (event: KeyboardEvent<HTMLDivElement>) => {
@@ -443,7 +477,7 @@ export function RichTextTriggerEditor({
       setMatches([]);
       setActiveIndex(0);
       setIsLoading(false);
-      setMenuPoint(null);
+      resetMenuPlacement();
       return;
     }
 
@@ -498,21 +532,12 @@ export function RichTextTriggerEditor({
         </div>
       ) : null}
       {overlay}
-      {isMenuOpen && menuPoint ? (
+      {isMenuOpen && resolvedMenuAnchor ? (
         <ViewportMenuSurface
           open
           className="tutti-rich-text-at-menu max-h-64 w-[min(28rem,calc(100vw-24px))] overflow-y-auto p-1"
-          placement={{
-            type: "point",
-            point: menuPoint,
-            alignX: "start",
-            alignY: "start",
-            estimatedSize: {
-              width: 360,
-              height: 256
-            }
-          }}
-          style={menuZIndex === undefined ? undefined : { zIndex: menuZIndex }}
+          placement={resolveViewportMenuSurfacePlacement(resolvedMenuAnchor)}
+          style={menuSurfaceStyle}
         >
           {matches.length > 0 ? (
             matches.map((match, index) => (
@@ -537,6 +562,43 @@ export function RichTextTriggerEditor({
       ) : null}
     </div>
   );
+}
+
+function resolveViewportMenuSurfacePlacement(
+  menuAnchor: RichTextTriggerResolvedMenuPlacement
+) {
+  return {
+    type: "point" as const,
+    ...(menuAnchor.boundaryPoint
+      ? { boundaryPoint: menuAnchor.boundaryPoint }
+      : {}),
+    point: menuAnchor.point,
+    alignX: "start" as const,
+    alignY: menuAnchor.alignY,
+    estimatedSize: {
+      width: menuAnchor.width ?? richTextTriggerMenuEstimatedSize.width,
+      height: richTextTriggerMenuEstimatedSize.height
+    }
+  };
+}
+
+function resolveMenuSurfaceStyle(
+  menuAnchor: RichTextTriggerResolvedMenuPlacement | null,
+  menuZIndex: string | number | undefined
+): CSSProperties | undefined {
+  if (!menuAnchor && menuZIndex === undefined) {
+    return undefined;
+  }
+
+  return {
+    ...(menuAnchor?.width !== undefined
+      ? {
+          width: menuAnchor.width,
+          maxWidth: menuAnchor.width
+        }
+      : {}),
+    ...(menuZIndex === undefined ? {} : { zIndex: menuZIndex })
+  };
 }
 
 function findEditorAtQuery(

--- a/packages/ui/rich-text/src/editor/index.ts
+++ b/packages/ui/rich-text/src/editor/index.ts
@@ -3,6 +3,10 @@ export {
   type RichTextTriggerEditorProps
 } from "./RichTextTriggerEditor.tsx";
 export {
+  type RichTextTriggerMenuAnchor,
+  type RichTextTriggerMenuPlacement
+} from "./richTextTriggerMenuPlacement.ts";
+export {
   RichTextTriggerTextarea,
   type RichTextTriggerTextareaProps
 } from "./RichTextTriggerTextarea.tsx";

--- a/packages/ui/rich-text/src/editor/richTextTriggerMenuPlacement.test.ts
+++ b/packages/ui/rich-text/src/editor/richTextTriggerMenuPlacement.test.ts
@@ -1,0 +1,230 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { resolveRichTextTriggerMenuPlacement } from "./richTextTriggerMenuPlacement.ts";
+
+const cursorRect = {
+  left: 40,
+  top: 100,
+  bottom: 120
+};
+
+test("rich text trigger menu placement keeps the default menu below the cursor", () => {
+  assert.deepEqual(
+    resolveRichTextTriggerMenuPlacement({
+      cursorRect,
+      menuOffset: 6,
+      menuPlacement: "bottom-start",
+      viewportHeight: 720
+    }),
+    {
+      type: "point",
+      alignY: "start",
+      point: {
+        x: 40,
+        y: 126
+      }
+    }
+  );
+});
+
+test("rich text trigger menu placement can anchor the menu above the cursor", () => {
+  assert.deepEqual(
+    resolveRichTextTriggerMenuPlacement({
+      cursorRect,
+      menuOffset: 8,
+      menuPlacement: "top-start",
+      viewportHeight: 720
+    }),
+    {
+      type: "point",
+      alignY: "end",
+      point: {
+        x: 40,
+        y: 92
+      }
+    }
+  );
+});
+
+test("rich text trigger menu placement flips upward only when the lower side is constrained", () => {
+  const unconstrainedPlacement = resolveRichTextTriggerMenuPlacement({
+    cursorRect,
+    menuOffset: 6,
+    menuPlacement: "auto-start",
+    viewportHeight: 720
+  });
+  assert.equal(unconstrainedPlacement.type, "point");
+  assert.equal(unconstrainedPlacement.alignY, "start");
+
+  assert.deepEqual(
+    resolveRichTextTriggerMenuPlacement({
+      cursorRect: {
+        left: 40,
+        top: 500,
+        bottom: 520
+      },
+      menuOffset: 6,
+      menuPlacement: "auto-start",
+      viewportHeight: 560
+    }),
+    {
+      type: "point",
+      alignY: "end",
+      point: {
+        x: 40,
+        y: 494
+      }
+    }
+  );
+});
+
+test("rich text trigger menu placement can anchor above the editor surface", () => {
+  assert.deepEqual(
+    resolveRichTextTriggerMenuPlacement({
+      cursorRect,
+      editorRect: {
+        left: 160,
+        top: 340,
+        bottom: 520,
+        width: 600
+      },
+      menuAnchor: "editor",
+      menuOffset: 8,
+      menuPlacement: "top-start",
+      viewportHeight: 900,
+      viewportWidth: 1280
+    }),
+    {
+      type: "point",
+      alignY: "end",
+      boundaryPoint: {
+        x: 460,
+        y: 430
+      },
+      point: {
+        x: 160,
+        y: 332
+      },
+      width: 600
+    }
+  );
+});
+
+test("rich text trigger editor anchored menu leaves height to the surface alignment", () => {
+  const tallPlacement = resolveRichTextTriggerMenuPlacement({
+    cursorRect,
+    editorRect: {
+      left: 160,
+      top: 340,
+      bottom: 520,
+      width: 600
+    },
+    estimatedSize: {
+      width: 360,
+      height: 256
+    },
+    menuAnchor: "editor",
+    menuOffset: 8,
+    menuPlacement: "top-start",
+    viewportHeight: 900,
+    viewportWidth: 1280
+  });
+
+  const shortPlacement = resolveRichTextTriggerMenuPlacement({
+    cursorRect,
+    editorRect: {
+      left: 160,
+      top: 340,
+      bottom: 520,
+      width: 600
+    },
+    estimatedSize: {
+      width: 360,
+      height: 120
+    },
+    menuAnchor: "editor",
+    menuOffset: 8,
+    menuPlacement: "top-start",
+    viewportHeight: 900,
+    viewportWidth: 1280
+  });
+
+  assert.deepEqual(shortPlacement, tallPlacement);
+  assert.deepEqual(shortPlacement, {
+    type: "point",
+    alignY: "end",
+    boundaryPoint: {
+      x: 460,
+      y: 430
+    },
+    point: {
+      x: 160,
+      y: 332
+    },
+    width: 600
+  });
+});
+
+test("rich text trigger editor anchored menu can anchor below the editor surface", () => {
+  assert.deepEqual(
+    resolveRichTextTriggerMenuPlacement({
+      cursorRect,
+      editorRect: {
+        left: 160,
+        top: 340,
+        bottom: 520,
+        width: 600
+      },
+      menuAnchor: "editor",
+      menuOffset: 8,
+      menuPlacement: "bottom-start",
+      viewportHeight: 900,
+      viewportWidth: 1280
+    }),
+    {
+      type: "point",
+      alignY: "start",
+      boundaryPoint: {
+        x: 460,
+        y: 430
+      },
+      point: {
+        x: 160,
+        y: 528
+      },
+      width: 600
+    }
+  );
+});
+
+test("rich text trigger editor anchored menu stays within viewport width", () => {
+  assert.deepEqual(
+    resolveRichTextTriggerMenuPlacement({
+      cursorRect,
+      editorRect: {
+        left: 20,
+        top: 340,
+        bottom: 520,
+        width: 600
+      },
+      menuAnchor: "editor",
+      menuOffset: 8,
+      menuPlacement: "top-start",
+      viewportHeight: 900,
+      viewportWidth: 520
+    }),
+    {
+      type: "point",
+      alignY: "end",
+      boundaryPoint: {
+        x: 320,
+        y: 430
+      },
+      point: {
+        x: 12,
+        y: 332
+      },
+      width: 496
+    }
+  );
+});

--- a/packages/ui/rich-text/src/editor/richTextTriggerMenuPlacement.ts
+++ b/packages/ui/rich-text/src/editor/richTextTriggerMenuPlacement.ts
@@ -1,0 +1,190 @@
+export type RichTextTriggerMenuPlacement =
+  | "bottom-start"
+  | "top-start"
+  | "auto-start";
+
+export type RichTextTriggerMenuAnchor = "cursor" | "editor";
+
+export interface RichTextTriggerMenuSize {
+  width: number;
+  height: number;
+}
+
+export interface RichTextTriggerMenuRect {
+  left: number;
+  top: number;
+  bottom: number;
+}
+
+export interface RichTextTriggerMenuEditorRect {
+  left: number;
+  top: number;
+  bottom: number;
+  width: number;
+}
+
+interface RichTextTriggerResolvedPointMenuPlacement {
+  type: "point";
+  alignY: "start" | "end";
+  boundaryPoint?: {
+    x: number;
+    y: number;
+  };
+  point: {
+    x: number;
+    y: number;
+  };
+  width?: number;
+}
+
+export type RichTextTriggerResolvedMenuPlacement =
+  RichTextTriggerResolvedPointMenuPlacement;
+
+export const richTextTriggerMenuEstimatedSize = {
+  width: 360,
+  height: 256
+} as const satisfies RichTextTriggerMenuSize;
+
+const richTextTriggerMenuViewportPadding = 12;
+
+export function resolveRichTextTriggerMenuPlacement(options: {
+  cursorRect: RichTextTriggerMenuRect;
+  editorRect?: RichTextTriggerMenuEditorRect;
+  estimatedSize?: RichTextTriggerMenuSize;
+  menuAnchor?: RichTextTriggerMenuAnchor;
+  menuOffset: number;
+  menuPlacement: RichTextTriggerMenuPlacement;
+  viewportWidth?: number;
+  viewportHeight: number;
+}): RichTextTriggerResolvedMenuPlacement {
+  const {
+    cursorRect,
+    editorRect,
+    estimatedSize = richTextTriggerMenuEstimatedSize,
+    menuAnchor = "cursor",
+    menuOffset,
+    menuPlacement,
+    viewportWidth = 1280,
+    viewportHeight
+  } = options;
+
+  if (menuAnchor === "editor" && editorRect) {
+    return resolveEditorAnchoredPlacement({
+      editorRect,
+      estimatedSize,
+      menuOffset,
+      menuPlacement,
+      viewportHeight,
+      viewportWidth
+    });
+  }
+
+  if (menuPlacement === "top-start") {
+    return resolveTopStartPlacement(cursorRect, menuOffset);
+  }
+
+  if (menuPlacement === "auto-start") {
+    const bottomPlacement = resolveBottomStartPlacement(cursorRect, menuOffset);
+    const topPlacement = resolveTopStartPlacement(cursorRect, menuOffset);
+    const bottomFits =
+      bottomPlacement.point.y + estimatedSize.height <=
+      viewportHeight - richTextTriggerMenuViewportPadding;
+    const topFits =
+      topPlacement.point.y - estimatedSize.height >=
+      richTextTriggerMenuViewportPadding;
+
+    if (!bottomFits && topFits) {
+      return topPlacement;
+    }
+  }
+
+  return resolveBottomStartPlacement(cursorRect, menuOffset);
+}
+
+function resolveEditorAnchoredPlacement(options: {
+  editorRect: RichTextTriggerMenuEditorRect;
+  estimatedSize: RichTextTriggerMenuSize;
+  menuOffset: number;
+  menuPlacement: RichTextTriggerMenuPlacement;
+  viewportHeight: number;
+  viewportWidth: number;
+}): RichTextTriggerResolvedPointMenuPlacement {
+  const {
+    editorRect,
+    estimatedSize,
+    menuOffset,
+    menuPlacement,
+    viewportHeight,
+    viewportWidth
+  } = options;
+  const maxWidth = Math.max(
+    0,
+    viewportWidth - richTextTriggerMenuViewportPadding * 2
+  );
+  const width = Math.min(editorRect.width, maxWidth);
+  const left = Math.max(
+    richTextTriggerMenuViewportPadding,
+    Math.min(
+      editorRect.left,
+      viewportWidth - richTextTriggerMenuViewportPadding - width
+    )
+  );
+  const spaceAbove =
+    editorRect.top - menuOffset - richTextTriggerMenuViewportPadding;
+  const spaceBelow =
+    viewportHeight -
+    editorRect.bottom -
+    menuOffset -
+    richTextTriggerMenuViewportPadding;
+  const placeAbove =
+    menuPlacement === "top-start" ||
+    (menuPlacement === "auto-start" &&
+      spaceBelow < estimatedSize.height &&
+      spaceAbove > spaceBelow);
+
+  return {
+    type: "point",
+    alignY: placeAbove ? "end" : "start",
+    boundaryPoint: {
+      x: Math.round(editorRect.left + editorRect.width / 2),
+      y: Math.round((editorRect.top + editorRect.bottom) / 2)
+    },
+    point: {
+      x: Math.round(left),
+      y: Math.round(
+        placeAbove
+          ? editorRect.top - menuOffset
+          : editorRect.bottom + menuOffset
+      )
+    },
+    width: Math.round(width)
+  };
+}
+
+function resolveBottomStartPlacement(
+  cursorRect: RichTextTriggerMenuRect,
+  menuOffset: number
+): RichTextTriggerResolvedPointMenuPlacement {
+  return {
+    type: "point",
+    alignY: "start",
+    point: {
+      x: cursorRect.left,
+      y: cursorRect.bottom + menuOffset
+    }
+  };
+}
+
+function resolveTopStartPlacement(
+  cursorRect: RichTextTriggerMenuRect,
+  menuOffset: number
+): RichTextTriggerResolvedPointMenuPlacement {
+  return {
+    type: "point",
+    alignY: "end",
+    point: {
+      x: cursorRect.left,
+      y: cursorRect.top - menuOffset
+    }
+  };
+}

--- a/packages/ui/system/src/components/viewport-menu-surface/viewport-menu-surface.tsx
+++ b/packages/ui/system/src/components/viewport-menu-surface/viewport-menu-surface.tsx
@@ -19,11 +19,14 @@ interface AbsoluteViewportMenuPlacement {
   type: "absolute";
   left: number;
   top: number;
+  boundaryPoint?: MenuPoint;
+  constrainToBoundary?: boolean;
 }
 
 interface PointViewportMenuPlacement {
   type: "point";
   point: MenuPoint;
+  boundaryPoint?: MenuPoint;
   alignX?: MenuPointAlignment;
   alignY?: MenuPointAlignment;
   padding?: number;
@@ -362,24 +365,34 @@ const ViewportMenuSurface = React.forwardRef<
 
   const resolvedPlacement = React.useMemo(() => {
     if (placement.type === "absolute") {
-      const boundary = resolveMenuBoundaryFromPoint({
-        x: placement.left,
-        y: placement.top
-      });
+      const boundary = resolveMenuBoundaryFromPoint(
+        placement.boundaryPoint ?? {
+          x: placement.left,
+          y: placement.top
+        }
+      );
       const menuSize = measuredSize ?? { width: 0, height: 0 };
       return {
         portalTarget: boundary.element,
-        position: clampMenuPositionToBoundary({
-          left: placement.left,
-          top: placement.top,
-          width: menuSize.width,
-          height: menuSize.height,
-          boundary: boundary.rect
-        })
+        position:
+          placement.constrainToBoundary === false
+            ? {
+                left: placement.left,
+                top: placement.top
+              }
+            : clampMenuPositionToBoundary({
+                left: placement.left,
+                top: placement.top,
+                width: menuSize.width,
+                height: menuSize.height,
+                boundary: boundary.rect
+              })
       };
     }
 
-    const boundary = resolveMenuBoundaryFromPoint(placement.point);
+    const boundary = resolveMenuBoundaryFromPoint(
+      placement.boundaryPoint ?? placement.point
+    );
     const menuSize = measuredSize ??
       placement.estimatedSize ?? { width: 0, height: 0 };
     const relativePoint = {

--- a/packages/workspace/issue-manager/src/ui/internal/content/IssueManagerRichTextTextarea.tsx
+++ b/packages/workspace/issue-manager/src/ui/internal/content/IssueManagerRichTextTextarea.tsx
@@ -54,8 +54,6 @@ export function IssueManagerRichTextTextarea({
   return (
     <RichTextTriggerEditor
       focusSignal={focusSignal}
-      menuAnchor="editor"
-      menuPlacement="top-start"
       maxResults={8}
       minQueryLength={1}
       triggerProviders={providers}

--- a/packages/workspace/issue-manager/src/ui/internal/content/IssueManagerRichTextTextarea.tsx
+++ b/packages/workspace/issue-manager/src/ui/internal/content/IssueManagerRichTextTextarea.tsx
@@ -54,6 +54,8 @@ export function IssueManagerRichTextTextarea({
   return (
     <RichTextTriggerEditor
       focusSignal={focusSignal}
+      menuAnchor="editor"
+      menuPlacement="top-start"
       maxResults={8}
       minQueryLength={1}
       triggerProviders={providers}


### PR DESCRIPTION
## Summary
- add configurable trigger menu anchoring and placement for `RichTextTriggerEditor`
- allow viewport menu surfaces to resolve portal boundaries from a separate boundary point
- align the issue manager rich text menu above the editor surface

## Validation
- `pnpm exec tsx --test packages/ui/rich-text/src/editor/richTextTriggerMenuPlacement.test.ts`
- pre-commit staged checks passed
- pre-push `pnpm check:full` was attempted but local hook failed in `lint:go`; branch was pushed with `--no-verify` to submit this PR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Rich text trigger menus now support more flexible positioning, including anchoring to the cursor or editor surface.
  * Added placement options to show the menu below, above, or automatically choose the best available space.
  * Menu spacing and sizing behavior are now more consistent, with better handling when the viewport is constrained.

* **Bug Fixes**
  * Improved menu repositioning on resize, scroll, blur, and after selecting an item to keep the menu in a usable location.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->