### PR TITLE
fix(agent-gui): clear composer images synchronously on submit

### DIFF
--- a/packages/agent/gui/agent-gui/agentGuiNode/AgentComposer.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/AgentComposer.tsx
@@ -820,6 +820,7 @@ export function AgentComposer({
   const [paletteDraftPrompt, setPaletteDraftPrompt] = useState(
     goalDraftObjective ?? draftPrompt
   );
+  const [displayDraftImages, setDisplayDraftImages] = useState(draftImages);
   const [fileMentionSuggestion, setFileMentionSuggestion] =
     useState<AgentFileMentionSuggestionState | null>(null);
   const [isSelectedProjectMissing, setIsSelectedProjectMissing] =
@@ -1151,6 +1152,7 @@ export function AgentComposer({
 
   useEffect(() => {
     draftImagesRef.current = draftImages;
+    setDisplayDraftImages(draftImages);
   }, [draftImages]);
 
   useEffect(() => {
@@ -1462,6 +1464,7 @@ export function AgentComposer({
       draftImagesRef.current = [];
       draftFilesRef.current = [];
       setPaletteDraftPrompt("");
+      setDisplayDraftImages([]);
       onDraftContentChange(emptyAgentComposerDraft());
     }
   );
@@ -2818,12 +2821,12 @@ export function AgentComposer({
                 }
                 style={promptInputAreaStyle}
               >
-                {draftImages.length > 0 ? (
+                {displayDraftImages.length > 0 ? (
                   <div
                     className="mb-2 flex w-full max-w-full flex-wrap items-start gap-2"
                     data-testid="agent-gui-composer-image-drafts"
                   >
-                    {draftImages.map((image) => (
+                    {displayDraftImages.map((image) => (
                       <AgentComposerDraftImagePreview
                         key={image.id}
                         image={image}


### PR DESCRIPTION
## Summary
- Images in the composer were rendered from `draftContent` prop (controller state), which only updates after the parent re-renders
- This left a visible gap where images remained in the composer after the message was sent
- Add a local `displayDraftImages` state that mirrors the prop but is cleared immediately on submit, matching the existing pattern used for `paletteDraftPrompt` text clearing

Closes #430

## Test plan
- [x] Existing `AgentComposer.spec.tsx` tests pass (60/60)
- [ ] Manual: send a message with images and verify images disappear immediately from composer

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the draft image preview in the composer so the displayed images reliably match the current draft content.
  * Fixed preview instability during submission by ensuring the preview is cleared/updated predictably while moving from the draft to the current prompt.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->