### PR TITLE
fix(desktop): publish release after assets are ready

### DIFF
--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -382,13 +382,14 @@ jobs:
             echo "TUTTI_DESKTOP_RELEASE_ASSETS_BASE_URL=https://${TUTTI_DESKTOP_RELEASE_ASSETS_S3_BUCKET}.s3-accelerate.amazonaws.com/${TUTTI_DESKTOP_RELEASE_ASSETS_S3_PREFIX%/}" >> "$GITHUB_ENV"
           fi
 
-      - name: Publish GitHub release
+      - name: Stage GitHub release assets
         uses: softprops/action-gh-release@v2
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           tag_name: ${{ env.TUTTI_DESKTOP_RELEASE_TAG }}
           target_commitish: ${{ env.TUTTI_DESKTOP_RELEASE_TARGET }}
           name: ${{ env.TUTTI_DESKTOP_RELEASE_TAG }}
+          draft: true
           prerelease: ${{ needs.resolve.outputs.release_prerelease == 'true' }}
           make_latest: ${{ needs.resolve.outputs.release_make_latest == 'true' }}
           generate_release_notes: true
@@ -443,6 +444,17 @@ jobs:
             release-assets \
             updated-release-body.md
           gh release edit "${TUTTI_DESKTOP_RELEASE_TAG}" --notes-file updated-release-body.md
+
+      - name: Publish GitHub release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TUTTI_DESKTOP_RELEASE_MAKE_LATEST: ${{ needs.resolve.outputs.release_make_latest }}
+        run: |
+          args=(gh release edit "${TUTTI_DESKTOP_RELEASE_TAG}" --draft=false)
+          if [[ "${TUTTI_DESKTOP_RELEASE_MAKE_LATEST}" == "true" ]]; then
+            args+=(--latest)
+          fi
+          "${args[@]}"
 
   notify-feishu:
     name: Notify Feishu

--- a/tools/scripts/desktop-release-config.test.mjs
+++ b/tools/scripts/desktop-release-config.test.mjs
@@ -201,6 +201,33 @@ test("desktop release workflow can mirror release assets to S3 and upsert direct
   );
 });
 
+test("desktop release workflow keeps GitHub release draft until assets are ready", async () => {
+  const workflow = await readFile(workflowPath, "utf8");
+  const publishJobMatch = workflow.match(
+    /publish:[\s\S]*?(?=\n\s{2}[a-z][a-z0-9_-]+:\n|$)/
+  );
+
+  assert.ok(publishJobMatch, "publish job should exist");
+  const publishJob = publishJobMatch[0];
+  const stageIndex = publishJob.indexOf("name: Stage GitHub release assets");
+  const s3Index = publishJob.indexOf("name: Upload release assets to AWS S3");
+  const notesIndex = publishJob.indexOf(
+    "name: Update release notes with direct downloads"
+  );
+  const publishIndex = publishJob.indexOf("name: Publish GitHub release");
+
+  assert.notEqual(stageIndex, -1, "release assets should be staged");
+  assert.notEqual(publishIndex, -1, "release should be published explicitly");
+  assert.match(publishJob, /draft:\s*true/);
+  assert.match(
+    publishJob,
+    /gh release edit "\$\{TUTTI_DESKTOP_RELEASE_TAG\}" --draft=false/
+  );
+  assert.ok(stageIndex < s3Index);
+  assert.ok(s3Index < notesIndex);
+  assert.ok(notesIndex < publishIndex);
+});
+
 test("desktop release workflow publishes only macOS release assets for now", async () => {
   const workflow = await readFile(workflowPath, "utf8");
   const publishJobMatch = workflow.match(


### PR DESCRIPTION
## Summary
- keep desktop GitHub releases as draft while uploading release assets
- publish the release only after S3/latest metadata and release notes are ready
- add workflow coverage for the draft-to-publish ordering

## Why
The exported logs showed the updater checking v0.1.4-rc.54 while latest-mac.yml was still unavailable, causing a 404 during update detection. Publishing only after assets are ready prevents updater clients from seeing a partial release.

## Verification
- node --test tools/scripts/desktop-release-config.test.mjs
- git diff --check
- pre-push check:full was attempted, but local test:go failed in unrelated existing tests: services/tuttid/app logging temp-file reads and services/tuttid/types development-root assertion under this local Tutti production environment.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Desktop releases are now staged before publishing, helping ensure download links and release assets are ready before the release goes live.
  * Release publication now happens explicitly after asset uploads and notes updates, improving release consistency.

* **Tests**
  * Added coverage for the desktop release flow to verify staging, upload order, and final publication behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->