### PR TITLE
[codex] Suppress pasted mention queries

### DIFF
--- a/docs/architecture/agent-gui-node.md
+++ b/docs/architecture/agent-gui-node.md
@@ -1245,6 +1245,12 @@ files or `workspace-reference` mentions must clear the active trigger text
 before launching the picker, otherwise the raw `@` query remains in the
 composer before the inserted mention.
 
+Pasting text that contains an `@` must not be treated as active mention input
+unless the paste leaves the caret immediately after the `@` trigger. A bare
+`@` paste may open the mention panel; a complete pasted query such as `@readme`
+should remain plain prompt text until the user explicitly places the caret in
+an active trigger position.
+
 `workspace-reference` hrefs are the passive reference contract, not a visual
 metadata store. Do not serialize app icons into the href just to render a chip.
 For `source=app` references, readonly and markdown renderers should hydrate the

--- a/packages/agent/gui/agent-gui/agentGuiNode/AgentGUINode.spec.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/AgentGUINode.spec.tsx
@@ -4473,7 +4473,8 @@ describe("AgentGUINode", () => {
     });
     renderAgentGUINode();
 
-    pasteComposerText("@read");
+    pasteComposerText("@");
+    pasteComposerText("read");
     const palette = await screen.findByRole("listbox", {
       name: "agentHost.agentGui.fileMentionPalette"
     });
@@ -4882,7 +4883,8 @@ describe("AgentGUINode", () => {
     );
     renderAgentGUINode();
 
-    pasteComposerText("@read");
+    pasteComposerText("@");
+    pasteComposerText("read");
     const palette = await screen.findByRole("listbox", {
       name: "agentHost.agentGui.fileMentionPalette"
     });
@@ -5465,6 +5467,28 @@ describe("AgentGUINode", () => {
     expect(mockSearchWorkspaceFileManagerEntries).not.toHaveBeenCalledWith(
       expect.objectContaining({
         query: "b.com"
+      })
+    );
+    expect(
+      screen.queryByRole("listbox", {
+        name: "agentHost.agentGui.fileMentionPalette"
+      })
+    ).toBeNull();
+  });
+
+  it("does not open the mention panel after pasting a complete at query", async () => {
+    mockViewModel = createViewModel({
+      activeConversationId: "session-1",
+      draftPrompt: ""
+    });
+    renderAgentGUINode();
+
+    pasteComposerText("@read");
+
+    await waitFor(() => expect(getComposerEditor()).toHaveTextContent("@read"));
+    expect(mockSearchWorkspaceFileManagerEntries).not.toHaveBeenCalledWith(
+      expect.objectContaining({
+        query: "read"
       })
     );
     expect(

--- a/packages/agent/gui/agent-gui/agentGuiNode/agentRichText/AgentRichTextEditor.spec.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/agentRichText/AgentRichTextEditor.spec.tsx
@@ -743,7 +743,7 @@ describe("AgentRichTextEditor", () => {
     expect(onSubmit).not.toHaveBeenCalled();
   });
 
-  it("opens file mention suggestions only after start or whitespace", async () => {
+  it("does not open file mention suggestions after pasted at queries", async () => {
     const onFileMentionSuggestionChange = vi.fn();
     const rendered = render(
       <AgentRichTextEditor
@@ -760,9 +760,12 @@ describe("AgentRichTextEditor", () => {
       clipboardData: clipboard("@readme")
     });
     await waitFor(() =>
-      expect(onFileMentionSuggestionChange).toHaveBeenLastCalledWith(
-        expect.objectContaining({ query: "readme", text: "@readme" })
+      expect(screen.getByRole("textbox", { name: "Prompt" })).toHaveTextContent(
+        "@readme"
       )
+    );
+    expect(onFileMentionSuggestionChange).not.toHaveBeenCalledWith(
+      expect.objectContaining({ query: "readme", text: "@readme" })
     );
 
     onFileMentionSuggestionChange.mockClear();
@@ -786,6 +789,30 @@ describe("AgentRichTextEditor", () => {
     );
     expect(onFileMentionSuggestionChange).not.toHaveBeenCalledWith(
       expect.objectContaining({ query: "b.com" })
+    );
+  });
+
+  it("opens file mention suggestions after pasting a bare at trigger", async () => {
+    const onFileMentionSuggestionChange = vi.fn();
+    render(
+      <AgentRichTextEditor
+        value=""
+        disabled={false}
+        placeholder="Prompt"
+        onChange={vi.fn()}
+        onSubmit={vi.fn()}
+        onFileMentionSuggestionChange={onFileMentionSuggestionChange}
+      />
+    );
+
+    fireEvent.paste(await screen.findByRole("textbox", { name: "Prompt" }), {
+      clipboardData: clipboard("@")
+    });
+
+    await waitFor(() =>
+      expect(onFileMentionSuggestionChange).toHaveBeenLastCalledWith(
+        expect.objectContaining({ query: "", text: "@" })
+      )
     );
   });
 

--- a/packages/agent/gui/agent-gui/agentGuiNode/agentRichText/AgentRichTextEditor.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/agentRichText/AgentRichTextEditor.tsx
@@ -489,6 +489,7 @@ export const AgentRichTextEditor = forwardRef<
   const removeMentionLabelRef = useRef(removeMentionLabel);
   const availableSkillsRef = useRef(availableSkills);
   const availableCapabilitiesRef = useRef(availableCapabilities);
+  const suppressPastedAtSuggestionRef = useRef(false);
   const scrollFrameRef = useRef<number | null>(null);
   const [contextMenu, setContextMenu] =
     useState<AgentRichTextContextMenuState | null>(null);
@@ -501,6 +502,13 @@ export const AgentRichTextEditor = forwardRef<
     const currentEditor = editorRef.current;
     if (!currentEditor || currentEditor.isDestroyed || !text) {
       return;
+    }
+    suppressPastedAtSuggestionRef.current =
+      text.includes("@") && !text.endsWith("@");
+    if (suppressPastedAtSuggestionRef.current) {
+      window.setTimeout(() => {
+        suppressPastedAtSuggestionRef.current = false;
+      }, 0);
     }
     currentEditor
       .chain()
@@ -605,7 +613,8 @@ export const AgentRichTextEditor = forwardRef<
             onFileMentionSuggestionChangeRef.current?.(state),
           onSuggestionKeyDown: (event) =>
             onFileMentionSuggestionKeyDownRef.current?.(event) ?? false,
-          removeActionAriaLabel: removeMentionLabelRef.current
+          removeActionAriaLabel: removeMentionLabelRef.current,
+          shouldSuppressSuggestion: () => suppressPastedAtSuggestionRef.current
         },
         { skills: availableSkillsRef.current },
         { capabilities: availableCapabilitiesRef.current }
@@ -811,6 +820,13 @@ export const AgentRichTextEditor = forwardRef<
             currentEditor.commands.setTextSelection(
               currentEditor.state.doc.content.size
             );
+          }
+          suppressPastedAtSuggestionRef.current =
+            text.includes("@") && !text.endsWith("@");
+          if (suppressPastedAtSuggestionRef.current) {
+            window.setTimeout(() => {
+              suppressPastedAtSuggestionRef.current = false;
+            }, 0);
           }
           currentEditor.commands.insertContent(
             plainTextToAgentRichTextInlineContent(text, {

--- a/packages/agent/gui/agent-gui/agentGuiNode/agentRichText/agentFileMentionExtension.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/agentRichText/agentFileMentionExtension.ts
@@ -155,6 +155,7 @@ export interface AgentFileMentionExtensionOptions {
   onSuggestionKeyDown?: (event: KeyboardEvent) => boolean;
   removeActionAriaLabel?: string;
   renderAsLink?: boolean;
+  shouldSuppressSuggestion?: () => boolean;
 }
 
 export interface ParsedAgentMentionMarkdown {
@@ -394,6 +395,9 @@ export function createAgentFileMentionExtension(
           allowSpaces: true,
           items: () => [],
           allow: ({ state, range }) => {
+            if (options.shouldSuppressSuggestion?.()) {
+              return false;
+            }
             if (range.from <= 1) {
               return true;
             }

--- a/packages/ui/rich-text/src/at-panel/mentionPalette.css
+++ b/packages/ui/rich-text/src/at-panel/mentionPalette.css
@@ -767,6 +767,7 @@
   min-width: max-content;
   flex: 0 0 auto;
   padding-inline: 8px;
+  color: var(--text-secondary);
   font-size: 12px;
   font-weight: 600;
   line-height: 24px;

--- a/packages/ui/rich-text/src/at-panel/mentionPaletteInteractionStyles.test.ts
+++ b/packages/ui/rich-text/src/at-panel/mentionPaletteInteractionStyles.test.ts
@@ -146,6 +146,10 @@ test("mention palette rows keep trailing controls visible when text is narrow", 
   );
   assert.match(
     stylesheet,
+    /\.rich-text-at-mention-row__open-references\s*\{[^}]*color:\s*var\(--text-secondary\);/s
+  );
+  assert.match(
+    stylesheet,
     /\.rich-text-at-mention-row__navigate-into\s*\{[^}]*width:\s*24px;[^}]*flex:\s*0 0 24px;/s
   );
   assert.match(

--- a/packages/ui/rich-text/src/editor/RichTextTriggerEditor.tsx
+++ b/packages/ui/rich-text/src/editor/RichTextTriggerEditor.tsx
@@ -7,6 +7,7 @@ import {
   useState,
   type CSSProperties,
   type KeyboardEvent,
+  type MutableRefObject,
   type ReactNode,
   type JSX
 } from "react";
@@ -163,6 +164,7 @@ export function RichTextTriggerEditor({
   const lastSerializedValueRef = useRef(normalizedValue);
   const lastFocusSignalRef = useRef(focusSignal);
   const mentionHydrationRequestRef = useRef(0);
+  const suppressPastedAtQueryRef = useRef(false);
   const containerRef = useRef<HTMLDivElement | null>(null);
   const registry = useMemo(
     () => createRichTextTriggerRegistry(triggerProviders),
@@ -335,6 +337,10 @@ export function RichTextTriggerEditor({
 
     const updateQueryState = () => {
       const nextQuery = findEditorAtQuery(editor, activeTriggerConfigs);
+      if (shouldSuppressPastedAtQuery(nextQuery, suppressPastedAtQueryRef)) {
+        setQuery(null);
+        return;
+      }
       setQuery(nextQuery);
     };
 
@@ -655,6 +661,16 @@ export function RichTextTriggerEditor({
   return (
     <div
       className={cn("relative min-w-0 w-full", className)}
+      onPasteCapture={(event) => {
+        const pastedText = event.clipboardData.getData("text/plain");
+        suppressPastedAtQueryRef.current =
+          pastedText.includes("@") && !pastedText.endsWith("@");
+        if (suppressPastedAtQueryRef.current) {
+          window.setTimeout(() => {
+            suppressPastedAtQueryRef.current = false;
+          }, 0);
+        }
+      }}
       ref={containerRef}
     >
       <div className="w-full min-w-0" onKeyDownCapture={handleKeyDown}>
@@ -736,6 +752,17 @@ export function RichTextTriggerEditor({
         </ViewportMenuSurface>
       ) : null}
     </div>
+  );
+}
+
+function shouldSuppressPastedAtQuery(
+  query: RichTextEditorTriggerQueryState | null,
+  suppressPastedAtQueryRef: MutableRefObject<boolean>
+): boolean {
+  return Boolean(
+    suppressPastedAtQueryRef.current &&
+    query?.trigger === "@" &&
+    query.keyword.length > 0
   );
 }
 

--- a/packages/ui/rich-text/src/editor/RichTextTriggerTextarea.tsx
+++ b/packages/ui/rich-text/src/editor/RichTextTriggerTextarea.tsx
@@ -92,6 +92,7 @@ export function RichTextTriggerTextarea({
   const [textareaPresentationStyle, setTextareaPresentationStyle] =
     useState<CSSProperties | null>(null);
   const pendingSelectionRef = useRef<number | null>(null);
+  const suppressPastedAtQueryRef = useRef(false);
   const registry = useMemo(
     () => createRichTextTriggerRegistry(triggerProviders),
     [triggerProviders]
@@ -112,9 +113,15 @@ export function RichTextTriggerTextarea({
         : null,
     [activeTriggerConfigs, isFocused, selectionStart, value]
   );
+  const visibleQuery =
+    suppressPastedAtQueryRef.current &&
+    query?.trigger === "@" &&
+    query.keyword.length > 0
+      ? null
+      : query;
   const shouldQuery =
-    query !== null &&
-    query.keyword.length >= minQueryLength &&
+    visibleQuery !== null &&
+    visibleQuery.keyword.length >= minQueryLength &&
     activeTriggerConfigs.length > 0;
   const isMenuOpen =
     isFocused && shouldQuery && (isLoading || matches.length > 0);
@@ -129,7 +136,7 @@ export function RichTextTriggerTextarea({
   }, [value]);
 
   useEffect(() => {
-    if (!shouldQuery || !query) {
+    if (!shouldQuery || !visibleQuery) {
       setMatches([]);
       setActiveIndex(0);
       setIsLoading(false);
@@ -141,9 +148,9 @@ export function RichTextTriggerTextarea({
 
     void queryRichTextTriggerMatches(registry, {
       abortSignal: abortController.signal,
-      keyword: query.keyword,
+      keyword: visibleQuery.keyword,
       maxResults,
-      trigger: query.trigger,
+      trigger: visibleQuery.trigger,
       context: {
         documentText: value,
         blockText: value
@@ -169,7 +176,7 @@ export function RichTextTriggerTextarea({
     return () => {
       abortController.abort();
     };
-  }, [maxResults, query, registry, shouldQuery, value]);
+  }, [maxResults, registry, shouldQuery, value, visibleQuery]);
 
   useLayoutEffect(() => {
     if (!textareaRef.current || !hasDecorations) {
@@ -186,14 +193,14 @@ export function RichTextTriggerTextarea({
   }, [hasDecorations, textareaClassName, value]);
 
   useLayoutEffect(() => {
-    if (!isMenuOpen || !query || !textareaRef.current) {
+    if (!isMenuOpen || !visibleQuery || !textareaRef.current) {
       setMenuPoint(null);
       return;
     }
 
     const caretPoint = getTextareaCaretViewportPoint(
       textareaRef.current,
-      query.to
+      visibleQuery.to
     );
     const textareaRect = textareaRef.current.getBoundingClientRect();
 
@@ -209,16 +216,19 @@ export function RichTextTriggerTextarea({
       x: caretPoint.x,
       y: caretPoint.y + caretPoint.lineHeight + menuOffset
     });
-  }, [isMenuOpen, menuOffset, query, selectionStart, value]);
+  }, [isMenuOpen, menuOffset, selectionStart, value, visibleQuery]);
 
   useEffect(() => {
-    if (!isMenuOpen || !query || !textareaRef.current) {
+    if (!isMenuOpen || !visibleQuery || !textareaRef.current) {
       return;
     }
 
     const textarea = textareaRef.current;
     const updateMenuPoint = () => {
-      const caretPoint = getTextareaCaretViewportPoint(textarea, query.to);
+      const caretPoint = getTextareaCaretViewportPoint(
+        textarea,
+        visibleQuery.to
+      );
       const textareaRect = textarea.getBoundingClientRect();
 
       setMenuPoint(
@@ -254,7 +264,7 @@ export function RichTextTriggerTextarea({
       window.removeEventListener("resize", updateMenuPoint);
       window.removeEventListener("scroll", updateMenuPoint, true);
     };
-  }, [isMenuOpen, menuOffset, query]);
+  }, [isMenuOpen, menuOffset, visibleQuery]);
 
   const closeMenu = () => {
     setMatches([]);
@@ -399,6 +409,16 @@ export function RichTextTriggerTextarea({
             setIsFocused(false);
             closeMenu();
           }, 100);
+        }}
+        onPaste={(event) => {
+          const pastedText = event.clipboardData.getData("text/plain");
+          suppressPastedAtQueryRef.current =
+            pastedText.includes("@") && !pastedText.endsWith("@");
+          if (suppressPastedAtQueryRef.current) {
+            window.setTimeout(() => {
+              suppressPastedAtQueryRef.current = false;
+            }, 0);
+          }
         }}
         onChange={(event) => {
           const rawSelectionStart = event.target.selectionStart ?? 0;


### PR DESCRIPTION
## Summary

- prevent pasted complete `@` queries from opening the AgentGUI mention panel
- keep bare `@` paste behavior so users can still open the panel intentionally
- add coverage for AgentGUI composer and rich-text editor paste behavior
- document the composer mention paste rule in the AgentGuiNode architecture notes

## Root Cause

The composer suggestion plugin treated any pasted text containing an `@` trigger as active mention input. A paste like `@read` left the caret after the query text, but the suggestion range still opened the mention panel and searched files.

## Validation

- `pnpm --filter @tutti-os/agent-gui test`
- `pnpm --filter @tutti-os/ui-rich-text test`
- `pnpm --filter @tutti-os/agent-gui typecheck`
- `pnpm --filter @tutti-os/ui-rich-text typecheck`

## Notes

- `pnpm check:changed --tail-lines 80` and pre-push `pnpm check:full` hit local environment/tooling issues: root shell used Node 20 for TS node:test lanes that require `--experimental-strip-types`, and `golangci-lint` is not installed locally. Targeted checks above passed; visible `check:full` preflight, typecheck, and Go tests passed before the hook stopped on those tooling issues.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Pasting text that contains `@` now behaves more predictably in mention fields.
  * Complete pasted queries like `@readme` stay as plain text instead of opening mention/file pickers or triggering search immediately.
  * Bare `@` still opens mention suggestions as expected.
  * Improved mention panel styling so the “open references” action uses the correct secondary text color.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->