### PR TITLE
fix(agent-gui): reset local submitting flag on turn settled

### DIFF
--- a/.changeset/reset-submitting-on-turn-settled.md
+++ b/.changeset/reset-submitting-on-turn-settled.md
@@ -1,0 +1,5 @@
+---
+"@tutti-os/agent-gui": patch
+---
+
+Reset the local submitting flag as soon as the server confirms a turn has settled, rather than waiting for the original send request promise to resolve. Fixes #428 where completed conversations briefly flashed a queued state when sending the next message.

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUINodeController.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUINodeController.ts
@@ -5527,6 +5527,13 @@ export function useAgentGUINodeController({
         const nextPending = { ...pendingTurnIdBySessionIdRef.current };
         delete nextPending[agentSessionId];
         pendingTurnIdBySessionIdRef.current = nextPending;
+        // Reset the local submitting flag as soon as the server confirms the
+        // turn has settled, rather than waiting for the .finally() of the
+        // original sendInput promise.  This prevents a brief "queued" flash
+        // when the user sends the next message right after completion (#428).
+        if (nextStatus !== null && !conversationBusyStatus(nextStatus)) {
+          setLocalIsSubmitting(false);
+        }
       }
       if (
         !nextStatus &&


### PR DESCRIPTION
## Problem

After a conversation has completed, sending another message briefly flashes a queued state before the message is actually sent.

Fixes #428

## Root Cause

When a conversation completes, the server sends a turn-settled event that clears the pending turn ID. However, the local submitting flag `localIsSubmitting` is only reset in the `.finally()` callback of the original `sendInput` promise, which may run slightly later. During this gap, `shouldQueuePromptLocally` returns `true` (because `isSubmitting` is still true), causing the next message to briefly enter the queued state.

## Solution

When clearing the pending submitted turn due to the conversation transitioning to a non-busy status, also reset `localIsSubmitting` immediately. This closes the race window between the server completion event and the promise cleanup.

## Changes

- `packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUINodeController.ts`: Reset `localIsSubmitting` when the turn is cleared due to non-busy conversation status.

## Changeset

- @tutti-os/agent-gui: patch