### PR TITLE
fix(browser-node): keep guest devtools visible

### DIFF
--- a/apps/desktop/src/main/ipc/browser.ts
+++ b/apps/desktop/src/main/ipc/browser.ts
@@ -1,4 +1,10 @@
-import { ipcMain, nativeTheme, shell, webContents } from "electron";
+import {
+  BrowserWindow,
+  ipcMain,
+  nativeTheme,
+  shell,
+  webContents
+} from "electron";
 import { fileURLToPath } from "node:url";
 import { registerBrowserNodeElectronMain } from "@tutti-os/browser-node/electron-main";
 import type { BrowserNodeElectronLogger } from "@tutti-os/browser-node/electron-main";
@@ -56,6 +62,9 @@ export function registerBrowserIpc(
       return resolveOwnerWindowFromEvent(event as Electron.IpcMainInvokeEvent);
     },
     getPreferredColorScheme: () => getPreferredColorScheme(preferences),
+    focusDevTools: (contents) => {
+      focusBrowserNodeDevToolsWindow(contents, logger);
+    },
     logger,
     openExternal: (url) => openBrowserNodeExternalUrl(url, logger),
     registerHandler(channel, handler) {
@@ -141,6 +150,32 @@ export function registerBrowserIpc(
       webContentsId: event.sender.id
     });
   });
+}
+
+function focusBrowserNodeDevToolsWindow(
+  contents: unknown,
+  logger: BrowserNodeElectronLogger
+): void {
+  const devToolsContents = (contents as Electron.WebContents)
+    .devToolsWebContents;
+  if (!devToolsContents || devToolsContents.isDestroyed()) {
+    return;
+  }
+
+  devToolsContents.focus();
+  const devToolsWindow = BrowserWindow.fromWebContents(devToolsContents);
+  if (!devToolsWindow || devToolsWindow.isDestroyed()) {
+    logger.debug?.("Browser Node devtools window unavailable for focus");
+    return;
+  }
+
+  if (devToolsWindow.isMinimized()) {
+    devToolsWindow.restore();
+  }
+  devToolsWindow.show();
+  devToolsWindow.focus();
+  devToolsWindow.moveTop();
+  devToolsWindow.setAlwaysOnTop(true, "floating");
 }
 
 function isBrowserDevToolsEnabled(): boolean {

--- a/packages/browser/workbench-node/src/electron-main/electronMain.test.ts
+++ b/packages/browser/workbench-node/src/electron-main/electronMain.test.ts
@@ -505,8 +505,12 @@ test("manages Browser Node guest lifecycle with mocked web contents", async () =
 
 test("opens Browser Node guest devtools for a registered node", async () => {
   const contents = new MockBrowserGuestWebContents(15);
+  const focusedContentsIds: number[] = [];
   const manager = createBrowserGuestManager({
     emit: () => undefined,
+    focusDevTools: (nextContents) => {
+      focusedContentsIds.push(nextContents.id ?? -1);
+    },
     openExternal: () => undefined,
     resolveWebContents: (id) => (id === contents.id ? contents : null)
   });
@@ -525,6 +529,7 @@ test("opens Browser Node guest devtools for a registered node", async () => {
   assert.deepEqual(contents.openDevToolsOptions, [
     { activate: true, mode: "detach" }
   ]);
+  assert.deepEqual(focusedContentsIds, [15]);
 });
 
 test("blocks cross-origin Browser Node guest navigation for policy-bound sessions", async () => {
@@ -775,6 +780,7 @@ test("registerBrowserNodeElectronMain routes guest open-url IPC through the owne
 
 test("registerBrowserNodeElectronMain routes open devtools IPC through the owner manager", async () => {
   const contents = new MockBrowserGuestWebContents(16);
+  const focusedContentsIds: number[] = [];
   const handlers = new Map<
     string,
     (event: unknown, payload: unknown) => unknown
@@ -803,6 +809,9 @@ test("registerBrowserNodeElectronMain routes open devtools IPC through the owner
       unregisterGuest: "browser:unregisterGuest"
     },
     getOwnerWindow: () => ownerWindow as never,
+    focusDevTools(nextContents) {
+      focusedContentsIds.push(nextContents.id ?? -1);
+    },
     openExternal: () => undefined,
     registerHandler(channel, handler) {
       handlers.set(channel, handler as never);
@@ -826,6 +835,7 @@ test("registerBrowserNodeElectronMain routes open devtools IPC through the owner
   );
 
   assert.equal(contents.openDevToolsCalls, 1);
+  assert.deepEqual(focusedContentsIds, [16]);
 });
 
 test("registerBrowserNodeElectronMain opens devtools from a native context menu action", async () => {

--- a/packages/browser/workbench-node/src/electron-main/guestManager.ts
+++ b/packages/browser/workbench-node/src/electron-main/guestManager.ts
@@ -233,6 +233,7 @@ async function applyPreferredColorSchemeToGuest(
 
 export function createBrowserGuestManager({
   emit,
+  focusDevTools,
   getPreferredColorScheme,
   logger,
   openExternal,
@@ -685,6 +686,7 @@ export function createBrowserGuestManager({
       if (contents && !contents.isDestroyed()) {
         try {
           contents.openDevTools?.({ activate: true, mode: "detach" });
+          focusDevTools?.(contents);
         } catch (error) {
           logger?.warn?.("Browser Node open devtools failed", {
             error: error instanceof Error ? error.message : String(error),

--- a/packages/browser/workbench-node/src/electron-main/registerElectronMain.ts
+++ b/packages/browser/workbench-node/src/electron-main/registerElectronMain.ts
@@ -51,6 +51,7 @@ export interface RegisterBrowserNodeElectronMainInput {
   readonly channels: BrowserNodeElectronMainChannels;
   readonly getOwnerWindow: (event: unknown) => BrowserWindow | null;
   readonly getPreferredColorScheme?: () => BrowserPreferredColorScheme;
+  readonly focusDevTools?: (contents: BrowserGuestWebContents) => void;
   readonly logger?: BrowserNodeElectronLogger;
   readonly loopbackPreviewRouting?: BrowserNodeLoopbackPreviewRoutingOptions;
   readonly openExternal: (url: string) => Promise<void> | void;
@@ -120,6 +121,7 @@ export function registerBrowserNodeElectronMain(
           ownerWindow.webContents.send(input.channels.event, browserEvent);
         }
       },
+      focusDevTools: input.focusDevTools,
       getPreferredColorScheme: input.getPreferredColorScheme,
       logger: input.logger,
       openExternal: input.openExternal,

--- a/packages/browser/workbench-node/src/electron-main/types.ts
+++ b/packages/browser/workbench-node/src/electron-main/types.ts
@@ -42,6 +42,7 @@ export interface BrowserGuestManagerInput {
   emit: (event: BrowserNodeEvent) => void;
   getPreferredColorScheme?: () => BrowserPreferredColorScheme;
   logger?: BrowserNodeElectronLogger;
+  focusDevTools?: (contents: BrowserGuestWebContents) => void;
   openExternal: (url: string) => Promise<void> | void;
   prepareSession?: (
     input: BrowserNodePrepareSessionInput


### PR DESCRIPTION
## Summary
- keep Browser Node guest DevTools in detached mode without closing/reopening it
- after opening DevTools, focus its WebContents and bring the detached DevTools window to the front
- keep the detached DevTools window always-on-top so it is not hidden behind the Tutti workspace window
- cover the focus callback path in electron-main tests

## Testing
- node --test --experimental-strip-types packages/browser/workbench-node/src/electron-main/electronMain.test.ts --test-name-pattern "devtools|DevTools|focus"
- node tools/scripts/run-tsgo-typecheck.mjs --package-root packages/browser/workbench-node
- pnpm --filter @tutti-os/desktop typecheck
- pnpm lint:ts
- pnpm --filter @tutti-os/desktop build

## Documentation
- No documentation impact found; no durable docs updated.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * DevTools opening for browser node guests now reliably brings the DevTools window into focus after it opens, including when DevTools are already open.
  * DevTools focus behavior is improved for requests routed through the owner manager, ensuring the expected registered contents receive focus.
* **Tests**
  * Added assertions to verify focus occurs for the correct registered web contents when opening DevTools directly and via IPC routing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->