### PR TITLE
[codex] use one window snapping selector

### DIFF
--- a/apps/desktop/src/renderer/src/features/workspace-workbench/ui/WorkspaceSettingsPanel.test.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/ui/WorkspaceSettingsPanel.test.ts
@@ -181,6 +181,32 @@ test("workspace settings appearance panel owns visual settings", () => {
   assert.match(source, /workspace\.settings\.appearance\.wallpaperLabel/);
 });
 
+test("workspace settings window snapping is controlled by one dropdown", () => {
+  const appearanceSectionStart = source.indexOf(
+    "function WorkspaceAppearanceSettingsSection"
+  );
+  const wallpaperPickerStart = source.indexOf(
+    "function WorkspaceWallpaperPicker"
+  );
+  const appearanceSection = source.slice(
+    appearanceSectionStart,
+    wallpaperPickerStart
+  );
+
+  assert.ok(appearanceSectionStart >= 0);
+  assert.ok(wallpaperPickerStart > appearanceSectionStart);
+  assert.doesNotMatch(appearanceSection, /<Switch/);
+  assert.match(
+    appearanceSection,
+    /pendingWorkbenchWindowSnapping\.enabled[\s\S]*\? pendingWorkbenchWindowSnapping\.shortcutPreset[\s\S]*: "off"/
+  );
+  assert.match(appearanceSection, /enabled: nextValue !== "off"/);
+  assert.match(
+    appearanceSection,
+    /workbenchWindowSnappingShortcutOptions\.off/
+  );
+});
+
 test("workspace settings app source control lives in developer settings", () => {
   const appsSectionStart = source.indexOf(
     "function WorkspaceAppsSettingsSection"

--- a/apps/desktop/src/renderer/src/features/workspace-workbench/ui/WorkspaceSettingsPanel.tsx
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/ui/WorkspaceSettingsPanel.tsx
@@ -1839,6 +1839,10 @@ function workspaceSettingsWindowSnappingShortcutLabelKey(
   }
 }
 
+type WorkspaceSettingsWindowSnappingSelectValue =
+  | "off"
+  | DesktopWorkbenchWindowSnappingShortcutPreset;
+
 function workspaceSettingsFileDefaultOpenerLabelKey(
   opener: DesktopFileDefaultOpener
 ): DesktopI18nKey {
@@ -2965,39 +2969,30 @@ function WorkspaceAppearanceSettingsSection({
             )}
           </p>
         </div>
-        <div className="flex w-[220px] min-w-[220px] flex-col gap-2 max-[560px]:w-full max-[560px]:min-w-0">
-          <div className="flex min-h-9 items-center justify-end max-[560px]:justify-start">
-            <Switch
-              aria-label={t(
-                "workspace.settings.appearance.workbenchWindowSnappingLabel"
-              )}
-              checked={pendingWorkbenchWindowSnapping.enabled}
-              disabled={isUpdatingWorkbenchWindowSnapping}
-              onCheckedChange={(enabled) =>
-                onWorkbenchWindowSnappingChange({
-                  ...pendingWorkbenchWindowSnapping,
-                  enabled
-                })
-              }
-            />
-          </div>
+        <div className="w-[220px] min-w-[220px] max-[560px]:w-full max-[560px]:min-w-0">
           <Select
-            disabled={
-              isUpdatingWorkbenchWindowSnapping ||
-              !pendingWorkbenchWindowSnapping.enabled
+            disabled={isUpdatingWorkbenchWindowSnapping}
+            value={
+              pendingWorkbenchWindowSnapping.enabled
+                ? pendingWorkbenchWindowSnapping.shortcutPreset
+                : "off"
             }
-            value={pendingWorkbenchWindowSnapping.shortcutPreset}
-            onValueChange={(value) =>
+            onValueChange={(value) => {
+              const nextValue =
+                value as WorkspaceSettingsWindowSnappingSelectValue;
               onWorkbenchWindowSnappingChange({
                 ...pendingWorkbenchWindowSnapping,
+                enabled: nextValue !== "off",
                 shortcutPreset:
-                  value as DesktopWorkbenchWindowSnappingShortcutPreset
-              })
-            }
+                  nextValue === "off"
+                    ? pendingWorkbenchWindowSnapping.shortcutPreset
+                    : nextValue
+              });
+            }}
           >
             <SelectTrigger
               aria-label={t(
-                "workspace.settings.appearance.workbenchWindowSnappingShortcutLabel"
+                "workspace.settings.appearance.workbenchWindowSnappingLabel"
               )}
               className={workspaceSettingsSelectTriggerClass}
             >
@@ -3007,6 +3002,11 @@ function WorkspaceAppearanceSettingsSection({
               className={workspaceSettingsSelectContentClass}
               style={{ zIndex: "var(--z-panel-popover)" }}
             >
+              <SelectItem value="off">
+                {t(
+                  "workspace.settings.appearance.workbenchWindowSnappingShortcutOptions.off"
+                )}
+              </SelectItem>
               {desktopWorkbenchWindowSnappingShortcutPresets.map((preset) => (
                 <SelectItem key={preset} value={preset}>
                   {t(workspaceSettingsWindowSnappingShortcutLabelKey(preset))}

--- a/apps/desktop/src/shared/i18n/locales/en.ts
+++ b/apps/desktop/src/shared/i18n/locales/en.ts
@@ -404,6 +404,7 @@ export const en = {
           "We couldn't update window snapping right now.",
         workbenchWindowSnappingShortcutLabel: "Window snapping shortcut",
         workbenchWindowSnappingShortcutOptions: {
+          off: "Off",
           commandArrows: "Command + Arrow keys",
           commandShiftArrows: "Command + Shift + Arrow keys"
         },

--- a/apps/desktop/src/shared/i18n/locales/zh-CN.ts
+++ b/apps/desktop/src/shared/i18n/locales/zh-CN.ts
@@ -389,6 +389,7 @@ export const zhCN = {
         workbenchWindowSnappingSaveFailed: "暂时无法更新窗口吸附设置。",
         workbenchWindowSnappingShortcutLabel: "窗口吸附快捷键",
         workbenchWindowSnappingShortcutOptions: {
+          off: "关闭",
           commandArrows: "Command + 方向键",
           commandShiftArrows: "Command + Shift + 方向键"
         },


### PR DESCRIPTION
## Summary

- Replace the separate Window snapping switch plus shortcut dropdown with a single selector in Settings > Appearance.
- Add an `Off` option that disables window snapping while preserving the last shortcut preset.
- Add source-level coverage for the single-dropdown contract and locale strings for English/Simplified Chinese.

## Validation

- `cd apps/desktop && /Users/zoezyu/.nvm/versions/node/v24.18.0/bin/node --import ./test/register-asset-stub.mjs --test --experimental-strip-types ./src/renderer/src/features/workspace-workbench/ui/WorkspaceSettingsPanel.test.ts`
- `PATH=/Users/zoezyu/.nvm/versions/node/v24.18.0/bin:/Users/zoezyu/go/bin:$PATH pnpm check:i18n`
- `git push -u origin codex/window-snapping-dropdown` ran pre-push `pnpm check:full` successfully


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Simplified the workspace window snapping setting into a single dropdown with an explicit **Off** option.
  * The selected snapping state now updates correctly when switching between **Off** and shortcut-based options.
  * Added missing **Off** text in English and Chinese for the appearance settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->