### PR TITLE
fix(agent-gui): handle N participants in dotted session mention parsing

### DIFF
--- a/packages/agent/gui/agent-gui/agentGuiNode/agentRichText/AgentMentionNodeView.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/agentRichText/AgentMentionNodeView.tsx
@@ -76,12 +76,18 @@ function parseDottedSessionText(
     .split("·")
     .map((part) => part.trim())
     .filter(Boolean);
-  if (parts.length < 3) {
+  if (parts.length < 2) {
     return null;
   }
+  if (parts.length === 2) {
+    return {
+      participant: `${parts[0]} & ${parts[1]}`,
+      summary: ""
+    };
+  }
   return {
-    participant: `${parts[0]} & ${parts[1]}`,
-    summary: normalizeSessionTitle(parts.slice(2).join(" "))
+    participant: parts.slice(0, -1).join(" & "),
+    summary: normalizeSessionTitle(parts[parts.length - 1]!)
   };
 }
 

--- a/packages/agent/gui/agent-gui/agentGuiNode/agentRichText/AgentMentionNodeView.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/agentRichText/AgentMentionNodeView.tsx
@@ -106,8 +106,11 @@ function sessionPresentation(attrs: Record<string, unknown>): {
     return {
       // i18n-check-ignore: Dynamic participant display names.
       label: `${initiatorName} & ${agentName}`,
-      summary:
-        dottedTitle?.summary || (title && title !== name ? title : inputPreview)
+      summary: dottedTitle
+        ? dottedTitle.summary
+        : title && title !== name
+          ? title
+          : inputPreview
     };
   }
 

--- a/packages/agent/gui/agent-gui/agentGuiNode/agentRichText/agentFileMentionExtension.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/agentRichText/agentFileMentionExtension.ts
@@ -1055,11 +1055,11 @@ function sessionMentionVisual(
     const dottedTitle = parseDottedSessionMentionText(title);
     return {
       participant: `${initiatorName} & ${agentName}`,
-      summary:
-        dottedTitle?.summary ||
-        (title && title !== item.name.trim()
+      summary: dottedTitle
+        ? dottedTitle.summary
+        : title && title !== item.name.trim()
           ? title
-          : item.inputPreview?.trim() || "")
+          : item.inputPreview?.trim() || ""
     };
   }
 

--- a/packages/agent/gui/agent-gui/agentGuiNode/agentRichText/agentFileMentionExtension.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/agentRichText/agentFileMentionExtension.ts
@@ -1087,12 +1087,18 @@ function parseDottedSessionMentionText(
     .split("·")
     .map((part) => part.trim())
     .filter(Boolean);
-  if (parts.length < 3) {
+  if (parts.length < 2) {
     return null;
   }
+  if (parts.length === 2) {
+    return {
+      participant: `${parts[0]} & ${parts[1]}`,
+      summary: ""
+    };
+  }
   return {
-    participant: `${parts[0]} & ${parts[1]}`,
-    summary: normalizeAgentSessionMentionTitle(parts.slice(2).join(" "))
+    participant: parts.slice(0, -1).join(" & "),
+    summary: normalizeAgentSessionMentionTitle(parts[parts.length - 1]!)
   };
 }
 


### PR DESCRIPTION
## Summary
- Handle N-participant dotted session mention parsing (e.g., `Alice · Codex · Bob`) instead of only 2-participant mentions
- Preserve intentional empty summary string in 2-participant path (per CodeRabbit review: use ternary instead of `||`)

## Verification

- `agentFileMentionExtension.spec.ts` — all mention parsing tests pass
- `AgentMentionNodeView.spec.tsx` — all rendering tests pass

## Checklist

- [x] I kept the change focused on one concern.
- [ ] I updated documentation when behavior, setup, or contributor workflow changed.
- [ ] I updated all README/CONTRIBUTING language variants when changing their English source.
- [x] I ran the lowest meaningful local checks for the changed surface.
- [x] My commits are signed off with DCO when required: `git commit -s`.

Closes #434