### PR TITLE
feat(agent): add provider launch prepare hook

### DIFF
--- a/packages/agent/daemon/README.md
+++ b/packages/agent/daemon/README.md
@@ -27,6 +27,18 @@ if err != nil {
 controller := runtime.Controller()
 ```
 
+Hosts that need to prepare a provider launch immediately before process spawn
+can set `ProviderLaunchPreparer`. The hook receives the provider, session,
+command, environment, cwd, and direct-start mode; it returns the command,
+environment, cwd, and optional cleanup function to use for `ProcessTransport`
+startup.
+
+Prepare errors fail session start before spawning a process. When prepare
+succeeds, cleanup runs after the provider process is closed, including process
+start or initialize failure, live-session close, idle release, and live process
+replacement. Cleanup failures are logged and do not replace the original close
+or start error.
+
 ## Package Ownership
 
 This package owns:

--- a/packages/agent/daemon/runtime.go
+++ b/packages/agent/daemon/runtime.go
@@ -27,12 +27,17 @@ type HostMetadata = agentruntime.HostMetadata
 type ProcessTransport = agentruntime.ProcessTransport
 type ProviderCommand = agentruntime.ProviderCommand
 type ProviderCommandResolver = agentruntime.ProviderCommandResolver
+type ProviderLaunchPrepareInput = agentruntime.ProviderLaunchPrepareInput
+type ProviderLaunchPrepareResult = agentruntime.ProviderLaunchPrepareResult
+type ProviderLaunchPreparer = agentruntime.ProviderLaunchPreparer
+type ProviderLaunchPreparerAdapter = agentruntime.ProviderLaunchPreparerAdapter
 
 type Config struct {
 	Reporter                ActivityReporter
 	ProcessTransport        ProcessTransport
 	HostMetadata            HostMetadata
 	ProviderCommandResolver ProviderCommandResolver
+	ProviderLaunchPreparer  ProviderLaunchPreparer
 	Adapters                []Adapter
 	LiveSessionReaper       LiveSessionReaperConfig
 }
@@ -53,6 +58,7 @@ type Runtime struct {
 func NewRuntime(config Config) (*Runtime, error) {
 	var controller *Controller
 	if len(config.Adapters) > 0 {
+		agentruntime.ApplyProviderLaunchPreparer(config.Adapters, config.ProviderLaunchPreparer)
 		controller = agentruntime.NewController(config.Adapters, config.Reporter)
 	} else {
 		if !hasCompleteHostMetadata(config.HostMetadata) {
@@ -67,6 +73,7 @@ func NewRuntime(config Config) (*Runtime, error) {
 			agentruntime.ControllerOptions{
 				HostMetadata:            config.HostMetadata,
 				ProviderCommandResolver: config.ProviderCommandResolver,
+				ProviderLaunchPreparer:  config.ProviderLaunchPreparer,
 			},
 		)
 	}

--- a/packages/agent/daemon/runtime/claude_sdk_adapter.go
+++ b/packages/agent/daemon/runtime/claude_sdk_adapter.go
@@ -36,6 +36,7 @@ const (
 
 type ClaudeCodeSDKAdapter struct {
 	transport ProcessTransport
+	preparer  ProviderLaunchPreparer
 
 	mu          sync.Mutex
 	sessions    map[string]*claudeSDKAdapterSession
@@ -130,6 +131,13 @@ func (*ClaudeCodeSDKAdapter) Provider() string {
 	return ProviderClaudeCode
 }
 
+func (a *ClaudeCodeSDKAdapter) SetProviderLaunchPreparer(preparer ProviderLaunchPreparer) {
+	if a == nil {
+		return
+	}
+	a.preparer = preparer
+}
+
 func (a *ClaudeCodeSDKAdapter) Start(ctx context.Context, session Session) ([]activityshared.Event, error) {
 	if a == nil || a.transport == nil {
 		return nil, ErrSessionDisconnected
@@ -141,7 +149,7 @@ func (a *ClaudeCodeSDKAdapter) Start(ctx context.Context, session Session) ([]ac
 	if err != nil {
 		return nil, err
 	}
-	conn, err := a.transport.Start(ctx, ProcessSpec{
+	spec, cleanup, err := prepareProviderLaunch(ctx, a.preparer, session, ProcessSpec{
 		Provider:       ProviderClaudeCode,
 		AgentSessionID: session.AgentSessionID,
 		RoomID:         session.RoomID,
@@ -153,6 +161,12 @@ func (a *ClaudeCodeSDKAdapter) Start(ctx context.Context, session Session) ([]ac
 	if err != nil {
 		return nil, err
 	}
+	conn, err := a.transport.Start(ctx, spec)
+	if err != nil {
+		cleanupPreparedLaunch(cleanup)
+		return nil, err
+	}
+	conn = wrapProviderLaunchCleanup(conn, cleanup)
 	adapterSession := &claudeSDKAdapterSession{
 		conn:              conn,
 		reader:            &claudeSDKLineReader{conn: conn},

--- a/packages/agent/daemon/runtime/claude_sdk_adapter_test.go
+++ b/packages/agent/daemon/runtime/claude_sdk_adapter_test.go
@@ -1297,6 +1297,60 @@ func TestClaudeCodeSDKAdapterStartSendsInitialSettings(t *testing.T) {
 	}
 }
 
+func TestClaudeCodeSDKAdapterProviderLaunchPrepareMutatesSpecAndCleansUpOnClose(t *testing.T) {
+	conn := &scriptedClaudeSDKConnection{
+		frames: []ProcessFrame{{
+			Stdout: []byte(`{"type":"session_started","payload":{"providerSessionId":"provider-session-1"}}` + "\n"),
+		}},
+	}
+	transport := &recordingClaudeSDKTransport{conn: conn}
+	adapter := NewClaudeCodeSDKAdapter(transport)
+	cleanupCalls := 0
+	adapter.SetProviderLaunchPreparer(func(_ context.Context, input ProviderLaunchPrepareInput) (ProviderLaunchPrepareResult, error) {
+		if input.Provider != ProviderClaudeCode {
+			t.Fatalf("Provider = %q, want %q", input.Provider, ProviderClaudeCode)
+		}
+		if !input.DirectStart {
+			t.Fatal("DirectStart = false, want true for Claude SDK")
+		}
+		return ProviderLaunchPrepareResult{
+			Command: []string{"prepared-node", "sidecar.ts"},
+			Env:     append(append([]string(nil), input.Env...), "HOOK_ENV=1"),
+			CWD:     "/prepared/claude-sdk",
+			Cleanup: func(context.Context) error {
+				cleanupCalls++
+				return nil
+			},
+		}, nil
+	})
+	session := standardTestSession(ProviderClaudeCode)
+	session.Env = []string{"SESSION_ENV=1"}
+	session.ProviderSessionID = "provider-session-1"
+
+	if _, err := adapter.Start(context.Background(), session); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	if cleanupCalls != 0 {
+		t.Fatalf("cleanup calls before close = %d, want 0", cleanupCalls)
+	}
+	if !slices.Equal(transport.spec.Command, []string{"prepared-node", "sidecar.ts"}) {
+		t.Fatalf("Command = %#v", transport.spec.Command)
+	}
+	if transport.spec.CWD != "/prepared/claude-sdk" {
+		t.Fatalf("CWD = %q", transport.spec.CWD)
+	}
+	if !containsString(transport.spec.Env, "SESSION_ENV=1") || !containsString(transport.spec.Env, "HOOK_ENV=1") {
+		t.Fatalf("Env = %#v, want session and hook env", transport.spec.Env)
+	}
+
+	if err := adapter.Close(context.Background(), session); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+	if cleanupCalls != 1 {
+		t.Fatalf("cleanup calls after close = %d, want 1", cleanupCalls)
+	}
+}
+
 func TestClaudeSDKSidecarCommandUsesVendoredEntryWithManagedNodeEnv(t *testing.T) {
 	t.Setenv(claudeSDKSidecarCommandEnv, "")
 	t.Setenv(claudeSDKSidecarEntryPathEnv, "")

--- a/packages/agent/daemon/runtime/codex_appserver_adapter.go
+++ b/packages/agent/daemon/runtime/codex_appserver_adapter.go
@@ -109,6 +109,7 @@ const defaultCodexAppServerGoalContinuationGraceWindow = 1500 * time.Millisecond
 type CodexAppServerAdapter struct {
 	transport   ProcessTransport
 	host        HostMetadata
+	preparer    ProviderLaunchPreparer
 	mu          sync.Mutex
 	sessions    map[string]*codexAppServerSession
 	commandSink CommandSnapshotSink
@@ -336,6 +337,13 @@ func (a *CodexAppServerAdapter) SetConfigOptionsUpdateSink(sink ConfigOptionsUpd
 	a.mu.Lock()
 	a.configSink = sink
 	a.mu.Unlock()
+}
+
+func (a *CodexAppServerAdapter) SetProviderLaunchPreparer(preparer ProviderLaunchPreparer) {
+	if a == nil {
+		return
+	}
+	a.preparer = preparer
 }
 
 func (*CodexAppServerAdapter) ValidatePromptContent(Session, []PromptContentBlock) error {
@@ -668,13 +676,8 @@ func (a *CodexAppServerAdapter) startInitializedClient(
 	if a == nil || a.transport == nil {
 		return nil, nil, errors.New("app-server process transport is unavailable")
 	}
-	trace.Log("process.start.begin", map[string]any{
-		"command": strings.Join([]string{codexAppServerCommand, codexAppServerSubcmd}, " "),
-		"cwd":     a.sessionCWD(session),
-	})
-	processStartedAt := time.Now()
 	spawnEnv := append(codexACPEnv(session, a.host), session.Env...)
-	conn, err := a.transport.Start(ctx, ProcessSpec{
+	spec, cleanup, err := prepareProviderLaunch(ctx, a.preparer, session, ProcessSpec{
 		Provider:       ProviderCodex,
 		AgentSessionID: session.AgentSessionID,
 		RoomID:         session.RoomID,
@@ -683,12 +686,26 @@ func (a *CodexAppServerAdapter) startInitializedClient(
 		Env:            spawnEnv,
 	})
 	if err != nil {
+		trace.Log("process.prepare.failed", map[string]any{
+			"error": err.Error(),
+		})
+		return nil, nil, err
+	}
+	trace.Log("process.start.begin", map[string]any{
+		"command": strings.Join(spec.Command, " "),
+		"cwd":     spec.CWD,
+	})
+	processStartedAt := time.Now()
+	conn, err := a.transport.Start(ctx, spec)
+	if err != nil {
+		cleanupPreparedLaunch(cleanup)
 		trace.Log("process.start.failed", map[string]any{
 			"duration_ms": time.Since(processStartedAt).Milliseconds(),
 			"error":       err.Error(),
 		})
 		return nil, nil, err
 	}
+	conn = wrapProviderLaunchCleanup(conn, cleanup)
 	trace.Log("process.start.succeeded", map[string]any{
 		"duration_ms": time.Since(processStartedAt).Milliseconds(),
 	})
@@ -727,7 +744,7 @@ func (a *CodexAppServerAdapter) startInitializedClient(
 
 	initializeResult, err := trace.TypedCall(acpStartCallTimeout, appServerMethodInitialize, func() (json.RawMessage, error) {
 		return client.Initialize(ctx, acpStartCallTimeout, map[string]any{
-			"clientInfo": codexClientInfoParams(a.host, spawnEnv),
+			"clientInfo": codexClientInfoParams(a.host, spec.Env),
 			"capabilities": map[string]any{
 				"experimentalApi": true,
 			},

--- a/packages/agent/daemon/runtime/codex_appserver_lifecycle_test.go
+++ b/packages/agent/daemon/runtime/codex_appserver_lifecycle_test.go
@@ -3,6 +3,7 @@ package agentruntime
 import (
 	"context"
 	"errors"
+	"reflect"
 	"sync"
 	"testing"
 )
@@ -79,6 +80,122 @@ func connClosed(conn *scriptedAppServerConnection) bool {
 	conn.mu.Lock()
 	defer conn.mu.Unlock()
 	return conn.closeCount > 0
+}
+
+func TestCodexAppServerAdapterProviderLaunchPrepareMutatesSpecAndCleansUpOnClose(t *testing.T) {
+	t.Parallel()
+
+	transport := newScriptedAppServerTransport()
+	adapter := NewCodexAppServerAdapter(transport)
+	cleanupCalls := 0
+	adapter.SetProviderLaunchPreparer(func(_ context.Context, input ProviderLaunchPrepareInput) (ProviderLaunchPrepareResult, error) {
+		if input.Provider != ProviderCodex {
+			t.Fatalf("Provider = %q, want %q", input.Provider, ProviderCodex)
+		}
+		if input.DirectStart {
+			t.Fatal("DirectStart = true, want false for codex app-server")
+		}
+		if input.Session.AgentSessionID != "agent-session-1" {
+			t.Fatalf("Session.AgentSessionID = %q", input.Session.AgentSessionID)
+		}
+		return ProviderLaunchPrepareResult{
+			Command: []string{"prepared-codex", "app-server"},
+			Env:     append(append([]string(nil), input.Env...), "HOOK_ENV=1"),
+			CWD:     "/prepared/workspace",
+			Cleanup: func(context.Context) error {
+				cleanupCalls++
+				return nil
+			},
+		}, nil
+	})
+
+	session := testAppServerSession()
+	session.Env = []string{"SESSION_ENV=1"}
+	if _, err := adapter.Start(context.Background(), session); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	if cleanupCalls != 0 {
+		t.Fatalf("cleanup calls before close = %d, want 0", cleanupCalls)
+	}
+	transport.mu.Lock()
+	specs := append([]ProcessSpec(nil), transport.specs...)
+	transport.mu.Unlock()
+	if len(specs) != 1 {
+		t.Fatalf("transport starts = %d, want 1", len(specs))
+	}
+	spec := specs[0]
+	if !reflect.DeepEqual(spec.Command, []string{"prepared-codex", "app-server"}) {
+		t.Fatalf("Command = %#v", spec.Command)
+	}
+	if spec.CWD != "/prepared/workspace" {
+		t.Fatalf("CWD = %q", spec.CWD)
+	}
+	if !reflect.DeepEqual(spec.Env[len(spec.Env)-2:], []string{"SESSION_ENV=1", "HOOK_ENV=1"}) {
+		t.Fatalf("Env tail = %#v", spec.Env)
+	}
+
+	if err := adapter.Close(context.Background(), session); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+	if cleanupCalls != 1 {
+		t.Fatalf("cleanup calls after close = %d, want 1", cleanupCalls)
+	}
+}
+
+func TestCodexAppServerAdapterProviderLaunchPrepareFailureDoesNotSpawn(t *testing.T) {
+	t.Parallel()
+
+	transport := &multiProcAppServerTransport{}
+	adapter := NewCodexAppServerAdapter(transport)
+	prepareErr := errors.New("prepare failed")
+	adapter.SetProviderLaunchPreparer(func(context.Context, ProviderLaunchPrepareInput) (ProviderLaunchPrepareResult, error) {
+		return ProviderLaunchPrepareResult{}, prepareErr
+	})
+
+	if _, err := adapter.Start(context.Background(), testAppServerSession()); !errors.Is(err, prepareErr) {
+		t.Fatalf("Start error = %v, want %v", err, prepareErr)
+	}
+	spawned, _ := transport.snapshot()
+	if spawned != 0 {
+		t.Fatalf("spawned processes = %d, want 0", spawned)
+	}
+}
+
+func TestCodexAppServerAdapterProviderLaunchCleanupRunsOnProcessStartFailure(t *testing.T) {
+	t.Parallel()
+
+	transport := &multiProcAppServerTransport{}
+	startErr := errors.New("process start failed")
+	transport.setStartErr(startErr)
+	adapter := NewCodexAppServerAdapter(transport)
+	cleanupCalls := 0
+	cleanupSawCanceledContext := false
+	adapter.SetProviderLaunchPreparer(func(_ context.Context, input ProviderLaunchPrepareInput) (ProviderLaunchPrepareResult, error) {
+		return ProviderLaunchPrepareResult{
+			Command: input.Command,
+			Env:     input.Env,
+			CWD:     input.CWD,
+			Cleanup: func(ctx context.Context) error {
+				if ctx.Err() != nil {
+					cleanupSawCanceledContext = true
+				}
+				cleanupCalls++
+				return nil
+			},
+		}, nil
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	if _, err := adapter.Start(ctx, testAppServerSession()); !errors.Is(err, startErr) {
+		t.Fatalf("Start error = %v, want %v", err, startErr)
+	}
+	if cleanupCalls != 1 {
+		t.Fatalf("cleanup calls = %d, want 1", cleanupCalls)
+	}
+	if cleanupSawCanceledContext {
+		t.Fatal("cleanup received canceled launch context")
+	}
 }
 
 // --- single-live-process invariant tests ---

--- a/packages/agent/daemon/runtime/controller.go
+++ b/packages/agent/daemon/runtime/controller.go
@@ -143,17 +143,16 @@ func NewDefaultControllerWithOptions(
 	options ControllerOptions,
 ) *Controller {
 	host := options.HostMetadata
-	return NewController(
-		[]Adapter{
-			newDefaultClaudeCodeAdapter(transport, host, options.ProviderCommandResolver),
-			NewCodexAppServerAdapterWithHostMetadata(transport, host),
-			NewNexightAdapterWithHostMetadata(transport, host),
-			NewGeminiAdapterWithHostMetadata(transport, host),
-			NewHermesAdapterWithHostMetadata(transport, host),
-			NewOpenClawAdapterWithHostMetadata(transport, host),
-		},
-		reporter,
-	)
+	adapters := []Adapter{
+		newDefaultClaudeCodeAdapter(transport, host, options.ProviderCommandResolver),
+		NewCodexAppServerAdapterWithHostMetadata(transport, host),
+		NewNexightAdapterWithHostMetadata(transport, host),
+		NewGeminiAdapterWithHostMetadata(transport, host),
+		NewHermesAdapterWithHostMetadata(transport, host),
+		NewOpenClawAdapterWithHostMetadata(transport, host),
+	}
+	setProviderLaunchPreparer(adapters, options.ProviderLaunchPreparer)
+	return NewController(adapters, reporter)
 }
 
 func newDefaultClaudeCodeAdapter(

--- a/packages/agent/daemon/runtime/host_metadata.go
+++ b/packages/agent/daemon/runtime/host_metadata.go
@@ -25,6 +25,7 @@ type HostMetadata struct {
 type ControllerOptions struct {
 	HostMetadata            HostMetadata
 	ProviderCommandResolver ProviderCommandResolver
+	ProviderLaunchPreparer  ProviderLaunchPreparer
 }
 
 type ProviderCommand struct {

--- a/packages/agent/daemon/runtime/process_transport.go
+++ b/packages/agent/daemon/runtime/process_transport.go
@@ -54,6 +54,9 @@ func (localProcessTransport) Start(ctx context.Context, spec ProcessSpec) (Proce
 	logProcessStartEnvDiagnostics(spec, env, resolvedCommand)
 	cmd := exec.CommandContext(processCtx, resolvedCommand, spec.Command[1:]...)
 	cmd.Env = env
+	if cwd := strings.TrimSpace(spec.CWD); cwd != "" {
+		cmd.Dir = cwd
+	}
 
 	stdin, err := cmd.StdinPipe()
 	if err != nil {

--- a/packages/agent/daemon/runtime/provider_launch_prepare.go
+++ b/packages/agent/daemon/runtime/provider_launch_prepare.go
@@ -1,0 +1,159 @@
+package agentruntime
+
+import (
+	"context"
+	"log/slog"
+	"sync"
+)
+
+type ProviderLaunchPrepareInput struct {
+	Provider    string
+	Session     Session
+	Command     []string
+	Env         []string
+	CWD         string
+	DirectStart bool
+}
+
+type ProviderLaunchPrepareResult struct {
+	Command []string
+	Env     []string
+	CWD     string
+	Cleanup func(context.Context) error
+}
+
+type ProviderLaunchPreparer func(context.Context, ProviderLaunchPrepareInput) (ProviderLaunchPrepareResult, error)
+
+type ProviderLaunchPreparerAdapter interface {
+	SetProviderLaunchPreparer(ProviderLaunchPreparer)
+}
+
+func setProviderLaunchPreparer(adapters []Adapter, preparer ProviderLaunchPreparer) {
+	ApplyProviderLaunchPreparer(adapters, preparer)
+}
+
+func ApplyProviderLaunchPreparer(adapters []Adapter, preparer ProviderLaunchPreparer) {
+	if preparer == nil {
+		return
+	}
+	for _, adapter := range adapters {
+		if setter, ok := adapter.(ProviderLaunchPreparerAdapter); ok {
+			setter.SetProviderLaunchPreparer(preparer)
+		}
+	}
+}
+
+func prepareProviderLaunch(
+	ctx context.Context,
+	preparer ProviderLaunchPreparer,
+	session Session,
+	spec ProcessSpec,
+) (ProcessSpec, func(context.Context), error) {
+	spec.Command = append([]string(nil), spec.Command...)
+	spec.Env = append([]string(nil), spec.Env...)
+	if preparer == nil {
+		return spec, nil, nil
+	}
+	result, err := preparer(ctx, ProviderLaunchPrepareInput{
+		Provider:    spec.Provider,
+		Session:     cloneProviderLaunchSession(session),
+		Command:     append([]string(nil), spec.Command...),
+		Env:         append([]string(nil), spec.Env...),
+		CWD:         spec.CWD,
+		DirectStart: spec.DirectStart,
+	})
+	if err != nil {
+		return ProcessSpec{}, nil, err
+	}
+	spec.Command = append([]string(nil), result.Command...)
+	spec.Env = append([]string(nil), result.Env...)
+	spec.CWD = result.CWD
+	return spec, providerLaunchCleanup(spec, result.Cleanup), nil
+}
+
+func cloneProviderLaunchSession(session Session) Session {
+	session.Env = append([]string(nil), session.Env...)
+	session.RuntimeContext = clonePayload(session.RuntimeContext)
+	session.ProviderTargetRef = clonePayload(session.ProviderTargetRef)
+	if session.Settings != nil {
+		session.Settings = cloneSessionSettings(*session.Settings)
+	}
+	return session
+}
+
+func providerLaunchCleanup(spec ProcessSpec, cleanup func(context.Context) error) func(context.Context) {
+	if cleanup == nil {
+		return nil
+	}
+	var once sync.Once
+	return func(ctx context.Context) {
+		once.Do(func() {
+			if ctx == nil {
+				ctx = context.Background()
+			}
+			if err := cleanup(ctx); err != nil {
+				slog.Warn("agent session provider launch cleanup failed",
+					"event", "agent_session.provider_launch.cleanup_failed",
+					"provider", spec.Provider,
+					"room_id", spec.RoomID,
+					"agent_session_id", spec.AgentSessionID,
+					"error", err.Error(),
+				)
+			}
+		})
+	}
+}
+
+func cleanupPreparedLaunch(cleanup func(context.Context)) {
+	if cleanup != nil {
+		cleanup(context.Background())
+	}
+}
+
+func wrapProviderLaunchCleanup(conn ProcessConnection, cleanup func(context.Context)) ProcessConnection {
+	if conn == nil || cleanup == nil {
+		return conn
+	}
+	wrapped := &providerLaunchCleanupConnection{
+		ProcessConnection: conn,
+		cleanup:           cleanup,
+	}
+	if graceful, ok := conn.(GracefulProcessConnection); ok {
+		return &providerLaunchCleanupGracefulConnection{
+			providerLaunchCleanupConnection: wrapped,
+			graceful:                        graceful,
+		}
+	}
+	return wrapped
+}
+
+type providerLaunchCleanupConnection struct {
+	ProcessConnection
+	cleanup func(context.Context)
+}
+
+func (c *providerLaunchCleanupConnection) Close() error {
+	if c == nil {
+		return nil
+	}
+	err := c.ProcessConnection.Close()
+	c.cleanup(context.Background())
+	return err
+}
+
+type providerLaunchCleanupGracefulConnection struct {
+	*providerLaunchCleanupConnection
+	graceful GracefulProcessConnection
+}
+
+func (c *providerLaunchCleanupGracefulConnection) CloseInput() error {
+	return c.graceful.CloseInput()
+}
+
+func (c *providerLaunchCleanupGracefulConnection) Terminate() error {
+	return c.graceful.Terminate()
+}
+
+func (c *providerLaunchCleanupGracefulConnection) Kill() error {
+	return c.graceful.Kill()
+}

--- a/packages/agent/daemon/runtime/standard_acp_adapter.go
+++ b/packages/agent/daemon/runtime/standard_acp_adapter.go
@@ -54,14 +54,17 @@ type standardACPConfig struct {
 }
 
 type standardACPAdapter struct {
-	config      standardACPConfig
-	transport   ProcessTransport
-	host        HostMetadata
-	mu          sync.Mutex
-	sessions    map[string]*standardACPSession
-	commandSink CommandSnapshotSink
-	eventSink   SessionEventSink
-	configSink  ConfigOptionsUpdateSink
+	config         standardACPConfig
+	transport      ProcessTransport
+	host           HostMetadata
+	preparer       ProviderLaunchPreparer
+	mu             sync.Mutex
+	sessions       map[string]*standardACPSession
+	commandSink    CommandSnapshotSink
+	eventSink      SessionEventSink
+	configSink     ConfigOptionsUpdateSink
+	lifecycleMu    sync.Mutex
+	lifecycleLocks map[string]*standardACPSessionLock
 }
 
 type standardACPSession struct {
@@ -75,6 +78,11 @@ type standardACPSession struct {
 	backgroundAgents map[string]standardACPBackgroundAgent
 	recentTurnID     string
 	recentTurnExpiry time.Time
+}
+
+type standardACPSessionLock struct {
+	mu   sync.Mutex
+	refs int
 }
 
 type pendingACPApproval = pendingACPRequest
@@ -589,7 +597,45 @@ func (a *standardACPAdapter) SetSessionEventSink(sink SessionEventSink) {
 	a.mu.Unlock()
 }
 
+func (a *standardACPAdapter) SetProviderLaunchPreparer(preparer ProviderLaunchPreparer) {
+	if a == nil {
+		return
+	}
+	a.preparer = preparer
+}
+
+func (a *standardACPAdapter) lockSessionLifecycle(agentSessionID string) func() {
+	if a == nil {
+		return func() {}
+	}
+	key := strings.TrimSpace(agentSessionID)
+	a.lifecycleMu.Lock()
+	if a.lifecycleLocks == nil {
+		a.lifecycleLocks = make(map[string]*standardACPSessionLock)
+	}
+	lock := a.lifecycleLocks[key]
+	if lock == nil {
+		lock = &standardACPSessionLock{}
+		a.lifecycleLocks[key] = lock
+	}
+	lock.refs++
+	a.lifecycleMu.Unlock()
+
+	lock.mu.Lock()
+	return func() {
+		lock.mu.Unlock()
+		a.lifecycleMu.Lock()
+		lock.refs--
+		if lock.refs <= 0 && a.lifecycleLocks[key] == lock {
+			delete(a.lifecycleLocks, key)
+		}
+		a.lifecycleMu.Unlock()
+	}
+}
+
 func (a *standardACPAdapter) Start(ctx context.Context, session Session) ([]activityshared.Event, error) {
+	unlockLifecycle := a.lockSessionLifecycle(session.AgentSessionID)
+	defer unlockLifecycle()
 	a.logHermesStartupDiagnostics("start.enter", map[string]any{
 		"room_id":            session.RoomID,
 		"agent_session_id":   session.AgentSessionID,
@@ -608,12 +654,17 @@ func (a *standardACPAdapter) Start(ctx context.Context, session Session) ([]acti
 	}
 	started := false
 	keepSession := false
+	previousSession := a.getSession(session.AgentSessionID)
 	defer func() {
 		if !started {
 			_ = client.Close()
 		}
 		if !keepSession {
-			a.removeSession(session.AgentSessionID)
+			if previousSession != nil {
+				a.storeSession(session.AgentSessionID, previousSession)
+			} else {
+				a.removeSession(session.AgentSessionID)
+			}
 		}
 	}()
 	acpSession := &standardACPSession{
@@ -700,6 +751,7 @@ func (a *standardACPAdapter) Start(ctx context.Context, session Session) ([]acti
 
 	started = true
 	keepSession = true
+	a.closeReplacedSession(previousSession, client)
 	a.logHermesStartupDiagnostics("start.succeeded", map[string]any{
 		"room_id":             session.RoomID,
 		"agent_session_id":    session.AgentSessionID,
@@ -717,6 +769,8 @@ func (a *standardACPAdapter) Resume(ctx context.Context, session Session) error 
 	if strings.TrimSpace(session.ProviderSessionID) == "" {
 		return missingProviderSessionResumeError(session)
 	}
+	unlockLifecycle := a.lockSessionLifecycle(session.AgentSessionID)
+	defer unlockLifecycle()
 	client, initializeResult, err := a.startInitializedClient(ctx, session)
 	if err != nil {
 		return err
@@ -781,6 +835,7 @@ func (a *standardACPAdapter) Resume(ctx context.Context, session Session) error 
 	}
 	started = true
 	keepSession = true
+	a.closeReplacedSession(previousSession, client)
 	return nil
 }
 
@@ -798,6 +853,8 @@ func (a *standardACPAdapter) Close(ctx context.Context, session Session) error {
 		return nil
 	}
 	agentSessionID := strings.TrimSpace(session.AgentSessionID)
+	unlockLifecycle := a.lockSessionLifecycle(agentSessionID)
+	defer unlockLifecycle()
 	a.rejectPendingApprovals(agentSessionID, errPermissionRequestCanceled)
 	a.mu.Lock()
 	acpSession := a.sessions[agentSessionID]
@@ -831,6 +888,19 @@ func (a *standardACPAdapter) closeProviderSession(ctx context.Context, session S
 	}
 	a.logACPCloseDiagnostics("protocol_close.succeeded", session, acpSession, nil)
 	a.waitForACPClientDone(acpSession.client, acpCloseGraceTimeout)
+}
+
+func (a *standardACPAdapter) closeReplacedSession(previousSession *standardACPSession, currentClient *acpClient) {
+	if previousSession == nil || previousSession.client == nil || previousSession.client == currentClient {
+		return
+	}
+	if err := previousSession.client.Close(); err != nil {
+		slog.Warn("agent session ACP replaced client close failed",
+			"event", "agent_session.acp.replaced_client.close_failed",
+			"provider", a.config.provider,
+			"error", err.Error(),
+		)
+	}
 }
 
 func (*standardACPAdapter) waitForACPClientDone(client *acpClient, timeout time.Duration) {
@@ -893,15 +963,7 @@ func (a *standardACPAdapter) startInitializedClient(
 	if a.config.commandWithSettings != nil {
 		command = a.config.commandWithSettings(command, session)
 	}
-	processStartedAt := time.Now()
-	a.logHermesStartupDiagnostics("process_start.start", map[string]any{
-		"room_id":          session.RoomID,
-		"agent_session_id": session.AgentSessionID,
-		"cwd":              session.CWD,
-		"command":          command,
-		"direct_start":     a.config.provider == ProviderClaudeCode,
-	})
-	conn, err := a.transport.Start(ctx, ProcessSpec{
+	spec, cleanup, err := prepareProviderLaunch(ctx, a.preparer, session, ProcessSpec{
 		Provider:             a.config.provider,
 		AgentSessionID:       session.AgentSessionID,
 		RoomID:               session.RoomID,
@@ -912,6 +974,24 @@ func (a *standardACPAdapter) startInitializedClient(
 		DirectStart:          a.config.provider == ProviderClaudeCode,
 	})
 	if err != nil {
+		a.logHermesStartupDiagnostics("process_prepare.failed", map[string]any{
+			"room_id":          session.RoomID,
+			"agent_session_id": session.AgentSessionID,
+			"error":            err.Error(),
+		})
+		return nil, nil, err
+	}
+	processStartedAt := time.Now()
+	a.logHermesStartupDiagnostics("process_start.start", map[string]any{
+		"room_id":          session.RoomID,
+		"agent_session_id": session.AgentSessionID,
+		"cwd":              spec.CWD,
+		"command":          spec.Command,
+		"direct_start":     spec.DirectStart,
+	})
+	conn, err := a.transport.Start(ctx, spec)
+	if err != nil {
+		cleanupPreparedLaunch(cleanup)
 		a.logHermesStartupDiagnostics("process_start.failed", map[string]any{
 			"room_id":          session.RoomID,
 			"agent_session_id": session.AgentSessionID,
@@ -920,6 +1000,7 @@ func (a *standardACPAdapter) startInitializedClient(
 		})
 		return nil, nil, err
 	}
+	conn = wrapProviderLaunchCleanup(conn, cleanup)
 	a.logHermesStartupDiagnostics("process_start.succeeded", map[string]any{
 		"room_id":          session.RoomID,
 		"agent_session_id": session.AgentSessionID,
@@ -3736,6 +3817,20 @@ func appendTuttiMentionRoutingPrompt(content []map[string]any, skills []string) 
 	out = append(out, map[string]any{
 		"type": "text",
 		"text": routingPrompt,
+	})
+	return out
+}
+
+func appendTuttiMentionRoutingContent(content []PromptContentBlock, skills []string) []PromptContentBlock {
+	routingPrompt := strings.TrimSpace(tuttiMentionRoutingPrompt(skills))
+	if routingPrompt == "" {
+		return content
+	}
+	out := make([]PromptContentBlock, 0, len(content)+1)
+	out = append(out, content...)
+	out = append(out, PromptContentBlock{
+		Type: "text",
+		Text: routingPrompt,
 	})
 	return out
 }

--- a/packages/agent/daemon/runtime/standard_acp_adapter_test.go
+++ b/packages/agent/daemon/runtime/standard_acp_adapter_test.go
@@ -58,6 +58,100 @@ func TestGeminiAdapterStartCreatesStandardACPSession(t *testing.T) {
 	}
 }
 
+func TestStandardACPAdapterProviderLaunchPrepareMutatesSpecAndCleansUpOnClose(t *testing.T) {
+	t.Parallel()
+
+	transport := newStandardACPTransport("Gemini CLI", "gemini-session-1")
+	adapter := NewGeminiAdapter(transport)
+	cleanupCalls := 0
+	adapter.SetProviderLaunchPreparer(func(_ context.Context, input ProviderLaunchPrepareInput) (ProviderLaunchPrepareResult, error) {
+		if input.Provider != ProviderGemini {
+			t.Fatalf("Provider = %q, want %q", input.Provider, ProviderGemini)
+		}
+		if input.DirectStart {
+			t.Fatal("DirectStart = true, want false for Gemini")
+		}
+		return ProviderLaunchPrepareResult{
+			Command: []string{"prepared-gemini", "--acp"},
+			Env:     append(append([]string(nil), input.Env...), "HOOK_ENV=1"),
+			CWD:     "/prepared/gemini",
+			Cleanup: func(context.Context) error {
+				cleanupCalls++
+				return nil
+			},
+		}, nil
+	})
+	session := standardTestSession(ProviderGemini)
+	session.Env = []string{"SESSION_ENV=1"}
+
+	if _, err := adapter.Start(context.Background(), session); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	if cleanupCalls != 0 {
+		t.Fatalf("cleanup calls before close = %d, want 0", cleanupCalls)
+	}
+	transport.mu.Lock()
+	specs := append([]ProcessSpec(nil), transport.specs...)
+	transport.mu.Unlock()
+	if len(specs) != 1 {
+		t.Fatalf("transport starts = %d, want 1", len(specs))
+	}
+	spec := specs[0]
+	if !reflect.DeepEqual(spec.Command, []string{"prepared-gemini", "--acp"}) {
+		t.Fatalf("Command = %#v", spec.Command)
+	}
+	if spec.CWD != "/prepared/gemini" {
+		t.Fatalf("CWD = %q", spec.CWD)
+	}
+	if !reflect.DeepEqual(spec.Env[len(spec.Env)-2:], []string{"SESSION_ENV=1", "HOOK_ENV=1"}) {
+		t.Fatalf("Env tail = %#v", spec.Env)
+	}
+
+	if err := adapter.Close(context.Background(), session); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+	if cleanupCalls != 1 {
+		t.Fatalf("cleanup calls after close = %d, want 1", cleanupCalls)
+	}
+}
+
+func TestStandardACPAdapterConcurrentStartsLeaveSingleLiveProcess(t *testing.T) {
+	t.Parallel()
+
+	transport := &multiProcStandardACPTransport{
+		agentTitle: "Gemini CLI",
+		sessionID:  "gemini-session-1",
+	}
+	adapter := NewGeminiAdapter(transport)
+	session := standardTestSession(ProviderGemini)
+
+	var wg sync.WaitGroup
+	errs := make([]error, 2)
+	for i := range errs {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			_, errs[i] = adapter.Start(context.Background(), session)
+		}(i)
+	}
+	wg.Wait()
+	for i, err := range errs {
+		if err != nil {
+			t.Fatalf("Start[%d]: %v", i, err)
+		}
+	}
+	spawned, live := transport.snapshot()
+	if spawned != 2 {
+		t.Fatalf("spawned processes = %d, want 2", spawned)
+	}
+	if len(live) != 1 {
+		t.Fatalf("live ACP processes = %d, want exactly 1", len(live))
+	}
+	if !adapter.HasLiveSession(session) {
+		t.Fatal("HasLiveSession = false, want true after concurrent starts")
+	}
+}
+
 func TestClaudeCodeAdapterStartUsesInjectedProviderCommand(t *testing.T) {
 	t.Parallel()
 
@@ -4045,6 +4139,14 @@ type standardACPTransport struct {
 	conn  *standardACPConnection
 }
 
+type multiProcStandardACPTransport struct {
+	mu         sync.Mutex
+	agentTitle string
+	sessionID  string
+	specs      []ProcessSpec
+	conns      []*standardACPConnection
+}
+
 func newStandardACPTransport(agentTitle string, sessionID string) *standardACPTransport {
 	return &standardACPTransport{
 		conn: &standardACPConnection{
@@ -4060,6 +4162,34 @@ func (t *standardACPTransport) Start(_ context.Context, spec ProcessSpec) (Proce
 	t.specs = append(t.specs, spec)
 	t.mu.Unlock()
 	return t.conn, nil
+}
+
+func (t *multiProcStandardACPTransport) Start(_ context.Context, spec ProcessSpec) (ProcessConnection, error) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	conn := &standardACPConnection{
+		recv:       make(chan ProcessFrame, 32),
+		agentTitle: t.agentTitle,
+		sessionID:  t.sessionID,
+	}
+	t.specs = append(t.specs, spec)
+	t.conns = append(t.conns, conn)
+	return conn, nil
+}
+
+func (t *multiProcStandardACPTransport) snapshot() (spawned int, live []*standardACPConnection) {
+	t.mu.Lock()
+	conns := append([]*standardACPConnection(nil), t.conns...)
+	t.mu.Unlock()
+	for _, conn := range conns {
+		conn.mu.Lock()
+		closed := conn.isClosed
+		conn.mu.Unlock()
+		if !closed {
+			live = append(live, conn)
+		}
+	}
+	return len(conns), live
 }
 
 type standardACPConnection struct {

--- a/packages/agent/daemon/runtime_test.go
+++ b/packages/agent/daemon/runtime_test.go
@@ -70,6 +70,26 @@ func TestNewRuntimeUsesCustomAdapters(t *testing.T) {
 	}
 }
 
+func TestNewRuntimeAppliesProviderLaunchPreparerToCustomAdapters(t *testing.T) {
+	t.Parallel()
+
+	adapter := &providerLaunchPreparerTestAdapter{
+		testAdapter: testAdapter{provider: "test-agent"},
+	}
+	_, err := NewRuntime(Config{
+		Adapters: []agentruntime.Adapter{adapter},
+		ProviderLaunchPreparer: func(context.Context, agentruntime.ProviderLaunchPrepareInput) (agentruntime.ProviderLaunchPrepareResult, error) {
+			return agentruntime.ProviderLaunchPrepareResult{}, nil
+		},
+	})
+	if err != nil {
+		t.Fatalf("NewRuntime() error = %v", err)
+	}
+	if adapter.preparer == nil {
+		t.Fatal("custom adapter did not receive ProviderLaunchPreparer")
+	}
+}
+
 func TestNewRuntimeCanDisableLiveSessionReaper(t *testing.T) {
 	t.Parallel()
 
@@ -105,6 +125,15 @@ func testHostMetadata() HostMetadata {
 
 type testAdapter struct {
 	provider string
+}
+
+type providerLaunchPreparerTestAdapter struct {
+	testAdapter
+	preparer agentruntime.ProviderLaunchPreparer
+}
+
+func (a *providerLaunchPreparerTestAdapter) SetProviderLaunchPreparer(preparer agentruntime.ProviderLaunchPreparer) {
+	a.preparer = preparer
 }
 
 func (a testAdapter) Provider() string {


### PR DESCRIPTION
## Summary
- add ProviderLaunchPreparer to agent runtime and facade config, including custom adapter support
- run provider launch prepare before Codex app-server, standard ACP, and Claude SDK process starts with cleanup on start/init/close/replacement
- document the provider launch prepare lifecycle for adapter integrations

## Validation
- go test ./packages/agent/daemon/runtime ./packages/agent/daemon -count=1
- git diff --check
- pnpm lint:go
- pre-push pnpm check:full was rerun but the local hook failed on lint:go while the same lint:go command passed standalone