### PR TITLE
fix(agent-daemon): rename module path to match packages/agent/daemon directory

### DIFF
--- a/packages/agent/daemon/activity/client.go
+++ b/packages/agent/daemon/activity/client.go
@@ -16,8 +16,8 @@ import (
 	"strings"
 	"time"
 
-	"github.com/tutti-os/tutti/packages/agentactivity/daemon/httpx"
-	controlplanehttp "github.com/tutti-os/tutti/packages/agentactivity/daemon/internal/httpclient"
+	"github.com/tutti-os/tutti/packages/agent/daemon/httpx"
+	controlplanehttp "github.com/tutti-os/tutti/packages/agent/daemon/internal/httpclient"
 )
 
 func NewClient(cfg Config) *Client {

--- a/packages/agent/daemon/activity/events/context/config.go
+++ b/packages/agent/daemon/activity/events/context/config.go
@@ -6,8 +6,8 @@ import (
 	"os"
 	"strings"
 
-	hostservicespkg "github.com/tutti-os/tutti/packages/agentactivity/daemon/internal/hostservices"
-	runtimepaths "github.com/tutti-os/tutti/packages/agentactivity/daemon/internal/runtimepaths"
+	hostservicespkg "github.com/tutti-os/tutti/packages/agent/daemon/internal/hostservices"
+	runtimepaths "github.com/tutti-os/tutti/packages/agent/daemon/internal/runtimepaths"
 )
 
 const ServiceGroup = "agent-context"

--- a/packages/agent/daemon/activity/events/relay_config.go
+++ b/packages/agent/daemon/activity/events/relay_config.go
@@ -1,6 +1,6 @@
 package events
 
-import hostservicespkg "github.com/tutti-os/tutti/packages/agentactivity/daemon/internal/hostservices"
+import hostservicespkg "github.com/tutti-os/tutti/packages/agent/daemon/internal/hostservices"
 
 const (
 	ServiceGroup = "agent-activity"

--- a/packages/agent/daemon/activity/functional_test.go
+++ b/packages/agent/daemon/activity/functional_test.go
@@ -7,7 +7,7 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	agentsessionstore "github.com/tutti-os/tutti/packages/agentactivity/daemon/activity"
+	agentsessionstore "github.com/tutti-os/tutti/packages/agent/daemon/activity"
 )
 
 func TestWorkspaceAgentMessageFunctionalFlow(t *testing.T) {

--- a/packages/agent/daemon/activity/hostquery/service.go
+++ b/packages/agent/daemon/activity/hostquery/service.go
@@ -6,8 +6,8 @@ import (
 	"strings"
 	"sync"
 
-	agentsessionstore "github.com/tutti-os/tutti/packages/agentactivity/daemon/activity"
-	guestdesktoprelayv1 "github.com/tutti-os/tutti/packages/agentactivity/daemon/internal/guestdesktoprelay/v1"
+	agentsessionstore "github.com/tutti-os/tutti/packages/agent/daemon/activity"
+	guestdesktoprelayv1 "github.com/tutti-os/tutti/packages/agent/daemon/internal/guestdesktoprelay/v1"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"

--- a/packages/agent/daemon/activity/hostquery/service_test.go
+++ b/packages/agent/daemon/activity/hostquery/service_test.go
@@ -4,8 +4,8 @@ import (
 	"context"
 	"testing"
 
-	agentsessionstore "github.com/tutti-os/tutti/packages/agentactivity/daemon/activity"
-	guestdesktoprelayv1 "github.com/tutti-os/tutti/packages/agentactivity/daemon/internal/guestdesktoprelay/v1"
+	agentsessionstore "github.com/tutti-os/tutti/packages/agent/daemon/activity"
+	guestdesktoprelayv1 "github.com/tutti-os/tutti/packages/agent/daemon/internal/guestdesktoprelay/v1"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 )

--- a/packages/agent/daemon/activity/ingress/dispatch.go
+++ b/packages/agent/daemon/activity/ingress/dispatch.go
@@ -5,8 +5,8 @@ import (
 	"strings"
 	"sync"
 
-	agentsessionstore "github.com/tutti-os/tutti/packages/agentactivity/daemon/activity"
-	guestdesktoprelayv1 "github.com/tutti-os/tutti/packages/agentactivity/daemon/internal/guestdesktoprelay/v1"
+	agentsessionstore "github.com/tutti-os/tutti/packages/agent/daemon/activity"
+	guestdesktoprelayv1 "github.com/tutti-os/tutti/packages/agent/daemon/internal/guestdesktoprelay/v1"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"

--- a/packages/agent/daemon/activity/ingress/dispatch_test.go
+++ b/packages/agent/daemon/activity/ingress/dispatch_test.go
@@ -4,8 +4,8 @@ import (
 	"context"
 	"testing"
 
-	agentsessionstore "github.com/tutti-os/tutti/packages/agentactivity/daemon/activity"
-	guestdesktoprelayv1 "github.com/tutti-os/tutti/packages/agentactivity/daemon/internal/guestdesktoprelay/v1"
+	agentsessionstore "github.com/tutti-os/tutti/packages/agent/daemon/activity"
+	guestdesktoprelayv1 "github.com/tutti-os/tutti/packages/agent/daemon/internal/guestdesktoprelay/v1"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 )

--- a/packages/agent/daemon/activity/ingress/service.go
+++ b/packages/agent/daemon/activity/ingress/service.go
@@ -5,8 +5,8 @@ import (
 	"fmt"
 	"strings"
 
-	agentsessionstore "github.com/tutti-os/tutti/packages/agentactivity/daemon/activity"
-	guestdesktoprelayv1 "github.com/tutti-os/tutti/packages/agentactivity/daemon/internal/guestdesktoprelay/v1"
+	agentsessionstore "github.com/tutti-os/tutti/packages/agent/daemon/activity"
+	guestdesktoprelayv1 "github.com/tutti-os/tutti/packages/agent/daemon/internal/guestdesktoprelay/v1"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"

--- a/packages/agent/daemon/activity/ingress/service_test.go
+++ b/packages/agent/daemon/activity/ingress/service_test.go
@@ -5,8 +5,8 @@ import (
 	"errors"
 	"testing"
 
-	agentsessionstore "github.com/tutti-os/tutti/packages/agentactivity/daemon/activity"
-	guestdesktoprelayv1 "github.com/tutti-os/tutti/packages/agentactivity/daemon/internal/guestdesktoprelay/v1"
+	agentsessionstore "github.com/tutti-os/tutti/packages/agent/daemon/activity"
+	guestdesktoprelayv1 "github.com/tutti-os/tutti/packages/agent/daemon/internal/guestdesktoprelay/v1"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/types/known/structpb"

--- a/packages/agent/daemon/activity/service.go
+++ b/packages/agent/daemon/activity/service.go
@@ -12,7 +12,7 @@ import (
 	"sync"
 	"time"
 
-	activityshared "github.com/tutti-os/tutti/packages/agentactivity/daemon/activity/events"
+	activityshared "github.com/tutti-os/tutti/packages/agent/daemon/activity/events"
 )
 
 type State struct {

--- a/packages/agent/daemon/activity/service_test.go
+++ b/packages/agent/daemon/activity/service_test.go
@@ -6,7 +6,7 @@ import (
 	"reflect"
 	"testing"
 
-	activityshared "github.com/tutti-os/tutti/packages/agentactivity/daemon/activity/events"
+	activityshared "github.com/tutti-os/tutti/packages/agent/daemon/activity/events"
 )
 
 func TestStoreTracksRoomsAndClonesState(t *testing.T) {

--- a/packages/agent/daemon/go.mod
+++ b/packages/agent/daemon/go.mod
@@ -1,4 +1,4 @@
-module github.com/tutti-os/tutti/packages/agentactivity/daemon
+module github.com/tutti-os/tutti/packages/agent/daemon
 
 go 1.24.3
 

--- a/packages/agent/daemon/httpx/client.go
+++ b/packages/agent/daemon/httpx/client.go
@@ -12,7 +12,7 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/tutti-os/tutti/packages/agentactivity/daemon/runtimecmd"
+	"github.com/tutti-os/tutti/packages/agent/daemon/runtimecmd"
 )
 
 // NewTransport clones the default transport and makes it proxy-aware.

--- a/packages/agent/daemon/runtime.go
+++ b/packages/agent/daemon/runtime.go
@@ -8,7 +8,7 @@ import (
 	"sync"
 	"time"
 
-	agentruntime "github.com/tutti-os/tutti/packages/agentactivity/daemon/runtime"
+	agentruntime "github.com/tutti-os/tutti/packages/agent/daemon/runtime"
 )
 
 var ErrHostMetadataRequired = errors.New("agent daemon host metadata is required")

--- a/packages/agent/daemon/runtime/acp_assert_helpers_test.go
+++ b/packages/agent/daemon/runtime/acp_assert_helpers_test.go
@@ -4,8 +4,8 @@ import (
 	"testing"
 	"time"
 
-	agentsessionstore "github.com/tutti-os/tutti/packages/agentactivity/daemon/activity"
-	activityshared "github.com/tutti-os/tutti/packages/agentactivity/daemon/activity/events"
+	agentsessionstore "github.com/tutti-os/tutti/packages/agent/daemon/activity"
+	activityshared "github.com/tutti-os/tutti/packages/agent/daemon/activity/events"
 )
 
 func activityMessagesWithRole(events []activityshared.Event, role activityshared.MessageRole) []activityshared.Event {

--- a/packages/agent/daemon/runtime/acp_pending.go
+++ b/packages/agent/daemon/runtime/acp_pending.go
@@ -6,7 +6,7 @@ import (
 	"errors"
 	"strings"
 
-	activityshared "github.com/tutti-os/tutti/packages/agentactivity/daemon/activity/events"
+	activityshared "github.com/tutti-os/tutti/packages/agent/daemon/activity/events"
 )
 
 type pendingACPRequest struct {

--- a/packages/agent/daemon/runtime/acp_shared.go
+++ b/packages/agent/daemon/runtime/acp_shared.go
@@ -4,7 +4,7 @@ import (
 	"errors"
 	"time"
 
-	runtimepaths "github.com/tutti-os/tutti/packages/agentactivity/daemon/internal/runtimepaths"
+	runtimepaths "github.com/tutti-os/tutti/packages/agent/daemon/internal/runtimepaths"
 )
 
 const (

--- a/packages/agent/daemon/runtime/acp_tool_normalizer.go
+++ b/packages/agent/daemon/runtime/acp_tool_normalizer.go
@@ -7,7 +7,7 @@ import (
 	"strconv"
 	"strings"
 
-	activityshared "github.com/tutti-os/tutti/packages/agentactivity/daemon/activity/events"
+	activityshared "github.com/tutti-os/tutti/packages/agent/daemon/activity/events"
 )
 
 func acpToolCallEvent(session Session, turnID string, update map[string]any) (activityshared.Event, bool) {

--- a/packages/agent/daemon/runtime/acp_turn_normalizer.go
+++ b/packages/agent/daemon/runtime/acp_turn_normalizer.go
@@ -4,7 +4,7 @@ import (
 	"sort"
 	"strings"
 
-	activityshared "github.com/tutti-os/tutti/packages/agentactivity/daemon/activity/events"
+	activityshared "github.com/tutti-os/tutti/packages/agent/daemon/activity/events"
 )
 
 type pendingToolCallSnapshot struct {

--- a/packages/agent/daemon/runtime/acp_turn_normalizer_test.go
+++ b/packages/agent/daemon/runtime/acp_turn_normalizer_test.go
@@ -4,7 +4,7 @@ import (
 	"strings"
 	"testing"
 
-	activityshared "github.com/tutti-os/tutti/packages/agentactivity/daemon/activity/events"
+	activityshared "github.com/tutti-os/tutti/packages/agent/daemon/activity/events"
 )
 
 func TestFinalizeThinkingItemReplacesWordTokenStream(t *testing.T) {

--- a/packages/agent/daemon/runtime/acp_update_events.go
+++ b/packages/agent/daemon/runtime/acp_update_events.go
@@ -6,8 +6,8 @@ import (
 	"errors"
 	"strings"
 
-	activityshared "github.com/tutti-os/tutti/packages/agentactivity/daemon/activity/events"
-	"github.com/tutti-os/tutti/packages/agentactivity/daemon/internal/titletext"
+	activityshared "github.com/tutti-os/tutti/packages/agent/daemon/activity/events"
+	"github.com/tutti-os/tutti/packages/agent/daemon/internal/titletext"
 )
 
 func acpModeValue(update map[string]any) string {

--- a/packages/agent/daemon/runtime/activity_projection.go
+++ b/packages/agent/daemon/runtime/activity_projection.go
@@ -3,8 +3,8 @@ package agentruntime
 import (
 	"strings"
 
-	agentsessionstore "github.com/tutti-os/tutti/packages/agentactivity/daemon/activity"
-	activityshared "github.com/tutti-os/tutti/packages/agentactivity/daemon/activity/events"
+	agentsessionstore "github.com/tutti-os/tutti/packages/agent/daemon/activity"
+	activityshared "github.com/tutti-os/tutti/packages/agent/daemon/activity/events"
 )
 
 func ReportableActivityEvents(events []activityshared.Event) []activityshared.Event {

--- a/packages/agent/daemon/runtime/activity_projection_test.go
+++ b/packages/agent/daemon/runtime/activity_projection_test.go
@@ -3,8 +3,8 @@ package agentruntime
 import (
 	"testing"
 
-	agentsessionstore "github.com/tutti-os/tutti/packages/agentactivity/daemon/activity"
-	activityshared "github.com/tutti-os/tutti/packages/agentactivity/daemon/activity/events"
+	agentsessionstore "github.com/tutti-os/tutti/packages/agent/daemon/activity"
+	activityshared "github.com/tutti-os/tutti/packages/agent/daemon/activity/events"
 )
 
 func TestReportableActivityEventsReportsOnlyCompletedAssistantSnapshots(t *testing.T) {

--- a/packages/agent/daemon/runtime/adapter.go
+++ b/packages/agent/daemon/runtime/adapter.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"errors"
 
-	activityshared "github.com/tutti-os/tutti/packages/agentactivity/daemon/activity/events"
+	activityshared "github.com/tutti-os/tutti/packages/agent/daemon/activity/events"
 )
 
 var ErrLiveSessionBusy = errors.New("agent live session is busy")

--- a/packages/agent/daemon/runtime/claude_sdk_adapter.go
+++ b/packages/agent/daemon/runtime/claude_sdk_adapter.go
@@ -15,7 +15,7 @@ import (
 	"strings"
 	"sync"
 
-	activityshared "github.com/tutti-os/tutti/packages/agentactivity/daemon/activity/events"
+	activityshared "github.com/tutti-os/tutti/packages/agent/daemon/activity/events"
 )
 
 const (

--- a/packages/agent/daemon/runtime/claude_sdk_adapter_test.go
+++ b/packages/agent/daemon/runtime/claude_sdk_adapter_test.go
@@ -15,8 +15,8 @@ import (
 	"testing"
 	"time"
 
-	agentsessionstore "github.com/tutti-os/tutti/packages/agentactivity/daemon/activity"
-	activityshared "github.com/tutti-os/tutti/packages/agentactivity/daemon/activity/events"
+	agentsessionstore "github.com/tutti-os/tutti/packages/agent/daemon/activity"
+	activityshared "github.com/tutti-os/tutti/packages/agent/daemon/activity/events"
 )
 
 func TestDefaultControllerUsesClaudeSDKAdapterByDefault(t *testing.T) {

--- a/packages/agent/daemon/runtime/claude_sdk_goal.go
+++ b/packages/agent/daemon/runtime/claude_sdk_goal.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 	"time"
 
-	activityshared "github.com/tutti-os/tutti/packages/agentactivity/daemon/activity/events"
+	activityshared "github.com/tutti-os/tutti/packages/agent/daemon/activity/events"
 )
 
 // claudeSDKGoalCommandTimeout bounds the sidecar ack round-trip for /goal

--- a/packages/agent/daemon/runtime/claude_sdk_goal_lifecycle_test.go
+++ b/packages/agent/daemon/runtime/claude_sdk_goal_lifecycle_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 	"time"
 
-	activityshared "github.com/tutti-os/tutti/packages/agentactivity/daemon/activity/events"
+	activityshared "github.com/tutti-os/tutti/packages/agent/daemon/activity/events"
 )
 
 func newClaudeSDKLifecycleTestSession(t *testing.T, adapter *ClaudeCodeSDKAdapter, conn ProcessConnection) (Session, *claudeSDKAdapterSession) {

--- a/packages/agent/daemon/runtime/claude_sdk_interactive.go
+++ b/packages/agent/daemon/runtime/claude_sdk_interactive.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	activityshared "github.com/tutti-os/tutti/packages/agentactivity/daemon/activity/events"
+	activityshared "github.com/tutti-os/tutti/packages/agent/daemon/activity/events"
 )
 
 func (a *ClaudeCodeSDKAdapter) SubmitInteractive(ctx context.Context, session Session, input SubmitInteractiveInput) (SubmitInteractiveResult, error) {

--- a/packages/agent/daemon/runtime/codex_appserver_adapter.go
+++ b/packages/agent/daemon/runtime/codex_appserver_adapter.go
@@ -14,7 +14,7 @@ import (
 	"sync/atomic"
 	"time"
 
-	activityshared "github.com/tutti-os/tutti/packages/agentactivity/daemon/activity/events"
+	activityshared "github.com/tutti-os/tutti/packages/agent/daemon/activity/events"
 )
 
 // Codex app-server JSON-RPC methods used by the adapter. The app-server

--- a/packages/agent/daemon/runtime/codex_appserver_adapter_test.go
+++ b/packages/agent/daemon/runtime/codex_appserver_adapter_test.go
@@ -12,7 +12,7 @@ import (
 	"testing"
 	"time"
 
-	activityshared "github.com/tutti-os/tutti/packages/agentactivity/daemon/activity/events"
+	activityshared "github.com/tutti-os/tutti/packages/agent/daemon/activity/events"
 )
 
 const (

--- a/packages/agent/daemon/runtime/codex_appserver_client.go
+++ b/packages/agent/daemon/runtime/codex_appserver_client.go
@@ -9,7 +9,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/tutti-os/tutti/packages/agentactivity/daemon/runtime/codexproto"
+	"github.com/tutti-os/tutti/packages/agent/daemon/runtime/codexproto"
 )
 
 type codexAppServerClient struct {

--- a/packages/agent/daemon/runtime/codex_appserver_events.go
+++ b/packages/agent/daemon/runtime/codex_appserver_events.go
@@ -9,8 +9,8 @@ import (
 	"log/slog"
 	"strings"
 
-	activityshared "github.com/tutti-os/tutti/packages/agentactivity/daemon/activity/events"
-	"github.com/tutti-os/tutti/packages/agentactivity/daemon/runtime/codexproto"
+	activityshared "github.com/tutti-os/tutti/packages/agent/daemon/activity/events"
+	"github.com/tutti-os/tutti/packages/agent/daemon/runtime/codexproto"
 )
 
 // handleAppServerMessage routes codex app-server server->client traffic.

--- a/packages/agent/daemon/runtime/codex_appserver_events_test.go
+++ b/packages/agent/daemon/runtime/codex_appserver_events_test.go
@@ -8,7 +8,7 @@ import (
 	"sync"
 	"testing"
 
-	activityshared "github.com/tutti-os/tutti/packages/agentactivity/daemon/activity/events"
+	activityshared "github.com/tutti-os/tutti/packages/agent/daemon/activity/events"
 )
 
 type appServerCaptureConn struct {

--- a/packages/agent/daemon/runtime/codex_appserver_reducer.go
+++ b/packages/agent/daemon/runtime/codex_appserver_reducer.go
@@ -6,7 +6,7 @@ import (
 	"log/slog"
 	"strings"
 
-	activityshared "github.com/tutti-os/tutti/packages/agentactivity/daemon/activity/events"
+	activityshared "github.com/tutti-os/tutti/packages/agent/daemon/activity/events"
 )
 
 type codexAppServerReducer struct {

--- a/packages/agent/daemon/runtime/codex_appserver_review.go
+++ b/packages/agent/daemon/runtime/codex_appserver_review.go
@@ -5,7 +5,7 @@ import (
 	"errors"
 	"strings"
 
-	activityshared "github.com/tutti-os/tutti/packages/agentactivity/daemon/activity/events"
+	activityshared "github.com/tutti-os/tutti/packages/agent/daemon/activity/events"
 )
 
 // appServerReviewTarget maps the `/review` slash-command args onto a codex

--- a/packages/agent/daemon/runtime/controller.go
+++ b/packages/agent/daemon/runtime/controller.go
@@ -12,8 +12,8 @@ import (
 	"sync"
 	"time"
 
-	agentsessionstore "github.com/tutti-os/tutti/packages/agentactivity/daemon/activity"
-	activityshared "github.com/tutti-os/tutti/packages/agentactivity/daemon/activity/events"
+	agentsessionstore "github.com/tutti-os/tutti/packages/agent/daemon/activity"
+	activityshared "github.com/tutti-os/tutti/packages/agent/daemon/activity/events"
 )
 
 var (

--- a/packages/agent/daemon/runtime/controller_test.go
+++ b/packages/agent/daemon/runtime/controller_test.go
@@ -10,8 +10,8 @@ import (
 	"testing"
 	"time"
 
-	agentsessionstore "github.com/tutti-os/tutti/packages/agentactivity/daemon/activity"
-	activityshared "github.com/tutti-os/tutti/packages/agentactivity/daemon/activity/events"
+	agentsessionstore "github.com/tutti-os/tutti/packages/agent/daemon/activity"
+	activityshared "github.com/tutti-os/tutti/packages/agent/daemon/activity/events"
 )
 
 type recordingReporter struct {

--- a/packages/agent/daemon/runtime/process_transport.go
+++ b/packages/agent/daemon/runtime/process_transport.go
@@ -13,7 +13,7 @@ import (
 	"syscall"
 	"time"
 
-	"github.com/tutti-os/tutti/packages/agentactivity/daemon/runtimecmd"
+	"github.com/tutti-os/tutti/packages/agent/daemon/runtimecmd"
 )
 
 type localProcessTransport struct{}

--- a/packages/agent/daemon/runtime/queued_reporter.go
+++ b/packages/agent/daemon/runtime/queued_reporter.go
@@ -5,7 +5,7 @@ import (
 	"errors"
 	"strings"
 
-	agentsessionstore "github.com/tutti-os/tutti/packages/agentactivity/daemon/activity"
+	agentsessionstore "github.com/tutti-os/tutti/packages/agent/daemon/activity"
 )
 
 type QueuedReporter struct {

--- a/packages/agent/daemon/runtime/queued_reporter_test.go
+++ b/packages/agent/daemon/runtime/queued_reporter_test.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"testing"
 
-	agentsessionstore "github.com/tutti-os/tutti/packages/agentactivity/daemon/activity"
+	agentsessionstore "github.com/tutti-os/tutti/packages/agent/daemon/activity"
 )
 
 type captureActivityClient struct {

--- a/packages/agent/daemon/runtime/real_codex_smoke_test.go
+++ b/packages/agent/daemon/runtime/real_codex_smoke_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 	"time"
 
-	activityshared "github.com/tutti-os/tutti/packages/agentactivity/daemon/activity/events"
+	activityshared "github.com/tutti-os/tutti/packages/agent/daemon/activity/events"
 )
 
 // TestRealCodexAppServerTurn drives the adapter against the locally

--- a/packages/agent/daemon/runtime/report_coalescer.go
+++ b/packages/agent/daemon/runtime/report_coalescer.go
@@ -4,7 +4,7 @@ import (
 	"strings"
 	"time"
 
-	agentsessionstore "github.com/tutti-os/tutti/packages/agentactivity/daemon/activity"
+	agentsessionstore "github.com/tutti-os/tutti/packages/agent/daemon/activity"
 )
 
 type streamingReportCoalescer struct {

--- a/packages/agent/daemon/runtime/report_coalescer_test.go
+++ b/packages/agent/daemon/runtime/report_coalescer_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 	"time"
 
-	agentsessionstore "github.com/tutti-os/tutti/packages/agentactivity/daemon/activity"
+	agentsessionstore "github.com/tutti-os/tutti/packages/agent/daemon/activity"
 )
 
 func TestStreamingReportCoalescerKeepsLatestMessageSnapshot(t *testing.T) {

--- a/packages/agent/daemon/runtime/report_log_summary.go
+++ b/packages/agent/daemon/runtime/report_log_summary.go
@@ -5,7 +5,7 @@ import (
 	"sort"
 	"strings"
 
-	agentsessionstore "github.com/tutti-os/tutti/packages/agentactivity/daemon/activity"
+	agentsessionstore "github.com/tutti-os/tutti/packages/agent/daemon/activity"
 )
 
 const (

--- a/packages/agent/daemon/runtime/reporter.go
+++ b/packages/agent/daemon/runtime/reporter.go
@@ -10,8 +10,8 @@ import (
 	"strings"
 	"time"
 
-	agentsessionstore "github.com/tutti-os/tutti/packages/agentactivity/daemon/activity"
-	activityshared "github.com/tutti-os/tutti/packages/agentactivity/daemon/activity/events"
+	agentsessionstore "github.com/tutti-os/tutti/packages/agent/daemon/activity"
+	activityshared "github.com/tutti-os/tutti/packages/agent/daemon/activity/events"
 )
 
 const WorkspaceAgentSessionOriginRuntime = "WORKSPACE_AGENT_SESSION_ORIGIN_RUNTIME"

--- a/packages/agent/daemon/runtime/reporter_test.go
+++ b/packages/agent/daemon/runtime/reporter_test.go
@@ -10,8 +10,8 @@ import (
 	"testing"
 	"time"
 
-	agentsessionstore "github.com/tutti-os/tutti/packages/agentactivity/daemon/activity"
-	activityshared "github.com/tutti-os/tutti/packages/agentactivity/daemon/activity/events"
+	agentsessionstore "github.com/tutti-os/tutti/packages/agent/daemon/activity"
+	activityshared "github.com/tutti-os/tutti/packages/agent/daemon/activity/events"
 )
 
 type retryingActivityClient struct {

--- a/packages/agent/daemon/runtime/standard_acp_adapter.go
+++ b/packages/agent/daemon/runtime/standard_acp_adapter.go
@@ -15,7 +15,7 @@ import (
 	"sync"
 	"time"
 
-	activityshared "github.com/tutti-os/tutti/packages/agentactivity/daemon/activity/events"
+	activityshared "github.com/tutti-os/tutti/packages/agent/daemon/activity/events"
 )
 
 type standardACPConfig struct {

--- a/packages/agent/daemon/runtime/standard_acp_adapter_test.go
+++ b/packages/agent/daemon/runtime/standard_acp_adapter_test.go
@@ -15,8 +15,8 @@ import (
 	"testing"
 	"time"
 
-	agentsessionstore "github.com/tutti-os/tutti/packages/agentactivity/daemon/activity"
-	activityshared "github.com/tutti-os/tutti/packages/agentactivity/daemon/activity/events"
+	agentsessionstore "github.com/tutti-os/tutti/packages/agent/daemon/activity"
+	activityshared "github.com/tutti-os/tutti/packages/agent/daemon/activity/events"
 )
 
 func TestGeminiAdapterStartCreatesStandardACPSession(t *testing.T) {

--- a/packages/agent/daemon/runtime/turn_lifecycle_authority_test.go
+++ b/packages/agent/daemon/runtime/turn_lifecycle_authority_test.go
@@ -7,8 +7,8 @@ import (
 	"testing"
 	"time"
 
-	agentsessionstore "github.com/tutti-os/tutti/packages/agentactivity/daemon/activity"
-	activityshared "github.com/tutti-os/tutti/packages/agentactivity/daemon/activity/events"
+	agentsessionstore "github.com/tutti-os/tutti/packages/agent/daemon/activity"
+	activityshared "github.com/tutti-os/tutti/packages/agent/daemon/activity/events"
 )
 
 func lifecycleWith(phase string, turnID string, outcome string) *TurnLifecycle {

--- a/packages/agent/daemon/runtime/turn_lifecycle_stamp.go
+++ b/packages/agent/daemon/runtime/turn_lifecycle_stamp.go
@@ -3,7 +3,7 @@ package agentruntime
 import (
 	"strings"
 
-	activityshared "github.com/tutti-os/tutti/packages/agentactivity/daemon/activity/events"
+	activityshared "github.com/tutti-os/tutti/packages/agent/daemon/activity/events"
 )
 
 // stampAdapterTurnLifecycleEvents stamps an adapter-origin TurnLifecycle

--- a/packages/agent/daemon/runtime/visible_error.go
+++ b/packages/agent/daemon/runtime/visible_error.go
@@ -6,8 +6,8 @@ import (
 	"strconv"
 	"strings"
 
-	agentsessionstore "github.com/tutti-os/tutti/packages/agentactivity/daemon/activity"
-	activityshared "github.com/tutti-os/tutti/packages/agentactivity/daemon/activity/events"
+	agentsessionstore "github.com/tutti-os/tutti/packages/agent/daemon/activity"
+	activityshared "github.com/tutti-os/tutti/packages/agent/daemon/activity/events"
 )
 
 const (

--- a/packages/agent/daemon/runtime/visible_error_test.go
+++ b/packages/agent/daemon/runtime/visible_error_test.go
@@ -3,7 +3,7 @@ package agentruntime
 import (
 	"testing"
 
-	agentsessionstore "github.com/tutti-os/tutti/packages/agentactivity/daemon/activity"
+	agentsessionstore "github.com/tutti-os/tutti/packages/agent/daemon/activity"
 )
 
 func TestVisibleFailureCodeClassifiesDeadlineExceededAsRequestTimedOut(t *testing.T) {

--- a/packages/agent/daemon/runtime_test.go
+++ b/packages/agent/daemon/runtime_test.go
@@ -6,8 +6,8 @@ import (
 	"testing"
 	"time"
 
-	activityshared "github.com/tutti-os/tutti/packages/agentactivity/daemon/activity/events"
-	agentruntime "github.com/tutti-os/tutti/packages/agentactivity/daemon/runtime"
+	activityshared "github.com/tutti-os/tutti/packages/agent/daemon/activity/events"
+	agentruntime "github.com/tutti-os/tutti/packages/agent/daemon/runtime"
 )
 
 func TestNewRuntimeCreatesDefaultController(t *testing.T) {

--- a/services/tuttid/agent_run_outcome_reporter.go
+++ b/services/tuttid/agent_run_outcome_reporter.go
@@ -4,8 +4,8 @@ import (
 	"context"
 	"strings"
 
-	agentdaemon "github.com/tutti-os/tutti/packages/agentactivity/daemon"
-	agentsessionstore "github.com/tutti-os/tutti/packages/agentactivity/daemon/activity"
+	agentdaemon "github.com/tutti-os/tutti/packages/agent/daemon"
+	agentsessionstore "github.com/tutti-os/tutti/packages/agent/daemon/activity"
 	agentstatusservice "github.com/tutti-os/tutti/services/tuttid/service/agentstatus"
 )
 

--- a/services/tuttid/agent_run_outcome_reporter_test.go
+++ b/services/tuttid/agent_run_outcome_reporter_test.go
@@ -3,7 +3,7 @@ package main
 import (
 	"testing"
 
-	agentsessionstore "github.com/tutti-os/tutti/packages/agentactivity/daemon/activity"
+	agentsessionstore "github.com/tutti-os/tutti/packages/agent/daemon/activity"
 )
 
 func TestMessageLooksLikeAuthFailureMatchesRealClaude401(t *testing.T) {

--- a/services/tuttid/agent_runtime_adapter.go
+++ b/services/tuttid/agent_runtime_adapter.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"errors"
 
-	agentruntime "github.com/tutti-os/tutti/packages/agentactivity/daemon/runtime"
+	agentruntime "github.com/tutti-os/tutti/packages/agent/daemon/runtime"
 	agentservice "github.com/tutti-os/tutti/services/tuttid/service/agent"
 )
 

--- a/services/tuttid/agent_runtime_adapter_test.go
+++ b/services/tuttid/agent_runtime_adapter_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 	"time"
 
-	agentruntime "github.com/tutti-os/tutti/packages/agentactivity/daemon/runtime"
+	agentruntime "github.com/tutti-os/tutti/packages/agent/daemon/runtime"
 	agentservice "github.com/tutti-os/tutti/services/tuttid/service/agent"
 )
 

--- a/services/tuttid/app/app.go
+++ b/services/tuttid/app/app.go
@@ -11,7 +11,7 @@ import (
 	"syscall"
 	"time"
 
-	"github.com/tutti-os/tutti/packages/agentactivity/daemon/runtimecmd"
+	"github.com/tutti-os/tutti/packages/agent/daemon/runtimecmd"
 )
 
 type App struct {

--- a/services/tuttid/builtin-apps/catalog.go
+++ b/services/tuttid/builtin-apps/catalog.go
@@ -16,7 +16,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/tutti-os/tutti/packages/agentactivity/daemon/httpx"
+	"github.com/tutti-os/tutti/packages/agent/daemon/httpx"
 	workspacebiz "github.com/tutti-os/tutti/services/tuttid/biz/workspace"
 )
 

--- a/services/tuttid/data/workspace/sqlite_agent_activity.go
+++ b/services/tuttid/data/workspace/sqlite_agent_activity.go
@@ -10,7 +10,7 @@ import (
 	"strings"
 	"time"
 
-	agentactivityprojection "github.com/tutti-os/tutti/packages/agentactivity/daemon/activity/projection"
+	agentactivityprojection "github.com/tutti-os/tutti/packages/agent/daemon/activity/projection"
 	agentactivitybiz "github.com/tutti-os/tutti/services/tuttid/biz/agentactivity"
 )
 

--- a/services/tuttid/data/workspace/sqlite_agent_activity_messages.go
+++ b/services/tuttid/data/workspace/sqlite_agent_activity_messages.go
@@ -9,7 +9,7 @@ import (
 	"strings"
 	"time"
 
-	agentactivityprojection "github.com/tutti-os/tutti/packages/agentactivity/daemon/activity/projection"
+	agentactivityprojection "github.com/tutti-os/tutti/packages/agent/daemon/activity/projection"
 	agentactivitybiz "github.com/tutti-os/tutti/services/tuttid/biz/agentactivity"
 )
 

--- a/services/tuttid/data/workspace/sqlite_agent_activity_projection.go
+++ b/services/tuttid/data/workspace/sqlite_agent_activity_projection.go
@@ -3,7 +3,7 @@ package workspace
 import (
 	"strings"
 
-	agentactivityprojection "github.com/tutti-os/tutti/packages/agentactivity/daemon/activity/projection"
+	agentactivityprojection "github.com/tutti-os/tutti/packages/agent/daemon/activity/projection"
 	agentactivitybiz "github.com/tutti-os/tutti/services/tuttid/biz/agentactivity"
 )
 

--- a/services/tuttid/data/workspace/sqlite_agent_generated_files_bench_test.go
+++ b/services/tuttid/data/workspace/sqlite_agent_generated_files_bench_test.go
@@ -6,7 +6,7 @@ import (
 	"path/filepath"
 	"testing"
 
-	agentsessionstore "github.com/tutti-os/tutti/packages/agentactivity/daemon/activity"
+	agentsessionstore "github.com/tutti-os/tutti/packages/agent/daemon/activity"
 	agentactivitybiz "github.com/tutti-os/tutti/services/tuttid/biz/agentactivity"
 	workspacebiz "github.com/tutti-os/tutti/services/tuttid/biz/workspace"
 )

--- a/services/tuttid/data/workspace/sqlite_store_test.go
+++ b/services/tuttid/data/workspace/sqlite_store_test.go
@@ -12,7 +12,7 @@ import (
 	"testing"
 	"time"
 
-	agentsessionstore "github.com/tutti-os/tutti/packages/agentactivity/daemon/activity"
+	agentsessionstore "github.com/tutti-os/tutti/packages/agent/daemon/activity"
 	agentactivitybiz "github.com/tutti-os/tutti/services/tuttid/biz/agentactivity"
 	agenttargetbiz "github.com/tutti-os/tutti/services/tuttid/biz/agenttarget"
 	userprojectbiz "github.com/tutti-os/tutti/services/tuttid/biz/userproject"

--- a/services/tuttid/go.mod
+++ b/services/tuttid/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/creack/pty v1.1.24
 	github.com/google/uuid v1.6.0
 	github.com/oapi-codegen/runtime v1.4.1
-	github.com/tutti-os/tutti/packages/agentactivity/daemon v0.0.0
+	github.com/tutti-os/tutti/packages/agent/daemon v0.0.0
 	github.com/tutti-os/tutti/packages/appcli/core v0.0.0
 	github.com/tutti-os/tutti/packages/auth/bridge-go v0.0.0
 	github.com/tutti-os/tutti/packages/events/stream-go v0.0.0
@@ -25,7 +25,7 @@ replace github.com/tutti-os/tutti/packages/events/stream-go => ../../packages/ev
 
 replace github.com/tutti-os/tutti/packages/workbench/service => ../../packages/workbench/service
 
-replace github.com/tutti-os/tutti/packages/agentactivity/daemon => ../../packages/agent/daemon
+replace github.com/tutti-os/tutti/packages/agent/daemon => ../../packages/agent/daemon
 
 replace github.com/tutti-os/tutti/packages/workspace/files => ../../packages/workspace/files
 

--- a/services/tuttid/integration/agent_activity_eventhub_test.go
+++ b/services/tuttid/integration/agent_activity_eventhub_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 	"time"
 
-	agentsessionstore "github.com/tutti-os/tutti/packages/agentactivity/daemon/activity"
+	agentsessionstore "github.com/tutti-os/tutti/packages/agent/daemon/activity"
 	eventprotocol "github.com/tutti-os/tutti/services/tuttid/api/events/generated"
 	agentactivitybiz "github.com/tutti-os/tutti/services/tuttid/biz/agentactivity"
 	workspacebiz "github.com/tutti-os/tutti/services/tuttid/biz/workspace"

--- a/services/tuttid/service/agent/activity_projection.go
+++ b/services/tuttid/service/agent/activity_projection.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 	"time"
 
-	agentsessionstore "github.com/tutti-os/tutti/packages/agentactivity/daemon/activity"
+	agentsessionstore "github.com/tutti-os/tutti/packages/agent/daemon/activity"
 	agentactivitybiz "github.com/tutti-os/tutti/services/tuttid/biz/agentactivity"
 	reporterservice "github.com/tutti-os/tutti/services/tuttid/service/reporter"
 	agentnoderesult "github.com/tutti-os/tutti/services/tuttid/service/reporter/events/agent/node_result"

--- a/services/tuttid/service/agent/activity_projection_session.go
+++ b/services/tuttid/service/agent/activity_projection_session.go
@@ -3,7 +3,7 @@ package agent
 import (
 	"strings"
 
-	agentactivityprojection "github.com/tutti-os/tutti/packages/agentactivity/daemon/activity/projection"
+	agentactivityprojection "github.com/tutti-os/tutti/packages/agent/daemon/activity/projection"
 	agentactivitybiz "github.com/tutti-os/tutti/services/tuttid/biz/agentactivity"
 )
 

--- a/services/tuttid/service/agent/codex_capability_catalog.go
+++ b/services/tuttid/service/agent/codex_capability_catalog.go
@@ -11,7 +11,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/tutti-os/tutti/packages/agentactivity/daemon/runtimecmd"
+	"github.com/tutti-os/tutti/packages/agent/daemon/runtimecmd"
 	"github.com/tutti-os/tutti/services/tuttid/biz/agentprovider"
 )
 

--- a/services/tuttid/service/agent/codex_model_catalog.go
+++ b/services/tuttid/service/agent/codex_model_catalog.go
@@ -13,7 +13,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/tutti-os/tutti/packages/agentactivity/daemon/runtimecmd"
+	"github.com/tutti-os/tutti/packages/agent/daemon/runtimecmd"
 )
 
 const (

--- a/services/tuttid/service/agent/gemini_model_catalog.go
+++ b/services/tuttid/service/agent/gemini_model_catalog.go
@@ -10,7 +10,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/tutti-os/tutti/packages/agentactivity/daemon/httpx"
+	"github.com/tutti-os/tutti/packages/agent/daemon/httpx"
 )
 
 const (

--- a/services/tuttid/service/agent/git_branches.go
+++ b/services/tuttid/service/agent/git_branches.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/tutti-os/tutti/packages/agentactivity/daemon/runtimecmd"
+	"github.com/tutti-os/tutti/packages/agent/daemon/runtimecmd"
 )
 
 // gitBranchListTimeout bounds the git subprocesses backing the review picker so

--- a/services/tuttid/service/agent/git_patch.go
+++ b/services/tuttid/service/agent/git_patch.go
@@ -13,7 +13,7 @@ import (
 	"strings"
 	"syscall"
 
-	"github.com/tutti-os/tutti/packages/agentactivity/daemon/runtimecmd"
+	"github.com/tutti-os/tutti/packages/agent/daemon/runtimecmd"
 )
 
 type ApplyGitPatchStatus string

--- a/services/tuttid/service/agent/service_resume_helpers.go
+++ b/services/tuttid/service/agent/service_resume_helpers.go
@@ -5,7 +5,7 @@ import (
 	"encoding/json"
 	"strings"
 
-	activityshared "github.com/tutti-os/tutti/packages/agentactivity/daemon/activity/events"
+	activityshared "github.com/tutti-os/tutti/packages/agent/daemon/activity/events"
 	agentactivitybiz "github.com/tutti-os/tutti/services/tuttid/biz/agentactivity"
 )
 

--- a/services/tuttid/service/agent/service_test.go
+++ b/services/tuttid/service/agent/service_test.go
@@ -11,7 +11,7 @@ import (
 	"testing"
 	"time"
 
-	agentsessionstore "github.com/tutti-os/tutti/packages/agentactivity/daemon/activity"
+	agentsessionstore "github.com/tutti-os/tutti/packages/agent/daemon/activity"
 	agentactivitybiz "github.com/tutti-os/tutti/services/tuttid/biz/agentactivity"
 	agenttargetbiz "github.com/tutti-os/tutti/services/tuttid/biz/agenttarget"
 	userprojectbiz "github.com/tutti-os/tutti/services/tuttid/biz/userproject"

--- a/services/tuttid/service/agentstatus/installer.go
+++ b/services/tuttid/service/agentstatus/installer.go
@@ -13,8 +13,8 @@ import (
 	"slices"
 	"strings"
 
-	"github.com/tutti-os/tutti/packages/agentactivity/daemon/httpx"
-	"github.com/tutti-os/tutti/packages/agentactivity/daemon/runtimecmd"
+	"github.com/tutti-os/tutti/packages/agent/daemon/httpx"
+	"github.com/tutti-os/tutti/packages/agent/daemon/runtimecmd"
 	"github.com/tutti-os/tutti/services/tuttid/biz/agentprovider"
 	managedruntime "github.com/tutti-os/tutti/services/tuttid/service/managedruntime"
 )

--- a/services/tuttid/service/agentstatus/installer_codex_cli.go
+++ b/services/tuttid/service/agentstatus/installer_codex_cli.go
@@ -10,7 +10,7 @@ import (
 	"slices"
 	"strings"
 
-	"github.com/tutti-os/tutti/packages/agentactivity/daemon/runtimecmd"
+	"github.com/tutti-os/tutti/packages/agent/daemon/runtimecmd"
 	managedruntime "github.com/tutti-os/tutti/services/tuttid/service/managedruntime"
 )
 

--- a/services/tuttid/service/agentstatus/network_probe.go
+++ b/services/tuttid/service/agentstatus/network_probe.go
@@ -8,7 +8,7 @@ import (
 	"net/url"
 	"time"
 
-	"github.com/tutti-os/tutti/packages/agentactivity/daemon/runtimecmd"
+	"github.com/tutti-os/tutti/packages/agent/daemon/runtimecmd"
 	"github.com/tutti-os/tutti/services/tuttid/biz/agentprovider"
 )
 

--- a/services/tuttid/service/agentstatus/service_helpers.go
+++ b/services/tuttid/service/agentstatus/service_helpers.go
@@ -13,7 +13,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/tutti-os/tutti/packages/agentactivity/daemon/runtimecmd"
+	"github.com/tutti-os/tutti/packages/agent/daemon/runtimecmd"
 	"github.com/tutti-os/tutti/services/tuttid/biz/agentprovider"
 )
 

--- a/services/tuttid/service/browser/browser_test.go
+++ b/services/tuttid/service/browser/browser_test.go
@@ -10,7 +10,7 @@ import (
 	"testing"
 	"time"
 
-	agentruntime "github.com/tutti-os/tutti/packages/agentactivity/daemon/runtime"
+	agentruntime "github.com/tutti-os/tutti/packages/agent/daemon/runtime"
 	preferencesbiz "github.com/tutti-os/tutti/services/tuttid/biz/preferences"
 	managedruntime "github.com/tutti-os/tutti/services/tuttid/service/managedruntime"
 )

--- a/services/tuttid/service/browser/mcpclient.go
+++ b/services/tuttid/service/browser/mcpclient.go
@@ -13,7 +13,7 @@ import (
 	"strings"
 	"sync"
 
-	agentruntime "github.com/tutti-os/tutti/packages/agentactivity/daemon/runtime"
+	agentruntime "github.com/tutti-os/tutti/packages/agent/daemon/runtime"
 )
 
 // mcpClient is a minimal newline-delimited JSON-RPC 2.0 client for an MCP

--- a/services/tuttid/service/browser/mcpclient_test.go
+++ b/services/tuttid/service/browser/mcpclient_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 	"time"
 
-	agentruntime "github.com/tutti-os/tutti/packages/agentactivity/daemon/runtime"
+	agentruntime "github.com/tutti-os/tutti/packages/agent/daemon/runtime"
 )
 
 type lockedScriptedConn struct {

--- a/services/tuttid/service/browser/service.go
+++ b/services/tuttid/service/browser/service.go
@@ -6,7 +6,7 @@ import (
 	"sync"
 	"time"
 
-	agentruntime "github.com/tutti-os/tutti/packages/agentactivity/daemon/runtime"
+	agentruntime "github.com/tutti-os/tutti/packages/agent/daemon/runtime"
 	preferencesbiz "github.com/tutti-os/tutti/services/tuttid/biz/preferences"
 	managedruntime "github.com/tutti-os/tutti/services/tuttid/service/managedruntime"
 )

--- a/services/tuttid/service/browser/session.go
+++ b/services/tuttid/service/browser/session.go
@@ -10,7 +10,7 @@ import (
 	"sync/atomic"
 	"time"
 
-	agentruntime "github.com/tutti-os/tutti/packages/agentactivity/daemon/runtime"
+	agentruntime "github.com/tutti-os/tutti/packages/agent/daemon/runtime"
 )
 
 // mcpProtocolVersion is the MCP version advertised at initialize. We do NOT

--- a/services/tuttid/service/computer/mcpclient.go
+++ b/services/tuttid/service/computer/mcpclient.go
@@ -12,7 +12,7 @@ import (
 	"strings"
 	"sync"
 
-	agentruntime "github.com/tutti-os/tutti/packages/agentactivity/daemon/runtime"
+	agentruntime "github.com/tutti-os/tutti/packages/agent/daemon/runtime"
 )
 
 // mcpClient is a minimal newline-delimited JSON-RPC 2.0 client for an MCP

--- a/services/tuttid/service/computer/service.go
+++ b/services/tuttid/service/computer/service.go
@@ -6,7 +6,7 @@ import (
 	"sync"
 	"time"
 
-	agentruntime "github.com/tutti-os/tutti/packages/agentactivity/daemon/runtime"
+	agentruntime "github.com/tutti-os/tutti/packages/agent/daemon/runtime"
 )
 
 // defaultIdleTTL shuts a workspace's computer session (and cua-driver) down

--- a/services/tuttid/service/computer/session.go
+++ b/services/tuttid/service/computer/session.go
@@ -10,7 +10,7 @@ import (
 	"sync/atomic"
 	"time"
 
-	agentruntime "github.com/tutti-os/tutti/packages/agentactivity/daemon/runtime"
+	agentruntime "github.com/tutti-os/tutti/packages/agent/daemon/runtime"
 )
 
 // mcpProtocolVersion is the MCP version advertised at initialize. We do NOT

--- a/services/tuttid/service/externalagentregistry/store.go
+++ b/services/tuttid/service/externalagentregistry/store.go
@@ -14,7 +14,7 @@ import (
 	"time"
 	"unicode"
 
-	"github.com/tutti-os/tutti/packages/agentactivity/daemon/httpx"
+	"github.com/tutti-os/tutti/packages/agent/daemon/httpx"
 	tuttitypes "github.com/tutti-os/tutti/services/tuttid/types"
 )
 

--- a/services/tuttid/service/managedcredentials/service.go
+++ b/services/tuttid/service/managedcredentials/service.go
@@ -17,7 +17,7 @@ import (
 	managedcredentialsbiz "github.com/tutti-os/tutti/services/tuttid/biz/managedcredentials"
 	workspacedata "github.com/tutti-os/tutti/services/tuttid/data/workspace"
 
-	"github.com/tutti-os/tutti/packages/agentactivity/daemon/httpx"
+	"github.com/tutti-os/tutti/packages/agent/daemon/httpx"
 )
 
 const GrantCodeTTL = 5 * time.Hour

--- a/services/tuttid/service/managedruntime/runtime.go
+++ b/services/tuttid/service/managedruntime/runtime.go
@@ -14,8 +14,8 @@ import (
 	"sync"
 	"unicode"
 
-	"github.com/tutti-os/tutti/packages/agentactivity/daemon/httpx"
-	"github.com/tutti-os/tutti/packages/agentactivity/daemon/runtimecmd"
+	"github.com/tutti-os/tutti/packages/agent/daemon/httpx"
+	"github.com/tutti-os/tutti/packages/agent/daemon/runtimecmd"
 	tuttitypes "github.com/tutti-os/tutti/services/tuttid/types"
 )
 

--- a/services/tuttid/service/workspace/app_archives.go
+++ b/services/tuttid/service/workspace/app_archives.go
@@ -15,7 +15,7 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/tutti-os/tutti/packages/agentactivity/daemon/httpx"
+	"github.com/tutti-os/tutti/packages/agent/daemon/httpx"
 	workspacebiz "github.com/tutti-os/tutti/services/tuttid/biz/workspace"
 )
 

--- a/services/tuttid/service/workspace/app_factory.go
+++ b/services/tuttid/service/workspace/app_factory.go
@@ -13,7 +13,7 @@ import (
 	"time"
 
 	"github.com/google/uuid"
-	agentsessionstore "github.com/tutti-os/tutti/packages/agentactivity/daemon/activity"
+	agentsessionstore "github.com/tutti-os/tutti/packages/agent/daemon/activity"
 	workspacefiles "github.com/tutti-os/tutti/packages/workspace/files"
 	workspacebiz "github.com/tutti-os/tutti/services/tuttid/biz/workspace"
 	workspacedata "github.com/tutti-os/tutti/services/tuttid/data/workspace"

--- a/services/tuttid/service/workspace/app_factory_agent_state.go
+++ b/services/tuttid/service/workspace/app_factory_agent_state.go
@@ -7,8 +7,8 @@ import (
 	"log/slog"
 	"strings"
 
-	agentsessionstore "github.com/tutti-os/tutti/packages/agentactivity/daemon/activity"
-	agentactivityprojection "github.com/tutti-os/tutti/packages/agentactivity/daemon/activity/projection"
+	agentsessionstore "github.com/tutti-os/tutti/packages/agent/daemon/activity"
+	agentactivityprojection "github.com/tutti-os/tutti/packages/agent/daemon/activity/projection"
 	agentactivitybiz "github.com/tutti-os/tutti/services/tuttid/biz/agentactivity"
 	workspacebiz "github.com/tutti-os/tutti/services/tuttid/biz/workspace"
 )

--- a/services/tuttid/service/workspace/app_factory_test.go
+++ b/services/tuttid/service/workspace/app_factory_test.go
@@ -10,7 +10,7 @@ import (
 	"strings"
 	"testing"
 
-	agentsessionstore "github.com/tutti-os/tutti/packages/agentactivity/daemon/activity"
+	agentsessionstore "github.com/tutti-os/tutti/packages/agent/daemon/activity"
 	workspacefiles "github.com/tutti-os/tutti/packages/workspace/files"
 	agentactivitybiz "github.com/tutti-os/tutti/services/tuttid/biz/agentactivity"
 	agenttargetbiz "github.com/tutti-os/tutti/services/tuttid/biz/agenttarget"

--- a/services/tuttid/service/workspace/app_references.go
+++ b/services/tuttid/service/workspace/app_references.go
@@ -14,7 +14,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/tutti-os/tutti/packages/agentactivity/daemon/httpx"
+	"github.com/tutti-os/tutti/packages/agent/daemon/httpx"
 	workspacebiz "github.com/tutti-os/tutti/services/tuttid/biz/workspace"
 )
 

--- a/services/tuttid/service/workspace/apps.go
+++ b/services/tuttid/service/workspace/apps.go
@@ -11,7 +11,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/tutti-os/tutti/packages/agentactivity/daemon/httpx"
+	"github.com/tutti-os/tutti/packages/agent/daemon/httpx"
 	workspacefiles "github.com/tutti-os/tutti/packages/workspace/files"
 	workspacebiz "github.com/tutti-os/tutti/services/tuttid/biz/workspace"
 	builtinapps "github.com/tutti-os/tutti/services/tuttid/builtin-apps"

--- a/services/tuttid/service/workspace/apps_runner.go
+++ b/services/tuttid/service/workspace/apps_runner.go
@@ -21,7 +21,7 @@ import (
 	workspacebiz "github.com/tutti-os/tutti/services/tuttid/biz/workspace"
 	tuttitypes "github.com/tutti-os/tutti/services/tuttid/types"
 
-	"github.com/tutti-os/tutti/packages/agentactivity/daemon/httpx"
+	"github.com/tutti-os/tutti/packages/agent/daemon/httpx"
 )
 
 const defaultAppHealthcheckTimeout = 30 * time.Second

--- a/services/tuttid/service/workspace/terminal_helpers.go
+++ b/services/tuttid/service/workspace/terminal_helpers.go
@@ -9,7 +9,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/tutti-os/tutti/packages/agentactivity/daemon/runtimecmd"
+	"github.com/tutti-os/tutti/packages/agent/daemon/runtimecmd"
 )
 
 func defaultTerminalHomeDir() (string, error) {

--- a/services/tuttid/wiring.go
+++ b/services/tuttid/wiring.go
@@ -9,7 +9,7 @@ import (
 	"net/http"
 	"time"
 
-	agentdaemon "github.com/tutti-os/tutti/packages/agentactivity/daemon"
+	agentdaemon "github.com/tutti-os/tutti/packages/agent/daemon"
 	workspaceissues "github.com/tutti-os/tutti/packages/workspace/issues"
 	tuttiapi "github.com/tutti-os/tutti/services/tuttid/api"
 	workspacedata "github.com/tutti-os/tutti/services/tuttid/data/workspace"


### PR DESCRIPTION
## Motivation

`packages/agent/daemon/go.mod` declared its module as `github.com/tutti-os/tutti/packages/agentactivity/daemon`, which does not match the actual directory `packages/agent/daemon`. Because the module proxy rejects a path mismatch, every submodule tag published so far for this package is un-fetchable via `go get`, and external consumers cannot depend on it; `services/tuttid` has only been able to consume it through a local `replace` directive.

This implements **Issue T1 (A1)** of the tsh↔tutti shared Agent modules RFC (`tutti-shared-agent-modules`, 2026-07-04 review), which blocks the entire tsh migration line. Reviewed decision: rename the module, keep the directory layout and tag sequence unchanged.

## Changes

- **98 files, 125 replacements** — purely mechanical rename `.../packages/agentactivity/daemon` → `.../packages/agent/daemon`:
  - the `module` declaration in `packages/agent/daemon/go.mod`;
  - all import paths (51 Go files under `packages/agent/daemon`, 45 under `services/tuttid`);
  - the left-hand side of the `require` and `replace` lines in `services/tuttid/go.mod`. The local `replace` (`=> ../../packages/agent/daemon`) is kept, so behavior is unchanged.
- Repo-wide scan confirms no other referrers (apps/cli, other go.mod/go.sum, go.work all clean) and no leftover occurrences of the old path.
- No other code changes.

## Verification

- `go build ./...` passes for both `packages/agent/daemon` and `services/tuttid`.
- `go test ./...` passes for both modules (all 20 tuttid packages green).
- Pre-push `check:full` (lint:go / test:go / test:ts / generated checks) passes locally.

## Note for the release owner

- Historic tags `packages/agent/daemon/v0.0.1`–`v0.0.59` are **permanently un-fetchable** from the Go module proxy due to the path mismatch — do not point anyone at them.
- This fix ships with the next stable release via the existing `publish-packages.mjs` flow (no dedicated release window needed). The next tag should be `packages/agent/daemon/v0.0.60`, which becomes the **minimum externally usable version** (for tsh).
- After the release, please sync that tag number to the tsh side so it can be recorded in the RFC as tsh's minimum required version. Acceptance: an external repo can successfully run `go get github.com/tutti-os/tutti/packages/agent/daemon@<tag>`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the agent runtime and related services to use the current package structure, helping ensure the app and tests continue to build and run correctly.
  * Aligned shared activity handling across runtime, browser, workspace, and agent-status features.

* **Chores**
  * Rewired internal references and test imports to match the new module layout.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->