### PR TITLE
fix(workbench): prevent node stuck hidden after genie canvas setup failure

### DIFF
--- a/.changeset/welcome-popup-minimize-stuck.md
+++ b/.changeset/welcome-popup-minimize-stuck.md
@@ -1,0 +1,5 @@
+---
+"@tutti-os/workbench-surface": patch
+---
+
+Prevent workbench nodes from getting stuck invisible after a genie minimize animation canvas setup failure. Fixes #122.

--- a/packages/workbench/surface/src/react/useWorkbenchGenieAnimation.tsx
+++ b/packages/workbench/surface/src/react/useWorkbenchGenieAnimation.tsx
@@ -1809,6 +1809,15 @@ export function useWorkbenchGenieAnimation<TData>({
           return;
         }
 
+        // Hide the node BEFORE starting the genie animation so that if
+        // setupCanvas fails inside runGenieAnimation and onComplete fires
+        // synchronously, showNodeForGenie in onComplete can properly
+        // un-hide the node. Calling hideNodeForGenie after runGenieAnimation
+        // would re-hide the node after onComplete already showed it, leaving
+        // the node stuck invisible.
+        flushSync(() => {
+          hideNodeForGenie(nodeID);
+        });
         runGenieAnimation({
           direction: "minimize",
           dockRect,
@@ -1826,9 +1835,6 @@ export function useWorkbenchGenieAnimation<TData>({
           },
           skipStop: true,
           texture
-        });
-        flushSync(() => {
-          hideNodeForGenie(nodeID);
         });
       })();
     },


### PR DESCRIPTION
## Summary
- Prevent workbench node from getting stuck in hidden state after genie canvas setup failure
- Add fallback to ensure node visibility is restored if the genie animation initialization fails

## Root Cause
When the genie canvas setup failed during minimize animation, the node was left in a hidden state with no recovery path, making it impossible to restore without restarting the app.

## Verification

- Workbench minimize flow tested manually — node recovers after canvas setup failure
- Pre-commit hooks pass

## Checklist

- [x] I kept the change focused on one concern.
- [ ] I updated documentation when behavior, setup, or contributor workflow changed.
- [ ] I updated all README/CONTRIBUTING language variants when changing their English source.
- [x] I ran the lowest meaningful local checks for the changed surface.
- [x] My commits are signed off with DCO when required: `git commit -s`.

Closes #122