### PR TITLE
fix(workbench): show not-allowed cursor on disabled launchpad icons

### DIFF
--- a/packages/workbench/launchpad/src/launchpadStyle.test.ts
+++ b/packages/workbench/launchpad/src/launchpadStyle.test.ts
@@ -86,3 +86,19 @@ test("launchpad item labels use stationary white on content", () => {
     /\.workspace-launchpad-item__label\s*{[^}]*color:\s*var\(--white-stationary\);/s
   );
 });
+
+test("launchpad disabled items signal non-interactivity with not-allowed cursor", () => {
+  // Disabled/greyed-out items previously kept `cursor: default`, which looks
+  // identical to a plain background on hover and reads as "broken" rather
+  // than "intentionally unavailable". Every other disabled control in the
+  // design system (button, input, select, checkbox, ...) uses
+  // `cursor: not-allowed` for this signal; match that convention here.
+  assert.match(
+    css,
+    /\.workspace-launchpad-item--disabled\s*{[^}]*cursor:\s*not-allowed;/s
+  );
+  assert.doesNotMatch(
+    css,
+    /\.workspace-launchpad-item--disabled\s*{[^}]*cursor:\s*default;/s
+  );
+});

--- a/packages/workbench/launchpad/src/styles/workbench-launchpad.css
+++ b/packages/workbench/launchpad/src/styles/workbench-launchpad.css
@@ -277,7 +277,7 @@
 }
 
 .workspace-launchpad-item--disabled {
-  cursor: default;
+  cursor: not-allowed;
   filter: grayscale(0.45);
   opacity: 0.42;
 }


### PR DESCRIPTION
## Problem

Greyed-out (disabled) app icons in the Launchpad give no interaction feedback on hover, so users think the app is broken rather than intentionally unavailable (Feishu tracker 2U3FAO, P1).

## Root cause

`.workspace-launchpad-item--disabled` in `workbench-launchpad.css` set `cursor: default`, and disabled items explicitly suppress the hover lift transform (`.workspace-launchpad-item--disabled:hover { transform: none; }`). Combined, hovering a disabled icon produces *zero* visible change — identical to hovering empty background — which reads as unresponsive/broken rather than as "present but unavailable."

Every other disabled interactive control in the design system (`Button`, `Input`, `Textarea`, `Select`, `Checkbox`, `Switch`, date picker, ...) uses `cursor: not-allowed` specifically as this signal (`disabled:cursor-not-allowed`), so the launchpad grid was a deviation from an otherwise-consistent convention.

(Agent-provider items already get a richer explanation via the existing hover panel with an install/reason tooltip after ~500ms; this fix covers the baseline cursor feedback for *all* disabled items, including plain app/node items that have no hover panel.)

## Fix

Changed `.workspace-launchpad-item--disabled`'s cursor from `default` to `not-allowed`, matching the rest of the design system.

## Tests

- `packages/workbench/launchpad`: `npm run test` — 6/6 pass (added `launchpad disabled items signal non-interactivity with not-allowed cursor`).
- `packages/workbench/launchpad`: `npm run typecheck` — clean.
- `oxlint --deny-warnings` on touched files — clean.

## Note on pre-push hook

This branch was pushed with `--no-verify` (user-authorized) after 4 consecutive `check:full` runs failed identically at `TestServiceCreateResolvesProviderFromAgentTarget` in `services/tuttid/service/agent` — a Go test with no relation to this diff (a single CSS property + a `node:test` assertion, no Go touched), timing out at the ~10-minute mark under heavy concurrent load from other agents on the shared build machine (load average 8-18, up to 50 simultaneous `check:full` runs observed). The bypass is about pre-existing test infrastructure contention, not about this change being unverified — see the local test/typecheck/lint results above, all run and green before pushing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
