### PR TITLE
fix(agent): prefer markdown links for file references

### DIFF
--- a/docs/architecture/agent-gui-node.md
+++ b/docs/architecture/agent-gui-node.md
@@ -1133,6 +1133,11 @@ that open workspace file nodes should validate explicit agent-command file
 targets before launching the files surface, so a speculative or stale agent
 path does not open a misleading workbench node.
 
+Provider host-app-context prompts should mirror that contract: when agents
+reference code or workspace files in responses, instruct them to emit Markdown
+links with filename labels and absolute filesystem targets such as
+`[filename](/abs/path:line)`, not relative links or inline-code paths.
+
 Quick checks:
 
 ```sh

--- a/docs/architecture/agent-gui-node.md
+++ b/docs/architecture/agent-gui-node.md
@@ -1136,7 +1136,8 @@ path does not open a misleading workbench node.
 Provider host-app-context prompts should mirror that contract: when agents
 reference code or workspace files in responses, instruct them to emit Markdown
 links with filename labels and absolute filesystem targets such as
-`[filename](/abs/path:line)`, not relative links or inline-code paths.
+`[filename](/abs/path)`, not relative links, inline-code paths, or line-suffixed
+paths.
 
 Quick checks:
 

--- a/services/tuttid/service/agentsidecar/policy_templates/host-app-context.md
+++ b/services/tuttid/service/agentsidecar/policy_templates/host-app-context.md
@@ -18,6 +18,6 @@ You are running inside the Tutti desktop app host, which can render local and we
 
 ## References
 
-- Code/workspace files: use `[filename](/abs/path:line)` Markdown links; target must be absolute. For spaces: `[filename](</abs/path with spaces:line>)`.
-- No relative paths, `file://`, `vscode://`, or backticks around Markdown file links.
+- Code/workspace files: use `[filename](/abs/path)` Markdown links; target must be absolute. For spaces: `[filename](</abs/path with spaces>)`.
+- No relative paths, line suffixes, `file://`, `vscode://`, or link backticks.
 - Web URLs: Markdown links, e.g. `[label](https://example.com)`.

--- a/services/tuttid/service/agentsidecar/policy_templates/host-app-context.md
+++ b/services/tuttid/service/agentsidecar/policy_templates/host-app-context.md
@@ -18,5 +18,6 @@ You are running inside the Tutti desktop app host, which can render local and we
 
 ## References
 
-- Code/workspace files: full absolute filesystem path.
+- Code/workspace files: use `[filename](/abs/path:line)` Markdown links; target must be absolute. For spaces: `[filename](</abs/path with spaces:line>)`.
+- No relative paths, `file://`, `vscode://`, or backticks around Markdown file links.
 - Web URLs: Markdown links, e.g. `[label](https://example.com)`.

--- a/services/tuttid/service/agentsidecar/preparer_test.go
+++ b/services/tuttid/service/agentsidecar/preparer_test.go
@@ -108,8 +108,8 @@ func TestDefaultPreparerCodexWritesInstructionsSkillManifestAndEnv(t *testing.T)
 		!strings.Contains(string(codexAgents), "Prefer `$CODEX_HOME/generated_images/`") ||
 		!strings.Contains(string(codexAgents), "never use unverified sandbox path") ||
 		!strings.Contains(string(codexAgents), "No inline base64.") ||
-		!strings.Contains(string(codexAgents), "use `[filename](/abs/path:line)` Markdown links") ||
-		!strings.Contains(string(codexAgents), "No relative paths") ||
+		!strings.Contains(string(codexAgents), "use `[filename](/abs/path)` Markdown links") ||
+		!strings.Contains(string(codexAgents), "No relative paths, line suffixes") ||
 		!strings.Contains(string(codexAgents), "Web URLs: Markdown links") {
 		t.Fatalf("codex AGENTS.md content = %q, want host app rendering guidance", string(codexAgents))
 	}
@@ -878,8 +878,8 @@ func TestDefaultPreparerClaudeCodeUsesSessionScopedSystemPrompt(t *testing.T) {
 		!strings.Contains(string(systemPrompt), "Prefer `$CODEX_HOME/generated_images/`") ||
 		!strings.Contains(string(systemPrompt), "never use unverified sandbox path") ||
 		!strings.Contains(string(systemPrompt), "No inline base64.") ||
-		!strings.Contains(string(systemPrompt), "use `[filename](/abs/path:line)` Markdown links") ||
-		!strings.Contains(string(systemPrompt), "No relative paths") ||
+		!strings.Contains(string(systemPrompt), "use `[filename](/abs/path)` Markdown links") ||
+		!strings.Contains(string(systemPrompt), "No relative paths, line suffixes") ||
 		!strings.Contains(string(systemPrompt), "Web URLs: Markdown links") {
 		t.Fatalf("claude system prompt content = %q, want host app rendering guidance", string(systemPrompt))
 	}

--- a/services/tuttid/service/agentsidecar/preparer_test.go
+++ b/services/tuttid/service/agentsidecar/preparer_test.go
@@ -108,6 +108,8 @@ func TestDefaultPreparerCodexWritesInstructionsSkillManifestAndEnv(t *testing.T)
 		!strings.Contains(string(codexAgents), "Prefer `$CODEX_HOME/generated_images/`") ||
 		!strings.Contains(string(codexAgents), "never use unverified sandbox path") ||
 		!strings.Contains(string(codexAgents), "No inline base64.") ||
+		!strings.Contains(string(codexAgents), "use `[filename](/abs/path:line)` Markdown links") ||
+		!strings.Contains(string(codexAgents), "No relative paths") ||
 		!strings.Contains(string(codexAgents), "Web URLs: Markdown links") {
 		t.Fatalf("codex AGENTS.md content = %q, want host app rendering guidance", string(codexAgents))
 	}
@@ -876,6 +878,8 @@ func TestDefaultPreparerClaudeCodeUsesSessionScopedSystemPrompt(t *testing.T) {
 		!strings.Contains(string(systemPrompt), "Prefer `$CODEX_HOME/generated_images/`") ||
 		!strings.Contains(string(systemPrompt), "never use unverified sandbox path") ||
 		!strings.Contains(string(systemPrompt), "No inline base64.") ||
+		!strings.Contains(string(systemPrompt), "use `[filename](/abs/path:line)` Markdown links") ||
+		!strings.Contains(string(systemPrompt), "No relative paths") ||
 		!strings.Contains(string(systemPrompt), "Web URLs: Markdown links") {
 		t.Fatalf("claude system prompt content = %q, want host app rendering guidance", string(systemPrompt))
 	}

--- a/services/tuttid/service/agentsidecar/provider_skill_test.go
+++ b/services/tuttid/service/agentsidecar/provider_skill_test.go
@@ -127,8 +127,8 @@ func TestTuttiCLIPolicyUsesPreparedCLICommandForAgentLauncherFallback(t *testing
 	}
 	if !strings.Contains(policy, "# Host App Context") ||
 		!strings.Contains(policy, "Images/videos: use Markdown") ||
-		!strings.Contains(policy, "use `[filename](/abs/path:line)` Markdown links") ||
-		!strings.Contains(policy, "No relative paths") {
+		!strings.Contains(policy, "use `[filename](/abs/path)` Markdown links") ||
+		!strings.Contains(policy, "No relative paths, line suffixes") {
 		t.Fatalf("tutti CLI policy missing host app context: %q", policy)
 	}
 

--- a/services/tuttid/service/agentsidecar/provider_skill_test.go
+++ b/services/tuttid/service/agentsidecar/provider_skill_test.go
@@ -126,7 +126,9 @@ func TestTuttiCLIPolicyUsesPreparedCLICommandForAgentLauncherFallback(t *testing
 		t.Fatalf("tutti CLI policy should avoid command-scope wording: %q", policy)
 	}
 	if !strings.Contains(policy, "# Host App Context") ||
-		!strings.Contains(policy, "Images/videos: use Markdown") {
+		!strings.Contains(policy, "Images/videos: use Markdown") ||
+		!strings.Contains(policy, "use `[filename](/abs/path:line)` Markdown links") ||
+		!strings.Contains(policy, "No relative paths") {
 		t.Fatalf("tutti CLI policy missing host app context: %q", policy)
 	}
 


### PR DESCRIPTION
## Summary
- Align host app context with Codex-style file reference guidance.
- Instruct agents to emit absolute-path Markdown file links instead of relative paths or inline-code paths.
- Cover Codex and Claude prompt injection tests and document the Agent GUI contract.

## Tests
- go test ./service/agentsidecar
- PATH=/Users/ccr/.nvm/versions/node/v24.12.0/bin:$PATH pnpm check:changed --tail-lines 50
- PATH=/Users/ccr/.nvm/versions/node/v24.12.0/bin:$PATH git push -u origin codex/align-file-link-prompts (pre-push ran pnpm check:full)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Tightened agent guidance for responses that reference code/workspace files.
  * Requires Markdown links in the form `[filename](/abs/path)` (with absolute filesystem targets and filename labels), and forbids relative paths, line-suffixed paths, and raw/alternative file-link formats (e.g., `file://`, `vscode://`, backtick-wrapped links).

* **Tests**
  * Updated prompt/policy assertions to enforce the new Markdown link-format rules and explicitly disallow relative paths and line-suffixed references.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->