### PR TITLE
fix(browser/agent): recover closed browser session; drop untracked claude sdk turn terminal events

### DIFF
--- a/packages/agent/daemon/runtime/claude_sdk_adapter.go
+++ b/packages/agent/daemon/runtime/claude_sdk_adapter.go
@@ -668,6 +668,19 @@ func (a *ClaudeCodeSDKAdapter) dispatchClaudeSDKEvent(agentSessionID string, ada
 		a.completeClaudeSDKWaiterEvent(adapterSession, waiter, turnID, next, terminal, err)
 		return
 	}
+	if terminal {
+		// No daemon-registered Exec()/ExecAsync() waiter is tracking this
+		// turnID's outcome: either its terminal event was already delivered
+		// once (the waiter already completed and was unregistered) or this
+		// turn never became the tracked active turn in the first place (for
+		// example an internal/queued Claude SDK turn — see turnQueue /
+		// settleQueuedTurn in the sidecar — that got settled without ever
+		// being submitted through Exec). Publishing it here would surface a
+		// stray, possibly contradictory outcome notification for the session:
+		// a phantom completed/failed toast landing alongside the real turn's
+		// own outcome toast for the same agent session. Drop it instead.
+		return
+	}
 	if err != nil {
 		next = append(next, newSessionActivityEvent(session, EventSessionFailed, SessionStatusFailed, map[string]any{
 			"error": err.Error(),

--- a/packages/agent/daemon/runtime/claude_sdk_adapter_test.go
+++ b/packages/agent/daemon/runtime/claude_sdk_adapter_test.go
@@ -972,6 +972,89 @@ func TestClaudeCodeSDKAdapterReaderKeepsDrainingAfterTurnTerminal(t *testing.T) 
 	}
 }
 
+// TestClaudeCodeSDKAdapterDropsUntrackedTurnTerminalEvent reproduces the
+// Rkyo8B report: the same agent session shows both a completion and a
+// failure toast simultaneously. The sidecar can settle a turn (e.g. a
+// queued/steered turn discarded via its own turnQueue) that never went
+// through Exec()/ExecAsync() and therefore never had a waiter registered.
+// Forwarding that stray terminal event unconditionally used to publish a
+// second, contradictory outcome-carrying activity event for the session
+// alongside the real turn's own completion. The dispatcher must drop
+// terminal events for turns it never tracked instead of forwarding them.
+func TestClaudeCodeSDKAdapterDropsUntrackedTurnTerminalEvent(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	adapter := NewClaudeCodeSDKAdapter(nil)
+	session := standardTestSession(ProviderClaudeCode)
+	conn := newBlockingClaudeSDKConnection()
+	defer func() { _ = conn.Close() }()
+	adapter.storeSession(session.AgentSessionID, &claudeSDKAdapterSession{
+		conn:              conn,
+		reader:            &claudeSDKLineReader{conn: conn},
+		session:           session,
+		providerSessionID: "provider-session-1",
+		pendingRequests:   make(map[string]*pendingACPRequest),
+		pendingResponses:  make(map[string]chan claudeSDKSidecarEvent),
+		turns:             make(map[string]*claudeSDKTurnWaiter),
+		liveState:         newClaudeSDKLiveState(),
+	})
+	sessionEvents := make(chan []activityshared.Event, 4)
+	adapter.SetSessionEventSink(func(agentSessionID string, events []activityshared.Event) {
+		if agentSessionID == session.AgentSessionID {
+			sessionEvents <- events
+		}
+	})
+
+	done := make(chan error, 1)
+	go func() {
+		_, err := adapter.Exec(ctx, session, []PromptContentBlock{{Type: "text", Text: "open the site"}}, "open the site", "turn-real", nil, nil)
+		done <- err
+	}()
+	waitForClaudeSDKSentRequest(t, conn, "exec")
+	conn.pushEvent(claudeSDKSidecarEvent{
+		Type:    "turn_completed",
+		Payload: map[string]any{"turnId": "turn-real", "stopReason": "end_turn"},
+	})
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("Exec: %v", err)
+		}
+	case <-ctx.Done():
+		t.Fatal("timed out waiting for Exec completion")
+	}
+
+	// A different, never-Exec'd turn (e.g. discarded from the sidecar's own
+	// turnQueue) settles as failed. No waiter was ever registered for it, so
+	// this must be dropped rather than published as a stray outcome event.
+	conn.pushEvent(claudeSDKSidecarEvent{
+		Type:    "turn_failed",
+		Payload: map[string]any{"turnId": "turn-queued-orphan", "error": "browser tool call failed"},
+	})
+	// Follow it with a normal, trackable event on a fresh turn to prove the
+	// reader keeps draining and the orphan didn't wedge or crash dispatch.
+	conn.pushEvent(claudeSDKSidecarEvent{
+		Type:    "assistant_completed",
+		Payload: map[string]any{"turnId": "turn-real", "content": "done"},
+	})
+
+	select {
+	case events := <-sessionEvents:
+		if len(events) != 1 || events[0].Type != activityshared.EventMessageAppended {
+			t.Fatalf("events = %#v, want only the trailing assistant message (orphan turn_failed must be dropped)", events)
+		}
+	case <-ctx.Done():
+		t.Fatal("timed out waiting for post-orphan event")
+	}
+
+	select {
+	case unexpected := <-sessionEvents:
+		t.Fatalf("unexpected extra session events published for orphan turn: %#v", unexpected)
+	case <-time.After(50 * time.Millisecond):
+	}
+}
+
 func TestClaudeCodeSDKAdapterRoundTripUsesReaderDispatcherAfterExec(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()

--- a/services/tuttid/service/browser/browser_test.go
+++ b/services/tuttid/service/browser/browser_test.go
@@ -264,6 +264,40 @@ func TestCallToolRestartsAfterProcessExit(t *testing.T) {
 	}
 }
 
+// TestCallToolRecoversAfterUserClosesBrowserWindow reproduces the case where
+// the user manually closes the automated browser window: chrome-devtools-mcp
+// stays connected (no process exit, so isClosed() never trips) but has zero
+// open pages, and returns "The selected page has been closed..." for any
+// page-scoped tool call. CallTool must self-heal by opening a fresh page and
+// retrying, rather than surfacing that error forever.
+func TestCallToolRecoversAfterUserClosesBrowserWindow(t *testing.T) {
+	transport := &pageGoneOnceTransport{}
+	svc := newTestService(transport)
+	ctx := context.Background()
+
+	res, err := svc.CallTool(ctx, "ws-1", "", "navigate_page", map[string]any{"url": "https://example.org"})
+	if err != nil {
+		t.Fatalf("CallTool: %v", err)
+	}
+	if !strings.Contains(res.Text, "Successfully navigated") {
+		t.Fatalf("unexpected result text: %q", res.Text)
+	}
+	if transport.startCnt != 1 {
+		t.Fatalf("start count = %d, want 1 (self-heal must not restart the subprocess)", transport.startCnt)
+	}
+
+	sent := transport.conn.toolNames()
+	want := []string{"navigate_page", "new_page", "navigate_page"}
+	if len(sent) != len(want) {
+		t.Fatalf("tool calls = %#v, want %#v", sent, want)
+	}
+	for i, name := range want {
+		if sent[i] != name {
+			t.Fatalf("tool calls = %#v, want %#v", sent, want)
+		}
+	}
+}
+
 func waitUntilBrowserSessionClosed(t *testing.T, svc *Service, workspaceID string) {
 	t.Helper()
 	timeout := time.After(2 * time.Second)
@@ -410,6 +444,77 @@ func (c *slowToolConn) Send(data []byte) error {
 			"content": []map[string]any{{"type": "text", "text": "slow ok"}},
 		}})
 	}
+	return nil
+}
+
+// pageGoneOnceTransport starts a single conn whose first navigate_page call
+// fails with the "selected page has been closed" error chrome-devtools-mcp
+// returns after the user closes the browser window out of band; a subsequent
+// new_page call, and any navigate_page call after that, succeed.
+type pageGoneOnceTransport struct {
+	mu       sync.Mutex
+	startCnt int
+	conn     *pageGoneOnceConn
+}
+
+func (t *pageGoneOnceTransport) Start(_ context.Context, _ agentruntime.ProcessSpec) (agentruntime.ProcessConnection, error) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	t.startCnt++
+	t.conn = newPageGoneOnceConn()
+	return t.conn, nil
+}
+
+type pageGoneOnceConn struct {
+	*scriptedConn
+	mu             sync.Mutex
+	navigateCalls  int
+	toolNamesCalls []string
+}
+
+func newPageGoneOnceConn() *pageGoneOnceConn {
+	return &pageGoneOnceConn{scriptedConn: newScriptedConn()}
+}
+
+func (c *pageGoneOnceConn) toolNames() []string {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return append([]string(nil), c.toolNamesCalls...)
+}
+
+func (c *pageGoneOnceConn) Send(data []byte) error {
+	var msg map[string]any
+	if err := json.Unmarshal(data, &msg); err != nil {
+		return err
+	}
+	method, _ := msg["method"].(string)
+	id := msg["id"]
+	if method != "tools/call" {
+		return c.scriptedConn.Send(data)
+	}
+	params, _ := msg["params"].(map[string]any)
+	name, _ := params["name"].(string)
+	c.mu.Lock()
+	c.toolNamesCalls = append(c.toolNamesCalls, name)
+	c.mu.Unlock()
+
+	if name == "navigate_page" {
+		c.mu.Lock()
+		c.navigateCalls++
+		first := c.navigateCalls == 1
+		c.mu.Unlock()
+		if first {
+			c.push(map[string]any{"jsonrpc": "2.0", "id": id, "result": map[string]any{
+				"isError": true,
+				"content": []map[string]any{{"type": "text", "text": "Error: The selected page has been closed. Call list_pages to see open pages."}},
+			}})
+			return nil
+		}
+	}
+	c.push(map[string]any{"jsonrpc": "2.0", "id": id, "result": map[string]any{
+		"isError": false,
+		"content": []map[string]any{{"type": "text", "text": "Successfully navigated to https://example.org"}},
+	}})
 	return nil
 }
 

--- a/services/tuttid/service/browser/service.go
+++ b/services/tuttid/service/browser/service.go
@@ -87,10 +87,36 @@ func (s *Service) CallTool(ctx context.Context, workspaceID, cwd, tool string, a
 		return ToolResult{}, err
 	}
 	result, err := session.callTool(ctx, tool, args)
+	if err != nil && tool != "new_page" && isBrowserPageGoneError(err) {
+		// The browser process is still alive and connected (so the process-exit
+		// recovery below never triggers), but it has zero open pages/tabs — most
+		// commonly because the user closed the automated browser window
+		// themselves rather than through Tutti. chrome-devtools-mcp does not
+		// auto-create a page in that state, so every page-scoped call would
+		// otherwise fail forever with the same error. Open a fresh page to
+		// restore a live session, then retry the original call once.
+		if _, healErr := session.callTool(ctx, "new_page", map[string]any{"url": "about:blank"}); healErr == nil {
+			result, err = session.callTool(ctx, tool, args)
+		}
+	}
 	if err != nil && session.client != nil && session.client.isClosed() {
 		s.Shutdown(workspaceID)
 	}
 	return result, err
+}
+
+// isBrowserPageGoneError reports whether err is chrome-devtools-mcp's error for
+// a page-scoped tool call made after the selected page (or all pages) closed
+// out from under the browser, e.g. because the user manually closed the
+// automated browser window. See McpContext#getSelectedMcpPage in the vendored
+// chrome-devtools-mcp package.
+func isBrowserPageGoneError(err error) bool {
+	if err == nil {
+		return false
+	}
+	msg := strings.ToLower(err.Error())
+	return strings.Contains(msg, "the selected page has been closed") ||
+		strings.Contains(msg, "no page selected")
 }
 
 func (s *Service) getOrCreate(workspaceID, connectionMode string) *browserSession {


### PR DESCRIPTION
## Summary

Two fixes from the Feishu 客户反馈 bug tracker, master cluster e9JXXc (浏览器/Browser Use/Computer Use/Playwright 任务生命周期).

### 2U5l4K — browser task fails forever after the user manually closes the browser window

**Problem:** A browser-opening task succeeds once; the user then manually closes the automated Chrome window themselves (not through Tutti). Every subsequent browser action in that session then fails, instead of Tutti detecting the closure and recovering.

**Root cause:** `services/tuttid/service/browser/session.go` / `service.go` only detect a *dead process* (`mcpClient.isClosed()`) and restart the subprocess in that case. When the user closes just the browser window, the vendored `chrome-devtools-mcp` process stays alive and connected (Puppeteer's `browser.connected` stays `true`), but has zero open pages. It does not auto-create a new page, so every page-scoped tool call (e.g. `navigate_page`) fails forever with `"The selected page has been closed. Call list_pages to see open pages."` — verified live against the real vendored `chrome-devtools-mcp@1.2.0` binary by closing the last page via a raw CDP `Target.closeTarget` call and observing the same session repeatedly fail.

**Fix:** `services/tuttid/service/browser/service.go` `CallTool` now recognizes this specific error, opens a fresh page (`new_page` with `about:blank`), and retries the original call once — verified end-to-end against the real binary that this heals the session (`navigate_page` succeeds on the retry).

### Rkyo8B — same session shows both a completion and a failure toast

**Problem:** For the same session, the top-right notification area shows both a completion toast and a failure toast simultaneously, when the session's browser/playwright call actually failed.

**Root cause:** `packages/agent/daemon/runtime/claude_sdk_adapter.go` `dispatchClaudeSDKEvent`'s fallback path (reached when no `Exec()`/`ExecAsync()` waiter is registered for the event's `turnId`) forwarded *any* terminal `turn_completed`/`turn_failed`/`turn_canceled` sidecar event straight to the session's event sink, with no check for whether that turn was ever tracked as the active turn. The Claude SDK sidecar has its own `turnQueue` / `settleQueuedTurn` mechanism that can independently settle a turn that never went through `Exec()` (e.g. a queued/steered turn discarded after a tool call, such as a browser/playwright call, fails). That produces a second, contradictory outcome-carrying `state_patch` for the same `agentSessionId`, which the desktop's `workspaceAgentOutcomeNotification.ts` controller fires as an independent toast (it does not dedupe by turn).

**Fix:** drop terminal turn events in the no-waiter fallback path instead of forwarding them — a terminal outcome is only meaningful when a live waiter is tracking that turn. Non-terminal late events (e.g. background-agent messages) are unaffected.

## Tests

- `services/tuttid/service/browser`: `go test ./service/browser/...` — all pass, including new `TestCallToolRecoversAfterUserClosesBrowserWindow`.
- `packages/agent/daemon/runtime`: `go test ./runtime/...` — all pass (33s), including new `TestClaudeCodeSDKAdapterDropsUntrackedTurnTerminalEvent`, which was verified to fail against the pre-fix code (red/green).
- Live-verified the 2U5l4K mechanism and fix against the real vendored `chrome-devtools-mcp@1.2.0` + Chrome (not just mocked Go tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved browser tool calls to recover automatically when a page is closed unexpectedly by opening a new page and retrying once.
  * Prevented extra session events from being emitted for terminal agent events that were never being tracked, reducing duplicate or misleading outcomes.
* **Tests**
  * Added coverage for browser recovery after a window is closed.
  * Added coverage for ignoring untracked terminal events while keeping normal dispatch behavior intact.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->