### PR TITLE
fix(agent-gui): add right-click copy context menu to markdown images

### DIFF
--- a/packages/agent/gui/shared/AgentMessageMarkdown.spec.tsx
+++ b/packages/agent/gui/shared/AgentMessageMarkdown.spec.tsx
@@ -1381,6 +1381,60 @@ describe("AgentMessageMarkdown", () => {
   });
 });
 
+  it("wraps non-zoomed markdown images with a copy-image context menu", () => {
+    // When enableImageZoom is false (default), markdown images should still
+    // have a ConversationImageContextMenu wrapper for right-click copy.
+    render(
+      <AgentMessageMarkdown
+        content={"![alt text](https://example.com/image.png)"}
+      />
+    );
+
+    // The context menu trigger wraps the image
+    const trigger = document.querySelector(
+      '[data-slot="context-menu-trigger"]'
+    );
+    expect(trigger).not.toBeNull();
+    // The image should be inside the trigger
+    const img = screen.getByRole("img", { name: "alt text" });
+    expect(trigger?.contains(img)).toBe(true);
+  });
+
+  it("copies image from non-zoomed markdown image context menu", async () => {
+    const fetchImage = vi.fn().mockResolvedValue({
+      blob: () =>
+        Promise.resolve(new Blob(["image"], { type: "image/png" }))
+    });
+    const write = vi.fn().mockResolvedValue(undefined);
+    vi.stubGlobal("fetch", fetchImage);
+    Object.defineProperty(navigator, "clipboard", {
+      configurable: true,
+      value: { write }
+    });
+    class TestClipboardItem {
+      constructor(items: unknown) {
+        // stored for verification
+      }
+    }
+    vi.stubGlobal("ClipboardItem", TestClipboardItem);
+
+    render(
+      <AgentMessageMarkdown
+        content={"![test image](https://example.com/pic.png)"}
+      />
+    );
+
+    const img = screen.getByRole("img", { name: "test image" });
+    fireEvent.contextMenu(img);
+
+    const copyItem = await screen.findByText("Copy image");
+    fireEvent.pointerDown(copyItem, { button: 0 });
+
+    await waitFor(() => {
+      expect(fetchImage).toHaveBeenCalledWith("https://example.com/pic.png");
+    });
+  });
+
 describe("splitStreamingMarkdownBlocks", () => {
   it("splits stable markdown blocks without splitting fenced code", () => {
     expect(

--- a/packages/agent/gui/shared/AgentMessageMarkdown.tsx
+++ b/packages/agent/gui/shared/AgentMessageMarkdown.tsx
@@ -18,6 +18,7 @@ import {
 } from "react";
 import { useTranslation } from "../i18n/index";
 import { ZoomableImage } from "../app/renderer/components/ZoomableImage";
+import { ConversationImageContextMenu } from "./agentConversation/components/ConversationImageContextMenu";
 import { cn } from "../app/renderer/lib/utils";
 import ReactMarkdown, { defaultUrlTransform } from "react-markdown";
 import rehypeSanitize, {
@@ -1126,13 +1127,15 @@ function MarkdownMedia({
 
     if (!shouldEnableZoom) {
       return (
-        <img
-          {...props}
-          src={resolvedSrc}
-          alt={alt}
-          title={title}
-          className={className}
-        />
+        <ConversationImageContextMenu src={resolvedSrc}>
+          <img
+            {...props}
+            src={resolvedSrc}
+            alt={alt}
+            title={title}
+            className={className}
+          />
+        </ConversationImageContextMenu>
       );
     }
 
@@ -1169,16 +1172,18 @@ function MarkdownMedia({
 
     if (!shouldEnableZoom) {
       return (
-        <img
-          {...props}
-          src={state.src}
-          alt={alt}
-          title={title}
-          className={cn(
-            "mt-2 block max-h-[360px] max-w-full rounded-[8px] bg-[var(--transparency-block)] object-contain",
-            className
-          )}
-        />
+        <ConversationImageContextMenu src={state.src}>
+          <img
+            {...props}
+            src={state.src}
+            alt={alt}
+            title={title}
+            className={cn(
+              "mt-2 block max-h-[360px] max-w-full rounded-[8px] bg-[var(--transparency-block)] object-contain",
+              className
+            )}
+          />
+        </ConversationImageContextMenu>
       );
     }
 


### PR DESCRIPTION
## 背景
对话媒体和文档内容应支持右键复制。

## 根因
`ConversationImageContextMenu` 组件存在并提供"复制图片"右键支持，但仅应用于：
- 消息块中的附件图片（`AgentMessageBlock.tsx`）
- 可缩放图片（`ZoomableImage.tsx`）

通过 `MarkdownMedia` 在 `AgentMessageMarkdown.tsx` 中渲染的 **Markdown 内联图片**在缩放禁用（默认）或图片在链接内时，裸 `<img>` 标签**没有上下文菜单**。

## 修复
用 `ConversationImageContextMenu` 包装 `MarkdownMedia` 中的两个裸 `<img>` 渲染路径：
1. 非工作区图片且 `!shouldEnableZoom` — 包装 `<ConversationImageContextMenu src={resolvedSrc}>`
2. 工作区图片且 `!shouldEnableZoom` — 包装 `<ConversationImageContextMenu src={state.src}>`

确保右键点击任何 markdown 图片都显示"复制图片"，无论缩放状态。

## 验证
- 55/55 测试通过（53 现有 + 2 新增）
- 新测试：非缩放 markdown 图片包装复制图片上下文菜单
- 新测试：从非缩放 markdown 图片上下文菜单复制图片