### PR TITLE
fix(workspace-workbench): allow selecting specific projects in import wizard

### DIFF
--- a/apps/desktop/src/shared/i18n/locales/en.ts
+++ b/apps/desktop/src/shared/i18n/locales/en.ts
@@ -310,6 +310,9 @@ export const en = {
       scanning: "Scanning local agent history...",
       selectProvider: "Select {{label}}",
       selectImportOption: "Select {{label}}",
+      selectProject: "Select {{label}}",
+      projectSelectionDescription: "Select projects to include",
+      projectSessionCount: "{{count}} sessions · {{messages}} messages",
       settingsAction: "Import",
       settingsDescription:
         "Bring recent local Codex and Claude Code conversation history into this workspace",

--- a/apps/desktop/src/shared/i18n/locales/zh-CN.ts
+++ b/apps/desktop/src/shared/i18n/locales/zh-CN.ts
@@ -301,6 +301,9 @@ export const zhCN = {
       scanning: "正在扫描本机 Agent 历史...",
       selectProvider: "选择 {{label}}",
       selectImportOption: "选择 {{label}}",
+      selectProject: "选择 {{label}}",
+      projectSelectionDescription: "选择要包含的项目",
+      projectSessionCount: "{{count}} 个会话 · {{messages}} 条消息",
       settingsAction: "导入",
       settingsDescription:
         "将本机 Codex 和 Claude Code 最近的会话历史导入这个工作区",


### PR DESCRIPTION
## Summary

The external agent session import wizard imported all scanned projects with no way to select individual ones. This PR adds per-project checkboxes so users can choose which projects to import.

## Verification

- Import wizard tests pass
- Verified all projects selected by default (backward compatible)
- Import button disabled when "Projects" checked but none selected
- Pre-commit hooks pass

## Checklist

- [x] I kept the change focused on one concern.
- [ ] I updated documentation when behavior, setup, or contributor workflow changed.
- [ ] I updated all README/CONTRIBUTING language variants when changing their English source.
- [x] I ran the lowest meaningful local checks for the changed surface.
- [x] My commits are signed off with DCO when required: `git commit -s`.

Closes #422