### PR TITLE
feat(agent-gui): add unified dock foundation

### DIFF
--- a/packages/agent/gui/agent-gui/agentGuiNode/model/agentGuiConversationFilter.spec.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/model/agentGuiConversationFilter.spec.ts
@@ -1,0 +1,90 @@
+import { describe, expect, it } from "vitest";
+import type { WorkspaceAgentActivitySession } from "../../../shared/workspaceAgentActivityTypes.ts";
+import type { AgentGUIConversationSummary } from "./agentGuiConversationModel.ts";
+import {
+  createAgentGUIConversationFilterState,
+  filterAgentGUIConversationSummaries,
+  filterWorkspaceAgentActivitySessionsForConversations
+} from "./agentGuiConversationFilter.ts";
+
+describe("agentGuiConversationFilter", () => {
+  it("includes Codex and Claude Code historical sessions for the all filter", () => {
+    expect(
+      filterWorkspaceAgentActivitySessionsForConversations(
+        [
+          session("codex-1", "codex"),
+          session("claude-1", "claude-code"),
+          session("gemini-1", "gemini")
+        ],
+        { kind: "all" }
+      ).map((item) => item.agentSessionId)
+    ).toEqual(["codex-1", "claude-1"]);
+  });
+
+  it("filters summaries by the selected provider only", () => {
+    expect(
+      filterAgentGUIConversationSummaries(
+        [
+          conversation("codex-1", "codex"),
+          conversation("claude-1", "claude-code"),
+          conversation("unknown-1", "unknown")
+        ],
+        { kind: "provider", provider: "claude-code" }
+      ).map((item) => item.id)
+    ).toEqual(["claude-1"]);
+  });
+
+  it("keeps the filter model independent from composer state", () => {
+    const composerState = Object.freeze({
+      defaultProviderTargetId: "local-codex",
+      selectedProviderTarget: "local-codex"
+    });
+
+    const filterState = createAgentGUIConversationFilterState({
+      kind: "provider",
+      provider: "claude-code"
+    });
+
+    expect(filterState).toEqual({
+      filter: {
+        kind: "provider",
+        provider: "claude-code"
+      }
+    });
+    expect(filterState).not.toHaveProperty("defaultProviderTargetId");
+    expect(filterState).not.toHaveProperty("selectedProviderTarget");
+    expect(composerState).toEqual({
+      defaultProviderTargetId: "local-codex",
+      selectedProviderTarget: "local-codex"
+    });
+  });
+});
+
+function session(
+  agentSessionId: string,
+  provider: WorkspaceAgentActivitySession["provider"]
+): WorkspaceAgentActivitySession {
+  return {
+    agentSessionId,
+    cwd: "/repo",
+    provider,
+    status: "completed",
+    title: agentSessionId,
+    updatedAtUnixMs: 1,
+    workspaceId: "workspace-1"
+  };
+}
+
+function conversation(
+  id: string,
+  provider: AgentGUIConversationSummary["provider"]
+): AgentGUIConversationSummary {
+  return {
+    id,
+    cwd: "/repo",
+    provider,
+    status: "completed",
+    title: id,
+    updatedAtUnixMs: 1
+  };
+}

--- a/packages/agent/gui/agent-gui/agentGuiNode/model/agentGuiConversationFilter.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/model/agentGuiConversationFilter.ts
@@ -1,0 +1,113 @@
+import type { AgentGUIProvider } from "../../../types.ts";
+import { normalizeAgentGUIProviderIdentity } from "../../../shared/agentConversationTitleProjection.ts";
+import type { WorkspaceAgentActivitySession } from "../../../shared/workspaceAgentActivityTypes.ts";
+import type { AgentGUIConversationSummary } from "./agentGuiConversationModel.ts";
+
+export type AgentGUIConversationFilterProvider = Extract<
+  AgentGUIProvider,
+  "codex" | "claude-code"
+>;
+
+export const agentGUIConversationFilterDefaultProviders = [
+  "codex",
+  "claude-code"
+] as const satisfies readonly AgentGUIConversationFilterProvider[];
+
+export type AgentGUIConversationFilter =
+  | {
+      kind: "all";
+    }
+  | {
+      kind: "provider";
+      provider: AgentGUIConversationFilterProvider;
+    };
+
+export interface AgentGUIConversationFilterState {
+  filter: AgentGUIConversationFilter;
+}
+
+export function createAgentGUIConversationFilterState(
+  filter: AgentGUIConversationFilter = { kind: "all" }
+): AgentGUIConversationFilterState {
+  return {
+    filter: normalizeAgentGUIConversationFilter(filter)
+  };
+}
+
+export function normalizeAgentGUIConversationFilter(
+  filter: AgentGUIConversationFilter | null | undefined
+): AgentGUIConversationFilter {
+  if (filter?.kind === "provider") {
+    const provider = normalizeAgentGUIProviderIdentity(filter.provider);
+    return !isAgentGUIConversationFilterProvider(provider)
+      ? { kind: "all" }
+      : { kind: "provider", provider };
+  }
+  return { kind: "all" };
+}
+
+export function filterAgentGUIConversationSummaries(
+  conversations: readonly AgentGUIConversationSummary[],
+  filter: AgentGUIConversationFilter,
+  options: {
+    allProviders?: readonly AgentGUIConversationFilterProvider[];
+  } = {}
+): AgentGUIConversationSummary[] {
+  const normalizedFilter = normalizeAgentGUIConversationFilter(filter);
+  const allProviderSet = createProviderSet(
+    options.allProviders ?? agentGUIConversationFilterDefaultProviders
+  );
+  return conversations.filter((conversation) =>
+    matchesAgentGUIConversationFilterProvider(
+      conversation.provider,
+      normalizedFilter,
+      allProviderSet
+    )
+  );
+}
+
+export function filterWorkspaceAgentActivitySessionsForConversations(
+  sessions: readonly WorkspaceAgentActivitySession[],
+  filter: AgentGUIConversationFilter,
+  options: {
+    allProviders?: readonly AgentGUIConversationFilterProvider[];
+  } = {}
+): WorkspaceAgentActivitySession[] {
+  const normalizedFilter = normalizeAgentGUIConversationFilter(filter);
+  const allProviderSet = createProviderSet(
+    options.allProviders ?? agentGUIConversationFilterDefaultProviders
+  );
+  return sessions.filter((session) =>
+    matchesAgentGUIConversationFilterProvider(
+      session.provider,
+      normalizedFilter,
+      allProviderSet
+    )
+  );
+}
+
+function matchesAgentGUIConversationFilterProvider(
+  provider: string | null | undefined,
+  filter: AgentGUIConversationFilter,
+  allProviderSet: ReadonlySet<AgentGUIConversationFilterProvider>
+): boolean {
+  const normalizedProvider = normalizeAgentGUIProviderIdentity(provider);
+  if (!isAgentGUIConversationFilterProvider(normalizedProvider)) {
+    return false;
+  }
+  return filter.kind === "all"
+    ? allProviderSet.has(normalizedProvider)
+    : normalizedProvider === filter.provider;
+}
+
+function createProviderSet(
+  providers: readonly AgentGUIConversationFilterProvider[]
+): ReadonlySet<AgentGUIConversationFilterProvider> {
+  return new Set(providers);
+}
+
+function isAgentGUIConversationFilterProvider(
+  provider: string
+): provider is AgentGUIConversationFilterProvider {
+  return provider === "codex" || provider === "claude-code";
+}

--- a/packages/agent/gui/workbench/launch.test.ts
+++ b/packages/agent/gui/workbench/launch.test.ts
@@ -1,10 +1,13 @@
 import { describe, expect, it } from "vitest";
 import {
   agentGuiWorkbenchPrefillPromptActivationType,
+  agentGuiWorkbenchDockEntryIdForLayout,
   agentGuiWorkbenchDockEntryId,
+  agentGuiWorkbenchDockIdentityFromIdentifier,
   agentGuiWorkbenchInstanceId,
   agentGuiWorkbenchProviderFromIdentifier,
   agentGuiWorkbenchProviderFromLaunchRequest,
+  agentGuiWorkbenchUnifiedDockEntryId,
   createAgentGuiWorkbenchDraftLaunchRequest,
   createAgentGuiWorkbenchInstanceId,
   createAgentGuiWorkbenchLaunchDescriptor
@@ -18,6 +21,9 @@ describe("agent gui workbench launch contract", () => {
     );
     expect(agentGuiWorkbenchInstanceId("codex")).toBe("agent-gui:codex");
     expect(agentGuiWorkbenchProviderFromIdentifier("agent-gui")).toBe("codex");
+    expect(agentGuiWorkbenchProviderFromIdentifier("agent-gui:codex")).toBe(
+      "codex"
+    );
     expect(agentGuiWorkbenchProviderFromIdentifier("agent-gui:openclaw")).toBe(
       "openclaw"
     );
@@ -58,6 +64,40 @@ describe("agent gui workbench launch contract", () => {
     ).toBe("codex");
   });
 
+  it("uses payload providers before legacy dock identifiers in launch descriptors", () => {
+    const descriptor = createAgentGuiWorkbenchLaunchDescriptor({
+      dockEntryId: "agent-gui:claude-code",
+      payload: { provider: "codex" },
+      typeId: "agent-gui"
+    });
+
+    expect(descriptor.dockEntryId).toBe("agent-gui");
+    expect(descriptor.instanceId).toContain("agent-gui:codex:panel:");
+    expect(descriptor.provider).toBe("codex");
+  });
+
+  it("parses the future unified dock identity separately from legacy provider dock ids", () => {
+    expect(agentGuiWorkbenchUnifiedDockEntryId()).toBe("agent-gui:unified");
+    expect(
+      agentGuiWorkbenchDockEntryIdForLayout({
+        dockLayout: "legacySplit",
+        provider: "claude-code"
+      })
+    ).toBe("agent-gui:claude-code");
+    expect(
+      agentGuiWorkbenchDockEntryIdForLayout({
+        dockLayout: "unified",
+        provider: "claude-code"
+      })
+    ).toBe("agent-gui:unified");
+    expect(
+      agentGuiWorkbenchDockIdentityFromIdentifier("agent-gui:unified")
+    ).toEqual({ kind: "unifiedAggregate" });
+    expect(
+      agentGuiWorkbenchDockIdentityFromIdentifier("agent-gui:claude-code")
+    ).toEqual({ kind: "legacyProvider", provider: "claude-code" });
+  });
+
   it("launches existing sessions into exact session instances", () => {
     expect(
       createAgentGuiWorkbenchLaunchDescriptor({
@@ -81,6 +121,20 @@ describe("agent gui workbench launch contract", () => {
       reuseDockEntryNode: false,
       targetAgentSessionId: "session-2"
     });
+  });
+
+  it("keeps unified aggregate dock launches provider-specific at the instance layer", () => {
+    const descriptor = createAgentGuiWorkbenchLaunchDescriptor({
+      dockEntryId: agentGuiWorkbenchUnifiedDockEntryId(),
+      payload: {
+        provider: "claude-code"
+      },
+      typeId: "agent-gui"
+    });
+
+    expect(descriptor.dockEntryId).toBe("agent-gui:unified");
+    expect(descriptor.instanceId).toContain("agent-gui:claude-code:panel:");
+    expect(descriptor.provider).toBe("claude-code");
   });
 
   it("creates draft prompt launch requests for provider dock entries", () => {
@@ -120,6 +174,40 @@ describe("agent gui workbench launch contract", () => {
       dockEntryId: "agent-gui",
       provider: "codex",
       reuseDockEntryNode: true,
+      targetAgentSessionId: null
+    });
+  });
+
+  it("does not reuse a shared unified aggregate dock node for provider-specific draft prompts", () => {
+    expect(
+      createAgentGuiWorkbenchLaunchDescriptor({
+        dockEntryId: agentGuiWorkbenchUnifiedDockEntryId(),
+        payload: {
+          draftPrompt: "Review this issue",
+          provider: "codex"
+        },
+        typeId: "agent-gui"
+      })
+    ).toMatchObject({
+      dockEntryId: "agent-gui:unified",
+      provider: "codex",
+      reuseDockEntryNode: false,
+      targetAgentSessionId: null
+    });
+
+    expect(
+      createAgentGuiWorkbenchLaunchDescriptor({
+        dockEntryId: agentGuiWorkbenchUnifiedDockEntryId(),
+        payload: {
+          draftPrompt: "Review this issue",
+          provider: "claude-code"
+        },
+        typeId: "agent-gui"
+      })
+    ).toMatchObject({
+      dockEntryId: "agent-gui:unified",
+      provider: "claude-code",
+      reuseDockEntryNode: false,
       targetAgentSessionId: null
     });
   });

--- a/packages/agent/gui/workbench/launch.ts
+++ b/packages/agent/gui/workbench/launch.ts
@@ -22,7 +22,19 @@ type AgentGuiWorkbenchLaunchRequestInput = Pick<
 export const agentGuiWorkbenchTypeId = "agent-gui";
 
 const agentGuiWorkbenchDockEntryPrefix = "agent-gui:";
+const agentGuiWorkbenchUnifiedDockEntryIdValue = "agent-gui:unified";
 let agentGuiWorkbenchInstanceSequence = 0;
+
+export type AgentGuiWorkbenchDockLayout = "legacySplit" | "unified";
+
+export type AgentGuiWorkbenchDockIdentity =
+  | {
+      kind: "legacyProvider";
+      provider: AgentGuiWorkbenchProvider;
+    }
+  | {
+      kind: "unifiedAggregate";
+    };
 
 export function agentGuiWorkbenchDockEntryId(
   provider: AgentGuiWorkbenchProvider
@@ -30,6 +42,19 @@ export function agentGuiWorkbenchDockEntryId(
   return provider === "codex"
     ? agentGuiWorkbenchTypeId
     : `${agentGuiWorkbenchDockEntryPrefix}${provider}`;
+}
+
+export function agentGuiWorkbenchUnifiedDockEntryId(): string {
+  return agentGuiWorkbenchUnifiedDockEntryIdValue;
+}
+
+export function agentGuiWorkbenchDockEntryIdForLayout(input: {
+  dockLayout: AgentGuiWorkbenchDockLayout;
+  provider: AgentGuiWorkbenchProvider;
+}): string {
+  return input.dockLayout === "unified"
+    ? agentGuiWorkbenchUnifiedDockEntryId()
+    : agentGuiWorkbenchDockEntryId(input.provider);
 }
 
 export function agentGuiWorkbenchInstanceId(
@@ -61,9 +86,22 @@ export function createAgentGuiWorkbenchInstanceId(input: {
 export function agentGuiWorkbenchProviderFromIdentifier(
   value: string | null | undefined
 ): AgentGuiWorkbenchProvider | null {
+  const identity = agentGuiWorkbenchDockIdentityFromIdentifier(value);
+  return identity?.kind === "legacyProvider" ? identity.provider : null;
+}
+
+export function agentGuiWorkbenchDockIdentityFromIdentifier(
+  value: string | null | undefined
+): AgentGuiWorkbenchDockIdentity | null {
   const normalized = value?.trim();
-  if (!normalized || normalized === agentGuiWorkbenchTypeId) {
-    return normalized === agentGuiWorkbenchTypeId ? "codex" : null;
+  if (!normalized) {
+    return null;
+  }
+  if (normalized === agentGuiWorkbenchUnifiedDockEntryId()) {
+    return { kind: "unifiedAggregate" };
+  }
+  if (normalized === agentGuiWorkbenchTypeId) {
+    return { kind: "legacyProvider", provider: "codex" };
   }
   if (!normalized.startsWith(agentGuiWorkbenchDockEntryPrefix)) {
     return null;
@@ -71,7 +109,9 @@ export function agentGuiWorkbenchProviderFromIdentifier(
   const provider = normalized
     .slice(agentGuiWorkbenchDockEntryPrefix.length)
     .split(":", 1)[0];
-  return isAgentGuiWorkbenchProvider(provider) ? provider : null;
+  return isAgentGuiWorkbenchProvider(provider)
+    ? { kind: "legacyProvider", provider }
+    : null;
 }
 
 export function agentGuiWorkbenchProviderFromLaunchRequest(
@@ -156,6 +196,10 @@ export function createAgentGuiWorkbenchLaunchDescriptor(
   request: AgentGuiWorkbenchLaunchRequestInput
 ): AgentGuiWorkbenchLaunchDescriptor {
   const provider = agentGuiWorkbenchProviderFromLaunchRequest(request);
+  const dockEntryId = resolveAgentGuiWorkbenchLaunchDockEntryId({
+    provider,
+    requestedDockEntryId: request.dockEntryId
+  });
   const prefillPrompt = prefillPromptFromLaunchPayload(request.payload);
   if (prefillPrompt) {
     return {
@@ -163,11 +207,13 @@ export function createAgentGuiWorkbenchLaunchDescriptor(
         payload: prefillPrompt,
         type: agentGuiWorkbenchPrefillPromptActivationType
       },
-      dockEntryId:
-        request.dockEntryId ?? agentGuiWorkbenchDockEntryId(provider),
+      dockEntryId,
       instanceId: createAgentGuiWorkbenchInstanceId({ provider }),
       provider,
-      reuseDockEntryNode: true,
+      reuseDockEntryNode: shouldReuseAgentGuiWorkbenchDockEntryNode({
+        dockEntryId,
+        launchKind: "prefill"
+      }),
       targetAgentSessionId: null
     };
   }
@@ -187,12 +233,41 @@ export function createAgentGuiWorkbenchLaunchDescriptor(
           type: agentGuiWorkbenchOpenSessionActivationType
         }
       : null,
-    dockEntryId: request.dockEntryId ?? agentGuiWorkbenchDockEntryId(provider),
+    dockEntryId,
     instanceId,
     provider,
-    reuseDockEntryNode: false,
+    reuseDockEntryNode: shouldReuseAgentGuiWorkbenchDockEntryNode({
+      dockEntryId,
+      launchKind: targetAgentSessionId ? "session" : "empty"
+    }),
     targetAgentSessionId
   };
+}
+
+export function resolveAgentGuiWorkbenchLaunchDockEntryId(input: {
+  provider: AgentGuiWorkbenchProvider;
+  requestedDockEntryId?: string | null;
+}): string {
+  const requestedIdentity = agentGuiWorkbenchDockIdentityFromIdentifier(
+    input.requestedDockEntryId
+  );
+  if (requestedIdentity?.kind === "unifiedAggregate") {
+    return agentGuiWorkbenchUnifiedDockEntryId();
+  }
+  return agentGuiWorkbenchDockEntryId(input.provider);
+}
+
+export function shouldReuseAgentGuiWorkbenchDockEntryNode(input: {
+  dockEntryId: string;
+  launchKind: "empty" | "prefill" | "session";
+}): boolean {
+  if (input.launchKind !== "prefill") {
+    return false;
+  }
+  return (
+    agentGuiWorkbenchDockIdentityFromIdentifier(input.dockEntryId)?.kind !==
+    "unifiedAggregate"
+  );
 }
 
 function encodeAgentGuiWorkbenchInstanceSegment(value: string): string {


### PR DESCRIPTION
## Summary
- add AgentGUI workbench unified dock identity and layout helper foundation
- keep legacy split dock ids compatible while preventing unified prefill cross-provider reuse
- add a pure conversation filter model for Codex and Claude Code sessions

## Checks
- pnpm --dir packages/agent/gui exec vitest run --environment jsdom workbench/launch.test.ts agent-gui/agentGuiNode/model/agentGuiConversationFilter.spec.ts
- pnpm --filter @tutti-os/agent-gui typecheck
- pnpm check:full

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for a unified agent dock alongside provider-specific docks.
  * Conversation filtering now supports selecting all conversations or filtering by provider.

* **Bug Fixes**
  * Improved launch behavior so provider selection is preserved more reliably.
  * Unified dock launches now avoid reusing the same dock node across different providers.

* **Tests**
  * Added coverage for conversation filtering and dock identity/launch behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->