### PR TITLE
Narrow Tutti skill bundle routing prompt

### DIFF
--- a/services/tuttid/service/agentsidecar/policy_templates/skill-bundle-routing.md
+++ b/services/tuttid/service/agentsidecar/policy_templates/skill-bundle-routing.md
@@ -2,6 +2,11 @@
 
 The host application has provided a Tutti dynamic skill bundle for this run.
 
+No-mention default:
+
+- When the current user turn has no `mention://...` URI, do not treat this dynamic skill bundle by itself as routing intent. Continue with the host application's native tools, MCP servers, and system prompt unless the user explicitly asks for Tutti, a Tutti workspace/app/issue/session capability, or a command described in this bundle.
+- Do not choose Tutti routing, Tutti skills, or a shell-mediated Tutti CLI call merely because this bundle or command guide is present. This guidance does not restrict host-application tools that are needed for the user's non-Tutti task.
+
 Available Tutti skills:
 
 - `tutti-cli`: global CLI reference for workspace-wide issues, tasks, topics, and `mention://agent-session/<sessionId>?workspaceId=...` session inspection.
@@ -49,7 +54,7 @@ Fallback only when the matching Tutti skill is unavailable:
 - For `mention://agent-session/<sessionId>?workspaceId=...`, parse the session id from the URL path and start context recovery with `{{CLI_COMMAND}} agent session-summary --session-id <session-id> --json`.
   {{BROWSER_USE_HANDOFF_LINES}}{{COMPUTER_USE_HANDOFF_LINES}}
 
-Use the bundled Tutti CLI for workspace context:
+Use the bundled Tutti CLI for routed Tutti context:
 
 {{COMMAND_GUIDE}}
 

--- a/services/tuttid/service/agentsidecar/provider_skill_test.go
+++ b/services/tuttid/service/agentsidecar/provider_skill_test.go
@@ -138,6 +138,10 @@ func TestDefaultPreparerRenderSkillBundleUsesDynamicGuide(t *testing.T) {
 		t.Fatalf("recommended system prompt = %#v", bundle.RecommendedSystemPrompt)
 	}
 	for _, want := range []string{
+		"do not treat this dynamic skill bundle by itself as routing intent",
+		"unless the user explicitly asks for Tutti",
+		"Do not choose Tutti routing, Tutti skills, or a shell-mediated Tutti CLI call merely because this bundle or command guide is present.",
+		"This guidance does not restrict host-application tools that are needed for the user's non-Tutti task.",
 		"agent session id: `run-1`",
 		"provider: `codex`",
 		"tutti-dev issue list --topic-id <topic-id>",
@@ -157,6 +161,9 @@ func TestDefaultPreparerRenderSkillBundleUsesDynamicGuide(t *testing.T) {
 	if strings.Contains(bundle.RecommendedSystemPrompt.Content, "CODEX_HOME/skills/<skill>/SKILL.md") ||
 		strings.Contains(bundle.RecommendedSystemPrompt.Content, "`workspace-app/SKILL.md`") {
 		t.Fatalf("recommended system prompt should not guess materialized skill paths: %q", bundle.RecommendedSystemPrompt.Content)
+	}
+	if strings.Contains(bundle.RecommendedSystemPrompt.Content, "does not contain any `mention://...` URI, do not use Tutti CLI") {
+		t.Fatalf("recommended system prompt should not ban explicit no-mention Tutti requests: %q", bundle.RecommendedSystemPrompt.Content)
 	}
 	if strings.Contains(bundle.RecommendedSystemPrompt.Content, "# Host App Context") ||
 		strings.Contains(bundle.RecommendedSystemPrompt.Content, "The app displays images and videos using standard Markdown syntax") {


### PR DESCRIPTION
## Summary
- clarify that a dynamic skill bundle is not routing intent by itself when a host-app turn has no mention URI
- still allow explicit user requests for Tutti workspace/app/issue/session capabilities or commands from the bundle
- rename the CLI guide section to routed Tutti context and add prompt regression assertions

## Tests
- go test ./services/tuttid/service/agentsidecar

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved dynamic skill routing to ignore the presence of a skill bundle/command guide when the user’s turn contains no explicit `mention://...` request.
  * Reduced unintended shell/Bash or Tutti CLI execution triggered only by routing guidance.
  * Tightened prompt behavior so bundled guidance applies only to routed Tutti context, not general workspace context.

* **Tests**
  * Expanded assertions to verify the new “no-mention default” routing safeguards and preserve explicit user Tutti requests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->