### PR TITLE
fix(auth-bridge): declare package repository

### DIFF
--- a/packages/auth/bridge/package.json
+++ b/packages/auth/bridge/package.json
@@ -2,6 +2,11 @@
   "name": "@tutti-os/auth-bridge",
   "version": "0.0.0-test.20260630000000.local",
   "private": false,
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/tutti-os/tutti.git",
+    "directory": "packages/auth/bridge"
+  },
   "type": "module",
   "types": "./src/browser.ts",
   "exports": {


### PR DESCRIPTION
## Summary
- add repository metadata to @tutti-os/auth-bridge package manifest
- unblock npm provenance validation for the package release workflow

## Validation
- node JSON parse for packages/auth/bridge/package.json
- git diff --check

Note: local pnpm validation was blocked because this machine has pnpm 11.7.0 while the repo requires pnpm 10.11.0; the GitHub release workflow uses pnpm 10.11.0.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated package metadata to include repository information for the auth bridge package.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->