### PR TITLE
fix(agent): avoid zero claude usage updates

### DIFF
--- a/docs/conventions/troubleshooting.md
+++ b/docs/conventions/troubleshooting.md
@@ -616,30 +616,46 @@ delimited by ---`, and the composer skill picker may show partial or
 
 - Symptom:
   Claude Agent provider status is not ready, or live ACP options do not match
-  the package version advertised by the ACP External Agent Registry.
+  the package version advertised by the ACP External Agent Registry. Another
+  form is Claude Code context usage briefly showing `0%` during a running
+  session or around compaction, then returning to the prior nonzero value on
+  the next usage update.
 - Quick checks:
   Inspect `<state-dir>/agent-providers/external-agent-registry/cache/registry.json`
   and the package manifest under
   `<state-dir>/agent-providers/external-agent-registry/packages/claude-acp/node_modules/@agentclientprotocol/claude-agent-acp/package.json`.
   `which claude-agent-acp` only describes a user/global shim and is no longer
-  the Tutti-owned Claude adapter source.
+  the Tutti-owned Claude adapter source. For usage flicker, inspect that
+  package's `dist/acp-agent.js` for `sessionUpdate: "usage_update"` near
+  `compact_boundary`; it must not publish `used: 0` when the SDK
+  `getContextUsage()` probe fails.
 - Root cause:
   Tutti resolves Claude ACP from the external agent registry and installs the
   npm adapter into a daemon-owned prefix with managed npm. A stale or missing
   prefix package, stale registry cache, or unavailable managed Node runtime can
   make the adapter unavailable even when a global `claude-agent-acp` exists.
+  Usage flicker can also come from the managed bridge bundle itself publishing
+  an invalid zero context usage after a failed compact-boundary usage probe;
+  AgentGUI only displays the normalized runtime context it receives.
 - Fix:
   Run the provider install action so tuttid refreshes the registry, resolves the
   managed Node runtime, and installs the npm package into the per-agent prefix.
   Do not compensate by changing static model catalogs for behavior that should
-  come from the live ACP package.
+  come from the live ACP package. Keep the Tutti claude-agent-acp patch script
+  authoritative for bridge behavior and apply it to the managed package; do not
+  mask invalid usage in AgentGUI.
 - Validation:
   Run `go test ./services/tuttid/service/agentstatus`, then confirm a stale
   global adapter is ignored and the install action uses managed npm with
   `--prefix <state-dir>/agent-providers/external-agent-registry/packages/claude-acp`.
+  For usage flicker, run
+  `node services/tuttid/service/agentstatus/assets/patch-claude-agent-acp.mjs --dist <managed-acp-dist>`
+  twice and confirm the second run reports no changes, then inspect the bundle
+  and confirm `lastAssistantTotalUsage = usedTokens ?? 0` is absent.
 - References:
   [service.go](../../services/tuttid/service/agentstatus/service.go)
   [store.go](../../services/tuttid/service/externalagentregistry/store.go)
+  [patch-claude-agent-acp.mjs](../../services/tuttid/service/agentstatus/assets/patch-claude-agent-acp.mjs)
 
 ### Published package runtime asset 404 because the consumer bundler never saw the file
 

--- a/services/tuttid/service/agentstatus/assets/patch-claude-agent-acp.mjs
+++ b/services/tuttid/service/agentstatus/assets/patch-claude-agent-acp.mjs
@@ -485,6 +485,67 @@ const PERMISSION_MODE_ALIASES = {`
   }
 ];
 
+const TOKEN_USAGE_COMPACT_EDITS = [
+  {
+    name: "do not publish zero usage when compact usage probe fails",
+    find: `                            case "compact_boundary": {
+                                // Refresh the displayed usage immediately so the client doesn't
+                                // keep showing the stale pre-compaction size (e.g. "944k/1m")
+                                // right after the user sees "Compacting completed", which is
+                                // confusing and wrong.
+                                //
+                                // Prefer the SDK's authoritative post-compaction \`used\` via
+                                // getContextUsage — it reflects the real retained context
+                                // (system prompt + tools + surviving messages), which the
+                                // per-message API usage numbers can't give us until the next
+                                // turn's result. If the control request fails, fall back to the
+                                // used:0 approximation: directionally correct (context just
+                                // dropped dramatically) and replaced within seconds by the next
+                                // result message.
+                                //
+                                // \`size\` keeps coming from session.contextWindowSize (learned
+                                // from modelUsage / the model heuristic) — getContextUsage's
+                                // window field under-reports extended 1M windows.
+                                //
+                                // The "Compacting completed." text is emitted from the \`status\`
+                                // handler (keyed on \`compact_result\`), not here, so the failure
+                                // path gets a message too.
+                                const usedTokens = await fetchContextUsedTokens(session.query, this.logger);
+                                lastAssistantUsage = null;
+                                lastAssistantTotalUsage = usedTokens ?? 0;
+                                await this.client.sessionUpdate({
+                                    sessionId: message.session_id,
+                                    update: {
+                                        sessionUpdate: "usage_update",
+                                        used: lastAssistantTotalUsage,
+                                        size: session.contextWindowSize,
+                                    },
+                                });
+                                break;
+                            }`,
+    replace: `                            case "compact_boundary": {
+                                // Refresh the displayed usage only when the SDK returns the
+                                // authoritative post-compaction value. Publishing 0 on probe
+                                // failure makes the client briefly show an impossible empty
+                                // context window before the next usage event restores reality.
+                                const usedTokens = await fetchContextUsedTokens(session.query, this.logger);
+                                lastAssistantUsage = null;
+                                if (typeof usedTokens === "number" && Number.isFinite(usedTokens)) {
+                                    lastAssistantTotalUsage = usedTokens;
+                                    await this.client.sessionUpdate({
+                                        sessionId: message.session_id,
+                                        update: {
+                                            sessionUpdate: "usage_update",
+                                            used: lastAssistantTotalUsage,
+                                            size: session.contextWindowSize,
+                                        },
+                                    });
+                                }
+                                break;
+                            }`
+  }
+];
+
 function applyEdits(source, edits) {
   let nextSource = source;
   for (const edit of edits) {
@@ -557,6 +618,13 @@ function hasGoalPromptUpdates(source) {
     source.includes(
       "const goalPromptUpdate = tuttiClaudeGoalPromptUpdate(firstText)"
     )
+  );
+}
+
+function hasCompactUsageProbeFailureFix(source) {
+  return (
+    source.includes("authoritative post-compaction value") &&
+    !source.includes("lastAssistantTotalUsage = usedTokens ?? 0")
   );
 }
 
@@ -640,6 +708,22 @@ if (hasGoalPromptUpdates(source)) {
   } catch (error) {
     console.error(
       `claude-agent-acp goal-prompt patch failed: ${error.message} Bridge layout changed; update services/tuttid/service/agentstatus/assets/patch-claude-agent-acp.mjs.`
+    );
+    process.exit(1);
+  }
+}
+
+if (hasCompactUsageProbeFailureFix(source)) {
+  console.log(
+    `Already avoids zero usage on Claude compact usage probe failures: ${distPath}`
+  );
+} else {
+  try {
+    source = applyEdits(source, TOKEN_USAGE_COMPACT_EDITS);
+    changed = true;
+  } catch (error) {
+    console.error(
+      `claude-agent-acp compact-usage patch failed: ${error.message} Bridge layout changed; update services/tuttid/service/agentstatus/assets/patch-claude-agent-acp.mjs.`
     );
     process.exit(1);
   }


### PR DESCRIPTION
## Summary
- stop the Claude ACP patch from publishing `used: 0` when compact-boundary context usage probing fails
- document the Claude ACP usage flicker troubleshooting path
- applied the updated patch to the local managed Claude ACP bridge for verification

## Validation
- `node --check services/tuttid/service/agentstatus/assets/patch-claude-agent-acp.mjs`
- `node services/tuttid/service/agentstatus/assets/patch-claude-agent-acp.mjs --dist /Users/vector/.tutti/agent-providers/external-agent-registry/packages/claude-acp/node_modules/@agentclientprotocol/claude-agent-acp/dist/acp-agent.js`
- `corepack pnpm exec prettier --check services/tuttid/service/agentstatus/assets/patch-claude-agent-acp.mjs docs/conventions/troubleshooting.md`
- `git diff --check`
- `corepack pnpm lint:go`
- pre-push `pnpm check:full` passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved context usage reporting after compaction so the UI no longer briefly shows `0%` or an empty usage value when usage data can’t be read.
  * Prevented invalid usage updates from being sent when a usage check fails, reducing flicker in the agent status display.

* **Documentation**
  * Expanded troubleshooting guidance with clearer checks, validation steps, and updated recovery instructions for adapter refresh and repair.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->