### PR TITLE
fix(browser): reuse existing browser window for links from workspace apps

### DIFF
--- a/apps/desktop/src/main/ipc/workspaceAppWindowOpen.test.ts
+++ b/apps/desktop/src/main/ipc/workspaceAppWindowOpen.test.ts
@@ -52,7 +52,7 @@ test("workspace app native window-open requests dispatch Browser Node open-url e
     {
       channel: desktopIpcChannels.browser.event,
       payload: {
-        reuseIfOpen: false,
+        reuseIfOpen: true,
         sourceNodeId: "workspace-app:99",
         type: "open-url",
         url: "https://www.producthunt.com/products/google-labs"
@@ -91,7 +91,7 @@ test("workspace app preload open-url requests dispatch Browser Node open-url eve
     {
       channel: desktopIpcChannels.browser.event,
       payload: {
-        reuseIfOpen: false,
+        reuseIfOpen: true,
         sourceNodeId: "workspace-app:99",
         type: "open-url",
         url: "https://www.producthunt.com/products/vc-boom"

--- a/apps/desktop/src/main/ipc/workspaceAppWindowOpen.ts
+++ b/apps/desktop/src/main/ipc/workspaceAppWindowOpen.ts
@@ -84,7 +84,7 @@ export function dispatchWorkspaceAppOpenUrl({
   }
 
   const payload: BrowserNodeOpenUrlEvent = {
-    reuseIfOpen: false,
+    reuseIfOpen: true,
     sourceNodeId: `workspace-app:${contents.id}`,
     type: "open-url",
     url: resolved.url

--- a/apps/desktop/src/renderer/src/features/workspace-agent/services/desktopAgentGUILinkActions.test.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-agent/services/desktopAgentGUILinkActions.test.ts
@@ -130,7 +130,7 @@ test("desktop agent gui link actions open urls through the workspace browser", a
   assert.equal(handled, true);
   assert.deepEqual(openedUrls, [
     {
-      reuseIfOpen: false,
+      reuseIfOpen: true,
       source: "agent_command",
       url: "https://example.com",
       workspaceId: "workspace-1"

--- a/apps/desktop/src/renderer/src/features/workspace-agent/services/desktopAgentGUILinkActions.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-agent/services/desktopAgentGUILinkActions.ts
@@ -71,7 +71,7 @@ export async function runDesktopAgentGUILinkAction(
       });
     case "open-url":
       return dependencies.openBrowserUrl({
-        reuseIfOpen: false,
+        reuseIfOpen: true,
         source: "agent_command",
         url: action.url,
         workspaceId: dependencies.workspaceId


### PR DESCRIPTION
## Problem
Opening multiple links from workspace apps (AI Docs, Daily Product Radar, etc.) and the Agent GUI creates separate browser windows, cluttering the workspace. The Browser should consolidate these into one window.

Closes #414

## Root Cause
Two URL dispatch paths set `reuseIfOpen: false`, forcing a new browser node creation for every link:

1. `workspaceAppWindowOpen.ts:87` — links clicked inside workspace app webviews
2. `desktopAgentGUILinkActions.ts:74` — links opened from agent GUI markdown

Meanwhile, links clicked inside the browser itself already use `reuseIfOpen: true` (guestManager.ts:537).

## Fix
Change `reuseIfOpen` from `false` to `true` in both dispatch paths. When an existing browser window is available, links now navigate to it instead of spawning a new window.

## Changes
- `apps/desktop/src/main/ipc/workspaceAppWindowOpen.ts` — workspace app links
- `apps/desktop/src/renderer/src/features/workspace-agent/services/desktopAgentGUILinkActions.ts` — agent GUI links
- Updated corresponding test assertions in both test files

## Verification
- `workspaceAppWindowOpen.test.ts`: 2/2 pass
- `desktopAgentGUILinkActions.test.ts`: 8/8 pass
- `workspaceBrowserService.test.ts`: 7/7 pass
- `workspaceBrowserLaunchCoordinator.test.ts`: 7/7 pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved how workspace “open URL” actions handle repeated links by reusing an existing browser window or tab when available, instead of opening a new one.
  * Updated related URL-opening flows so the reuse behavior is consistent across the desktop app.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->