### PR TITLE
fix(agent-gui): floor the @ mention palette width in narrow windows

### DIFF
--- a/packages/agent/gui/agent-gui/agentGuiNode/AgentComposer.spec.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/AgentComposer.spec.tsx
@@ -3512,6 +3512,50 @@ describe("AgentComposer", () => {
     expect(draftContent.prompt).not.toMatch(/^@/);
   });
 
+  it("floors the mention palette width instead of collapsing to the anchor's measured width", async () => {
+    // jsdom's getBoundingClientRect() always reports a zero-size rect, which
+    // reproduces the narrow-window case: with no lower bound, the palette
+    // used to render at 0px wide and clip its rows' right-side content
+    // (Feishu recvo2ITCPLrhC).
+    render(
+      <AgentComposer
+        workspaceId="workspace-1"
+        currentUserId="user-1"
+        provider="codex"
+        draftContent={createDraft("@")}
+        availableCommands={[] satisfies readonly AgentHostAgentSessionCommand[]}
+        disabled={false}
+        submitDisabled={false}
+        placeholder="placeholder"
+        composerSettings={createComposerSettings()}
+        queuedPrompts={[]}
+        drainingQueuedPromptId={null}
+        canQueueWhileBusy={false}
+        showStopButton={false}
+        activePrompt={null}
+        isInterrupting={false}
+        isSendingTurn={false}
+        isSubmittingPrompt={false}
+        labels={createLabels()}
+        workspaceUserProjectI18n={workspaceUserProjectI18n}
+        onDraftContentChange={vi.fn()}
+        onSettingsChange={vi.fn()}
+        onSubmit={vi.fn()}
+        onSendQueuedPromptNext={vi.fn()}
+        onRemoveQueuedPrompt={vi.fn()}
+        onEditQueuedPrompt={vi.fn()}
+        onInterruptCurrentTurn={vi.fn()}
+        onSubmitInteractivePrompt={vi.fn()}
+      />
+    );
+
+    const surface = await screen.findByTestId(
+      "agent-gui-mention-palette-surface"
+    );
+    const width = Number.parseFloat(surface.style.width);
+    expect(width).toBeGreaterThanOrEqual(280);
+  });
+
   it("keeps the active @ trigger after canceling references from a mention row", async () => {
     let draftContent = createDraft("@");
     const onDraftContentChange = vi.fn((nextDraft: AgentComposerDraft) => {

--- a/packages/agent/gui/agent-gui/agentGuiNode/AgentComposer.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/AgentComposer.tsx
@@ -732,6 +732,12 @@ const composerPaletteZIndex = "var(--z-popover)";
 const SLASH_PALETTE_HEIGHT_PX = 280;
 const MENTION_PALETTE_MIN_HEIGHT_PX = 280;
 const MENTION_PALETTE_MAX_HEIGHT_PX = 320;
+// Floor for the palette's width so narrow composer/window widths can't shrink
+// it below what a mention row's trailing status badge / action button needs
+// to stay visible (see: Feishu recvo2ITCPLrhC — right-side row content was
+// getting clipped off-screen in narrow windows because only an upper width
+// bound was enforced).
+const MENTION_PALETTE_MIN_WIDTH_PX = 280;
 const MENTION_PALETTE_GAP_PX = 8;
 const MENTION_PALETTE_VIEWPORT_PADDING_PX = 8;
 const DRAFT_IMAGE_PREVIEW_BASE_HEIGHT_PX = 72;
@@ -2262,12 +2268,13 @@ export function AgentComposer({
     const rect = anchor.getBoundingClientRect();
     const viewportWidth = window.innerWidth;
     const viewportHeight = window.innerHeight;
-    const width = Math.max(
+    const maxAvailableWidth = Math.max(
       0,
-      Math.min(
-        rect.width,
-        viewportWidth - MENTION_PALETTE_VIEWPORT_PADDING_PX * 2
-      )
+      viewportWidth - MENTION_PALETTE_VIEWPORT_PADDING_PX * 2
+    );
+    const width = Math.max(
+      Math.min(rect.width, maxAvailableWidth),
+      Math.min(MENTION_PALETTE_MIN_WIDTH_PX, maxAvailableWidth)
     );
     const left = Math.max(
       MENTION_PALETTE_VIEWPORT_PADDING_PX,


### PR DESCRIPTION
## Problem

In a narrow app window, the `@` mention popup panel's right-side row content (status badges, "查看产物"/open-target action) became invisible — clipped past the panel's right edge instead of wrapping or shrinking. (Feishu CPLrhC)

## Root cause

`packages/agent/gui/agent-gui/agentGuiNode/AgentComposer.tsx` — `syncMentionPaletteFrame` derives the palette's width straight from the composer input shell's measured `getBoundingClientRect().width`, clamped only against an *upper* bound (viewport width minus padding). Unlike the height computation right below it (which has a real floor, `MENTION_PALETTE_MIN_HEIGHT_PX`), there was no matching `MIN_WIDTH`. When the composer itself is narrow, the palette frame shrinks arbitrarily low, and once it drops below what a mention row's trailing status badge/action needs, that content gets clipped rather than wrapping.

## Fix

Added `MENTION_PALETTE_MIN_WIDTH_PX` (280px, matching the existing height floor) and clamped the computed width to never go below it, unless the viewport itself is narrower than that floor (in which case it falls back to the viewport bounds so it still can't be clipped by the window edges).

## Tests

- New test in `AgentComposer.spec.tsx`: "floors the mention palette width instead of collapsing to the anchor's measured width" — reproduces the narrow-window case via jsdom's zero-size `getBoundingClientRect()` and asserts the rendered palette surface's width is `>= 280px`.
- `pnpm test` in `packages/agent/gui`: **118 files / 1894 tests pass** (includes the new test above).
- `pnpm run typecheck`: clean. `oxlint --deny-warnings` / `oxfmt --check`: clean.

## Note on CI bypass

This branch was pushed with `git push --no-verify` (explicitly authorized by the user). The repo's pre-push `check:full` hook is currently hitting a **pre-existing, unrelated** hang: `TestServiceCreateResolvesProviderFromAgentTarget` (`services/tuttid/service/agent/service_test.go`) — a pure in-memory, fake-backed unit test with no network/IO — panics with `test timed out after 10m0s`, reproduced identically across 6 independent push attempts (solo and concurrent), while ~16-20 other concurrent agent processes on the same shared machine were contending on the same `GOCACHE`. This diff contains **zero Go file changes**, so it cannot be the cause. The bypass was to unblock the push mechanics only — every check that can run outside the flaky Go test lane (typecheck, lint, the full `packages/agent/gui` test suite including the new regression test) was run directly and passed, as cited above.

Addresses Feishu recvo2ITCPLrhC (CPLrhC).

🤖 Generated with [Claude Code](https://claude.com/claude-code)