### PR TITLE
fix(gui): strip markdown emphasis from copied agent replies

### DIFF
--- a/packages/agent/gui/shared/agentConversation/lib/stripMarkdownEmphasis.spec.ts
+++ b/packages/agent/gui/shared/agentConversation/lib/stripMarkdownEmphasis.spec.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it } from "vitest";
+import { stripMarkdownEmphasis } from "./stripMarkdownEmphasis";
+
+describe("stripMarkdownEmphasis", () => {
+  it("removes **bold** markers", () => {
+    expect(stripMarkdownEmphasis("This is **important** text.")).toBe(
+      "This is important text."
+    );
+  });
+
+  it("removes *italic* markers", () => {
+    expect(stripMarkdownEmphasis("This is *noted* text.")).toBe(
+      "This is noted text."
+    );
+  });
+
+  it("removes ***bold italic*** markers", () => {
+    expect(stripMarkdownEmphasis("This is ***very important*** text.")).toBe(
+      "This is very important text."
+    );
+  });
+
+  it("removes __bold__ markers", () => {
+    expect(stripMarkdownEmphasis("This is __underlined__ text.")).toBe(
+      "This is underlined text."
+    );
+  });
+
+  it("removes _italic_ markers between word boundaries", () => {
+    expect(stripMarkdownEmphasis("The _quick_ fox")).toBe("The quick fox");
+  });
+
+  it("strips bold markers from Chinese text (the reported issue)", () => {
+    expect(stripMarkdownEmphasis("**3 号线也不是最优**")).toBe(
+      "3 号线也不是最优"
+    );
+    expect(
+      stripMarkdownEmphasis("**福田站坐 11 号线 → 南山站下 → E2 出口步行过去**")
+    ).toBe("福田站坐 11 号线 → 南山站下 → E2 出口步行过去");
+  });
+
+  it("handles multiple emphasis in one string", () => {
+    expect(stripMarkdownEmphasis("**bold** and *italic* and __more__")).toBe(
+      "bold and italic and more"
+    );
+  });
+
+  it("preserves inline code spans", () => {
+    expect(stripMarkdownEmphasis("Run `git commit **not bold**` now")).toBe(
+      "Run `git commit **not bold**` now"
+    );
+  });
+
+  it("preserves fenced code blocks", () => {
+    const text = "Here:\n```js\nconst x = '**value**';\n```\nDone.";
+    expect(stripMarkdownEmphasis(text)).toBe(text);
+  });
+
+  it("strips emphasis outside code but preserves it inside", () => {
+    expect(stripMarkdownEmphasis("**bold** and `code *not italic*`")).toBe(
+      "bold and `code *not italic*`"
+    );
+  });
+
+  it("leaves unmatched asterisks alone", () => {
+    expect(stripMarkdownEmphasis("Use * for bullets")).toBe(
+      "Use * for bullets"
+    );
+  });
+
+  it("leaves snake_case identifiers alone", () => {
+    expect(stripMarkdownEmphasis("my_variable_name")).toBe("my_variable_name");
+  });
+
+  it("returns plain text unchanged", () => {
+    expect(stripMarkdownEmphasis("No markdown here.")).toBe(
+      "No markdown here."
+    );
+  });
+});

--- a/packages/agent/gui/shared/agentConversation/lib/stripMarkdownEmphasis.ts
+++ b/packages/agent/gui/shared/agentConversation/lib/stripMarkdownEmphasis.ts
@@ -1,0 +1,34 @@
+/**
+ * Removes Markdown emphasis markers (`**`, `*`, `__`, `_`) from prose text so
+ * that text copied from an agent reply reads as plain text. Inline code spans
+ * (`` `code` ``) and fenced code blocks are preserved — their content is
+ * meaningful and stripping markers inside would corrupt it.
+ */
+export function stripMarkdownEmphasis(text: string): string {
+  // Split into alternating [prose, code, prose, code, …] segments.
+  // The capturing group keeps code spans/blocks in the result array.
+  const parts = text.split(/(```[\s\S]*?```|`[^`]+`)/g);
+  return parts
+    .map((part, i) => {
+      // Odd indices are code spans / fenced blocks from the capturing group.
+      if (i % 2 === 1) return part;
+      return stripEmphasisDelimiters(part);
+    })
+    .join("");
+}
+
+function stripEmphasisDelimiters(prose: string): string {
+  return (
+    prose
+      // ***bold italic*** — strip before ** to avoid partial matches.
+      .replace(/\*\*\*(.+?)\*\*\*/gs, "$1")
+      // **bold**
+      .replace(/\*\*(.+?)\*\*/gs, "$1")
+      // *italic* — require non-* on both sides, no newlines inside.
+      .replace(/(^|[^*])\*([^*\n]+?)\*(?!\*)/g, "$1$2")
+      // __bold__
+      .replace(/__(.+?)__/gs, "$1")
+      // _italic_ — require word boundary on both sides, no newlines inside.
+      .replace(/(^|[^_\w])_([^_\n]+?)_(?![\w_])/g, "$1$2")
+  );
+}

--- a/packages/agent/gui/shared/agentConversation/projection/agentConversationProjection.ts
+++ b/packages/agent/gui/shared/agentConversation/projection/agentConversationProjection.ts
@@ -13,6 +13,7 @@ import type {
 } from "../contracts/agentMessageRowVM";
 import type { AgentToolCallVM } from "../contracts/agentToolCallVM";
 import type { AgentTranscriptRowVM } from "../contracts/agentTranscriptRowVM";
+import { stripMarkdownEmphasis } from "../lib/stripMarkdownEmphasis";
 import {
   buildAgentTurnSequenceItems,
   computeAgentToolGroups
@@ -438,7 +439,7 @@ function projectMessageCopyText(
         row.speaker === "user"
           ? copyTextForUserMessage(message)
           : assistantCopyTargetKeys.has(messageCopyTargetKey(row, message))
-            ? message.body
+            ? stripMarkdownEmphasis(message.body)
             : null;
       if ((message.copyText ?? null) === copyText) {
         return message;


### PR DESCRIPTION
## 背景
复制的 agent 文本包含原始的 `**bold**` 和 `*italic*` 标记，导致粘贴内容中出现多余星号。

## 修复
- 新增 `stripMarkdownEmphasis()` 工具函数，移除强调定界符同时保留内联代码跨度和围栏代码块
- 将其应用于 assistant `copyText` 投影，使剪贴板文本读起来像纯文本

## 验证
- 13 个单元测试覆盖加粗、斜体、粗斜体、`__bold__`、`_italic_`、中文文本、代码保留、snake_case 安全性和纯文本无操作
- 20 个现有投影测试通过
- 手动验证：复制包含 `**bold**` 文本的 agent 回复 → 粘贴 → 确认无星号