### PR TITLE
refactor(events): extract catalog-agnostic event-stream core (TS + Go)

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -8,6 +8,7 @@
   "commit": false,
   "fixed": [
     [
+      "@tutti-os/event-stream-core",
       "@tutti-os/workspace-file-manager",
       "@tutti-os/workspace-file-reference",
       "@tutti-os/workspace-issue-manager",

--- a/.changeset/event-stream-core-extract.md
+++ b/.changeset/event-stream-core-extract.md
@@ -1,0 +1,11 @@
+---
+"@tutti-os/event-stream-core": minor
+---
+
+Extract the catalog-agnostic event-stream transport core into a publishable
+package. The connection lifecycle, heartbeat, backoff reconnect, frame
+encode/decode and subscription registry now live in `@tutti-os/event-stream-core`,
+generic over the client/server event and scope types and parameterized by an
+injected `EventStreamProtocol`. `@tutti-os/client-tuttid-ts` keeps its public
+`createTuttidEventStreamClient` surface unchanged and becomes a thin tutti
+binding (workspace `scope.workspaceId`) on top of the core.

--- a/apps/desktop/electron.vite.config.ts
+++ b/apps/desktop/electron.vite.config.ts
@@ -48,6 +48,7 @@ const externalizeRuntimeDeps = externalizeDepsPlugin({
     "@tutti-os/client-tuttid-ts",
     "@tutti-os/browser-node",
     "@tutti-os/event-protocol",
+    "@tutti-os/event-stream-core",
     "@tutti-os/agent-gui",
     "@tutti-os/ui-i18n-runtime",
     "@tutti-os/ui-system",

--- a/go.work
+++ b/go.work
@@ -4,6 +4,8 @@ toolchain go1.24.5
 
 use ./services/tuttid
 
+use ./packages/events/stream-go
+
 use ./apps/cli
 
 use ./packages/workbench/service

--- a/packages/clients/tuttid-ts/package.json
+++ b/packages/clients/tuttid-ts/package.json
@@ -11,7 +11,8 @@
     ".": "./src/index.ts"
   },
   "dependencies": {
-    "@tutti-os/event-protocol": "workspace:*"
+    "@tutti-os/event-protocol": "workspace:*",
+    "@tutti-os/event-stream-core": "workspace:*"
   },
   "devDependencies": {
     "@types/node": "^24.0.1",

--- a/packages/clients/tuttid-ts/src/eventStreamClient.ts
+++ b/packages/clients/tuttid-ts/src/eventStreamClient.ts
@@ -1,11 +1,25 @@
+// Tutti binding of the catalog-agnostic transport core (@tutti-os/event-stream-core).
+//
+// The transport logic (connect / heartbeat / reconnect / frame send-recv /
+// subscription registry) lives in the core package. This module only injects the
+// tutti workspace protocol (validators, version/revision, workspaceId scope
+// strategy, client-event construction) and re-exposes the strongly typed
+// `TuttidEventStreamClient` surface so existing callers are unchanged.
+
+import {
+  createEventStreamClient,
+  type EventStreamConnectionState,
+  type EventStreamHeartbeatConfig,
+  type EventStreamProtocol,
+  type EventStreamReconnectConfig,
+  type EventStreamSocketFactory
+} from "@tutti-os/event-stream-core";
 import {
   assertValidClientFrame,
   assertValidServerFrame,
   businessEventCatalogRevision,
   businessEventProtocolVersion,
-  type BusinessEventClientFrameV1,
   type BusinessEventScopeV1,
-  type BusinessEventServerFrameV1,
   type ClientToServerEventTopic,
   type ClientToServerEventV1,
   type ServerToClientEventTopic,
@@ -15,9 +29,9 @@ import {
 export interface CreateTuttidEventStreamClientInput {
   defaultScope?: BusinessEventScopeV1;
   resolveUrl: () => Promise<string> | string;
-  webSocketFactory?: TuttidEventStreamSocketFactory;
-  heartbeat?: Partial<TuttidEventStreamHeartbeatConfig>;
-  reconnect?: false | Partial<TuttidEventStreamReconnectConfig>;
+  webSocketFactory?: EventStreamSocketFactory;
+  heartbeat?: Partial<EventStreamHeartbeatConfig>;
+  reconnect?: false | Partial<EventStreamReconnectConfig>;
 }
 
 type ClientEventByTopic = {
@@ -51,686 +65,65 @@ export interface TuttidEventStreamClient {
   ): () => void;
 }
 
-export type TuttidEventStreamConnectionState =
-  | "connected"
-  | "connecting"
-  | "disconnected"
-  | "disposed";
+export type TuttidEventStreamConnectionState = EventStreamConnectionState;
 
 export interface TuttidEventStreamSubscribeOptions {
   scope?: BusinessEventScopeV1 | null;
 }
 
-type TuttidEventStreamSocketFactory = (url: string) => TuttidEventStreamSocket;
-
-interface TuttidEventStreamSocket {
-  addEventListener(type: "close", listener: (event: CloseEvent) => void): void;
-  addEventListener(type: "error", listener: (event: Event) => void): void;
-  addEventListener(
-    type: "message",
-    listener: (event: MessageEvent) => void
-  ): void;
-  removeEventListener(
-    type: "close",
-    listener: (event: CloseEvent) => void
-  ): void;
-  removeEventListener(type: "error", listener: (event: Event) => void): void;
-  removeEventListener(
-    type: "message",
-    listener: (event: MessageEvent) => void
-  ): void;
-  close(code?: number, reason?: string): void;
-  send(data: string): void;
-}
-
-interface PendingPublish {
-  reject: (error: Error) => void;
-  resolve: () => void;
-}
-
-interface EventSubscriptionEntry {
-  listeners: Set<(event: ServerToClientEventV1) => void>;
-  scope?: BusinessEventScopeV1;
-  topic: ServerToClientEventTopic;
-}
-
-type ParsedServerFrame =
-  | {
-      frame: BusinessEventServerFrameV1;
-      ok: true;
-    }
-  | {
-      error: Error;
-      ok: false;
-    };
-
-interface SocketListeners {
-  close: (event: CloseEvent) => void;
-  error: (event: Event) => void;
-  message: (event: MessageEvent) => void;
-}
-
-type TimerCleanup = () => void;
-
-interface TuttidEventStreamHeartbeatConfig {
-  pingIntervalMs: number;
-  pongTimeoutMs: number;
-  scheduleInterval: (callback: () => void, delayMs: number) => TimerCleanup;
-  scheduleTimeout: (callback: () => void, delayMs: number) => TimerCleanup;
-}
-
-interface TuttidEventStreamReconnectConfig {
-  initialDelayMs: number;
-  maxDelayMs: number;
-  scheduleTimeout: (callback: () => void, delayMs: number) => TimerCleanup;
-}
-
-const defaultHeartbeatConfig: TuttidEventStreamHeartbeatConfig = {
-  pingIntervalMs: 15_000,
-  pongTimeoutMs: 10_000,
-  scheduleInterval: (callback, delayMs) => {
-    const handle = globalThis.setInterval(callback, delayMs);
-    return () => {
-      globalThis.clearInterval(handle);
-    };
+const tuttiEventStreamProtocol: EventStreamProtocol<
+  ClientToServerEventV1,
+  BusinessEventScopeV1
+> = {
+  protocolVersion: businessEventProtocolVersion,
+  catalogRevision: businessEventCatalogRevision,
+  assertValidClientFrame(frame) {
+    assertValidClientFrame(frame);
   },
-  scheduleTimeout: (callback, delayMs) => {
-    const handle = globalThis.setTimeout(callback, delayMs);
-    return () => {
-      globalThis.clearTimeout(handle);
-    };
-  }
-};
-const handshakeFailureCloseCode = 4002;
-
-const defaultReconnectConfig: TuttidEventStreamReconnectConfig = {
-  initialDelayMs: 500,
-  maxDelayMs: 10_000,
-  scheduleTimeout: (callback, delayMs) => {
-    const handle = globalThis.setTimeout(callback, delayMs);
-    return () => {
-      globalThis.clearTimeout(handle);
-    };
+  assertValidServerFrame(frame) {
+    assertValidServerFrame(frame);
+  },
+  createClientEvent(topic, payload) {
+    return {
+      emittedAt: new Date().toISOString(),
+      id: globalThis.crypto.randomUUID(),
+      payload,
+      topic,
+      version: businessEventProtocolVersion
+    } as ClientToServerEventV1;
+  },
+  normalizeScope(scope) {
+    const workspaceId = scope?.workspaceId?.trim();
+    if (!workspaceId) {
+      return undefined;
+    }
+    return { workspaceId };
+  },
+  scopeKey(scope) {
+    return scope?.workspaceId ?? "";
+  },
+  eventMatchesScope(eventScope, subscriptionScope) {
+    const workspaceId = subscriptionScope?.workspaceId?.trim();
+    if (!workspaceId) {
+      return true;
+    }
+    return eventScope?.workspaceId?.trim() === workspaceId;
   }
 };
 
 export function createTuttidEventStreamClient(
   input: CreateTuttidEventStreamClientInput
 ): TuttidEventStreamClient {
-  const webSocketFactory =
-    input.webSocketFactory ?? defaultTuttidEventStreamSocketFactory;
-  const heartbeat = {
-    ...defaultHeartbeatConfig,
-    ...input.heartbeat
-  };
-  const defaultScope = normalizeSubscriptionScope(input.defaultScope);
-  const subscriptions = new Map<string, EventSubscriptionEntry>();
-  const pendingPublishes = new Map<string, PendingPublish>();
-  const connectionStateListeners = new Set<
-    (state: TuttidEventStreamConnectionState) => void
-  >();
-  const reconnect =
-    input.reconnect === false
-      ? null
-      : {
-          ...defaultReconnectConfig,
-          ...input.reconnect
-        };
-  let socket: TuttidEventStreamSocket | null = null;
-  let connectPromise: Promise<void> | null = null;
-  let ready = false;
-  let disposed = false;
-  let nextRequestID = 1;
-  let heartbeatIntervalCleanup: TimerCleanup | null = null;
-  let pongTimeoutCleanup: TimerCleanup | null = null;
-  let reconnectCleanup: TimerCleanup | null = null;
-  let reconnectAttempt = 0;
-  let awaitingPong = false;
-
-  return {
-    connect() {
-      return connectInternal();
-    },
-    dispose() {
-      disposed = true;
-      cancelReconnect();
-      const activeSocket = socket;
-      if (!activeSocket) {
-        connectPromise = null;
-        ready = false;
-        notifyConnectionState("disposed");
-        return;
-      }
-
-      resetSocketState(activeSocket);
-      rejectPendingPublishes(new Error("Tuttid event stream was disposed."));
-      activeSocket.close(1000, "disposed");
-      notifyConnectionState("disposed");
-    },
-    async publishIntent(topic, payload) {
-      await this.connect();
-
-      const activeSocket = socket;
-      if (!activeSocket || !ready) {
-        throw new Error("Tuttid event stream is not connected.");
-      }
-
-      const requestId = createRequestID();
-      const completion = createPendingPublishCompletion(requestId);
-      pendingPublishes.set(requestId, completion);
-
-      const frame: BusinessEventClientFrameV1 = {
-        event: createClientEvent(topic, payload),
-        kind: "publish",
-        requestId
-      };
-      assertValidClientFrame(frame);
-      activeSocket.send(JSON.stringify(frame));
-
-      return await completion.promise;
-    },
-    subscribe(topic, listener, options) {
-      const scope =
-        options?.scope === null
-          ? undefined
-          : normalizeSubscriptionScope(options?.scope ?? defaultScope);
-      const key = createSubscriptionKey(topic, scope);
-      let subscription = subscriptions.get(key);
-      if (!subscription) {
-        subscription = {
-          listeners: new Set(),
-          scope,
-          topic
-        };
-        subscriptions.set(key, subscription);
-      }
-
-      subscription.listeners.add(
-        listener as (event: ServerToClientEventV1) => void
-      );
-      flushSubscription(subscription);
-
-      return () => {
-        const currentSubscription = subscriptions.get(key);
-        if (!currentSubscription) {
-          return;
-        }
-
-        currentSubscription.listeners.delete(
-          listener as (event: ServerToClientEventV1) => void
-        );
-        if (currentSubscription.listeners.size === 0) {
-          subscriptions.delete(key);
-          flushUnsubscription(currentSubscription);
-        }
-      };
-    },
-    subscribeConnectionState(listener) {
-      connectionStateListeners.add(listener);
-      return () => {
-        connectionStateListeners.delete(listener);
-      };
-    }
-  };
-
-  function connectInternal(): Promise<void> {
-    if (disposed) {
-      return Promise.reject(new Error("Tuttid event stream was disposed."));
-    }
-    cancelReconnect();
-    if (connectPromise) {
-      return connectPromise;
-    }
-
-    connectPromise = (async () => {
-      notifyConnectionState("connecting");
-      const url = await input.resolveUrl();
-      const nextSocket = webSocketFactory(url);
-      socket = nextSocket;
-      ready = false;
-
-      return await new Promise<void>((resolve, reject) => {
-        let settled = false;
-        let listeners: SocketListeners | null = null;
-
-        const fail = (error: Error) => {
-          if (settled) {
-            return;
-          }
-
-          settled = true;
-          detachSocketListeners(nextSocket, listeners);
-          listeners = null;
-          resetSocketState(nextSocket);
-          nextSocket.close(handshakeFailureCloseCode, "handshake_failed");
-          scheduleReconnect();
-          reject(error);
-        };
-
-        const messageListener = (event: MessageEvent) => {
-          const parsedFrame = parseServerFrame(event.data);
-          if (!parsedFrame.ok) {
-            if (!ready) {
-              fail(parsedFrame.error);
-            }
-            return;
-          }
-
-          const frame = parsedFrame.frame;
-
-          if (!ready) {
-            if (frame.kind !== "ready") {
-              fail(
-                frame.kind === "error"
-                  ? createFrameError(frame)
-                  : new Error(
-                      `Tuttid event stream received an unexpected ${frame.kind} frame before ready.`
-                    )
-              );
-              return;
-            }
-
-            if (frame.protocolVersion !== businessEventProtocolVersion) {
-              fail(
-                new Error(
-                  `Tuttid event stream protocol version mismatch. Expected ${String(businessEventProtocolVersion)}, received ${String(frame.protocolVersion)}.`
-                )
-              );
-              return;
-            }
-
-            if (frame.catalogRevision !== businessEventCatalogRevision) {
-              fail(
-                new Error(
-                  `Tuttid event stream catalog revision mismatch. Expected ${businessEventCatalogRevision}, received ${frame.catalogRevision}.`
-                )
-              );
-              return;
-            }
-
-            ready = true;
-            reconnectAttempt = 0;
-            flushSubscriptions();
-            startHeartbeat(nextSocket);
-            notifyConnectionState("connected");
-            if (!settled) {
-              settled = true;
-              resolve();
-            }
-            return;
-          }
-
-          handleServerFrame(frame);
-        };
-        const errorListener = () => {
-          if (!ready) {
-            fail(new Error("Tuttid event stream connection failed."));
-          }
-        };
-        const closeListener = (event: CloseEvent) => {
-          const closeError = createCloseError(event);
-          if (!ready) {
-            fail(closeError);
-            return;
-          }
-
-          detachSocketListeners(nextSocket, listeners);
-          listeners = null;
-          resetSocketState(nextSocket);
-          rejectPendingPublishes(closeError);
-          scheduleReconnect();
-        };
-
-        listeners = {
-          close: closeListener,
-          error: errorListener,
-          message: messageListener
-        };
-
-        nextSocket.addEventListener("message", messageListener);
-        nextSocket.addEventListener("error", errorListener);
-        nextSocket.addEventListener("close", closeListener);
-      });
-    })();
-
-    connectPromise.catch(() => {});
-    return connectPromise;
-  }
-
-  function createRequestID(): string {
-    return String(nextRequestID++);
-  }
-
-  function createPendingPublishCompletion(requestId: string): PendingPublish & {
-    promise: Promise<void>;
-  } {
-    let rejectFn: (error: Error) => void = () => {};
-    let resolveFn: () => void = () => {};
-    const promise = new Promise<void>((resolve, reject) => {
-      resolveFn = () => {
-        pendingPublishes.delete(requestId);
-        resolve();
-      };
-      rejectFn = (error) => {
-        pendingPublishes.delete(requestId);
-        reject(error);
-      };
-    });
-
-    return {
-      promise,
-      reject: rejectFn,
-      resolve: resolveFn
-    };
-  }
-
-  function flushSubscriptions() {
-    if (!socket || !ready) {
-      return;
-    }
-
-    for (const subscription of subscriptions.values()) {
-      flushSubscription(subscription);
-    }
-  }
-
-  function flushSubscription(subscription: EventSubscriptionEntry): void {
-    if (!socket || !ready) {
-      return;
-    }
-    const subscribeFrame: BusinessEventClientFrameV1 = {
-      kind: "subscribe",
-      requestId: createRequestID(),
-      topics: [subscription.topic]
-    };
-    if (subscription.scope) {
-      subscribeFrame.scope = subscription.scope;
-    }
-    assertValidClientFrame(subscribeFrame);
-    socket.send(JSON.stringify(subscribeFrame));
-  }
-
-  function flushUnsubscription(subscription: EventSubscriptionEntry): void {
-    if (!socket || !ready) {
-      return;
-    }
-    const unsubscribeFrame: BusinessEventClientFrameV1 = {
-      kind: "unsubscribe",
-      requestId: createRequestID(),
-      topics: [subscription.topic]
-    };
-    if (subscription.scope) {
-      unsubscribeFrame.scope = subscription.scope;
-    }
-    assertValidClientFrame(unsubscribeFrame);
-    socket.send(JSON.stringify(unsubscribeFrame));
-  }
-
-  function handleServerFrame(frame: BusinessEventServerFrameV1): void {
-    switch (frame.kind) {
-      case "ack": {
-        pendingPublishes.get(frame.requestId)?.resolve();
-        return;
-      }
-      case "error": {
-        if (frame.requestId) {
-          pendingPublishes
-            .get(frame.requestId)
-            ?.reject(createFrameError(frame));
-        }
-        return;
-      }
-      case "event": {
-        for (const subscription of subscriptions.values()) {
-          if (
-            subscription.topic !== frame.event.topic ||
-            !eventMatchesSubscriptionScope(
-              frame.event.scope,
-              subscription.scope
-            )
-          ) {
-            continue;
-          }
-          for (const topicListener of subscription.listeners) {
-            topicListener(frame.event);
-          }
-        }
-        return;
-      }
-      case "pong":
-        resolveHeartbeatPong();
-        return;
-      case "ready":
-        return;
-    }
-  }
-
-  function rejectPendingPublishes(error: Error): void {
-    for (const pendingPublish of pendingPublishes.values()) {
-      pendingPublish.reject(error);
-    }
-    pendingPublishes.clear();
-  }
-
-  function resetSocketState(nextSocket: TuttidEventStreamSocket): void {
-    if (socket === nextSocket) {
-      socket = null;
-    }
-    connectPromise = null;
-    ready = false;
-    stopHeartbeat();
-    if (!disposed) {
-      notifyConnectionState("disconnected");
-    }
-  }
-
-  function startHeartbeat(activeSocket: TuttidEventStreamSocket): void {
-    stopHeartbeat();
-    heartbeatIntervalCleanup = heartbeat.scheduleInterval(() => {
-      if (!ready || socket !== activeSocket || awaitingPong) {
-        return;
-      }
-
-      const pingFrame: BusinessEventClientFrameV1 = {
-        kind: "ping",
-        requestId: createRequestID(),
-        sentAt: new Date().toISOString()
-      };
-      assertValidClientFrame(pingFrame);
-      activeSocket.send(JSON.stringify(pingFrame));
-      awaitingPong = true;
-      pongTimeoutCleanup = heartbeat.scheduleTimeout(() => {
-        if (socket !== activeSocket || !awaitingPong) {
-          return;
-        }
-
-        activeSocket.close(4000, "heartbeat_timeout");
-      }, heartbeat.pongTimeoutMs);
-    }, heartbeat.pingIntervalMs);
-  }
-
-  function resolveHeartbeatPong(): void {
-    awaitingPong = false;
-    if (pongTimeoutCleanup) {
-      pongTimeoutCleanup();
-      pongTimeoutCleanup = null;
-    }
-  }
-
-  function stopHeartbeat(): void {
-    awaitingPong = false;
-    if (heartbeatIntervalCleanup) {
-      heartbeatIntervalCleanup();
-      heartbeatIntervalCleanup = null;
-    }
-    if (pongTimeoutCleanup) {
-      pongTimeoutCleanup();
-      pongTimeoutCleanup = null;
-    }
-  }
-
-  function scheduleReconnect(): void {
-    if (!reconnect || disposed || reconnectCleanup !== null) {
-      return;
-    }
-    reconnectAttempt += 1;
-    const delayMs = Math.min(
-      reconnect.initialDelayMs * 2 ** Math.max(0, reconnectAttempt - 1),
-      reconnect.maxDelayMs
-    );
-    reconnectCleanup = reconnect.scheduleTimeout(() => {
-      reconnectCleanup = null;
-      void connectInternal().catch(() => {
-        scheduleReconnect();
-      });
-    }, delayMs);
-  }
-
-  function cancelReconnect(): void {
-    if (!reconnectCleanup) {
-      return;
-    }
-    reconnectCleanup();
-    reconnectCleanup = null;
-  }
-
-  function notifyConnectionState(
-    state: TuttidEventStreamConnectionState
-  ): void {
-    for (const listener of connectionStateListeners) {
-      listener(state);
-    }
-  }
-}
-
-function normalizeSubscriptionScope(
-  scope: BusinessEventScopeV1 | undefined
-): BusinessEventScopeV1 | undefined {
-  const workspaceId = scope?.workspaceId?.trim();
-  if (!workspaceId) {
-    return undefined;
-  }
-  return { workspaceId };
-}
-
-function createSubscriptionKey(
-  topic: ServerToClientEventTopic,
-  scope: BusinessEventScopeV1 | undefined
-): string {
-  return `${topic}\n${scope?.workspaceId ?? ""}`;
-}
-
-function eventMatchesSubscriptionScope(
-  eventScope: BusinessEventScopeV1 | undefined,
-  subscriptionScope: BusinessEventScopeV1 | undefined
-): boolean {
-  const workspaceId = subscriptionScope?.workspaceId?.trim();
-  if (!workspaceId) {
-    return true;
-  }
-  return eventScope?.workspaceId?.trim() === workspaceId;
-}
-
-function createClientEvent<TTopic extends ClientToServerEventTopic>(
-  topic: TTopic,
-  payload: ClientEventByTopic[TTopic]["payload"]
-): ClientEventByTopic[TTopic] {
-  return {
-    emittedAt: new Date().toISOString(),
-    id: globalThis.crypto.randomUUID(),
-    payload,
-    topic,
-    version: businessEventProtocolVersion
-  };
-}
-
-function defaultTuttidEventStreamSocketFactory(
-  url: string
-): TuttidEventStreamSocket {
-  return new WebSocket(url);
-}
-
-function parseServerFrame(data: unknown): ParsedServerFrame {
-  if (typeof data !== "string") {
-    return {
-      error: new Error(
-        "Tuttid event stream received a non-text server frame during handshake."
-      ),
-      ok: false
-    };
-  }
-
-  try {
-    const frame = JSON.parse(data) as unknown;
-    const readyMismatchError = getReadyCompatibilityError(frame);
-    if (readyMismatchError) {
-      return {
-        error: readyMismatchError,
-        ok: false
-      };
-    }
-
-    assertValidServerFrame(frame);
-    return {
-      frame,
-      ok: true
-    };
-  } catch {
-    return {
-      error: new Error(
-        "Tuttid event stream received an invalid server frame during handshake."
-      ),
-      ok: false
-    };
-  }
-}
-
-function getReadyCompatibilityError(frame: unknown): Error | null {
-  if (!isRecord(frame) || frame.kind !== "ready") {
-    return null;
-  }
-
-  if (frame.protocolVersion !== businessEventProtocolVersion) {
-    return new Error(
-      `Tuttid event stream protocol version mismatch. Expected ${businessEventProtocolVersion}, received ${String(frame.protocolVersion)}.`
-    );
-  }
-
-  if (frame.catalogRevision !== businessEventCatalogRevision) {
-    return new Error(
-      `Tuttid event stream catalog revision mismatch. Expected ${businessEventCatalogRevision}, received ${String(frame.catalogRevision)}.`
-    );
-  }
-
-  return null;
-}
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === "object" && value !== null;
-}
-
-function detachSocketListeners(
-  socket: TuttidEventStreamSocket,
-  listeners: SocketListeners | null
-): void {
-  if (!listeners) {
-    return;
-  }
-
-  socket.removeEventListener("message", listeners.message);
-  socket.removeEventListener("error", listeners.error);
-  socket.removeEventListener("close", listeners.close);
-}
-
-function createCloseError(event: CloseEvent): Error {
-  const suffix = event.reason ? `: ${event.reason}` : "";
-  return new Error(
-    `Tuttid event stream closed (${event.code || 1006})${suffix}.`
-  );
-}
-
-function createFrameError(
-  frame: Extract<BusinessEventServerFrameV1, { kind: "error" }>
-): Error {
-  return new Error(frame.message || frame.code || "Tuttid event stream error.");
+  return createEventStreamClient<
+    ClientToServerEventV1,
+    ServerToClientEventV1,
+    BusinessEventScopeV1
+  >({
+    defaultScope: input.defaultScope,
+    heartbeat: input.heartbeat,
+    protocol: tuttiEventStreamProtocol,
+    reconnect: input.reconnect,
+    resolveUrl: input.resolveUrl,
+    webSocketFactory: input.webSocketFactory
+  }) as unknown as TuttidEventStreamClient;
 }

--- a/packages/events/stream-core/README.md
+++ b/packages/events/stream-core/README.md
@@ -1,0 +1,37 @@
+# @tutti-os/event-stream-core
+
+Catalog-agnostic transport core for the business event stream (daemon ↔ renderer
+over WebSocket). It owns the parts that have nothing to do with a concrete event
+catalog:
+
+- connection lifecycle (`connect` / `dispose`)
+- heartbeat (ping/pong) and exponential-backoff reconnect
+- frame encode/decode and the subscription registry
+- `connectionState` observability
+- topic + scope multiplexing over a single socket
+
+Everything catalog-specific — the concrete topics, payload validators, protocol
+version/revision, and the scope axis — is **injected** via an
+`EventStreamProtocol`. The core never imports a concrete catalog, so multiple
+products can bind their own:
+
+```ts
+import { createEventStreamClient } from "@tutti-os/event-stream-core";
+
+const client = createEventStreamClient<MyClientEvent, MyServerEvent, MyScope>({
+  resolveUrl: () => "ws://127.0.0.1:7790/v1/events/ws",
+  protocol: {
+    protocolVersion,
+    catalogRevision,
+    assertValidClientFrame,
+    assertValidServerFrame,
+    createClientEvent,
+    normalizeScope,
+    scopeKey,
+    eventMatchesScope
+  }
+});
+```
+
+The scope type `S` is generic: tutti binds it to `{ workspaceId }`, other products
+(e.g. group chat) can bind it to `{ roomId }`. The transport is identical.

--- a/packages/events/stream-core/package.json
+++ b/packages/events/stream-core/package.json
@@ -1,0 +1,38 @@
+{
+  "name": "@tutti-os/event-stream-core",
+  "version": "0.1.0",
+  "private": false,
+  "type": "module",
+  "types": "./src/index.ts",
+  "exports": {
+    ".": "./src/index.ts"
+  },
+  "files": [
+    "dist",
+    "README.md"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/tutti-os/tutti.git",
+    "directory": "packages/events/stream-core"
+  },
+  "scripts": {
+    "build": "tsup --config tsup.config.ts",
+    "typecheck": "node ../../../tools/scripts/run-tsgo-typecheck.mjs"
+  },
+  "devDependencies": {
+    "@tutti-os/config-tsconfig": "workspace:*",
+    "@types/node": "^24.0.1",
+    "typescript": "^5.8.3"
+  },
+  "publishConfig": {
+    "access": "public",
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js"
+      }
+    },
+    "types": "./dist/index.d.ts"
+  }
+}

--- a/packages/events/stream-core/src/eventStreamClient.ts
+++ b/packages/events/stream-core/src/eventStreamClient.ts
@@ -1,0 +1,716 @@
+// Transport core for the business event stream (daemon ↔ renderer over WS).
+//
+// This is catalog-agnostic infrastructure: connect / heartbeat / reconnect /
+// frame send-recv / subscription registry / connection-state. It knows nothing
+// about concrete topics or scope axes — those are injected via `protocol`
+// (see EventStreamProtocol). Each product (tutti workspace, tsh chat) binds its
+// own protocol and topic/scope types on top.
+
+export type EventStreamConnectionState =
+  | "connected"
+  | "connecting"
+  | "disconnected"
+  | "disposed";
+
+export interface EventStreamSocket {
+  addEventListener(type: "close", listener: (event: CloseEvent) => void): void;
+  addEventListener(type: "error", listener: (event: Event) => void): void;
+  addEventListener(
+    type: "message",
+    listener: (event: MessageEvent) => void
+  ): void;
+  removeEventListener(
+    type: "close",
+    listener: (event: CloseEvent) => void
+  ): void;
+  removeEventListener(type: "error", listener: (event: Event) => void): void;
+  removeEventListener(
+    type: "message",
+    listener: (event: MessageEvent) => void
+  ): void;
+  close(code?: number, reason?: string): void;
+  send(data: string): void;
+}
+
+export type EventStreamSocketFactory = (url: string) => EventStreamSocket;
+
+type TimerCleanup = () => void;
+
+export interface EventStreamHeartbeatConfig {
+  pingIntervalMs: number;
+  pongTimeoutMs: number;
+  scheduleInterval: (callback: () => void, delayMs: number) => TimerCleanup;
+  scheduleTimeout: (callback: () => void, delayMs: number) => TimerCleanup;
+}
+
+export interface EventStreamReconnectConfig {
+  initialDelayMs: number;
+  maxDelayMs: number;
+  scheduleTimeout: (callback: () => void, delayMs: number) => TimerCleanup;
+}
+
+// Wire frame shapes. Structure is fixed; the carried event payload and the
+// scope object are parameterized so each product can bind concrete types.
+export type EventStreamClientFrame<TClientEvent, TScope> =
+  | { kind: "subscribe"; requestId: string; topics: string[]; scope?: TScope }
+  | { kind: "unsubscribe"; requestId: string; topics: string[]; scope?: TScope }
+  | { kind: "publish"; requestId: string; event: TClientEvent }
+  | { kind: "ping"; requestId: string; sentAt: string };
+
+export type EventStreamServerFrame<TServerEvent> =
+  | {
+      kind: "ready";
+      protocolVersion: number;
+      catalogRevision: string;
+      serverTime?: string;
+    }
+  | { kind: "ack"; requestId: string; acceptedAt?: string }
+  | { kind: "error"; requestId?: string; code?: string; message?: string }
+  | { kind: "event"; event: TServerEvent }
+  | { kind: "pong"; requestId: string; sentAt?: string };
+
+// Server events must expose the topic they belong to and (optionally) the scope
+// they were published to, so the core can route + filter them.
+export interface EventStreamServerEvent<TScope> {
+  topic: string;
+  scope?: TScope;
+}
+
+// The product-specific seam. Everything catalog-aware lives here and is injected
+// into the transport core, which never imports a concrete catalog.
+export interface EventStreamProtocol<TClientEvent, TScope> {
+  protocolVersion: number;
+  catalogRevision: string;
+  // Validate-or-throw. The core casts after a successful validation.
+  assertValidClientFrame(frame: unknown): void;
+  assertValidServerFrame(frame: unknown): void;
+  createClientEvent(topic: string, payload: unknown): TClientEvent;
+  // Scope strategy (was hardcoded to workspaceId in the tutti monolith).
+  normalizeScope(scope: TScope | undefined): TScope | undefined;
+  // Canonical serialization of a scope for the subscription-key (scope half only;
+  // the core prepends the topic).
+  scopeKey(scope: TScope | undefined): string;
+  eventMatchesScope(
+    eventScope: TScope | undefined,
+    subscriptionScope: TScope | undefined
+  ): boolean;
+}
+
+export interface CreateEventStreamClientInput<TClientEvent, TScope> {
+  protocol: EventStreamProtocol<TClientEvent, TScope>;
+  resolveUrl: () => Promise<string> | string;
+  defaultScope?: TScope;
+  webSocketFactory?: EventStreamSocketFactory;
+  heartbeat?: Partial<EventStreamHeartbeatConfig>;
+  reconnect?: false | Partial<EventStreamReconnectConfig>;
+}
+
+export interface EventStreamClient<TServerEvent, TScope> {
+  connect(): Promise<void>;
+  dispose(): void;
+  publishIntent(topic: string, payload: unknown): Promise<void>;
+  subscribe(
+    topic: string,
+    listener: (event: TServerEvent) => void,
+    options?: { scope?: TScope | null }
+  ): () => void;
+  subscribeConnectionState(
+    listener: (state: EventStreamConnectionState) => void
+  ): () => void;
+}
+
+interface PendingPublish {
+  reject: (error: Error) => void;
+  resolve: () => void;
+}
+
+interface EventSubscriptionEntry<TServerEvent, TScope> {
+  listeners: Set<(event: TServerEvent) => void>;
+  scope?: TScope;
+  topic: string;
+}
+
+type ParsedServerFrame<TServerEvent> =
+  | { frame: EventStreamServerFrame<TServerEvent>; ok: true }
+  | { error: Error; ok: false };
+
+interface SocketListeners {
+  close: (event: CloseEvent) => void;
+  error: (event: Event) => void;
+  message: (event: MessageEvent) => void;
+}
+
+const defaultHeartbeatConfig: EventStreamHeartbeatConfig = {
+  pingIntervalMs: 15_000,
+  pongTimeoutMs: 10_000,
+  scheduleInterval: (callback, delayMs) => {
+    const handle = globalThis.setInterval(callback, delayMs);
+    return () => {
+      globalThis.clearInterval(handle);
+    };
+  },
+  scheduleTimeout: (callback, delayMs) => {
+    const handle = globalThis.setTimeout(callback, delayMs);
+    return () => {
+      globalThis.clearTimeout(handle);
+    };
+  }
+};
+const handshakeFailureCloseCode = 4002;
+
+const defaultReconnectConfig: EventStreamReconnectConfig = {
+  initialDelayMs: 500,
+  maxDelayMs: 10_000,
+  scheduleTimeout: (callback, delayMs) => {
+    const handle = globalThis.setTimeout(callback, delayMs);
+    return () => {
+      globalThis.clearTimeout(handle);
+    };
+  }
+};
+
+export function createEventStreamClient<
+  TClientEvent,
+  TServerEvent extends EventStreamServerEvent<TScope>,
+  TScope
+>(
+  input: CreateEventStreamClientInput<TClientEvent, TScope>
+): EventStreamClient<TServerEvent, TScope> {
+  const { protocol } = input;
+  const webSocketFactory =
+    input.webSocketFactory ?? defaultEventStreamSocketFactory;
+  const heartbeat = {
+    ...defaultHeartbeatConfig,
+    ...input.heartbeat
+  };
+  const defaultScope = protocol.normalizeScope(input.defaultScope);
+  const subscriptions = new Map<
+    string,
+    EventSubscriptionEntry<TServerEvent, TScope>
+  >();
+  const pendingPublishes = new Map<string, PendingPublish>();
+  const connectionStateListeners = new Set<
+    (state: EventStreamConnectionState) => void
+  >();
+  const reconnect =
+    input.reconnect === false
+      ? null
+      : {
+          ...defaultReconnectConfig,
+          ...input.reconnect
+        };
+  let socket: EventStreamSocket | null = null;
+  let connectPromise: Promise<void> | null = null;
+  let ready = false;
+  let disposed = false;
+  let nextRequestID = 1;
+  let heartbeatIntervalCleanup: TimerCleanup | null = null;
+  let pongTimeoutCleanup: TimerCleanup | null = null;
+  let reconnectCleanup: TimerCleanup | null = null;
+  let reconnectAttempt = 0;
+  let awaitingPong = false;
+
+  return {
+    connect() {
+      return connectInternal();
+    },
+    dispose() {
+      disposed = true;
+      cancelReconnect();
+      const activeSocket = socket;
+      if (!activeSocket) {
+        connectPromise = null;
+        ready = false;
+        notifyConnectionState("disposed");
+        return;
+      }
+
+      resetSocketState(activeSocket);
+      rejectPendingPublishes(new Error("Event stream was disposed."));
+      activeSocket.close(1000, "disposed");
+      notifyConnectionState("disposed");
+    },
+    async publishIntent(topic, payload) {
+      await this.connect();
+
+      const activeSocket = socket;
+      if (!activeSocket || !ready) {
+        throw new Error("Event stream is not connected.");
+      }
+
+      const requestId = createRequestID();
+      const completion = createPendingPublishCompletion(requestId);
+      pendingPublishes.set(requestId, completion);
+
+      const frame: EventStreamClientFrame<TClientEvent, TScope> = {
+        event: protocol.createClientEvent(topic, payload),
+        kind: "publish",
+        requestId
+      };
+      protocol.assertValidClientFrame(frame);
+      activeSocket.send(JSON.stringify(frame));
+
+      return await completion.promise;
+    },
+    subscribe(topic, listener, options) {
+      const scope =
+        options?.scope === null
+          ? undefined
+          : protocol.normalizeScope(options?.scope ?? defaultScope);
+      const key = createSubscriptionKey(topic, scope);
+      let subscription = subscriptions.get(key);
+      if (!subscription) {
+        subscription = {
+          listeners: new Set(),
+          scope,
+          topic
+        };
+        subscriptions.set(key, subscription);
+      }
+
+      subscription.listeners.add(listener);
+      flushSubscription(subscription);
+
+      return () => {
+        const currentSubscription = subscriptions.get(key);
+        if (!currentSubscription) {
+          return;
+        }
+
+        currentSubscription.listeners.delete(listener);
+        if (currentSubscription.listeners.size === 0) {
+          subscriptions.delete(key);
+          flushUnsubscription(currentSubscription);
+        }
+      };
+    },
+    subscribeConnectionState(listener) {
+      connectionStateListeners.add(listener);
+      return () => {
+        connectionStateListeners.delete(listener);
+      };
+    }
+  };
+
+  function connectInternal(): Promise<void> {
+    if (disposed) {
+      return Promise.reject(new Error("Event stream was disposed."));
+    }
+    cancelReconnect();
+    if (connectPromise) {
+      return connectPromise;
+    }
+
+    connectPromise = (async () => {
+      notifyConnectionState("connecting");
+      const url = await input.resolveUrl();
+      const nextSocket = webSocketFactory(url);
+      socket = nextSocket;
+      ready = false;
+
+      return await new Promise<void>((resolve, reject) => {
+        let settled = false;
+        let listeners: SocketListeners | null = null;
+
+        const fail = (error: Error) => {
+          if (settled) {
+            return;
+          }
+
+          settled = true;
+          detachSocketListeners(nextSocket, listeners);
+          listeners = null;
+          resetSocketState(nextSocket);
+          nextSocket.close(handshakeFailureCloseCode, "handshake_failed");
+          scheduleReconnect();
+          reject(error);
+        };
+
+        const messageListener = (event: MessageEvent) => {
+          const parsedFrame = parseServerFrame(event.data);
+          if (!parsedFrame.ok) {
+            if (!ready) {
+              fail(parsedFrame.error);
+            }
+            return;
+          }
+
+          const frame = parsedFrame.frame;
+
+          if (!ready) {
+            if (frame.kind !== "ready") {
+              fail(
+                frame.kind === "error"
+                  ? createFrameError(frame)
+                  : new Error(
+                      `Event stream received an unexpected ${frame.kind} frame before ready.`
+                    )
+              );
+              return;
+            }
+
+            if (frame.protocolVersion !== protocol.protocolVersion) {
+              fail(
+                new Error(
+                  `Event stream protocol version mismatch. Expected ${String(protocol.protocolVersion)}, received ${String(frame.protocolVersion)}.`
+                )
+              );
+              return;
+            }
+
+            if (frame.catalogRevision !== protocol.catalogRevision) {
+              fail(
+                new Error(
+                  `Event stream catalog revision mismatch. Expected ${protocol.catalogRevision}, received ${frame.catalogRevision}.`
+                )
+              );
+              return;
+            }
+
+            ready = true;
+            reconnectAttempt = 0;
+            flushSubscriptions();
+            startHeartbeat(nextSocket);
+            notifyConnectionState("connected");
+            if (!settled) {
+              settled = true;
+              resolve();
+            }
+            return;
+          }
+
+          handleServerFrame(frame);
+        };
+        const errorListener = () => {
+          if (!ready) {
+            fail(new Error("Event stream connection failed."));
+          }
+        };
+        const closeListener = (event: CloseEvent) => {
+          const closeError = createCloseError(event);
+          if (!ready) {
+            fail(closeError);
+            return;
+          }
+
+          detachSocketListeners(nextSocket, listeners);
+          listeners = null;
+          resetSocketState(nextSocket);
+          rejectPendingPublishes(closeError);
+          scheduleReconnect();
+        };
+
+        listeners = {
+          close: closeListener,
+          error: errorListener,
+          message: messageListener
+        };
+
+        nextSocket.addEventListener("message", messageListener);
+        nextSocket.addEventListener("error", errorListener);
+        nextSocket.addEventListener("close", closeListener);
+      });
+    })();
+
+    connectPromise.catch(() => {});
+    return connectPromise;
+  }
+
+  function createRequestID(): string {
+    return String(nextRequestID++);
+  }
+
+  function createSubscriptionKey(
+    topic: string,
+    scope: TScope | undefined
+  ): string {
+    return `${topic}\n${protocol.scopeKey(scope)}`;
+  }
+
+  function createPendingPublishCompletion(requestId: string): PendingPublish & {
+    promise: Promise<void>;
+  } {
+    let rejectFn: (error: Error) => void = () => {};
+    let resolveFn: () => void = () => {};
+    const promise = new Promise<void>((resolve, reject) => {
+      resolveFn = () => {
+        pendingPublishes.delete(requestId);
+        resolve();
+      };
+      rejectFn = (error) => {
+        pendingPublishes.delete(requestId);
+        reject(error);
+      };
+    });
+
+    return {
+      promise,
+      reject: rejectFn,
+      resolve: resolveFn
+    };
+  }
+
+  function flushSubscriptions() {
+    if (!socket || !ready) {
+      return;
+    }
+
+    for (const subscription of subscriptions.values()) {
+      flushSubscription(subscription);
+    }
+  }
+
+  function flushSubscription(
+    subscription: EventSubscriptionEntry<TServerEvent, TScope>
+  ): void {
+    if (!socket || !ready) {
+      return;
+    }
+    const subscribeFrame: EventStreamClientFrame<TClientEvent, TScope> = {
+      kind: "subscribe",
+      requestId: createRequestID(),
+      topics: [subscription.topic]
+    };
+    if (subscription.scope) {
+      subscribeFrame.scope = subscription.scope;
+    }
+    protocol.assertValidClientFrame(subscribeFrame);
+    socket.send(JSON.stringify(subscribeFrame));
+  }
+
+  function flushUnsubscription(
+    subscription: EventSubscriptionEntry<TServerEvent, TScope>
+  ): void {
+    if (!socket || !ready) {
+      return;
+    }
+    const unsubscribeFrame: EventStreamClientFrame<TClientEvent, TScope> = {
+      kind: "unsubscribe",
+      requestId: createRequestID(),
+      topics: [subscription.topic]
+    };
+    if (subscription.scope) {
+      unsubscribeFrame.scope = subscription.scope;
+    }
+    protocol.assertValidClientFrame(unsubscribeFrame);
+    socket.send(JSON.stringify(unsubscribeFrame));
+  }
+
+  function handleServerFrame(
+    frame: EventStreamServerFrame<TServerEvent>
+  ): void {
+    switch (frame.kind) {
+      case "ack": {
+        pendingPublishes.get(frame.requestId)?.resolve();
+        return;
+      }
+      case "error": {
+        if (frame.requestId) {
+          pendingPublishes
+            .get(frame.requestId)
+            ?.reject(createFrameError(frame));
+        }
+        return;
+      }
+      case "event": {
+        for (const subscription of subscriptions.values()) {
+          if (
+            subscription.topic !== frame.event.topic ||
+            !protocol.eventMatchesScope(frame.event.scope, subscription.scope)
+          ) {
+            continue;
+          }
+          for (const topicListener of subscription.listeners) {
+            topicListener(frame.event);
+          }
+        }
+        return;
+      }
+      case "pong":
+        resolveHeartbeatPong();
+        return;
+      case "ready":
+        return;
+    }
+  }
+
+  function rejectPendingPublishes(error: Error): void {
+    for (const pendingPublish of pendingPublishes.values()) {
+      pendingPublish.reject(error);
+    }
+    pendingPublishes.clear();
+  }
+
+  function resetSocketState(nextSocket: EventStreamSocket): void {
+    if (socket === nextSocket) {
+      socket = null;
+    }
+    connectPromise = null;
+    ready = false;
+    stopHeartbeat();
+    if (!disposed) {
+      notifyConnectionState("disconnected");
+    }
+  }
+
+  function startHeartbeat(activeSocket: EventStreamSocket): void {
+    stopHeartbeat();
+    heartbeatIntervalCleanup = heartbeat.scheduleInterval(() => {
+      if (!ready || socket !== activeSocket || awaitingPong) {
+        return;
+      }
+
+      const pingFrame: EventStreamClientFrame<TClientEvent, TScope> = {
+        kind: "ping",
+        requestId: createRequestID(),
+        sentAt: new Date().toISOString()
+      };
+      protocol.assertValidClientFrame(pingFrame);
+      activeSocket.send(JSON.stringify(pingFrame));
+      awaitingPong = true;
+      pongTimeoutCleanup = heartbeat.scheduleTimeout(() => {
+        if (socket !== activeSocket || !awaitingPong) {
+          return;
+        }
+
+        activeSocket.close(4000, "heartbeat_timeout");
+      }, heartbeat.pongTimeoutMs);
+    }, heartbeat.pingIntervalMs);
+  }
+
+  function resolveHeartbeatPong(): void {
+    awaitingPong = false;
+    if (pongTimeoutCleanup) {
+      pongTimeoutCleanup();
+      pongTimeoutCleanup = null;
+    }
+  }
+
+  function stopHeartbeat(): void {
+    awaitingPong = false;
+    if (heartbeatIntervalCleanup) {
+      heartbeatIntervalCleanup();
+      heartbeatIntervalCleanup = null;
+    }
+    if (pongTimeoutCleanup) {
+      pongTimeoutCleanup();
+      pongTimeoutCleanup = null;
+    }
+  }
+
+  function scheduleReconnect(): void {
+    if (!reconnect || disposed || reconnectCleanup !== null) {
+      return;
+    }
+    reconnectAttempt += 1;
+    const delayMs = Math.min(
+      reconnect.initialDelayMs * 2 ** Math.max(0, reconnectAttempt - 1),
+      reconnect.maxDelayMs
+    );
+    reconnectCleanup = reconnect.scheduleTimeout(() => {
+      reconnectCleanup = null;
+      void connectInternal().catch(() => {
+        scheduleReconnect();
+      });
+    }, delayMs);
+  }
+
+  function cancelReconnect(): void {
+    if (!reconnectCleanup) {
+      return;
+    }
+    reconnectCleanup();
+    reconnectCleanup = null;
+  }
+
+  function notifyConnectionState(state: EventStreamConnectionState): void {
+    for (const listener of connectionStateListeners) {
+      listener(state);
+    }
+  }
+
+  function parseServerFrame(data: unknown): ParsedServerFrame<TServerEvent> {
+    if (typeof data !== "string") {
+      return {
+        error: new Error(
+          "Event stream received a non-text server frame during handshake."
+        ),
+        ok: false
+      };
+    }
+
+    try {
+      const frame = JSON.parse(data) as unknown;
+      const readyMismatchError = getReadyCompatibilityError(frame);
+      if (readyMismatchError) {
+        return {
+          error: readyMismatchError,
+          ok: false
+        };
+      }
+
+      protocol.assertValidServerFrame(frame);
+      return {
+        frame: frame as EventStreamServerFrame<TServerEvent>,
+        ok: true
+      };
+    } catch {
+      return {
+        error: new Error(
+          "Event stream received an invalid server frame during handshake."
+        ),
+        ok: false
+      };
+    }
+  }
+
+  function getReadyCompatibilityError(frame: unknown): Error | null {
+    if (!isRecord(frame) || frame.kind !== "ready") {
+      return null;
+    }
+
+    if (frame.protocolVersion !== protocol.protocolVersion) {
+      return new Error(
+        `Event stream protocol version mismatch. Expected ${protocol.protocolVersion}, received ${String(frame.protocolVersion)}.`
+      );
+    }
+
+    if (frame.catalogRevision !== protocol.catalogRevision) {
+      return new Error(
+        `Event stream catalog revision mismatch. Expected ${protocol.catalogRevision}, received ${String(frame.catalogRevision)}.`
+      );
+    }
+
+    return null;
+  }
+}
+
+function defaultEventStreamSocketFactory(url: string): EventStreamSocket {
+  return new WebSocket(url);
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
+
+function detachSocketListeners(
+  socket: EventStreamSocket,
+  listeners: SocketListeners | null
+): void {
+  if (!listeners) {
+    return;
+  }
+
+  socket.removeEventListener("message", listeners.message);
+  socket.removeEventListener("error", listeners.error);
+  socket.removeEventListener("close", listeners.close);
+}
+
+function createCloseError(event: CloseEvent): Error {
+  const suffix = event.reason ? `: ${event.reason}` : "";
+  return new Error(`Event stream closed (${event.code || 1006})${suffix}.`);
+}
+
+function createFrameError(frame: { code?: string; message?: string }): Error {
+  return new Error(frame.message || frame.code || "Event stream error.");
+}

--- a/packages/events/stream-core/src/index.ts
+++ b/packages/events/stream-core/src/index.ts
@@ -1,0 +1,14 @@
+export {
+  createEventStreamClient,
+  type CreateEventStreamClientInput,
+  type EventStreamClient,
+  type EventStreamClientFrame,
+  type EventStreamConnectionState,
+  type EventStreamHeartbeatConfig,
+  type EventStreamProtocol,
+  type EventStreamReconnectConfig,
+  type EventStreamServerEvent,
+  type EventStreamServerFrame,
+  type EventStreamSocket,
+  type EventStreamSocketFactory
+} from "./eventStreamClient.ts";

--- a/packages/events/stream-core/tsconfig.json
+++ b/packages/events/stream-core/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../../../packages/configs/tsconfig/base.json",
+  "compilerOptions": {
+    "allowImportingTsExtensions": true
+  },
+  "include": ["src/**/*"]
+}

--- a/packages/events/stream-core/tsup.config.ts
+++ b/packages/events/stream-core/tsup.config.ts
@@ -1,0 +1,11 @@
+import { defineConfig } from "tsup";
+
+export default defineConfig({
+  clean: true,
+  dts: true,
+  entry: {
+    index: "src/index.ts"
+  },
+  format: ["esm"],
+  sourcemap: true
+});

--- a/packages/events/stream-go/README.md
+++ b/packages/events/stream-go/README.md
@@ -1,0 +1,22 @@
+# streamgo (github.com/tutti-os/tutti/packages/events/stream-go)
+
+Catalog-agnostic **server-side** core for the business event stream
+(daemon ↔ renderer over WebSocket). The Go counterpart to
+`@tutti-os/event-stream-core`.
+
+It owns the in-memory pub/sub registry, scope routing and session fan-out:
+
+- `Service[S comparable]` — sessions, subscriptions, scoped publish/fan-out
+- `Session[S]` — per-connection outbound event channel
+- the catalog **contract** (`Catalog`, `Direction`, `ValidationError`, …)
+
+It is generic over the scope type `S` and depends only on an injected `Catalog`
+(minimal: `TopicVersion` / `ValidatePublish` / `ValidateSubscription`) plus a
+`ScopeNormalizer[S]`. It contains **no concrete topics**. Each product binds its
+own scope and catalog:
+
+- tutti workspace → `Service[EventScope]` where `EventScope = { WorkspaceID }`
+- group chat → `Service[RoomScope]` where `RoomScope = { RoomID }`
+
+The WS frame encode/decode (which is woven through the generated protocol types)
+stays in each product's API layer and calls this registry.

--- a/packages/events/stream-go/contract.go
+++ b/packages/events/stream-go/contract.go
@@ -1,0 +1,72 @@
+// Package streamgo is the catalog-agnostic server-side core for the business
+// event stream (daemon ↔ renderer over WS). It owns the in-memory pub/sub
+// registry, scope routing and session fan-out; it knows nothing about concrete
+// topics or scope axes. Each product (tutti workspace, tsh chat) instantiates
+// Service with its own scope type S and injects a Catalog + scope normalizer.
+package streamgo
+
+import "context"
+
+// Direction is the allowed direction of an event topic on the wire.
+type Direction string
+
+const (
+	DirectionClientToServer Direction = "client->server"
+	DirectionServerToClient Direction = "server->client"
+)
+
+// ValidationCode classifies a ValidationError for the wire error frame.
+type ValidationCode string
+
+const (
+	ValidationCodeInvalidDirection ValidationCode = "invalid_direction"
+	ValidationCodeInvalidPayload   ValidationCode = "invalid_payload"
+	ValidationCodeInvalidTopic     ValidationCode = "invalid_topic"
+)
+
+// ValidationError is a structured, wire-mappable validation failure.
+type ValidationError struct {
+	Code      ValidationCode
+	Message   string
+	Topic     string
+	Direction Direction
+}
+
+func (e *ValidationError) Error() string {
+	if e == nil {
+		return ""
+	}
+	return e.Message
+}
+
+// Catalog is the minimal contract the registry needs from a product catalog.
+// Products implement it (e.g. tutti's StaticCatalog) and inject it into Service.
+type Catalog interface {
+	// TopicVersion returns the wire version of a known topic.
+	TopicVersion(topic string) (int, bool)
+	ValidatePublish(topic string, direction Direction, payload []byte) error
+	ValidateSubscription(topic string) error
+}
+
+// ClientEvent is a decoded client→server intent handed to an IntentHandler.
+type ClientEvent struct {
+	Topic   string
+	Payload []byte
+}
+
+// IntentHandler processes a validated client→server intent for a topic.
+type IntentHandler func(context.Context, ClientEvent) error
+
+// PublishedEvent is a server→client event fanned out to subscribed sessions.
+// S is the product scope type used for routing.
+type PublishedEvent[S comparable] struct {
+	ID        string
+	Topic     string
+	Version   int
+	EmittedAt string
+	Scope     S
+	Payload   []byte
+}
+
+// ScopeNormalizer canonicalizes/validates a product scope before routing.
+type ScopeNormalizer[S comparable] func(scope S) (S, error)

--- a/packages/events/stream-go/go.mod
+++ b/packages/events/stream-go/go.mod
@@ -1,0 +1,3 @@
+module github.com/tutti-os/tutti/packages/events/stream-go
+
+go 1.24.3

--- a/packages/events/stream-go/service.go
+++ b/packages/events/stream-go/service.go
@@ -1,0 +1,296 @@
+package streamgo
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"time"
+)
+
+// Session is one connected client. S is the product scope type.
+type Session[S comparable] struct {
+	id string
+
+	mu            sync.RWMutex
+	closed        bool
+	subscriptions map[subscriptionKey[S]]struct{}
+
+	events chan PublishedEvent[S]
+	once   sync.Once
+}
+
+type subscriptionKey[S comparable] struct {
+	topic string
+	scope S
+}
+
+// Service is the in-memory pub/sub registry with scope routing and fan-out.
+type Service[S comparable] struct {
+	catalog        Catalog
+	normalizeScope ScopeNormalizer[S]
+
+	mu       sync.RWMutex
+	sessions map[*Session[S]]struct{}
+	handlers map[string]IntentHandler
+
+	nextEventID   uint64
+	nextSessionID uint64
+}
+
+// NewService builds a registry for scope type S. catalog must not be nil.
+// normalizeScope canonicalizes/validates a scope (e.g. trim, reject blanks);
+// pass a no-op identity normalizer if a product needs none.
+func NewService[S comparable](
+	catalog Catalog,
+	handlers map[string]IntentHandler,
+	normalizeScope ScopeNormalizer[S],
+) *Service[S] {
+	clonedHandlers := make(map[string]IntentHandler, len(handlers))
+	for topic, handler := range handlers {
+		clonedHandlers[strings.TrimSpace(topic)] = handler
+	}
+	if normalizeScope == nil {
+		normalizeScope = func(scope S) (S, error) { return scope, nil }
+	}
+
+	return &Service[S]{
+		catalog:        catalog,
+		normalizeScope: normalizeScope,
+		handlers:       clonedHandlers,
+		sessions:       make(map[*Session[S]]struct{}),
+	}
+}
+
+func (s *Service[S]) RegisterIntentHandler(topic string, handler IntentHandler) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	trimmedTopic := strings.TrimSpace(topic)
+	if trimmedTopic == "" {
+		return
+	}
+	if handler == nil {
+		delete(s.handlers, trimmedTopic)
+		return
+	}
+	s.handlers[trimmedTopic] = handler
+}
+
+func (s *Service[S]) OpenSession() *Session[S] {
+	session := &Session[S]{
+		id:            fmt.Sprintf("session-%d", atomic.AddUint64(&s.nextSessionID, 1)),
+		subscriptions: make(map[subscriptionKey[S]]struct{}),
+		events:        make(chan PublishedEvent[S], 32),
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.sessions[session] = struct{}{}
+	return session
+}
+
+func (s *Service[S]) CloseSession(session *Session[S]) {
+	if session == nil {
+		return
+	}
+
+	s.mu.Lock()
+	delete(s.sessions, session)
+	s.mu.Unlock()
+
+	session.once.Do(func() {
+		session.mu.Lock()
+		session.closed = true
+		session.mu.Unlock()
+		close(session.events)
+	})
+}
+
+func (s *Service[S]) Subscribe(session *Session[S], topics []string, scope S) error {
+	normalizedTopics, err := normalizeTopics(topics)
+	if err != nil {
+		return err
+	}
+	normalizedScope, err := s.normalizeScope(scope)
+	if err != nil {
+		return err
+	}
+	for _, topic := range normalizedTopics {
+		if err := s.catalog.ValidateSubscription(topic); err != nil {
+			return err
+		}
+	}
+
+	session.mu.Lock()
+	defer session.mu.Unlock()
+	for _, topic := range normalizedTopics {
+		session.subscriptions[subscriptionKey[S]{topic: strings.TrimSpace(topic), scope: normalizedScope}] = struct{}{}
+	}
+	return nil
+}
+
+func (s *Service[S]) Unsubscribe(session *Session[S], topics []string, scope S) error {
+	normalizedTopics, err := normalizeTopics(topics)
+	if err != nil {
+		return err
+	}
+	normalizedScope, err := s.normalizeScope(scope)
+	if err != nil {
+		return err
+	}
+
+	session.mu.Lock()
+	defer session.mu.Unlock()
+	for _, topic := range normalizedTopics {
+		delete(session.subscriptions, subscriptionKey[S]{topic: strings.TrimSpace(topic), scope: normalizedScope})
+	}
+	return nil
+}
+
+func (s *Service[S]) PublishFromClient(ctx context.Context, event ClientEvent) error {
+	trimmedTopic := strings.TrimSpace(event.Topic)
+	if err := s.catalog.ValidatePublish(trimmedTopic, DirectionClientToServer, event.Payload); err != nil {
+		return err
+	}
+
+	s.mu.RLock()
+	handler := s.handlers[trimmedTopic]
+	s.mu.RUnlock()
+	if handler == nil {
+		return fmt.Errorf("intent handler is not configured for topic %q", trimmedTopic)
+	}
+	return handler(ctx, ClientEvent{
+		Topic:   trimmedTopic,
+		Payload: append([]byte(nil), event.Payload...),
+	})
+}
+
+func (s *Service[S]) PublishFromServer(ctx context.Context, topic string, payload []byte) error {
+	var zero S
+	return s.PublishFromServerScoped(ctx, topic, payload, zero)
+}
+
+func (s *Service[S]) PublishFromServerScoped(_ context.Context, topic string, payload []byte, scope S) error {
+	trimmedTopic := strings.TrimSpace(topic)
+	normalizedScope, err := s.normalizeScope(scope)
+	if err != nil {
+		return err
+	}
+	version, ok := s.catalog.TopicVersion(trimmedTopic)
+	if !ok {
+		return &ValidationError{
+			Code:    ValidationCodeInvalidTopic,
+			Message: fmt.Sprintf("unknown topic %q", trimmedTopic),
+			Topic:   trimmedTopic,
+		}
+	}
+	if err := s.catalog.ValidatePublish(trimmedTopic, DirectionServerToClient, payload); err != nil {
+		return err
+	}
+
+	event := PublishedEvent[S]{
+		ID:        fmt.Sprintf("event-%d", atomic.AddUint64(&s.nextEventID, 1)),
+		Topic:     trimmedTopic,
+		Version:   version,
+		EmittedAt: time.Now().UTC().Format(time.RFC3339Nano),
+		Scope:     normalizedScope,
+		Payload:   append([]byte(nil), payload...),
+	}
+
+	sessions := s.subscribedSessions(trimmedTopic, normalizedScope)
+	for _, session := range sessions {
+		if !session.enqueue(event) {
+			s.CloseSession(session)
+		}
+	}
+
+	return nil
+}
+
+func (*Service[S]) Events(session *Session[S]) <-chan PublishedEvent[S] {
+	if session == nil {
+		return nil
+	}
+	return session.Events()
+}
+
+// Events returns the read side of the session's outbound event channel.
+func (s *Session[S]) Events() <-chan PublishedEvent[S] {
+	return s.events
+}
+
+func normalizeTopics(topics []string) ([]string, error) {
+	if len(topics) == 0 {
+		return nil, &ValidationError{
+			Code:    ValidationCodeInvalidPayload,
+			Message: "at least one topic is required",
+		}
+	}
+
+	normalized := make([]string, 0, len(topics))
+	seen := make(map[string]struct{}, len(topics))
+	for _, topic := range topics {
+		trimmedTopic := strings.TrimSpace(topic)
+		if trimmedTopic == "" {
+			return nil, &ValidationError{
+				Code:    ValidationCodeInvalidPayload,
+				Message: "topic must not be empty",
+			}
+		}
+		if _, ok := seen[trimmedTopic]; ok {
+			continue
+		}
+		seen[trimmedTopic] = struct{}{}
+		normalized = append(normalized, trimmedTopic)
+	}
+	return normalized, nil
+}
+
+func (s *Service[S]) subscribedSessions(topic string, scope S) []*Session[S] {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	sessions := make([]*Session[S], 0, len(s.sessions))
+	for session := range s.sessions {
+		if session.isSubscribed(topic, scope) {
+			sessions = append(sessions, session)
+		}
+	}
+	return sessions
+}
+
+func (s *Session[S]) enqueue(event PublishedEvent[S]) bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if s.closed {
+		return false
+	}
+
+	select {
+	case s.events <- event:
+		return true
+	default:
+		return false
+	}
+}
+
+func (s *Session[S]) isSubscribed(topic string, scope S) bool {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	var zero S
+	for key := range s.subscriptions {
+		if key.topic != topic {
+			continue
+		}
+		if key.scope == zero {
+			return true
+		}
+		if key.scope == scope {
+			return true
+		}
+	}
+	return false
+}

--- a/packages/events/stream-go/service_test.go
+++ b/packages/events/stream-go/service_test.go
@@ -1,0 +1,70 @@
+package streamgo
+
+import (
+	"context"
+	"testing"
+)
+
+type fakeCatalog struct{}
+
+func (fakeCatalog) TopicVersion(string) (int, bool)                 { return 1, true }
+func (fakeCatalog) ValidatePublish(string, Direction, []byte) error { return nil }
+func (fakeCatalog) ValidateSubscription(string) error               { return nil }
+
+func TestClosedSessionRejectsFurtherEnqueueWithoutPanic(t *testing.T) {
+	t.Parallel()
+
+	service := NewService[string](fakeCatalog{}, nil, nil)
+	session := service.OpenSession()
+	service.CloseSession(session)
+
+	if session.enqueue(PublishedEvent[string]{Topic: "topic.x"}) {
+		t.Fatal("enqueue() = true, want false for a closed session")
+	}
+}
+
+func TestScopeRoutingDeliversAndFilters(t *testing.T) {
+	t.Parallel()
+
+	service := NewService[string](fakeCatalog{}, nil, nil)
+	scoped := service.OpenSession()
+	other := service.OpenSession()
+	wildcard := service.OpenSession()
+
+	if err := service.Subscribe(scoped, []string{"topic.x"}, "room-1"); err != nil {
+		t.Fatalf("subscribe scoped: %v", err)
+	}
+	if err := service.Subscribe(other, []string{"topic.x"}, "room-2"); err != nil {
+		t.Fatalf("subscribe other: %v", err)
+	}
+	if err := service.Subscribe(wildcard, []string{"topic.x"}, ""); err != nil {
+		t.Fatalf("subscribe wildcard: %v", err)
+	}
+
+	if err := service.PublishFromServerScoped(context.Background(), "topic.x", []byte(`{}`), "room-1"); err != nil {
+		t.Fatalf("publish: %v", err)
+	}
+
+	if got := receive(t, scoped); got.Scope != "room-1" {
+		t.Fatalf("scoped session scope = %q, want room-1", got.Scope)
+	}
+	if got := receive(t, wildcard); got.Scope != "room-1" {
+		t.Fatalf("wildcard session scope = %q, want room-1", got.Scope)
+	}
+	select {
+	case ev := <-other.Events():
+		t.Fatalf("other-scoped session unexpectedly received %#v", ev)
+	default:
+	}
+}
+
+func receive(t *testing.T, session *Session[string]) PublishedEvent[string] {
+	t.Helper()
+	select {
+	case event := <-session.Events():
+		return event
+	default:
+		t.Fatal("event not received")
+	}
+	return PublishedEvent[string]{}
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -429,6 +429,9 @@ importers:
       "@tutti-os/event-protocol":
         specifier: workspace:*
         version: link:../../events/protocol
+      "@tutti-os/event-stream-core":
+        specifier: workspace:*
+        version: link:../../events/stream-core
     devDependencies:
       "@types/node":
         specifier: ^24.0.1
@@ -442,6 +445,18 @@ importers:
   packages/configs/tsconfig: {}
 
   packages/events/protocol:
+    devDependencies:
+      "@tutti-os/config-tsconfig":
+        specifier: workspace:*
+        version: link:../../configs/tsconfig
+      "@types/node":
+        specifier: ^24.0.1
+        version: 24.12.4
+      typescript:
+        specifier: ^5.8.3
+        version: 5.9.3
+
+  packages/events/stream-core:
     devDependencies:
       "@tutti-os/config-tsconfig":
         specifier: workspace:*

--- a/services/tuttid/go.mod
+++ b/services/tuttid/go.mod
@@ -11,6 +11,7 @@ require (
 	github.com/oapi-codegen/runtime v1.4.1
 	github.com/tutti-os/tutti/packages/agentactivity/daemon v0.0.0
 	github.com/tutti-os/tutti/packages/appcli/core v0.0.0
+	github.com/tutti-os/tutti/packages/events/stream-go v0.0.0
 	github.com/tutti-os/tutti/packages/workbench/service v0.0.0
 	github.com/tutti-os/tutti/packages/workspace/files v0.0.0
 	github.com/tutti-os/tutti/packages/workspace/issues v0.0.0
@@ -18,6 +19,8 @@ require (
 	golang.org/x/sys v0.41.0
 	modernc.org/sqlite v1.45.0
 )
+
+replace github.com/tutti-os/tutti/packages/events/stream-go => ../../packages/events/stream-go
 
 replace github.com/tutti-os/tutti/packages/workbench/service => ../../packages/workbench/service
 

--- a/services/tuttid/service/eventstream/catalog.go
+++ b/services/tuttid/service/eventstream/catalog.go
@@ -24,21 +24,8 @@ const (
 	TopicWorkspaceWorkbenchNodeLaunchRequested = "workspace.workbench.node.launch.requested"
 )
 
-type Direction string
-
-const (
-	DirectionClientToServer Direction = "client->server"
-	DirectionServerToClient Direction = "server->client"
-)
-
-type ValidationCode string
-
-const (
-	ValidationCodeInvalidDirection ValidationCode = "invalid_direction"
-	ValidationCodeInvalidPayload   ValidationCode = "invalid_payload"
-	ValidationCodeInvalidTopic     ValidationCode = "invalid_topic"
-)
-
+// Direction, ValidationCode and ValidationError now live in stream-go and are
+// re-exported as aliases from service.go; PayloadValidator stays catalog-local.
 type PayloadValidator func([]byte) error
 
 type TopicDefinition struct {
@@ -76,6 +63,7 @@ func (d TopicDefinition) validatePayload(direction Direction, payload []byte) er
 type Catalog interface {
 	Topic(topic string) (TopicDefinition, bool)
 	Topics() []TopicDefinition
+	TopicVersion(topic string) (int, bool)
 	ValidatePublish(topic string, direction Direction, payload []byte) error
 	ValidateSubscription(topic string) error
 }
@@ -183,6 +171,14 @@ func (c StaticCatalog) Topic(topic string) (TopicDefinition, bool) {
 	return definition, ok
 }
 
+func (c StaticCatalog) TopicVersion(topic string) (int, bool) {
+	definition, ok := c.Topic(topic)
+	if !ok {
+		return 0, false
+	}
+	return definition.Version, true
+}
+
 func (c StaticCatalog) Topics() []TopicDefinition {
 	topics := make([]TopicDefinition, 0, len(c.topics))
 	for _, definition := range c.topics {
@@ -240,20 +236,6 @@ func (c StaticCatalog) ValidateSubscription(topic string) error {
 		}
 	}
 	return nil
-}
-
-type ValidationError struct {
-	Code      ValidationCode
-	Message   string
-	Topic     string
-	Direction Direction
-}
-
-func (e *ValidationError) Error() string {
-	if e == nil {
-		return ""
-	}
-	return e.Message
 }
 
 type analyticsDebugReportedPayload struct {

--- a/services/tuttid/service/eventstream/service.go
+++ b/services/tuttid/service/eventstream/service.go
@@ -1,318 +1,62 @@
+// Package eventstream is the tutti workspace binding of the catalog-agnostic
+// event-stream registry (github.com/tutti-os/tutti/packages/events/stream-go).
+//
+// The pub/sub registry, scope routing and session fan-out live in stream-go.
+// This package only fixes the scope axis to the workspace (EventScope) and keeps
+// the tutti catalog (TopicDefinition / StaticCatalog / DefaultCatalog + payload
+// validators). The aliases below preserve the original public surface so existing
+// callers (daemon_events.go, wiring.go, tests) are unchanged.
 package eventstream
 
 import (
-	"context"
-	"fmt"
 	"strings"
-	"sync"
-	"sync/atomic"
-	"time"
+
+	streamgo "github.com/tutti-os/tutti/packages/events/stream-go"
 )
 
-type ClientEvent struct {
-	Topic   string
-	Payload []byte
-}
-
-type PublishedEvent struct {
-	ID        string
-	Topic     string
-	Version   int
-	EmittedAt string
-	Scope     EventScope
-	Payload   []byte
-}
-
+// EventScope is the workspace scope axis used to route events.
 type EventScope struct {
 	WorkspaceID string
 }
 
-type IntentHandler func(context.Context, ClientEvent) error
+// Re-exported core types, instantiated with the workspace scope.
+type (
+	Service        = streamgo.Service[EventScope]
+	Session        = streamgo.Session[EventScope]
+	PublishedEvent = streamgo.PublishedEvent[EventScope]
+	ClientEvent    = streamgo.ClientEvent
+	IntentHandler  = streamgo.IntentHandler
 
-type Session struct {
-	id string
+	Direction       = streamgo.Direction
+	ValidationCode  = streamgo.ValidationCode
+	ValidationError = streamgo.ValidationError
+)
 
-	mu            sync.RWMutex
-	closed        bool
-	subscriptions map[subscriptionKey]EventScope
+const (
+	DirectionClientToServer = streamgo.DirectionClientToServer
+	DirectionServerToClient = streamgo.DirectionServerToClient
 
-	events chan PublishedEvent
-	once   sync.Once
-}
+	ValidationCodeInvalidDirection = streamgo.ValidationCodeInvalidDirection
+	ValidationCodeInvalidPayload   = streamgo.ValidationCodeInvalidPayload
+	ValidationCodeInvalidTopic     = streamgo.ValidationCodeInvalidTopic
+)
 
-type subscriptionKey struct {
-	topic       string
-	workspaceID string
-}
-
-type Service struct {
-	catalog Catalog
-
-	mu       sync.RWMutex
-	sessions map[*Session]struct{}
-	handlers map[string]IntentHandler
-
-	nextEventID   uint64
-	nextSessionID uint64
-}
-
+// NewService builds a workspace-scoped registry over the tutti catalog.
 func NewService(catalog Catalog, handlers map[string]IntentHandler) *Service {
 	if catalog == nil {
-		defaultCatalog := DefaultCatalog()
-		catalog = defaultCatalog
+		catalog = DefaultCatalog()
 	}
-
-	clonedHandlers := make(map[string]IntentHandler, len(handlers))
-	for topic, handler := range handlers {
-		clonedHandlers[strings.TrimSpace(topic)] = handler
-	}
-
-	return &Service{
-		catalog:  catalog,
-		handlers: clonedHandlers,
-		sessions: make(map[*Session]struct{}),
-	}
+	return streamgo.NewService[EventScope](catalog, handlers, normalizeWorkspaceScope)
 }
 
-func (s *Service) RegisterIntentHandler(topic string, handler IntentHandler) {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-
-	trimmedTopic := strings.TrimSpace(topic)
-	if trimmedTopic == "" {
-		return
-	}
-	if handler == nil {
-		delete(s.handlers, trimmedTopic)
-		return
-	}
-	s.handlers[trimmedTopic] = handler
-}
-
-func (s *Service) OpenSession() *Session {
-	session := &Session{
-		id:            fmt.Sprintf("session-%d", atomic.AddUint64(&s.nextSessionID, 1)),
-		subscriptions: make(map[subscriptionKey]EventScope),
-		events:        make(chan PublishedEvent, 32),
-	}
-
-	s.mu.Lock()
-	defer s.mu.Unlock()
-	s.sessions[session] = struct{}{}
-	return session
-}
-
-func (s *Service) CloseSession(session *Session) {
-	if session == nil {
-		return
-	}
-
-	s.mu.Lock()
-	delete(s.sessions, session)
-	s.mu.Unlock()
-
-	session.once.Do(func() {
-		session.mu.Lock()
-		session.closed = true
-		session.mu.Unlock()
-		close(session.events)
-	})
-}
-
-func (s *Service) Subscribe(session *Session, topics []string, scope EventScope) error {
-	normalizedTopics, err := normalizeTopics(topics)
-	if err != nil {
-		return err
-	}
-	normalizedScope, err := normalizeEventScope(scope)
-	if err != nil {
-		return err
-	}
-	for _, topic := range normalizedTopics {
-		if err := s.catalog.ValidateSubscription(topic); err != nil {
-			return err
-		}
-	}
-
-	session.mu.Lock()
-	defer session.mu.Unlock()
-	for _, topic := range normalizedTopics {
-		session.subscriptions[newSubscriptionKey(topic, normalizedScope)] = normalizedScope
-	}
-	return nil
-}
-
-func (*Service) Unsubscribe(session *Session, topics []string, scope EventScope) error {
-	normalizedTopics, err := normalizeTopics(topics)
-	if err != nil {
-		return err
-	}
-	normalizedScope, err := normalizeEventScope(scope)
-	if err != nil {
-		return err
-	}
-
-	session.mu.Lock()
-	defer session.mu.Unlock()
-	for _, topic := range normalizedTopics {
-		delete(session.subscriptions, newSubscriptionKey(topic, normalizedScope))
-	}
-	return nil
-}
-
-func (s *Service) PublishFromClient(ctx context.Context, event ClientEvent) error {
-	trimmedTopic := strings.TrimSpace(event.Topic)
-	if err := s.catalog.ValidatePublish(trimmedTopic, DirectionClientToServer, event.Payload); err != nil {
-		return err
-	}
-
-	s.mu.RLock()
-	handler := s.handlers[trimmedTopic]
-	s.mu.RUnlock()
-	if handler == nil {
-		return fmt.Errorf("intent handler is not configured for topic %q", trimmedTopic)
-	}
-	return handler(ctx, ClientEvent{
-		Topic:   trimmedTopic,
-		Payload: append([]byte(nil), event.Payload...),
-	})
-}
-
-func (s *Service) PublishFromServer(ctx context.Context, topic string, payload []byte) error {
-	return s.PublishFromServerScoped(ctx, topic, payload, EventScope{})
-}
-
-func (s *Service) PublishFromServerScoped(_ context.Context, topic string, payload []byte, scope EventScope) error {
-	trimmedTopic := strings.TrimSpace(topic)
-	normalizedScope, err := normalizeEventScope(scope)
-	if err != nil {
-		return err
-	}
-	definition, ok := s.catalog.Topic(trimmedTopic)
-	if !ok {
-		return &ValidationError{
-			Code:    ValidationCodeInvalidTopic,
-			Message: fmt.Sprintf("unknown topic %q", trimmedTopic),
-			Topic:   trimmedTopic,
-		}
-	}
-	if err := s.catalog.ValidatePublish(trimmedTopic, DirectionServerToClient, payload); err != nil {
-		return err
-	}
-
-	event := PublishedEvent{
-		ID:        fmt.Sprintf("event-%d", atomic.AddUint64(&s.nextEventID, 1)),
-		Topic:     trimmedTopic,
-		Version:   definition.Version,
-		EmittedAt: time.Now().UTC().Format(time.RFC3339Nano),
-		Scope:     normalizedScope,
-		Payload:   append([]byte(nil), payload...),
-	}
-
-	sessions := s.subscribedSessions(trimmedTopic, normalizedScope)
-	for _, session := range sessions {
-		if !session.enqueue(event) {
-			s.CloseSession(session)
-		}
-	}
-
-	return nil
-}
-
-func (*Service) Events(session *Session) <-chan PublishedEvent {
-	if session == nil {
-		return nil
-	}
-	return session.events
-}
-
-func normalizeTopics(topics []string) ([]string, error) {
-	if len(topics) == 0 {
-		return nil, &ValidationError{
-			Code:    ValidationCodeInvalidPayload,
-			Message: "at least one topic is required",
-		}
-	}
-
-	normalized := make([]string, 0, len(topics))
-	seen := make(map[string]struct{}, len(topics))
-	for _, topic := range topics {
-		trimmedTopic := strings.TrimSpace(topic)
-		if trimmedTopic == "" {
-			return nil, &ValidationError{
-				Code:    ValidationCodeInvalidPayload,
-				Message: "topic must not be empty",
-			}
-		}
-		if _, ok := seen[trimmedTopic]; ok {
-			continue
-		}
-		seen[trimmedTopic] = struct{}{}
-		normalized = append(normalized, trimmedTopic)
-	}
-	return normalized, nil
-}
-
-func normalizeEventScope(scope EventScope) (EventScope, error) {
+// normalizeWorkspaceScope trims the workspaceId and rejects whitespace-only ids.
+func normalizeWorkspaceScope(scope EventScope) (EventScope, error) {
 	workspaceID := strings.TrimSpace(scope.WorkspaceID)
 	if scope.WorkspaceID != "" && workspaceID == "" {
-		return EventScope{}, &ValidationError{
-			Code:    ValidationCodeInvalidPayload,
+		return EventScope{}, &streamgo.ValidationError{
+			Code:    streamgo.ValidationCodeInvalidPayload,
 			Message: "scope.workspaceId must not be empty",
 		}
 	}
 	return EventScope{WorkspaceID: workspaceID}, nil
-}
-
-func newSubscriptionKey(topic string, scope EventScope) subscriptionKey {
-	return subscriptionKey{
-		topic:       strings.TrimSpace(topic),
-		workspaceID: strings.TrimSpace(scope.WorkspaceID),
-	}
-}
-
-func (s *Service) subscribedSessions(topic string, scope EventScope) []*Session {
-	s.mu.RLock()
-	defer s.mu.RUnlock()
-
-	sessions := make([]*Session, 0, len(s.sessions))
-	for session := range s.sessions {
-		if session.isSubscribed(topic, scope) {
-			sessions = append(sessions, session)
-		}
-	}
-	return sessions
-}
-
-func (s *Session) enqueue(event PublishedEvent) bool {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-
-	if s.closed {
-		return false
-	}
-
-	select {
-	case s.events <- event:
-		return true
-	default:
-		return false
-	}
-}
-
-func (s *Session) isSubscribed(topic string, scope EventScope) bool {
-	s.mu.RLock()
-	defer s.mu.RUnlock()
-	for key, subscriptionScope := range s.subscriptions {
-		if key.topic != topic {
-			continue
-		}
-		if subscriptionScope.WorkspaceID == "" {
-			return true
-		}
-		if subscriptionScope.WorkspaceID == scope.WorkspaceID {
-			return true
-		}
-	}
-	return false
 }

--- a/services/tuttid/service/eventstream/service_test.go
+++ b/services/tuttid/service/eventstream/service_test.go
@@ -300,17 +300,8 @@ func TestDesktopPreferencesPublisherIncludesDockIconStyle(t *testing.T) {
 	}
 }
 
-func TestClosedSessionRejectsFurtherEnqueueWithoutPanic(t *testing.T) {
-	t.Parallel()
-
-	service := NewService(DefaultCatalog(), nil)
-	session := service.OpenSession()
-	service.CloseSession(session)
-
-	if session.enqueue(PublishedEvent{Topic: TopicPreferencesDesktopUpdated}) {
-		t.Fatal("enqueue() = true, want false for a closed session")
-	}
-}
+// TestClosedSessionRejectsFurtherEnqueueWithoutPanic moved to stream-go
+// (it exercises the registry's unexported enqueue path).
 
 func TestServiceFiltersScopedSubscriptions(t *testing.T) {
 	t.Parallel()
@@ -567,7 +558,7 @@ func assertReceivedEvent(t *testing.T, session *Session, workspaceID string) {
 func receiveEvent(t *testing.T, session *Session) PublishedEvent {
 	t.Helper()
 	select {
-	case event := <-session.events:
+	case event := <-session.Events():
 		return event
 	default:
 		t.Fatal("event not received")
@@ -578,7 +569,7 @@ func receiveEvent(t *testing.T, session *Session) PublishedEvent {
 func assertNoEvent(t *testing.T, session *Session) {
 	t.Helper()
 	select {
-	case event := <-session.events:
+	case event := <-session.Events():
 		t.Fatalf("unexpected event received: %#v", event)
 	default:
 	}


### PR DESCRIPTION
## What

Extract the event-stream transport/registry out of the tutti-coupled packages into two **neutral, publishable cores**, so other products (e.g. tsh group chat, which needs a per-room WS with `scope=roomId`) can reuse the exact same plumbing instead of vendoring or reimplementing it.

### `@tutti-os/event-stream-core` (TS, publishable)
The catalog-agnostic **client** transport: connection lifecycle, heartbeat (ping/pong), backoff reconnect, frame codec, subscription registry, `connectionState`. Generic over the client/server event + scope types and parameterized by an injected `EventStreamProtocol` (validators, version/revision, scope strategy, client-event factory). It imports **no concrete catalog**.

`@tutti-os/client-tuttid-ts` keeps its public `createTuttidEventStreamClient` surface **unchanged** and becomes a thin tutti binding (workspace `scope.workspaceId`) on top of the core.

### `streamgo` — `packages/events/stream-go` (Go module)
The catalog-agnostic **server** core: generic `Service[S comparable]` pub/sub registry + scope routing + session fan-out. `services/tuttid/service/eventstream` becomes a thin binding via type aliases — `daemon_events.go` and all catalog content files are **unchanged**. The scope axis is now generic and the catalog dependency is reduced to a minimal `TopicVersion` contract.

Also externalizes `@tutti-os/event-stream-core` in the Electron build (it joins the `client-tuttid-ts` source graph consumed by the main process).

## Why
Same `EventStreamProtocol` philosophy, two layers: a neutral infra core (this PR) + per-product topic catalogs. tutti binds `scope.workspaceId`; tsh chat can bind `scope.roomId` on the identical transport.

## Verification (local)
- `eventStreamClient.test.ts` **13/13 pass** (regression guard, unchanged).
- tuttid `eventstream` + `api` tests pass; new `streamgo` tests pass; `go build ./...` clean; `gofmt` + `go vet` clean.
- oxlint + typecheck clean on changed TS; electron/ui/renderer boundary checks pass.

## Follow-up (please run in canonical CI env)
`pnpm-lock.yaml` is intentionally **not** updated here: a local non-Linux `pnpm install` prunes cross-platform optional deps and reflows lockfile quoting. Run the canonical `pnpm install` to add the new `@tutti-os/event-stream-core` workspace edge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced a shared, catalog-agnostic event-stream WebSocket client core and re-implemented the Tuttid client on top of it.
  * Added a server-side stream service and Go wire contracts for catalog-scoped event publish/subscribe.
* **Bug Fixes**
  * Improved connection lifecycle behavior with heartbeat, backoff reconnect, and more reliable publish/ack handling.
* **Documentation**
  * Added end-to-end README documentation and configuration examples for the new event-stream core.
* **Tests**
  * Added unit tests validating session lifecycle and scope-based routing behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->