### PR TITLE
fix(agent-gui): keep image copy toast above preview overlay

### DIFF
--- a/packages/agent/gui/app/renderer/agentactivity.css
+++ b/packages/agent/gui/app/renderer/agentactivity.css
@@ -80,7 +80,7 @@
 }
 
 .tsh-zoom-dialog[data-rmiz-modal] {
-  z-index: 100300;
+  z-index: var(--z-dialog-overlay);
   -webkit-app-region: no-drag;
 }
 
@@ -112,14 +112,14 @@
   position: fixed;
   top: max(20px, calc(var(--cove-titlebar-reserve, 0px) + 10px));
   right: 72px;
-  z-index: 100301;
+  z-index: var(--z-dialog-popover);
   display: flex;
   gap: 8px;
 }
 
 .tsh-image-context-menu {
   position: fixed;
-  z-index: 100302;
+  z-index: var(--z-dialog-popover);
   min-width: 148px;
   overflow: hidden;
   border: 1px solid var(--line-2);

--- a/packages/agent/gui/app/renderer/components/ZoomableImage.tsx
+++ b/packages/agent/gui/app/renderer/components/ZoomableImage.tsx
@@ -9,6 +9,7 @@ import {
   useEffect,
   useState
 } from "react";
+import { createPortal } from "react-dom";
 import {
   ToastProvider,
   ToastRoot,
@@ -282,7 +283,7 @@ function ImageCopyStatusToast({
   onOpenChange: (open: boolean) => void;
   variant: ImageCopyStatus["variant"];
 }): JSX.Element {
-  return (
+  return createPortal(
     <ToastProvider duration={1600} swipeDirection="right">
       <ToastRoot
         open
@@ -297,10 +298,11 @@ function ImageCopyStatusToast({
         className="nodrag tsh-desktop-no-drag"
         style={{
           top: "max(20px, calc(var(--cove-titlebar-reserve, 0px) + 10px))",
-          zIndex: 100303
+          zIndex: "var(--z-dialog-popover)"
         }}
       />
-    </ToastProvider>
+    </ToastProvider>,
+    document.body
   );
 }
 

--- a/packages/agent/gui/shared/AgentMessageMarkdown.spec.tsx
+++ b/packages/agent/gui/shared/AgentMessageMarkdown.spec.tsx
@@ -766,7 +766,7 @@ describe("AgentMessageMarkdown", () => {
       value: vi.fn()
     });
 
-    render(
+    const { container } = render(
       <AgentMessageMarkdown
         content={"![generated image](/workspace/output/imagegen/dance.png)"}
         enableImageZoom
@@ -794,9 +794,12 @@ describe("AgentMessageMarkdown", () => {
     });
     expect(screen.getByRole("menu").closest(".tsh-zoom-dialog")).toBe(dialog);
     fireEvent.click(screen.getByRole("menuitem", { name: "Copy image" }));
+    const copyStatus = await screen.findByRole("status");
     await waitFor(() => {
-      expect(screen.getByRole("status")).toHaveTextContent("Copied");
+      expect(copyStatus).toHaveTextContent("Copied");
     });
+    expect(container).not.toContainElement(copyStatus);
+    expect(document.body).toContainElement(copyStatus);
     fireEvent.click(screen.getByRole("button", { name: "Download image" }));
     expect(clickDownload).toHaveBeenCalledTimes(1);
     expect(downloadedName).toMatch(/^dance-\d{8}-\d{6}-[a-z0-9]{4}\.png$/);


### PR DESCRIPTION
## Summary
- Portal the image copy status toast to document.body so it can render above the zoom preview overlay.
- Replace image zoom raw z-index values with existing semantic overlay tokens.
- Add a regression assertion that the copy status is rendered outside the markdown container.

## Test Plan
- [x] corepack pnpm exec vitest run --environment jsdom shared/AgentMessageMarkdown.spec.tsx -t "copies and downloads a workspace markdown image from preview actions" --maxWorkers=1
- [x] corepack pnpm --filter @tutti-os/agent-gui typecheck
- [x] corepack pnpm check:ui-boundaries
- [x] corepack pnpm exec lint-staged
- [x] corepack pnpm check:electron-runtime-boundaries:staged
- [x] corepack pnpm check:ui-boundaries:staged
- [x] corepack pnpm check:renderer-boundaries:staged

Note: git hooks in this shell pick up pnpm 11.7.0, while the repo requires pnpm 10.11.0. I ran the same staged checks with corepack pnpm and used --no-verify for commit/push to avoid the local pnpm shim mismatch.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved overlay and popover stacking so zoom, image actions, context menus, and copy status messages appear in the right order.
  * Updated the copy status toast to render consistently outside the image component, reducing layout and visibility issues.

* **Refactor**
  * Replaced hardcoded layering values with shared styling variables for more consistent UI behavior across the app.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->