### PR TITLE
fix(agent-gui): strip markdown emphasis from message center plain text

### DIFF
--- a/packages/agent/gui/agent-message-center/WorkspaceAgentMessageCenterCard.tsx
+++ b/packages/agent/gui/agent-message-center/WorkspaceAgentMessageCenterCard.tsx
@@ -25,6 +25,7 @@ import {
 } from "@tutti-os/ui-system";
 import { useTranslation } from "../i18n/index";
 import { normalizeAgentTitleText } from "../shared/utils/agentTitleText";
+import { stripMarkdownEmphasis } from "../shared/agentConversation/lib/stripMarkdownEmphasis";
 import { AgentInteractivePromptSurface } from "../shared/agentConversation/components/AgentInteractivePromptSurface";
 import { AgentMessageMarkdown } from "../shared/AgentMessageMarkdown";
 import { AgentVerticalScrollArea } from "../shared/AgentVerticalScrollArea";
@@ -91,7 +92,9 @@ export const WorkspaceAgentMessageCenterCard = memo(
     "use memo";
     const { t } = useTranslation();
     const prompt = item.pendingPrompt;
-    const displayTitle = normalizeAgentTitleText(item.title);
+    const displayTitle = stripMarkdownEmphasis(
+      normalizeAgentTitleText(item.title)
+    );
     const summary = messageCenterVisibleSummary(item);
     const displayStatus = statusClass(item);
     const statusTone = messageCenterStatusTone(item);
@@ -529,10 +532,10 @@ function MessageCenterStackSummary({
 function messageCenterStackPreviewText(
   item: WorkspaceAgentMessageCenterItem
 ): string {
-  return (
+  return stripMarkdownEmphasis(
     item.digest.primary.summary.trim() ||
-    item.lastAgentMessageSummary.trim() ||
-    normalizeAgentTitleText(item.title)
+      item.lastAgentMessageSummary.trim() ||
+      normalizeAgentTitleText(item.title)
   );
 }
 
@@ -734,7 +737,7 @@ function MessageCenterSummary({
         />
       ) : summary ? (
         <div className="whitespace-pre-wrap [overflow-wrap:anywhere]">
-          {summary}
+          {stripMarkdownEmphasis(summary)}
         </div>
       ) : (
         emptyLabel

--- a/packages/agent/gui/shared/agentConversation/lib/stripMarkdownEmphasis.ts
+++ b/packages/agent/gui/shared/agentConversation/lib/stripMarkdownEmphasis.ts
@@ -1,0 +1,34 @@
+/**
+ * Removes Markdown emphasis markers (`**`, `*`, `__`, `_`) from prose text so
+ * that text displayed in plain-text contexts reads without stray asterisks.
+ * Inline code spans (`` `code` ``) and fenced code blocks are preserved —
+ * their content is meaningful and stripping markers inside would corrupt it.
+ */
+export function stripMarkdownEmphasis(text: string): string {
+  // Split into alternating [prose, code, prose, code, …] segments.
+  // The capturing group keeps code spans/blocks in the result array.
+  const parts = text.split(/(```[\s\S]*?```|`[^`]+`)/g);
+  return parts
+    .map((part, i) => {
+      // Odd indices are code spans / fenced blocks from the capturing group.
+      if (i % 2 === 1) return part;
+      return stripEmphasisDelimiters(part);
+    })
+    .join("");
+}
+
+function stripEmphasisDelimiters(prose: string): string {
+  return (
+    prose
+      // ***bold italic*** — strip before ** to avoid partial matches.
+      .replace(/\*\*\*(.+?)\*\*\*/gs, "$1")
+      // **bold**
+      .replace(/\*\*(.+?)\*\*/gs, "$1")
+      // *italic* — require non-* on both sides, no newlines inside.
+      .replace(/(^|[^*])\*([^*\n]+?)\*(?!\*)/g, "$1$2")
+      // __bold__
+      .replace(/__(.+?)__/gs, "$1")
+      // _italic_ — require word boundary on both sides, no newlines inside.
+      .replace(/(^|[^_\w])_([^_\n]+?)_(?![\w_])/g, "$1$2")
+  );
+}


### PR DESCRIPTION
## 背景 / Summary

修复消息中心的标题、栈预览和后备摘要渲染原始 Markdown 强调标记（`**`、`*`、`__`、`_`）为字面星号的问题。

## 改动 / Changes

- 新增 `stripMarkdownEmphasis()` 工具函数，移除强调分隔符同时保留内联代码段和围栏代码块
- 在消息中心卡片的所有纯文本渲染路径中应用该函数（标题、栈预览、后备摘要）

## 验证 / Validation

- [x] All 103 existing message center tests pass
- [ ] Manual: verify messages with **bold** or *italic* markers render cleanly without stray asterisks