### PR TITLE
fix(agent): route markdown mentions at ACP submit

### DIFF
--- a/packages/agent/daemon/runtime/standard_acp_adapter.go
+++ b/packages/agent/daemon/runtime/standard_acp_adapter.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"log/slog"
 	"os"
+	"regexp"
 	"sort"
 	"strings"
 	"sync"
@@ -98,6 +99,7 @@ const claudeSystemPromptFileEnv = "TUTTI_CLAUDE_SYSTEM_PROMPT_FILE"
 const claudePluginDirEnv = "TUTTI_CLAUDE_PLUGIN_DIR"
 const claudeSDKMessageMethod = "_claude/sdkMessage"
 const claudePlanModeInstructions = "You are in plan mode. Inspect files and gather context as needed, but do not edit files, run mutation commands, or make external changes. Produce a concrete implementation plan first. If the user gives feedback, refine the plan. Only after the user approves leaving plan mode may you implement changes."
+const tuttiMentionRoutingReminder = "<system-reminder>mention:// links are Tutti internal references; use the exact visible tutti-cli skill first to route them.</system-reminder>"
 
 const (
 	sessionSpeedStandard = "standard"
@@ -115,6 +117,8 @@ var claudeCodeACPModelAliases = map[string]bool{
 	"sonnet[1m]": true,
 	"opusplan":   true,
 }
+
+var markdownMentionURIRegex = regexp.MustCompile(`\[(?:\\.|[^\]\\\r\n])*\]\((mention://[A-Za-z0-9][A-Za-z0-9._~-]*(?:[/?#][^\s)]*)?)\)`)
 
 const (
 	acpCloseCallTimeout  = 750 * time.Millisecond
@@ -1014,10 +1018,10 @@ func (a *standardACPAdapter) Exec(
 	session.ProviderSessionID = acpSession.providerSessionID
 	a.rememberSessionTurn(session.AgentSessionID, turnID)
 	explicitDisplayPrompt, visibleText := explicitAndVisiblePromptText(content, displayPrompt)
-	mentionRoutingApplied, mentionRoutingSkills := claudeCodeMentionRoutingSkills(a.config.provider, visibleText)
+	mentionRoutingApplied, mentionRoutingSkills := tuttiMentionRoutingSkills(visibleText)
 	acpPromptContent := promptContentForACP(content)
 	if mentionRoutingApplied {
-		acpPromptContent = prependClaudeCodeMentionRoutingPrompt(acpPromptContent, mentionRoutingSkills)
+		acpPromptContent = appendTuttiMentionRoutingPrompt(acpPromptContent, mentionRoutingSkills)
 	}
 	normalizer := newACPTurnNormalizer()
 	var events []activityshared.Event
@@ -1054,12 +1058,12 @@ func (a *standardACPAdapter) Exec(
 		"turn_id", turnID,
 		"prompt_length", len(visibleText),
 		"mention_uri_count", len(extractMentionURIs(visibleText)),
-		"claude_mention_routing_applied", mentionRoutingApplied,
-		"claude_mention_routing_skills", mentionRoutingSkills,
+		"mention_routing_applied", mentionRoutingApplied,
+		"mention_routing_skills", mentionRoutingSkills,
 	)
 	if mentionRoutingApplied {
-		slog.Info("agent session ACP claude mention routing applied",
-			"event", "agent_session.acp.claude_mention_routing.applied",
+		slog.Info("agent session ACP mention routing applied",
+			"event", "agent_session.acp.mention_routing.applied",
 			"provider", a.config.provider,
 			"adapter", a.config.adapterName,
 			"room_id", session.RoomID,
@@ -1230,10 +1234,7 @@ func claudeGoalSlashPromptUpdate(prompt string) (map[string]any, string, bool) {
 	}
 }
 
-func claudeCodeMentionRoutingSkills(provider string, visibleText string) (bool, []string) {
-	if strings.TrimSpace(provider) != ProviderClaudeCode {
-		return false, nil
-	}
+func tuttiMentionRoutingSkills(visibleText string) (bool, []string) {
 	var skills []string
 	seenSkills := map[string]struct{}{}
 	for _, mention := range extractMentionURIs(visibleText) {
@@ -1265,36 +1266,19 @@ func skillForMentionURI(uri string) string {
 }
 
 func extractMentionURIs(text string) []string {
-	const marker = "mention://"
 	var mentions []string
 	seen := map[string]struct{}{}
-	for offset := 0; offset < len(text); {
-		index := strings.Index(text[offset:], marker)
-		if index < 0 {
-			break
+	for _, match := range markdownMentionURIRegex.FindAllStringSubmatch(text, -1) {
+		if len(match) < 2 {
+			continue
 		}
-		start := offset + index
-		end := start
-		for end < len(text) && !mentionURITerminator(text[end]) {
-			end++
-		}
-		mention := strings.TrimSpace(text[start:end])
+		mention := strings.TrimSpace(match[1])
 		if _, ok := seen[mention]; mention != "" && !ok {
 			mentions = append(mentions, mention)
 			seen[mention] = struct{}{}
 		}
-		offset = end
 	}
 	return mentions
-}
-
-func mentionURITerminator(char byte) bool {
-	switch char {
-	case ' ', '\t', '\n', '\r', ')', ']', '>', '"', '\'':
-		return true
-	default:
-		return false
-	}
 }
 
 func (a *standardACPAdapter) Cancel(ctx context.Context, session Session, _ string) ([]activityshared.Event, error) {
@@ -3713,10 +3697,13 @@ func isTerminalACPToolStatus(status string) bool {
 }
 
 func shouldIgnoreStandardACPTitle(config standardACPConfig, currentTitle string, title string) bool {
+	if isInternalMentionRoutingTitle(title) {
+		return true
+	}
 	if strings.TrimSpace(config.provider) != ProviderClaudeCode {
 		return false
 	}
-	if isClaudeACPInterruptMarker(title) || isClaudeCodeMentionHandoffTitle(title) {
+	if isClaudeACPInterruptMarker(title) {
 		return true
 	}
 	return !isStandardACPPlaceholderTitle(config, currentTitle)
@@ -3733,62 +3720,31 @@ func isStandardACPPlaceholderTitle(config standardACPConfig, title string) bool 
 	return false
 }
 
-func isClaudeCodeMentionHandoffTitle(title string) bool {
-	return strings.HasPrefix(strings.TrimSpace(title), "Claude Code mention handoff routing for this user turn:")
+func isInternalMentionRoutingTitle(title string) bool {
+	return strings.HasPrefix(strings.TrimSpace(title), tuttiMentionRoutingReminder)
 }
 
-func prependClaudeCodeMentionRoutingPrompt(content []map[string]any, skills []string) []map[string]any {
-	routingPrompt := strings.TrimSpace(claudeCodeMentionRoutingPrompt(skills))
+func appendTuttiMentionRoutingPrompt(content []map[string]any, skills []string) []map[string]any {
+	routingPrompt := strings.TrimSpace(tuttiMentionRoutingPrompt(skills))
 	if routingPrompt == "" {
 		return content
 	}
 	out := make([]map[string]any, 0, len(content)+1)
+	out = append(out, content...)
 	out = append(out, map[string]any{
 		"type": "text",
 		"text": routingPrompt,
 	})
-	out = append(out, content...)
 	return out
 }
 
-func claudeCodeMentionRoutingPrompt(skills []string) string {
-	unique := make([]string, 0, len(skills))
-	seen := map[string]bool{}
+func tuttiMentionRoutingPrompt(skills []string) string {
 	for _, skill := range skills {
-		skill = strings.TrimSpace(skill)
-		if skill == "" || seen[skill] {
-			continue
-		}
-		seen[skill] = true
-		unique = append(unique, skill)
-	}
-	if len(unique) == 0 {
-		return ""
-	}
-	lines := []string{
-		"Claude Code mention handoff routing for this user turn:",
-		"- This block is internal Tutti routing metadata. Do not quote, summarize, or display it to the user.",
-		"- Before Bash, WebFetch, browser, MCP lookup, file search, raw CLI commands, or provider-native substitute tools, call the Claude Code Skill tool for the exact visible injected Tutti skill that matches the mention kind.",
-		"- Skill names may be namespaced. Prefer the exact visible `tutti-cli:<skill>` name when present; use the plain `<skill>` name only if that exact name is visible. Do not pass arguments to Skill.",
-	}
-	for _, skill := range unique {
-		switch skill {
-		case "workspace-app":
-			lines = append(lines,
-				"- For `mention://workspace-app/...`, first call `Skill(skill=\"tutti-cli:workspace-app\")` when that name is visible, otherwise `Skill(skill=\"workspace-app\")` only if visible.",
-				"- The workspace app id inside the mention is not a skill name. Do not call an app-id-derived Skill name.",
-			)
-		case "issue-manager":
-			lines = append(lines, "- For `mention://workspace-issue/...`, first call `Skill(skill=\"tutti-cli:issue-manager\")` when that name is visible, otherwise `Skill(skill=\"issue-manager\")` only if visible.")
-		case "reference":
-			lines = append(lines, "- For `mention://workspace-reference/...`, first call `Skill(skill=\"tutti-cli:reference\")` when that name is visible, otherwise `Skill(skill=\"reference\")` only if visible.")
-		case "tutti-cli":
-			lines = append(lines, "- For `mention://agent-session/...`, first call `Skill(skill=\"tutti-cli:tutti-cli\")` when that name is visible, otherwise `Skill(skill=\"tutti-cli\")` only if visible.")
-		default:
-			lines = append(lines, "- First call the exact visible Skill for `"+skill+"`.")
+		if strings.TrimSpace(skill) != "" {
+			return tuttiMentionRoutingReminder
 		}
 	}
-	return strings.Join(lines, "\n")
+	return ""
 }
 
 func isClaudeACPInterruptMarker(text string) bool {

--- a/packages/agent/daemon/runtime/standard_acp_adapter_test.go
+++ b/packages/agent/daemon/runtime/standard_acp_adapter_test.go
@@ -1398,7 +1398,7 @@ func TestClaudeCodeStandardACPUpdateDoesNotProjectSyntheticInterruptTitleAsSessi
 	for _, title := range []string{
 		"[Request interrupted by user]",
 		"[Request interrupted by user for tool use]",
-		"Claude Code mention handoff routing for this user turn: - Treat `mention://...` links as internal Tutti references.",
+		tuttiMentionRoutingReminder,
 	} {
 		events := standardACPUpdateEvents(standardACPClaudeCodeConfig(), session, "turn-1", json.RawMessage(`{
 			"update": {
@@ -1410,6 +1410,24 @@ func TestClaudeCodeStandardACPUpdateDoesNotProjectSyntheticInterruptTitleAsSessi
 			if event.Payload.Title == title {
 				t.Fatalf("events = %#v, want synthetic interrupt title %q excluded from title updates", events, title)
 			}
+		}
+	}
+}
+
+func TestStandardACPUpdateDoesNotProjectInternalMentionRoutingTitle(t *testing.T) {
+	t.Parallel()
+
+	session := standardTestSession(ProviderGemini)
+	session.ProviderSessionID = "gemini-session-1"
+	events := standardACPUpdateEvents(standardACPConfig{provider: ProviderGemini}, session, "turn-1", json.RawMessage(`{
+		"update": {
+			"sessionUpdate": "session_info_update",
+			"title": "`+tuttiMentionRoutingReminder+`"
+		}
+	}`), newACPTurnNormalizer())
+	for _, event := range events {
+		if event.Payload.Title == tuttiMentionRoutingReminder {
+			t.Fatalf("events = %#v, want internal mention routing title excluded from title updates", events)
 		}
 	}
 }
@@ -2347,7 +2365,7 @@ func TestClaudeCodeAdapterStartAppendsGeneralConversationDetailModeSystemPrompt(
 	}
 }
 
-func TestClaudeCodeAdapterExecAddsInternalMentionRoutingPromptOnlyForProvider(t *testing.T) {
+func TestClaudeCodeAdapterExecAddsInternalMentionRoutingPromptForMarkdownMention(t *testing.T) {
 	t.Parallel()
 
 	transport := newStandardACPTransport("Claude Agent", "claude-session-mention-routing")
@@ -2366,18 +2384,17 @@ func TestClaudeCodeAdapterExecAddsInternalMentionRoutingPromptOnlyForProvider(t 
 
 	texts := promptTexts(t, transport.conn.lastPromptParamsSnapshot)
 	if len(texts) < 2 {
-		t.Fatalf("prompt texts = %#v, want internal routing plus user prompt", texts)
+		t.Fatalf("prompt texts = %#v, want user prompt plus internal routing", texts)
 	}
-	if !strings.Contains(texts[0], "Claude Code mention handoff routing for this user turn:") ||
-		!strings.Contains(texts[0], "Skill(skill=\"tutti-cli:tutti-cli\")") {
-		t.Fatalf("routing prompt = %q, want internal Claude mention routing", texts[0])
+	if texts[0] != prompt {
+		t.Fatalf("user prompt text = %q, want unmodified prompt %q", texts[0], prompt)
 	}
-	if texts[1] != prompt {
-		t.Fatalf("user prompt text = %q, want unmodified prompt %q", texts[1], prompt)
+	if texts[len(texts)-1] != tuttiMentionRoutingReminder {
+		t.Fatalf("routing prompt = %q, want internal Claude mention routing", texts[len(texts)-1])
 	}
 	userContent := firstUserMessageContent(t, events)
 	if !strings.Contains(userContent, prompt) ||
-		strings.Contains(userContent, "Claude Code mention handoff routing") {
+		strings.Contains(userContent, "system-reminder") {
 		t.Fatalf("user activity event = %#v, want original user prompt only", events)
 	}
 }
@@ -2400,17 +2417,67 @@ func TestClaudeCodeAdapterExecRoutesWorkspaceReferenceMention(t *testing.T) {
 
 	texts := promptTexts(t, transport.conn.lastPromptParamsSnapshot)
 	if len(texts) < 2 {
-		t.Fatalf("prompt texts = %#v, want internal routing plus user prompt", texts)
+		t.Fatalf("prompt texts = %#v, want user prompt plus internal routing", texts)
 	}
-	if !strings.Contains(texts[0], "Skill(skill=\"tutti-cli:reference\")") {
-		t.Fatalf("routing prompt = %q, want reference skill routing", texts[0])
+	if texts[0] != prompt {
+		t.Fatalf("user prompt text = %q, want unmodified prompt %q", texts[0], prompt)
 	}
-	if texts[1] != prompt {
-		t.Fatalf("user prompt text = %q, want unmodified prompt %q", texts[1], prompt)
+	if texts[len(texts)-1] != tuttiMentionRoutingReminder {
+		t.Fatalf("routing prompt = %q, want reference skill routing", texts[len(texts)-1])
 	}
 }
 
-func TestStandardACPAdapterExecDoesNotPrependClaudeMentionRoutingForGemini(t *testing.T) {
+func TestClaudeCodeAdapterExecRoutesEscapedMarkdownMentionLabel(t *testing.T) {
+	t.Parallel()
+
+	transport := newStandardACPTransport("Claude Agent", "claude-escaped-label-routing")
+	adapter := NewClaudeCodeAdapter(transport)
+	session := standardTestSession(ProviderClaudeCode)
+	session.PermissionModeID = "default"
+	if _, err := adapter.Start(context.Background(), session); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	prompt := "请读取 [@设计\\]稿](mention://workspace-reference/app-1?groupId=group-1%29x&source=app&workspaceId=workspace-1)"
+
+	if _, err := adapter.Exec(context.Background(), session, textPrompt(prompt), "", "turn-escaped-reference", func([]activityshared.Event) {}, nil); err != nil {
+		t.Fatalf("Exec: %v", err)
+	}
+
+	texts := promptTexts(t, transport.conn.lastPromptParamsSnapshot)
+	if len(texts) < 2 {
+		t.Fatalf("prompt texts = %#v, want user prompt plus internal routing", texts)
+	}
+	if texts[0] != prompt {
+		t.Fatalf("user prompt text = %q, want unmodified prompt %q", texts[0], prompt)
+	}
+	if texts[len(texts)-1] != tuttiMentionRoutingReminder {
+		t.Fatalf("routing prompt = %q, want reference skill routing", texts[len(texts)-1])
+	}
+}
+
+func TestClaudeCodeAdapterExecDoesNotRouteBareMentionURI(t *testing.T) {
+	t.Parallel()
+
+	transport := newStandardACPTransport("Claude Agent", "claude-bare-mention-routing")
+	adapter := NewClaudeCodeAdapter(transport)
+	session := standardTestSession(ProviderClaudeCode)
+	session.PermissionModeID = "default"
+	if _, err := adapter.Start(context.Background(), session); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	prompt := "请读取 mention://workspace-reference/app-1?source=app&workspaceId=workspace-1&groupId=group-1"
+
+	if _, err := adapter.Exec(context.Background(), session, textPrompt(prompt), "", "turn-bare-reference", func([]activityshared.Event) {}, nil); err != nil {
+		t.Fatalf("Exec: %v", err)
+	}
+
+	text := firstPromptText(t, transport.conn.lastPromptParamsSnapshot)
+	if text != prompt {
+		t.Fatalf("prompt text = %q, want unmodified prompt %q", text, prompt)
+	}
+}
+
+func TestStandardACPAdapterExecAddsInternalMentionRoutingPromptForGemini(t *testing.T) {
 	t.Parallel()
 
 	transport := newStandardACPTransport("Gemini CLI", "gemini-session-mention-routing")
@@ -2426,9 +2493,15 @@ func TestStandardACPAdapterExecDoesNotPrependClaudeMentionRoutingForGemini(t *te
 		t.Fatalf("Exec: %v", err)
 	}
 
-	text := firstPromptText(t, transport.conn.lastPromptParamsSnapshot)
-	if text != prompt {
-		t.Fatalf("prompt text = %q, want unmodified prompt %q", text, prompt)
+	texts := promptTexts(t, transport.conn.lastPromptParamsSnapshot)
+	if len(texts) < 2 {
+		t.Fatalf("prompt texts = %#v, want user prompt plus internal routing", texts)
+	}
+	if texts[0] != prompt {
+		t.Fatalf("user prompt text = %q, want unmodified prompt %q", texts[0], prompt)
+	}
+	if texts[len(texts)-1] != tuttiMentionRoutingReminder {
+		t.Fatalf("routing prompt = %q, want internal mention routing", texts[len(texts)-1])
 	}
 }
 

--- a/services/tuttid/service/agent/external_import_parse.go
+++ b/services/tuttid/service/agent/external_import_parse.go
@@ -346,10 +346,9 @@ func resolveExternalSessionTitle(provider string, summaryTitle string, hint stri
 // VS Code injects IDE context ahead of the real Codex prompt; the actual
 // request lives under the final "## My request for Codex:" heading.
 const (
-	codexIDEContextPrefix              = "# Context from my IDE setup:"
-	codexRequestMarker                 = "my request for codex"
-	claudeMentionHandoffPrefix         = "Claude Code mention handoff routing for this user turn:"
-	claudeMentionHandoffPromptBoundary = "\n\nUser prompt:\n"
+	codexIDEContextPrefix       = "# Context from my IDE setup:"
+	codexRequestMarker          = "my request for codex"
+	tuttiMentionRoutingReminder = "<system-reminder>mention:// links are Tutti internal references; use the exact visible tutti-cli skill first to route them.</system-reminder>"
 )
 
 // externalImportTitleCandidate cleans a user message for use as a session title,
@@ -369,14 +368,12 @@ func externalImportCleanUserText(provider string, text string) (string, bool) {
 	if trimmed == "" {
 		return "", false
 	}
+	trimmed = stripTuttiMentionRoutingReminder(trimmed)
+	if trimmed == "" {
+		return "", false
+	}
 	switch provider {
 	case agentproviderbiz.ClaudeCode:
-		if title, ok := extractClaudeMentionHandoffUserPrompt(trimmed); ok {
-			return title, true
-		}
-		if strings.HasPrefix(trimmed, claudeMentionHandoffPrefix) {
-			return "", false
-		}
 		if strings.Contains(trimmed, "<local-command-caveat>") || strings.HasPrefix(trimmed, "<command-name>") {
 			return "", false
 		}
@@ -392,13 +389,12 @@ func externalImportCleanUserText(provider string, text string) (string, bool) {
 	}
 }
 
-func extractClaudeMentionHandoffUserPrompt(text string) (string, bool) {
-	if !strings.HasPrefix(text, claudeMentionHandoffPrefix) {
-		return "", false
+func stripTuttiMentionRoutingReminder(text string) string {
+	trimmed := strings.TrimSpace(text)
+	if !strings.HasSuffix(trimmed, tuttiMentionRoutingReminder) {
+		return trimmed
 	}
-	_, prompt, ok := strings.Cut(text, claudeMentionHandoffPromptBoundary)
-	prompt = strings.TrimSpace(prompt)
-	return prompt, ok && prompt != ""
+	return strings.TrimSpace(strings.TrimSuffix(trimmed, tuttiMentionRoutingReminder))
 }
 
 func extractCodexPromptFromIDEContext(text string) (string, bool) {

--- a/services/tuttid/service/agent/external_import_parse_test.go
+++ b/services/tuttid/service/agent/external_import_parse_test.go
@@ -305,7 +305,7 @@ func TestParseClaudeCodeJSONLPrefersCustomTitle(t *testing.T) {
 	}
 }
 
-func TestParseClaudeCodeJSONLUsesPromptInsideMentionHandoffTitle(t *testing.T) {
+func TestParseClaudeCodeJSONLStripsTuttiMentionRoutingReminder(t *testing.T) {
 	cwd := t.TempDir()
 	prompt := "[@AI Canvas](mention://workspace-app/ai-media-canvas?workspaceId=ws-1) 帮我生成图片"
 	session, ok, err := parseClaudeCodeJSONL(
@@ -313,12 +313,15 @@ func TestParseClaudeCodeJSONLUsesPromptInsideMentionHandoffTitle(t *testing.T) {
 		strings.NewReader(testAgentJSONL(t,
 			map[string]any{
 				"timestamp": "2026-06-18T00:00:00Z",
-				"sessionId": "claude-handoff",
+				"sessionId": "claude-reminder",
 				"cwd":       cwd,
 				"uuid":      "claude-1",
 				"message": map[string]any{
-					"role":    "user",
-					"content": []any{map[string]any{"type": "text", "text": "Claude Code mention handoff routing for this user turn:\n- Treat `mention://...` links as internal Tutti references.\n\nUser prompt:\n" + prompt}},
+					"role": "user",
+					"content": []any{
+						map[string]any{"type": "text", "text": prompt},
+						map[string]any{"type": "text", "text": tuttiMentionRoutingReminder},
+					},
 				},
 			},
 		)),
@@ -328,6 +331,12 @@ func TestParseClaudeCodeJSONLUsesPromptInsideMentionHandoffTitle(t *testing.T) {
 	}
 	if session.Title != prompt {
 		t.Fatalf("title = %q, want user prompt title", session.Title)
+	}
+	if len(session.Messages) != 1 {
+		t.Fatalf("message count = %d, want 1", len(session.Messages))
+	}
+	if session.Messages[0].Text != prompt {
+		t.Fatalf("message text = %q, want user prompt", session.Messages[0].Text)
 	}
 }
 


### PR DESCRIPTION
## Summary
- append a short runtime-only system reminder to standard ACP prompts when the user prompt contains a complete Markdown mention link
- keep the reminder out of renderer payloads, daemon activity events, and persisted session messages
- narrow detection to Markdown links and cover escaped-label / encoded-query cases

## Tests
- go test ./packages/agent/daemon/runtime
- pnpm check:full

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved mention handling so only mentions embedded in Markdown links are routed, while plain mention links are left unchanged.
  * Escaped mention labels now route correctly, and the original message content is preserved when routing is added.
  * Reduced noisy internal routing text shown in processing flow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->