### PR TITLE
fix(workspace-files): expand home-relative launches

### DIFF
--- a/apps/desktop/src/renderer/src/features/workspace-workbench/services/workspaceFilesLaunchCoordinator.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/services/workspaceFilesLaunchCoordinator.ts
@@ -40,7 +40,10 @@ export async function requestWorkspaceFilesLaunch(
   request: WorkspaceFilesLaunchRequest
 ): Promise<boolean> {
   const normalizedWorkspaceId = request.workspaceId.trim();
-  const normalizedPath = normalizeWorkspaceFilesLaunchPath(request.path);
+  const normalizedPath = normalizeWorkspaceFilesLaunchPath(
+    request.path,
+    request.homeDirectory
+  );
   if (!normalizedWorkspaceId || !normalizedPath) {
     return false;
   }
@@ -58,12 +61,18 @@ export async function requestWorkspaceFilesLaunch(
   });
 }
 
-function normalizeWorkspaceFilesLaunchPath(path: string): string | null {
+function normalizeWorkspaceFilesLaunchPath(
+  path: string,
+  homeDirectory?: string | null
+): string | null {
   const trimmed = path.trim();
   if (isUncLocalPath(trimmed)) {
     return null;
   }
-  const normalized = normalizeLocalPath(trimmed);
+  const normalized = normalizeHomeRelativePath(
+    normalizeLocalPath(trimmed),
+    homeDirectory
+  );
   if (
     !normalized ||
     isUrlLikeLocalPath(normalized) ||
@@ -112,6 +121,41 @@ function isWindowsAbsolutePath(path: string): boolean {
 
 function normalizeLocalPath(path: string): string {
   return path.trim().replaceAll("\\", "/").replace(/\/+$/, "");
+}
+
+function normalizeHomeRelativePath(
+  path: string,
+  homeDirectory?: string | null
+): string | null {
+  if (!isHomeRelativePath(path)) {
+    return path;
+  }
+
+  const home = normalizeHomeDirectory(homeDirectory);
+  if (!home) {
+    return null;
+  }
+
+  if (path === "~") {
+    return home;
+  }
+  const relativeHomePath = path.slice(2).replace(/^\/+/, "");
+  return home === "/" ? `/${relativeHomePath}` : `${home}/${relativeHomePath}`;
+}
+
+function normalizeHomeDirectory(path: string | null | undefined): string {
+  const raw = path?.trim().replaceAll("\\", "/") ?? "";
+  if (!raw) {
+    return "";
+  }
+  if (raw === "/") {
+    return "/";
+  }
+  return raw.replace(/\/+$/, "");
+}
+
+function isHomeRelativePath(path: string): boolean {
+  return path === "~" || path.startsWith("~/");
 }
 
 function cleanLocalPathForComparison(path: string): string {

--- a/apps/desktop/src/renderer/src/features/workspace-workbench/services/workspaceFilesRevealIntent.test.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/services/workspaceFilesRevealIntent.test.ts
@@ -117,6 +117,63 @@ test("workspace files launch coordinator preserves open directory mode", async (
   ]);
 });
 
+test("workspace files launch coordinator expands home-relative paths before dispatch", async () => {
+  const requests: Array<{
+    mode?: "reveal" | "open-directory";
+    path: string;
+    workspaceId: string;
+  }> = [];
+  const dispose = registerWorkspaceFilesLaunchHandler(
+    "workspace-home-relative",
+    (request) => {
+      requests.push(request);
+      return true;
+    }
+  );
+
+  assert.equal(
+    await requestWorkspaceFilesLaunch({
+      homeDirectory: "/Users/example",
+      path: "~/demo/README.md",
+      workspaceId: "workspace-home-relative"
+    }),
+    true
+  );
+  assert.equal(
+    await requestWorkspaceFilesLaunch({
+      homeDirectory: "/Users/example",
+      mode: "open-directory",
+      path: "~",
+      workspaceId: "workspace-home-relative"
+    }),
+    true
+  );
+  assert.equal(
+    await requestWorkspaceFilesLaunch({
+      homeDirectory: "C:\\Users\\example",
+      path: "~/Desktop/report.txt",
+      workspaceId: "workspace-home-relative"
+    }),
+    true
+  );
+  dispose();
+  assert.deepEqual(requests, [
+    {
+      path: "/Users/example/demo/README.md",
+      workspaceId: "workspace-home-relative"
+    },
+    {
+      mode: "open-directory",
+      path: "/Users/example",
+      workspaceId: "workspace-home-relative"
+    },
+    {
+      path: "C:/Users/example/Desktop/report.txt",
+      workspaceId: "workspace-home-relative"
+    }
+  ]);
+});
+
 test("workspace files launch coordinator preserves legacy absolute workspace paths", async () => {
   const requests: Array<{ path: string; workspaceId: string }> = [];
   const dispose = registerWorkspaceFilesLaunchHandler(

--- a/docs/conventions/troubleshooting.md
+++ b/docs/conventions/troubleshooting.md
@@ -1009,3 +1009,27 @@ information is not available yet`, but `ps` or `lsof` still shows an older
   Treat explicitly launched local absolute paths like direct hidden-file reveal:
   do not add them as projects or default locations, but allow FileManager to
   load the parent directory and apply normal local-file operations.
+
+### FileManager home-relative paths break only the list pane
+
+- Symptom:
+  Launching FileManager for a path such as `~/docs/spec.md` leaves the left
+  file list, selection, or reveal state wrong while a separate file preview can
+  still open the file.
+- Quick checks:
+  Trace whether the path reaches `requestWorkspaceFilesLaunch` as `~/...` or
+  was already rewritten by AgentGUI link resolution. Then compare the
+  FileManager list request with the preview-node read path.
+- Root cause:
+  FileManager list/reveal goes through workspace logical path normalization and
+  `tuttid` directory listing. Those layers treat `~/...` as a relative segment,
+  not as the user home. Preview nodes can bypass that chain by reading an
+  already absolute local file path directly.
+- Fix:
+  Expand `~` and `~/...` at the desktop launch boundary using the platform
+  home directory, and keep AgentGUI link actions from resolving home-relative
+  paths against the project root before desktop launch.
+- Validation:
+  Run the workspace files launch coordinator test and the AgentGUI workspace
+  link action test, then `pnpm check:changed` for mixed desktop and AgentGUI
+  changes.

--- a/packages/agent/gui/actions/workspaceLinkActions.spec.ts
+++ b/packages/agent/gui/actions/workspaceLinkActions.spec.ts
@@ -244,6 +244,34 @@ describe("resolveWorkspaceFileLinkAction", () => {
     });
   });
 
+  it("preserves home-relative paths for the desktop launch layer", () => {
+    expect(
+      resolveWorkspaceFileLinkAction({
+        path: "~/docs/spec.md",
+        workspaceRoot: "/Users/test/project/tutti",
+        source: "agent-markdown"
+      })
+    ).toMatchObject({
+      type: "open-workspace-file",
+      path: "~/docs/spec.md",
+      directoryPath: "~/docs",
+      workspaceRoot: "/Users/test/project/tutti"
+    });
+
+    expect(
+      resolveWorkspaceFileLinkAction({
+        path: "~",
+        workspaceRoot: "/Users/test/project/tutti",
+        source: "agent-markdown"
+      })
+    ).toMatchObject({
+      type: "open-workspace-file",
+      path: "~",
+      directoryPath: "~",
+      workspaceRoot: "/Users/test/project/tutti"
+    });
+  });
+
   it("allows Windows local paths inside the workspace root", () => {
     expect(
       resolveWorkspaceFileLinkAction({

--- a/packages/agent/gui/actions/workspaceLinkActions.ts
+++ b/packages/agent/gui/actions/workspaceLinkActions.ts
@@ -144,6 +144,15 @@ export function resolveWorkspaceFilePathCandidate({
   if (isStagedLocalAssetPath(normalizedPath)) {
     return null;
   }
+  if (isHomeRelativeWorkspaceFilePath(normalizedPath)) {
+    const directoryPath = dirnameForHomeRelativePath(normalizedPath);
+    return {
+      path: normalizedPath,
+      directoryPath,
+      workspaceRoot:
+        normalizeWorkspaceFilePath(workspaceRoot?.trim() ?? "") || directoryPath
+    };
+  }
   if (
     isAbsoluteLocalPath(normalizedPath) &&
     (isDirectAgentGeneratedMediaPath(normalizedPath) ||
@@ -394,6 +403,14 @@ function isUrlLikeWorkspaceFilePath(path: string): boolean {
 
 function isAbsoluteLocalPath(path: string): boolean {
   return path.startsWith("/") || isWindowsAbsolutePath(path);
+}
+
+function isHomeRelativeWorkspaceFilePath(path: string): boolean {
+  return path === "~" || path.startsWith("~/");
+}
+
+function dirnameForHomeRelativePath(path: string): string {
+  return path === "~" ? "~" : dirname(path);
 }
 
 function isWindowsAbsolutePath(path: string): boolean {


### PR DESCRIPTION
## Summary
- Expand `~` and `~/...` paths at the desktop workspace-files launch boundary using the provided platform home directory before FileManager reveal intents are dispatched.
- Preserve AgentGUI home-relative workspace links until desktop launch, and keep local asset preview routing ahead of workspace-file routing.
- Add a troubleshooting note for the FileManager list-pane-only breakage caused by unexpanded home-relative paths.

## Testing
- `pnpm exec node --import ./test/register-asset-stub.mjs --test --experimental-strip-types "./src/renderer/src/features/workspace-workbench/services/workspaceFilesRevealIntent.test.ts"` from `apps/desktop`
- `pnpm --filter @tutti-os/agent-gui exec vitest run --environment jsdom actions/workspaceLinkActions.spec.ts`
- `pnpm check:changed --tail-lines 30`
- `git diff --check`

## Known validation note
- `pnpm check:full` ran from the pre-push hook and failed in `test:go` at `TestProbeProviderAPIUnreachableReportsNetworkError`: this environment reached `https://api.anthropic.com/v1/messages`, while the test expected an unreachable `network_error`. The failure is outside the touched TS and docs paths.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Home-relative paths (`~`, `~/...`) are now expanded and normalized correctly before workspace file launches, including Windows-style home directories.
  * Workspace link actions preserve `~`-based inputs for the desktop launch layer and derive the correct home-relative directory context.
  * Prevents cases where home-relative paths broke the FileManager list pane while preview could still open files.
* **Documentation**
  * Added troubleshooting guidance for “FileManager home-relative paths break only the list pane”.
* **Tests**
  * Added coverage for `~` expansion in the launch coordinator and preservation in workspace link actions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->