### PR TITLE
[codex] fix reference search results

### DIFF
--- a/apps/desktop/src/renderer/src/features/agent-reference-sources/appReferenceListBackend.ts
+++ b/apps/desktop/src/renderer/src/features/agent-reference-sources/appReferenceListBackend.ts
@@ -124,9 +124,11 @@ export function createAppReferenceListBackend(
     ): Promise<ReferenceListResult> {
       // 选中分组节点解码出 appId(分组形如 `app:${appId}` 或更深的 `app:${appId}|grp:…`),
       // 把搜索限定到该应用;无 scope 时回退跨全部应用。
-      const scopedAppId = withinGroupId
-        ? decodeAppGroupId(withinGroupId).appId
+      const decodedScope = withinGroupId
+        ? decodeAppGroupId(withinGroupId)
         : null;
+      const scopedAppId = decodedScope?.appId ?? null;
+      const scopedGroupId = decodedScope?.groupId ?? null;
       const apps = (await listReferenceSupportingApps(tuttidClient, scope))
         .filter((app) => app.references.searchSupported)
         .filter((app) => scopedAppId == null || app.appId === scopedAppId);
@@ -141,25 +143,54 @@ export function createAppReferenceListBackend(
       const perApp = await Promise.all(
         apps.map(async (app) => {
           try {
-            const response = await tuttidClient.searchWorkspaceAppReferences(
-              scope.workspaceId,
-              app.appId,
-              {
-                query,
-                ...(limit == null ? {} : { limit }),
-                ...(filters && filters.length > 0 ? { filters } : {}),
-                kinds: ["file"]
-              }
-            );
             const appLabel = app.displayName?.trim() || app.appId;
-            const mapped = response.items.map((item) =>
+            const appIconUrl = app.iconUrl ?? undefined;
+            const queryText = query.trim();
+            const shouldSearchGroups =
+              queryText.length > 0 &&
+              scopedGroupId == null &&
+              (!filters || filters.length === 0);
+            const [groupResponse, searchResponse] = await Promise.all([
+              shouldSearchGroups
+                ? tuttidClient.listWorkspaceAppReferences(
+                    scope.workspaceId,
+                    app.appId,
+                    {
+                      parentGroupId: null,
+                      filterText: queryText,
+                      cursor: null,
+                      limit: limit ?? APP_REFERENCE_PAGE_LIMIT,
+                      kinds: ["file"]
+                    }
+                  )
+                : Promise.resolve({ items: [], nextCursor: null }),
+              tuttidClient.searchWorkspaceAppReferences(
+                scope.workspaceId,
+                app.appId,
+                {
+                  query,
+                  ...(limit == null ? {} : { limit }),
+                  ...(filters && filters.length > 0 ? { filters } : {}),
+                  kinds: ["file"]
+                }
+              )
+            ]);
+            const groupItems = groupResponse.items
+              .filter((item) => item.type === "group")
+              .map((item) =>
+                appItemToProtocol(app.appId, item, appLabel, appIconUrl)
+              );
+            const fileItems = searchResponse.items.map((item) =>
               appItemToProtocol(app.appId, item, appLabel)
             );
+            const mapped = [...groupItems, ...fileItems];
             // daemon 仅在 app 运行时才代理到其 server,否则静默返回空。
             // 记录每个 app 的命中数,便于区分「没起/没匹配/接口异常」。
             console.debug("[app-reference-search] app result", {
               appId: app.appId,
               query,
+              groupCount: groupItems.length,
+              fileCount: fileItems.length,
               count: mapped.length
             });
             return mapped;

--- a/apps/desktop/src/renderer/src/features/agent-reference-sources/referenceHandle.test.ts
+++ b/apps/desktop/src/renderer/src/features/agent-reference-sources/referenceHandle.test.ts
@@ -119,6 +119,83 @@ test("app backend labels child groups with app and project names", async () => {
   );
 });
 
+test("app backend search includes matching app project groups", async () => {
+  const calls: Array<{ endpoint: "list" | "search"; filterText?: string }> = [];
+  const tuttidClient = {
+    listWorkspaceApps: async () => ({
+      apps: [
+        {
+          appId: "ai-media-canvas",
+          displayName: "AI Canvas",
+          installed: true,
+          enabled: true,
+          references: { listSupported: true, searchSupported: true }
+        }
+      ]
+    }),
+    listWorkspaceAppReferences: async (
+      _workspaceId: string,
+      _appId: string,
+      input: { filterText?: string | null }
+    ) => {
+      calls.push({
+        endpoint: "list",
+        filterText: input.filterText ?? undefined
+      });
+      return {
+        items: [
+          {
+            type: "group",
+            id: "project-1",
+            displayName: "My First Project",
+            referenceCount: 0
+          }
+        ],
+        nextCursor: null
+      };
+    },
+    searchWorkspaceAppReferences: async () => {
+      calls.push({ endpoint: "search" });
+      return {
+        items: [
+          {
+            type: "reference",
+            reference: {
+              kind: "file",
+              displayName: "cover.png",
+              path: "project-assets/cover.png",
+              parentGroupLabel: "My First Project"
+            }
+          }
+        ],
+        nextCursor: null
+      };
+    }
+  } as unknown as TuttidClient;
+  const backend = createAppReferenceListBackend(tuttidClient);
+
+  const result = await backend.search?.(scope, {
+    query: "My First Project",
+    limit: 20
+  });
+
+  assert.equal(result?.items[0]?.type, "group");
+  assert.deepEqual(
+    result?.items.map((item) => item.type),
+    ["group", "reference"]
+  );
+  assert.equal(
+    result?.items[0] && "parentLabel" in result.items[0]
+      ? result.items[0].parentLabel
+      : undefined,
+    "AI Canvas / My First Project"
+  );
+  assert.deepEqual(calls, [
+    { endpoint: "list", filterText: "My First Project" },
+    { endpoint: "search" }
+  ]);
+});
+
 test("app reference app discovery caches repeated workspace app listing", async () => {
   let listCalls = 0;
   const tuttidClient = {

--- a/packages/workspace/files/search.go
+++ b/packages/workspace/files/search.go
@@ -72,12 +72,6 @@ type textMatchResult struct {
 	score   int
 }
 
-type pathSequenceChoice struct {
-	indices []int
-	ok      bool
-	score   int
-}
-
 func NormalizeSearchLimit(limit int) int {
 	if limit <= 0 {
 		return DefaultSearchLimit
@@ -260,11 +254,7 @@ func scoreSearchCandidate(query normalizedSearchQuery, candidate SearchCandidate
 
 	var match scoredSearchMatch
 	var ok bool
-	if query.hasPathIntent {
-		match, ok = scorePathAwareCandidate(query, context)
-	} else {
-		match, ok = scoreFilenameFirstCandidate(query.term, context)
-	}
+	match, ok = scoreFilenameCandidate(query.term, context)
 	if !ok {
 		return scoredSearchMatch{}, false
 	}
@@ -309,7 +299,7 @@ func trimSearchStem(value string) string {
 	return stem
 }
 
-func scoreFilenameFirstCandidate(term normalizedSearchTerm, candidate searchCandidateContext) (scoredSearchMatch, bool) {
+func scoreFilenameCandidate(term normalizedSearchTerm, candidate searchCandidateContext) (scoredSearchMatch, bool) {
 	if isDotLiteralSearchTerm(term) {
 		return scoreDotLiteralFilenameCandidate(term.tokens[0], candidate)
 	}
@@ -337,17 +327,6 @@ func scoreFilenameFirstCandidate(term normalizedSearchTerm, candidate searchCand
 			}
 			bestOk = true
 		}
-	}
-	if match, ok := scoreBestPathSegmentFallback(term, candidate); ok && (!bestOk || match.score > best.score) {
-		best, bestOk = match, true
-	}
-	if result, ok := scoreTextMatch(term, candidate.relativePath, 520000, 430000, 15000); ok && (!bestOk || result.score > best.score) {
-		best = scoredSearchMatch{
-			indices: result.indices,
-			score:   result.score,
-			target:  SearchMatchTargetPath,
-		}
-		bestOk = true
 	}
 
 	return best, bestOk
@@ -379,118 +358,6 @@ func scoreDotLiteralFilenameCandidate(literal string, candidate searchCandidateC
 		score:   score,
 		target:  SearchMatchTargetBasename,
 	}, true
-}
-
-func scoreBestPathSegmentFallback(term normalizedSearchTerm, candidate searchCandidateContext) (scoredSearchMatch, bool) {
-	best := scoredSearchMatch{}
-	bestOk := false
-	for index, segment := range candidate.segments {
-		result, ok := scorePathSegmentTerm(term, segment)
-		if !ok {
-			continue
-		}
-		score := 650000 + result.score - (index * 3000)
-		if !bestOk || score > best.score {
-			best = scoredSearchMatch{
-				indices: pathIndicesForSegment(candidate.segments, index, result.indices),
-				score:   score,
-				target:  SearchMatchTargetPath,
-			}
-			bestOk = true
-		}
-	}
-	return best, bestOk
-}
-
-func scorePathAwareCandidate(query normalizedSearchQuery, candidate searchCandidateContext) (scoredSearchMatch, bool) {
-	choice, ok := scorePathTermSequence(query.pathTerms, candidate.segments)
-	if !ok {
-		return scoredSearchMatch{}, false
-	}
-
-	score := 700000 + choice.score - len(candidate.relativePath) - (candidate.depth * 150)
-	if query.trailingSlash {
-		if candidate.kind == EntryKindDirectory {
-			score += 12000
-		} else {
-			score -= 6000
-		}
-	}
-	return scoredSearchMatch{
-		indices: choice.indices,
-		score:   score,
-		target:  SearchMatchTargetPath,
-	}, true
-}
-
-func scorePathTermSequence(terms []normalizedSearchTerm, segments []string) (pathSequenceChoice, bool) {
-	memo := map[[2]int]pathSequenceChoice{}
-	var visit func(termIndex int, segmentIndex int) pathSequenceChoice
-	visit = func(termIndex int, segmentIndex int) pathSequenceChoice {
-		if termIndex == len(terms) {
-			return pathSequenceChoice{ok: true, indices: []int{}}
-		}
-
-		key := [2]int{termIndex, segmentIndex}
-		if cached, ok := memo[key]; ok {
-			return cached
-		}
-
-		best := pathSequenceChoice{}
-		for index := segmentIndex; index < len(segments); index++ {
-			result, ok := scorePathSegmentTerm(terms[termIndex], segments[index])
-			if !ok {
-				continue
-			}
-
-			next := visit(termIndex+1, index+1)
-			if !next.ok {
-				continue
-			}
-
-			skippedSegments := index - segmentIndex
-			total := result.score + next.score - (skippedSegments * 4000)
-			if skippedSegments == 0 {
-				total += 2500
-			}
-			if termIndex == 0 {
-				total -= index * 2000
-			}
-
-			if !best.ok || total > best.score {
-				best = pathSequenceChoice{
-					indices: append(
-						pathIndicesForSegment(segments, index, result.indices),
-						next.indices...,
-					),
-					ok:    true,
-					score: total,
-				}
-			}
-		}
-
-		memo[key] = best
-		return best
-	}
-
-	result := visit(0, 0)
-	return result, result.ok
-}
-
-func scorePathSegmentTerm(term normalizedSearchTerm, segment string) (textMatchResult, bool) {
-	stem := trimSearchStem(segment)
-	best := textMatchResult{}
-	bestOk := false
-
-	if result, ok := scoreTextMatch(term, stem, 180000, 150000, 25000); ok {
-		best, bestOk = result, true
-	}
-	if stem != segment {
-		if result, ok := scoreTextMatch(term, segment, 170000, 140000, 18000); ok && (!bestOk || result.score > best.score) {
-			best, bestOk = result, true
-		}
-	}
-	return best, bestOk
 }
 
 func scoreTextMatch(term normalizedSearchTerm, target string, orderedBase int, subsequenceBase int, prefixBonus int) (textMatchResult, bool) {
@@ -687,19 +554,6 @@ func subsequenceMatch(target string, query string) (int, int, int, []int, bool) 
 		return 0, 0, 0, nil, false
 	}
 	return first, (last - first) + 1, gaps, indices, true
-}
-
-func pathIndicesForSegment(segments []string, segmentIndex int, segmentIndices []int) []int {
-	offset := 0
-	for index := 0; index < segmentIndex; index++ {
-		offset += len(segments[index]) + 1
-	}
-
-	result := make([]int, 0, len(segmentIndices))
-	for _, matchIndex := range segmentIndices {
-		result = append(result, offset+matchIndex)
-	}
-	return result
 }
 
 func compactSortedIndices(indices []int) []int {

--- a/packages/workspace/files/search_test.go
+++ b/packages/workspace/files/search_test.go
@@ -37,6 +37,23 @@ func TestScoreSearchCandidatesSupportsMultiTokenBasenameQuery(t *testing.T) {
 	}
 }
 
+func TestScoreSearchCandidatesDoesNotMatchParentPathOnly(t *testing.T) {
+	entries := ScoreSearchCandidates("/workspace", "New Project", []SearchCandidate{
+		{Kind: EntryKindDirectory, RelativePath: "Documents/New project/OpenCovibe/messages"},
+		{Kind: EntryKindDirectory, RelativePath: "Documents/New project"},
+	}, 10)
+
+	if len(entries) != 1 {
+		t.Fatalf("entries = %#v, want only basename match", entries)
+	}
+	if entries[0].Path != "/workspace/Documents/New project" {
+		t.Fatalf("entry = %#v, want New project directory only", entries[0])
+	}
+	if entries[0].MatchTarget != SearchMatchTargetBasename {
+		t.Fatalf("matchTarget = %q, want %q", entries[0].MatchTarget, SearchMatchTargetBasename)
+	}
+}
+
 func TestScoreSearchCandidatesTreatsDotQueryAsLiteralFilenameFragment(t *testing.T) {
 	entries := ScoreSearchCandidates("/workspace", ".dmg", []SearchCandidate{
 		{Kind: EntryKindFile, RelativePath: ".agents/skills/baoyu-slide-deck/scripts/merge-to-pdf.ts"},
@@ -121,29 +138,15 @@ func TestSearchQueryTargetsHiddenOrNoiseDoesNotTreatPathExtensionAsDirectoryInte
 	}
 }
 
-func TestScoreSearchCandidatesTreatsSlashQueryAsPathIntent(t *testing.T) {
+func TestScoreSearchCandidatesDoesNotMatchSlashQueryAgainstPath(t *testing.T) {
 	entries := ScoreSearchCandidates("/workspace", "tsh/", []SearchCandidate{
 		{Kind: EntryKindFile, RelativePath: ".agents/skills/lark-shared/SKILL.md"},
 		{Kind: EntryKindFile, RelativePath: "tools/tsh/runtime.md"},
 		{Kind: EntryKindFile, RelativePath: "notes/ts-helper/readme.md"},
 	}, 10)
 
-	if len(entries) == 0 {
-		t.Fatal("expected at least one path-aware match")
-	}
-	if entries[0].Path != "/workspace/tools/tsh/runtime.md" {
-		t.Fatalf("top entry = %q, want /workspace/tools/tsh/runtime.md", entries[0].Path)
-	}
-	if entries[0].MatchTarget != SearchMatchTargetPath {
-		t.Fatalf("top entry matchTarget = %q, want %q", entries[0].MatchTarget, SearchMatchTargetPath)
-	}
-	if len(entries[0].MatchIndices) == 0 {
-		t.Fatal("expected path match indices")
-	}
-	for _, entry := range entries {
-		if entry.Path == "/workspace/.agents/skills/lark-shared/SKILL.md" {
-			t.Fatalf("unexpected loose subsequence path match %q", entry.Path)
-		}
+	if len(entries) != 0 {
+		t.Fatalf("entries = %#v, want no path-only matches", entries)
 	}
 }
 
@@ -161,34 +164,25 @@ func TestScoreSearchCandidatesPenalizesHiddenAndNoisePaths(t *testing.T) {
 	}
 }
 
-func TestScoreSearchCandidatesAllowsExplicitHiddenTargetQuery(t *testing.T) {
+func TestScoreSearchCandidatesDoesNotMatchHiddenParentPath(t *testing.T) {
 	entries := ScoreSearchCandidates("/workspace", ".agents skill", []SearchCandidate{
 		{Kind: EntryKindFile, RelativePath: ".agents/skills/skill.md"},
 		{Kind: EntryKindFile, RelativePath: "docs/skill.md"},
 	}, 10)
 
-	if len(entries) == 0 {
-		t.Fatal("expected an explicit hidden-target match")
-	}
-	if entries[0].Path != "/workspace/.agents/skills/skill.md" {
-		t.Fatalf("top entry = %q, want /workspace/.agents/skills/skill.md", entries[0].Path)
-	}
-	if entries[0].MatchTarget != SearchMatchTargetPath {
-		t.Fatalf("top entry matchTarget = %q, want %q", entries[0].MatchTarget, SearchMatchTargetPath)
+	if len(entries) != 0 {
+		t.Fatalf("entries = %#v, want no parent-path matches", entries)
 	}
 }
 
-func TestScoreSearchCandidatesAllowsExplicitHiddenPathIntentQuery(t *testing.T) {
+func TestScoreSearchCandidatesDoesNotMatchHiddenPathIntentQuery(t *testing.T) {
 	entries := ScoreSearchCandidates("/workspace", ".git/conf", []SearchCandidate{
 		{Kind: EntryKindFile, RelativePath: ".git/config"},
 		{Kind: EntryKindFile, RelativePath: "configs/git.conf"},
 	}, 10)
 
-	if len(entries) == 0 {
-		t.Fatal("expected an explicit hidden path match")
-	}
-	if entries[0].Path != "/workspace/.git/config" {
-		t.Fatalf("top entry = %q, want /workspace/.git/config", entries[0].Path)
+	if len(entries) != 0 {
+		t.Fatalf("entries = %#v, want no path-intent matches", entries)
 	}
 }
 
@@ -221,18 +215,15 @@ func TestScoreSearchCandidatesPrefersDirectoryForTrailingSlashQuery(t *testing.T
 	}
 }
 
-func TestScoreSearchCandidatesRespectsPathSegmentOrder(t *testing.T) {
+func TestScoreSearchCandidatesDoesNotMatchPathSegmentOrder(t *testing.T) {
 	entries := ScoreSearchCandidates("/workspace", "docs/work", []SearchCandidate{
 		{Kind: EntryKindFile, RelativePath: "docs/workspace.md"},
 		{Kind: EntryKindFile, RelativePath: "workspace/docs.md"},
 		{Kind: EntryKindFile, RelativePath: "notes/workspace-docs.md"},
 	}, 10)
 
-	if len(entries) == 0 {
-		t.Fatal("expected a path-aware segment-order match")
-	}
-	if entries[0].Path != "/workspace/docs/workspace.md" {
-		t.Fatalf("top entry = %q, want /workspace/docs/workspace.md", entries[0].Path)
+	if len(entries) != 0 {
+		t.Fatalf("entries = %#v, want no path-segment matches", entries)
 	}
 }
 

--- a/services/tuttid/data/workspace/local_files_search.go
+++ b/services/tuttid/data/workspace/local_files_search.go
@@ -82,67 +82,16 @@ func (a LocalFilesAdapter) Search(
 		includeKinds[kind] = true
 	}
 
-	candidates := make([]workspacefiles.SearchCandidate, 0, input.Limit)
 	maxCandidates := a.maxSearchCandidates()
 	ignoredDirectories := a.ignoredDirectories()
 	allowHiddenFiles := input.IncludeHidden || workspacefiles.SearchQueryTargetsHiddenFile(input.Query)
 	allowHiddenAndNoiseDirectories := input.IncludeHidden || workspacefiles.SearchQueryTargetsHiddenOrNoise(input.Query)
-	stats := searchWalkStats{}
-	walkErr := filepath.WalkDir(searchRootPath, func(physicalPath string, entry fs.DirEntry, err error) error {
-		if err != nil {
-			stats.skippedUnreadableCount++
-			return nil
-		}
-		stats.scannedEntryCount++
-		if err := ctx.Err(); err != nil {
-			return err
-		}
-		if !input.Deadline.IsZero() && time.Now().After(input.Deadline) {
-			stats.deadlineExceeded = true
-			return context.DeadlineExceeded
-		}
-		if physicalPath == searchRootPath {
-			return nil
-		}
-		if entry.Type()&os.ModeSymlink != 0 {
-			stats.skippedSymlinkEntryCount++
-			return nil
-		}
-
-		kind := entryKind(entry.Type())
-		if kind != workspacefiles.EntryKindFile && kind != workspacefiles.EntryKindDirectory {
-			stats.skippedUnsupportedCount++
-			return nil
-		}
-		if entry.IsDir() {
-			if !allowHiddenAndNoiseDirectories && shouldIgnoreSearchEntryName(entry.Name(), ignoredDirectories) {
-				stats.ignoredDirectoryCount++
-				return filepath.SkipDir
-			}
-		}
-		if !allowHiddenFiles && shouldIgnoreHiddenSearchFile(entry) {
-			stats.skippedHiddenFileCount++
-			return nil
-		}
-		// 文件类型筛选:筛选生效时,搜索结果须是「关键词 ∩ 类型」的交集。目录不属于任何文件
-		// 类型,故不作为结果候选(但仍递归进入以发现匹配类型的文件,所以只跳过登记、不 SkipDir);
-		// 文件按其分类过滤。无筛选时不影响目录,保留按名/路径命中的文件夹。
-		// 全局统一口径,见 reference_filter_categories.go(TS 镜像同名)。
-		if len(input.Filters) > 0 {
-			if kind == workspacefiles.EntryKindDirectory {
-				return nil
-			}
-			if !matchesReferenceFilterCategories(entry.Name(), false, input.Filters) {
-				stats.skippedUnrequestedCount++
-				return nil
-			}
-		}
-		appendSearchCandidate(rootPath, physicalPath, kind, includeKinds, &candidates, &stats)
-		if len(candidates) >= maxCandidates {
-			stats.candidateCapReached = true
-			return fs.SkipAll
-		}
-		return nil
+	candidates, stats, walkErr := walkSearchCandidates(ctx, rootPath, searchRootPath, input, searchWalkOptions{
+		allowHiddenAndNoiseDirectories: allowHiddenAndNoiseDirectories,
+		allowHiddenFiles:               allowHiddenFiles,
+		ignoredDirectories:             ignoredDirectories,
+		includeKinds:                   includeKinds,
+		maxCandidates:                  maxCandidates,
 	})
 	if walkErr != nil &&
 		!errors.Is(walkErr, fs.SkipAll) &&
@@ -185,6 +134,88 @@ func (a LocalFilesAdapter) Search(
 		Root:        workspacefiles.NormalizeLogicalRoot(root.LogicalRoot),
 		Entries:     entries,
 	}, nil
+}
+
+type searchWalkOptions struct {
+	allowHiddenAndNoiseDirectories bool
+	allowHiddenFiles               bool
+	ignoredDirectories             map[string]struct{}
+	includeKinds                   map[workspacefiles.EntryKind]bool
+	maxCandidates                  int
+}
+
+func walkSearchCandidates(
+	ctx context.Context,
+	rootPath string,
+	searchRootPath string,
+	input workspacefiles.SearchInput,
+	options searchWalkOptions,
+) ([]workspacefiles.SearchCandidate, searchWalkStats, error) {
+	candidates := make([]workspacefiles.SearchCandidate, 0, input.Limit)
+	stats := searchWalkStats{scannedEntryCount: 1}
+	queue := []string{searchRootPath}
+
+	for len(queue) > 0 {
+		directoryPath := queue[0]
+		queue = queue[1:]
+
+		dirEntries, err := os.ReadDir(directoryPath)
+		if err != nil {
+			stats.skippedUnreadableCount++
+			continue
+		}
+
+		for _, entry := range dirEntries {
+			physicalPath := filepath.Join(directoryPath, entry.Name())
+			stats.scannedEntryCount++
+			if err := ctx.Err(); err != nil {
+				return candidates, stats, err
+			}
+			if !input.Deadline.IsZero() && time.Now().After(input.Deadline) {
+				stats.deadlineExceeded = true
+				return candidates, stats, context.DeadlineExceeded
+			}
+			if entry.Type()&os.ModeSymlink != 0 {
+				stats.skippedSymlinkEntryCount++
+				continue
+			}
+
+			kind := entryKind(entry.Type())
+			if kind != workspacefiles.EntryKindFile && kind != workspacefiles.EntryKindDirectory {
+				stats.skippedUnsupportedCount++
+				continue
+			}
+			if entry.IsDir() {
+				if !options.allowHiddenAndNoiseDirectories && shouldIgnoreSearchEntryName(entry.Name(), options.ignoredDirectories) {
+					stats.ignoredDirectoryCount++
+					continue
+				}
+				queue = append(queue, physicalPath)
+			}
+			if !options.allowHiddenFiles && shouldIgnoreHiddenSearchFile(entry) {
+				stats.skippedHiddenFileCount++
+				continue
+			}
+			// 文件类型筛选:筛选生效时,搜索结果须是「关键词 ∩ 类型」的交集。目录不属于任何文件
+			// 类型,故不作为结果候选(但仍递归进入以发现匹配类型的文件);文件按其分类过滤。
+			if len(input.Filters) > 0 {
+				if kind == workspacefiles.EntryKindDirectory {
+					continue
+				}
+				if !matchesReferenceFilterCategories(entry.Name(), false, input.Filters) {
+					stats.skippedUnrequestedCount++
+					continue
+				}
+			}
+			appendSearchCandidate(rootPath, physicalPath, kind, options.includeKinds, &candidates, &stats)
+			if len(candidates) >= options.maxCandidates {
+				stats.candidateCapReached = true
+				return candidates, stats, fs.SkipAll
+			}
+		}
+	}
+
+	return candidates, stats, nil
 }
 
 func appendSearchCandidate(

--- a/services/tuttid/data/workspace/local_files_test.go
+++ b/services/tuttid/data/workspace/local_files_test.go
@@ -752,11 +752,49 @@ func TestLocalFilesAdapterSearchSkipsHiddenNoiseDirectoriesForNormalQueries(t *t
 	}
 }
 
+func TestLocalFilesAdapterSearchKeepsShallowMatchesBeforeDeepCandidateCap(t *testing.T) {
+	t.Parallel()
+
+	rootDir := t.TempDir()
+	deepDir := filepath.Join(rootDir, "a-deep-project")
+	if err := os.MkdirAll(deepDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	for _, name := range []string{"filler-a.txt", "filler-b.txt", "filler-c.txt"} {
+		if err := os.WriteFile(
+			filepath.Join(deepDir, name),
+			[]byte("filler"),
+			0o644,
+		); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := os.WriteFile(filepath.Join(rootDir, "郑伟斌.csv"), []byte("a,b\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	adapter := LocalFilesAdapter{MaxSearchCandidates: 2}
+	result, err := adapter.Search(context.Background(), localFilesRoot(rootDir), workspacefiles.SearchInput{
+		Query:        "郑伟斌",
+		Limit:        5,
+		IncludeKinds: []workspacefiles.EntryKind{workspacefiles.EntryKindFile},
+	})
+	if err != nil {
+		t.Fatalf("Search() error = %v", err)
+	}
+	if len(result.Entries) != 1 {
+		t.Fatalf("entries = %#v, want shallow csv result", result.Entries)
+	}
+	if result.Entries[0].Path != "/workspace/郑伟斌.csv" {
+		t.Fatalf("first result = %#v, want /workspace/郑伟斌.csv", result.Entries[0])
+	}
+}
+
 func TestLocalFilesAdapterSearchTypeFilterExcludesDirectoriesButKeepsMatchingFiles(t *testing.T) {
 	t.Parallel()
 
 	rootDir := t.TempDir()
-	// 一个文件名/路径含 "22" 的目录:无筛选时按名命中,但开启「document」筛选后不应作为结果。
+	// 一个目录名含 "22" 的文档文件:开启「document」筛选后仍只按文件名匹配关键词。
 	docInFolder := filepath.Join(rootDir, "reports22", "q3.csv")
 	if err := os.MkdirAll(filepath.Dir(docInFolder), 0o755); err != nil {
 		t.Fatal(err)
@@ -792,8 +830,8 @@ func TestLocalFilesAdapterSearchTypeFilterExcludesDirectoriesButKeepsMatchingFil
 			t.Fatalf("entry = %#v, directories must be excluded when a type filter is active", entry)
 		}
 	}
-	// 交集:关键词 "22" ∩ 类型 document,且包含被筛掉目录下的文档文件。
-	wantPaths := []string{"/workspace/data22.csv", "/workspace/reports22/q3.csv"}
+	// 交集:文件名关键词 "22" ∩ 类型 document。
+	wantPaths := []string{"/workspace/data22.csv"}
 	for _, want := range wantPaths {
 		if !gotPaths[want] {
 			t.Fatalf("entries = %#v, want to include %s", result.Entries, want)
@@ -901,7 +939,7 @@ func TestLocalFilesAdapterSearchReturnsPartialResultsWhenDeadlineExpires(t *test
 	}
 }
 
-func TestLocalFilesAdapterSearchIncludesHiddenNoiseDirectoriesWhenQueryExplicitlyTargetsThem(t *testing.T) {
+func TestLocalFilesAdapterSearchDoesNotMatchExplicitHiddenPathWhenFilenameDiffers(t *testing.T) {
 	t.Parallel()
 
 	rootDir := t.TempDir()
@@ -930,11 +968,8 @@ func TestLocalFilesAdapterSearchIncludesHiddenNoiseDirectoriesWhenQueryExplicitl
 	if err != nil {
 		t.Fatalf("Search() error = %v", err)
 	}
-	if len(result.Entries) != 1 {
-		t.Fatalf("entries = %#v, want 1 result", result.Entries)
-	}
-	if result.Entries[0].Path != "/workspace/.git/config" {
-		t.Fatalf("first result = %#v, want /workspace/.git/config", result.Entries[0])
+	if len(result.Entries) != 0 {
+		t.Fatalf("entries = %#v, want no path-only matches", result.Entries)
 	}
 }
 
@@ -1104,7 +1139,7 @@ func TestLocalFilesAdapterSearchDoesNotDescendHiddenDirsForPathExtensionQuery(t 
 
 	adapter := LocalFilesAdapter{MaxSearchCandidates: 1}
 	result, err := adapter.Search(context.Background(), localFilesRoot(rootDir), workspacefiles.SearchInput{
-		Query:        "Downloads/.dmg",
+		Query:        ".dmg",
 		Limit:        5,
 		IncludeKinds: []workspacefiles.EntryKind{workspacefiles.EntryKindFile},
 	})


### PR DESCRIPTION
## Summary

- Fix local file reference search so shallow matches are not starved by deep directory traversal candidate caps.
- Limit local filename search matching to file/folder names instead of parent path text.
- Include app project/folder group matches in app reference search results while preserving file search behavior.

## Root Cause

- Local file search collected candidates depth-first, so deep directories could exhaust the cap before shallow desktop files were scored.
- Search scoring used path text, which allowed parent directories to make unrelated child folders appear as filename matches.
- App reference search only called each app search endpoint, whose contract returns flat file references; project folders available through list/filter were not searched.

## Validation

- pnpm check:changed
- git push pre-push hook: check:full passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Search results now better distinguish between app groups and file references, improving the ordering and labels shown in results.
  * File search scoring now behaves more consistently, avoiding unexpected matches from path-like queries and hidden locations.
  * Local file search now prefers closer matches when result limits are reached, and improves filtering for hidden paths and directory types.

* **Tests**
  * Updated and expanded search coverage for app, workspace, and local file search behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->