### PR TITLE
fix(issue-manager): stop truncating app mention results

### DIFF
--- a/packages/ui/rich-text/src/editor/RichTextTriggerEditor.tsx
+++ b/packages/ui/rich-text/src/editor/RichTextTriggerEditor.tsx
@@ -116,7 +116,7 @@ export function RichTextTriggerEditor({
   textareaClassName,
   placeholderClassName,
   minQueryLength = 0,
-  maxResults = 8,
+  maxResults,
   removeDecorationAriaLabel,
   i18n,
   textOverrides,

--- a/packages/ui/rich-text/src/editor/RichTextTriggerTextarea.tsx
+++ b/packages/ui/rich-text/src/editor/RichTextTriggerTextarea.tsx
@@ -65,7 +65,7 @@ export function RichTextTriggerTextarea({
   textareaClassName,
   rows,
   minQueryLength = 0,
-  maxResults = 8,
+  maxResults,
   removeDecorationAriaLabel,
   i18n,
   textOverrides,

--- a/packages/workspace/issue-manager/src/ui/internal/content/IssueManagerRichTextTextarea.tsx
+++ b/packages/workspace/issue-manager/src/ui/internal/content/IssueManagerRichTextTextarea.tsx
@@ -54,7 +54,6 @@ export function IssueManagerRichTextTextarea({
   return (
     <RichTextTriggerEditor
       focusSignal={focusSignal}
-      maxResults={8}
       minQueryLength={0}
       triggerProviders={providers}
       textOverrides={{


### PR DESCRIPTION
## Summary

- Remove the explicit `maxResults={8}` cap from Issue Manager rich-text `@` mentions.
- Stop `RichTextTriggerEditor` and `RichTextTriggerTextarea` from applying an implicit default cap, so callers only limit results when they opt in.

## Validation

- `node --test --experimental-strip-types packages/ui/rich-text/src/editor/richTextTriggerQuery.test.ts`
- `node --test --experimental-strip-types packages/workspace/issue-manager/src/ui/internal/content/IssueManagerRichTextTextarea.test.ts`
- `corepack pnpm --filter @tutti-os/ui-rich-text typecheck`
- `corepack pnpm --filter @tutti-os/workspace-issue-manager typecheck`
- `corepack pnpm check:ui-boundaries`
- `corepack pnpm exec lint-staged`
- `corepack pnpm check:electron-runtime-boundaries:staged`
- `corepack pnpm check:ui-boundaries:staged`
- `corepack pnpm check:renderer-boundaries:staged`

`corepack pnpm check:changed` could not complete because the local check runner resolves to pnpm 11.7.0 while this repo requires pnpm 10.11.0; the failure log only shows the pnpm engine mismatch.

## Documentation

No durable documentation update needed: this changes an internal UI result cap and no docs described the previous default.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Trigger suggestion lists now follow the caller’s configured limit more consistently instead of always using a fixed maximum in some editors.
  * Some rich-text entry points no longer apply an automatic cap when showing trigger matches, allowing the result count to vary based on configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->