### PR TITLE
fix(issue-manager): limit rich text mentions to apps

### DIFF
--- a/apps/desktop/src/renderer/src/features/rich-text-at/services/internal/desktopRichTextAtService.test.ts
+++ b/apps/desktop/src/renderer/src/features/rich-text-at/services/internal/desktopRichTextAtService.test.ts
@@ -773,6 +773,59 @@ test("desktop rich text @ service uses task icon fallback for issue manager app 
   });
 });
 
+test("desktop rich text @ service hides issue manager app mentions from issue manager", async () => {
+  const service = new DesktopRichTextAtService({
+    tuttidClient: {
+      async listWorkspaceAppMentionCandidates(workspaceId: string) {
+        return {
+          workspaceId,
+          apps: [
+            createWorkspaceAppMentionCandidate({
+              appId: "issue-manager",
+              commandCount: 1,
+              commandDescriptions: ["List workspace tasks."],
+              commandPaths: ["issue list"],
+              commandSummaries: ["List tasks"],
+              description: "Manage workspace tasks and runs.",
+              displayName: "Task Manager",
+              scopes: ["issue"]
+            }),
+            createWorkspaceAppMentionCandidate({
+              appId: "app-weather",
+              commandCount: 1,
+              commandDescriptions: ["Inspect weather forecasts."],
+              commandPaths: ["weather forecast"],
+              commandSummaries: ["Get a forecast"],
+              description: "Plan weather-sensitive work.",
+              displayName: "Weather Desk",
+              scopes: ["weather"]
+            })
+          ]
+        };
+      }
+    } as unknown as TuttidClient
+  });
+
+  const [provider] = service.getProviders({
+    capabilities: ["workspace-app"],
+    surface: "task",
+    target: "issue-manager",
+    workspaceId: "workspace-1"
+  });
+  assert.ok(provider);
+  const items = await provider.query({
+    context: {},
+    keyword: "",
+    maxResults: 5,
+    trigger: "@"
+  });
+
+  assert.deepEqual(
+    items.map((item) => provider.getItemKey(item)),
+    ["app-weather"]
+  );
+});
+
 function iconUrlFromProviderItem(item: unknown): string {
   if (!item || typeof item !== "object") {
     return "";

--- a/apps/desktop/src/renderer/src/features/rich-text-at/services/internal/desktopRichTextAtService.ts
+++ b/apps/desktop/src/renderer/src/features/rich-text-at/services/internal/desktopRichTextAtService.ts
@@ -249,6 +249,7 @@ function createWorkspaceAppAtContributor(contributorInput: {
             return workspaceAppAtItemsFromMentionCandidates({
               agentProviderStatuses: contributorInput.agentProviderStatuses?.(),
               candidates: response.apps,
+              excludedAppIds: excludedWorkspaceAppMentionIds(input.target),
               keyword: searchInput.keyword,
               locale: contributorInput.getLocale?.() ?? "",
               maxResults: searchInput.maxResults,
@@ -290,6 +291,7 @@ function createWorkspaceAppAtContributor(contributorInput: {
                 agentProviderStatuses:
                   contributorInput.agentProviderStatuses?.(),
                 candidates: response.apps,
+                excludedAppIds: excludedWorkspaceAppMentionIds(input.target),
                 keyword: "",
                 locale: contributorInput.getLocale?.() ?? "",
                 workspaceId
@@ -321,15 +323,22 @@ function workspaceAppAtItemsFromMentionCandidates(input: {
   candidates: Awaited<
     ReturnType<TuttidClient["listWorkspaceAppMentionCandidates"]>
   >["apps"];
+  excludedAppIds?: readonly string[];
   keyword: string;
   locale: string;
   maxResults?: number;
   workspaceId: string;
 }): WorkspaceAppAtItem[] {
   const apps: WorkspaceAppAtItem[] = [];
+  const excludedAppIds = new Set(
+    (input.excludedAppIds ?? []).map((appId) => appId.trim().toLowerCase())
+  );
   for (const candidate of input.candidates) {
     const appId = candidate.appId.trim();
     if (!appId) {
+      continue;
+    }
+    if (excludedAppIds.has(appId.toLowerCase())) {
       continue;
     }
     if (
@@ -388,6 +397,10 @@ function workspaceAppAtItemsFromMentionCandidates(input: {
   return input.maxResults === undefined
     ? matchedApps
     : matchedApps.slice(0, Math.max(0, input.maxResults));
+}
+
+function excludedWorkspaceAppMentionIds(target: string): readonly string[] {
+  return target === "issue-manager" ? ["issue-manager"] : [];
 }
 
 const WORKSPACE_AGENT_APP_PROVIDER_BY_ID: Readonly<

--- a/apps/desktop/src/renderer/src/features/workspace-workbench/services/internal/workspaceIssueManagerRichTextTriggerProviderRequest.test.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/services/internal/workspaceIssueManagerRichTextTriggerProviderRequest.test.ts
@@ -5,7 +5,7 @@ import {
   createWorkspaceIssueManagerRichTextTriggerProviderRequestFromIdentity
 } from "./workspaceIssueManagerRichTextTriggerProviderRequest.ts";
 
-test("workspace issue manager rich text at provider request matches Agent GUI capabilities and current user metadata", () => {
+test("workspace issue manager rich text at provider request only enables app mentions", () => {
   assert.deepEqual(
     createWorkspaceIssueManagerRichTextTriggerProviderRequest({
       currentUserId: "user-1",
@@ -13,12 +13,7 @@ test("workspace issue manager rich text at provider request matches Agent GUI ca
       workspaceId: "workspace-1"
     }),
     {
-      capabilities: [
-        "file",
-        "workspace-issue",
-        "agent-session",
-        "workspace-app"
-      ],
+      capabilities: ["workspace-app"],
       metadata: {
         currentUserId: "user-1"
       },
@@ -39,12 +34,7 @@ test("workspace issue manager rich text at provider request reads current user m
       workspaceId: "workspace-2"
     }),
     {
-      capabilities: [
-        "file",
-        "workspace-issue",
-        "agent-session",
-        "workspace-app"
-      ],
+      capabilities: ["workspace-app"],
       metadata: {
         currentUserId: "user-2"
       },

--- a/apps/desktop/src/renderer/src/features/workspace-workbench/services/internal/workspaceIssueManagerRichTextTriggerProviderRequest.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/services/internal/workspaceIssueManagerRichTextTriggerProviderRequest.ts
@@ -1,9 +1,6 @@
 import type { DesktopRichTextAtCapability } from "@renderer/features/rich-text-at";
 
 export const workspaceIssueManagerRichTextTriggerCapabilities = [
-  "file",
-  "workspace-issue",
-  "agent-session",
   "workspace-app"
 ] as const satisfies readonly DesktopRichTextAtCapability[];
 

--- a/docs/architecture/workspace-issue-manager.md
+++ b/docs/architecture/workspace-issue-manager.md
@@ -88,6 +88,13 @@ Expected exports:
 be the default dependency-injection entry for hosts. It owns service/session
 creation plus shared state orchestration. `./ui` should consume those services
 and stay focused on rendering, DOM interaction, and imperative UI bridges.
+Issue and task content editors consume host-provided `@` rich-text workspace app
+trigger providers through the workbench node seam. They should open providers as
+soon as the `@` trigger is typed, before a search term exists, so workspace app
+mentions stay discoverable in the same flow as Agent GUI and other rich-text
+surfaces. Files and issue references should stay on their explicit reference
+actions instead of appearing in this `@` picker, and the Task Center app itself
+should be excluded from issue-manager app mentions.
 
 The npm package name should be `@tutti-os/workspace-issue-manager`.
 It participates in the shared public npm release group documented in

--- a/packages/workspace/issue-manager/src/ui/internal/content/IssueManagerRichTextTextarea.test.ts
+++ b/packages/workspace/issue-manager/src/ui/internal/content/IssueManagerRichTextTextarea.test.ts
@@ -1,0 +1,12 @@
+import { readFileSync } from "node:fs";
+import assert from "node:assert/strict";
+import test from "node:test";
+
+const richTextTextareaSource = readFileSync(
+  new URL("./IssueManagerRichTextTextarea.tsx", import.meta.url),
+  "utf8"
+);
+
+test("rich text textarea opens @ providers before a query is typed", () => {
+  assert.match(richTextTextareaSource, /minQueryLength=\{0\}/);
+});

--- a/packages/workspace/issue-manager/src/ui/internal/content/IssueManagerRichTextTextarea.tsx
+++ b/packages/workspace/issue-manager/src/ui/internal/content/IssueManagerRichTextTextarea.tsx
@@ -55,7 +55,7 @@ export function IssueManagerRichTextTextarea({
     <RichTextTriggerEditor
       focusSignal={focusSignal}
       maxResults={8}
-      minQueryLength={1}
+      minQueryLength={0}
       triggerProviders={providers}
       textOverrides={{
         loadingLabel: controller.copy.t("richTextAt.loading"),


### PR DESCRIPTION
## Summary
- limit issue-manager rich-text @ mentions to workspace apps only
- hide the Task Center app from issue-manager's own app mention picker
- open the @ picker before a query is typed so app mentions are discoverable

## Validation
- rich-text-at + issue-manager provider request node tests
- pnpm --filter @tutti-os/desktop typecheck
- pnpm --filter @tutti-os/workspace-issue-manager test
- pnpm check:changed
- git diff --check
- pnpm test:go

Note: the first push attempt triggered the full pre-push hook and failed in the concurrent test:go lane with transient Go build failures; the same Go targets and standalone pnpm test:go passed afterward.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Mention triggers now open immediately when typing `@`, even before entering a search term.
  * Workspace app mentions are now available in issue/task editors right away.

* **Bug Fixes**
  * Certain app mentions are now excluded from issue-manager mention results, so only relevant apps appear.
  * The mention picker now behaves more consistently by showing workspace app options without requiring extra input.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->