### PR TITLE
test(agent-gui): clean up noisy diagnostics

### DIFF
--- a/packages/agent/gui/agent-gui/agentGuiNode/AgentGUINode.spec.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/AgentGUINode.spec.tsx
@@ -2,11 +2,12 @@ import {
   fireEvent,
   render,
   screen,
+  act,
   waitFor,
   within
 } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { StrictMode, act } from "react";
+import { StrictMode } from "react";
 import type { WorkspaceAgentSessionDetailViewModel } from "../../shared/workspaceAgentSessionDetailViewModel";
 import type { AgentHostManagedAgentsState } from "../../shared/contracts/dto";
 import type { WorkspaceFileReferenceAdapter } from "@tutti-os/workspace-file-reference/contracts";
@@ -1691,10 +1692,12 @@ describe("AgentGUINode", () => {
     });
     expect(railResizeHandle).not.toHaveAttribute("aria-hidden", "true");
 
-    fireEvent.pointerDown(screen.getByTestId("agentGui-node-resizer-right"), {
-      clientX: 720,
-      clientY: 0,
-      pointerId: 1
+    await act(async () => {
+      fireEvent.pointerDown(screen.getByTestId("agentGui-node-resizer-right"), {
+        clientX: 720,
+        clientY: 0,
+        pointerId: 1
+      });
     });
     await act(async () => {
       window.dispatchEvent(
@@ -2343,7 +2346,7 @@ describe("AgentGUINode", () => {
     vi.useRealTimers();
   });
 
-  it("refreshes relative time labels every minute while the session list stays open", () => {
+  it("refreshes relative time labels every minute while the session list stays open", async () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date("2026-05-18T17:20:00Z"));
     mockViewModel = createViewModel({
@@ -2364,7 +2367,7 @@ describe("AgentGUINode", () => {
 
     expect(screen.getByText("刚刚")).toBeTruthy();
 
-    act(() => {
+    await act(async () => {
       vi.advanceTimersByTime(60_000);
     });
 

--- a/packages/agent/gui/agent-message-center/WorkspaceAgentMessageCenterPanel.tsx
+++ b/packages/agent/gui/agent-message-center/WorkspaceAgentMessageCenterPanel.tsx
@@ -13,6 +13,8 @@ import {
   cn,
   Drawer,
   DrawerContent,
+  DrawerDescription,
+  DrawerTitle,
   StatusDot,
   TooltipProvider
 } from "@tutti-os/ui-system";
@@ -543,12 +545,12 @@ function WorkspaceAgentMessageCenterPanelContent({
           <div className="flex-none border-b border-[var(--border-1)] px-3.5 pt-3 pb-3">
             <div className="flex min-w-0 items-center justify-between gap-3">
               <div className="min-w-0">
-                <div className="truncate text-[13px] font-semibold leading-5 text-[var(--text-primary)]">
+                <DrawerTitle className="truncate text-[13px] font-semibold leading-5 text-[var(--text-primary)]">
                   {t("agentHost.workspaceAgentMessageCenterTitle")}
-                </div>
-                <div className="truncate text-[11px] leading-4 text-[var(--text-tertiary)]">
+                </DrawerTitle>
+                <DrawerDescription className="truncate text-[11px] leading-4 text-[var(--text-tertiary)]">
                   {headerSummary}
-                </div>
+                </DrawerDescription>
               </div>
               <MessageCenterViewMenu
                 filtersActive={hasActiveFilters}

--- a/packages/agent/gui/vitest.setup.ts
+++ b/packages/agent/gui/vitest.setup.ts
@@ -1,6 +1,7 @@
 import "@testing-library/jest-dom/vitest";
 import { cleanup } from "@testing-library/react";
 import { createElement, isValidElement, cloneElement, useState } from "react";
+import { createPortal } from "react-dom";
 import type {
   MouseEvent as ReactMouseEvent,
   ReactElement,
@@ -16,6 +17,14 @@ import type {
   AgentHostRuntimeApi
 } from "./host/agentHostApi";
 import { installReactRenderLoopConsoleTrap } from "./test/reactRenderLoopConsoleTrap";
+
+const originalConsoleInfo = console.info.bind(console);
+console.info = (...args: unknown[]) => {
+  if (isSuppressedAgentGuiDiagnostic(args)) {
+    return;
+  }
+  originalConsoleInfo(...args);
+};
 
 class TestResizeObserver implements ResizeObserver {
   observe(): void {}
@@ -143,6 +152,18 @@ vi.mock("react-medium-image-zoom", () => ({
       },
       labelUnzoom
     );
+    const modal = isOpen
+      ? createPortal(
+          createElement(
+            "span",
+            { role: "dialog", className: classDialog, "data-rmiz-modal": "" },
+            ZoomContent
+              ? ZoomContent({ buttonUnzoom, img: modalImage, modalState })
+              : [modalImage, buttonUnzoom]
+          ),
+          document.body
+        )
+      : null;
 
     return createElement(
       "span",
@@ -166,15 +187,7 @@ vi.mock("react-medium-image-zoom", () => ({
           labelZoom
         )
       ),
-      isOpen
-        ? createElement(
-            "span",
-            { role: "dialog", className: classDialog, "data-rmiz-modal": "" },
-            ZoomContent
-              ? ZoomContent({ buttonUnzoom, img: modalImage, modalState })
-              : [modalImage, buttonUnzoom]
-          )
-        : null
+      modal
     );
   }
 }));
@@ -260,4 +273,12 @@ function installTestAgentHostApi(): void {
     }
   });
   setAgentHostApiForTests(testAgentHostApi);
+}
+
+function isSuppressedAgentGuiDiagnostic(args: readonly unknown[]): boolean {
+  const [prefix] = args;
+  return (
+    prefix === "[agent-gui] mention-lifecycle" ||
+    prefix === "[agent-gui] mention-search"
+  );
 }


### PR DESCRIPTION
## Summary

- suppress noisy AgentGUI mention lifecycle/search diagnostics in Vitest setup while preserving other `console.info` output
- make the `react-medium-image-zoom` test double render its modal via a body portal, matching modal behavior and avoiding invalid markdown `<p>` nesting warnings
- use Testing Library `act` for AgentGUINode interaction/timer tests
- expose the message center drawer's existing visible title/summary through `DrawerTitle` and `DrawerDescription` to satisfy dialog accessibility requirements

## Before / After

Latest `main` baseline for `@tutti-os/agent-gui` full Vitest run:

- `117` test files passed, `1911 passed | 1 skipped`
- `29.60s real`, max RSS `717,750,272`
- noisy output included mention lifecycle/search `console.info`, React act environment warnings, markdown DOM nesting warnings, and Radix/Vaul dialog title/description warnings

This branch:

- `117` test files passed, `1911 passed | 1 skipped`
- `31.91s real`, max RSS `758,120,448`
- targeted warning scan is clean for `mention-lifecycle`, `mention-search`, `not configured to support act`, `not wrapped in act`, `DialogContent requires`, `Missing Description`, and invalid `<p>` nesting warnings

## Validation

- `pnpm --filter @tutti-os/agent-gui typecheck`
- `/usr/bin/time -l pnpm --filter @tutti-os/agent-gui exec vitest run --environment jsdom --maxWorkers=3 --reporter=dot`
- `pnpm check:changed`
- pre-push `pnpm check:full`

## Docs

No durable documentation update required: this change does not alter ownership, public APIs, runtime configuration, or user-visible copy.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the reliability of conversation resizing and session time refresh behavior.
  * Updated the message center header structure for better accessibility and consistency.
* **Chores**
  * Cleaned up test environment behavior to reduce noisy diagnostic output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->