### PR TITLE
[codex] Drive agent outcome notifications from turn events

### DIFF
--- a/apps/desktop/src/renderer/src/app/windows/workspace/createWorkspaceWindowContainer.ts
+++ b/apps/desktop/src/renderer/src/app/windows/workspace/createWorkspaceWindowContainer.ts
@@ -20,6 +20,8 @@ import { registerWorkspaceFileManagerServices } from "@renderer/features/workspa
 import { registerWorkspaceUserProjectServices } from "@renderer/features/workspace-user-project";
 import {
   createAgentProviderTerminalCommandRunner,
+  createWorkspaceAgentOutcomeForegroundNotificationPresenter,
+  createWorkspaceAgentOutcomeNotificationController,
   registerWorkspaceWorkbenchServices
 } from "@renderer/features/workspace-workbench";
 import {
@@ -29,6 +31,7 @@ import {
 } from "@tutti-os/agent-gui/agent-message-center";
 import { normalizeAgentActivityDisplayStatus } from "@tutti-os/agent-activity-core";
 import { tuttiAgentAssetUrls } from "../../../../../shared/tuttiAssetProtocol.ts";
+import { translate } from "../../../i18n";
 import { getActiveLocale } from "../../../i18n/runtime";
 import { INotificationService } from "@tutti-os/ui-notifications";
 import { createToastNotificationService } from "@renderer/lib/notificationService";
@@ -59,6 +62,11 @@ export interface WorkspaceWindowContainerResult {
 export function createWorkspaceWindowContainer(): WorkspaceWindowContainerResult {
   const environment = resolveDesktopEnvironment(window.tutti);
   const desktopApi = environment.desktopApi;
+  const routeWorkspaceID = new URLSearchParams(window.location.search).get(
+    "workspaceId"
+  );
+  const activeWorkspaceID =
+    routeWorkspaceID || environment.startupWorkspaceID || "__default__";
   const tuttidClient = createDesktopTuttidClient(desktopApi.runtime);
   const tuttidEventStreamClient = createDesktopTuttidEventStreamClient(
     desktopApi.runtime
@@ -108,6 +116,7 @@ export function createWorkspaceWindowContainer(): WorkspaceWindowContainerResult
     eventStreamClient: tuttidEventStreamClient,
     reporterService
   });
+  let disposeAgentOutcomeNotificationController: (() => void) | null = null;
   let releasedWindowAnalytics = false;
   const releaseWindowAnalytics = () => {
     if (releasedWindowAnalytics) {
@@ -115,6 +124,8 @@ export function createWorkspaceWindowContainer(): WorkspaceWindowContainerResult
     }
     releasedWindowAnalytics = true;
     window.removeEventListener("beforeunload", releaseWindowAnalytics);
+    disposeAgentOutcomeNotificationController?.();
+    disposeAgentOutcomeNotificationController = null;
     predefinePageviewAnalytics.dispose();
     daemonConnectionAnalytics.release();
   };
@@ -168,6 +179,18 @@ export function createWorkspaceWindowContainer(): WorkspaceWindowContainerResult
     ),
     workspaceUserProjectService
   });
+  const agentOutcomeNotificationController =
+    createWorkspaceAgentOutcomeNotificationController({
+      foreground: createWorkspaceAgentOutcomeForegroundNotificationPresenter(),
+      notifications: notificationService,
+      translate,
+      workspaceAgentActivityService:
+        workspaceAgentServices.workspaceAgentActivityService,
+      workspaceId: activeWorkspaceID
+    });
+  disposeAgentOutcomeNotificationController = () => {
+    agentOutcomeNotificationController.dispose();
+  };
   registerRichTextAtServices(registry, {
     tuttidClient,
     getLocale: getActiveLocale,

--- a/apps/desktop/src/renderer/src/features/workspace-agent/index.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-agent/index.ts
@@ -20,6 +20,7 @@ export {
   desktopAgentGUIOpenSessionActivationType,
   desktopAgentGUIProviderFromInstanceId,
   normalizeDesktopAgentGUINodeState,
+  normalizeDesktopAgentGUIProvider,
   normalizeDesktopAgentGUIWorkbenchState
 } from "./desktopAgentGUINodeState";
 export type {

--- a/apps/desktop/src/renderer/src/features/workspace-agent/services/registerWorkspaceAgentServices.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-agent/services/registerWorkspaceAgentServices.ts
@@ -35,6 +35,7 @@ export interface WorkspaceAgentServiceRegistrationInput {
 
 export interface WorkspaceAgentServiceRegistrationResult {
   agentProviderStatusService: IAgentProviderStatusService;
+  workspaceAgentActivityService: IWorkspaceAgentActivityService;
 }
 
 export function registerWorkspaceAgentServices(
@@ -71,5 +72,5 @@ export function registerWorkspaceAgentServices(
       workspaceUserProjectService: input.workspaceUserProjectService
     })
   );
-  return { agentProviderStatusService };
+  return { agentProviderStatusService, workspaceAgentActivityService };
 }

--- a/apps/desktop/src/renderer/src/features/workspace-workbench/index.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/index.ts
@@ -1,4 +1,6 @@
 export { WorkspaceWorkbench } from "./ui/WorkspaceWorkbench";
 export { registerWorkspaceWorkbenchServices } from "./services/registerWorkspaceWorkbenchServices";
 export { createAgentProviderTerminalCommandRunner } from "./services/createAgentProviderTerminalCommandRunner";
+export { createWorkspaceAgentOutcomeNotificationController } from "./services/workspaceAgentOutcomeNotification";
+export { createWorkspaceAgentOutcomeForegroundNotificationPresenter } from "./ui/WorkspaceAgentOutcomeNotificationToast";
 export { IWorkspaceSettingsService } from "./services/workspaceSettingsService.interface";

--- a/apps/desktop/src/renderer/src/features/workspace-workbench/services/workspaceAgentOutcomeNotification.test.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/services/workspaceAgentOutcomeNotification.test.ts
@@ -1,170 +1,183 @@
 import assert from "node:assert/strict";
 import test from "node:test";
-import type { WorkspaceAgentMessageCenterItem } from "@tutti-os/agent-gui/agent-message-center";
+import type { NotificationMessage } from "@tutti-os/ui-notifications";
 import {
-  buildWorkspaceAgentOutcomeNotification,
-  workspaceAgentOutcomeNotificationKey,
-  type WorkspaceAgentOutcomeNotificationLabels
+  buildWorkspaceAgentOutcomeNotificationFromSessionEvent,
+  createWorkspaceAgentOutcomeNotificationController
 } from "./workspaceAgentOutcomeNotification.ts";
 
-const labels: WorkspaceAgentOutcomeNotificationLabels = {
-  completedBody: "The agent finished this run.",
-  failedBody: "The agent run failed.",
-  fallbackAgentName: "Agent"
-};
-
-test("outcome notification builder reports completed turns as success", () => {
+test("outcome notification builder reports completed turn state patches as success", () => {
   assert.deepEqual(
-    buildWorkspaceAgentOutcomeNotification(
-      item({ status: "completed" }),
-      labels
+    buildWorkspaceAgentOutcomeNotificationFromSessionEvent(
+      statePatchEvent({ outcome: "success" })
     ),
     {
-      agentName: "Codex",
       agentSessionId: "session-1",
-      body: "The agent finished this run.",
       conversationTitle: "Build feature",
-      level: "success"
-    }
-  );
-});
-
-test("outcome notification builder reports latest completed turn outcomes while the session is idle", () => {
-  const completedTurn = item({
-    status: "idle",
-    latestTurnOutcome: {
-      notificationKey: "session-1:turn:turn-2:completed",
+      level: "success",
+      provider: "codex",
       status: "completed",
-      turnId: "turn-2"
-    }
-  });
-
-  assert.equal(
-    workspaceAgentOutcomeNotificationKey(completedTurn),
-    "session-1:turn:turn-2:completed"
-  );
-  assert.deepEqual(
-    buildWorkspaceAgentOutcomeNotification(completedTurn, labels),
-    {
-      agentName: "Codex",
-      agentSessionId: "session-1",
-      body: "The agent finished this run.",
-      conversationTitle: "Build feature",
-      level: "success"
+      workspaceId: "ws-1"
     }
   );
 });
 
-test("outcome notification builder reports terminal session status instead of stale turn outcomes", () => {
-  const failedSession = item({
-    status: "failed",
-    latestTurnOutcome: {
-      notificationKey: "session-1:turn:turn-1:completed",
-      status: "completed",
-      turnId: "turn-1"
-    }
-  });
-
-  assert.equal(
-    workspaceAgentOutcomeNotificationKey(failedSession),
-    "session-1:session:failed"
-  );
+test("outcome notification builder reports failed turn state patches as error", () => {
   assert.deepEqual(
-    buildWorkspaceAgentOutcomeNotification(failedSession, labels),
-    {
-      agentName: "Codex",
-      agentSessionId: "session-1",
-      body: "The agent run failed.",
-      conversationTitle: "Build feature",
-      level: "error"
-    }
-  );
-});
-
-test("outcome notification builder reports failed turns as error", () => {
-  assert.deepEqual(
-    buildWorkspaceAgentOutcomeNotification(item({ status: "failed" }), labels),
-    {
-      agentName: "Codex",
-      agentSessionId: "session-1",
-      body: "The agent run failed.",
-      conversationTitle: "Build feature",
-      level: "error"
-    }
-  );
-});
-
-test("outcome notification builder stays silent for canceled turns", () => {
-  assert.equal(
-    buildWorkspaceAgentOutcomeNotification(
-      item({ status: "canceled" }),
-      labels
+    buildWorkspaceAgentOutcomeNotificationFromSessionEvent(
+      statePatchEvent({ outcome: "failed" })
     ),
+    {
+      agentSessionId: "session-1",
+      conversationTitle: "Build feature",
+      level: "error",
+      provider: "codex",
+      status: "failed",
+      workspaceId: "ws-1"
+    }
+  );
+});
+
+test("outcome notification builder ignores message updates", () => {
+  assert.equal(
+    buildWorkspaceAgentOutcomeNotificationFromSessionEvent({
+      eventType: "message_update",
+      data: {
+        workspaceId: "ws-1",
+        agentSessionId: "session-1",
+        messages: [
+          {
+            role: "assistant",
+            status: "completed",
+            turnId: "turn-1"
+          }
+        ]
+      }
+    }),
     null
   );
 });
 
-test("outcome notification builder stays silent for non-terminal items", () => {
-  for (const status of ["idle", "waiting", "working"] as const) {
-    assert.equal(
-      buildWorkspaceAgentOutcomeNotification(item({ status }), labels),
-      null
-    );
-  }
-});
-
-test("outcome notification builder formats multi-part provider names", () => {
-  const notification = buildWorkspaceAgentOutcomeNotification(
-    item({ provider: "claude-code", status: "completed" }),
-    labels
+test("outcome notification builder ignores state patches without stable turn outcome", () => {
+  assert.equal(
+    buildWorkspaceAgentOutcomeNotificationFromSessionEvent(
+      statePatchEvent({ outcome: "canceled" })
+    ),
+    null
   );
-
-  assert.equal(notification?.agentName, "Claude Code");
-});
-
-test("outcome notification builder falls back to the agent label", () => {
-  const notification = buildWorkspaceAgentOutcomeNotification(
-    item({ provider: "  ", status: "failed" }),
-    labels
+  assert.equal(
+    buildWorkspaceAgentOutcomeNotificationFromSessionEvent(
+      statePatchEvent({ outcome: "success", turnId: "" })
+    ),
+    null
   );
-
-  assert.equal(notification?.agentName, "Agent");
-});
-
-test("outcome notification builder trims the conversation title", () => {
-  const notification = buildWorkspaceAgentOutcomeNotification(
-    item({ status: "completed", title: "  Build feature  " }),
-    labels
+  assert.equal(
+    buildWorkspaceAgentOutcomeNotificationFromSessionEvent({
+      eventType: "state_patch",
+      data: {
+        workspaceId: "ws-1",
+        agentSessionId: "session-1",
+        lifecycleStatus: "failed",
+        provider: "codex",
+        title: "Build feature"
+      }
+    }),
+    null
   );
-
-  assert.equal(notification?.conversationTitle, "Build feature");
 });
 
-function item(
-  overrides: Partial<WorkspaceAgentMessageCenterItem>
-): WorkspaceAgentMessageCenterItem {
-  return {
-    agentSessionId: "session-1",
-    userId: null,
-    cwd: "/workspace",
-    id: "message-center-session-1",
-    identity: null,
-    digest: {
-      primary: {
-        kind: "progress",
-        summary: "Summarized progress",
-        occurredAtUnixMs: 100
+test("outcome notification controller notifies from live session events", () => {
+  const events: Array<(event: unknown) => void> = [];
+  const foregroundNotifications: unknown[] = [];
+  const notifications: NotificationMessage[] = [];
+  const controller = createWorkspaceAgentOutcomeNotificationController({
+    foreground: {
+      show(notification) {
+        foregroundNotifications.push(notification);
       }
     },
-    lastAgentMessageAtUnixMs: 100,
-    lastAgentMessageSummary: "Summarized progress",
-    needsAttentionKind: null,
-    needsAttentionSummary: null,
-    pendingPrompt: null,
-    provider: "codex",
-    sortTimeUnixMs: 100,
-    status: "working",
-    title: "Build feature",
-    ...overrides
+    notifications: {
+      notify(message) {
+        notifications.push(message);
+      }
+    },
+    translate(key, params) {
+      if (key.endsWith("CompletedBody")) {
+        return "The agent finished this run.";
+      }
+      if (key.endsWith("CompletedTitle")) {
+        return `${params?.title} completed`;
+      }
+      if (key.endsWith("CompletedStatus")) {
+        return "Completed";
+      }
+      if (key === "workspace.agentGui.fallbackAgentLabel") {
+        return "Agent";
+      }
+      if (key === "common.close") {
+        return "Close";
+      }
+      return key;
+    },
+    workspaceAgentActivityService: {
+      onSessionEvent(workspaceId, listener) {
+        assert.equal(workspaceId, "ws-1");
+        events.push(listener);
+        return () => {
+          const index = events.indexOf(listener);
+          if (index >= 0) {
+            events.splice(index, 1);
+          }
+        };
+      }
+    },
+    workspaceId: "ws-1"
+  });
+
+  events[0]?.(statePatchEvent({ outcome: "success" }));
+
+  assert.deepEqual(foregroundNotifications, [
+    {
+      agentName: "Codex",
+      agentSessionId: "session-1",
+      body: "The agent finished this run.",
+      closeLabel: "Close",
+      conversationTitle: "Build feature",
+      level: "success",
+      provider: "codex",
+      statusLabel: "Completed",
+      workspaceId: "ws-1"
+    }
+  ]);
+  assert.equal(notifications.length, 1);
+  assert.deepEqual(notifications[0], {
+    description: "The agent finished this run.",
+    level: "success",
+    navigation: {
+      agentSessionId: "session-1",
+      provider: "codex",
+      workspaceId: "ws-1"
+    },
+    presentation: "background-only",
+    title: "Build feature completed"
+  });
+
+  controller.dispose();
+  assert.equal(events.length, 0);
+});
+
+function statePatchEvent(input: { outcome: string; turnId?: string }): unknown {
+  return {
+    eventType: "state_patch",
+    data: {
+      workspaceId: "ws-1",
+      agentSessionId: "session-1",
+      provider: "codex",
+      title: "Build feature",
+      turn: {
+        turnId: input.turnId ?? "turn-1",
+        outcome: input.outcome
+      }
+    }
   };
 }

--- a/apps/desktop/src/renderer/src/features/workspace-workbench/services/workspaceAgentOutcomeNotification.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/services/workspaceAgentOutcomeNotification.ts
@@ -1,73 +1,186 @@
-import type { WorkspaceAgentMessageCenterItem } from "@tutti-os/agent-gui/agent-message-center";
-import { formatAgentGuiConversationPlainTitle } from "@tutti-os/agent-gui/workbench/sessionTitle";
+import type { NotificationService } from "@tutti-os/ui-notifications";
+import type { CompositeNotificationMessage } from "@renderer/lib/compositeNotificationService";
+import type { DesktopI18nKey, I18nParams } from "@shared/i18n";
+import type { IWorkspaceAgentActivityService } from "@renderer/features/workspace-agent";
+
+export interface WorkspaceAgentOutcomeNotificationController {
+  dispose(): void;
+}
 
 export interface WorkspaceAgentOutcomeNotification {
+  agentSessionId: string;
+  conversationTitle: string;
+  level: "error" | "success";
+  provider: string;
+  status: "completed" | "failed";
+  workspaceId: string;
+}
+
+export interface WorkspaceAgentOutcomeForegroundNotification {
   agentName: string;
   agentSessionId: string;
   body: string;
+  closeLabel: string;
   conversationTitle: string;
   level: "error" | "success";
+  provider: string;
+  statusLabel: string;
+  workspaceId: string;
 }
 
-export interface WorkspaceAgentOutcomeNotificationLabels {
-  completedBody: string;
-  failedBody: string;
-  fallbackAgentName: string;
+export interface WorkspaceAgentOutcomeForegroundNotificationPresenter {
+  show(notification: WorkspaceAgentOutcomeForegroundNotification): void;
 }
 
-export function buildWorkspaceAgentOutcomeNotification(
-  item: WorkspaceAgentMessageCenterItem,
-  labels: WorkspaceAgentOutcomeNotificationLabels
-): WorkspaceAgentOutcomeNotification | null {
-  const status = workspaceAgentOutcomeNotificationStatus(item);
-  const level = outcomeNotificationLevel(status);
-  if (!level) {
-    return null;
+export interface WorkspaceAgentOutcomeNotificationControllerInput {
+  foreground?: WorkspaceAgentOutcomeForegroundNotificationPresenter;
+  notifications: Pick<NotificationService, "notify">;
+  translate(key: DesktopI18nKey, params?: I18nParams): string;
+  workspaceAgentActivityService: Pick<
+    IWorkspaceAgentActivityService,
+    "onSessionEvent"
+  >;
+  workspaceId: string;
+}
+
+export function createWorkspaceAgentOutcomeNotificationController(
+  input: WorkspaceAgentOutcomeNotificationControllerInput
+): WorkspaceAgentOutcomeNotificationController {
+  const workspaceId = input.workspaceId.trim();
+  if (!workspaceId) {
+    return { dispose() {} };
   }
+
+  const unsubscribe = input.workspaceAgentActivityService.onSessionEvent(
+    workspaceId,
+    (event) => {
+      const notification =
+        buildWorkspaceAgentOutcomeNotificationFromSessionEvent(event);
+      if (!notification) {
+        return;
+      }
+      input.foreground?.show(
+        workspaceAgentOutcomeForegroundNotification(
+          notification,
+          input.translate
+        )
+      );
+      input.notifications.notify(
+        workspaceAgentOutcomeNotificationMessage(notification, input.translate)
+      );
+    }
+  );
+
   return {
-    agentName:
-      formatWorkspaceAgentProviderName(item.provider) ||
-      labels.fallbackAgentName,
-    agentSessionId: item.agentSessionId,
-    body: level === "success" ? labels.completedBody : labels.failedBody,
-    conversationTitle: formatAgentGuiConversationPlainTitle(item),
-    level
+    dispose() {
+      unsubscribe();
+    }
   };
 }
 
-export function workspaceAgentOutcomeNotificationKey(
-  item: WorkspaceAgentMessageCenterItem
-): string | null {
-  if (item.latestTurnOutcome && item.status === "idle") {
-    return item.latestTurnOutcome.notificationKey;
-  }
-  const status = workspaceAgentOutcomeNotificationStatus(item);
-  if (!status) {
+export function buildWorkspaceAgentOutcomeNotificationFromSessionEvent(
+  event: unknown
+): WorkspaceAgentOutcomeNotification | null {
+  const source = recordValue(event);
+  if (stringValue(source?.eventType) !== "state_patch") {
     return null;
   }
-  return `${item.agentSessionId}:session:${status}`;
-}
-
-function workspaceAgentOutcomeNotificationStatus(
-  item: WorkspaceAgentMessageCenterItem
-): WorkspaceAgentMessageCenterItem["status"] | null {
-  if (item.latestTurnOutcome && item.status === "idle") {
-    return item.latestTurnOutcome.status;
+  const data = recordValue(source?.data);
+  const turn = recordValue(data?.turn);
+  const status = outcomeStatusFromTurnOutcome(stringValue(turn?.outcome));
+  const turnId = stringValue(turn?.turnId);
+  if (!data || !turn || !status || !turnId) {
+    return null;
   }
-  return item.status;
+  const workspaceId = stringValue(data.workspaceId);
+  const agentSessionId = stringValue(data.agentSessionId);
+  const provider = stringValue(data.provider);
+  if (!workspaceId || !agentSessionId || !provider) {
+    return null;
+  }
+  return {
+    agentSessionId,
+    conversationTitle: stringValue(data.title),
+    level: status === "completed" ? "success" : "error",
+    provider,
+    status,
+    workspaceId
+  };
 }
 
-function outcomeNotificationLevel(
-  status: WorkspaceAgentMessageCenterItem["status"] | null
-): WorkspaceAgentOutcomeNotification["level"] | null {
-  switch (status) {
+function workspaceAgentOutcomeNotificationMessage(
+  notification: WorkspaceAgentOutcomeNotification,
+  translate: WorkspaceAgentOutcomeNotificationControllerInput["translate"]
+): CompositeNotificationMessage {
+  const titleFallback =
+    notification.conversationTitle ||
+    formatWorkspaceAgentProviderName(notification.provider);
+  return {
+    description: translate(
+      notification.status === "completed"
+        ? "workspace.agentMessageCenter.outcomeNotificationCompletedBody"
+        : "workspace.agentMessageCenter.outcomeNotificationFailedBody"
+    ),
+    level: notification.level,
+    navigation: {
+      agentSessionId: notification.agentSessionId,
+      provider: notification.provider,
+      workspaceId: notification.workspaceId
+    },
+    presentation: "background-only",
+    title: translate(
+      notification.status === "completed"
+        ? "workspace.agentMessageCenter.outcomeNotificationCompletedTitle"
+        : "workspace.agentMessageCenter.outcomeNotificationFailedTitle",
+      {
+        title:
+          titleFallback || translate("workspace.agentGui.fallbackAgentLabel")
+      }
+    )
+  };
+}
+
+function workspaceAgentOutcomeForegroundNotification(
+  notification: WorkspaceAgentOutcomeNotification,
+  translate: WorkspaceAgentOutcomeNotificationControllerInput["translate"]
+): WorkspaceAgentOutcomeForegroundNotification {
+  const agentName =
+    formatWorkspaceAgentProviderName(notification.provider) ||
+    translate("workspace.agentGui.fallbackAgentLabel");
+  return {
+    agentName,
+    agentSessionId: notification.agentSessionId,
+    body: translate(
+      notification.status === "completed"
+        ? "workspace.agentMessageCenter.outcomeNotificationCompletedBody"
+        : "workspace.agentMessageCenter.outcomeNotificationFailedBody"
+    ),
+    closeLabel: translate("common.close"),
+    conversationTitle: notification.conversationTitle,
+    level: notification.level,
+    provider: notification.provider,
+    statusLabel: translate(
+      notification.status === "completed"
+        ? "workspace.agentMessageCenter.outcomeNotificationCompletedStatus"
+        : "workspace.agentMessageCenter.outcomeNotificationFailedStatus"
+    ),
+    workspaceId: notification.workspaceId
+  };
+}
+
+function outcomeStatusFromTurnOutcome(
+  outcome: string
+): WorkspaceAgentOutcomeNotification["status"] | null {
+  switch (outcome.trim().toLowerCase()) {
     case "completed":
-      return "success";
+    case "done":
+    case "success":
+    case "succeeded":
+      return "completed";
+    case "error":
     case "failed":
-      return "error";
+      return "failed";
     default:
-      // Canceled turns are user-initiated and must stay silent; non-terminal
-      // statuses are covered by the waiting/decision notifications.
       return null;
   }
 }
@@ -79,4 +192,14 @@ function formatWorkspaceAgentProviderName(provider: string): string {
     .filter(Boolean)
     .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
     .join(" ");
+}
+
+function recordValue(value: unknown): Record<string, unknown> | null {
+  return typeof value === "object" && value !== null
+    ? (value as Record<string, unknown>)
+    : null;
+}
+
+function stringValue(value: unknown): string {
+  return typeof value === "string" ? value.trim() : "";
 }

--- a/apps/desktop/src/renderer/src/features/workspace-workbench/ui/WorkspaceAgentOutcomeNotificationToast.tsx
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/ui/WorkspaceAgentOutcomeNotificationToast.tsx
@@ -1,0 +1,128 @@
+import { managedAgentRoundedIconUrl } from "@tutti-os/agent-gui/agent-message-center";
+import { Button, CloseIcon, StatusDot, toast } from "@tutti-os/ui-system";
+import {
+  normalizeDesktopAgentGUIProvider,
+  requestWorkspaceAgentGuiLaunch
+} from "@renderer/features/workspace-agent";
+import type {
+  WorkspaceAgentOutcomeForegroundNotification,
+  WorkspaceAgentOutcomeForegroundNotificationPresenter
+} from "../services/workspaceAgentOutcomeNotification";
+
+const WORKSPACE_AGENT_OUTCOME_TOAST_DURATION = 6000;
+const workspaceAgentDecisionToastClassName = "workspace-agent-decision-toast";
+
+export function createWorkspaceAgentOutcomeForegroundNotificationPresenter(): WorkspaceAgentOutcomeForegroundNotificationPresenter {
+  return {
+    show(notification) {
+      toast.custom(
+        (id) => (
+          <WorkspaceAgentOutcomeToast
+            agentIconUrl={managedAgentRoundedIconUrl(notification.provider)}
+            agentName={notification.agentName}
+            body={notification.body}
+            closeLabel={notification.closeLabel}
+            conversationTitle={notification.conversationTitle}
+            level={notification.level}
+            statusLabel={notification.statusLabel}
+            onClose={() => toast.dismiss(id)}
+            onOpen={() => {
+              toast.dismiss(id);
+              void requestWorkspaceAgentGuiLaunch({
+                agentSessionId: notification.agentSessionId,
+                provider: normalizeDesktopAgentGUIProvider(
+                  notification.provider
+                ),
+                workspaceId: notification.workspaceId
+              });
+            }}
+          />
+        ),
+        {
+          className: workspaceAgentDecisionToastClassName,
+          duration: WORKSPACE_AGENT_OUTCOME_TOAST_DURATION
+        }
+      );
+    }
+  };
+}
+
+function WorkspaceAgentOutcomeToast({
+  agentIconUrl,
+  agentName,
+  body,
+  closeLabel,
+  conversationTitle,
+  level,
+  statusLabel,
+  onClose,
+  onOpen
+}: {
+  agentIconUrl: string;
+  agentName: string;
+  body: string;
+  closeLabel: string;
+  conversationTitle: string;
+  level: WorkspaceAgentOutcomeForegroundNotification["level"];
+  statusLabel: string;
+  onClose: () => void;
+  onOpen: () => void;
+}) {
+  "use memo";
+  const displayTitle = conversationTitle || agentName;
+  const tone = level === "success" ? "green" : "red";
+
+  return (
+    <article className="relative w-full min-w-0 overflow-visible rounded-[12px] border border-[var(--tutti-purple-border)] bg-[var(--tutti-purple-bg)] p-3.5">
+      <span
+        aria-hidden="true"
+        className="workspace-agent-decision-toast__edge-glow agent-gui-edge-glow pointer-events-none inset-0 rounded-[12px]"
+        style={{ position: "absolute" }}
+      />
+      <Button
+        type="button"
+        aria-label={closeLabel}
+        className="workspace-agent-decision-toast__close absolute top-0 right-0 z-[2] size-6 translate-x-[35%] -translate-y-[35%] rounded-full border-[var(--line-2)] bg-[var(--background-panel)] text-[var(--text-secondary)] shadow-sm hover:bg-[var(--background-fronted)] hover:text-[var(--text-primary)] focus-visible:ring-[color-mix(in_srgb,var(--border-focus)_30%,transparent)]"
+        size="icon-xs"
+        variant="chrome"
+        onClick={onClose}
+      >
+        <CloseIcon className="size-4" />
+      </Button>
+      <button
+        type="button"
+        className="workspace-agent-decision-toast__content relative z-[1] grid w-full min-w-0 cursor-pointer gap-2.5 text-left"
+        onClick={onOpen}
+      >
+        <div className="flex min-w-0 items-center justify-between gap-2.5 pr-2">
+          <h3 className="min-w-0 truncate text-[13px] font-bold leading-5 text-[var(--text-secondary)]">
+            {displayTitle}
+          </h3>
+          <span
+            className="inline-flex shrink-0 items-center gap-1.5 text-[11px] font-semibold leading-4 text-[var(--text-secondary)]"
+            data-status={level}
+            title={statusLabel}
+          >
+            <StatusDot tone={tone} size="sm" title={statusLabel} />
+            <span>{statusLabel}</span>
+          </span>
+        </div>
+        <p className="workspace-agent-decision-toast__outcome-card min-w-0 text-[13px] leading-5 text-[var(--text-secondary)]">
+          {body}
+        </p>
+        <div className="flex min-w-0 items-center gap-2 text-[13px] leading-5 text-[var(--text-secondary)]">
+          <span className="inline-flex size-5 shrink-0 items-center justify-center overflow-hidden rounded-full border border-[var(--line-1)] bg-[var(--transparency-block)]">
+            <img
+              src={agentIconUrl}
+              alt={agentName}
+              className="size-full object-cover"
+              decoding="async"
+              draggable={false}
+            />
+          </span>
+          <span className="min-w-0 truncate">{agentName}</span>
+        </div>
+      </button>
+    </article>
+  );
+}

--- a/apps/desktop/src/renderer/src/features/workspace-workbench/ui/WorkspaceChrome.tsx
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/ui/WorkspaceChrome.tsx
@@ -12,7 +12,6 @@ import {
   buildWorkspaceAgentInteractivePromptLabels,
   buildWorkspaceAgentMessageCenterModel,
   isWaitingMessageCenterItem,
-  managedAgentRoundedIconUrl,
   stabilizeWorkspaceAgentMessageCenterModel,
   WorkspaceAgentMessageCenterPanel,
   type WorkspaceAgentMessageCenterItem,
@@ -63,10 +62,6 @@ import {
   buildWorkspaceAgentDecisionNotification,
   type WorkspaceAgentDecisionSubmitInput
 } from "../services/workspaceAgentDecisionNotification";
-import {
-  buildWorkspaceAgentOutcomeNotification,
-  workspaceAgentOutcomeNotificationKey
-} from "../services/workspaceAgentOutcomeNotification";
 import { resolveWorkspaceAgentMessageCenterTrigger } from "../services/workspaceAgentMessageCenterTrigger";
 import { toggleWorkspaceAgentMessageCenter } from "../services/workspaceAgentMessageCenterToggle";
 import { registerWorkspaceMessageCenterOpenHandler } from "../services/workspaceMessageCenterCoordinator";
@@ -88,8 +83,6 @@ const MESSAGE_CENTER_SUMMARY_MESSAGE_LIMIT = 20;
 const MESSAGE_CENTER_SUMMARY_PREFETCH_ITEM_LIMIT = 12;
 const MESSAGE_CENTER_VISIBLE_HISTORY_MS = 7 * 24 * 60 * 60 * 1000;
 const WORKSPACE_AGENT_DECISION_TOAST_DURATION = Infinity;
-// Completion is informational, so the card auto-dismisses after a short window.
-const WORKSPACE_AGENT_OUTCOME_TOAST_DURATION = 6000;
 const WORKSPACE_CHROME_MAC_TRAFFIC_LIGHT_INSET_PX = 16;
 const WORKSPACE_CHROME_MAC_TRAFFIC_LIGHT_GUTTER_PX = 64;
 const WORKSPACE_CHROME_MAC_TRAFFIC_LIGHT_RESERVED_WIDTH_PX =
@@ -272,7 +265,6 @@ function WorkspaceAgentMessageCenterAction({
   } | null>(null);
   const requestedMessageSummarySessionIdsRef = useRef<Set<string>>(new Set());
   const seenWaitingNotificationKeysRef = useRef<Set<string> | null>(null);
-  const seenOutcomeNotificationKeysRef = useRef<Set<string> | null>(null);
   const activeWaitingNotificationToastIdsRef = useRef<Map<string, string>>(
     new Map()
   );
@@ -378,7 +370,6 @@ function WorkspaceAgentMessageCenterAction({
   useEffect(() => {
     requestedMessageSummarySessionIdsRef.current.clear();
     seenWaitingNotificationKeysRef.current = null;
-    seenOutcomeNotificationKeysRef.current = null;
     for (const toastId of activeWaitingNotificationToastIdsRef.current.values()) {
       toast.dismiss(toastId);
     }
@@ -404,82 +395,6 @@ function WorkspaceAgentMessageCenterAction({
     },
     [launchNode]
   );
-
-  useEffect(() => {
-    const outcomeEntries = model.items
-      .map(
-        (item) => [workspaceAgentOutcomeNotificationKey(item), item] as const
-      )
-      .filter(
-        (entry): entry is readonly [string, WorkspaceAgentMessageCenterItem] =>
-          entry[0] !== null
-      );
-    const currentKeys = new Set(outcomeEntries.map(([key]) => key));
-    const seenKeys = seenOutcomeNotificationKeysRef.current;
-    if (!seenKeys) {
-      seenOutcomeNotificationKeysRef.current = currentKeys;
-      return;
-    }
-    const nextSeenKeys = new Set(seenKeys);
-    for (const key of currentKeys) {
-      nextSeenKeys.add(key);
-    }
-    seenOutcomeNotificationKeysRef.current = nextSeenKeys;
-    for (const [notificationKey, item] of outcomeEntries) {
-      if (seenKeys.has(notificationKey)) {
-        continue;
-      }
-      const notification = buildWorkspaceAgentOutcomeNotification(item, {
-        completedBody: t(
-          "workspace.agentMessageCenter.outcomeNotificationCompletedBody"
-        ),
-        failedBody: t(
-          "workspace.agentMessageCenter.outcomeNotificationFailedBody"
-        ),
-        fallbackAgentName: t("workspace.agentGui.fallbackAgentLabel")
-      });
-      if (!notification) {
-        continue;
-      }
-      // When the message center panel is open it already surfaces the outcome
-      // in-app, so skip the card. Otherwise raise an in-app notification card
-      // (no OS/system notification) that auto-dismisses after a short while.
-      if (open) {
-        continue;
-      }
-      const toastId = `workspace-agent-outcome:${workspace.id}:${notificationKey}`;
-      toast.custom(
-        (id) => (
-          <WorkspaceAgentOutcomeToast
-            agentIconUrl={managedAgentRoundedIconUrl(item.provider)}
-            agentName={notification.agentName}
-            body={notification.body}
-            closeLabel={t("common.close")}
-            conversationTitle={notification.conversationTitle}
-            level={notification.level}
-            statusLabel={t(
-              notification.level === "success"
-                ? "workspace.agentMessageCenter.outcomeNotificationCompletedStatus"
-                : "workspace.agentMessageCenter.outcomeNotificationFailedStatus"
-            )}
-            onClose={() => toast.dismiss(id)}
-            onOpen={() => {
-              toast.dismiss(id);
-              openMessageCenterChat({
-                agentSessionId: notification.agentSessionId,
-                provider: item.provider
-              });
-            }}
-          />
-        ),
-        {
-          className: workspaceAgentDecisionToastClassName,
-          id: toastId,
-          duration: WORKSPACE_AGENT_OUTCOME_TOAST_DURATION
-        }
-      );
-    }
-  }, [model, open, openMessageCenterChat, t, workspace.id]);
 
   useEffect(() => {
     const waitingEntries = waitingItems.map(
@@ -915,86 +830,6 @@ function WorkspaceAgentDecisionToast({
           <span className="min-w-0 truncate">{agentName}</span>
         </div>
       </div>
-    </article>
-  );
-}
-
-function WorkspaceAgentOutcomeToast({
-  agentIconUrl,
-  agentName,
-  body,
-  closeLabel,
-  conversationTitle,
-  level,
-  statusLabel,
-  onClose,
-  onOpen
-}: {
-  agentIconUrl: string;
-  agentName: string;
-  body: string;
-  closeLabel: string;
-  conversationTitle: string;
-  level: "error" | "success";
-  statusLabel: string;
-  onClose: () => void;
-  onOpen: () => void;
-}) {
-  "use memo";
-  const displayTitle = conversationTitle || agentName;
-  const tone = level === "success" ? "green" : "red";
-
-  return (
-    <article className="relative w-full min-w-0 overflow-visible rounded-[12px] border border-[var(--tutti-purple-border)] bg-[var(--tutti-purple-bg)] p-3.5">
-      <span
-        aria-hidden="true"
-        className="workspace-agent-decision-toast__edge-glow agent-gui-edge-glow pointer-events-none inset-0 rounded-[12px]"
-        style={{ position: "absolute" }}
-      />
-      <Button
-        type="button"
-        aria-label={closeLabel}
-        className="workspace-agent-decision-toast__close absolute top-0 right-0 z-[2] size-6 translate-x-[35%] -translate-y-[35%] rounded-full border-[var(--line-2)] bg-[var(--background-panel)] text-[var(--text-secondary)] shadow-sm hover:bg-[var(--background-fronted)] hover:text-[var(--text-primary)] focus-visible:ring-[color-mix(in_srgb,var(--border-focus)_30%,transparent)]"
-        size="icon-xs"
-        variant="chrome"
-        onClick={onClose}
-      >
-        <CloseIcon className="size-4" />
-      </Button>
-      <button
-        type="button"
-        className="workspace-agent-decision-toast__content relative z-[1] grid w-full min-w-0 cursor-pointer gap-2.5 text-left"
-        onClick={onOpen}
-      >
-        <div className="flex min-w-0 items-center justify-between gap-2.5 pr-2">
-          <h3 className="min-w-0 truncate text-[13px] font-bold leading-5 text-[var(--text-secondary)]">
-            {displayTitle}
-          </h3>
-          <span
-            className="inline-flex shrink-0 items-center gap-1.5 text-[11px] font-semibold leading-4 text-[var(--text-secondary)]"
-            data-status={level}
-            title={statusLabel}
-          >
-            <StatusDot tone={tone} size="sm" title={statusLabel} />
-            <span>{statusLabel}</span>
-          </span>
-        </div>
-        <p className="workspace-agent-decision-toast__outcome-card min-w-0 text-[13px] leading-5 text-[var(--text-secondary)]">
-          {body}
-        </p>
-        <div className="flex min-w-0 items-center gap-2 text-[13px] leading-5 text-[var(--text-secondary)]">
-          <span className="inline-flex size-5 shrink-0 items-center justify-center overflow-hidden rounded-full border border-[var(--line-1)] bg-[var(--transparency-block)]">
-            <img
-              src={agentIconUrl}
-              alt={agentName}
-              className="size-full object-cover"
-              decoding="async"
-              draggable={false}
-            />
-          </span>
-          <span className="min-w-0 truncate">{agentName}</span>
-        </div>
-      </button>
     </article>
   );
 }

--- a/apps/desktop/src/renderer/src/lib/toast.test.ts
+++ b/apps/desktop/src/renderer/src/lib/toast.test.ts
@@ -13,6 +13,13 @@ const workspaceChromeSource = readFileSync(
   ),
   "utf8"
 );
+const workspaceOutcomeToastSource = readFileSync(
+  new URL(
+    "../features/workspace-workbench/ui/WorkspaceAgentOutcomeNotificationToast.tsx",
+    import.meta.url
+  ),
+  "utf8"
+);
 const desktopToastStyleSource = readFileSync(
   new URL(
     "../../../../../../packages/agent/gui/app/renderer/agentactivity.css",
@@ -216,23 +223,43 @@ test("desktop decision toast mirrors the message-center prompt card chrome", () 
   );
 });
 
-test("desktop outcome toast puts only its middle notification content in a fronted card", () => {
-  assert.match(
+test("workspace chrome does not own outcome toast UI", () => {
+  assert.doesNotMatch(
     workspaceChromeSource,
-    /workspace-agent-decision-toast__content relative z-\[1\] grid w-full min-w-0 cursor-pointer gap-2\.5 text-left/
+    /WorkspaceAgentOutcomeToast|workspace-agent-decision-toast__outcome-card|workspace-agent-outcome/
+  );
+});
+
+test("desktop outcome foreground notification uses the agent toast card", () => {
+  assert.match(
+    workspaceOutcomeToastSource,
+    /toast\.custom\([\s\S]*<WorkspaceAgentOutcomeToast/
   );
   assert.match(
-    workspaceChromeSource,
-    /<p className="workspace-agent-decision-toast__outcome-card min-w-0 text-\[13px\] leading-5 text-\[var\(--text-secondary\)\]">[\s\S]*\{body\}[\s\S]*<\/p>/
+    workspaceOutcomeToastSource,
+    /className: workspaceAgentDecisionToastClassName/
+  );
+  assert.match(
+    workspaceOutcomeToastSource,
+    /duration: WORKSPACE_AGENT_OUTCOME_TOAST_DURATION/
+  );
+  assert.match(
+    workspaceOutcomeToastSource,
+    /className="relative w-full min-w-0 overflow-visible rounded-\[12px\] border border-\[var\(--tutti-purple-border\)\] bg-\[var\(--tutti-purple-bg\)\] p-3\.5"/
+  );
+  assert.match(
+    workspaceOutcomeToastSource,
+    /workspace-agent-decision-toast__edge-glow agent-gui-edge-glow pointer-events-none inset-0 rounded-\[12px\]/
+  );
+  assert.match(
+    workspaceOutcomeToastSource,
+    /workspace-agent-decision-toast__outcome-card/
   );
   assert.match(
     desktopToastStyleSource,
     /\.workspace-agent-decision-toast__outcome-card\s*{[^}]*border:\s*1px solid var\(--line-1\);[^}]*border-radius:\s*8px;[^}]*background:\s*var\(--background-fronted\);[^}]*padding:\s*10px;/s
   );
-  assert.doesNotMatch(
-    workspaceChromeSource,
-    /workspace-agent-decision-toast__outcome-title|workspace-agent-decision-toast__outcome-body|workspace-agent-decision-toast__outcome-muted/
-  );
+  assert.doesNotMatch(workspaceOutcomeToastSource, /Toast\.Success/);
 });
 
 test("desktop generic toasts do not use edge glow", () => {


### PR DESCRIPTION
## What changed

- Added a `WorkspaceAgentOutcomeNotificationController` wired through the workspace window composition root.
- Moved completed/failed outcome detection out of `WorkspaceChrome` and into the controller, driven only by live `state_patch` turn outcome events.
- Kept foreground completion UI as the original agent-style custom card, now behind a thin foreground presenter instead of a React snapshot-diff effect.
- Kept background delivery as `background-only` OS notifications with navigation back to the session.
- Removed the UI-layer outcome snapshot diff/key/reset path while keeping waiting/decision notifications unchanged.

## Why

The old implementation inferred completion from the message center model inside React effects. Imported sessions, unread refreshes, or snapshot reloads could therefore look like new completions and required UI-level dedupe/reset keys to paper over lifecycle problems.

The stable lifecycle signal is the lower-level agent activity event: a live turn `state_patch` with terminal `data.turn.outcome`. The controller now listens to that signal directly, so REST loads and message updates do not trigger completion notifications.

## Impact

- Foreground completed/failed turns show the agent-card completion popup, not the generic green success toast.
- Background completed/failed turns still produce OS notifications with session navigation.
- Imported sessions and conversation refresh/open flows no longer emit false completion notifications.
- Canceled turns and session-level failures without a stable turn outcome remain silent.

## Validation

- `node --import ./apps/desktop/test/register-asset-stub.mjs --test --experimental-strip-types ./apps/desktop/src/renderer/src/features/workspace-workbench/services/workspaceAgentOutcomeNotification.test.ts ./apps/desktop/src/renderer/src/lib/toast.test.ts ./apps/desktop/src/renderer/src/lib/compositeNotificationService.test.ts`
- `pnpm --filter @tutti-os/desktop typecheck`
- `pnpm check:changed --tail-lines 80`
- pre-commit staged checks
- pre-push `pnpm check:full`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Workspace agent outcome updates now appear as a dedicated notification, including a foreground toast with open and dismiss actions.
  * Notifications are now tied to the active workspace, so updates are shown in the correct context.

* **Bug Fixes**
  * Improved handling of workspace agent outcome events so only valid terminal results are shown.
  * Removed duplicate outcome toast behavior from the main workspace chrome for cleaner notification display.

* **Refactor**
  * Updated workspace agent services and exports to support the new notification flow and activity tracking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->