### PR TITLE
refactor(codex): step 7 completion — settle-owned turn terminals + cancel reconcile (ADR 0005 C+D)

### DIFF
--- a/docs/adr/0005-turn-lifecycle-optimal-projection.md
+++ b/docs/adr/0005-turn-lifecycle-optimal-projection.md
@@ -76,3 +76,52 @@ adapter API:
   enum beachhead, C+D = the structural completion; all committed, sequenced.**
 - Makes ADR 0004 (cursor) a hard prerequisite and ADR 0003 (`OwnerThreadID`) a
   feeder of the same unified projection.
+
+## Implementation outcome (2026-07-02, Phase 1)
+
+Step 7 (C+D) closed with three findings and two recorded deviations.
+
+**Finding — caller migration was already complete.** The controller's
+`runAsyncExecTurn` is purely event-driven (it finishes on terminal/steer
+events from the sink, never on `Exec`'s return); the blocking `adapter.Exec`
+path serves only non-`AsyncExecAdapter` providers. The strangler shim's
+"migrate callers one at a time" phase had therefore already happened; the
+remaining inversion was adapter-internal.
+
+**S1 — settle path owns terminal production (commit 2bb62315).** Turn outcome
+events (`EventTurnCompleted/Failed/Canceled` + finish classification) are now
+produced by the settle sequence itself, from all three exits: protocol settle
+(`settleActiveTurn`), force-cancel (`markTurnForceCanceled`), and an external
+death watcher (ctx cancel / client death become machine transitions). The
+blocking shell no longer classifies; it waits on the turn's `terminated`
+signal and snapshots. A dedupe-guarded shadow classification remains in the
+shell behind a 2s safety net, with `slog.Warn` telemetry on any shadow miss —
+this is the strangler's reversibility retained until Step 9 (Phase 2) proves
+the async path end-to-end, after which the shell can be deleted.
+
+**S2 deviation — submit/wait split skipped.** With S1 landed, the parked
+Exec goroutine only idles; it produces nothing. Splitting `Exec` into
+submit/await APIs would have churned the adapter surface for no behavioral
+gain. The essence of C — terminal truth owned by the projection/settle path,
+not the blocking await — is achieved without it.
+
+**S3 deviation — session-lifecycle ownership was already correct (doc-only).**
+The adapter owns live-session semantics and the busy veto
+(`ErrLiveSessionBusy`, test-covered); the controller owns scheduling and the
+idle-recycle policy over its own session timestamps
+(`ReleaseIdleLiveSessions`). No code change; the boundary matches this ADR's
+Cluster D intent.
+
+**S4 — controller cancel band-aid retired (commit b3043e85).** `Controller.Cancel`
+no longer skips when its turn registry has no record ("cancel skipped because
+no active turn exists"). It reconciles with the adapter: always calls
+`adapter.Cancel`, publishes returned events (e.g. linked child agents
+outliving a completed parent turn), and answers `Canceled=true` iff work was
+actually stopped. The adapter's `ErrSessionNoActiveTurn` maps to a calm
+"nothing to stop" result.
+
+Gates: Step-0 corpus (15) + Phase-0 expansion (18 runtime + 3 activity) green;
+full `packages/agent/daemon` module green; `-race` green for all app-server
+code (a pre-existing flaky race in `standard_acp_adapter.go`/
+`acp_turn_normalizer.go` — untouched by this refactor, inherited from main —
+was observed and is out of scope here).

--- a/docs/specs/2026-07-01-codex-appserver-refactor-design.md
+++ b/docs/specs/2026-07-01-codex-appserver-refactor-design.md
@@ -199,6 +199,17 @@ All four state machines are consolidated, but sequenced into independently shipp
 - **Exit:** approval flow is a standalone, tested unit reconciled against the snapshot; Cluster E cases covered (detail, approve/deny mapping, `requestUserInput`, `serverRequest/resolved` terminal, unknown-request reject).
 
 ### Step 7 — Thin the Adapter into a Thread/Turn facade + session lifecycle (state machine D) · *optimal path C+D (ADR 0005)*
+
+> **Status: DONE (2026-07-02, Phase 1).** The C inversion landed inside-out: the
+> controller's `runAsyncExecTurn` was already purely event-driven (blocking
+> `adapter.Exec` serves only non-async adapters), so the remaining work was
+> adapter-internal. Terminal event production now lives on the settle path
+> (protocol settle / force-cancel / external-death watcher); the blocking shell
+> is a dedupe-guarded shadow with warn telemetry, retained as the safety net
+> until Step 9 (Phase 2) completes. The controller `Cancel` no-active-turn
+> band-aid is retired in favor of adapter reconcile-cancel. Deviations and
+> verification: ADR 0005 "Implementation outcome" section.
+
 - What remains of `codex_appserver_adapter.go` collapses onto Thread/Turn lifecycle orchestration over the new layers (facade shape per `codex-sdk-go`).
 - **Invert `Exec` to non-blocking via a strangler shim (C):** introduce the async submit/observe core; keep the blocking `Exec([]activityshared.Event, error)` signature as a thin wrapper over it (block until the projection reports terminal); migrate `controller.go` and callers to the async API incrementally; delete the wrapper only when no caller needs it. The controller observes terminal outcome via the existing `EventSink` stream + projected turn state, not a blocking return — removing the wedge/liveness-floor/single-turn constraints by construction.
 - **Unify the projection (D):** turn state + messages share one per-session reconciled projection (one `Version` cursor per ADR 0004, `OwnerThreadID` lanes per ADR 0003) — matching t3code's single `sequence` log / traycer's single chat event log.

--- a/packages/agent/daemon/runtime/codex_appserver_adapter.go
+++ b/packages/agent/daemon/runtime/codex_appserver_adapter.go
@@ -11,6 +11,7 @@ import (
 	"sort"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	activityshared "github.com/tutti-os/tutti/packages/agentactivity/daemon/activity/events"
@@ -182,6 +183,19 @@ type codexAppServerActiveTurn struct {
 	// returns (turn fully finalized). Cancel waits on it so it only responds
 	// after the turn has actually stopped.
 	terminated chan struct{}
+	// terminatedOnce closes terminated exactly once regardless of which path
+	// finalizes the turn (settle path or the blocking shell).
+	terminatedOnce sync.Once
+	// emitTerminal delivers the turn's final events through the turn's own
+	// single-shot emission chain (the shell's turnClosed guard dedupes).
+	emitTerminal func([]activityshared.Event)
+	// settleEmits marks turns whose terminal events are produced by the
+	// settle path (notification loop) instead of a parked goroutine
+	// (ADR 0005 C inversion). Guarded by the adapter mutex.
+	settleEmits bool
+	// settleFinalized records that finalizeSettledTurn produced the terminal
+	// events; the blocking shell logs a shadow miss if it ever has to.
+	settleFinalized atomic.Bool
 
 	cancelRequested     bool
 	cancelInterruptSent bool
@@ -1156,6 +1170,108 @@ func (a *CodexAppServerAdapter) ExecAsync(
 	return nil
 }
 
+func (appTurn *codexAppServerActiveTurn) markTerminated() {
+	appTurn.terminatedOnce.Do(func() { close(appTurn.terminated) })
+}
+
+// markTurnSettleEmits flips the turn to settle-path terminal emission just
+// before the provider turn is submitted, under the adapter mutex so the
+// notification loop observes it consistently.
+func (a *CodexAppServerAdapter) markTurnSettleEmits(agentSessionID string, appTurn *codexAppServerActiveTurn) {
+	if a == nil || appTurn == nil {
+		return
+	}
+	a.mu.Lock()
+	appTurn.settleEmits = true
+	a.mu.Unlock()
+}
+
+// finalizeSettledTurn produces the settled turn's terminal events from the
+// notification path, releases the active-turn slot, and signals terminated —
+// terminal production no longer depends on a parked goroutine (ADR 0005 C).
+// Classification mirrors the blocking shell exactly; the shell's turnClosed
+// guard drops any duplicate.
+func (a *CodexAppServerAdapter) finalizeSettledTurn(agentSessionID string, appTurn *codexAppServerActiveTurn, terminal codexAppServerTurnTerminal) {
+	if a == nil || appTurn == nil || appTurn.emitTerminal == nil {
+		return
+	}
+	appTurn.settleFinalized.Store(true)
+	session := appTurn.session
+	turnID := appTurn.turnID
+	if terminal.err != nil {
+		if errors.Is(terminal.err, context.Canceled) ||
+			errors.Is(terminal.err, errPermissionRequestCanceled) ||
+			a.turnForceCanceled(appTurn) ||
+			terminal.phase == codexAppServerTurnPhaseCanceled {
+			terminalEvents := a.pendingRequestFailureEvents(session, turnID, errPermissionRequestCanceled)
+			terminalEvents = append(terminalEvents, appTurn.normalizer.FinishInterrupted(session, turnID, "interrupted")...)
+			terminalEvents = append(terminalEvents, newTurnActivityEvent(session, EventTurnCanceled, turnID, SessionStatusCanceled, "", "", map[string]any{
+				"error": terminal.err.Error(),
+			}))
+			appTurn.emitTerminal(terminalEvents)
+		} else {
+			terminalEvents := appTurn.normalizer.FinishFailed(session, turnID)
+			terminalEvents = append(terminalEvents, newTurnActivityEvent(session, EventTurnFailed, turnID, SessionStatusFailed, "", "", acpFailureMetadata(terminal.err)))
+			appTurn.emitTerminal(terminalEvents)
+		}
+	} else {
+		appTurn.normalizer.ApplyAssistantFinalText(appServerTurnFinalAssistantText(terminal.turn))
+		appTurn.emitTerminal(appServerTurnTerminalEvents(session, turnID, terminal.turn, appTurn.normalizer))
+	}
+	a.endActiveTurn(agentSessionID, appTurn)
+	appTurn.markTerminated()
+}
+
+// settleTurnExternal settles THIS turn (pointer match) from an external
+// death signal — context cancellation or client death — as a first-class
+// machine transition instead of a parked-goroutine select arm.
+func (a *CodexAppServerAdapter) settleTurnExternal(agentSessionID string, appTurn *codexAppServerActiveTurn, terminal codexAppServerTurnTerminal) {
+	if a == nil || appTurn == nil {
+		return
+	}
+	a.mu.Lock()
+	appSession := a.sessions[strings.TrimSpace(agentSessionID)]
+	settled := false
+	if appSession != nil && appSession.activeTurn == appTurn && !appTurn.phase.terminal() {
+		appTurn.phase = terminal.phase
+		appSession.activeTurnID = ""
+		settled = true
+	}
+	emits := settled && appTurn.settleEmits
+	a.mu.Unlock()
+	if !settled {
+		return
+	}
+	select {
+	case appTurn.terminal <- terminal:
+	default:
+	}
+	if emits {
+		a.finalizeSettledTurn(agentSessionID, appTurn, terminal)
+	}
+}
+
+// watchTurnExternalTermination translates external death signals (context
+// cancellation, client death) into turn-machine transitions. It exits as
+// soon as the turn terminates through any path.
+func (a *CodexAppServerAdapter) watchTurnExternalTermination(appSession *codexAppServerSession, appTurn *codexAppServerActiveTurn) {
+	select {
+	case <-appTurn.terminated:
+	case <-appTurn.ctx.Done():
+		a.settleTurnExternal(appTurn.session.AgentSessionID, appTurn, codexAppServerTurnTerminal{
+			err: appTurn.ctx.Err(), phase: codexAppServerTurnPhaseCanceled,
+		})
+	case <-appSession.client.Done():
+		err := appSession.client.Err()
+		if err == nil {
+			err = ErrSessionDisconnected
+		}
+		a.settleTurnExternal(appTurn.session.AgentSessionID, appTurn, codexAppServerTurnTerminal{
+			err: err, phase: codexAppServerTurnPhaseFailed,
+		})
+	}
+}
+
 func (a *CodexAppServerAdapter) execBlocking(
 	ctx context.Context,
 	session Session,
@@ -1242,9 +1358,11 @@ func (a *CodexAppServerAdapter) execBlocking(
 		terminal:     make(chan codexAppServerTurnTerminal, 1),
 		terminated:   make(chan struct{}),
 	}
+	appTurn.emitTerminal = emitTerminal
 	// Signal turn termination once this goroutine returns (after terminal events
 	// are emitted), so a concurrent Cancel only responds after the turn stopped.
-	defer close(appTurn.terminated)
+	// The settle path may finalize first; the Once keeps the close single.
+	defer appTurn.markTerminated()
 	if !a.beginActiveTurn(session.AgentSessionID, appTurn) {
 		return nil, ErrSessionActiveTurn
 	}
@@ -1253,6 +1371,10 @@ func (a *CodexAppServerAdapter) execBlocking(
 	if handled, err := a.execSlashCommand(ctx, appSession, session, visibleText, turnID, appTurn, normalizer, emitEvents, emitTerminal, emitCommands); handled {
 		return snapshotEvents(), err
 	}
+
+	// From here on the settle path (notification loop) owns terminal event
+	// production; the blocking shell below only waits and returns.
+	a.markTurnSettleEmits(session.AgentSessionID, appTurn)
 
 	trace := newCodexAppServerTurnTrace(session, turnID, execMetadataFromContext(ctx))
 	turnParams := appServerTurnStartParams(session, appSession.threadID, content, appSession.planModeMask, appSession.defaultModeMask, appSession.defaultModel)
@@ -1299,8 +1421,26 @@ func (a *CodexAppServerAdapter) execBlocking(
 			a.interruptActiveTurnAsync(appSession, session, appTurn, providerTurnID, "queued cancel")
 		}
 	}
+	go a.watchTurnExternalTermination(appSession, appTurn)
 	finalTurn, finishErr := a.awaitTurnCompletion(ctx, appSession, appTurn, initialTurn)
+	// The settle path finalizes AFTER delivering the terminal channel value:
+	// wait for terminated (closed at the end of finalize) so the snapshot
+	// includes the terminal events. The timeout is a safety net for any
+	// settle hole; the shell classification below then covers it.
+	select {
+	case <-appTurn.terminated:
+	case <-time.After(2 * time.Second):
+	}
 	a.endActiveTurn(session.AgentSessionID, appTurn)
+	if appTurn.settleFinalized.Load() {
+		// The settle path already produced the terminal events.
+		return snapshotEvents(), nil
+	}
+	slog.Warn(
+		"agent session app-server turn terminal produced by blocking shell (settle shadow miss)",
+		"agent_session_id", session.AgentSessionID,
+		"turn_id", turnID,
+	)
 	if finishErr != nil {
 		if errors.Is(finishErr, context.Canceled) || errors.Is(finishErr, errPermissionRequestCanceled) || a.turnForceCanceled(appTurn) {
 			terminalEvents := a.pendingRequestFailureEvents(session, turnID, errPermissionRequestCanceled)
@@ -1905,11 +2045,19 @@ func (a *CodexAppServerAdapter) markTurnForceCanceled(turn *codexAppServerActive
 	}
 	a.mu.Lock()
 	turn.forceCanceled = true
+	agentSessionID := turn.session.AgentSessionID
+	emits := turn.settleEmits && !turn.phase.terminal()
 	turn.phase = codexAppServerTurnPhaseCanceled
 	a.mu.Unlock()
+	terminal := codexAppServerTurnTerminal{err: errPermissionRequestCanceled, phase: codexAppServerTurnPhaseCanceled}
 	select {
-	case turn.terminal <- codexAppServerTurnTerminal{err: errPermissionRequestCanceled, phase: codexAppServerTurnPhaseCanceled}:
+	case turn.terminal <- terminal:
 	default:
+	}
+	// Force-cancel is a first-class terminal transition: finalize from here
+	// so terminal events do not depend on the (possibly wedged) shell.
+	if emits {
+		a.finalizeSettledTurn(agentSessionID, turn, terminal)
 	}
 }
 

--- a/packages/agent/daemon/runtime/codex_appserver_adapter_test.go
+++ b/packages/agent/daemon/runtime/codex_appserver_adapter_test.go
@@ -1457,6 +1457,83 @@ func TestCodexAppServerAdapterFetchesChildThreadNickname(t *testing.T) {
 	})
 }
 
+// Pins the terminal contract the settle-path inversion must preserve: a
+// normal turn emits exactly one turn-outcome event, delivered through the
+// emit sink before Exec returns.
+func TestCodexAppServerAdapterEmitsExactlyOneTurnOutcome(t *testing.T) {
+	t.Parallel()
+
+	adapter, _, session := startedAppServerAdapter(t)
+	var mu sync.Mutex
+	var streamed []activityshared.Event
+	events, err := adapter.Exec(context.Background(), session, []PromptContentBlock{{
+		Type: "text",
+		Text: "inspect the repo",
+	}}, "", "turn-local-1", func(next []activityshared.Event) {
+		mu.Lock()
+		defer mu.Unlock()
+		streamed = append(streamed, next...)
+	}, nil)
+	if err != nil {
+		t.Fatalf("Exec: %v", err)
+	}
+	countOutcomes := func(list []activityshared.Event) int {
+		count := 0
+		for _, event := range list {
+			switch string(event.Type) {
+			case string(activityshared.EventTurnCompleted), string(activityshared.EventTurnFailed), EventTurnCanceled:
+				count++
+			}
+		}
+		return count
+	}
+	if got := countOutcomes(events); got != 1 {
+		t.Fatalf("returned turn outcome events = %d, want exactly 1", got)
+	}
+	mu.Lock()
+	defer mu.Unlock()
+	if got := countOutcomes(streamed); got != 1 {
+		t.Fatalf("streamed turn outcome events = %d, want exactly 1", got)
+	}
+}
+
+// Pins the client-death terminal transition: when the app-server connection
+// dies mid-turn, the turn settles as failed instead of hanging.
+func TestCodexAppServerAdapterClientDeathSettlesTurn(t *testing.T) {
+	t.Parallel()
+
+	adapter, transport, session := startedAppServerAdapter(t)
+	transport.conn.holdTurn = true
+
+	execDone := make(chan []activityshared.Event, 1)
+	go func() {
+		events, _ := adapter.Exec(context.Background(), session, []PromptContentBlock{{
+			Type: "text", Text: "long task",
+		}}, "", "turn-local-1", nil, nil)
+		execDone <- events
+	}()
+	waitForCondition(t, func() bool {
+		return adapter.sessionActiveTurnID(session.AgentSessionID) == "turn-1"
+	})
+
+	_ = transport.conn.Close()
+
+	select {
+	case events := <-execDone:
+		outcomes := 0
+		for _, event := range events {
+			if event.Type == activityshared.EventTurnFailed {
+				outcomes++
+			}
+		}
+		if outcomes != 1 {
+			t.Fatalf("turn outcome after client death = %#v, want one EventTurnFailed", events)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatalf("Exec did not settle after client death")
+	}
+}
+
 func TestCodexAppServerAdapterCancelInterruptsLinkedChildThreads(t *testing.T) {
 	t.Parallel()
 

--- a/packages/agent/daemon/runtime/codex_appserver_turn_machine.go
+++ b/packages/agent/daemon/runtime/codex_appserver_turn_machine.go
@@ -108,6 +108,7 @@ func (a *CodexAppServerAdapter) settleActiveTurn(
 			activeTurn = nil
 		}
 	}
+	emits := activeTurn != nil && activeTurn.settleEmits
 	a.mu.Unlock()
 	if activeTurn == nil {
 		return
@@ -115,6 +116,9 @@ func (a *CodexAppServerAdapter) settleActiveTurn(
 	select {
 	case activeTurn.terminal <- terminal:
 	default:
+	}
+	if emits {
+		a.finalizeSettledTurn(agentSessionID, activeTurn, terminal)
 	}
 }
 

--- a/packages/agent/daemon/runtime/controller.go
+++ b/packages/agent/daemon/runtime/controller.go
@@ -1279,8 +1279,49 @@ func (c *Controller) Cancel(ctx context.Context, input CancelInput) (CancelResul
 	)
 	active, ok := c.activeTurn(session.RoomID, session.AgentSessionID)
 	if !ok {
-		slog.Info("agent session cancel skipped because no active turn exists",
-			"event", "agent_session.cancel.no_active_turn",
+		// No controller turn record - but the runtime may own cancellable
+		// work the registry does not know about (linked child agents that
+		// outlive their parent turn, or a desynced turn record). Reconcile
+		// with the adapter instead of skipping: the turn machine answers
+		// no-op cancels safely, and anything it actually stopped surfaces
+		// as events.
+		events, err := adapter.Cancel(ctx, session, reason)
+		if err != nil && errors.Is(err, ErrSessionNoActiveTurn) {
+			// The adapter's way of answering "nothing was running" - the
+			// reconcile found no runtime work either.
+			err = nil
+		}
+		if err != nil {
+			slog.Warn("agent session cancel adapter failed without active turn",
+				"event", "agent_session.cancel.reconcile_failed",
+				"room_id", session.RoomID,
+				"agent_session_id", session.AgentSessionID,
+				"provider", session.Provider,
+				"reason", reason,
+				"error", err.Error(),
+			)
+			return CancelResult{}, err
+		}
+		if len(events) > 0 {
+			session = applySessionEvents(session, events)
+			if shouldAdvanceSessionUpdatedAtFromEvents(events) {
+				session.UpdatedAtUnixMS = unixMS(now())
+			}
+			c.store(session)
+			c.publish(session, events)
+			c.enqueueSessionReport(ctx, session, events)
+			slog.Info("agent session cancel reconciled runtime work without a turn record",
+				"event", "agent_session.cancel.reconciled",
+				"room_id", session.RoomID,
+				"agent_session_id", session.AgentSessionID,
+				"provider", session.Provider,
+				"reason", reason,
+				"event_count", len(events),
+			)
+			return CancelResult{AgentSessionID: session.AgentSessionID, Canceled: true}, nil
+		}
+		slog.Info("agent session cancel found nothing to stop",
+			"event", "agent_session.cancel.nothing_to_stop",
 			"room_id", session.RoomID,
 			"agent_session_id", session.AgentSessionID,
 			"provider", session.Provider,

--- a/packages/agent/daemon/runtime/controller_test.go
+++ b/packages/agent/daemon/runtime/controller_test.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -2207,6 +2208,104 @@ func (a *asyncExecTestAdapter) calls() (bool, bool) {
 // prompt is steered into an already-running provider turn, so ExecAsync emits
 // only the steered user message for the new turn id and no terminal event ever
 // arrives for it.
+// The runtime can own cancellable work the controller's turn registry does
+// not know about - linked child agents outliving their parent turn, or a
+// desynced turn record. Cancel must reconcile with the adapter instead of
+// skipping ("cancel skipped because no active turn exists" band-aid).
+func TestControllerCancelWithoutTurnRecordReconcilesWithAdapter(t *testing.T) {
+	t.Parallel()
+
+	adapter := &cancelReconcileAdapter{}
+	controller := NewController([]Adapter{adapter}, nil)
+	started, err := controller.Start(context.Background(), StartInput{
+		RoomID:         "room-1",
+		AgentSessionID: "agent-session-1",
+		Provider:       ProviderCodex,
+		Title:          "Test",
+	})
+	if err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+
+	// No Exec ran: the controller holds no turn record, but the adapter still
+	// has running children to stop.
+	result, err := controller.Cancel(context.Background(), CancelInput{
+		RoomID:         "room-1",
+		AgentSessionID: started.Session.AgentSessionID,
+		Reason:         "user requested",
+	})
+	if err != nil {
+		t.Fatalf("Cancel: %v", err)
+	}
+	if adapter.cancelCalls.Load() != 1 {
+		t.Fatalf("adapter cancel calls = %d, want 1 (reconcile must reach the adapter)", adapter.cancelCalls.Load())
+	}
+	if !result.Canceled {
+		t.Fatalf("result = %#v, want Canceled=true when the adapter stopped work", result)
+	}
+}
+
+// When neither the controller nor the adapter has anything to cancel, the
+// reconciled path still answers calmly.
+func TestControllerCancelWithoutAnyWorkReturnsNotCanceled(t *testing.T) {
+	t.Parallel()
+
+	adapter := &cancelReconcileAdapter{empty: true}
+	controller := NewController([]Adapter{adapter}, nil)
+	started, err := controller.Start(context.Background(), StartInput{
+		RoomID:         "room-1",
+		AgentSessionID: "agent-session-1",
+		Provider:       ProviderCodex,
+		Title:          "Test",
+	})
+	if err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	result, err := controller.Cancel(context.Background(), CancelInput{
+		RoomID:         "room-1",
+		AgentSessionID: started.Session.AgentSessionID,
+	})
+	if err != nil {
+		t.Fatalf("Cancel: %v", err)
+	}
+	if adapter.cancelCalls.Load() != 1 {
+		t.Fatalf("adapter cancel calls = %d, want 1", adapter.cancelCalls.Load())
+	}
+	if result.Canceled {
+		t.Fatalf("result = %#v, want Canceled=false when nothing was running", result)
+	}
+}
+
+type cancelReconcileAdapter struct {
+	cancelCalls atomic.Int64
+	empty       bool
+}
+
+func (*cancelReconcileAdapter) Provider() string { return ProviderCodex }
+
+func (*cancelReconcileAdapter) Start(context.Context, Session) ([]activityshared.Event, error) {
+	return nil, nil
+}
+
+func (*cancelReconcileAdapter) Resume(context.Context, Session) error { return nil }
+
+func (*cancelReconcileAdapter) Close(context.Context, Session) error { return nil }
+
+func (*cancelReconcileAdapter) Exec(context.Context, Session, []PromptContentBlock, string, string, EventSink, CommandSnapshotSink) ([]activityshared.Event, error) {
+	return nil, nil
+}
+
+func (a *cancelReconcileAdapter) Cancel(_ context.Context, session Session, _ string) ([]activityshared.Event, error) {
+	a.cancelCalls.Add(1)
+	if a.empty {
+		return nil, nil
+	}
+	// Shape produced by interruptLinkedChildThreads: canceled child markers.
+	return []activityshared.Event{
+		appServerSubAgentLifecycleEvent(session, "child-thread-1", "turn-1", "canceled", "user requested"),
+	}, nil
+}
+
 type steeringAsyncExecAdapter struct {
 	execDone chan struct{}
 }


### PR DESCRIPTION
Phase 1 of the codex app-server refactor finish (stacked on #638 / Phase 0; retarget to `main` after #638 merges).

## What

Completes design-doc **Step 7** per **ADR 0005 C+D** — async submit/observe becomes the true core; the blocking shell is a thin wait; the controller cancel band-aid is retired.

- **S1 — settle path owns turn terminal event production** (`2bb62315`): turn outcome events are produced by the settle sequence itself from all three exits — protocol settle, force-cancel, and a per-turn external-death watcher (ctx cancel / client death become machine transitions). The blocking `Exec` shell no longer classifies; it waits on the turn's `terminated` signal and snapshots. A dedupe-guarded shadow classification stays in the shell behind a 2s safety net with `slog.Warn` telemetry on any miss (strangler reversibility until Phase 2 proves the async path end-to-end).
- **S4 — controller cancel no-active-turn band-aid retired** (`b3043e85`): `Controller.Cancel` no longer skips with "cancel skipped because no active turn exists". It reconciles with the adapter: always calls `adapter.Cancel`, publishes returned events (e.g. linked child agents outliving a completed parent turn), answers `Canceled=true` iff work was actually stopped, and maps the adapter's `ErrSessionNoActiveTurn` to a calm "nothing to stop" result.
- **Docs** (`c9f37dd8`): Step 7 marked done in the design doc; ADR 0005 gains an "Implementation outcome" section.

## Deviations from the migration plan (recorded in ADR 0005)

- **Caller migration was already done**: `runAsyncExecTurn` is purely event-driven; blocking `adapter.Exec` serves only non-async adapters — so the inversion was adapter-internal.
- **S2 (submit/wait API split) skipped**: after S1 the parked Exec goroutine only idles; splitting the API would churn the surface with no behavioral gain. The essence of C (terminal truth owned by the settle path, not the blocking await) is achieved.
- **S3 (session-lifecycle ownership) doc-only**: the boundary was already correct — adapter owns live-session semantics + the `ErrLiveSessionBusy` veto, controller owns scheduling + idle-recycle policy.
- **Blocking shell retained** until Phase 2 (Step 9 desktop rewrite) lands, per the conservative default.

## Tests

- New pins: `TestCodexAppServerAdapterEmitsExactlyOneTurnOutcome`, `TestCodexAppServerAdapterClientDeathSettlesTurn`, `TestControllerCancelWithoutTurnRecordReconcilesWithAdapter`, `TestControllerCancelWithoutAnyWorkReturnsNotCanceled` (TDD red-first).
- Step-0 corpus (15) + Phase-0 expansion (18 runtime + 3 activity) green; full `packages/agent/daemon` module green; `-race` green for app-server code.
- Observation, out of scope: a pre-existing flaky data race in `standard_acp_adapter.go`/`acp_turn_normalizer.go` (files untouched by this branch, inherited from main) surfaced intermittently under `-race`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)