### PR TITLE
fix(agent-gui): reconcile optimistic prompt messages

### DIFF
--- a/docs/architecture/agent-gui-node.md
+++ b/docs/architecture/agent-gui-node.md
@@ -172,6 +172,10 @@ Local overlays are allowed only to bridge UI latency:
 - optimistic pin or working status while a command is in flight
 
 Every overlay must have a reconciliation path back to the runtime snapshot.
+Optimistic prompt messages must stay overlay-owned even when they are used to
+scope the selected detail window. Do not promote them into durable/detail
+message bases: their local timestamp-derived versions can outrank lower
+authoritative daemon versions and suppress the durable user prompt during merge.
 
 ## User-Facing Data Flows
 
@@ -934,6 +938,11 @@ Quick checks:
   do not use their local timestamp-derived versions as durable message-window
   bounds; live runtime messages can have lower authoritative sequence versions
   and must still enter the transcript before a refresh.
+- If user prompts appear below assistant replies until the conversation is
+  reopened, inspect whether optimistic prompt messages were merged into
+  `detailMessages` or another durable/base set. Reconciliation should split
+  durable messages from optimistic overlays, then drop overlays that match a
+  durable `messageId`, `clientSubmitId`, or prompt signature.
 - When a live message or lifecycle patch reveals the real turn ID for a
   first-prompt create, retarget the optimistic prompt from its pending
   client-submit turn ID only after the event is known to belong to the current

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUINodeController.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUINodeController.ts
@@ -5856,24 +5856,37 @@ export function useAgentGUINodeController({
       const currentDetailMessages =
         getAgentSessionView(sessionViewRef(agentSessionId))?.detailMessages ??
         [];
+      const currentDurableDetailMessages = currentDetailMessages.filter(
+        (message) => !isWorkspaceAgentActivityOptimisticMessage(message)
+      );
+      const detailWindowScopeMessages =
+        currentMessages.length > 0
+          ? mergeWorkspaceAgentMessages(
+              currentDurableDetailMessages,
+              currentMessages
+            )
+          : currentDurableDetailMessages;
       const durableSnapshotMessages =
         agentActivitySnapshot.sessionMessagesById[agentSessionId] ?? [];
       const detailWindowMessages = filterMessagesForDetailWindowOverlay({
-        detailMessages: currentDetailMessages,
+        detailMessages: detailWindowScopeMessages,
         durableMessages: durableSnapshotMessages,
         localMessages: nextMessages
       });
+      const durableDetailWindowMessages = detailWindowMessages.filter(
+        (message) => !isWorkspaceAgentActivityOptimisticMessage(message)
+      );
       const nextDetailMessages =
-        detailWindowMessages.length > 0
+        durableDetailWindowMessages.length > 0
           ? mergeWorkspaceAgentMessages(
-              currentDetailMessages,
-              detailWindowMessages
+              currentDurableDetailMessages,
+              durableDetailWindowMessages
             )
-          : currentDetailMessages;
-      if (detailWindowMessages.length > 0) {
+          : currentDurableDetailMessages;
+      if (durableDetailWindowMessages.length > 0) {
         mergeAgentSessionViewDetailMessages(
           sessionViewRef(agentSessionId),
-          detailWindowMessages
+          durableDetailWindowMessages
         );
       }
       const durableMessages =
@@ -6528,9 +6541,6 @@ export function useAgentGUINodeController({
           content: [...normalizedInitialContent],
           occurredAtUnixMs: createdAtUnixMs
         });
-        mergeAgentSessionViewDetailMessages(sessionViewRef(agentSessionId), [
-          optimisticPromptMessage
-        ]);
         mergeAgentSessionViewOverlayMessages(sessionViewRef(agentSessionId), [
           optimisticPromptMessage
         ]);

--- a/packages/agent/gui/contexts/workspace/presentation/renderer/agentSessions/agentSessionViewStore.ts
+++ b/packages/agent/gui/contexts/workspace/presentation/renderer/agentSessions/agentSessionViewStore.ts
@@ -1,5 +1,4 @@
 import { useSyncExternalStore } from "react";
-import { mergeAgentActivityMessages } from "@tutti-os/agent-activity-core";
 import type {
   AgentHostAgentActivityStreamEvent,
   AgentHostAgentSessionCommand,
@@ -7,6 +6,7 @@ import type {
   AgentHostSubscribeAgentSessionEventsInput
 } from "../../../../../shared/contracts/dto";
 import type { WorkspaceAgentActivityMessage } from "../../../../../shared/workspaceAgentActivityTypes";
+import { mergeWorkspaceAgentMessages } from "../../../../../host/workspaceAgentSessionMessages";
 import { getOptionalAgentActivityRuntime } from "../../../../../agentActivityRuntime";
 
 const STREAM_LINGER_MS = 15000;
@@ -988,7 +988,7 @@ function mergeMessages(
   left: readonly WorkspaceAgentActivityMessage[],
   right: readonly WorkspaceAgentActivityMessage[]
 ): WorkspaceAgentActivityMessage[] {
-  return mergeAgentActivityMessages(left, right);
+  return mergeWorkspaceAgentMessages(left, right);
 }
 
 function sameMessages(

--- a/packages/agent/gui/host/workspaceAgentSessionMessages.test.ts
+++ b/packages/agent/gui/host/workspaceAgentSessionMessages.test.ts
@@ -81,6 +81,79 @@ describe("loadWorkspaceAgentSessionMessagePages", () => {
 
     expect(result.map((message) => message.version)).toEqual([1, 2]);
   });
+
+  it("lets a durable message replace a higher-version optimistic prompt with the same message id", () => {
+    const durableUserPrompt = userPromptMessage(1, {
+      messageId: "client-submit:user:submit-1",
+      payload: {
+        clientSubmitId: "submit-1",
+        text: "build and run tests"
+      }
+    });
+    const optimisticUserPrompt = optimisticUserPromptMessage({
+      clientSubmitId: "submit-1",
+      messageId: "client-submit:user:submit-1",
+      prompt: "build and run tests",
+      version: 1782719873985
+    });
+
+    const result = mergeWorkspaceAgentMessages(
+      [optimisticUserPrompt],
+      [durableUserPrompt]
+    );
+
+    expect(result).toHaveLength(1);
+    expect(result[0]?.version).toBe(1);
+    expect(result[0]?.payload.__agentGuiOptimisticPrompt).toBeUndefined();
+  });
+
+  it("drops a higher-version optimistic prompt when durable has the same client submit id", () => {
+    const durableUserPrompt = userPromptMessage(1, {
+      messageId: "daemon-message-1",
+      payload: {
+        clientSubmitId: "submit-1",
+        text: "build and run tests"
+      }
+    });
+    const optimisticUserPrompt = optimisticUserPromptMessage({
+      clientSubmitId: "submit-1",
+      messageId: "client-submit:user:submit-1",
+      prompt: "build and run tests",
+      version: 1782719873985
+    });
+
+    const result = mergeWorkspaceAgentMessages(
+      [optimisticUserPrompt],
+      [durableUserPrompt]
+    );
+
+    expect(result.map((message) => message.messageId)).toEqual([
+      "daemon-message-1"
+    ]);
+  });
+
+  it("keeps an unmatched optimistic prompt as a local overlay", () => {
+    const durableAssistantMessage = messageWithVersion(50, {
+      messageId: "assistant-1"
+    });
+    const optimisticUserPrompt = optimisticUserPromptMessage({
+      clientSubmitId: "submit-2",
+      messageId: "client-submit:user:submit-2",
+      prompt: "start local server",
+      version: 1782719980076
+    });
+
+    const result = mergeWorkspaceAgentMessages(
+      [durableAssistantMessage],
+      [optimisticUserPrompt]
+    );
+
+    expect(result.map((message) => message.messageId)).toEqual([
+      "assistant-1",
+      "client-submit:user:submit-2"
+    ]);
+    expect(result[1]?.payload.__agentGuiOptimisticPrompt).toBe(true);
+  });
 });
 
 function messageWithVersion(
@@ -101,4 +174,36 @@ function messageWithVersion(
     version,
     ...overrides
   };
+}
+
+function userPromptMessage(
+  version: number,
+  overrides: Partial<WorkspaceAgentActivityMessage> = {}
+): WorkspaceAgentActivityMessage {
+  return messageWithVersion(version, {
+    role: "user",
+    turnId: `turn-user-${version}`,
+    ...overrides
+  });
+}
+
+function optimisticUserPromptMessage(input: {
+  clientSubmitId: string;
+  messageId: string;
+  prompt: string;
+  version: number;
+}): WorkspaceAgentActivityMessage {
+  return userPromptMessage(input.version, {
+    id: input.version,
+    messageId: input.messageId,
+    occurredAtUnixMs: input.version,
+    payload: {
+      __agentGuiOptimisticPrompt: true,
+      clientSubmitId: input.clientSubmitId,
+      text: input.prompt
+    },
+    startedAtUnixMs: input.version,
+    status: "pending",
+    turnId: `pending:${input.clientSubmitId}`
+  });
 }

--- a/packages/agent/gui/host/workspaceAgentSessionMessages.ts
+++ b/packages/agent/gui/host/workspaceAgentSessionMessages.ts
@@ -2,7 +2,11 @@ import {
   loadAllAgentSessionMessages,
   mergeAgentActivityMessages
 } from "@tutti-os/agent-activity-core";
-import type { WorkspaceAgentActivityMessage } from "../shared/workspaceAgentActivityTypes";
+import {
+  isWorkspaceAgentActivityOptimisticMessage,
+  mergeWorkspaceAgentActivityDurableAndOverlayMessages,
+  type WorkspaceAgentActivityMessage
+} from "../shared/workspaceAgentActivityTypes";
 
 const DEFAULT_WORKSPACE_AGENT_MESSAGES_LIMIT = 20;
 
@@ -68,5 +72,28 @@ export function mergeWorkspaceAgentMessages(
   previous: readonly WorkspaceAgentActivityMessage[],
   incoming: readonly WorkspaceAgentActivityMessage[]
 ): WorkspaceAgentActivityMessage[] {
-  return mergeAgentActivityMessages(previous, incoming);
+  const previousDurableMessages = previous.filter(
+    (message) => !isWorkspaceAgentActivityOptimisticMessage(message)
+  );
+  const incomingDurableMessages = incoming.filter(
+    (message) => !isWorkspaceAgentActivityOptimisticMessage(message)
+  );
+  const durableMessages = mergeAgentActivityMessages(
+    previousDurableMessages,
+    incomingDurableMessages
+  );
+  const previousOptimisticMessages = previous.filter(
+    isWorkspaceAgentActivityOptimisticMessage
+  );
+  const incomingOptimisticMessages = incoming.filter(
+    isWorkspaceAgentActivityOptimisticMessage
+  );
+  const localMessages = mergeAgentActivityMessages(
+    previousOptimisticMessages,
+    incomingOptimisticMessages
+  );
+  return mergeWorkspaceAgentActivityDurableAndOverlayMessages({
+    durableMessages,
+    localMessages
+  });
 }

--- a/packages/agent/gui/shared/workspaceAgentActivityTypes.spec.ts
+++ b/packages/agent/gui/shared/workspaceAgentActivityTypes.spec.ts
@@ -141,6 +141,32 @@ describe("selectWorkspaceAgentActivityOverlayMessages", () => {
       })
     ).toEqual([optimisticMessage]);
   });
+
+  it("keeps a repeated optimistic user prompt with a new client submit id", () => {
+    const previousDurablePrompt = userMessage({
+      messageId: "durable-user-1",
+      payload: {
+        text: "run tests"
+      },
+      turnId: "turn-1"
+    });
+    const repeatedOptimisticPrompt = userMessage({
+      messageId: "client-submit:user:submit-2",
+      payload: {
+        __agentGuiOptimisticPrompt: true,
+        clientSubmitId: "submit-2",
+        text: "run tests"
+      },
+      turnId: "pending:submit-2"
+    });
+
+    expect(
+      selectWorkspaceAgentActivityOverlayMessages({
+        durableMessages: [previousDurablePrompt],
+        localMessages: [repeatedOptimisticPrompt]
+      })
+    ).toEqual([repeatedOptimisticPrompt]);
+  });
 });
 
 function userMessage(

--- a/packages/agent/gui/shared/workspaceAgentActivityTypes.ts
+++ b/packages/agent/gui/shared/workspaceAgentActivityTypes.ts
@@ -292,6 +292,9 @@ export function selectWorkspaceAgentActivityOverlayMessages(input: {
       ) {
         return false;
       }
+      if (clientSubmitId !== null) {
+        return true;
+      }
       const signature = workspaceAgentActivityUserPromptSignature(message);
       return signature === null || !durableUserPromptSignatures.has(signature);
     }


### PR DESCRIPTION
## Summary
- Keep optimistic prompt messages overlay-owned instead of promoting them into detail/base messages.
- Make AgentGUI workspace message merge split durable messages from optimistic overlays, so durable messages can replace matching optimistic prompts even when optimistic versions are timestamp-sized.
- Route session view message merging through the AgentGUI workspace-aware merge helper.
- Add regression coverage for durable user prompts replacing higher-version optimistic prompts.
- Document the AgentGuiNode overlay/detail reconciliation rule.

## Validation
- pnpm exec vitest run host/workspaceAgentSessionMessages.test.ts --environment jsdom
- pnpm exec vitest run agent-gui/agentGuiNode/controller/useAgentGUINodeController.spec.tsx --environment jsdom -t "renders live assistant messages for a newly created session"
- pnpm --filter @tutti-os/agent-gui typecheck
- pnpm lint:ts
- pnpm check:agent-activity-runtime-boundaries
- pnpm exec oxfmt --check <changed ts files>
- pnpm exec prettier --check docs/architecture/agent-gui-node.md

## Note
- Local pre-push full check was attempted and failed in unrelated Go checks: services/tuttid/app logging tests could not read the temp log file, and services/tuttid/types expected the development state root but observed ~/.tutti/logs. The targeted AgentGUI checks above passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved prompt timeline handling to keep user prompts correctly ordered as conversations update.
  * Adjusted how optimistic (pending) prompts are reconciled so they no longer become durable conversation messages, preventing prompts from appearing below assistant replies or reappearing after updates.
  * Enhanced message merging to better prioritize durable messages over matching optimistic variants.
* **Documentation**
  * Expanded troubleshooting guidance for “Prompt Sends But Timeline Does Not Update,” including a new failure mode and reconciliation checks.
* **Tests**
  * Added coverage for durable vs optimistic prompt merge scenarios and overlay retention behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->