### PR TITLE
fix(agent-gui): show a tooltip for truncated inline file mention paths

### DIFF
--- a/packages/agent/gui/agent-gui/agentGuiNode/agentRichText/AgentMentionNodeView.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/agentRichText/AgentMentionNodeView.tsx
@@ -410,7 +410,12 @@ function AgentMentionLegacyFileNodeView({
           ) : null}
         </span>
       )}
-      <span className="tsh-agent-object-token__main">{mention.label}</span>
+      <TruncatingPillLabel
+        className="tsh-agent-object-token__main"
+        tooltip={mention.label}
+      >
+        {mention.label}
+      </TruncatingPillLabel>
     </NodeViewWrapper>
   );
 }


### PR DESCRIPTION
## Problem

Long file paths shown as inline `@file` mention chips inside the composer text get truncated with plain CSS ellipsis and no way to recover the full path. (Feishu SOCv94, grouped under the CTkv3Y input/text-rendering cluster's "长路径截断" item)

## Root cause

`packages/agent/gui/agent-gui/agentGuiNode/agentRichText/AgentMentionNodeView.tsx` (`AgentMentionLegacyFileNodeView`, the "file" mention kind) rendered its label as a bare `<span className="tsh-agent-object-token__main">{mention.label}</span>`. The backing CSS (`packages/agent/gui/app/renderer/agentactivity.css`, `.tsh-agent-object-token__main`) truncates with `text-overflow: ellipsis` and even carries a comment implying the full text is recoverable via hover — but no `title`/tooltip was ever wired up for this specific mention kind. Every *other* mention kind rendered in the same file (`workspace-app`, `workspace-reference`, `agent-target`, the generic pill) already uses the shared `TruncatingPillLabel` component, which shows a real tooltip only when the label is actually overflow-truncated (via a `ResizeObserver`); the "file" kind was the one outlier that skipped it.

## Fix

Switched `AgentMentionLegacyFileNodeView`'s label to `TruncatingPillLabel` (passing the full `mention.label` as both children and `tooltip`), matching the pattern already used by every sibling mention kind. Same CSS class is preserved so visual truncation is unchanged; the only behavior added is the overflow-triggered tooltip.

## Tests

- `pnpm test` in `packages/agent/gui`: **118 files / 1894 tests pass**, including `AgentRichTextEditor.spec.tsx`'s (57/57) assertions on `.tsh-agent-object-token__main` text content (class name preserved via `TruncatingPillLabel`'s `className` prop).
- `pnpm run typecheck`: clean. `oxlint --deny-warnings` / `oxfmt --check`: clean.

## Note on CI bypass

This branch was pushed with `git push --no-verify` (explicitly authorized by the user). The repo's pre-push `check:full` hook is currently hitting a **pre-existing, unrelated** hang: `TestServiceCreateResolvesProviderFromAgentTarget` (`services/tuttid/service/agent/service_test.go`) — a pure in-memory, fake-backed unit test with no network/IO — panics with `test timed out after 10m0s`, reproduced identically across 6 independent push attempts (solo and concurrent), while ~16-20 other concurrent agent processes on the same shared machine were contending on the same `GOCACHE`. This diff contains **zero Go file changes**, so it cannot be the cause. The bypass was to unblock the push mechanics only — every check that can run outside the flaky Go test lane (typecheck, lint, the full `packages/agent/gui` test suite) was run directly and passed, as cited above.

Addresses Feishu recvnrZLSOCv94 (SOCv94).

🤖 Generated with [Claude Code](https://claude.com/claude-code)