### PR TITLE
fix(agent-gui): fix raw mention:// URLs rendering in conversation history

### DIFF
--- a/packages/agent/gui/shared/AgentMessageMarkdown.spec.tsx
+++ b/packages/agent/gui/shared/AgentMessageMarkdown.spec.tsx
@@ -1077,6 +1077,21 @@ describe("AgentMessageMarkdown", () => {
     expect(screen.queryByText(/mention:\/\/session/)).toBeNull();
   });
 
+  it("fixes mention links with query params outside the closing parenthesis", () => {
+    const { container } = render(
+      <AgentMessageMarkdown
+        content={
+          "[@Task Management](mention://workspace-app/task-mgmt)?workspaceId=room-1"
+        }
+      />
+    );
+
+    const mention = container.querySelector('[data-agent-file-mention="true"]');
+    expect(mention).toHaveAttribute("data-agent-mention-kind", "workspace-app");
+    expect(mention).toHaveTextContent("Task Management");
+    expect(screen.queryByText(/mention:\/\//)).toBeNull();
+  });
+
   it("turns inline code paths into clickable links", () => {
     const onLinkClick = vi.fn();
     render(

--- a/packages/agent/gui/shared/AgentMessageMarkdown.tsx
+++ b/packages/agent/gui/shared/AgentMessageMarkdown.tsx
@@ -1554,10 +1554,10 @@ function normalizePlainIssueMentionTitleContent(content: string): string {
   return content;
 }
 
-function normalizeMentionMarkdownLinks(content: string): string {
+export function normalizeMentionMarkdownLinks(content: string): string {
   return content
     .replace(/\]([\t ]*\r?\n[\t ]*)+\((mention:\/\/)/g, "]($2")
-    .replace(/\]\((mention:\/\/[A-Za-z0-9.-]+)\)\?([^\s)]+)/g, "]($1?$2)");
+    .replace(/\]\((mention:\/\/[^\s)]+)\)\?([^\s)]+)/g, "]($1?$2)");
 }
 
 function isMentionOnlyMarkdownContent(content: string): boolean {

--- a/packages/agent/gui/shared/AgentRichTextReadonly.tsx
+++ b/packages/agent/gui/shared/AgentRichTextReadonly.tsx
@@ -4,6 +4,7 @@ import { EditorContent, useEditor } from "@tiptap/react";
 import { cn } from "../app/renderer/lib/utils";
 import { plainTextToAgentRichTextDoc } from "../agent-gui/agentGuiNode/agentRichText/agentRichTextDocument";
 import { createAgentRichTextReadonlyExtensions } from "../agent-gui/agentGuiNode/agentRichText/agentRichTextExtensions";
+import { normalizeMentionMarkdownLinks } from "./AgentMessageMarkdown";
 import type { AgentMessageMarkdownWorkspaceAppIcon } from "./AgentMessageMarkdown";
 import type { AgentGUIProviderSkillOption } from "../agent-gui/agentGuiNode/model/agentGuiNodeTypes";
 
@@ -132,7 +133,10 @@ function plainTextToAgentRichTextDocWithWorkspaceAppIcons(
   availableSkills: readonly AgentGUIProviderSkillOption[],
   workspaceAppIcons: readonly AgentMessageMarkdownWorkspaceAppIcon[]
 ): JSONContent {
-  const doc = plainTextToAgentRichTextDoc(value, { skills: availableSkills });
+  const normalized = normalizeMentionMarkdownLinks(value);
+  const doc = plainTextToAgentRichTextDoc(normalized, {
+    skills: availableSkills
+  });
   if (workspaceAppIcons.length === 0) {
     return doc;
   }


### PR DESCRIPTION
## Summary
- Fixed `normalizeMentionMarkdownLinks` regex that only matched hostname patterns (`[A-Za-z0-9.-]+`) without entity paths, causing mention URLs like `mention://agent-session/entityId?workspaceId=ws-1` with `?` outside the closing `)` to render as raw text
- Widened the regex to `[^\s)]+` to capture the full mention URL including entity paths
- Exported `normalizeMentionMarkdownLinks` and applied it in `AgentRichTextReadonly` so user message history prompts also get mention link normalization (previously only applied in `AgentMessageMarkdown` for assistant messages)

## Test plan
- [x] Existing 53 AgentMessageMarkdown tests pass
- [x] Existing 6 AgentRichTextReadonly tests pass
- [x] Added test: "fixes mention links with query params outside the closing parenthesis" verifies `[@Task Management](mention://workspace-app/task-mgmt)?workspaceId=room-1` renders as a mention pill, not raw text

Fixes #436

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved parsing and rendering of agent mention links, including cases where query parameters appear after the closing parenthesis.
  * Ensured mentions consistently render as the correct mention chip (with expected label/icon) rather than raw link text.
  * Read-only rich text now normalizes mention formatting before rendering for more reliable results.
* **Tests**
  * Added a unit test to verify query-parameter mentions after the closing parenthesis are treated as a single workspace-app mention token.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->