### PR TITLE
fix(agent): filter generated file mentions by successful writes

### DIFF
--- a/docs/architecture/agent-gui-node.md
+++ b/docs/architecture/agent-gui-node.md
@@ -760,6 +760,22 @@ corepack pnpm --filter @tutti-os/agent-gui exec vitest run agent-gui/agentGuiNod
 corepack pnpm --filter @tutti-os/agent-gui exec vitest run shared/AgentRichTextReadonly.spec.tsx shared/AgentMessageMarkdown.spec.tsx
 ```
 
+### Agent Generated File Mentions
+
+```text
+Agent activity messages
+  -> generated-file collector in tuttid or AgentGUI fallback
+  -> desktop mention provider
+  -> mention palette grouping/count presentation
+  -> composer file mention insertion
+```
+
+Generated-file counts must be computed from collector output, not from palette
+rendering state. The collector owns the semantic filter: only successful
+file-change tool messages should contribute paths, and failed, canceled,
+running, or read-only tool calls must be ignored even when their payloads carry
+`path`, `filePath`, `fileChanges`, or `changes` fields.
+
 ### Approval Or Ask-User Prompt
 
 ```text

--- a/packages/agent/gui/shared/workspaceAgentActivityListViewModel.spec.ts
+++ b/packages/agent/gui/shared/workspaceAgentActivityListViewModel.spec.ts
@@ -1869,6 +1869,90 @@ describe("buildWorkspaceAgentActivityListViewModel", () => {
     ).toEqual([]);
   });
 
+  it("does not collect failed file change tool payloads as agent-generated files", () => {
+    const snapshot: AgentActivitySnapshot = {
+      workspaceId: "workspace-1",
+      presences: [],
+      sessions: [
+        {
+          agentSessionId: "session-25",
+          cwd: "/Users/demo/project",
+          provider: "codex",
+          status: "completed",
+          title: "Failed writes",
+          workspaceId: "workspace-1"
+        }
+      ],
+      sessionMessagesById: {
+        "session-25": [
+          {
+            agentSessionId: "session-25",
+            kind: "tool_call",
+            messageId: "message-failed-status",
+            payload: {
+              toolName: "Write",
+              fileChanges: {
+                files: [{ path: "failed-status.md" }]
+              }
+            },
+            role: "assistant",
+            status: "failed",
+            turnId: "turn-message-1",
+            occurredAtUnixMs: 1,
+            version: 1
+          },
+          {
+            agentSessionId: "session-25",
+            kind: "tool_call",
+            messageId: "message-failed-output",
+            payload: {
+              toolName: "Write",
+              output: {
+                filePath: "failed-output.md",
+                status: "failed",
+                success: false
+              }
+            },
+            role: "assistant",
+            status: "completed",
+            turnId: "turn-message-1",
+            occurredAtUnixMs: 2,
+            version: 2
+          },
+          {
+            agentSessionId: "session-25",
+            kind: "tool_call",
+            messageId: "message-success",
+            payload: {
+              toolName: "Write",
+              output: {
+                filePath: "ok.md",
+                status: "completed",
+                success: true
+              }
+            },
+            role: "assistant",
+            status: "completed",
+            turnId: "turn-message-1",
+            occurredAtUnixMs: 3,
+            version: 3
+          }
+        ]
+      }
+    };
+
+    expect(
+      collectWorkspaceAgentGeneratedFiles(snapshot, {
+        workspaceRoot: "/Users/demo/project"
+      })
+    ).toEqual([
+      {
+        path: "/Users/demo/project/ok.md",
+        label: "ok.md"
+      }
+    ]);
+  });
+
   it("resolves relative agent-generated file paths against the session cwd", () => {
     const snapshot: AgentActivitySnapshot = {
       workspaceId: "workspace-1",

--- a/packages/agent/gui/shared/workspaceAgentActivityListViewModel.spec.ts
+++ b/packages/agent/gui/shared/workspaceAgentActivityListViewModel.spec.ts
@@ -1837,9 +1837,17 @@ describe("buildWorkspaceAgentActivityListViewModel", () => {
             messageId: "message-1",
             payload: {
               callType: "tool",
+              fileChanges: {
+                files: [
+                  { path: "/Users/demo/project/apps/read-filechanges.md" }
+                ]
+              },
               input: {
                 command: "nl -ba 11.md",
                 cwd: "/Users/demo/project/apps",
+                changes: {
+                  "/Users/demo/project/apps/read-input-changes.md": "read"
+                },
                 file_path: "/Users/demo/project/apps/11.md"
               },
               locations: [{ path: "/Users/demo/project/apps/11.md" }],

--- a/packages/agent/gui/shared/workspaceAgentActivityListViewModel.ts
+++ b/packages/agent/gui/shared/workspaceAgentActivityListViewModel.ts
@@ -96,7 +96,9 @@ export function collectWorkspaceAgentGeneratedFiles(
     if (messages.length === 0) {
       continue;
     }
-    for (const file of changedFilesForSession(messages, normalizePath)) {
+    for (const file of changedFilesForSession(messages, normalizePath, {
+      requireSuccessfulFileChangeTool: true
+    })) {
       filesByPath.set(file.path, file);
     }
     for (const path of imageGenerationPathsFromMessages(
@@ -458,9 +460,14 @@ function resolveLatestActivity(
 
 type ChangedFilePathNormalizer = (value: unknown) => string | null;
 
+interface ChangedFileCollectionOptions {
+  requireSuccessfulFileChangeTool?: boolean;
+}
+
 function changedFilesForSession(
   messages: readonly WorkspaceAgentActivityMessage[],
-  normalizePath: ChangedFilePathNormalizer = defaultChangedFilePathNormalizer
+  normalizePath: ChangedFilePathNormalizer = defaultChangedFilePathNormalizer,
+  options: ChangedFileCollectionOptions = {}
 ): WorkspaceAgentChangedFile[] {
   const changedFilesByPath = new Map<string, WorkspaceAgentChangedFile>();
   const appendPath = (path: string | null): void => {
@@ -474,7 +481,11 @@ function changedFilesForSession(
   };
 
   for (const message of messages) {
-    for (const path of changedFilePathsFromMessage(message, normalizePath)) {
+    for (const path of changedFilePathsFromMessage(
+      message,
+      normalizePath,
+      options
+    )) {
       appendPath(path);
     }
   }
@@ -484,9 +495,11 @@ function changedFilesForSession(
 
 function changedFilePathsFromMessage(
   message: WorkspaceAgentActivityMessage,
-  normalizePath: ChangedFilePathNormalizer = defaultChangedFilePathNormalizer
+  normalizePath: ChangedFilePathNormalizer = defaultChangedFilePathNormalizer,
+  options: ChangedFileCollectionOptions = {}
 ): string[] {
-  if (!isSuccessfulFileChangeToolMessage(message)) {
+  const isSuccessfulFileChangeTool = isSuccessfulFileChangeToolMessage(message);
+  if (options.requireSuccessfulFileChangeTool && !isSuccessfulFileChangeTool) {
     return [];
   }
   const payload = objectValue(message.payload);
@@ -496,6 +509,9 @@ function changedFilePathsFromMessage(
   );
   if (explicitFileChanges.length > 0) {
     return explicitFileChanges;
+  }
+  if (!isSuccessfulFileChangeTool) {
+    return [];
   }
 
   const toolState = objectValue(payload?.tool_state);
@@ -842,20 +858,12 @@ function hasFileChangeSignal(payload: Record<string, unknown> | null): boolean {
     objectValue(payload.input),
     objectValue(payload.output),
     objectValue(toolState?.input)
-  ].some((record) => record !== null && recordHasFileChangeSignal(record));
+  ].some((record) => record !== null && recordHasFileChangeToolSignal(record));
 }
 
-function recordHasFileChangeSignal(record: Record<string, unknown>): boolean {
-  if ((arrayValue(objectValue(record.fileChanges)?.files)?.length ?? 0) > 0) {
-    return true;
-  }
-  const changesObject = objectValue(record.changes);
-  if (changesObject && Object.keys(changesObject).length > 0) {
-    return true;
-  }
-  if ((arrayValue(record.changes)?.length ?? 0) > 0) {
-    return true;
-  }
+function recordHasFileChangeToolSignal(
+  record: Record<string, unknown>
+): boolean {
   const activityKind = stringValue(record.activityKind);
   if (
     activityKind &&

--- a/packages/agent/gui/shared/workspaceAgentActivityListViewModel.ts
+++ b/packages/agent/gui/shared/workspaceAgentActivityListViewModel.ts
@@ -486,6 +486,9 @@ function changedFilePathsFromMessage(
   message: WorkspaceAgentActivityMessage,
   normalizePath: ChangedFilePathNormalizer = defaultChangedFilePathNormalizer
 ): string[] {
+  if (!isSuccessfulFileChangeToolMessage(message)) {
+    return [];
+  }
   const payload = objectValue(message.payload);
   const explicitFileChanges = fileChangePaths(
     arrayValue(objectValue(payload?.fileChanges)?.files),
@@ -493,9 +496,6 @@ function changedFilePathsFromMessage(
   );
   if (explicitFileChanges.length > 0) {
     return explicitFileChanges;
-  }
-  if (!isSuccessfulFileChangeToolMessage(message)) {
-    return [];
   }
 
   const toolState = objectValue(payload?.tool_state);
@@ -781,29 +781,92 @@ function isSuccessfulFileChangeToolMessage(
   if (normalizeToken(message.kind) !== "tool_call") {
     return false;
   }
-  const normalizedStatus = normalizeToken(message.status ?? undefined);
-  if (
-    normalizedStatus &&
-    normalizedStatus !== "completed" &&
-    normalizedStatus !== "success"
-  ) {
+  if (!isSuccessfulFileChangeStatus(message.status ?? undefined)) {
     return false;
   }
   const payload = objectValue(message.payload);
-  const activityKind = stringValue(payload?.activityKind);
+  if (!isSuccessfulFileChangePayloadStatus(payload)) {
+    return false;
+  }
+  return hasFileChangeSignal(payload);
+}
+
+function isSuccessfulFileChangePayloadStatus(
+  payload: Record<string, unknown> | null
+): boolean {
+  if (!payload) {
+    return true;
+  }
+  if (!isSuccessfulFileChangeRecordStatus(payload)) {
+    return false;
+  }
+  const output = objectValue(payload.output);
+  if (output && !isSuccessfulFileChangeRecordStatus(output)) {
+    return false;
+  }
+  return true;
+}
+
+function isSuccessfulFileChangeRecordStatus(
+  record: Record<string, unknown>
+): boolean {
+  const status = stringValue(record.status);
+  if (status && !isSuccessfulFileChangeStatus(status)) {
+    return false;
+  }
+  const success = booleanValue(record.success);
+  if (success === false) {
+    return false;
+  }
+  return true;
+}
+
+function isSuccessfulFileChangeStatus(value: string | undefined): boolean {
+  const normalizedStatus = normalizeToken(value);
+  return (
+    !normalizedStatus ||
+    normalizedStatus === "completed" ||
+    normalizedStatus === "success" ||
+    normalizedStatus === "succeeded" ||
+    normalizedStatus === "ok"
+  );
+}
+
+function hasFileChangeSignal(payload: Record<string, unknown> | null): boolean {
+  if (!payload) {
+    return false;
+  }
+  const toolState = objectValue(payload.tool_state);
+  return [
+    payload,
+    objectValue(payload.input),
+    objectValue(payload.output),
+    objectValue(toolState?.input)
+  ].some((record) => record !== null && recordHasFileChangeSignal(record));
+}
+
+function recordHasFileChangeSignal(record: Record<string, unknown>): boolean {
+  if ((arrayValue(objectValue(record.fileChanges)?.files)?.length ?? 0) > 0) {
+    return true;
+  }
+  const changesObject = objectValue(record.changes);
+  if (changesObject && Object.keys(changesObject).length > 0) {
+    return true;
+  }
+  if ((arrayValue(record.changes)?.length ?? 0) > 0) {
+    return true;
+  }
+  const activityKind = stringValue(record.activityKind);
   if (
-    activityKind === "write_file" ||
-    activityKind === "edit_file" ||
-    activityKind === "delete_file"
+    activityKind &&
+    isFileChangeNormalizedToolName(normalizeToolName(activityKind))
   ) {
     return true;
   }
-  if (stringValue(payload?.fileChangeKind)) {
+  if (stringValue(record.fileChangeKind)) {
     return true;
   }
-  const input = objectValue(payload?.input);
-  const toolCall =
-    objectValue(input?.toolCall) ?? objectValue(payload?.toolCall);
+  const toolCall = objectValue(record.toolCall);
   const toolCallKind = normalizeToken(stringValue(toolCall?.kind) ?? undefined);
   if (
     toolCallKind === "write" ||
@@ -813,9 +876,9 @@ function isSuccessfulFileChangeToolMessage(
     return true;
   }
   const toolName = normalizeToolName(
-    stringValue(payload?.toolName) ??
-      stringValue(payload?.title) ??
-      stringValue(payload?.name) ??
+    stringValue(record.toolName) ??
+      stringValue(record.title) ??
+      stringValue(record.name) ??
       ""
   );
   return isFileChangeNormalizedToolName(toolName);
@@ -916,6 +979,10 @@ function arrayValue(value: unknown): readonly unknown[] | null {
 
 function stringValue(value: unknown): string | null {
   return typeof value === "string" && value.trim() ? value.trim() : null;
+}
+
+function booleanValue(value: unknown): boolean | null {
+  return typeof value === "boolean" ? value : null;
 }
 
 function dedupeStrings(values: Array<string | null>): string[] {

--- a/services/tuttid/data/workspace/sqlite_agent_generated_files.go
+++ b/services/tuttid/data/workspace/sqlite_agent_generated_files.go
@@ -39,7 +39,7 @@ func (s *SQLiteStore) ListWorkspaceGeneratedFiles(
 	scanLimit := generatedFileMessageScanLimit(limit)
 
 	rows, err := s.db.QueryContext(ctx, `
-SELECT s.cwd, m.payload_json
+SELECT s.cwd, m.kind, m.status, m.payload_json
 FROM workspace_agent_messages m
 JOIN workspace_agent_sessions s
   ON s.workspace_id = m.workspace_id
@@ -60,13 +60,18 @@ LIMIT ?
 	files := make([]agentactivitybiz.GeneratedFile, 0, limit)
 	for rows.Next() {
 		var cwd string
+		var kind string
+		var status string
 		var payloadJSON string
-		if err := rows.Scan(&cwd, &payloadJSON); err != nil {
+		if err := rows.Scan(&cwd, &kind, &status, &payloadJSON); err != nil {
 			return agentactivitybiz.GeneratedFileList{}, false, fmt.Errorf("scan workspace agent generated file message: %w", err)
 		}
 		var payload map[string]any
 		if err := json.Unmarshal([]byte(payloadJSON), &payload); err != nil {
 			return agentactivitybiz.GeneratedFileList{}, false, fmt.Errorf("decode workspace agent generated file payload: %w", err)
+		}
+		if !isSuccessfulGeneratedFileMessage(kind, status, payload) {
+			continue
 		}
 		for _, filePath := range generatedFilePathsFromPayload(payload, cwd) {
 			if _, exists := filesByPath[filePath]; exists {
@@ -111,6 +116,152 @@ func generatedFileMessageScanLimit(limit int) int {
 		return 5000
 	}
 	return scanLimit
+}
+
+func isSuccessfulGeneratedFileMessage(kind string, status string, payload map[string]any) bool {
+	if normalizeGeneratedFileToken(kind) != "tool_call" {
+		return false
+	}
+	if !generatedFileStatusAllows(status) {
+		return false
+	}
+	if !generatedFilePayloadStatusAllows(payload) {
+		return false
+	}
+	return hasGeneratedFileChangeSignal(payload)
+}
+
+func generatedFilePayloadStatusAllows(payload map[string]any) bool {
+	if payload == nil {
+		return true
+	}
+	if !generatedFileRecordStatusAllows(payload) {
+		return false
+	}
+	if output, ok := objectField(payload, "output"); ok {
+		if !generatedFileRecordStatusAllows(output) {
+			return false
+		}
+	}
+	return true
+}
+
+func generatedFileRecordStatusAllows(record map[string]any) bool {
+	if record == nil {
+		return true
+	}
+	if status, ok := stringField(record, "status"); ok && !generatedFileStatusAllows(status) {
+		return false
+	}
+	if success, ok := boolField(record, "success"); ok && !success {
+		return false
+	}
+	return true
+}
+
+func generatedFileStatusAllows(status string) bool {
+	normalized := normalizeGeneratedFileToken(status)
+	if normalized == "" {
+		return true
+	}
+	switch normalized {
+	case "completed", "success", "succeeded", "ok":
+		return true
+	default:
+		return false
+	}
+}
+
+func hasGeneratedFileChangeSignal(payload map[string]any) bool {
+	for _, record := range generatedFileSignalRecords(payload) {
+		if recordHasGeneratedFileChangeSignal(record) {
+			return true
+		}
+	}
+	return false
+}
+
+func generatedFileSignalRecords(payload map[string]any) []map[string]any {
+	if payload == nil {
+		return nil
+	}
+	records := []map[string]any{payload}
+	if input, ok := objectField(payload, "input"); ok {
+		records = append(records, input)
+	}
+	if output, ok := objectField(payload, "output"); ok {
+		records = append(records, output)
+	}
+	if toolState, ok := objectField(payload, "tool_state"); ok {
+		if input, ok := objectField(toolState, "input"); ok {
+			records = append(records, input)
+		}
+	}
+	return records
+}
+
+func recordHasGeneratedFileChangeSignal(record map[string]any) bool {
+	if record == nil {
+		return false
+	}
+	if fileChanges, ok := objectField(record, "fileChanges"); ok {
+		if files, ok := fileChanges["files"].([]any); ok && len(files) > 0 {
+			return true
+		}
+	}
+	if changes, ok := objectField(record, "changes"); ok && len(changes) > 0 {
+		return true
+	}
+	if changes, ok := record["changes"].([]any); ok && len(changes) > 0 {
+		return true
+	}
+	if activityKind, ok := stringField(record, "activityKind"); ok &&
+		isGeneratedFileChangeToolName(normalizeGeneratedFileToolName(activityKind)) {
+		return true
+	}
+	if _, ok := stringField(record, "fileChangeKind"); ok {
+		return true
+	}
+	if toolCall, ok := objectField(record, "toolCall"); ok {
+		if kind, ok := stringField(toolCall, "kind"); ok {
+			switch normalizeGeneratedFileToken(kind) {
+			case "write", "edit", "delete":
+				return true
+			}
+		}
+	}
+	for _, key := range []string{"toolName", "title", "name"} {
+		if name, ok := stringField(record, key); ok &&
+			isGeneratedFileChangeToolName(normalizeGeneratedFileToolName(name)) {
+			return true
+		}
+	}
+	return false
+}
+
+func isGeneratedFileChangeToolName(normalized string) bool {
+	if normalized == "" {
+		return false
+	}
+	for _, candidate := range []string{
+		"write",
+		"writefile",
+		"create",
+		"createfile",
+		"delete",
+		"deletefile",
+		"edit",
+		"editfile",
+		"multiedit",
+		"applypatch",
+		"move",
+		"notebookedit",
+	} {
+		if normalized == candidate || strings.HasPrefix(normalized, candidate+"/") {
+			return true
+		}
+	}
+	return false
 }
 
 func generatedFilePathsFromPayload(payload map[string]any, cwd string) []string {
@@ -182,6 +333,40 @@ func objectField(payload map[string]any, key string) (map[string]any, bool) {
 	}
 	object, ok := value.(map[string]any)
 	return object, ok
+}
+
+func stringField(payload map[string]any, key string) (string, bool) {
+	value, ok := payload[key]
+	if !ok {
+		return "", false
+	}
+	text, ok := value.(string)
+	if !ok {
+		return "", false
+	}
+	text = strings.TrimSpace(text)
+	return text, text != ""
+}
+
+func boolField(payload map[string]any, key string) (bool, bool) {
+	value, ok := payload[key]
+	if !ok {
+		return false, false
+	}
+	boolValue, ok := value.(bool)
+	return boolValue, ok
+}
+
+func normalizeGeneratedFileToken(value string) string {
+	return strings.ToLower(strings.TrimSpace(value))
+}
+
+func normalizeGeneratedFileToolName(value string) string {
+	normalized := strings.ToLower(strings.TrimSpace(value))
+	normalized = strings.ReplaceAll(normalized, "_", "")
+	normalized = strings.ReplaceAll(normalized, "-", "")
+	normalized = strings.ReplaceAll(normalized, " ", "")
+	return normalized
 }
 
 func normalizeGeneratedFilePath(value any, cwd string) string {

--- a/services/tuttid/data/workspace/sqlite_agent_generated_files.go
+++ b/services/tuttid/data/workspace/sqlite_agent_generated_files.go
@@ -174,7 +174,7 @@ func generatedFileStatusAllows(status string) bool {
 
 func hasGeneratedFileChangeSignal(payload map[string]any) bool {
 	for _, record := range generatedFileSignalRecords(payload) {
-		if recordHasGeneratedFileChangeSignal(record) {
+		if recordHasGeneratedFileToolSignal(record) {
 			return true
 		}
 	}
@@ -200,20 +200,9 @@ func generatedFileSignalRecords(payload map[string]any) []map[string]any {
 	return records
 }
 
-func recordHasGeneratedFileChangeSignal(record map[string]any) bool {
+func recordHasGeneratedFileToolSignal(record map[string]any) bool {
 	if record == nil {
 		return false
-	}
-	if fileChanges, ok := objectField(record, "fileChanges"); ok {
-		if files, ok := fileChanges["files"].([]any); ok && len(files) > 0 {
-			return true
-		}
-	}
-	if changes, ok := objectField(record, "changes"); ok && len(changes) > 0 {
-		return true
-	}
-	if changes, ok := record["changes"].([]any); ok && len(changes) > 0 {
-		return true
 	}
 	if activityKind, ok := stringField(record, "activityKind"); ok &&
 		isGeneratedFileChangeToolName(normalizeGeneratedFileToolName(activityKind)) {

--- a/services/tuttid/data/workspace/sqlite_agent_generated_files_bench_test.go
+++ b/services/tuttid/data/workspace/sqlite_agent_generated_files_bench_test.go
@@ -100,6 +100,7 @@ func seedGeneratedFileBenchmarkMessages(
 					Kind:      "tool_call",
 					Status:    "completed",
 					Payload: map[string]any{
+						"toolName": "Write",
 						"fileChanges": map[string]any{
 							"files": []any{
 								map[string]any{

--- a/services/tuttid/data/workspace/sqlite_store_test.go
+++ b/services/tuttid/data/workspace/sqlite_store_test.go
@@ -429,6 +429,7 @@ func TestSQLiteStoreListsWorkspaceGeneratedFiles(t *testing.T) {
 				Kind:      "tool_call",
 				Status:    "completed",
 				Payload: map[string]any{
+					"toolName": "Write",
 					"fileChanges": map[string]any{
 						"files": []any{
 							map[string]any{"path": "report.md"},
@@ -596,8 +597,14 @@ func TestSQLiteStoreListWorkspaceGeneratedFilesIgnoresFailedAndReadTools(t *test
 				Status:    "completed",
 				Payload: map[string]any{
 					"toolName": "Bash",
+					"fileChanges": map[string]any{
+						"files": []any{
+							map[string]any{"path": "read-filechanges.md"},
+						},
+					},
 					"input": map[string]any{
 						"command":   "nl -ba readme.md",
+						"changes":   map[string]any{"read-input-changes.md": "read"},
 						"file_path": "readme.md",
 					},
 					"output": map[string]any{

--- a/services/tuttid/data/workspace/sqlite_store_test.go
+++ b/services/tuttid/data/workspace/sqlite_store_test.go
@@ -528,6 +528,125 @@ func TestSQLiteStoreListsWorkspaceGeneratedFiles(t *testing.T) {
 	}
 }
 
+func TestSQLiteStoreListWorkspaceGeneratedFilesIgnoresFailedAndReadTools(t *testing.T) {
+	t.Parallel()
+
+	store := openTestSQLiteStore(t)
+	ctx := context.Background()
+
+	if err := store.Create(ctx, workspacebiz.Summary{
+		ID:   "ws-agent-generated-files-failed",
+		Name: "Workspace Agent Generated Files Failed",
+	}); err != nil {
+		t.Fatalf("Create() error = %v", err)
+	}
+	if _, err := store.ReportSessionState(ctx, agentactivitybiz.SessionStateReport{
+		WorkspaceID:      "ws-agent-generated-files-failed",
+		AgentSessionID:   "session-1",
+		Origin:           agentsessionstore.WorkspaceAgentSessionOriginRuntime,
+		Provider:         "codex",
+		Cwd:              "/workspace",
+		Status:           "completed",
+		OccurredAtUnixMS: 100,
+	}); err != nil {
+		t.Fatalf("ReportSessionState() error = %v", err)
+	}
+	if _, err := store.ReportSessionMessages(ctx, agentactivitybiz.SessionMessageReport{
+		WorkspaceID:    "ws-agent-generated-files-failed",
+		AgentSessionID: "session-1",
+		Origin:         agentsessionstore.WorkspaceAgentSessionOriginRuntime,
+		Messages: []agentactivitybiz.MessageUpdate{
+			{
+				MessageID: "failed-status",
+				TurnID:    "turn-1",
+				Role:      "assistant",
+				Kind:      "tool_call",
+				Status:    "failed",
+				Payload: map[string]any{
+					"toolName": "Write",
+					"fileChanges": map[string]any{
+						"files": []any{
+							map[string]any{"path": "failed-status.md"},
+						},
+					},
+				},
+				OccurredAtUnixMS: 110,
+			},
+			{
+				MessageID: "failed-output",
+				TurnID:    "turn-1",
+				Role:      "assistant",
+				Kind:      "tool_call",
+				Status:    "completed",
+				Payload: map[string]any{
+					"toolName": "Write",
+					"output": map[string]any{
+						"path":    "failed-output.md",
+						"status":  "failed",
+						"success": false,
+					},
+				},
+				OccurredAtUnixMS: 120,
+			},
+			{
+				MessageID: "read-tool",
+				TurnID:    "turn-1",
+				Role:      "assistant",
+				Kind:      "tool_call",
+				Status:    "completed",
+				Payload: map[string]any{
+					"toolName": "Bash",
+					"input": map[string]any{
+						"command":   "nl -ba readme.md",
+						"file_path": "readme.md",
+					},
+					"output": map[string]any{
+						"status":  "completed",
+						"success": true,
+					},
+				},
+				OccurredAtUnixMS: 130,
+			},
+			{
+				MessageID: "successful-write",
+				TurnID:    "turn-1",
+				Role:      "assistant",
+				Kind:      "tool_call",
+				Status:    "completed",
+				Payload: map[string]any{
+					"toolName": "Write",
+					"output": map[string]any{
+						"filePath": "ok.md",
+						"status":   "completed",
+						"success":  true,
+					},
+				},
+				OccurredAtUnixMS: 140,
+			},
+		},
+	}); err != nil {
+		t.Fatalf("ReportSessionMessages() error = %v", err)
+	}
+
+	result, ok, err := store.ListWorkspaceGeneratedFiles(ctx, agentactivitybiz.ListWorkspaceGeneratedFilesInput{
+		WorkspaceID: "ws-agent-generated-files-failed",
+		SessionCwd:  "/workspace",
+		Limit:       10,
+	})
+	if err != nil {
+		t.Fatalf("ListWorkspaceGeneratedFiles() error = %v", err)
+	}
+	if !ok {
+		t.Fatal("ListWorkspaceGeneratedFiles() ok = false, want true")
+	}
+	if len(result.Files) != 1 {
+		t.Fatalf("len(files) = %d, want 1: %#v", len(result.Files), result.Files)
+	}
+	if result.Files[0].Path != "/workspace/ok.md" {
+		t.Fatalf("file path = %q, want /workspace/ok.md", result.Files[0].Path)
+	}
+}
+
 func TestSQLiteStoreReportsProviderSessionMessagesToCanonicalAgentSession(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary
- filter agent-generated file collection to successful file-change tool calls
- keep daemon and AgentGUI fallback collectors aligned
- document generated-file mention collector ownership

## Validation
- corepack pnpm --filter @tutti-os/agent-gui exec vitest run shared/workspaceAgentActivityListViewModel.spec.ts
- go test ./data/workspace -run 'TestSQLiteStoreListsWorkspaceGeneratedFiles|TestSQLiteStoreListWorkspaceGeneratedFilesIgnoresFailedAndReadTools'\n- pnpm check:full

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added guidance for how generated-file mention paths are computed, counting only successful file-change results and ignoring failed/canceled/running/read-only tool calls.

* **Bug Fixes**
  * Generated-file lists now include only entries from successful tool outcomes.
  * Improved filtering by message kind/status and nested payload output, ensuring only real write/edit/delete-style file changes are surfaced.

* **Tests**
  * Updated and added unit tests to verify failed/read tool calls are excluded; adjusted benchmark seed data accordingly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->