### PR TITLE
fix(agent-gui): strip markdown emphasis from message center titles and previews

### DIFF
--- a/packages/agent/gui/agent-message-center/WorkspaceAgentMessageCenterCard.tsx
+++ b/packages/agent/gui/agent-message-center/WorkspaceAgentMessageCenterCard.tsx
@@ -35,6 +35,7 @@ import {
 } from "@tutti-os/ui-rich-text/core";
 import { getActiveUiLanguage, useTranslation } from "../i18n/index";
 import { formatAgentSessionMentionText } from "../shared/utils/agentSessionMentionText";
+import { normalizeAgentTitleText } from "../shared/utils/agentTitleText";
 import { AgentInteractivePromptSurface } from "../shared/agentConversation/components/AgentInteractivePromptSurface";
 import { AgentMessageMarkdown } from "../shared/AgentMessageMarkdown";
 import { AgentVerticalScrollArea } from "../shared/AgentVerticalScrollArea";
@@ -545,7 +546,7 @@ function messageCenterStackRawPreviewText(
   return (
     item.digest.primary.summary.trim() ||
     item.lastAgentMessageSummary.trim() ||
-    item.title
+    normalizeAgentTitleText(item.title)
   );
 }
 
@@ -560,6 +561,18 @@ export function messageCenterStackPreviewText(
 const MESSAGE_CENTER_PREVIEW_MARKDOWN_LINK_PATTERN =
   /\[((?:\\.|[^\]\\])*)\]\(([^)\s]+)\)/g;
 const MESSAGE_CENTER_PREVIEW_LABEL_ESCAPE_PATTERN = /\\([\\[\]()])/g;
+const PREVIEW_BOLD_ASTERISK_PATTERN = /\*\*(.+?)\*\*/g;
+const PREVIEW_BOLD_UNDERSCORE_PATTERN = /__(.+?)__/g;
+const PREVIEW_ITALIC_ASTERISK_PATTERN = /\*([^\s*][^*]*?)\*/g;
+const PREVIEW_ITALIC_UNDERSCORE_PATTERN = /_([^\s_][^_]*?)_/g;
+
+function stripPreviewTextEmphasis(text: string): string {
+  return text
+    .replace(PREVIEW_BOLD_ASTERISK_PATTERN, "$1")
+    .replace(PREVIEW_BOLD_UNDERSCORE_PATTERN, "$1")
+    .replace(PREVIEW_ITALIC_ASTERISK_PATTERN, "$1")
+    .replace(PREVIEW_ITALIC_UNDERSCORE_PATTERN, "$1");
+}
 
 type MessageCenterPreviewMentionKind =
   | "session"
@@ -586,7 +599,7 @@ export function messageCenterStackPreviewNodes(
     const [fullMatch, rawLabel = "", href = ""] = match;
     const matchStart = match.index ?? 0;
     if (matchStart > lastIndex) {
-      nodes.push(text.slice(lastIndex, matchStart));
+      nodes.push(stripPreviewTextEmphasis(text.slice(lastIndex, matchStart)));
     }
 
     const label = rawLabel.replace(
@@ -595,7 +608,11 @@ export function messageCenterStackPreviewNodes(
     );
     const mention = parseRichTextMentionHref(href, label);
     if (!mention) {
-      nodes.push(isRichTextMentionHref(href) ? label : fullMatch);
+      nodes.push(
+        isRichTextMentionHref(href)
+          ? stripPreviewTextEmphasis(label)
+          : stripPreviewTextEmphasis(fullMatch)
+      );
     } else {
       const kind = messageCenterPreviewMentionKind(mention.providerId);
       const displayLabel = label || mention.label;
@@ -617,7 +634,7 @@ export function messageCenterStackPreviewNodes(
   }
 
   if (lastIndex < text.length) {
-    nodes.push(text.slice(lastIndex));
+    nodes.push(stripPreviewTextEmphasis(text.slice(lastIndex)));
   }
 
   return nodes;
@@ -868,7 +885,7 @@ function MessageCenterSummary({
         />
       ) : summary ? (
         <div className="whitespace-pre-wrap [overflow-wrap:anywhere]">
-          {summary}
+          {normalizeAgentTitleText(summary)}
         </div>
       ) : (
         emptyLabel

--- a/packages/agent/gui/shared/utils/agentTitleText.spec.ts
+++ b/packages/agent/gui/shared/utils/agentTitleText.spec.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from "vitest";
+import { normalizeAgentTitleText } from "./agentTitleText";
+
+describe("normalizeAgentTitleText", () => {
+  it("returns empty string for null or undefined", () => {
+    expect(normalizeAgentTitleText(null)).toBe("");
+    expect(normalizeAgentTitleText(undefined)).toBe("");
+  });
+
+  it("returns trimmed value for plain text", () => {
+    expect(normalizeAgentTitleText("  hello world  ")).toBe("hello world");
+  });
+
+  it("strips markdown link syntax and keeps the label", () => {
+    expect(normalizeAgentTitleText("[click here](https://example.com)")).toBe(
+      "click here"
+    );
+  });
+
+  it("strips bold markers with double asterisks", () => {
+    expect(normalizeAgentTitleText("**important** message")).toBe(
+      "important message"
+    );
+  });
+
+  it("strips bold markers with double underscores", () => {
+    expect(normalizeAgentTitleText("__important__ message")).toBe(
+      "important message"
+    );
+  });
+
+  it("strips italic markers with single asterisks", () => {
+    expect(normalizeAgentTitleText("*note* message")).toBe("note message");
+  });
+
+  it("strips italic markers with single underscores", () => {
+    expect(normalizeAgentTitleText("_note_ message")).toBe("note message");
+  });
+
+  it("strips bold-italic triple asterisk markers", () => {
+    expect(normalizeAgentTitleText("***important*** text")).toBe(
+      "important text"
+    );
+  });
+
+  it("does not strip single literal asterisk used as multiplication", () => {
+    expect(normalizeAgentTitleText("2 * 3 = 6")).toBe("2 * 3 = 6");
+  });
+
+  it("collapses multiple whitespace into single space", () => {
+    expect(normalizeAgentTitleText("hello\n\n  world")).toBe("hello world");
+  });
+
+  it("handles combined markdown links and bold markers", () => {
+    expect(
+      normalizeAgentTitleText("**See [docs](https://x.com)** for details")
+    ).toBe("See docs for details");
+  });
+});

--- a/packages/agent/gui/shared/utils/agentTitleText.ts
+++ b/packages/agent/gui/shared/utils/agentTitleText.ts
@@ -1,5 +1,9 @@
 const markdownLinkPattern = /\[((?:\\.|[^\]\\])*)\]\(([^)\s]+)\)/g;
 const markdownLabelEscapePattern = /\\([\\[\]()])/g;
+const markdownBoldAsteriskPattern = /\*\*(.+?)\*\*/g;
+const markdownBoldUnderscorePattern = /__(.+?)__/g;
+const markdownItalicAsteriskPattern = /\*([^\s*][^*]*?)\*/g;
+const markdownItalicUnderscorePattern = /_([^\s_][^_]*?)_/g;
 
 export function normalizeAgentTitleText(
   value: string | null | undefined
@@ -8,10 +12,16 @@ export function normalizeAgentTitleText(
   if (!trimmed) {
     return "";
   }
-  const normalized = trimmed.replace(markdownLinkPattern, (_, label: string) =>
-    unescapeMarkdownLabel(label)
+  const withoutLinks = trimmed.replace(
+    markdownLinkPattern,
+    (_, label: string) => unescapeMarkdownLabel(label)
   );
-  return normalized.replace(/\s+/g, " ").trim();
+  const withoutEmphasis = withoutLinks
+    .replace(markdownBoldAsteriskPattern, "$1")
+    .replace(markdownBoldUnderscorePattern, "$1")
+    .replace(markdownItalicAsteriskPattern, "$1")
+    .replace(markdownItalicUnderscorePattern, "$1");
+  return withoutEmphasis.replace(/\s+/g, " ").trim();
 }
 
 function unescapeMarkdownLabel(label: string): string {


### PR DESCRIPTION
## Summary
- Strip markdown bold/italic markers (asterisks and underscores) from message center titles and stack preview text segments
- Restore `normalizeAgentTitleText` import that was removed during a prior refactor, causing raw markdown to leak into the message center UI
- Add `stripPreviewTextEmphasis` helper with targeted patterns for `**bold**`, `__bold__`, `*italic*`, `_italic_` on stack preview segments
- Fix summary fallback to normalize through `normalizeAgentTitleText` for consistent display

## Verification

- Added 11 unit tests in `agentTitleText.spec.ts` covering null/undefined, plain text, links, bold/italic markers (asterisk + underscore), bold-italic triple markers, multiplication sign preservation, whitespace collapsing, and combined patterns
- Pre-commit hooks pass (oxfmt, oxlint, boundary checks)
- `pnpm check:full` passes

## Checklist

- [x] I kept the change focused on one concern.
- [ ] I updated documentation when behavior, setup, or contributor workflow changed.
- [ ] I updated all README/CONTRIBUTING language variants when changing their English source.
- [x] I ran the lowest meaningful local checks for the changed surface.
- [x] My commits are signed off with DCO when required: `git commit -s`.

## AI Disclosure
- Code was written with assistance from Claude (Anthropic). The fix was reviewed and verified by running the existing test suite.