### PR TITLE
fix(app-factory): add CSS overflow prevention constraints for generated workspace apps

### DIFF
--- a/services/tuttid/service/workspace/app_factory_prompts.go
+++ b/services/tuttid/service/workspace/app_factory_prompts.go
@@ -73,6 +73,8 @@ func writeAppFactoryMentionContext(workspace workspacebiz.Summary, physicalRoot 
 		Constraints: []string{
 			"Do not assume hidden Tutti daemon internals, preload APIs, tokens, or desktop APIs.",
 			"Validate against the App Factory skill before finishing.",
+			"Ensure all buttons, toolbars, and action bars adapt to window size using CSS flexbox wrapping or responsive layout; never allow buttons to overflow outside the document area.",
+			"Use max-width: 100% and overflow handling on container elements to prevent horizontal overflow at narrow viewport sizes.",
 			"Default new apps to a Node server; use Python only for existing Python projects or explicit Python requests.",
 			"If the app needs local agent or local LLM execution, Codex, Claude, or app-owned MCP/tooling, follow the tutti-agent-workspace-app skill and use @tutti-os/agent-acp-kit instead of TUTTI_CLI agent/codex/session polling.",
 			"Agent-enabled app main flows must detect and offer available Claude Code and Codex provider options, then choose one available provider by default.",

--- a/services/tuttid/service/workspace/app_factory_test.go
+++ b/services/tuttid/service/workspace/app_factory_test.go
@@ -425,6 +425,9 @@ func TestAppFactoryServiceCreateUsesDraftDirAndReferenceContext(t *testing.T) {
 	if len(mentionContext.Constraints) == 0 || !strings.Contains(constraints, "Do not assume hidden Tutti daemon internals") {
 		t.Fatalf("context constraints = %#v", mentionContext.Constraints)
 	}
+	if !strings.Contains(strings.Join(mentionContext.Constraints, "\n"), "overflow") {
+		t.Fatalf("context constraints should include overflow prevention: %#v", mentionContext.Constraints)
+	}
 	for _, want := range []string{
 		"Default new apps to a Node server",
 		"@tutti-os/agent-acp-kit",


### PR DESCRIPTION
## Summary

- Generated workspace apps (including AI Docs) had no layout constraints requiring buttons and toolbars to adapt to window size, allowing action bars to overflow outside the document area when the window was resized to a narrow width.
- Added two constraints to the AI app factory system prompt:
  1. Require buttons, toolbars, and action bars to use CSS flexbox wrapping or responsive layout — no fixed-width overflow.
  2. Require `max-width: 100%` and overflow handling on container elements to prevent horizontal overflow at narrow viewport sizes.

Closes #417

## Test plan

- [ ] Open AI Docs in Tutti desktop
- [ ] Resize the window to a narrow width
- [ ] Verify toolbar buttons wrap rather than overflow outside the document area
- [ ] Factory-generate a new workspace app with action buttons; verify buttons wrap on resize

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Generated app UI guidance now includes responsive layout constraints, encouraging wrapping and flexible arrangements.
  * Added overflow protection guidance so generated interfaces better fit smaller screens and avoid horizontal scrolling.

* **Tests**
  * Updated test assertions to verify the new generated mention-context constraints are present.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->