### PR TITLE
fix(agent): keep Codex scratch imports unassigned

### DIFF
--- a/docs/conventions/troubleshooting.md
+++ b/docs/conventions/troubleshooting.md
@@ -440,7 +440,8 @@ delimited by ---`, and the composer skill picker may show partial or
   user-project paths. For imported sessions, inspect `runtimeContext` for the
   daemon-owned `externalImportNoProject` marker. Check both the in-memory
   `rememberNoProjectPath` path and the restart fallback that recognizes
-  `Documents/tutti/session-<uuid>`.
+  `Documents/tutti/session-<uuid>`. Codex external history can also record its
+  own scratch cwd under `Documents/Codex/<yyyy-mm-dd>/<conversation>`.
 - Root cause:
   Conversation project grouping is a view-model join of `cwd x userProjects`.
   If a generated no-project cwd is not recognized before prefix/parent project
@@ -449,18 +450,20 @@ delimited by ---`, and the composer skill picker may show partial or
   `isNoProjectPath` callback because it has the user home-directory context;
   a package-level suffix check would misclassify real projects that contain a
   `Documents/tutti/session-<uuid>` subdirectory. External import has a similar
-  trap because provider transcripts may record `$HOME` as the cwd when no
-  project was selected; that intent must be persisted as session metadata rather
-  than inferred later from user-project prefix matching.
+  trap because provider transcripts may record `$HOME` or a provider-owned
+  scratch working directory as the cwd when no project was selected; that intent
+  must be persisted as session metadata rather than inferred later from
+  user-project prefix matching.
 - Fix:
   Treat exact user-project path matches as explicit user intent, then call the
   host no-project resolver before parent project matching. The desktop resolver
   should recognize generated `$HOME/Documents/tutti/session-<uuid>` cwd values
   while allowing explicit registered projects to override them. External import
-  should mark home-cwd sessions as no-project in `runtimeContext`, skip them
-  when registering user-project paths, and let Agent GUI preserve that no-project
-  mode during later project re-resolution. Keep the project field derived in the
-  Agent GUI view-model rather than writing it back into the conversation store.
+  should mark home-cwd sessions and known provider scratch cwd shapes as
+  no-project in `runtimeContext`, skip them when registering user-project paths,
+  and let Agent GUI preserve that no-project mode during later project
+  re-resolution. Keep the project field derived in the Agent GUI view-model
+  rather than writing it back into the conversation store.
 - Validation:
   Run
   `pnpm --filter @tutti-os/agent-gui test -- agent-gui/agentGuiNode/model/agentGuiConversationModel.spec.ts`,

--- a/services/tuttid/service/agent/external_import_parse.go
+++ b/services/tuttid/service/agent/external_import_parse.go
@@ -224,7 +224,7 @@ func normalizeExternalParsedSession(session externalImportedSession) (externalIm
 		return externalImportedSession{}, false, nil
 	}
 	session.Cwd = cwd
-	session.NoProject = isExternalImportNoProjectCwd(cwd)
+	session.NoProject = isExternalImportNoProjectCwd(session.Provider, cwd)
 	messages := make([]externalImportedMessage, 0, len(session.Messages))
 	for i, message := range session.Messages {
 		message.Role = normalizeExternalMessageRole(message.Role)
@@ -270,7 +270,7 @@ func normalizeExternalParsedSession(session externalImportedSession) (externalIm
 	return session, true, nil
 }
 
-func isExternalImportNoProjectCwd(cwd string) bool {
+func isExternalImportNoProjectCwd(provider string, cwd string) bool {
 	home, err := os.UserHomeDir()
 	if err != nil {
 		return false
@@ -279,7 +279,40 @@ func isExternalImportNoProjectCwd(cwd string) bool {
 	if !ok {
 		return false
 	}
-	return filepath.Clean(cwd) == filepath.Clean(home)
+	cwd = filepath.Clean(cwd)
+	home = filepath.Clean(home)
+	if cwd == home {
+		return true
+	}
+	return agentproviderbiz.Normalize(provider) == agentproviderbiz.Codex &&
+		isExternalImportCodexScratchCwd(home, cwd)
+}
+
+func isExternalImportCodexScratchCwd(home string, cwd string) bool {
+	rel, err := filepath.Rel(home, cwd)
+	if err != nil || rel == "." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) || rel == ".." {
+		return false
+	}
+	parts := strings.Split(filepath.ToSlash(rel), "/")
+	if len(parts) != 4 || parts[0] != "Documents" || parts[1] != "Codex" || parts[3] == "" {
+		return false
+	}
+	return isExternalImportDateSegment(parts[2])
+}
+
+func isExternalImportDateSegment(value string) bool {
+	if len(value) != len("2006-01-02") || value[4] != '-' || value[7] != '-' {
+		return false
+	}
+	for index, char := range value {
+		if index == 4 || index == 7 {
+			continue
+		}
+		if char < '0' || char > '9' {
+			return false
+		}
+	}
+	return true
 }
 
 func externalImportedMessageHasContent(message externalImportedMessage) bool {

--- a/services/tuttid/service/agent/external_import_parse_test.go
+++ b/services/tuttid/service/agent/external_import_parse_test.go
@@ -2,6 +2,7 @@ package agent
 
 import (
 	"encoding/json"
+	"os"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -199,6 +200,81 @@ func TestParseCodexJSONLSkipsAgentsAndEnvironmentPreamble(t *testing.T) {
 	}
 	if len(session.Messages) != 1 || session.Messages[0].Text != "Real question here" {
 		t.Fatalf("messages = %#v, want only the real user message", session.Messages)
+	}
+}
+
+func TestParseCodexJSONLMarksDocumentsCodexScratchCwdAsNoProject(t *testing.T) {
+	home := filepath.Join(t.TempDir(), "home")
+	cwd := filepath.Join(home, "Documents", "Codex", "2026-06-26", "ge")
+	if err := os.MkdirAll(cwd, 0o755); err != nil {
+		t.Fatalf("create codex scratch cwd error = %v", err)
+	}
+	if canonical, ok := canonicalExistingDir(home); ok {
+		home = canonical
+	}
+	if canonical, ok := canonicalExistingDir(cwd); ok {
+		cwd = canonical
+	}
+	t.Setenv("HOME", home)
+
+	session, ok, err := parseCodexJSONL(
+		filepath.Join(cwd, "rollout.jsonl"),
+		strings.NewReader(testAgentJSONL(t,
+			map[string]any{
+				"timestamp": "2026-06-18T00:00:00Z",
+				"type":      "session_meta",
+				"payload":   map[string]any{"id": "codex-scratch", "cwd": cwd},
+			},
+			map[string]any{
+				"timestamp": "2026-06-18T00:00:01Z",
+				"type":      "response_item",
+				"payload": map[string]any{
+					"type":    "message",
+					"role":    "user",
+					"content": []any{map[string]any{"type": "input_text", "text": "Scratch question"}},
+				},
+			},
+		)),
+	)
+	if err != nil || !ok {
+		t.Fatalf("parseCodexJSONL ok=%v err=%v", ok, err)
+	}
+	if !session.NoProject {
+		t.Fatalf("NoProject = false for Codex scratch cwd %q", session.Cwd)
+	}
+}
+
+func TestParseClaudeCodeJSONLDoesNotUseCodexScratchCwdNoProjectRule(t *testing.T) {
+	home := filepath.Join(t.TempDir(), "home")
+	cwd := filepath.Join(home, "Documents", "Codex", "2026-06-26", "ge")
+	if err := os.MkdirAll(cwd, 0o755); err != nil {
+		t.Fatalf("create codex scratch-shaped cwd error = %v", err)
+	}
+	if canonical, ok := canonicalExistingDir(home); ok {
+		home = canonical
+	}
+	if canonical, ok := canonicalExistingDir(cwd); ok {
+		cwd = canonical
+	}
+	t.Setenv("HOME", home)
+
+	session, ok, err := parseClaudeCodeJSONL(
+		filepath.Join(cwd, "claude.jsonl"),
+		strings.NewReader(testAgentJSONL(t,
+			map[string]any{
+				"timestamp": "2026-06-18T00:00:00Z",
+				"sessionId": "claude-project",
+				"cwd":       cwd,
+				"uuid":      "claude-1",
+				"message":   map[string]any{"role": "user", "content": []any{map[string]any{"type": "text", "text": "Project question"}}},
+			},
+		)),
+	)
+	if err != nil || !ok {
+		t.Fatalf("parseClaudeCodeJSONL ok=%v err=%v", ok, err)
+	}
+	if session.NoProject {
+		t.Fatalf("NoProject = true for non-Codex provider cwd %q", session.Cwd)
 	}
 }
 

--- a/services/tuttid/service/agent/service_test.go
+++ b/services/tuttid/service/agent/service_test.go
@@ -309,6 +309,71 @@ func TestServiceImportsHomeCwdAsNoProjectWithoutRegisteringUserHome(t *testing.T
 	}
 }
 
+func TestServiceImportsCodexScratchCwdAsNoProjectWithoutRegisteringIt(t *testing.T) {
+	ctx := context.Background()
+	store := openAgentServiceSQLiteStore(t)
+	if err := store.Create(ctx, workspacebiz.Summary{ID: "ws-1", Name: "Workspace One"}); err != nil {
+		t.Fatalf("Create workspace error = %v", err)
+	}
+	root := t.TempDir()
+	home := filepath.Join(root, "home")
+	scratchCwd := filepath.Join(home, "Documents", "Codex", "2026-06-26", "ge")
+	if err := os.MkdirAll(scratchCwd, 0o755); err != nil {
+		t.Fatalf("create codex scratch cwd error = %v", err)
+	}
+	if canonical, ok := canonicalExistingDir(home); ok {
+		home = canonical
+	}
+	if canonical, ok := canonicalExistingDir(scratchCwd); ok {
+		scratchCwd = canonical
+	}
+	codexHome := filepath.Join(root, "codex-home")
+	t.Setenv("HOME", home)
+	t.Setenv("CODEX_HOME", codexHome)
+	t.Setenv("CLAUDE_CONFIG_DIR", filepath.Join(root, "claude-home"))
+	now := time.Now().UTC().Format(time.RFC3339Nano)
+	writeAgentServiceJSONL(t, filepath.Join(codexHome, "sessions", "codex-scratch.jsonl"),
+		map[string]any{
+			"timestamp": now,
+			"type":      "session_meta",
+			"payload":   map[string]any{"id": "codex-scratch", "cwd": scratchCwd},
+		},
+		map[string]any{"timestamp": now, "type": "response_item", "payload": map[string]any{
+			"type": "message", "id": "codex-scratch-1", "role": "user",
+			"content": []any{map[string]any{"type": "input_text", "text": "Scratch question"}},
+		}},
+	)
+
+	service := NewService(newFakeRuntime())
+	projection := NewActivityProjection(store)
+	service.SessionReader = projection
+	service.MessageReader = projection
+	service.ExternalImportStore = store
+
+	result, err := service.ImportExternalSessions(ctx, "ws-1", ExternalImportInput{
+		Projects: []ExternalImportProjectSelection{{Path: scratchCwd}},
+	})
+	if err != nil {
+		t.Fatalf("ImportExternalSessions error = %v", err)
+	}
+	if result.ImportedSessions != 1 || result.ImportedMessages != 1 {
+		t.Fatalf("import result = %#v, want one imported no-project session", result)
+	}
+	if len(result.ProjectPaths) != 0 || result.ImportedProjects != 0 {
+		t.Fatalf("import result = %#v, want no registered project paths for Codex scratch cwd", result)
+	}
+	session, err := service.Get(ctx, "ws-1", externalImportedSessionID("codex", "codex-scratch"))
+	if err != nil {
+		t.Fatalf("Get imported Codex scratch session error = %v", err)
+	}
+	if session.Cwd != scratchCwd {
+		t.Fatalf("session cwd = %q, want imported scratch cwd %q", session.Cwd, scratchCwd)
+	}
+	if session.RuntimeContext["externalImportNoProject"] != true {
+		t.Fatalf("runtime context = %#v, want externalImportNoProject true", session.RuntimeContext)
+	}
+}
+
 func TestServiceListsImportedSessionsByExternalActivityTime(t *testing.T) {
 	ctx := context.Background()
 	store := openAgentServiceSQLiteStore(t)


### PR DESCRIPTION
## Summary
- mark Codex external-import cwd under `Documents/Codex/<yyyy-mm-dd>/<conversation>` as no-project
- keep scratch imported sessions out of registered user-project paths
- document the Codex scratch cwd troubleshooting case

## Tests
- `cd services/tuttid && go test ./service/agent ./api -run 'ExternalImport|ParseCodex|ParseClaude'`\n- `pnpm check:changed --tail-lines 80`\n- `pnpm lint:go`\n\nNote: local pre-push `check:full` hit a generated builtin app zip length mismatch while `lint:go` and `test:go` generated the same artifact concurrently; the failed `lint:go` lane passed when rerun standalone.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of imported sessions that were created without a selected project, so they stay correctly marked as “no project.”
  * Codex imports now better recognize scratch-style working directories under the user’s home folder and avoid treating them as project workspaces.
  * External session imports now preserve the original projectless intent during later project detection, reducing incorrect project assignment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->