### PR TITLE
fix(agent): harden external session import

### DIFF
--- a/apps/desktop/src/renderer/src/features/workspace-agent/services/desktopAgentGUILinkActions.test.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-agent/services/desktopAgentGUILinkActions.test.ts
@@ -71,6 +71,39 @@ test("desktop agent gui project menu opens the project folder path in workspace 
   ]);
 });
 
+test("desktop agent gui link actions reveal local asset previews in workspace files", async () => {
+  const launchedFiles: unknown[] = [];
+  const handled = await runDesktopAgentGUILinkAction(
+    {
+      name: "photo.png",
+      path: "/var/cache/tsh/local-assets/room-1/user-1/photo.png",
+      source: "agent-markdown",
+      type: "open-local-asset-preview"
+    },
+    {
+      homeDirectory: "/Users/local",
+      launchAgentGui: failLaunchAgentGui,
+      launchWorkspaceIssueManager: failLaunchWorkspaceIssueManager,
+      launchWorkspaceFiles(input) {
+        launchedFiles.push(input);
+        return true;
+      },
+      openBrowserUrl: failOpenBrowserUrl,
+      workspaceId: "workspace-1"
+    }
+  );
+
+  assert.equal(handled, true);
+  assert.deepEqual(launchedFiles, [
+    {
+      homeDirectory: "/Users/local",
+      path: "/var/cache/tsh/local-assets/room-1/user-1/photo.png",
+      source: "agent_command",
+      workspaceId: "workspace-1"
+    }
+  ]);
+});
+
 test("desktop agent gui link actions open urls through the workspace browser", async () => {
   const openedUrls: unknown[] = [];
 

--- a/apps/desktop/src/renderer/src/features/workspace-agent/services/desktopAgentGUILinkActions.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-agent/services/desktopAgentGUILinkActions.ts
@@ -61,7 +61,12 @@ export async function runDesktopAgentGUILinkAction(
         workspaceId: dependencies.workspaceId
       });
     case "open-local-asset-preview":
-      return false;
+      return dependencies.launchWorkspaceFiles({
+        homeDirectory: dependencies.homeDirectory,
+        path: action.path,
+        source: "agent_command",
+        workspaceId: dependencies.workspaceId
+      });
     case "open-url":
       return dependencies.openBrowserUrl({
         reuseIfOpen: false,

--- a/docs/conventions/troubleshooting.md
+++ b/docs/conventions/troubleshooting.md
@@ -371,11 +371,15 @@ delimited by ---`, and the composer skill picker may show partial or
 - Symptom:
   A conversation started with the "No project" selection appears in the Agent
   GUI rail under a parent user-project group such as the user's home directory.
+  Imported Codex or Claude Code conversations with `cwd` equal to `$HOME` can
+  show the same symptom even though the user never selected a project.
 - Quick checks:
   Inspect the session `cwd` from the activity snapshot. Generated no-project
   sessions should resolve as no-project before `cwd` is matched against parent
-  user-project paths. Check both the in-memory `rememberNoProjectPath` path and
-  the restart fallback that recognizes `Documents/tutti/session-<uuid>`.
+  user-project paths. For imported sessions, inspect `runtimeContext` for the
+  daemon-owned `externalImportNoProject` marker. Check both the in-memory
+  `rememberNoProjectPath` path and the restart fallback that recognizes
+  `Documents/tutti/session-<uuid>`.
 - Root cause:
   Conversation project grouping is a view-model join of `cwd x userProjects`.
   If a generated no-project cwd is not recognized before prefix/parent project
@@ -383,20 +387,29 @@ delimited by ---`, and the composer skill picker may show partial or
   project such as `$HOME`. Keep generated-path recognition in the host
   `isNoProjectPath` callback because it has the user home-directory context;
   a package-level suffix check would misclassify real projects that contain a
-  `Documents/tutti/session-<uuid>` subdirectory.
+  `Documents/tutti/session-<uuid>` subdirectory. External import has a similar
+  trap because provider transcripts may record `$HOME` as the cwd when no
+  project was selected; that intent must be persisted as session metadata rather
+  than inferred later from user-project prefix matching.
 - Fix:
   Treat exact user-project path matches as explicit user intent, then call the
   host no-project resolver before parent project matching. The desktop resolver
   should recognize generated `$HOME/Documents/tutti/session-<uuid>` cwd values
-  while allowing explicit registered projects to override them. Keep the project
-  field derived in the Agent GUI view-model rather than writing it back into the
-  conversation store.
+  while allowing explicit registered projects to override them. External import
+  should mark home-cwd sessions as no-project in `runtimeContext`, skip them
+  when registering user-project paths, and let Agent GUI preserve that no-project
+  mode during later project re-resolution. Keep the project field derived in the
+  Agent GUI view-model rather than writing it back into the conversation store.
 - Validation:
   Run
   `pnpm --filter @tutti-os/agent-gui test -- agent-gui/agentGuiNode/model/agentGuiConversationModel.spec.ts`,
+  `cd services/tuttid && go test ./service/agent ./api -run 'ExternalImport|ParseCodex|ParseClaude'`,
   `node --import ./test/register-asset-stub.mjs --test --experimental-strip-types ./src/renderer/src/features/workspace-user-project/services/internal/desktopWorkspaceUserProjectService.test.ts`
   from `apps/desktop`, then run `pnpm check:changed`.
 - References:
+  [external_import_parse.go](../../services/tuttid/service/agent/external_import_parse.go)
+  [external_import_projects.go](../../services/tuttid/service/agent/external_import_projects.go)
+  [agentGuiConversationModel.ts](../../packages/agent/gui/agent-gui/agentGuiNode/model/agentGuiConversationModel.ts)
   [desktopWorkspaceUserProjectService.ts](../../apps/desktop/src/renderer/src/features/workspace-user-project/services/internal/desktopWorkspaceUserProjectService.ts)
   [agentGuiConversationProjectResolver.ts](../../packages/agent/gui/agent-gui/agentGuiNode/model/agentGuiConversationProjectResolver.ts)
   [agentGuiConversationListStore.ts](../../packages/agent/gui/contexts/workspace/presentation/renderer/agentGuiConversationList/agentGuiConversationListStore.ts)
@@ -994,21 +1007,58 @@ information is not available yet`, but `ps` or `lsof` still shows an older
 
 - Symptom:
   Agent GUI shows a generated or changed file under a path such as
-  `/var/folders/.../T/codex-presentations/...`, but clicking the file does not
-  reveal it in FileManager.
+  `/var/folders/.../T/codex-presentations/...`, but clicking the file from
+  Agent GUI or Message Center does not reveal it in FileManager.
 - Quick checks:
   Confirm the desktop workspace files launch coordinator accepts the path, then
   confirm `tuttid` resolves the workspace file root for the requested absolute
-  path instead of forcing the user home root.
+  path instead of forcing the user home root. For Message Center clicks, confirm
+  `open-local-asset-preview` link actions route into the same workspace files
+  launch path as `open-file-manager`.
 - Root cause:
   Some agent tools write durable-looking outputs to system temporary
   directories. FileManager can reveal a precise local path, but both the
   renderer launch filter and daemon workspace root resolution must allow that
-  external absolute path.
+  external absolute path. Message Center shares Agent GUI link actions, so a
+  preview-only action that returns `false` can block the file panel even when
+  the lower-level FileManager support is correct.
 - Fix:
   Treat explicitly launched local absolute paths like direct hidden-file reveal:
   do not add them as projects or default locations, but allow FileManager to
-  load the parent directory and apply normal local-file operations.
+  load the parent directory and apply normal local-file operations. Route
+  `open-local-asset-preview` through `launchWorkspaceFiles` until a dedicated
+  preview surface exists.
+- Validation:
+  Run the desktop Agent GUI link action test, the workspace files launch
+  coordinator test, and `pnpm check:changed` for mixed desktop/Agent GUI
+  changes.
+- References:
+  [desktopAgentGUILinkActions.ts](../../apps/desktop/src/renderer/src/features/workspace-agent/services/desktopAgentGUILinkActions.ts)
+
+### Imported sessions inflate recently completed message-center groups
+
+- Symptom:
+  After importing Codex or Claude Code history, Message Center's priority view
+  briefly shows many items under the recently-completed group even though those
+  sessions are historical imports, not newly finished local runs.
+- Quick checks:
+  Inspect the session `runtimeContext`. Imported sessions should carry
+  `imported: true`, and Message Center items derived from them should preserve
+  that marker before priority grouping.
+- Root cause:
+  Message Center uses the recently-completed group as a notification-style
+  surface. Imported history is persisted as completed agent activity, so if the
+  grouping model treats imported sessions the same as live runtime completions,
+  a bulk import can look like a burst of fresh completed work.
+- Fix:
+  Keep imported sessions visible in Message Center and in the completed filter,
+  but exclude `runtimeContext.imported` items from the recently-completed group.
+- Validation:
+  Run
+  `pnpm --filter @tutti-os/agent-gui test -- agent-message-center/workspaceAgentMessageCenterModel.spec.ts agent-message-center/workspaceAgentMessageCenterViewModel.spec.ts`.
+- References:
+  [workspaceAgentMessageCenterModel.ts](../../packages/agent/gui/agent-message-center/workspaceAgentMessageCenterModel.ts)
+  [workspaceAgentMessageCenterViewModel.ts](../../packages/agent/gui/agent-message-center/workspaceAgentMessageCenterViewModel.ts)
 
 ### FileManager home-relative paths break only the list pane
 

--- a/packages/agent/gui/agent-gui/agentGuiNode/model/agentGuiConversationModel.spec.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/model/agentGuiConversationModel.spec.ts
@@ -170,6 +170,56 @@ describe("agentGuiConversationModel", () => {
     ]);
   });
 
+  it("keeps imported home-cwd sessions unassigned when external import marks no project", () => {
+    const snapshot: WorkspaceAgentActivitySnapshot = {
+      workspaceId: "workspace-1",
+      presences: [],
+      sessions: [
+        {
+          workspaceId: "workspace-1",
+          agentSessionId: "imported-home-session",
+          provider: "codex",
+          providerSessionId: "imported-home-session",
+          cwd: "/Users/local",
+          title: "Imported scratch",
+          status: "completed",
+          runtimeContext: {
+            imported: true,
+            externalImportNoProject: true
+          },
+          createdAtUnixMs: 1,
+          updatedAtUnixMs: 30
+        }
+      ],
+      sessionMessagesById: {}
+    };
+
+    const summaries = buildAgentGUIConversationSummaries({
+      snapshot,
+      provider: "codex",
+      userProjects: [userProject("home", "/Users/local", "Home")]
+    });
+
+    expect(summaries).toEqual([
+      expect.objectContaining({
+        id: "imported-home-session",
+        project: null,
+        projectMode: "none"
+      })
+    ]);
+    expect(
+      applyAgentGUIConversationProjects(summaries, [
+        userProject("home", "/Users/local", "Home")
+      ])
+    ).toEqual([
+      expect.objectContaining({
+        id: "imported-home-session",
+        project: null,
+        projectMode: "none"
+      })
+    ]);
+  });
+
   it("builds conversations only from runtime Codex sessions", () => {
     const snapshot: AgentHostWorkspaceAgentSnapshot = {
       presences: [],

--- a/packages/agent/gui/agent-gui/agentGuiNode/model/agentGuiConversationModel.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/model/agentGuiConversationModel.ts
@@ -65,6 +65,7 @@ export interface AgentGUIConversationSummary {
   status: AgentGUIConversationStatus;
   cwd: string;
   project?: AgentGUIConversationProjectSummary | null;
+  projectMode?: "none";
   pinnedAtUnixMs?: number | null;
   sortTimeUnixMs?: number;
   updatedAtUnixMs: number;
@@ -83,6 +84,7 @@ export type AgentGUIConversationProjectionSource = Pick<
   | "status"
   | "cwd"
   | "project"
+  | "projectMode"
   | "pinnedAtUnixMs"
   | "sortTimeUnixMs"
   | "updatedAtUnixMs"
@@ -381,7 +383,10 @@ export function conversationSummaryFromAgentSession(
     titleFallback,
     status: conversationStatusFromActivity("idle"),
     cwd: session.cwd?.trim() ?? "",
-    project: projectResolver.resolve(session.cwd),
+    project: resolveConversationProject(session, projectResolver),
+    ...(isExternalImportNoProjectSession(session)
+      ? { projectMode: "none" }
+      : {}),
     pinnedAtUnixMs: session.pinnedAtUnixMs ?? null,
     sortTimeUnixMs: resolveWorkspaceAgentSessionSortTimeUnixMs(
       workspaceAgentSession
@@ -403,7 +408,10 @@ export function applyAgentGUIConversationProjects(
     options
   );
   const next = conversations.map((conversation) => {
-    const project = projectResolver.resolve(conversation.cwd);
+    const project =
+      conversation.projectMode === "none"
+        ? null
+        : projectResolver.resolve(conversation.cwd);
     if (isSameAgentGUIConversationProject(conversation.project, project)) {
       return conversation;
     }
@@ -513,12 +521,33 @@ function conversationSummaryFromActivity(
     titleFallback,
     status,
     cwd: session?.cwd.trim() ?? "",
-    project: options.projectResolver.resolve(session?.cwd),
+    project: resolveConversationProject(session, options.projectResolver),
+    ...(isExternalImportNoProjectSession(session)
+      ? { projectMode: "none" }
+      : {}),
     pinnedAtUnixMs: session?.pinnedAtUnixMs ?? null,
     sortTimeUnixMs: activity.sortTimeUnixMs,
     updatedAtUnixMs: session?.updatedAtUnixMs || activity.sortTimeUnixMs || 0,
     syncState: session?.syncState
   };
+}
+
+function resolveConversationProject(
+  session: WorkspaceAgentActivitySession | AgentSession | undefined,
+  projectResolver: AgentGUIConversationProjectResolver
+): AgentGUIConversationProjectSummary | null {
+  if (isExternalImportNoProjectSession(session)) {
+    return null;
+  }
+  return projectResolver.resolve(session?.cwd);
+}
+
+function isExternalImportNoProjectSession(
+  session: WorkspaceAgentActivitySession | AgentSession | undefined
+): boolean {
+  const runtimeContext =
+    session && "runtimeContext" in session ? session.runtimeContext : undefined;
+  return runtimeContext?.externalImportNoProject === true;
 }
 
 function isSameAgentGUIConversationProject(

--- a/packages/agent/gui/agent-message-center/workspaceAgentMessageCenterModel.spec.ts
+++ b/packages/agent/gui/agent-message-center/workspaceAgentMessageCenterModel.spec.ts
@@ -421,6 +421,27 @@ describe("buildWorkspaceAgentMessageCenterModel", () => {
     expect(model.counts.waiting).toBe(0);
   });
 
+  it("marks imported sessions on message-center items", () => {
+    const model = buildWorkspaceAgentMessageCenterModel(
+      snapshot({
+        messages: [],
+        sessions: [
+          session({
+            agentSessionId: "imported-session",
+            runtimeContext: { imported: true },
+            status: "completed"
+          })
+        ]
+      })
+    );
+
+    expect(model.items[0]).toMatchObject({
+      agentSessionId: "imported-session",
+      imported: true,
+      status: "completed"
+    });
+  });
+
   it("records the latest completed turn outcome when the session has returned to idle", () => {
     const model = buildWorkspaceAgentMessageCenterModel(
       snapshot({

--- a/packages/agent/gui/agent-message-center/workspaceAgentMessageCenterModel.ts
+++ b/packages/agent/gui/agent-message-center/workspaceAgentMessageCenterModel.ts
@@ -42,6 +42,7 @@ export interface WorkspaceAgentMessageCenterItem {
   provider: string;
   userId: string | null;
   title: string;
+  imported?: boolean;
   identity: WorkspaceAgentMessageCenterIdentity | null;
   cwd: string;
   status: WorkspaceAgentActivityStatus;
@@ -142,6 +143,7 @@ export function buildWorkspaceAgentMessageCenterModel(
         provider: session.provider,
         userId: session.userId?.trim() || null,
         title,
+        ...(isImportedMessageCenterSession(session) ? { imported: true } : {}),
         identity: resolveMessageCenterIdentity(
           session.agentSessionId,
           options.identityBySessionId
@@ -193,6 +195,12 @@ function resolveMessageCenterIdentity(
     agentName,
     ...(agentAvatarUrl ? { agentAvatarUrl } : {})
   };
+}
+
+function isImportedMessageCenterSession(
+  session: AgentActivitySession
+): boolean {
+  return session.runtimeContext?.imported === true;
 }
 
 export function isWaitingMessageCenterItem(

--- a/packages/agent/gui/agent-message-center/workspaceAgentMessageCenterModelStability.ts
+++ b/packages/agent/gui/agent-message-center/workspaceAgentMessageCenterModelStability.ts
@@ -63,6 +63,7 @@ function messageCenterItemsEqual(
     left.provider === right.provider &&
     left.userId === right.userId &&
     left.title === right.title &&
+    left.imported === right.imported &&
     left.cwd === right.cwd &&
     left.status === right.status &&
     left.lastAgentMessageSummary === right.lastAgentMessageSummary &&

--- a/packages/agent/gui/agent-message-center/workspaceAgentMessageCenterViewModel.spec.ts
+++ b/packages/agent/gui/agent-message-center/workspaceAgentMessageCenterViewModel.spec.ts
@@ -214,6 +214,45 @@ describe("groupMessageCenterItems", () => {
       }
     ]);
   });
+
+  it("keeps imported completed items out of the recently completed group", () => {
+    const now = Date.now();
+    const groups = groupMessageCenterItems(
+      [
+        item({
+          agentSessionId: "recent-runtime",
+          lastAgentMessageAtUnixMs: now,
+          sortTimeUnixMs: now,
+          status: "completed"
+        }),
+        item({
+          agentSessionId: "recent-imported",
+          imported: true,
+          lastAgentMessageAtUnixMs: now,
+          sortTimeUnixMs: now,
+          status: "completed"
+        })
+      ],
+      "priority",
+      (key) => key
+    );
+
+    expect(
+      groups.map((group) => ({
+        id: group.id,
+        sessionIds: group.items.map((entry) => entry.agentSessionId)
+      }))
+    ).toEqual([
+      {
+        id: "recently-completed",
+        sessionIds: ["recent-runtime"]
+      },
+      {
+        id: "completed",
+        sessionIds: ["recent-imported"]
+      }
+    ]);
+  });
 });
 
 function item(

--- a/packages/agent/gui/agent-message-center/workspaceAgentMessageCenterViewModel.ts
+++ b/packages/agent/gui/agent-message-center/workspaceAgentMessageCenterViewModel.ts
@@ -321,6 +321,9 @@ export function isRecentlyCompletedMessageCenterItem(
   if (messageCenterStatusFilterValue(item) !== "completed") {
     return false;
   }
+  if (item.imported) {
+    return false;
+  }
   const completedAtUnixMs =
     item.sortTimeUnixMs || item.lastAgentMessageAtUnixMs || 0;
   if (completedAtUnixMs <= 0) {

--- a/services/tuttid/service/agent/external_import.go
+++ b/services/tuttid/service/agent/external_import.go
@@ -98,10 +98,12 @@ type externalImportedSession struct {
 	// (e.g. Claude `custom-title`/`summary` transcript lines or the Codex
 	// app-server `threads.title`). When present it wins over message-derived
 	// titles.
-	SummaryTitle    string
-	StartedAtUnixMS int64
-	UpdatedAtUnixMS int64
-	Messages        []externalImportedMessage
+	SummaryTitle     string
+	NoProject        bool
+	EventUserMessage externalImportedMessage
+	StartedAtUnixMS  int64
+	UpdatedAtUnixMS  int64
+	Messages         []externalImportedMessage
 }
 
 type externalImportedMessage struct {
@@ -154,7 +156,7 @@ func (s *Service) ImportExternalSessions(ctx context.Context, workspaceID string
 		if !selected {
 			continue
 		}
-		if session.UpdatedAtUnixMS > validProjectPaths[projectPath] {
+		if !session.NoProject && session.UpdatedAtUnixMS > validProjectPaths[projectPath] {
 			validProjectPaths[projectPath] = session.UpdatedAtUnixMS
 		}
 		importedMessages, imported, err := s.importExternalSession(ctx, workspaceID, session)
@@ -171,7 +173,9 @@ func (s *Service) ImportExternalSessions(ctx context.Context, workspaceID string
 		}
 		if importedMessages > 0 {
 			result.ImportedMessages += importedMessages
-			importedProjectPaths[projectPath] = struct{}{}
+			if !session.NoProject {
+				importedProjectPaths[projectPath] = struct{}{}
+			}
 		}
 	}
 	result.ImportedProjects = len(importedProjectPaths)
@@ -444,9 +448,10 @@ func (s *Service) importExternalSession(ctx context.Context, workspaceID string,
 		Provider:          session.Provider,
 		ProviderSessionID: session.ProviderSessionID,
 		RuntimeContext: map[string]any{
-			"visible":            true,
-			"imported":           true,
-			"externalSourcePath": session.SourcePath,
+			"visible":                 true,
+			"imported":                true,
+			"externalImportNoProject": session.NoProject,
+			"externalSourcePath":      session.SourcePath,
 		},
 		Cwd:              session.Cwd,
 		Title:            session.Title,

--- a/services/tuttid/service/agent/external_import_parse.go
+++ b/services/tuttid/service/agent/external_import_parse.go
@@ -5,6 +5,8 @@ import (
 	"encoding/json"
 	"errors"
 	"io"
+	"os"
+	"path/filepath"
 	"strconv"
 	"strings"
 
@@ -34,7 +36,20 @@ func parseCodexJSONL(path string, reader io.Reader) (externalImportedSession, bo
 		case "event_msg":
 			payload := mapField(raw, "payload")
 			if stringField(payload, "type") == "user_message" {
-				session.Title = firstNonEmptyString(session.Title, externalContentText(payload["message"]))
+				messageText := externalContentText(payload["message"])
+				session.Title = firstNonEmptyString(session.Title, messageText)
+				if text, ok := externalImportDisplayTextCandidate(session.Provider, messageText); ok {
+					session.EventUserMessage = externalImportedMessage{
+						RawID:             "event:" + strconv.Itoa(index),
+						Role:              "user",
+						Kind:              "text",
+						Status:            "completed",
+						Text:              text,
+						OccurredAtUnixMS:  timestamp,
+						StartedAtUnixMS:   timestamp,
+						CompletedAtUnixMS: timestamp,
+					}
+				}
 			}
 		}
 	})
@@ -209,12 +224,20 @@ func normalizeExternalParsedSession(session externalImportedSession) (externalIm
 		return externalImportedSession{}, false, nil
 	}
 	session.Cwd = cwd
+	session.NoProject = isExternalImportNoProjectCwd(cwd)
 	messages := make([]externalImportedMessage, 0, len(session.Messages))
 	for i, message := range session.Messages {
 		message.Role = normalizeExternalMessageRole(message.Role)
 		message.Kind = normalizeExternalMessageKind(message.Kind)
 		message.Status = normalizeExternalMessageStatus(message.Status)
 		message.Text = strings.TrimSpace(message.Text)
+		if message.Role == "user" && message.Kind == "text" {
+			cleanedText, ok := externalImportDisplayTextCandidate(session.Provider, message.Text)
+			if !ok {
+				continue
+			}
+			message.Text = cleanedText
+		}
 		if message.Role == "" || !externalImportedMessageHasContent(message) {
 			continue
 		}
@@ -233,13 +256,30 @@ func normalizeExternalParsedSession(session externalImportedSession) (externalIm
 		messages = append(messages, message)
 	}
 	if len(messages) == 0 {
-		return externalImportedSession{}, false, nil
+		if externalImportedMessageHasContent(session.EventUserMessage) {
+			messages = append(messages, session.EventUserMessage)
+		}
+		if len(messages) == 0 {
+			return externalImportedSession{}, false, nil
+		}
 	}
 	session.Messages = messages
 	session.StartedAtUnixMS = firstExternalMessageUnixMS(messages)
 	session.UpdatedAtUnixMS = lastExternalMessageUnixMS(messages)
 	session.Title = resolveExternalSessionTitle(session.Provider, session.SummaryTitle, session.Title, messages)
 	return session, true, nil
+}
+
+func isExternalImportNoProjectCwd(cwd string) bool {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return false
+	}
+	home, ok := canonicalExistingDir(home)
+	if !ok {
+		return false
+	}
+	return filepath.Clean(cwd) == filepath.Clean(home)
 }
 
 func externalImportedMessageHasContent(message externalImportedMessage) bool {
@@ -284,6 +324,14 @@ const (
 // surfaced. The Codex/Claude preamble rules are ported from cc-switch (MIT, see
 // NOTICE).
 func externalImportTitleCandidate(provider string, text string) (string, bool) {
+	return externalImportCleanUserText(provider, text)
+}
+
+func externalImportDisplayTextCandidate(provider string, text string) (string, bool) {
+	return externalImportCleanUserText(provider, text)
+}
+
+func externalImportCleanUserText(provider string, text string) (string, bool) {
 	trimmed := strings.TrimSpace(text)
 	if trimmed == "" {
 		return "", false

--- a/services/tuttid/service/agent/external_import_parse_test.go
+++ b/services/tuttid/service/agent/external_import_parse_test.go
@@ -156,6 +156,9 @@ func TestParseCodexJSONLExtractsPromptFromIDEContext(t *testing.T) {
 	if session.Title != "Refactor the parser" {
 		t.Fatalf("title = %q, want IDE request payload", session.Title)
 	}
+	if len(session.Messages) != 1 || session.Messages[0].Text != "Refactor the parser" {
+		t.Fatalf("messages = %#v, want IDE context replaced with request text", session.Messages)
+	}
 }
 
 func TestParseCodexJSONLSkipsAgentsAndEnvironmentPreamble(t *testing.T) {
@@ -193,6 +196,9 @@ func TestParseCodexJSONLSkipsAgentsAndEnvironmentPreamble(t *testing.T) {
 	}
 	if session.Title != "Real question here" {
 		t.Fatalf("title = %q, want first non-preamble user message", session.Title)
+	}
+	if len(session.Messages) != 1 || session.Messages[0].Text != "Real question here" {
+		t.Fatalf("messages = %#v, want only the real user message", session.Messages)
 	}
 }
 

--- a/services/tuttid/service/agent/external_import_projects.go
+++ b/services/tuttid/service/agent/external_import_projects.go
@@ -26,6 +26,9 @@ func (*Service) ExternalImportValidProjectPaths(ctx context.Context, input Exter
 		if ctx.Err() != nil {
 			return nil, ctx.Err()
 		}
+		if session.NoProject {
+			continue
+		}
 		if projectPath, ok := matchingExternalImportProject(session, selections); ok {
 			if session.UpdatedAtUnixMS > valid[projectPath] {
 				valid[projectPath] = session.UpdatedAtUnixMS
@@ -36,18 +39,47 @@ func (*Service) ExternalImportValidProjectPaths(ctx context.Context, input Exter
 }
 
 func projectFromExternalSession(session externalImportedSession) (ExternalImportProject, bool) {
-	cwd, ok := canonicalExistingDir(session.Cwd)
+	projectPath, ok := externalSessionProjectPath(session)
 	if !ok {
 		return ExternalImportProject{}, false
 	}
 	return ExternalImportProject{
-		Path:                cwd,
-		Label:               filepath.Base(cwd),
+		Path:                projectPath,
+		Label:               filepath.Base(projectPath),
 		Providers:           []string{session.Provider},
 		SessionCount:        1,
 		MessageCount:        len(session.Messages),
 		LastUpdatedAtUnixMS: session.UpdatedAtUnixMS,
 	}, true
+}
+
+func externalSessionProjectPath(session externalImportedSession) (string, bool) {
+	cwd, ok := canonicalExistingDir(session.Cwd)
+	if !ok {
+		return "", false
+	}
+	if session.NoProject {
+		return cwd, true
+	}
+	if gitRoot, ok := nearestExternalImportGitRoot(cwd); ok {
+		return gitRoot, true
+	}
+	return cwd, true
+}
+
+func nearestExternalImportGitRoot(cwd string) (string, bool) {
+	current := filepath.Clean(cwd)
+	for current != "" {
+		if _, err := os.Stat(filepath.Join(current, ".git")); err == nil {
+			return current, true
+		}
+		parent := filepath.Dir(current)
+		if parent == current {
+			break
+		}
+		current = parent
+	}
+	return "", false
 }
 
 func externalImportSessionSummary(session externalImportedSession, projectPath string) ExternalImportSession {

--- a/services/tuttid/service/agent/service_test.go
+++ b/services/tuttid/service/agent/service_test.go
@@ -225,6 +225,90 @@ func TestMatchingExternalImportProjectPrefersExactSelection(t *testing.T) {
 	}
 }
 
+func TestExternalSessionProjectPathUsesGitRoot(t *testing.T) {
+	root := t.TempDir()
+	project := filepath.Join(root, "repo")
+	child := filepath.Join(project, "packages", "app")
+	if err := os.MkdirAll(filepath.Join(project, ".git"), 0o755); err != nil {
+		t.Fatalf("create git dir error = %v", err)
+	}
+	if err := os.MkdirAll(child, 0o755); err != nil {
+		t.Fatalf("create child dir error = %v", err)
+	}
+	if canonical, ok := canonicalExistingDir(project); ok {
+		project = canonical
+	}
+	if canonical, ok := canonicalExistingDir(child); ok {
+		child = canonical
+	}
+
+	got, ok := externalSessionProjectPath(externalImportedSession{
+		Provider: "codex",
+		Cwd:      child,
+	})
+	if !ok || got != project {
+		t.Fatalf("externalSessionProjectPath() = %q, %v; want git root %q", got, ok, project)
+	}
+}
+
+func TestServiceImportsHomeCwdAsNoProjectWithoutRegisteringUserHome(t *testing.T) {
+	ctx := context.Background()
+	store := openAgentServiceSQLiteStore(t)
+	if err := store.Create(ctx, workspacebiz.Summary{ID: "ws-1", Name: "Workspace One"}); err != nil {
+		t.Fatalf("Create workspace error = %v", err)
+	}
+	root := t.TempDir()
+	home := filepath.Join(root, "home")
+	if err := os.MkdirAll(home, 0o755); err != nil {
+		t.Fatalf("create home error = %v", err)
+	}
+	if canonical, ok := canonicalExistingDir(home); ok {
+		home = canonical
+	}
+	codexHome := filepath.Join(root, "codex-home")
+	t.Setenv("HOME", home)
+	t.Setenv("CODEX_HOME", codexHome)
+	t.Setenv("CLAUDE_CONFIG_DIR", filepath.Join(root, "claude-home"))
+	now := time.Now().UTC().Format(time.RFC3339Nano)
+	writeAgentServiceJSONL(t, filepath.Join(codexHome, "sessions", "no-project.jsonl"),
+		map[string]any{
+			"timestamp": now,
+			"type":      "session_meta",
+			"payload":   map[string]any{"id": "no-project", "cwd": home},
+		},
+		map[string]any{"timestamp": now, "type": "response_item", "payload": map[string]any{
+			"type": "message", "id": "no-project-1", "role": "user",
+			"content": []any{map[string]any{"type": "input_text", "text": "Scratch question"}},
+		}},
+	)
+
+	service := NewService(newFakeRuntime())
+	projection := NewActivityProjection(store)
+	service.SessionReader = projection
+	service.MessageReader = projection
+	service.ExternalImportStore = store
+
+	result, err := service.ImportExternalSessions(ctx, "ws-1", ExternalImportInput{
+		Projects: []ExternalImportProjectSelection{{Path: home}},
+	})
+	if err != nil {
+		t.Fatalf("ImportExternalSessions error = %v", err)
+	}
+	if result.ImportedSessions != 1 || result.ImportedMessages != 1 {
+		t.Fatalf("import result = %#v, want one imported no-project session", result)
+	}
+	if len(result.ProjectPaths) != 0 || result.ImportedProjects != 0 {
+		t.Fatalf("import result = %#v, want no registered project paths for home cwd", result)
+	}
+	session, err := service.Get(ctx, "ws-1", externalImportedSessionID("codex", "no-project"))
+	if err != nil {
+		t.Fatalf("Get imported no-project session error = %v", err)
+	}
+	if session.RuntimeContext["externalImportNoProject"] != true {
+		t.Fatalf("runtime context = %#v, want externalImportNoProject true", session.RuntimeContext)
+	}
+}
+
 func TestServiceListsImportedSessionsByExternalActivityTime(t *testing.T) {
 	ctx := context.Background()
 	store := openAgentServiceSQLiteStore(t)
@@ -476,7 +560,7 @@ func TestServiceImportsExternalAgentSessionsByProject(t *testing.T) {
 		t.Fatalf("ImportExternalSessions rerun error = %v", err)
 	}
 	if rerun.ImportedSessions != 1 || rerun.ImportedMessages != 2 {
-		t.Fatalf("second import = %#v, want remaining project session and messages", rerun)
+		t.Fatalf("second import = %#v, want remaining project sessions and messages", rerun)
 	}
 	finalRerun, err := service.ImportExternalSessions(ctx, "ws-1", ExternalImportInput{
 		Projects: []ExternalImportProjectSelection{{Path: projectA}},


### PR DESCRIPTION
## Summary
- Normalize external Codex/Claude import project paths to git roots while preserving the existing 30-day scan window
- Preserve no-project imported sessions without registering the user home as a project, and hide provider-injected preambles from imported conversations
- Route imported/generated file links to workspace files and keep imported history out of the recently-completed message-center group
- Document the recurring import, no-project, and message-center troubleshooting rules

## Validation
- pnpm check:full
- pre-push hook: pnpm check:full

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Imported sessions are now clearly marked in the message center and conversation views.
  * Local asset preview links from the agent now open the correct file location.

* **Bug Fixes**
  * Sessions started from a home-directory workspace are now treated as having no project, preventing them from being grouped incorrectly.
  * Imported history is excluded from the “recently completed” group, keeping message-center lists more accurate.

* **Documentation**
  * Updated troubleshooting guidance with clearer checks and resolution steps for imported sessions and file-opening behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->