### PR TITLE
test(codex): phase-0 protocol verification + corpus enrollment

### DIFF
--- a/docs/adr/0003-step3-thread-registry-subagent-routing.md
+++ b/docs/adr/0003-step3-thread-registry-subagent-routing.md
@@ -75,3 +75,23 @@ parent turn (t3code's re-tag path, rejected — see Concurrency).
   required on item/started). Early child event before the announce → unknown-fallback
   (log+drop), validate against real logs. Registry map is owned by the single
   sequential reducer (or mutex-guarded).
+
+## Ordering verification (2026-07-02, Phase 0)
+
+ADR question: can child-thread events arrive before the parent
+`collabAgentToolCall` announces `receiverThreadIds`?
+
+- **Transport analysis:** notifications share one stdio NDJSON connection, so
+  delivery is strictly serialized; the only theoretical gap is the app-server
+  internally enqueueing child output between the spawn item's `started` (which
+  already carries the required `receiverThreadIds`) and the registration being
+  processed - a sub-millisecond window on the same pipe.
+- **Empirical:** across all four exported log bundles (2026-07-02 sessions with
+  4-5 concurrent children each), every declared receiver had a complete row
+  set; no early-drop evidence.
+- **Permanent telemetry:** the daemon now tracks unknown-thread drops per
+  session (bounded) and, when a child registers late, logs
+  `child events arrived before registration` with the lost-event count and
+  records it on the thread context (`droppedBeforeRegistration`, pinned by
+  `TestCodexAppServerChildRegistrationReportsEarlyDrops`). If real deployments
+  ever hit the window, the log answers it; no speculative buffer added.

--- a/docs/adr/0006-step6-approval-resolver-durable-projection.md
+++ b/docs/adr/0006-step6-approval-resolver-durable-projection.md
@@ -82,3 +82,20 @@ durable state honest regardless.
   carries turn state + messages; `SubmitInteractive` is a responder like the turn
   command; both reconcile against the Step-4 snapshot.
 - #418 detail is largely handled today; this ADR targets the pending STATE + resolution.
+
+## Live verification (2026-07-02, Phase 0)
+
+Ran against the real binary (`codex-cli 0.142.5`) via the env-gated test
+`TestLiveProtocolResumeServerRequestReissue`
+(`packages/agent/daemon/runtime/liveprotocol_verify_test.go`,
+`TUTTI_LIVE_PROTOCOL_VERIFY=1`): provoke `item/commandExecution/requestApproval`
+(read-only sandbox + untrusted policy), leave it unanswered, kill the client
+process, resume the thread from a fresh process.
+
+**Verdict: codex does NOT re-issue the pending server-request after
+`thread/resume`.** Additionally: the interrupted-mid-approval turn does not
+resume (thread status returns `idle`), and the unanswered approval item is NOT
+replayed by resume — so a daemon restart leaves no zombie `waiting_input` row
+in the rebuilt store either. The conservative reconnect policy stands
+confirmed: no RPC revival is possible; pending approvals die with their turn
+and the user re-drives. No code change required.

--- a/docs/specs/2026-07-01-codex-appserver-bug-corpus.md
+++ b/docs/specs/2026-07-01-codex-appserver-bug-corpus.md
@@ -22,3 +22,34 @@ diff to these tests is a regression.
 | **D — session / live-session lifecycle** | `TestCodexAppServerAdapterReleaseLiveSessionClosesClientAndKeepsProviderSession`, `TestCodexAppServerAdapterReleaseLiveSessionSkipsPendingRequests` | #604 | Step 7 (facade owns lifecycle; outcomes stay) |
 | **E — approval / interactive** | `TestCodexAppServerAdapterCommandApprovalApprove`, `TestCodexAppServerAdapterCommandApprovalDecisionMapping`, `TestCodexAppServerAdapterRequestUserInput`, `TestAppServerUserInputAnswers` | #418 | Step 6 (resolver extraction; outcomes stay) |
 | **A — daemon↔desktop hydration** (desktop-half; out of daemon scope) | GUI: `useAgentGUINodeController.spec.tsx` (#608) | sessions `7633ebb9`/`2d73bad7`/`08920807`; #608; #585 | **Step 9** (deferred desktop rewrite). Daemon-half contract is authored in **Step 4**. |
+
+## Corpus expansion (2026-07-02, refactor + live-testing regressions)
+
+The refactor round proved "all green ≠ bug-free": ten review findings and four
+live log-bundle bugs all landed in corpus gaps. Their regression tests are now
+part of the contract. Baseline re-check: `codex-cli 0.142.5` (unchanged), source
+SHA `6d2168f06ae275d5e1f73cabf935d2bcc8549998` (unchanged) — no drift, no bump.
+
+Run commands (work area `packages/agent/daemon`):
+
+```bash
+# runtime additions
+go test ./runtime/ -count=1 -run \
+  'TestCodexAppServerChildThreadErrorDoesNotFailParentTurn|TestCodexAppServerStrayTurnStartedDoesNotHijackActiveTurn|TestControllerExecSteerSettlesTurnRecordWithoutTerminalEvent|TestCodexAppServerAdapterCancelInterruptsLinkedChildThreads|TestCodexAppServerAdapterCancelAfterTurnCompletedStillMarksChildrenCanceled|TestCodexAppServerAdapterConcurrentStartsLeaveSingleLiveProcess|TestCodexAppServerAdapterStartOverLiveSessionStopsPreviousProcess|TestCodexAppServerAdapterResumeOverLiveSessionClosesPreviousProcess|TestCodexAppServerAdapterResumeSpawnFailureKeepsPreviousSessionLive|TestCodexAppServerAdapterResumeThreadFailureKeepsPreviousSessionLive|TestCodexAppServerAdapterStartReleaseRaceLeavesNoOrphanProcess|TestCodexAppServerClientCloseIsIdempotent|TestCodexAppServerAdapterRoutesLinkedChildThreadEvents|TestCodexAppServerChildThreadNameUpdateEmitsNameMarker|TestCodexAppServerAdapterFetchesChildThreadNickname|TestAppServerCollabAgentRawInputCarriesReceiverThreadIDs|TestCodexAppServerChildRegistrationReportsEarlyDrops|TestReportActivityInputForwardsSubAgentMarkerFieldsToPayload'
+
+# activity store additions (hydration cursor contract)
+go test ./activity/ -count=1 -run \
+  'TestStoreListSessionMessagesPagesByVersionDespiteOccurredAtOrder|TestStoreSortsSessionMessagesByOccurredAtNotVersion|TestStoreZeroOccurredAtLegacyRowSortsByFallbackTimestamp'
+```
+
+| Cluster | Added pinning test(s) | Origin |
+|---|---|---|
+| **C — turn lifecycle** | `ChildThreadErrorDoesNotFailParentTurn`, `StrayTurnStartedDoesNotHijackActiveTurn`, `ExecSteerSettlesTurnRecordWithoutTerminalEvent` | review round 2 (branch-introduced regressions) |
+| **B/C — cancel propagation** | `CancelInterruptsLinkedChildThreads`, `CancelAfterTurnCompletedStillMarksChildrenCanceled` | log bundle 20260702-145427 (`missing turnId` rejection) |
+| **D — single live process** | `ConcurrentStartsLeaveSingleLiveProcess`, `StartOverLiveSession…`, `ResumeOverLiveSession…`, `ResumeSpawnFailure…`, `ResumeThreadFailure…`, `StartReleaseRace…`, `ClientCloseIsIdempotent` | duplicate app-server processes (live) |
+| **A — hydration cursor** | `PagesByVersionDespiteOccurredAtOrder`, `SortsSessionMessagesByOccurredAtNotVersion`, `ZeroOccurredAtLegacyRowSortsByFallbackTimestamp` | ADR 0004 + review round 1 |
+| **B — child routing / identity** | `RoutesLinkedChildThreadEvents`, `ChildThreadNameUpdateEmitsNameMarker`, `FetchesChildThreadNickname`, `CollabAgentRawInputCarriesReceiverThreadIDs`, `ChildRegistrationReportsEarlyDrops`, `ForwardsSubAgentMarkerFieldsToPayload` | ADR 0003 + log bundles 153958/165411 |
+
+Live-gated protocol verification (not part of CI; run manually when protocol
+behavior is in question): `TUTTI_LIVE_PROTOCOL_VERIFY=1 go test ./runtime/ -run
+TestLiveProtocol -v` — see ADR 0006 "Live verification".

--- a/packages/agent/daemon/runtime/codex_appserver_adapter.go
+++ b/packages/agent/daemon/runtime/codex_appserver_adapter.go
@@ -144,6 +144,9 @@ type codexAppServerSession struct {
 	lastTurnID   string
 	activeTurn   *codexAppServerActiveTurn
 	childThreads map[string]*codexAppServerThreadContext
+	// recentForeignDrops remembers recently dropped unknown thread ids so a
+	// late registration can report how many events the ordering gap lost.
+	recentForeignDrops map[string]int
 	acpLiveState
 	pendingRequests map[string]*pendingACPRequest
 }
@@ -152,6 +155,10 @@ type codexAppServerThreadContext struct {
 	parentThreadID string
 	parentItemID   string
 	normalizer     *acpTurnNormalizer
+	// droppedBeforeRegistration counts events for this thread that arrived
+	// (and were dropped as unknown) before its receiverThreadIds registration
+	// - permanent telemetry for ADR 0003's ordering question.
+	droppedBeforeRegistration int
 }
 
 // codexAppServerActiveTurn carries the streaming context of an in-flight

--- a/packages/agent/daemon/runtime/codex_appserver_events.go
+++ b/packages/agent/daemon/runtime/codex_appserver_events.go
@@ -430,6 +430,7 @@ func (a *CodexAppServerAdapter) appServerNotificationRoute(
 
 	child, ok := a.appServerChildThread(session.AgentSessionID, eventThreadID)
 	if !ok {
+		a.recordForeignThreadDrop(session.AgentSessionID, eventThreadID)
 		a.logAppServerForeignThreadDrop(session, method, params, eventThreadID)
 		return appServerNotificationRoute{drop: true}
 	}
@@ -453,6 +454,33 @@ func (a *CodexAppServerAdapter) appServerNotificationRoute(
 		turnID:        firstNonEmpty(asString(params["turnId"]), asString(payloadObject(params["turn"])["id"])),
 		normalizer:    child.normalizer,
 	}
+}
+
+const appServerForeignDropTrackerCap = 64
+
+// recordForeignThreadDrop remembers an unknown-thread drop so a later child
+// registration can report events lost to the announce/stream ordering gap
+// (ADR 0003 verification telemetry). Bounded; unrelated foreign threads age
+// out by never being registered.
+func (a *CodexAppServerAdapter) recordForeignThreadDrop(agentSessionID string, threadID string) {
+	if a == nil {
+		return
+	}
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	appSession := a.sessions[strings.TrimSpace(agentSessionID)]
+	if appSession == nil {
+		return
+	}
+	if appSession.recentForeignDrops == nil {
+		appSession.recentForeignDrops = make(map[string]int)
+	}
+	if len(appSession.recentForeignDrops) >= appServerForeignDropTrackerCap {
+		if _, tracked := appSession.recentForeignDrops[threadID]; !tracked {
+			return
+		}
+	}
+	appSession.recentForeignDrops[threadID]++
 }
 
 func (a *CodexAppServerAdapter) rememberAppServerChildThreads(agentSessionID string, parentThreadID string, item map[string]any) []string {
@@ -488,11 +516,22 @@ func (a *CodexAppServerAdapter) rememberAppServerChildThreads(agentSessionID str
 			}
 			continue
 		}
-		appSession.childThreads[childThreadID] = &codexAppServerThreadContext{
+		context := &codexAppServerThreadContext{
 			parentThreadID: parentThreadID,
 			parentItemID:   parentItemID,
 			normalizer:     newACPTurnNormalizer(),
 		}
+		if dropped := appSession.recentForeignDrops[childThreadID]; dropped > 0 {
+			context.droppedBeforeRegistration = dropped
+			delete(appSession.recentForeignDrops, childThreadID)
+			slog.Warn(
+				"agent session app-server child events arrived before registration",
+				"agent_session_id", agentSessionID,
+				"child_thread_id", childThreadID,
+				"dropped_events", dropped,
+			)
+		}
+		appSession.childThreads[childThreadID] = context
 		added = append(added, childThreadID)
 	}
 	return added
@@ -510,9 +549,10 @@ func (a *CodexAppServerAdapter) appServerChildThread(agentSessionID string, chil
 		return nil, false
 	}
 	return &codexAppServerThreadContext{
-		parentThreadID: child.parentThreadID,
-		parentItemID:   child.parentItemID,
-		normalizer:     child.normalizer,
+		parentThreadID:            child.parentThreadID,
+		parentItemID:              child.parentItemID,
+		normalizer:                child.normalizer,
+		droppedBeforeRegistration: child.droppedBeforeRegistration,
 	}, true
 }
 

--- a/packages/agent/daemon/runtime/codex_appserver_events_test.go
+++ b/packages/agent/daemon/runtime/codex_appserver_events_test.go
@@ -302,6 +302,52 @@ func TestCodexAppServerUnhandledServerRequestCardOnlyForUnknownMethods(t *testin
 	}
 }
 
+// ADR 0003 open question: can child-thread events arrive before the parent
+// collabAgentToolCall announces receiverThreadIds? This detector makes real
+// deployments answer it permanently: unknown-thread drops are remembered, and
+// registration reports how many events were lost to the ordering gap.
+func TestCodexAppServerChildRegistrationReportsEarlyDrops(t *testing.T) {
+	t.Parallel()
+
+	adapter := NewCodexAppServerAdapter(nil)
+	session := Session{
+		AgentSessionID:    "agent-session-1",
+		Provider:          ProviderCodex,
+		ProviderSessionID: "parent-thread-1",
+	}
+	adapter.storeSession(session.AgentSessionID, &codexAppServerSession{threadID: session.ProviderSessionID})
+
+	// Two child events arrive before anything registered the child: both drop.
+	for range 2 {
+		route := adapter.appServerNotificationRoute(session, appServerNotifyAgentMessageDelta, map[string]any{
+			"threadId": "child-early-1",
+			"turnId":   "child-turn-1",
+			"delta":    "early output",
+		})
+		if !route.drop || route.ownerThreadID != "" {
+			t.Fatalf("unknown thread event should drop: %#v", route)
+		}
+	}
+
+	added := adapter.rememberAppServerChildThreads(session.AgentSessionID, session.ProviderSessionID, map[string]any{
+		"type":              "collabAgentToolCall",
+		"id":                "spawn-1",
+		"receiverThreadIds": []any{"child-early-1", "child-clean-2"},
+	})
+	if len(added) != 2 {
+		t.Fatalf("added = %#v, want both children", added)
+	}
+
+	early, ok := adapter.appServerChildThread(session.AgentSessionID, "child-early-1")
+	if !ok || early.droppedBeforeRegistration != 2 {
+		t.Fatalf("child-early-1 droppedBeforeRegistration = %#v (ok=%v), want 2", early, ok)
+	}
+	clean, ok := adapter.appServerChildThread(session.AgentSessionID, "child-clean-2")
+	if !ok || clean.droppedBeforeRegistration != 0 {
+		t.Fatalf("child-clean-2 droppedBeforeRegistration = %#v (ok=%v), want 0", clean, ok)
+	}
+}
+
 func TestCodexAppServerChildThreadNameUpdateEmitsNameMarker(t *testing.T) {
 	t.Parallel()
 

--- a/packages/agent/daemon/runtime/liveprotocol_verify_test.go
+++ b/packages/agent/daemon/runtime/liveprotocol_verify_test.go
@@ -1,0 +1,318 @@
+package agentruntime
+
+import (
+	"bufio"
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+// Live protocol verification for the two ADR-flagged questions that only a
+// real codex app-server can answer. Guarded behind an env var: these tests
+// spawn the installed codex binary, run a real (tiny) model turn, and need
+// the user's codex auth.
+//
+//	TUTTI_LIVE_PROTOCOL_VERIFY=1 go test ./runtime/ -run TestLiveProtocol -v -count=1
+//
+// ADR 0006 question: does codex re-issue a pending server-request
+// (item/commandExecution/requestApproval) after the client dies and a new
+// process does thread/resume? The reconnect policy (interrupted/re-offer vs
+// seamless approval revival) depends on the answer.
+func TestLiveProtocolResumeServerRequestReissue(t *testing.T) {
+	if os.Getenv("TUTTI_LIVE_PROTOCOL_VERIFY") == "" {
+		t.Skip("set TUTTI_LIVE_PROTOCOL_VERIFY=1 to run live protocol verification")
+	}
+
+	workDir := t.TempDir()
+
+	// --- Process 1: start a thread, provoke an approval, leave it pending.
+	proc1 := startLiveAppServer(t)
+	defer proc1.kill()
+
+	proc1.initialize(t)
+	threadID := proc1.threadStart(t, workDir)
+	t.Logf("thread started: %s", threadID)
+
+	turnResult := proc1.call(t, "turn/start", map[string]any{
+		"threadId":       threadID,
+		"approvalPolicy": "untrusted",
+		"input": []any{map[string]any{
+			"type": "text",
+			"text": "Create a file named tutti-live-verify.txt containing the word ok, using a shell command (for example `bash -lc \\\"echo ok > tutti-live-verify.txt\\\"`). Do it immediately without asking questions.",
+		}},
+	})
+	t.Logf("turn/start result: %s", compactJSON(turnResult))
+
+	pending := proc1.waitForServerRequest(t, "requestApproval", 120*time.Second)
+	if pending == nil {
+		t.Logf("notifications so far:\n%s", proc1.notificationDigest())
+		t.Fatalf("no approval server-request arrived; cannot verify re-issue behavior")
+	}
+	t.Logf("pending approval request: id=%v method=%s params=%s",
+		pending.ID, pending.Method, compactJSON(pending.Params))
+
+	// Leave the request unanswered and kill the process (simulates the
+	// daemon releasing/crashing while an approval is pending).
+	proc1.kill()
+	time.Sleep(1 * time.Second)
+
+	// --- Process 2: resume the same thread and observe.
+	proc2 := startLiveAppServer(t)
+	defer proc2.kill()
+	proc2.initialize(t)
+
+	resumeResult := proc2.call(t, "thread/resume", map[string]any{
+		"threadId": threadID,
+		"cwd":      workDir,
+	})
+	t.Logf("thread/resume result: %s", compactJSON(resumeResult))
+
+	// Observe the wire for a while: does the approval request re-issue?
+	reissued := proc2.waitForServerRequest(t, "requestApproval", 30*time.Second)
+	if reissued != nil {
+		t.Logf("VERDICT: codex RE-ISSUES the pending server-request on resume: id=%v method=%s params=%s",
+			reissued.ID, reissued.Method, compactJSON(reissued.Params))
+	} else {
+		t.Logf("VERDICT: codex does NOT re-issue the pending server-request within 30s of thread/resume")
+	}
+
+	// Also read the thread state for the turn's fate.
+	threadRead := proc2.call(t, "thread/read", map[string]any{
+		"threadId": threadID,
+	})
+	t.Logf("thread/read after resume: %s", truncateForLog(compactJSON(threadRead), 2000))
+
+	t.Logf("notifications observed after resume:\n%s", proc2.notificationDigest())
+}
+
+// --- minimal NDJSON JSON-RPC driver over the codex app-server binary ---
+
+type liveServerRequest struct {
+	ID     any
+	Method string
+	Params map[string]any
+}
+
+type liveAppServer struct {
+	t      *testing.T
+	cmd    *exec.Cmd
+	stdin  *json.Encoder
+	mu     sync.Mutex
+	nextID int
+	// responses by request id (client->server calls)
+	responses map[string]chan map[string]any
+	// server->client requests (messages with both id and method)
+	serverRequests chan liveServerRequest
+	notifications  []string
+	done           chan struct{}
+}
+
+func startLiveAppServer(t *testing.T) *liveAppServer {
+	t.Helper()
+	cmd := exec.Command("codex", "app-server")
+	cmd.Env = os.Environ()
+	stdin, err := cmd.StdinPipe()
+	if err != nil {
+		t.Fatalf("stdin pipe: %v", err)
+	}
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		t.Fatalf("stdout pipe: %v", err)
+	}
+	cmd.Stderr = os.Stderr
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("start codex app-server: %v", err)
+	}
+	server := &liveAppServer{
+		t:              t,
+		cmd:            cmd,
+		stdin:          json.NewEncoder(stdin),
+		responses:      map[string]chan map[string]any{},
+		serverRequests: make(chan liveServerRequest, 16),
+		done:           make(chan struct{}),
+	}
+	go server.readLoop(stdout)
+	return server
+}
+
+func (s *liveAppServer) readLoop(stdout interface{ Read([]byte) (int, error) }) {
+	scanner := bufio.NewScanner(stdout)
+	scanner.Buffer(make([]byte, 0, 1024*1024), 16*1024*1024)
+	for scanner.Scan() {
+		line := scanner.Bytes()
+		var message struct {
+			ID     any             `json:"id"`
+			Method string          `json:"method"`
+			Params map[string]any  `json:"params"`
+			Result json.RawMessage `json:"result"`
+			Error  json.RawMessage `json:"error"`
+		}
+		if err := json.Unmarshal(line, &message); err != nil {
+			continue
+		}
+		switch {
+		case message.ID != nil && message.Method != "":
+			// server -> client request
+			select {
+			case s.serverRequests <- liveServerRequest{ID: message.ID, Method: message.Method, Params: message.Params}:
+			default:
+			}
+		case message.ID != nil:
+			// response to one of our calls
+			s.mu.Lock()
+			key := fmt.Sprintf("%v", message.ID)
+			ch := s.responses[key]
+			delete(s.responses, key)
+			s.mu.Unlock()
+			if ch != nil {
+				payload := map[string]any{}
+				if len(message.Result) > 0 {
+					payload["result"] = json.RawMessage(message.Result)
+				}
+				if len(message.Error) > 0 {
+					payload["error"] = json.RawMessage(message.Error)
+				}
+				ch <- payload
+			}
+		default:
+			// notification
+			s.mu.Lock()
+			s.notifications = append(s.notifications,
+				fmt.Sprintf("%s %s", message.Method, truncateForLog(compactJSON(message.Params), 220)))
+			s.mu.Unlock()
+		}
+	}
+	close(s.done)
+}
+
+func (s *liveAppServer) call(t *testing.T, method string, params map[string]any) map[string]any {
+	t.Helper()
+	s.mu.Lock()
+	s.nextID++
+	id := s.nextID
+	ch := make(chan map[string]any, 1)
+	s.responses[fmt.Sprintf("%d", id)] = ch
+	s.mu.Unlock()
+	if err := s.stdin.Encode(map[string]any{
+		"jsonrpc": "2.0", "id": id, "method": method, "params": params,
+	}); err != nil {
+		t.Fatalf("send %s: %v", method, err)
+	}
+	select {
+	case response := <-ch:
+		return response
+	case <-time.After(120 * time.Second):
+		t.Fatalf("timeout waiting for %s response", method)
+		return nil
+	case <-s.done:
+		t.Fatalf("app-server exited while waiting for %s", method)
+		return nil
+	}
+}
+
+func (s *liveAppServer) notify(t *testing.T, method string, params map[string]any) {
+	t.Helper()
+	if err := s.stdin.Encode(map[string]any{
+		"jsonrpc": "2.0", "method": method, "params": params,
+	}); err != nil {
+		t.Fatalf("notify %s: %v", method, err)
+	}
+}
+
+func (s *liveAppServer) initialize(t *testing.T) {
+	t.Helper()
+	result := s.call(t, "initialize", map[string]any{
+		"clientInfo": codexClientInfoParamsForVersion(HostMetadata{}, "0.142.5"),
+	})
+	if _, hasError := result["error"]; hasError {
+		t.Fatalf("initialize failed: %s", compactJSON(result))
+	}
+	s.notify(t, "initialized", map[string]any{})
+}
+
+func (s *liveAppServer) threadStart(t *testing.T, cwd string) string {
+	t.Helper()
+	result := s.call(t, "thread/start", map[string]any{
+		"cwd":            cwd,
+		"approvalPolicy": "untrusted",
+		"sandbox":        "read-only",
+	})
+	raw, _ := result["result"].(json.RawMessage)
+	var parsed struct {
+		Thread struct {
+			ID string `json:"id"`
+		} `json:"thread"`
+		ThreadID string `json:"threadId"`
+	}
+	_ = json.Unmarshal(raw, &parsed)
+	threadID := parsed.Thread.ID
+	if threadID == "" {
+		threadID = parsed.ThreadID
+	}
+	if threadID == "" {
+		t.Fatalf("thread/start returned no thread id: %s", compactJSON(result))
+	}
+	return threadID
+}
+
+func (s *liveAppServer) waitForServerRequest(t *testing.T, methodSubstring string, timeout time.Duration) *liveServerRequest {
+	t.Helper()
+	deadline := time.After(timeout)
+	for {
+		select {
+		case request := <-s.serverRequests:
+			t.Logf("server request observed: %s", request.Method)
+			if strings.Contains(request.Method, methodSubstring) {
+				return &request
+			}
+		case <-deadline:
+			return nil
+		case <-s.done:
+			return nil
+		}
+	}
+}
+
+func (s *liveAppServer) notificationDigest() string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if len(s.notifications) == 0 {
+		return "(none)"
+	}
+	limit := len(s.notifications)
+	if limit > 80 {
+		limit = 80
+	}
+	return strings.Join(s.notifications[:limit], "\n")
+}
+
+func (s *liveAppServer) kill() {
+	if s.cmd != nil && s.cmd.Process != nil {
+		_ = s.cmd.Process.Kill()
+		_, _ = s.cmd.Process.Wait()
+	}
+}
+
+func compactJSON(value any) string {
+	switch typed := value.(type) {
+	case json.RawMessage:
+		return string(typed)
+	}
+	encoded, err := json.Marshal(value)
+	if err != nil {
+		return fmt.Sprintf("%v", value)
+	}
+	return string(encoded)
+}
+
+func truncateForLog(value string, limit int) string {
+	if len(value) <= limit {
+		return value
+	}
+	return value[:limit] + "…"
+}


### PR DESCRIPTION
## Summary

Phase 0 of the app-server refactor finish-line work (see docs/adr + design doc): settle the two ADR-flagged protocol questions with live evidence, and enroll the refactor round's regression tests into the bug-corpus contract.

## ADR 0006 — does codex re-issue pending server-requests on resume? **No.**

Live-verified against `codex-cli 0.142.5` via the new env-gated test (`TUTTI_LIVE_PROTOCOL_VERIFY=1 go test ./runtime/ -run TestLiveProtocol -v`): provoke a command approval, leave it unanswered, kill the client, resume from a fresh process →
- the pending `item/commandExecution/requestApproval` is **not re-issued**;
- the interrupted turn does **not** resume (thread returns `idle`);
- the unanswered approval item is **not replayed**, so a daemon restart leaves no zombie `waiting_input` row.

The conservative reconnect policy (no RPC revival; user re-drives) is confirmed — no code change needed.

## ADR 0003 — can child events beat the parent's receiverThreadIds announce?

Transport analysis (single NDJSON pipe = strict serialization) plus empirical evidence from four exported log bundles (no early drops) say the window is at most sub-millisecond. Instead of a speculative buffer, the daemon now **permanently detects** the case: an unknown-thread drop followed by that thread's registration logs `child events arrived before registration` with the lost-event count (`droppedBeforeRegistration`, pinned by `TestCodexAppServerChildRegistrationReportsEarlyDrops`).

## Corpus enrollment

21 regression tests from the refactor + live-testing round are now part of the bug-corpus contract (turn lifecycle, cancel propagation, single-process lifecycle, hydration cursor, child routing/identity), with run commands recorded in `docs/specs/2026-07-01-codex-appserver-bug-corpus.md`. Baseline re-checked: binary `0.142.5` / SHA `6d2168f0` — no drift.

## Testing
- Full `go test ./runtime/ ./activity/... -count=1`: green
- New corpus patterns: 18 runtime + 3 activity tests all match and pass
- Live protocol test: PASS (run twice; skipped by default without the env var)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of child-thread events that arrive before registration, reducing dropped notifications and adding follow-up reporting when they occur.
  * Added verification that pending approval requests are not re-issued after a resume.

* **Tests**
  * Added coverage for early child-thread event delivery and reporting.
  * Added a live verification test for resume behavior during a pending approval.

* **Documentation**
  * Updated ADRs and bug-corpus notes with the latest verification results and observed behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->