### PR TITLE
fix(agent-gui): message-center ask-user options, unread-badge, and web-fetch approval details

### DIFF
--- a/packages/agent/gui/agent-gui/agentGuiNode/AgentInteractivePromptSurface.spec.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/AgentInteractivePromptSurface.spec.tsx
@@ -1260,6 +1260,93 @@ describe("AgentInteractivePromptSurface", () => {
     ).toBeNull();
   });
 
+  it("shows read-only options for a compact multi-select ask-user prompt instead of hiding them", () => {
+    const onSubmit = vi.fn();
+    render(
+      <AgentInteractivePromptSurface
+        prompt={{
+          kind: "ask-user",
+          requestId: "ask-req-multi",
+          title: "Plan topic",
+          questions: [
+            {
+              id: "areas",
+              header: "Areas",
+              question: "Which areas need review?",
+              options: [
+                { label: "Backend", description: "API surface" },
+                { label: "Frontend", description: "UI surface" }
+              ],
+              multiSelect: true,
+              answer: null
+            }
+          ]
+        }}
+        variant="compact"
+        isSubmitting={false}
+        onSubmit={onSubmit}
+        labels={labels}
+      />
+    );
+
+    // Multi-select can't be answered with a single click here, but the
+    // options must still be visible (not silently dropped) as read-only
+    // context — the message-center card regression this guards against.
+    expect(screen.getByText("Backend")).toBeTruthy();
+    expect(screen.getByText("API surface")).toBeTruthy();
+    expect(screen.getByText("Frontend")).toBeTruthy();
+    expect(screen.queryByRole("button", { name: /Backend/ })).toBeNull();
+    expect(
+      screen
+        .getByText("Backend")
+        .closest(".agent-gui-conversation__interactive-option-display")
+    ).toBeTruthy();
+    expect(onSubmit).not.toHaveBeenCalled();
+  });
+
+  it("shows read-only options for the current compact multi-question ask-user prompt", () => {
+    render(
+      <AgentInteractivePromptSurface
+        prompt={{
+          kind: "ask-user",
+          requestId: "ask-req-multi-question",
+          title: "Rollout plan",
+          questions: [
+            {
+              id: "scope",
+              header: "Scope",
+              question: "Which scope should we use?",
+              options: [
+                { label: "Small", description: "Minimal change" },
+                { label: "Large", description: "Broader cleanup" }
+              ],
+              multiSelect: false,
+              answer: null
+            },
+            {
+              id: "details",
+              header: "Details",
+              question: "Anything else to include?",
+              options: [],
+              multiSelect: false,
+              answer: null
+            }
+          ]
+        }}
+        variant="compact"
+        isSubmitting={false}
+        onSubmit={vi.fn()}
+        labels={labels}
+      />
+    );
+
+    // Multiple questions also defer answering to the full conversation, but
+    // the first question's options should still surface as read-only.
+    expect(screen.getByText("Small")).toBeTruthy();
+    expect(screen.getByText("Large")).toBeTruthy();
+    expect(screen.queryByRole("button", { name: /Small/ })).toBeNull();
+  });
+
   it("offers only the implement decision for a compact plan-implementation prompt", () => {
     const onSubmit = vi.fn();
     render(

--- a/packages/agent/gui/shared/agentConversation/components/AgentInteractivePromptSurface.tsx
+++ b/packages/agent/gui/shared/agentConversation/components/AgentInteractivePromptSurface.tsx
@@ -161,7 +161,8 @@ export function AgentInteractivePromptSurface({
 // click — selecting an option submits it immediately, matching the approval and
 // plan cards. Multi-select / multi-question / free-text-only prompts can't be
 // answered in one tap, so they defer to the conversation (the card's "open
-// conversation" jump), showing just the question for context.
+// conversation" jump); their options are still shown as read-only context
+// (see the non-oneClickable branch below) rather than being omitted.
 function CompactAskUserPromptSurface({
   prompt,
   embedded = false,
@@ -226,6 +227,29 @@ function CompactAskUserPromptSurface({
                       </span>
                     ) : null}
                   </button>
+                ))}
+              </div>
+            ) : question.options.length > 0 ? (
+              // Multi-select / multi-question prompts can't be answered with a
+              // single click here, so the options are shown as read-only
+              // context instead of being silently omitted. Answering still
+              // happens in the full conversation via the card's "open
+              // conversation" jump.
+              <div className={styles.interactivePromptOptions}>
+                {question.options.map((option) => (
+                  <div
+                    key={option.label}
+                    className={styles.interactiveOptionDisplay}
+                  >
+                    <span className={styles.interactiveOptionTitle}>
+                      {option.label}
+                    </span>
+                    {option.description ? (
+                      <span className={styles.interactiveOptionDescription}>
+                        {option.description}
+                      </span>
+                    ) : null}
+                  </div>
                 ))}
               </div>
             ) : null}

--- a/packages/agent/gui/shared/agentConversation/components/tool-renderers/AgentApprovalContent.tsx
+++ b/packages/agent/gui/shared/agentConversation/components/tool-renderers/AgentApprovalContent.tsx
@@ -1,6 +1,11 @@
 import type { JSX } from "react";
-import type { AgentToolCallVM } from "../../contracts/agentToolCallVM";
+import type {
+  AgentToolCallVM,
+  AgentToolRendererKind
+} from "../../contracts/agentToolCallVM";
 import { AgentEditContent } from "./AgentEditContent";
+import { AgentWebFetchContent } from "./AgentWebFetchContent";
+import { AgentWebSearchContent } from "./AgentWebSearchContent";
 import {
   arrayValue,
   objectValue,
@@ -19,13 +24,56 @@ export function AgentApprovalContent({
     return null;
   }
   if (previewCall) {
-    return <AgentEditContent call={previewCall} onLinkClick={onLinkClick} />;
+    switch (previewCall.rendererKind) {
+      case "web-fetch":
+        return (
+          <AgentWebFetchContent call={previewCall} onLinkClick={onLinkClick} />
+        );
+      case "web-search":
+        return (
+          <AgentWebSearchContent call={previewCall} onLinkClick={onLinkClick} />
+        );
+      default:
+        return (
+          <AgentEditContent call={previewCall} onLinkClick={onLinkClick} />
+        );
+    }
   }
   return (
     <div className="workspace-agents-status-panel__detail-tool-body">
       <ToolMarkdownBlock content={call.summary} />
     </div>
   );
+}
+
+interface ApprovalPreviewKind {
+  rendererKind: AgentToolRendererKind;
+  toolName: string;
+}
+
+// The nested tool-call's `kind` follows the ACP vocabulary (edit/move/fetch/...)
+// when the provider sends it (e.g. Codex); Claude Code omits `kind` and only
+// sets `title`/`toolName` to the canonical tool name (e.g. "WebFetch"), so
+// both vocabularies are matched here.
+function approvalPreviewKindFor(
+  normalizedKind: string
+): ApprovalPreviewKind | null {
+  switch (normalizedKind) {
+    case "edit":
+    case "move":
+      return { rendererKind: "edit", toolName: "Edit" };
+    case "fetch":
+    case "webfetch":
+    case "web_fetch":
+    case "web-fetch":
+      return { rendererKind: "web-fetch", toolName: "WebFetch" };
+    case "websearch":
+    case "web_search":
+    case "web-search":
+      return { rendererKind: "web-search", toolName: "WebSearch" };
+    default:
+      return null;
+  }
 }
 
 function approvalPreviewCall(call: AgentToolCallVM): AgentToolCallVM | null {
@@ -38,7 +86,8 @@ function approvalPreviewCall(call: AgentToolCallVM): AgentToolCallVM | null {
       stringValue(toolCall.title) ??
       stringValue(toolCall.toolName)
   );
-  if (normalizedKind !== "edit" && normalizedKind !== "move") {
+  const preview = approvalPreviewKindFor(normalizedKind);
+  if (!preview) {
     return null;
   }
   const input = objectValue(toolCall.rawInput) ?? objectValue(toolCall.input);
@@ -49,7 +98,7 @@ function approvalPreviewCall(call: AgentToolCallVM): AgentToolCallVM | null {
     id: `${call.id}:approval-preview`,
     turnId: call.turnId,
     name: stringValue(toolCall.title) ?? call.name,
-    toolName: "Edit",
+    toolName: preview.toolName,
     callType: "tool",
     status: stringValue(toolCall.status) ?? call.status,
     statusKind: call.statusKind,
@@ -67,7 +116,7 @@ function approvalPreviewCall(call: AgentToolCallVM): AgentToolCallVM | null {
     metadata: null,
     content,
     locations,
-    rendererKind: "edit",
+    rendererKind: preview.rendererKind,
     approval: null,
     planMode: null,
     askUserQuestion: null,

--- a/packages/agent/gui/shared/agentConversation/components/tool-renderers/AgentExpandedToolContent.spec.tsx
+++ b/packages/agent/gui/shared/agentConversation/components/tool-renderers/AgentExpandedToolContent.spec.tsx
@@ -127,6 +127,76 @@ describe("AgentExpandedToolContent", () => {
     expect(screen.queryByText("Allow once")).toBeNull();
   });
 
+  it("renders web fetch URL details in a Claude Code web-read approval dialog", async () => {
+    setAgentGuiI18nTestLocale("en");
+
+    // Claude Code's approval payload has no ACP `kind` field — the nested
+    // toolCall is identified only by `title`/`toolName` ("WebFetch"), unlike
+    // Codex's ACP `kind: "fetch"`. Both must resolve to the web-fetch
+    // renderer instead of the bare summary fallback.
+    render(
+      <AgentExpandedToolContent
+        call={projectAgentToolCall(
+          toolCall({
+            callType: "approval",
+            toolName: "Approval",
+            status: "Completed",
+            statusKind: "completed",
+            payload: {
+              input: {
+                options: [{ id: "allow_once", label: "Allow once" }],
+                toolCall: {
+                  title: "WebFetch",
+                  toolName: "WebFetch",
+                  rawInput: {
+                    url: "https://docs.example.com/guide",
+                    prompt: "Summarize the guide"
+                  }
+                }
+              }
+            }
+          })
+        )}
+      />
+    );
+
+    expect(screen.getByText("URL")).toBeTruthy();
+    expect(screen.getByText("docs.example.com")).toBeTruthy();
+    expect(screen.getByText("https://docs.example.com/guide")).toBeTruthy();
+  });
+
+  it("renders web fetch URL details in an ACP (Codex) web-read approval dialog", async () => {
+    setAgentGuiI18nTestLocale("en");
+
+    render(
+      <AgentExpandedToolContent
+        call={projectAgentToolCall(
+          toolCall({
+            callType: "approval",
+            toolName: "Approval",
+            status: "Completed",
+            statusKind: "completed",
+            payload: {
+              input: {
+                options: [{ id: "allow_once", label: "Allow once" }],
+                toolCall: {
+                  kind: "fetch",
+                  title: "open_page",
+                  rawInput: {
+                    url: "https://docs.example.com/guide"
+                  }
+                }
+              }
+            }
+          })
+        )}
+      />
+    );
+
+    expect(screen.getByText("URL")).toBeTruthy();
+    expect(screen.getByText("docs.example.com")).toBeTruthy();
+  });
+
   it("renders ask-user options and selected answer from the typed ask-user vm", async () => {
     setAgentGuiI18nTestLocale("en");
 

--- a/services/tuttid/service/agent/service_session.go
+++ b/services/tuttid/service/agent/service_session.go
@@ -161,9 +161,57 @@ func mergePersistedSessionState(session Session, persisted PersistedSession) Ses
 	session.PermissionConfig = composerPermissionConfig(session.Provider, permissionModeIDFromSettings(session.Settings), preferencesbiz.DefaultDesktopLocale)
 	if len(session.RuntimeContext) == 0 {
 		session.RuntimeContext = clonePayload(persisted.RuntimeContext)
+	} else {
+		session.RuntimeContext = mergeImportRuntimeContextFields(session.RuntimeContext, persisted.RuntimeContext)
 	}
 	session.PinnedAtUnixMS = persisted.PinnedAtUnixMS
 	return session
+}
+
+// importRuntimeContextFields are the import-classification markers written
+// once at import time (see external_import.go's ReportSessionState call).
+// They are a Tutti-app-level annotation, not part of the underlying provider
+// adapter's own runtime bookkeeping, so a live RuntimeSession's RuntimeContext
+// never sets them itself.
+var importRuntimeContextFields = []string{
+	"imported",
+	"externalImportNoProject",
+	"externalSourcePath",
+}
+
+// mergeImportRuntimeContextFields carries the import-classification markers
+// forward onto a live runtime session's RuntimeContext. Without this, once an
+// imported session is opened/resumed into a live RuntimeSession, its live
+// RuntimeContext is non-empty (it carries the adapter's own bookkeeping), so
+// the all-or-nothing swap above never runs — silently dropping
+// "imported": true from the projected Session. The frontend's unread-badge
+// guard depends on that flag staying set, so losing it made a read imported
+// Codex session's unread badge reappear once its runtime session activated.
+func mergeImportRuntimeContextFields(live map[string]any, persisted map[string]any) map[string]any {
+	if len(persisted) == 0 {
+		return live
+	}
+	merged := live
+	cloned := false
+	for _, key := range importRuntimeContextFields {
+		if _, ok := merged[key]; ok {
+			continue
+		}
+		value, ok := persisted[key]
+		if !ok {
+			continue
+		}
+		if !cloned {
+			next := make(map[string]any, len(live)+len(importRuntimeContextFields))
+			for k, v := range live {
+				next[k] = v
+			}
+			merged = next
+			cloned = true
+		}
+		merged[key] = clonePayloadValue(value)
+	}
+	return merged
 }
 
 func permissionModeIDFromSettings(settings *ComposerSettings) string {

--- a/services/tuttid/service/agent/service_session_test.go
+++ b/services/tuttid/service/agent/service_session_test.go
@@ -1,0 +1,106 @@
+package agent
+
+import "testing"
+
+// TestMergePersistedSessionStatePreservesImportedFlagWithLiveRuntimeContext
+// guards against a regression where opening/resuming an imported Codex or
+// Claude Code session dropped the "imported" RuntimeContext marker the
+// moment the runtime controller held a live RuntimeSession for it. The
+// frontend's unread-completion badge is explicitly suppressed for imported
+// sessions (see agentGuiConversationListStore.ts's `isImported !== true`
+// guard), so losing the marker made a just-read historical session's unread
+// badge reappear once its runtime session activated.
+func TestMergePersistedSessionStatePreservesImportedFlagWithLiveRuntimeContext(t *testing.T) {
+	persisted := PersistedSession{
+		RuntimeContext: map[string]any{
+			"imported":                true,
+			"externalImportNoProject": true,
+			"externalSourcePath":      "/home/user/.codex/sessions/abc.jsonl",
+		},
+	}
+	// A live RuntimeSession's own RuntimeContext is never empty in practice
+	// (it carries the adapter's own bookkeeping), which is what defeats the
+	// all-or-nothing "only fill in when empty" swap this merge used to rely
+	// on exclusively.
+	live := Session{
+		RuntimeContext: map[string]any{
+			"visible": true,
+		},
+	}
+
+	merged := mergePersistedSessionState(live, persisted)
+
+	if merged.RuntimeContext["imported"] != true {
+		t.Fatalf("RuntimeContext = %#v, want imported preserved from persisted state", merged.RuntimeContext)
+	}
+	if merged.RuntimeContext["externalImportNoProject"] != true {
+		t.Fatalf("RuntimeContext = %#v, want externalImportNoProject preserved from persisted state", merged.RuntimeContext)
+	}
+	if merged.RuntimeContext["externalSourcePath"] != "/home/user/.codex/sessions/abc.jsonl" {
+		t.Fatalf("RuntimeContext = %#v, want externalSourcePath preserved from persisted state", merged.RuntimeContext)
+	}
+	if merged.RuntimeContext["visible"] != true {
+		t.Fatalf("RuntimeContext = %#v, want live runtime's own keys kept", merged.RuntimeContext)
+	}
+}
+
+// TestMergePersistedSessionStateDoesNotOverrideLiveImportFields ensures the
+// merge never clobbers a live RuntimeContext value with a persisted one for
+// the same key — it only fills in markers the live context doesn't already
+// have an opinion on.
+func TestMergePersistedSessionStateDoesNotOverrideLiveImportFields(t *testing.T) {
+	persisted := PersistedSession{
+		RuntimeContext: map[string]any{
+			"imported": true,
+		},
+	}
+	live := Session{
+		RuntimeContext: map[string]any{
+			"imported": false,
+		},
+	}
+
+	merged := mergePersistedSessionState(live, persisted)
+
+	if merged.RuntimeContext["imported"] != false {
+		t.Fatalf("RuntimeContext = %#v, want live's own imported value kept as-is", merged.RuntimeContext)
+	}
+}
+
+// TestMergePersistedSessionStateStillFillsEmptyLiveRuntimeContext keeps the
+// original all-or-nothing behavior intact for sessions whose live
+// RuntimeContext is genuinely empty (e.g. a freshly attached runtime that
+// hasn't reported anything yet).
+func TestMergePersistedSessionStateStillFillsEmptyLiveRuntimeContext(t *testing.T) {
+	persisted := PersistedSession{
+		RuntimeContext: map[string]any{
+			"imported": true,
+			"visible":  true,
+		},
+	}
+	live := Session{}
+
+	merged := mergePersistedSessionState(live, persisted)
+
+	if merged.RuntimeContext["imported"] != true || merged.RuntimeContext["visible"] != true {
+		t.Fatalf("RuntimeContext = %#v, want full persisted context copied when live context is empty", merged.RuntimeContext)
+	}
+}
+
+// TestMergePersistedSessionStateHandlesEmptyPersistedRuntimeContext ensures a
+// live RuntimeSession that never came from an import (no persisted
+// RuntimeContext at all) is left untouched.
+func TestMergePersistedSessionStateHandlesEmptyPersistedRuntimeContext(t *testing.T) {
+	persisted := PersistedSession{}
+	live := Session{
+		RuntimeContext: map[string]any{
+			"visible": true,
+		},
+	}
+
+	merged := mergePersistedSessionState(live, persisted)
+
+	if len(merged.RuntimeContext) != 1 || merged.RuntimeContext["visible"] != true {
+		t.Fatalf("RuntimeContext = %#v, want live context unchanged", merged.RuntimeContext)
+	}
+}


### PR DESCRIPTION
## Summary

Three P1 bugs from the 客户反馈 tracker, all under Agent GUI's message center / approval popups:

- **qk5N7k** — AskUserQuestion的等待卡片在消息中心没显示选项. The message center's compact ask-user card (`AgentInteractivePromptSurface.tsx`'s `CompactAskUserPromptSurface`) only rendered options when the prompt was a single, single-select question ("one-click submit"). Any multi-question or multi-select prompt hid the options entirely instead of showing them read-only. Now options render as read-only context whenever they can't be answered with one click, instead of being omitted.
- **cugQoD** — coedx历史会话消息已读后，过会再看历史列表仍会显示未读提醒. Root cause: `mergePersistedSessionState` (services/tuttid/service/agent/service_session.go) only copied the persisted `RuntimeContext` — which carries the `imported: true` classification flag written at import time — onto a live `RuntimeSession`'s projected `Session` when the live context was completely empty. Once an imported Codex/Claude Code session is opened and gets a live `RuntimeSession`, its own `RuntimeContext` is never empty, so the "imported" flag silently dropped out of the session the app reads back. The frontend's unread-completion badge is explicitly suppressed for `isImported === true` conversations, so losing that flag let the badge reappear for a session the user had already read. Fixed by always carrying the import-classification keys forward instead of an all-or-nothing swap.
- **ePcyCk** — claude code授权弹窗未显示读取网页的命令. `AgentApprovalContent`'s preview builder only special-cased `edit`/`move` tool kinds; every other kind (including WebFetch) fell back to `call.summary`, which Claude Code leaves empty for pending approvals. Distinct from (and not covered by) the still-unmerged PR #622, which generalizes the *fallback* path but doesn't route web-fetch/web-search approvals to their dedicated renderers either. Fixed by recognizing `fetch`/`webfetch` and `search`/`websearch` kinds (matching both the ACP `kind` vocabulary and Claude Code's toolName-only vocabulary) and rendering them through the existing `AgentWebFetchContent`/`AgentWebSearchContent` renderers.

## Test plan

- [x] `pnpm exec vitest run --environment jsdom` in `packages/agent/gui` — 1927/1927 passing (full package suite, includes the new/updated specs for qk5N7k and ePcyCk)
- [x] `pnpm run typecheck` in `packages/agent/gui` — clean
- [x] `go test ./...` in `services/tuttid/service/agent` — all passing, including 4 new tests covering `mergePersistedSessionState`'s import-flag preservation (cugQoD)
- [x] `go vet ./...` and `go build ./...` — clean
- [x] `gofmt -l` / `oxlint` on changed files — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)