### PR TITLE
fix(agent): stabilize Claude model discovery credentials

### DIFF
--- a/docs/conventions/troubleshooting.md
+++ b/docs/conventions/troubleshooting.md
@@ -1932,3 +1932,52 @@ target app`. Compare `/Applications/Tutti.app/Contents/Info.plist` with the
   Claude SDK sidecar process env includes `IS_SANDBOX=1`. Add callback coverage
   proving bypass mode allows an ordinary Bash request without
   `approval_requested`, while `AskUserQuestion` still surfaces user input.
+
+### Claude Code logs out after sending a message (invalid_grant, credentials wiped)
+
+- Symptom:
+  Inside the desktop app, sending a message around the OAuth token expiry window
+  leaves Claude Code in a "Not logged in · Please run /login" state. The keychain
+  entry (`Claude Code-credentials`) has empty `accessToken`/`refreshToken` and
+  `expiresAt: 0`, while the plaintext `~/.claude/.credentials.json` may still hold
+  a valid token. The Claude CLI alone does not reproduce it.
+- Quick checks:
+  Capture `/v1/oauth/token` traffic (mitmproxy). A failure may show `Client
+disconnected` immediately before later refresh attempts return `400
+invalid_grant`. Daemon logs may also show an extra `claude-code` process start
+  with `cwd=/`, `hasModel=false`, and a different `agent_session_id` from the
+  real conversation session; that shape is the hidden live-model discovery
+  session.
+- Root cause:
+  Composer-options loading spawned a hidden, `visible:false` Claude live-model
+  discovery session that shares the on-disk credential store with the real
+  conversation session and deleted it as soon as the model list was read. When
+  it performs an OAuth refresh near expiry, the server can rotate the refresh
+  token even if the local client disconnects before receiving or persisting the
+  response. The real session later refreshes with the now-consumed refresh
+  token, gets `400 invalid_grant`, and Claude Code wipes the stored credentials.
+  Because `fallbackStorage` prefers the (now empty) keychain entry over the
+  still-valid plaintext file, the user is locked out.
+- Fix:
+  Cold composer options must always have a static Claude fallback (`default`,
+  `opus`, `sonnet`, `haiku`, plus any configured custom model) so the UI never
+  depends on live discovery. A cold-start live discovery may run at most once per
+  provider/workspace/cwd cache key, but it must be hidden, serialized with other
+  Claude startups, and deleted only after a delayed grace period rather than
+  immediately after the model list appears. Successful discovery updates the
+  daemon live-model cache; later composer-options calls prefer cached models or
+  model options reported by a real running Claude session over the static
+  fallback. Claude Create model validation should only use cached live-model
+  options; it must not start discovery. If the daemon exits before the delayed
+  cleanup timer fires, later persisted-session reads must delete the stale
+  hidden discovery session instead of restoring it as a real conversation.
+- Validation:
+  Add daemon service tests for Create cache-only validation, SendInput waiting
+  on the Claude startup slot before runtime exec, static Claude cold-start model
+  options, reusing model options from a running Claude session, cold-start
+  discovery running once, delayed hidden discovery cleanup, and stale persisted
+  hidden discovery cleanup after restart. Run targeted agent service Go tests
+  plus the daemon Go lint/test/build lanes.
+- References:
+  [composer_live_model_discovery.go](../../services/tuttid/service/agent/composer_live_model_discovery.go)
+  [model_validation.go](../../services/tuttid/service/agent/model_validation.go)

--- a/services/tuttid/service/agent/composer_live_model_discovery.go
+++ b/services/tuttid/service/agent/composer_live_model_discovery.go
@@ -13,10 +13,85 @@ import (
 )
 
 const liveModelDiscoveryPollInterval = 100 * time.Millisecond
+const liveModelDiscoveryTimeout = 20 * time.Second
+const liveModelDiscoveryDeleteDelay = 10 * time.Minute
+const liveModelDiscoveryCleanupTimeout = 5 * time.Second
+
+// claudeStartupSerializer serializes credential-touching Claude startups so that
+// Tutti never runs two `claude` processes that both refresh the shared OAuth
+// token at the same time.
+//
+// Claude OAuth refresh rotates the refresh token. If two Claude startups
+// overlap and both read the same stale token, the later writer can leave the
+// shared credential store unusable. This is a channel-based mutex so acquisition
+// honors context cancel.
+type claudeStartupSerializer struct {
+	sem chan struct{}
+}
+
+func newClaudeStartupSerializer() *claudeStartupSerializer {
+	return &claudeStartupSerializer{sem: make(chan struct{}, 1)}
+}
+
+func (s *claudeStartupSerializer) acquire(ctx context.Context) error {
+	select {
+	case s.sem <- struct{}{}:
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}
+
+func (s *claudeStartupSerializer) release() {
+	select {
+	case <-s.sem:
+	default:
+	}
+}
+
+func (s *Service) claudeStartup() *claudeStartupSerializer {
+	if s.claudeStartupLock == nil {
+		s.claudeStartupLock = newClaudeStartupSerializer()
+	}
+	return s.claudeStartupLock
+}
+
+// awaitClaudeStartupSlot blocks until no other credential-touching Claude
+// startup is running, then returns a release function the caller must invoke
+// once its own session startup has completed. Non-Claude providers do not
+// participate and get a no-op release.
+func (s *Service) awaitClaudeStartupSlot(ctx context.Context, provider string) (func(), error) {
+	if agentprovider.Normalize(provider) != agentprovider.ClaudeCode {
+		return func() {}, nil
+	}
+	if err := s.claudeStartup().acquire(ctx); err != nil {
+		return nil, err
+	}
+	return s.claudeStartup().release, nil
+}
+
+// liveClaudeModelOptionsFromRunningSession returns the model list already
+// advertised by a live Claude session in the workspace, if any. It lets model
+// discovery reuse an in-flight conversation instead of spawning a second,
+// credential-sharing process next to it.
+func (s *Service) liveClaudeModelOptionsFromRunningSession(workspaceID string) ([]ComposerConfigOptionValue, bool) {
+	hasClaudeSession := false
+	for _, session := range s.controller().Sessions(workspaceID) {
+		if agentprovider.Normalize(session.Provider) != agentprovider.ClaudeCode {
+			continue
+		}
+		hasClaudeSession = true
+		if options := extractModelOptionsFromRuntimeContext(session.RuntimeContext); len(options) > 0 {
+			return options, true
+		}
+	}
+	return nil, hasClaudeSession
+}
 
 var liveComposerModelDiscoveryGroup singleflight.Group
 
 var errLiveModelDiscoverySessionFailed = errors.New("live model discovery session failed")
+var errLiveModelDiscoveryAlreadyAttempted = errors.New("live model discovery already attempted")
 
 func (s *Service) discoverLiveComposerModels(
 	ctx context.Context,
@@ -34,6 +109,9 @@ func (s *Service) discoverLiveComposerModels(
 		now := time.Now().UTC()
 		if cached, ok := s.getLiveComposerModelOptions(provider, workspaceID, cwd, now); ok && len(cached) > 0 {
 			return cached, nil
+		}
+		if !s.markLiveModelDiscoveryAttempted(cacheKey) {
+			return nil, errLiveModelDiscoveryAlreadyAttempted
 		}
 		discovered, discoverErr := s.discoverLiveComposerModelsUncached(ctx, workspaceID, cwd, settings)
 		if discoverErr != nil {
@@ -54,6 +132,23 @@ func (s *Service) discoverLiveComposerModels(
 	}
 }
 
+func (s *Service) markLiveModelDiscoveryAttempted(cacheKey string) bool {
+	cacheKey = strings.TrimSpace(cacheKey)
+	if cacheKey == "" {
+		return false
+	}
+	s.liveModelDiscoveryMu.Lock()
+	defer s.liveModelDiscoveryMu.Unlock()
+	if s.liveModelDiscoveryAttempted == nil {
+		s.liveModelDiscoveryAttempted = make(map[string]struct{})
+	}
+	if _, ok := s.liveModelDiscoveryAttempted[cacheKey]; ok {
+		return false
+	}
+	s.liveModelDiscoveryAttempted[cacheKey] = struct{}{}
+	return true
+}
+
 func (s *Service) discoverLiveComposerModelsUncached(
 	ctx context.Context,
 	workspaceID string,
@@ -61,9 +156,6 @@ func (s *Service) discoverLiveComposerModelsUncached(
 	settings ComposerSettings,
 ) ([]ComposerConfigOptionValue, error) {
 	provider := agentprovider.ClaudeCode
-	if err := s.ensureProviderRuntimeInstalled(ctx, provider); err != nil {
-		return nil, err
-	}
 	resolvedCwd := strings.TrimSpace(cwd)
 	if resolvedCwd != "" {
 		resolved, err := s.resolveCwd(ctx, &resolvedCwd)
@@ -72,6 +164,22 @@ func (s *Service) discoverLiveComposerModelsUncached(
 		}
 		resolvedCwd = resolved
 	}
+	if reused, hasClaudeSession := s.liveClaudeModelOptionsFromRunningSession(workspaceID); hasClaudeSession {
+		if len(reused) > 0 {
+			return reused, nil
+		}
+		return nil, errLiveModelDiscoveryAlreadyAttempted
+	}
+	if err := s.ensureProviderRuntimeInstalled(ctx, provider); err != nil {
+		return nil, err
+	}
+	spawnCtx, cancelSpawn := context.WithTimeout(ctx, liveModelDiscoveryTimeout)
+	defer cancelSpawn()
+	releaseStartup, err := s.awaitClaudeStartupSlot(spawnCtx, provider)
+	if err != nil {
+		return nil, err
+	}
+	var session RuntimeSession
 	visible := false
 	startInput := CreateSessionInput{
 		AgentSessionID:   uuid.NewString(),
@@ -85,36 +193,84 @@ func (s *Service) discoverLiveComposerModelsUncached(
 		Speed:            stringPointer(strings.TrimSpace(settings.Speed)),
 		Visible:          &visible,
 	}
-	prepared, err := s.prepareRuntime(ctx, workspaceID, resolvedCwd, startInput)
-	if err != nil {
-		return nil, err
-	}
-	session, err := s.controller().Start(ctx, RuntimeStartInput{
-		WorkspaceID:      workspaceID,
-		AgentSessionID:   startInput.AgentSessionID,
-		Provider:         provider,
-		Cwd:              prepared.Cwd,
-		Env:              prepared.Env,
-		PermissionModeID: value(startInput.PermissionModeID),
-		Model:            clampComposerModelForProvider(provider, value(startInput.Model)),
-		PlanMode:         clampComposerPlanModeForProvider(provider, valueBool(startInput.PlanMode)),
-		BrowserUse:       startInput.BrowserUse,
-		ComputerUse:      startInput.ComputerUse,
-		ReasoningEffort:  normalizeReasoningEffortForProvider(provider, value(startInput.ReasoningEffort)),
-		Speed:            normalizeSpeedForProvider(provider, value(startInput.Speed)),
-		Visible:          startInput.Visible,
-	})
+	session, err = func() (RuntimeSession, error) {
+		defer releaseStartup()
+		prepared, prepareErr := s.prepareRuntime(spawnCtx, workspaceID, resolvedCwd, startInput)
+		if prepareErr != nil {
+			return RuntimeSession{}, prepareErr
+		}
+		runtimeSession, startErr := s.controller().Start(spawnCtx, RuntimeStartInput{
+			WorkspaceID:      workspaceID,
+			AgentSessionID:   startInput.AgentSessionID,
+			Provider:         provider,
+			Cwd:              prepared.Cwd,
+			Env:              prepared.Env,
+			PermissionModeID: value(startInput.PermissionModeID),
+			Model:            clampComposerModelForProvider(provider, value(startInput.Model)),
+			PlanMode:         clampComposerPlanModeForProvider(provider, valueBool(startInput.PlanMode)),
+			BrowserUse:       startInput.BrowserUse,
+			ComputerUse:      startInput.ComputerUse,
+			ReasoningEffort:  normalizeReasoningEffortForProvider(provider, value(startInput.ReasoningEffort)),
+			Speed:            normalizeSpeedForProvider(provider, value(startInput.Speed)),
+			RuntimeContext: map[string]any{
+				"hiddenLiveModelDiscovery": true,
+				"visible":                  false,
+			},
+			Visible: startInput.Visible,
+		})
+		if startErr != nil {
+			return RuntimeSession{}, normalizeRuntimeError(startErr)
+		}
+		return runtimeSession, nil
+	}()
 	if err != nil {
 		cleanupErr := s.cleanupRuntime(ctx, workspaceID, startInput.AgentSessionID)
 		if cleanupErr != nil {
-			return nil, errors.Join(normalizeRuntimeError(err), cleanupErr)
+			return nil, errors.Join(err, cleanupErr)
 		}
-		return nil, normalizeRuntimeError(err)
+		return nil, err
 	}
-	defer func() {
-		_, _ = s.Delete(context.Background(), workspaceID, session.ID)
-	}()
-	return s.pollComposerModelOptions(ctx, workspaceID, session)
+	s.scheduleLiveModelDiscoveryDelete(workspaceID, session.ID)
+	return s.pollComposerModelOptions(spawnCtx, workspaceID, session)
+}
+
+func (s *Service) scheduleLiveModelDiscoveryDelete(workspaceID string, agentSessionID string) {
+	workspaceID = strings.TrimSpace(workspaceID)
+	agentSessionID = strings.TrimSpace(agentSessionID)
+	if workspaceID == "" || agentSessionID == "" {
+		return
+	}
+	delay := s.liveModelDiscoveryDeleteDelay()
+	time.AfterFunc(delay, func() {
+		cleanupCtx, cancelCleanup := context.WithTimeout(context.Background(), liveModelDiscoveryCleanupTimeout)
+		defer cancelCleanup()
+		_, _ = s.Delete(cleanupCtx, workspaceID, agentSessionID)
+	})
+}
+
+func (s *Service) liveModelDiscoveryDeleteDelay() time.Duration {
+	if s.LiveModelDiscoveryDeleteDelay != 0 {
+		return s.LiveModelDiscoveryDeleteDelay
+	}
+	return liveModelDiscoveryDeleteDelay
+}
+
+func isHiddenLiveModelDiscoveryRuntimeContext(runtimeContext map[string]any) bool {
+	hidden, _ := runtimeContext["hiddenLiveModelDiscovery"].(bool)
+	return hidden
+}
+
+func isStaleHiddenLiveModelDiscoverySession(session PersistedSession) bool {
+	if isHiddenLiveModelDiscoveryRuntimeContext(session.RuntimeContext) {
+		return true
+	}
+	if agentprovider.Normalize(session.Provider) != agentprovider.ClaudeCode {
+		return false
+	}
+	if visibleFromRuntimeContext(session.RuntimeContext, true) {
+		return false
+	}
+	return strings.TrimSpace(session.Settings.Model) == "" && strings.TrimSpace(session.Cwd) == "/"
 }
 
 func (s *Service) pollComposerModelOptions(
@@ -153,6 +309,30 @@ func liveModelDiscoverySessionFailureError(session RuntimeSession) error {
 		return errLiveModelDiscoverySessionFailed
 	}
 	return fmt.Errorf("%w: %s", errLiveModelDiscoverySessionFailed, lastError)
+}
+
+func staticClaudeComposerModelOptions(selectedModel string) []ComposerConfigOptionValue {
+	options := []ComposerConfigOptionValue{
+		{ID: "default", Label: "Default", Value: "default"},
+		{ID: "opus", Label: "Opus", Value: "opus"},
+		{ID: "sonnet", Label: "Sonnet", Value: "sonnet"},
+		{ID: "haiku", Label: "Haiku", Value: "haiku"},
+	}
+	selectedModel = strings.TrimSpace(selectedModel)
+	if selectedModel == "" {
+		return options
+	}
+	for _, option := range options {
+		if strings.TrimSpace(option.Value) == selectedModel {
+			return options
+		}
+	}
+	return append(options, ComposerConfigOptionValue{
+		ID:          selectedModel,
+		Label:       selectedModel,
+		Value:       selectedModel,
+		Description: "Claude configured custom model",
+	})
 }
 
 func extractModelOptionsFromRuntimeContext(runtimeContext map[string]any) []ComposerConfigOptionValue {
@@ -249,11 +429,21 @@ func (s *Service) mergeLiveComposerModelsForComposerOptions(
 ) (ComposerOptions, error) {
 	provider := agentprovider.ClaudeCode
 	var liveModels []ComposerConfigOptionValue
+	modelSource := "claude-static"
 	if strings.TrimSpace(input.WorkspaceID) != "" {
 		now := time.Now().UTC()
 		cached, ok := s.getLiveComposerModelOptions(provider, input.WorkspaceID, input.Cwd, now)
 		if ok {
 			liveModels = cached
+			modelSource = "acp-live-discovery"
+		} else if reused, hasClaudeSession := s.liveClaudeModelOptionsFromRunningSession(input.WorkspaceID); hasClaudeSession {
+			if len(reused) > 0 {
+				liveModels = reused
+				s.setLiveComposerModelOptions(provider, input.WorkspaceID, input.Cwd, now, reused)
+				modelSource = "acp-live-discovery"
+			}
+			// If a real Claude session exists but has not advertised a model list
+			// yet, do not spawn a hidden discovery session next to it.
 		} else {
 			discovered, err := s.discoverLiveComposerModels(ctx, input.WorkspaceID, input.Cwd, effectiveSettings)
 			if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
@@ -261,17 +451,25 @@ func (s *Service) mergeLiveComposerModelsForComposerOptions(
 			}
 			if err == nil && len(discovered) > 0 {
 				liveModels = discovered
-				s.setLiveComposerModelOptions(provider, input.WorkspaceID, input.Cwd, now, discovered)
+				modelSource = "acp-live-discovery"
 			}
 		}
 	}
 	if len(liveModels) > 0 {
-		return mergeLiveModelsIntoComposerOptions(options, liveModels), nil
+		return mergeComposerModelsIntoComposerOptions(options, liveModels, modelSource), nil
+	}
+	staticModels := staticClaudeComposerModelOptions(effectiveSettings.Model)
+	if len(staticModels) > 0 {
+		return mergeComposerModelsIntoComposerOptions(options, staticModels, modelSource), nil
 	}
 	return clearUnverifiedLiveComposerModel(options), nil
 }
 
 func mergeLiveModelsIntoComposerOptions(options ComposerOptions, liveModels []ComposerConfigOptionValue) ComposerOptions {
+	return mergeComposerModelsIntoComposerOptions(options, liveModels, "acp-live-discovery")
+}
+
+func mergeComposerModelsIntoComposerOptions(options ComposerOptions, liveModels []ComposerConfigOptionValue, modelSource string) ComposerOptions {
 	normalized := normalizeLiveComposerModelOptions(liveModels)
 	if len(normalized) == 0 {
 		return options
@@ -284,7 +482,7 @@ func mergeLiveModelsIntoComposerOptions(options ComposerOptions, liveModels []Co
 		DefaultValue: selected,
 		Options:      cloneComposerConfigOptionValues(normalized),
 	}
-	options.RuntimeContext = mergeLiveModelsIntoRuntimeContext(options.RuntimeContext, selected, normalized)
+	options.RuntimeContext = mergeLiveModelsIntoRuntimeContext(options.RuntimeContext, selected, normalized, modelSource)
 	return options
 }
 
@@ -370,6 +568,7 @@ func mergeLiveModelsIntoRuntimeContext(
 	runtimeContext map[string]any,
 	selectedModel string,
 	liveModels []ComposerConfigOptionValue,
+	modelSource string,
 ) map[string]any {
 	if runtimeContext == nil {
 		runtimeContext = map[string]any{}
@@ -389,7 +588,7 @@ func mergeLiveModelsIntoRuntimeContext(
 	}
 	runtimeContext["configOptions"] = configOptions
 	runtimeContext["model"] = nullableString(selectedModel)
-	runtimeContext["modelCatalogSource"] = "acp-live-discovery"
+	runtimeContext["modelCatalogSource"] = strings.TrimSpace(modelSource)
 	return runtimeContext
 }
 

--- a/services/tuttid/service/agent/model_validation.go
+++ b/services/tuttid/service/agent/model_validation.go
@@ -73,15 +73,7 @@ func (s *Service) availableComposerModelsForValidation(
 	case agentprovider.ClaudeCode:
 		models, ok := s.getLiveComposerModelOptions(provider, workspaceID, cwd, time.Now().UTC())
 		if !ok {
-			discovered, err := s.discoverLiveComposerModels(ctx, workspaceID, cwd, ComposerSettings{
-				PermissionModeID: defaultPermissionModeIDForProvider(provider),
-				ReasoningEffort:  composerDefaultReasoningEffort(provider),
-				Speed:            composerDefaultSpeed(provider),
-			})
-			if err != nil {
-				return nil, false, err
-			}
-			models = discovered
+			return nil, false, nil
 		}
 		return composerConfigOptionModelValues(models), true, nil
 	case agentprovider.Codex, agentprovider.Gemini:

--- a/services/tuttid/service/agent/service.go
+++ b/services/tuttid/service/agent/service.go
@@ -33,6 +33,7 @@ func NewService(runtime RuntimeController) *Service {
 		providerAvailabilityCache: newProviderAvailabilityCache(),
 		capabilityCatalogCache:    newComposerCapabilityCatalogCache(),
 		liveModelCache:            newComposerLiveModelCache(),
+		claudeStartupLock:         newClaudeStartupSerializer(),
 	}
 }
 
@@ -123,31 +124,41 @@ func (s *Service) Create(ctx context.Context, workspaceID string, input CreateSe
 	}
 	logAgentSubmitTrace("service.create.runtime_start_requested", workspaceID, input.AgentSessionID, input.Metadata, nil)
 	nodeStartedAt = time.Now()
-	session, err := s.controller().Start(ctx, RuntimeStartInput{
-		WorkspaceID:      workspaceID,
-		AgentSessionID:   strings.TrimSpace(input.AgentSessionID),
-		AgentTargetID:    input.AgentTargetID,
-		Provider:         provider,
-		Cwd:              prepared.Cwd,
-		Env:              prepared.Env,
-		Title:            value(input.Title),
-		PermissionModeID: value(input.PermissionModeID),
-		Model:            clampComposerModelForProvider(provider, value(input.Model)),
-		PlanMode:         clampComposerPlanModeForProvider(provider, valueBool(input.PlanMode)),
-		ReasoningEffort: normalizeReasoningEffortForProvider(
-			provider,
-			value(input.ReasoningEffort),
-		),
-		BrowserUse:        input.BrowserUse,
-		ComputerUse:       input.ComputerUse,
-		ProviderTargetRef: clonePayload(input.ProviderTargetRef),
-		Speed: normalizeSpeedForProvider(
-			provider,
-			value(input.Speed),
-		),
-		ConversationDetailMode: input.ConversationDetailMode,
-		Visible:                input.Visible,
-	})
+	// Wait out any in-flight Claude startup so this session never overlaps
+	// another credential-touching Claude process during OAuth refresh. Released
+	// as soon as this session has started.
+	releaseStartup, err := s.awaitClaudeStartupSlot(ctx, provider)
+	if err != nil {
+		return Session{}, cleanupPrepared(err)
+	}
+	session, err := func() (RuntimeSession, error) {
+		defer releaseStartup()
+		return s.controller().Start(ctx, RuntimeStartInput{
+			WorkspaceID:      workspaceID,
+			AgentSessionID:   strings.TrimSpace(input.AgentSessionID),
+			AgentTargetID:    input.AgentTargetID,
+			Provider:         provider,
+			Cwd:              prepared.Cwd,
+			Env:              prepared.Env,
+			Title:            value(input.Title),
+			PermissionModeID: value(input.PermissionModeID),
+			Model:            clampComposerModelForProvider(provider, value(input.Model)),
+			PlanMode:         clampComposerPlanModeForProvider(provider, valueBool(input.PlanMode)),
+			ReasoningEffort: normalizeReasoningEffortForProvider(
+				provider,
+				value(input.ReasoningEffort),
+			),
+			BrowserUse:        input.BrowserUse,
+			ComputerUse:       input.ComputerUse,
+			ProviderTargetRef: clonePayload(input.ProviderTargetRef),
+			Speed: normalizeSpeedForProvider(
+				provider,
+				value(input.Speed),
+			),
+			ConversationDetailMode: input.ConversationDetailMode,
+			Visible:                input.Visible,
+		})
+	}()
 	if err != nil {
 		normalizedErr := normalizeRuntimeError(err)
 		s.reportAgentServiceNodeFailure(ctx, input.AgentSessionID, "session_create", "runtime_started", provider, nodeStartedAt, normalizedErr)
@@ -424,6 +435,12 @@ func (s *Service) get(ctx context.Context, workspaceID string, agentSessionID st
 	}
 	if s.SessionReader != nil {
 		if persisted, ok := s.SessionReader.GetSession(workspaceID, agentSessionID); ok {
+			if isStaleHiddenLiveModelDiscoverySession(persisted) {
+				if _, err := s.Delete(ctx, workspaceID, agentSessionID); err != nil && !errors.Is(err, ErrSessionNotFound) {
+					return Session{}, err
+				}
+				return Session{}, ErrSessionNotFound
+			}
 			return sessionFromPersisted(
 				persisted,
 				persistedSessionCanResume(s.controller(), persisted),

--- a/services/tuttid/service/agent/service_resume_helpers.go
+++ b/services/tuttid/service/agent/service_resume_helpers.go
@@ -3,6 +3,7 @@ package agent
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"strings"
 
 	agentactivitybiz "github.com/tutti-os/tutti/services/tuttid/biz/agentactivity"
@@ -48,6 +49,12 @@ func (s *Service) ensureRuntimeSessionResult(
 	if !ok || strings.TrimSpace(persisted.Provider) == "" {
 		return ensuredRuntimeSession{}, ErrSessionNotFound
 	}
+	if isStaleHiddenLiveModelDiscoverySession(persisted) {
+		if _, err := s.Delete(ctx, workspaceID, agentSessionID); err != nil && !errors.Is(err, ErrSessionNotFound) {
+			return ensuredRuntimeSession{}, err
+		}
+		return ensuredRuntimeSession{}, ErrSessionNotFound
+	}
 	// Imported sessions used to be rejected here, which is what surfaced the
 	// "can't resume on this device, start a new conversation" dead-end. They now
 	// resume in place (same-device) or, when the provider session can't be
@@ -59,22 +66,32 @@ func (s *Service) ensureRuntimeSessionResult(
 	if err != nil {
 		return ensuredRuntimeSession{}, err
 	}
-	session, err := s.controller().Resume(ctx, RuntimeResumeInput{
-		WorkspaceID:       strings.TrimSpace(persisted.WorkspaceID),
-		AgentSessionID:    strings.TrimSpace(persisted.ID),
-		Provider:          strings.TrimSpace(persisted.Provider),
-		ProviderSessionID: strings.TrimSpace(persisted.ProviderSessionID),
-		Cwd:               strings.TrimSpace(prepared.Cwd),
-		Env:               append([]string(nil), prepared.Env...),
-		Title:             strings.TrimSpace(persisted.Title),
-		Status:            strings.TrimSpace(persisted.Status),
-		Settings:          cloneComposerSettings(persisted.Settings),
-		CreatedAtUnixMS:   persisted.CreatedAtUnixMS,
-		UpdatedAtUnixMS:   persisted.UpdatedAtUnixMS,
-		Visible:           boolPointer(visibleFromRuntimeContext(persisted.RuntimeContext, true)),
-		RuntimeContext:    clonePayload(persisted.RuntimeContext),
-		RecreateIfMissing: imported,
-	})
+	// Wait out any in-flight Claude startup so this resume never overlaps
+	// another credential-touching Claude process during OAuth refresh. Released
+	// as soon as the session has resumed.
+	releaseStartup, err := s.awaitClaudeStartupSlot(ctx, persisted.Provider)
+	if err != nil {
+		return ensuredRuntimeSession{}, err
+	}
+	session, err := func() (RuntimeSession, error) {
+		defer releaseStartup()
+		return s.controller().Resume(ctx, RuntimeResumeInput{
+			WorkspaceID:       strings.TrimSpace(persisted.WorkspaceID),
+			AgentSessionID:    strings.TrimSpace(persisted.ID),
+			Provider:          strings.TrimSpace(persisted.Provider),
+			ProviderSessionID: strings.TrimSpace(persisted.ProviderSessionID),
+			Cwd:               strings.TrimSpace(prepared.Cwd),
+			Env:               append([]string(nil), prepared.Env...),
+			Title:             strings.TrimSpace(persisted.Title),
+			Status:            strings.TrimSpace(persisted.Status),
+			Settings:          cloneComposerSettings(persisted.Settings),
+			CreatedAtUnixMS:   persisted.CreatedAtUnixMS,
+			UpdatedAtUnixMS:   persisted.UpdatedAtUnixMS,
+			Visible:           boolPointer(visibleFromRuntimeContext(persisted.RuntimeContext, true)),
+			RuntimeContext:    clonePayload(persisted.RuntimeContext),
+			RecreateIfMissing: imported,
+		})
+	}()
 	if err != nil {
 		return ensuredRuntimeSession{}, normalizeRuntimeError(err)
 	}

--- a/services/tuttid/service/agent/service_send_input.go
+++ b/services/tuttid/service/agent/service_send_input.go
@@ -47,13 +47,24 @@ func (s *Service) SendInput(ctx context.Context, workspaceID string, agentSessio
 	displayPrompt := strings.TrimSpace(input.DisplayPrompt)
 	logAgentSubmitTrace("service.send.exec_requested", workspaceID, agentSessionID, input.Metadata, nil)
 	nodeStartedAt = time.Now()
-	result, err := s.controller().Exec(ctx, RuntimeExecInput{
-		WorkspaceID:    workspaceID,
-		AgentSessionID: agentSessionID,
-		Content:        content,
-		DisplayPrompt:  displayPrompt,
-		Metadata:       cloneMetadata(input.Metadata),
-	})
+	// Exec may have to resume an idle-released Claude process inside the runtime
+	// controller. Hold the same startup slot used by Create/Resume while Exec
+	// performs that ensure-live step.
+	releaseStartup, err := s.awaitClaudeStartupSlot(ctx, provider)
+	if err != nil {
+		s.reportAgentServiceNodeFailure(ctx, agentSessionID, "message_send", "runtime_exec", provider, nodeStartedAt, err)
+		return SendInputResult{}, err
+	}
+	result, err := func() (RuntimeExecResult, error) {
+		defer releaseStartup()
+		return s.controller().Exec(ctx, RuntimeExecInput{
+			WorkspaceID:    workspaceID,
+			AgentSessionID: agentSessionID,
+			Content:        content,
+			DisplayPrompt:  displayPrompt,
+			Metadata:       cloneMetadata(input.Metadata),
+		})
+	}()
 	if err != nil {
 		normalizedErr := normalizeRuntimeError(err)
 		s.reportAgentServiceNodeFailure(ctx, agentSessionID, "message_send", "runtime_exec", provider, nodeStartedAt, normalizedErr)

--- a/services/tuttid/service/agent/service_session_list.go
+++ b/services/tuttid/service/agent/service_session_list.go
@@ -2,6 +2,7 @@ package agent
 
 import (
 	"context"
+	"errors"
 	"sort"
 	"strconv"
 	"strings"
@@ -41,7 +42,6 @@ func (s *Service) ListPage(ctx context.Context, workspaceID string, input ListSe
 }
 
 func (s *Service) listFilteredSortedSessions(ctx context.Context, workspaceID string, input ListSessionsInput) ([]Session, error) {
-	_ = ctx
 	workspaceID = strings.TrimSpace(workspaceID)
 	if workspaceID == "" {
 		return nil, ErrInvalidArgument
@@ -50,6 +50,15 @@ func (s *Service) listFilteredSortedSessions(ctx context.Context, workspaceID st
 	if s.SessionReader != nil {
 		if persisted, ok := s.SessionReader.ListSessions(workspaceID); ok {
 			for _, session := range persisted {
+				sessionID := strings.TrimSpace(session.ID)
+				if isStaleHiddenLiveModelDiscoverySession(session) {
+					if _, ok := s.controller().Session(workspaceID, sessionID); !ok {
+						if _, err := s.Delete(ctx, workspaceID, sessionID); err != nil && !errors.Is(err, ErrSessionNotFound) {
+							return nil, err
+						}
+					}
+					continue
+				}
 				sessionByID[strings.TrimSpace(session.ID)] = sessionFromPersisted(
 					session,
 					persistedSessionCanResume(s.controller(), session),

--- a/services/tuttid/service/agent/service_test.go
+++ b/services/tuttid/service/agent/service_test.go
@@ -1146,66 +1146,6 @@ func TestServiceCreateRejectsInvalidCachedClaudeModelBeforePreparingRuntime(t *t
 	}
 }
 
-func TestServiceCreateDiscoversClaudeModelsBeforeStartingInvalidModel(t *testing.T) {
-	runtime := newFakeRuntime()
-	runtime.startHook = func(input RuntimeStartInput, session RuntimeSession) RuntimeSession {
-		if input.Visible == nil || *input.Visible {
-			t.Fatalf("discovery start visible = %#v, want hidden draft session", input.Visible)
-		}
-		if input.Model != "" {
-			t.Fatalf("discovery start model = %q, want empty model", input.Model)
-		}
-		session.RuntimeContext = map[string]any{
-			"configOptions": []any{
-				map[string]any{
-					"id": "model",
-					"options": []any{
-						map[string]any{"value": "default", "name": "Default"},
-						map[string]any{"value": "sonnet", "name": "Sonnet"},
-						map[string]any{"value": "mimo-v2.5-pro", "name": "MIMO V2.5 Pro"},
-					},
-				},
-			},
-		}
-		return session
-	}
-	service := newTestService(runtime)
-	var prepareInput agentsidecarservice.PrepareInput
-	var cleanupCalls []agentsidecarservice.CleanupInput
-	service.RuntimePreparer = fakeRuntimePreparer{
-		input:        &prepareInput,
-		cleanupCalls: &cleanupCalls,
-	}
-
-	_, err := service.Create(context.Background(), "ws-1", CreateSessionInput{
-		AgentTargetID: agenttargetbiz.IDLocalClaudeCode,
-		Provider:      "claude-code",
-		Model:         stringRef("MiniMax-M2.7"),
-		Cwd:           stringRef("/repo"),
-	})
-	if err == nil {
-		t.Fatal("Create returned nil error, want invalid model error")
-	}
-	var invalidModel *InvalidModelError
-	if !errors.As(err, &invalidModel) {
-		t.Fatalf("Create error = %T %[1]v, want InvalidModelError", err)
-	}
-	if invalidModel.Provider != "claude-code" ||
-		invalidModel.Model != "MiniMax-M2.7" ||
-		!slices.Equal(invalidModel.AvailableModels, []string{"default", "sonnet", "mimo-v2.5-pro"}) {
-		t.Fatalf("invalid model error = %#v", invalidModel)
-	}
-	if len(runtime.startCalls) != 1 {
-		t.Fatalf("start calls = %d, want only hidden discovery session", len(runtime.startCalls))
-	}
-	if prepareInput.Provider != "claude-code" || prepareInput.Model != "" {
-		t.Fatalf("discovery prepare input = %#v, want claude-code without requested model", prepareInput)
-	}
-	if len(cleanupCalls) == 0 {
-		t.Fatal("cleanup calls = 0, want discovery runtime cleanup")
-	}
-}
-
 func TestServiceCreateUsesProviderDefaultModelWhenModelOmitted(t *testing.T) {
 	runtime := newFakeRuntime()
 	service := newTestService(runtime)
@@ -1639,6 +1579,29 @@ func TestServiceCreateEmptySessionDoesNotExec(t *testing.T) {
 	}
 }
 
+func TestServiceCreateClaudeModelValidationUsesOnlyCachedLiveModels(t *testing.T) {
+	t.Setenv("CLAUDE_CONFIG_DIR", t.TempDir())
+	runtime := newFakeRuntime()
+	service := newTestService(runtime)
+
+	_, err := service.Create(context.Background(), "ws-1", CreateSessionInput{
+		AgentSessionID: "session-1",
+		AgentTargetID:  agenttargetbiz.IDLocalClaudeCode,
+		Provider:       "claude-code",
+		Model:          stringRef("custom-claude-model"),
+		InitialContent: TextPromptContent("hello"),
+	})
+	if err != nil {
+		t.Fatalf("Create error = %v", err)
+	}
+	if len(runtime.startCalls) != 1 {
+		t.Fatalf("start calls = %d, want only real session start", len(runtime.startCalls))
+	}
+	if got := runtime.startCalls[0].AgentSessionID; got != "session-1" {
+		t.Fatalf("started session id = %q, want real session id", got)
+	}
+}
+
 func TestServiceCreateDoesNotPassDerivedPromptToRuntime(t *testing.T) {
 	runtime := newFakeRuntime()
 	service := newTestService(runtime)
@@ -1732,6 +1695,51 @@ func TestServiceSendInputPassesDisplayPromptToRuntime(t *testing.T) {
 	}
 	if _, ok := call.Metadata[""]; ok {
 		t.Fatalf("runtime metadata includes blank key: %#v", call.Metadata)
+	}
+}
+
+func TestServiceSendInputWaitsForClaudeStartupSlotBeforeExec(t *testing.T) {
+	runtime := newFakeRuntime()
+	runtime.sessions["ws-1:session-1"] = RuntimeSession{
+		ID:          "session-1",
+		WorkspaceID: "ws-1",
+		Provider:    "claude-code",
+		Status:      "ready",
+		Visible:     true,
+	}
+	service := NewService(runtime)
+	if err := service.claudeStartup().acquire(context.Background()); err != nil {
+		t.Fatalf("acquire startup lock: %v", err)
+	}
+
+	done := make(chan error, 1)
+	go func() {
+		_, err := service.SendInput(context.Background(), "ws-1", "session-1", SendInput{
+			Content: TextPromptContent("hello"),
+		})
+		done <- err
+	}()
+
+	select {
+	case err := <-done:
+		t.Fatalf("SendInput completed while startup slot held: %v", err)
+	case <-time.After(50 * time.Millisecond):
+	}
+	if len(runtime.execCalls) != 0 {
+		t.Fatalf("exec calls = %d, want blocked while startup slot held", len(runtime.execCalls))
+	}
+	service.claudeStartup().release()
+
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("SendInput error = %v", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("SendInput did not continue after startup slot release")
+	}
+	if len(runtime.execCalls) != 1 {
+		t.Fatalf("exec calls = %d, want 1 after startup slot release", len(runtime.execCalls))
 	}
 }
 
@@ -2252,12 +2260,19 @@ func TestServiceGetsComposerOptionsNormalizesClaudeMinimalReasoningEffort(t *tes
 	if !ok || len(configOptions) < 1 {
 		t.Fatalf("configOptions = %#v", options.RuntimeContext["configOptions"])
 	}
-	if configOptions[0]["id"] != "effort" {
-		t.Fatalf("first config option = %#v, want effort", configOptions[0])
+	var reasoningOption map[string]any
+	for _, option := range configOptions {
+		if option["id"] == "effort" {
+			reasoningOption = option
+			break
+		}
 	}
-	reasoningOptions, ok := configOptions[0]["options"].([]map[string]string)
+	if reasoningOption == nil {
+		t.Fatalf("configOptions = %#v, want effort option", configOptions)
+	}
+	reasoningOptions, ok := reasoningOption["options"].([]map[string]string)
 	if !ok {
-		t.Fatalf("reasoning options = %#v", configOptions[0]["options"])
+		t.Fatalf("reasoning options = %#v", reasoningOption["options"])
 	}
 	for _, option := range reasoningOptions {
 		if option["value"] == "minimal" {
@@ -2266,7 +2281,7 @@ func TestServiceGetsComposerOptionsNormalizesClaudeMinimalReasoningEffort(t *tes
 	}
 }
 
-func TestServiceGetsComposerOptionsSkipsClaudeStaticModelCatalog(t *testing.T) {
+func TestServiceGetsComposerOptionsUsesClaudeStaticModelsWithoutModelCatalog(t *testing.T) {
 	runtime := newFakeRuntime()
 	service := NewService(runtime)
 	t.Setenv("CLAUDE_CONFIG_DIR", t.TempDir())
@@ -2287,27 +2302,34 @@ func TestServiceGetsComposerOptionsSkipsClaudeStaticModelCatalog(t *testing.T) {
 	if err != nil {
 		t.Fatalf("GetComposerOptions returned error: %v", err)
 	}
-	if options.EffectiveSettings.Model != "" {
-		t.Fatalf("effectiveSettings.model = %q, want empty", options.EffectiveSettings.Model)
+	if options.EffectiveSettings.Model != "default" {
+		t.Fatalf("effectiveSettings.model = %q, want static default", options.EffectiveSettings.Model)
 	}
 	if options.EffectiveSettings.ReasoningEffort != "high" {
 		t.Fatalf("effectiveSettings.reasoningEffort = %q, want high", options.EffectiveSettings.ReasoningEffort)
 	}
-	if options.RuntimeContext["modelCatalogSource"] != nil {
-		t.Fatalf("modelCatalogSource = %#v, want nil", options.RuntimeContext["modelCatalogSource"])
+	if options.RuntimeContext["modelCatalogSource"] != "claude-static" {
+		t.Fatalf("modelCatalogSource = %#v, want claude-static", options.RuntimeContext["modelCatalogSource"])
 	}
 	configOptions, ok := options.RuntimeContext["configOptions"].([]map[string]any)
 	if !ok || len(configOptions) == 0 {
 		t.Fatalf("configOptions = %#v", options.RuntimeContext["configOptions"])
 	}
-	for _, option := range configOptions {
-		if option["id"] == "model" {
-			t.Fatalf("configOptions = %#v, want no static Claude model option", configOptions)
+	if configOptions[0]["id"] != "model" {
+		t.Fatalf("configOptions = %#v, want static Claude model option first", configOptions)
+	}
+	modelOptions, ok := configOptions[0]["options"].([]map[string]string)
+	if !ok || len(modelOptions) != 4 {
+		t.Fatalf("model options = %#v, want Claude static aliases", configOptions[0]["options"])
+	}
+	for _, option := range modelOptions {
+		if option["value"] == "test-ignored" {
+			t.Fatalf("model options = %#v, want no daemon ModelCatalog models for Claude", modelOptions)
 		}
 	}
 }
 
-func TestGetComposerOptionsClaudeCodeWithoutWorkspaceClearsUnverifiedSelectedModel(t *testing.T) {
+func TestGetComposerOptionsClaudeCodeWithoutWorkspaceUsesStaticModels(t *testing.T) {
 	runtime := newFakeRuntime()
 	service := NewService(runtime)
 
@@ -2321,34 +2343,70 @@ func TestGetComposerOptionsClaudeCodeWithoutWorkspaceClearsUnverifiedSelectedMod
 	if err != nil {
 		t.Fatalf("GetComposerOptions returned error: %v", err)
 	}
-	if options.EffectiveSettings.Model != "" {
-		t.Fatalf("effectiveSettings.model = %q, want empty without live model verification", options.EffectiveSettings.Model)
+	if options.EffectiveSettings.Model != "claude-sonnet-4-20250514" {
+		t.Fatalf("effectiveSettings.model = %q, want requested custom model", options.EffectiveSettings.Model)
 	}
-	if options.RuntimeContext["model"] != nil {
-		t.Fatalf("runtime model = %#v, want nil without live model verification", options.RuntimeContext["model"])
+	if options.RuntimeContext["model"] != "claude-sonnet-4-20250514" {
+		t.Fatalf("runtime model = %#v, want requested custom model", options.RuntimeContext["model"])
 	}
-	if options.ModelConfig.Configurable || len(options.ModelConfig.Options) != 0 {
-		t.Fatalf("modelConfig = %#v, want no unverified Claude model config", options.ModelConfig)
+	if !options.ModelConfig.Configurable || len(options.ModelConfig.Options) != 5 {
+		t.Fatalf("modelConfig = %#v, want static Claude models plus requested custom model", options.ModelConfig)
 	}
 	configOptions, ok := options.RuntimeContext["configOptions"].([]map[string]any)
 	if !ok || len(configOptions) == 0 {
 		t.Fatalf("configOptions = %#v", options.RuntimeContext["configOptions"])
 	}
-	for _, option := range configOptions {
-		if option["id"] == "model" {
-			t.Fatalf("configOptions = %#v, want no unverified Claude model option", configOptions)
-		}
+	if configOptions[0]["id"] != "model" {
+		t.Fatalf("configOptions = %#v, want static Claude model option first", configOptions)
+	}
+	if options.RuntimeContext["modelCatalogSource"] != "claude-static" {
+		t.Fatalf("modelCatalogSource = %#v, want claude-static", options.RuntimeContext["modelCatalogSource"])
 	}
 }
 
-func TestGetComposerOptionsClaudeCodeDiscoversLiveModels(t *testing.T) {
+func TestGetComposerOptionsClaudeCodeIncludesSettingsJSONModel(t *testing.T) {
+	configDir := t.TempDir()
+	t.Setenv("CLAUDE_CONFIG_DIR", configDir)
+	if err := os.WriteFile(filepath.Join(configDir, "settings.json"), []byte(`{"model":"claude-opus-4-6"}`), 0o600); err != nil {
+		t.Fatalf("write Claude settings: %v", err)
+	}
+	runtime := newFakeRuntime()
+	service := NewService(runtime)
+
+	options, err := service.GetComposerOptions(context.Background(), ComposerOptionsInput{
+		Provider: "claude-code",
+		Cwd:      "/repo",
+	})
+	if err != nil {
+		t.Fatalf("GetComposerOptions returned error: %v", err)
+	}
+	if options.EffectiveSettings.Model != "claude-opus-4-6" {
+		t.Fatalf("effectiveSettings.model = %q, want settings.json model", options.EffectiveSettings.Model)
+	}
+	found := false
+	for _, option := range options.ModelConfig.Options {
+		if option.Value == "claude-opus-4-6" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("modelConfig options = %#v, want settings.json model included", options.ModelConfig.Options)
+	}
+	if options.RuntimeContext["modelCatalogSource"] != "claude-static" {
+		t.Fatalf("modelCatalogSource = %#v, want claude-static", options.RuntimeContext["modelCatalogSource"])
+	}
+}
+
+func TestGetComposerOptionsClaudeCodeReusesRunningSessionLiveModels(t *testing.T) {
 	t.Setenv("CLAUDE_CONFIG_DIR", t.TempDir())
 	runtime := newFakeRuntime()
-	runtime.startHook = func(input RuntimeStartInput, session RuntimeSession) RuntimeSession {
-		if input.Provider != "claude-code" {
-			return session
-		}
-		session.RuntimeContext = map[string]any{
+	runtime.sessions["ws-1:session-1"] = RuntimeSession{
+		ID:          "session-1",
+		WorkspaceID: "ws-1",
+		Provider:    "claude-code",
+		Status:      "ready",
+		RuntimeContext: map[string]any{
 			"configOptions": []any{
 				map[string]any{
 					"id":           "model",
@@ -2366,8 +2424,7 @@ func TestGetComposerOptionsClaudeCodeDiscoversLiveModels(t *testing.T) {
 					},
 				},
 			},
-		}
-		return session
+		},
 	}
 	service := NewService(runtime)
 
@@ -2379,11 +2436,11 @@ func TestGetComposerOptionsClaudeCodeDiscoversLiveModels(t *testing.T) {
 	if err != nil {
 		t.Fatalf("GetComposerOptions returned error: %v", err)
 	}
-	if len(runtime.startCalls) != 1 {
-		t.Fatalf("start calls = %d, want 1", len(runtime.startCalls))
+	if len(runtime.startCalls) != 0 {
+		t.Fatalf("start calls = %d, want no hidden discovery", len(runtime.startCalls))
 	}
-	if len(runtime.closeCalls) != 1 {
-		t.Fatalf("close calls = %d, want 1", len(runtime.closeCalls))
+	if len(runtime.closeCalls) != 0 {
+		t.Fatalf("close calls = %d, want no hidden discovery cleanup", len(runtime.closeCalls))
 	}
 	if !options.ModelConfig.Configurable || len(options.ModelConfig.Options) != 2 {
 		t.Fatalf("modelConfig = %#v, want discovered model options", options.ModelConfig)
@@ -2400,14 +2457,12 @@ func TestGetComposerOptionsClaudeCodeDiscoversLiveModels(t *testing.T) {
 func TestGetComposerOptionsClaudeCodeLiveModelsSanitizesUnsupportedSelectedModel(t *testing.T) {
 	t.Setenv("CLAUDE_CONFIG_DIR", t.TempDir())
 	runtime := newFakeRuntime()
-	runtime.startHook = func(input RuntimeStartInput, session RuntimeSession) RuntimeSession {
-		if input.Provider != "claude-code" {
-			return session
-		}
-		if input.Model != "" {
-			t.Fatalf("discovery start model = %q, want empty model", input.Model)
-		}
-		session.RuntimeContext = map[string]any{
+	runtime.sessions["ws-1:session-1"] = RuntimeSession{
+		ID:          "session-1",
+		WorkspaceID: "ws-1",
+		Provider:    "claude-code",
+		Status:      "ready",
+		RuntimeContext: map[string]any{
 			"configOptions": []any{
 				map[string]any{
 					"id":           "model",
@@ -2420,8 +2475,7 @@ func TestGetComposerOptionsClaudeCodeLiveModelsSanitizesUnsupportedSelectedModel
 					},
 				},
 			},
-		}
-		return session
+		},
 	}
 	service := NewService(runtime)
 
@@ -2465,57 +2519,126 @@ func TestGetComposerOptionsClaudeCodeLiveModelsSanitizesUnsupportedSelectedModel
 	}
 }
 
-func TestGetComposerOptionsClaudeCodeDeletesHiddenDiscoverySession(t *testing.T) {
+func TestGetComposerOptionsClaudeCodeSkipsDiscoveryBesideRunningSession(t *testing.T) {
+	t.Setenv("CLAUDE_CONFIG_DIR", t.TempDir())
 	runtime := newFakeRuntime()
-	persisted := fakeSessionReader{sessions: map[string]PersistedSession{}}
+	runtime.sessions["ws-1:session-1"] = RuntimeSession{
+		ID:          "session-1",
+		WorkspaceID: "ws-1",
+		Provider:    "claude-code",
+		Status:      "ready",
+		RuntimeContext: map[string]any{
+			"capabilities": []any{"imageInput"},
+		},
+	}
+	service := NewService(runtime)
+
+	options, err := service.GetComposerOptions(context.Background(), ComposerOptionsInput{
+		Provider:    "claude-code",
+		WorkspaceID: "ws-1",
+		Cwd:         "/repo",
+	})
+	if err != nil {
+		t.Fatalf("GetComposerOptions returned error: %v", err)
+	}
+	if len(runtime.startCalls) != 0 {
+		t.Fatalf("start calls = %d, want no hidden discovery next to running session", len(runtime.startCalls))
+	}
+	if !options.ModelConfig.Configurable || len(options.ModelConfig.Options) != 4 {
+		t.Fatalf("modelConfig = %#v, want static Claude model config when running session has no models", options.ModelConfig)
+	}
+	if options.RuntimeContext["modelCatalogSource"] != "claude-static" {
+		t.Fatalf("modelCatalogSource = %#v, want claude-static", options.RuntimeContext["modelCatalogSource"])
+	}
+}
+
+func TestGetComposerOptionsClaudeCodeStartsHiddenDiscoveryOnceAndDeletesLater(t *testing.T) {
+	runtime := newFakeRuntime()
 	runtime.startHook = func(input RuntimeStartInput, session RuntimeSession) RuntimeSession {
 		if input.Provider != "claude-code" {
-			return session
+			t.Fatalf("start provider = %q, want claude-code", input.Provider)
+		}
+		if input.Visible == nil || *input.Visible {
+			t.Fatalf("visible = %#v, want hidden discovery session", input.Visible)
+		}
+		if input.RuntimeContext["hiddenLiveModelDiscovery"] != true {
+			t.Fatalf("runtime context = %#v, want hidden discovery marker", input.RuntimeContext)
 		}
 		session.RuntimeContext = map[string]any{
 			"configOptions": []any{
 				map[string]any{
 					"id":           "model",
-					"currentValue": "default",
+					"currentValue": "sonnet",
 					"options": []any{
-						map[string]any{"name": "Default", "value": "default"},
+						map[string]any{"name": "Sonnet", "value": "sonnet"},
+						map[string]any{"name": "Opus", "value": "opus"},
 					},
 				},
 			},
 		}
-		persisted.sessions[input.WorkspaceID+":"+session.ID] = PersistedSession{
-			ID:          session.ID,
-			WorkspaceID: input.WorkspaceID,
-			Provider:    input.Provider,
-			Visible:     session.Visible,
-		}
 		return session
 	}
 	service := NewService(runtime)
-	service.SessionReader = persisted
+	service.LiveModelDiscoveryDeleteDelay = 50 * time.Millisecond
 
-	if _, err := service.GetComposerOptions(context.Background(), ComposerOptionsInput{
+	options, err := service.GetComposerOptions(context.Background(), ComposerOptionsInput{
 		Provider:    "claude-code",
 		WorkspaceID: "ws-1",
 		Cwd:         "/repo",
-	}); err != nil {
+	})
+	if err != nil {
 		t.Fatalf("GetComposerOptions returned error: %v", err)
 	}
-	if len(runtime.closeCalls) != 1 {
-		t.Fatalf("close calls = %d, want 1", len(runtime.closeCalls))
+	if len(runtime.startCalls) != 1 {
+		t.Fatalf("start calls = %d, want one hidden discovery", len(runtime.startCalls))
 	}
-	if len(persisted.sessions) != 0 {
-		t.Fatalf("persisted sessions = %#v, want hidden discovery session deleted", persisted.sessions)
+	if len(runtime.closeCalls) != 0 {
+		t.Fatalf("close calls = %#v, want no immediate hidden discovery cleanup", runtime.closeCalls)
+	}
+	if !options.ModelConfig.Configurable || len(options.ModelConfig.Options) != 2 {
+		t.Fatalf("modelConfig = %#v, want discovered Claude model config", options.ModelConfig)
+	}
+	if options.RuntimeContext["modelCatalogSource"] != "acp-live-discovery" {
+		t.Fatalf("modelCatalogSource = %#v, want acp-live-discovery", options.RuntimeContext["modelCatalogSource"])
+	}
+
+	second, err := service.GetComposerOptions(context.Background(), ComposerOptionsInput{
+		Provider:    "claude-code",
+		WorkspaceID: "ws-1",
+		Cwd:         "/repo",
+	})
+	if err != nil {
+		t.Fatalf("GetComposerOptions second returned error: %v", err)
+	}
+	if len(runtime.startCalls) != 1 {
+		t.Fatalf("start calls = %d, want hidden discovery only once", len(runtime.startCalls))
+	}
+	if !second.ModelConfig.Configurable || len(second.ModelConfig.Options) != 2 {
+		t.Fatalf("second modelConfig = %#v, want cached discovered model config", second.ModelConfig)
+	}
+
+	deadline := time.After(2 * time.Second)
+	for len(runtime.closeCalls) == 0 {
+		select {
+		case <-deadline:
+			t.Fatalf("close calls = %#v, want delayed hidden discovery cleanup", runtime.closeCalls)
+		default:
+			time.Sleep(5 * time.Millisecond)
+		}
+	}
+	if runtime.closeCalls[0].AgentSessionID != runtime.startCalls[0].AgentSessionID {
+		t.Fatalf("close calls = %#v, want delayed cleanup for hidden discovery session %q", runtime.closeCalls, runtime.startCalls[0].AgentSessionID)
 	}
 }
 
 func TestGetComposerOptionsClaudeCodeLiveModelsUsesCache(t *testing.T) {
 	runtime := newFakeRuntime()
-	runtime.startHook = func(input RuntimeStartInput, session RuntimeSession) RuntimeSession {
-		if input.Provider != "claude-code" {
-			return session
-		}
-		session.RuntimeContext = map[string]any{
+	runtime.sessions["ws-1:session-1"] = RuntimeSession{
+		ID:          "session-1",
+		WorkspaceID: "ws-1",
+		Provider:    "claude-code",
+		Status:      "ready",
+		RuntimeContext: map[string]any{
 			"configOptions": []any{
 				map[string]any{
 					"id":           "model",
@@ -2525,13 +2648,12 @@ func TestGetComposerOptionsClaudeCodeLiveModelsUsesCache(t *testing.T) {
 					},
 				},
 			},
-		}
-		return session
+		},
 	}
 	service := NewService(runtime)
 
-	for range 2 {
-		_, err := service.GetComposerOptions(context.Background(), ComposerOptionsInput{
+	for index := range 2 {
+		options, err := service.GetComposerOptions(context.Background(), ComposerOptionsInput{
 			Provider:    "claude-code",
 			WorkspaceID: "ws-1",
 			Cwd:         "/repo",
@@ -2539,164 +2661,18 @@ func TestGetComposerOptionsClaudeCodeLiveModelsUsesCache(t *testing.T) {
 		if err != nil {
 			t.Fatalf("GetComposerOptions returned error: %v", err)
 		}
-	}
-	if len(runtime.startCalls) != 1 {
-		t.Fatalf("start calls = %d, want 1 with cache", len(runtime.startCalls))
-	}
-	if len(runtime.closeCalls) != 1 {
-		t.Fatalf("close calls = %d, want 1 with cache", len(runtime.closeCalls))
-	}
-}
-
-func TestGetComposerOptionsClaudeCodeLiveModelsFailedStartupReturnsQuickly(t *testing.T) {
-	runtime := newFakeRuntime()
-	runtime.startHook = func(input RuntimeStartInput, session RuntimeSession) RuntimeSession {
-		if input.Provider != "claude-code" {
-			return session
+		if !options.ModelConfig.Configurable || len(options.ModelConfig.Options) != 1 {
+			t.Fatalf("modelConfig = %#v, want cached live models", options.ModelConfig)
 		}
-		session.Status = "failed"
-		session.LastError = "auth failed"
-		return session
-	}
-	service := NewService(runtime)
-	startedAt := time.Now()
-
-	options, err := service.GetComposerOptions(context.Background(), ComposerOptionsInput{
-		Provider:    "claude-code",
-		WorkspaceID: "ws-failed",
-		Cwd:         "/repo",
-		Settings: ComposerSettings{
-			Model: "claude-sonnet-4-20250514",
-		},
-	})
-	if err != nil {
-		t.Fatalf("GetComposerOptions returned error: %v", err)
-	}
-	if elapsed := time.Since(startedAt); elapsed >= 400*time.Millisecond {
-		t.Fatalf("GetComposerOptions elapsed = %s, want failed discovery to return quickly", elapsed)
-	}
-	if len(runtime.closeCalls) != 1 {
-		t.Fatalf("close calls = %d, want 1", len(runtime.closeCalls))
-	}
-	if options.ModelConfig.Configurable || len(options.ModelConfig.Options) != 0 {
-		t.Fatalf("modelConfig = %#v, want no unverified Claude model config after failed discovery", options.ModelConfig)
-	}
-	if options.EffectiveSettings.Model != "" {
-		t.Fatalf("effectiveSettings.model = %q, want empty after failed live model verification", options.EffectiveSettings.Model)
-	}
-	if options.RuntimeContext["model"] != nil {
-		t.Fatalf("runtime model = %#v, want nil after failed live model verification", options.RuntimeContext["model"])
-	}
-}
-
-func TestGetComposerOptionsClaudeCodeLiveModelsPropagatesCallerCancellation(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-	runtime := newFakeRuntime()
-	closed := make(chan struct{})
-	runtime.closeHook = func(RuntimeCloseInput) {
-		select {
-		case <-closed:
-		default:
-			close(closed)
+		if index == 0 {
+			delete(runtime.sessions, "ws-1:session-1")
 		}
 	}
-	runtime.startHook = func(input RuntimeStartInput, session RuntimeSession) RuntimeSession {
-		if input.Provider == "claude-code" {
-			cancel()
-		}
-		return session
+	if len(runtime.startCalls) != 0 {
+		t.Fatalf("start calls = %d, want no hidden discovery", len(runtime.startCalls))
 	}
-	service := NewService(runtime)
-
-	_, err := service.GetComposerOptions(ctx, ComposerOptionsInput{
-		Provider:    "claude-code",
-		WorkspaceID: "ws-canceled",
-		Cwd:         "/repo",
-	})
-	if !errors.Is(err, context.Canceled) {
-		t.Fatalf("GetComposerOptions error = %v, want context canceled", err)
-	}
-	if len(runtime.startCalls) != 1 {
-		t.Fatalf("start calls = %d, want 1", len(runtime.startCalls))
-	}
-	select {
-	case <-closed:
-	case <-time.After(time.Second):
-		t.Fatal("runtime close was not called after caller cancellation")
-	}
-	if len(runtime.closeCalls) != 1 {
-		t.Fatalf("close calls = %d, want 1 even on caller cancellation", len(runtime.closeCalls))
-	}
-}
-
-func TestGetComposerOptionsClaudeCodeLiveModelsSharedDiscoveryHonorsCallerCancellation(t *testing.T) {
-	runtime := newFakeRuntime()
-	firstStarted := make(chan struct{})
-	firstClosed := make(chan struct{})
-	runtime.closeHook = func(RuntimeCloseInput) {
-		select {
-		case <-firstClosed:
-		default:
-			close(firstClosed)
-		}
-	}
-	runtime.startHook = func(input RuntimeStartInput, session RuntimeSession) RuntimeSession {
-		if input.Provider == "claude-code" {
-			select {
-			case <-firstStarted:
-			default:
-				close(firstStarted)
-			}
-		}
-		return session
-	}
-	service := NewService(runtime)
-	firstCtx, cancelFirst := context.WithCancel(context.Background())
-	defer cancelFirst()
-	firstDone := make(chan error, 1)
-	go func() {
-		_, err := service.GetComposerOptions(firstCtx, ComposerOptionsInput{
-			Provider:    "claude-code",
-			WorkspaceID: "ws-shared-canceled",
-			Cwd:         "/repo",
-		})
-		firstDone <- err
-	}()
-
-	select {
-	case <-firstStarted:
-	case <-time.After(time.Second):
-		t.Fatal("first live model discovery did not start")
-	}
-
-	secondCtx, cancelSecond := context.WithCancel(context.Background())
-	cancelSecond()
-	_, err := service.GetComposerOptions(secondCtx, ComposerOptionsInput{
-		Provider:    "claude-code",
-		WorkspaceID: "ws-shared-canceled",
-		Cwd:         "/repo",
-	})
-	if !errors.Is(err, context.Canceled) {
-		t.Fatalf("GetComposerOptions error = %v, want context canceled for shared caller", err)
-	}
-	if len(runtime.startCalls) != 1 {
-		t.Fatalf("start calls = %d, want 1 shared live model discovery", len(runtime.startCalls))
-	}
-
-	cancelFirst()
-	select {
-	case err := <-firstDone:
-		if !errors.Is(err, context.Canceled) {
-			t.Fatalf("first GetComposerOptions error = %v, want context canceled", err)
-		}
-	case <-time.After(time.Second):
-		t.Fatal("first live model discovery did not stop after cancellation")
-	}
-	select {
-	case <-firstClosed:
-	case <-time.After(time.Second):
-		t.Fatal("shared live model discovery did not close after cancellation")
+	if len(runtime.closeCalls) != 0 {
+		t.Fatalf("close calls = %d, want no hidden discovery cleanup", len(runtime.closeCalls))
 	}
 }
 
@@ -3482,6 +3458,43 @@ func TestServiceListFilteredMatchesSearchVisibilityLimitAndUpdatedOrder(t *testi
 	}
 	if list[0].ID != "session-newer" {
 		t.Fatalf("list[0].ID = %q, want session-newer", list[0].ID)
+	}
+}
+
+func TestServiceListDeletesStalePersistedHiddenLiveModelDiscoverySession(t *testing.T) {
+	reader := fakeSessionReader{
+		sessions: map[string]PersistedSession{
+			"ws-1:hidden": {
+				ID:          "hidden",
+				WorkspaceID: "ws-1",
+				Provider:    "claude-code",
+				Cwd:         "/",
+				RuntimeContext: map[string]any{
+					"visible": false,
+				},
+				UpdatedAtUnixMS: time.UnixMilli(5000).UnixMilli(),
+			},
+			"ws-1:session-1": {
+				ID:              "session-1",
+				WorkspaceID:     "ws-1",
+				Provider:        "claude-code",
+				Visible:         true,
+				UpdatedAtUnixMS: time.UnixMilli(4000).UnixMilli(),
+			},
+		},
+	}
+	service := NewService(newFakeRuntime())
+	service.SessionReader = reader
+
+	list, err := service.List(context.Background(), "ws-1")
+	if err != nil {
+		t.Fatalf("List returned error: %v", err)
+	}
+	if len(list) != 1 || list[0].ID != "session-1" {
+		t.Fatalf("sessions = %#v, want only session-1", list)
+	}
+	if _, ok := reader.sessions["ws-1:hidden"]; ok {
+		t.Fatal("hidden discovery session still persisted, want deleted")
 	}
 }
 
@@ -4419,6 +4432,32 @@ func TestServiceEnsureRuntimeSessionDoesNotReconcileLiveRuntimeWaitingApprovalTu
 	}
 }
 
+func TestServiceEnsureRuntimeSessionDeletesStalePersistedHiddenLiveModelDiscoverySession(t *testing.T) {
+	reader := fakeSessionReader{
+		sessions: map[string]PersistedSession{
+			"ws-1:hidden": {
+				ID:          "hidden",
+				WorkspaceID: "ws-1",
+				Provider:    "claude-code",
+				Cwd:         "/",
+				RuntimeContext: map[string]any{
+					"visible": false,
+				},
+			},
+		},
+	}
+	service := NewService(newFakeRuntime())
+	service.SessionReader = reader
+
+	_, err := service.ensureRuntimeSessionResult(context.Background(), "ws-1", "hidden")
+	if !errors.Is(err, ErrSessionNotFound) {
+		t.Fatalf("ensureRuntimeSessionResult error = %v, want %v", err, ErrSessionNotFound)
+	}
+	if _, ok := reader.sessions["ws-1:hidden"]; ok {
+		t.Fatal("hidden discovery session still persisted, want deleted")
+	}
+}
+
 func TestServiceGetDoesNotReconcileLiveRuntimePendingInteractive(t *testing.T) {
 	runtime := newFakeRuntime()
 	runtime.sessions["ws-1:session-1"] = RuntimeSession{
@@ -5121,6 +5160,7 @@ func (f *fakeRuntime) Start(_ context.Context, input RuntimeStartInput) (Runtime
 		Status:          "ready",
 		Title:           input.Title,
 		Visible:         input.Visible == nil || *input.Visible,
+		RuntimeContext:  clonePayload(input.RuntimeContext),
 		WorkspaceID:     input.WorkspaceID,
 		CreatedAtUnixMS: now,
 		UpdatedAtUnixMS: now,

--- a/services/tuttid/service/agent/session_types.go
+++ b/services/tuttid/service/agent/session_types.go
@@ -2,6 +2,7 @@ package agent
 
 import (
 	"context"
+	"sync"
 	"time"
 
 	agentactivitybiz "github.com/tutti-os/tutti/services/tuttid/biz/agentactivity"
@@ -12,26 +13,30 @@ import (
 )
 
 type Service struct {
-	Runtime                      RuntimeController
-	AnalyticsReporter            reporterservice.Reporter
-	AvailabilityChecker          ProviderAvailabilityChecker
-	ModelCatalog                 AgentModelCatalog
-	AgentTargetStore             AgentTargetStore
-	SessionReader                SessionReader
-	UserProjectReader            UserProjectReader
-	MessageReader                MessageReader
-	ExternalImportStore          agentactivitybiz.Repository
-	SessionDirectoryAllocator    SessionDirectoryAllocator
-	PromptAttachmentStore        PromptAttachmentStore
-	RuntimePreparer              agentsidecarservice.Preparer
-	CapabilityLister             ComposerCapabilityLister
-	ProviderAvailabilityCacheTTL time.Duration
-	CapabilityCatalogCacheTTL    time.Duration
-	LiveModelCacheTTL            time.Duration
-	skillOptionsCache            *composerSkillOptionsCache
-	providerAvailabilityCache    *providerAvailabilityCache
-	capabilityCatalogCache       *composerCapabilityCatalogCache
-	liveModelCache               *composerLiveModelCache
+	Runtime                       RuntimeController
+	AnalyticsReporter             reporterservice.Reporter
+	AvailabilityChecker           ProviderAvailabilityChecker
+	ModelCatalog                  AgentModelCatalog
+	AgentTargetStore              AgentTargetStore
+	SessionReader                 SessionReader
+	UserProjectReader             UserProjectReader
+	MessageReader                 MessageReader
+	ExternalImportStore           agentactivitybiz.Repository
+	SessionDirectoryAllocator     SessionDirectoryAllocator
+	PromptAttachmentStore         PromptAttachmentStore
+	RuntimePreparer               agentsidecarservice.Preparer
+	CapabilityLister              ComposerCapabilityLister
+	ProviderAvailabilityCacheTTL  time.Duration
+	CapabilityCatalogCacheTTL     time.Duration
+	LiveModelCacheTTL             time.Duration
+	LiveModelDiscoveryDeleteDelay time.Duration
+	skillOptionsCache             *composerSkillOptionsCache
+	providerAvailabilityCache     *providerAvailabilityCache
+	capabilityCatalogCache        *composerCapabilityCatalogCache
+	liveModelCache                *composerLiveModelCache
+	claudeStartupLock             *claudeStartupSerializer
+	liveModelDiscoveryMu          sync.Mutex
+	liveModelDiscoveryAttempted   map[string]struct{}
 }
 
 type StaleTurnResumeReconciler interface {


### PR DESCRIPTION
## Summary
- add a static Claude composer model fallback so cold-start options do not depend on live discovery
- run hidden Claude live-model discovery at most once per cache key and delay cleanup for ten minutes after successful discovery
- reuse model options from real Claude sessions, skip hidden discovery beside active sessions without options, and clean up stale hidden discovery records after restart
- document the Claude OAuth invalid_grant troubleshooting path

## Validation
- pnpm check:changed --tail-lines 80
- cd services/tuttid && go test ./service/agent/...
- git diff --check
- pre-push pnpm check:full
- manual OAuth near-expiry dev-gui test: hidden discovery started once, real Claude messages completed, keychain tokens remained present, second message did not update keychain, hidden discovery was deleted after the ten-minute grace period


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where Claude Code could unexpectedly log out after sending a message.
  * Improved reliability of model selection so the app falls back to available models when live discovery is unavailable.
  * Cleaned up stale hidden sessions automatically to reduce session and sign-in issues.
  * Prevented duplicate background discovery attempts, improving stability when multiple actions happen at once.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->