### PR TITLE
fix(workbench): constrain dock plate height to frame insets

### DIFF
--- a/packages/workbench/surface/src/styles/workbench.css
+++ b/packages/workbench/surface/src/styles/workbench.css
@@ -663,7 +663,10 @@
   width: auto;
   height: var(--desktop-dock-frame-size, auto);
   max-width: none;
-  max-height: calc(100vh - 48px);
+  max-height: calc(
+    100vh - var(--workbench-left-dock-top-inset) -
+      var(--workbench-left-dock-bottom-inset)
+  );
   padding: var(--desktop-dock-plate-padding-inline-start)
     var(--desktop-dock-plate-padding-inline-end)
     var(--desktop-dock-plate-padding-inline-start)


### PR DESCRIPTION
## Summary
- The left dock plate used a hardcoded `calc(100vh - 48px)` for `max-height`, which did not account for the actual top (54px) and bottom (24px) insets defined by `--workbench-left-dock-top-inset` and `--workbench-left-dock-bottom-inset`.
- When the app window was dragged to maximum size, the plate overflowed the available space, pushing dock icons outside the visible area.
- Replaced the hardcoded value with the existing CSS variables, matching the inner `.desktop-dock` element's `max-height` calculation (line 704).

Closes #415

## Test plan
- [ ] Open the app and drag the window to maximum size
- [ ] Verify dock icons remain within the visible area
- [ ] Verify dock still scrolls properly when there are many icons
- [ ] Test at different window sizes to confirm icons stay contained

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the left dock’s height behavior so it now respects the configured top and bottom insets, preventing it from overlapping or exceeding the available workspace area.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->