### PR TITLE
fix(agent-gui): prevent images from remaining in composer after send

### DIFF
--- a/packages/agent/gui/agent-gui/agentGuiNode/AgentComposer.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/AgentComposer.tsx
@@ -813,6 +813,7 @@ export function AgentComposer({
   const draftPromptRef = useRef(draftPrompt);
   const draftImagesRef = useRef<AgentComposerDraftImage[]>(draftImages);
   const draftFilesRef = useRef<AgentComposerDraftFile[]>(draftFiles);
+  const submittedRef = useRef(false);
   const promptTipRef = useRef<HTMLSpanElement | null>(null);
   const mentionControllerRef = useRef<AgentMentionSearchController | null>(
     null
@@ -1078,6 +1079,9 @@ export function AgentComposer({
 
   useEffect(() => {
     draftImagesRef.current = draftImages;
+    if (draftImages.length > 0) {
+      submittedRef.current = false;
+    }
   }, [draftImages]);
 
   useEffect(() => {
@@ -1359,6 +1363,7 @@ export function AgentComposer({
     draftPromptRef.current = "";
     draftImagesRef.current = [];
     draftFilesRef.current = [];
+    submittedRef.current = true;
     setPaletteDraftPrompt("");
     onDraftContentChange(emptyAgentComposerDraft());
     onSubmit(submitContent);
@@ -1802,6 +1807,9 @@ export function AgentComposer({
           ]
         })
           .then((result) => {
+            if (submittedRef.current) {
+              return;
+            }
             const uploadedImage = result.content.find(
               (block) => block.type === "image"
             );
@@ -1829,6 +1837,9 @@ export function AgentComposer({
             });
           })
           .catch((error: unknown) => {
+            if (submittedRef.current) {
+              return;
+            }
             const message =
               error instanceof Error ? error.message : String(error);
             const failedDraftImages = draftImagesRef.current.map((image) =>

--- a/packages/agent/gui/agent-gui/agentGuiNode/AgentComposer.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/AgentComposer.tsx
@@ -1356,12 +1356,12 @@ export function AgentComposer({
       provider,
       skills: availableSkills
     });
-    onSubmit(submitContent);
     draftPromptRef.current = "";
     draftImagesRef.current = [];
     draftFilesRef.current = [];
     setPaletteDraftPrompt("");
     onDraftContentChange(emptyAgentComposerDraft());
+    onSubmit(submitContent);
   });
 
   const submit = useCallback(


### PR DESCRIPTION
## Summary

- Fixes #430 — Sent images remain in the composer after the message is sent

## Root Cause

When images are pasted into the composer, they start async uploads (`uploadPromptContent`). The `.then()` and `.catch()` callbacks update `draftImagesRef` and call `onDraftContentChange()` to reflect upload progress. After the user clicks send, `submitCurrentPrompt` clears the refs and draft state synchronously. However, a pending upload completion callback can fire after submit, read the ref (which may have been re-populated by the `draftImages → draftImagesRef` sync effect during an intermediate render), and call `onDraftContentChange` with image data — re-adding the images to the composer.

## Fix

Add a `submittedRef` guard flag that is set to `true` when the user submits the prompt. The upload completion callbacks (`.then()` and `.catch()`) now check this guard and skip the draft content update if submit has already occurred. The guard is reset to `false` when new images are added to the draft.

## Test plan

- [x] Code passes pre-commit hooks (oxlint, oxfmt)
- [ ] Manual: paste an image into composer → wait for upload to complete → send → images clear immediately
- [ ] Manual: paste an image → send quickly before upload completes → submit is blocked (existing behavior)
- [ ] Manual: paste an image → send → paste another image in new message → works normally

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved composer behavior so image uploads no longer update or overwrite draft content after a prompt has already been submitted.
  - Reduced the chance of confusing draft image states when sending a message while uploads are still finishing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->