### PR TITLE
fix(agent-gui): render live agent replies in message center and issue widget while running

### DIFF
--- a/apps/desktop/src/renderer/src/features/workspace-workbench/ui/IssueManagerLatestRunMessageCenterCard.test.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/ui/IssueManagerLatestRunMessageCenterCard.test.ts
@@ -27,3 +27,30 @@ test("issue manager card does not submit the deck prompt interactively", () => {
     /workspaceAgentActivityService\.submitInteractive\(/
   );
 });
+
+test("issue manager card projects latest runs through message center snapshot", () => {
+  // While a run is actively streaming, the workspace agent activity snapshot
+  // frequently has not yet reconciled the session (that requires a request
+  // round-trip after the run starts). Without synthesizing a session entry
+  // from already-cached messages, the card falls back to a bare status
+  // digest instead of the real agent reply, which is what made the reply
+  // look unrendered specifically while running. Assert the model/session
+  // lookups run against the synthesized snapshot, not the raw one, so a
+  // cached-but-not-yet-tracked session's messages are picked up.
+  assert.match(source, /issueManagerLatestRunMessageCenterSnapshot/);
+  assert.match(
+    source,
+    /buildWorkspaceAgentMessageCenterModel\(messageCenterSnapshot,/
+  );
+  assert.match(source, /findWorkspaceAgentSession\(messageCenterSnapshot,/);
+});
+
+test("issue manager card only synthesizes a session once its messages are cached", () => {
+  // Synthesizing a session unconditionally (or before any message content
+  // is cached) would render an empty/placeholder detail pane instead of a
+  // digest that at least reflects the run's own summary text. The
+  // synthesis must be gated on already-cached messages and skipped once the
+  // real session is tracked.
+  assert.match(source, /hasCachedIssueManagerRunMessages/);
+  assert.match(source, /findWorkspaceAgentSession\(snapshot, agentSessionId\)/);
+});

--- a/apps/desktop/src/renderer/src/features/workspace-workbench/ui/IssueManagerLatestRunMessageCenterCard.tsx
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/ui/IssueManagerLatestRunMessageCenterCard.tsx
@@ -108,9 +108,27 @@ function IssueManagerLatestRunMessageCenterCard({
     void workspaceAgentActivityService.load(workspaceId);
   }, [workspaceAgentActivityService, workspaceId]);
 
+  // The workspace agent activity snapshot only tracks a session once the
+  // service has reconciled it (a request round-trip after the run starts).
+  // While a run is actively streaming, the issue-manager latest-run card
+  // otherwise has to fall back to a bare status digest (no real message
+  // content) even though the message summary fetch below may already have
+  // cached the actual reply. Synthesize a session entry from those cached
+  // messages so the same message-center projection (digest + full turn
+  // detail) used for a tracked session renders here too, instead of only
+  // after the run finishes and a later snapshot reconcile catches up.
+  const messageCenterSnapshot = useMemo(
+    () =>
+      issueManagerLatestRunMessageCenterSnapshot({
+        agentSessionId,
+        input,
+        snapshot
+      }),
+    [agentSessionId, input, snapshot]
+  );
   const model = useMemo(
     () =>
-      buildWorkspaceAgentMessageCenterModel(snapshot, {
+      buildWorkspaceAgentMessageCenterModel(messageCenterSnapshot, {
         promptFallbackLabels: {
           constraintHeader: i18n.t(
             "workspace.agentMessageCenter.promptConstraintHeader"
@@ -121,11 +139,11 @@ function IssueManagerLatestRunMessageCenterCard({
         },
         workspaceRoot: null
       }),
-    [i18n, snapshot]
+    [i18n, messageCenterSnapshot]
   );
   const targetSession = useMemo(
-    () => findWorkspaceAgentSession(snapshot, agentSessionId),
-    [agentSessionId, snapshot]
+    () => findWorkspaceAgentSession(messageCenterSnapshot, agentSessionId),
+    [agentSessionId, messageCenterSnapshot]
   );
   const modelItem = useMemo(
     () =>
@@ -284,6 +302,86 @@ function findWorkspaceAgentSession(
       workspaceAgentSessionMessageAliases(session).includes(target)
     ) ?? null
   );
+}
+
+function issueManagerLatestRunMessageCenterSnapshot({
+  agentSessionId,
+  input,
+  snapshot
+}: {
+  agentSessionId: string;
+  input: IssueManagerLatestRunStatusRenderInput;
+  snapshot: AgentActivitySnapshot;
+}): AgentActivitySnapshot {
+  if (
+    !agentSessionId ||
+    findWorkspaceAgentSession(snapshot, agentSessionId) ||
+    !hasCachedIssueManagerRunMessages(
+      snapshot.sessionMessagesById,
+      agentSessionId
+    )
+  ) {
+    return snapshot;
+  }
+  const latestRun = input.latestRun;
+  const timestamp = issueManagerRunTimestampToUnixMs(
+    latestRun.updatedAtUnix ??
+      latestRun.completedAtUnix ??
+      latestRun.startedAtUnix ??
+      latestRun.createdAtUnix
+  );
+  return {
+    ...snapshot,
+    sessions: [
+      ...snapshot.sessions,
+      {
+        workspaceId: snapshot.workspaceId || latestRun.workspaceId,
+        agentSessionId,
+        provider: latestRun.agentProvider?.trim() || "codex",
+        cwd: latestRun.executionDirectory?.trim() || "",
+        title: input.title || agentSessionId,
+        status: issueManagerRunStatusToAgentActivityStatus(latestRun.status),
+        userId: latestRun.requesterUserId?.trim() || undefined,
+        visible: true,
+        createdAtUnixMs: issueManagerRunTimestampToUnixMs(
+          latestRun.createdAtUnix
+        ),
+        startedAtUnixMs: issueManagerRunTimestampToUnixMs(
+          latestRun.startedAtUnix
+        ),
+        endedAtUnixMs: issueManagerRunTimestampToUnixMs(
+          latestRun.completedAtUnix
+        ),
+        updatedAtUnixMs: timestamp,
+        lastEventUnixMs: timestamp
+      }
+    ]
+  };
+}
+
+function hasCachedIssueManagerRunMessages(
+  sessionMessagesById: AgentActivitySnapshot["sessionMessagesById"],
+  agentSessionId: string
+): boolean {
+  return (sessionMessagesById[agentSessionId.trim()]?.length ?? 0) > 0;
+}
+
+function issueManagerRunStatusToAgentActivityStatus(status: string): string {
+  switch (status) {
+    case "running":
+    case "in_progress":
+      return "working";
+    case "pending_acceptance":
+      return "waiting";
+    case "completed":
+    case "failed":
+    case "canceled":
+      return status;
+    case "not_started":
+      return "queued";
+    default:
+      return "unknown";
+  }
 }
 
 function findWorkspaceAgentMessageCenterItem({

--- a/packages/agent/gui/agent-message-center/WorkspaceAgentMessageCenterCard.tsx
+++ b/packages/agent/gui/agent-message-center/WorkspaceAgentMessageCenterCard.tsx
@@ -38,6 +38,7 @@ import { formatAgentSessionMentionText } from "../shared/utils/agentSessionMenti
 import { AgentInteractivePromptSurface } from "../shared/agentConversation/components/AgentInteractivePromptSurface";
 import { AgentMessageMarkdown } from "../shared/AgentMessageMarkdown";
 import { AgentVerticalScrollArea } from "../shared/AgentVerticalScrollArea";
+import { WorkspaceAgentSessionDetail } from "../shared/WorkspaceAgentSessionDetail";
 import { managedAgentRoundedIconUrl } from "../shared/managedAgentIcons";
 import { workspaceAgentActivityStatusLabel } from "../shared/workspaceAgentActivityStatusLabel";
 import { workspaceAgentProviderLabel } from "../shared/workspaceAgentProviderLabel";
@@ -174,7 +175,9 @@ export const WorkspaceAgentMessageCenterCard = memo(
           </span>
         </div>
 
-        {summary ? (
+        {item.detail?.turns.length ? (
+          <MessageCenterSessionDetail item={item} onLinkAction={onLinkAction} />
+        ) : summary ? (
           <MessageCenterSummary
             item={item}
             lazy={lazySummary}
@@ -981,6 +984,57 @@ function useDeferredMessageCenterSummaryMeasureReady(
   }, [enabled, ready, ref]);
 
   return ready;
+}
+
+function MessageCenterSessionDetail({
+  item,
+  onLinkAction
+}: {
+  item: WorkspaceAgentMessageCenterItem;
+  onLinkAction?: (action: WorkspaceLinkAction) => void;
+}): JSX.Element | null {
+  "use memo";
+  const { t } = useTranslation();
+  const detail = item.detail ?? null;
+  const handleLinkAction = useCallback(
+    (action: WorkspaceLinkAction): void => {
+      onLinkAction?.(
+        action.type === "open-agent-session" && !action.provider
+          ? { ...action, provider: item.provider }
+          : action
+      );
+    },
+    [item.provider, onLinkAction]
+  );
+
+  if (!detail || detail.turns.length === 0) {
+    return null;
+  }
+
+  return (
+    <div
+      className="workspace-agent-message-center__session-detail min-w-0 rounded-md bg-transparency-block"
+      onPointerDown={stopMessageCenterTextPointerPropagation}
+    >
+      <AgentVerticalScrollArea
+        className="max-h-[360px] min-w-0"
+        viewportClassName="max-h-[360px] p-2.5 pr-4"
+        scrollbarClassName="top-2 bottom-2 right-1.5"
+        syncKey={`${item.agentSessionId}:${item.timelineItemCount ?? detail.turns.length}`}
+      >
+        <WorkspaceAgentSessionDetail
+          detail={detail}
+          isLoading={item.status === "working" || item.status === "waiting"}
+          timelineItemCount={item.timelineItemCount ?? detail.turns.length}
+          onLinkAction={handleLinkAction}
+          toolCallsLabel={(count) =>
+            t("agentHost.workspaceAgentSessionDetailToolCalls", { count })
+          }
+          thinkingLabel={t("agentHost.workspaceAgentSessionDetailThinking")}
+        />
+      </AgentVerticalScrollArea>
+    </div>
+  );
 }
 
 export function MessageCenterOpenChatButton({

--- a/packages/agent/gui/agent-message-center/WorkspaceAgentMessageCenterPanel.spec.tsx
+++ b/packages/agent/gui/agent-message-center/WorkspaceAgentMessageCenterPanel.spec.tsx
@@ -168,6 +168,99 @@ function openViewOptions(): void {
 }
 
 describe("WorkspaceAgentMessageCenterCard", () => {
+  it("renders canonical session detail when the message center item has transcript data", () => {
+    // Regression test: the card used to only show a truncated one-line
+    // digest even while an agent reply was fully available. This confirms
+    // the card now renders the actual turn-by-turn reply (the same
+    // projection as the full conversation window) instead of the digest
+    // fallback whenever transcript detail is present.
+    render(
+      <TooltipProvider>
+        <WorkspaceAgentMessageCenterCard
+          item={createTestCardItem({
+            digest: {
+              primary: {
+                kind: "summary",
+                summary: "Digest fallback should not render",
+                occurredAtUnixMs: 2
+              }
+            },
+            detail: {
+              activity: {
+                id: "activity-session-1",
+                sessionId: "session-1",
+                userId: null,
+                userName: "User",
+                agentProvider: "codex",
+                agentName: "Codex",
+                title: "整理本地文件夹",
+                status: "completed",
+                latestActivitySummary: "I found the relevant files.",
+                changedFiles: [],
+                sortTimeUnixMs: 2
+              },
+              session: {
+                workspaceId: "workspace-1",
+                agentSessionId: "session-1",
+                provider: "codex",
+                cwd: "/workspace",
+                title: "整理本地文件夹",
+                status: "completed"
+              },
+              cwd: "/workspace",
+              workspaceRoot: "/workspace",
+              turns: [
+                {
+                  id: "turn-1",
+                  userMessage: {
+                    id: "user-1",
+                    body: "Please inspect the workspace.",
+                    turnId: "turn-1"
+                  },
+                  userMessages: [
+                    {
+                      id: "user-1",
+                      body: "Please inspect the workspace.",
+                      turnId: "turn-1"
+                    }
+                  ],
+                  agentMessages: [
+                    {
+                      id: "assistant-1",
+                      body: "I found the relevant files.",
+                      turnId: "turn-1"
+                    }
+                  ],
+                  toolCalls: [],
+                  toolCallCount: 0,
+                  hasFailedToolCall: false,
+                  agentItems: [
+                    {
+                      kind: "message",
+                      message: {
+                        id: "assistant-1",
+                        body: "I found the relevant files.",
+                        turnId: "turn-1"
+                      }
+                    }
+                  ]
+                }
+              ]
+            },
+            timelineItemCount: 2
+          })}
+          isSubmitting={false}
+          onOpenChat={vi.fn()}
+          onSubmitPrompt={vi.fn()}
+        />
+      </TooltipProvider>
+    );
+
+    expect(screen.getByText("Please inspect the workspace.")).toBeTruthy();
+    expect(screen.getByText("I found the relevant files.")).toBeTruthy();
+    expect(screen.queryByText("Digest fallback should not render")).toBeNull();
+  });
+
   it("reports the provider and semantic action when submitting a notification prompt", () => {
     const onNotificationActioned = vi.fn();
     render(

--- a/packages/agent/gui/agent-message-center/workspaceAgentMessageCenterDigest.spec.ts
+++ b/packages/agent/gui/agent-message-center/workspaceAgentMessageCenterDigest.spec.ts
@@ -118,6 +118,37 @@ describe("buildWorkspaceAgentMessageCenterDigest", () => {
     });
   });
 
+  it("renders structured content arrays as message summaries", () => {
+    // While a session is actively streaming, a live assistant reply is
+    // frequently delivered as an array of structured content blocks rather
+    // than a single flat string. Picking only the first block (the old
+    // behavior) silently dropped the rest of the in-progress reply, which
+    // is what made the digest look broken specifically while running.
+    const digest = buildWorkspaceAgentMessageCenterDigest({
+      fallbackTitle: "Fallback title",
+      messages: [
+        message({
+          messageId: "assistant-1",
+          role: "assistant",
+          payload: {
+            content: [
+              { type: "text", text: "First paragraph." },
+              { type: "text", text: "Second paragraph." }
+            ]
+          },
+          occurredAtUnixMs: 10
+        })
+      ],
+      needsAttention: null,
+      pendingPrompt: null,
+      status: "working"
+    });
+
+    expect(digest.primary).toMatchObject({
+      summary: "First paragraph. Second paragraph."
+    });
+  });
+
   it("prioritizes input-required over terminal-looking message summaries", () => {
     const digest = buildWorkspaceAgentMessageCenterDigest({
       fallbackTitle: "Fallback title",

--- a/packages/agent/gui/agent-message-center/workspaceAgentMessageCenterDigest.ts
+++ b/packages/agent/gui/agent-message-center/workspaceAgentMessageCenterDigest.ts
@@ -235,7 +235,7 @@ function summaryCandidate(
   source: MessageSummarySource,
   value: unknown
 ): MessageSummaryCandidate | null {
-  const summary = normalizeSummaryText(stringValue(value));
+  const summary = normalizeSummaryText(messageSummaryText(value));
   return summary ? { source, summary } : null;
 }
 
@@ -252,7 +252,7 @@ function toolErrorSummaryCandidate(
       stringValue(error.message),
       stringValue(error.detail),
       stringValue(error.text),
-      textFromContentValue(error.content),
+      messageSummaryText(error.content),
       stringValue(error.output),
       stringValue(error.stdout),
       stringValue(error.stderr),
@@ -278,7 +278,7 @@ function toolOutputSummaryCandidate(
       stringValue(output.summary),
       stringValue(output.message),
       stringValue(output.text),
-      textFromContentValue(output.content),
+      messageSummaryText(output.content),
       stringValue(output.content),
       stringValue(output.result),
       stringValue(output.output),
@@ -469,16 +469,15 @@ function stringArrayFirstValue(value: unknown): string | null {
   );
 }
 
-function textFromContentValue(value: unknown): string | null {
+export function messageSummaryText(value: unknown): string | null {
   if (typeof value === "string") {
     return stringValue(value);
   }
   if (Array.isArray(value)) {
-    return (
-      value
-        .map(textFromContentValue)
-        .find((item): item is string => Boolean(item)) ?? null
-    );
+    const parts = value
+      .map(messageSummaryText)
+      .filter((item): item is string => Boolean(item));
+    return parts.length > 0 ? parts.join("\n") : null;
   }
   if (!value || typeof value !== "object") {
     return null;
@@ -486,7 +485,7 @@ function textFromContentValue(value: unknown): string | null {
   const record = value as Record<string, unknown>;
   return firstNonEmptyString(
     stringValue(record.text),
-    "content" in record ? textFromContentValue(record.content) : null
+    "content" in record ? messageSummaryText(record.content) : null
   );
 }
 

--- a/packages/agent/gui/agent-message-center/workspaceAgentMessageCenterModel.spec.ts
+++ b/packages/agent/gui/agent-message-center/workspaceAgentMessageCenterModel.spec.ts
@@ -291,6 +291,109 @@ describe("buildWorkspaceAgentMessageCenterModel", () => {
     );
   });
 
+  it("builds session detail from the same message timeline used by conversations", () => {
+    // The message-center card used to only show a single-line digest
+    // summary. This asserts it also carries the same turn-by-turn detail
+    // projection the full conversation window uses, so a live agent reply
+    // renders as a normal message instead of just a terse status line.
+    const model = buildWorkspaceAgentMessageCenterModel(
+      snapshot({
+        messages: [
+          message({
+            agentSessionId: "session-1",
+            messageId: "user-1",
+            role: "user",
+            kind: "text",
+            payload: { text: "Please inspect the workspace." },
+            occurredAtUnixMs: 10,
+            turnId: "turn-1"
+          }),
+          message({
+            agentSessionId: "session-1",
+            messageId: "assistant-1",
+            role: "assistant",
+            kind: "text",
+            payload: { text: "I found the relevant files." },
+            occurredAtUnixMs: 20,
+            turnId: "turn-1"
+          })
+        ],
+        sessions: [session({ agentSessionId: "session-1" })]
+      })
+    );
+
+    expect(model.items[0]?.timelineItemCount).toBe(2);
+    expect(model.items[0]?.detail?.turns[0]).toMatchObject({
+      userMessage: { body: "Please inspect the workspace." },
+      agentMessages: [{ body: "I found the relevant files." }]
+    });
+  });
+
+  it("keeps rebuilding session detail while a session is still running so a new agent reply is not stuck on stale turns", () => {
+    // Regression test for the "reply not rendered while running" bug: the
+    // message center panel memoizes items via
+    // stabilizeWorkspaceAgentMessageCenterModel to avoid re-rendering
+    // unchanged cards. If that stability check ignores `detail`/
+    // `timelineItemCount`, a session that is still `working` can appear to
+    // stop updating even though a fresh agent message has already arrived.
+    const runningSnapshot = (messages: AgentActivityMessage[]) =>
+      snapshot({
+        messages,
+        sessions: [session({ agentSessionId: "session-1", status: "working" })]
+      });
+
+    const firstModel = buildWorkspaceAgentMessageCenterModel(
+      runningSnapshot([
+        message({
+          agentSessionId: "session-1",
+          messageId: "user-1",
+          role: "user",
+          kind: "text",
+          payload: { text: "Please inspect the workspace." },
+          occurredAtUnixMs: 10,
+          turnId: "turn-1"
+        })
+      ])
+    );
+    const stableFirst = stabilizeWorkspaceAgentMessageCenterModel(
+      null,
+      firstModel
+    );
+
+    const secondModel = buildWorkspaceAgentMessageCenterModel(
+      runningSnapshot([
+        message({
+          agentSessionId: "session-1",
+          messageId: "user-1",
+          role: "user",
+          kind: "text",
+          payload: { text: "Please inspect the workspace." },
+          occurredAtUnixMs: 10,
+          turnId: "turn-1"
+        }),
+        message({
+          agentSessionId: "session-1",
+          messageId: "assistant-1",
+          role: "assistant",
+          kind: "text",
+          payload: { text: "Here is the first file I found." },
+          occurredAtUnixMs: 20,
+          turnId: "turn-1"
+        })
+      ])
+    );
+    const stableSecond = stabilizeWorkspaceAgentMessageCenterModel(
+      stableFirst,
+      secondModel
+    );
+
+    expect(stableFirst.items[0]?.timelineItemCount).toBe(1);
+    expect(stableSecond.items[0]?.timelineItemCount).toBe(2);
+    expect(stableSecond.items[0]?.detail?.turns[0]?.agentMessages).toEqual([
+      expect.objectContaining({ body: "Here is the first file I found." })
+    ]);
+  });
+
   it("prefers displayPrompt for message-center model summaries", () => {
     const model = buildWorkspaceAgentMessageCenterModel(
       snapshot({

--- a/packages/agent/gui/agent-message-center/workspaceAgentMessageCenterModel.ts
+++ b/packages/agent/gui/agent-message-center/workspaceAgentMessageCenterModel.ts
@@ -6,17 +6,27 @@ import {
   type AgentActivitySession,
   type AgentActivitySnapshot
 } from "@tutti-os/agent-activity-core";
+import { projectWorkspaceAgentMessagesToTimelineItems } from "../shared/agentConversation/projection/workspaceAgentMessageProjection";
 import type { AgentConversationPromptVM } from "../shared/agentConversation/contracts/agentConversationVM";
 import { normalizeAskUserQuestions } from "../shared/agentConversation/askUserQuestions";
 import { extractAgentMcpToolTarget } from "../shared/agentMcpToolTarget";
-import type { WorkspaceAgentActivityStatus } from "../shared/workspaceAgentActivityListViewModel";
+import {
+  buildWorkspaceAgentActivityListViewModel,
+  type WorkspaceAgentActivityCard,
+  type WorkspaceAgentActivityStatus
+} from "../shared/workspaceAgentActivityListViewModel";
 import { resolveWorkspaceAgentSessionSortTimeUnixMs } from "../shared/workspaceAgentSessionSortTime";
+import {
+  buildWorkspaceAgentSessionDetailViewModel,
+  type WorkspaceAgentSessionDetailViewModel
+} from "../shared/workspaceAgentSessionDetailViewModel";
 import {
   latestPlanTurnId,
   planImplementationPromptFromPlanTurn
 } from "../shared/agentConversation/planImplementation";
 import {
   buildWorkspaceAgentMessageCenterDigest,
+  messageSummaryText,
   resolveWorkspaceAgentMessageCenterDigestAgentMessageSummary,
   type WorkspaceAgentMessageCenterDigest,
   type WorkspaceAgentMessageCenterDigestAgentSummary
@@ -54,6 +64,8 @@ export interface WorkspaceAgentMessageCenterItem {
   digest: WorkspaceAgentMessageCenterDigest;
   lastAgentMessageSummary: string;
   lastAgentMessageAtUnixMs: number | null;
+  detail?: WorkspaceAgentSessionDetailViewModel | null;
+  timelineItemCount?: number;
   pendingPrompt: AgentConversationPromptVM | null;
   needsAttentionKind: AgentActivityNeedsAttentionItem["kind"] | null;
   needsAttentionSummary: string | null;
@@ -105,6 +117,11 @@ export function buildWorkspaceAgentMessageCenterModel(
     selectNeedsAttentionItems(snapshot)
   );
   const displayStatuses = selectSessionDisplayStatuses(snapshot);
+  const activitiesBySessionId = new Map(
+    buildWorkspaceAgentActivityListViewModel(snapshot, {
+      sessionMessagesById: snapshot.sessionMessagesById
+    }).activities.map((activity) => [activity.sessionId, activity])
+  );
   const items = snapshot.sessions
     .filter((session) => session.visible !== false)
     .map((session) => {
@@ -142,6 +159,12 @@ export function buildWorkspaceAgentMessageCenterModel(
           messages
         }
       );
+      const detail = buildMessageCenterSessionDetail({
+        activity: activitiesBySessionId.get(session.agentSessionId) ?? null,
+        messages,
+        session,
+        workspaceRoot: options.workspaceRoot ?? null
+      });
 
       return {
         id: `message-center-${session.agentSessionId}`,
@@ -160,6 +183,8 @@ export function buildWorkspaceAgentMessageCenterModel(
         lastAgentMessageSummary:
           lastAgentMessage?.summary ?? needsAttention?.summary ?? title,
         lastAgentMessageAtUnixMs: lastAgentMessage?.occurredAtUnixMs ?? null,
+        detail: detail?.detail ?? null,
+        timelineItemCount: detail?.timelineItemCount ?? 0,
         pendingPrompt,
         needsAttentionKind: needsAttention?.kind ?? null,
         needsAttentionSummary: needsAttention?.summary ?? null,
@@ -175,6 +200,35 @@ export function buildWorkspaceAgentMessageCenterModel(
     waitingCount: items.filter(isWaitingMessageCenterItem).length,
     items: items.sort(compareMessageCenterItems),
     counts: countMessageCenterItems(items)
+  };
+}
+
+function buildMessageCenterSessionDetail({
+  activity,
+  messages,
+  session,
+  workspaceRoot
+}: {
+  activity: WorkspaceAgentActivityCard | null;
+  messages: readonly AgentActivityMessage[];
+  session: AgentActivitySession;
+  workspaceRoot: string | null;
+}): {
+  detail: WorkspaceAgentSessionDetailViewModel;
+  timelineItemCount: number;
+} | null {
+  if (!activity) {
+    return null;
+  }
+  const timelineItems = projectWorkspaceAgentMessagesToTimelineItems(messages);
+  return {
+    detail: buildWorkspaceAgentSessionDetailViewModel({
+      activity,
+      session,
+      timelineItems,
+      workspaceRoot
+    }),
+    timelineItemCount: timelineItems.length
   };
 }
 
@@ -820,13 +874,13 @@ function includesAny(value: string, needles: readonly string[]): boolean {
 
 function messageSummary(message: AgentActivityMessage): string {
   return firstNonEmptyString(
-    stringValue(message.payload.summary),
-    stringValue(message.payload.displayPrompt),
-    stringValue(message.payload.text),
-    stringValue(message.payload.content),
-    stringValue(message.payload.message),
-    stringValue(message.payload.body),
-    stringValue(message.payload.title)
+    messageSummaryText(message.payload.summary),
+    messageSummaryText(message.payload.displayPrompt),
+    messageSummaryText(message.payload.text),
+    messageSummaryText(message.payload.content),
+    messageSummaryText(message.payload.message),
+    messageSummaryText(message.payload.body),
+    messageSummaryText(message.payload.title)
   );
 }
 

--- a/packages/agent/gui/agent-message-center/workspaceAgentMessageCenterModelStability.ts
+++ b/packages/agent/gui/agent-message-center/workspaceAgentMessageCenterModelStability.ts
@@ -68,6 +68,14 @@ function messageCenterItemsEqual(
     left.status === right.status &&
     left.lastAgentMessageSummary === right.lastAgentMessageSummary &&
     left.lastAgentMessageAtUnixMs === right.lastAgentMessageAtUnixMs &&
+    // A running session can gain new turn/tool-call detail (rendered by
+    // MessageCenterSessionDetail) without the top-level digest summary
+    // text changing (e.g. a new tool call with no distinct summary yet).
+    // Without this check the stability layer would keep serving the stale
+    // `detail`, so the in-progress conversation view would stop updating
+    // while a session is actively running even though newer messages have
+    // already arrived.
+    (left.timelineItemCount ?? 0) === (right.timelineItemCount ?? 0) &&
     left.needsAttentionKind === right.needsAttentionKind &&
     left.needsAttentionSummary === right.needsAttentionSummary &&
     left.sortTimeUnixMs === right.sortTimeUnixMs &&


### PR DESCRIPTION
## Summary

Fixes the P1 bug: "会话运行中，消息中心和issue的最新执行状态的agent回复未渲染出正常消息" (while a session is running, the message center and the issue-manager widget's latest-run card don't render the agent's reply as a normal message).

Root cause, in two parts:

1. **Both surfaces only ever rendered a terse one-line digest summary**, never the actual turn-by-turn agent reply content that the full conversation window shows. The digest text extraction also only used the *first* block of a structured multi-part message payload, silently dropping the rest — a shape that shows up specifically for in-progress/streamed replies.
2. **The issue-manager latest-run card could only find a session once the workspace agent activity snapshot had reconciled it** (a request round-trip after the run starts). While a run was actively streaming, that reconciliation frequently hadn't happened yet, so the card fell back to a bare status digest with no real message content at all — even though the card's own message-summary fetch may have already cached the reply.

Together this produced exactly the reported symptom: the agent's live reply looks unrendered specifically **while running**; once the run finishes (or the surface reloads), the underlying data eventually gets picked up through other paths and looks fine, so it reads as a running-only bug.

This closes out the still-relevant half of #262 ("Share agent session projection in message center"), which introduced this same mechanism but was left as an unmerged draft. #262 predates two changes that have since landed on `main` (card stacking, message-center open-performance) and no longer applies cleanly, so this re-implements it against the current model/card/stability code.

## Changes

- Message center cards (`WorkspaceAgentMessageCenterCard.tsx`) now render the same turn-by-turn session-detail projection used by the full conversation window (`buildWorkspaceAgentActivityListViewModel` / `projectWorkspaceAgentMessagesToTimelineItems` / `buildWorkspaceAgentSessionDetailViewModel`) whenever transcript detail is available, instead of falling back to a single digest line.
- Digest/summary text extraction now joins all blocks of structured multi-part message content instead of only using the first one.
- The issue-manager latest-run card (`IssueManagerLatestRunMessageCenterCard.tsx`) synthesizes a session entry into its local snapshot from already-cached messages when the real session hasn't been reconciled into the activity snapshot yet, so it can render the same rich detail as soon as message content is available.
- The message-center model's stability/memoization layer (`workspaceAgentMessageCenterModelStability.ts`) now also compares `timelineItemCount`, since a running session can gain new turn/tool-call detail without its digest text changing — without this, the memoization could keep serving a stale conversation view for a still-running session.

## Test plan

- [x] `packages/agent/gui`: `pnpm typecheck` and full `vitest run` (120 files / 1945 tests) pass, including new coverage:
  - digest: structured multi-block content is joined into the summary instead of truncated to the first block
  - model: session detail is built from the same message timeline as the conversation window
  - model: a **regression test simulating a session that is still `working`** — rebuilding the model after a new agent message arrives updates `timelineItemCount`/`detail` through the stability layer instead of getting stuck on stale turns
  - card: renders full turn transcript instead of the digest fallback when detail is present
- [x] `apps/desktop`: `pnpm typecheck` passes; `node --test` suite for `workspace-workbench/ui` (58 tests) and the issue-manager card's source-contract tests pass, including new assertions that the synthesized-snapshot mechanism is wired in and gated on cached messages
- [x] Pre-push `pnpm check:full` (full TS + Go suite) passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)