### PR TITLE
fix(agent): backport nested agent fixes to release/0704

### DIFF
--- a/apps/desktop/src/renderer/src/features/workspace-agent/services/internal/desktopAgentHostProjection.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-agent/services/internal/desktopAgentHostProjection.ts
@@ -189,9 +189,7 @@ export function toAgentHostAgentSessionState(
   } = {}
 ) {
   const agentSessionId = options.agentSessionId?.trim() || session.id;
-  const settings = session.settings
-    ? normalizeComposerSettings(session.settings)
-    : options.defaults?.settings;
+  const settings = agentSessionStateSettings(session, options.defaults);
   const runtimeContext =
     session.runtimeContext ?? options.defaults?.runtimeContext;
   return {
@@ -215,6 +213,29 @@ export function toAgentHostAgentSessionState(
     updatedAtUnixMs: toUnixMs(session.updatedAt ?? session.createdAt),
     workspaceId
   };
+}
+
+function agentSessionStateSettings(
+  session: WorkspaceAgentSession,
+  defaults: AgentHostAgentSessionStateDefaults | undefined
+): AgentHostAgentSessionComposerSettings | undefined {
+  if (!session.settings) {
+    return defaults?.settings;
+  }
+  const settings = normalizeComposerSettings(session.settings);
+  const defaultModel = normalizedOptionalString(defaults?.settings?.model);
+  if (
+    session.provider === "claude-code" &&
+    settings.model === "default" &&
+    defaultModel !== null &&
+    defaultModel !== "default"
+  ) {
+    return {
+      ...settings,
+      model: defaultModel
+    };
+  }
+  return settings;
 }
 
 export function agentHostWorkspaceSessionFromCore(

--- a/apps/desktop/src/renderer/src/features/workspace-agent/services/internal/workspaceAgentActivityService.test.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-agent/services/internal/workspaceAgentActivityService.test.ts
@@ -101,6 +101,50 @@ test("WorkspaceAgentActivityService.activateSession omits provider target refs f
   });
 });
 
+test("WorkspaceAgentActivityService keeps explicit Claude model display over default alias state", async () => {
+  const createdSession = workspaceAgentSession({
+    provider: "claude-code",
+    settings: { model: "opus" },
+    status: "working"
+  });
+  const loadedSession = workspaceAgentSession({
+    provider: "claude-code",
+    settings: { model: "default" },
+    status: "working"
+  });
+  const service = new WorkspaceAgentActivityService({
+    tuttidClient: {
+      createWorkspaceAgentSession: async () => createdSession,
+      getWorkspaceAgentSession: async () => loadedSession,
+      sendWorkspaceAgentSessionInput: async () => ({ session: loadedSession }),
+      updateWorkspaceAgentSessionVisibility: async () => loadedSession
+    } as unknown as TuttidClient,
+    runtimeApi: {
+      logTerminalDiagnostic: async () => {}
+    }
+  });
+
+  const activation = await service.activateSession({
+    agentSessionId: "session-1",
+    agentTargetId: "local:claude-code",
+    cwd: "/workspace",
+    initialContent: [{ type: "text", text: "hi" }],
+    mode: "new",
+    provider: "claude-code",
+    settings: { model: "opus" },
+    title: "Claude",
+    visible: true,
+    workspaceId: "ws-1"
+  });
+  const controlState = await service.getSessionControlState({
+    agentSessionId: "session-1",
+    workspaceId: "ws-1"
+  });
+
+  assert.equal(activation.session.status, "working");
+  assert.equal(controlState.settings?.model, "opus");
+});
+
 test("WorkspaceAgentActivityService composer options cache is agent target keyed", async () => {
   const composerOptionCalls: unknown[] = [];
   const service = new WorkspaceAgentActivityService({
@@ -487,14 +531,21 @@ test("WorkspaceAgentActivityService.submitPlanDecision routes a claude exit-plan
 });
 
 function workspaceAgentSession(overrides: {
+  provider?: string;
+  runtimeContext?: Record<string, unknown>;
+  settings?: Record<string, unknown>;
   status: string;
 }): Record<string, unknown> {
   return {
     id: "session-1",
-    provider: "codex",
+    provider: overrides.provider ?? "codex",
     cwd: "/workspace",
     title: "Session 1",
     status: overrides.status,
+    ...(overrides.runtimeContext
+      ? { runtimeContext: overrides.runtimeContext }
+      : {}),
+    ...(overrides.settings ? { settings: overrides.settings } : {}),
     visible: true,
     createdAt: "2026-06-16T00:00:00.000Z",
     updatedAt: "2026-06-16T00:00:00.000Z"

--- a/docs/architecture/agent-gui-node.md
+++ b/docs/architecture/agent-gui-node.md
@@ -682,6 +682,13 @@ may carry lifecycle status such as `active` while the visible state is derived
 from `currentPhase` or turn lifecycle. Projection layers that bridge into legacy
 Host DTOs must normalize the tuple together, or `active/idle` and
 `active/working` sessions will render as the wrong conversation state.
+Daemon terminal turn reports must settle the tuple atomically: clear
+`turn.activeTurnId` and `turnLifecycle.activeTurnId`, set
+`turnLifecycle.phase` to `settled`, set `currentPhase` to `idle`, and replace an
+`active_turn` submit block with `submitAvailability.state = "available"`.
+Message Center and AgentGUI should keep AgentActivityRuntime as the source of
+truth instead of guessing that a completed turn with stale active-turn fields is
+safe to treat as finished.
 
 When the visible symptom is a sticky error badge on a rail row, dock preview, or
 message-center trigger, also inspect the latest loaded turn messages. A

--- a/docs/conventions/troubleshooting.md
+++ b/docs/conventions/troubleshooting.md
@@ -43,6 +43,36 @@ Use this shape for new entries:
 
 ## Current Entries
 
+### Claude SDK context window shows 200k for 1M models
+
+- Symptom:
+  Claude Code GUI usage shows a 200k context window for a model that should have
+  1M context, such as Claude Sonnet 5.
+- Quick checks:
+  Inspect the session runtime context for `usage.contextWindow.totalTokens`,
+  then trace the Claude SDK sidecar `usage_updated` payload and daemon
+  `agent_session.claude_sdk.usage_update` log. If the payload keys include
+  `modelUsage` but `raw_total_tokens` is `0`, the daemon did not parse the
+  model-usage context window.
+- Root cause:
+  AgentGUI only renders `runtimeContext.usage`; the total comes from the daemon
+  and Claude SDK sidecar. Claude SDK result messages expose model usage as a
+  map keyed by model id, for example
+  `modelUsage["claude-sonnet-5"].contextWindow`. If either sidecar or daemon
+  only parses array-shaped `modelUsage`, the context-window total is missing and
+  daemon normalization falls back to 200k.
+- Fix:
+  Parse `modelUsage` recursively as both arrays and maps before using fallback
+  context-window values. Do not hard-code alias-to-model mappings in Tutti.
+- Validation:
+  Add sidecar and daemon coverage with map-shaped `modelUsage` carrying
+  `contextWindow: 1_000_000`, then run the Claude SDK sidecar tests, daemon Go
+  tests, and sidecar typecheck.
+- References:
+  [main.ts](../../packages/agent/claude-sdk-sidecar/src/main.ts)
+  [main.test.ts](../../packages/agent/claude-sdk-sidecar/src/main.test.ts)
+  [claude_sdk_adapter.go](../../packages/agent/daemon/runtime/claude_sdk_adapter.go)
+
 ### Codex npm install misses the platform package
 
 - Symptom:
@@ -1106,10 +1136,14 @@ delimited by ---`, and the composer skill picker may show partial or
   For nested launches: register tool_use blocks from child-stream assistant
   messages, treat the `Async agent launched successfully` result text as the
   authoritative subagent-launch signal even when the tool name is unknown,
-  inherit the delegated-task turn id along the parent tool-use chain, let
-  interactive requests fall back to any delegated task's turn id (settled
-  ones included) and open a synthetic turn as last resort rather than emit a
-  turnless event.
+  inherit the delegated-task turn id along the parent tool-use chain, and do
+  not settle a nested `end_turn` assistant while it still has a child tool_use
+  whose tool_result has not been processed. Use the sidecar's pending
+  `toolByID` entry for that pre-result window, then rely on the delegated task
+  created from the launch result while the grandchild is running. Let
+  interactive requests fall back to any delegated task's turn id (settled ones
+  included) and open a synthetic turn as last resort rather than emit a turnless
+  event.
 - Validation:
   Add adapter coverage that stored pending turn ids survive missing
   `approval_resolved.turnId`. Add service coverage for ghost approval reconcile
@@ -1120,8 +1154,9 @@ delimited by ---`, and the composer skill picker may show partial or
   launches, keep sidecar coverage that a grandchild launch registers with the
   inherited turn id (with and without an observed tool_use block), that a
   nested approval after the parent task completed still carries a turn id, and
-  that a child `end_turn` assistant defers completion while a grandchild task
-  is running.
+  that a child `end_turn` assistant defers completion both while a grandchild
+  tool_result is still pending and while the resulting grandchild task is
+  running.
 
 ### Claude SDK parent waits forever for background agents that already finished
 

--- a/packages/agent/activity-core/src/controller.test.ts
+++ b/packages/agent/activity-core/src/controller.test.ts
@@ -1126,6 +1126,64 @@ test("controller preserves inline state patch turn metadata", async () => {
   });
 });
 
+test("controller clears active turn and submit block from settled inline state patch", async () => {
+  const controller = createAgentActivityController({
+    adapter: fakeAdapter({
+      listSessions: () =>
+        Promise.resolve({
+          sessions: [
+            createSession({
+              turnLifecycle: { activeTurnId: "turn-1", phase: "running" },
+              submitAvailability: {
+                state: "blocked",
+                reason: "active_turn"
+              },
+              currentPhase: "working",
+              lastEventUnixMs: 1000,
+              updatedAtUnixMs: 1000
+            })
+          ]
+        })
+    }),
+    workspaceId: "workspace-1"
+  });
+
+  await controller.load();
+  const result = controller.applyActivityUpdatedEvent({
+    workspaceId: "workspace-1",
+    agentSessionId: "session-1",
+    eventType: "state_patch",
+    data: {
+      workspaceId: "workspace-1",
+      agentSessionId: "session-1",
+      eventType: "state_patch",
+      currentPhase: "idle",
+      lastEventUnixMs: 2000,
+      submitAvailability: { state: "available" },
+      turn: {
+        turnId: "turn-1",
+        activeTurnId: null,
+        phase: "settled",
+        outcome: "completed",
+        submitAvailability: { state: "available" },
+        completedAtUnixMs: 2000
+      }
+    }
+  });
+
+  assert.equal(result.applied, true);
+  const session = controller.getSnapshot().sessions[0];
+  assert.deepEqual(session?.turnLifecycle, {
+    activeTurnId: null,
+    phase: "settled",
+    settling: undefined,
+    outcome: "completed",
+    completedCommand: null
+  });
+  assert.deepEqual(session?.submitAvailability, { state: "available" });
+  assert.equal(session?.currentPhase, "idle");
+});
+
 test("controller maps session update events into complete session snapshots", () => {
   const controller = createAgentActivityController({
     adapter: fakeAdapter(),

--- a/packages/agent/claude-sdk-sidecar/package.json
+++ b/packages/agent/claude-sdk-sidecar/package.json
@@ -9,7 +9,7 @@
     "typecheck": "node ../../../tools/scripts/run-tsgo-typecheck.mjs"
   },
   "dependencies": {
-    "@anthropic-ai/claude-agent-sdk": "0.3.191",
+    "@anthropic-ai/claude-agent-sdk": "0.3.201",
     "zod": "^4.0.0"
   },
   "devDependencies": {

--- a/packages/agent/claude-sdk-sidecar/src/main.test.ts
+++ b/packages/agent/claude-sdk-sidecar/src/main.test.ts
@@ -279,6 +279,48 @@ test("session start emits SDK model config options from initialization", async (
   }
 });
 
+test("context usage prefers result modelUsage window over SDK maxTokens", async () => {
+  const events: Array<{ type: string; payload?: Record<string, unknown> }> = [];
+  const restoreSink = withSidecarEventSinkForTest((event) =>
+    events.push(event)
+  );
+  try {
+    const session = new SessionRuntime(
+      "provider-session-1",
+      "/repo",
+      {},
+      false,
+      false,
+      {
+        model: "sonnet",
+        permissionModeId: "default",
+        planMode: false,
+        effort: "",
+        speed: ""
+      },
+      sidecarClaudeOptionsFromPayload({}),
+      undefined,
+      ({ prompt }) => fakeContextUsageQuery(prompt)
+    );
+
+    await session.start();
+    session.exec("turn-1", "hi");
+    await waitForEvent(events, "turn_completed");
+
+    const usage = events.find(
+      (event) =>
+        event.type === "usage_updated" && isRecord(event.payload?.contextWindow)
+    );
+    const contextWindow = isRecord(usage?.payload?.contextWindow)
+      ? usage.payload.contextWindow
+      : undefined;
+    assert.equal(contextWindow?.usedTokens, 36_092);
+    assert.equal(contextWindow?.totalTokens, 1_000_000);
+  } finally {
+    restoreSink();
+  }
+});
+
 test("late compact boundary still attaches to slash compact turn", async () => {
   const events: Array<{ type: string; payload?: Record<string, unknown> }> = [];
   const restoreSink = withSidecarEventSinkForTest((event) =>
@@ -457,6 +499,7 @@ test("bypass permission mode allows ordinary tools without approval", async () =
             { command: "rm -rf /repo/*" },
             {
               signal: new AbortController().signal,
+              requestId: "request-bash",
               toolUseID: "toolu-bash"
             }
           );
@@ -517,6 +560,7 @@ test("bypass permission mode still surfaces AskUserQuestion", async () => {
             },
             {
               signal: new AbortController().signal,
+              requestId: "request-ask",
               toolUseID: "toolu-ask"
             }
           );
@@ -1245,6 +1289,57 @@ function fakeSimpleResultQuery(
     },
     close() {}
   } as AsyncIterable<SDKMessage>;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function fakeContextUsageQuery(
+  prompt: AsyncIterable<SDKUserMessage>
+): AsyncIterable<SDKMessage> & {
+  getContextUsage: () => Promise<unknown>;
+  close: () => void;
+} {
+  return {
+    async *[Symbol.asyncIterator]() {
+      const firstPrompt = await prompt[Symbol.asyncIterator]().next();
+      const promptMessage = firstPrompt.value as SDKUserMessage & {
+        uuid?: string;
+      };
+      yield {
+        ...promptMessage,
+        uuid: promptMessage.uuid,
+        type: "user",
+        parent_tool_use_id: null,
+        session_id: "provider-session-1"
+      } as SDKMessage;
+      yield {
+        type: "result",
+        subtype: "success",
+        modelUsage: {
+          "claude-sonnet-5": {
+            inputTokens: 12,
+            outputTokens: 3,
+            cacheReadInputTokens: 0,
+            cacheCreationInputTokens: 0,
+            webSearchRequests: 0,
+            costUSD: 0,
+            contextWindow: 1_000_000,
+            maxOutputTokens: 64_000
+          }
+        }
+      } as unknown as SDKMessage;
+    },
+    async getContextUsage() {
+      return {
+        totalTokens: 36_092,
+        maxTokens: 200_000,
+        rawMaxTokens: 1_000_000
+      };
+    },
+    close() {}
+  };
 }
 
 function fakeEarlyConsolidatedAssistantQuery(
@@ -2168,6 +2263,61 @@ test("nested end_turn assistant defers parent completion while grandchild runs",
   }
 });
 
+test("nested end_turn assistant defers parent completion while child tool result is pending", async () => {
+  const events: Array<{ type: string; payload?: Record<string, unknown> }> = [];
+  const restoreSink = withSidecarEventSinkForTest((event) =>
+    events.push(event)
+  );
+  try {
+    const session = new SessionRuntime(
+      "provider-session-1",
+      "/repo",
+      {},
+      false,
+      false,
+      {
+        model: "",
+        permissionModeId: "default",
+        planMode: false,
+        effort: "",
+        speed: ""
+      },
+      sidecarClaudeOptionsFromPayload({}),
+      undefined,
+      fakeNestedToolUseAndEndTurnQuery
+    );
+
+    await session.start();
+    session.exec("turn-1", "delegate task");
+    await waitForEvent(events, "task_completed");
+    // Let the fake stream drain the grandchild result and final parent end.
+    await new Promise((resolve) => setTimeout(resolve, 50));
+
+    const parentCompletions = events.filter(
+      (event) =>
+        event.type === "task_completed" &&
+        event.payload?.parentToolUseId === "toolu-parent"
+    );
+    assert.equal(parentCompletions.length, 1);
+    assert.equal(parentCompletions[0]?.payload?.summary, "Parent finished.");
+
+    const childCompletedIndex = events.findIndex(
+      (event) =>
+        event.type === "task_completed" &&
+        event.payload?.parentToolUseId === "toolu-child"
+    );
+    const parentCompletedIndex = events.findIndex(
+      (event) =>
+        event.type === "task_completed" &&
+        event.payload?.parentToolUseId === "toolu-parent"
+    );
+    assert.ok(childCompletedIndex >= 0);
+    assert.ok(parentCompletedIndex > childCompletedIndex);
+  } finally {
+    restoreSink();
+  }
+});
+
 function fakeNestedDelegatedLaunchQuery({
   prompt
 }: {
@@ -2285,6 +2435,7 @@ function fakeNestedApprovalQuery(
         { command: "ls" },
         {
           signal: new AbortController().signal,
+          requestId: "request-nested-bash",
           toolUseID: "toolu-nested-bash"
         }
       );
@@ -2346,6 +2497,52 @@ function fakeNestedDeferredParentCompletionQuery({
   } as AsyncIterable<SDKMessage>;
 }
 
+function fakeNestedToolUseAndEndTurnQuery({
+  prompt
+}: {
+  prompt: AsyncIterable<SDKUserMessage>;
+}): AsyncIterable<SDKMessage> {
+  return {
+    async *[Symbol.asyncIterator]() {
+      const firstPrompt = await prompt[Symbol.asyncIterator]().next();
+      const promptMessage = firstPrompt.value as SDKUserMessage & {
+        uuid?: string;
+      };
+      yield {
+        ...promptMessage,
+        uuid: promptMessage.uuid,
+        type: "user",
+        parent_tool_use_id: null,
+        session_id: "provider-session-1"
+      } as SDKMessage;
+      yield delegatedAgentToolUse("toolu-parent", "Parent task");
+      yield delegatedAgentToolResult("toolu-parent", "agent-parent");
+      yield {
+        type: "result",
+        subtype: "success"
+      } as unknown as SDKMessage;
+      yield nestedAssistantToolUseWithEndTurn(
+        "toolu-parent",
+        "toolu-child",
+        "Grandchild task",
+        "Launched grandchild."
+      );
+      yield nestedAgentLaunchResult(
+        "toolu-parent",
+        "toolu-child",
+        "agent-child"
+      );
+      yield userTaskNotification("agent-child", "toolu-child");
+      yield nestedEndTurnAssistant(
+        "toolu-parent",
+        "assistant-final-end",
+        "Parent finished."
+      );
+    },
+    close() {}
+  } as AsyncIterable<SDKMessage>;
+}
+
 function nestedAssistantToolUse(
   parentToolUseId: string,
   id: string,
@@ -2359,6 +2556,36 @@ function nestedAssistantToolUse(
     message: {
       role: "assistant",
       content: [
+        {
+          type: "tool_use",
+          id,
+          name: "Task",
+          input: {
+            description,
+            prompt: description
+          }
+        }
+      ]
+    }
+  } as unknown as SDKMessage;
+}
+
+function nestedAssistantToolUseWithEndTurn(
+  parentToolUseId: string,
+  id: string,
+  description: string,
+  text: string
+): SDKMessage {
+  return {
+    type: "assistant",
+    uuid: `${id}-nested-end-turn-assistant`,
+    parent_tool_use_id: parentToolUseId,
+    session_id: "provider-session-1",
+    message: {
+      role: "assistant",
+      stop_reason: "end_turn",
+      content: [
+        { type: "text", text },
         {
           type: "tool_use",
           id,

--- a/packages/agent/claude-sdk-sidecar/src/main.ts
+++ b/packages/agent/claude-sdk-sidecar/src/main.ts
@@ -1222,7 +1222,7 @@ export class SessionRuntime {
         }
         if (
           this.isNestedDelegatedTaskTerminalAssistant(message) &&
-          !this.hasRunningChildDelegatedTasks(parentToolUseID)
+          !this.hasUnsettledChildWork(parentToolUseID)
         ) {
           this.completeDelegatedTaskFromParentMessage(parentToolUseID, {
             status: "completed",
@@ -2660,6 +2660,22 @@ export class SessionRuntime {
     return false;
   }
 
+  private hasUnsettledChildWork(parentToolUseId: string): boolean {
+    return (
+      this.hasPendingChildToolResults(parentToolUseId) ||
+      this.hasRunningChildDelegatedTasks(parentToolUseId)
+    );
+  }
+
+  private hasPendingChildToolResults(parentToolUseId: string): boolean {
+    for (const tool of this.toolByID.values()) {
+      if (tool.parentToolUseId === parentToolUseId) {
+        return true;
+      }
+    }
+    return false;
+  }
+
   private emitDelegatedTaskParentUpdate(
     task: DelegatedTaskState,
     message: Record<string, unknown>
@@ -3357,6 +3373,15 @@ function contextWindowTokensFromModelUsage(value: unknown): number {
     "max"
   ]) {
     const tokens = numberValue(record[key]);
+    if (tokens > 0) {
+      return tokens;
+    }
+  }
+  for (const nested of Object.values(record)) {
+    if (typeof nested !== "object" || nested === null) {
+      continue;
+    }
+    const tokens = contextWindowTokensFromModelUsage(nested);
     if (tokens > 0) {
       return tokens;
     }

--- a/packages/agent/daemon/runtime/claude_sdk_adapter.go
+++ b/packages/agent/daemon/runtime/claude_sdk_adapter.go
@@ -1665,10 +1665,32 @@ func claudeSDKContextWindowTokens(payload map[string]any) int64 {
 	); ok {
 		return total
 	}
-	modelUsage, _ := payload["modelUsage"].([]any)
-	for _, item := range modelUsage {
-		if candidate, ok := item.(map[string]any); ok {
-			if total := claudeSDKContextWindowTokens(candidate); total > 0 {
+	if total := claudeSDKContextWindowTokensFromValue(payload["modelUsage"]); total > 0 {
+		return total
+	}
+	return 0
+}
+
+func claudeSDKContextWindowTokensFromValue(value any) int64 {
+	switch typed := value.(type) {
+	case []any:
+		for _, item := range typed {
+			if total := claudeSDKContextWindowTokensFromValue(item); total > 0 {
+				return total
+			}
+		}
+	case []map[string]any:
+		for _, item := range typed {
+			if total := claudeSDKContextWindowTokens(item); total > 0 {
+				return total
+			}
+		}
+	case map[string]any:
+		if total := claudeSDKContextWindowTokens(typed); total > 0 {
+			return total
+		}
+		for _, item := range typed {
+			if total := claudeSDKContextWindowTokensFromValue(item); total > 0 {
 				return total
 			}
 		}

--- a/packages/agent/daemon/runtime/claude_sdk_adapter_test.go
+++ b/packages/agent/daemon/runtime/claude_sdk_adapter_test.go
@@ -1754,6 +1754,46 @@ func TestClaudeCodeSDKAdapterMapsUsageUpdatedIntoRuntimeContext(t *testing.T) {
 	}
 }
 
+func TestClaudeCodeSDKAdapterMapsModelUsageContextWindowMap(t *testing.T) {
+	adapter := NewClaudeCodeSDKAdapter(nil)
+	session := standardTestSession(ProviderClaudeCode)
+	adapterSession := &claudeSDKAdapterSession{liveState: newClaudeSDKLiveState()}
+	adapter.storeSession(session.AgentSessionID, adapterSession)
+
+	events, terminal, err := adapter.sidecarTurnEvents(adapterSession, session, "turn-1", claudeSDKSidecarEvent{
+		Type: "usage_updated",
+		Payload: map[string]any{
+			"turnId": "turn-1",
+			"usage": map[string]any{
+				"input_tokens":                2,
+				"output_tokens":               13,
+				"cache_read_input_tokens":     18622,
+				"cache_creation_input_tokens": 17466,
+			},
+			"modelUsage": map[string]any{
+				"claude-sonnet-5": map[string]any{
+					"contextWindow": 1_000_000,
+				},
+			},
+		},
+	})
+	if err != nil || terminal {
+		t.Fatalf("usage_updated terminal=%v err=%v", terminal, err)
+	}
+	if len(events) != 1 || events[0].Type != activityshared.EventSessionUpdated {
+		t.Fatalf("usage events = %#v, want session.updated", events)
+	}
+	state := adapter.SessionState(session)
+	usage, _ := state.RuntimeContext["usage"].(map[string]any)
+	contextWindow, _ := usage["contextWindow"].(map[string]any)
+	if got, ok := acpInt64Value(contextWindow["usedTokens"]); !ok || got != 36103 {
+		t.Fatalf("usedTokens = %#v, want 36103", contextWindow["usedTokens"])
+	}
+	if got, ok := acpInt64Value(contextWindow["totalTokens"]); !ok || got != 1_000_000 {
+		t.Fatalf("totalTokens = %#v, want model usage context window", contextWindow["totalTokens"])
+	}
+}
+
 func TestClaudeCodeSDKAdapterMapsContextUsageUpdatedIntoRuntimeContext(t *testing.T) {
 	adapter := NewClaudeCodeSDKAdapter(nil)
 	session := standardTestSession(ProviderClaudeCode)

--- a/packages/agent/daemon/runtime/controller.go
+++ b/packages/agent/daemon/runtime/controller.go
@@ -859,7 +859,11 @@ func (c *Controller) runExecTurn(ctx context.Context, session Session, adapter A
 		previousStatus := session.Status
 		session = applySessionEvents(session, events)
 		session = applyTurnLifecycleFromEvents(session, events)
-		session = c.preserveActiveTurnStatus(session, turnID, previousStatus)
+		if turnEventsAreTerminal(events) {
+			session = reconcileFinishedTurnStatus(session)
+		} else {
+			session = c.preserveActiveTurnStatus(session, turnID, previousStatus)
+		}
 		if shouldAdvanceSessionUpdatedAtFromEvents(events) {
 			session.UpdatedAtUnixMS = unixMS(now())
 		}
@@ -1562,16 +1566,32 @@ func (c *Controller) reconcileSessionStatusLocked(key string, session Session) S
 	if sessionHasLiveTurnLifecycle(session) {
 		return session
 	}
+	return reconcileFinishedTurnStatus(session)
+}
+
+func reconcileFinishedTurnStatus(session Session) Session {
+	if sessionHasLiveTurnLifecycle(session) {
+		return session
+	}
 	if sessionHasLiveBackgroundAgents(session) {
 		session.Status = SessionStatusWorking
 		session.SubmitAvailability = blockedSubmitAvailability("background_agent")
 		return session
 	}
-	if session.Status != SessionStatusWorking {
-		return session
+	if session.Status == SessionStatusWorking {
+		session.Status = SessionStatusReady
 	}
-	session.Status = SessionStatusReady
 	return session
+}
+
+func turnEventsAreTerminal(events []activityshared.Event) bool {
+	for _, event := range events {
+		switch event.Type {
+		case activityshared.EventTurnCompleted, activityshared.EventTurnFailed:
+			return true
+		}
+	}
+	return false
 }
 
 func (c *Controller) UpdateSettings(ctx context.Context, input UpdateSettingsInput) (UpdateSettingsResult, error) {

--- a/packages/agent/daemon/runtime/controller_test.go
+++ b/packages/agent/daemon/runtime/controller_test.go
@@ -2656,6 +2656,72 @@ func TestControllerExecReconcilesWorkingStatusAfterTurnFinishesWithoutTerminalEv
 	}
 }
 
+func TestControllerExecReportsTerminalTurnAsSettledAndAvailable(t *testing.T) {
+	t.Parallel()
+
+	adapter := newBlockingExecAdapter()
+	adapter.provider = ProviderClaudeCode
+	reporter := &recordingReporter{}
+	controller := NewController([]Adapter{adapter}, reporter)
+	started, err := controller.Start(context.Background(), StartInput{
+		RoomID:         "room-1",
+		AgentSessionID: "agent-session-1",
+		Provider:       ProviderClaudeCode,
+		Title:          "Test",
+	})
+	if err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	if _, err := controller.Exec(context.Background(), ExecInput{
+		RoomID:         "room-1",
+		AgentSessionID: started.Session.AgentSessionID,
+		Content:        textPrompt("run"),
+	}); err != nil {
+		t.Fatalf("Exec: %v", err)
+	}
+	adapter.waitForPrompt(t, "run")
+	adapter.releaseNext()
+	session := waitForSessionStatus(t, controller, "room-1", started.Session.AgentSessionID, SessionStatusReady)
+	if session.SubmitAvailability == nil || session.SubmitAvailability.State != "available" {
+		t.Fatalf("session submit availability = %#v, want available", session.SubmitAvailability)
+	}
+
+	reports := reporter.waitForCalls(t, 3)
+	var terminalPatch *agentsessionstore.WorkspaceAgentStatePatch
+	for _, call := range reports {
+		for index := range call.report.StatePatches {
+			patch := &call.report.StatePatches[index]
+			if patch.Turn != nil && patch.Turn.CompletedAtUnixMS > 0 {
+				terminalPatch = patch
+			}
+		}
+	}
+	if terminalPatch == nil {
+		t.Fatalf("reports = %#v, missing terminal turn patch", reports)
+	}
+	if terminalPatch.CurrentPhase != string(activityshared.TurnPhaseIdle) {
+		t.Fatalf("terminal patch current phase = %q, want idle", terminalPatch.CurrentPhase)
+	}
+	if terminalPatch.Turn == nil ||
+		terminalPatch.Turn.ActiveTurnID != nil ||
+		terminalPatch.Turn.Phase != "settled" ||
+		terminalPatch.Turn.Outcome != "completed" ||
+		terminalPatch.Turn.SubmitAvailability == nil ||
+		terminalPatch.Turn.SubmitAvailability.State != "available" {
+		t.Fatalf("terminal turn patch = %#v, want settled available with nil active turn", terminalPatch.Turn)
+	}
+	if terminalPatch.TurnLifecycle == nil ||
+		terminalPatch.TurnLifecycle.ActiveTurnID != nil ||
+		terminalPatch.TurnLifecycle.Phase != "settled" ||
+		terminalPatch.TurnLifecycle.Outcome == nil ||
+		*terminalPatch.TurnLifecycle.Outcome != "completed" {
+		t.Fatalf("terminal turn lifecycle = %#v, want completed settled with nil active turn", terminalPatch.TurnLifecycle)
+	}
+	if terminalPatch.SubmitAvailability == nil || terminalPatch.SubmitAvailability.State != "available" {
+		t.Fatalf("terminal submit availability = %#v, want available", terminalPatch.SubmitAvailability)
+	}
+}
+
 func TestControllerExecUsesAsyncAdapterAndFinalizesFromTerminalEvent(t *testing.T) {
 	t.Parallel()
 
@@ -3862,6 +3928,69 @@ func TestControllerFinishParentTurnDoesNotOverwriteSyntheticLifecycle(t *testing
 	}
 	if _, ok := controller.activeTurn("room-1", "agent-session-1"); ok {
 		t.Fatal("parent active turn map entry still exists")
+	}
+}
+
+func TestControllerFinishTurnKeepsLiveBackgroundAgentsWorking(t *testing.T) {
+	t.Parallel()
+
+	controller := NewController(nil, nil)
+	turnID := "turn-1"
+	session := Session{
+		RoomID:         "room-1",
+		AgentSessionID: "agent-session-1",
+		Provider:       ProviderClaudeCode,
+		Status:         SessionStatusWorking,
+		TurnLifecycle: &TurnLifecycle{
+			ActiveTurnID: stringPtr(turnID),
+			Phase:        "running",
+		},
+		SubmitAvailability: blockedSubmitAvailability("active_turn"),
+		RuntimeContext: map[string]any{
+			"backgroundAgents": map[string]any{
+				"count": 1,
+				"items": []any{map[string]any{
+					"parentToolUseId": "call-agent-1",
+					"status":          "running",
+				}},
+			},
+		},
+	}
+	controller.store(session)
+	controller.mu.Lock()
+	controller.turns[sessionKey(session.RoomID, session.AgentSessionID)] = activeTurn{turnID: turnID}
+	controller.mu.Unlock()
+
+	outcome := "completed"
+	controller.finishTurn(Session{
+		RoomID:         session.RoomID,
+		AgentSessionID: session.AgentSessionID,
+		Provider:       session.Provider,
+		Status:         SessionStatusReady,
+		TurnLifecycle: &TurnLifecycle{
+			Phase:   "settled",
+			Outcome: &outcome,
+		},
+		SubmitAvailability: availableSubmitAvailability(),
+		RuntimeContext:     session.RuntimeContext,
+	}, turnID)
+
+	updated, ok := controller.get(session.RoomID, session.AgentSessionID)
+	if !ok {
+		t.Fatal("session missing after finish")
+	}
+	if updated.Status != SessionStatusWorking {
+		t.Fatalf("status = %q, want working while background agent runs", updated.Status)
+	}
+	if updated.SubmitAvailability == nil ||
+		updated.SubmitAvailability.State != "blocked" ||
+		updated.SubmitAvailability.Reason != "background_agent" {
+		t.Fatalf("submit availability = %#v, want blocked background_agent", updated.SubmitAvailability)
+	}
+	if updated.TurnLifecycle == nil ||
+		updated.TurnLifecycle.ActiveTurnID != nil ||
+		updated.TurnLifecycle.Phase != "settled" {
+		t.Fatalf("turn lifecycle = %#v, want settled parent turn", updated.TurnLifecycle)
 	}
 }
 

--- a/packages/agent/daemon/runtime/reporter.go
+++ b/packages/agent/daemon/runtime/reporter.go
@@ -816,7 +816,8 @@ func statePatchFromSessionEvent(source agentsessionstore.EventSource, event acti
 			patch.Turn.Phase = firstNonEmptyString(patch.Turn.Phase, patch.CurrentPhase)
 		}
 	case activityshared.EventTurnFailed:
-		patch.CurrentPhase = firstNonEmptyString(patch.CurrentPhase, string(activityshared.TurnPhaseFailed))
+		patch.LifecycleStatus = firstNonEmptyString(patch.LifecycleStatus, string(activityshared.SessionLifecycleStatusActive))
+		patch.CurrentPhase = firstNonEmptyString(patch.CurrentPhase, string(activityshared.TurnPhaseIdle))
 		if patch.Turn != nil {
 			patch.Turn.CompletedAtUnixMS = timestamp
 			patch.Turn.Phase = firstNonEmptyString(patch.Turn.Phase, patch.CurrentPhase)
@@ -891,7 +892,7 @@ func cloneInteractivePrompt(value *agentsessionstore.WorkspaceAgentInteractivePr
 }
 
 func applyExplicitTurnLifecycleToPatch(patch *agentsessionstore.WorkspaceAgentStatePatch, event activityshared.Event) {
-	if patch == nil || strings.TrimSpace(patch.Provider) != ProviderCodex {
+	if patch == nil || !providerUsesExplicitTurnLifecyclePatch(patch.Provider) {
 		return
 	}
 	turnID := strings.TrimSpace(event.Payload.TurnID)
@@ -908,6 +909,7 @@ func applyExplicitTurnLifecycleToPatch(patch *agentsessionstore.WorkspaceAgentSt
 	if lifecyclePhase == "settled" {
 		turnActive = nil
 		outcome = codexLifecycleOutcomeFromActivityEvent(event)
+		patch.CurrentPhase = string(activityshared.TurnPhaseIdle)
 	}
 	if patch.Turn == nil {
 		patch.Turn = &agentsessionstore.WorkspaceAgentTurnPatch{TurnID: turnID}
@@ -928,6 +930,15 @@ func applyExplicitTurnLifecycleToPatch(patch *agentsessionstore.WorkspaceAgentSt
 	}
 	if outcome != "" {
 		patch.TurnLifecycle.Outcome = &outcome
+	}
+}
+
+func providerUsesExplicitTurnLifecyclePatch(provider string) bool {
+	switch strings.TrimSpace(provider) {
+	case ProviderClaudeCode, ProviderCodex:
+		return true
+	default:
+		return false
 	}
 }
 

--- a/packages/agent/daemon/runtime/reporter_test.go
+++ b/packages/agent/daemon/runtime/reporter_test.go
@@ -1066,6 +1066,18 @@ func TestReporterProjectsSessionAndTurnLifecycleToStatePatches(t *testing.T) {
 	}
 	if input.StatePatches[2].Turn == nil ||
 		input.StatePatches[2].Turn.CompletedAtUnixMS == 0 ||
+		input.StatePatches[2].Turn.ActiveTurnID != nil ||
+		input.StatePatches[2].Turn.Phase != "settled" ||
+		input.StatePatches[2].Turn.Outcome != "completed" ||
+		input.StatePatches[2].Turn.SubmitAvailability == nil ||
+		input.StatePatches[2].Turn.SubmitAvailability.State != "available" ||
+		input.StatePatches[2].TurnLifecycle == nil ||
+		input.StatePatches[2].TurnLifecycle.ActiveTurnID != nil ||
+		input.StatePatches[2].TurnLifecycle.Phase != "settled" ||
+		input.StatePatches[2].TurnLifecycle.Outcome == nil ||
+		*input.StatePatches[2].TurnLifecycle.Outcome != "completed" ||
+		input.StatePatches[2].SubmitAvailability == nil ||
+		input.StatePatches[2].SubmitAvailability.State != "available" ||
 		input.StatePatches[2].CurrentPhase != string(activityshared.TurnPhaseIdle) {
 		t.Fatalf("turn completed patch = %#v", input.StatePatches[2])
 	}
@@ -1159,7 +1171,20 @@ func TestReporterProjectsTurnFailureErrorToStatePatch(t *testing.T) {
 	if len(input.StatePatches) != 1 {
 		t.Fatalf("state patches = %#v, want 1", input.StatePatches)
 	}
-	if input.StatePatches[0].CurrentPhase != string(activityshared.TurnPhaseFailed) {
+	if input.StatePatches[0].CurrentPhase != string(activityshared.TurnPhaseIdle) ||
+		input.StatePatches[0].Turn == nil ||
+		input.StatePatches[0].Turn.ActiveTurnID != nil ||
+		input.StatePatches[0].Turn.Phase != "settled" ||
+		input.StatePatches[0].Turn.Outcome != "failed" ||
+		input.StatePatches[0].Turn.SubmitAvailability == nil ||
+		input.StatePatches[0].Turn.SubmitAvailability.State != "available" ||
+		input.StatePatches[0].TurnLifecycle == nil ||
+		input.StatePatches[0].TurnLifecycle.ActiveTurnID != nil ||
+		input.StatePatches[0].TurnLifecycle.Phase != "settled" ||
+		input.StatePatches[0].TurnLifecycle.Outcome == nil ||
+		*input.StatePatches[0].TurnLifecycle.Outcome != "failed" ||
+		input.StatePatches[0].SubmitAvailability == nil ||
+		input.StatePatches[0].SubmitAvailability.State != "available" {
 		t.Fatalf("turn failed patch = %#v", input.StatePatches[0])
 	}
 	if input.StatePatches[0].LastError != "Codex request failed because a quota or rate limit was reached." {

--- a/packages/agent/gui/package.json
+++ b/packages/agent/gui/package.json
@@ -108,6 +108,10 @@
         "types": "./dist/agent-conversation/index.d.ts",
         "import": "./dist/agent-conversation/index.js"
       },
+      "./agent-env": {
+        "types": "./dist/agent-env/index.d.ts",
+        "import": "./dist/agent-env/index.js"
+      },
       "./context-mention-palette": {
         "types": "./dist/context-mention-palette/index.d.ts",
         "import": "./dist/context-mention-palette/index.js"
@@ -178,6 +182,9 @@
         ],
         "agent-conversation": [
           "./dist/agent-conversation/index.d.ts"
+        ],
+        "agent-env": [
+          "./dist/agent-env/index.d.ts"
         ],
         "context-mention-palette": [
           "./dist/context-mention-palette/index.d.ts"

--- a/packages/agent/gui/tsup.config.ts
+++ b/packages/agent/gui/tsup.config.ts
@@ -7,6 +7,7 @@ export default defineConfig({
     index: "index.ts",
     "agent-message-center/index": "agent-message-center/index.ts",
     "agent-conversation/index": "agent-conversation/index.ts",
+    "agent-env/index": "shared/agentEnv/index.ts",
     "context-mention-palette/index": "context-mention-palette/index.ts",
     "context-mention-provider":
       "agent-gui/agentGuiNode/agentContextMentionProvider.ts",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -245,8 +245,8 @@ importers:
   packages/agent/claude-sdk-sidecar:
     dependencies:
       "@anthropic-ai/claude-agent-sdk":
-        specifier: 0.3.191
-        version: 0.3.191(@anthropic-ai/sdk@0.109.0(zod@4.4.3))(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))(zod@4.4.3)
+        specifier: 0.3.201
+        version: 0.3.201(@anthropic-ai/sdk@0.109.0(zod@4.4.3))(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))(zod@4.4.3)
       zod:
         specifier: ^4.0.0
         version: 4.4.3
@@ -1155,74 +1155,74 @@ packages:
         integrity: sha512-6OzddxPio9UiWTCemp4N8cYLV2ZN1ncRnV1cVGtve7dhPOtRkleRyx32GQCYSwDYgaHU3USMm84tNsvKzRCa1Q==
       }
 
-  "@anthropic-ai/claude-agent-sdk-darwin-arm64@0.3.191":
+  "@anthropic-ai/claude-agent-sdk-darwin-arm64@0.3.201":
     resolution:
       {
-        integrity: sha512-rmpi5ONfuuw7oXdzyr9QJB5sK9Rr1MmdOUsiGutVFpcAqqSXpVYLmMvfaarmXvItgfwgGprzrGDfcAeAQHSUGw==
+        integrity: sha512-8Mcb3BDyKUGfJWFFTWwt+at37lbDH3ZwVtUNPWGG1toZ75RDCJry5U4kXRvQ2xokvJQlA0E+eNp6keWe5ZH22Q==
       }
     cpu: [arm64]
     os: [darwin]
 
-  "@anthropic-ai/claude-agent-sdk-darwin-x64@0.3.191":
+  "@anthropic-ai/claude-agent-sdk-darwin-x64@0.3.201":
     resolution:
       {
-        integrity: sha512-b/4pfSFTC2gkc0RoGSJ5B3DWo77qZFMi2hRlx8kwaRDiefeIOnbJu42gDBrs4F8nSJJug77HM9AsG6XHXvt5Fg==
+        integrity: sha512-TFR2bu0+ml3RHoMrtsgD0qDK5Oknw8kYGBV7qpQHn+IWmE96gnHhogG1LpJwpHtni08XkJIjfWk1DdlsUYtRkQ==
       }
     cpu: [x64]
     os: [darwin]
 
-  "@anthropic-ai/claude-agent-sdk-linux-arm64-musl@0.3.191":
+  "@anthropic-ai/claude-agent-sdk-linux-arm64-musl@0.3.201":
     resolution:
       {
-        integrity: sha512-+Gg7lKwYDr8uiA37EBMYI63if+YGdbrFt2tcRFBB4IhdVf5r1IkKwQ8rEYV6Y0nqGTKoXLh3bRc5QWOe5JwgbQ==
+        integrity: sha512-EiqbpfJIpChfkn+8Uj061Qjyw0eaRcOXtdrvVuHANyj8ZErVOr8HlH6op9PSeIUa9TX0m2+tNgKPQvOGseQckA==
       }
     cpu: [arm64]
     os: [linux]
 
-  "@anthropic-ai/claude-agent-sdk-linux-arm64@0.3.191":
+  "@anthropic-ai/claude-agent-sdk-linux-arm64@0.3.201":
     resolution:
       {
-        integrity: sha512-vm526e3InpItmh+Ua8a49eGTpFJvZTYLURX9ppKrtFb+Wo7rOgoXmK/Hzf/crEU7h72xtaD7PIOXm4P+psxO3w==
+        integrity: sha512-mShTo3MwF0gkN4dDw78wWJiB6aBDVRkl81cnApvoBofpdyUBYgm9Gw16CCjDTgelMKeBFqN6ErJpwjI3wbP00A==
       }
     cpu: [arm64]
     os: [linux]
 
-  "@anthropic-ai/claude-agent-sdk-linux-x64-musl@0.3.191":
+  "@anthropic-ai/claude-agent-sdk-linux-x64-musl@0.3.201":
     resolution:
       {
-        integrity: sha512-tUwwIXpPBrzJge3E4SQJQX8PuC+lxPb5xQBmyLsWxyjttlgpFpTG/jWPVQO5qH0HgYaEJS5JALHFiYcXwVrEkg==
+        integrity: sha512-IbxnzO5UCbqbm2TnzCHkSyJorAFw2isdKdIsFCTxJJjSs3ZC+v3LC1QSUiVCx0qi+CV6w3MKx6mLI11mrvhbbQ==
       }
     cpu: [x64]
     os: [linux]
 
-  "@anthropic-ai/claude-agent-sdk-linux-x64@0.3.191":
+  "@anthropic-ai/claude-agent-sdk-linux-x64@0.3.201":
     resolution:
       {
-        integrity: sha512-wj43/l0Behb4UWYt6Lomq2W7jhmuU7ARsEP0el6gLGCR348PDeqLGcB4dMOcYMGRZv8TYKfnhDwJnX4pJBT1vQ==
+        integrity: sha512-jrJBrRWrSuoFKIgjyqxHqmfd6Pb3Bs5Bvakg0knXCTC4fbUXGnC9Q6u7gdDwgXohUNP6/DD+s8U7bivvvVv0dg==
       }
     cpu: [x64]
     os: [linux]
 
-  "@anthropic-ai/claude-agent-sdk-win32-arm64@0.3.191":
+  "@anthropic-ai/claude-agent-sdk-win32-arm64@0.3.201":
     resolution:
       {
-        integrity: sha512-J8aTOi7n6AM7tHFlKt6hlJ4rue0TbY2glqcI2r6K3iK7Fmzvt9zfg00+l8fWKOais4K+8jqJCC4WSCUlz6+tKQ==
+        integrity: sha512-UsoytRJ/037uHpb3ATrIoe+AgwTf+PwKuFLGjddHAV/11wERJs0hlrnSmcnp43kf0PFxoSNinngme96YYASmQg==
       }
     cpu: [arm64]
     os: [win32]
 
-  "@anthropic-ai/claude-agent-sdk-win32-x64@0.3.191":
+  "@anthropic-ai/claude-agent-sdk-win32-x64@0.3.201":
     resolution:
       {
-        integrity: sha512-1rYlPuM9PS37IPCE/sAG7A7oCrWnIb0J7EY6eQBdImdXHEjwBngZ3E8KbtEM79fUTA3C810LqrnFpjOmNExLMA==
+        integrity: sha512-PhalN/0cWcqDfbx7iwoLNR2gurjTiqhBk1G6K+NRScxEcQjWuu5xKXCcdbX8ePVpT+nbEMmFEFpn2y+8V8hIdA==
       }
     cpu: [x64]
     os: [win32]
 
-  "@anthropic-ai/claude-agent-sdk@0.3.191":
+  "@anthropic-ai/claude-agent-sdk@0.3.201":
     resolution:
       {
-        integrity: sha512-DM9oYbt+WAb/CiD8l/CO6akqPKfyZ4sL1e+lP2O2eS9IR0f58sf90xWeji7V+/zfnIp+jyH3hJ3V6r7odCdB8g==
+        integrity: sha512-InT1XLmf2QpldWdtznKDWEoGJT4p+sXh24yxbeBQ++lMJCzMrI0W27MEmmmDWx0otpa+ubdHCF5YQ6oiNt7cmg==
       }
     engines: { node: ">=18.0.0" }
     peerDependencies:
@@ -11006,44 +11006,44 @@ snapshots:
 
   "@adobe/css-tools@4.5.0": {}
 
-  "@anthropic-ai/claude-agent-sdk-darwin-arm64@0.3.191":
+  "@anthropic-ai/claude-agent-sdk-darwin-arm64@0.3.201":
     optional: true
 
-  "@anthropic-ai/claude-agent-sdk-darwin-x64@0.3.191":
+  "@anthropic-ai/claude-agent-sdk-darwin-x64@0.3.201":
     optional: true
 
-  "@anthropic-ai/claude-agent-sdk-linux-arm64-musl@0.3.191":
+  "@anthropic-ai/claude-agent-sdk-linux-arm64-musl@0.3.201":
     optional: true
 
-  "@anthropic-ai/claude-agent-sdk-linux-arm64@0.3.191":
+  "@anthropic-ai/claude-agent-sdk-linux-arm64@0.3.201":
     optional: true
 
-  "@anthropic-ai/claude-agent-sdk-linux-x64-musl@0.3.191":
+  "@anthropic-ai/claude-agent-sdk-linux-x64-musl@0.3.201":
     optional: true
 
-  "@anthropic-ai/claude-agent-sdk-linux-x64@0.3.191":
+  "@anthropic-ai/claude-agent-sdk-linux-x64@0.3.201":
     optional: true
 
-  "@anthropic-ai/claude-agent-sdk-win32-arm64@0.3.191":
+  "@anthropic-ai/claude-agent-sdk-win32-arm64@0.3.201":
     optional: true
 
-  "@anthropic-ai/claude-agent-sdk-win32-x64@0.3.191":
+  "@anthropic-ai/claude-agent-sdk-win32-x64@0.3.201":
     optional: true
 
-  "@anthropic-ai/claude-agent-sdk@0.3.191(@anthropic-ai/sdk@0.109.0(zod@4.4.3))(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))(zod@4.4.3)":
+  "@anthropic-ai/claude-agent-sdk@0.3.201(@anthropic-ai/sdk@0.109.0(zod@4.4.3))(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))(zod@4.4.3)":
     dependencies:
       "@anthropic-ai/sdk": 0.109.0(zod@4.4.3)
       "@modelcontextprotocol/sdk": 1.29.0(zod@4.4.3)
       zod: 4.4.3
     optionalDependencies:
-      "@anthropic-ai/claude-agent-sdk-darwin-arm64": 0.3.191
-      "@anthropic-ai/claude-agent-sdk-darwin-x64": 0.3.191
-      "@anthropic-ai/claude-agent-sdk-linux-arm64": 0.3.191
-      "@anthropic-ai/claude-agent-sdk-linux-arm64-musl": 0.3.191
-      "@anthropic-ai/claude-agent-sdk-linux-x64": 0.3.191
-      "@anthropic-ai/claude-agent-sdk-linux-x64-musl": 0.3.191
-      "@anthropic-ai/claude-agent-sdk-win32-arm64": 0.3.191
-      "@anthropic-ai/claude-agent-sdk-win32-x64": 0.3.191
+      "@anthropic-ai/claude-agent-sdk-darwin-arm64": 0.3.201
+      "@anthropic-ai/claude-agent-sdk-darwin-x64": 0.3.201
+      "@anthropic-ai/claude-agent-sdk-linux-arm64": 0.3.201
+      "@anthropic-ai/claude-agent-sdk-linux-arm64-musl": 0.3.201
+      "@anthropic-ai/claude-agent-sdk-linux-x64": 0.3.201
+      "@anthropic-ai/claude-agent-sdk-linux-x64-musl": 0.3.201
+      "@anthropic-ai/claude-agent-sdk-win32-arm64": 0.3.201
+      "@anthropic-ai/claude-agent-sdk-win32-x64": 0.3.201
 
   "@anthropic-ai/sdk@0.109.0(zod@4.4.3)":
     dependencies:


### PR DESCRIPTION
## Summary
- Backport commit 4f35267da31c942736d0fbaf522ec775367556bd onto release/0704
- Preserve the nested agent race fixes and related Claude/AgentGUI follow-up fixes for the release branch
- Adjust the desktop projection narrowing so the backport typechecks on release/0704

## Validation
- PATH="/Users/vector/.nvm/versions/node/v24.18.0/bin:/Users/vector/.local/bin:/opt/homebrew/bin:/opt/homebrew/sbin:/usr/local/bin:/System/Cryptexes/App/usr/bin:/usr/bin:/bin:/usr/sbin:/sbin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/local/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/appleinternal/bin:/opt/pmk/env/global/bin:/usr/local/go/bin:/Users/vector/.codex/tmp/arg0/codex-arg0aM11mW:/Users/vector/.cache/codex-runtimes/codex-primary-runtime/dependencies/bin:/Users/vector/go/bin:/Users/vector/.local/bin:/opt/homebrew/opt/libpq/bin:/Users/vector/Library/pnpm:/Users/vector/.nvm/versions/node/v22.21.1/bin:/Users/vector/.cargo/bin:/Applications/Codex.app/Contents/Resources" pnpm --filter @tutti-os/claude-sdk-sidecar test
- go test ./packages/agent/daemon/runtime
- PATH="/Users/vector/.nvm/versions/node/v24.18.0/bin:/Users/vector/.local/bin:/opt/homebrew/bin:/opt/homebrew/sbin:/usr/local/bin:/System/Cryptexes/App/usr/bin:/usr/bin:/bin:/usr/sbin:/sbin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/local/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/appleinternal/bin:/opt/pmk/env/global/bin:/usr/local/go/bin:/Users/vector/.codex/tmp/arg0/codex-arg0aM11mW:/Users/vector/.cache/codex-runtimes/codex-primary-runtime/dependencies/bin:/Users/vector/go/bin:/Users/vector/.local/bin:/opt/homebrew/opt/libpq/bin:/Users/vector/Library/pnpm:/Users/vector/.nvm/versions/node/v22.21.1/bin:/Users/vector/.cargo/bin:/Applications/Codex.app/Contents/Resources" pnpm check:agent-activity-runtime-boundaries
- PATH="/Users/vector/.nvm/versions/node/v24.18.0/bin:/Users/vector/.local/bin:/opt/homebrew/bin:/opt/homebrew/sbin:/usr/local/bin:/System/Cryptexes/App/usr/bin:/usr/bin:/bin:/usr/sbin:/sbin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/local/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/appleinternal/bin:/opt/pmk/env/global/bin:/usr/local/go/bin:/Users/vector/.codex/tmp/arg0/codex-arg0aM11mW:/Users/vector/.cache/codex-runtimes/codex-primary-runtime/dependencies/bin:/Users/vector/go/bin:/Users/vector/.local/bin:/opt/homebrew/opt/libpq/bin:/Users/vector/Library/pnpm:/Users/vector/.nvm/versions/node/v22.21.1/bin:/Users/vector/.cargo/bin:/Applications/Codex.app/Contents/Resources" node --import ./test/register-asset-stub.mjs --test --experimental-strip-types ./src/renderer/src/features/workspace-agent/services/internal/workspaceAgentActivityService.test.ts (from apps/desktop)
- PATH="/Users/vector/.nvm/versions/node/v24.18.0/bin:/Users/vector/.local/bin:/opt/homebrew/bin:/opt/homebrew/sbin:/usr/local/bin:/System/Cryptexes/App/usr/bin:/usr/bin:/bin:/usr/sbin:/sbin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/local/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/appleinternal/bin:/opt/pmk/env/global/bin:/usr/local/go/bin:/Users/vector/.codex/tmp/arg0/codex-arg0aM11mW:/Users/vector/.cache/codex-runtimes/codex-primary-runtime/dependencies/bin:/Users/vector/go/bin:/Users/vector/.local/bin:/opt/homebrew/opt/libpq/bin:/Users/vector/Library/pnpm:/Users/vector/.nvm/versions/node/v22.21.1/bin:/Users/vector/.cargo/bin:/Applications/Codex.app/Contents/Resources" pnpm --filter @tutti-os/desktop typecheck
- PATH="/Users/vector/.nvm/versions/node/v24.18.0/bin:/Users/vector/.local/bin:/opt/homebrew/bin:/opt/homebrew/sbin:/usr/local/bin:/System/Cryptexes/App/usr/bin:/usr/bin:/bin:/usr/sbin:/sbin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/local/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/appleinternal/bin:/opt/pmk/env/global/bin:/usr/local/go/bin:/Users/vector/.codex/tmp/arg0/codex-arg0aM11mW:/Users/vector/.cache/codex-runtimes/codex-primary-runtime/dependencies/bin:/Users/vector/go/bin:/Users/vector/.local/bin:/opt/homebrew/opt/libpq/bin:/Users/vector/Library/pnpm:/Users/vector/.nvm/versions/node/v22.21.1/bin:/Users/vector/.cargo/bin:/Applications/Codex.app/Contents/Resources" pnpm check:changed -- --failed-only --tail-lines 40

Note: the first full check:changed attempt found the release-branch TypeScript narrowing issue fixed in this PR; its Go lane also hit a transient TestLocalProcessTransportFindsKnownNodeGlobalBin timeout, but the direct runtime Go test and failed-only rerun passed.