### PR TITLE
fix(agent): require verified Claude composer models

### DIFF
--- a/apps/desktop/src/renderer/src/features/workspace-agent/services/desktopAgentActivityAdapter.test.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-agent/services/desktopAgentActivityAdapter.test.ts
@@ -479,6 +479,66 @@ test("desktop agent activity adapter normalizes provider composer options", asyn
   ]);
 });
 
+test("desktop agent activity adapter cancels composer options when caller aborts", async () => {
+  const controller = new AbortController();
+  let requestSignal: AbortSignal | undefined;
+  const adapter = createDesktopAgentActivityAdapter({
+    tuttidClient: createTuttidClient({
+      async getAgentProviderComposerOptions(
+        _provider,
+        _request,
+        requestOptions
+      ) {
+        requestSignal = requestOptions?.signal ?? undefined;
+        return await new Promise(() => undefined);
+      }
+    }),
+    runtimeApi: createRuntimeApi()
+  });
+
+  const load = adapter.loadComposerOptions({
+    workspaceId,
+    provider: "codex",
+    signal: controller.signal
+  });
+  assert.equal(requestSignal?.aborted, false);
+
+  controller.abort(new Error("caller cancelled"));
+
+  await assert.rejects(load, /caller cancelled/);
+  assert.equal(requestSignal?.aborted, true);
+});
+
+test("desktop agent activity adapter times out composer options requests", async () => {
+  let requestSignal: AbortSignal | undefined;
+  const adapter = createDesktopAgentActivityAdapter({
+    composerOptionsRequestTimeoutMs: 1,
+    tuttidClient: createTuttidClient({
+      async getAgentProviderComposerOptions(
+        _provider,
+        _request,
+        requestOptions
+      ) {
+        requestSignal = requestOptions?.signal ?? undefined;
+        return await new Promise(() => undefined);
+      }
+    }),
+    runtimeApi: createRuntimeApi()
+  });
+
+  await assert.rejects(
+    adapter.loadComposerOptions({
+      workspaceId,
+      provider: "claude-code"
+    }),
+    (error) =>
+      error instanceof Error &&
+      error.message === "Agent composer options request timed out." &&
+      (error as NodeJS.ErrnoException).code === "ETIMEDOUT"
+  );
+  assert.equal(requestSignal?.aborted, true);
+});
+
 test("desktop agent activity adapter sends plan mode when creating sessions", async () => {
   const calls: unknown[] = [];
   const adapter = createDesktopAgentActivityAdapter({
@@ -538,6 +598,39 @@ test("desktop agent activity adapter sends plan mode when creating sessions", as
       }
     ]
   ]);
+});
+
+test("desktop agent activity adapter times out create session requests", async () => {
+  let requestSignal: AbortSignal | undefined;
+  const adapter = createDesktopAgentActivityAdapter({
+    agentSessionCreateRequestTimeoutMs: 1,
+    tuttidClient: createTuttidClient({
+      async createWorkspaceAgentSession(
+        _workspaceId,
+        _request,
+        requestOptions
+      ) {
+        requestSignal = requestOptions?.signal ?? undefined;
+        return await new Promise(() => undefined);
+      }
+    }),
+    runtimeApi: createRuntimeApi()
+  });
+
+  await assert.rejects(
+    adapter.createSession({
+      agentSessionId: "22222222-2222-4222-8222-222222222222",
+      initialContent: [],
+      model: "claude-sonnet-4-20250514",
+      provider: "claude-code",
+      workspaceId
+    }),
+    (error) =>
+      error instanceof Error &&
+      error.message === "Agent session create request timed out." &&
+      (error as NodeJS.ErrnoException).code === "ETIMEDOUT"
+  );
+  assert.equal(requestSignal?.aborted, true);
 });
 
 test("desktop agent activity adapter rejects unuploaded file prompt blocks", async () => {

--- a/apps/desktop/src/renderer/src/features/workspace-agent/services/desktopAgentActivityAdapter.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-agent/services/desktopAgentActivityAdapter.ts
@@ -24,12 +24,19 @@ import { shouldRefreshProviderStatusAfterSessionError } from "./internal/desktop
 
 export interface CreateDesktopAgentActivityAdapterInput {
   agentProviderStatusService?: Pick<IAgentProviderStatusService, "refresh">;
+  agentSessionCreateRequestTimeoutMs?: number;
+  composerOptionsRequestTimeoutMs?: number;
   tuttidClient: TuttidClient;
   runtimeApi: Pick<DesktopRuntimeApi, "logTerminalDiagnostic">;
 }
 
+const defaultAgentSessionCreateRequestTimeoutMs = 30_000;
+const defaultComposerOptionsRequestTimeoutMs = 15_000;
+
 export function createDesktopAgentActivityAdapter({
   agentProviderStatusService,
+  agentSessionCreateRequestTimeoutMs = defaultAgentSessionCreateRequestTimeoutMs,
+  composerOptionsRequestTimeoutMs = defaultComposerOptionsRequestTimeoutMs,
   tuttidClient,
   runtimeApi
 }: CreateDesktopAgentActivityAdapterInput): AgentActivityAdapter {
@@ -62,21 +69,31 @@ export function createDesktopAgentActivityAdapter({
     const agentSessionId =
       normalizeText(input.agentSessionId) ??
       createDesktopAgentActivitySessionId();
-    const promise = tuttidClient
-      .createWorkspaceAgentSession(input.workspaceId, {
-        agentSessionId,
-        cwd,
-        initialContent: [],
-        model: input.settings.model,
-        permissionModeId: input.settings.permissionModeId,
-        planMode: input.settings.planMode,
-        provider: "claude-code",
-        reasoningEffort: input.settings.reasoningEffort,
-        speed: input.settings.speed,
-        title: null,
-        visible: false
-      })
-      .then((session) => sessionWithClaudeDraftContext(session, draftKey));
+    const promise = withAbortableRequestTimeout(
+      (signal) =>
+        tuttidClient.createWorkspaceAgentSession(
+          input.workspaceId,
+          {
+            agentSessionId,
+            cwd,
+            initialContent: [],
+            model: input.settings.model,
+            permissionModeId: input.settings.permissionModeId,
+            planMode: input.settings.planMode,
+            provider: "claude-code",
+            reasoningEffort: input.settings.reasoningEffort,
+            speed: input.settings.speed,
+            title: null,
+            visible: false
+          },
+          { signal }
+        ),
+      {
+        signal: input.signal,
+        timeoutMessage: "Agent session create request timed out.",
+        timeoutMs: agentSessionCreateRequestTimeoutMs
+      }
+    ).then((session) => sessionWithClaudeDraftContext(session, draftKey));
     const entry: ClaudeDraftSessionEntry = {
       cwd,
       promise,
@@ -238,12 +255,21 @@ export function createDesktopAgentActivityAdapter({
     },
     async loadComposerOptions(input) {
       const cwd = input.cwd?.trim();
-      const result = await tuttidClient.getAgentProviderComposerOptions(
-        workspaceAgentProvider(input.provider),
+      const result = await withAbortableRequestTimeout(
+        (signal) =>
+          tuttidClient.getAgentProviderComposerOptions(
+            workspaceAgentProvider(input.provider),
+            {
+              ...(cwd ? { cwd } : {}),
+              workspaceId: input.workspaceId,
+              settings: input.settings ?? {}
+            },
+            { signal }
+          ),
         {
-          ...(cwd ? { cwd } : {}),
-          workspaceId: input.workspaceId,
-          settings: input.settings ?? {}
+          signal: input.signal,
+          timeoutMessage: "Agent composer options request timed out.",
+          timeoutMs: composerOptionsRequestTimeoutMs
         }
       );
       return agentActivityComposerOptionsFromTuttidResult(
@@ -298,6 +324,7 @@ export function createDesktopAgentActivityAdapter({
               reasoningEffort: input.reasoningEffort,
               speed: input.speed
             }),
+            signal: input.signal,
             workspaceId: input.workspaceId
           });
           const promotedDraft = await promoteClaudeDraft({
@@ -317,24 +344,33 @@ export function createDesktopAgentActivityAdapter({
           provider: input.provider,
           workspaceId: input.workspaceId
         });
-        const session = await tuttidClient.createWorkspaceAgentSession(
-          input.workspaceId,
-          {
-            agentSessionId,
-            cwd: input.cwd ?? null,
-            initialContent: toTuttidPromptContentBlocks(
-              input.initialContent ?? []
+        const session = await withAbortableRequestTimeout(
+          (signal) =>
+            tuttidClient.createWorkspaceAgentSession(
+              input.workspaceId,
+              {
+                agentSessionId,
+                cwd: input.cwd ?? null,
+                initialContent: toTuttidPromptContentBlocks(
+                  input.initialContent ?? []
+                ),
+                initialDisplayPrompt: input.initialDisplayPrompt ?? null,
+                ...(input.metadata ? { metadata: input.metadata } : {}),
+                model: input.model ?? null,
+                planMode: input.planMode ?? null,
+                permissionModeId: input.permissionModeId ?? null,
+                provider: workspaceAgentProvider(input.provider),
+                reasoningEffort: input.reasoningEffort ?? null,
+                speed: input.speed ?? null,
+                title: input.title ?? null,
+                visible: input.visible ?? null
+              },
+              { signal }
             ),
-            initialDisplayPrompt: input.initialDisplayPrompt ?? null,
-            ...(input.metadata ? { metadata: input.metadata } : {}),
-            model: input.model ?? null,
-            planMode: input.planMode ?? null,
-            permissionModeId: input.permissionModeId ?? null,
-            provider: workspaceAgentProvider(input.provider),
-            reasoningEffort: input.reasoningEffort ?? null,
-            speed: input.speed ?? null,
-            title: input.title ?? null,
-            visible: input.visible ?? null
+          {
+            signal: input.signal,
+            timeoutMessage: "Agent session create request timed out.",
+            timeoutMs: agentSessionCreateRequestTimeoutMs
           }
         );
         reportDesktopAgentSubmitTrace(runtimeApi, {
@@ -526,6 +562,7 @@ interface ClaudeDraftInput {
   agentSessionId?: string | null;
   cwd: string | null;
   settings: ClaudeDraftSettings;
+  signal?: AbortSignal;
   workspaceId: string;
 }
 
@@ -1075,6 +1112,74 @@ function firstTextValue(
     }
   }
   return null;
+}
+
+function withAbortableRequestTimeout<T>(
+  request: (signal: AbortSignal) => Promise<T>,
+  options: {
+    signal?: AbortSignal;
+    timeoutMessage: string;
+    timeoutMs: number;
+  }
+): Promise<T> {
+  const controller = new AbortController();
+  const racers: Array<Promise<T>> = [];
+  let timeoutId: ReturnType<typeof setTimeout> | null = null;
+  let abortListener: (() => void) | null = null;
+
+  if (options.signal) {
+    if (options.signal.aborted) {
+      const error = abortSignalError(options.signal);
+      controller.abort(error);
+      return Promise.reject(error);
+    }
+    racers.push(
+      new Promise<never>((_, reject) => {
+        abortListener = () => {
+          const error = abortSignalError(options.signal);
+          controller.abort(error);
+          reject(error);
+        };
+        options.signal?.addEventListener("abort", abortListener, {
+          once: true
+        });
+      })
+    );
+  }
+
+  racers.push(request(controller.signal));
+
+  if (Number.isFinite(options.timeoutMs) && options.timeoutMs > 0) {
+    racers.push(
+      new Promise<never>((_, reject) => {
+        timeoutId = setTimeout(() => {
+          const error = Object.assign(new Error(options.timeoutMessage), {
+            code: "ETIMEDOUT"
+          });
+          controller.abort(error);
+          reject(error);
+        }, options.timeoutMs);
+      })
+    );
+  }
+
+  return Promise.race(racers).finally(() => {
+    if (timeoutId) {
+      clearTimeout(timeoutId);
+    }
+    if (abortListener) {
+      options.signal?.removeEventListener("abort", abortListener);
+    }
+  });
+}
+
+function abortSignalError(signal: AbortSignal | undefined): Error {
+  if (signal?.reason instanceof Error) {
+    return signal.reason;
+  }
+  const error = new Error("Agent composer options request was cancelled.");
+  error.name = "AbortError";
+  return error;
 }
 
 function normalizeText(value: unknown): string | null {

--- a/apps/desktop/src/renderer/src/features/workspace-agent/services/internal/workspaceAgentActivityService.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-agent/services/internal/workspaceAgentActivityService.ts
@@ -589,6 +589,7 @@ export class WorkspaceAgentActivityService implements IWorkspaceAgentActivitySer
     cwd?: string | null;
     force?: boolean;
     provider?: string;
+    signal?: AbortSignal;
     settings?: Parameters<typeof normalizeComposerSettings>[0] | null;
     workspaceId: string;
   }): Promise<unknown> {
@@ -599,6 +600,7 @@ export class WorkspaceAgentActivityService implements IWorkspaceAgentActivitySer
       provider,
       cwd: input.cwd,
       force: input.force,
+      signal: input.signal,
       settings: normalizeComposerSettings(input.settings)
     });
   }

--- a/apps/desktop/src/renderer/src/features/workspace-agent/services/workspaceAgentActivityService.interface.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-agent/services/workspaceAgentActivityService.interface.ts
@@ -85,6 +85,7 @@ export interface IWorkspaceAgentActivityService {
     cwd?: string | null;
     force?: boolean;
     provider?: string;
+    signal?: AbortSignal;
     settings?: AgentHostAgentSessionComposerSettings | null;
     workspaceId: string;
   }): Promise<unknown>;

--- a/apps/desktop/src/renderer/src/platform/tuttid/createDesktopTuttidClient.ts
+++ b/apps/desktop/src/renderer/src/platform/tuttid/createDesktopTuttidClient.ts
@@ -144,10 +144,11 @@ export function createDesktopTuttidClient(
     async createWorkspace(request) {
       return (await resolveClient()).createWorkspace(request);
     },
-    async createWorkspaceAgentSession(workspaceID, request) {
+    async createWorkspaceAgentSession(workspaceID, request, requestOptions) {
       return (await resolveClient()).createWorkspaceAgentSession(
         workspaceID,
-        request
+        request,
+        requestOptions
       );
     },
     async updateWorkspaceAgentSessionVisibility(
@@ -308,10 +309,11 @@ export function createDesktopTuttidClient(
         agentSessionID
       );
     },
-    async getAgentProviderComposerOptions(provider, request) {
+    async getAgentProviderComposerOptions(provider, request, requestOptions) {
       return (await resolveClient()).getAgentProviderComposerOptions(
         provider,
-        request
+        request,
+        requestOptions
       );
     },
     async getAgentProviderStatuses(request) {

--- a/packages/clients/tuttid-ts/src/agentProvidersClient.ts
+++ b/packages/clients/tuttid-ts/src/agentProvidersClient.ts
@@ -20,11 +20,16 @@ export function createAgentProvidersClient(
   client: Client
 ): AgentProvidersClient {
   return {
-    async getAgentProviderComposerOptions(provider, request = {}) {
+    async getAgentProviderComposerOptions(
+      provider,
+      request = {},
+      requestOptions
+    ) {
       const response = await getAgentProviderComposerOptions({
         client,
         body: request,
-        path: { provider }
+        path: { provider },
+        ...requestOptions
       });
       return unwrapData(
         response,

--- a/packages/clients/tuttid-ts/src/generated/sdk.gen.ts
+++ b/packages/clients/tuttid-ts/src/generated/sdk.gen.ts
@@ -1429,7 +1429,7 @@ export const importWorkspaceExternalAgentSessions = <
   });
 
 /**
- * Get provider composer options with short-lived Claude Code discovery
+ * Get provider composer options with Claude Code live discovery
  */
 export const getAgentProviderComposerOptions = <
   ThrowOnError extends boolean = false

--- a/packages/clients/tuttid-ts/src/generated/types.gen.ts
+++ b/packages/clients/tuttid-ts/src/generated/types.gen.ts
@@ -4574,7 +4574,7 @@ export type GetAgentProviderComposerOptionsError =
 
 export type GetAgentProviderComposerOptionsResponses = {
   /**
-   * Agent provider composer options with short-lived Claude Code discovery when needed
+   * Agent provider composer options with Claude Code live discovery when needed
    */
   200: AgentProviderComposerOptionsResponse;
 };

--- a/packages/clients/tuttid-ts/src/index.test.ts
+++ b/packages/clients/tuttid-ts/src/index.test.ts
@@ -200,6 +200,8 @@ test("shared tuttid client creates workspace agent sessions with bearer auth", a
   let authorizationHeader = "";
   let requestPath = "";
   let requestBody: unknown;
+  const capturedRequest: { signal: AbortSignal | null } = { signal: null };
+  const abortController = new AbortController();
 
   const client = createTuttidClient({
     auth: "desktop-session-token",
@@ -209,6 +211,7 @@ test("shared tuttid client creates workspace agent sessions with bearer auth", a
       authorizationHeader = request.headers.get("authorization") ?? "";
       requestPath = new URL(request.url).pathname;
       requestBody = await request.json();
+      capturedRequest.signal = request.signal;
 
       return new Response(
         JSON.stringify({
@@ -230,15 +233,22 @@ test("shared tuttid client creates workspace agent sessions with bearer auth", a
     }
   });
 
-  const session = await client.createWorkspaceAgentSession("ws-1", {
-    agentSessionId: "11111111-1111-4111-8111-111111111111",
-    initialContent: [{ type: "text", text: "hello" }],
-    planMode: true,
-    provider: "codex"
-  });
+  const session = await client.createWorkspaceAgentSession(
+    "ws-1",
+    {
+      agentSessionId: "11111111-1111-4111-8111-111111111111",
+      initialContent: [{ type: "text", text: "hello" }],
+      planMode: true,
+      provider: "codex"
+    },
+    { signal: abortController.signal }
+  );
 
   assert.equal(authorizationHeader, "Bearer desktop-session-token");
   assert.equal(requestPath, "/v1/workspaces/ws-1/agent-sessions");
+  assert.notEqual(capturedRequest.signal, null);
+  abortController.abort();
+  assert.equal(capturedRequest.signal?.aborted, true);
   assert.deepEqual(requestBody, {
     agentSessionId: "11111111-1111-4111-8111-111111111111",
     initialContent: [{ type: "text", text: "hello" }],
@@ -701,6 +711,8 @@ test("shared tuttid client loads agent provider composer options", async () => {
   let requestMethod = "";
   let requestPath = "";
   let requestBody: unknown;
+  const capturedRequest: { signal: AbortSignal | null } = { signal: null };
+  const abortController = new AbortController();
 
   const client = createTuttidClient({
     fetch: async (input, init) => {
@@ -709,6 +721,7 @@ test("shared tuttid client loads agent provider composer options", async () => {
       requestMethod = request.method;
       requestPath = new URL(request.url).pathname;
       requestBody = await request.json();
+      capturedRequest.signal = request.signal;
 
       return new Response(
         JSON.stringify({
@@ -762,15 +775,24 @@ test("shared tuttid client loads agent provider composer options", async () => {
     }
   });
 
-  const result = await client.getAgentProviderComposerOptions("codex", {
-    settings: {
-      model: "gpt-5",
-      reasoningEffort: "high"
+  const result = await client.getAgentProviderComposerOptions(
+    "codex",
+    {
+      settings: {
+        model: "gpt-5",
+        reasoningEffort: "high"
+      }
+    },
+    {
+      signal: abortController.signal
     }
-  });
+  );
 
   assert.equal(requestMethod, "POST");
   assert.equal(requestPath, "/v1/agent-providers/codex/composer-options");
+  assert.notEqual(capturedRequest.signal, null);
+  abortController.abort();
+  assert.equal(capturedRequest.signal?.aborted, true);
   assert.deepEqual(requestBody, {
     settings: {
       model: "gpt-5",

--- a/packages/clients/tuttid-ts/src/tuttidClient.ts
+++ b/packages/clients/tuttid-ts/src/tuttidClient.ts
@@ -281,11 +281,12 @@ export function createTuttidClient(
       });
       return unwrapData(response, "Create workspace request failed.").workspace;
     },
-    async createWorkspaceAgentSession(workspaceID, request) {
+    async createWorkspaceAgentSession(workspaceID, request, requestOptions) {
       const response = await createWorkspaceAgentSession({
         client,
         body: request,
-        path: { workspaceID }
+        path: { workspaceID },
+        ...requestOptions
       });
       return unwrapData(
         response,

--- a/packages/clients/tuttid-ts/src/tuttidClientTypes.ts
+++ b/packages/clients/tuttid-ts/src/tuttidClientTypes.ts
@@ -198,7 +198,8 @@ export interface TuttidClient {
   createWorkspace(request: { name: string }): Promise<WorkspaceSummary>;
   createWorkspaceAgentSession(
     workspaceID: string,
-    request: CreateWorkspaceAgentSessionRequest
+    request: CreateWorkspaceAgentSessionRequest,
+    requestOptions?: TuttidRequestOptions
   ): Promise<WorkspaceAgentSession>;
   createWorkspaceTerminal(
     workspaceID: string,
@@ -251,7 +252,8 @@ export interface TuttidClient {
   ): Promise<WorkspaceAgentSession>;
   getAgentProviderComposerOptions(
     provider: WorkspaceAgentProvider,
-    request?: GetAgentProviderComposerOptionsRequest
+    request?: GetAgentProviderComposerOptionsRequest,
+    requestOptions?: TuttidRequestOptions
   ): Promise<AgentProviderComposerOptionsResponse>;
   getAgentProviderStatuses(request?: {
     providers?: WorkspaceAgentProvider[];

--- a/services/tuttid/api/generated/server.gen.go
+++ b/services/tuttid/api/generated/server.gen.go
@@ -25,7 +25,7 @@ type ServerInterface interface {
 	// Run a local agent provider action owned by tuttid
 	// (POST /v1/agent-providers/{provider}/actions/{actionID}/run)
 	RunAgentProviderAction(w http.ResponseWriter, r *http.Request, provider WorkspaceAgentProvider, actionID AgentProviderActionID)
-	// Get provider composer options with short-lived Claude Code discovery
+	// Get provider composer options with Claude Code live discovery
 	// (POST /v1/agent-providers/{provider}/composer-options)
 	GetAgentProviderComposerOptions(w http.ResponseWriter, r *http.Request, provider WorkspaceAgentProvider)
 	// Probe whether tuttid can start a local agent provider runtime command
@@ -19618,7 +19618,7 @@ type StrictServerInterface interface {
 	// Run a local agent provider action owned by tuttid
 	// (POST /v1/agent-providers/{provider}/actions/{actionID}/run)
 	RunAgentProviderAction(ctx context.Context, request RunAgentProviderActionRequestObject) (RunAgentProviderActionResponseObject, error)
-	// Get provider composer options with short-lived Claude Code discovery
+	// Get provider composer options with Claude Code live discovery
 	// (POST /v1/agent-providers/{provider}/composer-options)
 	GetAgentProviderComposerOptions(ctx context.Context, request GetAgentProviderComposerOptionsRequestObject) (GetAgentProviderComposerOptionsResponseObject, error)
 	// Probe whether tuttid can start a local agent provider runtime command

--- a/services/tuttid/api/openapi/tuttid.v1.yaml
+++ b/services/tuttid/api/openapi/tuttid.v1.yaml
@@ -1657,7 +1657,7 @@ paths:
       operationId: getAgentProviderComposerOptions
       tags:
         - agent-session
-      summary: Get provider composer options with short-lived Claude Code discovery
+      summary: Get provider composer options with Claude Code live discovery
       requestBody:
         required: false
         content:
@@ -1666,7 +1666,7 @@ paths:
               $ref: "#/components/schemas/GetAgentProviderComposerOptionsRequest"
       responses:
         "200":
-          description: Agent provider composer options with short-lived Claude Code discovery when needed
+          description: Agent provider composer options with Claude Code live discovery when needed
           content:
             application/json:
               schema:

--- a/services/tuttid/service/agent/composer_live_model_discovery.go
+++ b/services/tuttid/service/agent/composer_live_model_discovery.go
@@ -12,21 +12,11 @@ import (
 	"golang.org/x/sync/singleflight"
 )
 
-const (
-	defaultLiveModelDiscoveryTimeout = 8 * time.Second
-	liveModelDiscoveryPollInterval   = 100 * time.Millisecond
-)
+const liveModelDiscoveryPollInterval = 100 * time.Millisecond
 
 var liveComposerModelDiscoveryGroup singleflight.Group
 
 var errLiveModelDiscoverySessionFailed = errors.New("live model discovery session failed")
-
-func (s *Service) liveModelDiscoveryTimeout() time.Duration {
-	if s.LiveModelDiscoveryTimeout != 0 {
-		return s.LiveModelDiscoveryTimeout
-	}
-	return defaultLiveModelDiscoveryTimeout
-}
 
 func (s *Service) discoverLiveComposerModels(
 	ctx context.Context,
@@ -40,7 +30,7 @@ func (s *Service) discoverLiveComposerModels(
 	}
 	provider := agentprovider.ClaudeCode
 	cacheKey := composerLiveModelCacheKey(provider, workspaceID, cwd)
-	result, err, _ := liveComposerModelDiscoveryGroup.Do(cacheKey, func() (any, error) {
+	resultCh := liveComposerModelDiscoveryGroup.DoChan(cacheKey, func() (any, error) {
 		now := time.Now().UTC()
 		if cached, ok := s.getLiveComposerModelOptions(provider, workspaceID, cwd, now); ok && len(cached) > 0 {
 			return cached, nil
@@ -52,11 +42,16 @@ func (s *Service) discoverLiveComposerModels(
 		s.setLiveComposerModelOptions(provider, workspaceID, cwd, now, discovered)
 		return discovered, nil
 	})
-	if err != nil {
-		return nil, err
+	select {
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	case result := <-resultCh:
+		if result.Err != nil {
+			return nil, result.Err
+		}
+		models, _ := result.Val.([]ComposerConfigOptionValue)
+		return cloneComposerConfigOptionValues(models), nil
 	}
-	models, _ := result.([]ComposerConfigOptionValue)
-	return cloneComposerConfigOptionValues(models), nil
 }
 
 func (s *Service) discoverLiveComposerModelsUncached(
@@ -83,7 +78,6 @@ func (s *Service) discoverLiveComposerModelsUncached(
 		Provider:         provider,
 		Cwd:              &resolvedCwd,
 		PermissionModeID: stringPointer(strings.TrimSpace(settings.PermissionModeID)),
-		Model:            stringPointer(strings.TrimSpace(settings.Model)),
 		PlanMode:         boolPointer(settings.PlanMode),
 		BrowserUse:       settings.BrowserUse,
 		ComputerUse:      settings.ComputerUse,
@@ -128,9 +122,6 @@ func (s *Service) pollComposerModelOptions(
 	workspaceID string,
 	session RuntimeSession,
 ) ([]ComposerConfigOptionValue, error) {
-	timeout := s.liveModelDiscoveryTimeout()
-	pollCtx, cancel := context.WithTimeout(ctx, timeout)
-	defer cancel()
 	ticker := time.NewTicker(liveModelDiscoveryPollInterval)
 	defer ticker.Stop()
 	current := session
@@ -142,8 +133,8 @@ func (s *Service) pollComposerModelOptions(
 			return nil, err
 		}
 		select {
-		case <-pollCtx.Done():
-			return nil, pollCtx.Err()
+		case <-ctx.Done():
+			return nil, ctx.Err()
 		case <-ticker.C:
 			refreshed, ok := s.controller().Session(workspaceID, current.ID)
 			if ok {
@@ -250,12 +241,43 @@ func stringFromAny(input any) string {
 	return ""
 }
 
+func (s *Service) mergeLiveComposerModelsForComposerOptions(
+	ctx context.Context,
+	input ComposerOptionsInput,
+	effectiveSettings ComposerSettings,
+	options ComposerOptions,
+) (ComposerOptions, error) {
+	provider := agentprovider.ClaudeCode
+	var liveModels []ComposerConfigOptionValue
+	if strings.TrimSpace(input.WorkspaceID) != "" {
+		now := time.Now().UTC()
+		cached, ok := s.getLiveComposerModelOptions(provider, input.WorkspaceID, input.Cwd, now)
+		if ok {
+			liveModels = cached
+		} else {
+			discovered, err := s.discoverLiveComposerModels(ctx, input.WorkspaceID, input.Cwd, effectiveSettings)
+			if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+				return ComposerOptions{}, err
+			}
+			if err == nil && len(discovered) > 0 {
+				liveModels = discovered
+				s.setLiveComposerModelOptions(provider, input.WorkspaceID, input.Cwd, now, discovered)
+			}
+		}
+	}
+	if len(liveModels) > 0 {
+		return mergeLiveModelsIntoComposerOptions(options, liveModels), nil
+	}
+	return clearUnverifiedLiveComposerModel(options), nil
+}
+
 func mergeLiveModelsIntoComposerOptions(options ComposerOptions, liveModels []ComposerConfigOptionValue) ComposerOptions {
-	normalized := normalizeLiveComposerModelOptions(liveModels, options.EffectiveSettings.Model)
+	normalized := normalizeLiveComposerModelOptions(liveModels)
 	if len(normalized) == 0 {
 		return options
 	}
-	selected := strings.TrimSpace(options.EffectiveSettings.Model)
+	selected := liveComposerSelectedModel(options.EffectiveSettings.Model, normalized)
+	options.EffectiveSettings.Model = selected
 	options.ModelConfig = ComposerConfigOption{
 		Configurable: true,
 		CurrentValue: selected,
@@ -266,10 +288,30 @@ func mergeLiveModelsIntoComposerOptions(options ComposerOptions, liveModels []Co
 	return options
 }
 
-func normalizeLiveComposerModelOptions(
-	options []ComposerConfigOptionValue,
-	selectedModel string,
-) []ComposerConfigOptionValue {
+func clearUnverifiedLiveComposerModel(options ComposerOptions) ComposerOptions {
+	options.EffectiveSettings.Model = ""
+	options.ModelConfig = ComposerConfigOption{}
+	if options.RuntimeContext == nil {
+		return options
+	}
+	options.RuntimeContext["model"] = nil
+	delete(options.RuntimeContext, "modelCatalogSource")
+	configOptions := runtimeConfigOptionsAsMapSlice(options.RuntimeContext["configOptions"])
+	if len(configOptions) == 0 {
+		return options
+	}
+	filtered := make([]map[string]any, 0, len(configOptions))
+	for _, option := range configOptions {
+		if strings.TrimSpace(stringFromAny(option["id"])) == "model" {
+			continue
+		}
+		filtered = append(filtered, option)
+	}
+	options.RuntimeContext["configOptions"] = filtered
+	return options
+}
+
+func normalizeLiveComposerModelOptions(options []ComposerConfigOptionValue) []ComposerConfigOptionValue {
 	if len(options) == 0 {
 		return nil
 	}
@@ -299,17 +341,29 @@ func normalizeLiveComposerModelOptions(
 			Description: strings.TrimSpace(option.Description),
 		})
 	}
+	return normalized
+}
+
+func liveComposerSelectedModel(selectedModel string, liveModels []ComposerConfigOptionValue) string {
 	selectedModel = strings.TrimSpace(selectedModel)
 	if selectedModel != "" {
-		if _, ok := seen[selectedModel]; !ok {
-			normalized = append(normalized, ComposerConfigOptionValue{
-				ID:    selectedModel,
-				Label: selectedModel,
-				Value: selectedModel,
-			})
+		for _, option := range liveModels {
+			if strings.TrimSpace(option.Value) == selectedModel {
+				return selectedModel
+			}
 		}
 	}
-	return normalized
+	for _, option := range liveModels {
+		if strings.TrimSpace(option.Value) == "default" {
+			return "default"
+		}
+	}
+	for _, option := range liveModels {
+		if value := strings.TrimSpace(option.Value); value != "" {
+			return value
+		}
+	}
+	return ""
 }
 
 func mergeLiveModelsIntoRuntimeContext(
@@ -334,6 +388,7 @@ func mergeLiveModelsIntoRuntimeContext(
 		configOptions = append(configOptions, option)
 	}
 	runtimeContext["configOptions"] = configOptions
+	runtimeContext["model"] = nullableString(selectedModel)
 	runtimeContext["modelCatalogSource"] = "acp-live-discovery"
 	return runtimeContext
 }

--- a/services/tuttid/service/agent/composer_live_model_discovery_test.go
+++ b/services/tuttid/service/agent/composer_live_model_discovery_test.go
@@ -55,3 +55,75 @@ func TestMergeLiveModelsIntoComposerOptionsUpdatesRuntimeContext(t *testing.T) {
 		t.Fatalf("configOptions = %#v, want model + effort", merged.RuntimeContext["configOptions"])
 	}
 }
+
+func TestMergeLiveModelsIntoComposerOptionsDoesNotAppendUnsupportedSelectedModel(t *testing.T) {
+	merged := mergeLiveModelsIntoComposerOptions(ComposerOptions{
+		Provider: "claude-code",
+		EffectiveSettings: ComposerSettings{
+			Model: "claude-sonnet-4-20250514",
+		},
+		RuntimeContext: map[string]any{},
+	}, []ComposerConfigOptionValue{
+		{ID: "default", Label: "Default", Value: "default"},
+		{ID: "sonnet", Label: "Sonnet", Value: "sonnet"},
+		{ID: "opus", Label: "Opus", Value: "opus"},
+		{ID: "haiku", Label: "Haiku", Value: "haiku"},
+	})
+
+	if merged.ModelConfig.CurrentValue != "default" || merged.ModelConfig.DefaultValue != "default" {
+		t.Fatalf("modelConfig = %#v, want default current/default", merged.ModelConfig)
+	}
+	if merged.EffectiveSettings.Model != "default" {
+		t.Fatalf("effectiveSettings.model = %q, want default", merged.EffectiveSettings.Model)
+	}
+	for _, option := range merged.ModelConfig.Options {
+		if option.Value == "claude-sonnet-4-20250514" {
+			t.Fatalf("modelConfig options = %#v, want no unsupported selected model", merged.ModelConfig.Options)
+		}
+	}
+	configOptions, ok := merged.RuntimeContext["configOptions"].([]map[string]any)
+	if !ok || len(configOptions) == 0 {
+		t.Fatalf("configOptions = %#v, want model option", merged.RuntimeContext["configOptions"])
+	}
+	if configOptions[0]["currentValue"] != "default" {
+		t.Fatalf("model runtime option = %#v, want default currentValue", configOptions[0])
+	}
+	runtimeModelOptions, ok := configOptions[0]["options"].([]map[string]string)
+	if !ok {
+		t.Fatalf("runtime model options = %#v", configOptions[0]["options"])
+	}
+	for _, option := range runtimeModelOptions {
+		if option["value"] == "claude-sonnet-4-20250514" {
+			t.Fatalf("runtime model options = %#v, want no unsupported selected model", runtimeModelOptions)
+		}
+	}
+	if merged.RuntimeContext["model"] != "default" {
+		t.Fatalf("runtime model = %#v, want default", merged.RuntimeContext["model"])
+	}
+}
+
+func TestMergeLiveModelsIntoComposerOptionsKeepsSelectedAlias(t *testing.T) {
+	merged := mergeLiveModelsIntoComposerOptions(ComposerOptions{
+		Provider: "claude-code",
+		EffectiveSettings: ComposerSettings{
+			Model: "sonnet",
+		},
+		RuntimeContext: map[string]any{},
+	}, []ComposerConfigOptionValue{
+		{ID: "default", Label: "Default", Value: "default"},
+		{ID: "sonnet", Label: "Sonnet", Value: "sonnet"},
+		{ID: "opus", Label: "Opus", Value: "opus"},
+		{ID: "haiku", Label: "Haiku", Value: "haiku"},
+	})
+
+	if merged.ModelConfig.CurrentValue != "sonnet" || merged.ModelConfig.DefaultValue != "sonnet" {
+		t.Fatalf("modelConfig = %#v, want selected alias current/default", merged.ModelConfig)
+	}
+	configOptions, ok := merged.RuntimeContext["configOptions"].([]map[string]any)
+	if !ok || len(configOptions) == 0 {
+		t.Fatalf("configOptions = %#v, want model option", merged.RuntimeContext["configOptions"])
+	}
+	if configOptions[0]["currentValue"] != "sonnet" {
+		t.Fatalf("model runtime option = %#v, want selected alias currentValue", configOptions[0])
+	}
+}

--- a/services/tuttid/service/agent/composer_options.go
+++ b/services/tuttid/service/agent/composer_options.go
@@ -3,7 +3,6 @@ package agent
 import (
 	"context"
 	"strings"
-	"time"
 
 	"github.com/tutti-os/tutti/services/tuttid/biz/agentprovider"
 	preferencesbiz "github.com/tutti-os/tutti/services/tuttid/biz/preferences"
@@ -171,18 +170,11 @@ func (s *Service) GetComposerOptions(ctx context.Context, input ComposerOptionsI
 		Skills:            skills,
 		CapabilityCatalog: capabilityCatalog,
 	}
-	if provider == agentprovider.ClaudeCode && strings.TrimSpace(input.WorkspaceID) != "" {
-		now := time.Now().UTC()
-		liveModels, ok := s.getLiveComposerModelOptions(provider, input.WorkspaceID, input.Cwd, now)
-		if !ok {
-			discovered, err := s.discoverLiveComposerModels(ctx, input.WorkspaceID, input.Cwd, effectiveSettings)
-			if err == nil && len(discovered) > 0 {
-				liveModels = discovered
-				s.setLiveComposerModelOptions(provider, input.WorkspaceID, input.Cwd, now, discovered)
-			}
-		}
-		if len(liveModels) > 0 {
-			options = mergeLiveModelsIntoComposerOptions(options, liveModels)
+	if provider == agentprovider.ClaudeCode {
+		var err error
+		options, err = s.mergeLiveComposerModelsForComposerOptions(ctx, input, effectiveSettings, options)
+		if err != nil {
+			return ComposerOptions{}, err
 		}
 	}
 	return options, nil

--- a/services/tuttid/service/agent/service_test.go
+++ b/services/tuttid/service/agent/service_test.go
@@ -1737,6 +1737,40 @@ func TestServiceGetsComposerOptionsSkipsClaudeStaticModelCatalog(t *testing.T) {
 	}
 }
 
+func TestGetComposerOptionsClaudeCodeWithoutWorkspaceClearsUnverifiedSelectedModel(t *testing.T) {
+	runtime := newFakeRuntime()
+	service := NewService(runtime)
+
+	options, err := service.GetComposerOptions(context.Background(), ComposerOptionsInput{
+		Provider: "claude-code",
+		Cwd:      "/repo",
+		Settings: ComposerSettings{
+			Model: "claude-sonnet-4-20250514",
+		},
+	})
+	if err != nil {
+		t.Fatalf("GetComposerOptions returned error: %v", err)
+	}
+	if options.EffectiveSettings.Model != "" {
+		t.Fatalf("effectiveSettings.model = %q, want empty without live model verification", options.EffectiveSettings.Model)
+	}
+	if options.RuntimeContext["model"] != nil {
+		t.Fatalf("runtime model = %#v, want nil without live model verification", options.RuntimeContext["model"])
+	}
+	if options.ModelConfig.Configurable || len(options.ModelConfig.Options) != 0 {
+		t.Fatalf("modelConfig = %#v, want no unverified Claude model config", options.ModelConfig)
+	}
+	configOptions, ok := options.RuntimeContext["configOptions"].([]map[string]any)
+	if !ok || len(configOptions) == 0 {
+		t.Fatalf("configOptions = %#v", options.RuntimeContext["configOptions"])
+	}
+	for _, option := range configOptions {
+		if option["id"] == "model" {
+			t.Fatalf("configOptions = %#v, want no unverified Claude model option", configOptions)
+		}
+	}
+}
+
 func TestGetComposerOptionsClaudeCodeDiscoversLiveModels(t *testing.T) {
 	t.Setenv("CLAUDE_CONFIG_DIR", t.TempDir())
 	runtime := newFakeRuntime()
@@ -1790,6 +1824,74 @@ func TestGetComposerOptionsClaudeCodeDiscoversLiveModels(t *testing.T) {
 	configOptions, ok := options.RuntimeContext["configOptions"].([]map[string]any)
 	if !ok || len(configOptions) == 0 || configOptions[0]["id"] != "model" {
 		t.Fatalf("configOptions = %#v, want model option merged into runtime context", options.RuntimeContext["configOptions"])
+	}
+}
+
+func TestGetComposerOptionsClaudeCodeLiveModelsSanitizesUnsupportedSelectedModel(t *testing.T) {
+	t.Setenv("CLAUDE_CONFIG_DIR", t.TempDir())
+	runtime := newFakeRuntime()
+	runtime.startHook = func(input RuntimeStartInput, session RuntimeSession) RuntimeSession {
+		if input.Provider != "claude-code" {
+			return session
+		}
+		if input.Model != "" {
+			t.Fatalf("discovery start model = %q, want empty model", input.Model)
+		}
+		session.RuntimeContext = map[string]any{
+			"configOptions": []any{
+				map[string]any{
+					"id":           "model",
+					"currentValue": "default",
+					"options": []any{
+						map[string]any{"name": "Default", "value": "default"},
+						map[string]any{"name": "Sonnet", "value": "sonnet"},
+						map[string]any{"name": "Opus", "value": "opus"},
+						map[string]any{"name": "Haiku", "value": "haiku"},
+					},
+				},
+			},
+		}
+		return session
+	}
+	service := NewService(runtime)
+
+	options, err := service.GetComposerOptions(context.Background(), ComposerOptionsInput{
+		Provider:    "claude-code",
+		WorkspaceID: "ws-1",
+		Cwd:         "/repo",
+		Settings: ComposerSettings{
+			Model: "claude-sonnet-4-20250514",
+		},
+	})
+	if err != nil {
+		t.Fatalf("GetComposerOptions returned error: %v", err)
+	}
+	if options.EffectiveSettings.Model != "default" {
+		t.Fatalf("effectiveSettings.model = %q, want default", options.EffectiveSettings.Model)
+	}
+	if options.ModelConfig.CurrentValue != "default" || options.ModelConfig.DefaultValue != "default" {
+		t.Fatalf("modelConfig = %#v, want default current/default", options.ModelConfig)
+	}
+	for _, option := range options.ModelConfig.Options {
+		if option.Value == "claude-sonnet-4-20250514" {
+			t.Fatalf("modelConfig options = %#v, want no unsupported selected model", options.ModelConfig.Options)
+		}
+	}
+	configOptions, ok := options.RuntimeContext["configOptions"].([]map[string]any)
+	if !ok || len(configOptions) == 0 || configOptions[0]["id"] != "model" {
+		t.Fatalf("configOptions = %#v, want model option merged into runtime context", options.RuntimeContext["configOptions"])
+	}
+	if configOptions[0]["currentValue"] != "default" {
+		t.Fatalf("model runtime option = %#v, want default currentValue", configOptions[0])
+	}
+	runtimeModelOptions, ok := configOptions[0]["options"].([]map[string]string)
+	if !ok {
+		t.Fatalf("runtime model options = %#v", configOptions[0]["options"])
+	}
+	for _, option := range runtimeModelOptions {
+		if option["value"] == "claude-sonnet-4-20250514" {
+			t.Fatalf("runtime model options = %#v, want no unsupported selected model", runtimeModelOptions)
+		}
 	}
 }
 
@@ -1887,49 +1989,144 @@ func TestGetComposerOptionsClaudeCodeLiveModelsFailedStartupReturnsQuickly(t *te
 		return session
 	}
 	service := NewService(runtime)
-	service.LiveModelDiscoveryTimeout = time.Second
 	startedAt := time.Now()
 
 	options, err := service.GetComposerOptions(context.Background(), ComposerOptionsInput{
 		Provider:    "claude-code",
 		WorkspaceID: "ws-failed",
 		Cwd:         "/repo",
+		Settings: ComposerSettings{
+			Model: "claude-sonnet-4-20250514",
+		},
 	})
 	if err != nil {
 		t.Fatalf("GetComposerOptions returned error: %v", err)
 	}
 	if elapsed := time.Since(startedAt); elapsed >= 400*time.Millisecond {
-		t.Fatalf("GetComposerOptions elapsed = %s, want failed discovery to return before polling timeout", elapsed)
+		t.Fatalf("GetComposerOptions elapsed = %s, want failed discovery to return quickly", elapsed)
 	}
 	if len(runtime.closeCalls) != 1 {
 		t.Fatalf("close calls = %d, want 1", len(runtime.closeCalls))
 	}
 	if options.ModelConfig.Configurable || len(options.ModelConfig.Options) != 0 {
-		t.Fatalf("modelConfig = %#v, want untouched static fallback after failed discovery", options.ModelConfig)
+		t.Fatalf("modelConfig = %#v, want no unverified Claude model config after failed discovery", options.ModelConfig)
+	}
+	if options.EffectiveSettings.Model != "" {
+		t.Fatalf("effectiveSettings.model = %q, want empty after failed live model verification", options.EffectiveSettings.Model)
+	}
+	if options.RuntimeContext["model"] != nil {
+		t.Fatalf("runtime model = %#v, want nil after failed live model verification", options.RuntimeContext["model"])
 	}
 }
 
-func TestGetComposerOptionsClaudeCodeLiveModelsTimeoutDegradesGracefully(t *testing.T) {
+func TestGetComposerOptionsClaudeCodeLiveModelsPropagatesCallerCancellation(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
 	runtime := newFakeRuntime()
+	closed := make(chan struct{})
+	runtime.closeHook = func(RuntimeCloseInput) {
+		select {
+		case <-closed:
+		default:
+			close(closed)
+		}
+	}
+	runtime.startHook = func(input RuntimeStartInput, session RuntimeSession) RuntimeSession {
+		if input.Provider == "claude-code" {
+			cancel()
+		}
+		return session
+	}
 	service := NewService(runtime)
-	service.LiveModelDiscoveryTimeout = 250 * time.Millisecond
 
-	options, err := service.GetComposerOptions(context.Background(), ComposerOptionsInput{
+	_, err := service.GetComposerOptions(ctx, ComposerOptionsInput{
 		Provider:    "claude-code",
-		WorkspaceID: "ws-timeout",
+		WorkspaceID: "ws-canceled",
 		Cwd:         "/repo",
 	})
-	if err != nil {
-		t.Fatalf("GetComposerOptions returned error: %v", err)
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("GetComposerOptions error = %v, want context canceled", err)
 	}
 	if len(runtime.startCalls) != 1 {
 		t.Fatalf("start calls = %d, want 1", len(runtime.startCalls))
 	}
-	if len(runtime.closeCalls) != 1 {
-		t.Fatalf("close calls = %d, want 1 even on timeout", len(runtime.closeCalls))
+	select {
+	case <-closed:
+	case <-time.After(time.Second):
+		t.Fatal("runtime close was not called after caller cancellation")
 	}
-	if options.ModelConfig.Configurable || len(options.ModelConfig.Options) != 0 {
-		t.Fatalf("modelConfig = %#v, want untouched static fallback after timeout", options.ModelConfig)
+	if len(runtime.closeCalls) != 1 {
+		t.Fatalf("close calls = %d, want 1 even on caller cancellation", len(runtime.closeCalls))
+	}
+}
+
+func TestGetComposerOptionsClaudeCodeLiveModelsSharedDiscoveryHonorsCallerCancellation(t *testing.T) {
+	runtime := newFakeRuntime()
+	firstStarted := make(chan struct{})
+	firstClosed := make(chan struct{})
+	runtime.closeHook = func(RuntimeCloseInput) {
+		select {
+		case <-firstClosed:
+		default:
+			close(firstClosed)
+		}
+	}
+	runtime.startHook = func(input RuntimeStartInput, session RuntimeSession) RuntimeSession {
+		if input.Provider == "claude-code" {
+			select {
+			case <-firstStarted:
+			default:
+				close(firstStarted)
+			}
+		}
+		return session
+	}
+	service := NewService(runtime)
+	firstCtx, cancelFirst := context.WithCancel(context.Background())
+	defer cancelFirst()
+	firstDone := make(chan error, 1)
+	go func() {
+		_, err := service.GetComposerOptions(firstCtx, ComposerOptionsInput{
+			Provider:    "claude-code",
+			WorkspaceID: "ws-shared-canceled",
+			Cwd:         "/repo",
+		})
+		firstDone <- err
+	}()
+
+	select {
+	case <-firstStarted:
+	case <-time.After(time.Second):
+		t.Fatal("first live model discovery did not start")
+	}
+
+	secondCtx, cancelSecond := context.WithCancel(context.Background())
+	cancelSecond()
+	_, err := service.GetComposerOptions(secondCtx, ComposerOptionsInput{
+		Provider:    "claude-code",
+		WorkspaceID: "ws-shared-canceled",
+		Cwd:         "/repo",
+	})
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("GetComposerOptions error = %v, want context canceled for shared caller", err)
+	}
+	if len(runtime.startCalls) != 1 {
+		t.Fatalf("start calls = %d, want 1 shared live model discovery", len(runtime.startCalls))
+	}
+
+	cancelFirst()
+	select {
+	case err := <-firstDone:
+		if !errors.Is(err, context.Canceled) {
+			t.Fatalf("first GetComposerOptions error = %v, want context canceled", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("first live model discovery did not stop after cancellation")
+	}
+	select {
+	case <-firstClosed:
+	case <-time.After(time.Second):
+		t.Fatal("shared live model discovery did not close after cancellation")
 	}
 }
 
@@ -3216,6 +3413,7 @@ type fakeRuntime struct {
 	startErr               error
 	startCalls             []RuntimeStartInput
 	startHook              func(RuntimeStartInput, RuntimeSession) RuntimeSession
+	closeHook              func(RuntimeCloseInput)
 	validateErr            error
 	validateCalls          []RuntimeExecInput
 }
@@ -3352,6 +3550,9 @@ func (f *fakeRuntime) Cancel(_ context.Context, input RuntimeCancelInput) (Runti
 
 func (f *fakeRuntime) Close(_ context.Context, input RuntimeCloseInput) error {
 	f.closeCalls = append(f.closeCalls, input)
+	if f.closeHook != nil {
+		f.closeHook(input)
+	}
 	if f.closeErr != nil {
 		return f.closeErr
 	}

--- a/services/tuttid/service/agent/session_types.go
+++ b/services/tuttid/service/agent/session_types.go
@@ -22,7 +22,6 @@ type Service struct {
 	ProviderAvailabilityCacheTTL time.Duration
 	CapabilityCatalogCacheTTL    time.Duration
 	LiveModelCacheTTL            time.Duration
-	LiveModelDiscoveryTimeout    time.Duration
 	skillOptionsCache            *composerSkillOptionsCache
 	providerAvailabilityCache    *providerAvailabilityCache
 	capabilityCatalogCache       *composerCapabilityCatalogCache

--- a/services/tuttid/service/cli/providers/agentcontext/composer_options.go
+++ b/services/tuttid/service/cli/providers/agentcontext/composer_options.go
@@ -24,7 +24,7 @@ func (p Provider) newComposerOptionsCommand() cliservice.Command {
 		ID:          appID + ".agent.composer-options",
 		Path:        []string{"agent", "composer-options"},
 		Summary:     "Get agent composer options",
-		Description: "Get provider-specific model and reasoning options without starting an agent session. Claude Code may spin up a short-lived hidden discovery session.",
+		Description: "Get provider-specific model and reasoning options without starting an agent session. Claude Code may spin up a hidden live discovery session.",
 		Kind:        framework.KindGet,
 		Workspace:   framework.WorkspaceOptional,
 		Inputs:      framework.FromStruct[composerOptionsInput](),


### PR DESCRIPTION
## Summary
- require Claude Code composer model options to come from live discovery/cache before exposing model settings
- clear unverified Claude model values when workspace/live discovery is unavailable or fails
- remove daemon-owned live discovery timeout and propagate caller cancellation
- update OpenAPI/CLI descriptions and generated tuttid TS client docs

## Tests
- pnpm check:changed --tail-lines 80
- cd services/tuttid && go test ./service/agent ./service/cli/providers/agentcontext ./api
- pnpm check:full

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved live composer model handling by sanitizing unsupported selections and aligning runtime/config options with the finalized model.
  * Enhanced live discovery cancellation/failure behavior so composer options degrade quickly with invalid model state cleared and errors propagated.
* **New Features**
  * Added abort-aware timeouts for desktop agent session creation and composer-options loading, with consistent cancellation propagation.
  * Extended Tuttid client/desktop adapter APIs to accept request-level options (including abort signals).
* **Documentation**
  * Updated CLI/OpenAPI wording to clarify live discovery terminology.
* **Tests**
  * Added/updated coverage for model merging/sanitization, cancellation and fast-failure behavior, and timeout/abort propagation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->