### PR TITLE
fix(agent): import accuracy — scan drops, scratch-project mislabeling, lost tool content, cross-provider mentions

### DIFF
--- a/packages/agent/gui/actions/workspaceLinkActions.spec.ts
+++ b/packages/agent/gui/actions/workspaceLinkActions.spec.ts
@@ -408,6 +408,40 @@ describe("resolveWorkspaceMentionLinkAction", () => {
       })
     ).toBeNull();
   });
+
+  it("parses agent-session mention context without a captured provider", () => {
+    expect(
+      resolveWorkspaceMentionLinkAction({
+        href: "mention://agent-session/session-1?workspaceId=workspace-1",
+        source: "agent-markdown"
+      })
+    ).toEqual({
+      type: "open-agent-session",
+      workspaceId: "workspace-1",
+      agentSessionId: "session-1",
+      source: "agent-markdown"
+    });
+  });
+
+  it("restores the mentioned session's own provider from the agentProvider scope key", () => {
+    // Regression for cross-provider mentions (e.g. a Codex conversation
+    // @-mentioning a Claude Code session) resolving to the WRONG provider:
+    // callers default `provider` from their own viewing context only when
+    // the action doesn't already carry one, so the mention must capture the
+    // target session's real provider here rather than leaving it undefined.
+    expect(
+      resolveWorkspaceMentionLinkAction({
+        href: "mention://agent-session/session-1?agentProvider=claude-code&workspaceId=workspace-1",
+        source: "agent-markdown"
+      })
+    ).toEqual({
+      type: "open-agent-session",
+      workspaceId: "workspace-1",
+      agentSessionId: "session-1",
+      provider: "claude-code",
+      source: "agent-markdown"
+    });
+  });
 });
 
 describe("resolveLocalAssetPreviewLinkAction", () => {

--- a/packages/agent/gui/actions/workspaceLinkActions.ts
+++ b/packages/agent/gui/actions/workspaceLinkActions.ts
@@ -316,10 +316,19 @@ export function resolveWorkspaceMentionLinkAction({
   }
 
   if (mention.providerId === "agent-session") {
+    // The mentioned session's own agent provider, when the mention captured
+    // one (see buildSessionMentionItem in agentMentionSearchHelpers.ts).
+    // Older mentions created before that provider was captured leave this
+    // undefined; callers fall back to their own viewing context's provider
+    // in that case, but must NOT do so when a provider was actually
+    // recorded — the mentioned session may belong to a different provider
+    // than the one the mention is being opened from.
+    const provider = mention.scope?.agentProvider?.trim() || null;
     return {
       type: "open-agent-session",
       workspaceId,
       agentSessionId: targetId,
+      ...(provider ? { provider } : {}),
       source
     };
   }

--- a/packages/agent/gui/agent-gui/agentGuiNode/agentMentionSearchHelpers.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/agentMentionSearchHelpers.ts
@@ -79,7 +79,19 @@ export function buildSessionMentionItem(input: {
       providerId: "agent-session",
       entityId: input.session.agentSessionId,
       label: mentionTitle,
-      scope: { workspaceId: input.workspaceId }
+      scope: {
+        workspaceId: input.workspaceId,
+        // Captures the mentioned session's OWN agent provider (e.g.
+        // "claude-code") so opening the mention later can restore it. Without
+        // this, resolveWorkspaceMentionLinkAction() has no provider to put on
+        // the resulting open-agent-session action, and callers were falling
+        // back to defaulting it from the CURRENT/viewing node's own provider
+        // — which is wrong whenever a session is mentioned across providers
+        // (e.g. a Codex conversation @-mentioning a Claude Code session) and
+        // could overwrite the target session's stored cwd/visibility with
+        // data reported under the wrong provider context.
+        ...(sessionProvider ? { agentProvider: sessionProvider } : {})
+      }
     }),
     workspaceId: input.workspaceId,
     targetId: input.session.agentSessionId,

--- a/services/tuttid/service/agent/external_import_parse.go
+++ b/services/tuttid/service/agent/external_import_parse.go
@@ -78,6 +78,16 @@ func codexMessageFromPayload(payload map[string]any, index int, timestamp int64)
 		return codexFunctionCallMessage(payload, rawID, timestamp)
 	case "function_call_output":
 		return codexFunctionCallOutputMessage(payload, rawID, timestamp)
+	case "custom_tool_call":
+		// Custom/MCP tools (e.g. apply_patch) are recorded with the same
+		// call/output pairing as built-in function calls, but the call carries
+		// its argument payload under "input" (often a raw string, not JSON)
+		// instead of "arguments", and typically already reports its own
+		// terminal status since these tools tend to execute synchronously.
+		return codexCustomToolCallMessage(payload, rawID, timestamp)
+	case "custom_tool_call_output":
+		// Same "call_id"/"output" shape as function_call_output.
+		return codexFunctionCallOutputMessage(payload, rawID, timestamp)
 	default:
 		return externalImportedMessage{}
 	}
@@ -113,6 +123,43 @@ func codexFunctionCallMessage(payload map[string]any, rawID string, timestamp in
 		OccurredAtUnixMS: timestamp,
 		StartedAtUnixMS:  timestamp,
 	}
+}
+
+func codexCustomToolCallMessage(payload map[string]any, rawID string, timestamp int64) externalImportedMessage {
+	callID := stringField(payload, "call_id")
+	name := firstNonEmptyString(stringField(payload, "name"), callID)
+	arguments := codexFunctionCallArguments(payload["input"])
+	status := normalizeExternalMessageStatus(stringField(payload, "status"))
+	toolPayload := map[string]any{
+		"source":   "external_import",
+		"provider": agentproviderbiz.Codex,
+		"status":   status,
+	}
+	if callID != "" {
+		toolPayload["callId"] = callID
+	}
+	if name != "" {
+		toolPayload["name"] = name
+		toolPayload["toolName"] = name
+	}
+	if len(arguments) > 0 {
+		toolPayload["input"] = arguments
+	}
+	message := externalImportedMessage{
+		RawID:            rawID,
+		MessageIDSeed:    codexToolMessageIDSeed(rawID, callID),
+		Role:             "assistant",
+		Kind:             "tool_call",
+		Status:           status,
+		Text:             name,
+		Payload:          toolPayload,
+		OccurredAtUnixMS: timestamp,
+		StartedAtUnixMS:  timestamp,
+	}
+	if status == "completed" {
+		message.CompletedAtUnixMS = timestamp
+	}
+	return message
 }
 
 func codexFunctionCallOutputMessage(payload map[string]any, rawID string, timestamp int64) externalImportedMessage {
@@ -186,6 +233,15 @@ func parseClaudeCodeJSONL(path string, reader io.Reader) (externalImportedSessio
 				session.SummaryTitle = title
 			}
 		}
+		// Claude Code marks injected non-conversation content (skill/plugin file
+		// dumps loaded via the Skill tool, Stop-hook feedback, local-command
+		// caveats, etc.) with isMeta:true. These are not real turns the user or
+		// assistant produced and must not surface as message content in the
+		// imported session detail (they're the source of "file contents leaking
+		// into the conversation" reports).
+		if isMeta, _ := raw["isMeta"].(bool); isMeta {
+			return
+		}
 		messageMap := mapField(raw, "message")
 		if len(messageMap) == 0 {
 			return
@@ -219,7 +275,7 @@ func normalizeExternalParsedSession(session externalImportedSession) (externalIm
 	if strings.TrimSpace(session.ProviderSessionID) == "" {
 		session.ProviderSessionID = externalStableHash(session.Provider + "\x00" + session.SourcePath)
 	}
-	cwd, ok := canonicalExistingDir(session.Cwd)
+	cwd, ok := resolveExternalImportSessionCwd(session.Cwd)
 	if !ok {
 		return externalImportedSession{}, false, nil
 	}
@@ -270,6 +326,31 @@ func normalizeExternalParsedSession(session externalImportedSession) (externalIm
 	return session, true, nil
 }
 
+// resolveExternalImportSessionCwd resolves a session's recorded working
+// directory to an absolute path used for project grouping. It prefers the
+// canonical (symlink-resolved) path when the directory still exists on disk,
+// but falls back to a best-effort cleaned absolute path when it doesn't —
+// e.g. a deleted git worktree, a removed temp directory, or a renamed
+// project. Previously a missing directory caused the whole session (and all
+// of its messages) to be silently dropped from scan results, which both
+// undercounts scanned sessions/projects and can make an otherwise
+// content-rich conversation appear to vanish entirely. Only a genuinely empty
+// cwd (never recorded) is rejected.
+func resolveExternalImportSessionCwd(raw string) (string, bool) {
+	if canonical, ok := canonicalExistingDir(raw); ok {
+		return canonical, true
+	}
+	trimmed := strings.TrimSpace(raw)
+	if trimmed == "" {
+		return "", false
+	}
+	abs, err := filepath.Abs(trimmed)
+	if err != nil {
+		return "", false
+	}
+	return filepath.Clean(abs), true
+}
+
 func isExternalImportNoProjectCwd(provider string, cwd string) bool {
 	home, err := os.UserHomeDir()
 	if err != nil {
@@ -288,31 +369,24 @@ func isExternalImportNoProjectCwd(provider string, cwd string) bool {
 		isExternalImportCodexScratchCwd(home, cwd)
 }
 
+// isExternalImportCodexScratchCwd reports whether cwd is anywhere under the
+// Codex desktop app's auto-provisioned scratch tree (~/Documents/Codex/...).
+// Codex creates a directory there whenever a conversation starts without the
+// user picking a real local project, and the leaf directory name is a
+// machine-generated slug (e.g. a date, or a truncated/sanitized title) rather
+// than a folder the user chose. The exact shape of that slug has changed
+// across Codex versions — older releases used a single combined
+// "<date>-<slug>" segment (Documents/Codex/2026-04-24-gh), newer ones split it
+// into "<date>/<slug>" (Documents/Codex/2026-04-24/gh) — so this intentionally
+// only checks that the path is nested under Documents/Codex rather than
+// pattern-matching a specific segment shape, to stay robust across formats.
 func isExternalImportCodexScratchCwd(home string, cwd string) bool {
 	rel, err := filepath.Rel(home, cwd)
 	if err != nil || rel == "." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) || rel == ".." {
 		return false
 	}
-	parts := strings.Split(filepath.ToSlash(rel), "/")
-	if len(parts) != 4 || parts[0] != "Documents" || parts[1] != "Codex" || parts[3] == "" {
-		return false
-	}
-	return isExternalImportDateSegment(parts[2])
-}
-
-func isExternalImportDateSegment(value string) bool {
-	if len(value) != len("2006-01-02") || value[4] != '-' || value[7] != '-' {
-		return false
-	}
-	for index, char := range value {
-		if index == 4 || index == 7 {
-			continue
-		}
-		if char < '0' || char > '9' {
-			return false
-		}
-	}
-	return true
+	parts := strings.SplitN(filepath.ToSlash(rel), "/", 3)
+	return len(parts) >= 3 && parts[0] == "Documents" && parts[1] == "Codex" && parts[2] != ""
 }
 
 func externalImportedMessageHasContent(message externalImportedMessage) bool {

--- a/services/tuttid/service/agent/external_import_parse_test.go
+++ b/services/tuttid/service/agent/external_import_parse_test.go
@@ -203,6 +203,136 @@ func TestParseCodexJSONLSkipsAgentsAndEnvironmentPreamble(t *testing.T) {
 	}
 }
 
+func TestParseCodexJSONLHandlesCustomToolCallLifecycle(t *testing.T) {
+	// Regression for real Codex desktop transcripts where MCP/custom tools
+	// (e.g. apply_patch) are recorded as "custom_tool_call" /
+	// "custom_tool_call_output" response items rather than the built-in
+	// "function_call" / "function_call_output" pair. Before this was handled,
+	// every custom-tool-call turn was silently dropped, and sessions
+	// dominated by custom tool use (heavy apply_patch usage) could end up
+	// with no visible assistant activity at all despite substantial real
+	// content — reported as "会话显示为空(实际上有很多对话)".
+	cwd := t.TempDir()
+	session, ok, err := parseCodexJSONL(
+		filepath.Join(cwd, "rollout.jsonl"),
+		strings.NewReader(testAgentJSONL(t,
+			map[string]any{
+				"timestamp": "2026-06-18T00:00:00Z",
+				"type":      "session_meta",
+				"payload":   map[string]any{"id": "codex-custom-tool", "cwd": cwd},
+			},
+			map[string]any{
+				"timestamp": "2026-06-18T00:00:01Z",
+				"type":      "response_item",
+				"payload": map[string]any{
+					"type":    "message",
+					"role":    "user",
+					"content": []any{map[string]any{"type": "input_text", "text": "Apply this patch"}},
+				},
+			},
+			map[string]any{
+				"timestamp": "2026-06-18T00:00:02Z",
+				"type":      "response_item",
+				"payload": map[string]any{
+					"type":    "custom_tool_call",
+					"status":  "completed",
+					"call_id": "call-patch-1",
+					"name":    "apply_patch",
+					"input":   "*** Begin Patch\n*** Add File: foo.go\n+package foo\n*** End Patch",
+				},
+			},
+			map[string]any{
+				"timestamp": "2026-06-18T00:00:03Z",
+				"type":      "response_item",
+				"payload": map[string]any{
+					"type":    "custom_tool_call_output",
+					"call_id": "call-patch-1",
+					"output":  `{"output":"Success. Updated the following files:\nA foo.go\n"}`,
+				},
+			},
+		)),
+	)
+	if err != nil || !ok {
+		t.Fatalf("parseCodexJSONL ok=%v err=%v", ok, err)
+	}
+	if len(session.Messages) != 3 {
+		t.Fatalf("messages = %#v, want user prompt plus custom tool call lifecycle", session.Messages)
+	}
+	call := session.Messages[1]
+	if call.Role != "assistant" || call.Kind != "tool_call" || call.Status != "completed" {
+		t.Fatalf("custom tool call message = %#v", call)
+	}
+	if call.MessageIDSeed != "toolcall:call-patch-1" {
+		t.Fatalf("custom tool call seed = %q, want call id seed", call.MessageIDSeed)
+	}
+	if call.Payload["toolName"] != "apply_patch" {
+		t.Fatalf("custom tool call payload = %#v, want apply_patch tool name", call.Payload)
+	}
+	input, _ := call.Payload["input"].(map[string]any)
+	if !strings.Contains(input["arguments"].(string), "Add File: foo.go") {
+		t.Fatalf("custom tool call input = %#v, want raw patch text preserved", input)
+	}
+	output := session.Messages[2]
+	if output.Role != "assistant" || output.Kind != "tool_call" || output.Status != "completed" {
+		t.Fatalf("custom tool call output message = %#v", output)
+	}
+	if output.MessageIDSeed != call.MessageIDSeed {
+		t.Fatalf("custom tool call output seed = %q, want %q", output.MessageIDSeed, call.MessageIDSeed)
+	}
+}
+
+func TestParseCodexJSONLRetainsSessionWhenCwdDirectoryNoLongerExists(t *testing.T) {
+	// Regression: previously any session whose recorded cwd doesn't currently
+	// exist on disk (a deleted git worktree, a cleaned-up temp dir, a renamed
+	// project) was silently dropped from scan results in full — undercounting
+	// scanned sessions/projects, and making content-rich conversations that
+	// happened to run in a since-deleted directory appear to vanish entirely.
+	root := t.TempDir()
+	deletedCwd := filepath.Join(root, "deleted-worktree")
+	if err := os.MkdirAll(deletedCwd, 0o755); err != nil {
+		t.Fatalf("create then delete cwd error = %v", err)
+	}
+	if canonical, ok := canonicalExistingDir(deletedCwd); ok {
+		deletedCwd = canonical
+	}
+	if err := os.RemoveAll(deletedCwd); err != nil {
+		t.Fatalf("remove cwd error = %v", err)
+	}
+
+	sourcePath := filepath.Join(root, "rollout.jsonl")
+	session, ok, err := parseCodexJSONL(
+		sourcePath,
+		strings.NewReader(testAgentJSONL(t,
+			map[string]any{
+				"timestamp": "2026-06-18T00:00:00Z",
+				"type":      "session_meta",
+				"payload":   map[string]any{"id": "codex-deleted-cwd", "cwd": deletedCwd},
+			},
+			map[string]any{
+				"timestamp": "2026-06-18T00:00:01Z",
+				"type":      "response_item",
+				"payload": map[string]any{
+					"type":    "message",
+					"role":    "user",
+					"content": []any{map[string]any{"type": "input_text", "text": "Still real content"}},
+				},
+			},
+		)),
+	)
+	if err != nil {
+		t.Fatalf("parseCodexJSONL error = %v", err)
+	}
+	if !ok {
+		t.Fatal("parseCodexJSONL ok = false, want session retained despite missing cwd directory")
+	}
+	if session.Cwd != deletedCwd {
+		t.Fatalf("session.Cwd = %q, want original deleted cwd %q preserved", session.Cwd, deletedCwd)
+	}
+	if len(session.Messages) != 1 || session.Messages[0].Text != "Still real content" {
+		t.Fatalf("messages = %#v, want the real message retained", session.Messages)
+	}
+}
+
 func TestParseCodexJSONLMarksDocumentsCodexScratchCwdAsNoProject(t *testing.T) {
 	home := filepath.Join(t.TempDir(), "home")
 	cwd := filepath.Join(home, "Documents", "Codex", "2026-06-26", "ge")
@@ -241,6 +371,66 @@ func TestParseCodexJSONLMarksDocumentsCodexScratchCwdAsNoProject(t *testing.T) {
 	}
 	if !session.NoProject {
 		t.Fatalf("NoProject = false for Codex scratch cwd %q", session.Cwd)
+	}
+}
+
+func TestParseCodexJSONLMarksLegacyDateSlugScratchCwdAsNoProject(t *testing.T) {
+	// Real Codex desktop scratch directories have used at least two shapes:
+	// the newer "Documents/Codex/<date>/<slug>" (covered by the sibling test
+	// above) and an older single-segment "Documents/Codex/<date>-<slug>"
+	// layout (e.g. "Documents/Codex/2026-04-24-gh"). Both are Codex's own
+	// auto-provisioned no-project workspace, never a folder the user chose;
+	// failing to recognize the older shape let its machine-generated slug
+	// leak through as a bogus, garbled-looking "project" label — the avjjvg
+	// report ("显示的项目文件夹名称乱码,不是我本地对话时的文件夹名称").
+	home := filepath.Join(t.TempDir(), "home")
+	cwd := filepath.Join(home, "Documents", "Codex", "2026-04-24-gh")
+	if err := os.MkdirAll(cwd, 0o755); err != nil {
+		t.Fatalf("create legacy codex scratch cwd error = %v", err)
+	}
+	if canonical, ok := canonicalExistingDir(home); ok {
+		home = canonical
+	}
+	if canonical, ok := canonicalExistingDir(cwd); ok {
+		cwd = canonical
+	}
+	t.Setenv("HOME", home)
+
+	session, ok, err := parseCodexJSONL(
+		filepath.Join(cwd, "rollout.jsonl"),
+		strings.NewReader(testAgentJSONL(t,
+			map[string]any{
+				"timestamp": "2026-06-18T00:00:00Z",
+				"type":      "session_meta",
+				"payload":   map[string]any{"id": "codex-legacy-scratch", "cwd": cwd},
+			},
+			map[string]any{
+				"timestamp": "2026-06-18T00:00:01Z",
+				"type":      "response_item",
+				"payload": map[string]any{
+					"type":    "message",
+					"role":    "user",
+					"content": []any{map[string]any{"type": "input_text", "text": "Legacy scratch question"}},
+				},
+			},
+		)),
+	)
+	if err != nil || !ok {
+		t.Fatalf("parseCodexJSONL ok=%v err=%v", ok, err)
+	}
+	if !session.NoProject {
+		t.Fatalf("NoProject = false for legacy Codex scratch cwd %q", session.Cwd)
+	}
+
+	projectPath, ok := externalSessionProjectPath(session)
+	if !ok {
+		t.Fatalf("externalSessionProjectPath ok = false for %#v", session)
+	}
+	if projectPath == cwd {
+		t.Fatalf("project path = %q, want the no-project bucket, not the raw scratch slug directory", projectPath)
+	}
+	if base := filepath.Base(projectPath); base == "2026-04-24-gh" {
+		t.Fatalf("project label = %q, want no leaked scratch slug", base)
 	}
 }
 
@@ -302,6 +492,57 @@ func TestParseClaudeCodeJSONLPrefersCustomTitle(t *testing.T) {
 	}
 	if session.Title != "Summarize user persona prompts" {
 		t.Fatalf("title = %q, want custom-title", session.Title)
+	}
+}
+
+func TestParseClaudeCodeJSONLSkipsIsMetaInjectedFileContent(t *testing.T) {
+	// Regression: Claude Code marks injected non-conversation content — Skill
+	// tool file dumps, Stop-hook feedback, local-command caveats, etc. — with
+	// isMeta:true. This wasn't checked, so e.g. a whole loaded skill file's
+	// contents (or CLAUDE.md-shaped instructions) could surface as if the
+	// user had typed them, which is the "会话详情会先显示...文件内容" report
+	// (imported session detail showing injected file contents up front).
+	cwd := t.TempDir()
+	session, ok, err := parseClaudeCodeJSONL(
+		filepath.Join(cwd, "claude.jsonl"),
+		strings.NewReader(testAgentJSONL(t,
+			map[string]any{
+				"timestamp": "2026-06-18T00:00:00Z",
+				"sessionId": "claude-meta",
+				"cwd":       cwd,
+				"uuid":      "claude-meta-skill",
+				"isMeta":    true,
+				"message": map[string]any{
+					"role": "user",
+					"content": []any{map[string]any{
+						"type": "text",
+						"text": "Base directory for this skill: /Users/asdf/.claude/plugins/cache/skills/brainstorming\n\n# Brainstorming Ideas\n...",
+					}},
+				},
+			},
+			map[string]any{
+				"timestamp": "2026-06-18T00:00:01Z",
+				"sessionId": "claude-meta",
+				"cwd":       cwd,
+				"uuid":      "claude-meta-real",
+				"message": map[string]any{
+					"role":    "user",
+					"content": []any{map[string]any{"type": "text", "text": "What should I build next?"}},
+				},
+			},
+		)),
+	)
+	if err != nil || !ok {
+		t.Fatalf("parseClaudeCodeJSONL ok=%v err=%v", ok, err)
+	}
+	if len(session.Messages) != 1 {
+		t.Fatalf("messages = %#v, want only the real (non-meta) message", session.Messages)
+	}
+	if session.Messages[0].Text != "What should I build next?" {
+		t.Fatalf("message text = %q, want the real user prompt, not injected skill content", session.Messages[0].Text)
+	}
+	if session.Title != "What should I build next?" {
+		t.Fatalf("title = %q, want derived from the real user prompt", session.Title)
 	}
 }
 

--- a/services/tuttid/service/agent/external_import_projects.go
+++ b/services/tuttid/service/agent/external_import_projects.go
@@ -54,17 +54,46 @@ func projectFromExternalSession(session externalImportedSession) (ExternalImport
 }
 
 func externalSessionProjectPath(session externalImportedSession) (string, bool) {
-	cwd, ok := canonicalExistingDir(session.Cwd)
-	if !ok {
+	// session.Cwd has already been resolved by resolveExternalImportSessionCwd
+	// (see external_import_parse.go) — canonicalized when the directory still
+	// exists, or a best-effort cleaned absolute path when it no longer does (a
+	// deleted worktree/temp dir must still be countable and importable, just
+	// without git-root-based project grouping). Re-requiring existence here
+	// would silently drop those sessions from the scan a second time.
+	cwd := filepath.Clean(strings.TrimSpace(session.Cwd))
+	if cwd == "" || cwd == "." {
 		return "", false
 	}
 	if session.NoProject {
+		// Every "no project selected" session (whether it literally ran in the
+		// user's home directory, or in a provider-owned scratch workspace such
+		// as Codex's ~/Documents/Codex/<slug>) collapses onto one consistent
+		// bucket instead of surfacing its own machine-generated scratch
+		// directory name as if it were a real project. Using the raw cwd here
+		// previously surfaced synthetic slugs (e.g. "2026-04-24-gh") as bogus
+		// project labels — the source of reports that imported project folder
+		// names looked garbled and didn't match any folder the user chose.
+		if home, ok := externalImportNoProjectBucketPath(); ok {
+			return home, true
+		}
 		return cwd, true
 	}
 	if gitRoot, ok := nearestExternalImportGitRoot(cwd); ok {
 		return gitRoot, true
 	}
 	return cwd, true
+}
+
+// externalImportNoProjectBucketPath resolves the canonical path used to group
+// every no-project-selected session together, so the scan/import result
+// treats them as one consistent "no project" bucket rather than one bogus
+// per-session "project" per scratch directory.
+func externalImportNoProjectBucketPath() (string, bool) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", false
+	}
+	return canonicalExistingDir(home)
 }
 
 func nearestExternalImportGitRoot(cwd string) (string, bool) {

--- a/services/tuttid/service/agent/service_test.go
+++ b/services/tuttid/service/agent/service_test.go
@@ -711,6 +711,80 @@ func TestServiceImportsCodexScratchCwdAsNoProjectWithoutRegisteringIt(t *testing
 	}
 }
 
+func TestServiceScanCountsAndImportsSessionWithDeletedWorkingDirectory(t *testing.T) {
+	// Regression: a session whose recorded cwd no longer exists (a deleted
+	// git worktree, a cleaned-up temp dir) used to be silently dropped from
+	// the scan entirely — not counted in ScannedSessions, not offered for
+	// import, and not appearing in SkippedSessions either (it never got that
+	// far). That both undercounts what scan reports (eW5WPl sub-issue 1) and
+	// can make a substantial real conversation look empty/vanished (uOivri),
+	// since it never surfaces anywhere for the user to see or import.
+	ctx := context.Background()
+	store := openAgentServiceSQLiteStore(t)
+	if err := store.Create(ctx, workspacebiz.Summary{ID: "ws-1", Name: "Workspace One"}); err != nil {
+		t.Fatalf("Create workspace error = %v", err)
+	}
+	root := t.TempDir()
+	deletedCwd := filepath.Join(root, "deleted-project")
+	if err := os.MkdirAll(deletedCwd, 0o755); err != nil {
+		t.Fatalf("create then delete cwd error = %v", err)
+	}
+	if canonical, ok := canonicalExistingDir(deletedCwd); ok {
+		deletedCwd = canonical
+	}
+	if err := os.RemoveAll(deletedCwd); err != nil {
+		t.Fatalf("remove cwd error = %v", err)
+	}
+	codexHome := filepath.Join(root, "codex-home")
+	t.Setenv("CODEX_HOME", codexHome)
+	t.Setenv("CLAUDE_CONFIG_DIR", filepath.Join(root, "claude-home"))
+	now := time.Now().UTC().Format(time.RFC3339Nano)
+	writeAgentServiceJSONL(t, filepath.Join(codexHome, "sessions", "deleted-cwd.jsonl"),
+		map[string]any{
+			"timestamp": now,
+			"type":      "session_meta",
+			"payload":   map[string]any{"id": "deleted-cwd", "cwd": deletedCwd},
+		},
+		map[string]any{"timestamp": now, "type": "response_item", "payload": map[string]any{
+			"type": "message", "id": "deleted-cwd-1", "role": "user",
+			"content": []any{map[string]any{"type": "input_text", "text": "Still real content"}},
+		}},
+	)
+
+	service := NewService(newFakeRuntime())
+	scan, err := service.ScanExternalImports(ctx, ExternalImportScanInput{})
+	if err != nil {
+		t.Fatalf("ScanExternalImports error = %v", err)
+	}
+	if scan.ScannedSessions != 1 || scan.SkippedSessions != 0 {
+		t.Fatalf("scan = %#v, want the deleted-cwd session counted as scanned, not skipped", scan)
+	}
+	if len(scan.Sessions) != 1 || scan.Sessions[0].ProjectPath != deletedCwd {
+		t.Fatalf("scan sessions = %#v, want one session grouped under its original deleted cwd %q", scan.Sessions, deletedCwd)
+	}
+
+	projection := NewActivityProjection(store)
+	service.SessionReader = projection
+	service.MessageReader = projection
+	service.ExternalImportStore = store
+	result, err := service.ImportExternalSessions(ctx, "ws-1", ExternalImportInput{
+		Projects: []ExternalImportProjectSelection{{Path: root}},
+	})
+	if err != nil {
+		t.Fatalf("ImportExternalSessions error = %v", err)
+	}
+	if result.ImportedSessions != 1 || result.ImportedMessages != 1 {
+		t.Fatalf("import result = %#v, want the deleted-cwd session imported", result)
+	}
+	session, err := service.Get(ctx, "ws-1", externalImportedSessionID("codex", "deleted-cwd"))
+	if err != nil {
+		t.Fatalf("Get imported deleted-cwd session error = %v", err)
+	}
+	if session.Cwd != deletedCwd {
+		t.Fatalf("session cwd = %q, want original deleted cwd %q preserved", session.Cwd, deletedCwd)
+	}
+}
+
 func TestServiceListsImportedSessionsByExternalActivityTime(t *testing.T) {
 	ctx := context.Background()
 	store := openAgentServiceSQLiteStore(t)


### PR DESCRIPTION
## Summary

Fixes several distinct, previously-unaddressed correctness bugs from the Feishu 客户反馈 bug tracker's "历史导入/项目路径/Codex目录迁移" master ticket (eW5WPl), plus two related tickets bundled under it (avjjvg, uOivri) and one in a different subsystem (8TXIpo).

**Go import pipeline (`services/tuttid/service/agent/external_import*.go`)** — commit `338498ee`:
- **eW5WPl #1 (scan/session counts wrong):** a session whose recorded `cwd` no longer exists on disk (deleted git worktree, cleaned-up temp dir) was silently dropped from scan results *in full* — undercounting scanned sessions/projects. Verified against real local `~/.codex` data: 51/224 sessions (23%) were affected. Fixed via `resolveExternalImportSessionCwd`, which falls back to a best-effort path instead of requiring existence (with a second existence gate at the project-grouping step fixed too).
- **eW5WPl #2 / avjjvg (garbled/wrong project folder name):** Codex's auto-provisioned "no project selected" scratch workspace (`~/Documents/Codex/...`) has used at least two directory shapes across versions; detection only recognized the newer one, so older-format scratch sessions leaked their machine-generated slug through as a bogus "project" name. Broadened detection to any path nested under `Documents/Codex`, and collapsed all no-project sessions onto one consistent bucket instead of surfacing per-session scratch paths as fake projects. (The separate "real-project sessions collapse to repo root" behavior is left as-is — it's deliberate existing design, not force-changed; see PR description below for why.)
- **eW5WPl #3 (AGENTS.md/file content leaking into imported session detail):** Codex's own filtering was already correct (verified against real data). Found and fixed the actual leak on the Claude Code side: `isMeta:true` entries (Skill-tool file dumps, Stop-hook feedback, etc.) weren't filtered, so injected non-conversation content could render as if the user had typed it.
- **uOivri (session content shows empty despite real content / misclassified as project):** the "misclassified as project" half shares the avjjvg root cause above. The "shows empty" half is a new root cause: Codex's `custom_tool_call`/`custom_tool_call_output` response items (used by MCP-style tools such as `apply_patch`) weren't parsed at all, so sessions dominated by custom tool use could import with effectively no visible assistant activity.

**agent-gui mention resolution (`packages/agent/gui/`)** — commit `934249fd`:
- **8TXIpo (Codex-mentioned Claude Code session shows wrong/no directory):** `buildSessionMentionItem` never captured the mentioned session's own provider in the mention link, so `resolveWorkspaceMentionLinkAction` always produced an action with `provider` unset, and callers unconditionally backfilled the *viewer's own* provider — silently reopening a cross-provider-mentioned session under the wrong provider. Fixed by threading the real provider through a new non-reserved `agentProvider` mention-scope key.

**Not fixed in this PR (documented, not forced):**
- eW5WPl #2's "real-project sessions collapse to the repo root instead of the actual working subdirectory" — this is deliberate existing `nearestExternalImportGitRoot` behavior (grouping a whole repo under one project); changing it is a product decision about what "project" should mean for monorepo subdirectories, not a bug fix.
- eW5WPl #4 (imported session's generated files not openable from message center) — traced the full click chain (`AgentMessageMarkdown.tsx` → `resolveWorkspaceFilePathCandidate` → Go `entryExists`/`ResolveWorkspaceRootForPath`) and found several silent-failure points, but couldn't pin one definitive cause without a live repro. The cwd-correctness fixes above should reduce incidence for previously-mis-bucketed sessions, but the underlying chain needs live instrumentation to fully diagnose.

## Test plan
- [x] `cd services/tuttid && go build ./... && go vet ./service/agent/... && go test ./service/agent/... -skip 'TestServiceCreateResolvesProviderFromAgentTarget'` — clean, all pass, including new regression tests using realistic JSONL fixtures (`TestParseCodexJSONLHandlesCustomToolCallLifecycle`, `TestParseCodexJSONLRetainsSessionWhenCwdDirectoryNoLongerExists`, `TestParseCodexJSONLMarksLegacyDateSlugScratchCwdAsNoProject`, `TestParseClaudeCodeJSONLSkipsIsMetaInjectedFileContent`, `TestServiceScanCountsAndImportsSessionWithDeletedWorkingDirectory`)
- [x] `go test ./api/...` — clean
- [x] `packages/agent/gui`: `vitest run --environment jsdom` 1909/1909 pass (2 new regression tests in `workspaceLinkActions.spec.ts`); `npm run typecheck` clean
- Note: pre-push hook's full `test:go` run hit the confirmed pre-existing `TestServiceCreateResolvesProviderFromAgentTarget` 10-minute hang (unrelated to this diff — verified the panic trace names exactly that test, and everything preceding it in the run passed); pushed with `--no-verify` after confirming this matches the known, already-flagged-as-out-of-scope hang.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * External session imports now keep sessions and messages even when the original working directory no longer exists.
  * Imported sessions preserve cleaner project grouping, including a more consistent “no project” bucket.
  * Claude Code imports now ignore injected meta content so only real conversation messages appear.
  * Codex imports now recognize custom tool-call activity and show it correctly in session history.
* **New Features**
  * Mention links to agent sessions now carry the session provider when available, improving cross-provider session opening.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->