### PR TITLE
feat(agent-gui): enter conversation immediately on first message

### DIFF
--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUINodeController.spec.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUINodeController.spec.tsx
@@ -1255,6 +1255,163 @@ describe("useAgentGUINodeController", () => {
     expect(result.current.viewModel.sessionChrome.recovery).toBeNull();
   });
 
+  it("drops the optimistic entry and keeps the user put when they navigate away before a first-message create resolves", async () => {
+    let resolveActivate:
+      | ((result: AgentHostActivateAgentSessionResult) => void)
+      | undefined;
+    let createdId = "";
+    const activate = vi.fn((input: AgentHostActivateAgentSessionInput) => {
+      if (input.mode === "new") {
+        createdId = input.agentSessionId;
+        return new Promise<AgentHostActivateAgentSessionResult>((resolve) => {
+          resolveActivate = resolve;
+        });
+      }
+      return Promise.resolve<AgentHostActivateAgentSessionResult>({
+        session: agentSession(input.agentSessionId),
+        activation: { mode: input.mode, status: "attached" }
+      });
+    });
+    installAgentHostApi({
+      list: vi.fn(async () => snapshotWithSession("session-1")),
+      listSessionTimeline: vi.fn(async () => ({ timelineItems: [] })),
+      subscribeEvents: vi.fn(() => vi.fn()),
+      activate
+    });
+
+    const { result } = renderHook(() =>
+      useAgentGUINodeController({
+        workspaceId: "room-1",
+        currentUserId: "user-1",
+        workspacePath: "/workspace",
+        avoidGroupingEdits: false,
+        data: agentGuiData(null),
+        onDataChange: vi.fn()
+      })
+    );
+
+    await waitFor(() => {
+      expect(
+        result.current.viewModel.conversations.some((c) => c.id === "session-1")
+      ).toBe(true);
+    });
+
+    act(() => {
+      result.current.actions.submitPrompt(promptBlocks("abandoned turn"));
+    });
+    await waitFor(() => {
+      expect(activate).toHaveBeenCalledTimes(1);
+      expect(result.current.viewModel.activeConversationId).toBe(createdId);
+    });
+    // The optimistic user message is recorded before the user navigates away.
+    expect(
+      getAgentSessionView({ workspaceId: "room-1", agentSessionId: createdId })
+        ?.detailMessages.length
+    ).toBeGreaterThan(0);
+
+    act(() => {
+      result.current.actions.selectConversation("session-1");
+    });
+    await waitFor(() => {
+      expect(result.current.viewModel.activeConversationId).toBe("session-1");
+    });
+
+    // The create resolves while the user is on session-1.
+    act(() => {
+      resolveActivate?.({
+        session: agentSession(createdId),
+        activation: { mode: "new", status: "attached" }
+      });
+    });
+    await waitFor(() => {
+      expect(result.current.viewModel.isCreatingConversation).toBe(false);
+    });
+
+    // The abandoned create's optimistic messages are dropped — its pending-turn
+    // user prompt was never retargeted (the session wasn't watched), so it
+    // would reappear as a duplicate when the session is reopened — and the
+    // user stays where they navigated.
+    expect(
+      getAgentSessionView({ workspaceId: "room-1", agentSessionId: createdId })
+        ?.detailMessages ?? []
+    ).toEqual([]);
+    expect(result.current.viewModel.activeConversationId).toBe("session-1");
+  });
+
+  it("does not leak a first-message create error onto the conversation the user switched to during pending", async () => {
+    let rejectActivate: ((error: unknown) => void) | undefined;
+    let createdId = "";
+    const activate = vi.fn((input: AgentHostActivateAgentSessionInput) => {
+      if (input.mode === "new") {
+        createdId = input.agentSessionId;
+        return new Promise<AgentHostActivateAgentSessionResult>(
+          (_resolve, reject) => {
+            rejectActivate = reject;
+          }
+        );
+      }
+      return Promise.resolve<AgentHostActivateAgentSessionResult>({
+        session: agentSession(input.agentSessionId),
+        activation: { mode: input.mode, status: "attached" }
+      });
+    });
+    installAgentHostApi({
+      list: vi.fn(async () => snapshotWithSession("session-1")),
+      listSessionTimeline: vi.fn(async () => ({ timelineItems: [] })),
+      subscribeEvents: vi.fn(() => vi.fn()),
+      activate
+    });
+
+    const { result } = renderHook(() =>
+      useAgentGUINodeController({
+        workspaceId: "room-1",
+        currentUserId: "user-1",
+        workspacePath: "/workspace",
+        avoidGroupingEdits: false,
+        data: agentGuiData(null),
+        onDataChange: vi.fn()
+      })
+    );
+
+    await waitFor(() => {
+      expect(
+        result.current.viewModel.conversations.some((c) => c.id === "session-1")
+      ).toBe(true);
+    });
+
+    act(() => {
+      result.current.actions.submitPrompt(promptBlocks("abandoned turn"));
+    });
+    await waitFor(() => {
+      expect(activate).toHaveBeenCalledTimes(1);
+      expect(result.current.viewModel.activeConversationId).toBe(createdId);
+    });
+    expect(
+      getAgentSessionView({ workspaceId: "room-1", agentSessionId: createdId })
+        ?.detailMessages.length
+    ).toBeGreaterThan(0);
+
+    act(() => {
+      result.current.actions.selectConversation("session-1");
+    });
+    await waitFor(() => {
+      expect(result.current.viewModel.activeConversationId).toBe("session-1");
+    });
+
+    act(() => {
+      rejectActivate?.(new Error("runtime not connected"));
+    });
+    await waitFor(() => {
+      expect(result.current.viewModel.isCreatingConversation).toBe(false);
+    });
+
+    // The failure belongs to the abandoned create, not session-1: it is not
+    // surfaced on the conversation the user is now looking at, and the user
+    // stays where they navigated.
+    expect(result.current.viewModel.detailError).toBeNull();
+    expect(result.current.viewModel.activeConversationId).toBe("session-1");
+  });
+
   it("keeps background session timeline events in the activity snapshot", async () => {
     const retainEventStream = vi.fn(
       async ({ agentSessionId }: { agentSessionId: string }) => ({

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUINodeController.spec.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUINodeController.spec.tsx
@@ -1144,7 +1144,7 @@ describe("useAgentGUINodeController", () => {
     expect(releaseEventStream).not.toHaveBeenCalled();
   });
 
-  it("keeps the first created conversation on home before activation resolves", async () => {
+  it("enters the first created conversation immediately before activation resolves", async () => {
     let resolveActivate:
       | ((result: AgentHostActivateAgentSessionResult) => void)
       | undefined;
@@ -1185,15 +1185,22 @@ describe("useAgentGUINodeController", () => {
 
     await waitFor(() => {
       expect(capturedAgentSessionId).not.toBe("");
-      expect(
-        getAgentSessionView({
-          workspaceId: "room-1",
-          agentSessionId: capturedAgentSessionId
-        })?.isLoadingMessages
-      ).not.toBe(true);
+      expect(result.current.viewModel.activeConversationId).toBe(
+        capturedAgentSessionId
+      );
     });
-    expect(result.current.viewModel.activeConversationId).toBeNull();
+    // The optimistic user message is shown immediately, before activation
+    // resolves, and no per-session loading flag is left on.
+    expect(
+      getAgentSessionView({
+        workspaceId: "room-1",
+        agentSessionId: capturedAgentSessionId
+      })?.isLoadingMessages
+    ).not.toBe(true);
     expect(result.current.viewModel.isCreatingConversation).toBe(true);
+    expect(
+      result.current.viewModel.conversationDetail?.turns[0]?.userMessages
+    ).toEqual([expect.objectContaining({ body: "start the first turn" })]);
 
     await act(async () => {
       resolveActivate?.({
@@ -1207,6 +1214,45 @@ describe("useAgentGUINodeController", () => {
         capturedAgentSessionId
       );
     });
+  });
+
+  it("suppresses the connecting banner during a first-message create while activation is pending", async () => {
+    const activate = vi.fn(
+      (_input: AgentHostActivateAgentSessionInput) =>
+        new Promise<AgentHostActivateAgentSessionResult>(() => {
+          // Keep activation pending so the live state stays "activating".
+        })
+    );
+    installAgentHostApi({
+      list: vi.fn(async () => ({ presences: [], sessions: [] })),
+      listSessionTimeline: vi.fn(async () => ({ timelineItems: [] })),
+      subscribeEvents: vi.fn(() => vi.fn()),
+      activate
+    });
+
+    const { result } = renderHook(() =>
+      useAgentGUINodeController({
+        workspaceId: "room-1",
+        currentUserId: "user-1",
+        workspacePath: "/workspace",
+        avoidGroupingEdits: false,
+        data: agentGuiData(null),
+        onDataChange: vi.fn()
+      })
+    );
+
+    act(() => {
+      result.current.actions.submitPrompt(promptBlocks("first turn"));
+    });
+
+    await waitFor(() => {
+      expect(activate).toHaveBeenCalledTimes(1);
+    });
+    // The live state is "activating" (session creation in flight), but the
+    // initial first-message create must NOT surface the "reconnecting" banner —
+    // the user just submitted and is already seeing their optimistic message.
+    expect(result.current.viewModel.activeLiveState).toBe("activating");
+    expect(result.current.viewModel.sessionChrome.recovery).toBeNull();
   });
 
   it("keeps background session timeline events in the activity snapshot", async () => {
@@ -3453,7 +3499,7 @@ describe("useAgentGUINodeController", () => {
     });
   });
 
-  it("keeps home active while activation is pending and switches after activation succeeds", async () => {
+  it("enters the conversation immediately while activation is pending and stays after it succeeds", async () => {
     let resolveActivation:
       | ((value: AgentHostActivateAgentSessionResult) => void)
       | undefined;
@@ -3500,9 +3546,11 @@ describe("useAgentGUINodeController", () => {
     });
 
     const createdId = activate.mock.calls[0]![0].agentSessionId;
-    expect(result.current.viewModel.activeConversationId).toBeNull();
+    expect(result.current.viewModel.activeConversationId).toBe(createdId);
     expect(result.current.viewModel.isCreatingConversation).toBe(true);
-    expect(result.current.viewModel.draftPrompt).toBe("first prompt");
+    // The active surface is now the new session, whose draft was cleared; the
+    // optimistic user message is already present in the first turn.
+    expect(result.current.viewModel.draftPrompt).toBe("");
     expect(
       getAgentSessionView({
         workspaceId: "room-1",
@@ -3517,7 +3565,7 @@ describe("useAgentGUINodeController", () => {
     ]);
     expect(
       result.current.viewModel.conversationDetail?.turns[0]?.userMessages
-    ).toBeUndefined();
+    ).toEqual([expect.objectContaining({ body: "first prompt" })]);
     expect(exec).not.toHaveBeenCalled();
 
     act(() => {
@@ -3537,15 +3585,15 @@ describe("useAgentGUINodeController", () => {
     expect(exec).not.toHaveBeenCalled();
   });
 
-  it("preserves home draft edits made while first conversation activation is pending", async () => {
-    let resolveActivation:
-      | ((value: AgentHostActivateAgentSessionResult) => void)
-      | undefined;
+  it("restores the original home draft when first conversation activation fails after pending", async () => {
+    let rejectActivation: ((error: unknown) => void) | undefined;
     const activate = vi.fn((input: AgentHostActivateAgentSessionInput) => {
       if (input.mode === "new") {
-        return new Promise<AgentHostActivateAgentSessionResult>((resolve) => {
-          resolveActivation = resolve;
-        });
+        return new Promise<AgentHostActivateAgentSessionResult>(
+          (_resolve, reject) => {
+            rejectActivation = reject;
+          }
+        );
       }
       return Promise.resolve({
         session: agentSession(input.agentSessionId),
@@ -3581,27 +3629,27 @@ describe("useAgentGUINodeController", () => {
       );
     });
     const createdId = activate.mock.calls[0]![0].agentSessionId;
-
+    // During pending the user is already on the new session surface.
+    expect(result.current.viewModel.activeConversationId).toBe(createdId);
+    // Typing while pending edits the in-flight session draft, not the home
+    // draft, which retains the original submitted prompt for restore-on-failure.
     act(() => {
       result.current.actions.updateDraftContent(
-        draftContent("keep this draft")
+        draftContent("a different next turn")
       );
-      resolveActivation?.({
-        session: agentSession(createdId),
-        activation: { mode: "new", status: "attached" }
-      });
+    });
+
+    act(() => {
+      rejectActivation?.(new Error("runtime not connected"));
     });
 
     await waitFor(() => {
-      expect(result.current.viewModel.activeConversationId).toBe(createdId);
+      expect(result.current.viewModel.isCreatingConversation).toBe(false);
     });
-
-    act(() => {
-      result.current.actions.createConversation();
-    });
-
+    // Reverted to the home composer with the ORIGINAL submitted draft preserved.
     expect(result.current.viewModel.activeConversationId).toBeNull();
-    expect(result.current.viewModel.draftPrompt).toBe("keep this draft");
+    expect(result.current.viewModel.draftPrompt).toBe("first prompt");
+    expect(result.current.viewModel.detailError).toBe("runtime not connected");
   });
 
   it("keeps first conversation creation busy after the controller remounts before activation resolves", async () => {
@@ -3736,7 +3784,7 @@ describe("useAgentGUINodeController", () => {
     });
   });
 
-  it("passes the submitted prompt as the activation title without showing a pending history entry", async () => {
+  it("passes the submitted prompt as the activation title and shows an optimistic history entry immediately", async () => {
     const activate = vi.fn(
       (_input: AgentHostActivateAgentSessionInput) =>
         new Promise<AgentHostActivateAgentSessionResult>(() => {
@@ -3775,13 +3823,19 @@ describe("useAgentGUINodeController", () => {
         title: "hello from hero"
       })
     );
+    // No durable history entry yet (activation is still pending)...
     expect(result.current.viewModel.conversations).toEqual([]);
-    expect(result.current.viewModel.activeConversation).toBeNull();
-    expect(result.current.viewModel.activeConversationId).toBeNull();
+    // ...but the user is already on the conversation surface with their
+    // optimistic message shown immediately.
+    const createdId = activate.mock.calls[0]![0].agentSessionId;
+    expect(result.current.viewModel.activeConversationId).toBe(createdId);
+    expect(result.current.viewModel.activeConversation).toEqual(
+      expect.objectContaining({ id: createdId, title: "hello from hero" })
+    );
     expect(result.current.viewModel.isCreatingConversation).toBe(true);
     expect(
       result.current.viewModel.conversationDetail?.turns[0]?.userMessages
-    ).toBeUndefined();
+    ).toEqual([expect.objectContaining({ body: "hello from hero" })]);
   });
 
   it("blocks OpenClaw conversation creation until the gateway is ready", async () => {

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUINodeController.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUINodeController.ts
@@ -6193,6 +6193,22 @@ export function useAgentGUINodeController({
             if (isPendingCreatedConversation) {
               startingConversationIdRef.current = null;
             }
+            // The user navigated away from the optimistic create before it
+            // resolved. Drop the optimistic messages recorded for it: the
+            // optimistic user prompt keeps a pending turn id that retarget
+            // never rewrote (the session wasn't watched), so if it lingered it
+            // would reappear as a duplicate when the session is later reopened
+            // from the conversation list and reloaded from durable history.
+            resetAgentSessionViewDetailMessages(
+              sessionViewRef(conversation.id)
+            );
+            setAgentSessionViewOverlayMessages(
+              sessionViewRef(conversation.id),
+              []
+            );
+            if (transientConversationRef.current?.id === conversation.id) {
+              setTransientConversation(null);
+            }
             return;
           }
           if (isPendingCreatedConversation) {
@@ -6268,8 +6284,13 @@ export function useAgentGUINodeController({
               conversationId: pendingCreateAgentSessionId ?? agentSessionId
             });
           }
+          // Surface the failure only on the failed create's own surface —
+          // either the user is still on it, or they're back at the home
+          // composer where the create started. If they navigated to another
+          // conversation, the error must not leak onto that conversation; the
+          // create is cleaned up silently below.
           const shouldShowErrorOnHome =
-            startingConversationIdRef.current === agentSessionId ||
+            isCurrentConversation(agentSessionId) ||
             (activeConversationIdRef.current === null &&
               isComposerHomeRef.current);
           const submitTrace = submitTraceBySessionIdRef.current[agentSessionId];
@@ -6292,6 +6313,7 @@ export function useAgentGUINodeController({
             !shouldShowErrorOnHome &&
             !isCurrentConversation(agentSessionId)
           ) {
+            failedNewConversationIdsRef.current.add(agentSessionId);
             resetAgentSessionViewDetailMessages(sessionViewRef(agentSessionId));
             setAgentSessionViewOverlayMessages(
               sessionViewRef(agentSessionId),
@@ -6343,10 +6365,6 @@ export function useAgentGUINodeController({
             setActiveConversationId(null);
             setIntent({ tag: "home" });
             persistActiveConversation(null);
-            setAgentSessionViewOverlayMessages(
-              sessionViewRef(agentSessionId),
-              []
-            );
           }
           setIsLoadingMessages(false);
           setAgentSessionViewMessagesLoading(

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUINodeController.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUINodeController.ts
@@ -3378,6 +3378,7 @@ export function useAgentGUINodeController({
   const startingConversationIdRef = useRef<string | null>(null);
   const activatedConversationIdsRef = useRef(new Set<string>());
   const failedNewConversationIdsRef = useRef(new Set<string>());
+  const pendingHomeErrorRef = useRef<string | null>(null);
   const lastActiveModelByProviderRef = useRef<Record<string, string>>({});
   const pendingTurnIdBySessionIdRef = useRef<Record<string, string>>({});
   const submitTraceBySessionIdRef = useRef<
@@ -5768,7 +5769,11 @@ export function useAgentGUINodeController({
       return;
     }
     if (!activeConversationId) {
-      setDetailError(null);
+      // When a failed first-message create reverts to the home composer, the
+      // pending error should be surfaced there instead of being cleared.
+      const pendingHomeError = pendingHomeErrorRef.current;
+      pendingHomeErrorRef.current = null;
+      setDetailError(pendingHomeError ?? null);
       return;
     }
     if (failedNewConversationIdsRef.current.has(activeConversationId)) {
@@ -6032,6 +6037,23 @@ export function useAgentGUINodeController({
           workspaceId,
           fields: { mode: "new" }
         });
+        // Enter the conversation surface immediately so the user sees their
+        // message without waiting for the backend session-creation round-trip.
+        // The home draft is intentionally left intact so a failed activation
+        // can revert to the composer with the user's input preserved. The
+        // activation promise below still owns durable session state and the
+        // clientSubmitId reconciliation once the real turn arrives.
+        setTransientConversation(optimisticConversation);
+        setDraftBySessionId((current) => ({
+          ...current,
+          [agentSessionId]: emptyAgentComposerDraft()
+        }));
+        isComposerHomeRef.current = false;
+        setIsComposerHome(false);
+        activeConversationIdRef.current = agentSessionId;
+        setActiveConversationId(agentSessionId);
+        setIntent({ tag: "active", id: agentSessionId });
+        persistActiveConversation(agentSessionId);
         reportAgentSubmitTraceDiagnostic({
           event: "activation.requested",
           runtime: agentActivityRuntime,
@@ -6100,19 +6122,39 @@ export function useAgentGUINodeController({
             if (startingConversationIdRef.current === agentSessionId) {
               startingConversationIdRef.current = null;
             }
-            if (
+            const shouldRevertToHome =
               isMountedRef.current &&
-              activeConversationIdRef.current === null &&
-              isComposerHomeRef.current
-            ) {
+              (isCurrentConversation(agentSessionId) ||
+                (activeConversationIdRef.current === null &&
+                  isComposerHomeRef.current));
+            if (shouldRevertToHome) {
+              const homeErrorMessage =
+                result.error?.message?.trim() || "Session activation failed.";
+              if (isCurrentConversation(agentSessionId)) {
+                // Stash the error so the activeConversationId-null effect
+                // surfaces it on the home composer instead of clearing it.
+                pendingHomeErrorRef.current = homeErrorMessage;
+                // Undo the optimistic entry: send the user back to the home
+                // composer. The home draft was never cleared, so their input is
+                // preserved; only the error is surfaced there.
+                isComposerHomeRef.current = true;
+                setIsComposerHome(true);
+                activeConversationIdRef.current = null;
+                setActiveConversationId(null);
+                setIntent({ tag: "home" });
+                persistActiveConversation(null);
+                setTransientConversation(null);
+                setAgentSessionViewOverlayMessages(
+                  sessionViewRef(agentSessionId),
+                  []
+                );
+              }
               setIsLoadingMessages(false);
               setAgentSessionViewMessagesLoading(
                 sessionViewRef(agentSessionId),
                 false
               );
-              setDetailError(
-                result.error?.message?.trim() || "Session activation failed."
-              );
+              setDetailError(homeErrorMessage);
             }
             return;
           }
@@ -6287,6 +6329,24 @@ export function useAgentGUINodeController({
           }
           if (transientConversationRef.current?.id === agentSessionId) {
             setTransientConversation(null);
+          }
+          if (isCurrentConversation(agentSessionId)) {
+            // Stash the error so the activeConversationId-null effect surfaces
+            // it on the home composer instead of clearing it.
+            pendingHomeErrorRef.current = message;
+            // Undo the optimistic entry: send the user back to the home
+            // composer. The home draft was never cleared, so their input is
+            // preserved; only the error is surfaced there.
+            isComposerHomeRef.current = true;
+            setIsComposerHome(true);
+            activeConversationIdRef.current = null;
+            setActiveConversationId(null);
+            setIntent({ tag: "home" });
+            persistActiveConversation(null);
+            setAgentSessionViewOverlayMessages(
+              sessionViewRef(agentSessionId),
+              []
+            );
           }
           setIsLoadingMessages(false);
           setAgentSessionViewMessagesLoading(
@@ -9123,7 +9183,11 @@ export function useAgentGUINodeController({
             : null,
       approval: pendingApproval,
       recovery:
-        activeLiveState === "activating"
+        activeLiveState === "activating" &&
+        // Suppress the "reconnecting" banner during a first-message create:
+        // the user just submitted and is already seeing their optimistic
+        // message, so an activation-in-flight state is not a recovery event.
+        startingConversationIdRef.current !== activeConversationId
           ? {
               kind: "activating",
               // i18n-check-ignore: Legacy recovery fallback copy; localized presentation should move to view labels.
@@ -9146,6 +9210,7 @@ export function useAgentGUINodeController({
     activationError,
     activationErrorCode,
     activeLiveState,
+    activeConversationId,
     activeConversationResumeUnavailable,
     activeSessionState,
     hasProviderSessionNotFoundError,


### PR DESCRIPTION
## What

Sending the first message in a new chat now enters the conversation surface **immediately** and shows the user's own message, instead of waiting through the activation loading period before entering.

## Why

Previously the first-message create kept the user on the home composer until the backend session-creation round-trip resolved, only then switching into the conversation. This made the first send feel sluggish. The desired behavior is: send → instantly in the conversation seeing your message.

A prior PRD conflated "immediate entry" with showing a "正在连接会话…" (reconnecting) banner. This PR decouples them: immediate entry does **not** require the banner.

## How

- **Optimistic commit moved into the synchronous submission block** of `startConversation`. On submit we set the transient conversation, record the optimistic user message (keyed by `clientSubmitId`), clear the session draft, and flip `activeConversationId`/`isComposerHome`/`intent` to the new session — all before awaiting `activation.activate`. The home draft is intentionally left intact so a failed activation can revert with the user's input preserved.
- **`clientSubmitId` reconciliation reused** (no new mechanism): the optimistic turn uses `pending:<clientSubmitId>` and is retargeted to the real turn when the durable message lands, exactly as before — only the timing of the optimistic commit changed.
- **Banner suppressed during initial create**: `sessionChrome.recovery` only shows the `activating` banner when the active conversation is *not* the in-flight first-message create (`startingConversationIdRef.current !== activeConversationId`). Activation-in-flight on a brand-new session is not a recovery event.
- **Failure reverts to home**: the `.then` `activationFailed` branch and `.catch` undo the optimistic entry — back to the home composer with the original draft preserved and the error surfaced there (transient/overlay cleared, `activeConversationId=null`).
- **`pendingHomeErrorRef`**: the existing `activeConversationId`-null effect cleared `detailError` on any home transition, which would wipe the just-set failure error during the revert. A small ref stashes the error so the effect surfaces it on the home composer instead of clearing it. The ref is only set when actually reverting (`isCurrentConversation`), so it can't leak into unrelated home transitions.

## Verification

- `pnpm typecheck` (agent-gui) ✅
- `pnpm oxlint` on changed files ✅ (exit 0)
- `pnpm test` (agent-gui): 105 files / 1677 passed / 1 skipped ✅
- Updated the 4 tests that asserted the old "stay on composer" behavior; added a banner-suppression test asserting `activeLiveState === "activating"` with `sessionChrome.recovery === null` during a pending first-message create.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * First-message conversation creation now switches to the conversation view immediately, showing the optimistic message while activation is still pending.
  * Suppresses the reconnecting banner during the initial pending activation for the optimistic first-message flow.
  * If activation or creation fails, the app returns to the home composer with the correct draft restored, clears creation busy/loading state, and keeps the error associated with the right conversation even after navigation changes.

* **Tests**
  * Expanded regression coverage for pending flows, navigation-away/drop behavior, and draft restoration after activation rejection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->