### PR TITLE
fix(agent-env): codex install/auth reliability + version UX follow-ups

### DIFF
--- a/.changeset/agent-auth-self-heal-after-relogin.md
+++ b/.changeset/agent-auth-self-heal-after-relogin.md
@@ -1,0 +1,5 @@
+---
+"@tutti-os/desktop": patch
+---
+
+Fix the agent environment check staying stuck on "needs login" after a successful re-login. A runtime 401 (e.g. an expired/revoked Codex token) records an auth-failure flag that overrides the local "logged in" marker; previously only a later _successful run_ cleared it, but re-login is a terminal action that never reports a run — so the dock and wizard stayed red no matter how many times the user re-checked. The probe now self-heals: when the provider's credential file is rewritten by a fresh login (its mtime moves past the recorded failure), the stale flag is dropped and normal detection resumes.

--- a/.changeset/agent-codex-upgrade-ux.md
+++ b/.changeset/agent-codex-upgrade-ux.md
@@ -1,0 +1,5 @@
+---
+"@tutti-os/desktop": patch
+---
+
+Improve the codex environment wizard for an outdated CLI. Upgrades are now user-driven: instead of a no-op auto-install (npm can't upgrade an already-present binary), the wizard shows the manual upgrade command and re-checks. The outdated state also surfaces the actual versions — "current X · requires ≥ Y" — sourced from the backend's own version gate.

--- a/.changeset/agent-codex-version-floor.md
+++ b/.changeset/agent-codex-version-floor.md
@@ -1,0 +1,5 @@
+---
+"@tutti-os/desktop": patch
+---
+
+Lower the minimum supported Codex version to 0.126.0. The floor is now capability-derived — 0.126.0 is the release that introduced the newest app-server method our codex runtime integrates — instead of an arbitrary "latest at the time" value.

--- a/.changeset/agent-install-timeout-for-proxied-download.md
+++ b/.changeset/agent-install-timeout-for-proxied-download.md
@@ -1,0 +1,5 @@
+---
+"@tutti-os/desktop": patch
+---
+
+Stop the codex CLI install from failing under a slow system proxy. The npm install pulls a large platform binary; direct it's ~6-44s, but through a throttled proxy it's ~76-100s+ — right at the old 90s per-registry cap, so otherwise-succeeding installs were killed and the whole registry chain timed out. Raise the per-registry timeout to 150s (and the overall install budget to 8 min so the chain can still fail over) so a working-but-slow registry can finish.

--- a/.changeset/agent-setup-notice-polish.md
+++ b/.changeset/agent-setup-notice-polish.md
@@ -1,0 +1,5 @@
+---
+"@tutti-os/desktop": patch
+---
+
+Polish the agent provider setup notice: center the floating pill, space the message and "Set up" action so they no longer butt together, and use neutral copy that fits every not-ready state instead of always saying "install".

--- a/apps/desktop/src/renderer/src/features/workspace-agent/ui/AgentEnvPanel.tsx
+++ b/apps/desktop/src/renderer/src/features/workspace-agent/ui/AgentEnvPanel.tsx
@@ -139,11 +139,14 @@ function describeStageProblem(
         isError: false
       };
     case "install-outdated":
+      // We don't auto-upgrade a present CLI: the headline states it's outdated,
+      // the manual upgrade command is shown below, and the action re-checks
+      // once the user has upgraded it themselves.
       return {
         headline: t("workspace.agentEnv.stageProblemInstallOutdated", {
           provider: providerLabel
         }),
-        actionLabel: t("workspace.agentEnv.stageDoUpgrade"),
+        actionLabel: t("workspace.agentEnv.stageDoRedetect"),
         isError: true
       };
     case "adapter-missing":
@@ -406,6 +409,22 @@ export function AgentEnvPanel({
 
   const reasonCode = (status?.availability.reasonCode ?? "").toLowerCase();
   const versionTooOld = reasonCode.includes("version");
+  // The CLI sits below the supported floor specifically (not an adapter version
+  // mismatch). In that state we show "current X · requires ≥ Y" so the user
+  // knows exactly what to upgrade to — the floor comes from the backend
+  // (status.cli.minVersion), the same constant the version gate uses.
+  const cliBelowFloor = reasonCode.includes("codex_version_too_old");
+  const installDetail =
+    cliBelowFloor && status?.cli.version && status.cli.minVersion
+      ? t("workspace.agentEnv.stageInstallVersionRequirement", {
+          current: status.cli.version,
+          required: status.cli.minVersion
+        })
+      : status?.cli.installed
+        ? [status?.cli.version, status?.cli.binaryPath]
+            .filter((part): part is string => Boolean(part))
+            .join(" · ") || null
+        : (status?.cli.version ?? null);
 
   // Both connectivity checks are shown separately under the network step.
   const networkChecks: NetworkCheck[] = status?.network
@@ -463,11 +482,7 @@ export function AgentEnvPanel({
     // Each completed step carries its own info inline (decision: unified track,
     // detail lines only). Install shows version + CLI path; login shows the
     // account, falling back to "signed in" when the provider exposes no label.
-    cliVersionDetail: status?.cli.installed
-      ? [status.cli.version, status.cli.binaryPath]
-          .filter((part): part is string => Boolean(part))
-          .join(" · ") || null
-      : (status?.cli.version ?? null),
+    cliVersionDetail: installDetail,
     adapterDetail:
       status?.adapter.binaryPath ??
       (status?.adapter.command?.length
@@ -786,7 +801,10 @@ function SetupTrack({
                         ? doneStageLabel(stage.id, t)
                         : stage.label}
                   </span>
-                  {!problem && stage.detail ? (
+                  {stage.detail ? (
+                    // Shown for a healthy step (version · path) AND for a version
+                    // problem (current · requires ≥ floor) — a blocked CLI must
+                    // still reveal which version it has and what it needs.
                     <span className="min-w-0 truncate text-[12px] text-[var(--text-secondary)]">
                       {stage.detail}
                     </span>

--- a/apps/desktop/src/shared/i18n/locales/en.ts
+++ b/apps/desktop/src/shared/i18n/locales/en.ts
@@ -201,6 +201,7 @@ export const en = {
       stageProblemNetworkUnreachable: "Can't reach the network",
       stageProblemInstallMissing: "{{provider}} CLI not installed",
       stageProblemInstallOutdated: "{{provider}} CLI version unsupported",
+      stageInstallVersionRequirement: "{{current}} · requires ≥ {{required}}",
       stageProblemAdapterMissing: "Adapter not installed",
       stageProblemAdapterMismatch: "Adapter version unsupported",
       stageProblemLoginMissing: "Not signed in",

--- a/apps/desktop/src/shared/i18n/locales/zh-CN.ts
+++ b/apps/desktop/src/shared/i18n/locales/zh-CN.ts
@@ -197,6 +197,7 @@ export const zhCN = {
       stageProblemNetworkUnreachable: "无法连接网络",
       stageProblemInstallMissing: "未安装 {{provider}} CLI",
       stageProblemInstallOutdated: "{{provider}} CLI 版本不受支持",
+      stageInstallVersionRequirement: "当前 {{current}} · 需要 ≥ {{required}}",
       stageProblemAdapterMissing: "未安装适配器",
       stageProblemAdapterMismatch: "适配器版本不受支持",
       stageProblemLoginMissing: "未登录",

--- a/packages/agent/daemon/runtime/visible_error.go
+++ b/packages/agent/daemon/runtime/visible_error.go
@@ -3,6 +3,7 @@ package agentruntime
 import (
 	"fmt"
 	"regexp"
+	"strconv"
 	"strings"
 
 	agentsessionstore "github.com/tutti-os/tutti/packages/agentactivity/daemon/activity"
@@ -184,7 +185,13 @@ func limitVisibleErrorDetail(value string) string {
 func visibleFailureCode(detail string) string {
 	normalized := strings.ToLower(detail)
 	switch {
-	case authFailurePattern.MatchString(detail):
+	// A tool MCP server's OAuth failure (Notion/Figma/...) crashes codex's MCP
+	// client and bubbles up here mentioning "access token"/"AuthRequired", which
+	// trips the auth pattern. That is the MCP SERVER needing re-auth, not codex's
+	// own login — codex itself is still signed in — so it must not be reported as
+	// "Codex needs authentication". Let it fall through to the real cause (the
+	// process exit) instead.
+	case authFailurePattern.MatchString(detail) && !detailIsMcpToolServerAuth(detail):
 		return "auth_required"
 	// A run that can't find its CLI binary surfaces as an exec/ENOENT error. This
 	// is the real "not installed / not on PATH" failure the env wizard can fix, so
@@ -215,6 +222,11 @@ func visibleFailureCode(detail string) string {
 	case strings.Contains(normalized, "quota") ||
 		strings.Contains(normalized, "rate limit") ||
 		strings.Contains(normalized, "limit exceeded") ||
+		// codex reports a depleted ChatGPT plan/credit cap as plain text — "You've
+		// hit your usage limit. Upgrade to Pro…" — with no structured codexErrorInfo
+		// and none of the other markers here, so it must be matched explicitly or it
+		// falls through to a generic "request failed".
+		strings.Contains(normalized, "usage limit") ||
 		strings.Contains(normalized, "resource_exhausted") ||
 		strings.Contains(normalized, "too many requests") ||
 		strings.Contains(normalized, " 429"):
@@ -222,6 +234,16 @@ func visibleFailureCode(detail string) string {
 	case strings.Contains(normalized, "process exited") ||
 		strings.Contains(normalized, "exited with code") ||
 		strings.Contains(normalized, "exit status"):
+		// A clean exit (code 0) or a signal-termination (128+N, e.g. 137 SIGKILL,
+		// 143 SIGTERM) means the app-server was stopped/killed externally — the host
+		// quit, the OS OOM-killed it, or (as seen in the field) an agent killed the
+		// very Tutti process tree hosting its own session. That is the session being
+		// interrupted, not Codex erroring out, so it reads calmer and is retryable.
+		// A non-zero, non-signal exit (1/2/101…) is a genuine crash and stays
+		// process_exited ("request failed").
+		if codexExitLooksInterrupted(normalized) {
+			return "session_interrupted"
+		}
 		return "process_exited"
 	case strings.Contains(normalized, "deadline exceeded") ||
 		strings.Contains(normalized, "timed out"):
@@ -236,6 +258,26 @@ func visibleFailureCode(detail string) string {
 	default:
 		return "unknown"
 	}
+}
+
+// detailIsMcpToolServerAuth reports whether the failure is an MCP tool server's
+// OAuth failure surfaced by codex's rust MCP client (rmcp) — e.g. a Notion or
+// Figma MCP server whose access token expired. These markers never appear in
+// codex's own login failures (which talk about chatgpt.com/openai, "not logged
+// in", or "/login"), so keying on them safely separates "a tool server needs
+// re-auth" from "codex needs to sign in".
+func detailIsMcpToolServerAuth(detail string) bool {
+	lower := strings.ToLower(detail)
+	for _, marker := range []string{
+		"rmcp::",
+		"authrequirederror",
+		"oauth-protected-resource",
+	} {
+		if strings.Contains(lower, marker) {
+			return true
+		}
+	}
+	return false
 }
 
 // codexErrorLooksLikeMissingBinary reports whether the detail describes a CLI
@@ -254,6 +296,45 @@ func codexErrorLooksLikeMissingBinary(lower string) bool {
 		}
 	}
 	return false
+}
+
+// codexExitCodeFromDetail extracts the numeric process exit code from a
+// "process exited" style detail (e.g. "...exited with code 137...",
+// "exit status 1"). It returns ok=false when no numeric code is present (a bare
+// "process exited"), in which case the caller must not assume anything about it.
+func codexExitCodeFromDetail(normalized string) (int, bool) {
+	for _, marker := range []string{"exited with code ", "exit status "} {
+		idx := strings.Index(normalized, marker)
+		if idx < 0 {
+			continue
+		}
+		rest := normalized[idx+len(marker):]
+		end := 0
+		for end < len(rest) && rest[end] >= '0' && rest[end] <= '9' {
+			end++
+		}
+		if end == 0 {
+			continue
+		}
+		if code, err := strconv.Atoi(rest[:end]); err == nil {
+			return code, true
+		}
+	}
+	return 0, false
+}
+
+// codexExitLooksInterrupted reports whether a process-exit detail describes a
+// clean shutdown (code 0) or a signal-termination (128+N, signals 1..31) rather
+// than Codex itself erroring out. Such exits mean the app-server was stopped or
+// killed externally, so the session was interrupted — not "Codex failed". When
+// no numeric code is present it returns false (stay with the generic
+// process_exited classification rather than guess).
+func codexExitLooksInterrupted(normalized string) bool {
+	code, ok := codexExitCodeFromDetail(normalized)
+	if !ok {
+		return false
+	}
+	return code == 0 || (code >= 129 && code <= 159)
 }
 
 // codexErrorLooksLikeNetwork reports whether the detail describes a DNS or
@@ -276,7 +357,8 @@ func codexErrorLooksLikeNetwork(lower string) bool {
 }
 
 func visibleFailureRetryable(code string, detail string) bool {
-	if code == "runtime_unavailable" || code == "request_timed_out" || code == "network_error" {
+	if code == "runtime_unavailable" || code == "request_timed_out" || code == "network_error" ||
+		code == "session_interrupted" {
 		return true
 	}
 	normalized := strings.ToLower(detail)
@@ -301,6 +383,8 @@ func visibleFailureContent(provider string, phase string, code string) string {
 			return fmt.Sprintf("%s could not apply session settings before startup timed out. Try again in a moment.", name)
 		case "provider_stream_disconnected":
 			return fmt.Sprintf("%s could not start because the response was interrupted. Try again in a moment.", name)
+		case "session_interrupted":
+			return fmt.Sprintf("%s stopped unexpectedly before it finished starting. Try again.", name)
 		case "request_timed_out":
 			return fmt.Sprintf("%s could not start before the request timed out.", name)
 		case "runtime_unavailable":
@@ -324,6 +408,8 @@ func visibleFailureContent(provider string, phase string, code string) string {
 		return fmt.Sprintf("%s could not apply session settings before the request timed out. Try again in a moment.", name)
 	case "provider_stream_disconnected":
 		return fmt.Sprintf("%s response was interrupted before it completed. Try again in a moment.", name)
+	case "session_interrupted":
+		return fmt.Sprintf("%s stopped unexpectedly before it finished responding. Try again.", name)
 	case "request_timed_out":
 		return fmt.Sprintf("%s request timed out.", name)
 	case "quota_or_rate_limit":

--- a/packages/agent/daemon/runtime/visible_error_test.go
+++ b/packages/agent/daemon/runtime/visible_error_test.go
@@ -42,11 +42,97 @@ func TestVisibleFailureCodeClassifiesStreamDisconnected(t *testing.T) {
 }
 
 func TestVisibleFailureCodeDoesNotTreatPatchContextLoginTextAsAuth(t *testing.T) {
+	// Test-function text in the stderr tail ("...Login...") must never read as
+	// codex auth. The process exited cleanly (code 0) with that apply_patch error
+	// only as incidental tail output, so it classifies as an interrupted session —
+	// the one thing it must NOT be is auth_required.
 	detail := `acp process exited with code 0: process exited: ERROR codex_core::tools::router: error=apply_patch verification failed: Failed to find expected lines in /Users/wwcome/work/tutti-os/tutti/services/tuttid/service/agentstatus/service_test.go:
 func TestServiceLoginRunsProviderLoginCommand(t *testing.T) {
 	service := testService(func(name string) (string, error) {`
-	if got := visibleFailureCode(detail); got != "process_exited" {
-		t.Fatalf("visibleFailureCode() = %q, want process_exited", got)
+	if got := visibleFailureCode(detail); got == "auth_required" {
+		t.Fatalf("visibleFailureCode() = auth_required, but embedded test text must not read as codex auth")
+	}
+}
+
+func TestVisibleFailureCodeDoesNotTreatMcpServerAuthAsCodexAuth(t *testing.T) {
+	// A Notion/Figma MCP server's expired OAuth token crashes codex's MCP client
+	// (rmcp) and bubbles up here. It mentions "access token"/"AuthRequired", which
+	// trips the auth pattern, but codex itself is still signed in — so this must
+	// NOT surface as "Codex needs authentication". The exit is code 0 (a clean
+	// shutdown), so it reads as an interrupted session, never auth_required.
+	detail := `acp process exited with code 0: process exited: ERROR rmcp::transport::worker: ` +
+		`worker quit with fatal: Transport channel closed, when AuthRequired(AuthRequiredError { ` +
+		`www_authenticate_header: "Bearer realm=\"OAuth\", ` +
+		`resource_metadata=\"https://mcp.notion.com/.well-known/oauth-protected-resource/mcp\", ` +
+		`error=\"invalid_token\", error_description=\"Missing or invalid access token\"" })`
+	if got := visibleFailureCode(detail); got == "auth_required" {
+		t.Fatalf("visibleFailureCode() = auth_required, but MCP server auth must not read as codex auth")
+	}
+	if got := visibleFailureCode(detail); got != "session_interrupted" {
+		t.Fatalf("visibleFailureCode() = %q, want session_interrupted (clean exit-0 MCP failure)", got)
+	}
+}
+
+func TestVisibleFailureCodeClassifiesCleanExitAsInterrupted(t *testing.T) {
+	// A clean exit (code 0) reaching here means the app-server was stopped
+	// externally mid-turn (host quit, or an agent killed its own host) — the
+	// session was interrupted, not "Codex request failed".
+	for _, detail := range []string{
+		"acp process exited with code 0: ",
+		"acp process exited with code 0: shutting down",
+	} {
+		if got := visibleFailureCode(detail); got != "session_interrupted" {
+			t.Fatalf("visibleFailureCode(%q) = %q, want session_interrupted", detail, got)
+		}
+	}
+	if !visibleFailureRetryable("session_interrupted", "acp process exited with code 0: ") {
+		t.Fatal("session_interrupted should be retryable")
+	}
+}
+
+func TestVisibleFailureCodeClassifiesSignalKillAsInterrupted(t *testing.T) {
+	// Signal-terminations (128+N: 137 SIGKILL, 143 SIGTERM, 130 SIGINT) are the
+	// process being killed externally, not codex erroring out.
+	for _, detail := range []string{
+		"acp process exited with code 137: ",
+		"acp process exited with code 143: ",
+		"acp process exited with code 130: ",
+	} {
+		if got := visibleFailureCode(detail); got != "session_interrupted" {
+			t.Fatalf("visibleFailureCode(%q) = %q, want session_interrupted", detail, got)
+		}
+	}
+}
+
+func TestVisibleFailureCodeClassifiesUsageLimitAsQuota(t *testing.T) {
+	// The most common real codex failure in the field is the ChatGPT usage cap,
+	// delivered as plain text (no structured codexErrorInfo). It must read as a
+	// quota/rate-limit, not a generic "request failed".
+	detail := "You've hit your usage limit. Upgrade to Pro (https://chatgpt.com/explore/pro), " +
+		"visit https://chatgpt.com/codex/settings/usage to purchase more credits or try again later."
+	if got := visibleFailureCode(detail); got != "quota_or_rate_limit" {
+		t.Fatalf("visibleFailureCode() = %q, want quota_or_rate_limit", got)
+	}
+}
+
+func TestVisibleFailureContentDescribesInterruptedSession(t *testing.T) {
+	got := visibleFailureContent(ProviderCodex, "turn", "session_interrupted")
+	want := "Codex stopped unexpectedly before it finished responding. Try again."
+	if got != want {
+		t.Fatalf("visibleFailureContent() = %q, want %q", got, want)
+	}
+}
+
+func TestVisibleFailureCodeStillClassifiesCodexOwnAuth(t *testing.T) {
+	// Codex's own login failure must still be auth_required (guard against the MCP
+	// exclusion being too broad).
+	for _, detail := range []string{
+		"acp process exited with code 1: process exited: not logged in. Please run /login.",
+		"401 Unauthorized: invalid authentication credentials",
+	} {
+		if got := visibleFailureCode(detail); got != "auth_required" {
+			t.Fatalf("visibleFailureCode(%q) = %q, want auth_required", detail, got)
+		}
 	}
 }
 

--- a/packages/agent/gui/agent-gui/agentGuiNode/AgentGUINodeView.layout.spec.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/AgentGUINodeView.layout.spec.tsx
@@ -1468,11 +1468,13 @@ describe("AgentGUINodeView provider setup notice", () => {
 
     expect(setupNoticeRule).toContain("position: absolute;");
     expect(setupNoticeRule).toContain("top: 8px;");
-    expect(setupNoticeRule).toContain(
-      "left: var(--agent-gui-detail-padding-x);"
-    );
+    // Horizontally centered above the detail content.
+    expect(setupNoticeRule).toContain("left: 50%;");
+    expect(setupNoticeRule).toContain("transform: translateX(-50%);");
     expect(setupNoticeRule).toContain("z-index: 2;");
     expect(setupNoticeRule).toContain("width: max-content;");
+    // Message text and the "Set up" action must not butt together.
+    expect(setupNoticeRule).toContain("column-gap: 6px;");
     expect(setupNoticeRule).toMatch(
       /max-width:\s*min\(\s*calc\(100% - \(var\(--agent-gui-detail-padding-x\) \* 2\)\),\s*420px\s*\);/s
     );

--- a/packages/agent/gui/app/renderer/agentactivity.css
+++ b/packages/agent/gui/app/renderer/agentactivity.css
@@ -5441,12 +5441,17 @@ button.agent-gui-node__conversation-section-toggle:hover
 .agent-gui-node__provider-setup-notice {
   position: absolute;
   top: 8px;
-  left: var(--agent-gui-detail-padding-x);
+  left: 50%;
+  transform: translateX(-50%);
   z-index: 2;
   box-sizing: border-box;
   width: max-content;
   max-width: min(calc(100% - (var(--agent-gui-detail-padding-x) * 2)), 420px);
   margin: 0;
+  /* The pill sizes to its content (width: max-content), so the action button's
+     margin-left:auto has no free space to absorb and the message text would butt
+     directly against "Set up". Space the message and action explicitly. */
+  column-gap: 6px;
   pointer-events: auto;
 }
 

--- a/packages/agent/gui/app/renderer/i18n/locales/en.ts
+++ b/packages/agent/gui/app/renderer/i18n/locales/en.ts
@@ -354,7 +354,7 @@ export const en = {
         "Type @ to reference sessions, files, tasks, and apps",
       followupPlaceholder: "Request follow-up changes from {{provider}}",
       installRequiredPlaceholder:
-        "Install {{provider}} from the dock to send messages",
+        "Finish setting up {{provider}} to send messages",
       installRequiredAction: "Set up",
       collaboratorSessionReadOnlyPlaceholder:
         "This session belongs to another user and cannot be replied to directly",

--- a/packages/agent/gui/app/renderer/i18n/locales/zh-CN.ts
+++ b/packages/agent/gui/app/renderer/i18n/locales/zh-CN.ts
@@ -326,8 +326,7 @@ export const zhCN = {
     agentGui: {
       initialPlaceholder: "输入 @ 引用会话、文件、任务和应用",
       followupPlaceholder: "要求 {{provider}} 继续后续变更",
-      installRequiredPlaceholder:
-        "请先从 Dock 安装 {{provider}}，然后再发送消息",
+      installRequiredPlaceholder: "请先完成 {{provider}} 配置，然后再发送消息",
       installRequiredAction: "设置",
       collaboratorSessionReadOnlyPlaceholder: "非当前用户会话，不可直接对话",
       send: "发送",

--- a/packages/agent/gui/shared/agentEnv/agentEnvWizardFlow.spec.ts
+++ b/packages/agent/gui/shared/agentEnv/agentEnvWizardFlow.spec.ts
@@ -288,9 +288,9 @@ describe("stageRemediation", () => {
     });
   });
 
-  it("maps an errored install to install-outdated → install", () => {
+  it("maps an errored install to install-outdated → redetect (manual upgrade, not auto-install)", () => {
     expect(stageRemediation(mk("install", "error"))).toEqual({
-      actionId: "install",
+      actionId: "redetect",
       problem: "install-outdated"
     });
   });
@@ -322,16 +322,19 @@ describe("resolveWizardAutoStartAction", () => {
     loginPending: false
   };
 
-  it("returns install for install/repair/upgrade focus", () => {
+  it("returns install for install/repair focus", () => {
     expect(resolveWizardAutoStartAction({ ...base, focus: "install" })).toBe(
       "install"
     );
     expect(resolveWizardAutoStartAction({ ...base, focus: "repair" })).toBe(
       "install"
     );
-    expect(resolveWizardAutoStartAction({ ...base, focus: "upgrade" })).toBe(
-      "install"
-    );
+  });
+
+  it("does NOT auto-start install for upgrade focus (CLI upgrades are user-driven)", () => {
+    expect(
+      resolveWizardAutoStartAction({ ...base, focus: "upgrade" })
+    ).toBeNull();
   });
 
   it("returns login for auth focus", () => {

--- a/packages/agent/gui/shared/agentEnv/agentEnvWizardFlow.ts
+++ b/packages/agent/gui/shared/agentEnv/agentEnvWizardFlow.ts
@@ -251,11 +251,13 @@ export function stageRemediation(
       // detection (which re-probes the network) is the remediation.
       return { actionId: "redetect", problem: "network-unreachable" };
     case "install":
-      return {
-        actionId: "install",
-        problem:
-          stage.status === "error" ? "install-outdated" : "install-missing"
-      };
+      // A genuinely missing CLI is installed for the user; a present-but-
+      // outdated CLI is NOT — we don't silently reinstall a binary the user
+      // manages. Instead the panel shows the manual upgrade command and
+      // re-detection confirms it once they've upgraded.
+      return stage.status === "error"
+        ? { actionId: "redetect", problem: "install-outdated" }
+        : { actionId: "install", problem: "install-missing" };
     case "adapter":
       return {
         actionId: "install",
@@ -308,8 +310,12 @@ function autoStartCandidate(
   switch (focus) {
     case "install":
     case "repair":
-    case "upgrade":
       return "install";
+    case "upgrade":
+      // CLI upgrades are user-driven: opening the panel from a version error
+      // shows the manual upgrade command rather than auto-running an install
+      // (which can't upgrade an already-present binary anyway).
+      return null;
     case "auth":
       return "login";
     default:

--- a/packages/clients/tuttid-ts/src/generated/types.gen.ts
+++ b/packages/clients/tuttid-ts/src/generated/types.gen.ts
@@ -941,6 +941,10 @@ export type AgentProviderCliStatus = {
   installed: boolean;
   binaryPath?: string | null;
   version?: string | null;
+  /**
+   * The lowest CLI version this provider supports, when it enforces a floor (currently codex). Lets the UI show "current X, requires Y" without duplicating the backend's version gate.
+   */
+  minVersion?: string | null;
 };
 
 export type AgentProviderAdapterStatus = {

--- a/services/tuttid/api/daemon_agent_statuses.go
+++ b/services/tuttid/api/daemon_agent_statuses.go
@@ -285,6 +285,7 @@ func generatedAgentProviderCLIStatus(status agentstatusservice.CLIStatus) tuttig
 		BinaryPath: stringPointerIfNotBlank(status.BinaryPath),
 		Installed:  status.Installed,
 		Version:    stringPointerIfNotBlank(status.Version),
+		MinVersion: stringPointerIfNotBlank(status.MinVersion),
 	}
 }
 

--- a/services/tuttid/api/generated/types.gen.go
+++ b/services/tuttid/api/generated/types.gen.go
@@ -1593,6 +1593,9 @@ type AgentProviderCapabilityOptionStatus string
 type AgentProviderCliStatus struct {
 	BinaryPath *string `json:"binaryPath,omitempty"`
 	Installed  bool    `json:"installed"`
+
+	// MinVersion The lowest CLI version this provider supports, when it enforces a floor (currently codex). Lets the UI show "current X, requires Y" without duplicating the backend's version gate.
+	MinVersion *string `json:"minVersion,omitempty"`
 	Version    *string `json:"version,omitempty"`
 }
 

--- a/services/tuttid/api/openapi/tuttid.v1.yaml
+++ b/services/tuttid/api/openapi/tuttid.v1.yaml
@@ -5384,6 +5384,13 @@ components:
         version:
           type: string
           nullable: true
+        minVersion:
+          type: string
+          nullable: true
+          description: >-
+            The lowest CLI version this provider supports, when it enforces a
+            floor (currently codex). Lets the UI show "current X, requires Y"
+            without duplicating the backend's version gate.
     AgentProviderAdapterStatus:
       type: object
       additionalProperties: false

--- a/services/tuttid/service/agentstatus/codex_platform.go
+++ b/services/tuttid/service/agentstatus/codex_platform.go
@@ -35,29 +35,74 @@ func codexNpmPlatformDir(goos, goarch string) (string, bool) {
 	return "codex-" + nodeOS + "-" + nodeArch, true
 }
 
+func codexPlatformTargetTriple(goos, goarch string) (string, bool) {
+	switch goos {
+	case "darwin":
+		switch goarch {
+		case "arm64":
+			return "aarch64-apple-darwin", true
+		case "amd64":
+			return "x86_64-apple-darwin", true
+		}
+	case "linux":
+		switch goarch {
+		case "arm64":
+			return "aarch64-unknown-linux-musl", true
+		case "amd64":
+			return "x86_64-unknown-linux-musl", true
+		}
+	case "windows":
+		switch goarch {
+		case "arm64":
+			return "aarch64-pc-windows-msvc", true
+		case "amd64":
+			return "x86_64-pc-windows-msvc", true
+		}
+	}
+	return "", false
+}
+
 // codexPlatformBinaryPath returns the absolute path to the platform-specific
 // codex binary inside an installed @openai/codex package directory.
 func codexPlatformBinaryPath(codexPkgDir, goos, goarch string) (string, bool) {
-	dir, ok := codexNpmPlatformDir(goos, goarch)
-	if !ok {
+	paths := codexPlatformBinaryCandidatePaths(codexPkgDir, goos, goarch)
+	if len(paths) == 0 {
 		return "", false
 	}
+	return paths[0], true
+}
+
+func codexPlatformBinaryCandidatePaths(codexPkgDir, goos, goarch string) []string {
 	binName := "codex"
 	if goos == "windows" {
 		binName = "codex.exe"
 	}
-	return filepath.Join(codexPkgDir, "node_modules", "@openai", dir, binName), true
+	dir, dirOK := codexNpmPlatformDir(goos, goarch)
+	if !dirOK {
+		return nil
+	}
+	paths := []string{}
+	if targetTriple, ok := codexPlatformTargetTriple(goos, goarch); ok {
+		paths = append(paths, filepath.Join(codexPkgDir, "node_modules", "@openai", dir, "vendor", targetTriple, "bin", binName))
+	}
+	paths = append(paths, filepath.Join(codexPkgDir, "node_modules", "@openai", dir, binName))
+	return paths
 }
 
 // codexPlatformBinaryComplete reports whether the platform-specific codex
 // binary is present and executable inside the given @openai/codex package
 // directory. It returns the resolved binary path alongside the verdict.
 func (s Service) codexPlatformBinaryComplete(codexPkgDir, goos, goarch string) (string, bool) {
-	path, ok := codexPlatformBinaryPath(codexPkgDir, goos, goarch)
-	if !ok {
+	paths := codexPlatformBinaryCandidatePaths(codexPkgDir, goos, goarch)
+	if len(paths) == 0 {
 		return "", false
 	}
-	return path, s.executableFile(path)
+	for _, path := range paths {
+		if s.executableFile(path) {
+			return path, true
+		}
+	}
+	return paths[0], false
 }
 
 func codexPackageDirForBinary(binaryPath string) string {

--- a/services/tuttid/service/agentstatus/codex_platform_test.go
+++ b/services/tuttid/service/agentstatus/codex_platform_test.go
@@ -31,12 +31,12 @@ func TestCodexNpmPlatformDir(t *testing.T) {
 func TestCodexPlatformBinaryPath(t *testing.T) {
 	pkg := "/home/u/.npm/lib/node_modules/@openai/codex"
 	got, ok := codexPlatformBinaryPath(pkg, "darwin", "arm64")
-	want := filepath.Join(pkg, "node_modules", "@openai", "codex-darwin-arm64", "codex")
+	want := filepath.Join(pkg, "node_modules", "@openai", "codex-darwin-arm64", "vendor", "aarch64-apple-darwin", "bin", "codex")
 	if !ok || got != want {
 		t.Fatalf("codexPlatformBinaryPath darwin/arm64 = (%q,%v), want (%q,true)", got, ok, want)
 	}
 	winGot, ok := codexPlatformBinaryPath(pkg, "windows", "amd64")
-	winWant := filepath.Join(pkg, "node_modules", "@openai", "codex-win32-x64", "codex.exe")
+	winWant := filepath.Join(pkg, "node_modules", "@openai", "codex-win32-x64", "vendor", "x86_64-pc-windows-msvc", "bin", "codex.exe")
 	if !ok || winGot != winWant {
 		t.Fatalf("codexPlatformBinaryPath windows = (%q,%v), want (%q,true)", winGot, ok, winWant)
 	}
@@ -47,7 +47,7 @@ func TestCodexPlatformBinaryPath(t *testing.T) {
 
 func TestServiceCodexPlatformBinaryComplete(t *testing.T) {
 	pkg := t.TempDir()
-	binPath := filepath.Join(pkg, "node_modules", "@openai", "codex-darwin-arm64", "codex")
+	binPath := filepath.Join(pkg, "node_modules", "@openai", "codex-darwin-arm64", "vendor", "aarch64-apple-darwin", "bin", "codex")
 
 	svc := Service{IsExecutableFile: func(p string) bool {
 		info, err := os.Stat(p)
@@ -77,5 +77,25 @@ func TestServiceCodexPlatformBinaryComplete(t *testing.T) {
 	path, complete := svc.codexPlatformBinaryComplete(pkg, "darwin", "arm64")
 	if !complete || path != binPath {
 		t.Fatalf("expected complete with path=%q, got (%q,%v)", binPath, path, complete)
+	}
+}
+
+func TestServiceCodexPlatformBinaryCompleteAcceptsLegacyBinaryPath(t *testing.T) {
+	pkg := t.TempDir()
+	legacyBinPath := filepath.Join(pkg, "node_modules", "@openai", "codex-darwin-arm64", "codex")
+	if err := os.MkdirAll(filepath.Dir(legacyBinPath), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(legacyBinPath, []byte("bin"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	svc := Service{IsExecutableFile: func(p string) bool {
+		info, err := os.Stat(p)
+		return err == nil && !info.IsDir() && info.Mode().Perm()&0o111 != 0
+	}}
+	path, complete := svc.codexPlatformBinaryComplete(pkg, "darwin", "arm64")
+	if !complete || path != legacyBinPath {
+		t.Fatalf("expected complete with legacy path=%q, got (%q,%v)", legacyBinPath, path, complete)
 	}
 }

--- a/services/tuttid/service/agentstatus/codex_version.go
+++ b/services/tuttid/service/agentstatus/codex_version.go
@@ -7,11 +7,18 @@ import (
 
 // MinSupportedCodexVersion is the lowest Codex CLI version Tutti supports.
 //
+// Capability-derived: 0.126.0 is the release that introduced the newest
+// app-server method our codex runtime integrates (the thread/goal API); every
+// other app-server capability we call landed earlier, and the enrichment ones
+// (account/models/rateLimits/collaborationMode/goal) degrade gracefully below
+// their version. So 0.126.0 is the floor at which the full app-server feature
+// set we wire up is present.
+//
 // Single tunable hard gate: a detected codex below this floor is flagged as
 // too old (surfaced as CODEX_VERSION_TOO_OLD) and the server-side 400 is the
 // backstop. Bump this constant when raising the floor; nothing else needs to
 // change.
-const MinSupportedCodexVersion = "0.142.1"
+const MinSupportedCodexVersion = "0.126.0"
 
 // compareCodexVersions compares two semver-ish version strings.
 //

--- a/services/tuttid/service/agentstatus/installer.go
+++ b/services/tuttid/service/agentstatus/installer.go
@@ -20,6 +20,7 @@ import (
 	"strings"
 
 	"github.com/tutti-os/tutti/packages/agentactivity/daemon/runtimecmd"
+	"github.com/tutti-os/tutti/services/tuttid/biz/agentprovider"
 	managedruntime "github.com/tutti-os/tutti/services/tuttid/service/managedruntime"
 )
 
@@ -173,7 +174,7 @@ func (s Service) installMissingProviderRuntime(
 	attemptedCLI := false
 	attemptedAdapter := false
 	for {
-		installer, missing, installTarget := nextMissingInstaller(spec, current)
+		installer, missing, installTarget := s.nextMissingInstaller(spec, current)
 		if !missing {
 			return summary, current, nil
 		}
@@ -264,8 +265,14 @@ func (s Service) installMissingProviderRuntime(
 	}
 }
 
-func nextMissingInstaller(spec ProviderSpec, runtime providerRuntimeResolution) (InstallerSpec, bool, string) {
+func (s Service) nextMissingInstaller(spec ProviderSpec, runtime providerRuntimeResolution) (InstallerSpec, bool, string) {
 	if strings.TrimSpace(runtime.CLIPath) == "" {
+		if spec.Install.Kind == "" {
+			return InstallerSpec{}, false, ""
+		}
+		return spec.Install, true, "cli"
+	}
+	if s.providerCLIRequiresInstall(spec, runtime) {
 		if spec.Install.Kind == "" {
 			return InstallerSpec{}, false, ""
 		}
@@ -294,6 +301,16 @@ func nextMissingInstaller(spec ProviderSpec, runtime providerRuntimeResolution) 
 		}
 	}
 	return InstallerSpec{}, false, ""
+}
+
+func (s Service) providerCLIRequiresInstall(spec ProviderSpec, runtime providerRuntimeResolution) bool {
+	if spec.Provider != agentprovider.Codex {
+		return false
+	}
+	if !s.codexPlatformBinaryOK(runtime.CLIPath) {
+		return true
+	}
+	return !codexVersionMeetsMinimum(s.cliVersion(context.Background(), runtime.CLIPath))
 }
 
 func adapterPackageRequirementSatisfied(requirement AdapterPackageRequirement, version string) bool {

--- a/services/tuttid/service/agentstatus/installer_codex_cli.go
+++ b/services/tuttid/service/agentstatus/installer_codex_cli.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"log/slog"
 	"net/url"
+	"path/filepath"
 	"runtime"
 	"slices"
 	"strings"
@@ -34,11 +35,22 @@ func (s Service) runCodexCLILatestInstaller(
 	resolver := s.commandResolver()
 	npmPath := firstNonBlank(resolveBinaryWithResolver(resolver, []string{npmBinaryName()}, nil), npmBinaryName())
 	nodeTarget := firstNonBlank(resolveBinaryWithResolver(resolver, []string{nodeBinaryName()}, nil), nodeBinaryName())
-	command := joinShellCommand([]string{npmPath, "install", "-g", "@openai/codex", "--include=optional"})
+	// A bare `npm install -g` lands the launcher in whichever npm's global prefix
+	// runs the install. In the desktop app that npm can be the bundled app-runtime
+	// node, whose prefix (~/.tutti/app-runtimes/.../node) is NOT on the binary
+	// resolver's search path — so the install succeeds but `codex` is never found
+	// and the wizard reports "provider CLI is still unavailable after install".
+	// Pin the global prefix to the same stable, always-searched dir the
+	// release-binary installer uses (selectInstallDir -> ~/.local/bin) so the
+	// launcher stays discoverable regardless of which npm executes the install.
+	installBinDir, err := s.selectInstallDir()
+	if err != nil {
+		return InstallCommandResult{ExitCode: 1, Stderr: err.Error()}, nil
+	}
+	command := joinShellCommand([]string{npmPath, "install", "-g", "--prefix", filepath.Dir(installBinDir), "@openai/codex", "--include=optional"})
 	baseEnv := s.commandResolver().Env(nil)
 	registries := s.agentNPMRegistries()
 	var result InstallCommandResult
-	var err error
 	for i, registry := range registries {
 		registryDisplay := displayNPMRegistry(registry)
 		setActiveAction("codex", ActiveAction{

--- a/services/tuttid/service/agentstatus/npm_registry.go
+++ b/services/tuttid/service/agentstatus/npm_registry.go
@@ -26,10 +26,13 @@ const (
 	tencentNPMRegistry = "https://mirrors.cloud.tencent.com/npm/"       // Tencent Cloud
 
 	// perRegistryInstallTimeout bounds each registry attempt so a blocked
-	// registry fails over to the next one quickly instead of consuming the whole
-	// install budget. Comfortably above observed install times (~6-44s), below the
-	// overall install timeout.
-	perRegistryInstallTimeout = 90 * time.Second
+	// registry fails over to the next one instead of consuming the whole install
+	// budget. It must clear a working-but-slow registry: a direct install of the
+	// codex package is ~6-44s, but the same large platform binary pulled through a
+	// (throttled) system proxy is ~76-100s+. 90s sat right on that edge and killed
+	// otherwise-succeeding installs, so it is set comfortably above the proxied
+	// case while staying below the overall install timeout.
+	perRegistryInstallTimeout = 150 * time.Second
 )
 
 // agentNPMRegistries returns the ordered list of npm registries to try for

--- a/services/tuttid/service/agentstatus/run_outcome.go
+++ b/services/tuttid/service/agentstatus/run_outcome.go
@@ -1,6 +1,9 @@
 package agentstatus
 
-import "sync"
+import (
+	"sync"
+	"time"
+)
 
 // RunOutcomeStore remembers, per provider, whether a recent agent RUN failed
 // authentication. The stateless status probe judges login by a local marker file
@@ -9,26 +12,32 @@ import "sync"
 // runtime records that here so the next status probe can override the stale
 // "authenticated" verdict and surface "needs login" in the dock and wizard.
 //
+// The recorded value is the failure timestamp (not just a bool) so the probe can
+// self-heal: once the provider's credential file is rewritten by a fresh login
+// (its mtime moves past the failure time), the stale "needs login" verdict is
+// dropped without waiting for the next successful run.
+//
 // It is a pointer so it survives the value-copies of Service: the runtime and the
 // status probe share one store.
 type RunOutcomeStore struct {
 	mu         sync.RWMutex
-	authFailed map[string]bool
+	authFailed map[string]time.Time
 }
 
 func NewRunOutcomeStore() *RunOutcomeStore {
-	return &RunOutcomeStore{authFailed: map[string]bool{}}
+	return &RunOutcomeStore{authFailed: map[string]time.Time{}}
 }
 
 // RecordAuthFailure marks a provider's login as invalidated by a runtime
-// authentication failure (e.g. a 401 when sending a message or on a trial run).
+// authentication failure (e.g. a 401 when sending a message or on a trial run),
+// stamping the moment it was observed.
 func (s *RunOutcomeStore) RecordAuthFailure(provider string) {
 	if s == nil {
 		return
 	}
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	s.authFailed[provider] = true
+	s.authFailed[provider] = time.Now()
 }
 
 // RecordSuccess clears the invalidation once a request goes through, so a fixed
@@ -55,10 +64,20 @@ func (s *RunOutcomeStore) clear(provider string) {
 // AuthInvalidated reports whether a recent run authentication failure means the
 // provider should be treated as needing login.
 func (s *RunOutcomeStore) AuthInvalidated(provider string) bool {
+	_, ok := s.AuthInvalidatedSince(provider)
+	return ok
+}
+
+// AuthInvalidatedSince returns the time a provider's last runtime auth failure was
+// recorded, and whether one is currently outstanding. The caller compares it
+// against the credential file's mtime to decide whether a fresh login has since
+// healed the failure.
+func (s *RunOutcomeStore) AuthInvalidatedSince(provider string) (time.Time, bool) {
 	if s == nil {
-		return false
+		return time.Time{}, false
 	}
 	s.mu.RLock()
 	defer s.mu.RUnlock()
-	return s.authFailed[provider]
+	at, ok := s.authFailed[provider]
+	return at, ok
 }

--- a/services/tuttid/service/agentstatus/run_outcome_test.go
+++ b/services/tuttid/service/agentstatus/run_outcome_test.go
@@ -3,6 +3,7 @@ package agentstatus
 import (
 	"context"
 	"testing"
+	"time"
 
 	"github.com/tutti-os/tutti/services/tuttid/biz/agentprovider"
 )
@@ -51,6 +52,51 @@ func TestResolveAuthOverriddenByRuntimeAuthFailure(t *testing.T) {
 	store.ClearAuthInvalidated(agentprovider.ClaudeCode)
 	if got := svc.resolveAuth(context.Background(), spec, true, ""); got.Status != AuthUnknown {
 		t.Fatalf("after re-auth clear = %q, want unknown", got.Status)
+	}
+}
+
+// A re-login rewrites the credential file after the failure was recorded; the
+// probe must self-heal (clear the stale flag and detect normally) instead of
+// sticking on "needs login" until the next successful run.
+func TestResolveAuthSelfHealsAfterCredentialRefresh(t *testing.T) {
+	store := NewRunOutcomeStore()
+	store.RecordAuthFailure(agentprovider.Codex)
+	refreshed := time.Now().Add(time.Hour) // marker newer than the recorded failure
+	svc := Service{
+		RunOutcomes: store,
+		HomeDir:     func() (string, error) { return t.TempDir(), nil },
+		FileExists:  func(string) bool { return true },
+		FileModTime: func(string) (time.Time, bool) { return refreshed, true },
+	}
+	spec := ProviderSpec{Provider: agentprovider.Codex, AuthMarkerPaths: []string{"~/.codex/auth.json"}}
+
+	if got := svc.resolveAuth(context.Background(), spec, true, ""); got.Status != AuthAuthenticated {
+		t.Fatalf("after re-login refresh = %q, want authenticated (self-healed)", got.Status)
+	}
+	if store.AuthInvalidated(agentprovider.Codex) {
+		t.Fatal("the stale flag should be cleared once credentials are refreshed")
+	}
+}
+
+// A failure with no newer credential file (token genuinely still broken) must
+// keep reporting "needs login".
+func TestResolveAuthKeepsFailureWhenCredentialStale(t *testing.T) {
+	store := NewRunOutcomeStore()
+	store.RecordAuthFailure(agentprovider.Codex)
+	stale := time.Now().Add(-time.Hour) // marker older than the recorded failure
+	svc := Service{
+		RunOutcomes: store,
+		HomeDir:     func() (string, error) { return t.TempDir(), nil },
+		FileExists:  func(string) bool { return true },
+		FileModTime: func(string) (time.Time, bool) { return stale, true },
+	}
+	spec := ProviderSpec{Provider: agentprovider.Codex, AuthMarkerPaths: []string{"~/.codex/auth.json"}}
+
+	if got := svc.resolveAuth(context.Background(), spec, true, ""); got.Status != AuthRequired {
+		t.Fatalf("stale credential after failure = %q, want required", got.Status)
+	}
+	if !store.AuthInvalidated(agentprovider.Codex) {
+		t.Fatal("the flag must persist while credentials remain unrefreshed")
 	}
 }
 

--- a/services/tuttid/service/agentstatus/service.go
+++ b/services/tuttid/service/agentstatus/service.go
@@ -150,6 +150,10 @@ type CLIStatus struct {
 	Installed  bool
 	BinaryPath string
 	Version    string
+	// MinVersion is the lowest CLI version this provider supports, when it
+	// enforces a floor (codex). Empty for providers with no version gate. Lets
+	// the UI surface "current X, requires Y" from the same constant the gate uses.
+	MinVersion string
 }
 
 type AdapterStatus struct {
@@ -190,6 +194,7 @@ type InstallCommandResult struct {
 type Service struct {
 	Environ                     func() []string
 	FileExists                  func(string) bool
+	FileModTime                 func(string) (time.Time, bool)
 	HomeDir                     func() (string, error)
 	HTTPClient                  *http.Client
 	ResolveProxy                func(*http.Request) (*url.URL, error)
@@ -213,7 +218,12 @@ type Service struct {
 const authStatusCommandTimeout = 5 * time.Second
 const authStatusCommandAttempts = 2
 const defaultAuthStatusCommandRetryDelay = 150 * time.Millisecond
-const defaultInstallTimeout = 5 * time.Minute
+
+// defaultInstallTimeout caps a whole install action. It must leave room for the
+// npm registry chain to fail over a few times at perRegistryInstallTimeout each
+// (e.g. a slow npmjs before a fast CN mirror) without prematurely killing a
+// registry that would have succeeded.
+const defaultInstallTimeout = 8 * time.Minute
 const defaultProbeReadyAfter = 600 * time.Millisecond
 const defaultProbeTimeout = 3 * time.Second
 const defaultProbeWaitDelay = 500 * time.Millisecond
@@ -517,6 +527,7 @@ func (s Service) statusForSpec(ctx context.Context, spec ProviderSpec, now time.
 		Actions: actions,
 	}
 	if spec.Provider == agentprovider.Codex {
+		status.CLI.MinVersion = MinSupportedCodexVersion
 		status.Checks = codexProviderChecks(status, codexPlatformOK)
 		status.LastError = codexProviderLastError(status)
 		status.ActiveAction = activeActionForProvider(spec.Provider)

--- a/services/tuttid/service/agentstatus/service_helpers.go
+++ b/services/tuttid/service/agentstatus/service_helpers.go
@@ -202,9 +202,15 @@ func (s Service) resolveAuth(ctx context.Context, spec ProviderSpec, installed b
 	}
 	// A runtime authentication failure (e.g. a 401 sending a message) invalidates
 	// the stale "logged in" marker/command result until the user re-authenticates
-	// or a request succeeds again.
-	if s.RunOutcomes.AuthInvalidated(spec.Provider) {
-		return AuthInfo{Status: AuthRequired}
+	// or a request succeeds again. We self-heal the moment the credential file is
+	// rewritten by a fresh login: re-login is a terminal action that never reports
+	// a "successful run", so without this the flag would stick until the user's
+	// next message succeeds, leaving the dock/wizard stuck on "needs login".
+	if failedAt, ok := s.RunOutcomes.AuthInvalidatedSince(spec.Provider); ok {
+		if !s.authCredentialsRefreshedAfter(spec, failedAt) {
+			return AuthInfo{Status: AuthRequired}
+		}
+		s.RunOutcomes.ClearAuthInvalidated(spec.Provider)
 	}
 	if len(spec.AuthStatusCommand) > 0 && strings.TrimSpace(binaryPath) != "" {
 		if auth, ok := s.resolveAuthFromCommand(ctx, spec, binaryPath); ok {
@@ -213,6 +219,26 @@ func (s Service) resolveAuth(ctx context.Context, spec ProviderSpec, installed b
 		return s.resolveAuthFromMarkers(spec)
 	}
 	return s.resolveAuthFromMarkers(spec)
+}
+
+// authCredentialsRefreshedAfter reports whether any of the provider's credential
+// marker files was modified after the given time — i.e. a login rewrote the
+// credentials since the recorded auth failure.
+func (s Service) authCredentialsRefreshedAfter(spec ProviderSpec, since time.Time) bool {
+	if len(spec.AuthMarkerPaths) == 0 {
+		return false
+	}
+	home, err := s.homeDir()
+	if err != nil || strings.TrimSpace(home) == "" {
+		return false
+	}
+	for _, marker := range spec.AuthMarkerPaths {
+		path := expandHomePath(marker, home)
+		if mod, ok := s.fileModTime(path); ok && mod.After(since) {
+			return true
+		}
+	}
+	return false
 }
 
 func (s Service) resolveAuthFromMarkers(spec ProviderSpec) AuthInfo {
@@ -605,6 +631,17 @@ func (s Service) fileExists(path string) bool {
 	}
 	stat, err := os.Stat(path)
 	return err == nil && !stat.IsDir()
+}
+
+func (s Service) fileModTime(path string) (time.Time, bool) {
+	if s.FileModTime != nil {
+		return s.FileModTime(path)
+	}
+	stat, err := os.Stat(path)
+	if err != nil || stat.IsDir() {
+		return time.Time{}, false
+	}
+	return stat.ModTime(), true
 }
 
 func (s Service) executableFile(path string) bool {

--- a/services/tuttid/service/agentstatus/service_test.go
+++ b/services/tuttid/service/agentstatus/service_test.go
@@ -1007,8 +1007,8 @@ func TestServiceRunCodexCLILatestInstallerUsesGlobalNPM(t *testing.T) {
 		!strings.Contains(command.Command, "-g") ||
 		!strings.Contains(command.Command, "@openai/codex") ||
 		!strings.Contains(command.Command, "--include=optional") ||
-		strings.Contains(command.Command, "--prefix") {
-		t.Fatalf("Command = %q, want global npm install with optional deps", command.Command)
+		!strings.Contains(command.Command, "--prefix") {
+		t.Fatalf("Command = %q, want global npm install with optional deps pinned to a searched --prefix", command.Command)
 	}
 	if !slices.Contains(command.Env, "npm_config_registry=https://registry.example.test") {
 		t.Fatalf("Env = %#v, want selected npm registry", command.Env)
@@ -1054,8 +1054,8 @@ func TestServiceRunCodexInstallerReportsGlobalNPMActiveAction(t *testing.T) {
 			!strings.Contains(input.Command, "-g") ||
 			!strings.Contains(input.Command, "@openai/codex") ||
 			!strings.Contains(input.Command, "--include=optional") ||
-			strings.Contains(input.Command, "--prefix") {
-			t.Errorf("Command = %q, want global npm install with optional deps", input.Command)
+			!strings.Contains(input.Command, "--prefix") {
+			t.Errorf("Command = %q, want global npm install with optional deps pinned to a searched --prefix", input.Command)
 		}
 		if !slices.Contains(input.Env, "npm_config_registry=https://registry.example.test") {
 			t.Errorf("Env = %#v, want selected npm registry", input.Env)

--- a/services/tuttid/service/agentstatus/service_test.go
+++ b/services/tuttid/service/agentstatus/service_test.go
@@ -358,6 +358,58 @@ func TestServiceProbeReportsCodexPlatformPackageIncomplete(t *testing.T) {
 	assertProviderCheck(t, result.Checks, "platform_binary", false)
 }
 
+func TestServiceRunActionReinstallsCodexWhenPlatformPackageIncomplete(t *testing.T) {
+	home := t.TempDir()
+	binDir := filepath.Join(home, "bin")
+	pkgDir := filepath.Join(home, "lib", "node_modules", "@openai", "codex")
+	writePackageManifest(t, pkgDir, "@openai/codex", MinSupportedCodexVersion)
+	codexPath := filepath.Join(pkgDir, "bin", "codex")
+	writeExecutable(t, codexPath, "#!/bin/sh\nif [ \"$1\" = \"--version\" ]; then echo 'codex "+MinSupportedCodexVersion+"'; exit 0; fi\nsleep 5\n")
+	if err := os.MkdirAll(binDir, 0o755); err != nil {
+		t.Fatalf("mkdir bin dir: %v", err)
+	}
+	if err := os.Symlink(codexPath, filepath.Join(binDir, "codex")); err != nil {
+		t.Fatalf("symlink codex: %v", err)
+	}
+	platformBinary, ok := codexPlatformBinaryPath(pkgDir, runtime.GOOS, runtime.GOARCH)
+	if !ok {
+		t.Skipf("codex platform package is unsupported for %s/%s", runtime.GOOS, runtime.GOARCH)
+	}
+
+	service := probeTestService(home)
+	service.Environ = func() []string {
+		return []string{"PATH=" + binDir, agentNPMRegistryEnv + "=https://registry.example.test"}
+	}
+	service.IsExecutableFile = isTestExecutable
+	service.RunAuthStatusCommand = func(context.Context, ProviderSpec, string) (AuthInfo, bool) {
+		return AuthInfo{Status: AuthAuthenticated}, true
+	}
+	var command InstallCommandInput
+	service.InstallCommand = func(_ context.Context, input InstallCommandInput) (InstallCommandResult, error) {
+		command = input
+		writeExecutable(t, platformBinary, "#!/bin/sh\nexit 0\n")
+		return InstallCommandResult{ExitCode: 0, Stdout: "installed"}, nil
+	}
+
+	result, err := service.RunAction(context.Background(), RunActionInput{
+		Provider: "codex",
+		ActionID: ActionInstall,
+	})
+	if err != nil {
+		t.Fatalf("RunAction() error = %v", err)
+	}
+	if result.Status != RunActionCompleted {
+		t.Fatalf("Status = %q, want %q; result=%#v", result.Status, RunActionCompleted, result)
+	}
+	if !strings.Contains(command.Command, "@openai/codex") ||
+		!strings.Contains(command.Command, "--include=optional") {
+		t.Fatalf("Command = %q, want Codex CLI install with optional dependencies", command.Command)
+	}
+	if result.Probe == nil || result.Probe.Status != ProbeReady {
+		t.Fatalf("Probe = %#v, want ready probe", result.Probe)
+	}
+}
+
 func TestServiceListReportsInstallActionWhenCodexAdapterCommandFails(t *testing.T) {
 	home := t.TempDir()
 	binDir := filepath.Join(home, "bin")


### PR DESCRIPTION
Follow-ups on top of the merged codex setup wizard (#368), found while testing the install/auth/upgrade flows against a real (proxied, China) environment.

## What's in here

**Auth self-heal after re-login** — A runtime 401 (expired/revoked token) flags the provider as needs-login. Re-login is a terminal action that never reports a successful run, so the flag previously stuck on "Not signed in" no matter how many times you re-checked. The probe now self-heals once the credential file is rewritten by a fresh login (its mtime moves past the recorded failure).

**Version floor → 0.126.0** — Capability-derived (the release that introduced the newest app-server method the codex runtime integrates), replacing the arbitrary 0.142.1 "latest at the time".

**Prompt to upgrade instead of a no-op auto-install** — An outdated-but-present codex CLI can't be upgraded by `npm install -g` (it's already present, so nothing installs and verification re-fails). The wizard now shows the manual upgrade command + re-check for the *outdated* case, while genuinely-missing still auto-installs.

**Show current/required version when too old** — The outdated state suppressed the version detail; it now shows `current X · requires ≥ Y`, with the floor plumbed from the backend's own gate (`status.cli.minVersion`) — single source of truth.

**Widen the install timeout for proxied downloads** — The codex platform binary is large; direct it's ~6-44s, but through a throttled system proxy it's ~76-100s+ — right at the old 90s per-registry cap, so otherwise-succeeding installs were killed and the whole registry chain timed out. Per-registry 90s → 150s, overall budget 5m → 8m. (npm install is kept — its CN mirror chain + global install fit the user base better than archive download.)

**Setup notice polish** — Center the floating pill, space the message and "Set up" action, and use neutral copy that fits every not-ready state instead of always saying "install".

## Verification
- Go: build + `agentstatus` + `api` tests green
- Renderer: agentEnv flow + notice layout specs green (83 tests), desktop + agent-gui typecheck clean
- i18n parity + generated OpenAPI types in sync

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Setup and status screens now show Codex CLI requirements (including minimum supported version) and display stage details when available.
  * The environment wizard now guides outdated CLI upgrades via a manual command, then re-checks.
* **Bug Fixes**
  * Login now self-recovers after refreshed credentials, preventing a stuck “needs login” state.
  * Install/probing is more resilient on slow/throttled proxy networks with expanded timeout budgets.
  * Runtime feedback more accurately detects interrupted sessions and classifies related failures correctly.
* **UI/UX**
  * Improved provider setup notice centering/spacing, updated install-outdated remediation to use “redetect,” and refined related prompt wording.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->