### PR TITLE
feat(agent-cli): expose session turn lifecycle

### DIFF
--- a/docs/conventions/tutti-cli-contract.md
+++ b/docs/conventions/tutti-cli-contract.md
@@ -116,6 +116,11 @@ Action commands should return the smallest useful confirmation payload. For
 agent session actions, this normally means session id, provider, status, and
 whether a launch/open request was published.
 
+Agent session compact/detail JSON may include additive runtime protocol fields
+such as `turnLifecycle` and `submitAvailability` when the daemon has them. Keep
+their field names aligned with the HTTP/OpenAPI session shape so CLI callers can
+reason about active turns without switching transports.
+
 ## Naming Rules
 
 Command path segments and input names use lowercase kebab-case.

--- a/services/tuttid/service/cli/providers/agentcontext/compact_output.go
+++ b/services/tuttid/service/cli/providers/agentcontext/compact_output.go
@@ -70,10 +70,12 @@ func turnLifecycleCompactValue(value *agentservice.TurnLifecycle) map[string]any
 	result := map[string]any{
 		"activeTurnId": nil,
 		"phase":        strings.TrimSpace(value.Phase),
-		"settling":     value.Settling,
 	}
 	if value.ActiveTurnID != nil {
 		result["activeTurnId"] = strings.TrimSpace(*value.ActiveTurnID)
+	}
+	if value.Settling {
+		result["settling"] = true
 	}
 	if value.Outcome != nil {
 		result["outcome"] = strings.TrimSpace(*value.Outcome)
@@ -91,10 +93,13 @@ func submitAvailabilityCompactValue(value *agentservice.SubmitAvailability) map[
 	if value == nil {
 		return nil
 	}
-	return map[string]any{
-		"state":  strings.TrimSpace(value.State),
-		"reason": strings.TrimSpace(value.Reason),
+	result := map[string]any{
+		"state": strings.TrimSpace(value.State),
 	}
+	if reason := strings.TrimSpace(value.Reason); reason != "" {
+		result["reason"] = reason
+	}
+	return result
 }
 
 func messageCompactValue(message agentservice.SessionMessage) map[string]any {

--- a/services/tuttid/service/cli/providers/agentcontext/compact_output.go
+++ b/services/tuttid/service/cli/providers/agentcontext/compact_output.go
@@ -23,6 +23,12 @@ func sessionSummaryValue(session agentservice.Session) map[string]any {
 	if session.Title != nil {
 		value["title"] = strings.TrimSpace(*session.Title)
 	}
+	if turnLifecycle := turnLifecycleCompactValue(session.TurnLifecycle); turnLifecycle != nil {
+		value["turnLifecycle"] = turnLifecycle
+	}
+	if submitAvailability := submitAvailabilityCompactValue(session.SubmitAvailability); submitAvailability != nil {
+		value["submitAvailability"] = submitAvailability
+	}
 	return value
 }
 
@@ -55,6 +61,40 @@ func sessionSummaryValues(sessions []agentservice.Session) []any {
 		values = append(values, sessionSummaryValue(session))
 	}
 	return values
+}
+
+func turnLifecycleCompactValue(value *agentservice.TurnLifecycle) map[string]any {
+	if value == nil {
+		return nil
+	}
+	result := map[string]any{
+		"activeTurnId": nil,
+		"phase":        strings.TrimSpace(value.Phase),
+		"settling":     value.Settling,
+	}
+	if value.ActiveTurnID != nil {
+		result["activeTurnId"] = strings.TrimSpace(*value.ActiveTurnID)
+	}
+	if value.Outcome != nil {
+		result["outcome"] = strings.TrimSpace(*value.Outcome)
+	}
+	if value.CompletedCommand != nil {
+		result["completedCommand"] = map[string]any{
+			"kind":   strings.TrimSpace(value.CompletedCommand.Kind),
+			"status": strings.TrimSpace(value.CompletedCommand.Status),
+		}
+	}
+	return result
+}
+
+func submitAvailabilityCompactValue(value *agentservice.SubmitAvailability) map[string]any {
+	if value == nil {
+		return nil
+	}
+	return map[string]any{
+		"state":  strings.TrimSpace(value.State),
+		"reason": strings.TrimSpace(value.Reason),
+	}
 }
 
 func messageCompactValue(message agentservice.SessionMessage) map[string]any {

--- a/services/tuttid/service/cli/providers/agentcontext/compact_output_test.go
+++ b/services/tuttid/service/cli/providers/agentcontext/compact_output_test.go
@@ -49,6 +49,73 @@ func TestSessionSummaryValueOmitsRuntimeContext(t *testing.T) {
 	if _, ok := value["permissionConfig"]; ok {
 		t.Fatalf("value = %#v", value)
 	}
+	if _, ok := value["turnLifecycle"]; ok {
+		t.Fatalf("nil turn lifecycle should be omitted: %#v", value)
+	}
+	if _, ok := value["submitAvailability"]; ok {
+		t.Fatalf("nil submit availability should be omitted: %#v", value)
+	}
+}
+
+func TestSessionSummaryValueIncludesTurnLifecycleAndSubmitAvailability(t *testing.T) {
+	value := sessionSummaryValue(agentserviceSessionWithLifecycle())
+
+	lifecycle, ok := value["turnLifecycle"].(map[string]any)
+	if !ok {
+		t.Fatalf("turnLifecycle = %#v", value["turnLifecycle"])
+	}
+	if lifecycle["activeTurnId"] != "TURN-1" {
+		t.Fatalf("turnLifecycle = %#v", lifecycle)
+	}
+	if lifecycle["phase"] != "completed" {
+		t.Fatalf("turnLifecycle phase = %#v", lifecycle["phase"])
+	}
+	if lifecycle["settling"] != true {
+		t.Fatalf("turnLifecycle settling = %#v", lifecycle["settling"])
+	}
+	if lifecycle["outcome"] != "success" {
+		t.Fatalf("turnLifecycle outcome = %#v", lifecycle["outcome"])
+	}
+	completedCommand, ok := lifecycle["completedCommand"].(map[string]any)
+	if !ok {
+		t.Fatalf("completedCommand = %#v", lifecycle["completedCommand"])
+	}
+	if completedCommand["status"] != "succeeded" {
+		t.Fatalf("completedCommand status = %#v", completedCommand["status"])
+	}
+
+	availability, ok := value["submitAvailability"].(map[string]any)
+	if !ok {
+		t.Fatalf("submitAvailability = %#v", value["submitAvailability"])
+	}
+	if availability["state"] != "blocked" {
+		t.Fatalf("submitAvailability state = %#v", availability["state"])
+	}
+	if availability["reason"] != "turn_running" {
+		t.Fatalf("submitAvailability reason = %#v", availability["reason"])
+	}
+}
+
+func TestSessionInspectValueIncludesTurnLifecycleAndSubmitAvailability(t *testing.T) {
+	value := sessionInspectValue(agentserviceSessionWithLifecycle())
+
+	lifecycle, ok := value["turnLifecycle"].(map[string]any)
+	if !ok {
+		t.Fatalf("turnLifecycle = %#v", value["turnLifecycle"])
+	}
+	if lifecycle["phase"] != "completed" {
+		t.Fatalf("turnLifecycle phase = %#v", lifecycle["phase"])
+	}
+	completedCommand, ok := lifecycle["completedCommand"].(map[string]any)
+	if !ok {
+		t.Fatalf("completedCommand = %#v", lifecycle["completedCommand"])
+	}
+	if completedCommand["status"] != "succeeded" {
+		t.Fatalf("completedCommand status = %#v", completedCommand["status"])
+	}
+	if _, ok := value["submitAvailability"].(map[string]any); !ok {
+		t.Fatalf("submitAvailability = %#v", value["submitAvailability"])
+	}
 }
 
 func agentserviceSessionWithRuntime() agentservice.Session {
@@ -59,5 +126,31 @@ func agentserviceSessionWithRuntime() agentservice.Session {
 		Status:         "working",
 		Title:          &title,
 		RuntimeContext: map[string]any{"model": "gpt-5"},
+	}
+}
+
+func agentserviceSessionWithLifecycle() agentservice.Session {
+	title := "Work"
+	activeTurnID := " TURN-1 "
+	outcome := " success "
+	return agentservice.Session{
+		ID:       "SESSION-1",
+		Provider: "codex",
+		Status:   "working",
+		Title:    &title,
+		TurnLifecycle: &agentservice.TurnLifecycle{
+			ActiveTurnID: &activeTurnID,
+			Phase:        " completed ",
+			Settling:     true,
+			Outcome:      &outcome,
+			CompletedCommand: &agentservice.CompletedCommand{
+				Kind:   " exec ",
+				Status: " succeeded ",
+			},
+		},
+		SubmitAvailability: &agentservice.SubmitAvailability{
+			State:  " blocked ",
+			Reason: " turn_running ",
+		},
 	}
 }

--- a/services/tuttid/service/cli/providers/agentcontext/compact_output_test.go
+++ b/services/tuttid/service/cli/providers/agentcontext/compact_output_test.go
@@ -118,6 +118,44 @@ func TestSessionInspectValueIncludesTurnLifecycleAndSubmitAvailability(t *testin
 	}
 }
 
+func TestSessionSummaryValueOmitsOptionalEmptyRuntimeProtocolFields(t *testing.T) {
+	value := sessionSummaryValue(agentservice.Session{
+		ID:       "SESSION-1",
+		Provider: "codex",
+		Status:   "ready",
+		TurnLifecycle: &agentservice.TurnLifecycle{
+			Phase:    " ready ",
+			Settling: false,
+		},
+		SubmitAvailability: &agentservice.SubmitAvailability{
+			State:  " available ",
+			Reason: " ",
+		},
+	})
+
+	lifecycle, ok := value["turnLifecycle"].(map[string]any)
+	if !ok {
+		t.Fatalf("turnLifecycle = %#v", value["turnLifecycle"])
+	}
+	if lifecycle["phase"] != "ready" {
+		t.Fatalf("turnLifecycle phase = %#v", lifecycle["phase"])
+	}
+	if _, ok := lifecycle["settling"]; ok {
+		t.Fatalf("false settling should be omitted: %#v", lifecycle)
+	}
+
+	availability, ok := value["submitAvailability"].(map[string]any)
+	if !ok {
+		t.Fatalf("submitAvailability = %#v", value["submitAvailability"])
+	}
+	if availability["state"] != "available" {
+		t.Fatalf("submitAvailability state = %#v", availability["state"])
+	}
+	if _, ok := availability["reason"]; ok {
+		t.Fatalf("blank reason should be omitted: %#v", availability)
+	}
+}
+
 func agentserviceSessionWithRuntime() agentservice.Session {
 	title := "Work"
 	return agentservice.Session{


### PR DESCRIPTION
## Summary
- include optional turnLifecycle and submitAvailability in agent session compact/detail CLI JSON
- keep field names aligned with the daemon HTTP session shape
- document the additive CLI JSON fields in the Tutti CLI contract

## Validation
- pnpm check:full

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Session summaries and inspect views can now include additional runtime status details when available, such as turn lifecycle and submission availability.

* **Bug Fixes**
  * Improved consistency of CLI session output so active turn information and command completion status can be represented across transports.
  * Ensured these new details are omitted and normalized cleanly when not present or when optional fields are effectively empty.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->