### PR TITLE
fix(agent-gui): keep composer target and target tabs in sync with sessions

### DIFF
--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUINodeController.spec.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUINodeController.spec.tsx
@@ -460,11 +460,15 @@ describe("useAgentGUINodeController", () => {
         agentTargetId: "local:claude-code"
       });
     });
-    expect(result.current.viewModel.data.provider).toBe("codex");
+    // The home composer chip follows the selected tab (in-memory override)…
     expect(result.current.viewModel.selectedProviderTarget.provider).toBe(
-      "codex"
+      "claude-code"
     );
-    expect(result.current.viewModel.data.agentTargetId).toBe("local:codex");
+    expect(result.current.viewModel.data.provider).toBe("claude-code");
+    expect(result.current.viewModel.data.agentTargetId).toBe(
+      "local:claude-code"
+    );
+    // …without persisting the tab selection into the node target data.
     const currentData = agentGuiData(null, "codex", {
       agentTargetId: "local:codex",
       composerOverrides: { model: "gpt-5" }
@@ -572,7 +576,15 @@ describe("useAgentGUINodeController", () => {
         kind: "all"
       });
     });
-    expect(result.current.viewModel.data).toEqual(initialData);
+    // The home composer chip follows the selected tab target in memory…
+    expect(result.current.viewModel.selectedProviderTarget.targetId).toBe(
+      "shared-agent:codex-1"
+    );
+    expect(result.current.viewModel.data.provider).toBe("codex");
+    expect(result.current.viewModel.data.providerTargetId).toBe(
+      "shared-agent:codex-1"
+    );
+    // …without persisting the provider target ids into the node data.
     for (const [updater] of onDataChange.mock.calls) {
       const next = updater(initialData);
       expect(next).toMatchObject({
@@ -583,6 +595,234 @@ describe("useAgentGUINodeController", () => {
       expect(next.providerTargetId ?? null).toBeNull();
       expect(next.providerTargetRef ?? null).toBeNull();
     }
+  });
+
+  it("syncs the composer target to an activated conversation from another provider", async () => {
+    installAgentHostApi({
+      list: vi.fn(async () => ({
+        presences: [],
+        sessions: [
+          workspaceAgentSession("codex-session", {
+            provider: "codex",
+            agentTargetId: "local:codex",
+            title: "Codex session",
+            updatedAtUnixMs: 3
+          })
+        ]
+      })),
+      listSessionTimeline: vi.fn(async () => ({ timelineItems: [] })),
+      subscribeEvents: vi.fn(() => vi.fn())
+    });
+    const onDataChange = vi.fn();
+    const initialData = agentGuiData(null, "claude-code", {
+      agentTargetId: "local:claude-code"
+    });
+
+    const { result } = renderHook(() =>
+      useAgentGUINodeController({
+        workspaceId: "room-1",
+        currentUserId: "user-1",
+        workspacePath: "/workspace",
+        avoidGroupingEdits: false,
+        data: initialData,
+        conversationScope: "multi-provider",
+        providerTargets: [
+          {
+            targetId: "local:codex",
+            agentTargetId: "local:codex",
+            provider: "codex",
+            ref: { kind: "local-provider", provider: "codex" },
+            label: "Codex"
+          },
+          {
+            targetId: "local:claude-code",
+            agentTargetId: "local:claude-code",
+            provider: "claude-code",
+            ref: { kind: "local-provider", provider: "claude-code" },
+            label: "Claude Code"
+          }
+        ],
+        onDataChange
+      })
+    );
+
+    await waitFor(() => {
+      expect(
+        result.current.viewModel.conversations.map((item) => item.id)
+      ).toEqual(["codex-session"]);
+    });
+
+    act(() => {
+      result.current.actions.selectConversation("codex-session");
+    });
+
+    // Activating a conversation from another provider re-targets the node
+    // composer data at the session's own provider target.
+    await waitFor(() => {
+      const applied = onDataChange.mock.calls.reduce(
+        (data, [updater]) => updater(data),
+        initialData
+      );
+      expect(applied).toMatchObject({
+        provider: "codex",
+        agentTargetId: "local:codex"
+      });
+    });
+  });
+
+  it("aligns the home composer target with the filter tab when starting a new conversation", async () => {
+    installAgentHostApi({
+      list: vi.fn(async () => ({ presences: [], sessions: [] })),
+      listSessionTimeline: vi.fn(async () => ({ timelineItems: [] })),
+      subscribeEvents: vi.fn(() => vi.fn())
+    });
+
+    const { result } = renderHook(() =>
+      useAgentGUINodeController({
+        workspaceId: "room-1",
+        currentUserId: "user-1",
+        workspacePath: "/workspace",
+        avoidGroupingEdits: false,
+        data: agentGuiData(null, "codex", {
+          agentTargetId: "local:codex"
+        }),
+        conversationScope: "multi-provider",
+        providerTargets: [
+          {
+            targetId: "local:codex",
+            agentTargetId: "local:codex",
+            provider: "codex",
+            ref: { kind: "local-provider", provider: "codex" },
+            label: "Codex"
+          },
+          {
+            targetId: "local:claude-code",
+            agentTargetId: "local:claude-code",
+            provider: "claude-code",
+            ref: { kind: "local-provider", provider: "claude-code" },
+            label: "Claude Code"
+          }
+        ],
+        onDataChange: vi.fn()
+      })
+    );
+
+    act(() => {
+      result.current.actions.selectConversationFilterTarget({
+        provider: "claude-code",
+        providerTargetId: "local:claude-code"
+      });
+    });
+    // The user flips the chip away from the tab target…
+    act(() => {
+      result.current.actions.selectProvider({
+        provider: "codex",
+        providerTargetId: "local:codex"
+      });
+    });
+    await waitFor(() => {
+      expect(result.current.viewModel.selectedProviderTarget.provider).toBe(
+        "codex"
+      );
+    });
+
+    // …but "new conversation" composes for the tab the user is looking at.
+    act(() => {
+      result.current.actions.createConversation();
+    });
+
+    await waitFor(() => {
+      expect(result.current.viewModel.selectedProviderTarget.provider).toBe(
+        "claude-code"
+      );
+    });
+    expect(result.current.viewModel.data.provider).toBe("claude-code");
+    expect(result.current.viewModel.data.agentTargetId).toBe(
+      "local:claude-code"
+    );
+  });
+
+  it("moves the conversation filter to the created conversation's target tab", async () => {
+    const activate = vi.fn(
+      async (input: AgentHostActivateAgentSessionInput) => ({
+        session: agentSession(input.agentSessionId, {
+          provider: input.mode === "new" ? input.provider : "codex"
+        }),
+        activation: { mode: input.mode, status: "attached" as const }
+      })
+    );
+    installAgentHostApi({
+      list: vi.fn(async () => ({ presences: [], sessions: [] })),
+      listSessionTimeline: vi.fn(async () => ({ timelineItems: [] })),
+      subscribeEvents: vi.fn(() => vi.fn()),
+      activate
+    });
+
+    const { result } = renderHook(() =>
+      useAgentGUINodeController({
+        workspaceId: "room-1",
+        currentUserId: "user-1",
+        workspacePath: "/workspace",
+        avoidGroupingEdits: false,
+        data: agentGuiData(null, "codex", {
+          agentTargetId: "local:codex"
+        }),
+        conversationScope: "multi-provider",
+        providerTargets: [
+          {
+            targetId: "local:codex",
+            agentTargetId: "local:codex",
+            provider: "codex",
+            ref: { kind: "local-provider", provider: "codex" },
+            label: "Codex"
+          },
+          {
+            targetId: "local:claude-code",
+            agentTargetId: "local:claude-code",
+            provider: "claude-code",
+            ref: { kind: "local-provider", provider: "claude-code" },
+            label: "Claude Code"
+          }
+        ],
+        onDataChange: vi.fn()
+      })
+    );
+
+    // Looking at the Claude Code tab…
+    act(() => {
+      result.current.actions.selectConversationFilterTarget({
+        provider: "claude-code",
+        providerTargetId: "local:claude-code"
+      });
+    });
+    // …the user explicitly re-targets the chip at Codex and submits.
+    act(() => {
+      result.current.actions.selectProvider({
+        provider: "codex",
+        providerTargetId: "local:codex"
+      });
+    });
+    act(() => {
+      result.current.actions.submitPrompt(promptBlocks("start codex here"));
+    });
+
+    await waitFor(() => {
+      expect(activate).toHaveBeenCalledWith(
+        expect.objectContaining({
+          mode: "new",
+          agentTargetId: "local:codex",
+          provider: "codex"
+        })
+      );
+    });
+    // The created codex conversation must not stay pinned under the Claude
+    // Code tab: the filter follows the conversation's own target.
+    await waitFor(() => {
+      expect(result.current.viewModel.conversationFilter).toEqual({
+        kind: "agentTarget",
+        agentTargetId: "local:codex"
+      });
+    });
   });
 
   it("clears generic composer overrides when switching the empty composer provider", async () => {

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUINodeController.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUINodeController.ts
@@ -529,6 +529,38 @@ function reportAgentGUIRuntimeError(input: {
   }
 }
 
+function reportAgentGUIConversationFilterTargetUnresolved(input: {
+  provider: string;
+  providerTargetId: string | null;
+  providerTargetCount: number;
+  reason: "disabled" | "unresolved";
+  runtime: AgentActivityRuntime;
+  workspaceId: string;
+}): void {
+  const reportDiagnostic = input.runtime.reportDiagnostic;
+  if (!reportDiagnostic) {
+    return;
+  }
+  try {
+    void Promise.resolve(
+      reportDiagnostic.call(input.runtime, {
+        details: {
+          provider: input.provider,
+          providerTargetCount: input.providerTargetCount,
+          providerTargetId: input.providerTargetId,
+          reason: input.reason
+        },
+        event: "agent.gui.conversation_filter.target_unresolved",
+        level: "warn",
+        source: "agent-gui",
+        workspaceId: input.workspaceId
+      })
+    ).catch(() => {});
+  } catch {
+    // Diagnostic logging must never affect conversation filter selection.
+  }
+}
+
 function reportAgentGUIMessagePageDiagnostic(input: {
   agentSessionId: string;
   details?: Record<string, unknown>;
@@ -3751,6 +3783,8 @@ export function useAgentGUINodeController({
     useState<AgentGUIConversationFilter>(
       () => createAgentGUIConversationFilterState().filter
     );
+  const conversationFilterRef = useRef(conversationFilter);
+  conversationFilterRef.current = conversationFilter;
   const canUseConversationTargetFilter = conversationScope === "multi-provider";
   const queryConversationFilter = canUseConversationTargetFilter
     ? conversationFilter
@@ -7276,14 +7310,40 @@ export function useAgentGUINodeController({
           activatedConversationIdsRef.current.add(conversation.id);
           setTransientConversation(conversation);
           if (conversationListQuery) {
+            // Pin the freshly created conversation under the query of its own
+            // target tab, and move the filter there when it points elsewhere:
+            // a conversation must never stay pinned in a tab it does not
+            // belong to.
+            const createdAgentTargetId =
+              normalizeOptionalText(conversation.agentTargetId) ??
+              targetData.agentTargetId;
+            const createdConversationFilter: AgentGUIConversationFilter =
+              createdAgentTargetId
+                ? { kind: "agentTarget", agentTargetId: createdAgentTargetId }
+                : { kind: "all" };
+            const createdConversationQuery =
+              conversationListQuery.conversationFilter
+                ? {
+                    ...conversationListQuery,
+                    conversationFilter: createdConversationFilter
+                  }
+                : conversationListQuery;
             upsertLocalCreatedAgentGUIConversation({
-              query: conversationListQuery,
+              query: createdConversationQuery,
               conversation
             });
             scheduleAgentGUIConversationListProjection(
-              conversationListQuery,
+              createdConversationQuery,
               "local-create"
             );
+            if (conversationListQuery.conversationFilter) {
+              setConversationFilter((currentFilter) =>
+                currentFilter.kind === "agentTarget" &&
+                currentFilter.agentTargetId !== (createdAgentTargetId ?? "")
+                  ? createdConversationFilter
+                  : currentFilter
+              );
+            }
           }
           setAgentSessionViewMessagesLoading(
             sessionViewRef(conversation.id),
@@ -7475,12 +7535,34 @@ export function useAgentGUINodeController({
       setIsLoadingMessages(false);
       setDetailError(null);
       persistActiveConversation(null);
+      // Starting a new conversation from a target tab should compose for that
+      // tab's target, not for whatever target the node last remembered.
+      const filter = conversationFilterRef.current;
+      if (canUseConversationTargetFilter && filter.kind === "agentTarget") {
+        const filterTarget = resolveAgentGUIProviderTarget({
+          agentTargetId: filter.agentTargetId,
+          defaultProviderTargetId,
+          fallbackToLocal: false,
+          provider: dataRef.current.provider,
+          providerTargets: normalizedProviderTargets
+        });
+        if (
+          filterTarget &&
+          filterTarget.disabled !== true &&
+          (filterTarget.agentTargetId?.trim() ?? "") === filter.agentTargetId
+        ) {
+          setHomeComposerTargetOverride(filterTarget);
+        }
+      }
       loadDraftComposerOptions();
     },
     [
       activation,
       agentActivityRuntime,
+      canUseConversationTargetFilter,
+      defaultProviderTargetId,
       loadDraftComposerOptions,
+      normalizedProviderTargets,
       persistActiveConversation,
       workspaceId
     ]
@@ -9587,6 +9669,87 @@ export function useAgentGUINodeController({
     userProjects,
     workspacePath
   ]);
+  // Keep the node-level composer target aligned with the conversation the user
+  // activated: the composer chip must show the session's own provider/target,
+  // not whatever target was last selected in the home composer.
+  useEffect(() => {
+    if (previewMode || providerTargetsLoading || !activeConversationId) {
+      return;
+    }
+    const summary = resolveConversationSummaryById(
+      conversations,
+      activeConversationId,
+      transientConversationRef.current
+    );
+    if (!summary || summary.provider === "unknown") {
+      return;
+    }
+    const summaryAgentTargetId = normalizeOptionalText(summary.agentTargetId);
+    const providerMismatch = dataRef.current.provider !== summary.provider;
+    const agentTargetMismatch =
+      summaryAgentTargetId !== null &&
+      normalizeOptionalText(dataRef.current.agentTargetId) !==
+        summaryAgentTargetId;
+    if (!providerMismatch && !agentTargetMismatch) {
+      return;
+    }
+    const sessionTarget = resolveAgentGUIProviderTarget({
+      agentTargetId: summaryAgentTargetId,
+      defaultProviderTargetId,
+      fallbackToLocal: shouldFallbackToLocalProviderTargets,
+      provider: summary.provider,
+      providerTargets: normalizedProviderTargets
+    });
+    if (!sessionTarget || sessionTarget.provider !== summary.provider) {
+      return;
+    }
+    if (
+      !providerMismatch &&
+      summaryAgentTargetId !== null &&
+      (sessionTarget.agentTargetId?.trim() ?? "") !== summaryAgentTargetId
+    ) {
+      // The session's own target is not resolvable and the provider already
+      // matches — do not replace an explicit target with a guessed fallback.
+      return;
+    }
+    setHomeComposerTargetOverride(null);
+    const sessionTargetIsExplicit = normalizedExplicitProviderTargets.some(
+      (target) =>
+        target.provider === sessionTarget.provider &&
+        target.targetId === sessionTarget.targetId &&
+        agentGUIProviderTargetRefsEqual(target.ref, sessionTarget.ref)
+    );
+    onDataChangeRef.current((current) => {
+      const targetData = composerTargetDataFromProviderTarget({
+        current,
+        isExplicit: sessionTargetIsExplicit,
+        target: sessionTarget
+      });
+      if (
+        current.provider === targetData.provider &&
+        normalizeOptionalText(current.agentTargetId) ===
+          targetData.agentTargetId &&
+        (current.providerTargetId ?? null) === targetData.providerTargetId &&
+        agentGUIProviderTargetRefsEqual(
+          current.providerTargetRef,
+          targetData.providerTargetRef
+        )
+      ) {
+        return current;
+      }
+      dataRef.current = targetData.data;
+      return targetData.data;
+    });
+  }, [
+    activeConversationId,
+    conversations,
+    defaultProviderTargetId,
+    normalizedExplicitProviderTargets,
+    normalizedProviderTargets,
+    previewMode,
+    providerTargetsLoading,
+    shouldFallbackToLocalProviderTargets
+  ]);
   const visibleConversationsRef = useRef<AgentGUIConversationSummary[] | null>(
     null
   );
@@ -10532,7 +10695,20 @@ export function useAgentGUINodeController({
         providerTargets: normalizedProviderTargets
       });
       if (!nextTarget || nextTarget.disabled === true) {
+        reportAgentGUIConversationFilterTargetUnresolved({
+          provider: input.provider,
+          providerTargetId: input.providerTargetId ?? null,
+          providerTargetCount: normalizedProviderTargets.length,
+          reason: nextTarget ? "disabled" : "unresolved",
+          runtime: agentActivityRuntime,
+          workspaceId
+        });
         return;
+      }
+      // Keep the home composer chip in sync with the selected tab; an active
+      // conversation keeps owning the chip (it shows the session's target).
+      if (activeConversationIdRef.current === null) {
+        setHomeComposerTargetOverride(nextTarget);
       }
       const agentTargetId = nextTarget.agentTargetId?.trim() ?? "";
       const nextFilter = agentTargetId
@@ -10541,10 +10717,12 @@ export function useAgentGUINodeController({
       setConversationFilter(nextFilter);
     },
     [
+      agentActivityRuntime,
       canUseConversationTargetFilter,
       defaultProviderTargetId,
       normalizedProviderTargets,
-      shouldFallbackToLocalProviderTargets
+      shouldFallbackToLocalProviderTargets,
+      workspaceId
     ]
   );
   const stableCreateConversation =

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUINodeController.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUINodeController.ts
@@ -7310,24 +7310,27 @@ export function useAgentGUINodeController({
           activatedConversationIdsRef.current.add(conversation.id);
           setTransientConversation(conversation);
           if (conversationListQuery) {
-            // Pin the freshly created conversation under the query of its own
-            // target tab, and move the filter there when it points elsewhere:
-            // a conversation must never stay pinned in a tab it does not
-            // belong to.
+            // A conversation must never stay pinned in a tab it does not
+            // belong to: when the current agent-target filter excludes the
+            // created conversation, pin it under its own target tab's query
+            // and move the filter there.
             const createdAgentTargetId =
               normalizeOptionalText(conversation.agentTargetId) ??
               targetData.agentTargetId;
+            const currentQueryFilter = conversationListQuery.conversationFilter;
+            const filterExcludesCreatedConversation =
+              currentQueryFilter?.kind === "agentTarget" &&
+              currentQueryFilter.agentTargetId !== (createdAgentTargetId ?? "");
             const createdConversationFilter: AgentGUIConversationFilter =
               createdAgentTargetId
                 ? { kind: "agentTarget", agentTargetId: createdAgentTargetId }
                 : { kind: "all" };
-            const createdConversationQuery =
-              conversationListQuery.conversationFilter
-                ? {
-                    ...conversationListQuery,
-                    conversationFilter: createdConversationFilter
-                  }
-                : conversationListQuery;
+            const createdConversationQuery = filterExcludesCreatedConversation
+              ? {
+                  ...conversationListQuery,
+                  conversationFilter: createdConversationFilter
+                }
+              : conversationListQuery;
             upsertLocalCreatedAgentGUIConversation({
               query: createdConversationQuery,
               conversation
@@ -7336,13 +7339,8 @@ export function useAgentGUINodeController({
               createdConversationQuery,
               "local-create"
             );
-            if (conversationListQuery.conversationFilter) {
-              setConversationFilter((currentFilter) =>
-                currentFilter.kind === "agentTarget" &&
-                currentFilter.agentTargetId !== (createdAgentTargetId ?? "")
-                  ? createdConversationFilter
-                  : currentFilter
-              );
+            if (filterExcludesCreatedConversation) {
+              setConversationFilter(createdConversationFilter);
             }
           }
           setAgentSessionViewMessagesLoading(

--- a/packages/agent/gui/contexts/workspace/presentation/renderer/agentGuiConversationList/agentGuiConversationListStore.spec.ts
+++ b/packages/agent/gui/contexts/workspace/presentation/renderer/agentGuiConversationList/agentGuiConversationListStore.spec.ts
@@ -22,6 +22,7 @@ import {
   scheduleAgentGUIConversationListProjection,
   setAgentGUIConversationListActiveConversation,
   setAgentGUIConversationListConversationsForTests,
+  upsertLocalCreatedAgentGUIConversation,
   type AgentGUIConversationListQuery
 } from "./agentGuiConversationListStore";
 import type { AgentGUIConversationSummary } from "../../../../../agent-gui/agentGuiNode/model/agentGuiConversationModel";
@@ -161,6 +162,59 @@ describe("agentGuiConversationListStore", () => {
           claudeQuery
         )?.conversations.map((item) => item.id)
       ).toEqual(["claude-local"]);
+    });
+  });
+
+  it("releases local-created conversations that do not match the query's agent target filter", async () => {
+    const codexQuery: AgentGUIConversationListQuery = {
+      conversationFilter: { kind: "agentTarget", agentTargetId: "local:codex" },
+      workspaceId: "workspace-1",
+      userId: "user-1",
+      provider: "codex",
+      sessionOrigin: "WORKSPACE_AGENT_SESSION_ORIGIN_RUNTIME"
+    };
+    const snapshot: WorkspaceAgentActivitySnapshot = {
+      ...emptySnapshot(),
+      sessions: [
+        runtimeSession("codex-existing", 3_000, {
+          agentTargetId: "local:codex",
+          provider: "codex"
+        })
+      ]
+    };
+    setAgentActivityRuntimeForTests({
+      getSnapshot: () => snapshot,
+      load: async () => snapshot,
+      subscribe: () => () => {}
+    } as Partial<AgentActivityRuntime> as AgentActivityRuntime);
+
+    ensureAgentGUIConversationListQuery(codexQuery);
+    // A codex conversation created locally (not in the snapshot yet) stays
+    // pinned; a claude conversation mistakenly pinned under the codex tab
+    // must be released on refresh instead of sticking around.
+    upsertLocalCreatedAgentGUIConversation({
+      query: codexQuery,
+      conversation: conversation("codex-created", {
+        agentTargetId: "local:codex",
+        updatedAtUnixMs: 4_000
+      })
+    });
+    upsertLocalCreatedAgentGUIConversation({
+      query: codexQuery,
+      conversation: conversation("claude-created", {
+        provider: "claude-code",
+        agentTargetId: "local:claude-code",
+        updatedAtUnixMs: 5_000
+      })
+    });
+    scheduleAgentGUIConversationListProjection(codexQuery, "projection-sync");
+
+    await waitFor(() => {
+      expect(
+        getAgentGUIConversationListQuerySnapshot(codexQuery)?.conversations.map(
+          (item) => item.id
+        )
+      ).toEqual(["codex-created", "codex-existing"]);
     });
   });
 

--- a/packages/agent/gui/contexts/workspace/presentation/renderer/agentGuiConversationList/agentGuiConversationListStore.spec.ts
+++ b/packages/agent/gui/contexts/workspace/presentation/renderer/agentGuiConversationList/agentGuiConversationListStore.spec.ts
@@ -218,6 +218,62 @@ describe("agentGuiConversationListStore", () => {
     });
   });
 
+  it("drops a mismatching retained conversation once its session reaches the snapshot", async () => {
+    const codexQuery: AgentGUIConversationListQuery = {
+      conversationFilter: { kind: "agentTarget", agentTargetId: "local:codex" },
+      workspaceId: "workspace-1",
+      userId: "user-1",
+      provider: "codex",
+      sessionOrigin: "WORKSPACE_AGENT_SESSION_ORIGIN_RUNTIME"
+    };
+    let snapshot: WorkspaceAgentActivitySnapshot = {
+      ...emptySnapshot(),
+      sessions: [
+        runtimeSession("codex-existing", 3_000, {
+          agentTargetId: "local:codex",
+          provider: "codex"
+        })
+      ]
+    };
+    setAgentActivityRuntimeForTests({
+      getSnapshot: () => snapshot,
+      load: async () => snapshot,
+      subscribe: () => () => {}
+    } as Partial<AgentActivityRuntime> as AgentActivityRuntime);
+
+    ensureAgentGUIConversationListQuery(codexQuery);
+    // A claude conversation mistakenly pinned under the codex tab…
+    upsertLocalCreatedAgentGUIConversation({
+      query: codexQuery,
+      conversation: conversation("claude-created", {
+        provider: "claude-code",
+        agentTargetId: "local:claude-code",
+        updatedAtUnixMs: 5_000
+      })
+    });
+    // …must not be resurrected via snapshot-based retention once the daemon
+    // snapshot includes its session (which releases the local pin).
+    snapshot = {
+      ...snapshot,
+      sessions: [
+        ...snapshot.sessions,
+        runtimeSession("claude-created", 5_000, {
+          agentTargetId: "local:claude-code",
+          provider: "claude-code"
+        })
+      ]
+    };
+    scheduleAgentGUIConversationListProjection(codexQuery, "projection-sync");
+
+    await waitFor(() => {
+      expect(
+        getAgentGUIConversationListQuerySnapshot(codexQuery)?.conversations.map(
+          (item) => item.id
+        )
+      ).toEqual(["codex-existing"]);
+    });
+  });
+
   it("keeps explicit conversation filter query keys independent from provider", () => {
     const baseQuery: AgentGUIConversationListQuery = {
       conversationFilter: { kind: "all" },

--- a/packages/agent/gui/contexts/workspace/presentation/renderer/agentGuiConversationList/agentGuiConversationListStore.ts
+++ b/packages/agent/gui/contexts/workspace/presentation/renderer/agentGuiConversationList/agentGuiConversationListStore.ts
@@ -167,6 +167,23 @@ function conversationFilterKey(
   return `agent-target:${normalized.agentTargetId}`;
 }
 
+/**
+ * A conversation may only be retained (pinned/carried over) in a query state
+ * whose agent-target filter it does not contradict. Conversations without a
+ * known summary or without an agentTargetId are kept: we can only prove a
+ * mismatch when both sides are known.
+ */
+function conversationRetainableForQueryFilter(
+  conversation: AgentGUIConversationSummary | undefined,
+  filter: AgentGUIConversationFilter | null
+): boolean {
+  if (!conversation || !filter || filter.kind !== "agentTarget") {
+    return true;
+  }
+  const agentTargetId = conversation.agentTargetId?.trim() ?? "";
+  return agentTargetId.length === 0 || agentTargetId === filter.agentTargetId;
+}
+
 export function createAgentGUIConversationListQueryKey(
   input: AgentGUIConversationListQuery
 ): string | null {
@@ -1326,17 +1343,34 @@ async function refreshAgentGUIConversationListQuery(
           ...baseConversations.map((conversation) => conversation.id)
         ])
       : null;
+    const currentConversationsById = new Map(
+      currentConversations.map((conversation) => [
+        conversation.id,
+        conversation
+      ])
+    );
+    const retainableForQueryFilter = (agentSessionId: string): boolean =>
+      conversationRetainableForQueryFilter(
+        currentConversationsById.get(agentSessionId),
+        state.query.conversationFilter
+      );
     const retainedSessionIds = new Set(retainedSnapshotSessionIds);
     if (reason === "workspace-agent-update") {
       for (const conversation of currentConversations) {
-        if (!nextDeletedConversationIds.has(conversation.id)) {
+        if (
+          !nextDeletedConversationIds.has(conversation.id) &&
+          retainableForQueryFilter(conversation.id)
+        ) {
           retainedSessionIds.add(conversation.id);
         }
       }
     }
     if (retainedSnapshotSessionIds.size > 0) {
       for (const agentSessionId of localCreatedConversationIds) {
-        if (!nextDeletedConversationIds.has(agentSessionId)) {
+        if (
+          !nextDeletedConversationIds.has(agentSessionId) &&
+          retainableForQueryFilter(agentSessionId)
+        ) {
           retainedSessionIds.add(agentSessionId);
         }
       }
@@ -1344,7 +1378,10 @@ async function refreshAgentGUIConversationListQuery(
 
     if (canApplyDirtySessionProjection) {
       for (const conversation of currentConversations) {
-        if (!nextDeletedConversationIds.has(conversation.id)) {
+        if (
+          !nextDeletedConversationIds.has(conversation.id) &&
+          retainableForQueryFilter(conversation.id)
+        ) {
           retainedSessionIds.add(conversation.id);
         }
       }

--- a/packages/agent/gui/contexts/workspace/presentation/renderer/agentGuiConversationList/agentGuiConversationListStore.ts
+++ b/packages/agent/gui/contexts/workspace/presentation/renderer/agentGuiConversationList/agentGuiConversationListStore.ts
@@ -1349,12 +1349,38 @@ async function refreshAgentGUIConversationListQuery(
         conversation
       ])
     );
-    const retainableForQueryFilter = (agentSessionId: string): boolean =>
-      conversationRetainableForQueryFilter(
+    const snapshotSessionAgentTargetIdById = new Map(
+      workspaceAgentSnapshot.sessions.flatMap((session) => {
+        const agentSessionId = session.agentSessionId.trim();
+        const agentTargetId = session.agentTargetId?.trim() ?? "";
+        return agentSessionId && agentTargetId
+          ? [[agentSessionId, agentTargetId] as const]
+          : [];
+      })
+    );
+    const retainableForQueryFilter = (agentSessionId: string): boolean => {
+      const filter = state.query.conversationFilter;
+      if (!filter || filter.kind !== "agentTarget") {
+        return true;
+      }
+      // The fresh snapshot session's target is authoritative over a possibly
+      // stale current summary.
+      const snapshotAgentTargetId =
+        snapshotSessionAgentTargetIdById.get(agentSessionId);
+      if (snapshotAgentTargetId) {
+        return snapshotAgentTargetId === filter.agentTargetId;
+      }
+      return conversationRetainableForQueryFilter(
         currentConversationsById.get(agentSessionId),
-        state.query.conversationFilter
+        filter
       );
-    const retainedSessionIds = new Set(retainedSnapshotSessionIds);
+    };
+    // Retention must never resurrect a row that contradicts this query's
+    // agent-target filter: the snapshot spans the whole workspace, so its
+    // session ids are filtered here as well.
+    const retainedSessionIds = new Set(
+      [...retainedSnapshotSessionIds].filter(retainableForQueryFilter)
+    );
     if (reason === "workspace-agent-update") {
       for (const conversation of currentConversations) {
         if (

--- a/packages/agent/gui/shared/contracts/dto/agentHost.ts
+++ b/packages/agent/gui/shared/contracts/dto/agentHost.ts
@@ -908,6 +908,7 @@ export interface AgentHostWorkspaceAgentSession {
   id: number;
   workspaceId?: string;
   agentSessionId: string;
+  agentTargetId?: string | null;
   presenceId: number;
   userId?: string;
   provider?: AgentHostWorkspaceAgentProvider;


### PR DESCRIPTION
## 背景

业务接入 agent-gui 0.0.57 时报告了两个症状（根因均在包内）：

1. **composer 芯片和激活会话不对应**：芯片完全从节点级 data（上次选择的 target）派生，激活不同 provider 的历史会话时不同步。
2. **codex tab 里出现 claude 会话**：芯片错位时在 codex tab 的 home composer 发送，实际创建 claude 会话；会话列表的本地 pin 机制（`localCreatedConversationIds`）不校验是否匹配当前 target filter，该会话被钉在 codex tab 直到快照刷新。

另有一个隐患：`selectConversationFilterTarget` 在 target 解析失败时静默 return。

## 修复

- **芯片跟随会话/tab**：激活会话时把节点 composer target 同步为该会话自己的 provider + agentTargetId（仅在会话 target 明确可知或 provider 错位时写入，不用 fallback 猜测覆盖显式 target）；home 状态下点击 target tab 同步芯片（内存 override，不持久化）；"新建会话"时芯片对齐当前 tab。
- **pin/filter 一致性**：创建会话后，若当前 agent-target filter 会排除新会话，则把本地 pin 落到该会话自己 target tab 的 query 下并自动切换 filter；All tab 下保持原地 pin（否则新会话会在快照刷新前从列表消失）。store 刷新时不再保留与 query filter 矛盾的 local-created pin。
- **不再静默返回**：filter target 解析失败/disabled 时上报 `agent.gui.conversation_filter.target_unresolved` 诊断（warn）。
- 补充契约：`AgentHostWorkspaceAgentSession` 声明 `agentTargetId?`（daemon 实际下发、投影层已消费）。

## 测试

- 新增回归测试：跨 provider 激活同步芯片、新建会话对齐 tab、filter 自动跟随新会话 target、store 释放不匹配 filter 的 pin。
- `packages/agent/gui`：typecheck 通过，1905 个测试全部通过。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved multi-provider conversation handling so the composer and selected conversation stay aligned when switching tabs, starting new chats, or activating conversations from another provider.
  * New conversations now follow the currently selected filter more consistently.

* **Bug Fixes**
  * Fixed cases where conversations could appear in the wrong list after creation or refresh.
  * Prevented hidden state mismatches between the active conversation, composer, and filter selection.
  * Added better handling for unavailable conversation targets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->