### PR TITLE
[codex] Add AgentGUI transcript scroll-to-bottom action

### DIFF
--- a/packages/agent/gui/agent-gui/agentGuiNode/AgentGUINode.styles.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/AgentGUINode.styles.ts
@@ -1,6 +1,7 @@
 const styles = {
   bottomDock: "agent-gui-node__bottom-dock",
   bottomDockPrompt: "agent-gui-node__bottom-dock-prompt",
+  bottomDockScrollToBottom: "agent-gui-node__bottom-dock-scroll-to-bottom",
   body: "agent-gui-node__body",
   composer: "agent-gui-node__composer",
   composerChip: "agent-gui-node__composer-chip",

--- a/packages/agent/gui/agent-gui/agentGuiNode/AgentGUINode.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/AgentGUINode.tsx
@@ -1093,6 +1093,7 @@ export const AgentGUINode = memo(function AgentGUINode({
       selectConversation: t("agentHost.agentGui.selectConversation"),
       loadingConversations: t("agentHost.agentGui.loadingConversations"),
       loadingConversation: t("agentHost.agentGui.loadingConversation"),
+      scrollToBottom: t("agentHost.agentGui.scrollToBottom"),
       searchNoConversations: t("agentHost.agentGui.searchNoConversations"),
       conversationUnavailable: t("agentHost.agentGui.conversationUnavailable"),
       fallbackAgentTitle,

--- a/packages/agent/gui/agent-gui/agentGuiNode/AgentGUINodeView.layout.spec.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/AgentGUINodeView.layout.spec.tsx
@@ -2421,6 +2421,45 @@ describe("AgentGUINodeView layout persistence", () => {
       "agent-gui-node__timeline--scrolled-from-top"
     );
   });
+
+  it("shows a scroll-to-bottom action when the timeline is away from bottom", () => {
+    const activeConversation = createConversationSummary("session-1");
+    renderAgentGUINodeView({
+      viewModel: {
+        ...createViewModel(),
+        conversations: [activeConversation],
+        activeConversation,
+        activeConversationId: activeConversation.id,
+        conversationDetail: createConversationDetail()
+      }
+    });
+
+    const timeline = screen.getByTestId("agent-gui-timeline") as HTMLElement;
+    Object.defineProperty(timeline, "scrollHeight", {
+      configurable: true,
+      get: () => 1000
+    });
+    Object.defineProperty(timeline, "clientHeight", {
+      configurable: true,
+      get: () => 400
+    });
+    const scrollTo = vi.spyOn(timeline, "scrollTo");
+
+    timeline.scrollTop = 240;
+    fireEvent.scroll(timeline);
+
+    const button = screen.getByTestId("agent-gui-scroll-to-bottom");
+    expect(button).toHaveAccessibleName("scrollToBottom");
+
+    fireEvent.click(button);
+
+    expect(scrollTo).toHaveBeenCalledWith({
+      top: 600,
+      behavior: "smooth"
+    });
+    expect(screen.queryByTestId("agent-gui-scroll-to-bottom")).toBeNull();
+  });
+
   it("renders older-message loading above the transcript", () => {
     const activeConversation = createConversationSummary("session-1");
     renderAgentGUINodeView({
@@ -3434,6 +3473,7 @@ function createLabels(): AgentGUIViewLabels {
     selectConversation: "selectConversation",
     loadingConversations: "loadingConversations",
     loadingConversation: "loadingConversation",
+    scrollToBottom: "scrollToBottom",
     searchNoConversations: "searchNoConversations",
     conversationUnavailable: "conversationUnavailable",
     fallbackAgentTitle: "Agent",

--- a/packages/agent/gui/agent-gui/agentGuiNode/AgentGUINodeView.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/AgentGUINodeView.tsx
@@ -16,6 +16,7 @@ import { useSnapshot } from "valtio";
 import { proxy } from "valtio/vanilla";
 import {
   ChevronRight,
+  ChevronsDown,
   ExternalLink,
   Info,
   LayoutGrid,
@@ -326,6 +327,7 @@ export interface AgentGUIViewLabels {
   selectConversation: string;
   loadingConversations: string;
   loadingConversation: string;
+  scrollToBottom: string;
   searchNoConversations: string;
   conversationUnavailable: string;
   fallbackAgentTitle: string;
@@ -1699,6 +1701,8 @@ const AgentGUIDetailPane = memo(function AgentGUIDetailPane({
     scrollTop: number;
   } | null>(null);
   const [isTimelineScrolledToTop, setIsTimelineScrolledToTop] = useState(true);
+  const [isTimelineScrolledToBottom, setIsTimelineScrolledToBottom] =
+    useState(true);
   const [
     bottomDockDismissedPromptRequestId,
     setBottomDockDismissedPromptRequestId
@@ -2525,6 +2529,7 @@ const AgentGUIDetailPane = memo(function AgentGUIDetailPane({
       pendingPrependScrollAnchorRef.current = null;
       submittedPromptScrollConversationRef.current = null;
       setIsTimelineScrolledToTop(true);
+      setIsTimelineScrolledToBottom(true);
       return;
     }
 
@@ -2584,6 +2589,9 @@ const AgentGUIDetailPane = memo(function AgentGUIDetailPane({
     setIsTimelineScrolledToTop(
       nextScrollTop <= AGENT_GUI_TOP_MASK_SCROLL_EPSILON_PX
     );
+    setIsTimelineScrolledToBottom(
+      maxScrollTop - nextScrollTop <= AGENT_GUI_STICK_TO_BOTTOM_THRESHOLD_PX
+    );
   }, [
     conversation,
     showTimelineSkeleton,
@@ -2605,6 +2613,9 @@ const AgentGUIDetailPane = memo(function AgentGUIDetailPane({
       const bottomDockRect = bottomDock.getBoundingClientRect();
       let visualTop = bottomDockRect.top;
       bottomDock.querySelectorAll("*").forEach((element) => {
+        if (element.closest(`.${styles.bottomDockScrollToBottom}`)) {
+          return;
+        }
         const rect = element.getBoundingClientRect();
         if (rect.width > 0 && rect.height > 0) {
           visualTop = Math.min(visualTop, rect.top);
@@ -2616,6 +2627,10 @@ const AgentGUIDetailPane = memo(function AgentGUIDetailPane({
       );
       timeline.style.setProperty(
         "--agent-gui-bottom-dock-safe-area",
+        `${overflowHeight}px`
+      );
+      bottomDock.style.setProperty(
+        "--agent-gui-bottom-dock-floating-safe-area",
         `${overflowHeight}px`
       );
     };
@@ -2653,6 +2668,7 @@ const AgentGUIDetailPane = memo(function AgentGUIDetailPane({
         setIsTimelineScrolledToTop(
           maxScrollTop <= AGENT_GUI_TOP_MASK_SCROLL_EPSILON_PX
         );
+        setIsTimelineScrolledToBottom(true);
       });
     };
 
@@ -2660,6 +2676,9 @@ const AgentGUIDetailPane = memo(function AgentGUIDetailPane({
     if (typeof ResizeObserver === "undefined") {
       return () => {
         timeline.style.removeProperty("--agent-gui-bottom-dock-safe-area");
+        bottomDock.style.removeProperty(
+          "--agent-gui-bottom-dock-floating-safe-area"
+        );
         if (animationFrameId !== null) {
           window.cancelAnimationFrame(animationFrameId);
         }
@@ -2676,6 +2695,9 @@ const AgentGUIDetailPane = memo(function AgentGUIDetailPane({
     }
     return () => {
       timeline.style.removeProperty("--agent-gui-bottom-dock-safe-area");
+      bottomDock.style.removeProperty(
+        "--agent-gui-bottom-dock-floating-safe-area"
+      );
       if (animationFrameId !== null) {
         window.cancelAnimationFrame(animationFrameId);
       }
@@ -2700,6 +2722,10 @@ const AgentGUIDetailPane = memo(function AgentGUIDetailPane({
       };
       setIsTimelineScrolledToTop(
         scrollTop <= AGENT_GUI_TOP_MASK_SCROLL_EPSILON_PX
+      );
+      setIsTimelineScrolledToBottom(
+        timeline.scrollHeight - scrollTop - timeline.clientHeight <=
+          AGENT_GUI_STICK_TO_BOTTOM_THRESHOLD_PX
       );
       if (
         viewModel.hasOlderMessages &&
@@ -2726,6 +2752,30 @@ const AgentGUIDetailPane = memo(function AgentGUIDetailPane({
     viewModel.hasOlderMessages,
     viewModel.isLoadingOlderMessages
   ]);
+
+  const scrollTimelineToBottom = useCallback(() => {
+    const timeline = timelineRef.current;
+    const activeConversationId = viewModel.activeConversationId;
+    if (!timeline || !activeConversationId) {
+      return;
+    }
+
+    const maxScrollTop = Math.max(
+      0,
+      timeline.scrollHeight - timeline.clientHeight
+    );
+    setTimelineScrollTopWithUserTransition(timeline, maxScrollTop);
+    timelineScrollAnchorRef.current = {
+      conversationId: activeConversationId,
+      scrollHeight: timeline.scrollHeight,
+      scrollTop: maxScrollTop,
+      clientHeight: timeline.clientHeight
+    };
+    setIsTimelineScrolledToTop(
+      maxScrollTop <= AGENT_GUI_TOP_MASK_SCROLL_EPSILON_PX
+    );
+    setIsTimelineScrolledToBottom(true);
+  }, [viewModel.activeConversationId]);
 
   return (
     <main className={styles.detail}>
@@ -2829,6 +2879,9 @@ const AgentGUIDetailPane = memo(function AgentGUIDetailPane({
       {hasActiveConversation ? (
         <AgentGUIBottomDockPane
           bottomDockRef={bottomDockRef}
+          showScrollToBottom={!isTimelineScrolledToBottom}
+          scrollToBottomLabel={labels.scrollToBottom}
+          onScrollToBottom={scrollTimelineToBottom}
           bottomDockLiftedPrompt={bottomDockLiftedPrompt}
           bottomDockReplacementPrompt={bottomDockReplacementPrompt}
           store={bottomDockStore}
@@ -3238,6 +3291,9 @@ function EmptyHeroTitle({
 
 interface AgentGUIBottomDockPaneProps {
   bottomDockRef: React.RefObject<HTMLDivElement | null>;
+  showScrollToBottom: boolean;
+  scrollToBottomLabel: string;
+  onScrollToBottom: () => void;
   // Approval / ask-user prompts lifted above the inline notice (composer stays
   // visible below). Mutually exclusive with bottomDockReplacementPrompt.
   bottomDockLiftedPrompt:
@@ -3268,6 +3324,9 @@ interface AgentGUIBottomDockPaneProps {
 
 const AgentGUIBottomDockPane = memo(function AgentGUIBottomDockPane({
   bottomDockRef,
+  showScrollToBottom,
+  scrollToBottomLabel,
+  onScrollToBottom,
   bottomDockLiftedPrompt,
   bottomDockReplacementPrompt,
   store,
@@ -3310,6 +3369,22 @@ const AgentGUIBottomDockPane = memo(function AgentGUIBottomDockPane({
       className={styles.bottomDock}
       data-testid="agent-gui-bottom-dock"
     >
+      {showScrollToBottom ? (
+        <button
+          type="button"
+          className={cn(
+            styles.bottomDockScrollToBottom,
+            "nodrag tsh-desktop-no-drag [-webkit-app-region:no-drag]"
+          )}
+          data-testid="agent-gui-scroll-to-bottom"
+          aria-label={scrollToBottomLabel}
+          title={scrollToBottomLabel}
+          onPointerDown={(event) => event.stopPropagation()}
+          onClick={onScrollToBottom}
+        >
+          <ChevronsDown aria-hidden="true" size={15} strokeWidth={2.2} />
+        </button>
+      ) : null}
       {bottomDockLiftedPrompt ? (
         <div
           className={styles.bottomDockPrompt}
@@ -5625,5 +5700,22 @@ function setTimelineScrollTopInstantly(
 ): void {
   // Timeline anchoring runs for high-frequency streaming updates. Smooth scrolling
   // queues animations that can overlap with incoming layout commits and make the transcript flicker.
+  element.scrollTop = top;
+}
+
+function setTimelineScrollTopWithUserTransition(
+  element: HTMLElement,
+  top: number
+): void {
+  const reducedMotion =
+    typeof window.matchMedia === "function" &&
+    window.matchMedia("(prefers-reduced-motion: reduce)").matches;
+  if (typeof element.scrollTo === "function") {
+    element.scrollTo({
+      top,
+      behavior: reducedMotion ? "auto" : "smooth"
+    });
+    return;
+  }
   element.scrollTop = top;
 }

--- a/packages/agent/gui/app/renderer/agentactivity.css
+++ b/packages/agent/gui/app/renderer/agentactivity.css
@@ -6293,6 +6293,62 @@ button.agent-gui-node__conversation-section-toggle:hover
   pointer-events: none;
 }
 
+.agent-gui-node__bottom-dock-scroll-to-bottom {
+  position: absolute;
+  bottom: calc(
+    100% + var(--agent-gui-bottom-dock-floating-safe-area, 0px) + 8px
+  );
+  left: 50%;
+  z-index: 6;
+  display: inline-grid;
+  place-items: center;
+  width: 34px;
+  height: 34px;
+  margin: 0;
+  padding: 0;
+  border: 1px solid
+    color-mix(in srgb, var(--line-2, var(--tutti-line-2)) 72%, transparent);
+  border-radius: 999px;
+  background: var(--background-fronted, var(--tutti-surface-1));
+  box-shadow: 0 10px 26px rgb(0 0 0 / 10%);
+  color: var(--text-secondary, var(--tutti-text-secondary));
+  pointer-events: auto;
+  cursor: pointer;
+  transform: translateX(-50%);
+  transition:
+    background 140ms ease,
+    color 140ms ease,
+    transform 140ms ease;
+}
+
+.agent-gui-node__bottom-dock-scroll-to-bottom:hover {
+  background: var(--background-fronted, var(--tutti-surface-1));
+  color: var(--text-primary, var(--tutti-text-primary));
+  transform: translateX(-50%) translateY(-1px);
+}
+
+.agent-gui-node__bottom-dock-scroll-to-bottom:focus-visible {
+  border-color: color-mix(
+    in srgb,
+    var(--text-secondary, var(--tutti-text-secondary)) 46%,
+    transparent
+  );
+  background: var(--background-fronted, var(--tutti-surface-1));
+  color: var(--text-primary, var(--tutti-text-primary));
+  outline: none;
+  transform: translateX(-50%) translateY(-1px);
+}
+
+.agent-gui-node__bottom-dock-scroll-to-bottom:active {
+  transform: translateX(-50%);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .agent-gui-node__bottom-dock-scroll-to-bottom {
+    transition: none;
+  }
+}
+
 .agent-gui-node__bottom-dock > .agent-gui-chrome__session-chrome,
 .agent-gui-node__bottom-dock-prompt,
 .agent-gui-node__bottom-dock

--- a/packages/agent/gui/app/renderer/i18n/locales/en.ts
+++ b/packages/agent/gui/app/renderer/i18n/locales/en.ts
@@ -694,6 +694,7 @@ export const en = {
       selectConversation: "Select a session",
       loadingConversations: "Loading sessions...",
       loadingConversation: "Loading session...",
+      scrollToBottom: "Scroll to bottom",
       searchNoConversations: "No related sessions",
       conversationUnavailable: "Session unavailable.",
       contextPickerBrowseHint: "Search workspace files based on your input",

--- a/packages/agent/gui/app/renderer/i18n/locales/zh-CN.ts
+++ b/packages/agent/gui/app/renderer/i18n/locales/zh-CN.ts
@@ -641,6 +641,7 @@ export const zhCN = {
       selectConversation: "选择一个会话",
       loadingConversations: "正在加载会话...",
       loadingConversation: "正在加载会话...",
+      scrollToBottom: "滚动至底部",
       searchNoConversations: "暂无相关会话",
       conversationUnavailable: "会话不可用。",
       contextPickerBrowseHint: "根据你输入的内容搜索工作区文件",


### PR DESCRIPTION
## Summary

- Add a floating scroll-to-bottom action above the AgentGUI composer when the transcript is scrolled away from the bottom.
- Keep the action out of normal bottom-dock layout so it does not truncate the message stream, while still lifting it above inline notices, active prompts, and queued prompts.
- Use smooth user-triggered scrolling with reduced-motion fallback and add localized labels.

## Validation

- `pnpm --filter @tutti-os/agent-gui test -- AgentGUINodeView.layout.spec.tsx`
- `git diff --check`
- `pnpm check:changed`
- `pnpm check:i18n`
- `pnpm check:full` (via pre-push with Node 24.18.0 and golangci-lint v2.12.0 on PATH)

## Notes

- Documentation impact check: no durable docs updated; this is a local AgentGUI interaction/style change without API, ownership, or data-flow changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a “Scroll to bottom” button in the agent conversation view when the timeline is not at the latest message.
  * The button uses localized text, with support added for English and Simplified Chinese.

* **Bug Fixes**
  * Improved scrolling behavior so the view more reliably stays anchored near the bottom and smoothly returns there when requested.
  * Adjusted the button’s positioning and visibility to work better with the bottom dock and safe-area layout.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->