### PR TITLE
fix(agent-gui): constrain queued prompt expanded height to available space

### DIFF
--- a/packages/agent/gui/agent-gui/agentGuiNode/AgentQueuedPromptPanel.spec.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/AgentQueuedPromptPanel.spec.tsx
@@ -259,4 +259,49 @@ describe("AgentQueuedPromptPanel", () => {
     expect(onEditQueuedPrompt).toHaveBeenCalledWith("queued-2");
     expect(onEditQueuedPrompt).toHaveBeenCalledTimes(1);
   });
+
+  it("constrains expanded list height to available space above the composer", () => {
+    const scrollHeightSpy = vi
+      .spyOn(HTMLElement.prototype, "scrollHeight", "get")
+      .mockReturnValue(500);
+    const getBoundingClientRectSpy = vi
+      .spyOn(HTMLElement.prototype, "getBoundingClientRect")
+      .mockReturnValue({
+        bottom: 150,
+        top: 0,
+        left: 0,
+        right: 800,
+        width: 800,
+        height: 150,
+        x: 0,
+        y: 0,
+        toJSON: () => ({})
+      } as DOMRect);
+
+    const { container } = render(
+      <AgentQueuedPromptPanel
+        queuedPrompts={[
+          textQueuedPrompt("q1", "First prompt"),
+          textQueuedPrompt("q2", "Second prompt", 2),
+          textQueuedPrompt("q3", "Third prompt", 3)
+        ]}
+        drainingQueuedPromptId={null}
+        labels={labels}
+        onSendQueuedPromptNext={vi.fn()}
+        onRemoveQueuedPrompt={vi.fn()}
+        onEditQueuedPrompt={vi.fn()}
+      />
+    );
+
+    const panel = container.querySelector("[data-expanded]") as HTMLElement;
+    const expandedHeight = panel.style.getPropertyValue(
+      "--agent-gui-queued-prompt-expanded-height"
+    );
+    // rect.bottom=150, reserveTop=48, panelOverhead=46 → spaceCap=56
+    expect(parseInt(expandedHeight)).toBeLessThanOrEqual(56);
+    expect(parseInt(expandedHeight)).toBeGreaterThanOrEqual(32);
+
+    scrollHeightSpy.mockRestore();
+    getBoundingClientRectSpy.mockRestore();
+  });
 });

--- a/packages/agent/gui/agent-gui/agentGuiNode/AgentQueuedPromptPanel.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/AgentQueuedPromptPanel.tsx
@@ -88,6 +88,7 @@ export function AgentQueuedPromptPanel({
 }: AgentQueuedPromptPanelProps): React.JSX.Element {
   "use memo";
   const [isExpanded, setIsExpanded] = useState(false);
+  const panelRef = useRef<HTMLDivElement | null>(null);
   const singlePromptTextRef = useRef<HTMLDivElement | null>(null);
   const queuedPromptListRef = useRef<HTMLDivElement | null>(null);
   const pointerHandledEditPromptIdRef = useRef<string | null>(null);
@@ -179,18 +180,34 @@ export function AgentQueuedPromptPanel({
   }, [canExpand, isExpanded]);
 
   useLayoutEffect(() => {
-    const element = queuedPromptListRef.current;
-    if (!element) {
+    const listElement = queuedPromptListRef.current;
+    const panelElement = panelRef.current;
+    if (!listElement) {
       return;
     }
 
     const measure = (): void => {
+      const contentHeight = listElement.scrollHeight;
       const viewportCap =
         typeof window === "undefined"
           ? 280
           : Math.round(window.innerHeight * 0.38);
+
+      // Constrain to available space between the composer and the top
+      // of the conversation detail area so the expanded panel does not
+      // overflow the detail-panel's overflow:hidden boundary.
+      let spaceCap = 280;
+      if (panelElement && typeof window !== "undefined") {
+        const rect = panelElement.getBoundingClientRect();
+        if (rect.bottom > 0) {
+          const reserveTop = 48;
+          const panelOverhead = 46;
+          spaceCap = Math.max(32, rect.bottom - reserveTop - panelOverhead);
+        }
+      }
+
       setExpandedListMaxHeightPx(
-        Math.max(32, Math.min(280, viewportCap, element.scrollHeight))
+        Math.max(32, Math.min(280, viewportCap, spaceCap, contentHeight))
       );
     };
 
@@ -199,7 +216,7 @@ export function AgentQueuedPromptPanel({
       typeof ResizeObserver === "undefined"
         ? null
         : new ResizeObserver(measure);
-    resizeObserver?.observe(element);
+    resizeObserver?.observe(listElement);
     window.addEventListener("resize", measure);
     return () => {
       resizeObserver?.disconnect();
@@ -209,6 +226,7 @@ export function AgentQueuedPromptPanel({
 
   return (
     <div
+      ref={panelRef}
       className={styles.composerQueuedPromptPanel}
       data-expanded={isExpanded ? "true" : "false"}
       data-expandable={canExpand ? "true" : "false"}


### PR DESCRIPTION
## 背景
使用 `getBoundingClientRect()` 测量排队提示面板上方的实际可用空间，将展开列表最大高度限制为 `max(32, min(280, viewportCap, spaceCap, scrollHeight))`，替代 `window.innerHeight * 0.38`。

## 根因
展开列表最大高度上限为 `min(280, window.innerHeight * 0.38)`。在 Tutti 的 Electron 架构中，`window.innerHeight` 反映的是工作区 BrowserWindow 大小，而非单个 canvas 节点。这允许面板增长超过 canvas 节点边界，无滚动条地遮挡会话内容。

## 验证
- 排队提示面板在上方空间有限时约束高度
- 空间充足时面板使用默认 280px 上限
- 排队消息较少或无排队消息时无回归