### PR TITLE
[codex] report workspace app user activity

### DIFF
--- a/services/tuttid/builtin-apps/tutti-onboarding/src/App.jsx
+++ b/services/tuttid/builtin-apps/tutti-onboarding/src/App.jsx
@@ -3,6 +3,7 @@ import { Trans, useTranslation } from "react-i18next";
 
 import i18n from "./i18n";
 import { useAppLocale } from "./i18n/app-context";
+import { reportUserActiveOnce } from "./tutti-activity.js";
 
 const agentTabs = [
   { label: "Claude Code", image: "/assets/bind-claude.webp", altKey: "t_s1a" },
@@ -412,6 +413,10 @@ export default function App() {
   const navRef = useRef(null);
   const navSentinelRef = useRef(null);
   const isNavStuckRef = useRef(false);
+
+  useEffect(() => {
+    reportUserActiveOnce();
+  }, []);
 
   useEffect(() => {
     const app = window.tuttiExternal?.app;

--- a/services/tuttid/builtin-apps/tutti-onboarding/src/tutti-activity.js
+++ b/services/tuttid/builtin-apps/tutti-onboarding/src/tutti-activity.js
@@ -1,0 +1,22 @@
+let reportedUserActive = false;
+
+function getTuttiActivityBridge() {
+  if (typeof window === "undefined") return null;
+  return window.tuttiExternal?.activity ?? null;
+}
+
+export function reportUserActive() {
+  const reportActive = getTuttiActivityBridge()?.reportActive;
+  if (typeof reportActive !== "function") return;
+  try {
+    void Promise.resolve(reportActive()).catch(() => {});
+  } catch {
+    // Activity reporting must not affect the app workflow.
+  }
+}
+
+export function reportUserActiveOnce() {
+  if (reportedUserActive) return;
+  reportedUserActive = true;
+  reportUserActive();
+}

--- a/services/tuttid/builtin-apps/tutti-onboarding/src/tutti-activity.test.js
+++ b/services/tuttid/builtin-apps/tutti-onboarding/src/tutti-activity.test.js
@@ -1,0 +1,30 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { reportUserActive, reportUserActiveOnce } from "./tutti-activity.js";
+
+describe("tutti activity bridge", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("reports user activity through the host bridge", async () => {
+    const reportActive = vi.fn(async () => undefined);
+    vi.stubGlobal("window", { tuttiExternal: { activity: { reportActive } } });
+
+    reportUserActive();
+    await Promise.resolve();
+
+    expect(reportActive).toHaveBeenCalledTimes(1);
+  });
+
+  it("reports only once when using the once helper", async () => {
+    const reportActive = vi.fn(async () => undefined);
+    vi.stubGlobal("window", { tuttiExternal: { activity: { reportActive } } });
+
+    reportUserActiveOnce();
+    reportUserActiveOnce();
+    await Promise.resolve();
+
+    expect(reportActive).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
## Summary
- Adds a small Tutti activity bridge helper for this app.
- Reports the fixed workspace app user-active behavior after the configured successful user action.
- Keeps reporting best-effort so bridge failures never block app workflows.

## Validation
- `pnpm exec vitest run src/tutti-activity.test.js` passed in the builtin onboarding package.\n- `pnpm --filter @tutti-os/builtin-tutti-onboarding typecheck` passed.\n- Pre-push `check:full` passed.
