### PR TITLE
fix(agent-gui): show command details in approval cards when expanded

### DIFF
--- a/.changeset/approval-command-detail.md
+++ b/.changeset/approval-command-detail.md
@@ -1,0 +1,5 @@
+---
+"agent-gui": patch
+---
+
+Show command details in approval tool call cards when expanded. Previously, clicking an approval in conversation details only showed the summary text, omitting the actual command, path, or query being approved.

--- a/packages/agent/gui/app/renderer/agentactivity.css
+++ b/packages/agent/gui/app/renderer/agentactivity.css
@@ -1863,6 +1863,38 @@ aside.workspace-agents-status-panel
   background: transparent;
 }
 
+.workspace-agents-status-panel__detail-tool-detail-row {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: baseline;
+  gap: 6px;
+}
+
+.workspace-agents-status-panel__detail-tool-detail-label {
+  flex: 0 0 auto;
+  color: var(--text-secondary);
+  font-size: 11px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+.workspace-agents-status-panel__detail-tool-detail-value {
+  flex: 1 1 auto;
+  min-width: 0;
+  overflow-wrap: anywhere;
+  word-break: break-word;
+  color: var(--text-primary);
+  font-family: var(--tsh-font-mono);
+  font-size: 11px;
+}
+
+.workspace-agents-status-panel__detail-tool-detail-meta {
+  flex: 0 0 auto;
+  color: var(--text-secondary);
+  font-size: 11px;
+}
+
 .workspace-agents-status-panel__detail-tool-code--flat,
 .workspace-agents-status-panel__detail-tool-diff--flat,
 .workspace-agents-status-panel__detail-tool-monaco--flat {

--- a/packages/agent/gui/shared/agentConversation/components/tool-renderers/AgentApprovalContent.tsx
+++ b/packages/agent/gui/shared/agentConversation/components/tool-renderers/AgentApprovalContent.tsx
@@ -8,6 +8,7 @@ import {
   ToolMarkdownBlock,
   type AgentToolRendererProps
 } from "./agentToolContentShared";
+import { getPromptToolDetails } from "../../promptToolDetails";
 
 export function AgentApprovalContent({
   call,
@@ -15,7 +16,8 @@ export function AgentApprovalContent({
 }: AgentToolRendererProps): JSX.Element | null {
   "use memo";
   const previewCall = approvalPreviewCall(call);
-  if (!previewCall && !call.summary.trim()) {
+  const toolDetails = getPromptToolDetails(call.input ?? null);
+  if (!previewCall && !call.summary.trim() && toolDetails.length === 0) {
     return null;
   }
   if (previewCall) {
@@ -23,7 +25,29 @@ export function AgentApprovalContent({
   }
   return (
     <div className="workspace-agents-status-panel__detail-tool-body">
-      <ToolMarkdownBlock content={call.summary} />
+      {toolDetails.length > 0
+        ? toolDetails.map((detail) => (
+            <div
+              key={`${detail.kind}:${detail.value}`}
+              className="workspace-agents-status-panel__detail-tool-detail-row"
+            >
+              <span className="workspace-agents-status-panel__detail-tool-detail-label">
+                {detailLabel(detail.kind)}
+              </span>
+              <span className="workspace-agents-status-panel__detail-tool-detail-value">
+                {detail.value}
+              </span>
+              {detail.meta ? (
+                <span className="workspace-agents-status-panel__detail-tool-detail-meta">
+                  {detail.meta}
+                </span>
+              ) : null}
+            </div>
+          ))
+        : null}
+      {call.summary.trim() ? (
+        <ToolMarkdownBlock content={call.summary} onLinkClick={onLinkClick} />
+      ) : null}
     </div>
   );
 }
@@ -78,4 +102,17 @@ function approvalPreviewCall(call: AgentToolCallVM): AgentToolCallVM | null {
 
 function normalizeToolKind(value: string | null): string {
   return (value ?? "").trim().toLowerCase();
+}
+
+function detailLabel(kind: "command" | "mcp" | "path" | "query"): string {
+  switch (kind) {
+    case "command":
+      return "Command";
+    case "mcp":
+      return "MCP";
+    case "path":
+      return "Path";
+    case "query":
+      return "Query";
+  }
 }

--- a/packages/agent/gui/shared/agentConversation/components/tool-renderers/agentToolContentShared.tsx
+++ b/packages/agent/gui/shared/agentConversation/components/tool-renderers/agentToolContentShared.tsx
@@ -19,6 +19,7 @@ import {
 } from "./render-data/agentToolRenderData";
 import { CollapsibleReveal } from "../CollapsibleReveal";
 import { fileRange } from "./AgentReadContent";
+import { getPromptToolDetails } from "../../promptToolDetails";
 
 export interface AgentToolRendererProps {
   call: AgentToolCallVM;
@@ -189,7 +190,10 @@ export function AgentDefaultToolContent({
 
 export function hasAgentToolContent(call: AgentToolCallVM): boolean {
   if (call.rendererKind === "approval") {
-    return Boolean(call.input?.toolCall || call.summary.trim());
+    if (call.input?.toolCall || call.summary.trim()) {
+      return true;
+    }
+    return getPromptToolDetails(call.input ?? null).length > 0;
   }
 
   switch (call.rendererKind) {


### PR DESCRIPTION
## Summary
- Approval tool call cards in the conversation transcript only showed summary text when expanded, omitting the actual command, file path, or query being approved
- Now extracts tool details (command, path, query, MCP target) from the approval input using `getPromptToolDetails` and renders them in the expanded view
- Also updates `hasAgentToolContent` to recognize approval calls with extractable tool details, making the card expandable even when the summary is empty

Closes #418

## Test plan
- [ ] Trigger a command approval in Agent GUI (e.g., Claude Code requesting bash command permission)
- [ ] Verify the approval card in the conversation transcript is expandable (shows expand chevron)
- [ ] Click to expand and verify command text, path, or query is displayed
- [ ] Verify edit/move approvals still show the diff preview as before
- [ ] Verify approvals with only summary text (no structured input) still display correctly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Approval tool call cards now show the full approved command details, including related path or query information.
  * Approval entries with hidden command details now render properly instead of showing only the summary.
  * Tool detail rows have clearer formatting, improving readability in conversation views.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->