### PR TITLE
fix(agent-gui): strip markdown from copy text and message center previews (#432, #423)

### DIFF
--- a/packages/agent/gui/agent-message-center/WorkspaceAgentMessageCenterCard.tsx
+++ b/packages/agent/gui/agent-message-center/WorkspaceAgentMessageCenterCard.tsx
@@ -27,6 +27,7 @@ import { useTranslation } from "../i18n/index";
 import { normalizeAgentTitleText } from "../shared/utils/agentTitleText";
 import { AgentInteractivePromptSurface } from "../shared/agentConversation/components/AgentInteractivePromptSurface";
 import { AgentMessageMarkdown } from "../shared/AgentMessageMarkdown";
+import { stripMarkdownForCopy } from "../shared/agentConversation/lib/stripMarkdownForCopy";
 import { AgentVerticalScrollArea } from "../shared/AgentVerticalScrollArea";
 import { managedAgentRoundedIconUrl } from "../shared/managedAgentIcons";
 import { workspaceAgentActivityStatusLabel } from "../shared/workspaceAgentActivityStatusLabel";
@@ -529,10 +530,10 @@ function MessageCenterStackSummary({
 function messageCenterStackPreviewText(
   item: WorkspaceAgentMessageCenterItem
 ): string {
-  return (
+  return stripMarkdownForCopy(
     item.digest.primary.summary.trim() ||
-    item.lastAgentMessageSummary.trim() ||
-    normalizeAgentTitleText(item.title)
+      item.lastAgentMessageSummary.trim() ||
+      normalizeAgentTitleText(item.title)
   );
 }
 
@@ -734,7 +735,7 @@ function MessageCenterSummary({
         />
       ) : summary ? (
         <div className="whitespace-pre-wrap [overflow-wrap:anywhere]">
-          {summary}
+          {stripMarkdownForCopy(summary)}
         </div>
       ) : (
         emptyLabel

--- a/packages/agent/gui/shared/agentConversation/lib/stripMarkdownForCopy.spec.ts
+++ b/packages/agent/gui/shared/agentConversation/lib/stripMarkdownForCopy.spec.ts
@@ -89,6 +89,15 @@ describe("stripMarkdownForCopy", () => {
     );
   });
 
+  it("strips unmatched bold markers (stray ** without closing pair)", () => {
+    expect(stripMarkdownForCopy("Hello **World")).toBe("Hello World");
+    expect(stripMarkdownForCopy("**unmatched text")).toBe("unmatched text");
+  });
+
+  it("strips unmatched underscore bold markers (stray __ without closing pair)", () => {
+    expect(stripMarkdownForCopy("Hello __World")).toBe("Hello World");
+  });
+
   it("handles multiple formatting in a single paragraph", () => {
     const input = "Use **bold** and *italic* and `code` together.";
     expect(stripMarkdownForCopy(input)).toBe(

--- a/packages/agent/gui/shared/agentConversation/lib/stripMarkdownForCopy.spec.ts
+++ b/packages/agent/gui/shared/agentConversation/lib/stripMarkdownForCopy.spec.ts
@@ -1,0 +1,98 @@
+import { describe, expect, it } from "vitest";
+import { stripMarkdownForCopy } from "./stripMarkdownForCopy";
+
+describe("stripMarkdownForCopy", () => {
+  it("passes through plain text unchanged", () => {
+    expect(stripMarkdownForCopy("Hello world")).toBe("Hello world");
+  });
+
+  it("strips bold markers", () => {
+    expect(stripMarkdownForCopy("**bold text**")).toBe("bold text");
+  });
+
+  it("strips bold alt markers", () => {
+    expect(stripMarkdownForCopy("__bold text__")).toBe("bold text");
+  });
+
+  it("strips italic markers", () => {
+    expect(stripMarkdownForCopy("*italic text*")).toBe("italic text");
+  });
+
+  it("strips bold-italic markers", () => {
+    expect(stripMarkdownForCopy("***bold italic***")).toBe("bold italic");
+  });
+
+  it("strips strikethrough markers", () => {
+    expect(stripMarkdownForCopy("~~deleted~~")).toBe("deleted");
+  });
+
+  it("strips inline code markers", () => {
+    expect(stripMarkdownForCopy("`code`")).toBe("code");
+  });
+
+  it("unwraps link labels", () => {
+    expect(stripMarkdownForCopy("[label](https://example.com)")).toBe("label");
+  });
+
+  it("unwraps image alt text", () => {
+    expect(stripMarkdownForCopy("![alt text](image.png)")).toBe("alt text");
+  });
+
+  it("strips fenced code block markers", () => {
+    const input = "```js\nconst x = 1;\n```\nAfter";
+    expect(stripMarkdownForCopy(input)).toBe("const x = 1;\nAfter");
+  });
+
+  it("strips heading markers", () => {
+    expect(stripMarkdownForCopy("# Heading 1")).toBe("Heading 1");
+    expect(stripMarkdownForCopy("### Heading 3")).toBe("Heading 3");
+  });
+
+  it("strips unordered list markers", () => {
+    expect(stripMarkdownForCopy("- item one\n- item two")).toBe(
+      "item one\nitem two"
+    );
+  });
+
+  it("strips ordered list markers", () => {
+    expect(stripMarkdownForCopy("1. first\n2. second")).toBe("first\nsecond");
+  });
+
+  it("strips blockquote markers", () => {
+    expect(stripMarkdownForCopy("> quoted text")).toBe("quoted text");
+  });
+
+  it("strips horizontal rules", () => {
+    expect(stripMarkdownForCopy("before\n---\nafter")).toBe("before\n\nafter");
+  });
+
+  it("handles mixed content with bold and links", () => {
+    const input =
+      "This is **important** and see [docs](https://docs.example.com).";
+    expect(stripMarkdownForCopy(input)).toBe("This is important and see docs.");
+  });
+
+  it("preserves word-internal underscores", () => {
+    expect(stripMarkdownForCopy("file_name_here")).toBe("file_name_here");
+  });
+
+  it("does not strip list-bullet asterisks as italic", () => {
+    const input = "* item\n* another";
+    expect(stripMarkdownForCopy(input)).toBe("item\nanother");
+  });
+
+  it("handles Chinese text with bold markers (issue #432 scenario)", () => {
+    const input =
+      "**3 号线也不是最优**\n\n**福田站坐 11 号线 → 南山站下 → E2 出口步行过去**";
+    expect(stripMarkdownForCopy(input)).toBe(
+      "3 号线也不是最优\n\n福田站坐 11 号线 → 南山站下 → E2 出口步行过去"
+    );
+  });
+
+  it("handles multiple formatting in a single paragraph", () => {
+    const input = "Use **bold** and *italic* and `code` together.";
+    expect(stripMarkdownForCopy(input)).toBe(
+      "Use bold and italic and code together."
+    );
+  });
+});

--- a/packages/agent/gui/shared/agentConversation/lib/stripMarkdownForCopy.ts
+++ b/packages/agent/gui/shared/agentConversation/lib/stripMarkdownForCopy.ts
@@ -1,0 +1,53 @@
+/**
+ * Strips markdown formatting markers from text so that copying an agent
+ * message produces clean plain text without stray `**`, `*`, `__`, etc.
+ *
+ * Only formatting markers are removed — link labels are kept, code spans
+ * are unwrapped, and list/heading markers are stripped. The goal is a
+ * readable plain-text representation, not a full markdown-to-text engine.
+ */
+export function stripMarkdownForCopy(markdown: string): string {
+  let result = markdown;
+
+  // Fenced code blocks: ```\n...\n```  →  keep inner text, drop fences
+  result = result.replace(/```+[^\n]*\n?/g, "");
+
+  // Images: ![alt](url)  →  alt
+  result = result.replace(/!\[([^\]]*)\]\([^)]*\)/g, "$1");
+
+  // Links: [label](url)  →  label
+  result = result.replace(/\[([^\]]*)\]\([^)]*\)/g, "$1");
+
+  // Bold + italic: ***text***  →  text
+  result = result.replace(/\*{3}(.+?)\*{3}/g, "$1");
+  // Bold: **text**  →  text
+  result = result.replace(/\*{2}(.+?)\*{2}/g, "$1");
+  // Bold alt: __text__  →  text
+  result = result.replace(/_{2}(.+?)_{2}/g, "$1");
+
+  // Strikethrough: ~~text~~  →  text
+  result = result.replace(/~~(.+?)~~/g, "$1");
+
+  // Inline code: `text`  →  text
+  result = result.replace(/`{1,2}([^`]+)`{1,2}/g, "$1");
+
+  // Italic: *text*  →  text  (require non-space after opening * to avoid list bullets)
+  result = result.replace(/\*([^\s*](?:[^*\n]*[^\s*])?)\*/g, "$1");
+  // Italic alt: _text_  →  text  (avoid matching word-internal underscores)
+  result = result.replace(/(?<![\w/])_([^_\n]+)_(?![\w/])/g, "$1");
+
+  // Headings: # / ## / ### ...  →  strip leading markers
+  result = result.replace(/^#{1,6}\s+/gm, "");
+
+  // List markers: - / * / + / 1.  at line start  →  strip
+  result = result.replace(/^\s*[-*+]\s+/gm, "");
+  result = result.replace(/^\s*\d+\.\s+/gm, "");
+
+  // Blockquotes: > text  →  text
+  result = result.replace(/^\s*>\s?/gm, "");
+
+  // Horizontal rules: --- / *** / ___  →  remove
+  result = result.replace(/^\s*([-*_])\1{2,}\s*$/gm, "");
+
+  return result;
+}

--- a/packages/agent/gui/shared/agentConversation/lib/stripMarkdownForCopy.ts
+++ b/packages/agent/gui/shared/agentConversation/lib/stripMarkdownForCopy.ts
@@ -25,6 +25,10 @@ export function stripMarkdownForCopy(markdown: string): string {
   // Bold alt: __text__  →  text
   result = result.replace(/_{2}(.+?)_{2}/g, "$1");
 
+  // Remove unmatched bold markers (stray ** or __ without closing pair)
+  result = result.replace(/(?<!\*)\*{2}(?!\*)/g, "");
+  result = result.replace(/(?<!_)_{2}(?!_)/g, "");
+
   // Strikethrough: ~~text~~  →  text
   result = result.replace(/~~(.+?)~~/g, "$1");
 

--- a/packages/agent/gui/shared/agentConversation/projection/agentConversationProjection.ts
+++ b/packages/agent/gui/shared/agentConversation/projection/agentConversationProjection.ts
@@ -17,6 +17,7 @@ import {
   buildAgentTurnSequenceItems,
   computeAgentToolGroups
 } from "./agentToolGroupingProjection";
+import { stripMarkdownForCopy } from "../lib/stripMarkdownForCopy";
 import { projectTurnRows } from "./agentTurnRowProjection";
 import { projectAgentProcessingRow } from "./agentProcessingProjection";
 import {
@@ -438,7 +439,7 @@ function projectMessageCopyText(
         row.speaker === "user"
           ? copyTextForUserMessage(message)
           : assistantCopyTargetKeys.has(messageCopyTargetKey(row, message))
-            ? message.body
+            ? stripMarkdownForCopy(message.body)
             : null;
       if ((message.copyText ?? null) === copyText) {
         return message;


### PR DESCRIPTION
## Summary

- **Fixes #432**: Copying agent replies no longer includes stray markdown markers (`**`, `*`, `__`, etc.) — clipboard text is now clean plain text
- **Fixes #423**: Message Center stack preview and fallback summary strip markdown so collapsed/expanded views show readable text without stray double asterisks

## Changes

- **New utility** `stripMarkdownForCopy.ts`: Strips markdown formatting markers while preserving content (link labels kept, code spans unwrapped, list/heading markers removed)
- **Projection layer** (`agentConversationProjection.ts`): `copyText` now runs through `stripMarkdownForCopy` instead of using raw `message.body`
- **Message Center** (`WorkspaceAgentMessageCenterCard.tsx`): Applied `stripMarkdownForCopy` to `messageCenterStackPreviewText` (collapsed stack preview) and the plain-text fallback path in `MessageCenterSummary`

## Test plan

- [x] 20 unit tests in `stripMarkdownForCopy.spec.ts` covering: bold, italic, strikethrough, code spans, links, images, fenced code blocks, headings, lists, blockquotes, horizontal rules, mixed content, word-internal underscores, list-bullet asterisks, Chinese text with bold (issue #432 scenario)
- [x] Existing projection tests pass (20/20) — confirms no regression in copyText assignment
- [x] Pre-commit hooks pass: `oxfmt`, `oxlint`, electron-runtime boundaries, UI boundaries, renderer boundaries, i18n, tutti-names

## Notes

- Pre-push checks requiring `go`/`gofmt` were skipped (Go toolchain not installed on dev machine); all TypeScript/React checks passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Copying agent messages now produces cleaner plain text by removing markdown formatting.
  * Message previews and fallback summaries now display sanitized text instead of raw markdown.

* **Bug Fixes**
  * Improved handling of links, lists, quotes, code, headings, and emphasis so copied content reads naturally.
  * Preserved meaningful text like link labels and image alt text while stripping formatting markers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->