### PR TITLE
[codex] Rename pageview analytics event

### DIFF
--- a/apps/desktop/src/renderer/src/features/analytics/reporters/app-pageview/appPageviewReporter.ts
+++ b/apps/desktop/src/renderer/src/features/analytics/reporters/app-pageview/appPageviewReporter.ts
@@ -1,8 +1,8 @@
 import type { AnalyticsReporterDependencies } from "../baseReporter.ts";
 
-export class PredefinePageviewReporter {
+export class AppPageviewReporter {
   private readonly dependencies: AnalyticsReporterDependencies;
-  private readonly eventName = "predefine_pageview";
+  private readonly eventName = "app.pageview";
 
   constructor(dependencies: AnalyticsReporterDependencies) {
     this.dependencies = dependencies;

--- a/apps/desktop/src/renderer/src/features/analytics/reporters/app-pageview/index.ts
+++ b/apps/desktop/src/renderer/src/features/analytics/reporters/app-pageview/index.ts
@@ -1,0 +1,1 @@
+export { AppPageviewReporter } from "./appPageviewReporter.ts";

--- a/apps/desktop/src/renderer/src/features/analytics/reporters/index.ts
+++ b/apps/desktop/src/renderer/src/features/analytics/reporters/index.ts
@@ -1,4 +1,4 @@
-export { PredefinePageviewReporter } from "./predefine-pageview";
+export { AppPageviewReporter } from "./app-pageview";
 export { AppStartupFailedReporter } from "./app-startup-failed";
 export type { AppStartupFailedParams } from "./app-startup-failed";
 export { AppRendererErrorReporter } from "./app-renderer-error";

--- a/apps/desktop/src/renderer/src/features/analytics/reporters/predefine-pageview/index.ts
+++ b/apps/desktop/src/renderer/src/features/analytics/reporters/predefine-pageview/index.ts
@@ -1,1 +1,0 @@
-export { PredefinePageviewReporter } from "./predefinePageviewReporter.ts";

--- a/apps/desktop/src/renderer/src/features/analytics/reporters/reporterCompleteness.test.ts
+++ b/apps/desktop/src/renderer/src/features/analytics/reporters/reporterCompleteness.test.ts
@@ -4,7 +4,7 @@ import path from "node:path";
 import test from "node:test";
 
 const expectedAnalyticsEvents = [
-  "predefine_pageview",
+  "app.pageview",
   "app.startup_failed",
   "app.renderer_error",
   "daemon.startup_failed",

--- a/apps/desktop/src/renderer/src/features/analytics/services/internal/predefinePageviewAnalytics.test.ts
+++ b/apps/desktop/src/renderer/src/features/analytics/services/internal/predefinePageviewAnalytics.test.ts
@@ -23,7 +23,7 @@ test("predefine pageview analytics reports when the app opens", () => {
     [
       {
         clientTS: runtime.now(),
-        name: "predefine_pageview"
+        name: "app.pageview"
       }
     ]
   ]);
@@ -47,7 +47,7 @@ test("predefine pageview analytics reports app opens even after a focus report t
     [
       {
         clientTS: runtime.now(),
-        name: "predefine_pageview"
+        name: "app.pageview"
       }
     ]
   ]);
@@ -69,7 +69,7 @@ test("predefine pageview analytics reports explicit focus once per local day", (
 
   assert.deepEqual(
     reporterCalls.map((call) => call[0]?.name),
-    ["predefine_pageview", "predefine_pageview"]
+    ["app.pageview", "app.pageview"]
   );
 });
 
@@ -90,7 +90,7 @@ test("predefine pageview analytics reports explicit focus again on a new local d
 
   assert.deepEqual(
     reporterCalls.map((call) => call[0]?.name),
-    ["predefine_pageview", "predefine_pageview", "predefine_pageview"]
+    ["app.pageview", "app.pageview", "app.pageview"]
   );
 });
 

--- a/apps/desktop/src/renderer/src/features/analytics/services/internal/predefinePageviewAnalytics.ts
+++ b/apps/desktop/src/renderer/src/features/analytics/services/internal/predefinePageviewAnalytics.ts
@@ -1,7 +1,7 @@
-import { PredefinePageviewReporter } from "../../reporters/predefine-pageview/predefinePageviewReporter.ts";
+import { AppPageviewReporter } from "../../reporters/app-pageview/appPageviewReporter.ts";
 import type { IReporterService } from "../reporterService.interface.ts";
 
-const focusedDayStorageKey = "tutti.analytics.predefine_pageview.focused_day";
+const focusedDayStorageKey = "tutti.analytics.app.pageview.focused_day";
 
 export interface PredefinePageviewAnalyticsController {
   dispose(): void;
@@ -33,7 +33,7 @@ export function startPredefinePageviewAnalytics(input: {
     if (disposed) {
       return;
     }
-    void new PredefinePageviewReporter({
+    void new AppPageviewReporter({
       now,
       reporterService: input.reporterService
     }).report();

--- a/services/tuttid/api/daemon_tracking.go
+++ b/services/tuttid/api/daemon_tracking.go
@@ -90,16 +90,9 @@ func validateTrackEventsRequest(request tuttigenerated.TrackEventsRequestObject)
 }
 
 func isValidTrackEventName(name string) bool {
-	if isAllowedPredefinedTrackEventName(name) {
-		return true
-	}
 	return len(name) > 0 &&
 		len(name) <= maxTrackEventNameLength &&
 		trackEventNamePattern.MatchString(name)
-}
-
-func isAllowedPredefinedTrackEventName(name string) bool {
-	return name == "predefine_pageview"
 }
 
 func copyTrackEventParams(params *map[string]interface{}) map[string]any {

--- a/services/tuttid/api/daemon_tracking_test.go
+++ b/services/tuttid/api/daemon_tracking_test.go
@@ -38,7 +38,7 @@ func TestTrackEventsAcceptsEvents(t *testing.T) {
 					Params:   &params,
 				},
 				{
-					Name:     "predefine_pageview",
+					Name:     "app.pageview",
 					ClientTs: 1749124800010,
 				},
 			},
@@ -73,8 +73,8 @@ func TestTrackEventsAcceptsEvents(t *testing.T) {
 	}
 
 	pageviewEvent := reporter.events[1]
-	if pageviewEvent.Name != "predefine_pageview" {
-		t.Fatalf("pageview event.Name = %q, want %q", pageviewEvent.Name, "predefine_pageview")
+	if pageviewEvent.Name != "app.pageview" {
+		t.Fatalf("pageview event.Name = %q, want %q", pageviewEvent.Name, "app.pageview")
 	}
 	if pageviewEvent.ClientTS != 1749124800010 {
 		t.Fatalf("pageview event.ClientTS = %d, want %d", pageviewEvent.ClientTS, int64(1749124800010))
@@ -141,6 +141,13 @@ func TestTrackEventsRejectsInvalidEventShape(t *testing.T) {
 			name: "bad pattern name",
 			events: []tuttigenerated.TrackEvent{
 				{Name: "ClickWorkspaceCreate", ClientTs: 1749124800000},
+			},
+			wantReason: "analytics_event_name_invalid",
+		},
+		{
+			name: "legacy single segment pageview name",
+			events: []tuttigenerated.TrackEvent{
+				{Name: "predefine_pageview", ClientTs: 1749124800000},
 			},
 			wantReason: "analytics_event_name_invalid",
 		},


### PR DESCRIPTION
## Summary

- rename the renderer pageview analytics event from `predefine_pageview` to `app.pageview`
- move the reporter directory/export to `app-pageview` and update renderer analytics tests
- remove the daemon special-case whitelist for the legacy single-segment event name

## Validation

- `pnpm --filter @tutti-os/desktop test -- src/renderer/src/features/analytics/services/internal/predefinePageviewAnalytics.test.ts src/renderer/src/features/analytics/reporters/reporterCompleteness.test.ts`
- `go test ./api -run 'TestTrackEvents(AcceptsEvents|RejectsInvalidEventShape)'`\n- `pnpm lint:go`\n- `pnpm check:full`\n\n## Notes\n\nThe focus daily-dedupe localStorage key now follows the new event name: `tutti.analytics.app.pageview.focused_day`. Upgrading users may emit one new focus pageview on the first day after this rename because the old key is intentionally not migrated.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated app pageview analytics to use a new event name.
  * Kept pageview reporting behavior the same while changing how the event is identified.

* **Bug Fixes**
  * Improved analytics event validation so older legacy event names are no longer accepted.
  * Updated pageview tracking to use the new daily deduplication key.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->