### PR TITLE
fix(agent): preserve Codex collab agent outputs

### DIFF
--- a/docs/conventions/troubleshooting.md
+++ b/docs/conventions/troubleshooting.md
@@ -745,30 +745,45 @@ delimited by ---`, and the composer skill picker may show partial or
 - Symptom:
   A parent Codex AgentGUI turn that spawned subagents ends with a subagent-only
   answer such as `{"n":7}`, or a failed Agent/subagent tool detail shows the
-  prompt again under Output even though the tool never returned a result.
+  prompt again under Output even though the tool never returned a result. A
+  related symptom is a completed `spawnAgent`, `wait`, or `closeAgent` row that
+  expands to only the original task prompt, despite the Codex rollout JSONL
+  containing `function_call_output` details.
 - Quick checks:
   Compare `workspace_agent_sessions.provider_session_id` with app-server
   notification `threadId` values in `tuttid.log`/run traces. Inspect
   `workspace_agent_messages.payload` for the suspect tool call: if it has
   `input.prompt`/`input.task` but no `output` or `error`, the GUI must not
-  synthesize an Output section from the summary or prompt.
+  synthesize an Output section from the summary or prompt. For Codex
+  collaboration tools, also inspect the raw app-server `collabAgentToolCall`
+  item for `receiverThreadIds`/`receiver_thread_ids` and
+  `agentsStates`/`agents_states`; successful waits and closes often report
+  child results through those fields rather than top-level `output`.
 - Root cause:
   Codex app-server streams parent and child-thread notifications over the same
   connection. Transcript, tool, and `turn/completed` notifications must be
   scoped to the active provider thread before they update the parent turn. On
   the renderer side, task-like tools use the summary/title for compact labels,
-  but missing result payloads are not tool output.
+  but missing result payloads are not tool output. App-server collaboration
+  tools also use structured thread-state fields for results: `spawnAgent`
+  returns child thread ids, `wait` returns per-agent states, and `closeAgent`
+  returns the previous child state.
 - Fix:
   Drop notifications that carry a non-empty `threadId` different from the
   session `provider_session_id`, with debug logging that records expected
   thread, event thread, turn, item id/type/status, and method. Keep notifications
   without `threadId` compatible. For Agent/task cards, render Output only from
-  actual `output`/`error` payload text, not from the prompt or summary.
+  actual `output`/`error` payload text, not from the prompt or summary. When
+  normalizing `collabAgentToolCall`, carry `receiverThreadIds` and
+  `agentsStates` into `rawInput`/`rawOutput` so `wait` and `closeAgent` preserve
+  completed child results and `spawnAgent` preserves the started child id.
 - Validation:
   Add a Codex app-server test that injects foreign-thread `agentMessage` and
   `turn/completed` notifications during a parent turn, plus AgentGUI projection
-  tests for failed Agent calls with prompt-only payloads. Run the focused Go and
-  GUI specs for those paths.
+  tests for failed Agent calls with prompt-only payloads. Add collab-agent
+  normalizer tests for failed spawn output, started child ids, wait completed
+  results, and close previous status. Run the focused Go and GUI specs for
+  those paths.
 
 ### Concurrent agent CLI installs corrupt shared npm global state
 

--- a/packages/agent/daemon/runtime/codex_adapter.go
+++ b/packages/agent/daemon/runtime/codex_adapter.go
@@ -2219,6 +2219,10 @@ func acpToolName(callID string, title string, kind string, rawInput any) string 
 			return "Agent"
 		case "agent":
 			return "Agent"
+		case "closeagent":
+			return "CloseAgent"
+		case "wait":
+			return "Wait"
 		case "rg", "ripgrep":
 			return "Grep"
 		case "find", "fd":

--- a/packages/agent/daemon/runtime/codex_appserver_collab.go
+++ b/packages/agent/daemon/runtime/codex_appserver_collab.go
@@ -1,0 +1,393 @@
+package agentruntime
+
+import (
+	"bufio"
+	"encoding/json"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+)
+
+func appServerCollabAgentRawOutput(item map[string]any, tool string) map[string]any {
+	output := map[string]any{}
+	if message := firstNonEmpty(
+		appServerOutputText(item["error"]),
+		appServerOutputText(item["message"]),
+	); message != "" {
+		output["message"] = message
+	}
+	status := asString(item["status"])
+	if status != "" {
+		output["status"] = status
+	}
+	if text := firstNonEmpty(
+		appServerOutputText(item["output"]),
+		appServerOutputText(item["stdout"]),
+	); text != "" {
+		output["output"] = text
+	}
+	if stderr := appServerOutputText(item["stderr"]); stderr != "" {
+		output["stderr"] = stderr
+	}
+	if result := item["result"]; result != nil {
+		output["result"] = clonePayloadValue(result)
+	}
+	targets := appServerStringList(item["receiverThreadIds"], item["receiver_thread_ids"], item["targets"])
+	agentsStates := appServerAgentStates(item["agentsStates"], item["agents_states"])
+	if len(agentsStates) > 0 {
+		output["agentsStates"] = clonePayloadValue(agentsStates)
+	}
+	switch normalizeAgentToolToken(tool) {
+	case "spawnagent", "spawn":
+		if len(targets) > 0 {
+			output["agent_id"] = targets[0]
+			output["agentId"] = targets[0]
+		}
+	case "waitagent", "wait":
+		if len(agentsStates) > 0 {
+			statuses := make(map[string]any, len(agentsStates))
+			for agentID, state := range agentsStates {
+				statuses[agentID] = appServerCollabAgentStatusObject(state)
+			}
+			output["status"] = statuses
+			output["timed_out"] = normalizeAgentToolToken(status) == "timedout"
+		}
+	case "closeagent", "close":
+		if len(targets) > 0 {
+			output["agent_id"] = targets[0]
+		}
+		if previous := appServerFirstAgentState(targets, agentsStates); previous != nil {
+			output["previous_status"] = appServerCollabAgentStatusObject(previous)
+		}
+	}
+	if _, ok := output["output"]; !ok {
+		if summary := appServerCollabAgentOutputSummary(output); summary != "" {
+			output["output"] = summary
+		}
+	}
+	return output
+}
+
+func (a *CodexAppServerAdapter) completeAppServerCollabAgentToolOutput(
+	session Session,
+	item map[string]any,
+	update map[string]any,
+) {
+	output, _ := update["rawOutput"].(map[string]any)
+	if appServerCollabAgentHasMeaningfulOutput(output) {
+		return
+	}
+	callID := firstNonEmpty(asString(item["id"]), asString(update["toolCallId"]))
+	rolloutOutput := a.appServerCollabAgentRolloutOutput(
+		session.AgentSessionID,
+		session.ProviderSessionID,
+		callID,
+	)
+	if appServerCollabAgentHasMeaningfulOutput(rolloutOutput) {
+		update["rawOutput"] = rolloutOutput
+		return
+	}
+	if asString(update["status"]) == messageStreamStateFailed {
+		slog.Debug(
+			"agent session app-server collab agent failed without output",
+			"agent_session_id", session.AgentSessionID,
+			"provider_session_id", session.ProviderSessionID,
+			"itemId", callID,
+			"tool", asString(item["tool"]),
+			"rawItem", appServerItemJSON(item),
+		)
+	}
+}
+
+func appServerCollabAgentHasMeaningfulOutput(output map[string]any) bool {
+	if len(output) == 0 {
+		return false
+	}
+	for _, key := range []string{
+		"output",
+		"message",
+		"stderr",
+		"result",
+		"agent_id",
+		"agentId",
+		"agentsStates",
+		"previous_status",
+	} {
+		if value, ok := output[key]; ok && value != nil {
+			if strings.TrimSpace(asStringRaw(value)) != "" || len(payloadObject(value)) > 0 {
+				return true
+			}
+		}
+	}
+	statuses := payloadObject(output["status"])
+	return len(statuses) > 0
+}
+
+func (a *CodexAppServerAdapter) appServerCollabAgentRolloutOutput(
+	agentSessionID string,
+	providerThreadID string,
+	callID string,
+) map[string]any {
+	codexHome := a.appServerCodexHome(agentSessionID)
+	if strings.TrimSpace(codexHome) == "" || strings.TrimSpace(providerThreadID) == "" || strings.TrimSpace(callID) == "" {
+		return nil
+	}
+	output, err := appServerReadRolloutFunctionCallOutput(codexHome, providerThreadID, callID)
+	if err != nil {
+		slog.Debug(
+			"agent session app-server collab agent rollout output lookup failed",
+			"agent_session_id", agentSessionID,
+			"provider_session_id", providerThreadID,
+			"call_id", callID,
+			"error", err.Error(),
+		)
+		return nil
+	}
+	return output
+}
+
+func (a *CodexAppServerAdapter) appServerCodexHome(agentSessionID string) string {
+	if a == nil {
+		return ""
+	}
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	appSession := a.sessions[strings.TrimSpace(agentSessionID)]
+	if appSession == nil {
+		return ""
+	}
+	return strings.TrimSpace(asString(appSession.serverInfo["codexHome"]))
+}
+
+func appServerReadRolloutFunctionCallOutput(codexHome string, providerThreadID string, callID string) (map[string]any, error) {
+	path, err := appServerRolloutPath(codexHome, providerThreadID)
+	if err != nil || path == "" {
+		return nil, err
+	}
+	file, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	defer file.Close()
+
+	scanner := bufio.NewScanner(file)
+	scanner.Buffer(make([]byte, 0, 64*1024), 4*1024*1024)
+	for scanner.Scan() {
+		var entry struct {
+			Type    string         `json:"type"`
+			Payload map[string]any `json:"payload"`
+		}
+		if err := json.Unmarshal(scanner.Bytes(), &entry); err != nil {
+			continue
+		}
+		if entry.Type != "response_item" ||
+			asString(entry.Payload["type"]) != "function_call_output" ||
+			asString(entry.Payload["call_id"]) != callID {
+			continue
+		}
+		return appServerRolloutFunctionCallOutputBody(entry.Payload["output"]), nil
+	}
+	if err := scanner.Err(); err != nil {
+		return nil, err
+	}
+	return nil, nil
+}
+
+func appServerRolloutPath(codexHome string, providerThreadID string) (string, error) {
+	root := filepath.Join(codexHome, "sessions")
+	if _, err := os.Stat(root); err != nil {
+		if os.IsNotExist(err) {
+			return "", nil
+		}
+		return "", err
+	}
+	var newestPath string
+	var newestModTime int64
+	err := filepath.WalkDir(root, func(path string, entry os.DirEntry, err error) error {
+		if err != nil || entry == nil || entry.IsDir() {
+			return nil
+		}
+		if filepath.Ext(path) != ".jsonl" || !strings.Contains(filepath.Base(path), providerThreadID) {
+			return nil
+		}
+		info, statErr := entry.Info()
+		if statErr != nil {
+			return nil
+		}
+		modTime := info.ModTime().UnixNano()
+		if newestPath == "" || modTime > newestModTime {
+			newestPath = path
+			newestModTime = modTime
+		}
+		return nil
+	})
+	return newestPath, err
+}
+
+func appServerRolloutFunctionCallOutputBody(value any) map[string]any {
+	if object := payloadObject(value); len(object) > 0 {
+		out := clonePayloadDeep(object)
+		if _, ok := out["output"]; !ok {
+			if summary := appServerCollabAgentOutputSummary(out); summary != "" {
+				out["output"] = summary
+			}
+		}
+		return out
+	}
+	text := strings.TrimSpace(asStringRaw(value))
+	if text == "" {
+		return nil
+	}
+	var object map[string]any
+	if err := json.Unmarshal([]byte(text), &object); err == nil && len(object) > 0 {
+		out := clonePayloadDeep(object)
+		if _, ok := out["output"]; !ok {
+			if summary := appServerCollabAgentOutputSummary(out); summary != "" {
+				out["output"] = summary
+			}
+		}
+		return out
+	}
+	return map[string]any{
+		"message": text,
+		"output":  text,
+	}
+}
+
+func appServerStringList(values ...any) []string {
+	for _, value := range values {
+		switch typed := value.(type) {
+		case []string:
+			out := make([]string, 0, len(typed))
+			for _, item := range typed {
+				if text := strings.TrimSpace(item); text != "" {
+					out = append(out, text)
+				}
+			}
+			if len(out) > 0 {
+				return out
+			}
+		case []any:
+			out := make([]string, 0, len(typed))
+			for _, item := range typed {
+				if text := asString(item); text != "" {
+					out = append(out, text)
+				}
+			}
+			if len(out) > 0 {
+				return out
+			}
+		}
+	}
+	return nil
+}
+
+func appServerAgentStates(values ...any) map[string]any {
+	for _, value := range values {
+		if states := payloadObject(value); len(states) > 0 {
+			return states
+		}
+	}
+	return nil
+}
+
+func appServerFirstAgentState(targets []string, states map[string]any) any {
+	for _, target := range targets {
+		if state, ok := states[target]; ok {
+			return state
+		}
+	}
+	for _, state := range states {
+		return state
+	}
+	return nil
+}
+
+func appServerCollabAgentStatusObject(value any) any {
+	record := payloadObject(value)
+	if len(record) == 0 {
+		return clonePayloadValue(value)
+	}
+	message := firstNonEmpty(
+		appServerOutputText(record["message"]),
+		appServerOutputText(record["output"]),
+		appServerOutputText(record["result"]),
+		appServerOutputText(record["finalMessage"]),
+		appServerOutputText(record["final_message"]),
+	)
+	status := firstNonEmpty(asString(record["status"]), asString(record["state"]))
+	normalized := normalizeAgentToolToken(status)
+	switch {
+	case normalized == "completed" || normalized == "complete" || normalized == "done" || record["completed"] == true || record["done"] == true:
+		if message != "" {
+			return map[string]any{"completed": message}
+		}
+		out, _ := clonePayloadValue(record).(map[string]any)
+		if out == nil {
+			out = map[string]any{}
+		}
+		out["status"] = "completed"
+		return out
+	case normalized == "failed" || normalized == "error":
+		if message != "" {
+			return map[string]any{"failed": message}
+		}
+	case normalized == "canceled" || normalized == "cancelled":
+		if message != "" {
+			return map[string]any{"canceled": message}
+		}
+	}
+	return clonePayloadValue(record)
+}
+
+func appServerCollabAgentOutputSummary(output map[string]any) string {
+	if text := firstNonEmpty(
+		appServerOutputText(output["message"]),
+		appServerOutputText(output["result"]),
+	); text != "" {
+		return text
+	}
+	if previous := payloadObject(output["previous_status"]); len(previous) > 0 {
+		return firstNonEmpty(
+			appServerOutputText(previous["completed"]),
+			appServerOutputText(previous["failed"]),
+			appServerOutputText(previous["canceled"]),
+			appServerOutputText(previous["message"]),
+			appServerOutputText(previous["result"]),
+		)
+	}
+	statuses := payloadObject(output["status"])
+	if len(statuses) == 0 {
+		if agentID := asString(output["agent_id"]); agentID != "" {
+			return agentID
+		}
+		return ""
+	}
+	lines := make([]string, 0, len(statuses))
+	agentIDs := make([]string, 0, len(statuses))
+	for agentID := range statuses {
+		agentIDs = append(agentIDs, agentID)
+	}
+	sort.Strings(agentIDs)
+	for _, agentID := range agentIDs {
+		value := statuses[agentID]
+		state := payloadObject(value)
+		text := firstNonEmpty(
+			appServerOutputText(state["completed"]),
+			appServerOutputText(state["failed"]),
+			appServerOutputText(state["canceled"]),
+			appServerOutputText(state["message"]),
+			appServerOutputText(state["result"]),
+		)
+		if text == "" {
+			continue
+		}
+		if len(statuses) == 1 {
+			return text
+		}
+		lines = append(lines, agentID+": "+text)
+	}
+	return strings.Join(lines, "\n")
+}

--- a/packages/agent/daemon/runtime/codex_appserver_collab_test.go
+++ b/packages/agent/daemon/runtime/codex_appserver_collab_test.go
@@ -1,6 +1,10 @@
 package agentruntime
 
-import "testing"
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
 
 func TestAppServerCollabAgentFailedCarriesErrorOutput(t *testing.T) {
 	t.Parallel()
@@ -25,6 +29,56 @@ func TestAppServerCollabAgentFailedCarriesErrorOutput(t *testing.T) {
 	}
 	if got := asString(rawOutput["message"]); got != "collab spawn failed: agent thread limit reached" {
 		t.Fatalf("rawOutput.message = %q", got)
+	}
+}
+
+func TestAppServerCollabAgentFailedUsesRolloutOutputFallback(t *testing.T) {
+	t.Parallel()
+
+	codexHome := t.TempDir()
+	sessionDir := filepath.Join(codexHome, "sessions", "2026", "07", "01")
+	if err := os.MkdirAll(sessionDir, 0o755); err != nil {
+		t.Fatalf("mkdir session dir: %v", err)
+	}
+	rolloutPath := filepath.Join(sessionDir, "rollout-2026-07-01T18-03-27-thread-1.jsonl")
+	if err := os.WriteFile(rolloutPath, []byte(
+		`{"type":"response_item","payload":{"type":"function_call_output","call_id":"call-spawn-1","output":"collab spawn failed: agent thread limit reached"}}`+"\n",
+	), 0o644); err != nil {
+		t.Fatalf("write rollout: %v", err)
+	}
+	adapter := &CodexAppServerAdapter{
+		sessions: map[string]*codexAppServerSession{
+			"agent-session-1": {serverInfo: map[string]any{"codexHome": codexHome}},
+		},
+	}
+	item := map[string]any{
+		"type":   "collabAgentToolCall",
+		"id":     "call-spawn-1",
+		"tool":   "spawnAgent",
+		"status": "failed",
+		"prompt": "Generate one random integer.",
+	}
+	update, ok := appServerItemToolCallUpdate(item, true)
+	if !ok {
+		t.Fatalf("update was not produced")
+	}
+	if _, ok := update["rawOutput"]; ok {
+		t.Fatalf("rawOutput before fallback = %#v, want absent", update["rawOutput"])
+	}
+	adapter.completeAppServerCollabAgentToolOutput(Session{
+		AgentSessionID:    "agent-session-1",
+		ProviderSessionID: "thread-1",
+	}, item, update)
+
+	rawOutput, ok := update["rawOutput"].(map[string]any)
+	if !ok {
+		t.Fatalf("rawOutput = %#v, want map", update["rawOutput"])
+	}
+	if got := asString(rawOutput["message"]); got != "collab spawn failed: agent thread limit reached" {
+		t.Fatalf("rawOutput.message = %q", got)
+	}
+	if got := asString(rawOutput["output"]); got != "collab spawn failed: agent thread limit reached" {
+		t.Fatalf("rawOutput.output = %q", got)
 	}
 }
 
@@ -68,5 +122,102 @@ func TestAppServerWaitIsControlTool(t *testing.T) {
 	}
 	if got := acpToolName("call-wait-1", asString(update["title"]), asString(update["kind"]), update["rawInput"]); got != "Wait" {
 		t.Fatalf("acpToolName = %q, want Wait", got)
+	}
+}
+
+func TestAppServerCollabAgentSpawnCarriesStartedAgentOutput(t *testing.T) {
+	t.Parallel()
+
+	update, ok := appServerItemToolCallUpdate(map[string]any{
+		"type":              "collabAgentToolCall",
+		"id":                "call-spawn-1",
+		"tool":              "spawnAgent",
+		"status":            "completed",
+		"prompt":            "Generate one random integer.",
+		"receiverThreadIds": []any{"agent-1"},
+		"agentsStates": map[string]any{
+			"agent-1": map[string]any{"status": "pendingInit"},
+		},
+	}, true)
+	if !ok {
+		t.Fatalf("update was not produced")
+	}
+	rawOutput, ok := update["rawOutput"].(map[string]any)
+	if !ok {
+		t.Fatalf("rawOutput = %#v, want map", update["rawOutput"])
+	}
+	if got := asString(rawOutput["agent_id"]); got != "agent-1" {
+		t.Fatalf("rawOutput.agent_id = %q, want agent-1", got)
+	}
+	if got := asString(rawOutput["output"]); got != "agent-1" {
+		t.Fatalf("rawOutput.output = %q", got)
+	}
+}
+
+func TestAppServerCollabAgentWaitCarriesCompletedAgentOutput(t *testing.T) {
+	t.Parallel()
+
+	update, ok := appServerItemToolCallUpdate(map[string]any{
+		"type":              "collabAgentToolCall",
+		"id":                "call-wait-1",
+		"tool":              "wait",
+		"status":            "completed",
+		"receiverThreadIds": []any{"agent-1"},
+		"agentsStates": map[string]any{
+			"agent-1": map[string]any{"status": "completed", "message": "7"},
+		},
+	}, true)
+	if !ok {
+		t.Fatalf("update was not produced")
+	}
+	rawOutput, ok := update["rawOutput"].(map[string]any)
+	if !ok {
+		t.Fatalf("rawOutput = %#v, want map", update["rawOutput"])
+	}
+	if got := asString(rawOutput["output"]); got != "7" {
+		t.Fatalf("rawOutput.output = %q, want 7", got)
+	}
+	statuses, ok := rawOutput["status"].(map[string]any)
+	if !ok {
+		t.Fatalf("rawOutput.status = %#v, want map", rawOutput["status"])
+	}
+	agentStatus, ok := statuses["agent-1"].(map[string]any)
+	if !ok {
+		t.Fatalf("status[agent-1] = %#v, want map", statuses["agent-1"])
+	}
+	if got := asString(agentStatus["completed"]); got != "7" {
+		t.Fatalf("status[agent-1].completed = %q, want 7", got)
+	}
+}
+
+func TestAppServerCollabAgentCloseCarriesPreviousStatusOutput(t *testing.T) {
+	t.Parallel()
+
+	update, ok := appServerItemToolCallUpdate(map[string]any{
+		"type":              "collabAgentToolCall",
+		"id":                "call-close-1",
+		"tool":              "closeAgent",
+		"status":            "completed",
+		"receiverThreadIds": []any{"agent-1"},
+		"agentsStates": map[string]any{
+			"agent-1": map[string]any{"status": "completed", "message": "done"},
+		},
+	}, true)
+	if !ok {
+		t.Fatalf("update was not produced")
+	}
+	rawOutput, ok := update["rawOutput"].(map[string]any)
+	if !ok {
+		t.Fatalf("rawOutput = %#v, want map", update["rawOutput"])
+	}
+	if got := asString(rawOutput["output"]); got != "done" {
+		t.Fatalf("rawOutput.output = %q, want done", got)
+	}
+	previous, ok := rawOutput["previous_status"].(map[string]any)
+	if !ok {
+		t.Fatalf("rawOutput.previous_status = %#v, want map", rawOutput["previous_status"])
+	}
+	if got := asString(previous["completed"]); got != "done" {
+		t.Fatalf("previous_status.completed = %q, want done", got)
 	}
 }

--- a/packages/agent/daemon/runtime/codex_appserver_events.go
+++ b/packages/agent/daemon/runtime/codex_appserver_events.go
@@ -242,6 +242,9 @@ func (a *CodexAppServerAdapter) appServerItemEvents(
 		if !ok {
 			return nil
 		}
+		if completed && itemType == "collabAgentToolCall" {
+			a.completeAppServerCollabAgentToolOutput(session, item, update)
+		}
 		events, _ := normalizer.ToolCallEvents(session, turnID, update)
 		return events
 	}
@@ -403,22 +406,19 @@ func appServerItemToolCallUpdate(item map[string]any, completed bool) (map[strin
 		} else {
 			update["kind"] = "execute"
 		}
-		update["rawInput"] = map[string]any{
+		rawInput := map[string]any{
 			"task":      asStringRaw(item["prompt"]),
 			"agentName": tool,
 		}
+		if targets := appServerStringList(item["receiverThreadIds"], item["receiver_thread_ids"], item["targets"]); len(targets) > 0 {
+			rawInput["targets"] = targets
+			rawInput["target"] = targets[0]
+		}
+		update["rawInput"] = rawInput
 		if completed {
-			output := appServerCollabAgentRawOutput(item)
-			if len(output) > 0 {
+			output := appServerCollabAgentRawOutput(item, tool)
+			if appServerCollabAgentHasMeaningfulOutput(output) {
 				update["rawOutput"] = output
-			} else if update["status"] == messageStreamStateFailed {
-				slog.Debug(
-					"agent session app-server collab agent failed without output",
-					"itemId", itemID,
-					"tool", tool,
-					"status", status,
-					"rawItem", appServerItemJSON(item),
-				)
 			}
 		}
 	case "imageGeneration":
@@ -457,29 +457,6 @@ func appServerAgentControlToolName(tool string) string {
 	default:
 		return ""
 	}
-}
-
-func appServerCollabAgentRawOutput(item map[string]any) map[string]any {
-	output := map[string]any{}
-	if message := firstNonEmpty(
-		appServerOutputText(item["error"]),
-		appServerOutputText(item["message"]),
-	); message != "" {
-		output["message"] = message
-	}
-	if result := item["result"]; result != nil {
-		output["result"] = clonePayloadValue(result)
-	}
-	if text := firstNonEmpty(
-		appServerOutputText(item["output"]),
-		appServerOutputText(item["stdout"]),
-	); text != "" {
-		output["output"] = text
-	}
-	if stderr := appServerOutputText(item["stderr"]); stderr != "" {
-		output["stderr"] = stderr
-	}
-	return output
 }
 
 func appServerOutputText(value any) string {


### PR DESCRIPTION
## Summary
- Preserve Codex app-server collab agent outputs for spawn/wait/close tool rows
- Recover missing failed spawn details from Codex rollout function_call_output when app-server item payload is status-only
- Keep wait/closeAgent rendered as control tools instead of delegate-agent rows

## Validation
- go test ./packages/agent/daemon/runtime -run 'TestAppServerCollabAgent|TestAppServerCloseAgentIsControlTool|TestAppServerWaitIsControlTool'
- pnpm check:changed --tail-lines 80
- pnpm check:full

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved collaboration agent outputs so completed actions now show the correct child-thread results instead of the parent prompt.
  * Added better handling for spawn, wait, and close actions, including missing or incomplete output data.
  * Enhanced matching of session/thread information to reduce misattributed replies.

* **Documentation**
  * Expanded troubleshooting guidance with additional symptoms, validation checks, and clearer verification steps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->