### PR TITLE
fix(workbench): release header drag region while message center is open

### DIFF
--- a/apps/desktop/src/renderer/src/features/workspace-workbench/ui/WorkspaceChrome.test.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/ui/WorkspaceChrome.test.ts
@@ -9,6 +9,16 @@ const source = readFileSync(
   "utf8"
 );
 
+test("workspace chrome header releases the drag region while the message center is open", () => {
+  assert.match(
+    source,
+    /messageCenterOpen\s*\?\s*"\[-webkit-app-region:no-drag\]"\s*:\s*"\[-webkit-app-region:drag\]"/
+  );
+  assert.doesNotMatch(source, /min-h-\[52px\][^"]*\[-webkit-app-region:drag\]/);
+  assert.match(source, /open=\{messageCenterOpen\}/);
+  assert.match(source, /setOpen=\{setMessageCenterOpen\}/);
+});
+
 test("workspace chrome deck submit forwards to submitPlanDecision instead of branching on plan action", () => {
   // Must call submitPlanDecision with promptKind threaded from the panel
   assert.match(source, /workspaceAgentActivityService\.submitPlanDecision\(/);

--- a/apps/desktop/src/renderer/src/features/workspace-workbench/ui/WorkspaceChrome.tsx
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/ui/WorkspaceChrome.tsx
@@ -167,6 +167,7 @@ export function WorkspaceChrome({
           : `calc(${WORKSPACE_CHROME_MAC_TRAFFIC_LIGHT_INSET_PX}px + var(--cove-workspace-mac-traffic-light-gutter, ${WORKSPACE_CHROME_MAC_TRAFFIC_LIGHT_GUTTER_PX}px))`
       } as React.CSSProperties)
     : undefined;
+  const [messageCenterOpen, setMessageCenterOpen] = useState(false);
   const [externalImportWizardProviders, setExternalImportWizardProviders] =
     useState<WorkspaceAgentProvider[] | undefined>(undefined);
   const [externalImportWizardOpen, setExternalImportWizardOpen] =
@@ -183,7 +184,10 @@ export function WorkspaceChrome({
     <>
       <header
         className={cn(
-          "grid min-h-[52px] items-center gap-4 bg-transparent px-4 [-webkit-app-region:drag]",
+          "grid min-h-[52px] items-center gap-4 bg-transparent px-4",
+          messageCenterOpen
+            ? "[-webkit-app-region:no-drag]"
+            : "[-webkit-app-region:drag]",
           "grid-cols-[max-content_minmax(0,1fr)_max-content]",
           isDarwin && "pl-[var(--workspace-chrome-left-padding)]",
           isWindows &&
@@ -212,6 +216,8 @@ export function WorkspaceChrome({
           <WorkspaceFeedbackGroupPopover />
           <WorkspaceAgentMessageCenterAction
             launchNode={launchNode}
+            open={messageCenterOpen}
+            setOpen={setMessageCenterOpen}
             workspace={workspace}
           />
           <WorkspaceMissionControlActions
@@ -244,9 +250,13 @@ export function WorkspaceChrome({
 
 function WorkspaceAgentMessageCenterAction({
   launchNode,
+  open,
+  setOpen,
   workspace
 }: {
   launchNode?: WorkbenchHostChromeRenderContext["launchNode"];
+  open: boolean;
+  setOpen: (nextOpen: boolean) => void;
   workspace: WorkspaceSummary;
 }) {
   const { i18n, locale, t } = useTranslation();
@@ -256,7 +266,6 @@ function WorkspaceAgentMessageCenterAction({
   const reporterService = useService(IReporterService);
   const notifications = useService(INotificationService);
   const workbenchHostService = useWorkspaceWorkbenchHostService();
-  const [open, setOpen] = useState(false);
   const [highlightedMessageCenterItemId, setHighlightedMessageCenterItemId] =
     useState<string | null>(null);
   const snapshotRef = useRef<{
@@ -364,7 +373,7 @@ function WorkspaceAgentMessageCenterAction({
       registerWorkspaceMessageCenterOpenHandler(workspace.id, () => {
         setOpen(true);
       }),
-    [workspace.id]
+    [setOpen, workspace.id]
   );
 
   useEffect(() => {
@@ -393,7 +402,7 @@ function WorkspaceAgentMessageCenterAction({
         setOpen(false);
       });
     },
-    [launchNode]
+    [launchNode, setOpen]
   );
 
   useEffect(() => {
@@ -632,7 +641,7 @@ function WorkspaceAgentMessageCenterAction({
   );
   const closeMessageCenter = useCallback(() => {
     setOpen(false);
-  }, []);
+  }, [setOpen]);
   const handleHighlightedMessageCenterItemSettled = useCallback(
     (itemId: string) => {
       setHighlightedMessageCenterItemId((current) =>


### PR DESCRIPTION
## Problem

The workspace agent message center panel ("Control Panel" overlay) cannot be dismissed by clicking the top strip of the window (Feishu tracker recvnZR3F4oWpZ, P0).

## Root cause

The workbench chrome `<header>` in `WorkspaceChrome.tsx` is an Electron drag region (`[-webkit-app-region:drag]`). Drag regions consume mouse events at the OS level, so `pointerdown` never reaches the page document. The message center panel is dismissed via Radix `DismissableLayer`'s document-level `pointerdown` listener (`onPointerDownOutside`), which therefore never fires for clicks on the header strip.

## Fix

While the message center panel is open, the header temporarily becomes no-drag, so `pointerdown` reaches the document and the existing Radix dismiss chain works unchanged:

- Lifted the panel `open` state from `WorkspaceAgentMessageCenterAction` up to `WorkspaceChrome` (the header's direct parent), passed down as `open`/`setOpen` props.
- The header's app-region is now conditional: `no-drag` while the panel is open, `drag` otherwise. Electron recalculates draggable regions when styles change.
- Header buttons and the closed-state drag behavior are unchanged.

## Tests

Added a focused source test in `WorkspaceChrome.test.ts` asserting the header app-region toggles with the message center open state and that the unconditional drag class is gone. Scoped run: 5/5 pass. `pnpm typecheck` for `apps/desktop` is clean.

## Known follow-up

Clicks inside webview interiors still do not dismiss the panel — that is a separate issue (webview click-through) and will be handled in a follow-up fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
