### PR TITLE
[codex] Keep launchpad search focus visible

### DIFF
--- a/packages/workbench/launchpad/src/launchpadStyle.test.ts
+++ b/packages/workbench/launchpad/src/launchpadStyle.test.ts
@@ -61,7 +61,7 @@ test("launchpad top bar remains draggable without stealing controls", () => {
 test("launchpad search focus stays neutral", () => {
   assert.match(
     css,
-    /\.workspace-launchpad-search__input:focus,\s*\.workspace-launchpad-search__input:focus-visible\s*{[^}]*border-color:\s*var\(--border-1\);[^}]*box-shadow:\s*none;/s
+    /\.workspace-launchpad-search__input:focus,\s*\.workspace-launchpad-search__input:focus-visible\s*{[^}]*border-color:\s*color-mix\(in srgb,\s*var\(--text-primary\)\s*18%,\s*var\(--border-1\)\);[^}]*box-shadow:\s*0 0 0 2px\s*color-mix\(in srgb,\s*var\(--text-primary\)\s*10%,\s*transparent\);/s
   );
   assert.doesNotMatch(
     css,

--- a/packages/workbench/launchpad/src/styles/workbench-launchpad.css
+++ b/packages/workbench/launchpad/src/styles/workbench-launchpad.css
@@ -175,8 +175,8 @@
 
 .workspace-launchpad-search__input:focus,
 .workspace-launchpad-search__input:focus-visible {
-  border-color: var(--border-1);
-  box-shadow: none;
+  border-color: color-mix(in srgb, var(--text-primary) 18%, var(--border-1));
+  box-shadow: 0 0 0 2px color-mix(in srgb, var(--text-primary) 10%, transparent);
 }
 
 .workspace-launchpad-search__clear {


### PR DESCRIPTION
## Summary
- restore a visible neutral focus ring for the launchpad search input
- keep the focus treatment non-blue while preserving keyboard accessibility
- update the launchpad style regression assertion

## Validation
- `corepack pnpm --filter @tutti-os/workbench-launchpad test`
- `corepack pnpm --filter @tutti-os/workbench-launchpad typecheck`
- pre-push `pnpm check:full`

Follow-up to #393 after CodeRabbit flagged the search focus state as visually indistinguishable.