### PR TITLE
fix(agent-gui): prevent queued prompt flash with useLayoutEffect

### DIFF
--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUINodeController.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUINodeController.ts
@@ -7781,7 +7781,10 @@ export function useAgentGUINodeController({
     skip: dismissPlanImplementation
   };
 
-  useEffect(() => {
+  // Drain queued prompts synchronously before paint to prevent a brief
+  // "idle + queued" flash when the conversation transitions from working to
+  // settled while prompts are still queued (issue #428).
+  useLayoutEffect(() => {
     if (previewMode) {
       return;
     }


### PR DESCRIPTION
## Summary
- Change auto-drain `useEffect` → `useLayoutEffect` so queued prompts are drained synchronously before browser paint
- Prevents a brief "idle + queued" flash when conversation transitions from working to settled state

## Root Cause
When an agent completes a turn, the conversation status changes from "working" to "completed". React then renders the "idle + queued" frame before the drain `useEffect` fires (which runs after paint). Switching to `useLayoutEffect` ensures the drain happens before the browser paints, so the intermediate frame is never visible.

Closes #428

## Test plan
- [ ] Verify no "queued" state flash when completing a conversation with queued prompts
- [ ] Verify no regression in normal conversation flow

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved conversation state transitions to reduce a brief visual flash where the interface could appear both idle and queued at the same time.
  * Prompt handling behavior remains the same, but the transition now feels smoother and more consistent.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->