### PR TITLE
feat(agent): launch sessions by agent target id

### DIFF
--- a/apps/desktop/src/renderer/src/features/workspace-agent/desktopAgentGUINodeState.test.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-agent/desktopAgentGUINodeState.test.ts
@@ -10,6 +10,7 @@ import {
   projectDesktopAgentGUIWorkbenchState,
   type DesktopAgentGUINodeState
 } from "./desktopAgentGUINodeState.ts";
+import { withDesktopAgentGUIProviderComposerDefaults } from "./ui/desktopAgentGUIWorkbenchStateHelpers.ts";
 
 test("desktop agent gui node state preserves supported providers and falls back to codex", () => {
   assert.equal(
@@ -37,6 +38,7 @@ test("desktop agent gui workbench state only preserves whitelisted data", () => 
 
   assert.deepEqual(workbenchState, {
     composerOverrides: { permissionModeId: "full-access" },
+    composerOverridesByAgentTargetId: null,
     composerOverridesByProvider: null,
     conversationRailCollapsed: true,
     conversationRailWidthPx: null,
@@ -57,6 +59,7 @@ test("desktop agent gui workbench projection preserves rail state and permission
     }),
     {
       composerOverrides: { permissionModeId: "read-only" },
+      composerOverridesByAgentTargetId: null,
       composerOverridesByProvider: null,
       conversationRailCollapsed: true,
       conversationRailWidthPx: 360,
@@ -143,6 +146,51 @@ test("desktop agent gui workbench state preserves composer overrides by provider
   });
 });
 
+test("desktop agent gui workbench state preserves composer overrides by agent target", () => {
+  const workbenchState = normalizeDesktopAgentGUIWorkbenchState({
+    composerOverridesByAgentTargetId: {
+      "local:codex": {
+        model: "gpt-5",
+        permissionModeId: "auto",
+        reasoningEffort: "high"
+      }
+    }
+  });
+
+  assert.deepEqual(workbenchState.composerOverridesByAgentTargetId, {
+    "local:codex": {
+      model: "gpt-5",
+      permissionModeId: "auto",
+      reasoningEffort: "high"
+    }
+  });
+});
+
+test("desktop agent gui composer defaults are agent target keyed", () => {
+  const state = withDesktopAgentGUIProviderComposerDefaults(
+    {
+      ...createDefaultDesktopAgentGUINodeState("codex"),
+      agentTargetId: "local:codex"
+    },
+    "codex",
+    {
+      model: "gpt-5",
+      permissionModeId: "auto",
+      reasoningEffort: "high"
+    }
+  );
+
+  assert.deepEqual(state.composerOverridesByAgentTargetId, {
+    "local:codex": {
+      model: "gpt-5",
+      permissionModeId: "auto",
+      reasoningEffort: "high"
+    }
+  });
+  assert.equal(state.composerOverridesByProvider, null);
+  assert.equal(state.composerOverrides, null);
+});
+
 test("desktop agent gui node state normalizes partial runtime data", () => {
   assert.deepEqual(
     normalizeDesktopAgentGUINodeState({
@@ -223,6 +271,7 @@ test("desktop agent gui node state source consumes instance launch state after n
     }),
     {
       composerOverrides: { permissionModeId: "full-access" },
+      composerOverridesByAgentTargetId: null,
       composerOverridesByProvider: null,
       conversationRailCollapsed: true,
       conversationRailWidthPx: 360,
@@ -253,6 +302,7 @@ test("desktop agent gui node state source consumes instance launch state after n
     }),
     {
       composerOverrides: { permissionModeId: "read-only" },
+      composerOverridesByAgentTargetId: null,
       composerOverridesByProvider: null,
       conversationRailCollapsed: false,
       conversationRailWidthPx: 420,

--- a/apps/desktop/src/renderer/src/features/workspace-agent/services/createDesktopAgentGUIWorkbenchHostInput.test.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-agent/services/createDesktopAgentGUIWorkbenchHostInput.test.ts
@@ -1519,6 +1519,7 @@ test("desktop agent GUI workbench host input wires runtime composer options thro
   assert.deepEqual(
     await hostInput.agentActivityRuntime.getComposerOptions({
       workspaceId,
+      agentTargetId: "local:codex",
       provider: "codex",
       settings: { model: "gpt-5" }
     }),
@@ -1527,7 +1528,7 @@ test("desktop agent GUI workbench host input wires runtime composer options thro
       effectiveSettings: { model: "gpt-5" }
     }
   );
-  assert.deepEqual(calls, ["getComposerOptions:workspace-1:codex"]);
+  assert.deepEqual(calls, ["getComposerOptions:workspace-1:codex:local:codex"]);
 });
 
 test("desktop agent GUI workbench host input wires runtime activation through the workspace activity service", async () => {
@@ -2050,7 +2051,7 @@ function createWorkspaceAgentActivityService(
     },
     async getComposerOptions(input) {
       calls.push(
-        `getComposerOptions:${input.workspaceId}:${input.provider ?? ""}`
+        `getComposerOptions:${input.workspaceId}:${input.provider ?? ""}:${input.agentTargetId ?? ""}`
       );
       return {
         effectiveSettings: input.settings ?? {},

--- a/apps/desktop/src/renderer/src/features/workspace-agent/services/desktopAgentActivityAdapter.test.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-agent/services/desktopAgentActivityAdapter.test.ts
@@ -624,6 +624,7 @@ test("desktop agent activity adapter sends plan mode when creating sessions", as
 
   const session = await adapter.createSession({
     agentSessionId: "22222222-2222-4222-8222-222222222222",
+    agentTargetId: "local:codex",
     cwd: "/workspace",
     initialContent: [{ type: "text", text: "hello" }],
     metadata: {
@@ -652,6 +653,7 @@ test("desktop agent activity adapter sends plan mode when creating sessions", as
       workspaceId,
       {
         agentSessionId: "22222222-2222-4222-8222-222222222222",
+        agentTargetId: "local:codex",
         cwd: "/workspace",
         initialContent: [{ type: "text", text: "hello" }],
         initialDisplayPrompt: null,

--- a/apps/desktop/src/renderer/src/features/workspace-agent/services/desktopAgentActivityAdapter.test.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-agent/services/desktopAgentActivityAdapter.test.ts
@@ -666,11 +666,6 @@ test("desktop agent activity adapter sends plan mode when creating sessions", as
         permissionModeId: "read-only",
         planMode: true,
         provider: "codex",
-        providerTargetRef: {
-          kind: "sharedAgent",
-          provider: "codex",
-          sharedAgentId: "agent-1"
-        },
         reasoningEffort: "high",
         speed: null,
         title: "Plan",

--- a/apps/desktop/src/renderer/src/features/workspace-agent/services/desktopAgentActivityAdapter.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-agent/services/desktopAgentActivityAdapter.ts
@@ -86,7 +86,7 @@ export function createDesktopAgentActivityAdapter({
             permissionModeId: input.settings.permissionModeId,
             planMode: input.settings.planMode,
             provider: "claude-code",
-            ...(input.providerTargetRef
+            ...(!input.agentTargetId && input.providerTargetRef
               ? { providerTargetRef: input.providerTargetRef }
               : {}),
             reasoningEffort: input.settings.reasoningEffort,
@@ -433,7 +433,7 @@ export function createDesktopAgentActivityAdapter({
                 planMode: input.planMode ?? null,
                 permissionModeId: input.permissionModeId ?? null,
                 provider: workspaceAgentProvider(input.provider),
-                ...(input.providerTargetRef
+                ...(!input.agentTargetId && input.providerTargetRef
                   ? { providerTargetRef: input.providerTargetRef }
                   : {}),
                 reasoningEffort: input.reasoningEffort ?? null,

--- a/apps/desktop/src/renderer/src/features/workspace-agent/services/desktopAgentActivityAdapter.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-agent/services/desktopAgentActivityAdapter.ts
@@ -42,7 +42,7 @@ export function createDesktopAgentActivityAdapter({
   tuttidClient,
   runtimeApi
 }: CreateDesktopAgentActivityAdapterInput): AgentActivityAdapter {
-  // At most one pre-warm draft per workspace. Switching plan/permission/model
+  // At most one pre-warm draft per workspace target. Switching plan/permission/model
   // updates this draft in place via the ACP protocol instead of tearing it
   // down and creating a brand new hidden session on every toggle.
   const claudeDrafts = new Map<string, ClaudeDraftSessionEntry>();
@@ -52,8 +52,8 @@ export function createDesktopAgentActivityAdapter({
       return;
     }
     entry.status = "disposed";
-    if (claudeDrafts.get(entry.workspaceId) === entry) {
-      claudeDrafts.delete(entry.workspaceId);
+    if (claudeDrafts.get(entry.cacheKey) === entry) {
+      claudeDrafts.delete(entry.cacheKey);
     }
     void entry.promise
       .then((session) =>
@@ -77,6 +77,9 @@ export function createDesktopAgentActivityAdapter({
           input.workspaceId,
           {
             agentSessionId,
+            ...(input.agentTargetId
+              ? { agentTargetId: input.agentTargetId }
+              : {}),
             cwd,
             initialContent: [],
             model: input.settings.model,
@@ -100,15 +103,16 @@ export function createDesktopAgentActivityAdapter({
       }
     ).then((session) => sessionWithClaudeDraftContext(session, draftKey));
     const entry: ClaudeDraftSessionEntry = {
+      cacheKey: claudeDraftCacheKey(input),
       cwd,
       promise,
-      providerTargetKey: providerTargetRefKey(input.providerTargetRef),
+      providerTargetKey: claudeDraftTargetKey(input),
       sessionId: agentSessionId,
       settingsKey,
       status: "starting",
       workspaceId: input.workspaceId
     };
-    claudeDrafts.set(input.workspaceId, entry);
+    claudeDrafts.set(entry.cacheKey, entry);
     void promise.then(
       (session) => {
         if (entry.status === "starting") {
@@ -118,8 +122,8 @@ export function createDesktopAgentActivityAdapter({
       },
       () => {
         entry.status = "failed";
-        if (claudeDrafts.get(input.workspaceId) === entry) {
-          claudeDrafts.delete(input.workspaceId);
+        if (claudeDrafts.get(entry.cacheKey) === entry) {
+          claudeDrafts.delete(entry.cacheKey);
         }
       }
     );
@@ -131,8 +135,8 @@ export function createDesktopAgentActivityAdapter({
   ): Promise<WorkspaceAgentSession> => {
     const cwd = input.cwd ?? null;
     const settingsKey = JSON.stringify(input.settings);
-    const providerTargetKey = providerTargetRefKey(input.providerTargetRef);
-    const existing = claudeDrafts.get(input.workspaceId);
+    const providerTargetKey = claudeDraftTargetKey(input);
+    const existing = claudeDrafts.get(claudeDraftCacheKey(input));
     if (
       existing &&
       existing.status !== "disposed" &&
@@ -175,10 +179,21 @@ export function createDesktopAgentActivityAdapter({
       );
       return updated;
     }
+    const requestedAgentSessionId = normalizeText(input.agentSessionId);
+    const existingSameRequestedSession = requestedAgentSessionId
+      ? Array.from(claudeDrafts.values()).find(
+          (entry) =>
+            entry.workspaceId === input.workspaceId &&
+            entry.sessionId === requestedAgentSessionId &&
+            entry.providerTargetKey !== providerTargetKey &&
+            !isDeadDraftStatus(entry.status)
+        )
+      : undefined;
     const shouldCreateFreshDraftSession =
-      existing &&
-      existing.providerTargetKey !== providerTargetKey &&
-      normalizeText(input.agentSessionId) === existing.sessionId;
+      (existing &&
+        existing.providerTargetKey !== providerTargetKey &&
+        requestedAgentSessionId === existing.sessionId) ||
+      existingSameRequestedSession !== undefined;
     if (existing) {
       deleteClaudeDraft(existing);
     }
@@ -205,12 +220,11 @@ export function createDesktopAgentActivityAdapter({
     ) {
       return null;
     }
-    const entry = claudeDrafts.get(input.workspaceId);
+    const entry = claudeDrafts.get(claudeDraftCacheKey(input));
     if (
       !entry ||
       entry.sessionId !== agentSessionId ||
-      entry.providerTargetKey !==
-        providerTargetRefKey(input.providerTargetRef) ||
+      entry.providerTargetKey !== claudeDraftTargetKey(input) ||
       isDeadDraftStatus(entry.status)
     ) {
       return null;
@@ -226,8 +240,8 @@ export function createDesktopAgentActivityAdapter({
       { visible: true }
     );
     entry.status = "promoted";
-    if (claudeDrafts.get(input.workspaceId) === entry) {
-      claudeDrafts.delete(input.workspaceId);
+    if (claudeDrafts.get(entry.cacheKey) === entry) {
+      claudeDrafts.delete(entry.cacheKey);
     }
     const result = await tuttidClient.sendWorkspaceAgentSessionInput(
       input.workspaceId,
@@ -370,6 +384,7 @@ export function createDesktopAgentActivityAdapter({
         ) {
           const draft = await ensureClaudeDraft({
             agentSessionId: input.agentSessionId?.trim() ?? null,
+            agentTargetId: input.agentTargetId ?? null,
             cwd: input.cwd ?? null,
             settings: normalizedClaudeDraftSettings({
               model: input.model,
@@ -405,6 +420,9 @@ export function createDesktopAgentActivityAdapter({
               input.workspaceId,
               {
                 agentSessionId,
+                ...(input.agentTargetId
+                  ? { agentTargetId: input.agentTargetId }
+                  : {}),
                 cwd: input.cwd ?? null,
                 initialContent: toTuttidPromptContentBlocks(
                   input.initialContent ?? []
@@ -665,6 +683,7 @@ interface ClaudeDraftSettings {
 
 interface ClaudeDraftInput {
   agentSessionId?: string | null;
+  agentTargetId?: string | null;
   cwd: string | null;
   providerTargetRef?: AgentActivityProviderTargetRef | null;
   settings: ClaudeDraftSettings;
@@ -673,6 +692,7 @@ interface ClaudeDraftInput {
 }
 
 interface ClaudeDraftSessionEntry {
+  cacheKey: string;
   cwd: string | null;
   providerTargetKey: string;
   settingsKey: string;
@@ -709,11 +729,31 @@ function isDeadDraftStatus(status: ClaudeDraftStatus): boolean {
 
 function claudeDraftKey(input: ClaudeDraftInput): string {
   return JSON.stringify({
+    agentTargetId: normalizeText(input.agentTargetId) ?? "",
     cwd: input.cwd ?? "",
     providerTargetRef: sortProviderTargetRefValue(input.providerTargetRef),
     settings: input.settings,
     workspaceId: input.workspaceId
   });
+}
+
+function claudeDraftCacheKey(
+  input: Pick<
+    ClaudeDraftInput,
+    "agentTargetId" | "providerTargetRef" | "workspaceId"
+  >
+): string {
+  return `${input.workspaceId}:${claudeDraftTargetKey(input)}`;
+}
+
+function claudeDraftTargetKey(
+  input: Pick<ClaudeDraftInput, "agentTargetId" | "providerTargetRef">
+): string {
+  const agentTargetId = normalizeText(input.agentTargetId);
+  if (agentTargetId) {
+    return `agentTarget:${agentTargetId}`;
+  }
+  return `providerTarget:${providerTargetRefKey(input.providerTargetRef)}`;
 }
 
 function providerTargetRefKey(
@@ -793,8 +833,9 @@ export function agentActivitySessionFromTuttidSession(
   return {
     workspaceId,
     agentSessionId: session.id,
+    ...(session.agentTargetId ? { agentTargetId: session.agentTargetId } : {}),
     provider: session.provider,
-    providerSessionId: session.id,
+    providerSessionId: session.providerSessionId ?? session.id,
     cwd: session.cwd ?? "/",
     title: session.title ?? "",
     status: session.status,

--- a/apps/desktop/src/renderer/src/features/workspace-agent/services/desktopAgentGUIOpenSessionActivation.test.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-agent/services/desktopAgentGUIOpenSessionActivation.test.ts
@@ -101,6 +101,7 @@ test("consumeDesktopAgentGUIOpenSessionActivation activates and selects the requ
   assert.deepEqual(stateChanges, [
     {
       composerOverrides: null,
+      composerOverridesByAgentTargetId: null,
       composerOverridesByProvider: null,
       conversationRailCollapsed: false,
       conversationRailWidthPx: null,

--- a/apps/desktop/src/renderer/src/features/workspace-agent/services/internal/createDesktopAgentHostAgentSessionsApi.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-agent/services/internal/createDesktopAgentHostAgentSessionsApi.ts
@@ -356,12 +356,14 @@ export function createDesktopAgentHostAgentSessionsApi({
       return toAgentHostAgentSessionFromCore(workspaceId, session);
     },
     async getComposerOptions(payload: {
+      agentTargetId?: string | null;
       cwd?: string | null;
       provider?: string;
       settings?: AgentHostAgentSessionComposerSettings | null;
     }) {
       return agentActivityService.getComposerOptions({
         workspaceId,
+        agentTargetId: payload.agentTargetId,
         cwd: payload.cwd,
         provider: payload.provider,
         settings: payload.settings

--- a/apps/desktop/src/renderer/src/features/workspace-agent/services/internal/desktopAgentHostProjection.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-agent/services/internal/desktopAgentHostProjection.ts
@@ -160,6 +160,7 @@ export function toAgentHostAgentSessionFromCore(
 ): AgentHostAgentSession {
   return {
     agentSessionId: session.agentSessionId,
+    agentTargetId: session.agentTargetId ?? null,
     createdAtUnixMs: session.createdAtUnixMs ?? 0,
     cwd: options.cwd ?? session.cwd ?? "/",
     permissionModeId: options.permissionModeId ?? undefined,
@@ -195,6 +196,7 @@ export function toAgentHostAgentSessionState(
     session.runtimeContext ?? options.defaults?.runtimeContext;
   return {
     agentSessionId,
+    agentTargetId: session.agentTargetId ?? null,
     ...(settings ? { settings } : {}),
     ...(session.permissionConfig
       ? { permissionConfig: session.permissionConfig }
@@ -202,7 +204,7 @@ export function toAgentHostAgentSessionState(
     ...(runtimeContext ? { runtimeContext } : {}),
     permissionModeId: resolveComposerPermissionMode(settings) ?? undefined,
     provider: session.provider,
-    providerSessionId: session.id,
+    providerSessionId: session.providerSessionId ?? session.id,
     resumable: session.resumable ?? false,
     status: toAgentHostAgentSessionStatus(session.status),
     ...(session.turnLifecycle ? { turnLifecycle: session.turnLifecycle } : {}),
@@ -225,6 +227,7 @@ export function agentHostWorkspaceSessionFromCore(
     options.agentSessionId?.trim() || session.agentSessionId;
   return {
     agentSessionId,
+    agentTargetId: session.agentTargetId ?? null,
     createdAtUnixMs: session.createdAtUnixMs,
     cwd: session.cwd ?? "/",
     endedAtUnixMs: session.endedAtUnixMs,

--- a/apps/desktop/src/renderer/src/features/workspace-agent/services/internal/workspaceAgentActivityService.test.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-agent/services/internal/workspaceAgentActivityService.test.ts
@@ -61,6 +61,7 @@ test("WorkspaceAgentActivityService.activateSession forwards provider target ref
 
   await service.activateSession({
     agentSessionId: "11111111-1111-4111-8111-111111111111",
+    agentTargetId: "local:codex",
     cwd: "/workspace",
     initialContent: [{ type: "text", text: "hello" }],
     mode: "new",
@@ -80,6 +81,7 @@ test("WorkspaceAgentActivityService.activateSession forwards provider target ref
     workspaceId: "ws-1",
     request: {
       agentSessionId: "11111111-1111-4111-8111-111111111111",
+      agentTargetId: "local:codex",
       cwd: "/workspace",
       initialContent: [{ type: "text", text: "hello" }],
       initialDisplayPrompt: null,
@@ -98,6 +100,75 @@ test("WorkspaceAgentActivityService.activateSession forwards provider target ref
       visible: true
     }
   });
+});
+
+test("WorkspaceAgentActivityService composer options cache is agent target keyed", async () => {
+  const composerOptionCalls: unknown[] = [];
+  const service = new WorkspaceAgentActivityService({
+    tuttidClient: {
+      getAgentProviderComposerOptions: async (
+        provider: string,
+        request: unknown
+      ) => {
+        composerOptionCalls.push({ provider, request });
+        return {
+          provider,
+          modelConfig: {
+            configurable: true,
+            options: [{ value: `model-${composerOptionCalls.length}` }]
+          },
+          runtimeContext: {}
+        };
+      }
+    } as unknown as TuttidClient,
+    runtimeApi: {
+      logTerminalDiagnostic: async () => {}
+    }
+  });
+
+  const first = await service.getComposerOptions({
+    agentTargetId: "local:codex",
+    provider: "codex",
+    workspaceId: "ws-1"
+  });
+  const second = await service.getComposerOptions({
+    agentTargetId: "shared-codex",
+    provider: "codex",
+    workspaceId: "ws-1"
+  });
+  const firstCached = await service.getComposerOptions({
+    agentTargetId: "local:codex",
+    provider: "codex",
+    workspaceId: "ws-1"
+  });
+
+  assert.equal(composerOptionCalls.length, 2);
+  assert.equal(
+    service.getSnapshot("ws-1").composerOptionsByAgentTargetId?.["local:codex"]
+      ?.models[0]?.value,
+    "model-1"
+  );
+  assert.equal(
+    service.getSnapshot("ws-1").composerOptionsByAgentTargetId?.["shared-codex"]
+      ?.models[0]?.value,
+    "model-2"
+  );
+  assert.equal(
+    service.getSnapshot("ws-1").composerOptionsByProvider?.codex,
+    undefined
+  );
+  assert.equal(
+    (first as { models?: Array<{ value: string }> }).models?.[0]?.value,
+    "model-1"
+  );
+  assert.equal(
+    (second as { models?: Array<{ value: string }> }).models?.[0]?.value,
+    "model-2"
+  );
+  assert.equal(
+    (firstCached as { models?: Array<{ value: string }> }).models?.[0]?.value,
+    "model-1"
+  );
 });
 
 test("WorkspaceAgentActivityService.importExternalSessions refreshes sessions and projects", async () => {

--- a/apps/desktop/src/renderer/src/features/workspace-agent/services/internal/workspaceAgentActivityService.test.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-agent/services/internal/workspaceAgentActivityService.test.ts
@@ -42,7 +42,7 @@ test("WorkspaceAgentActivityService.sendInput keeps activity snapshot working wh
   assert.equal(snapshotSession?.currentPhase, "working");
 });
 
-test("WorkspaceAgentActivityService.activateSession forwards provider target refs to create", async () => {
+test("WorkspaceAgentActivityService.activateSession omits provider target refs for target-backed create", async () => {
   const createCalls: unknown[] = [];
   const service = new WorkspaceAgentActivityService({
     tuttidClient: {
@@ -89,11 +89,6 @@ test("WorkspaceAgentActivityService.activateSession forwards provider target ref
       permissionModeId: null,
       planMode: null,
       provider: "codex",
-      providerTargetRef: {
-        kind: "sharedAgent",
-        provider: "codex",
-        sharedAgentId: "agent-1"
-      },
       reasoningEffort: null,
       speed: null,
       title: "Shared Codex",

--- a/apps/desktop/src/renderer/src/features/workspace-agent/services/internal/workspaceAgentActivityService.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-agent/services/internal/workspaceAgentActivityService.ts
@@ -274,7 +274,10 @@ export class WorkspaceAgentActivityService implements IWorkspaceAgentActivitySer
       workspaceId: input.workspaceId,
       fields: { agentTargetId: input.agentTargetId ?? null }
     });
-    const session = await entry.adapter.createSession(input);
+    const adapterInput = input.agentTargetId
+      ? { ...input, providerTargetRef: null }
+      : input;
+    const session = await entry.adapter.createSession(adapterInput);
     reportAgentSubmitTraceDiagnostic(this.dependencies.runtimeApi, {
       agentSessionId: session.agentSessionId,
       event: "activity_service.create.adapter_resolved",
@@ -364,7 +367,9 @@ export class WorkspaceAgentActivityService implements IWorkspaceAgentActivitySer
         planMode: input.settings?.planMode ?? null,
         permissionModeId: resolveComposerPermissionMode(input.settings),
         provider,
-        providerTargetRef: input.providerTargetRef ?? null,
+        ...(input.agentTargetId
+          ? {}
+          : { providerTargetRef: input.providerTargetRef ?? null }),
         reasoningEffort: input.settings?.reasoningEffort ?? null,
         speed: input.settings?.speed ?? null,
         title: input.title ?? null,

--- a/apps/desktop/src/renderer/src/features/workspace-agent/services/internal/workspaceAgentActivityService.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-agent/services/internal/workspaceAgentActivityService.ts
@@ -262,7 +262,8 @@ export class WorkspaceAgentActivityService implements IWorkspaceAgentActivitySer
       event: "activity_service.create.entered",
       metadata: input.metadata,
       provider: input.provider,
-      workspaceId: input.workspaceId
+      workspaceId: input.workspaceId,
+      fields: { agentTargetId: input.agentTargetId ?? null }
     });
     const entry = this.controllerEntry(input.workspaceId);
     reportAgentSubmitTraceDiagnostic(this.dependencies.runtimeApi, {
@@ -270,7 +271,8 @@ export class WorkspaceAgentActivityService implements IWorkspaceAgentActivitySer
       event: "activity_service.create.adapter_requested",
       metadata: input.metadata,
       provider: input.provider,
-      workspaceId: input.workspaceId
+      workspaceId: input.workspaceId,
+      fields: { agentTargetId: input.agentTargetId ?? null }
     });
     const session = await entry.adapter.createSession(input);
     reportAgentSubmitTraceDiagnostic(this.dependencies.runtimeApi, {
@@ -306,7 +308,7 @@ export class WorkspaceAgentActivityService implements IWorkspaceAgentActivitySer
       metadata: input.metadata,
       provider,
       workspaceId,
-      fields: { mode: input.mode }
+      fields: { agentTargetId: input.agentTargetId ?? null, mode: input.mode }
     });
     if (input.mode === "new") {
       reportAgentSubmitTraceDiagnostic(this.dependencies.runtimeApi, {
@@ -332,7 +334,10 @@ export class WorkspaceAgentActivityService implements IWorkspaceAgentActivitySer
         metadata: input.metadata,
         provider,
         workspaceId,
-        fields: { cwd: resolvedCwd?.cwd ?? null }
+        fields: {
+          agentTargetId: input.agentTargetId ?? null,
+          cwd: resolvedCwd?.cwd ?? null
+        }
       });
     }
     let session: AgentActivitySession;
@@ -344,11 +349,13 @@ export class WorkspaceAgentActivityService implements IWorkspaceAgentActivitySer
         event: "activity_service.activate.create_requested",
         metadata: input.metadata,
         provider,
-        workspaceId
+        workspaceId,
+        fields: { agentTargetId: input.agentTargetId ?? null }
       });
       session = await this.createSession({
         workspaceId,
         agentSessionId: requestedAgentSessionId,
+        ...(input.agentTargetId ? { agentTargetId: input.agentTargetId } : {}),
         cwd: resolvedCwd?.cwd ?? null,
         initialContent: input.initialContent ?? [],
         initialDisplayPrompt: input.initialDisplayPrompt ?? null,
@@ -587,6 +594,7 @@ export class WorkspaceAgentActivityService implements IWorkspaceAgentActivitySer
   }
 
   async getComposerOptions(input: {
+    agentTargetId?: string | null;
     cwd?: string | null;
     force?: boolean;
     provider?: string;
@@ -598,6 +606,7 @@ export class WorkspaceAgentActivityService implements IWorkspaceAgentActivitySer
     return this.controllerEntry(
       input.workspaceId
     ).controller.loadComposerOptions({
+      agentTargetId: input.agentTargetId,
       provider,
       cwd: input.cwd,
       force: input.force,

--- a/apps/desktop/src/renderer/src/features/workspace-agent/services/workspaceAgentActivityService.interface.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-agent/services/workspaceAgentActivityService.interface.ts
@@ -82,6 +82,7 @@ export interface IWorkspaceAgentActivityService {
     agentSessionId: string
   ): Promise<AgentActivitySession>;
   getComposerOptions(input: {
+    agentTargetId?: string | null;
     cwd?: string | null;
     force?: boolean;
     provider?: string;

--- a/apps/desktop/src/renderer/src/features/workspace-agent/ui/desktopAgentGUIWorkbenchStateHelpers.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-agent/ui/desktopAgentGUIWorkbenchStateHelpers.ts
@@ -4,17 +4,20 @@ import {
   type DesktopAgentGUIComposerOverrides,
   type DesktopAgentGUINodeState,
   type DesktopAgentGUIProvider
-} from "../desktopAgentGUINodeState";
+} from "../desktopAgentGUINodeState.ts";
 
 export function withDesktopAgentGUIProviderComposerDefaults(
   state: DesktopAgentGUINodeState,
   provider: DesktopAgentGUIProvider,
   defaults: DesktopAgentComposerDefaults | null
 ): DesktopAgentGUINodeState {
+  const agentTargetId = state.agentTargetId?.trim() || null;
   if (
     !defaults ||
     state.lastActiveAgentSessionId ||
     state.composerOverrides ||
+    (agentTargetId &&
+      state.composerOverridesByAgentTargetId?.[agentTargetId]) ||
     state.composerOverridesByProvider?.[provider]
   ) {
     return state;
@@ -27,14 +30,22 @@ export function withDesktopAgentGUIProviderComposerDefaults(
   }
 
   return normalizeDesktopAgentGUINodeState(
-    {
-      ...state,
-      composerOverrides,
-      composerOverridesByProvider: {
-        ...(state.composerOverridesByProvider ?? {}),
-        [provider]: composerOverrides
-      }
-    },
+    agentTargetId
+      ? {
+          ...state,
+          composerOverridesByAgentTargetId: {
+            ...(state.composerOverridesByAgentTargetId ?? {}),
+            [agentTargetId]: composerOverrides
+          }
+        }
+      : {
+          ...state,
+          composerOverrides,
+          composerOverridesByProvider: {
+            ...(state.composerOverridesByProvider ?? {}),
+            [provider]: composerOverrides
+          }
+        },
     provider
   );
 }

--- a/apps/desktop/src/renderer/src/features/workspace-workbench/services/internal/workspaceAgentGuiProviderTargets.test.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/services/internal/workspaceAgentGuiProviderTargets.test.ts
@@ -6,13 +6,13 @@ import { mapAgentTargetsToAgentGuiProviderTargets } from "./workspaceAgentGuiPro
 test("maps daemon Agent Targets into AgentGUI provider targets in sort order", () => {
   const targets = mapAgentTargetsToAgentGuiProviderTargets([
     createAgentTarget({
-      id: "local-claude-code",
+      id: "local:claude-code",
       name: "Claude Code",
       provider: "claude-code",
       sortOrder: 20
     }),
     createAgentTarget({
-      id: "local-codex",
+      id: "local:codex",
       name: "Codex",
       provider: "codex",
       sortOrder: 10
@@ -38,13 +38,13 @@ test("maps daemon Agent Targets into AgentGUI provider targets in sort order", (
         disabled: false,
         kind: "local_cli",
         provider: "codex",
-        targetId: "local-codex"
+        targetId: "local:codex"
       },
       {
         disabled: false,
         kind: "local_cli",
         provider: "claude-code",
-        targetId: "local-claude-code"
+        targetId: "local:claude-code"
       },
       {
         disabled: true,

--- a/apps/desktop/src/renderer/src/features/workspace-workbench/services/internal/workspaceAgentGuiProviderTargets.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/services/internal/workspaceAgentGuiProviderTargets.ts
@@ -24,6 +24,7 @@ export function mapAgentTargetsToAgentGuiProviderTargets(
     };
     return {
       targetId: target.id,
+      agentTargetId: target.id,
       provider,
       ref,
       label: target.name,

--- a/docs/architecture/agent-activity-packages.md
+++ b/docs/architecture/agent-activity-packages.md
@@ -197,12 +197,27 @@ export interface AgentActivityAdapter {
 }
 ```
 
+`AgentActivityCreateSessionInput.agentTargetId` is the preferred authority for
+new target-backed launches. Shared UI passes it through unchanged; trusted host
+or daemon code resolves it against `agent_targets`, validates enabled state and
+launch ref shape, and derives the execution `provider` from the resolved target.
+The resulting `AgentActivitySession` and session events should preserve
+`agentTargetId` when present. State patch reducers must update the session when
+an event includes `agentTargetId`, but a patch that omits the field must not
+clear an existing target id because older runtimes and historical imports are
+provider-only.
+
+Composer options are cached by `agentTargetId` when a target-backed request
+includes one. Provider-keyed composer options remain a legacy/provider-only
+cache and may be used by UI as a fallback while target-specific options load,
+but target-backed loads must not reuse or overwrite the provider cache.
+
 `AgentActivityCreateSessionInput.providerTargetRef` is an optional opaque
-host-owned reference for selecting which target under the real provider should
-launch the session. It is not authority, a credential, or an invocation plan.
-Adapters and trusted launchers must re-authenticate and resolve it before using
-any concrete provider invocation. UI packages must keep `provider` as the real
-provider identity and must not synthesize providers for shared or remote
+host-owned legacy reference for selecting which target under the real provider
+should launch the session. It is not authority, a credential, or an invocation
+plan. Adapters and trusted launchers must re-authenticate and resolve it before
+using any concrete provider invocation. UI packages must keep `provider` as the
+real provider identity and must not synthesize providers for shared or remote
 targets.
 
 The adapter decides how to connect. The controller decides when to connect,

--- a/docs/architecture/agent-activity-packages.md
+++ b/docs/architecture/agent-activity-packages.md
@@ -200,12 +200,15 @@ export interface AgentActivityAdapter {
 `AgentActivityCreateSessionInput.agentTargetId` is the preferred authority for
 new target-backed launches. Shared UI passes it through unchanged; trusted host
 or daemon code resolves it against `agent_targets`, validates enabled state and
-launch ref shape, and derives the execution `provider` from the resolved target.
-The resulting `AgentActivitySession` and session events should preserve
-`agentTargetId` when present. State patch reducers must update the session when
-an event includes `agentTargetId`, but a patch that omits the field must not
-clear an existing target id because older runtimes and historical imports are
-provider-only.
+launch ref shape, and derives the execution `provider` and runtime
+`providerTargetRef` from the resolved target. Target-backed create requests may
+omit `provider`; if both fields are present, the daemon rejects provider
+mismatches. Client-provided `providerTargetRef` is not allowed to override the
+daemon-derived runtime ref when `agentTargetId` is present. The resulting
+`AgentActivitySession` and session events should preserve `agentTargetId` when
+present. State patch reducers must update the session when an event includes
+`agentTargetId`, but a patch that omits the field must not clear an existing
+target id because older runtimes and historical imports are provider-only.
 
 Composer options are cached by `agentTargetId` when a target-backed request
 includes one. Provider-keyed composer options remain a legacy/provider-only
@@ -215,10 +218,11 @@ but target-backed loads must not reuse or overwrite the provider cache.
 `AgentActivityCreateSessionInput.providerTargetRef` is an optional opaque
 host-owned legacy reference for selecting which target under the real provider
 should launch the session. It is not authority, a credential, or an invocation
-plan. Adapters and trusted launchers must re-authenticate and resolve it before
-using any concrete provider invocation. UI packages must keep `provider` as the
-real provider identity and must not synthesize providers for shared or remote
-targets.
+plan. It remains a provider-only compatibility hint; target-backed launches use
+the daemon-derived ref shape from `agent_targets` instead. Adapters and trusted
+launchers must re-authenticate and resolve it before using any concrete
+provider invocation. UI packages must keep `provider` as the real provider
+identity and must not synthesize providers for shared or remote targets.
 
 The adapter decides how to connect. The controller decides when to connect,
 when to disconnect, and how to merge the resulting events.

--- a/docs/architecture/agent-gui-node.md
+++ b/docs/architecture/agent-gui-node.md
@@ -933,10 +933,14 @@ AgentGUI distinguishes launch authority, real provider identity, and legacy
 provider-target compatibility. `agentTargetId` is the authority for new
 session launches, workbench target selection, and AgentGUI node state. The
 daemon resolves that id against `agent_targets` and derives the execution
-provider from the trusted target `launchRef`. `provider` continues to mean the
-concrete provider family (`codex`, `claude-code`, `nexight`, and so on) and
-remains the key for display labels/icons, probes, provider status, historical
-conversation filters, telemetry, and provider execution policy.
+provider and runtime `providerTargetRef` from the trusted target `launchRef`.
+Target-backed create requests may omit `provider`; if a request supplies both
+`agentTargetId` and `provider`, the daemon rejects mismatches. Client-supplied
+`providerTargetRef` must not override the daemon-derived target ref when
+`agentTargetId` is present. `provider` continues to mean the concrete provider
+family (`codex`, `claude-code`, `nexight`, and so on) and remains the key for
+display labels/icons, probes, provider status, historical conversation filters,
+telemetry, and provider execution policy.
 
 `providerTargets` lets a host expose multiple targets under that same provider.
 AgentGUI owns only target display and passthrough:
@@ -948,15 +952,19 @@ AgentGUI owns only target display and passthrough:
 - read legacy `providerTargetId` / `providerTargetRef` from old workbench node
   state to recover the selected target
 - pass `agentTargetId` through `AgentActivityRuntime.activateSession`
-- pass `providerTargetRef` only as a legacy opaque compatibility hint
+- pass `providerTargetRef` only as a legacy opaque compatibility hint for
+  provider-only launches
 
 `providerTargetId` and `providerTargetRef` are transition fields, not daemon
 authority. AgentGUI must not interpret `ref.kind`, mint invocation-control
 tokens, resolve invocation plans, contact command gateways, or handle raw
 credentials. Host/trusted code must re-authenticate the current user and
-workspace and resolve any invocation plan before launching. A target may
-identify shared, local, remote, or other host-owned launch mechanisms, but those
-meanings stay outside AgentGUI.
+workspace and resolve any invocation plan before launching. When
+`agentTargetId` is present, the daemon maps the stored launch ref to the runtime
+target ref shape, currently `{ kind: launchRef.type, provider, targetId }`, and
+runtime session reuse must match that ref as part of the launch key. A target
+may identify shared, local, remote, or other host-owned launch mechanisms, but
+those meanings stay outside AgentGUI.
 
 When `providerTargets` is omitted or empty, AgentGUI may synthesize local
 targets from the static provider catalog for picker/display compatibility. Those

--- a/docs/architecture/agent-gui-node.md
+++ b/docs/architecture/agent-gui-node.md
@@ -676,6 +676,10 @@ User-visible rules:
 - User composer defaults are owned by desktop preferences. AgentGUI may request
   a defaults write only from the home/new composer path, through an explicit host
   callback.
+- Target-backed home/new composer defaults and draft settings must be keyed by
+  `agentTargetId` first. Provider-keyed defaults are legacy fallback only, so two
+  targets under the same provider cannot share model, permission, reasoning,
+  speed, or draft state by accident.
 - Active session settings are session state. Opening, restoring, or editing an
   active session must not promote that session's model, permission mode, or
   reasoning setting into user defaults.
@@ -925,30 +929,42 @@ activity data source:
 
 ### Provider Targets
 
-AgentGUI distinguishes real provider identity from launch targets. `provider`
-continues to mean the concrete provider family (`codex`, `claude-code`,
-`nexight`, and so on) and remains the key for composer options, settings,
-icons, probes, provider status, and adapter policy.
+AgentGUI distinguishes launch authority, real provider identity, and legacy
+provider-target compatibility. `agentTargetId` is the authority for new
+session launches, workbench target selection, and AgentGUI node state. The
+daemon resolves that id against `agent_targets` and derives the execution
+provider from the trusted target `launchRef`. `provider` continues to mean the
+concrete provider family (`codex`, `claude-code`, `nexight`, and so on) and
+remains the key for display labels/icons, probes, provider status, historical
+conversation filters, telemetry, and provider execution policy.
 
 `providerTargets` lets a host expose multiple targets under that same provider.
 AgentGUI owns only target display and passthrough:
 
 - show `target.label` for new-session surfaces
 - keep provider behavior keyed by `target.provider`
-- persist `providerTargetId` / `providerTargetRef` in workbench node state
-- pass `providerTargetRef` through `AgentActivityRuntime.activateSession`
+- persist `agentTargetId` in new workbench node state when the host target has
+  one
+- read legacy `providerTargetId` / `providerTargetRef` from old workbench node
+  state to recover the selected target
+- pass `agentTargetId` through `AgentActivityRuntime.activateSession`
+- pass `providerTargetRef` only as a legacy opaque compatibility hint
 
-`providerTargetRef` is an opaque host reference, not authority. AgentGUI must
-not interpret `ref.kind`, mint invocation-control tokens, resolve invocation
-plans, contact command gateways, or handle raw credentials. Host/trusted code
-must re-authenticate the current user and workspace and resolve any invocation
-plan before launching. A target may identify shared, local, remote, or other
-host-owned launch mechanisms, but those meanings stay outside AgentGUI.
+`providerTargetId` and `providerTargetRef` are transition fields, not daemon
+authority. AgentGUI must not interpret `ref.kind`, mint invocation-control
+tokens, resolve invocation plans, contact command gateways, or handle raw
+credentials. Host/trusted code must re-authenticate the current user and
+workspace and resolve any invocation plan before launching. A target may
+identify shared, local, remote, or other host-owned launch mechanisms, but those
+meanings stay outside AgentGUI.
 
 When `providerTargets` is omitted or empty, AgentGUI may synthesize local
 targets from the static provider catalog for picker/display compatibility. Those
 fallback targets do not change the legacy activation contract: AgentGUI does not
-persist or send their `providerTargetRef`.
+persist or send their `providerTargetRef`. For system local Codex and Claude
+Code targets, the synthesized targets may expose `local:codex` and
+`local:claude-code` as `agentTargetId`, matching the legacy local
+`providerTargetId` format so old node state can fall back without remapping.
 
 ### Conversation Projection
 

--- a/docs/specs/2026-07-01-agent-unified-dock-prd.md
+++ b/docs/specs/2026-07-01-agent-unified-dock-prd.md
@@ -129,7 +129,7 @@ Initialize two system targets during repository/workspace setup:
 
 ```json
 {
-  "id": "local-codex",
+  "id": "local:codex",
   "provider": "codex",
   "launch_ref_json": {
     "type": "local_cli",
@@ -145,7 +145,7 @@ Initialize two system targets during repository/workspace setup:
 
 ```json
 {
-  "id": "local-claude-code",
+  "id": "local:claude-code",
   "provider": "claude-code",
   "launch_ref_json": {
     "type": "local_cli",

--- a/docs/specs/2026-07-01-agent-unified-dock-rd-acceptance.md
+++ b/docs/specs/2026-07-01-agent-unified-dock-rd-acceptance.md
@@ -122,8 +122,8 @@ agent_targets (
 
 第一阶段系统 rows:
 
-- `local-codex`: provider `codex`，launch ref `{ "type": "local_cli", "provider": "codex" }`。
-- `local-claude-code`: provider `claude-code`，launch ref `{ "type": "local_cli", "provider": "claude-code" }`。
+- `local:codex`: provider `codex`，launch ref `{ "type": "local_cli", "provider": "codex" }`。
+- `local:claude-code`: provider `claude-code`，launch ref `{ "type": "local_cli", "provider": "claude-code" }`。
 
 ### Launch Ref Union
 
@@ -394,7 +394,7 @@ pnpm check:full
 
 ### Data
 
-- Fresh workspace 自动存在 `local-codex` 与 `local-claude-code` system targets。
+- Fresh workspace 自动存在 `local:codex` 与 `local:claude-code` system targets。
 - `launch_ref_json` strict decode；unknown `type`、provider mismatch、extra config blob 被拒绝或安全忽略。
 - system targets 不会被普通 user edit/delete 删除。
 

--- a/packages/agent/activity-core/src/controller.test.ts
+++ b/packages/agent/activity-core/src/controller.test.ts
@@ -909,6 +909,42 @@ test("controller preserves runtime context from inline state patches", async () 
   );
 });
 
+test("controller keeps existing agent target id when state patch omits it", async () => {
+  const controller = createAgentActivityController({
+    adapter: fakeAdapter({
+      listSessions: () =>
+        Promise.resolve({
+          sessions: [
+            createSession({
+              agentSessionId: "session-1",
+              agentTargetId: "local:codex",
+              status: "working",
+              updatedAtUnixMs: 100
+            })
+          ]
+        })
+    }),
+    workspaceId: "workspace-1"
+  });
+  await controller.load();
+
+  controller.applyActivityUpdatedEvent({
+    workspaceId: "workspace-1",
+    agentSessionId: "session-1",
+    eventType: "state_patch",
+    data: {
+      agentSessionId: "session-1",
+      occurredAtUnixMs: 200,
+      lifecycleStatus: "completed"
+    }
+  });
+
+  assert.equal(
+    controller.getSnapshot().sessions[0]?.agentTargetId,
+    "local:codex"
+  );
+});
+
 test("controller uses cached latest message version when retaining events", async () => {
   let retainedAfterVersion: number | undefined;
   const adapter = fakeAdapter({
@@ -1113,6 +1149,73 @@ test("controller caches composer options by provider and clones snapshots", asyn
     controller.getSnapshot().composerOptionsByProvider?.codex?.permissionConfig
       ?.defaultValue,
     "auto"
+  );
+});
+
+test("controller caches composer options by agent target without mutating provider cache", async () => {
+  const adapterCalls: Array<{
+    agentTargetId: string | null | undefined;
+    provider: string;
+  }> = [];
+  const controller = createAgentActivityController({
+    adapter: fakeAdapter({
+      loadComposerOptions: async (input) => {
+        adapterCalls.push({
+          agentTargetId: input.agentTargetId,
+          provider: input.provider
+        });
+        return createComposerOptions({
+          provider: input.provider,
+          models: [
+            {
+              value: input.agentTargetId
+                ? `${input.agentTargetId}-model`
+                : `${input.provider}-model`,
+              label: "Model"
+            }
+          ]
+        });
+      }
+    }),
+    workspaceId: "workspace-1"
+  });
+
+  await controller.loadComposerOptions({ provider: "codex" });
+  const targetA = await controller.loadComposerOptions({
+    provider: "codex",
+    agentTargetId: "target-a"
+  });
+  const targetB = await controller.loadComposerOptions({
+    provider: "codex",
+    agentTargetId: "target-b"
+  });
+  const targetAAgain = await controller.loadComposerOptions({
+    provider: "codex",
+    agentTargetId: "target-a"
+  });
+
+  assert.equal(adapterCalls.length, 3);
+  assert.deepEqual(adapterCalls, [
+    { agentTargetId: null, provider: "codex" },
+    { agentTargetId: "target-a", provider: "codex" },
+    { agentTargetId: "target-b", provider: "codex" }
+  ]);
+  assert.equal(targetA.models[0]?.value, "target-a-model");
+  assert.equal(targetB.models[0]?.value, "target-b-model");
+  assert.equal(targetAAgain.models[0]?.value, "target-a-model");
+  assert.equal(
+    controller.getSnapshot().composerOptionsByProvider?.codex?.models[0]?.value,
+    "codex-model"
+  );
+  assert.equal(
+    controller.getSnapshot().composerOptionsByAgentTargetId?.["target-a"]
+      ?.models[0]?.value,
+    "target-a-model"
+  );
+  assert.equal(
+    controller.getSnapshot().composerOptionsByAgentTargetId?.["target-b"]
+      ?.models[0]?.value,
+    "target-b-model"
   );
 });
 

--- a/packages/agent/activity-core/src/controller.ts
+++ b/packages/agent/activity-core/src/controller.ts
@@ -79,10 +79,14 @@ export function createAgentActivityController({
     Promise<AgentActivityComposerOptions>
   >();
   const composerOptionsLoadVersions = new Map<string, number>();
-  const composerOptionsCwdByProvider = new Map<string, string>();
+  const composerOptionsCwdByCacheKey = new Map<string, string>();
   const activeComposerOptionsLoadCwds = new Map<string, string>();
   const normalizeComposerCwd = (cwd: string | null | undefined): string =>
     (cwd ?? "").trim();
+  const composerOptionsProviderCacheKey = (provider: string): string =>
+    `provider:${provider}`;
+  const composerOptionsTargetCacheKey = (agentTargetId: string): string =>
+    `target:${agentTargetId}`;
   const autoRetainedStreamReleases = new Map<string, () => void>();
   const retainedStreams = new Map<string, RetainedSessionStream>();
   let snapshot: AgentActivitySnapshot =
@@ -146,28 +150,39 @@ export function createAgentActivityController({
       if (!provider) {
         throw new Error("Agent composer options provider is required.");
       }
+      const agentTargetId =
+        typeof input.agentTargetId === "string" && input.agentTargetId.trim()
+          ? input.agentTargetId.trim()
+          : null;
+      const primaryCacheKey = agentTargetId
+        ? composerOptionsTargetCacheKey(agentTargetId)
+        : composerOptionsProviderCacheKey(provider);
       const requestedCwd = normalizeComposerCwd(input.cwd);
       if (!input.force) {
-        const cached = snapshot.composerOptionsByProvider?.[provider];
+        const cached = agentTargetId
+          ? snapshot.composerOptionsByAgentTargetId?.[agentTargetId]
+          : snapshot.composerOptionsByProvider?.[provider];
         if (
           cached &&
-          composerOptionsCwdByProvider.get(provider) === requestedCwd
+          composerOptionsCwdByCacheKey.get(primaryCacheKey) === requestedCwd
         ) {
           return cloneAgentActivityComposerOptions(cached);
         }
       }
-      const existingLoad = activeComposerOptionsLoads.get(provider);
+      const existingLoad = activeComposerOptionsLoads.get(primaryCacheKey);
       if (
         existingLoad &&
         !input.force &&
-        activeComposerOptionsLoadCwds.get(provider) === requestedCwd
+        activeComposerOptionsLoadCwds.get(primaryCacheKey) === requestedCwd
       ) {
         return existingLoad.then(cloneAgentActivityComposerOptions);
       }
-      const loadVersion = (composerOptionsLoadVersions.get(provider) ?? 0) + 1;
-      composerOptionsLoadVersions.set(provider, loadVersion);
+      const loadVersion =
+        (composerOptionsLoadVersions.get(primaryCacheKey) ?? 0) + 1;
+      composerOptionsLoadVersions.set(primaryCacheKey, loadVersion);
       const load = adapter
         .loadComposerOptions({
+          agentTargetId,
           workspaceId,
           provider,
           cwd: input.cwd,
@@ -180,18 +195,30 @@ export function createAgentActivityController({
             provider,
             loadedAtUnixMs: options.loadedAtUnixMs || Date.now()
           });
-          if (composerOptionsLoadVersions.get(provider) !== loadVersion) {
+          if (
+            composerOptionsLoadVersions.get(primaryCacheKey) !== loadVersion
+          ) {
             return cloneAgentActivityComposerOptions(normalizedOptions);
           }
-          composerOptionsCwdByProvider.set(provider, requestedCwd);
+          composerOptionsCwdByCacheKey.set(primaryCacheKey, requestedCwd);
           updateSnapshot((current) => {
-            const currentOptions =
-              current.composerOptionsByProvider?.[provider];
+            const currentOptions = agentTargetId
+              ? current.composerOptionsByAgentTargetId?.[agentTargetId]
+              : current.composerOptionsByProvider?.[provider];
             if (
               currentOptions &&
               areComposerOptionsEqual(currentOptions, normalizedOptions)
             ) {
               return current;
+            }
+            if (agentTargetId) {
+              return {
+                ...current,
+                composerOptionsByAgentTargetId: {
+                  ...current.composerOptionsByAgentTargetId,
+                  [agentTargetId]: normalizedOptions
+                }
+              };
             }
             return {
               ...current,
@@ -204,13 +231,13 @@ export function createAgentActivityController({
           return cloneAgentActivityComposerOptions(normalizedOptions);
         })
         .finally(() => {
-          if (activeComposerOptionsLoads.get(provider) === load) {
-            activeComposerOptionsLoads.delete(provider);
-            activeComposerOptionsLoadCwds.delete(provider);
+          if (activeComposerOptionsLoads.get(primaryCacheKey) === load) {
+            activeComposerOptionsLoads.delete(primaryCacheKey);
+            activeComposerOptionsLoadCwds.delete(primaryCacheKey);
           }
         });
-      activeComposerOptionsLoads.set(provider, load);
-      activeComposerOptionsLoadCwds.set(provider, requestedCwd);
+      activeComposerOptionsLoads.set(primaryCacheKey, load);
+      activeComposerOptionsLoadCwds.set(primaryCacheKey, requestedCwd);
       return load.then(cloneAgentActivityComposerOptions);
     },
     async listSessionMessages({
@@ -452,7 +479,8 @@ export function createEmptyAgentActivitySnapshot(
     sessions: [],
     presences: [],
     sessionMessagesById: {},
-    composerOptionsByProvider: {}
+    composerOptionsByProvider: {},
+    composerOptionsByAgentTargetId: {}
   };
 }
 
@@ -463,6 +491,14 @@ export function cloneAgentActivitySnapshot(
     workspaceId: snapshot.workspaceId,
     sessions: snapshot.sessions.map(cloneAgentActivitySession),
     presences: snapshot.presences.map((presence) => ({ ...presence })),
+    composerOptionsByAgentTargetId: Object.fromEntries(
+      Object.entries(snapshot.composerOptionsByAgentTargetId ?? {}).map(
+        ([agentTargetId, options]) => [
+          agentTargetId,
+          cloneAgentActivityComposerOptions(options)
+        ]
+      )
+    ),
     composerOptionsByProvider: Object.fromEntries(
       Object.entries(snapshot.composerOptionsByProvider ?? {}).map(
         ([provider, options]) => [
@@ -1132,6 +1168,7 @@ function sessionFromEvent(
   return {
     workspaceId: stringValue(source.workspaceId) || workspaceId,
     agentSessionId,
+    agentTargetId: nullableStringValue(source.agentTargetId),
     provider: stringValue(source.provider),
     providerSessionId: nullableStringValue(source.providerSessionId),
     model: nullableStringValue(source.model),
@@ -1351,6 +1388,8 @@ function agentActivitySessionFromInlineStatePatch(input: {
     ...input.existingSession,
     workspaceId: input.patch.workspaceId ?? input.workspaceId,
     agentSessionId: input.patch.agentSessionId,
+    agentTargetId:
+      input.patch.agentTargetId ?? input.existingSession.agentTargetId,
     provider: input.patch.provider ?? input.existingSession.provider,
     providerSessionId:
       input.patch.providerSessionId ?? input.existingSession.providerSessionId,

--- a/packages/agent/activity-core/src/selectors.test.ts
+++ b/packages/agent/activity-core/src/selectors.test.ts
@@ -172,6 +172,33 @@ test("session display status follows the latest turn instead of stale session fa
   );
 });
 
+test("session display status keeps failed sessions failed while latest turn is only working", () => {
+  const snapshot = snapshotWithSessionMessages(
+    [
+      session({
+        agentSessionId: "session-1",
+        status: "error"
+      })
+    ],
+    {
+      "session-1": [
+        message({
+          messageId: "latest-user",
+          role: "user",
+          status: null,
+          turnId: "turn-1",
+          version: 1
+        })
+      ]
+    }
+  );
+
+  assert.equal(
+    selectSessionDisplayStatuses(snapshot).get("session-1"),
+    "failed"
+  );
+});
+
 test("latest message display status uses only the newest turn", () => {
   assert.equal(
     resolveLatestAgentActivityMessageDisplayStatus([

--- a/packages/agent/activity-core/src/selectors.ts
+++ b/packages/agent/activity-core/src/selectors.ts
@@ -50,11 +50,19 @@ export function selectSessionDisplayStatuses(
       return [
         session.agentSessionId,
         sessionStatus === "failed"
-          ? (latestTurnStatus ?? sessionStatus)
+          ? shouldLatestTurnStatusOverrideFailedSession(latestTurnStatus)
+            ? latestTurnStatus
+            : sessionStatus
           : sessionStatus
       ];
     })
   );
+}
+
+function shouldLatestTurnStatusOverrideFailedSession(
+  status: AgentActivityDisplayStatus | null
+): status is AgentActivityDisplayStatus {
+  return status !== null && status !== "working" && status !== "idle";
 }
 
 export function resolveLatestAgentActivityMessageDisplayStatus(

--- a/packages/agent/activity-core/src/types.ts
+++ b/packages/agent/activity-core/src/types.ts
@@ -18,6 +18,7 @@ export type AgentActivityDisplayStatus =
 export interface AgentActivitySession {
   workspaceId: string;
   agentSessionId: string;
+  agentTargetId?: string | null;
   provider: string;
   providerSessionId?: string | null;
   userId?: string;
@@ -175,6 +176,7 @@ export interface AgentActivityComposerOptions {
 }
 
 export interface AgentActivityLoadComposerOptionsInput {
+  agentTargetId?: string | null;
   workspaceId: string;
   provider: string;
   cwd?: string | null;
@@ -187,6 +189,7 @@ export interface AgentActivitySnapshot {
   sessions: AgentActivitySession[];
   presences: AgentActivityPresence[];
   sessionMessagesById: Record<string, AgentActivityMessage[]>;
+  composerOptionsByAgentTargetId?: Record<string, AgentActivityComposerOptions>;
   composerOptionsByProvider?: Record<string, AgentActivityComposerOptions>;
 }
 
@@ -206,6 +209,7 @@ export interface AgentActivityUpdatedEvent {
 
 export interface AgentActivityStatePatch {
   agentSessionId: string;
+  agentTargetId?: string;
   currentPhase?: string;
   cwd?: string;
   lastError?: string;
@@ -251,6 +255,7 @@ export interface AgentActivityProviderTargetRef {
 export interface AgentActivityCreateSessionInput {
   workspaceId: string;
   agentSessionId?: string | null;
+  agentTargetId?: string | null;
   cwd?: string | null;
   initialContent?: AgentPromptContentBlock[] | null;
   /** 仅展示用的首轮文本(bundle 折叠成一个 chip);initialContent 仍带展开后的文件。 */

--- a/packages/agent/daemon/activity/compat.go
+++ b/packages/agent/daemon/activity/compat.go
@@ -184,6 +184,7 @@ func sessionStateUpdateFromPatch(patch WorkspaceAgentStatePatch) WorkspaceAgentS
 		currentPhase = deriveCurrentPhaseFromEntityPatches(patch.Entities)
 	}
 	out := WorkspaceAgentSessionStateUpdate{
+		AgentTargetID:      strings.TrimSpace(patch.AgentTargetID),
 		Provider:           strings.TrimSpace(patch.Provider),
 		ProviderSessionID:  strings.TrimSpace(patch.ProviderSessionID),
 		Model:              strings.TrimSpace(patch.Model),

--- a/packages/agent/daemon/activity/projection/projection.go
+++ b/packages/agent/daemon/activity/projection/projection.go
@@ -6,6 +6,7 @@ type SessionSnapshot struct {
 	WorkspaceID       string
 	AgentSessionID    string
 	Origin            string
+	AgentTargetID     string
 	Provider          string
 	ProviderSessionID string
 	Model             string
@@ -29,6 +30,7 @@ type SessionStateReport struct {
 	WorkspaceID       string
 	AgentSessionID    string
 	Origin            string
+	AgentTargetID     string
 	Provider          string
 	ProviderSessionID string
 	Model             string
@@ -71,6 +73,7 @@ func ProjectSessionState(
 		WorkspaceID:       strings.TrimSpace(report.WorkspaceID),
 		AgentSessionID:    strings.TrimSpace(report.AgentSessionID),
 		Origin:            strings.TrimSpace(report.Origin),
+		AgentTargetID:     strings.TrimSpace(report.AgentTargetID),
 		Provider:          strings.TrimSpace(report.Provider),
 		ProviderSessionID: strings.TrimSpace(report.ProviderSessionID),
 		Model:             strings.TrimSpace(report.Model),
@@ -95,6 +98,9 @@ func ProjectSessionState(
 		}
 		if session.Origin == "" {
 			session.Origin = existing.Origin
+		}
+		if session.AgentTargetID == "" {
+			session.AgentTargetID = existing.AgentTargetID
 		}
 		if session.Provider == "" {
 			session.Provider = existing.Provider

--- a/packages/agent/daemon/activity/runtime_projection.go
+++ b/packages/agent/daemon/activity/runtime_projection.go
@@ -70,6 +70,7 @@ func mergeRuntimeAgentSession(
 	if shouldKeepLocalCompletedTurn(upstream, local) {
 		merged := local
 		merged.AgentSessionID = preferredMergedAgentSessionID(upstream, local)
+		merged.AgentTargetID = firstNonEmptyString(local.AgentTargetID, upstream.AgentTargetID)
 		merged.Provider = firstNonEmptyString(local.Provider, upstream.Provider)
 		merged.ProviderSessionID = firstNonEmptyString(local.ProviderSessionID, upstream.ProviderSessionID)
 		merged.SessionOrigin = firstNonEmptyString(upstream.SessionOrigin, local.SessionOrigin)
@@ -95,6 +96,7 @@ func mergeRuntimeAgentSession(
 	if shouldKeepLocalBusyState(upstream, local) {
 		merged := local
 		merged.AgentSessionID = preferredMergedAgentSessionID(upstream, local)
+		merged.AgentTargetID = firstNonEmptyString(local.AgentTargetID, upstream.AgentTargetID)
 		merged.Provider = firstNonEmptyString(local.Provider, upstream.Provider)
 		merged.ProviderSessionID = firstNonEmptyString(local.ProviderSessionID, upstream.ProviderSessionID)
 		merged.SessionOrigin = firstNonEmptyString(upstream.SessionOrigin, local.SessionOrigin)
@@ -126,6 +128,7 @@ func mergeRuntimeAgentSession(
 	}
 	merged := upstream
 	merged.AgentSessionID = preferredMergedAgentSessionID(upstream, local)
+	merged.AgentTargetID = firstNonEmptyString(local.AgentTargetID, upstream.AgentTargetID)
 	merged.Provider = firstNonEmptyString(local.Provider, upstream.Provider)
 	merged.ProviderSessionID = firstNonEmptyString(local.ProviderSessionID, upstream.ProviderSessionID)
 	merged.SessionOrigin = firstNonEmptyString(upstream.SessionOrigin, local.SessionOrigin)

--- a/packages/agent/daemon/activity/service.go
+++ b/packages/agent/daemon/activity/service.go
@@ -436,6 +436,7 @@ func (s *Store) HideAgentSession(roomID string, agentSessionID string) {
 func statePatchFromSessionState(agentSessionID string, state WorkspaceAgentSessionStateUpdate) WorkspaceAgentStatePatch {
 	patch := WorkspaceAgentStatePatch{
 		AgentSessionID:     strings.TrimSpace(agentSessionID),
+		AgentTargetID:      strings.TrimSpace(state.AgentTargetID),
 		Provider:           strings.TrimSpace(state.Provider),
 		ProviderSessionID:  strings.TrimSpace(state.ProviderSessionID),
 		Model:              strings.TrimSpace(state.Model),
@@ -716,6 +717,7 @@ func applyStatePatchLocked(entry *sessionEntry, source EventSource, patch Worksp
 		)
 		session := WorkspaceAgentSession{
 			AgentSessionID:     sessionID,
+			AgentTargetID:      firstNonEmptyString(patch.AgentTargetID, source.AgentTargetID),
 			UserID:             strings.TrimSpace(source.UserID),
 			Provider:           firstNonEmptyString(patch.Provider, source.Provider),
 			ProviderSessionID:  firstNonEmptyString(patch.ProviderSessionID, source.ProviderSessionID),
@@ -762,6 +764,7 @@ func applyStatePatchLocked(entry *sessionEntry, source EventSource, patch Worksp
 		return
 	}
 	session.AgentSessionID = firstNonEmptyString(session.AgentSessionID, sessionID)
+	session.AgentTargetID = firstNonEmptyString(patch.AgentTargetID, session.AgentTargetID, source.AgentTargetID)
 	session.Provider = firstNonEmptyString(patch.Provider, session.Provider, source.Provider)
 	session.ProviderSessionID = firstNonEmptyString(patch.ProviderSessionID, session.ProviderSessionID, source.ProviderSessionID)
 	session.SessionOrigin = firstNonEmptyString(strings.TrimSpace(source.SessionOrigin), session.SessionOrigin)
@@ -1228,6 +1231,7 @@ func (s *Store) interruptWorkspaceAgents(ctx context.Context, roomID string, _ s
 
 		patches = append(patches, WorkspaceAgentStatePatch{
 			AgentSessionID:    strings.TrimSpace(session.AgentSessionID),
+			AgentTargetID:     strings.TrimSpace(session.AgentTargetID),
 			Provider:          strings.TrimSpace(session.Provider),
 			ProviderSessionID: strings.TrimSpace(session.ProviderSessionID),
 			CWD:               strings.TrimSpace(session.CWD),

--- a/packages/agent/daemon/activity/types.go
+++ b/packages/agent/daemon/activity/types.go
@@ -94,6 +94,7 @@ func (r *ReportSessionStateReply) UnmarshalJSON(data []byte) error {
 }
 
 type WorkspaceAgentSessionStateUpdate struct {
+	AgentTargetID      string                            `json:"agentTargetId,omitempty"`
 	Provider           string                            `json:"provider,omitempty"`
 	ProviderSessionID  string                            `json:"providerSessionId,omitempty"`
 	Model              string                            `json:"model,omitempty"`
@@ -320,6 +321,7 @@ type EventSource struct {
 	Provider          string `json:"provider,omitempty"`
 	ProviderSessionID string `json:"providerSessionId,omitempty"`
 	AgentID           string `json:"agentId,omitempty"`
+	AgentTargetID     string `json:"agentTargetId,omitempty"`
 	CWD               string `json:"cwd,omitempty"`
 	SessionOrigin     string `json:"sessionOrigin,omitempty"`
 	UserID            string `json:"-"`
@@ -327,6 +329,7 @@ type EventSource struct {
 
 type WorkspaceAgentStatePatch struct {
 	AgentSessionID     string                            `json:"agentSessionId"`
+	AgentTargetID      string                            `json:"agentTargetId,omitempty"`
 	Provider           string                            `json:"provider,omitempty"`
 	ProviderSessionID  string                            `json:"providerSessionId,omitempty"`
 	Model              string                            `json:"model,omitempty"`
@@ -468,6 +471,7 @@ type WorkspaceAgentPresence struct {
 type WorkspaceAgentSession struct {
 	ID                 uint64                            `json:"id"`
 	AgentSessionID     string                            `json:"agentSessionId"`
+	AgentTargetID      string                            `json:"agentTargetId,omitempty"`
 	PresenceID         uint64                            `json:"presenceId"`
 	UserID             string                            `json:"userId"`
 	Provider           string                            `json:"provider"`
@@ -492,6 +496,7 @@ func (s WorkspaceAgentSession) MarshalJSON() ([]byte, error) {
 	type output struct {
 		ID                 uint64                            `json:"id"`
 		AgentSessionID     string                            `json:"agentSessionId"`
+		AgentTargetID      string                            `json:"agentTargetId,omitempty"`
 		PresenceID         uint64                            `json:"presenceId"`
 		UserID             string                            `json:"userId"`
 		Provider           string                            `json:"provider"`
@@ -514,6 +519,7 @@ func (s WorkspaceAgentSession) MarshalJSON() ([]byte, error) {
 	return json.Marshal(output{
 		ID:                 s.ID,
 		AgentSessionID:     s.AgentSessionID,
+		AgentTargetID:      s.AgentTargetID,
 		PresenceID:         s.PresenceID,
 		UserID:             s.UserID,
 		Provider:           s.Provider,
@@ -604,6 +610,8 @@ func (s *WorkspaceAgentSession) UnmarshalJSON(data []byte) error {
 		ID                     flexibleUint64           `json:"id"`
 		AgentSessionID         string                   `json:"agentSessionId"`
 		AgentSessionIDSnake    string                   `json:"agent_session_id"`
+		AgentTargetID          string                   `json:"agentTargetId"`
+		AgentTargetIDSnake     string                   `json:"agent_target_id"`
 		AgentID                string                   `json:"agentId"`
 		AgentIDSnake           string                   `json:"agent_id"`
 		PresenceID             flexibleUint64           `json:"presenceId"`
@@ -645,9 +653,10 @@ func (s *WorkspaceAgentSession) UnmarshalJSON(data []byte) error {
 			raw.AgentID,
 			raw.AgentIDSnake,
 		),
-		PresenceID: uint64(firstNonZeroFlexibleUint64(raw.PresenceID, raw.PresenceIDSnake)),
-		UserID:     firstNonEmptyString(raw.UserID, raw.UserIDSnake),
-		Provider:   raw.Provider,
+		AgentTargetID: firstNonEmptyString(raw.AgentTargetID, raw.AgentTargetIDSnake),
+		PresenceID:    uint64(firstNonZeroFlexibleUint64(raw.PresenceID, raw.PresenceIDSnake)),
+		UserID:        firstNonEmptyString(raw.UserID, raw.UserIDSnake),
+		Provider:      raw.Provider,
 		ProviderSessionID: firstNonEmptyString(
 			raw.ProviderSessionID,
 			raw.ProviderSessionIDSnake,

--- a/packages/agent/daemon/runtime/activity_projection.go
+++ b/packages/agent/daemon/runtime/activity_projection.go
@@ -61,6 +61,7 @@ func eventSourceFromSession(session Session) agentsessionstore.EventSource {
 		Provider:          strings.TrimSpace(session.Provider),
 		ProviderSessionID: strings.TrimSpace(session.ProviderSessionID),
 		AgentID:           strings.TrimSpace(session.AgentSessionID),
+		AgentTargetID:     strings.TrimSpace(session.AgentTargetID),
 		CWD:               strings.TrimSpace(session.CWD),
 		SessionOrigin:     agentsessionstore.WorkspaceAgentSessionOriginRuntime,
 	}

--- a/packages/agent/daemon/runtime/controller.go
+++ b/packages/agent/daemon/runtime/controller.go
@@ -2012,7 +2012,7 @@ func (c *Controller) findStartSession(
 		if strings.TrimSpace(session.CWD) != cwd {
 			continue
 		}
-		if agentTargetID == "" && !providerTargetRefsEqual(session.ProviderTargetRef, providerTargetRef) {
+		if !providerTargetRefsEqual(session.ProviderTargetRef, providerTargetRef) {
 			continue
 		}
 		if title != "" && strings.TrimSpace(session.Title) != title {

--- a/packages/agent/daemon/runtime/controller.go
+++ b/packages/agent/daemon/runtime/controller.go
@@ -181,7 +181,7 @@ func (c *Controller) Start(ctx context.Context, input StartInput) (StartResult, 
 	)
 	permissionModeID := settings.PermissionModeID
 	if agentSessionID == "" {
-		if existing, ok := c.findStartSession(roomID, provider, input.CWD, input.Title, settings, input.ProviderTargetRef); ok {
+		if existing, ok := c.findStartSession(roomID, strings.TrimSpace(input.AgentTargetID), provider, input.CWD, input.Title, settings, input.ProviderTargetRef); ok {
 			return StartResult{Session: existing}, nil
 		}
 		agentSessionID = newID()
@@ -192,6 +192,7 @@ func (c *Controller) Start(ctx context.Context, input StartInput) (StartResult, 
 	session := Session{
 		RoomID:               roomID,
 		AgentSessionID:       agentSessionID,
+		AgentTargetID:        strings.TrimSpace(input.AgentTargetID),
 		Provider:             provider,
 		ProviderSessionID:    "",
 		CWD:                  strings.TrimSpace(input.CWD),
@@ -286,6 +287,7 @@ func (c *Controller) Resume(ctx context.Context, input ResumeInput) (Session, er
 	session := Session{
 		RoomID:            roomID,
 		AgentSessionID:    agentSessionID,
+		AgentTargetID:     strings.TrimSpace(input.AgentTargetID),
 		Provider:          provider,
 		ProviderSessionID: providerSessionID,
 		CWD:               strings.TrimSpace(input.CWD),
@@ -1343,6 +1345,7 @@ func (c *Controller) State(roomID, agentSessionID string) (SessionStateSnapshot,
 	snapshot := SessionStateSnapshot{
 		RoomID:             session.RoomID,
 		AgentSessionID:     session.AgentSessionID,
+		AgentTargetID:      session.AgentTargetID,
 		Provider:           session.Provider,
 		ProviderSessionID:  session.ProviderSessionID,
 		Status:             session.Status,
@@ -1371,6 +1374,9 @@ func (c *Controller) State(roomID, agentSessionID string) (SessionStateSnapshot,
 		}
 		if override.AgentSessionID != "" {
 			snapshot.AgentSessionID = override.AgentSessionID
+		}
+		if override.AgentTargetID != "" {
+			snapshot.AgentTargetID = override.AgentTargetID
 		}
 		if override.Provider != "" {
 			snapshot.Provider = override.Provider
@@ -1432,6 +1438,7 @@ func (c *Controller) sessionStateSnapshot(session Session) SessionStateSnapshot 
 	return SessionStateSnapshot{
 		RoomID:            session.RoomID,
 		AgentSessionID:    session.AgentSessionID,
+		AgentTargetID:     session.AgentTargetID,
 		Provider:          session.Provider,
 		ProviderSessionID: session.ProviderSessionID,
 		Status:            session.Status,
@@ -1675,6 +1682,7 @@ func sessionStateSnapshotStreamEvent(session Session) StreamEvent {
 		EventType: StreamEventStatePatch,
 		Data: agentsessionstore.WorkspaceAgentStatePatch{
 			AgentSessionID:    strings.TrimSpace(session.AgentSessionID),
+			AgentTargetID:     strings.TrimSpace(session.AgentTargetID),
 			Provider:          strings.TrimSpace(session.Provider),
 			ProviderSessionID: strings.TrimSpace(session.ProviderSessionID),
 			CWD:               strings.TrimSpace(session.CWD),
@@ -1690,6 +1698,7 @@ func statePatchFromSessionStateSnapshot(snapshot SessionStateSnapshot) agentsess
 	runtimeContext := clonePayload(snapshot.RuntimeContext)
 	return agentsessionstore.WorkspaceAgentStatePatch{
 		AgentSessionID:    strings.TrimSpace(snapshot.AgentSessionID),
+		AgentTargetID:     strings.TrimSpace(snapshot.AgentTargetID),
 		Provider:          strings.TrimSpace(snapshot.Provider),
 		ProviderSessionID: strings.TrimSpace(snapshot.ProviderSessionID),
 		Model:             strings.TrimSpace(runtimeContextString(runtimeContext, "model")),
@@ -1968,6 +1977,7 @@ func (c *Controller) acquireLifecycleLock(roomID, agentSessionID string) func() 
 
 func (c *Controller) findStartSession(
 	roomID,
+	agentTargetID,
 	provider,
 	cwd,
 	title string,
@@ -1978,6 +1988,7 @@ func (c *Controller) findStartSession(
 		return Session{}, false
 	}
 	roomID = strings.TrimSpace(roomID)
+	agentTargetID = strings.TrimSpace(agentTargetID)
 	provider = strings.TrimSpace(provider)
 	cwd = strings.TrimSpace(cwd)
 	title = strings.TrimSpace(title)
@@ -1991,10 +2002,17 @@ func (c *Controller) findStartSession(
 		if strings.TrimSpace(session.Provider) != provider {
 			continue
 		}
+		if agentTargetID != "" {
+			if strings.TrimSpace(session.AgentTargetID) != agentTargetID {
+				continue
+			}
+		} else if strings.TrimSpace(session.AgentTargetID) != "" {
+			continue
+		}
 		if strings.TrimSpace(session.CWD) != cwd {
 			continue
 		}
-		if !providerTargetRefsEqual(session.ProviderTargetRef, providerTargetRef) {
+		if agentTargetID == "" && !providerTargetRefsEqual(session.ProviderTargetRef, providerTargetRef) {
 			continue
 		}
 		if title != "" && strings.TrimSpace(session.Title) != title {

--- a/packages/agent/daemon/runtime/controller_test.go
+++ b/packages/agent/daemon/runtime/controller_test.go
@@ -176,6 +176,90 @@ func TestControllerStartDoesNotReuseSessionWithDifferentProviderTargetRef(t *tes
 	}
 }
 
+func TestControllerStartDoesNotReuseTargetSessionWithDifferentProviderTargetRef(t *testing.T) {
+	t.Parallel()
+
+	adapter := &recordingStartAdapter{provider: ProviderCodex}
+	controller := NewController([]Adapter{adapter}, nil)
+
+	first, err := controller.Start(context.Background(), StartInput{
+		RoomID:        "room-1",
+		Provider:      ProviderCodex,
+		AgentTargetID: "local:codex",
+		CWD:           "/workspace",
+		ProviderTargetRef: map[string]any{
+			"kind":     "local_cli",
+			"provider": ProviderCodex,
+			"targetId": "local:codex",
+		},
+	})
+	if err != nil {
+		t.Fatalf("first Start: %v", err)
+	}
+	second, err := controller.Start(context.Background(), StartInput{
+		RoomID:        "room-1",
+		Provider:      ProviderCodex,
+		AgentTargetID: "local:codex",
+		CWD:           "/workspace",
+		ProviderTargetRef: map[string]any{
+			"kind":     "local_cli",
+			"provider": ProviderCodex,
+			"targetId": "alternate-codex",
+		},
+	})
+	if err != nil {
+		t.Fatalf("second Start: %v", err)
+	}
+
+	if second.Session.AgentSessionID == first.Session.AgentSessionID {
+		t.Fatalf("second start reused session %q for a different provider target ref", second.Session.AgentSessionID)
+	}
+	if adapter.started.ProviderTargetRef["targetId"] != "alternate-codex" {
+		t.Fatalf("adapter provider target ref = %#v, want alternate-codex", adapter.started.ProviderTargetRef)
+	}
+}
+
+func TestControllerStartReusesTargetSessionWithSameProviderTargetRef(t *testing.T) {
+	t.Parallel()
+
+	adapter := &recordingStartAdapter{provider: ProviderCodex}
+	controller := NewController([]Adapter{adapter}, nil)
+	ref := map[string]any{
+		"kind":     "local_cli",
+		"provider": ProviderCodex,
+		"targetId": "local:codex",
+	}
+
+	first, err := controller.Start(context.Background(), StartInput{
+		RoomID:            "room-1",
+		Provider:          ProviderCodex,
+		AgentTargetID:     "local:codex",
+		CWD:               "/workspace",
+		ProviderTargetRef: ref,
+	})
+	if err != nil {
+		t.Fatalf("first Start: %v", err)
+	}
+	second, err := controller.Start(context.Background(), StartInput{
+		RoomID:        "room-1",
+		Provider:      ProviderCodex,
+		AgentTargetID: "local:codex",
+		CWD:           "/workspace",
+		ProviderTargetRef: map[string]any{
+			"kind":     "local_cli",
+			"provider": ProviderCodex,
+			"targetId": "local:codex",
+		},
+	})
+	if err != nil {
+		t.Fatalf("second Start: %v", err)
+	}
+
+	if second.Session.AgentSessionID != first.Session.AgentSessionID {
+		t.Fatalf("second start session = %q, want reused %q", second.Session.AgentSessionID, first.Session.AgentSessionID)
+	}
+}
+
 func TestControllerExecResumesExistingSessionWhenAdapterLiveSessionMissing(t *testing.T) {
 	t.Parallel()
 

--- a/packages/agent/daemon/runtime/types.go
+++ b/packages/agent/daemon/runtime/types.go
@@ -55,6 +55,7 @@ const (
 type StartInput struct {
 	RoomID               string
 	AgentSessionID       string
+	AgentTargetID        string
 	Provider             string
 	CWD                  string
 	Env                  []string
@@ -69,6 +70,7 @@ type StartInput struct {
 type ResumeInput struct {
 	RoomID            string
 	AgentSessionID    string
+	AgentTargetID     string
 	Provider          string
 	ProviderSessionID string
 	CWD               string
@@ -161,6 +163,7 @@ type PromptContentBlock struct {
 type Session struct {
 	RoomID               string              `json:"roomId"`
 	AgentSessionID       string              `json:"agentSessionId"`
+	AgentTargetID        string              `json:"agentTargetId,omitempty"`
 	Provider             string              `json:"provider"`
 	ProviderSessionID    string              `json:"providerSessionId"`
 	CWD                  string              `json:"cwd,omitempty"`
@@ -193,6 +196,7 @@ type SessionInteractivePrompt struct {
 type SessionStateSnapshot struct {
 	RoomID             string                    `json:"roomId"`
 	AgentSessionID     string                    `json:"agentSessionId"`
+	AgentTargetID      string                    `json:"agentTargetId,omitempty"`
 	Provider           string                    `json:"provider"`
 	ProviderSessionID  string                    `json:"providerSessionId,omitempty"`
 	Status             string                    `json:"status"`

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/agentGuiController.composerHelpers.spec.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/agentGuiController.composerHelpers.spec.ts
@@ -1,7 +1,14 @@
 import { afterEach, describe, expect, it } from "vitest";
 import { setAgentGuiI18nTestLocale } from "../../../i18n/testUtils";
 import type { AgentSessionPermissionConfig } from "../../../shared/agentSessionTypes";
-import { permissionModeOptions } from "./agentGuiController.composerHelpers";
+import type { AgentGUINodeData } from "../../../types";
+import {
+  buildNodeDefaultComposerSettings,
+  nodeDataFromComposerSettings,
+  permissionModeOptions,
+  readNodeDefaultDraftPrompt,
+  readNodeDefaultDraftSettings
+} from "./agentGuiController.composerHelpers";
 
 describe("permissionModeOptions", () => {
   afterEach(() => {
@@ -31,5 +38,91 @@ describe("permissionModeOptions", () => {
         description: "仅对检测到的风险操作请求批准"
       }
     ]);
+  });
+});
+
+describe("target-keyed composer defaults", () => {
+  const baseNodeData: AgentGUINodeData = {
+    provider: "codex",
+    agentTargetId: "local:codex",
+    providerTargetId: null,
+    providerTargetRef: null,
+    lastActiveAgentSessionId: null,
+    composerOverrides: null,
+    composerOverridesByAgentTargetId: {
+      "local:codex": { model: "target-model" }
+    },
+    composerOverridesByProvider: {
+      codex: { model: "provider-model" }
+    }
+  };
+
+  it("prefers target composer overrides and falls back to provider overrides", () => {
+    expect(buildNodeDefaultComposerSettings(baseNodeData).model).toBe(
+      "target-model"
+    );
+    expect(
+      buildNodeDefaultComposerSettings({
+        ...baseNodeData,
+        agentTargetId: "other-target"
+      }).model
+    ).toBe("provider-model");
+  });
+
+  it("writes target composer overrides without mutating provider defaults", () => {
+    const next = nodeDataFromComposerSettings(baseNodeData, {
+      model: "target-new",
+      reasoningEffort: null,
+      speed: null,
+      planMode: false,
+      browserUse: true,
+      computerUse: true,
+      permissionModeId: null
+    });
+
+    expect(next.composerOverridesByAgentTargetId?.["local:codex"]?.model).toBe(
+      "target-new"
+    );
+    expect(next.composerOverridesByProvider?.codex?.model).toBe(
+      "provider-model"
+    );
+    expect(next.composerOverrides?.model ?? null).toBeNull();
+  });
+
+  it("reads target draft defaults before provider legacy defaults", () => {
+    expect(
+      readNodeDefaultDraftPrompt({
+        data: baseNodeData,
+        drafts: {
+          "__agent_gui_node_defaults__:codex": "provider draft",
+          "__agent_gui_node_defaults__:target:local:codex": "target draft"
+        }
+      })
+    ).toBe("target draft");
+    expect(
+      readNodeDefaultDraftSettings({
+        data: baseNodeData,
+        drafts: {
+          "__agent_gui_node_defaults__:codex": {
+            model: "provider-draft-model",
+            reasoningEffort: null,
+            speed: null,
+            planMode: false,
+            browserUse: true,
+            computerUse: true,
+            permissionModeId: null
+          },
+          "__agent_gui_node_defaults__:target:local:codex": {
+            model: "target-draft-model",
+            reasoningEffort: null,
+            speed: null,
+            planMode: false,
+            browserUse: true,
+            computerUse: true,
+            permissionModeId: null
+          }
+        }
+      }).model
+    ).toBe("target-draft-model");
   });
 });

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/agentGuiController.composerHelpers.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/agentGuiController.composerHelpers.ts
@@ -396,7 +396,11 @@ export function buildNodeDefaultComposerSettings(
 export function nodeComposerOverridesForProvider(
   data: AgentGUINodeData
 ): AgentSessionComposerSettings | null {
+  const agentTargetId = normalizeOptionalText(data.agentTargetId);
   return (
+    (agentTargetId
+      ? data.composerOverridesByAgentTargetId?.[agentTargetId]
+      : null) ??
     data.composerOverridesByProvider?.[data.provider] ??
     data.composerOverrides ??
     null
@@ -464,6 +468,16 @@ export function nodeDataFromComposerSettings(
     computerUse: settings.computerUse,
     permissionModeId: normalizePermissionModeId(settings.permissionModeId)
   };
+  const agentTargetId = normalizeOptionalText(current.agentTargetId);
+  if (agentTargetId) {
+    return {
+      ...current,
+      composerOverridesByAgentTargetId: {
+        ...(current.composerOverridesByAgentTargetId ?? {}),
+        [agentTargetId]: composerOverrides
+      }
+    };
+  }
   return {
     ...current,
     composerOverrides,
@@ -526,15 +540,21 @@ export function removeQueuedPromptById(
 export const NODE_DEFAULT_DRAFT_KEY = "__agent_gui_node_defaults__";
 
 export function nodeDefaultDraftKey(
-  agentProvider: AgentGUINodeData["provider"]
+  agentProvider: AgentGUINodeData["provider"],
+  agentTargetId?: string | null
 ): string {
+  const normalizedAgentTargetId = normalizeOptionalText(agentTargetId);
+  if (normalizedAgentTargetId) {
+    return `${NODE_DEFAULT_DRAFT_KEY}:target:${normalizedAgentTargetId}`;
+  }
   return `${NODE_DEFAULT_DRAFT_KEY}:${agentProvider}`;
 }
 
 export function nodeDefaultDraftPromptKey(
-  agentProvider: AgentGUINodeData["provider"]
+  agentProvider: AgentGUINodeData["provider"],
+  agentTargetId?: string | null
 ): string {
-  return nodeDefaultDraftKey(agentProvider);
+  return nodeDefaultDraftKey(agentProvider, agentTargetId);
 }
 
 export function normalizeProjectDraftPath(
@@ -549,6 +569,9 @@ export function readNodeDefaultDraftPrompt(input: {
   drafts: Record<string, string>;
 }): string {
   return (
+    input.drafts[
+      nodeDefaultDraftPromptKey(input.data.provider, input.data.agentTargetId)
+    ] ??
     input.drafts[nodeDefaultDraftPromptKey(input.data.provider)] ??
     input.drafts[NODE_DEFAULT_DRAFT_KEY] ??
     ""
@@ -562,6 +585,9 @@ export function readNodeDefaultDraftSettings(input: {
   drafts: Record<string, AgentSessionComposerSettings>;
 }): AgentSessionComposerSettings {
   return (
+    input.drafts[
+      nodeDefaultDraftKey(input.data.provider, input.data.agentTargetId)
+    ] ??
     input.drafts[nodeDefaultDraftKey(input.data.provider)] ??
     input.drafts[NODE_DEFAULT_DRAFT_KEY] ??
     buildNodeDefaultComposerSettings(input.data, {

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUIActivation.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUIActivation.ts
@@ -12,6 +12,7 @@ import type { AgentGUIProviderTargetRef } from "../../../types";
 type AgentGUILiveState = "inactive" | "activating" | "active" | "failed";
 interface AgentGUIActivateInput {
   agentSessionId: string;
+  agentTargetId?: string | null;
   cwd?: string;
   initialContent?: AgentPromptContentBlock[];
   initialDisplayPrompt?: string;
@@ -70,6 +71,7 @@ export function useAgentGUIActivation({
                 mode: input.mode,
                 workspaceId,
                 agentSessionId,
+                agentTargetId: input.agentTargetId,
                 provider: input.provider,
                 cwd: input.cwd,
                 initialContent: input.initialContent,

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUINodeController.spec.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUINodeController.spec.tsx
@@ -1087,6 +1087,7 @@ describe("useAgentGUINodeController", () => {
         providerTargets: [
           {
             targetId: "shared-agent:agent-1",
+            agentTargetId: "agent-target-1",
             provider: "codex",
             ref: providerTargetRef,
             label: "Alice's Codex"
@@ -1105,6 +1106,7 @@ describe("useAgentGUINodeController", () => {
       expect(activate).toHaveBeenCalledWith(
         expect.objectContaining({
           mode: "new",
+          agentTargetId: "agent-target-1",
           provider: "codex",
           providerTargetRef
         })
@@ -1122,6 +1124,7 @@ describe("useAgentGUINodeController", () => {
     })?.[0];
     expect(persistTargetUpdate?.(agentGuiData(null))).toMatchObject({
       provider: "codex",
+      agentTargetId: "agent-target-1",
       providerTargetId: "shared-agent:agent-1",
       providerTargetRef
     });
@@ -1174,7 +1177,8 @@ describe("useAgentGUINodeController", () => {
       .filter(
         (next) =>
           next !== initialData &&
-          ("providerTargetId" in next || "providerTargetRef" in next)
+          ((next.providerTargetId ?? null) !== null ||
+            (next.providerTargetRef ?? null) !== null)
       );
     expect(providerTargetUpdates).toEqual([]);
   });
@@ -1238,7 +1242,8 @@ describe("useAgentGUINodeController", () => {
       .filter(
         (next) =>
           next !== initialData &&
-          ("providerTargetId" in next || "providerTargetRef" in next)
+          ((next.providerTargetId ?? null) !== null ||
+            (next.providerTargetRef ?? null) !== null)
       );
     expect(providerTargetUpdates).toEqual([]);
   });
@@ -14923,6 +14928,7 @@ function installAgentActivityRuntimeForHostMocks({
         ...(input.mode === "new"
           ? {
               provider: input.provider,
+              agentTargetId: input.agentTargetId,
               providerTargetRef: input.providerTargetRef,
               cwd: input.cwd,
               initialContent: input.initialContent,
@@ -14968,6 +14974,7 @@ function installAgentActivityRuntimeForHostMocks({
         workspaceId: input.workspaceId,
         agentSessionId: input.agentSessionId ?? createTestAgentSessionId(),
         provider: input.provider,
+        agentTargetId: input.agentTargetId,
         cwd: input.cwd ?? undefined,
         title: input.title ?? undefined,
         settings: {
@@ -15025,12 +15032,25 @@ function installAgentActivityRuntimeForHostMocks({
           input.provider ?? "codex",
           result
         );
+        const agentTargetId =
+          typeof input.agentTargetId === "string" && input.agentTargetId.trim()
+            ? input.agentTargetId.trim()
+            : null;
         setSnapshot(input.workspaceId, (current) => ({
           ...current,
-          composerOptionsByProvider: {
-            ...(current.composerOptionsByProvider ?? {}),
-            [options.provider]: options
-          }
+          ...(agentTargetId
+            ? {
+                composerOptionsByAgentTargetId: {
+                  ...(current.composerOptionsByAgentTargetId ?? {}),
+                  [agentTargetId]: options
+                }
+              }
+            : {
+                composerOptionsByProvider: {
+                  ...(current.composerOptionsByProvider ?? {}),
+                  [options.provider]: options
+                }
+              })
         }));
         return options;
       }
@@ -15075,6 +15095,10 @@ function installAgentActivityRuntimeForHostMocks({
         composerOptionsByProvider:
           current.composerOptionsByProvider ??
           next.composerOptionsByProvider ??
+          {},
+        composerOptionsByAgentTargetId:
+          current.composerOptionsByAgentTargetId ??
+          next.composerOptionsByAgentTargetId ??
           {},
         sessionMessagesById: {
           ...next.sessionMessagesById,
@@ -15332,6 +15356,7 @@ function emptyAgentActivitySnapshot(
     presences: [],
     sessions: [],
     sessionMessagesById: {},
+    composerOptionsByAgentTargetId: {},
     composerOptionsByProvider: {}
   };
 }
@@ -15485,30 +15510,19 @@ function cloneAgentActivitySnapshot(
     workspaceId: snapshot.workspaceId,
     presences: snapshot.presences.map((presence) => ({ ...presence })),
     sessions: snapshot.sessions.map((session) => ({ ...session })),
+    composerOptionsByAgentTargetId: Object.fromEntries(
+      Object.entries(snapshot.composerOptionsByAgentTargetId ?? {}).map(
+        ([agentTargetId, options]) => [
+          agentTargetId,
+          cloneComposerOptionsForTest(options)
+        ]
+      )
+    ),
     composerOptionsByProvider: Object.fromEntries(
       Object.entries(snapshot.composerOptionsByProvider ?? {}).map(
         ([provider, options]) => [
           provider,
-          {
-            ...options,
-            models: options.models.map((option) => ({ ...option })),
-            reasoningEfforts: options.reasoningEfforts.map((option) => ({
-              ...option
-            })),
-            permissionConfig: options.permissionConfig
-              ? {
-                  configurable: options.permissionConfig.configurable,
-                  defaultValue: options.permissionConfig.defaultValue ?? null,
-                  modes: options.permissionConfig.modes.map((mode) => ({
-                    ...mode
-                  }))
-                }
-              : (options.permissionConfig ?? null),
-            runtimeContext: options.runtimeContext
-              ? { ...options.runtimeContext }
-              : options.runtimeContext,
-            skills: options.skills.map((skill) => ({ ...skill }))
-          }
+          cloneComposerOptionsForTest(options)
         ]
       )
     ),
@@ -15523,6 +15537,35 @@ function cloneAgentActivitySnapshot(
         ]
       )
     )
+  };
+}
+
+function cloneComposerOptionsForTest(
+  options: AgentActivityComposerOptions
+): AgentActivityComposerOptions {
+  return {
+    ...options,
+    models: options.models.map((option) => ({ ...option })),
+    reasoningEfforts: options.reasoningEfforts.map((option) => ({
+      ...option
+    })),
+    speeds: (options.speeds ?? []).map((option) => ({ ...option })),
+    permissionConfig: options.permissionConfig
+      ? {
+          configurable: options.permissionConfig.configurable,
+          defaultValue: options.permissionConfig.defaultValue ?? null,
+          modes: options.permissionConfig.modes.map((mode) => ({
+            ...mode
+          }))
+        }
+      : (options.permissionConfig ?? null),
+    runtimeContext: options.runtimeContext
+      ? { ...options.runtimeContext }
+      : options.runtimeContext,
+    skills: options.skills.map((skill) => ({ ...skill })),
+    capabilityCatalog: options.capabilityCatalog?.map((capability) => ({
+      ...capability
+    }))
   };
 }
 
@@ -15554,6 +15597,12 @@ function agentActivitySnapshotFromHostSnapshot(
       agentActivitySessionFromWorkspaceAgentSession(session, workspaceId)
     ),
     sessionMessagesById,
+    composerOptionsByAgentTargetId:
+      (
+        snapshot as {
+          composerOptionsByAgentTargetId?: AgentActivitySnapshot["composerOptionsByAgentTargetId"];
+        }
+      ).composerOptionsByAgentTargetId ?? {},
     composerOptionsByProvider:
       (
         snapshot as {

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUINodeController.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUINodeController.ts
@@ -2853,15 +2853,21 @@ function areAgentComposerDraftsEqual(
 }
 
 function nodeDefaultDraftKey(
-  agentProvider: AgentGUINodeData["provider"]
+  agentProvider: AgentGUINodeData["provider"],
+  agentTargetId?: string | null
 ): string {
+  const normalizedAgentTargetId = normalizeOptionalText(agentTargetId);
+  if (normalizedAgentTargetId) {
+    return `${NODE_DEFAULT_DRAFT_KEY}:target:${normalizedAgentTargetId}`;
+  }
   return `${NODE_DEFAULT_DRAFT_KEY}:${agentProvider}`;
 }
 
 function nodeDefaultDraftContentKey(
-  agentProvider: AgentGUINodeData["provider"]
+  agentProvider: AgentGUINodeData["provider"],
+  agentTargetId?: string | null
 ): string {
-  return nodeDefaultDraftKey(agentProvider);
+  return nodeDefaultDraftKey(agentProvider, agentTargetId);
 }
 
 function normalizeProjectDraftPath(
@@ -2876,6 +2882,9 @@ function readNodeDefaultDraftContent(input: {
   drafts: Record<string, AgentComposerDraft>;
 }): AgentComposerDraft {
   return (
+    input.drafts[
+      nodeDefaultDraftContentKey(input.data.provider, input.data.agentTargetId)
+    ] ??
     input.drafts[nodeDefaultDraftContentKey(input.data.provider)] ??
     input.drafts[NODE_DEFAULT_DRAFT_KEY] ??
     EMPTY_AGENT_COMPOSER_DRAFT
@@ -2888,6 +2897,9 @@ function readNodeDefaultDraftSettings(input: {
   drafts: Record<string, AgentSessionComposerSettings>;
 }): AgentSessionComposerSettings {
   return (
+    input.drafts[
+      nodeDefaultDraftKey(input.data.provider, input.data.agentTargetId)
+    ] ??
     input.drafts[nodeDefaultDraftKey(input.data.provider)] ??
     input.drafts[NODE_DEFAULT_DRAFT_KEY] ??
     buildNodeDefaultComposerSettings(input.data, {
@@ -3319,6 +3331,7 @@ export function useAgentGUINodeController({
   const selectedProviderTarget = useMemo(
     () =>
       resolveAgentGUIProviderTarget({
+        agentTargetId: data.agentTargetId,
         defaultProviderTargetId,
         provider: data.provider,
         providerTargetId: data.providerTargetId,
@@ -3326,6 +3339,7 @@ export function useAgentGUINodeController({
       }),
     [
       data.provider,
+      data.agentTargetId,
       data.providerTargetId,
       defaultProviderTargetId,
       normalizedProviderTargets
@@ -3520,7 +3534,13 @@ export function useAgentGUINodeController({
   );
   const activeSessionState = activeSessionView?.controlState ?? null;
   const providerComposerOptions =
-    agentActivitySnapshot.composerOptionsByProvider?.[data.provider] ?? null;
+    (data.agentTargetId
+      ? agentActivitySnapshot.composerOptionsByAgentTargetId?.[
+          data.agentTargetId
+        ]
+      : null) ??
+    agentActivitySnapshot.composerOptionsByProvider?.[data.provider] ??
+    null;
   const resolvedPromptImagesSupported = resolveAgentActivityCapability(
     "imageInput",
     {
@@ -5678,6 +5698,7 @@ export function useAgentGUINodeController({
       // Composer options are loaded for every provider: besides settings they
       // carry the capabilities fallback and the skills list.
       const provider = dataRef.current.provider;
+      const agentTargetId = dataRef.current.agentTargetId ?? null;
       if (isCreatingConversationRef.current) {
         return;
       }
@@ -5694,6 +5715,7 @@ export function useAgentGUINodeController({
           cwd: composerOptionsCwd,
           force: options?.force,
           provider,
+          agentTargetId,
           settings
         })
       ).catch(() => undefined);
@@ -5708,7 +5730,7 @@ export function useAgentGUINodeController({
     if (!supports.model && !supports.reasoning && !supports.permission) {
       return;
     }
-    const projectKey = `${data.provider}\0${selectedProjectPath ?? ""}`;
+    const projectKey = `${data.agentTargetId ?? data.provider}\0${selectedProjectPath ?? ""}`;
     const previousProjectKey = composerOptionsProjectKeyRef.current;
     composerOptionsProjectKeyRef.current = projectKey;
     if (previousProjectKey === null || previousProjectKey === projectKey) {
@@ -6530,8 +6552,10 @@ export function useAgentGUINodeController({
         const provider = target.provider;
         const shouldUseProviderTargetRef =
           selectedProviderTargetIsExplicitRef.current;
+        const agentTargetId = target.agentTargetId ?? null;
         onDataChangeRef.current((current) =>
           current.provider === provider &&
+          (current.agentTargetId ?? null) === agentTargetId &&
           (current.providerTargetId ?? null) ===
             (shouldUseProviderTargetRef ? target.targetId : null) &&
           agentGUIProviderTargetRefsEqual(
@@ -6542,6 +6566,7 @@ export function useAgentGUINodeController({
             : {
                 ...current,
                 provider,
+                agentTargetId,
                 providerTargetId: shouldUseProviderTargetRef
                   ? target.targetId
                   : null,
@@ -6588,8 +6613,13 @@ export function useAgentGUINodeController({
             ? initialSettings
             : { ...initialSettings, model: inheritedModel };
         const snapshotComposerOptions =
+          (agentTargetId
+            ? agentActivityRuntime.getSnapshot(workspaceId)
+                .composerOptionsByAgentTargetId?.[agentTargetId]
+            : null) ??
           agentActivityRuntime.getSnapshot(workspaceId)
-            .composerOptionsByProvider?.[provider] ?? null;
+            .composerOptionsByProvider?.[provider] ??
+          null;
         const snapshotDraftAgentSessionId =
           normalizedInitialContent.length > 0 && provider === "claude-code"
             ? draftAgentSessionIdFromComposerOptions(snapshotComposerOptions)
@@ -6703,6 +6733,7 @@ export function useAgentGUINodeController({
         return activation.activate({
           mode: "new",
           agentSessionId,
+          agentTargetId,
           provider,
           providerTargetRef: shouldUseProviderTargetRef ? target.ref : null,
           cwd: selectedProjectPath ?? "",
@@ -8173,7 +8204,10 @@ export function useAgentGUINodeController({
       };
       const agentSessionId = activeConversationIdRef.current;
       if (!agentSessionId) {
-        const defaultDraftKey = nodeDefaultDraftKey(dataRef.current.provider);
+        const defaultDraftKey = nodeDefaultDraftKey(
+          dataRef.current.provider,
+          dataRef.current.agentTargetId
+        );
         const storedDefaults = readNodeDefaultDraftSettings({
           data: dataRef.current,
           defaultReasoningEffort,

--- a/packages/agent/gui/agent-gui/agentGuiNode/model/agentGuiConversationFilter.spec.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/model/agentGuiConversationFilter.spec.ts
@@ -50,8 +50,8 @@ describe("agentGuiConversationFilter", () => {
 
   it("keeps the filter model independent from composer state", () => {
     const composerState = Object.freeze({
-      defaultProviderTargetId: "local-codex",
-      selectedProviderTarget: "local-codex"
+      defaultProviderTargetId: "local:codex",
+      selectedProviderTarget: "local:codex"
     });
 
     const filterState = createAgentGUIConversationFilterState({
@@ -68,8 +68,8 @@ describe("agentGuiConversationFilter", () => {
     expect(filterState).not.toHaveProperty("defaultProviderTargetId");
     expect(filterState).not.toHaveProperty("selectedProviderTarget");
     expect(composerState).toEqual({
-      defaultProviderTargetId: "local-codex",
-      selectedProviderTarget: "local-codex"
+      defaultProviderTargetId: "local:codex",
+      selectedProviderTarget: "local:codex"
     });
   });
 });

--- a/packages/agent/gui/agentActivityRuntime.tsx
+++ b/packages/agent/gui/agentActivityRuntime.tsx
@@ -88,6 +88,7 @@ export interface AgentActivityRuntimeGetSessionControlStateInput {
 }
 
 export interface AgentActivityRuntimeGetComposerOptionsInput {
+  agentTargetId?: string | null;
   cwd?: string | null;
   force?: boolean;
   provider?: string;
@@ -122,6 +123,7 @@ export interface AgentActivityRuntimeDiagnosticInput {
 
 export interface AgentActivityRuntimeActivateSessionInput {
   agentSessionId: string;
+  agentTargetId?: string | null;
   cwd?: string;
   initialContent?: AgentActivitySendInput["content"];
   /** 仅展示用首轮文本(bundle 折叠成一个 chip);initialContent 仍带展开后的文件。 */

--- a/packages/agent/gui/providerTargets.spec.ts
+++ b/packages/agent/gui/providerTargets.spec.ts
@@ -11,6 +11,7 @@ describe("agent gui provider targets", () => {
   it("creates local targets for the default provider catalog", () => {
     expect(createLocalAgentGUIProviderTarget("codex")).toEqual({
       targetId: "local:codex",
+      agentTargetId: "local:codex",
       provider: "codex",
       ref: {
         kind: "local",

--- a/packages/agent/gui/providerTargets.ts
+++ b/packages/agent/gui/providerTargets.ts
@@ -25,8 +25,11 @@ export const agentGUIDefaultTargetProviders = [
 export function createLocalAgentGUIProviderTarget(
   provider: AgentGUIProvider
 ): AgentGUIProviderTarget {
+  const targetId = localAgentGUIProviderTargetId(provider);
+  const agentTargetId = localAgentGUIAgentTargetId(provider);
   return {
-    targetId: localAgentGUIProviderTargetId(provider),
+    targetId,
+    ...(agentTargetId ? { agentTargetId } : {}),
     provider,
     ref: {
       kind: "local",
@@ -48,6 +51,19 @@ export function localAgentGUIProviderTargetId(
   provider: AgentGUIProvider
 ): string {
   return `local:${provider}`;
+}
+
+export function localAgentGUIAgentTargetId(
+  provider: AgentGUIProvider
+): string | null {
+  switch (provider) {
+    case "codex":
+      return "local:codex";
+    case "claude-code":
+      return "local:claude-code";
+    default:
+      return null;
+  }
 }
 
 export function normalizeAgentGUIProviderTargets(
@@ -76,6 +92,7 @@ export function normalizeAgentGUIProviderTargets(
 }
 
 export function resolveAgentGUIProviderTarget(input: {
+  agentTargetId?: string | null;
   defaultProviderTargetId?: string | null;
   provider: AgentGUIProvider;
   providerTargetId?: string | null;
@@ -87,7 +104,13 @@ export function resolveAgentGUIProviderTarget(input: {
   const targetById = new Map(
     providerTargets.map((target) => [target.targetId, target])
   );
+  const targetByAgentTargetId = new Map(
+    providerTargets.flatMap((target) =>
+      target.agentTargetId ? [[target.agentTargetId, target] as const] : []
+    )
+  );
   return (
+    targetByAgentTargetId.get(input.agentTargetId?.trim() ?? "") ??
     targetById.get(input.providerTargetId?.trim() ?? "") ??
     targetById.get(input.defaultProviderTargetId?.trim() ?? "") ??
     targetById.get(localAgentGUIProviderTargetId(input.provider)) ??
@@ -117,6 +140,7 @@ function normalizeAgentGUIProviderTarget(
   target: AgentGUIProviderTarget
 ): AgentGUIProviderTarget | null {
   const targetId = target.targetId.trim();
+  const agentTargetId = target.agentTargetId?.trim();
   const label = target.label.trim();
   const kind =
     typeof target.ref.kind === "string" ? target.ref.kind.trim() : "";
@@ -126,6 +150,7 @@ function normalizeAgentGUIProviderTarget(
   return {
     ...target,
     targetId,
+    ...(agentTargetId ? { agentTargetId } : {}),
     provider: target.provider,
     ref: {
       ...target.ref,

--- a/packages/agent/gui/shared/contracts/dto/agentSession.ts
+++ b/packages/agent/gui/shared/contracts/dto/agentSession.ts
@@ -55,6 +55,7 @@ export interface AgentHostAgentSessionComposerSettings {
 export interface AgentHostAgentSession {
   workspaceId: string;
   agentSessionId: string;
+  agentTargetId?: string | null;
   provider: AgentHostAgentSessionProvider;
   providerSessionId: string;
   resumable?: boolean;
@@ -74,6 +75,7 @@ export interface AgentHostAgentSessionEvent {
   id: string;
   workspaceId: string;
   agentSessionId: string;
+  agentTargetId?: string | null;
   provider: AgentHostAgentSessionProvider;
   providerSessionId?: string;
   type: string;
@@ -99,6 +101,7 @@ export interface AgentHostAgentSessionInteractivePrompt {
 export interface AgentHostAgentSessionState {
   workspaceId: string;
   agentSessionId: string;
+  agentTargetId?: string | null;
   provider: AgentHostAgentSessionProvider;
   providerSessionId?: string;
   resumable?: boolean;
@@ -151,6 +154,7 @@ interface AgentHostActivateAgentSessionInputBase {
 
 export interface AgentHostActivateNewAgentSessionInput extends AgentHostActivateAgentSessionInputBase {
   mode: "new";
+  agentTargetId?: string | null;
   provider: AgentHostAgentSessionProvider;
   /**
    * Opaque target reference supplied by the host. It is not authority,

--- a/packages/agent/gui/types.ts
+++ b/packages/agent/gui/types.ts
@@ -44,6 +44,7 @@ export interface AgentNodeData {
 
 export interface AgentGUINodeData {
   provider: AgentGUIProvider;
+  agentTargetId?: string | null;
   providerTargetId?: string | null;
   providerTargetRef?: AgentGUIProviderTargetRef | null;
   lastActiveAgentSessionId: string | null;
@@ -52,6 +53,10 @@ export interface AgentGUINodeData {
   conversationRailWidthPx?: number | null;
   conversationRailCollapsed?: boolean | null;
   composerOverrides?: AgentHostAgentSessionComposerSettings | null;
+  composerOverridesByAgentTargetId?: Record<
+    string,
+    AgentHostAgentSessionComposerSettings | null
+  > | null;
   composerOverridesByProvider?: Partial<
     Record<AgentGUIProvider, AgentHostAgentSessionComposerSettings | null>
   > | null;
@@ -70,6 +75,7 @@ export interface AgentGUIProviderTargetRef {
 
 export interface AgentGUIProviderTarget {
   targetId: string;
+  agentTargetId?: string | null;
   provider: AgentGUIProvider;
   ref: AgentGUIProviderTargetRef;
   label: string;

--- a/packages/agent/gui/workbench/contribution.test.ts
+++ b/packages/agent/gui/workbench/contribution.test.ts
@@ -106,6 +106,7 @@ describe("agent GUI workbench contribution copy", () => {
     expect(entries[0]?.id).toBe(agentGuiWorkbenchUnifiedDockEntryId());
     expect(entries[0]?.label).toBe("Agent");
     expect(entries[0]?.launchPayload).toEqual({
+      agentTargetId: "local:claude-code",
       provider: "claude-code",
       providerTargetId: "local:claude-code",
       providerTargetRef: claudeTarget.ref
@@ -115,11 +116,13 @@ describe("agent GUI workbench contribution copy", () => {
   it("uses the first enabled target in host order after an unavailable default provider", () => {
     const disabledClaudeTarget = {
       ...createLocalAgentGUIProviderTarget("claude-code"),
+      agentTargetId: "disabled-claude",
       disabled: true,
       targetId: "disabled-claude"
     };
     const enabledClaudeTarget = {
       ...createLocalAgentGUIProviderTarget("claude-code"),
+      agentTargetId: "daemon-claude",
       targetId: "daemon-claude"
     };
     const entries = buildAgentGuiDockEntries({
@@ -138,6 +141,7 @@ describe("agent GUI workbench contribution copy", () => {
     });
 
     expect(entries[0]?.launchPayload).toEqual({
+      agentTargetId: "daemon-claude",
       provider: "claude-code",
       providerTargetId: "daemon-claude",
       providerTargetRef: enabledClaudeTarget.ref
@@ -147,6 +151,7 @@ describe("agent GUI workbench contribution copy", () => {
   it("uses host target order for an available default provider", () => {
     const daemonCodexTarget = {
       ...createLocalAgentGUIProviderTarget("codex"),
+      agentTargetId: "daemon-codex",
       targetId: "daemon-codex"
     };
     const localCodexTarget = createLocalAgentGUIProviderTarget("codex");
@@ -161,6 +166,7 @@ describe("agent GUI workbench contribution copy", () => {
     });
 
     expect(entries[0]?.launchPayload).toEqual({
+      agentTargetId: "daemon-codex",
       provider: "codex",
       providerTargetId: "daemon-codex",
       providerTargetRef: daemonCodexTarget.ref
@@ -259,6 +265,7 @@ describe("agent GUI workbench contribution copy", () => {
       ],
       renderBody: () => null,
       resolveDockLaunchPayload: () => ({
+        agentTargetId: claudeTarget.agentTargetId,
         provider: "claude-code",
         providerTargetId: claudeTarget.targetId,
         providerTargetRef: claudeTarget.ref
@@ -290,13 +297,16 @@ describe("agent GUI workbench contribution copy", () => {
       dockEntryId: agentGuiWorkbenchUnifiedDockEntryId(),
       title: "Claude Code"
     });
-    expect(launchResult?.instanceId).toContain("agent-gui:claude-code:panel:");
+    expect(launchResult?.instanceId).toBe(
+      "agent-gui:claude-code:target:local%3Aclaude-code"
+    );
     expect(
       contribution.externalStateSource?.getSnapshotNodeState?.({
         instanceId: launchResult?.instanceId ?? "",
         typeId: agentGuiWorkbenchTypeId
       } as never)
     ).toMatchObject({
+      agentTargetId: "local:claude-code",
       providerTargetId: "local:claude-code",
       providerTargetRef: claudeTarget.ref
     });
@@ -335,14 +345,18 @@ describe("agent GUI workbench contribution copy", () => {
       dockEntryId: agentGuiWorkbenchUnifiedDockEntryId(),
       title: "Claude Code"
     });
-    expect(launchResult?.instanceId).toContain("agent-gui:claude-code:panel:");
+    expect(launchResult?.instanceId).toBe(
+      "agent-gui:claude-code:target:local%3Aclaude-code"
+    );
     expect(
       contribution.externalStateSource?.getSnapshotNodeState?.({
         instanceId: launchResult?.instanceId ?? "",
         typeId: agentGuiWorkbenchTypeId
       } as never)
     ).toEqual({
+      agentTargetId: "local:claude-code",
       composerOverrides: null,
+      composerOverridesByAgentTargetId: null,
       composerOverridesByProvider: null,
       conversationRailCollapsed: false,
       conversationRailWidthPx: null,

--- a/packages/agent/gui/workbench/contribution.ts
+++ b/packages/agent/gui/workbench/contribution.ts
@@ -389,6 +389,9 @@ export function createAgentGuiWorkbenchContribution(
             ...(targetAgentSessionId
               ? { lastActiveAgentSessionId: targetAgentSessionId }
               : {}),
+            ...(providerTarget.agentTargetId
+              ? { agentTargetId: providerTarget.agentTargetId }
+              : {}),
             ...(providerTarget.providerTargetId
               ? { providerTargetId: providerTarget.providerTargetId }
               : {}),
@@ -399,6 +402,7 @@ export function createAgentGuiWorkbenchContribution(
           typeId: agentGuiWorkbenchTypeId
         });
       } else if (
+        providerTarget.agentTargetId ||
         providerTarget.providerTargetId ||
         providerTarget.providerTargetRef
       ) {
@@ -410,6 +414,9 @@ export function createAgentGuiWorkbenchContribution(
           instanceId,
           state: {
             ...normalizeAgentGuiWorkbenchState(previousState),
+            ...(providerTarget.agentTargetId
+              ? { agentTargetId: providerTarget.agentTargetId }
+              : {}),
             ...(providerTarget.providerTargetId
               ? { providerTargetId: providerTarget.providerTargetId }
               : {}),
@@ -522,6 +529,7 @@ export function resolveAgentGuiUnifiedDockLaunchPayload(
   >
 ): {
   provider: AgentGuiWorkbenchProvider;
+  agentTargetId?: string;
   providerTargetId?: string;
   providerTargetRef?: AgentGUIProviderTargetRef;
 } {
@@ -529,6 +537,7 @@ export function resolveAgentGuiUnifiedDockLaunchPayload(
   if (target) {
     return {
       provider: target.provider,
+      ...(target.agentTargetId ? { agentTargetId: target.agentTargetId } : {}),
       providerTargetId: target.targetId,
       providerTargetRef: target.ref
     };
@@ -833,20 +842,27 @@ function providerTargetLaunchPayloadFromRequest(
   payload: unknown,
   expectedProvider: AgentGuiWorkbenchProvider
 ): {
+  agentTargetId: string | null;
   providerTargetId: string | null;
   providerTargetRef: AgentGUIProviderTargetRef | null;
 } {
   if (!payload || typeof payload !== "object" || Array.isArray(payload)) {
     return {
+      agentTargetId: null,
       providerTargetId: null,
       providerTargetRef: null
     };
   }
+  const agentTargetId = (payload as { agentTargetId?: unknown }).agentTargetId;
   const providerTargetId = (payload as { providerTargetId?: unknown })
     .providerTargetId;
   const providerTargetRef = (payload as { providerTargetRef?: unknown })
     .providerTargetRef;
   return {
+    agentTargetId:
+      typeof agentTargetId === "string" && agentTargetId.trim()
+        ? agentTargetId.trim()
+        : null,
     providerTargetId:
       typeof providerTargetId === "string" && providerTargetId.trim()
         ? providerTargetId.trim()

--- a/packages/agent/gui/workbench/launch.ts
+++ b/packages/agent/gui/workbench/launch.ts
@@ -65,6 +65,7 @@ export function agentGuiWorkbenchInstanceId(
 
 export function createAgentGuiWorkbenchInstanceId(input: {
   agentSessionId?: string | null;
+  agentTargetId?: string | null;
   provider: AgentGuiWorkbenchProvider;
 }): string {
   const prefix = agentGuiWorkbenchInstanceId(input.provider);
@@ -72,6 +73,12 @@ export function createAgentGuiWorkbenchInstanceId(input: {
   if (agentSessionId) {
     return `${prefix}:session:${encodeAgentGuiWorkbenchInstanceSegment(
       agentSessionId
+    )}`;
+  }
+  const agentTargetId = input.agentTargetId?.trim();
+  if (agentTargetId) {
+    return `${prefix}:target:${encodeAgentGuiWorkbenchInstanceSegment(
+      agentTargetId
     )}`;
   }
 
@@ -208,7 +215,10 @@ export function createAgentGuiWorkbenchLaunchDescriptor(
         type: agentGuiWorkbenchPrefillPromptActivationType
       },
       dockEntryId,
-      instanceId: createAgentGuiWorkbenchInstanceId({ provider }),
+      instanceId: createAgentGuiWorkbenchInstanceId({
+        agentTargetId: agentTargetIdFromLaunchPayload(request.payload),
+        provider
+      }),
       provider,
       reuseDockEntryNode: shouldReuseAgentGuiWorkbenchDockEntryNode({
         dockEntryId,
@@ -221,6 +231,7 @@ export function createAgentGuiWorkbenchLaunchDescriptor(
   const targetAgentSessionId = agentSessionIdFromLaunchPayload(request.payload);
   const instanceId = createAgentGuiWorkbenchInstanceId({
     agentSessionId: targetAgentSessionId,
+    agentTargetId: agentTargetIdFromLaunchPayload(request.payload),
     provider
   });
 
@@ -315,5 +326,15 @@ function agentSessionIdFromLaunchPayload(payload: unknown): string | null {
     .agentSessionId;
   return typeof agentSessionId === "string" && agentSessionId.trim()
     ? agentSessionId.trim()
+    : null;
+}
+
+function agentTargetIdFromLaunchPayload(payload: unknown): string | null {
+  if (!payload || typeof payload !== "object" || Array.isArray(payload)) {
+    return null;
+  }
+  const agentTargetId = (payload as { agentTargetId?: unknown }).agentTargetId;
+  return typeof agentTargetId === "string" && agentTargetId.trim()
+    ? agentTargetId.trim()
     : null;
 }

--- a/packages/agent/gui/workbench/state.test.ts
+++ b/packages/agent/gui/workbench/state.test.ts
@@ -22,6 +22,9 @@ describe("agent gui workbench state", () => {
     expect(
       normalizeAgentGuiWorkbenchNodeState({
         composerOverrides: { model: "gpt-5" },
+        composerOverridesByAgentTargetId: {
+          "target-a": { model: "target-model" }
+        },
         composerOverridesByProvider: {
           gemini: { permissionModeId: "read-only" },
           unsupported: { model: "ignored" }
@@ -32,6 +35,9 @@ describe("agent gui workbench state", () => {
     ).toEqual({
       ...createDefaultAgentGuiWorkbenchNodeState("gemini"),
       composerOverrides: { model: "gpt-5" },
+      composerOverridesByAgentTargetId: {
+        "target-a": { model: "target-model" }
+      },
       composerOverridesByProvider: {
         gemini: { permissionModeId: "read-only" }
       },
@@ -44,6 +50,9 @@ describe("agent gui workbench state", () => {
       projectAgentGuiWorkbenchState({
         ...createDefaultAgentGuiWorkbenchNodeState("gemini"),
         composerOverrides: { permissionModeId: "read-only" },
+        composerOverridesByAgentTargetId: {
+          "target-a": { model: "target-model" }
+        },
         composerOverridesByProvider: {
           gemini: { model: "gemini-2.5-pro" }
         },
@@ -55,6 +64,9 @@ describe("agent gui workbench state", () => {
       })
     ).toEqual({
       composerOverrides: { permissionModeId: "read-only" },
+      composerOverridesByAgentTargetId: {
+        "target-a": { model: "target-model" }
+      },
       composerOverridesByProvider: {
         gemini: { model: "gemini-2.5-pro" }
       },
@@ -115,6 +127,9 @@ describe("agent gui workbench state", () => {
       areAgentGuiWorkbenchStatesEqual(
         normalizeAgentGuiWorkbenchState({
           composerOverrides: { permissionModeId: "auto" },
+          composerOverridesByAgentTargetId: {
+            "target-a": { model: "target-model" }
+          },
           composerOverridesByProvider: {
             codex: { model: "gpt-5" }
           },
@@ -123,6 +138,9 @@ describe("agent gui workbench state", () => {
         }),
         normalizeAgentGuiWorkbenchState({
           composerOverrides: { permissionModeId: "auto" },
+          composerOverridesByAgentTargetId: {
+            "target-a": { model: "target-model" }
+          },
           composerOverridesByProvider: {
             codex: { model: "gpt-5" }
           },
@@ -193,6 +211,7 @@ describe("agent gui workbench state", () => {
       })
     ).toEqual({
       composerOverrides: { permissionModeId: "full-access" },
+      composerOverridesByAgentTargetId: null,
       composerOverridesByProvider: {
         gemini: { model: "gemini-2.5-pro" }
       },
@@ -225,6 +244,7 @@ describe("agent gui workbench state", () => {
       })
     ).toEqual({
       composerOverrides: { permissionModeId: "read-only" },
+      composerOverridesByAgentTargetId: null,
       composerOverridesByProvider: null,
       conversationRailCollapsed: false,
       conversationRailWidthPx: 420,

--- a/packages/agent/gui/workbench/state.ts
+++ b/packages/agent/gui/workbench/state.ts
@@ -10,6 +10,7 @@ import {
 import { agentGUIProviderTargetRefsEqual } from "../providerTargets.ts";
 import type {
   AgentGuiWorkbenchComposerOverrides,
+  AgentGuiWorkbenchComposerOverridesByAgentTargetId,
   AgentGuiWorkbenchComposerOverridesByProvider,
   AgentGuiWorkbenchNodeState,
   AgentGuiWorkbenchProvider,
@@ -29,6 +30,7 @@ export function createDefaultAgentGuiWorkbenchNodeState(
 ): AgentGuiWorkbenchNodeState {
   return {
     composerOverrides: null,
+    composerOverridesByAgentTargetId: null,
     composerOverridesByProvider: null,
     conversationCount: null,
     conversationRailCollapsed: false,
@@ -36,6 +38,7 @@ export function createDefaultAgentGuiWorkbenchNodeState(
     lastActiveAgentSessionId: null,
     lastActiveConversationTitle: null,
     provider,
+    agentTargetId: null,
     providerTargetId: null,
     providerTargetRef: null
   };
@@ -50,6 +53,7 @@ export function normalizeAgentGuiWorkbenchState(
   const providerTargetId = normalizeOptionalNonEmptyString(
     state.providerTargetId
   );
+  const agentTargetId = normalizeOptionalNonEmptyString(state.agentTargetId);
   const providerTargetRef = normalizeAgentGuiProviderTargetRef(
     state.providerTargetRef
   );
@@ -57,6 +61,10 @@ export function normalizeAgentGuiWorkbenchState(
     composerOverrides: normalizeAgentGuiWorkbenchComposerOverrides(
       state.composerOverrides
     ),
+    composerOverridesByAgentTargetId:
+      normalizeAgentGuiWorkbenchComposerOverridesByAgentTargetId(
+        state.composerOverridesByAgentTargetId
+      ),
     composerOverridesByProvider:
       normalizeAgentGuiWorkbenchComposerOverridesByProvider(
         state.composerOverridesByProvider
@@ -69,6 +77,7 @@ export function normalizeAgentGuiWorkbenchState(
       typeof state.lastActiveAgentSessionId === "string"
         ? state.lastActiveAgentSessionId
         : null,
+    ...(agentTargetId ? { agentTargetId } : {}),
     ...(providerTargetId ? { providerTargetId } : {}),
     ...(providerTargetRef ? { providerTargetRef } : {})
   };
@@ -80,6 +89,7 @@ export function projectAgentGuiWorkbenchState(
   const providerTargetId = normalizeOptionalNonEmptyString(
     state.providerTargetId
   );
+  const agentTargetId = normalizeOptionalNonEmptyString(state.agentTargetId);
   const providerTargetRef = normalizeAgentGuiProviderTargetRef(
     state.providerTargetRef,
     state.provider
@@ -88,6 +98,10 @@ export function projectAgentGuiWorkbenchState(
     composerOverrides: normalizeAgentGuiWorkbenchComposerOverrides(
       state.composerOverrides
     ),
+    composerOverridesByAgentTargetId:
+      normalizeAgentGuiWorkbenchComposerOverridesByAgentTargetId(
+        state.composerOverridesByAgentTargetId
+      ),
     composerOverridesByProvider:
       normalizeAgentGuiWorkbenchComposerOverridesByProvider(
         state.composerOverridesByProvider
@@ -97,6 +111,7 @@ export function projectAgentGuiWorkbenchState(
       state.conversationRailWidthPx
     ),
     lastActiveAgentSessionId: state.lastActiveAgentSessionId ?? null,
+    ...(agentTargetId ? { agentTargetId } : {}),
     ...(providerTargetId ? { providerTargetId } : {}),
     ...(providerTargetRef ? { providerTargetRef } : {})
   };
@@ -108,6 +123,10 @@ export function areAgentGuiWorkbenchStatesEqual(
 ): boolean {
   return (
     composerOverridesEqual(left.composerOverrides, right.composerOverrides) &&
+    composerOverridesByAgentTargetIdEqual(
+      left.composerOverridesByAgentTargetId,
+      right.composerOverridesByAgentTargetId
+    ) &&
     composerOverridesByProviderEqual(
       left.composerOverridesByProvider,
       right.composerOverridesByProvider
@@ -115,6 +134,7 @@ export function areAgentGuiWorkbenchStatesEqual(
     left.conversationRailCollapsed === right.conversationRailCollapsed &&
     left.conversationRailWidthPx === right.conversationRailWidthPx &&
     left.lastActiveAgentSessionId === right.lastActiveAgentSessionId &&
+    (left.agentTargetId ?? null) === (right.agentTargetId ?? null) &&
     (left.providerTargetId ?? null) === (right.providerTargetId ?? null) &&
     agentGUIProviderTargetRefsEqual(
       left.providerTargetRef,
@@ -136,6 +156,10 @@ export function normalizeAgentGuiWorkbenchNodeState(
     composerOverrides: normalizeAgentGuiWorkbenchComposerOverrides(
       state?.composerOverrides
     ),
+    composerOverridesByAgentTargetId:
+      normalizeAgentGuiWorkbenchComposerOverridesByAgentTargetId(
+        state?.composerOverridesByAgentTargetId
+      ),
     composerOverridesByProvider:
       normalizeAgentGuiWorkbenchComposerOverridesByProvider(
         state?.composerOverridesByProvider
@@ -156,6 +180,9 @@ export function normalizeAgentGuiWorkbenchNodeState(
         ? state.lastActiveConversationTitle
         : null,
     provider,
+    agentTargetId:
+      normalizeOptionalNonEmptyString(state?.agentTargetId) ??
+      normalizeOptionalNonEmptyString(state?.providerTargetId),
     providerTargetId: normalizeOptionalNonEmptyString(state?.providerTargetId),
     providerTargetRef: normalizeAgentGuiProviderTargetRef(
       state?.providerTargetRef,
@@ -170,6 +197,10 @@ export function areAgentGuiWorkbenchNodeStatesEqual(
 ): boolean {
   return (
     composerOverridesEqual(left.composerOverrides, right.composerOverrides) &&
+    composerOverridesByAgentTargetIdEqual(
+      left.composerOverridesByAgentTargetId,
+      right.composerOverridesByAgentTargetId
+    ) &&
     composerOverridesByProviderEqual(
       left.composerOverridesByProvider,
       right.composerOverridesByProvider
@@ -180,6 +211,7 @@ export function areAgentGuiWorkbenchNodeStatesEqual(
     left.lastActiveAgentSessionId === right.lastActiveAgentSessionId &&
     left.lastActiveConversationTitle === right.lastActiveConversationTitle &&
     left.provider === right.provider &&
+    (left.agentTargetId ?? null) === (right.agentTargetId ?? null) &&
     (left.providerTargetId ?? null) === (right.providerTargetId ?? null) &&
     agentGUIProviderTargetRefsEqual(
       left.providerTargetRef,
@@ -354,6 +386,7 @@ function agentGuiWorkbenchInstanceStateKey(
 function createDefaultAgentGuiWorkbenchState(): AgentGuiWorkbenchState {
   return {
     composerOverrides: null,
+    composerOverridesByAgentTargetId: null,
     composerOverridesByProvider: null,
     conversationRailCollapsed: false,
     conversationRailWidthPx: null,
@@ -433,6 +466,26 @@ function normalizeAgentGuiWorkbenchComposerOverridesByProvider(
   return Object.keys(result).length > 0 ? result : null;
 }
 
+function normalizeAgentGuiWorkbenchComposerOverridesByAgentTargetId(
+  value: unknown
+): AgentGuiWorkbenchComposerOverridesByAgentTargetId | null {
+  if (!isRecord(value)) {
+    return null;
+  }
+  const result: AgentGuiWorkbenchComposerOverridesByAgentTargetId = {};
+  for (const [rawAgentTargetId, rawOverrides] of Object.entries(value)) {
+    const agentTargetId = normalizeOptionalNonEmptyString(rawAgentTargetId);
+    if (!agentTargetId) {
+      continue;
+    }
+    const overrides = normalizeAgentGuiWorkbenchComposerOverrides(rawOverrides);
+    if (overrides) {
+      result[agentTargetId] = overrides;
+    }
+  }
+  return Object.keys(result).length > 0 ? result : null;
+}
+
 function normalizeOptionalPositiveNumber(value: unknown): number | null {
   return typeof value === "number" && Number.isFinite(value) && value > 0
     ? Math.round(value)
@@ -467,6 +520,22 @@ function composerOverridesByProviderEqual(
     }
   }
   return true;
+}
+
+function composerOverridesByAgentTargetIdEqual(
+  left: AgentGuiWorkbenchComposerOverridesByAgentTargetId | null | undefined,
+  right: AgentGuiWorkbenchComposerOverridesByAgentTargetId | null | undefined
+): boolean {
+  const leftKeys = Object.keys(left ?? {}).sort();
+  const rightKeys = Object.keys(right ?? {}).sort();
+  if (leftKeys.length !== rightKeys.length) {
+    return false;
+  }
+  return leftKeys.every(
+    (key, index) =>
+      key === rightKeys[index] &&
+      composerOverridesEqual(left?.[key], right?.[key])
+  );
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {

--- a/packages/agent/gui/workbench/types.ts
+++ b/packages/agent/gui/workbench/types.ts
@@ -31,8 +31,14 @@ export type AgentGuiWorkbenchComposerOverridesByProvider = Partial<
   Record<AgentGuiWorkbenchProvider, AgentGuiWorkbenchComposerOverrides | null>
 >;
 
+export type AgentGuiWorkbenchComposerOverridesByAgentTargetId = Record<
+  string,
+  AgentGuiWorkbenchComposerOverrides | null
+>;
+
 export interface AgentGuiWorkbenchNodeState {
   composerOverrides?: AgentGuiWorkbenchComposerOverrides | null;
+  composerOverridesByAgentTargetId?: AgentGuiWorkbenchComposerOverridesByAgentTargetId | null;
   composerOverridesByProvider?: AgentGuiWorkbenchComposerOverridesByProvider | null;
   conversationCount?: number | null;
   conversationRailCollapsed?: boolean | null;
@@ -41,18 +47,21 @@ export interface AgentGuiWorkbenchNodeState {
   /** @deprecated Conversation titles are derived from the active session id. */
   lastActiveConversationTitle?: string | null;
   provider: AgentGuiWorkbenchProvider;
+  agentTargetId?: string | null;
   providerTargetId?: string | null;
   providerTargetRef?: AgentGUIProviderTargetRef | null;
 }
 
 export interface AgentGuiWorkbenchState {
   composerOverrides?: AgentGuiWorkbenchComposerOverrides | null;
+  composerOverridesByAgentTargetId?: AgentGuiWorkbenchComposerOverridesByAgentTargetId | null;
   composerOverridesByProvider?: AgentGuiWorkbenchComposerOverridesByProvider | null;
   conversationRailCollapsed?: boolean | null;
   conversationRailWidthPx?: number | null;
   lastActiveAgentSessionId: string | null;
   /** @deprecated Conversation titles are derived from the active session id. */
   lastActiveConversationTitle?: string | null;
+  agentTargetId?: string | null;
   providerTargetId?: string | null;
   providerTargetRef?: AgentGUIProviderTargetRef | null;
 }

--- a/packages/clients/tuttid-ts/src/generated/types.gen.ts
+++ b/packages/clients/tuttid-ts/src/generated/types.gen.ts
@@ -1100,6 +1100,10 @@ export type AgentProviderStatusListResponse = {
 
 export type WorkspaceAgentSession = {
   id: string;
+  /**
+   * Agent target that authorized this session launch. Historical or imported provider-only sessions may omit it.
+   */
+  agentTargetId?: string | null;
   provider: WorkspaceAgentProvider;
   providerSessionId?: string | null;
   cwd: string | null;
@@ -1300,6 +1304,10 @@ export type UpdateWorkspaceAgentSessionVisibilityRequest = {
 
 export type CreateWorkspaceAgentSessionRequest = {
   agentSessionId: string;
+  /**
+   * Preferred target-first session launch authority. When present, the daemon derives provider from the stored agent target launchRef and rejects mismatched provider values.
+   */
+  agentTargetId?: string | null;
   provider: WorkspaceAgentProvider;
   initialContent: Array<AgentPromptContentBlock>;
   /**
@@ -1450,6 +1458,7 @@ export type SubmitWorkspaceAgentInteractiveRequest = {
 export type WorkspaceAgentSessionEventEnvelope = {
   seq: number;
   agentSessionId: string;
+  agentTargetId?: string | null;
   type: string;
   occurredAt: string;
   payload: {

--- a/packages/clients/tuttid-ts/src/generated/types.gen.ts
+++ b/packages/clients/tuttid-ts/src/generated/types.gen.ts
@@ -1308,7 +1308,7 @@ export type CreateWorkspaceAgentSessionRequest = {
    * Preferred target-first session launch authority. When present, the daemon derives provider from the stored agent target launchRef and rejects mismatched provider values.
    */
   agentTargetId?: string | null;
-  provider: WorkspaceAgentProvider;
+  provider?: WorkspaceAgentProvider;
   initialContent: Array<AgentPromptContentBlock>;
   /**
    * Optional display-only text for the first turn (e.g. a folder bundle shown as one chip while initialContent carries the expanded files).

--- a/packages/clients/tuttid-ts/src/index.test.ts
+++ b/packages/clients/tuttid-ts/src/index.test.ts
@@ -125,7 +125,7 @@ test("shared tuttid client unwraps agent target responses", async () => {
         JSON.stringify({
           targets: [
             {
-              id: "local-codex",
+              id: "local:codex",
               provider: "codex",
               launchRef: {
                 type: "local_cli",
@@ -152,7 +152,7 @@ test("shared tuttid client unwraps agent target responses", async () => {
   assert.deepEqual(await client.listAgentTargets(), {
     targets: [
       {
-        id: "local-codex",
+        id: "local:codex",
         provider: "codex",
         launchRef: {
           type: "local_cli",

--- a/packages/clients/tuttid-ts/src/index.test.ts
+++ b/packages/clients/tuttid-ts/src/index.test.ts
@@ -14,6 +14,7 @@ import {
   type AgentProviderComposerOptionsResponse,
   type AppReferenceListResponse,
   type CliCapabilitiesResponse,
+  type CreateWorkspaceAgentSessionRequest,
   type IssueManagerReferenceSearchResponse,
   type ListAgentTargetsResponse,
   type ListWorkspacesResponse,
@@ -21,6 +22,16 @@ import {
   type WorkspaceGitPatchSupportResponse,
   type WorkspaceGitPatchResponse
 } from "./index.ts";
+
+test("create workspace agent session request supports target-only authority", () => {
+  const request = {
+    agentSessionId: "11111111-1111-4111-8111-111111111111",
+    agentTargetId: "local:codex",
+    initialContent: [{ type: "text", text: "hello" }]
+  } satisfies CreateWorkspaceAgentSessionRequest;
+
+  assert.equal(request.agentTargetId, "local:codex");
+});
 
 test("generated tuttid client returns parsed health response", async () => {
   const client = createClient({

--- a/packages/events/protocol/definitions/agent/activity.updated.event.json
+++ b/packages/events/protocol/definitions/agent/activity.updated.event.json
@@ -44,6 +44,9 @@
                 "type": "string",
                 "minLength": 1
               },
+              "agentTargetId": {
+                "type": "string"
+              },
               "eventType": {
                 "const": "session_update"
               },
@@ -273,6 +276,9 @@
               "provider": {
                 "type": "string"
               },
+              "agentTargetId": {
+                "type": "string"
+              },
               "providerSessionId": {
                 "type": "string"
               },
@@ -341,6 +347,9 @@
       "agentSessionId": {
         "type": "string",
         "minLength": 1
+      },
+      "agentTargetId": {
+        "type": "string"
       },
       "eventType": {
         "type": "string",

--- a/packages/events/protocol/src/generated/contracts.ts
+++ b/packages/events/protocol/src/generated/contracts.ts
@@ -193,6 +193,7 @@ export type AgentActivityUpdatedPayloadV1 =
       data: {
         workspaceId: string;
         agentSessionId: string;
+        agentTargetId?: string;
         eventType: "session_update";
         lastEventUnixMs: number;
       };
@@ -247,6 +248,7 @@ export type AgentActivityUpdatedPayloadV1 =
         lastEventUnixMs: number;
         occurredAtUnixMs?: number;
         provider?: string;
+        agentTargetId?: string;
         providerSessionId?: string;
         model?: string;
         cwd?: string;

--- a/packages/events/protocol/src/generated/registry.ts
+++ b/packages/events/protocol/src/generated/registry.ts
@@ -33,7 +33,7 @@ export interface BusinessEventDefinition {
   scope: BusinessEventScopeName;
 }
 
-export const businessEventCatalogRevision = "sha256:143671a4b35668c2" as const;
+export const businessEventCatalogRevision = "sha256:00e7c0e227c0387c" as const;
 
 export const businessEventDefinitions = [
   {

--- a/packages/events/protocol/src/generated/schemas.ts
+++ b/packages/events/protocol/src/generated/schemas.ts
@@ -606,6 +606,9 @@ export const agentActivityUpdatedPayloadSchema = {
               type: "string",
               minLength: 1
             },
+            agentTargetId: {
+              type: "string"
+            },
             eventType: {
               const: "session_update"
             },
@@ -835,6 +838,9 @@ export const agentActivityUpdatedPayloadSchema = {
             provider: {
               type: "string"
             },
+            agentTargetId: {
+              type: "string"
+            },
             providerSessionId: {
               type: "string"
             },
@@ -903,6 +909,9 @@ export const agentActivityUpdatedPayloadSchema = {
     agentSessionId: {
       type: "string",
       minLength: 1
+    },
+    agentTargetId: {
+      type: "string"
     },
     eventType: {
       type: "string",

--- a/services/tuttid/agent_runtime_adapter.go
+++ b/services/tuttid/agent_runtime_adapter.go
@@ -207,6 +207,7 @@ func (a agentRuntimeAdapter) Resume(ctx context.Context, input agentservice.Runt
 	session, err := a.controller.Resume(ctx, agentruntime.ResumeInput{
 		RoomID:            input.WorkspaceID,
 		AgentSessionID:    input.AgentSessionID,
+		AgentTargetID:     input.AgentTargetID,
 		Provider:          input.Provider,
 		ProviderSessionID: input.ProviderSessionID,
 		CWD:               input.Cwd,
@@ -255,6 +256,7 @@ func (a agentRuntimeAdapter) Start(ctx context.Context, input agentservice.Runti
 	result, err := a.controller.Start(ctx, agentruntime.StartInput{
 		RoomID:            input.WorkspaceID,
 		AgentSessionID:    input.AgentSessionID,
+		AgentTargetID:     input.AgentTargetID,
 		Provider:          input.Provider,
 		CWD:               input.Cwd,
 		Env:               append([]string(nil), input.Env...),
@@ -301,6 +303,7 @@ func agentRuntimeSession(session agentruntime.Session) agentservice.RuntimeSessi
 	return agentservice.RuntimeSession{
 		ID:                 session.AgentSessionID,
 		WorkspaceID:        session.RoomID,
+		AgentTargetID:      session.AgentTargetID,
 		Provider:           session.Provider,
 		ProviderSessionID:  session.ProviderSessionID,
 		Cwd:                session.CWD,

--- a/services/tuttid/api/daemon_agent_sessions.go
+++ b/services/tuttid/api/daemon_agent_sessions.go
@@ -712,6 +712,7 @@ func generatedAgentSession(session agentservice.Session) tuttigenerated.Workspac
 	}
 	runtimeContext := clonePayloadPointer(session.RuntimeContext)
 	return tuttigenerated.WorkspaceAgentSession{
+		AgentTargetId:      optionalStringPointer(strings.TrimSpace(session.AgentTargetID)),
 		CreatedAt:          session.CreatedAt,
 		Cwd:                stringPointer(strings.TrimSpace(session.Cwd)),
 		EndedAt:            session.EndedAt,

--- a/services/tuttid/api/daemon_agent_submit_handlers.go
+++ b/services/tuttid/api/daemon_agent_submit_handlers.go
@@ -29,7 +29,8 @@ func (api DaemonAPI) CreateWorkspaceAgentSession(ctx context.Context, request tu
 	}
 	agentSessionID := request.Body.AgentSessionId.String()
 	metadata := mapValue(request.Body.Metadata)
-	logCreateAgentSubmitTrace("api.create.received", string(request.WorkspaceID), agentSessionID, metadata, string(request.Body.Provider), "", nil)
+	provider := workspaceAgentProviderString(request.Body.Provider)
+	logCreateAgentSubmitTrace("api.create.received", string(request.WorkspaceID), agentSessionID, metadata, provider, "", nil)
 	session, err := api.AgentSessionService.Create(ctx, string(request.WorkspaceID), agentservice.CreateSessionInput{
 		AgentSessionID:         agentSessionID,
 		AgentTargetID:          stringPtrValue(request.Body.AgentTargetId),
@@ -42,7 +43,7 @@ func (api DaemonAPI) CreateWorkspaceAgentSession(ctx context.Context, request tu
 		PlanMode:               request.Body.PlanMode,
 		BrowserUse:             request.Body.BrowserUse,
 		ProviderTargetRef:      mapValue(request.Body.ProviderTargetRef),
-		Provider:               string(request.Body.Provider),
+		Provider:               provider,
 		ReasoningEffort:        request.Body.ReasoningEffort,
 		Speed:                  request.Body.Speed,
 		Title:                  request.Body.Title,
@@ -57,6 +58,13 @@ func (api DaemonAPI) CreateWorkspaceAgentSession(ctx context.Context, request tu
 	return tuttigenerated.CreateWorkspaceAgentSession201JSONResponse{
 		Session: generatedAgentSession(session),
 	}, nil
+}
+
+func workspaceAgentProviderString(provider *tuttigenerated.WorkspaceAgentProvider) string {
+	if provider == nil {
+		return ""
+	}
+	return string(*provider)
 }
 
 func (api DaemonAPI) SendWorkspaceAgentSessionInput(ctx context.Context, request tuttigenerated.SendWorkspaceAgentSessionInputRequestObject) (tuttigenerated.SendWorkspaceAgentSessionInputResponseObject, error) {

--- a/services/tuttid/api/daemon_agent_submit_handlers.go
+++ b/services/tuttid/api/daemon_agent_submit_handlers.go
@@ -32,6 +32,7 @@ func (api DaemonAPI) CreateWorkspaceAgentSession(ctx context.Context, request tu
 	logCreateAgentSubmitTrace("api.create.received", string(request.WorkspaceID), agentSessionID, metadata, string(request.Body.Provider), "", nil)
 	session, err := api.AgentSessionService.Create(ctx, string(request.WorkspaceID), agentservice.CreateSessionInput{
 		AgentSessionID:         agentSessionID,
+		AgentTargetID:          stringPtrValue(request.Body.AgentTargetId),
 		Cwd:                    request.Body.Cwd,
 		InitialContent:         agentPromptContentFromGenerated(request.Body.InitialContent),
 		InitialDisplayPrompt:   stringPtrValue(request.Body.InitialDisplayPrompt),

--- a/services/tuttid/api/daemon_test.go
+++ b/services/tuttid/api/daemon_test.go
@@ -1009,6 +1009,48 @@ func TestDaemonAPIGeneratedRoutesCreateAgentSession(t *testing.T) {
 	}
 }
 
+func TestDaemonAPIGeneratedRoutesCreateAgentSessionAllowsTargetOnlyRequest(t *testing.T) {
+	createdAt := time.Date(2026, 5, 30, 8, 0, 0, 0, time.UTC)
+	mux := http.NewServeMux()
+	RegisterRoutes(mux, NewRoutes(DaemonAPI{
+		AgentSessionService: stubAgentSessionService{
+			createFn: func(_ context.Context, workspaceID string, input agentservice.CreateSessionInput) (agentservice.Session, error) {
+				if workspaceID != "ws-1" {
+					t.Fatalf("workspaceID = %q, want ws-1", workspaceID)
+				}
+				if input.AgentTargetID != agenttargetbiz.IDLocalCodex {
+					t.Fatalf("agent target id = %q, want %s", input.AgentTargetID, agenttargetbiz.IDLocalCodex)
+				}
+				if input.Provider != "" {
+					t.Fatalf("provider = %q, want empty pre-service target-only authority", input.Provider)
+				}
+				return agentservice.Session{
+					ID:            input.AgentSessionID,
+					AgentTargetID: input.AgentTargetID,
+					Provider:      "codex",
+					Status:        "created",
+					CreatedAt:     createdAt,
+				}, nil
+			},
+		},
+	}))
+
+	recorder := performGeneratedRouteRequest(t, mux, http.MethodPost, "/v1/workspaces/ws-1/agent-sessions", map[string]any{
+		"agentSessionId": "11111111-1111-4111-8111-111111111111",
+		"agentTargetId":  agenttargetbiz.IDLocalCodex,
+		"initialContent": []map[string]any{{"type": "text", "text": "hello"}},
+	})
+	if recorder.Code != http.StatusCreated {
+		t.Fatalf("status = %d, want %d; body: %s", recorder.Code, http.StatusCreated, recorder.Body.String())
+	}
+
+	var response tuttigenerated.WorkspaceAgentSessionResponse
+	decodeGeneratedRouteResponse(t, recorder, &response)
+	if response.Session.AgentTargetId == nil || *response.Session.AgentTargetId != agenttargetbiz.IDLocalCodex {
+		t.Fatalf("session agent target id = %#v, want %s", response.Session.AgentTargetId, agenttargetbiz.IDLocalCodex)
+	}
+}
+
 func TestDaemonAPIGeneratedRoutesUpdateAgentSessionPin(t *testing.T) {
 	createdAt := time.Date(2026, 5, 30, 8, 0, 0, 0, time.UTC)
 	mux := http.NewServeMux()

--- a/services/tuttid/api/events/generated/protocol.gen.go
+++ b/services/tuttid/api/events/generated/protocol.gen.go
@@ -6,7 +6,7 @@ import "encoding/json"
 
 const (
 	BusinessEventProtocolVersion = 1
-	BusinessEventCatalogRevision = "sha256:143671a4b35668c2"
+	BusinessEventCatalogRevision = "sha256:00e7c0e227c0387c"
 )
 
 type Topic string
@@ -190,10 +190,11 @@ type WorkspaceWorkspaceApp struct {
 }
 
 type AgentActivityUpdatedPayload struct {
-	WorkspaceId    string `json:"workspaceId"`
-	AgentSessionId string `json:"agentSessionId"`
-	EventType      string `json:"eventType"`
-	Data           any    `json:"data"`
+	WorkspaceId    string  `json:"workspaceId"`
+	AgentSessionId string  `json:"agentSessionId"`
+	AgentTargetId  *string `json:"agentTargetId,omitempty"`
+	EventType      string  `json:"eventType"`
+	Data           any     `json:"data"`
 }
 
 type AnalyticsDebugReportedPayload struct {

--- a/services/tuttid/api/generated/types.gen.go
+++ b/services/tuttid/api/generated/types.gen.go
@@ -2305,7 +2305,10 @@ type CreateIssueManagerTopicRequest struct {
 
 // CreateWorkspaceAgentSessionRequest defines model for CreateWorkspaceAgentSessionRequest.
 type CreateWorkspaceAgentSessionRequest struct {
-	AgentSessionId openapi_types.UUID        `json:"agentSessionId"`
+	AgentSessionId openapi_types.UUID `json:"agentSessionId"`
+
+	// AgentTargetId Preferred target-first session launch authority. When present, the daemon derives provider from the stored agent target launchRef and rejects mismatched provider values.
+	AgentTargetId  *string                   `json:"agentTargetId,omitempty"`
 	BrowserUse     *bool                     `json:"browserUse,omitempty"`
 	Cwd            *string                   `json:"cwd,omitempty"`
 	InitialContent []AgentPromptContentBlock `json:"initialContent"`
@@ -3225,6 +3228,8 @@ type WorkspaceAgentProvider string
 
 // WorkspaceAgentSession defines model for WorkspaceAgentSession.
 type WorkspaceAgentSession struct {
+	// AgentTargetId Agent target that authorized this session launch. Historical or imported provider-only sessions may omit it.
+	AgentTargetId      *string                          `json:"agentTargetId,omitempty"`
 	CreatedAt          time.Time                        `json:"createdAt"`
 	Cwd                *string                          `json:"cwd"`
 	EndedAt            *time.Time                       `json:"endedAt,omitempty"`
@@ -3274,6 +3279,7 @@ type WorkspaceAgentSessionCancelResultReason string
 // WorkspaceAgentSessionEventEnvelope defines model for WorkspaceAgentSessionEventEnvelope.
 type WorkspaceAgentSessionEventEnvelope struct {
 	AgentSessionId string                 `json:"agentSessionId"`
+	AgentTargetId  *string                `json:"agentTargetId,omitempty"`
 	OccurredAt     time.Time              `json:"occurredAt"`
 	Payload        map[string]interface{} `json:"payload"`
 	Seq            int64                  `json:"seq"`

--- a/services/tuttid/api/generated/types.gen.go
+++ b/services/tuttid/api/generated/types.gen.go
@@ -2321,7 +2321,7 @@ type CreateWorkspaceAgentSessionRequest struct {
 	Model            *string                 `json:"model,omitempty"`
 	PermissionModeId *string                 `json:"permissionModeId,omitempty"`
 	PlanMode         *bool                   `json:"planMode,omitempty"`
-	Provider         WorkspaceAgentProvider  `json:"provider"`
+	Provider         *WorkspaceAgentProvider `json:"provider,omitempty"`
 
 	// ProviderTargetRef Opaque host-owned provider target reference. It is not authority; trusted launchers must re-authenticate and resolve it before invoking a provider.
 	ProviderTargetRef *map[string]interface{} `json:"providerTargetRef,omitempty"`

--- a/services/tuttid/api/openapi/tuttid.v1.yaml
+++ b/services/tuttid/api/openapi/tuttid.v1.yaml
@@ -5915,6 +5915,10 @@ components:
         id:
           type: string
           minLength: 1
+        agentTargetId:
+          type: string
+          nullable: true
+          description: Agent target that authorized this session launch. Historical or imported provider-only sessions may omit it.
         provider:
           $ref: "#/components/schemas/WorkspaceAgentProvider"
         providerSessionId:
@@ -6457,6 +6461,10 @@ components:
           type: string
           format: uuid
           minLength: 1
+        agentTargetId:
+          type: string
+          nullable: true
+          description: Preferred target-first session launch authority. When present, the daemon derives provider from the stored agent target launchRef and rejects mismatched provider values.
         provider:
           $ref: "#/components/schemas/WorkspaceAgentProvider"
         initialContent:
@@ -6797,6 +6805,9 @@ components:
         agentSessionId:
           type: string
           minLength: 1
+        agentTargetId:
+          type: string
+          nullable: true
         type:
           type: string
           minLength: 1

--- a/services/tuttid/api/openapi/tuttid.v1.yaml
+++ b/services/tuttid/api/openapi/tuttid.v1.yaml
@@ -6454,7 +6454,6 @@ components:
       additionalProperties: false
       required:
         - agentSessionId
-        - provider
         - initialContent
       properties:
         agentSessionId:
@@ -6467,6 +6466,7 @@ components:
           description: Preferred target-first session launch authority. When present, the daemon derives provider from the stored agent target launchRef and rejects mismatched provider values.
         provider:
           $ref: "#/components/schemas/WorkspaceAgentProvider"
+          description: Legacy provider-first launch authority. Optional when agentTargetId is present; when both are present, the daemon rejects mismatches with the target launchRef-derived provider. Required when agentTargetId is absent.
         initialContent:
           type: array
           minItems: 1

--- a/services/tuttid/biz/agentactivity/activity.go
+++ b/services/tuttid/biz/agentactivity/activity.go
@@ -58,6 +58,7 @@ type Session struct {
 	ID                string
 	WorkspaceID       string
 	Origin            string
+	AgentTargetID     string
 	Provider          string
 	ProviderSessionID string
 	Model             string
@@ -81,6 +82,7 @@ type SessionStateReport struct {
 	WorkspaceID       string
 	AgentSessionID    string
 	Origin            string
+	AgentTargetID     string
 	Provider          string
 	ProviderSessionID string
 	Model             string

--- a/services/tuttid/biz/agenttarget/model.go
+++ b/services/tuttid/biz/agenttarget/model.go
@@ -84,6 +84,25 @@ func MustLocalCLILaunchRefJSON(provider string) string {
 	return raw
 }
 
+func RuntimeProviderTargetRef(target Target) (map[string]any, error) {
+	normalized, err := NormalizeTarget(target)
+	if err != nil {
+		return nil, err
+	}
+	var launchRef LaunchRef
+	if err := json.Unmarshal([]byte(normalized.LaunchRefJSON), &launchRef); err != nil {
+		return nil, fmt.Errorf("%w: %w", ErrInvalidLaunchRef, err)
+	}
+	if _, err := CanonicalLaunchRefJSON(normalized.Provider, launchRef); err != nil {
+		return nil, err
+	}
+	return map[string]any{
+		"kind":     launchRef.Type,
+		"provider": launchRef.Provider,
+		"targetId": normalized.ID,
+	}, nil
+}
+
 func NormalizeTarget(value Target) (Target, error) {
 	value.ID = strings.TrimSpace(value.ID)
 	value.Provider = normalizeFirstIterationProvider(value.Provider)

--- a/services/tuttid/biz/agenttarget/model.go
+++ b/services/tuttid/biz/agenttarget/model.go
@@ -12,8 +12,8 @@ import (
 )
 
 const (
-	IDLocalCodex      = "local-codex"
-	IDLocalClaudeCode = "local-claude-code"
+	IDLocalCodex      = "local:codex"
+	IDLocalClaudeCode = "local:claude-code"
 
 	LaunchRefTypeLocalCLI = "local_cli"
 

--- a/services/tuttid/data/workspace/agent_targets_migrations.go
+++ b/services/tuttid/data/workspace/agent_targets_migrations.go
@@ -8,6 +8,9 @@ import (
 	agenttargetbiz "github.com/tutti-os/tutti/services/tuttid/biz/agenttarget"
 )
 
+const legacyIDLocalCodex = "local-codex"
+const legacyIDLocalClaudeCode = "local-claude-code"
+
 func (s *SQLiteStore) applyAgentTargetsV1(ctx context.Context) error {
 	applied, err := s.hasMigration(ctx, schemaMigrationAgentTargetsV1)
 	if err != nil {
@@ -42,6 +45,12 @@ INSERT INTO tuttid_schema_migrations (id, applied_at_unix_ms)
 }
 
 func (s *SQLiteStore) seedSystemAgentTargets(ctx context.Context, now int64) error {
+	if err := s.reconcileLegacySystemAgentTargetID(ctx, legacyIDLocalCodex, agenttargetbiz.IDLocalCodex, now); err != nil {
+		return err
+	}
+	if err := s.reconcileLegacySystemAgentTargetID(ctx, legacyIDLocalClaudeCode, agenttargetbiz.IDLocalClaudeCode, now); err != nil {
+		return err
+	}
 	for _, target := range agenttargetbiz.DefaultSystemTargets(now) {
 		if _, err := s.db.ExecContext(ctx, `
 INSERT OR IGNORE INTO agent_targets (
@@ -60,6 +69,33 @@ VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 `, target.ID, target.Provider, target.LaunchRefJSON, target.Name, target.IconKey, target.Enabled, target.Source, target.SortOrder, target.CreatedAtUnixMS, target.UpdatedAtUnixMS); err != nil {
 			return fmt.Errorf("seed system agent target %q: %w", target.ID, err)
 		}
+	}
+	return nil
+}
+
+func (s *SQLiteStore) reconcileLegacySystemAgentTargetID(ctx context.Context, legacyID string, currentID string, now int64) error {
+	if _, err := s.db.ExecContext(ctx, `
+UPDATE workspace_agent_sessions
+SET agent_target_id = ?
+WHERE agent_target_id = ?
+`, currentID, legacyID); err != nil {
+		return fmt.Errorf("reconcile legacy agent target session id %q: %w", legacyID, err)
+	}
+	if _, err := s.db.ExecContext(ctx, `
+UPDATE agent_targets
+SET id = ?, updated_at_ms = ?
+WHERE id = ?
+  AND source = ?
+  AND NOT EXISTS (SELECT 1 FROM agent_targets WHERE id = ?)
+`, currentID, now, legacyID, agenttargetbiz.SourceSystem, currentID); err != nil {
+		return fmt.Errorf("reconcile legacy system agent target id %q: %w", legacyID, err)
+	}
+	if _, err := s.db.ExecContext(ctx, `
+DELETE FROM agent_targets
+WHERE id = ?
+  AND source = ?
+`, legacyID, agenttargetbiz.SourceSystem); err != nil {
+		return fmt.Errorf("delete legacy system agent target %q: %w", legacyID, err)
 	}
 	return nil
 }

--- a/services/tuttid/data/workspace/migrations.go
+++ b/services/tuttid/data/workspace/migrations.go
@@ -15,6 +15,7 @@ const schemaMigrationWorkspacesV4 = "workspaces_v4"
 const schemaMigrationWorkspaceAgentActivityV1 = "workspace_agent_activity_v1"
 const schemaMigrationWorkspaceAgentActivityV2 = "workspace_agent_activity_v2"
 const schemaMigrationWorkspaceAgentActivityV3 = "workspace_agent_activity_v3"
+const schemaMigrationWorkspaceAgentActivityV4 = "workspace_agent_activity_v4"
 const schemaMigrationAgentTargetsV1 = "agent_targets_v1"
 const schemaMigrationWorkspaceIssuesV1 = "workspace_issues_v1"
 const schemaMigrationWorkspaceIssuesV2 = "workspace_issues_v2"
@@ -109,6 +110,10 @@ INSERT OR IGNORE INTO tuttid_schema_migrations (id, applied_at_unix_ms)
 	}
 
 	if err := s.applyWorkspaceAgentActivityV3(ctx); err != nil {
+		return err
+	}
+
+	if err := s.applyWorkspaceAgentActivityV4(ctx); err != nil {
 		return err
 	}
 
@@ -578,6 +583,7 @@ CREATE TABLE IF NOT EXISTS workspace_agent_sessions (
   workspace_id TEXT NOT NULL,
   agent_session_id TEXT NOT NULL,
   origin TEXT NOT NULL DEFAULT '',
+  agent_target_id TEXT,
   provider TEXT NOT NULL DEFAULT '',
   provider_session_id TEXT NOT NULL DEFAULT '',
   model TEXT NOT NULL DEFAULT '',
@@ -704,6 +710,35 @@ INSERT INTO tuttid_schema_migrations (id, applied_at_unix_ms)
   VALUES (?, ?);
 `, schemaMigrationWorkspaceAgentActivityV3, now); err != nil {
 		return fmt.Errorf("record workspace agent activity v3 migration: %w", err)
+	}
+	return nil
+}
+
+func (s *SQLiteStore) applyWorkspaceAgentActivityV4(ctx context.Context) error {
+	applied, err := s.hasMigration(ctx, schemaMigrationWorkspaceAgentActivityV4)
+	if err != nil {
+		return err
+	}
+
+	hasAgentTargetID, err := s.hasColumn(ctx, "workspace_agent_sessions", "agent_target_id")
+	if err != nil {
+		return err
+	}
+
+	now := unixMs(time.Now().UTC())
+	if !hasAgentTargetID {
+		if _, err := s.db.ExecContext(ctx, `ALTER TABLE workspace_agent_sessions ADD COLUMN agent_target_id TEXT;`); err != nil {
+			return fmt.Errorf("migrate workspace agent activity to v4 agent target id: %w", err)
+		}
+	}
+	if applied {
+		return nil
+	}
+	if _, err := s.db.ExecContext(ctx, `
+INSERT INTO tuttid_schema_migrations (id, applied_at_unix_ms)
+  VALUES (?, ?);
+`, schemaMigrationWorkspaceAgentActivityV4, now); err != nil {
+		return fmt.Errorf("record workspace agent activity v4 migration: %w", err)
 	}
 	return nil
 }

--- a/services/tuttid/data/workspace/sqlite_agent_activity.go
+++ b/services/tuttid/data/workspace/sqlite_agent_activity.go
@@ -138,7 +138,7 @@ func (s *SQLiteStore) GetSession(
 		return agentactivitybiz.Session{}, false, nil
 	}
 	row := s.db.QueryRowContext(ctx, `
-SELECT workspace_id, agent_session_id, origin, provider, provider_session_id, model,
+SELECT workspace_id, agent_session_id, origin, agent_target_id, provider, provider_session_id, model,
        settings_json, runtime_context_json, cwd,
        title, status, current_phase, last_error, message_version, last_event_at_unix_ms,
        started_at_unix_ms, ended_at_unix_ms, pinned_at_unix_ms,
@@ -168,7 +168,7 @@ func (s *SQLiteStore) ListSessions(
 		return nil, false, nil
 	}
 	rows, err := s.db.QueryContext(ctx, `
-SELECT workspace_id, agent_session_id, origin, provider, provider_session_id, model,
+SELECT workspace_id, agent_session_id, origin, agent_target_id, provider, provider_session_id, model,
        settings_json, runtime_context_json, cwd,
        title, status, current_phase, last_error, message_version, last_event_at_unix_ms,
        started_at_unix_ms, ended_at_unix_ms, pinned_at_unix_ms,
@@ -579,6 +579,7 @@ func upsertAgentSessionTx(
 			WorkspaceID:       workspaceID,
 			AgentSessionID:    agentSessionID,
 			Origin:            input.Origin,
+			AgentTargetID:     input.AgentTargetID,
 			Provider:          input.Provider,
 			ProviderSessionID: input.ProviderSessionID,
 			Model:             input.Model,
@@ -609,13 +610,14 @@ func upsertAgentSessionTx(
 	}
 	result, err := tx.ExecContext(ctx, `
 INSERT INTO workspace_agent_sessions (
-  workspace_id, agent_session_id, origin, provider, provider_session_id, model,
+  workspace_id, agent_session_id, origin, agent_target_id, provider, provider_session_id, model,
   settings_json, runtime_context_json, cwd,
   title, status, current_phase, last_error, last_event_at_unix_ms, started_at_unix_ms,
   ended_at_unix_ms, created_at_unix_ms, updated_at_unix_ms
-) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 ON CONFLICT(workspace_id, agent_session_id) DO UPDATE SET
   origin = excluded.origin,
+  agent_target_id = excluded.agent_target_id,
   provider = excluded.provider,
   provider_session_id = excluded.provider_session_id,
   model = excluded.model,
@@ -632,7 +634,7 @@ ON CONFLICT(workspace_id, agent_session_id) DO UPDATE SET
   deleted_at_unix_ms = 0,
   updated_at_unix_ms = excluded.updated_at_unix_ms
 WHERE workspace_agent_sessions.deleted_at_unix_ms = 0
-	`, session.WorkspaceID, session.AgentSessionID, session.Origin, session.Provider,
+	`, session.WorkspaceID, session.AgentSessionID, session.Origin, nullString(session.AgentTargetID), session.Provider,
 		session.ProviderSessionID, session.Model, settingsJSON, runtimeContextJSON,
 		session.CWD, session.Title,
 		session.Status, session.CurrentPhase, session.LastError, session.LastEventUnixMS,
@@ -655,7 +657,7 @@ func getAgentSessionForUpdate(
 	agentSessionID string,
 ) (agentactivityprojection.SessionSnapshot, bool, error) {
 	row := tx.QueryRowContext(ctx, `
-SELECT workspace_id, agent_session_id, origin, provider, provider_session_id, model,
+SELECT workspace_id, agent_session_id, origin, agent_target_id, provider, provider_session_id, model,
        settings_json, runtime_context_json, cwd,
        title, status, current_phase, last_error, message_version, last_event_at_unix_ms,
        started_at_unix_ms, ended_at_unix_ms, created_at_unix_ms, updated_at_unix_ms,
@@ -664,12 +666,14 @@ FROM workspace_agent_sessions
 WHERE workspace_id = ? AND agent_session_id = ?
 `, workspaceID, agentSessionID)
 	var session agentactivityprojection.SessionSnapshot
+	var agentTargetID sql.NullString
 	var settingsJSON string
 	var runtimeContextJSON string
 	err := row.Scan(
 		&session.WorkspaceID,
 		&session.AgentSessionID,
 		&session.Origin,
+		&agentTargetID,
 		&session.Provider,
 		&session.ProviderSessionID,
 		&session.Model,
@@ -697,6 +701,7 @@ WHERE workspace_id = ? AND agent_session_id = ?
 	if session.Settings, err = unmarshalJSONMap(settingsJSON); err != nil {
 		return agentactivityprojection.SessionSnapshot{}, false, fmt.Errorf("decode workspace agent session settings: %w", err)
 	}
+	session.AgentTargetID = strings.TrimSpace(agentTargetID.String)
 	if session.RuntimeContext, err = unmarshalJSONMap(runtimeContextJSON); err != nil {
 		return agentactivityprojection.SessionSnapshot{}, false, fmt.Errorf("decode workspace agent session runtime context: %w", err)
 	}
@@ -709,12 +714,14 @@ type rowScanner interface {
 
 func scanAgentSession(scanner rowScanner) (agentactivitybiz.Session, error) {
 	var session agentactivitybiz.Session
+	var agentTargetID sql.NullString
 	var settingsJSON string
 	var runtimeContextJSON string
 	err := scanner.Scan(
 		&session.WorkspaceID,
 		&session.ID,
 		&session.Origin,
+		&agentTargetID,
 		&session.Provider,
 		&session.ProviderSessionID,
 		&session.Model,
@@ -739,10 +746,19 @@ func scanAgentSession(scanner rowScanner) (agentactivitybiz.Session, error) {
 	if session.Settings, err = unmarshalJSONMap(settingsJSON); err != nil {
 		return agentactivitybiz.Session{}, fmt.Errorf("decode workspace agent session settings: %w", err)
 	}
+	session.AgentTargetID = strings.TrimSpace(agentTargetID.String)
 	if session.RuntimeContext, err = unmarshalJSONMap(runtimeContextJSON); err != nil {
 		return agentactivitybiz.Session{}, fmt.Errorf("decode workspace agent session runtime context: %w", err)
 	}
 	return session, nil
+}
+
+func nullString(value string) sql.NullString {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return sql.NullString{}
+	}
+	return sql.NullString{String: value, Valid: true}
 }
 
 func marshalJSONMap(payload map[string]any) (string, error) {

--- a/services/tuttid/data/workspace/sqlite_agent_activity_projection.go
+++ b/services/tuttid/data/workspace/sqlite_agent_activity_projection.go
@@ -27,6 +27,7 @@ func projectionSessionToBiz(session agentactivityprojection.SessionSnapshot) age
 		ID:                session.AgentSessionID,
 		WorkspaceID:       session.WorkspaceID,
 		Origin:            session.Origin,
+		AgentTargetID:     session.AgentTargetID,
 		Provider:          session.Provider,
 		ProviderSessionID: session.ProviderSessionID,
 		Model:             session.Model,

--- a/services/tuttid/data/workspace/sqlite_agent_targets_test.go
+++ b/services/tuttid/data/workspace/sqlite_agent_targets_test.go
@@ -39,6 +39,73 @@ func TestSQLiteStoreSeedsSystemAgentTargets(t *testing.T) {
 	}
 }
 
+func TestSQLiteStoreSeedReconcilesLegacySystemAgentTargetIDs(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	store := openTestSQLiteStore(t)
+	now := int64(1700000000000)
+	if _, err := store.db.ExecContext(ctx, `
+INSERT INTO workspaces (id, name, created_at_unix_ms, updated_at_unix_ms)
+VALUES ('ws-legacy-targets', 'Legacy Targets', ?, ?);
+`, now, now); err != nil {
+		t.Fatalf("insert legacy workspace fixture: %v", err)
+	}
+	if _, err := store.db.ExecContext(ctx, `
+INSERT INTO agent_targets (
+  id,
+  provider,
+  launch_ref_json,
+  name,
+  icon_key,
+  enabled,
+  source,
+  sort_order,
+  created_at_ms,
+  updated_at_ms
+)
+VALUES (?, 'codex', ?, 'Legacy Codex', 'codex', 1, 'system', 10, ?, ?);
+`, legacyIDLocalCodex, agenttargetbiz.MustLocalCLILaunchRefJSON("codex"), now, now); err != nil {
+		t.Fatalf("insert legacy agent target fixture: %v", err)
+	}
+	if _, err := store.db.ExecContext(ctx, `
+INSERT INTO workspace_agent_sessions (
+  workspace_id,
+  agent_session_id,
+  origin,
+  agent_target_id,
+  provider,
+  status,
+  created_at_unix_ms,
+  updated_at_unix_ms
+)
+VALUES ('ws-legacy-targets', 'session-1', 'runtime', ?, 'codex', 'ready', ?, ?);
+`, legacyIDLocalCodex, now, now); err != nil {
+		t.Fatalf("insert legacy agent session fixture: %v", err)
+	}
+
+	if err := store.seedSystemAgentTargets(ctx, now+1); err != nil {
+		t.Fatalf("seedSystemAgentTargets() error = %v", err)
+	}
+
+	if _, err := store.GetAgentTarget(ctx, legacyIDLocalCodex); !errors.Is(err, ErrAgentTargetNotFound) {
+		t.Fatalf("GetAgentTarget(legacy) error = %v, want ErrAgentTargetNotFound", err)
+	}
+	if _, err := store.GetAgentTarget(ctx, agenttargetbiz.IDLocalCodex); err != nil {
+		t.Fatalf("GetAgentTarget(current) error = %v", err)
+	}
+	sessions, ok, err := store.ListSessions(ctx, "ws-legacy-targets")
+	if err != nil {
+		t.Fatalf("ListSessions() error = %v", err)
+	}
+	if !ok || len(sessions) != 1 {
+		t.Fatalf("ListSessions() ok/len = %v/%d, want true/1", ok, len(sessions))
+	}
+	if sessions[0].AgentTargetID != agenttargetbiz.IDLocalCodex {
+		t.Fatalf("session agent target id = %q, want %s", sessions[0].AgentTargetID, agenttargetbiz.IDLocalCodex)
+	}
+}
+
 func TestSQLiteStorePutAgentTargetRejectsInvalidLaunchRefs(t *testing.T) {
 	t.Parallel()
 

--- a/services/tuttid/data/workspace/sqlite_store_test.go
+++ b/services/tuttid/data/workspace/sqlite_store_test.go
@@ -2,6 +2,7 @@ package workspace
 
 import (
 	"context"
+	"database/sql"
 	"errors"
 	"path/filepath"
 	"strings"
@@ -38,6 +39,48 @@ func TestSQLiteStoreMigrationDropsLegacyLocalPathColumn(t *testing.T) {
 	}
 	if hasLocalPath {
 		t.Fatal("expected local_path column to be removed")
+	}
+}
+
+func TestSQLiteStoreMigrationRepairsAgentTargetIDColumnWhenMarkerExists(t *testing.T) {
+	t.Parallel()
+
+	dbPath := filepath.Join(t.TempDir(), "tuttid.db")
+	createLegacyAgentActivityV4MarkedDatabaseWithoutAgentTargetID(t, dbPath)
+
+	store, err := OpenSQLiteStore(dbPath)
+	if err != nil {
+		t.Fatalf("OpenSQLiteStore() error = %v", err)
+	}
+	t.Cleanup(func() {
+		_ = store.Close()
+	})
+
+	ctx := context.Background()
+	if err := store.Migrate(ctx); err != nil {
+		t.Fatalf("Migrate() error = %v", err)
+	}
+
+	hasAgentTargetID, err := store.hasColumn(ctx, "workspace_agent_sessions", "agent_target_id")
+	if err != nil {
+		t.Fatalf("hasColumn() error = %v", err)
+	}
+	if !hasAgentTargetID {
+		t.Fatal("agent_target_id column was not repaired")
+	}
+
+	sessions, ok, err := store.ListSessions(ctx, "ws-legacy-agent-target-id")
+	if err != nil {
+		t.Fatalf("ListSessions() error = %v", err)
+	}
+	if !ok {
+		t.Fatal("ListSessions() ok = false, want true")
+	}
+	if len(sessions) != 1 {
+		t.Fatalf("ListSessions() len = %d, want 1", len(sessions))
+	}
+	if sessions[0].AgentTargetID != "" {
+		t.Fatalf("AgentTargetID = %q, want empty legacy value", sessions[0].AgentTargetID)
 	}
 }
 
@@ -396,6 +439,70 @@ func TestSQLiteStoreReportAndListAgentActivityMessages(t *testing.T) {
 	}
 	if !ok || len(older.Messages) != 1 || older.Messages[0].Version != 2 {
 		t.Fatalf("older page = %#v ok=%v", older, ok)
+	}
+}
+
+func TestSQLiteStorePreservesAgentTargetIDAcrossStateReports(t *testing.T) {
+	t.Parallel()
+
+	store := openTestSQLiteStore(t)
+	ctx := context.Background()
+
+	if err := store.Create(ctx, workspacebiz.Summary{
+		ID:   "ws-agent-target-activity",
+		Name: "Workspace Agent Target Activity",
+	}); err != nil {
+		t.Fatalf("Create() error = %v", err)
+	}
+
+	if _, err := store.ReportSessionState(ctx, agentactivitybiz.SessionStateReport{
+		WorkspaceID:       "ws-agent-target-activity",
+		AgentSessionID:    "session-1",
+		AgentTargetID:     "local:codex",
+		Origin:            agentsessionstore.WorkspaceAgentSessionOriginRuntime,
+		Provider:          "codex",
+		ProviderSessionID: "provider-session-1",
+		Cwd:               "/workspace",
+		Title:             "target session",
+		Status:            "running",
+		OccurredAtUnixMS:  100,
+		StartedAtUnixMS:   90,
+	}); err != nil {
+		t.Fatalf("ReportSessionState(with target) error = %v", err)
+	}
+	if _, err := store.ReportSessionState(ctx, agentactivitybiz.SessionStateReport{
+		WorkspaceID:      "ws-agent-target-activity",
+		AgentSessionID:   "session-1",
+		Origin:           agentsessionstore.WorkspaceAgentSessionOriginRuntime,
+		Provider:         "codex",
+		Cwd:              "/workspace",
+		Title:            "target session",
+		Status:           "ready",
+		OccurredAtUnixMS: 200,
+		StartedAtUnixMS:  90,
+	}); err != nil {
+		t.Fatalf("ReportSessionState(without target) error = %v", err)
+	}
+
+	session, ok, err := store.GetSession(ctx, "ws-agent-target-activity", "session-1")
+	if err != nil {
+		t.Fatalf("GetSession() error = %v", err)
+	}
+	if !ok {
+		t.Fatal("GetSession() ok = false, want true")
+	}
+	if session.AgentTargetID != "local:codex" {
+		t.Fatalf("GetSession() agent target id = %q, want local:codex", session.AgentTargetID)
+	}
+	sessions, ok, err := store.ListSessions(ctx, "ws-agent-target-activity")
+	if err != nil {
+		t.Fatalf("ListSessions() error = %v", err)
+	}
+	if !ok || len(sessions) != 1 {
+		t.Fatalf("ListSessions() ok=%v len=%d, want one session", ok, len(sessions))
+	}
+	if sessions[0].AgentTargetID != "local:codex" {
+		t.Fatalf("ListSessions() agent target id = %q, want local:codex", sessions[0].AgentTargetID)
 	}
 }
 
@@ -1390,4 +1497,114 @@ func openTestSQLiteStore(t *testing.T) *SQLiteStore {
 	}
 
 	return store
+}
+
+func createLegacyAgentActivityV4MarkedDatabaseWithoutAgentTargetID(t *testing.T, dbPath string) {
+	t.Helper()
+
+	db, err := sql.Open("sqlite", dbPath)
+	if err != nil {
+		t.Fatalf("open legacy db: %v", err)
+	}
+	defer db.Close()
+
+	_, err = db.Exec(`
+CREATE TABLE tuttid_schema_migrations (
+  id TEXT PRIMARY KEY,
+  applied_at_unix_ms INTEGER NOT NULL
+);
+INSERT INTO tuttid_schema_migrations (id, applied_at_unix_ms) VALUES
+  ('workspaces_v1', 1),
+  ('workspaces_v2', 1),
+  ('workspaces_v3', 1),
+  ('workspaces_v4', 1),
+  ('workspace_agent_activity_v1', 1),
+  ('workspace_agent_activity_v2', 1),
+  ('workspace_agent_activity_v3', 1),
+  ('workspace_agent_activity_v4', 1);
+
+CREATE TABLE workspaces (
+  id TEXT PRIMARY KEY,
+  name TEXT NOT NULL,
+  created_at_unix_ms INTEGER NOT NULL,
+  updated_at_unix_ms INTEGER NOT NULL,
+  last_opened_at_unix_ms INTEGER
+);
+INSERT INTO workspaces (id, name, created_at_unix_ms, updated_at_unix_ms, last_opened_at_unix_ms)
+VALUES ('ws-legacy-agent-target-id', 'Legacy Agent Target ID', 1, 1, 1);
+
+CREATE TABLE workspace_workbench_snapshots (
+  workspace_id TEXT PRIMARY KEY,
+  schema_version INTEGER NOT NULL,
+  snapshot_json TEXT NOT NULL,
+  created_at_unix_ms INTEGER NOT NULL,
+  updated_at_unix_ms INTEGER NOT NULL,
+  FOREIGN KEY (workspace_id) REFERENCES workspaces(id) ON DELETE CASCADE
+);
+
+CREATE TABLE workspace_agent_sessions (
+  workspace_id TEXT NOT NULL,
+  agent_session_id TEXT NOT NULL,
+  origin TEXT NOT NULL DEFAULT '',
+  provider TEXT NOT NULL DEFAULT '',
+  provider_session_id TEXT NOT NULL DEFAULT '',
+  model TEXT NOT NULL DEFAULT '',
+  settings_json TEXT NOT NULL DEFAULT '{}',
+  runtime_context_json TEXT NOT NULL DEFAULT '{}',
+  cwd TEXT NOT NULL DEFAULT '',
+  title TEXT NOT NULL DEFAULT '',
+  status TEXT NOT NULL DEFAULT '',
+  current_phase TEXT NOT NULL DEFAULT '',
+  last_error TEXT NOT NULL DEFAULT '',
+  message_version INTEGER NOT NULL DEFAULT 0,
+  last_event_at_unix_ms INTEGER NOT NULL DEFAULT 0,
+  started_at_unix_ms INTEGER NOT NULL DEFAULT 0,
+  ended_at_unix_ms INTEGER NOT NULL DEFAULT 0,
+  deleted_at_unix_ms INTEGER NOT NULL DEFAULT 0,
+  created_at_unix_ms INTEGER NOT NULL,
+  updated_at_unix_ms INTEGER NOT NULL,
+  pinned_at_unix_ms INTEGER NOT NULL DEFAULT 0,
+  PRIMARY KEY (workspace_id, agent_session_id),
+  FOREIGN KEY (workspace_id) REFERENCES workspaces(id) ON DELETE CASCADE
+);
+INSERT INTO workspace_agent_sessions (
+  workspace_id, agent_session_id, origin, provider, provider_session_id, model,
+  settings_json, runtime_context_json, cwd, title, status, current_phase,
+  last_error, message_version, last_event_at_unix_ms, started_at_unix_ms,
+  ended_at_unix_ms, deleted_at_unix_ms, created_at_unix_ms, updated_at_unix_ms,
+  pinned_at_unix_ms
+) VALUES (
+  'ws-legacy-agent-target-id', 'session-legacy', 'runtime', 'codex', 'provider-session-legacy', '',
+  '{}', '{}', '/', 'Legacy Session', 'running', 'idle',
+  '', 0, 1, 1,
+  0, 0, 1, 1,
+  0
+);
+
+CREATE TABLE workspace_agent_messages (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  workspace_id TEXT NOT NULL,
+  agent_session_id TEXT NOT NULL,
+  message_id TEXT NOT NULL,
+  version INTEGER NOT NULL,
+  turn_id TEXT NOT NULL DEFAULT '',
+  role TEXT NOT NULL DEFAULT '',
+  kind TEXT NOT NULL DEFAULT '',
+  status TEXT NOT NULL DEFAULT '',
+  payload_json TEXT NOT NULL DEFAULT '{}',
+  occurred_at_unix_ms INTEGER NOT NULL DEFAULT 0,
+  started_at_unix_ms INTEGER NOT NULL DEFAULT 0,
+  completed_at_unix_ms INTEGER NOT NULL DEFAULT 0,
+  deleted_at_unix_ms INTEGER NOT NULL DEFAULT 0,
+  created_at_unix_ms INTEGER NOT NULL,
+  updated_at_unix_ms INTEGER NOT NULL,
+  UNIQUE (workspace_id, agent_session_id, message_id),
+  FOREIGN KEY (workspace_id, agent_session_id)
+    REFERENCES workspace_agent_sessions(workspace_id, agent_session_id)
+    ON DELETE CASCADE
+);
+`)
+	if err != nil {
+		t.Fatalf("create legacy agent activity database: %v", err)
+	}
 }

--- a/services/tuttid/service/agent/activity_projection.go
+++ b/services/tuttid/service/agent/activity_projection.go
@@ -7,7 +7,6 @@ import (
 	"time"
 
 	agentsessionstore "github.com/tutti-os/tutti/packages/agentactivity/daemon/activity"
-	agentactivityprojection "github.com/tutti-os/tutti/packages/agentactivity/daemon/activity/projection"
 	agentactivitybiz "github.com/tutti-os/tutti/services/tuttid/biz/agentactivity"
 	reporterservice "github.com/tutti-os/tutti/services/tuttid/service/reporter"
 	agentnoderesult "github.com/tutti-os/tutti/services/tuttid/service/reporter/events/agent/node_result"
@@ -122,6 +121,7 @@ func (p *ActivityProjection) ReportSessionState(
 		WorkspaceID:       strings.TrimSpace(input.WorkspaceID),
 		AgentSessionID:    strings.TrimSpace(input.AgentSessionID),
 		Origin:            strings.TrimSpace(input.SessionOrigin),
+		AgentTargetID:     strings.TrimSpace(firstNonEmptyString(input.State.AgentTargetID, input.Source.AgentTargetID)),
 		Provider:          strings.TrimSpace(firstNonEmptyString(input.State.Provider, input.Source.Provider)),
 		ProviderSessionID: strings.TrimSpace(firstNonEmptyString(input.State.ProviderSessionID, input.Source.ProviderSessionID)),
 		Model:             strings.TrimSpace(input.State.Model),
@@ -160,7 +160,12 @@ func (p *ActivityProjection) ReportSessionState(
 				input.WorkspaceID,
 				input.AgentSessionID,
 				"session_update",
-				activitySessionUpdateEventPayload(input.WorkspaceID, input.AgentSessionID, result.LastEventUnixMS),
+				activitySessionUpdateEventPayload(
+					input.WorkspaceID,
+					input.AgentSessionID,
+					result.LastEventUnixMS,
+					firstNonEmptyString(input.State.AgentTargetID, input.Source.AgentTargetID),
+				),
 			)
 		}
 		if result.StateApplied {
@@ -207,6 +212,9 @@ func activityStatePatchEventPayload(
 	}
 	if provider := strings.TrimSpace(firstNonEmptyString(state.Provider, input.Source.Provider)); provider != "" {
 		payload["provider"] = provider
+	}
+	if agentTargetID := strings.TrimSpace(firstNonEmptyString(state.AgentTargetID, input.Source.AgentTargetID)); agentTargetID != "" {
+		payload["agentTargetId"] = agentTargetID
 	}
 	if providerSessionID := strings.TrimSpace(firstNonEmptyString(state.ProviderSessionID, input.Source.ProviderSessionID)); providerSessionID != "" {
 		payload["providerSessionId"] = providerSessionID
@@ -266,16 +274,22 @@ func sessionStateTitle(state agentsessionstore.WorkspaceAgentSessionStateUpdate)
 	)
 }
 
-func activitySessionUpdateEventPayload(workspaceID string, agentSessionID string, lastEventUnixMS int64) map[string]any {
+func activitySessionUpdateEventPayload(workspaceID string, agentSessionID string, lastEventUnixMS int64, agentTargetID ...string) map[string]any {
 	if lastEventUnixMS <= 0 {
 		lastEventUnixMS = time.Now().UnixMilli()
 	}
-	return map[string]any{
+	payload := map[string]any{
 		"agentSessionId":  strings.TrimSpace(agentSessionID),
 		"eventType":       "session_update",
 		"lastEventUnixMs": lastEventUnixMS,
 		"workspaceId":     strings.TrimSpace(workspaceID),
 	}
+	if len(agentTargetID) > 0 {
+		if value := strings.TrimSpace(agentTargetID[0]); value != "" {
+			payload["agentTargetId"] = value
+		}
+	}
+	return payload
 }
 
 func activitySessionDeletedEventPayload(workspaceID string, agentSessionID string) map[string]any {
@@ -766,60 +780,6 @@ func activityMessagesEventPayload(messages []agentactivitybiz.Message) []map[str
 			item["updatedAtUnixMs"] = message.UpdatedAtUnixMS
 		}
 		out = append(out, item)
-	}
-	return out
-}
-
-func persistedSessionFromActivity(session agentactivitybiz.Session) PersistedSession {
-	return PersistedSession{
-		ID:                strings.TrimSpace(session.ID),
-		WorkspaceID:       strings.TrimSpace(session.WorkspaceID),
-		Origin:            strings.TrimSpace(session.Origin),
-		Provider:          strings.TrimSpace(session.Provider),
-		ProviderSessionID: strings.TrimSpace(session.ProviderSessionID),
-		Cwd:               strings.TrimSpace(session.Cwd),
-		Settings:          composerSettingsFromPayload(session.Settings),
-		RuntimeContext:    clonePayload(session.RuntimeContext),
-		Status:            agentActivitySessionStatus(session),
-		CurrentPhase:      strings.TrimSpace(session.CurrentPhase),
-		Visible:           visibleFromRuntimeContext(session.RuntimeContext, true),
-		Title:             strings.TrimSpace(session.Title),
-		LastError:         strings.TrimSpace(session.LastError),
-		PinnedAtUnixMS:    session.PinnedAtUnixMS,
-		LastEventUnixMS:   session.LastEventUnixMS,
-		StartedAtUnixMS:   session.StartedAtUnixMS,
-		EndedAtUnixMS:     session.EndedAtUnixMS,
-		CreatedAtUnixMS:   session.CreatedAtUnixMS,
-		UpdatedAtUnixMS:   session.UpdatedAtUnixMS,
-	}
-}
-
-func agentActivitySessionStatus(session agentactivitybiz.Session) string {
-	return agentactivityprojection.CanonicalSessionStatus(session.Status, session.CurrentPhase)
-}
-
-func sessionMessagesFromActivity(messages []agentactivitybiz.Message) []SessionMessage {
-	if len(messages) == 0 {
-		return nil
-	}
-	out := make([]SessionMessage, 0, len(messages))
-	for _, message := range messages {
-		out = append(out, SessionMessage{
-			ID:                message.ID,
-			AgentSessionID:    strings.TrimSpace(message.AgentSessionID),
-			MessageID:         strings.TrimSpace(message.MessageID),
-			TurnID:            strings.TrimSpace(message.TurnID),
-			Role:              strings.TrimSpace(message.Role),
-			Kind:              strings.TrimSpace(message.Kind),
-			Status:            strings.TrimSpace(message.Status),
-			Payload:           message.Payload,
-			OccurredAtUnixMS:  message.OccurredAtUnixMS,
-			StartedAtUnixMS:   message.StartedAtUnixMS,
-			CompletedAtUnixMS: message.CompletedAtUnixMS,
-			CreatedAtUnixMS:   message.CreatedAtUnixMS,
-			UpdatedAtUnixMS:   message.UpdatedAtUnixMS,
-			Version:           message.Version,
-		})
 	}
 	return out
 }

--- a/services/tuttid/service/agent/activity_projection_session.go
+++ b/services/tuttid/service/agent/activity_projection_session.go
@@ -1,0 +1,63 @@
+package agent
+
+import (
+	"strings"
+
+	agentactivityprojection "github.com/tutti-os/tutti/packages/agentactivity/daemon/activity/projection"
+	agentactivitybiz "github.com/tutti-os/tutti/services/tuttid/biz/agentactivity"
+)
+
+func persistedSessionFromActivity(session agentactivitybiz.Session) PersistedSession {
+	return PersistedSession{
+		ID:                strings.TrimSpace(session.ID),
+		WorkspaceID:       strings.TrimSpace(session.WorkspaceID),
+		Origin:            strings.TrimSpace(session.Origin),
+		AgentTargetID:     strings.TrimSpace(session.AgentTargetID),
+		Provider:          strings.TrimSpace(session.Provider),
+		ProviderSessionID: strings.TrimSpace(session.ProviderSessionID),
+		Cwd:               strings.TrimSpace(session.Cwd),
+		Settings:          composerSettingsFromPayload(session.Settings),
+		RuntimeContext:    clonePayload(session.RuntimeContext),
+		Status:            agentActivitySessionStatus(session),
+		CurrentPhase:      strings.TrimSpace(session.CurrentPhase),
+		Visible:           visibleFromRuntimeContext(session.RuntimeContext, true),
+		Title:             strings.TrimSpace(session.Title),
+		LastError:         strings.TrimSpace(session.LastError),
+		PinnedAtUnixMS:    session.PinnedAtUnixMS,
+		LastEventUnixMS:   session.LastEventUnixMS,
+		StartedAtUnixMS:   session.StartedAtUnixMS,
+		EndedAtUnixMS:     session.EndedAtUnixMS,
+		CreatedAtUnixMS:   session.CreatedAtUnixMS,
+		UpdatedAtUnixMS:   session.UpdatedAtUnixMS,
+	}
+}
+
+func agentActivitySessionStatus(session agentactivitybiz.Session) string {
+	return agentactivityprojection.CanonicalSessionStatus(session.Status, session.CurrentPhase)
+}
+
+func sessionMessagesFromActivity(messages []agentactivitybiz.Message) []SessionMessage {
+	if len(messages) == 0 {
+		return nil
+	}
+	out := make([]SessionMessage, 0, len(messages))
+	for _, message := range messages {
+		out = append(out, SessionMessage{
+			ID:                message.ID,
+			AgentSessionID:    strings.TrimSpace(message.AgentSessionID),
+			MessageID:         strings.TrimSpace(message.MessageID),
+			TurnID:            strings.TrimSpace(message.TurnID),
+			Role:              strings.TrimSpace(message.Role),
+			Kind:              strings.TrimSpace(message.Kind),
+			Status:            strings.TrimSpace(message.Status),
+			Payload:           message.Payload,
+			OccurredAtUnixMS:  message.OccurredAtUnixMS,
+			StartedAtUnixMS:   message.StartedAtUnixMS,
+			CompletedAtUnixMS: message.CompletedAtUnixMS,
+			CreatedAtUnixMS:   message.CreatedAtUnixMS,
+			UpdatedAtUnixMS:   message.UpdatedAtUnixMS,
+			Version:           message.Version,
+		})
+	}
+	return out
+}

--- a/services/tuttid/service/agent/service.go
+++ b/services/tuttid/service/agent/service.go
@@ -2,14 +2,18 @@ package agent
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
+	"fmt"
 	"log/slog"
 	"sort"
 	"strings"
 	"time"
 
 	"github.com/google/uuid"
+	agenttargetbiz "github.com/tutti-os/tutti/services/tuttid/biz/agenttarget"
 	preferencesbiz "github.com/tutti-os/tutti/services/tuttid/biz/preferences"
+	workspacedata "github.com/tutti-os/tutti/services/tuttid/data/workspace"
 	agentsidecarservice "github.com/tutti-os/tutti/services/tuttid/service/agentsidecar"
 )
 
@@ -90,7 +94,11 @@ func (s *Service) ListFiltered(ctx context.Context, workspaceID string, input Li
 
 func (s *Service) Create(ctx context.Context, workspaceID string, input CreateSessionInput) (Session, error) {
 	workspaceID = strings.TrimSpace(workspaceID)
-	provider := strings.TrimSpace(input.Provider)
+	input.AgentTargetID = strings.TrimSpace(input.AgentTargetID)
+	provider, err := s.resolveCreateSessionProvider(ctx, input)
+	if err != nil {
+		return Session{}, err
+	}
 	if workspaceID == "" || provider == "" {
 		return Session{}, ErrInvalidArgument
 	}
@@ -172,6 +180,7 @@ func (s *Service) Create(ctx context.Context, workspaceID string, input CreateSe
 	session, err := s.controller().Start(ctx, RuntimeStartInput{
 		WorkspaceID:      workspaceID,
 		AgentSessionID:   strings.TrimSpace(input.AgentSessionID),
+		AgentTargetID:    input.AgentTargetID,
 		Provider:         provider,
 		Cwd:              prepared.Cwd,
 		Env:              prepared.Env,
@@ -264,6 +273,43 @@ func (s *Service) Create(ctx context.Context, workspaceID string, input CreateSe
 	), nil
 }
 
+func (s *Service) resolveCreateSessionProvider(ctx context.Context, input CreateSessionInput) (string, error) {
+	requestProvider := strings.TrimSpace(input.Provider)
+	agentTargetID := strings.TrimSpace(input.AgentTargetID)
+	if agentTargetID == "" {
+		return requestProvider, nil
+	}
+	if s.AgentTargetStore == nil {
+		return "", fmt.Errorf("%w: agent target store is unavailable", ErrInvalidArgument)
+	}
+	target, err := s.AgentTargetStore.GetAgentTarget(ctx, agentTargetID)
+	if err != nil {
+		if errors.Is(err, workspacedata.ErrAgentTargetNotFound) {
+			return "", fmt.Errorf("%w: agent target not found", ErrInvalidArgument)
+		}
+		return "", fmt.Errorf("get agent target: %w", err)
+	}
+	normalized, err := agenttargetbiz.NormalizeTarget(target)
+	if err != nil {
+		return "", fmt.Errorf("%w: %v", ErrInvalidArgument, err)
+	}
+	if !normalized.Enabled {
+		return "", fmt.Errorf("%w: agent target is disabled", ErrInvalidArgument)
+	}
+	var launchRef agenttargetbiz.LaunchRef
+	if err := json.Unmarshal([]byte(normalized.LaunchRefJSON), &launchRef); err != nil {
+		return "", fmt.Errorf("%w: invalid agent target launch ref", ErrInvalidArgument)
+	}
+	if _, err := agenttargetbiz.CanonicalLaunchRefJSON(normalized.Provider, launchRef); err != nil {
+		return "", fmt.Errorf("%w: invalid agent target launch ref", ErrInvalidArgument)
+	}
+	derivedProvider := strings.TrimSpace(launchRef.Provider)
+	if requestProvider != "" && requestProvider != derivedProvider {
+		return "", fmt.Errorf("%w: provider does not match agent target", ErrInvalidArgument)
+	}
+	return derivedProvider, nil
+}
+
 func (s *Service) resolveCreateSessionModel(ctx context.Context, provider string, model *string) *string {
 	resolved := normalizeComposerModelForProvider(
 		provider,
@@ -299,6 +345,7 @@ func (s *Service) prepareRuntime(ctx context.Context, workspaceID string, cwd st
 	prepared, err := s.RuntimePreparer.Prepare(ctx, agentsidecarservice.PrepareInput{
 		WorkspaceID:       workspaceID,
 		AgentSessionID:    strings.TrimSpace(input.AgentSessionID),
+		AgentTargetID:     strings.TrimSpace(input.AgentTargetID),
 		Provider:          provider,
 		Cwd:               cwd,
 		Title:             value(input.Title),

--- a/services/tuttid/service/agent/service.go
+++ b/services/tuttid/service/agent/service.go
@@ -2,7 +2,6 @@ package agent
 
 import (
 	"context"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"log/slog"
@@ -95,14 +94,16 @@ func (s *Service) ListFiltered(ctx context.Context, workspaceID string, input Li
 func (s *Service) Create(ctx context.Context, workspaceID string, input CreateSessionInput) (Session, error) {
 	workspaceID = strings.TrimSpace(workspaceID)
 	input.AgentTargetID = strings.TrimSpace(input.AgentTargetID)
-	provider, err := s.resolveCreateSessionProvider(ctx, input)
+	launch, err := s.resolveCreateSessionLaunch(ctx, input)
 	if err != nil {
 		return Session{}, err
 	}
+	provider := launch.Provider
 	if workspaceID == "" || provider == "" {
 		return Session{}, ErrInvalidArgument
 	}
 	input.Provider = provider
+	input.ProviderTargetRef = launch.ProviderTargetRef
 	input.ConversationDetailMode = preferencesbiz.NormalizeDesktopAgentConversationDetailMode(input.ConversationDetailMode)
 	if normalizedPermissionModeID := normalizePermissionModeIDForProvider(
 		provider,
@@ -273,41 +274,50 @@ func (s *Service) Create(ctx context.Context, workspaceID string, input CreateSe
 	), nil
 }
 
-func (s *Service) resolveCreateSessionProvider(ctx context.Context, input CreateSessionInput) (string, error) {
+type resolvedCreateSessionLaunch struct {
+	Provider          string
+	ProviderTargetRef map[string]any
+}
+
+func (s *Service) resolveCreateSessionLaunch(ctx context.Context, input CreateSessionInput) (resolvedCreateSessionLaunch, error) {
 	requestProvider := strings.TrimSpace(input.Provider)
 	agentTargetID := strings.TrimSpace(input.AgentTargetID)
 	if agentTargetID == "" {
-		return requestProvider, nil
+		return resolvedCreateSessionLaunch{
+			Provider:          requestProvider,
+			ProviderTargetRef: clonePayload(input.ProviderTargetRef),
+		}, nil
 	}
 	if s.AgentTargetStore == nil {
-		return "", fmt.Errorf("%w: agent target store is unavailable", ErrInvalidArgument)
+		return resolvedCreateSessionLaunch{}, fmt.Errorf("%w: agent target store is unavailable", ErrInvalidArgument)
 	}
 	target, err := s.AgentTargetStore.GetAgentTarget(ctx, agentTargetID)
 	if err != nil {
 		if errors.Is(err, workspacedata.ErrAgentTargetNotFound) {
-			return "", fmt.Errorf("%w: agent target not found", ErrInvalidArgument)
+			return resolvedCreateSessionLaunch{}, fmt.Errorf("%w: agent target not found", ErrInvalidArgument)
 		}
-		return "", fmt.Errorf("get agent target: %w", err)
+		return resolvedCreateSessionLaunch{}, fmt.Errorf("get agent target: %w", err)
 	}
 	normalized, err := agenttargetbiz.NormalizeTarget(target)
 	if err != nil {
-		return "", fmt.Errorf("%w: %v", ErrInvalidArgument, err)
+		return resolvedCreateSessionLaunch{}, fmt.Errorf("%w: %v", ErrInvalidArgument, err)
 	}
 	if !normalized.Enabled {
-		return "", fmt.Errorf("%w: agent target is disabled", ErrInvalidArgument)
+		return resolvedCreateSessionLaunch{}, fmt.Errorf("%w: agent target is disabled", ErrInvalidArgument)
 	}
-	var launchRef agenttargetbiz.LaunchRef
-	if err := json.Unmarshal([]byte(normalized.LaunchRefJSON), &launchRef); err != nil {
-		return "", fmt.Errorf("%w: invalid agent target launch ref", ErrInvalidArgument)
+	derivedRef, err := agenttargetbiz.RuntimeProviderTargetRef(normalized)
+	if err != nil {
+		return resolvedCreateSessionLaunch{}, fmt.Errorf("%w: invalid agent target launch ref", ErrInvalidArgument)
 	}
-	if _, err := agenttargetbiz.CanonicalLaunchRefJSON(normalized.Provider, launchRef); err != nil {
-		return "", fmt.Errorf("%w: invalid agent target launch ref", ErrInvalidArgument)
-	}
-	derivedProvider := strings.TrimSpace(launchRef.Provider)
+	derivedProvider, _ := derivedRef["provider"].(string)
+	derivedProvider = strings.TrimSpace(derivedProvider)
 	if requestProvider != "" && requestProvider != derivedProvider {
-		return "", fmt.Errorf("%w: provider does not match agent target", ErrInvalidArgument)
+		return resolvedCreateSessionLaunch{}, fmt.Errorf("%w: provider does not match agent target", ErrInvalidArgument)
 	}
-	return derivedProvider, nil
+	return resolvedCreateSessionLaunch{
+		Provider:          derivedProvider,
+		ProviderTargetRef: derivedRef,
+	}, nil
 }
 
 func (s *Service) resolveCreateSessionModel(ctx context.Context, provider string, model *string) *string {

--- a/services/tuttid/service/agent/service_session.go
+++ b/services/tuttid/service/agent/service_session.go
@@ -11,6 +11,7 @@ func runtimeResumeInputFromRuntimeSession(session RuntimeSession) RuntimeResumeI
 	return RuntimeResumeInput{
 		WorkspaceID:       strings.TrimSpace(session.WorkspaceID),
 		AgentSessionID:    strings.TrimSpace(session.ID),
+		AgentTargetID:     strings.TrimSpace(session.AgentTargetID),
 		Provider:          strings.TrimSpace(session.Provider),
 		ProviderSessionID: strings.TrimSpace(session.ProviderSessionID),
 		Cwd:               strings.TrimSpace(session.Cwd),
@@ -28,6 +29,7 @@ func runtimeResumeInputFromPersistedSession(session PersistedSession) RuntimeRes
 	return RuntimeResumeInput{
 		WorkspaceID:       strings.TrimSpace(session.WorkspaceID),
 		AgentSessionID:    strings.TrimSpace(session.ID),
+		AgentTargetID:     strings.TrimSpace(session.AgentTargetID),
 		Provider:          strings.TrimSpace(session.Provider),
 		ProviderSessionID: strings.TrimSpace(session.ProviderSessionID),
 		Cwd:               strings.TrimSpace(session.Cwd),
@@ -74,6 +76,7 @@ func serviceSession(session RuntimeSession, resumable bool) Session {
 	)
 	return Session{
 		ID:                 strings.TrimSpace(session.ID),
+		AgentTargetID:      strings.TrimSpace(session.AgentTargetID),
 		Provider:           normalizedProvider,
 		ProviderSessionID:  strings.TrimSpace(session.ProviderSessionID),
 		Cwd:                strings.TrimSpace(session.Cwd),
@@ -117,6 +120,7 @@ func sessionFromPersisted(session PersistedSession, resumable bool) Session {
 	return serviceSession(RuntimeSession{
 		ID:                strings.TrimSpace(session.ID),
 		WorkspaceID:       strings.TrimSpace(session.WorkspaceID),
+		AgentTargetID:     strings.TrimSpace(session.AgentTargetID),
 		Provider:          strings.TrimSpace(session.Provider),
 		ProviderSessionID: strings.TrimSpace(session.ProviderSessionID),
 		Cwd:               strings.TrimSpace(session.Cwd),
@@ -146,6 +150,9 @@ func importedSessionDisplayUpdatedAtUnixMS(session PersistedSession) int64 {
 }
 
 func mergePersistedSessionState(session Session, persisted PersistedSession) Session {
+	if strings.TrimSpace(session.AgentTargetID) == "" {
+		session.AgentTargetID = strings.TrimSpace(persisted.AgentTargetID)
+	}
 	if session.Settings == nil {
 		session.Settings = normalizeComposerSettingsPointerForProvider(session.Provider, &persisted.Settings)
 	}

--- a/services/tuttid/service/agent/service_test.go
+++ b/services/tuttid/service/agent/service_test.go
@@ -13,6 +13,7 @@ import (
 
 	agentsessionstore "github.com/tutti-os/tutti/packages/agentactivity/daemon/activity"
 	agentactivitybiz "github.com/tutti-os/tutti/services/tuttid/biz/agentactivity"
+	agenttargetbiz "github.com/tutti-os/tutti/services/tuttid/biz/agenttarget"
 	workspacebiz "github.com/tutti-os/tutti/services/tuttid/biz/workspace"
 	workspacedata "github.com/tutti-os/tutti/services/tuttid/data/workspace"
 	agentsidecarservice "github.com/tutti-os/tutti/services/tuttid/service/agentsidecar"
@@ -59,6 +60,119 @@ func TestServiceCreatesAndListsSessions(t *testing.T) {
 	}
 	if got.ID != session.ID {
 		t.Fatalf("got session ID = %q, want %q", got.ID, session.ID)
+	}
+}
+
+func TestServiceCreateResolvesProviderFromAgentTarget(t *testing.T) {
+	runtime := newFakeRuntime()
+	service := NewService(runtime)
+	service.AgentTargetStore = fakeAgentTargetStore{
+		targets: map[string]agenttargetbiz.Target{
+			agenttargetbiz.IDLocalClaudeCode: {
+				ID:            agenttargetbiz.IDLocalClaudeCode,
+				Provider:      "claude-code",
+				LaunchRefJSON: agenttargetbiz.MustLocalCLILaunchRefJSON("claude-code"),
+				Name:          "Claude Code",
+				Enabled:       true,
+				Source:        agenttargetbiz.SourceSystem,
+			},
+		},
+	}
+
+	session, err := service.Create(context.Background(), "ws-1", CreateSessionInput{
+		AgentSessionID: "target-session-1",
+		AgentTargetID:  agenttargetbiz.IDLocalClaudeCode,
+		Provider:       "claude-code",
+		InitialContent: TextPromptContent("hello target"),
+	})
+	if err != nil {
+		t.Fatalf("Create returned error: %v", err)
+	}
+	if session.Provider != "claude-code" || session.AgentTargetID != agenttargetbiz.IDLocalClaudeCode {
+		t.Fatalf("session provider/target = %q/%q, want claude-code/%s", session.Provider, session.AgentTargetID, agenttargetbiz.IDLocalClaudeCode)
+	}
+	if len(runtime.startCalls) != 1 {
+		t.Fatalf("start calls = %d, want 1", len(runtime.startCalls))
+	}
+	if got := runtime.startCalls[0].Provider; got != "claude-code" {
+		t.Fatalf("runtime provider = %q, want claude-code", got)
+	}
+	if got := runtime.startCalls[0].AgentTargetID; got != agenttargetbiz.IDLocalClaudeCode {
+		t.Fatalf("runtime agent target id = %q, want %s", got, agenttargetbiz.IDLocalClaudeCode)
+	}
+}
+
+func TestServiceCreateRejectsInvalidAgentTargetInputs(t *testing.T) {
+	for _, tc := range []struct {
+		name        string
+		input       CreateSessionInput
+		targets     map[string]agenttargetbiz.Target
+		errContains string
+	}{
+		{
+			name: "missing target",
+			input: CreateSessionInput{
+				AgentSessionID: "target-session-missing",
+				AgentTargetID:  "missing-target",
+				Provider:       "codex",
+				InitialContent: TextPromptContent("hello"),
+			},
+			errContains: "agent target not found",
+		},
+		{
+			name: "disabled target",
+			input: CreateSessionInput{
+				AgentSessionID: "target-session-disabled",
+				AgentTargetID:  "disabled-codex",
+				Provider:       "codex",
+				InitialContent: TextPromptContent("hello"),
+			},
+			targets: map[string]agenttargetbiz.Target{
+				"disabled-codex": {
+					ID:            "disabled-codex",
+					Provider:      "codex",
+					LaunchRefJSON: agenttargetbiz.MustLocalCLILaunchRefJSON("codex"),
+					Name:          "Disabled Codex",
+					Enabled:       false,
+					Source:        agenttargetbiz.SourceUser,
+				},
+			},
+			errContains: "agent target is disabled",
+		},
+		{
+			name: "provider mismatch",
+			input: CreateSessionInput{
+				AgentSessionID: "target-session-mismatch",
+				AgentTargetID:  agenttargetbiz.IDLocalCodex,
+				Provider:       "claude-code",
+				InitialContent: TextPromptContent("hello"),
+			},
+			targets: map[string]agenttargetbiz.Target{
+				agenttargetbiz.IDLocalCodex: {
+					ID:            agenttargetbiz.IDLocalCodex,
+					Provider:      "codex",
+					LaunchRefJSON: agenttargetbiz.MustLocalCLILaunchRefJSON("codex"),
+					Name:          "Codex",
+					Enabled:       true,
+					Source:        agenttargetbiz.SourceSystem,
+				},
+			},
+			errContains: "provider does not match agent target",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			runtime := newFakeRuntime()
+			service := NewService(runtime)
+			service.AgentTargetStore = fakeAgentTargetStore{targets: tc.targets}
+
+			_, err := service.Create(context.Background(), "ws-1", tc.input)
+			if !errors.Is(err, ErrInvalidArgument) || !strings.Contains(err.Error(), tc.errContains) {
+				t.Fatalf("Create error = %v, want ErrInvalidArgument containing %q", err, tc.errContains)
+			}
+			if len(runtime.startCalls) != 0 {
+				t.Fatalf("start calls = %d, want 0", len(runtime.startCalls))
+			}
+		})
 	}
 }
 
@@ -3961,6 +4075,22 @@ type fakeRuntime struct {
 	validateCalls          []RuntimeExecInput
 }
 
+type fakeAgentTargetStore struct {
+	err     error
+	targets map[string]agenttargetbiz.Target
+}
+
+func (f fakeAgentTargetStore) GetAgentTarget(_ context.Context, id string) (agenttargetbiz.Target, error) {
+	if f.err != nil {
+		return agenttargetbiz.Target{}, f.err
+	}
+	target, ok := f.targets[strings.TrimSpace(id)]
+	if !ok {
+		return agenttargetbiz.Target{}, workspacedata.ErrAgentTargetNotFound
+	}
+	return target, nil
+}
+
 type fakeRuntimePreparer struct {
 	result       agentsidecarservice.PreparedRuntime
 	err          error
@@ -4172,6 +4302,7 @@ func (f *fakeRuntime) Resume(_ context.Context, input RuntimeResumeInput) (Runti
 	f.resumeCalls = append(f.resumeCalls, input)
 	session := RuntimeSession{
 		ID:                input.AgentSessionID,
+		AgentTargetID:     input.AgentTargetID,
 		Provider:          input.Provider,
 		ProviderSessionID: input.ProviderSessionID,
 		Cwd:               input.Cwd,
@@ -4276,9 +4407,10 @@ func (f *fakeRuntime) Start(_ context.Context, input RuntimeStartInput) (Runtime
 		id = "session-" + string(rune('0'+f.nextID))
 	}
 	session := RuntimeSession{
-		ID:       id,
-		Provider: input.Provider,
-		Cwd:      input.Cwd,
+		ID:            id,
+		AgentTargetID: input.AgentTargetID,
+		Provider:      input.Provider,
+		Cwd:           input.Cwd,
 		Settings: &ComposerSettings{
 			Model:                  input.Model,
 			PermissionModeID:       input.PermissionModeID,

--- a/services/tuttid/service/agent/service_test.go
+++ b/services/tuttid/service/agent/service_test.go
@@ -82,8 +82,12 @@ func TestServiceCreateResolvesProviderFromAgentTarget(t *testing.T) {
 	session, err := service.Create(context.Background(), "ws-1", CreateSessionInput{
 		AgentSessionID: "target-session-1",
 		AgentTargetID:  agenttargetbiz.IDLocalClaudeCode,
-		Provider:       "claude-code",
 		InitialContent: TextPromptContent("hello target"),
+		ProviderTargetRef: map[string]any{
+			"kind":     "local_cli",
+			"provider": "codex",
+			"targetId": "wrong-target",
+		},
 	})
 	if err != nil {
 		t.Fatalf("Create returned error: %v", err)
@@ -99,6 +103,12 @@ func TestServiceCreateResolvesProviderFromAgentTarget(t *testing.T) {
 	}
 	if got := runtime.startCalls[0].AgentTargetID; got != agenttargetbiz.IDLocalClaudeCode {
 		t.Fatalf("runtime agent target id = %q, want %s", got, agenttargetbiz.IDLocalClaudeCode)
+	}
+	ref := runtime.startCalls[0].ProviderTargetRef
+	if ref["kind"] != agenttargetbiz.LaunchRefTypeLocalCLI ||
+		ref["provider"] != "claude-code" ||
+		ref["targetId"] != agenttargetbiz.IDLocalClaudeCode {
+		t.Fatalf("runtime provider target ref = %#v, want daemon-derived local_cli claude target", ref)
 	}
 }
 
@@ -158,6 +168,14 @@ func TestServiceCreateRejectsInvalidAgentTargetInputs(t *testing.T) {
 				},
 			},
 			errContains: "provider does not match agent target",
+		},
+		{
+			name: "missing launch authority",
+			input: CreateSessionInput{
+				AgentSessionID: "target-session-no-authority",
+				InitialContent: TextPromptContent("hello"),
+			},
+			errContains: ErrInvalidArgument.Error(),
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {

--- a/services/tuttid/service/agent/session_types.go
+++ b/services/tuttid/service/agent/session_types.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	agentactivitybiz "github.com/tutti-os/tutti/services/tuttid/biz/agentactivity"
+	agenttargetbiz "github.com/tutti-os/tutti/services/tuttid/biz/agenttarget"
 	agentsidecarservice "github.com/tutti-os/tutti/services/tuttid/service/agentsidecar"
 	reporterservice "github.com/tutti-os/tutti/services/tuttid/service/reporter"
 )
@@ -14,6 +15,7 @@ type Service struct {
 	AnalyticsReporter            reporterservice.Reporter
 	AvailabilityChecker          ProviderAvailabilityChecker
 	ModelCatalog                 AgentModelCatalog
+	AgentTargetStore             AgentTargetStore
 	SessionReader                SessionReader
 	MessageReader                MessageReader
 	ExternalImportStore          agentactivitybiz.Repository
@@ -54,12 +56,17 @@ type SessionDirectoryAllocator interface {
 	CreateSessionDirectory(context.Context) (string, error)
 }
 
+type AgentTargetStore interface {
+	GetAgentTarget(context.Context, string) (agenttargetbiz.Target, error)
+}
+
 type ComposerCapabilityLister interface {
 	ListComposerCapabilityOptions(context.Context, string, string, []ComposerSkillOption) ([]ComposerCapabilityOption, []string)
 }
 
 type Session struct {
 	ID                 string
+	AgentTargetID      string
 	Provider           string
 	ProviderSessionID  string
 	Cwd                string
@@ -103,6 +110,7 @@ type PersistedSession struct {
 	ID                string
 	WorkspaceID       string
 	Origin            string
+	AgentTargetID     string
 	Provider          string
 	ProviderSessionID string
 	Cwd               string
@@ -164,6 +172,7 @@ type SessionPinUpdater interface {
 type RuntimeSession struct {
 	ID                 string
 	WorkspaceID        string
+	AgentTargetID      string
 	Provider           string
 	ProviderSessionID  string
 	Cwd                string
@@ -184,6 +193,7 @@ type RuntimeSession struct {
 type RuntimeStartInput struct {
 	WorkspaceID            string
 	AgentSessionID         string
+	AgentTargetID          string
 	Provider               string
 	Cwd                    string
 	Env                    []string
@@ -203,6 +213,7 @@ type RuntimeStartInput struct {
 type RuntimeResumeInput struct {
 	WorkspaceID       string
 	AgentSessionID    string
+	AgentTargetID     string
 	Provider          string
 	ProviderSessionID string
 	Cwd               string
@@ -309,6 +320,7 @@ type RuntimeStreamEvent struct {
 
 type CreateSessionInput struct {
 	AgentSessionID         string
+	AgentTargetID          string
 	Provider               string
 	InitialContent         []PromptContentBlock
 	InitialDisplayPrompt   string

--- a/services/tuttid/service/agentsidecar/types.go
+++ b/services/tuttid/service/agentsidecar/types.go
@@ -18,6 +18,7 @@ type SkillBundleRenderer interface {
 type PrepareInput struct {
 	WorkspaceID            string
 	AgentSessionID         string
+	AgentTargetID          string
 	Provider               string
 	Cwd                    string
 	CLICommand             string

--- a/services/tuttid/wiring.go
+++ b/services/tuttid/wiring.go
@@ -276,6 +276,7 @@ func buildDaemonAPI(ctx context.Context, store workspacedata.CatalogStore, analy
 	)
 	agentSessionService.AnalyticsReporter = analyticsReporter
 	agentSessionService.ModelCatalog = agentservice.NewAgentModelCatalog()
+	agentSessionService.AgentTargetStore = agentTargetStore
 	agentSessionService.SessionReader = agentActivityProjection
 	agentSessionService.MessageReader = agentActivityProjection
 	agentSessionService.ExternalImportStore = agentActivityRepo


### PR DESCRIPTION
## Summary
- Add target-first workspace agent session creation across OpenAPI/generated clients, tuttid storage/session service, runtime/activity projection, desktop adapter, and AgentGUI workbench launch/node state.
- Derive execution provider from AgentTarget.launchRef when agentTargetId is present while keeping provider-only legacy session creation and provider display/filter/telemetry behavior.
- Preserve compatibility for providerTargetId/providerTargetRef and legacy dock ids, with new writes carrying agentTargetId and target-keyed AgentGUI/workbench session reuse.
- Update durable architecture docs for AgentGUI node state and agent activity package semantics.

## Validation
- pnpm format:check
- pnpm lint:ts
- pnpm typecheck
- pnpm check:api-generated
- pnpm check:event-protocol-generated
- pnpm lint:go
- cd services/tuttid && go test ./... && go build ./...
- pnpm --filter @tutti-os/agent-activity-core test -- --runInBand
- pnpm --filter @tutti-os/agent-gui exec vitest run --environment jsdom providerTargets.spec.ts workbench/launch.test.ts workbench/contribution.test.ts workbench/state.test.ts
- node --import ./test/register-asset-stub.mjs --test --experimental-strip-types ./src/renderer/src/features/workspace-agent/services/desktopAgentActivityAdapter.test.ts (apps/desktop)
- node --import ./test/register-asset-stub.mjs --test --experimental-strip-types ./src/renderer/src/features/workspace-agent/services/internal/workspaceAgentActivityService.test.ts (apps/desktop)
- pnpm --filter @tutti-os/client-tuttid-ts test
- git diff --check
- pre-push pnpm check:full

## Compatibility
- provider fields and provider endpoints remain available.
- provider-only imported/historical sessions remain supported.
- agentTargetId + mismatched provider is rejected in the new create path.
- Missing or disabled targets are rejected before runtime start.
- Activity patches that omit agentTargetId preserve the existing target id.