### PR TITLE
fix(browser-node): inject CSS to fix text cursor behind images in AI Docs

### DIFF
--- a/packages/browser/workbench-node/src/electron-main/electronMain.test.ts
+++ b/packages/browser/workbench-node/src/electron-main/electronMain.test.ts
@@ -907,6 +907,53 @@ test("registerBrowserNodeElectronMain opens devtools from a native context menu 
   assert.equal(contents.openDevToolsCalls, 1);
 });
 
+test("injects cursor fix CSS when Browser Node guests register and navigate", async () => {
+  const contents = new MockBrowserGuestWebContents(11);
+  const manager = createBrowserGuestManager({
+    emit: () => undefined,
+    openExternal: () => undefined,
+    resolveWebContents: (id) => (id === contents.id ? contents : null)
+  });
+
+  await manager.prepareSession({
+    nodeId: "browser-css",
+    profileId: null,
+    sessionMode: "shared"
+  });
+  await manager.activate({
+    nodeId: "browser-css",
+    profileId: null,
+    sessionMode: "shared",
+    url: "example.com"
+  });
+  await manager.registerGuest({
+    nodeId: "browser-css",
+    profileId: null,
+    sessionMode: "shared",
+    webContentsId: 11
+  });
+
+  assert.ok(contents.injectedCssChunks.length >= 1, "CSS should be injected on registration");
+  assert.ok(
+    contents.injectedCssChunks[0]!.includes("contenteditable"),
+    "Injected CSS should target contentEditable elements"
+  );
+  assert.ok(
+    contents.injectedCssChunks[0]!.includes("ProseMirror"),
+    "Injected CSS should target ProseMirror editors"
+  );
+
+  const injectCountBeforeNavigation = contents.injectedCssChunks.length;
+  contents.emit("did-navigate", {}, "https://example.com/page2", 200, "OK");
+
+  assert.ok(
+    contents.injectedCssChunks.length > injectCountBeforeNavigation,
+    "CSS should be re-injected after navigation"
+  );
+
+  await manager.close({ nodeId: "browser-css" });
+});
+
 test("syncs the preferred color scheme to Browser Node guests", async () => {
   const contents = new MockBrowserGuestWebContents(10);
   let currentScheme: "dark" | "light" = "dark";
@@ -1295,6 +1342,12 @@ class MockBrowserGuestWebContents
 
   openDevToolsCalls = 0;
   openDevToolsOptions: unknown[] = [];
+  injectedCssChunks: string[] = [];
+
+  async insertCSS(css: string): Promise<string> {
+    this.injectedCssChunks.push(css);
+    return "inject-key";
+  }
 
   openDevTools(options?: unknown): void {
     this.openDevToolsCalls += 1;

--- a/packages/browser/workbench-node/src/electron-main/guestManager.ts
+++ b/packages/browser/workbench-node/src/electron-main/guestManager.ts
@@ -22,6 +22,34 @@ const browserPreviewMaxWidth = 260;
 const browserPreviewMaxHeight = 170;
 const abortedNavigationErrorCode = -3;
 
+const guestCursorFixCss = [
+  '[contenteditable=""], [contenteditable="true"], .ProseMirror {',
+  "  position: relative;",
+  "  z-index: 0;",
+  "}",
+  '[contenteditable=""] img, [contenteditable="true"] img, .ProseMirror img {',
+  "  position: relative;",
+  "  z-index: 0;",
+  "}"
+].join("\n");
+
+async function injectGuestCursorFixCss(
+  contents: BrowserGuestWebContents,
+  logger?: BrowserGuestManagerInput["logger"]
+): Promise<void> {
+  if (!contents.insertCSS || contents.isDestroyed()) {
+    return;
+  }
+
+  try {
+    await contents.insertCSS(guestCursorFixCss);
+  } catch (error) {
+    logger?.warn?.("Browser Node failed to inject cursor fix CSS", {
+      error: error instanceof Error ? error.message : String(error)
+    });
+  }
+}
+
 interface BrowserGuestSession {
   appliedColorScheme: BrowserPreferredColorScheme | null;
   contents: BrowserGuestWebContents | null;
@@ -365,6 +393,7 @@ export function createBrowserGuestManager({
       const statusCode = typeof args[2] === "number" ? args[2] : undefined;
       const statusText = typeof args[3] === "string" ? args[3] : undefined;
       publishState(session);
+      void injectGuestCursorFixCss(contents, logger);
       if (!isHttpErrorStatusCode(statusCode)) {
         return;
       }
@@ -768,6 +797,7 @@ export function createBrowserGuestManager({
         preferredColorScheme
       );
       await loadDesiredUrl(session);
+      await injectGuestCursorFixCss(contents, logger);
     },
     reload(input) {
       const contents = sessions.get(input.nodeId)?.contents;

--- a/packages/browser/workbench-node/src/electron-main/types.ts
+++ b/packages/browser/workbench-node/src/electron-main/types.ts
@@ -82,6 +82,7 @@ export interface BrowserGuestWebContents {
   getTitle(): string;
   getURL(): string;
   getUserAgent?(): string;
+  insertCSS?(css: string): Promise<string>;
   goBack(): void;
   goForward(): void;
   isDestroyed(): boolean;


### PR DESCRIPTION
## Summary

Fix the AI Docs text cursor rendering behind inserted images. Images with `position: relative` in `contentEditable` editors create compositor layers that occlude the native text caret. This PR injects CSS via Electron's `insertCSS` API to establish a correct stacking context.

## Verification

- 78/78 browser-node tests pass (`pnpm --filter @tutti-os/browser-node test`)
- New test verifies CSS injection on registration and re-injection after navigation
- Pre-commit hooks pass

## Checklist

- [x] I kept the change focused on one concern.
- [ ] I updated documentation when behavior, setup, or contributor workflow changed.
- [ ] I updated all README/CONTRIBUTING language variants when changing their English source.
- [x] I ran the lowest meaningful local checks for the changed surface.
- [x] My commits are signed off with DCO when required: `git commit -s`.

Fixes #416