### PR TITLE
fix(agent-gui): surface an error instead of silently no-op'ing when the Files panel can't open

### DIFF
--- a/apps/desktop/src/renderer/src/features/workspace-workbench/ui/WorkspaceWorkbench.source.test.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/ui/WorkspaceWorkbench.source.test.ts
@@ -38,6 +38,18 @@ test("WorkspaceWorkbench validates requested file targets before opening workspa
   );
 });
 
+test("WorkspaceWorkbench surfaces a toast instead of silently no-op'ing when a requested file target doesn't exist", () => {
+  // Regression coverage for imported (historical Codex/Claude Code) sessions
+  // whose recorded working directory may no longer exist on this machine —
+  // previously, opening the Files panel for such a session (via a file link
+  // or the project menu's "Open folder" action) silently did nothing with no
+  // user-facing feedback at all.
+  assert.match(
+    source,
+    /workspaceID: request\.workspaceId[\s\S]*?\}\)\)\s*\)\s*\{[\s\S]*?Toast\.Error\(\s*translate\(\s*"workspace\.workbenchDesktop\.filesLaunch\.openFailedTitle"\s*\),\s*translate\(\s*"workspace\.workbenchDesktop\.filesLaunch\.openFailedDescription"\s*\)\s*\);\s*return false;/
+  );
+});
+
 test("WorkspaceWorkbench uses temporary dock retention to control app visibility", () => {
   assert.match(source, /temporaryWorkspaceAppDockRetentionActionPrefix/);
   assert.match(source, /resolveTemporaryDockRetentionContribution/);

--- a/apps/desktop/src/renderer/src/features/workspace-workbench/ui/WorkspaceWorkbench.tsx
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/ui/WorkspaceWorkbench.tsx
@@ -45,7 +45,9 @@ import {
 } from "@renderer/features/workspace-agent/desktopAgentGUINodeState";
 import { useService } from "@tutti-os/infra/di";
 import { useTranslation } from "@renderer/i18n";
+import { translate } from "@renderer/i18n/appRuntime";
 import { cn } from "@renderer/lib/format";
+import { Toast } from "@renderer/lib/toast";
 import {
   createWorkspaceAgentGuiDraftLaunchRequest,
   createWorkspaceAgentGuiSessionLaunchRequest
@@ -920,6 +922,16 @@ async function openWorkspaceFilesNode(
       workspaceID: request.workspaceId
     }))
   ) {
+    // The requested path doesn't exist on this machine (e.g. an imported
+    // historical session's recorded working directory has since been deleted
+    // or moved — see resolveExternalImportSessionCwd on the import side,
+    // which deliberately keeps such sessions instead of dropping them). Surface
+    // this instead of silently doing nothing, which previously looked like the
+    // Files panel simply refused to open with no explanation.
+    Toast.Error(
+      translate("workspace.workbenchDesktop.filesLaunch.openFailedTitle"),
+      translate("workspace.workbenchDesktop.filesLaunch.openFailedDescription")
+    );
     return false;
   }
 

--- a/apps/desktop/src/shared/i18n/locales/en.ts
+++ b/apps/desktop/src/shared/i18n/locales/en.ts
@@ -840,6 +840,11 @@ export const en = {
         unsupportedFallback:
           "Preview is not supported yet. Opening with your local app."
       },
+      filesLaunch: {
+        openFailedDescription:
+          "This session's original working directory could no longer be found on this computer.",
+        openFailedTitle: "Couldn't open folder"
+      },
       agentProviders: {
         checking: "Checking local CLI status...",
         comingSoon: "Coming soon",

--- a/apps/desktop/src/shared/i18n/locales/zh-CN.ts
+++ b/apps/desktop/src/shared/i18n/locales/zh-CN.ts
@@ -802,6 +802,10 @@ export const zhCN = {
         unsaved: "有未保存更改",
         unsupportedFallback: "暂时不支持预览，使用本地软件打开。"
       },
+      filesLaunch: {
+        openFailedDescription: "这个会话原本的工作目录在本机上已经找不到了。",
+        openFailedTitle: "无法打开文件夹"
+      },
       agentProviders: {
         checking: "正在检测本地 CLI 状态...",
         comingSoon: "敬请期待",


### PR DESCRIPTION
## Problem

Feishu bug 客户反馈 tracker, master ticket eW5WPl, sub-issue #4: **消息中心无法打开档案面板** — after importing a historical Codex/Claude Code conversation, opening the file panel for that session appears to do nothing.

3 of the 4 sub-issues on this ticket were already fixed in #714 (scan/count accuracy, imported project directory correctness, Codex directory/model-settings migration). That PR's description documented sub-issue #4 as traced-but-unresolved: "found several silent-failure points, but couldn't pin one definitive cause without a live repro."

## Root cause

Opening the Files panel — whether triggered by clicking a file link in a message, or by the project section's **"Open folder"** menu item in the agent GUI (`AgentGUINodeView.tsx`) — funnels through the same path: `requestWorkspaceFilesLaunch` → the registered handler `openWorkspaceFilesNode` (`apps/desktop/src/renderer/src/features/workspace-workbench/ui/WorkspaceWorkbench.tsx`).

When the request carries `validateExists: true` (which the `"open-workspace-file"` action always sets), `openWorkspaceFilesNode` calls `workspaceFileManagerService.entryExists(path)` *before* launching the panel node. `entryExists` does a real directory listing (`os.Stat` under the hood, `services/tuttid/data/workspace/local_files.go`); if the directory doesn't exist, it returns `false`, and `openWorkspaceFilesNode` aborts **without ever launching the panel**.

Every caller of this chain discards the boolean result (`void runDesktopAgentGUILinkAction(...)`), so when this happens, nothing visible occurs at all — no toast, no disabled state, no error. The user just sees the panel silently fail to open.

This disproportionately affects **imported** sessions: `resolveExternalImportSessionCwd` (`services/tuttid/service/agent/external_import_parse.go`) deliberately keeps sessions whose recorded working directory no longer exists on disk (a deleted git worktree, a removed temp dir, a renamed project) instead of dropping them — a fix from #714 for the "wrong session counts" sub-issue. That means a meaningful fraction of imported sessions now have a `cwd` that genuinely can't be browsed anymore. A **live** session's `cwd` is always the real, currently-existing working directory of a running process, so it essentially never hits this path — which is why the symptom reads as import-specific even though the underlying code path is shared.

## Fix

Surface a clear `Toast.Error` (title + description, new `workspace.workbenchDesktop.filesLaunch.*` i18n keys in `en.ts`/`zh-CN.ts`) instead of silently returning `false`, at the single shared choke point (`openWorkspaceFilesNode`) both trigger paths funnel through. This doesn't try to resurrect a deleted directory — it just tells the user clearly why the panel didn't open, instead of leaving them staring at nothing.

## Test plan

- [x] Added a regression test to `WorkspaceWorkbench.source.test.ts` (this file already uses source-regex assertions around `openWorkspaceFilesNode`, since the surrounding component is Electron-host-heavy and not unit-render-tested) asserting the toast fires on the `entryExists` failure branch.
- [x] `apps/desktop`: `node --import ./test/register-asset-stub.mjs --test --experimental-strip-types "./src/**/*.test.ts"` — 1198/1201 pass (3 pre-existing skips, 0 failures).
- [x] `apps/desktop`: `node ../../tools/scripts/run-tsgo-typecheck.mjs` — clean.
- [x] `oxfmt --check` / `oxlint` on touched files — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Shows an error message when a requested file or folder can’t be opened instead of failing silently.
  * The message is localized for supported languages.
* **Tests**
  * Added coverage for the missing-file/open-failure behavior to prevent regressions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->