### PR TITLE
fix(agent-gui): preserve file names in path labels

### DIFF
--- a/packages/agent/gui/app/renderer/agentactivity.css
+++ b/packages/agent/gui/app/renderer/agentactivity.css
@@ -1497,6 +1497,46 @@ aside.workspace-agents-status-panel
   color: var(--agent-turn-summary-path);
 }
 
+.agent-turn-summary-card__path-directory,
+.agent-turn-summary-card__path-file {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.agent-turn-summary-card__path-directory {
+  flex: 0 1 auto;
+}
+
+.agent-turn-summary-card__path-file {
+  flex: 0 0 auto;
+  max-width: 100%;
+}
+
+.agent-path-tail-label {
+  display: flex;
+  min-width: 0;
+  max-width: 100%;
+  overflow: hidden;
+  white-space: nowrap;
+}
+
+.agent-path-tail-label__directory,
+.agent-path-tail-label__file {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.agent-path-tail-label__directory {
+  flex: 0 1 auto;
+}
+
+.agent-path-tail-label__file {
+  flex: 0 0 auto;
+  max-width: 100%;
+}
+
 .workspace-agents-status-panel__detail-turn-summary
   .workspace-agents-status-panel__detail-tool-diff-added {
   color: var(--state-success);

--- a/packages/agent/gui/shared/agentConversation/components/AgentTranscriptItemView.spec.tsx
+++ b/packages/agent/gui/shared/agentConversation/components/AgentTranscriptItemView.spec.tsx
@@ -18,6 +18,7 @@ const mockState = vi.hoisted(() => ({
 }));
 
 vi.mock("../../../i18n/index", () => ({
+  getActiveUiLanguage: () => "en",
   useTranslation: () => ({
     t: (key: string) => key
   }),
@@ -267,10 +268,10 @@ describe("AgentTranscriptItemView render stability", () => {
       /\.agent-gui-conversation__message-group::after\s*{[^}]*top:\s*100%[^}]*right:\s*0[^}]*left:\s*0[^}]*height:\s*26px/s
     );
     expect(css).toMatch(
-      /\.agent-gui-conversation__message-group:has\(\s*> \.agent-gui-conversation__message-copy-button\s*\)\s*{[^}]*margin-bottom:\s*26px/s
+      /\.agent-gui-conversation__message-group:has\(\s*> \.agent-gui-conversation__message-footer\s*\)\s*{[^}]*margin-bottom:\s*26px/s
     );
     expect(css).toMatch(
-      /\.agent-gui-conversation__message-group:hover[\s\S]*?> \.agent-gui-conversation__message-copy-button,[\s\S]*?\.agent-gui-conversation__message-group:focus-within[\s\S]*?> \.agent-gui-conversation__message-copy-button\s*{[^}]*opacity:\s*1[^}]*pointer-events:\s*auto/s
+      /\.agent-gui-conversation__message-group:hover[\s\S]*?> \.agent-gui-conversation__message-footer,[\s\S]*?\.agent-gui-conversation__message-group:focus-within[\s\S]*?> \.agent-gui-conversation__message-footer\s*{[^}]*opacity:\s*1[^}]*pointer-events:\s*auto/s
     );
     expect(css).not.toMatch(
       /\.agent-gui-conversation__message-group::after\s*{[^}]*height:\s*10px/s
@@ -281,7 +282,10 @@ describe("AgentTranscriptItemView render stability", () => {
     const css = readFileSync(resolve("app/renderer/agentactivity.css"), "utf8");
 
     expect(css).toMatch(
-      /\.agent-gui-conversation__message-copy-button\s*{[^}]*top:\s*calc\(100% \+ 4px\)[^}]*width:\s*22px[^}]*min-width:\s*22px[^}]*height:\s*22px[^}]*min-height:\s*22px[^}]*border-radius:\s*5px/s
+      /\.agent-gui-conversation__message-footer\s*{[^}]*top:\s*calc\(100% \+ 4px\)/s
+    );
+    expect(css).toMatch(
+      /\.agent-gui-conversation__message-copy-button\s*{[^}]*position:\s*static[^}]*width:\s*22px[^}]*min-width:\s*22px[^}]*height:\s*22px[^}]*min-height:\s*22px[^}]*border-radius:\s*5px/s
     );
     expect(css).not.toMatch(
       /\.agent-gui-conversation__message-copy-button\s*{[^}]*width:\s*28px/s
@@ -290,7 +294,7 @@ describe("AgentTranscriptItemView render stability", () => {
       /\.agent-gui-conversation__message-copy-button\s*{[^}]*top:\s*calc\(100% \+ 8px\)/s
     );
     expect(css).not.toMatch(
-      /\.agent-gui-conversation__message-group:has\(\s*> \.agent-gui-conversation__message-copy-button\s*\)\s*{[^}]*margin-bottom:\s*36px/s
+      /\.agent-gui-conversation__message-group:has\(\s*> \.agent-gui-conversation__message-footer\s*\)\s*{[^}]*margin-bottom:\s*36px/s
     );
   });
 
@@ -516,7 +520,7 @@ describe("AgentTranscriptItemView render stability", () => {
       /\.workspace-agents-status-panel__detail-user-message\.agent-gui-conversation__user-message-bubble\s*{[^}]*font-size:\s*13px/s
     );
     expect(css).toMatch(
-      /\.agent-gui-conversation__message-copy-button\s*{[^}]*position:\s*absolute[^}]*opacity:\s*0/s
+      /\.agent-gui-conversation__message-copy-button\s*{[^}]*position:\s*static[^}]*opacity:\s*0/s
     );
     expect(messageBlockSource).toContain("CanvasNodeGhostIconButton");
     expect(css).toMatch(
@@ -568,6 +572,21 @@ describe("AgentTranscriptItemView render stability", () => {
     );
     expect(css).toMatch(
       /\.workspace-agents-status-panel__detail-tool-diff-removed\s*{[^}]*color:\s*var\(--state-danger\)/s
+    );
+    expect(css).toMatch(
+      /\.agent-turn-summary-card__path-directory\s*{[^}]*flex:\s*0 1 auto/s
+    );
+    expect(css).toMatch(
+      /\.agent-turn-summary-card__path-file\s*{[^}]*flex:\s*0 0 auto[^}]*max-width:\s*100%/s
+    );
+    expect(css).toMatch(
+      /\.agent-path-tail-label\s*{[^}]*display:\s*flex[^}]*overflow:\s*hidden[^}]*white-space:\s*nowrap/s
+    );
+    expect(css).toMatch(
+      /\.agent-path-tail-label__directory\s*{[^}]*flex:\s*0 1 auto/s
+    );
+    expect(css).toMatch(
+      /\.agent-path-tail-label__file\s*{[^}]*flex:\s*0 0 auto[^}]*max-width:\s*100%/s
     );
   });
 

--- a/packages/agent/gui/shared/agentConversation/components/AgentTranscriptView.spec.tsx
+++ b/packages/agent/gui/shared/agentConversation/components/AgentTranscriptView.spec.tsx
@@ -952,8 +952,8 @@ describe("AgentTranscriptView", () => {
       })
     );
     await flushCollapsibleRevealFrames();
-    expect(screen.getByText("src/App.tsx")).toBeTruthy();
-    expect(screen.getByText("src/routes.ts")).toBeTruthy();
+    expect(screen.getByTitle("src/App.tsx")).toBeTruthy();
+    expect(screen.getByTitle("src/routes.ts")).toBeTruthy();
   });
 
   it("renders visible agent errors as an alert with collapsible details", async () => {

--- a/packages/agent/gui/shared/agentConversation/components/AgentTurnSummaryRow.spec.tsx
+++ b/packages/agent/gui/shared/agentConversation/components/AgentTurnSummaryRow.spec.tsx
@@ -1037,7 +1037,7 @@ describe("AgentTurnSummaryRow", () => {
       />
     );
 
-    expect(screen.queryByText("src/file-4.ts")).toBeNull();
+    expect(screen.queryByTitle("src/file-4.ts")).toBeNull();
 
     fireEvent.click(
       screen.getByRole("button", {
@@ -1046,10 +1046,10 @@ describe("AgentTurnSummaryRow", () => {
     );
 
     await waitFor(() => {
-      expect(screen.getByText("src/file-4.ts")).toBeTruthy();
+      expect(screen.getByTitle("src/file-4.ts")).toBeTruthy();
     });
     expect(
-      screen.getByText("src/file-4.ts").closest(".agent-collapsible-reveal")
+      screen.getByTitle("src/file-4.ts").closest(".agent-collapsible-reveal")
     ).toHaveAttribute("data-expanded", "true");
     expect(
       screen.getByRole("button", {
@@ -1199,7 +1199,7 @@ describe("AgentTurnSummaryRow", () => {
 
     expect(screen.getAllByText("-1")).toHaveLength(2);
     expect(screen.queryByText("+1")).toBeNull();
-    expect(screen.getByText("/workspace/a.md").className).toContain(
+    expect(screen.getByTitle("/workspace/a.md").className).toContain(
       "line-through"
     );
 
@@ -1244,6 +1244,12 @@ describe("AgentTurnSummaryRow", () => {
     const pathLabel = screen.getByTitle(
       "/workspace/very/deep/path/to/a/file/with/a/really-long-name/today_news_summary_2026-05-20.txt"
     );
+    const directoryLabel = pathLabel.querySelector(
+      ".agent-turn-summary-card__path-directory"
+    );
+    const fileNameLabel = pathLabel.querySelector(
+      ".agent-turn-summary-card__path-file"
+    );
     const pathToggle = pathLabel.closest("button");
     const pathContainer = pathLabel.parentElement;
     const fileRow = pathToggle?.closest(".agent-turn-summary-card__file");
@@ -1251,9 +1257,22 @@ describe("AgentTurnSummaryRow", () => {
       .getByText("agentHost.agentGui.turnSummaryFilesChanged:1")
       .closest("section");
 
-    expect(pathLabel.className).toContain("truncate");
-    expect(pathLabel.className).toContain("block");
+    expect(pathLabel.className).toContain("flex");
     expect(pathLabel.className).toContain("min-w-0");
+    expect(pathLabel.className).toContain("overflow-hidden");
+    expect(pathLabel.className).toContain("whitespace-nowrap");
+    expect(directoryLabel?.textContent).toBe(
+      "/workspace/very/deep/path/to/a/file/with/a/really-long-name/"
+    );
+    expect(directoryLabel?.className).toContain(
+      "agent-turn-summary-card__path-directory"
+    );
+    expect(fileNameLabel?.textContent).toBe(
+      "today_news_summary_2026-05-20.txt"
+    );
+    expect(fileNameLabel?.className).toContain(
+      "agent-turn-summary-card__path-file"
+    );
     expect(pathContainer?.className).toContain("flex-1");
     expect(pathContainer?.className).toContain("overflow-hidden");
     expect(pathToggle?.className).toContain("flex-1");

--- a/packages/agent/gui/shared/agentConversation/components/AgentTurnSummaryRow.tsx
+++ b/packages/agent/gui/shared/agentConversation/components/AgentTurnSummaryRow.tsx
@@ -415,12 +415,19 @@ function TurnSummaryFileCard({
           >
             <div className="min-w-0 flex-1 overflow-hidden">
               <span
-                className={`agent-turn-summary-card__path block min-w-0 truncate text-[13px] font-medium leading-5 text-[var(--text-secondary)] ${
+                className={`agent-turn-summary-card__path flex min-w-0 max-w-full overflow-hidden whitespace-nowrap text-[13px] font-medium leading-5 text-[var(--text-secondary)] ${
                   file.changeType === "deleted" ? "line-through" : ""
                 }`}
                 title={file.path}
               >
-                {file.path}
+                {file.directory ? (
+                  <span className="agent-turn-summary-card__path-directory">
+                    {file.directory}/
+                  </span>
+                ) : null}
+                <span className="agent-turn-summary-card__path-file">
+                  {file.fileName}
+                </span>
               </span>
             </div>
             <span className="shrink-0 text-[var(--text-tertiary)] opacity-0 transition-opacity group-hover/file-toggle:opacity-100 group-focus-visible/file-toggle:opacity-100">

--- a/packages/agent/gui/shared/agentConversation/components/tool-renderers/AgentExpandedToolContent.spec.tsx
+++ b/packages/agent/gui/shared/agentConversation/components/tool-renderers/AgentExpandedToolContent.spec.tsx
@@ -167,9 +167,13 @@ describe("AgentExpandedToolContent", () => {
     fireEvent.click(stepButton);
     await flushCollapsibleRevealFrames();
 
+    const pathLabel = screen.getByTitle("/workspace/src/agent.ts");
     expect(
-      screen.getAllByText("/workspace/src/agent.ts").length
-    ).toBeGreaterThan(0);
+      pathLabel.querySelector(".agent-path-tail-label__directory")?.textContent
+    ).toBe("/workspace/src/");
+    expect(
+      pathLabel.querySelector(".agent-path-tail-label__file")?.textContent
+    ).toBe("agent.ts");
     expect(
       screen.getAllByText("Loaded agent conversation contract.").length
     ).toBeGreaterThan(0);
@@ -250,9 +254,13 @@ describe("AgentExpandedToolContent", () => {
       />
     );
 
-    expect(screen.getAllByText("/workspace/src/app.ts").length).toBeGreaterThan(
-      0
-    );
+    const pathLabel = screen.getByTitle("/workspace/src/app.ts");
+    expect(
+      pathLabel.querySelector(".agent-path-tail-label__directory")?.textContent
+    ).toBe("/workspace/src/");
+    expect(
+      pathLabel.querySelector(".agent-path-tail-label__file")?.textContent
+    ).toBe("app.ts");
     expect(screen.getByText(/typescript/i)).toBeTruthy();
     expect(screen.getByText(/1 lines/i)).toBeTruthy();
     expect(screen.getByText("const app = true")).toBeTruthy();
@@ -277,7 +285,13 @@ describe("AgentExpandedToolContent", () => {
       />
     );
 
-    expect(screen.getByText("/workspace/src/app.ts")).toBeTruthy();
+    const pathLabel = screen.getByTitle("/workspace/src/app.ts");
+    expect(
+      pathLabel.querySelector(".agent-path-tail-label__directory")?.textContent
+    ).toBe("/workspace/src/");
+    expect(
+      pathLabel.querySelector(".agent-path-tail-label__file")?.textContent
+    ).toBe("app.ts");
     expect(screen.getByText(/L2-4/i)).toBeTruthy();
     expect(screen.getByText(/10 lines/i)).toBeTruthy();
     expect(screen.queryByText("const app = true")).toBeNull();

--- a/packages/agent/gui/shared/agentConversation/components/tool-renderers/AgentPathTailLabel.spec.tsx
+++ b/packages/agent/gui/shared/agentConversation/components/tool-renderers/AgentPathTailLabel.spec.tsx
@@ -1,0 +1,33 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { AgentPathTailLabel } from "./AgentPathTailLabel";
+
+describe("AgentPathTailLabel", () => {
+  it("splits a path so the directory can shrink before the file name", () => {
+    render(
+      <AgentPathTailLabel
+        path="/workspace/very/deep/path/manifest.json"
+        fallback="File"
+      />
+    );
+
+    const label = screen.getByTitle("/workspace/very/deep/path/manifest.json");
+    const directory = label.querySelector(".agent-path-tail-label__directory");
+    const fileName = label.querySelector(".agent-path-tail-label__file");
+
+    expect(label.className).toContain("agent-path-tail-label");
+    expect(directory?.textContent).toBe("/workspace/very/deep/path/");
+    expect(fileName?.textContent).toBe("manifest.json");
+  });
+
+  it("renders unsplittable labels as the file segment", () => {
+    render(<AgentPathTailLabel path={null} fallback="Code" />);
+
+    const fileName = screen.getByText("Code");
+
+    expect(fileName.className).toContain("agent-path-tail-label__file");
+    expect(
+      fileName.closest(".agent-path-tail-label")?.getAttribute("title")
+    ).toBeNull();
+  });
+});

--- a/packages/agent/gui/shared/agentConversation/components/tool-renderers/AgentPathTailLabel.tsx
+++ b/packages/agent/gui/shared/agentConversation/components/tool-renderers/AgentPathTailLabel.tsx
@@ -1,0 +1,55 @@
+import type { JSX } from "react";
+
+interface AgentPathTailLabelProps {
+  path?: string | null;
+  fallback: string;
+  className?: string;
+}
+
+export function AgentPathTailLabel({
+  path,
+  fallback,
+  className
+}: AgentPathTailLabelProps): JSX.Element {
+  "use memo";
+  const label = path?.trim() || fallback;
+  const parts = splitPathTail(label);
+
+  if (!parts) {
+    return (
+      <span
+        className={`agent-path-tail-label ${className ?? ""}`}
+        title={path ?? undefined}
+      >
+        <span className="agent-path-tail-label__file">{label}</span>
+      </span>
+    );
+  }
+
+  return (
+    <span
+      className={`agent-path-tail-label ${className ?? ""}`}
+      title={path ?? undefined}
+    >
+      <span className="agent-path-tail-label__directory">
+        {parts.directory}
+      </span>
+      <span className="agent-path-tail-label__file">{parts.fileName}</span>
+    </span>
+  );
+}
+
+function splitPathTail(
+  value: string
+): { directory: string; fileName: string } | null {
+  const lastForwardSlash = value.lastIndexOf("/");
+  const lastBackwardSlash = value.lastIndexOf("\\");
+  const lastSeparator = Math.max(lastForwardSlash, lastBackwardSlash);
+  if (lastSeparator <= 0 || lastSeparator === value.length - 1) {
+    return null;
+  }
+  return {
+    directory: value.slice(0, lastSeparator + 1),
+    fileName: value.slice(lastSeparator + 1)
+  };
+}

--- a/packages/agent/gui/shared/agentConversation/components/tool-renderers/AgentReadContent.tsx
+++ b/packages/agent/gui/shared/agentConversation/components/tool-renderers/AgentReadContent.tsx
@@ -5,6 +5,7 @@ import {
   stringValue,
   type AgentToolRendererProps
 } from "./agentToolContentShared";
+import { AgentPathTailLabel } from "./AgentPathTailLabel";
 
 export function AgentReadContent({
   call
@@ -39,9 +40,11 @@ export function AgentReadContent({
       ) : path || fileLineRange || fileTotalLines !== null ? (
         <div className="rounded-[8px] border border-[var(--line-2)] bg-[var(--background-panel)] px-3 py-2">
           {path ? (
-            <div className="font-[var(--tsh-font-mono)] text-[11px] text-[var(--text-secondary)]">
-              {path}
-            </div>
+            <AgentPathTailLabel
+              path={path}
+              fallback="File"
+              className="font-[var(--tsh-font-mono)] text-[11px] text-[var(--text-secondary)]"
+            />
           ) : null}
           {fileLineRange || fileTotalLines !== null ? (
             <div className="mt-1 text-[11px] text-[var(--text-secondary)]">

--- a/packages/agent/gui/shared/agentConversation/components/tool-renderers/code/AgentCodeBlock.tsx
+++ b/packages/agent/gui/shared/agentConversation/components/tool-renderers/code/AgentCodeBlock.tsx
@@ -1,5 +1,6 @@
 import { useMemo, useState, type JSX } from "react";
 import { translate } from "../../../../../i18n/index";
+import { AgentPathTailLabel } from "../AgentPathTailLabel";
 
 const MAX_VISIBLE_LINES = 120;
 
@@ -102,9 +103,11 @@ export function AgentCodeBlock({
         <>
           {showHeader ? (
             <div className="flex items-center justify-between gap-3 border-b border-[var(--line-2)] bg-[var(--transparency-block)] px-3 py-1.5 text-[11px] text-[var(--text-secondary)]">
-              <span className="truncate font-[var(--tsh-font-mono)]">
-                {path || "Code"}
-              </span>
+              <AgentPathTailLabel
+                path={path}
+                fallback="Code"
+                className="font-[var(--tsh-font-mono)]"
+              />
               <span className="shrink-0">
                 {language ? `${language} · ` : ""}
                 {lineCount} lines

--- a/packages/agent/gui/shared/agentConversation/components/tool-renderers/file-diff/AgentMonacoDiffViewer.tsx
+++ b/packages/agent/gui/shared/agentConversation/components/tool-renderers/file-diff/AgentMonacoDiffViewer.tsx
@@ -1,6 +1,7 @@
 import { lazy, Suspense, type JSX } from "react";
 import { AtomIcon } from "../../../../../app/renderer/components/icons/AtomIcon";
 import { translate } from "../../../../../i18n/index";
+import { AgentPathTailLabel } from "../AgentPathTailLabel";
 
 const MonacoDiffEditor = lazy(async () => {
   const module = await import("@monaco-editor/react");
@@ -32,7 +33,11 @@ export function AgentMonacoDiffViewer({
           className="border-b border-[var(--line-2)] bg-[var(--transparency-block)] px-3 py-1.5 text-[11px] text-[var(--text-secondary)]"
           data-agent-diff-header="true"
         >
-          {path || "Diff"}
+          <AgentPathTailLabel
+            path={path}
+            fallback="Diff"
+            className="font-[var(--tsh-font-mono)]"
+          />
         </div>
       ) : null}
       <div className="h-[220px] bg-[var(--background-panel)]">

--- a/packages/agent/gui/shared/agentConversation/components/tool-renderers/file-diff/AgentUnifiedPatchViewer.tsx
+++ b/packages/agent/gui/shared/agentConversation/components/tool-renderers/file-diff/AgentUnifiedPatchViewer.tsx
@@ -1,6 +1,7 @@
 import { useMemo, useState, type JSX } from "react";
 import { translate } from "../../../../../i18n/index";
 import { AgentToolScrollArea } from "../AgentToolScrollArea";
+import { AgentPathTailLabel } from "../AgentPathTailLabel";
 import {
   parseAgentUnifiedDiffLines,
   parseAgentUnifiedDiffStats
@@ -132,7 +133,11 @@ export function AgentUnifiedPatchViewer({
               className="border-b border-[var(--line-2)] bg-[var(--transparency-block)] px-3 py-1.5 text-[11px] text-[var(--text-secondary)]"
               data-agent-diff-header="true"
             >
-              {path || "Patch"}
+              <AgentPathTailLabel
+                path={path}
+                fallback="Patch"
+                className="font-[var(--tsh-font-mono)]"
+              />
             </div>
           ) : null}
           <AgentToolScrollArea viewportClassName="agent-tool-diff__viewport px-4 py-3 text-[11px] leading-5">


### PR DESCRIPTION
## Summary
- split AgentGUI changed-file paths into directory and filename spans so filenames stay visible as rows narrow
- add reusable AgentPathTailLabel for tool detail file headers and read fallback paths
- update focused tests and CSS assertions for path-tail layout

## Tests
- pnpm --filter @tutti-os/agent-gui exec vitest run --environment jsdom shared/agentConversation/components/tool-renderers/AgentPathTailLabel.spec.tsx shared/agentConversation/components/tool-renderers/AgentExpandedToolContent.spec.tsx shared/agentConversation/components/AgentTranscriptItemView.spec.tsx shared/agentConversation/components/AgentTurnSummaryRow.spec.tsx shared/agentConversation/components/AgentTranscriptView.spec.tsx
- pnpm --filter @tutti-os/agent-gui typecheck
- pnpm check:changed --tail-lines 80
- pnpm check:full (pre-push)

## Documentation
- No durable docs updated; this is an internal AgentGUI presentation/styling change with no API, data-flow, or ownership change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * File paths in agent views now display in a more compact, readable format by splitting long paths into directory and filename parts.
  * Path labels now appear consistently in file content, code, and diff headers.

* **Bug Fixes**
  * Long paths now truncate correctly with ellipses and fit within their containers.
  * Path labels keep their tooltip/title behavior while improving layout in narrow views.

* **Tests**
  * Updated and added coverage for the new path rendering and truncation behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->