### PR TITLE
[codex] Mark unread AgentGUI locator responses

### DIFF
--- a/packages/agent/gui/app/renderer/agentactivity.css
+++ b/packages/agent/gui/app/renderer/agentactivity.css
@@ -5772,6 +5772,20 @@ button.agent-gui-node__conversation-section-toggle:hover
   background: transparent;
 }
 
+.agent-gui-message-locator__tick[data-unread-agent-response="true"]
+  .agent-gui-message-locator__dot {
+  background: var(--tutti-purple);
+}
+
+.agent-gui-message-locator__tick[data-unread-agent-response="true"]:hover
+  .agent-gui-message-locator__dot,
+.agent-gui-message-locator__tick[data-unread-agent-response="true"]:focus-visible
+  .agent-gui-message-locator__dot {
+  border-width: 2px;
+  border-color: var(--tutti-purple);
+  background: transparent;
+}
+
 .agent-gui-message-locator__panel {
   position: absolute;
   top: 50%;

--- a/packages/agent/gui/shared/agentConversation/components/AgentTranscriptView.spec.tsx
+++ b/packages/agent/gui/shared/agentConversation/components/AgentTranscriptView.spec.tsx
@@ -303,6 +303,90 @@ describe("AgentTranscriptView", () => {
     }
   });
 
+  it("marks newly answered user message locator ticks as unread until located", async () => {
+    const base = detailViewModel();
+    const followUpTurn = {
+      id: "turn-2",
+      userMessage: { id: "user-2", body: "Follow-up request" },
+      userMessages: [{ id: "user-2", body: "Follow-up request" }],
+      agentMessages: [],
+      toolCalls: [],
+      toolCallCount: 0,
+      hasFailedToolCall: false,
+      agentItems: []
+    };
+    const labels = {
+      thinkingLabel: "Thought process",
+      toolCallsLabel: (count: number) => `Tool calls (${count})`,
+      processing: "Planning next moves",
+      turnSummary: "Changed files",
+      userMessageLocator: "User messages"
+    };
+    const conversationForTurns = (
+      turns: WorkspaceAgentSessionDetailViewModel["turns"]
+    ) => projectAgentConversationVM(detailViewModel({ turns }));
+    const { rerender } = render(
+      <AgentTranscriptView
+        conversation={conversationForTurns([base.turns[0]!, followUpTurn])}
+        labels={labels}
+      />
+    );
+
+    const locator = screen.getByTestId("agent-message-locator");
+    const initialTicks = locator.querySelectorAll(
+      ".agent-gui-message-locator__tick"
+    );
+    expect(initialTicks[0]).not.toHaveAttribute(
+      "data-unread-agent-response",
+      "true"
+    );
+    expect(initialTicks[1]).not.toHaveAttribute(
+      "data-unread-agent-response",
+      "true"
+    );
+
+    rerender(
+      <AgentTranscriptView
+        conversation={conversationForTurns([
+          base.turns[0]!,
+          {
+            ...followUpTurn,
+            agentMessages: [{ id: "assistant-2", body: "Follow-up answer" }],
+            agentItems: [
+              {
+                kind: "message",
+                message: {
+                  id: "assistant-2",
+                  body: "Follow-up answer"
+                }
+              }
+            ]
+          }
+        ])}
+        labels={labels}
+      />
+    );
+
+    await waitFor(() => {
+      expect(
+        locator.querySelectorAll(".agent-gui-message-locator__tick")[1]
+      ).toHaveAttribute("data-unread-agent-response", "true");
+    });
+    expect(
+      locator.querySelectorAll(".agent-gui-message-locator__tick")[0]
+    ).not.toHaveAttribute("data-unread-agent-response", "true");
+
+    fireEvent.click(
+      locator.querySelectorAll(".agent-gui-message-locator__tick")[1]!
+    );
+
+    await waitFor(() => {
+      expect(
+        locator.querySelectorAll(".agent-gui-message-locator__tick")[1]
+      ).not.toHaveAttribute("data-unread-agent-response", "true");
+    });
+  });
+
   it("renders attached thinking before assistant message content within the same row", () => {
     render(
       <AgentTranscriptView

--- a/packages/agent/gui/shared/agentConversation/components/AgentTranscriptView.tsx
+++ b/packages/agent/gui/shared/agentConversation/components/AgentTranscriptView.tsx
@@ -53,6 +53,7 @@ interface AgentTranscriptViewProps {
 }
 
 interface AgentMessageLocatorItem {
+  hasAgentResponse: boolean;
   key: string;
   rowKey: string;
   turnGroupIndex: number;
@@ -385,6 +386,13 @@ function AgentMessageLocatorRail({
   const [shouldRenderPanel, setShouldRenderPanel] = useState(false);
   const [activeKey, setActiveKey] = useState<string | null>(null);
   const [selectedKey, setSelectedKey] = useState<string | null>(null);
+  const previousAgentResponseByKeyRef = useRef<ReadonlyMap<
+    string,
+    boolean
+  > | null>(null);
+  const [unreadAgentResponseKeys, setUnreadAgentResponseKeys] = useState<
+    ReadonlySet<string>
+  >(new Set());
   const [visibleHeightPx, setVisibleHeightPx] = useState<number | null>(null);
   useEffect(() => {
     if (isPanelOpen) {
@@ -410,6 +418,59 @@ function AgentMessageLocatorRail({
       setSelectedKey(null);
     }
   }, [items, selectedKey]);
+  useEffect(() => {
+    const previousAgentResponseByKey = previousAgentResponseByKeyRef.current;
+    const currentKeys = new Set(items.map((item) => item.key));
+
+    setUnreadAgentResponseKeys((currentUnreadKeys) => {
+      let nextUnreadKeys: Set<string> | null = null;
+      const ensureNextUnreadKeys = (): Set<string> => {
+        if (!nextUnreadKeys) {
+          nextUnreadKeys = new Set(currentUnreadKeys);
+        }
+        return nextUnreadKeys;
+      };
+
+      for (const key of currentUnreadKeys) {
+        if (!currentKeys.has(key)) {
+          ensureNextUnreadKeys().delete(key);
+        }
+      }
+
+      if (previousAgentResponseByKey) {
+        for (const item of items) {
+          const hadAgentResponse =
+            previousAgentResponseByKey.get(item.key) ?? false;
+          if (
+            item.hasAgentResponse &&
+            !hadAgentResponse &&
+            item.key !== selectedKey
+          ) {
+            ensureNextUnreadKeys().add(item.key);
+          }
+        }
+      }
+
+      return nextUnreadKeys ?? currentUnreadKeys;
+    });
+
+    previousAgentResponseByKeyRef.current = new Map(
+      items.map((item) => [item.key, item.hasAgentResponse])
+    );
+  }, [items, selectedKey]);
+  useEffect(() => {
+    if (!selectedKey) {
+      return;
+    }
+    setUnreadAgentResponseKeys((currentUnreadKeys) => {
+      if (!currentUnreadKeys.has(selectedKey)) {
+        return currentUnreadKeys;
+      }
+      const nextUnreadKeys = new Set(currentUnreadKeys);
+      nextUnreadKeys.delete(selectedKey);
+      return nextUnreadKeys;
+    });
+  }, [selectedKey]);
   useLayoutEffect(() => {
     const locator = locatorRef.current;
     const scrollParent = locator
@@ -492,9 +553,20 @@ function AgentMessageLocatorRail({
 
   const railHeight = (items.length - 1) * 30 + 18;
   const activeOrSelectedKey = activeKey ?? selectedKey;
+  const markItemRead = (itemKey: string): void => {
+    setUnreadAgentResponseKeys((currentUnreadKeys) => {
+      if (!currentUnreadKeys.has(itemKey)) {
+        return currentUnreadKeys;
+      }
+      const nextUnreadKeys = new Set(currentUnreadKeys);
+      nextUnreadKeys.delete(itemKey);
+      return nextUnreadKeys;
+    });
+  };
   const handleLocateItem = (item: AgentMessageLocatorItem): void => {
     setSelectedKey(item.key);
     setActiveKey(item.key);
+    markItemRead(item.key);
     onLocate(item);
   };
   const openPanel = (): void => {
@@ -579,6 +651,9 @@ function AgentMessageLocatorRail({
           aria-label={item.summary}
           title={item.summary}
           data-selected={item.key === selectedKey ? "true" : undefined}
+          data-unread-agent-response={
+            unreadAgentResponseKeys.has(item.key) ? "true" : undefined
+          }
           onClick={() => handleLocateItem(item)}
           onFocus={() => setActiveKey(item.key)}
           onMouseEnter={() => setActiveKey(item.key)}
@@ -748,6 +823,7 @@ function buildUserMessageLocatorItems(
     }
     const rowKey = rowKeys[rowIndex] ?? transcriptRowKey(row);
     items.push({
+      hasAgentResponse: hasAgentResponseForTurn(rows, row, rowIndex),
       key: `user-message:${rowKey}`,
       rowKey,
       turnGroupIndex: turnGroupIndexByRowIndex.get(rowIndex) ?? rowIndex,
@@ -756,6 +832,30 @@ function buildUserMessageLocatorItems(
     });
   });
   return items;
+}
+
+function hasAgentResponseForTurn(
+  rows: ReadonlyArray<AgentConversationVM["rows"][number]>,
+  userRow: AgentConversationVM["rows"][number],
+  userRowIndex: number
+): boolean {
+  const turnId = userRow.turnId ?? null;
+  for (let index = userRowIndex + 1; index < rows.length; index += 1) {
+    const row = rows[index];
+    if (row.kind !== "message") {
+      continue;
+    }
+    if (row.speaker === "user") {
+      return false;
+    }
+    if (turnId && row.turnId !== turnId) {
+      return false;
+    }
+    if (row.speaker === "assistant") {
+      return true;
+    }
+  }
+  return false;
 }
 
 function summarizeUserMessageRow(


### PR DESCRIPTION
## Summary

- mark user-message locator ticks as unread when an agent response arrives after the current page load
- render unread locator ticks with `--tutti-purple`, keeping hover/focus as a 2px purple ring
- clear the unread marker when the user scrolls to or clicks the corresponding locator tick

## Validation

- `pnpm --dir packages/agent/gui exec vitest run shared/agentConversation/components/AgentTranscriptView.spec.tsx --environment jsdom`
- `pnpm exec prettier --check packages/agent/gui/app/renderer/agentactivity.css --config packages/configs/prettier/base.mjs`
- `pnpm exec oxfmt --check packages/agent/gui/shared/agentConversation/components/AgentTranscriptView.tsx packages/agent/gui/shared/agentConversation/components/AgentTranscriptView.spec.tsx`

## Notes

Full local pre-push validation is blocked in this environment because the checkout shell is running Node 20 while full desktop tests require Node 24, and the pinned `golangci-lint` binary is not installed locally.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Message locator ticks now indicate when a user message has a new agent response.
  * Unread responses are highlighted visually and clear once the item is opened or clicked.

* **Bug Fixes**
  * Improved locator behavior so unread markers update correctly when conversation context changes.
  * Selection changes now keep read/unread state in sync for the active message.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->