### PR TITLE
fix(agent-gui): align app reference mention colors

### DIFF
--- a/packages/agent/gui/agent-gui/agentGuiNode/AgentFileMentionPalette.spec.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/AgentFileMentionPalette.spec.tsx
@@ -2033,14 +2033,14 @@ describe("AgentFileMentionPalette", () => {
       /\[data-agent-file-mention="true"\]\[data-agent-mention-kind="file"\]\.tsh-agent-object-token--file\s*{[^}]*color:\s*var\(--folder\)/s
     );
     expect(css).toMatch(
-      /\[data-agent-mention-kind="workspace-app"\]\.tsh-agent-object-token--entity\s*{[^}]*color:\s*var\(--tutti-purple\)/s
+      /\[data-agent-mention-kind="workspace-app"\]\.tsh-agent-object-token--entity,\s*\[data-agent-mention-kind="workspace-reference"\]\[data-agent-reference-source="app"\]\.tsh-agent-object-token--entity\s*{[^}]*color:\s*var\(--agent-gui-mention-app-color,\s*var\(--tutti-purple\)\)/s
     );
     expect(css).toMatch(
       /\.workspace-agents-status-panel__activity-summary\s+\.workspace-agents-status-panel__detail-markdown\s+a,[\s\S]*?\.workspace-agents-status-panel__detail-markdown\s+code\s+a\s*{[^}]*color:\s*var\(--tutti-purple\)/s
     );
   });
 
-  it("uses accent blue for editable workspace app mentions", () => {
+  it("uses the Agent GUI app mention color for editable workspace app mentions", () => {
     const nodeViewSource = readFileSync(
       resolve("agent-gui/agentGuiNode/agentRichText/AgentMentionNodeView.tsx"),
       "utf8"
@@ -2048,10 +2048,16 @@ describe("AgentFileMentionPalette", () => {
     const css = readFileSync(resolve("app/renderer/agentactivity.css"), "utf8");
     const workspaceAppFallbackIconRule =
       css.match(
-        /\[data-agent-mention-kind="workspace-app"\]\s+\[data-agent-mention-app-icon="true"\]\s+\.tsh-agent-object-token__kind-icon\s*{[^}]*}/s
+        /\[data-agent-mention-kind="workspace-app"\]\s+\[data-agent-mention-app-icon="true"\]\s+\.tsh-agent-object-token__kind-icon,[\s\S]*?\[data-agent-mention-kind="workspace-reference"\]\[data-agent-reference-source="app"\]\s+\[data-agent-mention-app-icon="true"\]\s+\.tsh-agent-object-token__kind-icon\s*{[^}]*}/s
       )?.[0] ?? "";
 
-    expect(nodeViewSource).toContain("text-[var(--accent)]");
+    expect(nodeViewSource).toContain(
+      "text-[var(--agent-gui-mention-app-color,var(--tutti-purple))]"
+    );
+    expect(nodeViewSource).not.toContain("text-[var(--accent)]");
+    expect(css).toMatch(
+      /--agent-gui-mention-app-color:\s*var\(--tutti-purple\);/
+    );
     expect(nodeViewSource).toContain("text-[13px]");
     expect(nodeViewSource).toContain("relative grid size-4");
     expect(nodeViewSource).not.toContain("size-[18px]");

--- a/packages/agent/gui/agent-gui/agentGuiNode/agentRichText/AgentMentionNodeView.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/agentRichText/AgentMentionNodeView.tsx
@@ -435,7 +435,7 @@ export function AgentMentionNodeView(props: NodeViewProps): JSX.Element {
         data-agent-mention-kind={mention.kind}
       >
         <span
-          className="group relative top-0 inline-flex max-w-[min(100%,var(--agent-mention-max-width,16rem))] cursor-pointer items-center gap-1 overflow-hidden rounded-[4px] border border-transparent bg-transparent px-1 py-0 align-middle text-[13px] font-medium leading-6 text-[var(--accent)] no-underline transition-colors hover:border-transparent hover:bg-[color-mix(in_srgb,currentColor_12%,transparent)]"
+          className="group relative top-0 inline-flex max-w-[min(100%,var(--agent-mention-max-width,16rem))] cursor-pointer items-center gap-1 overflow-hidden rounded-[4px] border border-transparent bg-transparent px-1 py-0 align-middle text-[13px] font-medium leading-6 text-[var(--agent-gui-mention-app-color,var(--tutti-purple))] no-underline transition-colors hover:border-transparent hover:bg-[color-mix(in_srgb,currentColor_12%,transparent)]"
           data-agent-mention-kind={mention.kind}
           data-slot="mention-pill"
         >

--- a/packages/agent/gui/app/renderer/agentactivity.css
+++ b/packages/agent/gui/app/renderer/agentactivity.css
@@ -276,6 +276,7 @@
   --agent-gui-package-danger: var(--state-danger);
   --agent-gui-accent: var(--agent-gui-package-accent);
   --agent-gui-accent-strong: var(--agent-gui-package-accent-strong);
+  --agent-gui-mention-app-color: var(--tutti-purple);
   --agent-gui-success: var(--agent-gui-package-success);
   --agent-gui-warning: var(--agent-gui-package-warning);
   --agent-gui-danger: var(--agent-gui-package-danger);
@@ -3929,8 +3930,9 @@ aside.workspace-agents-status-panel
   -webkit-mask-size: 16px 16px;
 }
 
-[data-agent-mention-kind="workspace-app"].tsh-agent-object-token--entity {
-  color: var(--tutti-purple);
+[data-agent-mention-kind="workspace-app"].tsh-agent-object-token--entity,
+[data-agent-mention-kind="workspace-reference"][data-agent-reference-source="app"].tsh-agent-object-token--entity {
+  color: var(--agent-gui-mention-app-color, var(--tutti-purple));
 }
 
 [data-agent-mention-kind="skill"].tsh-agent-object-token--entity,
@@ -3966,6 +3968,9 @@ aside.workspace-agents-status-panel
 }
 
 [data-agent-mention-kind="workspace-app"]
+  [data-agent-mention-app-icon="true"]
+  .tsh-agent-object-token__kind-icon,
+[data-agent-mention-kind="workspace-reference"][data-agent-reference-source="app"]
   [data-agent-mention-app-icon="true"]
   .tsh-agent-object-token__kind-icon {
   display: block;
@@ -4131,6 +4136,7 @@ aside.workspace-agents-status-panel
   --agent-gui-accent-strong: var(--agent-gui-package-accent-strong);
   --agent-gui-accent-bg: var(--agent-gui-package-accent-bg);
   --agent-gui-border-focus: var(--agent-gui-package-border-focus);
+  --agent-gui-mention-app-color: var(--tutti-purple);
   --agent-gui-success: var(--agent-gui-package-success);
   --agent-gui-warning: var(--agent-gui-package-warning);
   --agent-gui-danger: var(--agent-gui-package-danger);
@@ -8318,7 +8324,6 @@ html[data-theme="light"] [data-message-center-item-id].agent-gui-edge-glow {
   display: block;
 }
 
-
 .workspace-agents-status-panel__detail-subagent-log {
   display: flex;
   flex-direction: column;
@@ -8354,7 +8359,6 @@ html[data-theme="light"] [data-message-center-item-id].agent-gui-edge-glow {
 .workspace-agents-status-panel__detail-subagent-activity--failure {
   color: var(--tutti-status-danger, #c0392b);
 }
-
 
 .workspace-agents-status-panel__detail-subagent-name {
   color: var(--tutti-text-primary, rgba(0, 0, 0, 0.85));

--- a/packages/agent/gui/shared/AgentMessageMarkdown.spec.tsx
+++ b/packages/agent/gui/shared/AgentMessageMarkdown.spec.tsx
@@ -28,6 +28,7 @@ describe("AgentMessageMarkdown", () => {
       "data-agent-mention-kind",
       "workspace-reference"
     );
+    expect(chip).toHaveAttribute("data-agent-reference-source", "task");
     // 角标数字已移除:chip 只展示标签,不再渲染文件数。
     expect(chip).toHaveTextContent("我的小项目");
     expect(chip).not.toHaveTextContent("3");
@@ -53,6 +54,7 @@ describe("AgentMessageMarkdown", () => {
       "data-agent-mention-kind",
       "workspace-reference"
     );
+    expect(mention).toHaveAttribute("data-agent-reference-source", "app");
     expect(mention).toHaveAttribute("data-agent-mention-icon-url", iconUrl);
     expect(
       mention?.querySelector('[data-agent-mention-app-icon="true"] img')

--- a/packages/agent/gui/shared/AgentMessageMarkdown.tsx
+++ b/packages/agent/gui/shared/AgentMessageMarkdown.tsx
@@ -852,6 +852,7 @@ function MentionLink({
       data-agent-mention-icon-url={mention.iconUrl}
       data-agent-mention-href={href}
       data-agent-mention-kind={mention.kind}
+      data-agent-reference-source={mention.referenceSource}
       aria-label={mention.label}
       role="link"
       tabIndex={0}
@@ -1622,6 +1623,7 @@ interface ParsedMentionLink {
   label: string;
   iconUrl?: string;
   participant: string;
+  referenceSource?: string;
   summary: string;
   /** 引用文件数量(workspace-reference 专用,来自 href 的 count 参数)。 */
   fileCount?: number;
@@ -1703,6 +1705,7 @@ function parseMentionLink(
       iconUrl: mention.scope?.icon?.trim() || appIconUrl,
       fileCount: referenceFileCountFromParam(mention.scope?.count ?? null),
       participant: label,
+      referenceSource: source || undefined,
       summary: ""
     };
   }


### PR DESCRIPTION
## Summary
- make workspace-reference mentions sourced from apps use the same app mention color as workspace-app mentions
- expose the reference source as a data attribute so CSS can target app-backed reference mentions
- align editable app mention color with the Agent GUI app mention token

## Verification
- pnpm --dir packages/agent/gui typecheck
- pnpm --dir packages/agent/gui exec vitest run --environment jsdom shared/AgentMessageMarkdown.spec.tsx agent-gui/agentGuiNode/AgentFileMentionPalette.spec.tsx
- git push pre-push check: pnpm check:full


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Workspace reference mentions now include clearer source metadata, improving how app- and task-related mentions are displayed and styled.
  * App mention styling is now consistent across the agent interface, including mention pills and related icons.

* **Bug Fixes**
  * Fixed app/workspace reference mention colors to use the dedicated Agent GUI app mention theme color (with the existing fallback), replacing the generic accent styling.
  * Updated mention rendering and tests to ensure app-related references are correctly identified via `data-agent-reference-source` and styled consistently.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->