### PR TITLE
fix(agent-gui): strip markdown formatting from copied assistant replies

### DIFF
--- a/packages/agent/gui/shared/agentConversation/lib/markdownToPlainText.spec.ts
+++ b/packages/agent/gui/shared/agentConversation/lib/markdownToPlainText.spec.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect } from "vitest";
+
+import { markdownToPlainText } from "./markdownToPlainText";
+
+describe("markdownToPlainText", () => {
+  it("leaves plain text unchanged", () => {
+    expect(markdownToPlainText("Hello world")).toBe("Hello world");
+  });
+
+  it("strips bold markers", () => {
+    expect(markdownToPlainText("This is **bold** text")).toBe(
+      "This is bold text"
+    );
+  });
+
+  it("strips italic markers", () => {
+    expect(markdownToPlainText("This is *italic* text")).toBe(
+      "This is italic text"
+    );
+  });
+
+  it("strips bold underscore markers", () => {
+    expect(markdownToPlainText("This is __bold__ text")).toBe(
+      "This is bold text"
+    );
+  });
+
+  it("strips inline code backticks", () => {
+    expect(markdownToPlainText("Run `npm install` now")).toBe(
+      "Run npm install now"
+    );
+  });
+
+  it("strips strikethrough markers", () => {
+    expect(markdownToPlainText("This is ~~old~~ text")).toBe(
+      "This is old text"
+    );
+  });
+
+  it("converts links to just the link text", () => {
+    expect(markdownToPlainText("See [the docs](https://example.com)")).toBe(
+      "See the docs"
+    );
+  });
+
+  it("converts images to just the alt text", () => {
+    expect(markdownToPlainText("![logo](https://example.com/logo.png)")).toBe(
+      "logo"
+    );
+  });
+
+  it("strips heading markers", () => {
+    expect(markdownToPlainText("## Section Title\nSome body")).toBe(
+      "Section Title\nSome body"
+    );
+  });
+
+  it("removes code fence markers but keeps content", () => {
+    const input = "Here is code:\n```ts\nconst x = 1;\n```\nDone.";
+    const result = markdownToPlainText(input);
+    expect(result).toBe("Here is code:\nconst x = 1;\nDone.");
+  });
+
+  it("handles multiple formatting markers in one string", () => {
+    expect(
+      markdownToPlainText(
+        "**Bold** and *italic* and `code` and ~~strike~~ and [link](url)"
+      )
+    ).toBe("Bold and italic and code and strike and link");
+  });
+
+  it("does not modify snake_case identifiers", () => {
+    expect(markdownToPlainText("use my_variable_name here")).toBe(
+      "use my_variable_name here"
+    );
+  });
+
+  it("handles nested bold inside italic gracefully", () => {
+    expect(markdownToPlainText("**bold** remaining")).toBe("bold remaining");
+  });
+});

--- a/packages/agent/gui/shared/agentConversation/lib/markdownToPlainText.ts
+++ b/packages/agent/gui/shared/agentConversation/lib/markdownToPlainText.ts
@@ -1,0 +1,38 @@
+/**
+ * Strips common markdown formatting markers from text so that copying
+ * an agent reply produces clean plain text without stray `**`, `*`,
+ * backticks, or similar markup characters.
+ */
+export function markdownToPlainText(text: string): string {
+  let result = text;
+
+  // Fenced code blocks: remove the fence markers, keep the content
+  result = result.replace(/```[^\n]*\n?/g, "");
+  result = result.replace(/```/g, "");
+
+  // Images: ![alt](url) → alt
+  result = result.replace(/!\[([^\]]*)\]\([^)]*\)/g, "$1");
+
+  // Links: [text](url) → text
+  result = result.replace(/\[([^\]]+)\]\([^)]*\)/g, "$1");
+
+  // Bold: **text** → text
+  result = result.replace(/\*\*(.+?)\*\*/g, "$1");
+
+  // Bold with underscores: __text__ → text
+  result = result.replace(/__(.+?)__/g, "$1");
+
+  // Inline code: `text` → text
+  result = result.replace(/`([^`]+)`/g, "$1");
+
+  // Italic: *text* → text
+  result = result.replace(/\*([^*\n]+?)\*/g, "$1");
+
+  // Strikethrough: ~~text~~ → text
+  result = result.replace(/~~(.+?)~~/g, "$1");
+
+  // Heading markers at line start: "# " or "## " etc.
+  result = result.replace(/^#{1,6}\s+/gm, "");
+
+  return result;
+}

--- a/packages/agent/gui/shared/agentConversation/projection/agentConversationProjection.spec.ts
+++ b/packages/agent/gui/shared/agentConversation/projection/agentConversationProjection.spec.ts
@@ -881,6 +881,56 @@ describe("projectAgentConversationVM", () => {
     expect(assistantRow?.messages[0]?.copyText).toBeUndefined();
   });
 
+  it("strips markdown formatting from assistant copy text", () => {
+    const conversation = projectAgentConversationVM(
+      detailViewModel({
+        session: {
+          ...detailViewModel().session,
+          status: "completed"
+        },
+        turns: [
+          {
+            id: "turn-1",
+            userMessage: { id: "user-1", body: "Explain" },
+            userMessages: [{ id: "user-1", body: "Explain" }],
+            agentMessages: [
+              {
+                id: "assistant-1",
+                body: "Here is **bold** and *italic* and `code` text."
+              }
+            ],
+            toolCalls: [],
+            toolCallCount: 0,
+            hasFailedToolCall: false,
+            agentItems: [
+              {
+                kind: "message",
+                message: {
+                  id: "assistant-1",
+                  body: "Here is **bold** and *italic* and `code` text."
+                }
+              }
+            ]
+          }
+        ],
+        showProcessingIndicator: false
+      })
+    );
+
+    const assistantRow = conversation.rows.find(
+      (
+        row
+      ): row is Extract<
+        (typeof conversation.rows)[number],
+        { kind: "message" }
+      > => row.kind === "message" && row.speaker === "assistant"
+    );
+
+    expect(assistantRow?.messages[0]?.copyText).toBe(
+      "Here is bold and italic and code text."
+    );
+  });
+
   it("projects user prompt images before text and keeps the session workspace id", () => {
     const conversation = projectAgentConversationVM(
       detailViewModel({

--- a/packages/agent/gui/shared/agentConversation/projection/agentConversationProjection.ts
+++ b/packages/agent/gui/shared/agentConversation/projection/agentConversationProjection.ts
@@ -13,6 +13,7 @@ import type {
 } from "../contracts/agentMessageRowVM";
 import type { AgentToolCallVM } from "../contracts/agentToolCallVM";
 import type { AgentTranscriptRowVM } from "../contracts/agentTranscriptRowVM";
+import { markdownToPlainText } from "../lib/markdownToPlainText";
 import {
   buildAgentTurnSequenceItems,
   computeAgentToolGroups
@@ -438,7 +439,7 @@ function projectMessageCopyText(
         row.speaker === "user"
           ? copyTextForUserMessage(message)
           : assistantCopyTargetKeys.has(messageCopyTargetKey(row, message))
-            ? message.body
+            ? markdownToPlainText(message.body)
             : null;
       if ((message.copyText ?? null) === copyText) {
         return message;


### PR DESCRIPTION
## Summary
- Add `markdownToPlainText` utility that strips common markdown markers (`**`, `*`, `` ` ``, `~~`, `[]()`, headings, code fences) from text
- Apply it to the assistant copy text projection so clipboard output is clean plain text instead of raw markdown
- Add unit tests for the utility and an integration test in the projection spec

Closes #432

## Test plan
- [x] `markdownToPlainText.spec.ts` — 13 unit tests covering bold, italic, code, strikethrough, links, images, headings, code fences, snake_case safety
- [x] `agentConversationProjection.spec.ts` — all 20 existing tests pass + new integration test verifying markdown stripping in the copy projection
- [x] Pre-commit lint and boundary checks pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved assistant message copy to paste clean plain text by stripping common Markdown formatting (bold, italics, strikethrough, headings, inline code, and code fence markers).
  * Preserves visible content, including link text and image alt text.
* **Bug Fixes**
  * Prevents copied assistant messages from including leftover Markdown characters.
* **Tests**
  * Added automated coverage for Markdown-to-plain-text conversion and verified the assistant transcript copy behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->