### PR TITLE
fix(app-center): add UI and icon style constraints to factory app generation

### DIFF
--- a/services/tuttid/service/workspace/app_factory_prompts.go
+++ b/services/tuttid/service/workspace/app_factory_prompts.go
@@ -76,6 +76,9 @@ func writeAppFactoryMentionContext(workspace workspacebiz.Summary, physicalRoot 
 			"Default new apps to a Node server; use Python only for existing Python projects or explicit Python requests.",
 			"If the app needs local agent or local LLM execution, Codex, Claude, or app-owned MCP/tooling, follow the tutti-agent-workspace-app skill and use @tutti-os/agent-acp-kit instead of TUTTI_CLI agent/codex/session polling.",
 			"Agent-enabled app main flows must detect and offer available Claude Code and Codex provider options, then choose one available provider by default.",
+			"Use an SVG icon with a clean, simple design on a transparent background; prefer 64x64 viewport.",
+			"Support both light and dark themes using CSS prefers-color-scheme; do not hardcode light-only colors.",
+			"Follow Tutti visual conventions: rounded corners, subtle borders, and system font stack.",
 		},
 		Metadata: appFactoryMentionMetadata{
 			AppID:       strings.TrimSpace(job.AppID),


### PR DESCRIPTION
## Summary
- Factory-generated apps lacked consistent UI and icon style guidance
- Add three new constraints to the `context.json` passed to the generating agent:
  - SVG icon with clean design on transparent background (64x64 preferred)
  - Light/dark theme support via CSS `prefers-color-scheme`
  - Tutti visual conventions (rounded corners, subtle borders, system font stack)

Closes #412

## Test plan
- [x] Existing test verifies constraints are non-empty and contain the daemon internals warning
- [ ] Manual: generate a factory app and verify it follows Tutti visual style guidelines

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added clearer visual guidance for generated workspace apps, including cleaner SVG icon styling, better light/dark theme support, and alignment with Tutti’s visual style.
  * Updated app generation prompts to encourage more consistent UI appearance across themes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->