### PR TITLE
[codex] fix duplicate failed node analytics

### DIFF
--- a/services/tuttid/service/agent/activity_projection.go
+++ b/services/tuttid/service/agent/activity_projection.go
@@ -163,7 +163,9 @@ func (p *ActivityProjection) ReportSessionState(
 				activitySessionUpdateEventPayload(input.WorkspaceID, input.AgentSessionID, result.LastEventUnixMS),
 			)
 		}
-		p.reportFailedRuntimeNodeResult(ctx, input)
+		if result.StateApplied {
+			p.reportFailedRuntimeNodeResult(ctx, input)
+		}
 	}
 	p.observeSessionState(ctx, input, reply)
 	return reply, nil

--- a/services/tuttid/service/agent/service_test.go
+++ b/services/tuttid/service/agent/service_test.go
@@ -2703,6 +2703,38 @@ func TestActivityProjectionReportsFailedRuntimeNodeResult(t *testing.T) {
 	}
 }
 
+func TestActivityProjectionSkipsFailedRuntimeNodeResultWhenStateNotApplied(t *testing.T) {
+	repo := &activityProjectionRepoStub{
+		stateResult: agentactivitybiz.StateReportResult{
+			Accepted:        true,
+			StateApplied:    false,
+			LastEventUnixMS: 200,
+		},
+	}
+	reporter := &recordingAgentAnalyticsReporter{}
+	projection := NewActivityProjection(repo)
+	projection.SetAnalyticsReporter(reporter)
+
+	_, err := projection.ReportSessionState(context.Background(), agentsessionstore.ReportSessionStateInput{
+		WorkspaceID:    "ws-1",
+		AgentSessionID: "session-1",
+		Source: agentsessionstore.EventSource{
+			Provider: "codex",
+		},
+		State: agentsessionstore.WorkspaceAgentSessionStateUpdate{
+			LifecycleStatus:  "failed",
+			LastError:        "network connection disconnected",
+			OccurredAtUnixMS: 150,
+		},
+	})
+	if err != nil {
+		t.Fatalf("ReportSessionState() error = %v", err)
+	}
+	if len(reporter.events) != 0 {
+		t.Fatalf("analytics events = %d, want 0: %#v", len(reporter.events), reporter.events)
+	}
+}
+
 func TestActivityProjectionPublishesCanonicalSessionIDForMessageUpdates(t *testing.T) {
 	repo := &activityProjectionRepoStub{
 		messageResult: agentactivitybiz.MessageReportResult{


### PR DESCRIPTION
## Summary
- Avoid reporting failed runtime node analytics when an accepted state report did not apply a new state.
- Add regression coverage for the accepted-but-not-applied failed-state path.

## Root cause
`ActivityProjection.ReportSessionState` reported `agent.node_result` failures for every accepted failed state report. When the activity repository accepted an already-seen state but returned `StateApplied=false`, the projection could emit the same failed runtime node result again.

## Validation
- `go test -count=1 ./service/agent` from `services/tuttid`

## Notes
- This PR is scoped to daemon-side duplicate failed node analytics. Provider status polling events observed during manual capture are separate no-session provider setup checks.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Adjusted session state reporting so failure analytics are only sent when a state change was actually applied.
  * Prevents false failure events from being emitted for accepted reports that did not update state.

* **Tests**
  * Added coverage to confirm no failure analytics are generated when a failed session report is accepted but no state patch is applied.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->