### PR TITLE
fix(terminal): stop IME post-composition window from swallowing real input

### DIFF
--- a/docs/conventions/troubleshooting.md
+++ b/docs/conventions/troubleshooting.md
@@ -536,6 +536,38 @@ delimited by ---`, and the composer skill picker may show partial or
   [terminalImeInputGuard.ts](../../packages/workspace/terminal/src/react/terminalImeInputGuard.ts)
   [terminalSurfaceRuntime.ts](../../packages/workspace/terminal/src/react/terminalSurfaceRuntime.ts)
 
+### Post-composition suppression window swallows real terminal input
+
+- Symptom:
+  After committing Chinese IME text in a workspace terminal, the next quick
+  keystroke is intermittently lost: Enter pressed right after the candidate
+  commits does not execute the command (it must be pressed twice), fast typing
+  drops the first letter of the next word, or a full-width punctuation mark
+  typed immediately after a commit never reaches the PTY.
+- Quick checks:
+  Reproduce with fast input — commit a candidate with Space, then press Enter
+  or type the next character within ~80ms. Losses that disappear when typing
+  slowly point at the IME guard's post-composition window, not the PTY.
+- Root cause:
+  The guard suppressed every unmodified key for a fixed window after
+  `compositionend` to swallow ghost commit-key events. Only the commit key
+  itself (Enter, Escape, Space) ever replays after `compositionend`; blanket
+  suppression also swallowed genuine next keystrokes, and blocking keyCode 229
+  keydowns kept xterm's `CompositionHelper._handleAnyTextareaChanges` from
+  forwarding IME punctuation entered right after a commit.
+- Fix:
+  Inside the window, suppress only Enter, Escape, and Space; let all other keys
+  through so xterm's own keyCode 229 handling still runs. Ghost events replay
+  before the physical key is released, so close the window as soon as a keyup
+  arrives outside composition — any later keydown is genuine user input.
+- Validation:
+  Unit-cover letters and `Process` keys passing through the window, keyup
+  closing the window so a repeated Enter is processed, and commit keys staying
+  suppressed. Manually commit with Space then immediately press Enter, and type
+  full-width punctuation right after a commit.
+- References:
+  [terminalImeInputGuard.ts](../../packages/workspace/terminal/src/react/terminalImeInputGuard.ts)
+
 ### Agent GUI app mentions show unavailable workspace apps
 
 - Symptom:

--- a/docs/conventions/troubleshooting.md
+++ b/docs/conventions/troubleshooting.md
@@ -550,20 +550,23 @@ delimited by ---`, and the composer skill picker may show partial or
   slowly point at the IME guard's post-composition window, not the PTY.
 - Root cause:
   The guard suppressed every unmodified key for a fixed window after
-  `compositionend` to swallow ghost commit-key events. Only the commit key
-  itself (Enter, Escape, Space) ever replays after `compositionend`; blanket
-  suppression also swallowed genuine next keystrokes, and blocking keyCode 229
-  keydowns kept xterm's `CompositionHelper._handleAnyTextareaChanges` from
-  forwarding IME punctuation entered right after a commit.
+  `compositionend` to swallow ghost commit-key events. Only keys that can
+  commit a candidate (Enter, Escape, Space, digit selection keys) can replay
+  after `compositionend`; blanket suppression also swallowed genuine next
+  keystrokes, and blocking keyCode 229 keydowns kept xterm's
+  `CompositionHelper._handleAnyTextareaChanges` from forwarding IME
+  punctuation entered right after a commit.
 - Fix:
-  Inside the window, suppress only Enter, Escape, and Space; let all other keys
-  through so xterm's own keyCode 229 handling still runs. Ghost events replay
-  before the physical key is released, so close the window as soon as a keyup
-  arrives outside composition — any later keydown is genuine user input.
+  Inside the window, suppress only commit-capable keys (Enter, Escape, Space,
+  digits); let all other keys through so xterm's own keyCode 229 handling
+  still runs. Ghost events replay before the physical key is released, so
+  close the window as soon as a keyup arrives outside composition — any later
+  keydown is genuine user input, including genuine digits.
 - Validation:
   Unit-cover letters and `Process` keys passing through the window, keyup
-  closing the window so a repeated Enter is processed, and commit keys staying
-  suppressed. Manually commit with Space then immediately press Enter, and type
+  closing the window so a repeated Enter or digit is processed, and commit
+  keys (including digits) staying suppressed. Manually commit with Space then
+  immediately press Enter, select a candidate with a digit key, and type
   full-width punctuation right after a commit.
 - References:
   [terminalImeInputGuard.ts](../../packages/workspace/terminal/src/react/terminalImeInputGuard.ts)

--- a/packages/workspace/terminal/src/react/terminalImeInputGuard.test.ts
+++ b/packages/workspace/terminal/src/react/terminalImeInputGuard.test.ts
@@ -115,6 +115,62 @@ test("terminal IME guard does not suppress delayed input after composition", () 
   assert.equal(guard.shouldProcessKeyEvent(keyEvent({ key: "a" })), true);
 });
 
+test("terminal IME guard lets genuine input through right after composition", () => {
+  let preventDefaultCalls = 0;
+  const guard = createTerminalImeInputGuard({});
+
+  guard.handleCompositionStart();
+  guard.handleCompositionEnd();
+
+  assert.equal(
+    guard.shouldProcessKeyEvent(
+      keyEvent({
+        key: "a",
+        preventDefault: () => {
+          preventDefaultCalls += 1;
+        }
+      })
+    ),
+    true
+  );
+  assert.equal(preventDefaultCalls, 0);
+});
+
+test("terminal IME guard passes IME process keys through after composition", () => {
+  const guard = createTerminalImeInputGuard({});
+
+  guard.handleCompositionStart();
+  guard.handleCompositionEnd();
+
+  assert.equal(guard.shouldProcessKeyEvent(keyEvent({ key: "Process" })), true);
+});
+
+test("terminal IME guard closes the suppression window on keyup", () => {
+  const guard = createTerminalImeInputGuard({});
+
+  guard.handleCompositionStart();
+  guard.handleCompositionEnd();
+
+  assert.equal(guard.shouldProcessKeyEvent(keyEvent({ key: "Enter" })), false);
+  assert.equal(
+    guard.shouldProcessKeyEvent(keyEvent({ key: "Enter", type: "keyup" })),
+    true
+  );
+  assert.equal(guard.shouldProcessKeyEvent(keyEvent({ key: "Enter" })), true);
+});
+
+test("terminal IME guard keeps composition suppression across keyups", () => {
+  const guard = createTerminalImeInputGuard({});
+
+  guard.handleCompositionStart();
+
+  assert.equal(
+    guard.shouldProcessKeyEvent(keyEvent({ key: "n", type: "keyup" })),
+    true
+  );
+  assert.equal(guard.shouldProcessKeyEvent(keyEvent({ key: "n" })), false);
+});
+
 test("terminal IME guard consumes post-composition state for shortcuts", () => {
   const guard = createTerminalImeInputGuard({});
 

--- a/packages/workspace/terminal/src/react/terminalImeInputGuard.test.ts
+++ b/packages/workspace/terminal/src/react/terminalImeInputGuard.test.ts
@@ -145,6 +145,20 @@ test("terminal IME guard passes IME process keys through after composition", () 
   assert.equal(guard.shouldProcessKeyEvent(keyEvent({ key: "Process" })), true);
 });
 
+test("terminal IME guard suppresses candidate-selection digits after composition", () => {
+  const guard = createTerminalImeInputGuard({});
+
+  guard.handleCompositionStart();
+  guard.handleCompositionEnd();
+
+  assert.equal(guard.shouldProcessKeyEvent(keyEvent({ key: "2" })), false);
+  assert.equal(
+    guard.shouldProcessKeyEvent(keyEvent({ key: "2", type: "keyup" })),
+    true
+  );
+  assert.equal(guard.shouldProcessKeyEvent(keyEvent({ key: "2" })), true);
+});
+
 test("terminal IME guard closes the suppression window on keyup", () => {
   const guard = createTerminalImeInputGuard({});
 

--- a/packages/workspace/terminal/src/react/terminalImeInputGuard.ts
+++ b/packages/workspace/terminal/src/react/terminalImeInputGuard.ts
@@ -46,6 +46,14 @@ export function createTerminalImeInputGuard(input: {
       compositionEndedAt = null;
     },
     shouldProcessKeyEvent(event) {
+      if (event.type === "keyup") {
+        // Ghost commit-key events replay before the physical key is released,
+        // so any keyup after compositionend means later keydowns are genuine.
+        if (!composing) {
+          compositionEndedAt = null;
+        }
+        return true;
+      }
       if (!isKeyInputEvent(event)) {
         return true;
       }
@@ -63,6 +71,13 @@ export function createTerminalImeInputGuard(input: {
         return true;
       }
       if (!isPlainKeyEvent(event)) {
+        compositionEndedAt = null;
+        return true;
+      }
+      if (!isCompositionCommitKey(event.key)) {
+        // Letters, digits, and IME "Process" keydowns right after a commit are
+        // new input, not commit-key ghosts; xterm must keep handling them so
+        // keyCode 229 punctuation still reaches the PTY.
         compositionEndedAt = null;
         return true;
       }
@@ -90,6 +105,10 @@ function isKeyInputEvent(event: TerminalImeKeyEvent): boolean {
 
 function isPlainKeyEvent(event: TerminalImeKeyEvent): boolean {
   return !event.altKey && !event.ctrlKey && !event.metaKey;
+}
+
+function isCompositionCommitKey(key: string): boolean {
+  return key === "Enter" || key === "Escape" || key === " ";
 }
 
 function isModifierOnlyKey(key: string): boolean {

--- a/packages/workspace/terminal/src/react/terminalImeInputGuard.ts
+++ b/packages/workspace/terminal/src/react/terminalImeInputGuard.ts
@@ -108,7 +108,15 @@ function isPlainKeyEvent(event: TerminalImeKeyEvent): boolean {
 }
 
 function isCompositionCommitKey(key: string): boolean {
-  return key === "Enter" || key === "Escape" || key === " ";
+  // Digits commit candidates too (数字键选词), so treat them as commit keys;
+  // genuine digits typed after the commit key's keyup are unaffected because
+  // the keyup already closed the suppression window.
+  return (
+    key === "Enter" ||
+    key === "Escape" ||
+    key === " " ||
+    (key.length === 1 && key >= "0" && key <= "9")
+  );
 }
 
 function isModifierOnlyKey(key: string): boolean {


### PR DESCRIPTION
## Summary

Third pass at the workspace-terminal Chinese IME input bug. The previous two fixes (6a93a55b4, b0b101000) added an IME guard with an 80ms post-composition suppression window that blocks **every** unmodified key after `compositionend`. That over-suppression is itself the remaining bug users still hit:

- Enter pressed right after committing a candidate is swallowed — the command does not execute and Enter must be pressed twice.
- Fast typing drops the first keystroke of the next word.
- Full-width punctuation (。！？) typed right after a commit never reaches the PTY, because blocking keyCode 229 keydowns skips xterm's `CompositionHelper._handleAnyTextareaChanges()` path.

Verified against xterm 6.0.0 sources (`CoreBrowserTerminal.ts`, `CompositionHelper.ts`): only commit-capable keys (Enter / Escape / Space, plus digit candidate-selection keys) can replay as ghost events after `compositionend`, and ghost events always arrive before the physical key is released.

## Changes

- `terminalImeInputGuard.ts`: inside the post-composition window, suppress only commit-capable keys (Enter / Escape / Space / digits); let all other keys through so xterm's own keyCode 229 handling keeps working. Close the window on the first keyup outside composition — any later keydown is genuine user input, so a real Enter right after a commit is no longer swallowed.
- `terminalImeInputGuard.test.ts`: 5 new cases — letters pass through the window without `preventDefault`, `Process` keys pass through, keyup closes the window so a repeated Enter is processed, keyups during composition don't break suppression. All 8 existing cases unchanged and passing.
- `docs/conventions/troubleshooting.md`: new entry documenting this root cause next to the two previous IME entries.

Review follow-up (second commit): digits also commit candidates in Chinese IMEs, so they are included in the suppressed commit-key set; genuine digits are unaffected because the commit key's keyup closes the window before real input arrives.

## Testing

- `pnpm --filter @tutti-os/workspace-terminal test` — 70/70 pass
- `pnpm --filter @tutti-os/workspace-terminal typecheck` — pass
- Note: local `check:full` has two pre-existing failures unrelated to this diff (missing `node_modules` for `@tutti-os/claude-sdk-sidecar` locally, and a 600s timeout in `services/tuttid/service/agent` Go tests). This PR touches no Go code and no sidecar code.

Manual verification suggested: commit a candidate with Space then immediately press Enter (should execute once), and type full-width punctuation right after a commit (should appear in the terminal).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved terminal handling immediately after IME composition, reducing cases where genuine keystrokes could be swallowed.
  * Corrected post-composition behavior for common input keys (including Enter, letters, candidate-selection digits, and punctuation), so typing resumes as expected.

* **Tests**
  * Added new scenarios covering keydown/keypress/keyup behavior right after IME composition, including IME “Process” keys and suppression timing.

* **Documentation**
  * Updated troubleshooting guidance with a described IME failure mode and how the fix changes suppression behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
