### PR TITLE
fix(agent-gui): add right-click copy context menu to markdown images

### DIFF
--- a/packages/agent/gui/shared/AgentMessageMarkdown.tsx
+++ b/packages/agent/gui/shared/AgentMessageMarkdown.tsx
@@ -1126,10 +1126,19 @@ function MarkdownMedia({
     }
 
     if (!shouldEnableZoom) {
+      if (typeof resolvedSrc !== "string") {
+        return (
+          <img
+            {...props}
+            src={resolvedSrc}
+            alt={alt}
+            title={title}
+            className={className}
+          />
+        );
+      }
       return (
-        <ConversationImageContextMenu
-          src={typeof resolvedSrc === "string" ? resolvedSrc : undefined}
-        >
+        <ConversationImageContextMenu src={resolvedSrc}>
           <img
             {...props}
             src={resolvedSrc}

--- a/packages/agent/gui/shared/AgentMessageMarkdown.tsx
+++ b/packages/agent/gui/shared/AgentMessageMarkdown.tsx
@@ -18,6 +18,7 @@ import {
 } from "react";
 import { useTranslation } from "../i18n/index";
 import { ZoomableImage } from "../app/renderer/components/ZoomableImage";
+import { ConversationImageContextMenu } from "./agentConversation/components/ConversationImageContextMenu";
 import { cn } from "../app/renderer/lib/utils";
 import ReactMarkdown, { defaultUrlTransform } from "react-markdown";
 import rehypeSanitize, {
@@ -1126,13 +1127,17 @@ function MarkdownMedia({
 
     if (!shouldEnableZoom) {
       return (
-        <img
-          {...props}
-          src={resolvedSrc}
-          alt={alt}
-          title={title}
-          className={className}
-        />
+        <ConversationImageContextMenu
+          src={typeof resolvedSrc === "string" ? resolvedSrc : undefined}
+        >
+          <img
+            {...props}
+            src={resolvedSrc}
+            alt={alt}
+            title={title}
+            className={className}
+          />
+        </ConversationImageContextMenu>
       );
     }
 
@@ -1169,16 +1174,18 @@ function MarkdownMedia({
 
     if (!shouldEnableZoom) {
       return (
-        <img
-          {...props}
-          src={state.src}
-          alt={alt}
-          title={title}
-          className={cn(
-            "mt-2 block max-h-[360px] max-w-full rounded-[8px] bg-[var(--transparency-block)] object-contain",
-            className
-          )}
-        />
+        <ConversationImageContextMenu src={state.src}>
+          <img
+            {...props}
+            src={state.src}
+            alt={alt}
+            title={title}
+            className={cn(
+              "mt-2 block max-h-[360px] max-w-full rounded-[8px] bg-[var(--transparency-block)] object-contain",
+              className
+            )}
+          />
+        </ConversationImageContextMenu>
       );
     }
 

--- a/packages/agent/gui/shared/agentConversation/components/ConversationImageContextMenu.tsx
+++ b/packages/agent/gui/shared/agentConversation/components/ConversationImageContextMenu.tsx
@@ -22,7 +22,7 @@ export function ConversationImageContextMenu({
   asChild = false,
   contentStyle
 }: {
-  src: string;
+  src: string | undefined;
   children: ReactNode;
   /**
    * Attach the right-click listener directly to the child element instead of a
@@ -40,7 +40,7 @@ export function ConversationImageContextMenu({
   const copyStartedRef = useRef(false);
   const [menuResetKey, setMenuResetKey] = useState(0);
   const copyAndClose = useCallback(() => {
-    if (copyStartedRef.current) {
+    if (!src || copyStartedRef.current) {
       return;
     }
     copyStartedRef.current = true;


### PR DESCRIPTION
## Summary
- Images rendered in agent markdown content without zoom enabled were plain `<img>` elements without the `ConversationImageContextMenu` wrapper
- Right-click copy only worked on zoomable images (which had the context menu), not on regular inline images
- Wrap all non-zoom image paths with `ConversationImageContextMenu` so right-click copy works consistently

Closes #420

## Test plan
- [x] All 53 existing `AgentMessageMarkdown.spec.tsx` tests pass
- [ ] Manual: right-click an inline image in an agent reply and verify "Copy image" appears in the context menu

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Conversation markdown images now include a context menu whenever zoom is unavailable, including both workspace-loaded and ready cached images.

* **Bug Fixes**
  * The image copy action is now more reliable: it safely handles cases where the image source is missing and prevents duplicate or re-entrant copy attempts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->