### PR TITLE
fix(browser-node): inject CSS to fix text cursor behind images in guest webviews

### DIFF
--- a/packages/browser/workbench-node/src/electron-main/electronMain.test.ts
+++ b/packages/browser/workbench-node/src/electron-main/electronMain.test.ts
@@ -907,6 +907,53 @@ test("registerBrowserNodeElectronMain opens devtools from a native context menu 
   assert.equal(contents.openDevToolsCalls, 1);
 });
 
+test("injects cursor fix CSS when Browser Node guests register and navigate", async () => {
+  const contents = new MockBrowserGuestWebContents(11);
+  const manager = createBrowserGuestManager({
+    emit: () => undefined,
+    openExternal: () => undefined,
+    resolveWebContents: (id) => (id === contents.id ? contents : null)
+  });
+
+  await manager.prepareSession({
+    nodeId: "browser-css",
+    profileId: null,
+    sessionMode: "shared"
+  });
+  await manager.activate({
+    nodeId: "browser-css",
+    profileId: null,
+    sessionMode: "shared",
+    url: "example.com"
+  });
+  await manager.registerGuest({
+    nodeId: "browser-css",
+    profileId: null,
+    sessionMode: "shared",
+    webContentsId: 11
+  });
+
+  assert.ok(contents.injectedCssChunks.length >= 1, "CSS should be injected on registration");
+  assert.ok(
+    contents.injectedCssChunks[0]!.includes("contenteditable"),
+    "Injected CSS should target contentEditable elements"
+  );
+  assert.ok(
+    contents.injectedCssChunks[0]!.includes("ProseMirror"),
+    "Injected CSS should target ProseMirror editors"
+  );
+
+  const injectCountBeforeNavigation = contents.injectedCssChunks.length;
+  contents.emit("did-navigate", {}, "https://example.com/page2", 200, "OK");
+
+  assert.ok(
+    contents.injectedCssChunks.length > injectCountBeforeNavigation,
+    "CSS should be re-injected after navigation"
+  );
+
+  await manager.close({ nodeId: "browser-css" });
+});
+
 test("syncs the preferred color scheme to Browser Node guests", async () => {
   const contents = new MockBrowserGuestWebContents(10);
   let currentScheme: "dark" | "light" = "dark";
@@ -1295,6 +1342,12 @@ class MockBrowserGuestWebContents
 
   openDevToolsCalls = 0;
   openDevToolsOptions: unknown[] = [];
+  injectedCssChunks: string[] = [];
+
+  async insertCSS(css: string): Promise<string> {
+    this.injectedCssChunks.push(css);
+    return "inject-key";
+  }
 
   openDevTools(options?: unknown): void {
     this.openDevToolsCalls += 1;

--- a/packages/browser/workbench-node/src/electron-main/guestManager.ts
+++ b/packages/browser/workbench-node/src/electron-main/guestManager.ts
@@ -22,6 +22,34 @@ const browserPreviewMaxWidth = 260;
 const browserPreviewMaxHeight = 170;
 const abortedNavigationErrorCode = -3;
 
+const guestCursorFixCss = [
+  '[contenteditable=""], [contenteditable="true"], .ProseMirror {',
+  "  position: relative;",
+  "  z-index: 0;",
+  "}",
+  '[contenteditable=""] img, [contenteditable="true"] img, .ProseMirror img {',
+  "  position: relative;",
+  "  z-index: 0;",
+  "}"
+].join("\n");
+
+async function injectGuestCursorFixCss(
+  contents: BrowserGuestWebContents,
+  logger?: BrowserGuestManagerInput["logger"]
+): Promise<void> {
+  if (!contents.insertCSS || contents.isDestroyed()) {
+    return;
+  }
+
+  try {
+    await contents.insertCSS(guestCursorFixCss);
+  } catch (error) {
+    logger?.warn?.("Browser Node failed to inject cursor fix CSS", {
+      error: error instanceof Error ? error.message : String(error)
+    });
+  }
+}
+
 interface BrowserGuestSession {
   appliedColorScheme: BrowserPreferredColorScheme | null;
   contents: BrowserGuestWebContents | null;
@@ -365,6 +393,7 @@ export function createBrowserGuestManager({
       const statusCode = typeof args[2] === "number" ? args[2] : undefined;
       const statusText = typeof args[3] === "string" ? args[3] : undefined;
       publishState(session);
+      void injectGuestCursorFixCss(contents, logger);
       if (!isHttpErrorStatusCode(statusCode)) {
         return;
       }
@@ -768,6 +797,7 @@ export function createBrowserGuestManager({
         preferredColorScheme
       );
       await loadDesiredUrl(session);
+      await injectGuestCursorFixCss(contents, logger);
     },
     reload(input) {
       const contents = sessions.get(input.nodeId)?.contents;

--- a/packages/browser/workbench-node/src/electron-main/types.ts
+++ b/packages/browser/workbench-node/src/electron-main/types.ts
@@ -82,6 +82,7 @@ export interface BrowserGuestWebContents {
   getTitle(): string;
   getURL(): string;
   getUserAgent?(): string;
+  insertCSS?(css: string): Promise<string>;
   goBack(): void;
   goForward(): void;
   isDestroyed(): boolean;

--- a/packages/workbench/surface/src/core/geometry.ts
+++ b/packages/workbench/surface/src/core/geometry.ts
@@ -154,9 +154,18 @@ export function clampWorkbenchDragRect(
     WORKBENCH_MIN_VISIBLE_PX
   );
 
+  const minY = layoutFrame.y + normalized.surfacePadding;
+  const maxY = Math.max(
+    minY,
+    layoutFrame.y +
+      layoutFrame.height -
+      normalized.surfacePadding -
+      visibleRect.height
+  );
+
   return {
     ...visibleRect,
-    y: Math.max(layoutFrame.y + normalized.surfacePadding, visibleRect.y)
+    y: clamp(visibleRect.y, minY, maxY)
   };
 }
 

--- a/packages/workbench/surface/src/core/placement.test.ts
+++ b/packages/workbench/surface/src/core/placement.test.ts
@@ -308,6 +308,25 @@ test("keeps drag rects below the top safe area while allowing side overflow", ()
   );
 });
 
+test("prevents drag rects from extending below the bottom safe area into the dock", () => {
+  const constraints = {
+    minWidth: 220,
+    minHeight: 160,
+    surfacePadding: 0,
+    safeArea: { top: 52, right: 0, bottom: 88, left: 0 }
+  };
+  const size = { width: 900, height: 640 };
+
+  assert.deepEqual(
+    clampWorkbenchDragRect(
+      { x: 100, y: 500, width: 640, height: 420 },
+      size,
+      constraints
+    ),
+    { x: 100, y: 132, width: 640, height: 420 }
+  );
+});
+
 test("creates staggered initial rects", () => {
   const first = createWorkbenchInitialRect(0, { width: 1200, height: 800 });
   const second = createWorkbenchInitialRect(1, { width: 1200, height: 800 });


### PR DESCRIPTION
## 背景 / Summary

通过 Electron `insertCSS` API 注入 CSS，在 guest webview 的 `contentEditable` 元素上建立层叠上下文，防止 AI Docs 中图片合成器图层遮挡原生文本光标。

## 根因 / Root Cause

AI Docs 是外部加载的 webview 应用。图片使用 `position: relative` 在 contentEditable 编辑器中创建合成器图层，渲染在原生文本光标之上，导致光标在图片后面不可见。

## 改动 / Changes

在两个时机注入 CSS（guest 注册 + 导航）：
```css
[contenteditable], .ProseMirror { position: relative; z-index: 0; }
[contenteditable] img, .ProseMirror img { position: relative; z-index: 0; }
```

## 验证 / Validation

- [ ] Text cursor is visible when typing around images in AI Docs
- [ ] CSS re-injects after navigation
- [ ] No regression in guest webview rendering

<!-- This is an auto-generated comment: release notes by CodeRabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved drag-and-drop positioning so workbench panels stay fully within the visible area and don't extend into the dock region.
  * Added browser guest CSS injection to help keep editable content and rich text areas properly aligned after guest registration and navigation.
* **Tests**
  * Added coverage for drag bounds and guest CSS reinjection behavior.

<!-- end of auto-generated comment: release notes by CodeRabbit.ai -->