### PR TITLE
fix(agent-gui): cascade opened conversation windows

### DIFF
--- a/apps/desktop/src/renderer/src/features/workspace-agent/services/workspaceAgentGuiLaunchCoordinator.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-agent/services/workspaceAgentGuiLaunchCoordinator.ts
@@ -4,6 +4,7 @@ export interface WorkspaceAgentGuiLaunchRequest {
   agentSessionId?: string;
   autoSubmit?: boolean;
   draftPrompt?: string;
+  openInNewWindow?: boolean;
   provider: DesktopAgentGUIProvider;
   userProjectPath?: string | null;
   workspaceId: string;

--- a/apps/desktop/src/renderer/src/features/workspace-workbench/services/internal/workspaceAgentGuiContribution.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/services/internal/workspaceAgentGuiContribution.ts
@@ -131,7 +131,10 @@ export function createWorkspaceAgentGuiContribution(input: {
       onCapabilitySettingsRequest: input.onCapabilitySettingsRequest,
       onLinkAction: handleLinkAction,
       onOpenAgentConversationWindow: async (request) => {
-        await requestWorkspaceAgentGuiLaunch(request);
+        await requestWorkspaceAgentGuiLaunch({
+          ...request,
+          openInNewWindow: true
+        });
       },
       onStateChange: (...args) => helpers.onStateChange(...args),
       previewMode: options?.previewMode,

--- a/apps/desktop/src/renderer/src/features/workspace-workbench/ui/WorkspaceWorkbench.source.test.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/ui/WorkspaceWorkbench.source.test.ts
@@ -9,6 +9,12 @@ const source = readFileSync(
   ),
   "utf8"
 );
+const agentGuiContributionSource = readFileSync(
+  resolve(
+    "src/renderer/src/features/workspace-workbench/services/internal/workspaceAgentGuiContribution.ts"
+  ),
+  "utf8"
+);
 
 test("WorkspaceWorkbench does not render a global agent install pending overlay", () => {
   assert.doesNotMatch(source, /WorkspaceAgentConnectingCard/);
@@ -60,5 +66,12 @@ test("WorkspaceWorkbench opens manage agents dialog from agent-manage feature re
   assert.match(
     source,
     /setAgentProviderManageFocusedProvider\(\s*isDesktopAgentGUIProvider\(request\.provider\) \? request\.provider : null\s*\)/s
+  );
+});
+
+test("agent gui rail external action opens an internal agent session window", () => {
+  assert.match(
+    agentGuiContributionSource,
+    /onOpenAgentConversationWindow:\s*async \(request\) => \{\s*await requestWorkspaceAgentGuiLaunch\(\{\s*\.\.\.request,\s*openInNewWindow: true\s*\}\);[\s\S]*?\}/
   );
 });

--- a/apps/desktop/src/renderer/src/features/workspace-workbench/ui/WorkspaceWorkbench.tsx
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/ui/WorkspaceWorkbench.tsx
@@ -327,6 +327,7 @@ function ReadyWorkspaceWorkbench({
             agentSessionId,
             autoSubmit,
             draftPrompt,
+            openInNewWindow,
             provider,
             userProjectPath
           }) => {
@@ -341,6 +342,7 @@ function ReadyWorkspaceWorkbench({
                   })
                 : createWorkspaceAgentGuiSessionLaunchRequest({
                     agentSessionId,
+                    openInNewWindow,
                     provider
                   })
             );

--- a/docs/architecture/agent-gui-node.md
+++ b/docs/architecture/agent-gui-node.md
@@ -139,6 +139,16 @@ Workbench dock or external launch
 This means an AgentGUI bug can start at several different interfaces. Do not
 assume that a visible UI symptom starts in the visible UI component.
 
+Conversation rail "open in new window" actions are internal workbench-window
+launches, not Electron `BrowserWindow` launches. The action should stay inside
+the current Tutti workspace surface: `DesktopAgentGUIWorkbenchBody` calls
+`requestWorkspaceAgentGuiLaunch`, the workspace launch handler calls
+`host.launchNode`, and AgentGUI opens the requested session through an
+`agent-gui:open-session` activation. Normal session launches may reuse an
+already-open node showing that session; the explicit new-window action must pass
+`openInNewWindow` so the descriptor creates a fresh panel-scoped AgentGUI
+instance while still activating the same durable session.
+
 ## Runtime Data Chain
 
 Durable activity state flows in one direction:

--- a/packages/agent/gui/workbench/contribution.test.ts
+++ b/packages/agent/gui/workbench/contribution.test.ts
@@ -7,6 +7,7 @@ import { agentGuiDockIconUrls } from "../dockIcons.ts";
 import {
   AGENT_GUI_WORKBENCH_NEW_CONVERSATION_EVENT,
   agentGuiWorkbenchDefaultCopy,
+  agentGuiWorkbenchNewWindowCascadeOffset,
   createAgentGuiWorkbenchContribution,
   resolveAgentGuiWorkbenchDefaultLaunchFrame,
   resolveAgentGuiWorkbenchContributionCopy
@@ -283,6 +284,109 @@ describe("agent GUI workbench contribution copy", () => {
         y: 81
       },
       framePolicy: "absolute"
+    });
+  });
+
+  it("opens requested sessions in new panel instances when explicitly requested", async () => {
+    const contribution = createTestAgentGuiWorkbenchContribution({
+      renderBody: () => null,
+      workspaceId: "workspace-1"
+    });
+    const baseRequest = {
+      layoutConstraints: {
+        minHeight: 160,
+        minWidth: 280,
+        safeArea: {
+          bottom: 79,
+          left: 0,
+          right: 0,
+          top: 52
+        },
+        surfacePadding: 0
+      },
+      reason: "host" as const,
+      surfaceSize: {
+        height: 900,
+        width: 1440
+      },
+      typeId: "agent-gui",
+      workspaceId: "workspace-1"
+    };
+
+    const existingLaunch = await contribution.onLaunchRequest?.({
+      ...baseRequest,
+      payload: {
+        agentSessionId: "session-1",
+        provider: "codex"
+      }
+    });
+    const newWindowLaunch = await contribution.onLaunchRequest?.({
+      ...baseRequest,
+      payload: {
+        agentSessionId: "session-1",
+        openInNewWindow: true,
+        provider: "codex"
+      }
+    });
+
+    expect(existingLaunch?.instanceId).toBe(
+      "agent-gui:codex:session:session-1"
+    );
+    expect(newWindowLaunch?.instanceId).toContain("agent-gui:codex:panel:");
+    expect(newWindowLaunch?.instanceId).not.toBe(existingLaunch?.instanceId);
+    expect(existingLaunch?.cascadeOffset).toBeUndefined();
+    expect(newWindowLaunch?.cascadeOffset).toEqual(
+      agentGuiWorkbenchNewWindowCascadeOffset
+    );
+    expect(newWindowLaunch?.activation).toEqual({
+      payload: {
+        agentSessionId: "session-1"
+      },
+      type: "agent-gui:open-session"
+    });
+  });
+
+  it("keeps compact new-window session launches on the cascade policy", async () => {
+    const contribution = createTestAgentGuiWorkbenchContribution({
+      renderBody: () => null,
+      workspaceId: "workspace-1"
+    });
+
+    const launchResult = await contribution.onLaunchRequest?.({
+      layoutConstraints: {
+        minHeight: 160,
+        minWidth: 280,
+        safeArea: {
+          bottom: 79,
+          left: 0,
+          right: 0,
+          top: 52
+        },
+        surfacePadding: 0
+      },
+      payload: {
+        agentSessionId: "session-1",
+        openInNewWindow: true,
+        provider: "codex"
+      },
+      reason: "host",
+      surfaceSize: {
+        height: 700,
+        width: 980
+      },
+      typeId: "agent-gui",
+      workspaceId: "workspace-1"
+    });
+
+    expect(launchResult).toMatchObject({
+      cascadeOffset: agentGuiWorkbenchNewWindowCascadeOffset,
+      defaultFrame: {
+        height: 512,
+        width: 882,
+        x: 49,
+        y: 81
+      },
+      framePolicy: "cascade-same-type-centered"
     });
   });
 

--- a/packages/agent/gui/workbench/contribution.ts
+++ b/packages/agent/gui/workbench/contribution.ts
@@ -49,6 +49,7 @@ export const agentGuiWorkbenchDefaultNodeFrame: WorkbenchFrame = {
 
 export const agentGuiWorkbenchDefaultUsableHeightRatio = 0.7;
 export const agentGuiWorkbenchCompactVisibleAreaRatio = 0.9;
+export const agentGuiWorkbenchNewWindowCascadeOffset = { x: 180, y: 88 };
 
 export const AGENT_GUI_WORKBENCH_CONVERSATION_RAIL_TOGGLE_EVENT =
   "tutti:agent-gui-workbench-conversation-rail-toggle";
@@ -340,16 +341,19 @@ export function createAgentGuiWorkbenchContribution(
         activation,
         dockEntryId,
         instanceId: descriptorInstanceId,
+        openInNewWindow,
         provider,
         reuseDockEntryNode,
+        reuseExistingSessionNode,
         targetAgentSessionId
       } = createAgentGuiWorkbenchLaunchDescriptor(request);
       // Locate an already-open node currently showing this session (its launch
       // instanceId may differ from the session-keyed one, e.g. a conversation
       // started fresh as a draft) so we focus it instead of opening a duplicate.
-      const existingInstanceId = targetAgentSessionId
-        ? nodeStateSource.findInstanceIdByAgentSessionId(targetAgentSessionId)
-        : null;
+      const existingInstanceId =
+        targetAgentSessionId && reuseExistingSessionNode
+          ? nodeStateSource.findInstanceIdByAgentSessionId(targetAgentSessionId)
+          : null;
       const instanceId = existingInstanceId ?? descriptorInstanceId;
       const title = resolveAgentGuiWorkbenchProviderLabel(provider);
       if (targetAgentSessionId) {
@@ -374,11 +378,16 @@ export function createAgentGuiWorkbenchContribution(
       });
       return {
         activation,
+        ...(openInNewWindow
+          ? { cascadeOffset: agentGuiWorkbenchNewWindowCascadeOffset }
+          : {}),
         defaultFrame,
         dockEntryId,
-        framePolicy: isAgentGuiWorkbenchCompactVisibleFrame(defaultFrame, frame)
-          ? "absolute"
-          : "cascade-same-type-centered",
+        framePolicy:
+          !openInNewWindow &&
+          isAgentGuiWorkbenchCompactVisibleFrame(defaultFrame, frame)
+            ? "absolute"
+            : "cascade-same-type-centered",
         instanceId,
         reuseDockEntryNode,
         title,

--- a/packages/agent/gui/workbench/launch.test.ts
+++ b/packages/agent/gui/workbench/launch.test.ts
@@ -117,10 +117,36 @@ describe("agent gui workbench launch contract", () => {
       },
       dockEntryId: "agent-gui",
       instanceId: "agent-gui:codex:session:session-2",
+      openInNewWindow: false,
       provider: "codex",
       reuseDockEntryNode: false,
+      reuseExistingSessionNode: true,
       targetAgentSessionId: "session-2"
     });
+  });
+
+  it("can launch an existing session into a new internal window", () => {
+    const descriptor = createAgentGuiWorkbenchLaunchDescriptor({
+      dockEntryId: "agent-gui",
+      payload: {
+        agentSessionId: "session-2",
+        openInNewWindow: true,
+        provider: "codex"
+      },
+      typeId: "agent-gui"
+    });
+
+    expect(descriptor.activation).toEqual({
+      payload: {
+        agentSessionId: "session-2"
+      },
+      type: "agent-gui:open-session"
+    });
+    expect(descriptor.instanceId).toContain("agent-gui:codex:panel:");
+    expect(descriptor.openInNewWindow).toBe(true);
+    expect(descriptor.reuseDockEntryNode).toBe(false);
+    expect(descriptor.reuseExistingSessionNode).toBe(false);
+    expect(descriptor.targetAgentSessionId).toBe("session-2");
   });
 
   it("keeps unified aggregate dock launches provider-specific at the instance layer", () => {
@@ -174,6 +200,7 @@ describe("agent gui workbench launch contract", () => {
       dockEntryId: "agent-gui",
       provider: "codex",
       reuseDockEntryNode: true,
+      reuseExistingSessionNode: true,
       targetAgentSessionId: null
     });
   });

--- a/packages/agent/gui/workbench/launch.ts
+++ b/packages/agent/gui/workbench/launch.ts
@@ -135,6 +135,7 @@ export function agentGuiWorkbenchProviderFromLaunchRequest(
 
 export function createAgentGuiWorkbenchSessionLaunchRequest(input: {
   agentSessionId?: string;
+  openInNewWindow?: boolean;
   provider: unknown;
 }) {
   const provider = normalizeAgentGuiWorkbenchProvider(input.provider);
@@ -142,6 +143,7 @@ export function createAgentGuiWorkbenchSessionLaunchRequest(input: {
     dockEntryId: agentGuiWorkbenchDockEntryId(provider),
     payload: {
       ...(input.agentSessionId ? { agentSessionId: input.agentSessionId } : {}),
+      ...(input.openInNewWindow ? { openInNewWindow: true } : {}),
       provider
     },
     reason: "host" as const,
@@ -187,8 +189,10 @@ export interface AgentGuiWorkbenchLaunchDescriptor {
     | null;
   dockEntryId: string;
   instanceId: string;
+  openInNewWindow: boolean;
   provider: AgentGuiWorkbenchProvider;
   reuseDockEntryNode: boolean;
+  reuseExistingSessionNode: boolean;
   targetAgentSessionId: string | null;
 }
 
@@ -209,18 +213,21 @@ export function createAgentGuiWorkbenchLaunchDescriptor(
       },
       dockEntryId,
       instanceId: createAgentGuiWorkbenchInstanceId({ provider }),
+      openInNewWindow: false,
       provider,
       reuseDockEntryNode: shouldReuseAgentGuiWorkbenchDockEntryNode({
         dockEntryId,
         launchKind: "prefill"
       }),
+      reuseExistingSessionNode: true,
       targetAgentSessionId: null
     };
   }
 
   const targetAgentSessionId = agentSessionIdFromLaunchPayload(request.payload);
+  const openInNewWindow = openInNewWindowFromLaunchPayload(request.payload);
   const instanceId = createAgentGuiWorkbenchInstanceId({
-    agentSessionId: targetAgentSessionId,
+    agentSessionId: openInNewWindow ? null : targetAgentSessionId,
     provider
   });
 
@@ -235,11 +242,13 @@ export function createAgentGuiWorkbenchLaunchDescriptor(
       : null,
     dockEntryId,
     instanceId,
+    openInNewWindow,
     provider,
     reuseDockEntryNode: shouldReuseAgentGuiWorkbenchDockEntryNode({
       dockEntryId,
       launchKind: targetAgentSessionId ? "session" : "empty"
     }),
+    reuseExistingSessionNode: !openInNewWindow,
     targetAgentSessionId
   };
 }
@@ -316,4 +325,11 @@ function agentSessionIdFromLaunchPayload(payload: unknown): string | null {
   return typeof agentSessionId === "string" && agentSessionId.trim()
     ? agentSessionId.trim()
     : null;
+}
+
+function openInNewWindowFromLaunchPayload(payload: unknown): boolean {
+  if (!payload || typeof payload !== "object" || Array.isArray(payload)) {
+    return false;
+  }
+  return (payload as { openInNewWindow?: unknown }).openInNewWindow === true;
 }

--- a/packages/workbench/surface/src/core/placement.test.ts
+++ b/packages/workbench/surface/src/core/placement.test.ts
@@ -348,3 +348,135 @@ test("cascades the next rect from the active node", () => {
     { x: 248, y: 168, width: 900, height: 560 }
   );
 });
+
+test("cascades the next rect with a custom offset", () => {
+  assert.deepEqual(
+    resolveWorkbenchCascadedRect({
+      cascadeOffset: { x: 180, y: 88 },
+      currentNodeStack: ["node-a"],
+      existingNodes: [
+        {
+          id: "node-a",
+          kind: "agent-gui",
+          title: "Codex",
+          frame: { x: 140, y: 48, width: 1040, height: 538 },
+          displayMode: "floating",
+          restoreFrame: null,
+          isMinimized: false,
+          data: null
+        }
+      ],
+      preferredFrame: { x: 140, y: 48, width: 1040, height: 538 },
+      surfaceSize: { width: 1440, height: 900 }
+    }),
+    { x: 320, y: 136, width: 1040, height: 538 }
+  );
+});
+
+test("chooses another cascade position when clamping would repeat an existing rect", () => {
+  const frame = resolveWorkbenchCascadedRect({
+    cascadeOffset: { x: 180, y: 88 },
+    constraints: {
+      minHeight: 160,
+      minWidth: 280,
+      safeArea: {
+        bottom: 88,
+        left: 0,
+        right: 0,
+        top: 52
+      },
+      surfacePadding: 0
+    },
+    currentNodeStack: ["node-a", "node-b", "node-c", "node-d"],
+    existingNodes: [
+      {
+        id: "node-a",
+        kind: "agent-gui",
+        title: "Codex",
+        frame: { x: 140, y: 48, width: 1040, height: 538 },
+        displayMode: "floating",
+        restoreFrame: null,
+        isMinimized: false,
+        data: null
+      },
+      {
+        id: "node-b",
+        kind: "agent-gui",
+        title: "Codex",
+        frame: { x: 320, y: 136, width: 1040, height: 538 },
+        displayMode: "floating",
+        restoreFrame: null,
+        isMinimized: false,
+        data: null
+      },
+      {
+        id: "node-c",
+        kind: "agent-gui",
+        title: "Codex",
+        frame: { x: 400, y: 224, width: 1040, height: 538 },
+        displayMode: "floating",
+        restoreFrame: null,
+        isMinimized: false,
+        data: null
+      },
+      {
+        id: "node-d",
+        kind: "agent-gui",
+        title: "Codex",
+        frame: { x: 400, y: 274, width: 1040, height: 538 },
+        displayMode: "floating",
+        restoreFrame: null,
+        isMinimized: false,
+        data: null
+      }
+    ],
+    preferredFrame: { x: 140, y: 48, width: 1040, height: 538 },
+    surfaceSize: { width: 1440, height: 900 }
+  });
+
+  assert.deepEqual(frame, { x: 0, y: 274, width: 1040, height: 538 });
+});
+
+test("chooses another cascade position when relaunching from the same active node", () => {
+  const frame = resolveWorkbenchCascadedRect({
+    cascadeOffset: { x: 180, y: 88 },
+    constraints: {
+      minHeight: 160,
+      minWidth: 280,
+      safeArea: {
+        bottom: 88,
+        left: 0,
+        right: 0,
+        top: 52
+      },
+      surfacePadding: 0
+    },
+    currentNodeStack: ["node-b", "node-a"],
+    existingNodes: [
+      {
+        id: "node-a",
+        kind: "agent-gui",
+        title: "Codex",
+        frame: { x: 140, y: 48, width: 1040, height: 538 },
+        displayMode: "floating",
+        restoreFrame: null,
+        isMinimized: false,
+        data: null
+      },
+      {
+        id: "node-b",
+        kind: "agent-gui",
+        title: "Codex",
+        frame: { x: 320, y: 136, width: 1039, height: 537 },
+        displayMode: "floating",
+        restoreFrame: null,
+        isMinimized: false,
+        data: null
+      }
+    ],
+    preferredFrame: { x: 140, y: 48, width: 1040, height: 538 },
+    surfaceSize: { width: 1440, height: 900 }
+  });
+
+  assert.deepEqual(frame, { x: 0, y: 274, width: 1040, height: 538 });
+});

--- a/packages/workbench/surface/src/core/placement.ts
+++ b/packages/workbench/surface/src/core/placement.ts
@@ -9,6 +9,18 @@ import {
 } from "./types.ts";
 
 export const WORKBENCH_WINDOW_CASCADE_OFFSET = 28;
+const WORKBENCH_WINDOW_CASCADE_FALLBACK_LIMIT = 12;
+const WORKBENCH_WINDOW_CASCADE_POSITION_TOLERANCE = 4;
+
+interface WorkbenchCascadedRectInput<TData> {
+  cascadeOffset?: { x: number; y: number };
+  constraints?: WorkbenchLayoutConstraints;
+  currentNodeStack: readonly string[];
+  existingNodes: readonly WorkbenchNode<TData>[];
+  preferredFrame: WorkbenchFrame;
+  sizeConstraints?: WorkbenchNodeSizeConstraints | null;
+  surfaceSize: WorkbenchSize;
+}
 
 export function createWorkbenchInitialRect(
   index: number,
@@ -37,14 +49,14 @@ export function createWorkbenchInitialRect(
   );
 }
 
-export function resolveWorkbenchCascadedRect<TData>(input: {
-  constraints?: WorkbenchLayoutConstraints;
-  currentNodeStack: readonly string[];
-  existingNodes: readonly WorkbenchNode<TData>[];
-  preferredFrame: WorkbenchFrame;
-  sizeConstraints?: WorkbenchNodeSizeConstraints | null;
-  surfaceSize: WorkbenchSize;
-}): WorkbenchFrame {
+export function resolveWorkbenchCascadedRect<TData>(
+  input: WorkbenchCascadedRectInput<TData>
+): WorkbenchFrame {
+  const hasCustomCascadeOffset = input.cascadeOffset !== undefined;
+  const cascadeOffset = input.cascadeOffset ?? {
+    x: WORKBENCH_WINDOW_CASCADE_OFFSET,
+    y: WORKBENCH_WINDOW_CASCADE_OFFSET
+  };
   const activeNode =
     input.existingNodes.find(
       (node) => node.id === input.currentNodeStack.at(-1)
@@ -59,17 +71,161 @@ export function resolveWorkbenchCascadedRect<TData>(input: {
     );
   }
 
+  const preferredCandidate = createWorkbenchCascadeCandidate({
+    input,
+    x: activeNode.frame.x + cascadeOffset.x,
+    y: activeNode.frame.y + cascadeOffset.y
+  });
+  if (
+    (!hasCustomCascadeOffset || input.existingNodes.length <= 1) &&
+    !workbenchCascadeCandidateMatchesExisting(preferredCandidate, input)
+  ) {
+    return preferredCandidate;
+  }
+
+  const candidateOrigins = [
+    {
+      x: activeNode.frame.x + cascadeOffset.x,
+      y: activeNode.frame.y + cascadeOffset.y
+    },
+    {
+      x: activeNode.frame.x - cascadeOffset.x,
+      y: activeNode.frame.y + cascadeOffset.y
+    },
+    {
+      x: activeNode.frame.x + cascadeOffset.x,
+      y: activeNode.frame.y - cascadeOffset.y
+    },
+    {
+      x: activeNode.frame.x - cascadeOffset.x,
+      y: activeNode.frame.y - cascadeOffset.y
+    }
+  ];
+
+  for (
+    let index = 1;
+    index <= WORKBENCH_WINDOW_CASCADE_FALLBACK_LIMIT;
+    index += 1
+  ) {
+    candidateOrigins.push(
+      {
+        x: input.preferredFrame.x + cascadeOffset.x * index,
+        y: input.preferredFrame.y + cascadeOffset.y * index
+      },
+      {
+        x: input.preferredFrame.x - cascadeOffset.x * index,
+        y: input.preferredFrame.y + cascadeOffset.y * index
+      },
+      {
+        x: input.preferredFrame.x + cascadeOffset.x * index,
+        y: input.preferredFrame.y - cascadeOffset.y * index
+      },
+      {
+        x: input.preferredFrame.x - cascadeOffset.x * index,
+        y: input.preferredFrame.y - cascadeOffset.y * index
+      }
+    );
+  }
+
+  return resolveBestWorkbenchCascadeCandidate({
+    candidateOrigins,
+    fallbackFrame: preferredCandidate,
+    input
+  });
+}
+
+function createWorkbenchCascadeCandidate<TData>(input: {
+  input: WorkbenchCascadedRectInput<TData>;
+  x: number;
+  y: number;
+}): WorkbenchFrame {
   return clampWorkbenchRect(
     {
-      x: activeNode.frame.x + WORKBENCH_WINDOW_CASCADE_OFFSET,
-      y: activeNode.frame.y + WORKBENCH_WINDOW_CASCADE_OFFSET,
-      width: input.preferredFrame.width,
-      height: input.preferredFrame.height
+      x: input.x,
+      y: input.y,
+      width: input.input.preferredFrame.width,
+      height: input.input.preferredFrame.height
     },
-    input.surfaceSize,
-    input.constraints,
-    input.sizeConstraints
+    input.input.surfaceSize,
+    input.input.constraints,
+    input.input.sizeConstraints
   );
+}
+
+function workbenchCascadeCandidateMatchesExisting<TData>(
+  candidate: WorkbenchFrame,
+  input: WorkbenchCascadedRectInput<TData>
+): boolean {
+  return input.existingNodes.some((node) => {
+    return (
+      Math.abs(node.frame.x - candidate.x) <=
+        WORKBENCH_WINDOW_CASCADE_POSITION_TOLERANCE &&
+      Math.abs(node.frame.y - candidate.y) <=
+        WORKBENCH_WINDOW_CASCADE_POSITION_TOLERANCE
+    );
+  });
+}
+
+function resolveBestWorkbenchCascadeCandidate<TData>(input: {
+  candidateOrigins: readonly Pick<WorkbenchFrame, "x" | "y">[];
+  fallbackFrame: WorkbenchFrame;
+  input: WorkbenchCascadedRectInput<TData>;
+}): WorkbenchFrame {
+  let bestFrame: WorkbenchFrame | null = null;
+  let bestScore = Number.POSITIVE_INFINITY;
+  const seen = new Set<string>();
+  for (const candidate of input.candidateOrigins) {
+    const frame = createWorkbenchCascadeCandidate({
+      input: input.input,
+      x: candidate.x,
+      y: candidate.y
+    });
+    const key = `${frame.x}:${frame.y}:${frame.width}:${frame.height}`;
+    if (seen.has(key)) {
+      continue;
+    }
+    seen.add(key);
+
+    const score = scoreWorkbenchCascadeCandidate(frame, input.input);
+    if (score < bestScore) {
+      bestFrame = frame;
+      bestScore = score;
+    }
+  }
+
+  return bestFrame ?? input.fallbackFrame;
+}
+
+function scoreWorkbenchCascadeCandidate<TData>(
+  candidate: WorkbenchFrame,
+  input: WorkbenchCascadedRectInput<TData>
+): number {
+  const overlapArea = input.existingNodes.reduce((total, node) => {
+    return total + workbenchFrameIntersectionArea(candidate, node.frame);
+  }, 0);
+  const positionCollisionPenalty = workbenchCascadeCandidateMatchesExisting(
+    candidate,
+    input
+  )
+    ? candidate.width * candidate.height
+    : 0;
+
+  return overlapArea + positionCollisionPenalty;
+}
+
+function workbenchFrameIntersectionArea(
+  a: WorkbenchFrame,
+  b: WorkbenchFrame
+): number {
+  const width = Math.max(
+    0,
+    Math.min(a.x + a.width, b.x + b.width) - Math.max(a.x, b.x)
+  );
+  const height = Math.max(
+    0,
+    Math.min(a.y + a.height, b.y + b.height) - Math.max(a.y, b.y)
+  );
+  return width * height;
 }
 
 export function placeWorkbenchNode<TData>(

--- a/packages/workbench/surface/src/host/session.test.ts
+++ b/packages/workbench/surface/src/host/session.test.ts
@@ -13,6 +13,7 @@ import {
 import { createWorkbenchHostSession } from "./session.ts";
 import {
   COMPACT_LAUNCH_FRAME_SCALE,
+  closedDockWindowFramesMetadataKey,
   resolveCompactWorkbenchPreferredFrame
 } from "./sessionState.ts";
 import type { WorkbenchHostNodeDefinition } from "./types.ts";
@@ -2324,6 +2325,132 @@ test("launchNode offsets later same-type-centered cascade windows by same type",
     .nodes.find((entry) => entry.id === nodeId);
   assert.notDeepEqual(node?.frame, centeredPreferredFrame);
   assert.deepEqual(node?.frame, expectedFrame);
+
+  session.dispose();
+});
+
+test("launchNode applies custom same-type cascade offsets", async () => {
+  const firstAgentFrame = { x: 140, y: 48, width: 1040, height: 538 };
+  const session = createWorkbenchHostSession({
+    nodes: [agentGuiNodeDefinition],
+    onLaunchRequest() {
+      return {
+        cascadeOffset: { x: 180, y: 88 },
+        defaultFrame: firstAgentFrame,
+        instanceId: "agent-gui:codex:panel:new",
+        framePolicy: "cascade-same-type-centered",
+        typeId: "agent-gui"
+      };
+    },
+    snapshotRepository: {
+      async load() {
+        return createWorkbenchSnapshotFromState(
+          {
+            nodeStack: ["agent-gui:agent-gui:codex:panel:existing"],
+            nodes: [
+              {
+                data: {
+                  instanceId: "agent-gui:codex:panel:existing",
+                  typeId: "agent-gui"
+                },
+                displayMode: "floating",
+                frame: firstAgentFrame,
+                id: "agent-gui:agent-gui:codex:panel:existing",
+                isMinimized: false,
+                kind: "agent-gui",
+                restoreFrame: null,
+                title: "Codex"
+              }
+            ]
+          },
+          {
+            metadata: {
+              workbenchHostInitialized: true
+            }
+          }
+        );
+      },
+      async save(_workspaceId, snapshot) {
+        return snapshot;
+      }
+    },
+    workspaceId: "workspace-1"
+  });
+
+  await session.load();
+  session.controller.commands.setSurfaceSize({ width: 1440, height: 900 });
+  const nodeId = await session.launchNode({
+    reason: "host",
+    typeId: "agent-gui"
+  });
+
+  const node = session.controller
+    .getSnapshot()
+    .nodes.find((entry) => entry.id === nodeId);
+  assert.deepEqual(node?.frame, { x: 320, y: 136, width: 1040, height: 538 });
+
+  session.dispose();
+});
+
+test("launchNode skips closed dock frames when dock entry reuse is disabled", async () => {
+  const closedDockFrame = { x: 657, y: 126, width: 884, height: 476 };
+  const preferredFrame = { x: 140, y: 48, width: 1040, height: 538 };
+  const session = createWorkbenchHostSession({
+    nodes: [agentGuiNodeDefinition],
+    onLaunchRequest() {
+      return {
+        cascadeOffset: { x: 180, y: 88 },
+        defaultFrame: preferredFrame,
+        dockEntryId: "agent-gui",
+        instanceId: "agent-gui:codex:panel:new",
+        framePolicy: "cascade-same-type-centered",
+        reuseDockEntryNode: false,
+        typeId: "agent-gui"
+      };
+    },
+    snapshotRepository: {
+      async load() {
+        return createWorkbenchSnapshotFromState(
+          {
+            nodeStack: [],
+            nodes: []
+          },
+          {
+            metadata: {
+              [closedDockWindowFramesMetadataKey]: {
+                version: 1,
+                entries: [
+                  {
+                    dockEntryId: "agent-gui",
+                    frame: closedDockFrame,
+                    typeId: "agent-gui"
+                  }
+                ]
+              },
+              workbenchHostInitialized: true
+            }
+          }
+        );
+      },
+      async save(_workspaceId, snapshot) {
+        return snapshot;
+      }
+    },
+    workspaceId: "workspace-1"
+  });
+
+  await session.load();
+  session.controller.commands.setSurfaceSize({ width: 1440, height: 900 });
+  const nodeId = await session.launchNode({
+    reason: "host",
+    typeId: "agent-gui"
+  });
+
+  const node = session.controller
+    .getSnapshot()
+    .nodes.find((entry) => entry.id === nodeId);
+  assert.notDeepEqual(node?.frame, closedDockFrame);
+  assert.deepEqual(node?.frame, { x: 200, y: 163, width: 1040, height: 538 });
 
   session.dispose();
 });

--- a/packages/workbench/surface/src/host/session.ts
+++ b/packages/workbench/surface/src/host/session.ts
@@ -1002,7 +1002,7 @@ class WorkbenchHostSessionController implements WorkbenchHostRuntimeHandle {
     result: WorkbenchHostLaunchResult
   ): WorkbenchHostLaunchResult {
     const dockEntryId = result.dockEntryId?.trim();
-    if (!dockEntryId) {
+    if (!dockEntryId || result.reuseDockEntryNode === false) {
       return result;
     }
 

--- a/packages/workbench/surface/src/host/sessionState.ts
+++ b/packages/workbench/surface/src/host/sessionState.ts
@@ -176,6 +176,7 @@ export function resolveWorkbenchLaunchedHostNodeFrame(input: {
     );
 
     return resolveWorkbenchCascadedRect({
+      cascadeOffset: input.result.cascadeOffset,
       currentNodeStack: input.currentState.nodeStack.filter((nodeId) =>
         existingSameTypeNodeIds.has(nodeId)
       ),
@@ -193,6 +194,7 @@ export function resolveWorkbenchLaunchedHostNodeFrame(input: {
   }
 
   return resolveWorkbenchCascadedRect({
+    cascadeOffset: input.result.cascadeOffset,
     currentNodeStack: input.currentState.nodeStack,
     existingNodes: input.currentState.nodes,
     preferredFrame: responsivePreferredFrame,

--- a/packages/workbench/surface/src/host/types.ts
+++ b/packages/workbench/surface/src/host/types.ts
@@ -150,6 +150,7 @@ export interface WorkbenchHostLaunchResult {
     payload?: unknown;
     type: string;
   } | null;
+  cascadeOffset?: { x: number; y: number };
   defaultFrame?: WorkbenchFrame;
   displayMode?: WorkbenchDisplayMode;
   dockEntryId?: string;


### PR DESCRIPTION
## Summary

Fixes the AgentGUI conversation rail action that opens a Codex conversation in a new Tutti internal workbench window.

- Propagates the explicit `openInNewWindow` intent from the desktop AgentGUI rail launch path.
- Opens requested sessions in fresh AgentGUI panel instances while still activating the requested session.
- Adds a custom same-type cascade offset and fallback placement so repeated new Codex windows avoid landing on the same rect.
- Prevents explicit non-reused dock launches from being forced back to a closed dock frame.
- Documents the AgentGUI new-window launch behavior boundary.

## Root Cause

The rail action was not carrying a distinct new-window intent through the launch contract. After that was fixed, the workbench host could still apply the remembered closed-dock frame for the same dock entry, forcing every newly opened AgentGUI panel back to the same position.

## Validation

Passed locally:

- `corepack pnpm --filter @tutti-os/workbench-surface test`
- `corepack pnpm --dir packages/agent/gui exec vitest run --environment jsdom workbench/launch.test.ts workbench/contribution.test.ts workbench/state.test.ts`
- `corepack pnpm --filter @tutti-os/workbench-surface typecheck`
- `corepack pnpm --filter @tutti-os/agent-gui typecheck`
- `corepack pnpm --filter @tutti-os/desktop typecheck`
- `corepack pnpm lint:ts`
- `corepack pnpm check:renderer-boundaries`
- `corepack pnpm check:electron-runtime-boundaries`
- `corepack pnpm --filter @tutti-os/desktop build`
- Electron CDP automation: repeatedly clicked the rail open-in-new-window button and verified the newly created internal Codex windows used distinct rects.

`pnpm check:full` was attempted during pre-push. It progressed through TS/Go tests, but `lint:go` failed on existing unrelated staticcheck findings in `services/tuttid/service/agentstatus/installer_codex_cli.go` (`ST1005` capitalized error strings). This PR does not touch that file.

## Recording

https://github.com/user-attachments/assets/30f0c6a6-d589-4791-ac03-710b7c00be93

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an “open in new window” option for agent conversations and session launches.
  * When requested, launches open in a fresh panel instead of reusing an existing window/node.
  * Improved window placement for new launches to better avoid overlaps using smarter cascading and offsets.
* **Bug Fixes**
  * Existing sessions and previously closed dock positions are now handled more consistently during relaunch.
  * “Open in new window” launches no longer inherit frames from existing session windows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->