### PR TITLE
Improve app CLI metadata and dynamic help

### DIFF
--- a/apps/cli/internal/app/run.go
+++ b/apps/cli/internal/app/run.go
@@ -329,9 +329,11 @@ func commandHelpPrefix(args []string) ([]string, bool) {
 func writeCommandOutput(stdout io.Writer, stderr io.Writer, output daemon.CommandOutput) int {
 	switch output.Kind {
 	case "plain", "markdown":
+		writeCommandWarnings(stderr, output.Warnings)
 		fmt.Fprintln(stdout, output.Text)
 		return 0
 	case "table":
+		writeCommandWarnings(stderr, output.Warnings)
 		writeTable(stdout, output.Columns, output.Rows)
 		return 0
 	case "json":
@@ -342,6 +344,19 @@ func writeCommandOutput(stdout io.Writer, stderr io.Writer, output daemon.Comman
 }
 
 func writeDynamicJSON(stdout io.Writer, stderr io.Writer, output daemon.CommandOutput) int {
+	if len(output.Warnings) > 0 {
+		envelope := map[string]any{
+			"warnings": output.Warnings,
+		}
+		if len(output.Value) > 0 {
+			envelope["value"] = output.Value
+		} else if output.Rows != nil {
+			envelope["rows"] = output.Rows
+		} else {
+			envelope["output"] = output
+		}
+		return writeJSON(stdout, stderr, envelope)
+	}
 	if len(output.Value) > 0 {
 		return writeJSON(stdout, stderr, output.Value)
 	}
@@ -349,6 +364,18 @@ func writeDynamicJSON(stdout io.Writer, stderr io.Writer, output daemon.CommandO
 		return writeJSON(stdout, stderr, output.Rows)
 	}
 	return writeJSON(stdout, stderr, output)
+}
+
+func writeCommandWarnings(stderr io.Writer, warnings []daemon.CommandWarning) {
+	for _, warning := range warnings {
+		message := strings.TrimSpace(warning.Message)
+		if message == "" {
+			message = strings.TrimSpace(warning.Code)
+		}
+		if message != "" {
+			fmt.Fprintf(stderr, "warning: %s\n", message)
+		}
+	}
 }
 
 func writeJSON(stdout io.Writer, stderr io.Writer, value any) int {

--- a/apps/cli/internal/app/run.go
+++ b/apps/cli/internal/app/run.go
@@ -14,6 +14,8 @@ import (
 	"github.com/tutti-os/tutti/apps/cli/internal/defaults"
 )
 
+const prefixHelpGroupPreviewLimit = 5
+
 type options struct {
 	json bool
 }
@@ -120,6 +122,9 @@ func runDynamic(ctx context.Context, commandName string, opts options, args []st
 			if printCommandPrefixHelp(stdout, commandName, prefix, capabilities.Commands) {
 				return 0
 			}
+		}
+		if printCommandPrefixHelp(stdout, commandName, args, capabilities.Commands) {
+			return 2
 		}
 		fmt.Fprintf(stderr, "unknown command: %s\n", strings.Join(args, " "))
 		return 2
@@ -468,6 +473,12 @@ func printDynamicCommandHelp(stdout io.Writer, commandName string, command daemo
 			description = "  " + flag.Description
 		}
 		fmt.Fprintf(stdout, "  --%-*s  %s%s%s\n", width, flag.Name, flag.Type, required, description)
+		if len(flag.Values) > 0 {
+			fmt.Fprintf(stdout, "      Values: %s\n", strings.Join(flag.Values, ", "))
+		}
+		if flag.HasDefault {
+			fmt.Fprintf(stdout, "      Default: %s\n", flag.Default)
+		}
 	}
 	printDocumentationHints(stdout, []daemon.Capability{command})
 }
@@ -477,6 +488,8 @@ type helpCommandRow struct {
 	Summary                 string
 	IntegrationOnly         bool
 	IncludesIntegrationOnly bool
+	Children                []helpCommandRow
+	RemainingChildren       int
 }
 
 func rootHelpRows(commands []daemon.Capability) []helpCommandRow {
@@ -599,14 +612,111 @@ func prefixHelpRows(prefix []string, commands []daemon.Capability) []helpCommand
 		if summary == "" {
 			summary = fmt.Sprintf("%d commands", item.count)
 		}
+		if item.count == 1 {
+			if required := requiredFlagSummaryForPrefixCommand(prefix, name, commands); required != "" {
+				summary = summary + "  required: " + required
+			}
+		}
 		rows = append(rows, helpCommandRow{
 			Name:                    name,
 			Summary:                 summary,
 			IntegrationOnly:         item.count > 0 && item.integrationCount == item.count,
 			IncludesIntegrationOnly: item.integrationCount > 0 && item.integrationCount < item.count,
+			Children:                prefixHelpChildRows(prefix, name, commands, prefixHelpGroupPreviewLimit),
+			RemainingChildren:       prefixHelpRemainingChildCount(prefix, name, commands, prefixHelpGroupPreviewLimit),
 		})
 	}
 	return rows
+}
+
+func prefixHelpChildRows(prefix []string, name string, commands []daemon.Capability, limit int) []helpCommandRow {
+	if limit <= 0 {
+		return nil
+	}
+	childPrefix := append(append([]string(nil), prefix...), name)
+	leaves := make([]daemon.Capability, 0)
+	for _, command := range commands {
+		if len(command.Path) != len(childPrefix)+1 {
+			continue
+		}
+		if !pathHasPrefix(command.Path, childPrefix) {
+			continue
+		}
+		leaves = append(leaves, command)
+	}
+	sort.SliceStable(leaves, func(left, right int) bool {
+		return strings.Join(leaves[left].Path, " ") < strings.Join(leaves[right].Path, " ")
+	})
+	if len(leaves) > limit {
+		leaves = leaves[:limit]
+	}
+	rows := make([]helpCommandRow, 0, len(leaves))
+	for _, command := range leaves {
+		childName := command.Path[len(childPrefix)]
+		summary := strings.TrimSpace(command.Summary)
+		if required := requiredFlagSummary(command); required != "" {
+			summary = summary + "  required: " + required
+		}
+		rows = append(rows, helpCommandRow{
+			Name:            childName,
+			Summary:         summary,
+			IntegrationOnly: isIntegrationCapability(command),
+		})
+	}
+	return rows
+}
+
+func prefixHelpRemainingChildCount(prefix []string, name string, commands []daemon.Capability, limit int) int {
+	if limit <= 0 {
+		return 0
+	}
+	childPrefix := append(append([]string(nil), prefix...), name)
+	count := 0
+	for _, command := range commands {
+		if len(command.Path) == len(childPrefix)+1 && pathHasPrefix(command.Path, childPrefix) {
+			count++
+		}
+	}
+	if count <= limit {
+		return 0
+	}
+	return count - limit
+}
+
+func pathHasPrefix(path []string, prefix []string) bool {
+	if len(path) < len(prefix) {
+		return false
+	}
+	for index, segment := range prefix {
+		if path[index] != segment {
+			return false
+		}
+	}
+	return true
+}
+
+func requiredFlagSummaryForPrefixCommand(prefix []string, name string, commands []daemon.Capability) string {
+	for _, command := range commands {
+		if len(command.Path) != len(prefix)+1 {
+			continue
+		}
+		if command.Path[len(prefix)] != name {
+			continue
+		}
+		return requiredFlagSummary(command)
+	}
+	return ""
+}
+
+func requiredFlagSummary(command daemon.Capability) string {
+	flags := commandFlags(command.InputSchema)
+	required := make([]string, 0)
+	for _, flag := range flags {
+		if flag.Required {
+			required = append(required, "--"+flag.Name+" <value>")
+		}
+	}
+	return strings.Join(required, " ")
 }
 
 func printHelpRows(stdout io.Writer, rows []helpCommandRow) {
@@ -625,6 +735,29 @@ func printHelpRows(stdout io.Writer, rows []helpCommandRow) {
 			summary += " [includes integration-only]"
 		}
 		fmt.Fprintf(stdout, "  %-*s  %s\n", width, row.Name, summary)
+		printHelpChildRows(stdout, row)
+	}
+}
+
+func printHelpChildRows(stdout io.Writer, row helpCommandRow) {
+	if len(row.Children) == 0 && row.RemainingChildren == 0 {
+		return
+	}
+	childWidth := 0
+	for _, child := range row.Children {
+		if len(child.Name) > childWidth {
+			childWidth = len(child.Name)
+		}
+	}
+	for _, child := range row.Children {
+		summary := child.Summary
+		if child.IntegrationOnly {
+			summary += " [integration-only]"
+		}
+		fmt.Fprintf(stdout, "    %-*s  %s\n", childWidth, child.Name, summary)
+	}
+	if row.RemainingChildren > 0 {
+		fmt.Fprintf(stdout, "    ...   %d more commands\n", row.RemainingChildren)
 	}
 }
 
@@ -693,6 +826,9 @@ type commandFlag struct {
 	Type        string
 	Description string
 	Required    bool
+	Values      []string
+	Default     string
+	HasDefault  bool
 }
 
 func commandFlags(schema map[string]any) []commandFlag {
@@ -717,6 +853,9 @@ func commandFlags(schema map[string]any) []commandFlag {
 			Type:        schemaPropertyType(property),
 			Description: schemaPropertyDescription(property),
 			Required:    true,
+			Values:      schemaPropertyEnumValues(property),
+			Default:     schemaPropertyDefault(property),
+			HasDefault:  schemaPropertyHasDefault(property),
 		})
 	}
 
@@ -732,6 +871,9 @@ func commandFlags(schema map[string]any) []commandFlag {
 			Name:        name,
 			Type:        schemaPropertyType(properties[name]),
 			Description: schemaPropertyDescription(properties[name]),
+			Values:      schemaPropertyEnumValues(properties[name]),
+			Default:     schemaPropertyDefault(properties[name]),
+			HasDefault:  schemaPropertyHasDefault(properties[name]),
 		})
 	}
 	return flags
@@ -781,4 +923,55 @@ func schemaPropertyDescription(property any) string {
 		return ""
 	}
 	return strings.TrimSpace(description)
+}
+
+func schemaPropertyEnumValues(property any) []string {
+	propertyMap, ok := property.(map[string]any)
+	if !ok {
+		return nil
+	}
+	value, ok := propertyMap["enum"].([]any)
+	if !ok {
+		return nil
+	}
+	values := make([]string, 0, len(value))
+	for _, item := range value {
+		values = append(values, formatSchemaValue(item))
+	}
+	return values
+}
+
+func schemaPropertyDefault(property any) string {
+	propertyMap, ok := property.(map[string]any)
+	if !ok {
+		return ""
+	}
+	value, ok := propertyMap["default"]
+	if !ok {
+		return ""
+	}
+	return formatSchemaValue(value)
+}
+
+func schemaPropertyHasDefault(property any) bool {
+	propertyMap, ok := property.(map[string]any)
+	if !ok {
+		return false
+	}
+	_, ok = propertyMap["default"]
+	return ok
+}
+
+func formatSchemaValue(value any) string {
+	switch typed := value.(type) {
+	case json.Number:
+		return typed.String()
+	case float64:
+		if typed == float64(int64(typed)) {
+			return fmt.Sprintf("%.0f", typed)
+		}
+		return fmt.Sprint(typed)
+	default:
+		return fmt.Sprint(value)
+	}
 }

--- a/apps/cli/internal/app/run_test.go
+++ b/apps/cli/internal/app/run_test.go
@@ -9,6 +9,8 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/tutti-os/tutti/apps/cli/internal/daemon"
 )
 
 func TestRunHelpUsesDefaultCommandName(t *testing.T) {
@@ -69,6 +71,38 @@ func TestCliInvokeContextFromEnvIncludesAgentSessionID(t *testing.T) {
 		context.ParentCommandID != "parent-1" ||
 		context.AgentSessionID != "session-1" {
 		t.Fatalf("context = %#v", context)
+	}
+}
+
+func TestWriteDynamicJSONKeepsCommandWarningsOutOfAppValue(t *testing.T) {
+	output := daemon.CommandOutput{
+		Kind: "json",
+		Value: map[string]any{
+			"ok":       true,
+			"warnings": "app-defined",
+		},
+		Warnings: []daemon.CommandWarning{{
+			Code:    "unknown_input_ignored",
+			Message: "Unknown input ignored.",
+		}},
+	}
+
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	if code := writeCommandOutput(&stdout, &stderr, output); code != 0 {
+		t.Fatalf("code = %d stderr = %q", code, stderr.String())
+	}
+	var envelope map[string]any
+	if err := json.Unmarshal(stdout.Bytes(), &envelope); err != nil {
+		t.Fatalf("decode stdout: %v\n%s", err, stdout.String())
+	}
+	value := envelope["value"].(map[string]any)
+	if value["warnings"] != "app-defined" {
+		t.Fatalf("app warnings field was clobbered: %#v", value["warnings"])
+	}
+	warnings := envelope["warnings"].([]any)
+	if len(warnings) != 1 || warnings[0].(map[string]any)["code"] != "unknown_input_ignored" {
+		t.Fatalf("warnings = %#v", envelope["warnings"])
 	}
 }
 

--- a/apps/cli/internal/app/run_test.go
+++ b/apps/cli/internal/app/run_test.go
@@ -316,7 +316,7 @@ func TestRunDynamicCommandHelpRendersInputSchema(t *testing.T) {
 		w.Header().Set("Content-Type", "application/json")
 		switch r.URL.Path {
 		case "/v1/cli/capabilities":
-			_, _ = w.Write([]byte(`{"commands":[{"id":"issue-manager.issue.task.create","path":["issue","task","create"],"summary":"Create an issue task","description":"Create a task under an issue.","inputSchema":{"type":"object","properties":{"issue-id":{"type":"string","description":"Issue that owns the task."},"task-id":{"type":"string","description":"Stable task id to create; generated when omitted."},"title":{"type":"string","description":"Task title."},"content":{"type":"string","description":"Task instructions or notes."},"priority":{"type":"string","description":"Task priority: high, medium, or low."},"due-at-unix":{"type":"string","description":"Due time as a Unix timestamp in seconds."}},"required":["issue-id","title"]},"output":{"defaultMode":"json","json":true}}]}`))
+			_, _ = w.Write([]byte(`{"commands":[{"id":"issue-manager.issue.task.create","path":["issue","task","create"],"summary":"Create an issue task","description":"Create a task under an issue.","inputSchema":{"type":"object","properties":{"issue-id":{"type":"string","description":"Issue that owns the task."},"task-id":{"type":"string","description":"Stable task id to create; generated when omitted."},"title":{"type":"string","description":"Task title."},"content":{"type":"string","description":"Task instructions or notes."},"priority":{"type":"string","description":"Task priority.","enum":["high","medium","low"],"default":"medium"},"enabled":{"type":"boolean","description":"Whether the task is enabled.","default":true},"due-at-unix":{"type":"integer","description":"Due time as a Unix timestamp in seconds.","default":1893456000}},"required":["issue-id","title"]},"output":{"defaultMode":"json","json":true}}]}`))
 		case "/v1/cli/commands/issue-manager.issue.task.create/invoke":
 			invoked = true
 			http.Error(w, "unexpected invoke", http.StatusInternalServerError)
@@ -344,11 +344,16 @@ func TestRunDynamicCommandHelpRendersInputSchema(t *testing.T) {
 		"--title",
 		"--content",
 		"--due-at-unix",
+		"--enabled",
 		"--priority",
 		"--task-id",
 		"required",
 		"Task title.",
-		"Task priority: high, medium, or low.",
+		"Task priority.",
+		"Values: high, medium, low",
+		"Default: medium",
+		"Default: true",
+		"Default: 1893456000",
 	} {
 		if !strings.Contains(output, expected) {
 			t.Fatalf("stdout missing %q:\n%s", expected, output)
@@ -364,7 +369,7 @@ func TestRunDynamicScopeHelpListsCommandsAndDocumentation(t *testing.T) {
 		case "/v1/cli/capabilities":
 			_, _ = w.Write([]byte(`{"commands":[
         {"id":"app.automation.automation.list","path":["automation","list"],"summary":"List automations","output":{"defaultMode":"table","json":true},"source":{"kind":"app","appId":"automation","appName":"Automation","documentationFile":"COMMANDS.md","documentationPath":"/tmp/tutti/apps/automation/COMMANDS.md"}},
-        {"id":"app.automation.automation.run","path":["automation","run"],"summary":"Run an automation","output":{"defaultMode":"json","json":true},"source":{"kind":"app","appId":"automation","appName":"Automation","documentationFile":"COMMANDS.md","documentationPath":"/tmp/tutti/apps/automation/COMMANDS.md"}},
+        {"id":"app.automation.automation.run","path":["automation","run"],"summary":"Run an automation","inputSchema":{"type":"object","properties":{"automation-id":{"type":"string","description":"Automation id."},"name":{"type":"string","description":"Exact automation name."}},"required":["automation-id"]},"output":{"defaultMode":"json","json":true},"source":{"kind":"app","appId":"automation","appName":"Automation","documentationFile":"COMMANDS.md","documentationPath":"/tmp/tutti/apps/automation/COMMANDS.md"}},
         {"id":"app.automation.automation.runs","path":["automation","runs"],"summary":"List automation runs","output":{"defaultMode":"table","json":true},"source":{"kind":"app","appId":"automation","appName":"Automation","documentationFile":"COMMANDS.md","documentationPath":"/tmp/tutti/apps/automation/COMMANDS.md"}}
       ]}`))
 		case "/v1/cli/commands/app.automation.automation.list/invoke":
@@ -391,7 +396,7 @@ func TestRunDynamicScopeHelpListsCommandsAndDocumentation(t *testing.T) {
 	for _, expected := range []string{
 		"Usage: tutti automation <command> [--json]",
 		"list  List automations",
-		"run   Run an automation",
+		"run   Run an automation  required: --automation-id <value>",
 		"runs  List automation runs",
 		`Use "tutti automation <command> --help" for command details.`,
 		"More documentation:",
@@ -400,6 +405,141 @@ func TestRunDynamicScopeHelpListsCommandsAndDocumentation(t *testing.T) {
 		if !strings.Contains(output, expected) {
 			t.Fatalf("stdout missing %q:\n%s", expected, output)
 		}
+	}
+}
+
+func TestRunDynamicScopeHelpShowsRequiredFlagsForBuiltinCommands(t *testing.T) {
+	invoked := false
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/v1/cli/capabilities":
+			_, _ = w.Write([]byte(`{"commands":[
+        {"id":"issue-manager.issue.run.create","path":["issue","run","create"],"summary":"Create issue run","inputSchema":{"type":"object","properties":{"issue-id":{"type":"string"},"agent-provider":{"type":"string"},"agent-session-id":{"type":"string"}},"required":["agent-provider","agent-session-id","issue-id"]},"output":{"defaultMode":"json","json":true},"source":{"kind":"builtin"}},
+        {"id":"issue-manager.issue.run.complete","path":["issue","run","complete"],"summary":"Complete issue run","inputSchema":{"type":"object","properties":{"issue-id":{"type":"string"},"run-id":{"type":"string"},"status":{"type":"string"}},"required":["issue-id","run-id","status"]},"output":{"defaultMode":"json","json":true},"source":{"kind":"builtin"}},
+        {"id":"issue-manager.issue.topic.list","path":["issue","topic","list"],"summary":"List issue topics","output":{"defaultMode":"table","json":true},"source":{"kind":"builtin"}},
+        {"id":"issue-manager.issue.topic.create","path":["issue","topic","create"],"summary":"Create issue topic","inputSchema":{"type":"object","properties":{"title":{"type":"string"}},"required":["title"]},"output":{"defaultMode":"json","json":true},"source":{"kind":"builtin"}},
+        {"id":"issue-manager.issue.topic.delete","path":["issue","topic","delete"],"summary":"Delete issue topic","inputSchema":{"type":"object","properties":{"topic-id":{"type":"string"}},"required":["topic-id"]},"output":{"defaultMode":"json","json":true},"source":{"kind":"builtin"}},
+        {"id":"issue-manager.issue.topic.update","path":["issue","topic","update"],"summary":"Update issue topic","inputSchema":{"type":"object","properties":{"topic-id":{"type":"string"}},"required":["topic-id"]},"output":{"defaultMode":"json","json":true},"source":{"kind":"builtin"}},
+        {"id":"issue-manager.issue.list","path":["issue","list"],"summary":"List issues","inputSchema":{"type":"object","properties":{"topic-id":{"type":"string","description":"Required topic id."},"status":{"type":"string","description":"Issue status."}},"required":["topic-id"]},"output":{"defaultMode":"table","json":true},"source":{"kind":"builtin"}},
+        {"id":"issue-manager.issue.get","path":["issue","get"],"summary":"Get issue detail","inputSchema":{"type":"object","properties":{"issue-id":{"type":"string","description":"Issue id."}},"required":["issue-id"]},"output":{"defaultMode":"json","json":true},"source":{"kind":"builtin"}}
+      ]}`))
+		case "/v1/cli/commands/issue-manager.issue.list/invoke":
+			invoked = true
+			http.Error(w, "unexpected invoke", http.StatusInternalServerError)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	writeEndpoint(t, server.URL, "token-1")
+
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	code := Run(t.Context(), []string{"issue", "--help"}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("code = %d, stderr = %s", code, stderr.String())
+	}
+	if invoked {
+		t.Fatal("command was invoked")
+	}
+	output := stdout.String()
+	for _, expected := range []string{
+		"Usage: tutti issue <command> [--json]",
+		"get    Get issue detail  required: --issue-id <value>",
+		"list   List issues  required: --topic-id <value>",
+		"run    2 commands",
+		"create    Create issue run  required: --agent-provider <value> --agent-session-id <value> --issue-id <value>",
+		"complete  Complete issue run  required: --issue-id <value> --run-id <value> --status <value>",
+		"topic  4 commands",
+		"create  Create issue topic  required: --title <value>",
+		"delete  Delete issue topic  required: --topic-id <value>",
+		"list    List issue topics",
+		"update  Update issue topic  required: --topic-id <value>",
+	} {
+		if !strings.Contains(output, expected) {
+			t.Fatalf("stdout missing %q:\n%s", expected, output)
+		}
+	}
+}
+
+func TestRunDynamicCommandGroupWithoutSubcommandShowsPrefixHelp(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if r.URL.Path == "/v1/cli/capabilities" {
+			_, _ = w.Write([]byte(`{"commands":[
+        {"id":"issue-manager.issue.topic.list","path":["issue","topic","list"],"summary":"List issue topics","output":{"defaultMode":"table","json":true},"source":{"kind":"builtin"}},
+        {"id":"issue-manager.issue.topic.create","path":["issue","topic","create"],"summary":"Create issue topic","inputSchema":{"type":"object","properties":{"title":{"type":"string"}},"required":["title"]},"output":{"defaultMode":"json","json":true},"source":{"kind":"builtin"}}
+      ]}`))
+			return
+		}
+		http.NotFound(w, r)
+	}))
+	defer server.Close()
+
+	writeEndpoint(t, server.URL, "token-1")
+
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	code := Run(t.Context(), []string{"issue", "topic"}, &stdout, &stderr)
+	if code != 2 {
+		t.Fatalf("code = %d, stderr = %s", code, stderr.String())
+	}
+	if stderr.String() != "" {
+		t.Fatalf("stderr = %q, want empty when prefix help is shown", stderr.String())
+	}
+	output := stdout.String()
+	for _, expected := range []string{
+		"Usage: tutti issue topic <command> [--json]",
+		"create  Create issue topic  required: --title <value>",
+		"list    List issue topics",
+	} {
+		if !strings.Contains(output, expected) {
+			t.Fatalf("stdout missing %q:\n%s", expected, output)
+		}
+	}
+}
+
+func TestRunDynamicScopeHelpLimitsGroupedCommandPreview(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if r.URL.Path == "/v1/cli/capabilities" {
+			_, _ = w.Write([]byte(`{"commands":[
+        {"id":"issue-manager.issue.task.a","path":["issue","task","a"],"summary":"A","output":{"defaultMode":"json","json":true},"source":{"kind":"builtin"}},
+        {"id":"issue-manager.issue.task.b","path":["issue","task","b"],"summary":"B","output":{"defaultMode":"json","json":true},"source":{"kind":"builtin"}},
+        {"id":"issue-manager.issue.task.c","path":["issue","task","c"],"summary":"C","output":{"defaultMode":"json","json":true},"source":{"kind":"builtin"}},
+        {"id":"issue-manager.issue.task.d","path":["issue","task","d"],"summary":"D","output":{"defaultMode":"json","json":true},"source":{"kind":"builtin"}},
+        {"id":"issue-manager.issue.task.e","path":["issue","task","e"],"summary":"E","output":{"defaultMode":"json","json":true},"source":{"kind":"builtin"}},
+        {"id":"issue-manager.issue.task.f","path":["issue","task","f"],"summary":"F","output":{"defaultMode":"json","json":true},"source":{"kind":"builtin"}}
+      ]}`))
+			return
+		}
+		http.NotFound(w, r)
+	}))
+	defer server.Close()
+
+	writeEndpoint(t, server.URL, "token-1")
+
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	code := Run(t.Context(), []string{"issue", "--help"}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("code = %d, stderr = %s", code, stderr.String())
+	}
+	output := stdout.String()
+	for _, expected := range []string{
+		"task  6 commands",
+		"a  A",
+		"e  E",
+		"...   1 more commands",
+	} {
+		if !strings.Contains(output, expected) {
+			t.Fatalf("stdout missing %q:\n%s", expected, output)
+		}
+	}
+	if strings.Contains(output, "f  F") {
+		t.Fatalf("stdout includes command beyond preview limit:\n%s", output)
 	}
 }
 

--- a/apps/cli/internal/daemon/client.go
+++ b/apps/cli/internal/daemon/client.go
@@ -97,11 +97,17 @@ type InvokeResponse struct {
 }
 
 type CommandOutput struct {
-	Kind    string           `json:"kind"`
-	Columns []TableColumn    `json:"columns,omitempty"`
-	Rows    []map[string]any `json:"rows,omitempty"`
-	Value   map[string]any   `json:"value,omitempty"`
-	Text    string           `json:"text,omitempty"`
+	Kind     string           `json:"kind"`
+	Columns  []TableColumn    `json:"columns,omitempty"`
+	Rows     []map[string]any `json:"rows,omitempty"`
+	Value    map[string]any   `json:"value,omitempty"`
+	Text     string           `json:"text,omitempty"`
+	Warnings []CommandWarning `json:"warnings,omitempty"`
+}
+
+type CommandWarning struct {
+	Code    string `json:"code"`
+	Message string `json:"message"`
 }
 
 func NewClient(endpoint Endpoint) (*Client, error) {

--- a/apps/cli/internal/daemon/client_contract_test.go
+++ b/apps/cli/internal/daemon/client_contract_test.go
@@ -25,7 +25,9 @@ func TestClientTransportModelTracksOpenAPIContract(t *testing.T) {
 		"agentSessionId:",
 		"CliInvokeResponse:",
 		"CliCommandOutput:",
+		"CliCommandWarning:",
 		"CliOutputMode:",
+		"warnings:",
 	}
 
 	for _, fragment := range requiredFragments {

--- a/docs/conventions/tutti-cli-contract.md
+++ b/docs/conventions/tutti-cli-contract.md
@@ -47,6 +47,10 @@ Keep these semantics stable unless the app CLI manifest version changes:
 - app commands may declare optional `visibility: "integration"` to stay out of
   ordinary user and Agent discovery while remaining available to app-runtime
   integrations; omitted visibility is `public`
+- app command input schema properties may include `enum` and `default`
+  annotations when their values match the declared property type; `default` is
+  metadata for help and discovery, not a host-side input value that is injected
+  into handler requests
 
 Do not require migration for existing app manifests when changing builtin CLI
 implementation internals.

--- a/packages/agent/daemon/runtime/standard_acp_adapter.go
+++ b/packages/agent/daemon/runtime/standard_acp_adapter.go
@@ -813,6 +813,9 @@ func (a *standardACPAdapter) Exec(
 	explicitDisplayPrompt, visibleText := explicitAndVisiblePromptText(content, displayPrompt)
 	mentionRoutingApplied, mentionRoutingSkills := claudeCodeMentionRoutingSkills(a.config.provider, visibleText)
 	acpPromptContent := promptContentForACP(content)
+	if mentionRoutingApplied {
+		acpPromptContent = prependClaudeCodeMentionRoutingPrompt(acpPromptContent, mentionRoutingSkills)
+	}
 	normalizer := newACPTurnNormalizer()
 	var events []activityshared.Event
 	emitEvents := func(next []activityshared.Event) {
@@ -2984,6 +2987,60 @@ func isStandardACPPlaceholderTitle(config standardACPConfig, title string) bool 
 
 func isClaudeCodeMentionHandoffTitle(title string) bool {
 	return strings.HasPrefix(strings.TrimSpace(title), "Claude Code mention handoff routing for this user turn:")
+}
+
+func prependClaudeCodeMentionRoutingPrompt(content []map[string]any, skills []string) []map[string]any {
+	routingPrompt := strings.TrimSpace(claudeCodeMentionRoutingPrompt(skills))
+	if routingPrompt == "" {
+		return content
+	}
+	out := make([]map[string]any, 0, len(content)+1)
+	out = append(out, map[string]any{
+		"type": "text",
+		"text": routingPrompt,
+	})
+	out = append(out, content...)
+	return out
+}
+
+func claudeCodeMentionRoutingPrompt(skills []string) string {
+	unique := make([]string, 0, len(skills))
+	seen := map[string]bool{}
+	for _, skill := range skills {
+		skill = strings.TrimSpace(skill)
+		if skill == "" || seen[skill] {
+			continue
+		}
+		seen[skill] = true
+		unique = append(unique, skill)
+	}
+	if len(unique) == 0 {
+		return ""
+	}
+	lines := []string{
+		"Claude Code mention handoff routing for this user turn:",
+		"- This block is internal Tutti routing metadata. Do not quote, summarize, or display it to the user.",
+		"- Before Bash, WebFetch, browser, MCP lookup, file search, raw CLI commands, or provider-native substitute tools, call the Claude Code Skill tool for the exact visible injected Tutti skill that matches the mention kind.",
+		"- Skill names may be namespaced. Prefer the exact visible `tutti-cli:<skill>` name when present; use the plain `<skill>` name only if that exact name is visible. Do not pass arguments to Skill.",
+	}
+	for _, skill := range unique {
+		switch skill {
+		case "workspace-app":
+			lines = append(lines,
+				"- For `mention://workspace-app/...`, first call `Skill(skill=\"tutti-cli:workspace-app\")` when that name is visible, otherwise `Skill(skill=\"workspace-app\")` only if visible.",
+				"- The workspace app id inside the mention is not a skill name. Do not call an app-id-derived Skill name.",
+			)
+		case "issue-manager":
+			lines = append(lines, "- For `mention://workspace-issue/...`, first call `Skill(skill=\"tutti-cli:issue-manager\")` when that name is visible, otherwise `Skill(skill=\"issue-manager\")` only if visible.")
+		case "reference":
+			lines = append(lines, "- For `mention://workspace-reference/...`, first call `Skill(skill=\"tutti-cli:reference\")` when that name is visible, otherwise `Skill(skill=\"reference\")` only if visible.")
+		case "tutti-cli":
+			lines = append(lines, "- For `mention://agent-session/...`, first call `Skill(skill=\"tutti-cli:tutti-cli\")` when that name is visible, otherwise `Skill(skill=\"tutti-cli\")` only if visible.")
+		default:
+			lines = append(lines, "- First call the exact visible Skill for `"+skill+"`.")
+		}
+	}
+	return strings.Join(lines, "\n")
 }
 
 func isClaudeACPInterruptMarker(text string) bool {

--- a/packages/agent/daemon/runtime/standard_acp_adapter_test.go
+++ b/packages/agent/daemon/runtime/standard_acp_adapter_test.go
@@ -2026,7 +2026,7 @@ func TestClaudeCodeAdapterStartAppendsSessionScopedSystemPrompt(t *testing.T) {
 	}
 }
 
-func TestClaudeCodeAdapterExecKeepsMentionPromptUnmodified(t *testing.T) {
+func TestClaudeCodeAdapterExecAddsInternalMentionRoutingPromptOnlyForProvider(t *testing.T) {
 	t.Parallel()
 
 	transport := newStandardACPTransport("Claude Agent", "claude-session-mention-routing")
@@ -2043,9 +2043,16 @@ func TestClaudeCodeAdapterExecKeepsMentionPromptUnmodified(t *testing.T) {
 		t.Fatalf("Exec: %v", err)
 	}
 
-	text := firstPromptText(t, transport.conn.lastPromptParamsSnapshot)
-	if text != prompt {
-		t.Fatalf("prompt text = %q, want unmodified prompt %q", text, prompt)
+	texts := promptTexts(t, transport.conn.lastPromptParamsSnapshot)
+	if len(texts) < 2 {
+		t.Fatalf("prompt texts = %#v, want internal routing plus user prompt", texts)
+	}
+	if !strings.Contains(texts[0], "Claude Code mention handoff routing for this user turn:") ||
+		!strings.Contains(texts[0], "Skill(skill=\"tutti-cli:tutti-cli\")") {
+		t.Fatalf("routing prompt = %q, want internal Claude mention routing", texts[0])
+	}
+	if texts[1] != prompt {
+		t.Fatalf("user prompt text = %q, want unmodified prompt %q", texts[1], prompt)
 	}
 	userContent := firstUserMessageContent(t, events)
 	if !strings.Contains(userContent, prompt) ||
@@ -2070,9 +2077,15 @@ func TestClaudeCodeAdapterExecRoutesWorkspaceReferenceMention(t *testing.T) {
 		t.Fatalf("Exec: %v", err)
 	}
 
-	text := firstPromptText(t, transport.conn.lastPromptParamsSnapshot)
-	if text != prompt {
-		t.Fatalf("prompt text = %q, want unmodified prompt %q", text, prompt)
+	texts := promptTexts(t, transport.conn.lastPromptParamsSnapshot)
+	if len(texts) < 2 {
+		t.Fatalf("prompt texts = %#v, want internal routing plus user prompt", texts)
+	}
+	if !strings.Contains(texts[0], "Skill(skill=\"tutti-cli:reference\")") {
+		t.Fatalf("routing prompt = %q, want reference skill routing", texts[0])
+	}
+	if texts[1] != prompt {
+		t.Fatalf("user prompt text = %q, want unmodified prompt %q", texts[1], prompt)
 	}
 }
 
@@ -2234,19 +2247,32 @@ func TestClaudeCodeAdapterMirrorsSDKGoalStatusIntoRuntimeContext(t *testing.T) {
 
 func firstPromptText(t *testing.T, params map[string]any) string {
 	t.Helper()
+	texts := promptTexts(t, params)
+	if len(texts) == 0 {
+		t.Fatalf("prompt params = %#v, want prompt text", params)
+	}
+	return texts[0]
+}
+
+func promptTexts(t *testing.T, params map[string]any) []string {
+	t.Helper()
 	items, ok := params["prompt"].([]any)
 	if !ok || len(items) == 0 {
 		t.Fatalf("prompt params = %#v, want prompt items", params)
 	}
-	first, ok := items[0].(map[string]any)
-	if !ok {
-		t.Fatalf("first prompt item = %#v, want map", items[0])
+	texts := make([]string, 0, len(items))
+	for _, item := range items {
+		block, ok := item.(map[string]any)
+		if !ok {
+			t.Fatalf("prompt item = %#v, want map", item)
+		}
+		text, ok := block["text"].(string)
+		if !ok {
+			continue
+		}
+		texts = append(texts, text)
 	}
-	text, ok := first["text"].(string)
-	if !ok {
-		t.Fatalf("first prompt text = %#v, want string", first["text"])
-	}
-	return text
+	return texts
 }
 
 func firstUserMessageContent(t *testing.T, events []activityshared.Event) string {

--- a/packages/appcli/core/input.go
+++ b/packages/appcli/core/input.go
@@ -4,13 +4,19 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"sort"
 	"strconv"
 	"strings"
 )
 
 func NormalizeInput(schema map[string]any, input map[string]any) (map[string]any, error) {
+	normalized, _, err := NormalizeInputWithWarnings(schema, input)
+	return normalized, err
+}
+
+func NormalizeInputWithWarnings(schema map[string]any, input map[string]any) (map[string]any, []InputWarning, error) {
 	if len(schema) == 0 {
-		return map[string]any{}, nil
+		return map[string]any{}, unknownInputWarnings(input, nil), nil
 	}
 	properties, _ := schema["properties"].(map[string]any)
 	required := map[string]bool{}
@@ -26,16 +32,37 @@ func NormalizeInput(schema map[string]any, input map[string]any) (map[string]any
 		propertyMap, _ := property.(map[string]any)
 		normalized, err := normalizeValue(schemaType(propertyMap), value)
 		if err != nil {
-			return nil, fmt.Errorf("%w: invalid input %q", ErrInvalidInput, key)
+			return nil, nil, fmt.Errorf("%w: invalid input %q", ErrInvalidInput, key)
 		}
 		result[key] = normalized
 	}
 	for name := range required {
 		if _, ok := result[name]; !ok {
-			return nil, fmt.Errorf("%w: required input %q is missing", ErrInvalidInput, name)
+			return nil, nil, fmt.Errorf("%w: required input %q is missing", ErrInvalidInput, name)
 		}
 	}
-	return result, nil
+	return result, unknownInputWarnings(input, properties), nil
+}
+
+func unknownInputWarnings(input map[string]any, properties map[string]any) []InputWarning {
+	if len(input) == 0 {
+		return nil
+	}
+	unknown := make([]string, 0)
+	for key := range input {
+		if _, ok := properties[key]; !ok {
+			unknown = append(unknown, key)
+		}
+	}
+	sort.Strings(unknown)
+	warnings := make([]InputWarning, 0, len(unknown))
+	for _, key := range unknown {
+		warnings = append(warnings, InputWarning{
+			Code:    "unknown_input_ignored",
+			Message: fmt.Sprintf("Ignoring unknown input %q; this CLI may be newer than the app handler.", key),
+		})
+	}
+	return warnings
 }
 
 func normalizeValue(typeName string, value any) (any, error) {

--- a/packages/appcli/core/input_test.go
+++ b/packages/appcli/core/input_test.go
@@ -2,6 +2,7 @@ package core
 
 import (
 	"errors"
+	"strings"
 	"testing"
 )
 
@@ -28,6 +29,29 @@ func TestNormalizeInputIgnoresUnknownAndCoercesScalars(t *testing.T) {
 	}
 	if _, ok := input["unknown"]; ok {
 		t.Fatalf("unknown input was forwarded: %#v", input)
+	}
+}
+
+func TestNormalizeInputWithWarningsReportsUnknownInput(t *testing.T) {
+	input, warnings, err := NormalizeInputWithWarnings(map[string]any{
+		"type": "object",
+		"properties": map[string]any{
+			"name": map[string]any{"type": "string"},
+		},
+	}, map[string]any{
+		"name":     "daily",
+		"schedule": "0 9 * * *",
+	})
+	if err != nil {
+		t.Fatalf("NormalizeInputWithWarnings() error = %v", err)
+	}
+	if input["name"] != "daily" {
+		t.Fatalf("input = %#v", input)
+	}
+	if len(warnings) != 1 ||
+		warnings[0].Code != "unknown_input_ignored" ||
+		!strings.Contains(warnings[0].Message, `"schedule"`) {
+		t.Fatalf("warnings = %#v", warnings)
 	}
 }
 

--- a/packages/appcli/core/manifest.go
+++ b/packages/appcli/core/manifest.go
@@ -218,14 +218,25 @@ func validateInputSchema(schema map[string]any, location string) error {
 		if !ok {
 			return fmt.Errorf("cli manifest %s.properties.%s must be an object", location, name)
 		}
-		switch schemaType(propertyMap) {
+		propertyType := schemaType(propertyMap)
+		switch propertyType {
 		case "string", "boolean", "integer":
 		default:
 			return fmt.Errorf("cli manifest %s.properties.%s.type must be string, boolean, or integer", location, name)
 		}
 		for key := range propertyMap {
-			if key != "type" && key != "description" {
+			if key != "type" && key != "description" && key != "enum" && key != "default" {
 				return fmt.Errorf("cli manifest %s.properties.%s has unsupported key %q", location, name, key)
+			}
+		}
+		if enum, ok := propertyMap["enum"]; ok {
+			if err := validateInputSchemaEnum(propertyType, enum, fmt.Sprintf("%s.properties.%s.enum", location, name)); err != nil {
+				return err
+			}
+		}
+		if defaultValue, ok := propertyMap["default"]; ok {
+			if err := validateInputSchemaValue(propertyType, defaultValue, fmt.Sprintf("%s.properties.%s.default", location, name)); err != nil {
+				return err
 			}
 		}
 	}
@@ -238,6 +249,47 @@ func validateInputSchema(schema map[string]any, location string) error {
 		if key != "type" && key != "properties" && key != "required" {
 			return fmt.Errorf("cli manifest %s has unsupported key %q", location, key)
 		}
+	}
+	return nil
+}
+
+func validateInputSchemaEnum(typeName string, value any, location string) error {
+	items, ok := value.([]any)
+	if !ok {
+		return fmt.Errorf("cli manifest %s must be an array", location)
+	}
+	for index, item := range items {
+		if err := validateInputSchemaValue(typeName, item, fmt.Sprintf("%s[%d]", location, index)); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func validateInputSchemaValue(typeName string, value any, location string) error {
+	switch typeName {
+	case "string":
+		if _, ok := value.(string); !ok {
+			return fmt.Errorf("cli manifest %s must be a string", location)
+		}
+	case "boolean":
+		if _, ok := value.(bool); !ok {
+			return fmt.Errorf("cli manifest %s must be a boolean", location)
+		}
+	case "integer":
+		switch typed := value.(type) {
+		case int, int64:
+			return nil
+		case float64:
+			if typed == float64(int64(typed)) {
+				return nil
+			}
+		case json.Number:
+			if _, err := typed.Int64(); err == nil {
+				return nil
+			}
+		}
+		return fmt.Errorf("cli manifest %s must be an integer", location)
 	}
 	return nil
 }

--- a/packages/appcli/core/manifest_test.go
+++ b/packages/appcli/core/manifest_test.go
@@ -35,6 +35,66 @@ func TestValidateManifestRejectsUnknownVisibility(t *testing.T) {
 	}
 }
 
+func TestValidateManifestAcceptsEnumAndDefaultInputAnnotations(t *testing.T) {
+	err := ValidateManifest(Manifest{
+		SchemaVersion: ManifestSchemaVersion,
+		Scope:         "automation",
+		Commands: []ManifestCommand{{
+			Path:    []string{"create"},
+			Summary: "Create automation",
+			InputSchema: map[string]any{
+				"type": "object",
+				"properties": map[string]any{
+					"schedule-type": map[string]any{
+						"type":        "string",
+						"description": "Schedule type.",
+						"enum":        []any{"manual", "interval", "daily", "weekly", "cron"},
+						"default":     "manual",
+					},
+					"enabled": map[string]any{
+						"type":    "boolean",
+						"default": true,
+					},
+					"interval-minutes": map[string]any{
+						"type":    "integer",
+						"default": 60,
+					},
+				},
+			},
+			Output:  ManifestCommandOutput{DefaultMode: OutputModeJSON, JSON: true},
+			Handler: ManifestCommandHandler{Kind: "http", Method: "POST", Path: "/tutti/cli/create"},
+		}},
+	})
+	if err != nil {
+		t.Fatalf("ValidateManifest() error = %v", err)
+	}
+}
+
+func TestValidateManifestRejectsEnumValuesWithWrongType(t *testing.T) {
+	err := ValidateManifest(Manifest{
+		SchemaVersion: ManifestSchemaVersion,
+		Scope:         "automation",
+		Commands: []ManifestCommand{{
+			Path:    []string{"create"},
+			Summary: "Create automation",
+			InputSchema: map[string]any{
+				"type": "object",
+				"properties": map[string]any{
+					"schedule-type": map[string]any{
+						"type": "string",
+						"enum": []any{"manual", 1},
+					},
+				},
+			},
+			Output:  ManifestCommandOutput{DefaultMode: OutputModeJSON, JSON: true},
+			Handler: ManifestCommandHandler{Kind: "http", Method: "POST", Path: "/tutti/cli/create"},
+		}},
+	})
+	if err == nil {
+		t.Fatal("ValidateManifest() error = nil, want enum type error")
+	}
+}
+
 func TestBuildCommandsBuildsAppCapability(t *testing.T) {
 	manifest := Manifest{
 		SchemaVersion: ManifestSchemaVersion,

--- a/packages/appcli/core/types.go
+++ b/packages/appcli/core/types.go
@@ -62,6 +62,11 @@ type CommandOutput struct {
 	Text    string
 }
 
+type InputWarning struct {
+	Code    string `json:"code"`
+	Message string `json:"message"`
+}
+
 type Command struct {
 	Capability Capability
 	Manifest   ManifestCommand

--- a/packages/clients/tuttid-ts/src/generated/index.ts
+++ b/packages/clients/tuttid-ts/src/generated/index.ts
@@ -234,6 +234,7 @@ export type {
   CliCapabilityVisibility,
   CliCommandId,
   CliCommandOutput,
+  CliCommandWarning,
   ClientOptions,
   CliInvokeContext,
   CliInvokeRequest,

--- a/packages/clients/tuttid-ts/src/generated/types.gen.ts
+++ b/packages/clients/tuttid-ts/src/generated/types.gen.ts
@@ -143,6 +143,12 @@ export type CliCommandOutput = {
     [key: string]: unknown;
   } | null;
   text?: string | null;
+  warnings?: Array<CliCommandWarning>;
+};
+
+export type CliCommandWarning = {
+  code: string;
+  message: string;
 };
 
 export type CliInvokeResponse = {

--- a/services/tuttid/api/daemon_cli.go
+++ b/services/tuttid/api/daemon_cli.go
@@ -213,6 +213,16 @@ func generatedCliCommandOutput(output cliservice.CommandOutput) *tuttigenerated.
 		}
 		result.Value = &value
 	}
+	if len(output.Warnings) > 0 {
+		warnings := make([]tuttigenerated.CliCommandWarning, 0, len(output.Warnings))
+		for _, warning := range output.Warnings {
+			warnings = append(warnings, tuttigenerated.CliCommandWarning{
+				Code:    warning.Code,
+				Message: warning.Message,
+			})
+		}
+		result.Warnings = &warnings
+	}
 	if output.Text != "" {
 		result.Text = stringPointer(output.Text)
 	}

--- a/services/tuttid/api/generated/types.gen.go
+++ b/services/tuttid/api/generated/types.gen.go
@@ -2011,11 +2011,18 @@ type CliCapabilityVisibility string
 
 // CliCommandOutput defines model for CliCommandOutput.
 type CliCommandOutput struct {
-	Columns *[]CliTableColumn         `json:"columns,omitempty"`
-	Kind    CliOutputMode             `json:"kind"`
-	Rows    *[]map[string]interface{} `json:"rows,omitempty"`
-	Text    *string                   `json:"text,omitempty"`
-	Value   *map[string]interface{}   `json:"value,omitempty"`
+	Columns  *[]CliTableColumn         `json:"columns,omitempty"`
+	Kind     CliOutputMode             `json:"kind"`
+	Rows     *[]map[string]interface{} `json:"rows,omitempty"`
+	Text     *string                   `json:"text,omitempty"`
+	Value    *map[string]interface{}   `json:"value,omitempty"`
+	Warnings *[]CliCommandWarning      `json:"warnings,omitempty"`
+}
+
+// CliCommandWarning defines model for CliCommandWarning.
+type CliCommandWarning struct {
+	Code    string `json:"code"`
+	Message string `json:"message"`
 }
 
 // CliInvokeContext Client-supplied invocation context. These fields are hints for routing and audit only; authorization and workspace validation remain daemon-owned.

--- a/services/tuttid/api/openapi/tuttid.v1.yaml
+++ b/services/tuttid/api/openapi/tuttid.v1.yaml
@@ -3515,6 +3515,21 @@ components:
         text:
           type: string
           nullable: true
+        warnings:
+          type: array
+          items:
+            $ref: "#/components/schemas/CliCommandWarning"
+    CliCommandWarning:
+      type: object
+      additionalProperties: false
+      required:
+        - code
+        - message
+      properties:
+        code:
+          type: string
+        message:
+          type: string
     CliInvokeResponse:
       type: object
       additionalProperties: false

--- a/services/tuttid/service/agentsidecar/command_catalog.go
+++ b/services/tuttid/service/agentsidecar/command_catalog.go
@@ -36,17 +36,21 @@ func commandGuideFromCapabilities(cliName string, capabilities []cliservice.Capa
 		if strings.TrimSpace(command.Description) != "" {
 			line += " - " + strings.TrimSpace(command.Description)
 		}
+		if command.InputDetails != "" {
+			line += " Arguments: " + command.InputDetails
+		}
 		lines = append(lines, line)
 	}
 	return strings.Join(lines, "\n")
 }
 
 type runtimeCommand struct {
-	ID          string
-	Summary     string
-	Description string
-	Example     string
-	Rank        int
+	ID           string
+	Summary      string
+	Description  string
+	Example      string
+	InputDetails string
+	Rank         int
 }
 
 func relevantRuntimeCommands(cliName string, capabilities []cliservice.Capability) []runtimeCommand {
@@ -120,11 +124,12 @@ func runtimeCommandFromCapability(cliName string, capability cliservice.Capabili
 		}
 	}
 	return runtimeCommand{
-		ID:          id,
-		Summary:     summary,
-		Description: description,
-		Example:     normalizeCLICommandName(cliName) + " " + path + requiredInputHintForCommand(id, capability.InputSchema) + commandExampleSuffix(id),
-		Rank:        commandRank(id),
+		ID:           id,
+		Summary:      summary,
+		Description:  description,
+		Example:      normalizeCLICommandName(cliName) + " " + path + requiredInputHintForCommand(id, capability.InputSchema) + commandExampleSuffix(id),
+		InputDetails: inputDetailsForCommand(id, capability.InputSchema),
+		Rank:         commandRank(id),
 	}, true
 }
 
@@ -185,6 +190,98 @@ func agentLauncherCommandUsesDefaultModel(id string) bool {
 	default:
 		return false
 	}
+}
+
+func inputDetailsForCommand(id string, schema map[string]any) string {
+	properties := mapSchemaValue(schema["properties"])
+	if len(properties) == 0 {
+		return ""
+	}
+	required := map[string]bool{}
+	for _, name := range stringSliceSchemaValue(schema["required"]) {
+		name = strings.TrimSpace(name)
+		if name != "" {
+			required[name] = true
+		}
+	}
+	if agentLauncherCommandUsesDefaultModel(id) {
+		delete(required, "model")
+	}
+	names := make([]string, 0, len(properties))
+	for name := range properties {
+		name = strings.TrimSpace(name)
+		if name != "" {
+			names = append(names, name)
+		}
+	}
+	sort.SliceStable(names, func(left, right int) bool {
+		leftRequired := required[names[left]]
+		rightRequired := required[names[right]]
+		if leftRequired != rightRequired {
+			return leftRequired
+		}
+		return names[left] < names[right]
+	})
+	parts := make([]string, 0, len(names))
+	for _, name := range names {
+		property := mapSchemaValue(properties[name])
+		detail := "--" + name
+		if typ := schemaTypeLabel(property); typ != "" {
+			detail += " <" + typ + ">"
+		}
+		var qualifiers []string
+		if required[name] {
+			qualifiers = append(qualifiers, "required")
+		} else {
+			qualifiers = append(qualifiers, "optional")
+		}
+		if enum := stringSliceSchemaValue(property["enum"]); len(enum) > 0 {
+			qualifiers = append(qualifiers, "values: "+strings.Join(enum, "|"))
+		}
+		if defaultValue, ok := property["default"]; ok {
+			if defaultText := strings.TrimSpace(fmt.Sprint(defaultValue)); defaultText != "" {
+				qualifiers = append(qualifiers, "default: "+defaultText)
+			}
+		}
+		if len(qualifiers) > 0 {
+			detail += " (" + strings.Join(qualifiers, "; ") + ")"
+		}
+		if description := strings.TrimSpace(asSchemaString(property["description"])); description != "" {
+			detail += " - " + description
+		}
+		parts = append(parts, detail)
+	}
+	return strings.Join(parts, "; ")
+}
+
+func schemaTypeLabel(property map[string]any) string {
+	typeLabel := strings.TrimSpace(asSchemaString(property["type"]))
+	switch typeLabel {
+	case "integer", "number":
+		return "number"
+	case "boolean":
+		return "true|false"
+	case "array":
+		return "json"
+	case "object":
+		return "json"
+	default:
+		return typeLabel
+	}
+}
+
+func mapSchemaValue(value any) map[string]any {
+	if typed, ok := value.(map[string]any); ok {
+		return typed
+	}
+	return nil
+}
+
+func asSchemaString(value any) string {
+	if text, ok := value.(string); ok {
+		return text
+	}
+	return ""
 }
 
 func commandExampleSuffix(id string) string {

--- a/services/tuttid/service/agentsidecar/command_catalog_test.go
+++ b/services/tuttid/service/agentsidecar/command_catalog_test.go
@@ -27,7 +27,21 @@ func TestCommandGuideFromCapabilitiesUsesRelevantRegistryCommands(t *testing.T) 
 			Path:        []string{"issue", "list"},
 			Summary:     "List issues",
 			Description: "List issue records in one workspace topic. Requires --topic-id; use `issue topic list --json` first when the topic is unknown. JSON output omits issue content bodies.",
-			InputSchema: map[string]any{"required": []any{"topic-id"}},
+			InputSchema: map[string]any{
+				"properties": map[string]any{
+					"topic-id": map[string]any{
+						"type":        "string",
+						"description": "Issue topic id.",
+					},
+					"status": map[string]any{
+						"type":        "string",
+						"description": "Optional issue status filter.",
+						"enum":        []any{"open", "completed"},
+						"default":     "open",
+					},
+				},
+				"required": []any{"topic-id"},
+			},
 		},
 		{
 			ID:          "issue-manager.issue.get",
@@ -135,6 +149,10 @@ func TestCommandGuideFromCapabilitiesUsesRelevantRegistryCommands(t *testing.T) 
 	}
 	if strings.Contains(guide, "use `issue topic list --json` first when the topic is unknown") {
 		t.Fatalf("guide contains unqualified topic discovery guidance: %q", guide)
+	}
+	if !strings.Contains(guide, "--topic-id <string> (required) - Issue topic id.") ||
+		!strings.Contains(guide, "--status <string> (optional; values: open|completed; default: open) - Optional issue status filter.") {
+		t.Fatalf("guide missing argument details: %q", guide)
 	}
 	if !strings.Contains(guide, "tutti issue update --issue-id <issue-id> --status completed --json") {
 		t.Fatalf("guide missing issue update: %q", guide)

--- a/services/tuttid/service/agentsidecar/skill_templates/workspace-app.md
+++ b/services/tuttid/service/agentsidecar/skill_templates/workspace-app.md
@@ -31,12 +31,13 @@ After reading the mention query, recover the smallest useful app context through
 3. If `appId` is `agent-codex` and the user asks to start Codex work, use `{{CLI_COMMAND}} codex start --prompt <task> --show --json`. Add `--model <model>` only when the user explicitly requested a model or command output gives an exact model to reuse.
 4. If `appId` is `agent-claude-code` and the user asks to start Claude Code work, use `{{CLI_COMMAND}} claude start --prompt <task> --show --json`. Add `--model <model>` only when the user explicitly requested a model or command output gives an exact model to reuse.
 5. If `appId` is `issue-manager` and the user asks issue/task work, read and follow the injected `issue-manager` skill for issue/task context and workflows before using generic workspace app command matching.
-6. When `--cwd` is not specified, tuttid inherits the caller agent session working directory.
-7. For agent launcher mentions, ask for a missing task prompt before invoking. Do not ask for a missing model; when `--model` is omitted, tuttid uses the target provider's configured/default model. If the user provided a model and the command rejects it, use the error's available model list to ask for or select a valid value.
-8. For other app ids, use the injected Tutti command guide, find command entries whose metadata says `App id: <appId>` in its `## Commands` section, then run the exact backticked command path shown there. The actual CLI prefix is `{{CLI_COMMAND}}` and may be a production command or a local debug command. If no entry is listed, refresh the command guide or skill bundle capability reference that preserves `App id:` metadata before deciding the app command is unavailable.
-9. If several apps have similar names, match by `appId` from the mention, not only by the visible label.
-10. Use the listed `{{CLI_COMMAND}} <scope> <command>` examples to inspect or invoke the app. Do not derive a command path from the skill slug.
-11. Prefer `--json` when the command output is used as context for reasoning.
+6. For any workspace app mention, if the injected command guide exposes app-specific CLI capabilities for the requested operation, use those persisted app commands instead of provider-native or OS-native substitutes. The external app owns the exact command syntax, validation rules, and domain-specific restrictions through its capability metadata, command guide, and command handler errors.
+7. When `--cwd` is not specified, tuttid inherits the caller agent session working directory.
+8. For agent launcher mentions, ask for a missing task prompt before invoking. Do not ask for a missing model; when `--model` is omitted, tuttid uses the target provider's configured/default model. If the user provided a model and the command rejects it, use the error's available model list to ask for or select a valid value.
+9. For other app ids, use the injected Tutti command guide, find command entries whose metadata says `App id: <appId>` in its `## Commands` section, then run the exact backticked command path shown there. The actual CLI prefix is `{{CLI_COMMAND}}` and may be a production command or a local debug command. If no entry is listed, refresh the command guide or skill bundle capability reference that preserves `App id:` metadata before deciding the app command is unavailable.
+10. If several apps have similar names, match by `appId` from the mention, not only by the visible label.
+11. Use the listed `{{CLI_COMMAND}} <scope> <command>` examples to inspect or invoke the app. Do not derive a command path from the skill slug.
+12. Prefer `--json` when the command output is used as context for reasoning.
 
 If the mentioned app has no visible CLI commands after checking the injected `tutti-cli` command guide and any refreshed capability reference that preserves `App id:` metadata, explain that the app is not currently exposing usable CLI capabilities instead of guessing an app-specific command.
 

--- a/services/tuttid/service/cli/appcli/registry.go
+++ b/services/tuttid/service/cli/appcli/registry.go
@@ -214,30 +214,13 @@ func (r *Registry) Invoke(ctx context.Context, request cliservice.InvokeRequest)
 	if err != nil {
 		return cliservice.CommandOutput{}, serviceInvokeError(err)
 	}
-	output = appendInputWarningsToOutput(output, warnings)
 	output, err = appclicore.ValidateCommandOutput(command.Capability.Output, output)
 	if err != nil {
 		return cliservice.CommandOutput{}, serviceInvokeError(err)
 	}
-	return serviceCommandOutput(output), nil
-}
-
-func appendInputWarningsToOutput(output appclicore.CommandOutput, warnings []appclicore.InputWarning) appclicore.CommandOutput {
-	if len(warnings) == 0 || output.Kind != appclicore.OutputModeJSON {
-		return output
-	}
-	if output.Value == nil {
-		output.Value = map[string]any{}
-	}
-	values := make([]map[string]any, 0, len(warnings))
-	for _, warning := range warnings {
-		values = append(values, map[string]any{
-			"code":    warning.Code,
-			"message": warning.Message,
-		})
-	}
-	output.Value["warnings"] = values
-	return output
+	result := serviceCommandOutput(output)
+	result.Warnings = serviceInputWarnings(warnings)
+	return result, nil
 }
 
 func (r *Registry) command(workspaceID string, commandID string) (appclicore.RegisteredApp, appclicore.Command, bool) {
@@ -460,6 +443,20 @@ func serviceCommandOutput(output appclicore.CommandOutput) cliservice.CommandOut
 		Value:   output.Value,
 		Text:    output.Text,
 	}
+}
+
+func serviceInputWarnings(warnings []appclicore.InputWarning) []cliservice.CommandWarning {
+	if len(warnings) == 0 {
+		return nil
+	}
+	result := make([]cliservice.CommandWarning, 0, len(warnings))
+	for _, warning := range warnings {
+		result = append(result, cliservice.CommandWarning{
+			Code:    warning.Code,
+			Message: warning.Message,
+		})
+	}
+	return result
 }
 
 func serviceTableColumns(columns []appclicore.TableColumn) []cliservice.TableColumn {

--- a/services/tuttid/service/cli/appcli/registry.go
+++ b/services/tuttid/service/cli/appcli/registry.go
@@ -189,7 +189,7 @@ func (r *Registry) Invoke(ctx context.Context, request cliservice.InvokeRequest)
 	if request.OutputMode == "" {
 		request.OutputMode = serviceOutputMode(command.Capability.Output.DefaultMode)
 	}
-	input, err := appclicore.NormalizeInput(command.Manifest.InputSchema, request.Input)
+	input, warnings, err := appclicore.NormalizeInputWithWarnings(command.Manifest.InputSchema, request.Input)
 	if err != nil {
 		return cliservice.CommandOutput{}, serviceInvokeError(err)
 	}
@@ -214,11 +214,30 @@ func (r *Registry) Invoke(ctx context.Context, request cliservice.InvokeRequest)
 	if err != nil {
 		return cliservice.CommandOutput{}, serviceInvokeError(err)
 	}
+	output = appendInputWarningsToOutput(output, warnings)
 	output, err = appclicore.ValidateCommandOutput(command.Capability.Output, output)
 	if err != nil {
 		return cliservice.CommandOutput{}, serviceInvokeError(err)
 	}
 	return serviceCommandOutput(output), nil
+}
+
+func appendInputWarningsToOutput(output appclicore.CommandOutput, warnings []appclicore.InputWarning) appclicore.CommandOutput {
+	if len(warnings) == 0 || output.Kind != appclicore.OutputModeJSON {
+		return output
+	}
+	if output.Value == nil {
+		output.Value = map[string]any{}
+	}
+	values := make([]map[string]any, 0, len(warnings))
+	for _, warning := range warnings {
+		values = append(values, map[string]any{
+			"code":    warning.Code,
+			"message": warning.Message,
+		})
+	}
+	output.Value["warnings"] = values
+	return output
 }
 
 func (r *Registry) command(workspaceID string, commandID string) (appclicore.RegisteredApp, appclicore.Command, bool) {

--- a/services/tuttid/service/cli/appcli/registry_test.go
+++ b/services/tuttid/service/cli/appcli/registry_test.go
@@ -205,7 +205,7 @@ func TestRegistryInvokeIgnoresUnknownInput(t *testing.T) {
 			t.Fatalf("decode envelope: %v", err)
 		}
 		w.Header().Set("Content-Type", "application/json")
-		_, _ = w.Write([]byte(`{"kind":"json","value":{"ok":true}}`))
+		_, _ = w.Write([]byte(`{"kind":"json","value":{"ok":true,"warnings":"app-defined"}}`))
 	}))
 	defer server.Close()
 
@@ -224,9 +224,11 @@ func TestRegistryInvokeIgnoresUnknownInput(t *testing.T) {
 	if output.Kind != cliservice.OutputModeJSON {
 		t.Fatalf("output = %#v", output)
 	}
-	warnings, ok := output.Value["warnings"].([]map[string]any)
-	if !ok || len(warnings) != 1 || warnings[0]["code"] != "unknown_input_ignored" {
-		t.Fatalf("output warnings = %#v", output.Value["warnings"])
+	if output.Value["warnings"] != "app-defined" {
+		t.Fatalf("app output warnings field was clobbered: %#v", output.Value["warnings"])
+	}
+	if len(output.Warnings) != 1 || output.Warnings[0].Code != "unknown_input_ignored" {
+		t.Fatalf("output warnings = %#v", output.Warnings)
 	}
 	input, ok := envelope["input"].(map[string]any)
 	if !ok || input["name"] != "daily" {

--- a/services/tuttid/service/cli/appcli/registry_test.go
+++ b/services/tuttid/service/cli/appcli/registry_test.go
@@ -224,6 +224,10 @@ func TestRegistryInvokeIgnoresUnknownInput(t *testing.T) {
 	if output.Kind != cliservice.OutputModeJSON {
 		t.Fatalf("output = %#v", output)
 	}
+	warnings, ok := output.Value["warnings"].([]map[string]any)
+	if !ok || len(warnings) != 1 || warnings[0]["code"] != "unknown_input_ignored" {
+		t.Fatalf("output warnings = %#v", output.Value["warnings"])
+	}
 	input, ok := envelope["input"].(map[string]any)
 	if !ok || input["name"] != "daily" {
 		t.Fatalf("envelope input = %#v", envelope["input"])

--- a/services/tuttid/service/cli/types.go
+++ b/services/tuttid/service/cli/types.go
@@ -79,11 +79,17 @@ type InvokeRequest struct {
 }
 
 type CommandOutput struct {
-	Kind    OutputMode
-	Columns []TableColumn
-	Rows    []map[string]any
-	Value   map[string]any
-	Text    string
+	Kind     OutputMode
+	Columns  []TableColumn
+	Rows     []map[string]any
+	Value    map[string]any
+	Text     string
+	Warnings []CommandWarning
+}
+
+type CommandWarning struct {
+	Code    string
+	Message string
 }
 
 type Handler func(context.Context, InvokeRequest) (CommandOutput, error)

--- a/services/tuttid/service/workspace/app_factory_reference/references/cli-manifest-contract.md
+++ b/services/tuttid/service/workspace/app_factory_reference/references/cli-manifest-contract.md
@@ -64,8 +64,9 @@ Rules:
 - Handler `kind` must be `http`, `method` must be `POST`, and `path` must start with `/tutti/cli/`.
 - Do not declare host, port, or full URLs; Tutti routes to the app runtime port.
 - Handler `timeoutMs`, when present, must be an integer between `1000` and `600000`.
-- Supported input schema is a small object-only subset: `type`, `properties`, `required`, and property `description`.
+- Supported input schema is a small object-only subset: `type`, `properties`, `required`, and property `description`, `enum`, and `default`.
 - Property `type` may be `string`, `boolean`, or `integer`.
+- Property `enum` and `default` values must match the declared property type. Treat `default` as manifest metadata for help and discovery; app handlers must still apply any business default they need.
 - `defaultMode` may be `json` or `table`; table output must declare static columns.
 - Successful handler responses must return the `CliCommandOutput` shape directly. Do not wrap it in an invoke response such as `{"ok":true,"output":...}`.
 


### PR DESCRIPTION
## Summary
- Allow app CLI manifests to expose enum/default metadata and render values/defaults in dynamic command help.
- Carry richer command input metadata through app CLI registry and agent sidecar catalog flows.
- Update related CLI contract docs and tests.
- Includes all uncommitted changes that were present in the tutti worktree.

## Verification
- `pnpm lint:go`
- Husky pre-push `check:full` passed while pushing `feat/better-cli`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced CLI help with nested command groups, bounded previews, and improved required-flag rendering.
  * CLI help now shows schema-derived flag `Values` and `Default`, and command guides include an “Arguments” section.
  * Provider prompt text now includes mention handoff routing when applicable.
* **Bug Fixes**
  * Unknown input fields now produce warnings (`unknown_input_ignored`) and are preserved in JSON where applicable.
  * Command output/JSON now surfaces command warnings consistently (including in API responses).
* **Documentation**
  * Updated CLI manifest/schema contract to support and validate `enum` and `default` for input schemas.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->