### PR TITLE
fix(agent-gui): show full session title on hover when truncated

### DIFF
--- a/packages/agent/gui/agent-gui/agentGuiNode/AgentGUINode.spec.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/AgentGUINode.spec.tsx
@@ -2074,6 +2074,44 @@ describe("AgentGUINode", () => {
       expect(root.querySelector('[data-agent-file-mention="true"]')).toBeNull();
     }
   });
+  it("exposes the full session title as a native tooltip when the title is CSS-truncated", () => {
+    const longTitle =
+      "Investigate why English session titles truncate after only three or four words in the narrow sidebar rail";
+    const conversation = {
+      id: "session-1",
+      provider: "codex" as const,
+      title: longTitle,
+      status: "ready" as const,
+      cwd: "/workspace",
+      updatedAtUnixMs: 1
+    };
+    mockViewModel = createViewModel({
+      conversations: [conversation],
+      activeConversation: conversation,
+      activeConversationId: "session-1",
+      conversationDetail: detailViewModel({
+        activity: {
+          ...detailViewModel().activity,
+          title: longTitle
+        },
+        session: {
+          ...detailViewModel().session,
+          title: longTitle
+        }
+      })
+    });
+
+    const { container } = renderAgentGUINode();
+    const railTitle = container.querySelector(
+      ".agent-gui-node__conversation-title"
+    );
+    const headerTitle = container.querySelector(
+      ".agent-gui-node__detail-header-title"
+    );
+
+    expect(railTitle).toHaveAttribute("title", longTitle);
+    expect(headerTitle).toHaveAttribute("title", longTitle);
+  });
   it("filters conversations from the sidebar search field", () => {
     mockViewModel = createViewModel({
       conversations: [

--- a/packages/agent/gui/agent-gui/agentGuiNode/AgentGUINodeView.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/AgentGUINodeView.tsx
@@ -2837,12 +2837,17 @@ const AgentGUIDetailHeader = memo(function AgentGUIDetailHeader({
 
   const runPath = activeConversation.cwd.trim();
   const statusTitle = showSyncIndicator ? syncLabel : undefined;
+  const plainTitle = conversationPlainTitle(
+    activeConversation,
+    labels,
+    uiLanguage
+  );
 
   return (
     <div className={styles.detailHeader}>
       <span className={styles.detailHeaderTitleGroup}>
-        <span className={styles.detailHeaderTitle}>
-          {conversationPlainTitle(activeConversation, labels, uiLanguage)}
+        <span className={styles.detailHeaderTitle} title={plainTitle}>
+          {plainTitle}
         </span>
         {runPath ? (
           <AgentRunPathInfo path={runPath} previewMode={previewMode} />
@@ -4705,6 +4710,7 @@ const AgentGUIConversationRailItem = memo(
   }: AgentGUIConversationRailItemProps): React.JSX.Element {
     "use memo";
     const pinned = (item.pinnedAtUnixMs ?? 0) > 0;
+    const plainTitle = conversationPlainTitle(item, labels, uiLanguage);
     const setItemElement = useCallback(
       (element: HTMLDivElement | null) => {
         registerItemElement(item.id, element);
@@ -4744,8 +4750,8 @@ const AgentGUIConversationRailItem = memo(
           className={styles.conversationSelect}
           onClick={handleSelect}
         >
-          <span className={styles.conversationTitle}>
-            {conversationPlainTitle(item, labels, uiLanguage)}
+          <span className={styles.conversationTitle} title={plainTitle}>
+            {plainTitle}
           </span>
           <ConversationMeta item={item} nowMs={currentTimeMs} labels={labels} />
         </button>

--- a/packages/agent/gui/workbench/contribution.test.ts
+++ b/packages/agent/gui/workbench/contribution.test.ts
@@ -1096,6 +1096,10 @@ describe("agent GUI workbench contribution copy", () => {
     expect(screen.getByText("Current session title")).toHaveClass(
       "agent-gui-workbench-header__title-text"
     );
+    expect(screen.getByText("Current session title")).toHaveAttribute(
+      "title",
+      "Current session title"
+    );
     expect(screen.queryByTestId("agent-gui-window-detail-title")).toBeNull();
 
     fireEvent.click(screen.getByTestId("agent-gui-window-close"));
@@ -1237,6 +1241,11 @@ describe("agent GUI workbench contribution copy", () => {
     expect(
       screen.getByTestId("agent-gui-window-detail-title")
     ).toHaveTextContent("Current session title");
+    expect(
+      screen
+        .getByTestId("agent-gui-window-detail-title")
+        .querySelector(".agent-gui-workbench-header__title-text")
+    ).toHaveAttribute("title", "Current session title");
     expect(
       screen.queryByRole("button", { name: "window actions" })
     ).not.toBeInTheDocument();

--- a/packages/agent/gui/workbench/header.ts
+++ b/packages/agent/gui/workbench/header.ts
@@ -220,7 +220,8 @@ export function AgentGuiWorkbenchHeader({
             createElement(
               "span",
               {
-                className: "agent-gui-workbench-header__title-text"
+                className: "agent-gui-workbench-header__title-text",
+                title: sessionTitle
               },
               sessionTitle
             )
@@ -237,7 +238,8 @@ export function AgentGuiWorkbenchHeader({
           createElement(
             "span",
             {
-              className: "agent-gui-workbench-header__title-text"
+              className: "agent-gui-workbench-header__title-text",
+              title: sessionTitle
             },
             sessionTitle
           )


### PR DESCRIPTION
## Problem

Feishu CPGqE7 (P1): Agent GUI session titles get truncated too aggressively — in English scenarios only 3-4 words show before truncation — and the report also bundles title-content-inconsistency and hyperlink-as-plain-text complaints.

Feishu tyUGHQ (P1): auto-summarized session titles come out in English even for non-English conversations.

## Root cause

**CPGqE7 (a) truncation:** Every surface that shows the persistent session title — conversation rail item, detail header, collapsed/expanded workbench header — applies single-line CSS ellipsis truncation inside a narrow, resizable sidebar column (`packages/agent/gui/app/renderer/agentactivity.css:6349-6358`, `:1260-1266` assertions in `workbench/contribution.test.ts`). On row hover, the rail item's available title width shrinks further (`agentactivity.css:5462-5465`, `padding-right: 96px` reserved for hover action buttons) — exactly when a user is trying to read it, which is why only 3-4 English words survive. None of the title spans exposed the full text anywhere else (no native tooltip, no expand-on-hover).

**CPGqE7 (b) cross-surface inconsistency:** confirmed there are at least 5 independently-computed title-fallback chains (rail/detail header formatter, workbench header resolver, shared title projection, Go-side ACP title fallback, and the separate PR#671/474798eb outcome-notification title formatter) that can diverge for the same session. Verified via `git show 474798eb` that PR#671 only touches the background-task completion notification pipeline, not any in-app title-display path — confirming it's unrelated. Unifying these 5 resolvers is a genuine cross-cutting refactor (Go + TS, several call sites); out of scope for a targeted fix, needs a dedicated follow-up.

**CPGqE7 (c) hyperlink-as-plain-text:** every title-rendering call site renders the title as plain text, and shared title-normalization utilities actively strip markdown link syntax down to a plain label. Making single-line, ellipsis-truncated titles render live, clickable hyperlinks is a materially larger feature (rich content + click handling + truncation interaction + URL sanitization across 5+ call sites) than a targeted bug fix; out of scope here, needs design sign-off as a follow-up.

**tyUGHQ:** Tutti's own code does not generate session-title text for any provider — it only relays the title reported by the external agent process:
- Claude Code: `packages/agent/claude-sdk-sidecar/src/main.ts:1606-1635` uses `info.customTitle || info.summary` from `@anthropic-ai/claude-agent-sdk`'s `getSessionInfo()`. Per the SDK's own type docs (`sdk.d.ts:3963-3965`), `summary` already folds in `customTitle` ("custom title, auto-generated summary, or first prompt") — the actual title text is generated entirely inside the external SDK/CLI, outside this repo.
- Codex: `packages/agent/daemon/runtime/codex_appserver_reducer.go:132-133` uses `threadName` verbatim from Codex's own app-server.
- Generic ACP providers: `packages/agent/daemon/runtime/acp_update_events.go:524-534` uses `title`/`name`/`summary` verbatim from the external agent binary's own protocol notifications.

No fix implemented for tyUGHQ — see Tests/Follow-up below.

## Fix

Added a native `title` attribute (browser tooltip) carrying the full, already-normalized title text to the three persistent-title surfaces, so hovering reveals the complete title without any layout change:
- `packages/agent/gui/agent-gui/agentGuiNode/AgentGUINodeView.tsx` — conversation rail item (`plainTitle` computed once) and detail header title
- `packages/agent/gui/workbench/header.ts` — collapsed session-title span and expanded detail-title span

This addresses CPGqE7 sub-complaint (a) only. Sub-complaints (b) and (c), and tyUGHQ, are documented above as follow-up work needed — see reasoning for why a forced fix would be premature/risky.

## Tests

- `pnpm --filter @tutti-os/agent-gui test` (vitest, jsdom): 118 test files / 1894 tests passed, including a new test asserting the tooltip on the rail item + detail header, and two updated assertions in `workbench/contribution.test.ts` for the workbench header tooltip.
- `pnpm --filter @tutti-os/agent-gui typecheck`: passed.
- `oxlint` on touched files: clean.
- Pre-push `check:full` hit an unrelated, pre-existing Go test flake (`services/tuttid/service/agent`, `TestServiceCreateResolvesProviderFromAgentTarget`, timing out at 600s) twice in a row across two attempts — confirmed unrelated since this diff touches no Go files. Pushed with `--no-verify` per explicit authorization after confirming the failure reason both times.

## Follow-up needed (not in this PR)

1. CPGqE7 (b): unify the ~5 divergent title-fallback/formatting call sites (rail/detail header, workbench header, shared title projection, Go ACP fallback, notification formatter) behind one canonical resolver.
2. CPGqE7 (c): design + implement clickable titles when they contain a URL (currently titles are plain text everywhere, and link syntax is actively stripped).
3. tyUGHQ: title text for Claude Code/Codex/ACP sessions is generated entirely by the external provider process, not by Tutti. One unverified lever exists: the Claude Agent SDK's `Settings.language` field (`sdk.d.ts:5707-5709`, "Preferred language for Claude responses and voice dictation") is never forwarded by `packages/agent/claude-sdk-sidecar/src/main.ts` (`querySettingsFromSessionSettings` only sets `fastMode`). Needs empirical verification that this field actually affects auto-title language (vs. just chat responses) before wiring it up, and a decision on whether to source it from app UI locale or detected conversation language.

Addresses Feishu CPGqE7 (sub-complaint (a) only) and documents findings for tyUGHQ (no fix).