### PR TITLE
fix(agent-gui): show localized runtime connection lost message instead of raw error

### DIFF
--- a/packages/agent/gui/agent-gui/agentGuiNode/AgentSessionChrome.spec.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/AgentSessionChrome.spec.tsx
@@ -449,6 +449,93 @@ describe("AgentSessionChrome", () => {
       })
     ).toBeNull();
   });
+  it("renders connection-lost recovery chrome with title, description, and retry action", () => {
+    const onRetryActivation = vi.fn();
+
+    render(
+      <AgentSessionChrome
+        chrome={{
+          auth: null,
+          approval: null,
+          recovery: {
+            kind: "connection-lost",
+            message: "Runtime connection lost",
+            description:
+              "The managed runtime connection could not recover quickly. Restart the app to continue.",
+            canRetry: true
+          },
+          rawState: null
+        }}
+        isRespondingApproval={false}
+        onSubmitApprovalOption={vi.fn()}
+        onRetryActivation={onRetryActivation}
+        onContinueInNewConversation={vi.fn()}
+        labels={{
+          approvalRequired: "Approval required",
+          authRequired: "Authentication required",
+          activatingSession: "Connecting session...",
+          retryActivation: "Retry",
+          continueInNewConversation: "Continue in new session"
+        }}
+      />
+    );
+
+    // Title and description should be visible
+    expect(screen.getByText("Runtime connection lost")).toBeTruthy();
+    expect(
+      screen.getByText(
+        "The managed runtime connection could not recover quickly. Restart the app to continue."
+      )
+    ).toBeTruthy();
+
+    // Retry button should be present
+    const retryButton = screen.getByRole("button", { name: "Retry" });
+    expect(retryButton).toBeTruthy();
+
+    // The recovery section should use warning styling (not danger)
+    const recoverySection = screen.getByText("Runtime connection lost").closest("section");
+    expect(recoverySection?.className).toContain("agent-gui-chrome__card--warning");
+
+    // Should have alert role for accessibility
+    expect(recoverySection).toHaveAttribute("role", "alert");
+
+    // Clicking retry should call the handler
+    fireEvent.click(retryButton);
+    expect(onRetryActivation).toHaveBeenCalledTimes(1);
+  });
+
+  it("hides retry action for connection-lost recovery when canRetry is false", () => {
+    render(
+      <AgentSessionChrome
+        chrome={{
+          auth: null,
+          approval: null,
+          recovery: {
+            kind: "connection-lost",
+            message: "Runtime connection lost",
+            description: "The runtime could not recover.",
+            canRetry: false
+          },
+          rawState: null
+        }}
+        isRespondingApproval={false}
+        onSubmitApprovalOption={vi.fn()}
+        onRetryActivation={vi.fn()}
+        onContinueInNewConversation={vi.fn()}
+        labels={{
+          approvalRequired: "Approval required",
+          authRequired: "Authentication required",
+          activatingSession: "Connecting session...",
+          retryActivation: "Retry",
+          continueInNewConversation: "Continue in new session"
+        }}
+      />
+    );
+
+    expect(screen.getByText("Runtime connection lost")).toBeTruthy();
+    expect(screen.queryByRole("button", { name: "Retry" })).toBeNull();
+  });
+
 });
 
 function chromeState(): AgentGUISessionChrome {

--- a/packages/agent/gui/agent-gui/agentGuiNode/AgentSessionChrome.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/AgentSessionChrome.tsx
@@ -202,8 +202,10 @@ export function AgentSessionChrome({
       ? labels.activatingSession
       : (visibleRecovery?.message ?? "");
   const recoveryHasInlineAction =
-    visibleRecovery?.kind === "failed" &&
-    (visibleRecovery.followupAction === "continue-in-new-conversation" ||
+    (visibleRecovery?.kind === "failed" &&
+      (visibleRecovery.followupAction === "continue-in-new-conversation" ||
+        visibleRecovery.canRetry !== false)) ||
+    (visibleRecovery?.kind === "connection-lost" &&
       visibleRecovery.canRetry !== false);
   const activatingMessage = splitTrailingEllipsis(recoveryMessage);
   const measureExpandableCards = useCallback((): void => {
@@ -398,9 +400,9 @@ export function AgentSessionChrome({
       {visibleRecovery ? (
         <section
           ref={recoveryCardRef}
-          role={visibleRecovery.kind === "failed" ? "alert" : undefined}
+          role={visibleRecovery.kind === "failed" || visibleRecovery.kind === "connection-lost" ? "alert" : undefined}
           aria-live={
-            visibleRecovery.kind === "failed" ? "assertive" : undefined
+            visibleRecovery.kind === "failed" || visibleRecovery.kind === "connection-lost" ? "assertive" : undefined
           }
           data-expandable={expandableCards.has("recovery") ? "true" : "false"}
           data-expanded={
@@ -416,9 +418,11 @@ export function AgentSessionChrome({
               ? styles.chromeCardDanger
               : visibleRecovery.kind === "warning"
                 ? styles.chromeCardDanger
-                : visibleRecovery.kind === "activating"
-                  ? styles.chromeCardConnecting
-                  : styles.chromeCardMuted
+                : visibleRecovery.kind === "connection-lost"
+                  ? styles.chromeCardWarning
+                  : visibleRecovery.kind === "activating"
+                    ? styles.chromeCardConnecting
+                    : styles.chromeCardMuted
           )}
           onClick={() => toggleExpandedCard("recovery")}
           onKeyDown={handleExpandableCardKeyDown("recovery")}
@@ -451,6 +455,17 @@ export function AgentSessionChrome({
                     </span>
                     {activatingMessage.ellipsis ? <LoadingEllipsis /> : null}
                   </>
+                ) : visibleRecovery.kind === "connection-lost" ? (
+                  <>
+                    <span className={styles.chromeNoticeTitle}>
+                      {recoveryMessage}
+                    </span>
+                    {visibleRecovery.description ? (
+                      <span className={styles.chromeNoticeDescription}>
+                        {visibleRecovery.description}
+                      </span>
+                    ) : null}
+                  </>
                 ) : (
                   recoveryMessage
                 )}
@@ -482,7 +497,8 @@ export function AgentSessionChrome({
                 >
                   {labels.continueInNewConversation}
                 </Button>
-              ) : visibleRecovery.kind === "failed" &&
+              ) : (visibleRecovery.kind === "failed" ||
+                  visibleRecovery.kind === "connection-lost") &&
                 visibleRecovery.canRetry !== false ? (
                 <Button
                   type="button"

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUINodeController.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUINodeController.ts
@@ -754,6 +754,13 @@ function isSessionNotFoundErrorCode(
   return code === AGENT_SESSION_NOT_FOUND_ERROR;
 }
 
+const CONNECTION_ERROR_PATTERN =
+  /\b(connection|websocket|socket|network|econnrefused|econnreset|disconnected|timeout|timed out|hang up|hangs up|epipe|host unreachable|net::err)\b/i;
+
+function isConnectionRelatedError(message: string): boolean {
+  return CONNECTION_ERROR_PATTERN.test(message);
+}
+
 const WORKSPACE_AGENT_SESSION_NOT_READY_REASON =
   "workspace_agent_session_not_found";
 
@@ -9113,6 +9120,10 @@ export function useAgentGUINodeController({
     const recoveryIsNonRetryable =
       isNonRetryableResumeErrorCode(activationErrorCode) ||
       activeConversationResumeUnavailable;
+    const isConnectionError =
+      !isAuthError &&
+      normalizedError !== "" &&
+      isConnectionRelatedError(normalizedError);
     return {
       auth: hasProviderSessionNotFoundError
         ? null
@@ -9129,7 +9140,14 @@ export function useAgentGUINodeController({
               // i18n-check-ignore: Legacy recovery fallback copy; localized presentation should move to view labels.
               message: "Reconnecting to the live agent session…"
             }
-          : !isAuthError && recoveryMessage
+          : isConnectionError
+            ? {
+                kind: "connection-lost",
+                message: translate("agentHost.runtimeConnectionLostTitle"),
+                description: translate("agentHost.runtimeConnectionLostSummary"),
+                canRetry: true
+              }
+            : !isAuthError && recoveryMessage
             ? {
                 kind: "failed",
                 message: recoveryMessage,

--- a/packages/agent/gui/agent-gui/agentGuiNode/model/agentGuiNodeTypes.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/model/agentGuiNodeTypes.ts
@@ -24,8 +24,9 @@ export interface AgentGUISessionChrome {
   } | null;
   approval: AgentGUIApprovalRequest | null;
   recovery: {
-    kind: "activating" | "failed" | "warning";
+    kind: "activating" | "failed" | "warning" | "connection-lost";
     message: string;
+    description?: string;
     canRetry?: boolean;
     followupAction?: "continue-in-new-conversation";
   } | null;


### PR DESCRIPTION
## Summary

When an agent triggers a Tutti restart, the session chrome showed a raw WebSocket/network error message instead of a clean notification. This PR wires up the existing localized i18n strings to display a friendly "runtime connection lost" message with a retry button.

## Verification

- 13/13 tests pass (11 existing + 2 new)
- New test: renders connection-lost recovery chrome with title, description, and retry action
- New test: hides retry action when `canRetry` is false
- Pre-commit hooks pass

## Checklist

- [x] I kept the change focused on one concern.
- [ ] I updated documentation when behavior, setup, or contributor workflow changed.
- [ ] I updated all README/CONTRIBUTING language variants when changing their English source.
- [x] I ran the lowest meaningful local checks for the changed surface.
- [x] My commits are signed off with DCO when required: `git commit -s`.

Closes #419