### PR TITLE
fix(workspace-agent): format outcome notification titles

### DIFF
--- a/apps/desktop/src/renderer/src/features/workspace-workbench/services/workspaceAgentOutcomeNotification.test.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/services/workspaceAgentOutcomeNotification.test.ts
@@ -1,5 +1,9 @@
 import assert from "node:assert/strict";
 import test from "node:test";
+import type {
+  AgentActivityMessage,
+  AgentActivitySnapshot
+} from "@tutti-os/agent-activity-core";
 import type { NotificationMessage } from "@tutti-os/ui-notifications";
 import {
   buildWorkspaceAgentOutcomeNotificationFromSessionEvent,
@@ -106,63 +110,22 @@ test("outcome notification builder ignores state patches without stable turn out
 });
 
 test("outcome notification controller notifies from live session events", () => {
-  const events: Array<(event: unknown) => void> = [];
-  const foregroundNotifications: unknown[] = [];
-  const notifications: NotificationMessage[] = [];
-  const controller = createWorkspaceAgentOutcomeNotificationController({
-    foreground: {
-      show(notification) {
-        foregroundNotifications.push(notification);
-      }
-    },
-    notifications: {
-      notify(message) {
-        notifications.push(message);
-      }
-    },
-    translate(key, params) {
-      if (key.endsWith("CompletedBody")) {
-        return "The agent finished this run.";
-      }
-      if (key.endsWith("CompletedTitle")) {
-        return `${params?.title} completed`;
-      }
-      if (key.endsWith("CompletedStatus")) {
-        return "Completed";
-      }
-      if (key === "workspace.agentGui.fallbackAgentLabel") {
-        return "Agent";
-      }
-      if (key === "common.close") {
-        return "Close";
-      }
-      return key;
-    },
-    workspaceAgentActivityService: {
-      onSessionEvent(workspaceId, listener) {
-        assert.equal(workspaceId, "ws-1");
-        events.push(listener);
-        return () => {
-          const index = events.indexOf(listener);
-          if (index >= 0) {
-            events.splice(index, 1);
-          }
-        };
-      }
-    },
-    workspaceId: "ws-1"
-  });
+  const harness = createOutcomeNotificationHarness((workspaceId) =>
+    activitySnapshot({ workspaceId })
+  );
 
-  events[0]?.(
+  harness.events[0]?.(
     messageUpdateEvent({
       content: "Fix the installer bug",
       role: "user",
       turnId: "turn-1"
     })
   );
-  events[0]?.(statePatchEvent({ outcome: "success", title: "Build feature" }));
+  harness.events[0]?.(
+    statePatchEvent({ outcome: "success", title: "Build feature" })
+  );
 
-  assert.deepEqual(foregroundNotifications, [
+  assert.deepEqual(harness.foregroundNotifications, [
     {
       agentName: "Codex",
       agentSessionId: "session-1",
@@ -175,8 +138,8 @@ test("outcome notification controller notifies from live session events", () => 
       workspaceId: "ws-1"
     }
   ]);
-  assert.equal(notifications.length, 1);
-  assert.deepEqual(notifications[0], {
+  assert.equal(harness.notifications.length, 1);
+  assert.deepEqual(harness.notifications[0], {
     description: "The agent finished this run.",
     level: "success",
     navigation: {
@@ -188,61 +151,23 @@ test("outcome notification controller notifies from live session events", () => 
     title: "Fix the installer bug completed"
   });
 
-  controller.dispose();
-  assert.equal(events.length, 0);
+  harness.controller.dispose();
+  assert.equal(harness.events.length, 0);
 });
 
 test("outcome notification controller uses the matching latest user message title", () => {
-  const events: Array<(event: unknown) => void> = [];
-  const foregroundNotifications: unknown[] = [];
-  const notifications: NotificationMessage[] = [];
-  createWorkspaceAgentOutcomeNotificationController({
-    foreground: {
-      show(notification) {
-        foregroundNotifications.push(notification);
-      }
-    },
-    notifications: {
-      notify(message) {
-        notifications.push(message);
-      }
-    },
-    translate(key, params) {
-      if (key.endsWith("CompletedBody")) {
-        return "The agent finished this run.";
-      }
-      if (key.endsWith("CompletedTitle")) {
-        return `${params?.title} completed`;
-      }
-      if (key.endsWith("CompletedStatus")) {
-        return "Completed";
-      }
-      if (key === "workspace.agentGui.fallbackAgentLabel") {
-        return "Agent";
-      }
-      if (key === "common.close") {
-        return "Close";
-      }
-      return key;
-    },
-    workspaceAgentActivityService: {
-      onSessionEvent(workspaceId, listener) {
-        assert.equal(workspaceId, "ws-1");
-        events.push(listener);
-        return () => {};
-      }
-    },
-    workspaceId: "ws-1"
-  });
+  const harness = createOutcomeNotificationHarness((workspaceId) =>
+    activitySnapshot({ workspaceId })
+  );
 
-  events[0]?.(
+  harness.events[0]?.(
     messageUpdateEvent({
       content: "6",
       role: "user",
       turnId: "turn-6"
     })
   );
-  events[0]?.(
+  harness.events[0]?.(
     statePatchEvent({
       outcome: "completed",
       title: "1",
@@ -251,11 +176,82 @@ test("outcome notification controller uses the matching latest user message titl
   );
 
   assert.equal(
-    (foregroundNotifications[0] as { conversationTitle?: string })
+    (harness.foregroundNotifications[0] as { conversationTitle?: string })
       .conversationTitle,
     "6"
   );
-  assert.equal(notifications[0]?.title, "6 completed");
+  assert.equal(harness.notifications[0]?.title, "6 completed");
+});
+
+const snapshotMentionTitleCases = [
+  {
+    name: "session mention markdown",
+    title:
+      "[@wang jomes & Codex hi](mention://agent-session/session-linked?workspaceId=ws-1)",
+    expected: "@session · wang jomes & Codex hi"
+  },
+  {
+    name: "plain session mention",
+    title: "@sunhello135-png & Nexight 长标题会话",
+    expected: "@session · sunhello135-png & Nexight 长标题会话"
+  },
+  {
+    name: "workspace issue mention markdown",
+    title:
+      "[@调研 spool 仓库 这个任务](mention://workspace-issue/issue-1?workspaceId=ws-1)",
+    expected: "@调研 spool 仓库 这个任务"
+  },
+  {
+    name: "workspace app mention markdown",
+    title:
+      "[@Claude Code](mention://workspace-app/agent-claude-code?workspaceId=ws-1) 派发个子agent去看看呢？",
+    expected: "@Claude Code 派发个子agent去看看呢？"
+  }
+] as const;
+
+for (const { name, title, expected } of snapshotMentionTitleCases) {
+  test(`outcome notification controller formats ${name} like Agent GUI`, () => {
+    const harness = createOutcomeNotificationHarness((workspaceId) =>
+      activitySnapshot({ workspaceId, title })
+    );
+
+    harness.events[0]?.(
+      statePatchEvent({ outcome: "completed", title: "Codex" })
+    );
+
+    assert.equal(
+      (harness.foregroundNotifications[0] as { conversationTitle?: string })
+        .conversationTitle,
+      expected
+    );
+    assert.equal(harness.notifications[0]?.title, `${expected} completed`);
+  });
+}
+
+test("outcome notification controller resolves provider default titles from snapshot messages", () => {
+  const harness = createOutcomeNotificationHarness((workspaceId) =>
+    activitySnapshot({
+      messages: [
+        activityMessage({
+          content: "Ship the title fix.",
+          messageId: "message-user-1"
+        })
+      ],
+      workspaceId,
+      title: "Codex"
+    })
+  );
+
+  harness.events[0]?.(
+    statePatchEvent({ outcome: "completed", title: "Codex" })
+  );
+
+  assert.equal(
+    (harness.foregroundNotifications[0] as { conversationTitle?: string })
+      .conversationTitle,
+    "Ship the title fix"
+  );
+  assert.equal(harness.notifications[0]?.title, "Ship the title fix completed");
 });
 
 function statePatchEvent(input: {
@@ -298,5 +294,114 @@ function messageUpdateEvent(input: {
       workspaceId: "ws-1"
     },
     eventType: "message_update"
+  };
+}
+
+function activitySnapshot(input: {
+  messages?: AgentActivityMessage[];
+  title?: string;
+  workspaceId: string;
+}): AgentActivitySnapshot {
+  return {
+    workspaceId: input.workspaceId,
+    sessions: [
+      {
+        workspaceId: input.workspaceId,
+        agentSessionId: "session-1",
+        provider: "codex",
+        cwd: "/workspace",
+        title: input.title ?? "Build feature",
+        status: "completed"
+      }
+    ],
+    presences: [],
+    sessionMessagesById: {
+      "session-1": input.messages ?? []
+    }
+  };
+}
+
+function createOutcomeNotificationHarness(
+  snapshot:
+    | AgentActivitySnapshot
+    | ((workspaceId: string) => AgentActivitySnapshot)
+): {
+  controller: ReturnType<
+    typeof createWorkspaceAgentOutcomeNotificationController
+  >;
+  events: Array<(event: unknown) => void>;
+  foregroundNotifications: unknown[];
+  notifications: NotificationMessage[];
+} {
+  const events: Array<(event: unknown) => void> = [];
+  const foregroundNotifications: unknown[] = [];
+  const notifications: NotificationMessage[] = [];
+  const controller = createWorkspaceAgentOutcomeNotificationController({
+    foreground: {
+      show(notification) {
+        foregroundNotifications.push(notification);
+      }
+    },
+    notifications: {
+      notify(message) {
+        notifications.push(message);
+      }
+    },
+    translate(key, params) {
+      if (key.endsWith("CompletedBody")) {
+        return "The agent finished this run.";
+      }
+      if (key.endsWith("CompletedTitle")) {
+        return `${params?.title} completed`;
+      }
+      if (key.endsWith("CompletedStatus")) {
+        return "Completed";
+      }
+      if (key === "workspace.agentGui.fallbackAgentLabel") {
+        return "Agent";
+      }
+      if (key === "common.close") {
+        return "Close";
+      }
+      return key;
+    },
+    workspaceAgentActivityService: {
+      getSnapshot(workspaceId) {
+        return typeof snapshot === "function"
+          ? snapshot(workspaceId)
+          : snapshot;
+      },
+      onSessionEvent(workspaceId, listener) {
+        assert.equal(workspaceId, "ws-1");
+        events.push(listener);
+        return () => {
+          const index = events.indexOf(listener);
+          if (index >= 0) {
+            events.splice(index, 1);
+          }
+        };
+      }
+    },
+    workspaceId: "ws-1"
+  });
+  return { controller, events, foregroundNotifications, notifications };
+}
+
+function activityMessage(input: {
+  content: string;
+  messageId: string;
+}): AgentActivityMessage {
+  return {
+    workspaceId: "ws-1",
+    agentSessionId: "session-1",
+    messageId: input.messageId,
+    version: 1,
+    turnId: "turn-1",
+    role: "user",
+    kind: "message.user",
+    payload: {
+      text: input.content
+    },
+    occurredAtUnixMs: 1
   };
 }

--- a/apps/desktop/src/renderer/src/features/workspace-workbench/services/workspaceAgentOutcomeNotification.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/services/workspaceAgentOutcomeNotification.ts
@@ -1,3 +1,4 @@
+import { resolveAgentGuiWorkbenchSessionTitle } from "@tutti-os/agent-gui/workbench/sessionTitle";
 import type { NotificationService } from "@tutti-os/ui-notifications";
 import type { CompositeNotificationMessage } from "@renderer/lib/compositeNotificationService";
 import type { DesktopI18nKey, I18nParams } from "@shared/i18n";
@@ -38,7 +39,7 @@ export interface WorkspaceAgentOutcomeNotificationControllerInput {
   translate(key: DesktopI18nKey, params?: I18nParams): string;
   workspaceAgentActivityService: Pick<
     IWorkspaceAgentActivityService,
-    "onSessionEvent"
+    "getSnapshot" | "onSessionEvent"
   >;
   workspaceId: string;
 }
@@ -68,10 +69,15 @@ export function createWorkspaceAgentOutcomeNotificationController(
         event,
         userTitleCache
       );
+      const resolvedConversationTitle =
+        conversationTitle ||
+        resolveWorkspaceAgentOutcomeConversationTitle(event, {
+          workspaceAgentActivityService: input.workspaceAgentActivityService
+        });
       const notification =
         buildWorkspaceAgentOutcomeNotificationFromSessionEvent(
           event,
-          conversationTitle
+          resolvedConversationTitle
         );
       if (!notification) {
         return;
@@ -93,6 +99,40 @@ export function createWorkspaceAgentOutcomeNotificationController(
       unsubscribe();
     }
   };
+}
+
+function resolveWorkspaceAgentOutcomeConversationTitle(
+  event: unknown,
+  input: {
+    workspaceAgentActivityService: Pick<
+      IWorkspaceAgentActivityService,
+      "getSnapshot"
+    >;
+  }
+): string {
+  const source = recordValue(event);
+  if (stringValue(source?.eventType) !== "state_patch") {
+    return "";
+  }
+  const data = recordValue(source?.data);
+  if (!data) {
+    return "";
+  }
+  const workspaceId = stringValue(data.workspaceId);
+  const agentSessionId = stringValue(data.agentSessionId);
+  const provider = stringValue(data.provider);
+  if (!workspaceId || !agentSessionId || !provider) {
+    return "";
+  }
+  const snapshot = input.workspaceAgentActivityService.getSnapshot(workspaceId);
+  return (
+    resolveAgentGuiWorkbenchSessionTitle({
+      agentSessionId,
+      fallbackTitle: stringValue(data.title),
+      provider,
+      snapshot
+    }).title ?? ""
+  );
 }
 
 export function buildWorkspaceAgentOutcomeNotificationFromSessionEvent(


### PR DESCRIPTION
## Summary
- Reuse the AgentGUI workbench session title resolver for workspace agent outcome notifications.
- Keep matching live user-message titles preferred, with snapshot titles and event titles used as fallback.
- Cover agent-session, plain session, workspace-issue, workspace-app mention titles, and provider-default title fallback.

## Validation
- cd apps/desktop && node --import ./test/register-asset-stub.mjs --test --experimental-strip-types src/renderer/src/features/workspace-workbench/services/workspaceAgentOutcomeNotification.test.ts
- pnpm --filter @tutti-os/desktop typecheck
- pnpm check:changed --tail-lines 80
- make dev-web manual browser validation for outcome toast @mention rendering
- pnpm check:full (pre-push)

## Documentation
- No documentation impact found: no public API, config, durable data-flow ownership, or user-visible copy changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved workspace agent outcome notifications so titles are more reliably populated, including cases with mentions and snapshot-based messages.
  * Notifications now better handle empty or missing conversation titles, resulting in clearer notification text for users.
  * Expanded automated coverage for notification title formatting and listener cleanup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->