### PR TITLE
fix(agentstatus): repair Codex launch failures on install

### DIFF
--- a/docs/conventions/troubleshooting.md
+++ b/docs/conventions/troubleshooting.md
@@ -76,7 +76,10 @@ Use this shape for new entries:
   lightweight package metadata probe before attempting the install. Preserve
   `TUTTI_AGENT_NPM_REGISTRY` as an explicit single-registry pin with no mirror
   fallback. Also pass the same managed Node `PATH` through provider command
-  resolution, version checks, auth-status checks, and adapter probes.
+  resolution, version checks, auth-status checks, and adapter probes. If the
+  CLI path exists but `codex app-server` cannot launch, treat the failed probe
+  as a repair trigger so the install action does not clear immediately without
+  running an installer.
 - Validation:
   Reproduce in a temporary prefix/cache using the Tutti-managed npm. Confirm
   `codex --version`, the platform package metadata and vendor binary, and a

--- a/services/tuttid/service/agentstatus/installer.go
+++ b/services/tuttid/service/agentstatus/installer.go
@@ -308,6 +308,14 @@ func (s Service) nextMissingInstaller(spec ProviderSpec, runtime providerRuntime
 		}
 		return spec.Install, true, "cli"
 	}
+	if strings.TrimSpace(runtime.ReasonCode) == "acp_adapter_launch_failed" {
+		if spec.AdapterInstall.Kind != "" {
+			return spec.AdapterInstall, true, "adapter"
+		}
+		if spec.Install.Kind != "" {
+			return spec.Install, true, "cli"
+		}
+	}
 	if strings.TrimSpace(runtime.AdapterPath) == "" {
 		if spec.AdapterInstall.Kind != "" {
 			return spec.AdapterInstall, true, "adapter"

--- a/services/tuttid/service/agentstatus/service.go
+++ b/services/tuttid/service/agentstatus/service.go
@@ -442,25 +442,9 @@ func (s Service) runInstallAction(ctx context.Context, spec ProviderSpec, result
 	defer clearActiveAction(installCtx, spec.Provider)
 	runtimeResolution := s.resolveProviderRuntime(ctx, spec)
 	summary, updatedRuntime, err := s.installMissingProviderRuntime(installCtx, spec, runtimeResolution)
-	result.Command = strings.Join(summary.Commands, " && ")
-	result.Stdout = trimActionOutput(strings.Join(summary.Stdout, "\n"))
-	result.Stderr = trimActionOutput(strings.Join(summary.Stderr, "\n"))
-	result.ExitCode = summary.ExitCode
+	result = applyInstallerExecutionSummary(result, summary)
 	if err != nil {
-		result.Status = RunActionFailed
-		if errors.Is(err, context.DeadlineExceeded) {
-			result.ReasonCode = "install_timed_out"
-			result.Message = "Install command timed out after " + s.installTimeout().String()
-			return result, nil
-		}
-		if errors.Is(err, context.Canceled) {
-			result.ReasonCode = "install_canceled"
-			result.Message = err.Error()
-			return result, nil
-		}
-		result.ReasonCode = "install_start_failed"
-		result.Message = err.Error()
-		return result, nil
+		return installActionErrorResult(result, err, s.installTimeout()), nil
 	}
 	if len(summary.Commands) == 0 {
 		probeStartedAt := s.now()
@@ -477,6 +461,19 @@ func (s Service) runInstallAction(ctx context.Context, spec ProviderSpec, result
 		}
 		result.Probe = &probe
 		if probe.Status == ProbeFailed {
+			repairStatus := s.statusForSpec(ctx, spec, s.now())
+			if repairStatus.Availability.ReasonCode == "acp_adapter_launch_failed" {
+				runtimeResolution.ReasonCode = "acp_adapter_launch_failed"
+				summary, updatedRuntime, err = s.installMissingProviderRuntime(installCtx, spec, runtimeResolution)
+				result = applyInstallerExecutionSummary(result, summary)
+				result.Probe = nil
+				if err != nil {
+					return installActionErrorResult(result, err, s.installTimeout()), nil
+				}
+				if len(summary.Commands) > 0 {
+					goto postInstallProbe
+				}
+			}
 			result.Status = RunActionFailed
 			result.ReasonCode = "post_install_probe_failed"
 			result.Message = firstNonBlank(probe.Message, probe.ReasonCode, "Agent provider runtime probe failed")
@@ -504,6 +501,7 @@ func (s Service) runInstallAction(ctx context.Context, spec ProviderSpec, result
 		return result, nil
 	}
 
+postInstallProbe:
 	probeStartedAt := s.now()
 	probe, err := s.Probe(ctx, ProbeInput{Provider: spec.Provider})
 	if err != nil {
@@ -540,6 +538,31 @@ func (s Service) runInstallAction(ctx context.Context, spec ProviderSpec, result
 	}
 	result.Status = RunActionCompleted
 	return result, nil
+}
+
+func applyInstallerExecutionSummary(result RunActionResult, summary installerExecutionSummary) RunActionResult {
+	result.Command = strings.Join(summary.Commands, " && ")
+	result.Stdout = trimActionOutput(strings.Join(summary.Stdout, "\n"))
+	result.Stderr = trimActionOutput(strings.Join(summary.Stderr, "\n"))
+	result.ExitCode = summary.ExitCode
+	return result
+}
+
+func installActionErrorResult(result RunActionResult, err error, timeout time.Duration) RunActionResult {
+	result.Status = RunActionFailed
+	if errors.Is(err, context.DeadlineExceeded) {
+		result.ReasonCode = "install_timed_out"
+		result.Message = "Install command timed out after " + timeout.String()
+		return result
+	}
+	if errors.Is(err, context.Canceled) {
+		result.ReasonCode = "install_canceled"
+		result.Message = err.Error()
+		return result
+	}
+	result.ReasonCode = "install_start_failed"
+	result.Message = err.Error()
+	return result
 }
 
 func (s Service) statusForSpec(ctx context.Context, spec ProviderSpec, now time.Time) ProviderStatus {

--- a/services/tuttid/service/agentstatus/service_test.go
+++ b/services/tuttid/service/agentstatus/service_test.go
@@ -524,6 +524,60 @@ func TestServiceRunActionReinstallsCodexWhenPlatformPackageIncomplete(t *testing
 	}
 }
 
+func TestServiceRunActionRepairsCodexWhenAppServerLaunchFails(t *testing.T) {
+	home := t.TempDir()
+	binDir := filepath.Join(home, "bin")
+	pkgDir := filepath.Join(home, "lib", "node_modules", "@openai", "codex")
+	writePackageManifest(t, pkgDir, "@openai/codex", MinSupportedCodexVersion)
+	codexPath := filepath.Join(pkgDir, "bin", "codex")
+	writeExecutable(t, codexPath, "#!/bin/sh\nif [ \"$1\" = \"--version\" ]; then echo 'codex "+MinSupportedCodexVersion+"'; exit 0; fi\nif [ \"$1\" = \"app-server\" ]; then echo 'app-server failed' >&2; exit 127; fi\nexit 0\n")
+	if err := os.MkdirAll(binDir, 0o755); err != nil {
+		t.Fatalf("mkdir bin dir: %v", err)
+	}
+	if err := os.Symlink(codexPath, filepath.Join(binDir, "codex")); err != nil {
+		t.Fatalf("symlink codex: %v", err)
+	}
+	platformBinary, ok := codexPlatformBinaryPath(pkgDir, runtime.GOOS, runtime.GOARCH)
+	if !ok {
+		t.Skipf("codex platform package is unsupported for %s/%s", runtime.GOOS, runtime.GOARCH)
+	}
+	writeExecutable(t, platformBinary, "#!/bin/sh\nexit 0\n")
+
+	service := probeTestService(home)
+	service.Environ = func() []string {
+		return []string{"PATH=" + binDir, agentNPMRegistryEnv + "=https://registry.example.test"}
+	}
+	service.IsExecutableFile = isTestExecutable
+	service.RunAuthStatusCommand = func(context.Context, ProviderSpec, string) (AuthInfo, bool) {
+		return AuthInfo{Status: AuthAuthenticated}, true
+	}
+
+	var command InstallCommandInput
+	service.InstallCommand = func(_ context.Context, input InstallCommandInput) (InstallCommandResult, error) {
+		command = input
+		writeExecutable(t, codexPath, "#!/bin/sh\nif [ \"$1\" = \"--version\" ]; then echo 'codex "+MinSupportedCodexVersion+"'; exit 0; fi\nif [ \"$1\" = \"app-server\" ]; then sleep 5; fi\nexit 0\n")
+		return InstallCommandResult{ExitCode: 0, Stdout: "installed"}, nil
+	}
+
+	result, err := service.RunAction(context.Background(), RunActionInput{
+		Provider: "codex",
+		ActionID: ActionInstall,
+	})
+	if err != nil {
+		t.Fatalf("RunAction() error = %v", err)
+	}
+	if result.Status != RunActionCompleted {
+		t.Fatalf("Status = %q, want %q; result=%#v", result.Status, RunActionCompleted, result)
+	}
+	if !strings.Contains(command.Command, "@openai/codex") ||
+		!strings.Contains(command.Command, "--include=optional") {
+		t.Fatalf("Command = %q, want Codex CLI repair install with optional deps", command.Command)
+	}
+	if result.Probe == nil || result.Probe.Status != ProbeReady {
+		t.Fatalf("Probe = %#v, want ready probe", result.Probe)
+	}
+}
+
 func TestServiceListReportsInstallActionWhenCodexAdapterCommandFails(t *testing.T) {
 	home := t.TempDir()
 	binDir := filepath.Join(home, "bin")


### PR DESCRIPTION
## Summary
- Treat `acp_adapter_launch_failed` as a repair-install trigger instead of letting Codex install actions no-op.
- Re-run install after post-probe confirms the local `codex app-server` cannot launch.
- Add a regression test for an installed Codex shim/platform package whose app-server launch fails.
- Document the troubleshooting pattern.

## Validation
- `go test ./services/tuttid/service/agentstatus`
- `go test ./services/tuttid/...`

Note: local git hooks were skipped for push because the Codex runtime pnpm is 11.7.0 while this repo requires pnpm 10.11.0.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved install handling when the app server cannot launch, so the app now retries with a repair path instead of ending prematurely.
  * Adjusted installer selection to better recover from launch failures and continue with the most relevant install step.
  * Fixed post-install behavior so failed startup checks can trigger a successful repair and follow-up validation.
* **Tests**
  * Added coverage for the install-and-repair flow when the app server fails to start.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->