### PR TITLE
Register omni-catcher as a community app

### DIFF
--- a/packages/workspace/app-center/src/core/appCenterAppOrdering.test.ts
+++ b/packages/workspace/app-center/src/core/appCenterAppOrdering.test.ts
@@ -203,6 +203,11 @@ describe("sortCommunityApps", () => {
         id: "design-review",
         name: "Design Review",
         sourceKind: "bundled"
+      }),
+      createApp({
+        id: "omni-catcher",
+        name: "Omni Catcher",
+        sourceKind: "bundled"
       })
     ];
 
@@ -213,7 +218,8 @@ describe("sortCommunityApps", () => {
         "design-review",
         "product-competition",
         "daily-tech-radar",
-        "draw-topic-app"
+        "draw-topic-app",
+        "omni-catcher"
       ]
     );
   });
@@ -226,6 +232,7 @@ describe("isCommunityRecommendedApp", () => {
     assert.equal(isCommunityRecommendedApp("product-competition"), true);
     assert.equal(isCommunityRecommendedApp("design-review"), true);
     assert.equal(isCommunityRecommendedApp("draw-topic-app"), true);
+    assert.equal(isCommunityRecommendedApp("omni-catcher"), true);
     assert.equal(isCommunityRecommendedApp("automation"), false);
     assert.equal(isCommunityRecommendedApp("vibe-design"), false);
   });

--- a/packages/workspace/app-center/src/core/appCenterAppOrdering.ts
+++ b/packages/workspace/app-center/src/core/appCenterAppOrdering.ts
@@ -21,7 +21,8 @@ const communityRecommendedAppIdGroups = [
   ["design-review"],
   ["product-competition"],
   ["daily-product-radar", "daily-tech-radar", "radar"],
-  ["draw-topic-app", "answer-book", "app_answer_book", "idea-draw"]
+  ["draw-topic-app", "answer-book", "app_answer_book", "idea-draw"],
+  ["omni-catcher"]
 ] as const;
 
 const recommendedAppDisplayRankById = buildRecommendedAppDisplayRankById();


### PR DESCRIPTION
## Summary
- Adds `omni-catcher` to `communityRecommendedAppIdGroups` in `appCenterAppOrdering.ts` so App Center groups it under **Community apps** instead of **Official apps** once it appears in the catalog snapshot.
- Updates `appCenterAppOrdering.test.ts` per the convention in `docs/conventions/workspace-app-catalog.md` (id list and ordering tests must move together).

## Test plan
- [x] `node --experimental-strip-types --test src/core/appCenterAppOrdering.test.ts` (8/8 passing)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for the community app **omni-catcher** in app ordering.
  * It now appears in the expected position alongside other community-recommended apps.
* **Bug Fixes**
  * Updated recommendation handling so **omni-catcher** is recognized as a community-recommended app.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->