### PR TITLE
fix(agent-install): isolate npm cache so adapter install survives a root-owned ~/.npm

### DIFF
--- a/services/tuttid/service/agentstatus/installer.go
+++ b/services/tuttid/service/agentstatus/installer.go
@@ -531,6 +531,10 @@ func (s Service) runExternalAgentRegistryNPMInstaller(ctx context.Context, spec 
 		packageSpec,
 	})
 	baseEnv := managedruntime.ProcessEnv(append(appRuntime.EnvOverrides, envMapToList(npmSpec.Env)...)...)
+	// Use a dedicated, tutti-owned npm cache inside the install prefix rather than
+	// the user's global ~/.npm, which on some machines holds root-owned files that
+	// make every user-mode npm install fail with EACCES before any registry is hit.
+	baseEnv = withAgentNPMCache(baseEnv, filepath.Join(npmSpec.PrefixDir, agentNPMCacheDirName))
 
 	// Try official npm first (fastest when reachable), then fall back through the
 	// CN-available mirrors when it is slow or blocked. Each attempt is bounded so a

--- a/services/tuttid/service/agentstatus/installer_codex_cli.go
+++ b/services/tuttid/service/agentstatus/installer_codex_cli.go
@@ -47,8 +47,13 @@ func (s Service) runCodexCLILatestInstaller(
 	if err != nil {
 		return InstallCommandResult{ExitCode: 1, Stderr: err.Error()}, nil
 	}
-	command := joinShellCommand([]string{npmPath, "install", "-g", "--prefix", filepath.Dir(installBinDir), "@openai/codex", "--include=optional"})
+	installPrefix := filepath.Dir(installBinDir)
+	command := joinShellCommand([]string{npmPath, "install", "-g", "--prefix", installPrefix, "@openai/codex", "--include=optional"})
 	baseEnv := s.commandResolver().Env(nil)
+	// Pin a dedicated, tutti-owned npm cache instead of the user's global ~/.npm,
+	// which on some machines holds root-owned files that make every user-mode npm
+	// install fail with EACCES before any registry is hit.
+	baseEnv = withAgentNPMCache(baseEnv, filepath.Join(installPrefix, agentNPMCacheDirName))
 	registries := s.agentNPMRegistries()
 	var result InstallCommandResult
 	for i, registry := range registries {

--- a/services/tuttid/service/agentstatus/npm_registry.go
+++ b/services/tuttid/service/agentstatus/npm_registry.go
@@ -25,6 +25,11 @@ const (
 	huaweiNPMRegistry  = "https://repo.huaweicloud.com/repository/npm/" // Huawei Cloud
 	tencentNPMRegistry = "https://mirrors.cloud.tencent.com/npm/"       // Tencent Cloud
 
+	// agentNPMCacheDirName is the dedicated npm cache directory agent installs use
+	// instead of npm's global ~/.npm. It lives inside the install prefix so it is
+	// always tutti-owned and writable by the daemon's user. See withAgentNPMCache.
+	agentNPMCacheDirName = ".npm-cache"
+
 	// perRegistryInstallTimeout bounds each registry attempt so a blocked
 	// registry fails over to the next one instead of consuming the whole install
 	// budget. It must clear a working-but-slow registry: a direct install of the
@@ -70,6 +75,27 @@ func withAgentNPMRegistry(env []string, registry string) []string {
 		result = append(result, kv)
 	}
 	return append(result, prefix+registry)
+}
+
+// withAgentNPMCache returns env with npm_config_cache pinned to cacheDir,
+// dropping any inherited value.
+//
+// Agent installs must not rely on npm's global cache (~/.npm). On machines where
+// a prior `sudo npm install` left root-owned files there, every user-mode
+// `npm install` fails with "EACCES ... cache folder contains root-owned files"
+// before it ever reaches a registry — so the install can never succeed, and
+// retrying across mirrors is futile (the failure is local, not network). Pinning
+// a dedicated tutti-owned cache sidesteps the broken global cache entirely.
+func withAgentNPMCache(env []string, cacheDir string) []string {
+	const prefix = "npm_config_cache="
+	result := make([]string, 0, len(env)+1)
+	for _, kv := range env {
+		if strings.HasPrefix(strings.ToLower(kv), prefix) {
+			continue
+		}
+		result = append(result, kv)
+	}
+	return append(result, prefix+cacheDir)
 }
 
 // lookupEnv reads a single environment variable, honoring an injected Environ for

--- a/services/tuttid/service/agentstatus/npm_registry_test.go
+++ b/services/tuttid/service/agentstatus/npm_registry_test.go
@@ -2,6 +2,7 @@ package agentstatus
 
 import (
 	"context"
+	"path/filepath"
 	"slices"
 	"testing"
 )
@@ -119,6 +120,109 @@ func TestResolveExternalRegistryNPMSpecExecEnvInjectsPrimaryRegistry(t *testing.
 	if !slices.Contains(result.Env, "npm_config_registry=https://registry.npmjs.org") {
 		t.Fatalf("adapter env = %#v, want primary (official) registry", result.Env)
 	}
+}
+
+func TestWithAgentNPMCacheReplacesInheritedCacheEnv(t *testing.T) {
+	env := []string{
+		"PATH=/usr/bin",
+		"npm_config_cache=/Users/someone/.npm",
+	}
+	got := withAgentNPMCache(env, "/tmp/tutti/npm-cache")
+
+	var caches []string
+	for _, kv := range got {
+		if len(kv) > len("npm_config_cache=") && kv[:len("npm_config_cache=")] == "npm_config_cache=" {
+			caches = append(caches, kv)
+		}
+	}
+	if !slices.Equal(caches, []string{"npm_config_cache=/tmp/tutti/npm-cache"}) {
+		t.Fatalf("npm_config_cache entries = %#v, want exactly the dedicated cache (inherited ~/.npm dropped)", caches)
+	}
+}
+
+func TestRunExternalAgentRegistryNPMInstallerPinsDedicatedCache(t *testing.T) {
+	runtimeRoot := fakeManagedRuntimeRoot(t)
+	prefixDir := t.TempDir()
+	service := Service{
+		ManagedRuntime: fakeManagedRuntimeResolver(t, runtimeRoot),
+		Environ:        func() []string { return []string{"PATH=/usr/bin:/bin"} },
+	}
+	spec := InstallerSpec{
+		Kind: InstallerKindExternalAgentRegistryNPM,
+		RegistryNPM: &ExternalAgentRegistryNPMInstallerSpec{
+			Package:   "@agentclientprotocol/claude-agent-acp@0.50.0",
+			PrefixDir: prefixDir,
+		},
+	}
+	var gotCache string
+	service.InstallCommand = func(_ context.Context, in InstallCommandInput) (InstallCommandResult, error) {
+		gotCache = cacheFromEnv(in.Env)
+		return InstallCommandResult{ExitCode: 0}, nil
+	}
+
+	if _, err := service.runExternalAgentRegistryNPMInstaller(context.Background(), spec); err != nil {
+		t.Fatalf("runExternalAgentRegistryNPMInstaller() error = %v", err)
+	}
+	want := filepath.Join(prefixDir, agentNPMCacheDirName)
+	if gotCache != want {
+		t.Fatalf("npm_config_cache = %q, want dedicated cache %q (must not depend on global ~/.npm)", gotCache, want)
+	}
+}
+
+func TestResolveExternalRegistryNPMSpecExecEnvPinsDedicatedCache(t *testing.T) {
+	home := t.TempDir()
+	registryStore, prefixDir := fakeClaudeExternalRegistry(t)
+	runtimeRoot := fakeManagedRuntimeRoot(t)
+
+	service := probeTestService(home)
+	service.ExternalAgentRegistry = registryStore
+	service.ManagedRuntime = fakeManagedRuntimeResolver(t, runtimeRoot)
+
+	result, err := service.ResolveProviderCommand(context.Background(), "claude-code")
+	if err != nil {
+		t.Fatalf("ResolveProviderCommand() error = %v", err)
+	}
+	want := "npm_config_cache=" + filepath.Join(prefixDir, agentNPMCacheDirName)
+	if !slices.Contains(result.Env, want) {
+		t.Fatalf("adapter env = %#v, want dedicated npm cache %q", result.Env, want)
+	}
+}
+
+func TestRunCodexCLILatestInstallerPinsDedicatedCache(t *testing.T) {
+	home := t.TempDir()
+	binDir := filepath.Join(home, "bin")
+	writeExecutable(t, filepath.Join(binDir, npmBinaryNameForTest()), "#!/bin/sh\nexit 0\n")
+	writeExecutable(t, filepath.Join(binDir, nodeBinaryNameForTest()), "#!/bin/sh\nexit 0\n")
+	service := probeTestService(home)
+	service.Environ = func() []string { return []string{"PATH=" + binDir} }
+	service.IsExecutableFile = isTestExecutableUnderHome(home)
+
+	var gotCache string
+	service.InstallCommand = func(_ context.Context, in InstallCommandInput) (InstallCommandResult, error) {
+		gotCache = cacheFromEnv(in.Env)
+		return InstallCommandResult{ExitCode: 0}, nil
+	}
+
+	if _, err := service.runCodexCLILatestInstaller(context.Background(), InstallerSpec{
+		Kind:     InstallerKindCodexCLILatest,
+		CodexCLI: &CodexCLILatestInstallerSpec{},
+	}, ""); err != nil {
+		t.Fatalf("runCodexCLILatestInstaller() error = %v", err)
+	}
+	if gotCache == "" || filepath.Base(gotCache) != agentNPMCacheDirName {
+		t.Fatalf("npm_config_cache = %q, want a dedicated cache dir (must not depend on global ~/.npm)", gotCache)
+	}
+}
+
+// cacheFromEnv extracts the npm_config_cache value from a command env.
+func cacheFromEnv(env []string) string {
+	const prefix = "npm_config_cache="
+	for _, kv := range env {
+		if len(kv) > len(prefix) && kv[:len(prefix)] == prefix {
+			return kv[len(prefix):]
+		}
+	}
+	return ""
 }
 
 // registryFromEnv extracts the npm_config_registry value from a command env.

--- a/services/tuttid/service/agentstatus/provider_resolution.go
+++ b/services/tuttid/service/agentstatus/provider_resolution.go
@@ -140,6 +140,9 @@ func (s Service) resolveExternalRegistryNPMSpec(
 	// registry (override, else official). Harmless when running the installed bin
 	// directly, which never consults npm.
 	spec.AdapterEnv = withAgentNPMRegistry(spec.AdapterEnv, s.primaryAgentNPMRegistry())
+	// Pin a dedicated cache for the `npm exec` fallback too, so it never trips over
+	// a root-owned global ~/.npm. Harmless when running the installed bin directly.
+	spec.AdapterEnv = withAgentNPMCache(spec.AdapterEnv, filepath.Join(prefixDir, agentNPMCacheDirName))
 	return spec
 }
 


### PR DESCRIPTION
## Problem

A user reported that clicking **进行安装** for the Claude Code **适配器 (adapter)** in the onboarding wizard never succeeds, even though the CLI is installed, the account is logged in, and all network probes pass.

The daemon logs (`tuttid.log`) show every install attempt — across all four registries (`npmjs → npmmirror → huawei → tencent`) and the Codex CLI install too — failing with the **same local error**:

```
npm error code EACCES
npm error syscall mkdir
npm error path /Users/<user>/.npm/_cacache/index-v5/9b/50
npm error Your cache folder contains root-owned files, due to a bug in
npm error previous versions of npm ...
npm error   sudo chown -R 501:20 "/Users/<user>/.npm"
```

## Root cause

The user's global npm cache (`~/.npm`) contains **root-owned files** (left behind by a past `sudo npm install`). When the daemon runs `npm install` as the normal user, npm can't write its cache and aborts with `EACCES` — **before it ever contacts a registry**. That's why:

- the network probes are green but the install still fails, and
- the multi-registry fallback chain is useless here — each attempt re-hits the same broken local cache.

Tutti never overrode `npm_config_cache`, so it inherited (and was at the mercy of) the user's global `~/.npm`.

## Fix

Pin a dedicated, **tutti-owned** npm cache (`<install-prefix>/.npm-cache`) for every agent npm invocation, via a new `withAgentNPMCache` helper that sets `npm_config_cache`:

- external-agent-registry **adapter install** (`runExternalAgentRegistryNPMInstaller`)
- its **`npm exec` fallback** (`resolveExternalRegistryNPMSpec`)
- the **Codex CLI install** (`runCodexCLILatestInstaller`)

This sidesteps the user's broken global `~/.npm` entirely. No privilege escalation is needed (running the install as root would *propagate* the corruption and leave root-owned files behind), and installed artifacts stay user-owned.

## Tests

TDD — added to `npm_registry_test.go`:

- `TestWithAgentNPMCacheReplacesInheritedCacheEnv` — drops any inherited `npm_config_cache`, keeps exactly the dedicated dir
- `TestRunExternalAgentRegistryNPMInstallerPinsDedicatedCache`
- `TestResolveExternalRegistryNPMSpecExecEnvPinsDedicatedCache`
- `TestRunCodexCLILatestInstallerPinsDedicatedCache`

`go test ./services/tuttid/service/agentstatus/` passes; `go vet`, `gofmt`, and `go build ./services/tuttid/...` are clean.

## Note for the affected user

This change makes future installs robust, but their existing `~/.npm` is still root-owned. A one-time cleanup also unblocks any other npm usage:

```
sudo chown -R $(id -u):$(id -g) ~/.npm
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Installer flows now use a dedicated npm cache stored alongside the installation, reducing failures caused by a shared or corrupted global cache.
  * External registry installs and fallback execution now avoid relying on the user’s `~/.npm` cache.
  * Codex CLI “latest” installs now consistently use the same installation prefix and cache location, improving reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->