### PR TITLE
fix(workspace-apps): reopen pending updates from dock

### DIFF
--- a/apps/desktop/src/renderer/src/features/workspace-app-center/services/internal/workspaceAppCenterContribution.tsx
+++ b/apps/desktop/src/renderer/src/features/workspace-app-center/services/internal/workspaceAppCenterContribution.tsx
@@ -133,6 +133,7 @@ export function createWorkspaceAppCenterDockEntries(input: {
         createWorkspaceAppDockEntry({
           app: projection.app,
           captureWebviewPreview: input.captureWebviewPreview,
+          clickBehavior: projection.clickBehavior,
           index,
           launchEnabled: projection.launchEnabled,
           state: projection.state
@@ -173,6 +174,7 @@ function createWorkspaceAppDockEntry(input: {
   captureWebviewPreview?: (
     nodeId: string
   ) => Promise<string | null> | string | null;
+  clickBehavior?: WorkbenchHostDockEntry["clickBehavior"];
   index: number;
   launchEnabled: boolean;
   state?: WorkbenchHostDockEntry["state"];
@@ -186,6 +188,7 @@ function createWorkspaceAppDockEntry(input: {
             input.captureWebviewPreview?.(node.id) ?? null
         }
       : {}),
+    ...(input.clickBehavior ? { clickBehavior: input.clickBehavior } : {}),
     icon: createWorkspaceAppDockIcon(input.app),
     id: dockEntryId,
     instanceMode: "single",

--- a/apps/desktop/src/renderer/src/features/workspace-app-center/services/internal/workspaceAppCenterDockProjection.test.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-app-center/services/internal/workspaceAppCenterDockProjection.test.ts
@@ -35,6 +35,7 @@ test("projectWorkspaceAppCenterDockState maps runtime status to dock state", () 
   assert.deepEqual(
     projectWorkspaceAppCenterDockState("installed_pending_restart", null),
     {
+      clickBehavior: "launch",
       launchEnabled: true,
       state: { kind: "enabled" }
     }

--- a/apps/desktop/src/renderer/src/features/workspace-app-center/services/internal/workspaceAppCenterDockProjection.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-app-center/services/internal/workspaceAppCenterDockProjection.ts
@@ -1,4 +1,7 @@
-import type { WorkbenchHostDockEntryState } from "@tutti-os/workbench-surface";
+import type {
+  WorkbenchHostDockEntry,
+  WorkbenchHostDockEntryState
+} from "@tutti-os/workbench-surface";
 import type {
   WorkspaceAppCenterApp,
   WorkspaceAppCenterRuntimeStatus
@@ -6,6 +9,7 @@ import type {
 
 export interface WorkspaceAppCenterDockProjection {
   app: WorkspaceAppCenterApp;
+  clickBehavior?: WorkbenchHostDockEntry["clickBehavior"];
   launchEnabled: boolean;
   state?: WorkbenchHostDockEntryState;
 }
@@ -29,7 +33,10 @@ export function projectWorkspaceAppCenterDockState(
   status: WorkspaceAppCenterRuntimeStatus,
   launchUrl: string | null | undefined,
   installed = true
-): Pick<WorkspaceAppCenterDockProjection, "launchEnabled" | "state"> {
+): Pick<
+  WorkspaceAppCenterDockProjection,
+  "clickBehavior" | "launchEnabled" | "state"
+> {
   if (status === "installing") {
     return {
       launchEnabled: false,
@@ -50,6 +57,7 @@ export function projectWorkspaceAppCenterDockState(
   }
   if (status === "installed_pending_restart") {
     return {
+      clickBehavior: "launch",
       launchEnabled: true,
       state: { kind: "enabled" }
     };

--- a/docs/bugfixes/2026-06-27-feishu-bugs.md
+++ b/docs/bugfixes/2026-06-27-feishu-bugs.md
@@ -14,3 +14,18 @@
 - Status: fixed locally
 - Commit: pending
 - Feishu status update: not updated; real Base record id could not be resolved from the supplied short link.
+
+## NFCyrr5Z8eVe02c7uNDcKVKrnog - workspace app update reopens stale Vibe Design
+
+- Link: https://ccn53rwonxso.feishu.cn/record/NFCyrr5Z8eVe02c7uNDcKVKrnog
+- Base record id: `recvmCg08QQojR`
+- Bug: 点击更新按钮后，关掉 Vibe Design 后再打开没有获取到最新版本，需要重启 Tutti 才能看到最新功能改动。
+- Evidence: The Base record has no downloadable log zip; it includes recording attachment `录屏2026-06-15 20.44.23.mov`. Code inspection showed `installed_pending_restart` apps can still have a matching `workspace-app-webview` dock node, and workbench dock single-instance clicks focus that node before launch resolution.
+- Cause: The dock entry for a pending-restart workspace app still used the default single-instance focus behavior. When a stale app webview node still matched the dock entry, dock clicks bypassed `resolveWorkspaceAppCenterLaunchRequest`, so `restartAndOpenApp` did not close the old view and restart/open the updated package.
+- Fix: Pending-restart workspace app dock entries now force dock clicks through the normal launch request path. The existing launch resolver then calls `restartAndOpenApp`; normal running apps keep the regular focus behavior.
+- Verification:
+  - `node --import ./apps/desktop/test/register-asset-stub.mjs --test --experimental-strip-types ./apps/desktop/src/renderer/src/features/workspace-app-center/services/internal/workspaceAppCenterContribution.test.ts`
+  - `node --test --experimental-strip-types packages/workbench/surface/src/host/dockEntries.test.ts`
+- Status: fixed locally
+- Commit: pending
+- Feishu status update: not updated.

--- a/docs/conventions/troubleshooting.md
+++ b/docs/conventions/troubleshooting.md
@@ -102,6 +102,36 @@ Use this shape for new entries:
   [apps.go](../../services/tuttid/service/workspace/apps.go)
   [apps_test.go](../../services/tuttid/service/workspace/apps_test.go)
 
+### Workspace app update reopens the old dock window
+
+- Symptom:
+  After updating a running workspace app, clicking the app from the dock still
+  shows the old UI or old port until Tutti itself is restarted.
+- Quick checks:
+  Inspect the App Center snapshot for `installed_pending_restart` while a
+  matching `workspace-app-webview` node still exists. Dock debug logs showing
+  `clickResolution.kind = "focus-node"` for that app mean the launch resolver
+  is being bypassed.
+- Root cause:
+  Workbench dock single-instance entries focus a matching node before launching.
+  If a workspace app is waiting for restart and the dock entry still uses the
+  default click behavior, clicking the dock can restore the stale webview
+  instead of entering `resolveWorkspaceAppCenterLaunchRequest` and
+  `restartAndOpenApp`.
+- Fix:
+  Route `installed_pending_restart` workspace app dock clicks through the
+  launch request path even when a stale webview node still matches the dock
+  entry. Keep normal `running` apps on the default focus path so existing app
+  state is preserved.
+- Validation:
+  Run the workspace app-center contribution tests and the workspace workbench
+  surface dock click-resolution tests that cover pending-restart launch
+  routing.
+- References:
+  [workspaceAppCenterContribution.tsx](../../apps/desktop/src/renderer/src/features/workspace-app-center/services/internal/workspaceAppCenterContribution.tsx)
+  [workspaceAppCenterLaunchRequest.ts](../../apps/desktop/src/renderer/src/features/workspace-app-center/services/internal/workspaceAppCenterLaunchRequest.ts)
+  [dockEntries.ts](../../packages/workbench/surface/src/host/dockEntries.ts)
+
 ### Load unpacked project roots with source manifests
 
 - Symptom:

--- a/packages/workbench/surface/src/host/dockEntries.test.ts
+++ b/packages/workbench/surface/src/host/dockEntries.test.ts
@@ -221,6 +221,32 @@ test("dock click resolution allows a dock entry to override a multi node type", 
   );
 });
 
+test("dock click resolution can keep an entry on the launch path", () => {
+  const entry: WorkbenchHostDockEntry = {
+    clickBehavior: "launch",
+    icon: null,
+    id: "workspace-app:calendar",
+    instanceMode: "single",
+    label: "Calendar",
+    typeId: "workspace-app-webview"
+  };
+
+  assert.deepEqual(
+    resolveWorkbenchDockEntryClick({
+      entry,
+      instanceMode: entry.instanceMode,
+      matchedNodes: [
+        makeNode(
+          "workspace-app:calendar",
+          "workspace-app-webview",
+          "workspace-app:calendar"
+        )
+      ]
+    }),
+    { kind: "launch" }
+  );
+});
+
 test("dock click resolution can trigger host actions", () => {
   const entry: WorkbenchHostDockEntry = {
     clickActionId: "open-launchpad",

--- a/packages/workbench/surface/src/host/dockEntries.ts
+++ b/packages/workbench/surface/src/host/dockEntries.ts
@@ -128,6 +128,9 @@ export function resolveWorkbenchDockEntryClick(input: {
   if (isWorkbenchDockEntryBlocked(input.entry)) {
     return { kind: "blocked" };
   }
+  if (input.entry.clickBehavior === "launch") {
+    return { kind: "launch" };
+  }
   if (input.instanceMode === "multi" && input.matchedNodes.length > 0) {
     return { kind: "open-popup" };
   }

--- a/packages/workbench/surface/src/host/types.ts
+++ b/packages/workbench/surface/src/host/types.ts
@@ -250,6 +250,11 @@ export interface WorkbenchHostDockEntry {
   badge?: WorkbenchHostDockEntryBadge;
   capturePopupItemPreview?: WorkbenchHostNodePreviewCapture;
   clickActionId?: string;
+  /**
+   * `launch` keeps clicks on the launch request path even when matching nodes
+   * already exist.
+   */
+  clickBehavior?: "default" | "launch";
   hoverActions?: readonly WorkbenchHostDockEntryAction[];
   icon: ReactNode;
   iconSize?: "default" | "large";


### PR DESCRIPTION
## Summary
- route pending-restart workspace app dock clicks through launch requests instead of focusing stale webview nodes
- add a workbench dock clickBehavior override with regression coverage
- document the Feishu bug and troubleshooting playbook

## Validation
- node --import ./apps/desktop/test/register-asset-stub.mjs --test --experimental-strip-types ./apps/desktop/src/renderer/src/features/workspace-app-center/services/internal/workspaceAppCenterContribution.test.ts
- node --test --experimental-strip-types packages/workbench/surface/src/host/dockEntries.test.ts
- npx -y pnpm@10.11.0 check:changed --tail-lines 80
- npx -y pnpm@10.11.0 exec lint-staged
- npx -y pnpm@10.11.0 check:electron-runtime-boundaries:staged
- npx -y pnpm@10.11.0 check:ui-boundaries:staged
- npx -y pnpm@10.11.0 check:renderer-boundaries:staged
- npx -y pnpm@10.11.0 lint:go

## Notes
- npx -y pnpm@10.11.0 check:full --tail-lines 80 passed preflight, TS lint, typecheck, TS tests, and Go tests, but the concurrent full runner reported lint:go failed; rerunning lint:go standalone passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Clicking an updated workspace app now opens the latest version instead of reusing a stale screen.
  * Apps marked for restart now follow the normal launch flow when clicked, improving reliability after updates.
  * Dock clicks for affected apps now behave consistently, even when an older instance is still present.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->