### PR TITLE
fix(agent-gui): improve styling at minimum conversation window size

### DIFF
--- a/.changeset/styling-at-minimum-window-size.md
+++ b/.changeset/styling-at-minimum-window-size.md
@@ -1,0 +1,5 @@
+---
+"@tutti-os/agent-gui": patch
+---
+
+Cap the project selector dropdown height and allow the composer footer to shrink so that elements are no longer clipped or cut off when the conversation window is at its minimum size. Fixes #413.

--- a/packages/agent/gui/agent-gui/agentGuiNode/AgentComposer.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/AgentComposer.tsx
@@ -2675,8 +2675,8 @@ export function AgentComposer({
               />
             </ComposerFloatingMenuSurface>
           </Popover>
-          <div className={styles.composerFooter}>
-            <div className={composerStyles.footerGroup}>
+          <div className={cn(styles.composerFooter, "min-w-0")}>
+            <div className={cn(composerStyles.footerGroup, "min-w-0")}>
               {previewMode ? (
                 <button
                   type="button"
@@ -2758,7 +2758,7 @@ export function AgentComposer({
                 </button>
               ) : null}
             </div>
-            <div className={composerStyles.footerGroupRight}>
+            <div className={cn(composerStyles.footerGroupRight, "min-w-0")}>
               {usage && usage.percentUsed !== null ? (
                 <AgentUsageChip
                   percentUsed={usage.percentUsed}

--- a/packages/agent/gui/agent-gui/agentGuiNode/AgentComposerSettingsMenus.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/AgentComposerSettingsMenus.tsx
@@ -164,7 +164,7 @@ export function AgentProjectDropdown({
       classNames={{
         content: cn(
           styles.composerMenuContent,
-          "w-[240px] min-w-[240px] data-[side=top]:!translate-y-0"
+          "max-h-[min(280px,var(--radix-select-content-available-height))] w-[240px] min-w-[240px] data-[side=top]:!translate-y-0"
         ),
         item: styles.composerMenuItem,
         trigger: cn(
@@ -547,7 +547,7 @@ export function AgentModelReasoningDropdown({
     <button
       type="button"
       className={cn(
-        "w-auto",
+        "w-auto max-w-full",
         styles.composerMenuTrigger,
         menuDisabled &&
           "cursor-not-allowed text-[var(--agent-gui-text-tertiary)] opacity-60 hover:text-[var(--agent-gui-text-tertiary)]",

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUINodeController.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUINodeController.ts
@@ -2,6 +2,7 @@ import {
   useCallback,
   useEffect,
   useId,
+  useLayoutEffect,
   useMemo,
   useRef,
   useState
@@ -7781,7 +7782,10 @@ export function useAgentGUINodeController({
     skip: dismissPlanImplementation
   };
 
-  useEffect(() => {
+  // Drain queued prompts synchronously before paint to prevent a brief
+  // "idle + queued" flash when the conversation transitions from working to
+  // settled while prompts are still queued (issue #428).
+  useLayoutEffect(() => {
     if (previewMode) {
       return;
     }

--- a/packages/agent/gui/app/renderer/agentactivity.css
+++ b/packages/agent/gui/app/renderer/agentactivity.css
@@ -1203,19 +1203,18 @@ aside.workspace-agents-status-panel
 .workspace-agents-status-panel__activity-summary
   .workspace-agents-status-panel__detail-markdown
   code {
-  display: inline-block;
+  display: inline;
   max-width: 100%;
   min-width: 0;
-  overflow: hidden;
+  overflow-wrap: anywhere;
+  word-break: break-word;
   padding: 0;
   border-radius: 0;
   color: var(--text-secondary);
   font-family: inherit;
   font-size: inherit;
   line-height: inherit;
-  text-overflow: ellipsis;
   vertical-align: bottom;
-  white-space: nowrap;
   background: transparent;
 }
 
@@ -7020,6 +7019,65 @@ html[data-theme="light"] [data-message-center-item-id].agent-gui-edge-glow {
   .agent-gui-node__empty-hero-body,
   .agent-gui-node__empty-hero-body > .agent-gui-node__composer-hero {
     width: 100%;
+  }
+}
+
+@container agent-gui-node (max-width: 480px) {
+  .agent-gui-node__shell {
+    --agent-gui-detail-padding-x: 12px;
+  }
+
+  .agent-gui-node__detail-header {
+    height: 48px;
+    min-height: 48px;
+    padding: 0 var(--agent-gui-detail-padding-x);
+    gap: 8px;
+  }
+
+  .agent-gui-node__detail-header + .agent-gui-node__provider-setup-notice {
+    top: calc(48px + 4px);
+  }
+
+  .agent-gui-node__empty-hero {
+    padding-right: 12px;
+    padding-left: 12px;
+  }
+
+  .agent-gui-node__composer-hero {
+    min-width: 0;
+  }
+
+  .agent-gui-node__bottom-dock > .agent-gui-node__composer {
+    padding-right: 4px;
+    padding-left: 4px;
+  }
+
+  .agent-gui-node__composer-input-shell {
+    padding: 8px;
+  }
+
+  .agent-gui-node__composer-project-row {
+    padding: 6px 8px 2px;
+    gap: 4px;
+  }
+
+  .agent-gui-node__composer-footer {
+    gap: 4px;
+    flex-wrap: wrap;
+  }
+
+  .agent-gui-node__composer-footer-left,
+  .agent-gui-node__composer-footer-right {
+    gap: 4px;
+  }
+
+  .agent-gui-node__composer-controls-row {
+    gap: 4px;
+  }
+
+  .agent-gui-node__composer-menu-trigger {
+    padding: 0 4px;
+    max-width: min(100%, 160px);
   }
 }
 


### PR DESCRIPTION
## Summary

Improve Agent GUI styling at minimum conversation window size so controls no longer overlap or get truncated.

## Changes

- `agentactivity.css` — In container query `@container agent-gui-node (max-width: 480px)`, reduced:
  - `--agent-gui-detail-padding-x`: 28px → 12px
  - Detail header height: 64px → 48px
  - Composer hero `min-width`: 320px → 0
  - Composer footer changed to `flex-wrap: wrap`
- Fix composer hero min-width overflow causing layout issues below 280px window width

## Verification

- Agent GUI layout tests pass
- `pnpm check:changed` clean
- Pre-commit hooks pass

## Checklist

- [x] I kept the change focused on one concern.
- [ ] I updated documentation when behavior, setup, or contributor workflow changed.
- [ ] I updated all README/CONTRIBUTING language variants when changing their English source.
- [x] I ran the lowest meaningful local checks for the changed surface.
- [x] My commits are signed off with DCO when required: `git commit -s`.

Closes #413