### PR TITLE
fix(agent-gui): show composer settings controls with a loading hint while options load

### DIFF
--- a/packages/agent/gui/agent-gui/agentGuiNode/AgentComposer.spec.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/AgentComposer.spec.tsx
@@ -3233,6 +3233,7 @@ function createLabels(): Parameters<typeof AgentComposer>[0]["labels"] {
     modelContextWindowSuffix: "上下文窗口",
     modelTooltipVersionLabel: "版本",
     defaultModel: "默认模型",
+    loadingOptions: "正在加载",
     inheritedUnavailable: "不可用",
     loadingConversation: "加载会话中",
     reasoningLabel: "推理",

--- a/packages/agent/gui/agent-gui/agentGuiNode/AgentComposer.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/AgentComposer.tsx
@@ -193,6 +193,7 @@ export interface AgentComposerProps {
     modelContextWindowSuffix: string;
     modelTooltipVersionLabel: string;
     defaultModel: string;
+    loadingOptions: string;
     inheritedUnavailable: string;
     loadingConversation: string;
     reasoningLabel: string;
@@ -2772,7 +2773,8 @@ export function AgentComposer({
                   disabled={settingsControlsDisabled}
                   previewMode={previewMode}
                   labels={{
-                    permissionLabel: labels.permissionLabel
+                    permissionLabel: labels.permissionLabel,
+                    loadingOptions: labels.loadingOptions
                   }}
                   onSettingsChange={(patch) => onSettingsChange(patch)}
                 />
@@ -2809,8 +2811,8 @@ export function AgentComposer({
                     permissionLabel: labels.permissionLabel,
                     modelDescriptions: labels.modelDescriptions,
                     defaultModel: labels.defaultModel,
-                    inheritedUnavailable: labels.inheritedUnavailable,
-                    loadingSettings: labels.loadingConversation
+                    loadingOptions: labels.loadingOptions,
+                    inheritedUnavailable: labels.inheritedUnavailable
                   }}
                   onSettingsChange={onSettingsChange}
                 />

--- a/packages/agent/gui/agent-gui/agentGuiNode/AgentComposerSettingsMenus.spec.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/AgentComposerSettingsMenus.spec.tsx
@@ -118,11 +118,9 @@ describe("AgentProjectDropdown", () => {
     const trigger = screen.getByRole("combobox", { name: "Project" });
     expect(trigger).toHaveTextContent("No project");
     expect(trigger.querySelector(".lucide-folder")).toBeNull();
-    expect(mockAgentHostApi.userProjects.isNoProjectPath).toHaveBeenCalledWith(
-      {
-        path: noProjectPath
-      }
-    );
+    expect(mockAgentHostApi.userProjects.isNoProjectPath).toHaveBeenCalledWith({
+      path: noProjectPath
+    });
   });
 
   it("opens the project folder menu through ui-system Select layering", async () => {
@@ -1166,7 +1164,10 @@ function openComposerSubmenu(trigger: HTMLElement): void {
   fireEvent.click(trigger);
 }
 
-function renderPermissionModeDropdown(permissionMode: string) {
+function renderPermissionModeDropdown(
+  permissionMode: string,
+  overrides: Partial<AgentGUIComposerSettingsVM> = {}
+) {
   return render(
     <TooltipProvider>
       <AgentPermissionModeDropdown
@@ -1204,7 +1205,8 @@ function renderPermissionModeDropdown(permissionMode: string) {
               label: "Full access",
               description: "Can make changes and run commands directly."
             }
-          ]
+          ],
+          ...overrides
         }}
         labels={labels}
         onSettingsChange={vi.fn()}
@@ -1220,6 +1222,29 @@ describe("AgentPermissionModeDropdown", () => {
     expect(
       screen.getByRole("combobox", { name: "Run permissions" })
     ).toHaveAttribute("data-permission-tone", "success");
+  });
+
+  it("wires a loading hint tooltip while composer options load", () => {
+    renderPermissionModeDropdown("full-access", {
+      isSettingsLoading: true,
+      availablePermissionModes: []
+    });
+    const combobox = screen.getByRole("combobox", { name: "Run permissions" });
+    const wrapper = combobox.closest("span[tabindex]");
+    expect(wrapper).not.toBeNull();
+    expect(wrapper).toHaveAttribute("data-state");
+    // The trigger must show the loading copy, never the raw permission-mode id.
+    expect(combobox).toHaveTextContent("Loading…");
+    expect(combobox).not.toHaveTextContent("full-access");
+  });
+
+  it("omits the loading hint once permission options are available", () => {
+    renderPermissionModeDropdown("read-only");
+    expect(
+      screen
+        .getByRole("combobox", { name: "Run permissions" })
+        .closest("span[tabindex]")
+    ).toBeNull();
   });
 
   it("colors the ask for approval trigger when the selected value is display text", () => {
@@ -1503,11 +1528,13 @@ describe("AgentModelReasoningDropdown", () => {
     return {
       onSettingsChange,
       ...render(
-        <AgentModelReasoningDropdown
-          composerSettings={composerSettings}
-          labels={labels}
-          onSettingsChange={onSettingsChange}
-        />
+        <TooltipProvider>
+          <AgentModelReasoningDropdown
+            composerSettings={composerSettings}
+            labels={labels}
+            onSettingsChange={onSettingsChange}
+          />
+        </TooltipProvider>
       )
     };
   }
@@ -1665,6 +1692,22 @@ describe("AgentModelReasoningDropdown", () => {
     expect(modelReasoningTrigger()).toHaveClass("animate-pulse");
   });
 
+  it("wires a loading hint tooltip while the model list loads", () => {
+    renderModelReasoning({ isModelOptionsLoading: true });
+    // The trigger is wrapped in a focusable span so the loading tooltip can
+    // surface even when the (disabled) trigger swallows pointer events.
+    const wrapper = modelReasoningTrigger().closest("span[tabindex]");
+    expect(wrapper).not.toBeNull();
+    // Radix marks its tooltip trigger with data-state, confirming the span is
+    // the loading-hint tooltip's trigger rather than a bare wrapper.
+    expect(wrapper).toHaveAttribute("data-state");
+  });
+
+  it("omits the loading hint once models are available", () => {
+    renderModelReasoning({ isModelOptionsLoading: false });
+    expect(modelReasoningTrigger().closest("span[tabindex]")).toBeNull();
+  });
+
   it("shows model details in right-side row tooltips", async () => {
     render(
       <TooltipProvider>
@@ -1774,8 +1817,8 @@ const labels = {
   modelContextWindowSuffix: "context window",
   modelTooltipVersionLabel: "Version",
   defaultModel: "Default model",
+  loadingOptions: "Loading…",
   inheritedUnavailable: "Unavailable",
-  loadingSettings: "Loading conversation",
   reasoningLabel: "Reasoning",
   reasoningDegreeLabel: "Reasoning degree",
   reasoningOptionDefault: "Default",

--- a/packages/agent/gui/agent-gui/agentGuiNode/AgentComposerSettingsMenus.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/AgentComposerSettingsMenus.tsx
@@ -202,7 +202,10 @@ export function AgentPermissionModeDropdown({
   composerSettings: AgentGUIComposerSettingsVM;
   disabled?: boolean;
   previewMode?: boolean;
-  labels: Pick<AgentComposerSettingsMenuLabels, "permissionLabel">;
+  labels: Pick<
+    AgentComposerSettingsMenuLabels,
+    "permissionLabel" | "loadingOptions"
+  >;
   onSettingsChange: (patch: {
     permissionModeId?: string | null;
     planMode?: boolean;
@@ -210,6 +213,12 @@ export function AgentPermissionModeDropdown({
 }): React.JSX.Element {
   "use memo";
   const [isSelectOpen, setIsSelectOpen] = useState(false);
+  // While the daemon's composer options load, the permission options are empty
+  // and the trigger is disabled; surface a hover hint so the user knows it is
+  // still loading rather than permanently unavailable.
+  const isLoading =
+    composerSettings.isSettingsLoading ||
+    composerSettings.isModelOptionsLoading === true;
   const availableOptions = composerSettings.availablePermissionModes ?? [];
   const selectedValue =
     composerSettings.selectedPermissionModeValue ??
@@ -227,8 +236,14 @@ export function AgentPermissionModeDropdown({
     permissionOptions.length === 0;
   const selectedOption =
     permissionOptions.find((option) => option.value === selectedValue) ?? null;
-  const triggerLabel =
-    selectedOption?.label ?? selectedValue?.trim() ?? labels.permissionLabel;
+  // While loading, the permission options are empty and `selectedValue` is a
+  // raw mode id (e.g. "full-access"); show the loading copy instead so the
+  // trigger never surfaces an untranslated enum value.
+  const triggerLabel = isLoading
+    ? labels.loadingOptions
+    : (selectedOption?.label ??
+      selectedValue?.trim() ??
+      labels.permissionLabel);
   const triggerTone = selectDisabled
     ? undefined
     : resolvePermissionModeTriggerTone(selectedValue);
@@ -277,6 +292,24 @@ export function AgentPermissionModeDropdown({
     return trigger;
   }
 
+  const selectTrigger = (
+    <SelectTrigger
+      className={cn(
+        "w-auto max-w-full",
+        styles.composerMenuTrigger,
+        selectDisabled &&
+          "cursor-not-allowed text-[var(--agent-gui-text-tertiary)] opacity-60 hover:text-[var(--agent-gui-text-tertiary)]",
+        isLoading && "animate-pulse"
+      )}
+      aria-label={labels.permissionLabel}
+      data-permission-tone={triggerTone}
+    >
+      <span className="flex min-w-0 flex-1 items-center">
+        <span className="truncate">{triggerLabel}</span>
+      </span>
+    </SelectTrigger>
+  );
+
   return (
     <Select
       open={isSelectOpen}
@@ -285,21 +318,21 @@ export function AgentPermissionModeDropdown({
       onOpenChange={setIsSelectOpen}
       onValueChange={applyPermissionModeId}
     >
-      <SelectTrigger
-        className={cn(
-          "w-auto max-w-full",
-          styles.composerMenuTrigger,
-          selectDisabled &&
-            "cursor-not-allowed text-[var(--agent-gui-text-tertiary)] opacity-60 hover:text-[var(--agent-gui-text-tertiary)]",
-          composerSettings.isSettingsLoading && "animate-pulse"
-        )}
-        aria-label={labels.permissionLabel}
-        data-permission-tone={triggerTone}
-      >
-        <span className="flex min-w-0 flex-1 items-center">
-          <span className="truncate">{triggerLabel}</span>
-        </span>
-      </SelectTrigger>
+      {isLoading ? (
+        // The trigger is disabled while loading, so pointer events never reach
+        // it. Target the tooltip at a focusable wrapper span (Radix's pattern
+        // for disabled triggers) so hover/focus reliably surfaces the hint.
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <span className="inline-flex" tabIndex={0}>
+              {selectTrigger}
+            </span>
+          </TooltipTrigger>
+          <TooltipContent side="top">{labels.loadingOptions}</TooltipContent>
+        </Tooltip>
+      ) : (
+        selectTrigger
+      )}
       {isSelectOpen ? (
         <SelectContent
           align="end"
@@ -496,6 +529,12 @@ export function AgentModelReasoningDropdown({
   const [menuOpen, setMenuOpen] = useState(false);
   const menu = buildComposerModelMenuModel(composerSettings, labels);
   const menuDisabled = disabled || menu.disabled;
+  // While the model list is still loading the trigger shows a placeholder
+  // ("Default") that reads like a real selection. Surface a hover hint so the
+  // user knows the list is still loading rather than already resolved.
+  const isModelLoading =
+    composerSettings.isModelOptionsLoading ||
+    composerSettings.isSettingsLoading;
   const applySettingsChange = (patch: {
     model?: string;
     reasoningEffort?: string;
@@ -547,9 +586,25 @@ export function AgentModelReasoningDropdown({
 
   return (
     <DropdownMenu open={menuOpen} onOpenChange={setMenuOpen}>
-      <DropdownMenuTrigger asChild disabled={menuDisabled}>
-        {trigger}
-      </DropdownMenuTrigger>
+      {isModelLoading ? (
+        // The trigger is disabled while loading, so pointer events never reach
+        // it. Target the tooltip at a focusable wrapper span (Radix's pattern
+        // for disabled triggers) so hover/focus reliably surfaces the hint.
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <span className="inline-flex" tabIndex={0}>
+              <DropdownMenuTrigger asChild disabled={menuDisabled}>
+                {trigger}
+              </DropdownMenuTrigger>
+            </span>
+          </TooltipTrigger>
+          <TooltipContent side="top">{labels.loadingOptions}</TooltipContent>
+        </Tooltip>
+      ) : (
+        <DropdownMenuTrigger asChild disabled={menuDisabled}>
+          {trigger}
+        </DropdownMenuTrigger>
+      )}
       <DropdownMenuContent
         align="end"
         side="top"

--- a/packages/agent/gui/agent-gui/agentGuiNode/AgentGUINode.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/AgentGUINode.tsx
@@ -743,6 +743,7 @@ export const AgentGUINode = memo(function AgentGUINode({
         "agentHost.agentGui.modelTooltipVersionLabel"
       ),
       defaultModel: t("agentHost.agentGui.defaultModel"),
+      loadingOptions: t("agentHost.agentGui.loadingOptions"),
       inheritedUnavailable: t("agentHost.agentGui.inheritedUnavailable"),
       reasoningLabel: t("agentHost.agentGui.reasoningLabel"),
       reasoningDegreeLabel: t("agentHost.agentGui.reasoningDegreeLabel"),

--- a/packages/agent/gui/agent-gui/agentGuiNode/AgentGUINodeView.layout.spec.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/AgentGUINodeView.layout.spec.tsx
@@ -1734,6 +1734,7 @@ function createLabels(): AgentGUIViewLabels {
     modelContextWindowSuffix: "context window",
     modelTooltipVersionLabel: "Version",
     defaultModel: "defaultModel",
+    loadingOptions: "loadingOptions",
     inheritedUnavailable: "inheritedUnavailable",
     reasoningLabel: "reasoning",
     reasoningDegreeLabel: "reasoningDegreeLabel",

--- a/packages/agent/gui/agent-gui/agentGuiNode/AgentGUINodeView.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/AgentGUINodeView.tsx
@@ -216,6 +216,7 @@ export interface AgentGUIViewLabels {
   modelContextWindowSuffix: string;
   modelTooltipVersionLabel: string;
   defaultModel: string;
+  loadingOptions: string;
   inheritedUnavailable: string;
   reasoningLabel: string;
   reasoningDegreeLabel: string;
@@ -1811,6 +1812,7 @@ const AgentGUIDetailPane = memo(function AgentGUIDetailPane({
       modelContextWindowSuffix: labels.modelContextWindowSuffix,
       modelTooltipVersionLabel: labels.modelTooltipVersionLabel,
       defaultModel: labels.defaultModel,
+      loadingOptions: labels.loadingOptions,
       inheritedUnavailable: labels.inheritedUnavailable,
       loadingConversation: labels.loadingConversation,
       reasoningLabel: labels.reasoningLabel,
@@ -2027,8 +2029,9 @@ const AgentGUIDetailPane = memo(function AgentGUIDetailPane({
   const stableRequestWorkspaceReferences = useOptionalStableEventCallback(
     onRequestWorkspaceReferences
   );
-  const stableSelectProjectDirectory =
-    useOptionalStableEventCallback(selectProjectDirectory);
+  const stableSelectProjectDirectory = useOptionalStableEventCallback(
+    selectProjectDirectory
+  );
   const stableRequestGitBranches =
     useOptionalStableEventCallback(onRequestGitBranches);
   const authLogin = useOptionalStableEventCallback(onAgentProviderLogin);

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUINodeController.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUINodeController.ts
@@ -8821,6 +8821,13 @@ export function useAgentGUINodeController({
       activeSessionRuntimeContext,
       "models"
     );
+    // Before the daemon's composer options arrive, the options-derived
+    // `composerSupport` is all-false, which would hide every settings control
+    // and leave an empty row. Fall back to the provider-static capabilities
+    // while loading so the controls still render (disabled, with a loading
+    // hint); once options load, the accurate options-derived flags take over.
+    const optionsLoading = isSettingsLoading || isModelOptionsLoading;
+    const providerSupport = composerSupportForProvider(data.provider);
     const selectedModelValue = draftModel;
     const selectedReasoningEffortValue =
       draftReasoningEffort as AgentSessionReasoningEffort | null;
@@ -8842,12 +8849,17 @@ export function useAgentGUINodeController({
           draftSettings.permissionModeId
         )
       },
-      supportsModel: composerSupport.model,
-      supportsReasoningEffort: composerSupport.reasoning,
+      supportsModel:
+        composerSupport.model || (optionsLoading && providerSupport.model),
+      supportsReasoningEffort:
+        composerSupport.reasoning ||
+        (optionsLoading && providerSupport.reasoning),
       supportsSpeed: composerSupport.speed,
       supportsBrowser: composerSupport.browser,
       supportsComputerUse: composerSupport.computer,
-      supportsPermissionMode,
+      supportsPermissionMode:
+        supportsPermissionMode ||
+        (optionsLoading && providerSupport.permission),
       supportsPlanMode: composerSupport.plan,
       planExclusiveWithPermissionMode: data.provider === "claude-code",
       isSettingsLoading,

--- a/packages/agent/gui/agent-gui/agentGuiNode/model/composerSettingsMenuModel.spec.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/model/composerSettingsMenuModel.spec.ts
@@ -12,8 +12,8 @@ const labels: AgentComposerSettingsMenuLabels = {
   modelContextWindowSuffix: "context window",
   modelTooltipVersionLabel: "Version",
   defaultModel: "Default model",
+  loadingOptions: "Loading…",
   inheritedUnavailable: "Unavailable",
-  loadingSettings: "Loading",
   reasoningLabel: "Reasoning",
   reasoningDegreeLabel: "Reasoning degree",
   reasoningOptionDefault: "Default",
@@ -270,6 +270,36 @@ describe("buildComposerModelMenuModel", () => {
     expect(menu.model.show).toBe(true);
     expect(menu.reasoning.show).toBe(false);
     expect(menu.speed.show).toBe(false);
+  });
+
+  it("shows the loading copy on the trigger while options load", () => {
+    // No model resolved yet — the placeholder must read as loading, not the
+    // "Default" fallback (which looks like a real choice).
+    const loadingVm = (overrides: Partial<AgentGUIComposerSettingsVM>) =>
+      vm({
+        availableModels: [],
+        draftSettings: {
+          model: null,
+          reasoningEffort: null,
+          speed: null,
+          planMode: false,
+          permissionModeId: null
+        },
+        selectedModelValue: null,
+        ...overrides
+      });
+    expect(
+      buildComposerModelMenuModel(
+        loadingVm({ isSettingsLoading: true }),
+        labels
+      ).trigger.modelLabel
+    ).toBe("Loading…");
+    expect(
+      buildComposerModelMenuModel(
+        loadingVm({ isModelOptionsLoading: true }),
+        labels
+      ).trigger.modelLabel
+    ).toBe("Loading…");
   });
 
   it("disables the menu while settings load or nothing is configurable", () => {

--- a/packages/agent/gui/agent-gui/agentGuiNode/model/composerSettingsMenuModel.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/model/composerSettingsMenuModel.ts
@@ -9,8 +9,8 @@ export type AgentComposerSettingsMenuLabels = {
   modelContextWindowSuffix: string;
   modelTooltipVersionLabel: string;
   defaultModel: string;
+  loadingOptions: string;
   inheritedUnavailable: string;
-  loadingSettings: string;
   reasoningLabel: string;
   reasoningDegreeLabel: string;
   reasoningOptionDefault: string;
@@ -414,7 +414,7 @@ function resolveSelectedModelLabel(
   composerSettings: AgentGUIComposerSettingsVM,
   labels: Pick<
     AgentComposerSettingsMenuLabels,
-    "defaultModel" | "inheritedUnavailable" | "loadingSettings"
+    "defaultModel" | "inheritedUnavailable" | "loadingOptions"
   >
 ): string {
   const selectedValue = selectedComposerModelValue(composerSettings);
@@ -424,11 +424,16 @@ function resolveSelectedModelLabel(
   if (selected) {
     return shortModelDisplayLabel(selected.label);
   }
+  // While composer options load, show a clear loading placeholder rather than
+  // falling through to the "Default" label (which reads like a real choice).
+  if (
+    composerSettings.isSettingsLoading ||
+    composerSettings.isModelOptionsLoading === true
+  ) {
+    return labels.loadingOptions;
+  }
   if (composerSettings.modelUnavailable) {
     return labels.inheritedUnavailable;
-  }
-  if (composerSettings.isSettingsLoading) {
-    return labels.loadingSettings;
   }
   const firstAvailableModel = composerSettings.availableModels[0]?.label;
   if (firstAvailableModel) {

--- a/packages/agent/gui/app/renderer/i18n/locales/en.ts
+++ b/packages/agent/gui/app/renderer/i18n/locales/en.ts
@@ -362,6 +362,7 @@ export const en = {
       modelLabel: "Model",
       modelSelectionLabel: "Model selection",
       defaultModel: "Default model",
+      loadingOptions: "Loading…",
       inheritedUnavailable: "Inherited / unavailable",
       reasoningLabel: "Reasoning",
       reasoningDegreeLabel: "Reasoning level",

--- a/packages/agent/gui/app/renderer/i18n/locales/zh-CN.ts
+++ b/packages/agent/gui/app/renderer/i18n/locales/zh-CN.ts
@@ -333,6 +333,7 @@ export const zhCN = {
       modelLabel: "模型",
       modelSelectionLabel: "模型选择",
       defaultModel: "默认模型",
+      loadingOptions: "正在加载",
       inheritedUnavailable: "继承 / 不可用",
       reasoningLabel: "推理强度",
       reasoningDegreeLabel: "推理程度",


### PR DESCRIPTION
## 背景 / Problem

新开一个会话时，composer 底部的「权限」「模型/推理」下拉选择器所在的一整行是**空白的**，直到 daemon 下发 composer options 后才突然出现。

根因：这些控件的展示由 options-derived 的 `composerSupport`（`composerSettingsSupportFromOptions`）门控，而它在选项到达前**全部为 `false`** → 两个下拉都渲染成 `null` → 空行。即使勉强展示，触发器文案也不对：模型显示 `Default` / `正在加载会话…`，权限直接暴露原始枚举 id `full-access`。

期望：加载期**控件照常展示**，点击禁用，并给出「正在加载」的占位文案 + hover tooltip。

## 改动 / Fix

- **controller** (`useAgentGUINodeController.ts`)：加载窗口期（`isSettingsLoading || isModelOptionsLoading`）将 support 门控**回退到 provider 静态能力** `composerSupportForProvider(data.provider)`（仓库里本就为"选项未就绪"准备的标志），选项到达后交还给准确的 options-derived 标志。只对本就支持该控件的 provider 生效（如 gemini 无权限选择则加载期也不展示）。
- **统一加载文案**：新增通用标签 `loadingOptions`（`正在加载` / `Loading…`），模型与权限触发器加载期都显示它，替代原先的 `Default` / `正在加载会话…` / 原始 mode-id。
- **加载 tooltip**：两个触发器在加载期都挂一个可聚焦 wrapper span 上的 tooltip（Radix 对 disabled trigger 的标准做法，避免 disabled 按钮吞掉指针事件）。
- **清理**：移除不再使用的 `loadingSettings` 菜单标签。

## 验证 / Verification

- `pnpm typecheck` 通过；pre-commit boundary/lint 检查通过。
- 相关 5 个 spec 共 **161 测试全过**，含新增断言：
  - 模型 trigger 加载期为 `Loading…`（`isSettingsLoading` 与 `isModelOptionsLoading` 两条路径）。
  - 权限 trigger 加载期为 `Loading…` 且**绝不含 `full-access`**。
  - 两个 trigger 加载期挂载 / 加载完成卸载 loading tooltip。
- 全量套件唯一失败为 `AgentFileMentionPalette.spec.tsx`，已在未改动 baseline 上复现，**与本 PR 无关**。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added clearer loading text in the agent composer and settings menus.
  * Loading states now show “Loading…” / “正在加载” instead of blank or fallback values.

* **Bug Fixes**
  * Kept composer settings visible while options are still loading.
  * Improved loading behavior for model and permission selectors, including tooltip hints on disabled controls.
  * Ensured model selection shows a loading placeholder until options are ready.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->