### PR TITLE
fix(agent-gui): support host file drops

### DIFF
--- a/apps/desktop/src/main/ipc/hostFiles.ts
+++ b/apps/desktop/src/main/ipc/hostFiles.ts
@@ -1,5 +1,7 @@
 import {
   desktopIpcChannels,
+  type DesktopArchiveAgentPromptFileInput,
+  type DesktopArchiveAgentPromptFileResult,
   type DesktopClipboardImagePayload,
   type DesktopCreateUserDocumentsProjectDirectoryInput,
   type DesktopTerminalLinkPathPayload,
@@ -7,6 +9,10 @@ import {
   type DesktopWorkspaceFilePathPayload
 } from "../../shared/contracts/ipc";
 import { app, shell } from "electron";
+import { createHash } from "node:crypto";
+import { createReadStream } from "node:fs";
+import { chmod, copyFile, mkdir, stat, writeFile } from "node:fs/promises";
+import path from "node:path";
 import {
   writeFilesToSystemClipboard,
   writeImageToSystemClipboard
@@ -104,6 +110,11 @@ export function registerHostFilesIpc(deps: HostFilesIpcDependencies): void {
     (_event, payload: string) => hostAccess.readLocalPreviewFile(payload)
   );
   registerDesktopIpcHandler(
+    desktopIpcChannels.host.files.archiveAgentPromptFile,
+    (_event, payload: DesktopArchiveAgentPromptFileInput) =>
+      archiveAgentPromptFile(payload)
+  );
+  registerDesktopIpcHandler(
     desktopIpcChannels.host.files.readPreviewFile,
     (_event, payload: DesktopWorkspaceFilePathPayload) =>
       hostAccess.readPreviewFile(payload)
@@ -156,4 +167,110 @@ export function registerHostFilesIpc(deps: HostFilesIpcDependencies): void {
       writeFilesToSystemClipboard(payload);
     }
   );
+}
+
+async function archiveAgentPromptFile(
+  input: DesktopArchiveAgentPromptFileInput
+): Promise<DesktopArchiveAgentPromptFileResult> {
+  const workspaceID = sanitizeAgentPromptAssetSegment(input.workspaceID);
+  const displayName = normalizeAgentPromptAssetDisplayName(
+    input.displayName ?? input.hostPath ?? "attachment"
+  );
+  const dataBase64 = input.dataBase64?.trim() ?? "";
+  const hostPath = input.hostPath?.trim() ?? "";
+  let bytes: Buffer | null = null;
+  let sourcePath = "";
+  let sizeBytes = 0;
+  if (dataBase64) {
+    bytes = Buffer.from(dataBase64, "base64");
+    sizeBytes = bytes.byteLength;
+  } else if (hostPath) {
+    const sourceStat = await stat(hostPath);
+    if (!sourceStat.isFile()) {
+      throw new Error("Only regular files can be archived as prompt assets.");
+    }
+    sourcePath = hostPath;
+    sizeBytes = sourceStat.size;
+  } else {
+    throw new Error("Prompt asset archive requires hostPath or dataBase64.");
+  }
+  const hash = createHash("sha256");
+  if (bytes) {
+    hash.update(bytes);
+  } else {
+    await new Promise<void>((resolve, reject) => {
+      const stream = createReadStream(sourcePath);
+      stream.on("data", (chunk) => hash.update(chunk));
+      stream.on("error", reject);
+      stream.on("end", resolve);
+    });
+  }
+  const sha256 = hash.digest("hex");
+  const extension =
+    safeAgentPromptAssetExtension(displayName) ??
+    safeAgentPromptAssetExtension(input.mimeType ?? "") ??
+    "";
+  const archiveDir = path.join(
+    app.getPath("userData"),
+    "agent-prompt-assets",
+    workspaceID,
+    sha256.slice(0, 2)
+  );
+  await mkdir(archiveDir, { recursive: true, mode: 0o700 });
+  const archivePath = path.join(archiveDir, `${sha256}${extension}`);
+  if (bytes) {
+    await writeFile(archivePath, bytes, { mode: 0o600 });
+  } else {
+    await copyFile(sourcePath, archivePath);
+    await chmod(archivePath, 0o600);
+  }
+  return {
+    name: displayName,
+    path: archivePath,
+    sizeBytes
+  };
+}
+
+function normalizeAgentPromptAssetDisplayName(value: string): string {
+  const baseName = path.basename(value.trim()) || "attachment";
+  return baseName.replace(/[\r\n]/g, " ").trim() || "attachment";
+}
+
+function sanitizeAgentPromptAssetSegment(value: string): string {
+  const normalized = value.trim().replace(/[^a-zA-Z0-9._-]/g, "_");
+  if (!normalized || normalized === "." || normalized === "..") {
+    throw new Error("workspaceID is required to archive prompt assets.");
+  }
+  return normalized;
+}
+
+function safeAgentPromptAssetExtension(value: string): string | null {
+  const normalized = value.trim().toLowerCase();
+  const fromMimeType = normalized.includes("/")
+    ? promptAssetExtensionFromMimeType(normalized)
+    : "";
+  const extension = fromMimeType || path.extname(normalized);
+  if (!extension || extension.length > 16) {
+    return null;
+  }
+  return /^\.[a-z0-9]+$/.test(extension) ? extension : null;
+}
+
+function promptAssetExtensionFromMimeType(mimeType: string): string {
+  switch (mimeType) {
+    case "image/png":
+      return ".png";
+    case "image/jpeg":
+      return ".jpg";
+    case "image/webp":
+      return ".webp";
+    case "application/pdf":
+      return ".pdf";
+    case "text/plain":
+      return ".txt";
+    case "application/json":
+      return ".json";
+    default:
+      return "";
+  }
 }

--- a/apps/desktop/src/preload/api/host.ts
+++ b/apps/desktop/src/preload/api/host.ts
@@ -132,6 +132,12 @@ export function createHostDesktopApi(): DesktopHostApi {
           path
         );
       },
+      archiveAgentPromptFile(input) {
+        return invokeDesktopApi(
+          desktopIpcChannels.host.files.archiveAgentPromptFile,
+          input
+        );
+      },
       readPreviewFile(workspaceID: string, path: string): Promise<Uint8Array> {
         return invokeDesktopApi(desktopIpcChannels.host.files.readPreviewFile, {
           path,

--- a/apps/desktop/src/preload/types.ts
+++ b/apps/desktop/src/preload/types.ts
@@ -35,7 +35,9 @@ import type {
   DesktopWorkspaceAppExternalRendererRequest,
   DesktopWorkspaceAppExternalRendererResult,
   DesktopWorkspaceAppOpenFileResolvedPayload,
-  DesktopWorkspaceOpenFeatureRequest
+  DesktopWorkspaceOpenFeatureRequest,
+  DesktopArchiveAgentPromptFileInput,
+  DesktopArchiveAgentPromptFileResult
 } from "../shared/contracts/ipc";
 import type { BrowserNodeHostApi } from "@tutti-os/browser-node";
 
@@ -172,6 +174,9 @@ export interface DesktopHostFilesApi {
   }): Promise<void>;
   readLocalFileText(path: string): Promise<DesktopLocalFileTextResult>;
   readLocalPreviewFile(path: string): Promise<Uint8Array>;
+  archiveAgentPromptFile(
+    input: DesktopArchiveAgentPromptFileInput
+  ): Promise<DesktopArchiveAgentPromptFileResult>;
   readPreviewFile(workspaceID: string, path: string): Promise<Uint8Array>;
   resolveEntryIcon(
     workspaceID: string,

--- a/apps/desktop/src/renderer/src/features/workspace-agent/services/createDesktopAgentActivityRuntime.test.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-agent/services/createDesktopAgentActivityRuntime.test.ts
@@ -39,6 +39,15 @@ test("desktop agent activity runtime forwards package diagnostics to renderer di
   ]);
 });
 
+test("desktop agent activity runtime hides prompt uploads without archive support", () => {
+  const runtime = createDesktopAgentActivityRuntime(
+    createWorkspaceAgentActivityService()
+  );
+
+  assert.equal(runtime.promptContentUploadSupport?.file, false);
+  assert.equal(runtime.uploadPromptContent, undefined);
+});
+
 test("desktop agent activity runtime archives prompt file uploads", async () => {
   const archiveInputs: unknown[] = [];
   const runtime = createDesktopAgentActivityRuntime(

--- a/apps/desktop/src/renderer/src/features/workspace-agent/services/createDesktopAgentActivityRuntime.test.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-agent/services/createDesktopAgentActivityRuntime.test.ts
@@ -39,6 +39,111 @@ test("desktop agent activity runtime forwards package diagnostics to renderer di
   ]);
 });
 
+test("desktop agent activity runtime archives prompt file uploads", async () => {
+  const archiveInputs: unknown[] = [];
+  const runtime = createDesktopAgentActivityRuntime(
+    createWorkspaceAgentActivityService(),
+    {
+      hostFilesApi: {
+        async archiveAgentPromptFile(input) {
+          archiveInputs.push(input);
+          return {
+            name: input.displayName ?? "attachment",
+            path: "/Users/local/Library/Application Support/Tutti/agent-prompt-assets/ws/report.pdf",
+            sizeBytes: 42
+          };
+        }
+      }
+    }
+  );
+
+  const result = await runtime.uploadPromptContent?.({
+    workspaceId: "workspace-1",
+    content: [
+      {
+        type: "file",
+        hostPath: "/Users/local/Downloads/report.pdf",
+        name: "report.pdf",
+        kind: "file"
+      }
+    ]
+  });
+
+  assert.deepEqual(archiveInputs, [
+    {
+      workspaceID: "workspace-1",
+      hostPath: "/Users/local/Downloads/report.pdf",
+      displayName: "report.pdf",
+      mimeType: null
+    }
+  ]);
+  assert.deepEqual(result, {
+    content: [
+      {
+        type: "file",
+        hostPath: "/Users/local/Downloads/report.pdf",
+        name: "report.pdf",
+        kind: "file",
+        path: "/Users/local/Library/Application Support/Tutti/agent-prompt-assets/ws/report.pdf",
+        sizeBytes: 42,
+        uploadStatus: "uploaded"
+      }
+    ]
+  });
+});
+
+test("desktop agent activity runtime archives prompt image uploads", async () => {
+  const archiveInputs: unknown[] = [];
+  const runtime = createDesktopAgentActivityRuntime(
+    createWorkspaceAgentActivityService(),
+    {
+      hostFilesApi: {
+        async archiveAgentPromptFile(input) {
+          archiveInputs.push(input);
+          return {
+            name: input.displayName ?? "image.png",
+            path: "/Users/local/Library/Application Support/Tutti/agent-prompt-assets/ws/image.png",
+            sizeBytes: 12
+          };
+        }
+      }
+    }
+  );
+
+  const result = await runtime.uploadPromptContent?.({
+    workspaceId: "workspace-1",
+    content: [
+      {
+        type: "image",
+        mimeType: "image/png",
+        data: "aW1hZ2U=",
+        name: "image.png"
+      }
+    ]
+  });
+
+  assert.deepEqual(archiveInputs, [
+    {
+      workspaceID: "workspace-1",
+      dataBase64: "aW1hZ2U=",
+      displayName: "image.png",
+      mimeType: "image/png"
+    }
+  ]);
+  assert.deepEqual(result, {
+    content: [
+      {
+        type: "image",
+        mimeType: "image/png",
+        name: "image.png",
+        path: "/Users/local/Library/Application Support/Tutti/agent-prompt-assets/ws/image.png",
+        sizeBytes: 12,
+        uploadStatus: "uploaded"
+      }
+    ]
+  });
+});
+
 function createWorkspaceAgentActivityService(): IWorkspaceAgentActivityService {
   return {
     _serviceBrand: undefined,

--- a/apps/desktop/src/renderer/src/features/workspace-agent/services/createDesktopAgentActivityRuntime.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-agent/services/createDesktopAgentActivityRuntime.ts
@@ -147,9 +147,10 @@ export function createDesktopAgentActivityRuntime(
     reporterNow: options.reporterNow,
     reporterService: options.reporterService
   });
+  const archiveAgentPromptFile = options.hostFilesApi?.archiveAgentPromptFile;
   return {
     promptContentUploadSupport: {
-      file: true,
+      file: Boolean(archiveAgentPromptFile),
       image: false
     },
     async activateSession(input) {
@@ -370,59 +371,58 @@ export function createDesktopAgentActivityRuntime(
       });
       return result;
     },
-    async uploadPromptContent(input) {
-      if (!options.hostFilesApi?.archiveAgentPromptFile) {
-        throw new Error(
-          "Prompt file uploads are not supported by this agent runtime."
-        );
-      }
-      const content = await Promise.all(
-        input.content.map(async (block) => {
-          if (block.type === "file") {
-            const hostPath = block.hostPath?.trim() ?? "";
-            if (!hostPath) {
-              throw new Error("Prompt file upload requires hostPath.");
-            }
-            const archived = await options.hostFilesApi!.archiveAgentPromptFile(
-              {
-                workspaceID: input.workspaceId,
-                hostPath,
-                displayName: block.name ?? null,
-                mimeType: block.mimeType ?? null
-              }
+    ...(archiveAgentPromptFile
+      ? {
+          async uploadPromptContent(
+            input: Parameters<
+              NonNullable<AgentActivityRuntime["uploadPromptContent"]>
+            >[0]
+          ) {
+            const content = await Promise.all(
+              input.content.map(async (block) => {
+                if (block.type === "file") {
+                  const hostPath = block.hostPath?.trim() ?? "";
+                  if (!hostPath) {
+                    throw new Error("Prompt file upload requires hostPath.");
+                  }
+                  const archived = await archiveAgentPromptFile({
+                    workspaceID: input.workspaceId,
+                    hostPath,
+                    displayName: block.name ?? null,
+                    mimeType: block.mimeType ?? null
+                  });
+                  return {
+                    ...block,
+                    name: archived.name,
+                    path: archived.path,
+                    sizeBytes: archived.sizeBytes,
+                    uploadStatus: "uploaded"
+                  };
+                }
+                if (block.type === "image" && block.data) {
+                  const archived = await archiveAgentPromptFile({
+                    workspaceID: input.workspaceId,
+                    dataBase64: block.data,
+                    displayName: block.name ?? null,
+                    mimeType: block.mimeType ?? null
+                  });
+                  const blockWithoutData = { ...block };
+                  delete blockWithoutData.data;
+                  return {
+                    ...blockWithoutData,
+                    name: archived.name,
+                    path: archived.path,
+                    sizeBytes: archived.sizeBytes,
+                    uploadStatus: "uploaded"
+                  };
+                }
+                return block;
+              })
             );
-            return {
-              ...block,
-              name: archived.name,
-              path: archived.path,
-              sizeBytes: archived.sizeBytes,
-              uploadStatus: "uploaded"
-            };
+            return { content };
           }
-          if (block.type === "image" && block.data) {
-            const archived = await options.hostFilesApi!.archiveAgentPromptFile(
-              {
-                workspaceID: input.workspaceId,
-                dataBase64: block.data,
-                displayName: block.name ?? null,
-                mimeType: block.mimeType ?? null
-              }
-            );
-            const blockWithoutData = { ...block };
-            delete blockWithoutData.data;
-            return {
-              ...blockWithoutData,
-              name: archived.name,
-              path: archived.path,
-              sizeBytes: archived.sizeBytes,
-              uploadStatus: "uploaded"
-            };
-          }
-          return block;
-        })
-      );
-      return { content };
-    },
+        }
+      : {}),
     readSessionAttachment: (input) =>
       workspaceAgentActivityService.readSessionAttachment(input),
     async setSessionPinned(input) {

--- a/apps/desktop/src/renderer/src/features/workspace-agent/services/createDesktopAgentActivityRuntime.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-agent/services/createDesktopAgentActivityRuntime.ts
@@ -6,7 +6,7 @@ import type {
   AgentActivitySessionEventEnvelope,
   AgentActivitySnapshot
 } from "@tutti-os/agent-activity-core";
-import type { DesktopRuntimeApi } from "@preload/types";
+import type { DesktopHostFilesApi, DesktopRuntimeApi } from "@preload/types";
 import type { IReporterService } from "../../analytics/services/reporterService.interface.ts";
 import { AgentConversationPinnedReporter } from "../../analytics/reporters/agent-conversation-pinned/agentConversationPinnedReporter.ts";
 import { AgentConversationUnpinnedReporter } from "../../analytics/reporters/agent-conversation-unpinned/agentConversationUnpinnedReporter.ts";
@@ -43,6 +43,7 @@ type AgentComposerSettingsChange = {
 interface CreateDesktopAgentActivityRuntimeOptions {
   reporterNow?: () => number;
   reporterService?: Pick<IReporterService, "trackEvents">;
+  hostFilesApi?: Pick<DesktopHostFilesApi, "archiveAgentPromptFile">;
   runtimeApi?: Pick<
     DesktopRuntimeApi,
     "logRendererDiagnostic" | "logTerminalDiagnostic"
@@ -147,6 +148,10 @@ export function createDesktopAgentActivityRuntime(
     reporterService: options.reporterService
   });
   return {
+    promptContentUploadSupport: {
+      file: true,
+      image: false
+    },
     async activateSession(input) {
       reportAgentSubmitTraceDiagnostic({
         agentSessionId: input.agentSessionId,
@@ -364,6 +369,59 @@ export function createDesktopAgentActivityRuntime(
         success: true
       });
       return result;
+    },
+    async uploadPromptContent(input) {
+      if (!options.hostFilesApi?.archiveAgentPromptFile) {
+        throw new Error(
+          "Prompt file uploads are not supported by this agent runtime."
+        );
+      }
+      const content = await Promise.all(
+        input.content.map(async (block) => {
+          if (block.type === "file") {
+            const hostPath = block.hostPath?.trim() ?? "";
+            if (!hostPath) {
+              throw new Error("Prompt file upload requires hostPath.");
+            }
+            const archived = await options.hostFilesApi!.archiveAgentPromptFile(
+              {
+                workspaceID: input.workspaceId,
+                hostPath,
+                displayName: block.name ?? null,
+                mimeType: block.mimeType ?? null
+              }
+            );
+            return {
+              ...block,
+              name: archived.name,
+              path: archived.path,
+              sizeBytes: archived.sizeBytes,
+              uploadStatus: "uploaded"
+            };
+          }
+          if (block.type === "image" && block.data) {
+            const archived = await options.hostFilesApi!.archiveAgentPromptFile(
+              {
+                workspaceID: input.workspaceId,
+                dataBase64: block.data,
+                displayName: block.name ?? null,
+                mimeType: block.mimeType ?? null
+              }
+            );
+            const blockWithoutData = { ...block };
+            delete blockWithoutData.data;
+            return {
+              ...blockWithoutData,
+              name: archived.name,
+              path: archived.path,
+              sizeBytes: archived.sizeBytes,
+              uploadStatus: "uploaded"
+            };
+          }
+          return block;
+        })
+      );
+      return { content };
     },
     readSessionAttachment: (input) =>
       workspaceAgentActivityService.readSessionAttachment(input),

--- a/apps/desktop/src/renderer/src/features/workspace-agent/services/createDesktopAgentGUIWorkbenchHostInput.test.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-agent/services/createDesktopAgentGUIWorkbenchHostInput.test.ts
@@ -103,6 +103,54 @@ test("desktop agent GUI workbench host input reuses an injected agent host api",
   ]);
 });
 
+test("desktop agent GUI resolves dropped system files as host-local references", async () => {
+  const droppedFileA = new File(["a"], "report.pdf", {
+    type: "application/pdf"
+  });
+  const droppedFileB = new File(["b"], "notes.txt", {
+    type: "text/plain"
+  });
+  const resolvedFiles: File[][] = [];
+  const hostInput = createDesktopAgentGUIWorkbenchHostInput({
+    hostFilesApi: createHostFilesApi(),
+    tuttidClient: createTuttidClient(),
+    platformApi: createPlatformApi({
+      resolveDroppedPaths(files) {
+        resolvedFiles.push([...files]);
+        return [
+          "/Users/local/Downloads/report.pdf",
+          "/Users/local/Downloads/notes.txt"
+        ];
+      }
+    }),
+    richTextAtService: createRichTextAtService({ providers: [] }),
+    runtimeApi: createRuntimeApi(),
+    workspaceAgentActivityService: createWorkspaceAgentActivityService([]),
+    workspaceId
+  });
+
+  assert.deepEqual(
+    await hostInput.resolveDroppedFileReferences([droppedFileA, droppedFileB]),
+    [
+      {
+        displayName: "report.pdf",
+        hostPath: "/Users/local/Downloads/report.pdf",
+        kind: "file",
+        path: "/Users/local/Downloads/report.pdf",
+        sourceId: "host-local-file"
+      },
+      {
+        displayName: "notes.txt",
+        hostPath: "/Users/local/Downloads/notes.txt",
+        kind: "file",
+        path: "/Users/local/Downloads/notes.txt",
+        sourceId: "host-local-file"
+      }
+    ]
+  );
+  assert.deepEqual(resolvedFiles, [[droppedFileA, droppedFileB]]);
+});
+
 test("desktop agent GUI workbench host input creates the default agent host api", async () => {
   const hostInput = createDesktopAgentGUIWorkbenchHostInput({
     hostFilesApi: createHostFilesApi(),
@@ -1030,6 +1078,13 @@ function createHostFilesApi(): DesktopHostFilesApi {
     async readLocalPreviewFile() {
       return new Uint8Array();
     },
+    async archiveAgentPromptFile(input) {
+      return {
+        name: input.displayName ?? "attachment",
+        path: "/Users/local/Library/Application Support/Tutti/agent-prompt-assets/ws/report.pdf",
+        sizeBytes: 10
+      };
+    },
     async readPreviewFile() {
       return new Uint8Array();
     },
@@ -1184,7 +1239,14 @@ function createTuttidClient(): TuttidClient {
   } as unknown as TuttidClient;
 }
 
-function createPlatformApi(): Pick<
+function createPlatformApi(
+  overrides: Partial<
+    Pick<
+      DesktopPlatformApi,
+      "homeDirectory" | "os" | "resolveDroppedEntries" | "resolveDroppedPaths"
+    >
+  > = {}
+): Pick<
   DesktopPlatformApi,
   "homeDirectory" | "os" | "resolveDroppedEntries" | "resolveDroppedPaths"
 > {
@@ -1196,7 +1258,8 @@ function createPlatformApi(): Pick<
     },
     resolveDroppedPaths() {
       return [];
-    }
+    },
+    ...overrides
   };
 }
 

--- a/apps/desktop/src/renderer/src/features/workspace-agent/services/createDesktopAgentGUIWorkbenchHostInput.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-agent/services/createDesktopAgentGUIWorkbenchHostInput.ts
@@ -60,6 +60,9 @@ export interface DesktopAgentGUIWorkbenchHostInput {
   workspaceFileReferenceAdapter: NonNullable<
     AgentGUIProps["workspaceFileReferenceAdapter"]
   >;
+  resolveDroppedFileReferences: NonNullable<
+    AgentGUIProps["resolveDroppedFileReferences"]
+  >;
   onRequestGitBranches: NonNullable<AgentGUIProps["onRequestGitBranches"]>;
   referenceSourceAggregator: ReferenceSourceAggregator;
   resolveWorkspaceReferenceEntryIconUrl: NonNullable<
@@ -139,6 +142,7 @@ export function createDesktopAgentGUIWorkbenchHostInput({
     {
       reporterNow,
       reporterService,
+      hostFilesApi,
       runtimeApi,
       warmupOpenclawGateway,
       workspaceUserProjectService
@@ -200,6 +204,27 @@ export function createDesktopAgentGUIWorkbenchHostInput({
       })
     ])
   );
+  const resolveDroppedFileReferences: NonNullable<
+    AgentGUIProps["resolveDroppedFileReferences"]
+  > = (files) => {
+    const droppedPaths = platformApi.resolveDroppedPaths([...files]);
+    return files.flatMap((file, index): WorkspaceFileReference[] => {
+      const hostPath = droppedPaths[index]?.trim() ?? "";
+      if (!hostPath) {
+        return [];
+      }
+      const displayName = file.name.trim() || hostPath.split(/[\\/]/).at(-1);
+      return [
+        {
+          path: hostPath,
+          hostPath,
+          kind: "file",
+          ...(displayName ? { displayName } : {}),
+          sourceId: "host-local-file"
+        }
+      ];
+    });
+  };
   return {
     agentActivityRuntime,
     agentQueuedPromptRuntime,
@@ -221,6 +246,7 @@ export function createDesktopAgentGUIWorkbenchHostInput({
     trackWorkspaceFileReferences: (input) =>
       workspaceFileReferenceTracker.track(input),
     workspaceFileReferenceAdapter,
+    resolveDroppedFileReferences,
     onRequestGitBranches: async ({ agentSessionId, workingDirectory }) => {
       const result = agentSessionId
         ? await tuttidClient.listWorkspaceAgentSessionGitBranches(

--- a/apps/desktop/src/renderer/src/features/workspace-agent/services/createDesktopAgentHostApi.test.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-agent/services/createDesktopAgentHostApi.test.ts
@@ -2911,6 +2911,13 @@ function createHostFilesApi(
     async readLocalPreviewFile() {
       return new Uint8Array();
     },
+    async archiveAgentPromptFile(input) {
+      return {
+        name: input.displayName ?? "attachment",
+        path: "/Users/local/Library/Application Support/Tutti/agent-prompt-assets/ws/attachment",
+        sizeBytes: 1
+      };
+    },
     async readPreviewFile() {
       return new Uint8Array();
     },

--- a/apps/desktop/src/renderer/src/features/workspace-agent/ui/DesktopAgentGUIWorkbenchBody.tsx
+++ b/apps/desktop/src/renderer/src/features/workspace-agent/ui/DesktopAgentGUIWorkbenchBody.tsx
@@ -106,6 +106,9 @@ interface DesktopAgentGUIWorkbenchBodyProps {
   workspaceFileReferenceAdapter: NonNullable<
     AgentGUIProps["workspaceFileReferenceAdapter"]
   >;
+  resolveDroppedFileReferences: NonNullable<
+    AgentGUIProps["resolveDroppedFileReferences"]
+  >;
   onRequestGitBranches: NonNullable<AgentGUIProps["onRequestGitBranches"]>;
   referenceSourceAggregator?: AgentGUIProps["referenceSourceAggregator"];
   resolveWorkspaceReferenceEntryIconUrl?: AgentGUIProps["resolveWorkspaceReferenceEntryIconUrl"];
@@ -167,6 +170,8 @@ function areDesktopAgentGUIWorkbenchBodyPropsEqual(
       next.trackWorkspaceFileReferences &&
     previous.workspaceFileReferenceAdapter ===
       next.workspaceFileReferenceAdapter &&
+    previous.resolveDroppedFileReferences ===
+      next.resolveDroppedFileReferences &&
     previous.onRequestGitBranches === next.onRequestGitBranches &&
     previous.referenceSourceAggregator === next.referenceSourceAggregator &&
     previous.resolveWorkspaceReferenceEntryIconUrl ===
@@ -242,6 +247,7 @@ function DesktopAgentGUIWorkbenchBodyImpl({
   trackAgentProviderChatReady,
   trackWorkspaceFileReferences,
   workspaceFileReferenceAdapter,
+  resolveDroppedFileReferences,
   onRequestGitBranches,
   referenceSourceAggregator,
   resolveWorkspaceReferenceEntryIconUrl,
@@ -988,6 +994,9 @@ function DesktopAgentGUIWorkbenchBodyImpl({
         width={frame.width}
         workspaceFileReferenceAdapter={
           previewMode ? null : workspaceFileReferenceAdapter
+        }
+        resolveDroppedFileReferences={
+          previewMode ? null : resolveDroppedFileReferences
         }
         onRequestGitBranches={previewMode ? null : onRequestGitBranches}
         referenceSourceAggregator={

--- a/apps/desktop/src/renderer/src/features/workspace-file-manager/services/internal/workspaceFileManagerService.test.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-file-manager/services/internal/workspaceFileManagerService.test.ts
@@ -735,6 +735,7 @@ function createDependenciesStub(): {
       openTerminalLink: fail,
       readLocalFileText: fail,
       readLocalPreviewFile: fail,
+      archiveAgentPromptFile: fail,
       readPreviewFile: fail,
       resolveEntryIcon: async () => null,
       selectAppArchive: fail,

--- a/apps/desktop/src/renderer/src/features/workspace-workbench/services/internal/adapters/desktopWorkspaceTerminalAdapter.test.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/services/internal/adapters/desktopWorkspaceTerminalAdapter.test.ts
@@ -523,6 +523,13 @@ function createHostFilesApi(
     async readLocalPreviewFile() {
       return new Uint8Array();
     },
+    async archiveAgentPromptFile(input) {
+      return {
+        name: input.displayName ?? "attachment",
+        path: "/Users/local/Library/Application Support/Tutti/agent-prompt-assets/ws/attachment",
+        sizeBytes: 1
+      };
+    },
     async readPreviewFile() {
       return new Uint8Array();
     },

--- a/apps/desktop/src/renderer/src/features/workspace-workbench/services/internal/workspaceAgentGuiContribution.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/services/internal/workspaceAgentGuiContribution.ts
@@ -146,6 +146,8 @@ export function createWorkspaceAgentGuiContribution(input: {
         agentGUIWorkbenchHostInput.trackWorkspaceFileReferences,
       workspaceFileReferenceAdapter:
         agentGUIWorkbenchHostInput.workspaceFileReferenceAdapter,
+      resolveDroppedFileReferences:
+        agentGUIWorkbenchHostInput.resolveDroppedFileReferences,
       onRequestGitBranches: agentGUIWorkbenchHostInput.onRequestGitBranches,
       referenceSourceAggregator:
         agentGUIWorkbenchHostInput.referenceSourceAggregator,

--- a/apps/desktop/src/renderer/src/platform/desktop/web/createWebDesktopApi.ts
+++ b/apps/desktop/src/renderer/src/platform/desktop/web/createWebDesktopApi.ts
@@ -264,6 +264,9 @@ function createWebHostApi(): DesktopHostApi {
       readLocalPreviewFile() {
         return Promise.reject(electronDebugRequired("readLocalPreviewFile"));
       },
+      archiveAgentPromptFile() {
+        return Promise.reject(electronDebugRequired("archiveAgentPromptFile"));
+      },
       readPreviewFile() {
         return Promise.reject(electronDebugRequired("readPreviewFile"));
       },

--- a/apps/desktop/src/shared/contracts/ipc.ts
+++ b/apps/desktop/src/shared/contracts/ipc.ts
@@ -169,6 +169,7 @@ export const desktopIpcChannels = {
       openTerminalLink: "host:files:openTerminalLink",
       readLocalFileText: "host:files:readLocalFileText",
       readLocalPreviewFile: "host:files:readLocalPreviewFile",
+      archiveAgentPromptFile: "host:files:archiveAgentPromptFile",
       readPreviewFile: "host:files:readPreviewFile",
       resolveEntryIcon: "host:files:resolveEntryIcon",
       selectAppArchive: "host:files:selectAppArchive",
@@ -252,6 +253,20 @@ export interface DesktopWorkspaceFileEntryIconPayload extends DesktopWorkspaceFi
   entryKind: string;
   entryMtimeMs: number | null;
   entryName: string;
+}
+
+export interface DesktopArchiveAgentPromptFileInput {
+  dataBase64?: string;
+  displayName?: string | null;
+  hostPath?: string;
+  mimeType?: string | null;
+  workspaceID: string;
+}
+
+export interface DesktopArchiveAgentPromptFileResult {
+  name: string;
+  path: string;
+  sizeBytes: number;
 }
 
 export interface DesktopClipboardImagePayload {
@@ -761,6 +776,8 @@ export interface DesktopInvokePayloadByChannel {
   [desktopIpcChannels.host.files.readLocalFileText]: string;
   [desktopIpcChannels.host.files.readLocalPreviewFile]: string;
   [desktopIpcChannels.host.files
+    .archiveAgentPromptFile]: DesktopArchiveAgentPromptFileInput;
+  [desktopIpcChannels.host.files
     .readPreviewFile]: DesktopWorkspaceFilePathPayload;
   [desktopIpcChannels.host.files
     .resolveEntryIcon]: DesktopWorkspaceFileEntryIconPayload;
@@ -875,6 +892,8 @@ export interface DesktopInvokeResultByChannel {
   [desktopIpcChannels.host.files.openTerminalLink]: void;
   [desktopIpcChannels.host.files.readLocalFileText]: DesktopLocalFileTextResult;
   [desktopIpcChannels.host.files.readLocalPreviewFile]: Uint8Array;
+  [desktopIpcChannels.host.files
+    .archiveAgentPromptFile]: DesktopArchiveAgentPromptFileResult;
   [desktopIpcChannels.host.files.readPreviewFile]: Uint8Array;
   [desktopIpcChannels.host.files.resolveEntryIcon]: string | null;
   [desktopIpcChannels.host.files.selectAppArchive]: string | null;

--- a/docs/architecture/agent-gui-node.md
+++ b/docs/architecture/agent-gui-node.md
@@ -1000,6 +1000,21 @@ For `source=app` references, readonly and markdown renderers should hydrate the
 icon from the same `workspaceAppIcons` appId/workspaceId table used by ordinary
 `workspace-app` mentions.
 
+System file drag-and-drop uses the same composer mention path as the reference
+picker. `@tutti-os/agent-gui` receives a host-injected dropped-file resolver
+that returns host-local `WorkspaceFileReference` values with `hostPath`,
+`displayName`, `kind`, and `sourceId`; it must not import Electron or resolve
+desktop `File` objects itself. The desktop host owns `File -> hostPath`
+resolution through platform capabilities. Before insertion, AgentGUI sends
+host-local file references through `AgentActivityRuntime.uploadPromptContent`
+and only inserts the returned agent-readable path as a normal markdown file
+mention. The original host path is an upload source, not prompt content.
+The desktop runtime implements this upload by asking the host file capability
+to archive the selected file under a Tutti-managed agent prompt assets
+directory, then returns that managed absolute path to AgentGUI. This capability
+is file-only in desktop today; image drafts keep the existing image input path
+unless a runtime explicitly advertises image prompt upload support.
+
 Quick check:
 
 ```sh

--- a/packages/agent/gui/agent-gui/agentGuiNode/AgentComposer.spec.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/AgentComposer.spec.tsx
@@ -72,6 +72,21 @@ function createFileDataTransfer(files: readonly File[]): DataTransfer {
   } as unknown as DataTransfer;
 }
 
+function createProtectedFileDragDataTransfer(
+  files: readonly File[]
+): DataTransfer {
+  const dataTransfer = createFileDataTransfer(files) as unknown as {
+    files: readonly File[];
+    items: Array<{ getAsFile: () => File | null }>;
+  };
+  dataTransfer.files = [];
+  dataTransfer.items = dataTransfer.items.map((item) => ({
+    ...item,
+    getAsFile: () => null
+  }));
+  return dataTransfer as unknown as DataTransfer;
+}
+
 function createImageDataTransfer(file: File): DataTransfer {
   return createFileDataTransfer([file]);
 }
@@ -3302,10 +3317,11 @@ describe("AgentComposer", () => {
     );
     const { container } = render(renderComposer());
     const detailPanel = container.querySelector("#agent-gui-detail");
+    const dragDataTransfer = createProtectedFileDragDataTransfer([report]);
     const dataTransfer = createFileDataTransfer([report]);
 
-    fireEvent.dragOver(detailPanel!, { dataTransfer });
-    expect(dataTransfer.dropEffect).toBe("copy");
+    fireEvent.dragOver(detailPanel!, { dataTransfer: dragDataTransfer });
+    expect(dragDataTransfer.dropEffect).toBe("copy");
     fireEvent.drop(detailPanel!, { dataTransfer });
 
     await waitFor(() =>
@@ -3329,6 +3345,74 @@ describe("AgentComposer", () => {
       )
     );
     expect(draftContent.prompt).not.toContain("/Users/local/Downloads");
+  });
+
+  it("does not accept dropped host files when prompt file uploads are unsupported", async () => {
+    const uploadPromptContent = vi.fn();
+    const resolveDroppedFileReferences = vi.fn(() => [
+      {
+        path: "/Users/local/Downloads/report.pdf",
+        hostPath: "/Users/local/Downloads/report.pdf",
+        displayName: "report.pdf",
+        kind: "file" as const,
+        sourceId: "host-local-file"
+      }
+    ]);
+    const onDraftContentChange = vi.fn();
+    setAgentActivityRuntimeForTests({
+      promptContentUploadSupport: { file: false },
+      uploadPromptContent
+    } as unknown as AgentActivityRuntime);
+    const report = new File(["report"], "report.pdf", {
+      type: "application/pdf"
+    });
+    const { container } = render(
+      <div id="agent-gui-detail">
+        <AgentComposer
+          workspaceId="workspace-1"
+          currentUserId="user-1"
+          provider="codex"
+          draftContent={createDraft("")}
+          availableCommands={
+            [] satisfies readonly AgentHostAgentSessionCommand[]
+          }
+          disabled={false}
+          submitDisabled={false}
+          placeholder="placeholder"
+          composerSettings={createComposerSettings()}
+          queuedPrompts={[]}
+          drainingQueuedPromptId={null}
+          canQueueWhileBusy={false}
+          showStopButton={false}
+          activePrompt={null}
+          isInterrupting={false}
+          isSendingTurn={false}
+          isSubmittingPrompt={false}
+          labels={createLabels()}
+          workspaceUserProjectI18n={workspaceUserProjectI18n}
+          onDraftContentChange={onDraftContentChange}
+          onSettingsChange={vi.fn()}
+          onSubmit={vi.fn()}
+          onSendQueuedPromptNext={vi.fn()}
+          onRemoveQueuedPrompt={vi.fn()}
+          onEditQueuedPrompt={vi.fn()}
+          onInterruptCurrentTurn={vi.fn()}
+          onSubmitInteractivePrompt={vi.fn()}
+          resolveDroppedFileReferences={resolveDroppedFileReferences}
+        />
+      </div>
+    );
+    const detailPanel = container.querySelector("#agent-gui-detail");
+    const dragDataTransfer = createProtectedFileDragDataTransfer([report]);
+    const dataTransfer = createFileDataTransfer([report]);
+
+    fireEvent.dragOver(detailPanel!, { dataTransfer: dragDataTransfer });
+    expect(dragDataTransfer.dropEffect).toBe("none");
+    fireEvent.drop(detailPanel!, { dataTransfer });
+
+    expect(resolveDroppedFileReferences).not.toHaveBeenCalled();
+    expect(uploadPromptContent).not.toHaveBeenCalled();
+    expect(onDraftContentChange).not.toHaveBeenCalled();
   });
 
   it("keeps mixed system image and file drops on their separate draft paths", async () => {

--- a/packages/agent/gui/agent-gui/agentGuiNode/AgentComposer.spec.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/AgentComposer.spec.tsx
@@ -58,20 +58,22 @@ function createDraft(
   return { prompt, images, files };
 }
 
-function createImageDataTransfer(file: File): DataTransfer {
+function createFileDataTransfer(files: readonly File[]): DataTransfer {
   return {
     effectAllowed: "copy",
     dropEffect: "none",
     types: ["Files"],
-    files: [file],
-    items: [
-      {
-        kind: "file",
-        type: file.type,
-        getAsFile: () => file
-      }
-    ]
+    files,
+    items: files.map((file) => ({
+      kind: "file",
+      type: file.type,
+      getAsFile: () => file
+    }))
   } as unknown as DataTransfer;
+}
+
+function createImageDataTransfer(file: File): DataTransfer {
+  return createFileDataTransfer([file]);
 }
 
 vi.mock("../../app/renderer/components/ui/popover", () => ({
@@ -3231,6 +3233,196 @@ describe("AgentComposer", () => {
         "data:image/png;base64,aW1hZ2U="
       )
     );
+  });
+
+  it("uploads dropped non-image system files on the AgentGUI detail panel as file mentions", async () => {
+    let draftContent = createDraft("");
+    const onDraftContentChange = vi.fn((nextDraft: AgentComposerDraft) => {
+      draftContent = nextDraft;
+    });
+    const uploadPromptContent = vi.fn(async () => ({
+      content: [
+        {
+          type: "file" as const,
+          path: "/var/cache/tsh/local-assets/room-1/report.pdf",
+          name: "report.pdf",
+          kind: "file" as const
+        }
+      ]
+    }));
+    setAgentActivityRuntimeForTests({
+      uploadPromptContent
+    } as unknown as AgentActivityRuntime);
+    const report = new File(["report"], "report.pdf", {
+      type: "application/pdf"
+    });
+    const renderComposer = () => (
+      <div id="agent-gui-detail">
+        <AgentComposer
+          workspaceId="workspace-1"
+          currentUserId="user-1"
+          provider="codex"
+          draftContent={draftContent}
+          availableCommands={
+            [] satisfies readonly AgentHostAgentSessionCommand[]
+          }
+          disabled={false}
+          submitDisabled={false}
+          placeholder="placeholder"
+          composerSettings={createComposerSettings()}
+          queuedPrompts={[]}
+          drainingQueuedPromptId={null}
+          canQueueWhileBusy={false}
+          showStopButton={false}
+          activePrompt={null}
+          isInterrupting={false}
+          isSendingTurn={false}
+          isSubmittingPrompt={false}
+          labels={createLabels()}
+          workspaceUserProjectI18n={workspaceUserProjectI18n}
+          onDraftContentChange={onDraftContentChange}
+          onSettingsChange={vi.fn()}
+          onSubmit={vi.fn()}
+          onSendQueuedPromptNext={vi.fn()}
+          onRemoveQueuedPrompt={vi.fn()}
+          onEditQueuedPrompt={vi.fn()}
+          onInterruptCurrentTurn={vi.fn()}
+          onSubmitInteractivePrompt={vi.fn()}
+          resolveDroppedFileReferences={(files) =>
+            files.map((file) => ({
+              path: "/Users/local/Downloads/report.pdf",
+              hostPath: "/Users/local/Downloads/report.pdf",
+              displayName: file.name,
+              kind: "file",
+              sourceId: "host-local-file"
+            }))
+          }
+        />
+      </div>
+    );
+    const { container } = render(renderComposer());
+    const detailPanel = container.querySelector("#agent-gui-detail");
+    const dataTransfer = createFileDataTransfer([report]);
+
+    fireEvent.dragOver(detailPanel!, { dataTransfer });
+    expect(dataTransfer.dropEffect).toBe("copy");
+    fireEvent.drop(detailPanel!, { dataTransfer });
+
+    await waitFor(() =>
+      expect(uploadPromptContent).toHaveBeenCalledWith({
+        workspaceId: "workspace-1",
+        content: [
+          {
+            type: "file",
+            hostPath: "/Users/local/Downloads/report.pdf",
+            name: "report.pdf",
+            kind: "file"
+          }
+        ]
+      })
+    );
+    await waitFor(() =>
+      expect(onDraftContentChange).toHaveBeenCalledWith(
+        createDraft(
+          "[@report.pdf](/var/cache/tsh/local-assets/room-1/report.pdf) "
+        )
+      )
+    );
+    expect(draftContent.prompt).not.toContain("/Users/local/Downloads");
+  });
+
+  it("keeps mixed system image and file drops on their separate draft paths", async () => {
+    let draftContent = createDraft("");
+    const onDraftContentChange = vi.fn((nextDraft: AgentComposerDraft) => {
+      draftContent = nextDraft;
+    });
+    const uploadPromptContent = vi.fn(async () => ({
+      content: [
+        {
+          type: "file" as const,
+          path: "/var/cache/tsh/local-assets/room-1/report.pdf",
+          name: "report.pdf",
+          kind: "file" as const
+        }
+      ]
+    }));
+    setAgentActivityRuntimeForTests({
+      uploadPromptContent
+    } as unknown as AgentActivityRuntime);
+    const renderComposer = () => (
+      <div id="agent-gui-detail">
+        <AgentComposer
+          workspaceId="workspace-1"
+          currentUserId="user-1"
+          provider="codex"
+          draftContent={draftContent}
+          availableCommands={
+            [] satisfies readonly AgentHostAgentSessionCommand[]
+          }
+          disabled={false}
+          submitDisabled={false}
+          placeholder="placeholder"
+          composerSettings={createComposerSettings()}
+          queuedPrompts={[]}
+          drainingQueuedPromptId={null}
+          canQueueWhileBusy={false}
+          showStopButton={false}
+          activePrompt={null}
+          isInterrupting={false}
+          isSendingTurn={false}
+          isSubmittingPrompt={false}
+          labels={createLabels()}
+          workspaceUserProjectI18n={workspaceUserProjectI18n}
+          onDraftContentChange={onDraftContentChange}
+          onSettingsChange={vi.fn()}
+          onSubmit={vi.fn()}
+          onSendQueuedPromptNext={vi.fn()}
+          onRemoveQueuedPrompt={vi.fn()}
+          onEditQueuedPrompt={vi.fn()}
+          onInterruptCurrentTurn={vi.fn()}
+          onSubmitInteractivePrompt={vi.fn()}
+          resolveDroppedFileReferences={(files) =>
+            files.map((file) => ({
+              path: "/Users/local/Downloads/report.pdf",
+              hostPath: "/Users/local/Downloads/report.pdf",
+              displayName: file.name,
+              kind: "file",
+              sourceId: "host-local-file"
+            }))
+          }
+        />
+      </div>
+    );
+    const { container, rerender } = render(renderComposer());
+    const detailPanel = container.querySelector("#agent-gui-detail");
+    const dataTransfer = createFileDataTransfer([
+      new File(["image"], "panel.png", { type: "image/png" }),
+      new File(["report"], "report.pdf", { type: "application/pdf" })
+    ]);
+
+    fireEvent.drop(detailPanel!, { dataTransfer });
+
+    await waitFor(() =>
+      expect(onDraftContentChange).toHaveBeenCalledWith(
+        expect.objectContaining({
+          prompt:
+            "[@report.pdf](/var/cache/tsh/local-assets/room-1/report.pdf) "
+        })
+      )
+    );
+    await waitFor(() =>
+      expect(draftContent.images).toEqual([
+        expect.objectContaining({
+          name: "panel.png",
+          mimeType: "image/png",
+          data: "aW1hZ2U="
+        })
+      ])
+    );
+    rerender(renderComposer());
+    expect(
+      await screen.findByTestId("agent-gui-composer-image-drafts")
+    ).toBeInTheDocument();
   });
 
   it("uses the tracked spinner while the send button is waiting for a turn to start", () => {

--- a/packages/agent/gui/agent-gui/agentGuiNode/AgentComposer.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/AgentComposer.tsx
@@ -100,6 +100,8 @@ import {
 } from "./agentRichText/AgentRichTextEditor";
 import {
   imageFilesFromDataTransfer,
+  nonImageFilesFromDataTransfer,
+  systemFileDragInfoFromDataTransfer,
   readAgentRichTextPromptImages
 } from "./agentRichText/agentRichTextPromptImages";
 import type { AgentPromptContentBlock } from "../../shared/contracts/dto/agentSession";
@@ -819,6 +821,13 @@ export function AgentComposer({
   const agentActivityRuntime = useOptionalAgentActivityRuntime();
   const agentHostApi = useOptionalAgentHostApi();
   const getReferenceForFile = agentHostApi?.workspace.getReferenceForFile;
+  const promptFileUploadSupported = Boolean(
+    agentActivityRuntime?.uploadPromptContent &&
+    (agentActivityRuntime.promptContentUploadSupport?.file ?? true)
+  );
+  const promptFilesSupported = Boolean(
+    resolveDroppedFileReferences && promptFileUploadSupported
+  );
   const [isPaletteOpen, setIsPaletteOpen] = useState(true);
   const [isReviewPickerOpen, setIsReviewPickerOpen] = useState(false);
   const [highlightedIndex, setHighlightedIndex] = useState(0);
@@ -2050,7 +2059,9 @@ export function AgentComposer({
   const applyReferencePickResult = useCallback(
     async (result: WorkspaceReferencePickResult) => {
       if (result.files.length > 0) {
-        const uploadPromptContent = agentActivityRuntime?.uploadPromptContent;
+        const uploadPromptContent = promptFileUploadSupported
+          ? agentActivityRuntime?.uploadPromptContent
+          : undefined;
         const uploadedFiles = await Promise.all(
           result.files.map(async (file) => {
             const hostPath = file.hostPath?.trim() ?? "";
@@ -2100,7 +2111,7 @@ export function AgentComposer({
         editorHandleRef.current?.insertMentionItems(result.mentionItems);
       }
     },
-    [agentActivityRuntime, workspaceId]
+    [agentActivityRuntime, promptFileUploadSupported, workspaceId]
   );
 
   const handleWorkspaceReferencePicker = useCallback(async () => {
@@ -2112,7 +2123,11 @@ export function AgentComposer({
 
   const applyDroppedFileReferences = useCallback(
     async (files: readonly File[]) => {
-      if (!resolveDroppedFileReferences || files.length === 0) {
+      if (
+        !promptFilesSupported ||
+        !resolveDroppedFileReferences ||
+        files.length === 0
+      ) {
         return;
       }
       const references = await resolveDroppedFileReferences(files);
@@ -2121,7 +2136,11 @@ export function AgentComposer({
       }
       await applyReferencePickResult({ files: references, mentionItems: [] });
     },
-    [applyReferencePickResult, resolveDroppedFileReferences]
+    [
+      applyReferencePickResult,
+      promptFilesSupported,
+      resolveDroppedFileReferences
+    ]
   );
 
   // @ 面板里点任务/应用行的「查看产物」入口:关掉面板,打开引用 picker 并定位到该实体;
@@ -2280,6 +2299,25 @@ export function AgentComposer({
       return target instanceof Node && dropTarget.contains(target);
     };
 
+    const systemFileDrag = (
+      event: DragEvent
+    ): { hasImageFiles: boolean; hasRegularFiles: boolean } | null => {
+      if (
+        event.defaultPrevented ||
+        inputDisabled ||
+        !containsEventTarget(event) ||
+        hasWorkspaceFileDropData(event.dataTransfer)
+      ) {
+        return null;
+      }
+      const dragInfo = systemFileDragInfoFromDataTransfer(event.dataTransfer);
+      const hasRegularFiles = dragInfo.hasRegularFiles && promptFilesSupported;
+      if (!dragInfo.hasImageFiles && !hasRegularFiles) {
+        return null;
+      }
+      return { hasImageFiles: dragInfo.hasImageFiles, hasRegularFiles };
+    };
+
     const systemFileDrop = (
       event: DragEvent
     ): { imageFiles: File[]; regularFiles: File[] } | null => {
@@ -2291,33 +2329,31 @@ export function AgentComposer({
       ) {
         return null;
       }
-      const files = Array.from(event.dataTransfer?.files ?? []);
-      if (files.length === 0) {
-        return null;
-      }
       const imageFiles = imageFilesFromDataTransfer(event.dataTransfer);
       const imageFileSet = new Set(imageFiles);
-      const regularFiles = files.filter((file) => !imageFileSet.has(file));
-      const canResolveRegularFiles = Boolean(resolveDroppedFileReferences);
-      const effectiveRegularFiles = canResolveRegularFiles ? regularFiles : [];
-      if (imageFiles.length === 0 && effectiveRegularFiles.length === 0) {
+      const regularFiles = promptFilesSupported
+        ? nonImageFilesFromDataTransfer(event.dataTransfer).filter(
+            (file) => !imageFileSet.has(file)
+          )
+        : [];
+      if (imageFiles.length === 0 && regularFiles.length === 0) {
         return null;
       }
-      return { imageFiles, regularFiles: effectiveRegularFiles };
+      return { imageFiles, regularFiles };
     };
 
     const handleDragOver: EventListener = (event): void => {
       if (!isDragEvent(event)) {
         return;
       }
-      const drop = systemFileDrop(event);
-      if (!drop) {
+      const drag = systemFileDrag(event);
+      if (!drag) {
         return;
       }
       event.preventDefault();
       if (
-        drop.regularFiles.length === 0 &&
-        drop.imageFiles.length > 0 &&
+        !drag.hasRegularFiles &&
+        drag.hasImageFiles &&
         !promptImagesSupported
       ) {
         return;
@@ -2373,8 +2409,8 @@ export function AgentComposer({
     applyDroppedFileReferences,
     inputDisabled,
     onPromptImagesUnsupported,
+    promptFilesSupported,
     promptImagesSupported,
-    resolveDroppedFileReferences,
     scheduleComposerFocus
   ]);
   useEffect(() => {
@@ -2981,7 +3017,7 @@ export function AgentComposer({
                     onPasteImages={handlePastedImages}
                     getReferenceForFile={getReferenceForFile}
                     onDropFiles={
-                      resolveDroppedFileReferences
+                      promptFilesSupported
                         ? applyDroppedFileReferences
                         : undefined
                     }

--- a/packages/agent/gui/agent-gui/agentGuiNode/AgentComposer.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/AgentComposer.tsx
@@ -144,6 +144,7 @@ import {
 } from "./model/agentUsageThresholds";
 import { useOptionalAgentActivityRuntime } from "../../agentActivityRuntime";
 import { useOptionalAgentHostApi } from "../../agentActivityHost";
+import type { AgentDroppedFileReferenceResolver } from "./model/agentDroppedFileReferences";
 
 export { formatSlashStatusTokenCount };
 
@@ -402,6 +403,7 @@ export interface AgentComposerProps {
         entity?: AgentContextMentionItem | null
       ) => Promise<WorkspaceReferencePickResult>)
     | null;
+  resolveDroppedFileReferences?: AgentDroppedFileReferenceResolver | null;
   selectProjectDirectory?: () => Promise<{ path: string } | null>;
   onRequestGitBranches?: AgentComposerGitBranchLoader | null;
   contextMentionProviders?: readonly AgentContextMentionProvider[];
@@ -803,6 +805,7 @@ export function AgentComposer({
   onCapabilitySettingsRequest,
   onLinkAction,
   onRequestWorkspaceReferences = null,
+  resolveDroppedFileReferences = null,
   selectProjectDirectory,
   onRequestGitBranches = null,
   contextMentionProviders = EMPTY_CONTEXT_MENTION_PROVIDERS
@@ -1922,7 +1925,11 @@ export function AgentComposer({
       if (remainingSlots === 0) {
         return;
       }
-      const uploadPromptContent = agentActivityRuntime?.uploadPromptContent;
+      const uploadPromptContent =
+        agentActivityRuntime?.uploadPromptContent &&
+        (agentActivityRuntime.promptContentUploadSupport?.image ?? true)
+          ? agentActivityRuntime.uploadPromptContent
+          : undefined;
       const nextImages = images.slice(0, remainingSlots).map((image) => ({
         id: `${Date.now().toString(36)}-${Math.random().toString(36).slice(2)}`,
         name: image.name,
@@ -2103,6 +2110,20 @@ export function AgentComposer({
     await applyReferencePickResult(await onRequestWorkspaceReferences());
   }, [applyReferencePickResult, onRequestWorkspaceReferences]);
 
+  const applyDroppedFileReferences = useCallback(
+    async (files: readonly File[]) => {
+      if (!resolveDroppedFileReferences || files.length === 0) {
+        return;
+      }
+      const references = await resolveDroppedFileReferences(files);
+      if (references.length === 0) {
+        return;
+      }
+      await applyReferencePickResult({ files: references, mentionItems: [] });
+    },
+    [applyReferencePickResult, resolveDroppedFileReferences]
+  );
+
   // @ 面板里点任务/应用行的「查看产物」入口:关掉面板,打开引用 picker 并定位到该实体;
   // 选中的文件仍按常规插入,但不会把该任务/应用本身作为 mention 插入。
   const handleOpenReferencesForEntity = useCallback(
@@ -2259,27 +2280,46 @@ export function AgentComposer({
       return target instanceof Node && dropTarget.contains(target);
     };
 
-    const hasPromptImageFiles = (event: DragEvent): boolean => {
+    const systemFileDrop = (
+      event: DragEvent
+    ): { imageFiles: File[]; regularFiles: File[] } | null => {
       if (
         event.defaultPrevented ||
         inputDisabled ||
         !containsEventTarget(event) ||
         hasWorkspaceFileDropData(event.dataTransfer)
       ) {
-        return false;
+        return null;
       }
-      return imageFilesFromDataTransfer(event.dataTransfer).length > 0;
+      const files = Array.from(event.dataTransfer?.files ?? []);
+      if (files.length === 0) {
+        return null;
+      }
+      const imageFiles = imageFilesFromDataTransfer(event.dataTransfer);
+      const imageFileSet = new Set(imageFiles);
+      const regularFiles = files.filter((file) => !imageFileSet.has(file));
+      const canResolveRegularFiles = Boolean(resolveDroppedFileReferences);
+      const effectiveRegularFiles = canResolveRegularFiles ? regularFiles : [];
+      if (imageFiles.length === 0 && effectiveRegularFiles.length === 0) {
+        return null;
+      }
+      return { imageFiles, regularFiles: effectiveRegularFiles };
     };
 
     const handleDragOver: EventListener = (event): void => {
       if (!isDragEvent(event)) {
         return;
       }
-      if (!hasPromptImageFiles(event)) {
+      const drop = systemFileDrop(event);
+      if (!drop) {
         return;
       }
       event.preventDefault();
-      if (!promptImagesSupported) {
+      if (
+        drop.regularFiles.length === 0 &&
+        drop.imageFiles.length > 0 &&
+        !promptImagesSupported
+      ) {
         return;
       }
       if (event.dataTransfer) {
@@ -2291,17 +2331,28 @@ export function AgentComposer({
       if (!isDragEvent(event)) {
         return;
       }
-      if (!hasPromptImageFiles(event)) {
+      const drop = systemFileDrop(event);
+      if (!drop) {
         return;
       }
       event.preventDefault();
       event.stopPropagation();
+      if (drop.regularFiles.length > 0) {
+        editorHandleRef.current?.focusAtEnd();
+        void applyDroppedFileReferences(drop.regularFiles).then(() => {
+          if (!isDisposed) {
+            scheduleComposerFocus();
+          }
+        });
+      }
+      if (drop.imageFiles.length === 0) {
+        return;
+      }
       if (!promptImagesSupported) {
         onPromptImagesUnsupported?.();
         return;
       }
-      const imageFiles = imageFilesFromDataTransfer(event.dataTransfer);
-      void readAgentRichTextPromptImages(imageFiles).then((images) => {
+      void readAgentRichTextPromptImages(drop.imageFiles).then((images) => {
         if (isDisposed || images.length === 0) {
           return;
         }
@@ -2319,9 +2370,11 @@ export function AgentComposer({
     };
   }, [
     addDraftImages,
+    applyDroppedFileReferences,
     inputDisabled,
     onPromptImagesUnsupported,
     promptImagesSupported,
+    resolveDroppedFileReferences,
     scheduleComposerFocus
   ]);
   useEffect(() => {
@@ -2927,6 +2980,11 @@ export function AgentComposer({
                     onPromptImagesUnsupported={onPromptImagesUnsupported}
                     onPasteImages={handlePastedImages}
                     getReferenceForFile={getReferenceForFile}
+                    onDropFiles={
+                      resolveDroppedFileReferences
+                        ? applyDroppedFileReferences
+                        : undefined
+                    }
                   />
                   {!isHeroLayout ? composerActionButton : null}
                 </div>

--- a/packages/agent/gui/agent-gui/agentGuiNode/AgentGUINode.spec.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/AgentGUINode.spec.tsx
@@ -177,12 +177,18 @@ function pasteComposerText(text: string): void {
   });
 }
 
-function createDataTransferStub(): DataTransfer {
+function createDataTransferStub(files: readonly File[] = []): DataTransfer {
   const store = new Map<string, string>();
   const dataTransfer = {
     effectAllowed: "none",
     dropEffect: "none",
     types: [] as string[],
+    files,
+    items: files.map((file) => ({
+      kind: "file",
+      type: file.type,
+      getAsFile: () => file
+    })),
     setData(format: string, data: string) {
       store.set(format, data);
       dataTransfer.types = [...store.keys()];
@@ -4683,6 +4689,135 @@ describe("AgentGUINode", () => {
     ).not.toBeInTheDocument();
   });
 
+  it("inserts dropped host-local files into the active conversation draft through upload", async () => {
+    const uploadPromptContent = vi.fn(async () => ({
+      content: [
+        {
+          type: "file" as const,
+          path: "/var/cache/tsh/local-assets/room-1/user-1/report.pdf",
+          name: "report.pdf",
+          kind: "file" as const
+        }
+      ]
+    }));
+    mockViewModel = createViewModel({
+      activeConversationId: "session-1",
+      draftPrompt: "看下 "
+    });
+
+    renderAgentGUINode({
+      agentActivityRuntime: {
+        uploadPromptContent
+      } as unknown as AgentActivityRuntime,
+      resolveDroppedFileReferences: (files) =>
+        files.map((file) => ({
+          path: "/Users/local/Downloads/report.pdf",
+          hostPath: "/Users/local/Downloads/report.pdf",
+          displayName: file.name,
+          kind: "file",
+          sourceId: "host-local-file"
+        }))
+    });
+
+    const detailPanel = document.querySelector("#agent-gui-detail");
+    const dataTransfer = createDataTransferStub([
+      new File(["report"], "report.pdf", { type: "application/pdf" })
+    ]);
+
+    fireEvent.dragOver(detailPanel!, { dataTransfer });
+    expect(dataTransfer.dropEffect).toBe("copy");
+    fireEvent.drop(detailPanel!, { dataTransfer });
+
+    await waitFor(() =>
+      expect(uploadPromptContent).toHaveBeenCalledWith({
+        workspaceId: "room-1",
+        content: [
+          {
+            type: "file",
+            hostPath: "/Users/local/Downloads/report.pdf",
+            name: "report.pdf",
+            kind: "file"
+          }
+        ]
+      })
+    );
+    await waitFor(() =>
+      expect(mockUpdateDraftContent).toHaveBeenCalledWith(
+        createDraft(
+          "看下 [@report.pdf](/var/cache/tsh/local-assets/room-1/user-1/report.pdf) "
+        )
+      )
+    );
+  });
+
+  it("uploads host-local files dropped directly into the editor before inserting mentions", async () => {
+    const uploadPromptContent = vi.fn(async () => ({
+      content: [
+        {
+          type: "file" as const,
+          path: "/var/cache/tsh/local-assets/room-1/user-1/report.pdf",
+          name: "report.pdf",
+          kind: "file" as const
+        }
+      ]
+    }));
+    mockViewModel = createViewModel({
+      activeConversationId: "session-1",
+      draftPrompt: ""
+    });
+
+    renderAgentGUINode({
+      agentActivityRuntime: {
+        uploadPromptContent
+      } as unknown as AgentActivityRuntime,
+      resolveDroppedFileReferences: (files) =>
+        files.map((file) => ({
+          path: "/Users/local/Downloads/report.pdf",
+          hostPath: "/Users/local/Downloads/report.pdf",
+          displayName: file.name,
+          kind: "file",
+          sourceId: "host-local-file"
+        }))
+    });
+
+    const editor = getComposerEditor();
+    const dataTransfer = createDataTransferStub([
+      new File(["report"], "report.pdf", { type: "application/pdf" })
+    ]);
+
+    fireEvent.dragOver(editor, { dataTransfer });
+    expect(dataTransfer.dropEffect).toBe("copy");
+    fireEvent.drop(editor, {
+      dataTransfer,
+      clientX: 8,
+      clientY: 8
+    });
+
+    await waitFor(() =>
+      expect(uploadPromptContent).toHaveBeenCalledWith({
+        workspaceId: "room-1",
+        content: [
+          {
+            type: "file",
+            hostPath: "/Users/local/Downloads/report.pdf",
+            name: "report.pdf",
+            kind: "file"
+          }
+        ]
+      })
+    );
+    await waitFor(() =>
+      expect(mockUpdateDraftContent).toHaveBeenCalledWith(
+        createDraft(
+          "[@report.pdf](/var/cache/tsh/local-assets/room-1/user-1/report.pdf) "
+        )
+      )
+    );
+    expect(mockUpdateDraftContent).not.toHaveBeenCalledWith(
+      createDraft("[@report.pdf](/Users/local/Downloads/report.pdf) ")
+    );
+  });
+
   it("opens the shared workspace reference picker with the selected project path revealed", async () => {
     const baseViewModel = createViewModel();
     const loadReferenceTree = vi.fn(
@@ -7259,6 +7394,7 @@ function renderAgentGUINode({
   >(),
   onResize = vi.fn(),
   workspaceFileReferenceAdapter = createWorkspaceFileReferenceAdapter(),
+  resolveDroppedFileReferences,
   referenceSourceAggregator,
   agentActivityRuntime,
   onShowMessage = vi.fn(),
@@ -7293,6 +7429,9 @@ function renderAgentGUINode({
   ) => void;
   onResize?: React.ComponentProps<typeof AgentGUINode>["onResize"];
   workspaceFileReferenceAdapter?: WorkspaceFileReferenceAdapter | null;
+  resolveDroppedFileReferences?: React.ComponentProps<
+    typeof AgentGUINode
+  >["resolveDroppedFileReferences"];
   referenceSourceAggregator?: ReferenceSourceAggregator | null;
   agentActivityRuntime?: AgentActivityRuntime | null;
   onShowMessage?: React.ComponentProps<typeof AgentGUINode>["onShowMessage"];
@@ -7326,6 +7465,7 @@ function renderAgentGUINode({
       currentUserId="user-1"
       workspacePath="/workspace"
       workspaceFileReferenceAdapter={workspaceFileReferenceAdapter}
+      resolveDroppedFileReferences={resolveDroppedFileReferences}
       referenceSourceAggregator={referenceSourceAggregator}
       agentSettings={{ avoidGroupingEdits: false }}
       title={title}

--- a/packages/agent/gui/agent-gui/agentGuiNode/AgentGUINode.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/AgentGUINode.tsx
@@ -59,6 +59,7 @@ import {
   workspaceAgentProbeRenderStateEqualsForProvider
 } from "../workspaceDesktop/view/desktopDockAgentProbeTooltipModel";
 import { AgentProbeInfoPopover } from "../workspaceDesktop/view/AgentProbeInfoPopover";
+import type { AgentComposerProps } from "./AgentComposer";
 import {
   getAgentHostManagedToolchainAgentByName,
   resolveAgentHostManagedToolchainAgentAction
@@ -162,6 +163,7 @@ export interface AgentGUINodeProps {
   workspaceFileReferenceAdapter?: WorkspaceFileReferenceAdapter | null;
   onRequestGitBranches?: AgentComposerGitBranchLoader | null;
   selectProjectDirectory?: () => Promise<{ path: string } | null>;
+  resolveDroppedFileReferences?: AgentComposerProps["resolveDroppedFileReferences"];
   referenceSourceAggregator?: ReferenceSourceAggregator | null;
   resolveWorkspaceReferenceEntryIconUrl?: (
     entry: WorkspaceFileEntry
@@ -478,6 +480,8 @@ function areAgentGUINodePropsEqual(
     previous.workspacePath === next.workspacePath &&
     previous.workspaceFileReferenceAdapter ===
       next.workspaceFileReferenceAdapter &&
+    previous.resolveDroppedFileReferences ===
+      next.resolveDroppedFileReferences &&
     previous.selectProjectDirectory === next.selectProjectDirectory &&
     previous.referenceSourceAggregator === next.referenceSourceAggregator &&
     previous.resolveWorkspaceReferenceEntryIconUrl ===
@@ -542,6 +546,7 @@ export const AgentGUINode = memo(function AgentGUINode({
   workspaceFileReferenceAdapter = null,
   onRequestGitBranches = null,
   selectProjectDirectory,
+  resolveDroppedFileReferences = null,
   referenceSourceAggregator = null,
   resolveWorkspaceReferenceEntryIconUrl,
   resolveMentionReferenceTarget = null,
@@ -1486,6 +1491,7 @@ export const AgentGUINode = memo(function AgentGUINode({
                 ? handleWorkspaceFileReferencesAdded
                 : undefined
             }
+            resolveDroppedFileReferences={resolveDroppedFileReferences}
             onConversationRailWidthChanged={handleConversationRailWidthChanged}
             labels={labels}
             workspaceUserProjectI18n={workspaceUserProjectI18n}

--- a/packages/agent/gui/agent-gui/agentGuiNode/AgentGUINodeView.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/AgentGUINodeView.tsx
@@ -504,6 +504,7 @@ interface AgentGUINodeViewProps {
   onWorkspaceFileReferencesAdded?: (
     references: readonly WorkspaceFileReference[]
   ) => void | Promise<void>;
+  resolveDroppedFileReferences?: AgentComposerProps["resolveDroppedFileReferences"];
   onConversationRailWidthChanged: (widthPx: number) => void;
   labels: AgentGUIViewLabels;
   workspaceUserProjectI18n: WorkspaceUserProjectI18nRuntime;
@@ -826,6 +827,7 @@ export function AgentGUINodeView({
   detailMinWidthPx,
   uiLanguage,
   onWorkspaceFileReferencesAdded,
+  resolveDroppedFileReferences = null,
   onConversationRailWidthChanged,
   labels,
   workspaceUserProjectI18n,
@@ -1383,6 +1385,7 @@ export function AgentGUINodeView({
             onCapabilitySettingsRequest={onCapabilitySettingsRequest}
             onAgentProviderLogin={onAgentProviderLogin}
             onRequestWorkspaceReferences={requestWorkspaceReferences}
+            resolveDroppedFileReferences={resolveDroppedFileReferences}
             selectProjectDirectory={selectProjectDirectory}
             onRequestGitBranches={onRequestGitBranches}
             contextMentionProviders={contextMentionProviders}
@@ -1450,6 +1453,7 @@ interface AgentGUIDetailPaneProps {
         entity?: AgentContextMentionItem | null
       ) => Promise<WorkspaceReferencePickResult>)
     | null;
+  resolveDroppedFileReferences?: AgentComposerProps["resolveDroppedFileReferences"];
   selectProjectDirectory?: () => Promise<{ path: string } | null>;
   onRequestGitBranches?: AgentComposerGitBranchLoader | null;
   contextMentionProviders?: readonly AgentContextMentionProvider[];
@@ -1540,6 +1544,7 @@ const AgentGUIDetailPane = memo(function AgentGUIDetailPane({
   onCapabilitySettingsRequest,
   onAgentProviderLogin,
   onRequestWorkspaceReferences,
+  resolveDroppedFileReferences = null,
   selectProjectDirectory,
   onRequestGitBranches,
   contextMentionProviders,
@@ -2187,6 +2192,7 @@ const AgentGUIDetailPane = memo(function AgentGUIDetailPane({
       onCapabilitySettingsRequest,
       onLinkAction: stableLinkAction,
       onRequestWorkspaceReferences: stableRequestWorkspaceReferences,
+      resolveDroppedFileReferences,
       selectProjectDirectory: stableSelectProjectDirectory,
       onRequestGitBranches: stableRequestGitBranches,
       contextMentionProviders
@@ -2210,6 +2216,7 @@ const AgentGUIDetailPane = memo(function AgentGUIDetailPane({
       onCapabilitySettingsRequest,
       contextMentionProviders,
       removeQueuedPrompt,
+      resolveDroppedFileReferences,
       sendQueuedPromptNext,
       showPromptImagesUnsupported,
       showStopButton,

--- a/packages/agent/gui/agent-gui/agentGuiNode/agentRichText/AgentRichTextEditor.spec.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/agentRichText/AgentRichTextEditor.spec.tsx
@@ -76,6 +76,23 @@ function createDataTransferFilesFallbackStub(
   return dataTransfer as unknown as DataTransfer;
 }
 
+function createProtectedFileDragDataTransferStub(
+  files: readonly File[] = []
+): DataTransfer {
+  const dataTransfer = createDataTransferStub(files) as unknown as {
+    files: readonly File[];
+    items: Array<{ getAsFile: () => File | null }>;
+    types: string[];
+  };
+  dataTransfer.files = [];
+  dataTransfer.items = dataTransfer.items.map((item) => ({
+    ...item,
+    getAsFile: () => null
+  }));
+  dataTransfer.types = ["Files"];
+  return dataTransfer as unknown as DataTransfer;
+}
+
 function selectEditorText(editor: HTMLElement, from: number, to: number): void {
   const textNode = editor.querySelector("p")?.firstChild;
   if (!textNode) {
@@ -1707,6 +1724,30 @@ describe("AgentRichTextEditor", () => {
       expect.objectContaining({ name: "notes.txt" })
     ]);
     expect(onChange).not.toHaveBeenCalled();
+  });
+
+  it("accepts protected system file drags before FileList is readable", async () => {
+    const onDropFiles = vi.fn();
+    render(
+      <AgentRichTextEditor
+        value=""
+        disabled={false}
+        placeholder="Prompt"
+        onChange={vi.fn()}
+        onSubmit={vi.fn()}
+        onDropFiles={onDropFiles}
+      />
+    );
+
+    const dataTransfer = createProtectedFileDragDataTransferStub([
+      new File(["report"], "report.pdf", { type: "application/pdf" })
+    ]);
+    const editor = await screen.findByRole("textbox", { name: "Prompt" });
+
+    fireEvent.dragOver(editor, { dataTransfer });
+
+    expect(dataTransfer.dropEffect).toBe("copy");
+    expect(onDropFiles).not.toHaveBeenCalled();
   });
 
   it("keeps mixed system image and file drops in their separate composer paths", async () => {

--- a/packages/agent/gui/agent-gui/agentGuiNode/agentRichText/AgentRichTextEditor.spec.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/agentRichText/AgentRichTextEditor.spec.tsx
@@ -1674,6 +1674,84 @@ describe("AgentRichTextEditor", () => {
     expect(onChange).not.toHaveBeenCalled();
   });
 
+  it("passes dropped system non-image files to the composer upload path", async () => {
+    const onChange = vi.fn();
+    const onDropFiles = vi.fn();
+    render(
+      <AgentRichTextEditor
+        value=""
+        disabled={false}
+        placeholder="Prompt"
+        onChange={onChange}
+        onSubmit={vi.fn()}
+        onDropFiles={onDropFiles}
+      />
+    );
+
+    const dataTransfer = createDataTransferStub([
+      new File(["report"], "report.pdf", { type: "application/pdf" }),
+      new File(["notes"], "notes.txt", { type: "text/plain" })
+    ]);
+    const editor = await screen.findByRole("textbox", { name: "Prompt" });
+
+    fireEvent.dragOver(editor, { dataTransfer });
+    expect(dataTransfer.dropEffect).toBe("copy");
+    fireEvent.drop(editor, {
+      dataTransfer,
+      clientX: 8,
+      clientY: 8
+    });
+
+    expect(onDropFiles).toHaveBeenCalledWith([
+      expect.objectContaining({ name: "report.pdf" }),
+      expect.objectContaining({ name: "notes.txt" })
+    ]);
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
+  it("keeps mixed system image and file drops in their separate composer paths", async () => {
+    const onChange = vi.fn();
+    const onPasteImages = vi.fn();
+    const onDropFiles = vi.fn();
+    render(
+      <AgentRichTextEditor
+        value=""
+        disabled={false}
+        placeholder="Prompt"
+        onChange={onChange}
+        onSubmit={vi.fn()}
+        onPasteImages={onPasteImages}
+        onDropFiles={onDropFiles}
+      />
+    );
+
+    const dataTransfer = createDataTransferStub([
+      new File(["image"], "diagram.png", { type: "image/png" }),
+      new File(["report"], "report.pdf", { type: "application/pdf" })
+    ]);
+    const editor = await screen.findByRole("textbox", { name: "Prompt" });
+
+    fireEvent.drop(editor, {
+      dataTransfer,
+      clientX: 8,
+      clientY: 8
+    });
+
+    expect(onDropFiles).toHaveBeenCalledWith([
+      expect.objectContaining({ name: "report.pdf" })
+    ]);
+    await waitFor(() =>
+      expect(onPasteImages).toHaveBeenCalledWith([
+        {
+          name: "diagram.png",
+          mimeType: "image/png",
+          data: "aW1hZ2U="
+        }
+      ])
+    );
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
   it("inserts multiple dropped workspace mentions in drag order", async () => {
     const onChange = vi.fn();
     render(

--- a/packages/agent/gui/agent-gui/agentGuiNode/agentRichText/AgentRichTextEditor.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/agentRichText/AgentRichTextEditor.tsx
@@ -51,6 +51,7 @@ import {
   imageFilesFromDataTransfer,
   nonImageFilesFromDataTransfer,
   readAgentRichTextPromptImages,
+  systemFileDragInfoFromDataTransfer,
   type AgentRichTextPromptImage
 } from "./agentRichTextPromptImages";
 
@@ -863,15 +864,17 @@ export const AgentRichTextEditor = forwardRef<
           if (!dataTransfer || disabled) {
             return false;
           }
-          const imageFiles = imageFilesFromDataTransfer(dataTransfer);
-          const hasRegularSystemFiles =
-            Array.from(dataTransfer.files ?? []).some(
-              (file) => !imageFiles.includes(file)
-            ) && Boolean(onDropFilesRef.current);
-          if (imageFiles.length > 0 || hasRegularSystemFiles) {
+          const systemFileDragInfo =
+            systemFileDragInfoFromDataTransfer(dataTransfer);
+          const canDropRegularSystemFiles =
+            systemFileDragInfo.hasRegularFiles &&
+            Boolean(onDropFilesRef.current);
+          if (systemFileDragInfo.hasImageFiles || canDropRegularSystemFiles) {
             event.preventDefault();
             dataTransfer.dropEffect =
-              hasRegularSystemFiles || promptImagesSupportedRef.current
+              canDropRegularSystemFiles ||
+              (systemFileDragInfo.hasImageFiles &&
+                promptImagesSupportedRef.current)
                 ? "copy"
                 : "none";
             return true;
@@ -895,9 +898,10 @@ export const AgentRichTextEditor = forwardRef<
             return false;
           }
           const imageFiles = imageFilesFromDataTransfer(dataTransfer);
-          const files = Array.from(dataTransfer.files ?? []);
           const imageFileSet = new Set(imageFiles);
-          const regularFiles = files.filter((file) => !imageFileSet.has(file));
+          const regularFiles = nonImageFilesFromDataTransfer(
+            dataTransfer
+          ).filter((file) => !imageFileSet.has(file));
           const canHandleRegularFiles = Boolean(onDropFilesRef.current);
           if (
             imageFiles.length > 0 ||

--- a/packages/agent/gui/agent-gui/agentGuiNode/agentRichText/AgentRichTextEditor.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/agentRichText/AgentRichTextEditor.tsx
@@ -77,6 +77,7 @@ export interface AgentRichTextEditorProps {
   onPromptImagesUnsupported?: () => void;
   onPasteImages?: (images: AgentRichTextPastedImage[]) => void;
   getReferenceForFile?: (file: File) => WorkspaceFileReference | null;
+  onDropFiles?: (files: readonly File[]) => void;
 }
 
 export interface AgentRichTextEditorHandle {
@@ -458,7 +459,8 @@ export const AgentRichTextEditor = forwardRef<
     promptImagesSupported = true,
     onPromptImagesUnsupported,
     onPasteImages,
-    getReferenceForFile
+    getReferenceForFile,
+    onDropFiles
   },
   ref
 ): React.JSX.Element {
@@ -479,6 +481,7 @@ export const AgentRichTextEditor = forwardRef<
   const onLinkClickRef = useRef(onLinkClick);
   const onPromptImagesUnsupportedRef = useRef(onPromptImagesUnsupported);
   const onPasteImagesRef = useRef(onPasteImages);
+  const onDropFilesRef = useRef(onDropFiles);
   const promptImagesSupportedRef = useRef(promptImagesSupported);
   const getReferenceForFileRef = useRef(getReferenceForFile);
   const placeholderRef = useRef(placeholder);
@@ -621,6 +624,7 @@ export const AgentRichTextEditor = forwardRef<
   onLinkClickRef.current = onLinkClick;
   onPromptImagesUnsupportedRef.current = onPromptImagesUnsupported;
   onPasteImagesRef.current = onPasteImages;
+  onDropFilesRef.current = onDropFiles;
   promptImagesSupportedRef.current = promptImagesSupported;
   getReferenceForFileRef.current = getReferenceForFile;
   placeholderRef.current = placeholder;
@@ -860,11 +864,16 @@ export const AgentRichTextEditor = forwardRef<
             return false;
           }
           const imageFiles = imageFilesFromDataTransfer(dataTransfer);
-          if (imageFiles.length > 0) {
+          const hasRegularSystemFiles =
+            Array.from(dataTransfer.files ?? []).some(
+              (file) => !imageFiles.includes(file)
+            ) && Boolean(onDropFilesRef.current);
+          if (imageFiles.length > 0 || hasRegularSystemFiles) {
             event.preventDefault();
-            dataTransfer.dropEffect = promptImagesSupportedRef.current
-              ? "copy"
-              : "none";
+            dataTransfer.dropEffect =
+              hasRegularSystemFiles || promptImagesSupportedRef.current
+                ? "copy"
+                : "none";
             return true;
           }
           if (!hasWorkspaceFileDropData(dataTransfer)) {
@@ -886,8 +895,44 @@ export const AgentRichTextEditor = forwardRef<
             return false;
           }
           const imageFiles = imageFilesFromDataTransfer(dataTransfer);
-          if (imageFiles.length > 0) {
+          const files = Array.from(dataTransfer.files ?? []);
+          const imageFileSet = new Set(imageFiles);
+          const regularFiles = files.filter((file) => !imageFileSet.has(file));
+          const canHandleRegularFiles = Boolean(onDropFilesRef.current);
+          if (
+            imageFiles.length > 0 ||
+            (regularFiles.length > 0 && canHandleRegularFiles)
+          ) {
             event.preventDefault();
+            const currentEditor = editorRef.current;
+            if (
+              regularFiles.length > 0 &&
+              onDropFilesRef.current &&
+              currentEditor &&
+              !currentEditor.isDestroyed
+            ) {
+              const coordinatePosition = currentEditor.view.posAtCoords({
+                left: event.clientX,
+                top: event.clientY
+              })?.pos;
+              const fallbackSelectionPosition =
+                currentEditor.state.selection.from;
+              const insertPosition =
+                coordinatePosition ??
+                (Number.isInteger(fallbackSelectionPosition)
+                  ? fallbackSelectionPosition
+                  : null) ??
+                currentEditor.state.doc.content.size;
+              currentEditor
+                .chain()
+                .focus()
+                .setTextSelection(insertPosition)
+                .run();
+              onDropFilesRef.current(regularFiles);
+            }
+            if (imageFiles.length === 0) {
+              return true;
+            }
             if (!promptImagesSupportedRef.current) {
               onPromptImagesUnsupportedRef.current?.();
               return true;

--- a/packages/agent/gui/agent-gui/agentGuiNode/agentRichText/agentRichTextPromptImages.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/agentRichText/agentRichTextPromptImages.ts
@@ -71,6 +71,43 @@ export function nonImageFilesFromDataTransfer(
   return files;
 }
 
+export function systemFileDragInfoFromDataTransfer(
+  dataTransfer: DataTransfer | null
+): { hasImageFiles: boolean; hasRegularFiles: boolean } {
+  if (!dataTransfer) {
+    return { hasImageFiles: false, hasRegularFiles: false };
+  }
+  const items = (dataTransfer as { items?: DataTransferItemList | null }).items;
+  if (items) {
+    let hasImageFiles = false;
+    let hasRegularFiles = false;
+    for (const item of Array.from(items)) {
+      if (item.kind !== "file") {
+        continue;
+      }
+      if (supportedPromptImageMimeType(item.type)) {
+        hasImageFiles = true;
+      } else {
+        hasRegularFiles = true;
+      }
+    }
+    return { hasImageFiles, hasRegularFiles };
+  }
+  let hasImageFiles = false;
+  let hasRegularFiles = false;
+  for (const file of Array.from(dataTransfer.files ?? [])) {
+    if (
+      supportedPromptImageMimeType(file.type) ||
+      supportedPromptImageFileName(file.name)
+    ) {
+      hasImageFiles = true;
+    } else {
+      hasRegularFiles = true;
+    }
+  }
+  return { hasImageFiles, hasRegularFiles };
+}
+
 export function supportedPromptImageMimeType(
   value: string
 ): value is AgentRichTextPromptImage["mimeType"] {

--- a/packages/agent/gui/agent-gui/agentGuiNode/agentRichText/agentWorkspaceFileReferences.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/agentRichText/agentWorkspaceFileReferences.ts
@@ -65,9 +65,7 @@ export function createAgentFileMentionContent(
         ? ([
             { type: "text", text: AGENT_RICH_TEXT_CARET_ANCHOR }
           ] as JSONContent[])
-        : index > 0
-          ? ([{ type: "text", text: " " }] as JSONContent[])
-          : []),
+        : []),
       {
         type: "agentFileMention",
         attrs: {

--- a/packages/agent/gui/agent-gui/agentGuiNode/model/agentDroppedFileReferences.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/model/agentDroppedFileReferences.ts
@@ -1,0 +1,7 @@
+import type { WorkspaceFileReference } from "@tutti-os/workspace-file-reference/contracts";
+
+export type AgentDroppedFileReferenceResolver = (
+  files: readonly File[]
+) =>
+  | Promise<readonly WorkspaceFileReference[]>
+  | readonly WorkspaceFileReference[];

--- a/packages/agent/gui/agentActivityRuntime.tsx
+++ b/packages/agent/gui/agentActivityRuntime.tsx
@@ -206,6 +206,10 @@ export interface AgentActivityRuntimePromptAsset {
 }
 
 export interface AgentActivityRuntime {
+  promptContentUploadSupport?: {
+    file?: boolean;
+    image?: boolean;
+  };
   cancelSession(
     input: AgentActivityCancelSessionInput
   ): Promise<AgentActivityCancelSessionResult>;


### PR DESCRIPTION
## Summary

- Route dropped non-image system files through the shared AgentComposer reference insertion path.
- Archive host-local files through the desktop host capability before inserting file mentions.
- Keep image drag/drop on the existing image draft flow and document the host-local drag/drop data flow.

## Validation

- `pnpm --filter @tutti-os/agent-gui typecheck`
- `pnpm --filter @tutti-os/desktop typecheck`
- `pnpm --filter @tutti-os/agent-gui exec vitest run --environment jsdom agent-gui/agentGuiNode/AgentComposer.spec.tsx agent-gui/agentGuiNode/agentRichText/AgentRichTextEditor.spec.tsx agent-gui/agentGuiNode/AgentGUINode.spec.tsx`
- `node --import ./apps/desktop/test/register-asset-stub.mjs --test --experimental-strip-types ./apps/desktop/src/renderer/src/features/workspace-agent/services/createDesktopAgentActivityRuntime.test.ts ./apps/desktop/src/renderer/src/features/workspace-agent/services/createDesktopAgentGUIWorkbenchHostInput.test.ts`
- `pnpm lint:ts`
- `pnpm check:agent-activity-runtime-boundaries`
- `pnpm check:full`

## Documentation

- Updated `docs/architecture/agent-gui-node.md` for host-local file drag/drop data flow.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added desktop support for archiving and uploading prompt attachments, including dropped local files.
  * Drag-and-drop now resolves non-image system files into workspace file references and inserts them as file mentions/attachments.
  * The desktop agent uploads file and image prompt content when supported, and exposes this capability to the runtime.
* **Bug Fixes**
  * Dropped-file metadata and insertion behavior are now consistent across the editor, detail pane, and desktop app.
  * Mixed image + non-image drops follow the correct pipeline, with uploads enabled only when the runtime supports them.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->