### PR TITLE
[codex] Translate task step fallback label

### DIFF
--- a/packages/agent/gui/app/renderer/i18n/locales/en.ts
+++ b/packages/agent/gui/app/renderer/i18n/locales/en.ts
@@ -1354,6 +1354,7 @@ export const en = {
         questionFallback: "Question",
         delegateSession: "Delegate session",
         noMatches: "No matches",
+        stepLabel: "Step {{index}}",
         noMatchingTools: "No matching tools",
         loadedAvailable: "{{loaded}} loaded · {{available}} available",
         contentTruncated: "Content truncated",

--- a/packages/agent/gui/app/renderer/i18n/locales/zh-CN.ts
+++ b/packages/agent/gui/app/renderer/i18n/locales/zh-CN.ts
@@ -1269,6 +1269,7 @@ export const zhCN = {
         questionFallback: "问题",
         delegateSession: "委托会话",
         noMatches: "没有匹配结果",
+        stepLabel: "步骤 {{index}}",
         noMatchingTools: "没有匹配的工具",
         loadedAvailable: "已加载 {{loaded}} 个 · 共 {{available}} 个",
         contentTruncated: "内容已截断",

--- a/packages/agent/gui/shared/agentConversation/components/tool-renderers/agentToolContentShared.tsx
+++ b/packages/agent/gui/shared/agentConversation/components/tool-renderers/agentToolContentShared.tsx
@@ -352,7 +352,11 @@ export function normalizeTaskSteps(call: AgentToolCallVM): TaskStepView[] {
       stringValue(step.tool_name) ??
       stringValue(step.name) ??
       null;
-    const name = toolName ? humanizeToolLabel(toolName) : `Step ${index + 1}`;
+    const name = toolName
+      ? humanizeToolLabel(toolName)
+      : translate("agentHost.agentTool.details.stepLabel", {
+          index: index + 1
+        });
     const status =
       stringValue(step.status) ??
       stringValue(optionRecord(step.toolResult)?.status) ??


### PR DESCRIPTION
## Summary
Replace the hardcoded `"Step {n}"` fallback label in `agentToolContentShared.tsx` with a proper `translate()` call so unnamed task steps render localized in all supported languages.

Adds `stepLabel` key to `en` and `zh-CN` locales.

## Test plan
- [x] `pnpm check:full` passes
- [ ] Verify unnamed agent task steps show localized label in Chinese locale

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Step names in agent tool details now use localized text when no tool name is available.
  * Added support for displaying step labels in English and Simplified Chinese.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->