### PR TITLE
fix(gui): clear composer draft synchronously to prevent queue flash

### DIFF
--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUINodeController.spec.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUINodeController.spec.tsx
@@ -12555,6 +12555,54 @@ describe("useAgentGUINodeController", () => {
     expect(result.current.viewModel.draftContent.images).toEqual([]);
   });
 
+  it("clears the draft synchronously on submit before the server responds", async () => {
+    const exec = vi.fn(
+      () =>
+        new Promise<{
+          accepted: boolean;
+          agentSessionId: string;
+          turnId: string;
+          sessionStatus: string;
+        }>(() => {
+          // Never resolve — we want to check state before the server responds.
+        })
+    );
+    installAgentHostApi({
+      list: vi.fn(async () => snapshotWithSession("session-1")),
+      listSessionTimeline: vi.fn(async () => ({ timelineItems: [] })),
+      subscribeEvents: vi.fn(() => vi.fn()),
+      exec
+    });
+
+    const { result } = renderHook(() =>
+      useAgentGUINodeController({
+        workspaceId: "room-1",
+        currentUserId: "user-1",
+        workspacePath: "/workspace",
+        avoidGroupingEdits: false,
+        data: agentGuiData("session-1"),
+        onDataChange: vi.fn()
+      })
+    );
+
+    await waitFor(() => {
+      expect(result.current.viewModel.activeConversationId).toBe("session-1");
+    });
+
+    act(() => {
+      result.current.actions.updateDraftContent({
+        prompt: "hello world",
+        images: [],
+        files: []
+      });
+      result.current.actions.submitPrompt(promptBlocks("hello world"));
+    });
+
+    // The draft should already be cleared even though exec has not resolved.
+    expect(result.current.viewModel.draftPrompt).toBe("");
+    expect(result.current.viewModel.isSubmitting).toBe(true);
+  });
+
   it("edits a local queued prompt back into the draft", async () => {
     installAgentHostApi({
       list: vi.fn(async () => snapshotWithWaitingSession("session-1")),

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUINodeController.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUINodeController.ts
@@ -6617,6 +6617,26 @@ export function useAgentGUINodeController({
       }
       setLocalIsSubmitting(true);
       setDetailError(null);
+      // Clear the submitted draft synchronously so the composer does not
+      // briefly flash a queued-state UI while isSubmitting is true but the
+      // draft content has not yet been cleared.
+      if (!queuedPromptId) {
+        setDraftBySessionId((current) => {
+          const currentDraft = current[agentSessionId];
+          if (
+            !shouldClearSubmittedDraft({
+              currentDraft,
+              submittedContent: normalizedContent
+            })
+          ) {
+            return current;
+          }
+          return {
+            ...current,
+            [agentSessionId]: emptyAgentComposerDraft()
+          };
+        });
+      }
       patchConversation(agentSessionId, (conversation) => ({
         status: "working",
         sortTimeUnixMs: Math.max(
@@ -6721,23 +6741,6 @@ export function useAgentGUINodeController({
             patchConversation(agentSessionId, {
               status: submittedStatus,
               updatedAtUnixMs: Date.now()
-            });
-          }
-          if (!queuedPromptId) {
-            setDraftBySessionId((current) => {
-              const currentDraft = current[agentSessionId];
-              if (
-                !shouldClearSubmittedDraft({
-                  currentDraft,
-                  submittedContent: normalizedContent
-                })
-              ) {
-                return current;
-              }
-              return {
-                ...current,
-                [agentSessionId]: emptyAgentComposerDraft()
-              };
             });
           }
           if (queuedPromptId) {


### PR DESCRIPTION
## Summary
- When submitting a prompt in a completed conversation, the draft was only cleared after the server responded (inside `.then()` callback)
- This left a render cycle where `isSubmitting=true` and draft still had content, causing `canQueueWhileBusy` to be true and the send button to briefly flash to "queue" mode
- Fix: move the draft clearing to happen synchronously in `executePrompt`, before the async `sendInput` call, so React batches the `isSubmitting=true` and draft-clear in the same render

## Test plan
- [x] 190 controller tests pass (189 existing + 1 new)
- [x] New test: "clears the draft synchronously on submit before the server responds" — uses a never-resolving exec promise to verify draft is empty before server responds
- [ ] Manual: in a completed conversation, send a new message → verify no brief "queue" flash on the send button

Closes #428

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Draft text is now cleared immediately when you submit a prompt, even before the response finishes loading.
  * The app keeps the submission state active until the server responds, preventing the draft from lingering during in-flight requests.

* **Tests**
  * Added coverage for the prompt submission flow to prevent regressions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->