### PR TITLE
[codex] Refine AgentGUI mention palette styling

### DIFF
--- a/packages/agent/gui/agent-gui/agentGuiNode/AgentComposer.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/AgentComposer.tsx
@@ -699,7 +699,7 @@ const composerStyles = {
   footerGroup: styles.composerFooterLeft,
   footerGroupRight: styles.composerFooterRight,
   dropdownSurface:
-    "nodrag isolate rounded-[12px] border border-hairline bg-background-fronted p-[4px] text-foreground shadow-[var(--tsh-shell-shadow)] [-webkit-app-region:no-drag]"
+    "nodrag isolate rounded-[12px] border border-hairline bg-background-fronted p-[4px] text-foreground shadow-[var(--shadow-panel)] [-webkit-app-region:no-drag]"
 };
 
 const workspaceReferenceSelectValue = "__tutti_workspace_reference_idle__";

--- a/packages/agent/gui/app/renderer/agentactivity.css
+++ b/packages/agent/gui/app/renderer/agentactivity.css
@@ -2406,6 +2406,10 @@ aside.workspace-agents-status-panel
   white-space: nowrap;
 }
 
+.agent-gui-node__mention-palette-hint-item > span:last-child {
+  font-size: 11px;
+}
+
 .agent-gui-node__mention-palette-hint-button,
 .agent-gui-node__mention-palette-shortcut-button {
   appearance: none;
@@ -2427,10 +2431,11 @@ aside.workspace-agents-status-panel
   justify-content: center;
   height: 20px;
   min-width: 20px;
+  border: 1px solid var(--line-2, var(--tutti-line-2));
   border-radius: 4px;
   background: color-mix(in srgb, var(--transparency-block) 72%, transparent);
   color: var(--agent-gui-text-secondary, var(--text-secondary));
-  font-size: 13px;
+  font-size: 11px;
   font-weight: 600;
   line-height: 1;
   padding: 4px 6px;
@@ -2454,7 +2459,7 @@ aside.workspace-agents-status-panel
 .agent-gui-node__mention-palette-shortcut--arrow {
   width: 20px;
   min-width: 20px;
-  font-size: 13px;
+  font-size: 11px;
   line-height: 1;
   padding: 0;
 }
@@ -2476,6 +2481,18 @@ aside.workspace-agents-status-panel
 
 .agent-gui-node__mention-palette {
   --agent-mention-file-icon-size: 16px;
+}
+
+.agent-gui-node__mention-palette .rich-text-at-mention-palette__row-button,
+.agent-gui-node__mention-palette .rich-text-at-mention-palette__expand-button {
+  min-height: 28px;
+  padding-top: 4px;
+  padding-bottom: 4px;
+}
+
+.agent-gui-node__mention-palette
+  .rich-text-at-mention-palette__empty-state-inner {
+  width: min(100%, 52ch);
 }
 
 .agent-gui-node__mention-file-thumb {
@@ -7620,12 +7637,12 @@ html[data-theme="light"] [data-message-center-item-id].agent-gui-edge-glow {
   align-items: center;
   justify-content: space-between;
   gap: 8px;
-  padding: 8px 12px 4px;
+  padding: 2px 12px;
 }
 
 .agent-gui-node__composer-input-group-hero
   .agent-gui-node__composer-project-row {
-  padding: 4px 12px 4px;
+  padding: 2px 12px;
 }
 
 .agent-gui-node__composer-project-row .agent-gui-node__composer-menu-trigger {


### PR DESCRIPTION
## Summary

- tighten AgentGUI @ mention palette option vertical spacing and row height
- reduce footer shortcut hint typography to 11px and add line-2 borders to shortcut keys
- widen empty-state text and use the shared panel shadow token for the palette surface

## Impact

Improves the AgentGUI composer @ panel density and visual consistency without changing mention search behavior or data flow.

## Validation

- pnpm check:changed --tail-lines 40
- pnpm setup:dev with Node 24 / Go 1.24 / golangci-lint v2.12.0
- pre-push pnpm check:full

## Documentation

No durable documentation impact found; this is a local AgentGUI presentation-only change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Refined the mention palette and composer spacing for a cleaner, more compact interface.
  * Updated shortcut and hint text sizing for better visual balance.
  * Improved palette layout with tighter row spacing, a defined minimum height, and a more constrained empty-state width.
  * Adjusted the palette container shadow to better match the surrounding panel styling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->