### PR TITLE
[codex] fix agent mention rendering

### DIFF
--- a/docs/architecture/agent-gui-node.md
+++ b/docs/architecture/agent-gui-node.md
@@ -710,6 +710,37 @@ composer document
 Never fix send bugs only in the composer UI. Also inspect the pending overlay,
 runtime command input, and timeline merge path.
 
+### Composer Mention References
+
+```text
+@ trigger range
+  -> AgentRichTextEditor suggestion state
+  -> AgentFileMentionPalette row action
+  -> mention command OR reference picker launch
+  -> composer document update
+  -> prompt mention serialization
+```
+
+The `@` trigger range is the source of truth for replacing typed mention text.
+Normal row selection replaces that range through the suggestion command. Any
+side action inside a mention row that opens another picker and later inserts
+files or `workspace-reference` mentions must clear the active trigger text
+before launching the picker, otherwise the raw `@` query remains in the
+composer before the inserted mention.
+
+`workspace-reference` hrefs are the passive reference contract, not a visual
+metadata store. Do not serialize app icons into the href just to render a chip.
+For `source=app` references, readonly and markdown renderers should hydrate the
+icon from the same `workspaceAppIcons` appId/workspaceId table used by ordinary
+`workspace-app` mentions.
+
+Quick check:
+
+```sh
+corepack pnpm --filter @tutti-os/agent-gui exec vitest run agent-gui/agentGuiNode/AgentComposer.spec.tsx -t "removes the active @ trigger"
+corepack pnpm --filter @tutti-os/agent-gui exec vitest run shared/AgentRichTextReadonly.spec.tsx shared/AgentMessageMarkdown.spec.tsx
+```
+
 ### Approval Or Ask-User Prompt
 
 ```text

--- a/packages/agent/gui/agent-gui/agentGuiNode/AgentComposer.spec.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/AgentComposer.spec.tsx
@@ -91,12 +91,14 @@ vi.mock("./agentRichText/AgentRichTextEditor", async () => {
           disabled,
           onChange,
           onPasteImages,
+          onFileMentionSuggestionChange,
           onKeyDownForPalette,
           value,
           placeholder
         }: {
           disabled?: boolean;
           onChange: (value: string) => void;
+          onFileMentionSuggestionChange?: (state: any) => void;
           onPasteImages?: (images: unknown[]) => void;
           onKeyDownForPalette?: (event: KeyboardEvent) => boolean;
           value: string;
@@ -104,6 +106,29 @@ vi.mock("./agentRichText/AgentRichTextEditor", async () => {
         },
         ref
       ) => {
+        React.useEffect(() => {
+          if (!value.startsWith("@")) {
+            return;
+          }
+          onFileMentionSuggestionChange?.({
+            editor: {
+              view: {
+                state: {
+                  tr: {
+                    setMeta() {
+                      return this;
+                    }
+                  }
+                },
+                dispatch() {}
+              }
+            },
+            range: { from: 1, to: value.length + 1 },
+            query: value.slice(1),
+            text: value,
+            command: vi.fn()
+          });
+        }, [onFileMentionSuggestionChange, value]);
         React.useImperativeHandle(ref, () => ({
           focusAtStart() {},
           focusAtEnd() {},
@@ -121,10 +146,18 @@ vi.mock("./agentRichText/AgentRichTextEditor", async () => {
               .join(" ");
             onChange(`${value}${mentions} `);
           },
-          insertMentionItems() {},
+          insertMentionItems(
+            items: ReadonlyArray<{ href: string; name: string }>
+          ) {
+            const mentions = items
+              .map((item) => `[@${item.name}](${item.href})`)
+              .join(" ");
+            onChange(`${value}${mentions} `);
+          },
           replaceTextBeforeSelection(_length: number, text: string) {
-            onChange(`${value}${text}`);
-            return `${value}${text}`;
+            const nextValue = `${value.slice(0, Math.max(0, value.length - _length))}${text}`;
+            onChange(nextValue);
+            return nextValue;
           }
         }));
         return (
@@ -309,7 +342,30 @@ vi.mock("./AgentQueuedPromptPanel", () => ({
 }));
 
 vi.mock("./AgentFileMentionPalette", () => ({
-  AgentFileMentionPalette: () => null,
+  AgentFileMentionPalette: ({
+    onOpenReferences
+  }: {
+    onOpenReferences?: (item: any) => void;
+  }) =>
+    onOpenReferences ? (
+      <button
+        type="button"
+        data-testid="mock-open-references"
+        onClick={() =>
+          onOpenReferences({
+            kind: "workspace-issue",
+            href: "mention://workspace-issue/issue-1?workspaceId=workspace-1",
+            workspaceId: "workspace-1",
+            targetId: "issue-1",
+            topicId: "topic-1",
+            name: "制作一个1000字小说",
+            title: "制作一个1000字小说"
+          })
+        }
+      >
+        查看产物文件
+      </button>
+    ) : null,
   agentMentionItemKey: (item: {
     kind: string;
     targetId?: string;
@@ -2686,6 +2742,70 @@ describe("AgentComposer", () => {
         text: "看下这张图[@首页 (1).jpg](/var/cache/tsh/local-assets/workspace-1/user-1/home.jpg)"
       }
     ]);
+  });
+
+  it("removes the active @ trigger before inserting references opened from a mention row", async () => {
+    let draftContent = createDraft("@");
+    const onDraftContentChange = vi.fn((nextDraft: AgentComposerDraft) => {
+      draftContent = nextDraft;
+    });
+    const onRequestWorkspaceReferences = vi.fn(async () => ({
+      files: [],
+      mentionItems: [
+        {
+          kind: "workspace-reference" as const,
+          href: "mention://workspace-reference/topic-1?groupId=issue-1&source=task&workspaceId=workspace-1",
+          workspaceId: "workspace-1",
+          targetId: "topic-1",
+          source: "task" as const,
+          groupId: "issue-1",
+          name: "制作一个1000字小说",
+          fileCount: 2
+        }
+      ]
+    }));
+
+    render(
+      <AgentComposer
+        workspaceId="workspace-1"
+        currentUserId="user-1"
+        provider="codex"
+        draftContent={draftContent}
+        availableCommands={[] satisfies readonly AgentHostAgentSessionCommand[]}
+        disabled={false}
+        submitDisabled={false}
+        placeholder="placeholder"
+        composerSettings={createComposerSettings()}
+        queuedPrompts={[]}
+        drainingQueuedPromptId={null}
+        canQueueWhileBusy={false}
+        showStopButton={false}
+        activePrompt={null}
+        isInterrupting={false}
+        isSendingTurn={false}
+        isSubmittingPrompt={false}
+        labels={createLabels()}
+        workspaceUserProjectI18n={workspaceUserProjectI18n}
+        onDraftContentChange={onDraftContentChange}
+        onSettingsChange={vi.fn()}
+        onSubmit={vi.fn()}
+        onSendQueuedPromptNext={vi.fn()}
+        onRemoveQueuedPrompt={vi.fn()}
+        onEditQueuedPrompt={vi.fn()}
+        onInterruptCurrentTurn={vi.fn()}
+        onSubmitInteractivePrompt={vi.fn()}
+        onRequestWorkspaceReferences={onRequestWorkspaceReferences}
+      />
+    );
+
+    fireEvent.click(await screen.findByTestId("mock-open-references"));
+
+    await waitFor(() =>
+      expect(draftContent.prompt).toBe(
+        "[@制作一个1000字小说](mention://workspace-reference/topic-1?groupId=issue-1&source=task&workspaceId=workspace-1) "
+      )
+    );
+    expect(draftContent.prompt).not.toMatch(/^@/);
   });
 
   it("renders controlled text and image draft content", () => {

--- a/packages/agent/gui/agent-gui/agentGuiNode/AgentComposer.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/AgentComposer.tsx
@@ -1412,6 +1412,26 @@ export function AgentComposer({
     setIsPaletteOpen(false);
   }, [fileMentionSuggestion]);
 
+  const clearActiveFileMentionTrigger = useCallback((): void => {
+    if (!fileMentionSuggestion) {
+      return;
+    }
+    const triggerLength = Math.max(
+      fileMentionSuggestion.range.to - fileMentionSuggestion.range.from,
+      fileMentionSuggestion.text.length
+    );
+    const nextDraft =
+      triggerLength > 0
+        ? editorHandleRef.current?.replaceTextBeforeSelection(triggerLength, "")
+        : null;
+    if (nextDraft === null || nextDraft === undefined) {
+      return;
+    }
+    draftPromptRef.current = nextDraft;
+    setPaletteDraftPrompt(nextDraft);
+    onDraftContentChange({ ...draftContent, prompt: nextDraft });
+  }, [draftContent, fileMentionSuggestion, onDraftContentChange]);
+
   const closeOpenPalette = useCallback((): void => {
     if (showFileMentionPalette) {
       closeFileMentionPalette();
@@ -1898,6 +1918,7 @@ export function AgentComposer({
   // 选中的文件仍按常规插入,但不会把该任务/应用本身作为 mention 插入。
   const handleOpenReferencesForEntity = useCallback(
     (entity: AgentContextMentionItem): void => {
+      clearActiveFileMentionTrigger();
       closeFileMentionPalette();
       if (!onRequestWorkspaceReferences) {
         return;
@@ -1907,6 +1928,7 @@ export function AgentComposer({
       );
     },
     [
+      clearActiveFileMentionTrigger,
       closeFileMentionPalette,
       applyReferencePickResult,
       onRequestWorkspaceReferences

--- a/packages/agent/gui/agent-gui/agentGuiNode/AgentFileMentionPalette.spec.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/AgentFileMentionPalette.spec.tsx
@@ -2171,6 +2171,14 @@ describe("AgentFileMentionPalette", () => {
       css.match(
         /\.workspace-agents-status-panel__detail-user-message\s+>\s+div,[\s\S]*?\.workspace-agents-status-panel__detail-user-message\s+\.ProseMirror\s*{[^}]*}/s
       )?.[0] ?? "";
+    const userParagraphRule =
+      css.match(
+        /\.workspace-agents-status-panel__detail-user-message\.agent-gui-conversation__user-message-bubble\s+p\s*{[^}]*}/s
+      )?.[0] ?? "";
+    const mentionOnlyUserEditorRule =
+      css.match(
+        /\.workspace-agents-status-panel__detail-user-message\[data-agent-mention-only="true"\]\.agent-gui-conversation__user-message-bubble\s*{[^}]*}/s
+      )?.[0] ?? "";
 
     expect(userBubbleRule).toMatch(/display:\s*inline-block/);
     expect(userBubbleRule).toMatch(/justify-self:\s*end/);
@@ -2193,8 +2201,15 @@ describe("AgentFileMentionPalette", () => {
     expect(userAppMessageTokenRule).toMatch(/vertical-align:\s*middle/);
     expect(userAppMessageTextRule).toMatch(/overflow:\s*visible/);
     expect(userEditorRule).toMatch(/width:\s*fit-content/);
+    expect(userEditorRule).toMatch(/display:\s*inline-block/);
+    expect(userEditorRule).toMatch(/vertical-align:\s*top/);
     expect(userEditorRule).toMatch(/max-width:\s*100%/);
     expect(userEditorRule).toMatch(/font-size:\s*inherit/);
     expect(userEditorRule).toMatch(/line-height:\s*inherit/);
+    expect(userParagraphRule).toMatch(/width:\s*fit-content/);
+    expect(userParagraphRule).toMatch(/max-width:\s*100%/);
+    expect(mentionOnlyUserEditorRule).toMatch(
+      /max-width:\s*min\(100%,\s*calc\(var\(--agent-mention-max-width,\s*16rem\)\s*\+\s*24px\)\)/
+    );
   });
 });

--- a/packages/agent/gui/app/renderer/agentactivity.css
+++ b/packages/agent/gui/app/renderer/agentactivity.css
@@ -3346,6 +3346,10 @@ aside.workspace-agents-status-panel
   box-shadow: none;
 }
 
+.workspace-agents-status-panel__detail-user-message[data-agent-mention-only="true"].agent-gui-conversation__user-message-bubble {
+  max-width: min(100%, calc(var(--agent-mention-max-width, 16rem) + 24px));
+}
+
 .workspace-agents-status-panel__detail-user-message .tsh-agent-object-token {
   font-size: inherit;
   overflow: visible;
@@ -3359,15 +3363,19 @@ aside.workspace-agents-status-panel
 .workspace-agents-status-panel__detail-user-message > div,
 .workspace-agents-status-panel__detail-user-message > [contenteditable="false"],
 .workspace-agents-status-panel__detail-user-message .ProseMirror {
+  display: inline-block;
   width: fit-content;
   min-width: 0;
   max-width: 100%;
+  vertical-align: top;
   font-size: inherit;
   line-height: inherit;
 }
 
 .workspace-agents-status-panel__detail-user-message.agent-gui-conversation__user-message-bubble
   p {
+  width: fit-content;
+  max-width: 100%;
   margin: 0;
 }
 

--- a/packages/agent/gui/shared/AgentMessageMarkdown.spec.tsx
+++ b/packages/agent/gui/shared/AgentMessageMarkdown.spec.tsx
@@ -33,6 +33,33 @@ describe("AgentMessageMarkdown", () => {
     expect(chip).not.toHaveTextContent("3");
   });
 
+  it("renders app workspace-reference mentions with app icons", () => {
+    const iconUrl = "data:image/png;base64,canvas";
+    const { container } = render(
+      <AgentMessageMarkdown
+        content="使用 [@AI Canvas](mention://workspace-reference/ai-canvas?source=app&workspaceId=room-1)"
+        workspaceAppIcons={[
+          {
+            appId: "ai-canvas",
+            iconUrl,
+            workspaceId: "room-1"
+          }
+        ]}
+      />
+    );
+
+    const mention = container.querySelector('[data-agent-file-mention="true"]');
+    expect(mention).toHaveAttribute(
+      "data-agent-mention-kind",
+      "workspace-reference"
+    );
+    expect(mention).toHaveAttribute("data-agent-mention-icon-url", iconUrl);
+    expect(
+      mention?.querySelector('[data-agent-mention-app-icon="true"] img')
+    ).toHaveAttribute("src", iconUrl);
+    expect(mention).toHaveTextContent("AI Canvas");
+  });
+
   it("renders markdown links, inline code, and lists", () => {
     const { container } = render(
       <AgentMessageMarkdown

--- a/packages/agent/gui/shared/AgentMessageMarkdown.tsx
+++ b/packages/agent/gui/shared/AgentMessageMarkdown.tsx
@@ -1694,10 +1694,20 @@ function parseMentionLink(
     };
   }
   if (kind === "workspace-reference") {
+    const source = mention.scope?.source?.trim() ?? "";
+    const workspaceId = mention.scope?.workspaceId?.trim() || "";
+    const appIconUrl =
+      source === "app"
+        ? resolveWorkspaceAppMentionIconUrl({
+            appId: entityId,
+            workspaceAppIcons,
+            workspaceId
+          })
+        : undefined;
     return {
       kind,
       label,
-      iconUrl: mention.scope?.icon?.trim() || undefined,
+      iconUrl: mention.scope?.icon?.trim() || appIconUrl,
       fileCount: referenceFileCountFromParam(mention.scope?.count ?? null),
       participant: label,
       summary: ""

--- a/packages/agent/gui/shared/AgentRichTextReadonly.spec.tsx
+++ b/packages/agent/gui/shared/AgentRichTextReadonly.spec.tsx
@@ -39,6 +39,97 @@ describe("AgentRichTextReadonly", () => {
     expect(mention?.querySelector("img")).toHaveAttribute("src", iconUrl);
   });
 
+  it("does not override mention wrapper width in readonly messages", async () => {
+    const { container } = render(
+      <AgentRichTextReadonly
+        value={
+          "Run [@Long Workspace App Name](mention://workspace-app/weather?workspaceId=workspace-1)"
+        }
+      />
+    );
+
+    await waitFor(() =>
+      expect(
+        container.querySelector('[data-agent-mention-kind="workspace-app"]')
+      ).not.toBeNull()
+    );
+
+    const editor = container.querySelector(".ProseMirror");
+    expect(editor).not.toHaveClass(
+      "[&_[data-agent-file-mention=true]]:max-w-full"
+    );
+  });
+
+  it("marks readonly messages that only contain one mention", async () => {
+    const { container, rerender } = render(
+      <AgentRichTextReadonly
+        value={
+          "[@Long Workspace App Name](mention://workspace-app/weather?workspaceId=workspace-1)"
+        }
+      />
+    );
+
+    await waitFor(() =>
+      expect(
+        container.querySelector('[data-agent-mention-kind="workspace-app"]')
+      ).not.toBeNull()
+    );
+
+    expect(container.firstElementChild).toHaveAttribute(
+      "data-agent-mention-only",
+      "true"
+    );
+
+    rerender(
+      <AgentRichTextReadonly
+        value={
+          "Run [@Long Workspace App Name](mention://workspace-app/weather?workspaceId=workspace-1)"
+        }
+      />
+    );
+
+    expect(container.firstElementChild).not.toHaveAttribute(
+      "data-agent-mention-only"
+    );
+  });
+
+  it("hydrates app workspace-reference mention icons from workspace app icons", async () => {
+    const iconUrl = "data:image/png;base64,canvas";
+    const { container } = render(
+      <AgentRichTextReadonly
+        value={
+          "Use [@AI Canvas](mention://workspace-reference/ai-canvas?source=app&workspaceId=workspace-1)"
+        }
+        workspaceAppIcons={[
+          {
+            appId: "ai-canvas",
+            workspaceId: "workspace-1",
+            iconUrl
+          }
+        ]}
+      />
+    );
+
+    await waitFor(() =>
+      expect(
+        container.querySelector(
+          '[data-agent-mention-kind="workspace-reference"]'
+        )
+      ).not.toBeNull()
+    );
+
+    const mention = container.querySelector(
+      '[data-agent-mention-kind="workspace-reference"]'
+    );
+    expect(mention).toHaveTextContent("AI Canvas");
+    expect(mention).toHaveAttribute(
+      "data-agent-mention-href",
+      "mention://workspace-reference/ai-canvas?source=app&workspaceId=workspace-1"
+    );
+    expect(mention).toHaveAttribute("data-agent-mention-icon-url", iconUrl);
+    expect(mention?.querySelector("img")).toHaveAttribute("src", iconUrl);
+  });
+
   it("renders workspace app factory markdown as a mention token", async () => {
     const { container } = render(
       <AgentRichTextReadonly

--- a/packages/agent/gui/shared/AgentRichTextReadonly.tsx
+++ b/packages/agent/gui/shared/AgentRichTextReadonly.tsx
@@ -28,22 +28,24 @@ export function AgentRichTextReadonly({
   workspaceAppIcons = EMPTY_WORKSPACE_APP_ICONS
 }: AgentRichTextReadonlyProps): JSX.Element {
   "use memo";
+  const contentDoc = plainTextToAgentRichTextDocWithWorkspaceAppIcons(
+    value,
+    availableSkills,
+    workspaceAppIcons
+  );
+  const isMentionOnly = isMentionOnlyRichTextDoc(contentDoc);
   const editor = useEditor({
     immediatelyRender: false,
     editable: false,
     extensions: createAgentRichTextReadonlyExtensions({
       skills: availableSkills
     }),
-    content: plainTextToAgentRichTextDocWithWorkspaceAppIcons(
-      value,
-      availableSkills,
-      workspaceAppIcons
-    ),
+    content: contentDoc,
     editorProps: {
       attributes: {
         class: cn(
           editorClassName,
-          "max-w-full overflow-x-hidden overflow-y-auto whitespace-pre-wrap break-words [overflow-wrap:anywhere] [&_p]:m-0 [&_p]:min-h-[1.45em] [&_a[data-agent-file-mention=true]]:cursor-pointer [&_[data-agent-file-mention=true]]:max-w-full [&_[data-agent-file-mention=true]]:overflow-hidden"
+          "max-w-full overflow-x-hidden overflow-y-auto whitespace-pre-wrap break-words [overflow-wrap:anywhere] [&_p]:m-0 [&_p]:min-h-[1.45em] [&_a[data-agent-file-mention=true]]:cursor-pointer [&_[data-agent-file-mention=true]]:overflow-hidden"
         )
       },
       handleDOMEvents: {
@@ -89,13 +91,39 @@ export function AgentRichTextReadonly({
   }, [availableSkills, editor, value, workspaceAppIcons]);
 
   if (!editor) {
-    return <div className={className} />;
+    return (
+      <div
+        className={className}
+        data-agent-mention-only={isMentionOnly ? "true" : undefined}
+      />
+    );
   }
 
   return (
-    <div className={className}>
+    <div
+      className={className}
+      data-agent-mention-only={isMentionOnly ? "true" : undefined}
+    >
       <EditorContent editor={editor} />
     </div>
+  );
+}
+
+function isMentionOnlyRichTextDoc(doc: JSONContent): boolean {
+  if (doc.type !== "doc") {
+    return false;
+  }
+  const blocks = doc.content ?? [];
+  if (blocks.length !== 1) {
+    return false;
+  }
+  const paragraph = blocks[0];
+  if (paragraph?.type !== "paragraph") {
+    return false;
+  }
+  const inlineContent = paragraph.content ?? [];
+  return (
+    inlineContent.length === 1 && inlineContent[0]?.type === "agentFileMention"
   );
 }
 
@@ -118,21 +146,24 @@ function hydrateWorkspaceAppMentionIcons(
   const nextContent = node.content?.map((child) =>
     hydrateWorkspaceAppMentionIcons(child, workspaceAppIcons)
   );
-  if (
-    node.type !== "agentFileMention" ||
-    node.attrs?.kind !== "workspace-app"
-  ) {
+  if (node.type !== "agentFileMention") {
+    return nextContent ? { ...node, content: nextContent } : node;
+  }
+  const attrs = node.attrs ?? {};
+  const kind = typeof attrs.kind === "string" ? attrs.kind : "";
+  const isWorkspaceAppMention = kind === "workspace-app";
+  const isAppWorkspaceReferenceMention =
+    kind === "workspace-reference" && attrs.source === "app";
+  if (!isWorkspaceAppMention && !isAppWorkspaceReferenceMention) {
     return nextContent ? { ...node, content: nextContent } : node;
   }
   const workspaceId =
-    typeof node.attrs.workspaceId === "string"
-      ? node.attrs.workspaceId.trim()
-      : "";
+    typeof attrs.workspaceId === "string" ? attrs.workspaceId.trim() : "";
   const appId =
-    typeof node.attrs.appId === "string"
-      ? node.attrs.appId.trim()
-      : typeof node.attrs.targetId === "string"
-        ? node.attrs.targetId.trim()
+    isWorkspaceAppMention && typeof attrs.appId === "string"
+      ? attrs.appId.trim()
+      : typeof attrs.targetId === "string"
+        ? attrs.targetId.trim()
         : "";
   const iconUrl = resolveWorkspaceAppIconUrl({
     appId,


### PR DESCRIPTION
## What changed

- Remove stale `@` trigger text when opening references from a mention palette row.
- Hydrate workspace-reference app icons from workspace app icon metadata in readonly and markdown renderers.
- Tighten readonly user-message mention layout so mention-only bubbles use the mention width budget instead of the full untruncated label width.
- Document the composer mention rendering contracts and add regression coverage for the affected paths.

## Why

Mention references had three related rendering regressions: opening references could leave the raw `@` in the composer, app-backed references could render without their app icon, and mention-only user bubbles could be wider or taller than the visible mention because wrapper elements were sizing from block/max-content behavior instead of the rendered chip constraints.

## Validation

- `pnpm --filter @tutti-os/agent-gui exec vitest run shared/AgentRichTextReadonly.spec.tsx agent-gui/agentGuiNode/AgentFileMentionPalette.spec.tsx`
- `pnpm --filter @tutti-os/agent-gui typecheck`
- `pnpm --filter @tutti-os/agent-gui test`
- `pnpm check:agent-activity-runtime-boundaries`
- `pnpm check:changed`
- pre-push `pnpm check:full`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Workspace reference mentions now display the correct app icon when sourced from an app.
  * Mention-only messages now receive dedicated styling so they render more cleanly and with a consistent width.

* **Bug Fixes**
  * Opening reference pickers now clears any active `@` trigger text first, preventing stale mention text from remaining in the draft.
  * Read-only mention rendering now shows the correct mention text, link target, and icon without requiring icon details in the link itself.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->