### PR TITLE
fix(agent-gui): strip markdown from message center titles

### DIFF
--- a/packages/agent/gui/shared/agentConversation/lib/markdownToPlainText.ts
+++ b/packages/agent/gui/shared/agentConversation/lib/markdownToPlainText.ts
@@ -1,0 +1,38 @@
+/**
+ * Strips common markdown formatting markers from text so that copying
+ * an agent reply produces clean plain text without stray `**`, `*`,
+ * backticks, or similar markup characters.
+ */
+export function markdownToPlainText(text: string): string {
+  let result = text;
+
+  // Fenced code blocks: remove the fence markers, keep the content
+  result = result.replace(/```[^\n]*\n?/g, "");
+  result = result.replace(/```/g, "");
+
+  // Images: ![alt](url) → alt
+  result = result.replace(/!\[([^\]]*)\]\([^)]*\)/g, "$1");
+
+  // Links: [text](url) → text
+  result = result.replace(/\[([^\]]+)\]\([^)]*\)/g, "$1");
+
+  // Bold: **text** → text
+  result = result.replace(/\*\*(.+?)\*\*/g, "$1");
+
+  // Bold with underscores: __text__ → text
+  result = result.replace(/__(.+?)__/g, "$1");
+
+  // Inline code: `text` → text
+  result = result.replace(/`([^`]+)`/g, "$1");
+
+  // Italic: *text* → text
+  result = result.replace(/\*([^*\n]+?)\*/g, "$1");
+
+  // Strikethrough: ~~text~~ → text
+  result = result.replace(/~~(.+?)~~/g, "$1");
+
+  // Heading markers at line start: "# " or "## " etc.
+  result = result.replace(/^#{1,6}\s+/gm, "");
+
+  return result;
+}

--- a/packages/agent/gui/shared/utils/agentTitleText.spec.ts
+++ b/packages/agent/gui/shared/utils/agentTitleText.spec.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect } from "vitest";
+
+import { normalizeAgentTitleText } from "./agentTitleText";
+
+describe("normalizeAgentTitleText", () => {
+  it("strips bold markdown markers", () => {
+    expect(normalizeAgentTitleText("**Important** task")).toBe(
+      "Important task"
+    );
+  });
+
+  it("strips italic markdown markers", () => {
+    expect(normalizeAgentTitleText("Fix *urgent* bug")).toBe("Fix urgent bug");
+  });
+
+  it("strips inline code markers", () => {
+    expect(normalizeAgentTitleText("Run `npm test`")).toBe("Run npm test");
+  });
+
+  it("strips markdown links", () => {
+    expect(normalizeAgentTitleText("See [docs](https://example.com)")).toBe(
+      "See docs"
+    );
+  });
+
+  it("collapses whitespace", () => {
+    expect(normalizeAgentTitleText("Multiple    spaces\n\nhere")).toBe(
+      "Multiple spaces here"
+    );
+  });
+
+  it("returns empty string for null or undefined", () => {
+    expect(normalizeAgentTitleText(null)).toBe("");
+    expect(normalizeAgentTitleText(undefined)).toBe("");
+  });
+
+  it("leaves plain text unchanged", () => {
+    expect(normalizeAgentTitleText("Simple title")).toBe("Simple title");
+  });
+});

--- a/packages/agent/gui/shared/utils/agentTitleText.ts
+++ b/packages/agent/gui/shared/utils/agentTitleText.ts
@@ -1,5 +1,4 @@
-const markdownLinkPattern = /\[((?:\\.|[^\]\\])*)\]\(([^)\s]+)\)/g;
-const markdownLabelEscapePattern = /\\([\\[\]()])/g;
+import { markdownToPlainText } from "../agentConversation/lib/markdownToPlainText";
 
 export function normalizeAgentTitleText(
   value: string | null | undefined
@@ -8,12 +7,5 @@ export function normalizeAgentTitleText(
   if (!trimmed) {
     return "";
   }
-  const normalized = trimmed.replace(markdownLinkPattern, (_, label: string) =>
-    unescapeMarkdownLabel(label)
-  );
-  return normalized.replace(/\s+/g, " ").trim();
-}
-
-function unescapeMarkdownLabel(label: string): string {
-  return label.replace(markdownLabelEscapePattern, "$1");
+  return markdownToPlainText(trimmed).replace(/\s+/g, " ").trim();
 }


### PR DESCRIPTION
## Summary
- `normalizeAgentTitleText` only stripped markdown links `[text](url)` but left `**bold**`, `*italic*`, `` `code` ``, and other inline markers intact
- This caused stray double asterisks to appear in Message Center card titles when agent messages contained bold markdown
- Now uses `markdownToPlainText` utility for comprehensive stripping of all common inline markdown markers

Closes #423

## Test plan
- [x] `agentTitleText.spec.ts` — 7 unit tests covering bold, italic, code, links, whitespace, null/undefined, plain text
- [x] `WorkspaceAgentMessageCenterPanel.spec.tsx` — all 103 existing tests pass
- [x] Pre-commit lint and boundary checks pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved text cleanup for agent titles and conversation content by converting markdown into readable plain text.
  * Preserves link and image text while removing formatting markers like bold, italics, code, and strikethrough.

* **Bug Fixes**
  * Agent titles now normalize spacing more consistently, trimming extra whitespace and collapsing repeated spaces.
  * Added coverage to ensure empty, null, and plain-text cases behave as expected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->