### PR TITLE
fix(workbench): track dock magnification across gaps

### DIFF
--- a/packages/workbench/surface/src/host/WorkbenchHostDock.tsx
+++ b/packages/workbench/surface/src/host/WorkbenchHostDock.tsx
@@ -447,6 +447,7 @@ export function WorkbenchHostDock({
   } = useDockMagnification({
     dockPlacement,
     dockRootRef: dockMeasureRef,
+    dockViewportRef: dockItemsRef,
     slotRefs
   });
   const clearSlotMagnificationRef = useRef<(anchorKey: string) => void>(() => {

--- a/packages/workbench/surface/src/host/dockMagnification.test.ts
+++ b/packages/workbench/surface/src/host/dockMagnification.test.ts
@@ -8,6 +8,8 @@ import {
   DOCK_ICON_BASE_SIZE,
   DOCK_ICON_PEAK_SIZE,
   DOCK_MAGNIFICATION_HALF_RANGE,
+  createDockMagnificationGlobalPointerTracker,
+  isDockMagnificationPointInsideHitBounds,
   isDockMagnificationSlotLayoutLocked,
   isDockMagnificationSpringSettled,
   mapDistanceToTargetSize,
@@ -29,6 +31,56 @@ function assertBoundsEqual(
   assert.ok(Math.abs(actual.crossStart - expected.crossStart) < 0.001);
   assert.ok(Math.abs(actual.mainEnd - expected.mainEnd) < 0.001);
   assert.ok(Math.abs(actual.mainStart - expected.mainStart) < 0.001);
+}
+
+class FakePointerTrackingTarget {
+  readonly listeners = new Map<
+    string,
+    Set<EventListenerOrEventListenerObject>
+  >();
+  readonly added: string[] = [];
+  readonly removed: string[] = [];
+
+  addEventListener(
+    type: string,
+    listener: EventListenerOrEventListenerObject | null
+  ) {
+    if (!listener) {
+      return;
+    }
+    this.added.push(type);
+    let listenersForType = this.listeners.get(type);
+    if (!listenersForType) {
+      listenersForType = new Set();
+      this.listeners.set(type, listenersForType);
+    }
+    listenersForType.add(listener);
+  }
+
+  removeEventListener(
+    type: string,
+    listener: EventListenerOrEventListenerObject | null
+  ) {
+    if (!listener) {
+      return;
+    }
+    this.removed.push(type);
+    this.listeners.get(type)?.delete(listener);
+  }
+
+  dispatch(type: string, event: Event) {
+    for (const listener of this.listeners.get(type) ?? []) {
+      if (typeof listener === "function") {
+        listener(event);
+      } else {
+        listener.handleEvent(event);
+      }
+    }
+  }
+
+  listenerCount(type: string) {
+    return this.listeners.get(type)?.size ?? 0;
+  }
 }
 
 test("mapDistanceToTargetSize peaks at center and falls off linearly", () => {
@@ -79,6 +131,35 @@ test("dock magnification hit bounds exclude scroll-control padding before the fi
     mainEnd: 203.2,
     mainStart: 100
   });
+});
+
+test("dock magnification hit bounds include the transparent gap between slots", () => {
+  const hitBounds = resolveDockMagnificationHitBounds(
+    [
+      { bottom: 80, left: 100, right: 143.2, top: 36.8 },
+      { bottom: 80, left: 160, right: 203.2, top: 36.8 }
+    ],
+    "bottom"
+  );
+
+  assert.equal(
+    isDockMagnificationPointInsideHitBounds({
+      clientX: 151.6,
+      clientY: 60,
+      dockPlacement: "bottom",
+      hitBounds
+    }),
+    true
+  );
+  assert.equal(
+    isDockMagnificationPointInsideHitBounds({
+      clientX: 99,
+      clientY: 60,
+      dockPlacement: "bottom",
+      hitBounds
+    }),
+    false
+  );
 });
 
 test("left dock magnification hit bounds use the vertical slot range", () => {
@@ -174,6 +255,77 @@ test("dock magnification keeps active styles until leave animation settles", () 
     /if \(pointerAxis === null && allSettled\) \{[\s\S]*?setMagnifyActive\(false\);/
   );
   assert.doesNotMatch(handlePointerLeaveSource, /setMagnifyActive\(false\);/);
+});
+
+test("dock magnification global pointer tracker forwards gap moves and cleans up", () => {
+  const pointerTarget = new FakePointerTrackingTarget();
+  const blurTarget = new FakePointerTrackingTarget();
+  const moves: Array<{ clientX: number; clientY: number }> = [];
+  let canceled = 0;
+  const tracker = createDockMagnificationGlobalPointerTracker({
+    blurTarget,
+    onPointerCancel: () => {
+      canceled += 1;
+    },
+    onPointerMove: (clientX, clientY) => {
+      moves.push({ clientX, clientY });
+    },
+    pointerTarget
+  });
+
+  tracker.start();
+  tracker.start();
+
+  assert.equal(tracker.isActive(), true);
+  assert.equal(pointerTarget.listenerCount("pointermove"), 1);
+  assert.equal(pointerTarget.listenerCount("pointercancel"), 1);
+  assert.equal(blurTarget.listenerCount("blur"), 1);
+  assert.deepEqual(pointerTarget.added, ["pointermove", "pointercancel"]);
+  assert.deepEqual(blurTarget.added, ["blur"]);
+
+  pointerTarget.dispatch("pointermove", {
+    clientX: 151,
+    clientY: 60
+  } as unknown as Event);
+  assert.deepEqual(moves, [{ clientX: 151, clientY: 60 }]);
+
+  pointerTarget.dispatch("pointercancel", new Event("pointercancel"));
+  assert.equal(canceled, 1);
+  assert.equal(tracker.isActive(), false);
+  assert.equal(pointerTarget.listenerCount("pointermove"), 0);
+  assert.equal(pointerTarget.listenerCount("pointercancel"), 0);
+  assert.equal(blurTarget.listenerCount("blur"), 0);
+
+  tracker.start();
+  blurTarget.dispatch("blur", new Event("blur"));
+  assert.equal(canceled, 2);
+  assert.equal(tracker.isActive(), false);
+  assert.equal(pointerTarget.listenerCount("pointermove"), 0);
+  assert.equal(pointerTarget.listenerCount("pointercancel"), 0);
+  assert.equal(blurTarget.listenerCount("blur"), 0);
+});
+
+test("dock magnification starts global tracking on active pointers and stops on bounds exit or reset", () => {
+  assert.match(
+    source,
+    /createDockMagnificationGlobalPointerTracker\(\{[\s\S]*?pointerTarget: document/
+  );
+  assert.match(
+    source,
+    /startGlobalPointerTracking\(\);[\s\S]*?scheduleAnimation\(\);/
+  );
+  assert.match(
+    source,
+    /if \([\s\S]*?!isDockMagnificationPointInsideHitBounds\([\s\S]*?\) \{[\s\S]*?stopGlobalPointerTracking\(\);[\s\S]*?clearTrackedPointer\(\);/
+  );
+  assert.match(
+    source,
+    /const resetMagnification = useCallback\([\s\S]*?stopGlobalPointerTracking\(\);/
+  );
+  assert.match(
+    source,
+    /useEffect\(\s*\(\) => \(\) => \{[\s\S]*?resetMagnification\(\);/
+  );
 });
 
 test("dock magnification caches slot shell lookups during animation", () => {

--- a/packages/workbench/surface/src/host/dockMagnification.test.ts
+++ b/packages/workbench/surface/src/host/dockMagnification.test.ts
@@ -15,7 +15,8 @@ import {
   mapDistanceToTargetSize,
   resolveDockMagnificationHitBounds,
   resolveDockMagnificationSlotLayoutSize,
-  resolveDockMagnificationSlotCenter
+  resolveDockMagnificationSlotCenter,
+  resolveDockMagnificationVisibleHitBounds
 } from "./dockMagnification.ts";
 
 const source = readFileSync(resolve("src/host/dockMagnification.ts"), "utf8");
@@ -157,6 +158,47 @@ test("dock magnification hit bounds include the transparent gap between slots", 
       clientY: 60,
       dockPlacement: "bottom",
       hitBounds
+    }),
+    false
+  );
+});
+
+test("dock magnification visible hit bounds clip overflow slots to the viewport", () => {
+  const slotHitBounds = resolveDockMagnificationHitBounds(
+    [
+      { bottom: 80, left: 100, right: 143.2, top: 36.8 },
+      { bottom: 80, left: 160, right: 203.2, top: 36.8 },
+      { bottom: 80, left: 720, right: 763.2, top: 36.8 }
+    ],
+    "bottom"
+  );
+  const visibleHitBounds = resolveDockMagnificationVisibleHitBounds({
+    dockPlacement: "bottom",
+    hitBounds: slotHitBounds,
+    viewportRect: { bottom: 88, left: 64, right: 560, top: 0 }
+  });
+
+  assertBoundsEqual(visibleHitBounds, {
+    crossEnd: 88,
+    crossStart: 28.8,
+    mainEnd: 560,
+    mainStart: 100
+  });
+  assert.equal(
+    isDockMagnificationPointInsideHitBounds({
+      clientX: 151.6,
+      clientY: 60,
+      dockPlacement: "bottom",
+      hitBounds: visibleHitBounds
+    }),
+    true
+  );
+  assert.equal(
+    isDockMagnificationPointInsideHitBounds({
+      clientX: 730,
+      clientY: 60,
+      dockPlacement: "bottom",
+      hitBounds: visibleHitBounds
     }),
     false
   );

--- a/packages/workbench/surface/src/host/dockMagnification.ts
+++ b/packages/workbench/surface/src/host/dockMagnification.ts
@@ -37,10 +37,26 @@ interface DockMagnificationHitBounds {
   mainStart: number;
 }
 
+interface DockMagnificationPointerTrackingTarget {
+  addEventListener: EventTarget["addEventListener"];
+  removeEventListener: EventTarget["removeEventListener"];
+}
+
+interface DockMagnificationGlobalPointerTracker {
+  isActive: () => boolean;
+  start: () => void;
+  stop: () => void;
+}
+
 const dockMagnificationShellBySlot = new WeakMap<
   HTMLElement,
   HTMLElement | null
 >();
+
+const globalPointerListenerOptions = {
+  capture: true,
+  passive: true
+} as const;
 
 export function mapDistanceToTargetSize(
   distance: number,
@@ -107,7 +123,7 @@ export function resolveDockMagnificationHitBounds(
   };
 }
 
-function isDockMagnificationPointInsideHitBounds({
+export function isDockMagnificationPointInsideHitBounds({
   clientX,
   clientY,
   dockPlacement,
@@ -130,6 +146,72 @@ function isDockMagnificationPointInsideHitBounds({
     crossAxis >= hitBounds.crossStart &&
     crossAxis <= hitBounds.crossEnd
   );
+}
+
+export function createDockMagnificationGlobalPointerTracker({
+  blurTarget,
+  onPointerCancel,
+  onPointerMove,
+  pointerTarget
+}: {
+  blurTarget: DockMagnificationPointerTrackingTarget | null;
+  onPointerCancel: () => void;
+  onPointerMove: (clientX: number, clientY: number) => void;
+  pointerTarget: DockMagnificationPointerTrackingTarget;
+}): DockMagnificationGlobalPointerTracker {
+  let active = false;
+
+  const handlePointerMove = (event: Event) => {
+    const pointerEvent = event as PointerEvent;
+    onPointerMove(pointerEvent.clientX, pointerEvent.clientY);
+  };
+
+  const handlePointerCancel = () => {
+    stop();
+    onPointerCancel();
+  };
+
+  const start = () => {
+    if (active) {
+      return;
+    }
+    active = true;
+    pointerTarget.addEventListener(
+      "pointermove",
+      handlePointerMove,
+      globalPointerListenerOptions
+    );
+    pointerTarget.addEventListener(
+      "pointercancel",
+      handlePointerCancel,
+      globalPointerListenerOptions
+    );
+    blurTarget?.addEventListener("blur", handlePointerCancel);
+  };
+
+  const stop = () => {
+    if (!active) {
+      return;
+    }
+    active = false;
+    pointerTarget.removeEventListener(
+      "pointermove",
+      handlePointerMove,
+      globalPointerListenerOptions
+    );
+    pointerTarget.removeEventListener(
+      "pointercancel",
+      handlePointerCancel,
+      globalPointerListenerOptions
+    );
+    blurTarget?.removeEventListener("blur", handlePointerCancel);
+  };
+
+  return {
+    isActive: () => active,
+    start,
+    stop
+  };
 }
 
 export function resolveDockMagnificationSlotCenter(
@@ -308,6 +390,16 @@ export function useDockMagnification({
   const hitBoundsRef = useRef<DockMagnificationHitBounds | null>(null);
   const slotOrderRef = useRef<string[]>([]);
   const magnifyActiveRef = useRef(false);
+  const globalPointerTrackerRef =
+    useRef<DockMagnificationGlobalPointerTracker | null>(null);
+  const handleGlobalPointerMoveRef = useRef<
+    (clientX: number, clientY: number) => void
+  >(() => {
+    return;
+  });
+  const handleGlobalPointerCancelRef = useRef<() => void>(() => {
+    return;
+  });
 
   const setMagnifyActive = useCallback(
     (active: boolean) => {
@@ -516,6 +608,41 @@ export function useDockMagnification({
     animationFrameRef.current = requestAnimationFrame(runAnimationFrame);
   }, [runAnimationFrame]);
 
+  const stopGlobalPointerTracking = useCallback(() => {
+    globalPointerTrackerRef.current?.stop();
+  }, []);
+
+  const startGlobalPointerTracking = useCallback(() => {
+    if (typeof document === "undefined") {
+      return;
+    }
+
+    globalPointerTrackerRef.current ??=
+      createDockMagnificationGlobalPointerTracker({
+        blurTarget: typeof window === "undefined" ? null : window,
+        onPointerCancel: () => {
+          handleGlobalPointerCancelRef.current();
+        },
+        onPointerMove: (clientX, clientY) => {
+          handleGlobalPointerMoveRef.current(clientX, clientY);
+        },
+        pointerTarget: document
+      });
+    globalPointerTrackerRef.current.start();
+  }, []);
+
+  const clearTrackedPointer = useCallback(() => {
+    pendingPointerAxisRef.current = null;
+    pointerAxisRef.current = null;
+    entryRampStartedAtRef.current = null;
+    scheduleAnimation();
+  }, [scheduleAnimation]);
+
+  const handleGlobalPointerCancel = useCallback(() => {
+    stopGlobalPointerTracking();
+    clearTrackedPointer();
+  }, [clearTrackedPointer, stopGlobalPointerTracking]);
+
   const handlePointerMove = useCallback(
     (clientX: number, clientY: number) => {
       if (restCentersRef.current === null) {
@@ -530,10 +657,8 @@ export function useDockMagnification({
           hitBounds: hitBoundsRef.current
         })
       ) {
-        pendingPointerAxisRef.current = null;
-        pointerAxisRef.current = null;
-        entryRampStartedAtRef.current = null;
-        scheduleAnimation();
+        stopGlobalPointerTracking();
+        clearTrackedPointer();
         return;
       }
 
@@ -542,10 +667,21 @@ export function useDockMagnification({
       if (!magnifyActiveRef.current) {
         setMagnifyActive(true);
       }
+      startGlobalPointerTracking();
       scheduleAnimation();
     },
-    [captureRestCenters, dockPlacement, scheduleAnimation, setMagnifyActive]
+    [
+      captureRestCenters,
+      clearTrackedPointer,
+      dockPlacement,
+      scheduleAnimation,
+      setMagnifyActive,
+      startGlobalPointerTracking,
+      stopGlobalPointerTracking
+    ]
   );
+  handleGlobalPointerMoveRef.current = handlePointerMove;
+  handleGlobalPointerCancelRef.current = handleGlobalPointerCancel;
 
   const handlePointerLeave = useCallback(() => {
     pendingPointerAxisRef.current = null;
@@ -571,14 +707,16 @@ export function useDockMagnification({
   );
 
   const pauseMagnification = useCallback(() => {
+    stopGlobalPointerTracking();
     stopAnimation();
     pendingPointerAxisRef.current = null;
     pointerAxisRef.current = null;
     entryRampStartedAtRef.current = null;
     lastFrameTimeRef.current = null;
-  }, [stopAnimation]);
+  }, [stopAnimation, stopGlobalPointerTracking]);
 
   const resetMagnification = useCallback(() => {
+    stopGlobalPointerTracking();
     stopAnimation();
     for (const slotElement of slotRefs.current.values()) {
       clearDockSlotMagnification(slotElement, appliedStylesRef.current);
@@ -592,7 +730,7 @@ export function useDockMagnification({
     pendingPointerAxisRef.current = null;
     entryRampStartedAtRef.current = null;
     setMagnifyActive(false);
-  }, [setMagnifyActive, slotRefs, stopAnimation]);
+  }, [setMagnifyActive, slotRefs, stopAnimation, stopGlobalPointerTracking]);
 
   useEffect(
     () => () => {

--- a/packages/workbench/surface/src/host/dockMagnification.ts
+++ b/packages/workbench/surface/src/host/dockMagnification.ts
@@ -1,4 +1,15 @@
 import { useCallback, useEffect, useRef, type RefObject } from "react";
+import {
+  isDockMagnificationPointInsideHitBounds,
+  resolveDockMagnificationVisibleHitBounds,
+  type DockMagnificationHitBounds
+} from "./dockMagnificationBounds.ts";
+
+export {
+  isDockMagnificationPointInsideHitBounds,
+  resolveDockMagnificationVisibleHitBounds,
+  type DockMagnificationHitBounds
+} from "./dockMagnificationBounds.ts";
 
 export const DOCK_ICON_BASE_SIZE = 43.2;
 export const DOCK_ICON_PEAK_SIZE = DOCK_ICON_BASE_SIZE * 1.7;
@@ -28,13 +39,6 @@ export interface DockMagnificationSlotRect {
   left: number;
   right: number;
   top: number;
-}
-
-interface DockMagnificationHitBounds {
-  crossEnd: number;
-  crossStart: number;
-  mainEnd: number;
-  mainStart: number;
 }
 
 interface DockMagnificationPointerTrackingTarget {
@@ -121,31 +125,6 @@ export function resolveDockMagnificationHitBounds(
     mainEnd,
     mainStart
   };
-}
-
-export function isDockMagnificationPointInsideHitBounds({
-  clientX,
-  clientY,
-  dockPlacement,
-  hitBounds
-}: {
-  clientX: number;
-  clientY: number;
-  dockPlacement: "bottom" | "left";
-  hitBounds: DockMagnificationHitBounds | null;
-}): boolean {
-  if (!hitBounds) {
-    return false;
-  }
-
-  const mainAxis = dockPlacement === "left" ? clientY : clientX;
-  const crossAxis = dockPlacement === "left" ? clientX : clientY;
-  return (
-    mainAxis >= hitBounds.mainStart &&
-    mainAxis <= hitBounds.mainEnd &&
-    crossAxis >= hitBounds.crossStart &&
-    crossAxis <= hitBounds.crossEnd
-  );
 }
 
 export function createDockMagnificationGlobalPointerTracker({
@@ -371,10 +350,12 @@ function clearDockSlotMagnification(
 export function useDockMagnification({
   dockPlacement,
   dockRootRef,
+  dockViewportRef,
   slotRefs
 }: {
   dockPlacement: "bottom" | "left";
   dockRootRef: RefObject<HTMLElement | null>;
+  dockViewportRef: RefObject<HTMLElement | null>;
   slotRefs: RefObject<Map<string, HTMLElement>>;
 }) {
   const pointerAxisRef = useRef<number | null>(null);
@@ -429,6 +410,7 @@ export function useDockMagnification({
     const centers = new Map<string, number>();
     const slotRects: DockMagnificationSlotRect[] = [];
     const order: string[] = [];
+    const viewportRect = dockViewportRef.current?.getBoundingClientRect();
     for (const [anchorKey, slotElement] of slots) {
       order.push(anchorKey);
       const rect = slotElement.getBoundingClientRect();
@@ -442,12 +424,20 @@ export function useDockMagnification({
       centers.set(anchorKey, center);
     }
     slotOrderRef.current = order;
-    hitBoundsRef.current = resolveDockMagnificationHitBounds(
-      slotRects,
-      dockPlacement
-    );
+    hitBoundsRef.current = resolveDockMagnificationVisibleHitBounds({
+      dockPlacement,
+      hitBounds: resolveDockMagnificationHitBounds(slotRects, dockPlacement),
+      viewportRect: viewportRect
+        ? {
+            bottom: viewportRect.bottom,
+            left: viewportRect.left,
+            right: viewportRect.right,
+            top: viewportRect.top
+          }
+        : null
+    });
     restCentersRef.current = centers;
-  }, [dockPlacement, slotRefs]);
+  }, [dockPlacement, dockViewportRef, slotRefs]);
 
   const runAnimationFrame = useCallback(
     (frameTime: number) => {

--- a/packages/workbench/surface/src/host/dockMagnificationBounds.ts
+++ b/packages/workbench/surface/src/host/dockMagnificationBounds.ts
@@ -1,0 +1,86 @@
+import type { DockMagnificationSlotRect } from "./dockMagnification.ts";
+
+export interface DockMagnificationHitBounds {
+  crossEnd: number;
+  crossStart: number;
+  mainEnd: number;
+  mainStart: number;
+}
+
+function resolveDockMagnificationViewportBounds(
+  viewportRect: DockMagnificationSlotRect,
+  dockPlacement: "bottom" | "left"
+): DockMagnificationHitBounds {
+  return dockPlacement === "left"
+    ? {
+        crossEnd: viewportRect.right,
+        crossStart: viewportRect.left,
+        mainEnd: viewportRect.bottom,
+        mainStart: viewportRect.top
+      }
+    : {
+        crossEnd: viewportRect.bottom,
+        crossStart: viewportRect.top,
+        mainEnd: viewportRect.right,
+        mainStart: viewportRect.left
+      };
+}
+
+export function resolveDockMagnificationVisibleHitBounds({
+  dockPlacement,
+  hitBounds,
+  viewportRect
+}: {
+  dockPlacement: "bottom" | "left";
+  hitBounds: DockMagnificationHitBounds | null;
+  viewportRect: DockMagnificationSlotRect | null;
+}): DockMagnificationHitBounds | null {
+  if (!hitBounds || !viewportRect) {
+    return hitBounds;
+  }
+
+  const viewportBounds = resolveDockMagnificationViewportBounds(
+    viewportRect,
+    dockPlacement
+  );
+  const visibleBounds = {
+    crossEnd: Math.min(hitBounds.crossEnd, viewportBounds.crossEnd),
+    crossStart: Math.max(hitBounds.crossStart, viewportBounds.crossStart),
+    mainEnd: Math.min(hitBounds.mainEnd, viewportBounds.mainEnd),
+    mainStart: Math.max(hitBounds.mainStart, viewportBounds.mainStart)
+  };
+
+  if (
+    visibleBounds.mainStart > visibleBounds.mainEnd ||
+    visibleBounds.crossStart > visibleBounds.crossEnd
+  ) {
+    return null;
+  }
+
+  return visibleBounds;
+}
+
+export function isDockMagnificationPointInsideHitBounds({
+  clientX,
+  clientY,
+  dockPlacement,
+  hitBounds
+}: {
+  clientX: number;
+  clientY: number;
+  dockPlacement: "bottom" | "left";
+  hitBounds: DockMagnificationHitBounds | null;
+}): boolean {
+  if (!hitBounds) {
+    return false;
+  }
+
+  const mainAxis = dockPlacement === "left" ? clientY : clientX;
+  const crossAxis = dockPlacement === "left" ? clientX : clientY;
+  return (
+    mainAxis >= hitBounds.mainStart &&
+    mainAxis <= hitBounds.mainEnd &&
+    crossAxis >= hitBounds.crossStart &&
+    crossAxis <= hitBounds.crossEnd
+  );
+}


### PR DESCRIPTION
## Summary
- Decouple dock magnification pointer coordinate sampling from CSS hit testing by tracking pointer moves at document/window level after entering the dock hit bounds.
- Preserve transparent gap click-through behavior by keeping dock gap pointer-events unchanged.
- Add focused tests for continuous hit bounds, global listener forwarding/dedup/cleanup, and reset/unmount cleanup paths.

## Checks
- pnpm --filter @tutti-os/workbench-surface test -- src/host/dockMagnification.test.ts src/styles/workbenchStyle.test.ts src/host/WorkbenchHostDock.test.ts
- pnpm --filter @tutti-os/workbench-surface typecheck
- pnpm check:changed --tail-lines 80
- git diff --check
- pre-commit hooks: oxfmt, oxlint, electron runtime boundaries, UI boundaries, renderer boundaries
- pre-push hook: pnpm check:full

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved dock magnification pointer tracking for smoother, more reliable behavior.
  * Fixed hit detection around adjacent dock slots, including the transparent gap and viewport-clipped “visible” bounds.
  * Updated dock magnification to respect the dock’s scrolling/viewport region when determining the interactive area.
  * Magnification now cleanly pauses/stops and resets on pointer leave, cancellation, or window focus loss.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->