### PR TITLE
fix(desktop): allow claude sdk sidecar universal packaging

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -56,6 +56,7 @@
       "entitlements": "build/entitlements.mac.plist",
       "entitlementsInherit": "build/entitlements.mac.inherit.plist",
       "hardenedRuntime": true,
+      "x64ArchFiles": "Contents/Resources/bin/claude-sdk-sidecar/node_modules/@anthropic-ai/claude-agent-sdk-darwin-arm64/claude",
       "binaries": [
         "Contents/Resources/bin/tuttid",
         "Contents/Resources/bin/tutti"

--- a/tools/scripts/desktop-release-config.test.mjs
+++ b/tools/scripts/desktop-release-config.test.mjs
@@ -296,6 +296,10 @@ test("desktop macOS packaging builds architecture-specific and universal artifac
     /lipo\s+"\$\{output_path\}"\s+-verify_arch\s+arm64\s+x86_64\s+\|\|\s+\{/
   );
   assert.match(buildScript, /electron-builder --mac --x64 --arm64 --universal/);
+  assert.equal(
+    packageJson.build.mac.x64ArchFiles,
+    "Contents/Resources/bin/claude-sdk-sidecar/node_modules/@anthropic-ai/claude-agent-sdk-darwin-arm64/claude"
+  );
 });
 
 test("desktop release workflow opts JavaScript actions into Node 24", async () => {


### PR DESCRIPTION
## Summary

- allow the vendored Claude SDK sidecar darwin-arm64 binary during Electron universal macOS packaging
- add release config coverage so the universal packaging exception stays configured

## Verification

- `node --test tools/scripts/desktop-release-config.test.mjs`
- `pnpm --filter @tutti-os/desktop build:mac:unsigned`
- `pnpm check:full` (via pre-push)

## Checklist

- [x] I kept the change focused on one concern.
- [x] I updated documentation when behavior, setup, or contributor workflow changed.
- [x] I updated all README/CONTRIBUTING language variants when changing their English source.
- [x] I ran the lowest meaningful local checks for the changed surface.
- [x] My commits are signed off with DCO when required: `git commit -s`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved macOS packaging so the desktop app includes the correct bundled command-line component for Intel Macs.
  * Added coverage to ensure the macOS release package is built with the expected desktop resources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->