### PR TITLE
feat(agent/daemon): open cloud projection extension points in activity package (RFC T3)

### DIFF
--- a/packages/agent/daemon/README.md
+++ b/packages/agent/daemon/README.md
@@ -66,10 +66,15 @@ restores the last cursor on resume.
 ## Cloud Projection Extension Points
 
 External daemons (for example tsh desktopd) can project local agent activity to
-a remote controlplane without forking any `activity/` code. Note on naming: a
-controlplane _room_ is the same identifier this package calls a _workspace_ —
-`roomID` in store interfaces equals the `WorkspaceID` on report inputs and is
-sent on the wire as `roomId`.
+a remote controlplane without forking any `activity/` code.
+
+**Scope ID semantics (RFC hard constraint):** the scope identifier in these
+shared contracts is opaque — on the tutti side it is the **workspace ID**, for
+external daemons such as tsh it is the **control-plane room ID**. workspace ≡
+room, one-to-one, with no implicit translation anywhere: `roomID` in the store
+interfaces is exactly the `WorkspaceID` on report inputs and is sent on the
+wire as `roomId`. External daemons must pass the control-plane room ID directly
+and must not introduce a second mapping in between.
 
 - **`SyncStateStore`** — inject persistence for per-session sync states
   (pending counts, failure counters, last error) via

--- a/packages/agent/daemon/README.md
+++ b/packages/agent/daemon/README.md
@@ -63,6 +63,47 @@ owns SDK stream ordering, turn cancellation, orphan result draining, and cursor
 updates; the Go adapter forwards requests, persists session state patches, and
 restores the last cursor on resume.
 
+## Cloud Projection Extension Points
+
+External daemons (for example tsh desktopd) can project local agent activity to
+a remote controlplane without forking any `activity/` code. Note on naming: a
+controlplane _room_ is the same identifier this package calls a _workspace_ —
+`roomID` in store interfaces equals the `WorkspaceID` on report inputs and is
+sent on the wire as `roomId`.
+
+- **`SyncStateStore`** — inject persistence for per-session sync states
+  (pending counts, failure counters, last error) via
+  `agentsessionstore.WithSyncStateStore`. `FileAgentSyncStateStore` is a
+  ready-made file-backed implementation.
+- **`SessionActivityReporterAdapter`** — wraps any `SessionActivityReporter`
+  (such as `agentsessionstore.Client` configured with the controlplane
+  `BaseURL`) into an `ActivityReporter`. It converts `ReportActivityInput`
+  into per-session state and message reports and tracks/persists sync state
+  through a `SyncStateStore`.
+- **Syncer backoff and cursor persistence** — `WithSyncBackoff`
+  (`DefaultSyncBackoffConfig`: 10s initial, 5min cap, 2.0 multiplier) enables
+  per-session exponential backoff for failed message syncs, and
+  `WithMessageCursorStore` persists message sync cursors so pulls resume after
+  a restart. Both are opt-in; without them behavior is unchanged.
+
+```go
+client := agentsessionstore.NewClient(agentsessionstore.Config{
+    BaseURL: "https://controlplane.example.com",
+    Token:   token,
+})
+fileStore := agentsessionstore.NewFileAgentSyncStateStore(stateDir)
+reporter := agentsessionstore.NewSessionActivityReporterAdapter(
+    client,
+    agentsessionstore.WithReporterSyncStateStore(fileStore),
+)
+store := agentsessionstore.New(
+    client,
+    agentsessionstore.WithSyncStateStore(fileStore),
+    agentsessionstore.WithMessageCursorStore(fileStore),
+    agentsessionstore.WithSyncBackoff(agentsessionstore.DefaultSyncBackoffConfig()),
+)
+```
+
 ## Legacy Defaults
 
 The legacy runtime constructors still default to `TUTTI_WORKSPACE_ID`,

--- a/packages/agent/daemon/activity/client.go
+++ b/packages/agent/daemon/activity/client.go
@@ -54,8 +54,12 @@ func (c *Client) ReportSessionState(ctx context.Context, input ReportSessionStat
 		url.PathEscape(workspaceID),
 		url.PathEscape(agentSessionID),
 	)
-	agentTargetID := strings.TrimSpace(input.AgentTargetID)
-	deviceID := strings.TrimSpace(input.DeviceID)
+	// Metadata resolution: explicit input fields win, then the source, then
+	// (for the state document) the state itself. Existing non-empty values
+	// are left byte-identical in place; resolution only fills empty slots, so
+	// callers that carry no metadata anywhere produce an unchanged request.
+	agentTargetID := firstNonEmptyString(input.AgentTargetID, input.Source.AgentTargetID, input.State.AgentTargetID)
+	deviceID := firstNonEmptyString(input.DeviceID, input.Source.DeviceID, input.State.DeviceID)
 	source := input.Source
 	if agentTargetID != "" && strings.TrimSpace(source.AgentTargetID) == "" {
 		source.AgentTargetID = agentTargetID
@@ -107,8 +111,10 @@ func (c *Client) ReportSessionMessages(ctx context.Context, input ReportSessionM
 		url.PathEscape(workspaceID),
 		url.PathEscape(agentSessionID),
 	)
-	agentTargetID := strings.TrimSpace(input.AgentTargetID)
-	deviceID := strings.TrimSpace(input.DeviceID)
+	// Metadata resolution mirrors ReportSessionState: explicit input fields
+	// win, then the source; only empty slots are filled.
+	agentTargetID := firstNonEmptyString(input.AgentTargetID, input.Source.AgentTargetID)
+	deviceID := firstNonEmptyString(input.DeviceID, input.Source.DeviceID)
 	source := input.Source
 	if agentTargetID != "" && strings.TrimSpace(source.AgentTargetID) == "" {
 		source.AgentTargetID = agentTargetID

--- a/packages/agent/daemon/activity/client.go
+++ b/packages/agent/daemon/activity/client.go
@@ -545,6 +545,8 @@ func marshalReportSessionMessagesRequestsForUpload(req reportSessionMessagesRequ
 
 	base := reportSessionMessagesRequest{
 		WorkspaceID:   req.WorkspaceID,
+		AgentTargetID: req.AgentTargetID,
+		DeviceID:      req.DeviceID,
 		SessionOrigin: req.SessionOrigin,
 		Connector:     req.Connector,
 		Source:        req.Source,

--- a/packages/agent/daemon/activity/client.go
+++ b/packages/agent/daemon/activity/client.go
@@ -54,13 +54,31 @@ func (c *Client) ReportSessionState(ctx context.Context, input ReportSessionStat
 		url.PathEscape(workspaceID),
 		url.PathEscape(agentSessionID),
 	)
+	agentTargetID := strings.TrimSpace(input.AgentTargetID)
+	deviceID := strings.TrimSpace(input.DeviceID)
+	source := input.Source
+	if agentTargetID != "" && strings.TrimSpace(source.AgentTargetID) == "" {
+		source.AgentTargetID = agentTargetID
+	}
+	if deviceID != "" && strings.TrimSpace(source.DeviceID) == "" {
+		source.DeviceID = deviceID
+	}
+	state := sanitizeSessionStateUpdateForUpstream(input.State)
+	if agentTargetID != "" && strings.TrimSpace(state.AgentTargetID) == "" {
+		state.AgentTargetID = agentTargetID
+	}
+	if deviceID != "" && strings.TrimSpace(state.DeviceID) == "" {
+		state.DeviceID = deviceID
+	}
 	requestBody, err := marshalRequestBody(reportSessionStateRequest{
 		WorkspaceID:    workspaceID,
 		AgentSessionID: agentSessionID,
+		AgentTargetID:  agentTargetID,
+		DeviceID:       deviceID,
 		SessionOrigin:  sessionOriginCanonicalRequestValue(input.SessionOrigin),
 		Connector:      input.Connector,
-		Source:         &input.Source,
-		State:          sanitizeSessionStateUpdateForUpstream(input.State),
+		Source:         &source,
+		State:          state,
 	})
 	if err != nil {
 		return ReportSessionStateReply{}, fmt.Errorf("prepare agent session state request: %w", err)
@@ -89,11 +107,22 @@ func (c *Client) ReportSessionMessages(ctx context.Context, input ReportSessionM
 		url.PathEscape(workspaceID),
 		url.PathEscape(agentSessionID),
 	)
+	agentTargetID := strings.TrimSpace(input.AgentTargetID)
+	deviceID := strings.TrimSpace(input.DeviceID)
+	source := input.Source
+	if agentTargetID != "" && strings.TrimSpace(source.AgentTargetID) == "" {
+		source.AgentTargetID = agentTargetID
+	}
+	if deviceID != "" && strings.TrimSpace(source.DeviceID) == "" {
+		source.DeviceID = deviceID
+	}
 	requestBatches, err := marshalReportSessionMessagesRequestsForUpload(reportSessionMessagesRequest{
 		WorkspaceID:   workspaceID,
+		AgentTargetID: agentTargetID,
+		DeviceID:      deviceID,
 		SessionOrigin: sessionOriginCanonicalRequestValue(input.SessionOrigin),
 		Connector:     input.Connector,
-		Source:        &input.Source,
+		Source:        &source,
 		Updates:       sanitizeSessionMessageUpdatesForUpstream(input.Updates),
 	})
 	if err != nil {
@@ -173,6 +202,9 @@ func (c *Client) ListAgentsWithFilter(ctx context.Context, input ListAgentsInput
 	if userID := strings.TrimSpace(input.UserID); userID != "" {
 		query.Set("user_id", userID)
 	}
+	if deviceID := strings.TrimSpace(input.DeviceID); deviceID != "" {
+		query.Set("device_id", deviceID)
+	}
 	if encoded := query.Encode(); encoded != "" {
 		endpoint += "?" + encoded
 	}
@@ -224,6 +256,9 @@ func (c *Client) ListSessionMessages(ctx context.Context, input ListSessionMessa
 	}
 	if origin := sessionOriginCanonicalQueryValue(input.SessionOrigin); origin != "" {
 		query.Set("session_origin", origin)
+	}
+	if deviceID := strings.TrimSpace(input.DeviceID); deviceID != "" {
+		query.Set("device_id", deviceID)
 	}
 
 	endpoint := fmt.Sprintf(
@@ -975,6 +1010,8 @@ type reportActivityRequest struct {
 type reportSessionStateRequest struct {
 	WorkspaceID    string                           `json:"roomId,omitempty"`
 	AgentSessionID string                           `json:"agentSessionId,omitempty"`
+	AgentTargetID  string                           `json:"agentTargetId,omitempty"`
+	DeviceID       string                           `json:"deviceId,omitempty"`
 	SessionOrigin  string                           `json:"sessionOrigin,omitempty"`
 	Source         *EventSource                     `json:"source,omitempty"`
 	Connector      *ConnectorInfo                   `json:"connector,omitempty"`
@@ -983,6 +1020,8 @@ type reportSessionStateRequest struct {
 
 type reportSessionMessagesRequest struct {
 	WorkspaceID   string                               `json:"roomId,omitempty"`
+	AgentTargetID string                               `json:"agentTargetId,omitempty"`
+	DeviceID      string                               `json:"deviceId,omitempty"`
 	SessionOrigin string                               `json:"sessionOrigin,omitempty"`
 	Source        *EventSource                         `json:"source,omitempty"`
 	Connector     *ConnectorInfo                       `json:"connector,omitempty"`

--- a/packages/agent/daemon/activity/client_device_metadata_test.go
+++ b/packages/agent/daemon/activity/client_device_metadata_test.go
@@ -90,6 +90,80 @@ func TestReportSessionStateOmitsMetadataKeysWhenUnset(t *testing.T) {
 	}
 }
 
+func TestReportSessionStateDerivesTopLevelMetadataFromSourceAndState(t *testing.T) {
+	var got map[string]any
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if err := json.NewDecoder(r.Body).Decode(&got); err != nil {
+			t.Fatal(err)
+		}
+		_, _ = w.Write([]byte(`{"accepted":true}`))
+	}))
+	defer server.Close()
+
+	client := NewClient(Config{BaseURL: server.URL, HTTPClient: server.Client()})
+	// The adapter path carries metadata only inside Source/State; the
+	// explicit input fields stay empty. Top-level request metadata must still
+	// be populated so controlplanes keying off it get scoped activity.
+	_, err := client.ReportSessionState(context.Background(), ReportSessionStateInput{
+		WorkspaceID:    "ws-1",
+		AgentSessionID: "session-1",
+		SessionOrigin:  WorkspaceAgentSessionOriginRuntime,
+		Source: EventSource{
+			Provider:      "codex",
+			AgentTargetID: "target-1",
+			DeviceID:      "device-1",
+			SessionOrigin: WorkspaceAgentSessionOriginRuntime,
+		},
+		State: WorkspaceAgentSessionStateUpdate{LifecycleStatus: "active"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got["agentTargetId"] != "target-1" || got["deviceId"] != "device-1" {
+		t.Fatalf("request metadata = %#v, want top-level metadata derived from source", got)
+	}
+	state, ok := got["state"].(map[string]any)
+	if !ok || state["agentTargetId"] != "target-1" || state["deviceId"] != "device-1" {
+		t.Fatalf("state = %#v, want metadata filled from source", got["state"])
+	}
+}
+
+func TestReportSessionMessagesDerivesTopLevelMetadataFromSource(t *testing.T) {
+	var got map[string]any
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if err := json.NewDecoder(r.Body).Decode(&got); err != nil {
+			t.Fatal(err)
+		}
+		_, _ = w.Write([]byte(`{"acceptedCount":1}`))
+	}))
+	defer server.Close()
+
+	client := NewClient(Config{BaseURL: server.URL, HTTPClient: server.Client()})
+	_, err := client.ReportSessionMessages(context.Background(), ReportSessionMessagesInput{
+		WorkspaceID:    "ws-1",
+		AgentSessionID: "session-1",
+		SessionOrigin:  WorkspaceAgentSessionOriginRuntime,
+		Source: EventSource{
+			Provider:      "codex",
+			AgentTargetID: "target-1",
+			DeviceID:      "device-1",
+			SessionOrigin: WorkspaceAgentSessionOriginRuntime,
+		},
+		Updates: []WorkspaceAgentSessionMessageUpdate{{
+			MessageID: "message-1",
+			TurnID:    "turn-1",
+			Role:      "assistant",
+			Kind:      "text",
+		}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got["agentTargetId"] != "target-1" || got["deviceId"] != "device-1" {
+		t.Fatalf("request metadata = %#v, want top-level metadata derived from source", got)
+	}
+}
+
 func TestReportSessionStateRequestBodyIsByteIdenticalWhenMetadataUnset(t *testing.T) {
 	var raw []byte
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/packages/agent/daemon/activity/client_device_metadata_test.go
+++ b/packages/agent/daemon/activity/client_device_metadata_test.go
@@ -3,8 +3,11 @@ package agentsessionstore
 import (
 	"context"
 	"encoding/json"
+	"io"
 	"net/http"
 	"net/http/httptest"
+	"strconv"
+	"strings"
 	"testing"
 )
 
@@ -84,6 +87,85 @@ func TestReportSessionStateOmitsMetadataKeysWhenUnset(t *testing.T) {
 	}
 	if _, present := source["deviceId"]; present {
 		t.Fatalf("source unexpectedly contains deviceId: %s", raw["source"])
+	}
+}
+
+func TestReportSessionStateRequestBodyIsByteIdenticalWhenMetadataUnset(t *testing.T) {
+	var raw []byte
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, err := io.ReadAll(r.Body)
+		if err != nil {
+			t.Fatal(err)
+		}
+		raw = body
+		_, _ = w.Write([]byte(`{"accepted":true}`))
+	}))
+	defer server.Close()
+
+	client := NewClient(Config{BaseURL: server.URL, HTTPClient: server.Client()})
+	_, err := client.ReportSessionState(context.Background(), ReportSessionStateInput{
+		WorkspaceID:    "ws-1",
+		AgentSessionID: "session-1",
+		SessionOrigin:  WorkspaceAgentSessionOriginRuntime,
+		Source:         EventSource{Provider: "codex"},
+		State:          WorkspaceAgentSessionStateUpdate{LifecycleStatus: "active"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Golden body: exactly what this request serialized to before the
+	// optional AgentTargetID/DeviceID inputs existed. Guards the hard
+	// constraint that unset metadata leaves the wire byte-for-byte unchanged.
+	want := `{"roomId":"ws-1","agentSessionId":"session-1",` +
+		`"sessionOrigin":"WORKSPACE_AGENT_SESSION_ORIGIN_RUNTIME",` +
+		`"source":{"provider":"codex"},"state":{"lifecycleStatus":"active"}}`
+	if string(raw) != want {
+		t.Fatalf("request body = %s, want %s", raw, want)
+	}
+}
+
+func TestReportSessionMessagesSplitBatchesPreserveMetadata(t *testing.T) {
+	rawText := strings.Repeat("x", maxUpstreamToolPayloadStringBytes+512)
+	var requestCount int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var got reportSessionMessagesRequest
+		if err := json.NewDecoder(r.Body).Decode(&got); err != nil {
+			t.Fatal(err)
+		}
+		requestCount++
+		if got.AgentTargetID != "target-1" || got.DeviceID != "device-1" {
+			t.Fatalf("batch %d metadata = %q/%q, want target-1/device-1", requestCount, got.AgentTargetID, got.DeviceID)
+		}
+		_, _ = w.Write([]byte(`{"acceptedCount":` + strconv.Itoa(len(got.Updates)) + `}`))
+	}))
+	defer server.Close()
+
+	updates := make([]WorkspaceAgentSessionMessageUpdate, 0, 80)
+	for i := 0; i < 80; i++ {
+		updates = append(updates, WorkspaceAgentSessionMessageUpdate{
+			MessageID: "message-" + strconv.Itoa(i),
+			TurnID:    "turn-1",
+			Role:      "assistant",
+			Kind:      "tool_call",
+			Payload: map[string]any{
+				"input":  map[string]any{"stdout": rawText},
+				"output": map[string]any{"stdout": rawText},
+			},
+		})
+	}
+
+	client := NewClient(Config{BaseURL: server.URL, HTTPClient: server.Client()})
+	if _, err := client.ReportSessionMessages(context.Background(), ReportSessionMessagesInput{
+		WorkspaceID:    "ws-1",
+		AgentSessionID: "session-1",
+		AgentTargetID:  "target-1",
+		DeviceID:       "device-1",
+		Updates:        updates,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if requestCount < 2 {
+		t.Fatalf("requestCount = %d, want oversized request split into multiple uploads", requestCount)
 	}
 }
 

--- a/packages/agent/daemon/activity/client_device_metadata_test.go
+++ b/packages/agent/daemon/activity/client_device_metadata_test.go
@@ -1,0 +1,206 @@
+package agentsessionstore
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestReportSessionStateIncludesOptionalAgentTargetAndDeviceMetadata(t *testing.T) {
+	var got map[string]any
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if err := json.NewDecoder(r.Body).Decode(&got); err != nil {
+			t.Fatal(err)
+		}
+		_, _ = w.Write([]byte(`{"accepted":true}`))
+	}))
+	defer server.Close()
+
+	client := NewClient(Config{BaseURL: server.URL, HTTPClient: server.Client()})
+	_, err := client.ReportSessionState(context.Background(), ReportSessionStateInput{
+		WorkspaceID:    "ws-1",
+		AgentSessionID: "session-1",
+		AgentTargetID:  "target-1",
+		DeviceID:       "device-1",
+		SessionOrigin:  WorkspaceAgentSessionOriginRuntime,
+		Source: EventSource{
+			Provider:      "codex",
+			AgentID:       "session-1",
+			SessionOrigin: WorkspaceAgentSessionOriginRuntime,
+		},
+		State: WorkspaceAgentSessionStateUpdate{LifecycleStatus: "active"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got["agentTargetId"] != "target-1" || got["deviceId"] != "device-1" {
+		t.Fatalf("request metadata = %#v, want top-level agentTargetId/deviceId", got)
+	}
+	source, ok := got["source"].(map[string]any)
+	if !ok || source["agentTargetId"] != "target-1" || source["deviceId"] != "device-1" {
+		t.Fatalf("source = %#v, want propagated metadata", got["source"])
+	}
+	state, ok := got["state"].(map[string]any)
+	if !ok || state["agentTargetId"] != "target-1" || state["deviceId"] != "device-1" {
+		t.Fatalf("state = %#v, want propagated metadata", got["state"])
+	}
+}
+
+func TestReportSessionStateOmitsMetadataKeysWhenUnset(t *testing.T) {
+	var raw map[string]json.RawMessage
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if err := json.NewDecoder(r.Body).Decode(&raw); err != nil {
+			t.Fatal(err)
+		}
+		_, _ = w.Write([]byte(`{"accepted":true}`))
+	}))
+	defer server.Close()
+
+	client := NewClient(Config{BaseURL: server.URL, HTTPClient: server.Client()})
+	_, err := client.ReportSessionState(context.Background(), ReportSessionStateInput{
+		WorkspaceID:    "ws-1",
+		AgentSessionID: "session-1",
+		SessionOrigin:  WorkspaceAgentSessionOriginRuntime,
+		Source: EventSource{
+			Provider:      "codex",
+			AgentID:       "session-1",
+			SessionOrigin: WorkspaceAgentSessionOriginRuntime,
+		},
+		State: WorkspaceAgentSessionStateUpdate{LifecycleStatus: "active"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, key := range []string{"agentTargetId", "deviceId"} {
+		if _, present := raw[key]; present {
+			t.Fatalf("request unexpectedly contains %q: %s", key, raw[key])
+		}
+	}
+	var source map[string]json.RawMessage
+	if err := json.Unmarshal(raw["source"], &source); err != nil {
+		t.Fatal(err)
+	}
+	if _, present := source["deviceId"]; present {
+		t.Fatalf("source unexpectedly contains deviceId: %s", raw["source"])
+	}
+}
+
+func TestReportSessionMessagesIncludesOptionalMetadata(t *testing.T) {
+	var got map[string]any
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if err := json.NewDecoder(r.Body).Decode(&got); err != nil {
+			t.Fatal(err)
+		}
+		_, _ = w.Write([]byte(`{"acceptedCount":1}`))
+	}))
+	defer server.Close()
+
+	client := NewClient(Config{BaseURL: server.URL, HTTPClient: server.Client()})
+	_, err := client.ReportSessionMessages(context.Background(), ReportSessionMessagesInput{
+		WorkspaceID:    "ws-1",
+		AgentSessionID: "session-1",
+		AgentTargetID:  "target-1",
+		DeviceID:       "device-1",
+		SessionOrigin:  WorkspaceAgentSessionOriginRuntime,
+		Source: EventSource{
+			Provider:      "codex",
+			AgentID:       "session-1",
+			SessionOrigin: WorkspaceAgentSessionOriginRuntime,
+		},
+		Updates: []WorkspaceAgentSessionMessageUpdate{{
+			MessageID: "message-1",
+			TurnID:    "turn-1",
+			Role:      "assistant",
+			Kind:      "text",
+		}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got["agentTargetId"] != "target-1" || got["deviceId"] != "device-1" {
+		t.Fatalf("request metadata = %#v, want top-level agentTargetId/deviceId", got)
+	}
+	source, ok := got["source"].(map[string]any)
+	if !ok || source["deviceId"] != "device-1" {
+		t.Fatalf("source = %#v, want propagated deviceId", got["source"])
+	}
+}
+
+func TestListSessionMessagesSendsDeviceIDQueryOnlyWhenSet(t *testing.T) {
+	var queries []string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		queries = append(queries, r.URL.Query().Get("device_id"))
+		_, _ = w.Write([]byte(`{"messages":[]}`))
+	}))
+	defer server.Close()
+
+	client := NewClient(Config{BaseURL: server.URL, HTTPClient: server.Client()})
+	if _, err := client.ListSessionMessages(context.Background(), ListSessionMessagesInput{
+		WorkspaceID:    "ws-1",
+		AgentSessionID: "session-1",
+		DeviceID:       "device-1",
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := client.ListSessionMessages(context.Background(), ListSessionMessagesInput{
+		WorkspaceID:    "ws-1",
+		AgentSessionID: "session-1",
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if len(queries) != 2 || queries[0] != "device-1" || queries[1] != "" {
+		t.Fatalf("device_id queries = %#v, want [device-1 \"\"]", queries)
+	}
+}
+
+func TestListAgentsWithFilterSendsDeviceIDQuery(t *testing.T) {
+	var deviceID string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		deviceID = r.URL.Query().Get("device_id")
+		_, _ = w.Write([]byte(`{"presences":[],"sessions":[]}`))
+	}))
+	defer server.Close()
+
+	client := NewClient(Config{BaseURL: server.URL, HTTPClient: server.Client()})
+	if _, err := client.ListAgentsWithFilter(context.Background(), ListAgentsInput{
+		WorkspaceID: "ws-1",
+		DeviceID:    "device-1",
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if deviceID != "device-1" {
+		t.Fatalf("device_id query = %q, want device-1", deviceID)
+	}
+}
+
+func TestWorkspaceAgentSessionUnmarshalsDeviceIDLeniently(t *testing.T) {
+	var camel WorkspaceAgentSession
+	if err := json.Unmarshal([]byte(`{"agentSessionId":"session-1","deviceId":"device-1"}`), &camel); err != nil {
+		t.Fatal(err)
+	}
+	if camel.DeviceID != "device-1" {
+		t.Fatalf("camelCase deviceId = %q, want device-1", camel.DeviceID)
+	}
+
+	var snake WorkspaceAgentSession
+	if err := json.Unmarshal([]byte(`{"agent_session_id":"session-1","device_id":"device-2"}`), &snake); err != nil {
+		t.Fatal(err)
+	}
+	if snake.DeviceID != "device-2" {
+		t.Fatalf("snake_case device_id = %q, want device-2", snake.DeviceID)
+	}
+
+	roundtrip, err := json.Marshal(WorkspaceAgentSession{AgentSessionID: "session-1", DeviceID: "device-1"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	var decoded map[string]any
+	if err := json.Unmarshal(roundtrip, &decoded); err != nil {
+		t.Fatal(err)
+	}
+	if decoded["deviceId"] != "device-1" {
+		t.Fatalf("marshal output = %s, want deviceId", roundtrip)
+	}
+}

--- a/packages/agent/daemon/activity/compat.go
+++ b/packages/agent/daemon/activity/compat.go
@@ -185,6 +185,7 @@ func sessionStateUpdateFromPatch(patch WorkspaceAgentStatePatch) WorkspaceAgentS
 	}
 	out := WorkspaceAgentSessionStateUpdate{
 		AgentTargetID:      strings.TrimSpace(patch.AgentTargetID),
+		DeviceID:           strings.TrimSpace(patch.DeviceID),
 		Provider:           strings.TrimSpace(patch.Provider),
 		ProviderSessionID:  strings.TrimSpace(patch.ProviderSessionID),
 		Model:              strings.TrimSpace(patch.Model),

--- a/packages/agent/daemon/activity/message_cursor_store_test.go
+++ b/packages/agent/daemon/activity/message_cursor_store_test.go
@@ -137,6 +137,34 @@ func TestStoreWithoutCursorStoreStartsFromZeroAfterRestart(t *testing.T) {
 	}
 }
 
+func TestAppendSessionMessagesDoesNotPersistCursorForHiddenSession(t *testing.T) {
+	cursorStore := NewFileAgentSyncStateStore(t.TempDir())
+	client := newFakeSyncerRepository()
+	client.snapshots["room-1"] = &WorkspaceAgentSnapshot{}
+
+	svc := New(client, WithMessageCursorStore(cursorStore))
+	svc.TrackRoom("room-1")
+	svc.HideAgentSession("room-1", "session-1")
+
+	// A late-arriving sync result for a hidden session must not resurrect
+	// its persisted cursor.
+	svc.appendSessionMessages("room-1", "session-1", []WorkspaceAgentSessionMessage{{
+		AgentSessionID: "session-1",
+		MessageID:      "message-1",
+		Role:           "assistant",
+		Kind:           "text",
+		Version:        4,
+	}}, 4)
+
+	cursors, err := cursorStore.LoadRoomMessageCursors(context.Background(), "room-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(cursors) != 0 {
+		t.Fatalf("cursors after hidden-session append = %#v, want empty", cursors)
+	}
+}
+
 func TestHideAgentSessionDeletesPersistedCursor(t *testing.T) {
 	cursorStore := NewFileAgentSyncStateStore(t.TempDir())
 	client := newFakeSyncerRepository()

--- a/packages/agent/daemon/activity/message_cursor_store_test.go
+++ b/packages/agent/daemon/activity/message_cursor_store_test.go
@@ -1,0 +1,172 @@
+package agentsessionstore
+
+import (
+	"context"
+	"reflect"
+	"testing"
+)
+
+func TestFileAgentSyncStateStoreMessageCursorRoundtrip(t *testing.T) {
+	store := NewFileAgentSyncStateStore(t.TempDir())
+	ctx := context.Background()
+
+	if err := store.SaveMessageCursor(ctx, "room-1", "session-1", 7); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.SaveMessageCursor(ctx, "room-1", "session-2", 3); err != nil {
+		t.Fatal(err)
+	}
+	// Cursors and sync states share the room document without clobbering
+	// each other.
+	if err := store.SaveAgentSyncState(ctx, "room-1", WorkspaceAgentSyncState{
+		AgentSessionID: "session-1",
+		Status:         WorkspaceAgentSyncStatusSynced,
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	cursors, err := store.LoadRoomMessageCursors(ctx, "room-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if want := map[string]uint64{"session-1": 7, "session-2": 3}; !reflect.DeepEqual(cursors, want) {
+		t.Fatalf("cursors = %#v, want %#v", cursors, want)
+	}
+	syncStates, err := store.LoadRoomSyncStates(ctx, "room-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if syncStates["session-1"].Status != WorkspaceAgentSyncStatusSynced {
+		t.Fatalf("sync states = %#v, want session-1 synced", syncStates)
+	}
+
+	if err := store.DeleteMessageCursor(ctx, "room-1", "session-1"); err != nil {
+		t.Fatal(err)
+	}
+	cursors, err = store.LoadRoomMessageCursors(ctx, "room-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if want := map[string]uint64{"session-2": 3}; !reflect.DeepEqual(cursors, want) {
+		t.Fatalf("cursors after delete = %#v, want %#v", cursors, want)
+	}
+}
+
+func TestFileAgentSyncStateStoreLoadMessageCursorsMissingRoom(t *testing.T) {
+	store := NewFileAgentSyncStateStore(t.TempDir())
+	cursors, err := store.LoadRoomMessageCursors(context.Background(), "room-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(cursors) != 0 {
+		t.Fatalf("cursors = %#v, want empty", cursors)
+	}
+}
+
+func TestStoreResumesMessageSyncFromPersistedCursor(t *testing.T) {
+	dir := t.TempDir()
+	cursorStore := NewFileAgentSyncStateStore(dir)
+	snapshot := &WorkspaceAgentSnapshot{
+		Sessions: []WorkspaceAgentSession{{
+			AgentSessionID:  "session-1",
+			SessionOrigin:   WorkspaceAgentSessionOriginRuntime,
+			LifecycleStatus: "active",
+			EffectiveStatus: "working",
+		}},
+	}
+
+	client := newFakeSyncerRepository()
+	client.snapshots["room-1"] = snapshot
+	client.messages["room-1/session-1"] = []ListSessionMessagesReply{{
+		Messages: []WorkspaceAgentSessionMessage{{
+			AgentSessionID: "session-1",
+			MessageID:      "message-1",
+			Role:           "assistant",
+			Kind:           "text",
+			Version:        2,
+		}},
+		LatestVersion: 2,
+	}}
+
+	svc := New(client, WithMessageCursorStore(cursorStore))
+	svc.TrackRoom("room-1")
+	syncer := newSessionSyncer(svc, client)
+	syncer.syncAllRooms(context.Background())
+
+	cursors, err := cursorStore.LoadRoomMessageCursors(context.Background(), "room-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cursors["session-1"] != 2 {
+		t.Fatalf("persisted cursor = %#v, want session-1 => 2", cursors)
+	}
+
+	// A fresh Store (simulated restart) seeds the cursor from the store and
+	// resumes paging after the persisted version.
+	restartClient := newFakeSyncerRepository()
+	restartClient.snapshots["room-1"] = snapshot
+	restarted := New(restartClient, WithMessageCursorStore(cursorStore))
+	restarted.TrackRoom("room-1")
+	restartSyncer := newSessionSyncer(restarted, restartClient)
+	restartSyncer.syncAllRooms(context.Background())
+
+	if got := restartClient.afterVersionsFor("session-1"); !reflect.DeepEqual(got, []uint64{2}) {
+		t.Fatalf("after versions on restart = %#v, want [2]", got)
+	}
+}
+
+func TestStoreWithoutCursorStoreStartsFromZeroAfterRestart(t *testing.T) {
+	snapshot := &WorkspaceAgentSnapshot{
+		Sessions: []WorkspaceAgentSession{{
+			AgentSessionID:  "session-1",
+			SessionOrigin:   WorkspaceAgentSessionOriginRuntime,
+			LifecycleStatus: "active",
+			EffectiveStatus: "working",
+		}},
+	}
+	client := newFakeSyncerRepository()
+	client.snapshots["room-1"] = snapshot
+
+	svc := New(client)
+	svc.TrackRoom("room-1")
+	syncer := newSessionSyncer(svc, client)
+	syncer.syncAllRooms(context.Background())
+
+	if got := client.afterVersionsFor("session-1"); !reflect.DeepEqual(got, []uint64{0}) {
+		t.Fatalf("after versions without cursor store = %#v, want [0]", got)
+	}
+}
+
+func TestHideAgentSessionDeletesPersistedCursor(t *testing.T) {
+	cursorStore := NewFileAgentSyncStateStore(t.TempDir())
+	client := newFakeSyncerRepository()
+	client.snapshots["room-1"] = &WorkspaceAgentSnapshot{}
+
+	svc := New(client, WithMessageCursorStore(cursorStore))
+	svc.TrackRoom("room-1")
+	svc.appendSessionMessages("room-1", "session-1", []WorkspaceAgentSessionMessage{{
+		AgentSessionID: "session-1",
+		MessageID:      "message-1",
+		Role:           "assistant",
+		Kind:           "text",
+		Version:        4,
+	}}, 4)
+
+	cursors, err := cursorStore.LoadRoomMessageCursors(context.Background(), "room-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cursors["session-1"] != 4 {
+		t.Fatalf("persisted cursor = %#v, want session-1 => 4", cursors)
+	}
+
+	svc.HideAgentSession("room-1", "session-1")
+
+	cursors, err = cursorStore.LoadRoomMessageCursors(context.Background(), "room-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(cursors) != 0 {
+		t.Fatalf("cursors after hide = %#v, want empty", cursors)
+	}
+}

--- a/packages/agent/daemon/activity/repo.go
+++ b/packages/agent/daemon/activity/repo.go
@@ -20,12 +20,13 @@ type ReadRepository interface {
 // inject their own persistence via WithSyncStateStore. FileAgentSyncStateStore
 // is a ready-made file-backed implementation.
 //
-// All methods are keyed by room id. A room is the controlplane-side name for
-// what this codebase calls a workspace: roomID here is always the same value
-// as the WorkspaceID carried by report inputs, and is what goes on the wire as
-// roomId. Implementations must be safe for concurrent use. When no store is
-// injected the Store keeps sync states in memory only, matching historical
-// behavior.
+// All methods are keyed by roomID, an opaque scope identifier: on the tutti
+// side it is the workspace ID; for external daemons such as tsh it is the
+// control-plane room ID. workspace ≡ room, one-to-one — the same value as the
+// WorkspaceID carried by report inputs (sent on the wire as roomId), with no
+// implicit translation anywhere. Implementations must be safe for concurrent
+// use. When no store is injected the Store keeps sync states in memory only,
+// matching historical behavior.
 type SyncStateStore interface {
 	// LoadRoomSyncStates returns the persisted sync states for a room keyed by
 	// agent session id. A nil map with a nil error means nothing is persisted.
@@ -44,11 +45,12 @@ type SyncStateStore interface {
 // version zero. Without one, cursors live in memory only (historical
 // behavior).
 //
-// Like SyncStateStore, all methods are keyed by room id, which is identical to
-// the workspace id used elsewhere in this package (room is the controlplane
-// name for a workspace). Implementations must be safe for concurrent use, and
-// deleting an absent cursor must not be an error. FileAgentSyncStateStore
-// implements this interface alongside SyncStateStore.
+// Like SyncStateStore, all methods are keyed by roomID, an opaque scope
+// identifier: tutti side = workspace ID, external daemons (tsh) = control-plane
+// room ID; workspace ≡ room, one-to-one, no implicit translation.
+// Implementations must be safe for concurrent use, and deleting an absent
+// cursor must not be an error. FileAgentSyncStateStore implements this
+// interface alongside SyncStateStore.
 type MessageCursorStore interface {
 	// LoadRoomMessageCursors returns the persisted cursors for a room keyed by
 	// agent session id. A nil map with a nil error means nothing is persisted.

--- a/packages/agent/daemon/activity/repo.go
+++ b/packages/agent/daemon/activity/repo.go
@@ -13,8 +13,48 @@ type ReadRepository interface {
 	ListSessionMessages(ctx context.Context, input ListSessionMessagesInput) (*ListSessionMessagesReply, error)
 }
 
+// SyncStateStore persists per-session activity sync state (pending report
+// counts, failure counters, last error) across daemon restarts. It is a public
+// extension point: external daemons embedding this package (for example a
+// desktop daemon projecting local agent activity to a cloud controlplane) can
+// inject their own persistence via WithSyncStateStore. FileAgentSyncStateStore
+// is a ready-made file-backed implementation.
+//
+// All methods are keyed by room id. A room is the controlplane-side name for
+// what this codebase calls a workspace: roomID here is always the same value
+// as the WorkspaceID carried by report inputs, and is what goes on the wire as
+// roomId. Implementations must be safe for concurrent use. When no store is
+// injected the Store keeps sync states in memory only, matching historical
+// behavior.
 type SyncStateStore interface {
+	// LoadRoomSyncStates returns the persisted sync states for a room keyed by
+	// agent session id. A nil map with a nil error means nothing is persisted.
 	LoadRoomSyncStates(ctx context.Context, roomID string) (map[string]WorkspaceAgentSyncState, error)
+	// SaveAgentSyncState upserts the sync state for state.AgentSessionID.
 	SaveAgentSyncState(ctx context.Context, roomID string, state WorkspaceAgentSyncState) error
+	// DeleteAgentSyncState removes the sync state for the given agent session.
+	// Deleting an absent entry must not be an error.
 	DeleteAgentSyncState(ctx context.Context, roomID string, agentSessionID string) error
+}
+
+// MessageCursorStore persists per-session message sync cursors: the highest
+// remote message version the Store has already ingested for a session. With a
+// store injected (WithMessageCursorStore) the syncer resumes message pulls
+// from the persisted cursor after a daemon restart instead of refetching from
+// version zero. Without one, cursors live in memory only (historical
+// behavior).
+//
+// Like SyncStateStore, all methods are keyed by room id, which is identical to
+// the workspace id used elsewhere in this package (room is the controlplane
+// name for a workspace). Implementations must be safe for concurrent use, and
+// deleting an absent cursor must not be an error. FileAgentSyncStateStore
+// implements this interface alongside SyncStateStore.
+type MessageCursorStore interface {
+	// LoadRoomMessageCursors returns the persisted cursors for a room keyed by
+	// agent session id. A nil map with a nil error means nothing is persisted.
+	LoadRoomMessageCursors(ctx context.Context, roomID string) (map[string]uint64, error)
+	// SaveMessageCursor upserts the cursor for the given agent session.
+	SaveMessageCursor(ctx context.Context, roomID string, agentSessionID string, version uint64) error
+	// DeleteMessageCursor removes the cursor for the given agent session.
+	DeleteMessageCursor(ctx context.Context, roomID string, agentSessionID string) error
 }

--- a/packages/agent/daemon/activity/reporter_adapter.go
+++ b/packages/agent/daemon/activity/reporter_adapter.go
@@ -21,6 +21,11 @@ import (
 // BaseURL (or any custom SessionActivityReporter implementation) and wrap it
 // in this adapter to obtain a drop-in ActivityReporter with durable sync-state
 // tracking. No activity package code needs to be forked.
+//
+// Scope identifier: ReportActivityInput.WorkspaceID is used verbatim as the
+// SyncStateStore roomID — tutti side = workspace ID, external daemons (tsh) =
+// control-plane room ID; workspace ≡ room, one-to-one. The adapter never
+// translates or remaps this value.
 type SessionActivityReporterAdapter struct {
 	reporter SessionActivityReporter
 	store    SyncStateStore
@@ -78,6 +83,9 @@ func (a *SessionActivityReporterAdapter) Report(ctx context.Context, input Repor
 	if a == nil || a.reporter == nil {
 		return nil
 	}
+	// The workspace ID is the scope identifier used as-is for sync-state
+	// persistence and report inputs below (workspace ≡ control-plane room,
+	// one-to-one, no translation).
 	workspaceID := strings.TrimSpace(input.WorkspaceID)
 	if workspaceID == "" {
 		return errors.New("workspace id is required")
@@ -149,8 +157,9 @@ func (a *SessionActivityReporterAdapter) reportSessionWork(
 
 // RoomSyncStates returns the adapter's current sync states for a room keyed by
 // agent session id, seeding from the injected SyncStateStore on first touch.
-// The room id is the workspace id passed to Report (room is the controlplane
-// name for a workspace).
+// roomID is the scope identifier: it is exactly the WorkspaceID passed to
+// Report (tutti side = workspace ID, tsh side = control-plane room ID;
+// workspace ≡ room, one-to-one).
 func (a *SessionActivityReporterAdapter) RoomSyncStates(roomID string) map[string]WorkspaceAgentSyncState {
 	roomID = strings.TrimSpace(roomID)
 	if a == nil || roomID == "" {

--- a/packages/agent/daemon/activity/reporter_adapter.go
+++ b/packages/agent/daemon/activity/reporter_adapter.go
@@ -224,8 +224,12 @@ func (a *SessionActivityReporterAdapter) updateSyncState(
 	}
 	next := update(current, a.adapterNow().UnixMilli())
 	current.state = next
-	a.mu.Unlock()
+	// Persist while holding a.mu so the persisted order matches the
+	// transition order under concurrent Reports: a stale pending write must
+	// never land after a newer synced/failed write, or a restart would
+	// resurrect it as a spurious failure.
 	a.persistSyncState(roomID, next)
+	a.mu.Unlock()
 }
 
 func (a *SessionActivityReporterAdapter) roomStatesLocked(roomID string) map[string]*agentSessionSyncState {

--- a/packages/agent/daemon/activity/reporter_adapter.go
+++ b/packages/agent/daemon/activity/reporter_adapter.go
@@ -1,0 +1,285 @@
+package agentsessionstore
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"strings"
+	"sync"
+	"time"
+)
+
+// SessionActivityReporterAdapter bridges the coarse ActivityReporter interface
+// to a SessionActivityReporter backend. Each Report call is converted into
+// per-session state patches (ReportSessionState) and message-update groups
+// (ReportSessionMessages), and the per-session sync outcome
+// (pending/synced/failed with pending counts and last error) is tracked and —
+// when a SyncStateStore is injected — persisted across restarts.
+//
+// This is the extension point for external daemons that project local agent
+// activity to a remote controlplane: construct a Client with the controlplane
+// BaseURL (or any custom SessionActivityReporter implementation) and wrap it
+// in this adapter to obtain a drop-in ActivityReporter with durable sync-state
+// tracking. No activity package code needs to be forked.
+type SessionActivityReporterAdapter struct {
+	reporter SessionActivityReporter
+	store    SyncStateStore
+	now      func() time.Time
+
+	mu     sync.Mutex
+	rooms  map[string]map[string]*agentSessionSyncState
+	loaded map[string]struct{}
+}
+
+var _ ActivityReporter = (*SessionActivityReporterAdapter)(nil)
+
+// SessionActivityReporterAdapterOption configures a
+// SessionActivityReporterAdapter.
+type SessionActivityReporterAdapterOption func(*SessionActivityReporterAdapter)
+
+// WithReporterSyncStateStore persists the adapter's per-session sync states.
+// Previously persisted states seed the adapter on first touch of a room, and
+// every transition is written through. Without this option sync states live
+// in memory only.
+func WithReporterSyncStateStore(store SyncStateStore) SessionActivityReporterAdapterOption {
+	return func(adapter *SessionActivityReporterAdapter) {
+		if adapter != nil {
+			adapter.store = store
+		}
+	}
+}
+
+// NewSessionActivityReporterAdapter returns an ActivityReporter that forwards
+// activity to the given SessionActivityReporter.
+func NewSessionActivityReporterAdapter(
+	reporter SessionActivityReporter,
+	opts ...SessionActivityReporterAdapterOption,
+) *SessionActivityReporterAdapter {
+	adapter := &SessionActivityReporterAdapter{
+		reporter: reporter,
+		now:      time.Now,
+		rooms:    make(map[string]map[string]*agentSessionSyncState),
+		loaded:   make(map[string]struct{}),
+	}
+	for _, opt := range opts {
+		if opt != nil {
+			opt(adapter)
+		}
+	}
+	return adapter
+}
+
+// Report converts the activity input into session state and message reports
+// and forwards them session by session. Each session's batch transitions its
+// sync state to pending before sending and to synced or failed afterwards.
+// The first send failure marks that session failed and aborts the report;
+// sessions not yet attempted keep their previous sync state.
+func (a *SessionActivityReporterAdapter) Report(ctx context.Context, input ReportActivityInput) error {
+	if a == nil || a.reporter == nil {
+		return nil
+	}
+	workspaceID := strings.TrimSpace(input.WorkspaceID)
+	if workspaceID == "" {
+		return errors.New("workspace id is required")
+	}
+	stateInputs := SessionStateInputsFromActivity(input)
+	messageInputs, err := SessionMessageInputsFromActivity(input)
+	if err != nil {
+		return err
+	}
+
+	type sessionWork struct {
+		agentSessionID string
+		states         []ReportSessionStateInput
+		messages       []ReportSessionMessagesInput
+		messageUpdates int
+	}
+	order := make([]string, 0, len(stateInputs)+len(messageInputs))
+	workBySession := make(map[string]*sessionWork)
+	workFor := func(agentSessionID string) *sessionWork {
+		work := workBySession[agentSessionID]
+		if work == nil {
+			work = &sessionWork{agentSessionID: agentSessionID}
+			workBySession[agentSessionID] = work
+			order = append(order, agentSessionID)
+		}
+		return work
+	}
+	for _, stateInput := range stateInputs {
+		stateInput.WorkspaceID = workspaceID
+		work := workFor(stateInput.AgentSessionID)
+		work.states = append(work.states, stateInput)
+	}
+	for _, messagesInput := range messageInputs {
+		messagesInput.WorkspaceID = workspaceID
+		work := workFor(messagesInput.AgentSessionID)
+		work.messages = append(work.messages, messagesInput)
+		work.messageUpdates += len(messagesInput.Updates)
+	}
+
+	for _, agentSessionID := range order {
+		work := workBySession[agentSessionID]
+		a.markSyncPending(workspaceID, agentSessionID, len(work.states), work.messageUpdates)
+		if err := a.reportSessionWork(ctx, work.states, work.messages); err != nil {
+			a.markSyncFailed(workspaceID, agentSessionID, err)
+			return err
+		}
+		a.markSyncSucceeded(workspaceID, agentSessionID, len(work.states), work.messageUpdates)
+	}
+	return nil
+}
+
+func (a *SessionActivityReporterAdapter) reportSessionWork(
+	ctx context.Context,
+	states []ReportSessionStateInput,
+	messages []ReportSessionMessagesInput,
+) error {
+	for _, stateInput := range states {
+		if _, err := a.reporter.ReportSessionState(ctx, stateInput); err != nil {
+			return err
+		}
+	}
+	for _, messagesInput := range messages {
+		if _, err := a.reporter.ReportSessionMessages(ctx, messagesInput); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// RoomSyncStates returns the adapter's current sync states for a room keyed by
+// agent session id, seeding from the injected SyncStateStore on first touch.
+// The room id is the workspace id passed to Report (room is the controlplane
+// name for a workspace).
+func (a *SessionActivityReporterAdapter) RoomSyncStates(roomID string) map[string]WorkspaceAgentSyncState {
+	roomID = strings.TrimSpace(roomID)
+	if a == nil || roomID == "" {
+		return nil
+	}
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	room := a.roomStatesLocked(roomID)
+	out := make(map[string]WorkspaceAgentSyncState, len(room))
+	for agentSessionID, current := range room {
+		out[agentSessionID] = current.state
+	}
+	return out
+}
+
+func (a *SessionActivityReporterAdapter) markSyncPending(
+	roomID string,
+	agentSessionID string,
+	statePatchCount int,
+	messageUpdateCount int,
+) {
+	a.updateSyncState(roomID, agentSessionID, func(current *agentSessionSyncState, now int64) WorkspaceAgentSyncState {
+		return applyActivitySyncPending(current, agentSessionID, 0, statePatchCount, messageUpdateCount, now)
+	})
+}
+
+func (a *SessionActivityReporterAdapter) markSyncSucceeded(
+	roomID string,
+	agentSessionID string,
+	statePatchCount int,
+	messageUpdateCount int,
+) {
+	a.updateSyncState(roomID, agentSessionID, func(current *agentSessionSyncState, now int64) WorkspaceAgentSyncState {
+		return applyActivitySyncSucceeded(current, agentSessionID, 0, statePatchCount, messageUpdateCount, now)
+	})
+}
+
+func (a *SessionActivityReporterAdapter) markSyncFailed(roomID string, agentSessionID string, err error) {
+	a.updateSyncState(roomID, agentSessionID, func(current *agentSessionSyncState, now int64) WorkspaceAgentSyncState {
+		return applyActivitySyncFailed(current, agentSessionID, err, now)
+	})
+}
+
+func (a *SessionActivityReporterAdapter) updateSyncState(
+	roomID string,
+	agentSessionID string,
+	update func(*agentSessionSyncState, int64) WorkspaceAgentSyncState,
+) {
+	roomID = strings.TrimSpace(roomID)
+	agentSessionID = strings.TrimSpace(agentSessionID)
+	if a == nil || roomID == "" || agentSessionID == "" || update == nil {
+		return
+	}
+	a.mu.Lock()
+	room := a.roomStatesLocked(roomID)
+	current := room[agentSessionID]
+	if current == nil {
+		current = &agentSessionSyncState{
+			state: WorkspaceAgentSyncState{AgentSessionID: agentSessionID},
+		}
+		room[agentSessionID] = current
+	}
+	next := update(current, a.adapterNow().UnixMilli())
+	current.state = next
+	a.mu.Unlock()
+	a.persistSyncState(roomID, next)
+}
+
+func (a *SessionActivityReporterAdapter) roomStatesLocked(roomID string) map[string]*agentSessionSyncState {
+	if a.rooms == nil {
+		a.rooms = make(map[string]map[string]*agentSessionSyncState)
+	}
+	room := a.rooms[roomID]
+	if room == nil {
+		room = make(map[string]*agentSessionSyncState)
+		a.rooms[roomID] = room
+	}
+	if a.loaded == nil {
+		a.loaded = make(map[string]struct{})
+	}
+	if _, ok := a.loaded[roomID]; !ok {
+		a.loaded[roomID] = struct{}{}
+		for agentSessionID, syncState := range a.loadPersistedSyncStates(roomID) {
+			agentSessionID = strings.TrimSpace(agentSessionID)
+			if agentSessionID == "" {
+				continue
+			}
+			if _, exists := room[agentSessionID]; exists {
+				continue
+			}
+			room[agentSessionID] = syncEntryFromState(syncState)
+		}
+	}
+	return room
+}
+
+func (a *SessionActivityReporterAdapter) loadPersistedSyncStates(roomID string) map[string]WorkspaceAgentSyncState {
+	if a.store == nil {
+		return nil
+	}
+	states, err := a.store.LoadRoomSyncStates(context.Background(), roomID)
+	if err != nil {
+		slog.Warn("agent activity reporter sync state load failed",
+			"event", "agent_activity.reporter_sync_state.load_failed",
+			"room_id", roomID,
+			"error", err,
+		)
+		return nil
+	}
+	return states
+}
+
+func (a *SessionActivityReporterAdapter) persistSyncState(roomID string, syncState WorkspaceAgentSyncState) {
+	if a == nil || a.store == nil {
+		return
+	}
+	if err := a.store.SaveAgentSyncState(context.Background(), roomID, syncState); err != nil {
+		slog.Warn("agent activity reporter sync state save failed",
+			"event", "agent_activity.reporter_sync_state.save_failed",
+			"room_id", roomID,
+			"agent_session_id", strings.TrimSpace(syncState.AgentSessionID),
+			"error", err,
+		)
+	}
+}
+
+func (a *SessionActivityReporterAdapter) adapterNow() time.Time {
+	if a != nil && a.now != nil {
+		return a.now()
+	}
+	return time.Now()
+}

--- a/packages/agent/daemon/activity/reporter_adapter_test.go
+++ b/packages/agent/daemon/activity/reporter_adapter_test.go
@@ -1,0 +1,192 @@
+package agentsessionstore
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+)
+
+func TestSessionActivityReporterAdapterReportsStateAndMessages(t *testing.T) {
+	reporter := &fakeSessionActivityReporter{}
+	store := NewFileAgentSyncStateStore(t.TempDir())
+	adapter := NewSessionActivityReporterAdapter(reporter, WithReporterSyncStateStore(store))
+
+	err := adapter.Report(context.Background(), ReportActivityInput{
+		WorkspaceID: "room-1",
+		Source: EventSource{
+			Provider:      "codex",
+			AgentID:       "session-1",
+			SessionOrigin: WorkspaceAgentSessionOriginRuntime,
+		},
+		StatePatches: []WorkspaceAgentStatePatch{{
+			AgentSessionID:  "session-1",
+			LifecycleStatus: "active",
+			CurrentPhase:    "working",
+		}},
+		MessageUpdates: []WorkspaceAgentMessageUpdate{
+			{AgentSessionID: "session-1", MessageID: "message-1", TurnID: "turn-1", Role: "assistant", Kind: "text"},
+			{AgentSessionID: "session-1", MessageID: "message-2", TurnID: "turn-1", Role: "assistant", Kind: "text"},
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(reporter.stateInputs) != 1 || reporter.stateInputs[0].AgentSessionID != "session-1" {
+		t.Fatalf("state inputs = %#v, want one for session-1", reporter.stateInputs)
+	}
+	if reporter.stateInputs[0].State.LifecycleStatus != "active" {
+		t.Fatalf("state update = %#v", reporter.stateInputs[0].State)
+	}
+	if len(reporter.messageInputs) != 1 || len(reporter.messageInputs[0].Updates) != 2 {
+		t.Fatalf("message inputs = %#v, want one group with two updates", reporter.messageInputs)
+	}
+
+	syncStates := adapter.RoomSyncStates("room-1")
+	syncState, ok := syncStates["session-1"]
+	if !ok {
+		t.Fatalf("sync states = %#v, want session-1", syncStates)
+	}
+	if syncState.Status != WorkspaceAgentSyncStatusSynced {
+		t.Fatalf("sync status = %q, want synced", syncState.Status)
+	}
+	if syncState.PendingStatePatchCount != 0 || syncState.PendingMessageUpdateCount != 0 {
+		t.Fatalf("pending counts = %#v, want zero", syncState)
+	}
+	if syncState.LastSyncedAtUnixMS <= 0 {
+		t.Fatalf("last synced = %d, want > 0", syncState.LastSyncedAtUnixMS)
+	}
+
+	persisted, err := store.LoadRoomSyncStates(context.Background(), "room-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if persisted["session-1"].Status != WorkspaceAgentSyncStatusSynced {
+		t.Fatalf("persisted sync state = %#v, want synced", persisted["session-1"])
+	}
+}
+
+func TestSessionActivityReporterAdapterMarksFailedAndPersistsLastError(t *testing.T) {
+	reporter := &fakeSessionActivityReporter{stateErr: errors.New("controlplane unavailable")}
+	store := NewFileAgentSyncStateStore(t.TempDir())
+	adapter := NewSessionActivityReporterAdapter(reporter, WithReporterSyncStateStore(store))
+
+	err := adapter.Report(context.Background(), ReportActivityInput{
+		WorkspaceID: "room-1",
+		Source: EventSource{
+			Provider:      "codex",
+			AgentID:       "session-1",
+			SessionOrigin: WorkspaceAgentSessionOriginRuntime,
+		},
+		StatePatches: []WorkspaceAgentStatePatch{{
+			AgentSessionID:  "session-1",
+			LifecycleStatus: "active",
+		}},
+	})
+	if err == nil {
+		t.Fatal("expected report error")
+	}
+
+	syncState := adapter.RoomSyncStates("room-1")["session-1"]
+	if syncState.Status != WorkspaceAgentSyncStatusFailed {
+		t.Fatalf("sync status = %q, want failed", syncState.Status)
+	}
+	if syncState.LastError != "controlplane unavailable" {
+		t.Fatalf("last error = %q", syncState.LastError)
+	}
+	if syncState.FailedReportCount != 1 {
+		t.Fatalf("failed report count = %d, want 1", syncState.FailedReportCount)
+	}
+
+	persisted, err := store.LoadRoomSyncStates(context.Background(), "room-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if persisted["session-1"].Status != WorkspaceAgentSyncStatusFailed || persisted["session-1"].LastError == "" {
+		t.Fatalf("persisted sync state = %#v, want failed with last error", persisted["session-1"])
+	}
+}
+
+func TestSessionActivityReporterAdapterSeedsFromPersistedStates(t *testing.T) {
+	store := NewFileAgentSyncStateStore(t.TempDir())
+	if err := store.SaveAgentSyncState(context.Background(), "room-1", WorkspaceAgentSyncState{
+		AgentSessionID:    "session-1",
+		Status:            WorkspaceAgentSyncStatusFailed,
+		FailedReportCount: 3,
+		LastError:         "boom",
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	adapter := NewSessionActivityReporterAdapter(&fakeSessionActivityReporter{}, WithReporterSyncStateStore(store))
+	syncState, ok := adapter.RoomSyncStates("room-1")["session-1"]
+	if !ok || syncState.Status != WorkspaceAgentSyncStatusFailed || syncState.FailedReportCount != 3 {
+		t.Fatalf("seeded sync state = %#v, ok=%v", syncState, ok)
+	}
+}
+
+func TestSessionActivityReporterAdapterRejectsMessageUpdateWithoutTurnID(t *testing.T) {
+	reporter := &fakeSessionActivityReporter{}
+	adapter := NewSessionActivityReporterAdapter(reporter)
+
+	err := adapter.Report(context.Background(), ReportActivityInput{
+		WorkspaceID: "room-1",
+		Source: EventSource{
+			AgentID:       "session-1",
+			SessionOrigin: WorkspaceAgentSessionOriginRuntime,
+		},
+		MessageUpdates: []WorkspaceAgentMessageUpdate{{
+			AgentSessionID: "session-1",
+			MessageID:      "message-1",
+			Role:           "assistant",
+			Kind:           "text",
+		}},
+	})
+	if err == nil {
+		t.Fatal("expected missing turnId error")
+	}
+	if len(reporter.stateInputs) != 0 || len(reporter.messageInputs) != 0 {
+		t.Fatalf("reporter received inputs despite conversion error: %#v %#v", reporter.stateInputs, reporter.messageInputs)
+	}
+}
+
+func TestSessionActivityReporterAdapterRequiresWorkspaceID(t *testing.T) {
+	adapter := NewSessionActivityReporterAdapter(&fakeSessionActivityReporter{})
+	if err := adapter.Report(context.Background(), ReportActivityInput{}); err == nil {
+		t.Fatal("expected workspace id error")
+	}
+}
+
+type fakeSessionActivityReporter struct {
+	mu            sync.Mutex
+	stateInputs   []ReportSessionStateInput
+	messageInputs []ReportSessionMessagesInput
+	stateErr      error
+	messagesErr   error
+}
+
+func (f *fakeSessionActivityReporter) ReportSessionState(
+	_ context.Context,
+	input ReportSessionStateInput,
+) (ReportSessionStateReply, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.stateErr != nil {
+		return ReportSessionStateReply{}, f.stateErr
+	}
+	f.stateInputs = append(f.stateInputs, input)
+	return ReportSessionStateReply{Accepted: true, StateApplied: true}, nil
+}
+
+func (f *fakeSessionActivityReporter) ReportSessionMessages(
+	_ context.Context,
+	input ReportSessionMessagesInput,
+) (ReportSessionMessagesReply, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.messagesErr != nil {
+		return ReportSessionMessagesReply{}, f.messagesErr
+	}
+	f.messageInputs = append(f.messageInputs, input)
+	return ReportSessionMessagesReply{AcceptedCount: len(input.Updates)}, nil
+}

--- a/packages/agent/daemon/activity/service.go
+++ b/packages/agent/daemon/activity/service.go
@@ -1741,8 +1741,11 @@ func (s *Store) updateActivitySyncState(
 	}
 	next := update(current, time.Now().UnixMilli())
 	current.state = next
-	entry.mu.Unlock()
+	// Persist while holding entry.mu so sync-state writes serialize with
+	// HideAgentSession's delete (also under entry.mu): a save must never land
+	// after the delete and resurrect a hidden session's sync state.
 	s.saveSyncState(roomID, next)
+	entry.mu.Unlock()
 	s.notifyRoomUpdate(roomID)
 	return next, true
 }

--- a/packages/agent/daemon/activity/service.go
+++ b/packages/agent/daemon/activity/service.go
@@ -2082,13 +2082,19 @@ func (s *Store) appendSessionMessages(
 	}
 
 	entry.mu.Lock()
-	cursorBefore := entry.remoteMessageVersionBySession[agentSessionID]
+	// The locked append resolves provider aliases, so read the cursor under
+	// the canonical session id.
+	canonicalID := resolveKnownOrProviderAliasSessionID(entry.state.Sessions, agentSessionID, "", "", "", "")
+	cursorBefore := entry.remoteMessageVersionBySession[canonicalID]
 	changed := appendSessionMessagesLocked(entry, agentSessionID, messages, latestVersion)
-	cursorAfter := entry.remoteMessageVersionBySession[agentSessionID]
-	entry.mu.Unlock()
-	if cursorAfter > cursorBefore {
-		s.saveMessageCursor(roomID, agentSessionID, cursorAfter)
+	cursorAfter := entry.remoteMessageVersionBySession[canonicalID]
+	// Persist while holding entry.mu so cursor writes serialize with
+	// HideAgentSession's delete (also under entry.mu): a save must never land
+	// after the delete and resurrect a hidden session's cursor.
+	if cursorAfter > cursorBefore && !isHiddenAgentSession(entry, canonicalID) {
+		s.saveMessageCursor(roomID, canonicalID, cursorAfter)
 	}
+	entry.mu.Unlock()
 	if changed {
 		s.notifyRoomUpdate(roomID)
 	}

--- a/packages/agent/daemon/activity/service.go
+++ b/packages/agent/daemon/activity/service.go
@@ -67,6 +67,10 @@ type Option func(*Store)
 // sync states. Loaded states seed TrackRoom, updates are written through on
 // every sync-state transition, and entries are deleted when a session is
 // hidden. Without this option sync states live in memory only.
+//
+// Store keys are the scope identifier passed to TrackRoom: tutti side =
+// workspace ID, external daemons (tsh) = control-plane room ID; workspace ≡
+// room, one-to-one, no implicit translation.
 func WithSyncStateStore(store SyncStateStore) Option {
 	return func(svc *Store) {
 		if svc != nil {
@@ -80,6 +84,10 @@ func WithSyncStateStore(store SyncStateStore) Option {
 // pulls where it left off, cursor advances are written through, and entries
 // are deleted when a session is hidden. Without this option cursors live in
 // memory only.
+//
+// Store keys are the scope identifier passed to TrackRoom: tutti side =
+// workspace ID, external daemons (tsh) = control-plane room ID; workspace ≡
+// room, one-to-one, no implicit translation.
 func WithMessageCursorStore(store MessageCursorStore) Option {
 	return func(svc *Store) {
 		if svc != nil {

--- a/packages/agent/daemon/activity/service.go
+++ b/packages/agent/daemon/activity/service.go
@@ -50,21 +50,52 @@ type sessionEntry struct {
 }
 
 type Store struct {
-	mu             sync.RWMutex
-	rooms          map[string]*sessionEntry
-	client         ReadRepository
-	syncer         *sessionSyncer
-	syncStateStore SyncStateStore
-	updateListener func(roomID string, snapshot WorkspaceAgentSnapshot)
-	startOnce      sync.Once
+	mu                 sync.RWMutex
+	rooms              map[string]*sessionEntry
+	client             ReadRepository
+	syncer             *sessionSyncer
+	syncStateStore     SyncStateStore
+	messageCursorStore MessageCursorStore
+	syncBackoff        SyncBackoffConfig
+	updateListener     func(roomID string, snapshot WorkspaceAgentSnapshot)
+	startOnce          sync.Once
 }
 
 type Option func(*Store)
 
+// WithSyncStateStore injects a persistence backend for per-session activity
+// sync states. Loaded states seed TrackRoom, updates are written through on
+// every sync-state transition, and entries are deleted when a session is
+// hidden. Without this option sync states live in memory only.
 func WithSyncStateStore(store SyncStateStore) Option {
 	return func(svc *Store) {
 		if svc != nil {
 			svc.syncStateStore = store
+		}
+	}
+}
+
+// WithMessageCursorStore injects a persistence backend for per-session message
+// sync cursors. Loaded cursors seed TrackRoom so the syncer resumes message
+// pulls where it left off, cursor advances are written through, and entries
+// are deleted when a session is hidden. Without this option cursors live in
+// memory only.
+func WithMessageCursorStore(store MessageCursorStore) Option {
+	return func(svc *Store) {
+		if svc != nil {
+			svc.messageCursorStore = store
+		}
+	}
+}
+
+// WithSyncBackoff enables per-session exponential backoff for failed message
+// syncs in the background syncer. The zero config disables backoff, which is
+// the default and matches historical behavior (every sync tick retries
+// immediately). Use DefaultSyncBackoffConfig for field-proven values.
+func WithSyncBackoff(cfg SyncBackoffConfig) Option {
+	return func(svc *Store) {
+		if svc != nil {
+			svc.syncBackoff = cfg
 		}
 	}
 }
@@ -98,6 +129,7 @@ func (s *Store) TrackRoom(roomID string) {
 		return
 	}
 	loadedSyncStates := s.loadStoredSyncStates(roomID)
+	loadedCursors := s.loadStoredMessageCursors(roomID)
 
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -113,6 +145,13 @@ func (s *Store) TrackRoom(roomID string) {
 		}
 		for agentSessionID, syncState := range loadedSyncStates {
 			entry.syncStates[agentSessionID] = syncEntryFromState(syncState)
+		}
+		for agentSessionID, cursor := range loadedCursors {
+			agentSessionID = strings.TrimSpace(agentSessionID)
+			if agentSessionID == "" || cursor == 0 {
+				continue
+			}
+			entry.remoteMessageVersionBySession[agentSessionID] = cursor
 		}
 		s.rooms[roomID] = entry
 	}
@@ -440,6 +479,16 @@ func (s *Store) HideAgentSession(roomID string, agentSessionID string) {
 			)
 		}
 	}
+	if s.messageCursorStore != nil {
+		if err := s.messageCursorStore.DeleteMessageCursor(context.Background(), roomID, agentSessionID); err != nil {
+			slog.Warn("agent activity message cursor delete failed",
+				"event", "agent_activity.message_cursor.delete_failed",
+				"room_id", roomID,
+				"agent_session_id", agentSessionID,
+				"error", err,
+			)
+		}
+	}
 	changed := !workspaceAgentSnapshotBusinessEqual(before, snapshotFromEntryLocked(entry))
 	entry.mu.Unlock()
 	if changed {
@@ -451,6 +500,7 @@ func statePatchFromSessionState(agentSessionID string, state WorkspaceAgentSessi
 	patch := WorkspaceAgentStatePatch{
 		AgentSessionID:     strings.TrimSpace(agentSessionID),
 		AgentTargetID:      strings.TrimSpace(state.AgentTargetID),
+		DeviceID:           strings.TrimSpace(state.DeviceID),
 		Provider:           strings.TrimSpace(state.Provider),
 		ProviderSessionID:  strings.TrimSpace(state.ProviderSessionID),
 		Model:              strings.TrimSpace(state.Model),
@@ -535,17 +585,7 @@ func (s *Store) MarkActivitySyncPending(
 	messageUpdateCount int,
 ) (WorkspaceAgentSyncState, bool) {
 	return s.updateActivitySyncState(roomID, agentSessionID, func(current *agentSessionSyncState, now int64) WorkspaceAgentSyncState {
-		current.pendingReports++
-		current.state.AgentSessionID = strings.TrimSpace(agentSessionID)
-		current.state.Status = WorkspaceAgentSyncStatusPending
-		current.state.PendingTimelineItemCount += max(0, timelineItemCount)
-		current.state.PendingStatePatchCount += max(0, statePatchCount)
-		current.state.PendingMessageUpdateCount += max(0, messageUpdateCount)
-		current.state.AttemptCount++
-		current.state.FailedReportCount = current.failedReports
-		current.state.LastAttemptAtUnixMS = now
-		current.state.UpdatedAtUnixMS = now
-		return current.state
+		return applyActivitySyncPending(current, agentSessionID, timelineItemCount, statePatchCount, messageUpdateCount, now)
 	})
 }
 
@@ -557,27 +597,7 @@ func (s *Store) MarkActivitySyncSucceeded(
 	messageUpdateCount int,
 ) (WorkspaceAgentSyncState, bool) {
 	return s.updateActivitySyncState(roomID, agentSessionID, func(current *agentSessionSyncState, now int64) WorkspaceAgentSyncState {
-		if current.pendingReports > 0 {
-			current.pendingReports--
-		}
-		current.state.AgentSessionID = strings.TrimSpace(agentSessionID)
-		current.state.PendingTimelineItemCount = max(0, current.state.PendingTimelineItemCount-max(0, timelineItemCount))
-		current.state.PendingStatePatchCount = max(0, current.state.PendingStatePatchCount-max(0, statePatchCount))
-		current.state.PendingMessageUpdateCount = max(0, current.state.PendingMessageUpdateCount-max(0, messageUpdateCount))
-		current.failedReports = 0
-		current.state.FailedReportCount = 0
-		current.state.LastError = ""
-		if current.pendingReports == 0 {
-			current.state.Status = WorkspaceAgentSyncStatusSynced
-			current.state.PendingTimelineItemCount = 0
-			current.state.PendingStatePatchCount = 0
-			current.state.PendingMessageUpdateCount = 0
-			current.state.LastSyncedAtUnixMS = now
-		} else {
-			current.state.Status = WorkspaceAgentSyncStatusPending
-		}
-		current.state.UpdatedAtUnixMS = now
-		return current.state
+		return applyActivitySyncSucceeded(current, agentSessionID, timelineItemCount, statePatchCount, messageUpdateCount, now)
 	})
 }
 
@@ -590,18 +610,7 @@ func (s *Store) MarkActivitySyncFailed(
 	err error,
 ) (WorkspaceAgentSyncState, bool) {
 	return s.updateActivitySyncState(roomID, agentSessionID, func(current *agentSessionSyncState, now int64) WorkspaceAgentSyncState {
-		if current.pendingReports > 0 {
-			current.pendingReports--
-		}
-		current.failedReports++
-		current.state.AgentSessionID = strings.TrimSpace(agentSessionID)
-		current.state.Status = WorkspaceAgentSyncStatusFailed
-		current.state.FailedReportCount = current.failedReports
-		if err != nil {
-			current.state.LastError = strings.TrimSpace(err.Error())
-		}
-		current.state.UpdatedAtUnixMS = now
-		return current.state
+		return applyActivitySyncFailed(current, agentSessionID, err, now)
 	})
 }
 
@@ -828,6 +837,7 @@ func applyStatePatchLocked(entry *sessionEntry, source EventSource, patch Worksp
 		session := WorkspaceAgentSession{
 			AgentSessionID:     sessionID,
 			AgentTargetID:      firstNonEmptyString(patch.AgentTargetID, source.AgentTargetID),
+			DeviceID:           firstNonEmptyString(patch.DeviceID, source.DeviceID),
 			UserID:             strings.TrimSpace(source.UserID),
 			Provider:           firstNonEmptyString(patch.Provider, source.Provider),
 			ProviderSessionID:  firstNonEmptyString(patch.ProviderSessionID, source.ProviderSessionID),
@@ -875,6 +885,7 @@ func applyStatePatchLocked(entry *sessionEntry, source EventSource, patch Worksp
 	}
 	session.AgentSessionID = firstNonEmptyString(session.AgentSessionID, sessionID)
 	session.AgentTargetID = firstNonEmptyString(patch.AgentTargetID, session.AgentTargetID, source.AgentTargetID)
+	session.DeviceID = firstNonEmptyString(patch.DeviceID, session.DeviceID, source.DeviceID)
 	session.Provider = firstNonEmptyString(patch.Provider, session.Provider, source.Provider)
 	session.ProviderSessionID = firstNonEmptyString(patch.ProviderSessionID, session.ProviderSessionID, source.ProviderSessionID)
 	session.SessionOrigin = firstNonEmptyString(strings.TrimSpace(source.SessionOrigin), session.SessionOrigin)
@@ -1744,6 +1755,36 @@ func (s *Store) loadStoredSyncStates(roomID string) map[string]WorkspaceAgentSyn
 	return states
 }
 
+func (s *Store) loadStoredMessageCursors(roomID string) map[string]uint64 {
+	if s == nil || s.messageCursorStore == nil {
+		return nil
+	}
+	cursors, err := s.messageCursorStore.LoadRoomMessageCursors(context.Background(), roomID)
+	if err != nil {
+		slog.Warn("agent activity message cursor load failed",
+			"event", "agent_activity.message_cursor.load_failed",
+			"room_id", strings.TrimSpace(roomID),
+			"error", err,
+		)
+		return nil
+	}
+	return cursors
+}
+
+func (s *Store) saveMessageCursor(roomID, agentSessionID string, version uint64) {
+	if s == nil || s.messageCursorStore == nil {
+		return
+	}
+	if err := s.messageCursorStore.SaveMessageCursor(context.Background(), roomID, agentSessionID, version); err != nil {
+		slog.Warn("agent activity message cursor save failed",
+			"event", "agent_activity.message_cursor.save_failed",
+			"room_id", strings.TrimSpace(roomID),
+			"agent_session_id", strings.TrimSpace(agentSessionID),
+			"error", err,
+		)
+	}
+}
+
 func (s *Store) saveSyncState(roomID string, syncState WorkspaceAgentSyncState) {
 	if s == nil || s.syncStateStore == nil {
 		return
@@ -1756,6 +1797,78 @@ func (s *Store) saveSyncState(roomID string, syncState WorkspaceAgentSyncState) 
 			"error", err,
 		)
 	}
+}
+
+func applyActivitySyncPending(
+	current *agentSessionSyncState,
+	agentSessionID string,
+	timelineItemCount int,
+	statePatchCount int,
+	messageUpdateCount int,
+	now int64,
+) WorkspaceAgentSyncState {
+	current.pendingReports++
+	current.state.AgentSessionID = strings.TrimSpace(agentSessionID)
+	current.state.Status = WorkspaceAgentSyncStatusPending
+	current.state.PendingTimelineItemCount += max(0, timelineItemCount)
+	current.state.PendingStatePatchCount += max(0, statePatchCount)
+	current.state.PendingMessageUpdateCount += max(0, messageUpdateCount)
+	current.state.AttemptCount++
+	current.state.FailedReportCount = current.failedReports
+	current.state.LastAttemptAtUnixMS = now
+	current.state.UpdatedAtUnixMS = now
+	return current.state
+}
+
+func applyActivitySyncSucceeded(
+	current *agentSessionSyncState,
+	agentSessionID string,
+	timelineItemCount int,
+	statePatchCount int,
+	messageUpdateCount int,
+	now int64,
+) WorkspaceAgentSyncState {
+	if current.pendingReports > 0 {
+		current.pendingReports--
+	}
+	current.state.AgentSessionID = strings.TrimSpace(agentSessionID)
+	current.state.PendingTimelineItemCount = max(0, current.state.PendingTimelineItemCount-max(0, timelineItemCount))
+	current.state.PendingStatePatchCount = max(0, current.state.PendingStatePatchCount-max(0, statePatchCount))
+	current.state.PendingMessageUpdateCount = max(0, current.state.PendingMessageUpdateCount-max(0, messageUpdateCount))
+	current.failedReports = 0
+	current.state.FailedReportCount = 0
+	current.state.LastError = ""
+	if current.pendingReports == 0 {
+		current.state.Status = WorkspaceAgentSyncStatusSynced
+		current.state.PendingTimelineItemCount = 0
+		current.state.PendingStatePatchCount = 0
+		current.state.PendingMessageUpdateCount = 0
+		current.state.LastSyncedAtUnixMS = now
+	} else {
+		current.state.Status = WorkspaceAgentSyncStatusPending
+	}
+	current.state.UpdatedAtUnixMS = now
+	return current.state
+}
+
+func applyActivitySyncFailed(
+	current *agentSessionSyncState,
+	agentSessionID string,
+	err error,
+	now int64,
+) WorkspaceAgentSyncState {
+	if current.pendingReports > 0 {
+		current.pendingReports--
+	}
+	current.failedReports++
+	current.state.AgentSessionID = strings.TrimSpace(agentSessionID)
+	current.state.Status = WorkspaceAgentSyncStatusFailed
+	current.state.FailedReportCount = current.failedReports
+	if err != nil {
+		current.state.LastError = strings.TrimSpace(err.Error())
+	}
+	current.state.UpdatedAtUnixMS = now
+	return current.state
 }
 
 func syncEntryFromState(syncState WorkspaceAgentSyncState) *agentSessionSyncState {
@@ -1961,8 +2074,13 @@ func (s *Store) appendSessionMessages(
 	}
 
 	entry.mu.Lock()
+	cursorBefore := entry.remoteMessageVersionBySession[agentSessionID]
 	changed := appendSessionMessagesLocked(entry, agentSessionID, messages, latestVersion)
+	cursorAfter := entry.remoteMessageVersionBySession[agentSessionID]
 	entry.mu.Unlock()
+	if cursorAfter > cursorBefore {
+		s.saveMessageCursor(roomID, agentSessionID, cursorAfter)
+	}
 	if changed {
 		s.notifyRoomUpdate(roomID)
 	}

--- a/packages/agent/daemon/activity/sync_state_persistence_test.go
+++ b/packages/agent/daemon/activity/sync_state_persistence_test.go
@@ -1,0 +1,103 @@
+package agentsessionstore
+
+import (
+	"context"
+	"reflect"
+	"sync"
+	"testing"
+	"time"
+)
+
+// Regression test for a pre-existing race: sync-state saves used to run after
+// entry.mu was released, so HideAgentSession could delete the persisted state
+// and then a stale save would resurrect it. Saves now hold entry.mu, which
+// serializes them with the hide path's delete.
+func TestSyncStatePersistenceSerializesWithHide(t *testing.T) {
+	store := newBlockingSyncStateStore()
+	client := newFakeSyncerRepository()
+	client.snapshots["room-1"] = &WorkspaceAgentSnapshot{}
+	svc := New(client, WithSyncStateStore(store))
+	svc.TrackRoom("room-1")
+
+	markDone := make(chan struct{})
+	go func() {
+		defer close(markDone)
+		svc.MarkActivitySyncPending("room-1", "session-1", 0, 1, 0)
+	}()
+	<-store.saveEntered
+
+	hideDone := make(chan struct{})
+	go func() {
+		defer close(hideDone)
+		svc.HideAgentSession("room-1", "session-1")
+	}()
+
+	select {
+	case <-hideDone:
+		t.Fatal("HideAgentSession completed while a sync-state save was still in flight")
+	case <-time.After(50 * time.Millisecond):
+	}
+
+	close(store.saveGate)
+	<-markDone
+	<-hideDone
+
+	if got := store.operations(); !reflect.DeepEqual(got, []string{"save", "delete"}) {
+		t.Fatalf("store operations = %#v, want [save delete]", got)
+	}
+	if _, resurrected := store.session("session-1"); resurrected {
+		t.Fatal("hidden session sync state was resurrected by a stale save")
+	}
+}
+
+type blockingSyncStateStore struct {
+	mu          sync.Mutex
+	ops         []string
+	sessions    map[string]WorkspaceAgentSyncState
+	saveGate    chan struct{}
+	saveEntered chan struct{}
+	enteredOnce sync.Once
+}
+
+func newBlockingSyncStateStore() *blockingSyncStateStore {
+	return &blockingSyncStateStore{
+		sessions:    make(map[string]WorkspaceAgentSyncState),
+		saveGate:    make(chan struct{}),
+		saveEntered: make(chan struct{}),
+	}
+}
+
+func (s *blockingSyncStateStore) LoadRoomSyncStates(_ context.Context, _ string) (map[string]WorkspaceAgentSyncState, error) {
+	return nil, nil
+}
+
+func (s *blockingSyncStateStore) SaveAgentSyncState(_ context.Context, _ string, state WorkspaceAgentSyncState) error {
+	s.enteredOnce.Do(func() { close(s.saveEntered) })
+	<-s.saveGate
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.ops = append(s.ops, "save")
+	s.sessions[state.AgentSessionID] = state
+	return nil
+}
+
+func (s *blockingSyncStateStore) DeleteAgentSyncState(_ context.Context, _ string, agentSessionID string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.ops = append(s.ops, "delete")
+	delete(s.sessions, agentSessionID)
+	return nil
+}
+
+func (s *blockingSyncStateStore) operations() []string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return append([]string(nil), s.ops...)
+}
+
+func (s *blockingSyncStateStore) session(agentSessionID string) (WorkspaceAgentSyncState, bool) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	state, ok := s.sessions[agentSessionID]
+	return state, ok
+}

--- a/packages/agent/daemon/activity/sync_state_store.go
+++ b/packages/agent/daemon/activity/sync_state_store.go
@@ -13,10 +13,12 @@ import (
 
 // FileAgentSyncStateStore is a file-backed SyncStateStore and
 // MessageCursorStore. Each room is stored as one JSON document under the root
-// directory (file name derived from the room id), tracking per-session sync
-// status, pending report counts, failure counters, last error, and message
-// sync cursors. Writes are atomic (temp file + rename) and guarded by a
-// process-wide mutex, so a single store instance is safe for concurrent use.
+// directory (file name derived from the roomID scope identifier: tutti side =
+// workspace ID, external daemons (tsh) = control-plane room ID; workspace ≡
+// room, one-to-one), tracking per-session sync status, pending report counts,
+// failure counters, last error, and message sync cursors. Writes are atomic
+// (temp file + rename) and guarded by a process-wide mutex, so a single store
+// instance is safe for concurrent use.
 type FileAgentSyncStateStore struct {
 	root string
 	mu   sync.Mutex

--- a/packages/agent/daemon/activity/sync_state_store.go
+++ b/packages/agent/daemon/activity/sync_state_store.go
@@ -11,11 +11,24 @@ import (
 	"sync"
 )
 
+// FileAgentSyncStateStore is a file-backed SyncStateStore and
+// MessageCursorStore. Each room is stored as one JSON document under the root
+// directory (file name derived from the room id), tracking per-session sync
+// status, pending report counts, failure counters, last error, and message
+// sync cursors. Writes are atomic (temp file + rename) and guarded by a
+// process-wide mutex, so a single store instance is safe for concurrent use.
 type FileAgentSyncStateStore struct {
 	root string
 	mu   sync.Mutex
 }
 
+var (
+	_ SyncStateStore     = (*FileAgentSyncStateStore)(nil)
+	_ MessageCursorStore = (*FileAgentSyncStateStore)(nil)
+)
+
+// NewFileAgentSyncStateStore returns a FileAgentSyncStateStore rooted at the
+// given directory. The directory is created lazily on first write.
 func NewFileAgentSyncStateStore(root string) *FileAgentSyncStateStore {
 	return &FileAgentSyncStateStore{root: strings.TrimSpace(root)}
 }
@@ -76,8 +89,61 @@ func (s *FileAgentSyncStateStore) DeleteAgentSyncState(_ context.Context, roomID
 	})
 }
 
+func (s *FileAgentSyncStateStore) LoadRoomMessageCursors(_ context.Context, roomID string) (map[string]uint64, error) {
+	path, err := s.roomPath(roomID)
+	if err != nil {
+		return nil, err
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	var doc fileAgentSyncStateDocument
+	if err := json.Unmarshal(raw, &doc); err != nil {
+		return nil, err
+	}
+	out := make(map[string]uint64, len(doc.Cursors))
+	for agentSessionID, cursor := range doc.Cursors {
+		agentSessionID = strings.TrimSpace(agentSessionID)
+		if agentSessionID == "" || cursor == 0 {
+			continue
+		}
+		out[agentSessionID] = cursor
+	}
+	return out, nil
+}
+
+func (s *FileAgentSyncStateStore) SaveMessageCursor(_ context.Context, roomID string, agentSessionID string, version uint64) error {
+	agentSessionID = strings.TrimSpace(agentSessionID)
+	if agentSessionID == "" {
+		return nil
+	}
+	return s.updateRoom(roomID, func(doc *fileAgentSyncStateDocument) {
+		if doc.Cursors == nil {
+			doc.Cursors = make(map[string]uint64)
+		}
+		doc.Cursors[agentSessionID] = version
+	})
+}
+
+func (s *FileAgentSyncStateStore) DeleteMessageCursor(_ context.Context, roomID string, agentSessionID string) error {
+	agentSessionID = strings.TrimSpace(agentSessionID)
+	if agentSessionID == "" {
+		return nil
+	}
+	return s.updateRoom(roomID, func(doc *fileAgentSyncStateDocument) {
+		delete(doc.Cursors, agentSessionID)
+	})
+}
+
 type fileAgentSyncStateDocument struct {
 	Sessions map[string]WorkspaceAgentSyncState `json:"sessions"`
+	Cursors  map[string]uint64                  `json:"cursors,omitempty"`
 }
 
 func (s *FileAgentSyncStateStore) updateRoom(roomID string, update func(*fileAgentSyncStateDocument)) error {

--- a/packages/agent/daemon/activity/syncer.go
+++ b/packages/agent/daemon/activity/syncer.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"errors"
 	"log/slog"
+	"net"
 	"strings"
 	"sync"
 	"time"
@@ -381,7 +382,17 @@ func isRetryableMessageSyncError(err error) bool {
 	if errors.As(err, &httpErr) {
 		return httpErr.StatusCode == 429 || httpErr.StatusCode >= 500
 	}
-	return false
+	// Transport-level failures (connection refused, DNS errors, timeouts) are
+	// the most common outage mode and exactly what backoff is meant to
+	// absorb. Deliberate cancellation is not retryable.
+	if errors.Is(err, context.Canceled) {
+		return false
+	}
+	if errors.Is(err, context.DeadlineExceeded) {
+		return true
+	}
+	var netErr net.Error
+	return errors.As(err, &netErr)
 }
 
 func messageSyncKey(roomID, agentSessionID string) string {

--- a/packages/agent/daemon/activity/syncer.go
+++ b/packages/agent/daemon/activity/syncer.go
@@ -3,6 +3,7 @@ package agentsessionstore
 
 import (
 	"context"
+	"errors"
 	"log/slog"
 	"strings"
 	"sync"
@@ -15,18 +16,83 @@ const (
 	messageMaxPages = 10
 )
 
+// SyncBackoffConfig configures per-session exponential backoff for failed
+// message syncs in the background syncer. After a retryable failure (HTTP 429
+// or 5xx) the session's message sync is skipped until the backoff window
+// elapses; each consecutive failure multiplies the delay by Multiplier up to
+// MaxDelay, and any success resets it. The zero value disables backoff
+// entirely, preserving historical retry-every-tick behavior.
+type SyncBackoffConfig struct {
+	// InitialDelay is the wait after the first retryable failure. A
+	// non-positive value disables backoff.
+	InitialDelay time.Duration
+	// MaxDelay caps the backoff delay. Defaults to InitialDelay when unset.
+	MaxDelay time.Duration
+	// Multiplier scales the delay after each consecutive failure. Values
+	// below 1 are treated as 1 (constant delay).
+	Multiplier float64
+}
+
+// DefaultSyncBackoffConfig returns the recommended backoff configuration:
+// 10s initial delay, 5min cap, doubling per consecutive failure.
+func DefaultSyncBackoffConfig() SyncBackoffConfig {
+	return SyncBackoffConfig{
+		InitialDelay: 10 * time.Second,
+		MaxDelay:     5 * time.Minute,
+		Multiplier:   2.0,
+	}
+}
+
+func (c SyncBackoffConfig) enabled() bool {
+	return c.InitialDelay > 0
+}
+
+func (c SyncBackoffConfig) nextDelay(current time.Duration) time.Duration {
+	if current <= 0 {
+		return c.InitialDelay
+	}
+	multiplier := c.Multiplier
+	if multiplier < 1 {
+		multiplier = 1
+	}
+	next := time.Duration(float64(current) * multiplier)
+	maxDelay := c.MaxDelay
+	if maxDelay <= 0 {
+		maxDelay = c.InitialDelay
+	}
+	if next > maxDelay {
+		next = maxDelay
+	}
+	return next
+}
+
 type sessionSyncer struct {
 	svc      *Store
 	client   ReadRepository
 	triggers chan string
+
+	backoff             SyncBackoffConfig
+	mu                  sync.Mutex
+	messageBackoffUntil map[string]time.Time
+	messageBackoffDelay map[string]time.Duration
+	now                 func() time.Time
 }
 
 func newSessionSyncer(svc *Store, client ReadRepository) *sessionSyncer {
-	return &sessionSyncer{
+	syncer := &sessionSyncer{
 		svc:      svc,
 		client:   client,
 		triggers: make(chan string, 64),
+		now:      time.Now,
 	}
+	if svc != nil {
+		syncer.backoff = svc.syncBackoff
+	}
+	if syncer.backoff.enabled() {
+		syncer.messageBackoffUntil = make(map[string]time.Time)
+		syncer.messageBackoffDelay = make(map[string]time.Duration)
+	}
+	return syncer
 }
 
 func (s *sessionSyncer) run(ctx context.Context) {
@@ -217,6 +283,10 @@ func (s *sessionSyncer) syncSessionMessagePages(ctx context.Context, roomID, age
 	if agentSessionID == "" {
 		return
 	}
+	backoffKey := messageSyncKey(roomID, agentSessionID)
+	if s.messageSyncBackoffActive(backoffKey) {
+		return
+	}
 
 	afterVersion := s.svc.getMessageVersionCursor(roomID, agentSessionID)
 	for page := 0; page < messageMaxPages; page++ {
@@ -229,9 +299,11 @@ func (s *sessionSyncer) syncSessionMessagePages(ctx context.Context, roomID, age
 		})
 		if err != nil {
 			slog.Warn("agent activity message sync failed", "room_id", roomID, "agent_session_id", agentSessionID, "error", err)
+			s.recordMessageSyncError(backoffKey, err)
 			return
 		}
 		if reply == nil {
+			s.clearMessageSyncBackoff(backoffKey)
 			return
 		}
 		s.svc.appendSessionMessages(roomID, agentSessionID, reply.Messages, reply.LatestVersion)
@@ -240,8 +312,78 @@ func (s *sessionSyncer) syncSessionMessagePages(ctx context.Context, roomID, age
 			nextVersion = maxSessionMessageVersion(afterVersion, reply.Messages)
 		}
 		if !reply.HasMore || nextVersion <= afterVersion {
+			s.clearMessageSyncBackoff(backoffKey)
 			return
 		}
 		afterVersion = nextVersion
 	}
+	s.clearMessageSyncBackoff(backoffKey)
+}
+
+func (s *sessionSyncer) messageSyncBackoffActive(key string) bool {
+	if s == nil || !s.backoff.enabled() {
+		return false
+	}
+	now := s.syncerNow()
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	until, ok := s.messageBackoffUntil[key]
+	if !ok {
+		return false
+	}
+	if now.Before(until) {
+		return true
+	}
+	delete(s.messageBackoffUntil, key)
+	return false
+}
+
+func (s *sessionSyncer) recordMessageSyncError(key string, err error) {
+	if s == nil || !s.backoff.enabled() || !isRetryableMessageSyncError(err) {
+		return
+	}
+	now := s.syncerNow()
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.messageBackoffUntil == nil {
+		s.messageBackoffUntil = make(map[string]time.Time)
+	}
+	if s.messageBackoffDelay == nil {
+		s.messageBackoffDelay = make(map[string]time.Duration)
+	}
+	delay := s.messageBackoffDelay[key]
+	if delay <= 0 {
+		delay = s.backoff.InitialDelay
+	}
+	s.messageBackoffUntil[key] = now.Add(delay)
+	s.messageBackoffDelay[key] = s.backoff.nextDelay(delay)
+}
+
+func (s *sessionSyncer) clearMessageSyncBackoff(key string) {
+	if s == nil || !s.backoff.enabled() {
+		return
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	delete(s.messageBackoffUntil, key)
+	delete(s.messageBackoffDelay, key)
+}
+
+func (s *sessionSyncer) syncerNow() time.Time {
+	if s != nil && s.now != nil {
+		return s.now()
+	}
+	return time.Now()
+}
+
+func isRetryableMessageSyncError(err error) bool {
+	var httpErr HTTPError
+	if errors.As(err, &httpErr) {
+		return httpErr.StatusCode == 429 || httpErr.StatusCode >= 500
+	}
+	return false
+}
+
+func messageSyncKey(roomID, agentSessionID string) string {
+	return strings.TrimSpace(roomID) + "\x00" + strings.TrimSpace(agentSessionID)
 }

--- a/packages/agent/daemon/activity/syncer_backoff_test.go
+++ b/packages/agent/daemon/activity/syncer_backoff_test.go
@@ -2,6 +2,8 @@ package agentsessionstore
 
 import (
 	"context"
+	"errors"
+	"net"
 	"sync"
 	"testing"
 	"time"
@@ -79,6 +81,28 @@ func TestSyncBackoffIgnoresNonRetryableErrors(t *testing.T) {
 	syncer.syncRoom(context.Background(), "room-1")
 	if got := client.messageCallCount(); got != 2 {
 		t.Fatalf("message calls with non-retryable error = %d, want 2", got)
+	}
+}
+
+func TestSyncBackoffAppliesToTransportErrors(t *testing.T) {
+	_, syncer, client, _ := newBackoffTestFixture(t, WithSyncBackoff(DefaultSyncBackoffConfig()))
+	client.setMessageError(&net.OpError{Op: "dial", Err: errors.New("connection refused")})
+
+	syncer.syncRoom(context.Background(), "room-1")
+	syncer.syncRoom(context.Background(), "room-1")
+	if got := client.messageCallCount(); got != 1 {
+		t.Fatalf("message calls with transport error = %d, want 1 (backed off)", got)
+	}
+}
+
+func TestSyncBackoffIgnoresContextCancellation(t *testing.T) {
+	_, syncer, client, _ := newBackoffTestFixture(t, WithSyncBackoff(DefaultSyncBackoffConfig()))
+	client.setMessageError(context.Canceled)
+
+	syncer.syncRoom(context.Background(), "room-1")
+	syncer.syncRoom(context.Background(), "room-1")
+	if got := client.messageCallCount(); got != 2 {
+		t.Fatalf("message calls with canceled context = %d, want 2 (no backoff)", got)
 	}
 }
 

--- a/packages/agent/daemon/activity/syncer_backoff_test.go
+++ b/packages/agent/daemon/activity/syncer_backoff_test.go
@@ -1,0 +1,157 @@
+package agentsessionstore
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+)
+
+func newBackoffTestFixture(t *testing.T, opts ...Option) (*Store, *sessionSyncer, *backoffTestRepository, *time.Time) {
+	t.Helper()
+	client := &backoffTestRepository{
+		snapshot: &WorkspaceAgentSnapshot{
+			Sessions: []WorkspaceAgentSession{{
+				AgentSessionID:  "session-1",
+				SessionOrigin:   WorkspaceAgentSessionOriginRuntime,
+				LifecycleStatus: "active",
+				EffectiveStatus: "working",
+			}},
+		},
+	}
+	svc := New(client, opts...)
+	svc.TrackRoom("room-1")
+	syncer := newSessionSyncer(svc, client)
+	current := time.UnixMilli(1_710_000_000_000)
+	syncer.now = func() time.Time { return current }
+	return svc, syncer, client, &current
+}
+
+func TestSyncBackoffSkipsMessageSyncUntilWindowElapses(t *testing.T) {
+	_, syncer, client, current := newBackoffTestFixture(t, WithSyncBackoff(DefaultSyncBackoffConfig()))
+	client.setMessageError(HTTPError{StatusCode: 500})
+
+	syncer.syncRoom(context.Background(), "room-1")
+	if got := client.messageCallCount(); got != 1 {
+		t.Fatalf("message calls after first failure = %d, want 1", got)
+	}
+
+	syncer.syncRoom(context.Background(), "room-1")
+	if got := client.messageCallCount(); got != 1 {
+		t.Fatalf("message calls within backoff window = %d, want still 1", got)
+	}
+
+	*current = current.Add(10 * time.Second)
+	syncer.syncRoom(context.Background(), "room-1")
+	if got := client.messageCallCount(); got != 2 {
+		t.Fatalf("message calls after initial delay elapsed = %d, want 2", got)
+	}
+
+	// The second consecutive failure doubles the delay to 20s.
+	*current = current.Add(19 * time.Second)
+	syncer.syncRoom(context.Background(), "room-1")
+	if got := client.messageCallCount(); got != 2 {
+		t.Fatalf("message calls before doubled delay elapsed = %d, want still 2", got)
+	}
+	*current = current.Add(time.Second)
+	syncer.syncRoom(context.Background(), "room-1")
+	if got := client.messageCallCount(); got != 3 {
+		t.Fatalf("message calls after doubled delay elapsed = %d, want 3", got)
+	}
+}
+
+func TestSyncBackoffDisabledByDefaultRetriesEveryTick(t *testing.T) {
+	_, syncer, client, _ := newBackoffTestFixture(t)
+	client.setMessageError(HTTPError{StatusCode: 500})
+
+	syncer.syncRoom(context.Background(), "room-1")
+	syncer.syncRoom(context.Background(), "room-1")
+	if got := client.messageCallCount(); got != 2 {
+		t.Fatalf("message calls without backoff = %d, want 2", got)
+	}
+}
+
+func TestSyncBackoffIgnoresNonRetryableErrors(t *testing.T) {
+	_, syncer, client, _ := newBackoffTestFixture(t, WithSyncBackoff(DefaultSyncBackoffConfig()))
+	client.setMessageError(HTTPError{StatusCode: 404})
+
+	syncer.syncRoom(context.Background(), "room-1")
+	syncer.syncRoom(context.Background(), "room-1")
+	if got := client.messageCallCount(); got != 2 {
+		t.Fatalf("message calls with non-retryable error = %d, want 2", got)
+	}
+}
+
+func TestSyncBackoffResetsAfterSuccess(t *testing.T) {
+	_, syncer, client, current := newBackoffTestFixture(t, WithSyncBackoff(DefaultSyncBackoffConfig()))
+	client.setMessageError(HTTPError{StatusCode: 500})
+
+	syncer.syncRoom(context.Background(), "room-1")
+	*current = current.Add(10 * time.Second)
+	client.setMessageError(nil)
+	syncer.syncRoom(context.Background(), "room-1")
+	if got := client.messageCallCount(); got != 2 {
+		t.Fatalf("message calls after recovery = %d, want 2", got)
+	}
+
+	// A fresh failure after success starts over at the initial delay instead
+	// of continuing the previous doubling.
+	client.setMessageError(HTTPError{StatusCode: 500})
+	syncer.syncRoom(context.Background(), "room-1")
+	if got := client.messageCallCount(); got != 3 {
+		t.Fatalf("message calls on fresh failure = %d, want 3", got)
+	}
+	*current = current.Add(10 * time.Second)
+	syncer.syncRoom(context.Background(), "room-1")
+	if got := client.messageCallCount(); got != 4 {
+		t.Fatalf("message calls after reset initial delay = %d, want 4", got)
+	}
+}
+
+func TestSyncBackoffCapsDelayAtMax(t *testing.T) {
+	cfg := SyncBackoffConfig{InitialDelay: 10 * time.Second, MaxDelay: 15 * time.Second, Multiplier: 2.0}
+	if got := cfg.nextDelay(10 * time.Second); got != 15*time.Second {
+		t.Fatalf("nextDelay(10s) = %s, want capped 15s", got)
+	}
+	if got := cfg.nextDelay(0); got != 10*time.Second {
+		t.Fatalf("nextDelay(0) = %s, want initial 10s", got)
+	}
+}
+
+type backoffTestRepository struct {
+	mu           sync.Mutex
+	snapshot     *WorkspaceAgentSnapshot
+	messageErr   error
+	messageCalls int
+}
+
+func (r *backoffTestRepository) ListAgents(_ context.Context, _ string) (*WorkspaceAgentSnapshot, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.snapshot, nil
+}
+
+func (r *backoffTestRepository) ListSessionMessages(
+	_ context.Context,
+	_ ListSessionMessagesInput,
+) (*ListSessionMessagesReply, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.messageCalls++
+	if r.messageErr != nil {
+		return nil, r.messageErr
+	}
+	return &ListSessionMessagesReply{}, nil
+}
+
+func (r *backoffTestRepository) setMessageError(err error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.messageErr = err
+}
+
+func (r *backoffTestRepository) messageCallCount() int {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.messageCalls
+}

--- a/packages/agent/daemon/activity/types.go
+++ b/packages/agent/daemon/activity/types.go
@@ -53,10 +53,15 @@ type ReportActivityReply struct {
 type ReportSessionStateInput struct {
 	WorkspaceID    string
 	AgentSessionID string
-	SessionOrigin  string
-	Connector      *ConnectorInfo
-	Source         EventSource
-	State          WorkspaceAgentSessionStateUpdate
+	// AgentTargetID and DeviceID are optional metadata; when set they are
+	// propagated into the request source/state so remote controlplanes can
+	// attribute the session. Empty values leave the request unchanged.
+	AgentTargetID string
+	DeviceID      string
+	SessionOrigin string
+	Connector     *ConnectorInfo
+	Source        EventSource
+	State         WorkspaceAgentSessionStateUpdate
 }
 
 type ReportSessionStateReply struct {
@@ -95,6 +100,7 @@ func (r *ReportSessionStateReply) UnmarshalJSON(data []byte) error {
 
 type WorkspaceAgentSessionStateUpdate struct {
 	AgentTargetID      string                            `json:"agentTargetId,omitempty"`
+	DeviceID           string                            `json:"deviceId,omitempty"`
 	Provider           string                            `json:"provider,omitempty"`
 	ProviderSessionID  string                            `json:"providerSessionId,omitempty"`
 	Model              string                            `json:"model,omitempty"`
@@ -159,10 +165,15 @@ type WorkspaceAgentInteractivePrompt struct {
 type ReportSessionMessagesInput struct {
 	WorkspaceID    string
 	AgentSessionID string
-	SessionOrigin  string
-	Connector      *ConnectorInfo
-	Source         EventSource
-	Updates        []WorkspaceAgentSessionMessageUpdate
+	// AgentTargetID and DeviceID are optional metadata; when set they are
+	// propagated into the request source so remote controlplanes can
+	// attribute the session. Empty values leave the request unchanged.
+	AgentTargetID string
+	DeviceID      string
+	SessionOrigin string
+	Connector     *ConnectorInfo
+	Source        EventSource
+	Updates       []WorkspaceAgentSessionMessageUpdate
 }
 
 type ReportSessionMessagesReply struct {
@@ -209,9 +220,12 @@ type WorkspaceAgentSessionMessageUpdate struct {
 type ListSessionMessagesInput struct {
 	WorkspaceID    string
 	AgentSessionID string
-	AfterVersion   uint64
-	Limit          int
-	SessionOrigin  string
+	// DeviceID optionally scopes the query to sessions reported by a device.
+	// Empty means no device filter (historical behavior).
+	DeviceID      string
+	AfterVersion  uint64
+	Limit         int
+	SessionOrigin string
 }
 
 type ListSessionMessagesReply struct {
@@ -334,14 +348,18 @@ type EventSource struct {
 	ProviderSessionID string `json:"providerSessionId,omitempty"`
 	AgentID           string `json:"agentId,omitempty"`
 	AgentTargetID     string `json:"agentTargetId,omitempty"`
-	CWD               string `json:"cwd,omitempty"`
-	SessionOrigin     string `json:"sessionOrigin,omitempty"`
-	UserID            string `json:"-"`
+	// DeviceID optionally identifies the reporting device so multi-device
+	// controlplanes can attribute and scope sessions. Empty means unset.
+	DeviceID      string `json:"deviceId,omitempty"`
+	CWD           string `json:"cwd,omitempty"`
+	SessionOrigin string `json:"sessionOrigin,omitempty"`
+	UserID        string `json:"-"`
 }
 
 type WorkspaceAgentStatePatch struct {
 	AgentSessionID            string                            `json:"agentSessionId"`
 	AgentTargetID             string                            `json:"agentTargetId,omitempty"`
+	DeviceID                  string                            `json:"deviceId,omitempty"`
 	Provider                  string                            `json:"provider,omitempty"`
 	ProviderSessionID         string                            `json:"providerSessionId,omitempty"`
 	Model                     string                            `json:"model,omitempty"`
@@ -479,6 +497,9 @@ type ListAgentsInput struct {
 	WorkspaceID   string
 	SessionOrigin string
 	UserID        string
+	// DeviceID optionally scopes the query to sessions reported by a device.
+	// Empty means no device filter (historical behavior).
+	DeviceID string
 }
 
 type WorkspaceAgentSnapshot struct {
@@ -504,6 +525,7 @@ type WorkspaceAgentSession struct {
 	ID                 uint64                            `json:"id"`
 	AgentSessionID     string                            `json:"agentSessionId"`
 	AgentTargetID      string                            `json:"agentTargetId,omitempty"`
+	DeviceID           string                            `json:"deviceId,omitempty"`
 	PresenceID         uint64                            `json:"presenceId"`
 	UserID             string                            `json:"userId"`
 	Provider           string                            `json:"provider"`
@@ -529,6 +551,7 @@ func (s WorkspaceAgentSession) MarshalJSON() ([]byte, error) {
 		ID                 uint64                            `json:"id"`
 		AgentSessionID     string                            `json:"agentSessionId"`
 		AgentTargetID      string                            `json:"agentTargetId,omitempty"`
+		DeviceID           string                            `json:"deviceId,omitempty"`
 		PresenceID         uint64                            `json:"presenceId"`
 		UserID             string                            `json:"userId"`
 		Provider           string                            `json:"provider"`
@@ -552,6 +575,7 @@ func (s WorkspaceAgentSession) MarshalJSON() ([]byte, error) {
 		ID:                 s.ID,
 		AgentSessionID:     s.AgentSessionID,
 		AgentTargetID:      s.AgentTargetID,
+		DeviceID:           s.DeviceID,
 		PresenceID:         s.PresenceID,
 		UserID:             s.UserID,
 		Provider:           s.Provider,
@@ -644,6 +668,8 @@ func (s *WorkspaceAgentSession) UnmarshalJSON(data []byte) error {
 		AgentSessionIDSnake    string                   `json:"agent_session_id"`
 		AgentTargetID          string                   `json:"agentTargetId"`
 		AgentTargetIDSnake     string                   `json:"agent_target_id"`
+		DeviceID               string                   `json:"deviceId"`
+		DeviceIDSnake          string                   `json:"device_id"`
 		AgentID                string                   `json:"agentId"`
 		AgentIDSnake           string                   `json:"agent_id"`
 		PresenceID             flexibleUint64           `json:"presenceId"`
@@ -686,6 +712,7 @@ func (s *WorkspaceAgentSession) UnmarshalJSON(data []byte) error {
 			raw.AgentIDSnake,
 		),
 		AgentTargetID: firstNonEmptyString(raw.AgentTargetID, raw.AgentTargetIDSnake),
+		DeviceID:      firstNonEmptyString(raw.DeviceID, raw.DeviceIDSnake),
 		PresenceID:    uint64(firstNonZeroFlexibleUint64(raw.PresenceID, raw.PresenceIDSnake)),
 		UserID:        firstNonEmptyString(raw.UserID, raw.UserIDSnake),
 		Provider:      raw.Provider,


### PR DESCRIPTION
## Summary

Issue T3 of the tsh↔tutti shared agent modules RFC: opens three additive extension points in `packages/agent/daemon/activity` so external daemons (tsh desktopd) can project local agent activity to a cloud controlplane **without forking any `activity/` file**.

### 1. `SyncStateStore` promoted to public API
- Documented the existing exported interface (`LoadRoomSyncStates` / `SaveAgentSyncState` / `DeleteAgentSyncState`) and `WithSyncStateStore` as an injection point for external persistence.
- `FileAgentSyncStateStore` documented as the ready-made file-backed implementation (per-session status / pending counts / lastError, atomic writes).

### 2. New `SessionActivityReporterAdapter`
- Converts a generic `ReportActivityInput` into per-session state patches + message groups and bridges them to the existing `SessionActivityReporter` interface (`ReportSessionState` / `ReportSessionMessages`).
- Tracks per-session sync state (pending → synced/failed, pending counts, lastError) with the same transition semantics as the in-process `Store` (logic extracted into shared `applyActivitySync*` helpers — no behavior change), persisted through an injected `SyncStateStore` and seeded from it on restart.

### 3. Syncer backoff + cursor persistence injection
- `WithSyncBackoff(SyncBackoffConfig)` — per-session exponential backoff for failed message syncs (retryable = HTTP 429/5xx). `DefaultSyncBackoffConfig()` carries the tsh field-proven values: **10s initial, 5min cap, 2.0 multiplier**. Zero config = disabled = historical retry-every-tick behavior.
- `WithMessageCursorStore(MessageCursorStore)` — persists the per-session message sync cursor so pulls resume from the persisted version after a daemon restart. `FileAgentSyncStateStore` implements this interface too (additive `cursors` section in the same room document).

### Ported upstream from the tsh fork
- Syncer exponential backoff + message cursor semantics (adapted to the tutti syncer structure).
- Additive `AgentTargetID` / `DeviceID` wire metadata: optional fields on `ReportSessionStateInput` / `ReportSessionMessagesInput` / `ListAgentsInput` / `ListSessionMessagesInput`, `deviceId` on `EventSource` / `WorkspaceAgentStatePatch` / `WorkspaceAgentSessionStateUpdate` / `WorkspaceAgentSession`, request-body fields (`agentTargetId` / `deviceId`, omitempty), `device_id` query filters, and lenient camel/snake JSON parsing.

## Scope ID semantics（跨仓契约，RFC 决策 1 硬性约束）

The scope identifier in these shared contracts is **opaque** and its semantics are explicitly aligned across the two repos (RFC decision 1 "作用域标识对齐", 2026-07-05):

- **tutti 侧 = workspace ID；tsh 等外部 daemon 侧 = control-plane room ID。workspace ≡ room，一一对应，不做隐式换算。** tsh has no local workspace table — the room is the carrier of that structure.
- Existing per-layer parameter names are kept (no breaking renames): `agentsessionstore` interfaces say `roomID`, report inputs say `WorkspaceID`, and the wire field is `roomId`. Every new/exported interface in this PR (`SyncStateStore`, `MessageCursorStore`, `WithSyncStateStore` / `WithMessageCursorStore`, `FileAgentSyncStateStore`, `SessionActivityReporterAdapter`) carries a doc comment stating this alignment.
- `SessionActivityReporterAdapter` passes `ReportActivityInput.WorkspaceID` **verbatim** as the `SyncStateStore` roomID — there is intentionally no conversion/mapping logic at that boundary, and none may be added. External daemons must pass the control-plane room ID directly (no second mapping in between, per RFC).

Reviewers: please treat this alignment as part of the cross-repo contract, not just local naming style.

## Compatibility guarantees

- **All wire changes are additive**: new optional fields only; no existing field semantics changed, no signatures removed or altered.
- **Zero behavior change when nothing is injected**: no options → in-memory sync states/cursors and no backoff, exactly as before; empty metadata inputs → request bodies are byte-for-byte identical (covered by tests asserting the keys are absent).
- Existing tuttid usage untouched.

## Acceptance criteria

An external daemon (tsh desktopd) completes cloud projection purely by **implementing the interfaces + configuring the `Client` `BaseURL` to its controlplane** — no fork of any `activity/` file is needed. See the new "Cloud Projection Extension Points" section in `packages/agent/daemon/README.md` for the wiring snippet.

## Verification

- `packages/agent/daemon`: `go vet ./...`, `go build ./...`, `go test ./...` — all pass (9 packages ok).
- `services/tuttid`: `go build ./...`, `go test ./...` — all pass (36 packages ok).
- `pnpm lint:go` (golangci-lint 2.12.0) — 0 issues.
- New tests: adapter conversion/sync-state persistence/failure paths, syncer backoff windows (skip/double/reset/cap, disabled-by-default, non-retryable errors), cursor persistence round-trip + restart resume + hide cleanup, client metadata wire assertions (present when set, absent when unset), lenient `deviceId`/`device_id` parsing.

## 给发版负责人

本 PR 合入后的**下一次 stable release（应为 `packages/agent/daemon/v0.0.60+`）**将同时覆盖 T1 module path 修复（#735）与本扩展点三件套。该 tag 即 tsh 侧的最低可用版本；发版后请同步 tsh，tsh A4 的云投影改写（reporter 注入方式）依赖此版本。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added device-aware attribution across session state/messages reporting and device-scoped agent/message filtering.
  * Introduced restart-resumable per-session message cursor persistence and a session activity reporter adapter with optional persisted sync-state.
  * Added configurable exponential backoff for failed background message syncs, plus expanded daemon extension documentation with setup guidance and examples.
* **Bug Fixes**
  * Improved consistency of device/target metadata handling (including wire-format backfilling and device ID field compatibility).
  * Hidden sessions now reliably clear persisted cursor/sync state to prevent stale resume.
* **Tests**
  * Added unit tests for serialization stability, cursor persistence/resume, and backoff behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->