### PR TITLE
Fix Markdown formatting in Message Center stack previews

### DIFF
--- a/packages/agent/gui/agent-message-center/WorkspaceAgentMessageCenterCard.tsx
+++ b/packages/agent/gui/agent-message-center/WorkspaceAgentMessageCenterCard.tsx
@@ -517,9 +517,13 @@ function MessageCenterStackSummary({
           />
         </span>
         <span className="min-w-0 rounded-md bg-transparency-block p-2.5 text-[13px] leading-[1.45] text-[var(--text-primary)]">
-          <span className="line-clamp-2 min-w-0 [overflow-wrap:anywhere]">
-            {messageCenterStackPreviewText(firstItem)}
-          </span>
+          <AgentMessageMarkdown
+            content={messageCenterStackPreviewText(firstItem)}
+            inline
+            previewMode
+            renderProfile="inline-preview"
+            className="line-clamp-2 !overflow-hidden text-[var(--text-primary)] [overflow-wrap:anywhere] [&_a]:text-inherit [&_code]:text-[var(--text-secondary)] [&_p]:m-0"
+          />
         </span>
       </span>
     </button>

--- a/packages/agent/gui/agent-message-center/WorkspaceAgentMessageCenterPanel.spec.tsx
+++ b/packages/agent/gui/agent-message-center/WorkspaceAgentMessageCenterPanel.spec.tsx
@@ -1,5 +1,11 @@
 import "@testing-library/jest-dom/vitest";
-import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import {
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+  within
+} from "@testing-library/react";
 import { TooltipProvider } from "@tutti-os/ui-system";
 import { describe, expect, it, vi } from "vitest";
 import {
@@ -1146,6 +1152,63 @@ describe("WorkspaceAgentMessageCenterPanel", () => {
     expect(screen.queryByText("Running task 3")).toBeNull();
     expect(screen.queryByText("Running task 4")).toBeNull();
     expect(screen.queryByText("Running task 5")).toBeNull();
+  });
+
+  it("renders markdown formatting in collapsed stack previews", () => {
+    render(
+      <WorkspaceAgentMessageCenterPanel
+        open
+        model={createMessageCenterModel([
+          createMessageCenterItem({
+            agentSessionId: "working-session-1",
+            title: "Running task 1",
+            status: "working",
+            digest: {
+              primary: {
+                kind: "progress",
+                summary:
+                  "**跳过总结** 当前没有可**结果**：无法完成[分析任务](https://example.com)。![截图](/tmp/result.png)\n\nNext step\n\n---\n\nAfter break\n\n- [x] 列表项\n\n| 列 | 值 |\n| --- | --- |\n| A | B |\n\n```text\n代码块\n```",
+                occurredAtUnixMs: 1
+              }
+            }
+          }),
+          createMessageCenterItem({
+            agentSessionId: "working-session-2",
+            title: "Running task 2",
+            status: "working"
+          })
+        ])}
+        onClose={vi.fn()}
+        onOpenChat={vi.fn()}
+        onSubmitPrompt={vi.fn()}
+      />
+    );
+
+    const summary = screen.getByTestId(
+      "workspace-agent-message-stack-summary-working:agent-user:codex:unknown-user"
+    );
+
+    expect(summary).not.toHaveTextContent("**");
+    expect(within(summary).getByText("跳过总结").tagName).toBe("STRONG");
+    expect(within(summary).getByText("结果").tagName).toBe("STRONG");
+    expect(summary).toHaveTextContent("无法完成分析任务");
+    expect(summary).toHaveTextContent("截图 Next step");
+    expect(summary).toHaveTextContent("After break");
+    expect(summary).toHaveTextContent("截图");
+    expect(summary).toHaveTextContent("列表项");
+    expect(summary).toHaveTextContent("代码块");
+    expect(summary.querySelector("a")).toBeNull();
+    const markdown = summary.querySelector("[data-workspace-agent-markdown]");
+    expect(markdown?.querySelector("blockquote")).toBeNull();
+    expect(markdown?.querySelector("hr")).toBeNull();
+    expect(markdown?.querySelector("img")).toBeNull();
+    expect(markdown?.querySelector("input")).toBeNull();
+    expect(markdown?.querySelector("ol")).toBeNull();
+    expect(markdown?.querySelector("pre")).toBeNull();
+    expect(markdown?.querySelector("table")).toBeNull();
+    expect(markdown?.querySelector("ul")).toBeNull();
+    expect(markdown?.querySelector("video")).toBeNull();
+    expect(within(summary).queryByRole("link")).toBeNull();
   });
 
   it("aggregates stacked cards by agent provider and user inside a group", () => {

--- a/packages/agent/gui/shared/AgentMessageMarkdown.tsx
+++ b/packages/agent/gui/shared/AgentMessageMarkdown.tsx
@@ -117,6 +117,7 @@ interface AgentMessageMarkdownProps {
   deferLongContentRender?: boolean;
   enableImageZoom?: boolean;
   previewMode?: boolean;
+  renderProfile?: AgentMessageMarkdownRenderProfile;
   streaming?: boolean;
 }
 
@@ -136,6 +137,8 @@ type MarkdownDomProps<Tag extends keyof JSX.IntrinsicElements> =
 
 const MarkdownLinkContext = createContext(false);
 
+type AgentMessageMarkdownRenderProfile = "default" | "inline-preview";
+
 type ReactMarkdownComponents = ComponentPropsWithoutRef<
   typeof ReactMarkdown
 >["components"];
@@ -154,6 +157,7 @@ export function AgentMessageMarkdown({
   deferLongContentRender = false,
   enableImageZoom = false,
   previewMode = false,
+  renderProfile = "default",
   streaming = false
 }: AgentMessageMarkdownProps): JSX.Element {
   "use memo";
@@ -180,6 +184,7 @@ export function AgentMessageMarkdown({
   const shouldCollapse =
     collapsible && isLikelyLongerThanLineLimit(stabilizedContent);
   const isCollapsed = shouldCollapse && !isExpanded;
+  const isInlinePreview = renderProfile === "inline-preview";
   const ContainerTag = inline ? "span" : "div";
   const contentSignature = useMemo(
     () => hashMarkdownProfilerContent(stabilizedContent),
@@ -231,6 +236,9 @@ export function AgentMessageMarkdown({
   );
   const handleAnchorClickCapture = useCallback(
     (event: MouseEvent<HTMLElement>): void => {
+      if (isInlinePreview) {
+        return;
+      }
       const href = resolveMarkdownAnchorHref(event.target);
       if (!href) {
         return;
@@ -239,7 +247,7 @@ export function AgentMessageMarkdown({
       event.stopPropagation();
       handleLinkClick(href);
     },
-    [handleLinkClick]
+    [handleLinkClick, isInlinePreview]
   );
   const markdownComponents = useMemo(
     () => ({
@@ -249,22 +257,58 @@ export function AgentMessageMarkdown({
           onLinkClick={handleLinkClick}
           workspaceAppIcons={workspaceAppIcons}
           previewMode={previewMode}
+          interactiveLinks={!isInlinePreview}
         />
       ),
       code: (props: MarkdownDomProps<"code">) => (
-        <MarkdownCode {...props} onLinkClick={handleLinkClick} />
+        <MarkdownCode
+          {...props}
+          onLinkClick={isInlinePreview ? undefined : handleLinkClick}
+        />
       ),
-      img: (props: MarkdownDomProps<"img">) => (
-        <MarkdownMedia {...props} enableZoom={enableImageZoom} />
-      ),
-      p: (props: MarkdownDomProps<"p">) => (
-        <MarkdownParagraph {...props} inline={inline} />
-      ),
-      ul: MarkdownUnorderedList,
-      ol: MarkdownOrderedList,
-      li: MarkdownListItem
+      img: (props: MarkdownDomProps<"img">) =>
+        isInlinePreview ? (
+          <MarkdownMediaText {...props} />
+        ) : (
+          <MarkdownMedia {...props} enableZoom={enableImageZoom} />
+        ),
+      p: isInlinePreview
+        ? MarkdownInlineBlock
+        : (props: MarkdownDomProps<"p">) => (
+            <MarkdownParagraph {...props} inline={inline} />
+          ),
+      ...(isInlinePreview
+        ? {
+            blockquote: MarkdownInlineBlock,
+            h1: MarkdownInlineBlock,
+            h2: MarkdownInlineBlock,
+            h3: MarkdownInlineBlock,
+            h4: MarkdownInlineBlock,
+            h5: MarkdownInlineBlock,
+            h6: MarkdownInlineBlock,
+            hr: MarkdownInlineBlock,
+            pre: MarkdownInlineBlock,
+            table: MarkdownInlineBlock,
+            tbody: MarkdownInlineBlock,
+            td: MarkdownInlineBlock,
+            th: MarkdownInlineBlock,
+            thead: MarkdownInlineBlock,
+            tr: MarkdownInlineBlock,
+            input: MarkdownInlineHiddenInput
+          }
+        : {}),
+      ul: isInlinePreview ? MarkdownInlineBlock : MarkdownUnorderedList,
+      ol: isInlinePreview ? MarkdownInlineBlock : MarkdownOrderedList,
+      li: isInlinePreview ? MarkdownInlineListItem : MarkdownListItem
     }),
-    [enableImageZoom, handleLinkClick, inline, previewMode, workspaceAppIcons]
+    [
+      enableImageZoom,
+      handleLinkClick,
+      inline,
+      isInlinePreview,
+      previewMode,
+      workspaceAppIcons
+    ]
   );
 
   return (
@@ -604,16 +648,27 @@ function MarkdownLink({
   onLinkClick,
   workspaceAppIcons,
   previewMode,
+  interactiveLinks = true,
   href,
   ...props
 }: MarkdownDomProps<"a"> & {
   onLinkClick?: (href: string) => void;
   workspaceAppIcons?: readonly AgentMessageMarkdownWorkspaceAppIcon[];
   previewMode?: boolean;
+  interactiveLinks?: boolean;
 }): JSX.Element {
   "use memo";
   const { t } = useTranslation();
   const targetHref = href?.trim() ?? "";
+  if (!interactiveLinks) {
+    return (
+      <MarkdownLinkContext.Provider value={true}>
+        <span className={props.className} title={props.title}>
+          {props.children}
+        </span>
+      </MarkdownLinkContext.Provider>
+    );
+  }
   const mention = targetHref
     ? parseMentionLink(
         targetHref,
@@ -1209,6 +1264,19 @@ function MarkdownMedia({
   );
 }
 
+function MarkdownMediaText({
+  node: _node,
+  alt,
+  title
+}: MarkdownDomProps<"img">): JSX.Element | null {
+  "use memo";
+  const label = String(alt || title || "").trim();
+  if (!label) {
+    return null;
+  }
+  return <span>{label}</span>;
+}
+
 function UnsupportedMarkdownMediaPreview(): JSX.Element {
   const { t } = useTranslation();
   return (
@@ -1278,6 +1346,35 @@ function MarkdownListItem({
 }: MarkdownDomProps<"li">): JSX.Element {
   "use memo";
   return <li {...props} style={{ ...MARKDOWN_LIST_ITEM_STYLE, ...style }} />;
+}
+
+function MarkdownInlineBlock({
+  node: _node,
+  children
+}: {
+  node?: unknown;
+  children?: ReactNode;
+}): JSX.Element {
+  "use memo";
+  return <span>{children} </span>;
+}
+
+function MarkdownInlineListItem({
+  node: _node,
+  children
+}: {
+  node?: unknown;
+  children?: ReactNode;
+}): JSX.Element {
+  "use memo";
+  return <span>{children} </span>;
+}
+
+function MarkdownInlineHiddenInput({
+  node: _node
+}: MarkdownDomProps<"input">): null {
+  "use memo";
+  return null;
 }
 
 function MarkdownParagraph({


### PR DESCRIPTION
## Summary

Fix collapsed Agent Message Center stack previews rendering Markdown syntax as plain text.

Expanded message cards already render summaries through `AgentMessageMarkdown`, but collapsed stack previews rendered the summary string directly. As a result, assistant summaries such as `**跳过总结**` could show raw Markdown markers in the stack preview.

This change makes collapsed stack previews use the existing `AgentMessageMarkdown` renderer in inline preview mode, so formatting is consistent with expanded cards.

## Changes

- Render `MessageCenterStackSummary` preview text with `AgentMessageMarkdown`.
- Add a regression test for bold Markdown in collapsed stack previews.

## Tests

- `node_modules/.bin/vitest run --config vitest.config.ts agent-message-center/WorkspaceAgentMessageCenterPanel.spec.tsx`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Updated agent message-center collapsed stack previews to use an inline markdown preview with consistent two-line truncation and improved typography.
  * Added an `inline-preview` rendering mode for message markdown to suppress interactive link behavior and use simplified inline media output.
* **Bug Fixes**
  * “Working” stack previews now render markdown (e.g., bold) without showing raw markdown markers, and embedded links/media no longer appear as interactive elements.
* **Tests**
  * Added coverage to verify inline-preview rendering (bold/strong, no link elements, and omission of unsupported block-level constructs like lists, images, and tables).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->