### PR TITLE
fix(agent): persist session rail fields

### DIFF
--- a/docs/conventions/troubleshooting.md
+++ b/docs/conventions/troubleshooting.md
@@ -598,15 +598,14 @@ delimited by ---`, and the composer skill picker may show partial or
   must be persisted as session metadata rather than inferred later from
   user-project prefix matching.
 - Fix:
-  Treat exact user-project path matches as explicit user intent, then call the
-  host no-project resolver before parent project matching. The desktop resolver
-  should recognize generated `$HOME/Documents/tutti/session-<uuid>` cwd values
-  while allowing explicit registered projects to override them. External import
-  should mark home-cwd sessions and known provider scratch cwd shapes as
-  no-project in `runtimeContext`, skip them when registering user-project paths,
-  and let Agent GUI preserve that no-project mode during later project
-  re-resolution. Keep the project field derived in the Agent GUI view-model
-  rather than writing it back into the conversation store.
+  Persist Agent GUI rail grouping in daemon-owned
+  `workspace_agent_sessions.rail_section_*` fields from the shared
+  `services/tuttid/data/workspace` classifier. Migration and session-state
+  upsert should both use that classifier, matching exact user projects and
+  longest project parents before falling back to conversations for no-project
+  or provider scratch cwd shapes. Do not rederive historical rail assignment
+  from the current user-project list during read pagination; keep existing rail
+  fields stable when a session's final cwd has not changed.
 - Validation:
   Run
   `pnpm --filter @tutti-os/agent-gui test -- agent-gui/agentGuiNode/model/agentGuiConversationModel.spec.ts`,

--- a/docs/conventions/troubleshooting.md
+++ b/docs/conventions/troubleshooting.md
@@ -601,11 +601,11 @@ delimited by ---`, and the composer skill picker may show partial or
   Persist Agent GUI rail grouping in daemon-owned
   `workspace_agent_sessions.rail_section_*` fields from the shared
   `services/tuttid/data/workspace` classifier. Migration and session-state
-  upsert should both use that classifier, matching exact user projects and
-  longest project parents before falling back to conversations for no-project
-  or provider scratch cwd shapes. Do not rederive historical rail assignment
-  from the current user-project list during read pagination; keep existing rail
-  fields stable when a session's final cwd has not changed.
+  upsert should both use that classifier, matching exact user projects first,
+  then preserving no-project/provider scratch cwd shapes as conversations, then
+  applying longest parent-project matches. Do not rederive historical rail
+  assignment from the current user-project list during read pagination; keep
+  existing rail fields stable when a session's final cwd has not changed.
 - Validation:
   Run
   `pnpm --filter @tutti-os/agent-gui test -- agent-gui/agentGuiNode/model/agentGuiConversationModel.spec.ts`,

--- a/services/tuttid/data/workspace/agent_session_rail.go
+++ b/services/tuttid/data/workspace/agent_session_rail.go
@@ -1,0 +1,260 @@
+package workspace
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+)
+
+const (
+	agentSessionRailSectionKindConversations = "conversations"
+	agentSessionRailSectionKindProject       = "project"
+	agentSessionRailSectionKeyConversations  = "conversations"
+)
+
+type agentSessionRailSection struct {
+	Kind        string
+	ProjectPath string
+	Key         string
+}
+
+type existingAgentSessionRailSection struct {
+	Section agentSessionRailSection
+	Found   bool
+	Valid   bool
+}
+
+type agentSessionRailProject struct {
+	Path string
+}
+
+type agentSessionRailProjectQueryer interface {
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+}
+
+func classifyAgentSessionRailSectionTx(
+	ctx context.Context,
+	tx *sql.Tx,
+	cwd string,
+) (agentSessionRailSection, error) {
+	projects, err := listAgentSessionRailProjects(ctx, tx)
+	if err != nil {
+		return agentSessionRailSection{}, err
+	}
+	return classifyAgentSessionRailSection(cwd, projects), nil
+}
+
+func resolveAgentSessionRailSectionTx(
+	ctx context.Context,
+	tx *sql.Tx,
+	workspaceID string,
+	agentSessionID string,
+	hasExisting bool,
+	existingCWD string,
+	finalCWD string,
+) (agentSessionRailSection, error) {
+	existingRail, err := getExistingAgentSessionRailSectionTx(ctx, tx, workspaceID, agentSessionID)
+	if err != nil {
+		return agentSessionRailSection{}, err
+	}
+	if hasExisting && existingRail.Found && existingRail.Valid && strings.TrimSpace(existingCWD) == strings.TrimSpace(finalCWD) {
+		return existingRail.Section, nil
+	}
+	return classifyAgentSessionRailSectionTx(ctx, tx, finalCWD)
+}
+
+func getExistingAgentSessionRailSectionTx(
+	ctx context.Context,
+	tx *sql.Tx,
+	workspaceID string,
+	agentSessionID string,
+) (existingAgentSessionRailSection, error) {
+	row := tx.QueryRowContext(ctx, `
+SELECT rail_section_kind, rail_project_path, rail_section_key
+FROM workspace_agent_sessions
+WHERE workspace_id = ? AND agent_session_id = ?
+`, workspaceID, agentSessionID)
+	var section agentSessionRailSection
+	if err := row.Scan(&section.Kind, &section.ProjectPath, &section.Key); err != nil {
+		if err == sql.ErrNoRows {
+			return existingAgentSessionRailSection{}, nil
+		}
+		return existingAgentSessionRailSection{}, fmt.Errorf("get workspace agent session rail section: %w", err)
+	}
+	section = normalizeAgentSessionRailSection(section)
+	return existingAgentSessionRailSection{
+		Section: section,
+		Found:   true,
+		Valid:   isValidAgentSessionRailSection(section),
+	}, nil
+}
+
+func classifyAgentSessionRailSection(
+	cwd string,
+	projects []agentSessionRailProject,
+) agentSessionRailSection {
+	normalizedCWD := normalizeAgentSessionRailPath(cwd)
+	for _, project := range projects {
+		if agentSessionRailPathContains(project.Path, normalizedCWD) {
+			return agentSessionRailSection{
+				Kind:        agentSessionRailSectionKindProject,
+				ProjectPath: project.Path,
+				Key:         agentSessionRailSectionKeyForProject(project.Path),
+			}
+		}
+	}
+	if isAgentSessionScratchCWD(normalizedCWD) {
+		return conversationsAgentSessionRailSection()
+	}
+	return conversationsAgentSessionRailSection()
+}
+
+func listAgentSessionRailProjects(
+	ctx context.Context,
+	queryer agentSessionRailProjectQueryer,
+) ([]agentSessionRailProject, error) {
+	rows, err := queryer.QueryContext(ctx, `
+SELECT path
+FROM user_projects
+WHERE TRIM(path) != ''
+ORDER BY length(path) DESC, path ASC
+`)
+	if err != nil {
+		return nil, fmt.Errorf("list user projects for workspace agent session rail classification: %w", err)
+	}
+	defer rows.Close()
+
+	projects := make([]agentSessionRailProject, 0)
+	for rows.Next() {
+		var project agentSessionRailProject
+		if err := rows.Scan(&project.Path); err != nil {
+			return nil, fmt.Errorf("scan user project for workspace agent session rail classification: %w", err)
+		}
+		project.Path = normalizeAgentSessionRailPath(project.Path)
+		if project.Path != "" {
+			projects = append(projects, project)
+		}
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate user projects for workspace agent session rail classification: %w", err)
+	}
+	sort.SliceStable(projects, func(left, right int) bool {
+		if len(projects[left].Path) == len(projects[right].Path) {
+			return projects[left].Path < projects[right].Path
+		}
+		return len(projects[left].Path) > len(projects[right].Path)
+	})
+	return projects, nil
+}
+
+func normalizeAgentSessionRailPath(path string) string {
+	path = strings.TrimSpace(path)
+	if path == "" {
+		return ""
+	}
+	absolute, err := filepath.Abs(path)
+	if err != nil {
+		return filepath.Clean(path)
+	}
+	if info, statErr := os.Stat(absolute); statErr == nil && info.IsDir() {
+		if evaluated, evalErr := filepath.EvalSymlinks(absolute); evalErr == nil {
+			absolute = evaluated
+		}
+	}
+	return filepath.Clean(absolute)
+}
+
+func agentSessionRailPathContains(parent string, child string) bool {
+	parent = normalizeAgentSessionRailPath(parent)
+	child = normalizeAgentSessionRailPath(child)
+	if parent == "" || child == "" {
+		return false
+	}
+	if parent == child {
+		return true
+	}
+	rel, err := filepath.Rel(parent, child)
+	if err != nil {
+		return false
+	}
+	return rel != "." && rel != ".." && !strings.HasPrefix(rel, ".."+string(filepath.Separator))
+}
+
+func isAgentSessionScratchCWD(cwd string) bool {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return false
+	}
+	home = normalizeAgentSessionRailPath(home)
+	cwd = normalizeAgentSessionRailPath(cwd)
+	if home == "" || cwd == "" {
+		return false
+	}
+	for _, providerDir := range []string{"Codex", "Tutti"} {
+		root := normalizeAgentSessionRailPath(filepath.Join(home, "Documents", providerDir))
+		rel, err := filepath.Rel(root, cwd)
+		if err != nil || rel == "." || rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+			continue
+		}
+		parts := strings.Split(filepath.ToSlash(rel), "/")
+		if len(parts) == 2 && parts[1] != "" && isAgentSessionRailDateSegment(parts[0]) {
+			return true
+		}
+	}
+	return false
+}
+
+func isAgentSessionRailDateSegment(value string) bool {
+	if len(value) != len("2006-01-02") || value[4] != '-' || value[7] != '-' {
+		return false
+	}
+	for index, char := range value {
+		if index == 4 || index == 7 {
+			continue
+		}
+		if char < '0' || char > '9' {
+			return false
+		}
+	}
+	return true
+}
+
+func conversationsAgentSessionRailSection() agentSessionRailSection {
+	return agentSessionRailSection{
+		Kind: agentSessionRailSectionKindConversations,
+		Key:  agentSessionRailSectionKeyConversations,
+	}
+}
+
+func agentSessionRailSectionKeyForProject(projectPath string) string {
+	projectPath = normalizeAgentSessionRailPath(projectPath)
+	if projectPath == "" {
+		return agentSessionRailSectionKeyConversations
+	}
+	return "project:" + projectPath
+}
+
+func normalizeAgentSessionRailSection(section agentSessionRailSection) agentSessionRailSection {
+	section.Kind = strings.TrimSpace(section.Kind)
+	section.ProjectPath = normalizeAgentSessionRailPath(section.ProjectPath)
+	section.Key = strings.TrimSpace(section.Key)
+	if section.Kind == agentSessionRailSectionKindConversations {
+		section.ProjectPath = ""
+	}
+	return section
+}
+
+func isValidAgentSessionRailSection(section agentSessionRailSection) bool {
+	switch section.Kind {
+	case agentSessionRailSectionKindConversations:
+		return section.ProjectPath == "" && section.Key == agentSessionRailSectionKeyConversations
+	case agentSessionRailSectionKindProject:
+		return section.ProjectPath != "" && section.Key == agentSessionRailSectionKeyForProject(section.ProjectPath)
+	default:
+		return false
+	}
+}

--- a/services/tuttid/data/workspace/agent_session_rail.go
+++ b/services/tuttid/data/workspace/agent_session_rail.go
@@ -40,12 +40,13 @@ func classifyAgentSessionRailSectionTx(
 	ctx context.Context,
 	tx *sql.Tx,
 	cwd string,
+	runtimeContext map[string]any,
 ) (agentSessionRailSection, error) {
 	projects, err := listAgentSessionRailProjects(ctx, tx)
 	if err != nil {
 		return agentSessionRailSection{}, err
 	}
-	return classifyAgentSessionRailSection(cwd, projects), nil
+	return classifyAgentSessionRailSection(cwd, runtimeContext, projects), nil
 }
 
 func resolveAgentSessionRailSectionTx(
@@ -56,6 +57,7 @@ func resolveAgentSessionRailSectionTx(
 	hasExisting bool,
 	existingCWD string,
 	finalCWD string,
+	runtimeContext map[string]any,
 ) (agentSessionRailSection, error) {
 	existingRail, err := getExistingAgentSessionRailSectionTx(ctx, tx, workspaceID, agentSessionID)
 	if err != nil {
@@ -64,7 +66,7 @@ func resolveAgentSessionRailSectionTx(
 	if hasExisting && existingRail.Found && existingRail.Valid && strings.TrimSpace(existingCWD) == strings.TrimSpace(finalCWD) {
 		return existingRail.Section, nil
 	}
-	return classifyAgentSessionRailSectionTx(ctx, tx, finalCWD)
+	return classifyAgentSessionRailSectionTx(ctx, tx, finalCWD, runtimeContext)
 }
 
 func getExistingAgentSessionRailSectionTx(
@@ -95,9 +97,22 @@ WHERE workspace_id = ? AND agent_session_id = ?
 
 func classifyAgentSessionRailSection(
 	cwd string,
+	runtimeContext map[string]any,
 	projects []agentSessionRailProject,
 ) agentSessionRailSection {
 	normalizedCWD := normalizeAgentSessionRailPath(cwd)
+	for _, project := range projects {
+		if project.Path == normalizedCWD {
+			return agentSessionRailSection{
+				Kind:        agentSessionRailSectionKindProject,
+				ProjectPath: project.Path,
+				Key:         agentSessionRailSectionKeyForProject(project.Path),
+			}
+		}
+	}
+	if isAgentSessionNoProjectRuntimeContext(runtimeContext) || isAgentSessionScratchCWD(normalizedCWD) {
+		return conversationsAgentSessionRailSection()
+	}
 	for _, project := range projects {
 		if agentSessionRailPathContains(project.Path, normalizedCWD) {
 			return agentSessionRailSection{
@@ -106,9 +121,6 @@ func classifyAgentSessionRailSection(
 				Key:         agentSessionRailSectionKeyForProject(project.Path),
 			}
 		}
-	}
-	if isAgentSessionScratchCWD(normalizedCWD) {
-		return conversationsAgentSessionRailSection()
 	}
 	return conversationsAgentSessionRailSection()
 }
@@ -182,6 +194,21 @@ func agentSessionRailPathContains(parent string, child string) bool {
 		return false
 	}
 	return rel != "." && rel != ".." && !strings.HasPrefix(rel, ".."+string(filepath.Separator))
+}
+
+func isAgentSessionNoProjectRuntimeContext(runtimeContext map[string]any) bool {
+	value, ok := runtimeContext["externalImportNoProject"]
+	if !ok {
+		return false
+	}
+	switch typed := value.(type) {
+	case bool:
+		return typed
+	case string:
+		return strings.EqualFold(strings.TrimSpace(typed), "true")
+	default:
+		return false
+	}
 }
 
 func isAgentSessionScratchCWD(cwd string) bool {

--- a/services/tuttid/data/workspace/migrations.go
+++ b/services/tuttid/data/workspace/migrations.go
@@ -6,8 +6,6 @@ import (
 	"errors"
 	"fmt"
 	"time"
-
-	agenttargetbiz "github.com/tutti-os/tutti/services/tuttid/biz/agenttarget"
 )
 
 const schemaMigrationWorkspacesV1 = "workspaces_v1"
@@ -19,6 +17,7 @@ const schemaMigrationWorkspaceAgentActivityV2 = "workspace_agent_activity_v2"
 const schemaMigrationWorkspaceAgentActivityV3 = "workspace_agent_activity_v3"
 const schemaMigrationWorkspaceAgentActivityV4 = "workspace_agent_activity_v4"
 const schemaMigrationWorkspaceAgentActivityV5 = "workspace_agent_activity_v5"
+const schemaMigrationWorkspaceAgentActivityRailV1 = "workspace_agent_activity_rail_v1"
 const schemaMigrationAgentTargetsV1 = "agent_targets_v1"
 const schemaMigrationWorkspaceIssuesV1 = "workspace_issues_v1"
 const schemaMigrationWorkspaceIssuesV2 = "workspace_issues_v2"
@@ -178,6 +177,10 @@ INSERT OR IGNORE INTO tuttid_schema_migrations (id, applied_at_unix_ms)
 	}
 
 	if err := s.applyUserProjectsV1(ctx); err != nil {
+		return err
+	}
+
+	if err := s.applyWorkspaceAgentActivityRailV1(ctx); err != nil {
 		return err
 	}
 
@@ -572,224 +575,6 @@ INSERT INTO tuttid_schema_migrations (id, applied_at_unix_ms)
 		return fmt.Errorf("migrate workspace database for issue manager v2: %w", err)
 	}
 
-	return nil
-}
-
-func (s *SQLiteStore) applyWorkspaceAgentActivityV1(ctx context.Context) error {
-	applied, err := s.hasMigration(ctx, schemaMigrationWorkspaceAgentActivityV1)
-	if err != nil {
-		return err
-	}
-	if applied {
-		return nil
-	}
-
-	now := unixMs(time.Now().UTC())
-	_, err = s.db.ExecContext(ctx, `
-CREATE TABLE IF NOT EXISTS workspace_agent_sessions (
-  workspace_id TEXT NOT NULL,
-  agent_session_id TEXT NOT NULL,
-  origin TEXT NOT NULL DEFAULT '',
-  agent_target_id TEXT,
-  provider TEXT NOT NULL DEFAULT '',
-  provider_session_id TEXT NOT NULL DEFAULT '',
-  model TEXT NOT NULL DEFAULT '',
-  settings_json TEXT NOT NULL DEFAULT '{}',
-  runtime_context_json TEXT NOT NULL DEFAULT '{}',
-  cwd TEXT NOT NULL DEFAULT '',
-  title TEXT NOT NULL DEFAULT '',
-  status TEXT NOT NULL DEFAULT '',
-  current_phase TEXT NOT NULL DEFAULT '',
-  last_error TEXT NOT NULL DEFAULT '',
-  message_version INTEGER NOT NULL DEFAULT 0,
-  last_event_at_unix_ms INTEGER NOT NULL DEFAULT 0,
-  started_at_unix_ms INTEGER NOT NULL DEFAULT 0,
-  ended_at_unix_ms INTEGER NOT NULL DEFAULT 0,
-  deleted_at_unix_ms INTEGER NOT NULL DEFAULT 0,
-  created_at_unix_ms INTEGER NOT NULL,
-  updated_at_unix_ms INTEGER NOT NULL,
-  PRIMARY KEY (workspace_id, agent_session_id),
-  FOREIGN KEY (workspace_id) REFERENCES workspaces(id) ON DELETE CASCADE
-);
-
-CREATE INDEX IF NOT EXISTS idx_workspace_agent_sessions_workspace_updated
-  ON workspace_agent_sessions(workspace_id, deleted_at_unix_ms, updated_at_unix_ms);
-
-CREATE TABLE IF NOT EXISTS workspace_agent_messages (
-  id INTEGER PRIMARY KEY AUTOINCREMENT,
-  workspace_id TEXT NOT NULL,
-  agent_session_id TEXT NOT NULL,
-  message_id TEXT NOT NULL,
-  version INTEGER NOT NULL,
-  turn_id TEXT NOT NULL DEFAULT '',
-  role TEXT NOT NULL DEFAULT '',
-  kind TEXT NOT NULL DEFAULT '',
-  status TEXT NOT NULL DEFAULT '',
-  payload_json TEXT NOT NULL DEFAULT '{}',
-  occurred_at_unix_ms INTEGER NOT NULL DEFAULT 0,
-  started_at_unix_ms INTEGER NOT NULL DEFAULT 0,
-  completed_at_unix_ms INTEGER NOT NULL DEFAULT 0,
-  deleted_at_unix_ms INTEGER NOT NULL DEFAULT 0,
-  created_at_unix_ms INTEGER NOT NULL,
-  updated_at_unix_ms INTEGER NOT NULL,
-  UNIQUE (workspace_id, agent_session_id, message_id),
-  FOREIGN KEY (workspace_id, agent_session_id)
-    REFERENCES workspace_agent_sessions(workspace_id, agent_session_id)
-    ON DELETE CASCADE
-);
-
-CREATE INDEX IF NOT EXISTS idx_workspace_agent_messages_session_version
-  ON workspace_agent_messages(workspace_id, agent_session_id, deleted_at_unix_ms, version);
-
-CREATE INDEX IF NOT EXISTS idx_workspace_agent_messages_session_display
-  ON workspace_agent_messages(workspace_id, agent_session_id, deleted_at_unix_ms, id);
-
-INSERT INTO tuttid_schema_migrations (id, applied_at_unix_ms)
-  VALUES (?, ?);
-`, schemaMigrationWorkspaceAgentActivityV1, now)
-	if err != nil {
-		return fmt.Errorf("migrate workspace database agent activity v1: %w", err)
-	}
-
-	return nil
-}
-
-func (s *SQLiteStore) applyWorkspaceAgentActivityV2(ctx context.Context) error {
-	applied, err := s.hasMigration(ctx, schemaMigrationWorkspaceAgentActivityV2)
-	if err != nil {
-		return err
-	}
-	if applied {
-		return nil
-	}
-
-	hasSettings, err := s.hasColumn(ctx, "workspace_agent_sessions", "settings_json")
-	if err != nil {
-		return err
-	}
-	hasRuntimeContext, err := s.hasColumn(ctx, "workspace_agent_sessions", "runtime_context_json")
-	if err != nil {
-		return err
-	}
-
-	now := unixMs(time.Now().UTC())
-	if !hasSettings {
-		if _, err := s.db.ExecContext(ctx, `ALTER TABLE workspace_agent_sessions ADD COLUMN settings_json TEXT NOT NULL DEFAULT '{}';`); err != nil {
-			return fmt.Errorf("migrate workspace agent activity to v2 settings: %w", err)
-		}
-	}
-	if !hasRuntimeContext {
-		if _, err := s.db.ExecContext(ctx, `ALTER TABLE workspace_agent_sessions ADD COLUMN runtime_context_json TEXT NOT NULL DEFAULT '{}';`); err != nil {
-			return fmt.Errorf("migrate workspace agent activity to v2 runtime context: %w", err)
-		}
-	}
-	if _, err := s.db.ExecContext(ctx, `
-INSERT INTO tuttid_schema_migrations (id, applied_at_unix_ms)
-  VALUES (?, ?);
-`, schemaMigrationWorkspaceAgentActivityV2, now); err != nil {
-		return fmt.Errorf("record workspace agent activity v2 migration: %w", err)
-	}
-	return nil
-}
-
-func (s *SQLiteStore) applyWorkspaceAgentActivityV3(ctx context.Context) error {
-	applied, err := s.hasMigration(ctx, schemaMigrationWorkspaceAgentActivityV3)
-	if err != nil {
-		return err
-	}
-	if applied {
-		return nil
-	}
-
-	hasPinnedAt, err := s.hasColumn(ctx, "workspace_agent_sessions", "pinned_at_unix_ms")
-	if err != nil {
-		return err
-	}
-
-	now := unixMs(time.Now().UTC())
-	if !hasPinnedAt {
-		if _, err := s.db.ExecContext(ctx, `ALTER TABLE workspace_agent_sessions ADD COLUMN pinned_at_unix_ms INTEGER NOT NULL DEFAULT 0;`); err != nil {
-			return fmt.Errorf("migrate workspace agent activity to v3 pinned state: %w", err)
-		}
-	}
-	if _, err := s.db.ExecContext(ctx, `
-INSERT INTO tuttid_schema_migrations (id, applied_at_unix_ms)
-  VALUES (?, ?);
-`, schemaMigrationWorkspaceAgentActivityV3, now); err != nil {
-		return fmt.Errorf("record workspace agent activity v3 migration: %w", err)
-	}
-	return nil
-}
-
-func (s *SQLiteStore) applyWorkspaceAgentActivityV4(ctx context.Context) error {
-	applied, err := s.hasMigration(ctx, schemaMigrationWorkspaceAgentActivityV4)
-	if err != nil {
-		return err
-	}
-
-	hasAgentTargetID, err := s.hasColumn(ctx, "workspace_agent_sessions", "agent_target_id")
-	if err != nil {
-		return err
-	}
-
-	now := unixMs(time.Now().UTC())
-	if !hasAgentTargetID {
-		if _, err := s.db.ExecContext(ctx, `ALTER TABLE workspace_agent_sessions ADD COLUMN agent_target_id TEXT;`); err != nil {
-			return fmt.Errorf("migrate workspace agent activity to v4 agent target id: %w", err)
-		}
-	}
-	if applied {
-		return nil
-	}
-	if _, err := s.db.ExecContext(ctx, `
-INSERT INTO tuttid_schema_migrations (id, applied_at_unix_ms)
-  VALUES (?, ?);
-`, schemaMigrationWorkspaceAgentActivityV4, now); err != nil {
-		return fmt.Errorf("record workspace agent activity v4 migration: %w", err)
-	}
-	return nil
-}
-
-func (s *SQLiteStore) applyWorkspaceAgentActivityV5(ctx context.Context) error {
-	applied, err := s.hasMigration(ctx, schemaMigrationWorkspaceAgentActivityV5)
-	if err != nil {
-		return err
-	}
-	if applied {
-		return nil
-	}
-
-	if err := s.backfillSystemAgentTargetIDs(ctx); err != nil {
-		return err
-	}
-
-	now := unixMs(time.Now().UTC())
-	if _, err := s.db.ExecContext(ctx, `
-INSERT INTO tuttid_schema_migrations (id, applied_at_unix_ms)
-  VALUES (?, ?);
-`, schemaMigrationWorkspaceAgentActivityV5, now); err != nil {
-		return fmt.Errorf("record workspace agent activity v5 migration: %w", err)
-	}
-	return nil
-}
-
-func (s *SQLiteStore) backfillSystemAgentTargetIDs(ctx context.Context) error {
-	if _, err := s.db.ExecContext(ctx, `
-UPDATE workspace_agent_sessions
-SET agent_target_id = ?
-WHERE (agent_target_id IS NULL OR TRIM(agent_target_id) = '')
-  AND provider = 'codex'
-`, agenttargetbiz.IDLocalCodex); err != nil {
-		return fmt.Errorf("backfill codex agent target ids: %w", err)
-	}
-	if _, err := s.db.ExecContext(ctx, `
-UPDATE workspace_agent_sessions
-SET agent_target_id = ?
-WHERE (agent_target_id IS NULL OR TRIM(agent_target_id) = '')
-  AND provider = 'claude-code'
-`, agenttargetbiz.IDLocalClaudeCode); err != nil {
-		return fmt.Errorf("backfill claude-code agent target ids: %w", err)
-	}
 	return nil
 }
 

--- a/services/tuttid/data/workspace/migrations_agent_activity.go
+++ b/services/tuttid/data/workspace/migrations_agent_activity.go
@@ -1,0 +1,227 @@
+package workspace
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	agenttargetbiz "github.com/tutti-os/tutti/services/tuttid/biz/agenttarget"
+)
+
+func (s *SQLiteStore) applyWorkspaceAgentActivityV1(ctx context.Context) error {
+	applied, err := s.hasMigration(ctx, schemaMigrationWorkspaceAgentActivityV1)
+	if err != nil {
+		return err
+	}
+	if applied {
+		return nil
+	}
+
+	now := unixMs(time.Now().UTC())
+	_, err = s.db.ExecContext(ctx, `
+CREATE TABLE IF NOT EXISTS workspace_agent_sessions (
+  workspace_id TEXT NOT NULL,
+  agent_session_id TEXT NOT NULL,
+  origin TEXT NOT NULL DEFAULT '',
+  agent_target_id TEXT,
+  provider TEXT NOT NULL DEFAULT '',
+  provider_session_id TEXT NOT NULL DEFAULT '',
+  model TEXT NOT NULL DEFAULT '',
+  settings_json TEXT NOT NULL DEFAULT '{}',
+  runtime_context_json TEXT NOT NULL DEFAULT '{}',
+  cwd TEXT NOT NULL DEFAULT '',
+  title TEXT NOT NULL DEFAULT '',
+  status TEXT NOT NULL DEFAULT '',
+  current_phase TEXT NOT NULL DEFAULT '',
+  last_error TEXT NOT NULL DEFAULT '',
+  message_version INTEGER NOT NULL DEFAULT 0,
+  last_event_at_unix_ms INTEGER NOT NULL DEFAULT 0,
+  started_at_unix_ms INTEGER NOT NULL DEFAULT 0,
+  ended_at_unix_ms INTEGER NOT NULL DEFAULT 0,
+  deleted_at_unix_ms INTEGER NOT NULL DEFAULT 0,
+  created_at_unix_ms INTEGER NOT NULL,
+  updated_at_unix_ms INTEGER NOT NULL,
+  PRIMARY KEY (workspace_id, agent_session_id),
+  FOREIGN KEY (workspace_id) REFERENCES workspaces(id) ON DELETE CASCADE
+);
+
+CREATE INDEX IF NOT EXISTS idx_workspace_agent_sessions_workspace_updated
+  ON workspace_agent_sessions(workspace_id, deleted_at_unix_ms, updated_at_unix_ms);
+
+CREATE TABLE IF NOT EXISTS workspace_agent_messages (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  workspace_id TEXT NOT NULL,
+  agent_session_id TEXT NOT NULL,
+  message_id TEXT NOT NULL,
+  version INTEGER NOT NULL,
+  turn_id TEXT NOT NULL DEFAULT '',
+  role TEXT NOT NULL DEFAULT '',
+  kind TEXT NOT NULL DEFAULT '',
+  status TEXT NOT NULL DEFAULT '',
+  payload_json TEXT NOT NULL DEFAULT '{}',
+  occurred_at_unix_ms INTEGER NOT NULL DEFAULT 0,
+  started_at_unix_ms INTEGER NOT NULL DEFAULT 0,
+  completed_at_unix_ms INTEGER NOT NULL DEFAULT 0,
+  deleted_at_unix_ms INTEGER NOT NULL DEFAULT 0,
+  created_at_unix_ms INTEGER NOT NULL,
+  updated_at_unix_ms INTEGER NOT NULL,
+  UNIQUE (workspace_id, agent_session_id, message_id),
+  FOREIGN KEY (workspace_id, agent_session_id)
+    REFERENCES workspace_agent_sessions(workspace_id, agent_session_id)
+    ON DELETE CASCADE
+);
+
+CREATE INDEX IF NOT EXISTS idx_workspace_agent_messages_session_version
+  ON workspace_agent_messages(workspace_id, agent_session_id, deleted_at_unix_ms, version);
+
+CREATE INDEX IF NOT EXISTS idx_workspace_agent_messages_session_display
+  ON workspace_agent_messages(workspace_id, agent_session_id, deleted_at_unix_ms, id);
+
+INSERT INTO tuttid_schema_migrations (id, applied_at_unix_ms)
+  VALUES (?, ?);
+`, schemaMigrationWorkspaceAgentActivityV1, now)
+	if err != nil {
+		return fmt.Errorf("migrate workspace database agent activity v1: %w", err)
+	}
+
+	return nil
+}
+
+func (s *SQLiteStore) applyWorkspaceAgentActivityV2(ctx context.Context) error {
+	applied, err := s.hasMigration(ctx, schemaMigrationWorkspaceAgentActivityV2)
+	if err != nil {
+		return err
+	}
+	if applied {
+		return nil
+	}
+
+	hasSettings, err := s.hasColumn(ctx, "workspace_agent_sessions", "settings_json")
+	if err != nil {
+		return err
+	}
+	hasRuntimeContext, err := s.hasColumn(ctx, "workspace_agent_sessions", "runtime_context_json")
+	if err != nil {
+		return err
+	}
+
+	now := unixMs(time.Now().UTC())
+	if !hasSettings {
+		if _, err := s.db.ExecContext(ctx, `ALTER TABLE workspace_agent_sessions ADD COLUMN settings_json TEXT NOT NULL DEFAULT '{}';`); err != nil {
+			return fmt.Errorf("migrate workspace agent activity to v2 settings: %w", err)
+		}
+	}
+	if !hasRuntimeContext {
+		if _, err := s.db.ExecContext(ctx, `ALTER TABLE workspace_agent_sessions ADD COLUMN runtime_context_json TEXT NOT NULL DEFAULT '{}';`); err != nil {
+			return fmt.Errorf("migrate workspace agent activity to v2 runtime context: %w", err)
+		}
+	}
+	if _, err := s.db.ExecContext(ctx, `
+INSERT INTO tuttid_schema_migrations (id, applied_at_unix_ms)
+  VALUES (?, ?);
+`, schemaMigrationWorkspaceAgentActivityV2, now); err != nil {
+		return fmt.Errorf("record workspace agent activity v2 migration: %w", err)
+	}
+	return nil
+}
+
+func (s *SQLiteStore) applyWorkspaceAgentActivityV3(ctx context.Context) error {
+	applied, err := s.hasMigration(ctx, schemaMigrationWorkspaceAgentActivityV3)
+	if err != nil {
+		return err
+	}
+	if applied {
+		return nil
+	}
+
+	hasPinnedAt, err := s.hasColumn(ctx, "workspace_agent_sessions", "pinned_at_unix_ms")
+	if err != nil {
+		return err
+	}
+
+	now := unixMs(time.Now().UTC())
+	if !hasPinnedAt {
+		if _, err := s.db.ExecContext(ctx, `ALTER TABLE workspace_agent_sessions ADD COLUMN pinned_at_unix_ms INTEGER NOT NULL DEFAULT 0;`); err != nil {
+			return fmt.Errorf("migrate workspace agent activity to v3 pinned state: %w", err)
+		}
+	}
+	if _, err := s.db.ExecContext(ctx, `
+INSERT INTO tuttid_schema_migrations (id, applied_at_unix_ms)
+  VALUES (?, ?);
+`, schemaMigrationWorkspaceAgentActivityV3, now); err != nil {
+		return fmt.Errorf("record workspace agent activity v3 migration: %w", err)
+	}
+	return nil
+}
+
+func (s *SQLiteStore) applyWorkspaceAgentActivityV4(ctx context.Context) error {
+	applied, err := s.hasMigration(ctx, schemaMigrationWorkspaceAgentActivityV4)
+	if err != nil {
+		return err
+	}
+
+	hasAgentTargetID, err := s.hasColumn(ctx, "workspace_agent_sessions", "agent_target_id")
+	if err != nil {
+		return err
+	}
+
+	now := unixMs(time.Now().UTC())
+	if !hasAgentTargetID {
+		if _, err := s.db.ExecContext(ctx, `ALTER TABLE workspace_agent_sessions ADD COLUMN agent_target_id TEXT;`); err != nil {
+			return fmt.Errorf("migrate workspace agent activity to v4 agent target id: %w", err)
+		}
+	}
+	if applied {
+		return nil
+	}
+	if _, err := s.db.ExecContext(ctx, `
+INSERT INTO tuttid_schema_migrations (id, applied_at_unix_ms)
+  VALUES (?, ?);
+`, schemaMigrationWorkspaceAgentActivityV4, now); err != nil {
+		return fmt.Errorf("record workspace agent activity v4 migration: %w", err)
+	}
+	return nil
+}
+
+func (s *SQLiteStore) applyWorkspaceAgentActivityV5(ctx context.Context) error {
+	applied, err := s.hasMigration(ctx, schemaMigrationWorkspaceAgentActivityV5)
+	if err != nil {
+		return err
+	}
+	if applied {
+		return nil
+	}
+
+	if err := s.backfillSystemAgentTargetIDs(ctx); err != nil {
+		return err
+	}
+
+	now := unixMs(time.Now().UTC())
+	if _, err := s.db.ExecContext(ctx, `
+INSERT INTO tuttid_schema_migrations (id, applied_at_unix_ms)
+  VALUES (?, ?);
+`, schemaMigrationWorkspaceAgentActivityV5, now); err != nil {
+		return fmt.Errorf("record workspace agent activity v5 migration: %w", err)
+	}
+	return nil
+}
+
+func (s *SQLiteStore) backfillSystemAgentTargetIDs(ctx context.Context) error {
+	if _, err := s.db.ExecContext(ctx, `
+UPDATE workspace_agent_sessions
+SET agent_target_id = ?
+WHERE (agent_target_id IS NULL OR TRIM(agent_target_id) = '')
+  AND provider = 'codex'
+`, agenttargetbiz.IDLocalCodex); err != nil {
+		return fmt.Errorf("backfill codex agent target ids: %w", err)
+	}
+	if _, err := s.db.ExecContext(ctx, `
+UPDATE workspace_agent_sessions
+SET agent_target_id = ?
+WHERE (agent_target_id IS NULL OR TRIM(agent_target_id) = '')
+  AND provider = 'claude-code'
+`, agenttargetbiz.IDLocalClaudeCode); err != nil {
+		return fmt.Errorf("backfill claude-code agent target ids: %w", err)
+	}
+	return nil
+}

--- a/services/tuttid/data/workspace/migrations_agent_activity_rail.go
+++ b/services/tuttid/data/workspace/migrations_agent_activity_rail.go
@@ -1,0 +1,130 @@
+package workspace
+
+import (
+	"context"
+	"fmt"
+	"time"
+)
+
+func (s *SQLiteStore) applyWorkspaceAgentActivityRailV1(ctx context.Context) error {
+	applied, err := s.hasMigration(ctx, schemaMigrationWorkspaceAgentActivityRailV1)
+	if err != nil {
+		return err
+	}
+
+	hasRailSectionKind, err := s.hasColumn(ctx, "workspace_agent_sessions", "rail_section_kind")
+	if err != nil {
+		return err
+	}
+	hasRailProjectPath, err := s.hasColumn(ctx, "workspace_agent_sessions", "rail_project_path")
+	if err != nil {
+		return err
+	}
+	hasRailSectionKey, err := s.hasColumn(ctx, "workspace_agent_sessions", "rail_section_key")
+	if err != nil {
+		return err
+	}
+
+	if !hasRailSectionKind {
+		if _, err := s.db.ExecContext(ctx, `ALTER TABLE workspace_agent_sessions ADD COLUMN rail_section_kind TEXT NOT NULL DEFAULT 'conversations';`); err != nil {
+			return fmt.Errorf("migrate workspace agent activity rail section kind: %w", err)
+		}
+	}
+	if !hasRailProjectPath {
+		if _, err := s.db.ExecContext(ctx, `ALTER TABLE workspace_agent_sessions ADD COLUMN rail_project_path TEXT NOT NULL DEFAULT '';`); err != nil {
+			return fmt.Errorf("migrate workspace agent activity rail project path: %w", err)
+		}
+	}
+	if !hasRailSectionKey {
+		if _, err := s.db.ExecContext(ctx, `ALTER TABLE workspace_agent_sessions ADD COLUMN rail_section_key TEXT NOT NULL DEFAULT 'conversations';`); err != nil {
+			return fmt.Errorf("migrate workspace agent activity rail section key: %w", err)
+		}
+	}
+
+	if _, err := s.db.ExecContext(ctx, `
+CREATE INDEX IF NOT EXISTS idx_workspace_agent_sessions_rail_section_page
+  ON workspace_agent_sessions(workspace_id, rail_section_key, deleted_at_unix_ms, updated_at_unix_ms DESC, agent_session_id ASC);
+`); err != nil {
+		return fmt.Errorf("create workspace agent activity rail section index: %w", err)
+	}
+	if applied {
+		return nil
+	}
+
+	if err := s.backfillAgentSessionRailSections(ctx); err != nil {
+		return err
+	}
+
+	now := unixMs(time.Now().UTC())
+	if _, err := s.db.ExecContext(ctx, `
+INSERT INTO tuttid_schema_migrations (id, applied_at_unix_ms)
+  VALUES (?, ?);
+`, schemaMigrationWorkspaceAgentActivityRailV1, now); err != nil {
+		return fmt.Errorf("record workspace agent activity rail migration: %w", err)
+	}
+	return nil
+}
+
+func (s *SQLiteStore) backfillAgentSessionRailSections(ctx context.Context) error {
+	projects, err := listAgentSessionRailProjects(ctx, s.db)
+	if err != nil {
+		return err
+	}
+
+	rows, err := s.db.QueryContext(ctx, `
+SELECT workspace_id, agent_session_id, cwd
+FROM workspace_agent_sessions
+WHERE rail_section_key = ?
+`, agentSessionRailSectionKeyConversations)
+	if err != nil {
+		return fmt.Errorf("list workspace agent sessions for rail section backfill: %w", err)
+	}
+	defer rows.Close()
+
+	type railBackfill struct {
+		WorkspaceID    string
+		AgentSessionID string
+		Section        agentSessionRailSection
+	}
+	backfills := make([]railBackfill, 0)
+	for rows.Next() {
+		var workspaceID string
+		var agentSessionID string
+		var cwd string
+		if err := rows.Scan(&workspaceID, &agentSessionID, &cwd); err != nil {
+			return fmt.Errorf("scan workspace agent session for rail section backfill: %w", err)
+		}
+		section := classifyAgentSessionRailSection(cwd, projects)
+		if section.Kind != agentSessionRailSectionKindProject {
+			continue
+		}
+		backfills = append(backfills, railBackfill{
+			WorkspaceID:    workspaceID,
+			AgentSessionID: agentSessionID,
+			Section:        section,
+		})
+	}
+	if err := rows.Err(); err != nil {
+		return fmt.Errorf("iterate workspace agent sessions for rail section backfill: %w", err)
+	}
+	if err := rows.Close(); err != nil {
+		return fmt.Errorf("close workspace agent sessions rail section backfill rows: %w", err)
+	}
+
+	for _, backfill := range backfills {
+		_, err := s.db.ExecContext(ctx, `
+UPDATE workspace_agent_sessions
+SET rail_section_kind = ?,
+    rail_project_path = ?,
+    rail_section_key = ?
+WHERE workspace_id = ?
+  AND agent_session_id = ?
+  AND rail_section_key = ?
+`, backfill.Section.Kind, backfill.Section.ProjectPath, backfill.Section.Key,
+			backfill.WorkspaceID, backfill.AgentSessionID, agentSessionRailSectionKeyConversations)
+		if err != nil {
+			return fmt.Errorf("backfill workspace agent session rail section for %s/%s: %w", backfill.WorkspaceID, backfill.AgentSessionID, err)
+		}
+	}
+	return nil
+}

--- a/services/tuttid/data/workspace/migrations_agent_activity_rail.go
+++ b/services/tuttid/data/workspace/migrations_agent_activity_rail.go
@@ -72,7 +72,7 @@ func (s *SQLiteStore) backfillAgentSessionRailSections(ctx context.Context) erro
 	}
 
 	rows, err := s.db.QueryContext(ctx, `
-SELECT workspace_id, agent_session_id, cwd
+SELECT workspace_id, agent_session_id, cwd, runtime_context_json
 FROM workspace_agent_sessions
 WHERE rail_section_key = ?
 `, agentSessionRailSectionKeyConversations)
@@ -91,10 +91,15 @@ WHERE rail_section_key = ?
 		var workspaceID string
 		var agentSessionID string
 		var cwd string
-		if err := rows.Scan(&workspaceID, &agentSessionID, &cwd); err != nil {
+		var runtimeContextJSON string
+		if err := rows.Scan(&workspaceID, &agentSessionID, &cwd, &runtimeContextJSON); err != nil {
 			return fmt.Errorf("scan workspace agent session for rail section backfill: %w", err)
 		}
-		section := classifyAgentSessionRailSection(cwd, projects)
+		runtimeContext, err := unmarshalJSONMap(runtimeContextJSON)
+		if err != nil {
+			return fmt.Errorf("decode workspace agent session runtime context for rail section backfill: %w", err)
+		}
+		section := classifyAgentSessionRailSection(cwd, runtimeContext, projects)
 		if section.Kind != agentSessionRailSectionKindProject {
 			continue
 		}

--- a/services/tuttid/data/workspace/sqlite_agent_activity.go
+++ b/services/tuttid/data/workspace/sqlite_agent_activity.go
@@ -608,13 +608,25 @@ func upsertAgentSessionTx(
 	if err != nil {
 		return false, false, 0, agentactivitybiz.Session{}, err
 	}
+	railSection, err := resolveAgentSessionRailSectionTx(
+		ctx,
+		tx,
+		workspaceID,
+		agentSessionID,
+		hasExisting,
+		existing.CWD,
+		session.CWD,
+	)
+	if err != nil {
+		return false, false, 0, agentactivitybiz.Session{}, err
+	}
 	result, err := tx.ExecContext(ctx, `
 INSERT INTO workspace_agent_sessions (
   workspace_id, agent_session_id, origin, agent_target_id, provider, provider_session_id, model,
-  settings_json, runtime_context_json, cwd,
+  settings_json, runtime_context_json, cwd, rail_section_kind, rail_project_path, rail_section_key,
   title, status, current_phase, last_error, last_event_at_unix_ms, started_at_unix_ms,
   ended_at_unix_ms, created_at_unix_ms, updated_at_unix_ms
-) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 ON CONFLICT(workspace_id, agent_session_id) DO UPDATE SET
   origin = excluded.origin,
   agent_target_id = excluded.agent_target_id,
@@ -624,6 +636,9 @@ ON CONFLICT(workspace_id, agent_session_id) DO UPDATE SET
   settings_json = excluded.settings_json,
   runtime_context_json = excluded.runtime_context_json,
   cwd = excluded.cwd,
+  rail_section_kind = excluded.rail_section_kind,
+  rail_project_path = excluded.rail_project_path,
+  rail_section_key = excluded.rail_section_key,
   title = excluded.title,
   status = excluded.status,
   current_phase = excluded.current_phase,
@@ -634,9 +649,9 @@ ON CONFLICT(workspace_id, agent_session_id) DO UPDATE SET
   deleted_at_unix_ms = 0,
   updated_at_unix_ms = excluded.updated_at_unix_ms
 WHERE workspace_agent_sessions.deleted_at_unix_ms = 0
-	`, session.WorkspaceID, session.AgentSessionID, session.Origin, nullString(session.AgentTargetID), session.Provider,
+`, session.WorkspaceID, session.AgentSessionID, session.Origin, nullString(session.AgentTargetID), session.Provider,
 		session.ProviderSessionID, session.Model, settingsJSON, runtimeContextJSON,
-		session.CWD, session.Title,
+		session.CWD, railSection.Kind, railSection.ProjectPath, railSection.Key, session.Title,
 		session.Status, session.CurrentPhase, session.LastError, session.LastEventUnixMS,
 		session.StartedAtUnixMS, session.EndedAtUnixMS, session.CreatedAtUnixMS,
 		session.UpdatedAtUnixMS)

--- a/services/tuttid/data/workspace/sqlite_agent_activity.go
+++ b/services/tuttid/data/workspace/sqlite_agent_activity.go
@@ -616,6 +616,7 @@ func upsertAgentSessionTx(
 		hasExisting,
 		existing.CWD,
 		session.CWD,
+		session.RuntimeContext,
 	)
 	if err != nil {
 		return false, false, 0, agentactivitybiz.Session{}, err

--- a/services/tuttid/data/workspace/sqlite_store_test.go
+++ b/services/tuttid/data/workspace/sqlite_store_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"errors"
+	"os"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -12,6 +13,7 @@ import (
 	agentsessionstore "github.com/tutti-os/tutti/packages/agentactivity/daemon/activity"
 	agentactivitybiz "github.com/tutti-os/tutti/services/tuttid/biz/agentactivity"
 	agenttargetbiz "github.com/tutti-os/tutti/services/tuttid/biz/agenttarget"
+	userprojectbiz "github.com/tutti-os/tutti/services/tuttid/biz/userproject"
 	workspacebiz "github.com/tutti-os/tutti/services/tuttid/biz/workspace"
 )
 
@@ -447,6 +449,421 @@ func TestSQLiteStoreReportAndListAgentActivityMessages(t *testing.T) {
 	}
 	if !ok || len(older.Messages) != 1 || older.Messages[0].Version != 2 {
 		t.Fatalf("older page = %#v ok=%v", older, ok)
+	}
+}
+
+func TestSQLiteStoreClassifiesAgentSessionRailSections(t *testing.T) {
+	t.Parallel()
+
+	store := openTestSQLiteStore(t)
+	ctx := context.Background()
+
+	if err := store.Create(ctx, workspacebiz.Summary{
+		ID:   "ws-agent-rail",
+		Name: "Workspace Agent Rail",
+	}); err != nil {
+		t.Fatalf("Create() error = %v", err)
+	}
+
+	root := t.TempDir()
+	repo := filepath.Join(root, "repo")
+	repoSubdir := filepath.Join(repo, "packages", "api")
+	repoSimilarPrefix := filepath.Join(root, "repo-a")
+	nestedRepo := filepath.Join(repo, "packages", "web")
+	nestedRepoSubdir := filepath.Join(nestedRepo, "src")
+	for _, path := range []string{repoSubdir, repoSimilarPrefix, nestedRepoSubdir} {
+		if err := mkdirAll(path); err != nil {
+			t.Fatalf("mkdir %q error = %v", path, err)
+		}
+	}
+	repoCanonical := normalizeAgentSessionRailPath(repo)
+	nestedRepoCanonical := normalizeAgentSessionRailPath(nestedRepo)
+	if _, err := store.PutUserProject(ctx, userprojectbiz.Project{
+		ID:    "project-repo",
+		Path:  repo,
+		Label: "repo",
+	}); err != nil {
+		t.Fatalf("PutUserProject(repo) error = %v", err)
+	}
+	if _, err := store.PutUserProject(ctx, userprojectbiz.Project{
+		ID:    "project-nested",
+		Path:  nestedRepo,
+		Label: "web",
+	}); err != nil {
+		t.Fatalf("PutUserProject(nested) error = %v", err)
+	}
+
+	for _, tc := range []struct {
+		sessionID       string
+		cwd             string
+		wantKind        string
+		wantProjectPath string
+		wantKey         string
+	}{
+		{
+			sessionID:       "session-root",
+			cwd:             repo,
+			wantKind:        agentSessionRailSectionKindProject,
+			wantProjectPath: repoCanonical,
+			wantKey:         agentSessionRailSectionKeyForProject(repo),
+		},
+		{
+			sessionID:       "session-subdir",
+			cwd:             repoSubdir,
+			wantKind:        agentSessionRailSectionKindProject,
+			wantProjectPath: repoCanonical,
+			wantKey:         agentSessionRailSectionKeyForProject(repo),
+		},
+		{
+			sessionID:       "session-similar-prefix",
+			cwd:             repoSimilarPrefix,
+			wantKind:        agentSessionRailSectionKindConversations,
+			wantProjectPath: "",
+			wantKey:         agentSessionRailSectionKeyConversations,
+		},
+		{
+			sessionID:       "session-nested",
+			cwd:             nestedRepoSubdir,
+			wantKind:        agentSessionRailSectionKindProject,
+			wantProjectPath: nestedRepoCanonical,
+			wantKey:         agentSessionRailSectionKeyForProject(nestedRepo),
+		},
+	} {
+		if _, err := store.ReportSessionState(ctx, agentactivitybiz.SessionStateReport{
+			WorkspaceID:      "ws-agent-rail",
+			AgentSessionID:   tc.sessionID,
+			Origin:           agentsessionstore.WorkspaceAgentSessionOriginRuntime,
+			Provider:         "codex",
+			Cwd:              tc.cwd,
+			Status:           "completed",
+			OccurredAtUnixMS: 100,
+		}); err != nil {
+			t.Fatalf("ReportSessionState(%s) error = %v", tc.sessionID, err)
+		}
+		rail := getTestAgentSessionRailSection(t, store, "ws-agent-rail", tc.sessionID)
+		if rail.Kind != tc.wantKind || rail.ProjectPath != tc.wantProjectPath || rail.Key != tc.wantKey {
+			t.Fatalf("rail(%s) = %#v, want kind=%q projectPath=%q key=%q", tc.sessionID, rail, tc.wantKind, tc.wantProjectPath, tc.wantKey)
+		}
+	}
+}
+
+func TestSQLiteStoreAgentSessionRailProjectDeletionDoesNotRewriteHistory(t *testing.T) {
+	t.Parallel()
+
+	store := openTestSQLiteStore(t)
+	ctx := context.Background()
+
+	if err := store.Create(ctx, workspacebiz.Summary{
+		ID:   "ws-agent-rail-delete",
+		Name: "Workspace Agent Rail Delete",
+	}); err != nil {
+		t.Fatalf("Create() error = %v", err)
+	}
+
+	repo := filepath.Join(t.TempDir(), "repo")
+	repoSubdir := filepath.Join(repo, "pkg")
+	if err := mkdirAll(repoSubdir); err != nil {
+		t.Fatalf("mkdir repo error = %v", err)
+	}
+	repoCanonical := normalizeAgentSessionRailPath(repo)
+	if _, err := store.PutUserProject(ctx, userprojectbiz.Project{
+		ID:    "project-repo",
+		Path:  repo,
+		Label: "repo",
+	}); err != nil {
+		t.Fatalf("PutUserProject(repo) error = %v", err)
+	}
+
+	if _, err := store.ReportSessionState(ctx, agentactivitybiz.SessionStateReport{
+		WorkspaceID:      "ws-agent-rail-delete",
+		AgentSessionID:   "session-before-delete",
+		Origin:           agentsessionstore.WorkspaceAgentSessionOriginRuntime,
+		Provider:         "codex",
+		Cwd:              repoSubdir,
+		Status:           "completed",
+		OccurredAtUnixMS: 100,
+	}); err != nil {
+		t.Fatalf("ReportSessionState(before delete) error = %v", err)
+	}
+	beforeDelete := getTestAgentSessionRailSection(t, store, "ws-agent-rail-delete", "session-before-delete")
+	if beforeDelete.Key != agentSessionRailSectionKeyForProject(repoCanonical) {
+		t.Fatalf("before delete rail = %#v, want project key", beforeDelete)
+	}
+
+	if err := store.DeleteUserProject(ctx, "project-repo"); err != nil {
+		t.Fatalf("DeleteUserProject() error = %v", err)
+	}
+	if _, err := store.ReportSessionState(ctx, agentactivitybiz.SessionStateReport{
+		WorkspaceID:      "ws-agent-rail-delete",
+		AgentSessionID:   "session-before-delete",
+		Origin:           agentsessionstore.WorkspaceAgentSessionOriginRuntime,
+		Provider:         "codex",
+		Cwd:              repoSubdir,
+		Status:           "completed",
+		OccurredAtUnixMS: 150,
+	}); err != nil {
+		t.Fatalf("ReportSessionState(after delete same cwd) error = %v", err)
+	}
+	afterDeleteUpsert := getTestAgentSessionRailSection(t, store, "ws-agent-rail-delete", "session-before-delete")
+	if afterDeleteUpsert != beforeDelete {
+		t.Fatalf("rail changed after same-cwd upsert with deleted user project: got %#v want %#v", afterDeleteUpsert, beforeDelete)
+	}
+
+	if _, err := store.PutUserProject(ctx, userprojectbiz.Project{
+		ID:    "project-repo-readded",
+		Path:  repo,
+		Label: "repo",
+	}); err != nil {
+		t.Fatalf("PutUserProject(repo readded) error = %v", err)
+	}
+	if _, err := store.ReportSessionState(ctx, agentactivitybiz.SessionStateReport{
+		WorkspaceID:      "ws-agent-rail-delete",
+		AgentSessionID:   "session-after-readd",
+		Origin:           agentsessionstore.WorkspaceAgentSessionOriginRuntime,
+		Provider:         "codex",
+		Cwd:              repoSubdir,
+		Status:           "completed",
+		OccurredAtUnixMS: 200,
+	}); err != nil {
+		t.Fatalf("ReportSessionState(after readd) error = %v", err)
+	}
+	afterReadd := getTestAgentSessionRailSection(t, store, "ws-agent-rail-delete", "session-after-readd")
+	if afterReadd.Key != beforeDelete.Key {
+		t.Fatalf("rail key after readd = %q, want %q", afterReadd.Key, beforeDelete.Key)
+	}
+}
+
+func TestSQLiteStoreAgentSessionRailReclassifiesWhenCwdChangesOrRailMissing(t *testing.T) {
+	t.Parallel()
+
+	store := openTestSQLiteStore(t)
+	ctx := context.Background()
+
+	if err := store.Create(ctx, workspacebiz.Summary{
+		ID:   "ws-agent-rail-reclassify",
+		Name: "Workspace Agent Rail Reclassify",
+	}); err != nil {
+		t.Fatalf("Create() error = %v", err)
+	}
+
+	root := t.TempDir()
+	repo := filepath.Join(root, "repo")
+	repoSubdir := filepath.Join(repo, "pkg")
+	otherDir := filepath.Join(root, "other")
+	for _, path := range []string{repoSubdir, otherDir} {
+		if err := mkdirAll(path); err != nil {
+			t.Fatalf("mkdir %q error = %v", path, err)
+		}
+	}
+	repoCanonical := normalizeAgentSessionRailPath(repo)
+	if _, err := store.PutUserProject(ctx, userprojectbiz.Project{
+		ID:    "project-repo",
+		Path:  repo,
+		Label: "repo",
+	}); err != nil {
+		t.Fatalf("PutUserProject(repo) error = %v", err)
+	}
+
+	if _, err := store.ReportSessionState(ctx, agentactivitybiz.SessionStateReport{
+		WorkspaceID:      "ws-agent-rail-reclassify",
+		AgentSessionID:   "session-cwd-change",
+		Origin:           agentsessionstore.WorkspaceAgentSessionOriginRuntime,
+		Provider:         "codex",
+		Cwd:              repoSubdir,
+		Status:           "running",
+		OccurredAtUnixMS: 100,
+	}); err != nil {
+		t.Fatalf("ReportSessionState(project cwd) error = %v", err)
+	}
+	if _, err := store.ReportSessionState(ctx, agentactivitybiz.SessionStateReport{
+		WorkspaceID:      "ws-agent-rail-reclassify",
+		AgentSessionID:   "session-cwd-change",
+		Origin:           agentsessionstore.WorkspaceAgentSessionOriginRuntime,
+		Provider:         "codex",
+		Cwd:              otherDir,
+		Status:           "completed",
+		OccurredAtUnixMS: 200,
+	}); err != nil {
+		t.Fatalf("ReportSessionState(other cwd) error = %v", err)
+	}
+	changed := getTestAgentSessionRailSection(t, store, "ws-agent-rail-reclassify", "session-cwd-change")
+	if changed.Kind != agentSessionRailSectionKindConversations ||
+		changed.ProjectPath != "" ||
+		changed.Key != agentSessionRailSectionKeyConversations {
+		t.Fatalf("changed cwd rail = %#v, want conversations", changed)
+	}
+
+	if _, err := store.ReportSessionState(ctx, agentactivitybiz.SessionStateReport{
+		WorkspaceID:      "ws-agent-rail-reclassify",
+		AgentSessionID:   "session-empty-rail",
+		Origin:           agentsessionstore.WorkspaceAgentSessionOriginRuntime,
+		Provider:         "codex",
+		Cwd:              repoSubdir,
+		Status:           "running",
+		OccurredAtUnixMS: 100,
+	}); err != nil {
+		t.Fatalf("ReportSessionState(empty rail initial) error = %v", err)
+	}
+	if _, err := store.db.ExecContext(ctx, `
+UPDATE workspace_agent_sessions
+SET rail_section_kind = '',
+    rail_project_path = '',
+    rail_section_key = ''
+WHERE workspace_id = ? AND agent_session_id = ?;
+`, "ws-agent-rail-reclassify", "session-empty-rail"); err != nil {
+		t.Fatalf("clear rail fields error = %v", err)
+	}
+	if _, err := store.ReportSessionState(ctx, agentactivitybiz.SessionStateReport{
+		WorkspaceID:      "ws-agent-rail-reclassify",
+		AgentSessionID:   "session-empty-rail",
+		Origin:           agentsessionstore.WorkspaceAgentSessionOriginRuntime,
+		Provider:         "codex",
+		Cwd:              repoSubdir,
+		Status:           "completed",
+		OccurredAtUnixMS: 200,
+	}); err != nil {
+		t.Fatalf("ReportSessionState(empty rail repair) error = %v", err)
+	}
+	repaired := getTestAgentSessionRailSection(t, store, "ws-agent-rail-reclassify", "session-empty-rail")
+	if repaired.Key != agentSessionRailSectionKeyForProject(repoCanonical) {
+		t.Fatalf("repaired rail = %#v, want project key", repaired)
+	}
+}
+
+func TestSQLiteStoreAgentSessionRailMessageOnlySessionUsesConversations(t *testing.T) {
+	t.Parallel()
+
+	store := openTestSQLiteStore(t)
+	ctx := context.Background()
+
+	if err := store.Create(ctx, workspacebiz.Summary{
+		ID:   "ws-agent-rail-message-only",
+		Name: "Workspace Agent Rail Message Only",
+	}); err != nil {
+		t.Fatalf("Create() error = %v", err)
+	}
+
+	if _, err := store.ReportSessionMessages(ctx, agentactivitybiz.SessionMessageReport{
+		WorkspaceID:    "ws-agent-rail-message-only",
+		AgentSessionID: "session-message-only",
+		Origin:         agentsessionstore.WorkspaceAgentSessionOriginRuntime,
+		Provider:       "codex",
+		Messages: []agentactivitybiz.MessageUpdate{{
+			MessageID:        "message-1",
+			Role:             "user",
+			Kind:             "text",
+			Status:           "completed",
+			Payload:          map[string]any{"text": "hello"},
+			OccurredAtUnixMS: 100,
+		}},
+	}); err != nil {
+		t.Fatalf("ReportSessionMessages() error = %v", err)
+	}
+	rail := getTestAgentSessionRailSection(t, store, "ws-agent-rail-message-only", "session-message-only")
+	if rail.Kind != agentSessionRailSectionKindConversations ||
+		rail.ProjectPath != "" ||
+		rail.Key != agentSessionRailSectionKeyConversations {
+		t.Fatalf("message-only rail = %#v, want conversations", rail)
+	}
+}
+
+func TestAgentSessionRailScratchDateDirectoriesUseConversations(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	for _, cwd := range []string{
+		filepath.Join(home, "Documents", "Codex", "2026-07-03", "codex-session"),
+		filepath.Join(home, "Documents", "Tutti", "2026-07-03", "tutti-session"),
+	} {
+		if err := mkdirAll(cwd); err != nil {
+			t.Fatalf("mkdir %q error = %v", cwd, err)
+		}
+		rail := classifyAgentSessionRailSection(cwd, nil)
+		if rail.Kind != agentSessionRailSectionKindConversations ||
+			rail.ProjectPath != "" ||
+			rail.Key != agentSessionRailSectionKeyConversations {
+			t.Fatalf("scratch cwd %q rail = %#v, want conversations", cwd, rail)
+		}
+	}
+}
+
+func TestSQLiteStoreMigrationBackfillsAgentSessionRailSectionsFromUserProjects(t *testing.T) {
+	t.Parallel()
+
+	dbPath := filepath.Join(t.TempDir(), "tuttid.db")
+	store, err := OpenSQLiteStore(dbPath)
+	if err != nil {
+		t.Fatalf("OpenSQLiteStore() error = %v", err)
+	}
+	t.Cleanup(func() {
+		_ = store.Close()
+	})
+
+	repo := filepath.Join(t.TempDir(), "repo")
+	repoSubdir := filepath.Join(repo, "pkg")
+	otherDir := filepath.Join(t.TempDir(), "other")
+	for _, path := range []string{repoSubdir, otherDir} {
+		if err := mkdirAll(path); err != nil {
+			t.Fatalf("mkdir %q error = %v", path, err)
+		}
+	}
+	repoCanonical := normalizeAgentSessionRailPath(repo)
+
+	ctx := context.Background()
+	if _, err := store.db.ExecContext(ctx, `
+CREATE TABLE tuttid_schema_migrations (
+  id TEXT PRIMARY KEY,
+  applied_at_unix_ms INTEGER NOT NULL
+);
+CREATE TABLE user_projects (
+  id TEXT PRIMARY KEY,
+  path TEXT NOT NULL UNIQUE,
+  label TEXT NOT NULL,
+  created_at_unix_ms INTEGER NOT NULL,
+  updated_at_unix_ms INTEGER NOT NULL,
+  last_used_at_unix_ms INTEGER NOT NULL DEFAULT 0
+);
+CREATE TABLE workspace_agent_sessions (
+  workspace_id TEXT NOT NULL,
+  agent_session_id TEXT NOT NULL,
+  cwd TEXT NOT NULL DEFAULT '',
+  deleted_at_unix_ms INTEGER NOT NULL DEFAULT 0,
+  updated_at_unix_ms INTEGER NOT NULL,
+  PRIMARY KEY (workspace_id, agent_session_id)
+);
+`); err != nil {
+		t.Fatalf("create legacy rail schema error = %v", err)
+	}
+	if _, err := store.db.ExecContext(ctx, `
+INSERT INTO user_projects (id, path, label, created_at_unix_ms, updated_at_unix_ms, last_used_at_unix_ms)
+VALUES ('project-repo', ?, 'repo', 1, 1, 1);
+`, repo); err != nil {
+		t.Fatalf("insert legacy user project error = %v", err)
+	}
+	if _, err := store.db.ExecContext(ctx, `
+INSERT INTO workspace_agent_sessions (workspace_id, agent_session_id, cwd, deleted_at_unix_ms, updated_at_unix_ms)
+VALUES
+  ('ws-agent-rail-migration', 'session-project', ?, 0, 1),
+  ('ws-agent-rail-migration', 'session-conversations', ?, 0, 1);
+`, repoSubdir, otherDir); err != nil {
+		t.Fatalf("insert legacy agent sessions error = %v", err)
+	}
+
+	if err := store.applyWorkspaceAgentActivityRailV1(ctx); err != nil {
+		t.Fatalf("applyWorkspaceAgentActivityRailV1() error = %v", err)
+	}
+
+	projectRail := getTestAgentSessionRailSection(t, store, "ws-agent-rail-migration", "session-project")
+	if projectRail.Kind != agentSessionRailSectionKindProject ||
+		projectRail.ProjectPath != repoCanonical ||
+		projectRail.Key != agentSessionRailSectionKeyForProject(repoCanonical) {
+		t.Fatalf("project rail = %#v, want project %q", projectRail, repoCanonical)
+	}
+	conversationRail := getTestAgentSessionRailSection(t, store, "ws-agent-rail-migration", "session-conversations")
+	if conversationRail.Kind != agentSessionRailSectionKindConversations ||
+		conversationRail.ProjectPath != "" ||
+		conversationRail.Key != agentSessionRailSectionKeyConversations {
+		t.Fatalf("conversation rail = %#v, want conversations", conversationRail)
 	}
 }
 
@@ -1505,6 +1922,36 @@ func openTestSQLiteStore(t *testing.T) *SQLiteStore {
 	}
 
 	return store
+}
+
+type testAgentSessionRailSection struct {
+	Kind        string
+	ProjectPath string
+	Key         string
+}
+
+func getTestAgentSessionRailSection(
+	t *testing.T,
+	store *SQLiteStore,
+	workspaceID string,
+	agentSessionID string,
+) testAgentSessionRailSection {
+	t.Helper()
+
+	row := store.db.QueryRowContext(context.Background(), `
+SELECT rail_section_kind, rail_project_path, rail_section_key
+FROM workspace_agent_sessions
+WHERE workspace_id = ? AND agent_session_id = ?
+`, workspaceID, agentSessionID)
+	var rail testAgentSessionRailSection
+	if err := row.Scan(&rail.Kind, &rail.ProjectPath, &rail.Key); err != nil {
+		t.Fatalf("scan agent session rail section: %v", err)
+	}
+	return rail
+}
+
+func mkdirAll(path string) error {
+	return os.MkdirAll(path, 0o755)
 }
 
 func createLegacyAgentActivityV4MarkedDatabaseWithoutAgentTargetID(t *testing.T, dbPath string) {

--- a/services/tuttid/data/workspace/sqlite_store_test.go
+++ b/services/tuttid/data/workspace/sqlite_store_test.go
@@ -778,12 +778,124 @@ func TestAgentSessionRailScratchDateDirectoriesUseConversations(t *testing.T) {
 		if err := mkdirAll(cwd); err != nil {
 			t.Fatalf("mkdir %q error = %v", cwd, err)
 		}
-		rail := classifyAgentSessionRailSection(cwd, nil)
+		rail := classifyAgentSessionRailSection(cwd, nil, nil)
 		if rail.Kind != agentSessionRailSectionKindConversations ||
 			rail.ProjectPath != "" ||
 			rail.Key != agentSessionRailSectionKeyConversations {
 			t.Fatalf("scratch cwd %q rail = %#v, want conversations", cwd, rail)
 		}
+	}
+}
+
+func TestSQLiteStoreAgentSessionRailNoProjectPrecedesParentProject(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	store := openTestSQLiteStore(t)
+	ctx := context.Background()
+
+	if err := store.Create(ctx, workspacebiz.Summary{
+		ID:   "ws-agent-rail-no-project",
+		Name: "Workspace Agent Rail No Project",
+	}); err != nil {
+		t.Fatalf("Create() error = %v", err)
+	}
+
+	scratchCwd := filepath.Join(home, "Documents", "Codex", "2026-07-03", "codex-session")
+	importedNoProjectCwd := filepath.Join(home, "external-import")
+	for _, path := range []string{scratchCwd, importedNoProjectCwd} {
+		if err := mkdirAll(path); err != nil {
+			t.Fatalf("mkdir %q error = %v", path, err)
+		}
+	}
+	if _, err := store.PutUserProject(ctx, userprojectbiz.Project{
+		ID:    "project-home",
+		Path:  home,
+		Label: "home",
+	}); err != nil {
+		t.Fatalf("PutUserProject(home) error = %v", err)
+	}
+
+	for _, tc := range []struct {
+		sessionID      string
+		cwd            string
+		runtimeContext map[string]any
+	}{
+		{
+			sessionID: "session-scratch-under-home",
+			cwd:       scratchCwd,
+		},
+		{
+			sessionID:      "session-import-marker-under-home",
+			cwd:            importedNoProjectCwd,
+			runtimeContext: map[string]any{"externalImportNoProject": true},
+		},
+	} {
+		if _, err := store.ReportSessionState(ctx, agentactivitybiz.SessionStateReport{
+			WorkspaceID:      "ws-agent-rail-no-project",
+			AgentSessionID:   tc.sessionID,
+			Origin:           agentsessionstore.WorkspaceAgentSessionOriginRuntime,
+			Provider:         "codex",
+			RuntimeContext:   tc.runtimeContext,
+			Cwd:              tc.cwd,
+			Status:           "completed",
+			OccurredAtUnixMS: 100,
+		}); err != nil {
+			t.Fatalf("ReportSessionState(%s) error = %v", tc.sessionID, err)
+		}
+		rail := getTestAgentSessionRailSection(t, store, "ws-agent-rail-no-project", tc.sessionID)
+		if rail.Kind != agentSessionRailSectionKindConversations ||
+			rail.ProjectPath != "" ||
+			rail.Key != agentSessionRailSectionKeyConversations {
+			t.Fatalf("rail(%s) = %#v, want conversations", tc.sessionID, rail)
+		}
+	}
+}
+
+func TestSQLiteStoreAgentSessionRailExactProjectPrecedesNoProject(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	store := openTestSQLiteStore(t)
+	ctx := context.Background()
+
+	if err := store.Create(ctx, workspacebiz.Summary{
+		ID:   "ws-agent-rail-exact-project",
+		Name: "Workspace Agent Rail Exact Project",
+	}); err != nil {
+		t.Fatalf("Create() error = %v", err)
+	}
+
+	scratchCwd := filepath.Join(home, "Documents", "Codex", "2026-07-03", "codex-session")
+	if err := mkdirAll(scratchCwd); err != nil {
+		t.Fatalf("mkdir scratch cwd error = %v", err)
+	}
+	scratchCanonical := normalizeAgentSessionRailPath(scratchCwd)
+	if _, err := store.PutUserProject(ctx, userprojectbiz.Project{
+		ID:    "project-scratch",
+		Path:  scratchCwd,
+		Label: "scratch",
+	}); err != nil {
+		t.Fatalf("PutUserProject(scratch) error = %v", err)
+	}
+
+	if _, err := store.ReportSessionState(ctx, agentactivitybiz.SessionStateReport{
+		WorkspaceID:      "ws-agent-rail-exact-project",
+		AgentSessionID:   "session-exact-scratch",
+		Origin:           agentsessionstore.WorkspaceAgentSessionOriginRuntime,
+		Provider:         "codex",
+		RuntimeContext:   map[string]any{"externalImportNoProject": true},
+		Cwd:              scratchCwd,
+		Status:           "completed",
+		OccurredAtUnixMS: 100,
+	}); err != nil {
+		t.Fatalf("ReportSessionState() error = %v", err)
+	}
+	rail := getTestAgentSessionRailSection(t, store, "ws-agent-rail-exact-project", "session-exact-scratch")
+	if rail.Kind != agentSessionRailSectionKindProject ||
+		rail.ProjectPath != scratchCanonical ||
+		rail.Key != agentSessionRailSectionKeyForProject(scratchCanonical) {
+		t.Fatalf("rail = %#v, want exact scratch project %q", rail, scratchCanonical)
 	}
 }
 
@@ -801,8 +913,9 @@ func TestSQLiteStoreMigrationBackfillsAgentSessionRailSectionsFromUserProjects(t
 
 	repo := filepath.Join(t.TempDir(), "repo")
 	repoSubdir := filepath.Join(repo, "pkg")
+	importedNoProjectDir := filepath.Join(repo, "imported-no-project")
 	otherDir := filepath.Join(t.TempDir(), "other")
-	for _, path := range []string{repoSubdir, otherDir} {
+	for _, path := range []string{repoSubdir, importedNoProjectDir, otherDir} {
 		if err := mkdirAll(path); err != nil {
 			t.Fatalf("mkdir %q error = %v", path, err)
 		}
@@ -826,6 +939,7 @@ CREATE TABLE user_projects (
 CREATE TABLE workspace_agent_sessions (
   workspace_id TEXT NOT NULL,
   agent_session_id TEXT NOT NULL,
+  runtime_context_json TEXT NOT NULL DEFAULT '{}',
   cwd TEXT NOT NULL DEFAULT '',
   deleted_at_unix_ms INTEGER NOT NULL DEFAULT 0,
   updated_at_unix_ms INTEGER NOT NULL,
@@ -841,11 +955,12 @@ VALUES ('project-repo', ?, 'repo', 1, 1, 1);
 		t.Fatalf("insert legacy user project error = %v", err)
 	}
 	if _, err := store.db.ExecContext(ctx, `
-INSERT INTO workspace_agent_sessions (workspace_id, agent_session_id, cwd, deleted_at_unix_ms, updated_at_unix_ms)
+INSERT INTO workspace_agent_sessions (workspace_id, agent_session_id, runtime_context_json, cwd, deleted_at_unix_ms, updated_at_unix_ms)
 VALUES
-  ('ws-agent-rail-migration', 'session-project', ?, 0, 1),
-  ('ws-agent-rail-migration', 'session-conversations', ?, 0, 1);
-`, repoSubdir, otherDir); err != nil {
+  ('ws-agent-rail-migration', 'session-project', '{}', ?, 0, 1),
+  ('ws-agent-rail-migration', 'session-import-no-project', '{"externalImportNoProject":true}', ?, 0, 1),
+  ('ws-agent-rail-migration', 'session-conversations', '{}', ?, 0, 1);
+`, repoSubdir, importedNoProjectDir, otherDir); err != nil {
 		t.Fatalf("insert legacy agent sessions error = %v", err)
 	}
 
@@ -858,6 +973,12 @@ VALUES
 		projectRail.ProjectPath != repoCanonical ||
 		projectRail.Key != agentSessionRailSectionKeyForProject(repoCanonical) {
 		t.Fatalf("project rail = %#v, want project %q", projectRail, repoCanonical)
+	}
+	importNoProjectRail := getTestAgentSessionRailSection(t, store, "ws-agent-rail-migration", "session-import-no-project")
+	if importNoProjectRail.Kind != agentSessionRailSectionKindConversations ||
+		importNoProjectRail.ProjectPath != "" ||
+		importNoProjectRail.Key != agentSessionRailSectionKeyConversations {
+		t.Fatalf("import no-project rail = %#v, want conversations", importNoProjectRail)
 	}
 	conversationRail := getTestAgentSessionRailSection(t, store, "ws-agent-rail-migration", "session-conversations")
 	if conversationRail.Kind != agentSessionRailSectionKindConversations ||


### PR DESCRIPTION
## Summary
- add daemon-owned rail classification and persistence fields for workspace agent sessions
- migrate/backfill rail section metadata and keep same-cwd historical rail stable
- cover project matching, scratch cwd, message-only sessions, reclassification, and legacy migration backfill

## Checks
- git diff --check HEAD~1 HEAD
- go test ./services/tuttid/data/workspace -count=1
- PATH="/Users/liying/go/bin:/Users/liying/.codex/packages/standalone/releases/0.142.5-aarch64-apple-darwin/codex-path:/Users/liying/.codex/packages/standalone/releases/0.142.5-aarch64-apple-darwin/codex-path:/Users/liying/.tutti/agent/runs/918fa72b-0e33-4dd6-b8c6-796e02dbc810/codex-home/tmp/arg0/codex-arg0oCmdbO:/Users/liying/.tutti/bin:/Users/liying/.local/bin:/usr/local/bin:/System/Cryptexes/App/usr/bin:/usr/bin:/bin:/usr/sbin:/sbin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/local/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/appleinternal/bin:/opt/pmk/env/global/bin:/Users/liying/bin:/Users/liying/.npm-global/bin:/Users/liying/.n/bin:/Users/liying/n/bin:/Users/liying/.volta/bin:/Users/liying/.asdf/shims:/Users/liying/.mise/shims:/Users/liying/.bun/bin:/Users/liying/Library/pnpm:/opt/homebrew/bin" pnpm lint:go
- PATH="/Users/liying/go/bin:/Users/liying/.codex/packages/standalone/releases/0.142.5-aarch64-apple-darwin/codex-path:/Users/liying/.codex/packages/standalone/releases/0.142.5-aarch64-apple-darwin/codex-path:/Users/liying/.tutti/agent/runs/918fa72b-0e33-4dd6-b8c6-796e02dbc810/codex-home/tmp/arg0/codex-arg0oCmdbO:/Users/liying/.tutti/bin:/Users/liying/.local/bin:/usr/local/bin:/System/Cryptexes/App/usr/bin:/usr/bin:/bin:/usr/sbin:/sbin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/local/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/appleinternal/bin:/opt/pmk/env/global/bin:/Users/liying/bin:/Users/liying/.npm-global/bin:/Users/liying/.n/bin:/Users/liying/n/bin:/Users/liying/.volta/bin:/Users/liying/.asdf/shims:/Users/liying/.mise/shims:/Users/liying/.bun/bin:/Users/liying/Library/pnpm:/opt/homebrew/bin" git push --set-upstream origin fix/agent-session-rail-fields (pre-push pnpm check:full passed)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added persistent “rail section” grouping for agent sessions, distinguishing project-based vs conversations-style sessions.
  * Improved migration support so existing sessions get the correct persisted grouping.

* **Bug Fixes**
  * Ensures sessions keep the same rail assignment when their location hasn’t changed (including during pagination).
  * Prevents incorrect regrouping when projects are deleted or session state is repaired.

* **Documentation**
  * Updated troubleshooting guidance for missing project session rail grouping behavior.

* **Tests**
  * Added classification, precedence, scratch-date handling, repair/reclassification, project deletion, and migration backfill coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->