### PR TITLE
fix(agent-gui, issue-manager): message-center/session-window projection mismatches

### DIFF
--- a/packages/agent/gui/agent-message-center/workspaceAgentMessageCenterDigest.ts
+++ b/packages/agent/gui/agent-message-center/workspaceAgentMessageCenterDigest.ts
@@ -108,7 +108,10 @@ export function buildWorkspaceAgentMessageCenterDigest(
 export function resolveWorkspaceAgentMessageCenterDigestAgentMessageSummary(
   message: AgentActivityMessage
 ): string {
-  if (!isAgentMessageRole(message.role)) {
+  if (
+    !isAgentMessageRole(message.role) ||
+    isReasoningMessageKind(message.kind)
+  ) {
     return "";
   }
   return meaningfulMessageSummary(message);
@@ -145,6 +148,15 @@ function promptTimeUnixMs(
 function isAgentMessageRole(role: string): boolean {
   const normalized = role.trim().toLowerCase();
   return normalized === "assistant" || normalized === "agent";
+}
+
+/**
+ * Mirrors the same-named guard in workspaceAgentMessageCenterModel.ts: a
+ * reasoning/thinking message carries an assistant-like `role` but
+ * `kind: "reasoning"` and must never be summarized as a normal agent reply.
+ */
+function isReasoningMessageKind(kind: string): boolean {
+  return kind.trim().toLowerCase() === "reasoning";
 }
 
 type MessageSummarySource =

--- a/packages/agent/gui/agent-message-center/workspaceAgentMessageCenterModel.spec.ts
+++ b/packages/agent/gui/agent-message-center/workspaceAgentMessageCenterModel.spec.ts
@@ -256,6 +256,41 @@ describe("buildWorkspaceAgentMessageCenterModel", () => {
     });
   });
 
+  it("skips reasoning/thinking messages when picking the latest agent message summary", () => {
+    const model = buildWorkspaceAgentMessageCenterModel(
+      snapshot({
+        messages: [
+          message({
+            agentSessionId: "session-1",
+            messageId: "reply-1",
+            role: "assistant",
+            kind: "text",
+            payload: { text: "你好！系统正常，我已准备好为你提供帮助。" },
+            occurredAtUnixMs: 10
+          }),
+          message({
+            agentSessionId: "session-1",
+            messageId: "reasoning-1",
+            role: "assistant",
+            kind: "reasoning",
+            payload: {
+              text: '<reasoning>用户发送了</reasoning><reasoning>"test", 这是一个简单的测试消息。</reasoning>'
+            },
+            occurredAtUnixMs: 20
+          })
+        ],
+        sessions: [session({ agentSessionId: "session-1" })]
+      })
+    );
+
+    expect(model.items[0]?.lastAgentMessageSummary).toBe(
+      "你好！系统正常，我已准备好为你提供帮助。"
+    );
+    expect(model.items[0]?.digest.primary.summary).toBe(
+      "你好！系统正常，我已准备好为你提供帮助。"
+    );
+  });
+
   it("prefers displayPrompt for message-center model summaries", () => {
     const model = buildWorkspaceAgentMessageCenterModel(
       snapshot({

--- a/packages/agent/gui/agent-message-center/workspaceAgentMessageCenterModel.ts
+++ b/packages/agent/gui/agent-message-center/workspaceAgentMessageCenterModel.ts
@@ -344,7 +344,10 @@ function analyzeMessageCenterSessionMessages(
         }
       }
     }
-    if (isAgentMessageRole(message.role)) {
+    if (
+      isAgentMessageRole(message.role) &&
+      !isReasoningMessageKind(message.kind)
+    ) {
       const summary = messageSummary(message);
       if (summary) {
         const occurredAtUnixMs = messageTimeUnixMs(message);
@@ -722,6 +725,19 @@ function compareMessageCenterItems(
 function isAgentMessageRole(role: string): boolean {
   const normalized = role.trim().toLowerCase();
   return normalized === "assistant" || normalized === "agent";
+}
+
+/**
+ * Reasoning/thinking messages are stored with an assistant-like `role` but a
+ * distinct `kind: "reasoning"` (see workspaceAgentMessageProjection.ts, which
+ * routes `kind === "reasoning"` to a separate "assistant_thinking" timeline
+ * item instead of a normal reply). The message center must not treat these as
+ * a normal agent reply when picking the latest message to preview, otherwise
+ * raw thinking content (occasionally still carrying literal tag markup) can
+ * surface verbatim in the message-center list instead of the actual reply.
+ */
+function isReasoningMessageKind(kind: string): boolean {
+  return kind.trim().toLowerCase() === "reasoning";
 }
 
 function isUserMessageRole(role: string): boolean {

--- a/packages/workspace/issue-manager/src/services/internal/controllerActions.executionDirectory.test.ts
+++ b/packages/workspace/issue-manager/src/services/internal/controllerActions.executionDirectory.test.ts
@@ -1,7 +1,42 @@
 import assert from "node:assert/strict";
 import test from "node:test";
-import type { WorkspaceUserProjectApi } from "@tutti-os/workspace-user-project/contracts";
-import { createControllerActionsHarness } from "./controllerActionTestHarness.ts";
+import type {
+  WorkspaceUserProjectApi,
+  WorkspaceUserProjectService,
+  WorkspaceUserProjectValtioStore
+} from "@tutti-os/workspace-user-project/contracts";
+import type {
+  IssueManagerAgentBreakdownRequest,
+  IssueManagerAgentRunRequest
+} from "../../contracts/index.ts";
+import {
+  createControllerActionsHarness,
+  createIssueSummary,
+  createTaskSummary
+} from "./controllerActionTestHarness.ts";
+
+function stubDefaultProjectService(
+  defaultPath: string
+): WorkspaceUserProjectService {
+  return {
+    async getDefaultSelection() {
+      return { path: defaultPath };
+    },
+    prepareSelection() {
+      throw new Error("not used in this test");
+    },
+    refresh() {
+      throw new Error("not used in this test");
+    },
+    store: {
+      error: null,
+      initialized: true,
+      isLoading: false,
+      projects: [],
+      revision: 0
+    } as unknown as WorkspaceUserProjectValtioStore
+  };
+}
 
 test("controller actions useExecutionDirectory updates state and remembers the project", async () => {
   const usedPaths: string[] = [];
@@ -58,4 +93,138 @@ test("controller actions support missing execution directory picker methods", as
     harness.nodeState.current.selectedExecutionDirectory,
     "/workspace/tutti"
   );
+});
+
+test("controller actions fall back to the remembered default project when running a task without an explicit execution directory", async () => {
+  const runnerCalls: IssueManagerAgentRunRequest[] = [];
+  const issue = createIssueSummary({ issueId: "issue-1", title: "Issue" });
+  const task = createTaskSummary({
+    issueId: "issue-1",
+    taskId: "task-1",
+    title: "Task"
+  });
+  const harness = createControllerActionsHarness({
+    agentRunner: {
+      async runTask(input) {
+        runnerCalls.push(input);
+        return { status: "opened" };
+      }
+    },
+    executionDirectoryPicker: {
+      service: stubDefaultProjectService("/workspace/test-tutti")
+    },
+    issueDetail: {
+      contextRefs: [],
+      issue,
+      latestOutputs: [],
+      recentRuns: [],
+      tasks: [task]
+    },
+    nodeState: {
+      issueSearchQuery: "",
+      issueStatusFilter: "all",
+      selectedAgentProvider: "codex",
+      selectedIssueId: "issue-1",
+      selectedTaskId: "task-1"
+    },
+    taskDetail: {
+      contextRefs: [],
+      latestOutputs: [],
+      recentRuns: [],
+      task
+    }
+  });
+
+  await harness.actions.runTask();
+
+  assert.equal(runnerCalls.length, 1);
+  assert.equal(runnerCalls[0]?.executionDirectory, "/workspace/test-tutti");
+  // The user never touched the picker, so it should remain unset in state -
+  // only the outgoing run request gets the resolved default.
+  assert.equal(
+    harness.nodeState.current.selectedExecutionDirectory ?? null,
+    null
+  );
+});
+
+test("controller actions do not override an explicitly selected execution directory when running a task", async () => {
+  const runnerCalls: IssueManagerAgentRunRequest[] = [];
+  const issue = createIssueSummary({ issueId: "issue-1", title: "Issue" });
+  const task = createTaskSummary({
+    issueId: "issue-1",
+    taskId: "task-1",
+    title: "Task"
+  });
+  const harness = createControllerActionsHarness({
+    agentRunner: {
+      async runTask(input) {
+        runnerCalls.push(input);
+        return { status: "opened" };
+      }
+    },
+    executionDirectoryPicker: {
+      service: stubDefaultProjectService("/workspace/should-not-be-used")
+    },
+    issueDetail: {
+      contextRefs: [],
+      issue,
+      latestOutputs: [],
+      recentRuns: [],
+      tasks: [task]
+    },
+    nodeState: {
+      issueSearchQuery: "",
+      issueStatusFilter: "all",
+      selectedAgentProvider: "codex",
+      selectedExecutionDirectory: "/workspace/picked-by-user",
+      selectedIssueId: "issue-1",
+      selectedTaskId: "task-1"
+    },
+    taskDetail: {
+      contextRefs: [],
+      latestOutputs: [],
+      recentRuns: [],
+      task
+    }
+  });
+
+  await harness.actions.runTask();
+
+  assert.equal(runnerCalls.length, 1);
+  assert.equal(runnerCalls[0]?.executionDirectory, "/workspace/picked-by-user");
+});
+
+test("controller actions fall back to the remembered default project when starting a task breakdown without an explicit execution directory", async () => {
+  const breakdownCalls: IssueManagerAgentBreakdownRequest[] = [];
+  const issue = createIssueSummary({ issueId: "issue-1", title: "Issue" });
+  const harness = createControllerActionsHarness({
+    agentBreakdownLauncher: {
+      async startBreakdown(input) {
+        breakdownCalls.push(input);
+        return { status: "opened" };
+      }
+    },
+    executionDirectoryPicker: {
+      service: stubDefaultProjectService("/workspace/test-tutti")
+    },
+    issueDetail: {
+      contextRefs: [],
+      issue,
+      latestOutputs: [],
+      recentRuns: [],
+      tasks: []
+    },
+    nodeState: {
+      issueSearchQuery: "",
+      issueStatusFilter: "all",
+      selectedAgentProvider: "codex",
+      selectedIssueId: "issue-1",
+      selectedTaskId: null
+    }
+  });
+
+  await harness.actions.startTaskBreakdown();
+
+  assert.equal(breakdownCalls.length, 1);
+  assert.equal(breakdownCalls[0]?.executionDirectory, "/workspace/test-tutti");
 });

--- a/packages/workspace/issue-manager/src/services/internal/controllerActions.ts
+++ b/packages/workspace/issue-manager/src/services/internal/controllerActions.ts
@@ -193,6 +193,35 @@ function resolveIssueManagerMovedTaskOrder(input: {
   ];
 }
 
+/**
+ * Resolves the execution directory (project path) to run a task/breakdown in.
+ *
+ * The user's explicit per-issue selection (`selectedExecutionDirectory`)
+ * always wins. Otherwise this falls back to the same remembered "default
+ * project" that ad-hoc new agent-GUI sessions use, so a task run/breakdown
+ * launched without the user ever touching the execution-directory picker
+ * still gets associated with a real project instead of silently landing in
+ * the agent runtime's internal session-storage directory (which then shows
+ * up as the session's project path in both the session window and the
+ * message center).
+ */
+async function resolveIssueManagerExecutionDirectory(input: {
+  feature: IssueManagerFeature;
+  selectedExecutionDirectory: string | null | undefined;
+}): Promise<string | null> {
+  const selected = input.selectedExecutionDirectory?.trim();
+  if (selected) {
+    return selected;
+  }
+  try {
+    const defaultSelection =
+      await input.feature.executionDirectoryPicker?.service?.getDefaultSelection?.();
+    return defaultSelection?.path?.trim() || null;
+  } catch {
+    return null;
+  }
+}
+
 export function createIssueManagerControllerActions(
   input: CreateIssueManagerControllerActionsInput
 ) {
@@ -672,12 +701,14 @@ export function createIssueManagerControllerActions(
 
       setIsRunningTask(true);
       try {
+        const executionDirectory = await resolveIssueManagerExecutionDirectory({
+          feature,
+          selectedExecutionDirectory: nodeState.selectedExecutionDirectory
+        });
         trackIssueManagerAnalytics(feature, {
           name: "issue_manager.task_run_initiated",
           params: {
-            hasExecutionDirectory: Boolean(
-              nodeState.selectedExecutionDirectory?.trim()
-            ),
+            hasExecutionDirectory: Boolean(executionDirectory),
             issueId: currentIssueDetail.issue.issueId,
             provider: runPlan.provider,
             taskId: currentTaskDetail?.task.taskId ?? null
@@ -687,7 +718,7 @@ export function createIssueManagerControllerActions(
           feature,
           issue: currentIssueDetail.issue,
           provider: runPlan.provider,
-          executionDirectory: nodeState.selectedExecutionDirectory,
+          executionDirectory,
           task: currentTaskDetail?.task,
           workspaceId
         });
@@ -739,6 +770,10 @@ export function createIssueManagerControllerActions(
 
       setIsRunningTask(true);
       try {
+        const executionDirectory = await resolveIssueManagerExecutionDirectory({
+          feature,
+          selectedExecutionDirectory: nodeState.selectedExecutionDirectory
+        });
         trackIssueManagerAnalytics(feature, {
           name: "issue_manager.issue_breakdown_initiated",
           params: {
@@ -747,11 +782,7 @@ export function createIssueManagerControllerActions(
           }
         });
         const result = await breakdownLauncher.startBreakdown({
-          ...(nodeState.selectedExecutionDirectory?.trim()
-            ? {
-                executionDirectory: nodeState.selectedExecutionDirectory.trim()
-              }
-            : {}),
+          ...(executionDirectory ? { executionDirectory } : {}),
           issueDetail: currentIssueDetail,
           provider: breakdownPlan.provider,
           workspaceId


### PR DESCRIPTION
## Summary

Fixes two P1 bugs from the Feishu message-center/status-panel/notification projection cluster (master ticket BjBUG0). See per-bug detail below. CP5GxX (approval-popup timing) was investigated but intentionally NOT changed here — see the last section.

## HVZM4c — 消息中心的会话详情显示跟会话窗口的不太一致

**Problem**: The message-center list preview for a session sometimes showed raw, unparsed reasoning/thinking content (including literal `<reasoning>...</reasoning>` markup) instead of the agent's actual reply, while the session window rendered the same turn correctly (reasoning styled separately from the reply).

**Root cause**: `analyzeMessageCenterSessionMessages` (`packages/agent/gui/agent-message-center/workspaceAgentMessageCenterModel.ts`) picked the "latest agent message" for the preview by `role` only (`assistant`/`agent`). Reasoning/thinking messages carry that same assistant-like role but a distinct `kind: "reasoning"` — the timeline projection (`workspaceAgentMessageProjection.ts`) already keys off `kind` to route them to a separate `assistant_thinking` item, never mixing them into a normal reply. The message-center picker never checked `kind`, so when a reasoning message was the most recent assistant-role message, its raw content surfaced as the preview.

**Fix**: Exclude `kind === "reasoning"` when selecting `latestAgentMessage` / `latestDigestAgentMessage`, mirroring the check the projection layer already uses. Same guard added defensively inside `resolveWorkspaceAgentMessageCenterDigestAgentMessageSummary` in `workspaceAgentMessageCenterDigest.ts`.

**Tests**: New regression test in `workspaceAgentMessageCenterModel.spec.ts` reproducing the screenshot's exact scenario (reasoning message with literal tag markup arriving after a clean reply) — asserts the preview and digest summary both surface the real reply, not the reasoning content. `packages/agent/gui` message-center suite: 106/106 passing. Typecheck clean.

## t7g1wc — 让claude code拆解任务，会话项目和消息中心的路径显示均和任务里的项目对不上

(Master ticket for this cluster; merges recvmLPiOwpuHL "无法复现" and recvmvDoHVZM4c/HVZM4c — HVZM4c turned out to be a distinct root cause, fixed separately above.)

**Problem**: After running/decomposing a task via the issue manager, the resulting agent session's project path — shown identically in both the session window and the message center — was the agent runtime's own internal session-storage directory (`~/.tutti/agent/sessions/<date>-<seq>`) instead of the task's actual project.

**Root cause**: `runTask` and `startTaskBreakdown` (`packages/workspace/issue-manager/src/services/internal/controllerActions.ts`) only ever passed `nodeState.selectedExecutionDirectory` — populated exclusively by the user manually picking a directory via the execution-directory trigger — as the new session's project path. When a run/breakdown happened without that manual pick, `executionDirectory` came through empty, the agent-GUI draft launched with no project, and the server (`LocalSessionDirectoryAllocator`, `services/tuttid/service/agent/session_directory.go`) fell back to its internal session-storage path as `cwd`. Both the message center and the session window read that same `session.cwd`, so one bad/missing write showed up identically in both places — matching the ticket's exact phrasing.

**Fix**: Added `resolveIssueManagerExecutionDirectory`, which prefers the user's explicit selection and otherwise falls back to the same remembered "default project" (`getDefaultSelection`) that ad-hoc new agent-GUI sessions already use — so a task run/breakdown always gets a real project association unless the user is intentionally working project-less. Used in both `runTask` and `startTaskBreakdown`.

**Tests**: New regression tests in `controllerActions.executionDirectory.test.ts`: falls back to the default project for both `runTask`/`startTaskBreakdown` when nothing was explicitly picked, and does not override an explicit user pick. Full `packages/workspace/issue-manager` suite: 215/215 passing. Typecheck clean.

## CP5GxX — 授权请求通知弹出时机不合理 (investigated, not changed)

**Finding**: The ticket's literal ask — gate the popup on whether the Agent GUI window is open/focused — is **already implemented** for the OS-level system notification: `compositeNotificationService.ts`'s `notify()` only raises it when `!isForeground()` (`document.hasFocus()`), wired per-window in `createWorkspaceWindowContainer.ts`. This path is not a bug.

There is a narrower, real gap: the **in-app toast** (`WorkspaceChrome.tsx`, the `useEffect` building `WorkspaceAgentDecisionToast`) has no per-conversation focus check — it fires whenever the window is focused, even if the user is already looking at the exact conversation where the same approval renders inline. The message center itself already receives/records every waiting approval independently of any popup, so "only handle in message center" requires no new plumbing on that side.

Implementing the toast-side fix would require adding a new accessor to `IWorkspaceWorkbenchHostService` and threading the live workbench host handle (currently owned by a sibling component, `WorkspaceWorkbench.tsx`, with no path into `WorkspaceChrome.tsx` today) across components — real, non-trivial plumbing, not a two-line change. It also raises a genuine product question (should some lighter reminder still surface for multi-window cases, or is fully skipping the toast when the exact node is focused the intended behavior?) that risks an approval silently stalling unseen if decided wrong. Given the P1/business-escalation context, this is left undone pending product input rather than shipped as an unreviewed guess. No PR changes included for this ticket.

## Test plan
- [x] `packages/agent/gui` message-center suite (106/106) + typecheck
- [x] `packages/workspace/issue-manager` full suite (215/215) + typecheck
- [x] Pre-push `check:full` was interrupted by the known pre-existing `TestServiceCreateResolvesProviderFromAgentTarget` hang in `services/tuttid/service/agent`; this diff touches zero Go files, so pushed with `--no-verify` per the confirmed pre-existing-flake exception.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>