### PR TITLE
fix(agent-gui): keep first prompt messages in live transcript

### DIFF
--- a/docs/architecture/agent-gui-node.md
+++ b/docs/architecture/agent-gui-node.md
@@ -788,6 +788,16 @@ Quick checks:
 - Confirm pending overlay messages are inserted and later reconciled.
 - Confirm live events or message page reload contains a newer version.
 - Inspect timeline item merge and dedupe keys.
+- When the selected detail window only contains optimistic prompt messages,
+  do not use their local timestamp-derived versions as durable message-window
+  bounds; live runtime messages can have lower authoritative sequence versions
+  and must still enter the transcript before a refresh.
+- When a live message or lifecycle patch reveals the real turn ID for a
+  first-prompt create, retarget the optimistic prompt from its pending
+  client-submit turn ID only after the event is known to belong to the current
+  submit; retained history must not retarget that optimistic prompt. Do this
+  before projecting rows so the user prompt stays grouped above the agent
+  response.
 
 Likely fix area:
 

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUINodeController.spec.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUINodeController.spec.tsx
@@ -92,6 +92,28 @@ function conversationBodies(viewModel: {
   ).filter(Boolean);
 }
 
+function conversationMessageRows(viewModel: {
+  conversation?: {
+    rows: readonly {
+      kind: string;
+      speaker?: string;
+      messages?: readonly { body?: string }[];
+    }[];
+  } | null;
+}): Array<{ speaker: string; body: string }> {
+  return (
+    viewModel.conversation?.rows.flatMap((row) => {
+      if (row.kind !== "message" || !row.speaker || !row.messages) {
+        return [];
+      }
+      return row.messages
+        .map((message) => message.body?.trim() ?? "")
+        .filter(Boolean)
+        .map((body) => ({ speaker: row.speaker!, body }));
+    }) ?? []
+  );
+}
+
 function promptContent(text: string): { content: AgentPromptContentBlock[] } {
   return { content: promptBlocks(text) };
 }
@@ -2742,6 +2764,129 @@ describe("useAgentGUINodeController", () => {
       expect(result.current.viewModel.activeConversation?.id).toBe(createdId);
     });
     expect(exec).not.toHaveBeenCalled();
+  });
+
+  it("renders live assistant messages for a newly created session with only an optimistic prompt in detail", async () => {
+    let resolveActivation:
+      | ((value: AgentHostActivateAgentSessionResult) => void)
+      | undefined;
+    const activate = vi.fn((input: AgentHostActivateAgentSessionInput) => {
+      if (input.mode === "existing") {
+        return Promise.resolve({
+          session: agentSession(input.agentSessionId),
+          activation: { mode: input.mode, status: "attached" as const }
+        });
+      }
+      return new Promise<AgentHostActivateAgentSessionResult>((resolve) => {
+        resolveActivation = resolve;
+      });
+    });
+    const subscribeEvents = vi.fn(() => vi.fn());
+    installAgentHostApi({
+      list: vi.fn(async () => ({ presences: [], sessions: [] })),
+      listSessionTimeline: vi.fn(async () => ({ timelineItems: [] })),
+      subscribeEvents,
+      activate
+    });
+
+    const { result } = renderHook(() =>
+      useAgentGUINodeController({
+        workspaceId: "room-1",
+        currentUserId: "user-1",
+        workspacePath: "/workspace",
+        avoidGroupingEdits: false,
+        data: agentGuiData(null),
+        onDataChange: vi.fn()
+      })
+    );
+
+    await waitFor(() => {
+      expect(result.current.viewModel.activeConversationId).toBeNull();
+    });
+
+    act(() => {
+      result.current.actions.submitPrompt(promptBlocks("Start a fresh chat"));
+    });
+
+    await waitFor(() => {
+      expect(activate).toHaveBeenCalledWith(
+        expect.objectContaining({
+          mode: "new",
+          ...initialPromptContent("Start a fresh chat")
+        })
+      );
+    });
+    const createdId = activate.mock.calls[0]![0].agentSessionId;
+
+    act(() => {
+      resolveActivation?.({
+        session: agentSession(createdId, { status: "working" }),
+        activation: { mode: "new", status: "attached" }
+      });
+    });
+
+    await waitFor(() => {
+      expect(result.current.viewModel.activeConversationId).toBe(createdId);
+      expect(conversationBodies(result.current.viewModel)).toContain(
+        "Start a fresh chat"
+      );
+    });
+    await waitFor(() => {
+      expect(subscribeEvents).toHaveBeenCalledWith(
+        expect.objectContaining({
+          agentSessionId: createdId,
+          workspaceId: "room-1"
+        }),
+        expect.any(Function)
+      );
+    });
+
+    act(() => {
+      emitRuntimeSessionEventForTests?.(
+        streamMessage({
+          agentSessionId: createdId,
+          eventId: "assistant-old-history",
+          id: 1,
+          role: "assistant",
+          content: "Old retained answer",
+          turnId: "turn-old",
+          occurredAtUnixMs: 1
+        })
+      );
+    });
+
+    await waitFor(() => {
+      expect(conversationMessageRows(result.current.viewModel)).toEqual([
+        { speaker: "user", body: "Start a fresh chat" }
+      ]);
+      expect(conversationBodies(result.current.viewModel)).not.toContain(
+        "Old retained answer"
+      );
+    });
+
+    act(() => {
+      emitRuntimeSessionEventForTests?.(
+        streamMessage({
+          agentSessionId: createdId,
+          eventId: "assistant-first",
+          id: 2,
+          role: "assistant",
+          content: "First answer",
+          turnId: "turn-1",
+          occurredAtUnixMs: Date.now() + 1_000
+        })
+      );
+    });
+
+    await waitFor(() => {
+      expect(conversationBodies(result.current.viewModel)).toEqual(
+        expect.arrayContaining(["Start a fresh chat", "First answer"])
+      );
+      expect(conversationMessageRows(result.current.viewModel)).toEqual([
+        { speaker: "user", body: "Start a fresh chat" },
+        { speaker: "assistant", body: "First answer" }
+      ]);
+    });
   });
 
   it("inherits the current same-provider model when creating a new conversation without a draft model", async () => {
@@ -14287,7 +14432,8 @@ function timelineMessage({
   eventId,
   role,
   content,
-  turnId
+  turnId,
+  occurredAtUnixMs
 }: {
   agentSessionId: string;
   id: number;
@@ -14295,7 +14441,9 @@ function timelineMessage({
   role: "user" | "assistant";
   content: string;
   turnId?: string;
+  occurredAtUnixMs?: number;
 }): AgentHostWorkspaceAgentTimelineItem {
+  const messageTimeUnixMs = occurredAtUnixMs ?? id;
   return {
     id,
     workspaceId: "room-1",
@@ -14307,8 +14455,8 @@ function timelineMessage({
     itemType: "message",
     role,
     content,
-    occurredAtUnixMs: id,
-    createdAtUnixMs: id
+    occurredAtUnixMs: messageTimeUnixMs,
+    createdAtUnixMs: messageTimeUnixMs
   };
 }
 

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUINodeController.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUINodeController.ts
@@ -178,6 +178,7 @@ const EMPTY_AGENT_GUI_MESSAGES: readonly WorkspaceAgentActivityMessage[] = [];
 const EMPTY_AGENT_GUI_AVAILABLE_COMMANDS: AgentSessionCommand[] = [];
 const ACTIVITY_STREAM_STATE_RELOAD_DEBOUNCE_MS = 150;
 const AGENT_GUI_DETAIL_MESSAGES_PAGE_SIZE = 100;
+const AGENT_GUI_SUBMIT_RETARGET_EARLY_MESSAGE_TOLERANCE_MS = 5_000;
 
 function mergeAgentModelCatalogInvalidationEvents(
   events: AgentModelCatalogInvalidatedEvent[]
@@ -1187,8 +1188,21 @@ function filterMessagesForDetailWindowOverlay(input: {
     });
   }
 
-  const oldestDetailVersion = minFiniteMessageVersion(input.detailMessages);
-  const newestDetailVersion = maxFiniteMessageVersion(input.detailMessages);
+  const boundedDetailMessages = input.detailMessages.filter(
+    (message) => !isWorkspaceAgentActivityOptimisticMessage(message)
+  );
+  const oldestDetailVersion = minFiniteMessageVersion(boundedDetailMessages);
+  const newestDetailVersion = maxFiniteMessageVersion(boundedDetailMessages);
+  if (oldestDetailVersion === null && newestDetailVersion === null) {
+    const optimisticWindowMessages = filterMessagesForOptimisticDetailWindow({
+      detailMessages: input.detailMessages,
+      localMessages: input.localMessages
+    });
+    return optimisticWindowMessages.length > 0 ||
+      input.detailMessages.some(isWorkspaceAgentActivityOptimisticMessage)
+      ? optimisticWindowMessages
+      : [...input.localMessages];
+  }
   return input.localMessages.filter((message) => {
     if (isWorkspaceAgentActivityOptimisticMessage(message)) {
       return true;
@@ -1203,6 +1217,99 @@ function filterMessagesForDetailWindowOverlay(input: {
       oldestDetailVersion !== null && message.version >= oldestDetailVersion
     );
   });
+}
+
+function filterMessagesForOptimisticDetailWindow(input: {
+  detailMessages: readonly WorkspaceAgentActivityMessage[];
+  localMessages: readonly WorkspaceAgentActivityMessage[];
+}): WorkspaceAgentActivityMessage[] {
+  const optimisticTurnIds = new Set(
+    input.detailMessages
+      .filter(isWorkspaceAgentActivityOptimisticMessage)
+      .map((message) => message.turnId?.trim() ?? "")
+      .filter(Boolean)
+  );
+  if (optimisticTurnIds.size === 0) {
+    return [];
+  }
+  return input.localMessages.filter((message) => {
+    if (isWorkspaceAgentActivityOptimisticMessage(message)) {
+      return true;
+    }
+    const turnId = message.turnId?.trim() ?? "";
+    return turnId !== "" && optimisticTurnIds.has(turnId);
+  });
+}
+
+function retargetOptimisticPromptMessages(
+  messages: readonly WorkspaceAgentActivityMessage[],
+  input: { clientSubmitId: string; turnId: string }
+): { changed: boolean; messages: WorkspaceAgentActivityMessage[] } {
+  const clientSubmitId = input.clientSubmitId.trim();
+  const turnId = input.turnId.trim();
+  if (!clientSubmitId || !turnId || messages.length === 0) {
+    return { changed: false, messages: [...messages] };
+  }
+  const pendingTurnId = createPendingOptimisticTurnId(clientSubmitId);
+  let changed = false;
+  const retargeted = messages.map((message) => {
+    if (
+      !isWorkspaceAgentActivityOptimisticMessage(message) ||
+      message.turnId?.trim() !== pendingTurnId
+    ) {
+      return message;
+    }
+    const messageClientSubmitId = message.payload?.clientSubmitId;
+    if (
+      typeof messageClientSubmitId === "string" &&
+      messageClientSubmitId.trim() &&
+      messageClientSubmitId.trim() !== clientSubmitId
+    ) {
+      return message;
+    }
+    changed = true;
+    return { ...message, turnId };
+  });
+  return { changed, messages: retargeted };
+}
+
+function shouldRetargetOptimisticPromptFromMessage(
+  message: WorkspaceAgentActivityMessage,
+  trace: AgentSubmitTraceState
+): boolean {
+  const turnId = message.turnId?.trim() ?? "";
+  if (!turnId || trace.turnId) {
+    return false;
+  }
+  const clientSubmitId = stringPayloadValue(message.payload, "clientSubmitId");
+  if (clientSubmitId?.trim()) {
+    return clientSubmitId.trim() === trace.clientSubmitId;
+  }
+  if (message.role.trim().toLowerCase() === "user") {
+    return false;
+  }
+  const messageTimeUnixMs = messageActivityTimeUnixMs(message);
+  return (
+    messageTimeUnixMs === null ||
+    messageTimeUnixMs >=
+      trace.startedAtUnixMs -
+        AGENT_GUI_SUBMIT_RETARGET_EARLY_MESSAGE_TOLERANCE_MS
+  );
+}
+
+function messageActivityTimeUnixMs(
+  message: WorkspaceAgentActivityMessage
+): number | null {
+  for (const value of [
+    message.occurredAtUnixMs,
+    message.startedAtUnixMs,
+    message.completedAtUnixMs
+  ]) {
+    if (typeof value === "number" && Number.isFinite(value) && value > 0) {
+      return value;
+    }
+  }
+  return null;
 }
 
 function minFiniteMessageVersion(
@@ -5048,6 +5155,47 @@ export function useAgentGUINodeController({
     ]
   );
 
+  const retargetOptimisticPromptTurn = useCallback(
+    (agentSessionId: string, clientSubmitId: string, turnId: string) => {
+      const normalizedAgentSessionId = agentSessionId.trim();
+      const normalizedTurnId = turnId.trim();
+      if (
+        !normalizedAgentSessionId ||
+        !clientSubmitId.trim() ||
+        !normalizedTurnId
+      ) {
+        return;
+      }
+      const sessionView = getAgentSessionView(
+        sessionViewRef(normalizedAgentSessionId)
+      );
+      if (!sessionView) {
+        return;
+      }
+      const detail = retargetOptimisticPromptMessages(
+        sessionView.detailMessages,
+        { clientSubmitId, turnId: normalizedTurnId }
+      );
+      if (detail.changed) {
+        setAgentSessionViewDetailMessages(
+          sessionViewRef(normalizedAgentSessionId),
+          detail.messages
+        );
+      }
+      const overlay = retargetOptimisticPromptMessages(
+        sessionView.overlayMessages,
+        { clientSubmitId, turnId: normalizedTurnId }
+      );
+      if (overlay.changed) {
+        setAgentSessionViewOverlayMessages(
+          sessionViewRef(normalizedAgentSessionId),
+          overlay.messages
+        );
+      }
+    },
+    [sessionViewRef]
+  );
+
   const applyStatePatch = useCallback(
     (patch: WorkspaceAgentActivityStatePatch) => {
       const agentSessionId = patch.agentSessionId.trim();
@@ -5072,7 +5220,13 @@ export function useAgentGUINodeController({
           patchActiveTurnId === submitTrace.turnId;
         if (matchesTraceTurn) {
           if (!submitTrace.turnId && (patchTurnId || patchActiveTurnId)) {
-            submitTrace.turnId = patchTurnId || patchActiveTurnId;
+            const resolvedTurnId = patchTurnId || patchActiveTurnId;
+            submitTrace.turnId = resolvedTurnId;
+            retargetOptimisticPromptTurn(
+              agentSessionId,
+              submitTrace.clientSubmitId,
+              resolvedTurnId
+            );
           }
           reportAgentSubmitTraceDiagnostic({
             event: `lifecycle.${structuredTurnPhase}`,
@@ -5227,6 +5381,7 @@ export function useAgentGUINodeController({
     [
       patchConversation,
       resolveSessionMessages,
+      retargetOptimisticPromptTurn,
       sessionViewRef,
       setTransientConversation,
       statePatchErrorBySessionId,
@@ -5273,6 +5428,20 @@ export function useAgentGUINodeController({
           if (!agentSessionId) {
             continue;
           }
+          const submitTrace = submitTraceBySessionIdRef.current[agentSessionId];
+          const messageTurnId = message.turnId?.trim() ?? "";
+          if (
+            submitTrace &&
+            messageTurnId &&
+            shouldRetargetOptimisticPromptFromMessage(message, submitTrace)
+          ) {
+            submitTrace.turnId = messageTurnId;
+            retargetOptimisticPromptTurn(
+              agentSessionId,
+              submitTrace.clientSubmitId,
+              messageTurnId
+            );
+          }
           const completionKey = completionKeyFromMessage(message);
           if (completionKey) {
             pendingCompletionKeysBySessionId.set(agentSessionId, completionKey);
@@ -5296,7 +5465,8 @@ export function useAgentGUINodeController({
       applyStatePatch,
       applyBackgroundTimelineStatusUpdate,
       conversationListQuery,
-      recordLocalMessages
+      recordLocalMessages,
+      retargetOptimisticPromptTurn
     ]
   );
   const handleBackgroundActivityStreamEvents = useCallback(


### PR DESCRIPTION
## Summary

- Keep live runtime messages visible when a new-session detail window only has optimistic prompt messages.
- Retarget the optimistic first prompt to the authoritative turn only when the live message or lifecycle patch belongs to the current submit.
- Add regression coverage and document the AgentGuiNode troubleshooting invariant.

## Verification

- `pnpm --filter @tutti-os/agent-gui test -- agent-gui/agentGuiNode/controller/useAgentGUINodeController.spec.tsx`
- `pnpm check:agent-activity-runtime-boundaries`
- `pnpm check:changed`
- `pnpm check:full` via pre-push hook

## Checklist

- [x] I kept the change focused on one concern.
- [x] I updated documentation when behavior, setup, or contributor workflow changed.
- [x] I updated all README/CONTRIBUTING language variants when changing their English source. (Not applicable: README/CONTRIBUTING were not changed.)
- [x] I ran the lowest meaningful local checks for the changed surface.
- [x] My commits are signed off with DCO when required: `git commit -s`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the Agent GUI so newly created sessions now show live assistant messages more reliably when the detail view initially contains only an optimistic prompt.
  * Fixed history handling so older retained messages are no longer incorrectly shown in the current conversation timeline.

* **Documentation**
  * Updated the troubleshooting guide with clearer guidance for cases where the prompt appears but the timeline does not update.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->