### PR TITLE
refactor(agent-gui): expose message center primitives

### DIFF
--- a/packages/agent/gui/agent-message-center/WorkspaceAgentMessageCenterAttentionDeck.tsx
+++ b/packages/agent/gui/agent-message-center/WorkspaceAgentMessageCenterAttentionDeck.tsx
@@ -1,4 +1,11 @@
-import { useEffect, useMemo, useRef, useState, type JSX } from "react";
+import {
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type JSX,
+  type ReactNode
+} from "react";
 import { cn } from "@tutti-os/ui-system";
 import { useTranslation } from "../i18n/index";
 import type { WorkspaceLinkAction } from "../actions/workspaceLinkActions";
@@ -14,6 +21,9 @@ export interface WorkspaceAgentMessageCenterAttentionDeckProps {
   highlightedItemId?: string | null;
   submittingPromptKey: string | null;
   registerNode?: (itemId: string, node: HTMLElement | null) => void;
+  renderCard?: (
+    input: WorkspaceAgentMessageCenterAttentionDeckRenderCardInput
+  ) => ReactNode;
   onLinkAction?: (action: WorkspaceLinkAction) => void;
   onOpenChat: (input: { agentSessionId: string; provider: string }) => void;
   onSubmitPrompt: (
@@ -27,11 +37,26 @@ export interface WorkspaceAgentMessageCenterAttentionDeckProps {
   ) => void;
 }
 
+export interface WorkspaceAgentMessageCenterAttentionDeckRenderCardInput {
+  cardRef?: (node: HTMLElement | null) => void;
+  highlighted: boolean;
+  interactive: boolean;
+  isSubmitting: boolean;
+  item: WorkspaceAgentMessageCenterItem;
+  onSubmitPrompt: (input: {
+    action?: string;
+    optionId?: string;
+    payload?: Record<string, unknown>;
+    requestId: string;
+  }) => void;
+}
+
 export function WorkspaceAgentMessageCenterAttentionDeck({
   items,
   highlightedItemId = null,
   submittingPromptKey,
   registerNode,
+  renderCard,
   onLinkAction,
   onOpenChat,
   onSubmitPrompt
@@ -152,13 +177,23 @@ export function WorkspaceAgentMessageCenterAttentionDeck({
               }
             }}
           >
-            <WorkspaceAgentMessageCenterCard
-              interactive={false}
-              isSubmitting={false}
-              item={leavingItem}
-              onOpenChat={onOpenChat}
-              onSubmitPrompt={() => {}}
-            />
+            {renderCard ? (
+              renderCard({
+                highlighted: false,
+                interactive: false,
+                isSubmitting: false,
+                item: leavingItem,
+                onSubmitPrompt: () => {}
+              })
+            ) : (
+              <WorkspaceAgentMessageCenterCard
+                interactive={false}
+                isSubmitting={false}
+                item={leavingItem}
+                onOpenChat={onOpenChat}
+                onSubmitPrompt={() => {}}
+              />
+            )}
           </div>
         ) : null}
         <div
@@ -171,20 +206,33 @@ export function WorkspaceAgentMessageCenterAttentionDeck({
                   "shadow-[0_7px_0_-4px_var(--background-fronted),0_7px_0_-3px_var(--line-2)]"
           )}
         >
-          <WorkspaceAgentMessageCenterCard
-            cardRef={
-              registerNode
+          {renderCard ? (
+            renderCard({
+              cardRef: registerNode
                 ? (node) => registerNode(topItem.id, node)
-                : undefined
-            }
-            highlighted={topItem.id === highlightedItemId}
-            interactive
-            isSubmitting={topIsSubmitting || isTopCoolingDown}
-            item={topItem}
-            onLinkAction={onLinkAction}
-            onOpenChat={onOpenChat}
-            onSubmitPrompt={(input) => onSubmitPrompt(topItem, input)}
-          />
+                : undefined,
+              highlighted: topItem.id === highlightedItemId,
+              interactive: true,
+              isSubmitting: topIsSubmitting || isTopCoolingDown,
+              item: topItem,
+              onSubmitPrompt: (input) => onSubmitPrompt(topItem, input)
+            })
+          ) : (
+            <WorkspaceAgentMessageCenterCard
+              cardRef={
+                registerNode
+                  ? (node) => registerNode(topItem.id, node)
+                  : undefined
+              }
+              highlighted={topItem.id === highlightedItemId}
+              interactive
+              isSubmitting={topIsSubmitting || isTopCoolingDown}
+              item={topItem}
+              onLinkAction={onLinkAction}
+              onOpenChat={onOpenChat}
+              onSubmitPrompt={(input) => onSubmitPrompt(topItem, input)}
+            />
+          )}
         </div>
       </div>
     </section>

--- a/packages/agent/gui/agent-message-center/WorkspaceAgentMessageCenterCard.tsx
+++ b/packages/agent/gui/agent-message-center/WorkspaceAgentMessageCenterCard.tsx
@@ -53,10 +53,14 @@ import { formatAgentGuiConversationPlainTitle } from "../workbench/sessionTitle"
 export interface WorkspaceAgentMessageCenterCardProps {
   item: WorkspaceAgentMessageCenterItem;
   cardRef?: (node: HTMLElement | null) => void;
+  actionsAccessory?: ReactNode;
+  footerAccessory?: ReactNode;
+  headerAccessory?: ReactNode;
   highlighted?: boolean;
   interactive?: boolean;
   isSubmitting: boolean;
   lazySummary?: boolean;
+  summaryAccessory?: ReactNode;
   onLinkAction?: (action: WorkspaceLinkAction) => void;
   onOpenChat: (input: { agentSessionId: string; provider: string }) => void;
   onSubmitPrompt: (input: {
@@ -90,11 +94,15 @@ function stopMessageCenterTextPointerPropagation(
 export const WorkspaceAgentMessageCenterCard = memo(
   function WorkspaceAgentMessageCenterCard({
     cardRef,
+    actionsAccessory,
+    footerAccessory,
+    headerAccessory,
     highlighted = false,
     interactive = true,
     item,
     isSubmitting,
     lazySummary = false,
+    summaryAccessory,
     onLinkAction,
     onOpenChat,
     onSubmitPrompt
@@ -143,23 +151,26 @@ export const WorkspaceAgentMessageCenterCard = memo(
             </LazyMessageCenterTooltip>
             {item.cwd ? <ProjectPathInfo path={item.cwd} /> : null}
           </div>
-          <span
-            className={cn(
-              "workspace-agent-message-center__status inline-flex shrink-0 items-center gap-1.5 text-[11px] font-semibold leading-4",
-              messageCenterStatusToneClass(statusTone)
-            )}
-            data-status={displayStatus}
-            title={statusLabel}
-          >
-            <StatusDot
-              tone={statusTone}
-              pulse={
-                isWaitingMessageCenterItem(item) || item.status === "working"
-              }
-              size="sm"
+          <span className="flex shrink-0 items-center gap-2">
+            {headerAccessory}
+            <span
+              className={cn(
+                "workspace-agent-message-center__status inline-flex shrink-0 items-center gap-1.5 text-[11px] font-semibold leading-4",
+                messageCenterStatusToneClass(statusTone)
+              )}
+              data-status={displayStatus}
               title={statusLabel}
-            />
-            <span>{statusLabel}</span>
+            >
+              <StatusDot
+                tone={statusTone}
+                pulse={
+                  isWaitingMessageCenterItem(item) || item.status === "working"
+                }
+                size="sm"
+                title={statusLabel}
+              />
+              <span>{statusLabel}</span>
+            </span>
           </span>
         </div>
 
@@ -172,6 +183,8 @@ export const WorkspaceAgentMessageCenterCard = memo(
             emptyLabel={t("agentHost.workspaceAgentMessageCenterNoSummary")}
           />
         ) : null}
+
+        {summaryAccessory}
 
         {prompt && interactive ? (
           <div className="min-w-0">
@@ -190,7 +203,10 @@ export const WorkspaceAgentMessageCenterCard = memo(
           </div>
         ) : null}
 
+        {footerAccessory}
+
         <MessageCenterOpenChatButton
+          actionsAccessory={actionsAccessory}
           provider={item.provider}
           item={item}
           label={t("agentHost.workspaceAgentMessageCenterOpenChat")}
@@ -781,7 +797,7 @@ function isGenericApprovalSummary(summary: string): boolean {
   return normalized === "approval";
 }
 
-function MessageCenterSummary({
+export function MessageCenterSummary({
   emptyLabel,
   item,
   lazy,
@@ -967,13 +983,15 @@ function useDeferredMessageCenterSummaryMeasureReady(
   return ready;
 }
 
-function MessageCenterOpenChatButton({
+export function MessageCenterOpenChatButton({
+  actionsAccessory,
   alwaysVisible = false,
   item,
   label,
   onOpenChat,
   provider
 }: {
+  actionsAccessory?: ReactNode;
   alwaysVisible?: boolean;
   item: WorkspaceAgentMessageCenterItem;
   label: string;
@@ -988,29 +1006,32 @@ function MessageCenterOpenChatButton({
         identity={item.identity}
         provider={provider}
       />
-      <Button
-        type="button"
-        variant="ghost"
-        size="default"
-        className={cn(
-          "workspace-agent-message-center__open-chat-button h-auto gap-1.5 border-0 bg-transparent p-0 text-[var(--accent-codex)] shadow-none transition-[color,opacity,visibility] hover:bg-transparent hover:text-[var(--accent-codex)] focus-visible:bg-transparent focus-visible:text-[var(--accent-codex)] active:bg-transparent",
-          !alwaysVisible &&
-            "invisible opacity-0 group-hover/message-card:visible group-hover/message-card:opacity-100 group-focus-within/message-card:visible group-focus-within/message-card:opacity-100"
-        )}
-        onClick={() =>
-          onOpenChat({
-            agentSessionId: item.agentSessionId,
-            provider: item.provider
-          })
-        }
-      >
-        <ExternalLink
-          className="size-[15px]"
-          strokeWidth={2.2}
-          aria-hidden="true"
-        />
-        {label}
-      </Button>
+      <span className="inline-flex shrink-0 items-center gap-2">
+        {actionsAccessory}
+        <Button
+          type="button"
+          variant="ghost"
+          size="default"
+          className={cn(
+            "workspace-agent-message-center__open-chat-button h-auto gap-1.5 border-0 bg-transparent p-0 text-[var(--accent-codex)] shadow-none transition-[color,opacity,visibility] hover:bg-transparent hover:text-[var(--accent-codex)] focus-visible:bg-transparent focus-visible:text-[var(--accent-codex)] active:bg-transparent",
+            !alwaysVisible &&
+              "invisible opacity-0 group-hover/message-card:visible group-hover/message-card:opacity-100 group-focus-within/message-card:visible group-focus-within/message-card:opacity-100"
+          )}
+          onClick={() =>
+            onOpenChat({
+              agentSessionId: item.agentSessionId,
+              provider: item.provider
+            })
+          }
+        >
+          <ExternalLink
+            className="size-[15px]"
+            strokeWidth={2.2}
+            aria-hidden="true"
+          />
+          {label}
+        </Button>
+      </span>
     </div>
   );
 }
@@ -1267,7 +1288,7 @@ export type MessageCenterStatusTone =
   | "neutral"
   | "red";
 
-function messageCenterStatusTone(
+export function messageCenterStatusTone(
   item: WorkspaceAgentMessageCenterItem
 ): MessageCenterStatusTone {
   if (isWaitingMessageCenterItem(item)) {

--- a/packages/agent/gui/agent-message-center/WorkspaceAgentMessageCenterPanel.tsx
+++ b/packages/agent/gui/agent-message-center/WorkspaceAgentMessageCenterPanel.tsx
@@ -704,7 +704,7 @@ const MessageCenterRenderedCard = memo(function MessageCenterRenderedCard({
   );
 });
 
-function MessageCenterGroupHeading({
+export function MessageCenterGroupHeading({
   group
 }: {
   group: ReturnType<typeof groupMessageCenterItems>[number];

--- a/packages/agent/gui/agent-message-center/index.ts
+++ b/packages/agent/gui/agent-message-center/index.ts
@@ -1,8 +1,25 @@
-export { WorkspaceAgentMessageCenterPanel } from "./WorkspaceAgentMessageCenterPanel";
+export {
+  MessageCenterGroupHeading,
+  WorkspaceAgentMessageCenterPanel
+} from "./WorkspaceAgentMessageCenterPanel";
 export {
   buildWorkspaceAgentInteractivePromptLabels,
-  WorkspaceAgentMessageCenterCard
+  MessageCenterIdentityAvatarMark,
+  MessageCenterIdentityAvatarStack,
+  MessageCenterIdentityLabel,
+  MessageCenterOpenChatButton,
+  MessageCenterSummary,
+  messageCenterStatusTone,
+  messageCenterStatusToneClass,
+  messageCenterStackPreviewNodes,
+  messageCenterStackPreviewText,
+  resolveMessageCenterNotificationAction,
+  WorkspaceAgentMessageCenterCard,
+  WorkspaceAgentMessageCenterStack
 } from "./WorkspaceAgentMessageCenterCard";
+export { WorkspaceAgentMessageCenterAttentionDeck } from "./WorkspaceAgentMessageCenterAttentionDeck";
+export { MessageCenterViewMenu as WorkspaceAgentMessageCenterViewMenu } from "./WorkspaceAgentMessageCenterViewControls";
+export { AgentVerticalScrollArea } from "../shared/AgentVerticalScrollArea";
 export { AgentInteractivePromptSurface } from "../shared/agentConversation/components/AgentInteractivePromptSurface";
 export { managedAgentRoundedIconUrl } from "../shared/managedAgentIcons";
 export { userAvatarPlaceholderUrl } from "../shared/userAvatarPlaceholder";
@@ -18,12 +35,41 @@ export {
 } from "../shared/agentConversation/planImplementation";
 export type { PromptToolDetail } from "../shared/agentConversation/promptToolDetails";
 export type { WorkspaceAgentMessageCenterPanelProps } from "./WorkspaceAgentMessageCenterPanel";
-export type { WorkspaceAgentMessageCenterCardProps } from "./WorkspaceAgentMessageCenterCard";
+export type {
+  MessageCenterStatusTone,
+  WorkspaceAgentMessageCenterCardProps
+} from "./WorkspaceAgentMessageCenterCard";
+export type {
+  WorkspaceAgentMessageCenterAttentionDeckProps,
+  WorkspaceAgentMessageCenterAttentionDeckRenderCardInput
+} from "./WorkspaceAgentMessageCenterAttentionDeck";
 export {
   buildWorkspaceAgentMessageCenterModel,
-  isWaitingMessageCenterItem
+  isInteractiveMessageCenterItem,
+  isWaitingMessageCenterItem,
+  selectMessageCenterAttentionDeckItems
 } from "./workspaceAgentMessageCenterModel";
 export { stabilizeWorkspaceAgentMessageCenterModel } from "./workspaceAgentMessageCenterModelStability";
+export {
+  buildMessageCenterProviderOptions,
+  buildMessageCenterStatusOptions,
+  groupMessageCenterItems,
+  isRecentlyCompletedMessageCenterItem,
+  itemMatchesViewFilters,
+  messageCenterAgentUserStackId,
+  messageCenterGroupLabel,
+  messageCenterStackRenderId,
+  messageCenterStackScrollSyncSegment,
+  messageCenterStatusFilterValue,
+  partitionMessageCenterItemsByAgentUser,
+  statusFilterSummary
+} from "./workspaceAgentMessageCenterViewModel";
+export {
+  messageCenterFiltersStorageKey,
+  readMessageCenterFilterPreferences,
+  writeMessageCenterFilterPreferences
+} from "./messageCenterFilterPreferences";
+export type { MessageCenterFilterPreferences } from "./messageCenterFilterPreferences";
 export type {
   WorkspaceAgentMessageCenterDigest,
   WorkspaceAgentMessageCenterDigestPrimary,
@@ -36,3 +82,12 @@ export type {
   WorkspaceAgentMessageCenterItem,
   WorkspaceAgentMessageCenterModel
 } from "./workspaceAgentMessageCenterModel";
+export type {
+  MessageCenterAgentUserStack,
+  MessageCenterGroup,
+  MessageCenterGroupBy,
+  MessageCenterProviderOption,
+  MessageCenterStatusFilter,
+  MessageCenterStatusOption,
+  MessageCenterTranslate
+} from "./workspaceAgentMessageCenterViewModel";


### PR DESCRIPTION
## Summary
- expose message center primitive components and view-model helpers from @tutti-os/agent-gui/agent-message-center
- add non-breaking card accessory slots for host-specific extensions
- allow the attention deck to accept a host-provided card renderer while preserving the default renderer

## Verification
- pnpm --dir packages/agent/gui typecheck
- pnpm --dir packages/agent/gui exec vitest run --environment jsdom agent-message-center (fails existing model expectation: workspaceAgentMessageCenterModel.spec.ts expects failed status but current model returns working)
- local pre-push full check was bypassed after unrelated Go failure in services/tuttid/service/agentstatus: TestServiceListReportsCodexChecksVersionAndLastError expected Codex CLI version 0.100.0 but got empty string

## Risk
- Public API expansion only; existing WorkspaceAgentMessageCenterPanel behavior remains compatible.
