### PR TITLE
[codex] Preserve resource picker output timestamps

### DIFF
--- a/apps/desktop/src/renderer/src/features/agent-reference-sources/issueReferenceListBackend.ts
+++ b/apps/desktop/src/renderer/src/features/agent-reference-sources/issueReferenceListBackend.ts
@@ -123,6 +123,7 @@ export function createIssueReferenceListBackend(
       const items: ReferenceListItem[] = detail.latestOutputs.map((output) => ({
         type: "reference",
         reference: {
+          createdTimeMs: unixSecondsToMs(output.createdAtUnix),
           path: output.path,
           displayName: output.displayName,
           parentLabel: issueLabel,
@@ -161,6 +162,7 @@ export function createIssueReferenceListBackend(
       const items: ReferenceListItem[] = response.items.map((hit) => ({
         type: "reference",
         reference: {
+          createdTimeMs: unixSecondsToMs(hit.output.createdAtUnix),
           path: hit.output.path,
           displayName: hit.output.displayName,
           parentLabel: hit.issueTitle?.trim() || hit.output.issueId,

--- a/apps/desktop/src/renderer/src/features/agent-reference-sources/workspaceFileLocationReferenceSources.test.ts
+++ b/apps/desktop/src/renderer/src/features/agent-reference-sources/workspaceFileLocationReferenceSources.test.ts
@@ -199,6 +199,36 @@ test("location reference source scopes directory search by selected location", a
   assert.deepEqual(withinValues, ["/Users/local/repo"]);
 });
 
+test("location reference source preserves creation times on search results", async () => {
+  const adapter: WorkspaceFileReferenceAdapter = {
+    async searchReferences() {
+      return [
+        {
+          createdTimeMs: 1_800_000_000_000,
+          kind: "file",
+          mtimeMs: 1_800_000_001_000,
+          path: "/Users/local/report.md"
+        }
+      ];
+    }
+  };
+  const [, localSource] = createWorkspaceFileLocationReferenceSources({
+    adapter,
+    getLocationSections: () => locationSections,
+    localLabel: "Local",
+    projectLabel: "Project"
+  });
+
+  const result = await localSource?.search?.(
+    { workspaceId: "workspace-1" },
+    {
+      query: "report"
+    }
+  );
+
+  assert.equal(result?.entries[0]?.createdTimeMs, 1_800_000_000_000);
+});
+
 const locationSections: WorkspaceFileLocationSection[] = [
   {
     id: "project",

--- a/apps/desktop/src/renderer/src/features/agent-reference-sources/workspaceFileLocationReferenceSources.ts
+++ b/apps/desktop/src/renderer/src/features/agent-reference-sources/workspaceFileLocationReferenceSources.ts
@@ -86,6 +86,9 @@ function createLocationReferenceSource(input: {
       kind,
       displayName: ref.displayName?.trim() || basename(ref.path),
       ...(kind === "folder" ? { hasChildren: true } : {}),
+      ...(ref.createdTimeMs == null
+        ? {}
+        : { createdTimeMs: ref.createdTimeMs }),
       ...(ref.sizeBytes == null ? {} : { sizeBytes: ref.sizeBytes }),
       ...(ref.mtimeMs == null ? {} : { mtimeMs: ref.mtimeMs })
     };

--- a/apps/desktop/src/renderer/src/features/agent-reference-sources/workspaceFileReferenceSource.ts
+++ b/apps/desktop/src/renderer/src/features/agent-reference-sources/workspaceFileReferenceSource.ts
@@ -75,6 +75,9 @@ export function createWorkspaceFileReferenceSource(input: {
       kind,
       displayName: ref.displayName?.trim() || basename(ref.path),
       ...(kind === "folder" ? { hasChildren: true } : {}),
+      ...(ref.createdTimeMs == null
+        ? {}
+        : { createdTimeMs: ref.createdTimeMs }),
       ...(ref.sizeBytes == null ? {} : { sizeBytes: ref.sizeBytes }),
       ...(ref.mtimeMs == null ? {} : { mtimeMs: ref.mtimeMs })
     };

--- a/apps/desktop/src/renderer/src/features/workspace-file-manager/services/createDesktopWorkspaceFileReferenceAdapter.test.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-file-manager/services/createDesktopWorkspaceFileReferenceAdapter.test.ts
@@ -136,6 +136,39 @@ test("desktop workspace file reference adapter passes search abort signals to tu
   assert.equal(observedSignal, abortController.signal);
 });
 
+test("desktop workspace file reference adapter preserves file creation times from search", async () => {
+  const adapter = createDesktopWorkspaceFileReferenceAdapter({
+    hostFilesApi: {} as DesktopHostFilesApi,
+    tuttidClient: {
+      async searchWorkspaceFiles() {
+        return {
+          entries: [
+            {
+              createdTimeMs: 1_800_000_000_000,
+              kind: "file",
+              lastOpenedMs: null,
+              mtimeMs: 1_800_000_001_000,
+              name: "prd.md",
+              path: "/Users/test/prd.md",
+              sizeBytes: 42
+            }
+          ],
+          root: "/Users/test",
+          workspaceId: "workspace-1"
+        };
+      }
+    } as unknown as TuttidClient,
+    workspaceId: "workspace-1"
+  });
+
+  const refs = await adapter.searchReferences?.({
+    query: "prd",
+    workspaceId: "workspace-1"
+  });
+
+  assert.equal(refs?.[0]?.createdTimeMs, 1_800_000_000_000);
+});
+
 test("desktop workspace file reference adapter opens previewable files with the canvas preview first", async () => {
   const calls: string[] = [];
   const adapter = createDesktopWorkspaceFileReferenceAdapter({

--- a/apps/desktop/src/renderer/src/features/workspace-file-manager/services/createDesktopWorkspaceFileReferenceAdapter.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-file-manager/services/createDesktopWorkspaceFileReferenceAdapter.ts
@@ -173,6 +173,7 @@ export function createDesktopWorkspaceFileReferenceAdapter(input: {
 }
 
 export function mapDesktopWorkspaceFileReferenceEntry(entry: {
+  createdTimeMs?: number | null;
   kind: string;
   mtimeMs?: number | null;
   name?: string;
@@ -201,6 +202,7 @@ function mapReferenceTreeDirectory(
 }
 
 type ReferenceTreeTransportEntry = {
+  createdTimeMs?: number | null;
   hasChildren?: boolean;
   kind: string;
   mtimeMs?: number | null;
@@ -230,12 +232,16 @@ function mapReferenceTreeEntry(
     prefetchedDirectory: entry.prefetchedDirectory
       ? mapReferenceTreeDirectory(entry.prefetchedDirectory)
       : null,
+    ...(entry.createdTimeMs === undefined
+      ? {}
+      : { createdTimeMs: entry.createdTimeMs }),
     ...(entry.mtimeMs === undefined ? {} : { mtimeMs: entry.mtimeMs }),
     ...(entry.sizeBytes === undefined ? {} : { sizeBytes: entry.sizeBytes })
   };
 }
 
 function mapFileReferenceEntry(entry: {
+  createdTimeMs?: number | null;
   kind: string;
   mtimeMs?: number | null;
   name?: string;
@@ -246,6 +252,9 @@ function mapFileReferenceEntry(entry: {
     displayName: entry.name,
     kind: entry.kind === "directory" ? "folder" : "file",
     path: entry.path,
+    ...(entry.createdTimeMs === undefined
+      ? {}
+      : { createdTimeMs: entry.createdTimeMs }),
     ...(entry.mtimeMs === undefined ? {} : { mtimeMs: entry.mtimeMs }),
     ...(entry.sizeBytes === undefined ? {} : { sizeBytes: entry.sizeBytes })
   };
@@ -255,6 +264,7 @@ function referenceToWorkspaceFileEntry(
   reference: WorkspaceFileReference
 ): WorkspaceFileEntry {
   return {
+    createdTimeMs: reference.createdTimeMs ?? null,
     hasChildren: reference.kind === "folder",
     kind: reference.kind === "folder" ? "directory" : "file",
     mtimeMs: reference.mtimeMs ?? null,

--- a/packages/workspace/file-reference/src/contracts/index.ts
+++ b/packages/workspace/file-reference/src/contracts/index.ts
@@ -1,6 +1,7 @@
 import type { WorkspaceFileOpenWithApplication } from "@tutti-os/workspace-file-manager/services";
 
 export interface WorkspaceFileReference {
+  createdTimeMs?: number | null;
   displayName?: string;
   hostPath?: string;
   kind: "file" | "folder" | (string & {});

--- a/packages/workspace/file-reference/src/contracts/referenceSource.ts
+++ b/packages/workspace/file-reference/src/contracts/referenceSource.ts
@@ -39,6 +39,7 @@ export interface ReferenceNode {
   childCount?: number | null;
   /** 可选图标(data URL / 远程 URL),如应用产物源的 app 图标;有则替代默认文件夹图标。 */
   iconUrl?: string | null;
+  createdTimeMs?: number | null;
   sizeBytes?: number | null;
   mtimeMs?: number | null;
   mimeType?: string | null;

--- a/packages/workspace/file-reference/src/core/index.ts
+++ b/packages/workspace/file-reference/src/core/index.ts
@@ -18,6 +18,9 @@ export function uniqueWorkspaceFileReferences(
       displayName: ref.displayName?.trim() || undefined,
       kind: ref.kind === "folder" ? "folder" : "file",
       path: normalizedPath,
+      ...(ref.createdTimeMs === undefined
+        ? {}
+        : { createdTimeMs: ref.createdTimeMs }),
       ...(ref.mtimeMs === undefined ? {} : { mtimeMs: ref.mtimeMs }),
       ...(ref.sizeBytes === undefined ? {} : { sizeBytes: ref.sizeBytes })
     });

--- a/packages/workspace/file-reference/src/core/referenceListSource.ts
+++ b/packages/workspace/file-reference/src/core/referenceListSource.ts
@@ -44,6 +44,7 @@ export interface ReferenceListFile {
    * 各源在「跨整源搜索拍平」时填入父级上下文;不填则副标题回退展示 nodeId。
    */
   parentLabel?: string | null;
+  createdTimeMs?: number | null;
   sizeBytes?: number | null;
   mtimeMs?: number | null;
   mimeType?: string | null;
@@ -324,6 +325,9 @@ function itemToNode(sourceId: string, item: ReferenceListItem): ReferenceNode {
     ...(reference.parentLabel?.trim()
       ? { contextLabel: reference.parentLabel.trim() }
       : {}),
+    ...(reference.createdTimeMs == null
+      ? {}
+      : { createdTimeMs: reference.createdTimeMs }),
     ...(reference.sizeBytes == null ? {} : { sizeBytes: reference.sizeBytes }),
     ...(reference.mtimeMs == null ? {} : { mtimeMs: reference.mtimeMs }),
     ...(reference.mimeType ? { mimeType: reference.mimeType } : {})

--- a/packages/workspace/file-reference/src/ui/internal/reference/ReferenceSourcePicker.tsx
+++ b/packages/workspace/file-reference/src/ui/internal/reference/ReferenceSourcePicker.tsx
@@ -70,6 +70,7 @@ import {
 import {
   formatReferenceNodePathText,
   formatReferencePreviewDateTime,
+  resolveReferencePreviewTimestampMs,
   resolveReferencePreviewSizeBytes
 } from "./referenceSourcePickerPresentation.ts";
 
@@ -1030,6 +1031,7 @@ function PreviewInfoPane({
   const sizeBytes = node
     ? resolveReferencePreviewSizeBytes(node, previewState)
     : null;
+  const timestampMs = node ? resolveReferencePreviewTimestampMs(node) : null;
   return (
     <aside className="flex h-full min-h-0 w-full flex-col bg-[var(--background-fronted)]">
       {node ? (
@@ -1072,9 +1074,9 @@ function PreviewInfoPane({
                 {sourceLabel}
               </Badge>
             </InfoRow>
-            {node.mtimeMs != null ? (
+            {timestampMs != null ? (
               <InfoRow label={copy.t("referencePicker.previewModified")}>
-                {formatReferencePreviewDateTime(node.mtimeMs)}
+                {formatReferencePreviewDateTime(timestampMs)}
               </InfoRow>
             ) : null}
             {sizeBytes != null ? (

--- a/packages/workspace/file-reference/src/ui/internal/reference/referenceSourcePickerPresentation.test.ts
+++ b/packages/workspace/file-reference/src/ui/internal/reference/referenceSourcePickerPresentation.test.ts
@@ -6,6 +6,7 @@ import {
   formatHierarchyTitle,
   formatReferenceNodePathText,
   formatReferencePreviewDateTime,
+  resolveReferencePreviewTimestampMs,
   resolveReferencePreviewSizeBytes
 } from "./referenceSourcePickerPresentation.ts";
 
@@ -69,6 +70,29 @@ test("formatReferencePreviewDateTime formats timestamps in the requested user ti
     }),
     "2026-06-12 11:24"
   );
+});
+
+test("resolveReferencePreviewTimestampMs prefers creation time over modified time", () => {
+  const node = {
+    createdTimeMs: 1_800_000_000_000,
+    displayName: "prd.md",
+    kind: "file",
+    mtimeMs: 1_800_000_001_000,
+    ref: { sourceId: "workspace-file", nodeId: "f:prd.md" }
+  } satisfies ReferenceNode;
+
+  assert.equal(resolveReferencePreviewTimestampMs(node), 1_800_000_000_000);
+});
+
+test("resolveReferencePreviewTimestampMs falls back to modified time", () => {
+  const node = {
+    displayName: "prd.md",
+    kind: "file",
+    mtimeMs: 1_800_000_001_000,
+    ref: { sourceId: "workspace-file", nodeId: "f:prd.md" }
+  } satisfies ReferenceNode;
+
+  assert.equal(resolveReferencePreviewTimestampMs(node), 1_800_000_001_000);
 });
 
 test("resolveReferencePreviewSizeBytes prefers loaded preview bytes over zero metadata", () => {

--- a/packages/workspace/file-reference/src/ui/internal/reference/referenceSourcePickerPresentation.ts
+++ b/packages/workspace/file-reference/src/ui/internal/reference/referenceSourcePickerPresentation.ts
@@ -55,6 +55,15 @@ export function formatReferencePreviewDateTime(
   return `${parts.year}-${parts.month}-${parts.day} ${parts.hour}:${parts.minute}`;
 }
 
+export function resolveReferencePreviewTimestampMs(
+  node: Pick<ReferenceNode, "createdTimeMs" | "mtimeMs">
+): number | null {
+  return (
+    normalizedTimestampMs(node.createdTimeMs) ??
+    normalizedTimestampMs(node.mtimeMs)
+  );
+}
+
 export function resolveReferencePreviewSizeBytes(
   node: ReferenceNode,
   previewState: {
@@ -78,6 +87,10 @@ export function resolveReferencePreviewSizeBytes(
     }
   }
   return metadataSize;
+}
+
+function normalizedTimestampMs(ms: number | null | undefined): number | null {
+  return typeof ms === "number" && Number.isFinite(ms) && ms >= 0 ? ms : null;
 }
 
 function completeHierarchy(


### PR DESCRIPTION
## Summary
- Preserve `createdTimeMs` across workspace file reference contracts, desktop adapters, and source mappings.
- Prefer creation/output time in the resource picker preview panel, with modified time as fallback.
- Add regression coverage for desktop adapter mapping, location source search results, and preview timestamp selection.

## Root Cause
Search results had file creation/output time available from the daemon, but the desktop/shared resource picker mapping dropped it before building `ReferenceNode`, so the detail panel had no timestamp to render.

## Validation
- `git diff --check`
- `pnpm --filter @tutti-os/desktop exec node --test --experimental-strip-types src/renderer/src/features/workspace-file-manager/services/createDesktopWorkspaceFileReferenceAdapter.test.ts src/renderer/src/features/agent-reference-sources/workspaceFileLocationReferenceSources.test.ts`
- `pnpm --filter @tutti-os/workspace-file-reference test -- src/ui/internal/reference/referenceSourcePickerPresentation.test.ts`
- `pnpm --filter @tutti-os/workspace-file-reference typecheck`
- `pnpm check:changed --tail-lines 80`

## Note
- Local pre-push `pnpm check:full` was attempted but failed in unrelated Go tests: `services/tuttid/service/agentstatus` (`TestServiceListReportsCodexChecksVersionAndLastError`) and `services/tuttid/types` (`TestTuttidDerivedPathsUseDevelopmentRoot`). This branch only changes TypeScript/React resource picker files.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Reference items and workspace file entries now retain file creation time when available.
  * Preview details now prefer creation time for the displayed timestamp, falling back to modified time when needed.

* **Bug Fixes**
  * Fixed timestamp loss while searching and listing references.
  * Improved consistency so creation time is preserved across reference browsing and preview rendering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->