### PR TITLE
fix(userproject): prune Codex scratch-cwd folders from the project list

### DIFF
--- a/services/tuttid/service/userproject/service.go
+++ b/services/tuttid/service/userproject/service.go
@@ -52,6 +52,12 @@ func (s Service) List(ctx context.Context) ([]userprojectbiz.Project, error) {
 	}
 	result := make([]userprojectbiz.Project, 0, len(projects))
 	for _, project := range projects {
+		if isCodexScratchProjectPath(project.Path) {
+			if err := s.Store.DeleteUserProject(ctx, project.ID); err != nil {
+				return nil, fmt.Errorf("prune codex scratch user project: %w", err)
+			}
+			continue
+		}
 		available, prune := projectDirectoryStatus(project.Path)
 		if available {
 			result = append(result, project)
@@ -157,4 +163,64 @@ func projectDirectoryStatus(path string) (available bool, prune bool) {
 func projectID(path string) string {
 	sum := sha256.Sum256([]byte(path))
 	return "user_project_" + hex.EncodeToString(sum[:])[:24]
+}
+
+// isCodexScratchProjectPath reports whether path is anywhere under the Codex
+// desktop app's auto-provisioned scratch tree (~/Documents/Codex/...). Codex
+// creates a directory there whenever a conversation starts without the user
+// picking a real local project, and the leaf directory name is a
+// machine-generated slug rather than a folder the user chose, so it must
+// never be surfaced as a "project" in the workspace file manager / project
+// list. Mirrors isExternalImportCodexScratchCwd in
+// service/agent/external_import_parse.go, which applies the same rule while
+// scanning external sessions to import; this copy guards the user-project
+// list/store directly so that any project record that already ended up
+// pointing at a scratch directory (for example one registered by an import
+// that ran before that scan-side fix existed, or by any other future caller
+// of Use) gets pruned rather than surfacing indefinitely. The exact shape of
+// the scratch slug has changed across Codex versions — older releases used a
+// single combined "<date>-<slug>" segment (Documents/Codex/2026-04-24-gh),
+// newer ones split it into "<date>/<slug>" (Documents/Codex/2026-04-24/gh) —
+// so this intentionally only checks that the path is nested under
+// Documents/Codex rather than pattern-matching a specific segment shape, to
+// stay robust across formats.
+func isCodexScratchProjectPath(path string) bool {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return false
+	}
+	home, ok := canonicalExistingDir(home)
+	if !ok {
+		return false
+	}
+	path = strings.TrimSpace(path)
+	if path == "" {
+		return false
+	}
+	path = filepath.Clean(path)
+	rel, err := filepath.Rel(home, path)
+	if err != nil || rel == "." || rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+		return false
+	}
+	parts := strings.SplitN(filepath.ToSlash(rel), "/", 3)
+	return len(parts) >= 3 && parts[0] == "Documents" && parts[1] == "Codex" && parts[2] != ""
+}
+
+func canonicalExistingDir(path string) (string, bool) {
+	path = strings.TrimSpace(path)
+	if path == "" {
+		return "", false
+	}
+	abs, err := filepath.Abs(path)
+	if err != nil {
+		return "", false
+	}
+	info, err := os.Stat(abs)
+	if err != nil || !info.IsDir() {
+		return "", false
+	}
+	if resolved, err := filepath.EvalSymlinks(abs); err == nil {
+		abs = resolved
+	}
+	return filepath.Clean(abs), true
 }

--- a/services/tuttid/service/userproject/service_test.go
+++ b/services/tuttid/service/userproject/service_test.go
@@ -138,6 +138,53 @@ func TestServiceListPrunesUnavailableProjects(t *testing.T) {
 	}
 }
 
+func TestServiceListPrunesCodexScratchProjects(t *testing.T) {
+	ctx := context.Background()
+	home := filepath.Join(t.TempDir(), "home")
+	scratchCwd := filepath.Join(home, "Documents", "Codex", "2026-06-26", "ge")
+	legacyScratchCwd := filepath.Join(home, "Documents", "Codex", "2026-04-24-gh")
+	realProjectDir := filepath.Join(home, "Documents", "tutti")
+	for _, dir := range []string{scratchCwd, legacyScratchCwd, realProjectDir} {
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			t.Fatalf("MkdirAll(%q) error = %v", dir, err)
+		}
+	}
+	if canonical, ok := canonicalExistingDir(home); ok {
+		home = canonical
+	}
+	if canonical, ok := canonicalExistingDir(scratchCwd); ok {
+		scratchCwd = canonical
+	}
+	if canonical, ok := canonicalExistingDir(legacyScratchCwd); ok {
+		legacyScratchCwd = canonical
+	}
+	if canonical, ok := canonicalExistingDir(realProjectDir); ok {
+		realProjectDir = canonical
+	}
+	t.Setenv("HOME", home)
+
+	store := &recordingUserProjectStore{
+		projects: []userprojectbiz.Project{
+			{ID: "scratch", Path: scratchCwd, Label: "ge"},
+			{ID: "legacy-scratch", Path: legacyScratchCwd, Label: "2026-04-24-gh"},
+			{ID: "real", Path: realProjectDir, Label: "tutti"},
+		},
+	}
+	service := Service{Store: store}
+
+	projects, err := service.List(ctx)
+	if err != nil {
+		t.Fatalf("List() error = %v", err)
+	}
+
+	if len(projects) != 1 || projects[0].ID != "real" {
+		t.Fatalf("List() projects = %#v, want only the real project", projects)
+	}
+	if strings.Join(store.deletedIDs, ",") != "scratch,legacy-scratch" {
+		t.Fatalf("deleted IDs = %#v, want scratch,legacy-scratch", store.deletedIDs)
+	}
+}
+
 func TestServiceCheckPathReportsDirectoryStatusWithoutStore(t *testing.T) {
 	ctx := context.Background()
 	root := t.TempDir()


### PR DESCRIPTION
## Summary

A P0 bug report asked whether it's expected for folders under Codex's own auto-provisioned scratch directory (e.g. `~/Documents/Codex/<date>/<slug>`) to show up in the workspace file manager / project list. It is not expected — those folders are machine-generated scratch workspaces Codex creates whenever a conversation starts without the user picking a real project, not something the user chose, and they shouldn't be surfaced as "projects".

Investigation found that the workspace file manager's project list is backed entirely by the persisted `user_projects` store, which is only ever written to via two paths: explicit user actions (create/select-existing-folder in the composer's project picker) and the external session import flow. The import flow used to register a project entry for every distinct session `cwd`, including Codex's own scratch directories — that specific mislabeling bug was already fixed earlier today in a separate commit (making no-project sessions collapse onto a single consistent bucket instead of surfacing each scratch slug as its own fake project).

That fix prevents *new* imports from creating these bad entries, but it doesn't clean up a project record that already ended up pointing at a Codex scratch directory (for example one registered by an import that ran before that fix existed). Since the scratch folder genuinely exists on disk, `userproject.Service.List()`'s existing "prune projects whose directory no longer exists" logic never removes it, so it lingers in the project list indefinitely.

This PR closes that gap: `List()` now also prunes (deletes from the store) any registered project whose path is nested under `~/Documents/Codex/...`, mirroring the same `isExternalImportCodexScratchCwd`-style detection already used on the import-scan side. This self-heals any already-corrupted project lists and guards against any future caller of `Use()` doing the same thing.

## Test plan

- [x] `go test ./services/tuttid/service/userproject/...` — added `TestServiceListPrunesCodexScratchProjects` covering both the newer (`Documents/Codex/<date>/<slug>`) and legacy (`Documents/Codex/<date>-<slug>`) scratch directory shapes, alongside a real registered project that must be kept.
- [x] `go vet ./...` and `gofmt -l` on the touched package
- [x] Full `go test ./...` for `services/tuttid` (two failures are pre-existing/unrelated: a known-flaky app-center test that passes in isolation, and `TestSQLiteStoreListSessionSectionPagesByRailSectionKey`, which fails identically on `main` without this change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * User project lists now automatically remove entries that point to Codex Desktop scratch locations, so only real projects appear.
  * Improved path handling to better recognize scratch directories even when symlinks or different path formats are involved.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->