### PR TITLE
[codex] Add copy button to agent tool code blocks

### DIFF
--- a/packages/agent/gui/app/renderer/i18n/locales/en.ts
+++ b/packages/agent/gui/app/renderer/i18n/locales/en.ts
@@ -539,6 +539,7 @@ export const en = {
       usageCompactAction: "Compact",
       planCardTitle: "Plan",
       planCardCopy: "Copy plan",
+      copyCode: "Copy code",
       planCardExpand: "Expand plan",
       planCardCollapse: "Collapse plan",
       planImplementationLead: "Implement this plan?",

--- a/packages/agent/gui/app/renderer/i18n/locales/zh-CN.ts
+++ b/packages/agent/gui/app/renderer/i18n/locales/zh-CN.ts
@@ -495,6 +495,7 @@ export const zhCN = {
       usageCompactAction: "压缩",
       planCardTitle: "计划",
       planCardCopy: "复制计划",
+      copyCode: "复制代码",
       planCardExpand: "展开方案",
       planCardCollapse: "收起方案",
       planImplementationLead: "是否实作此方案？",

--- a/packages/agent/gui/shared/agentConversation/components/tool-renderers/code/AgentCodeBlock.spec.tsx
+++ b/packages/agent/gui/shared/agentConversation/components/tool-renderers/code/AgentCodeBlock.spec.tsx
@@ -1,5 +1,5 @@
 import { render, screen } from "@testing-library/react";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { AgentCodeBlock } from "./AgentCodeBlock";
 
 describe("AgentCodeBlock", () => {
@@ -45,5 +45,29 @@ describe("AgentCodeBlock", () => {
     expect(disclosure.parentElement?.className).toContain(
       "workspace-agents-status-panel__detail-scroll-region"
     );
+  });
+
+  it("renders a copy button in the header when showHeader is true", () => {
+    render(<AgentCodeBlock content="const x = 1" showHeader />);
+
+    expect(screen.getByTestId("agent-code-block-copy")).toBeInTheDocument();
+  });
+
+  it("does not render a copy button when showHeader is false", () => {
+    render(<AgentCodeBlock content="const x = 1" showHeader={false} />);
+
+    expect(screen.queryByTestId("agent-code-block-copy")).toBeNull();
+  });
+
+  it("copies code content to clipboard on copy button click", async () => {
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    Object.assign(navigator, { clipboard: { writeText } });
+
+    render(<AgentCodeBlock content="const hello = 'world'" showHeader />);
+
+    screen.getByTestId("agent-code-block-copy").click();
+    await vi.waitFor(() => {
+      expect(writeText).toHaveBeenCalledWith("const hello = 'world'");
+    });
   });
 });

--- a/packages/agent/gui/shared/agentConversation/components/tool-renderers/code/AgentCodeBlock.tsx
+++ b/packages/agent/gui/shared/agentConversation/components/tool-renderers/code/AgentCodeBlock.tsx
@@ -1,4 +1,5 @@
-import { useMemo, useState, type JSX } from "react";
+import { useCallback, useMemo, useRef, useState, type JSX } from "react";
+import { Check, Copy } from "lucide-react";
 import { translate } from "../../../../../i18n/index";
 import { AgentPathTailLabel } from "../AgentPathTailLabel";
 
@@ -21,12 +22,41 @@ export function AgentCodeBlock({
 }): JSX.Element | null {
   "use memo";
   const [expanded, setExpanded] = useState(false);
+  const [copied, setCopied] = useState(false);
+  const copyResetRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const normalized = content.trimEnd();
   const lines = useMemo(
     () => (normalized ? normalized.split("\n") : []),
     [normalized]
   );
   const lineCount = lines.length;
+
+  const handleCopy = useCallback(() => {
+    void navigator.clipboard?.writeText(normalized).then(() => {
+      setCopied(true);
+      if (copyResetRef.current) {
+        clearTimeout(copyResetRef.current);
+      }
+      copyResetRef.current = setTimeout(() => setCopied(false), 1500);
+    });
+  }, [normalized]);
+
+  const copyButton = (
+    <button
+      type="button"
+      data-testid="agent-code-block-copy"
+      className="inline-flex size-5 shrink-0 items-center justify-center rounded-[4px] text-[var(--text-tertiary)] transition-colors hover:bg-[var(--transparency-hover)] hover:text-[var(--text-secondary)]"
+      aria-label={translate("agentHost.agentGui.copyCode")}
+      title={translate("agentHost.agentGui.copyCode")}
+      onClick={handleCopy}
+    >
+      {copied ? (
+        <Check size={13} strokeWidth={2} aria-hidden="true" />
+      ) : (
+        <Copy size={13} strokeWidth={2} aria-hidden="true" />
+      )}
+    </button>
+  );
   const truncated = collapsible && !expanded && lineCount > MAX_VISIBLE_LINES;
   const visibleContent = truncated
     ? lines.slice(0, MAX_VISIBLE_LINES).join("\n")
@@ -80,6 +110,7 @@ export function AgentCodeBlock({
               <span className="shrink-0 font-semibold text-[var(--state-success)]">
                 +{addedCount}
               </span>
+              {copyButton}
             </div>
           ) : null}
           <div className="workspace-agents-status-panel__detail-scroll-region max-h-[240px] overflow-auto bg-[var(--background-panel)]">
@@ -112,6 +143,7 @@ export function AgentCodeBlock({
                 {language ? `${language} · ` : ""}
                 {lineCount} lines
               </span>
+              {copyButton}
             </div>
           ) : null}
           <pre className="workspace-agents-status-panel__detail-scroll-region max-h-[200px] overflow-auto px-3 py-2 text-[11px] leading-5 text-[var(--text-primary)]">


### PR DESCRIPTION
## Summary
- Add a copy-to-clipboard button to `AgentCodeBlock` headers in both flat and standard render modes
- Follows the existing `AgentPlanCard` copy pattern: `Copy`/`Check` icons from lucide-react with 1.5s visual feedback
- Adds `copyCode` i18n key for en and zh-CN locales

## Test plan
- [x] `vitest run --environment jsdom shared/agentConversation/components/tool-renderers/code/AgentCodeBlock.spec.tsx` — 5/5 pass
- [x] `oxlint` clean on changed files
- [x] `tsc --noEmit` clean
- [x] `AgentTranscriptItemView.spec.tsx` — 19/19 pass (no regressions)
- [x] `pnpm check:full` (pre-push hook) passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a “Copy code” action to code blocks, making it easier to copy code snippets directly from the interface.
  * The copy control now briefly changes to a confirmation state after use.

* **Tests**
  * Added coverage for the new code-copy behavior, including when the header is shown or hidden and when copying content to the clipboard.

* **Documentation**
  * Added updated localizations for the new “Copy code” label in English and Chinese.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->