### PR TITLE
fix(desktop): repair universal release packaging

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -59,7 +59,8 @@
       "binaries": [
         "Contents/Resources/bin/tuttid",
         "Contents/Resources/bin/tutti"
-      ]
+      ],
+      "x64ArchFiles": "Contents/Resources/bin/claude-sdk-sidecar/node_modules/@anthropic-ai/claude-agent-sdk-darwin-*/claude"
     },
     "dmg": {
       "sign": true,

--- a/docs/conventions/desktop-release.md
+++ b/docs/conventions/desktop-release.md
@@ -87,6 +87,8 @@ apps/desktop/build/tuttid/
 
 For macOS packages, the bundled `tuttid` daemon and `tutti` CLI must be universal binaries. Build both `darwin/arm64` and `darwin/amd64`, merge them with `lipo`, and verify the resulting binary contains `arm64` and `x86_64` slices before packaging.
 
+Vendored Node runtimes that bring their own Mach-O binaries, such as `claude-sdk-sidecar`, must be compatible with Electron's universal merge. If the same packaged binary is copied into both the x64 and arm64 app bundles, cover that path with `build.mac.x64ArchFiles` so `@electron/universal` can skip `lipo` for the duplicate resource.
+
 `electron-builder` then packages that daemon into the desktop app as:
 
 ```text

--- a/tools/scripts/desktop-release-config.test.mjs
+++ b/tools/scripts/desktop-release-config.test.mjs
@@ -296,6 +296,11 @@ test("desktop macOS packaging builds architecture-specific and universal artifac
     /lipo\s+"\$\{output_path\}"\s+-verify_arch\s+arm64\s+x86_64\s+\|\|\s+\{/
   );
   assert.match(buildScript, /electron-builder --mac --x64 --arm64 --universal/);
+  assert.equal(
+    packageJson.build.mac.x64ArchFiles,
+    "Contents/Resources/bin/claude-sdk-sidecar/node_modules/@anthropic-ai/claude-agent-sdk-darwin-*/claude",
+    "Claude SDK sidecar arch-specific binary must be covered for electron-builder universal merges"
+  );
 });
 
 test("desktop release workflow opts JavaScript actions into Node 24", async () => {


### PR DESCRIPTION
## Summary
- add the Electron Builder universal merge exception for the vendored Claude SDK sidecar Mach-O binary
- cover the macOS release packaging config in the desktop release config test
- document the vendored Node runtime universal merge rule in desktop release conventions

## Validation
- node --test tools/scripts/desktop-release-config.test.mjs
- pnpm check:changed --tail-lines 80
- pnpm typecheck
- PATH="$PATH:$(go env GOPATH)/bin" pnpm lint:go
- PATH="$PATH:$(go env GOPATH)/bin" git push -u origin fix/desktop-release-universal-sidecar (pre-push ran pnpm check:full and passed)

## Notes
- Desktop Release runs #130 and #131 failed before publishing while @electron/universal merged macOS bundles; run #129 was a separate bad target_commitish checkout.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved macOS packaging so bundled sidecar components work correctly across both Intel and Apple Silicon builds.
  * Reduced the chance of packaging errors when combining app bundles into a universal macOS release.

* **Documentation**
  * Added guidance for packaging vendor-supplied binaries that need to stay compatible with universal macOS builds.

* **Tests**
  * Expanded packaging validation to cover the new macOS architecture-specific path handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->