### PR TITLE
fix(agent-gui): show friendly message for slow-network 524/504 errors

### DIFF
--- a/packages/agent/gui/shared/agentConversation/components/AgentMessageBlock.tsx
+++ b/packages/agent/gui/shared/agentConversation/components/AgentMessageBlock.tsx
@@ -26,6 +26,7 @@ import { workspaceAgentProviderLabel } from "../../workspaceAgentProviderLabel";
 import { openAgentEnvPanel } from "../../agentEnv/agentEnvPanelStore";
 import {
   classifyFailedAgentMessage,
+  reclassifyVisibleErrorDetail,
   resolveAgentErrorPresentation
 } from "../../agentEnv/agentErrorPresentation";
 import type { AgentGUIProviderSkillOption } from "../../../agent-gui/agentGuiNode/model/agentGuiNodeTypes";
@@ -655,10 +656,12 @@ function AgentVisibleErrorMessage({
   const providerLabel = workspaceAgentProviderLabel(
     error?.provider ?? "unknown"
   );
-  const presentation = resolveAgentErrorPresentation(error?.code);
+  const effectiveCode =
+    reclassifyVisibleErrorDetail(error?.code, detail) ?? error?.code;
+  const presentation = resolveAgentErrorPresentation(effectiveCode);
   const headline = presentation?.messageKey
     ? translate(presentation.messageKey, { provider: providerLabel })
-    : visibleErrorTitle(message);
+    : visibleErrorTitle(message, effectiveCode);
   const focus = presentation?.focus ?? null;
   const actionKey = presentation?.actionKey ?? null;
   const hint = visibleErrorHint(message);
@@ -748,10 +751,13 @@ function AgentMessageDetailsDisclosure({
   );
 }
 
-function visibleErrorTitle(message: AgentMessageContentVM): string {
+function visibleErrorTitle(
+  message: AgentMessageContentVM,
+  effectiveCode?: string | null
+): string {
   const error = message.visibleError;
   const provider = workspaceAgentProviderLabel(error?.provider ?? "unknown");
-  switch (error?.code) {
+  switch (effectiveCode ?? error?.code) {
     case "auth_required":
       return translate("agentHost.agentGui.visibleErrorAuthRequired", {
         provider

--- a/packages/agent/gui/shared/agentConversation/components/AgentMessageBlock.visibleError.spec.tsx
+++ b/packages/agent/gui/shared/agentConversation/components/AgentMessageBlock.visibleError.spec.tsx
@@ -78,14 +78,12 @@ describe("AgentVisibleErrorMessage", () => {
     const { getByText, getAllByRole } = renderBlock(
       buildRow(
         {
-          // The real code a missing CLI surfaces as at run time.
           code: "cli_not_found",
           phase: "start",
           provider: "codex",
           detail: "spawn codex ENOENT",
           retryable: false
         },
-        // The raw body must NOT be surfaced as the card title.
         "codex exited: spawn codex ENOENT"
       )
     );
@@ -156,7 +154,6 @@ describe("AgentVisibleErrorMessage", () => {
     );
 
     expect(getByText("Codex request timed out")).toBeTruthy();
-    // No env-panel call-to-action — the wizard cannot fix a transient timeout.
     expect(queryByText("Set up")).toBeNull();
     expect(queryByText("Open setup")).toBeNull();
     expect(queryByText("Sign in")).toBeNull();
@@ -169,7 +166,6 @@ describe("AgentVisibleErrorMessage", () => {
       ),
       "claude-code"
     );
-    // Rendered as the structured card (not dead red text), routing to the wizard.
     expect(
       getByText("Claude Code needs authentication or configuration")
     ).toBeTruthy();
@@ -190,5 +186,21 @@ describe("AgentVisibleErrorMessage", () => {
       "codex"
     );
     expect(queryByText("Sign in")).toBeNull();
+  });
+
+  it("reclassifies a 524 Cloudflare timeout as 'request timed out'", () => {
+    const { getByText, queryByText } = renderBlock(
+      buildRow({
+        code: "provider_error",
+        phase: "turn",
+        provider: "claude-code",
+        detail:
+          'acp session/prompt failed: Internal error: API Error: 524 {"error":{"code":524}}',
+        retryable: true
+      })
+    );
+
+    expect(getByText("Claude Code request timed out")).toBeTruthy();
+    expect(queryByText(/acp session\/prompt failed/)).toBeNull();
   });
 });

--- a/packages/agent/gui/shared/agentEnv/agentErrorPresentation.spec.ts
+++ b/packages/agent/gui/shared/agentEnv/agentErrorPresentation.spec.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import {
   classifyFailedAgentMessage,
+  reclassifyVisibleErrorDetail,
   resolveAgentErrorPresentation
 } from "./agentErrorPresentation";
 
@@ -30,6 +31,58 @@ describe("classifyFailedAgentMessage", () => {
     expect(classifyFailedAgentMessage("request timed out")).toBeNull();
     expect(classifyFailedAgentMessage("here is your answer")).toBeNull();
     expect(classifyFailedAgentMessage(null)).toBeNull();
+  });
+
+  it("recovers request_timed_out from Cloudflare 524 / gateway timeout text", () => {
+    expect(
+      classifyFailedAgentMessage(
+        'acp session/prompt failed: Internal error: API Error: 524 {"error":{"code":524}}'
+      )
+    ).toBe("request_timed_out");
+    expect(
+      classifyFailedAgentMessage("gateway timeout from upstream proxy")
+    ).toBe("request_timed_out");
+  });
+});
+
+describe("reclassifyVisibleErrorDetail", () => {
+  it("reclassifies provider_error with 524 detail to request_timed_out", () => {
+    expect(
+      reclassifyVisibleErrorDetail(
+        "provider_error",
+        'acp session/prompt failed: Internal error: API Error: 524 {"error":{"code":524}}'
+      )
+    ).toBe("request_timed_out");
+  });
+
+  it("reclassifies unknown with 504 detail to request_timed_out", () => {
+    expect(
+      reclassifyVisibleErrorDetail("unknown", "API Error: 504 Gateway Timeout")
+    ).toBe("request_timed_out");
+  });
+
+  it("reclassifies process_exited with connection timed out detail", () => {
+    expect(
+      reclassifyVisibleErrorDetail("process_exited", "connection timed out")
+    ).toBe("request_timed_out");
+  });
+
+  it("returns null for non-ambiguous codes", () => {
+    expect(
+      reclassifyVisibleErrorDetail("request_timed_out", "API Error: 524")
+    ).toBeNull();
+  });
+
+  it("returns null when detail has no timeout markers", () => {
+    expect(
+      reclassifyVisibleErrorDetail("provider_error", "some other error")
+    ).toBeNull();
+  });
+
+  it("returns null for null/empty inputs", () => {
+    expect(reclassifyVisibleErrorDetail(null, "524")).toBeNull();
+    expect(reclassifyVisibleErrorDetail("provider_error", null)).toBeNull();
+    expect(reclassifyVisibleErrorDetail("provider_error", "")).toBeNull();
   });
 });
 

--- a/packages/agent/gui/shared/agentEnv/agentErrorPresentation.ts
+++ b/packages/agent/gui/shared/agentEnv/agentErrorPresentation.ts
@@ -154,6 +154,56 @@ const FAILED_MESSAGE_CODE_MARKERS: ReadonlyArray<
 ];
 
 /**
+ * Markers that indicate a slow-network gateway timeout. The daemon often
+ * classifies these as a generic provider_error or unknown, which causes
+ * the card to render the raw Cloudflare JSON as the headline.
+ */
+const TIMEOUT_DETAIL_MARKERS: readonly string[] = [
+  "api error: 524",
+  "api error: 504",
+  "524 ",
+  "504 ",
+  '"status":524',
+  '"status":504',
+  "gateway timeout",
+  "connection timed out",
+  "etimedout",
+  "readtimeout"
+];
+
+/**
+ * When the daemon classifies a slow-network gateway timeout (Cloudflare 524,
+ * HTTP 504) as a generic provider_error or unknown, the card renders the
+ * raw Cloudflare JSON as the headline.  This inspects the detail text of
+ * ambiguous codes and, when it clearly indicates a timeout, reclassifies it
+ * to request_timed_out so the user sees a friendly message instead.
+ *
+ * Returns null when the code is not ambiguous or the detail does not match a
+ * timeout pattern, so the caller keeps the original code.
+ */
+export function reclassifyVisibleErrorDetail(
+  code: string | null | undefined,
+  detail: string | null | undefined
+): AgentRunErrorCode | null {
+  if (
+    !code ||
+    (code !== "provider_error" &&
+      code !== "unknown" &&
+      code !== "process_exited")
+  ) {
+    return null;
+  }
+  if (!detail) {
+    return null;
+  }
+  const lower = detail.toLowerCase();
+  if (TIMEOUT_DETAIL_MARKERS.some((marker) => lower.includes(marker))) {
+    return "request_timed_out";
+  }
+  return null;
+}
+
+/**
  * Some providers (notably Claude Code) report an environment failure — e.g. a
  * dropped login (401) — as a plain failed assistant message rather than a
  * structured visibleError, so it never gets the remediation card. This recovers
@@ -172,6 +222,11 @@ export function classifyFailedAgentMessage(
     if (markers.some((marker) => lower.includes(marker))) {
       return code;
     }
+  }
+  // Recover timeout-like failures from plain text too, so they get the
+  // structured "request timed out" card rather than a dead red message.
+  if (TIMEOUT_DETAIL_MARKERS.some((marker) => lower.includes(marker))) {
+    return "request_timed_out";
   }
   return null;
 }


### PR DESCRIPTION
## Summary

Reclassify slow-network 524/504 gateway timeout errors as `request_timed_out` instead of showing raw error JSON.

## Root Cause

Under slow network conditions, Cloudflare 524 / HTTP 504 timeouts were classified as generic `provider_error` or `unknown`, causing raw error JSON to render directly in the conversation card.

## Changes

- Add `reclassifyVisibleErrorDetail()` function to detect timeout markers in error details (524, 504, gateway timeout, ETIMEDOUT)
- Extend `classifyFailedAgentMessage()` to recover timeout-type failures from generic failed messages

## Verification

- `agentErrorPresentation.spec.ts` — 14 tests pass (7 existing + 7 new)
- `AgentMessageBlock.visibleError.spec.tsx` — 7 tests pass (6 existing + 1 new)

## Checklist

- [x] I kept the change focused on one concern.
- [ ] I updated documentation when behavior, setup, or contributor workflow changed.
- [ ] I updated all README/CONTRIBUTING language variants when changing their English source.
- [x] I ran the lowest meaningful local checks for the changed surface.
- [x] My commits are signed off with DCO when required: `git commit -s`.

Closes #427