### PR TITLE
fix(agent-gui): add bottom padding to composer dock for Dock clearance

### DIFF
--- a/packages/agent/gui/app/renderer/agentactivity.css
+++ b/packages/agent/gui/app/renderer/agentactivity.css
@@ -5369,6 +5369,7 @@ button.agent-gui-node__conversation-section-toggle:hover
   );
   margin-top: auto;
   padding-top: 0;
+  padding-bottom: 8px;
   background: transparent;
   border-top: 0;
 }


### PR DESCRIPTION
## Summary
- Add `padding-bottom: 8px` to `.agent-gui-node__bottom-dock` to create clearance between the composer content and the window's bottom edge
- Ensures the permission switch remains clickable even when the window overlaps the macOS Dock

## Root Cause
The `.agent-gui-node__bottom-dock` had `position: sticky; bottom: 0` with no `padding-bottom`. The permission switch in the composer footer sat flush against the window edge, where the macOS Dock intercepts pointer events.

Closes #426

## Test plan
- [ ] Permission switch is clickable when window is near/under the macOS Dock
- [ ] No visual regression in composer layout

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Adjusted bottom spacing in the agent activity view for a cleaner layout and improved visual balance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->