### PR TITLE
refactor(agent): clean up runtime state patches from #727

### DIFF
--- a/packages/agent/daemon/runtime/claude_sdk_adapter.go
+++ b/packages/agent/daemon/runtime/claude_sdk_adapter.go
@@ -1551,7 +1551,7 @@ func (s *claudeSDKAdapterSession) applyUsageUpdated(payload map[string]any) bool
 	contextModel := s.currentUsageModel(payload)
 	update := claudeSDKUsageUpdate(payload, previous, contextModel)
 	if len(update) == 0 {
-		s.logUsageUpdate(payload, update, previous, acpUsageState{}, false, "empty_normalized_update")
+		s.logUsageUpdate(payload, update, previous, acpUsageState{}, contextModel, false, "empty_normalized_update")
 		return false
 	}
 	if usage, ok := acpUsageValue(update); ok {
@@ -1559,10 +1559,10 @@ func (s *claudeSDKAdapterSession) applyUsageUpdated(payload map[string]any) bool
 			usage.contextModel = contextModel
 		}
 		s.liveState.usage = mergeACPUsageState(previous, usage)
-		s.logUsageUpdate(payload, update, previous, s.liveState.usage, true, "")
+		s.logUsageUpdate(payload, update, previous, s.liveState.usage, contextModel, true, "")
 		return true
 	}
-	s.logUsageUpdate(payload, update, previous, acpUsageState{}, false, "invalid_normalized_update")
+	s.logUsageUpdate(payload, update, previous, acpUsageState{}, contextModel, false, "invalid_normalized_update")
 	return false
 }
 
@@ -1571,6 +1571,7 @@ func (s *claudeSDKAdapterSession) logUsageUpdate(
 	update map[string]any,
 	previous acpUsageState,
 	current acpUsageState,
+	contextModel string,
 	applied bool,
 	reason string,
 ) {
@@ -1599,7 +1600,6 @@ func (s *claudeSDKAdapterSession) logUsageUpdate(
 		rawContextSource = contextWindow
 	}
 	rawUsed, _ := firstACPInt64(rawContextSource, "usedTokens", "used_tokens", "used", "totalTokens", "total_tokens", "total")
-	contextModel := s.currentUsageModel(payload)
 	rawTotal := claudeSDKContextWindowTokens(payload, contextModel)
 	if rawTotal <= 0 {
 		rawTotal = claudeSDKContextWindowTokens(usageSource, contextModel)
@@ -1869,30 +1869,29 @@ func claudeSDKContextWindowTokensFromValue(value any, contextModel string) int64
 		if total := claudeSDKContextWindowTokens(typed, contextModel); total > 0 {
 			return total
 		}
-		for _, key := range sortedPayloadKeys(typed) {
-			if !claudeSDKModelUsageKeyMatches(key, contextModel) {
-				continue
-			}
-			if total := claudeSDKContextWindowTokensFromValue(typed[key], contextModel); total > 0 {
-				return total
+		normalizedModel := strings.ToLower(strings.TrimSpace(claudeSDKCanonicalModel(contextModel)))
+		keys := sortedPayloadKeys(typed)
+		for _, key := range keys {
+			if normalizedModel != "" && claudeSDKModelKeyMatchesNormalized(key, normalizedModel) {
+				if total := claudeSDKContextWindowTokensFromValue(typed[key], contextModel); total > 0 {
+					return total
+				}
 			}
 		}
-		for _, key := range sortedPayloadKeys(typed) {
-			if total := claudeSDKContextWindowTokensFromValue(typed[key], contextModel); total > 0 {
-				return total
+		for _, key := range keys {
+			if normalizedModel == "" || !claudeSDKModelKeyMatchesNormalized(key, normalizedModel) {
+				if total := claudeSDKContextWindowTokensFromValue(typed[key], contextModel); total > 0 {
+					return total
+				}
 			}
 		}
 	}
 	return 0
 }
 
-func claudeSDKModelUsageKeyMatches(key string, contextModel string) bool {
+func claudeSDKModelKeyMatchesNormalized(key string, normalizedModel string) bool {
 	key = strings.ToLower(strings.TrimSpace(key))
-	contextModel = strings.ToLower(strings.TrimSpace(claudeSDKCanonicalModel(contextModel)))
-	if key == "" || contextModel == "" {
-		return false
-	}
-	return key == contextModel || strings.Contains(key, contextModel)
+	return key != "" && (key == normalizedModel || strings.Contains(key, normalizedModel))
 }
 
 func (s *claudeSDKAdapterSession) send(request claudeSDKSidecarRequest) error {

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUINodeController.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUINodeController.ts
@@ -8693,19 +8693,15 @@ export function useAgentGUINodeController({
           const queuedUpdate =
             queuedComposerSettingsUpdatesRef.current[agentSessionId] ?? null;
           const optimisticSettings = queuedUpdate?.sessionSettingsPatch ?? null;
-          const confirmedModelSetting =
-            sessionSettingsPatch.model !== undefined
-              ? { model: sessionSettingsPatch.model }
-              : {};
           const nextAppliedSettings = optimisticSettings
             ? {
                 ...result.settings,
-                ...confirmedModelSetting,
+                ...sessionSettingsPatch,
                 ...optimisticSettings
               }
             : {
                 ...result.settings,
-                ...confirmedModelSetting
+                ...sessionSettingsPatch
               };
           updateAgentSessionViewControlState(
             sessionViewRef(agentSessionId),


### PR DESCRIPTION
Three implementation issues in the rough fixes from #727:

Go — claude_sdk_adapter:
- logUsageUpdate recomputed currentUsageModel(payload) independently even though applyUsageUpdated had already resolved it; pass contextModel as a parameter instead
- claudeSDKContextWindowTokensFromValue called sortedPayloadKeys twice on the same map, allocating two sorted slices; compute once and reuse
- claudeSDKModelUsageKeyMatches re-canonicalized contextModel on every key in the loop; pre-normalize once before the loop and replace the function with claudeSDKModelKeyMatchesNormalized that takes a pre-normalized value

TypeScript — useAgentGUINodeController:
- confirmedModelSetting only preserved model from the confirmed patch, but the correct invariant is that the entire confirmed sessionSettingsPatch takes priority over result.settings (which may be incomplete for the Claude Code provider); spread the full patch directly instead

## Summary

<!-- What changed and why? -->

## Verification

<!-- Commands run, manual checks, or why verification is not applicable. -->

## Checklist

- [ ] I kept the change focused on one concern.
- [ ] I updated documentation when behavior, setup, or contributor workflow changed.
- [ ] I updated all README/CONTRIBUTING language variants when changing their English source.
- [ ] I ran the lowest meaningful local checks for the changed surface.
- [ ] My commits are signed off with DCO when required: `git commit -s`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved session settings updates so all changes are now applied consistently after saving, including non-model composer settings.
  * Better handling of usage updates and context-window token tracking for more accurate activity reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->