### PR TITLE
fix(terminal,codex): IME composition leak fix and goal continuation loop

### DIFF
--- a/docs/conventions/troubleshooting.md
+++ b/docs/conventions/troubleshooting.md
@@ -362,6 +362,37 @@ delimited by ---`, and the composer skill picker may show partial or
   [WorkspaceFileReferencePickerTree.tsx](../../packages/workspace/file-reference/src/ui/internal/reference/WorkspaceFileReferencePickerTree.tsx:131)
   [IssueManagerSidebarSections.tsx](../../packages/workspace/issue-manager/src/ui/internal/shell/IssueManagerSidebarSections.tsx:190)
 
+### IME composition leaks native input into xterm terminals
+
+- Symptom:
+  Chinese, Japanese, or Korean text appears in a workspace terminal, but using
+  Space or Enter to commit the candidate sends extra or strange input into the
+  PTY, leaving the shell prompt or terminal display in an unexpected state.
+- Quick checks:
+  Inspect custom `attachCustomKeyEventHandler` logic before suspecting the PTY
+  or websocket encoding. In xterm 6, the custom key handler runs before
+  `CompositionHelper.keydown`; returning `false` skips that xterm path but does
+  not automatically prevent the browser's hidden textarea from receiving native
+  input.
+- Root cause:
+  A guard that suppresses a post-composition commit key by only returning
+  `false` can still allow the browser default action to mutate xterm's textarea.
+  The later xterm `input` or delayed composition send can then forward polluted
+  textarea content as terminal input.
+- Fix:
+  During active composition, do not call `preventDefault`; the browser and IME
+  need native composition behavior. For post-composition commit-key suppression,
+  call `preventDefault` and `stopPropagation` before returning `false`, and keep
+  the short suppression window open for repeated native key events.
+- Validation:
+  Add unit coverage that active composition is not prevented, post-composition
+  commit keys are prevented, and repeated native key events within the window
+  stay suppressed. Manually verify Chinese IME candidate commit with Space and
+  Enter in the workspace terminal.
+- References:
+  [terminalImeInputGuard.ts](../../packages/workspace/terminal/src/react/terminalImeInputGuard.ts)
+  [terminalSurfaceRuntime.ts](../../packages/workspace/terminal/src/react/terminalSurfaceRuntime.ts)
+
 ### Agent GUI app mentions show unavailable workspace apps
 
 - Symptom:

--- a/packages/agent/daemon/runtime/codex_appserver_adapter.go
+++ b/packages/agent/daemon/runtime/codex_appserver_adapter.go
@@ -1447,8 +1447,12 @@ func (a *CodexAppServerAdapter) awaitGoalOperationCompletion(
 			nextInitialTurn = nextTurn
 			continue
 		}
-		if err := a.requestActiveGoalContinuation(ctx, appSession, session, turnID, normalizer, emitEvents, emitCommands); err != nil {
+		continued, err = a.requestActiveGoalContinuation(ctx, appSession, session, turnID, normalizer, emitEvents, emitCommands)
+		if err != nil {
 			return nil, err
+		}
+		if !continued {
+			return finalTurn, nil
 		}
 		nextInitialTurn = nil
 	}
@@ -1502,10 +1506,10 @@ func (a *CodexAppServerAdapter) requestActiveGoalContinuation(
 	normalizer *acpTurnNormalizer,
 	emitEvents func([]activityshared.Event),
 	emitCommands CommandSnapshotSink,
-) error {
+) (bool, error) {
 	goal := a.sessionGoal(session.AgentSessionID)
 	if strings.TrimSpace(asString(goal["status"])) != "active" {
-		return nil
+		return false, nil
 	}
 	params := map[string]any{
 		"threadId": appSession.threadID,
@@ -1521,12 +1525,12 @@ func (a *CodexAppServerAdapter) requestActiveGoalContinuation(
 		a.appServerMessageHandler(appSession, session, turnID, normalizer, emitEvents, emitCommands),
 	)
 	if err != nil {
-		return err
+		return true, err
 	}
 	if nextGoal := appServerGoalFromResult(result); len(nextGoal) > 0 {
 		a.applyGoalUpdate(session.AgentSessionID, nextGoal)
 	}
-	return nil
+	return true, nil
 }
 
 func (a *CodexAppServerAdapter) Cancel(ctx context.Context, session Session, reason string) ([]activityshared.Event, error) {

--- a/packages/agent/daemon/runtime/codex_appserver_adapter.go
+++ b/packages/agent/daemon/runtime/codex_appserver_adapter.go
@@ -92,6 +92,7 @@ const codexAppServerAuthRequiredMessage = "Codex requires authentication. " +
 // defaultCodexAppServerCancelGraceWindow is how long Cancel waits for codex to
 // honor turn/interrupt gracefully before force-closing the app-server process.
 const defaultCodexAppServerCancelGraceWindow = 3 * time.Second
+const defaultCodexAppServerGoalContinuationGraceWindow = 100 * time.Millisecond
 
 type CodexAppServerAdapter struct {
 	transport   ProcessTransport
@@ -1353,7 +1354,17 @@ func (a *CodexAppServerAdapter) execSlashCommand(
 					a.interruptActiveTurnAsync(appSession, session, appTurn, providerTurnID, "queued cancel")
 				}
 			}
-			finalTurn, finishErr := a.awaitTurnCompletion(ctx, appSession, appTurn, initialTurn)
+			finalTurn, finishErr := a.awaitGoalOperationCompletion(
+				ctx,
+				appSession,
+				session,
+				turnID,
+				appTurn,
+				initialTurn,
+				normalizer,
+				emitEvents,
+				emitCommands,
+			)
 			a.endActiveTurn(session.AgentSessionID, appTurn)
 			if finishErr != nil {
 				if errors.Is(finishErr, context.Canceled) || errors.Is(finishErr, errPermissionRequestCanceled) || a.turnForceCanceled(appTurn) {
@@ -1404,6 +1415,118 @@ func (a *CodexAppServerAdapter) execSlashCommand(
 	default:
 		return false, nil
 	}
+}
+
+func (a *CodexAppServerAdapter) awaitGoalOperationCompletion(
+	ctx context.Context,
+	appSession *codexAppServerSession,
+	session Session,
+	turnID string,
+	appTurn *codexAppServerActiveTurn,
+	initialTurn map[string]any,
+	normalizer *acpTurnNormalizer,
+	emitEvents func([]activityshared.Event),
+	emitCommands CommandSnapshotSink,
+) (map[string]any, error) {
+	nextInitialTurn := initialTurn
+	for {
+		finalTurn, err := a.awaitTurnCompletion(ctx, appSession, appTurn, nextInitialTurn)
+		if err != nil {
+			return nil, err
+		}
+		if !a.shouldContinueActiveGoalAfterTurn(session.AgentSessionID, finalTurn) {
+			return finalTurn, nil
+		}
+		normalizer.ApplyAssistantFinalText(appServerTurnFinalAssistantText(finalTurn))
+		emitEvents(normalizer.FinishCompleted(session, turnID))
+		nextTurn, continued, err := a.waitForAutomaticGoalContinuation(ctx, session.AgentSessionID, appTurn)
+		if err != nil {
+			return nil, err
+		}
+		if continued {
+			nextInitialTurn = nextTurn
+			continue
+		}
+		if err := a.requestActiveGoalContinuation(ctx, appSession, session, turnID, normalizer, emitEvents, emitCommands); err != nil {
+			return nil, err
+		}
+		nextInitialTurn = nil
+	}
+}
+
+func (a *CodexAppServerAdapter) waitForAutomaticGoalContinuation(
+	ctx context.Context,
+	agentSessionID string,
+	appTurn *codexAppServerActiveTurn,
+) (map[string]any, bool, error) {
+	timer := time.NewTimer(defaultCodexAppServerGoalContinuationGraceWindow)
+	defer timer.Stop()
+	select {
+	case finalTurn := <-appTurn.done:
+		return finalTurn, true, nil
+	case <-ctx.Done():
+		return nil, false, ctx.Err()
+	case <-timer.C:
+		if a.sessionActiveTurnID(agentSessionID) != "" {
+			return nil, true, nil
+		}
+		return nil, false, nil
+	}
+}
+
+func (a *CodexAppServerAdapter) shouldContinueActiveGoalAfterTurn(agentSessionID string, turn map[string]any) bool {
+	if strings.TrimSpace(asString(turn["status"])) != "completed" {
+		return false
+	}
+	return strings.TrimSpace(asString(a.sessionGoal(agentSessionID)["status"])) == "active"
+}
+
+func (a *CodexAppServerAdapter) sessionGoal(agentSessionID string) map[string]any {
+	if a == nil {
+		return nil
+	}
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	appSession := a.sessions[strings.TrimSpace(agentSessionID)]
+	if appSession == nil {
+		return nil
+	}
+	return clonePayload(appSession.goal)
+}
+
+func (a *CodexAppServerAdapter) requestActiveGoalContinuation(
+	ctx context.Context,
+	appSession *codexAppServerSession,
+	session Session,
+	turnID string,
+	normalizer *acpTurnNormalizer,
+	emitEvents func([]activityshared.Event),
+	emitCommands CommandSnapshotSink,
+) error {
+	goal := a.sessionGoal(session.AgentSessionID)
+	if strings.TrimSpace(asString(goal["status"])) != "active" {
+		return nil
+	}
+	params := map[string]any{
+		"threadId": appSession.threadID,
+		"status":   "active",
+	}
+	if objective := strings.TrimSpace(asStringRaw(goal["objective"])); objective != "" {
+		params["objective"] = objective
+	}
+	result, err := appSession.client.Call(
+		ctx,
+		appServerMethodThreadGoalSet,
+		params,
+		a.appServerMessageHandler(appSession, session, turnID, normalizer, emitEvents, emitCommands),
+	)
+	if err != nil {
+		return err
+	}
+	if nextGoal := appServerGoalFromResult(result); len(nextGoal) > 0 {
+		a.applyGoalUpdate(session.AgentSessionID, nextGoal)
+	}
+	return nil
 }
 
 func (a *CodexAppServerAdapter) Cancel(ctx context.Context, session Session, reason string) ([]activityshared.Event, error) {

--- a/packages/agent/daemon/runtime/codex_appserver_adapter_test.go
+++ b/packages/agent/daemon/runtime/codex_appserver_adapter_test.go
@@ -4,6 +4,7 @@ package agentruntime
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"io"
 	"strings"
 	"sync"
@@ -37,7 +38,8 @@ func newScriptedAppServerTransport() *scriptedAppServerTransport {
 
 func newScriptedAppServerConnection() *scriptedAppServerConnection {
 	return &scriptedAppServerConnection{
-		recv: make(chan ProcessFrame, 128),
+		recv:                     make(chan ProcessFrame, 128),
+		goalCompletionAfterTurns: 1,
 	}
 }
 
@@ -73,6 +75,8 @@ type scriptedAppServerConnection struct {
 	approvalResponse             map[string]any
 	goal                         map[string]any
 	goalStartsTurn               bool
+	goalTurnsStarted             int
+	goalCompletionAfterTurns     int
 	goalCleared                  bool
 	replayTokenUsageOnResume     bool // mirror real codex: emit token usage during thread/resume
 	closeOnce                    sync.Once
@@ -449,10 +453,22 @@ func (c *scriptedAppServerConnection) Send(data []byte) error {
 			c.mu.Lock()
 			previousGoal := clonePayload(c.goal)
 			goalStartsTurn := c.goalStartsTurn
+			goalTurnNumber := c.goalTurnsStarted
+			if goalStartsTurn && strings.TrimSpace(asString(message.Params["objective"])) != "" {
+				c.goalTurnsStarted++
+				goalTurnNumber = c.goalTurnsStarted
+			}
+			goalStatus := firstNonEmpty(asString(message.Params["status"]), "active")
+			if goalStartsTurn &&
+				goalTurnNumber > 0 &&
+				c.goalCompletionAfterTurns > 0 &&
+				goalTurnNumber >= c.goalCompletionAfterTurns {
+				goalStatus = "complete"
+			}
 			goal := map[string]any{
 				"threadId":        "codex-thread-1",
 				"objective":       firstNonEmpty(asString(message.Params["objective"]), asString(previousGoal["objective"])),
-				"status":          firstNonEmpty(asString(message.Params["status"]), "active"),
+				"status":          goalStatus,
 				"tokensUsed":      int64(0),
 				"timeUsedSeconds": int64(0),
 				"createdAt":       int64(1750000000),
@@ -467,21 +483,27 @@ func (c *scriptedAppServerConnection) Send(data []byte) error {
 				"id":     message.ID,
 				"result": map[string]any{"goal": goal},
 			})
-			if goalStartsTurn && strings.TrimSpace(asString(message.Params["objective"])) != "" {
+			if goalStartsTurn && goalTurnNumber > 0 {
+				turnID := fmt.Sprintf("turn-goal-%d", goalTurnNumber)
+				itemID := fmt.Sprintf("item-goal-%d", goalTurnNumber)
+				messageText := "I'll work on the goal."
+				if goalStatus == "complete" && goalTurnNumber > 1 {
+					messageText = "Goal complete."
+				}
 				c.notify(appServerNotifyTurnStarted, map[string]any{
 					"threadId": "codex-thread-1",
-					"turn":     map[string]any{"id": "turn-goal", "status": "inProgress", "items": []any{}},
+					"turn":     map[string]any{"id": turnID, "status": "inProgress", "items": []any{}},
 				})
 				c.notify(appServerNotifyAgentMessageDelta, map[string]any{
-					"threadId": "codex-thread-1", "turnId": "turn-goal", "itemId": "item-goal", "delta": "I'll work on the goal.",
+					"threadId": "codex-thread-1", "turnId": turnID, "itemId": itemID, "delta": messageText,
 				})
 				c.notify(appServerNotifyTurnCompleted, map[string]any{
 					"threadId": "codex-thread-1",
 					"turn": map[string]any{
-						"id":     "turn-goal",
+						"id":     turnID,
 						"status": "completed",
 						"items": []any{
-							map[string]any{"type": "agentMessage", "id": "item-goal", "text": "I'll work on the goal."},
+							map[string]any{"type": "agentMessage", "id": itemID, "text": messageText},
 						},
 					},
 				})
@@ -1806,6 +1828,45 @@ func TestCodexAppServerAdapterSlashGoalSetsObjective(t *testing.T) {
 	}
 	if completed := eventsOfType(events, activityshared.EventTurnCompleted); len(completed) != 1 {
 		t.Fatalf("goal turn completed events = %d, want 1", len(completed))
+	}
+}
+
+func TestCodexAppServerAdapterSlashGoalContinuesUntilTerminalGoal(t *testing.T) {
+	t.Parallel()
+
+	adapter, transport, session := startedAppServerAdapter(t)
+	transport.conn.goalStartsTurn = true
+	transport.conn.goalCompletionAfterTurns = 2
+	events, err := adapter.Exec(context.Background(), session, []PromptContentBlock{{
+		Type: "text", Text: "/goal finish the DrawingML pass",
+	}}, "", "turn-local-goal", nil, nil)
+	if err != nil {
+		t.Fatalf("Exec: %v", err)
+	}
+
+	goalSets := appServerRequestParamsList(t, transport.conn, appServerMethodThreadGoalSet)
+	if len(goalSets) != 2 {
+		t.Fatalf("goal/set requests = %d, want 2", len(goalSets))
+	}
+	if asString(goalSets[1]["status"]) != "active" {
+		t.Fatalf("continuation goal/set params = %#v, want active status", goalSets[1])
+	}
+	if asString(goalSets[1]["objective"]) != "finish the DrawingML pass" {
+		t.Fatalf("continuation goal objective = %#v", goalSets[1])
+	}
+
+	assistantMessages := []string{}
+	for _, event := range eventsOfType(events, activityshared.EventMessageAppended) {
+		if event.Payload.Role == activityshared.MessageRoleAssistant &&
+			event.Payload.Metadata["streamState"] == messageStreamStateCompleted {
+			assistantMessages = append(assistantMessages, event.Payload.Content)
+		}
+	}
+	if strings.Join(assistantMessages, "\n") != "I'll work on the goal.\nGoal complete." {
+		t.Fatalf("assistant messages = %#v", assistantMessages)
+	}
+	if completed := eventsOfType(events, activityshared.EventTurnCompleted); len(completed) != 1 {
+		t.Fatalf("logical goal completed events = %d, want 1", len(completed))
 	}
 }
 

--- a/packages/workspace/terminal/src/react/terminalImeInputGuard.test.ts
+++ b/packages/workspace/terminal/src/react/terminalImeInputGuard.test.ts
@@ -30,12 +30,78 @@ test("terminal IME guard allows regular input outside composition", () => {
 test("terminal IME guard suppresses the key that commits composition", () => {
   let now = 1_000;
   const guard = createTerminalImeInputGuard({ now: () => now });
+  const event = keyEvent({
+    key: "Enter",
+    preventDefault: () => undefined,
+    stopPropagation: () => undefined
+  });
 
   guard.handleCompositionStart();
   guard.handleCompositionEnd();
 
-  assert.equal(guard.shouldProcessKeyEvent(keyEvent({ key: "Enter" })), false);
+  assert.equal(guard.shouldProcessKeyEvent(event), false);
+  now += 100;
   assert.equal(guard.shouldProcessKeyEvent(keyEvent({ key: "a" })), true);
+});
+
+test("terminal IME guard prevents native input for post-composition commit keys", () => {
+  let preventDefaultCalls = 0;
+  let stopPropagationCalls = 0;
+  const guard = createTerminalImeInputGuard({});
+
+  guard.handleCompositionStart();
+  guard.handleCompositionEnd();
+
+  assert.equal(
+    guard.shouldProcessKeyEvent(
+      keyEvent({
+        key: " ",
+        preventDefault: () => {
+          preventDefaultCalls += 1;
+        },
+        stopPropagation: () => {
+          stopPropagationCalls += 1;
+        }
+      })
+    ),
+    false
+  );
+  assert.equal(preventDefaultCalls, 1);
+  assert.equal(stopPropagationCalls, 1);
+});
+
+test("terminal IME guard keeps the post-composition window open for repeated native events", () => {
+  let now = 1_000;
+  const guard = createTerminalImeInputGuard({ now: () => now });
+
+  guard.handleCompositionStart();
+  guard.handleCompositionEnd();
+
+  assert.equal(guard.shouldProcessKeyEvent(keyEvent({ key: " " })), false);
+  now += 10;
+  assert.equal(guard.shouldProcessKeyEvent(keyEvent({ key: " " })), false);
+  now += 100;
+  assert.equal(guard.shouldProcessKeyEvent(keyEvent({ key: " " })), true);
+});
+
+test("terminal IME guard does not prevent native input during active composition", () => {
+  let preventDefaultCalls = 0;
+  const guard = createTerminalImeInputGuard({});
+
+  guard.handleCompositionStart();
+
+  assert.equal(
+    guard.shouldProcessKeyEvent(
+      keyEvent({
+        key: "z",
+        preventDefault: () => {
+          preventDefaultCalls += 1;
+        }
+      })
+    ),
+    false
+  );
+  assert.equal(preventDefaultCalls, 0);
 });
 
 test("terminal IME guard does not suppress delayed input after composition", () => {

--- a/packages/workspace/terminal/src/react/terminalImeInputGuard.ts
+++ b/packages/workspace/terminal/src/react/terminalImeInputGuard.ts
@@ -6,6 +6,8 @@ export interface TerminalImeKeyEvent {
   isComposing: boolean;
   key: string;
   metaKey: boolean;
+  preventDefault?: () => void;
+  stopPropagation?: () => void;
   type: string;
 }
 
@@ -64,7 +66,8 @@ export function createTerminalImeInputGuard(input: {
         compositionEndedAt = null;
         return true;
       }
-      compositionEndedAt = null;
+      event.preventDefault?.();
+      event.stopPropagation?.();
       return false;
     }
   };

--- a/services/tuttid/app/logging_test.go
+++ b/services/tuttid/app/logging_test.go
@@ -48,6 +48,7 @@ func TestSetupLoggerFromEnvWritesToFileByDefault(t *testing.T) {
 	t.Setenv("TUTTI_ENV", "development")
 	t.Setenv("TUTTID_LOG_OUTPUT", "file")
 	t.Setenv("TUTTID_LOG_PATH", "")
+	t.Setenv("TUTTI_LOG_DIR", "")
 	t.Setenv("TUTTI_LOG_DIR", tuttitypes.TuttidLogsDir())
 
 	setup, err := SetupLoggerFromEnv()
@@ -84,6 +85,7 @@ func TestSetupLoggerFromEnvIncludesSessionIDWhenPresent(t *testing.T) {
 	t.Setenv("TUTTI_ENV", "development")
 	t.Setenv("TUTTID_LOG_OUTPUT", "file")
 	t.Setenv("TUTTID_LOG_PATH", "")
+	t.Setenv("TUTTI_LOG_DIR", "")
 	t.Setenv("TUTTI_LOG_DIR", tuttitypes.TuttidLogsDir())
 	t.Setenv("TUTTI_SESSION_ID", "desktop-session-123")
 

--- a/services/tuttid/types/statepaths_test.go
+++ b/services/tuttid/types/statepaths_test.go
@@ -43,6 +43,7 @@ func TestTuttidDerivedPathsUseDevelopmentRoot(t *testing.T) {
 	t.Setenv("HOME", homeDir)
 	t.Setenv("TUTTI_STATE_DIR", "")
 	t.Setenv("TUTTI_ENV", "development")
+	t.Setenv("TUTTI_LOG_DIR", "")
 	t.Setenv("TUTTID_DB_PATH", "")
 	t.Setenv("TUTTID_LOG_PATH", "")
 	t.Setenv("TUTTID_RUN_DIR", "")


### PR DESCRIPTION
## Summary
- **Terminal IME guard**: call preventDefault + stopPropagation on post-composition commit keys so the browser default action cannot mutate xterm hidden textarea, and keep the suppression window open for repeated native key events from the IME commit.
- **Codex appserver**: wrap turn completion in a goal-continuation loop (awaitGoalOperationCompletion) that re-drives turns while the goal stays active, with a 100ms grace window for automatic Codex continuations before falling back to explicit thread/goal.set requests.
- **Tuttid test env leak**: clear TUTTI_LOG_DIR in statepaths and logger tests so they pass inside Tutti agent sessions where the daemon injects that variable.

## Test plan
- [x] Terminal IME guard: unit tests cover active composition not prevented, post-composition commit keys prevented with preventDefault/stopPropagation, repeated native events within window suppressed
- [x] Codex goal continuation: TestCodexAppServerAdapterSlashGoalContinuesUntilTerminalGoal verifies multi-turn goal loop with 2 turns
- [x] Tuttid env leak: statepaths and logger tests pass in agent session environment
- [x] Manual IME testing with Chinese input in workspace terminal

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * The `/goal` command now continues automatically while a goal remains active, chaining follow-up turns until the terminal goal state is reached.
* **Bug Fixes**
  * Improved terminal IME handling to reduce composition text leakage into workspace terminals.
  * Post-composition key events are now blocked more reliably, preventing unintended/duplicate input.
* **Documentation**
  * Added troubleshooting guidance for IME-related terminal input issues, including how to identify and validate the behavior.
* **Tests**
  * Expanded IME guard and goal-continuation test coverage; tightened logger environment setup in tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->