### PR TITLE
[codex] Center AgentGUI message locator

### DIFF
--- a/packages/agent/gui/app/renderer/agentactivity.css
+++ b/packages/agent/gui/app/renderer/agentactivity.css
@@ -5664,9 +5664,19 @@ button.agent-gui-node__conversation-section-toggle:hover
   --agent-message-locator-dot-size: 6px;
   --agent-message-locator-hit-size: 18px;
   --agent-message-locator-center-offset: 10px;
+  --agent-message-locator-visible-height: 100vh;
 
   position: sticky;
-  top: 50%;
+  top: max(
+    0px,
+    calc(
+      (
+          var(--agent-message-locator-visible-height) -
+            var(--agent-message-locator-height)
+        ) /
+        2
+    )
+  );
   right: 0;
   z-index: 7;
   justify-self: stretch;
@@ -5674,7 +5684,6 @@ button.agent-gui-node__conversation-section-toggle:hover
   height: var(--agent-message-locator-height);
   margin-right: calc(-1 * var(--agent-gui-message-locator-inline-offset));
   margin-bottom: calc(-1 * var(--agent-message-locator-height));
-  transform: translateY(-50%);
   pointer-events: none;
 }
 

--- a/packages/agent/gui/shared/agentConversation/components/AgentTranscriptView.tsx
+++ b/packages/agent/gui/shared/agentConversation/components/AgentTranscriptView.tsx
@@ -385,6 +385,7 @@ function AgentMessageLocatorRail({
   const [shouldRenderPanel, setShouldRenderPanel] = useState(false);
   const [activeKey, setActiveKey] = useState<string | null>(null);
   const [selectedKey, setSelectedKey] = useState<string | null>(null);
+  const [visibleHeightPx, setVisibleHeightPx] = useState<number | null>(null);
   useEffect(() => {
     if (isPanelOpen) {
       setShouldRenderPanel(true);
@@ -409,6 +410,45 @@ function AgentMessageLocatorRail({
       setSelectedKey(null);
     }
   }, [items, selectedKey]);
+  useLayoutEffect(() => {
+    const locator = locatorRef.current;
+    const scrollParent = locator
+      ? findMessageLocatorScrollParent(locator)
+      : null;
+    if (!scrollParent) {
+      return;
+    }
+
+    let animationFrame: number | null = null;
+    const updateVisibleHeight = (): void => {
+      animationFrame = null;
+      const nextHeight = scrollParent.clientHeight;
+      setVisibleHeightPx((current) =>
+        current === nextHeight ? current : nextHeight
+      );
+    };
+    const scheduleUpdate = (): void => {
+      if (animationFrame !== null) {
+        return;
+      }
+      animationFrame = window.requestAnimationFrame(updateVisibleHeight);
+    };
+
+    scheduleUpdate();
+    const resizeObserver =
+      typeof ResizeObserver === "undefined"
+        ? null
+        : new ResizeObserver(scheduleUpdate);
+    resizeObserver?.observe(scrollParent);
+    window.addEventListener("resize", scheduleUpdate);
+    return () => {
+      resizeObserver?.disconnect();
+      window.removeEventListener("resize", scheduleUpdate);
+      if (animationFrame !== null) {
+        window.cancelAnimationFrame(animationFrame);
+      }
+    };
+  }, [items.length]);
   useEffect(() => {
     const locator = locatorRef.current;
     const scrollParent = locator
@@ -505,7 +545,12 @@ function AgentMessageLocatorRail({
       onMouseLeave={closePanelSoon}
       style={
         {
-          "--agent-message-locator-height": `${railHeight}px`
+          "--agent-message-locator-height": `${railHeight}px`,
+          ...(visibleHeightPx !== null
+            ? {
+                "--agent-message-locator-visible-height": `${visibleHeightPx}px`
+              }
+            : {})
         } as CSSProperties
       }
     >


### PR DESCRIPTION
## Summary

- center the AgentGUI message locator rail using the visible conversation flow height
- observe the conversation scroll parent so the locator updates when the timeline resizes
- keep the selected and hover locator dots as 2px rings with transparent fill

## Validation

- `pnpm --dir packages/agent/gui exec vitest run shared/agentConversation/components/AgentTranscriptView.spec.tsx --environment jsdom`
- `pnpm exec prettier --check packages/agent/gui/app/renderer/agentactivity.css packages/agent/gui/shared/agentConversation/components/AgentTranscriptView.tsx --config packages/configs/prettier/base.mjs`

## Notes

Full local pre-push validation is blocked in this environment because the checkout is running Node 20 while the repo requires Node 24 for desktop tests, and the pinned `golangci-lint` binary is not installed locally.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the vertical placement of the message locator so it stays centered within the visible area, even when the window or scroll container size changes.
  * Made the locator rail respond more accurately to viewport and container resizing for more consistent positioning.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->