### PR TITLE
fix(ui-system): declare missing agent-gui node-window CSS variables

### DIFF
--- a/packages/ui/system/src/styles/theme.css
+++ b/packages/ui/system/src/styles/theme.css
@@ -97,6 +97,8 @@
   --border-2: rgb(60 60 60 / 8%);
   --line-1: var(--border-1);
   --line-2: var(--border-2);
+  /* Legacy TSH-era name still read by agentactivity.css (--agent-gui-border); never declared. */
+  --cove-border: var(--line-1);
   --line-focus-window: rgb(60 60 60 / 12%);
   --border-focus: rgb(65 130 245 / 24%);
   --input: oklch(0.936 0.006 252);
@@ -187,6 +189,23 @@
   --workbench-focused-border: rgb(255 255 255 / 68%);
   --workbench-scrim: color-mix(in srgb, var(--card) 78%, transparent);
   --workbench-window-elevation: 0 18px 44px rgb(0 0 0 / 26%);
+
+  /*
+   * Agent GUI node-window chrome (packages/agent/gui/agent-gui/shared/WorkspaceNodeWindow.tsx
+   * and .workspace-agents-status-panel in agentactivity.css) reads these --node- and
+   * --window-drop-shadow custom properties directly. They were never declared anywhere in
+   * the design system, so the floating node window chrome (border, shadow, backdrop blur,
+   * header/body surfaces) silently resolved to nothing. Alias them onto the equivalent
+   * --workbench- window tokens above so the two chrome layers stay in sync.
+   */
+  --node-surface: var(--workbench-node-surface);
+  --terminal-node-surface: var(--workbench-node-surface);
+  --node-header-surface: var(--workbench-window-header-bg);
+  --node-window-border: var(--workbench-border);
+  --node-header-border: var(--workbench-border);
+  --node-window-backdrop-filter: var(--workbench-window-backdrop-filter);
+  --window-drop-shadow: var(--workbench-window-elevation);
+  --node-header-height: 40px;
   --workbench-control-hover-bg: color-mix(
     in srgb,
     var(--workbench-foreground) 9%,


### PR DESCRIPTION
## Problem

The cloud/web build of Agent GUI sometimes fails to pick up styling — components read CSS custom properties that are missing or undeclared in the shared UI System package, so styling silently drops when a cloud host only imports `ui-system`'s stylesheet. (Feishu tracker CPCpC5, P1)

## Root cause

`packages/agent/gui/agent-gui/shared/WorkspaceNodeWindow.tsx` (the floating node-window chrome: border, shadow, backdrop blur, header/body surfaces) and `.workspace-agents-status-panel` in `agentactivity.css` read `--node-surface`, `--terminal-node-surface`, `--node-header-surface`, `--node-window-border`, `--node-header-border`, `--node-window-backdrop-filter`, `--window-drop-shadow`, `--node-header-height`, and `--cove-border`.

None of these custom properties were ever declared anywhere in `packages/ui/system/src/styles/theme.css` or elsewhere in the design system. Desktop happened to work because other loaded stylesheets coincidentally masked the gap in some cases, but any host (including a cloud/web build) that only bundles `@tutti-os/ui-system`'s `styles.css` gets these var() references resolving to nothing.

## Fix

`packages/ui/system/src/styles/theme.css`: declared the missing custom properties inside the existing `:root` block, aliasing them onto the equivalent, already-declared `--workbench-*` window tokens (and `--cove-border` onto `--line-1`), so both naming schemes resolve consistently regardless of which package stylesheets a host app bundles. Because these are `var()` indirections declared once in `:root`, they correctly re-resolve against whichever `--workbench-*` value is active in a given light/dark theme scope — no per-theme-block duplication needed.

## Tests

- `pnpm build` in `packages/ui/system` — success.
- `pnpm test` (vitest) in `packages/ui/system` — 1/1 passed.
- Manually confirmed all aliased `--workbench-*` targets exist in both the light and dark theme blocks of `theme.css`.

## Note on CI bypass

This branch was pushed with `git push --no-verify`, explicitly authorized by the user, because the local pre-push hook (`pnpm check:full`) deterministically hangs in an unrelated, pre-existing test: `TestServiceCreateResolvesProviderFromAgentTarget` in `services/tuttid/service/agent/service_test.go` polls forever in `pollComposerModelOptions` (`services/tuttid/service/agent/composer_live_model_discovery.go:135`) because the test's fake runtime double never populates `RuntimeContext` or marks the session `"failed"` — a latent gap since `ecf73863` ("require verified Claude composer models"). This diff contains **no Go changes** and cannot affect that test; the hang was independently reproduced in isolation (`go test ./service/agent/... -run TestServiceCreateResolvesProviderFromAgentTarget -timeout 60s -count=3`, hangs all 3 times) and confirmed non-flaky across multiple retries under varying system load. All other check:full lanes and the tests specific to this change were verified manually (above).

## Follow-up

The bug report calls for a broader "整体检查" (overall audit) of the design system's CSS variables for cloud-build gaps. This PR fixes the one clear, concrete case found; a wider audit of `packages/ui/system` custom properties vs. actual consumers is still recommended as separate follow-up work.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added missing styling variables to improve compatibility with legacy and agent activity UI styles.
  * Introduced new design-token aliases for node window and header chrome, helping ensure consistent surfaces, borders, shadows, and header sizing across the interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->