### PR TITLE
fix(agent-gui): show command details for non-edit approval tool calls

### DIFF
--- a/packages/agent/gui/shared/agentConversation/components/tool-renderers/AgentApprovalContent.tsx
+++ b/packages/agent/gui/shared/agentConversation/components/tool-renderers/AgentApprovalContent.tsx
@@ -2,6 +2,7 @@ import type { JSX } from "react";
 import type { AgentToolCallVM } from "../../contracts/agentToolCallVM";
 import { AgentEditContent } from "./AgentEditContent";
 import {
+  AgentDefaultToolContent,
   arrayValue,
   objectValue,
   stringValue,
@@ -14,12 +15,25 @@ export function AgentApprovalContent({
   onLinkClick
 }: AgentToolRendererProps): JSX.Element | null {
   "use memo";
-  const previewCall = approvalPreviewCall(call);
-  if (!previewCall && !call.summary.trim()) {
+  const editPreviewCall = approvalEditPreviewCall(call);
+  const genericPreviewCall = editPreviewCall
+    ? null
+    : approvalGenericPreviewCall(call);
+  if (!editPreviewCall && !genericPreviewCall && !call.summary.trim()) {
     return null;
   }
-  if (previewCall) {
-    return <AgentEditContent call={previewCall} onLinkClick={onLinkClick} />;
+  if (editPreviewCall) {
+    return (
+      <AgentEditContent call={editPreviewCall} onLinkClick={onLinkClick} />
+    );
+  }
+  if (genericPreviewCall) {
+    return (
+      <AgentDefaultToolContent
+        call={genericPreviewCall}
+        onLinkClick={onLinkClick}
+      />
+    );
   }
   return (
     <div className="workspace-agents-status-panel__detail-tool-body">
@@ -28,7 +42,9 @@ export function AgentApprovalContent({
   );
 }
 
-function approvalPreviewCall(call: AgentToolCallVM): AgentToolCallVM | null {
+function approvalEditPreviewCall(
+  call: AgentToolCallVM
+): AgentToolCallVM | null {
   const toolCall = objectValue(call.input?.toolCall);
   if (!toolCall) {
     return null;
@@ -68,6 +84,45 @@ function approvalPreviewCall(call: AgentToolCallVM): AgentToolCallVM | null {
     content,
     locations,
     rendererKind: "edit",
+    approval: null,
+    planMode: null,
+    askUserQuestion: null,
+    task: null,
+    occurredAtUnixMs: call.occurredAtUnixMs
+  };
+}
+
+function approvalGenericPreviewCall(
+  call: AgentToolCallVM
+): AgentToolCallVM | null {
+  const toolCall = objectValue(call.input?.toolCall);
+  if (!toolCall) {
+    return null;
+  }
+  const input = objectValue(toolCall.rawInput);
+  const content = arrayValue(toolCall.content);
+  const toolTitle =
+    stringValue(toolCall.title) ?? stringValue(toolCall.toolName) ?? call.name;
+  return {
+    kind: "tool-call",
+    id: `${call.id}:approval-preview`,
+    turnId: call.turnId,
+    name: toolTitle,
+    toolName: toolTitle,
+    callType: "tool",
+    status: stringValue(toolCall.status) ?? call.status,
+    statusKind: call.statusKind,
+    summary: "",
+    compactSummary: null,
+    payload: { input, content },
+    toolState: null,
+    input,
+    output: null,
+    error: null,
+    metadata: null,
+    content,
+    locations: null,
+    rendererKind: "default",
     approval: null,
     planMode: null,
     askUserQuestion: null,

--- a/packages/agent/gui/shared/agentConversation/components/tool-renderers/AgentExpandedToolContent.spec.tsx
+++ b/packages/agent/gui/shared/agentConversation/components/tool-renderers/AgentExpandedToolContent.spec.tsx
@@ -89,6 +89,39 @@ describe("AgentExpandedToolContent", () => {
     expect(screen.queryByText("Allow once")).toBeNull();
   });
 
+  it("renders approval details for non-edit tool calls (e.g. bash)", async () => {
+    setAgentGuiI18nTestLocale("en");
+
+    render(
+      <AgentExpandedToolContent
+        call={projectAgentToolCall(
+          toolCall({
+            callType: "approval",
+            toolName: "Approval",
+            status: "Completed",
+            statusKind: "completed",
+            payload: {
+              input: {
+                options: [{ id: "allow_once", label: "Allow once" }],
+                toolCall: {
+                  kind: "bash",
+                  title: "Run build script",
+                  status: "pending",
+                  rawInput: {
+                    command: "pnpm build"
+                  }
+                }
+              }
+            }
+          })
+        )}
+      />
+    );
+
+    expect(screen.getByText("Run build script")).toBeTruthy();
+    expect(screen.getByText("pnpm build")).toBeTruthy();
+  });
+
   it("renders ask-user options and selected answer from the typed ask-user vm", async () => {
     setAgentGuiI18nTestLocale("en");
 


### PR DESCRIPTION
## Summary
- Previously, `AgentApprovalContent` only rendered details for edit and move tool kinds. All other tool kinds (bash, read, write, etc.) returned null, causing the expanded view to appear empty even though `hasAgentToolContent` reported content was available.
- Split the preview logic into `approvalEditPreviewCall` (edit/move, unchanged) and `approvalGenericPreviewCall` (all other tool kinds). The generic preview constructs a default VM from the nested toolCall's rawInput and delegates to `AgentDefaultToolContent`, which renders input/output/error sections.
- Added test coverage for bash-type approval rendering alongside the existing edit-type approval test.

## Verification

- Pre-commit hooks pass (oxfmt, oxlint, boundary checks)
- `pnpm check:full` passes
- AgentExpandedToolContent spec tests pass (existing + new test)

## Checklist

- [x] I kept the change focused on one concern.
- [ ] I updated documentation when behavior, setup, or contributor workflow changed.
- [ ] I updated all README/CONTRIBUTING language variants when changing their English source.
- [x] I ran the lowest meaningful local checks for the changed surface.
- [x] My commits are signed off with DCO when required: `git commit -s`.

## AI Disclosure
- Code was written with assistance from Claude (Anthropic). The fix was reviewed and verified by running the existing test suite.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Approval cards now show a clearer preview for more tool types, including edit/move actions and other commands.
  * If no preview is available, the app now falls back to displaying the tool summary text instead of leaving the area blank.

* **Tests**
  * Added coverage for approval rendering when the nested tool call is a non-edit command, such as a build script.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->