### PR TITLE
fix(agent-gui): keep processing row visible while turn lifecycle is running

### DIFF
--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUINodeController.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUINodeController.ts
@@ -9162,6 +9162,10 @@ export function useAgentGUINodeController({
         return null;
       }
       const previous = projectionConversationRef.current;
+      const turnLifecycle =
+        activeSessionState?.agentSessionId === activeConversation.id
+          ? (activeSessionState.turnLifecycle ?? null)
+          : null;
       if (
         previous &&
         previous.id === activeConversation.id &&
@@ -9170,7 +9174,13 @@ export function useAgentGUINodeController({
         previous.title === activeConversation.title &&
         previous.titleFallback === activeConversation.titleFallback &&
         previous.status === activeConversation.status &&
-        previous.cwd === activeConversation.cwd
+        previous.cwd === activeConversation.cwd &&
+        (previous.turnLifecycle?.activeTurnId ?? null) ===
+          (turnLifecycle?.activeTurnId ?? null) &&
+        (previous.turnLifecycle?.phase ?? null) ===
+          (turnLifecycle?.phase ?? null) &&
+        (previous.turnLifecycle?.settling ?? false) ===
+          (turnLifecycle?.settling ?? false)
       ) {
         return previous;
       }
@@ -9184,7 +9194,8 @@ export function useAgentGUINodeController({
             status: activeConversation.status,
             cwd: activeConversation.cwd,
             updatedAtUnixMs: activeConversation.updatedAtUnixMs,
-            syncState: activeConversation.syncState
+            syncState: activeConversation.syncState,
+            turnLifecycle
           }
         : null;
       projectionConversationRef.current = next;
@@ -9198,7 +9209,11 @@ export function useAgentGUINodeController({
       activeConversation?.status,
       activeConversation?.title,
       activeConversation?.titleFallback,
-      activeConversation?.userId
+      activeConversation?.userId,
+      activeSessionState?.agentSessionId,
+      activeSessionState?.turnLifecycle?.activeTurnId,
+      activeSessionState?.turnLifecycle?.phase,
+      activeSessionState?.turnLifecycle?.settling
     ]);
   const draftContent = activeConversationId
     ? (draftBySessionId[activeConversationId] ?? EMPTY_AGENT_COMPOSER_DRAFT)

--- a/packages/agent/gui/agent-gui/agentGuiNode/model/agentGuiConversationModel.spec.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/model/agentGuiConversationModel.spec.ts
@@ -909,6 +909,64 @@ describe("agentGuiConversationModel", () => {
     ]);
   });
 
+  it("keeps the processing row after an interim assistant message while the turn lifecycle is running", () => {
+    const interimTimelineItems = [
+      timelineItem({
+        id: 1,
+        eventId: "user-1",
+        turnId: "turn-1",
+        actorType: "user",
+        actorId: "user-1",
+        itemType: "message.user",
+        role: "user",
+        content: "Dispatch the sub-agents",
+        occurredAtUnixMs: 10
+      }),
+      timelineItem({
+        id: 2,
+        eventId: "assistant-1",
+        turnId: "turn-1",
+        actorType: "agent",
+        actorId: "codex",
+        itemType: "message.assistant",
+        role: "assistant",
+        content: "I will now dispatch the sub-agents.",
+        status: "completed",
+        occurredAtUnixMs: 20
+      })
+    ];
+    const conversationSource = {
+      id: "session-1",
+      provider: "codex" as const,
+      title: "Codex",
+      titleFallback: null,
+      status: "working" as const,
+      cwd: "/workspace",
+      updatedAtUnixMs: 20
+    };
+
+    const withRunningTurn = buildAgentGUIConversationVM({
+      conversation: {
+        ...conversationSource,
+        turnLifecycle: { activeTurnId: "turn-1", phase: "running" }
+      },
+      workspaceRoot: "/workspace",
+      timelineItems: interimTimelineItems
+    });
+    const withoutTurnLifecycle = buildAgentGUIConversationVM({
+      conversation: conversationSource,
+      workspaceRoot: "/workspace",
+      timelineItems: interimTimelineItems
+    });
+
+    expect(withRunningTurn?.rows.some((row) => row.kind === "processing")).toBe(
+      true
+    );
+    expect(
+      withoutTurnLifecycle?.rows.some((row) => row.kind === "processing")
+    ).toBe(false);
+  });
+
   it("derives pending approval from ACP call.started approval timeline items", () => {
     const conversation = buildAgentGUIConversationVM({
       conversation: {

--- a/packages/agent/gui/agent-gui/agentGuiNode/model/agentGuiConversationModel.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/model/agentGuiConversationModel.ts
@@ -101,7 +101,9 @@ export type AgentGUIConversationProjectionSource = Pick<
   | "sortTimeUnixMs"
   | "updatedAtUnixMs"
   | "syncState"
->;
+> & {
+  turnLifecycle?: WorkspaceAgentActivitySession["turnLifecycle"];
+};
 
 interface AgentGUIConversationProjectResolutionContext {
   projectResolver: AgentGUIConversationProjectResolver;
@@ -774,6 +776,7 @@ function timelineSessionFromItems(
     cwd: conversation?.cwd?.trim() ?? "",
     lifecycleStatus: sessionLifecycleStatus(conversation?.status ?? "ready"),
     turnPhase: conversation?.status === "working" ? "working" : "idle",
+    turnLifecycle: conversation?.turnLifecycle ?? null,
     effectiveStatus: conversation?.status ?? "ready",
     status: conversation?.status ?? "ready",
     title: conversation?.title,

--- a/packages/agent/gui/shared/agentConversation/projection/workspaceAgentTimelineProjection.spec.ts
+++ b/packages/agent/gui/shared/agentConversation/projection/workspaceAgentTimelineProjection.spec.ts
@@ -466,6 +466,100 @@ describe("projectWorkspaceAgentTimelineToConversationVM", () => {
       false
     );
   });
+
+  it("keeps processing after an interim assistant message while the turn lifecycle reports an active turn", () => {
+    const interimReplyTimelineItems: AgentHostWorkspaceAgentTimelineItem[] = [
+      timelineItems()[0]!,
+      {
+        id: 99,
+        workspaceId: "room-1",
+        agentSessionId: "session-1",
+        turnId: "turn-1",
+        seq: 99,
+        eventId: "event-99",
+        actorType: "agent",
+        actorId: "codex",
+        itemType: "message.assistant",
+        role: "assistant",
+        status: "completed",
+        content: "I will now dispatch the sub-agents.",
+        occurredAtUnixMs: 99,
+        createdAtUnixMs: 99
+      }
+    ];
+    const workingSession = {
+      ...session({
+        status: "working",
+        effectiveStatus: "working",
+        turnPhase: "working"
+      }),
+      turnLifecycle: {
+        activeTurnId: "turn-1",
+        phase: "running"
+      }
+    };
+
+    const detail = buildCanonicalWorkspaceAgentDetailView({
+      activity: activity(),
+      session: workingSession,
+      workspaceRoot: "/workspace/demo",
+      timelineItems: interimReplyTimelineItems
+    });
+    const conversation = projectWorkspaceAgentTimelineToConversationVM({
+      activity: activity(),
+      session: workingSession,
+      workspaceRoot: "/workspace/demo",
+      timelineItems: interimReplyTimelineItems
+    });
+
+    expect(detail.showProcessingIndicator).toBe(true);
+    expect(conversation.rows.some((row) => row.kind === "processing")).toBe(
+      true
+    );
+  });
+
+  it("does not append processing after a terminal assistant message once the turn lifecycle is settling", () => {
+    const settlingReplyTimelineItems: AgentHostWorkspaceAgentTimelineItem[] = [
+      timelineItems()[0]!,
+      {
+        id: 99,
+        workspaceId: "room-1",
+        agentSessionId: "session-1",
+        turnId: "turn-1",
+        seq: 99,
+        eventId: "event-99",
+        actorType: "agent",
+        actorId: "codex",
+        itemType: "message.assistant",
+        role: "assistant",
+        status: "completed",
+        content: "Done.",
+        occurredAtUnixMs: 99,
+        createdAtUnixMs: 99
+      }
+    ];
+    const settlingSession = {
+      ...session({
+        status: "working",
+        effectiveStatus: "working",
+        turnPhase: "working"
+      }),
+      turnLifecycle: {
+        activeTurnId: "turn-1",
+        phase: "running",
+        settling: true
+      }
+    };
+
+    const detail = buildCanonicalWorkspaceAgentDetailView({
+      activity: activity(),
+      session: settlingSession,
+      workspaceRoot: "/workspace/demo",
+      timelineItems: settlingReplyTimelineItems
+    });
+
+    expect(detail.showProcessingIndicator).toBe(false);
+  });
 });
 
 function activity(

--- a/packages/agent/gui/shared/workspaceAgentTimelineCanonical.ts
+++ b/packages/agent/gui/shared/workspaceAgentTimelineCanonical.ts
@@ -1017,13 +1017,30 @@ function shouldShowProcessingIndicator(
   const lastAgentItem = lastTurn.agentItems.at(-1);
   if (
     lastAgentItem?.kind === "message" &&
-    isTerminalAgentMessageStatus(lastAgentItem.message.statusKind)
+    isTerminalAgentMessageStatus(lastAgentItem.message.statusKind) &&
+    !hasActiveRunningTurnLifecycle(session)
   ) {
     return false;
   }
   return !lastTurn.toolCalls.some(
     (call) => call.statusKind === "working" || call.statusKind === "waiting"
   );
+}
+
+// A completed assistant message usually means the turn is about to settle, so
+// the indicator is suppressed to avoid trailing dots after the final answer.
+// Providers can also emit completed interim messages mid-turn (e.g. codex
+// narration between tool phases); when the turn lifecycle still reports an
+// active, non-settling turn, keep the indicator visible.
+function hasActiveRunningTurnLifecycle(
+  session: BuildWorkspaceAgentSessionDetailInput["session"]
+): boolean {
+  const lifecycle = session.turnLifecycle;
+  if (!lifecycle?.activeTurnId || lifecycle.settling === true) {
+    return false;
+  }
+  const phase = lifecycle.phase?.trim().toLowerCase() ?? "";
+  return phase === "submitted" || phase === "running" || phase === "waiting";
 }
 
 function isTerminalAgentMessageStatus(


### PR DESCRIPTION
## Problem

While a codex turn is actively running, the transcript can show **no loading indicator for minutes** — the session is busy (composer locked with `active_turn`, stop button showing), but the area below the last assistant message is blank.

Reproduced from an exported log bundle (session `c601865e`, 2026-07-02): renderer `agent.gui.node.render_state_changed` diagnostics show `processingRowCount: 0` while `runtimeSession.turnPhase: running` continuously from 14:26:06Z to 14:29:11Z.

## Root cause

`shouldShowProcessingIndicator` in `packages/agent/gui/shared/workspaceAgentTimelineCanonical.ts` hides the processing row whenever the last agent item of the last turn is a **completed assistant message**. This is an anti-flicker heuristic for the case where the turn already ended but the session patch still says `working`.

Codex (GPT-5.5) emits completed **interim narration messages mid-turn**, then keeps working in collab/sub-agent threads that contribute no turn-level tool calls. The heuristic misreads that as "turn about to settle" and hides the indicator for the entire remainder of the turn. Measured from diagnostics, the flicker window this heuristic protects against is only ~100ms at real turn end.

## Fix

Trust the authoritative turn lifecycle instead of guessing from message shape:

- `workspaceAgentTimelineCanonical.ts`: only apply the terminal-message suppression when the session turn lifecycle does **not** report an active, non-settling turn (`activeTurnId` set, phase `submitted`/`running`/`waiting`, `settling !== true`).
- `agentGuiConversationModel.ts`: add `turnLifecycle` to `AgentGUIConversationProjectionSource` and pass it into the synthesized timeline session.
- `useAgentGUINodeController.ts`: feed `activeSessionState.turnLifecycle` into the projection source memo (with field-level stability comparison so summary-only patches stay cheap).

Sessions without lifecycle info (stale-patch protection scenario, other projection surfaces) keep the existing behavior.

## Tests

- `workspaceAgentTimelineProjection.spec.ts`: interim completed message + running lifecycle → indicator stays; settling lifecycle → hidden; existing stale-patch spec unchanged.
- `agentGuiConversationModel.spec.ts`: GUI-node path keeps the processing row with a running `turnLifecycle` and preserves old behavior without one.
- `pnpm typecheck`, `oxlint`, package suites (projection 12/12, shared 650/650, model 55/55, controller 198/198), and `check:full` all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the conversation “processing” indicator so it stays visible during active turns and disappears at the right time after a turn settles.
  * Processing rows now remain present for interim assistant messages when work is still in progress, reducing flicker and premature completion states.
  * Conversation updates now refresh more reliably when turn status changes, keeping the UI in sync with the latest activity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->