### PR TITLE
fix(agent-gui): remove top offset causing text misalignment after app mention

### DIFF
--- a/.changeset/app-mention-text-alignment.md
+++ b/.changeset/app-mention-text-alignment.md
@@ -1,0 +1,5 @@
+---
+"@tutti-os/agent-gui": patch
+---
+
+Remove the vertical offset on mention node views that caused text entered after an @app mention to appear misaligned. Fixes #435.

--- a/packages/agent/gui/agent-gui/agentGuiNode/agentRichText/AgentMentionNodeView.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/agentRichText/AgentMentionNodeView.tsx
@@ -430,7 +430,7 @@ export function AgentMentionNodeView(props: NodeViewProps): JSX.Element {
         data-agent-mention-kind={mention.kind}
       >
         <span
-          className="group relative top-[3px] inline-flex max-w-[min(100%,var(--agent-mention-max-width,16rem))] cursor-pointer items-center gap-1 overflow-hidden rounded-[4px] border border-transparent bg-transparent px-1 py-0.5 align-baseline text-[13px] font-medium leading-5 text-[var(--accent)] no-underline transition-colors hover:border-transparent hover:bg-[color-mix(in_srgb,currentColor_12%,transparent)]"
+          className="group relative inline-flex max-w-[min(100%,var(--agent-mention-max-width,16rem))] cursor-pointer items-center gap-1 overflow-hidden rounded-[4px] border border-transparent bg-transparent px-1 py-0.5 align-baseline text-[13px] font-medium leading-5 text-[var(--accent)] no-underline transition-colors hover:border-transparent hover:bg-[color-mix(in_srgb,currentColor_12%,transparent)]"
           data-agent-mention-kind={mention.kind}
           data-slot="mention-pill"
         >


### PR DESCRIPTION
## Summary

Fixes #435 — Text entered after an @app mention is misaligned.

## Root Cause

The workspace-app mention pill in AgentMentionNodeView had a top-[3px] relative offset on its inner span, shifting the pill down 3px from the text baseline. Text typed after an @app mention appeared at the normal baseline while the pill was visually offset.

## Fix

Removed the top-[3px] offset. The inner span already uses items-center for vertical centering, making the offset unnecessary.

## Changes

- packages/agent/gui/agent-gui/agentGuiNode/agentRichText/AgentMentionNodeView.tsx: Removed top-[3px] from workspace-app mention inner span className

## Test plan

- [x] Pre-commit hooks pass (oxfmt, oxlint, electron-runtime, ui-boundaries, renderer-boundaries)
- [ ] Manual: type @app mention followed by text — text should align with surrounding content

Signed-off-by: copizza <copizzah@copizzaHdeMacBook-Pro.local>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the appearance of mention chips in the rich text editor.
  * Mentions now use refreshed spacing, alignment, and hover styling for a cleaner, more interactive look.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->