### PR TITLE
[codex] Customize predefine pageview timing

### DIFF
--- a/apps/desktop/src/renderer/src/features/analytics/services/internal/predefinePageviewAnalytics.test.ts
+++ b/apps/desktop/src/renderer/src/features/analytics/services/internal/predefinePageviewAnalytics.test.ts
@@ -7,18 +7,17 @@ import {
   type PredefinePageviewAnalyticsStorage
 } from "./predefinePageviewAnalytics.ts";
 
-test("predefine pageview analytics reports once for a visible local day", () => {
+test("predefine pageview analytics reports when the app opens", () => {
   const reporterCalls: ReporterEventInput[][] = [];
   const runtime = createRuntimeHarness();
   const storage = createStorageHarness();
-  const analytics = startPredefinePageviewAnalytics({
+
+  startPredefinePageviewAnalytics({
     reporterService: createReporterService(reporterCalls),
     reporterNow: () => runtime.now(),
     runtime,
     storage
   });
-
-  analytics.reportToday();
 
   assert.deepEqual(reporterCalls, [
     [
@@ -30,11 +29,11 @@ test("predefine pageview analytics reports once for a visible local day", () => 
   ]);
 });
 
-test("predefine pageview analytics skips a day already reported by another window", () => {
+test("predefine pageview analytics reports app opens even after a focus report that day", () => {
   const reporterCalls: ReporterEventInput[][] = [];
   const runtime = createRuntimeHarness();
   const storage = createStorageHarness({
-    reportedDay: "2026-06-09"
+    focusedDay: "2026-06-09"
   });
 
   startPredefinePageviewAnalytics({
@@ -44,14 +43,19 @@ test("predefine pageview analytics skips a day already reported by another windo
     storage
   });
 
-  assert.deepEqual(reporterCalls, []);
+  assert.deepEqual(reporterCalls, [
+    [
+      {
+        clientTS: runtime.now(),
+        name: "predefine_pageview"
+      }
+    ]
+  ]);
 });
 
-test("predefine pageview analytics reports when a resident app crosses local day", () => {
+test("predefine pageview analytics reports explicit focus once per local day", () => {
   const reporterCalls: ReporterEventInput[][] = [];
-  const runtime = createRuntimeHarness({
-    now: new Date(2026, 5, 9, 23, 59, 50).getTime()
-  });
+  const runtime = createRuntimeHarness();
   const storage = createStorageHarness();
 
   startPredefinePageviewAnalytics({
@@ -60,17 +64,16 @@ test("predefine pageview analytics reports when a resident app crosses local day
     runtime,
     storage
   });
-  runtime.advanceTo(new Date(2026, 5, 10, 0, 0, 0).getTime());
-  runtime.flushDueTimers();
+  runtime.emitFocus();
+  runtime.emitFocus();
 
-  assert.equal(reporterCalls.length, 2);
   assert.deepEqual(
     reporterCalls.map((call) => call[0]?.name),
     ["predefine_pageview", "predefine_pageview"]
   );
 });
 
-test("predefine pageview analytics reports a new day on foreground restore", () => {
+test("predefine pageview analytics reports explicit focus again on a new local day", () => {
   const reporterCalls: ReporterEventInput[][] = [];
   const runtime = createRuntimeHarness();
   const storage = createStorageHarness();
@@ -81,13 +84,14 @@ test("predefine pageview analytics reports a new day on foreground restore", () 
     runtime,
     storage
   });
-  runtime.visibilityState = "hidden";
-  runtime.emitVisibilityChange();
+  runtime.emitFocus();
   runtime.advanceTo(new Date(2026, 5, 10, 10, 0, 0).getTime());
-  runtime.visibilityState = "visible";
-  runtime.emitVisibilityChange();
+  runtime.emitFocus();
 
-  assert.equal(reporterCalls.length, 2);
+  assert.deepEqual(
+    reporterCalls.map((call) => call[0]?.name),
+    ["predefine_pageview", "predefine_pageview", "predefine_pageview"]
+  );
 });
 
 function createReporterService(calls: ReporterEventInput[][] = []) {
@@ -100,70 +104,41 @@ function createReporterService(calls: ReporterEventInput[][] = []) {
 
 function createRuntimeHarness(input: { now?: number } = {}) {
   let now = input.now ?? new Date(2026, 5, 9, 10, 0, 0).getTime();
-  const visibilityListeners = new Set<() => void>();
-  const timers: Array<{ active: boolean; dueAt: number; task: () => void }> =
-    [];
+  const focusListeners = new Set<() => void>();
   const runtime: PredefinePageviewAnalyticsRuntime & {
     advanceTo(nextNow: number): void;
-    emitVisibilityChange(): void;
-    flushDueTimers(): void;
+    emitFocus(): void;
     now(): number;
-    visibilityState: DocumentVisibilityState;
   } = {
-    visibilityState: "visible",
-    addVisibilityChangeListener(listener) {
-      visibilityListeners.add(listener);
+    addFocusListener(listener) {
+      focusListeners.add(listener);
       return () => {
-        visibilityListeners.delete(listener);
+        focusListeners.delete(listener);
       };
     },
     advanceTo(nextNow) {
       now = nextNow;
     },
-    clearTimeout(handle) {
-      const timer = handle as { active: boolean };
-      timer.active = false;
-    },
-    emitVisibilityChange() {
-      for (const listener of [...visibilityListeners]) {
+    emitFocus() {
+      for (const listener of [...focusListeners]) {
         listener();
       }
     },
-    flushDueTimers() {
-      for (const timer of timers) {
-        if (timer.active && timer.dueAt <= now) {
-          timer.active = false;
-          timer.task();
-        }
-      }
-    },
-    getVisibilityState() {
-      return runtime.visibilityState;
-    },
     now() {
       return now;
-    },
-    setTimeout(task, delayMs) {
-      const timer = {
-        active: true,
-        dueAt: now + delayMs,
-        task
-      };
-      timers.push(timer);
-      return timer;
     }
   };
   return runtime;
 }
 
-function createStorageHarness(input: { reportedDay?: string } = {}) {
-  let reportedDay = input.reportedDay ?? null;
+function createStorageHarness(input: { focusedDay?: string } = {}) {
+  let focusedDay = input.focusedDay ?? null;
   return {
-    getReportedDay() {
-      return reportedDay;
+    getFocusedDay() {
+      return focusedDay;
     },
-    setReportedDay(dayKey) {
-      reportedDay = dayKey;
+    setFocusedDay(dayKey) {
+      focusedDay = dayKey;
     }
   } satisfies PredefinePageviewAnalyticsStorage;
 }

--- a/apps/desktop/src/renderer/src/features/analytics/services/internal/predefinePageviewAnalytics.ts
+++ b/apps/desktop/src/renderer/src/features/analytics/services/internal/predefinePageviewAnalytics.ts
@@ -1,23 +1,21 @@
 import { PredefinePageviewReporter } from "../../reporters/predefine-pageview/predefinePageviewReporter.ts";
 import type { IReporterService } from "../reporterService.interface.ts";
 
-const reportedDayStorageKey = "tutti.analytics.predefine_pageview.reported_day";
+const focusedDayStorageKey = "tutti.analytics.predefine_pageview.focused_day";
 
 export interface PredefinePageviewAnalyticsController {
   dispose(): void;
-  reportToday(): void;
+  reportAppOpen(): void;
+  reportFocus(): void;
 }
 
 export interface PredefinePageviewAnalyticsRuntime {
-  addVisibilityChangeListener(listener: () => void): () => void;
-  clearTimeout(handle: unknown): void;
-  getVisibilityState(): DocumentVisibilityState;
-  setTimeout(task: () => void, delayMs: number): unknown;
+  addFocusListener(listener: () => void): () => void;
 }
 
 export interface PredefinePageviewAnalyticsStorage {
-  getReportedDay(): string | null;
-  setReportedDay(dayKey: string): void;
+  getFocusedDay(): string | null;
+  setFocusedDay(dayKey: string): void;
 }
 
 export function startPredefinePageviewAnalytics(input: {
@@ -30,47 +28,36 @@ export function startPredefinePageviewAnalytics(input: {
   const storage = input.storage ?? createLocalStoragePredefinePageviewStorage();
   const now = input.reporterNow ?? Date.now;
   let disposed = false;
-  let nextDayTimer: unknown = null;
 
-  const reportToday = () => {
-    if (disposed || runtime.getVisibilityState() !== "visible") {
+  const reportPageview = () => {
+    if (disposed) {
       return;
     }
-    const dayKey = toLocalDayKey(now());
-    if (storage.getReportedDay() === dayKey) {
-      return;
-    }
-    storage.setReportedDay(dayKey);
     void new PredefinePageviewReporter({
       now,
       reporterService: input.reporterService
     }).report();
   };
 
-  const scheduleNextDayReport = () => {
-    clearNextDayReport();
+  const reportAppOpen = () => {
+    reportPageview();
+  };
+
+  const reportFocus = () => {
     if (disposed) {
       return;
     }
-    nextDayTimer = runtime.setTimeout(
-      () => {
-        nextDayTimer = null;
-        reportToday();
-        scheduleNextDayReport();
-      },
-      Math.max(1, nextLocalDayStart(now()) - now())
-    );
+    const dayKey = toLocalDayKey(now());
+    if (storage.getFocusedDay() === dayKey) {
+      return;
+    }
+    storage.setFocusedDay(dayKey);
+    reportPageview();
   };
 
-  const unsubscribeVisibility = runtime.addVisibilityChangeListener(() => {
-    if (runtime.getVisibilityState() === "visible") {
-      reportToday();
-      scheduleNextDayReport();
-    }
-  });
+  const unsubscribeFocus = runtime.addFocusListener(reportFocus);
 
-  reportToday();
-  scheduleNextDayReport();
+  reportAppOpen();
 
   return {
     dispose() {
@@ -78,19 +65,11 @@ export function startPredefinePageviewAnalytics(input: {
         return;
       }
       disposed = true;
-      unsubscribeVisibility();
-      clearNextDayReport();
+      unsubscribeFocus();
     },
-    reportToday
+    reportAppOpen,
+    reportFocus
   };
-
-  function clearNextDayReport(): void {
-    if (nextDayTimer === null) {
-      return;
-    }
-    runtime.clearTimeout(nextDayTimer);
-    nextDayTimer = null;
-  }
 }
 
 function toLocalDayKey(timestamp: number): string {
@@ -102,49 +81,29 @@ function toLocalDayKey(timestamp: number): string {
   ].join("-");
 }
 
-function nextLocalDayStart(timestamp: number): number {
-  const date = new Date(timestamp);
-  return new Date(
-    date.getFullYear(),
-    date.getMonth(),
-    date.getDate() + 1
-  ).getTime();
-}
-
 function createDocumentPredefinePageviewRuntime(): PredefinePageviewAnalyticsRuntime {
   return {
-    addVisibilityChangeListener(listener) {
-      document.addEventListener("visibilitychange", listener);
+    addFocusListener(listener) {
+      window.addEventListener("focus", listener);
       return () => {
-        document.removeEventListener("visibilitychange", listener);
+        window.removeEventListener("focus", listener);
       };
-    },
-    clearTimeout(handle) {
-      globalThis.clearTimeout(
-        handle as ReturnType<typeof globalThis.setTimeout>
-      );
-    },
-    getVisibilityState() {
-      return document.visibilityState;
-    },
-    setTimeout(task, delayMs) {
-      return globalThis.setTimeout(task, delayMs);
     }
   };
 }
 
 function createLocalStoragePredefinePageviewStorage(): PredefinePageviewAnalyticsStorage {
   return {
-    getReportedDay() {
+    getFocusedDay() {
       try {
-        return globalThis.localStorage.getItem(reportedDayStorageKey);
+        return globalThis.localStorage.getItem(focusedDayStorageKey);
       } catch {
         return null;
       }
     },
-    setReportedDay(dayKey) {
+    setFocusedDay(dayKey) {
       try {
-        globalThis.localStorage.setItem(reportedDayStorageKey, dayKey);
+        globalThis.localStorage.setItem(focusedDayStorageKey, dayKey);
       } catch {
         // Storage is only a dedupe aid; analytics remains best-effort.
       }


### PR DESCRIPTION
## Summary
- Report `predefine_pageview` immediately when the Tutti workspace renderer opens.
- Report another `predefine_pageview` when the user explicitly focuses/activates Tutti, deduped to once per local day.
- Replace the previous visibility/timer based daily pageview behavior with focus-day storage.

## Validation
- `node --import ./test/register-asset-stub.mjs --test --experimental-strip-types ./src/renderer/src/features/analytics/services/internal/predefinePageviewAnalytics.test.ts`
- `pnpm --filter @tutti-os/desktop typecheck`
- `pnpm check:full` via pre-push


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved pageview tracking so app opens and window focus events are counted more reliably.
  * Prevented duplicate focus-related reports within the same day while still allowing new daily reporting after a day change.
  * Kept reporting consistent when restoring the app to the foreground across day boundaries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->