### PR TITLE
fix(agent-gui): stabilize inline mentions

### DIFF
--- a/packages/agent/gui/agent-gui/agentGuiNode/AgentComposer.spec.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/AgentComposer.spec.tsx
@@ -2083,10 +2083,119 @@ describe("AgentComposer", () => {
           screen.getByTestId("agent-gui-composer-image-drafts").parentElement
         ).toHaveStyle({
           "--agent-gui-composer-attachment-height": "56px",
-          "--agent-gui-composer-input-height": "200px",
-          "--agent-gui-composer-input-max-height": "200px"
+          "--agent-gui-composer-input-height": "190px",
+          "--agent-gui-composer-input-max-height": "190px"
         })
       );
+    } finally {
+      if (scrollHeightDescriptor) {
+        Object.defineProperty(
+          HTMLElement.prototype,
+          "scrollHeight",
+          scrollHeightDescriptor
+        );
+      } else {
+        Reflect.deleteProperty(HTMLElement.prototype, "scrollHeight");
+      }
+    }
+  });
+
+  it("keeps overflowing dock prompt text clipped to a partial line", async () => {
+    const scrollHeightDescriptor = Object.getOwnPropertyDescriptor(
+      HTMLElement.prototype,
+      "scrollHeight"
+    );
+    Object.defineProperty(HTMLElement.prototype, "scrollHeight", {
+      configurable: true,
+      get() {
+        if (!(this instanceof HTMLElement)) {
+          return 24;
+        }
+        if (
+          this.classList.contains("agent-gui-node__composer-prompt-input-area")
+        ) {
+          return 132;
+        }
+        return this.classList.contains("agent-gui-node__composer-textarea")
+          ? 120
+          : 24;
+      }
+    });
+
+    try {
+      render(
+        <AgentComposer
+          workspaceId="workspace-1"
+          currentUserId="user-1"
+          provider="codex"
+          draftContent={createDraft("one\ntwo\nthree\nfour\nfive")}
+          availableCommands={
+            [] satisfies readonly AgentHostAgentSessionCommand[]
+          }
+          disabled={false}
+          submitDisabled={false}
+          placeholder="placeholder"
+          composerSettings={createComposerSettings()}
+          queuedPrompts={[]}
+          drainingQueuedPromptId={null}
+          canQueueWhileBusy={false}
+          showStopButton={false}
+          activePrompt={null}
+          isInterrupting={false}
+          isSendingTurn={false}
+          isSubmittingPrompt={false}
+          labels={createLabels()}
+          workspaceUserProjectI18n={workspaceUserProjectI18n}
+          onDraftContentChange={vi.fn()}
+          onSettingsChange={vi.fn()}
+          onSubmit={vi.fn()}
+          onSendQueuedPromptNext={vi.fn()}
+          onRemoveQueuedPrompt={vi.fn()}
+          onEditQueuedPrompt={vi.fn()}
+          onInterruptCurrentTurn={vi.fn()}
+          onSubmitInteractivePrompt={vi.fn()}
+        />
+      );
+
+      await waitFor(() => {
+        const promptInputArea = screen
+          .getByPlaceholderText("placeholder")
+          .closest(".agent-gui-node__composer-prompt-input-area");
+        expect(promptInputArea).toHaveStyle({
+          "--agent-gui-composer-input-height": "110px",
+          "--agent-gui-composer-input-max-height": "110px",
+          "--agent-gui-composer-text-height": "110px",
+          "--agent-gui-composer-text-line-height": "24px",
+          "--agent-gui-composer-text-max-visible-lines": "3.5",
+          "--agent-gui-composer-text-viewport-height": "84px"
+        });
+      });
+
+      const promptInputArea = screen
+        .getByPlaceholderText("placeholder")
+        .closest(".agent-gui-node__composer-prompt-input-area");
+      if (!(promptInputArea instanceof HTMLElement)) {
+        throw new Error("Expected composer prompt input area");
+      }
+      const textLineHeight = Number.parseFloat(
+        promptInputArea.style.getPropertyValue(
+          "--agent-gui-composer-text-line-height"
+        ) || "0"
+      );
+      const maxVisibleTextLines = Number.parseFloat(
+        promptInputArea.style.getPropertyValue(
+          "--agent-gui-composer-text-max-visible-lines"
+        ) || "0"
+      );
+      const textViewportHeight = Number.parseFloat(
+        promptInputArea.style.getPropertyValue(
+          "--agent-gui-composer-text-viewport-height"
+        ) || "0"
+      );
+      const visibleTextLines = textViewportHeight / textLineHeight;
+      expect(textViewportHeight).toBe(textLineHeight * maxVisibleTextLines);
+      expect(visibleTextLines).toBe(3.5);
+      expect(Number.isInteger(visibleTextLines)).toBe(false);
     } finally {
       if (scrollHeightDescriptor) {
         Object.defineProperty(
@@ -2107,7 +2216,7 @@ describe("AgentComposer", () => {
       /\.agent-gui-node__composer\[data-layout="dock"\]\s+\.agent-gui-node__composer-input-shell\s*{[^}]*padding:\s*0[^}]*border:\s*0[^}]*background:\s*transparent/s
     );
     expect(css).toMatch(
-      /\.agent-gui-node__composer\[data-layout="dock"\]\s+\.agent-gui-node__composer-prompt-input-area\s*{[^}]*display:\s*grid[^}]*grid-template-rows:\s*minmax\(0,\s*1fr\)[^}]*height:\s*var\(--agent-gui-composer-input-height,\s*56px\)[^}]*min-height:\s*56px[^}]*max-height:\s*var\(--agent-gui-composer-input-max-height,\s*120px\)[^}]*align-items:\s*center[^}]*overflow:\s*hidden[^}]*padding:\s*0 12px/s
+      /\.agent-gui-node__composer\[data-layout="dock"\]\s+\.agent-gui-node__composer-prompt-input-area\s*{[^}]*display:\s*grid[^}]*grid-template-rows:\s*minmax\(0,\s*1fr\)[^}]*height:\s*var\(--agent-gui-composer-input-height,\s*56px\)[^}]*min-height:\s*56px[^}]*max-height:\s*var\(--agent-gui-composer-input-max-height,\s*110px\)[^}]*align-items:\s*center[^}]*overflow:\s*hidden[^}]*padding:\s*0 12px/s
     );
     expect(css).toMatch(
       /\.agent-gui-node__composer\[data-layout="dock"\]\s+\.agent-gui-node__composer-prompt-input-area\s*{[^}]*transition:[^}]*height\s+160ms\s+ease[^}]*border-color\s+140ms\s+ease[^}]*box-shadow\s+140ms\s+ease/s
@@ -2131,19 +2240,16 @@ describe("AgentComposer", () => {
       /\.agent-gui-node__composer\[data-layout="dock"\][\s\S]*?\.agent-gui-node__composer-prompt-input-area\[data-has-draft-images="true"\][\s\S]*?\.agent-gui-node__composer-prompt-input-line\s*{[^}]*min-height:\s*40px[^}]*height:\s*calc\(var\(--agent-gui-composer-text-height,\s*56px\)\s*-\s*2px\)[^}]*max-height:\s*118px[^}]*padding:\s*4px 0 11px/s
     );
     expect(css).toMatch(
-      /\.agent-gui-node__composer\[data-layout="dock"\]\s+textarea,[\s\S]*?\.agent-gui-node__composer\[data-layout="dock"\]\s+\.agent-gui-node__composer-textarea\s*{[^}]*display:\s*block[^}]*height:\s*auto[^}]*min-height:\s*24px[^}]*max-height:\s*calc\(var\(--agent-gui-composer-text-height,\s*56px\)\s*-\s*26px\)[^}]*overflow-x:\s*hidden[^}]*overflow-y:\s*auto[^}]*overflow-wrap:\s*anywhere[^}]*scrollbar-width:\s*none[^}]*white-space:\s*pre-wrap/s
+      /\.agent-gui-node__composer\[data-layout="dock"\]\s+textarea,[\s\S]*?\.agent-gui-node__composer\[data-layout="dock"\]\s+\.agent-gui-node__composer-textarea\s*{[^}]*display:\s*block[^}]*height:\s*auto[^}]*min-height:\s*24px[^}]*max-height:\s*var\(--agent-gui-composer-text-viewport-height\)[^}]*overflow-x:\s*hidden[^}]*overflow-y:\s*auto[^}]*overflow-wrap:\s*anywhere[^}]*scrollbar-width:\s*none[^}]*white-space:\s*pre-wrap/s
     );
     expect(css).toMatch(
-      /\.agent-gui-node__composer\[data-layout="dock"\][\s\S]*?\.agent-gui-node__composer-prompt-input-area\[data-has-draft-images="true"\][\s\S]*?textarea,[\s\S]*?\.agent-gui-node__composer\[data-layout="dock"\][\s\S]*?\.agent-gui-node__composer-prompt-input-area\[data-has-draft-images="true"\][\s\S]*?\.agent-gui-node__composer-textarea\s*{[^}]*max-height:\s*calc\([^}]*var\(--agent-gui-composer-text-height,\s*56px\)[^}]*26px/s
+      /\.agent-gui-node__composer\[data-layout="dock"\][\s\S]*?\.agent-gui-node__composer-prompt-input-area\[data-has-draft-images="true"\][\s\S]*?textarea,[\s\S]*?\.agent-gui-node__composer\[data-layout="dock"\][\s\S]*?\.agent-gui-node__composer-prompt-input-area\[data-has-draft-images="true"\][\s\S]*?\.agent-gui-node__composer-textarea\s*{[^}]*max-height:\s*var\(--agent-gui-composer-text-viewport-height\)/s
     );
     expect(css).toMatch(
-      /\.agent-gui-node__composer\[data-layout="dock"\][\s\S]*?\.agent-gui-node__composer-prompt-input-area:hover[\s\S]*?\.agent-gui-node__composer-textarea,[\s\S]*?\.agent-gui-node__composer\[data-layout="dock"\][\s\S]*?\.agent-gui-node__composer-prompt-input-area:focus-within[\s\S]*?\.agent-gui-node__composer-textarea\s*{[^}]*scrollbar-width:\s*thin/s
+      /\.agent-gui-node__composer\[data-layout="dock"\]\s+textarea::-webkit-scrollbar,[\s\S]*?\.agent-gui-node__composer\[data-layout="dock"\s*\][\s\S]*?\.agent-gui-node__composer-textarea::-webkit-scrollbar\s*{[^}]*display:\s*block[^}]*width:\s*0[^}]*height:\s*0/s
     );
     expect(css).toMatch(
-      /\.agent-gui-node__composer\[data-layout="dock"\]\s+textarea::-webkit-scrollbar,[\s\S]*?\.agent-gui-node__composer\[data-layout="dock"\s*\][\s\S]*?\.agent-gui-node__composer-textarea::-webkit-scrollbar\s*{[^}]*display:\s*none[^}]*width:\s*4px/s
-    );
-    expect(css).toMatch(
-      /\.agent-gui-node__composer\[data-layout="dock"\][\s\S]*?\.agent-gui-node__composer-prompt-input-area:hover[\s\S]*?::-webkit-scrollbar,[\s\S]*?\.agent-gui-node__composer\[data-layout="dock"\][\s\S]*?\.agent-gui-node__composer-prompt-input-area:focus-within[\s\S]*?::-webkit-scrollbar\s*{[^}]*display:\s*block/s
+      /\.agent-gui-node__composer\[data-layout="dock"\][\s\S]*?\.agent-gui-node__composer-prompt-input-area:hover[\s\S]*?::-webkit-scrollbar,[\s\S]*?\.agent-gui-node__composer\[data-layout="dock"\][\s\S]*?\.agent-gui-node__composer-prompt-input-area:focus-within[\s\S]*?::-webkit-scrollbar\s*{[^}]*width:\s*4px[^}]*height:\s*4px/s
     );
     expect(css).toMatch(
       /\.agent-gui-node__composer\[data-layout="dock"\]\s+\.agent-gui-node__composer-textarea\s+p\s*{[^}]*display:\s*block[^}]*width:\s*auto[^}]*min-width:\s*0[^}]*overflow:\s*visible[^}]*overflow-wrap:\s*anywhere[^}]*white-space:\s*pre-wrap/s
@@ -3048,7 +3154,7 @@ describe("AgentComposer", () => {
       /\.agent-gui-node__composer-textarea\s*{[^}]*font-size:\s*13px/s
     );
     expect(css).toMatch(
-      /\.agent-gui-node__composer-textarea\s*{[^}]*max-height:\s*72px;[^}]*overflow-y:\s*auto;[^}]*scrollbar-width:\s*thin;[^}]*scrollbar-gutter:\s*stable/s
+      /\.agent-gui-node__composer-textarea\s*{[^}]*--agent-gui-composer-text-line-height:\s*24px;[^}]*--agent-gui-composer-text-max-visible-lines:\s*3\.5;[^}]*--agent-gui-composer-text-viewport-height:\s*calc\([^}]*var\(--agent-gui-composer-text-line-height\)[^}]*\*[^}]*var\(--agent-gui-composer-text-max-visible-lines\)[^}]*\);[^}]*max-height:\s*var\(--agent-gui-composer-text-viewport-height\);[^}]*overflow-y:\s*auto;[^}]*scrollbar-width:\s*thin;[^}]*scrollbar-gutter:\s*stable/s
     );
     expect(css).toMatch(
       /\.agent-gui-node__composer-textarea::-webkit-scrollbar\s*{[^}]*display:\s*block;[^}]*width:\s*4px/s
@@ -3793,8 +3899,8 @@ describe("AgentComposer", () => {
           screen.getByTestId("agent-gui-composer-image-drafts").parentElement
         ).toHaveStyle({
           "--agent-gui-composer-attachment-height": "56px",
-          "--agent-gui-composer-input-height": "200px",
-          "--agent-gui-composer-input-max-height": "200px"
+          "--agent-gui-composer-input-height": "190px",
+          "--agent-gui-composer-input-max-height": "190px"
         })
       );
 

--- a/packages/agent/gui/agent-gui/agentGuiNode/AgentComposer.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/AgentComposer.tsx
@@ -148,10 +148,16 @@ export { formatSlashStatusTokenCount };
 
 const USAGE_POPOVER_HOVER_DELAY_MS = 120;
 const DOCK_COMPOSER_INPUT_MIN_HEIGHT = 56;
-const DOCK_COMPOSER_INPUT_MAX_HEIGHT = 120;
+const DOCK_COMPOSER_TEXT_LINE_HEIGHT = 24;
+const DOCK_COMPOSER_MAX_VISIBLE_TEXT_LINES = 3.5;
+const DOCK_COMPOSER_INPUT_TEXT_CHROME_HEIGHT = 26;
+const DOCK_COMPOSER_TEXT_VIEWPORT_MAX_HEIGHT =
+  DOCK_COMPOSER_TEXT_LINE_HEIGHT * DOCK_COMPOSER_MAX_VISIBLE_TEXT_LINES;
+const DOCK_COMPOSER_INPUT_MAX_HEIGHT =
+  DOCK_COMPOSER_INPUT_TEXT_CHROME_HEIGHT +
+  DOCK_COMPOSER_TEXT_VIEWPORT_MAX_HEIGHT;
 const DOCK_COMPOSER_INPUT_BORDER_HEIGHT = 2;
 const DOCK_COMPOSER_INPUT_PADDING_BLOCK_HEIGHT = 24;
-const DOCK_COMPOSER_INPUT_TEXT_CHROME_HEIGHT = 26;
 
 /**
  * 引用 picker 的确认结果:松散文件按 file mention 插入;mentionItems(如文件夹 bundle)
@@ -2544,7 +2550,10 @@ export function AgentComposer({
             "--agent-gui-composer-attachment-height": `${dockComposerAttachmentHeight}px`,
             "--agent-gui-composer-input-height": `${dockComposerInputHeight}px`,
             "--agent-gui-composer-input-max-height": `${dockComposerInputMaxHeight}px`,
-            "--agent-gui-composer-text-height": `${dockComposerTextHeight}px`
+            "--agent-gui-composer-text-height": `${dockComposerTextHeight}px`,
+            "--agent-gui-composer-text-line-height": `${DOCK_COMPOSER_TEXT_LINE_HEIGHT}px`,
+            "--agent-gui-composer-text-max-visible-lines": `${DOCK_COMPOSER_MAX_VISIBLE_TEXT_LINES}`,
+            "--agent-gui-composer-text-viewport-height": `${DOCK_COMPOSER_TEXT_VIEWPORT_MAX_HEIGHT}px`
           } as CSSProperties),
     [
       dockComposerAttachmentHeight,

--- a/packages/agent/gui/agent-gui/agentGuiNode/AgentGUINode.spec.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/AgentGUINode.spec.tsx
@@ -639,6 +639,15 @@ vi.mock("../../i18n/index", () => ({
           "Context usage unavailable",
         "agentHost.agentGui.slashStatusLimitsUnavailable":
           "Rate limits unavailable",
+        "agentHost.agentGui.slashCommandCompactLabel": "compact",
+        "agentHost.agentGui.slashCommandContextLabel": "context",
+        "agentHost.agentGui.slashCommandFastLabel": "fast",
+        "agentHost.agentGui.slashCommandGoalLabel": "goal",
+        "agentHost.agentGui.slashCommandInitLabel": "init",
+        "agentHost.agentGui.slashCommandPlanLabel": "plan",
+        "agentHost.agentGui.slashCommandReviewLabel": "review",
+        "agentHost.agentGui.slashCommandStatusLabel": "status",
+        "agentHost.agentGui.slashCommandUsageLabel": "usage",
         "agentHost.agentGui.collaboratorSessionReadOnlyPlaceholder":
           "非当前用户会话，不可直接对话",
         "agentHost.agentGui.promptTipsPrefix": "Tips：",
@@ -6392,6 +6401,33 @@ describe("AgentGUINode", () => {
     );
     expect(css).toMatch(
       /\.agent-gui-node__bottom-dock\s*>\s*\.agent-gui-chrome__session-chrome,[\s\S]*?\.agent-gui-node__composer-input-shell\s*{[^}]*pointer-events:\s*auto/s
+    );
+    expect(css).toMatch(
+      /\.agent-gui-node__composer\[data-layout="dock"\]\s+\.agent-gui-node__composer-prompt-input-area:hover\s+textarea,[\s\S]*?\.agent-gui-node__composer-prompt-input-area:focus-within\s+\.agent-gui-node__composer-textarea\s*{[^}]*scrollbar-width:\s*thin/s
+    );
+    expect(css).toMatch(
+      /\.agent-gui-node__composer\[data-layout="dock"\]\s+textarea::-webkit-scrollbar,[\s\S]*?\.agent-gui-node__composer-textarea::-webkit-scrollbar\s*{[^}]*display:\s*block[^}]*width:\s*0[^}]*height:\s*0/s
+    );
+    expect(css).toMatch(
+      /\.agent-gui-node__composer\[data-layout="dock"\]\s+\.agent-gui-node__composer-prompt-input-area:hover\s+textarea::-webkit-scrollbar,[\s\S]*?\.agent-gui-node__composer-prompt-input-area:focus-within\s+\.agent-gui-node__composer-textarea::-webkit-scrollbar\s*{[^}]*width:\s*4px[^}]*height:\s*4px/s
+    );
+    expect(css).toMatch(
+      /\.agent-gui-node__composer-textarea\s+\.agent-rich-text-mention-node\s*{[^}]*display:\s*inline-flex[^}]*align-items:\s*center[^}]*height:\s*24px[^}]*min-height:\s*24px[^}]*line-height:\s*24px[^}]*vertical-align:\s*middle/s
+    );
+    expect(css).toMatch(
+      /\.agent-gui-node__composer-textarea\s+\.agent-rich-text-mention-node\[data-agent-file-mention="true"\]\.tsh-agent-object-token,[\s\S]*?\.agent-rich-text-mention-node\s+\[data-slot="mention-pill"\]\s*{[^}]*display:\s*inline-flex[^}]*align-items:\s*center[^}]*top:\s*0[^}]*height:\s*24px[^}]*min-height:\s*24px[^}]*padding-top:\s*0[^}]*padding-bottom:\s*0[^}]*line-height:\s*24px[^}]*transform:\s*none[^}]*vertical-align:\s*middle/s
+    );
+    expect(css).toMatch(
+      /\.agent-gui-node__composer-textarea\s+\.agent-rich-text-mention-node\s+\[data-slot="mention-pill"\]\s*{[^}]*height:\s*24px/s
+    );
+    expect(css).toMatch(
+      /\.agent-gui-node__composer-textarea\s+\[data-agent-file-mention="true"\]\.tsh-agent-object-token--file\s*{[^}]*vertical-align:\s*middle/s
+    );
+    expect(css).toMatch(
+      /\.agent-gui-node__composer-textarea\s+\.agent-rich-text-placeholder-node:first-child::before\s*{[^}]*font-size:\s*13px[^}]*line-height:\s*24px/s
+    );
+    expect(css).toMatch(
+      /\.agent-gui-node__composer textarea::placeholder,[\s\S]*?\.agent-gui-node__composer-textarea::placeholder\s*{[^}]*line-height:\s*24px/s
     );
   });
 

--- a/packages/agent/gui/agent-gui/agentGuiNode/agentRichText/AgentMentionNodeView.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/agentRichText/AgentMentionNodeView.tsx
@@ -10,6 +10,7 @@ import {
   resolveAgentMentionFileThumbnailUrl,
   resolveAgentMentionFileVisualKind
 } from "../../shared/mentionFilePresentation";
+import { AGENT_RICH_TEXT_CARET_ANCHOR } from "./agentRichTextCaretAnchor";
 
 type AgentMentionNodeViewKind =
   | "file"
@@ -233,7 +234,11 @@ function hasPromptContentAfterMentionRemoval(
       hasContent = true;
       return false;
     }
-    if (node.isText && node.textContent.trim().length > 0) {
+    if (
+      node.isText &&
+      node.textContent.replaceAll(AGENT_RICH_TEXT_CARET_ANCHOR, "").trim()
+        .length > 0
+    ) {
       hasContent = true;
       return false;
     }
@@ -289,7 +294,7 @@ function AgentMentionLegacyFileNodeView({
     <NodeViewWrapper
       as="span"
       aria-label={mention.ariaLabel}
-      className={`group tsh-agent-object-token tsh-agent-object-token--file ${
+      className={`agent-rich-text-mention-node group tsh-agent-object-token tsh-agent-object-token--file ${
         selected ? "is-selected" : ""
       }`}
       contentEditable={false}
@@ -420,7 +425,7 @@ export function AgentMentionNodeView(props: NodeViewProps): JSX.Element {
       <NodeViewWrapper
         as="span"
         aria-label={mention.ariaLabel}
-        className={`inline-flex max-w-[min(100%,var(--agent-mention-max-width,16rem))] align-baseline ${
+        className={`agent-rich-text-mention-node inline-flex max-w-[min(100%,var(--agent-mention-max-width,16rem))] align-middle ${
           selected ? "is-selected" : ""
         }`}
         contentEditable={false}
@@ -430,7 +435,7 @@ export function AgentMentionNodeView(props: NodeViewProps): JSX.Element {
         data-agent-mention-kind={mention.kind}
       >
         <span
-          className="group relative top-[3px] inline-flex max-w-[min(100%,var(--agent-mention-max-width,16rem))] cursor-pointer items-center gap-1 overflow-hidden rounded-[4px] border border-transparent bg-transparent px-1 py-0.5 align-baseline text-[13px] font-medium leading-5 text-[var(--accent)] no-underline transition-colors hover:border-transparent hover:bg-[color-mix(in_srgb,currentColor_12%,transparent)]"
+          className="group relative top-0 inline-flex max-w-[min(100%,var(--agent-mention-max-width,16rem))] cursor-pointer items-center gap-1 overflow-hidden rounded-[4px] border border-transparent bg-transparent px-1 py-0 align-middle text-[13px] font-medium leading-6 text-[var(--accent)] no-underline transition-colors hover:border-transparent hover:bg-[color-mix(in_srgb,currentColor_12%,transparent)]"
           data-agent-mention-kind={mention.kind}
           data-slot="mention-pill"
         >
@@ -484,13 +489,14 @@ export function AgentMentionNodeView(props: NodeViewProps): JSX.Element {
   return (
     <NodeViewWrapper
       as="span"
-      className={`inline-flex max-w-[min(100%,var(--agent-mention-max-width,16rem))] align-baseline ${
+      className={`agent-rich-text-mention-node inline-flex max-w-[min(100%,var(--agent-mention-max-width,16rem))] align-middle ${
         selected ? "is-selected" : ""
       }`}
       contentEditable={false}
     >
       <MentionPill
         aria-label={mention.ariaLabel}
+        className="top-0 h-6 py-0 align-middle leading-6"
         data-agent-mention-href={mention.href}
         data-agent-mention-kind={mention.kind}
         kind={mention.kind === "session" ? "session" : "issue"}

--- a/packages/agent/gui/agent-gui/agentGuiNode/agentRichText/AgentRichTextEditor.spec.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/agentRichText/AgentRichTextEditor.spec.tsx
@@ -713,6 +713,84 @@ describe("AgentRichTextEditor", () => {
     expect(onChange).not.toHaveBeenCalled();
   });
 
+  it("keeps line-start caret anchors out of copied prompt text", async () => {
+    const clipboardData = writableClipboard();
+    render(
+      <AgentRichTextEditor
+        value={
+          "[@README.md](/workspace/docs/README.md)\n[@docs](/workspace/docs)"
+        }
+        disabled={false}
+        placeholder="Prompt"
+        onChange={vi.fn()}
+        onSubmit={vi.fn()}
+      />
+    );
+
+    const editor = await screen.findByRole("textbox", { name: "Prompt" });
+    await waitFor(() => expect(editor).toHaveTextContent("README.md"));
+    selectEditorContents(editor);
+    fireEvent.copy(editor, { clipboardData });
+    expect(clipboardData.getData("text/plain")).not.toContain("\u200B");
+    expect(clipboardData.getData("text/plain")).toBe(
+      "[@README.md](/workspace/docs/README.md)\n[@docs](/workspace/docs)"
+    );
+  });
+
+  it("skips line-start caret anchors when navigating right into a mention", async () => {
+    const onChange = vi.fn();
+    const ref = createRef<AgentRichTextEditorHandle>();
+    render(
+      <AgentRichTextEditor
+        ref={ref}
+        value="[@README.md](/workspace/docs/README.md)"
+        disabled={false}
+        placeholder="Prompt"
+        onChange={onChange}
+        onSubmit={vi.fn()}
+      />
+    );
+
+    const editor = await screen.findByRole("textbox", { name: "Prompt" });
+    await waitFor(() => expect(editor).toHaveTextContent("README.md"));
+    act(() => {
+      ref.current?.focusAtStart();
+    });
+    fireEvent.keyDown(editor, { key: "ArrowRight" });
+    fireEvent.paste(editor, { clipboardData: clipboard("x") });
+
+    await waitFor(() =>
+      expect(onChange).toHaveBeenLastCalledWith(
+        "[@README.md](/workspace/docs/README.md)x"
+      )
+    );
+  });
+
+  it("skips line-start caret anchors when navigating left over a mention", async () => {
+    const onChange = vi.fn();
+    const ref = createRef<AgentRichTextEditorHandle>();
+    render(
+      <AgentRichTextEditor
+        ref={ref}
+        value="[@README.md](/workspace/docs/README.md)"
+        disabled={false}
+        placeholder="Prompt"
+        onChange={onChange}
+        onSubmit={vi.fn()}
+      />
+    );
+
+    const editor = await screen.findByRole("textbox", { name: "Prompt" });
+    await waitFor(() => expect(editor).toHaveTextContent("README.md"));
+    act(() => {
+      ref.current?.focusAtEnd();
+    });
+    expect(ref.current?.getPromptTextBeforeSelection()).not.toBe("");
+    fireEvent.keyDown(editor, { key: "ArrowLeft" });
+    expect(ref.current?.getPromptTextBeforeSelection()).toBe("");
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
   it("removes hydrated file mentions through the icon hover remove button", async () => {
     const onChange = vi.fn();
     render(

--- a/packages/agent/gui/agent-gui/agentGuiNode/agentRichText/AgentRichTextEditor.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/agentRichText/AgentRichTextEditor.tsx
@@ -10,7 +10,14 @@ import {
 } from "react";
 import { createPortal } from "react-dom";
 import { Extension, type Editor, type JSONContent } from "@tiptap/core";
-import { Plugin, PluginKey } from "@tiptap/pm/state";
+import type { Node as ProseMirrorNode } from "@tiptap/pm/model";
+import {
+  Plugin,
+  PluginKey,
+  TextSelection,
+  type EditorState,
+  type Transaction
+} from "@tiptap/pm/state";
 import { Decoration, DecorationSet } from "@tiptap/pm/view";
 import { EditorContent, useEditor } from "@tiptap/react";
 import { cn } from "../../../app/renderer/lib/utils";
@@ -27,6 +34,7 @@ import {
   plainTextToAgentRichTextInlineContent,
   plainTextToAgentRichTextDoc
 } from "./agentRichTextDocument";
+import { AGENT_RICH_TEXT_CARET_ANCHOR } from "./agentRichTextCaretAnchor";
 import {
   createAgentFileMentionContent,
   createAgentMentionContent
@@ -94,9 +102,15 @@ function buildWorkspaceFileMentionDropContent(
     path: string;
     name: string;
     kind: AgentFileMentionKind;
-  }>
+  }>,
+  options: { prefixCaretAnchor?: boolean } = {}
 ): JSONContent[] {
-  return entries.flatMap((entry) => [
+  return entries.flatMap((entry, index) => [
+    ...(index === 0 && options.prefixCaretAnchor
+      ? ([
+          { type: "text", text: AGENT_RICH_TEXT_CARET_ANCHOR }
+        ] as JSONContent[])
+      : []),
     {
       type: "agentFileMention",
       attrs: {
@@ -109,6 +123,98 @@ function buildWorkspaceFileMentionDropContent(
     },
     { type: "text", text: " " }
   ]);
+}
+
+function isPromptVisualLineStart(editor: Editor, position: number): boolean {
+  if (position <= 1) {
+    return true;
+  }
+  return (
+    editor.state.doc.textBetween(
+      Math.max(1, position - 1),
+      position,
+      "\n",
+      "\n"
+    ) === "\n"
+  );
+}
+
+function findCaretAnchorBeforeAtomicRun(
+  doc: ProseMirrorNode,
+  position: number
+): number | null {
+  let anchorPosition: number | null = null;
+  doc.descendants((node, nodePosition) => {
+    if (nodePosition >= position) {
+      return false;
+    }
+    if (node.isText) {
+      const text = node.text ?? "";
+      for (let offset = 0; offset < text.length; offset += 1) {
+        const characterPosition = nodePosition + offset;
+        if (characterPosition >= position) {
+          return false;
+        }
+        if (text[offset] === AGENT_RICH_TEXT_CARET_ANCHOR) {
+          anchorPosition = characterPosition;
+          continue;
+        }
+        if (anchorPosition !== null) {
+          anchorPosition = null;
+        }
+      }
+      return true;
+    }
+    if (node.type.name === "agentFileMention") {
+      return false;
+    }
+    if (node.isInline && anchorPosition !== null) {
+      anchorPosition = null;
+    }
+    return true;
+  });
+  return anchorPosition;
+}
+
+function moveSelectionOverCaretAnchor(
+  state: EditorState,
+  dispatch: (transaction: Transaction) => void,
+  key: string
+): boolean {
+  const { doc, selection } = state;
+  if (!selection.empty) {
+    return false;
+  }
+  const position = selection.from;
+  if (key === "ArrowLeft") {
+    const anchorPosition = findCaretAnchorBeforeAtomicRun(doc, position);
+    if (anchorPosition === null) {
+      return false;
+    }
+    dispatch(state.tr.setSelection(TextSelection.create(doc, anchorPosition)));
+    return true;
+  }
+  if (
+    key === "ArrowRight" &&
+    position < doc.content.size &&
+    doc.textBetween(position, position + 1) === AGENT_RICH_TEXT_CARET_ANCHOR
+  ) {
+    const afterAnchor = position + 1;
+    const mentionAfterAnchor = doc.resolve(afterAnchor).nodeAfter;
+    dispatch(
+      state.tr.setSelection(
+        TextSelection.create(
+          doc,
+          afterAnchor +
+            (mentionAfterAnchor?.type.name === "agentFileMention"
+              ? mentionAfterAnchor.nodeSize
+              : 0)
+        )
+      )
+    );
+    return true;
+  }
+  return false;
 }
 
 function createAgentRichTextPlaceholderExtension(
@@ -138,6 +244,43 @@ function createAgentRichTextPlaceholderExtension(
                   "data-agent-rich-text-placeholder": getPlaceholder()
                 })
               ]);
+            }
+          }
+        })
+      ];
+    }
+  });
+}
+
+function createAgentRichTextCaretAnchorExtension(): Extension {
+  return Extension.create({
+    name: "agentRichTextCaretAnchor",
+    addProseMirrorPlugins() {
+      return [
+        new Plugin({
+          key: new PluginKey("agentRichTextCaretAnchor"),
+          props: {
+            handleKeyDown(view, event) {
+              if (
+                (event.key !== "ArrowLeft" && event.key !== "ArrowRight") ||
+                event.shiftKey ||
+                event.metaKey ||
+                event.ctrlKey ||
+                event.altKey
+              ) {
+                return false;
+              }
+              if (
+                moveSelectionOverCaretAnchor(
+                  view.state,
+                  (transaction) => view.dispatch(transaction),
+                  event.key
+                )
+              ) {
+                event.preventDefault();
+                return true;
+              }
+              return false;
             }
           }
         })
@@ -459,6 +602,7 @@ export const AgentRichTextEditor = forwardRef<
         { skills: availableSkillsRef.current },
         { capabilities: availableCapabilitiesRef.current }
       ),
+      createAgentRichTextCaretAnchorExtension(),
       createAgentRichTextPlaceholderExtension(() => placeholderRef.current)
     ],
     [enableFileMentionSuggestions]
@@ -740,7 +884,12 @@ export const AgentRichTextEditor = forwardRef<
             .focus()
             .insertContentAt(
               insertPosition,
-              buildWorkspaceFileMentionDropContent(entries)
+              buildWorkspaceFileMentionDropContent(entries, {
+                prefixCaretAnchor: isPromptVisualLineStart(
+                  currentEditor,
+                  insertPosition
+                )
+              })
             )
             .run();
           return true;
@@ -776,6 +925,28 @@ export const AgentRichTextEditor = forwardRef<
       event.preventDefault();
       event.stopPropagation();
       return;
+    }
+    if (
+      (event.key === "ArrowLeft" || event.key === "ArrowRight") &&
+      !event.shiftKey &&
+      !event.metaKey &&
+      !event.ctrlKey &&
+      !event.altKey
+    ) {
+      const currentEditor = editorRef.current;
+      if (
+        currentEditor &&
+        !currentEditor.isDestroyed &&
+        moveSelectionOverCaretAnchor(
+          currentEditor.state,
+          (transaction) => currentEditor.view.dispatch(transaction),
+          event.key
+        )
+      ) {
+        event.preventDefault();
+        event.stopPropagation();
+        return;
+      }
     }
     if (
       event.key === "Enter" &&
@@ -888,7 +1059,14 @@ export const AgentRichTextEditor = forwardRef<
         currentEditor
           .chain()
           .focus()
-          .insertContent(createAgentFileMentionContent(items))
+          .insertContent(
+            createAgentFileMentionContent(items, {
+              prefixCaretAnchor: isPromptVisualLineStart(
+                currentEditor,
+                currentEditor.state.selection.from
+              )
+            })
+          )
           .run();
       },
       insertMentionItems(items) {
@@ -899,7 +1077,14 @@ export const AgentRichTextEditor = forwardRef<
         currentEditor
           .chain()
           .focus()
-          .insertContent(createAgentMentionContent(items))
+          .insertContent(
+            createAgentMentionContent(items, {
+              prefixCaretAnchor: isPromptVisualLineStart(
+                currentEditor,
+                currentEditor.state.selection.from
+              )
+            })
+          )
           .run();
       },
       replaceTextBeforeSelection(length, text) {

--- a/packages/agent/gui/agent-gui/agentGuiNode/agentRichText/agentFileMentionExtension.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/agentRichText/agentFileMentionExtension.ts
@@ -15,6 +15,7 @@ import {
 } from "../../shared/mentionFilePresentation";
 import { translate } from "../../../i18n/index";
 import { AgentMentionNodeView } from "./AgentMentionNodeView";
+import { AGENT_RICH_TEXT_CARET_ANCHOR } from "./agentRichTextCaretAnchor";
 
 export type AgentFileMentionKind = "file" | "directory" | "unknown";
 export type AgentMentionFileNavigationAction =
@@ -390,10 +391,26 @@ export function createAgentFileMentionExtension(
             return isRichTextTriggerPrefixBoundary(previous, "whitespace");
           },
           command: ({ editor, range, props }) => {
+            const prefixCaretAnchor =
+              range.from <= 1 ||
+              editor.state.doc.textBetween(
+                Math.max(1, range.from - 1),
+                range.from,
+                "\n",
+                "\n"
+              ) === "\n";
             editor
               .chain()
               .focus()
               .insertContentAt(range, [
+                ...(prefixCaretAnchor
+                  ? ([
+                      {
+                        type: "text",
+                        text: AGENT_RICH_TEXT_CARET_ANCHOR
+                      }
+                    ] as const)
+                  : []),
                 {
                   type: this.name,
                   attrs: mentionItemToAttrs(props)

--- a/packages/agent/gui/agent-gui/agentGuiNode/agentRichText/agentRichTextCaretAnchor.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/agentRichText/agentRichTextCaretAnchor.ts
@@ -1,0 +1,1 @@
+export const AGENT_RICH_TEXT_CARET_ANCHOR = "\u200B";

--- a/packages/agent/gui/agent-gui/agentGuiNode/agentRichText/agentRichTextDocument.spec.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/agentRichText/agentRichTextDocument.spec.ts
@@ -4,6 +4,7 @@ import {
   plainTextToAgentRichTextDoc,
   plainTextToAgentRichTextInlineContent
 } from "./agentRichTextDocument";
+import { AGENT_RICH_TEXT_CARET_ANCHOR } from "./agentRichTextCaretAnchor";
 import { createRichTextMentionHref } from "@tutti-os/ui-rich-text/core";
 
 describe("agentRichTextDocument", () => {
@@ -87,6 +88,7 @@ describe("agentRichTextDocument", () => {
               }
             },
             { type: "hardBreak" },
+            { type: "text", text: AGENT_RICH_TEXT_CARET_ANCHOR },
             {
               type: "agentFileMention",
               attrs: {
@@ -121,7 +123,15 @@ describe("agentRichTextDocument", () => {
       }
     });
     const doc = plainTextToAgentRichTextDoc(`[@我的小项目](${href})`);
-    const mention = doc.content?.[0]?.content?.[0];
+    expect(agentRichTextDocToPromptText(doc)).not.toContain(
+      AGENT_RICH_TEXT_CARET_ANCHOR
+    );
+    expect(agentRichTextDocToPromptText(doc)).toContain(
+      "mention://workspace-reference/topic-1?"
+    );
+    const mention = doc.content?.[0]?.content?.find(
+      (node) => node.type === "agentFileMention"
+    );
     expect(mention?.attrs?.kind).toBe("workspace-reference");
     expect(mention?.attrs?.source).toBe("task");
     expect(mention?.attrs?.fileCount).toBe("3");
@@ -197,6 +207,7 @@ describe("agentRichTextDocument", () => {
         {
           type: "paragraph",
           content: [
+            { type: "text", text: AGENT_RICH_TEXT_CARET_ANCHOR },
             {
               type: "agentFileMention",
               attrs: {

--- a/packages/agent/gui/agent-gui/agentGuiNode/agentRichText/agentRichTextDocument.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/agentRichText/agentRichTextDocument.ts
@@ -11,6 +11,7 @@ import {
   parseAgentCapabilityToken,
   type AgentCapabilityTokenOption
 } from "./agentCapabilityTokenExtension";
+import { AGENT_RICH_TEXT_CARET_ANCHOR } from "./agentRichTextCaretAnchor";
 
 export interface AgentRichTextDocumentOptions {
   capabilities?: readonly AgentCapabilityTokenOption[];
@@ -22,6 +23,10 @@ function createEmptyDocument(): JSONContent {
     type: "doc",
     content: [{ type: "paragraph" }]
   };
+}
+
+function isVisualLineStart(content: readonly JSONContent[]): boolean {
+  return content.length === 0 || content.at(-1)?.type === "hardBreak";
 }
 
 function createParagraphFromText(
@@ -52,6 +57,9 @@ function createParagraphFromText(
     const parsedMention = parseAgentMentionMarkdown(text, index);
     if (parsedMention) {
       flushTextBuffer();
+      if (isVisualLineStart(content)) {
+        content.push({ type: "text", text: AGENT_RICH_TEXT_CARET_ANCHOR });
+      }
       content.push({
         type: "agentFileMention",
         // 转成规范 node attrs(如 workspace-reference 的 source/groupId/fileCount),
@@ -150,7 +158,7 @@ function isBlockPromptNode(node: JSONContent): boolean {
 
 function nodeToPromptText(node: JSONContent): string {
   if (node.type === "text") {
-    return node.text ?? "";
+    return (node.text ?? "").replaceAll(AGENT_RICH_TEXT_CARET_ANCHOR, "");
   }
   if (node.type === "agentFileMention") {
     return formatAgentMentionMarkdown(attrsToMentionItem(node.attrs ?? {}));

--- a/packages/agent/gui/agent-gui/agentGuiNode/agentRichText/agentWorkspaceFileReferences.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/agentRichText/agentWorkspaceFileReferences.ts
@@ -4,6 +4,7 @@ import {
   mentionItemToAttrs,
   type AgentContextMentionItem
 } from "./agentFileMentionExtension";
+import { AGENT_RICH_TEXT_CARET_ANCHOR } from "./agentRichTextCaretAnchor";
 
 function basename(path: string): string {
   const normalized = path.trim().replace(/\/+$/, "");
@@ -36,23 +37,37 @@ function referenceMentionPath(item: WorkspaceFileReference): string {
  * 每个 item 走 mentionItemToAttrs 归一为节点 attrs;item 之间补空格。
  */
 export function createAgentMentionContent(
-  items: readonly AgentContextMentionItem[]
+  items: readonly AgentContextMentionItem[],
+  options: { prefixCaretAnchor?: boolean } = {}
 ): JSONContent[] {
   return items.flatMap((item, index) => [
-    ...(index > 0 ? ([{ type: "text", text: " " }] as JSONContent[]) : []),
+    ...(index === 0 && options.prefixCaretAnchor
+      ? ([
+          { type: "text", text: AGENT_RICH_TEXT_CARET_ANCHOR }
+        ] as JSONContent[])
+      : index > 0
+        ? ([{ type: "text", text: " " }] as JSONContent[])
+        : []),
     { type: "agentFileMention", attrs: mentionItemToAttrs(item) },
     { type: "text", text: " " }
   ]);
 }
 
 export function createAgentFileMentionContent(
-  items: readonly WorkspaceFileReference[]
+  items: readonly WorkspaceFileReference[],
+  options: { prefixCaretAnchor?: boolean } = {}
 ): JSONContent[] {
   return items.flatMap((item, index) => {
     const path = referenceMentionPath(item);
     const name = item.displayName?.trim() || basename(path);
     return [
-      ...(index > 0 ? ([{ type: "text", text: " " }] as JSONContent[]) : []),
+      ...(index === 0 && options.prefixCaretAnchor
+        ? ([
+            { type: "text", text: AGENT_RICH_TEXT_CARET_ANCHOR }
+          ] as JSONContent[])
+        : index > 0
+          ? ([{ type: "text", text: " " }] as JSONContent[])
+          : []),
       {
         type: "agentFileMention",
         attrs: {

--- a/packages/agent/gui/app/renderer/agentactivity.css
+++ b/packages/agent/gui/app/renderer/agentactivity.css
@@ -6931,10 +6931,8 @@ html[data-theme="light"] [data-message-center-item-id].agent-gui-edge-glow {
 .agent-gui-node__composer-textarea {
   --agent-gui-composer-text-line-height: 24px;
   --agent-gui-composer-text-max-visible-lines: 3.5;
-  --agent-gui-composer-text-viewport-height: calc(
-    var(--agent-gui-composer-text-line-height) *
-      var(--agent-gui-composer-text-max-visible-lines)
-  );
+  /* prettier-ignore */
+  --agent-gui-composer-text-viewport-height: calc(var(--agent-gui-composer-text-line-height) * var(--agent-gui-composer-text-max-visible-lines));
 
   width: 100%;
   min-width: 0;

--- a/packages/agent/gui/app/renderer/agentactivity.css
+++ b/packages/agent/gui/app/renderer/agentactivity.css
@@ -3763,14 +3763,41 @@ aside.workspace-agents-status-panel
   color: inherit;
 }
 
-.agent-gui-node__composer-textarea [data-slot="mention-pill"],
+.agent-gui-node__composer-textarea .agent-rich-text-mention-node {
+  display: inline-flex;
+  align-items: center;
+  height: 24px;
+  min-height: 24px;
+  line-height: 24px;
+  vertical-align: middle;
+}
+
 .agent-gui-node__composer-textarea
-  [data-agent-file-mention="true"].tsh-agent-object-token {
+  .agent-rich-text-mention-node[data-agent-file-mention="true"].tsh-agent-object-token,
+.agent-gui-node__composer-textarea
+  .agent-rich-text-mention-node
+  [data-slot="mention-pill"] {
+  display: inline-flex;
+  align-items: center;
   cursor: pointer;
+  top: 0;
+  height: 24px;
+  min-height: 24px;
+  padding-top: 0;
   padding-right: 4px;
+  padding-bottom: 0;
   padding-left: 4px;
   border-radius: 4px;
+  line-height: 24px;
+  transform: none;
   transition: background-color 140ms ease-in-out;
+  vertical-align: middle;
+}
+
+.agent-gui-node__composer-textarea
+  .agent-rich-text-mention-node
+  [data-slot="mention-pill"] {
+  height: 24px;
 }
 
 .agent-gui-node__composer-textarea
@@ -3850,7 +3877,7 @@ aside.workspace-agents-status-panel
 
 .agent-gui-node__composer-textarea
   [data-agent-file-mention="true"].tsh-agent-object-token--file {
-  vertical-align: baseline;
+  vertical-align: middle;
 }
 
 .agent-gui-node__shell {
@@ -6205,7 +6232,7 @@ button.agent-gui-node__conversation-section-toggle:hover
   box-sizing: border-box;
   height: var(--agent-gui-composer-input-height, 56px);
   min-height: 56px;
-  max-height: var(--agent-gui-composer-input-max-height, 120px);
+  max-height: var(--agent-gui-composer-input-max-height, 110px);
   align-items: center;
   overflow: hidden;
   padding: 0 12px;
@@ -6902,17 +6929,24 @@ html[data-theme="light"] [data-message-center-item-id].agent-gui-edge-glow {
 
 .agent-gui-node__composer textarea,
 .agent-gui-node__composer-textarea {
+  --agent-gui-composer-text-line-height: 24px;
+  --agent-gui-composer-text-max-visible-lines: 3.5;
+  --agent-gui-composer-text-viewport-height: calc(
+    var(--agent-gui-composer-text-line-height) *
+      var(--agent-gui-composer-text-max-visible-lines)
+  );
+
   width: 100%;
   min-width: 0;
   min-height: 46px;
-  max-height: 72px;
+  max-height: var(--agent-gui-composer-text-viewport-height);
   overflow-y: auto;
   border: 0;
   background: transparent;
   color: var(--agent-gui-text-primary);
   font: inherit;
   font-size: 13px;
-  line-height: 24px;
+  line-height: var(--agent-gui-composer-text-line-height);
   outline: 0;
   padding: 0;
   resize: none;
@@ -6928,7 +6962,7 @@ html[data-theme="light"] [data-message-center-item-id].agent-gui-edge-glow {
   display: block;
   height: auto;
   min-height: 24px;
-  max-height: calc(var(--agent-gui-composer-text-height, 56px) - 26px);
+  max-height: var(--agent-gui-composer-text-viewport-height);
   overflow-x: hidden;
   overflow-y: auto;
   overflow-wrap: anywhere;
@@ -6943,12 +6977,18 @@ html[data-theme="light"] [data-message-center-item-id].agent-gui-edge-glow {
 .agent-gui-node__composer[data-layout="dock"]
   .agent-gui-node__composer-prompt-input-area[data-has-draft-images="true"]
   .agent-gui-node__composer-textarea {
-  max-height: calc(var(--agent-gui-composer-text-height, 56px) - 26px);
+  max-height: var(--agent-gui-composer-text-viewport-height);
 }
 
 .agent-gui-node__composer[data-layout="dock"]
   .agent-gui-node__composer-prompt-input-area:hover
+  textarea,
+.agent-gui-node__composer[data-layout="dock"]
+  .agent-gui-node__composer-prompt-input-area:hover
   .agent-gui-node__composer-textarea,
+.agent-gui-node__composer[data-layout="dock"]
+  .agent-gui-node__composer-prompt-input-area:focus-within
+  textarea,
 .agent-gui-node__composer[data-layout="dock"]
   .agent-gui-node__composer-prompt-input-area:focus-within
   .agent-gui-node__composer-textarea {
@@ -6958,8 +6998,9 @@ html[data-theme="light"] [data-message-center-item-id].agent-gui-edge-glow {
 .agent-gui-node__composer[data-layout="dock"] textarea::-webkit-scrollbar,
 .agent-gui-node__composer[data-layout="dock"]
   .agent-gui-node__composer-textarea::-webkit-scrollbar {
-  display: none;
-  width: 4px;
+  display: block;
+  width: 0;
+  height: 0;
 }
 
 .agent-gui-node__composer[data-layout="dock"]
@@ -6974,7 +7015,8 @@ html[data-theme="light"] [data-message-center-item-id].agent-gui-edge-glow {
 .agent-gui-node__composer[data-layout="dock"]
   .agent-gui-node__composer-prompt-input-area:focus-within
   .agent-gui-node__composer-textarea::-webkit-scrollbar {
-  display: block;
+  width: 4px;
+  height: 4px;
 }
 
 .agent-gui-node__composer textarea::-webkit-scrollbar,
@@ -7057,7 +7099,7 @@ html[data-theme="light"] [data-message-center-item-id].agent-gui-edge-glow {
   height: 0;
   color: var(--agent-gui-text-tertiary);
   font-size: 13px;
-  line-height: 1.3;
+  line-height: 24px;
   pointer-events: none;
 }
 
@@ -7077,7 +7119,7 @@ html[data-theme="light"] [data-message-center-item-id].agent-gui-edge-glow {
 .agent-gui-node__composer textarea::placeholder,
 .agent-gui-node__composer-textarea::placeholder {
   color: var(--agent-gui-text-tertiary);
-  line-height: 1.3;
+  line-height: 24px;
 }
 
 .agent-gui-node__composer-input-shell:focus-within,

--- a/packages/agent/gui/shared/AgentRichTextReadonly.tsx
+++ b/packages/agent/gui/shared/AgentRichTextReadonly.tsx
@@ -3,6 +3,7 @@ import type { JSONContent } from "@tiptap/core";
 import { EditorContent, useEditor } from "@tiptap/react";
 import { cn } from "../app/renderer/lib/utils";
 import { plainTextToAgentRichTextDoc } from "../agent-gui/agentGuiNode/agentRichText/agentRichTextDocument";
+import { AGENT_RICH_TEXT_CARET_ANCHOR } from "../agent-gui/agentGuiNode/agentRichText/agentRichTextCaretAnchor";
 import { createAgentRichTextReadonlyExtensions } from "../agent-gui/agentGuiNode/agentRichText/agentRichTextExtensions";
 import type { AgentMessageMarkdownWorkspaceAppIcon } from "./AgentMessageMarkdown";
 import type { AgentGUIProviderSkillOption } from "../agent-gui/agentGuiNode/model/agentGuiNodeTypes";
@@ -121,7 +122,14 @@ function isMentionOnlyRichTextDoc(doc: JSONContent): boolean {
   if (paragraph?.type !== "paragraph") {
     return false;
   }
-  const inlineContent = paragraph.content ?? [];
+  const inlineContent = (paragraph.content ?? []).filter(
+    (node) =>
+      !(
+        node.type === "text" &&
+        (node.text ?? "").replaceAll(AGENT_RICH_TEXT_CARET_ANCHOR, "")
+          .length === 0
+      )
+  );
   return (
     inlineContent.length === 1 && inlineContent[0]?.type === "agentFileMention"
   );

--- a/packages/workspace/issue-manager/src/core/content.test.ts
+++ b/packages/workspace/issue-manager/src/core/content.test.ts
@@ -74,6 +74,7 @@ test("issue-manager run prompt keeps execute handoff issue-scoped", () => {
     prompt,
     /\[@Plan migration\]\(mention:\/\/workspace-issue\/issue-1\?workspaceId=workspace-1&topicId=topic-1&mode=execute\)/
   );
+  assert.doesNotMatch(prompt, /\n+\[@Plan migration\]/);
   assert.doesNotMatch(prompt, /Port renderer/);
   assert.doesNotMatch(prompt, /taskId=/);
   assert.doesNotMatch(prompt, /runId=/);
@@ -114,6 +115,7 @@ test("issue-manager run prompt targets selected task when provided", () => {
     prompt,
     /\[@Plan migration \/ Port renderer\]\(mention:\/\/workspace-issue\/issue-1\?workspaceId=workspace-1&topicId=topic-1&mode=execute&taskId=task-1\)/
   );
+  assert.doesNotMatch(prompt, /\n+\[@Plan migration \/ Port renderer\]/);
   assert.doesNotMatch(prompt, /runId=/);
   assert.doesNotMatch(prompt, /outputDir=/);
 });
@@ -181,6 +183,7 @@ test("issue-manager task breakdown prompt captures issue context", () => {
     prompt,
     /\[@Plan migration\]\(mention:\/\/workspace-issue\/issue-1\?workspaceId=workspace-1&topicId=topic-1&mode=breakdown\)/
   );
+  assert.doesNotMatch(prompt, /\n+\[@Plan migration\]/);
   assert.match(prompt, /Break this task reference down into executable tasks/);
   assert.doesNotMatch(prompt, /现有子任务数：1/);
   assert.doesNotMatch(prompt, /引用资料数：1/);

--- a/packages/workspace/issue-manager/src/core/runPrompt.ts
+++ b/packages/workspace/issue-manager/src/core/runPrompt.ts
@@ -52,11 +52,9 @@ export function buildIssueManagerRunPrompt(input: {
     task: input.task,
     mode: "execute"
   });
-  return [
-    input.copy?.t("runPrompts.executeIntro") ?? "Handle this task reference.",
-    "",
-    mentionMarkdown
-  ].join("\n");
+  const intro =
+    input.copy?.t("runPrompts.executeIntro") ?? "Handle this task reference.";
+  return `${intro} ${mentionMarkdown}`;
 }
 
 export function buildIssueManagerTaskBreakdownPrompt(input: {
@@ -74,12 +72,10 @@ export function buildIssueManagerTaskBreakdownPrompt(input: {
     mode: "breakdown"
   });
 
-  return [
+  const intro =
     input.copy?.t("runPrompts.breakdownIntro") ??
-      "Break this task reference down into executable tasks.",
-    "",
-    issueMention
-  ].join("\n");
+    "Break this task reference down into executable tasks.";
+  return `${intro} ${issueMention}`;
 }
 
 function buildIssueManagerIssueMention(input: {

--- a/packages/workspace/issue-manager/src/ui/internal/content/IssueManagerDescriptionSection.test.ts
+++ b/packages/workspace/issue-manager/src/ui/internal/content/IssueManagerDescriptionSection.test.ts
@@ -10,10 +10,22 @@ const descriptionSectionSource = readFileSync(
 test("description readonly content wraps long unbroken text", () => {
   assert.match(
     descriptionSectionSource,
-    /className="min-w-0 max-w-full \[overflow-wrap:anywhere\]"/
+    /className="min-w-0 max-w-full \[overflow-wrap:anywhere\]/
   );
   assert.match(
     descriptionSectionSource,
-    /paragraphClassName="break-words \[overflow-wrap:anywhere\]"/
+    /paragraphClassName="break-words leading-5 \[overflow-wrap:anywhere\]"/
+  );
+});
+
+test("description readonly mentions stay on the body text rhythm", () => {
+  assert.match(descriptionSectionSource, /\[&>\*\+\*\]:!mt-1/);
+  assert.match(
+    descriptionSectionSource,
+    /\[&_\.tutti-rich-text-mention\]:!\[line-height:20px\]/
+  );
+  assert.match(
+    descriptionSectionSource,
+    /\[&_\.tutti-rich-text-mention\]:!py-0/
   );
 });

--- a/packages/workspace/issue-manager/src/ui/internal/content/IssueManagerDescriptionSection.tsx
+++ b/packages/workspace/issue-manager/src/ui/internal/content/IssueManagerDescriptionSection.tsx
@@ -142,8 +142,8 @@ function IssueManagerDescriptionContent({
 }): JSX.Element {
   return (
     <RichTextReadonlyContent
-      className="min-w-0 max-w-full [overflow-wrap:anywhere]"
-      paragraphClassName="break-words [overflow-wrap:anywhere]"
+      className="min-w-0 max-w-full [overflow-wrap:anywhere] [&>*+*]:!mt-1 [&_.tutti-rich-text-mention]:!py-0 [&_.tutti-rich-text-mention]:![line-height:20px] [&_.tutti-rich-text-mention]:align-baseline"
+      paragraphClassName="break-words leading-5 [overflow-wrap:anywhere]"
       value={content}
       onMentionAction={onMentionAction}
       onOpenWorkspaceReference={


### PR DESCRIPTION
## Summary
- Add a zero-width caret anchor before line-start Agent GUI rich-text mentions so the cursor can land before atomic mention nodes.
- Strip caret anchors from prompt serialization, copy output, and mention-only readonly detection.
- Tighten composer mention line-height, scrollbar, and dock text viewport behavior so line-start mentions align with prompt text.
- Keep Issue Manager task handoff mentions inline with their intro sentence and align readonly description mentions with body text rhythm.

## Validation
- pnpm --filter @tutti-os/agent-gui typecheck
- pnpm --filter @tutti-os/agent-gui exec vitest run --environment jsdom agent-gui/agentGuiNode/AgentComposer.spec.tsx agent-gui/agentGuiNode/AgentGUINode.spec.tsx agent-gui/agentGuiNode/agentRichText/AgentRichTextEditor.spec.tsx agent-gui/agentGuiNode/agentRichText/agentRichTextDocument.spec.ts
- pnpm --filter @tutti-os/workspace-issue-manager exec tsx --test src/core/content.test.ts src/ui/internal/content/IssueManagerDescriptionSection.test.ts
- pnpm check:full (pre-push)

## Notes
- Base branch is latest origin/main (8885ad1d).
- Local desktop/docs edits remain uncommitted and are not part of this PR.
- Documentation impact check: no durable docs update needed for the committed changes; behavior is limited to rich-text composer/editing and Issue Manager prompt/readonly presentation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved cursor navigation and mention insertion behavior in the rich-text editor, including more natural movement at visual line starts.
  * Rich-text mention handling now keeps internal navigation markers out of copied/exported prompt text.
* **Bug Fixes**
  * Fixed dock composer sizing and scrolling: textarea height/viewport behavior and hover/focus scrollbar presentation are more consistent.
  * Refined mention pill alignment and readonly mention styling for consistent spacing and line wrapping.
  * Updated issue-manager prompt generation to avoid unintended blank lines and keep intro+mention text on a single line.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->