### PR TITLE
fix(agent): run Codex through managed Node

### DIFF
--- a/docs/conventions/troubleshooting.md
+++ b/docs/conventions/troubleshooting.md
@@ -50,7 +50,9 @@ Use this shape for new entries:
   `codex app-server` probe is still missing. Logs may show
   `Missing optional dependency @openai/codex-darwin-arm64`, a long wait on an
   npm registry, or a later repair failure such as `ENOTEMPTY` while moving an
-  existing `@openai/codex` directory.
+  existing `@openai/codex` directory. Another form is an immediate launcher
+  failure such as `env: node: No such file or directory` after the JavaScript
+  `codex` shim has been installed.
 - Quick checks:
   Inspect the npm debug log under the install cache for
   `reify failed optional dependency`, then check whether the matching platform
@@ -63,17 +65,24 @@ Use this shape for new entries:
   when an optional dependency fetch failed, which leaves the launcher installed
   but unable to start. A registry can also be reachable but too slow for the
   platform tarball, so retrying the same source burns the install timeout before
-  mirrors are tried.
+  mirrors are tried. The launcher itself uses `#!/usr/bin/env node`, so every
+  daemon-run Codex command (`--version`, `login status`, and `app-server`) must
+  run with the Tutti-managed Node bin directory on `PATH`; fixing only the npm
+  install command leaves post-install probes broken on machines without system
+  Node.
 - Fix:
   Keep Codex installs on the Tutti-managed Node/npm runtime, install with
   optional dependencies included, and rank configured npm registries with a
   lightweight package metadata probe before attempting the install. Preserve
   `TUTTI_AGENT_NPM_REGISTRY` as an explicit single-registry pin with no mirror
-  fallback.
+  fallback. Also pass the same managed Node `PATH` through provider command
+  resolution, version checks, auth-status checks, and adapter probes.
 - Validation:
   Reproduce in a temporary prefix/cache using the Tutti-managed npm. Confirm
   `codex --version`, the platform package metadata and vendor binary, and a
-  short `codex app-server` probe before touching the user's real install.
+  short `codex app-server` probe before touching the user's real install. Include
+  a case where the visible `codex` shim uses `#!/usr/bin/env node` and the normal
+  user `PATH` does not contain `node`.
 - References:
   [npm_registry.go](../../services/tuttid/service/agentstatus/npm_registry.go)
   [installer_codex_cli.go](../../services/tuttid/service/agentstatus/installer_codex_cli.go)

--- a/services/tuttid/service/agentstatus/installer.go
+++ b/services/tuttid/service/agentstatus/installer.go
@@ -347,7 +347,7 @@ func (s Service) providerCLIRequiresInstall(spec ProviderSpec, runtime providerR
 	if !s.codexPlatformBinaryOK(runtime.CLIPath) {
 		return true
 	}
-	return !codexVersionMeetsMinimum(s.cliVersion(context.Background(), runtime.CLIPath))
+	return !codexVersionMeetsMinimum(s.cliVersion(context.Background(), runtime.CLIPath, runtime.Env))
 }
 
 func adapterPackageRequirementSatisfied(requirement AdapterPackageRequirement, version string) bool {
@@ -391,7 +391,7 @@ func (s Service) executeInstaller(
 	case InstallerKindShellCommand:
 		result, err := s.installCommand(installCtx, InstallCommandInput{
 			Command:  spec.ShellCommand,
-			Env:      s.commandResolver().Env(nil),
+			Env:      s.shellCommandInstallerEnv(installCtx, spec),
 			OnStdout: activeActionStdoutAppender(ctx, provider),
 		})
 		if err == nil && result.ExitCode == 0 {
@@ -438,6 +438,23 @@ func (s Service) executeInstaller(
 	default:
 		return command, InstallCommandResult{ExitCode: 1, Stderr: fmt.Sprintf("unsupported installer kind %q", spec.Kind)}, nil
 	}
+}
+
+func (s Service) shellCommandInstallerEnv(ctx context.Context, spec InstallerSpec) []string {
+	resolver := s.commandResolver()
+	if !shellCommandUsesNPM(spec.ShellCommand) {
+		return resolver.Env(nil)
+	}
+	appRuntime, ok := s.resolveManagedNodeRuntimeForProvider(ctx, false)
+	if !ok {
+		return resolver.Env(nil)
+	}
+	return resolver.Env(appRuntime.EnvOverrides)
+}
+
+func shellCommandUsesNPM(command string) bool {
+	fields := strings.Fields(command)
+	return len(fields) > 0 && fields[0] == npmBinaryName()
 }
 
 func installerLockCommand(spec InstallerSpec) string {

--- a/services/tuttid/service/agentstatus/installer_codex_cli.go
+++ b/services/tuttid/service/agentstatus/installer_codex_cli.go
@@ -125,23 +125,36 @@ func (s Service) resolveCodexInstallerNodeRuntime(
 	ctx context.Context,
 	resolver runtimecmd.Resolver,
 ) (string, string, []string, error) {
-	if npmPath := strings.TrimSpace(resolveBinaryWithResolver(resolver, []string{npmBinaryName()}, nil)); npmPath != "" {
-		nodeTarget := firstNonBlank(resolveBinaryWithResolver(resolver, []string{nodeBinaryName()}, nil), nodeBinaryName())
-		return npmPath, nodeTarget, resolver.Env(nil), nil
-	}
 	appRuntime, err := s.resolveCodexManagedNodeRuntime(ctx)
 	if err != nil {
-		return "", "", nil, fmt.Errorf("npm was not found on PATH and Tutti managed Node runtime is unavailable: %w", err)
+		if npmPath := strings.TrimSpace(resolveBinaryWithResolver(resolver, []string{npmBinaryName()}, nil)); npmPath != "" {
+			nodeTarget := firstNonBlank(resolveBinaryWithResolver(resolver, []string{nodeBinaryName()}, nil), nodeBinaryName())
+			return npmPath, nodeTarget, resolver.Env(nil), nil
+		}
+		return "", "", nil, fmt.Errorf("Tutti managed Node runtime is unavailable and npm was not found on PATH: %w", err)
 	}
 	npmPath := strings.TrimSpace(appRuntime.NPM)
 	if npmPath == "" {
-		return "", "", nil, fmt.Errorf("npm was not found on PATH and Tutti managed Node runtime did not provide npm")
+		if fallbackNPM := strings.TrimSpace(resolveBinaryWithResolver(resolver, []string{npmBinaryName()}, nil)); fallbackNPM != "" {
+			nodeTarget := firstNonBlank(resolveBinaryWithResolver(resolver, []string{nodeBinaryName()}, nil), nodeBinaryName())
+			return fallbackNPM, nodeTarget, resolver.Env(nil), nil
+		}
+		return "", "", nil, fmt.Errorf("Tutti managed Node runtime did not provide npm and npm was not found on PATH")
 	}
 	return npmPath, firstNonBlank(appRuntime.Node, nodeBinaryName()), managedruntime.ProcessEnv(appRuntime.EnvOverrides...), nil
 }
 
 func (s Service) resolveCodexManagedNodeRuntime(ctx context.Context) (managedruntime.ResolvedRuntime, error) {
 	resolver := s.managedRuntimeResolver()
+	if managed, ok := resolver.(managedruntime.DefaultResolver); ok {
+		root := strings.TrimSpace(managed.RuntimeRoot)
+		if root == "" {
+			root = managed.DefaultRoot()
+		}
+		if runtime, ok := resolvedExistingManagedNodeRuntime(root, s.Environ); ok {
+			return runtime, nil
+		}
+	}
 	if profileResolver, ok := resolver.(managedruntime.ProfileResolver); ok {
 		return profileResolver.ResolveProfile(ctx, managedruntime.NodeStaticProfile)
 	}

--- a/services/tuttid/service/agentstatus/npm_registry_test.go
+++ b/services/tuttid/service/agentstatus/npm_registry_test.go
@@ -5,10 +5,13 @@ import (
 	"errors"
 	"io"
 	"net/http"
+	"os"
 	"path/filepath"
 	"slices"
 	"strings"
 	"testing"
+
+	managedruntime "github.com/tutti-os/tutti/services/tuttid/service/managedruntime"
 )
 
 func TestAgentNPMRegistriesDefaultsToOfficialFirstThenMirrors(t *testing.T) {
@@ -223,6 +226,24 @@ func TestRunCodexCLILatestInstallerPinsDedicatedCache(t *testing.T) {
 	}
 	if gotCache == "" || filepath.Base(gotCache) != agentNPMCacheDirName {
 		t.Fatalf("npm_config_cache = %q, want a dedicated cache dir (must not depend on global ~/.npm)", gotCache)
+	}
+}
+
+func TestShellCommandNPMInstallerEnvPrefersManagedRuntime(t *testing.T) {
+	runtimeRoot := fakeManagedRuntimeRoot(t)
+	managedNodeBin := filepath.Join(runtimeRoot, "node", "bin")
+	service := Service{
+		ManagedRuntime: fakeManagedRuntimeResolver(t, runtimeRoot),
+		Environ:        func() []string { return []string{"PATH=/usr/bin:/bin"} },
+	}
+
+	env := service.shellCommandInstallerEnv(context.Background(), InstallerSpec{
+		Kind:         InstallerKindShellCommand,
+		ShellCommand: "npm install -g openclaw",
+	})
+	path := managedruntime.EnvValue(env, "PATH")
+	if !strings.HasPrefix(path, managedNodeBin+string(os.PathListSeparator)) {
+		t.Fatalf("PATH = %q, want managed node bin first", path)
 	}
 }
 

--- a/services/tuttid/service/agentstatus/provider_resolution.go
+++ b/services/tuttid/service/agentstatus/provider_resolution.go
@@ -10,6 +10,7 @@ import (
 	"runtime"
 	"strings"
 
+	"github.com/tutti-os/tutti/services/tuttid/biz/agentprovider"
 	externalagentregistry "github.com/tutti-os/tutti/services/tuttid/service/externalagentregistry"
 	managedruntime "github.com/tutti-os/tutti/services/tuttid/service/managedruntime"
 )
@@ -59,7 +60,7 @@ func (s Service) ResolveProviderCommand(ctx context.Context, provider string) (P
 
 func (s Service) resolveProviderSpec(ctx context.Context, spec ProviderSpec, requireManagedRuntime bool) (ProviderSpec, error) {
 	if strings.TrimSpace(spec.ExternalRegistryID) == "" {
-		return spec, nil
+		return s.resolveStaticProviderSpec(ctx, spec, requireManagedRuntime), nil
 	}
 	agent, err := s.externalAgentRegistry().Agent(ctx, spec.ExternalRegistryID)
 	if err != nil {
@@ -74,6 +75,21 @@ func (s Service) resolveProviderSpec(ctx context.Context, spec ProviderSpec, req
 	}
 	spec.AdapterUnavailableReasonCode = "external_agent_registry_distribution_unavailable"
 	return spec, nil
+}
+
+func (s Service) resolveStaticProviderSpec(ctx context.Context, spec ProviderSpec, requireManagedRuntime bool) ProviderSpec {
+	if spec.Provider != agentprovider.Codex {
+		return spec
+	}
+	appRuntime, ok := s.resolveManagedNodeRuntimeForProvider(ctx, requireManagedRuntime)
+	if !ok {
+		if requireManagedRuntime {
+			spec.AdapterUnavailableReasonCode = ReasonManagedRuntimeUnavailable
+		}
+		return spec
+	}
+	spec.AdapterEnv = append(s.managedRuntimeAdapterEnv(appRuntime), spec.AdapterEnv...)
+	return spec
 }
 
 func (s Service) resolveExternalRegistryNPMSpec(
@@ -134,7 +150,7 @@ func (s Service) resolveExternalRegistryNPMSpec(
 	}
 	command = append(command, distribution.Args...)
 	spec.AdapterCommand = command
-	spec.AdapterEnv = append(appRuntime.EnvOverrides, envMapToList(distribution.Env)...)
+	spec.AdapterEnv = append(s.managedRuntimeAdapterEnv(appRuntime), envMapToList(distribution.Env)...)
 	// Seed the registry for the `npm exec` fallback. Callers that actually execute
 	// this fallback re-rank providers first, because this single-shot path can't
 	// retry a chain.
@@ -191,6 +207,78 @@ func (s Service) resolveExternalRegistryBinarySpec(spec ProviderSpec, agent exte
 	spec.AdapterCommand = command
 	spec.AdapterEnv = envMapToList(target.Env)
 	return spec
+}
+
+func (s Service) managedRuntimeAdapterEnv(appRuntime managedruntime.ResolvedRuntime) []string {
+	env := make([]string, 0, len(appRuntime.EnvOverrides)+1)
+	for _, override := range appRuntime.EnvOverrides {
+		key, _, ok := strings.Cut(override, "=")
+		if ok && strings.EqualFold(key, "PATH") {
+			continue
+		}
+		env = append(env, override)
+	}
+	basePath := managedruntime.EnvValue(s.commandResolver().Env(nil), "PATH")
+	pathDirs := append([]string{}, appRuntime.BinDirs...)
+	pathDirs = append(pathDirs, filepath.SplitList(basePath)...)
+	env = append(env, "PATH="+strings.Join(pathDirs, string(os.PathListSeparator)))
+	return env
+}
+
+func (s Service) resolveManagedNodeRuntimeForProvider(ctx context.Context, require bool) (managedruntime.ResolvedRuntime, bool) {
+	resolver := s.managedRuntimeResolver()
+	if managed, ok := resolver.(managedruntime.DefaultResolver); ok {
+		root := strings.TrimSpace(managed.RuntimeRoot)
+		if root == "" {
+			root = managed.DefaultRoot()
+		}
+		if runtime, ok := resolvedExistingManagedNodeRuntime(root, s.Environ); ok {
+			return runtime, true
+		}
+		if !require {
+			return managedruntime.ResolvedRuntime{}, false
+		}
+	}
+	runtime, err := s.resolveCodexManagedNodeRuntime(ctx)
+	if err != nil {
+		return managedruntime.ResolvedRuntime{}, false
+	}
+	return runtime, true
+}
+
+func resolvedExistingManagedNodeRuntime(root string, environ func() []string) (managedruntime.ResolvedRuntime, bool) {
+	root = strings.TrimSpace(root)
+	if root == "" {
+		return managedruntime.ResolvedRuntime{}, false
+	}
+	nodeBinDir := filepath.Join(root, "node", "bin")
+	nodePath := filepath.Join(nodeBinDir, nodeBinaryName())
+	npmPath := filepath.Join(nodeBinDir, npmBinaryName())
+	if !isExecutablePath(nodePath) || !isExecutablePath(npmPath) {
+		return managedruntime.ResolvedRuntime{}, false
+	}
+	baseEnv := []string(nil)
+	if environ != nil {
+		baseEnv = environ()
+	}
+	basePath := managedruntime.EnvValue(baseEnv, "PATH")
+	return managedruntime.ResolvedRuntime{
+		Root:    root,
+		Node:    nodePath,
+		NPM:     npmPath,
+		BinDirs: []string{nodeBinDir},
+		EnvOverrides: []string{
+			"TUTTI_APP_RUNTIME_ROOT=" + root,
+			"TUTTI_APP_NODE=" + nodePath,
+			"TUTTI_APP_NPM=" + npmPath,
+			"PATH=" + strings.Join(append([]string{nodeBinDir}, filepath.SplitList(basePath)...), string(os.PathListSeparator)),
+		},
+	}, true
+}
+
+func isExecutablePath(path string) bool {
+	info, err := os.Stat(path)
+	return err == nil && !info.IsDir() && info.Mode().Perm()&0o111 != 0
 }
 
 func (s Service) resolveManagedRuntimeForProvider(ctx context.Context, require bool) (managedruntime.ResolvedRuntime, bool) {

--- a/services/tuttid/service/agentstatus/service.go
+++ b/services/tuttid/service/agentstatus/service.go
@@ -561,7 +561,7 @@ func (s Service) statusForSpec(ctx context.Context, spec ProviderSpec, now time.
 	auth := s.resolveAuth(ctx, spec, installed, runtimeResolution.CLIPath)
 	cliVersion := ""
 	if installed {
-		cliVersion = s.cliVersion(ctx, runtimeResolution.CLIPath)
+		cliVersion = s.cliVersion(ctx, runtimeResolution.CLIPath, runtimeResolution.Env)
 	}
 	codexPlatformOK := true
 	if spec.Provider == agentprovider.Codex && installed {

--- a/services/tuttid/service/agentstatus/service_helpers.go
+++ b/services/tuttid/service/agentstatus/service_helpers.go
@@ -292,7 +292,7 @@ func (s Service) runAuthStatusCommand(ctx context.Context, spec ProviderSpec, bi
 	if s.RunAuthStatusCommand != nil {
 		return s.RunAuthStatusCommand(ctx, spec, binaryPath)
 	}
-	return runAuthStatusCommand(ctx, spec, binaryPath)
+	return runAuthStatusCommand(ctx, spec, binaryPath, s.commandResolver().Env(spec.AdapterEnv))
 }
 
 // cliVersionTokenPattern matches the first semver-ish token in `--version`
@@ -311,7 +311,7 @@ func parseCLIVersion(output string) string {
 // "" when the binary is absent, errors, or prints nothing version-like. Used for
 // every supported provider (not just codex) so the config panel can show the
 // installed CLI version.
-func (Service) cliVersion(ctx context.Context, binaryPath string) string {
+func (Service) cliVersion(ctx context.Context, binaryPath string, env []string) string {
 	binaryPath = strings.TrimSpace(binaryPath)
 	if binaryPath == "" {
 		return ""
@@ -321,7 +321,11 @@ func (Service) cliVersion(ctx context.Context, binaryPath string) string {
 	}
 	commandCtx, cancel := context.WithTimeout(ctx, authStatusCommandTimeout)
 	defer cancel()
-	output, err := exec.CommandContext(commandCtx, binaryPath, "--version").CombinedOutput()
+	command := exec.CommandContext(commandCtx, binaryPath, "--version")
+	if env != nil {
+		command.Env = env
+	}
+	output, err := command.CombinedOutput()
 	if err != nil {
 		return ""
 	}
@@ -443,7 +447,7 @@ func (s Service) authStatusCommandRetryDelay() time.Duration {
 	return defaultAuthStatusCommandRetryDelay
 }
 
-func runAuthStatusCommand(ctx context.Context, spec ProviderSpec, binaryPath string) (AuthInfo, bool) {
+func runAuthStatusCommand(ctx context.Context, spec ProviderSpec, binaryPath string, env []string) (AuthInfo, bool) {
 	commandCtx, cancel := context.WithTimeout(ctx, authStatusCommandTimeout)
 	defer cancel()
 	command := exec.CommandContext(commandCtx, binaryPath, spec.AuthStatusCommand...)
@@ -451,7 +455,7 @@ func runAuthStatusCommand(ctx context.Context, spec ProviderSpec, binaryPath str
 	// API through the same proxy as spawned agents (mirroring agent install &
 	// login), instead of connecting directly and hitting `403 Request not allowed`
 	// from a restricted region.
-	command.Env = runtimecmd.InjectSystemProxyEnv(os.Environ())
+	command.Env = runtimecmd.InjectSystemProxyEnv(env)
 	output, err := command.Output()
 	if err != nil {
 		if exitErr, ok := err.(*exec.ExitError); ok {

--- a/services/tuttid/service/agentstatus/service_test.go
+++ b/services/tuttid/service/agentstatus/service_test.go
@@ -368,6 +368,53 @@ func TestServiceListReportsCodexChecksVersionAndLastError(t *testing.T) {
 	assertProviderCheck(t, status.Checks, "auth", true)
 }
 
+func TestServiceListRunsCodexLauncherWithManagedNodePath(t *testing.T) {
+	home := t.TempDir()
+	binDir := filepath.Join(home, "bin")
+	pkgDir := filepath.Join(home, "lib", "node_modules", "@openai", "codex")
+	writePackageManifest(t, pkgDir, "@openai/codex", MinSupportedCodexVersion)
+	codexPath := filepath.Join(pkgDir, "bin", "codex")
+	writeExecutable(t, codexPath, "#!/usr/bin/env node\n")
+	if err := os.MkdirAll(binDir, 0o755); err != nil {
+		t.Fatalf("mkdir bin dir: %v", err)
+	}
+	if err := os.Symlink(codexPath, filepath.Join(binDir, "codex")); err != nil {
+		t.Fatalf("symlink codex: %v", err)
+	}
+	platformPath, ok := codexPlatformBinaryPath(pkgDir, runtime.GOOS, runtime.GOARCH)
+	if !ok {
+		t.Skipf("codex platform package unavailable for %s/%s", runtime.GOOS, runtime.GOARCH)
+	}
+	writeExecutable(t, platformPath, "#!/bin/sh\nexit 0\n")
+
+	runtimeRoot := fakeManagedRuntimeRoot(t)
+	managedNode := filepath.Join(runtimeRoot, "node", "bin", nodeBinaryNameForTest())
+	writeExecutable(t, managedNode, "#!/bin/sh\nif [ \"$2\" = \"--version\" ]; then echo 'codex "+MinSupportedCodexVersion+"'; exit 0; fi\nexit 0\n")
+
+	service := probeTestService(home)
+	service.Environ = func() []string {
+		return []string{"PATH=" + binDir}
+	}
+	service.IsExecutableFile = isTestExecutable
+	service.ManagedRuntime = fakeManagedRuntimeResolver(t, runtimeRoot)
+	service.RunAuthStatusCommand = func(context.Context, ProviderSpec, string) (AuthInfo, bool) {
+		return AuthInfo{Status: AuthAuthenticated}, true
+	}
+
+	snapshot, err := service.List(context.Background(), ListInput{Providers: []string{"codex"}})
+	if err != nil {
+		t.Fatalf("List() error = %v", err)
+	}
+
+	status := onlyStatus(t, snapshot)
+	if status.Availability.Status != AvailabilityReady {
+		t.Fatalf("Availability.Status = %q, want ready; reason=%q lastError=%#v", status.Availability.Status, status.Availability.ReasonCode, status.LastError)
+	}
+	if status.CLI.Version != MinSupportedCodexVersion {
+		t.Fatalf("CLI.Version = %q, want %q", status.CLI.Version, MinSupportedCodexVersion)
+	}
+}
+
 func TestServiceProbeReportsCodexPlatformPackageIncomplete(t *testing.T) {
 	home := t.TempDir()
 	binDir := filepath.Join(home, "bin")
@@ -1090,16 +1137,18 @@ func TestServiceRunActionInstallsThenProbesProvider(t *testing.T) {
 	}
 }
 
-func TestServiceRunCodexCLILatestInstallerUsesGlobalNPM(t *testing.T) {
+func TestServiceRunCodexCLILatestInstallerPrefersManagedNPM(t *testing.T) {
 	home := t.TempDir()
 	binDir := filepath.Join(home, "bin")
-	npmPath := filepath.Join(binDir, npmBinaryNameForTest())
-	writeExecutable(t, npmPath, "#!/bin/sh\nexit 0\n")
+	writeExecutable(t, filepath.Join(binDir, npmBinaryNameForTest()), "#!/bin/sh\nexit 0\n")
+	runtimeRoot := fakeManagedRuntimeRoot(t)
+	managedNPM := filepath.Join(runtimeRoot, "node", "bin", npmBinaryNameForTest())
 	service := probeTestService(home)
 	service.Environ = func() []string {
 		return []string{"PATH=" + binDir, agentNPMRegistryEnv + "=https://registry.example.test"}
 	}
 	service.IsExecutableFile = isTestExecutableUnderHome(home)
+	service.ManagedRuntime = fakeManagedRuntimeResolver(t, runtimeRoot)
 	service.RunAuthStatusCommand = func(context.Context, ProviderSpec, string) (AuthInfo, bool) {
 		return AuthInfo{Status: AuthAuthenticated}, true
 	}
@@ -1128,31 +1177,33 @@ func TestServiceRunCodexCLILatestInstallerUsesGlobalNPM(t *testing.T) {
 	if result.ExitCode != 0 {
 		t.Fatalf("ExitCode = %d, want 0; stderr=%q", result.ExitCode, result.Stderr)
 	}
-	if !strings.Contains(command.Command, npmPath) ||
+	if !strings.Contains(command.Command, managedNPM) ||
 		!strings.Contains(command.Command, "install") ||
 		!strings.Contains(command.Command, "-g") ||
 		!strings.Contains(command.Command, "@openai/codex") ||
 		!strings.Contains(command.Command, "--include=optional") ||
 		!strings.Contains(command.Command, "--prefix") {
-		t.Fatalf("Command = %q, want global npm install with optional deps pinned to a searched --prefix", command.Command)
+		t.Fatalf("Command = %q, want managed npm install with optional deps pinned to a searched --prefix", command.Command)
 	}
 	if !slices.Contains(command.Env, "npm_config_registry=https://registry.example.test") {
 		t.Fatalf("Env = %#v, want selected npm registry", command.Env)
 	}
 }
 
-func TestServiceRunCodexInstallerReportsGlobalNPMActiveAction(t *testing.T) {
+func TestServiceRunCodexInstallerReportsManagedNPMActiveAction(t *testing.T) {
 	home := t.TempDir()
 	binDir := filepath.Join(home, "bin")
-	npmPath := filepath.Join(binDir, npmBinaryNameForTest())
-	nodePath := filepath.Join(binDir, nodeBinaryNameForTest())
-	writeExecutable(t, npmPath, "#!/bin/sh\nexit 0\n")
-	writeExecutable(t, nodePath, "#!/bin/sh\nexit 0\n")
+	writeExecutable(t, filepath.Join(binDir, npmBinaryNameForTest()), "#!/bin/sh\nexit 0\n")
+	writeExecutable(t, filepath.Join(binDir, nodeBinaryNameForTest()), "#!/bin/sh\nexit 0\n")
+	runtimeRoot := fakeManagedRuntimeRoot(t)
+	managedNPM := filepath.Join(runtimeRoot, "node", "bin", npmBinaryNameForTest())
+	managedNode := filepath.Join(runtimeRoot, "node", "bin", nodeBinaryNameForTest())
 	service := probeTestService(home)
 	service.Environ = func() []string {
 		return []string{"PATH=" + binDir, agentNPMRegistryEnv + "=https://registry.example.test"}
 	}
 	service.IsExecutableFile = isTestExecutableUnderHome(home)
+	service.ManagedRuntime = fakeManagedRuntimeResolver(t, runtimeRoot)
 	service.RunAuthStatusCommand = func(context.Context, ProviderSpec, string) (AuthInfo, bool) {
 		return AuthInfo{Status: AuthAuthenticated}, true
 	}
@@ -1175,13 +1226,16 @@ func TestServiceRunCodexInstallerReportsGlobalNPMActiveAction(t *testing.T) {
 		// This callback runs on the RunAction goroutine, so it must never call
 		// t.Fatalf/t.Skipf — those Goexit only this goroutine and hang the test on
 		// <-done. Use t.Errorf and return so the test goroutine unblocks.
-		if !strings.Contains(input.Command, npmPath) ||
+		if !strings.Contains(input.Command, managedNPM) ||
 			!strings.Contains(input.Command, "install") ||
 			!strings.Contains(input.Command, "-g") ||
 			!strings.Contains(input.Command, "@openai/codex") ||
 			!strings.Contains(input.Command, "--include=optional") ||
 			!strings.Contains(input.Command, "--prefix") {
-			t.Errorf("Command = %q, want global npm install with optional deps pinned to a searched --prefix", input.Command)
+			t.Errorf("Command = %q, want managed npm install with optional deps pinned to a searched --prefix", input.Command)
+		}
+		if !slices.Contains(input.Env, "TUTTI_APP_NODE="+managedNode) {
+			t.Errorf("Env = %#v, want managed node marker", input.Env)
 		}
 		if !slices.Contains(input.Env, "npm_config_registry=https://registry.example.test") {
 			t.Errorf("Env = %#v, want selected npm registry", input.Env)
@@ -1237,8 +1291,8 @@ func TestServiceRunCodexInstallerReportsGlobalNPMActiveAction(t *testing.T) {
 	if status.ActiveAction.Registry != "https://registry.example.test" {
 		t.Fatalf("ActiveAction.Registry = %q, want registry override", status.ActiveAction.Registry)
 	}
-	if status.ActiveAction.NodeTarget != nodePath {
-		t.Fatalf("ActiveAction.NodeTarget = %q, want %q", status.ActiveAction.NodeTarget, nodePath)
+	if status.ActiveAction.NodeTarget != managedNode {
+		t.Fatalf("ActiveAction.NodeTarget = %q, want %q", status.ActiveAction.NodeTarget, managedNode)
 	}
 	if !strings.Contains(status.ActiveAction.Stdout, "fetching @openai/codex") {
 		t.Fatalf("ActiveAction.Stdout = %q, want npm stdout", status.ActiveAction.Stdout)


### PR DESCRIPTION
## Summary
- prefer Tutti-managed Node/npm for Codex CLI installs while keeping PATH npm as a fallback
- inject managed Node PATH into Codex provider command resolution, version checks, auth-status checks, and app-server probes
- apply managed Node PATH to legacy npm shell installers when a local managed runtime already exists
- document the Codex JS launcher / env node troubleshooting path

## Validation
- PATH=/Users/wwcome/.homebrew/Cellar/go@1.24/1.24.13_1/bin:$PATH go test ./services/tuttid/service/agentstatus
- PATH=/Users/wwcome/.homebrew/Cellar/go@1.24/1.24.13_1/bin:$PATH go test ./services/tuttid/...
- PATH=/Users/wwcome/.homebrew/Cellar/go@1.24/1.24.13_1/bin:$PATH go build ./services/tuttid/...
- git diff --check

## Notes
- pnpm-based check:changed / Husky hooks are blocked on this machine because the runner invokes pnpm 11.7.0 while the repo requires pnpm 10.11.0; golangci-lint is also not installed locally.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Codex install and launcher behavior on machines without system Node, preventing `env: node: No such file or directory` failures.
  * Ensured Codex commands and status checks use the managed Node runtime when available, with better fallback handling.
  * Fixed environment handling so CLI, auth, and installer probes run with the right PATH and proxy settings.

* **Documentation**
  * Updated troubleshooting guidance for Codex install issues, including new validation examples.

* **Tests**
  * Added coverage for managed Node/npm selection and Codex launcher behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->