### PR TITLE
fix(agent-gui): disable compact button while a turn is actively running

### DIFF
--- a/packages/agent/gui/agent-gui/agentGuiNode/AgentComposer.spec.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/AgentComposer.spec.tsx
@@ -2227,7 +2227,10 @@ describe("AgentComposer", () => {
     ).not.toBeInTheDocument();
   });
 
-  it("keeps the compact context button enabled while a session is running", async () => {
+  it("keeps the compact context button enabled while showStopButton is true but no turn is actively executing", async () => {
+    // showStopButton alone (e.g. pending approval / interrupting, with
+    // isSendingTurn false) must NOT disable compact -- that overly broad
+    // gate was the bug fixed by 0e736412 and must not be reintroduced.
     const onSubmit = vi.fn();
     render(
       <AgentComposer
@@ -2270,6 +2273,102 @@ describe("AgentComposer", () => {
     expect(compactButton).not.toBeDisabled();
     fireEvent.click(compactButton);
     expect(onSubmit).toHaveBeenCalledWith(textPromptContent("/compact"));
+  });
+
+  it("disables the compact context button while a turn is actively running (isSendingTurn=true)", async () => {
+    const onSubmit = vi.fn();
+    render(
+      <AgentComposer
+        workspaceId="workspace-1"
+        currentUserId="user-1"
+        provider="codex"
+        usage={{ usedTokens: 50_000, totalTokens: 200_000, percentUsed: 25 }}
+        draftContent={createDraft("")}
+        availableCommands={[] satisfies readonly AgentHostAgentSessionCommand[]}
+        disabled={false}
+        submitDisabled={false}
+        placeholder="placeholder"
+        composerSettings={createComposerSettings()}
+        queuedPrompts={[]}
+        drainingQueuedPromptId={null}
+        canQueueWhileBusy={false}
+        showStopButton={true}
+        activePrompt={null}
+        isInterrupting={false}
+        isSendingTurn={true}
+        isSubmittingPrompt={false}
+        compactSupported={true}
+        hasCompactableContext={true}
+        labels={createLabels()}
+        workspaceUserProjectI18n={workspaceUserProjectI18n}
+        onDraftContentChange={vi.fn()}
+        onSettingsChange={vi.fn()}
+        onSubmit={onSubmit}
+        onSendQueuedPromptNext={vi.fn()}
+        onRemoveQueuedPrompt={vi.fn()}
+        onEditQueuedPrompt={vi.fn()}
+        onInterruptCurrentTurn={vi.fn()}
+        onSubmitInteractivePrompt={vi.fn()}
+      />
+    );
+
+    await openUsagePopoverByHover(screen.getByTestId("agent-gui-usage-chip"));
+    const compactButton = screen.getByTestId("agent-gui-compact-button");
+    expect(compactButton).toBeInTheDocument();
+    expect(compactButton).toBeDisabled();
+    fireEvent.click(compactButton);
+    expect(onSubmit).not.toHaveBeenCalled();
+  });
+
+  it("re-enables the compact context button once the turn settles", async () => {
+    const onSubmit = vi.fn();
+    const renderComposer = (
+      isSendingTurn: boolean,
+      showStopButton: boolean
+    ) => (
+      <AgentComposer
+        workspaceId="workspace-1"
+        currentUserId="user-1"
+        provider="codex"
+        usage={{ usedTokens: 50_000, totalTokens: 200_000, percentUsed: 25 }}
+        draftContent={createDraft("")}
+        availableCommands={[] satisfies readonly AgentHostAgentSessionCommand[]}
+        disabled={false}
+        submitDisabled={false}
+        placeholder="placeholder"
+        composerSettings={createComposerSettings()}
+        queuedPrompts={[]}
+        drainingQueuedPromptId={null}
+        canQueueWhileBusy={false}
+        showStopButton={showStopButton}
+        activePrompt={null}
+        isInterrupting={false}
+        isSendingTurn={isSendingTurn}
+        isSubmittingPrompt={false}
+        compactSupported={true}
+        hasCompactableContext={true}
+        labels={createLabels()}
+        workspaceUserProjectI18n={workspaceUserProjectI18n}
+        onDraftContentChange={vi.fn()}
+        onSettingsChange={vi.fn()}
+        onSubmit={onSubmit}
+        onSendQueuedPromptNext={vi.fn()}
+        onRemoveQueuedPrompt={vi.fn()}
+        onEditQueuedPrompt={vi.fn()}
+        onInterruptCurrentTurn={vi.fn()}
+        onSubmitInteractivePrompt={vi.fn()}
+      />
+    );
+
+    const { rerender } = render(renderComposer(true, true));
+
+    await openUsagePopoverByHover(screen.getByTestId("agent-gui-usage-chip"));
+    expect(screen.getByTestId("agent-gui-compact-button")).toBeDisabled();
+
+    rerender(renderComposer(false, false));
+
+    await openUsagePopoverByHover(screen.getByTestId("agent-gui-usage-chip"));
+    expect(screen.getByTestId("agent-gui-compact-button")).not.toBeDisabled();
   });
 
   it("shows the compact context button disabled when no user message has been sent", async () => {

--- a/packages/agent/gui/agent-gui/agentGuiNode/AgentComposer.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/AgentComposer.tsx
@@ -3491,8 +3491,16 @@ export function AgentComposer({
                   totalTokens={usage.totalTokens}
                   tooltipsEnabled={!previewMode}
                   compactSupported={compactSupported ?? false}
+                  // Only guard against compacting mid-turn: isSendingTurn is
+                  // the narrow "a turn is actively executing right now"
+                  // signal. showStopButton alone (e.g. pending approval or
+                  // interrupting, with isSendingTurn false) must keep this
+                  // enabled -- that broader gate was the bug fixed by
+                  // 0e736412 and should not be reintroduced.
                   compactDisabled={
-                    !hasCompactableContext || composerControlsHardDisabled
+                    !hasCompactableContext ||
+                    composerControlsHardDisabled ||
+                    isSendingTurn
                   }
                   onCompact={() => onSubmit(textPromptContent("/compact"))}
                   labels={{


### PR DESCRIPTION
## Problem
The Feishu bug tracker ticket "運行過程應該禁用壓縮" (yhO1t4) reports that the "Compact" button in the composer's token-usage popover (`AgentComposer.tsx`) is clickable even while a turn is actively running, letting the user trigger `/compact` mid-execution.

## Root cause
Commit `0e736412` ("fix(agent): polish setup and mission control controls", 2026-06-30) correctly fixed an over-broad disable: previously the button disabled whenever `settingsControlsDisabled` (`isSendingTurn || isSubmittingPrompt || showStopButton`) was true, which also blocked compaction during states like pending-approval or interrupting where compaction is safe. That fix replaced the gate with `composerControlsHardDisabled`, which deliberately excludes `isSendingTurn`/`showStopButton` — but in doing so it dropped any guard at all for the one case that should still block compaction: a turn actively executing right now.

This PR is an ADDITION on top of the already-correct `0e736412` fix, not a revert of it. The button stays generally clickable (including during pending-approval/interrupting `showStopButton` states); it is now also disabled specifically while `isSendingTurn` is true.

## Fix
`packages/agent/gui/agent-gui/agentGuiNode/AgentComposer.tsx` (~line 3494): `compactDisabled` now also includes `isSendingTurn`, the narrow "a turn is actively executing right now" signal already used elsewhere in this component (e.g. gating the send/stop button). `showStopButton` alone (without `isSendingTurn`, e.g. pending approval / interrupting) still leaves the button enabled, matching `0e736412`'s intent.

## Tests
`packages/agent/gui/agent-gui/agentGuiNode/AgentComposer.spec.tsx`:
- Kept (renamed for clarity) the `0e736412` case: enabled when `showStopButton=true` but `isSendingTurn=false`.
- Added: disabled when `isSendingTurn=true`.
- Added: re-enables once the turn settles (rerender from `isSendingTurn=true` to `false`).

Ran `vitest run` for the full `packages/agent/gui` package (118 files / 1925 tests, all passing) and the package's tsgo typecheck (clean).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented the compact action from being used while a turn is actively sending, so the button now stays disabled in that state.
  * Restored the button to an enabled state once the turn finishes and the compact action is available again.
  * Updated behavior checks to match the new enable/disable rules for the compact control.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->