### PR TITLE
fix(agent-gui): hydrate messages after new session attach

### DIFF
--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUINodeController.spec.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUINodeController.spec.tsx
@@ -12432,6 +12432,84 @@ describe("useAgentGUINodeController", () => {
     expect(activate).not.toHaveBeenCalled();
   });
 
+  it("hydrates a newly created conversation from messages after activation", async () => {
+    let createdAgentSessionId = "";
+    const activate = vi.fn(
+      async (input: AgentHostActivateAgentSessionInput) => {
+        createdAgentSessionId = input.agentSessionId;
+        return {
+          session: agentSession(input.agentSessionId, {
+            status: "ready",
+            title: "Created session"
+          }),
+          activation: { mode: input.mode, status: "attached" as const }
+        };
+      }
+    );
+    const listSessionTimeline = vi.fn(
+      async (input: { agentSessionId: string }) => ({
+        timelineItems:
+          input.agentSessionId === createdAgentSessionId
+            ? [
+                timelineMessage({
+                  agentSessionId: createdAgentSessionId,
+                  id: 1,
+                  eventId: "new-user",
+                  role: "user",
+                  content: "New ask",
+                  turnId: "turn-1"
+                }),
+                timelineMessage({
+                  agentSessionId: createdAgentSessionId,
+                  id: 2,
+                  eventId: "new-assistant",
+                  role: "assistant",
+                  content: "New answer",
+                  turnId: "turn-1"
+                })
+              ]
+            : []
+      })
+    );
+    installAgentHostApi({
+      list: vi.fn(async () => ({ presences: [], sessions: [] })),
+      listSessionTimeline,
+      subscribeEvents: vi.fn(() => vi.fn()),
+      activate
+    });
+
+    const { result } = renderHook(() =>
+      useAgentGUINodeController({
+        workspaceId: "room-1",
+        currentUserId: "user-1",
+        workspacePath: "/workspace",
+        avoidGroupingEdits: false,
+        data: agentGuiData(null),
+        onDataChange: vi.fn()
+      })
+    );
+
+    act(() => {
+      result.current.actions.submitPrompt(promptBlocks("New ask"));
+    });
+
+    await waitFor(() => {
+      expect(activate).toHaveBeenCalled();
+    });
+    await waitFor(() => {
+      expect(conversationBodies(result.current.viewModel)).toContain(
+        "New answer"
+      );
+    });
+    expect(listSessionTimeline).toHaveBeenCalledWith(
+      expect.objectContaining({
+        agentSessionId: createdAgentSessionId,
+        cache: false,
+        order: "desc"
+      })
+    );
+  });
+
   it("keeps a newly submitted prompt at the tail when live events arrive before the remote timeline catches up", async () => {
     let emitEvent:
       | ((event: AgentHostAgentActivityStreamEvent) => void)

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUINodeController.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUINodeController.ts
@@ -6837,7 +6837,7 @@ export function useAgentGUINodeController({
           });
           persistActiveConversation(conversation.id);
           setIsLoadingMessages(true);
-          void refreshMessagesFromSnapshot(conversation.id);
+          void loadSelectedConversationMessages(conversation.id);
           void loadSessionState(conversation.id);
           void syncConversationListProjection(conversation.id);
         })
@@ -6936,6 +6936,7 @@ export function useAgentGUINodeController({
       isCreatingConversation,
       openclawGateway?.status,
       syncConversationListProjection,
+      loadSelectedConversationMessages,
       loadSessionState,
       refreshMessagesFromSnapshot,
       persistActiveConversation,


### PR DESCRIPTION
## Summary
- hydrate newly created Agent GUI conversations from the persisted session timeline immediately after attach
- keep session state/list projection sync unchanged
- add regression coverage for a new conversation that has backend user/assistant messages but an initially empty local snapshot

## Validation
- pnpm lint:ts -- packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUINodeController.ts packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUINodeController.spec.tsx
- pnpm typecheck
- NODE_OPTIONS=--max-old-space-size=8192 pnpm exec vitest run --environment jsdom agent-gui/agentGuiNode/controller/useAgentGUINodeController.spec.tsx -t "hydrates a newly created conversation from messages after activation" --pool=forks --maxWorkers=1
- pnpm check:full

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Newly created conversations now load and display the latest messages correctly after activation.
  * Conversation views now hydrate from the current timeline, improving the accuracy of the initial chat history shown to users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->