### PR TITLE
[codex] polish settings and zoom control states

### DIFF
--- a/apps/desktop/src/renderer/src/features/workspace-workbench/ui/WorkspaceSettingsPanel.test.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/ui/WorkspaceSettingsPanel.test.ts
@@ -52,6 +52,13 @@ test("workspace settings agent panel lists agent controls", () => {
   assert.match(source, /onAgentConversationDetailModeChange\(mode\)/);
 });
 
+test("workspace settings work mode selected state uses a tutti purple border", () => {
+  assert.match(
+    source,
+    /selected\s*\?\s*"border border-\[var\(--tutti-purple\)\] bg-\[var\(--background-fronted\)\]/
+  );
+});
+
 test("workspace settings general panel lists system controls", () => {
   assert.match(
     source,

--- a/apps/desktop/src/renderer/src/features/workspace-workbench/ui/WorkspaceSettingsPanel.tsx
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/ui/WorkspaceSettingsPanel.tsx
@@ -2382,10 +2382,10 @@ function WorkspaceAgentSettingsSection({
                 key={mode}
                 aria-checked={selected}
                 className={cn(
-                  "flex min-h-[72px] min-w-0 flex-col items-start justify-center gap-1 rounded-[8px] border px-3 py-2.5 text-left transition-colors duration-150 disabled:cursor-default disabled:opacity-70",
+                  "flex min-h-[72px] min-w-0 flex-col items-start justify-center gap-1 rounded-[8px] border-solid px-3 py-2.5 text-left transition-colors duration-150 disabled:cursor-default disabled:opacity-70",
                   selected
-                    ? "border-[var(--border-focus)] bg-[var(--transparency-active)] text-[var(--text-primary)]"
-                    : "border-[var(--border-1)] bg-[var(--transparency-block)] text-[var(--text-primary)] hover:bg-[var(--transparency-hover)]"
+                    ? "border border-[var(--tutti-purple)] bg-[var(--background-fronted)] text-[var(--text-primary)]"
+                    : "border border-[var(--border-1)] bg-[var(--transparency-block)] text-[var(--text-primary)] hover:bg-[var(--transparency-hover)]"
                 )}
                 disabled={isUpdatingAgentConversationDetailMode}
                 role="radio"

--- a/packages/agent/gui/agent-gui/agentGuiNode/AgentComposer.spec.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/AgentComposer.spec.tsx
@@ -2370,6 +2370,9 @@ describe("AgentComposer", () => {
       await vi.advanceTimersByTimeAsync(1);
     });
     expect(screen.getByTestId("agent-gui-usage-popover")).toBeVisible();
+    expect(screen.getByTestId("agent-gui-usage-popover")).toHaveTextContent(
+      "上下文用量"
+    );
     expect(
       screen.getByTestId("agent-gui-usage-context-meter")
     ).toHaveTextContent("上下文窗口");
@@ -4620,7 +4623,7 @@ function createLabels(): Parameters<typeof AgentComposer>[0]["labels"] {
     slashStatusLimitsUnavailable: "Rate limits unavailable",
     usageChipLabel: ({ percent }) => `上下文 ${percent}%`,
     usageTooltipLabel: "上下文用量",
-    usagePopoverTitle: "用量",
+    usagePopoverTitle: "上下文用量",
     usageContextWindowLabel: "上下文窗口",
     usageTokensLabel: "Token 用量",
     usageLimitsLabel: "限额",

--- a/packages/agent/gui/app/renderer/agentactivity.css
+++ b/packages/agent/gui/app/renderer/agentactivity.css
@@ -119,11 +119,11 @@
   z-index: 100301;
   display: flex;
   align-items: center;
-  gap: 4px;
-  height: 40px;
-  padding: 0 6px;
+  gap: 2px;
+  height: 32px;
+  padding: 0 2px;
   border-radius: 999px;
-  background: color-mix(in srgb, var(--background-panel) 78%, black 22%);
+  background: var(--background-fronted);
   box-shadow:
     0 18px 40px color-mix(in srgb, black 26%, transparent),
     0 0 0 1px color-mix(in srgb, white 12%, transparent);
@@ -168,9 +168,10 @@
 
 .tsh-zoom-dialog__zoom-controls button {
   justify-content: center;
-  width: 30px;
-  height: 30px;
+  width: 28px;
+  height: 28px;
   padding: 0;
+  border-radius: 999px;
 }
 
 .tsh-zoom-dialog__zoom-controls button:disabled {
@@ -183,8 +184,8 @@
   padding: 0 4px;
   text-align: center;
   font-size: 12px;
-  line-height: 30px;
-  color: var(--text-secondary);
+  line-height: 28px;
+  color: var(--text-primary);
   font-variant-numeric: tabular-nums;
 }
 
@@ -208,9 +209,12 @@
 
 .tsh-zoom-dialog__icon-button:hover,
 .tsh-zoom-dialog__image-actions button:hover,
-.tsh-zoom-dialog__zoom-controls button:not(:disabled):hover,
 .tsh-image-context-menu button:hover {
   background: color-mix(in srgb, var(--background-panel) 82%, white 12%);
+}
+
+.tsh-zoom-dialog__zoom-controls button:not(:disabled):hover {
+  background: color-mix(in srgb, var(--background-panel) 86%, black 8%);
 }
 
 .workspace-agents-status-panel {

--- a/packages/agent/gui/app/renderer/i18n/locales/en.ts
+++ b/packages/agent/gui/app/renderer/i18n/locales/en.ts
@@ -532,7 +532,7 @@ export const en = {
       slashStatusLimitsUnavailable: "Rate limits unavailable from this agent",
       usageChipLabel: "Context {{percent}}%",
       usageTooltipLabel: "Context usage",
-      usagePopoverTitle: "Plan usage",
+      usagePopoverTitle: "Context Usage",
       usageContextWindowLabel: "Context window",
       usageTokensLabel: "Tokens",
       usageLimitsLabel: "Limits",

--- a/packages/agent/gui/app/renderer/i18n/locales/zh-CN.ts
+++ b/packages/agent/gui/app/renderer/i18n/locales/zh-CN.ts
@@ -488,7 +488,7 @@ export const zhCN = {
       slashStatusLimitsUnavailable: "当前 Agent 未提供额度限制",
       usageChipLabel: "上下文 {{percent}}%",
       usageTooltipLabel: "上下文用量",
-      usagePopoverTitle: "计划用量",
+      usagePopoverTitle: "上下文用量",
       usageContextWindowLabel: "上下文窗口",
       usageTokensLabel: "Token 用量",
       usageLimitsLabel: "限额",

--- a/packages/agent/gui/workbench/contribution.test.ts
+++ b/packages/agent/gui/workbench/contribution.test.ts
@@ -717,6 +717,20 @@ describe("agent GUI workbench contribution copy", () => {
     );
   });
 
+  it("keeps zoom image modal zoom controls aligned with action buttons", () => {
+    const css = readFileSync(resolve("app/renderer/agentactivity.css"), "utf8");
+
+    expect(css).toMatch(
+      /\.tsh-zoom-dialog__zoom-controls\s*{[^}]*height:\s*32px;[^}]*padding:\s*0 2px;[^}]*border-radius:\s*999px;[^}]*background:\s*var\(--background-fronted\);/s
+    );
+    expect(css).toMatch(
+      /\.tsh-zoom-dialog__zoom-controls button\s*{[^}]*width:\s*28px;[^}]*height:\s*28px;[^}]*border-radius:\s*999px;/s
+    );
+    expect(css).toMatch(
+      /\.tsh-zoom-dialog__zoom-controls span\s*{[^}]*line-height:\s*28px;[^}]*color:\s*var\(--text-primary\);/s
+    );
+  });
+
   it("keeps the traffic light group aligned with the agent identity", () => {
     const css = readFileSync(resolve("app/renderer/agentactivity.css"), "utf8");
 


### PR DESCRIPTION
## Summary

- Update the Settings > Agent work mode selected state to use a 1px `var(--tutti-purple)` border and `var(--background-fronted)` background.
- Tighten the Agent GUI zoom image modal controls so the pill, icon buttons, and percentage label align with the surrounding action buttons.
- Clarify the Agent GUI usage popover title copy in English and Simplified Chinese.
- Add source-level assertions for both visual contracts.

## Validation

- `cd apps/desktop && /Users/zoezyu/.nvm/versions/node/v24.18.0/bin/node --import ./test/register-asset-stub.mjs --test --experimental-strip-types ./src/renderer/src/features/workspace-workbench/ui/WorkspaceSettingsPanel.test.ts`
- `PATH=/Users/zoezyu/.nvm/versions/node/v24.18.0/bin:$PATH pnpm exec vitest run --environment jsdom workbench/contribution.test.ts` from `packages/agent/gui`
- `PATH=/Users/zoezyu/.nvm/versions/node/v24.18.0/bin:$PATH pnpm exec vitest run --environment jsdom agent-gui/agentGuiNode/AgentComposer.spec.tsx` from `packages/agent/gui`
- `PATH=/Users/zoezyu/.nvm/versions/node/v24.18.0/bin:/Users/zoezyu/go/bin:$PATH pnpm check:i18n`
- `git push -u origin ui-improve-0701` ran pre-push `pnpm check:full` successfully

## Notes

- Local setup needed `/Users/zoezyu/go/bin` on PATH for the pinned `golangci-lint` used by `pnpm lint:go`.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **UI Improvements**
  * Updated workspace settings radio buttons with clearer selected and unselected visual states.
  * Refined zoom dialog controls for a more compact, polished appearance and improved hover feedback.

* **Localization**
  * Renamed the usage popover title to **“Context Usage”** in English and Chinese.

* **Tests**
  * Added coverage to verify the updated styling and localized usage popover text.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->