### PR TITLE
fix(file-manager): support arrow-key drill-down in the file tree list

### DIFF
--- a/packages/workspace/file-manager/src/ui/WorkspaceFileManagerPanels.tsx
+++ b/packages/workspace/file-manager/src/ui/WorkspaceFileManagerPanels.tsx
@@ -13,6 +13,7 @@ import type { WorkspaceFileManagerI18nRuntime } from "../i18n/workspaceFileManag
 import type {
   CSSProperties,
   DragEvent as ReactDragEvent,
+  KeyboardEvent as ReactKeyboardEvent,
   MouseEvent as ReactMouseEvent,
   PointerEvent as ReactPointerEvent,
   ReactElement,
@@ -49,7 +50,12 @@ import {
   type WorkspaceFileManagerArrangeMode
 } from "./workspaceFileManagerArrangeMode.ts";
 import type { WorkspaceFileManagerLayoutMode } from "./workspaceFileManagerLayoutMode.ts";
-import type { WorkspaceFileManagerVisibleTreeRow } from "./workspaceFileManagerVisibleTree.ts";
+import {
+  findWorkspaceFileManagerAdjacentEntryPath,
+  findWorkspaceFileManagerFirstChildRow,
+  findWorkspaceFileManagerParentEntryPath,
+  type WorkspaceFileManagerVisibleTreeRow
+} from "./workspaceFileManagerVisibleTree.ts";
 
 const workspaceFileManagerTableGridClassName =
   "grid-cols-[minmax(0,_1fr)_148px_96px]";
@@ -326,6 +332,94 @@ export function WorkspaceFileManagerPanels({
       onSelect(entry.path);
     },
     [entrySelectionEnabled, onOpenEntry, onSelect, shouldSuppressEntryClick]
+  );
+  const handleEntryKeyDown = useCallback(
+    (
+      entry: WorkspaceFileEntry,
+      event: ReactKeyboardEvent<HTMLElement>
+    ): void => {
+      if (!entrySelectionEnabled) {
+        return;
+      }
+      const row = treeRows.find(
+        (candidate) =>
+          candidate.kind === "entry" && candidate.entry.path === entry.path
+      );
+      if (!row || row.kind !== "entry") {
+        return;
+      }
+
+      switch (event.key) {
+        case "ArrowDown": {
+          event.preventDefault();
+          const nextPath = findWorkspaceFileManagerAdjacentEntryPath(
+            treeRows,
+            entry.path,
+            1
+          );
+          if (nextPath) {
+            onSelect(nextPath);
+          }
+          return;
+        }
+        case "ArrowUp": {
+          event.preventDefault();
+          const previousPath = findWorkspaceFileManagerAdjacentEntryPath(
+            treeRows,
+            entry.path,
+            -1
+          );
+          if (previousPath) {
+            onSelect(previousPath);
+          }
+          return;
+        }
+        case "ArrowRight": {
+          if (entry.kind !== "directory") {
+            return;
+          }
+          event.preventDefault();
+          if (row.expandable && !row.expanded) {
+            // Lazily fetches the next-level directory listing (empty state
+            // renders once the load resolves with zero entries). The second
+            // argument mirrors DirectoryDisclosureButton's onClick: it
+            // reports the *current* (pre-toggle) expanded state, not the
+            // target state.
+            onToggleDirectoryExpanded(entry, row.expanded);
+            return;
+          }
+          if (row.expanded) {
+            const childRow = findWorkspaceFileManagerFirstChildRow(
+              treeRows,
+              entry.path
+            );
+            if (childRow?.kind === "entry") {
+              onSelect(childRow.entry.path);
+            }
+          }
+          return;
+        }
+        case "ArrowLeft": {
+          if (entry.kind === "directory" && row.expanded) {
+            event.preventDefault();
+            onToggleDirectoryExpanded(entry, row.expanded);
+            return;
+          }
+          const parentPath = findWorkspaceFileManagerParentEntryPath(
+            treeRows,
+            entry.path
+          );
+          if (parentPath) {
+            event.preventDefault();
+            onSelect(parentPath);
+          }
+          return;
+        }
+        default:
+          return;
+      }
+    },
+    [entrySelectionEnabled, onSelect, onToggleDirectoryExpanded, treeRows]
   );
   useEffect(() => {
     lastEntryClickRef.current = null;
@@ -656,6 +750,7 @@ export function WorkspaceFileManagerPanels({
                     onContextMenu={onEntryContextMenu}
                     onDragStart={onEntryDragStart}
                     onClick={handleEntryClick}
+                    onKeyDown={handleEntryKeyDown}
                     onPointerDown={handleEntryPointerDown}
                     onToggleDirectoryExpanded={onToggleDirectoryExpanded}
                   />
@@ -833,6 +928,7 @@ function EntryRow({
   onContextMenu,
   onDragStart,
   onClick,
+  onKeyDown,
   onPointerDown,
   onToggleDirectoryExpanded
 }: {
@@ -869,6 +965,10 @@ function EntryRow({
   ) => void;
   onDragStart?: (entry: WorkspaceFileEntry, dataTransfer: DataTransfer) => void;
   onClick: (entry: WorkspaceFileEntry) => void;
+  onKeyDown: (
+    entry: WorkspaceFileEntry,
+    event: ReactKeyboardEvent<HTMLElement>
+  ) => void;
   onPointerDown: (
     entry: WorkspaceFileEntry,
     event: ReactPointerEvent<HTMLElement>
@@ -891,6 +991,19 @@ function EntryRow({
       block: "nearest",
       inline: "nearest"
     });
+    // Move DOM focus along with selection only when focus is already inside
+    // this row list (i.e. the user is navigating with arrow keys). This
+    // keeps a roving tabindex-style focus in sync without stealing focus
+    // from elsewhere in the app on programmatic selection changes.
+    const activeElement = document.activeElement;
+    if (
+      buttonRowRef.current &&
+      activeElement instanceof HTMLElement &&
+      activeElement !== buttonRowRef.current &&
+      activeElement.hasAttribute("data-workspace-file-entry-path")
+    ) {
+      buttonRowRef.current.focus();
+    }
   }, [selected]);
 
   const rowClassName = cn(
@@ -995,6 +1108,9 @@ function EntryRow({
       }}
       onClick={() => {
         onClick(entry);
+      }}
+      onKeyDown={(event) => {
+        onKeyDown(entry, event);
       }}
     >
       {nameCell}

--- a/packages/workspace/file-manager/src/ui/workspaceFileManagerVisibleTree.test.ts
+++ b/packages/workspace/file-manager/src/ui/workspaceFileManagerVisibleTree.test.ts
@@ -2,7 +2,10 @@ import assert from "node:assert/strict";
 import test from "node:test";
 import {
   buildWorkspaceFileManagerVisibleTreeRows,
-  collectWorkspaceFileManagerVisibleTreeEntries
+  collectWorkspaceFileManagerVisibleTreeEntries,
+  findWorkspaceFileManagerAdjacentEntryPath,
+  findWorkspaceFileManagerFirstChildRow,
+  findWorkspaceFileManagerParentEntryPath
 } from "./workspaceFileManagerVisibleTree.ts";
 import type {
   WorkspaceFileDirectoryExpansionState,
@@ -114,6 +117,145 @@ test("visible tree rows show child loading, empty, and error states", () => {
         status: "error"
       }
     ]
+  );
+});
+
+test("keyboard navigation finds adjacent, parent, and first-child rows across an expanded tree", () => {
+  const rows = buildWorkspaceFileManagerVisibleTreeRows({
+    arrangeMode: "name",
+    directoryExpansionByPath: {
+      "/workspace/src": directoryState([
+        entry("/workspace/src/index.ts", "file"),
+        entry("/workspace/src/components", "directory", true)
+      ]),
+      "/workspace/src/components": directoryState([
+        entry("/workspace/src/components/Button.tsx", "file")
+      ])
+    },
+    entries: [
+      entry("/workspace/README.md", "file"),
+      entry("/workspace/src", "directory", true)
+    ],
+    expandedDirectoryPaths: {
+      "/workspace/src": true,
+      "/workspace/src/components": true
+    }
+  });
+
+  // Rows in order: /workspace/src, /workspace/src/components,
+  // /workspace/src/components/Button.tsx, /workspace/src/index.ts,
+  // /workspace/README.md
+
+  assert.equal(
+    findWorkspaceFileManagerAdjacentEntryPath(rows, "/workspace/src", 1),
+    "/workspace/src/components"
+  );
+  assert.equal(
+    findWorkspaceFileManagerAdjacentEntryPath(
+      rows,
+      "/workspace/src/components/Button.tsx",
+      1
+    ),
+    "/workspace/src/index.ts"
+  );
+  assert.equal(
+    findWorkspaceFileManagerAdjacentEntryPath(rows, "/workspace/README.md", -1),
+    "/workspace/src/index.ts"
+  );
+  assert.equal(
+    findWorkspaceFileManagerAdjacentEntryPath(rows, "/workspace/src", -1),
+    null
+  );
+  assert.equal(
+    findWorkspaceFileManagerAdjacentEntryPath(rows, "/workspace/README.md", 1),
+    null
+  );
+
+  assert.equal(
+    findWorkspaceFileManagerParentEntryPath(rows, "/workspace/src/components"),
+    "/workspace/src"
+  );
+  assert.equal(
+    findWorkspaceFileManagerParentEntryPath(
+      rows,
+      "/workspace/src/components/Button.tsx"
+    ),
+    "/workspace/src/components"
+  );
+  assert.equal(
+    findWorkspaceFileManagerParentEntryPath(rows, "/workspace/src"),
+    null
+  );
+
+  const firstChildOfSrc = findWorkspaceFileManagerFirstChildRow(
+    rows,
+    "/workspace/src"
+  );
+  assert.equal(firstChildOfSrc?.kind, "entry");
+  assert.equal(
+    firstChildOfSrc?.kind === "entry" ? firstChildOfSrc.entry.path : null,
+    "/workspace/src/components"
+  );
+});
+
+test("keyboard navigation surfaces the loading/empty/error feedback row as the first child of an expanded directory", () => {
+  const rows = buildWorkspaceFileManagerVisibleTreeRows({
+    arrangeMode: "none",
+    directoryExpansionByPath: {
+      "/workspace/docs": {
+        entries: [],
+        error: null,
+        isLoading: true,
+        loaded: false
+      },
+      "/workspace/empty": directoryState([]),
+      "/workspace/failed": {
+        entries: [],
+        error: "Permission denied",
+        isLoading: false,
+        loaded: false
+      }
+    },
+    entries: [
+      entry("/workspace/docs", "directory", true),
+      entry("/workspace/empty", "directory", true),
+      entry("/workspace/failed", "directory", true)
+    ],
+    expandedDirectoryPaths: {
+      "/workspace/docs": true,
+      "/workspace/empty": true,
+      "/workspace/failed": true
+    }
+  });
+
+  const loadingRow = findWorkspaceFileManagerFirstChildRow(
+    rows,
+    "/workspace/docs"
+  );
+  assert.equal(loadingRow?.kind, "feedback");
+  assert.equal(
+    loadingRow?.kind === "feedback" ? loadingRow.status : null,
+    "loading"
+  );
+
+  const emptyRow = findWorkspaceFileManagerFirstChildRow(
+    rows,
+    "/workspace/empty"
+  );
+  assert.equal(emptyRow?.kind, "feedback");
+  assert.equal(emptyRow?.kind === "feedback" ? emptyRow.status : null, "empty");
+
+  const errorRow = findWorkspaceFileManagerFirstChildRow(
+    rows,
+    "/workspace/failed"
+  );
+  assert.equal(errorRow?.kind, "feedback");
+  assert.equal(errorRow?.kind === "feedback" ? errorRow.status : null, "error");
+
+  // A collapsed/unexpanded directory has no visible child row yet.
+  assert.equal(
+    findWorkspaceFileManagerFirstChildRow(rows, "/does/not/exist"),
+    null
   );
 });
 

--- a/packages/workspace/file-manager/src/ui/workspaceFileManagerVisibleTree.ts
+++ b/packages/workspace/file-manager/src/ui/workspaceFileManagerVisibleTree.ts
@@ -46,6 +46,82 @@ export function collectWorkspaceFileManagerVisibleTreeEntries(
   return rows.flatMap((row) => (row.kind === "entry" ? [row.entry] : []));
 }
 
+/**
+ * Finds the nearest visible entry row before/after `fromPath` in tree order,
+ * skipping feedback rows (loading/empty/error placeholders are not
+ * selectable). Powers ArrowUp/ArrowDown keyboard navigation.
+ */
+export function findWorkspaceFileManagerAdjacentEntryPath(
+  rows: readonly WorkspaceFileManagerVisibleTreeRow[],
+  fromPath: string,
+  direction: 1 | -1
+): string | null {
+  const fromIndex = rows.findIndex(
+    (row) => row.kind === "entry" && row.entry.path === fromPath
+  );
+  if (fromIndex === -1) {
+    return null;
+  }
+  for (
+    let index = fromIndex + direction;
+    index >= 0 && index < rows.length;
+    index += direction
+  ) {
+    const row = rows[index];
+    if (row && row.kind === "entry") {
+      return row.entry.path;
+    }
+  }
+  return null;
+}
+
+/**
+ * Finds the first visible row immediately below an expanded directory row
+ * (its first child entry, or a loading/empty/error feedback row). Powers
+ * ArrowRight moving focus into an already-expanded directory.
+ */
+export function findWorkspaceFileManagerFirstChildRow(
+  rows: readonly WorkspaceFileManagerVisibleTreeRow[],
+  parentPath: string
+): WorkspaceFileManagerVisibleTreeRow | null {
+  const parentIndex = rows.findIndex(
+    (row) => row.kind === "entry" && row.entry.path === parentPath
+  );
+  if (parentIndex === -1) {
+    return null;
+  }
+  return rows[parentIndex + 1] ?? null;
+}
+
+/**
+ * Finds the nearest ancestor entry row for `fromPath` (the row directly one
+ * depth level up). Powers ArrowLeft collapsing/exiting back to the parent
+ * directory.
+ */
+export function findWorkspaceFileManagerParentEntryPath(
+  rows: readonly WorkspaceFileManagerVisibleTreeRow[],
+  fromPath: string
+): string | null {
+  const fromIndex = rows.findIndex(
+    (row) => row.kind === "entry" && row.entry.path === fromPath
+  );
+  if (fromIndex === -1) {
+    return null;
+  }
+  const fromRow = rows[fromIndex];
+  const fromDepth = fromRow?.depth ?? 0;
+  if (fromDepth === 0) {
+    return null;
+  }
+  for (let index = fromIndex - 1; index >= 0; index -= 1) {
+    const row = rows[index];
+    if (row && row.kind === "entry" && row.depth === fromDepth - 1) {
+      return row.entry.path;
+    }
+  }
+  return null;
+}
+
 function appendWorkspaceFileManagerVisibleTreeRows(input: {
   arrangeMode: WorkspaceFileManagerArrangeMode;
   depth: number;


### PR DESCRIPTION
## Problem

In the file/artifact list panel (list layout mode), the current state does not support left/right (or up/down) arrow keys to navigate into a subfolder — pressing an arrow key does nothing, forcing users to click the disclosure triangle with a mouse. (Feishu tracker CPF5q8, P1)

## Root cause

File list rows in `packages/workspace/file-manager/src/ui/WorkspaceFileManagerPanels.tsx` were plain buttons with no keyboard handling beyond native Enter/Space activation. There was no `onKeyDown` wiring for `ArrowLeft`/`ArrowRight`/`ArrowUp`/`ArrowDown`, so directory drill-down (lazy-loading the next-level listing) and row-to-row navigation were only reachable via mouse click on the disclosure control.

## Fix

- Wired `ArrowRight`/`ArrowLeft` to the same `onToggleDirectoryExpanded` path the existing disclosure button already uses — this lazy-loads the folder's children only when the user actually navigates into it, and reuses the existing loading/empty/error feedback row rather than introducing new UI states.
- Wired `ArrowUp`/`ArrowDown` to move selection between the currently visible rows.
- Changes are in `packages/workspace/file-manager/src/ui/WorkspaceFileManagerPanels.tsx` and `packages/workspace/file-manager/src/ui/workspaceFileManagerVisibleTree.ts`.

## Tests

- `pnpm test` (`node --test`) in `packages/workspace/file-manager` — 141/141 passed, including new keyboard-navigation cases (`keyboard navigation finds adjacent, parent, and first-child rows across an expanded tree`, `keyboard navigation surfaces the loading/empty/error feedback row as the first child of an expanded directory`).
- `pnpm typecheck` in `packages/workspace/file-manager` — clean.

## Note on CI bypass

This branch was pushed with `git push --no-verify`, explicitly authorized by the user, because the local pre-push hook (`pnpm check:full`) deterministically hangs in an unrelated, pre-existing test: `TestServiceCreateResolvesProviderFromAgentTarget` in `services/tuttid/service/agent/service_test.go` polls forever in `pollComposerModelOptions` (`services/tuttid/service/agent/composer_live_model_discovery.go:135`) because the test's fake runtime double never populates `RuntimeContext` or marks the session `"failed"` — a latent gap since `ecf73863` ("require verified Claude composer models"). This diff contains **no Go changes** and cannot affect that test; the hang was independently reproduced in isolation (`go test ./service/agent/... -run TestServiceCreateResolvesProviderFromAgentTarget -timeout 60s -count=3`, hangs all 3 times) and confirmed non-flaky across multiple retries under varying system load. All other check:full lanes and the tests specific to this change were verified manually (above).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added keyboard navigation in the workspace file manager for moving between files and folders with arrow keys.
  * Directory navigation now supports expanding/collapsing folders and moving into parent or first child items from the keyboard.

* **Bug Fixes**
  * Improved focus behavior so the selected item stays in sync with keyboard navigation and remains visible in the list.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->