### PR TITLE
fix(agent-gui): remove top offset causing text misalignment after @app mention

### DIFF
--- a/packages/agent/gui/agent-gui/agentGuiNode/agentRichText/AgentMentionNodeView.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/agentRichText/AgentMentionNodeView.tsx
@@ -430,7 +430,7 @@ export function AgentMentionNodeView(props: NodeViewProps): JSX.Element {
         data-agent-mention-kind={mention.kind}
       >
         <span
-          className="group relative top-[3px] inline-flex max-w-[min(100%,var(--agent-mention-max-width,16rem))] cursor-pointer items-center gap-1 overflow-hidden rounded-[4px] border border-transparent bg-transparent px-1 py-0.5 align-baseline text-[13px] font-medium leading-5 text-[var(--accent)] no-underline transition-colors hover:border-transparent hover:bg-[color-mix(in_srgb,currentColor_12%,transparent)]"
+          className="group relative inline-flex max-w-[min(100%,var(--agent-mention-max-width,16rem))] cursor-pointer items-center gap-1 overflow-hidden rounded-[4px] border border-transparent bg-transparent px-1 py-0.5 align-baseline text-[13px] font-medium leading-5 text-[var(--accent)] no-underline transition-colors hover:border-transparent hover:bg-[color-mix(in_srgb,currentColor_12%,transparent)]"
           data-agent-mention-kind={mention.kind}
           data-slot="mention-pill"
         >


### PR DESCRIPTION
## 背景
从 `AgentMentionNodeView.tsx` 中的 workspace-app mention pill 移除 `top-[3px]` 相对偏移。此偏移在不影响内联流基线的情况下移动了 pill 的视觉位置，导致 @app mention 后输入的文本出现在不同的垂直位置。

## 根因
`workspace-app` / `workspace-reference` mention pill 的内部 `<span>` 的 className 中有 `relative top-[3px]`。虽然 `position: relative` 是绝对定位删除按钮所需的，但 `top-[3px]` 偏移导致 pill 渲染位置比实际内联基线低 3px。mention 之后的文本保持在正常基线，产生明显的垂直错位。

## 验证
- 现有 `AgentRichTextEditor.spec.tsx` 测试通过（41/41）
- 手动验证：在编辑器中输入 `@app` mention，确认后续文本与 pill 芯片对齐
- 手动验证：删除按钮（悬停时的 ×）位置正确