### PR TITLE
fix(agent-gui): wrap long file paths instead of truncating

### DIFF
--- a/packages/agent/gui/shared/agentConversation/components/tool-renderers/AgentReadContent.tsx
+++ b/packages/agent/gui/shared/agentConversation/components/tool-renderers/AgentReadContent.tsx
@@ -39,7 +39,10 @@ export function AgentReadContent({
       ) : path || fileLineRange || fileTotalLines !== null ? (
         <div className="rounded-[8px] border border-[var(--line-2)] bg-[var(--background-panel)] px-3 py-2">
           {path ? (
-            <div className="font-[var(--tsh-font-mono)] text-[11px] text-[var(--text-secondary)]">
+            <div
+              className="break-all font-[var(--tsh-font-mono)] text-[11px] text-[var(--text-secondary)]"
+              title={path}
+            >
               {path}
             </div>
           ) : null}

--- a/packages/agent/gui/shared/agentConversation/components/tool-renderers/code/AgentCodeBlock.spec.tsx
+++ b/packages/agent/gui/shared/agentConversation/components/tool-renderers/code/AgentCodeBlock.spec.tsx
@@ -46,4 +46,33 @@ describe("AgentCodeBlock", () => {
       "workspace-agents-status-panel__detail-scroll-region"
     );
   });
+
+  it("wraps long file paths with break-all instead of truncating (flat)", () => {
+    const longPath =
+      "/Users/test/.tutti/apps/installations/ai-slide/e7499ff49e24abc4/data/projects/1516ee94-0b47-4d04-a97c-39e08cc124cb/deck.slides/slides/02-contents.html";
+
+    render(
+      <AgentCodeBlock path={longPath} content="<html></html>" flat showHeader />
+    );
+
+    // Flat variant shows the filename, not the full path
+    const pathSpan = screen.getByText("02-contents.html");
+    expect(pathSpan.className).toContain("break-all");
+    expect(pathSpan.className).not.toContain("truncate");
+    expect(pathSpan.getAttribute("title")).toBe(longPath);
+  });
+
+  it("wraps long file paths with break-all instead of truncating (non-flat)", () => {
+    const longPath =
+      "/Users/test/.tutti/apps/installations/ai-slide/e7499ff49e24abc4/data/projects/1516ee94-0b47-4d04-a97c-39e08cc124cb/deck.slides/slides/02-contents.html";
+
+    render(
+      <AgentCodeBlock path={longPath} content="<html></html>" showHeader />
+    );
+
+    const pathSpan = screen.getByText(longPath);
+    expect(pathSpan.className).toContain("break-all");
+    expect(pathSpan.className).not.toContain("truncate");
+    expect(pathSpan.getAttribute("title")).toBe(longPath);
+  });
 });

--- a/packages/agent/gui/shared/agentConversation/components/tool-renderers/code/AgentCodeBlock.tsx
+++ b/packages/agent/gui/shared/agentConversation/components/tool-renderers/code/AgentCodeBlock.tsx
@@ -71,7 +71,7 @@ export function AgentCodeBlock({
           {showHeader ? (
             <div className="flex items-center justify-between gap-3 border-b border-[var(--line-2)] bg-[var(--transparency-block)] px-3 py-1.5 text-[11px]">
               <span
-                className="truncate font-[var(--tsh-font-mono)] text-[var(--text-secondary)]"
+                className="break-all font-[var(--tsh-font-mono)] text-[var(--text-secondary)]"
                 title={path ?? undefined}
               >
                 {fileLabel}
@@ -102,7 +102,10 @@ export function AgentCodeBlock({
         <>
           {showHeader ? (
             <div className="flex items-center justify-between gap-3 border-b border-[var(--line-2)] bg-[var(--transparency-block)] px-3 py-1.5 text-[11px] text-[var(--text-secondary)]">
-              <span className="truncate font-[var(--tsh-font-mono)]">
+              <span
+                className="break-all font-[var(--tsh-font-mono)]"
+                title={path ?? undefined}
+              >
                 {path || "Code"}
               </span>
               <span className="shrink-0">

--- a/packages/agent/gui/shared/agentConversation/components/tool-renderers/file-diff/AgentMonacoDiffViewer.tsx
+++ b/packages/agent/gui/shared/agentConversation/components/tool-renderers/file-diff/AgentMonacoDiffViewer.tsx
@@ -29,8 +29,9 @@ export function AgentMonacoDiffViewer({
     >
       {showHeader ? (
         <div
-          className="border-b border-[var(--line-2)] bg-[var(--transparency-block)] px-3 py-1.5 text-[11px] text-[var(--text-secondary)]"
+          className="break-all border-b border-[var(--line-2)] bg-[var(--transparency-block)] px-3 py-1.5 text-[11px] text-[var(--text-secondary)]"
           data-agent-diff-header="true"
+          title={path ?? undefined}
         >
           {path || "Diff"}
         </div>

--- a/packages/agent/gui/shared/agentConversation/components/tool-renderers/file-diff/AgentUnifiedPatchViewer.tsx
+++ b/packages/agent/gui/shared/agentConversation/components/tool-renderers/file-diff/AgentUnifiedPatchViewer.tsx
@@ -96,7 +96,7 @@ export function AgentUnifiedPatchViewer({
               data-agent-diff-header="true"
             >
               <span
-                className="truncate font-[var(--tsh-font-mono)] text-[var(--text-secondary)]"
+                className="break-all font-[var(--tsh-font-mono)] text-[var(--text-secondary)]"
                 title={path ?? undefined}
               >
                 {fileLabel}
@@ -129,8 +129,9 @@ export function AgentUnifiedPatchViewer({
         <>
           {showHeader ? (
             <div
-              className="border-b border-[var(--line-2)] bg-[var(--transparency-block)] px-3 py-1.5 text-[11px] text-[var(--text-secondary)]"
+              className="break-all border-b border-[var(--line-2)] bg-[var(--transparency-block)] px-3 py-1.5 text-[11px] text-[var(--text-secondary)]"
               data-agent-diff-header="true"
+              title={path ?? undefined}
             >
               {path || "Patch"}
             </div>


### PR DESCRIPTION
## Summary
- Wrap long file paths in agent GUI instead of truncating them
- Add `break-all` CSS and `title` attributes for full path on hover

## Verification

- `AgentCodeBlock.spec.tsx` — tests pass for long-path wrapping (`break-all` + `title`)
- Pre-commit hooks pass

## Checklist

- [x] I kept the change focused on one concern.
- [ ] I updated documentation when behavior, setup, or contributor workflow changed.
- [ ] I updated all README/CONTRIBUTING language variants when changing their English source.
- [x] I ran the lowest meaningful local checks for the changed surface.
- [x] My commits are signed off with DCO when required: `git commit -s`.

Closes #421