### PR TITLE
fix(desktop): re-resolve tuttid daemon base URL on every renderer request

### DIFF
--- a/apps/desktop/src/renderer/src/platform/tuttid/createDesktopTuttidClient.test.ts
+++ b/apps/desktop/src/renderer/src/platform/tuttid/createDesktopTuttidClient.test.ts
@@ -68,3 +68,52 @@ test("createDesktopTuttidClient forwards workspace agent session query params", 
     sectionKey: "project:/workspace/project"
   });
 });
+
+test("createDesktopTuttidClient re-resolves the daemon base URL after it changes (e.g. daemon restart)", async () => {
+  const requestedBaseUrls: string[] = [];
+  const originalFetch = globalThis.fetch;
+
+  globalThis.fetch = async (input, init) => {
+    const request = input instanceof Request ? input : new Request(input, init);
+    requestedBaseUrls.push(new URL(request.url).origin);
+
+    return new Response(
+      JSON.stringify({ hasMore: false, sessions: [], workspaceId: "ws-1" }),
+      { headers: { "content-type": "application/json" }, status: 200 }
+    );
+  };
+
+  let currentBaseUrl = "http://127.0.0.1:18080";
+
+  try {
+    const client = createDesktopTuttidClient({
+      getBackendConfig: async () => ({
+        accessToken: "test-token",
+        baseUrl: currentBaseUrl
+      })
+    } as DesktopRuntimeApi);
+
+    await client.listWorkspaceAgentSessionSectionPage(
+      "ws-1",
+      { agentTargetId: "claude-target", limit: 30, sectionKey: "s" },
+      {}
+    );
+
+    // Simulate the managed tuttid daemon dying and being respawned on a new
+    // ephemeral port, as happens on crash/update-relaunch recovery.
+    currentBaseUrl = "http://127.0.0.1:19090";
+
+    await client.listWorkspaceAgentSessionSectionPage(
+      "ws-1",
+      { agentTargetId: "claude-target", limit: 30, sectionKey: "s" },
+      {}
+    );
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+
+  assert.deepEqual(requestedBaseUrls, [
+    "http://127.0.0.1:18080",
+    "http://127.0.0.1:19090"
+  ]);
+});

--- a/apps/desktop/src/renderer/src/platform/tuttid/createDesktopTuttidClient.ts
+++ b/apps/desktop/src/renderer/src/platform/tuttid/createDesktopTuttidClient.ts
@@ -3,22 +3,38 @@ import {
   type TuttidClient
 } from "@tutti-os/client-tuttid-ts";
 import type { DesktopRuntimeApi } from "@preload/types";
+import type { DesktopBackendConfig } from "@shared/contracts/ipc";
 
 export function createDesktopTuttidClient(
   runtimeApi: DesktopRuntimeApi
 ): TuttidClient {
-  let clientPromise: Promise<TuttidClient> | null = null;
+  let cachedConfig: DesktopBackendConfig | null = null;
+  let cachedClient: TuttidClient | null = null;
 
+  // The managed tuttid daemon can restart (crash recovery, forced update
+  // relaunch, etc.) and rebinds to a new ephemeral port each time it comes
+  // back up. getBackendConfig() is a cheap main-process IPC read (no network
+  // I/O), so we re-check it on every call and only rebuild the underlying
+  // client when the resolved endpoint actually changed. Caching the client
+  // (and therefore its baseUrl) for the lifetime of the renderer would leave
+  // every request silently pointed at a dead port after a daemon restart.
   const resolveClient = async (): Promise<TuttidClient> => {
-    clientPromise ??= runtimeApi.getBackendConfig().then((config) =>
-      createTuttidClient({
+    const config = await runtimeApi.getBackendConfig();
+    if (
+      !cachedClient ||
+      !cachedConfig ||
+      cachedConfig.baseUrl !== config.baseUrl ||
+      cachedConfig.accessToken !== config.accessToken
+    ) {
+      cachedConfig = config;
+      cachedClient = createTuttidClient({
         auth: config.accessToken,
         baseUrl: config.baseUrl,
         fetch: globalThis.fetch.bind(globalThis)
-      })
-    );
+      });
+    }
 
-    return clientPromise;
+    return cachedClient;
   };
 
   return {


### PR DESCRIPTION
## Summary
- Fixes 客户反馈 ticket `recvonI8hU1PRd` (P0): "codex发消息报错" (Codex message send fails).
- `createDesktopTuttidClient` cached the resolved backend config (base URL + access token) for the lifetime of the renderer window via `clientPromise ??= ...`. When the managed `tuttid` daemon restarts (crash recovery, forced update relaunch, etc.) it rebinds to a new ephemeral port, but the renderer kept sending every subsequent request to the old, now-dead port until the whole window reloaded.
- Root-caused from a user-submitted diagnostic log bundle: `tuttid` received SIGTERM and respawned on a new port, immediately followed by a string of `send_prompt` / `create_conversation` failures reported by the renderer that never show up anywhere in the daemon's own log (because the requests never reached the new port at all).
- Fix: re-check `getBackendConfig()` on every call (it's a cheap main-process IPC read, no network I/O) and only rebuild the underlying `TuttidClient` when the resolved base URL/token actually changed — matching the pattern already used correctly by `desktopWorkspaceSettingsClient`'s `requestDaemon()` helper, which does not have this bug.

## Test plan
- [x] Added a regression test that simulates a daemon restart (backend config's `baseUrl` changing between two calls) and asserts the client issues the second request to the new URL; verified it fails against the pre-fix code and passes with the fix.
- [x] `node --test` on `apps/desktop/src/renderer/src/platform/**/*.test.ts` — all pass.
- [x] `pnpm --filter apps/desktop typecheck` — clean.
- [x] `git push` full check (`check:full`, Go + TS) — passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when the desktop backend restarts, so requests are sent to the current service address instead of a stale one.
  * Prevents failures that could occur after the backend reconnects on a new port, helping features continue working without needing an app restart.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->