### PR TITLE
fix(workspace): launch app factory sessions with agent target id

### DIFF
--- a/services/tuttid/service/workspace/app_factory.go
+++ b/services/tuttid/service/workspace/app_factory.go
@@ -319,6 +319,7 @@ func (s *AppFactoryService) Create(ctx context.Context, workspaceID string, inpu
 	}
 	session, err := s.AgentSessionService.Create(ctx, workspaceID, agentservice.CreateSessionInput{
 		AgentSessionID: agentSessionID,
+		AgentTargetID:  factoryAgentTargetID(job.Provider),
 		Provider:       job.Provider,
 		InitialContent: agentservice.TextPromptContent(initialPrompt),
 		Title:          &title,

--- a/services/tuttid/service/workspace/app_factory_helpers.go
+++ b/services/tuttid/service/workspace/app_factory_helpers.go
@@ -5,6 +5,8 @@ import (
 	"strconv"
 	"strings"
 
+	agentproviderbiz "github.com/tutti-os/tutti/services/tuttid/biz/agentprovider"
+	agenttargetbiz "github.com/tutti-os/tutti/services/tuttid/biz/agenttarget"
 	workspacebiz "github.com/tutti-os/tutti/services/tuttid/biz/workspace"
 )
 
@@ -14,6 +16,17 @@ func normalizeFactoryProvider(provider string) string {
 		return defaultFactoryProvider
 	}
 	return provider
+}
+
+func factoryAgentTargetID(provider string) string {
+	switch normalizeFactoryProvider(provider) {
+	case agentproviderbiz.Codex:
+		return agenttargetbiz.IDLocalCodex
+	case agentproviderbiz.ClaudeCode:
+		return agenttargetbiz.IDLocalClaudeCode
+	default:
+		return ""
+	}
 }
 
 func appFactoryActionKey(action string, workspaceID string, jobID string) string {

--- a/services/tuttid/service/workspace/app_factory_test.go
+++ b/services/tuttid/service/workspace/app_factory_test.go
@@ -13,6 +13,7 @@ import (
 	agentsessionstore "github.com/tutti-os/tutti/packages/agentactivity/daemon/activity"
 	workspacefiles "github.com/tutti-os/tutti/packages/workspace/files"
 	agentactivitybiz "github.com/tutti-os/tutti/services/tuttid/biz/agentactivity"
+	agenttargetbiz "github.com/tutti-os/tutti/services/tuttid/biz/agenttarget"
 	workspacebiz "github.com/tutti-os/tutti/services/tuttid/biz/workspace"
 	builtinapps "github.com/tutti-os/tutti/services/tuttid/builtin-apps"
 	workspacedata "github.com/tutti-os/tutti/services/tuttid/data/workspace"
@@ -247,6 +248,9 @@ func TestAppFactoryServiceCreateUsesDraftDirAndReferenceContext(t *testing.T) {
 	if sessions.createInput.Cwd == nil || *sessions.createInput.Cwd != job.DraftDir {
 		t.Fatalf("CreateSession cwd = %v, want %q", sessions.createInput.Cwd, job.DraftDir)
 	}
+	if sessions.createInput.AgentTargetID != agenttargetbiz.IDLocalCodex {
+		t.Fatalf("CreateSession agentTargetId = %q, want %q", sessions.createInput.AgentTargetID, agenttargetbiz.IDLocalCodex)
+	}
 	if job.ReasoningEffort != "high" {
 		t.Fatalf("job reasoningEffort = %q, want high", job.ReasoningEffort)
 	}
@@ -448,6 +452,73 @@ func TestAppFactoryServiceCreateUsesDraftDirAndReferenceContext(t *testing.T) {
 	}
 	if secondJob.DraftDir == job.DraftDir {
 		t.Fatalf("second draft dir reused first draft dir %q", job.DraftDir)
+	}
+}
+
+func TestAppFactoryServiceCreateLaunchesSessionsWithAgentTargetID(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name         string
+		provider     string
+		wantTargetID string
+		wantProvider string
+	}{
+		{
+			name:         "codex",
+			provider:     "codex",
+			wantTargetID: agenttargetbiz.IDLocalCodex,
+			wantProvider: "codex",
+		},
+		{
+			name:         "claude code",
+			provider:     "claude-code",
+			wantTargetID: agenttargetbiz.IDLocalClaudeCode,
+			wantProvider: "claude-code",
+		},
+		{
+			name:         "default provider",
+			provider:     "",
+			wantTargetID: agenttargetbiz.IDLocalCodex,
+			wantProvider: "codex",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			sessions := &factoryAgentSessionServiceStub{}
+			service := AppFactoryService{
+				Store:               newAppFactoryStoreStub(),
+				AgentSessionService: sessions,
+				StateDir:            t.TempDir(),
+				WorkspaceRootResolver: workspaceRootResolverStub{root: workspacefiles.WorkspaceRoot{
+					LogicalRoot:  "/workspace",
+					PhysicalRoot: "/Users/example",
+				}},
+				WorkspaceStore: &catalogStoreStub{
+					getWorkspace: workspacebiz.Summary{ID: "ws-1", Name: "Workspace"},
+				},
+			}
+
+			job, err := service.Create(context.Background(), "ws-1", CreateAppFactoryJobInput{
+				DisplayName: "Target App",
+				Prompt:      "Create an app.",
+				Provider:    tt.provider,
+			})
+			if err != nil {
+				t.Fatalf("Create() error = %v", err)
+			}
+			if job.Status != workspacebiz.AppFactoryJobStatusGenerating {
+				t.Fatalf("status = %q, want generating", job.Status)
+			}
+			if sessions.createInput.AgentTargetID != tt.wantTargetID {
+				t.Fatalf("CreateSession agentTargetId = %q, want %q", sessions.createInput.AgentTargetID, tt.wantTargetID)
+			}
+			if sessions.createInput.Provider != tt.wantProvider {
+				t.Fatalf("CreateSession provider = %q, want %q", sessions.createInput.Provider, tt.wantProvider)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
## Problem

App Factory ("create app" in App Center) fails instantly on every job with:

```
invalid agent session request: agent target id is required for agent session launch
```

This is a regression from the agent-target launch feature (f53dc588, refined in 49042e2f): `agent.Service.Create` now routes through `resolveCreateSessionLaunch`, which requires `CreateSessionInput.AgentTargetID`, resolves the target from the agent target store, and derives the runtime `ProviderTargetRef` from it. The App Factory caller in `services/tuttid/service/workspace/app_factory.go` was never updated — it still passed only `Provider`, so every job failed at session creation.

## Fix

Pass `AgentTargetID` derived from the job provider via a small `factoryAgentTargetID` helper (reusing `normalizeFactoryProvider`):

- `codex` (and empty/default) → `agenttargetbiz.IDLocalCodex` (`local:codex`)
- `claude-code` → `agenttargetbiz.IDLocalClaudeCode` (`local:claude-code`)

These match the builtin system targets in `agenttargetbiz.DefaultSystemTargets`, so the service-side provider/target consistency check passes and the `ProviderTargetRef` is derived from the target store as designed. `Provider` is still passed as before.

## Tests

- `TestAppFactoryServiceCreateLaunchesSessionsWithAgentTargetID`: table test asserting the `CreateSessionInput` carries the right agent target id and provider for `codex`, `claude-code`, and the empty/default provider.
- Extended `TestAppFactoryServiceCreateUsesDraftDirAndReferenceContext` to assert the default launch uses `local:codex`.

`go test ./service/workspace/...` (tuttid module): all app factory tests pass. Two pre-existing `TestAppCenterServiceInitializes*` failures reproduce on clean origin/main (missing generated builtin app archives in a fresh worktree) and are unrelated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Agent sessions launched from the app factory now use the correct target based on the selected provider.
  * Provider values are handled more consistently, including normalized and default cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->