### PR TITLE
Fix agent GUI image copy and download actions

### DIFF
--- a/packages/agent/gui/agent-gui/agentGuiNode/AgentGUINodeView.layout.spec.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/AgentGUINodeView.layout.spec.tsx
@@ -1537,7 +1537,7 @@ describe("AgentGUINodeView provider setup notice", () => {
     );
     expect(setupNoticeRule).toContain("margin: 0;");
     expect(setupNoticeRule).not.toContain("background:");
-    expect(setupNoticeRule).toContain("pointer-events: auto;");
+    expect(setupNoticeRule).toContain("pointer-events: none;");
     expect(css).toContain(
       ".agent-gui-node__detail-header + .agent-gui-node__provider-setup-notice"
     );
@@ -1545,6 +1545,7 @@ describe("AgentGUINodeView provider setup notice", () => {
     const setupNoticeActionRule = css.match(
       /\.agent-gui-node__provider-setup-notice-action\s*{[^}]*}/s
     )?.[0];
+    expect(setupNoticeActionRule).toContain("pointer-events: auto;");
     expect(setupNoticeActionRule).toContain("-webkit-app-region: no-drag;");
   });
 

--- a/packages/agent/gui/app/renderer/agentactivity.css
+++ b/packages/agent/gui/app/renderer/agentactivity.css
@@ -6045,7 +6045,7 @@ button.agent-gui-node__conversation-section-toggle:hover
      margin-left:auto has no free space to absorb and the message text would butt
      directly against "Set up". Space the message and action explicitly. */
   column-gap: 6px;
-  pointer-events: auto;
+  pointer-events: none;
 }
 
 .agent-gui-node__detail-header + .agent-gui-node__provider-setup-notice {
@@ -6062,6 +6062,7 @@ button.agent-gui-node__conversation-section-toggle:hover
   font: inherit;
   text-decoration: underline;
   cursor: pointer;
+  pointer-events: auto;
   -webkit-app-region: no-drag;
 }
 

--- a/packages/agent/gui/app/renderer/components/ZoomableImage.tsx
+++ b/packages/agent/gui/app/renderer/components/ZoomableImage.tsx
@@ -67,6 +67,7 @@ export function ZoomableImage({
   const [copyStatus, setCopyStatus] = useState<ImageCopyStatus | null>(null);
   const [imagePreviewZoom, setImagePreviewZoom] = useState(1);
   const [isWheelZooming, setIsWheelZooming] = useState(false);
+  const [isImagePreviewOpen, setIsImagePreviewOpen] = useState(false);
   const imagePreviewZoomPercent = Math.round(imagePreviewZoom * 100);
   const canZoomOut = imagePreviewZoom > IMAGE_PREVIEW_ZOOM_MIN;
   const canZoomIn = imagePreviewZoom < IMAGE_PREVIEW_ZOOM_MAX;
@@ -283,6 +284,18 @@ export function ZoomableImage({
             />
           </div>
         ) : null}
+        {copyStatus ? (
+          <ImageCopyStatusToast
+            busy={copyStatus.busy}
+            message={copyStatus.message}
+            variant={copyStatus.variant}
+            onOpenChange={(open) => {
+              if (!open) {
+                setCopyStatus(null);
+              }
+            }}
+          />
+        ) : null}
         <Button
           asChild
           className="tsh-zoom-dialog__icon-button nodrag tsh-desktop-no-drag"
@@ -314,6 +327,13 @@ export function ZoomableImage({
         wrapElement={wrapElement}
         zoomMargin={24}
         ZoomContent={renderZoomContent}
+        onZoomChange={(zoomed) => {
+          setIsImagePreviewOpen(zoomed);
+          if (!zoomed) {
+            setIsWheelZooming(false);
+            setImagePreviewZoom(1);
+          }
+        }}
       >
         <img
           {...props}
@@ -323,28 +343,29 @@ export function ZoomableImage({
           className={cn("nodrag tsh-desktop-no-drag cursor-zoom-in", className)}
         />
       </Zoom>
-      {contextMenuPosition &&
-      !contextMenuPosition.inZoomDialog &&
-      actionButtons ? (
-        <div
-          className="tsh-image-context-menu nodrag tsh-desktop-no-drag"
-          style={{
-            left: contextMenuPosition.x,
-            top: contextMenuPosition.y
-          }}
-          role="menu"
-          onClick={(event) => event.stopPropagation()}
-        >
-          <ImageActionButtons
-            copyLabel={t("common.copyImage")}
-            downloadLabel={t("common.downloadImage")}
-            itemRole="menuitem"
-            onCopy={handleCopyImageAction}
-            onDownload={handleDownloadImage}
-          />
-        </div>
-      ) : null}
-      {copyStatus
+      {contextMenuPosition && !contextMenuPosition.inZoomDialog && actionButtons
+        ? createPortal(
+            <div
+              className="tsh-image-context-menu nodrag tsh-desktop-no-drag"
+              style={{
+                left: contextMenuPosition.x,
+                top: contextMenuPosition.y
+              }}
+              role="menu"
+              onClick={(event) => event.stopPropagation()}
+            >
+              <ImageActionButtons
+                copyLabel={t("common.copyImage")}
+                downloadLabel={t("common.downloadImage")}
+                itemRole="menuitem"
+                onCopy={handleCopyImageAction}
+                onDownload={handleDownloadImage}
+              />
+            </div>,
+            document.body
+          )
+        : null}
+      {copyStatus && !isImagePreviewOpen
         ? createPortal(
             <ImageCopyStatusToast
               busy={copyStatus.busy}
@@ -381,6 +402,8 @@ function ImageCopyStatusToast({
         anchor="viewport"
         busy={busy}
         variant={variant}
+        data-tsh-image-copy-status="true"
+        style={{ zIndex: 100303 }}
         onOpenChange={onOpenChange}
       >
         <ToastTitle>{message}</ToastTitle>
@@ -485,6 +508,7 @@ function ImageActionButtons({
           className="tsh-zoom-dialog__icon-button"
           size="icon"
           title={copyLabel}
+          onPointerDown={(event) => event.stopPropagation()}
           variant="chrome"
           onClick={(event) => {
             event.preventDefault();
@@ -499,6 +523,7 @@ function ImageActionButtons({
           className="tsh-zoom-dialog__icon-button"
           size="icon"
           title={downloadLabel}
+          onPointerDown={(event) => event.stopPropagation()}
           variant="chrome"
           onClick={(event) => {
             event.preventDefault();
@@ -518,6 +543,7 @@ function ImageActionButtons({
         type="button"
         role={itemRole}
         title={copyLabel}
+        onPointerDown={(event) => event.stopPropagation()}
         onClick={(event) => {
           event.preventDefault();
           event.stopPropagation();
@@ -531,6 +557,7 @@ function ImageActionButtons({
         type="button"
         role={itemRole}
         title={downloadLabel}
+        onPointerDown={(event) => event.stopPropagation()}
         onClick={(event) => {
           event.preventDefault();
           event.stopPropagation();

--- a/packages/agent/gui/shared/AgentMessageMarkdown.spec.tsx
+++ b/packages/agent/gui/shared/AgentMessageMarkdown.spec.tsx
@@ -877,7 +877,9 @@ describe("AgentMessageMarkdown", () => {
 
     const image = await screen.findByRole("img", { name: "generated image" });
     fireEvent.contextMenu(image, { clientX: 12, clientY: 34 });
-    expect(screen.getByRole("menu")).toHaveStyle({ left: "12px", top: "34px" });
+    const inlineMenu = screen.getByRole("menu");
+    expect(inlineMenu).toHaveStyle({ left: "12px", top: "34px" });
+    expect(inlineMenu.parentElement).toBe(document.body);
 
     fireEvent.click(screen.getByRole("menuitem", { name: "Copy image" }));
     await waitFor(() => {

--- a/packages/agent/gui/vitest.setup.ts
+++ b/packages/agent/gui/vitest.setup.ts
@@ -86,12 +86,17 @@ vi.mock("react-medium-image-zoom", () => ({
     a11yNameButtonUnzoom,
     children,
     classDialog,
+    onZoomChange,
     ZoomContent
   }: {
     a11yNameButtonZoom?: string;
     a11yNameButtonUnzoom?: string;
     children?: ReactNode;
     classDialog?: string;
+    onZoomChange?: (
+      value: boolean,
+      data: { event: ReactMouseEvent | Event }
+    ) => void;
     ZoomContent?: (props: {
       buttonUnzoom: ReactElement;
       img: ReactElement | null;
@@ -114,6 +119,7 @@ vi.mock("react-medium-image-zoom", () => ({
         ? cloneElement(childElement, {
             onClick: (event: ReactMouseEvent) => {
               childElement.props.onClick?.(event);
+              onZoomChange?.(true, { event });
               setModalState("LOADED");
             }
           })
@@ -130,7 +136,10 @@ vi.mock("react-medium-image-zoom", () => ({
       {
         type: "button",
         "aria-label": labelUnzoom,
-        onClick: () => setModalState("UNLOADING")
+        onClick: (event: ReactMouseEvent) => {
+          onZoomChange?.(false, { event });
+          setModalState("UNLOADING");
+        }
       },
       labelUnzoom
     );
@@ -149,7 +158,10 @@ vi.mock("react-medium-image-zoom", () => ({
             "aria-label": labelZoom,
             "aria-hidden": isOpen ? true : undefined,
             "data-rmiz-btn-zoom": "",
-            onClick: () => setModalState("LOADED")
+            onClick: (event: ReactMouseEvent) => {
+              onZoomChange?.(true, { event });
+              setModalState("LOADED");
+            }
           },
           labelZoom
         )


### PR DESCRIPTION
## Summary
- portal conversation image context menus outside clipped message containers
- keep provider setup notice from intercepting image right-clicks while preserving the Settings action
- render image copy toasts inside the zoom dialog top layer when preview is open

## Verification
- pnpm --filter @tutti-os/agent-gui exec vitest run --environment jsdom shared/AgentMessageMarkdown.spec.tsx agent-gui/agentGuiNode/AgentGUINodeView.layout.spec.tsx
- pnpm --filter @tutti-os/agent-gui exec oxlint app/renderer/components/ZoomableImage.tsx shared/AgentMessageMarkdown.spec.tsx app/renderer/agentactivity.css agent-gui/agentGuiNode/AgentGUINodeView.layout.spec.tsx vitest.setup.ts --deny-warnings
- git push pre-push check:full

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved image preview interactions so copy/download controls no longer interfere with zooming or dragging.
  * Kept copy status messages visible in the right place while the image preview is open.
  * Updated the provider setup notice so only its action button is clickable, preventing accidental interactions with the notice itself.
  * Refined image preview menu positioning and behavior for more reliable display.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->