### PR TITLE
fix(agent): include cwd in active peers

### DIFF
--- a/services/tuttid/service/cli/providers/agentcontext/active_peers.go
+++ b/services/tuttid/service/cli/providers/agentcontext/active_peers.go
@@ -2,6 +2,7 @@ package agentcontext
 
 import (
 	"context"
+	"strings"
 
 	agentservice "github.com/tutti-os/tutti/services/tuttid/service/agent"
 	cliservice "github.com/tutti-os/tutti/services/tuttid/service/cli"
@@ -13,7 +14,7 @@ func (p Provider) newActivePeersCommand() cliservice.Command {
 		ID:          appID + ".agent.active-peers",
 		Path:        []string{"agent", "active-peers"},
 		Summary:     "Show active peer agents",
-		Description: "Show logical active peer agents in the current workspace before editing files.",
+		Description: "Show logical active peer agents and their execution cwd in the current workspace before editing files.",
 		Kind:        framework.KindList,
 		Workspace:   framework.WorkspaceRequired,
 		Workspaces:  p.workspaces,
@@ -52,6 +53,7 @@ func activePeerValues(peers []agentservice.ActivePeer) []any {
 		value := map[string]any{
 			"agentSessionId": peer.Session.ID,
 			"provider":       peer.Session.Provider,
+			"cwd":            strings.TrimSpace(peer.Session.Cwd),
 			"status":         string(peer.Session.Status),
 			"title":          "",
 		}

--- a/services/tuttid/service/cli/providers/agentcontext/provider_test.go
+++ b/services/tuttid/service/cli/providers/agentcontext/provider_test.go
@@ -206,7 +206,7 @@ func (f *fakeAgentSessions) ListActivePeers(_ context.Context, workspaceID strin
 	title := "Work"
 	return agentservice.ActivePeers{
 		Agents: []agentservice.ActivePeer{{
-			Session:      agentservice.Session{ID: "SESSION-1", Provider: "codex", Status: "working", Title: &title, CreatedAt: time.Unix(1, 0)},
+			Session:      agentservice.Session{ID: "SESSION-1", Provider: "codex", Cwd: "/workspace/repo", Status: "working", Title: &title, CreatedAt: time.Unix(1, 0)},
 			SelfRelation: "unknown",
 		}},
 		SelfKnown:      false,
@@ -1585,6 +1585,9 @@ func TestActivePeersReturnsServiceProjection(t *testing.T) {
 	}
 	agents := output.Value["agents"].([]any)
 	if len(agents) != 1 || agents[0].(map[string]any)["agentSessionId"] != "SESSION-1" {
+		t.Fatalf("agents = %#v", agents)
+	}
+	if agents[0].(map[string]any)["cwd"] != "/workspace/repo" {
 		t.Fatalf("agents = %#v", agents)
 	}
 	if agents[0].(map[string]any)["selfRelation"] != "unknown" {


### PR DESCRIPTION
## Summary
- include each active peer session cwd in `tutti agent active-peers --json`
- clarify the command description so agents know the output carries execution cwd context
- cover the active-peers cwd projection in the CLI provider test

## Validation
- go test ./services/tuttid/service/cli/providers/agentcontext
- pnpm check:changed --tail-lines 80
- git diff --check
- pre-push pnpm check:full

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The active peers command now shows each peer’s workspace working directory, making it easier to identify where agents are running.
  * The command description has been expanded to clarify that it lists logical active peer agents and their current workspace location.

* **Tests**
  * Updated command coverage to verify the working directory is included in active peer output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->