### PR TITLE
fix(agent): validate markdown file links

### DIFF
--- a/apps/desktop/src/renderer/src/features/workspace-agent/services/desktopAgentGUILinkActions.test.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-agent/services/desktopAgentGUILinkActions.test.ts
@@ -31,6 +31,7 @@ test("desktop agent gui link actions launch workspace files with resolved action
       homeDirectory: "/Users/local",
       path: "/Users/local/project/a.md",
       source: "agent_command",
+      validateExists: true,
       workspaceId: "workspace-1"
     }
   ]);
@@ -66,6 +67,7 @@ test("desktop agent gui project menu opens the project folder path in workspace 
       mode: "open-directory",
       path: "/Users/local/project",
       source: "agent_command",
+      validateExists: true,
       workspaceId: "workspace-1"
     }
   ]);

--- a/apps/desktop/src/renderer/src/features/workspace-agent/services/desktopAgentGUILinkActions.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-agent/services/desktopAgentGUILinkActions.ts
@@ -23,6 +23,7 @@ export interface DesktopAgentGUILinkActionDependencies {
     mode?: "reveal" | "open-directory";
     path: string;
     source?: "agent_command";
+    validateExists?: boolean;
     workspaceId: string;
   }): Promise<boolean> | boolean;
   launchWorkspaceApp?: (input: {
@@ -58,6 +59,7 @@ export async function runDesktopAgentGUILinkAction(
         ...(action.mode ? { mode: action.mode } : {}),
         path: action.path,
         source: "agent_command",
+        validateExists: true,
         workspaceId: dependencies.workspaceId
       });
     case "open-local-asset-preview":

--- a/apps/desktop/src/renderer/src/features/workspace-file-manager/services/internal/workspaceFileManagerService.test.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-file-manager/services/internal/workspaceFileManagerService.test.ts
@@ -90,6 +90,86 @@ test("workspace file manager service defaults new sessions to the user home dire
   assert.equal(session.store.currentDirectoryPath, "/Users/local");
 });
 
+test("workspace file manager service checks whether an entry exists by listing its parent", async () => {
+  const dependencies = createDependenciesStub();
+  let capturedWorkspaceId: string | undefined;
+  let capturedRequest:
+    | Parameters<TuttidClient["listWorkspaceFileDirectory"]>[1]
+    | undefined;
+  dependencies.tuttidClient.listWorkspaceFileDirectory = async (
+    workspaceId,
+    input
+  ) => {
+    capturedWorkspaceId = workspaceId;
+    capturedRequest = input;
+    return {
+      directoryPath: input?.path || "/Users/local/project",
+      entries: [
+        {
+          createdTimeMs: null,
+          hasChildren: false,
+          kind: "file",
+          lastOpenedMs: null,
+          mtimeMs: null,
+          name: "README.md",
+          path: "/Users/local/project/README.md",
+          sizeBytes: 12
+        }
+      ],
+      root: "/Users/local/project",
+      workspaceId
+    };
+  };
+  const service = new WorkspaceFileManagerService(dependencies);
+
+  assert.equal(
+    await service.entryExists({
+      path: "/Users/local/project/README.md",
+      workspaceID: "workspace-1"
+    }),
+    true
+  );
+  assert.equal(capturedWorkspaceId, "workspace-1");
+  assert.deepEqual(capturedRequest, {
+    includeHidden: true,
+    path: "/Users/local/project"
+  });
+});
+
+test("workspace file manager service treats missing or unreadable entries as absent", async () => {
+  const dependencies = createDependenciesStub();
+  dependencies.tuttidClient.listWorkspaceFileDirectory = async (
+    workspaceId,
+    input
+  ) => ({
+    directoryPath: input?.path || "/Users/local/project",
+    entries: [],
+    root: "/Users/local/project",
+    workspaceId
+  });
+  const service = new WorkspaceFileManagerService(dependencies);
+
+  assert.equal(
+    await service.entryExists({
+      path: "/Users/local/project/MISSING.md",
+      workspaceID: "workspace-1"
+    }),
+    false
+  );
+
+  dependencies.tuttidClient.listWorkspaceFileDirectory = async () => {
+    throw new Error("missing parent");
+  };
+
+  assert.equal(
+    await service.entryExists({
+      path: "/Users/local/project/MISSING.md",
+      workspaceID: "workspace-1"
+    }),
+    false
+  );
+});
+
 test("workspace file manager service restores snapshot state without localStorage", () => {
   const restoreStorage = installForbiddenLocalStorage();
   try {

--- a/apps/desktop/src/renderer/src/features/workspace-file-manager/services/internal/workspaceFileManagerService.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-file-manager/services/internal/workspaceFileManagerService.ts
@@ -77,6 +77,40 @@ export class WorkspaceFileManagerService implements IWorkspaceFileManagerService
     return this.dependencies.platformApi.os;
   }
 
+  async entryExists(input: {
+    path: string;
+    workspaceID: string;
+  }): Promise<boolean> {
+    const targetPath = normalizeComparableWorkspaceFilePath(input.path);
+    if (!targetPath) {
+      return false;
+    }
+
+    try {
+      const listing =
+        await this.dependencies.tuttidClient.listWorkspaceFileDirectory(
+          input.workspaceID,
+          {
+            includeHidden: true,
+            path: dirnameForWorkspaceFilePath(targetPath)
+          }
+        );
+      if (
+        normalizeComparableWorkspaceFilePath(listing.directoryPath) ===
+          targetPath ||
+        normalizeComparableWorkspaceFilePath(listing.root) === targetPath
+      ) {
+        return true;
+      }
+      return listing.entries.some(
+        (entry) =>
+          normalizeComparableWorkspaceFilePath(entry.path) === targetPath
+      );
+    } catch {
+      return false;
+    }
+  }
+
   getSession(
     workspaceID: string,
     i18n: WorkspaceFileManagerI18nRuntime,
@@ -307,6 +341,25 @@ function resolveDesktopFileDefaultOpener(
     desktopPreferencesService?.store.fileDefaultOpenersByExtension[extension] ??
     null
   );
+}
+
+function dirnameForWorkspaceFilePath(path: string): string {
+  const index = path.lastIndexOf("/");
+  if (index <= 0) {
+    return path.startsWith("/") ? "/" : path;
+  }
+  return path.slice(0, index);
+}
+
+function normalizeComparableWorkspaceFilePath(path: string): string {
+  const normalized = path.trim().replaceAll("\\", "/").replace(/\/+/g, "/");
+  if (!normalized) {
+    return "";
+  }
+  if (normalized === "/") {
+    return "/";
+  }
+  return normalized.replace(/\/+$/g, "");
 }
 
 function serializeWorkspaceFileLocationRefreshSnapshot(input: {

--- a/apps/desktop/src/renderer/src/features/workspace-file-manager/services/workspaceFileManagerService.interface.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-file-manager/services/workspaceFileManagerService.interface.ts
@@ -16,6 +16,7 @@ export interface IWorkspaceFileManagerService {
   readonly _serviceBrand: undefined;
   readonly hostOs: NodeJS.Platform;
 
+  entryExists(input: { path: string; workspaceID: string }): Promise<boolean>;
   getSession(
     workspaceID: string,
     i18n: WorkspaceFileManagerI18nRuntime,

--- a/apps/desktop/src/renderer/src/features/workspace-workbench/services/internal/workspaceFilesContribution.test.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/services/internal/workspaceFilesContribution.test.ts
@@ -171,6 +171,9 @@ function createFileManagerServiceStub(
         listener();
       }
     },
+    async entryExists() {
+      return false;
+    },
     getSession() {
       throw new Error("getSession should not be called");
     },

--- a/apps/desktop/src/renderer/src/features/workspace-workbench/services/workspaceFilesLaunchCoordinator.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/services/workspaceFilesLaunchCoordinator.ts
@@ -3,6 +3,7 @@ export interface WorkspaceFilesLaunchRequest {
   mode?: WorkspaceFilesLaunchMode;
   path: string;
   source?: "agent_command" | "issue_manager";
+  validateExists?: boolean;
   workspaceId: string;
 }
 
@@ -57,6 +58,7 @@ export async function requestWorkspaceFilesLaunch(
     ...(request.mode ? { mode: request.mode } : {}),
     path: normalizedPath,
     ...(request.source ? { source: request.source } : {}),
+    ...(request.validateExists ? { validateExists: true } : {}),
     workspaceId: normalizedWorkspaceId
   });
 }

--- a/apps/desktop/src/renderer/src/features/workspace-workbench/services/workspaceFilesRevealIntent.test.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/services/workspaceFilesRevealIntent.test.ts
@@ -117,6 +117,39 @@ test("workspace files launch coordinator preserves open directory mode", async (
   ]);
 });
 
+test("workspace files launch coordinator preserves existence validation intent", async () => {
+  const requests: Array<{
+    path: string;
+    validateExists?: boolean;
+    workspaceId: string;
+  }> = [];
+  const dispose = registerWorkspaceFilesLaunchHandler(
+    "workspace-exists",
+    (request) => {
+      requests.push(request);
+      return true;
+    }
+  );
+
+  assert.equal(
+    await requestWorkspaceFilesLaunch({
+      homeDirectory: "/Users/example",
+      path: "~/demo/README.md",
+      validateExists: true,
+      workspaceId: "workspace-exists"
+    }),
+    true
+  );
+  dispose();
+  assert.deepEqual(requests, [
+    {
+      path: "/Users/example/demo/README.md",
+      validateExists: true,
+      workspaceId: "workspace-exists"
+    }
+  ]);
+});
+
 test("workspace files launch coordinator expands home-relative paths before dispatch", async () => {
   const requests: Array<{
     mode?: "reveal" | "open-directory";

--- a/apps/desktop/src/renderer/src/features/workspace-workbench/ui/WorkspaceWorkbench.source.test.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/ui/WorkspaceWorkbench.source.test.ts
@@ -25,6 +25,13 @@ test("WorkspaceWorkbench forwards open-directory mode to workspace files", () =>
   );
 });
 
+test("WorkspaceWorkbench validates requested file targets before opening workspace files", () => {
+  assert.match(
+    source,
+    /request\.validateExists[\s\S]*workspaceFileManagerService\.entryExists\(\{[\s\S]*path: request\.path[\s\S]*workspaceID: request\.workspaceId[\s\S]*return false;[\s\S]*host\.launchNode/s
+  );
+});
+
 test("WorkspaceWorkbench uses temporary dock retention to control app visibility", () => {
   assert.match(source, /temporaryWorkspaceAppDockRetentionActionPrefix/);
   assert.match(source, /resolveTemporaryDockRetentionContribution/);

--- a/apps/desktop/src/renderer/src/features/workspace-workbench/ui/WorkspaceWorkbench.tsx
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/ui/WorkspaceWorkbench.tsx
@@ -30,6 +30,7 @@ import {
   WorkspaceAppCenterIntegration,
   workspaceAppCenterNodeID
 } from "@renderer/features/workspace-app-center";
+import type { IWorkspaceFileManagerService } from "@renderer/features/workspace-file-manager";
 import { useWorkspaceCatalogService } from "@renderer/features/workspace-catalog";
 import {
   AgentEnvPanel,
@@ -213,15 +214,19 @@ function ReadyWorkspaceWorkbench({
       if (!workbenchHost) {
         throw new Error("Workspace host is unavailable.");
       }
-      const opened = await openWorkspaceFilesNode(workbenchHost, {
-        path: input.path,
-        workspaceId: state.workspace.id
-      });
+      const opened = await openWorkspaceFilesNode(
+        workbenchHost,
+        {
+          path: input.path,
+          workspaceId: state.workspace.id
+        },
+        runtime.workspaceFileManagerService
+      );
       if (!opened) {
         throw new Error("Workspace files could not be opened.");
       }
     },
-    [state.workspace.id, workbenchHost]
+    [runtime.workspaceFileManagerService, state.workspace.id, workbenchHost]
   );
   const onDockEntryAction = useCallback(
     (
@@ -344,7 +349,11 @@ function ReadyWorkspaceWorkbench({
       unregisterFilesLaunchRef.current = registerWorkspaceFilesLaunchHandler(
         state.workspace.id,
         async (request) => {
-          return openWorkspaceFilesNode(host, request);
+          return openWorkspaceFilesNode(
+            host,
+            request,
+            runtime.workspaceFileManagerService
+          );
         }
       );
       unregisterIssueManagerLaunchRef.current =
@@ -899,8 +908,19 @@ function shouldPublishWorkspaceAppLaunchIntentBeforeLaunch(input: {
 
 async function openWorkspaceFilesNode(
   host: WorkbenchHostHandle,
-  request: WorkspaceFilesLaunchRequest
+  request: WorkspaceFilesLaunchRequest,
+  workspaceFileManagerService: IWorkspaceFileManagerService
 ): Promise<boolean> {
+  if (
+    request.validateExists &&
+    !(await workspaceFileManagerService.entryExists({
+      path: request.path,
+      workspaceID: request.workspaceId
+    }))
+  ) {
+    return false;
+  }
+
   const nodeId = await host.launchNode({
     launchSource: request.source,
     reason: "host",

--- a/apps/desktop/src/renderer/src/features/workspace-workbench/ui/useWorkspaceWorkbenchShellRuntime.tsx
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/ui/useWorkspaceWorkbenchShellRuntime.tsx
@@ -100,6 +100,9 @@ export interface WorkspaceWorkbenchShellRuntime {
     fit: WorkbenchSurfaceWallpaperFit;
     url: string;
   };
+  workspaceFileManagerService: ReturnType<
+    typeof useWorkspaceFileManagerService
+  >;
   workbenchWindowSnapping: DesktopWorkbenchWindowSnapping;
   workbenchHostService: ReturnType<typeof useWorkspaceWorkbenchHostService>;
 }
@@ -441,6 +444,7 @@ export function useWorkspaceWorkbenchShellRuntime({
       fit: shellRuntimeSnapshot.wallpaperSelection.wallpaper.fit,
       url: shellRuntimeSnapshot.wallpaperSelection.wallpaper.url
     },
+    workspaceFileManagerService,
     workbenchWindowSnapping: desktopPreferencesState.workbenchWindowSnapping,
     workbenchHostService
   };

--- a/docs/architecture/agent-gui-node.md
+++ b/docs/architecture/agent-gui-node.md
@@ -803,6 +803,21 @@ rich text document
 IME behavior, search state, serialization, and transcript rendering are separate
 links. A local picker fix can break prompt serialization or rendered links.
 
+Rendered transcript markdown should only promote explicit file targets to
+workspace file actions: local absolute paths, home-relative paths, and Windows
+absolute paths. Relative markdown links remain display text unless another
+structured reference contract marks them as a workspace reference. Host adapters
+that open workspace file nodes should validate explicit agent-command file
+targets before launching the files surface, so a speculative or stale agent
+path does not open a misleading workbench node.
+
+Quick checks:
+
+```sh
+pnpm --filter @tutti-os/agent-gui test -- shared/AgentMessageMarkdown.spec.tsx
+pnpm --filter @tutti-os/desktop test -- src/renderer/src/features/workspace-file-manager/services/internal/workspaceFileManagerService.test.ts src/renderer/src/features/workspace-workbench/services/workspaceFilesRevealIntent.test.ts
+```
+
 ## Troubleshooting Playbook
 
 ### Blank Or Stale Conversation Detail

--- a/packages/agent/gui/agent-message-center/WorkspaceAgentMessageCenterPanel.spec.tsx
+++ b/packages/agent/gui/agent-message-center/WorkspaceAgentMessageCenterPanel.spec.tsx
@@ -594,7 +594,7 @@ describe("WorkspaceAgentMessageCenterCard", () => {
     ).toHaveClass("rounded-full");
   });
 
-  it("resolves summary file links through the shared workspace link action", () => {
+  it("renders summary relative file links as plain text", () => {
     const onLinkAction = vi.fn();
     render(
       <TooltipProvider>
@@ -612,20 +612,11 @@ describe("WorkspaceAgentMessageCenterCard", () => {
       </TooltipProvider>
     );
 
-    const link = screen.getByRole("link", { name: "PROJECT_SUMMARY.md" });
-    expect(link.closest('[data-workspace-agent-markdown="true"]')).toHaveClass(
-      "[&_a]:text-[var(--tutti-purple)]"
-    );
-
-    fireEvent.click(link);
-
-    expect(onLinkAction).toHaveBeenCalledWith({
-      type: "open-workspace-file",
-      path: "/Users/local/.tutti/agent/sessions/2026-06-05-001/PROJECT_SUMMARY.md",
-      directoryPath: "/Users/local/.tutti/agent/sessions/2026-06-05-001",
-      workspaceRoot: "/Users/local/.tutti/agent/sessions/2026-06-05-001",
-      source: "agent-markdown"
-    });
+    expect(
+      screen.queryByRole("link", { name: "PROJECT_SUMMARY.md" })
+    ).toBeNull();
+    expect(screen.getByText("PROJECT_SUMMARY.md")).toBeInTheDocument();
+    expect(onLinkAction).not.toHaveBeenCalled();
   });
 
   it("allows copying the card title and summary text", () => {

--- a/packages/agent/gui/shared/AgentMessageMarkdown.spec.tsx
+++ b/packages/agent/gui/shared/AgentMessageMarkdown.spec.tsx
@@ -69,10 +69,8 @@ describe("AgentMessageMarkdown", () => {
       />
     );
 
-    expect(screen.getByRole("link", { name: "README.md" })).toHaveAttribute(
-      "data-agent-link-href",
-      "README.md"
-    );
+    expect(screen.queryByRole("link", { name: "README.md" })).toBeNull();
+    expect(screen.getByText("README.md")).toBeInTheDocument();
     expect(screen.getByText("src/App.tsx")).toBeInTheDocument();
     expect(screen.getByText("重点").tagName).toBe("STRONG");
     expect(screen.getByText("第一项")).toBeInTheDocument();
@@ -219,18 +217,27 @@ describe("AgentMessageMarkdown", () => {
     expect(event).toBe(false);
   });
 
-  it("dispatches link clicks when an action handler is provided", () => {
-    const onLinkClick = vi.fn();
+  it("renders relative markdown links as plain text", () => {
+    const onLinkAction = vi.fn();
     render(
       <AgentMessageMarkdown
-        content={"已读取 [README.md](README.md)"}
-        onLinkClick={onLinkClick}
+        content={
+          "已读取 [README.md](README.md)，目录 [content/posts](content/posts)。"
+        }
+        onLinkAction={onLinkAction}
+        workspaceLinkContext={{
+          workspaceRoot: "/Users/local/project",
+          basePath: "/Users/local/project/docs",
+          source: "agent-markdown"
+        }}
       />
     );
 
-    fireEvent.click(screen.getByRole("link", { name: "README.md" }));
-
-    expect(onLinkClick).toHaveBeenCalledWith("README.md");
+    expect(screen.queryByRole("link", { name: "README.md" })).toBeNull();
+    expect(screen.queryByRole("link", { name: "content/posts" })).toBeNull();
+    expect(screen.getByText("README.md")).toBeInTheDocument();
+    expect(screen.getByText("content/posts")).toBeInTheDocument();
+    expect(onLinkAction).not.toHaveBeenCalled();
   });
 
   it("does not nest path links inside markdown links with inline code labels", () => {
@@ -264,7 +271,7 @@ describe("AgentMessageMarkdown", () => {
     const onLinkAction = vi.fn();
     render(
       <AgentMessageMarkdown
-        content={"已读取 [README.md](README.md)"}
+        content={"已读取 [README.md](/Users/local/project/docs/README.md)"}
         onLinkAction={onLinkAction}
         workspaceLinkContext={{
           workspaceRoot: "/Users/local/project",
@@ -281,6 +288,56 @@ describe("AgentMessageMarkdown", () => {
       path: "/Users/local/project/docs/README.md",
       directoryPath: "/Users/local/project/docs",
       workspaceRoot: "/Users/local/project",
+      source: "agent-markdown"
+    });
+  });
+
+  it("resolves home-relative markdown file links when workspace context is provided", () => {
+    const onLinkAction = vi.fn();
+    render(
+      <AgentMessageMarkdown
+        content={"已保存 [notes](~/docs/notes.md)"}
+        onLinkAction={onLinkAction}
+        workspaceLinkContext={{
+          workspaceRoot: "/Users/local/project",
+          basePath: "/Users/local/project",
+          source: "agent-markdown"
+        }}
+      />
+    );
+
+    fireEvent.click(screen.getByRole("link", { name: "notes" }));
+
+    expect(onLinkAction).toHaveBeenCalledWith({
+      type: "open-workspace-file",
+      path: "~/docs/notes.md",
+      directoryPath: "~/docs",
+      workspaceRoot: "/Users/local/project",
+      source: "agent-markdown"
+    });
+  });
+
+  it("resolves Windows absolute markdown file links when workspace context is provided", () => {
+    const onLinkAction = vi.fn();
+    render(
+      <AgentMessageMarkdown
+        content={"已读取 [README.md](C:/Users/local/project/docs/README.md)"}
+        onLinkAction={onLinkAction}
+        workspaceLinkContext={{
+          workspaceRoot: "C:/Users/local/project",
+          basePath: "C:/Users/local/project/docs",
+          source: "agent-markdown"
+        }}
+      />
+    );
+
+    fireEvent.click(screen.getByRole("link", { name: "README.md" }));
+
+    expect(onLinkAction).toHaveBeenCalledWith({
+      type: "open-workspace-file",
+      path: "C:/Users/local/project/docs/README.md",
+      directoryPath: "C:/Users/local/project/docs",
+      workspaceRoot: "C:/Users/local/project",
       source: "agent-markdown"
     });
   });
@@ -697,7 +754,7 @@ describe("AgentMessageMarkdown", () => {
     render(
       <AgentMessageMarkdown
         content={
-          "[![generated image](/workspace/output/imagegen/dance.png)](README.md)"
+          "[![generated image](/workspace/output/imagegen/dance.png)](https://example.com/generated-image)"
         }
         onLinkClick={onLinkClick}
         enableImageZoom
@@ -709,7 +766,9 @@ describe("AgentMessageMarkdown", () => {
 
     fireEvent.click(link);
 
-    expect(onLinkClick).toHaveBeenCalledWith("README.md");
+    expect(onLinkClick).toHaveBeenCalledWith(
+      "https://example.com/generated-image"
+    );
   });
 
   it("supports inline rendering for title-sized markdown content", () => {
@@ -935,6 +994,60 @@ describe("AgentMessageMarkdown", () => {
     expect(onLinkClick).toHaveBeenCalledWith("/Users/example/demo/abc");
   });
 
+  it("turns inline code home-relative paths into clickable links", () => {
+    const onLinkAction = vi.fn();
+    render(
+      <AgentMessageMarkdown
+        content={"已保存到 `~/docs/a.md`。"}
+        onLinkAction={onLinkAction}
+        workspaceLinkContext={{
+          workspaceRoot: "/Users/example/demo",
+          basePath: "/Users/example/demo",
+          source: "agent-markdown"
+        }}
+      />
+    );
+
+    fireEvent.click(screen.getByRole("link", { name: "~/docs/a.md" }));
+
+    expect(onLinkAction).toHaveBeenCalledWith({
+      type: "open-workspace-file",
+      path: "~/docs/a.md",
+      directoryPath: "~/docs",
+      workspaceRoot: "/Users/example/demo",
+      source: "agent-markdown"
+    });
+  });
+
+  it("turns inline code Windows absolute paths into clickable links", () => {
+    const onLinkAction = vi.fn();
+    render(
+      <AgentMessageMarkdown
+        content={"已保存到 `C:\\Users\\local\\project\\docs\\README.md`。"}
+        onLinkAction={onLinkAction}
+        workspaceLinkContext={{
+          workspaceRoot: "C:/Users/local/project",
+          basePath: "C:/Users/local/project",
+          source: "agent-markdown"
+        }}
+      />
+    );
+
+    fireEvent.click(
+      screen.getByRole("link", {
+        name: "C:\\Users\\local\\project\\docs\\README.md"
+      })
+    );
+
+    expect(onLinkAction).toHaveBeenCalledWith({
+      type: "open-workspace-file",
+      path: "C:/Users/local/project/docs/README.md",
+      directoryPath: "C:/Users/local/project/docs",
+      workspaceRoot: "C:/Users/local/project",
+      source: "agent-markdown"
+    });
+  });
+
   it("turns inline code http urls into clickable links", () => {
     const onLinkClick = vi.fn();
     render(
@@ -1031,12 +1144,12 @@ describe("AgentMessageMarkdown", () => {
     expect(onLinkClick).not.toHaveBeenCalled();
   });
 
-  it("links relative file paths inside inline code when workspace context is provided", () => {
+  it("does not link relative file paths inside inline code when workspace context is provided", () => {
     const onLinkAction = vi.fn();
     render(
       <AgentMessageMarkdown
         content={
-          "已创建目录 [empty-files](empty-files/)，里面包含：\n- `xx.html`\n- `xx.md`"
+          "已创建目录 [empty-files](empty-files/)，里面包含：\n- `xx.html`\n- `xx.md`\n- `content/posts`\n- `lib/site.ts`\n- `README.md`"
         }
         onLinkAction={onLinkAction}
         workspaceLinkContext={{
@@ -1047,23 +1160,18 @@ describe("AgentMessageMarkdown", () => {
       />
     );
 
-    fireEvent.click(screen.getByRole("link", { name: "xx.html" }));
-    fireEvent.click(screen.getByRole("link", { name: "xx.md" }));
-
-    expect(onLinkAction).toHaveBeenNthCalledWith(1, {
-      type: "open-workspace-file",
-      path: "/Users/local/project/empty-files/xx.html",
-      directoryPath: "/Users/local/project/empty-files",
-      workspaceRoot: "/Users/local/project",
-      source: "agent-markdown"
-    });
-    expect(onLinkAction).toHaveBeenNthCalledWith(2, {
-      type: "open-workspace-file",
-      path: "/Users/local/project/empty-files/xx.md",
-      directoryPath: "/Users/local/project/empty-files",
-      workspaceRoot: "/Users/local/project",
-      source: "agent-markdown"
-    });
+    for (const label of [
+      "empty-files",
+      "xx.html",
+      "xx.md",
+      "content/posts",
+      "lib/site.ts",
+      "README.md"
+    ]) {
+      expect(screen.queryByRole("link", { name: label })).toBeNull();
+      expect(screen.getByText(label)).toBeInTheDocument();
+    }
+    expect(onLinkAction).not.toHaveBeenCalled();
   });
 
   it("does not treat ordinary inline code as a path", () => {
@@ -1159,10 +1267,8 @@ describe("AgentMessageMarkdown", () => {
         vi.advanceTimersByTime(80);
       });
 
-      expect(screen.getByRole("link", { name: "README.md" })).toHaveAttribute(
-        "data-agent-link-href",
-        "README.md"
-      );
+      expect(screen.queryByRole("link", { name: "README.md" })).toBeNull();
+      expect(screen.getByText("README.md")).toBeInTheDocument();
       expect(
         container.querySelector(
           '[data-workspace-agent-markdown-deferred="true"]'

--- a/packages/agent/gui/shared/AgentMessageMarkdown.spec.tsx
+++ b/packages/agent/gui/shared/AgentMessageMarkdown.spec.tsx
@@ -240,6 +240,42 @@ describe("AgentMessageMarkdown", () => {
     expect(onLinkAction).not.toHaveBeenCalled();
   });
 
+  it("keeps standard markdown link hrefs clickable", () => {
+    const onLinkClick = vi.fn();
+    render(
+      <AgentMessageMarkdown
+        content={
+          "[Email](mailto:hello@example.com) [Phone](tel:+123456789) [Section](#details) [Chat](xmpp:hello@example.com)"
+        }
+        onLinkClick={onLinkClick}
+      />
+    );
+
+    for (const [label, href] of [
+      ["Email", "mailto:hello@example.com"],
+      ["Phone", "tel:+123456789"],
+      ["Section", "#details"],
+      ["Chat", "xmpp:hello@example.com"]
+    ] as const) {
+      fireEvent.click(screen.getByRole("link", { name: label }));
+      expect(onLinkClick).toHaveBeenLastCalledWith(href);
+    }
+  });
+
+  it("renders unsafe markdown links as plain text", () => {
+    const onLinkClick = vi.fn();
+    render(
+      <AgentMessageMarkdown
+        content={"不要打开 [bad](javascript:alert(1))"}
+        onLinkClick={onLinkClick}
+      />
+    );
+
+    expect(screen.queryByRole("link", { name: "bad" })).toBeNull();
+    expect(screen.getByText("bad")).toBeInTheDocument();
+    expect(onLinkClick).not.toHaveBeenCalled();
+  });
+
   it("does not nest path links inside markdown links with inline code labels", () => {
     const onLinkClick = vi.fn();
     const { container } = render(

--- a/packages/agent/gui/shared/AgentMessageMarkdown.tsx
+++ b/packages/agent/gui/shared/AgentMessageMarkdown.tsx
@@ -48,7 +48,6 @@ import {
 } from "../agentActivityHost";
 import {
   isDirectAgentGeneratedMediaPath,
-  resolveWorkspaceFilePathCandidate,
   resolveWorkspaceLinkAction,
   type WorkspaceLinkAction,
   type WorkspaceLinkActionSource
@@ -71,6 +70,8 @@ const PLAIN_SESSION_MENTION_AGENT_LABELS = [
   "Nexight",
   "Codex"
 ] as const;
+const WINDOWS_DRIVE_HREF_PROTOCOLS =
+  "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ".split("");
 export const AGENT_MARKDOWN_PLAIN_TITLE_CLASSNAME =
   "[font-size:inherit] [line-height:inherit] text-inherit [&_a]:text-inherit [&_a]:font-inherit [&_a]:no-underline [&_a:hover]:no-underline [&_a:focus-visible]:no-underline [&_strong]:font-inherit [&_strong]:text-inherit";
 
@@ -78,7 +79,11 @@ const MARKDOWN_SANITIZE_SCHEMA: RehypeSanitizeOptions = {
   ...defaultSchema,
   protocols: {
     ...defaultSchema.protocols,
-    href: [...(defaultSchema.protocols?.href ?? []), "mention"]
+    href: [
+      ...(defaultSchema.protocols?.href ?? []),
+      "mention",
+      ...WINDOWS_DRIVE_HREF_PROTOCOLS
+    ]
   }
 };
 
@@ -199,13 +204,8 @@ export function AgentMessageMarkdown({
   const handleLinkClick = useCallback(
     (href: string): void => {
       if (workspaceLinkSource && onLinkAction && workspaceRoot) {
-        const resolvedHref =
-          resolveWorkspaceFileHrefFromMessage(href, stabilizedContent, {
-            workspaceRoot,
-            basePath
-          }) ?? href;
         const action = resolveWorkspaceLinkAction({
-          href: resolvedHref,
+          href,
           workspaceRoot,
           basePath,
           source: workspaceLinkSource
@@ -217,14 +217,7 @@ export function AgentMessageMarkdown({
       }
       onLinkClick?.(href);
     },
-    [
-      basePath,
-      onLinkAction,
-      onLinkClick,
-      stabilizedContent,
-      workspaceLinkSource,
-      workspaceRoot
-    ]
+    [basePath, onLinkAction, onLinkClick, workspaceLinkSource, workspaceRoot]
   );
   const handleAnchorClickCapture = useCallback(
     (event: MouseEvent<HTMLElement>): void => {
@@ -249,13 +242,7 @@ export function AgentMessageMarkdown({
         />
       ),
       code: (props: MarkdownDomProps<"code">) => (
-        <MarkdownCode
-          {...props}
-          onLinkClick={handleLinkClick}
-          workspaceFileLinksEnabled={Boolean(
-            workspaceRoot && workspaceLinkSource
-          )}
-        />
+        <MarkdownCode {...props} onLinkClick={handleLinkClick} />
       ),
       img: (props: MarkdownDomProps<"img">) => (
         <MarkdownMedia {...props} enableZoom={enableImageZoom} />
@@ -267,15 +254,7 @@ export function AgentMessageMarkdown({
       ol: MarkdownOrderedList,
       li: MarkdownListItem
     }),
-    [
-      enableImageZoom,
-      handleLinkClick,
-      inline,
-      previewMode,
-      workspaceAppIcons,
-      workspaceLinkSource,
-      workspaceRoot
-    ]
+    [enableImageZoom, handleLinkClick, inline, previewMode, workspaceAppIcons]
   );
 
   return (
@@ -660,6 +639,15 @@ function MarkdownLink({
       />
     );
   }
+  if (!isClickableMarkdownHref(targetHref)) {
+    return (
+      <MarkdownLinkContext.Provider value={true}>
+        <span className={props.className} title={props.title}>
+          {props.children}
+        </span>
+      </MarkdownLinkContext.Provider>
+    );
+  }
 
   return (
     <MarkdownLinkContext.Provider value={true}>
@@ -939,11 +927,9 @@ function MarkdownCode({
   children,
   className,
   onLinkClick,
-  workspaceFileLinksEnabled = false,
   ...props
 }: MarkdownDomProps<"code"> & {
   onLinkClick?: (href: string) => void;
-  workspaceFileLinksEnabled?: boolean;
 }): JSX.Element {
   "use memo";
   const isInsideLink = useContext(MarkdownLinkContext);
@@ -952,9 +938,7 @@ function MarkdownCode({
     !isInsideLink &&
     onLinkClick &&
     !className &&
-    (isLocalAbsolutePath(text) ||
-      isHttpUrl(text) ||
-      (workspaceFileLinksEnabled && isLikelyWorkspaceRelativeFilePath(text)));
+    (isExplicitWorkspaceFilePath(text) || isHttpUrl(text));
   if (isLinkablePath) {
     return (
       <PathLink href={text} onLinkClick={onLinkClick}>
@@ -1311,6 +1295,44 @@ function isLocalAbsolutePath(path: string): boolean {
   );
 }
 
+function isHomeRelativePath(path: string): boolean {
+  const candidate = path.trim();
+  return (
+    candidate.length > 0 &&
+    !/\s/.test(candidate) &&
+    (candidate === "~" ||
+      candidate.startsWith("~/") ||
+      candidate.startsWith("~\\"))
+  );
+}
+
+function isWindowsAbsolutePath(path: string): boolean {
+  const candidate = path.trim();
+  return /^[A-Za-z]:[\\/]/.test(candidate) && !/\s/.test(candidate);
+}
+
+function isExplicitWorkspaceFilePath(path: string): boolean {
+  const candidate = path.trim();
+  if (!candidate || candidate.includes("://")) {
+    return false;
+  }
+  return (
+    isLocalAbsolutePath(candidate) ||
+    isHomeRelativePath(candidate) ||
+    isWindowsAbsolutePath(candidate)
+  );
+}
+
+function isClickableMarkdownHref(href: string): boolean {
+  const target = href.trim();
+  return Boolean(
+    target &&
+    (isHttpUrl(target) ||
+      isRichTextMentionHref(target) ||
+      isExplicitWorkspaceFilePath(target))
+  );
+}
+
 function resolveRenderableMarkdownMediaSrc(src: string): string {
   const trimmed = src.trim();
   if (!trimmed) {
@@ -1432,85 +1454,6 @@ function isHttpUrl(value: string): boolean {
   }
 }
 
-function resolveWorkspaceFileHrefFromMessage(
-  rawPath: string,
-  messageContent: string,
-  context: {
-    workspaceRoot: string;
-    basePath: string | null;
-  }
-): string | null {
-  const path = trimTrailingPathPunctuation(rawPath.trim());
-  if (
-    !path ||
-    isHttpUrl(path) ||
-    isLocalAbsolutePath(path) ||
-    !isLikelyWorkspaceRelativeFilePath(path)
-  ) {
-    return null;
-  }
-
-  const directoryHrefs = extractWorkspaceDirectoryLinkHrefs(messageContent);
-  const candidates: string[] = [];
-  if (path.includes("/")) {
-    candidates.push(path);
-  } else {
-    for (const directoryHref of directoryHrefs) {
-      candidates.push(`${directoryHref}/${path}`);
-    }
-    candidates.push(path);
-  }
-
-  for (const candidate of candidates) {
-    if (
-      resolveWorkspaceFilePathCandidate({
-        path: candidate,
-        workspaceRoot: context.workspaceRoot,
-        basePath: context.basePath
-      })
-    ) {
-      return candidate;
-    }
-  }
-  return null;
-}
-
-function extractWorkspaceDirectoryLinkHrefs(content: string): string[] {
-  const directories: string[] = [];
-  let index = 0;
-  while (index < content.length) {
-    const linkEnd = markdownLinkEndIndex(content, index);
-    if (linkEnd <= index) {
-      index += 1;
-      continue;
-    }
-
-    const slice = content.slice(index, linkEnd);
-    const match = /^\[([^\]]*)\]\(([^)]+)\)$/.exec(slice);
-    if (match) {
-      const href = match[2]?.trim() ?? "";
-      if (href && !isRichTextMentionHref(href) && !href.includes("://")) {
-        const normalizedHref = href.replace(/\/+$/g, "");
-        if (
-          href.endsWith("/") ||
-          (!normalizedHref.includes(".") && !normalizedHref.includes(" "))
-        ) {
-          directories.push(normalizedHref);
-        }
-      }
-    }
-    index = linkEnd;
-  }
-  return [...new Set(directories)];
-}
-
-function isLikelyWorkspaceRelativeFilePath(path: string): boolean {
-  if (!path || /\s/.test(path) || path.includes("://")) {
-    return false;
-  }
-  return path.includes("/") || /\.[A-Za-z0-9][A-Za-z0-9._-]{0,15}$/.test(path);
-}
-
 function linkBareLocalAbsolutePaths(content: string): string {
   let out = "";
   for (let index = 0; index < content.length; ) {
@@ -1613,7 +1556,10 @@ function normalizePlainSessionMentionTitle(content: string): string {
 }
 
 function markdownUrlTransform(value: string): string {
-  return isRichTextMentionHref(value) ? value : defaultUrlTransform(value);
+  const target = value.trim();
+  return isRichTextMentionHref(target) || isExplicitWorkspaceFilePath(target)
+    ? target
+    : defaultUrlTransform(value);
 }
 
 type MentionKind =

--- a/packages/agent/gui/shared/AgentMessageMarkdown.tsx
+++ b/packages/agent/gui/shared/AgentMessageMarkdown.tsx
@@ -70,6 +70,15 @@ const PLAIN_SESSION_MENTION_AGENT_LABELS = [
   "Nexight",
   "Codex"
 ] as const;
+const STANDARD_MARKDOWN_LINK_PROTOCOLS = [
+  "http",
+  "https",
+  "irc",
+  "ircs",
+  "mailto",
+  "tel",
+  "xmpp"
+] as const;
 const WINDOWS_DRIVE_HREF_PROTOCOLS =
   "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ".split("");
 export const AGENT_MARKDOWN_PLAIN_TITLE_CLASSNAME =
@@ -82,6 +91,7 @@ const MARKDOWN_SANITIZE_SCHEMA: RehypeSanitizeOptions = {
     href: [
       ...(defaultSchema.protocols?.href ?? []),
       "mention",
+      ...STANDARD_MARKDOWN_LINK_PROTOCOLS,
       ...WINDOWS_DRIVE_HREF_PROTOCOLS
     ]
   }
@@ -1327,9 +1337,29 @@ function isClickableMarkdownHref(href: string): boolean {
   const target = href.trim();
   return Boolean(
     target &&
-    (isHttpUrl(target) ||
+    (isStandardMarkdownLinkHref(target) ||
       isRichTextMentionHref(target) ||
       isExplicitWorkspaceFilePath(target))
+  );
+}
+
+function isStandardMarkdownLinkHref(href: string): boolean {
+  const target = href.trim();
+  if (!target || isExplicitWorkspaceFilePath(target)) {
+    return false;
+  }
+  if (target.startsWith("#")) {
+    return target.length > 1;
+  }
+  let url: URL;
+  try {
+    url = new URL(target);
+  } catch {
+    return false;
+  }
+  const protocol = url.protocol.replace(/:$/, "").toLowerCase();
+  return STANDARD_MARKDOWN_LINK_PROTOCOLS.includes(
+    protocol as (typeof STANDARD_MARKDOWN_LINK_PROTOCOLS)[number]
   );
 }
 
@@ -1557,7 +1587,9 @@ function normalizePlainSessionMentionTitle(content: string): string {
 
 function markdownUrlTransform(value: string): string {
   const target = value.trim();
-  return isRichTextMentionHref(target) || isExplicitWorkspaceFilePath(target)
+  return isRichTextMentionHref(target) ||
+    isExplicitWorkspaceFilePath(target) ||
+    isStandardMarkdownLinkHref(target)
     ? target
     : defaultUrlTransform(value);
 }

--- a/packages/agent/gui/shared/agentConversation/components/AgentTranscriptView.spec.tsx
+++ b/packages/agent/gui/shared/agentConversation/components/AgentTranscriptView.spec.tsx
@@ -336,7 +336,7 @@ describe("AgentTranscriptView", () => {
     );
   });
 
-  it("resolves agent markdown relative links from the session cwd", () => {
+  it("renders agent markdown relative links as plain text", () => {
     const onLinkAction = vi.fn();
     render(
       <AgentTranscriptView
@@ -378,15 +378,11 @@ describe("AgentTranscriptView", () => {
       />
     );
 
-    fireEvent.click(screen.getByRole("link", { name: "stock-dashboard.html" }));
-
-    expect(onLinkAction).toHaveBeenCalledWith({
-      type: "open-workspace-file",
-      path: "/workspace/demo/reports/stock-dashboard.html",
-      directoryPath: "/workspace/demo/reports",
-      workspaceRoot: "/workspace/demo",
-      source: "agent-markdown"
-    });
+    expect(
+      screen.queryByRole("link", { name: "stock-dashboard.html" })
+    ).toBeNull();
+    expect(screen.getByText("stock-dashboard.html")).toBeTruthy();
+    expect(onLinkAction).not.toHaveBeenCalled();
   });
 
   it("opens local absolute paths inside the current workspace root", () => {


### PR DESCRIPTION
## Summary
- render relative agent markdown file links as plain text unless they are explicit local/home/Windows paths
- validate agent-command workspace file targets before opening the files workbench node
- document the AgentGUI markdown/file reference rule in docs/architecture/agent-gui-node.md

## Validation
- env PATH=/Users/ccr/.nvm/versions/node/v24.12.0/bin:$PATH pnpm check:changed --tail-lines 80
- env PATH=/Users/ccr/.nvm/versions/node/v24.12.0/bin:$PATH pnpm check:full

## Documentation Impact
- improve: updated docs/architecture/agent-gui-node.md with the explicit file-link promotion rule and validation commands

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Workspace file link handling can now optionally validate that the target exists before opening, improving reliability.
  * Supports broader explicit path formats in agent content (including home-relative and Windows-style paths) for workspace file actions.

* **Bug Fixes**
  * Relative markdown links embedded in agent messages are no longer treated as clickable workspace links; they render as plain text.
  * File opening/launch behavior is safer when targets are missing, malformed, or otherwise not found (fails early instead of opening unintended nodes).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->