### PR TITLE
fix(agent): route agent target mentions in acp prompts

### DIFF
--- a/docs/architecture/agent-reference-mention-resolution.md
+++ b/docs/architecture/agent-reference-mention-resolution.md
@@ -80,6 +80,10 @@ has a dedicated `agent-target` provider for first-party Agent targets:
 - `workspace-app` must not return `agent-codex` or `agent-claude-code` pseudo
   apps. Existing historical pseudo-app mention tokens can remain display-only;
   do not create new ones.
+- ACP runtime mention routing treats `agent-target` mentions as Tutti-internal
+  references for the generic runtime-only routing reminder. The reminder may be
+  appended to the provider prompt, but it must not be persisted into renderer
+  payloads, daemon activity events, or imported session messages.
 
 ---
 

--- a/packages/agent/daemon/runtime/standard_acp_adapter.go
+++ b/packages/agent/daemon/runtime/standard_acp_adapter.go
@@ -1260,6 +1260,8 @@ func skillForMentionURI(uri string) string {
 		return "reference"
 	case strings.HasPrefix(uri, "mention://agent-session/"):
 		return "tutti-cli"
+	case strings.HasPrefix(uri, "mention://agent-target/"):
+		return "tutti-cli"
 	default:
 		return ""
 	}

--- a/packages/agent/daemon/runtime/standard_acp_adapter_test.go
+++ b/packages/agent/daemon/runtime/standard_acp_adapter_test.go
@@ -2427,6 +2427,34 @@ func TestClaudeCodeAdapterExecRoutesWorkspaceReferenceMention(t *testing.T) {
 	}
 }
 
+func TestClaudeCodeAdapterExecRoutesAgentTargetMention(t *testing.T) {
+	t.Parallel()
+
+	transport := newStandardACPTransport("Claude Agent", "claude-agent-target-routing")
+	adapter := NewClaudeCodeAdapter(transport)
+	session := standardTestSession(ProviderClaudeCode)
+	session.PermissionModeID = "default"
+	if _, err := adapter.Start(context.Background(), session); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	prompt := "让 [@Claude Code](mention://agent-target/local:claude-code?workspaceId=workspace-1) 来 review"
+
+	if _, err := adapter.Exec(context.Background(), session, textPrompt(prompt), "", "turn-agent-target", func([]activityshared.Event) {}, nil); err != nil {
+		t.Fatalf("Exec: %v", err)
+	}
+
+	texts := promptTexts(t, transport.conn.lastPromptParamsSnapshot)
+	if len(texts) < 2 {
+		t.Fatalf("prompt texts = %#v, want user prompt plus internal routing", texts)
+	}
+	if texts[0] != prompt {
+		t.Fatalf("user prompt text = %q, want unmodified prompt %q", texts[0], prompt)
+	}
+	if texts[len(texts)-1] != tuttiMentionRoutingReminder {
+		t.Fatalf("routing prompt = %q, want agent target routing", texts[len(texts)-1])
+	}
+}
+
 func TestClaudeCodeAdapterExecRoutesEscapedMarkdownMentionLabel(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary
- cherry-pick main fix for agent-target mention routing into release/0704
- treat `mention://agent-target/...` as an internal Tutti mention for ACP runtime routing reminders
- add Claude Code ACP coverage and architecture note

## Validation
- `go test ./packages/agent/daemon/runtime -run 'TestClaudeCodeAdapterExec(RoutesAgentTargetMention|AddsInternalMentionRoutingPromptForMarkdownMention|RoutesWorkspaceReferenceMention|DoesNotRouteBareMentionURI)'`
- `git diff --check HEAD~1..HEAD`

## Upstream
- Main PR: https://github.com/tutti-os/tutti/pull/742