### PR TITLE
fix(agent-gui): add image copy and download actions

### DIFF
--- a/packages/agent/gui/agent-gui/agentGuiNode/AgentComposer.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/AgentComposer.tsx
@@ -2980,6 +2980,7 @@ function AgentComposerDraftImagePreview({
           src={image.previewUrl}
           alt={image.name}
           className="size-full object-contain"
+          downloadName={image.name || "image.png"}
           draggable={false}
           onLoad={(event) => {
             const element = event.currentTarget;

--- a/packages/agent/gui/app/renderer/agentactivity.css
+++ b/packages/agent/gui/app/renderer/agentactivity.css
@@ -117,22 +117,25 @@
   gap: 8px;
 }
 
-.tsh-image-context-menu {
+.tsh-image-copy-status {
   position: fixed;
-  z-index: 100302;
-  min-width: 148px;
-  overflow: hidden;
+  left: 50%;
+  top: max(20px, calc(var(--cove-titlebar-reserve, 0px) + 10px));
+  z-index: 100303;
+  transform: translateX(-50%);
   border: 1px solid var(--line-2);
   border-radius: 8px;
   background: var(--background-panel);
   box-shadow: 0 18px 40px color-mix(in srgb, black 26%, transparent);
   color: var(--text-primary);
-  padding: 4px;
+  font-size: 13px;
+  font-weight: 600;
+  line-height: 20px;
+  padding: 8px 12px;
   -webkit-app-region: no-drag;
 }
 
-.tsh-zoom-dialog__image-actions button,
-.tsh-image-context-menu button {
+.tsh-zoom-dialog__image-actions button {
   display: flex;
   align-items: center;
   gap: 8px;
@@ -144,12 +147,9 @@
   font: inherit;
   font-size: 13px;
   line-height: 20px;
-}
-
-.tsh-zoom-dialog__image-actions button {
-  justify-content: center;
   width: 40px;
   height: 40px;
+  justify-content: center;
   background: color-mix(in srgb, var(--background-panel) 78%, black 22%);
   box-shadow:
     0 18px 40px color-mix(in srgb, black 26%, transparent),
@@ -165,13 +165,7 @@
   white-space: nowrap;
 }
 
-.tsh-image-context-menu button {
-  width: 100%;
-  padding: 7px 10px;
-}
-
-.tsh-zoom-dialog__image-actions button:hover,
-.tsh-image-context-menu button:hover {
+.tsh-zoom-dialog__image-actions button:hover {
   background: color-mix(in srgb, var(--background-panel) 82%, white 12%);
 }
 

--- a/packages/agent/gui/app/renderer/components/ZoomableImage.tsx
+++ b/packages/agent/gui/app/renderer/components/ZoomableImage.tsx
@@ -4,22 +4,31 @@ import {
   type ComponentPropsWithoutRef,
   type JSX,
   type MouseEvent,
+  type PointerEvent,
   type ReactElement,
+  type SyntheticEvent,
   useCallback,
   useEffect,
   useMemo,
+  useRef,
   useState
 } from "react";
 import { CopyIcon, DownloadIcon } from "lucide-react";
 import Zoom from "react-medium-image-zoom";
+import { ViewportMenuSurface, menuItemClassName } from "@tutti-os/ui-system";
 import { useTranslation } from "../../../i18n/index";
 import { cn } from "../lib/utils";
-import { ConversationImageContextMenu } from "../../../shared/agentConversation/components/ConversationImageContextMenu";
+import { useOptionalAgentHostApi } from "../../../agentActivityHost";
 import { copyImageToClipboard } from "../../../shared/agentConversation/lib/copyImageToClipboard";
 
 interface ZoomableImageProps extends ComponentPropsWithoutRef<"img"> {
   downloadName?: string;
   wrapElement?: "div" | "span";
+}
+
+interface ImageContextMenuState {
+  point: { x: number; y: number };
+  portalTarget: Element | null;
 }
 
 export function ZoomableImage({
@@ -31,6 +40,7 @@ export function ZoomableImage({
   ...props
 }: ZoomableImageProps): JSX.Element {
   const { t } = useTranslation();
+  const agentHostApi = useOptionalAgentHostApi();
   const actionSource =
     typeof src === "string" && src.trim() ? src.trim() : null;
   const hasImageActions = Boolean(actionSource && downloadName !== undefined);
@@ -38,47 +48,37 @@ export function ZoomableImage({
     () => resolveImageDownloadName(downloadName, actionSource),
     [actionSource, downloadName]
   );
-  const [contextMenuPosition, setContextMenuPosition] = useState<{
-    x: number;
-    y: number;
-  } | null>(null);
-
-  const closeContextMenu = useCallback(() => {
-    setContextMenuPosition(null);
-  }, []);
+  const [copyStatusMessage, setCopyStatusMessage] = useState<string | null>(
+    null
+  );
+  const [imageContextMenu, setImageContextMenu] =
+    useState<ImageContextMenuState | null>(null);
 
   useEffect(() => {
-    if (!contextMenuPosition) {
+    if (!copyStatusMessage) {
       return;
     }
-
-    document.addEventListener("click", closeContextMenu);
-    document.addEventListener("scroll", closeContextMenu, true);
-    return () => {
-      document.removeEventListener("click", closeContextMenu);
-      document.removeEventListener("scroll", closeContextMenu, true);
-    };
-  }, [closeContextMenu, contextMenuPosition]);
-
-  const handleContextMenu = useCallback(
-    (event: MouseEvent<HTMLImageElement>): void => {
-      onContextMenu?.(event);
-      if (event.defaultPrevented || !actionSource || !hasImageActions) {
-        return;
-      }
-      event.preventDefault();
-      setContextMenuPosition({ x: event.clientX, y: event.clientY });
-    },
-    [actionSource, hasImageActions, onContextMenu]
-  );
+    const timer = setTimeout(() => setCopyStatusMessage(null), 1600);
+    return () => clearTimeout(timer);
+  }, [copyStatusMessage]);
 
   const handleCopyImage = useCallback(async (): Promise<void> => {
     if (!actionSource) {
       return;
     }
-    closeContextMenu();
-    await copyImageToClipboard(actionSource);
-  }, [actionSource, closeContextMenu]);
+    setCopyStatusMessage(t("agentHost.agentGui.imageCopying"));
+    const copied = await copyImageToClipboard(
+      actionSource,
+      agentHostApi?.clipboard
+    );
+    setCopyStatusMessage(
+      t(
+        copied
+          ? "agentHost.agentGui.imageCopied"
+          : "agentHost.agentGui.imageCopyFailed"
+      )
+    );
+  }, [actionSource, agentHostApi?.clipboard, t]);
 
   const handleCopyImageAction = useCallback((): void => {
     void handleCopyImage().catch(() => undefined);
@@ -88,9 +88,38 @@ export function ZoomableImage({
     if (!actionSource) {
       return;
     }
-    closeContextMenu();
     downloadImage(actionSource, resolvedDownloadName);
-  }, [actionSource, closeContextMenu, resolvedDownloadName]);
+    setCopyStatusMessage(t("agentHost.agentGui.imageDownloadStarted"));
+  }, [actionSource, resolvedDownloadName, t]);
+
+  const closeImageContextMenu = useCallback((): void => {
+    setImageContextMenu(null);
+  }, []);
+
+  const handleImageContextMenu = useCallback(
+    (event: MouseEvent<HTMLImageElement>): void => {
+      onContextMenu?.(event);
+      if (!hasImageActions || event.defaultPrevented) {
+        return;
+      }
+
+      event.preventDefault();
+      event.stopPropagation();
+      setImageContextMenu({
+        point: { x: event.clientX, y: event.clientY },
+        portalTarget: event.currentTarget.closest(".tsh-zoom-dialog")
+      });
+    },
+    [hasImageActions, onContextMenu]
+  );
+
+  const handleContextMenuCopy = useCallback((): void => {
+    handleCopyImageAction();
+  }, [handleCopyImageAction]);
+
+  const handleContextMenuDownload = useCallback((): void => {
+    handleDownloadImage();
+  }, [handleDownloadImage]);
 
   const actionButtons = hasImageActions ? (
     <ImageActionButtons
@@ -113,19 +142,17 @@ export function ZoomableImage({
       typeof (img.props as { src?: unknown }).src === "string"
         ? (img.props as { src: string }).src
         : null;
+    const modalDownloadName = actionButtons ? resolvedDownloadName : undefined;
     return (
       <>
-        {!actionButtons && img && zoomSrc ? (
-          <ConversationImageContextMenu
-            src={zoomSrc}
-            asChild
-            contentStyle={{ zIndex: "var(--z-dialog-popover)" }}
-          >
-            {img}
-          </ConversationImageContextMenu>
-        ) : (
-          img
-        )}
+        {img && zoomSrc
+          ? cloneElement(img as ReactElement<ComponentPropsWithoutRef<"img">>, {
+              onContextMenu:
+                modalDownloadName !== undefined
+                  ? handleImageContextMenu
+                  : onContextMenu
+            })
+          : img}
         {actionButtons ? (
           <div className="tsh-zoom-dialog__image-actions nodrag tsh-desktop-no-drag">
             {actionButtons}
@@ -147,6 +174,7 @@ export function ZoomableImage({
         a11yNameButtonZoom={t("common.expandImage")}
         a11yNameButtonUnzoom={t("common.minimizeImage")}
         classDialog="tsh-zoom-dialog nodrag tsh-desktop-no-drag"
+        isDisabled={imageContextMenu !== null}
         wrapElement={wrapElement}
         zoomMargin={24}
         ZoomContent={renderZoomContent}
@@ -154,30 +182,128 @@ export function ZoomableImage({
         <img
           {...props}
           src={src}
-          onContextMenu={hasImageActions ? handleContextMenu : onContextMenu}
+          onContextMenu={
+            hasImageActions ? handleImageContextMenu : onContextMenu
+          }
           className={cn("nodrag tsh-desktop-no-drag cursor-zoom-in", className)}
         />
       </Zoom>
-      {contextMenuPosition && actionButtons ? (
-        <div
-          className="tsh-image-context-menu nodrag tsh-desktop-no-drag"
-          style={{
-            left: contextMenuPosition.x,
-            top: contextMenuPosition.y
-          }}
-          role="menu"
-          onClick={(event) => event.stopPropagation()}
-        >
-          <ImageActionButtons
-            copyLabel={t("common.copyImage")}
-            downloadLabel={t("common.downloadImage")}
-            itemRole="menuitem"
-            onCopy={handleCopyImageAction}
-            onDownload={handleDownloadImage}
-          />
+      {hasImageActions && imageContextMenu ? (
+        <ImageContextMenuSurface
+          copyLabel={t("common.copyImage")}
+          downloadLabel={t("common.downloadImage")}
+          onCopy={handleContextMenuCopy}
+          onDismiss={closeImageContextMenu}
+          onDownload={handleContextMenuDownload}
+          point={imageContextMenu.point}
+          portalTarget={imageContextMenu.portalTarget}
+        />
+      ) : null}
+      {copyStatusMessage ? (
+        <div className="tsh-image-copy-status" role="status">
+          {copyStatusMessage}
         </div>
       ) : null}
     </>
+  );
+}
+
+function ImageContextMenuSurface({
+  copyLabel,
+  downloadLabel,
+  onCopy,
+  onDismiss,
+  onDownload,
+  point,
+  portalTarget
+}: {
+  copyLabel: string;
+  downloadLabel: string;
+  onCopy: () => void;
+  onDismiss: () => void;
+  onDownload: () => void;
+  point: { x: number; y: number };
+  portalTarget: Element | null;
+}): JSX.Element {
+  const actionPendingRef = useRef(false);
+  const runAction = useCallback((action: () => void): void => {
+    if (actionPendingRef.current) {
+      return;
+    }
+    actionPendingRef.current = true;
+    action();
+  }, []);
+  const runPointerAction = useCallback(
+    (event: PointerEvent<HTMLButtonElement>, action: () => void): void => {
+      event.stopPropagation();
+      runAction(action);
+    },
+    [runAction]
+  );
+  const runClickAction = useCallback(
+    (event: SyntheticEvent<HTMLButtonElement>, action: () => void): void => {
+      event.preventDefault();
+      event.stopPropagation();
+      runAction(action);
+      onDismiss();
+    },
+    [onDismiss, runAction]
+  );
+  const stopMenuButtonEvent = useCallback(
+    (event: SyntheticEvent<HTMLButtonElement>): void => {
+      event.preventDefault();
+      event.stopPropagation();
+    },
+    []
+  );
+
+  return (
+    <ViewportMenuSurface
+      open
+      className="min-w-[148px]"
+      dismissOnEscape
+      dismissOnPointerDownOutside
+      dismissOnScroll
+      onDismiss={onDismiss}
+      placement={{
+        type: "point",
+        point,
+        estimatedSize: { width: 148, height: 67 },
+        padding: 8
+      }}
+      portalTarget={portalTarget}
+      role="menu"
+      style={{ zIndex: 100302 }}
+    >
+      <button
+        className={cn(
+          menuItemClassName,
+          "w-full border-0 bg-transparent text-left"
+        )}
+        onClick={(event) => runClickAction(event, onCopy)}
+        onMouseDown={stopMenuButtonEvent}
+        onPointerDown={(event) => runPointerAction(event, onCopy)}
+        onPointerUp={stopMenuButtonEvent}
+        role="menuitem"
+        type="button"
+      >
+        <span>{copyLabel}</span>
+      </button>
+      <button
+        className={cn(
+          menuItemClassName,
+          "w-full border-0 bg-transparent text-left"
+        )}
+        onClick={(event) => runClickAction(event, onDownload)}
+        onMouseDown={stopMenuButtonEvent}
+        onPointerDown={(event) => runPointerAction(event, onDownload)}
+        onPointerUp={stopMenuButtonEvent}
+        role="menuitem"
+        type="button"
+      >
+        <span>{downloadLabel}</span>
+      </button>
+    </ViewportMenuSurface>
   );
 }
 

--- a/packages/agent/gui/app/renderer/i18n/locales/en.ts
+++ b/packages/agent/gui/app/renderer/i18n/locales/en.ts
@@ -545,6 +545,10 @@ export const en = {
       composerTextMenu: "Composer text actions",
       copyMessage: "Copy message",
       copyImage: "Copy image",
+      imageCopying: "Copying image...",
+      imageCopied: "Image copied",
+      imageCopyFailed: "Unable to copy image",
+      imageDownloadStarted: "Image download started",
       messageCopied: "Copied",
       promptTipsPrefix: "Tips: ",
       reviewPicker: {

--- a/packages/agent/gui/app/renderer/i18n/locales/zh-CN.ts
+++ b/packages/agent/gui/app/renderer/i18n/locales/zh-CN.ts
@@ -500,6 +500,10 @@ export const zhCN = {
       composerTextMenu: "输入框文本操作",
       copyMessage: "复制消息",
       copyImage: "复制图片",
+      imageCopying: "正在复制图片...",
+      imageCopied: "图片已复制",
+      imageCopyFailed: "图片复制失败",
+      imageDownloadStarted: "图片下载已开始",
       messageCopied: "已复制",
       promptTipsPrefix: "Tips：",
       reviewPicker: {

--- a/packages/agent/gui/shared/AgentMessageMarkdown.spec.tsx
+++ b/packages/agent/gui/shared/AgentMessageMarkdown.spec.tsx
@@ -772,19 +772,42 @@ describe("AgentMessageMarkdown", () => {
 
     const image = await screen.findByRole("img", { name: "generated image" });
     fireEvent.contextMenu(image, { clientX: 12, clientY: 34 });
-    expect(screen.getByRole("menu")).toHaveStyle({ left: "12px", top: "34px" });
+    expect(screen.getByRole("menu")).toHaveStyle({ zIndex: "100302" });
 
-    fireEvent.click(screen.getByRole("menuitem", { name: "Copy image" }));
+    const copyMenuItem = screen.getByRole("menuitem", { name: "Copy image" });
+    fireEvent.pointerDown(copyMenuItem);
+    expect(screen.getByRole("menu")).toBeInTheDocument();
+    expect(screen.queryByRole("dialog")).toBeNull();
+    fireEvent.click(image);
+    expect(screen.queryByRole("dialog")).toBeNull();
+    fireEvent.pointerUp(copyMenuItem);
+    fireEvent.click(copyMenuItem);
     await waitFor(() => {
       expect(write).toHaveBeenCalledTimes(1);
+      expect(screen.getByRole("status")).toHaveTextContent("Image copied");
     });
+    expect(screen.queryByRole("dialog")).toBeNull();
     expect(fetchImage).toHaveBeenCalledWith("blob:tsh-markdown-image");
     expect(clipboardItems).toHaveLength(1);
 
     fireEvent.click(screen.getByRole("button", { name: /Zoom image/ }));
-    await screen.findByRole("dialog");
-    fireEvent.click(screen.getByRole("button", { name: "Download image" }));
+    const dialog = await screen.findByRole("dialog");
+    const modalImage = dialog.querySelector("img");
+    expect(modalImage).toBeInstanceOf(HTMLElement);
+    fireEvent.contextMenu(modalImage as HTMLElement, {
+      clientX: 18,
+      clientY: 40
+    });
+    expect(screen.getByRole("menu").closest(".tsh-zoom-dialog")).toBe(dialog);
+    const downloadMenuItem = screen.getByRole("menuitem", {
+      name: "Download image"
+    });
+    fireEvent.pointerDown(downloadMenuItem);
+    expect(screen.getByRole("menu").closest(".tsh-zoom-dialog")).toBe(dialog);
+    fireEvent.pointerUp(downloadMenuItem);
+    fireEvent.click(downloadMenuItem);
     expect(clickDownload).toHaveBeenCalledTimes(1);
+    expect(screen.getByRole("dialog")).toBeInTheDocument();
 
     clickDownload.mockRestore();
   });
@@ -820,10 +843,10 @@ describe("AgentMessageMarkdown", () => {
 
     const dialog = await screen.findByRole("dialog");
     expect(dialog).toBeInTheDocument();
+    const modalImage = dialog.querySelector("img");
+    expect(modalImage).toBeInstanceOf(HTMLElement);
 
     fireEvent.click(screen.getByRole("button", { name: /Minimize image/ }));
-    const modalImage = dialog.querySelector("[data-rmiz-modal-img]");
-    expect(modalImage).toBeInstanceOf(HTMLElement);
     fireEvent.transitionEnd(modalImage as HTMLElement);
 
     await waitFor(() => {

--- a/packages/agent/gui/shared/agentConversation/components/AgentMessageBlock.tsx
+++ b/packages/agent/gui/shared/agentConversation/components/AgentMessageBlock.tsx
@@ -39,7 +39,6 @@ import { AgentThinkingDisclosure } from "./AgentThinkingDisclosure";
 import { RawTimelineJsonDisclosure } from "./RawTimelineJsonDisclosure";
 import styles from "../../../agent-gui/agentGuiNode/AgentGUIConversation.styles";
 import { CanvasNodeGhostIconButton } from "../../../contexts/workspace/presentation/renderer/components/shared/CanvasNodeGhostIconButton";
-import { ConversationImageContextMenu } from "./ConversationImageContextMenu";
 
 const MESSAGE_COPY_FEEDBACK_MS = 1400;
 const CONTEXT_COMPACTION_NOTICE_TITLE = "Context compacted.";
@@ -337,14 +336,13 @@ function AgentUserImageGrid({
             className="max-h-20 min-w-0 overflow-hidden rounded-[6px]"
           >
             {src ? (
-              <ConversationImageContextMenu src={src}>
-                <ZoomableImage
-                  src={src}
-                  alt={image.name?.trim() || "image"}
-                  className="block max-h-20 w-full rounded-[6px] object-contain"
-                  draggable={false}
-                />
-              </ConversationImageContextMenu>
+              <ZoomableImage
+                src={src}
+                alt={image.name?.trim() || "image"}
+                className="block max-h-20 w-full rounded-[6px] object-contain"
+                draggable={false}
+                downloadName={image.name?.trim() || "image.png"}
+              />
             ) : loading ? (
               <div
                 className="flex h-20 w-full items-center justify-center bg-[color-mix(in_srgb,var(--text-primary)_6%,transparent)]"

--- a/packages/agent/gui/shared/agentConversation/components/ConversationImageContextMenu.spec.tsx
+++ b/packages/agent/gui/shared/agentConversation/components/ConversationImageContextMenu.spec.tsx
@@ -48,7 +48,7 @@ describe("ConversationImageContextMenu", () => {
     );
   });
 
-  it("copies and closes the menu on pointer down", async () => {
+  it("shows feedback after copying from the context menu", async () => {
     copyImageToClipboardMock.mockResolvedValue(true);
 
     render(
@@ -58,16 +58,33 @@ describe("ConversationImageContextMenu", () => {
     );
 
     fireEvent.contextMenu(screen.getByTestId("image"));
-
-    const copyItem = await screen.findByText("Copy image");
-    fireEvent.pointerDown(copyItem, { button: 0 });
+    const copyItem = await screen.findByRole("menuitem", {
+      name: "Copy image"
+    });
+    fireEvent.pointerDown(copyItem);
+    expect(screen.getByRole("menuitem", { name: "Copy image" })).toBeVisible();
+    fireEvent.pointerUp(copyItem);
+    fireEvent.click(copyItem);
 
     expect(copyImageToClipboardMock).toHaveBeenCalledWith(
       "blob:preview",
       expect.anything()
     );
     await waitFor(() => {
-      expect(screen.queryByText("Copy image")).toBeNull();
+      expect(screen.getByRole("status")).toHaveTextContent("Image copied");
+      expect(screen.queryByRole("menuitem", { name: "Copy image" })).toBeNull();
     });
+  });
+
+  it("keeps the context menu above zoom previews", async () => {
+    render(
+      <ConversationImageContextMenu src="blob:preview">
+        <img data-testid="image" alt="" />
+      </ConversationImageContextMenu>
+    );
+
+    fireEvent.contextMenu(screen.getByTestId("image"));
+
+    expect(await screen.findByRole("menu")).toHaveStyle({ zIndex: "100302" });
   });
 });

--- a/packages/agent/gui/shared/agentConversation/components/ConversationImageContextMenu.tsx
+++ b/packages/agent/gui/shared/agentConversation/components/ConversationImageContextMenu.tsx
@@ -1,10 +1,13 @@
 import {
   useCallback,
+  useEffect,
   useRef,
   useState,
   type CSSProperties,
   type JSX,
-  type ReactNode
+  type PointerEvent,
+  type ReactNode,
+  type SyntheticEvent
 } from "react";
 import {
   ContextMenu,
@@ -16,14 +19,18 @@ import { useOptionalAgentHostApi } from "../../../agentActivityHost";
 import { copyImageToClipboard } from "../lib/copyImageToClipboard";
 import { translate } from "../../../i18n/index";
 
+type ImageActionStatus = "copying" | "success" | "failed" | "download";
+
 export function ConversationImageContextMenu({
   src,
   children,
   asChild = false,
-  contentStyle
+  contentStyle,
+  downloadName
 }: {
   src: string;
   children: ReactNode;
+  downloadName?: string;
   /**
    * Attach the right-click listener directly to the child element instead of a
    * wrapper span. Used for the zoomed image, whose positioning the zoom library
@@ -37,36 +44,145 @@ export function ConversationImageContextMenu({
   contentStyle?: CSSProperties;
 }): JSX.Element {
   const agentHostApi = useOptionalAgentHostApi();
-  const copyStartedRef = useRef(false);
   const [menuResetKey, setMenuResetKey] = useState(0);
-  const copyAndClose = useCallback(() => {
-    if (copyStartedRef.current) {
-      return;
-    }
-    copyStartedRef.current = true;
-    setMenuResetKey((key) => key + 1);
-    void copyImageToClipboard(src, agentHostApi?.clipboard).finally(() => {
-      copyStartedRef.current = false;
+  const [contentVisible, setContentVisible] = useState(false);
+  const [actionStatus, setActionStatus] = useState<ImageActionStatus | null>(
+    null
+  );
+  const actionPendingRef = useRef(false);
+
+  const handleCopy = useCallback(() => {
+    setActionStatus("copying");
+    void copyImageToClipboard(src, agentHostApi?.clipboard).then((ok) => {
+      setActionStatus(ok ? "success" : "failed");
     });
   }, [agentHostApi?.clipboard, src]);
-  return (
-    <ContextMenu key={menuResetKey}>
-      <ContextMenuTrigger asChild={asChild}>{children}</ContextMenuTrigger>
-      <ContextMenuContent style={contentStyle}>
-        <ContextMenuItem
-          onClick={copyAndClose}
-          onPointerDown={(event) => {
-            if (event.button !== 0) {
-              return;
-            }
-            event.preventDefault();
-            copyAndClose();
-          }}
-          onSelect={copyAndClose}
-        >
-          {translate("agentHost.agentGui.copyImage")}
-        </ContextMenuItem>
-      </ContextMenuContent>
-    </ContextMenu>
+
+  const handleDownload = useCallback(() => {
+    downloadImage(src, downloadName || "image.png");
+    setActionStatus("download");
+  }, [downloadName, src]);
+
+  const runMenuAction = useCallback((action: () => void) => {
+    if (actionPendingRef.current) {
+      return;
+    }
+    actionPendingRef.current = true;
+    action();
+  }, []);
+
+  const handleMenuItemSelect = useCallback(
+    (event: Event, action: () => void) => {
+      event.preventDefault();
+      event.stopPropagation();
+      runMenuAction(action);
+    },
+    [runMenuAction]
   );
+
+  const handleMenuItemPointerDown = useCallback(
+    (event: PointerEvent<HTMLElement>, action: () => void) => {
+      event.preventDefault();
+      event.stopPropagation();
+      runMenuAction(action);
+    },
+    [runMenuAction]
+  );
+  const stopMenuItemEvent = useCallback(
+    (event: SyntheticEvent<HTMLElement>) => {
+      event.preventDefault();
+      event.stopPropagation();
+    },
+    []
+  );
+  const handleMenuItemClick = useCallback(
+    (event: SyntheticEvent<HTMLElement>, action: () => void) => {
+      event.preventDefault();
+      event.stopPropagation();
+      runMenuAction(action);
+      setContentVisible(false);
+      setMenuResetKey((key) => key + 1);
+      actionPendingRef.current = false;
+    },
+    [runMenuAction]
+  );
+
+  useEffect(() => {
+    if (!actionStatus) {
+      return;
+    }
+    const timer = setTimeout(() => setActionStatus(null), 1600);
+    return () => clearTimeout(timer);
+  }, [actionStatus]);
+
+  return (
+    <>
+      <ContextMenu key={menuResetKey} modal={false}>
+        <ContextMenuTrigger
+          asChild={asChild}
+          onContextMenu={() => setContentVisible(true)}
+        >
+          {children}
+        </ContextMenuTrigger>
+        {contentVisible ? (
+          <ContextMenuContent
+            style={{
+              minWidth: 148,
+              zIndex: 100302,
+              ...contentStyle
+            }}
+          >
+            <ContextMenuItem
+              onClick={(event) => handleMenuItemClick(event, handleCopy)}
+              onPointerDown={(event) =>
+                handleMenuItemPointerDown(event, handleCopy)
+              }
+              onPointerUp={stopMenuItemEvent}
+              onSelect={(event) => handleMenuItemSelect(event, handleCopy)}
+            >
+              <span>{translate("agentHost.agentGui.copyImage")}</span>
+            </ContextMenuItem>
+            <ContextMenuItem
+              onClick={(event) => handleMenuItemClick(event, handleDownload)}
+              onPointerDown={(event) =>
+                handleMenuItemPointerDown(event, handleDownload)
+              }
+              onPointerUp={stopMenuItemEvent}
+              onSelect={(event) => handleMenuItemSelect(event, handleDownload)}
+            >
+              <span>{translate("common.downloadImage")}</span>
+            </ContextMenuItem>
+          </ContextMenuContent>
+        ) : null}
+      </ContextMenu>
+      {actionStatus ? (
+        <span className="tsh-image-copy-status" role="status">
+          {translate(imageActionStatusMessageKey(actionStatus))}
+        </span>
+      ) : null}
+    </>
+  );
+}
+
+function imageActionStatusMessageKey(status: ImageActionStatus): string {
+  if (status === "copying") {
+    return "agentHost.agentGui.imageCopying";
+  }
+  if (status === "success") {
+    return "agentHost.agentGui.imageCopied";
+  }
+  if (status === "download") {
+    return "agentHost.agentGui.imageDownloadStarted";
+  }
+  return "agentHost.agentGui.imageCopyFailed";
+}
+
+function downloadImage(src: string, name: string): void {
+  const link = document.createElement("a");
+  link.href = src;
+  link.download = name;
+  link.rel = "noopener";
+  document.body.append(link);
+  link.click();
+  link.remove();
 }

--- a/packages/agent/gui/shared/agentConversation/lib/copyImageToClipboard.spec.ts
+++ b/packages/agent/gui/shared/agentConversation/lib/copyImageToClipboard.spec.ts
@@ -3,6 +3,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import { copyImageToClipboard } from "./copyImageToClipboard";
 
 afterEach(() => {
+  vi.useRealTimers();
   vi.restoreAllMocks();
   vi.unstubAllGlobals();
 });
@@ -89,5 +90,28 @@ describe("copyImageToClipboard", () => {
       vi.fn().mockResolvedValue({ blob: () => Promise.resolve(pngBlob) })
     );
     expect(await copyImageToClipboard("blob:abc")).toBe(false);
+  });
+
+  it("returns false when clipboard write does not resolve", async () => {
+    vi.useFakeTimers();
+    const write = vi.fn().mockReturnValue(new Promise(() => {}));
+    const pngBlob = new Blob(["png"], { type: "image/png" });
+    vi.stubGlobal("navigator", { clipboard: { write } });
+    vi.stubGlobal(
+      "ClipboardItem",
+      class {
+        constructor(_: unknown) {}
+      }
+    );
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({ blob: () => Promise.resolve(pngBlob) })
+    );
+
+    const result = copyImageToClipboard("blob:abc");
+    await vi.runAllTimersAsync();
+
+    expect(await result).toBe(false);
+    expect(write).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/agent/gui/shared/agentConversation/lib/copyImageToClipboard.ts
+++ b/packages/agent/gui/shared/agentConversation/lib/copyImageToClipboard.ts
@@ -1,3 +1,5 @@
+const COPY_IMAGE_TIMEOUT_MS = 1500;
+
 // ClipboardItem reliably supports only image/png, so non-png sources are
 // rasterised to png via an offscreen canvas before writing.
 export interface CopyImageClipboardHost {
@@ -39,6 +41,25 @@ async function blobToBase64(blob: Blob): Promise<string> {
   });
 }
 
+function withTimeout<T>(promise: Promise<T>, fallback: T): Promise<T> {
+  return new Promise((resolve) => {
+    const timer = globalThis.setTimeout(
+      () => resolve(fallback),
+      COPY_IMAGE_TIMEOUT_MS
+    );
+    promise.then(
+      (value) => {
+        globalThis.clearTimeout(timer);
+        resolve(value);
+      },
+      () => {
+        globalThis.clearTimeout(timer);
+        resolve(fallback);
+      }
+    );
+  });
+}
+
 async function copyImageWithWebClipboard(blob: Blob): Promise<boolean> {
   if (
     typeof navigator === "undefined" ||
@@ -55,7 +76,7 @@ async function copyImageWithWebClipboard(blob: Blob): Promise<boolean> {
   }
 }
 
-export async function copyImageToClipboard(
+async function copyImageToClipboardUnchecked(
   src: string,
   hostClipboard?: CopyImageClipboardHost | null
 ): Promise<boolean> {
@@ -82,4 +103,11 @@ export async function copyImageToClipboard(
   } catch {
     return false;
   }
+}
+
+export function copyImageToClipboard(
+  src: string,
+  hostClipboard?: CopyImageClipboardHost | null
+): Promise<boolean> {
+  return withTimeout(copyImageToClipboardUnchecked(src, hostClipboard), false);
 }

--- a/packages/agent/gui/vitest.setup.ts
+++ b/packages/agent/gui/vitest.setup.ts
@@ -86,12 +86,14 @@ vi.mock("react-medium-image-zoom", () => ({
     a11yNameButtonUnzoom,
     children,
     classDialog,
+    isDisabled,
     ZoomContent
   }: {
     a11yNameButtonZoom?: string;
     a11yNameButtonUnzoom?: string;
     children?: ReactNode;
     classDialog?: string;
+    isDisabled?: boolean;
     ZoomContent?: (props: {
       buttonUnzoom: ReactElement;
       img: ReactElement | null;
@@ -110,7 +112,9 @@ vi.mock("react-medium-image-zoom", () => ({
         ? cloneElement(childElement, {
             onClick: (event: ReactMouseEvent) => {
               childElement.props.onClick?.(event);
-              setIsOpen(true);
+              if (!isDisabled) {
+                setIsOpen(true);
+              }
             }
           })
         : children;
@@ -144,7 +148,11 @@ vi.mock("react-medium-image-zoom", () => ({
             "aria-label": labelZoom,
             "aria-hidden": isOpen ? true : undefined,
             "data-rmiz-btn-zoom": "",
-            onClick: () => setIsOpen(true)
+            onClick: () => {
+              if (!isDisabled) {
+                setIsOpen(true);
+              }
+            }
           },
           labelZoom
         )

--- a/packages/ui/system/src/components/viewport-menu-surface/viewport-menu-surface.tsx
+++ b/packages/ui/system/src/components/viewport-menu-surface/viewport-menu-surface.tsx
@@ -49,6 +49,7 @@ export interface ViewportMenuSurfaceProps extends Omit<
   dismissOnEscape?: boolean;
   dismissOnScroll?: boolean;
   dismissIgnoreRefs?: Array<React.RefObject<HTMLElement | null>>;
+  portalTarget?: Element | null;
   stopEventPropagation?: boolean;
 }
 
@@ -239,6 +240,7 @@ const ViewportMenuSurface = React.forwardRef<
     dismissOnEscape = false,
     dismissOnScroll = false,
     dismissIgnoreRefs = [],
+    portalTarget: explicitPortalTarget,
     stopEventPropagation = true,
     style,
     onMouseDown,
@@ -421,7 +423,8 @@ const ViewportMenuSurface = React.forwardRef<
     return null;
   }
 
-  const portalTarget = resolvedPlacement.portalTarget ?? document.body;
+  const portalTarget =
+    explicitPortalTarget ?? resolvedPlacement.portalTarget ?? document.body;
 
   return createPortal(
     <MenuSurface


### PR DESCRIPTION
## Summary
- add copy/download actions for agent GUI image previews and zoomed images
- use ui-system viewport menu surface so right-click menus stay above zoom layers
- route image copy through the desktop host clipboard when available, with browser clipboard fallback and timeout feedback

## Verification
- make dev-gui, Electron renderer via remote debugging: normal image right-click copy -> 图片已复制
- make dev-gui, Electron renderer via remote debugging: normal image right-click download -> 图片下载已开始
- make dev-gui, Electron renderer via remote debugging: zoomed image right-click menu portals inside .tsh-zoom-dialog with z-index 100302 over dialog 100300
- make dev-gui, Electron renderer via remote debugging: zoomed image copy/download both show success/download-started feedback
- corepack pnpm --filter @tutti-os/agent-gui typecheck
- corepack pnpm --filter @tutti-os/ui-system typecheck
- corepack pnpm --filter @tutti-os/agent-gui exec vitest run --environment jsdom shared/AgentMessageMarkdown.spec.tsx shared/agentConversation/components/ConversationImageContextMenu.spec.tsx shared/agentConversation/lib/copyImageToClipboard.spec.ts
- corepack pnpm --filter @tutti-os/agent-gui exec oxlint ... --deny-warnings
- corepack pnpm --filter @tutti-os/ui-system exec oxlint src/components/viewport-menu-surface/viewport-menu-surface.tsx --deny-warnings
- corepack pnpm check:i18n
- corepack pnpm check:ui-boundaries
- pre-push check:full passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Image previews now support both **Copy** and **Download** from the image menu, with an appropriate download filename (defaults to `image.png`).
  * Image actions show brief **copy/download status feedback** (progress, success, failure).
* **Bug Fixes**
  * Improved image menu interaction and layering so it reliably appears above zoom previews.
  * Clipboard image copy now **fails cleanly** if the clipboard operation hangs (uses a timeout).
* **Localization**
  * Added new English and Simplified Chinese strings for image copy/download states.
* **Tests**
  * Updated context-menu and zoom-preview tests to match the revised copy/download flow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->