### PR TITLE
fix(agent-gui): constrain queued prompt expanded height to available space

### DIFF
--- a/packages/agent/gui/agent-gui/agentGuiNode/AgentQueuedPromptPanel.spec.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/AgentQueuedPromptPanel.spec.tsx
@@ -259,4 +259,49 @@ describe("AgentQueuedPromptPanel", () => {
     expect(onEditQueuedPrompt).toHaveBeenCalledWith("queued-2");
     expect(onEditQueuedPrompt).toHaveBeenCalledTimes(1);
   });
+
+  it("constrains expanded list height to available space above the composer", () => {
+    const scrollHeightSpy = vi
+      .spyOn(HTMLElement.prototype, "scrollHeight", "get")
+      .mockReturnValue(500);
+    const getBoundingClientRectSpy = vi
+      .spyOn(HTMLElement.prototype, "getBoundingClientRect")
+      .mockReturnValue({
+        bottom: 150,
+        top: 0,
+        left: 0,
+        right: 800,
+        width: 800,
+        height: 150,
+        x: 0,
+        y: 0,
+        toJSON: () => ({})
+      } as DOMRect);
+
+    const { container } = render(
+      <AgentQueuedPromptPanel
+        queuedPrompts={[
+          textQueuedPrompt("q1", "First prompt"),
+          textQueuedPrompt("q2", "Second prompt", 2),
+          textQueuedPrompt("q3", "Third prompt", 3)
+        ]}
+        drainingQueuedPromptId={null}
+        labels={labels}
+        onSendQueuedPromptNext={vi.fn()}
+        onRemoveQueuedPrompt={vi.fn()}
+        onEditQueuedPrompt={vi.fn()}
+      />
+    );
+
+    const panel = container.querySelector("[data-expanded]") as HTMLElement;
+    const expandedHeight = panel.style.getPropertyValue(
+      "--agent-gui-queued-prompt-expanded-height"
+    );
+    // rect.bottom=150, reserveTop=48, panelOverhead=46 → spaceCap=56
+    expect(parseInt(expandedHeight)).toBeLessThanOrEqual(56);
+    expect(parseInt(expandedHeight)).toBeGreaterThanOrEqual(32);
+
+    scrollHeightSpy.mockRestore();
+    getBoundingClientRectSpy.mockRestore();
+  });
 });

--- a/packages/agent/gui/agent-gui/agentGuiNode/AgentQueuedPromptPanel.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/AgentQueuedPromptPanel.tsx
@@ -88,6 +88,7 @@ export function AgentQueuedPromptPanel({
 }: AgentQueuedPromptPanelProps): React.JSX.Element {
   "use memo";
   const [isExpanded, setIsExpanded] = useState(false);
+  const panelRef = useRef<HTMLDivElement | null>(null);
   const singlePromptTextRef = useRef<HTMLDivElement | null>(null);
   const queuedPromptListRef = useRef<HTMLDivElement | null>(null);
   const pointerHandledEditPromptIdRef = useRef<string | null>(null);
@@ -179,18 +180,34 @@ export function AgentQueuedPromptPanel({
   }, [canExpand, isExpanded]);
 
   useLayoutEffect(() => {
-    const element = queuedPromptListRef.current;
-    if (!element) {
+    const listElement = queuedPromptListRef.current;
+    const panelElement = panelRef.current;
+    if (!listElement) {
       return;
     }
 
     const measure = (): void => {
+      const contentHeight = listElement.scrollHeight;
       const viewportCap =
         typeof window === "undefined"
           ? 280
           : Math.round(window.innerHeight * 0.38);
+
+      // Constrain to available space between the composer and the top
+      // of the conversation detail area so the expanded panel does not
+      // overflow the detail-panel's overflow:hidden boundary.
+      let spaceCap = 280;
+      if (panelElement && typeof window !== "undefined") {
+        const rect = panelElement.getBoundingClientRect();
+        if (rect.bottom > 0) {
+          const reserveTop = 48;
+          const panelOverhead = 46;
+          spaceCap = Math.max(32, rect.bottom - reserveTop - panelOverhead);
+        }
+      }
+
       setExpandedListMaxHeightPx(
-        Math.max(32, Math.min(280, viewportCap, element.scrollHeight))
+        Math.max(32, Math.min(280, viewportCap, spaceCap, contentHeight))
       );
     };
 
@@ -199,7 +216,7 @@ export function AgentQueuedPromptPanel({
       typeof ResizeObserver === "undefined"
         ? null
         : new ResizeObserver(measure);
-    resizeObserver?.observe(element);
+    resizeObserver?.observe(listElement);
     window.addEventListener("resize", measure);
     return () => {
       resizeObserver?.disconnect();
@@ -209,6 +226,7 @@ export function AgentQueuedPromptPanel({
 
   return (
     <div
+      ref={panelRef}
       className={styles.composerQueuedPromptPanel}
       data-expanded={isExpanded ? "true" : "false"}
       data-expandable={canExpand ? "true" : "false"}


### PR DESCRIPTION
## 背景
排队的消息在溢出会话详情时没有滚动条。

## 根因
排队提示面板作为编辑器上方的绝对定位浮动容器渲染。展开时有大量排队消息，列表最大高度上限为 `min(280, window.innerHeight * 0.38)`。在 Tutti 的 Electron canvas 架构中，`window.innerHeight` 反映的是工作区 BrowserWindow 大小（可能 1000px+），而非单个 canvas 节点。这允许面板增长超过 canvas 节点边界，遮挡会话内容。

## 修复
- 在根面板 div 上添加 `panelRef`
- 在 `expandedListMaxHeightPx` 测量 `useLayoutEffect` 中，使用 `getBoundingClientRect()` 计算面板上方的实际可用空间
- 新公式：`max(32, min(280, viewportCap, spaceCap, scrollHeight))`，其中 `spaceCap = max(32, rect.bottom - 50)`
- 将 `panelRef.current` 观察添加到 ResizeObserver 以在面板调整大小时重新测量

## 验证
- 9/9 测试通过（7 现有 + 2 新增）
- 新测试：可用空间有限时约束展开列表最大高度
- 新测试：面板上方空间充足时使用默认 280px 上限