### PR TITLE
fix(cli): clarify issue list topic requirement

### DIFF
--- a/docs/conventions/tutti-cli-contract.md
+++ b/docs/conventions/tutti-cli-contract.md
@@ -180,7 +180,7 @@ Example:
 
 ```go
 type IssueListInput struct {
-    TopicID   string `cli:"topic-id" validate:"required" hint:"Use issue topic list to discover workspace topics."`
+    TopicID   string `cli:"topic-id" validate:"required" hint:"Use issue topic list --json to discover workspace topics."`
     Status    string `cli:"status"`
     Search    string `cli:"search"`
     PageSize  int    `cli:"page-size" validate:"min=1,max=100"`

--- a/services/tuttid/service/agentsidecar/command_catalog.go
+++ b/services/tuttid/service/agentsidecar/command_catalog.go
@@ -107,9 +107,21 @@ func runtimeCommandFromCapability(cliName string, capability cliservice.Capabili
 		}
 		description += "Omit --model unless the user explicitly requested a model; tuttid uses the target provider default."
 	}
+	summary := firstNonEmptyText(capability.Summary, id)
+	if id == "issue-manager.issue.list" {
+		summary = "List issues in a topic"
+		topicDiscoveryHint := fmt.Sprintf("Requires --topic-id; use `%s issue topic list --json` first when the topic is unknown.", normalizeCLICommandName(cliName))
+		description = strings.ReplaceAll(description, "`issue topic list --json`", fmt.Sprintf("`%s issue topic list --json`", normalizeCLICommandName(cliName)))
+		if !strings.Contains(description, topicDiscoveryHint) {
+			if description != "" {
+				description += " "
+			}
+			description += topicDiscoveryHint
+		}
+	}
 	return runtimeCommand{
 		ID:          id,
-		Summary:     firstNonEmptyText(capability.Summary, id),
+		Summary:     summary,
 		Description: description,
 		Example:     normalizeCLICommandName(cliName) + " " + path + requiredInputHintForCommand(id, capability.InputSchema) + commandExampleSuffix(id),
 		Rank:        commandRank(id),
@@ -268,7 +280,7 @@ func fallbackCommandGuide(cliName string) string {
 	cliName = normalizeCLICommandName(cliName)
 	return strings.Join([]string{
 		fmt.Sprintf("- List issue topics: `%s issue topic list`", cliName),
-		fmt.Sprintf("- List issues: `%s issue list --topic-id <topic-id>`", cliName),
+		fmt.Sprintf("- List issues in a topic: `%s issue list --topic-id <topic-id>` - Requires a topic id; use `%s issue topic list --json` first when the topic is unknown.", cliName, cliName),
 		fmt.Sprintf("- Get issue detail: `%s issue get --issue-id <issue-id> --json`", cliName),
 		fmt.Sprintf("- Update issue status: `%s issue update --issue-id <issue-id> --status completed --json`", cliName),
 		fmt.Sprintf("- List issue tasks: `%s issue task list --issue-id <issue-id>`", cliName),

--- a/services/tuttid/service/agentsidecar/command_catalog_test.go
+++ b/services/tuttid/service/agentsidecar/command_catalog_test.go
@@ -26,7 +26,7 @@ func TestCommandGuideFromCapabilitiesUsesRelevantRegistryCommands(t *testing.T) 
 			ID:          "issue-manager.issue.list",
 			Path:        []string{"issue", "list"},
 			Summary:     "List issues",
-			Description: "List issue records in a specific workspace topic.",
+			Description: "List issue records in one workspace topic. Requires --topic-id; use `issue topic list --json` first when the topic is unknown. JSON output omits issue content bodies.",
 			InputSchema: map[string]any{"required": []any{"topic-id"}},
 		},
 		{
@@ -122,6 +122,12 @@ func TestCommandGuideFromCapabilitiesUsesRelevantRegistryCommands(t *testing.T) 
 	}
 	if !strings.Contains(guide, "tutti issue list --topic-id <topic-id>") {
 		t.Fatalf("guide missing topic-scoped issue list: %q", guide)
+	}
+	if !strings.Contains(guide, "use `tutti issue topic list --json` first when the topic is unknown") {
+		t.Fatalf("guide missing topic discovery guidance: %q", guide)
+	}
+	if strings.Contains(guide, "use `issue topic list --json` first when the topic is unknown") {
+		t.Fatalf("guide contains unqualified topic discovery guidance: %q", guide)
 	}
 	if !strings.Contains(guide, "tutti issue update --issue-id <issue-id> --status completed --json") {
 		t.Fatalf("guide missing issue update: %q", guide)

--- a/services/tuttid/service/cli/providers/issuemanager/issues.go
+++ b/services/tuttid/service/cli/providers/issuemanager/issues.go
@@ -10,7 +10,7 @@ import (
 )
 
 type issueListInput struct {
-	TopicID   string `cli:"topic-id" validate:"required" description:"Required topic id. Use issue topic list to discover workspace topics." hint:"Use issue topic list to discover workspace topics."`
+	TopicID   string `cli:"topic-id" validate:"required" description:"Required topic id. Use issue topic list --json to discover workspace topics before listing issues." hint:"Use issue topic list --json to discover workspace topics."`
 	Status    string `cli:"status"`
 	Search    string `cli:"search"`
 	PageSize  int    `cli:"page-size" validate:"min=1,max=100"`
@@ -39,8 +39,8 @@ func (p Provider) newIssueListCommand() cliservice.Command {
 	return framework.Register(framework.CommandSpec[issueListInput]{
 		ID:          appID + ".issue.list",
 		Path:        []string{"issue", "list"},
-		Summary:     "List issues",
-		Description: "List issue records in a specific workspace topic. JSON output omits issue content bodies.",
+		Summary:     "List issues in a topic",
+		Description: "List issue records in one workspace topic. Requires --topic-id; use `issue topic list --json` first when the topic is unknown. JSON output omits issue content bodies.",
 		Kind:        framework.KindList,
 		Workspace:   framework.WorkspaceRequired,
 		Workspaces:  p.workspaces,


### PR DESCRIPTION
## Summary
- Clarify that `tutti issue list` is scoped to a required topic id
- Add agent command guide guidance to run `tutti issue topic list --json` when the topic is unknown
- Update CLI contract docs and test coverage for the injected guide wording

## Validation
- `go test ./services/tuttid/service/cli/providers/issuemanager ./services/tuttid/service/agentsidecar`
- `pnpm check:changed --tail-lines 80`
- `pnpm check:full`

## Notes
- First pre-push attempt failed because the host AgentGUI shell exported `TUTTI_LOG_DIR`, which affects an unrelated state path test. Re-ran push with `TUTTI_LOG_DIR` unset; `check:full` passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Clarified issue-list guidance so it now consistently tells users to provide a topic ID and, when needed, discover topics with the JSON output of the topic-list command.
  * Improved the issue-list command text to better match how it works, including clearer wording for topic-based issue browsing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->