### PR TITLE
fix(agent-gui): show command details in approval tool call cards

### DIFF
--- a/packages/agent/gui/shared/agentConversation/components/AgentToolCallCard.spec.tsx
+++ b/packages/agent/gui/shared/agentConversation/components/AgentToolCallCard.spec.tsx
@@ -813,6 +813,136 @@ describe("Agent specialized tool cards", () => {
       document.querySelector(".workspace-agents-status-panel__detail-tool-body")
     ).not.toBeInTheDocument();
   });
+  it("expands command approval cards to show command details", async () => {
+    setAgentGuiI18nTestLocale("en");
+
+    render(
+      <AgentToolCallCard
+        call={projectAgentToolCall(
+          toolCall({
+            name: "Approval",
+            toolName: "Approval",
+            callType: "tool",
+            status: "Completed",
+            statusKind: "completed",
+            payload: {
+              input: {
+                requestId: "req-1",
+                toolCall: {
+                  kind: "bash",
+                  title: "Run command",
+                  toolName: "Bash",
+                  rawInput: {
+                    command: "npm test"
+                  }
+                },
+                options: [
+                  { optionId: "approved", name: "Allow" }
+                ]
+              }
+            }
+          })
+        )}
+      />
+    );
+
+    // Card should be collapsible (has expand button)
+    const toggle = screen.getByRole("button", { expanded: false });
+    expect(toggle).toHaveAttribute("aria-expanded", "false");
+
+    // Expand it
+    fireEvent.click(toggle);
+    await flushCollapsibleRevealFrames();
+
+    // Command detail should be visible
+    expect(toggle).toHaveAttribute("aria-expanded", "true");
+    expect(screen.getByText("npm test")).toBeTruthy();
+  });
+
+  it("expands bash approval cards with array-form command", async () => {
+    setAgentGuiI18nTestLocale("en");
+
+    render(
+      <AgentToolCallCard
+        call={projectAgentToolCall(
+          toolCall({
+            name: "Approval",
+            toolName: "Approval",
+            callType: "tool",
+            status: "Completed",
+            statusKind: "completed",
+            payload: {
+              input: {
+                requestId: "req-2",
+                toolCall: {
+                  kind: "bash",
+                  title: "Run script",
+                  toolName: "Bash",
+                  rawInput: {
+                    command: ["/bin/bash", "-c", "echo hello && ls -la"]
+                  }
+                },
+                options: [
+                  { optionId: "approved", name: "Allow" }
+                ]
+              }
+            }
+          })
+        )}
+      />
+    );
+
+    const toggle = screen.getByRole("button", { expanded: false });
+    fireEvent.click(toggle);
+    await flushCollapsibleRevealFrames();
+
+    expect(toggle).toHaveAttribute("aria-expanded", "true");
+    expect(screen.getByText("echo hello && ls -la")).toBeTruthy();
+  });
+
+  it("expands path approval cards to show file path details", async () => {
+    setAgentGuiI18nTestLocale("en");
+
+    render(
+      <AgentToolCallCard
+        call={projectAgentToolCall(
+          toolCall({
+            name: "Approval",
+            toolName: "Approval",
+            callType: "tool",
+            status: "Completed",
+            statusKind: "completed",
+            payload: {
+              input: {
+                requestId: "req-3",
+                toolCall: {
+                  kind: "read",
+                  title: "Read file",
+                  toolName: "Read",
+                  rawInput: {
+                    file_path: "/workspace/src/index.ts",
+                    startLine: 1,
+                    endLine: 50
+                  }
+                },
+                options: [
+                  { optionId: "approved", name: "Allow" }
+                ]
+              }
+            }
+          })
+        )}
+      />
+    );
+
+    const toggle = screen.getByRole("button", { expanded: false });
+    fireEvent.click(toggle);
+    await flushCollapsibleRevealFrames();
+
+    expect(toggle).toHaveAttribute("aria-expanded", "true");
+    expect(screen.getByText("/workspace/src/index.ts")).toBeTruthy();
+  });
+
 });
 
 async function flushCollapsibleRevealFrames(): Promise<void> {

--- a/packages/agent/gui/shared/agentConversation/components/tool-renderers/AgentApprovalContent.tsx
+++ b/packages/agent/gui/shared/agentConversation/components/tool-renderers/AgentApprovalContent.tsx
@@ -6,8 +6,11 @@ import {
   objectValue,
   stringValue,
   ToolMarkdownBlock,
+  ToolSection,
   type AgentToolRendererProps
 } from "./agentToolContentShared";
+import { getPromptToolDetails } from "../../promptToolDetails";
+import { translate } from "../../../../i18n/index";
 
 export function AgentApprovalContent({
   call,
@@ -15,15 +18,39 @@ export function AgentApprovalContent({
 }: AgentToolRendererProps): JSX.Element | null {
   "use memo";
   const previewCall = approvalPreviewCall(call);
-  if (!previewCall && !call.summary.trim()) {
-    return null;
-  }
   if (previewCall) {
     return <AgentEditContent call={previewCall} onLinkClick={onLinkClick} />;
   }
+  const toolDetails = getPromptToolDetails(call.input ?? null);
+  const summary = call.summary.trim();
+  if (toolDetails.length === 0 && !summary) {
+    return null;
+  }
   return (
     <div className="workspace-agents-status-panel__detail-tool-body">
-      <ToolMarkdownBlock content={call.summary} />
+      {toolDetails.length > 0 ? (
+        <ToolSection title="Details">
+          {toolDetails.map((detail) => (
+            <div
+              key={`${detail.kind}:${detail.value}`}
+              className="workspace-agents-status-panel__detail-approval-detail-row"
+            >
+              <span className="workspace-agents-status-panel__detail-approval-detail-label">
+                {promptToolDetailLabel(detail.kind)}
+              </span>
+              <span className="workspace-agents-status-panel__detail-approval-detail-value">
+                {detail.value}
+              </span>
+              {detail.meta ? (
+                <span className="workspace-agents-status-panel__detail-approval-detail-meta">
+                  {detail.meta}
+                </span>
+              ) : null}
+            </div>
+          ))}
+        </ToolSection>
+      ) : null}
+      {summary ? <ToolMarkdownBlock content={summary} onLinkClick={onLinkClick} /> : null}
     </div>
   );
 }
@@ -78,4 +105,17 @@ function approvalPreviewCall(call: AgentToolCallVM): AgentToolCallVM | null {
 
 function normalizeToolKind(value: string | null): string {
   return (value ?? "").trim().toLowerCase();
+}
+
+function promptToolDetailLabel(kind: "command" | "mcp" | "path" | "query"): string {
+  switch (kind) {
+    case "command":
+      return translate("agentHost.agentTool.details.command");
+    case "mcp":
+      return translate("agentHost.agentTool.details.mcp");
+    case "path":
+      return translate("agentHost.agentTool.details.path");
+    case "query":
+      return translate("agentHost.agentTool.details.query");
+  }
 }


### PR DESCRIPTION
## Summary
- Extend `AgentApprovalContent` to render tool details for command/bash/read/MCP approvals using `getPromptToolDetails()`
- Previously only edit/move approvals showed detail — other types returned null, making the expand/collapse a no-op
- Reuses the same `getPromptToolDetails` logic already used by the interactive approval prompt surface

## Root Cause
`AgentApprovalContent.tsx` only rendered detail for edit/move approvals via `approvalPreviewCall()`. For command/bash/read/etc. approvals, it returned `null`, but `hasAgentToolContent()` returned `true` — the card appeared expandable but showed nothing when clicked.

Closes #418

## Test plan
- [ ] Click a command approval card → should show full command text
- [ ] Click a bash approval with array-form command → should show full command
- [ ] Click a read approval → should show file path
- [ ] Edit/move approvals unchanged

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Approval cards now expand reliably to show the underlying tool details, such as commands, file paths, and other relevant information.
  * Summary text is displayed more consistently, with improved handling of empty or trimmed content.

* **Tests**
  * Added coverage for expanded approval-card behavior, including command and file-path details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->