### PR TITLE
fix(activity-core): preserve failed session status over non-terminal turn status

### DIFF
--- a/packages/agent/activity-core/src/selectors.ts
+++ b/packages/agent/activity-core/src/selectors.ts
@@ -50,7 +50,10 @@ export function selectSessionDisplayStatuses(
       return [
         session.agentSessionId,
         sessionStatus === "failed"
-          ? (latestTurnStatus ?? sessionStatus)
+          ? latestTurnStatus != null &&
+            isTerminalDisplayStatus(latestTurnStatus)
+            ? latestTurnStatus
+            : sessionStatus
           : sessionStatus
       ];
     })
@@ -421,6 +424,17 @@ function displayStatusFromTerminalStatus(
 
 function isWorkingStatus(status: string): boolean {
   return status === "running" || status === "streaming" || status === "working";
+}
+
+function isTerminalDisplayStatus(
+  status: AgentActivityDisplayStatus | null
+): boolean {
+  return (
+    status === "completed" ||
+    status === "failed" ||
+    status === "canceled" ||
+    status === "idle"
+  );
 }
 
 function normalizeStatus(status: string | null | undefined): string {


### PR DESCRIPTION
## Summary
- In `selectSessionDisplayStatuses`, when a session was marked "failed", the display status was overridden by `latestTurnStatus` regardless of whether that turn status was terminal. This caused error sessions to appear as "working" when the latest message still had a running/streaming status.
- Only override the session failure with `latestTurnStatus` when it is itself a terminal display status (completed, failed, canceled, idle). This ensures error sessions show as failed in the message center until a terminal turn status arrives.
- Fixes the pre-existing test failure: "counts error message-center sessions as failed, not completed"

## Verification

- All 13 selector tests pass (`node --test src/selectors.test.ts`)
- All 33 message center model tests pass (including previously failing test)
- Pre-commit hooks pass (oxfmt, oxlint, boundary checks)
- `pnpm check:full` passes

## Checklist

- [x] I kept the change focused on one concern.
- [ ] I updated documentation when behavior, setup, or contributor workflow changed.
- [ ] I updated all README/CONTRIBUTING language variants when changing their English source.
- [x] I ran the lowest meaningful local checks for the changed surface.
- [x] My commits are signed off with DCO when required: `git commit -s`.

## AI Disclosure
- Code was written with assistance from Claude (Anthropic). The fix was reviewed and verified by running the existing test suite and TypeScript type checking.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved session status display so the latest turn status only overrides the session’s main status when it represents a final outcome.
  * Prevents in-progress or intermediate statuses from replacing the normalized session status, making activity state more accurate and consistent.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->