### PR TITLE
fix(agent-gui): strip stray markdown asterisks from copied replies and message center

### DIFF
--- a/packages/agent/gui/agent-message-center/WorkspaceAgentMessageCenterCard.tsx
+++ b/packages/agent/gui/agent-message-center/WorkspaceAgentMessageCenterCard.tsx
@@ -25,6 +25,7 @@ import {
 } from "@tutti-os/ui-system";
 import { useTranslation } from "../i18n/index";
 import { normalizeAgentTitleText } from "../shared/utils/agentTitleText";
+import { stripMarkdownFormatting } from "../shared/utils/markdownPlainText";
 import { AgentInteractivePromptSurface } from "../shared/agentConversation/components/AgentInteractivePromptSurface";
 import { AgentMessageMarkdown } from "../shared/AgentMessageMarkdown";
 import { AgentVerticalScrollArea } from "../shared/AgentVerticalScrollArea";
@@ -529,10 +530,10 @@ function MessageCenterStackSummary({
 function messageCenterStackPreviewText(
   item: WorkspaceAgentMessageCenterItem
 ): string {
-  return (
+  return stripMarkdownFormatting(
     item.digest.primary.summary.trim() ||
-    item.lastAgentMessageSummary.trim() ||
-    normalizeAgentTitleText(item.title)
+      item.lastAgentMessageSummary.trim() ||
+      normalizeAgentTitleText(item.title)
   );
 }
 
@@ -734,7 +735,7 @@ function MessageCenterSummary({
         />
       ) : summary ? (
         <div className="whitespace-pre-wrap [overflow-wrap:anywhere]">
-          {summary}
+          {stripMarkdownFormatting(summary)}
         </div>
       ) : (
         emptyLabel

--- a/packages/agent/gui/shared/agentConversation/projection/agentConversationProjection.ts
+++ b/packages/agent/gui/shared/agentConversation/projection/agentConversationProjection.ts
@@ -23,6 +23,7 @@ import {
   projectAgentTurnSummaryRowForTurn,
   projectAgentTurnSummaryRows
 } from "./agentTurnSummaryProjection";
+import { stripMarkdownFormatting } from "../../utils/markdownPlainText";
 
 export interface AgentConversationProjectionOptions {
   avoidGroupingEdits?: boolean;
@@ -438,7 +439,7 @@ function projectMessageCopyText(
         row.speaker === "user"
           ? copyTextForUserMessage(message)
           : assistantCopyTargetKeys.has(messageCopyTargetKey(row, message))
-            ? message.body
+            ? stripMarkdownFormatting(message.body)
             : null;
       if ((message.copyText ?? null) === copyText) {
         return message;

--- a/packages/agent/gui/shared/utils/markdownPlainText.spec.ts
+++ b/packages/agent/gui/shared/utils/markdownPlainText.spec.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from "vitest";
+import { stripMarkdownFormatting } from "./markdownPlainText";
+
+describe("stripMarkdownFormatting", () => {
+  it("strips bold markers", () => {
+    expect(stripMarkdownFormatting("**bold text**")).toBe("bold text");
+    expect(stripMarkdownFormatting("__bold text__")).toBe("bold text");
+  });
+
+  it("strips italic markers", () => {
+    expect(stripMarkdownFormatting("*italic text*")).toBe("italic text");
+  });
+
+  it("strips bold+italic combos", () => {
+    expect(stripMarkdownFormatting("***bold italic***")).toBe("bold italic");
+  });
+
+  it("strips inline code", () => {
+    expect(stripMarkdownFormatting("`code`")).toBe("code");
+    expect(stripMarkdownFormatting("``code``")).toBe("code");
+  });
+
+  it("strips strikethrough", () => {
+    expect(stripMarkdownFormatting("~~struck~~")).toBe("struck");
+  });
+
+  it("converts links to label only", () => {
+    expect(stripMarkdownFormatting("[link text](https://example.com)")).toBe(
+      "link text"
+    );
+  });
+
+  it("converts images to alt text", () => {
+    expect(
+      stripMarkdownFormatting("![alt text](https://example.com/img.png)")
+    ).toBe("alt text");
+  });
+
+  it("strips heading markers", () => {
+    expect(stripMarkdownFormatting("# Heading")).toBe("Heading");
+    expect(stripMarkdownFormatting("### Sub Heading")).toBe("Sub Heading");
+  });
+
+  it("strips list markers", () => {
+    expect(stripMarkdownFormatting("- item")).toBe("item");
+    expect(stripMarkdownFormatting("* item")).toBe("item");
+    expect(stripMarkdownFormatting("1. item")).toBe("item");
+  });
+
+  it("strips blockquote markers", () => {
+    expect(stripMarkdownFormatting("> quoted text")).toBe("quoted text");
+  });
+
+  it("handles mixed content", () => {
+    const input =
+      "**Important:** Please review [the docs](https://example.com) and `config.json`.";
+    const result = stripMarkdownFormatting(input);
+    expect(result).toBe("Important: Please review the docs and config.json.");
+  });
+
+  it("preserves plain text", () => {
+    expect(stripMarkdownFormatting("Just plain text.")).toBe(
+      "Just plain text."
+    );
+  });
+
+  it("handles empty string", () => {
+    expect(stripMarkdownFormatting("")).toBe("");
+  });
+
+  it("does not strip underscores in file paths", () => {
+    expect(stripMarkdownFormatting("/path/to/my_file_name.ts")).toBe(
+      "/path/to/my_file_name.ts"
+    );
+  });
+});

--- a/packages/agent/gui/shared/utils/markdownPlainText.ts
+++ b/packages/agent/gui/shared/utils/markdownPlainText.ts
@@ -1,0 +1,51 @@
+/**
+ * Strips common Markdown formatting markers from a string, returning plain text
+ * suitable for clipboard copy or non-rendered preview contexts.
+ *
+ * Handles: bold/italic (**, *, __, _), inline code (`), strikethrough (~~),
+ * links ([text](url) → text), images (![alt](url) → alt), headings (#),
+ * and list markers (-, *, +, digit.).
+ */
+export function stripMarkdownFormatting(markdown: string): string {
+  let result = markdown;
+
+  // Remove images: ![alt text](url) → alt text
+  result = result.replace(/!\[([^\]]*)\]\([^)]*\)/g, "$1");
+
+  // Remove links: [text](url) → text
+  result = result.replace(/\[([^\]]*)\]\([^)]*\)/g, "$1");
+
+  // Remove bold+italic combos first: ***text*** or ___text___
+  result = result.replace(/\*{3}(.+?)\*{3}/g, "$1");
+  result = result.replace(/_{3}(.+?)_{3}/g, "$1");
+
+  // Remove bold: **text** or __text__
+  result = result.replace(/\*{2}(.+?)\*{2}/g, "$1");
+  result = result.replace(/_{2}(.+?)_{2}/g, "$1");
+
+  // Remove strikethrough: ~~text~~
+  result = result.replace(/~~(.+?)~~/g, "$1");
+
+  // Remove inline code: `code` (including multi-backtick)
+  result = result.replace(/`{1,}([^`]+)`{1,}/g, "$1");
+
+  // Remove italic: *text* or _text_
+  // Use word-boundary-aware regex to avoid stripping valid underscores in paths
+  result = result.replace(/(?<![\w*])\*(?!\s)(.+?)(?<!\s)\*(?![\w*])/g, "$1");
+  result = result.replace(/(?<![\w_])_(?!\s)(.+?)(?<!\s)_(?![\w_])/g, "$1");
+
+  // Remove heading markers: # ## ### etc. at line start
+  result = result.replace(/^#{1,6}\s+/gm, "");
+
+  // Remove list markers at line start: -, *, +, digit.
+  result = result.replace(/^\s*[-*+]\s+/gm, "");
+  result = result.replace(/^\s*\d+\.\s+/gm, "");
+
+  // Remove blockquote markers: >
+  result = result.replace(/^\s*>\s?/gm, "");
+
+  // Remove horizontal rules: ---, ***, ___
+  result = result.replace(/^\s*[-*_]{3,}\s*$/gm, "");
+
+  return result;
+}


### PR DESCRIPTION
## Summary

- Fixes #432 — Copied agent replies sometimes include stray asterisks around text
- Fixes #423 — Message Center renders stray asterisks around messages

## Root Cause

Agent message bodies are markdown-formatted strings (e.g. `**bold text**`). Two code paths displayed or copied this raw markdown without rendering it through `AgentMessageMarkdown`:

1. **Copy button** (`agentConversationProjection.ts`): the `copyText` for assistant messages was set directly to `message.body`, so copying pasted raw `**bold**` markers into the clipboard.
2. **Message Center stack preview** (`WorkspaceAgentMessageCenterCard.tsx`): collapsed stack summaries and the non-rich-text fallback rendered raw markdown text in plain `<span>`/`<div>` elements, showing literal `**` characters.

## Fix

Add a `stripMarkdownFormatting` utility (`packages/agent/gui/shared/utils/markdownPlainText.ts`) that converts common markdown syntax to plain text:

- Bold/italic markers (`**`, `*`, `__`, `_`)
- Inline code (`` ` ``)
- Strikethrough (`~~`)
- Links (`[text](url)` → `text`)
- Images (`![alt](url)` → `alt`)
- Headings (`#`)
- List markers (`-`, `*`, `1.`)
- Blockquotes (`>`)

Apply it in both locations so clipboard text and preview text are always plain text.

## Test plan

- [x] 14 unit tests added for `stripMarkdownFormatting` covering all syntax types
- [x] Existing `markdownPlainText.spec.ts` tests pass
- [ ] Manual: copy an agent reply with bold text → paste should not contain `**`
- [ ] Manual: message center collapsed stack preview → no stray asterisks

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Plain-text message previews and copied assistant messages now remove markdown formatting for cleaner, more readable text.
* **Bug Fixes**
  * Summary text shown in fallback views now displays without markdown markers.
  * Links, code, headings, lists, and other formatting are reduced to readable plain text in clipboard-style output.
* **Tests**
  * Added coverage for common markdown cases to ensure formatting is stripped correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->