### PR TITLE
fix(desktop-update): reset legacy preview channel on stable builds

### DIFF
--- a/apps/desktop/src/main/desktopHostPreferences.test.ts
+++ b/apps/desktop/src/main/desktopHostPreferences.test.ts
@@ -2,6 +2,7 @@ import assert from "node:assert/strict";
 import { mkdir, mkdtemp, readFile, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { setTimeout as sleep } from "node:timers/promises";
 import test from "node:test";
 import type { PutDesktopPreferencesRequest } from "@tutti-os/client-tuttid-ts";
 import { createDesktopHostPreferencesState } from "./desktopHostPreferences.ts";
@@ -382,7 +383,7 @@ test("createDesktopHostPreferencesState preserves initialized rc channel on rc p
   assert.equal(state.getUpdateChannel(), "rc");
 });
 
-test("createDesktopHostPreferencesState preserves rc after the stable default migration ran", async () => {
+test("createDesktopHostPreferencesState migrates rc even after the old stable default migration ran", async () => {
   const migrationStateRootDir = await mkdtemp(
     join(tmpdir(), "tutti-update-channel-migration-")
   );
@@ -392,6 +393,65 @@ test("createDesktopHostPreferencesState preserves rc after the stable default mi
       migrationStateRootDir,
       "migrations",
       "desktop-update-channel-default-stable-v1"
+    ),
+    "applied",
+    "utf8"
+  );
+  const putRequests: PutDesktopPreferencesRequest[] = [];
+  const state = await createDesktopHostPreferencesState({
+    fallbackLocale: "zh-CN",
+    logger: createLogger(),
+    migrationStateRootDir,
+    tuttidClient: {
+      async getDesktopPreferences() {
+        return {
+          initialized: true,
+          preferences: {
+            agentComposerDefaultsByProvider: {},
+            agentGuiConversationRailCollapsedByProvider: {},
+            agentConversationDetailMode: "coding",
+            agentDockLayout: "legacySplit",
+            appCatalogChannel: "production",
+            defaultAgentProvider: "codex",
+
+            dockIconStyle: "default",
+            dockPlacement: "bottom",
+            fileDefaultOpenersByExtension: { html: "defaultBrowser" },
+            locale: "zh-CN",
+            minimizeAnimation: "scale",
+            sleepPreventionMode: "never",
+            showAppDeveloperSources: false,
+            themeSource: "dark",
+            updateChannel: "rc",
+            updatePolicy: "prompt"
+          }
+        };
+      },
+      async putDesktopPreferences(request) {
+        putRequests.push(request);
+        return {
+          initialized: true,
+          preferences: request.preferences
+        };
+      }
+    }
+  });
+
+  assert.equal(state.getUpdateChannel(), "stable");
+  assert.equal(putRequests.length, 1);
+  assert.equal(putRequests[0]?.preferences.updateChannel, "stable");
+});
+
+test("createDesktopHostPreferencesState preserves explicitly selected rc on stable packages", async () => {
+  const migrationStateRootDir = await mkdtemp(
+    join(tmpdir(), "tutti-update-channel-migration-")
+  );
+  await mkdir(join(migrationStateRootDir, "migrations"), { recursive: true });
+  await writeFile(
+    join(
+      migrationStateRootDir,
+      "migrations",
+      "desktop-update-channel-explicit-preview-opt-in-v1"
     ),
     "applied",
     "utf8"
@@ -435,6 +495,61 @@ test("createDesktopHostPreferencesState preserves rc after the stable default mi
 
   assert.equal(putCalls, 0);
   assert.equal(state.getUpdateChannel(), "rc");
+});
+
+test("createDesktopHostPreferencesState records explicit preview opt-in after sync", async () => {
+  const migrationStateRootDir = await mkdtemp(
+    join(tmpdir(), "tutti-update-channel-migration-")
+  );
+  const state = await createDesktopHostPreferencesState({
+    fallbackLocale: "en",
+    logger: createLogger(),
+    migrationStateRootDir,
+    tuttidClient: {
+      async getDesktopPreferences() {
+        return {
+          initialized: true,
+          preferences: {
+            agentComposerDefaultsByProvider: {},
+            agentGuiConversationRailCollapsedByProvider: {},
+            agentConversationDetailMode: "coding",
+            agentDockLayout: "legacySplit",
+            appCatalogChannel: "production",
+            browserUseConnectionMode: "isolated",
+            defaultAgentProvider: "codex",
+
+            dockIconStyle: "default",
+            dockPlacement: "bottom",
+            fileDefaultOpenersByExtension: { html: "defaultBrowser" },
+            locale: "en",
+            minimizeAnimation: "scale",
+            sleepPreventionMode: "never",
+            showAppDeveloperSources: false,
+            themeSource: "system",
+            updateChannel: "stable",
+            updatePolicy: "prompt"
+          }
+        };
+      },
+      async putDesktopPreferences() {
+        throw new Error("putDesktopPreferences should not be called");
+      }
+    }
+  });
+
+  state.sync({ updateChannel: "rc" });
+
+  assert.equal(state.getUpdateChannel(), "rc");
+  assert.match(
+    await readFileEventually(
+      join(
+        migrationStateRootDir,
+        "migrations",
+        "desktop-update-channel-explicit-preview-opt-in-v1"
+      )
+    ),
+    /^\d{4}-\d{2}-\d{2}T/
+  );
 });
 
 test("createDesktopHostPreferencesState notifies subscribers after sync changes", async () => {
@@ -503,4 +618,17 @@ function createLogger(): DesktopLogger {
     error() {},
     async close() {}
   };
+}
+
+async function readFileEventually(path: string): Promise<string> {
+  let lastError: unknown;
+  for (let attempt = 0; attempt < 20; attempt += 1) {
+    try {
+      return await readFile(path, "utf8");
+    } catch (error) {
+      lastError = error;
+      await sleep(10);
+    }
+  }
+  throw lastError instanceof Error ? lastError : new Error(String(lastError));
 }

--- a/apps/desktop/src/main/desktopHostPreferences.ts
+++ b/apps/desktop/src/main/desktopHostPreferences.ts
@@ -55,6 +55,8 @@ import { resolveDesktopDefaultsFromEnv } from "./defaults.ts";
 
 const updateChannelDefaultMigrationID =
   "desktop-update-channel-default-stable-v1";
+const updateChannelExplicitPreviewOptInID =
+  "desktop-update-channel-explicit-preview-opt-in-v1";
 
 export interface DesktopHostPreferencesState {
   getAgentComposerDefaultsByProvider(): DesktopAgentComposerDefaultsByProvider;
@@ -312,6 +314,9 @@ export async function createDesktopHostPreferencesState(
         themeSource = input.themeSource;
       }
       if (input.updateChannel) {
+        if (previousUpdateChannel !== "rc" && input.updateChannel === "rc") {
+          void writeUpdateChannelExplicitPreviewOptInMarker(options);
+        }
         updateChannel = input.updateChannel;
       }
       if (input.updatePolicy) {
@@ -447,10 +452,7 @@ async function migrateInitializedDesktopPreferences(
   const normalizedAgentDockLayout = normalizeDesktopAgentDockLayout(
     preferences.agentDockLayout
   );
-  if (
-    preferences.updateChannel !== "rc" ||
-    defaultUpdateChannel !== "stable"
-  ) {
+  if (preferences.updateChannel !== "rc" || defaultUpdateChannel !== "stable") {
     if (
       preferences.minimizeAnimation === normalizedMinimizeAnimation &&
       preferences.agentConversationDetailMode ===
@@ -467,8 +469,9 @@ async function migrateInitializedDesktopPreferences(
     };
   }
 
-  const markerPath = resolveUpdateChannelDefaultMigrationMarkerPath(options);
-  if (await hasMigrationMarker(markerPath)) {
+  const explicitPreviewOptInMarkerPath =
+    resolveUpdateChannelExplicitPreviewOptInMarkerPath(options);
+  if (await hasMigrationMarker(explicitPreviewOptInMarkerPath)) {
     if (
       preferences.minimizeAnimation === normalizedMinimizeAnimation &&
       preferences.agentConversationDetailMode ===
@@ -486,6 +489,7 @@ async function migrateInitializedDesktopPreferences(
   }
 
   try {
+    const markerPath = resolveUpdateChannelDefaultMigrationMarkerPath(options);
     const response = await options.tuttidClient.putDesktopPreferences({
       preferences: {
         ...preferences,
@@ -521,6 +525,23 @@ function resolveDefaultDesktopUpdateChannel(
   return defaultDesktopUpdateChannel;
 }
 
+async function writeUpdateChannelExplicitPreviewOptInMarker(
+  options: CreateDesktopHostPreferencesOptions
+): Promise<void> {
+  try {
+    await writeMigrationMarker(
+      resolveUpdateChannelExplicitPreviewOptInMarkerPath(options)
+    );
+  } catch (error) {
+    options.logger.warn(
+      "failed to record explicit desktop preview update channel opt-in",
+      {
+        error: error instanceof Error ? error.message : String(error)
+      }
+    );
+  }
+}
+
 function resolveUpdateChannelDefaultMigrationMarkerPath(
   options: CreateDesktopHostPreferencesOptions
 ): string {
@@ -528,6 +549,15 @@ function resolveUpdateChannelDefaultMigrationMarkerPath(
     options.migrationStateRootDir ??
     resolveDesktopDefaultsFromEnv().state.rootDir;
   return join(stateRootDir, "migrations", updateChannelDefaultMigrationID);
+}
+
+function resolveUpdateChannelExplicitPreviewOptInMarkerPath(
+  options: CreateDesktopHostPreferencesOptions
+): string {
+  const stateRootDir =
+    options.migrationStateRootDir ??
+    resolveDesktopDefaultsFromEnv().state.rootDir;
+  return join(stateRootDir, "migrations", updateChannelExplicitPreviewOptInID);
 }
 
 async function hasMigrationMarker(markerPath: string): Promise<boolean> {

--- a/docs/conventions/desktop-release.md
+++ b/docs/conventions/desktop-release.md
@@ -142,7 +142,7 @@ Channel meanings:
 - `rc`: maps to electron-updater `channel="rc"` with `allowPrerelease=true`
 - `beta`: reserved for beta prerelease artifacts such as `v1.12.19-beta.0`; expose it in developer settings only if the team decides beta users should auto-update between beta builds
 
-When no desktop preference has been stored yet, the initial update channel follows the package version: plain stable versions use `stable`, `-rc.N` versions use `rc`, and `-beta.N` versions still use `stable` until beta auto-update is explicitly exposed. Existing stored `rc` defaults from older stable builds are migrated back to `stable` once. After that migration, users who explicitly select `rc` in developer settings keep that preference.
+When no desktop preference has been stored yet, the initial update channel follows the package version: plain stable versions use `stable`, `-rc.N` versions use `rc`, and `-beta.N` versions still use `stable` until beta auto-update is explicitly exposed. Stable builds migrate legacy stored `rc` defaults from older builds back to `stable` unless the user has explicitly selected the preview channel in developer settings. Selecting preview from developer settings records that opt-in so later stable builds can preserve it.
 
 Prerelease auto-update depends on both release shape and update metadata:
 


### PR DESCRIPTION
## Summary

- reset legacy saved preview/RC update-channel values back to stable when a stable desktop package starts
- preserve preview updates only after the user explicitly opts in from Developer settings
- document the explicit preview opt-in behavior and add focused desktop preference regression tests

## Why

After #679 merged, a stable package can still show `预览版` if the local desktop preferences already contain `updateChannel=rc`. The logs from `tutti-logs-20260704-155158.zip` showed the running package was stable `0.1.6`, but update checks used `channel="rc"` and downloaded `0.1.7-rc.0`.

The old migration marker only proved the stable-default migration had run before; it did not prove the user explicitly chose preview. This PR adds a separate explicit preview opt-in marker so stable packages can reset historical RC defaults without blocking intentional preview opt-ins.

## Validation

- `node --import ./apps/desktop/test/register-asset-stub.mjs --test --experimental-strip-types apps/desktop/src/main/desktopHostPreferences.test.ts`
- `/Users/wwcome/work/tutti-os/tutti/node_modules/.bin/oxfmt --check apps/desktop/src/main/desktopHostPreferences.ts apps/desktop/src/main/desktopHostPreferences.test.ts`
- `/Users/wwcome/work/tutti-os/tutti/node_modules/.bin/prettier --check --config packages/configs/prettier/base.mjs docs/conventions/desktop-release.md`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Desktop update channels now preserve an explicit preview opt-in, so choosing the preview channel is remembered during future preference migrations.

* **Bug Fixes**
  * Existing desktop preferences now migrate legacy preview-channel settings to stable more consistently, even after older stable migration steps have already run.
  * Improved handling for update-channel preference migration to avoid losing an intentional preview selection.

* **Documentation**
  * Clarified how desktop update-channel selection and migration behave for stable and preview builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->