### PR TITLE
fix(file-manager): distinct hover/press feedback for file rows

### DIFF
--- a/packages/workspace/file-manager/src/ui/WorkspaceFileManagerIconGrid.tsx
+++ b/packages/workspace/file-manager/src/ui/WorkspaceFileManagerIconGrid.tsx
@@ -182,7 +182,7 @@ function WorkspaceFileManagerIconTile({
     "flex min-w-0 max-w-[148px] flex-col items-center gap-1.5 rounded-md border border-transparent px-2 py-2 text-center transition-colors",
     isInlineRenaming
       ? "cursor-default"
-      : "cursor-pointer hover:bg-transparency-block",
+      : "cursor-pointer hover:bg-transparency-hover active:bg-[var(--transparency-active)]",
     moveDragActive && "cursor-grabbing",
     selected || contextMenuActive || isInlineRenaming
       ? "border-[var(--border-focus)] bg-transparency-block text-[var(--text-primary)]"

--- a/packages/workspace/file-manager/src/ui/WorkspaceFileManagerPanels.tsx
+++ b/packages/workspace/file-manager/src/ui/WorkspaceFileManagerPanels.tsx
@@ -898,7 +898,7 @@ function EntryRow({
     gridClassName,
     isInlineRenaming
       ? "cursor-default"
-      : "cursor-pointer hover:bg-transparency-block",
+      : "cursor-pointer hover:bg-transparency-hover active:bg-[var(--transparency-active)]",
     canMove && moveDragActive && "cursor-grabbing",
     selected || contextMenuActive || isInlineRenaming
       ? "bg-transparency-block text-[var(--text-primary)]"

--- a/packages/workspace/file-manager/src/ui/workspaceFileManagerRowInteractionStyles.test.ts
+++ b/packages/workspace/file-manager/src/ui/workspaceFileManagerRowInteractionStyles.test.ts
@@ -1,0 +1,57 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { readFileSync } from "node:fs";
+
+// Regression coverage for the file manager's row/tile interaction feedback
+// (hover, selected, pressed). Before this fix, hover and selected both
+// resolved to the same `--transparency-block` token (indistinguishable) and
+// there was no press/active feedback at all. See bug 8l4JLW.
+function readComponentSource(fileName: string) {
+  return readFileSync(new URL(`./${fileName}`, import.meta.url), "utf8");
+}
+
+// Extracts the `const <name> = cn(...)` call body so assertions target the
+// row/tile's own class list rather than unrelated nested controls (e.g. the
+// expand/collapse chevron button) that happen to share token names.
+function extractClassNameBuilder(source: string, constName: string): string {
+  const startMarker = `const ${constName} = cn(`;
+  const start = source.indexOf(startMarker);
+  assert.ok(start >= 0, `expected to find "${startMarker}"`);
+  const bodyStart = start + startMarker.length;
+  let depth = 1;
+  let index = bodyStart;
+  while (depth > 0 && index < source.length) {
+    const char = source[index];
+    if (char === "(") depth++;
+    if (char === ")") depth--;
+    index++;
+  }
+  return source.slice(bodyStart, index - 1);
+}
+
+const targets: Array<{ fileName: string; constName: string }> = [
+  { fileName: "WorkspaceFileManagerPanels.tsx", constName: "rowClassName" },
+  { fileName: "WorkspaceFileManagerIconGrid.tsx", constName: "tileClassName" }
+];
+
+for (const { fileName, constName } of targets) {
+  test(`${fileName} ${constName} has distinct hover, selected, and pressed feedback`, () => {
+    const source = extractClassNameBuilder(
+      readComponentSource(fileName),
+      constName
+    );
+
+    // Hover uses a stronger token than the persistent "selected" background
+    // so hovering an unselected row is visibly different from selecting it.
+    assert.match(source, /hover:bg-transparency-hover/);
+
+    // Selected/persisted state keeps the existing token.
+    assert.match(source, /bg-transparency-block/);
+
+    // Press/click feedback must exist (previously entirely absent).
+    assert.match(source, /active:bg-\[var\(--transparency-active\)\]/);
+
+    // Hover and selected must not resolve to the same token string.
+    assert.doesNotMatch(source, /hover:bg-transparency-block(?!\S)/);
+  });
+}


### PR DESCRIPTION
## Summary
- The file manager's row (list view) and tile (icon-grid view) used the same `--transparency-block` token for both hover and the persistent selected state, making hover feedback nearly invisible and indistinguishable from selection.
- There was no press/click (`:active`) feedback at all.
- Switches hover to the stronger `--transparency-hover` token and adds `active:bg-[var(--transparency-active)]` for press feedback, matching the existing three-tier interaction pattern already used by `button.tsx`'s `chrome` variant. Selected state is unchanged (`--transparency-block`).

Fixes bug 8l4JLW (文件管理器 hover, 選中，點擊沒有明確交互反饋), P1, 文件中心.

## Test plan
- [x] Added `packages/workspace/file-manager/src/ui/workspaceFileManagerRowInteractionStyles.test.ts` — regression coverage asserting the row/tile class builders use distinct hover/selected/active tokens.
- [x] `node --test --experimental-strip-types "./src/**/*.test.ts"` in `packages/workspace/file-manager` — 141/141 pass.
- [x] Package typecheck (`run-tsgo-typecheck.mjs`) — clean.
- [x] `oxlint` on changed files — clean.
- [x] `git push` pre-push hook (`check:full`, including Go tests) — passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)