### PR TITLE
fix(agent-env): contain report consent panel

### DIFF
--- a/apps/desktop/src/renderer/src/features/workspace-agent/ui/AgentEnvReportConsent.tsx
+++ b/apps/desktop/src/renderer/src/features/workspace-agent/ui/AgentEnvReportConsent.tsx
@@ -12,14 +12,14 @@ export function AgentEnvReportConsent({
   t: ReturnType<typeof useTranslation>["t"];
 }): JSX.Element {
   return (
-    <div className="shrink-0 border-t border-[var(--border-1)] bg-[var(--transparency-block)] px-5 py-3">
+    <div className="mx-5 mb-4 shrink-0 rounded-[8px] border border-[var(--border-1)] bg-[var(--transparency-block)] px-4 py-3 shadow-[0_6px_16px_var(--shadow-elevated)]">
       <p className="m-0 text-[13px] font-medium text-[var(--text-primary)]">
         {t("workspace.agentEnv.reportConsentTitle")}
       </p>
       <p className="m-0 mt-1 text-[12px] text-[var(--text-secondary)]">
         {t("workspace.agentEnv.reportConsentBody")}
       </p>
-      <div className="mt-2 flex justify-end gap-2">
+      <div className="mt-2 flex flex-wrap justify-end gap-2">
         <Button size="sm" type="button" variant="ghost" onClick={onCancel}>
           {t("workspace.agentEnv.reportConsentCancel")}
         </Button>


### PR DESCRIPTION
## Summary
- render the agent environment report consent as an inset panel inside the dialog
- add wrapping to consent actions so narrow dialog widths do not clip controls

## Validation
- pnpm lint:ts apps/desktop/src/renderer/src/features/workspace-agent/ui/AgentEnvReportConsent.tsx
- pnpm --filter @tutti-os/desktop typecheck
- pnpm check:full (pre-push)

## Documentation
- No documentation impact found.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the consent dialog layout and spacing for a cleaner, more polished appearance.
  * Improved the action button area so buttons wrap more gracefully and stay aligned on smaller screens.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->