### PR TITLE
fix(workbench-surface): trigger dock connect action on pointerdown

### DIFF
--- a/.changeset/dock-connect-pointerdown.md
+++ b/.changeset/dock-connect-pointerdown.md
@@ -1,0 +1,5 @@
+---
+"@tutti-os/workbench-surface": patch
+---
+
+Fix the dock agent-provider "连接/登录" popover button doing nothing when clicked. The hover-panel action fired on `onClick`, but the panel can be torn down between pointerdown and pointerup (a re-render race, or the overlapping workspace-app webview swallowing the pointerup), so the browser never dispatched the click and the button looked dead. The action now triggers on `pointerdown` (the event proven to reliably reach the button), with keyboard activation still flowing through `onClick` and a short dedupe so a mouse press doesn't double-fire.

--- a/packages/workbench/surface/src/host/WorkbenchHostDock.tsx
+++ b/packages/workbench/surface/src/host/WorkbenchHostDock.tsx
@@ -2952,9 +2952,46 @@ function WorkbenchHostDockHoverPanel({
   setPendingActionKeys: Dispatch<SetStateAction<Set<string>>>;
   state: WorkbenchHostDockHoverPanelState;
 }) {
+  const lastPointerActionAtRef = useRef<Map<string, number>>(new Map());
   if (!entry) {
     return null;
   }
+  const hoverPanelEntry = entry;
+
+  const runHoverAction = (
+    actionKey: string,
+    actionId: string,
+    disabled: boolean
+  ): void => {
+    if (disabled || pendingActionKeys.has(actionKey)) {
+      return;
+    }
+    setPendingActionKeys((current) => {
+      const next = new Set(current);
+      next.add(actionKey);
+      return next;
+    });
+    void (async () => {
+      try {
+        await onDockEntryAction?.({
+          actionId,
+          entryId: hoverPanelEntry.id,
+          host
+        });
+      } catch {
+        // Keep dock action failures contained.
+      } finally {
+        setPendingActionKeys((current) => {
+          if (!current.has(actionKey)) {
+            return current;
+          }
+          const next = new Set(current);
+          next.delete(actionKey);
+          return next;
+        });
+      }
+    })();
+  };
 
   return (
     <div
@@ -2997,40 +3034,48 @@ function WorkbenchHostDockHoverPanel({
                 className="desktop-dock__hover-action"
                 disabled={action.disabled || isLocallyPending}
                 type="button"
+                onPointerDown={(event) => {
+                  // The dock hover panel can be torn down between pointerdown
+                  // and the synthetic click — a re-render race, or the
+                  // overlapping workspace-app webview swallowing the pointerup —
+                  // which silently drops the click and makes the button look
+                  // dead. Act on pointerdown (primary button), the event proven
+                  // to reliably reach this button; keyboard activation still
+                  // flows through onClick below.
+                  if (event.button !== 0) {
+                    return;
+                  }
+                  event.preventDefault();
+                  event.stopPropagation();
+                  lastPointerActionAtRef.current.set(
+                    actionKey,
+                    performance.now()
+                  );
+                  runHoverAction(
+                    actionKey,
+                    action.id,
+                    action.disabled === true
+                  );
+                }}
                 onClick={(event) => {
                   event.preventDefault();
                   event.stopPropagation();
+                  // A mouse activation already ran on pointerdown; skip its
+                  // trailing click. Only the keyboard path (Enter/Space, with no
+                  // preceding pointerdown) should trigger the action here.
+                  const lastPointerAt =
+                    lastPointerActionAtRef.current.get(actionKey);
                   if (
-                    action.disabled === true ||
-                    pendingActionKeys.has(actionKey)
+                    lastPointerAt !== undefined &&
+                    performance.now() - lastPointerAt < 700
                   ) {
                     return;
                   }
-                  setPendingActionKeys((current) => {
-                    const next = new Set(current);
-                    next.add(actionKey);
-                    return next;
-                  });
-                  void (async () => {
-                    try {
-                      await onDockEntryAction?.({
-                        actionId: action.id,
-                        entryId: entry.id,
-                        host
-                      });
-                    } catch {
-                      // Keep dock action failures contained.
-                    } finally {
-                      setPendingActionKeys((current) => {
-                        if (!current.has(actionKey)) {
-                          return current;
-                        }
-                        const next = new Set(current);
-                        next.delete(actionKey);
-                        return next;
-                      });
-                    }
-                  })();
+                  runHoverAction(
+                    actionKey,
+                    action.id,
+                    action.disabled === true
+                  );
                 }}
               >
                 {isPending


### PR DESCRIPTION
## Problem

Clicking the dock agent-provider popover button (e.g. **Claude Code → 连接 / 登录**) did nothing. Codex worked because a ready provider launches on icon click and never shows this "not installed → connect" hover popover.

## Root cause

The hover-panel action button bound its action to `onClick`. Instrumented renderer diagnostics (`window.tutti.runtime.logRendererDiagnostic`) proved the failure precisely:

- `env-panel.render open:false` on load → the panel is mounted, logger works (baseline).
- **3× `hover-panel.pointerdown`** on `desktop-dock__hover-action` → pointer/press reliably reaches the button.
- **0× `click` / 0× dock-action** → the `click` event is never dispatched.

`pointerdown` arrives but `click` does not = the button is removed/replaced between pointerdown and pointerup. The hover panel is torn down mid-press — a re-render race, and/or the overlapping workspace-app `<webview>` swallowing the pointerup — so the browser never fires the synthetic click. It is intermittent (one session did open), matching a race.

This `onClick`-based handler has existed unchanged since the initial open-source commit (`e2120fb2`); it was latent until the agent-provider connect popover on a not-installed provider, overlapping the onboarding webview, exposed it reliably.

## Fix

`WorkbenchHostDock` — trigger the hover-action on `pointerdown` (primary button, the event proven to reach the button); keep `onClick` for keyboard activation (Enter/Space) with a `performance.now()` < 700ms dedupe so a mouse press doesn't double-fire. Action logic extracted into `runHoverAction`.

## Verification

- `@tutti-os/workbench-surface`: 242 tests pass; surface typecheck clean; oxlint + oxfmt clean.
- Manually confirmed in a dev build: clicking 连接 now opens the agent environment setup wizard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a dock popover button issue where clicks could become unresponsive.
  * Improved interaction reliability for mouse and touch input, while keeping keyboard activation working normally.
  * Prevented duplicate actions from firing when a button is triggered twice in quick succession.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->