### PR TITLE
fix(agent-gui): stabilize message display ordering

### DIFF
--- a/packages/agent/gui/shared/agentConversation/projection/agentConversationProjection.spec.ts
+++ b/packages/agent/gui/shared/agentConversation/projection/agentConversationProjection.spec.ts
@@ -573,6 +573,44 @@ describe("projectAgentConversationVM", () => {
     );
   });
 
+  it("scopes the transient processing row identity to the latest turn", () => {
+    const firstTurn = detailViewModel().turns[0]!;
+    const secondTurn = {
+      id: "turn-2",
+      userMessage: {
+        id: "user-2",
+        body: "Follow-up request",
+        turnId: "turn-2"
+      },
+      userMessages: [
+        { id: "user-2", body: "Follow-up request", turnId: "turn-2" }
+      ],
+      agentMessages: [],
+      toolCalls: [],
+      toolCallCount: 0,
+      hasFailedToolCall: false,
+      agentItems: []
+    };
+
+    const conversation = projectAgentConversationVM(
+      detailViewModel({
+        turns: [firstTurn, secondTurn],
+        showProcessingIndicator: true
+      })
+    );
+
+    const processing = conversation.rows.find(
+      (row) => row.kind === "processing"
+    );
+
+    expect(processing).toEqual(
+      expect.objectContaining({
+        id: "processing:turn-2",
+        turnId: "turn-2"
+      })
+    );
+  });
+
   it("keeps Edit and Write tool calls as standalone rows when avoidGroupingEdits is enabled", () => {
     const detail = detailViewModel();
 

--- a/packages/agent/gui/shared/agentConversation/projection/agentProcessingProjection.ts
+++ b/packages/agent/gui/shared/agentConversation/projection/agentProcessingProjection.ts
@@ -16,10 +16,11 @@ export function projectAgentProcessingRow(
   if (hasSpecificProgressRow(rows)) {
     return null;
   }
+  const turnId = detail.turns.at(-1)?.id ?? null;
   return {
     kind: "processing",
-    id: "processing",
-    turnId: detail.turns.at(-1)?.id ?? null,
+    id: `processing:${turnId ?? "session"}`,
+    turnId,
     occurredAtUnixMs:
       detail.session.updatedAtUnixMs ?? detail.session.createdAtUnixMs ?? null
   };

--- a/packages/agent/gui/shared/agentConversation/projection/workspaceAgentMessageProjection.spec.ts
+++ b/packages/agent/gui/shared/agentConversation/projection/workspaceAgentMessageProjection.spec.ts
@@ -118,6 +118,68 @@ describe("projectWorkspaceAgentMessagesToConversationVM", () => {
     ]);
   });
 
+  it("orders late completed tool calls by start time before the final assistant answer", () => {
+    const conversation = projectWorkspaceAgentMessagesToConversationVM({
+      activity: activity(),
+      session: session(),
+      messages: [
+        message({
+          messageId: "user-1",
+          id: 1,
+          version: 1,
+          role: "user",
+          kind: "text",
+          payload: { text: "Inspect AI Canvas" },
+          occurredAtUnixMs: 100,
+          startedAtUnixMs: 100
+        }),
+        message({
+          messageId: "toolcall:search-1",
+          id: 2,
+          version: 4,
+          role: "assistant",
+          kind: "tool_call",
+          status: "completed",
+          payload: {
+            callId: "search-1",
+            title: "Bash",
+            toolName: "Bash",
+            input: { command: "rg 陶瓷家具与冲浪 /Users/Sun" }
+          },
+          startedAtUnixMs: 110,
+          occurredAtUnixMs: 400,
+          completedAtUnixMs: 400
+        }),
+        message({
+          messageId: "assistant-final",
+          id: 3,
+          version: 3,
+          role: "assistant",
+          kind: "text",
+          payload: { text: "项目里有图片和视频。" },
+          occurredAtUnixMs: 300,
+          startedAtUnixMs: 300
+        })
+      ]
+    });
+
+    expect(
+      conversation.rows.map((row) => {
+        if (row.kind === "message") {
+          return `${row.speaker}:${row.messages[0]?.body}`;
+        }
+        if (row.kind === "tool-group") {
+          return `tool:${row.calls[0]?.toolName}`;
+        }
+        return row.kind;
+      })
+    ).toEqual([
+      "user:Inspect AI Canvas",
+      "tool:Bash",
+      "assistant:项目里有图片和视频。"
+    ]);
+  });
+
   it("projects text, reasoning, errors, and unknown kinds conservatively", () => {
     const conversation = projectWorkspaceAgentMessagesToConversationVM({
       activity: activity(),

--- a/packages/agent/gui/shared/agentConversation/projection/workspaceAgentMessageProjection.ts
+++ b/packages/agent/gui/shared/agentConversation/projection/workspaceAgentMessageProjection.ts
@@ -266,6 +266,10 @@ function compareMessagesByDisplayOrder(
   left: WorkspaceAgentActivityMessage,
   right: WorkspaceAgentActivityMessage
 ): number {
+  // This comparator decides the rendered message position. startedAt is the
+  // start time for long-running items, occurredAt is the append time for plain
+  // messages, and completedAt is only a last fallback; version/id are stable
+  // tie-breakers when two messages share the same display time.
   return (
     messageDisplayOrderTime(left) - messageDisplayOrderTime(right) ||
     normalizedPositiveNumber(left.version) -

--- a/packages/agent/gui/shared/agentConversation/projection/workspaceAgentMessageProjection.ts
+++ b/packages/agent/gui/shared/agentConversation/projection/workspaceAgentMessageProjection.ts
@@ -49,10 +49,7 @@ export function projectWorkspaceAgentMessagesToTimelineItems(
     const seq = index + 1;
     const eventId = message.messageId.trim() || `message:${id}`;
     const turnId = message.turnId?.trim() || undefined;
-    const occurredAtUnixMs =
-      message.occurredAtUnixMs ??
-      message.completedAtUnixMs ??
-      message.startedAtUnixMs;
+    const occurredAtUnixMs = messageDisplayOrderTime(message);
 
     if (kind === "tool_call") {
       const callId = firstNonEmptyString(
@@ -270,9 +267,9 @@ function compareMessagesByDisplayOrder(
   right: WorkspaceAgentActivityMessage
 ): number {
   return (
+    messageDisplayOrderTime(left) - messageDisplayOrderTime(right) ||
     normalizedPositiveNumber(left.version) -
       normalizedPositiveNumber(right.version) ||
-    messageOrderTime(left) - messageOrderTime(right) ||
     normalizedPositiveNumber(left.id) - normalizedPositiveNumber(right.id) ||
     (left.version ?? 0) - (right.version ?? 0) ||
     left.messageId.localeCompare(right.messageId)
@@ -292,10 +289,12 @@ function normalizedPositiveNumber(value: number | undefined): number {
     : 0;
 }
 
-function messageOrderTime(message: WorkspaceAgentActivityMessage): number {
+function messageDisplayOrderTime(
+  message: WorkspaceAgentActivityMessage
+): number {
   return (
-    normalizedPositiveNumber(message.occurredAtUnixMs) ||
     normalizedPositiveNumber(message.startedAtUnixMs) ||
+    normalizedPositiveNumber(message.occurredAtUnixMs) ||
     normalizedPositiveNumber(message.completedAtUnixMs)
   );
 }


### PR DESCRIPTION
## Summary

- Order AgentGUI durable message projection by display time derived from `startedAtUnixMs` first, with existing version/id fallbacks for ties.
- Use the same start-time-first value as the projected timeline item timestamp so late-completing tool calls stay before the final assistant response in old and new conversations.
- Scope the transient processing row identity to the latest turn so a new running turn does not reuse the previous turn's loading row identity.
- Add regression coverage for both late-completing tool calls and turn-scoped processing rows.

## Verification

- `pnpm --filter @tutti-os/agent-gui exec oxfmt --check packages/agent/gui/shared/agentConversation/projection/workspaceAgentMessageProjection.ts packages/agent/gui/shared/agentConversation/projection/workspaceAgentMessageProjection.spec.ts`
- `pnpm --filter @tutti-os/agent-gui exec vitest run shared/agentConversation/projection/workspaceAgentMessageProjection.spec.ts`
- `pnpm --filter @tutti-os/agent-gui exec oxfmt --check shared/agentConversation/projection/agentProcessingProjection.ts shared/agentConversation/projection/agentConversationProjection.spec.ts`
- `pnpm --filter @tutti-os/agent-gui exec vitest run shared/agentConversation/projection/agentConversationProjection.spec.ts`
- `pnpm check:full`

## Checklist

- [x] I kept the change focused on one concern.
- [x] I updated documentation when behavior, setup, or contributor workflow changed. No durable docs were needed for these projection-only display fixes; behavior is covered by regression tests.
- [x] I updated all README/CONTRIBUTING language variants when changing their English source. Not applicable.
- [x] I ran the lowest meaningful local checks for the changed surface.
- [x] My commits are signed off with DCO when required: `git commit -s`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved conversation message ordering so tool-call rows and the final assistant response appear in the correct sequence, including when tool completion is delayed.
  * Updated the timestamp logic used for display ordering to better match what users see in the timeline.
  * Fixed the “processing” indicator so it’s tied to the latest turn rather than a generic session marker.
* **Tests**
  * Added test coverage for ordering with late-completed tool calls.
  * Added test coverage ensuring the processing indicator targets the most recent turn.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->