### PR TITLE
fix(agent-gui): show approval details for non-edit tool calls

### DIFF
--- a/packages/agent/gui/shared/agentConversation/components/tool-renderers/AgentApprovalContent.tsx
+++ b/packages/agent/gui/shared/agentConversation/components/tool-renderers/AgentApprovalContent.tsx
@@ -2,6 +2,7 @@ import type { JSX } from "react";
 import type { AgentToolCallVM } from "../../contracts/agentToolCallVM";
 import { AgentEditContent } from "./AgentEditContent";
 import {
+  AgentDefaultToolContent,
   arrayValue,
   objectValue,
   stringValue,
@@ -19,7 +20,12 @@ export function AgentApprovalContent({
     return null;
   }
   if (previewCall) {
-    return <AgentEditContent call={previewCall} onLinkClick={onLinkClick} />;
+    if (previewCall.rendererKind === "edit") {
+      return <AgentEditContent call={previewCall} onLinkClick={onLinkClick} />;
+    }
+    return (
+      <AgentDefaultToolContent call={previewCall} onLinkClick={onLinkClick} />
+    );
   }
   return (
     <div className="workspace-agents-status-panel__detail-tool-body">
@@ -33,27 +39,27 @@ function approvalPreviewCall(call: AgentToolCallVM): AgentToolCallVM | null {
   if (!toolCall) {
     return null;
   }
+  const input = objectValue(toolCall.rawInput);
+  const content = arrayValue(toolCall.content);
+  const locations = arrayValue(toolCall.locations);
   const normalizedKind = normalizeToolKind(
     stringValue(toolCall.kind) ??
       stringValue(toolCall.title) ??
       stringValue(toolCall.toolName)
   );
-  if (normalizedKind !== "edit" && normalizedKind !== "move") {
-    return null;
-  }
-  const input = objectValue(toolCall.rawInput);
-  const content = arrayValue(toolCall.content);
-  const locations = arrayValue(toolCall.locations);
+  const isEditLike = normalizedKind === "edit" || normalizedKind === "move";
   return {
     kind: "tool-call",
     id: `${call.id}:approval-preview`,
     turnId: call.turnId,
     name: stringValue(toolCall.title) ?? call.name,
-    toolName: "Edit",
+    toolName: isEditLike
+      ? "Edit"
+      : (stringValue(toolCall.toolName) ?? call.name),
     callType: "tool",
     status: stringValue(toolCall.status) ?? call.status,
     statusKind: call.statusKind,
-    summary: "",
+    summary: call.summary,
     compactSummary: null,
     payload: {
       input,
@@ -67,7 +73,7 @@ function approvalPreviewCall(call: AgentToolCallVM): AgentToolCallVM | null {
     metadata: null,
     content,
     locations,
-    rendererKind: "edit",
+    rendererKind: isEditLike ? "edit" : "default",
     approval: null,
     planMode: null,
     askUserQuestion: null,

--- a/packages/agent/gui/shared/agentConversation/components/tool-renderers/AgentExpandedToolContent.spec.tsx
+++ b/packages/agent/gui/shared/agentConversation/components/tool-renderers/AgentExpandedToolContent.spec.tsx
@@ -89,6 +89,40 @@ describe("AgentExpandedToolContent", () => {
     expect(screen.queryByText("Allow once")).toBeNull();
   });
 
+  it("renders non-edit approval toolCall details (e.g. bash command)", async () => {
+    setAgentGuiI18nTestLocale("en");
+
+    render(
+      <AgentExpandedToolContent
+        call={projectAgentToolCall(
+          toolCall({
+            callType: "approval",
+            toolName: "Approval",
+            status: "Completed",
+            statusKind: "completed",
+            payload: {
+              input: {
+                toolCall: {
+                  kind: "bash",
+                  title: "Bash",
+                  toolName: "Bash",
+                  status: "pending",
+                  rawInput: {
+                    command: "npm install",
+                    description: "Install dependencies"
+                  }
+                }
+              }
+            }
+          })
+        )}
+      />
+    );
+
+    // The approval should render the command details instead of nothing
+    expect(screen.getByText("npm install")).toBeTruthy();
+  });
+
   it("renders ask-user options and selected answer from the typed ask-user vm", async () => {
     setAgentGuiI18nTestLocale("en");
 


### PR DESCRIPTION
## Summary

- Fix approval cards showing empty content when expanded for non-edit/move tool calls (#418)
- Extend `approvalPreviewCall` to handle all tool kinds, not just edit/move
- Non-edit/move approvals now render via `AgentDefaultToolContent` showing the raw input data

## Root cause

`AgentApprovalContent` only rendered detail previews for edit/move tool kinds. For other kinds (bash commands, reads, etc.), `approvalPreviewCall` returned `null`, and if `call.summary` was also empty, the expanded section rendered nothing — even though `hasAgentToolContent` returned `true` (because `call.input.toolCall` exists), making the card appear expandable.

## Changes

- `AgentApprovalContent.tsx`: Extend `approvalPreviewCall` to create preview VMs for all tool kinds. Edit/move uses `rendererKind: "edit"` (unchanged). Other kinds use `rendererKind: "default"` which renders input/output via `AgentDefaultToolContent`. Also pass `call.summary` through to the preview VM.
- `AgentExpandedToolContent.spec.tsx`: New test verifying a bash-type approval renders the command details.

## Test plan

- [x] All 34 tests in `AgentExpandedToolContent.spec.tsx` pass (33 existing + 1 new)
- [x] All 33 tests in `AgentToolCallCard.spec.tsx` + `AgentToolGroupRow.spec.tsx` pass
- [x] Pre-commit hooks pass (oxfmt, oxlint, electron-runtime, ui-boundaries, renderer-boundaries)

Closes #418

Signed-off-by: Shiyao-Huang <Shiyao-Huang@users.noreply.github.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Approval previews now display the correct tool content for non-edit actions instead of always using the edit view.
  * Preview details now show the provided summary and tool name more accurately for different action types.

* **Tests**
  * Added coverage for approval previews involving non-edit tool actions, including command-style content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->