### PR TITLE
[codex] Avoid unread locator state on session load

### DIFF
--- a/packages/agent/gui/app/renderer/agentactivity.css
+++ b/packages/agent/gui/app/renderer/agentactivity.css
@@ -5804,6 +5804,7 @@ button.agent-gui-node__conversation-section-toggle:hover
   --agent-message-locator-dot-size: 6px;
   --agent-message-locator-hit-size: 18px;
   --agent-message-locator-center-offset: 10px;
+  --agent-message-locator-scrollbar-gap: 4px;
   --agent-message-locator-visible-height: 100vh;
   --agent-message-locator-visible-top-offset: 0px;
   --agent-message-locator-viewport-height: var(--agent-message-locator-height);
@@ -5836,7 +5837,8 @@ button.agent-gui-node__conversation-section-toggle:hover
   position: absolute;
   top: 0;
   right: calc(
-    var(--agent-message-locator-center-offset) -
+    var(--agent-message-locator-scrollbar-gap) +
+      var(--agent-message-locator-center-offset) -
       var(--agent-message-locator-hit-size) / 2
   );
   width: var(--agent-message-locator-hit-size);
@@ -5944,7 +5946,7 @@ button.agent-gui-node__conversation-section-toggle:hover
 .agent-gui-message-locator__panel {
   position: absolute;
   top: 50%;
-  right: 22px;
+  right: calc(22px + var(--agent-message-locator-scrollbar-gap));
   display: grid;
   width: min(360px, calc(100vw - 112px));
   max-width: max-content;

--- a/packages/agent/gui/shared/agentConversation/components/AgentTranscriptView.spec.tsx
+++ b/packages/agent/gui/shared/agentConversation/components/AgentTranscriptView.spec.tsx
@@ -483,6 +483,60 @@ describe("AgentTranscriptView", () => {
     expect(timelineWheel).not.toHaveBeenCalled();
   });
 
+  it("does not mark loaded historical agent responses as unread", async () => {
+    const base = detailViewModel();
+    const loadedTurn = {
+      id: "turn-2",
+      userMessage: { id: "user-2", body: "Follow-up request" },
+      userMessages: [{ id: "user-2", body: "Follow-up request" }],
+      agentMessages: [{ id: "assistant-2", body: "Follow-up answer" }],
+      toolCalls: [],
+      toolCallCount: 0,
+      hasFailedToolCall: false,
+      agentItems: [
+        {
+          kind: "message" as const,
+          message: {
+            id: "assistant-2",
+            body: "Follow-up answer"
+          }
+        }
+      ]
+    };
+    const labels = {
+      thinkingLabel: "Thought process",
+      toolCallsLabel: (count: number) => `Tool calls (${count})`,
+      processing: "Planning next moves",
+      turnSummary: "Changed files",
+      userMessageLocator: "User messages"
+    };
+    const { rerender } = render(
+      <AgentTranscriptView
+        conversation={projectAgentConversationVM(
+          detailViewModel({ turns: [] })
+        )}
+        labels={labels}
+      />
+    );
+
+    rerender(
+      <AgentTranscriptView
+        conversation={projectAgentConversationVM(
+          detailViewModel({ turns: [base.turns[0]!, loadedTurn] })
+        )}
+        labels={labels}
+      />
+    );
+
+    await act(async () => undefined);
+    const locator = screen.getByTestId("agent-message-locator");
+    for (const tick of locator.querySelectorAll(
+      ".agent-gui-message-locator__tick"
+    )) {
+      expect(tick).not.toHaveAttribute("data-unread-agent-response", "true");
+    }
+  });
+
   it("marks newly answered user message locator ticks as unread until located", async () => {
     const base = detailViewModel();
     const followUpTurn = {

--- a/packages/agent/gui/shared/agentConversation/components/AgentTranscriptView.tsx
+++ b/packages/agent/gui/shared/agentConversation/components/AgentTranscriptView.tsx
@@ -453,6 +453,7 @@ function AgentMessageLocatorRail({
           const hadAgentResponse =
             previousAgentResponseByKey.get(item.key) ?? false;
           if (
+            previousAgentResponseByKey.has(item.key) &&
             item.hasAgentResponse &&
             !hadAgentResponse &&
             item.key !== selectedKey


### PR DESCRIPTION
## Summary
- Avoid marking already-loaded historical agent responses as unread when entering an AgentGUI session.
- Keep a 4px gap between the message locator hit area and the transcript scrollbar.
- Add a regression test for loading a session from an empty detail state into historical answered turns.

## Impact
The message locator no longer turns historical dots purple just because the user opened or re-entered a session. Dots still turn purple when an existing user message receives a new agent response while the view is open. The locator also no longer visually hugs the right-side scrollbar.

## Root Cause
The locator compared `hasAgentResponse` against a previous map, but treated missing previous keys as `false`. When a session loaded from an empty detail state, every historical answered item looked like a new response. The fix only marks unread when the same locator key existed in the previous render and transitions from no response to response.

## Validation
- `pnpm --dir packages/agent/gui exec vitest run --environment jsdom shared/agentConversation/components/AgentTranscriptView.spec.tsx`
- `pnpm check:changed --tail-lines 80`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed message locator positioning so it stays aligned when a scrollbar gap is present.
  * Corrected unread indicators in the agent transcript so historical messages are no longer marked as unread after reloads or rerenders.
  
* **Tests**
  * Added coverage for rerendering transcripts with previously loaded turns to ensure locator ticks do not show unread states incorrectly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->