### PR TITLE
fix(workspace): avoid premature app factory validation

### DIFF
--- a/services/tuttid/service/workspace/app_factory_agent_state.go
+++ b/services/tuttid/service/workspace/app_factory_agent_state.go
@@ -8,7 +8,6 @@ import (
 	"strings"
 
 	agentsessionstore "github.com/tutti-os/tutti/packages/agent/daemon/activity"
-	agentactivityprojection "github.com/tutti-os/tutti/packages/agent/daemon/activity/projection"
 	agentactivitybiz "github.com/tutti-os/tutti/services/tuttid/biz/agentactivity"
 	workspacebiz "github.com/tutti-os/tutti/services/tuttid/biz/workspace"
 )
@@ -123,13 +122,16 @@ func (s *AppFactoryService) reconcileFromPersistedAgentSession(ctx context.Conte
 	if !ok {
 		return false, nil
 	}
-	status := normalizeFactoryAgentSessionStatus(
-		agentactivityprojection.CanonicalSessionStatus(session.Status, session.CurrentPhase),
-	)
-	if status == "" {
-		return s.reconcileCompletedAgentSessionMessages(ctx, workspaceID, job)
+	if status := normalizePersistedFactoryAgentSessionStatus(session.Status); status != "" {
+		return true, s.handleAgentSessionTerminalState(ctx, workspaceID, agentSessionID, status, session.LastError)
 	}
-	return true, s.handleAgentSessionTerminalState(ctx, workspaceID, agentSessionID, status, session.LastError)
+	if strings.ToLower(strings.TrimSpace(session.CurrentPhase)) == "failed" {
+		return true, s.handleAgentSessionTerminalState(ctx, workspaceID, agentSessionID, "failed", session.LastError)
+	}
+	if isPersistedFactoryAgentSessionActive(session.Status, session.CurrentPhase) {
+		return true, nil
+	}
+	return s.reconcileCompletedAgentSessionMessages(ctx, workspaceID, job)
 }
 
 func (s *AppFactoryService) reconcileCompletedAgentSessionMessages(ctx context.Context, workspaceID string, job workspacebiz.AppFactoryJob) (bool, error) {
@@ -152,15 +154,8 @@ func (s *AppFactoryService) agentSessionHasCompletedFactoryOutput(workspaceID st
 		switch normalizeFactoryAgentSessionStatus(session.Status) {
 		case "completed":
 			return true
-		case "canceled":
-			return false
-		case "failed":
-			return false
 		default:
-			if strings.ToLower(strings.TrimSpace(session.Status)) != "active" ||
-				strings.ToLower(strings.TrimSpace(session.CurrentPhase)) != "idle" {
-				return false
-			}
+			return false
 		}
 	}
 	page, ok := s.AgentMessageReader.ListSessionMessages(agentactivitybiz.ListSessionMessagesInput{
@@ -274,7 +269,7 @@ func isRecoverablePreValidationAgentFailure(job workspacebiz.AppFactoryJob) bool
 
 func normalizeFactoryAgentSessionStatus(status string) string {
 	switch strings.ToLower(strings.TrimSpace(status)) {
-	case "completed", "complete", "succeeded", "success":
+	case "completed", "complete", "ended", "succeeded", "success":
 		return "completed"
 	case "canceled":
 		return "canceled"
@@ -287,6 +282,19 @@ func normalizeFactoryAgentSessionStatus(status string) string {
 
 func normalizePersistedFactoryAgentSessionStatus(status string) string {
 	return normalizeFactoryAgentSessionStatus(status)
+}
+
+func isPersistedFactoryAgentSessionActive(status string, currentPhase string) bool {
+	switch strings.ToLower(strings.TrimSpace(status)) {
+	case "active", "created", "queued", "running", "working", "waiting":
+		return true
+	}
+	switch strings.ToLower(strings.TrimSpace(currentPhase)) {
+	case "idle", "working", "running", "streaming", "waiting", "waiting_approval", "awaiting_approval", "waiting_input":
+		return true
+	default:
+		return false
+	}
 }
 
 func factoryAgentTerminalStatus(state agentsessionstore.WorkspaceAgentSessionStateUpdate) string {

--- a/services/tuttid/service/workspace/app_factory_test.go
+++ b/services/tuttid/service/workspace/app_factory_test.go
@@ -793,7 +793,7 @@ printf '%s\n' "$TUTTI_APP_TOOLCHAIN_ROOT" > "$TUTTI_APP_DATA_DIR/toolchain-root.
 	}
 }
 
-func TestAppFactoryServiceReconcileIdleCompletedAgentSessionStartsValidation(t *testing.T) {
+func TestAppFactoryServiceReconcileIdleCompletedAgentSessionKeepsGenerating(t *testing.T) {
 	t.Parallel()
 
 	ctx := context.Background()
@@ -854,11 +854,11 @@ func TestAppFactoryServiceReconcileIdleCompletedAgentSessionStartsValidation(t *
 	if err != nil {
 		t.Fatalf("GetAppFactoryJob() error = %v", err)
 	}
-	if job.Status != workspacebiz.AppFactoryJobStatusFailed {
-		t.Fatalf("status = %q, want failed validation", job.Status)
+	if job.Status != workspacebiz.AppFactoryJobStatusGenerating {
+		t.Fatalf("status = %q, want generating", job.Status)
 	}
-	if strings.TrimSpace(job.ValidationResultJSON) == "" {
-		t.Fatal("validation result is empty, want failed validation result")
+	if strings.TrimSpace(job.ValidationResultJSON) != "" {
+		t.Fatalf("validation result = %q, want empty", job.ValidationResultJSON)
 	}
 }
 
@@ -890,7 +890,7 @@ func TestAppFactoryServiceReconcileRecoversPreValidationFailure(t *testing.T) {
 				appFactoryJobStoreKey("ws-1", "session-1"): {
 					ID:           "session-1",
 					WorkspaceID:  "ws-1",
-					Status:       "active",
+					Status:       "completed",
 					CurrentPhase: "idle",
 				},
 			},


### PR DESCRIPTION
## Summary
- keep App Factory jobs generating while persisted agent sessions are still active/idle
- require explicit terminal session state before running package validation
- update regression coverage for completed assistant messages during active sessions

## Tests
- go test ./service/workspace -run 'TestAppFactoryService(ReconcileIdleCompletedAgentSessionKeepsGenerating|ReconcileRecoversPreValidationFailure|CompletedAgentSessionStartsValidation|FailedAgentSessionFailsGeneratingJob|FactoryAgentTerminalStatus|CompletedAgentSessionRecoversPreValidationFailure)|TestNormalizePersistedFactoryAgentSessionStatusDoesNotTreatActiveAsCompleted'
- pnpm check:changed --tail-lines 80
- pnpm check:full (pre-push)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved how workspace jobs recover from persisted agent-session states, reducing incorrect transitions during session reconciliation.
  * Jobs now keep generating in some idle/completed session cases instead of prematurely switching to a failed validation state.
  * Sessions marked as finished in more ways, including “ended,” are now recognized consistently.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->