### PR TITLE
fix(workbench): preserve dock magnification edge hover

### DIFF
--- a/packages/workbench/surface/src/host/dockMagnification.test.ts
+++ b/packages/workbench/surface/src/host/dockMagnification.test.ts
@@ -480,6 +480,14 @@ test("dock magnification samples ambient pointer moves without taking dock point
   );
   assert.match(
     source,
+    /const clearAmbientPointerSample = \(\) => \{[\s\S]*?latestPoint = null;[\s\S]*?cancelAnimationFrame\(animationFrame\);/
+  );
+  assert.match(
+    source,
+    /!isPointNearDockScreenEdge\([\s\S]*?\) \{[\s\S]*?clearAmbientPointerSample\(\);[\s\S]*?return;/
+  );
+  assert.match(
+    source,
     /isPointerInsideDockMagnificationTarget\(point\.clientX, point\.clientY\)[\s\S]*?handlePointerMove\(point\.clientX, point\.clientY\);/
   );
 });

--- a/packages/workbench/surface/src/host/dockMagnification.test.ts
+++ b/packages/workbench/surface/src/host/dockMagnification.test.ts
@@ -10,13 +10,15 @@ import {
   DOCK_MAGNIFICATION_HALF_RANGE,
   createDockMagnificationGlobalPointerTracker,
   isDockMagnificationPointInsideHitBounds,
+  isDockMagnificationPointInsideSlotRect,
   isDockMagnificationSlotLayoutLocked,
   isDockMagnificationSpringSettled,
   mapDistanceToTargetSize,
   resolveDockMagnificationHitBounds,
   resolveDockMagnificationSlotLayoutSize,
   resolveDockMagnificationSlotCenter,
-  resolveDockMagnificationVisibleHitBounds
+  resolveDockMagnificationVisibleHitBounds,
+  resolveDockMagnificationVisibleSlotRects
 } from "./dockMagnification.ts";
 
 const source = readFileSync(resolve("src/host/dockMagnification.ts"), "utf8");
@@ -204,6 +206,38 @@ test("dock magnification visible hit bounds clip overflow slots to the viewport"
   );
 });
 
+test("dock magnification visible hit bounds preserve edge hover room near the viewport", () => {
+  const slotHitBounds = resolveDockMagnificationHitBounds(
+    [
+      { bottom: 80, left: 100, right: 143.2, top: 36.8 },
+      { bottom: 80, left: 160, right: 203.2, top: 36.8 }
+    ],
+    "bottom"
+  );
+  const visibleHitBounds = resolveDockMagnificationVisibleHitBounds({
+    dockPlacement: "bottom",
+    hitBounds: slotHitBounds,
+    mainAxisEdgePadding: DOCK_ICON_BASE_SIZE / 2,
+    viewportRect: { bottom: 88, left: 90, right: 210, top: 0 }
+  });
+
+  assertBoundsEqual(visibleHitBounds, {
+    crossEnd: 88,
+    crossStart: 28.8,
+    mainEnd: 224.8,
+    mainStart: 78.4
+  });
+  assert.equal(
+    isDockMagnificationPointInsideHitBounds({
+      clientX: 80,
+      clientY: 60,
+      dockPlacement: "bottom",
+      hitBounds: visibleHitBounds
+    }),
+    true
+  );
+});
+
 test("left dock magnification hit bounds use the vertical slot range", () => {
   const hitBounds = resolveDockMagnificationHitBounds(
     [
@@ -244,6 +278,65 @@ test("dock magnification expands both slot axes so neighbors keep spacing", () =
       height: DOCK_ICON_PEAK_SIZE,
       width: DOCK_ICON_PEAK_SIZE
     }
+  );
+});
+
+test("dock magnification keeps slot edge points eligible", () => {
+  const rect = { bottom: 80, left: 100, right: 143.2, top: 36.8 };
+
+  assert.equal(
+    isDockMagnificationPointInsideSlotRect({
+      clientX: 100,
+      clientY: 60,
+      rect
+    }),
+    true
+  );
+  assert.equal(
+    isDockMagnificationPointInsideSlotRect({
+      clientX: 143.2,
+      clientY: 60,
+      rect
+    }),
+    true
+  );
+  assert.equal(
+    isDockMagnificationPointInsideSlotRect({
+      clientX: 99.9,
+      clientY: 60,
+      rect
+    }),
+    false
+  );
+});
+
+test("dock magnification clips slot edge eligibility to the viewport", () => {
+  const visibleRects = resolveDockMagnificationVisibleSlotRects({
+    slotRects: [
+      { bottom: 80, left: 100, right: 143.2, top: 36.8 },
+      { bottom: 80, left: 720, right: 763.2, top: 36.8 }
+    ],
+    viewportRect: { bottom: 88, left: 64, right: 120, top: 0 }
+  });
+
+  assert.deepEqual(visibleRects, [
+    { bottom: 80, left: 100, right: 120, top: 36.8 }
+  ]);
+  assert.equal(
+    isDockMagnificationPointInsideSlotRect({
+      clientX: 120,
+      clientY: 60,
+      rect: visibleRects[0]!
+    }),
+    true
+  );
+  assert.equal(
+    isDockMagnificationPointInsideSlotRect({
+      clientX: 130,
+      clientY: 60,
+      rect: visibleRects[0]!
+    }),
+    false
   );
 });
 
@@ -358,7 +451,11 @@ test("dock magnification starts global tracking on active pointers and stops on 
   );
   assert.match(
     source,
-    /if \([\s\S]*?!isDockMagnificationPointInsideHitBounds\([\s\S]*?\) \{[\s\S]*?stopGlobalPointerTracking\(\);[\s\S]*?clearTrackedPointer\(\);/
+    /const isPointerInsideDockMagnificationTarget = useCallback\([\s\S]*?isDockMagnificationPointInsideHitBounds\([\s\S]*?\) \|\| isPointerInsideAnyVisibleDockSlot\(clientX, clientY\)/
+  );
+  assert.match(
+    source,
+    /if \(!isPointerInsideDockMagnificationTarget\(clientX, clientY\)\) \{[\s\S]*?stopGlobalPointerTracking\(\);[\s\S]*?clearTrackedPointer\(\);/
   );
   assert.match(
     source,
@@ -367,6 +464,23 @@ test("dock magnification starts global tracking on active pointers and stops on 
   assert.match(
     source,
     /useEffect\(\s*\(\) => \(\) => \{[\s\S]*?resetMagnification\(\);/
+  );
+});
+
+test("dock magnification samples ambient pointer moves without taking dock pointer events", () => {
+  assert.match(
+    source,
+    /document\.addEventListener\(\s*"pointermove",\s*handleAmbientPointerMove/
+  );
+  assert.match(source, /isPointNearDockScreenEdge\(/);
+  assert.match(source, /isPointNearDockViewport\(/);
+  assert.match(
+    source,
+    /const handleAmbientPointerMove = \(event: PointerEvent\) => \{[\s\S]*?!isPointNearDockScreenEdge\([\s\S]*?return;[\s\S]*?latestPoint =/
+  );
+  assert.match(
+    source,
+    /isPointerInsideDockMagnificationTarget\(point\.clientX, point\.clientY\)[\s\S]*?handlePointerMove\(point\.clientX, point\.clientY\);/
   );
 });
 
@@ -421,6 +535,6 @@ test("dock magnification refreshes slot centers while the pointer is active", ()
   );
   assert.match(
     source,
-    /if \(restCentersRef\.current === null\) \{[\s\S]*?captureRestCenters\(\);/
+    /const ensureDockMagnificationGeometry = useCallback\([\s\S]*?restCentersRef\.current === null[\s\S]*?hitBoundsRef\.current === null[\s\S]*?visibleSlotRectsRef\.current === null[\s\S]*?captureRestCenters\(\);/
   );
 });

--- a/packages/workbench/surface/src/host/dockMagnification.ts
+++ b/packages/workbench/surface/src/host/dockMagnification.ts
@@ -773,6 +773,14 @@ export function useDockMagnification({
     let animationFrame: number | null = null;
     let latestPoint: { clientX: number; clientY: number } | null = null;
 
+    const clearAmbientPointerSample = () => {
+      latestPoint = null;
+      if (animationFrame !== null) {
+        cancelAnimationFrame(animationFrame);
+        animationFrame = null;
+      }
+    };
+
     const runAmbientPointerMove = () => {
       animationFrame = null;
       const point = latestPoint;
@@ -812,6 +820,7 @@ export function useDockMagnification({
 
     const handleAmbientPointerMove = (event: PointerEvent) => {
       if (magnifyActiveRef.current) {
+        clearAmbientPointerSample();
         return;
       }
       if (
@@ -821,6 +830,7 @@ export function useDockMagnification({
           dockPlacement
         })
       ) {
+        clearAmbientPointerSample();
         return;
       }
       latestPoint = { clientX: event.clientX, clientY: event.clientY };
@@ -840,9 +850,7 @@ export function useDockMagnification({
         handleAmbientPointerMove,
         globalPointerListenerOptions
       );
-      if (animationFrame !== null) {
-        cancelAnimationFrame(animationFrame);
-      }
+      clearAmbientPointerSample();
     };
   }, [
     dockPlacement,

--- a/packages/workbench/surface/src/host/dockMagnification.ts
+++ b/packages/workbench/surface/src/host/dockMagnification.ts
@@ -1,13 +1,17 @@
 import { useCallback, useEffect, useRef, type RefObject } from "react";
 import {
   isDockMagnificationPointInsideHitBounds,
+  isDockMagnificationPointInsideSlotRect,
   resolveDockMagnificationVisibleHitBounds,
+  resolveDockMagnificationVisibleSlotRects,
   type DockMagnificationHitBounds
 } from "./dockMagnificationBounds.ts";
 
 export {
   isDockMagnificationPointInsideHitBounds,
+  isDockMagnificationPointInsideSlotRect,
   resolveDockMagnificationVisibleHitBounds,
+  resolveDockMagnificationVisibleSlotRects,
   type DockMagnificationHitBounds
 } from "./dockMagnificationBounds.ts";
 
@@ -24,6 +28,9 @@ const MAX_MAGNIFICATION_STEP_SECONDS = 1 / 30;
 const MAGNIFICATION_INFLUENCE_PADDING = 8;
 const DOCK_MAGNIFICATION_ENTRY_RAMP_MS = 90;
 const DOCK_MAGNIFICATION_CROSS_AXIS_PADDING = 8;
+const DOCK_MAGNIFICATION_MAIN_AXIS_EDGE_PADDING = DOCK_ICON_BASE_SIZE / 2;
+const DOCK_MAGNIFICATION_AMBIENT_EDGE_RANGE = 180;
+const DOCK_MAGNIFICATION_AMBIENT_VIEWPORT_PADDING = 8;
 
 interface DockMagnificationSpring {
   value: number;
@@ -347,6 +354,52 @@ function clearDockSlotMagnification(
   shell?.style.removeProperty("transform");
 }
 
+function isPointNearDockScreenEdge({
+  clientX,
+  clientY,
+  dockPlacement
+}: {
+  clientX: number;
+  clientY: number;
+  dockPlacement: "bottom" | "left";
+}): boolean {
+  if (typeof window === "undefined") {
+    return true;
+  }
+
+  return dockPlacement === "left"
+    ? clientX <= DOCK_MAGNIFICATION_AMBIENT_EDGE_RANGE
+    : window.innerHeight - clientY <= DOCK_MAGNIFICATION_AMBIENT_EDGE_RANGE;
+}
+
+function isPointNearDockViewport({
+  clientX,
+  clientY,
+  dockPlacement,
+  viewportRect
+}: {
+  clientX: number;
+  clientY: number;
+  dockPlacement: "bottom" | "left";
+  viewportRect: DockMagnificationSlotRect;
+}): boolean {
+  const horizontalPadding =
+    dockPlacement === "bottom"
+      ? DOCK_MAGNIFICATION_MAIN_AXIS_EDGE_PADDING
+      : DOCK_MAGNIFICATION_AMBIENT_VIEWPORT_PADDING;
+  const verticalPadding =
+    dockPlacement === "left"
+      ? DOCK_MAGNIFICATION_MAIN_AXIS_EDGE_PADDING
+      : DOCK_MAGNIFICATION_AMBIENT_VIEWPORT_PADDING;
+
+  return (
+    clientX >= viewportRect.left - horizontalPadding &&
+    clientX <= viewportRect.right + horizontalPadding &&
+    clientY >= viewportRect.top - verticalPadding &&
+    clientY <= viewportRect.bottom + verticalPadding
+  );
+}
+
 export function useDockMagnification({
   dockPlacement,
   dockRootRef,
@@ -369,6 +422,7 @@ export function useDockMagnification({
   const entryRampStartedAtRef = useRef<number | null>(null);
   const restCentersRef = useRef<Map<string, number> | null>(null);
   const hitBoundsRef = useRef<DockMagnificationHitBounds | null>(null);
+  const visibleSlotRectsRef = useRef<DockMagnificationSlotRect[] | null>(null);
   const slotOrderRef = useRef<string[]>([]);
   const magnifyActiveRef = useRef(false);
   const globalPointerTrackerRef =
@@ -424,20 +478,65 @@ export function useDockMagnification({
       centers.set(anchorKey, center);
     }
     slotOrderRef.current = order;
+    const visibleViewportRect = viewportRect
+      ? {
+          bottom: viewportRect.bottom,
+          left: viewportRect.left,
+          right: viewportRect.right,
+          top: viewportRect.top
+        }
+      : null;
     hitBoundsRef.current = resolveDockMagnificationVisibleHitBounds({
       dockPlacement,
       hitBounds: resolveDockMagnificationHitBounds(slotRects, dockPlacement),
-      viewportRect: viewportRect
-        ? {
-            bottom: viewportRect.bottom,
-            left: viewportRect.left,
-            right: viewportRect.right,
-            top: viewportRect.top
-          }
-        : null
+      mainAxisEdgePadding: DOCK_MAGNIFICATION_MAIN_AXIS_EDGE_PADDING,
+      viewportRect: visibleViewportRect
+    });
+    visibleSlotRectsRef.current = resolveDockMagnificationVisibleSlotRects({
+      slotRects,
+      viewportRect: visibleViewportRect
     });
     restCentersRef.current = centers;
   }, [dockPlacement, dockViewportRef, slotRefs]);
+
+  const isPointerInsideAnyVisibleDockSlot = useCallback(
+    (clientX: number, clientY: number): boolean => {
+      for (const rect of visibleSlotRectsRef.current ?? []) {
+        if (
+          isDockMagnificationPointInsideSlotRect({
+            clientX,
+            clientY,
+            rect
+          })
+        ) {
+          return true;
+        }
+      }
+      return false;
+    },
+    []
+  );
+
+  const ensureDockMagnificationGeometry = useCallback(() => {
+    if (
+      restCentersRef.current === null ||
+      hitBoundsRef.current === null ||
+      visibleSlotRectsRef.current === null
+    ) {
+      captureRestCenters();
+    }
+  }, [captureRestCenters]);
+
+  const isPointerInsideDockMagnificationTarget = useCallback(
+    (clientX: number, clientY: number): boolean =>
+      isDockMagnificationPointInsideHitBounds({
+        clientX,
+        clientY,
+        dockPlacement,
+        hitBounds: hitBoundsRef.current
+      }) || isPointerInsideAnyVisibleDockSlot(clientX, clientY),
+    [dockPlacement, isPointerInsideAnyVisibleDockSlot]
+  );
 
   const runAnimationFrame = useCallback(
     (frameTime: number) => {
@@ -576,6 +675,7 @@ export function useDockMagnification({
         entryRampStartedAtRef.current = null;
         restCentersRef.current = null;
         hitBoundsRef.current = null;
+        visibleSlotRectsRef.current = null;
         slotOrderRef.current = [];
         setMagnifyActive(false);
       }
@@ -635,18 +735,9 @@ export function useDockMagnification({
 
   const handlePointerMove = useCallback(
     (clientX: number, clientY: number) => {
-      if (restCentersRef.current === null) {
-        captureRestCenters();
-      }
+      ensureDockMagnificationGeometry();
 
-      if (
-        !isDockMagnificationPointInsideHitBounds({
-          clientX,
-          clientY,
-          dockPlacement,
-          hitBounds: hitBoundsRef.current
-        })
-      ) {
+      if (!isPointerInsideDockMagnificationTarget(clientX, clientY)) {
         stopGlobalPointerTracking();
         clearTrackedPointer();
         return;
@@ -661,9 +752,10 @@ export function useDockMagnification({
       scheduleAnimation();
     },
     [
-      captureRestCenters,
       clearTrackedPointer,
       dockPlacement,
+      ensureDockMagnificationGeometry,
+      isPointerInsideDockMagnificationTarget,
       scheduleAnimation,
       setMagnifyActive,
       startGlobalPointerTracking,
@@ -672,6 +764,93 @@ export function useDockMagnification({
   );
   handleGlobalPointerMoveRef.current = handlePointerMove;
   handleGlobalPointerCancelRef.current = handleGlobalPointerCancel;
+
+  useEffect(() => {
+    if (typeof document === "undefined") {
+      return;
+    }
+
+    let animationFrame: number | null = null;
+    let latestPoint: { clientX: number; clientY: number } | null = null;
+
+    const runAmbientPointerMove = () => {
+      animationFrame = null;
+      const point = latestPoint;
+      latestPoint = null;
+      if (!point || magnifyActiveRef.current) {
+        return;
+      }
+
+      const viewportRect = dockViewportRef.current?.getBoundingClientRect();
+      if (!viewportRect) {
+        return;
+      }
+      const visibleViewportRect = {
+        bottom: viewportRect.bottom,
+        left: viewportRect.left,
+        right: viewportRect.right,
+        top: viewportRect.top
+      };
+      if (
+        !isPointNearDockViewport({
+          clientX: point.clientX,
+          clientY: point.clientY,
+          dockPlacement,
+          viewportRect: visibleViewportRect
+        })
+      ) {
+        return;
+      }
+
+      ensureDockMagnificationGeometry();
+      if (
+        isPointerInsideDockMagnificationTarget(point.clientX, point.clientY)
+      ) {
+        handlePointerMove(point.clientX, point.clientY);
+      }
+    };
+
+    const handleAmbientPointerMove = (event: PointerEvent) => {
+      if (magnifyActiveRef.current) {
+        return;
+      }
+      if (
+        !isPointNearDockScreenEdge({
+          clientX: event.clientX,
+          clientY: event.clientY,
+          dockPlacement
+        })
+      ) {
+        return;
+      }
+      latestPoint = { clientX: event.clientX, clientY: event.clientY };
+      if (animationFrame === null) {
+        animationFrame = requestAnimationFrame(runAmbientPointerMove);
+      }
+    };
+
+    document.addEventListener(
+      "pointermove",
+      handleAmbientPointerMove,
+      globalPointerListenerOptions
+    );
+    return () => {
+      document.removeEventListener(
+        "pointermove",
+        handleAmbientPointerMove,
+        globalPointerListenerOptions
+      );
+      if (animationFrame !== null) {
+        cancelAnimationFrame(animationFrame);
+      }
+    };
+  }, [
+    dockPlacement,
+    dockViewportRef,
+    ensureDockMagnificationGeometry,
+    handlePointerMove,
+    isPointerInsideDockMagnificationTarget
+  ]);
 
   const handlePointerLeave = useCallback(() => {
     pendingPointerAxisRef.current = null;
@@ -685,6 +864,7 @@ export function useDockMagnification({
       restCentersRef.current?.delete(anchorKey);
       appliedStylesRef.current.delete(anchorKey);
       hitBoundsRef.current = null;
+      visibleSlotRectsRef.current = null;
       slotOrderRef.current = slotOrderRef.current.filter(
         (key) => key !== anchorKey
       );
@@ -715,6 +895,7 @@ export function useDockMagnification({
     appliedStylesRef.current.clear();
     restCentersRef.current = null;
     hitBoundsRef.current = null;
+    visibleSlotRectsRef.current = null;
     slotOrderRef.current = [];
     pointerAxisRef.current = null;
     pendingPointerAxisRef.current = null;

--- a/packages/workbench/surface/src/host/dockMagnificationBounds.ts
+++ b/packages/workbench/surface/src/host/dockMagnificationBounds.ts
@@ -29,10 +29,12 @@ function resolveDockMagnificationViewportBounds(
 export function resolveDockMagnificationVisibleHitBounds({
   dockPlacement,
   hitBounds,
+  mainAxisEdgePadding = 0,
   viewportRect
 }: {
   dockPlacement: "bottom" | "left";
   hitBounds: DockMagnificationHitBounds | null;
+  mainAxisEdgePadding?: number;
   viewportRect: DockMagnificationSlotRect | null;
 }): DockMagnificationHitBounds | null {
   if (!hitBounds || !viewportRect) {
@@ -46,8 +48,14 @@ export function resolveDockMagnificationVisibleHitBounds({
   const visibleBounds = {
     crossEnd: Math.min(hitBounds.crossEnd, viewportBounds.crossEnd),
     crossStart: Math.max(hitBounds.crossStart, viewportBounds.crossStart),
-    mainEnd: Math.min(hitBounds.mainEnd, viewportBounds.mainEnd),
-    mainStart: Math.max(hitBounds.mainStart, viewportBounds.mainStart)
+    mainEnd: Math.min(
+      hitBounds.mainEnd + mainAxisEdgePadding,
+      viewportBounds.mainEnd + mainAxisEdgePadding
+    ),
+    mainStart: Math.max(
+      hitBounds.mainStart - mainAxisEdgePadding,
+      viewportBounds.mainStart - mainAxisEdgePadding
+    )
   };
 
   if (
@@ -58,6 +66,37 @@ export function resolveDockMagnificationVisibleHitBounds({
   }
 
   return visibleBounds;
+}
+
+export function resolveDockMagnificationVisibleSlotRects({
+  slotRects,
+  viewportRect
+}: {
+  slotRects: readonly DockMagnificationSlotRect[];
+  viewportRect: DockMagnificationSlotRect | null;
+}): DockMagnificationSlotRect[] {
+  if (!viewportRect) {
+    return [...slotRects];
+  }
+
+  const visibleSlotRects: DockMagnificationSlotRect[] = [];
+  for (const rect of slotRects) {
+    const visibleRect = {
+      bottom: Math.min(rect.bottom, viewportRect.bottom),
+      left: Math.max(rect.left, viewportRect.left),
+      right: Math.min(rect.right, viewportRect.right),
+      top: Math.max(rect.top, viewportRect.top)
+    };
+
+    if (
+      visibleRect.left <= visibleRect.right &&
+      visibleRect.top <= visibleRect.bottom
+    ) {
+      visibleSlotRects.push(visibleRect);
+    }
+  }
+
+  return visibleSlotRects;
 }
 
 export function isDockMagnificationPointInsideHitBounds({
@@ -82,5 +121,22 @@ export function isDockMagnificationPointInsideHitBounds({
     mainAxis <= hitBounds.mainEnd &&
     crossAxis >= hitBounds.crossStart &&
     crossAxis <= hitBounds.crossEnd
+  );
+}
+
+export function isDockMagnificationPointInsideSlotRect({
+  clientX,
+  clientY,
+  rect
+}: {
+  clientX: number;
+  clientY: number;
+  rect: DockMagnificationSlotRect;
+}): boolean {
+  return (
+    clientX >= rect.left &&
+    clientX <= rect.right &&
+    clientY >= rect.top &&
+    clientY <= rect.bottom
   );
 }


### PR DESCRIPTION
## Summary
- preserve dock magnification hover eligibility near viewport edges
- track visible dock slot rects so edge points remain eligible after clipping
- sample ambient pointer movement near the dock without taking pointer events from slots

## Verification
- pnpm check:full

## Checklist
- [x] I kept the change focused on one concern.
- [x] I updated documentation when behavior, setup, or contributor workflow changed, or verified no documentation impact was required.
- [x] I updated all README/CONTRIBUTING language variants when changing their English source, or did not change them.
- [x] I ran the lowest meaningful local checks for the changed surface.
- [x] My commits are signed off with DCO when required: git commit -s.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved dock magnification behavior near screen edges, making activation feel more consistent and responsive.
  * Fixed cases where dock items at the edges were incorrectly ignored or lost eligibility when the view was partially clipped.
  * Refined pointer handling so magnification now updates more reliably when moving near the dock, reducing missed activations and stale hover states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->