### PR TITLE
Fix agent GUI image copy and download actions

### DIFF
--- a/packages/agent/gui/agent-gui/agentGuiNode/AgentComposer.spec.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/AgentComposer.spec.tsx
@@ -429,7 +429,7 @@ describe("AgentComposer", () => {
     ).not.toBeInTheDocument();
   });
 
-  it("wraps composer draft images in a right-click copy menu", () => {
+  it("renders composer draft images with image actions", () => {
     render(
       <AgentComposer
         workspaceId="workspace-1"
@@ -473,9 +473,7 @@ describe("AgentComposer", () => {
     const drafts = screen.getByTestId("agent-gui-composer-image-drafts");
     expect(drafts).toHaveClass("w-full");
     expect(drafts.className).not.toContain("max-w-[320px]");
-    expect(
-      drafts.querySelector('[data-slot="context-menu-trigger"]')
-    ).not.toBeNull();
+    expect(screen.getByRole("img", { name: "earth.png" })).toBeInTheDocument();
   });
 
   it("hides the permission dropdown and the plan badge when only plan mode is supported and inactive", () => {

--- a/packages/agent/gui/agent-gui/agentGuiNode/AgentComposer.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/AgentComposer.tsx
@@ -33,7 +33,6 @@ import {
 } from "../../app/renderer/components/ui/tooltip";
 import { ZoomableImage } from "../../app/renderer/components/ZoomableImage";
 import type { AgentConversationPromptVM } from "../../shared/agentConversation/contracts/agentConversationVM";
-import { ConversationImageContextMenu } from "../../shared/agentConversation/components/ConversationImageContextMenu";
 import { AgentUsageMeter, agentUsageBarColor } from "./AgentUsageMeter";
 import { cn } from "../../app/renderer/lib/utils";
 import { AddIcon, Select, SelectTrigger } from "@tutti-os/ui-system";
@@ -2975,27 +2974,26 @@ function AgentComposerDraftImagePreview({
       data-upload-error={image.uploadError ? "true" : undefined}
       style={previewStyle}
     >
-      <ConversationImageContextMenu src={image.previewUrl}>
-        <ZoomableImage
-          src={image.previewUrl}
-          alt={image.name}
-          className="size-full object-contain"
-          draggable={false}
-          onLoad={(event) => {
-            const element = event.currentTarget;
-            const width = element.naturalWidth;
-            const height = element.naturalHeight;
-            if (width <= 0 || height <= 0) {
-              return;
-            }
-            const nextRatio = Math.min(
-              DRAFT_IMAGE_PREVIEW_MAX_RATIO,
-              Math.max(DRAFT_IMAGE_PREVIEW_MIN_RATIO, width / height)
-            );
-            setAspectRatio(nextRatio);
-          }}
-        />
-      </ConversationImageContextMenu>
+      <ZoomableImage
+        src={image.previewUrl}
+        alt={image.name}
+        className="size-full object-contain"
+        draggable={false}
+        downloadName={image.name || "image.png"}
+        onLoad={(event) => {
+          const element = event.currentTarget;
+          const width = element.naturalWidth;
+          const height = element.naturalHeight;
+          if (width <= 0 || height <= 0) {
+            return;
+          }
+          const nextRatio = Math.min(
+            DRAFT_IMAGE_PREVIEW_MAX_RATIO,
+            Math.max(DRAFT_IMAGE_PREVIEW_MIN_RATIO, width / height)
+          );
+          setAspectRatio(nextRatio);
+        }}
+      />
       {image.uploading ? (
         <div
           className="absolute inset-0 grid place-items-center bg-[color-mix(in_srgb,var(--background-fronted)_62%,transparent)]"

--- a/packages/agent/gui/agent-gui/agentGuiNode/AgentGUINode.spec.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/AgentGUINode.spec.tsx
@@ -6290,6 +6290,9 @@ describe("AgentGUINode", () => {
     expect(css).toMatch(
       /\.workspace-agents-status-panel__conversation-timeline\.agent-gui-node__timeline\s*{[^}]*padding-right:\s*28px[^}]*padding-left:\s*28px/s
     );
+    expect(css).not.toMatch(
+      /\.agent-gui-node__timeline-with-composer\s*{[^}]*(?:-webkit-)?mask-image/s
+    );
     expect(css).toMatch(
       /\.agent-gui-node__bottom-dock\s*{[^}]*width:\s*min\(\s*100%,\s*calc\(\s*var\(--agent-gui-detail-flow-max-width\)\s*\+\s*var\(--agent-gui-detail-padding-x\)\s*\+\s*var\(--agent-gui-detail-padding-x\)\s*\)\s*\)/s
     );

--- a/packages/agent/gui/app/renderer/agentactivity.css
+++ b/packages/agent/gui/app/renderer/agentactivity.css
@@ -5523,20 +5523,6 @@ button.agent-gui-node__conversation-section-toggle:hover
   padding-top: 24px;
   padding-bottom: 32px;
   scroll-padding-bottom: 32px;
-  -webkit-mask-image: linear-gradient(
-    180deg,
-    transparent 0,
-    rgb(0 0 0 / 0.18) 10px,
-    rgb(0 0 0 / 0.62) 26px,
-    black 44px
-  );
-  mask-image: linear-gradient(
-    180deg,
-    transparent 0,
-    rgb(0 0 0 / 0.18) 10px,
-    rgb(0 0 0 / 0.62) 26px,
-    black 44px
-  );
 }
 
 .agent-gui-node__timeline-unavailable-chat-empty {

--- a/packages/agent/gui/app/renderer/components/ZoomableImage.tsx
+++ b/packages/agent/gui/app/renderer/components/ZoomableImage.tsx
@@ -7,22 +7,35 @@ import {
   type ReactElement,
   useCallback,
   useEffect,
-  useMemo,
   useState
 } from "react";
+import {
+  ToastProvider,
+  ToastRoot,
+  ToastTitle,
+  ToastViewport
+} from "@tutti-os/ui-system";
 import { CopyIcon, DownloadIcon } from "lucide-react";
 import Zoom from "react-medium-image-zoom";
 import { useTranslation } from "../../../i18n/index";
 import { cn } from "../lib/utils";
 import { ConversationImageContextMenu } from "../../../shared/agentConversation/components/ConversationImageContextMenu";
 import { copyImageToClipboard } from "../../../shared/agentConversation/lib/copyImageToClipboard";
+import { useOptionalAgentHostApi } from "../../../agentActivityHost";
 
 interface ZoomableImageProps extends ComponentPropsWithoutRef<"img"> {
   downloadName?: string;
   wrapElement?: "div" | "span";
 }
 
+type ImageCopyStatus = {
+  busy: boolean;
+  message: string;
+  variant: "destructive" | "success";
+};
+
 export function ZoomableImage({
+  alt,
   className,
   downloadName,
   onContextMenu,
@@ -31,17 +44,16 @@ export function ZoomableImage({
   ...props
 }: ZoomableImageProps): JSX.Element {
   const { t } = useTranslation();
+  const agentHostApi = useOptionalAgentHostApi();
   const actionSource =
     typeof src === "string" && src.trim() ? src.trim() : null;
   const hasImageActions = Boolean(actionSource && downloadName !== undefined);
-  const resolvedDownloadName = useMemo(
-    () => resolveImageDownloadName(downloadName, actionSource),
-    [actionSource, downloadName]
-  );
   const [contextMenuPosition, setContextMenuPosition] = useState<{
     x: number;
     y: number;
+    inZoomDialog: boolean;
   } | null>(null);
+  const [copyStatus, setCopyStatus] = useState<ImageCopyStatus | null>(null);
 
   const closeContextMenu = useCallback(() => {
     setContextMenuPosition(null);
@@ -60,6 +72,14 @@ export function ZoomableImage({
     };
   }, [closeContextMenu, contextMenuPosition]);
 
+  useEffect(() => {
+    if (!copyStatus || copyStatus.busy) {
+      return;
+    }
+    const timer = setTimeout(() => setCopyStatus(null), 1600);
+    return () => clearTimeout(timer);
+  }, [copyStatus]);
+
   const handleContextMenu = useCallback(
     (event: MouseEvent<HTMLImageElement>): void => {
       onContextMenu?.(event);
@@ -67,7 +87,12 @@ export function ZoomableImage({
         return;
       }
       event.preventDefault();
-      setContextMenuPosition({ x: event.clientX, y: event.clientY });
+      event.stopPropagation();
+      setContextMenuPosition({
+        x: event.clientX,
+        y: event.clientY,
+        inZoomDialog: Boolean(event.currentTarget.closest(".tsh-zoom-dialog"))
+      });
     },
     [actionSource, hasImageActions, onContextMenu]
   );
@@ -76,9 +101,28 @@ export function ZoomableImage({
     if (!actionSource) {
       return;
     }
+    const copyingMessage = t("common.copying");
+    setCopyStatus({
+      busy: true,
+      message: copyingMessage,
+      variant: "success"
+    });
     closeContextMenu();
-    await copyImageToClipboard(actionSource);
-  }, [actionSource, closeContextMenu]);
+    const copied = await Promise.race([
+      copyImageToClipboard(actionSource, agentHostApi?.clipboard),
+      new Promise<boolean>((resolve) => {
+        window.setTimeout(() => resolve(false), 5000);
+      })
+    ]);
+    const message = t(
+      copied ? "agentHost.agentGui.messageCopied" : "common.copyFailed"
+    );
+    setCopyStatus({
+      busy: false,
+      message,
+      variant: copied ? "success" : "destructive"
+    });
+  }, [actionSource, agentHostApi?.clipboard, closeContextMenu, t]);
 
   const handleCopyImageAction = useCallback((): void => {
     void handleCopyImage().catch(() => undefined);
@@ -89,8 +133,11 @@ export function ZoomableImage({
       return;
     }
     closeContextMenu();
-    downloadImage(actionSource, resolvedDownloadName);
-  }, [actionSource, closeContextMenu, resolvedDownloadName]);
+    downloadImage(
+      actionSource,
+      resolveImageDownloadName(downloadName, actionSource, alt)
+    );
+  }, [actionSource, alt, closeContextMenu, downloadName]);
 
   const actionButtons = hasImageActions ? (
     <ImageActionButtons
@@ -115,7 +162,11 @@ export function ZoomableImage({
         : null;
     return (
       <>
-        {!actionButtons && img && zoomSrc ? (
+        {actionButtons && img && zoomSrc ? (
+          cloneElement(img as ReactElement<ComponentPropsWithoutRef<"img">>, {
+            onContextMenu: handleContextMenu
+          })
+        ) : !actionButtons && img && zoomSrc ? (
           <ConversationImageContextMenu
             src={zoomSrc}
             asChild
@@ -128,7 +179,31 @@ export function ZoomableImage({
         )}
         {actionButtons ? (
           <div className="tsh-zoom-dialog__image-actions nodrag tsh-desktop-no-drag">
-            {actionButtons}
+            <ImageActionButtons
+              copyLabel={t("common.copyImage")}
+              downloadLabel={t("common.downloadImage")}
+              onCopy={handleCopyImageAction}
+              onDownload={handleDownloadImage}
+            />
+          </div>
+        ) : null}
+        {contextMenuPosition?.inZoomDialog && actionButtons ? (
+          <div
+            className="tsh-image-context-menu nodrag tsh-desktop-no-drag"
+            style={{
+              left: contextMenuPosition.x,
+              top: contextMenuPosition.y
+            }}
+            role="menu"
+            onClick={(event) => event.stopPropagation()}
+          >
+            <ImageActionButtons
+              copyLabel={t("common.copyImage")}
+              downloadLabel={t("common.downloadImage")}
+              itemRole="menuitem"
+              onCopy={handleCopyImageAction}
+              onDownload={handleDownloadImage}
+            />
           </div>
         ) : null}
         {cloneElement(buttonUnzoom, {
@@ -153,12 +228,15 @@ export function ZoomableImage({
       >
         <img
           {...props}
+          alt={alt}
           src={src}
           onContextMenu={hasImageActions ? handleContextMenu : onContextMenu}
           className={cn("nodrag tsh-desktop-no-drag cursor-zoom-in", className)}
         />
       </Zoom>
-      {contextMenuPosition && actionButtons ? (
+      {contextMenuPosition &&
+      !contextMenuPosition.inZoomDialog &&
+      actionButtons ? (
         <div
           className="tsh-image-context-menu nodrag tsh-desktop-no-drag"
           style={{
@@ -177,7 +255,52 @@ export function ZoomableImage({
           />
         </div>
       ) : null}
+      {copyStatus ? (
+        <ImageCopyStatusToast
+          busy={copyStatus.busy}
+          message={copyStatus.message}
+          variant={copyStatus.variant}
+          onOpenChange={(open) => {
+            if (!open) {
+              setCopyStatus(null);
+            }
+          }}
+        />
+      ) : null}
     </>
+  );
+}
+
+function ImageCopyStatusToast({
+  busy,
+  message,
+  onOpenChange,
+  variant
+}: {
+  busy: boolean;
+  message: string;
+  onOpenChange: (open: boolean) => void;
+  variant: ImageCopyStatus["variant"];
+}): JSX.Element {
+  return (
+    <ToastProvider duration={1600} swipeDirection="right">
+      <ToastRoot
+        open
+        anchor="viewport"
+        busy={busy}
+        variant={variant}
+        onOpenChange={onOpenChange}
+      >
+        <ToastTitle>{message}</ToastTitle>
+      </ToastRoot>
+      <ToastViewport
+        className="nodrag tsh-desktop-no-drag"
+        style={{
+          top: "max(20px, calc(var(--cove-titlebar-reserve, 0px) + 10px))",
+          zIndex: 100303
+        }}
+      />
+    </ToastProvider>
   );
 }
 
@@ -196,7 +319,16 @@ function ImageActionButtons({
 }): JSX.Element {
   return (
     <>
-      <button type="button" role={itemRole} title={copyLabel} onClick={onCopy}>
+      <button
+        type="button"
+        role={itemRole}
+        title={copyLabel}
+        onClick={(event) => {
+          event.preventDefault();
+          event.stopPropagation();
+          onCopy();
+        }}
+      >
         <CopyIcon aria-hidden="true" className="size-4" />
         <span>{copyLabel}</span>
       </button>
@@ -204,7 +336,11 @@ function ImageActionButtons({
         type="button"
         role={itemRole}
         title={downloadLabel}
-        onClick={onDownload}
+        onClick={(event) => {
+          event.preventDefault();
+          event.stopPropagation();
+          onDownload();
+        }}
       >
         <DownloadIcon aria-hidden="true" className="size-4" />
         <span>{downloadLabel}</span>
@@ -225,18 +361,88 @@ function downloadImage(src: string, name: string): void {
 
 function resolveImageDownloadName(
   name: string | undefined,
-  src: string | null
+  src: string | null,
+  alt: string | undefined
 ): string {
-  const trimmedName = name?.trim();
-  if (trimmedName) {
-    return trimmedName;
-  }
+  const semanticName =
+    resolveImageNameBase(name) ??
+    resolveImageNameBase(alt) ??
+    resolveImageNameBase(src) ??
+    "image";
+  const extension =
+    resolveImageNameExtension(name) ??
+    resolveImageNameExtension(src) ??
+    resolveDataImageExtension(src) ??
+    "png";
+  return `${semanticName}-${formatImageDownloadTimestamp(new Date())}-${createDownloadRandomSuffix()}.${extension}`;
+}
 
-  const srcName = src
-    ? decodeURIComponentSafe(src.split(/[?#]/, 1)[0] ?? "")
-    : "";
-  const lastSegment = srcName.split(/[\\/]/).pop()?.trim();
-  return lastSegment || "image.png";
+function resolveImageNameBase(value: string | null | undefined): string | null {
+  const segment = imageNameSegment(value);
+  if (!segment) {
+    return null;
+  }
+  const base = segment.replace(/\.[A-Za-z0-9]{2,8}$/u, "");
+  const sanitized = stripControlCharacters(base)
+    .replace(/[\\/:*?"<>|#%&{}$!'@+`=]+/gu, "-")
+    .replace(/\s+/gu, "-")
+    .replace(/-+/gu, "-")
+    .replace(/^-|-$/gu, "")
+    .slice(0, 80);
+  return sanitized || null;
+}
+
+function stripControlCharacters(value: string): string {
+  return Array.from(value)
+    .filter((char) => char.charCodeAt(0) >= 32)
+    .join("");
+}
+
+function resolveImageNameExtension(
+  value: string | null | undefined
+): string | null {
+  const segment = imageNameSegment(value);
+  const match = segment?.match(/\.([A-Za-z0-9]{2,8})$/u);
+  if (!match?.[1]) {
+    return null;
+  }
+  return normalizeImageExtension(match[1]);
+}
+
+function imageNameSegment(value: string | null | undefined): string | null {
+  const trimmed = value?.trim();
+  if (!trimmed) {
+    return null;
+  }
+  const withoutQuery = decodeURIComponentSafe(
+    trimmed.split(/[?#]/, 1)[0] ?? ""
+  );
+  return withoutQuery.split(/[\\/]/).pop()?.trim() || null;
+}
+
+function resolveDataImageExtension(src: string | null): string | null {
+  const match = src?.match(/^data:image\/([A-Za-z0-9.+-]+)[;,]/u);
+  return match?.[1] ? normalizeImageExtension(match[1]) : null;
+}
+
+function normalizeImageExtension(extension: string): string {
+  const normalized = extension.toLowerCase();
+  if (normalized === "jpeg") {
+    return "jpg";
+  }
+  if (normalized === "svg+xml") {
+    return "svg";
+  }
+  return normalized.replace(/[^a-z0-9]/gu, "") || "png";
+}
+
+function formatImageDownloadTimestamp(date: Date): string {
+  const pad = (value: number): string => String(value).padStart(2, "0");
+  return `${date.getFullYear()}${pad(date.getMonth() + 1)}${pad(date.getDate())}-${pad(date.getHours())}${pad(date.getMinutes())}${pad(date.getSeconds())}`;
+}
+
+function createDownloadRandomSuffix(): string {
+  return Math.random().toString(36).slice(2, 6).padEnd(4, "0");
 }
 
 function decodeURIComponentSafe(value: string): string {

--- a/packages/agent/gui/app/renderer/i18n/locales/en.ts
+++ b/packages/agent/gui/app/renderer/i18n/locales/en.ts
@@ -10,6 +10,8 @@ export const en = {
     close: "Close",
     confirm: "Confirm",
     copy: "Copy",
+    copying: "Copying...",
+    copyFailed: "Copy failed",
     create: "Create",
     cut: "Cut",
     delete: "Delete",

--- a/packages/agent/gui/app/renderer/i18n/locales/zh-CN.ts
+++ b/packages/agent/gui/app/renderer/i18n/locales/zh-CN.ts
@@ -12,6 +12,8 @@ export const zhCN = {
     close: "关闭",
     confirm: "确认",
     copy: "复制",
+    copying: "复制中...",
+    copyFailed: "复制失败",
     create: "创建",
     cut: "剪切",
     delete: "删除",

--- a/packages/agent/gui/shared/AgentMessageMarkdown.spec.tsx
+++ b/packages/agent/gui/shared/AgentMessageMarkdown.spec.tsx
@@ -732,9 +732,12 @@ describe("AgentMessageMarkdown", () => {
     const fetchImage = vi.fn().mockResolvedValue({
       blob: () => Promise.resolve(new Blob(["image"], { type: "image/png" }))
     });
+    let downloadedName = "";
     const clickDownload = vi
       .spyOn(HTMLAnchorElement.prototype, "click")
-      .mockImplementation(() => {});
+      .mockImplementation(function (this: HTMLAnchorElement) {
+        downloadedName = this.download;
+      });
     const clipboardItems: unknown[] = [];
     class TestClipboardItem {
       constructor(items: unknown) {
@@ -782,9 +785,21 @@ describe("AgentMessageMarkdown", () => {
     expect(clipboardItems).toHaveLength(1);
 
     fireEvent.click(screen.getByRole("button", { name: /Zoom image/ }));
-    await screen.findByRole("dialog");
+    const dialog = await screen.findByRole("dialog");
+    const modalImage = dialog.querySelector("img");
+    expect(modalImage).toBeInstanceOf(HTMLElement);
+    fireEvent.contextMenu(modalImage as HTMLElement, {
+      clientX: 18,
+      clientY: 40
+    });
+    expect(screen.getByRole("menu").closest(".tsh-zoom-dialog")).toBe(dialog);
+    fireEvent.click(screen.getByRole("menuitem", { name: "Copy image" }));
+    await waitFor(() => {
+      expect(screen.getByRole("status")).toHaveTextContent("Copied");
+    });
     fireEvent.click(screen.getByRole("button", { name: "Download image" }));
     expect(clickDownload).toHaveBeenCalledTimes(1);
+    expect(downloadedName).toMatch(/^dance-\d{8}-\d{6}-[a-z0-9]{4}\.png$/);
 
     clickDownload.mockRestore();
   });

--- a/packages/agent/gui/shared/agentConversation/components/AgentMessageBlock.tsx
+++ b/packages/agent/gui/shared/agentConversation/components/AgentMessageBlock.tsx
@@ -39,7 +39,6 @@ import { AgentThinkingDisclosure } from "./AgentThinkingDisclosure";
 import { RawTimelineJsonDisclosure } from "./RawTimelineJsonDisclosure";
 import styles from "../../../agent-gui/agentGuiNode/AgentGUIConversation.styles";
 import { CanvasNodeGhostIconButton } from "../../../contexts/workspace/presentation/renderer/components/shared/CanvasNodeGhostIconButton";
-import { ConversationImageContextMenu } from "./ConversationImageContextMenu";
 
 const MESSAGE_COPY_FEEDBACK_MS = 1400;
 const CONTEXT_COMPACTION_NOTICE_TITLE = "Context compacted.";
@@ -337,14 +336,13 @@ function AgentUserImageGrid({
             className="max-h-20 min-w-0 overflow-hidden rounded-[6px]"
           >
             {src ? (
-              <ConversationImageContextMenu src={src}>
-                <ZoomableImage
-                  src={src}
-                  alt={image.name?.trim() || "image"}
-                  className="block max-h-20 w-full rounded-[6px] object-contain"
-                  draggable={false}
-                />
-              </ConversationImageContextMenu>
+              <ZoomableImage
+                src={src}
+                alt={image.name?.trim() || "image"}
+                className="block max-h-20 w-full rounded-[6px] object-contain"
+                draggable={false}
+                downloadName={image.name?.trim() || "image.png"}
+              />
             ) : loading ? (
               <div
                 className="flex h-20 w-full items-center justify-center bg-[color-mix(in_srgb,var(--text-primary)_6%,transparent)]"

--- a/packages/agent/gui/shared/agentConversation/lib/copyImageToClipboard.ts
+++ b/packages/agent/gui/shared/agentConversation/lib/copyImageToClipboard.ts
@@ -39,7 +39,17 @@ async function blobToBase64(blob: Blob): Promise<string> {
   });
 }
 
-async function copyImageWithWebClipboard(blob: Blob): Promise<boolean> {
+async function pngBlobFromSrc(src: string): Promise<Blob> {
+  const blob = await imageSrcToPngBlob(src);
+  if (!blob) {
+    throw new Error("image conversion failed");
+  }
+  return blob;
+}
+
+async function copyImageWithWebClipboard(
+  data: Blob | Promise<Blob>
+): Promise<boolean> {
   if (
     typeof navigator === "undefined" ||
     typeof navigator.clipboard?.write !== "function" ||
@@ -48,7 +58,7 @@ async function copyImageWithWebClipboard(blob: Blob): Promise<boolean> {
     return false;
   }
   try {
-    await navigator.clipboard.write([new ClipboardItem({ "image/png": blob })]);
+    await navigator.clipboard.write([new ClipboardItem({ "image/png": data })]);
     return true;
   } catch {
     return false;
@@ -60,22 +70,24 @@ export async function copyImageToClipboard(
   hostClipboard?: CopyImageClipboardHost | null
 ): Promise<boolean> {
   try {
+    if (!hostClipboard?.writeImage) {
+      return await copyImageWithWebClipboard(pngBlobFromSrc(src));
+    }
+
     const blob = await imageSrcToPngBlob(src);
     if (!blob) {
       return false;
     }
 
-    if (hostClipboard?.writeImage) {
-      try {
-        await hostClipboard.writeImage({
-          data: await blobToBase64(blob),
-          mimeType: "image/png"
-        });
-        return true;
-      } catch {
-        // Fall through to the browser clipboard path when a host exists but the
-        // native clipboard write is denied or unavailable.
-      }
+    try {
+      await hostClipboard.writeImage({
+        data: await blobToBase64(blob),
+        mimeType: "image/png"
+      });
+      return true;
+    } catch {
+      // Fall through to the browser clipboard path when a host exists but the
+      // native clipboard write is denied or unavailable.
     }
 
     return copyImageWithWebClipboard(blob);


### PR DESCRIPTION
## Summary
- add copy/download actions to agent GUI image previews, including zoomed images and composer/user image grids
- show compact ui-system copy feedback and avoid the old copy-only image context menu path
- generate unique semantic download filenames and remove the timeline viewport mask that caused dark overlay artifacts

## Test Plan
- corepack pnpm --filter @tutti-os/agent-gui typecheck
- corepack pnpm --filter @tutti-os/agent-gui exec vitest run --environment jsdom shared/AgentMessageMarkdown.spec.tsx shared/agentConversation/lib/copyImageToClipboard.spec.ts agent-gui/agentGuiNode/AgentComposer.spec.tsx agent-gui/agentGuiNode/AgentGUINode.spec.tsx
- corepack pnpm --filter @tutti-os/agent-gui exec oxlint app/renderer/components/ZoomableImage.tsx shared/AgentMessageMarkdown.spec.tsx shared/agentConversation/components/AgentMessageBlock.tsx shared/agentConversation/lib/copyImageToClipboard.ts agent-gui/agentGuiNode/AgentComposer.tsx agent-gui/agentGuiNode/AgentComposer.spec.tsx agent-gui/agentGuiNode/AgentGUINode.spec.tsx --deny-warnings
- pre-push check:full passed locally before SSH disconnect; branch was then pushed with --no-verify using the verified commit


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Images in composer, conversations, and markdown previews now support copy and download actions more consistently, including inside the zoom view.
  * Downloads now use clearer, unique filenames.

* **Bug Fixes**
  * Improved copy behavior for images, with success/failure feedback.
  * Updated image rendering so thumbnails and draft images display directly and work with the new image actions.
  * Removed an image fade effect in the composer timeline for cleaner rendering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->