### PR TITLE
fix(agent-gui): show toast notification on image download success

### DIFF
--- a/.changeset/download-success-notification.md
+++ b/.changeset/download-success-notification.md
@@ -1,0 +1,5 @@
+---
+"@tutti-os/agent-gui": patch
+---
+
+Show a toast notification when an image download completes successfully. Fixes #438.

--- a/packages/agent/gui/app/renderer/components/ZoomableImage.tsx
+++ b/packages/agent/gui/app/renderer/components/ZoomableImage.tsx
@@ -12,6 +12,7 @@ import {
 } from "react";
 import { CopyIcon, DownloadIcon } from "lucide-react";
 import Zoom from "react-medium-image-zoom";
+import { toast } from "@tutti-os/ui-system";
 import { useTranslation } from "../../../i18n/index";
 import { cn } from "../lib/utils";
 import { ConversationImageContextMenu } from "../../../shared/agentConversation/components/ConversationImageContextMenu";
@@ -90,7 +91,8 @@ export function ZoomableImage({
     }
     closeContextMenu();
     downloadImage(actionSource, resolvedDownloadName);
-  }, [actionSource, closeContextMenu, resolvedDownloadName]);
+    toast.success(t("common.imageDownloaded"));
+  }, [actionSource, closeContextMenu, resolvedDownloadName, t]);
 
   const actionButtons = hasImageActions ? (
     <ImageActionButtons

--- a/packages/agent/gui/app/renderer/i18n/locales/en.ts
+++ b/packages/agent/gui/app/renderer/i18n/locales/en.ts
@@ -17,6 +17,7 @@ export const en = {
     download: "Download",
     copyImage: "Copy image",
     downloadImage: "Download image",
+    imageDownloaded: "Image downloaded.",
     expandImage: "Zoom image",
     error: "Error",
     generateByAi: "Generate by AI",

--- a/packages/agent/gui/app/renderer/i18n/locales/zh-CN.ts
+++ b/packages/agent/gui/app/renderer/i18n/locales/zh-CN.ts
@@ -19,6 +19,7 @@ export const zhCN = {
     download: "下载",
     copyImage: "复制图片",
     downloadImage: "下载图片",
+    imageDownloaded: "图片已下载。",
     expandImage: "放大图片",
     error: "错误",
     generateByAi: "AI 生成",


### PR DESCRIPTION
## Summary
- Show toast notification on image download success so users get confirmation that their download completed

## Validation
- Download notification tests pass
- Pre-commit hooks pass

Closes #438