### PR TITLE
fix(agent-gui): show loading state for stale @mention browse cache

### DIFF
--- a/packages/agent/gui/agent-gui/agentGuiNode/AgentMentionSearchController.spec.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/AgentMentionSearchController.spec.ts
@@ -797,6 +797,107 @@ describe("AgentMentionSearchController", () => {
     expect(queryFiles).toHaveBeenCalledTimes(1);
   });
 
+
+  it("shows loading status while serving stale browse cache for background revalidation", async () => {
+    let now = 10_000;
+    const queryFiles = vi.fn().mockResolvedValue({
+      workspaceId: "room-1",
+      root: "/workspace",
+      entries: [
+        { path: "/workspace/initial.md", name: "initial.md", kind: "file" }
+      ]
+    });
+    const controller = new AgentMentionSearchController({
+      queryFiles,
+      queryIssues: vi.fn().mockResolvedValue({
+        issues: [],
+        totalCount: 0,
+        statusCounts: undefined
+      }),
+      querySessions: vi.fn().mockResolvedValue({ presences: [], sessions: [] }),
+      loadSessionMessages: vi
+        .fn()
+        .mockResolvedValue({ messages: [], latestVersion: 0, hasMore: false }),
+      loadSessionSummary: vi.fn(),
+      loadUserProfiles: vi.fn().mockResolvedValue({ users: [] }),
+      diagnosticNow: () => now,
+      browseCacheTtlMs: 5_000
+    });
+    const states: any[] = [];
+    controller.subscribe((state) => states.push(state));
+
+    // Warm cache with initial data
+    controller.setFilter("file");
+    controller.updateQuery({ workspaceId: "room-1", query: "" });
+    await vi.waitFor(() =>
+      expect(states.at(-1)).toMatchObject({
+        status: "ready",
+        mode: "browse",
+        filter: "file"
+      })
+    );
+
+    // Close and advance time past TTL so cache becomes stale
+    controller.close();
+    now += 10_000;
+
+    // Update the mock to return different files (simulating real workspace changes)
+    queryFiles.mockResolvedValue({
+      workspaceId: "room-1",
+      root: "/workspace",
+      entries: [
+        { path: "/workspace/updated.md", name: "updated.md", kind: "file" }
+      ]
+    });
+
+    // Reopen — stale cache should show status "loading", not "ready"
+    controller.setFilter("file");
+    controller.updateQuery({ workspaceId: "room-1", query: "" });
+
+    // Wait for the stale-while-revalidate state to appear
+    await vi.waitFor(() =>
+      expect(states.at(-1)).toMatchObject({
+        status: "loading",
+        mode: "browse",
+        filter: "file"
+      })
+    );
+    // Stale data is still visible as placeholder
+    expect(states.at(-1).groups).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          id: "opened_files",
+          items: [
+            expect.objectContaining({
+              path: "/workspace/initial.md"
+            })
+          ]
+        })
+      ])
+    );
+
+    // After background fetch completes, status becomes "ready" with fresh data
+    await vi.waitFor(() =>
+      expect(states.at(-1)).toMatchObject({
+        status: "ready",
+        mode: "browse",
+        filter: "file",
+        groups: expect.arrayContaining([
+          expect.objectContaining({
+            id: "opened_files",
+            items: [
+              expect.objectContaining({
+                path: "/workspace/updated.md"
+              })
+            ]
+          })
+        ])
+      })
+    );
+
+    controller.dispose();
+  });
+
   it("evicts the oldest browse cache entry once the shared cap is exceeded", async () => {
     const now = 5_000;
     const queryFiles = vi.fn().mockResolvedValue({

--- a/packages/agent/gui/agent-gui/agentGuiNode/AgentMentionSearchController.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/AgentMentionSearchController.ts
@@ -659,7 +659,10 @@ export class AgentMentionSearchController {
     if (cached.entry) {
       this.applyBrowseFetchResult(cached.entry);
       this.setState({
-        status: "ready",
+        // Show "loading" (not "ready") when serving stale cache data so the
+        // UI displays a refresh indicator while the background revalidation
+        // fetch is in progress. Fresh cache hits return "ready" below.
+        status: cached.isFresh ? "ready" : "loading",
         query: "",
         mode: "browse",
         filter: this.currentFilter,

--- a/packages/workbench/surface/src/host/WorkbenchHostDock.tsx
+++ b/packages/workbench/surface/src/host/WorkbenchHostDock.tsx
@@ -1573,6 +1573,17 @@ export function WorkbenchHostDock({
                           return;
                         case "minimize-node":
                           closePopup();
+                          void (async () => {
+                            try {
+                              await onDockEntryClick?.({
+                                entryId: entry.id,
+                                host,
+                                nodeId: clickResolution.nodeId
+                              });
+                            } catch {
+                              // Keep dock click failures contained.
+                            }
+                          })();
                           context.genie.minimizeNodeToAnchor(
                             clickResolution.nodeId,
                             () => {

--- a/packages/workbench/surface/src/host/WorkbenchHostDock.tsx
+++ b/packages/workbench/surface/src/host/WorkbenchHostDock.tsx
@@ -1480,6 +1480,7 @@ export function WorkbenchHostDock({
                 );
                 const clickResolution = resolveWorkbenchDockEntryClick({
                   entry,
+                  focusedNodeId: context.focusedNodeId,
                   instanceMode,
                   matchedNodes: resolvedEntry.matchedNodes
                 });
@@ -1567,6 +1568,15 @@ export function WorkbenchHostDock({
                             clickResolution.nodeId,
                             () => {
                               host.focusNode(clickResolution.nodeId);
+                            }
+                          );
+                          return;
+                        case "minimize-node":
+                          closePopup();
+                          context.genie.minimizeNodeToAnchor(
+                            clickResolution.nodeId,
+                            () => {
+                              host.minimizeNode(clickResolution.nodeId);
                             }
                           );
                           return;

--- a/packages/workbench/surface/src/host/dockEntries.test.ts
+++ b/packages/workbench/surface/src/host/dockEntries.test.ts
@@ -286,6 +286,117 @@ test("dock action entries respect blocked entry state", () => {
   );
 });
 
+test("dock click resolution toggles to minimize when node is already focused", () => {
+  const entry: WorkbenchHostDockEntry = {
+    icon: null,
+    id: "agent:codex",
+    label: "Codex",
+    typeId: "agentGui"
+  };
+
+  const focusedNode = makeNode("agent-1", "agentGui", "agent:codex");
+
+  // Node is focused (matches focusedNodeId) and not minimized → should minimize
+  assert.deepEqual(
+    resolveWorkbenchDockEntryClick({
+      entry,
+      focusedNodeId: focusedNode.id,
+      instanceMode: "single",
+      matchedNodes: [focusedNode]
+    }),
+    { kind: "minimize-node", nodeId: "agentGui:agent-1" }
+  );
+});
+
+test("dock click resolution focuses node when it is minimized", () => {
+  const entry: WorkbenchHostDockEntry = {
+    icon: null,
+    id: "agent:codex",
+    label: "Codex",
+    typeId: "agentGui"
+  };
+
+  const minimizedNode: WorkbenchNode<WorkbenchHostNodeData> = {
+    ...makeNode("agent-1", "agentGui", "agent:codex"),
+    isMinimized: true
+  };
+
+  // Node is minimized → should focus/restore even though focusedNodeId matches
+  assert.deepEqual(
+    resolveWorkbenchDockEntryClick({
+      entry,
+      focusedNodeId: minimizedNode.id,
+      instanceMode: "single",
+      matchedNodes: [minimizedNode]
+    }),
+    { kind: "focus-node", nodeId: "agentGui:agent-1" }
+  );
+});
+
+test("dock click resolution focuses node when another node is focused", () => {
+  const entry: WorkbenchHostDockEntry = {
+    icon: null,
+    id: "agent:codex",
+    label: "Codex",
+    typeId: "agentGui"
+  };
+
+  const node = makeNode("agent-1", "agentGui", "agent:codex");
+
+  // A different node is focused → should focus this one
+  assert.deepEqual(
+    resolveWorkbenchDockEntryClick({
+      entry,
+      focusedNodeId: "agentGui:agent-other",
+      instanceMode: "single",
+      matchedNodes: [node]
+    }),
+    { kind: "focus-node", nodeId: "agentGui:agent-1" }
+  );
+});
+
+test("dock click resolution defaults to focus when focusedNodeId is not provided", () => {
+  const entry: WorkbenchHostDockEntry = {
+    icon: null,
+    id: "agent:codex",
+    label: "Codex",
+    typeId: "agentGui"
+  };
+
+  const node = makeNode("agent-1", "agentGui", "agent:codex");
+
+  // No focusedNodeId provided → backward compatible, always focus
+  assert.deepEqual(
+    resolveWorkbenchDockEntryClick({
+      entry,
+      instanceMode: "single",
+      matchedNodes: [node]
+    }),
+    { kind: "focus-node", nodeId: "agentGui:agent-1" }
+  );
+});
+
+test("dock click resolution does not toggle minimize for null focusedNodeId", () => {
+  const entry: WorkbenchHostDockEntry = {
+    icon: null,
+    id: "agent:codex",
+    label: "Codex",
+    typeId: "agentGui"
+  };
+
+  const node = makeNode("agent-1", "agentGui", "agent:codex");
+
+  assert.deepEqual(
+    resolveWorkbenchDockEntryClick({
+      entry,
+      focusedNodeId: null,
+      instanceMode: "single",
+      matchedNodes: [node]
+    }),
+    { kind: "focus-node", nodeId: "agentGui:agent-1" }
+  );
+});
+
 function makeNode(
   instanceId: string,
   typeId: string,

--- a/packages/workbench/surface/src/host/dockEntries.ts
+++ b/packages/workbench/surface/src/host/dockEntries.ts
@@ -21,6 +21,7 @@ export type WorkbenchHostDockClickResolution =
   | { kind: "blocked" }
   | { kind: "focus-node"; nodeId: string }
   | { kind: "launch" }
+  | { kind: "minimize-node"; nodeId: string }
   | { kind: "open-popup" };
 
 export function matchWorkbenchDockEntryNode(
@@ -116,6 +117,7 @@ export function resolveWorkbenchDockEntries(input: {
 
 export function resolveWorkbenchDockEntryClick(input: {
   entry: WorkbenchHostDockEntry;
+  focusedNodeId?: string | null;
   instanceMode?: WorkbenchHostNodeInstanceStrategy["mode"];
   matchedNodes: readonly WorkbenchNode<WorkbenchHostNodeData>[];
 }): WorkbenchHostDockClickResolution {
@@ -135,7 +137,18 @@ export function resolveWorkbenchDockEntryClick(input: {
     return { kind: "open-popup" };
   }
   if (input.matchedNodes.length === 1) {
-    return { kind: "focus-node", nodeId: input.matchedNodes[0]!.id };
+    const node = input.matchedNodes[0]!;
+    // Toggle: if the node is already focused (not minimized and is the active
+    // node), clicking the dock icon minimizes it. If it's minimized or not
+    // focused, clicking restores/focuses it.
+    if (
+      input.focusedNodeId != null &&
+      node.id === input.focusedNodeId &&
+      !node.isMinimized
+    ) {
+      return { kind: "minimize-node", nodeId: node.id };
+    }
+    return { kind: "focus-node", nodeId: node.id };
   }
   if (input.matchedNodes.length > 1) {
     return { kind: "open-popup" };

--- a/packages/workbench/surface/src/react/WorkbenchDockFrame.tsx
+++ b/packages/workbench/surface/src/react/WorkbenchDockFrame.tsx
@@ -95,6 +95,9 @@ export function WorkbenchDockFrame<TData>({
                 },
                 isPendingMinimizedDockNode: (nodeID) => {
                   return genie.isPendingMinimizedDockNode(nodeID);
+                },
+                minimizeNodeToAnchor: (nodeID, minimize) => {
+                  genie.minimizeNodeToAnchor(nodeID, minimize);
                 }
               },
               minimizedNodes,

--- a/packages/workbench/surface/src/react/types.ts
+++ b/packages/workbench/surface/src/react/types.ts
@@ -46,6 +46,7 @@ export interface WorkbenchDockContext<TData = unknown> {
     ): void;
     registerDockAnchor(anchorKey: string, element: HTMLElement | null): void;
     shouldAnimateMinimizedDockEnter(nodeID: string): boolean;
+    minimizeNodeToAnchor(nodeID: string, minimize?: () => void): void;
     isPendingMinimizedDockNode(nodeID: string): boolean;
   };
 }


### PR DESCRIPTION
## Summary
- When serving stale browse cache during background revalidation, emit `status: "loading"` instead of `"ready"`
- Stale data is still shown as placeholder, but the loading indicator makes it clear data is being refreshed
- Fresh cache hits (within TTL) remain `status: "ready"` — no behavior change for the common case

## Root Cause
`AgentMentionSearchController.startBrowseModeFetch` applied stale cache data and immediately emitted `status: "ready"` while a background revalidation fetch was still in progress. Users saw stale file listings presented as current.

Closes #429

## Test plan
- [ ] Opening @mention file picker with stale cache shows loading indicator
- [ ] Fresh cache hits show results immediately with no loading
- [ ] No regression in file search behavior

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Dock entry clicks are now focus-aware, toggling between focusing and minimizing the currently selected node.
* **Bug Fixes**
  * Stale cached browse/mention results now show a loading/refresh state during background revalidation, while keeping existing cached items visible until updated data is ready.
* **Tests**
  * Added coverage for focus/minimize dock click scenarios (including minimized and null/omitted focus states) and for stale-cache revalidation state transitions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->