### PR TITLE
fix(terminal): ensure UTF-8 locale for CJK character support

### DIFF
--- a/services/tuttid/service/workspace/terminal_helpers.go
+++ b/services/tuttid/service/workspace/terminal_helpers.go
@@ -77,15 +77,19 @@ func resolveTerminalShellInvocation(shell string) []string {
 }
 
 func terminalProcessEnv(cwd string) []string {
-	// Inject the macOS system proxy so commands run in the workspace terminal —
-	// notably agent `login` flows — reach the upstream API through the same proxy
-	// as spawned agents, instead of connecting directly and hitting `403 Request
-	// not allowed` from a restricted region.
-	return runtimecmd.InjectSystemProxyEnv(append(os.Environ(),
+	env := append(os.Environ(),
 		"PWD="+cwd,
 		"TERM=xterm-256color",
 		"COLORTERM=truecolor",
-	))
+	)
+	// Ensure a UTF-8 locale so CJK and other multi-byte characters render
+	// correctly.  Daemon processes launched outside a login shell (e.g. via
+	// Finder/Spotlight) may not inherit the user's locale settings.
+	lang := os.Getenv("LANG")
+	if lang == "" || lang == "C" || lang == "POSIX" {
+		env = append(env, "LANG=en_US.UTF-8")
+	}
+	return runtimecmd.InjectSystemProxyEnv(env)
 }
 
 func normalizeTerminalDimension(value *int, fallback int) int {

--- a/services/tuttid/service/workspace/terminal_test.go
+++ b/services/tuttid/service/workspace/terminal_test.go
@@ -161,6 +161,43 @@ func TestTerminalServiceCreatesShellWithXtermEnvironment(t *testing.T) {
 	t.Fatalf("snapshot data = %q, want xterm terminal environment", snapshot.Data)
 }
 
+func TestTerminalServiceEnsuresUTF8LocaleWhenLangUnset(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Windows terminal support needs ConPTY-specific implementation")
+	}
+
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("SHELL", "/bin/sh")
+	t.Setenv("LANG", "")
+
+	service := &TerminalService{}
+	initialInput := "printf 'lang-env:%s\\n' \"$LANG\"\r"
+
+	session, err := service.Create(context.Background(), "ws-1", CreateTerminalInput{
+		InitialInput: &initialInput,
+	})
+	if err != nil {
+		t.Fatalf("Create() error = %v", err)
+	}
+	t.Cleanup(func() {
+		_, _ = service.Terminate(context.Background(), "ws-1", session.ID)
+	})
+
+	var snapshot TerminalSnapshot
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		snapshot, err = service.Snapshot(context.Background(), "ws-1", session.ID)
+		if err != nil {
+			t.Fatalf("Snapshot() error = %v", err)
+		}
+		if strings.Contains(snapshot.Data, "lang-env:en_US.UTF-8") {
+			return
+		}
+		time.Sleep(25 * time.Millisecond)
+	}
+	t.Fatalf("snapshot data = %q, want LANG=en_US.UTF-8 in terminal environment", snapshot.Data)
+}
+
 func TestTerminalServiceCloseGuardRequiresConfirmationForForegroundProcess(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("Windows terminal support needs ConPTY-specific implementation")


### PR DESCRIPTION
## Summary
- Terminal sessions inherit the daemon's environment, which may not include `LANG` when Tutti is launched via Finder/Spotlight on macOS
- Without a UTF-8 locale, multi-byte characters (Chinese, Japanese, Korean, etc.) render as `????` in the terminal
- Set `LANG=en_US.UTF-8` when the inherited locale is empty, `C`, or `POSIX`

Fixes #124

## Test plan
- [x] Existing terminal tests pass (xterm env test pattern reused)
- [x] Added test verifying `LANG=en_US.UTF-8` is set in terminal when daemon `LANG` is unset
- [ ] Manual: launch Tutti from Finder, type Chinese characters in terminal, verify they render correctly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Terminal sessions now ensure a UTF-8 locale is set when the system locale is missing or set to a non-UTF-8 default, helping avoid encoding issues in the terminal.
  * Environment variables for terminal sessions are now assembled more consistently, improving reliability of shell startup behavior.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->