### PR TITLE
fix(agent-gui): remove vertical offset from mention pills

### DIFF
--- a/packages/agent/gui/agent-gui/agentGuiNode/agentRichText/AgentMentionNodeView.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/agentRichText/AgentMentionNodeView.tsx
@@ -430,7 +430,7 @@ export function AgentMentionNodeView(props: NodeViewProps): JSX.Element {
         data-agent-mention-kind={mention.kind}
       >
         <span
-          className="group relative top-[3px] inline-flex max-w-[min(100%,var(--agent-mention-max-width,16rem))] cursor-pointer items-center gap-1 overflow-hidden rounded-[4px] border border-transparent bg-transparent px-1 py-0.5 align-baseline text-[13px] font-medium leading-5 text-[var(--accent)] no-underline transition-colors hover:border-transparent hover:bg-[color-mix(in_srgb,currentColor_12%,transparent)]"
+          className="group relative inline-flex max-w-[min(100%,var(--agent-mention-max-width,16rem))] cursor-pointer items-center gap-1 overflow-hidden rounded-[4px] border border-transparent bg-transparent px-1 py-0.5 align-baseline text-[13px] font-medium leading-5 text-[var(--accent)] no-underline transition-colors hover:border-transparent hover:bg-[color-mix(in_srgb,currentColor_12%,transparent)]"
           data-agent-mention-kind={mention.kind}
           data-slot="mention-pill"
         >

--- a/packages/ui/rich-text/src/extensions/workspaceReference.ts
+++ b/packages/ui/rich-text/src/extensions/workspaceReference.ts
@@ -64,7 +64,7 @@ export const WorkspaceReference = Node.create({
         "data-slot": "mention-pill",
         title: presentation.fullPath,
         class: [
-          "group relative top-[3px] inline-flex max-w-full cursor-default items-center gap-1.5 overflow-hidden rounded-[4px] border border-transparent bg-transparent px-1.5 py-0.5 align-baseline text-[13px] font-medium leading-5 no-underline transition-colors hover:border-transparent hover:bg-[color-mix(in_srgb,currentColor_12%,transparent)]",
+          "group relative inline-flex max-w-full cursor-default items-center gap-1.5 overflow-hidden rounded-[4px] border border-transparent bg-transparent px-1.5 py-0.5 align-baseline text-[13px] font-medium leading-5 no-underline transition-colors hover:border-transparent hover:bg-[color-mix(in_srgb,currentColor_12%,transparent)]",
           referenceColorClassName
         ].join(" ")
       }),

--- a/packages/ui/system/src/components/mention-pill/mention-pill.tsx
+++ b/packages/ui/system/src/components/mention-pill/mention-pill.tsx
@@ -82,7 +82,7 @@ function MentionPill({
   return (
     <span
       className={cn(
-        "group relative top-[3px] inline-flex max-w-[min(100%,var(--agent-mention-max-width,16rem))] cursor-default items-center overflow-hidden rounded-[4px] border border-transparent bg-transparent py-0.5 align-baseline text-[13px] font-medium leading-5 no-underline transition-colors hover:border-transparent hover:bg-[color-mix(in_srgb,currentColor_12%,transparent)]",
+        "group relative inline-flex max-w-[min(100%,var(--agent-mention-max-width,16rem))] cursor-default items-center overflow-hidden rounded-[4px] border border-transparent bg-transparent py-0.5 align-baseline text-[13px] font-medium leading-5 no-underline transition-colors hover:border-transparent hover:bg-[color-mix(in_srgb,currentColor_12%,transparent)]",
         isFile ? "gap-1.5 px-1.5" : "gap-1 px-1",
         className
       )}


### PR DESCRIPTION
## Summary
- Mention pills (workspace-app, file, session, issue) had a `top-[3px]` CSS offset that pushed them below the text baseline
- This caused text entered after an @app mention to appear vertically misaligned in the composer
- Removed the offset from all three mention pill variants so they rely on `align-baseline` for proper vertical positioning

Closes #435

## Test plan
- [x] Pre-commit lint and boundary checks pass
- [x] `AgentGUINode.spec.tsx` — all 172 tests pass
- [x] Verified `top-[3px]` is removed from all 3 files: `AgentMentionNodeView.tsx`, `mention-pill.tsx`, `workspaceReference.ts`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Refined mention-pill and workspace reference visual styling for consistent inline alignment and spacing.
* **Bug Fixes**
  * Removed a small vertical offset so workspace app/reference mentions render more consistently with surrounding text, maintaining the existing hover, layout, and typography behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->