### PR TITLE
fix(agent-gui): clear composer draft immediately on submit

### DIFF
--- a/.changeset/clear-composer-draft-on-submit.md
+++ b/.changeset/clear-composer-draft-on-submit.md
@@ -1,0 +1,5 @@
+---
+"@tutti-os/agent-gui": patch
+---
+
+Clear the composer draft (including images) immediately when a prompt is submitted instead of waiting for the send request to resolve. Fixes #430 where sent images remained visible in the composer for a while after sending.

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUINodeController.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUINodeController.ts
@@ -6655,6 +6655,25 @@ export function useAgentGUINodeController({
         trace: submitTrace,
         workspaceId
       });
+      // Clear the composer draft immediately (optimistic) so that images and
+      // text do not linger in the composer while the send request is in flight.
+      if (!queuedPromptId) {
+        setDraftBySessionId((current) => {
+          const currentDraft = current[agentSessionId];
+          if (
+            !shouldClearSubmittedDraft({
+              currentDraft,
+              submittedContent: normalizedContent
+            })
+          ) {
+            return current;
+          }
+          return {
+            ...current,
+            [agentSessionId]: emptyAgentComposerDraft()
+          };
+        });
+      }
       void Promise.resolve()
         .then(() => {
           if (!isCurrentConversation(agentSessionId)) {
@@ -6721,23 +6740,6 @@ export function useAgentGUINodeController({
             patchConversation(agentSessionId, {
               status: submittedStatus,
               updatedAtUnixMs: Date.now()
-            });
-          }
-          if (!queuedPromptId) {
-            setDraftBySessionId((current) => {
-              const currentDraft = current[agentSessionId];
-              if (
-                !shouldClearSubmittedDraft({
-                  currentDraft,
-                  submittedContent: normalizedContent
-                })
-              ) {
-                return current;
-              }
-              return {
-                ...current,
-                [agentSessionId]: emptyAgentComposerDraft()
-              };
             });
           }
           if (queuedPromptId) {


### PR DESCRIPTION
## Problem

After sending a message with images, the images remain visible in the composer for a while — they only disappear after the async send request resolves. This creates a confusing UX where the user sees stale content after sending.

Fixes #430

## Root Cause

The draft clearing logic in executePrompt was inside the .then callback of the async sendInput promise. This means the composer draft (text + images) was only cleared after the server responded, not when the user clicked send.

## Solution

Move the draft clearing logic from the .then callback to execute synchronously right after the optimistic state patch, before the async call begins. This ensures the composer is emptied immediately when the user submits.

The shouldClearSubmittedDraft guard is preserved — the draft is only cleared if it still matches the submitted content.

## Changes

- packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUINodeController.ts: Moved draft clearing from async callback to synchronous execution point.

## Changeset

- @tutti-os/agent-gui: patch