### PR TITLE
fix(agent-message-center): unify zh-CN running label copy

### DIFF
--- a/packages/agent/gui/app/renderer/i18n/locales/zh-CN.ts
+++ b/packages/agent/gui/app/renderer/i18n/locales/zh-CN.ts
@@ -1110,7 +1110,7 @@ export const zhCN = {
     workspaceAgentMessageCenterWaitingCount_other: "{{count}} 个等待中",
     workspaceAgentMessageCenterFilterAll: "全部",
     workspaceAgentMessageCenterFilterWaiting: "等待中",
-    workspaceAgentMessageCenterFilterWorking: "工作中",
+    workspaceAgentMessageCenterFilterWorking: "运行中",
     workspaceAgentMessageCenterFilterCompleted: "已完成",
     workspaceAgentMessageCenterFilterFailed: "错误",
     workspaceAgentMessageCenterViewOptions: "视图选项",

--- a/packages/agent/gui/shared/workspaceAgentActivityStatusLabel.spec.ts
+++ b/packages/agent/gui/shared/workspaceAgentActivityStatusLabel.spec.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+import { agentGuiI18nResources } from "../i18n/index";
 import {
   normalizeWorkspaceAgentActivityDisplayStatus,
   workspaceAgentActivityStatusLabel
@@ -52,5 +53,27 @@ describe("workspaceAgentActivityStatusLabel", () => {
     expect(workspaceAgentActivityStatusLabel("completed", t)).toBe("已完成");
     expect(workspaceAgentActivityStatusLabel("canceled", t)).toBe("已取消");
     expect(workspaceAgentActivityStatusLabel("failed", t)).toBe("错误");
+  });
+
+  it("keeps the message center's running filter/group label in sync with the shared activity status label in every locale", () => {
+    // Regression guard: the message center panel shows a group/filter label
+    // ("Running") right above cards whose own status pill is rendered via
+    // workspaceAgentActivityStatusLabel for the same "working" status. These
+    // must read as the same word in every locale, or the panel shows two
+    // different labels for the same "running" state side by side (the exact
+    // wording inconsistency reported against the message status panel).
+    for (const locale of Object.keys(
+      agentGuiI18nResources
+    ) as (keyof typeof agentGuiI18nResources)[]) {
+      const dictionary = agentGuiI18nResources[locale] as {
+        agentHost: {
+          workspaceAgentMessageCenterFilterWorking: string;
+          workspaceAgentActivityStatusWorking: string;
+        };
+      };
+      expect(
+        dictionary.agentHost.workspaceAgentMessageCenterFilterWorking
+      ).toBe(dictionary.agentHost.workspaceAgentActivityStatusWorking);
+    }
   });
 });


### PR DESCRIPTION
## Summary
- Fixes a Feishu-reported bug (P1): the message center's "running" status wording was inconsistent within the panel itself in Chinese.
- The message center groups/filters items into a "运行中" bucket via `agentHost.workspaceAgentMessageCenterFilterWorking`, while each card inside that group renders its own status pill via the shared `workspaceAgentActivityStatusLabel` helper (`agentHost.workspaceAgentActivityStatusWorking`) for the identical `"working"` status. In English both happened to read "Running", masking the bug, but in zh-CN they diverged: the group heading said 工作中 while the card right below it said 运行中 for the exact same running session — the wording inconsistency the report described.
- Aligns the zh-CN group/filter label to 运行中 (the term already used everywhere else for this status: activity status label, app-center, terminal node, etc.).
- Adds a regression test (`workspaceAgentActivityStatusLabel.spec.ts`) asserting the two i18n keys stay identical across every locale, so this can't silently drift apart again.

## Test plan
- [x] `npx vitest run shared/workspaceAgentActivityStatusLabel.spec.ts agent-message-center` (109 tests passed) in `packages/agent/gui`
- [x] `pnpm typecheck` in `packages/agent/gui`
- [x] `npx oxlint` on changed files
- [x] Confirmed the new test fails against the pre-fix 工作中 value and passes after the fix
- [x] `check:full` passed via pre-push hook (TS + Go suites)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the Chinese localization label for the “working/running” filter to use the correct wording.
  * Added regression coverage to keep the message center filter label consistent with the shared activity status label across all supported locales.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->