### PR TITLE
fix(agent-gui): show loading skeleton immediately on conversation creation

### DIFF
--- a/packages/agent/gui/agent-gui/agentGuiNode/AgentGUINodeView.layout.spec.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/AgentGUINodeView.layout.spec.tsx
@@ -1232,6 +1232,44 @@ describe("AgentGUINodeView layout persistence", () => {
     expect(screen.getByTestId("agent-conversation-flow")).toBeInTheDocument();
   });
 
+  it("shows the transcript skeleton immediately when creating a conversation", () => {
+    // During conversation creation the user should see the loading skeleton
+    // right away — not the empty hero pane which makes the UI feel stuck.
+    renderAgentGUINodeView({
+      viewModel: {
+        ...createViewModel(),
+        isCreatingConversation: true,
+        isLoadingMessages: true
+      }
+    });
+
+    // The transcript loading skeleton should be rendered (not the hero pane).
+    expect(screen.getByTestId("agent-conversation-flow")).toBeInTheDocument();
+    // The bottom dock (composer) should also be visible during creation.
+    expect(screen.getByTestId("agent-gui-bottom-dock")).toBeInTheDocument();
+    expect(screen.getByTestId("agent-composer")).toBeInTheDocument();
+  });
+
+  it("shows the empty hero pane when not creating a conversation", () => {
+    renderAgentGUINodeView({
+      viewModel: {
+        ...createViewModel(),
+        isCreatingConversation: false,
+        isLoadingMessages: false
+      }
+    });
+
+    // The conversation flow should NOT be rendered on the home screen.
+    expect(
+      screen.queryByTestId("agent-conversation-flow")
+    ).not.toBeInTheDocument();
+    // The composer is rendered inside the hero pane, not the bottom dock.
+    expect(
+      screen.queryByTestId("agent-gui-bottom-dock")
+    ).not.toBeInTheDocument();
+    expect(screen.getByTestId("agent-composer")).toBeInTheDocument();
+  });
+
   it("prefetches older messages near the top and preserves the prepend anchor", () => {
     const activeConversation = createConversationSummary("session-1");
     const actions = createActions();

--- a/packages/agent/gui/agent-gui/agentGuiNode/AgentGUINodeView.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/AgentGUINodeView.tsx
@@ -2435,13 +2435,13 @@ const AgentGUIDetailPane = memo(function AgentGUIDetailPane({
         viewportRef={timelineRef}
         viewportTestId="agent-gui-timeline"
         viewportClassName={`${styles.timeline} ${
-          hasActiveConversation
+          hasActiveConversation || viewModel.isCreatingConversation
             ? styles.timelineWithComposer
             : styles.timelineCentered
         } ${showUnavailableChatEmpty ? styles.timelineUnavailableChatEmpty : ""}`.trim()}
         viewportContentStyle={AGENT_GUI_TIMELINE_SCROLL_AREA_CONTENT_STYLE}
       >
-        {!hasActiveConversation ? (
+        {!hasActiveConversation && !viewModel.isCreatingConversation ? (
           <AgentGUIEmptyHeroPane
             provider={viewModel.data.provider}
             emptyLabel={labels.empty}
@@ -2471,7 +2471,7 @@ const AgentGUIDetailPane = memo(function AgentGUIDetailPane({
           />
         )}
       </ScrollArea>
-      {hasActiveConversation ? (
+      {hasActiveConversation || viewModel.isCreatingConversation ? (
         <AgentGUIBottomDockPane
           bottomDockRef={bottomDockRef}
           bottomDockLiftedPrompt={bottomDockLiftedPrompt}

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUINodeController.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUINodeController.ts
@@ -5885,6 +5885,9 @@ export function useAgentGUINodeController({
       isCreatingConversationRef.current = true;
       setLocalIsCreatingConversation(true);
       setDetailError(null);
+      // Show the loading skeleton immediately so the UI does not feel stuck
+      // during the async activation round-trip.
+      setIsLoadingMessages(true);
       let pendingCreateAgentSessionId: string | null = null;
       let pendingOptimisticConversation: AgentGUIConversationSummary | null =
         null;


### PR DESCRIPTION
## Summary
- When starting a new conversation, the async activation round-trip can take several hundred milliseconds. During this time the empty hero pane was still shown, making the UI feel stuck even though the user had already submitted their prompt.
- Set `isLoadingMessages=true` at the start of `startConversation` so the transcript skeleton appears immediately.
- Render the timeline pane + bottom dock (instead of the hero pane) whenever `isCreatingConversation` is true, so the user sees the loading skeleton and the composer dock right away.

Closes #425

## Test plan
- [x] New test: "shows the transcript skeleton immediately when creating a conversation" — verifies the conversation flow and bottom dock render during creation
- [x] New test: "shows the empty hero pane when not creating a conversation" — verifies the hero pane still shows on the home screen
- [x] All 53 layout spec tests pass
- [x] All 189 controller spec tests pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the conversation setup experience so the loading skeleton appears immediately while messages are loading.
  * Ensured the composer and bottom dock remain visible during conversation creation, matching the active-conversation layout.
  * Refined empty-state behavior so the home view shows only when there’s no active conversation and no conversation is currently being created.
  * Updated transcript/composer layout consistency across loading and non-loading states.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->