### PR TITLE
[codex] Fix resource picker file icons

### DIFF
--- a/apps/desktop/src/renderer/src/features/workspace-agent/services/createDesktopAgentGUIWorkbenchHostInput.test.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-agent/services/createDesktopAgentGUIWorkbenchHostInput.test.ts
@@ -1202,9 +1202,13 @@ function createPlatformApi(): Pick<
 
 function createWorkspaceFileManagerService(input: {
   openCanvasFilePreview: IWorkspaceFileManagerService["openCanvasFilePreview"];
-}): Pick<IWorkspaceFileManagerService, "openCanvasFilePreview"> {
+}): Pick<
+  IWorkspaceFileManagerService,
+  "openCanvasFilePreview" | "resolveEntryIconUrl"
+> {
   return {
-    openCanvasFilePreview: input.openCanvasFilePreview
+    openCanvasFilePreview: input.openCanvasFilePreview,
+    resolveEntryIconUrl: async () => null
   };
 }
 

--- a/apps/desktop/src/renderer/src/features/workspace-agent/services/createDesktopAgentGUIWorkbenchHostInput.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-agent/services/createDesktopAgentGUIWorkbenchHostInput.ts
@@ -13,6 +13,7 @@ import type {
   DesktopPlatformApi,
   DesktopRuntimeApi
 } from "@preload/types";
+import type { WorkspaceFileEntry } from "@tutti-os/workspace-file-manager/services";
 import type { IDesktopRichTextAtService } from "@renderer/features/rich-text-at";
 import type { IReporterService } from "@renderer/features/analytics";
 import type { IWorkspaceFileManagerService } from "@renderer/features/workspace-file-manager";
@@ -61,6 +62,9 @@ export interface DesktopAgentGUIWorkbenchHostInput {
   >;
   onRequestGitBranches: NonNullable<AgentGUIProps["onRequestGitBranches"]>;
   referenceSourceAggregator: ReferenceSourceAggregator;
+  resolveWorkspaceReferenceEntryIconUrl: NonNullable<
+    AgentGUIProps["resolveWorkspaceReferenceEntryIconUrl"]
+  >;
   resolveMentionReferenceTarget: NonNullable<
     AgentGUIProps["resolveMentionReferenceTarget"]
   >;
@@ -84,7 +88,7 @@ export interface CreateDesktopAgentGUIWorkbenchHostInputInput {
   workspaceAgentActivityService: IWorkspaceAgentActivityService;
   workspaceFileManagerService?: Pick<
     IWorkspaceFileManagerService,
-    "openCanvasFilePreview"
+    "openCanvasFilePreview" | "resolveEntryIconUrl"
   >;
   workspaceUserProjectService?: IWorkspaceUserProjectService;
   workspaceId: string;
@@ -235,6 +239,9 @@ export function createDesktopAgentGUIWorkbenchHostInput({
       };
     },
     referenceSourceAggregator,
+    resolveWorkspaceReferenceEntryIconUrl: (entry: WorkspaceFileEntry) =>
+      workspaceFileManagerService?.resolveEntryIconUrl(workspaceId, entry) ??
+      Promise.resolve(null),
     resolveMentionReferenceTarget,
     resolveWorkspaceReferenceInitialTarget
   };

--- a/apps/desktop/src/renderer/src/features/workspace-agent/ui/DesktopAgentGUIWorkbenchBody.tsx
+++ b/apps/desktop/src/renderer/src/features/workspace-agent/ui/DesktopAgentGUIWorkbenchBody.tsx
@@ -108,6 +108,7 @@ interface DesktopAgentGUIWorkbenchBodyProps {
   >;
   onRequestGitBranches: NonNullable<AgentGUIProps["onRequestGitBranches"]>;
   referenceSourceAggregator?: AgentGUIProps["referenceSourceAggregator"];
+  resolveWorkspaceReferenceEntryIconUrl?: AgentGUIProps["resolveWorkspaceReferenceEntryIconUrl"];
   resolveMentionReferenceTarget?: AgentGUIProps["resolveMentionReferenceTarget"];
   resolveWorkspaceReferenceInitialTarget?: AgentGUIProps["resolveWorkspaceReferenceInitialTarget"];
   workspaceId: string;
@@ -168,6 +169,8 @@ function areDesktopAgentGUIWorkbenchBodyPropsEqual(
       next.workspaceFileReferenceAdapter &&
     previous.onRequestGitBranches === next.onRequestGitBranches &&
     previous.referenceSourceAggregator === next.referenceSourceAggregator &&
+    previous.resolveWorkspaceReferenceEntryIconUrl ===
+      next.resolveWorkspaceReferenceEntryIconUrl &&
     previous.resolveMentionReferenceTarget ===
       next.resolveMentionReferenceTarget &&
     previous.resolveWorkspaceReferenceInitialTarget ===
@@ -241,6 +244,7 @@ function DesktopAgentGUIWorkbenchBodyImpl({
   workspaceFileReferenceAdapter,
   onRequestGitBranches,
   referenceSourceAggregator,
+  resolveWorkspaceReferenceEntryIconUrl,
   resolveMentionReferenceTarget,
   resolveWorkspaceReferenceInitialTarget,
   workspaceId
@@ -988,6 +992,9 @@ function DesktopAgentGUIWorkbenchBodyImpl({
         onRequestGitBranches={previewMode ? null : onRequestGitBranches}
         referenceSourceAggregator={
           previewMode ? null : referenceSourceAggregator
+        }
+        resolveWorkspaceReferenceEntryIconUrl={
+          previewMode ? undefined : resolveWorkspaceReferenceEntryIconUrl
         }
         resolveMentionReferenceTarget={
           previewMode ? undefined : resolveMentionReferenceTarget

--- a/apps/desktop/src/renderer/src/features/workspace-workbench/services/internal/workspaceAgentGuiContribution.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/services/internal/workspaceAgentGuiContribution.ts
@@ -149,6 +149,8 @@ export function createWorkspaceAgentGuiContribution(input: {
       onRequestGitBranches: agentGUIWorkbenchHostInput.onRequestGitBranches,
       referenceSourceAggregator:
         agentGUIWorkbenchHostInput.referenceSourceAggregator,
+      resolveWorkspaceReferenceEntryIconUrl:
+        agentGUIWorkbenchHostInput.resolveWorkspaceReferenceEntryIconUrl,
       resolveMentionReferenceTarget:
         agentGUIWorkbenchHostInput.resolveMentionReferenceTarget,
       resolveWorkspaceReferenceInitialTarget:

--- a/packages/agent/gui/agent-gui/agentGuiNode/AgentGUINode.spec.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/AgentGUINode.spec.tsx
@@ -473,6 +473,7 @@ function ensurePointerCaptureSupport(): void {
 }
 
 vi.mock("../../i18n/index", () => ({
+  getActiveUiLanguage: () => "zh-CN",
   translate: (key: string, options?: { count?: number }) => {
     if (key === "agentHost.agentGui.contextPickerExpandMore") {
       return `展开更多 ${options?.count ?? 0} 条`;

--- a/packages/agent/gui/agent-gui/agentGuiNode/AgentGUINode.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/AgentGUINode.tsx
@@ -1,6 +1,7 @@
 import { memo, useCallback, useEffect, useMemo } from "react";
 import { createWorkspaceUserProjectI18nRuntime } from "@tutti-os/workspace-user-project/i18n";
 import { createWorkspaceFileManagerI18nRuntime } from "@tutti-os/workspace-file-manager";
+import type { WorkspaceFileEntry } from "@tutti-os/workspace-file-manager/services";
 import { useTranslation, type TranslateFn } from "../../i18n/index";
 import { toLocalShortDateTime } from "../../app/renderer/shell/utils/format";
 import type {
@@ -162,6 +163,9 @@ export interface AgentGUINodeProps {
   onRequestGitBranches?: AgentComposerGitBranchLoader | null;
   selectProjectDirectory?: () => Promise<{ path: string } | null>;
   referenceSourceAggregator?: ReferenceSourceAggregator | null;
+  resolveWorkspaceReferenceEntryIconUrl?: (
+    entry: WorkspaceFileEntry
+  ) => Promise<string | null | undefined>;
   resolveMentionReferenceTarget?: AgentMentionReferenceTargetResolver | null;
   resolveWorkspaceReferenceInitialTarget?: AgentWorkspaceReferenceInitialTargetResolver | null;
   agentSettings: Pick<AgentSettings, "avoidGroupingEdits">;
@@ -476,6 +480,8 @@ function areAgentGUINodePropsEqual(
       next.workspaceFileReferenceAdapter &&
     previous.selectProjectDirectory === next.selectProjectDirectory &&
     previous.referenceSourceAggregator === next.referenceSourceAggregator &&
+    previous.resolveWorkspaceReferenceEntryIconUrl ===
+      next.resolveWorkspaceReferenceEntryIconUrl &&
     previous.resolveMentionReferenceTarget ===
       next.resolveMentionReferenceTarget &&
     previous.resolveWorkspaceReferenceInitialTarget ===
@@ -537,6 +543,7 @@ export const AgentGUINode = memo(function AgentGUINode({
   onRequestGitBranches = null,
   selectProjectDirectory,
   referenceSourceAggregator = null,
+  resolveWorkspaceReferenceEntryIconUrl,
   resolveMentionReferenceTarget = null,
   resolveWorkspaceReferenceInitialTarget = null,
   agentSettings,
@@ -1488,6 +1495,9 @@ export const AgentGUINode = memo(function AgentGUINode({
             onRequestGitBranches={onRequestGitBranches}
             selectProjectDirectory={selectProjectDirectory}
             referenceSourceAggregator={referenceSourceAggregator}
+            resolveWorkspaceReferenceEntryIconUrl={
+              resolveWorkspaceReferenceEntryIconUrl
+            }
             resolveMentionReferenceTarget={resolveMentionReferenceTarget}
             resolveWorkspaceReferenceInitialTarget={
               resolveWorkspaceReferenceInitialTarget

--- a/packages/agent/gui/agent-gui/agentGuiNode/AgentGUINodeView.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/AgentGUINodeView.tsx
@@ -47,6 +47,7 @@ import {
 import { WorkspaceUserProjectSelect } from "@tutti-os/workspace-user-project/ui";
 import type { WorkspaceUserProjectI18nRuntime } from "@tutti-os/workspace-user-project/i18n";
 import type { WorkspaceFileManagerI18nRuntime } from "@tutti-os/workspace-file-manager";
+import type { WorkspaceFileEntry } from "@tutti-os/workspace-file-manager/services";
 import { BareIconButton, ScrollArea } from "@tutti-os/ui-system/components";
 import { Button } from "../../app/renderer/components/ui/button";
 import {
@@ -514,6 +515,9 @@ interface AgentGUINodeViewProps {
   workspaceFileReferenceCopy?: WorkspaceFileReferenceCopy | null;
   contextMentionProviders?: readonly AgentContextMentionProvider[];
   referenceSourceAggregator?: ReferenceSourceAggregator | null;
+  resolveWorkspaceReferenceEntryIconUrl?: (
+    entry: WorkspaceFileEntry
+  ) => Promise<string | null | undefined>;
   resolveMentionReferenceTarget?: AgentMentionReferenceTargetResolver | null;
   resolveWorkspaceReferenceInitialTarget?: AgentWorkspaceReferenceInitialTargetResolver | null;
   workspaceAppIcons?: readonly AgentMessageMarkdownWorkspaceAppIcon[];
@@ -833,6 +837,7 @@ export function AgentGUINodeView({
   onRequestGitBranches = null,
   contextMentionProviders,
   referenceSourceAggregator = null,
+  resolveWorkspaceReferenceEntryIconUrl,
   resolveMentionReferenceTarget = null,
   resolveWorkspaceReferenceInitialTarget = null,
   workspaceAppIcons = EMPTY_WORKSPACE_APP_ICONS
@@ -1397,6 +1402,7 @@ export function AgentGUINodeView({
           isNodeSelectable={isWorkspaceReferencePickerNodeSelectable}
           fileManagerCopy={workspaceFileManagerCopy ?? undefined}
           open={workspaceReferencePickerOpen}
+          resolveEntryIconUrl={resolveWorkspaceReferenceEntryIconUrl}
           workspaceId={viewModel.workspaceId}
           onClose={closeWorkspaceReferencePicker}
           onConfirm={confirmWorkspaceReferencePicker}

--- a/packages/workspace/file-manager/src/index.ts
+++ b/packages/workspace/file-manager/src/index.ts
@@ -65,6 +65,8 @@ export {
   WorkspaceFileManagerContextMenu,
   type WorkspaceFileManagerContextMenuProps
 } from "./ui/WorkspaceFileManagerContextMenu.tsx";
+export { WorkspaceFileEntryIcon } from "./ui/WorkspaceFileEntryIcon.tsx";
+export { useWorkspaceFileEntryIconUrls } from "./ui/useWorkspaceFileEntryIconUrls.ts";
 export type { WorkspaceFileManagerEntryDragMode } from "./ui/WorkspaceFileManagerPanels.tsx";
 export type {
   WorkspaceFileManagerFileActivationRequest,

--- a/packages/workspace/file-reference/src/ui/internal/reference/ReferenceSourcePicker.source.test.ts
+++ b/packages/workspace/file-reference/src/ui/internal/reference/ReferenceSourcePicker.source.test.ts
@@ -155,3 +155,26 @@ test("reference picker context menu uses the same viewport boundary as file mana
   assert.match(source, /data-slot="viewport-menu-boundary"/);
   assert.match(source, /data-workspace-file-menu-boundary=""/);
 });
+
+test("reference source picker renders rows with workspace file manager entry icons", () => {
+  assert.match(
+    source,
+    /WorkspaceFileEntryIcon,\s*useWorkspaceFileEntryIconUrls,/
+  );
+  assert.match(source, /function referenceNodeToWorkspaceFileEntry/);
+  assert.match(source, /function ReferenceNodeIcon/);
+  assert.match(
+    source,
+    /<ReferenceNodeIcon[\s\S]*frameClassName="size-7"[\s\S]*iconClassName="size-6"[\s\S]*node=\{node\}/
+  );
+  assert.match(
+    source,
+    /<ReferenceNodeIcon[\s\S]*frameClassName="size-7"[\s\S]*iconClassName="size-6"[\s\S]*node=\{node\}/
+  );
+  assert.match(
+    source,
+    /<ReferenceNodeIcon[\s\S]*frameClassName="size-10"[\s\S]*iconClassName="size-9"[\s\S]*node=\{entry\}/
+  );
+  assert.match(source, /function resolveReferenceNodeIconPath/);
+  assert.doesNotMatch(source, /path:\s*nodeRefKey\(node\.ref\),/);
+});

--- a/packages/workspace/file-reference/src/ui/internal/reference/ReferenceSourcePicker.tsx
+++ b/packages/workspace/file-reference/src/ui/internal/reference/ReferenceSourcePicker.tsx
@@ -1,6 +1,7 @@
 import {
   useEffect,
   useId,
+  useMemo,
   useRef,
   useState,
   type CSSProperties,
@@ -22,7 +23,6 @@ import {
   CheckIcon,
   ChevronDownIcon,
   CloseIcon,
-  FileIcon,
   FolderFilledIcon,
   Input,
   IssueIcon,
@@ -43,6 +43,8 @@ import {
   type WorkspaceFilePreviewSurfaceState
 } from "@tutti-os/workspace-file-preview/react";
 import {
+  WorkspaceFileEntryIcon,
+  useWorkspaceFileEntryIconUrls,
   WorkspaceFileManagerContextMenu,
   resolveRevealInFolderLabel,
   type WorkspaceFileEntry,
@@ -59,6 +61,7 @@ import type {
 } from "../../../contracts/index.ts";
 import type { ReferenceSourceAggregator } from "../../../core/referenceSourceAggregator.ts";
 import {
+  base64UrlDecode,
   nodeRefKey,
   type ReferenceFilterCategory
 } from "../../../core/index.ts";
@@ -85,6 +88,9 @@ export interface ReferenceSourcePickerProps {
   resolveOpenWithApplicationIcon?: (
     application: WorkspaceFileOpenWithApplication
   ) => JSX.Element | null;
+  resolveEntryIconUrl?: (
+    entry: WorkspaceFileEntry
+  ) => Promise<string | null | undefined>;
   onClose: () => void;
   onConfirm: (refs: WorkspaceFileReference[]) => void;
   /**
@@ -104,6 +110,9 @@ export interface ReferenceSourcePickerProps {
 const SIDEBAR_GROUP_PAGE_SIZE = 5;
 
 type PickerView = ReturnType<typeof useReferenceSourcePickerView>;
+type ReferenceNodeIconUrlState = ReturnType<
+  typeof useWorkspaceFileEntryIconUrls
+>;
 interface ReferenceSourceContextMenuState {
   node: ReferenceNode;
   x: number;
@@ -161,6 +170,7 @@ export function ReferenceSourcePicker({
   onConfirm,
   onConfirmBundles,
   open,
+  resolveEntryIconUrl,
   resolveOpenWithApplicationIcon,
   workspaceId
 }: ReferenceSourcePickerProps): JSX.Element | null {
@@ -208,6 +218,31 @@ export function ReferenceSourcePicker({
     WorkspaceFileOpenWithApplication[]
   >([]);
   const [openWithLoading, setOpenWithLoading] = useState(false);
+  const retainedIconEntries = useMemo(
+    () =>
+      collectReferenceNodeIconEntries({
+        childrenByKey: view.childrenByKey,
+        currentEntries: view.currentEntries,
+        expandedKeys: view.expandedKeys,
+        focusedNode: view.focusedNode,
+        searchResults: view.searchResults,
+        selection: view.selection,
+        sidebarGroupsBySource: view.sidebarGroupsBySource
+      }),
+    [
+      view.childrenByKey,
+      view.currentEntries,
+      view.expandedKeys,
+      view.focusedNode,
+      view.searchResults,
+      view.selection,
+      view.sidebarGroupsBySource
+    ]
+  );
+  const iconUrls = useWorkspaceFileEntryIconUrls({
+    entries: retainedIconEntries,
+    resolveEntryIconUrl
+  });
 
   useEffect(() => {
     if (!contextMenu || !fileManagerCopy) {
@@ -463,6 +498,7 @@ export function ReferenceSourcePicker({
                             <SearchResultRow
                               key={nodeRefKey(node.ref)}
                               focused={isFocused(view.focusedNode, node)}
+                              iconUrls={iconUrls}
                               node={node}
                               selected={view.isSelected(node)}
                               onFocus={view.setFocusedNode}
@@ -491,6 +527,7 @@ export function ReferenceSourcePicker({
                             key={nodeRefKey(node.ref)}
                             copy={copy}
                             depth={0}
+                            iconUrls={iconUrls}
                             node={node}
                             onContextMenu={openReferenceContextMenu}
                             view={view}
@@ -610,6 +647,7 @@ export function ReferenceSourcePicker({
                 <PreviewInfoPane
                   copy={copy}
                   hierarchy={view.breadcrumb}
+                  iconUrls={iconUrls}
                   node={view.focusedNode}
                   previewState={view.previewState}
                   sourceLabel={view.activeTabLabel}
@@ -810,6 +848,7 @@ function SourceSidebar({
 function SearchResultRow({
   node,
   focused,
+  iconUrls,
   selected,
   selectable,
   onFocus,
@@ -820,6 +859,7 @@ function SearchResultRow({
 }: {
   node: ReferenceNode;
   focused: boolean;
+  iconUrls: ReferenceNodeIconUrlState;
   selected: boolean;
   selectable: boolean;
   onFocus: (node: ReferenceNode) => void;
@@ -828,7 +868,6 @@ function SearchResultRow({
   onSingleSelect: (node: ReferenceNode) => void;
   onToggle: (node: ReferenceNode) => void;
 }): JSX.Element {
-  const isFolder = node.kind === "folder";
   const contextLabel = node.contextLabel ?? node.ref.nodeId;
   const active = selected || (focused && selectable);
   return (
@@ -855,11 +894,12 @@ function SearchResultRow({
     >
       <div className="flex min-w-0 items-center gap-3 text-left">
         <span className="grid size-9 shrink-0 place-items-center rounded-lg bg-[var(--transparency-block)] text-[var(--text-tertiary)]">
-          {isFolder ? (
-            <FolderFilledIcon className="size-4 text-[var(--rich-text-folder)]" />
-          ) : (
-            <FileIcon className="size-4 text-[var(--text-tertiary)]" />
-          )}
+          <ReferenceNodeIcon
+            frameClassName="size-7"
+            iconClassName="size-6"
+            iconUrls={iconUrls}
+            node={node}
+          />
         </span>
         <span className="min-w-0">
           <FullTextTooltip content={node.displayName}>
@@ -1018,12 +1058,14 @@ function FullTextTooltip({
 function PreviewInfoPane({
   copy,
   hierarchy,
+  iconUrls,
   node,
   previewState,
   sourceLabel
 }: {
   copy: WorkspaceFileReferenceCopy;
   hierarchy: readonly ReferenceNode[];
+  iconUrls: ReferenceNodeIconUrlState;
   node: ReferenceNode | null;
   previewState: ReferenceNodePreviewState;
   sourceLabel: string;
@@ -1048,13 +1090,14 @@ function PreviewInfoPane({
             loadingIndicator={<Spinner size={16} />}
             loadingMessage={copy.t("referencePicker.previewLoading")}
             messageClassName="mx-auto max-w-[24ch] text-[13px] leading-5 text-[var(--text-secondary)] [overflow-wrap:anywhere]"
-            renderIcon={(entry) =>
-              entry.kind === "folder" ? (
-                <FolderFilledIcon className="size-9 text-[var(--rich-text-folder)]" />
-              ) : (
-                <FileIcon className="size-9 text-[var(--text-tertiary)]" />
-              )
-            }
+            renderIcon={(entry) => (
+              <ReferenceNodeIcon
+                frameClassName="size-10"
+                iconClassName="size-9"
+                iconUrls={iconUrls}
+                node={entry}
+              />
+            )}
             state={toPreviewSurfaceState(node, previewState, copy)}
             textClassName="h-full w-full overflow-auto p-3 text-left text-[11px] leading-5 whitespace-pre-wrap break-words text-[var(--text-primary)]"
             textFrameClassName="items-stretch justify-stretch"
@@ -1424,12 +1467,14 @@ function isFocused(
 function TreeNodeRow({
   node,
   depth,
+  iconUrls,
   onContextMenu,
   view,
   copy
 }: {
   node: ReferenceNode;
   depth: number;
+  iconUrls: ReferenceNodeIconUrlState;
   onContextMenu: (event: MouseEvent<HTMLElement>, node: ReferenceNode) => void;
   view: PickerView;
   copy: WorkspaceFileReferenceCopy;
@@ -1482,6 +1527,7 @@ function TreeNodeRow({
             key={nodeRefKey(child.ref)}
             copy={copy}
             depth={depth + 1}
+            iconUrls={iconUrls}
             node={child}
             onContextMenu={onContextMenu}
             view={view}
@@ -1542,11 +1588,12 @@ function TreeNodeRow({
             />
           </button>
         ) : null}
-        {isFolder ? (
-          <FolderFilledIcon className="size-4 shrink-0 text-[var(--rich-text-folder)]" />
-        ) : (
-          <FileIcon className="size-4 shrink-0 text-[var(--text-tertiary)]" />
-        )}
+        <ReferenceNodeIcon
+          frameClassName="size-7"
+          iconClassName="size-6"
+          iconUrls={iconUrls}
+          node={node}
+        />
         <FullTextTooltip content={node.displayName}>
           <span
             className="min-w-0 flex-1 truncate text-[13px] text-[var(--text-primary)]"
@@ -1621,6 +1668,67 @@ function formatBytes(bytes: number): string {
   return `${value.toFixed(1)} ${units[unitIndex]}`;
 }
 
+function ReferenceNodeIcon({
+  frameClassName,
+  iconClassName,
+  iconUrls,
+  node
+}: {
+  frameClassName?: string;
+  iconClassName: string;
+  iconUrls: ReferenceNodeIconUrlState;
+  node: ReferenceNode;
+}): JSX.Element {
+  const entry = useMemo(() => referenceNodeToWorkspaceFileEntry(node), [node]);
+  return (
+    <WorkspaceFileEntryIcon
+      entry={entry}
+      frameClassName={frameClassName}
+      iconClassName={iconClassName}
+      iconUrlByCacheKey={iconUrls.iconUrlByCacheKey}
+      onViewportEnter={iconUrls.reportEntryIconViewportEnter}
+      onViewportLeave={iconUrls.reportEntryIconViewportLeave}
+    />
+  );
+}
+
+function collectReferenceNodeIconEntries(input: {
+  childrenByKey: PickerView["childrenByKey"];
+  currentEntries: readonly ReferenceNode[];
+  expandedKeys: PickerView["expandedKeys"];
+  focusedNode: ReferenceNode | null;
+  searchResults: readonly ReferenceNode[];
+  selection: readonly ReferenceNode[];
+  sidebarGroupsBySource: PickerView["sidebarGroupsBySource"];
+}): WorkspaceFileEntry[] {
+  const byKey = new Map<string, ReferenceNode>();
+  const retain = (node: ReferenceNode): void => {
+    byKey.set(nodeRefKey(node.ref), node);
+  };
+  const retainTree = (node: ReferenceNode): void => {
+    retain(node);
+    const key = nodeRefKey(node.ref);
+    if (!input.expandedKeys[key]) {
+      return;
+    }
+    for (const child of input.childrenByKey[key]?.entries ?? []) {
+      retainTree(child);
+    }
+  };
+
+  input.currentEntries.forEach(retainTree);
+  input.searchResults.forEach(retain);
+  input.selection.forEach(retain);
+  if (input.focusedNode) {
+    retain(input.focusedNode);
+  }
+  for (const groups of Object.values(input.sidebarGroupsBySource)) {
+    groups.forEach(retain);
+  }
+
+  return [...byKey.values()].map(referenceNodeToWorkspaceFileEntry);
+}
+
 function referenceNodeToWorkspaceFileEntry(
   node: ReferenceNode
 ): WorkspaceFileEntry {
@@ -1629,9 +1737,20 @@ function referenceNodeToWorkspaceFileEntry(
     kind: node.kind === "folder" ? "directory" : "file",
     mtimeMs: node.mtimeMs ?? null,
     name: node.displayName,
-    path: nodeRefKey(node.ref),
+    path: resolveReferenceNodeIconPath(node),
     sizeBytes: node.sizeBytes ?? null
   };
+}
+
+function resolveReferenceNodeIconPath(node: ReferenceNode): string {
+  if (node.kind === "file" && node.ref.nodeId.startsWith("f:")) {
+    try {
+      return base64UrlDecode(node.ref.nodeId.slice(2));
+    } catch {
+      return node.ref.nodeId;
+    }
+  }
+  return node.ref.nodeId;
 }
 
 function noopVoid(): void {}


### PR DESCRIPTION
## Summary

- Reuse the workspace file manager icon component and icon URL resolver in the resource picker.
- Pass the desktop file-manager icon resolver through AgentGUI so picker rows can resolve the same host/default app icons as file manager.
- Fix picker icon entry paths to use real reference file paths instead of opaque node identity keys, and size row icons like file manager rows so document fallbacks show as file icons instead of small white dots.

## Root Cause

The resource picker previously rendered generic file icons. The first reuse pass also adapted ReferenceNode to WorkspaceFileEntry using nodeRefKey(node.ref), which is a picker identity key, not a real file path. For small size-4 document fallback icons, the file-manager component hides extension text, leaving a white document body that looked like a dot on the dark picker background.

## Validation

- pnpm --filter @tutti-os/workspace-file-reference test -- src/ui/internal/reference/ReferenceSourcePicker.source.test.ts
- pnpm --filter @tutti-os/workspace-file-reference typecheck
- pnpm --filter @tutti-os/agent-gui typecheck
- pnpm --filter @tutti-os/desktop typecheck
- pnpm check:changed
- pre-push pnpm check:full
