### PR TITLE
fix(agent): harden session lifecycle stability

### DIFF
--- a/apps/desktop/src/preload/api/platform.ts
+++ b/apps/desktop/src/preload/api/platform.ts
@@ -1,11 +1,24 @@
 import { webUtils } from "electron";
 import { homedir } from "node:os";
+import { statSync } from "node:fs";
 import type { DesktopPlatformApi } from "../types";
 
 export function createPlatformDesktopApi(): DesktopPlatformApi {
   return {
     homeDirectory: homedir(),
     os: process.platform,
+    resolveDroppedEntries(files: File[]) {
+      return files.map((file) => {
+        const path = webUtils.getPathForFile(file);
+        let kind: "file" | "folder" = "file";
+        try {
+          kind = statSync(path).isDirectory() ? "folder" : "file";
+        } catch {
+          kind = "file";
+        }
+        return { path, kind };
+      });
+    },
     resolveDroppedPaths(files: File[]): string[] {
       return files.map((file) => webUtils.getPathForFile(file));
     }

--- a/apps/desktop/src/preload/types.ts
+++ b/apps/desktop/src/preload/types.ts
@@ -66,7 +66,13 @@ export interface DesktopDockPreviewCacheApi {
 export interface DesktopPlatformApi {
   homeDirectory: string;
   os: NodeJS.Platform;
+  resolveDroppedEntries(files: File[]): DesktopDroppedEntry[];
   resolveDroppedPaths(files: File[]): string[];
+}
+
+export interface DesktopDroppedEntry {
+  kind: "file" | "folder";
+  path: string;
 }
 
 export interface DesktopHostWorkspaceApi {

--- a/apps/desktop/src/renderer/src/features/workspace-agent/services/createDesktopAgentGUIWorkbenchHostInput.test.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-agent/services/createDesktopAgentGUIWorkbenchHostInput.test.ts
@@ -1186,11 +1186,14 @@ function createTuttidClient(): TuttidClient {
 
 function createPlatformApi(): Pick<
   DesktopPlatformApi,
-  "homeDirectory" | "os" | "resolveDroppedPaths"
+  "homeDirectory" | "os" | "resolveDroppedEntries" | "resolveDroppedPaths"
 > {
   return {
     homeDirectory: "/Users/local",
     os: "darwin",
+    resolveDroppedEntries() {
+      return [];
+    },
     resolveDroppedPaths() {
       return [];
     }

--- a/apps/desktop/src/renderer/src/features/workspace-agent/services/createDesktopAgentGUIWorkbenchHostInput.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-agent/services/createDesktopAgentGUIWorkbenchHostInput.ts
@@ -75,7 +75,7 @@ export interface CreateDesktopAgentGUIWorkbenchHostInputInput {
   tuttidClient: TuttidClient;
   platformApi: Pick<
     DesktopPlatformApi,
-    "homeDirectory" | "os" | "resolveDroppedPaths"
+    "homeDirectory" | "os" | "resolveDroppedEntries" | "resolveDroppedPaths"
   >;
   reporterNow?: () => number;
   reporterService?: Pick<IReporterService, "trackEvents">;

--- a/apps/desktop/src/renderer/src/features/workspace-agent/services/createDesktopAgentHostApi.test.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-agent/services/createDesktopAgentHostApi.test.ts
@@ -282,7 +282,7 @@ interface DesktopAgentHostApiUnderTest {
       root?: string;
       supported: boolean;
     }>;
-    getPathForFile(file: File): string;
+    getReferenceForFile(file: File): { kind: "file" | "folder"; path: string };
     readFile(input: {
       path: string;
     }): Promise<{ content: string; path: string }>;
@@ -2640,8 +2640,11 @@ test("desktop agent host api reuses desktop host file operations", async () => {
     platformApi: {
       homeDirectory: "/Users/local",
       os: "darwin",
-      resolveDroppedPaths(files) {
-        return files.map((file) => `/resolved/${file.name}`);
+      resolveDroppedEntries(files) {
+        return files.map((file) => ({
+          path: `/resolved/${file.name}`,
+          kind: file.name === "assets" ? "folder" : "file"
+        }));
       }
     }
   });
@@ -2677,10 +2680,14 @@ test("desktop agent host api reuses desktop host file operations", async () => {
     content: "hello",
     path: "/workspace/file.txt"
   });
-  assert.equal(
-    api.workspace.getPathForFile(new File([], "drop.txt")),
-    "/resolved/drop.txt"
-  );
+  assert.deepEqual(api.workspace.getReferenceForFile(new File([], "drop")), {
+    path: "/resolved/drop",
+    kind: "file"
+  });
+  assert.deepEqual(api.workspace.getReferenceForFile(new File([], "assets")), {
+    path: "/resolved/assets",
+    kind: "folder"
+  });
   assert.deepEqual(
     await api.filesystem.readFileText({ uri: "file:///tmp/prompt.md" }),
     {
@@ -2942,13 +2949,13 @@ function createHostFilesApi(
 
 function createPlatformApi(
   overrides: Partial<
-    Pick<DesktopPlatformApi, "homeDirectory" | "os" | "resolveDroppedPaths">
+    Pick<DesktopPlatformApi, "homeDirectory" | "os" | "resolveDroppedEntries">
   > = {}
-): Pick<DesktopPlatformApi, "homeDirectory" | "os" | "resolveDroppedPaths"> {
+): Pick<DesktopPlatformApi, "homeDirectory" | "os" | "resolveDroppedEntries"> {
   return {
     homeDirectory: "/Users/local",
     os: "darwin",
-    resolveDroppedPaths() {
+    resolveDroppedEntries() {
       return [];
     },
     ...overrides

--- a/apps/desktop/src/renderer/src/features/workspace-agent/services/createDesktopAgentHostApi.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-agent/services/createDesktopAgentHostApi.ts
@@ -37,7 +37,7 @@ interface CreateDesktopAgentHostApiInput {
   tuttidClient: TuttidClient;
   platformApi: Pick<
     DesktopPlatformApi,
-    "homeDirectory" | "os" | "resolveDroppedPaths"
+    "homeDirectory" | "os" | "resolveDroppedEntries"
   >;
   runtimeApi: DesktopRuntimeApi;
   reporterNow?: () => number;
@@ -222,8 +222,15 @@ export function createDesktopAgentHostApi({
         await navigator.clipboard.writeText(payload.path);
       },
       ensureDirectory: async () => {},
-      getPathForFile: (file: File) =>
-        platformApi.resolveDroppedPaths([file])[0] ?? file.name,
+      getReferenceForFile: (file: File) => {
+        const entry = platformApi.resolveDroppedEntries([file])[0] ?? null;
+        const kind: "file" | "folder" =
+          entry?.kind === "folder" ? "folder" : "file";
+        return {
+          path: entry?.path || file.name,
+          kind
+        };
+      },
       readFile: async (payload: { path: string }) => {
         const bytes = await hostFilesApi.readPreviewFile(
           workspaceId,

--- a/apps/desktop/src/renderer/src/features/workspace-agent/services/desktopAgentActivityAdapter.test.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-agent/services/desktopAgentActivityAdapter.test.ts
@@ -16,9 +16,12 @@ test("desktop agent activity adapter maps tuttid sessions and messages", async (
   const diagnostics: unknown[] = [];
   const adapter = createDesktopAgentActivityAdapter({
     tuttidClient: createTuttidClient({
-      async listWorkspaceAgentSessions(requestWorkspaceId: string) {
+      async listWorkspaceAgentSessions(
+        requestWorkspaceId: string,
+        request?: { limit?: number }
+      ) {
         calls.push({
-          args: [requestWorkspaceId],
+          args: [requestWorkspaceId, request],
           method: "listSessions"
         });
         return {
@@ -80,7 +83,7 @@ test("desktop agent activity adapter maps tuttid sessions and messages", async (
 
   assert.deepEqual(calls, [
     {
-      args: [workspaceId],
+      args: [workspaceId, { limit: 100 }],
       method: "listSessions"
     },
     {

--- a/apps/desktop/src/renderer/src/features/workspace-agent/services/desktopAgentActivityAdapter.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-agent/services/desktopAgentActivityAdapter.ts
@@ -33,6 +33,7 @@ export interface CreateDesktopAgentActivityAdapterInput {
 
 const defaultAgentSessionCreateRequestTimeoutMs = 30_000;
 const defaultComposerOptionsRequestTimeoutMs = 15_000;
+const agentActivitySessionListLimit = 100;
 
 export function createDesktopAgentActivityAdapter({
   agentProviderStatusService,
@@ -245,7 +246,8 @@ export function createDesktopAgentActivityAdapter({
   return {
     async listSessions(input) {
       const response = await tuttidClient.listWorkspaceAgentSessions(
-        input.workspaceId
+        input.workspaceId,
+        { limit: agentActivitySessionListLimit }
       );
       return {
         sessions: response.sessions.map((session) =>

--- a/apps/desktop/src/renderer/src/features/workspace-agent/services/internal/desktopManagedAgentProviders.test.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-agent/services/internal/desktopManagedAgentProviders.test.ts
@@ -9,7 +9,8 @@ import {
   desktopManagedAgentProviders,
   ensureDesktopManagedAgentProviderStatuses,
   isDesktopManagedAgentProvider,
-  projectDesktopManagedAgentsState
+  projectDesktopManagedAgentsState,
+  projectDesktopManagedAgentsStateForAgentGUI
 } from "./desktopManagedAgentProviders.ts";
 
 test("ensureDesktopManagedAgentProviderStatuses delegates managed provider loading to the status service", async () => {
@@ -56,6 +57,39 @@ test("projectDesktopManagedAgentsState derives AgentGUI managed state from provi
   assert.equal(state.items[0]?.agentId, "claude-code");
   assert.equal(state.items[1]?.agentId, "codex");
   assert.equal(state.items[1]?.decisionReason, "auth_required");
+});
+
+test("projectDesktopManagedAgentsStateForAgentGUI keeps provider readiness unknown before first snapshot", () => {
+  const state = projectDesktopManagedAgentsStateForAgentGUI({
+    capturedAt: null,
+    defaultProvider: null,
+    error: null,
+    isLoading: true,
+    pendingActions: [],
+    statuses: []
+  });
+
+  assert.equal(state, null);
+});
+
+test("projectDesktopManagedAgentsStateForAgentGUI projects captured provider status", () => {
+  const state = projectDesktopManagedAgentsStateForAgentGUI({
+    capturedAt: "2026-06-02T08:00:00.000Z",
+    defaultProvider: "codex",
+    error: null,
+    isLoading: false,
+    pendingActions: [],
+    statuses: [
+      createProviderStatus({
+        adapterInstalled: true,
+        availability: "ready",
+        cliInstalled: true,
+        provider: "codex"
+      })
+    ]
+  });
+
+  assert.deepEqual(state?.readyAgentIds, ["codex"]);
 });
 
 test("isDesktopManagedAgentProvider accepts only desktop managed providers", () => {

--- a/apps/desktop/src/renderer/src/features/workspace-agent/services/internal/desktopManagedAgentProviders.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-agent/services/internal/desktopManagedAgentProviders.ts
@@ -72,6 +72,16 @@ export function projectDesktopManagedAgentsState(
   };
 }
 
+export function projectDesktopManagedAgentsStateForAgentGUI(
+  snapshot: AgentProviderStatusSnapshot
+): AgentHostManagedAgentsState | null {
+  if (!snapshot.capturedAt) {
+    return null;
+  }
+
+  return projectDesktopManagedAgentsState(snapshot);
+}
+
 export function isDesktopManagedAgentProvider(
   value: unknown
 ): value is WorkspaceAgentProvider {

--- a/apps/desktop/src/renderer/src/features/workspace-agent/ui/useDesktopManagedAgentsState.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-agent/ui/useDesktopManagedAgentsState.ts
@@ -6,7 +6,7 @@ import type {
 } from "../services/agentProviderStatusService.interface";
 import {
   ensureDesktopManagedAgentProviderStatuses,
-  projectDesktopManagedAgentsState
+  projectDesktopManagedAgentsStateForAgentGUI
 } from "../services/internal/desktopManagedAgentProviders.ts";
 
 const EMPTY_AGENT_PROVIDER_STATUS_SNAPSHOT: AgentProviderStatusSnapshot = {
@@ -44,7 +44,7 @@ export function useDesktopManagedAgentsState(
   return useMemo(
     () =>
       agentProviderStatusService
-        ? projectDesktopManagedAgentsState(snapshot)
+        ? projectDesktopManagedAgentsStateForAgentGUI(snapshot)
         : null,
     [agentProviderStatusService, snapshot]
   );

--- a/apps/desktop/src/renderer/src/features/workspace-workbench/services/internal/workspaceAgentGuiContribution.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/services/internal/workspaceAgentGuiContribution.ts
@@ -62,7 +62,7 @@ export function createWorkspaceAgentGuiContribution(input: {
   tuttidClient: TuttidClient;
   platformApi: Pick<
     DesktopPlatformApi,
-    "homeDirectory" | "os" | "resolveDroppedPaths"
+    "homeDirectory" | "os" | "resolveDroppedEntries" | "resolveDroppedPaths"
   >;
   reporterService?: Pick<IReporterService, "trackEvents">;
   richTextAtService: IDesktopRichTextAtService;

--- a/apps/desktop/src/renderer/src/features/workspace-workbench/services/internal/workspaceWorkbenchContributionFactory.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/services/internal/workspaceWorkbenchContributionFactory.ts
@@ -69,7 +69,7 @@ export interface DesktopWorkbenchContributionContext {
   tuttidClient: TuttidClient;
   platformApi: Pick<
     DesktopPlatformApi,
-    "homeDirectory" | "os" | "resolveDroppedPaths"
+    "homeDirectory" | "os" | "resolveDroppedEntries" | "resolveDroppedPaths"
   >;
   reporterService?: Pick<IReporterService, "trackEvents">;
   renderFilesNodeBody: (

--- a/apps/desktop/src/renderer/src/features/workspace-workbench/services/internal/workspaceWorkbenchHostService.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/services/internal/workspaceWorkbenchHostService.ts
@@ -143,7 +143,7 @@ export interface WorkspaceWorkbenchHostServiceDependencies {
   tuttidClient: TuttidClient;
   platformApi: Pick<
     DesktopPlatformApi,
-    "homeDirectory" | "os" | "resolveDroppedPaths"
+    "homeDirectory" | "os" | "resolveDroppedEntries" | "resolveDroppedPaths"
   >;
   repository: DesktopWorkspaceWorkbenchRepository;
   reporterService?: Pick<IReporterService, "trackEvents">;
@@ -167,7 +167,7 @@ export interface WorkspaceWorkbenchHostExternalDependencies {
   tuttidClient: TuttidClient;
   platformApi: Pick<
     DesktopPlatformApi,
-    "homeDirectory" | "os" | "resolveDroppedPaths"
+    "homeDirectory" | "os" | "resolveDroppedEntries" | "resolveDroppedPaths"
   >;
   reporterService?: Pick<IReporterService, "trackEvents">;
   runtimeApi: DesktopRuntimeApi;

--- a/apps/desktop/src/renderer/src/platform/desktop/web/createWebDesktopApi.ts
+++ b/apps/desktop/src/renderer/src/platform/desktop/web/createWebDesktopApi.ts
@@ -190,6 +190,9 @@ function createWebPlatformApi(): DesktopPlatformApi {
   return {
     homeDirectory: "",
     os: inferPlatform(),
+    resolveDroppedEntries() {
+      return [];
+    },
     resolveDroppedPaths() {
       return [];
     }

--- a/docs/architecture/agent-gui-node.md
+++ b/docs/architecture/agent-gui-node.md
@@ -176,6 +176,10 @@ Optimistic prompt messages must stay overlay-owned even when they are used to
 scope the selected detail window. Do not promote them into durable/detail
 message bases: their local timestamp-derived versions can outrank lower
 authoritative daemon versions and suppress the durable user prompt during merge.
+Existing-session submit must record the optimistic user prompt before the
+`sendInput` acknowledgement returns, then retarget or remove that prompt by
+`clientSubmitId`; otherwise switching away during submit can leave only later
+assistant stream events visible when the user returns.
 
 ### Turn Summary Undo/Reapply
 
@@ -458,6 +462,11 @@ The provider/runtime reports are the durable return path. AgentGUI should not
 parse provider stdout, terminal text, or runtime internals directly. It consumes
 normalized sessions, messages, state patches, and message pages through
 `AgentActivityRuntime`.
+If a provider exposes final assistant text through a side-channel such as a
+Claude SDK message rather than an ACP `agent_message_chunk`, the daemon adapter
+must normalize that text into the same persisted message projection. AgentGUI
+must not read provider transcript files or SDK-specific logs to recover missing
+final output.
 
 ### Event Reconcile And UI Refresh
 
@@ -692,20 +701,25 @@ User-visible rules:
 
 ### Loading State Taxonomy
 
-| Visible state                  | Primary owner                    | Starts when                                             | Clears when                                                                    |
-| ------------------------------ | -------------------------------- | ------------------------------------------------------- | ------------------------------------------------------------------------------ |
-| Rail skeleton or empty loading | conversation list query/store    | runtime list load starts                                | list load resolves or errors                                                   |
-| Selected detail skeleton       | session view store/controller    | active session messages load starts                     | `listSessionMessages` resolves or active session changes                       |
-| Home first-create busy         | controller local create state    | home `startConversation` begins                         | new-session activation succeeds, fails, or is abandoned as stale               |
-| "Connecting conversation"      | existing-session activation      | existing session open/retry calls `activate`            | activation succeeds, fails, or is abandoned as stale                           |
-| Transcript processing row      | transcript/session projection    | runtime reports working/turn phase                      | runtime reports ready/completed/failed or newer message projection replaces it |
-| Send button spinner            | controller local submit state    | `executePrompt` or approval submit begins               | command promise settles                                                        |
-| Composer settings loading      | composer options/settings model  | provider options load starts or settings source missing | options/settings resolve or fallback state is applied                          |
-| Approval response spinner      | controller approval submit state | prompt/approval option submit begins                    | runtime command settles and prompt projection updates                          |
+| Visible state                  | Primary owner                    | Starts when                                                    | Clears when                                                                    |
+| ------------------------------ | -------------------------------- | -------------------------------------------------------------- | ------------------------------------------------------------------------------ |
+| Rail skeleton or empty loading | conversation list query/store    | runtime list load starts                                       | list load resolves or errors                                                   |
+| Selected detail skeleton       | session view store/controller    | active session messages load starts                            | `listSessionMessages` resolves or active session changes                       |
+| Home first-create busy         | controller local create state    | home `startConversation` begins                                | new-session activation succeeds, fails, or is abandoned as stale               |
+| "Connecting conversation"      | existing-session activation      | existing session open/retry calls `activate`                   | activation succeeds, fails, or is abandoned as stale                           |
+| Transcript processing row      | transcript/session projection    | runtime reports working/turn phase                             | runtime reports ready/completed/failed or newer message projection replaces it |
+| Send button spinner            | controller local submit state    | `executePrompt` or approval submit begins                      | command promise settles                                                        |
+| Composer settings loading      | composer options/settings model  | provider options load starts or settings source missing        | options/settings resolve or fallback state is applied                          |
+| Provider setup notice          | desktop provider status adapter  | captured provider status says the active provider is not ready | captured status says provider is ready or user fixes setup                     |
+| Approval response spinner      | controller approval submit state | prompt/approval option submit begins                           | runtime command settles and prompt projection updates                          |
 
 When a loading state is wrong, first identify which row in this table is
 visible. Then debug that owner and clearing condition. Avoid moving a spinner
 between surfaces to hide a state-source mismatch.
+Desktop restore must not project "not ready" from an uncaptured provider-status
+snapshot. Until the first captured provider status exists, pass unknown provider
+readiness into AgentGUI so startup does not flash a false "configure provider"
+notice before local Codex or other provider detection returns.
 
 ### Error, Retry, And Recovery
 

--- a/docs/architecture/agent-gui-node.md
+++ b/docs/architecture/agent-gui-node.md
@@ -284,6 +284,11 @@ The session list is not owned by AgentGuiNode. AgentGuiNode may keep query,
 selection, pending create/delete/submit overlays, and read-state UI metadata.
 The session rows themselves come from the runtime snapshot and are refreshed
 through `load`, event reconciliation, or explicit session fetches.
+The desktop adapter should keep broad session-list loads bounded before they
+enter `AgentActivityRuntime`; large workspaces can accumulate hundreds or
+thousands of historical agent sessions, and pushing all of them through the
+runtime snapshot forces AgentGuiNode to repeatedly project and reconcile data
+the user is unlikely to inspect in the rail.
 Conversation-list read-state metadata is notification-style UI state. Historical
 imports that carry `runtimeContext.imported === true` should remain visible in
 the rail, but they must not seed unread completion lamps as though they just

--- a/docs/conventions/troubleshooting.md
+++ b/docs/conventions/troubleshooting.md
@@ -1082,6 +1082,33 @@ information is not available yet`, but `ps` or `lsof` still shows an older
   [main.tsx](../../apps/desktop/src/renderer/src/main.tsx)
   [whyDidYouRender.ts](../../apps/desktop/src/renderer/src/lib/whyDidYouRender.ts)
 
+### AgentGUI freezes when session history is large
+
+- Symptom:
+  The workspace renderer freezes, tears visually in screen recordings, or feels
+  stuck while opening AgentGUI or submitting an agent prompt in a workspace with
+  a long agent history.
+- Quick checks:
+  Inspect developer logs for `agent.gui.runtime.snapshot_changed` diagnostics.
+  If `sessionCount` is in the hundreds or thousands, check whether the desktop
+  adapter is calling `listWorkspaceAgentSessions` without a `limit`.
+- Root cause:
+  Unbounded session-list loads push every historical agent session into
+  `AgentActivityRuntime`, and each live event can make AgentGuiNode rebuild
+  conversation projections for history the visible rail does not need.
+- Fix:
+  Keep broad runtime session-list requests bounded at the desktop adapter or
+  daemon API boundary. Use targeted message/session fetches for the selected
+  detail rather than widening the runtime snapshot.
+- Validation:
+  Reproduce with a large session table and confirm runtime diagnostics report a
+  bounded `sessionCount`. Run the desktop adapter tests and `pnpm check:changed`
+  for mixed AgentGUI/desktop changes.
+- References:
+  [desktopAgentActivityAdapter.ts](../../apps/desktop/src/renderer/src/features/workspace-agent/services/desktopAgentActivityAdapter.ts)
+  [createDesktopAgentActivityRuntime.ts](../../apps/desktop/src/renderer/src/features/workspace-agent/services/createDesktopAgentActivityRuntime.ts)
+  [agent-gui-node.md](../architecture/agent-gui-node.md)
+
 ### Browser Node focus pings miss iframe-hosted editors
 
 - Symptom:

--- a/packages/agent/daemon/runtime/acp_client.go
+++ b/packages/agent/daemon/runtime/acp_client.go
@@ -30,7 +30,14 @@ type acpClient struct {
 	stderrSink          func([]byte)
 	done                chan struct{}
 	doneErr             error
+	exitCode            *int
+	stderrTail          []byte
 	doneOnce            sync.Once
+}
+
+type acpClientDiagnostics struct {
+	ExitCode   *int
+	StderrTail string
 }
 
 type acpMessage struct {
@@ -149,6 +156,22 @@ func (c *acpClient) Done() <-chan struct{} {
 // Err reports why the connection terminated; valid after Done is closed.
 func (c *acpClient) Err() error {
 	return c.finishError()
+}
+
+func (c *acpClient) Diagnostics() acpClientDiagnostics {
+	if c == nil {
+		return acpClientDiagnostics{}
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	diag := acpClientDiagnostics{
+		StderrTail: strings.TrimSpace(string(c.stderrTail)),
+	}
+	if c.exitCode != nil {
+		exitCode := *c.exitCode
+		diag.ExitCode = &exitCode
+	}
+	return diag
 }
 
 func (c *acpClient) Notify(ctx context.Context, method string, params any) error {
@@ -395,6 +418,7 @@ func (c *acpClient) readLoop() {
 			if len(stderrTail) > 8192 {
 				stderrTail = stderrTail[len(stderrTail)-8192:]
 			}
+			c.setStderrTail(stderrTail)
 			c.mu.Lock()
 			stderrSink := c.stderrSink
 			c.mu.Unlock()
@@ -413,6 +437,7 @@ func (c *acpClient) readLoop() {
 			continue
 		}
 		if frame.ExitCode != nil {
+			c.setExitCode(*frame.ExitCode)
 			message := strings.TrimSpace(frame.Message)
 			if stderr := strings.TrimSpace(string(stderrTail)); stderr != "" {
 				message = firstNonEmpty(message, "process exited") + ": " + stderr
@@ -433,6 +458,18 @@ func (c *acpClient) readLoop() {
 			c.dispatchLine(line)
 		}
 	}
+}
+
+func (c *acpClient) setStderrTail(tail []byte) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.stderrTail = append(c.stderrTail[:0], tail...)
+}
+
+func (c *acpClient) setExitCode(exitCode int) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.exitCode = &exitCode
 }
 
 func (c *acpClient) dispatchLine(line []byte) {

--- a/packages/agent/daemon/runtime/acp_turn_normalizer.go
+++ b/packages/agent/daemon/runtime/acp_turn_normalizer.go
@@ -90,6 +90,35 @@ func (n *acpTurnNormalizer) ApplyAssistantFinalText(finalText string) {
 	_, _ = n.assistantContent.WriteString(finalText)
 }
 
+func (n *acpTurnNormalizer) AppendAssistantSnapshot(
+	session Session,
+	turnID string,
+	text string,
+	messageID string,
+) []activityshared.Event {
+	if n == nil {
+		return nil
+	}
+	text = strings.TrimSpace(text)
+	if text == "" {
+		return nil
+	}
+	current := strings.TrimSpace(n.assistantContent.String())
+	if current == text && n.assistantMessageID != "" {
+		if n.assistantSegmentCompleted {
+			return nil
+		}
+		return n.Finish(session, turnID, messageStreamStateCompleted)
+	}
+	if n.assistantMessageID == "" || n.assistantSegmentCompleted {
+		n.assistantMessageID = firstNonEmpty(strings.TrimSpace(messageID), newID())
+		n.assistantSegmentCompleted = false
+	}
+	n.assistantContent.Reset()
+	_, _ = n.assistantContent.WriteString(text)
+	return n.Finish(session, turnID, messageStreamStateCompleted)
+}
+
 func (n *acpTurnNormalizer) mergeAssistantText(next string) {
 	if n == nil || next == "" {
 		return

--- a/packages/agent/daemon/runtime/adapter.go
+++ b/packages/agent/daemon/runtime/adapter.go
@@ -30,6 +30,13 @@ type ProcessConnection interface {
 	Close() error
 }
 
+type GracefulProcessConnection interface {
+	ProcessConnection
+	CloseInput() error
+	Terminate() error
+	Kill() error
+}
+
 type ProcessTransport interface {
 	Start(context.Context, ProcessSpec) (ProcessConnection, error)
 }

--- a/packages/agent/daemon/runtime/process_transport.go
+++ b/packages/agent/daemon/runtime/process_transport.go
@@ -30,6 +30,7 @@ type localProcessConnection struct {
 	closeOnce sync.Once
 	sendMu    sync.Mutex
 	inputOnce sync.Once
+	closeErr  error
 }
 
 func NewLocalProcessTransport() ProcessTransport {
@@ -228,9 +229,20 @@ func (c *localProcessConnection) Close() error {
 			_ = c.Terminate()
 		}
 		if !c.waitDone(750 * time.Millisecond) {
-			_ = c.Kill()
+			killErr := c.Kill()
+			if !c.waitDone(2 * time.Second) {
+				if killErr != nil {
+					c.closeErr = killErr
+					return
+				}
+				c.closeErr = errors.New("process did not exit after kill")
+				return
+			}
 		}
 	})
+	if c.closeErr != nil {
+		return c.closeErr
+	}
 	<-c.done
 	return nil
 }

--- a/packages/agent/daemon/runtime/process_transport.go
+++ b/packages/agent/daemon/runtime/process_transport.go
@@ -9,6 +9,8 @@ import (
 	"path/filepath"
 	"strings"
 	"sync"
+	"syscall"
+	"time"
 
 	"github.com/tutti-os/tutti/packages/agentactivity/daemon/runtimecmd"
 )
@@ -27,6 +29,7 @@ type localProcessConnection struct {
 
 	closeOnce sync.Once
 	sendMu    sync.Mutex
+	inputOnce sync.Once
 }
 
 func NewLocalProcessTransport() ProcessTransport {
@@ -220,13 +223,59 @@ func (c *localProcessConnection) Close() error {
 	}
 	c.closeOnce.Do(func() {
 		close(c.closing)
-		c.cancel()
-		_ = c.stdin.Close()
-		_ = c.stdout.Close()
-		_ = c.stderr.Close()
+		_ = c.CloseInput()
+		if !c.waitDone(250 * time.Millisecond) {
+			_ = c.Terminate()
+		}
+		if !c.waitDone(750 * time.Millisecond) {
+			_ = c.Kill()
+		}
 	})
 	<-c.done
 	return nil
+}
+
+func (c *localProcessConnection) CloseInput() error {
+	if c == nil || c.stdin == nil {
+		return nil
+	}
+	var err error
+	c.inputOnce.Do(func() {
+		err = c.stdin.Close()
+	})
+	return err
+}
+
+func (c *localProcessConnection) Terminate() error {
+	if c == nil || c.cmd == nil || c.cmd.Process == nil {
+		return nil
+	}
+	return c.cmd.Process.Signal(syscall.SIGTERM)
+}
+
+func (c *localProcessConnection) Kill() error {
+	if c == nil {
+		return nil
+	}
+	c.cancel()
+	if c.cmd == nil || c.cmd.Process == nil {
+		return nil
+	}
+	return c.cmd.Process.Kill()
+}
+
+func (c *localProcessConnection) waitDone(timeout time.Duration) bool {
+	if c == nil {
+		return true
+	}
+	timer := time.NewTimer(timeout)
+	defer timer.Stop()
+	select {
+	case <-c.done:
+		return true
+	case <-timer.C:
+		return false
+	}
 }
 
 func (c *localProcessConnection) readPipe(readers *sync.WaitGroup, reader io.Reader, stdout bool) {

--- a/packages/agent/daemon/runtime/process_transport_test.go
+++ b/packages/agent/daemon/runtime/process_transport_test.go
@@ -82,6 +82,38 @@ func TestLocalProcessTransportFindsKnownNodeGlobalBin(t *testing.T) {
 	}
 }
 
+func TestLocalProcessTransportCloseKillsProcessAfterGracefulShutdownFails(t *testing.T) {
+	shPath, err := exec.LookPath("sh")
+	if err != nil {
+		t.Skip("sh is unavailable")
+	}
+
+	conn, err := NewLocalProcessTransport().Start(context.Background(), ProcessSpec{
+		Command: []string{shPath, "-c", "trap '' TERM; while true; do sleep 1; done"},
+	})
+	if err != nil {
+		t.Fatalf("start transport: %v", err)
+	}
+
+	done := make(chan error, 1)
+	startedAt := time.Now()
+	go func() {
+		done <- conn.Close()
+	}()
+
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("Close: %v", err)
+		}
+	case <-time.After(4 * time.Second):
+		t.Fatal("Close did not force-kill process after graceful shutdown failed")
+	}
+	if elapsed := time.Since(startedAt); elapsed < 900*time.Millisecond {
+		t.Fatalf("Close returned after %s, want SIGTERM grace before kill fallback", elapsed)
+	}
+}
+
 func TestProcessStartEnvDiagnosticsSummarizesFinalPath(t *testing.T) {
 	tuttiBin := filepath.Join(string(os.PathSeparator), "Users", "Sun", ".tutti", "bin")
 	managedBin := filepath.Join(string(os.PathSeparator), "managed", "node", "bin")

--- a/packages/agent/daemon/runtime/standard_acp_adapter.go
+++ b/packages/agent/daemon/runtime/standard_acp_adapter.go
@@ -1901,7 +1901,32 @@ func (a *standardACPAdapter) handleACPMessage(
 		return acpPermissionResolvedEvents(session, turnID, pending, selection, nil), nil
 	case claudeSDKMessageMethod:
 		a.logClaudeSDKMessage(session, turnID, message.Params)
+		projection := claudeSDKAssistantTextProjection(message.Params)
 		events := a.mirrorClaudeSDKGoalStatus(session, message.Params)
+		textEvents := claudeSDKAssistantTextEvents(session, turnID, projection, normalizer)
+		if len(textEvents) > 0 {
+			events = append(events, textEvents...)
+		}
+		if projection.shouldLog() {
+			slog.Info("agent session Claude SDK assistant text projection",
+				"event", "agent_session.claude_sdk.assistant_text_projection",
+				"provider", a.config.provider,
+				"adapter", a.config.adapterName,
+				"room_id", session.RoomID,
+				"agent_session_id", session.AgentSessionID,
+				"provider_session_id", session.ProviderSessionID,
+				"turn_id", turnID,
+				"message_id", projection.messageID,
+				"message_type", projection.messageType,
+				"message_role", projection.role,
+				"stop_reason", projection.stopReason,
+				"content_types", projection.contentTypes,
+				"has_tool_use", projection.hasToolUse,
+				"text_len", len(projection.text),
+				"projected", len(textEvents) > 0,
+				"skip_reason", projection.skipReason,
+			)
+		}
 		if len(events) > 0 && emit == nil {
 			a.emitSessionEvents(session.AgentSessionID, events)
 		}
@@ -2097,6 +2122,114 @@ func (a *standardACPAdapter) logClaudeSDKMessage(session Session, turnID string,
 			"detail", detail,
 		)
 	}
+}
+
+type claudeSDKAssistantTextProjectionResult struct {
+	messageID    string
+	messageType  string
+	role         string
+	stopReason   string
+	contentTypes []string
+	hasToolUse   bool
+	text         string
+	skipReason   string
+}
+
+func (p claudeSDKAssistantTextProjectionResult) shouldLog() bool {
+	return p.text != "" || p.role == "assistant" || p.skipReason == "decode_failed"
+}
+
+func claudeSDKAssistantTextProjection(raw json.RawMessage) claudeSDKAssistantTextProjectionResult {
+	var decoded any
+	if err := json.Unmarshal(raw, &decoded); err != nil {
+		return claudeSDKAssistantTextProjectionResult{skipReason: "decode_failed"}
+	}
+	root := payloadObject(decoded)
+	if len(root) == 0 {
+		return claudeSDKAssistantTextProjectionResult{skipReason: "empty_payload"}
+	}
+	envelope := payloadObject(root["message"])
+	if len(envelope) == 0 {
+		envelope = root
+	}
+	message := envelope
+	if inner := payloadObject(envelope["message"]); strings.TrimSpace(asString(inner["role"])) == "assistant" {
+		message = inner
+	}
+	result := claudeSDKAssistantTextProjectionResult{
+		messageID:   strings.TrimSpace(asString(message["id"])),
+		messageType: firstNonEmpty(strings.TrimSpace(asString(envelope["type"])), strings.TrimSpace(asString(message["type"]))),
+		role:        strings.TrimSpace(asString(message["role"])),
+		stopReason:  firstNonEmpty(strings.TrimSpace(asString(envelope["stop_reason"])), strings.TrimSpace(asString(message["stop_reason"]))),
+	}
+	if result.role != "assistant" {
+		result.skipReason = "not_assistant"
+		return result
+	}
+	result.text, result.contentTypes, result.hasToolUse = claudeSDKAssistantTextFromContent(message["content"])
+	if result.text == "" {
+		result.skipReason = "no_text_content"
+	}
+	return result
+}
+
+func claudeSDKAssistantTextFromContent(content any) (string, []string, bool) {
+	switch typed := content.(type) {
+	case string:
+		text := strings.TrimSpace(typed)
+		if text == "" {
+			return "", nil, false
+		}
+		return text, []string{"string"}, false
+	case []any:
+		parts := make([]string, 0, len(typed))
+		contentTypes := make([]string, 0, len(typed))
+		hasToolUse := false
+		for _, item := range typed {
+			block := payloadObject(item)
+			if len(block) == 0 {
+				continue
+			}
+			blockType := strings.TrimSpace(asString(block["type"]))
+			if blockType != "" {
+				contentTypes = append(contentTypes, blockType)
+			}
+			if blockType == "tool_use" {
+				hasToolUse = true
+				continue
+			}
+			if blockType != "" && blockType != "text" {
+				continue
+			}
+			if text := strings.TrimSpace(asString(block["text"])); text != "" {
+				parts = append(parts, text)
+			}
+		}
+		return strings.TrimSpace(strings.Join(parts, "\n")), contentTypes, hasToolUse
+	default:
+		return "", nil, false
+	}
+}
+
+func claudeSDKAssistantTextEvents(
+	session Session,
+	turnID string,
+	projection claudeSDKAssistantTextProjectionResult,
+	normalizer *acpTurnNormalizer,
+) []activityshared.Event {
+	if strings.TrimSpace(projection.text) == "" {
+		return nil
+	}
+	if normalizer != nil {
+		return normalizer.AppendAssistantSnapshot(session, turnID, projection.text, projection.messageID)
+	}
+	messageID := firstNonEmpty(strings.TrimSpace(projection.messageID), newID())
+	return []activityshared.Event{newTurnActivityEventWithID(session, messageID, EventMessage, turnID, messageStreamStateCompleted, RoleAssistant, projection.text, map[string]any{
+		"messageId":   messageID,
+		"contentMode": messageContentModeSnapshot,
+		"streamState": messageStreamStateCompleted,
+		"source":      "claude_sdk",
+	})}
 }
 
 func (a *standardACPAdapter) mirrorClaudeSDKGoalStatus(session Session, raw json.RawMessage) []activityshared.Event {

--- a/packages/agent/daemon/runtime/standard_acp_adapter.go
+++ b/packages/agent/daemon/runtime/standard_acp_adapter.go
@@ -53,6 +53,7 @@ type standardACPSession struct {
 	providerSessionID string
 	agentInfo         map[string]any
 	promptImage       bool
+	sessionClose      bool
 	acpLiveState
 	pendingApprovals map[string]*pendingACPApproval
 	recentTurnID     string
@@ -64,6 +65,7 @@ type pendingACPApproval = pendingACPRequest
 const standardACPRecentTurnTTL = 10 * time.Minute
 
 const acpMethodSetConfigOption = "session/set_config_option"
+const acpMethodCloseSession = "session/close"
 const claudeSystemPromptFileEnv = "TUTTI_CLAUDE_SYSTEM_PROMPT_FILE"
 const claudePluginDirEnv = "TUTTI_CLAUDE_PLUGIN_DIR"
 const claudeSDKMessageMethod = "_claude/sdkMessage"
@@ -77,6 +79,11 @@ var claudeCodeACPModelAliases = map[string]bool{
 	"sonnet[1m]": true,
 	"opusplan":   true,
 }
+
+const (
+	acpCloseCallTimeout  = 750 * time.Millisecond
+	acpCloseGraceTimeout = 200 * time.Millisecond
+)
 
 // claudeCodeLegacyACPModelCandidates lists live ACP model values to try when a
 // persisted alias (e.g. "opus") is not directly advertised. Order matters:
@@ -305,6 +312,16 @@ func standardACPProviderPromptImageSupported(provider string, raw json.RawMessag
 	return standardACPPromptImageSupported(raw)
 }
 
+func standardACPSessionCloseSupported(raw json.RawMessage) bool {
+	var result struct {
+		SessionCapabilities map[string]bool `json:"sessionCapabilities"`
+	}
+	if err := json.Unmarshal(raw, &result); err != nil {
+		return false
+	}
+	return result.SessionCapabilities["close"]
+}
+
 func mergeACPParamsMeta(params map[string]any, meta map[string]any) {
 	if len(meta) == 0 {
 		return
@@ -483,6 +500,7 @@ func (a *standardACPAdapter) Start(ctx context.Context, session Session) ([]acti
 		client:           client,
 		agentInfo:        acpAgentInfo(initializeResult),
 		promptImage:      standardACPProviderPromptImageSupported(a.config.provider, initializeResult),
+		sessionClose:     standardACPSessionCloseSupported(initializeResult),
 		acpLiveState:     standardACPInitialLiveState(a.config.provider),
 		pendingApprovals: make(map[string]*pendingACPApproval),
 	}
@@ -602,6 +620,7 @@ func (a *standardACPAdapter) Resume(ctx context.Context, session Session) error 
 		providerSessionID: session.ProviderSessionID,
 		agentInfo:         acpAgentInfo(initializeResult),
 		promptImage:       standardACPProviderPromptImageSupported(a.config.provider, initializeResult),
+		sessionClose:      standardACPSessionCloseSupported(initializeResult),
 		acpLiveState:      standardACPInitialLiveState(a.config.provider),
 		pendingApprovals:  make(map[string]*pendingACPApproval),
 	}
@@ -651,7 +670,7 @@ func (a *standardACPAdapter) HasLiveSession(session Session) bool {
 	return acpSession != nil && acpSession.client != nil
 }
 
-func (a *standardACPAdapter) Close(_ context.Context, session Session) error {
+func (a *standardACPAdapter) Close(ctx context.Context, session Session) error {
 	if a == nil || a.transport == nil {
 		return nil
 	}
@@ -662,9 +681,70 @@ func (a *standardACPAdapter) Close(_ context.Context, session Session) error {
 	delete(a.sessions, agentSessionID)
 	a.mu.Unlock()
 	if acpSession != nil && acpSession.client != nil {
-		return acpSession.client.Close()
+		a.closeProviderSession(ctx, session, acpSession)
+		closeErr := acpSession.client.Close()
+		if closeErr != nil {
+			a.logACPCloseDiagnostics("transport_close.failed", session, acpSession, closeErr)
+			return closeErr
+		}
+		a.logACPCloseDiagnostics("closed", session, acpSession, nil)
 	}
 	return nil
+}
+
+func (a *standardACPAdapter) closeProviderSession(ctx context.Context, session Session, acpSession *standardACPSession) {
+	if a == nil || acpSession == nil || acpSession.client == nil || !acpSession.sessionClose {
+		return
+	}
+	providerSessionID := strings.TrimSpace(firstNonEmptyString(acpSession.providerSessionID, session.ProviderSessionID))
+	if providerSessionID == "" {
+		a.logACPCloseDiagnostics("protocol_close.skipped_missing_session_id", session, acpSession, nil)
+		return
+	}
+	params := map[string]any{"sessionId": providerSessionID}
+	if _, err := acpSession.client.CallNoHandlerWithTimeout(ctx, acpCloseCallTimeout, acpMethodCloseSession, params); err != nil {
+		a.logACPCloseDiagnostics("protocol_close.failed", session, acpSession, err)
+		return
+	}
+	a.logACPCloseDiagnostics("protocol_close.succeeded", session, acpSession, nil)
+	a.waitForACPClientDone(acpSession.client, acpCloseGraceTimeout)
+}
+
+func (a *standardACPAdapter) waitForACPClientDone(client *acpClient, timeout time.Duration) {
+	if client == nil {
+		return
+	}
+	timer := time.NewTimer(timeout)
+	defer timer.Stop()
+	select {
+	case <-client.Done():
+	case <-timer.C:
+	}
+}
+
+func (a *standardACPAdapter) logACPCloseDiagnostics(stage string, session Session, acpSession *standardACPSession, err error) {
+	if a == nil || acpSession == nil || acpSession.client == nil {
+		return
+	}
+	diag := acpSession.client.Diagnostics()
+	args := []any{
+		"event", "agent_session.acp.close",
+		"provider", a.config.provider,
+		"stage", stage,
+		"room_id", session.RoomID,
+		"agent_session_id", session.AgentSessionID,
+		"provider_session_id", firstNonEmptyString(acpSession.providerSessionID, session.ProviderSessionID),
+		"stderr_tail", truncateACPLogValue(diag.StderrTail, 1200),
+	}
+	if diag.ExitCode != nil {
+		args = append(args, "exit_code", *diag.ExitCode)
+	}
+	if err != nil {
+		args = append(args, "error", err.Error())
+		slog.Warn("agent session ACP close diagnostic", args...)
+		return
+	}
+	slog.Info("agent session ACP close diagnostic", args...)
 }
 
 func (a *standardACPAdapter) startInitializedClient(
@@ -1763,6 +1843,9 @@ func (a *standardACPAdapter) handleACPMessage(
 	)
 	switch message.Method {
 	case acpMethodUpdate:
+		if !a.standardACPUpdateMatchesProviderSession(session, message.Params) {
+			return nil, nil
+		}
 		if snapshot := a.applyACPUpdate(session.AgentSessionID, message.Params); snapshot != nil {
 			if emitCommands != nil {
 				emitCommands(*snapshot)
@@ -1840,6 +1923,45 @@ func (a *standardACPAdapter) handleACPMessage(
 		}
 		return nil, nil
 	}
+}
+
+func (a *standardACPAdapter) standardACPUpdateMatchesProviderSession(session Session, raw json.RawMessage) bool {
+	updateSessionID, ok := acpUpdateProviderSessionID(raw)
+	if !ok {
+		return true
+	}
+	liveSessionID := ""
+	if acpSession := a.getSession(session.AgentSessionID); acpSession != nil {
+		liveSessionID = strings.TrimSpace(acpSession.providerSessionID)
+	}
+	currentSessionID := firstNonEmptyString(liveSessionID, strings.TrimSpace(session.ProviderSessionID))
+	if liveSessionID == "" && currentSessionID == strings.TrimSpace(session.AgentSessionID) {
+		currentSessionID = ""
+	}
+	if currentSessionID == "" || updateSessionID == currentSessionID {
+		return true
+	}
+	slog.Debug("agent session ACP ignored update for foreign provider session",
+		"event", "agent_session.acp.update.foreign_provider_session_ignored",
+		"provider", a.config.provider,
+		"adapter", a.config.adapterName,
+		"room_id", session.RoomID,
+		"agent_session_id", session.AgentSessionID,
+		"provider_session_id", currentSessionID,
+		"update_provider_session_id", updateSessionID,
+	)
+	return false
+}
+
+func acpUpdateProviderSessionID(raw json.RawMessage) (string, bool) {
+	var params struct {
+		SessionID string `json:"sessionId"`
+	}
+	if err := json.Unmarshal(raw, &params); err != nil {
+		return "", false
+	}
+	sessionID := strings.TrimSpace(params.SessionID)
+	return sessionID, sessionID != ""
 }
 
 func (a *standardACPAdapter) SetConfigOptionsUpdateSink(sink ConfigOptionsUpdateSink) {

--- a/packages/agent/daemon/runtime/standard_acp_adapter_test.go
+++ b/packages/agent/daemon/runtime/standard_acp_adapter_test.go
@@ -2367,6 +2367,100 @@ func TestClaudeCodeAdapterMirrorsSDKGoalStatusIntoRuntimeContext(t *testing.T) {
 	}
 }
 
+func TestClaudeCodeAdapterProjectsSDKAssistantTextMessage(t *testing.T) {
+	t.Parallel()
+
+	adapter := NewClaudeCodeAdapter(newStandardACPTransport("Claude Agent", "claude-session-sdk-text"))
+	session := standardTestSession(ProviderClaudeCode)
+	session.ProviderSessionID = "claude-session-sdk-text"
+	raw, err := json.Marshal(map[string]any{
+		"message": map[string]any{
+			"type": "assistant",
+			"message": map[string]any{
+				"id":          "msg-final",
+				"type":        "message",
+				"role":        "assistant",
+				"stop_reason": "end_turn",
+				"content": []any{
+					map[string]any{
+						"type": "text",
+						"text": "final answer",
+					},
+				},
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("marshal sdk assistant text: %v", err)
+	}
+
+	events, err := adapter.handleACPMessage(context.Background(), nil, session, "turn-final", acpMessage{
+		Method: claudeSDKMessageMethod,
+		Params: raw,
+	}, nil, nil, nil)
+	if err != nil {
+		t.Fatalf("handle sdk assistant text: %v", err)
+	}
+	messages := activityMessagesWithRole(events, activityshared.MessageRoleAssistant)
+	if len(messages) != 1 {
+		t.Fatalf("assistant messages = %#v, want one", messages)
+	}
+	if got := messages[0].Payload.Content; got != "final answer" {
+		t.Fatalf("content = %q, want final answer", got)
+	}
+	if got := messages[0].Payload.Metadata["messageId"]; got != "msg-final" {
+		t.Fatalf("messageId = %#v, want msg-final", got)
+	}
+	if got := messages[0].Payload.Metadata["source"]; got != "claude_sdk" {
+		t.Fatalf("source = %#v, want claude_sdk", got)
+	}
+}
+
+func TestClaudeCodeAdapterSkipsDuplicateSDKAssistantText(t *testing.T) {
+	t.Parallel()
+
+	adapter := NewClaudeCodeAdapter(newStandardACPTransport("Claude Agent", "claude-session-sdk-text"))
+	session := standardTestSession(ProviderClaudeCode)
+	session.ProviderSessionID = "claude-session-sdk-text"
+	normalizer := newACPTurnNormalizer()
+	normalizer.ApplyAssistantFinalText("already projected")
+	completed := normalizer.FinishCompleted(session, "turn-final")
+	if len(activityMessagesWithRole(completed, activityshared.MessageRoleAssistant)) != 1 {
+		t.Fatalf("completed events = %#v, want baseline assistant message", completed)
+	}
+	raw, err := json.Marshal(map[string]any{
+		"message": map[string]any{
+			"type": "assistant",
+			"message": map[string]any{
+				"id":          "msg-final",
+				"type":        "message",
+				"role":        "assistant",
+				"stop_reason": "end_turn",
+				"content": []any{
+					map[string]any{
+						"type": "text",
+						"text": "already projected",
+					},
+				},
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("marshal sdk assistant text: %v", err)
+	}
+
+	events, err := adapter.handleACPMessage(context.Background(), nil, session, "turn-final", acpMessage{
+		Method: claudeSDKMessageMethod,
+		Params: raw,
+	}, normalizer, nil, nil)
+	if err != nil {
+		t.Fatalf("handle duplicate sdk assistant text: %v", err)
+	}
+	if messages := activityMessagesWithRole(events, activityshared.MessageRoleAssistant); len(messages) != 0 {
+		t.Fatalf("assistant messages = %#v, want duplicate skipped", messages)
+	}
+}
+
 func firstPromptText(t *testing.T, params map[string]any) string {
 	t.Helper()
 	texts := promptTexts(t, params)

--- a/packages/agent/daemon/runtime/standard_acp_adapter_test.go
+++ b/packages/agent/daemon/runtime/standard_acp_adapter_test.go
@@ -1630,6 +1630,128 @@ func TestStandardACPConfigOptionUpdateSignalsSessionStateReload(t *testing.T) {
 	}
 }
 
+func TestStandardACPIgnoresForeignProviderSessionUpdateDuringTurn(t *testing.T) {
+	t.Parallel()
+
+	transport := newStandardACPTransport("Claude Agent", "claude-session-current")
+	adapter := NewClaudeCodeAdapter(transport)
+	session := standardTestSession(ProviderClaudeCode)
+	if _, err := adapter.Start(context.Background(), session); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	session.ProviderSessionID = "claude-session-current"
+
+	var commandSnapshots []AgentSessionCommandSnapshot
+	var emittedEvents [][]activityshared.Event
+	var configUpdates []AgentSessionConfigOptionsUpdate
+	adapter.SetCommandSnapshotSink(func(snapshot AgentSessionCommandSnapshot) {
+		commandSnapshots = append(commandSnapshots, snapshot)
+	})
+	adapter.SetSessionEventSink(func(_ string, events []activityshared.Event) {
+		emittedEvents = append(emittedEvents, events)
+	})
+	adapter.SetConfigOptionsUpdateSink(func(update AgentSessionConfigOptionsUpdate) {
+		configUpdates = append(configUpdates, update)
+	})
+
+	events, err := adapter.handleACPMessage(context.Background(), nil, session, "turn-foreign", acpMessage{
+		Method: acpMethodUpdate,
+		Params: json.RawMessage(`{
+			"sessionId": "claude-session-foreign",
+			"update": {
+				"sessionUpdate": "session_info_update",
+				"title": "Foreign title"
+			}
+		}`),
+	}, newACPTurnNormalizer(), nil, nil)
+	if err != nil {
+		t.Fatalf("handle foreign title update: %v", err)
+	}
+	if len(events) != 0 || len(emittedEvents) != 0 {
+		t.Fatalf("foreign title events = %#v emitted=%#v, want none", events, emittedEvents)
+	}
+
+	if _, err := adapter.handleACPMessage(context.Background(), nil, session, "turn-foreign", acpMessage{
+		Method: acpMethodUpdate,
+		Params: json.RawMessage(`{
+			"sessionId": "claude-session-foreign",
+			"update": {
+				"sessionUpdate": "available_commands_update",
+				"availableCommands": [{
+					"name": "foreign-web",
+					"description": "Foreign command"
+				}]
+			}
+		}`),
+	}, newACPTurnNormalizer(), nil, nil); err != nil {
+		t.Fatalf("handle foreign command update: %v", err)
+	}
+	if _, err := adapter.handleACPMessage(context.Background(), nil, session, "turn-foreign", acpMessage{
+		Method: acpMethodUpdate,
+		Params: json.RawMessage(`{
+			"sessionId": "claude-session-foreign",
+			"update": {
+				"sessionUpdate": "config_option_update",
+				"key": "model",
+				"value": "foreign-model"
+			}
+		}`),
+	}, newACPTurnNormalizer(), nil, nil); err != nil {
+		t.Fatalf("handle foreign config update: %v", err)
+	}
+	if len(commandSnapshots) != 0 {
+		t.Fatalf("foreign command snapshots = %#v, want none", commandSnapshots)
+	}
+	if len(configUpdates) != 0 {
+		t.Fatalf("foreign config updates = %#v, want none", configUpdates)
+	}
+
+	snapshot, ok := adapter.SessionCommandSnapshot(session)
+	if !ok {
+		t.Fatal("SessionCommandSnapshot ok=false, want baseline Claude commands")
+	}
+	if names := agentSessionCommandNames(snapshot.Commands); containsString(names, "foreign-web") {
+		t.Fatalf("command names = %#v, want foreign command filtered", names)
+	}
+	state := adapter.SessionState(session)
+	config := payloadObject(state.RuntimeContext["config"])
+	if got := asString(config["model"]); got == "foreign-model" {
+		t.Fatalf("runtime config model = %q, want foreign config filtered", got)
+	}
+}
+
+func TestStandardACPAcceptsMatchingProviderSessionUpdate(t *testing.T) {
+	t.Parallel()
+
+	transport := newStandardACPTransport("Claude Agent", "claude-session-current")
+	adapter := NewClaudeCodeAdapter(transport)
+	session := standardTestSession(ProviderClaudeCode)
+	if _, err := adapter.Start(context.Background(), session); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	session.ProviderSessionID = "claude-session-current"
+
+	events, err := adapter.handleACPMessage(context.Background(), nil, session, "turn-current", acpMessage{
+		Method: acpMethodUpdate,
+		Params: json.RawMessage(`{
+			"sessionId": "claude-session-current",
+			"update": {
+				"sessionUpdate": "session_info_update",
+				"title": "Current title"
+			}
+		}`),
+	}, newACPTurnNormalizer(), nil, nil)
+	if err != nil {
+		t.Fatalf("handle matching update: %v", err)
+	}
+	if len(events) != 1 || events[0].Type != activityshared.EventSessionUpdated {
+		t.Fatalf("events = %#v, want matching session update projected", events)
+	}
+	if got := events[0].Payload.Title; got != "Current title" {
+		t.Fatalf("title = %q, want Current title", got)
+	}
+}
+
 func standardACPClaudeCodeConfig() standardACPConfig {
 	return standardACPConfig{provider: ProviderClaudeCode}
 }
@@ -3238,6 +3360,7 @@ func TestStandardACPAdapterResumePreservesCommandsAdvertisedDuringLoadSession(t 
 	adapter := NewOpenClawAdapter(transport)
 	session := standardTestSession(ProviderOpenClaw)
 	session.ProviderSessionID = "persisted-openclaw-session-id"
+	transport.conn.sessionID = session.ProviderSessionID
 
 	if err := adapter.Resume(context.Background(), session); err != nil {
 		t.Fatalf("Resume: %v", err)
@@ -3282,6 +3405,55 @@ func TestSelectGeminiACPAuthMethodFallsBackToAPIKey(t *testing.T) {
 	}
 }
 
+func TestStandardACPAdapterCloseSendsProtocolSessionCloseBeforeTransportClose(t *testing.T) {
+	t.Parallel()
+
+	transport := newStandardACPTransport("Gemini CLI", "gemini-session-close")
+	transport.conn.supportsCloseSession = true
+	transport.conn.closeSessionExits = true
+	adapter := NewGeminiAdapter(transport)
+	session := standardTestSession(ProviderGemini)
+
+	if _, err := adapter.Start(context.Background(), session); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	if err := adapter.Close(context.Background(), session); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+
+	params := transport.conn.closeSessionParams()
+	if got := asString(params["sessionId"]); got != "gemini-session-close" {
+		t.Fatalf("session/close sessionId = %q, want provider session id", got)
+	}
+	if !transport.conn.closed() {
+		t.Fatal("transport was not closed after protocol session close")
+	}
+}
+
+func TestStandardACPAdapterCloseFallsBackWhenProtocolSessionCloseFails(t *testing.T) {
+	t.Parallel()
+
+	transport := newStandardACPTransport("Gemini CLI", "gemini-session-close-failure")
+	transport.conn.supportsCloseSession = true
+	transport.conn.closeSessionError = &acpError{Code: -32601, Message: "session close unavailable"}
+	adapter := NewGeminiAdapter(transport)
+	session := standardTestSession(ProviderGemini)
+
+	if _, err := adapter.Start(context.Background(), session); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	if err := adapter.Close(context.Background(), session); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+
+	if got := asString(transport.conn.closeSessionParams()["sessionId"]); got != "gemini-session-close-failure" {
+		t.Fatalf("session/close sessionId = %q, want provider session id", got)
+	}
+	if !transport.conn.closed() {
+		t.Fatal("transport was not closed after protocol close failure")
+	}
+}
+
 func standardTestSession(provider string) Session {
 	return Session{
 		RoomID:            "room-1",
@@ -3319,6 +3491,7 @@ func (t *standardACPTransport) Start(_ context.Context, spec ProcessSpec) (Proce
 
 type standardACPConnection struct {
 	mu                            sync.Mutex
+	closeOnce                     sync.Once
 	recv                          chan ProcessFrame
 	agentTitle                    string
 	sessionID                     string
@@ -3337,11 +3510,15 @@ type standardACPConnection struct {
 	lastAuthenticatedMethodID     string
 	setModeError                  *acpError
 	loadSessionError              *acpError
+	closeSessionError             *acpError
 	rejectModelValue              string
 	supportsLoadSession           bool
+	supportsCloseSession          bool
+	closeSessionExits             bool
 	isClosed                      bool
 	lastNewSessionParams          map[string]any
 	lastLoadSessionParams         map[string]any
+	lastCloseSessionParams        map[string]any
 	lastPromptParamsSnapshot      map[string]any
 	setConfigOptionSnapshots      []map[string]any
 }
@@ -3371,18 +3548,25 @@ func (c *standardACPConnection) Send(data []byte) error {
 					"title": c.agentTitle,
 				},
 			}
+			sessionCapabilities := map[string]any{}
 			if strings.EqualFold(c.agentTitle, "Gemini CLI") {
 				result["authMethods"] = []map[string]any{
 					{"id": "oauth-personal", "name": "Login with Google"},
 					{"id": "gemini-api-key", "name": "Gemini API Key"},
 				}
-				result["sessionCapabilities"] = map[string]any{"load": true}
+				sessionCapabilities["load"] = true
 			}
 			if strings.EqualFold(c.agentTitle, "Claude Agent") {
-				result["sessionCapabilities"] = map[string]any{"resume": true}
+				sessionCapabilities["resume"] = true
 			}
 			if c.supportsLoadSession || strings.EqualFold(strings.TrimSpace(c.agentTitle), "OpenClaw") {
-				result["sessionCapabilities"] = map[string]any{"load": true}
+				sessionCapabilities["load"] = true
+			}
+			if c.supportsCloseSession {
+				sessionCapabilities["close"] = true
+			}
+			if len(sessionCapabilities) > 0 {
+				result["sessionCapabilities"] = sessionCapabilities
 			}
 			c.sendJSON(map[string]any{
 				"jsonrpc": "2.0",
@@ -3453,6 +3637,34 @@ func (c *standardACPConnection) Send(data []byte) error {
 					"configOptions": c.defaultConfigOptions(),
 				},
 			})
+		case acpMethodCloseSession:
+			var request struct {
+				Params map[string]any `json:"params"`
+			}
+			_ = json.Unmarshal([]byte(line), &request)
+			c.mu.Lock()
+			if request.Params != nil {
+				c.lastCloseSessionParams = maps.Clone(request.Params)
+			}
+			closeSessionError := c.closeSessionError
+			closeSessionExits := c.closeSessionExits
+			c.mu.Unlock()
+			if closeSessionError != nil {
+				c.sendJSON(map[string]any{
+					"jsonrpc": "2.0",
+					"id":      message.ID,
+					"error":   closeSessionError,
+				})
+				return nil
+			}
+			c.sendJSON(map[string]any{
+				"jsonrpc": "2.0",
+				"id":      message.ID,
+				"result":  map[string]any{},
+			})
+			if closeSessionExits {
+				c.closeRecv()
+			}
 		case acpMethodSetMode:
 			var request struct {
 				Params map[string]any `json:"params"`
@@ -3668,8 +3880,14 @@ func (c *standardACPConnection) Close() error {
 	c.mu.Lock()
 	c.isClosed = true
 	c.mu.Unlock()
-	close(c.recv)
+	c.closeRecv()
 	return nil
+}
+
+func (c *standardACPConnection) closeRecv() {
+	c.closeOnce.Do(func() {
+		close(c.recv)
+	})
 }
 
 func (c *standardACPConnection) sendJSON(value any) {
@@ -3806,6 +4024,15 @@ func (c *standardACPConnection) lastSetModeParams() map[string]any {
 		return nil
 	}
 	return maps.Clone(c.lastSetModeParamsSnapshot)
+}
+
+func (c *standardACPConnection) closeSessionParams() map[string]any {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.lastCloseSessionParams == nil {
+		return nil
+	}
+	return maps.Clone(c.lastCloseSessionParams)
 }
 
 func (c *standardACPConnection) authenticatedMethodID() string {

--- a/packages/agent/gui/agent-gui/agentGuiNode/AgentComposer.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/AgentComposer.tsx
@@ -143,6 +143,7 @@ import {
   USAGE_WARN_PERCENT
 } from "./model/agentUsageThresholds";
 import { useOptionalAgentActivityRuntime } from "../../agentActivityRuntime";
+import { useOptionalAgentHostApi } from "../../agentActivityHost";
 
 export { formatSlashStatusTokenCount };
 
@@ -813,6 +814,8 @@ export function AgentComposer({
   const draftImages = draftContent.images;
   const draftFiles = draftContent.files ?? [];
   const agentActivityRuntime = useOptionalAgentActivityRuntime();
+  const agentHostApi = useOptionalAgentHostApi();
+  const getPathForFile = agentHostApi?.workspace.getPathForFile;
   const [isPaletteOpen, setIsPaletteOpen] = useState(true);
   const [isReviewPickerOpen, setIsReviewPickerOpen] = useState(false);
   const [highlightedIndex, setHighlightedIndex] = useState(0);
@@ -2923,6 +2926,7 @@ export function AgentComposer({
                     promptImagesSupported={promptImagesSupported}
                     onPromptImagesUnsupported={onPromptImagesUnsupported}
                     onPasteImages={handlePastedImages}
+                    getPathForFile={getPathForFile}
                   />
                   {!isHeroLayout ? composerActionButton : null}
                 </div>

--- a/packages/agent/gui/agent-gui/agentGuiNode/AgentComposer.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/AgentComposer.tsx
@@ -815,7 +815,7 @@ export function AgentComposer({
   const draftFiles = draftContent.files ?? [];
   const agentActivityRuntime = useOptionalAgentActivityRuntime();
   const agentHostApi = useOptionalAgentHostApi();
-  const getPathForFile = agentHostApi?.workspace.getPathForFile;
+  const getReferenceForFile = agentHostApi?.workspace.getReferenceForFile;
   const [isPaletteOpen, setIsPaletteOpen] = useState(true);
   const [isReviewPickerOpen, setIsReviewPickerOpen] = useState(false);
   const [highlightedIndex, setHighlightedIndex] = useState(0);
@@ -2926,7 +2926,7 @@ export function AgentComposer({
                     promptImagesSupported={promptImagesSupported}
                     onPromptImagesUnsupported={onPromptImagesUnsupported}
                     onPasteImages={handlePastedImages}
-                    getPathForFile={getPathForFile}
+                    getReferenceForFile={getReferenceForFile}
                   />
                   {!isHeroLayout ? composerActionButton : null}
                 </div>

--- a/packages/agent/gui/agent-gui/agentGuiNode/agentRichText/AgentRichTextEditor.spec.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/agentRichText/AgentRichTextEditor.spec.tsx
@@ -139,6 +139,39 @@ describe("AgentRichTextEditor", () => {
     await waitFor(() => expect(onChange).toHaveBeenCalledWith("hello\nworld"));
   });
 
+  it("pastes non-image files as file mention chips", async () => {
+    const onChange = vi.fn();
+    render(
+      <AgentRichTextEditor
+        value=""
+        disabled={false}
+        placeholder="Prompt"
+        onChange={onChange}
+        onSubmit={vi.fn()}
+        getPathForFile={(file) => `/workspace/docs/${file.name}`}
+      />
+    );
+
+    const editor = await screen.findByRole("textbox", { name: "Prompt" });
+    fireEvent.paste(editor, {
+      clipboardData: createDataTransferStub([
+        new File(["readme"], "README.md", { type: "text/markdown" })
+      ])
+    });
+
+    await waitFor(() =>
+      expect(onChange).toHaveBeenLastCalledWith(
+        "[@README.md](/workspace/docs/README.md) "
+      )
+    );
+    const mention = editor.querySelector('[data-agent-file-mention="true"]');
+    expect(mention).toHaveAttribute("data-agent-mention-kind", "file");
+    expect(mention).toHaveAttribute(
+      "data-agent-mention-href",
+      "/workspace/docs/README.md"
+    );
+  });
+
   it("pastes plain text after an existing reference mention", async () => {
     const onChange = vi.fn();
     render(

--- a/packages/agent/gui/agent-gui/agentGuiNode/agentRichText/AgentRichTextEditor.spec.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/agentRichText/AgentRichTextEditor.spec.tsx
@@ -63,6 +63,19 @@ function createDataTransferStub(files: readonly File[] = []): DataTransfer {
   return dataTransfer as unknown as DataTransfer;
 }
 
+function createDataTransferFilesFallbackStub(
+  files: readonly File[] = []
+): DataTransfer {
+  const dataTransfer = createDataTransferStub(files) as unknown as {
+    items: Array<{ getAsFile: () => File | null }>;
+  };
+  dataTransfer.items = dataTransfer.items.map((item) => ({
+    ...item,
+    getAsFile: () => null
+  }));
+  return dataTransfer as unknown as DataTransfer;
+}
+
 function selectEditorText(editor: HTMLElement, from: number, to: number): void {
   const textNode = editor.querySelector("p")?.firstChild;
   if (!textNode) {
@@ -148,7 +161,10 @@ describe("AgentRichTextEditor", () => {
         placeholder="Prompt"
         onChange={onChange}
         onSubmit={vi.fn()}
-        getPathForFile={(file) => `/workspace/docs/${file.name}`}
+        getReferenceForFile={(file) => ({
+          path: `/workspace/docs/${file.name}`,
+          kind: "file"
+        })}
       />
     );
 
@@ -169,6 +185,120 @@ describe("AgentRichTextEditor", () => {
     expect(mention).toHaveAttribute(
       "data-agent-mention-href",
       "/workspace/docs/README.md"
+    );
+  });
+
+  it("pastes folders as directory mention chips", async () => {
+    const onChange = vi.fn();
+    render(
+      <AgentRichTextEditor
+        value=""
+        disabled={false}
+        placeholder="Prompt"
+        onChange={onChange}
+        onSubmit={vi.fn()}
+        getReferenceForFile={(file) => ({
+          path: `/workspace/docs/${file.name}`,
+          kind: "folder"
+        })}
+      />
+    );
+
+    const editor = await screen.findByRole("textbox", { name: "Prompt" });
+    fireEvent.paste(editor, {
+      clipboardData: createDataTransferStub([new File([""], "assets")])
+    });
+
+    await waitFor(() =>
+      expect(onChange).toHaveBeenLastCalledWith(
+        "[@assets](/workspace/docs/assets/) "
+      )
+    );
+    const mention = editor.querySelector('[data-agent-file-mention="true"]');
+    expect(mention).toHaveAttribute("data-agent-file-entry-kind", "directory");
+    expect(mention).toHaveAttribute("data-agent-file-visual-kind", "folder");
+  });
+
+  it("pastes files when clipboard items cannot resolve files but files are present", async () => {
+    const onChange = vi.fn();
+    render(
+      <AgentRichTextEditor
+        value=""
+        disabled={false}
+        placeholder="Prompt"
+        onChange={onChange}
+        onSubmit={vi.fn()}
+        getReferenceForFile={(file) => ({
+          path: `/workspace/docs/${file.name}`,
+          kind: "file"
+        })}
+      />
+    );
+
+    const editor = await screen.findByRole("textbox", { name: "Prompt" });
+    fireEvent.paste(editor, {
+      clipboardData: createDataTransferFilesFallbackStub([
+        new File(["readme"], "README.md", { type: "text/markdown" })
+      ])
+    });
+
+    await waitFor(() =>
+      expect(onChange).toHaveBeenLastCalledWith(
+        "[@README.md](/workspace/docs/README.md) "
+      )
+    );
+  });
+
+  it("does not paste supported image files with empty MIME types as file mention chips", async () => {
+    const getReferenceForFile = vi.fn((file: File) => ({
+      path: `/workspace/docs/${file.name}`,
+      kind: "file" as const
+    }));
+    render(
+      <AgentRichTextEditor
+        value=""
+        disabled={false}
+        placeholder="Prompt"
+        onChange={vi.fn()}
+        onSubmit={vi.fn()}
+        getReferenceForFile={getReferenceForFile}
+      />
+    );
+
+    const editor = await screen.findByRole("textbox", { name: "Prompt" });
+    fireEvent.paste(editor, {
+      clipboardData: createDataTransferStub([new File(["png"], "photo.png")])
+    });
+
+    expect(getReferenceForFile).not.toHaveBeenCalled();
+    expect(editor.querySelector('[data-agent-file-mention="true"]')).toBeNull();
+  });
+
+  it("still pastes unsupported image-like files with empty MIME types as file mention chips", async () => {
+    const onChange = vi.fn();
+    render(
+      <AgentRichTextEditor
+        value=""
+        disabled={false}
+        placeholder="Prompt"
+        onChange={onChange}
+        onSubmit={vi.fn()}
+        getReferenceForFile={(file) => ({
+          path: `/workspace/docs/${file.name}`,
+          kind: "file"
+        })}
+      />
+    );
+
+    const editor = await screen.findByRole("textbox", { name: "Prompt" });
+    fireEvent.paste(editor, {
+      clipboardData: createDataTransferStub([new File(["gif"], "clip.gif")])
+    });
+
+    await waitFor(() =>
+      expect(onChange).toHaveBeenLastCalledWith(
+        "[@clip.gif](/workspace/docs/clip.gif) "
+      )
     );
   });
 

--- a/packages/agent/gui/agent-gui/agentGuiNode/agentRichText/AgentRichTextEditor.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/agentRichText/AgentRichTextEditor.tsx
@@ -49,6 +49,7 @@ import type { AgentGUIProviderSkillOption } from "../model/agentGuiNodeTypes";
 import type { AgentCapabilityTokenOption } from "./agentCapabilityTokenExtension";
 import {
   imageFilesFromDataTransfer,
+  nonImageFilesFromDataTransfer,
   readAgentRichTextPromptImages,
   type AgentRichTextPromptImage
 } from "./agentRichTextPromptImages";
@@ -75,6 +76,7 @@ export interface AgentRichTextEditorProps {
   promptImagesSupported?: boolean;
   onPromptImagesUnsupported?: () => void;
   onPasteImages?: (images: AgentRichTextPastedImage[]) => void;
+  getPathForFile?: (file: File) => string;
 }
 
 export interface AgentRichTextEditorHandle {
@@ -455,7 +457,8 @@ export const AgentRichTextEditor = forwardRef<
     onLinkClick,
     promptImagesSupported = true,
     onPromptImagesUnsupported,
-    onPasteImages
+    onPasteImages,
+    getPathForFile
   },
   ref
 ): React.JSX.Element {
@@ -477,6 +480,7 @@ export const AgentRichTextEditor = forwardRef<
   const onPromptImagesUnsupportedRef = useRef(onPromptImagesUnsupported);
   const onPasteImagesRef = useRef(onPasteImages);
   const promptImagesSupportedRef = useRef(promptImagesSupported);
+  const getPathForFileRef = useRef(getPathForFile);
   const placeholderRef = useRef(placeholder);
   const removeMentionLabelRef = useRef(removeMentionLabel);
   const availableSkillsRef = useRef(availableSkills);
@@ -618,6 +622,7 @@ export const AgentRichTextEditor = forwardRef<
   onPromptImagesUnsupportedRef.current = onPromptImagesUnsupported;
   onPasteImagesRef.current = onPasteImages;
   promptImagesSupportedRef.current = promptImagesSupported;
+  getPathForFileRef.current = getPathForFile;
   placeholderRef.current = placeholder;
   removeMentionLabelRef.current = removeMentionLabel;
   availableSkillsRef.current = availableSkills;
@@ -743,6 +748,50 @@ export const AgentRichTextEditor = forwardRef<
               }
             });
             return true;
+          }
+          const getPathForFileFn = getPathForFileRef.current;
+          if (getPathForFileFn) {
+            const nonImageFiles = nonImageFilesFromDataTransfer(
+              event.clipboardData
+            );
+            if (nonImageFiles.length > 0) {
+              const paths = nonImageFiles
+                .map((file) => {
+                  try {
+                    return getPathForFileFn(file);
+                  } catch {
+                    return null;
+                  }
+                })
+                .filter((p): p is string => Boolean(p));
+              if (paths.length > 0) {
+                event.preventDefault();
+                const currentEditor = editorRef.current;
+                if (!currentEditor) {
+                  return true;
+                }
+                if (!currentEditor.isFocused) {
+                  currentEditor.commands.setTextSelection(
+                    currentEditor.state.doc.content.size
+                  );
+                }
+                currentEditor.commands.insertContent(
+                  createAgentFileMentionContent(
+                    paths.map((path) => ({
+                      path,
+                      kind: "file"
+                    })),
+                    {
+                      prefixCaretAnchor: isPromptVisualLineStart(
+                        currentEditor,
+                        currentEditor.state.selection.from
+                      )
+                    }
+                  )
+                );
+                return true;
+              }
+            }
           }
           const html = event.clipboardData?.getData("text/html") ?? "";
           if (html.includes("data-agent-file-mention")) {

--- a/packages/agent/gui/agent-gui/agentGuiNode/agentRichText/AgentRichTextEditor.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/agentRichText/AgentRichTextEditor.tsx
@@ -76,7 +76,7 @@ export interface AgentRichTextEditorProps {
   promptImagesSupported?: boolean;
   onPromptImagesUnsupported?: () => void;
   onPasteImages?: (images: AgentRichTextPastedImage[]) => void;
-  getPathForFile?: (file: File) => string;
+  getReferenceForFile?: (file: File) => WorkspaceFileReference | null;
 }
 
 export interface AgentRichTextEditorHandle {
@@ -458,7 +458,7 @@ export const AgentRichTextEditor = forwardRef<
     promptImagesSupported = true,
     onPromptImagesUnsupported,
     onPasteImages,
-    getPathForFile
+    getReferenceForFile
   },
   ref
 ): React.JSX.Element {
@@ -480,7 +480,7 @@ export const AgentRichTextEditor = forwardRef<
   const onPromptImagesUnsupportedRef = useRef(onPromptImagesUnsupported);
   const onPasteImagesRef = useRef(onPasteImages);
   const promptImagesSupportedRef = useRef(promptImagesSupported);
-  const getPathForFileRef = useRef(getPathForFile);
+  const getReferenceForFileRef = useRef(getReferenceForFile);
   const placeholderRef = useRef(placeholder);
   const removeMentionLabelRef = useRef(removeMentionLabel);
   const availableSkillsRef = useRef(availableSkills);
@@ -622,7 +622,7 @@ export const AgentRichTextEditor = forwardRef<
   onPromptImagesUnsupportedRef.current = onPromptImagesUnsupported;
   onPasteImagesRef.current = onPasteImages;
   promptImagesSupportedRef.current = promptImagesSupported;
-  getPathForFileRef.current = getPathForFile;
+  getReferenceForFileRef.current = getReferenceForFile;
   placeholderRef.current = placeholder;
   removeMentionLabelRef.current = removeMentionLabel;
   availableSkillsRef.current = availableSkills;
@@ -749,22 +749,24 @@ export const AgentRichTextEditor = forwardRef<
             });
             return true;
           }
-          const getPathForFileFn = getPathForFileRef.current;
-          if (getPathForFileFn) {
+          const getReferenceForFileFn = getReferenceForFileRef.current;
+          if (getReferenceForFileFn) {
             const nonImageFiles = nonImageFilesFromDataTransfer(
               event.clipboardData
             );
             if (nonImageFiles.length > 0) {
-              const paths = nonImageFiles
+              const references = nonImageFiles
                 .map((file) => {
                   try {
-                    return getPathForFileFn(file);
+                    return getReferenceForFileFn(file);
                   } catch {
                     return null;
                   }
                 })
-                .filter((p): p is string => Boolean(p));
-              if (paths.length > 0) {
+                .filter((reference): reference is WorkspaceFileReference =>
+                  Boolean(reference?.path)
+                );
+              if (references.length > 0) {
                 event.preventDefault();
                 const currentEditor = editorRef.current;
                 if (!currentEditor) {
@@ -776,18 +778,12 @@ export const AgentRichTextEditor = forwardRef<
                   );
                 }
                 currentEditor.commands.insertContent(
-                  createAgentFileMentionContent(
-                    paths.map((path) => ({
-                      path,
-                      kind: "file"
-                    })),
-                    {
-                      prefixCaretAnchor: isPromptVisualLineStart(
-                        currentEditor,
-                        currentEditor.state.selection.from
-                      )
-                    }
-                  )
+                  createAgentFileMentionContent(references, {
+                    prefixCaretAnchor: isPromptVisualLineStart(
+                      currentEditor,
+                      currentEditor.state.selection.from
+                    )
+                  })
                 );
                 return true;
               }

--- a/packages/agent/gui/agent-gui/agentGuiNode/agentRichText/agentRichTextPromptImages.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/agentRichText/agentRichTextPromptImages.ts
@@ -29,6 +29,31 @@ export function imageFilesFromDataTransfer(
   return files;
 }
 
+export function nonImageFilesFromDataTransfer(
+  dataTransfer: DataTransfer | null
+): File[] {
+  if (!dataTransfer) {
+    return [];
+  }
+  const files: File[] = [];
+  const items = (dataTransfer as { items?: DataTransferItemList | null }).items;
+  if (!items) {
+    return Array.from(dataTransfer.files ?? []).filter(
+      (file) => !supportedPromptImageMimeType(file.type)
+    );
+  }
+  for (const item of Array.from(items)) {
+    if (item.kind !== "file" || supportedPromptImageMimeType(item.type)) {
+      continue;
+    }
+    const file = item.getAsFile();
+    if (file) {
+      files.push(file);
+    }
+  }
+  return files;
+}
+
 export function supportedPromptImageMimeType(
   value: string
 ): value is AgentRichTextPromptImage["mimeType"] {

--- a/packages/agent/gui/agent-gui/agentGuiNode/agentRichText/agentRichTextPromptImages.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/agentRichText/agentRichTextPromptImages.ts
@@ -26,6 +26,11 @@ export function imageFilesFromDataTransfer(
       files.push(file);
     }
   }
+  if (files.length === 0) {
+    return Array.from(dataTransfer.files ?? []).filter((file) =>
+      supportedPromptImageMimeType(file.type)
+    );
+  }
   return files;
 }
 
@@ -39,7 +44,9 @@ export function nonImageFilesFromDataTransfer(
   const items = (dataTransfer as { items?: DataTransferItemList | null }).items;
   if (!items) {
     return Array.from(dataTransfer.files ?? []).filter(
-      (file) => !supportedPromptImageMimeType(file.type)
+      (file) =>
+        !supportedPromptImageMimeType(file.type) &&
+        !supportedPromptImageFileName(file.name)
     );
   }
   for (const item of Array.from(items)) {
@@ -47,9 +54,19 @@ export function nonImageFilesFromDataTransfer(
       continue;
     }
     const file = item.getAsFile();
+    if (file && supportedPromptImageFileName(file.name)) {
+      continue;
+    }
     if (file) {
       files.push(file);
     }
+  }
+  if (files.length === 0) {
+    return Array.from(dataTransfer.files ?? []).filter(
+      (file) =>
+        !supportedPromptImageMimeType(file.type) &&
+        !supportedPromptImageFileName(file.name)
+    );
   }
   return files;
 }
@@ -60,6 +77,10 @@ export function supportedPromptImageMimeType(
   return (
     value === "image/png" || value === "image/jpeg" || value === "image/webp"
   );
+}
+
+function supportedPromptImageFileName(value: string): boolean {
+  return /\.(png|jpe?g|webp)$/i.test(value.trim());
 }
 
 export async function readAgentRichTextPromptImages(

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUINodeController.spec.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUINodeController.spec.tsx
@@ -1484,6 +1484,104 @@ describe("useAgentGUINodeController", () => {
     ]);
   });
 
+  it("keeps an existing-session submitted prompt visible after switching away before send resolves", async () => {
+    let resolveExec:
+      | ((value: { sessionStatus: string; turnId: string }) => void)
+      | undefined;
+    const exec = vi.fn(
+      () =>
+        new Promise<{ sessionStatus: string; turnId: string }>((resolve) => {
+          resolveExec = resolve;
+        })
+    );
+    installAgentHostApi({
+      exec,
+      list: vi.fn(async () => ({
+        presences: [],
+        sessions: [
+          workspaceAgentSession("session-1", { effectiveStatus: "ready" }),
+          workspaceAgentSession("session-2", { effectiveStatus: "ready" })
+        ]
+      })),
+      listSessionTimeline: vi.fn(async () => ({ timelineItems: [] })),
+      subscribeEvents: vi.fn(() => vi.fn())
+    });
+
+    const { result } = renderHook(() =>
+      useAgentGUINodeController({
+        workspaceId: "room-1",
+        currentUserId: "user-1",
+        workspacePath: "/workspace",
+        avoidGroupingEdits: false,
+        data: agentGuiData("session-1"),
+        onDataChange: vi.fn()
+      })
+    );
+
+    await waitFor(() => {
+      expect(result.current.viewModel.activeConversationId).toBe("session-1");
+    });
+
+    act(() => {
+      result.current.actions.submitPrompt(promptBlocks("A1"));
+    });
+
+    await waitFor(() => {
+      expect(exec).toHaveBeenCalledWith({
+        workspaceId: "room-1",
+        agentSessionId: "session-1",
+        content: promptBlocks("A1")
+      });
+      expect(
+        getAgentSessionView({
+          workspaceId: "room-1",
+          agentSessionId: "session-1"
+        })?.overlayMessages
+      ).toEqual([
+        expect.objectContaining({
+          role: "user",
+          payload: expect.objectContaining({ text: "A1" })
+        })
+      ]);
+    });
+
+    act(() => {
+      result.current.actions.selectConversation("session-2");
+    });
+
+    await waitFor(() => {
+      expect(result.current.viewModel.activeConversationId).toBe("session-2");
+    });
+
+    await act(async () => {
+      resolveExec?.({ sessionStatus: "working", turnId: "turn-a1" });
+    });
+    act(() => {
+      emitRuntimeSessionEventForTests?.(
+        streamMessage({
+          agentSessionId: "session-1",
+          id: 2,
+          eventId: "session-1-assistant-a2",
+          role: "assistant",
+          content: "A2",
+          turnId: "turn-a1",
+          occurredAtUnixMs: 2
+        })
+      );
+    });
+
+    act(() => {
+      result.current.actions.selectConversation("session-1");
+    });
+
+    await waitFor(() => {
+      expect(conversationBodies(result.current.viewModel)).toEqual([
+        "A1",
+        "A2"
+      ]);
+    });
+  });
+
   it("keeps each window selection independent when another window creates a new session", async () => {
     let resolveActivation:
       | ((value: AgentHostActivateAgentSessionResult) => void)

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUINodeController.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUINodeController.ts
@@ -1604,6 +1604,30 @@ function retargetOptimisticPromptMessages(
   return { changed, messages: retargeted };
 }
 
+function removeOptimisticPromptMessagesByClientSubmitId(
+  messages: readonly WorkspaceAgentActivityMessage[],
+  clientSubmitId: string
+): { changed: boolean; messages: WorkspaceAgentActivityMessage[] } {
+  const normalizedClientSubmitId = clientSubmitId.trim();
+  if (!normalizedClientSubmitId || messages.length === 0) {
+    return { changed: false, messages: [...messages] };
+  }
+  const filtered = messages.filter((message) => {
+    if (!isWorkspaceAgentActivityOptimisticMessage(message)) {
+      return true;
+    }
+    const messageClientSubmitId = message.payload?.clientSubmitId;
+    return (
+      typeof messageClientSubmitId !== "string" ||
+      messageClientSubmitId.trim() !== normalizedClientSubmitId
+    );
+  });
+  return {
+    changed: filtered.length !== messages.length,
+    messages: filtered
+  };
+}
+
 function shouldRetargetOptimisticPromptFromMessage(
   message: WorkspaceAgentActivityMessage,
   trace: AgentSubmitTraceState
@@ -6048,6 +6072,42 @@ export function useAgentGUINodeController({
     [sessionViewRef]
   );
 
+  const removeOptimisticPrompt = useCallback(
+    (agentSessionId: string, clientSubmitId: string) => {
+      const normalizedAgentSessionId = agentSessionId.trim();
+      if (!normalizedAgentSessionId || !clientSubmitId.trim()) {
+        return;
+      }
+      const sessionView = getAgentSessionView(
+        sessionViewRef(normalizedAgentSessionId)
+      );
+      if (!sessionView) {
+        return;
+      }
+      const detail = removeOptimisticPromptMessagesByClientSubmitId(
+        sessionView.detailMessages,
+        clientSubmitId
+      );
+      if (detail.changed) {
+        setAgentSessionViewDetailMessages(
+          sessionViewRef(normalizedAgentSessionId),
+          detail.messages
+        );
+      }
+      const overlay = removeOptimisticPromptMessagesByClientSubmitId(
+        sessionView.overlayMessages,
+        clientSubmitId
+      );
+      if (overlay.changed) {
+        setAgentSessionViewOverlayMessages(
+          sessionViewRef(normalizedAgentSessionId),
+          overlay.messages
+        );
+      }
+    },
+    [sessionViewRef]
+  );
+
   const applyStatePatch = useCallback(
     (patch: WorkspaceAgentActivityStatePatch) => {
       const agentSessionId = patch.agentSessionId.trim();
@@ -7246,6 +7306,13 @@ export function useAgentGUINodeController({
             }
           : current
       );
+      const pendingOptimisticTurnId = createPendingOptimisticTurnId(
+        submitTrace.clientSubmitId
+      );
+      pendingTurnIdBySessionIdRef.current = {
+        ...pendingTurnIdBySessionIdRef.current,
+        [agentSessionId]: pendingOptimisticTurnId
+      };
       applyStatePatch({
         agentSessionId,
         currentPhase: "working",
@@ -7258,11 +7325,29 @@ export function useAgentGUINodeController({
         workspaceId
       });
       let queuedPromptClaimCompleted = false;
+      const shouldRecordPendingOptimisticPrompt = queuedPromptId === undefined;
+      if (shouldRecordPendingOptimisticPrompt) {
+        recordLocalMessages(agentSessionId, [
+          createOptimisticPromptMessage({
+            workspaceId,
+            agentSessionId,
+            turnId: pendingOptimisticTurnId,
+            clientSubmitId: submitTrace.clientSubmitId,
+            userId: currentUserId?.trim() || "user",
+            prompt: submittedPromptText,
+            content: normalizedContent,
+            occurredAtUnixMs: submittedAtUnixMs
+          })
+        ]);
+        reportAgentSubmitTraceDiagnostic({
+          event: "optimistic_user_message_recorded",
+          runtime: agentActivityRuntime,
+          trace: submitTrace,
+          workspaceId
+        });
+      }
       void Promise.resolve()
         .then(() => {
-          if (!isCurrentConversation(agentSessionId)) {
-            return null;
-          }
           reportAgentSubmitTraceDiagnostic({
             event: "send_input.requested",
             runtime: agentActivityRuntime,
@@ -7279,7 +7364,7 @@ export function useAgentGUINodeController({
           });
         })
         .then((result) => {
-          if (!result || !isCurrentConversation(agentSessionId)) {
+          if (!result) {
             return;
           }
           submitTrace.turnId = result.turnId.trim() || null;
@@ -7360,24 +7445,32 @@ export function useAgentGUINodeController({
               ...pendingTurnIdBySessionIdRef.current,
               [agentSessionId]: submittedTurnId
             };
-            recordLocalMessages(agentSessionId, [
-              createOptimisticPromptMessage({
-                workspaceId,
+            if (shouldRecordPendingOptimisticPrompt) {
+              retargetOptimisticPromptTurn(
                 agentSessionId,
-                turnId: submittedTurnId,
-                clientSubmitId: submitTrace.clientSubmitId,
-                userId: currentUserId?.trim() || "user",
-                prompt: submittedPromptText,
-                content: normalizedContent,
-                occurredAtUnixMs: Date.now()
-              })
-            ]);
-            reportAgentSubmitTraceDiagnostic({
-              event: "optimistic_user_message_recorded",
-              runtime: agentActivityRuntime,
-              trace: submitTrace,
-              workspaceId
-            });
+                submitTrace.clientSubmitId,
+                submittedTurnId
+              );
+            } else {
+              recordLocalMessages(agentSessionId, [
+                createOptimisticPromptMessage({
+                  workspaceId,
+                  agentSessionId,
+                  turnId: submittedTurnId,
+                  clientSubmitId: submitTrace.clientSubmitId,
+                  userId: currentUserId?.trim() || "user",
+                  prompt: submittedPromptText,
+                  content: normalizedContent,
+                  occurredAtUnixMs: Date.now()
+                })
+              ]);
+              reportAgentSubmitTraceDiagnostic({
+                event: "optimistic_user_message_recorded",
+                runtime: agentActivityRuntime,
+                trace: submitTrace,
+                workspaceId
+              });
+            }
             scheduleAgentSubmitTracePaint({
               runtime: agentActivityRuntime,
               trace: submitTrace,
@@ -7398,6 +7491,12 @@ export function useAgentGUINodeController({
           const nextTraces = { ...submitTraceBySessionIdRef.current };
           delete nextTraces[agentSessionId];
           submitTraceBySessionIdRef.current = nextTraces;
+          if (shouldRecordPendingOptimisticPrompt) {
+            removeOptimisticPrompt(agentSessionId, submitTrace.clientSubmitId);
+          }
+          const nextPendingTurns = { ...pendingTurnIdBySessionIdRef.current };
+          delete nextPendingTurns[agentSessionId];
+          pendingTurnIdBySessionIdRef.current = nextPendingTurns;
           reportAgentSubmitTraceDiagnostic({
             event: "submit.failed",
             runtime: agentActivityRuntime,
@@ -7513,6 +7612,8 @@ export function useAgentGUINodeController({
       loadSessionState,
       refreshMessagesFromSnapshot,
       recordLocalMessages,
+      removeOptimisticPrompt,
+      retargetOptimisticPromptTurn,
       sessionViewRef,
       setTransientConversation,
       patchConversation,

--- a/packages/agent/gui/app/preload/types/globals.d.ts
+++ b/packages/agent/gui/app/preload/types/globals.d.ts
@@ -240,7 +240,10 @@ export interface AgentHostPreloadApi {
     }) => Promise<WorkspaceFileSelection[]>;
     selectContextEntries: () => Promise<WorkspaceContextSelection>;
     ensureDirectory: (payload: EnsureDirectoryInput) => Promise<void>;
-    getPathForFile: (file: File) => string;
+    getReferenceForFile?: (file: File) => {
+      kind: "file" | "folder";
+      path: string;
+    };
     readFile: (
       payload: ReadWorkspaceFileInput
     ) => Promise<ReadWorkspaceFileResult>;

--- a/packages/agent/gui/host/agentHostApi.ts
+++ b/packages/agent/gui/host/agentHostApi.ts
@@ -144,7 +144,10 @@ export type AgentHostWorkspaceApi = AgentHostRecord & {
   ) => AgentHostAsyncResult<AgentHostResolveWorkspaceGitPatchSupportResult>;
   copyPath?: (input: { path: string }) => AgentHostAsyncResult<void>;
   ensureDirectory: (input: { path: string }) => AgentHostAsyncResult<void>;
-  getPathForFile: (file: File) => string;
+  getReferenceForFile?: (file: File) => {
+    kind: "file" | "folder";
+    path: string;
+  };
   readFile: (input: {
     path: string;
   }) => AgentHostAsyncResult<AgentHostReadWorkspaceFileResult>;


### PR DESCRIPTION
## Summary
- bound desktop AgentGUI session-list loads to avoid pushing large historical session tables into AgentActivityRuntime
- filter standard ACP `session/update` notifications by provider session id before projecting timeline, command, or config state
- close ACP sessions via protocol-level `session/close` before transport cleanup, with stderr/exit diagnostics and stdin/SIGTERM/SIGKILL local process fallback

## Validation
- `git rebase --autostash origin/main`
- `pnpm check:changed --tail-lines 80`
- `go test ./packages/agent/daemon/runtime -run 'TestStandardACPIgnoresForeignProviderSessionUpdateDuringTurn|TestStandardACPAcceptsMatchingProviderSessionUpdate|TestStandardACPAdapterCloseSendsProtocolSessionCloseBeforeTransportClose|TestStandardACPAdapterCloseFallsBackWhenProtocolSessionCloseFails|TestLocalProcessTransportCloseKillsProcessAfterGracefulShutdownFails'`\n- `pnpm lint:go`\n- pre-push `pnpm check:full` passed\n\n## Documentation\n- updated AgentGUI architecture notes for bounded session-list loading\n- added troubleshooting note for AgentGUI freezes with large session history\n

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Desktop session history listing is now capped for faster large-workspace loading.
  * Added richer file-drop support by resolving dropped items into typed file/folder references, and improved paste-to-mention for non-image files.
* **Bug Fixes**
  * Optimistic user prompts are now correctly retained/re-targeted across session switches.
  * Session-update events for non-active provider sessions are ignored; assistant text projection is deduplicated.
  * Improved shutdown/close sequencing for agent connections with clearer diagnostics.
* **Documentation**
  * Expanded architecture guidance and added troubleshooting for freezing with large session history.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->