### PR TITLE
[codex] Fix compact usage popover focus handling

### DIFF
--- a/packages/agent/gui/agent-gui/agentGuiNode/AgentComposer.spec.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/AgentComposer.spec.tsx
@@ -89,18 +89,81 @@ function createImageDataTransfer(file: File): DataTransfer {
   return createFileDataTransfer([file]);
 }
 
-vi.mock("../../app/renderer/components/ui/popover", () => ({
-  Popover: ({ children }: { children?: React.ReactNode }) => <>{children}</>,
-  PopoverAnchor: ({ children }: { children?: React.ReactNode }) => (
-    <div>{children}</div>
-  ),
-  PopoverTrigger: ({ children }: { children?: React.ReactNode }) => (
-    <>{children}</>
-  ),
-  PopoverContent: ({ children }: { children?: React.ReactNode }) => (
-    <div data-testid="agent-gui-usage-popover">{children}</div>
-  )
-}));
+async function openUsagePopoverByHover(usageChip: HTMLElement): Promise<void> {
+  vi.useFakeTimers();
+  fireEvent.pointerOver(usageChip, { pointerType: "mouse" });
+  await act(async () => {
+    await vi.advanceTimersByTimeAsync(120);
+  });
+}
+
+vi.mock("../../app/renderer/components/ui/popover", async () => {
+  const React = await import("react");
+  interface MockPopoverContextValue {
+    onOpenChange?: (open: boolean) => void;
+    open: boolean;
+  }
+  const MockPopoverContext = React.createContext<MockPopoverContextValue>({
+    open: false
+  });
+  type MockPopoverRootProps = {
+    children?: React.ReactNode;
+    onOpenChange?: (open: boolean) => void;
+    open?: boolean;
+  };
+  type MockPopoverTriggerProps = {
+    asChild?: boolean;
+    children?: React.ReactNode;
+  };
+  type MockPopoverContentProps = React.ComponentProps<"div"> & {
+    align?: string;
+    onOpenAutoFocus?: (event: Event) => void;
+    side?: string;
+  };
+  return {
+    Popover: ({
+      children,
+      onOpenChange,
+      open = false
+    }: MockPopoverRootProps) => (
+      <MockPopoverContext.Provider value={{ onOpenChange, open }}>
+        {children}
+      </MockPopoverContext.Provider>
+    ),
+    PopoverAnchor: ({ children }: { children?: React.ReactNode }) => (
+      <>{children}</>
+    ),
+    PopoverTrigger: ({ children }: MockPopoverTriggerProps) => {
+      const { onOpenChange, open } = React.useContext(MockPopoverContext);
+      if (React.isValidElement<React.HTMLAttributes<HTMLElement>>(children)) {
+        const existingOnClick = children.props.onClick;
+        return React.cloneElement(children, {
+          onClick: (event: React.MouseEvent<HTMLElement>) => {
+            existingOnClick?.(event);
+            onOpenChange?.(!open);
+          }
+        });
+      }
+      return <>{children}</>;
+    },
+    PopoverContent: React.forwardRef<HTMLDivElement, MockPopoverContentProps>(
+      (
+        {
+          align: _align,
+          children,
+          onOpenAutoFocus: _onOpenAutoFocus,
+          side: _side,
+          ...props
+        },
+        ref
+      ) => (
+        <div ref={ref} {...props}>
+          {children}
+        </div>
+      )
+    )
+  };
+});
 
 vi.mock("./agentRichText/AgentRichTextEditor", async () => {
   const React = await import("react");
@@ -2097,6 +2160,8 @@ describe("AgentComposer", () => {
       await vi.advanceTimersByTimeAsync(1);
     });
     expect(screen.getByTestId("agent-gui-usage-popover")).toBeVisible();
+    fireEvent.click(usageChip);
+    expect(screen.getByTestId("agent-gui-usage-popover")).toBeVisible();
     expect(screen.getByTestId("agent-gui-usage-popover")).toHaveTextContent(
       "上下文用量"
     );
@@ -2237,9 +2302,8 @@ describe("AgentComposer", () => {
       />
     );
 
-    // Open the usage popover before asserting/clicking the compact button
     const usageChip = screen.getByTestId("agent-gui-usage-chip");
-    fireEvent.click(usageChip);
+    await openUsagePopoverByHover(usageChip);
 
     const compactButton = screen.queryByTestId("agent-gui-compact-button");
     expect(compactButton).toBeInTheDocument();
@@ -2247,6 +2311,60 @@ describe("AgentComposer", () => {
     expect(compactButton).toHaveAttribute("data-size", "sm");
     expect(compactButton).toHaveClass("h-7");
     fireEvent.click(compactButton!);
+    expect(onSubmit).toHaveBeenCalledWith(textPromptContent("/compact"));
+  });
+
+  it("keeps the usage popover mounted when focus moves from the usage chip to the compact button", async () => {
+    const onSubmit = vi.fn();
+    render(
+      <AgentComposer
+        workspaceId="workspace-1"
+        currentUserId="user-1"
+        provider="codex"
+        usage={{ usedTokens: 50_000, totalTokens: 200_000, percentUsed: 25 }}
+        draftContent={createDraft("")}
+        availableCommands={[] satisfies readonly AgentHostAgentSessionCommand[]}
+        disabled={false}
+        submitDisabled={false}
+        placeholder="placeholder"
+        composerSettings={createComposerSettings()}
+        queuedPrompts={[]}
+        drainingQueuedPromptId={null}
+        canQueueWhileBusy={false}
+        showStopButton={false}
+        activePrompt={null}
+        isInterrupting={false}
+        isSendingTurn={false}
+        isSubmittingPrompt={false}
+        compactSupported={true}
+        hasCompactableContext={true}
+        labels={createLabels()}
+        workspaceUserProjectI18n={workspaceUserProjectI18n}
+        onDraftContentChange={vi.fn()}
+        onSettingsChange={vi.fn()}
+        onSubmit={onSubmit}
+        onSendQueuedPromptNext={vi.fn()}
+        onRemoveQueuedPrompt={vi.fn()}
+        onEditQueuedPrompt={vi.fn()}
+        onInterruptCurrentTurn={vi.fn()}
+        onSubmitInteractivePrompt={vi.fn()}
+      />
+    );
+
+    const usageChip = screen.getByTestId("agent-gui-usage-chip");
+    await openUsagePopoverByHover(usageChip);
+    fireEvent.focus(usageChip);
+    const compactButton = screen.getByTestId("agent-gui-compact-button");
+
+    fireEvent.pointerOut(usageChip, { pointerType: "mouse" });
+    fireEvent.blur(usageChip, { relatedTarget: compactButton });
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(140);
+    });
+
+    expect(screen.getByTestId("agent-gui-compact-button")).toBe(compactButton);
+    fireEvent.click(compactButton);
     expect(onSubmit).toHaveBeenCalledWith(textPromptContent("/compact"));
   });
 
@@ -2291,7 +2409,7 @@ describe("AgentComposer", () => {
     ).not.toBeInTheDocument();
   });
 
-  it("keeps the compact context button enabled while a session is running", () => {
+  it("keeps the compact context button enabled while a session is running", async () => {
     const onSubmit = vi.fn();
     render(
       <AgentComposer
@@ -2328,7 +2446,7 @@ describe("AgentComposer", () => {
       />
     );
 
-    fireEvent.click(screen.getByTestId("agent-gui-usage-chip"));
+    await openUsagePopoverByHover(screen.getByTestId("agent-gui-usage-chip"));
     const compactButton = screen.getByTestId("agent-gui-compact-button");
     expect(compactButton).toBeInTheDocument();
     expect(compactButton).not.toBeDisabled();
@@ -2336,7 +2454,7 @@ describe("AgentComposer", () => {
     expect(onSubmit).toHaveBeenCalledWith(textPromptContent("/compact"));
   });
 
-  it("shows the compact context button disabled when no user message has been sent", () => {
+  it("shows the compact context button disabled when no user message has been sent", async () => {
     const onSubmit = vi.fn();
     render(
       <AgentComposer
@@ -2373,14 +2491,14 @@ describe("AgentComposer", () => {
       />
     );
 
-    fireEvent.click(screen.getByTestId("agent-gui-usage-chip"));
+    await openUsagePopoverByHover(screen.getByTestId("agent-gui-usage-chip"));
     const compactButton = screen.getByTestId("agent-gui-compact-button");
     expect(compactButton).toBeDisabled();
     fireEvent.click(compactButton);
     expect(onSubmit).not.toHaveBeenCalled();
   });
 
-  it("shows the compact context button disabled when the composer is blocked (read-only)", () => {
+  it("shows the compact context button disabled when the composer is blocked (read-only)", async () => {
     const onSubmit = vi.fn();
     render(
       <AgentComposer
@@ -2417,7 +2535,7 @@ describe("AgentComposer", () => {
       />
     );
 
-    fireEvent.click(screen.getByTestId("agent-gui-usage-chip"));
+    await openUsagePopoverByHover(screen.getByTestId("agent-gui-usage-chip"));
     const compactButton = screen.getByTestId("agent-gui-compact-button");
     expect(compactButton).toBeDisabled();
     fireEvent.click(compactButton);

--- a/packages/agent/gui/agent-gui/agentGuiNode/AgentComposer.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/AgentComposer.tsx
@@ -6,6 +6,7 @@ import {
   useRef,
   useState,
   type CSSProperties,
+  type FocusEvent as ReactFocusEvent,
   type FormEvent
 } from "react";
 import { createPortal } from "react-dom";
@@ -22,8 +23,7 @@ import type {
 import {
   Popover,
   PopoverAnchor,
-  PopoverContent,
-  PopoverTrigger
+  PopoverContent
 } from "../../app/renderer/components/ui/popover";
 import { Spinner } from "../../app/renderer/components/ui/spinner";
 import {
@@ -524,6 +524,7 @@ function AgentUsageChip({
   const usagePopoverHoverTimerRef = useRef<ReturnType<
     typeof setTimeout
   > | null>(null);
+  const usagePopoverContentRef = useRef<HTMLDivElement | null>(null);
   const clampedPercent = Math.max(0, Math.min(100, percentUsed));
   const chipLabel = labels.usageChipLabel({ percent: clampedPercent });
   const showTokens = usedTokens !== null && totalTokens !== null;
@@ -580,6 +581,25 @@ function AgentUsageChip({
     },
     [closeUsagePopover, openUsagePopover]
   );
+  const handleUsageTriggerBlur = useCallback(
+    (event: ReactFocusEvent<HTMLButtonElement>) => {
+      const nextFocusTarget = event.relatedTarget;
+      if (
+        nextFocusTarget instanceof Node &&
+        usagePopoverContentRef.current?.contains(nextFocusTarget)
+      ) {
+        clearUsagePopoverHoverTimer();
+        clearUsagePopoverCloseTimer();
+        return;
+      }
+      closeUsagePopover();
+    },
+    [
+      clearUsagePopoverCloseTimer,
+      clearUsagePopoverHoverTimer,
+      closeUsagePopover
+    ]
+  );
 
   useEffect(
     () => () => {
@@ -598,8 +618,7 @@ function AgentUsageChip({
       )}
       data-testid="agent-gui-usage-chip"
       data-usage-level={usageLevel}
-      onBlur={tooltipsEnabled ? closeUsagePopover : undefined}
-      onClick={tooltipsEnabled ? openUsagePopover : undefined}
+      onBlur={tooltipsEnabled ? handleUsageTriggerBlur : undefined}
       onFocus={tooltipsEnabled ? openUsagePopoverAfterHoverDelay : undefined}
       onPointerEnter={(event) => {
         if (tooltipsEnabled && event.pointerType !== "touch") {
@@ -628,9 +647,10 @@ function AgentUsageChip({
       open={usagePopoverOpen}
       onOpenChange={handleUsagePopoverOpenChange}
     >
-      <PopoverTrigger asChild>{trigger}</PopoverTrigger>
+      <PopoverAnchor asChild>{trigger}</PopoverAnchor>
       {usagePopoverOpen ? (
         <PopoverContent
+          ref={usagePopoverContentRef}
           side="bottom"
           align="end"
           className="w-[320px] max-w-[calc(100vw-32px)] gap-3 text-xs"


### PR DESCRIPTION
## Summary

Fixes the AgentGUI compact action in the usage popover so clicking the compact button no longer closes the popover before the click can fire. The usage ring now behaves as a hover/focus anchor instead of a click-toggle trigger, so clicking a hover-opened usage popover does not collapse it.

## Root Cause

The usage ring trigger closed the controlled popover immediately on blur. In the browser, pressing the compact button moves focus from the usage ring into the popover before the click event fires, so the blur handler unmounted the button and the compact submit never ran. The trigger also carried Radix click-toggle semantics, so clicking a popover that was opened by hover could collapse it instead of leaving the hover interaction stable.

## Changes

- Track the usage popover content element with a ref.
- Keep the popover open when focus moves from the usage ring into the popover content.
- Use the usage ring as a `PopoverAnchor` instead of a `PopoverTrigger`, removing click-toggle behavior while preserving hover/focus positioning.
- Add regression coverage for hover-opened popovers, usage-ring clicks, and the compact-button focus transition.

## Validation

- `pnpm --filter @tutti-os/agent-gui exec vitest run --environment jsdom --maxWorkers=3 agent-gui/agentGuiNode/AgentComposer.spec.tsx`
- `pnpm lint:ts -- packages/agent/gui/agent-gui/agentGuiNode/AgentComposer.tsx packages/agent/gui/agent-gui/agentGuiNode/AgentComposer.spec.tsx`
- `pnpm --filter @tutti-os/agent-gui typecheck`
- `pnpm check:changed`
- `pnpm check:full`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the usage popover focus/blur behavior so it stays open when moving from the usage chip to the popover content.
  * Fixed focus transitions to keep the compact action accessible, including correct submission of `/compact`.
* **Tests**
  * Refreshed and expanded automated coverage for the usage popover interactions and compact button behavior (including hover/open and focus/blur transitions).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->