### PR TITLE
fix(desktop): guard app quit while agents run

### DIFF
--- a/apps/desktop/src/main/bootstrap.ts
+++ b/apps/desktop/src/main/bootstrap.ts
@@ -29,6 +29,7 @@ import { ensureSingleInstance } from "./singleInstance";
 import { getSystemDesktopLocale } from "./desktopLocale";
 import { openDesktopWorkspaceAppFolder } from "./host/workspaceAppFolderAccess";
 import { openPerfMonitorDevToolsWindow } from "./windows/perfMonitorDevToolsWindow.ts";
+import { requestWorkspaceWindowsClose } from "./windows/workspaceWindow.ts";
 import { createTranslator } from "../shared/i18n/index.ts";
 import {
   registerTuttiAssetProtocol,
@@ -242,6 +243,7 @@ export async function bootstrapDesktopApp(): Promise<void> {
 
   registerDesktopAppLifecycle({
     logger,
+    requestWorkspaceWindowsClose,
     tuttid: desktopAppServices.tuttid,
     disposables: [
       hostPreferencesEventStream,

--- a/apps/desktop/src/main/desktopAppLifecycle.test.ts
+++ b/apps/desktop/src/main/desktopAppLifecycle.test.ts
@@ -153,6 +153,115 @@ test("before quit waits for managed tuttid stop before quitting the app", async 
   assert.equal(events.at(-1), "app:quit");
 });
 
+test("before quit requests workspace windows to close before stopping tuttid", async () => {
+  const events: string[] = [];
+  const handlers = createDesktopAppLifecycleHandlers(
+    {
+      logger: createLogger(events),
+      requestWorkspaceWindowsClose: async (payload) => {
+        events.push(`workspace-windows:close:${payload.reason}`);
+        return "approved";
+      },
+      tuttid: createTuttidManager(async () => {
+        events.push("tuttid:stop");
+      }),
+      updateService: createUpdateService(events),
+      workspaceLaunch: createWorkspaceLaunch()
+    },
+    createRuntime(events)
+  );
+
+  handlers.beforeQuit({
+    preventDefault() {
+      events.push("quit:prevented");
+    }
+  });
+
+  await Promise.resolve();
+  await Promise.resolve();
+  await new Promise((resolve) => setImmediate(resolve));
+
+  assert.deepEqual(events, [
+    "quit:prevented",
+    "info:desktop app before quit",
+    "workspace-windows:close:quit",
+    "tuttid:stop",
+    "windows:destroy-all",
+    "app:quit"
+  ]);
+});
+
+test("before quit leaves tuttid running when a workspace window blocks quit", async () => {
+  const events: string[] = [];
+  const handlers = createDesktopAppLifecycleHandlers(
+    {
+      logger: createLogger(events),
+      requestWorkspaceWindowsClose: async (payload) => {
+        events.push(`workspace-windows:close:${payload.reason}`);
+        return "blocked";
+      },
+      tuttid: createTuttidManager(async () => {
+        events.push("tuttid:stop");
+      }),
+      updateService: createUpdateService(events),
+      workspaceLaunch: createWorkspaceLaunch()
+    },
+    createRuntime(events)
+  );
+
+  handlers.beforeQuit({
+    preventDefault() {
+      events.push("quit:prevented");
+    }
+  });
+
+  await Promise.resolve();
+  await Promise.resolve();
+  await new Promise((resolve) => setImmediate(resolve));
+
+  assert.deepEqual(events, [
+    "quit:prevented",
+    "info:desktop app before quit",
+    "workspace-windows:close:quit"
+  ]);
+});
+
+test("before quit leaves tuttid running when workspace close request fails", async () => {
+  const events: string[] = [];
+  const handlers = createDesktopAppLifecycleHandlers(
+    {
+      logger: createLogger(events),
+      requestWorkspaceWindowsClose: async (payload) => {
+        events.push(`workspace-windows:close:${payload.reason}`);
+        throw new Error("close guard failed");
+      },
+      tuttid: createTuttidManager(async () => {
+        events.push("tuttid:stop");
+      }),
+      updateService: createUpdateService(events),
+      workspaceLaunch: createWorkspaceLaunch()
+    },
+    createRuntime(events)
+  );
+
+  handlers.beforeQuit({
+    preventDefault() {
+      events.push("quit:prevented");
+    }
+  });
+
+  await Promise.resolve();
+  await Promise.resolve();
+  await new Promise((resolve) => setImmediate(resolve));
+
+  assert.deepEqual(events, [
+    "quit:prevented",
+    "info:desktop app before quit",
+    "workspace-windows:close:quit",
+    "error:failed to request workspace close during quit"
+  ]);
+});
+
 test("before quit does not trigger a second stop while shutdown is already in progress", async () => {
   const events: string[] = [];
   const handlers = createDesktopAppLifecycleHandlers(

--- a/apps/desktop/src/main/desktopAppLifecycle.test.ts
+++ b/apps/desktop/src/main/desktopAppLifecycle.test.ts
@@ -34,7 +34,10 @@ function createWorkspaceLaunch(): WorkspaceLaunch {
   };
 }
 
-function createUpdateService(events: string[]): AppUpdateService {
+function createUpdateService(
+  events: string[],
+  options: { quitAndInstallPending?: boolean } = {}
+): AppUpdateService {
   return {
     async checkForUpdates() {
       throw new Error("not used");
@@ -53,6 +56,9 @@ function createUpdateService(events: string[]): AppUpdateService {
     },
     async installUpdate() {
       throw new Error("not used");
+    },
+    isQuitAndInstallPending() {
+      return options.quitAndInstallPending ?? false;
     },
     onStateChanged() {
       return () => undefined;
@@ -189,6 +195,42 @@ test("before quit requests workspace windows to close before stopping tuttid", a
     "windows:destroy-all",
     "app:quit"
   ]);
+});
+
+test("before quit bypasses workspace close guard while update install is pending", async () => {
+  const events: string[] = [];
+  const handlers = createDesktopAppLifecycleHandlers(
+    {
+      logger: createLogger(events),
+      requestWorkspaceWindowsClose: async (payload) => {
+        events.push(`workspace-windows:close:${payload.reason}`);
+        return "blocked";
+      },
+      tuttid: createTuttidManager(async () => {
+        events.push("tuttid:stop");
+      }),
+      updateService: createUpdateService(events, {
+        quitAndInstallPending: true
+      }),
+      workspaceLaunch: createWorkspaceLaunch()
+    },
+    createRuntime(events)
+  );
+
+  let prevented = false;
+  handlers.beforeQuit({
+    preventDefault() {
+      prevented = true;
+      events.push("quit:prevented");
+    }
+  });
+
+  await Promise.resolve();
+  await Promise.resolve();
+  await new Promise((resolve) => setImmediate(resolve));
+
+  assert.equal(prevented, false);
+  assert.deepEqual(events, ["info:desktop app before quit for update install"]);
 });
 
 test("before quit leaves tuttid running when a workspace window blocks quit", async () => {

--- a/apps/desktop/src/main/desktopAppLifecycle.ts
+++ b/apps/desktop/src/main/desktopAppLifecycle.ts
@@ -30,6 +30,9 @@ interface DesktopElectronModule {
 export interface DesktopAppLifecycleDependencies {
   disposables?: readonly DesktopAppLifecycleDisposable[];
   logger: DesktopLogger;
+  requestWorkspaceWindowsClose?: (payload: {
+    reason: "quit";
+  }) => Promise<"approved" | "blocked">;
   tuttid: TuttidManager;
   updateService: AppUpdateService;
   workspaceLaunch: WorkspaceLaunch;
@@ -117,6 +120,22 @@ export function createDesktopAppLifecycleHandlers(
       event.preventDefault();
       deps.logger.info("desktop app before quit");
       void (async () => {
+        try {
+          const closeResult = await deps.requestWorkspaceWindowsClose?.({
+            reason: "quit"
+          });
+          if (closeResult === "blocked") {
+            isStoppingDaemon = false;
+            return;
+          }
+        } catch (error: unknown) {
+          deps.logger.error("failed to request workspace close during quit", {
+            error: error instanceof Error ? error.message : String(error)
+          });
+          isStoppingDaemon = false;
+          return;
+        }
+
         try {
           await deps.tuttid.stop();
         } catch (error: unknown) {

--- a/apps/desktop/src/main/desktopAppLifecycle.ts
+++ b/apps/desktop/src/main/desktopAppLifecycle.ts
@@ -112,6 +112,11 @@ export function createDesktopAppLifecycleHandlers(
     },
 
     beforeQuit(event) {
+      if (deps.updateService.isQuitAndInstallPending()) {
+        deps.logger.info("desktop app before quit for update install");
+        return;
+      }
+
       if (isStoppingDaemon) {
         return;
       }

--- a/apps/desktop/src/main/desktopAppServices.test.ts
+++ b/apps/desktop/src/main/desktopAppServices.test.ts
@@ -135,6 +135,9 @@ function createUpdateService(): AppUpdateService {
     async installUpdate() {
       throw new Error("not used");
     },
+    isQuitAndInstallPending() {
+      return false;
+    },
     onStateChanged() {
       return () => undefined;
     }

--- a/apps/desktop/src/main/update/appUpdateAccess.test.ts
+++ b/apps/desktop/src/main/update/appUpdateAccess.test.ts
@@ -38,6 +38,9 @@ function createAppUpdateServiceStub(): AppUpdateService {
       return createAppUpdateState();
     },
     async installUpdate() {},
+    isQuitAndInstallPending() {
+      return false;
+    },
     onStateChanged() {
       return () => undefined;
     }

--- a/apps/desktop/src/main/update/appUpdateService.test.ts
+++ b/apps/desktop/src/main/update/appUpdateService.test.ts
@@ -179,6 +179,74 @@ test("createAppUpdateService skips downloading state when cached update is alrea
   }
 });
 
+test("createAppUpdateService marks quit-and-install pending while installing a downloaded update", async () => {
+  const listeners: {
+    downloaded?: (info: UpdateDownloadedEvent) => void;
+  } = {};
+  let quitAndInstallCallCount = 0;
+  const driver = createFakeDriver({
+    onUpdateDownloaded(listener) {
+      listeners.downloaded = listener;
+      return noop;
+    },
+    quitAndInstall() {
+      quitAndInstallCallCount += 1;
+    }
+  });
+  const service = createAppUpdateService(driver, {
+    supportsUpdates: true
+  });
+
+  try {
+    await service.configure({
+      channel: "stable",
+      policy: "prompt"
+    });
+    assert.equal(service.isQuitAndInstallPending(), false);
+
+    listeners.downloaded?.(createUpdateDownloadedInfoFixture("1.1.0"));
+    await service.installUpdate();
+    await service.installUpdate();
+
+    assert.equal(service.isQuitAndInstallPending(), true);
+    assert.equal(quitAndInstallCallCount, 1);
+  } finally {
+    service.dispose();
+  }
+});
+
+test("createAppUpdateService clears quit-and-install pending when install launch fails", async () => {
+  const listeners: {
+    downloaded?: (info: UpdateDownloadedEvent) => void;
+  } = {};
+  const driver = createFakeDriver({
+    onUpdateDownloaded(listener) {
+      listeners.downloaded = listener;
+      return noop;
+    },
+    quitAndInstall() {
+      throw new Error("quit install failed");
+    }
+  });
+  const service = createAppUpdateService(driver, {
+    supportsUpdates: true
+  });
+
+  try {
+    await service.configure({
+      channel: "stable",
+      policy: "prompt"
+    });
+    listeners.downloaded?.(createUpdateDownloadedInfoFixture("1.1.0"));
+
+    await assert.rejects(() => service.installUpdate(), /quit install failed/);
+
+    assert.equal(service.isQuitAndInstallPending(), false);
+  } finally {
+    service.dispose();
+  }
+});
+
 test("createAppUpdateService refreshes update availability before downloading", async () => {
   const listeners: {
     checking?: () => void;

--- a/apps/desktop/src/main/update/appUpdateService.ts
+++ b/apps/desktop/src/main/update/appUpdateService.ts
@@ -69,6 +69,7 @@ export interface AppUpdateService {
   downloadUpdate(): Promise<AppUpdateState>;
   getState(): AppUpdateState;
   installUpdate(): Promise<void>;
+  isQuitAndInstallPending(): boolean;
   onStateChanged(
     listener: (state: AppUpdateState, previousState: AppUpdateState) => void
   ): () => void;
@@ -472,6 +473,7 @@ export function createAppUpdateService(
   let activeCheckPromise: Promise<void> | null = null;
   let activeDownloadPromise: Promise<void> | null = null;
   let preserveAvailableStateDuringCheck = false;
+  let quitAndInstallPending = false;
   const stateChangedListeners = new Set<
     (state: AppUpdateState, previousState: AppUpdateState) => void
   >();
@@ -767,10 +769,19 @@ export function createAppUpdateService(
       return state;
     },
     installUpdate() {
-      if (state.status === "downloaded") {
-        resolvedDriver.quitAndInstall();
+      if (state.status === "downloaded" && !quitAndInstallPending) {
+        quitAndInstallPending = true;
+        try {
+          resolvedDriver.quitAndInstall();
+        } catch (error) {
+          quitAndInstallPending = false;
+          return Promise.reject(error);
+        }
       }
       return Promise.resolve();
+    },
+    isQuitAndInstallPending() {
+      return quitAndInstallPending;
     },
     onStateChanged(listener) {
       stateChangedListeners.add(listener);

--- a/apps/desktop/src/renderer/src/features/workspace-workbench/services/internal/contributions/agentGuiWorkbenchContributionFactory.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/services/internal/contributions/agentGuiWorkbenchContributionFactory.ts
@@ -11,6 +11,7 @@ export const agentGuiWorkbenchContributionFactory: DesktopWorkbenchContributionF
         appCenterService: context.appCenterService,
         appI18n: context.appI18n,
         computerUseApi: context.computerUseApi,
+        confirmCloseGuard: context.confirmCloseGuard,
         dockIconUrls: context.dockIcons.agents,
         dockPreviewCache: context.dockPreviewCache,
         defaultProviderTargetId: context.defaultProviderTargetId,

--- a/apps/desktop/src/renderer/src/features/workspace-workbench/services/internal/workspaceAgentGuiContribution.test.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/services/internal/workspaceAgentGuiContribution.test.ts
@@ -1,0 +1,123 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  workspaceWorkbenchDesktopI18nKeys,
+  type WorkspaceWorkbenchDesktopI18nKey,
+  type WorkspaceWorkbenchDesktopI18nRuntime
+} from "../../../../../../shared/i18n/index.ts";
+import {
+  createAgentQuitGuardRequest,
+  type AgentQuitGuardSession
+} from "./workspaceAgentQuitGuard.ts";
+
+test("agent quit guard is omitted when all agent sessions are idle", () => {
+  assert.equal(
+    createAgentQuitGuardRequest({
+      i18n: createTestI18n(),
+      sessions: [
+        createSession("ready-session", { status: "ready" }),
+        createSession("completed-session", { status: "completed" })
+      ]
+    }),
+    null
+  );
+});
+
+test("agent quit guard summarizes running and waiting agent sessions", () => {
+  const request = createAgentQuitGuardRequest({
+    i18n: createTestI18n(),
+    sessions: [
+      createSession("running-session", {
+        provider: "codex",
+        status: "running",
+        title: "Refactor desktop shutdown"
+      }),
+      createSession("waiting-session", {
+        provider: "claude-code",
+        title: "Review generated files",
+        turnPhase: "waiting_approval"
+      }),
+      createSession("completed-session", {
+        provider: "gemini",
+        status: "completed",
+        title: "Already done"
+      })
+    ]
+  });
+
+  assert.equal(request?.title, "Quit while agents are running?");
+  assert.equal(request?.variant, "destructive");
+  assert.equal(
+    request?.details,
+    [
+      "Codex: Refactor desktop shutdown",
+      "Claude Code: Review generated files"
+    ].join("\n")
+  );
+});
+
+test("agent quit guard caps details for many running sessions", () => {
+  const request = createAgentQuitGuardRequest({
+    i18n: createTestI18n(),
+    sessions: Array.from({ length: 7 }, (_, index) =>
+      createSession(`session-${index}`, {
+        provider: "codex",
+        status: "working",
+        title: `Task ${index}`
+      })
+    )
+  });
+
+  assert.equal(
+    request?.details,
+    [
+      "Codex: Task 0",
+      "Codex: Task 1",
+      "Codex: Task 2",
+      "Codex: Task 3",
+      "Codex: Task 4",
+      "and 2 more"
+    ].join("\n")
+  );
+});
+
+function createSession(
+  agentSessionId: string,
+  overrides: Partial<AgentQuitGuardSession>
+): AgentQuitGuardSession {
+  return {
+    agentSessionId,
+    provider: "codex",
+    status: "ready",
+    ...overrides
+  };
+}
+
+function createTestI18n(): WorkspaceWorkbenchDesktopI18nRuntime {
+  const dictionary: Partial<Record<WorkspaceWorkbenchDesktopI18nKey, string>> =
+    {
+      [workspaceWorkbenchDesktopI18nKeys.agentQuitGuard.cancel]:
+        "Keep Tutti open",
+      [workspaceWorkbenchDesktopI18nKeys.agentQuitGuard.confirm]:
+        "Quit and stop agents",
+      [workspaceWorkbenchDesktopI18nKeys.agentQuitGuard.description]:
+        "Local agent sessions are still running.",
+      [workspaceWorkbenchDesktopI18nKeys.agentQuitGuard.detailsMore]:
+        "and {{count}} more",
+      [workspaceWorkbenchDesktopI18nKeys.agentQuitGuard.title]:
+        "Quit while agents are running?"
+    };
+  return {
+    has(key) {
+      return key in dictionary;
+    },
+    t(key, params) {
+      const template = dictionary[key] ?? key;
+      return template.replaceAll("{{count}}", String(params?.count ?? ""));
+    },
+    tFirst(keys, params) {
+      const key = keys.find((item) => this.has(item)) ?? keys[0];
+      return key ? this.t(key, params) : "";
+    }
+  };
+}

--- a/apps/desktop/src/renderer/src/features/workspace-workbench/services/internal/workspaceAgentGuiContribution.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/services/internal/workspaceAgentGuiContribution.ts
@@ -10,7 +10,8 @@ import type { I18nRuntime } from "@tutti-os/ui-i18n-runtime";
 import type { TuttidClient } from "@tutti-os/client-tuttid-ts";
 import type {
   WorkbenchContribution,
-  WorkbenchDockPreviewCache
+  WorkbenchDockPreviewCache,
+  WorkbenchHostCloseDialogRequest
 } from "@tutti-os/workbench-surface";
 import type {
   DesktopComputerUseApi,
@@ -42,6 +43,7 @@ import { requestWorkspaceIssueManagerLaunch } from "../workspaceIssueManagerLaun
 import { requestGroupChatLaunch } from "../groupChatLaunchCoordinator.ts";
 import { workspaceAgentGuiNodeFrame } from "./workspaceWorkbenchComposition.ts";
 import { isWorkspaceAgentGuiDefaultDockProvider } from "./workspaceAgentProviderCatalog.ts";
+import { createAgentQuitGuardRequest } from "./workspaceAgentQuitGuard.ts";
 
 export function createWorkspaceAgentGuiContribution(input: {
   agentProviderStatusService: AgentProviderStatusService;
@@ -54,6 +56,9 @@ export function createWorkspaceAgentGuiContribution(input: {
   >[0]["dockIconUrls"];
   hostFilesApi: DesktopHostFilesApi;
   i18n: WorkspaceWorkbenchDesktopI18nRuntime;
+  confirmCloseGuard: (
+    request: WorkbenchHostCloseDialogRequest
+  ) => Promise<boolean> | boolean;
   onCapabilitySettingsRequest?: Parameters<
     typeof DesktopAgentGUIWorkbenchBody
   >[0]["onCapabilitySettingsRequest"];
@@ -156,7 +161,7 @@ export function createWorkspaceAgentGuiContribution(input: {
       workspaceId: input.workspaceId
     });
 
-  return createAgentGuiWorkbenchContribution({
+  const contribution = createAgentGuiWorkbenchContribution({
     copy: {
       collapseConversationRail: input.appI18n.t(
         "workspace.agentGui.collapseConversationRail"
@@ -202,6 +207,23 @@ export function createWorkspaceAgentGuiContribution(input: {
       isWorkspaceAgentGuiDefaultDockProvider(provider) ? "always" : "never",
     workspaceId: input.workspaceId
   });
+
+  return {
+    ...contribution,
+    prepareHostClose: async () => {
+      const request = createAgentQuitGuardRequest({
+        i18n: input.i18n,
+        sessions: input.workspaceAgentActivityService.getSnapshot(
+          input.workspaceId
+        ).sessions
+      });
+      if (!request) {
+        return true;
+      }
+
+      return input.confirmCloseGuard(request);
+    }
+  };
 }
 
 function resolveWorkspaceAgentGuiDockPopupTitle(

--- a/apps/desktop/src/renderer/src/features/workspace-workbench/services/internal/workspaceAgentQuitGuard.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/services/internal/workspaceAgentQuitGuard.ts
@@ -1,0 +1,100 @@
+import {
+  isAgentGuiWorkbenchProvider,
+  resolveAgentGuiWorkbenchProviderLabel
+} from "@tutti-os/agent-gui/workbench/providerCatalog";
+import type { WorkbenchHostCloseDialogRequest } from "@tutti-os/workbench-surface";
+import {
+  workspaceWorkbenchDesktopI18nKeys,
+  type WorkspaceWorkbenchDesktopI18nRuntime
+} from "../../../../../../shared/i18n/index.ts";
+
+const agentQuitGuardDetailLimit = 5;
+
+export interface AgentQuitGuardSession {
+  agentSessionId: string;
+  currentPhase?: string | null;
+  effectiveStatus?: string | null;
+  provider?: string | null;
+  status?: string | null;
+  title?: string | null;
+  turnLifecycle?: {
+    phase?: string | null;
+  } | null;
+  turnPhase?: string | null;
+}
+
+export function createAgentQuitGuardRequest(input: {
+  i18n: WorkspaceWorkbenchDesktopI18nRuntime;
+  sessions: readonly AgentQuitGuardSession[];
+}): WorkbenchHostCloseDialogRequest | null {
+  const runningSessions = input.sessions.filter(isAgentSessionQuitSensitive);
+  if (runningSessions.length === 0) {
+    return null;
+  }
+
+  const detailLines = runningSessions
+    .slice(0, agentQuitGuardDetailLimit)
+    .map(formatAgentQuitGuardSession);
+  const remainingCount = runningSessions.length - detailLines.length;
+  if (remainingCount > 0) {
+    detailLines.push(
+      input.i18n.t(
+        workspaceWorkbenchDesktopI18nKeys.agentQuitGuard.detailsMore,
+        { count: remainingCount }
+      )
+    );
+  }
+
+  return {
+    cancelLabel: input.i18n.t(
+      workspaceWorkbenchDesktopI18nKeys.agentQuitGuard.cancel
+    ),
+    confirmLabel: input.i18n.t(
+      workspaceWorkbenchDesktopI18nKeys.agentQuitGuard.confirm
+    ),
+    description: input.i18n.t(
+      workspaceWorkbenchDesktopI18nKeys.agentQuitGuard.description
+    ),
+    details: detailLines.join("\n"),
+    scope: "window",
+    title: input.i18n.t(workspaceWorkbenchDesktopI18nKeys.agentQuitGuard.title),
+    variant: "destructive"
+  };
+}
+
+function formatAgentQuitGuardSession(session: AgentQuitGuardSession): string {
+  const provider = session.provider?.trim() ?? "";
+  const providerLabel = isAgentGuiWorkbenchProvider(provider)
+    ? resolveAgentGuiWorkbenchProviderLabel(provider)
+    : provider || "Agent";
+  const title = session.title?.trim();
+  return title ? `${providerLabel}: ${title}` : providerLabel;
+}
+
+function isAgentSessionQuitSensitive(session: AgentQuitGuardSession): boolean {
+  return [
+    session.currentPhase,
+    session.effectiveStatus,
+    session.status,
+    session.turnLifecycle?.phase,
+    session.turnPhase
+  ].some(isQuitSensitiveAgentStatus);
+}
+
+function isQuitSensitiveAgentStatus(
+  status: string | null | undefined
+): boolean {
+  switch (status?.trim().toLowerCase()) {
+    case "submitted":
+    case "working":
+    case "running":
+    case "streaming":
+    case "waiting":
+    case "waiting_approval":
+    case "awaiting_approval":
+    case "waiting_input":
+      return true;
+    default:
+      return false;
+  }
+}

--- a/apps/desktop/src/shared/i18n/locales/en.ts
+++ b/apps/desktop/src/shared/i18n/locales/en.ts
@@ -655,6 +655,14 @@ export const en = {
       trigger: "Settings"
     },
     workbenchDesktop: {
+      agentQuitGuard: {
+        cancel: "Keep Tutti open",
+        confirm: "Quit and stop agents",
+        description:
+          "Local agent sessions are still running. Quitting Tutti will stop them.",
+        detailsMore: "and {{count}} more",
+        title: "Quit while agents are running?"
+      },
       closeGuard: {
         cancel: "Cancel",
         confirm: "Terminate terminal",

--- a/apps/desktop/src/shared/i18n/locales/zh-CN.ts
+++ b/apps/desktop/src/shared/i18n/locales/zh-CN.ts
@@ -627,6 +627,13 @@ export const zhCN = {
       trigger: "设置"
     },
     workbenchDesktop: {
+      agentQuitGuard: {
+        cancel: "保留 Tutti",
+        confirm: "退出并停止 Agent",
+        description: "仍有本地 Agent 会话在运行。退出 Tutti 会停止这些会话。",
+        detailsMore: "还有 {{count}} 个",
+        title: "要在 Agent 运行时退出吗？"
+      },
       closeGuard: {
         cancel: "取消",
         confirm: "终止终端",

--- a/apps/desktop/src/shared/i18n/workspaceWorkbenchDesktopI18n.ts
+++ b/apps/desktop/src/shared/i18n/workspaceWorkbenchDesktopI18n.ts
@@ -32,6 +32,13 @@ export type WorkspaceWorkbenchDesktopI18nRuntime =
   I18nRuntime<WorkspaceWorkbenchDesktopI18nKey>;
 
 export const workspaceWorkbenchDesktopI18nKeys = {
+  agentQuitGuard: {
+    cancel: "agentQuitGuard.cancel",
+    confirm: "agentQuitGuard.confirm",
+    description: "agentQuitGuard.description",
+    detailsMore: "agentQuitGuard.detailsMore",
+    title: "agentQuitGuard.title"
+  },
   closeGuard: {
     cancel: "closeGuard.cancel",
     confirm: "closeGuard.confirm",

--- a/docs/architecture/desktop-windows.md
+++ b/docs/architecture/desktop-windows.md
@@ -99,6 +99,21 @@ the workspace window shell in main. They are enabled only for development
 renderer sessions and are intercepted without entering the close-guard flow.
 Packaged builds intercept those shortcuts without reloading the product window.
 
+## App Quit Guard Behavior
+
+App quit is gated before managed daemon shutdown. When Electron emits
+`before-quit`, the main process sends a typed quit close request to every
+workspace window and waits for the renderer response. Only after every
+workspace approves the quit does the main process stop `tuttid`, destroy
+remaining windows, and resume the app quit path.
+
+The workspace renderer uses the same close-guard channel for quit as it uses
+for native window close. Contributions that own long-running local work can
+block quit from `prepareHostClose`; for example, the desktop AgentGUI
+contribution prompts when local agent sessions are still running or waiting for
+input. If the user keeps Tutti open, daemon shutdown is skipped and the running
+agent sessions stay connected.
+
 ## Relationship To Layering
 
 This window model follows the desktop layering rules:

--- a/docs/architecture/desktop-windows.md
+++ b/docs/architecture/desktop-windows.md
@@ -114,6 +114,11 @@ contribution prompts when local agent sessions are still running or waiting for
 input. If the user keeps Tutti open, daemon shutdown is skipped and the running
 agent sessions stay connected.
 
+Update-install quits are not user-initiated workspace close decisions. When the
+desktop update service has already requested `quitAndInstall()`, the main
+process lets Electron continue the update quit without entering the workspace
+close guard.
+
 ## Relationship To Layering
 
 This window model follows the desktop layering rules:


### PR DESCRIPTION
## Summary

Tutti currently stops the managed daemon as soon as the app quit path reaches `before-quit`, which can cut off local AgentGUI sessions that are still running or waiting for input. This PR gates app quit through the existing workspace close-guard channel before daemon shutdown, so the renderer can warn about active local agents and let the user keep Tutti open.

The guard lives at the app lifecycle boundary instead of inside AgentGUI alone because `tuttid.stop()` is owned by the desktop main process. The AgentGUI contribution only decides whether there is local agent work worth protecting; main remains responsible for waiting on workspace close approval before stopping `tuttid`, destroying windows, and resuming quit.

This intentionally covers normal app quit paths such as Cmd+Q/menu quit/app.quit. Update replacement and OS shutdown paths have different Electron sequencing and platform behavior, so they should be handled separately if we want the same guarantee there.

## Changes

- Add a `requestWorkspaceWindowsClose({ reason: "quit" })` gate before managed daemon shutdown in the desktop app lifecycle.
- Wire the AgentGUI workbench contribution into `prepareHostClose` so running or waiting local agent sessions produce a localized close-guard dialog.
- Add focused tests for app lifecycle blocking/failure behavior and AgentGUI session summarization.
- Document the app quit guard behavior in the desktop windows architecture note.

## Validation

Passed:

- `node --import ./test/register-asset-stub.mjs --test --experimental-strip-types src/main/desktopAppLifecycle.test.ts src/renderer/src/features/workspace-workbench/services/internal/workspaceAgentGuiContribution.test.ts`
- `corepack pnpm@10.11.0 --filter @tutti-os/desktop typecheck`
- `corepack pnpm@10.11.0 lint:ts`
- `corepack pnpm@10.11.0 check:i18n`
- `corepack pnpm@10.11.0 check:electron-runtime-boundaries`
- `corepack pnpm@10.11.0 check:renderer-boundaries`
- `git diff --check`
- Pre-commit staged formatting, Electron runtime boundary, UI boundary, and renderer boundary checks

Attempted `pnpm check:full` during pre-push with the repo-pinned pnpm shim. It did not complete locally because this machine is missing the pinned `golangci-lint`, and the unrelated `services/tuttid/service/computer` integration test failed to produce accessibility/screenshot content. The desktop TypeScript, i18n, boundary, typecheck, and targeted quit-guard tests passed.

---

[![Compound Engineering](https://img.shields.io/badge/Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
🤖 Generated with GPT-5 via [Codex](https://openai.com/codex)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an “agent quit guard” confirmation when quitting while agent sessions are active, including localized UI text and a capped “and N more” session summary.
  * Implemented a workspace quit-close request/approval flow that can block or allow shutdown.
* **Bug Fixes**
  * If the quit-close guard is blocked or fails, shutdown is aborted and existing agent connectivity is preserved.
  * When an update install is pending, the guard is bypassed.
* **Tests**
  * Added/expanded lifecycle, quit-guard, and update-install pending coverage.
* **Documentation**
  * Documented the app quit-guard behavior for workspace windows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->