### PR TITLE
fix(agent-gui): composer @ mention tooltip + Enter-on-empty-results contract

### DIFF
--- a/packages/agent/gui/agent-gui/agentGuiNode/AgentComposer.spec.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/AgentComposer.spec.tsx
@@ -3652,6 +3652,63 @@ describe("AgentComposer", () => {
     expect(onDraftContentChange).not.toHaveBeenCalled();
   });
 
+  it("cancels an empty-result @ search on Enter instead of sending, then sends on the next Enter", () => {
+    // A non-empty query (rather than a bare "@") puts the mention search in
+    // "results" mode, matching the reported scenario: the user typed @ plus
+    // some text and the search resolved to zero matches. No providers are
+    // wired up in this test, so it deterministically has no results.
+    let draftContent = createDraft("@doesnotexist12345");
+    const onDraftContentChange = vi.fn((nextDraft: AgentComposerDraft) => {
+      draftContent = nextDraft;
+    });
+    const onSubmit = vi.fn();
+
+    render(
+      <AgentComposer
+        workspaceId="workspace-1"
+        currentUserId="user-1"
+        provider="codex"
+        draftContent={draftContent}
+        availableCommands={[] satisfies readonly AgentHostAgentSessionCommand[]}
+        disabled={false}
+        submitDisabled={false}
+        placeholder="placeholder"
+        composerSettings={createComposerSettings()}
+        queuedPrompts={[]}
+        drainingQueuedPromptId={null}
+        canQueueWhileBusy={false}
+        showStopButton={false}
+        activePrompt={null}
+        isInterrupting={false}
+        isSendingTurn={false}
+        isSubmittingPrompt={false}
+        labels={createLabels()}
+        workspaceUserProjectI18n={workspaceUserProjectI18n}
+        onDraftContentChange={onDraftContentChange}
+        onSettingsChange={vi.fn()}
+        onSubmit={onSubmit}
+        onSendQueuedPromptNext={vi.fn()}
+        onRemoveQueuedPrompt={vi.fn()}
+        onEditQueuedPrompt={vi.fn()}
+        onInterruptCurrentTurn={vi.fn()}
+        onSubmitInteractivePrompt={vi.fn()}
+      />
+    );
+
+    const textbox = screen.getByPlaceholderText("placeholder");
+
+    // The first Enter should dismiss the empty panel rather than send — the
+    // typed "@doesnotexist12345" text stays untouched.
+    fireEvent.keyDown(textbox, { key: "Enter" });
+    expect(onSubmit).not.toHaveBeenCalled();
+    expect(draftContent.prompt).toBe("@doesnotexist12345");
+
+    // With the search cancelled, the next Enter behaves as if there were no
+    // active @ context and sends the message normally.
+    fireEvent.keyDown(textbox, { key: "Enter" });
+    expect(onSubmit).toHaveBeenCalled();
+  });
+
   it("opens the mention palette from the @ footer button", async () => {
     let draftContent = createDraft("");
     const onDraftContentChange = vi.fn((nextDraft: AgentComposerDraft) => {

--- a/packages/agent/gui/agent-gui/agentGuiNode/AgentComposer.spec.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/AgentComposer.spec.tsx
@@ -2442,6 +2442,46 @@ describe("AgentComposer", () => {
     ).toBeNull();
   });
 
+  it("shows a hover tooltip explaining the mention (@) button", async () => {
+    render(
+      <AgentComposer
+        workspaceId="workspace-1"
+        currentUserId="user-1"
+        provider="codex"
+        draftContent={createDraft("")}
+        availableCommands={[] satisfies readonly AgentHostAgentSessionCommand[]}
+        disabled={false}
+        submitDisabled={false}
+        placeholder="placeholder"
+        composerSettings={createComposerSettings()}
+        queuedPrompts={[]}
+        drainingQueuedPromptId={null}
+        canQueueWhileBusy={false}
+        showStopButton={false}
+        activePrompt={null}
+        isInterrupting={false}
+        isSendingTurn={false}
+        isSubmittingPrompt={false}
+        labels={createLabels()}
+        workspaceUserProjectI18n={workspaceUserProjectI18n}
+        onDraftContentChange={vi.fn()}
+        onSettingsChange={vi.fn()}
+        onSubmit={vi.fn()}
+        onSendQueuedPromptNext={vi.fn()}
+        onRemoveQueuedPrompt={vi.fn()}
+        onEditQueuedPrompt={vi.fn()}
+        onInterruptCurrentTurn={vi.fn()}
+        onSubmitInteractivePrompt={vi.fn()}
+      />
+    );
+
+    const mentionButton = screen.getByRole("button", { name: "提及上下文" });
+    expect(screen.queryByRole("tooltip")).toBeNull();
+    fireEvent.pointerMove(mentionButton, { pointerType: "mouse" });
+
+    expect(await screen.findByRole("tooltip")).toHaveTextContent("提及上下文");
+  });
+
   it("hides the project row for locked dock composers in existing conversations", () => {
     const { container } = render(
       <AgentComposer

--- a/packages/agent/gui/agent-gui/agentGuiNode/AgentComposer.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/AgentComposer.tsx
@@ -1768,7 +1768,16 @@ export function AgentComposer({
       return makeAtPanelKeyDown({
         close: closeFileMentionPalette,
         commitSelection: () => {
-          createFileMentionPaletteAdapter().commitHighlighted();
+          // No highlighted/committable entry (e.g. the search has zero
+          // results): Enter has nothing to select, so treat it as
+          // dismissing the empty panel instead of a silent no-op. This
+          // matches Escape's behavior and mirrors the "clear the active
+          // mention context" contract — a second Enter afterwards then
+          // falls through to the normal submit handler.
+          const result = createFileMentionPaletteAdapter().commitHighlighted();
+          if (result.type === "none") {
+            closeFileMentionPalette();
+          }
         },
         cycleFilter: cycleFileMentionFilter,
         moveSelection: moveFileMentionSelection,

--- a/packages/agent/gui/agent-gui/agentGuiNode/AgentComposer.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/AgentComposer.tsx
@@ -3325,34 +3325,42 @@ export function AgentComposer({
                     </Tooltip>
                   </TooltipProvider>
                 )}
-                <button
-                  type="button"
-                  aria-label={labels.mentionPalette}
-                  title={labels.mentionPalette}
-                  disabled={composerControlsHardDisabled || inputDisabled}
-                  className={cn(
-                    styles.composerMenuTrigger,
-                    styles.composerReferenceTrigger,
-                    "group w-auto justify-center text-[var(--agent-gui-text-secondary)] disabled:pointer-events-none disabled:opacity-50 [&_svg]:shrink-0"
-                  )}
-                  onMouseDown={(event) => event.preventDefault()}
-                  onClick={handleMentionPaletteButton}
-                >
-                  <span
-                    aria-hidden
-                    className="inline-block size-3.5 bg-[var(--text-secondary)] transition-colors group-hover:bg-[var(--text-primary)] group-focus-visible:bg-[var(--text-primary)]"
-                    style={{
-                      WebkitMaskImage: `url("${atLinedIconUrl}")`,
-                      WebkitMaskPosition: "center",
-                      WebkitMaskRepeat: "no-repeat",
-                      WebkitMaskSize: "contain",
-                      maskImage: `url("${atLinedIconUrl}")`,
-                      maskPosition: "center",
-                      maskRepeat: "no-repeat",
-                      maskSize: "contain"
-                    }}
-                  />
-                </button>
+                <TooltipProvider delayDuration={120}>
+                  <Tooltip>
+                    <TooltipTrigger asChild>
+                      <button
+                        type="button"
+                        aria-label={labels.mentionPalette}
+                        disabled={composerControlsHardDisabled || inputDisabled}
+                        className={cn(
+                          styles.composerMenuTrigger,
+                          styles.composerReferenceTrigger,
+                          "group w-auto justify-center text-[var(--agent-gui-text-secondary)] disabled:pointer-events-none disabled:opacity-50 [&_svg]:shrink-0"
+                        )}
+                        onMouseDown={(event) => event.preventDefault()}
+                        onClick={handleMentionPaletteButton}
+                      >
+                        <span
+                          aria-hidden
+                          className="inline-block size-3.5 bg-[var(--text-secondary)] transition-colors group-hover:bg-[var(--text-primary)] group-focus-visible:bg-[var(--text-primary)]"
+                          style={{
+                            WebkitMaskImage: `url("${atLinedIconUrl}")`,
+                            WebkitMaskPosition: "center",
+                            WebkitMaskRepeat: "no-repeat",
+                            WebkitMaskSize: "contain",
+                            maskImage: `url("${atLinedIconUrl}")`,
+                            maskPosition: "center",
+                            maskRepeat: "no-repeat",
+                            maskSize: "contain"
+                          }}
+                        />
+                      </button>
+                    </TooltipTrigger>
+                    <TooltipContent side="top">
+                      {labels.mentionPalette}
+                    </TooltipContent>
+                  </Tooltip>
+                </TooltipProvider>
               </div>
               {showProviderSelect && selectedProviderSwitchTarget ? (
                 <Select


### PR DESCRIPTION
## Summary

Two independent composer fixes, both from the Feishu 客户反馈 bug tracker, on the same branch per the coordinator's instruction to keep working in this worktree.

### 1. KU9pBF — @ button has no hover tooltip
- The composer's @ (mention palette) button only had a native `title` attribute, unlike its sibling composer button (the reference/add-file button) which uses the shared design-system `Tooltip` component — giving it an inconsistent and, per the bug report, effectively invisible hover explanation.
- Wraps the @ button with the same `TooltipProvider`/`Tooltip`/`TooltipTrigger`/`TooltipContent` pattern already used by the neighboring reference button, keeping `aria-label` for accessibility and dropping the redundant native `title`.

### 2. eifRld — @ mention panel with zero results swallows Enter
- Root cause: when the @ mention search resolves to zero matching results, `commitHighlighted()` has nothing to commit, but Enter still called `event.preventDefault()` and consumed the keystroke — a silent no-op. The panel stayed open and the message never sent, so the user appeared stuck.
- Per Ricky's clarified spec: when there are zero results, the first Enter should cancel/dismiss the search (same as Escape does), and a second Enter then sends the message normally, as if there were no active @ context. Panels *with* results still commit the highlighted candidate on Enter — unchanged.
- This addresses the "stuck, can't send" symptom described in eifRld (the runaway @ query from ordinary typed prose now has a keyboard escape hatch, and tiptap's own `dismissedRange` tracking keeps that same @ span from reactivating afterwards).
- **Not addressed / still open**: *why* the @ query keeps growing across soft-wrapped text in the first place (tiptap's `Suggestion` plugin uses `allowSpaces: true`, which only terminates a query at a second literal `" @"` or end-of-text). Ricky has not yet given a termination heuristic for that case — it remains a separate, pending decision, not invented here.

## Test plan
- [x] `AgentComposer.spec.tsx`:
  - New test asserting a `role="tooltip"` element with the mention-palette label appears on pointer hover (KU9pBF).
  - New test asserting Enter on a zero-result @ search cancels the search (no submit, draft text untouched) and a second Enter then submits normally (eifRld). Verified this test fails without the fix and passes with it.
- [x] `npx vitest run agentGuiNode/AgentComposer.spec.tsx` — 66/66 passed.
- [x] `node ./tools/scripts/run-tsgo-typecheck.mjs` (packages/agent/gui) — clean.
- [x] `npx oxlint` on changed files — clean.
- [x] Pre-push hook `check:full` (full go + ts suite) — passed (both pushes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the `@` mention search flow so pressing Enter with no results now closes the empty results panel, and a second Enter submits the message normally.
  * Added a visible tooltip to the mention button so its label appears on hover instead of only as a button title.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->