### PR TITLE
fix(agent-gui): preserve active submit target

### DIFF
--- a/apps/desktop/src/renderer/src/features/workspace-agent/services/desktopAgentActivityAdapter.test.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-agent/services/desktopAgentActivityAdapter.test.ts
@@ -13,6 +13,7 @@ const workspaceId = "workspace-1";
 
 test("desktop agent activity adapter maps tuttid sessions and messages", async () => {
   const calls: Array<{ method: string; args: unknown[] }> = [];
+  const diagnostics: unknown[] = [];
   const adapter = createDesktopAgentActivityAdapter({
     tuttidClient: createTuttidClient({
       async listWorkspaceAgentSessions(requestWorkspaceId: string) {
@@ -66,7 +67,7 @@ test("desktop agent activity adapter maps tuttid sessions and messages", async (
         };
       }
     }),
-    runtimeApi: createRuntimeApi()
+    runtimeApi: createRuntimeApi(diagnostics)
   });
 
   const sessions = await adapter.listSessions({ workspaceId });
@@ -137,6 +138,36 @@ test("desktop agent activity adapter maps tuttid sessions and messages", async (
       }
     ]
   });
+  assert.equal(diagnostics.length, 2);
+  assert.deepEqual(diagnostics[0], {
+    details: {
+      afterVersion: 3,
+      agentSessionId: "agent-session-1",
+      beforeVersion: null,
+      event: "requested",
+      limit: 10,
+      order: null
+    },
+    event: "agent.activity.messages.list",
+    level: "info",
+    workspaceId
+  });
+  const resolvedDiagnostic = diagnostics[1] as {
+    details?: Record<string, unknown>;
+    event?: string;
+    level?: string;
+    workspaceId?: string;
+  };
+  assert.equal(resolvedDiagnostic.event, "agent.activity.messages.list");
+  assert.equal(resolvedDiagnostic.level, "info");
+  assert.equal(resolvedDiagnostic.workspaceId, workspaceId);
+  assert.equal(resolvedDiagnostic.details?.agentSessionId, "agent-session-1");
+  assert.equal(resolvedDiagnostic.details?.event, "resolved");
+  assert.equal(resolvedDiagnostic.details?.firstVersion, 5);
+  assert.equal(resolvedDiagnostic.details?.lastVersion, 5);
+  assert.equal(resolvedDiagnostic.details?.latestVersion, 5);
+  assert.equal(resolvedDiagnostic.details?.messageCount, 1);
+  assert.equal(typeof resolvedDiagnostic.details?.durationMs, "number");
 });
 
 test("desktop agent activity adapter returns cancel result metadata", async () => {

--- a/apps/desktop/src/renderer/src/features/workspace-agent/services/desktopAgentActivityAdapter.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-agent/services/desktopAgentActivityAdapter.ts
@@ -254,23 +254,56 @@ export function createDesktopAgentActivityAdapter({
       };
     },
     async listSessionMessages(input) {
-      const response = await tuttidClient.listWorkspaceAgentSessionMessages(
-        input.workspaceId,
-        input.agentSessionId,
-        {
-          afterVersion: input.afterVersion ?? 0,
-          beforeVersion: input.beforeVersion,
-          order: input.order,
-          limit: input.limit
-        }
-      );
-      return {
-        hasMore: response.hasMore,
-        latestVersion: response.latestVersion,
-        messages: response.messages.map((message) =>
+      const startedAt = Date.now();
+      reportDesktopAgentMessageListDiagnostic(runtimeApi, input.workspaceId, {
+        afterVersion: input.afterVersion ?? 0,
+        agentSessionId: input.agentSessionId,
+        beforeVersion: input.beforeVersion ?? null,
+        event: "requested",
+        limit: input.limit ?? null,
+        order: input.order ?? null
+      });
+      try {
+        const response = await tuttidClient.listWorkspaceAgentSessionMessages(
+          input.workspaceId,
+          input.agentSessionId,
+          {
+            afterVersion: input.afterVersion ?? 0,
+            beforeVersion: input.beforeVersion,
+            order: input.order,
+            limit: input.limit
+          }
+        );
+        const messages = response.messages.map((message) =>
           agentActivityMessageFromTuttidMessage(input.workspaceId, message)
-        )
-      };
+        );
+        const versions = messages
+          .map((message) => message.version)
+          .filter((version) => Number.isFinite(version));
+        reportDesktopAgentMessageListDiagnostic(runtimeApi, input.workspaceId, {
+          agentSessionId: input.agentSessionId,
+          durationMs: Date.now() - startedAt,
+          event: "resolved",
+          firstVersion: versions.length ? Math.min(...versions) : null,
+          hasMore: response.hasMore,
+          lastVersion: versions.length ? Math.max(...versions) : null,
+          latestVersion: response.latestVersion,
+          messageCount: messages.length
+        });
+        return {
+          hasMore: response.hasMore,
+          latestVersion: response.latestVersion,
+          messages
+        };
+      } catch (error) {
+        reportDesktopAgentMessageListDiagnostic(runtimeApi, input.workspaceId, {
+          agentSessionId: input.agentSessionId,
+          durationMs: Date.now() - startedAt,
+          event: "failed",
+          ...normalizeDesktopAgentDiagnosticError(error)
+        });
+        throw error;
+      }
     },
     async loadComposerOptions(input) {
       const cwd = input.cwd?.trim();
@@ -492,6 +525,53 @@ export function createDesktopAgentActivityAdapter({
         input.agentSessionId
       );
     }
+  };
+}
+
+function reportDesktopAgentMessageListDiagnostic(
+  runtimeApi: Pick<DesktopRuntimeApi, "logTerminalDiagnostic">,
+  workspaceId: string,
+  details: Record<string, string | number | boolean | null>
+): void {
+  try {
+    void runtimeApi
+      .logTerminalDiagnostic({
+        details,
+        event: "agent.activity.messages.list",
+        level: details.event === "failed" ? "warn" : "info",
+        workspaceId
+      })
+      .catch(() => {});
+  } catch {
+    // Diagnostic logging must not affect message loading.
+  }
+}
+
+function normalizeDesktopAgentDiagnosticError(
+  error: unknown
+): Record<string, string | number | boolean | null> {
+  if (!(error instanceof Error)) {
+    return { errorName: typeof error };
+  }
+  const record = error as Error & {
+    code?: unknown;
+    reason?: unknown;
+    retryable?: unknown;
+    statusCode?: unknown;
+  };
+  return {
+    ...(typeof record.code === "string" ? { errorCode: record.code } : {}),
+    errorMessageLength: error.message.length,
+    errorName: error.name,
+    ...(typeof record.reason === "string"
+      ? { errorReason: record.reason }
+      : {}),
+    ...(typeof record.retryable === "boolean"
+      ? { errorRetryable: record.retryable }
+      : {}),
+    ...(typeof record.statusCode === "number"
+      ? { errorStatusCode: record.statusCode }
+      : {})
   };
 }
 

--- a/docs/architecture/agent-gui-node.md
+++ b/docs/architecture/agent-gui-node.md
@@ -225,6 +225,12 @@ activeConversationId changes
 Detail loading is separate from list loading. A conversation can appear in the
 rail before its messages are loaded. The detail panel should show message
 loading from the session view store, not infer it from the send button state.
+Older-history prefetch is opportunistic UI behavior. If a page load for a
+specific `(agentSessionId, beforeVersion)` cursor fails, AgentGuiNode should
+record that failed cursor and suppress automatic retries until the detail page
+is reloaded or a different oldest durable version is reached. Do not let scroll
+position and `isLoadingOlderMessages=false` form an immediate retry loop against
+the same failing backend page.
 
 ### First Prompt In A New Conversation
 
@@ -288,6 +294,13 @@ The local working patch is a latency bridge only. If the runtime returns a
 ready-looking session while the turn is still being processed, the desktop
 service can preserve optimistic `working` until a later authoritative event
 settles the session.
+
+The submit target is not just a render detail. A detail-page composer must not
+fall back to `startConversation` because a UI-local active conversation ref is
+temporarily empty. If the view is not on the home composer, resolve the existing
+session from the durable active-session hint and route through the existing
+send path, or block/recover explicitly with diagnostics. Only an intentional
+home-composer submit should create a new agent session.
 
 ### Resume Or Re-Attach Existing Session
 
@@ -468,6 +481,10 @@ User-visible rules:
 - Home composer submit with no active conversation starts activation. Detail
   composer submit with an active conversation sends input. First-message
   activation keeps the user on the home composer until activation succeeds.
+- Treat active-session refs as controller caches, not the source of truth for
+  whether a submit is new or existing. React effect cleanup, projection reloads,
+  and conversation-list refreshes may temporarily disturb UI-local refs; they
+  must not retarget the user's prompt to a newly created session.
 - The send button spinner is local submit/approval response state. For
   first-message activation, this same busy state is the only normal pending
   indicator. The "connecting conversation" state belongs to existing-session

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUINodeController.spec.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUINodeController.spec.tsx
@@ -2555,6 +2555,104 @@ describe("useAgentGUINodeController", () => {
     });
   });
 
+  it("suppresses repeated older message loads for the same failed cursor", async () => {
+    const timelineRequests: Array<{
+      beforeVersion?: number;
+      agentSessionId: string;
+      order?: string;
+    }> = [];
+    const listSessionTimeline = vi.fn(
+      async ({
+        beforeVersion,
+        agentSessionId,
+        order
+      }: {
+        beforeVersion?: number;
+        agentSessionId: string;
+        order?: string;
+      }) => {
+        timelineRequests.push({ agentSessionId, beforeVersion, order });
+        if (agentSessionId !== "session-2") {
+          return { timelineItems: [], hasMore: false };
+        }
+        if (order === "desc" && beforeVersion === undefined) {
+          return {
+            timelineItems: [
+              timelineMessage({
+                agentSessionId: "session-2",
+                id: 1,
+                eventId: "user-1",
+                role: "user",
+                content: "latest ask",
+                turnId: "turn-1"
+              })
+            ],
+            hasMore: true
+          };
+        }
+        throw new Error("older page failed");
+      }
+    );
+    installAgentHostApi({
+      list: vi.fn(async () => ({
+        presences: [],
+        sessions: [
+          workspaceAgentSession("session-1"),
+          workspaceAgentSession("session-2")
+        ]
+      })),
+      listSessionTimeline,
+      subscribeEvents: vi.fn(() => vi.fn())
+    });
+
+    const { result } = renderHook(() =>
+      useAgentGUINodeController({
+        workspaceId: "room-1",
+        currentUserId: "user-1",
+        workspacePath: "/workspace",
+        avoidGroupingEdits: false,
+        data: agentGuiData("session-1"),
+        onDataChange: vi.fn()
+      })
+    );
+
+    await waitFor(() => {
+      expect(result.current.viewModel.activeConversationId).toBe("session-1");
+    });
+    act(() => {
+      result.current.actions.selectConversation("session-2");
+    });
+
+    await waitFor(() => {
+      expect(result.current.viewModel.hasOlderMessages).toBe(true);
+    });
+    await act(async () => {
+      await result.current.actions.loadOlderConversationMessages();
+    });
+    await waitFor(() => {
+      expect(result.current.viewModel.isLoadingOlderMessages).toBe(false);
+    });
+    const failedOlderRequestCount = timelineRequests.filter(
+      (request) =>
+        request.agentSessionId === "session-2" &&
+        request.order === "desc" &&
+        request.beforeVersion === 1
+    ).length;
+
+    await act(async () => {
+      await result.current.actions.loadOlderConversationMessages();
+    });
+
+    expect(
+      timelineRequests.filter(
+        (request) =>
+          request.agentSessionId === "session-2" &&
+          request.order === "desc" &&
+          request.beforeVersion === 1
+      )
+    ).toHaveLength(failedOlderRequestCount);
+  });
+
   it("clears older message loading when a stale older request resolves", async () => {
     let resolveOlder:
       | ((value: { timelineItems: unknown[]; hasMore: boolean }) => void)
@@ -4211,6 +4309,74 @@ describe("useAgentGUINodeController", () => {
       expect(exec).toHaveBeenCalledWith({
         workspaceId: "room-1",
         agentSessionId: "session-openclaw",
+        ...promptContent("keep going")
+      });
+    });
+    expect(activate).not.toHaveBeenCalled();
+  });
+
+  it("keeps the existing submit target after controller lifecycle dependencies update", async () => {
+    const activate = vi.fn(
+      async (input: AgentHostActivateAgentSessionInput) => ({
+        session: agentSession(input.agentSessionId, {
+          provider: "claude-code",
+          status: "ready",
+          title: "Claude Code"
+        }),
+        activation: { mode: input.mode, status: "attached" as const },
+        events: []
+      })
+    );
+    const exec = vi.fn(async () => ({ turnId: "turn-1" }));
+    installAgentHostApi({
+      list: vi.fn(async () => ({
+        presences: [],
+        sessions: [
+          {
+            ...workspaceAgentSession("session-claude"),
+            provider: "claude-code",
+            title: "Claude Code",
+            effectiveStatus: "ready",
+            turnPhase: "idle"
+          }
+        ]
+      })),
+      listSessionTimeline: vi.fn(async () => ({ timelineItems: [] })),
+      subscribeEvents: vi.fn(() => vi.fn()),
+      activate,
+      exec
+    });
+
+    const { result, rerender } = renderHook(
+      (props: { currentUserId: string }) =>
+        useAgentGUINodeController({
+          workspaceId: "room-1",
+          currentUserId: props.currentUserId,
+          workspacePath: "/workspace",
+          avoidGroupingEdits: false,
+          data: agentGuiData("session-claude", "claude-code"),
+          onDataChange: vi.fn()
+        }),
+      { initialProps: { currentUserId: "user-1" } }
+    );
+
+    await waitFor(() => {
+      expect(result.current.viewModel.activeConversationId).toBe(
+        "session-claude"
+      );
+    });
+
+    rerender({ currentUserId: "user-2" });
+    await Promise.resolve();
+
+    act(() => {
+      result.current.actions.submitPrompt(promptBlocks("keep going"));
+    });
+
+    await waitFor(() => {
+      expect(exec).toHaveBeenCalledWith({
+        workspaceId: "room-1",
+        agentSessionId: "session-claude",
         ...promptContent("keep going")
       });
     });

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUINodeController.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUINodeController.ts
@@ -518,6 +518,42 @@ function reportAgentGUISubmitWithoutActiveConversation(input: {
   }
 }
 
+function reportAgentGUISubmitRecoveredActiveConversation(input: {
+  blockCount: number;
+  conversationCount: number;
+  conversationListQueryReady: boolean;
+  promptLength: number;
+  provider: string | null;
+  recoveredAgentSessionId: string;
+  runtime: AgentActivityRuntime;
+  workspaceId: string;
+}): void {
+  const reportDiagnostic = input.runtime.reportDiagnostic;
+  if (!reportDiagnostic) {
+    return;
+  }
+  try {
+    void Promise.resolve(
+      reportDiagnostic.call(input.runtime, {
+        details: {
+          blockCount: input.blockCount,
+          conversationCount: input.conversationCount,
+          conversationListQueryReady: input.conversationListQueryReady,
+          promptLength: input.promptLength,
+          provider: input.provider,
+          recoveredAgentSessionId: input.recoveredAgentSessionId
+        },
+        event: "agent.gui.submit.recovered_active_conversation",
+        level: "info",
+        source: "agent-gui",
+        workspaceId: input.workspaceId
+      })
+    ).catch(() => {});
+  } catch {
+    // Diagnostic logging must never affect active conversation routing.
+  }
+}
+
 function reportAgentGUICancelDiagnostic(input: {
   agentSessionId: string;
   busySource?: string | null;
@@ -3697,6 +3733,9 @@ export function useAgentGUINodeController({
   });
   const selectedConversationMessageLoadSeqRef = useRef(0);
   const selectedConversationOlderMessageLoadSeqRef = useRef(0);
+  const failedOlderMessageCursorBySessionIdRef = useRef<Map<string, number>>(
+    new Map()
+  );
   const lastConversationProjectionDiagnosticKeyRef = useRef<string | null>(
     null
   );
@@ -5219,6 +5258,9 @@ export function useAgentGUINodeController({
           durableMessages: detailMessages,
           localMessages: windowOverlayMessages
         });
+        failedOlderMessageCursorBySessionIdRef.current.delete(
+          normalizedAgentSessionId
+        );
         setAgentSessionViewDetailMessages(
           sessionViewRef(normalizedAgentSessionId),
           detailMessages,
@@ -5312,6 +5354,25 @@ export function useAgentGUINodeController({
         });
         return;
       }
+      const beforeVersion = currentView.oldestLoadedVersion;
+      if (
+        failedOlderMessageCursorBySessionIdRef.current.get(
+          normalizedAgentSessionId
+        ) === beforeVersion
+      ) {
+        reportAgentGUIMessagePageDiagnostic({
+          agentSessionId: normalizedAgentSessionId,
+          details: {
+            beforeVersion,
+            reason: "previous_cursor_error"
+          },
+          event: "agent.gui.messages.older.suppressed_after_error",
+          level: "warn",
+          runtime: agentActivityRuntime,
+          workspaceId
+        });
+        return;
+      }
       const requestId = ++selectedConversationOlderMessageLoadSeqRef.current;
       setAgentSessionViewOlderMessagesLoading(
         sessionViewRef(normalizedAgentSessionId),
@@ -5321,7 +5382,7 @@ export function useAgentGUINodeController({
         reportAgentGUIMessagePageDiagnostic({
           agentSessionId: normalizedAgentSessionId,
           details: {
-            beforeVersion: currentView.oldestLoadedVersion,
+            beforeVersion,
             limit: AGENT_GUI_DETAIL_MESSAGES_PAGE_SIZE,
             order: "desc",
             requestId
@@ -5333,7 +5394,7 @@ export function useAgentGUINodeController({
         const page = await agentActivityRuntime.listSessionMessages({
           workspaceId,
           agentSessionId: normalizedAgentSessionId,
-          beforeVersion: currentView.oldestLoadedVersion,
+          beforeVersion,
           cache: false,
           limit: AGENT_GUI_DETAIL_MESSAGES_PAGE_SIZE,
           order: "desc"
@@ -5352,7 +5413,7 @@ export function useAgentGUINodeController({
         reportAgentGUIMessagePageDiagnostic({
           agentSessionId: normalizedAgentSessionId,
           details: {
-            beforeVersion: currentView.oldestLoadedVersion,
+            beforeVersion,
             hasMore: page.hasMore,
             latestVersion: page.latestVersion,
             requestId
@@ -5362,6 +5423,9 @@ export function useAgentGUINodeController({
           runtime: agentActivityRuntime,
           workspaceId
         });
+        failedOlderMessageCursorBySessionIdRef.current.delete(
+          normalizedAgentSessionId
+        );
         const nextDetailMessages = mergeWorkspaceAgentMessages(
           currentView.detailMessages,
           page.messages
@@ -5402,8 +5466,16 @@ export function useAgentGUINodeController({
           );
           return;
         }
+        failedOlderMessageCursorBySessionIdRef.current.set(
+          normalizedAgentSessionId,
+          beforeVersion
+        );
         reportAgentGUIRuntimeError({
           agentSessionId: normalizedAgentSessionId,
+          context: {
+            beforeVersion,
+            requestId
+          },
           error,
           phase: "load_session_messages",
           provider: dataRef.current.provider,
@@ -5604,6 +5676,20 @@ export function useAgentGUINodeController({
       ),
     [loadSessionState]
   );
+  const scheduleActivityStreamStateReloadRef = useRef(
+    scheduleActivityStreamStateReload
+  );
+  const clearSelectedConversationNotFoundRetryRef = useRef(
+    clearSelectedConversationNotFoundRetry
+  );
+  useEffect(() => {
+    scheduleActivityStreamStateReloadRef.current =
+      scheduleActivityStreamStateReload;
+  }, [scheduleActivityStreamStateReload]);
+  useEffect(() => {
+    clearSelectedConversationNotFoundRetryRef.current =
+      clearSelectedConversationNotFoundRetry;
+  }, [clearSelectedConversationNotFoundRetry]);
 
   const applyTimelineProjectionUpdate = useCallback(
     (
@@ -6196,8 +6282,8 @@ export function useAgentGUINodeController({
   useEffect(() => {
     isMountedRef.current = true;
     return () => {
-      scheduleActivityStreamStateReload.cancel();
-      clearSelectedConversationNotFoundRetry();
+      scheduleActivityStreamStateReloadRef.current.cancel();
+      clearSelectedConversationNotFoundRetryRef.current();
       const current = activeConversationIdRef.current;
       const pendingNewConversationId = startingConversationIdRef.current;
       isMountedRef.current = false;
@@ -6211,10 +6297,7 @@ export function useAgentGUINodeController({
         void unactivateRef.current(pendingNewConversationId);
       }
     };
-  }, [
-    scheduleActivityStreamStateReload,
-    clearSelectedConversationNotFoundRetry
-  ]);
+  }, []);
 
   const startConversation = useCallback(
     (initialContentInput?: unknown, displayPrompt?: string) => {
@@ -7380,41 +7463,12 @@ export function useAgentGUINodeController({
     [agentActivityDisplayStatuses, isRespondingApproval, isSubmitting]
   );
 
-  const submitPrompt = useCallback(
-    (content: AgentPromptContentBlock[], displayPrompt?: string) => {
-      const agentSessionId = activeConversationIdRef.current;
-      const normalizedContent = normalizeAgentPromptContentBlocks(content);
-      if (normalizedContent.length === 0) {
-        return;
-      }
-      const displayPromptText =
-        displayPrompt && displayPrompt.trim() ? displayPrompt : undefined;
-      if (
-        resolvedPromptImagesSupported === false &&
-        agentPromptContentHasImage(normalizedContent)
-      ) {
-        setDetailError(translate("agentHost.agentGui.promptImagesUnsupported"));
-        return;
-      }
-      if (!agentSessionId) {
-        if (!isComposerHomeRef.current) {
-          reportAgentGUISubmitWithoutActiveConversation({
-            blockCount: normalizedContent.length,
-            conversationCount: conversationsRef.current.length,
-            conversationListQueryReady: conversationListQuery !== null,
-            dataLastActiveAgentSessionId:
-              dataRef.current.lastActiveAgentSessionId ?? null,
-            isComposerHome: isComposerHomeRef.current,
-            promptLength:
-              agentPromptContentDisplayText(normalizedContent).length,
-            provider: dataRef.current.provider ?? null,
-            runtime: agentActivityRuntime,
-            workspaceId
-          });
-        }
-        startConversation(normalizedContent, displayPromptText);
-        return;
-      }
+  const submitExistingPrompt = useCallback(
+    (
+      agentSessionId: string,
+      normalizedContent: AgentPromptContentBlock[],
+      displayPromptText?: string
+    ) => {
       if (isSessionMarkedNonResumable(agentSessionId)) {
         setDetailError(
           getAgentGUIErrorMessage(buildResumeSessionNotLocalActivationError())
@@ -7453,14 +7507,86 @@ export function useAgentGUINodeController({
     },
     [
       activation,
-      agentActivityRuntime,
-      conversationListQuery,
       executePrompt,
       isSessionMarkedNonResumable,
-      resolvedPromptImagesSupported,
       queuePromptLocally,
-      shouldQueuePromptLocally,
+      shouldQueuePromptLocally
+    ]
+  );
+
+  const submitPrompt = useCallback(
+    (content: AgentPromptContentBlock[], displayPrompt?: string) => {
+      const agentSessionId = activeConversationIdRef.current;
+      const normalizedContent = normalizeAgentPromptContentBlocks(content);
+      if (normalizedContent.length === 0) {
+        return;
+      }
+      const displayPromptText =
+        displayPrompt && displayPrompt.trim() ? displayPrompt : undefined;
+      if (
+        resolvedPromptImagesSupported === false &&
+        agentPromptContentHasImage(normalizedContent)
+      ) {
+        setDetailError(translate("agentHost.agentGui.promptImagesUnsupported"));
+        return;
+      }
+      if (!agentSessionId) {
+        if (!isComposerHomeRef.current) {
+          const promptLength =
+            agentPromptContentDisplayText(normalizedContent).length;
+          reportAgentGUISubmitWithoutActiveConversation({
+            blockCount: normalizedContent.length,
+            conversationCount: conversationsRef.current.length,
+            conversationListQueryReady: conversationListQuery !== null,
+            dataLastActiveAgentSessionId:
+              dataRef.current.lastActiveAgentSessionId ?? null,
+            isComposerHome: isComposerHomeRef.current,
+            promptLength,
+            provider: dataRef.current.provider ?? null,
+            runtime: agentActivityRuntime,
+            workspaceId
+          });
+          const recoveredAgentSessionId =
+            dataRef.current.lastActiveAgentSessionId?.trim() ?? "";
+          if (recoveredAgentSessionId) {
+            reportAgentGUISubmitRecoveredActiveConversation({
+              blockCount: normalizedContent.length,
+              conversationCount: conversationsRef.current.length,
+              conversationListQueryReady: conversationListQuery !== null,
+              promptLength,
+              provider: dataRef.current.provider ?? null,
+              recoveredAgentSessionId,
+              runtime: agentActivityRuntime,
+              workspaceId
+            });
+            activeConversationIdRef.current = recoveredAgentSessionId;
+            setActiveConversationId(recoveredAgentSessionId);
+            setIntent({ tag: "active", id: recoveredAgentSessionId });
+            persistActiveConversation(recoveredAgentSessionId);
+            submitExistingPrompt(
+              recoveredAgentSessionId,
+              normalizedContent,
+              displayPromptText
+            );
+            return;
+          }
+        }
+        startConversation(normalizedContent, displayPromptText);
+        return;
+      }
+      submitExistingPrompt(
+        agentSessionId,
+        normalizedContent,
+        displayPromptText
+      );
+    },
+    [
+      agentActivityRuntime,
+      conversationListQuery,
+      resolvedPromptImagesSupported,
+      persistActiveConversation,
       startConversation,
+      submitExistingPrompt,
       workspaceId
     ]
   );

--- a/services/tuttid/api/daemon_agent_session_messages.go
+++ b/services/tuttid/api/daemon_agent_session_messages.go
@@ -1,0 +1,93 @@
+package api
+
+import (
+	"fmt"
+	"strings"
+
+	tuttigenerated "github.com/tutti-os/tutti/services/tuttid/api/generated"
+	"github.com/tutti-os/tutti/services/tuttid/apierrors"
+	agentservice "github.com/tutti-os/tutti/services/tuttid/service/agent"
+)
+
+func generatedAgentSessionMessages(messages []agentservice.SessionMessage) ([]tuttigenerated.WorkspaceAgentSessionMessage, error) {
+	result := make([]tuttigenerated.WorkspaceAgentSessionMessage, 0, len(messages))
+	for _, message := range messages {
+		turnID := strings.TrimSpace(message.TurnID)
+		if turnID == "" {
+			messageID := strings.TrimSpace(message.MessageID)
+			if messageID == "" {
+				messageID = fmt.Sprintf("id:%d", message.ID)
+			}
+			return nil, apierrors.WorkspaceOperationFailed(
+				apierrors.WithDeveloperMessage(fmt.Sprintf("workspace agent session message %q is missing turnId", messageID)),
+			)
+		}
+		result = append(result, tuttigenerated.WorkspaceAgentSessionMessage{
+			AgentSessionId:    strings.TrimSpace(message.AgentSessionID),
+			CompletedAtUnixMs: int64Pointer(message.CompletedAtUnixMS),
+			CreatedAtUnixMs:   int64Pointer(message.CreatedAtUnixMS),
+			Id:                int64(message.ID),
+			Kind:              strings.TrimSpace(message.Kind),
+			MessageId:         strings.TrimSpace(message.MessageID),
+			OccurredAtUnixMs:  normalizedGeneratedMessageOccurredAtUnixMS(message),
+			Payload:           clonePayloadPointer(message.Payload),
+			Role:              strings.TrimSpace(message.Role),
+			StartedAtUnixMs:   int64Pointer(message.StartedAtUnixMS),
+			Status:            stringPointer(strings.TrimSpace(message.Status)),
+			TurnId:            turnID,
+			UpdatedAtUnixMs:   int64Pointer(message.UpdatedAtUnixMS),
+			Version:           int64(message.Version),
+		})
+	}
+	return result, nil
+}
+
+func agentSessionMessageVersionRange(messages []agentservice.SessionMessage) (uint64, uint64) {
+	var first uint64
+	var last uint64
+	for _, message := range messages {
+		if first == 0 || message.Version < first {
+			first = message.Version
+		}
+		if message.Version > last {
+			last = message.Version
+		}
+	}
+	return first, last
+}
+
+func generatedAgentSessionMessageVersionRange(messages []tuttigenerated.WorkspaceAgentSessionMessage) (int64, int64) {
+	var first int64
+	var last int64
+	for _, message := range messages {
+		if first == 0 || message.Version < first {
+			first = message.Version
+		}
+		if message.Version > last {
+			last = message.Version
+		}
+	}
+	return first, last
+}
+
+func normalizedGeneratedMessageOccurredAtUnixMS(message agentservice.SessionMessage) int64 {
+	return firstPositiveInt64(
+		message.OccurredAtUnixMS,
+		message.StartedAtUnixMS,
+		message.CompletedAtUnixMS,
+		message.CreatedAtUnixMS,
+		message.UpdatedAtUnixMS,
+		int64(message.Version),
+		int64(message.ID),
+		1,
+	)
+}
+
+func firstPositiveInt64(values ...int64) int64 {
+	for _, value := range values {
+		if value > 0 {
+			return value
+		}
+	}
+	return 0
+}

--- a/services/tuttid/api/daemon_agent_sessions.go
+++ b/services/tuttid/api/daemon_agent_sessions.go
@@ -2,8 +2,9 @@ package api
 
 import (
 	"context"
-	"fmt"
+	"log/slog"
 	"strings"
+	"time"
 
 	tuttigenerated "github.com/tutti-os/tutti/services/tuttid/api/generated"
 	"github.com/tutti-os/tutti/services/tuttid/apierrors"
@@ -158,6 +159,9 @@ func (api DaemonAPI) ListWorkspaceAgentSessionMessages(ctx context.Context, requ
 			ServiceUnavailableErrorJSONResponse: agentSessionServiceUnavailableError(),
 		}, nil
 	}
+	startedAt := time.Now()
+	workspaceID := string(request.WorkspaceID)
+	agentSessionID := string(request.AgentSessionID)
 	input := agentservice.ListMessagesInput{}
 	if request.Params.AfterVersion != nil {
 		if *request.Params.AfterVersion < 0 {
@@ -187,19 +191,72 @@ func (api DaemonAPI) ListWorkspaceAgentSessionMessages(ctx context.Context, requ
 		}
 		input.Limit = *request.Params.Limit
 	}
+	slog.Info("workspace agent session messages list requested",
+		"event", "workspace.agent_session.messages.api.list_requested",
+		"workspace_id", workspaceID,
+		"agent_session_id", agentSessionID,
+		"after_version", input.AfterVersion,
+		"before_version", input.BeforeVersion,
+		"order", input.Order,
+		"limit", input.Limit,
+	)
 	page, err := api.AgentSessionService.ListMessages(
 		ctx,
-		string(request.WorkspaceID),
-		string(request.AgentSessionID),
+		workspaceID,
+		agentSessionID,
 		input,
 	)
 	if err != nil {
+		slog.Warn("workspace agent session messages list failed",
+			"event", "workspace.agent_session.messages.api.list_failed",
+			"workspace_id", workspaceID,
+			"agent_session_id", agentSessionID,
+			"after_version", input.AfterVersion,
+			"before_version", input.BeforeVersion,
+			"order", input.Order,
+			"limit", input.Limit,
+			"duration_ms", time.Since(startedAt).Milliseconds(),
+			"error", err,
+		)
 		return writeListWorkspaceAgentSessionMessagesError(err), nil
 	}
 	messages, err := generatedAgentSessionMessages(page.Messages)
 	if err != nil {
+		firstVersion, lastVersion := agentSessionMessageVersionRange(page.Messages)
+		slog.Warn("workspace agent session messages response transform failed",
+			"event", "workspace.agent_session.messages.api.transform_failed",
+			"workspace_id", workspaceID,
+			"agent_session_id", agentSessionID,
+			"after_version", input.AfterVersion,
+			"before_version", input.BeforeVersion,
+			"order", input.Order,
+			"limit", input.Limit,
+			"message_count", len(page.Messages),
+			"first_version", firstVersion,
+			"last_version", lastVersion,
+			"latest_version", page.LatestVersion,
+			"has_more", page.HasMore,
+			"duration_ms", time.Since(startedAt).Milliseconds(),
+			"error", err,
+		)
 		return writeListWorkspaceAgentSessionMessagesError(err), nil
 	}
+	firstVersion, lastVersion := generatedAgentSessionMessageVersionRange(messages)
+	slog.Info("workspace agent session messages list completed",
+		"event", "workspace.agent_session.messages.api.list_completed",
+		"workspace_id", workspaceID,
+		"agent_session_id", agentSessionID,
+		"after_version", input.AfterVersion,
+		"before_version", input.BeforeVersion,
+		"order", input.Order,
+		"limit", input.Limit,
+		"message_count", len(messages),
+		"first_version", firstVersion,
+		"last_version", lastVersion,
+		"latest_version", page.LatestVersion,
+		"has_more", page.HasMore,
+		"duration_ms", time.Since(startedAt).Milliseconds(),
+	)
 	return tuttigenerated.ListWorkspaceAgentSessionMessages200JSONResponse{
 		AgentSessionId: page.AgentSessionID,
 		HasMore:        page.HasMore,
@@ -569,61 +626,6 @@ func optionalStringPointer(value string) *string {
 		return nil
 	}
 	return &value
-}
-
-func generatedAgentSessionMessages(messages []agentservice.SessionMessage) ([]tuttigenerated.WorkspaceAgentSessionMessage, error) {
-	result := make([]tuttigenerated.WorkspaceAgentSessionMessage, 0, len(messages))
-	for _, message := range messages {
-		turnID := strings.TrimSpace(message.TurnID)
-		if turnID == "" {
-			messageID := strings.TrimSpace(message.MessageID)
-			if messageID == "" {
-				messageID = fmt.Sprintf("id:%d", message.ID)
-			}
-			return nil, apierrors.WorkspaceOperationFailed(
-				apierrors.WithDeveloperMessage(fmt.Sprintf("workspace agent session message %q is missing turnId", messageID)),
-			)
-		}
-		result = append(result, tuttigenerated.WorkspaceAgentSessionMessage{
-			AgentSessionId:    strings.TrimSpace(message.AgentSessionID),
-			CompletedAtUnixMs: int64Pointer(message.CompletedAtUnixMS),
-			CreatedAtUnixMs:   int64Pointer(message.CreatedAtUnixMS),
-			Id:                int64(message.ID),
-			Kind:              strings.TrimSpace(message.Kind),
-			MessageId:         strings.TrimSpace(message.MessageID),
-			OccurredAtUnixMs:  normalizedGeneratedMessageOccurredAtUnixMS(message),
-			Payload:           clonePayloadPointer(message.Payload),
-			Role:              strings.TrimSpace(message.Role),
-			StartedAtUnixMs:   int64Pointer(message.StartedAtUnixMS),
-			Status:            stringPointer(strings.TrimSpace(message.Status)),
-			TurnId:            turnID,
-			UpdatedAtUnixMs:   int64Pointer(message.UpdatedAtUnixMS),
-			Version:           int64(message.Version),
-		})
-	}
-	return result, nil
-}
-
-func normalizedGeneratedMessageOccurredAtUnixMS(message agentservice.SessionMessage) int64 {
-	return firstPositiveInt64(
-		message.OccurredAtUnixMS,
-		message.StartedAtUnixMS,
-		message.CompletedAtUnixMS,
-		message.CreatedAtUnixMS,
-		message.UpdatedAtUnixMS,
-		int64(message.Version),
-		int64(message.ID),
-		1,
-	)
-}
-
-func firstPositiveInt64(values ...int64) int64 {
-	for _, value := range values {
-		if value > 0 {
-			return value
-		}
-	}
-	return 0
 }
 
 func generatedAgentGeneratedFiles(files []agentservice.GeneratedFile) []tuttigenerated.WorkspaceAgentGeneratedFileEntry {

--- a/services/tuttid/data/workspace/sqlite_agent_activity.go
+++ b/services/tuttid/data/workspace/sqlite_agent_activity.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"log/slog"
 	"strings"
 	"time"
 
@@ -448,6 +449,17 @@ LIMIT ?
 		return agentactivitybiz.MessagePage{}, false, fmt.Errorf("unsupported workspace agent message order: %s", order)
 	}
 	if err != nil {
+		slog.Warn("workspace agent messages query failed",
+			"event", "workspace.agent_session.messages.sqlite.query_failed",
+			"workspace_id", workspaceID,
+			"agent_session_id", agentSessionID,
+			"after_version", input.AfterVersion,
+			"before_version", input.BeforeVersion,
+			"order", order,
+			"limit", input.Limit,
+			"query_limit", queryLimit,
+			"error", err,
+		)
 		return agentactivitybiz.MessagePage{}, false, fmt.Errorf("list workspace agent messages: %w", err)
 	}
 	defer rows.Close()
@@ -456,11 +468,35 @@ LIMIT ?
 	for rows.Next() {
 		message, err := scanAgentMessage(rows)
 		if err != nil {
+			slog.Warn("workspace agent message row scan failed",
+				"event", "workspace.agent_session.messages.sqlite.scan_failed",
+				"workspace_id", workspaceID,
+				"agent_session_id", agentSessionID,
+				"after_version", input.AfterVersion,
+				"before_version", input.BeforeVersion,
+				"order", order,
+				"limit", input.Limit,
+				"query_limit", queryLimit,
+				"scanned_message_count", len(messages),
+				"error", err,
+			)
 			return agentactivitybiz.MessagePage{}, false, err
 		}
 		messages = append(messages, message)
 	}
 	if err := rows.Err(); err != nil {
+		slog.Warn("workspace agent messages row iteration failed",
+			"event", "workspace.agent_session.messages.sqlite.iterate_failed",
+			"workspace_id", workspaceID,
+			"agent_session_id", agentSessionID,
+			"after_version", input.AfterVersion,
+			"before_version", input.BeforeVersion,
+			"order", order,
+			"limit", input.Limit,
+			"query_limit", queryLimit,
+			"scanned_message_count", len(messages),
+			"error", err,
+		)
 		return agentactivitybiz.MessagePage{}, false, fmt.Errorf("iterate workspace agent messages: %w", err)
 	}
 	hasMore := false

--- a/services/tuttid/data/workspace/sqlite_agent_activity_messages.go
+++ b/services/tuttid/data/workspace/sqlite_agent_activity_messages.go
@@ -170,14 +170,24 @@ func scanAgentMessage(scanner rowScanner) (agentactivitybiz.Message, error) {
 		&message.UpdatedAtUnixMS,
 	)
 	if err != nil {
-		return agentactivitybiz.Message{}, err
+		return agentactivitybiz.Message{}, fmt.Errorf("scan workspace agent message row: %w", err)
 	}
 	if strings.TrimSpace(payloadJSON) == "" {
 		message.Payload = map[string]any{}
 		return message, nil
 	}
 	if err := json.Unmarshal([]byte(payloadJSON), &message.Payload); err != nil {
-		return agentactivitybiz.Message{}, fmt.Errorf("decode workspace agent message payload: %w", err)
+		return agentactivitybiz.Message{}, fmt.Errorf(
+			"decode workspace agent message payload id=%d message_id=%q version=%d turn_id=%q role=%q kind=%q status=%q: %w",
+			message.ID,
+			message.MessageID,
+			message.Version,
+			message.TurnID,
+			message.Role,
+			message.Kind,
+			message.Status,
+			err,
+		)
 	}
 	return message, nil
 }

--- a/services/tuttid/service/agent/activity_projection.go
+++ b/services/tuttid/service/agent/activity_projection.go
@@ -462,6 +462,10 @@ func (p *ActivityProjection) ListSessionMessages(
 			"event", "workspace.agent_session.messages.list_failed",
 			"workspace_id", input.WorkspaceID,
 			"agent_session_id", input.AgentSessionID,
+			"after_version", input.AfterVersion,
+			"before_version", input.BeforeVersion,
+			"order", input.Order,
+			"limit", input.Limit,
 			"error", err,
 		)
 		return SessionMessagesPage{}, false


### PR DESCRIPTION
## Summary
- preserve AgentGUI existing-session submit target when controller lifecycle cleanup runs
- suppress repeated older-message loads after a failed cursor and add related diagnostics
- add backend/adapter diagnostics for agent message pagination and update the AgentGuiNode architecture note

## Validation
- pnpm check:full
- pnpm check:agent-activity-runtime-boundaries
- pnpm --filter @tutti-os/agent-gui exec oxlint agent-gui/agentGuiNode/controller/useAgentGUINodeController.ts agent-gui/agentGuiNode/controller/useAgentGUINodeController.spec.tsx
- pnpm --filter @tutti-os/agent-gui exec tsc --noEmit --pretty false
- pnpm exec vitest run --environment jsdom agent-gui/agentGuiNode/controller/useAgentGUINodeController.spec.tsx -t "keeps the existing submit target|suppresses repeated older message loads|does not auto-activate an existing conversation|selects an externally requested active conversation"


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented repeated retries against the same failing “older messages” cursor, improving message loading reliability.
  * Ensured prompts are routed to the correct recovered/active conversation instead of creating a new session.
  * Avoided incorrect submit targeting when UI state briefly refreshes.
* **Logging & Diagnostics**
  * Added structured request lifecycle diagnostics and more detailed failure context for session message listing.
* **Tests**
  * Added regression coverage for suppressed retry loops and preserved submit targets across lifecycle updates.
* **Documentation**
  * Updated architecture guidance for session recovery, composer behavior, and retry suppression rules.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->