### PR TITLE
fix(agent): align Codex auto approvals reviewer

### DIFF
--- a/packages/agent/daemon/runtime/codex_appserver_adapter_test.go
+++ b/packages/agent/daemon/runtime/codex_appserver_adapter_test.go
@@ -798,12 +798,40 @@ func TestCodexAppServerAdapterStartAppliesSettingsAndPermissionMode(t *testing.T
 	if asString(threadStart["sandbox"]) != "read-only" {
 		t.Fatalf("thread/start sandbox = %q, want read-only", threadStart["sandbox"])
 	}
+	if asString(threadStart["approvalsReviewer"]) != "user" {
+		t.Fatalf("thread/start approvalsReviewer = %q, want user", threadStart["approvalsReviewer"])
+	}
 	config, _ := threadStart["config"].(map[string]any)
 	if asString(config["model_reasoning_effort"]) != "xhigh" {
 		t.Fatalf("thread/start config = %#v, want model_reasoning_effort=xhigh", config)
 	}
 	if asString(config["model_reasoning_summary"]) != "auto" {
 		t.Fatalf("thread/start config = %#v, want reasoning summaries enabled for inline review on spark", config)
+	}
+}
+
+func TestCodexAppServerAdapterStartAutoPermissionUsesAutoReviewer(t *testing.T) {
+	t.Parallel()
+
+	transport := newScriptedAppServerTransport()
+	adapter := NewCodexAppServerAdapter(transport)
+	session := testAppServerSession()
+	session.PermissionModeID = "auto"
+	session.Settings = &SessionSettings{
+		PermissionModeID: "auto",
+	}
+	if _, err := adapter.Start(context.Background(), session); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	threadStart := appServerRequestParams(t, transport.conn, appServerMethodThreadStart)
+	if asString(threadStart["approvalPolicy"]) != "on-request" {
+		t.Fatalf("thread/start approvalPolicy = %q, want on-request", threadStart["approvalPolicy"])
+	}
+	if asString(threadStart["sandbox"]) != "workspace-write" {
+		t.Fatalf("thread/start sandbox = %q, want workspace-write", threadStart["sandbox"])
+	}
+	if asString(threadStart["approvalsReviewer"]) != "auto_review" {
+		t.Fatalf("thread/start approvalsReviewer = %q, want auto_review", threadStart["approvalsReviewer"])
 	}
 }
 
@@ -1068,6 +1096,61 @@ func TestCodexAppServerAdapterExecSendsTurnOverrides(t *testing.T) {
 	sandboxPolicy, _ := turnStart["sandboxPolicy"].(map[string]any)
 	if asString(sandboxPolicy["type"]) != "dangerFullAccess" {
 		t.Fatalf("turn/start sandboxPolicy = %#v", turnStart["sandboxPolicy"])
+	}
+	if _, ok := turnStart["approvalsReviewer"]; ok {
+		t.Fatalf("turn/start approvalsReviewer = %#v, want omitted for full-access", turnStart["approvalsReviewer"])
+	}
+}
+
+func TestCodexAppServerAdapterExecReadOnlyPermissionUsesUserReviewer(t *testing.T) {
+	t.Parallel()
+
+	adapter, transport, session := startedAppServerAdapter(t)
+	session.PermissionModeID = "read-only"
+	session.Settings = &SessionSettings{
+		PermissionModeID: "read-only",
+	}
+	if _, err := adapter.Exec(context.Background(), session, []PromptContentBlock{{
+		Type: "text", Text: "go",
+	}}, "", "turn-local-1", nil, nil); err != nil {
+		t.Fatalf("Exec: %v", err)
+	}
+	turnStart := appServerRequestParams(t, transport.conn, appServerMethodTurnStart)
+	if asString(turnStart["approvalPolicy"]) != "on-request" {
+		t.Fatalf("turn/start approvalPolicy = %q, want on-request", turnStart["approvalPolicy"])
+	}
+	sandboxPolicy, _ := turnStart["sandboxPolicy"].(map[string]any)
+	if asString(sandboxPolicy["type"]) != "readOnly" {
+		t.Fatalf("turn/start sandboxPolicy = %#v", turnStart["sandboxPolicy"])
+	}
+	if asString(turnStart["approvalsReviewer"]) != "user" {
+		t.Fatalf("turn/start approvalsReviewer = %q, want user", turnStart["approvalsReviewer"])
+	}
+}
+
+func TestCodexAppServerAdapterExecAutoPermissionUsesAutoReviewer(t *testing.T) {
+	t.Parallel()
+
+	adapter, transport, session := startedAppServerAdapter(t)
+	session.PermissionModeID = "auto"
+	session.Settings = &SessionSettings{
+		PermissionModeID: "auto",
+	}
+	if _, err := adapter.Exec(context.Background(), session, []PromptContentBlock{{
+		Type: "text", Text: "go",
+	}}, "", "turn-local-1", nil, nil); err != nil {
+		t.Fatalf("Exec: %v", err)
+	}
+	turnStart := appServerRequestParams(t, transport.conn, appServerMethodTurnStart)
+	if asString(turnStart["approvalPolicy"]) != "on-request" {
+		t.Fatalf("turn/start approvalPolicy = %q, want on-request", turnStart["approvalPolicy"])
+	}
+	sandboxPolicy, _ := turnStart["sandboxPolicy"].(map[string]any)
+	if asString(sandboxPolicy["type"]) != "workspaceWrite" {
+		t.Fatalf("turn/start sandboxPolicy = %#v", turnStart["sandboxPolicy"])
+	}
+	if asString(turnStart["approvalsReviewer"]) != "auto_review" {
+		t.Fatalf("turn/start approvalsReviewer = %q, want auto_review", turnStart["approvalsReviewer"])
 	}
 }
 

--- a/packages/agent/daemon/runtime/codex_appserver_events.go
+++ b/packages/agent/daemon/runtime/codex_appserver_events.go
@@ -1048,6 +1048,9 @@ func appServerThreadStartParams(session Session, cwd string) map[string]any {
 	if sandbox := codexAppServerSandboxMode(session.PermissionModeID); sandbox != "" {
 		params["sandbox"] = sandbox
 	}
+	if approvalsReviewer := codexAppServerApprovalsReviewer(session.PermissionModeID); approvalsReviewer != "" {
+		params["approvalsReviewer"] = approvalsReviewer
+	}
 	return params
 }
 
@@ -1074,6 +1077,9 @@ func appServerTurnStartParams(session Session, threadID string, content []Prompt
 	}
 	if sandboxPolicy := codexAppServerSandboxPolicy(session.PermissionModeID); sandboxPolicy != nil {
 		params["sandboxPolicy"] = sandboxPolicy
+	}
+	if approvalsReviewer := codexAppServerApprovalsReviewer(session.PermissionModeID); approvalsReviewer != "" {
+		params["approvalsReviewer"] = approvalsReviewer
 	}
 	return params
 }
@@ -1274,6 +1280,17 @@ func codexAppServerSandboxPolicy(modeID string) map[string]any {
 		return map[string]any{"type": "dangerFullAccess"}
 	default:
 		return nil
+	}
+}
+
+func codexAppServerApprovalsReviewer(modeID string) string {
+	switch codexACPModeID(modeID) {
+	case "read-only":
+		return "user"
+	case "auto":
+		return "auto_review"
+	default:
+		return ""
 	}
 }
 


### PR DESCRIPTION
## Summary
- send approvalsReviewer auto_review for Codex app-server permissionModeId=auto on both thread/start and turn/start
- keep read-only and full-access reviewer behavior unchanged
- add app-server tests for auto mode and reviewer omission on other permission modes

## Tests
- go test ./packages/agent/daemon/runtime -run TestCodexAppServerAdapter|TestCodexAppServer
- go test ./services/tuttid/service/agent
- pnpm lint:go
- pre-push pnpm check:full

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Start requests now include the appropriate approval reviewer based on permission mode, improving how approval flows are routed.
  * Automatic mode now uses an auto-review path, while read-only mode routes approvals to the user.

* **Bug Fixes**
  * Ensured approval-related settings are applied consistently across session start and execution flows.
  * Confirmed full-access mode does not send approval reviewer details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->