### PR TITLE
fix(agent): reconcile stale running turn phases

### DIFF
--- a/services/tuttid/service/agent/service_resume_helpers.go
+++ b/services/tuttid/service/agent/service_resume_helpers.go
@@ -69,7 +69,7 @@ func hasStaleResumeOpenToolCall(messages []SessionMessage) bool {
 
 func isResumeStaleTurnStatus(status string) bool {
 	switch strings.TrimSpace(status) {
-	case "working", "waiting":
+	case "running", "streaming", "submitted", "working", "waiting":
 		return true
 	default:
 		return false

--- a/services/tuttid/service/agent/service_test.go
+++ b/services/tuttid/service/agent/service_test.go
@@ -3309,6 +3309,39 @@ func TestServiceReconcilesStalePersistedTurnBeforeCanceling(t *testing.T) {
 	}
 }
 
+func TestServiceReconcilesPhaseOnlyStalePersistedTurnBeforeCanceling(t *testing.T) {
+	runtime := newFakeRuntime()
+	reconciled := make([]PersistedSession, 0)
+	service := NewService(runtime)
+	service.SessionReader = fakeSessionReader{
+		reconciled: &reconciled,
+		sessions: map[string]PersistedSession{
+			"ws-1:session-1": {
+				ID:                "session-1",
+				WorkspaceID:       "ws-1",
+				Provider:          "codex",
+				ProviderSessionID: "provider-session-1",
+				Status:            "created",
+				CurrentPhase:      "running",
+			},
+		},
+	}
+
+	result, err := service.Cancel(context.Background(), "ws-1", "session-1")
+	if err != nil {
+		t.Fatalf("Cancel returned error: %v", err)
+	}
+	if result.Canceled || result.Reason != CancelReasonStaleTurnReconciled {
+		t.Fatalf("cancel result = %#v, want phase-only stale turn reconciled without cancel", result)
+	}
+	if len(reconciled) != 1 || reconciled[0].CurrentPhase != "running" {
+		t.Fatalf("reconciled = %#v, want phase-only stale persisted session", reconciled)
+	}
+	if len(runtime.cancelCalls) != 0 {
+		t.Fatalf("cancel calls = %#v, want skipped stale runtime cancel", runtime.cancelCalls)
+	}
+}
+
 func TestServiceCancelReportsActiveTurnCanceled(t *testing.T) {
 	runtime := newFakeRuntime()
 	runtime.sessions["ws-1:session-1"] = RuntimeSession{


### PR DESCRIPTION
## Summary
- Treat persisted `running`, `streaming`, and `submitted` phases as stale active turns during resume/cancel reconciliation.
- Add a regression test for a persisted session whose top-level status is non-busy (`created`) but whose current phase is still `running`.

## Why
A completed runtime turn can leave persisted UI-facing state stuck in a running phase. When the user presses Stop afterward, runtime may already have no active turn, so cancel returns `no_active_turn` and the stale blocked state remains. This makes phase-derived active states eligible for the existing stale-turn reconciliation path.

## Tests
- `go test ./services/tuttid/service/agent -run 'TestService(GetReconcilesStalePersistedTurn|ReconcilesStalePersistedTurnBeforeCanceling|ReconcilesPhaseOnlyStalePersistedTurnBeforeCanceling|CancelReports)'`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved resume handling so more in-progress session states are recognized as stale and reconciled earlier.
  * Cancel actions now better preserve and reconcile sessions when only the persisted phase is out of sync, avoiding unnecessary cancellation paths.

* **Tests**
  * Added coverage for reconciling stale persisted turns before canceling, including cases where runtime cancellation should be skipped.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->