### PR TITLE
fix(agent): scope single-provider rail sections to provider-local agent target

### DIFF
--- a/packages/agent/gui/agent-gui/agentGuiNode/AgentGUINodeView.layout.spec.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/AgentGUINodeView.layout.spec.tsx
@@ -1281,7 +1281,7 @@ describe("AgentGUINodeView layout persistence", () => {
     ).toBeInTheDocument();
   });
 
-  it("does not refetch runtime rail sections when an existing conversation summary or active provider updates", async () => {
+  it("refetches runtime rail sections only for provider changes, not conversation summary updates", async () => {
     const listSessionSections = vi.fn<
       NonNullable<AgentActivityRuntime["listSessionSections"]>
     >(async (input) => ({
@@ -1354,11 +1354,6 @@ describe("AgentGUINodeView layout persistence", () => {
         labels: { ...labels },
         viewModel: {
           ...viewModel,
-          data: {
-            ...viewModel.data,
-            provider: "codex" as const
-          },
-          selectedProviderTarget: createLocalAgentGUIProviderTarget("codex"),
           activeConversation: updatedConversation,
           activeConversationId: updatedConversation.id,
           conversations: [updatedConversation]
@@ -1372,6 +1367,34 @@ describe("AgentGUINodeView layout persistence", () => {
       ).toHaveTextContent("Updated title");
     });
     expect(listSessionSections).toHaveBeenCalledTimes(1);
+    expect(listSessionSections).toHaveBeenCalledWith(
+      expect.objectContaining({ agentTargetId: "local:claude-code" })
+    );
+
+    rendered.rerender(
+      buildAgentGUINodeViewElement({
+        activityRuntime,
+        labels: { ...labels },
+        viewModel: {
+          ...viewModel,
+          data: {
+            ...viewModel.data,
+            provider: "codex" as const
+          },
+          selectedProviderTarget: createLocalAgentGUIProviderTarget("codex"),
+          activeConversation: updatedConversation,
+          activeConversationId: updatedConversation.id,
+          conversations: [updatedConversation]
+        }
+      })
+    );
+
+    await waitFor(() => {
+      expect(listSessionSections).toHaveBeenCalledTimes(2);
+    });
+    expect(listSessionSections).toHaveBeenLastCalledWith(
+      expect.objectContaining({ agentTargetId: "local:codex" })
+    );
   });
 
   it("passes the active agent target filter to runtime rail section requests", async () => {

--- a/packages/agent/gui/agent-gui/agentGuiNode/AgentGUINodeView.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/AgentGUINodeView.tsx
@@ -172,6 +172,16 @@ const AGENT_GUI_TOP_MASK_SCROLL_EPSILON_PX = 1;
 const AGENT_GUI_CONVERSATION_RAIL_SECTION_PAGE_SIZE = 5;
 const AGENT_GUI_CONVERSATION_RAIL_PROJECTION_PROVIDER: AgentGUIProvider =
   "codex";
+// TODO(legacySplit-removal): remove together with the legacySplit dock layout.
+// Single-provider docks have no agent-target filter, so rail sections scope to
+// the provider's system-local target. Ids must match the daemon backfill
+// (services/tuttid/biz/agenttarget/model.go IDLocalCodex/IDLocalClaudeCode).
+const AGENT_GUI_SINGLE_PROVIDER_SECTION_AGENT_TARGET_IDS: Partial<
+  Record<AgentGUIProvider, string>
+> = {
+  "claude-code": "local:claude-code",
+  codex: "local:codex"
+};
 
 const AGENT_GUI_TIMELINE_SCROLL_AREA_CONTENT_STYLE: CSSProperties = {
   width: "100%",
@@ -1306,6 +1316,12 @@ export function AgentGUINodeView({
       : railConfigProvider;
   const effectiveRailSlashStatusLimits =
     railSlashStatusLimits ?? slashStatusLimits;
+  const sectionAgentTargetFallbackId =
+    viewModel.conversationScope === "single-provider"
+      ? (AGENT_GUI_SINGLE_PROVIDER_SECTION_AGENT_TARGET_IDS[
+          viewModel.data.provider
+        ] ?? null)
+      : null;
   const openAgentEnvSetup = useCallback(() => {
     if (!effectiveRailConfigProvider) {
       return;
@@ -1336,6 +1352,7 @@ export function AgentGUINodeView({
         providerTargetsLoading: viewModel.providerTargetsLoading,
         conversationScope: viewModel.conversationScope,
         conversationFilter: viewModel.conversationFilter,
+        sectionAgentTargetFallbackId,
         onCreateConversation: requestCreateConversation,
         onUpdateConversationFilter: actions.updateConversationFilter,
         onSelectConversationFilterTarget:
@@ -1374,6 +1391,7 @@ export function AgentGUINodeView({
         retryOpenclawGateway,
         selectConversation,
         selectProjectDirectory,
+        sectionAgentTargetFallbackId,
         effectiveRailConfigProvider,
         effectiveRailSlashStatusLimits,
         viewModel.selectedProviderTarget,
@@ -3384,6 +3402,7 @@ interface AgentGUIConversationRailPaneProps {
   providerTargetsLoading: AgentGUINodeViewModel["providerTargetsLoading"];
   conversationScope: AgentGUINodeViewModel["conversationScope"];
   conversationFilter: AgentGUINodeViewModel["conversationFilter"];
+  sectionAgentTargetFallbackId: string | null;
   onUpdateConversationFilter: (
     filter: AgentGUINodeViewModel["conversationFilter"]
   ) => void;
@@ -3486,6 +3505,8 @@ function agentGUIConversationRailStoreSnapshotsEqual(
     current.providerTargetsLoading === next.providerTargetsLoading &&
     current.conversationScope === next.conversationScope &&
     current.conversationFilter === next.conversationFilter &&
+    current.sectionAgentTargetFallbackId ===
+      next.sectionAgentTargetFallbackId &&
     current.onUpdateConversationFilter === next.onUpdateConversationFilter &&
     current.onSelectConversationFilterTarget ===
       next.onSelectConversationFilterTarget &&
@@ -4038,6 +4059,7 @@ interface AgentGUIConversationRailInput {
   conversations: AgentGUINodeViewModel["conversations"];
   labels: AgentGUIViewLabels;
   previewMode: boolean;
+  sectionAgentTargetFallbackId: string | null;
   userProjects: AgentGUINodeViewModel["userProjects"];
   workspaceId: string;
 }
@@ -4048,6 +4070,7 @@ function useAgentGUIConversationRail({
   conversations,
   labels,
   previewMode,
+  sectionAgentTargetFallbackId,
   userProjects,
   workspaceId
 }: AgentGUIConversationRailInput): {
@@ -4075,7 +4098,7 @@ function useAgentGUIConversationRail({
   const sectionAgentTargetId =
     conversationFilter.kind === "agentTarget"
       ? conversationFilter.agentTargetId.trim()
-      : "";
+      : (sectionAgentTargetFallbackId?.trim() ?? "");
   const userProjectPaths = useMemo(
     () =>
       userProjects
@@ -4350,6 +4373,7 @@ const AgentGUIConversationRailPane = memo(
     providerTargetsLoading,
     conversationScope,
     conversationFilter,
+    sectionAgentTargetFallbackId,
     onUpdateConversationFilter,
     onSelectConversationFilterTarget,
     onCreateConversation,
@@ -4400,6 +4424,7 @@ const AgentGUIConversationRailPane = memo(
       conversations,
       labels,
       previewMode,
+      sectionAgentTargetFallbackId,
       userProjects,
       workspaceId
     });


### PR DESCRIPTION
## Summary

After #680 the conversation rail fetches sessions through the new rail section endpoints (`listSessionSections` / `listSessionSectionPage`). In the legacySplit dock layout each dock runs with `conversationScope: "single-provider"`, where the agent-target filter is intentionally disabled (`conversationFilter` stays `{kind: "all"}`), so the section requests carried no `agentTargetId`. The daemon then returned every session in the workspace, and both the Codex dock and the Claude Code dock rendered all providers' sessions mixed together. The old store-based rail scoped by provider, so this scoping was lost in the migration to runtime sections.

## Fix

- Single-provider docks now fall back to the provider's system-local agent target id (`local:codex` / `local:claude-code`) for rail section requests when no explicit agent-target filter is active. These ids match the daemon backfill (`backfillSystemAgentTargetIDs` in `services/tuttid/data/workspace/migrations_agent_activity.go`), which stamped every legacy session's `agent_target_id` with the provider-local target, so the server-side filter is complete for these providers.
- Providers without a system-local target (nexight, gemini, ...) keep the previous unfiltered behavior, so their rails cannot go empty from a filter that matches nothing.
- Multi-provider (unified) docks are unchanged: the fallback is only computed for single-provider scope.
- This is temporary compatibility for the legacySplit layout and is marked `TODO(legacySplit-removal)` for deletion together with that layout.

Known accepted trade-off: sessions created on a non-local target of the same provider (e.g. launched via unified mode on a remote target, then switching back to legacySplit) are hidden from the legacy dock instead of shown, since the dock now scopes to the local target.

## Tests

- Updated the layout spec: conversation summary updates still do not refetch sections; switching the single-provider dock provider now refetches with the new provider-local `agentTargetId`.
- `pnpm --filter @tutti-os/agent-gui test` (118 files, 1923 tests) and `pnpm --filter @tutti-os/agent-gui typecheck` pass.
- Note: local pre-push `pnpm check:full` hit the known transient concurrent-preflight failure in `check:ui-boundaries` (same as documented in #680); the check passes when run sequentially.

🤖 Generated with [Claude Code](https://claude.com/claude-code)