### PR TITLE
fix(agent): carry model description into composer runtime options

### DIFF
--- a/services/tuttid/service/agent/composer_live_model_discovery.go
+++ b/services/tuttid/service/agent/composer_live_model_discovery.go
@@ -407,10 +407,17 @@ func composerConfigOptionValuesToRuntimeModelOptions(options []ComposerConfigOpt
 		if label == "" {
 			label = value
 		}
-		result = append(result, map[string]string{
+		entry := map[string]string{
 			"name":  label,
 			"value": value,
-		})
+		}
+		// Carry the per-model description through to RuntimeContext. The desktop
+		// composer projection prefers this live model list over ModelConfig.Options,
+		// so dropping the description here removes the model hover detail.
+		if description := strings.TrimSpace(option.Description); description != "" {
+			entry["description"] = description
+		}
+		result = append(result, entry)
 	}
 	return result
 }

--- a/services/tuttid/service/agent/composer_live_model_discovery_test.go
+++ b/services/tuttid/service/agent/composer_live_model_discovery_test.go
@@ -56,6 +56,36 @@ func TestMergeLiveModelsIntoComposerOptionsUpdatesRuntimeContext(t *testing.T) {
 	}
 }
 
+func TestMergeLiveModelsIntoComposerOptionsKeepsModelDescriptionInRuntimeContext(t *testing.T) {
+	// Regression: the desktop composer projection prefers the model list in
+	// RuntimeContext["configOptions"] over ModelConfig.Options, so the per-model
+	// description must survive into the runtime configOptions or the hover
+	// detail disappears.
+	merged := mergeLiveModelsIntoComposerOptions(ComposerOptions{
+		Provider:          "claude-code",
+		EffectiveSettings: ComposerSettings{Model: "default"},
+		RuntimeContext:    map[string]any{},
+	}, []ComposerConfigOptionValue{
+		{ID: "default", Label: "Default", Value: "default", Description: "Opus 4.8 with 1M context · Best for everyday, complex tasks"},
+		{ID: "sonnet", Label: "Sonnet", Value: "sonnet", Description: "Sonnet 4.6 · Efficient for routine tasks"},
+	})
+
+	configOptions, ok := merged.RuntimeContext["configOptions"].([]map[string]any)
+	if !ok || len(configOptions) == 0 || configOptions[0]["id"] != "model" {
+		t.Fatalf("configOptions = %#v, want model option", merged.RuntimeContext["configOptions"])
+	}
+	options, ok := configOptions[0]["options"].([]map[string]string)
+	if !ok || len(options) != 2 {
+		t.Fatalf("model options = %#v, want 2 entries", configOptions[0]["options"])
+	}
+	if got := options[0]["description"]; got != "Opus 4.8 with 1M context · Best for everyday, complex tasks" {
+		t.Fatalf("default description = %q, want the Opus description", got)
+	}
+	if got := options[1]["description"]; got != "Sonnet 4.6 · Efficient for routine tasks" {
+		t.Fatalf("sonnet description = %q, want the Sonnet description", got)
+	}
+}
+
 func TestMergeLiveModelsIntoComposerOptionsDoesNotAppendUnsupportedSelectedModel(t *testing.T) {
 	merged := mergeLiveModelsIntoComposerOptions(ComposerOptions{
 		Provider: "claude-code",


### PR DESCRIPTION
## Problem

The agent composer model picker shows model labels (Default / Opus / Sonnet / Sonnet / Haiku) but **no hover detail** — the per-model description / context-window / version tooltip is gone.

## Root cause

The desktop composer projection (`agentComposerOptionsProjection.ts`) **prefers the live model list in `RuntimeContext["configOptions"]` over `ModelConfig.Options`**:

```ts
models: modelsFromLiveConfig.length > 0 ? modelsFromLiveConfig : modelsFromConfig
```

But `composerConfigOptionValuesToRuntimeModelOptions` (the builder for that runtime model list) emitted only `name` + `value` and **dropped `description`**. So the source the GUI actually uses had no description → `option.description` empty → `modelOptionPresentation` produces `tooltip: undefined` → the hover detail never renders. `ModelConfig.Options` *did* carry the descriptions, but the projection never falls back to it because the live list is non-empty.

### Evidence

End-to-end daemon logging confirmed the description is present at every backend checkpoint — ACP input, daemon RuntimeContext, live-discovery extract/normalize, and the final `GetComposerOptions` `ModelConfig.Options` (all `descLen=60`) — yet the runtime `configOptions` model entries the GUI prefers carried none. claude-agent-acp 0.46 itself advertises descriptions (verified by directly driving the ACP handshake), so this was purely a tutti-side field drop.

## Fix

Carry the per-model `description` through into the runtime model options so the source the GUI prefers matches `ModelConfig.Options`. No change to the projection's "prefer live list" design; no effect on providers without descriptions (e.g. Codex).

## Test

Added `TestMergeLiveModelsIntoComposerOptionsKeepsModelDescriptionInRuntimeContext` (RED before the fix, GREEN after). `go build` + `go test ./services/tuttid/service/agent/` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Preserved model descriptions in runtime option data, so hover and detail information now appears correctly for available model choices.
  * Added a regression test to ensure model descriptions remain included in the runtime context.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->