### PR TITLE
feat(workspace-files): expose reference source locations

### DIFF
--- a/apps/desktop/src/renderer/src/features/agent-reference-sources/workspaceFileLocationReferenceSources.ts
+++ b/apps/desktop/src/renderer/src/features/agent-reference-sources/workspaceFileLocationReferenceSources.ts
@@ -326,19 +326,28 @@ function locationNodes(
   locations: readonly WorkspaceFileLocation[],
   sourceId: string
 ): ReferenceNode[] {
-  return locations.map((location) => ({
-    ref: {
-      sourceId,
-      nodeId:
-        location.kind === "recent"
-          ? RECENT_GROUP_NODE_ID
-          : location.referenceNodeId
-    },
-    kind: "folder",
-    displayName: location.label,
-    ...(location.contextLabel ? { contextLabel: location.contextLabel } : {}),
-    hasChildren: true
-  }));
+  return locations
+    .filter(
+      (
+        location
+      ): location is Extract<
+        WorkspaceFileLocation,
+        { kind: "directory" | "recent" }
+      > => location.kind === "directory" || location.kind === "recent"
+    )
+    .map((location) => ({
+      ref: {
+        sourceId,
+        nodeId:
+          location.kind === "recent"
+            ? RECENT_GROUP_NODE_ID
+            : location.referenceNodeId
+      },
+      kind: "folder",
+      displayName: location.label,
+      ...(location.contextLabel ? { contextLabel: location.contextLabel } : {}),
+      hasChildren: true
+    }));
 }
 
 async function resolveSearchLocations(input: {

--- a/apps/desktop/src/renderer/src/features/workspace-file-manager/services/internal/workspaceFileManagerService.test.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-file-manager/services/internal/workspaceFileManagerService.test.ts
@@ -77,6 +77,43 @@ test("workspace file manager service does not refresh unchanged locations during
   assert.deepEqual(notifications, []);
 });
 
+test("workspace file manager service caches reference aggregators by locale", async () => {
+  const dependencies = createDependenciesStub();
+  dependencies.tuttidClient.listWorkspaceApps = async () => ({
+    apps: [],
+    catalogStatus: {
+      lastError: null,
+      status: "ready",
+      updatedAtUnixMs: null
+    },
+    workspaceId: "workspace-1"
+  });
+  const service = new WorkspaceFileManagerService(dependencies);
+
+  const enAggregator = service.getReferenceSourceAggregator(
+    "workspace-1",
+    "en"
+  );
+  const zhAggregator = service.getReferenceSourceAggregator(
+    "workspace-1",
+    "zh-CN"
+  );
+
+  assert.equal(
+    service.getReferenceSourceAggregator("workspace-1", "en"),
+    enAggregator
+  );
+  assert.notEqual(enAggregator, zhAggregator);
+  assert.equal(
+    (await enAggregator.listSources({ workspaceId: "workspace-1" }))[0]?.label,
+    "Tasks"
+  );
+  assert.equal(
+    (await zhAggregator.listSources({ workspaceId: "workspace-1" }))[0]?.label,
+    "任务"
+  );
+});
+
 test("workspace file manager service defaults new sessions to the user home directory", () => {
   const service = new WorkspaceFileManagerService(createDependenciesStub());
   const copy = createWorkspaceFileManagerI18nRuntime(

--- a/apps/desktop/src/renderer/src/features/workspace-file-manager/services/internal/workspaceFileManagerService.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-file-manager/services/internal/workspaceFileManagerService.ts
@@ -1,6 +1,7 @@
 import {
   createWorkspaceFileManagerService,
   resolveWorkspaceFileExtension,
+  type WorkspaceFileExternalLocation,
   type WorkspaceFileEntry,
   type WorkspaceFileLocationSection,
   type WorkspaceFileManagerFileDefaultOpener,
@@ -8,6 +9,16 @@ import {
   type WorkspaceFileManagerMutationErrorMessage,
   type WorkspaceFileManagerPersistedState
 } from "@tutti-os/workspace-file-manager/services";
+import {
+  createReferenceSourceAggregator,
+  createStaticReferenceSourceRegistry,
+  SOURCE_ROOT_NODE_ID,
+  type ReferenceSourceAggregator
+} from "@tutti-os/workspace-file-reference/core";
+import type {
+  NodeRef,
+  ReferenceNode
+} from "@tutti-os/workspace-file-reference/contracts";
 import { getActiveLocale } from "../../../../i18n/runtime.ts";
 import { createDesktopWorkspaceFileManagerAdapter } from "./desktopWorkspaceFileManagerAdapter.ts";
 import type {
@@ -16,6 +27,7 @@ import type {
   WorkspaceFileManagerSession
 } from "../workspaceFileManagerService.interface";
 import type { TuttidClient } from "@tutti-os/client-tuttid-ts";
+import type { DesktopLocale } from "@shared/i18n";
 import {
   INotificationService,
   type NotificationService
@@ -33,6 +45,13 @@ import {
   loadDesktopWorkspaceFileLocationSections,
   resolveDesktopWorkspaceFileDefaultLocationId
 } from "../desktopWorkspaceFileLocations.ts";
+import { createDesktopWorkspaceFileReferenceAdapter } from "../createDesktopWorkspaceFileReferenceAdapter.ts";
+import {
+  APP_ARTIFACT_SOURCE_ID,
+  createAppArtifactReferenceSource,
+  createIssueReferenceSource,
+  ISSUE_SOURCE_ID
+} from "../../../agent-reference-sources/index.ts";
 
 export interface WorkspaceFileManagerServiceDependencies {
   hostFilesApi: DesktopHostFilesApi;
@@ -54,11 +73,19 @@ export class WorkspaceFileManagerService implements IWorkspaceFileManagerService
   >();
   private readonly dependencies: WorkspaceFileManagerServiceDependencies;
   private readonly listeners = new Map<string, Set<() => void>>();
+  private readonly i18nRuntimeByWorkspace = new Map<
+    string,
+    WorkspaceFileManagerI18nRuntime
+  >();
   private readonly locationRefreshSnapshotByWorkspace = new Map<
     string,
     string
   >();
   private readonly notifications: NotificationService;
+  private readonly referenceSourceAggregators = new Map<
+    string,
+    ReferenceSourceAggregator
+  >();
   private readonly sharedService = createWorkspaceFileManagerService();
   private readonly sessions = new Map<string, WorkspaceFileManagerSession>();
 
@@ -75,6 +102,44 @@ export class WorkspaceFileManagerService implements IWorkspaceFileManagerService
 
   get hostOs(): NodeJS.Platform {
     return this.dependencies.platformApi.os;
+  }
+
+  getReferenceSourceAggregator(
+    workspaceID: string,
+    locale: DesktopLocale = getActiveLocale()
+  ): ReferenceSourceAggregator {
+    const cacheKey = referenceSourceAggregatorCacheKey(workspaceID, locale);
+    const existing = this.referenceSourceAggregators.get(cacheKey);
+    if (existing) {
+      return existing;
+    }
+    const appI18n = getAppI18nRuntime(locale);
+    const workspaceFileReferenceAdapter =
+      createDesktopWorkspaceFileReferenceAdapter({
+        hostFilesApi: this.dependencies.hostFilesApi,
+        openCanvasFilePreview: (target, workspaceId) =>
+          this.openCanvasFilePreview(workspaceId, target),
+        tuttidClient: this.dependencies.tuttidClient,
+        workspaceId: workspaceID
+      });
+    const aggregator = createReferenceSourceAggregator(
+      createStaticReferenceSourceRegistry([
+        createAppArtifactReferenceSource({
+          tuttidClient: this.dependencies.tuttidClient,
+          adapter: workspaceFileReferenceAdapter,
+          label: appI18n.t("workspace.referenceSources.appSourceLabel"),
+          order: 1
+        }),
+        createIssueReferenceSource({
+          tuttidClient: this.dependencies.tuttidClient,
+          adapter: workspaceFileReferenceAdapter,
+          label: appI18n.t("workspace.referenceSources.issueSourceLabel"),
+          order: 2
+        })
+      ])
+    );
+    this.referenceSourceAggregators.set(cacheKey, aggregator);
+    return aggregator;
   }
 
   async entryExists(input: {
@@ -118,7 +183,12 @@ export class WorkspaceFileManagerService implements IWorkspaceFileManagerService
   ): WorkspaceFileManagerSession {
     const existing = this.sessions.get(workspaceID);
     if (existing) {
+      const previousI18n = this.i18nRuntimeByWorkspace.get(workspaceID);
       existing.setI18nRuntime(i18n);
+      if (previousI18n !== i18n) {
+        this.i18nRuntimeByWorkspace.set(workspaceID, i18n);
+        void this.refreshSessionLocations(workspaceID, existing);
+      }
       return existing;
     }
     const locationSections = getCurrentDesktopWorkspaceFileLocationSections({
@@ -184,6 +254,7 @@ export class WorkspaceFileManagerService implements IWorkspaceFileManagerService
       workspaceID
     });
     this.sessions.set(workspaceID, session);
+    this.i18nRuntimeByWorkspace.set(workspaceID, i18n);
     void this.refreshSessionLocations(workspaceID, session);
     return session;
   }
@@ -260,10 +331,13 @@ export class WorkspaceFileManagerService implements IWorkspaceFileManagerService
   ): Promise<void> {
     const workspaceUserProjectService =
       this.dependencies.workspaceUserProjectService;
-    const locationSections = await loadDesktopWorkspaceFileLocationSections({
-      homeDirectory: this.dependencies.platformApi.homeDirectory,
-      workspaceUserProjectService
-    });
+    const locationSections = [
+      ...(await loadDesktopWorkspaceFileLocationSections({
+        homeDirectory: this.dependencies.platformApi.homeDirectory,
+        workspaceUserProjectService
+      })),
+      ...(await this.loadReferenceLocationSections(workspaceID))
+    ];
     const defaultLocationId = resolveDesktopWorkspaceFileDefaultLocationId({
       projects: workspaceUserProjectService?.getSnapshot().projects ?? []
     });
@@ -289,6 +363,40 @@ export class WorkspaceFileManagerService implements IWorkspaceFileManagerService
     target: Parameters<WorkspaceFileManagerCanvasPreviewLauncher>[0]
   ): Promise<boolean> {
     return this.openCanvasFilePreview(workspaceID, target);
+  }
+
+  private async loadReferenceLocationSections(
+    workspaceID: string
+  ): Promise<WorkspaceFileLocationSection[]> {
+    try {
+      const aggregator = this.getReferenceSourceAggregator(workspaceID);
+      const scope = { workspaceId: workspaceID };
+      const tabs = await aggregator.listSources(scope);
+      const sections = await Promise.all(
+        tabs
+          .filter(
+            (tab) =>
+              tab.sourceId === APP_ARTIFACT_SOURCE_ID ||
+              tab.sourceId === ISSUE_SOURCE_ID
+          )
+          .map(async (tab): Promise<WorkspaceFileLocationSection> => {
+            const result = await aggregator.listChildren(
+              scope,
+              sourceRootRef(tab.sourceId)
+            );
+            return {
+              id: `reference:${tab.sourceId}`,
+              label: tab.label,
+              locations: result.entries
+                .filter((node) => node.kind === "folder")
+                .map((node) => referenceNodeToLocation(tab.sourceId, node))
+            };
+          })
+      );
+      return sections.filter((section) => section.locations.length > 0);
+    } catch {
+      return [];
+    }
   }
 
   private notifyHandledMutationError(
@@ -388,14 +496,53 @@ function serializeWorkspaceFileLocationRefreshSnapshot(input: {
               path: location.path,
               referenceNodeId: location.referenceNodeId
             }
-          : {
-              id: location.id,
-              kind: location.kind,
-              label: location.label
-            }
+          : location.kind === "external"
+            ? {
+                contextLabel: location.contextLabel,
+                externalType: location.externalType,
+                iconUrl: location.iconUrl,
+                id: location.id,
+                kind: location.kind,
+                label: location.label,
+                metadata: location.metadata
+              }
+            : {
+                id: location.id,
+                kind: location.kind,
+                label: location.label
+              }
       )
     }))
   });
+}
+
+function sourceRootRef(sourceId: string): NodeRef {
+  return { sourceId, nodeId: SOURCE_ROOT_NODE_ID };
+}
+
+function referenceSourceAggregatorCacheKey(
+  workspaceID: string,
+  locale: DesktopLocale
+): string {
+  return `${workspaceID}:${locale}`;
+}
+
+function referenceNodeToLocation(
+  sourceId: string,
+  node: ReferenceNode
+): WorkspaceFileExternalLocation {
+  return {
+    contextLabel: node.contextLabel,
+    externalType: "workspace-reference",
+    iconUrl: node.iconUrl,
+    id: `reference:${sourceId}:${node.ref.nodeId}`,
+    kind: "external",
+    label: node.displayName,
+    metadata: {
+      sourceId,
+      nodeId: node.ref.nodeId
+    }
+  };
 }
 
 // Avoid decorator syntax so the renderer Babel pass can parse this file.

--- a/apps/desktop/src/renderer/src/features/workspace-file-manager/services/workspaceFileManagerService.interface.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-file-manager/services/workspaceFileManagerService.interface.ts
@@ -1,4 +1,6 @@
 import { createDecorator } from "@tutti-os/infra/di";
+import type { ReferenceSourceAggregator } from "@tutti-os/workspace-file-reference/core";
+import type { DesktopLocale } from "@shared/i18n";
 import type {
   WorkspaceFileActivationTarget,
   WorkspaceFileEntry,
@@ -22,6 +24,10 @@ export interface IWorkspaceFileManagerService {
     i18n: WorkspaceFileManagerI18nRuntime,
     restoredState?: WorkspaceFileManagerPersistedState | null
   ): WorkspaceFileManagerSession;
+  getReferenceSourceAggregator(
+    workspaceID: string,
+    locale?: DesktopLocale
+  ): ReferenceSourceAggregator;
   getSnapshotState(
     workspaceID: string
   ): WorkspaceFileManagerPersistedState | null;

--- a/apps/desktop/src/renderer/src/features/workspace-file-manager/ui/WorkspaceFileManagerPane.tsx
+++ b/apps/desktop/src/renderer/src/features/workspace-file-manager/ui/WorkspaceFileManagerPane.tsx
@@ -3,10 +3,16 @@ import {
   type WorkspaceFileManagerPersistedState,
   WorkspaceFileManager
 } from "@tutti-os/workspace-file-manager";
+import { ReferenceSourceContentPane } from "@tutti-os/workspace-file-reference/ui";
+import type {
+  NodeRef,
+  WorkspaceFileReferenceCopy
+} from "@tutti-os/workspace-file-reference/contracts";
 import browserDockIconUrl from "@tutti-os/browser-node/assets/workspace-dock-website.png";
 import { useService } from "@tutti-os/infra/di";
 import { useCallback, useEffect, useMemo } from "react";
 import type { WorkspaceFileEntry } from "@tutti-os/workspace-file-manager/services";
+import type { WorkspaceFileExternalLocation } from "@tutti-os/workspace-file-manager/services";
 import { resolveOpenWithApplicationIconOverrideDataUrl } from "@shared/openWithApplicationIconOverrides";
 import { FileManagerDirectoryExpandedReporter } from "@renderer/features/analytics/reporters/file-manager-directory-expanded/fileManagerDirectoryExpandedReporter.ts";
 import { FileManagerPathCopiedReporter } from "@renderer/features/analytics/reporters/file-manager-path-copied/fileManagerPathCopiedReporter.ts";
@@ -62,6 +68,56 @@ export function WorkspaceFileManagerPane({
       featureService.resolveEntryIconUrl(workspaceID, entry),
     [featureService, workspaceID]
   );
+  const referenceCopy = useMemo<WorkspaceFileReferenceCopy>(
+    () => createWorkspaceFileReferenceCopy(appI18n),
+    [appI18n]
+  );
+  const referenceSourceAggregator = useMemo(
+    () => featureService.getReferenceSourceAggregator(workspaceID, locale),
+    [featureService, locale, workspaceID]
+  );
+  const renderExternalLocationContent = useCallback(
+    (location: WorkspaceFileExternalLocation) => {
+      if (location.externalType !== "workspace-reference") {
+        return null;
+      }
+      const initialNodeRef = externalLocationToNodeRef(location);
+      if (!initialNodeRef) {
+        return null;
+      }
+      return (
+        <ReferenceSourceContentPane
+          key={location.id}
+          aggregator={referenceSourceAggregator}
+          copy={referenceCopy}
+          fileManagerCopy={i18n}
+          hostOs={featureService.hostOs}
+          initialNodeRef={initialNodeRef}
+          resolveEntryIconUrl={resolveEntryIconUrl}
+          resolveOpenWithApplicationIcon={(application) => {
+            const iconDataUrl =
+              resolveOpenWithApplicationIconOverrideDataUrl(application);
+            return iconDataUrl ? (
+              <img
+                alt=""
+                className="size-4 rounded-[4px] object-contain"
+                src={iconDataUrl}
+              />
+            ) : null;
+          }}
+          workspaceId={workspaceID}
+        />
+      );
+    },
+    [
+      featureService.hostOs,
+      i18n,
+      referenceCopy,
+      referenceSourceAggregator,
+      resolveEntryIconUrl,
+      workspaceID
+    ]
+  );
 
   return (
     <WorkspaceFileManager
@@ -111,10 +167,105 @@ export function WorkspaceFileManagerPane({
         ).report();
       }}
       resolveEntryIconUrl={resolveEntryIconUrl}
+      renderExternalLocationContent={renderExternalLocationContent}
       session={session}
       surface="embedded"
     />
   );
+}
+
+const workspaceFileReferenceLocaleKeyByPickerKey: Record<string, string> = {
+  "actions.cancel": "common.cancel",
+  "referencePicker.confirm": "agentHost.agentGui.referencePicker.confirm",
+  "referencePicker.clearFilter":
+    "agentHost.agentGui.referencePicker.clearFilter",
+  "referencePicker.emptyDirectory":
+    "agentHost.agentGui.referencePicker.emptyDirectory",
+  "referencePicker.emptyPreview":
+    "agentHost.agentGui.referencePicker.emptyPreview",
+  "referencePicker.emptySearch":
+    "agentHost.agentGui.referencePicker.emptySearch",
+  "referencePicker.fileTypeAll":
+    "agentHost.agentGui.referencePicker.fileTypeAll",
+  "referencePicker.fileTypeDocument":
+    "agentHost.agentGui.referencePicker.fileTypeDocument",
+  "referencePicker.fileTypeImage":
+    "agentHost.agentGui.referencePicker.fileTypeImage",
+  "referencePicker.fileTypeOther":
+    "agentHost.agentGui.referencePicker.fileTypeOther",
+  "referencePicker.fileTypeSeparator":
+    "agentHost.agentGui.referencePicker.fileTypeSeparator",
+  "referencePicker.fileTypeVideo":
+    "agentHost.agentGui.referencePicker.fileTypeVideo",
+  "referencePicker.fileTypeWebpage":
+    "agentHost.agentGui.referencePicker.fileTypeWebpage",
+  "referencePicker.loadMore": "agentHost.agentGui.referencePicker.loadMore",
+  "referencePicker.loadMoreGroups":
+    "agentHost.agentGui.referencePicker.loadMoreGroups",
+  "referencePicker.loading": "agentHost.agentGui.referencePicker.loading",
+  "referencePicker.previewBinary":
+    "agentHost.agentGui.referencePicker.previewBinary",
+  "referencePicker.previewDecodeFailed":
+    "agentHost.agentGui.referencePicker.previewDecodeFailed",
+  "referencePicker.previewError":
+    "agentHost.agentGui.referencePicker.previewError",
+  "referencePicker.previewFileTooLarge":
+    "agentHost.agentGui.referencePicker.previewFileTooLarge",
+  "referencePicker.previewFolder":
+    "agentHost.agentGui.referencePicker.previewFolder",
+  "referencePicker.previewHierarchy":
+    "agentHost.agentGui.referencePicker.previewHierarchy",
+  "referencePicker.previewLoading":
+    "agentHost.agentGui.referencePicker.previewLoading",
+  "referencePicker.previewModified":
+    "agentHost.agentGui.referencePicker.previewModified",
+  "referencePicker.previewSize":
+    "agentHost.agentGui.referencePicker.previewSize",
+  "referencePicker.previewSource":
+    "agentHost.agentGui.referencePicker.previewSource",
+  "referencePicker.previewTextTooLarge":
+    "agentHost.agentGui.referencePicker.previewTextTooLarge",
+  "referencePicker.previewTooLarge":
+    "agentHost.agentGui.referencePicker.previewTooLarge",
+  "referencePicker.previewUnavailable":
+    "agentHost.agentGui.referencePicker.previewUnavailable",
+  "referencePicker.previewUnsupported":
+    "agentHost.agentGui.referencePicker.previewUnsupported",
+  "referencePicker.searchPlaceholder":
+    "agentHost.agentGui.referencePicker.searchPlaceholder",
+  "referencePicker.selectGroupHint":
+    "agentHost.agentGui.referencePicker.selectGroupHint",
+  "referencePicker.selectedCount":
+    "agentHost.agentGui.referencePicker.selectedCount",
+  "referencePicker.workspaceRootGroup":
+    "agentHost.agentGui.referencePicker.workspaceRootGroup",
+  "referencePicker.sourceColumn":
+    "agentHost.agentGui.referencePicker.sourceColumn",
+  "referencePicker.title": "agentHost.agentGui.referencePicker.title"
+};
+
+function createWorkspaceFileReferenceCopy(i18n: {
+  t(key: string, values?: Record<string, number | string>): string;
+}): WorkspaceFileReferenceCopy {
+  return {
+    t(key, values) {
+      return i18n.t(
+        workspaceFileReferenceLocaleKeyByPickerKey[key] ?? key,
+        values
+      );
+    }
+  };
+}
+
+function externalLocationToNodeRef(
+  location: WorkspaceFileExternalLocation
+): NodeRef | null {
+  const sourceId = location.metadata.sourceId?.trim();
+  const nodeId = location.metadata.nodeId?.trim();
+  if (!sourceId || !nodeId) {
+    return null;
+  }
+  return { sourceId, nodeId };
 }
 
 function resolveDirectoryDepth(path: string): number {

--- a/apps/desktop/src/renderer/src/features/workspace-workbench/services/internal/workspaceFilesContribution.test.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/services/internal/workspaceFilesContribution.test.ts
@@ -207,6 +207,9 @@ function createFileManagerServiceStub(
     getSession() {
       throw new Error("getSession should not be called");
     },
+    getReferenceSourceAggregator() {
+      throw new Error("getReferenceSourceAggregator should not be called");
+    },
     getSnapshotState() {
       return snapshotState;
     },

--- a/docs/architecture/agent-reference-source-services.md
+++ b/docs/architecture/agent-reference-source-services.md
@@ -86,6 +86,7 @@ host openFile  host openFile   任务通道
 - **契约 + 聚合 + base 工具 + picker UI** → 放在 `@tutti-os/workspace-file-reference`(UI 无关部分在 `core`/`contracts`,UI 在 `ui`)。
 - **各源实现** → `apps/desktop`(依赖 `tuttidClient` / `hostFilesApi`),通过 DI 注册进 registry。
 - AgentGui(`@tutti-os/agent-gui`)只通过 `AgentGUINodeView` 的 prop 接收聚合后的能力,**不感知具体源**。
+- File Manager 通过 `external` location 扩展槽消费应用/任务产物源:左栏 location 由 desktop 从 `ReferenceSourceAggregator` 的根分组生成,右侧内容使用嵌入式 reference explorer 渲染。`@tutti-os/workspace-file-manager` 不得反向依赖 `@tutti-os/workspace-file-reference`,因为 reference 包已复用 file-manager 的图标、排序、open-with 和预览类型。
 
 ### 1.4 本地文件:回归防护(避免改造引入 bug)
 

--- a/packages/workspace/file-manager/src/index.ts
+++ b/packages/workspace/file-manager/src/index.ts
@@ -31,6 +31,7 @@ export {
 export {
   findWorkspaceFileLocationById,
   flattenWorkspaceFileLocations,
+  isWorkspaceFileExternalLocation,
   isWorkspaceFileRecentLocation,
   resolveWorkspaceFileLocationDefaultId
 } from "./services/workspaceFileManagerLocations.ts";
@@ -46,6 +47,7 @@ export {
   type WorkspaceFileLocationKind,
   type WorkspaceFileLocationSection,
   type WorkspaceFileDirectoryLocation,
+  type WorkspaceFileExternalLocation,
   type WorkspaceFileRecentLocation,
   type WorkspaceFileManagerCapabilities,
   type WorkspaceFileOpenWithApplication,

--- a/packages/workspace/file-manager/src/services/index.ts
+++ b/packages/workspace/file-manager/src/services/index.ts
@@ -58,6 +58,7 @@ export {
 export {
   findWorkspaceFileLocationById,
   flattenWorkspaceFileLocations,
+  isWorkspaceFileExternalLocation,
   isWorkspaceFileRecentLocation,
   resolveWorkspaceFileLocationDefaultId
 } from "./workspaceFileManagerLocations.ts";
@@ -74,6 +75,7 @@ export {
   type WorkspaceFileLocationKind,
   type WorkspaceFileLocationSection,
   type WorkspaceFileDirectoryLocation,
+  type WorkspaceFileExternalLocation,
   type WorkspaceFileRecentLocation,
   type WorkspaceFileManagerCapabilities,
   type WorkspaceFileManagerFileDefaultOpener,

--- a/packages/workspace/file-manager/src/services/internal/workspaceFileManagerSession.ts
+++ b/packages/workspace/file-manager/src/services/internal/workspaceFileManagerSession.ts
@@ -7,6 +7,7 @@ import {
 import { getWorkspaceFileManagerPersistedState } from "./workspaceFileManagerStore.ts";
 import {
   findWorkspaceFileLocationById,
+  isWorkspaceFileExternalLocation,
   isWorkspaceFileRecentLocation,
   resolveWorkspaceFileLocationDefaultId
 } from "../workspaceFileManagerLocations.ts";
@@ -234,7 +235,7 @@ export class DefaultWorkspaceFileManagerSession implements WorkspaceFileManagerS
   }
 
   async confirmCreateDialog(): Promise<void> {
-    if (this.isRecentLocationSelected()) {
+    if (this.isReadOnlyLocationSelected()) {
       return;
     }
     const createDialog = this.store.createDialog;
@@ -327,21 +328,21 @@ export class DefaultWorkspaceFileManagerSession implements WorkspaceFileManagerS
   }
 
   async createDirectory(path: string): Promise<void> {
-    if (this.isRecentLocationSelected()) {
+    if (this.isReadOnlyLocationSelected()) {
       return;
     }
     await this.mutationController.createDirectory(path);
   }
 
   async createFile(path: string): Promise<void> {
-    if (this.isRecentLocationSelected()) {
+    if (this.isReadOnlyLocationSelected()) {
       return;
     }
     await this.mutationController.createFile(path);
   }
 
   async deleteSelected(): Promise<void> {
-    if (this.isRecentLocationSelected()) {
+    if (this.isReadOnlyLocationSelected()) {
       return;
     }
     await this.mutationController.deleteSelected();
@@ -468,7 +469,7 @@ export class DefaultWorkspaceFileManagerSession implements WorkspaceFileManagerS
   }
 
   openCreateDirectoryDialog(): void {
-    if (this.isRecentLocationSelected()) {
+    if (this.isReadOnlyLocationSelected()) {
       return;
     }
     this.store.contextMenu = null;
@@ -481,7 +482,7 @@ export class DefaultWorkspaceFileManagerSession implements WorkspaceFileManagerS
   }
 
   openCreateFileDialog(): void {
-    if (this.isRecentLocationSelected()) {
+    if (this.isReadOnlyLocationSelected()) {
       return;
     }
     this.store.contextMenu = null;
@@ -494,7 +495,7 @@ export class DefaultWorkspaceFileManagerSession implements WorkspaceFileManagerS
   }
 
   openDeleteDialog(entry: WorkspaceFileEntry): void {
-    if (this.isRecentLocationSelected()) {
+    if (this.isReadOnlyLocationSelected()) {
       return;
     }
     this.store.contextMenu = null;
@@ -505,7 +506,7 @@ export class DefaultWorkspaceFileManagerSession implements WorkspaceFileManagerS
   }
 
   startInlineRename(entry: WorkspaceFileEntry): void {
-    if (this.isRecentLocationSelected()) {
+    if (this.isReadOnlyLocationSelected()) {
       return;
     }
     this.store.contextMenu = null;
@@ -520,6 +521,9 @@ export class DefaultWorkspaceFileManagerSession implements WorkspaceFileManagerS
   }
 
   async copyToClipboard(entry: WorkspaceFileEntry): Promise<void> {
+    if (this.isExternalLocationSelected()) {
+      return;
+    }
     if (!this.host.copyEntriesToClipboard) {
       return;
     }
@@ -646,7 +650,7 @@ export class DefaultWorkspaceFileManagerSession implements WorkspaceFileManagerS
     entry: WorkspaceFileEntry,
     targetDirectoryPath: string
   ): Promise<void> {
-    if (this.isRecentLocationSelected()) {
+    if (this.isReadOnlyLocationSelected()) {
       return;
     }
     this.store.busyAction = "move";
@@ -659,6 +663,9 @@ export class DefaultWorkspaceFileManagerSession implements WorkspaceFileManagerS
 
   async refresh(): Promise<void> {
     const selectedLocation = this.selectedLocation();
+    if (isWorkspaceFileExternalLocation(selectedLocation)) {
+      return;
+    }
     if (selectedLocation?.kind === "recent") {
       await this.loadRecentLocation(selectedLocation);
       return;
@@ -739,6 +746,11 @@ export class DefaultWorkspaceFileManagerSession implements WorkspaceFileManagerS
     this.store.inlineRenameEntryPath = null;
     this.store.inlineRenameValidation = null;
     this.clearSearchState();
+    if (location.kind === "external") {
+      this.store.selectedPath = null;
+      this.store.previewState = { status: "empty" };
+      return;
+    }
     if (location.kind === "recent") {
       await this.loadRecentLocation(location);
       return;
@@ -795,7 +807,13 @@ export class DefaultWorkspaceFileManagerSession implements WorkspaceFileManagerS
       previousLocation?.kind !== nextLocation?.kind ||
       (previousLocation?.kind === "directory" &&
         nextLocation?.kind === "directory" &&
-        !areWorkspaceFilePathsEqual(previousLocation.path, nextLocation.path));
+        !areWorkspaceFilePathsEqual(
+          previousLocation.path,
+          nextLocation.path
+        )) ||
+      (previousLocation?.kind === "external" &&
+        nextLocation?.kind === "external" &&
+        previousLocation.externalType !== nextLocation.externalType);
     if (selectedLocationChanged) {
       await this.selectLocation(nextLocationId);
     }
@@ -820,7 +838,7 @@ export class DefaultWorkspaceFileManagerSession implements WorkspaceFileManagerS
     dataTransfer: Pick<DataTransfer, "files" | "items">,
     targetDirectoryPath: string
   ): Promise<WorkspaceFileManagerHostActionResult> {
-    if (this.isRecentLocationSelected()) {
+    if (this.isReadOnlyLocationSelected()) {
       return { supported: false } as const;
     }
     return this.importController.importDroppedFiles(
@@ -832,7 +850,7 @@ export class DefaultWorkspaceFileManagerSession implements WorkspaceFileManagerS
   async importFiles(
     targetDirectoryPath: string
   ): Promise<WorkspaceFileManagerHostActionResult> {
-    if (this.isRecentLocationSelected()) {
+    if (this.isReadOnlyLocationSelected()) {
       return { supported: false } as const;
     }
     return this.importController.importFiles(targetDirectoryPath);
@@ -879,6 +897,9 @@ export class DefaultWorkspaceFileManagerSession implements WorkspaceFileManagerS
 
   private async loadSelectedLocationOrDirectory(): Promise<void> {
     const selectedLocation = this.selectedLocation();
+    if (isWorkspaceFileExternalLocation(selectedLocation)) {
+      return;
+    }
     if (selectedLocation?.kind === "recent") {
       await this.loadRecentLocation(selectedLocation);
       return;
@@ -925,6 +946,18 @@ export class DefaultWorkspaceFileManagerSession implements WorkspaceFileManagerS
 
   private isRecentLocationSelected(): boolean {
     return isWorkspaceFileRecentLocation(this.selectedLocation());
+  }
+
+  private isExternalLocationSelected(): boolean {
+    return isWorkspaceFileExternalLocation(this.selectedLocation());
+  }
+
+  private isReadOnlyLocationSelected(): boolean {
+    const selectedLocation = this.selectedLocation();
+    return (
+      isWorkspaceFileRecentLocation(selectedLocation) ||
+      isWorkspaceFileExternalLocation(selectedLocation)
+    );
   }
 
   private resolveInitialDirectoryPath(

--- a/packages/workspace/file-manager/src/services/internal/workspaceFileManagerViewModel.ts
+++ b/packages/workspace/file-manager/src/services/internal/workspaceFileManagerViewModel.ts
@@ -5,6 +5,7 @@ import {
 } from "../workspaceFileManagerModel.ts";
 import {
   findWorkspaceFileLocationById,
+  isWorkspaceFileExternalLocation,
   isWorkspaceFileRecentLocation
 } from "../workspaceFileManagerLocations.ts";
 import type { WorkspaceFileManagerI18nRuntime } from "../../i18n/workspaceFileManagerI18n.ts";
@@ -116,11 +117,18 @@ export function resolveWorkspaceFileManagerRootViewState(input: {
       state.selectedLocationId
     )
   );
+  const isExternalLocation = isWorkspaceFileExternalLocation(
+    findWorkspaceFileLocationById(
+      state.locationSections,
+      state.selectedLocationId
+    )
+  );
   const isSearchMode = state.searchQuery.trim().length > 0;
   return {
     canImportFromDrop:
       state.capabilities.canImportFromDrop &&
       !isRecentLocation &&
+      !isExternalLocation &&
       !isSearchMode,
     currentDirectoryPath: state.currentDirectoryPath,
     isBusy: state.busyAction !== null,
@@ -170,8 +178,15 @@ export function resolveWorkspaceFileManagerPanelsViewState(input: {
       state.selectedLocationId
     )
   );
+  const isExternalLocation = isWorkspaceFileExternalLocation(
+    findWorkspaceFileLocationById(
+      state.locationSections,
+      state.selectedLocationId
+    )
+  );
   return {
-    canMove: state.capabilities.canMove && !isRecentLocation,
+    canMove:
+      state.capabilities.canMove && !isRecentLocation && !isExternalLocation,
     contextMenuEntryPath: state.contextMenuEntryPath,
     entries: state.entries,
     error: state.error,
@@ -190,6 +205,7 @@ export function resolveWorkspaceFileManagerPanelsViewState(input: {
     selectedPath: state.selectedPath,
     showDropOverlay:
       state.capabilities.canImportFromDrop &&
+      !isExternalLocation &&
       state.dragDepth > 0 &&
       state.busyAction === null
   };
@@ -236,6 +252,12 @@ export function resolveWorkspaceFileManagerContextMenuViewState(input: {
       state.selectedLocationId
     )
   );
+  const isExternalLocation = isWorkspaceFileExternalLocation(
+    findWorkspaceFileLocationById(
+      state.locationSections,
+      state.selectedLocationId
+    )
+  );
   const isSearchMode = state.searchQuery.trim().length > 0;
   const contextMenuEntry = state.contextMenu?.entryPath
     ? findEntry(state, state.contextMenu.entryPath)
@@ -255,22 +277,32 @@ export function resolveWorkspaceFileManagerContextMenuViewState(input: {
     isLoading: state.isLoading,
     isMutating: state.isMutating,
     showCreateAction:
+      !isExternalLocation &&
       !isRecentLocation &&
       !isSearchMode &&
       (state.capabilities.canCreateDirectory ||
         state.capabilities.canCreateFile),
     showCopyAction: state.capabilities.canCopy,
     showDeleteAction:
-      state.capabilities.canDelete && !isRecentLocation && !isSearchMode,
-    showExportAction: state.capabilities.canExport,
+      state.capabilities.canDelete &&
+      !isExternalLocation &&
+      !isRecentLocation &&
+      !isSearchMode,
+    showExportAction: state.capabilities.canExport && !isExternalLocation,
     showImportAction:
       state.capabilities.canImportFromPicker &&
+      !isExternalLocation &&
       !isRecentLocation &&
       !isSearchMode,
     showMoveAction:
-      state.capabilities.canMove && !isRecentLocation && !isSearchMode,
-    showOpenInAppBrowserAction: state.capabilities.canOpenInAppBrowser,
-    showOpenInDefaultBrowserAction: state.capabilities.canOpenInDefaultBrowser,
+      state.capabilities.canMove &&
+      !isExternalLocation &&
+      !isRecentLocation &&
+      !isSearchMode,
+    showOpenInAppBrowserAction:
+      state.capabilities.canOpenInAppBrowser && !isExternalLocation,
+    showOpenInDefaultBrowserAction:
+      state.capabilities.canOpenInDefaultBrowser && !isExternalLocation,
     showOpenInFileViewerAction:
       contextMenuEntry !== null &&
       isContextMenuFile &&
@@ -278,9 +310,13 @@ export function resolveWorkspaceFileManagerContextMenuViewState(input: {
     showOpenWithAction: state.capabilities.canOpenWith && isContextMenuFile,
     showOpenWithOtherAction:
       state.capabilities.canPickOtherOpenWithApplication && isContextMenuFile,
-    showRevealInFolderAction: state.capabilities.canRevealInFolder,
+    showRevealInFolderAction:
+      state.capabilities.canRevealInFolder && !isExternalLocation,
     showRenameAction:
-      state.capabilities.canRename && !isRecentLocation && !isSearchMode
+      state.capabilities.canRename &&
+      !isExternalLocation &&
+      !isRecentLocation &&
+      !isSearchMode
   };
 }
 

--- a/packages/workspace/file-manager/src/services/workspaceFileManagerLocations.ts
+++ b/packages/workspace/file-manager/src/services/workspaceFileManagerLocations.ts
@@ -57,3 +57,9 @@ export function isWorkspaceFileRecentLocation(
 ): boolean {
   return location?.kind === "recent";
 }
+
+export function isWorkspaceFileExternalLocation(
+  location: WorkspaceFileLocation | null | undefined
+): boolean {
+  return location?.kind === "external";
+}

--- a/packages/workspace/file-manager/src/services/workspaceFileManagerSession.test.ts
+++ b/packages/workspace/file-manager/src/services/workspaceFileManagerSession.test.ts
@@ -981,6 +981,104 @@ test("setLocations reloads the selected directory when its path changes", async 
   session.dispose();
 });
 
+test("external locations select without loading directories and persist their id", async () => {
+  let copyCalls = 0;
+  let importCalls = 0;
+  const listedPaths: string[] = [];
+  const session = createWorkspaceFileManagerService().createSession({
+    host: {
+      async copyEntriesToClipboard() {
+        copyCalls += 1;
+      },
+      async importFiles() {
+        importCalls += 1;
+        return { supported: true };
+      },
+      async listDirectory(input) {
+        listedPaths.push(input.path);
+        return {
+          directoryPath: input.path,
+          entries: [
+            {
+              hasChildren: false,
+              kind: "file",
+              mtimeMs: 1,
+              name: "notes.txt",
+              path: "/Users/demo/notes.txt",
+              sizeBytes: 12
+            }
+          ],
+          root: "/Users/demo",
+          workspaceID: input.workspaceID
+        };
+      }
+    },
+    i18n: createTestI18nRuntime(),
+    defaultLocationId: "local:home",
+    locationSections: [
+      {
+        id: "local",
+        label: "Local",
+        locations: [
+          {
+            id: "local:home",
+            kind: "directory",
+            label: "Home",
+            path: "/Users/demo",
+            referenceNodeId: "/Users/demo"
+          }
+        ]
+      },
+      {
+        id: "reference:app-artifact",
+        label: "Apps",
+        locations: [
+          {
+            externalType: "workspace-reference",
+            id: "reference:app-artifact:g:app",
+            kind: "external",
+            label: "Design App",
+            metadata: {
+              nodeId: "g:app",
+              sourceId: "app-artifact"
+            }
+          }
+        ]
+      }
+    ],
+    workspaceID: "workspace-1"
+  });
+
+  await session.initialize();
+  const entry = session.store.entries[0]!;
+  session.select(entry.path);
+  assert.equal(session.store.selectedPath, entry.path);
+  await session.selectLocation("reference:app-artifact:g:app");
+  await session.refresh();
+  await session.copyToClipboard(entry);
+  session.startInlineRename(entry);
+  session.openCreateFileDialog();
+  await session.importFiles("/Users/demo");
+
+  assert.equal(
+    session.store.selectedLocationId,
+    "reference:app-artifact:g:app"
+  );
+  assert.equal(session.store.currentDirectoryPath, "/Users/demo");
+  assert.equal(session.store.selectedPath, null);
+  assert.deepEqual(session.store.previewState, { status: "empty" });
+  assert.equal(session.store.inlineRenameEntryPath, null);
+  assert.equal(session.store.createDialog, null);
+  assert.deepEqual(listedPaths, ["/Users/demo"]);
+  assert.equal(copyCalls, 0);
+  assert.equal(importCalls, 0);
+  assert.equal(
+    session.getPersistedState().selectedLocationId,
+    "reference:app-artifact:g:app"
+  );
+  session.dispose();
+});
+
 test("recent locations load recent entries, search locally, and block mutations", async () => {
   let createFileCalls = 0;
   let hostSearchCalls = 0;

--- a/packages/workspace/file-manager/src/services/workspaceFileManagerTypes.ts
+++ b/packages/workspace/file-manager/src/services/workspaceFileManagerTypes.ts
@@ -9,7 +9,7 @@ export type WorkspaceFileEntryKind = "file" | "directory" | "unknown";
 export type WorkspaceFileSearchMatchTarget = "basename" | "path";
 export type WorkspaceFileImportConflictKind = "replaceable" | "type_mismatch";
 export type WorkspaceFilePreviewKind = "image" | "text" | "video";
-export type WorkspaceFileLocationKind = "directory" | "recent";
+export type WorkspaceFileLocationKind = "directory" | "external" | "recent";
 export type WorkspaceFileManagerFileDefaultOpener =
   | "appBrowser"
   | "defaultBrowser"
@@ -88,6 +88,7 @@ export interface WorkspaceFileLocationSection {
 
 export type WorkspaceFileLocation =
   | WorkspaceFileDirectoryLocation
+  | WorkspaceFileExternalLocation
   | WorkspaceFileRecentLocation;
 
 export interface WorkspaceFileDirectoryLocation {
@@ -97,6 +98,16 @@ export interface WorkspaceFileDirectoryLocation {
   label: string;
   path: string;
   referenceNodeId: string;
+}
+
+export interface WorkspaceFileExternalLocation {
+  contextLabel?: string | null;
+  externalType: string;
+  iconUrl?: string | null;
+  id: string;
+  kind: "external";
+  label: string;
+  metadata: Record<string, string>;
 }
 
 export interface WorkspaceFileRecentLocation {

--- a/packages/workspace/file-manager/src/ui/WorkspaceFileManager.tsx
+++ b/packages/workspace/file-manager/src/ui/WorkspaceFileManager.tsx
@@ -11,6 +11,7 @@ import type { WorkspaceFileManagerSession } from "../services/workspaceFileManag
 import type { WorkspaceFileManagerI18nRuntime } from "../i18n/workspaceFileManagerI18n.ts";
 import type {
   WorkspaceFileEntry,
+  WorkspaceFileLocation,
   WorkspaceFileOpenWithApplication
 } from "../services/workspaceFileManagerTypes.ts";
 import { WorkspaceFileManagerContextMenuContainer } from "./WorkspaceFileManagerContextMenuContainer.tsx";
@@ -42,6 +43,7 @@ import {
   type WorkspaceFileManagerVisibleTreeRow
 } from "./workspaceFileManagerVisibleTree.ts";
 import { workspaceFileSearchEntryToEntry } from "../services/workspaceFileManagerModel.ts";
+import { findWorkspaceFileLocationById } from "../services/workspaceFileManagerLocations.ts";
 import {
   useWorkspaceFileManagerDialogsView,
   useWorkspaceFileManagerPanelsView,
@@ -69,6 +71,9 @@ export interface WorkspaceFileManagerProps {
   resolveEntryIconUrl?: (
     entry: WorkspaceFileEntry
   ) => Promise<string | null | undefined>;
+  renderExternalLocationContent?: (
+    location: Extract<WorkspaceFileLocation, { kind: "external" }>
+  ) => ReactElement | null;
   hostOs?: NodeJS.Platform;
   i18n: WorkspaceFileManagerI18nRuntime;
   session: WorkspaceFileManagerSession;
@@ -87,6 +92,7 @@ export function WorkspaceFileManager({
   openInAppBrowserIcon,
   resolveOpenWithApplicationIcon,
   resolveEntryIconUrl,
+  renderExternalLocationContent,
   hostOs = "linux",
   session,
   surface = "card"
@@ -97,6 +103,13 @@ export function WorkspaceFileManager({
   const rootView = useWorkspaceFileManagerRootView(session);
   const { state: panelsState, view: panelsView } =
     useWorkspaceFileManagerPanelsView(session);
+  const selectedExternalLocation = useMemo(() => {
+    const location = findWorkspaceFileLocationById(
+      rootView.locationSections,
+      rootView.selectedLocationId
+    );
+    return location?.kind === "external" ? location : null;
+  }, [rootView.locationSections, rootView.selectedLocationId]);
 
   useEffect(() => {
     function handleCopyShortcut(event: KeyboardEvent): void {
@@ -111,6 +124,9 @@ export function WorkspaceFileManager({
         return;
       }
       if (!rootRef.current?.contains(event.target as Node)) {
+        return;
+      }
+      if (selectedExternalLocation) {
         return;
       }
       if (
@@ -138,7 +154,13 @@ export function WorkspaceFileManager({
     return () => {
       window.removeEventListener("keydown", handleCopyShortcut);
     };
-  }, [onCopyEntry, panelsState, panelsView.selectedEntry, session]);
+  }, [
+    onCopyEntry,
+    panelsState,
+    panelsView.selectedEntry,
+    selectedExternalLocation,
+    session
+  ]);
 
   useEffect(() => {
     function handleRenameShortcut(event: KeyboardEvent): void {
@@ -154,6 +176,9 @@ export function WorkspaceFileManager({
         return;
       }
       if (!rootRef.current?.contains(event.target as Node)) {
+        return;
+      }
+      if (selectedExternalLocation) {
         return;
       }
       if (
@@ -180,7 +205,12 @@ export function WorkspaceFileManager({
     return () => {
       window.removeEventListener("keydown", handleRenameShortcut);
     };
-  }, [panelsState, panelsView.selectedEntry, session]);
+  }, [
+    panelsState,
+    panelsView.selectedEntry,
+    selectedExternalLocation,
+    session
+  ]);
 
   useEffect(() => {
     function resetDropOverlay(): void {
@@ -328,47 +358,57 @@ export function WorkspaceFileManager({
         }}
       />
       <div className="flex min-h-0 min-w-0 flex-1 flex-col overflow-hidden">
-        <WorkspaceFileManagerToolbarContainer
-          i18n={i18n}
-          arrangeMode={arrangeMode}
-          layoutMode={layoutMode}
-          onArrangeModeChange={setArrangeMode}
-          onDirectoryExpanded={onDirectoryExpanded}
-          onLayoutModeChange={setLayoutMode}
-          session={session}
-        />
-        <div
-          className="@max-[600px]/workspace-file-manager:flex-col @max-[600px]/workspace-file-manager:gap-3 flex min-h-0 min-w-0 flex-1 overflow-hidden"
-          style={
-            {
-              "--workspace-file-manager-dialog-overlay-z-index": "20"
-            } as CSSProperties
-          }
-        >
-          <WorkspaceFileManagerPanelsContainer
-            dateLocale={dateLocale}
-            entryDragMode={entryDragMode}
-            arrangeMode={arrangeMode}
+        {selectedExternalLocation ? (
+          (renderExternalLocationContent?.(selectedExternalLocation) ?? null)
+        ) : (
+          <>
+            <WorkspaceFileManagerToolbarContainer
+              i18n={i18n}
+              arrangeMode={arrangeMode}
+              layoutMode={layoutMode}
+              onArrangeModeChange={setArrangeMode}
+              onDirectoryExpanded={onDirectoryExpanded}
+              onLayoutModeChange={setLayoutMode}
+              session={session}
+            />
+            <div
+              className="@max-[600px]/workspace-file-manager:flex-col @max-[600px]/workspace-file-manager:gap-3 flex min-h-0 min-w-0 flex-1 overflow-hidden"
+              style={
+                {
+                  "--workspace-file-manager-dialog-overlay-z-index": "20"
+                } as CSSProperties
+              }
+            >
+              <WorkspaceFileManagerPanelsContainer
+                dateLocale={dateLocale}
+                entryDragMode={entryDragMode}
+                arrangeMode={arrangeMode}
+                i18n={i18n}
+                layoutMode={layoutMode}
+                onDirectoryExpanded={onDirectoryExpanded}
+                onEntryDragStart={onEntryDragStart}
+                onOpenContextMenu={openContextMenu}
+                resolveEntryIconUrl={resolveEntryIconUrl}
+                session={session}
+              />
+            </div>
+          </>
+        )}
+      </div>
+      {!selectedExternalLocation ? (
+        <>
+          <WorkspaceFileManagerDialogsContainer i18n={i18n} session={session} />
+          <WorkspaceFileManagerContextMenuContainer
+            hostOs={hostOs}
             i18n={i18n}
-            layoutMode={layoutMode}
-            onDirectoryExpanded={onDirectoryExpanded}
-            onEntryDragStart={onEntryDragStart}
-            onOpenContextMenu={openContextMenu}
-            resolveEntryIconUrl={resolveEntryIconUrl}
+            onCopyEntry={onCopyEntry}
+            onCopyPath={onCopyPath}
+            openInAppBrowserIcon={openInAppBrowserIcon}
+            resolveOpenWithApplicationIcon={resolveOpenWithApplicationIcon}
             session={session}
           />
-        </div>
-      </div>
-      <WorkspaceFileManagerDialogsContainer i18n={i18n} session={session} />
-      <WorkspaceFileManagerContextMenuContainer
-        hostOs={hostOs}
-        i18n={i18n}
-        onCopyEntry={onCopyEntry}
-        onCopyPath={onCopyPath}
-        openInAppBrowserIcon={openInAppBrowserIcon}
-        resolveOpenWithApplicationIcon={resolveOpenWithApplicationIcon}
-        session={session}
-      />
+        </>
+      ) : null}
     </section>
   );
 }

--- a/packages/workspace/file-manager/src/ui/WorkspaceFileManagerSidebar.tsx
+++ b/packages/workspace/file-manager/src/ui/WorkspaceFileManagerSidebar.tsx
@@ -11,6 +11,7 @@ import {
 import type { ReactElement } from "react";
 import type {
   WorkspaceFileLocation,
+  WorkspaceFileExternalLocation,
   WorkspaceFileLocationSection
 } from "../services/workspaceFileManagerTypes.ts";
 
@@ -90,7 +91,11 @@ function WorkspaceFileManagerSidebarLocation({
         onSelectLocation(location);
       }}
     >
-      <Icon className="size-4 flex-none" />
+      {location.kind === "external" && location.iconUrl ? (
+        <ExternalLocationIcon location={location} />
+      ) : (
+        <Icon className="size-4 flex-none" />
+      )}
       <span className="min-w-0 flex-1 overflow-hidden text-ellipsis whitespace-nowrap">
         {location.label}
       </span>
@@ -106,5 +111,19 @@ function WorkspaceFileManagerSidebarLocation({
       <TooltipTrigger asChild>{content}</TooltipTrigger>
       <TooltipContent side="right">{location.contextLabel}</TooltipContent>
     </Tooltip>
+  );
+}
+
+function ExternalLocationIcon({
+  location
+}: {
+  location: WorkspaceFileExternalLocation;
+}): ReactElement {
+  return (
+    <img
+      alt=""
+      className="size-4 flex-none rounded-[3px] object-cover"
+      src={location.iconUrl ?? undefined}
+    />
   );
 }

--- a/packages/workspace/file-reference/src/ui/index.ts
+++ b/packages/workspace/file-reference/src/ui/index.ts
@@ -3,7 +3,9 @@ export {
   type WorkspaceFileReferencePickerProps
 } from "./internal/reference/WorkspaceFileReferencePicker.tsx";
 export {
+  ReferenceSourceContentPane,
   ReferenceSourcePicker,
+  type ReferenceSourceContentPaneProps,
   type ReferenceSourcePickerProps
 } from "./internal/reference/ReferenceSourcePicker.tsx";
 export type {

--- a/packages/workspace/file-reference/src/ui/internal/reference/ReferenceSourcePicker.tsx
+++ b/packages/workspace/file-reference/src/ui/internal/reference/ReferenceSourcePicker.tsx
@@ -52,6 +52,7 @@ import {
   type WorkspaceFileOpenWithApplication
 } from "@tutti-os/workspace-file-manager";
 import type {
+  NodeRef,
   ReferenceLocateTarget,
   ReferenceNode
 } from "../../../contracts/referenceSource.ts";
@@ -678,6 +679,412 @@ export function ReferenceSourcePicker({
     return dialog;
   }
   return createPortal(dialog, document.body);
+}
+
+export interface ReferenceSourceContentPaneProps {
+  aggregator: ReferenceSourceAggregator;
+  className?: string;
+  copy: WorkspaceFileReferenceCopy;
+  fileManagerCopy?: WorkspaceFileManagerI18nRuntime;
+  hostOs?: NodeJS.Platform;
+  initialNodeRef?: NodeRef | null;
+  initialTarget?: ReferenceLocateTarget | null;
+  resolveEntryIconUrl?: (
+    entry: WorkspaceFileEntry
+  ) => Promise<string | null | undefined>;
+  resolveOpenWithApplicationIcon?: (
+    application: WorkspaceFileOpenWithApplication
+  ) => JSX.Element | null;
+  workspaceId: string;
+}
+
+export function ReferenceSourceContentPane({
+  aggregator,
+  className,
+  copy,
+  fileManagerCopy,
+  hostOs = "darwin",
+  initialNodeRef = null,
+  initialTarget = null,
+  resolveEntryIconUrl,
+  resolveOpenWithApplicationIcon,
+  workspaceId
+}: ReferenceSourceContentPaneProps): JSX.Element {
+  const view = useReferenceSourcePickerView({
+    aggregator,
+    workspaceId,
+    open: true,
+    workspaceRootGroupLabel: copy.t("referencePicker.workspaceRootGroup"),
+    initialTarget,
+    isNodeSelectable: () => false,
+    onClose: noopVoid,
+    onConfirm: noopVoid
+  });
+  useEffect(() => {
+    if (!initialNodeRef) {
+      return;
+    }
+    if (view.selectedGroupKey === nodeRefKey(initialNodeRef)) {
+      return;
+    }
+    const group = view.sidebarGroupsBySource[initialNodeRef.sourceId]?.find(
+      (item) => item.ref.nodeId === initialNodeRef.nodeId
+    );
+    if (!group) {
+      return;
+    }
+    view.selectGroup(group);
+  }, [
+    initialNodeRef,
+    view.selectedGroupKey,
+    view.sidebarGroupsBySource,
+    view.selectGroup
+  ]);
+  const activeFilterSet = new Set(view.activeFilters);
+  const toggleFilter = (id: string) => {
+    const next = new Set(activeFilterSet);
+    if (next.has(id)) {
+      next.delete(id);
+    } else {
+      next.add(id);
+    }
+    view.setFilters([...next]);
+  };
+  const clearFilters = () => view.setFilters([]);
+  const searchInput = useComposedInputValue({
+    onCommit: view.setSearchQuery,
+    value: view.searchQuery
+  });
+  const contextMenuRef = useRef<HTMLDivElement | null>(null);
+  const [contextMenu, setContextMenu] =
+    useState<ReferenceSourceContextMenuState | null>(null);
+  const [openWithApplications, setOpenWithApplications] = useState<
+    WorkspaceFileOpenWithApplication[]
+  >([]);
+  const [openWithLoading, setOpenWithLoading] = useState(false);
+  const retainedIconEntries = useMemo(
+    () =>
+      collectReferenceNodeIconEntries({
+        childrenByKey: view.childrenByKey,
+        currentEntries: view.currentEntries,
+        expandedKeys: view.expandedKeys,
+        focusedNode: view.focusedNode,
+        searchResults: view.searchResults,
+        selection: view.selection,
+        sidebarGroupsBySource: view.sidebarGroupsBySource
+      }),
+    [
+      view.childrenByKey,
+      view.currentEntries,
+      view.expandedKeys,
+      view.focusedNode,
+      view.searchResults,
+      view.selection,
+      view.sidebarGroupsBySource
+    ]
+  );
+  const iconUrls = useWorkspaceFileEntryIconUrls({
+    entries: retainedIconEntries,
+    includeImageThumbnails: resolveEntryIconUrl !== undefined,
+    resolveEntryIconUrl
+  });
+
+  useEffect(() => {
+    if (!contextMenu || !fileManagerCopy) {
+      setOpenWithApplications([]);
+      setOpenWithLoading(false);
+      return;
+    }
+
+    let cancelled = false;
+    const cachedApplications = view.getCachedOpenWithApplications(
+      contextMenu.node
+    );
+    if (cachedApplications) {
+      setOpenWithApplications(cachedApplications);
+      setOpenWithLoading(false);
+      return;
+    }
+
+    setOpenWithApplications([]);
+    setOpenWithLoading(true);
+    void view
+      .listOpenWithApplications(contextMenu.node)
+      .then((applications) => {
+        if (cancelled) {
+          return;
+        }
+        setOpenWithApplications(applications);
+        setOpenWithLoading(false);
+      })
+      .catch(() => {
+        if (cancelled) {
+          return;
+        }
+        setOpenWithApplications([]);
+        setOpenWithLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [contextMenu?.node, fileManagerCopy]);
+
+  useEffect(() => {
+    if (!contextMenu) {
+      return;
+    }
+
+    function handlePointerDown(event: globalThis.PointerEvent): void {
+      const target = event.target;
+      if (target instanceof Node && contextMenuRef.current?.contains(target)) {
+        return;
+      }
+      if (
+        target instanceof Element &&
+        target.closest("[data-workspace-file-manager-submenu]")
+      ) {
+        return;
+      }
+      setContextMenu(null);
+    }
+
+    function handleKeyDown(event: KeyboardEvent): void {
+      if (event.key === "Escape") {
+        setContextMenu(null);
+      }
+    }
+
+    window.addEventListener("pointerdown", handlePointerDown);
+    window.addEventListener("keydown", handleKeyDown);
+    return () => {
+      window.removeEventListener("pointerdown", handlePointerDown);
+      window.removeEventListener("keydown", handleKeyDown);
+    };
+  }, [contextMenu]);
+
+  const openReferenceContextMenu = (
+    event: MouseEvent<HTMLElement>,
+    node: ReferenceNode
+  ): void => {
+    if (!fileManagerCopy || node.kind !== "file") {
+      return;
+    }
+    event.preventDefault();
+    event.stopPropagation();
+    view.setFocusedNode(node);
+    setContextMenu({
+      node,
+      x: event.clientX,
+      y: event.clientY
+    });
+  };
+  const hasSelectedGroup = view.selectedGroupKey != null;
+
+  return (
+    <div
+      className={cn(
+        "relative flex min-h-0 min-w-0 flex-1 overflow-hidden bg-[var(--background-fronted)]",
+        className
+      )}
+      data-slot="viewport-menu-boundary"
+      data-workspace-file-menu-boundary=""
+      style={
+        {
+          "--workspace-file-manager-dialog-overlay-z-index": "20"
+        } as CSSProperties
+      }
+    >
+      <div className="flex min-h-0 min-w-0 flex-[1.7] flex-col border-r border-[var(--line-1)]">
+        <div className="flex items-center gap-2 border-b border-[var(--line-1)] p-3">
+          <div className="relative flex-1">
+            <SearchIcon className="pointer-events-none absolute top-1/2 left-3 size-4 -translate-y-1/2 text-[var(--text-tertiary)]" />
+            <Input
+              className="pl-9"
+              placeholder={copy.t("referencePicker.searchPlaceholder")}
+              value={searchInput.value}
+              onBlur={searchInput.onBlur}
+              onChange={searchInput.onChange}
+              onCompositionEnd={searchInput.onCompositionEnd}
+              onCompositionStart={searchInput.onCompositionStart}
+            />
+          </div>
+          {view.capabilities?.filterable && view.filterCategories.length > 0 ? (
+            <FilterCategoryFilter
+              categories={view.filterCategories}
+              copy={copy}
+              selected={activeFilterSet}
+              onClear={clearFilters}
+              onToggle={toggleFilter}
+            />
+          ) : null}
+        </div>
+        <ScrollArea
+          className="min-h-0 flex-1"
+          viewportProps={{
+            onScroll: (event) => {
+              const el = event.currentTarget;
+              if (
+                view.hasMore &&
+                !view.isLoading &&
+                !view.isLoadingMore &&
+                el.scrollHeight - el.scrollTop - el.clientHeight < 120
+              ) {
+                view.loadMore();
+              }
+            }
+          }}
+        >
+          <div className="flex flex-col gap-[2px] p-3">
+            {view.isLoading ? (
+              <Feedback>
+                <Spinner size={16} />
+              </Feedback>
+            ) : view.isQuery ? (
+              view.searchResults.length === 0 ? (
+                <Feedback>{copy.t("referencePicker.emptySearch")}</Feedback>
+              ) : (
+                view.searchResults.map((node) => (
+                  <SearchResultRow
+                    key={nodeRefKey(node.ref)}
+                    focused={isFocused(view.focusedNode, node)}
+                    iconUrls={iconUrls}
+                    node={node}
+                    selected={view.isSelected(node)}
+                    onFocus={view.setFocusedNode}
+                    onContextMenu={openReferenceContextMenu}
+                    onOpen={view.openNode}
+                    selectable={view.isSelectable(node)}
+                    onSingleSelect={view.toggleSingleSelectionAndExpand}
+                    onToggle={view.toggleSelection}
+                  />
+                ))
+              )
+            ) : view.currentEntries.length === 0 ? (
+              <Feedback>
+                {copy.t(
+                  hasSelectedGroup
+                    ? "referencePicker.emptyDirectory"
+                    : "referencePicker.selectGroupHint"
+                )}
+              </Feedback>
+            ) : (
+              view.currentEntries.map((node) => (
+                <TreeNodeRow
+                  key={nodeRefKey(node.ref)}
+                  copy={copy}
+                  depth={0}
+                  iconUrls={iconUrls}
+                  node={node}
+                  onContextMenu={openReferenceContextMenu}
+                  view={view}
+                />
+              ))
+            )}
+            {view.hasMore && (view.isQuery || hasSelectedGroup) ? (
+              <Button
+                className="mt-1 w-full"
+                disabled={view.isLoadingMore}
+                size="sm"
+                type="button"
+                variant="ghost"
+                onClick={view.loadMore}
+              >
+                {view.isLoadingMore ? (
+                  <Spinner className="text-current" size={14} />
+                ) : null}
+                {copy.t("referencePicker.loadMore")}
+              </Button>
+            ) : null}
+          </div>
+        </ScrollArea>
+        {fileManagerCopy ? (
+          <WorkspaceFileManagerContextMenu
+            busy={view.isOpeningReference}
+            contextMenu={
+              contextMenu
+                ? {
+                    entry: referenceNodeToWorkspaceFileEntry(contextMenu.node),
+                    x: contextMenu.x,
+                    y: contextMenu.y
+                  }
+                : null
+            }
+            contextMenuRef={contextMenuRef}
+            copy={fileManagerCopy}
+            openWithApplications={openWithApplications}
+            openWithLoading={openWithLoading}
+            positionMode="viewport"
+            revealInFolderLabel={resolveRevealInFolderLabel(
+              fileManagerCopy,
+              hostOs
+            )}
+            resolveOpenWithApplicationIcon={resolveOpenWithApplicationIcon}
+            showCopyAction={false}
+            showCopyPathAction={false}
+            showCreateAction={false}
+            showDeleteAction={false}
+            showExportAction={false}
+            showImportAction={false}
+            showOpenInAppBrowserAction={false}
+            showOpenInDefaultBrowserAction={false}
+            showOpenInFileViewerAction={false}
+            showOpenWithAction={true}
+            showOpenWithOtherAction={true}
+            showRevealInFolderAction={true}
+            showRenameAction={false}
+            onClose={() => setContextMenu(null)}
+            onCopy={noopAsync}
+            onCopyPath={noopAsync}
+            onCreateDirectory={noopVoid}
+            onCreateFile={noopVoid}
+            onDelete={noopVoid}
+            onExport={noopAsync}
+            onImport={noopAsync}
+            onOpen={async () => {
+              if (contextMenu) {
+                await view.openNode(contextMenu.node);
+              }
+            }}
+            onOpenInAppBrowser={noopAsync}
+            onOpenInDefaultBrowser={noopAsync}
+            onOpenInFileViewer={noopAsync}
+            onOpenWithApplication={async (applicationPath) => {
+              if (contextMenu) {
+                await view.openWithApplication(
+                  contextMenu.node,
+                  applicationPath
+                );
+              }
+            }}
+            onOpenWithOtherApplication={async () => {
+              if (contextMenu) {
+                await view.openWithOtherApplication(
+                  contextMenu.node,
+                  fileManagerCopy.t("openWithOtherPickerPrompt")
+                );
+              }
+            }}
+            onRevealInFolder={async () => {
+              if (contextMenu) {
+                await view.revealNode(contextMenu.node);
+              }
+            }}
+            onRename={noopVoid}
+          />
+        ) : null}
+      </div>
+      <div className="@max-[760px]/workspace-file-manager:hidden min-h-0 min-w-[220px] flex-1">
+        <PreviewInfoPane
+          copy={copy}
+          hierarchy={view.breadcrumb}
+          iconUrls={iconUrls}
+          node={view.focusedNode}
+          previewState={view.previewState}
+          sourceLabel={view.activeTabLabel}
+        />
+      </div>
+    </div>
+  );
 }
 
 /**


### PR DESCRIPTION
## Summary
- expose app artifact and issue reference source groups as external File Manager locations
- render external reference locations through the embedded reference explorer without adding a reverse package dependency
- add session/service coverage and document the ownership boundary

## Validation
- pnpm check:changed --tail-lines 80
- PATH="$(go env GOPATH)/bin:$PATH" pnpm lint:go
- PATH="$(go env GOPATH)/bin:$PATH" git push -u origin feat/workspace-file-reference-locations (pre-push pnpm check:full passed)

## Docs
- updated docs/architecture/agent-reference-source-services.md

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for workspace “external” locations in the file manager, including custom icons and dedicated content views.
  * Reference sources can now be browsed directly from the workspace file manager with localized labels and search/navigation support.
* **Bug Fixes**
  * Disabled create, rename, move, refresh, copy, and import actions for read-only/external locations.
  * Improved selection behavior so external locations no longer trigger directory loading and keep their state properly.
* **Documentation**
  * Updated architecture guidance for how reference sources are integrated into the file manager.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->