### PR TITLE
fix(tuttid): stop TestServiceCreateResolvesProviderFromAgentTarget from hanging/flaking

### DIFF
--- a/services/tuttid/service/agent/service_test.go
+++ b/services/tuttid/service/agent/service_test.go
@@ -67,6 +67,27 @@ func TestServiceCreatesAndListsSessions(t *testing.T) {
 
 func TestServiceCreateResolvesProviderFromAgentTarget(t *testing.T) {
 	runtime := newFakeRuntime()
+	// Service.Create validates the Claude composer model via a hidden live
+	// discovery session (composer_live_model_discovery.go); without a
+	// populated RuntimeContext the poll loop never sees model options and
+	// spins until the test's own timeout kills it. Supply one immediately so
+	// discovery resolves on its first check, matching the pattern used by
+	// TestServiceCreateDiscoversClaudeModelsBeforeStartingInvalidModel below.
+	runtime.startHook = func(input RuntimeStartInput, session RuntimeSession) RuntimeSession {
+		if input.Visible != nil && !*input.Visible {
+			session.RuntimeContext = map[string]any{
+				"configOptions": []any{
+					map[string]any{
+						"id": "model",
+						"options": []any{
+							map[string]any{"value": "default", "name": "Default"},
+						},
+					},
+				},
+			}
+		}
+		return session
+	}
 	service := NewService(runtime)
 	service.AgentTargetStore = fakeAgentTargetStore{
 		targets: map[string]agenttargetbiz.Target{
@@ -84,6 +105,12 @@ func TestServiceCreateResolvesProviderFromAgentTarget(t *testing.T) {
 	session, err := service.Create(context.Background(), "ws-1", CreateSessionInput{
 		AgentSessionID: "target-session-1",
 		AgentTargetID:  agenttargetbiz.IDLocalClaudeCode,
+		// Pin the model explicitly so resolveCreateSessionModel never falls
+		// through to composerDefaultModel's readClaudeCodeConfiguredDefaultModel,
+		// which reads the *real* local Claude Code CLI config file on the
+		// machine running the test — making the test's behavior depend on
+		// whatever model happens to be configured on the developer's machine.
+		Model:          stringPointer("default"),
 		InitialContent: TextPromptContent("hello target"),
 		ProviderTargetRef: map[string]any{
 			"kind":     "local_cli",
@@ -97,16 +124,29 @@ func TestServiceCreateResolvesProviderFromAgentTarget(t *testing.T) {
 	if session.Provider != "claude-code" || session.AgentTargetID != agenttargetbiz.IDLocalClaudeCode {
 		t.Fatalf("session provider/target = %q/%q, want claude-code/%s", session.Provider, session.AgentTargetID, agenttargetbiz.IDLocalClaudeCode)
 	}
-	if len(runtime.startCalls) != 1 {
-		t.Fatalf("start calls = %d, want 1", len(runtime.startCalls))
+	// Service.Create's Claude composer model validation runs a hidden
+	// (Visible=false) discovery session start in addition to the real,
+	// user-facing session start — assert against the visible one specifically
+	// rather than assuming index/count, so this doesn't re-break if discovery
+	// internals change again.
+	var visibleStart *RuntimeStartInput
+	for i := range runtime.startCalls {
+		call := runtime.startCalls[i]
+		if call.Visible == nil || *call.Visible {
+			visibleStart = &runtime.startCalls[i]
+			break
+		}
 	}
-	if got := runtime.startCalls[0].Provider; got != "claude-code" {
+	if visibleStart == nil {
+		t.Fatalf("start calls = %#v, want one visible (user-facing) start call", runtime.startCalls)
+	}
+	if got := visibleStart.Provider; got != "claude-code" {
 		t.Fatalf("runtime provider = %q, want claude-code", got)
 	}
-	if got := runtime.startCalls[0].AgentTargetID; got != agenttargetbiz.IDLocalClaudeCode {
+	if got := visibleStart.AgentTargetID; got != agenttargetbiz.IDLocalClaudeCode {
 		t.Fatalf("runtime agent target id = %q, want %s", got, agenttargetbiz.IDLocalClaudeCode)
 	}
-	ref := runtime.startCalls[0].ProviderTargetRef
+	ref := visibleStart.ProviderTargetRef
 	if ref["kind"] != agenttargetbiz.LaunchRefTypeLocalCLI ||
 		ref["provider"] != "claude-code" ||
 		ref["targetId"] != agenttargetbiz.IDLocalClaudeCode {


### PR DESCRIPTION
## Problem

`TestServiceCreateResolvesProviderFromAgentTarget` hangs for the full 10-minute `go test` default timeout (or panics once `-timeout` is hit), blocking the `check:full` pre-push hook for anyone whose branch touches `services/tuttid`. This has been independently rediscovered and worked around (via `-skip` or `--no-verify`) across at least 7 separate pushes in one afternoon.

## Root cause — two distinct bugs, both in the test itself, not production code

1. `fakeRuntime.Start` never populates `RuntimeContext` or a `"failed"` `Status` on the session it returns. `Service.Create`'s Claude composer model validation path (added by `ecf73863`, "require verified Claude composer models") starts a hidden discovery session and polls `pollComposerModelOptions` (`composer_live_model_discovery.go:135`) waiting for `RuntimeContext` to carry model options, or the session to fail. With the fake runtime returning neither, the poll's exit conditions are never met and it spins forever.
2. Independently, this test relies on `CreateSessionInput.Model` being empty, which makes `resolveCreateSessionModel` fall through to `composerDefaultModel` → `readClaudeCodeConfiguredDefaultModel` — a function that reads the **real local Claude Code CLI config file** on the machine running the test. This makes the test's behavior depend on whatever model happens to be configured on the developer's machine (confirmed: on this machine it resolves to a locally-configured model, which then fails `InvalidModelError` validation against the fake's empty model list once bug 1 is fixed and the poll actually returns).

Together this explains why the hang reproduces identically for every developer who's hit it (bug 1), and why a naive fix that only addresses the poll immediately surfaces a second, environment-dependent failure (bug 2) — which is why prior investigations correctly found the hang but never got far enough to see bug 2.

## Fix

- Added a `startHook` to the test's `fakeRuntime` supplying a minimal `RuntimeContext` with model config options for the hidden discovery session specifically (matching the pattern already used by the neighboring `TestServiceCreateDiscoversClaudeModelsBeforeStartingInvalidModel`), so the poll resolves on its first check.
- Pinned `CreateSessionInput.Model` explicitly instead of leaving it empty, so model resolution never falls through to reading real local machine state.
- Updated the start-call assertions to find the visible (user-facing) start call specifically rather than assuming index 0 / count == 1 — the hidden discovery session is a second, legitimate `Start` call the original assertions predate (written before `ecf73863` added the discovery path).

## Tests

- `go test ./service/agent/... -run TestServiceCreateResolvesProviderFromAgentTarget -count=5 -v`: 5/5 pass in 0.2s total (previously: hang/timeout).
- `go test ./service/agent/...`: full package suite green in 23s.
- `go build ./...`, `go vet ./...`, `gofmt -l`: clean.
- Verified the hang reproduces identically on a clean, unmodified `origin/main` checkout in an isolated worktree before making any change, confirming this is a genuine pre-existing bug unrelated to any other in-flight branch.
- This PR itself pushed through the full `check:full` pre-push hook with **no bypass** — the best possible confirmation the fix works end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)