### PR TITLE
fix(agent): align claude sdk provider detection

### DIFF
--- a/apps/desktop/src/renderer/src/features/workspace-agent/services/internal/desktopAgentProviderStatusSync.test.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-agent/services/internal/desktopAgentProviderStatusSync.test.ts
@@ -24,6 +24,26 @@ test("shouldRefreshProviderStatusAfterSessionError matches provider availability
     ),
     true
   );
+  assert.equal(
+    shouldRefreshProviderStatusAfterSessionError(
+      new TuttidProtocolError({
+        code: "workspace_operation_failed",
+        reason: "claude_sdk_sidecar_unavailable",
+        statusCode: 502
+      })
+    ),
+    true
+  );
+  assert.equal(
+    shouldRefreshProviderStatusAfterSessionError(
+      new TuttidProtocolError({
+        code: "workspace_operation_failed",
+        reason: "managed_runtime_unavailable",
+        statusCode: 502
+      })
+    ),
+    true
+  );
 });
 
 test("shouldRefreshProviderStatusAfterSessionError ignores unrelated failures", () => {

--- a/apps/desktop/src/renderer/src/features/workspace-agent/services/internal/desktopAgentProviderStatusSync.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-agent/services/internal/desktopAgentProviderStatusSync.ts
@@ -7,7 +7,9 @@ const providerStatusRefreshReasons = new Set([
   "agent_provider_unavailable",
   "auth_required",
   "auth_unknown",
-  "cli_not_found"
+  "claude_sdk_sidecar_unavailable",
+  "cli_not_found",
+  "managed_runtime_unavailable"
 ]);
 
 export function shouldRefreshProviderStatusAfterSessionError(

--- a/docs/conventions/runtime-overrides.md
+++ b/docs/conventions/runtime-overrides.md
@@ -94,6 +94,11 @@ Use the owner documents linked below for detailed behavior. This file exists to 
 | `TUTTI_MOCK_AGENT_UNBOUND`             | This document                                   | Forces Codex unbound and Claude Code auth-required for onboarding diagnostics.                   |
 | `TUTTI_WORKSPACE_ID`                   | This document                                   | Supplies a workspace id to migrated agent context readers when no input id is provided.          |
 
+Claude Code provider availability follows `TUTTI_CLAUDE_CODE_RUNTIME`: the
+default `sdk` runtime checks the `claude` CLI plus the Claude SDK sidecar entry
+and Node runtime, while `acp` keeps using the legacy `claude-acp` package from
+the ACP External Agent Registry.
+
 ## Desktop Renderer Diagnostics
 
 | Variable                               | Owner document                          | Purpose                                                                                       |

--- a/docs/conventions/troubleshooting.md
+++ b/docs/conventions/troubleshooting.md
@@ -982,7 +982,14 @@ delimited by ---`, and the composer skill picker may show partial or
   was still live, leaving ghost durable approvals. Text-only subagent completions
   that finish with a nested `end_turn` assistant message never emitted
   `task_completed`, so background-agent counts stayed stale and submit paths
-  kept blocking.
+  kept blocking. For nested launches (a subagent launching its own async
+  agents), the grandchild `Task` tool_use blocks only appear inside
+  child-stream assistant messages that the sidecar previously dropped, so the
+  grandchild task state was never registered: its approvals resolved no turn
+  id (the daemon rejects turnless `message_update`s, silently dropping the
+  approval card and deadlocking the grandchild), and a child `end_turn`
+  assistant could settle the child task while grandchildren were still
+  running.
 - Fix:
   Store the originating turn id on pending interactive requests in the sidecar and
   Go adapter, and reuse it when emitting `approval_resolved` if the event omits
@@ -991,18 +998,31 @@ delimited by ---`, and the composer skill picker may show partial or
   `SubmitInteractive` returns a stale no-longer-live error, reconcile the
   persisted approval instead of surfacing the raw failure. Treat nested assistant
   messages with non-empty `parent_tool_use_id` and `stop_reason=end_turn` as
-  delegated-task completion when no child `result` arrives. In the Claude SDK
-  sidecar, also parse fold-in `queued_command` attachments and user-string
-  `<task-notification>` payloads (not only `system/task_notification`), binding
-  completion by `tool-use-id`/`tool_use_id` so concurrent async agents settle
-  independently.
+  delegated-task completion when no child `result` arrives, but only once no
+  delegated child task launched by that subagent is still running. In the
+  Claude SDK sidecar, also parse fold-in `queued_command` attachments and
+  user-string `<task-notification>` payloads (not only
+  `system/task_notification`), binding completion by
+  `tool-use-id`/`tool_use_id` so concurrent async agents settle independently.
+  For nested launches: register tool_use blocks from child-stream assistant
+  messages, treat the `Async agent launched successfully` result text as the
+  authoritative subagent-launch signal even when the tool name is unknown,
+  inherit the delegated-task turn id along the parent tool-use chain, let
+  interactive requests fall back to any delegated task's turn id (settled
+  ones included) and open a synthetic turn as last resort rather than emit a
+  turnless event.
 - Validation:
   Add adapter coverage that stored pending turn ids survive missing
   `approval_resolved.turnId`. Add service coverage for ghost approval reconcile
   with live background agents and stale submit reconciliation. Add sidecar
   coverage that nested `end_turn` assistant text completes the delegated task,
   fold-in `queued_command` notifications complete running agents, and dequeued
-  user-string task notifications complete by parent tool use id.
+  user-string task notifications complete by parent tool use id. For nested
+  launches, keep sidecar coverage that a grandchild launch registers with the
+  inherited turn id (with and without an observed tool_use block), that a
+  nested approval after the parent task completed still carries a turn id, and
+  that a child `end_turn` assistant defers completion while a grandchild task
+  is running.
 
 ### Claude SDK parent waits forever for background agents that already finished
 
@@ -1131,16 +1151,20 @@ delimited by ---`, and the composer skill picker may show partial or
   `pnpm check:api-generated`. Trigger a Claude Code install and confirm status
   responses include `activeAction` while the CLI or adapter step is in flight.
 
-### ACP adapter appears stale after external registry migration
+### Legacy Claude ACP adapter appears stale after external registry migration
 
 - Symptom:
-  Claude Agent provider status is not ready, or live ACP options do not match
-  the package version advertised by the ACP External Agent Registry. Another
-  form is Claude Code context usage briefly showing `0%` during a running
-  session or around compaction, then returning to the prior nonzero value on
-  the next usage update. A third form is new Claude Code sessions failing
-  during startup with `Invalid value for config option fast: standard`.
+  With `TUTTI_CLAUDE_CODE_RUNTIME=acp`, Claude Agent provider status is not
+  ready, or live ACP options do not match the package version advertised by the
+  ACP External Agent Registry. Another form is Claude Code context usage briefly
+  showing `0%` during a running session or around compaction, then returning to
+  the prior nonzero value on the next usage update. A third form is new Claude
+  Code sessions failing during startup with
+  `Invalid value for config option fast: standard`.
 - Quick checks:
+  First confirm the runtime is legacy ACP. The default Claude Code runtime is
+  SDK; SDK provider availability checks the `claude` CLI plus the Claude SDK
+  sidecar entry and must not require `claude-acp`.
   Inspect `<state-dir>/agent-providers/external-agent-registry/cache/registry.json`
   and the package manifest under
   `<state-dir>/agent-providers/external-agent-registry/packages/claude-acp/node_modules/@agentclientprotocol/claude-agent-acp/package.json`.

--- a/packages/agent/claude-sdk-sidecar/src/main.test.ts
+++ b/packages/agent/claude-sdk-sidecar/src/main.test.ts
@@ -1964,6 +1964,472 @@ function fakeUserTaskNotificationQuery({
   } as AsyncIterable<SDKMessage>;
 }
 
+test("nested agent launch registers grandchild task with inherited turn id", async () => {
+  const events: Array<{ type: string; payload?: Record<string, unknown> }> = [];
+  const restoreSink = withSidecarEventSinkForTest((event) =>
+    events.push(event)
+  );
+  try {
+    const session = new SessionRuntime(
+      "provider-session-1",
+      "/repo",
+      {},
+      false,
+      false,
+      {
+        model: "",
+        permissionModeId: "default",
+        planMode: false,
+        effort: "",
+        speed: ""
+      },
+      sidecarClaudeOptionsFromPayload({}),
+      undefined,
+      fakeNestedDelegatedLaunchQuery
+    );
+
+    await session.start();
+    session.exec("turn-1", "delegate task");
+    await waitForEvent(events, "task_completed");
+
+    const childCompleted = events.find(
+      (event) =>
+        event.type === "task_completed" &&
+        event.payload?.parentToolUseId === "toolu-child"
+    );
+    assert.equal(childCompleted?.payload?.turnId, "turn-1");
+    assert.equal(childCompleted?.payload?.agentId, "agent-child");
+
+    const childToolCompleted = events.find(
+      (event) =>
+        event.type === "tool_completed" &&
+        event.payload?.toolCallId === "toolu-child" &&
+        event.payload?.status === "completed"
+    );
+    assert.equal(childToolCompleted?.payload?.turnId, "turn-1");
+  } finally {
+    restoreSink();
+  }
+});
+
+test("nested launch without observed tool_use block still registers task", async () => {
+  const events: Array<{ type: string; payload?: Record<string, unknown> }> = [];
+  const restoreSink = withSidecarEventSinkForTest((event) =>
+    events.push(event)
+  );
+  try {
+    const session = new SessionRuntime(
+      "provider-session-1",
+      "/repo",
+      {},
+      false,
+      false,
+      {
+        model: "",
+        permissionModeId: "default",
+        planMode: false,
+        effort: "",
+        speed: ""
+      },
+      sidecarClaudeOptionsFromPayload({}),
+      undefined,
+      fakeNestedLaunchWithoutToolUseQuery
+    );
+
+    await session.start();
+    session.exec("turn-1", "delegate task");
+    await waitForEvent(events, "task_completed");
+
+    const childCompleted = events.find(
+      (event) =>
+        event.type === "task_completed" &&
+        event.payload?.parentToolUseId === "toolu-child"
+    );
+    assert.equal(childCompleted?.payload?.turnId, "turn-1");
+
+    const launchToolCompleted = events.find(
+      (event) =>
+        event.type === "tool_completed" &&
+        event.payload?.toolCallId === "toolu-child" &&
+        (event.payload?.metadata as Record<string, unknown> | undefined)
+          ?.subagentAsync === true
+    );
+    assert.equal(launchToolCompleted?.payload?.turnId, "turn-1");
+  } finally {
+    restoreSink();
+  }
+});
+
+test("nested approval after parent task completed still carries a turn id", async () => {
+  const events: Array<{ type: string; payload?: Record<string, unknown> }> = [];
+  const restoreSink = withSidecarEventSinkForTest((event) =>
+    events.push(event)
+  );
+  let permissionResult: unknown;
+  try {
+    const session = new SessionRuntime(
+      "provider-session-1",
+      "/repo",
+      {},
+      false,
+      false,
+      {
+        model: "",
+        permissionModeId: "default",
+        planMode: false,
+        effort: "",
+        speed: ""
+      },
+      sidecarClaudeOptionsFromPayload({}),
+      undefined,
+      ({ prompt, options }) =>
+        fakeNestedApprovalQuery(prompt, options, (result) => {
+          permissionResult = result;
+        })
+    );
+
+    await session.start();
+    session.exec("turn-1", "delegate task");
+    await waitForEvent(events, "approval_requested");
+
+    const request = events.find((event) => event.type === "approval_requested");
+    assert.equal(request?.payload?.turnId, "turn-1");
+
+    session.submitInteractive(
+      String(request?.payload?.requestId ?? ""),
+      "submit",
+      "allow",
+      {}
+    );
+    await waitForEvent(events, "approval_resolved");
+    await new Promise((resolve) => setTimeout(resolve, 20));
+
+    assert.deepEqual(permissionResult, {
+      behavior: "allow",
+      updatedInput: { command: "ls" }
+    });
+  } finally {
+    restoreSink();
+  }
+});
+
+test("nested end_turn assistant defers parent completion while grandchild runs", async () => {
+  const events: Array<{ type: string; payload?: Record<string, unknown> }> = [];
+  const restoreSink = withSidecarEventSinkForTest((event) =>
+    events.push(event)
+  );
+  try {
+    const session = new SessionRuntime(
+      "provider-session-1",
+      "/repo",
+      {},
+      false,
+      false,
+      {
+        model: "",
+        permissionModeId: "default",
+        planMode: false,
+        effort: "",
+        speed: ""
+      },
+      sidecarClaudeOptionsFromPayload({}),
+      undefined,
+      fakeNestedDeferredParentCompletionQuery
+    );
+
+    await session.start();
+    session.exec("turn-1", "delegate task");
+    await waitForEvent(events, "task_completed");
+    // Let the fake stream drain the remaining nested messages.
+    await new Promise((resolve) => setTimeout(resolve, 50));
+
+    const parentCompletions = events.filter(
+      (event) =>
+        event.type === "task_completed" &&
+        event.payload?.parentToolUseId === "toolu-parent"
+    );
+    assert.equal(parentCompletions.length, 1);
+    assert.equal(parentCompletions[0]?.payload?.summary, "Parent finished.");
+
+    const childCompletedIndex = events.findIndex(
+      (event) =>
+        event.type === "task_completed" &&
+        event.payload?.parentToolUseId === "toolu-child"
+    );
+    const parentCompletedIndex = events.findIndex(
+      (event) =>
+        event.type === "task_completed" &&
+        event.payload?.parentToolUseId === "toolu-parent"
+    );
+    assert.ok(childCompletedIndex >= 0);
+    assert.ok(parentCompletedIndex > childCompletedIndex);
+  } finally {
+    restoreSink();
+  }
+});
+
+function fakeNestedDelegatedLaunchQuery({
+  prompt
+}: {
+  prompt: AsyncIterable<SDKUserMessage>;
+}): AsyncIterable<SDKMessage> {
+  return {
+    async *[Symbol.asyncIterator]() {
+      const firstPrompt = await prompt[Symbol.asyncIterator]().next();
+      const promptMessage = firstPrompt.value as SDKUserMessage & {
+        uuid?: string;
+      };
+      yield {
+        ...promptMessage,
+        uuid: promptMessage.uuid,
+        type: "user",
+        parent_tool_use_id: null,
+        session_id: "provider-session-1"
+      } as SDKMessage;
+      yield delegatedAgentToolUse("toolu-parent", "Parent task");
+      yield delegatedAgentToolResult("toolu-parent", "agent-parent");
+      yield {
+        type: "result",
+        subtype: "success"
+      } as unknown as SDKMessage;
+      // Child stream: the child agent launches a grandchild Task after the
+      // launching turn already settled.
+      yield nestedAssistantToolUse(
+        "toolu-parent",
+        "toolu-child",
+        "Grandchild task"
+      );
+      yield nestedAgentLaunchResult(
+        "toolu-parent",
+        "toolu-child",
+        "agent-child"
+      );
+      yield userTaskNotification("agent-child", "toolu-child");
+    },
+    close() {}
+  } as AsyncIterable<SDKMessage>;
+}
+
+function fakeNestedLaunchWithoutToolUseQuery({
+  prompt
+}: {
+  prompt: AsyncIterable<SDKUserMessage>;
+}): AsyncIterable<SDKMessage> {
+  return {
+    async *[Symbol.asyncIterator]() {
+      const firstPrompt = await prompt[Symbol.asyncIterator]().next();
+      const promptMessage = firstPrompt.value as SDKUserMessage & {
+        uuid?: string;
+      };
+      yield {
+        ...promptMessage,
+        uuid: promptMessage.uuid,
+        type: "user",
+        parent_tool_use_id: null,
+        session_id: "provider-session-1"
+      } as SDKMessage;
+      yield delegatedAgentToolUse("toolu-parent", "Parent task");
+      yield delegatedAgentToolResult("toolu-parent", "agent-parent");
+      yield {
+        type: "result",
+        subtype: "success"
+      } as unknown as SDKMessage;
+      // Only the launch result streams through; the grandchild tool_use block
+      // was never observed, so the local tool name is unknown.
+      yield nestedAgentLaunchResult(
+        "toolu-parent",
+        "toolu-child",
+        "agent-child"
+      );
+      yield userTaskNotification("agent-child", "toolu-child");
+    },
+    close() {}
+  } as AsyncIterable<SDKMessage>;
+}
+
+function fakeNestedApprovalQuery(
+  prompt: AsyncIterable<SDKUserMessage>,
+  options: ClaudeQueryOptions,
+  onPermissionResult: (result: unknown) => void
+): AsyncIterable<SDKMessage> {
+  return {
+    async *[Symbol.asyncIterator]() {
+      const firstPrompt = await prompt[Symbol.asyncIterator]().next();
+      const promptMessage = firstPrompt.value as SDKUserMessage & {
+        uuid?: string;
+      };
+      yield {
+        ...promptMessage,
+        uuid: promptMessage.uuid,
+        type: "user",
+        parent_tool_use_id: null,
+        session_id: "provider-session-1"
+      } as SDKMessage;
+      yield delegatedAgentToolUse("toolu-parent", "Parent task");
+      yield delegatedAgentToolResult("toolu-parent", "agent-parent");
+      yield {
+        type: "result",
+        subtype: "success"
+      } as unknown as SDKMessage;
+      yield {
+        type: "system",
+        subtype: "task_notification",
+        task_id: "agent-parent",
+        status: "completed",
+        summary: "Parent done"
+      } as unknown as SDKMessage;
+      // A grandchild tool runs after the parent task completed; its approval
+      // must still resolve a turn id or the approval card never surfaces.
+      const result = await options.canUseTool?.(
+        "Bash",
+        { command: "ls" },
+        {
+          signal: new AbortController().signal,
+          toolUseID: "toolu-nested-bash"
+        }
+      );
+      onPermissionResult(result);
+    },
+    close() {}
+  } as AsyncIterable<SDKMessage>;
+}
+
+function fakeNestedDeferredParentCompletionQuery({
+  prompt
+}: {
+  prompt: AsyncIterable<SDKUserMessage>;
+}): AsyncIterable<SDKMessage> {
+  return {
+    async *[Symbol.asyncIterator]() {
+      const firstPrompt = await prompt[Symbol.asyncIterator]().next();
+      const promptMessage = firstPrompt.value as SDKUserMessage & {
+        uuid?: string;
+      };
+      yield {
+        ...promptMessage,
+        uuid: promptMessage.uuid,
+        type: "user",
+        parent_tool_use_id: null,
+        session_id: "provider-session-1"
+      } as SDKMessage;
+      yield delegatedAgentToolUse("toolu-parent", "Parent task");
+      yield delegatedAgentToolResult("toolu-parent", "agent-parent");
+      yield {
+        type: "result",
+        subtype: "success"
+      } as unknown as SDKMessage;
+      yield nestedAssistantToolUse(
+        "toolu-parent",
+        "toolu-child",
+        "Grandchild task"
+      );
+      yield nestedAgentLaunchResult(
+        "toolu-parent",
+        "toolu-child",
+        "agent-child"
+      );
+      // The child ends its own turn while the grandchild is still running;
+      // this must not settle the child's delegated task yet.
+      yield nestedEndTurnAssistant(
+        "toolu-parent",
+        "assistant-premature-end",
+        "All grandchildren launched."
+      );
+      yield userTaskNotification("agent-child", "toolu-child");
+      yield nestedEndTurnAssistant(
+        "toolu-parent",
+        "assistant-final-end",
+        "Parent finished."
+      );
+    },
+    close() {}
+  } as AsyncIterable<SDKMessage>;
+}
+
+function nestedAssistantToolUse(
+  parentToolUseId: string,
+  id: string,
+  description: string
+): SDKMessage {
+  return {
+    type: "assistant",
+    uuid: `${id}-nested-assistant`,
+    parent_tool_use_id: parentToolUseId,
+    session_id: "provider-session-1",
+    message: {
+      role: "assistant",
+      content: [
+        {
+          type: "tool_use",
+          id,
+          name: "Task",
+          input: {
+            description,
+            prompt: description
+          }
+        }
+      ]
+    }
+  } as unknown as SDKMessage;
+}
+
+function nestedAgentLaunchResult(
+  parentToolUseId: string,
+  toolUseId: string,
+  agentId: string
+): SDKMessage {
+  return {
+    type: "user",
+    parent_tool_use_id: parentToolUseId,
+    session_id: "provider-session-1",
+    message: {
+      role: "user",
+      content: [
+        {
+          type: "tool_result",
+          tool_use_id: toolUseId,
+          content: `Async agent launched successfully\nagentId: ${agentId}\noutput_file: /tmp/${agentId}.output`
+        }
+      ]
+    }
+  } as unknown as SDKMessage;
+}
+
+function nestedEndTurnAssistant(
+  parentToolUseId: string,
+  uuid: string,
+  text: string
+): SDKMessage {
+  return {
+    type: "assistant",
+    uuid,
+    parent_tool_use_id: parentToolUseId,
+    session_id: "provider-session-1",
+    message: {
+      role: "assistant",
+      stop_reason: "end_turn",
+      content: [{ type: "text", text }]
+    }
+  } as unknown as SDKMessage;
+}
+
+function userTaskNotification(taskId: string, toolUseId: string): SDKMessage {
+  return {
+    type: "user",
+    parent_tool_use_id: null,
+    session_id: "provider-session-1",
+    message: {
+      role: "user",
+      content: `<task-notification>
+<task-id>${taskId}</task-id>
+<tool-use-id>${toolUseId}</tool-use-id>
+<status>completed</status>
+<summary>done</summary>
+</task-notification>`
+    }
+  } as unknown as SDKMessage;
+}
+
 async function waitForEvent(
   events: Array<{ type: string }>,
   type: string

--- a/packages/agent/claude-sdk-sidecar/src/main.ts
+++ b/packages/agent/claude-sdk-sidecar/src/main.ts
@@ -151,6 +151,9 @@ type DelegatedTaskState = {
   subject?: string;
   description?: string;
   status: DelegatedTaskStatus;
+  // Tool use id of the delegated task that launched this one, set when a
+  // nested agent launch is observed inside a child stream.
+  parentTaskToolUseId?: string;
 };
 
 type AssistantSegmentKind = "assistant" | "thinking";
@@ -813,7 +816,11 @@ export class SessionRuntime {
   ): Promise<InteractiveSubmission> {
     const requestId = crypto.randomUUID();
     const toolUseID = callbackOptions.toolUseID || requestId;
-    const turnId = this.resolveInteractiveTurnId(callbackOptions);
+    // Never emit a turnless interactive request: the daemon rejects it and
+    // the requesting agent would wait forever on an invisible approval.
+    const turnId =
+      this.resolveInteractiveTurnId(callbackOptions) ||
+      this.activateSyntheticTurn().turnId;
     const request = new Promise<InteractiveSubmission>((resolve, reject) => {
       this.pendingInteractions.set(requestId, {
         requestId,
@@ -888,7 +895,17 @@ export class SessionRuntime {
         return turn.turnId;
       }
     }
-    return "";
+    // A settled delegated task is still a better anchor than an empty turn
+    // id: turnless interactive events are rejected by the daemon activity
+    // store, which silently drops the approval card and deadlocks the
+    // requesting nested agent.
+    let latestTaskTurnId = "";
+    for (const task of this.delegatedTasksByParentToolUseID.values()) {
+      if (task.turnId) {
+        latestTaskTurnId = task.turnId;
+      }
+    }
+    return latestTaskTurnId;
   }
 
   private emitInteractiveResolved(
@@ -1115,7 +1132,24 @@ export class SessionRuntime {
 
     if (message.type === "assistant") {
       if (parentToolUseID) {
-        if (this.isNestedDelegatedTaskTerminalAssistant(message)) {
+        // Nested agent launches (grandchild Task calls) only surface as
+        // tool_use blocks inside child-stream assistant messages. Register
+        // them so their launch results can create delegated task state and
+        // later events (approvals, notifications) can resolve a turn id.
+        for (const block of contentBlocksFromMessage(message)) {
+          if (isToolUseBlock(block)) {
+            this.upsertToolUse(
+              block,
+              undefined,
+              "tool_updated",
+              parentToolUseID
+            );
+          }
+        }
+        if (
+          this.isNestedDelegatedTaskTerminalAssistant(message) &&
+          !this.hasRunningChildDelegatedTasks(parentToolUseID)
+        ) {
           this.completeDelegatedTaskFromParentMessage(parentToolUseID, {
             status: "completed",
             summary:
@@ -1127,7 +1161,8 @@ export class SessionRuntime {
         // the child is still running, so they are not a completion signal.
         // Delegated tasks settle through the child result message, the
         // task_notification system message, the TaskCompleted hook, or a
-        // terminal assistant message tagged with end_turn.
+        // terminal assistant message tagged with end_turn once no launched
+        // child tasks remain running.
         return;
       }
       if (!this.ensureActiveTurn("assistant")) {
@@ -2392,7 +2427,12 @@ export class SessionRuntime {
     status: "streaming" | "completed" | "failed",
     result?: Record<string, unknown>
   ): void {
-    const payload = toolPayload(this.activeTurnId, tool, status, result);
+    const payload = toolPayload(
+      this.resolveToolEventTurnId(tool),
+      tool,
+      status,
+      result
+    );
     if (type === "tool_completed" || type === "tool_failed") {
       this.appendParentTaskStep(tool, payload);
       this.rememberDelegatedTaskFromToolPayload(tool, payload);
@@ -2403,15 +2443,30 @@ export class SessionRuntime {
     });
   }
 
+  private resolveToolEventTurnId(tool: ToolState): string {
+    if (this.activeTurnId) {
+      return this.activeTurnId;
+    }
+    // Child-stream tool events can arrive after the launching turn settled;
+    // attribute them to the turn of the delegated task they belong to.
+    const parentToolUseID = stringValue(tool.parentToolUseId);
+    if (parentToolUseID) {
+      const task = this.delegatedTasksByParentToolUseID.get(parentToolUseID);
+      if (task?.turnId) {
+        return task.turnId;
+      }
+    }
+    return "";
+  }
+
   private rememberDelegatedTaskFromToolPayload(
     tool: ToolState,
     payload: Record<string, unknown>
   ): void {
     const metadata = recordValue(payload.metadata);
-    if (
-      stringValue(payload.callType) !== "subagent" ||
-      metadata?.subagentAsync !== true
-    ) {
+    // The launch result text sets subagentAsync; nested launches may stream
+    // without a locally known tool name, so callType alone cannot gate here.
+    if (metadata?.subagentAsync !== true) {
       return;
     }
     const parentToolUseId = stringValue(payload.toolCallId) || tool.id;
@@ -2423,13 +2478,23 @@ export class SessionRuntime {
     const outputFile =
       stringValue(metadata.subagentOutputFile) ||
       stringValue(metadata.outputFile);
+    const launchingTask = this.delegatedTasksByParentToolUseID.get(
+      stringValue(tool.parentToolUseId)
+    );
     const task: DelegatedTaskState = {
       parentToolUseId,
-      turnId: stringValue(payload.turnId) || this.activeTurnId,
+      turnId:
+        stringValue(payload.turnId) ||
+        this.activeTurnId ||
+        launchingTask?.turnId ||
+        "",
       input: recordValue(payload.input) ?? { ...tool.input },
       ...(agentId ? { agentId } : {}),
       ...(outputFile ? { outputFile } : {}),
-      status: "running"
+      status: "running",
+      ...(launchingTask
+        ? { parentTaskToolUseId: launchingTask.parentToolUseId }
+        : {})
     };
     this.delegatedTasksByParentToolUseID.set(parentToolUseId, task);
     if (agentId) {
@@ -2503,6 +2568,18 @@ export class SessionRuntime {
   private hasDelegatedTaskAliases(): boolean {
     for (const task of this.delegatedTasksByParentToolUseID.values()) {
       if (task.agentId || task.taskId) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  private hasRunningChildDelegatedTasks(parentToolUseId: string): boolean {
+    for (const task of this.delegatedTasksByParentToolUseID.values()) {
+      if (
+        task.parentTaskToolUseId === parentToolUseId &&
+        task.status === "running"
+      ) {
         return true;
       }
     }

--- a/packages/agent/claude-sdk-sidecar/src/normalizer.ts
+++ b/packages/agent/claude-sdk-sidecar/src/normalizer.ts
@@ -399,9 +399,9 @@ function subagentLaunchMetadata(
   tool: ToolState,
   result?: Record<string, unknown>
 ): Record<string, unknown> | undefined {
-  if (toolCallType(tool.name) !== "subagent") {
-    return undefined;
-  }
+  // Nested agent launches stream through the parent query without a locally
+  // observed tool_use block, so the tool name may be unknown here. The launch
+  // result text is the authoritative signal, not the tool call type.
   const text = toolResultText(result);
   if (!/Async agent launched successfully/i.test(text)) {
     return undefined;

--- a/packages/agent/daemon/runtime/claude_sdk_adapter.go
+++ b/packages/agent/daemon/runtime/claude_sdk_adapter.go
@@ -111,7 +111,7 @@ func NewClaudeCodeSDKAdapter(transport ProcessTransport) *ClaudeCodeSDKAdapter {
 	}
 }
 
-func (_ *ClaudeCodeSDKAdapter) Provider() string {
+func (*ClaudeCodeSDKAdapter) Provider() string {
 	return ProviderClaudeCode
 }
 
@@ -471,7 +471,7 @@ func (a *ClaudeCodeSDKAdapter) SessionCommandSnapshot(session Session) (AgentSes
 	return adapterSession.commandSnapshot(session.AgentSessionID)
 }
 
-func (_ *ClaudeCodeSDKAdapter) applySidecarSessionEvent(adapterSession *claudeSDKAdapterSession, session Session, event claudeSDKSidecarEvent) []activityshared.Event {
+func (*ClaudeCodeSDKAdapter) applySidecarSessionEvent(adapterSession *claudeSDKAdapterSession, session Session, event claudeSDKSidecarEvent) []activityshared.Event {
 	if event.Type == "usage_updated" {
 		adapterSession.applyUsageUpdated(event.Payload)
 		return nil

--- a/packages/agent/daemon/runtime/claude_sdk_adapter_test.go
+++ b/packages/agent/daemon/runtime/claude_sdk_adapter_test.go
@@ -2415,11 +2415,11 @@ func (c *recordingClaudeSDKConnection) Send(data []byte) error {
 	return nil
 }
 
-func (_ *recordingClaudeSDKConnection) Recv() (ProcessFrame, error) {
+func (*recordingClaudeSDKConnection) Recv() (ProcessFrame, error) {
 	return ProcessFrame{}, errors.New("recording claude sdk connection does not receive")
 }
 
-func (_ *recordingClaudeSDKConnection) Close() error {
+func (*recordingClaudeSDKConnection) Close() error {
 	return nil
 }
 
@@ -2462,7 +2462,7 @@ func (c *ackClaudeSDKConnection) Recv() (ProcessFrame, error) {
 	return frame, nil
 }
 
-func (_ *ackClaudeSDKConnection) Close() error {
+func (*ackClaudeSDKConnection) Close() error {
 	return nil
 }
 
@@ -2500,7 +2500,7 @@ func (c *scriptedClaudeSDKConnection) Recv() (ProcessFrame, error) {
 	return frame, nil
 }
 
-func (c *scriptedClaudeSDKConnection) Close() error {
+func (*scriptedClaudeSDKConnection) Close() error {
 	return nil
 }
 

--- a/services/tuttid/service/agent/provider_availability.go
+++ b/services/tuttid/service/agent/provider_availability.go
@@ -209,13 +209,27 @@ func providerAvailabilityChecksFromAgentStatus(status agentstatusservice.Provide
 		{
 			Name:   "adapter",
 			Passed: status.Adapter.Installed,
-			Detail: firstNonEmptyString(status.Adapter.BinaryPath, "ACP adapter not found"),
+			Detail: providerAvailabilityAdapterDetail(status),
 		},
 		{
 			Name:   "auth",
 			Passed: status.Auth.Status == agentstatusservice.AuthAuthenticated,
 			Detail: providerAvailabilityAuthDetail(status.Auth),
 		},
+	}
+}
+
+func providerAvailabilityAdapterDetail(status agentstatusservice.ProviderStatus) string {
+	if strings.TrimSpace(status.Adapter.BinaryPath) != "" {
+		return strings.TrimSpace(status.Adapter.BinaryPath)
+	}
+	switch strings.TrimSpace(status.Availability.ReasonCode) {
+	case agentstatusservice.ReasonClaudeSDKSidecarUnavailable:
+		return "Claude SDK sidecar not found"
+	case agentstatusservice.ReasonManagedRuntimeUnavailable:
+		return "Managed Node runtime is unavailable"
+	default:
+		return "ACP adapter not found"
 	}
 }
 
@@ -235,7 +249,7 @@ func providerAvailabilityNeedsInstall(availability ProviderAvailability) bool {
 		return false
 	}
 	switch strings.TrimSpace(availability.LastError.Code) {
-	case "cli_not_found", "acp_adapter_not_found":
+	case "cli_not_found", "acp_adapter_not_found", agentstatusservice.ReasonClaudeSDKSidecarUnavailable, agentstatusservice.ReasonManagedRuntimeUnavailable:
 		return true
 	default:
 		return false
@@ -297,7 +311,7 @@ func providerAvailabilityErrorMessage(status agentstatusservice.ProviderStatus) 
 			return "CLI binary not found"
 		}
 		if !status.Adapter.Installed {
-			return "ACP adapter not found"
+			return providerAvailabilityAdapterDetail(status)
 		}
 		return "provider is not installed"
 	case agentstatusservice.AvailabilityAuthRequired:

--- a/services/tuttid/service/agent/provider_availability_test.go
+++ b/services/tuttid/service/agent/provider_availability_test.go
@@ -80,6 +80,45 @@ func TestServiceListProviderAvailabilityUsesAgentStatusSnapshot(t *testing.T) {
 	}
 }
 
+func TestServiceListProviderAvailabilityUsesClaudeSDKSidecarDetail(t *testing.T) {
+	capturedAt := time.Unix(10, 0).UTC()
+	lister := &fakeAgentProviderStatusLister{
+		snapshot: agentstatusservice.Snapshot{
+			CapturedAt: capturedAt,
+			Providers: []agentstatusservice.ProviderStatus{{
+				Provider: "claude-code",
+				Availability: agentstatusservice.Availability{
+					CheckedAt:  &capturedAt,
+					ReasonCode: agentstatusservice.ReasonClaudeSDKSidecarUnavailable,
+					Status:     agentstatusservice.AvailabilityNotInstalled,
+				},
+				CLI: agentstatusservice.CLIStatus{
+					Installed:  true,
+					BinaryPath: "/usr/local/bin/claude",
+				},
+				Adapter: agentstatusservice.AdapterStatus{Installed: false},
+				Auth:    agentstatusservice.AuthInfo{Status: agentstatusservice.AuthAuthenticated},
+			}},
+		},
+	}
+	service := NewService(newFakeRuntime())
+	service.AvailabilityChecker = AgentStatusProviderAvailabilityChecker{Service: lister}
+
+	availability, err := service.ListProviderAvailability(context.Background(), ProviderAvailabilityInput{
+		Provider: "claude-code",
+	})
+	if err != nil {
+		t.Fatalf("ListProviderAvailability returned error: %v", err)
+	}
+	got := availability[0]
+	if got.LastError == nil || got.LastError.Message != "Claude SDK sidecar not found" {
+		t.Fatalf("lastError = %#v, want SDK sidecar message", got.LastError)
+	}
+	if len(got.Checks) < 2 || got.Checks[1].Detail != "Claude SDK sidecar not found" {
+		t.Fatalf("checks = %#v, want SDK sidecar adapter detail", got.Checks)
+	}
+}
+
 func TestServiceListProviderAvailabilityUsesShortCache(t *testing.T) {
 	capturedAt := time.Unix(10, 0).UTC()
 	lister := &fakeAgentProviderStatusLister{

--- a/services/tuttid/service/agentstatus/installer.go
+++ b/services/tuttid/service/agentstatus/installer.go
@@ -45,7 +45,7 @@ func (s Service) resolveProviderRuntime(ctx context.Context, spec ProviderSpec) 
 	if strings.TrimSpace(spec.ExternalRegistryID) != "" {
 		return s.resolveExternalProviderRuntime(ctx, spec, resolver, env)
 	}
-	adapterPath := resolveBinaryWithResolver(resolver, adapterBinaryNames(spec), nil)
+	adapterPath := resolveBinaryWithResolver(resolver, adapterBinaryNames(spec), spec.AdapterEnv)
 	return providerRuntimeResolution{
 		CLIPath:        resolveBinaryWithResolver(resolver, spec.BinaryNames, nil),
 		AdapterPath:    adapterPath,

--- a/services/tuttid/service/agentstatus/npm_registry_test.go
+++ b/services/tuttid/service/agentstatus/npm_registry_test.go
@@ -112,6 +112,8 @@ func TestRunExternalAgentRegistryNPMInstallerReplacesExistingRegistryEnv(t *test
 }
 
 func TestResolveExternalRegistryNPMSpecExecEnvUsesRankedRegistry(t *testing.T) {
+	forceClaudeACPRuntime(t)
+
 	home := t.TempDir()
 	registryStore, prefixDir := fakeClaudeExternalRegistry(t)
 	runtimeRoot := fakeManagedRuntimeRoot(t)
@@ -184,6 +186,8 @@ func TestRunExternalAgentRegistryNPMInstallerPinsDedicatedCache(t *testing.T) {
 }
 
 func TestResolveExternalRegistryNPMSpecExecEnvPinsDedicatedCache(t *testing.T) {
+	forceClaudeACPRuntime(t)
+
 	home := t.TempDir()
 	registryStore, prefixDir := fakeClaudeExternalRegistry(t)
 	runtimeRoot := fakeManagedRuntimeRoot(t)

--- a/services/tuttid/service/agentstatus/provider_resolution.go
+++ b/services/tuttid/service/agentstatus/provider_resolution.go
@@ -17,6 +17,14 @@ import (
 
 const ReasonExternalAgentRegistryUnavailable = "external_agent_registry_unavailable"
 const ReasonManagedRuntimeUnavailable = "managed_runtime_unavailable"
+const ReasonClaudeSDKSidecarUnavailable = "claude_sdk_sidecar_unavailable"
+
+const claudeCodeRuntimeEnv = "TUTTI_CLAUDE_CODE_RUNTIME"
+const claudeCodeRuntimeACP = "acp"
+const claudeCodeRuntimeSDK = "sdk"
+const claudeSDKSidecarCommandEnv = "TUTTI_CLAUDE_SDK_SIDECAR_COMMAND"
+const claudeSDKSidecarEntryPathEnv = "TUTTI_CLAUDE_SDK_SIDECAR_ENTRY_PATH"
+const claudeSDKSidecarDefaultNodeArg = "--experimental-strip-types"
 
 type ProviderCommandResolution struct {
 	Command []string
@@ -59,6 +67,9 @@ func (s Service) ResolveProviderCommand(ctx context.Context, provider string) (P
 }
 
 func (s Service) resolveProviderSpec(ctx context.Context, spec ProviderSpec, requireManagedRuntime bool) (ProviderSpec, error) {
+	if spec.Provider == agentprovider.ClaudeCode {
+		spec = s.resolveClaudeCodeRuntimeSpec(ctx, spec, requireManagedRuntime)
+	}
 	if strings.TrimSpace(spec.ExternalRegistryID) == "" {
 		return s.resolveStaticProviderSpec(ctx, spec, requireManagedRuntime), nil
 	}
@@ -75,6 +86,113 @@ func (s Service) resolveProviderSpec(ctx context.Context, spec ProviderSpec, req
 	}
 	spec.AdapterUnavailableReasonCode = "external_agent_registry_distribution_unavailable"
 	return spec, nil
+}
+
+func (s Service) resolveClaudeCodeRuntimeSpec(ctx context.Context, spec ProviderSpec, requireManagedRuntime bool) ProviderSpec {
+	if claudeCodeAgentStatusRuntime() == claudeCodeRuntimeACP {
+		return claudeCodeACPProviderSpec(spec)
+	}
+	return s.resolveClaudeCodeSDKProviderSpec(ctx, spec, requireManagedRuntime)
+}
+
+func claudeCodeAgentStatusRuntime() string {
+	runtime := strings.TrimSpace(os.Getenv(claudeCodeRuntimeEnv))
+	if strings.EqualFold(runtime, claudeCodeRuntimeACP) {
+		return claudeCodeRuntimeACP
+	}
+	return claudeCodeRuntimeSDK
+}
+
+func claudeCodeACPProviderSpec(spec ProviderSpec) ProviderSpec {
+	spec.ExternalRegistryID = firstNonBlank(spec.ExternalRegistryID, "claude-acp")
+	if spec.AdapterInstall.Kind == "" {
+		spec.AdapterInstall.Kind = InstallerKindExternalAgentRegistryNPM
+	}
+	spec.AdapterInstall.DisplayCommand = firstNonBlank(
+		spec.AdapterInstall.DisplayCommand,
+		"Install claude-acp from ACP External Agent Registry",
+	)
+	if spec.AdapterInstall.PostInstall == InstallerPostStepNone {
+		spec.AdapterInstall.PostInstall = InstallerPostStepPatchClaudeAgentACP
+	}
+	return spec
+}
+
+func (s Service) resolveClaudeCodeSDKProviderSpec(ctx context.Context, spec ProviderSpec, requireManagedRuntime bool) ProviderSpec {
+	spec.ExternalRegistryID = ""
+	spec.AdapterPackage = AdapterPackageRequirement{}
+	spec.AdapterInstall = InstallerSpec{}
+	spec.AdapterUnavailableReasonCode = ""
+
+	if command := strings.TrimSpace(os.Getenv(claudeSDKSidecarCommandEnv)); command != "" {
+		spec.AdapterCommand = strings.Fields(command)
+		if len(spec.AdapterCommand) > 0 {
+			spec.AdapterBinaryNames = []string{spec.AdapterCommand[0]}
+		}
+		return spec
+	}
+
+	entry := s.resolveClaudeSDKSidecarEntryPath()
+	if entry == "" {
+		spec.AdapterCommand = nil
+		spec.AdapterBinaryNames = []string{"tutti-claude-sdk-sidecar-missing"}
+		spec.AdapterUnavailableReasonCode = ReasonClaudeSDKSidecarUnavailable
+		return spec
+	}
+
+	nodeBinary := nodeBinaryName()
+	nodeCommand := nodeBinary
+	if appRuntime, ok := s.resolveManagedNodeRuntimeForProvider(ctx, requireManagedRuntime); ok {
+		spec.AdapterEnv = append(s.managedRuntimeAdapterEnv(appRuntime), spec.AdapterEnv...)
+		nodeCommand = appRuntime.Node
+	} else if requireManagedRuntime {
+		spec.AdapterUnavailableReasonCode = ReasonManagedRuntimeUnavailable
+	}
+	spec.AdapterCommand = []string{nodeCommand, claudeSDKSidecarDefaultNodeArg, entry}
+	spec.AdapterBinaryNames = []string{nodeBinary}
+	return spec
+}
+
+func (s Service) resolveClaudeSDKSidecarEntryPath() string {
+	env := s.commandResolver().Env(nil)
+	if entry := strings.TrimSpace(managedruntime.EnvValue(env, claudeSDKSidecarEntryPathEnv)); entry != "" {
+		if s.fileExists(entry) {
+			return entry
+		}
+		return ""
+	}
+	root := findClaudeSDKRepoRoot()
+	if root == "" {
+		return ""
+	}
+	entry := filepath.Join(root, "packages/agent/claude-sdk-sidecar/src/main.ts")
+	if s.fileExists(entry) {
+		return entry
+	}
+	return ""
+}
+
+func findClaudeSDKRepoRoot() string {
+	dir, err := os.Getwd()
+	if err != nil {
+		return ""
+	}
+	for {
+		if fileExistsPath(filepath.Join(dir, "pnpm-workspace.yaml")) &&
+			fileExistsPath(filepath.Join(dir, "packages/agent/claude-sdk-sidecar/src/main.ts")) {
+			return dir
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			return ""
+		}
+		dir = parent
+	}
+}
+
+func fileExistsPath(path string) bool {
+	info, err := os.Stat(path)
+	return err == nil && !info.IsDir()
 }
 
 func (s Service) resolveStaticProviderSpec(ctx context.Context, spec ProviderSpec, requireManagedRuntime bool) ProviderSpec {

--- a/services/tuttid/service/agentstatus/registry.go
+++ b/services/tuttid/service/agentstatus/registry.go
@@ -83,22 +83,15 @@ func (r Registry) Select(providers []string) ([]ProviderSpec, error) {
 func DefaultRegistry() Registry {
 	specsByProvider := map[string]ProviderSpec{
 		agentprovider.ClaudeCode: {
-			Provider:           agentprovider.ClaudeCode,
-			BinaryNames:        []string{"claude"},
-			ExternalRegistryID: "claude-acp",
-			AuthStatusCommand:  []string{"auth", "status"},
-			AuthMarkerPaths:    []string{"~/.claude.json", "~/.claude/auth.json"},
+			Provider:          agentprovider.ClaudeCode,
+			BinaryNames:       []string{"claude"},
+			AuthStatusCommand: []string{"auth", "status"},
+			AuthMarkerPaths:   []string{"~/.claude.json", "~/.claude/auth.json"},
 			Install: InstallerSpec{
 				Kind:           InstallerKindOfficialScript,
 				DisplayCommand: "curl -fsSL https://claude.ai/install.sh | bash",
 				ScriptURL:      "https://claude.ai/install.sh",
 				ScriptShell:    "bash",
-			},
-			AdapterInstall: InstallerSpec{
-				Kind:           InstallerKindExternalAgentRegistryNPM,
-				DisplayCommand: "Install claude-acp from ACP External Agent Registry",
-				// Auto-apply the fast-mode bridge patch after a successful install.
-				PostInstall: InstallerPostStepPatchClaudeAgentACP,
 			},
 			LoginArgs: []string{"auth", "login"},
 		},

--- a/services/tuttid/service/agentstatus/service.go
+++ b/services/tuttid/service/agentstatus/service.go
@@ -754,6 +754,8 @@ func agentProviderProbeAdapterUnavailableMessage(reasonCode string) string {
 		return "ACP external agent registry is unavailable"
 	case ReasonManagedRuntimeUnavailable:
 		return "Managed Node runtime is unavailable"
+	case ReasonClaudeSDKSidecarUnavailable:
+		return "Claude SDK sidecar not found"
 	default:
 		return "ACP adapter not found"
 	}

--- a/services/tuttid/service/agentstatus/service_test.go
+++ b/services/tuttid/service/agentstatus/service_test.go
@@ -659,6 +659,8 @@ func TestServiceListReportsInstallActionWhenCodexAdapterCommandFails(t *testing.
 }
 
 func TestServiceListIgnoresStaleGlobalClaudeACPAdapter(t *testing.T) {
+	forceClaudeACPRuntime(t)
+
 	home := t.TempDir()
 	binDir := filepath.Join(home, ".nvm", "versions", "node", "v24.12.0", "bin")
 	if err := os.MkdirAll(binDir, 0o755); err != nil {
@@ -722,6 +724,8 @@ func TestServiceListIgnoresStaleGlobalClaudeACPAdapter(t *testing.T) {
 }
 
 func TestServiceListReportsInstallActionWhenExternalAdapterCommandFails(t *testing.T) {
+	forceClaudeACPRuntime(t)
+
 	home := t.TempDir()
 	binDir := filepath.Join(home, ".local", "bin")
 	claudePath := filepath.Join(binDir, "claude")
@@ -786,6 +790,8 @@ func TestServiceListReportsInstallActionWhenExternalAdapterCommandFails(t *testi
 }
 
 func TestServiceListExternalAdapterCommandUsesRankedRegistry(t *testing.T) {
+	forceClaudeACPRuntime(t)
+
 	home := t.TempDir()
 	binDir := filepath.Join(home, ".local", "bin")
 	claudePath := filepath.Join(binDir, "claude")
@@ -847,6 +853,8 @@ func TestServiceListExternalAdapterCommandUsesRankedRegistry(t *testing.T) {
 }
 
 func TestServiceListReportsInstallActionWhenExternalAdapterCommandFailsAfterReadyWindow(t *testing.T) {
+	forceClaudeACPRuntime(t)
+
 	home := t.TempDir()
 	binDir := filepath.Join(home, ".local", "bin")
 	claudePath := filepath.Join(binDir, "claude")
@@ -1378,11 +1386,21 @@ func TestServiceRunCodexInstallerReportsManagedNPMActiveAction(t *testing.T) {
 func TestServiceRunActionReportsActiveActionForClaudeInstall(t *testing.T) {
 	home := t.TempDir()
 	binDir := filepath.Join(home, "bin")
-	service := probeTestService(home)
-	service.Environ = func() []string {
-		return []string{"PATH=" + binDir}
+	entry := filepath.Join(home, "claude-sdk-sidecar", "src", "main.ts")
+	if err := os.MkdirAll(filepath.Dir(entry), 0o755); err != nil {
+		t.Fatalf("mkdir sidecar entry dir: %v", err)
 	}
-	service.IsExecutableFile = isTestExecutableUnderHome(home)
+	if err := os.WriteFile(entry, []byte("export {};"), 0o644); err != nil {
+		t.Fatalf("write sidecar entry: %v", err)
+	}
+	runtimeRoot := fakeManagedRuntimeRoot(t)
+	service := probeTestService(home)
+	service.FileExists = fileExistsForTest
+	service.Environ = func() []string {
+		return []string{"PATH=" + binDir, claudeSDKSidecarEntryPathEnv + "=" + entry}
+	}
+	service.IsExecutableFile = isTestExecutable
+	service.ManagedRuntime = fakeManagedRuntimeResolver(t, runtimeRoot)
 	service.Registry = Registry{Specs: []ProviderSpec{{
 		Provider:       "claude-code",
 		BinaryNames:    []string{"claude-test"},
@@ -1574,6 +1592,8 @@ func TestServiceRunActionReportsInstallTimeouts(t *testing.T) {
 }
 
 func TestServiceRunActionUpgradesStaleClaudeACPAdapter(t *testing.T) {
+	forceClaudeACPRuntime(t)
+
 	home := t.TempDir()
 	binDir := filepath.Join(home, ".nvm", "versions", "node", "v24.12.0", "bin")
 	if err := os.MkdirAll(binDir, 0o755); err != nil {
@@ -1634,6 +1654,7 @@ func TestServiceRunActionUpgradesStaleClaudeACPAdapter(t *testing.T) {
 }
 
 func TestServiceRunActionSerializesConcurrentExternalRegistryNPMInstalls(t *testing.T) {
+	forceClaudeACPRuntime(t)
 	t.Setenv("TUTTI_STATE_DIR", t.TempDir())
 
 	home := t.TempDir()
@@ -1741,6 +1762,8 @@ func TestServiceRunActionSerializesConcurrentExternalRegistryNPMInstalls(t *test
 }
 
 func TestServiceResolveProviderCommandCreatesExternalRegistryNPMPrefix(t *testing.T) {
+	forceClaudeACPRuntime(t)
+
 	home := t.TempDir()
 	registryStore, prefixDir := fakeClaudeExternalRegistry(t)
 	runtimeRoot := fakeManagedRuntimeRoot(t)
@@ -1768,6 +1791,8 @@ func TestServiceResolveProviderCommandCreatesExternalRegistryNPMPrefix(t *testin
 }
 
 func TestServiceResolveProviderCommandUsesInstalledExternalRegistryNPMBin(t *testing.T) {
+	forceClaudeACPRuntime(t)
+
 	home := t.TempDir()
 	registryStore, prefixDir := fakeClaudeExternalRegistry(t)
 	runtimeRoot := fakeManagedRuntimeRoot(t)
@@ -1800,6 +1825,132 @@ func TestServiceResolveProviderCommandUsesInstalledExternalRegistryNPMBin(t *tes
 	}
 	if slices.Contains(result.Command, "exec") {
 		t.Fatalf("Command = %#v, want installed bin without npm exec", result.Command)
+	}
+}
+
+func TestServiceResolveProviderCommandDefaultsClaudeCodeToSDKSidecar(t *testing.T) {
+	t.Setenv(claudeCodeRuntimeEnv, "")
+
+	home := t.TempDir()
+	entry := filepath.Join(home, "claude-sdk-sidecar", "src", "main.ts")
+	if err := os.MkdirAll(filepath.Dir(entry), 0o755); err != nil {
+		t.Fatalf("mkdir sidecar entry dir: %v", err)
+	}
+	if err := os.WriteFile(entry, []byte("export {};"), 0o644); err != nil {
+		t.Fatalf("write sidecar entry: %v", err)
+	}
+	runtimeRoot := fakeManagedRuntimeRoot(t)
+	service := probeTestService(home)
+	service.FileExists = fileExistsForTest
+	service.Environ = func() []string {
+		return []string{"PATH=/usr/bin:/bin", claudeSDKSidecarEntryPathEnv + "=" + entry}
+	}
+	service.ExternalAgentRegistry = externalagentregistry.Store{
+		SourceURL: filepath.Join(home, "missing-registry.json"),
+	}
+	service.ManagedRuntime = fakeManagedRuntimeResolver(t, runtimeRoot)
+
+	result, err := service.ResolveProviderCommand(context.Background(), "claude-code")
+	if err != nil {
+		t.Fatalf("ResolveProviderCommand() error = %v", err)
+	}
+	managedNode := filepath.Join(runtimeRoot, "node", "bin", nodeBinaryNameForTest())
+	if !slices.Equal(result.Command, []string{managedNode, claudeSDKSidecarDefaultNodeArg, entry}) {
+		t.Fatalf("Command = %#v, want SDK sidecar command", result.Command)
+	}
+	if slices.Contains(result.Command, "exec") || slices.Contains(result.Command, "@agentclientprotocol/claude-agent-acp") {
+		t.Fatalf("Command = %#v, must not use ACP registry package in SDK mode", result.Command)
+	}
+}
+
+func TestServiceListClaudeCodeSDKDoesNotRequireACPAdapter(t *testing.T) {
+	t.Setenv(claudeCodeRuntimeEnv, "")
+
+	home := t.TempDir()
+	binDir := filepath.Join(home, "bin")
+	claudePath := filepath.Join(binDir, "claude")
+	writeExecutable(t, claudePath, "#!/bin/sh\nexit 0\n")
+	entry := filepath.Join(home, "claude-sdk-sidecar", "src", "main.ts")
+	if err := os.MkdirAll(filepath.Dir(entry), 0o755); err != nil {
+		t.Fatalf("mkdir sidecar entry dir: %v", err)
+	}
+	if err := os.WriteFile(entry, []byte("export {};"), 0o644); err != nil {
+		t.Fatalf("write sidecar entry: %v", err)
+	}
+	runtimeRoot := fakeManagedRuntimeRoot(t)
+	service := probeTestService(home)
+	service.FileExists = fileExistsForTest
+	service.Environ = func() []string {
+		return []string{"PATH=" + binDir, claudeSDKSidecarEntryPathEnv + "=" + entry}
+	}
+	service.LookPath = func(name string) (string, error) {
+		if name == "claude" {
+			return claudePath, nil
+		}
+		return "", errors.New("not found")
+	}
+	service.IsExecutableFile = isTestExecutable
+	service.ManagedRuntime = fakeManagedRuntimeResolver(t, runtimeRoot)
+	service.RunAuthStatusCommand = func(context.Context, ProviderSpec, string) (AuthInfo, bool) {
+		return AuthInfo{Status: AuthAuthenticated}, true
+	}
+	service.ExternalAgentRegistry = externalagentregistry.Store{
+		SourceURL: filepath.Join(home, "missing-registry.json"),
+	}
+
+	snapshot, err := service.List(context.Background(), ListInput{Providers: []string{"claude-code"}})
+	if err != nil {
+		t.Fatalf("List() error = %v", err)
+	}
+	status := onlyStatus(t, snapshot)
+	if status.Availability.Status != AvailabilityReady {
+		t.Fatalf("Availability.Status = %q, want ready; reason=%q", status.Availability.Status, status.Availability.ReasonCode)
+	}
+	if strings.HasPrefix(status.Availability.ReasonCode, "acp_adapter") {
+		t.Fatalf("ReasonCode = %q, must not report ACP adapter in SDK mode", status.Availability.ReasonCode)
+	}
+	if !status.Adapter.Installed {
+		t.Fatalf("Adapter.Installed = false, want SDK sidecar runtime installed; status=%#v", status)
+	}
+	if strings.Contains(strings.Join(status.Adapter.Command, " "), "claude-agent-acp") {
+		t.Fatalf("Adapter.Command = %#v, must not use ACP adapter", status.Adapter.Command)
+	}
+}
+
+func TestServiceListClaudeCodeSDKReportsMissingSidecarEntry(t *testing.T) {
+	t.Setenv(claudeCodeRuntimeEnv, "")
+
+	home := t.TempDir()
+	binDir := filepath.Join(home, "bin")
+	claudePath := filepath.Join(binDir, "claude")
+	writeExecutable(t, claudePath, "#!/bin/sh\nexit 0\n")
+	service := probeTestService(home)
+	service.Environ = func() []string {
+		return []string{"PATH=" + binDir, claudeSDKSidecarEntryPathEnv + "=" + filepath.Join(home, "missing-main.ts")}
+	}
+	service.LookPath = func(name string) (string, error) {
+		if name == "claude" {
+			return claudePath, nil
+		}
+		return "", errors.New("not found")
+	}
+	service.RunAuthStatusCommand = func(context.Context, ProviderSpec, string) (AuthInfo, bool) {
+		return AuthInfo{Status: AuthAuthenticated}, true
+	}
+
+	snapshot, err := service.List(context.Background(), ListInput{Providers: []string{"claude-code"}})
+	if err != nil {
+		t.Fatalf("List() error = %v", err)
+	}
+	status := onlyStatus(t, snapshot)
+	if status.Availability.Status != AvailabilityNotInstalled {
+		t.Fatalf("Availability.Status = %q, want not_installed", status.Availability.Status)
+	}
+	if status.Availability.ReasonCode != ReasonClaudeSDKSidecarUnavailable {
+		t.Fatalf("ReasonCode = %q, want %q", status.Availability.ReasonCode, ReasonClaudeSDKSidecarUnavailable)
+	}
+	if status.Adapter.Installed {
+		t.Fatal("Adapter.Installed = true, want false when SDK sidecar entry is missing")
 	}
 }
 
@@ -2864,6 +3015,11 @@ func firstAction(t *testing.T, actions []Action) Action {
 	return actions[0]
 }
 
+func forceClaudeACPRuntime(t *testing.T) {
+	t.Helper()
+	t.Setenv(claudeCodeRuntimeEnv, claudeCodeRuntimeACP)
+}
+
 func assertProviderCheck(t *testing.T, checks []ProviderCheck, name string, passed bool) {
 	t.Helper()
 	for _, check := range checks {
@@ -2880,6 +3036,11 @@ func assertProviderCheck(t *testing.T, checks []ProviderCheck, name string, pass
 func isTestExecutable(path string) bool {
 	stat, err := os.Stat(path)
 	return err == nil && !stat.IsDir() && stat.Mode().Perm()&0111 != 0
+}
+
+func fileExistsForTest(path string) bool {
+	stat, err := os.Stat(path)
+	return err == nil && !stat.IsDir()
 }
 
 func isTestExecutableUnderHome(home string) func(string) bool {


### PR DESCRIPTION
## Summary

- default Claude Code provider detection to the SDK sidecar path and only require `claude-acp` when `TUTTI_CLAUDE_CODE_RUNTIME=acp`
- surface SDK sidecar / managed Node availability reasons through tuttid provider availability and desktop refresh handling
- preserve nested Claude SDK sidecar task turn attribution so grandchild tasks and approvals do not become turnless
- document the SDK-vs-ACP runtime override and legacy ACP troubleshooting path

## Verification

- `pnpm --filter @tutti-os/claude-sdk-sidecar test`
- `go test ./packages/agent/daemon/runtime`
- `go test ./services/tuttid/service/agentstatus`
- `go test -count=1 ./services/tuttid/service/agent`
- `pnpm --filter @tutti-os/desktop test -- desktopAgentProviderStatusSync.test.ts`
- `pnpm check:full` (via pre-push)

## Checklist

- [x] I kept the change focused on one concern.
- [x] I updated documentation when behavior, setup, or contributor workflow changed.
- [x] I updated all README/CONTRIBUTING language variants when changing their English source.
- [x] I ran the lowest meaningful local checks for the changed surface.
- [x] My commits are signed off with DCO when required: `git commit -s`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Claude Code can now use the SDK sidecar runtime, with improved detection of the available runtime and adapter path.
  * Nested agent tasks and approval flows are handled more reliably, including better turn tracking for interactive events.

* **Bug Fixes**
  * Provider status now refreshes correctly for additional workspace errors when the sidecar or managed runtime is unavailable.
  * Claude Code availability messages now more accurately explain whether the sidecar or adapter is missing.

* **Documentation**
  * Expanded runtime and troubleshooting guidance for Claude Code and nested approval scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->