### PR TITLE
[codex] enable analytics debug stream in production

### DIFF
--- a/apps/desktop/src/renderer/src/features/analytics/services/internal/predefinePageviewAnalytics.test.ts
+++ b/apps/desktop/src/renderer/src/features/analytics/services/internal/predefinePageviewAnalytics.test.ts
@@ -3,20 +3,17 @@ import test from "node:test";
 import type { ReporterEventInput } from "../reporterService.interface.ts";
 import {
   startPredefinePageviewAnalytics,
-  type PredefinePageviewAnalyticsRuntime,
-  type PredefinePageviewAnalyticsStorage
+  type PredefinePageviewAnalyticsRuntime
 } from "./predefinePageviewAnalytics.ts";
 
 test("predefine pageview analytics reports when the app opens", () => {
   const reporterCalls: ReporterEventInput[][] = [];
   const runtime = createRuntimeHarness();
-  const storage = createStorageHarness();
 
   startPredefinePageviewAnalytics({
     reporterService: createReporterService(reporterCalls),
     reporterNow: () => runtime.now(),
-    runtime,
-    storage
+    runtime
   });
 
   assert.deepEqual(reporterCalls, [
@@ -29,21 +26,24 @@ test("predefine pageview analytics reports when the app opens", () => {
   ]);
 });
 
-test("predefine pageview analytics reports app opens even after a focus report that day", () => {
+test("predefine pageview analytics reports app opens before focus", () => {
   const reporterCalls: ReporterEventInput[][] = [];
   const runtime = createRuntimeHarness();
-  const storage = createStorageHarness({
-    focusedDay: "2026-06-09"
-  });
 
   startPredefinePageviewAnalytics({
     reporterService: createReporterService(reporterCalls),
     reporterNow: () => runtime.now(),
-    runtime,
-    storage
+    runtime
   });
+  runtime.emitFocus();
 
   assert.deepEqual(reporterCalls, [
+    [
+      {
+        clientTS: runtime.now(),
+        name: "app.pageview"
+      }
+    ],
     [
       {
         clientTS: runtime.now(),
@@ -53,36 +53,32 @@ test("predefine pageview analytics reports app opens even after a focus report t
   ]);
 });
 
-test("predefine pageview analytics reports explicit focus once per local day", () => {
+test("predefine pageview analytics reports every explicit focus", () => {
   const reporterCalls: ReporterEventInput[][] = [];
   const runtime = createRuntimeHarness();
-  const storage = createStorageHarness();
 
   startPredefinePageviewAnalytics({
     reporterService: createReporterService(reporterCalls),
     reporterNow: () => runtime.now(),
-    runtime,
-    storage
+    runtime
   });
   runtime.emitFocus();
   runtime.emitFocus();
 
   assert.deepEqual(
     reporterCalls.map((call) => call[0]?.name),
-    ["app.pageview", "app.pageview"]
+    ["app.pageview", "app.pageview", "app.pageview"]
   );
 });
 
-test("predefine pageview analytics reports explicit focus again on a new local day", () => {
+test("predefine pageview analytics reports focus after time changes", () => {
   const reporterCalls: ReporterEventInput[][] = [];
   const runtime = createRuntimeHarness();
-  const storage = createStorageHarness();
 
   startPredefinePageviewAnalytics({
     reporterService: createReporterService(reporterCalls),
     reporterNow: () => runtime.now(),
-    runtime,
-    storage
+    runtime
   });
   runtime.emitFocus();
   runtime.advanceTo(new Date(2026, 5, 10, 10, 0, 0).getTime());
@@ -129,16 +125,4 @@ function createRuntimeHarness(input: { now?: number } = {}) {
     }
   };
   return runtime;
-}
-
-function createStorageHarness(input: { focusedDay?: string } = {}) {
-  let focusedDay = input.focusedDay ?? null;
-  return {
-    getFocusedDay() {
-      return focusedDay;
-    },
-    setFocusedDay(dayKey) {
-      focusedDay = dayKey;
-    }
-  } satisfies PredefinePageviewAnalyticsStorage;
 }

--- a/apps/desktop/src/renderer/src/features/analytics/services/internal/predefinePageviewAnalytics.ts
+++ b/apps/desktop/src/renderer/src/features/analytics/services/internal/predefinePageviewAnalytics.ts
@@ -1,8 +1,6 @@
 import { AppPageviewReporter } from "../../reporters/app-pageview/appPageviewReporter.ts";
 import type { IReporterService } from "../reporterService.interface.ts";
 
-const focusedDayStorageKey = "tutti.analytics.app.pageview.focused_day";
-
 export interface PredefinePageviewAnalyticsController {
   dispose(): void;
   reportAppOpen(): void;
@@ -13,19 +11,12 @@ export interface PredefinePageviewAnalyticsRuntime {
   addFocusListener(listener: () => void): () => void;
 }
 
-export interface PredefinePageviewAnalyticsStorage {
-  getFocusedDay(): string | null;
-  setFocusedDay(dayKey: string): void;
-}
-
 export function startPredefinePageviewAnalytics(input: {
   reporterNow?: () => number;
   reporterService: Pick<IReporterService, "trackEvents">;
   runtime?: PredefinePageviewAnalyticsRuntime;
-  storage?: PredefinePageviewAnalyticsStorage;
 }): PredefinePageviewAnalyticsController {
   const runtime = input.runtime ?? createDocumentPredefinePageviewRuntime();
-  const storage = input.storage ?? createLocalStoragePredefinePageviewStorage();
   const now = input.reporterNow ?? Date.now;
   let disposed = false;
 
@@ -47,11 +38,6 @@ export function startPredefinePageviewAnalytics(input: {
     if (disposed) {
       return;
     }
-    const dayKey = toLocalDayKey(now());
-    if (storage.getFocusedDay() === dayKey) {
-      return;
-    }
-    storage.setFocusedDay(dayKey);
     reportPageview();
   };
 
@@ -72,15 +58,6 @@ export function startPredefinePageviewAnalytics(input: {
   };
 }
 
-function toLocalDayKey(timestamp: number): string {
-  const date = new Date(timestamp);
-  return [
-    date.getFullYear(),
-    String(date.getMonth() + 1).padStart(2, "0"),
-    String(date.getDate()).padStart(2, "0")
-  ].join("-");
-}
-
 function createDocumentPredefinePageviewRuntime(): PredefinePageviewAnalyticsRuntime {
   return {
     addFocusListener(listener) {
@@ -88,25 +65,6 @@ function createDocumentPredefinePageviewRuntime(): PredefinePageviewAnalyticsRun
       return () => {
         window.removeEventListener("focus", listener);
       };
-    }
-  };
-}
-
-function createLocalStoragePredefinePageviewStorage(): PredefinePageviewAnalyticsStorage {
-  return {
-    getFocusedDay() {
-      try {
-        return globalThis.localStorage.getItem(focusedDayStorageKey);
-      } catch {
-        return null;
-      }
-    },
-    setFocusedDay(dayKey) {
-      try {
-        globalThis.localStorage.setItem(focusedDayStorageKey, dayKey);
-      } catch {
-        // Storage is only a dedupe aid; analytics remains best-effort.
-      }
     }
   };
 }

--- a/services/tuttid/wiring.go
+++ b/services/tuttid/wiring.go
@@ -152,12 +152,7 @@ func (w *tuttiWiring) buildWorkspaceModule(ctx context.Context) error {
 	}
 
 	analyticsConfig := tuttitypes.ResolveAnalyticsConfig()
-	var debugPublisher reporterservice.DebugPublisher
-	if analyticsConfig.Debug {
-		debugPublisher = analyticsDebugEventPublisher{
-			service: api.EventStreamService,
-		}
-	}
+	debugPublisher := resolveAnalyticsDebugPublisher(analyticsConfig, api.EventStreamService)
 	analyticsReporter, err := reporterservice.New(reporterservice.Config{
 		Analytics:      analyticsConfig,
 		DebugPublisher: debugPublisher,
@@ -172,6 +167,15 @@ func (w *tuttiWiring) buildWorkspaceModule(ctx context.Context) error {
 	w.appCenterService = appCenterService
 	w.agentRuntime = agentRuntime
 	return nil
+}
+
+func resolveAnalyticsDebugPublisher(analyticsConfig tuttitypes.AnalyticsConfig, service analyticsDebugEventStream) reporterservice.DebugPublisher {
+	if analyticsConfig.Disabled || service == nil {
+		return nil
+	}
+	return analyticsDebugEventPublisher{
+		service: service,
+	}
 }
 
 func attachAnalyticsReporter(api *tuttiapi.DaemonAPI, analyticsReporter reporterservice.Reporter) {

--- a/services/tuttid/wiring_test.go
+++ b/services/tuttid/wiring_test.go
@@ -1,0 +1,42 @@
+package main
+
+import (
+	"context"
+	"testing"
+
+	reporterservice "github.com/tutti-os/tutti/services/tuttid/service/reporter"
+	tuttitypes "github.com/tutti-os/tutti/services/tuttid/types"
+)
+
+type fakeAnalyticsDebugEventStream struct{}
+
+func (fakeAnalyticsDebugEventStream) PublishFromServer(context.Context, string, []byte) error {
+	return nil
+}
+
+func TestResolveAnalyticsDebugPublisherAllowsProductionAnalyticsDebugStream(t *testing.T) {
+	got := resolveAnalyticsDebugPublisher(tuttitypes.AnalyticsConfig{
+		AppID:         20004092,
+		AppKey:        "app-key",
+		ChannelDomain: "https://example.test",
+	}, fakeAnalyticsDebugEventStream{})
+
+	if _, ok := got.(analyticsDebugEventPublisher); !ok {
+		t.Fatalf("debug publisher = %T, want analyticsDebugEventPublisher", got)
+	}
+}
+
+func TestResolveAnalyticsDebugPublisherSkipsDisabledAnalytics(t *testing.T) {
+	got := resolveAnalyticsDebugPublisher(tuttitypes.AnalyticsConfig{
+		Disabled:      true,
+		AppID:         20004092,
+		AppKey:        "app-key",
+		ChannelDomain: "https://example.test",
+	}, fakeAnalyticsDebugEventStream{})
+
+	if got != nil {
+		t.Fatalf("debug publisher = %T, want nil", got)
+	}
+}
+
+var _ reporterservice.DebugPublisher = analyticsDebugEventPublisher{}


### PR DESCRIPTION
## Summary
- remove the per-day focus dedupe for `app.pageview` so every workspace window focus emits the event
- keep the analytics debug floating panel usable in production by wiring a debug publisher whenever analytics is enabled
- preserve real production TEA reporting by leaving `Analytics.Debug` semantics unchanged and only duplicating events to `analytics.debug.reported`

## Root Cause
The renderer-side analytics debug UI is available in production, but the daemon only registered `DebugPublisher` when `analyticsConfig.Debug` was true. In production that flag is false, and setting it true would switch the reporter to debug-only mode instead of the real TEA reporter.

## Validation
- `go test .` in `services/tuttid`
- `go test ./service/reporter ./types` in `services/tuttid`
- `pnpm --filter @tutti-os/desktop test -- ./src/renderer/src/features/analytics/services/internal/predefinePageviewAnalytics.test.ts`
- `pnpm --filter @tutti-os/desktop typecheck`
- `pnpm typecheck`
- pre-push `pnpm check:full` passed during `git push`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Pageview tracking now records a pageview on every explicit focus, and also when the app opens before focus.
  * Removed day-based focus deduping so analytics events are reported more consistently.
  * Analytics debug publishing now follows the analytics-enabled state more reliably.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->