### PR TITLE
fix(agent-gui): constrain queued prompt expanded height to available space

### DIFF
--- a/packages/agent/gui/agent-gui/agentGuiNode/AgentQueuedPromptPanel.spec.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/AgentQueuedPromptPanel.spec.tsx
@@ -259,4 +259,49 @@ describe("AgentQueuedPromptPanel", () => {
     expect(onEditQueuedPrompt).toHaveBeenCalledWith("queued-2");
     expect(onEditQueuedPrompt).toHaveBeenCalledTimes(1);
   });
+
+  it("constrains expanded list height to available space above the composer", () => {
+    const scrollHeightSpy = vi
+      .spyOn(HTMLElement.prototype, "scrollHeight", "get")
+      .mockReturnValue(500);
+    const getBoundingClientRectSpy = vi
+      .spyOn(HTMLElement.prototype, "getBoundingClientRect")
+      .mockReturnValue({
+        bottom: 150,
+        top: 0,
+        left: 0,
+        right: 800,
+        width: 800,
+        height: 150,
+        x: 0,
+        y: 0,
+        toJSON: () => ({})
+      } as DOMRect);
+
+    const { container } = render(
+      <AgentQueuedPromptPanel
+        queuedPrompts={[
+          textQueuedPrompt("q1", "First prompt"),
+          textQueuedPrompt("q2", "Second prompt", 2),
+          textQueuedPrompt("q3", "Third prompt", 3)
+        ]}
+        drainingQueuedPromptId={null}
+        labels={labels}
+        onSendQueuedPromptNext={vi.fn()}
+        onRemoveQueuedPrompt={vi.fn()}
+        onEditQueuedPrompt={vi.fn()}
+      />
+    );
+
+    const panel = container.querySelector("[data-expanded]") as HTMLElement;
+    const expandedHeight = panel.style.getPropertyValue(
+      "--agent-gui-queued-prompt-expanded-height"
+    );
+    // rect.bottom=150, reserveTop=48, panelOverhead=46 → spaceCap=56
+    expect(parseInt(expandedHeight)).toBeLessThanOrEqual(56);
+    expect(parseInt(expandedHeight)).toBeGreaterThanOrEqual(32);
+
+    scrollHeightSpy.mockRestore();
+    getBoundingClientRectSpy.mockRestore();
+  });
 });

--- a/packages/agent/gui/agent-gui/agentGuiNode/AgentQueuedPromptPanel.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/AgentQueuedPromptPanel.tsx
@@ -88,6 +88,7 @@ export function AgentQueuedPromptPanel({
 }: AgentQueuedPromptPanelProps): React.JSX.Element {
   "use memo";
   const [isExpanded, setIsExpanded] = useState(false);
+  const panelRef = useRef<HTMLDivElement | null>(null);
   const singlePromptTextRef = useRef<HTMLDivElement | null>(null);
   const queuedPromptListRef = useRef<HTMLDivElement | null>(null);
   const pointerHandledEditPromptIdRef = useRef<string | null>(null);
@@ -179,18 +180,34 @@ export function AgentQueuedPromptPanel({
   }, [canExpand, isExpanded]);
 
   useLayoutEffect(() => {
-    const element = queuedPromptListRef.current;
-    if (!element) {
+    const listElement = queuedPromptListRef.current;
+    const panelElement = panelRef.current;
+    if (!listElement) {
       return;
     }
 
     const measure = (): void => {
+      const contentHeight = listElement.scrollHeight;
       const viewportCap =
         typeof window === "undefined"
           ? 280
           : Math.round(window.innerHeight * 0.38);
+
+      // Constrain to available space between the composer and the top
+      // of the conversation detail area so the expanded panel does not
+      // overflow the detail-panel's overflow:hidden boundary.
+      let spaceCap = 280;
+      if (panelElement && typeof window !== "undefined") {
+        const rect = panelElement.getBoundingClientRect();
+        if (rect.bottom > 0) {
+          const reserveTop = 48;
+          const panelOverhead = 46;
+          spaceCap = Math.max(32, rect.bottom - reserveTop - panelOverhead);
+        }
+      }
+
       setExpandedListMaxHeightPx(
-        Math.max(32, Math.min(280, viewportCap, element.scrollHeight))
+        Math.max(32, Math.min(280, viewportCap, spaceCap, contentHeight))
       );
     };
 
@@ -199,7 +216,7 @@ export function AgentQueuedPromptPanel({
       typeof ResizeObserver === "undefined"
         ? null
         : new ResizeObserver(measure);
-    resizeObserver?.observe(element);
+    resizeObserver?.observe(listElement);
     window.addEventListener("resize", measure);
     return () => {
       resizeObserver?.disconnect();
@@ -209,6 +226,7 @@ export function AgentQueuedPromptPanel({
 
   return (
     <div
+      ref={panelRef}
       className={styles.composerQueuedPromptPanel}
       data-expanded={isExpanded ? "true" : "false"}
       data-expandable={canExpand ? "true" : "false"}


### PR DESCRIPTION
## Summary

- Fix the expanded queued prompt panel overflowing the conversation detail area without a scrollbar (#431)
- Add a `panelRef` to measure actual available space between the composer and the top of the conversation detail area
- Use the measured `spaceCap` as an additional constraint on the expanded list `max-height`, alongside the existing viewport-based cap

## Root cause

The expanded queued prompt panel used a fixed viewport-based cap (`window.innerHeight * 0.38`) for `max-height` that could exceed the actual space between the composer and the top of the conversation detail area. When this happened, the panel extended beyond the detail-panel's `overflow: hidden` boundary, making the collapse button and top items unreachable.

## Changes

- `AgentQueuedPromptPanel.tsx`: Added `panelRef` on the panel root div. Modified the `useLayoutEffect` measurement to calculate `spaceCap` from `panelRef.current.getBoundingClientRect()`, constraining the expanded list height to fit within the visible conversation area.
- `AgentQueuedPromptPanel.spec.tsx`: New test verifying the height is constrained when available space is limited.

## Test plan

- [x] All 8 existing + new tests pass (`vitest run AgentQueuedPromptPanel.spec.tsx`)
- [x] Pre-commit hooks pass (oxfmt, oxlint, electron-runtime, ui-boundaries, renderer-boundaries)
- [ ] Manual verification: expand queued prompt panel with many items on a short viewport

Closes #431

Signed-off-by: Shiyao-Huang <Shiyao-Huang@users.noreply.github.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the expanded queued-prompt panel so its height now stays within the available space above the composer.
  * Added coverage to verify the expanded list respects layout constraints across different viewport sizes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->