### PR TITLE
fix(agent-gui): refresh provider usage on info open

### DIFF
--- a/apps/desktop/src/renderer/src/features/workspace-agent/ui/DesktopAgentGUIWorkbenchBody.tsx
+++ b/apps/desktop/src/renderer/src/features/workspace-agent/ui/DesktopAgentGUIWorkbenchBody.tsx
@@ -137,6 +137,7 @@ const DESKTOP_AGENT_GUI_AGENT_SETTINGS = {
   avoidGroupingEdits: false
 } satisfies NonNullable<AgentGUIProps["agentSettings"]>;
 const DESKTOP_AGENT_GUI_NOOP = (): void => {};
+const AGENT_PROBE_REFRESH_DEBOUNCE_MS = 300;
 const DESKTOP_AGENT_GUI_EMPTY_CONTEXT_MENTION_PROVIDERS =
   [] satisfies NonNullable<AgentGUIProps["contextMentionProviders"]>;
 const DESKTOP_AGENT_GUI_POSITION = { x: 0, y: 0 };
@@ -483,6 +484,10 @@ function DesktopAgentGUIWorkbenchBodyImpl({
   const [agentProbeDemandBySource, setAgentProbeDemandBySource] = useState<
     Record<string, string>
   >({});
+  const agentProbeRefreshTimerRef = useRef<ReturnType<
+    typeof setTimeout
+  > | null>(null);
+  const [agentProbeRefreshSequence, setAgentProbeRefreshSequence] = useState(0);
   const [workspaceAgentProbes, setWorkspaceAgentProbes] =
     useState<DesktopAgentProbeState | null>(null);
   const [openSessionRequest, setOpenSessionRequest] = useState<NonNullable<
@@ -578,6 +583,30 @@ function DesktopAgentGUIWorkbenchBodyImpl({
       };
     });
   }, []);
+  const handleAgentProbeRefreshRequest: NonNullable<
+    AgentGUIProps["onAgentProbeRefreshRequest"]
+  > = useCallback((probeProvider, sourceId = "default") => {
+    setAgentProbeDemandBySource((current) =>
+      current[sourceId] === probeProvider
+        ? current
+        : { ...current, [sourceId]: probeProvider }
+    );
+    if (agentProbeRefreshTimerRef.current) {
+      clearTimeout(agentProbeRefreshTimerRef.current);
+    }
+    agentProbeRefreshTimerRef.current = setTimeout(() => {
+      agentProbeRefreshTimerRef.current = null;
+      setAgentProbeRefreshSequence((current) => current + 1);
+    }, AGENT_PROBE_REFRESH_DEBOUNCE_MS);
+  }, []);
+  useEffect(() => {
+    return () => {
+      if (agentProbeRefreshTimerRef.current) {
+        clearTimeout(agentProbeRefreshTimerRef.current);
+        agentProbeRefreshTimerRef.current = null;
+      }
+    };
+  }, []);
   const handleOpenSessionActivationError = useCallback(
     (input: { agentSessionId: string; error: unknown }) => {
       Toast.Error(
@@ -656,6 +685,7 @@ function DesktopAgentGUIWorkbenchBodyImpl({
     };
   }, [
     agentHostApi.workspaceAgentProbes,
+    agentProbeRefreshSequence,
     agentProbeProviders,
     agentProbeProvidersKey,
     runtimeApi,
@@ -961,6 +991,9 @@ function DesktopAgentGUIWorkbenchBodyImpl({
         workspaceAgentProbes={workspaceAgentProbes}
         onAgentProbeDemandChange={
           previewMode ? undefined : handleAgentProbeDemandChange
+        }
+        onAgentProbeRefreshRequest={
+          previewMode ? undefined : handleAgentProbeRefreshRequest
         }
         onAgentProviderLogin={
           !previewMode && agentProviderStatusService

--- a/packages/agent/gui/agent-gui/agentGuiNode/AgentGUINode.spec.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/AgentGUINode.spec.tsx
@@ -907,6 +907,40 @@ describe("AgentGUINode", () => {
     );
   });
 
+  it("requests a fresh agent probe when the title info entry opens", () => {
+    const onAgentProbeRefreshRequest = vi.fn();
+
+    renderAgentGUINode({
+      workspaceAgentProbes: {
+        isLoadingAvailability: false,
+        isLoadingUsage: false,
+        snapshot: {
+          workspaceId: "workspace-1",
+          capturedAtUnixMs: 1,
+          providers: [
+            {
+              provider: "codex",
+              availability: { status: "available", detailsVisible: false },
+              usage: {
+                capturedAtUnixMs: 1,
+                quotas: [{ quotaType: "session", percentRemaining: 79 }]
+              }
+            }
+          ]
+        }
+      },
+      agentActivityRuntime: {} as AgentActivityRuntime,
+      onAgentProbeRefreshRequest
+    });
+
+    fireEvent.mouseEnter(screen.getByTestId("agent-gui-window-agent-info"));
+
+    expect(onAgentProbeRefreshRequest).toHaveBeenCalledWith(
+      "codex",
+      "agent-gui:agent-gui-1"
+    );
+  });
+
   it("updates slash status limits when the selected Codex model changes", () => {
     const workspaceAgentProbes: React.ComponentProps<
       typeof AgentGUINode
@@ -7402,6 +7436,7 @@ function renderAgentGUINode({
   onToggleMaximize,
   workspaceAgentProbes = null,
   onAgentProbeDemandChange,
+  onAgentProbeRefreshRequest,
   managedAgentsState = createManagedAgentsState(),
   workspaceAppIcons,
   strictMode = false,
@@ -7443,6 +7478,9 @@ function renderAgentGUINode({
   onAgentProbeDemandChange?: React.ComponentProps<
     typeof AgentGUINode
   >["onAgentProbeDemandChange"];
+  onAgentProbeRefreshRequest?: React.ComponentProps<
+    typeof AgentGUINode
+  >["onAgentProbeRefreshRequest"];
   managedAgentsState?: React.ComponentProps<
     typeof AgentGUINode
   >["managedAgentsState"];
@@ -7486,6 +7524,7 @@ function renderAgentGUINode({
       onShowMessage={onShowMessage}
       workspaceAgentProbes={workspaceAgentProbes}
       onAgentProbeDemandChange={onAgentProbeDemandChange}
+      onAgentProbeRefreshRequest={onAgentProbeRefreshRequest}
       managedAgentsState={managedAgentsState}
       workspaceAppIcons={workspaceAppIcons}
       contextMentionProviders={createAgentGUITestContextMentionProviders()}

--- a/packages/agent/gui/agent-gui/agentGuiNode/AgentGUINode.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/AgentGUINode.tsx
@@ -29,6 +29,7 @@ import { agentGUIProviderTargetRefsEqual } from "../../providerTargets";
 import type {
   DesktopSize,
   WorkspaceDesktopAgentProbeDemandChange,
+  WorkspaceDesktopAgentProbeRefreshRequest,
   WorkspaceDesktopAgentProbesState
 } from "../workspaceDesktop/types";
 import { resolveCanonicalNodeMinSize } from "../../utils/workspaceNodeSizing";
@@ -213,6 +214,7 @@ export interface AgentGUINodeProps {
   ) => void;
   workspaceAgentProbes?: WorkspaceDesktopAgentProbesState | null;
   onAgentProbeDemandChange?: WorkspaceDesktopAgentProbeDemandChange;
+  onAgentProbeRefreshRequest?: WorkspaceDesktopAgentProbeRefreshRequest;
   managedAgentsState?: AgentHostManagedAgentsState | null;
   contextMentionProviders?: readonly AgentContextMentionProvider[];
   workspaceAppIcons?: readonly AgentMessageMarkdownWorkspaceAppIcon[];
@@ -523,6 +525,7 @@ function areAgentGUINodePropsEqual(
       previous.state.provider
     ) &&
     previous.onAgentProbeDemandChange === next.onAgentProbeDemandChange &&
+    previous.onAgentProbeRefreshRequest === next.onAgentProbeRefreshRequest &&
     previous.managedAgentsState === next.managedAgentsState &&
     previous.contextMentionProviders === next.contextMentionProviders &&
     previous.workspaceAppIcons === next.workspaceAppIcons &&
@@ -582,6 +585,7 @@ export const AgentGUINode = memo(function AgentGUINode({
   onShowMessage,
   workspaceAgentProbes,
   onAgentProbeDemandChange,
+  onAgentProbeRefreshRequest,
   managedAgentsState,
   contextMentionProviders,
   workspaceAppIcons,
@@ -1380,6 +1384,12 @@ export const AgentGUINode = memo(function AgentGUINode({
       onAgentProbeDemandChange(null, probeSourceId);
     };
   }, [activeProbeProvider, nodeId, onAgentProbeDemandChange, previewMode]);
+  const handleAgentProbeInfoOpen = useCallback(() => {
+    if (previewMode || !onAgentProbeRefreshRequest) {
+      return;
+    }
+    onAgentProbeRefreshRequest(activeProbeProvider, `agent-gui:${nodeId}`);
+  }, [activeProbeProvider, nodeId, onAgentProbeRefreshRequest, previewMode]);
 
   return (
     <WorkspaceNodeWindow
@@ -1413,6 +1423,7 @@ export const AgentGUINode = memo(function AgentGUINode({
             lines={agentProbeLines}
             testId="agent-gui-window-agent-info"
             className={styles.windowAgentInfo}
+            onOpen={handleAgentProbeInfoOpen}
           />
           <CanvasNodeGhostIconButton
             aria-label={

--- a/packages/agent/gui/agent-gui/workspaceDesktop/types.ts
+++ b/packages/agent/gui/agent-gui/workspaceDesktop/types.ts
@@ -171,6 +171,11 @@ export type WorkspaceDesktopAgentProbeDemandChange = (
   sourceId?: string
 ) => void;
 
+export type WorkspaceDesktopAgentProbeRefreshRequest = (
+  provider: AgentProvider,
+  sourceId?: string
+) => void;
+
 export interface WorkspaceDesktopProps {
   workspaceId: string;
   currentUserId?: string | null;
@@ -200,6 +205,8 @@ export interface WorkspaceDesktopProps {
   workspaceAgentProbes?: WorkspaceDesktopAgentProbesState | null;
   /** Registers which Agent GUI providers currently need workspace agent probe data. */
   onAgentProbeDemandChange?: WorkspaceDesktopAgentProbeDemandChange;
+  /** Requests a fresh provider probe for an already visible Agent GUI surface. */
+  onAgentProbeRefreshRequest?: WorkspaceDesktopAgentProbeRefreshRequest;
   onRefreshWorkspaceShellRuntime?: () => void | Promise<void>;
   canvasUserWallpaperUrl?: string | null;
   pendingWorkspaceIssueNavigation?: {

--- a/packages/agent/gui/agent-gui/workspaceDesktop/view/AgentProbeInfoPopover.tsx
+++ b/packages/agent/gui/agent-gui/workspaceDesktop/view/AgentProbeInfoPopover.tsx
@@ -54,17 +54,25 @@ function getDockAgentProbeLineLabel(line: DockAgentProbeTooltipLine): string {
 export function AgentProbeInfoPopover({
   lines,
   testId = "agent-probe-info",
-  className
+  className,
+  onOpen
 }: {
   lines: DockAgentProbeTooltipLine[];
   testId?: string;
   className?: string;
+  onOpen?: () => void;
 }): React.JSX.Element | null {
   "use memo";
   const anchorRef = useRef<HTMLDivElement | null>(null);
   const popoverRef = useRef<HTMLDivElement | null>(null);
   const [isOpen, setIsOpen] = useState(false);
   const [popoverStyle, setPopoverStyle] = useState<CSSProperties | null>(null);
+  const openPopover = useCallback((): void => {
+    if (!isOpen) {
+      onOpen?.();
+    }
+    setIsOpen(true);
+  }, [isOpen, onOpen]);
   const closeIfPointerLeavesPopover = useCallback((event: MouseEvent): void => {
     const nextTarget = event.relatedTarget;
     if (
@@ -137,7 +145,7 @@ export function AgentProbeInfoPopover({
       className="desktop-dock-popup__agent-info-popover desktop-dock-popup__agent-info-popover--portal"
       role="status"
       style={popoverStyle ?? undefined}
-      onMouseEnter={() => setIsOpen(true)}
+      onMouseEnter={openPopover}
       onMouseLeave={closeIfPointerLeavesPopover}
     >
       <ul className="desktop-dock-popup__agent-info-list">
@@ -178,12 +186,12 @@ export function AgentProbeInfoPopover({
       data-testid={testId}
       onMouseEnter={() => {
         updatePopoverPosition();
-        setIsOpen(true);
+        openPopover();
       }}
       onMouseLeave={closeIfPointerLeavesPopover}
       onFocus={() => {
         updatePopoverPosition();
-        setIsOpen(true);
+        openPopover();
       }}
       onBlur={() => setIsOpen(false)}
     >

--- a/packages/agent/gui/contexts/workspace/presentation/renderer/components/workspaceDesktop/types.ts
+++ b/packages/agent/gui/contexts/workspace/presentation/renderer/components/workspaceDesktop/types.ts
@@ -173,6 +173,11 @@ export type WorkspaceDesktopAgentProbeDemandChange = (
   sourceId?: string
 ) => void;
 
+export type WorkspaceDesktopAgentProbeRefreshRequest = (
+  provider: AgentProvider,
+  sourceId?: string
+) => void;
+
 export interface WorkspaceDesktopProps {
   workspaceId: string;
   currentUserId?: string | null;
@@ -202,6 +207,8 @@ export interface WorkspaceDesktopProps {
   workspaceAgentProbes?: WorkspaceDesktopAgentProbesState | null;
   /** Registers which Agent GUI providers currently need workspace agent probe data. */
   onAgentProbeDemandChange?: WorkspaceDesktopAgentProbeDemandChange;
+  /** Requests a fresh provider probe for an already visible Agent GUI surface. */
+  onAgentProbeRefreshRequest?: WorkspaceDesktopAgentProbeRefreshRequest;
   onRefreshWorkspaceShellRuntime?: () => void | Promise<void>;
   canvasUserWallpaperUrl?: string | null;
   pendingWorkspaceIssueNavigation?: {


### PR DESCRIPTION
## Summary
- refresh provider usage probes when the Agent GUI title info popover opens
- debounce repeated open requests in the desktop host before calling the existing includeUsage probe path
- add an AgentGUINode regression test for the refresh request

## Testing
- pnpm --filter @tutti-os/desktop typecheck
- pnpm --filter @tutti-os/agent-gui exec vitest run --environment jsdom agent-gui/agentGuiNode/AgentGUINode.spec.tsx -t "requests a fresh agent probe"
- pre-commit: oxfmt, oxlint, staged electron/ui/renderer boundary checks
- pre-push: pnpm check:full

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Agent info panels now refresh more responsively when opened, helping show up-to-date probe data.
  * Probe refresh requests are now debounced to avoid repeated updates from quick successive interactions.
* **Bug Fixes**
  * Improved consistency so opening agent probe details reliably triggers a fresh refresh.
  * Reduced unnecessary rerenders and duplicate refresh activity during agent UI interactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->