### PR TITLE
fix(agent-gui): strip Markdown emphasis from plain-text rendering

### DIFF
--- a/.changeset/strip-markdown-emphasis-plain-text.md
+++ b/.changeset/strip-markdown-emphasis-plain-text.md
@@ -1,0 +1,5 @@
+---
+"@tutti-os/agent-gui": patch
+---
+
+Strip Markdown emphasis markers (**bold**, *italic*, __bold__, _italic_, ~~strike~~, `code`) from agent message text when it is shown in plain-text contexts — clipboard copy and Message Center stack previews / lazy fallback rendering.  Fixes stray asterisks visible in copied agent replies (#432) and Message Center digests (#423).

--- a/packages/agent/gui/agent-message-center/WorkspaceAgentMessageCenterCard.tsx
+++ b/packages/agent/gui/agent-message-center/WorkspaceAgentMessageCenterCard.tsx
@@ -25,6 +25,7 @@ import {
 } from "@tutti-os/ui-system";
 import { useTranslation } from "../i18n/index";
 import { normalizeAgentTitleText } from "../shared/utils/agentTitleText";
+import { stripMarkdownEmphasis } from "../shared/utils/stripMarkdownEmphasis";
 import { AgentInteractivePromptSurface } from "../shared/agentConversation/components/AgentInteractivePromptSurface";
 import { AgentMessageMarkdown } from "../shared/AgentMessageMarkdown";
 import { AgentVerticalScrollArea } from "../shared/AgentVerticalScrollArea";
@@ -529,11 +530,11 @@ function MessageCenterStackSummary({
 function messageCenterStackPreviewText(
   item: WorkspaceAgentMessageCenterItem
 ): string {
-  return (
+  const raw =
     item.digest.primary.summary.trim() ||
     item.lastAgentMessageSummary.trim() ||
-    normalizeAgentTitleText(item.title)
-  );
+    normalizeAgentTitleText(item.title);
+  return stripMarkdownEmphasis(raw);
 }
 
 export function resolveMessageCenterNotificationAction(
@@ -734,7 +735,7 @@ function MessageCenterSummary({
         />
       ) : summary ? (
         <div className="whitespace-pre-wrap [overflow-wrap:anywhere]">
-          {summary}
+          {stripMarkdownEmphasis(summary)}
         </div>
       ) : (
         emptyLabel

--- a/packages/agent/gui/shared/agentConversation/projection/agentConversationProjection.ts
+++ b/packages/agent/gui/shared/agentConversation/projection/agentConversationProjection.ts
@@ -23,6 +23,7 @@ import {
   projectAgentTurnSummaryRowForTurn,
   projectAgentTurnSummaryRows
 } from "./agentTurnSummaryProjection";
+import { stripMarkdownEmphasis } from "../../utils/stripMarkdownEmphasis";
 
 export interface AgentConversationProjectionOptions {
   avoidGroupingEdits?: boolean;
@@ -438,7 +439,7 @@ function projectMessageCopyText(
         row.speaker === "user"
           ? copyTextForUserMessage(message)
           : assistantCopyTargetKeys.has(messageCopyTargetKey(row, message))
-            ? message.body
+            ? stripMarkdownEmphasis(message.body)
             : null;
       if ((message.copyText ?? null) === copyText) {
         return message;

--- a/packages/agent/gui/shared/utils/stripMarkdownEmphasis.spec.ts
+++ b/packages/agent/gui/shared/utils/stripMarkdownEmphasis.spec.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect } from "vitest";
+import { stripMarkdownEmphasis } from "./stripMarkdownEmphasis";
+
+describe("stripMarkdownEmphasis", () => {
+  it("strips bold markers (**)", () => {
+    expect(stripMarkdownEmphasis("**hello**")).toBe("hello");
+  });
+
+  it("strips bold markers (__)", () => {
+    expect(stripMarkdownEmphasis("__hello__")).toBe("hello");
+  });
+
+  it("strips italic markers (*)", () => {
+    expect(stripMarkdownEmphasis("*hello*")).toBe("hello");
+  });
+
+  it("strips italic markers (_)", () => {
+    expect(stripMarkdownEmphasis("_hello_")).toBe("hello");
+  });
+
+  it("strips strikethrough markers (~~)", () => {
+    expect(stripMarkdownEmphasis("~~hello~~")).toBe("hello");
+  });
+
+  it("strips inline code markers (`)", () => {
+    expect(stripMarkdownEmphasis("`hello`")).toBe("hello");
+  });
+
+  it("strips bold-italic markers (***)", () => {
+    expect(stripMarkdownEmphasis("***hello***")).toBe("hello");
+  });
+
+  it("handles mixed emphasis in a sentence", () => {
+    expect(stripMarkdownEmphasis("This is **bold** and *italic* text.")).toBe(
+      "This is bold and italic text."
+    );
+  });
+
+  it("does not strip unpaired markers", () => {
+    expect(stripMarkdownEmphasis("5 * 3 = 15")).toBe("5 * 3 = 15");
+  });
+
+  it("does not strip lone asterisks", () => {
+    expect(stripMarkdownEmphasis("This is not **bold")).toBe(
+      "This is not **bold"
+    );
+  });
+
+  it("preserves text without emphasis", () => {
+    expect(stripMarkdownEmphasis("Hello world")).toBe("Hello world");
+  });
+
+  it("handles empty string", () => {
+    expect(stripMarkdownEmphasis("")).toBe("");
+  });
+
+  it("handles multiple emphasis in sequence", () => {
+    expect(
+      stripMarkdownEmphasis("**bold** and _italic_ and `code`")
+    ).toBe("bold and italic and code");
+  });
+});

--- a/packages/agent/gui/shared/utils/stripMarkdownEmphasis.ts
+++ b/packages/agent/gui/shared/utils/stripMarkdownEmphasis.ts
@@ -1,0 +1,20 @@
+/**
+ * Strips common Markdown emphasis markers from text, leaving the inner
+ * content intact.  This is used when a Markdown string needs to be shown
+ * as plain text (e.g. clipboard copy, truncated previews) where the raw
+ * `**`, `*`, `__`, `_`, `~~` or backtick delimiters would otherwise appear
+ * as stray characters.
+ *
+ * Only **paired** delimiters are removed; lone markers are left untouched
+ * so that text which happens to contain asterisks (e.g. `5 * 3`) is not
+ * mangled.
+ */
+export function stripMarkdownEmphasis(value: string): string {
+  return value
+    .replace(/\*\*(.+?)\*\*/g, "$1")
+    .replace(/__(.+?)__/g, "$1")
+    .replace(/(?<!\*)\*(?!\*)(.+?)(?<!\*)\*(?!\*)/g, "$1")
+    .replace(/(?<!_)_(?!_)(.+?)(?<!_)_(?!_)/g, "$1")
+    .replace(/~~(.+?)~~/g, "$1")
+    .replace(/`(.+?)`/g, "$1");
+}


### PR DESCRIPTION
## Motivation

Agent replies and Message Center digests sometimes show stray asterisks () when Markdown source is displayed in plain-text contexts — clipboard copies, stack previews, and lazy fallback rendering.

Fixes #432
Fixes #423

## Changes

- Add `stripMarkdownEmphasis` utility (`packages/agent/gui/shared/utils/stripMarkdownEmphasis.ts`) that removes paired `**`, `__`, `*`, `_`, `~~`, and backtick delimiters while preserving inner content
- Apply it to assistant message `copyText` in `agentConversationProjection.ts` — clipboard copies now produce clean text without raw Markdown markers
- Apply it to Message Center stack preview text and the non-rich summary fallback in `WorkspaceAgentMessageCenterCard.tsx`

## How to test

1. Open Tutti desktop, start a conversation with Claude Code or Codex
2. Have the agent reply with Markdown bold/italic (e.g. `**Important**`)
3. Click the copy button on the agent reply → pasted text should say `Important`, not `**Important**`
4. In the Message Center, collapsed stack previews should show clean text without `**` markers
5. Run `npx vitest run packages/agent/gui/shared/utils/stripMarkdownEmphasis.spec.ts` — 13 tests pass

## Checklist

- [x] Conventional Commit format (`fix(agent-gui): ...`)
- [x] DCO sign-off (`-s` flag)
- [x] Changeset added (`.changeset/strip-markdown-emphasis-plain-text.md`)
- [x] Unit tests added (13 cases covering bold, italic, strikethrough, code, mixed, unpaired, empty)
- [x] Lint passes (`npx oxlint`)
- [x] No user-visible copy added — utility only strips formatting, no i18n needed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Plain-text message copies and Message Center previews now remove Markdown styling markers, so pasted or previewed text appears cleaner.
  - Assistant message text shown in non-rich views now displays without bold, italic, strikethrough, or inline-code markers.

- **Tests**
  - Added coverage for Markdown marker removal, including mixed formatting, plain text, empty input, and unmatched symbols.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->