### PR TITLE
[codex] Add copy button and i18n to terminal tool output

### DIFF
--- a/packages/agent/gui/app/renderer/i18n/locales/en.ts
+++ b/packages/agent/gui/app/renderer/i18n/locales/en.ts
@@ -539,6 +539,7 @@ export const en = {
       usageCompactAction: "Compact",
       planCardTitle: "Plan",
       planCardCopy: "Copy plan",
+      copyCode: "Copy code",
       planCardExpand: "Expand plan",
       planCardCollapse: "Collapse plan",
       planImplementationLead: "Implement this plan?",
@@ -1363,7 +1364,9 @@ export const en = {
         imagePreviewAlt: "Image generation preview",
         showFullContent: "Show full content ({{count}} lines)",
         collapseContent: "Collapse content",
-        showFullDiff: "Show full diff ({{count}} lines)"
+        showFullDiff: "Show full diff ({{count}} lines)",
+        showFullOutput: "Show full output ({{count}} lines)",
+        collapseOutput: "Collapse output"
       },
       labels: {
         runCommand: "Run command",

--- a/packages/agent/gui/app/renderer/i18n/locales/zh-CN.ts
+++ b/packages/agent/gui/app/renderer/i18n/locales/zh-CN.ts
@@ -495,6 +495,7 @@ export const zhCN = {
       usageCompactAction: "压缩",
       planCardTitle: "计划",
       planCardCopy: "复制计划",
+      copyCode: "复制代码",
       planCardExpand: "展开方案",
       planCardCollapse: "收起方案",
       planImplementationLead: "是否实作此方案？",
@@ -1278,7 +1279,9 @@ export const zhCN = {
         imagePreviewAlt: "图片生成预览",
         showFullContent: "展开完整内容（{{count}} 行）",
         collapseContent: "收起内容",
-        showFullDiff: "展开完整差异（{{count}} 行）"
+        showFullDiff: "展开完整差异（{{count}} 行）",
+        showFullOutput: "展开完整输出（{{count}} 行）",
+        collapseOutput: "收起输出"
       },
       labels: {
         runCommand: "执行命令",

--- a/packages/agent/gui/shared/agentConversation/components/tool-renderers/terminal/AgentTerminalBlock.spec.tsx
+++ b/packages/agent/gui/shared/agentConversation/components/tool-renderers/terminal/AgentTerminalBlock.spec.tsx
@@ -1,5 +1,5 @@
 import { render, screen } from "@testing-library/react";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { AgentTerminalBlock } from "./AgentTerminalBlock";
 
 describe("AgentTerminalBlock", () => {
@@ -107,5 +107,56 @@ describe("AgentTerminalBlock", () => {
       output?.closest(".workspace-agents-status-panel__detail-scroll-region")
         ?.className
     ).toContain("text-[var(--state-danger)]");
+  });
+
+  it("renders a copy button when there is output", () => {
+    render(
+      <AgentTerminalBlock
+        command="echo hello"
+        stdout="hello"
+        stderr=""
+        exitCode={0}
+        durationMs={100}
+        status="completed"
+      />
+    );
+
+    expect(screen.getByTestId("agent-terminal-copy")).toBeInTheDocument();
+  });
+
+  it("does not render a copy button when there is no output", () => {
+    render(
+      <AgentTerminalBlock
+        command="echo hello"
+        stdout=""
+        stderr=""
+        exitCode={0}
+        durationMs={100}
+        status="completed"
+      />
+    );
+
+    expect(screen.queryByTestId("agent-terminal-copy")).toBeNull();
+  });
+
+  it("copies output text to clipboard on copy button click", async () => {
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    Object.assign(navigator, { clipboard: { writeText } });
+
+    render(
+      <AgentTerminalBlock
+        command="echo hello"
+        stdout="hello world"
+        stderr=""
+        exitCode={0}
+        durationMs={100}
+        status="completed"
+      />
+    );
+
+    screen.getByTestId("agent-terminal-copy").click();
+    await vi.waitFor(() => {
+      expect(writeText).toHaveBeenCalledWith("hello world");
+    });
   });
 });

--- a/packages/agent/gui/shared/agentConversation/components/tool-renderers/terminal/AgentTerminalBlock.tsx
+++ b/packages/agent/gui/shared/agentConversation/components/tool-renderers/terminal/AgentTerminalBlock.tsx
@@ -1,4 +1,6 @@
-import { useMemo, useState, type JSX } from "react";
+import { useCallback, useMemo, useRef, useState, type JSX } from "react";
+import { Check, Copy } from "lucide-react";
+import { translate } from "../../../../../i18n/index";
 import { AgentToolScrollArea } from "../AgentToolScrollArea";
 
 const MAX_OUTPUT_LINES = 200;
@@ -18,6 +20,8 @@ export function AgentTerminalBlock({
 }): JSX.Element | null {
   "use memo";
   const [expanded, setExpanded] = useState(false);
+  const [copied, setCopied] = useState(false);
+  const copyResetRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const outputText = useMemo(
     () => [stdout, stderr].filter(Boolean).join("\n"),
     [stdout, stderr]
@@ -32,6 +36,33 @@ export function AgentTerminalBlock({
     : outputText;
   const failed = status === "failed";
   const hasOutput = Boolean(visibleOutput);
+
+  const handleCopy = useCallback(() => {
+    void navigator.clipboard?.writeText(outputText).then(() => {
+      setCopied(true);
+      if (copyResetRef.current) {
+        clearTimeout(copyResetRef.current);
+      }
+      copyResetRef.current = setTimeout(() => setCopied(false), 1500);
+    });
+  }, [outputText]);
+
+  const copyButton = hasOutput ? (
+    <button
+      type="button"
+      data-testid="agent-terminal-copy"
+      className="inline-flex size-5 shrink-0 items-center justify-center rounded-[4px] text-[var(--text-tertiary)] transition-colors hover:bg-[var(--transparency-hover)] hover:text-[var(--text-secondary)]"
+      aria-label={translate("agentHost.agentGui.copyCode")}
+      title={translate("agentHost.agentGui.copyCode")}
+      onClick={handleCopy}
+    >
+      {copied ? (
+        <Check size={13} strokeWidth={2} aria-hidden="true" />
+      ) : (
+        <Copy size={13} strokeWidth={2} aria-hidden="true" />
+      )}
+    </button>
+  ) : null;
   const disclosureButton =
     outputLines.length > MAX_OUTPUT_LINES ? (
       <button
@@ -40,8 +71,10 @@ export function AgentTerminalBlock({
         onClick={() => setExpanded((value) => !value)}
       >
         {expanded
-          ? "Collapse output"
-          : `Show full output (${outputLines.length} lines)`}
+          ? translate("agentHost.agentTool.details.collapseOutput")
+          : translate("agentHost.agentTool.details.showFullOutput", {
+              count: outputLines.length
+            })}
       </button>
     ) : null;
 
@@ -65,6 +98,7 @@ export function AgentTerminalBlock({
           >
             {command}
           </span>
+          {copyButton}
         </div>
       ) : null}
       {hasOutput ? (


### PR DESCRIPTION
## Summary
- Replace hardcoded English strings in `AgentTerminalBlock` disclosure button with `translate()` calls
- Add copy-to-clipboard button for terminal output in the command header
- Add `showFullOutput` / `collapseOutput` / `copyCode` i18n keys for en and zh-CN

## Test plan
- [x] `vitest run --environment jsdom shared/agentConversation/components/tool-renderers/terminal/AgentTerminalBlock.spec.tsx` — 6/6 pass
- [x] `oxlint` clean on changed files
- [x] `pnpm check:i18n` passed
- [x] `pnpm check:full` (pre-push hook) passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a copy button for terminal output, letting you copy command output directly to the clipboard.
  * Improved the terminal output controls with localized labels for “show full output” and “collapse output.”
  * Added a “Copy code” label in the interface, including updated English and Chinese text.

* **Bug Fixes**
  * The copy button now appears only when output is available, avoiding empty-state clutter.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->