### PR TITLE
[codex] Add folder enter affordance in mention palette

### DIFF
--- a/packages/agent/gui/agent-gui/agentGuiNode/AgentComposer.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/AgentComposer.tsx
@@ -1661,6 +1661,13 @@ export function AgentComposer({
     [createFileMentionPaletteAdapter]
   );
 
+  const navigateIntoFileMentionItem = useCallback(
+    (item: AgentContextMentionItem): void => {
+      mentionControllerRef.current?.selectAgentGeneratedMentionItem(item);
+    },
+    []
+  );
+
   const handleFileMentionKeyDown = useCallback(
     (event: KeyboardEvent): boolean => {
       if (!showFileMentionPalette) {
@@ -2943,6 +2950,7 @@ export function AgentComposer({
                         mentionControllerRef.current?.expandGroup(groupId)
                       }
                       onNavigateHierarchy={navigateFileMentionHierarchy}
+                      onNavigateIntoItem={navigateIntoFileMentionItem}
                       onOpenReferences={
                         onRequestWorkspaceReferences
                           ? handleOpenReferencesForEntity

--- a/packages/agent/gui/agent-gui/agentGuiNode/AgentFileMentionPalette.spec.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/AgentFileMentionPalette.spec.tsx
@@ -4,6 +4,7 @@ import { fireEvent, render, screen, within } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
 import { AgentFileMentionPalette } from "./AgentFileMentionPalette";
 import type { AgentMentionSearchState } from "./AgentMentionSearchController";
+import type { AgentContextMentionItem } from "./agentRichText/agentFileMentionExtension";
 
 vi.mock("../../i18n/index", async () => {
   const actual =
@@ -19,6 +20,7 @@ vi.mock("../../i18n/index", async () => {
     "agentHost.agentGui.mentionGroupIssues": "任务",
     "agentHost.agentGui.mentionEmptyIssues": "暂无任务",
     "agentHost.agentGui.mentionFilterIssue": "任务",
+    "agentHost.agentGui.fileMentionEnterFolder": "进入文件夹",
     "agentHost.agentGui.fileMentionSwitchCategory": "切换分类",
     "agentHost.agentGui.fileMentionNavigateHierarchy": "进入/返回文件夹",
     "agentHost.agentGui.fileMentionSwitchSelection": "切换选中",
@@ -1053,6 +1055,80 @@ describe("AgentFileMentionPalette", () => {
     );
     expect(backIcon).not.toBeNull();
     expect(backIcon?.querySelector("svg")).not.toBeNull();
+  });
+
+  it("enters agent generated folders from the row arrow without selecting the row", () => {
+    const folderItem = {
+      kind: "file" as const,
+      href: "",
+      path: "/workspace/demo/agentGuiNode",
+      name: "agentGuiNode",
+      entryKind: "directory",
+      directoryPath: "/workspace/demo",
+      mentionNavigation: "agent-generated-folder" as const,
+      childCount: 5
+    } satisfies AgentContextMentionItem;
+    const state: AgentMentionSearchState = {
+      status: "ready",
+      query: "",
+      mode: "browse",
+      filter: "file",
+      categories: [],
+      groups: [
+        {
+          id: "agent_generated_files",
+          items: [folderItem],
+          totalCount: 1,
+          visibleCount: 1,
+          hasMore: false
+        }
+      ],
+      error: null
+    };
+    const onNavigateIntoItem = vi.fn();
+    const onSelectItem = vi.fn();
+
+    render(
+      <AgentFileMentionPalette
+        state={state}
+        highlightedKey="agent_generated_files:file:/workspace/demo/agentGuiNode"
+        label="mention palette"
+        loadingLabel="loading"
+        emptyLabel="empty"
+        errorLabel="error"
+        tabHintLabel="hint"
+        maxHeightPx={320}
+        onHighlightChange={vi.fn()}
+        onSelectItem={onSelectItem}
+        onSelectCategory={vi.fn()}
+        onSelectFilter={vi.fn()}
+        onExpandGroup={vi.fn()}
+        onNavigateIntoItem={onNavigateIntoItem}
+      />
+    );
+
+    const folderRow = screen
+      .getByText("agentGuiNode")
+      .closest('[data-agent-file-mention="true"]');
+    const enterButton = screen.getByRole("button", { name: "进入文件夹" });
+
+    expect(folderRow).toHaveAttribute(
+      "data-agent-mention-navigation",
+      "agent-generated-folder"
+    );
+    expect(enterButton).toHaveAttribute(
+      "data-agent-mention-navigate-into",
+      "true"
+    );
+
+    fireEvent.click(enterButton);
+
+    expect(onNavigateIntoItem).toHaveBeenCalledWith(folderItem);
+    expect(onSelectItem).not.toHaveBeenCalled();
+
+    fireEvent.click(folderRow!);
+
+    expect(onSelectItem).toHaveBeenCalledWith(folderItem);
   });
 
   it("renders image mention rows with thumbnails instead of default file icons", () => {

--- a/packages/agent/gui/agent-gui/agentGuiNode/AgentFileMentionPalette.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/AgentFileMentionPalette.tsx
@@ -68,6 +68,7 @@ export interface AgentFileMentionPaletteProps {
   onSelectFilter: (filter: AgentMentionFilterId) => void;
   onExpandGroup: (groupId: AgentMentionGroupId) => void;
   onNavigateHierarchy?: (delta: 1 | -1) => void;
+  onNavigateIntoItem?: (item: AgentContextMentionItem) => void;
   /**
    * 可选:点击 issue / app 行末尾的「查看产物文件」图标时回调(打开引用 picker 并定位)。
    * 仅 workspace-issue / workspace-app 行渲染该入口。
@@ -192,11 +193,15 @@ export function AgentFileMentionPalette({
   onSelectFilter,
   onExpandGroup,
   onNavigateHierarchy,
+  onNavigateIntoItem,
   onOpenReferences
 }: AgentFileMentionPaletteProps): React.JSX.Element {
   "use memo";
   const openReferencesLabel = translate(
     "agentHost.agentGui.mentionOpenReferences"
+  );
+  const navigateIntoLabel = translate(
+    "agentHost.agentGui.fileMentionEnterFolder"
   );
   const filter = state.filter as AgentMentionFilterId;
   const highlightedBrowseCategory = highlightedKey?.startsWith("category:")
@@ -255,10 +260,16 @@ export function AgentFileMentionPalette({
       state={shellState}
       highlightedKey={highlightedKey}
       getItemKey={agentMentionItemKey}
-      renderItem={(item) =>
+      renderItem={(item, { group }) =>
         renderMentionRow(agentMentionItemToRowItem(item), {
           classNames: AGENT_MENTION_ROW_CLASS_NAMES,
           dataAttributeMode: "agent",
+          ...(onNavigateIntoItem && canNavigateIntoMentionItem(item, group)
+            ? {
+                onNavigateInto: () => onNavigateIntoItem(item),
+                navigateIntoLabel
+              }
+            : {}),
           ...(onOpenReferences && isReferenceableMentionItem(item)
             ? {
                 onOpenReferences: () => onOpenReferences(item),
@@ -517,6 +528,17 @@ function isReferenceableMentionItem(item: AgentContextMentionItem): boolean {
     return item.referencesListSupported === true;
   }
   return false;
+}
+
+function canNavigateIntoMentionItem(
+  item: AgentContextMentionItem,
+  group: AgentMentionGroup
+): boolean {
+  return (
+    group.id === "agent_generated_files" &&
+    item.kind === "file" &&
+    item.mentionNavigation === "agent-generated-folder"
+  );
 }
 
 function mentionSessionAgentProvider(

--- a/packages/agent/gui/app/renderer/i18n/locales/en.ts
+++ b/packages/agent/gui/app/renderer/i18n/locales/en.ts
@@ -936,6 +936,7 @@ export const en = {
       projectLocked: "Project cannot be changed after the session starts",
       projectMissingDescription:
         "This conversation's working directory no longer exists",
+      fileMentionEnterFolder: "Enter folder",
       fileMentionSwitchCategory: "Switch category",
       fileMentionNavigateHierarchy: "Enter/leave folder",
       fileMentionSwitchSelection: "Switch selection",

--- a/packages/agent/gui/app/renderer/i18n/locales/zh-CN.ts
+++ b/packages/agent/gui/app/renderer/i18n/locales/zh-CN.ts
@@ -867,6 +867,7 @@ export const zhCN = {
       },
       projectLocked: "会话开始后项目不可更改",
       projectMissingDescription: "此对话的工作目录已不存在",
+      fileMentionEnterFolder: "进入文件夹",
       fileMentionSwitchCategory: "切换分类",
       fileMentionNavigateHierarchy: "进入/返回文件夹",
       fileMentionSwitchSelection: "切换选中",

--- a/packages/ui/rich-text/src/at-panel/MentionPalette.tsx
+++ b/packages/ui/rich-text/src/at-panel/MentionPalette.tsx
@@ -387,7 +387,10 @@ function MentionPaletteGroups<TItem>({
   highlightedKey: string | null;
   highlightedOptionRef: MutableRefObject<HTMLButtonElement | null>;
   getItemKey: (item: TItem, group: MentionPaletteGroup<TItem>) => string;
-  renderItem: (item: TItem, ctx: { active: boolean }) => ReactNode;
+  renderItem: (
+    item: TItem,
+    ctx: { active: boolean; group: MentionPaletteGroup<TItem> }
+  ) => ReactNode;
   onHighlightChange: (key: string) => void;
   onSelectItem: (item: TItem, group: MentionPaletteGroup<TItem>) => void;
   onExpandGroup: (groupId: string) => void;
@@ -439,7 +442,7 @@ function MentionPaletteGroups<TItem>({
                     onMouseDown={(event) => event.preventDefault()}
                     onClick={() => onSelectItem(item, group)}
                   >
-                    {renderItem(item, { active: isHighlighted })}
+                    {renderItem(item, { active: isHighlighted, group })}
                   </button>
                 );
               })}

--- a/packages/ui/rich-text/src/at-panel/MentionPaletteFromState.tsx
+++ b/packages/ui/rich-text/src/at-panel/MentionPaletteFromState.tsx
@@ -5,6 +5,7 @@ import {
   type MentionPaletteStateAdapterInput
 } from "./mentionPaletteStateAdapter.ts";
 import type {
+  MentionPaletteGroup,
   MentionPaletteProps,
   MentionPaletteTheme
 } from "./mentionPaletteTypes.ts";
@@ -15,7 +16,10 @@ export interface MentionPaletteFromStateProps<
   labels: MentionPaletteProps<TItem>["labels"];
   hintLabels: MentionPaletteProps<TItem>["hintLabels"];
   maxHeightPx: number;
-  renderItem: (item: TItem, ctx: { active: boolean }) => ReactNode;
+  renderItem: (
+    item: TItem,
+    ctx: { active: boolean; group: MentionPaletteGroup<TItem> }
+  ) => ReactNode;
   renderListFooter?: () => ReactNode;
   loadingBanner?: ReactNode;
   scrollHighlightedIntoViewCentered?: boolean;

--- a/packages/ui/rich-text/src/at-panel/MentionRow.tsx
+++ b/packages/ui/rich-text/src/at-panel/MentionRow.tsx
@@ -1,5 +1,6 @@
 import {
   ArrowLeftIcon,
+  ArrowRightIcon,
   Badge,
   FileCodeIcon,
   FileTextIcon,
@@ -84,6 +85,10 @@ export interface MentionRowRenderOptions {
   onOpenReferences?: () => void;
   /** 入口图标的无障碍标签 / tooltip 文案。 */
   openReferencesLabel?: string;
+  /** 当提供时,文件夹行末尾渲染一个「进入下一级」箭头按钮。 */
+  onNavigateInto?: () => void;
+  /** 「进入下一级」箭头按钮的无障碍标签 / tooltip 文案。 */
+  navigateIntoLabel?: string;
 }
 
 interface ResolvedMentionRowRenderOptions {
@@ -91,6 +96,8 @@ interface ResolvedMentionRowRenderOptions {
   dataAttributeMode: MentionRowDataAttributeMode;
   onOpenReferences?: () => void;
   openReferencesLabel?: string;
+  onNavigateInto?: () => void;
+  navigateIntoLabel?: string;
 }
 
 const DEFAULT_MENTION_ROW_CLASS_NAMES = {
@@ -122,7 +129,9 @@ function resolveMentionRowRenderOptions(
       classNames: options.classNames,
       dataAttributeMode: options.dataAttributeMode ?? "shared",
       onOpenReferences: options.onOpenReferences,
-      openReferencesLabel: options.openReferencesLabel
+      openReferencesLabel: options.openReferencesLabel,
+      onNavigateInto: options.onNavigateInto,
+      navigateIntoLabel: options.navigateIntoLabel
     };
   }
   return {
@@ -136,7 +145,10 @@ function isMentionRowRenderOptions(
 ): options is MentionRowRenderOptions {
   return (
     options !== undefined &&
-    ("classNames" in options || "dataAttributeMode" in options)
+    ("classNames" in options ||
+      "dataAttributeMode" in options ||
+      "onOpenReferences" in options ||
+      "onNavigateInto" in options)
   );
 }
 
@@ -157,7 +169,9 @@ export function renderMentionRow(
     classNames,
     dataAttributeMode,
     onOpenReferences,
-    openReferencesLabel
+    openReferencesLabel,
+    onNavigateInto,
+    navigateIntoLabel
   } = resolveMentionRowRenderOptions(options);
   const resolved = resolveMentionRowClassNames(classNames);
   const referencesButton = onOpenReferences ? (
@@ -173,6 +187,8 @@ export function renderMentionRow(
         item={item}
         classNames={resolved}
         dataAttributeMode={dataAttributeMode}
+        navigateIntoLabel={navigateIntoLabel}
+        onNavigateInto={onNavigateInto}
       />
     );
   }
@@ -307,14 +323,50 @@ function MentionOpenReferencesButton({
   );
 }
 
+function MentionNavigateIntoButton({
+  label,
+  onNavigateInto,
+  dataAttributeMode
+}: {
+  label?: string;
+  onNavigateInto: () => void;
+  dataAttributeMode: MentionRowDataAttributeMode;
+}): React.JSX.Element {
+  return (
+    <span
+      role="button"
+      tabIndex={-1}
+      aria-label={label}
+      title={label}
+      className="rich-text-at-mention-row__navigate-into"
+      {...mentionRowDataAttribute(dataAttributeMode, "navigateInto", "true")}
+      onMouseDown={(event) => {
+        event.preventDefault();
+        event.stopPropagation();
+      }}
+      onClick={(event) => {
+        event.preventDefault();
+        event.stopPropagation();
+        onNavigateInto();
+      }}
+    >
+      <ArrowRightIcon size={16} />
+    </span>
+  );
+}
+
 function MentionFileRow({
   item,
   classNames,
-  dataAttributeMode
+  dataAttributeMode,
+  navigateIntoLabel,
+  onNavigateInto
 }: {
   item: MentionRowFileItem;
   classNames: Required<MentionRowClassNames>;
   dataAttributeMode: MentionRowDataAttributeMode;
+  navigateIntoLabel?: string;
+  onNavigateInto?: () => void;
 }): React.JSX.Element {
   return (
     <span
@@ -353,6 +405,13 @@ function MentionFileRow({
           </span>
         ) : null}
       </span>
+      {onNavigateInto ? (
+        <MentionNavigateIntoButton
+          label={navigateIntoLabel}
+          onNavigateInto={onNavigateInto}
+          dataAttributeMode={dataAttributeMode}
+        />
+      ) : null}
     </span>
   );
 }

--- a/packages/ui/rich-text/src/at-panel/mentionPalette.css
+++ b/packages/ui/rich-text/src/at-panel/mentionPalette.css
@@ -581,6 +581,10 @@
   gap: 4px;
 }
 
+.rich-text-at-mention-row__file-text {
+  flex: 1 1 auto;
+}
+
 .rich-text-at-mention-row__app-text {
   flex: 1 1 auto;
 }
@@ -658,22 +662,30 @@
   object-fit: cover;
 }
 
-.rich-text-at-mention-row__open-references {
+.rich-text-at-mention-row__open-references,
+.rich-text-at-mention-row__navigate-into {
+  appearance: none;
   display: grid;
   place-items: center;
   width: 24px;
   height: 24px;
   margin-left: auto;
   flex: 0 0 24px;
+  padding: 0;
+  border: 0;
   border-radius: 5px;
+  background: transparent;
   color: var(--rich-text-at-mention-text-tertiary);
   cursor: pointer;
+  outline: none;
   transition:
     background-color 160ms ease,
     color 160ms ease;
 }
 
-.rich-text-at-mention-row__open-references:hover {
+.rich-text-at-mention-row__open-references:hover,
+.rich-text-at-mention-row__navigate-into:hover,
+.rich-text-at-mention-row__navigate-into:focus-visible {
   background: var(--rich-text-at-mention-active);
   color: var(--rich-text-at-mention-text-secondary);
 }

--- a/packages/ui/rich-text/src/at-panel/mentionPaletteTypes.ts
+++ b/packages/ui/rich-text/src/at-panel/mentionPaletteTypes.ts
@@ -114,7 +114,10 @@ export interface MentionPaletteProps<TItem> {
   state: MentionPaletteState<TItem>;
   highlightedKey: string | null;
   getItemKey: (item: TItem, group: MentionPaletteGroup<TItem>) => string;
-  renderItem: (item: TItem, ctx: { active: boolean }) => ReactNode;
+  renderItem: (
+    item: TItem,
+    ctx: { active: boolean; group: MentionPaletteGroup<TItem> }
+  ) => ReactNode;
   labels: {
     loading: string;
     empty: string;

--- a/packages/ui/rich-text/src/at-panel/mentionRowDataAttributes.ts
+++ b/packages/ui/rich-text/src/at-panel/mentionRowDataAttributes.ts
@@ -9,6 +9,7 @@ export type MentionRowDataAttributeKey =
   | "fileThumb"
   | "fileVisualKind"
   | "navigation"
+  | "navigateInto"
   | "openReferences"
   | "statusTag"
   | "userAvatar";
@@ -24,6 +25,7 @@ const MENTION_ROW_DATA_ATTRIBUTES: Record<
     fileThumb: "data-rich-text-at-mention-file-thumb",
     fileVisualKind: "data-rich-text-at-mention-file-visual-kind",
     navigation: "data-rich-text-at-mention-navigation",
+    navigateInto: "data-rich-text-at-mention-navigate-into",
     openReferences: "data-rich-text-at-mention-open-references",
     statusTag: "data-rich-text-at-mention-status-tag",
     userAvatar: "data-rich-text-at-mention-user-avatar"
@@ -35,6 +37,7 @@ const MENTION_ROW_DATA_ATTRIBUTES: Record<
     fileThumb: "data-agent-mention-file-thumb",
     fileVisualKind: "data-agent-file-visual-kind",
     navigation: "data-agent-mention-navigation",
+    navigateInto: "data-agent-mention-navigate-into",
     openReferences: "data-agent-mention-open-references",
     statusTag: "data-agent-mention-status-tag",
     userAvatar: "data-agent-mention-user-avatar"


### PR DESCRIPTION
## Summary
- add a right-arrow affordance on Agent-generated folder rows in the composer mention palette
- reuse the existing folder navigation behavior for mouse clicks while keeping row selection unchanged
- add localized labels and regression coverage for the new control

## Tests
- pnpm --filter @tutti-os/ui-rich-text test
- pnpm --dir packages/agent/gui exec vitest run --environment jsdom agent-gui/agentGuiNode/AgentFileMentionPalette.spec.tsx
- pnpm typecheck
- pnpm check:i18n
- pnpm check:agent-activity-runtime-boundaries
- pnpm check:changed --tail-lines 80
- pnpm check:full

## Notes
- The local untracked build artifact `apps/desktop/build/nextopd/` was left out of this PR.
- Documentation impact check: no durable docs update needed for this localized UI affordance.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new “enter folder” action for supported mention/file rows, letting users navigate into nested items directly from the picker.
  * Updated the mention UI to show the new action with proper labels and keyboard/mouse behavior.
* **Bug Fixes**
  * Improved row selection behavior so clicking the enter control no longer selects the item.
  * Added missing translation text for English and Simplified Chinese.
* **Tests**
  * Expanded coverage for the new navigation action and related row interactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->