### PR TITLE
fix(agentstatus): treat Claude Code API Usage Billing as authenticated

### DIFF
--- a/.changeset/claude-code-api-billing-auth.md
+++ b/.changeset/claude-code-api-billing-auth.md
@@ -2,4 +2,4 @@
 "@tutti-os/desktop": patch
 ---
 
-Treat Claude Code API Usage Billing as authenticated in the environment wizard. When Claude Code is configured with an Anthropic API key or a custom API endpoint, the provider status probe now reports the provider as ready instead of blocking on "未登录", since no Anthropic Console login session is required.
+Treat Claude Code API Usage Billing as authenticated in the environment wizard. When Claude Code is configured with an Anthropic API key or a custom API endpoint, the provider status probe now reports the provider as ready instead of blocking on "未登录", since no Anthropic Console login session is required. The login step label now also distinguishes between a Console OAuth session ("已登录账号") and API Usage Billing ("已配置 API 计费").

--- a/.changeset/claude-code-api-billing-auth.md
+++ b/.changeset/claude-code-api-billing-auth.md
@@ -2,4 +2,4 @@
 "@tutti-os/desktop": patch
 ---
 
-Treat Claude Code API Usage Billing as authenticated in the environment wizard. When Claude Code is configured with an Anthropic API key or a custom API endpoint, the provider status probe now reports the provider as ready instead of blocking on "未登录", since no Anthropic Console login session is required. The login step label now also distinguishes between a Console OAuth session ("已登录账号") and API Usage Billing ("已配置 API 计费").
+Treat Claude Code API Usage Billing as authenticated in the environment wizard. Claude Code can run on an API key / auth token / apiKeyHelper instead of an Anthropic Console login; `claude auth status` only reflects the stored OAuth session and is blind to those env/settings credentials, so the provider status probe now detects them directly and reports the provider as ready instead of blocking on "未登录". The login step label now distinguishes between a Console OAuth session ("已登录账号") and API Usage Billing ("已配置 API 计费"). A bare custom API endpoint without any credential is not treated as API billing, since the user may still be on an OAuth session against that endpoint.

--- a/.changeset/claude-code-api-billing-auth.md
+++ b/.changeset/claude-code-api-billing-auth.md
@@ -1,0 +1,5 @@
+---
+"@tutti-os/desktop": patch
+---
+
+Treat Claude Code API Usage Billing as authenticated in the environment wizard. When Claude Code is configured with an Anthropic API key or a custom API endpoint, the provider status probe now reports the provider as ready instead of blocking on "未登录", since no Anthropic Console login session is required.

--- a/apps/desktop/src/renderer/src/features/workspace-agent/ui/AgentEnvSetupTrack.tsx
+++ b/apps/desktop/src/renderer/src/features/workspace-agent/ui/AgentEnvSetupTrack.tsx
@@ -171,7 +171,7 @@ export function AgentEnvSetupTrack({
                     {problem
                       ? problem.headline
                       : stage.status === "ok"
-                        ? doneStageLabel(stage.id, t)
+                        ? doneStageLabel(stage.id, stage.authMethod, t)
                         : stage.label}
                   </span>
                   {stageDetailText ? (

--- a/apps/desktop/src/renderer/src/features/workspace-agent/ui/agentEnvPanelText.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-agent/ui/agentEnvPanelText.ts
@@ -81,7 +81,11 @@ export function describeStageProblem(
 // A completed step reads in the done tense ("已安装 CLI") rather than the
 // imperative track label ("安装 CLI"); the imperative is kept for pending/running
 // rows where the step is still a to-do.
-export function doneStageLabel(stageId: AgentSetupStageId, t: T): string {
+export function doneStageLabel(
+  stageId: AgentSetupStageId,
+  authMethod: string | null | undefined,
+  t: T
+): string {
   switch (stageId) {
     case "detect":
       return t("workspace.agentEnv.stageDetectDone");
@@ -92,6 +96,9 @@ export function doneStageLabel(stageId: AgentSetupStageId, t: T): string {
     case "adapter":
       return t("workspace.agentEnv.stageAdapterDone");
     case "login":
+      if (authMethod === "apiKey") {
+        return t("workspace.agentEnv.stageLoginDoneApiBilling");
+      }
       return t("workspace.agentEnv.stageLoginDone");
     case "ready":
       return t("workspace.agentEnv.stageReadyDone");

--- a/apps/desktop/src/shared/i18n/locales/en.ts
+++ b/apps/desktop/src/shared/i18n/locales/en.ts
@@ -187,6 +187,7 @@ export const en = {
       stageInstallDone: "CLI installed",
       stageAdapterDone: "Adapter installed",
       stageLoginDone: "Signed in",
+      stageLoginDoneApiBilling: "API billing configured",
       stageReadyDone: "Ready",
       networkCheckRegistry: "Install source",
       networkCheckApi: "Service API",

--- a/apps/desktop/src/shared/i18n/locales/zh-CN.ts
+++ b/apps/desktop/src/shared/i18n/locales/zh-CN.ts
@@ -184,6 +184,7 @@ export const zhCN = {
       stageInstallDone: "已安装 CLI",
       stageAdapterDone: "已安装适配器",
       stageLoginDone: "已登录账号",
+      stageLoginDoneApiBilling: "已配置 API 计费",
       stageReadyDone: "已就绪",
       networkCheckRegistry: "安装源",
       networkCheckApi: "服务接口",

--- a/packages/agent/gui/shared/agentEnv/agentEnvViewModel.spec.ts
+++ b/packages/agent/gui/shared/agentEnv/agentEnvViewModel.spec.ts
@@ -34,7 +34,11 @@ function status(
       version: "2.0.0",
       requiredVersion: "2.0.0"
     },
-    auth: { status: "authenticated", accountLabel: "me@x.com" },
+    auth: {
+      status: "authenticated",
+      accountLabel: "me@x.com",
+      authMethod: "oauth"
+    },
     actions: [],
     network: null,
     activeAction: null,
@@ -174,7 +178,7 @@ describe("buildAgentEnvWizardViewModel", () => {
       input({
         status: status({
           availability: { status: "auth_required", reasonCode: null },
-          auth: { status: "required", accountLabel: null }
+          auth: { status: "required", accountLabel: null, authMethod: null }
         })
       })
     );
@@ -185,7 +189,7 @@ describe("buildAgentEnvWizardViewModel", () => {
     const vm = buildAgentEnvWizardViewModel(
       input({
         status: status({
-          auth: { status: "required", accountLabel: null },
+          auth: { status: "required", accountLabel: null, authMethod: null },
           availability: { status: "auth_required", reasonCode: null }
         }),
         revealIndex: 0

--- a/packages/agent/gui/shared/agentEnv/agentEnvViewModel.ts
+++ b/packages/agent/gui/shared/agentEnv/agentEnvViewModel.ts
@@ -188,6 +188,7 @@ export function buildAgentEnvWizardViewModel(
     : status?.auth.status === "authenticated"
       ? { kind: "text", text: "__SIGNED_IN__" }
       : null;
+  const authMethod: string | null = status?.auth.authMethod ?? null;
 
   const stages = deriveAgentSetupStages({
     detected: status !== null,
@@ -205,6 +206,7 @@ export function buildAgentEnvWizardViewModel(
     cliVersionDetail: cliDetail,
     adapterDetail,
     accountDetail,
+    authMethod,
     networkDetail: null,
     labels: input.stageLabels
   });

--- a/packages/agent/gui/shared/agentEnv/agentEnvWizardFlow.spec.ts
+++ b/packages/agent/gui/shared/agentEnv/agentEnvWizardFlow.spec.ts
@@ -65,6 +65,7 @@ function input(
     cliVersionDetail: null,
     adapterDetail: null,
     accountDetail: null,
+    authMethod: null,
     networkDetail: null,
     labels,
     ...overrides
@@ -214,7 +215,8 @@ describe("deriveAgentSetupStages", () => {
         ready: true,
         activePhase: "done",
         cliVersionDetail: { kind: "text", text: "0.142.1" },
-        accountDetail: { kind: "text", text: "user@example.com" }
+        accountDetail: { kind: "text", text: "user@example.com" },
+        authMethod: "oauth"
       })
     );
     expect(stages.map((s) => s.status)).toEqual([
@@ -229,6 +231,21 @@ describe("deriveAgentSetupStages", () => {
       kind: "text",
       text: "user@example.com"
     });
+    expect(stage(stages, "login").authMethod).toBe("oauth");
+  });
+
+  it("carries authMethod on the login stage for API billing", () => {
+    const stages = deriveAgentSetupStages(
+      input({
+        cliInstalled: true,
+        adapterInstalled: true,
+        authenticated: true,
+        ready: true,
+        accountDetail: { kind: "text", text: "API Usage Billing" },
+        authMethod: "apiKey"
+      })
+    );
+    expect(stage(stages, "login").authMethod).toBe("apiKey");
   });
 
   it("flags the network stage as error when connectivity is unreachable", () => {

--- a/packages/agent/gui/shared/agentEnv/agentEnvWizardFlow.ts
+++ b/packages/agent/gui/shared/agentEnv/agentEnvWizardFlow.ts
@@ -35,6 +35,7 @@ export interface AgentSetupStage {
   label: string;
   status: CodexSetupStepStatus;
   detail: StageDetailToken | null;
+  authMethod?: string | null;
 }
 
 export interface AgentSetupStageLabels {
@@ -73,6 +74,7 @@ export interface DeriveAgentSetupStagesInput {
   cliVersionDetail: StageDetailToken | null;
   adapterDetail: StageDetailToken | null;
   accountDetail: StageDetailToken | null;
+  authMethod: string | null;
   networkDetail: StageDetailToken | null;
   labels: AgentSetupStageLabels;
 }
@@ -171,7 +173,8 @@ export function deriveAgentSetupStages(
       id: "login",
       label: input.labels.login,
       status: loginStatus,
-      detail: input.accountDetail
+      detail: input.accountDetail,
+      authMethod: input.authMethod
     },
     {
       id: "ready",

--- a/packages/clients/tuttid-ts/src/generated/types.gen.ts
+++ b/packages/clients/tuttid-ts/src/generated/types.gen.ts
@@ -999,6 +999,10 @@ export type AgentProviderAdapterStatus = {
 export type AgentProviderAuthInfo = {
   status: AgentProviderAuthStatus;
   accountLabel?: string | null;
+  /**
+   * The authentication method reported by the provider CLI (e.g. oauth, apiKey).
+   */
+  authMethod?: string | null;
 };
 
 export type AgentProviderStatus = {

--- a/services/tuttid/api/daemon_agent_statuses.go
+++ b/services/tuttid/api/daemon_agent_statuses.go
@@ -354,6 +354,7 @@ func generatedAgentProviderAdapterStatus(status agentstatusservice.AdapterStatus
 func generatedAgentProviderAuthInfo(auth agentstatusservice.AuthInfo) tuttigenerated.AgentProviderAuthInfo {
 	return tuttigenerated.AgentProviderAuthInfo{
 		AccountLabel: stringPointerIfNotBlank(auth.AccountLabel),
+		AuthMethod:   stringPointerIfNotBlank(auth.AuthMethod),
 		Status:       tuttigenerated.AgentProviderAuthStatus(auth.Status),
 	}
 }

--- a/services/tuttid/api/daemon_agent_statuses_test.go
+++ b/services/tuttid/api/daemon_agent_statuses_test.go
@@ -170,6 +170,56 @@ func TestDaemonAPIRoutesUnsupportedAgentProviderStatus(t *testing.T) {
 	}
 }
 
+func TestDaemonAPIRoutesAgentProviderAuthIncludesAuthMethod(t *testing.T) {
+	mux := http.NewServeMux()
+	RegisterRoutes(mux, NewRoutes(DaemonAPI{
+		AgentStatusService: stubAgentStatusService{
+			listFn: func(_ context.Context, input agentstatusservice.ListInput) (agentstatusservice.Snapshot, error) {
+				if len(input.Providers) != 1 || input.Providers[0] != "claude-code" {
+					t.Fatalf("providers = %#v, want [claude-code]", input.Providers)
+				}
+				return agentstatusservice.Snapshot{
+					Providers: []agentstatusservice.ProviderStatus{{
+						Actions: []agentstatusservice.Action{},
+						Auth: agentstatusservice.AuthInfo{
+							Status:       agentstatusservice.AuthAuthenticated,
+							AccountLabel: "API Usage Billing",
+							AuthMethod:   "apiKey",
+						},
+						Availability: agentstatusservice.Availability{
+							Status: agentstatusservice.AvailabilityReady,
+						},
+						CLI:      agentstatusservice.CLIStatus{Installed: true, BinaryPath: "/usr/local/bin/claude"},
+						Adapter:  agentstatusservice.AdapterStatus{Installed: true},
+						Provider: "claude-code",
+					}},
+				}, nil
+			},
+		},
+	}))
+
+	recorder := performGeneratedRouteRequest(t, mux, http.MethodGet, "/v1/agent-providers/status?providers=claude-code", nil)
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d; body: %s", recorder.Code, http.StatusOK, recorder.Body.String())
+	}
+
+	var response tuttigenerated.AgentProviderStatusListResponse
+	decodeGeneratedRouteResponse(t, recorder, &response)
+	if len(response.Providers) != 1 {
+		t.Fatalf("providers length = %d, want 1", len(response.Providers))
+	}
+	auth := response.Providers[0].Auth
+	if auth.Status != tuttigenerated.AgentProviderAuthStatusAuthenticated {
+		t.Fatalf("auth status = %q, want authenticated", auth.Status)
+	}
+	if auth.AccountLabel == nil || *auth.AccountLabel != "API Usage Billing" {
+		t.Fatalf("accountLabel = %#v, want API Usage Billing", auth.AccountLabel)
+	}
+	if auth.AuthMethod == nil || *auth.AuthMethod != "apiKey" {
+		t.Fatalf("authMethod = %#v, want apiKey", auth.AuthMethod)
+	}
+}
+
 func TestDaemonAPIRoutesAgentProviderProbe(t *testing.T) {
 	checkedAt := time.Date(2026, 6, 2, 8, 0, 0, 0, time.UTC)
 	mux := http.NewServeMux()

--- a/services/tuttid/api/generated/types.gen.go
+++ b/services/tuttid/api/generated/types.gen.go
@@ -1632,8 +1632,11 @@ type AgentProviderAdapterStatus struct {
 
 // AgentProviderAuthInfo defines model for AgentProviderAuthInfo.
 type AgentProviderAuthInfo struct {
-	AccountLabel *string                 `json:"accountLabel,omitempty"`
-	Status       AgentProviderAuthStatus `json:"status"`
+	AccountLabel *string `json:"accountLabel,omitempty"`
+
+	// AuthMethod The authentication method reported by the provider CLI (e.g. oauth, apiKey).
+	AuthMethod *string                 `json:"authMethod,omitempty"`
+	Status     AgentProviderAuthStatus `json:"status"`
 }
 
 // AgentProviderAuthStatus defines model for AgentProviderAuthStatus.

--- a/services/tuttid/api/openapi/tuttid.v1.yaml
+++ b/services/tuttid/api/openapi/tuttid.v1.yaml
@@ -5517,6 +5517,10 @@ components:
         accountLabel:
           type: string
           nullable: true
+        authMethod:
+          type: string
+          nullable: true
+          description: The authentication method reported by the provider CLI (e.g. oauth, apiKey).
     AgentProviderStatus:
       type: object
       additionalProperties: false

--- a/services/tuttid/service/agentstatus/provider_custom_config.go
+++ b/services/tuttid/service/agentstatus/provider_custom_config.go
@@ -9,14 +9,33 @@ import (
 	"github.com/tutti-os/tutti/services/tuttid/biz/agentprovider"
 )
 
-// providerUsesCustomConfig reports whether the user configured their own API key
-// or a custom API endpoint for the provider — via environment variables OR the
-// CLI's on-disk config. When they have, the default API endpoint is not what the
-// CLI actually talks to, so the service-API reachability probe is skipped.
+// A provider CLI can diverge from its default Console/OAuth login in two
+// independent ways, detected from env vars and on-disk config:
+//
+//   - A custom API endpoint (ANTHROPIC_BASE_URL, OPENAI_BASE_URL, ...): the CLI
+//     talks to a user-supplied gateway instead of the provider's default host.
+//     The service-API reachability probe is skipped in that case, since probing
+//     the default endpoint would mislead.
+//   - An API credential (ANTHROPIC_API_KEY, ANTHROPIC_AUTH_TOKEN, apiKeyHelper,
+//     OPENAI_API_KEY, ...): usage is billed to an API account and overrides any
+//     stored OAuth/subscription session. The auth status reported to the
+//     environment wizard reflects this so a configured API user is not told to
+//     "log in".
+//
+// The two are orthogonal — a custom endpoint can carry an OAuth session, and an
+// API key can target the default host — so they are detected separately.
+// providerUsesCustomConfig (either axis set) drives the network-probe skip;
+// providerHasAPICredential (credential axis only) drives the auth/billing label.
 //
 // The config-file parsing mirrors the runtime's endpoint adaptation in
 // packages/agent/daemon/runtime/provider_endpoint.go (Codex config.toml,
 // Claude settings.json); kept in sync by intent.
+
+// providerUsesCustomConfig reports whether the user configured their own API
+// key or a custom API endpoint for the provider — via environment variables OR
+// the CLI's on-disk config. When they have, the default API endpoint is not
+// what the CLI actually talks to, so the service-API reachability probe is
+// skipped.
 func (s Service) providerUsesCustomConfig(provider string) bool {
 	for _, key := range providerCustomConfigEnvVars(provider) {
 		if strings.TrimSpace(s.lookupEnv(key)) != "" {
@@ -25,16 +44,39 @@ func (s Service) providerUsesCustomConfig(provider string) bool {
 	}
 	switch provider {
 	case agentprovider.Codex:
-		return s.codexConfigHasCustomEndpoint()
+		return s.codexConfigDeclares("base_url", "chatgpt_base_url", "api_key")
 	case agentprovider.ClaudeCode:
-		return s.claudeSettingsHasCustomConfig()
+		return s.claudeSettingsDeclares(claudeCustomConfigKeys, true)
 	default:
 		return false
 	}
 }
 
-// providerCustomConfigEnvVars lists the env vars that signal a user-provided API
-// key or a custom base URL for a provider.
+// providerHasAPICredential reports whether the user configured an API
+// credential for the provider (an API key, an auth token, or an API key helper)
+// via env vars or on-disk config. This is the signal that usage is billed to an
+// API account rather than a Console/subscription session, and it overrides
+// whatever `claude auth status` reports (which only reflects the stored OAuth
+// session, not env/settings credentials).
+func (s Service) providerHasAPICredential(provider string) bool {
+	for _, key := range providerCredentialEnvVars(provider) {
+		if strings.TrimSpace(s.lookupEnv(key)) != "" {
+			return true
+		}
+	}
+	switch provider {
+	case agentprovider.Codex:
+		return s.codexConfigDeclares("api_key")
+	case agentprovider.ClaudeCode:
+		return s.claudeSettingsDeclares(claudeAPICredentialKeys, true)
+	default:
+		return false
+	}
+}
+
+// providerCustomConfigEnvVars lists env vars that signal a user-provided API
+// key OR a custom base URL for a provider — either axis counts as custom config
+// for the network-probe skip.
 func providerCustomConfigEnvVars(provider string) []string {
 	switch provider {
 	case agentprovider.Codex:
@@ -58,9 +100,43 @@ func providerCustomConfigEnvVars(provider string) []string {
 	}
 }
 
-// codexConfigHasCustomEndpoint reports whether ~/.codex/config.toml (or
-// $CODEX_HOME) declares a custom base URL or an inline API key.
-func (s Service) codexConfigHasCustomEndpoint() bool {
+// providerCredentialEnvVars lists env vars that signal a user-provided API
+// credential (key/token) for a provider — the billing axis only, excluding
+// custom base URLs.
+func providerCredentialEnvVars(provider string) []string {
+	switch provider {
+	case agentprovider.Codex:
+		return []string{"OPENAI_API_KEY"}
+	case agentprovider.ClaudeCode:
+		return []string{"ANTHROPIC_API_KEY", "ANTHROPIC_AUTH_TOKEN"}
+	case agentprovider.Gemini:
+		return []string{"GEMINI_API_KEY", "GOOGLE_API_KEY"}
+	default:
+		return nil
+	}
+}
+
+// claudeCustomConfigKeys are the ~/.claude/settings.json env keys that count as
+// custom config (credential or endpoint) for Claude Code.
+var claudeCustomConfigKeys = []string{
+	"ANTHROPIC_API_KEY",
+	"ANTHROPIC_AUTH_TOKEN",
+	"ANTHROPIC_BASE_URL",
+	"ANTHROPIC_API_BASE_URL",
+}
+
+// claudeAPICredentialKeys are the ~/.claude/settings.json env keys that count
+// as an API credential for Claude Code — the billing axis, excluding endpoints.
+var claudeAPICredentialKeys = []string{
+	"ANTHROPIC_API_KEY",
+	"ANTHROPIC_AUTH_TOKEN",
+}
+
+// codexConfigDeclares reports whether ~/.codex/config.toml (or $CODEX_HOME)
+// assigns a non-empty value to any of the given keys (e.g. "base_url",
+// "api_key") in a top-level or [model_providers.*] block. Mirrors the runtime's
+// TOML parsing.
+func (s Service) codexConfigDeclares(keys ...string) bool {
 	codexHome := strings.TrimSpace(s.lookupEnv("CODEX_HOME"))
 	if codexHome == "" {
 		home, err := s.homeDir()
@@ -82,9 +158,8 @@ func (s Service) codexConfigHasCustomEndpoint() bool {
 		if !ok {
 			continue
 		}
-		switch key {
-		case "base_url", "chatgpt_base_url", "api_key":
-			if value != "" {
+		for _, want := range keys {
+			if key == want && value != "" {
 				return true
 			}
 		}
@@ -92,9 +167,10 @@ func (s Service) codexConfigHasCustomEndpoint() bool {
 	return false
 }
 
-// claudeSettingsHasCustomConfig reports whether ~/.claude/settings.json declares
-// a custom API key or base URL (in its `env` block) or an apiKeyHelper.
-func (s Service) claudeSettingsHasCustomConfig() bool {
+// claudeSettingsDeclares reports whether ~/.claude/settings.json sets any of
+// the given env keys to a non-blank value, or — when withAPIKeyHelper is true —
+// declares a non-blank apiKeyHelper.
+func (s Service) claudeSettingsDeclares(keys []string, withAPIKeyHelper bool) bool {
 	home, err := s.homeDir()
 	if err != nil || strings.TrimSpace(home) == "" {
 		return false
@@ -110,27 +186,15 @@ func (s Service) claudeSettingsHasCustomConfig() bool {
 	if err := json.Unmarshal(content, &parsed); err != nil {
 		return false
 	}
-	if strings.TrimSpace(parsed.APIKeyHelper) != "" {
+	if withAPIKeyHelper && strings.TrimSpace(parsed.APIKeyHelper) != "" {
 		return true
 	}
-	for _, key := range []string{
-		"ANTHROPIC_API_KEY",
-		"ANTHROPIC_AUTH_TOKEN",
-		"ANTHROPIC_BASE_URL",
-		"ANTHROPIC_API_BASE_URL",
-	} {
+	for _, key := range keys {
 		if value, ok := parsed.Env[key].(string); ok && strings.TrimSpace(value) != "" {
 			return true
 		}
 	}
 	return false
-}
-
-// claudeCodeUsesAPIBilling reports whether Claude Code is configured to use
-// API Usage Billing (an API key, an auth token, an API key helper, or a custom
-// Anthropic API endpoint) rather than an Anthropic Console login session.
-func (s Service) claudeCodeUsesAPIBilling() bool {
-	return s.providerUsesCustomConfig(agentprovider.ClaudeCode)
 }
 
 // splitTomlAssignment parses a `key = "value"` line, stripping quotes. Mirrors

--- a/services/tuttid/service/agentstatus/provider_custom_config.go
+++ b/services/tuttid/service/agentstatus/provider_custom_config.go
@@ -124,6 +124,13 @@ func (s Service) claudeSettingsHasCustomConfig() bool {
 	return false
 }
 
+// claudeCodeUsesAPIBilling reports whether Claude Code is configured to use
+// API Usage Billing (an API key, an API key helper, or a custom Anthropic API
+// endpoint) rather than an Anthropic Console login session.
+func (s Service) claudeCodeUsesAPIBilling() bool {
+	return s.providerUsesCustomConfig(agentprovider.ClaudeCode)
+}
+
 // splitTomlAssignment parses a `key = "value"` line, stripping quotes. Mirrors
 // the runtime's splitSimpleTomlAssignment.
 func splitTomlAssignment(line string) (string, string, bool) {

--- a/services/tuttid/service/agentstatus/provider_custom_config.go
+++ b/services/tuttid/service/agentstatus/provider_custom_config.go
@@ -47,6 +47,7 @@ func providerCustomConfigEnvVars(provider string) []string {
 	case agentprovider.ClaudeCode:
 		return []string{
 			"ANTHROPIC_API_KEY",
+			"ANTHROPIC_AUTH_TOKEN",
 			"ANTHROPIC_BASE_URL",
 			"ANTHROPIC_API_BASE_URL",
 		}
@@ -114,6 +115,7 @@ func (s Service) claudeSettingsHasCustomConfig() bool {
 	}
 	for _, key := range []string{
 		"ANTHROPIC_API_KEY",
+		"ANTHROPIC_AUTH_TOKEN",
 		"ANTHROPIC_BASE_URL",
 		"ANTHROPIC_API_BASE_URL",
 	} {
@@ -125,8 +127,8 @@ func (s Service) claudeSettingsHasCustomConfig() bool {
 }
 
 // claudeCodeUsesAPIBilling reports whether Claude Code is configured to use
-// API Usage Billing (an API key, an API key helper, or a custom Anthropic API
-// endpoint) rather than an Anthropic Console login session.
+// API Usage Billing (an API key, an auth token, an API key helper, or a custom
+// Anthropic API endpoint) rather than an Anthropic Console login session.
 func (s Service) claudeCodeUsesAPIBilling() bool {
 	return s.providerUsesCustomConfig(agentprovider.ClaudeCode)
 }

--- a/services/tuttid/service/agentstatus/provider_custom_config_test.go
+++ b/services/tuttid/service/agentstatus/provider_custom_config_test.go
@@ -116,3 +116,97 @@ func TestProviderUsesCustomConfigNoConfigNoEnv(t *testing.T) {
 		t.Fatal("no env and no config should not be custom")
 	}
 }
+
+func TestProviderHasAPICredentialEnvAPIKey(t *testing.T) {
+	svc := customConfigService(t.TempDir())
+	svc.Environ = func() []string { return []string{"ANTHROPIC_API_KEY=sk-test"} }
+	if !svc.providerHasAPICredential(agentprovider.ClaudeCode) {
+		t.Fatal("expected env ANTHROPIC_API_KEY to count as an API credential")
+	}
+}
+
+func TestProviderHasAPICredentialEnvAuthToken(t *testing.T) {
+	svc := customConfigService(t.TempDir())
+	svc.Environ = func() []string { return []string{"ANTHROPIC_AUTH_TOKEN=sk-test"} }
+	if !svc.providerHasAPICredential(agentprovider.ClaudeCode) {
+		t.Fatal("expected env ANTHROPIC_AUTH_TOKEN to count as an API credential")
+	}
+}
+
+func TestProviderHasAPICredentialSettingsAuthToken(t *testing.T) {
+	home := t.TempDir()
+	writeFile(t, filepath.Join(home, ".claude", "settings.json"),
+		`{"env":{"ANTHROPIC_AUTH_TOKEN":"sk-test"}}`)
+	svc := customConfigService(home)
+	if !svc.providerHasAPICredential(agentprovider.ClaudeCode) {
+		t.Fatal("expected settings ANTHROPIC_AUTH_TOKEN to count as an API credential")
+	}
+}
+
+func TestProviderHasAPICredentialSettingsApiKeyHelper(t *testing.T) {
+	home := t.TempDir()
+	writeFile(t, filepath.Join(home, ".claude", "settings.json"),
+		`{"apiKeyHelper":"/usr/local/bin/get-key.sh"}`)
+	svc := customConfigService(home)
+	if !svc.providerHasAPICredential(agentprovider.ClaudeCode) {
+		t.Fatal("expected apiKeyHelper to count as an API credential")
+	}
+}
+
+// A bare custom endpoint without any API credential must NOT be reported as an
+// API credential: the user may still be on an OAuth/subscription session against
+// that endpoint, so labeling them "API Usage Billing" would be wrong.
+func TestProviderHasAPICredentialCustomEndpointOnlyIsNotCredential(t *testing.T) {
+	home := t.TempDir()
+	writeFile(t, filepath.Join(home, ".claude", "settings.json"),
+		`{"env":{"ANTHROPIC_BASE_URL":"https://gw.local"}}`)
+	svc := customConfigService(home)
+	if svc.providerHasAPICredential(agentprovider.ClaudeCode) {
+		t.Fatal("a custom endpoint without a credential must not count as API billing")
+	}
+	// ...but it still counts as custom config for the network-probe skip.
+	if !svc.providerUsesCustomConfig(agentprovider.ClaudeCode) {
+		t.Fatal("a custom endpoint should still count as custom config")
+	}
+}
+
+func TestProviderHasAPICredentialEnvBaseUrlOnlyIsNotCredential(t *testing.T) {
+	svc := customConfigService(t.TempDir())
+	svc.Environ = func() []string { return []string{"ANTHROPIC_BASE_URL=https://gw.local"} }
+	if svc.providerHasAPICredential(agentprovider.ClaudeCode) {
+		t.Fatal("env ANTHROPIC_BASE_URL alone must not count as an API credential")
+	}
+}
+
+func TestProviderHasAPICredentialCodexConfigTomlInlineKey(t *testing.T) {
+	home := t.TempDir()
+	writeFile(t, filepath.Join(home, ".codex", "config.toml"),
+		`[model_providers.openai]`+"\n"+`api_key = "sk-inline"`)
+	svc := customConfigService(home)
+	if !svc.providerHasAPICredential(agentprovider.Codex) {
+		t.Fatal("expected codex config.toml api_key to count as an API credential")
+	}
+}
+
+func TestProviderHasAPICredentialCodexConfigTomlEndpointOnlyIsNotCredential(t *testing.T) {
+	home := t.TempDir()
+	writeFile(t, filepath.Join(home, ".codex", "config.toml"), `
+model_provider = "mycorp"
+[model_providers.mycorp]
+base_url = "https://gateway.mycorp.com/v1"
+`)
+	svc := customConfigService(home)
+	if svc.providerHasAPICredential(agentprovider.Codex) {
+		t.Fatal("codex config.toml base_url without api_key must not count as an API credential")
+	}
+}
+
+func TestProviderHasAPICredentialNone(t *testing.T) {
+	svc := customConfigService(t.TempDir())
+	if svc.providerHasAPICredential(agentprovider.ClaudeCode) {
+		t.Fatal("no env and no config should not have an API credential")
+	}
+	if svc.providerHasAPICredential(agentprovider.Codex) {
+		t.Fatal("no env and no config should not have an API credential")
+	}
+}

--- a/services/tuttid/service/agentstatus/provider_custom_config_test.go
+++ b/services/tuttid/service/agentstatus/provider_custom_config_test.go
@@ -76,6 +76,16 @@ func TestProviderUsesCustomConfigClaudeSettings(t *testing.T) {
 	}
 }
 
+func TestProviderUsesCustomConfigClaudeAuthToken(t *testing.T) {
+	home := t.TempDir()
+	writeFile(t, filepath.Join(home, ".claude", "settings.json"),
+		`{"env":{"ANTHROPIC_AUTH_TOKEN":"sk-test"}}`)
+	svc := customConfigService(home)
+	if !svc.providerUsesCustomConfig(agentprovider.ClaudeCode) {
+		t.Fatal("expected claude settings ANTHROPIC_AUTH_TOKEN to count as custom config")
+	}
+}
+
 func TestProviderUsesCustomConfigClaudeApiKeyHelper(t *testing.T) {
 	home := t.TempDir()
 	writeFile(t, filepath.Join(home, ".claude", "settings.json"),

--- a/services/tuttid/service/agentstatus/service.go
+++ b/services/tuttid/service/agentstatus/service.go
@@ -177,6 +177,7 @@ type AdapterStatus struct {
 type AuthInfo struct {
 	Status       AuthStatus
 	AccountLabel string
+	AuthMethod   string
 }
 
 type Action struct {
@@ -558,6 +559,7 @@ func (s Service) statusForSpec(ctx context.Context, spec ProviderSpec, now time.
 			if spec.Provider == agentprovider.ClaudeCode && s.claudeCodeUsesAPIBilling() {
 				auth.Status = AuthAuthenticated
 				auth.AccountLabel = firstNonBlank(auth.AccountLabel, "API Usage Billing")
+				auth.AuthMethod = "apiKey"
 			} else {
 				availability.Status = AvailabilityAuthRequired
 				if auth.Status == AuthRequired {

--- a/services/tuttid/service/agentstatus/service.go
+++ b/services/tuttid/service/agentstatus/service.go
@@ -548,14 +548,25 @@ func (s Service) statusForSpec(ctx context.Context, spec ProviderSpec, now time.
 	} else {
 		actions = append(actions, terminalAction(ActionLogin, loginCommandForRuntime(spec, runtimeResolution)))
 		switch auth.Status {
-		case AuthRequired:
-			availability.Status = AvailabilityAuthRequired
-			availability.ReasonCode = "auth_required"
-			actions = append(actions, Action{ID: ActionRefresh, Kind: ActionKindRefresh})
-		case AuthUnknown:
-			availability.Status = AvailabilityAuthRequired
-			availability.ReasonCode = "auth_unknown"
-			actions = append(actions, Action{ID: ActionRefresh, Kind: ActionKindRefresh})
+		case AuthAuthenticated:
+			// already ready
+		case AuthRequired, AuthUnknown:
+			// Claude Code can run in API Usage Billing mode (API key or custom
+			// endpoint) without an Anthropic Console login session. Treat that
+			// configuration as authenticated so the environment wizard doesn't
+			// block users who have a working CLI but no console login.
+			if spec.Provider == agentprovider.ClaudeCode && s.claudeCodeUsesAPIBilling() {
+				auth.Status = AuthAuthenticated
+				auth.AccountLabel = firstNonBlank(auth.AccountLabel, "API Usage Billing")
+			} else {
+				availability.Status = AvailabilityAuthRequired
+				if auth.Status == AuthRequired {
+					availability.ReasonCode = "auth_required"
+				} else {
+					availability.ReasonCode = "auth_unknown"
+				}
+				actions = append(actions, Action{ID: ActionRefresh, Kind: ActionKindRefresh})
+			}
 		}
 	}
 

--- a/services/tuttid/service/agentstatus/service.go
+++ b/services/tuttid/service/agentstatus/service.go
@@ -549,10 +549,16 @@ func (s Service) statusForSpec(ctx context.Context, spec ProviderSpec, now time.
 	} else {
 		actions = append(actions, terminalAction(ActionLogin, loginCommandForRuntime(spec, runtimeResolution)))
 
-		// Claude Code can run in API Usage Billing mode (API key or custom
-		// endpoint). When the user has configured that, prefer it over whatever
-		// auth status / method the CLI reports, so the wizard reflects reality.
-		if spec.Provider == agentprovider.ClaudeCode && s.claudeCodeUsesAPIBilling() {
+		// Claude Code can run in API Usage Billing mode — an API key, an auth
+		// token, or an apiKeyHelper — which bills usage to an API account and
+		// overrides any stored OAuth/subscription session. `claude auth status`
+		// only reflects the stored session, so it is blind to these env/settings
+		// credentials; detect them directly and prefer that signal over whatever
+		// the CLI reports, so the wizard shows "已配置 API 计费" instead of a
+		// stale OAuth label or "未登录". A bare custom endpoint without a
+		// credential is NOT API billing (the user may still be on an OAuth
+		// session), so it does not trigger this override.
+		if spec.Provider == agentprovider.ClaudeCode && s.providerHasAPICredential(agentprovider.ClaudeCode) {
 			auth.Status = AuthAuthenticated
 			auth.AccountLabel = "API Usage Billing"
 			auth.AuthMethod = "apiKey"

--- a/services/tuttid/service/agentstatus/service.go
+++ b/services/tuttid/service/agentstatus/service.go
@@ -548,25 +548,25 @@ func (s Service) statusForSpec(ctx context.Context, spec ProviderSpec, now time.
 		actions = append(actions, daemonAction(ActionInstall))
 	} else {
 		actions = append(actions, terminalAction(ActionLogin, loginCommandForRuntime(spec, runtimeResolution)))
-		switch auth.Status {
-		case AuthAuthenticated:
-			// already ready
-		case AuthRequired, AuthUnknown:
-			// Claude Code can run in API Usage Billing mode (API key or custom
-			// endpoint) without an Anthropic Console login session. Treat that
-			// configuration as authenticated so the environment wizard doesn't
-			// block users who have a working CLI but no console login.
-			if spec.Provider == agentprovider.ClaudeCode && s.claudeCodeUsesAPIBilling() {
-				auth.Status = AuthAuthenticated
-				auth.AccountLabel = firstNonBlank(auth.AccountLabel, "API Usage Billing")
-				auth.AuthMethod = "apiKey"
-			} else {
+
+		// Claude Code can run in API Usage Billing mode (API key or custom
+		// endpoint). When the user has configured that, prefer it over whatever
+		// auth status / method the CLI reports, so the wizard reflects reality.
+		if spec.Provider == agentprovider.ClaudeCode && s.claudeCodeUsesAPIBilling() {
+			auth.Status = AuthAuthenticated
+			auth.AccountLabel = "API Usage Billing"
+			auth.AuthMethod = "apiKey"
+		} else {
+			switch auth.Status {
+			case AuthAuthenticated:
+				// already ready
+			case AuthRequired:
 				availability.Status = AvailabilityAuthRequired
-				if auth.Status == AuthRequired {
-					availability.ReasonCode = "auth_required"
-				} else {
-					availability.ReasonCode = "auth_unknown"
-				}
+				availability.ReasonCode = "auth_required"
+				actions = append(actions, Action{ID: ActionRefresh, Kind: ActionKindRefresh})
+			case AuthUnknown:
+				availability.Status = AvailabilityAuthRequired
+				availability.ReasonCode = "auth_unknown"
 				actions = append(actions, Action{ID: ActionRefresh, Kind: ActionKindRefresh})
 			}
 		}

--- a/services/tuttid/service/agentstatus/service_helpers.go
+++ b/services/tuttid/service/agentstatus/service_helpers.go
@@ -526,10 +526,11 @@ func parseClaudeAuthStatusOutput(output []byte) (AuthInfo, bool) {
 		if *payload.LoggedIn {
 			return AuthInfo{
 				AccountLabel: firstNonBlank(payload.AccountLabel, payload.Email, payload.AuthMethod),
+				AuthMethod:   payload.AuthMethod,
 				Status:       AuthAuthenticated,
 			}, true
 		}
-		return AuthInfo{Status: AuthRequired}, true
+		return AuthInfo{Status: AuthRequired, AuthMethod: payload.AuthMethod}, true
 	}
 	normalized := strings.ToLower(string(output))
 	if strings.Contains(normalized, `"loggedin":false`) ||
@@ -571,10 +572,11 @@ func parseClaudeAuthMarkerContent(content []byte) (AuthInfo, bool) {
 		if *payload.LoggedIn {
 			return AuthInfo{
 				AccountLabel: firstNonBlank(payload.AccountLabel, payload.Email, payload.AuthMethod, payload.UserID),
+				AuthMethod:   payload.AuthMethod,
 				Status:       AuthAuthenticated,
 			}, true
 		}
-		return AuthInfo{Status: AuthRequired}, true
+		return AuthInfo{Status: AuthRequired, AuthMethod: payload.AuthMethod}, true
 	}
 	if strings.TrimSpace(payload.UserID) != "" {
 		return AuthInfo{

--- a/services/tuttid/service/agentstatus/service_test.go
+++ b/services/tuttid/service/agentstatus/service_test.go
@@ -2331,10 +2331,26 @@ func TestParseClaudeAuthStatusOutputReportsAuthenticated(t *testing.T) {
 	if auth.AccountLabel != "oauth" {
 		t.Fatalf("AccountLabel = %q, want oauth", auth.AccountLabel)
 	}
+	if auth.AuthMethod != "oauth" {
+		t.Fatalf("AuthMethod = %q, want oauth", auth.AuthMethod)
+	}
+}
+
+func TestParseClaudeAuthStatusOutputReportsAuthMethodWhenNotLoggedIn(t *testing.T) {
+	auth, ok := parseClaudeAuthStatusOutput([]byte(`{"loggedIn":false,"authMethod":"apiKey"}`))
+	if !ok {
+		t.Fatal("parseClaudeAuthStatusOutput ok = false, want true")
+	}
+	if auth.Status != AuthRequired {
+		t.Fatalf("Status = %q, want %q", auth.Status, AuthRequired)
+	}
+	if auth.AuthMethod != "apiKey" {
+		t.Fatalf("AuthMethod = %q, want apiKey", auth.AuthMethod)
+	}
 }
 
 func TestParseClaudeAuthMarkerContentReportsAuthenticated(t *testing.T) {
-	auth, ok := parseClaudeAuthMarkerContent([]byte(`{"loggedIn":true,"email":"dev@example.com"}`))
+	auth, ok := parseClaudeAuthMarkerContent([]byte(`{"loggedIn":true,"email":"dev@example.com","authMethod":"oauth"}`))
 	if !ok {
 		t.Fatal("parseClaudeAuthMarkerContent ok = false, want true")
 	}
@@ -2343,6 +2359,9 @@ func TestParseClaudeAuthMarkerContentReportsAuthenticated(t *testing.T) {
 	}
 	if auth.AccountLabel != "dev@example.com" {
 		t.Fatalf("AccountLabel = %q, want dev@example.com", auth.AccountLabel)
+	}
+	if auth.AuthMethod != "oauth" {
+		t.Fatalf("AuthMethod = %q, want oauth", auth.AuthMethod)
 	}
 }
 

--- a/services/tuttid/service/agentstatus/service_test.go
+++ b/services/tuttid/service/agentstatus/service_test.go
@@ -2060,6 +2060,134 @@ func TestServiceListReportsAuthRequiredFromClaudeAuthStatusCommand(t *testing.T)
 	}
 }
 
+func TestServiceListReportsReadyForClaudeAPIBillingWithEnvKey(t *testing.T) {
+	home := t.TempDir()
+	binDir := filepath.Join(home, ".nvm", "versions", "node", "v24.12.0", "bin")
+	if err := os.MkdirAll(binDir, 0o755); err != nil {
+		t.Fatalf("mkdir bin dir: %v", err)
+	}
+	claudePath := filepath.Join(binDir, "claude")
+	writeExecutable(t, claudePath, "#!/bin/sh\nexit 0\n")
+	writeExecutable(t, filepath.Join(binDir, "claude-agent-acp"), "#!/bin/sh\nexit 0\n")
+	writePackageManifest(t, binDir, "@agentclientprotocol/claude-agent-acp", "0.46.0")
+	registryStore, prefixDir := fakeClaudeExternalRegistry(t)
+	runtimeRoot := fakeManagedRuntimeRoot(t)
+	packageDir := npmPackageInstallDir(prefixDir, "@agentclientprotocol/claude-agent-acp")
+	if err := os.MkdirAll(packageDir, 0o755); err != nil {
+		t.Fatalf("mkdir package dir: %v", err)
+	}
+	writePackageManifest(t, packageDir, "@agentclientprotocol/claude-agent-acp", "0.46.0")
+
+	service := Service{
+		Environ: func() []string {
+			return []string{"PATH=/usr/bin:/bin", "ANTHROPIC_API_KEY=sk-test"}
+		},
+		HomeDir: func() (string, error) {
+			return home, nil
+		},
+		LookPath: func(_ string) (string, error) {
+			return "", errors.New("not found")
+		},
+		Now: func() time.Time {
+			return time.Date(2026, 6, 2, 8, 0, 0, 0, time.UTC)
+		},
+		RunAuthStatusCommand: func(_ context.Context, spec ProviderSpec, binaryPath string) (AuthInfo, bool) {
+			if spec.Provider != "claude-code" {
+				t.Fatalf("auth status provider = %q, want claude-code", spec.Provider)
+			}
+			if binaryPath != claudePath {
+				t.Fatalf("auth status binaryPath = %q, want %q", binaryPath, claudePath)
+			}
+			return AuthInfo{Status: AuthRequired}, true
+		},
+		ExternalAgentRegistry: registryStore,
+		ManagedRuntime:        fakeManagedRuntimeResolver(t, runtimeRoot),
+	}
+
+	snapshot, err := service.List(context.Background(), ListInput{Providers: []string{"claude-code"}})
+	if err != nil {
+		t.Fatalf("List() error = %v", err)
+	}
+
+	status := onlyStatus(t, snapshot)
+	if status.Availability.Status != AvailabilityReady {
+		t.Fatalf("Availability.Status = %q, want %q", status.Availability.Status, AvailabilityReady)
+	}
+	if status.Auth.Status != AuthAuthenticated {
+		t.Fatalf("Auth.Status = %q, want %q", status.Auth.Status, AuthAuthenticated)
+	}
+	if status.Auth.AccountLabel != "API Usage Billing" {
+		t.Fatalf("Auth.AccountLabel = %q, want %q", status.Auth.AccountLabel, "API Usage Billing")
+	}
+}
+
+func TestServiceListReportsReadyForClaudeAPIBillingWithSettingsKey(t *testing.T) {
+	home := t.TempDir()
+	binDir := filepath.Join(home, ".nvm", "versions", "node", "v24.12.0", "bin")
+	if err := os.MkdirAll(binDir, 0o755); err != nil {
+		t.Fatalf("mkdir bin dir: %v", err)
+	}
+	claudePath := filepath.Join(binDir, "claude")
+	writeExecutable(t, claudePath, "#!/bin/sh\nexit 0\n")
+	writeExecutable(t, filepath.Join(binDir, "claude-agent-acp"), "#!/bin/sh\nexit 0\n")
+	writePackageManifest(t, binDir, "@agentclientprotocol/claude-agent-acp", "0.46.0")
+	if err := os.MkdirAll(filepath.Join(home, ".claude"), 0o755); err != nil {
+		t.Fatalf("mkdir .claude dir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(home, ".claude", "settings.json"), []byte(`{"env":{"ANTHROPIC_API_KEY":"sk-test"}}`), 0o600); err != nil {
+		t.Fatalf("write settings.json: %v", err)
+	}
+	registryStore, prefixDir := fakeClaudeExternalRegistry(t)
+	runtimeRoot := fakeManagedRuntimeRoot(t)
+	packageDir := npmPackageInstallDir(prefixDir, "@agentclientprotocol/claude-agent-acp")
+	if err := os.MkdirAll(packageDir, 0o755); err != nil {
+		t.Fatalf("mkdir package dir: %v", err)
+	}
+	writePackageManifest(t, packageDir, "@agentclientprotocol/claude-agent-acp", "0.46.0")
+
+	service := Service{
+		Environ: func() []string {
+			return []string{"PATH=/usr/bin:/bin"}
+		},
+		HomeDir: func() (string, error) {
+			return home, nil
+		},
+		LookPath: func(_ string) (string, error) {
+			return "", errors.New("not found")
+		},
+		Now: func() time.Time {
+			return time.Date(2026, 6, 2, 8, 0, 0, 0, time.UTC)
+		},
+		RunAuthStatusCommand: func(_ context.Context, spec ProviderSpec, binaryPath string) (AuthInfo, bool) {
+			if spec.Provider != "claude-code" {
+				t.Fatalf("auth status provider = %q, want claude-code", spec.Provider)
+			}
+			if binaryPath != claudePath {
+				t.Fatalf("auth status binaryPath = %q, want %q", binaryPath, claudePath)
+			}
+			return AuthInfo{Status: AuthRequired}, true
+		},
+		ExternalAgentRegistry: registryStore,
+		ManagedRuntime:        fakeManagedRuntimeResolver(t, runtimeRoot),
+	}
+
+	snapshot, err := service.List(context.Background(), ListInput{Providers: []string{"claude-code"}})
+	if err != nil {
+		t.Fatalf("List() error = %v", err)
+	}
+
+	status := onlyStatus(t, snapshot)
+	if status.Availability.Status != AvailabilityReady {
+		t.Fatalf("Availability.Status = %q, want %q", status.Availability.Status, AvailabilityReady)
+	}
+	if status.Auth.Status != AuthAuthenticated {
+		t.Fatalf("Auth.Status = %q, want %q", status.Auth.Status, AuthAuthenticated)
+	}
+	if status.Auth.AccountLabel != "API Usage Billing" {
+		t.Fatalf("Auth.AccountLabel = %q, want %q", status.Auth.AccountLabel, "API Usage Billing")
+	}
+}
+
 func TestServiceListRetriesClaudeAuthStatusCommandWhenOutputIsUnrecognized(t *testing.T) {
 	home := t.TempDir()
 	binDir := filepath.Join(home, ".nvm", "versions", "node", "v24.12.0", "bin")

--- a/services/tuttid/service/agentstatus/service_test.go
+++ b/services/tuttid/service/agentstatus/service_test.go
@@ -2260,6 +2260,70 @@ func TestServiceListReportsReadyForClaudeAPIBillingDespiteOauthTokenStatus(t *te
 	}
 }
 
+// A bare custom endpoint (no API credential) must NOT be mislabeled as API
+// Usage Billing. The user may be on an OAuth/subscription session against that
+// endpoint, so the CLI-reported auth status and label must be preserved.
+func TestServiceListDoesNotMislabelCustomEndpointOnlyAsAPIBilling(t *testing.T) {
+	home := t.TempDir()
+	binDir := filepath.Join(home, ".nvm", "versions", "node", "v24.12.0", "bin")
+	if err := os.MkdirAll(binDir, 0o755); err != nil {
+		t.Fatalf("mkdir bin dir: %v", err)
+	}
+	claudePath := filepath.Join(binDir, "claude")
+	writeExecutable(t, claudePath, "#!/bin/sh\nexit 0\n")
+	writeExecutable(t, filepath.Join(binDir, "claude-agent-acp"), "#!/bin/sh\nexit 0\n")
+	writePackageManifest(t, binDir, "@agentclientprotocol/claude-agent-acp", "0.46.0")
+	if err := os.MkdirAll(filepath.Join(home, ".claude"), 0o755); err != nil {
+		t.Fatalf("mkdir .claude dir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(home, ".claude", "settings.json"), []byte(`{"env":{"ANTHROPIC_BASE_URL":"https://gw.local"}}`), 0o600); err != nil {
+		t.Fatalf("write settings.json: %v", err)
+	}
+	registryStore, prefixDir := fakeClaudeExternalRegistry(t)
+	runtimeRoot := fakeManagedRuntimeRoot(t)
+	packageDir := npmPackageInstallDir(prefixDir, "@agentclientprotocol/claude-agent-acp")
+	if err := os.MkdirAll(packageDir, 0o755); err != nil {
+		t.Fatalf("mkdir package dir: %v", err)
+	}
+	writePackageManifest(t, packageDir, "@agentclientprotocol/claude-agent-acp", "0.46.0")
+
+	service := Service{
+		Environ: func() []string {
+			return []string{"PATH=/usr/bin:/bin"}
+		},
+		HomeDir: func() (string, error) {
+			return home, nil
+		},
+		LookPath: func(_ string) (string, error) {
+			return "", errors.New("not found")
+		},
+		Now: func() time.Time {
+			return time.Date(2026, 6, 2, 8, 0, 0, 0, time.UTC)
+		},
+		RunAuthStatusCommand: func(_ context.Context, _ ProviderSpec, _ string) (AuthInfo, bool) {
+			return AuthInfo{Status: AuthAuthenticated, AuthMethod: "oauth", AccountLabel: "me@x.com"}, true
+		},
+		ExternalAgentRegistry: registryStore,
+		ManagedRuntime:        fakeManagedRuntimeResolver(t, runtimeRoot),
+	}
+
+	snapshot, err := service.List(context.Background(), ListInput{Providers: []string{"claude-code"}})
+	if err != nil {
+		t.Fatalf("List() error = %v", err)
+	}
+
+	status := onlyStatus(t, snapshot)
+	if status.Availability.Status != AvailabilityReady {
+		t.Fatalf("Availability.Status = %q, want %q", status.Availability.Status, AvailabilityReady)
+	}
+	if status.Auth.AuthMethod != "oauth" {
+		t.Fatalf("Auth.AuthMethod = %q, want oauth (not overridden to apiKey)", status.Auth.AuthMethod)
+	}
+	if status.Auth.AccountLabel != "me@x.com" {
+		t.Fatalf("Auth.AccountLabel = %q, want me@x.com (CLI label preserved)", status.Auth.AccountLabel)
+	}
+}
+
 func TestServiceListRetriesClaudeAuthStatusCommandWhenOutputIsUnrecognized(t *testing.T) {
 	home := t.TempDir()
 	binDir := filepath.Join(home, ".nvm", "versions", "node", "v24.12.0", "bin")

--- a/services/tuttid/service/agentstatus/service_test.go
+++ b/services/tuttid/service/agentstatus/service_test.go
@@ -2188,6 +2188,78 @@ func TestServiceListReportsReadyForClaudeAPIBillingWithSettingsKey(t *testing.T)
 	}
 }
 
+func TestServiceListReportsReadyForClaudeAPIBillingDespiteOauthTokenStatus(t *testing.T) {
+	home := t.TempDir()
+	binDir := filepath.Join(home, ".nvm", "versions", "node", "v24.12.0", "bin")
+	if err := os.MkdirAll(binDir, 0o755); err != nil {
+		t.Fatalf("mkdir bin dir: %v", err)
+	}
+	claudePath := filepath.Join(binDir, "claude")
+	writeExecutable(t, claudePath, "#!/bin/sh\nexit 0\n")
+	writeExecutable(t, filepath.Join(binDir, "claude-agent-acp"), "#!/bin/sh\nexit 0\n")
+	writePackageManifest(t, binDir, "@agentclientprotocol/claude-agent-acp", "0.46.0")
+	if err := os.MkdirAll(filepath.Join(home, ".claude"), 0o755); err != nil {
+		t.Fatalf("mkdir .claude dir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(home, ".claude", "settings.json"), []byte(`{"env":{"ANTHROPIC_AUTH_TOKEN":"sk-test","ANTHROPIC_BASE_URL":"https://api.moonshot.cn/anthropic"}}`), 0o600); err != nil {
+		t.Fatalf("write settings.json: %v", err)
+	}
+	registryStore, prefixDir := fakeClaudeExternalRegistry(t)
+	runtimeRoot := fakeManagedRuntimeRoot(t)
+	packageDir := npmPackageInstallDir(prefixDir, "@agentclientprotocol/claude-agent-acp")
+	if err := os.MkdirAll(packageDir, 0o755); err != nil {
+		t.Fatalf("mkdir package dir: %v", err)
+	}
+	writePackageManifest(t, packageDir, "@agentclientprotocol/claude-agent-acp", "0.46.0")
+
+	service := Service{
+		Environ: func() []string {
+			return []string{"PATH=/usr/bin:/bin"}
+		},
+		HomeDir: func() (string, error) {
+			return home, nil
+		},
+		LookPath: func(_ string) (string, error) {
+			return "", errors.New("not found")
+		},
+		Now: func() time.Time {
+			return time.Date(2026, 6, 2, 8, 0, 0, 0, time.UTC)
+		},
+		RunAuthStatusCommand: func(_ context.Context, spec ProviderSpec, binaryPath string) (AuthInfo, bool) {
+			if spec.Provider != "claude-code" {
+				t.Fatalf("auth status provider = %q, want claude-code", spec.Provider)
+			}
+			if binaryPath != claudePath {
+				t.Fatalf("auth status binaryPath = %q, want %q", binaryPath, claudePath)
+			}
+			// Simulate a CLI that reports an OAuth-style authMethod even though
+			// the user is actually configured for API Usage Billing.
+			return AuthInfo{Status: AuthAuthenticated, AuthMethod: "oauth_token", AccountLabel: "oauth_token"}, true
+		},
+		ExternalAgentRegistry: registryStore,
+		ManagedRuntime:        fakeManagedRuntimeResolver(t, runtimeRoot),
+	}
+
+	snapshot, err := service.List(context.Background(), ListInput{Providers: []string{"claude-code"}})
+	if err != nil {
+		t.Fatalf("List() error = %v", err)
+	}
+
+	status := onlyStatus(t, snapshot)
+	if status.Availability.Status != AvailabilityReady {
+		t.Fatalf("Availability.Status = %q, want %q", status.Availability.Status, AvailabilityReady)
+	}
+	if status.Auth.Status != AuthAuthenticated {
+		t.Fatalf("Auth.Status = %q, want %q", status.Auth.Status, AuthAuthenticated)
+	}
+	if status.Auth.AuthMethod != "apiKey" {
+		t.Fatalf("Auth.AuthMethod = %q, want %q", status.Auth.AuthMethod, "apiKey")
+	}
+	if status.Auth.AccountLabel != "API Usage Billing" {
+		t.Fatalf("Auth.AccountLabel = %q, want %q", status.Auth.AccountLabel, "API Usage Billing")
+	}
+}
+
 func TestServiceListRetriesClaudeAuthStatusCommandWhenOutputIsUnrecognized(t *testing.T) {
 	home := t.TempDir()
 	binDir := filepath.Join(home, ".nvm", "versions", "node", "v24.12.0", "bin")


### PR DESCRIPTION
When Claude Code is configured with an Anthropic API key or a custom API endpoint, the environment wizard currently reports the provider as "未登录" and blocks usage. API Usage Billing does not require an Anthropic Console login session, so this change treats that configuration as authenticated.

Changes:
- Added `claudeCodeUsesAPIBilling` helper that detects API key / custom endpoint configuration for Claude Code.
- Updated the provider status logic to mark Claude Code as ready when API Usage Billing is configured, even if `claude auth status` reports `loggedIn: false`.
- Added tests covering both `ANTHROPIC_API_KEY` env var and `~/.claude/settings.json` API key configuration.
- Added changeset for the desktop package.

Fixes the issue where API-only Claude Code users were intercepted by the environment setup dialog.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Claude Code now reports as **ready** when Anthropic credentials are configured, instead of appearing unauthenticated.
  * Prevents incorrectly labeling a custom endpoint as **API-billing** when no credential is provided.
  * The Agent Environment “login” completion label now clearly distinguishes **OAuth login** vs **API billing configured**.
* **New Features**
  * Provider status responses and the Agent Environment wizard can now expose/display the **authentication method**.
* **Tests**
  * Expanded coverage for API-billing readiness, label/authMethod behavior, and daemon/API response assertions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->