### PR TITLE
[codex] fix AgentGUI handoff provider targets

### DIFF
--- a/docs/architecture/agent-gui-node.md
+++ b/docs/architecture/agent-gui-node.md
@@ -170,7 +170,10 @@ select with a handoff affordance. Handoff is a workbench launch, not an
 in-session provider switch: AgentGUI serializes the active session as a single
 `agent-session` mention in a draft prompt, passes the selected provider target
 through the host launch callback, and the desktop workbench opens a new empty
-composer for that target via the existing draft prefill activation path.
+composer for that target via the existing draft prefill activation path. The
+prefill activation provider is authoritative for the new workbench panel's
+initial provider chrome, so choosing Codex from a Claude Code session must open
+a Codex panel before the draft prefill effect runs.
 When provider selection happens from the empty-home composer or title control
 while the rail is already scoped to a provider target in multi-provider scope,
 it must update the rail conversation filter to the matching agent target so the
@@ -192,6 +195,10 @@ launch preparation.
 UI affordances that aggregate across providers, such as rail provider filters
 and composer provider switching, are always part of the unified AgentGUI
 surface and do not belong to durable AgentGUI node data.
+Provider rail containers and tiles are interactive workbench chrome: they must
+explicitly release host/window drag regions with `nodrag` and
+`-webkit-app-region: no-drag`, otherwise clicks near the window edge can be
+captured as drag gestures before AgentGUI sees the provider filter action.
 Provider-scoped rail footer affordances, such as usage limits and environment
 setup, follow the rail's active provider filter target in multi-provider scope;
 when the rail filter is `All`, they should stay hidden because there is no
@@ -808,9 +815,11 @@ User-visible rules:
   desktop default provider, or composer-default preferences. All-filter clicks
   must only clear the `agentTargetId` constraint. Provider target rail clicks
   may update the home composer launch target only when there is no active
-  conversation; active conversations keep owning their displayed target. React
-  view components must not dispatch separate filter and home-composer target
-  actions for one rail click.
+  conversation; active conversations keep owning their displayed target until
+  the target-filtered list initializes. If that target list is empty, AgentGUI
+  should unactivate the current conversation and show the selected target's
+  new-conversation empty composer. React view components must not dispatch
+  separate filter and home-composer target actions for one rail click.
   Apply them only for multi-provider conversation scopes. Single-provider
   panels should let the node provider constrain the query and collapse target
   filter actions back to All in the controller.
@@ -1237,13 +1246,14 @@ AgentGUI so Codex and Claude Code can use service-backed agent targets. An empty
 snapshot still resolves to omitted `providerTargets`, letting AgentGUI preserve
 the static catalog for picker/display compatibility instead of hiding the rail.
 Future providers in the static provider catalog, such as Tutti, Hermes, and
-OpenClaw, must render as disabled/coming-soon targets rather than clickable
-launch targets until their real `/agents` targets are supported.
+OpenClaw, must render as selectable disabled/coming-soon targets: provider rail
+clicks may select their empty composer state, but launch/send controls stay
+disabled until their real `/agents` targets are supported.
 Static catalog targets do not change the legacy activation contract: AgentGUI
-does not persist or send their `providerTargetRef`. For system local Codex and
-Claude Code targets, the synthesized targets may expose `local:codex` and
-`local:claude-code` as `agentTargetId`, matching the legacy local
-`providerTargetId` format so old node state can fall back without remapping.
+does not persist or send their `providerTargetRef`. Synthesized local targets
+may expose stable `local:<provider>` values as `agentTargetId`, including
+coming-soon placeholders, so the conversation rail can scope to an empty
+provider-specific list without falling back to All.
 
 ### Conversation Projection
 

--- a/packages/agent/gui/agent-gui/agentGuiNode/AgentComposer.spec.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/AgentComposer.spec.tsx
@@ -1150,6 +1150,160 @@ describe("AgentComposer", () => {
     expect(onHandoffConversation).toHaveBeenCalledWith(claudeTarget);
   });
 
+  it("marks the handoff icon disabled with the handoff trigger", () => {
+    const codexTarget = {
+      targetId: "local:codex",
+      agentTargetId: "local:codex",
+      provider: "codex" as const,
+      ref: { kind: "local-provider", provider: "codex" as const },
+      label: "Codex"
+    };
+    const claudeTarget = {
+      targetId: "local:claude-code",
+      agentTargetId: "local:claude-code",
+      provider: "claude-code" as const,
+      ref: { kind: "local-provider", provider: "claude-code" as const },
+      label: "Claude Code"
+    };
+
+    render(
+      <AgentComposer
+        workspaceId="workspace-1"
+        currentUserId="user-1"
+        provider="codex"
+        selectedProviderTarget={codexTarget}
+        providerTargets={[codexTarget, claudeTarget]}
+        providerSelectReadonly
+        draftContent={createDraft("")}
+        availableCommands={[] satisfies readonly AgentHostAgentSessionCommand[]}
+        disabled={false}
+        submitDisabled={false}
+        placeholder="placeholder"
+        composerSettings={createComposerSettings()}
+        queuedPrompts={[]}
+        drainingQueuedPromptId={null}
+        canQueueWhileBusy={false}
+        showStopButton={false}
+        activePrompt={null}
+        isInterrupting={false}
+        isSendingTurn={false}
+        isSubmittingPrompt={false}
+        labels={createLabels()}
+        workspaceUserProjectI18n={workspaceUserProjectI18n}
+        onDraftContentChange={vi.fn()}
+        onSettingsChange={vi.fn()}
+        onSubmit={vi.fn()}
+        onSendQueuedPromptNext={vi.fn()}
+        onRemoveQueuedPrompt={vi.fn()}
+        onEditQueuedPrompt={vi.fn()}
+        onInterruptCurrentTurn={vi.fn()}
+        onSubmitInteractivePrompt={vi.fn()}
+      />
+    );
+
+    const handoffTrigger = screen.getByRole("combobox", { name: "Handoff" });
+    const handoffIcon = handoffTrigger.querySelector(
+      ".agent-gui-node__composer-handoff-icon"
+    );
+
+    expect(handoffTrigger).toBeDisabled();
+    expect(handoffIcon).toHaveAttribute("data-disabled", "true");
+  });
+
+  it("omits disabled targets from the provider switch menu", async () => {
+    const codexTarget = {
+      targetId: "local:codex",
+      agentTargetId: "local:codex",
+      provider: "codex" as const,
+      ref: { kind: "local-provider", provider: "codex" as const },
+      label: "Codex"
+    };
+    const claudeTarget = {
+      targetId: "local:claude-code",
+      agentTargetId: "local:claude-code",
+      provider: "claude-code" as const,
+      ref: { kind: "local-provider", provider: "claude-code" as const },
+      label: "Claude Code"
+    };
+    const disabledTargets = [
+      {
+        targetId: "local:tutti",
+        agentTargetId: "local:tutti",
+        provider: "nexight" as const,
+        ref: { kind: "local-provider", provider: "nexight" as const },
+        label: "Tutti Agent",
+        disabled: true
+      },
+      {
+        targetId: "local:hermes",
+        agentTargetId: "local:hermes",
+        provider: "hermes" as const,
+        ref: { kind: "local-provider", provider: "hermes" as const },
+        label: "Hermes",
+        disabled: true
+      },
+      {
+        targetId: "local:openclaw",
+        agentTargetId: "local:openclaw",
+        provider: "openclaw" as const,
+        ref: { kind: "local-provider", provider: "openclaw" as const },
+        label: "OpenClaw",
+        disabled: true
+      }
+    ];
+
+    render(
+      <AgentComposer
+        workspaceId="workspace-1"
+        currentUserId="user-1"
+        provider="claude-code"
+        selectedProviderTarget={claudeTarget}
+        providerTargets={[codexTarget, claudeTarget, ...disabledTargets]}
+        providerSelectLabel="切换 Provider"
+        draftContent={createDraft("")}
+        availableCommands={[] satisfies readonly AgentHostAgentSessionCommand[]}
+        disabled={false}
+        submitDisabled={false}
+        placeholder="placeholder"
+        composerSettings={createComposerSettings()}
+        queuedPrompts={[]}
+        drainingQueuedPromptId={null}
+        canQueueWhileBusy={false}
+        showStopButton={false}
+        activePrompt={null}
+        isInterrupting={false}
+        isSendingTurn={false}
+        isSubmittingPrompt={false}
+        labels={createLabels()}
+        workspaceUserProjectI18n={workspaceUserProjectI18n}
+        onDraftContentChange={vi.fn()}
+        onSettingsChange={vi.fn()}
+        onSubmit={vi.fn()}
+        onSendQueuedPromptNext={vi.fn()}
+        onRemoveQueuedPrompt={vi.fn()}
+        onEditQueuedPrompt={vi.fn()}
+        onInterruptCurrentTurn={vi.fn()}
+        onSubmitInteractivePrompt={vi.fn()}
+      />
+    );
+
+    fireEvent.keyDown(screen.getByRole("combobox", { name: "切换 Provider" }), {
+      key: "ArrowDown"
+    });
+
+    expect(await screen.findByRole("option", { name: "Codex" })).toBeVisible();
+    expect(screen.getByRole("option", { name: "Claude Code" })).toBeVisible();
+    expect(
+      screen.queryByRole("option", { name: "Tutti Agent" })
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("option", { name: "Hermes" })
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("option", { name: "OpenClaw" })
+    ).not.toBeInTheDocument();
+  });
+
   it("matches the browser-use slash capability by its English alias", async () => {
     render(
       <AgentComposer

--- a/packages/agent/gui/agent-gui/agentGuiNode/AgentComposer.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/AgentComposer.tsx
@@ -8,6 +8,7 @@ import {
   type CSSProperties,
   type FocusEvent as ReactFocusEvent,
   type FormEvent,
+  type HTMLAttributes,
   type JSX
 } from "react";
 import { createPortal, flushSync } from "react-dom";
@@ -166,7 +167,25 @@ import type { AgentGUIProvider, AgentGUIProviderTarget } from "../../types";
 
 export { formatSlashStatusTokenCount };
 
+type DotLottieElementProps = HTMLAttributes<HTMLElement> & {
+  autoplay?: boolean;
+  loop?: boolean;
+  src?: string;
+};
+
+declare module "react" {
+  namespace JSX {
+    interface IntrinsicElements {
+      "dotlottie-wc": DotLottieElementProps;
+    }
+  }
+}
+
 const USAGE_POPOVER_HOVER_DELAY_MS = 120;
+const HANDOFF_LOTTIE_PLAYER_SCRIPT_SRC =
+  "https://unpkg.com/@lottiefiles/dotlottie-wc@0.9.14/dist/dotlottie-wc.js";
+const HANDOFF_LOTTIE_ANIMATION_SRC =
+  "https://lottie.host/03d75946-52e5-4ccf-97df-174919a13ced/Av6piqVmPa.lottie";
 const DOCK_COMPOSER_INPUT_MIN_HEIGHT = 56;
 const DOCK_COMPOSER_TEXT_LINE_HEIGHT = 24;
 const DOCK_COMPOSER_MAX_VISIBLE_TEXT_LINES = 3.5;
@@ -862,9 +881,76 @@ function AgentComposerMaskIcon({
 
 const HANDOFF_SELECT_IDLE_VALUE = "__agent-handoff-idle__";
 
-function AgentComposerHandoffIcon(): JSX.Element {
+let handoffLottiePlayerLoadPromise: Promise<boolean> | null = null;
+
+function loadHandoffLottiePlayer(): Promise<boolean> {
+  if (typeof window === "undefined" || typeof document === "undefined") {
+    return Promise.resolve(false);
+  }
+  if (window.customElements?.get("dotlottie-wc")) {
+    return Promise.resolve(true);
+  }
+  if (handoffLottiePlayerLoadPromise) {
+    return handoffLottiePlayerLoadPromise;
+  }
+
+  handoffLottiePlayerLoadPromise = new Promise((resolve) => {
+    const existingScript = document.querySelector<HTMLScriptElement>(
+      'script[data-agent-gui-handoff-lottie="true"]'
+    );
+    const script = existingScript ?? document.createElement("script");
+
+    const handleLoad = () => {
+      resolve(Boolean(window.customElements?.get("dotlottie-wc")));
+    };
+    const handleError = () => {
+      resolve(false);
+    };
+
+    script.addEventListener("load", handleLoad, { once: true });
+    script.addEventListener("error", handleError, { once: true });
+
+    if (!existingScript) {
+      script.dataset.agentGuiHandoffLottie = "true";
+      script.src = HANDOFF_LOTTIE_PLAYER_SCRIPT_SRC;
+      script.type = "module";
+      document.head.append(script);
+    }
+  });
+
+  return handoffLottiePlayerLoadPromise;
+}
+
+function AgentComposerHandoffIcon({
+  disabled,
+  isPlaying
+}: {
+  disabled: boolean;
+  isPlaying: boolean;
+}): JSX.Element {
+  const [isLottieReady, setIsLottieReady] = useState(false);
+
+  useEffect(() => {
+    let isMounted = true;
+    void loadHandoffLottiePlayer().then((isReady) => {
+      if (isMounted) {
+        setIsLottieReady(isReady);
+      }
+    });
+    return () => {
+      isMounted = false;
+    };
+  }, []);
+
+  const shouldShowAnimation = !disabled && isPlaying && isLottieReady;
+
   return (
-    <span aria-hidden="true" className={styles.composerHandoffIcon}>
+    <span
+      aria-hidden="true"
+      className={styles.composerHandoffIcon}
+      data-disabled={disabled ? "true" : undefined}
+      data-playing={shouldShowAnimation ? "true" : undefined}
+    >
       <span
         className={styles.composerHandoffStaticIcon}
         style={{
@@ -877,6 +963,13 @@ function AgentComposerHandoffIcon(): JSX.Element {
           maskRepeat: "no-repeat",
           maskSize: "contain"
         }}
+      />
+      <dotlottie-wc
+        autoplay
+        className={styles.composerHandoffAnimatedIcon}
+        data-active={shouldShowAnimation ? "true" : undefined}
+        loop
+        src={HANDOFF_LOTTIE_ANIMATION_SRC}
       />
     </span>
   );
@@ -967,6 +1060,7 @@ export function AgentComposer({
   );
   const [isPaletteOpen, setIsPaletteOpen] = useState(true);
   const [isReviewPickerOpen, setIsReviewPickerOpen] = useState(false);
+  const [isHandoffIconPlaying, setIsHandoffIconPlaying] = useState(false);
   const [highlightedIndex, setHighlightedIndex] = useState(0);
   const [mentionHighlightedKey, setMentionHighlightedKey] = useState<
     string | null
@@ -2420,6 +2514,10 @@ export function AgentComposer({
     () => providerTargets.filter(Boolean),
     [providerTargets]
   );
+  const enabledProviderSwitchTargets = useMemo(
+    () => providerSwitchTargets.filter((target) => target.disabled !== true),
+    [providerSwitchTargets]
+  );
   const selectedProviderTargetId =
     selectedProviderTarget?.targetId ?? `local:${provider}`;
   const selectedProviderSwitchTarget =
@@ -2430,11 +2528,11 @@ export function AgentComposer({
     selectedProviderTarget;
   const providerMenuTargets =
     selectedProviderSwitchTarget &&
-    !providerSwitchTargets.some(
+    !enabledProviderSwitchTargets.some(
       (target) => target.targetId === selectedProviderSwitchTarget.targetId
     )
-      ? [selectedProviderSwitchTarget, ...providerSwitchTargets]
-      : providerSwitchTargets;
+      ? [selectedProviderSwitchTarget, ...enabledProviderSwitchTargets]
+      : enabledProviderSwitchTargets;
   const handoffMenuTargets = selectedProviderSwitchTarget
     ? providerMenuTargets.filter((target) => {
         if (target.disabled === true) {
@@ -3503,6 +3601,18 @@ export function AgentComposer({
                     size="sm"
                     aria-label={effectiveHandoffLabel}
                     title={effectiveHandoffLabel}
+                    onBlur={() => {
+                      setIsHandoffIconPlaying(false);
+                    }}
+                    onFocus={() => {
+                      setIsHandoffIconPlaying(true);
+                    }}
+                    onMouseEnter={() => {
+                      setIsHandoffIconPlaying(true);
+                    }}
+                    onMouseLeave={() => {
+                      setIsHandoffIconPlaying(false);
+                    }}
                     className={cn(
                       styles.composerMenuTrigger,
                       styles.composerProviderSelect,
@@ -3511,7 +3621,10 @@ export function AgentComposer({
                     )}
                   >
                     <span className="flex min-w-0 items-center gap-1.5">
-                      <AgentComposerHandoffIcon />
+                      <AgentComposerHandoffIcon
+                        disabled={handoffDisabled}
+                        isPlaying={isHandoffIconPlaying}
+                      />
                       <span className="min-w-0 truncate">
                         {effectiveHandoffLabel}
                       </span>

--- a/packages/agent/gui/agent-gui/agentGuiNode/AgentGUINode.styles.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/AgentGUINode.styles.ts
@@ -12,6 +12,7 @@ const styles = {
   composerHero: "agent-gui-node__composer-hero",
   composerFloatingPrompt: "agent-gui-node__composer-floating-prompt",
   composerHandoffIcon: "agent-gui-node__composer-handoff-icon",
+  composerHandoffAnimatedIcon: "agent-gui-node__composer-handoff-icon-animated",
   composerHandoffMenuContent: "agent-gui-node__composer-handoff-menu-content",
   composerHandoffStaticIcon: "agent-gui-node__composer-handoff-icon-static",
   composerHandoffTrigger: "agent-gui-node__composer-handoff-trigger",

--- a/packages/agent/gui/agent-gui/agentGuiNode/AgentGUINodeView.layout.spec.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/AgentGUINodeView.layout.spec.tsx
@@ -200,6 +200,8 @@ describe("AgentGUINodeView layout persistence", () => {
       ".agent-gui-node__provider-rail-panel"
     );
     expect(providerRailPanel).not.toBeNull();
+    expect(providerRailPanel).toHaveClass("nodrag");
+    expect(providerRailPanel).toHaveClass("tsh-desktop-no-drag");
     expect(providerRailPanel).toContainElement(
       container.querySelector('[role="tablist"]')
     );
@@ -256,6 +258,15 @@ describe("AgentGUINodeView layout persistence", () => {
 
     expect(css).toMatch(
       /\.agent-gui-node__provider-rail-tile\s*\{[^}]*grid-template-rows:\s*32px;[^}]*gap:\s*0;[^}]*padding:\s*0;/s
+    );
+    expect(css).toMatch(
+      /\.agent-gui-node__provider-rail-panel\s*\{[^}]*-webkit-app-region:\s*no-drag;/s
+    );
+    expect(css).toMatch(
+      /\.agent-gui-node__provider-rail\s*\{[^}]*-webkit-app-region:\s*no-drag;/s
+    );
+    expect(css).toMatch(
+      /\.agent-gui-node__provider-rail-tile\s*\{[^}]*-webkit-app-region:\s*no-drag;/s
     );
     expect(css).toMatch(
       /\.agent-gui-node__provider-rail-tile\s*\+\s*\.agent-gui-node__provider-rail-tile\s*\{[^}]*margin-top:\s*12px;/s
@@ -498,7 +509,7 @@ describe("AgentGUINodeView layout persistence", () => {
     expect(actions.selectHomeComposerAgentTarget).not.toHaveBeenCalled();
   });
 
-  it("keeps unavailable provider rail targets disabled and non-selectable", () => {
+  it("keeps unavailable provider rail targets visually disabled but selectable", () => {
     const actions = createActions();
     const tuttiTarget = {
       ...createLocalAgentGUIProviderTarget("nexight"),
@@ -533,15 +544,27 @@ describe("AgentGUINodeView layout persistence", () => {
     expect(tuttiTile).toHaveAttribute("data-disabled", "true");
     expect(hermesTile).toHaveAttribute("data-disabled", "true");
     expect(openclawTile).toHaveAttribute("data-disabled", "true");
-    expect(tuttiTile).toBeDisabled();
-    expect(hermesTile).toBeDisabled();
-    expect(openclawTile).toBeDisabled();
+    expect(tuttiTile).not.toBeDisabled();
+    expect(hermesTile).not.toBeDisabled();
+    expect(openclawTile).not.toBeDisabled();
 
     fireEvent.click(tuttiTile);
     fireEvent.click(hermesTile);
     fireEvent.click(openclawTile);
 
-    expect(actions.selectConversationFilterTarget).not.toHaveBeenCalled();
+    expect(actions.selectConversationFilterTarget).toHaveBeenCalledTimes(3);
+    expect(actions.selectConversationFilterTarget).toHaveBeenNthCalledWith(1, {
+      provider: "nexight",
+      providerTargetId: tuttiTarget.targetId
+    });
+    expect(actions.selectConversationFilterTarget).toHaveBeenNthCalledWith(2, {
+      provider: "hermes",
+      providerTargetId: hermesTarget.targetId
+    });
+    expect(actions.selectConversationFilterTarget).toHaveBeenNthCalledWith(3, {
+      provider: "openclaw",
+      providerTargetId: openclawTarget.targetId
+    });
     expect(actions.updateConversationFilter).not.toHaveBeenCalled();
     expect(actions.selectHomeComposerAgentTarget).not.toHaveBeenCalled();
   });
@@ -860,7 +883,7 @@ describe("AgentGUINodeView layout persistence", () => {
     );
   });
 
-  it("dims disabled provider options in the empty hero provider select", async () => {
+  it("omits disabled provider options in the empty hero provider select", async () => {
     const actions = createActions();
     const disabledTuttiTarget = {
       ...createLocalAgentGUIProviderTarget("nexight"),
@@ -899,18 +922,14 @@ describe("AgentGUINodeView layout persistence", () => {
     });
     fireEvent.keyDown(providerSelect, { key: "ArrowDown" });
 
-    const tuttiOption = await screen.findByRole("option", {
-      name: "Tutti Agent"
-    });
-    const hermesOption = screen.getByRole("option", { name: "Hermes" });
-
-    expect(tuttiOption).toHaveAttribute("data-disabled");
-    expect(tuttiOption).toHaveClass("opacity-30");
-    expect(tuttiOption.querySelector("img")).toHaveClass("grayscale");
-    expect(hermesOption).toHaveAttribute("data-disabled");
-    expect(hermesOption).toHaveClass("opacity-30");
-
-    fireEvent.click(tuttiOption);
+    expect(await screen.findByRole("option", { name: "Codex" })).toBeVisible();
+    expect(screen.getByRole("option", { name: "Claude Code" })).toBeVisible();
+    expect(
+      screen.queryByRole("option", { name: "Tutti Agent" })
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("option", { name: "Hermes" })
+    ).not.toBeInTheDocument();
 
     expect(actions.selectHomeComposerAgentTarget).not.toHaveBeenCalled();
   });
@@ -980,9 +999,9 @@ describe("AgentGUINodeView layout persistence", () => {
     expect(screen.getByRole("tab", { name: "Tutti" })).toBeInTheDocument();
     expect(screen.getByRole("tab", { name: "Hermes" })).toBeInTheDocument();
     expect(screen.getByRole("tab", { name: "OpenClaw" })).toBeInTheDocument();
-    expect(screen.getByRole("tab", { name: "Tutti" })).toBeDisabled();
-    expect(screen.getByRole("tab", { name: "Hermes" })).toBeDisabled();
-    expect(screen.getByRole("tab", { name: "OpenClaw" })).toBeDisabled();
+    expect(screen.getByRole("tab", { name: "Tutti" })).not.toBeDisabled();
+    expect(screen.getByRole("tab", { name: "Hermes" })).not.toBeDisabled();
+    expect(screen.getByRole("tab", { name: "OpenClaw" })).not.toBeDisabled();
     expect(
       screen.getAllByRole("tab").map((tab) => tab.getAttribute("aria-label"))
     ).toEqual(["All", "Codex", "Claude Code", "Tutti", "Hermes", "OpenClaw"]);
@@ -3343,6 +3362,42 @@ describe("AgentGUINodeView provider readiness gate", () => {
     fireEvent.click(action);
 
     expect(onAction).toHaveBeenCalledWith("codex", "login");
+  });
+
+  it("renders a disabled action for placeholder provider targets", () => {
+    const tuttiTarget = {
+      ...createLocalAgentGUIProviderTarget("nexight"),
+      disabled: true
+    };
+    renderAgentGUINodeView({
+      viewModel: createViewModel({
+        data: {
+          provider: "nexight",
+          agentTargetId: tuttiTarget.agentTargetId,
+          lastActiveAgentSessionId: null,
+          conversationRailWidthPx: null
+        },
+        conversationFilter: {
+          kind: "agentTarget",
+          agentTargetId: tuttiTarget.agentTargetId ?? ""
+        },
+        selectedProviderTarget: tuttiTarget,
+        providerTargets: [
+          createLocalAgentGUIProviderTarget("codex"),
+          tuttiTarget
+        ]
+      })
+    });
+
+    expect(
+      screen.getByTestId("agent-gui-provider-readiness-gate")
+    ).toHaveTextContent("providerGateComingSoonTitle");
+    const action = screen.getByTestId(
+      "agent-gui-provider-readiness-gate-action"
+    );
+    expect(action).toHaveTextContent("providerGateComingSoonAction");
+    expect(action).toBeDisabled();
+    expect(screen.queryByTestId("agent-composer")).toBeNull();
   });
 
   it("renders the aggregate agents checking gate when the All tab is active", () => {

--- a/packages/agent/gui/agent-gui/agentGuiNode/AgentGUINodeView.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/AgentGUINodeView.tsx
@@ -1562,7 +1562,7 @@ export function AgentGUINodeView({
       >
         {showProviderRail ? (
           <aside
-            className={styles.providerRailPanel}
+            className={`${styles.providerRailPanel} nodrag tsh-desktop-no-drag`}
             aria-label={labels.providerSwitchLabel}
             aria-hidden={conversationRailCollapsed ? "true" : undefined}
             inert={conversationRailCollapsed ? true : undefined}
@@ -3646,8 +3646,13 @@ function EmptyHeroTitle({
   const selectedProviderTargetId =
     selectedProviderTarget?.targetId ??
     `local:${selectedProviderTarget?.provider ?? ""}`;
+  const enabledProviderTargets = providerTargets.filter(
+    (target) => target.disabled !== true
+  );
   const canSwitchProvider =
-    providerTargets.length > 1 && selectedProviderTarget && onProviderSelect;
+    enabledProviderTargets.length > 1 &&
+    selectedProviderTarget &&
+    onProviderSelect;
   const providerName = label.slice(providerStart, providerEnd);
 
   return (
@@ -3657,10 +3662,10 @@ function EmptyHeroTitle({
         <Select
           value={selectedProviderTargetId}
           onValueChange={(nextTargetId) => {
-            const target = providerTargets.find(
+            const target = enabledProviderTargets.find(
               (candidate) => candidate.targetId === nextTargetId
             );
-            if (!target || target.disabled === true) {
+            if (!target) {
               return;
             }
             onProviderSelect({
@@ -3681,27 +3686,17 @@ function EmptyHeroTitle({
             align="center"
             className={cn(styles.composerMenuContent, "min-w-[190px]")}
           >
-            {providerTargets.map((target) => (
+            {enabledProviderTargets.map((target) => (
               <SelectItem
                 key={`${target.provider}:${target.targetId}`}
                 value={target.targetId}
-                className={cn(
-                  styles.composerMenuItem,
-                  "gap-2 data-[disabled]:cursor-not-allowed data-[disabled]:opacity-30 data-[disabled]:text-[var(--text-disabled,var(--text-tertiary))]",
-                  target.disabled === true
-                    ? "cursor-not-allowed opacity-30"
-                    : null
-                )}
-                disabled={target.disabled === true}
+                className={cn(styles.composerMenuItem, "gap-2")}
               >
                 <span className="flex min-w-0 items-center gap-1.5">
                   <img
                     alt=""
                     aria-hidden="true"
-                    className={cn(
-                      "size-4 shrink-0 rounded-[4px]",
-                      target.disabled === true ? "grayscale opacity-30" : null
-                    )}
+                    className="size-4 shrink-0 rounded-[4px]"
                     src={
                       agentGUIProviderIconPresentation(
                         target.provider,
@@ -3709,16 +3704,7 @@ function EmptyHeroTitle({
                       ).iconUrl
                     }
                   />
-                  <span
-                    className={cn(
-                      "min-w-0 truncate",
-                      target.disabled === true
-                        ? "text-[var(--text-disabled,var(--text-tertiary))]"
-                        : null
-                    )}
-                  >
-                    {target.label}
-                  </span>
+                  <span className="min-w-0 truncate">{target.label}</span>
                 </span>
               </SelectItem>
             ))}
@@ -4668,7 +4654,7 @@ const AgentGUIProviderRail = memo(function AgentGUIProviderRail({
             data-disabled={target.disabled === true ? "true" : undefined}
             data-provider-tile="true"
             data-selected={providerSelected ? "true" : "false"}
-            disabled={previewMode || target.disabled === true}
+            disabled={previewMode}
             onClick={() => selectAgentTargetTile(target)}
           >
             <span className={styles.providerRailAvatar}>

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUINodeController.spec.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUINodeController.spec.tsx
@@ -481,7 +481,118 @@ describe("useAgentGUINodeController", () => {
     expect(nextData?.providerTargetRef ?? null).toBeNull();
   });
 
-  it("keeps the active conversation when selecting a rail filter target", async () => {
+  it("resets the empty composer provider when switching the rail filter back to All", async () => {
+    installAgentHostApi({
+      list: vi.fn(async () => ({
+        presences: [],
+        sessions: [
+          workspaceAgentSession("codex-session", {
+            agentTargetId: "local:codex",
+            provider: "codex",
+            title: "Codex session",
+            updatedAtUnixMs: 3
+          }),
+          workspaceAgentSession("claude-session", {
+            agentTargetId: "local:claude-code",
+            provider: "claude-code",
+            title: "Claude session",
+            updatedAtUnixMs: 2
+          })
+        ]
+      })),
+      listSessionTimeline: vi.fn(async () => ({ timelineItems: [] })),
+      subscribeEvents: vi.fn(() => vi.fn())
+    });
+    const onDataChange = vi.fn();
+    const initialData = agentGuiData(null, "codex", {
+      agentTargetId: "local:codex"
+    });
+    let renderedData = initialData;
+
+    const { result, rerender } = renderHook(
+      ({ data }) =>
+        useAgentGUINodeController({
+          workspaceId: "room-1",
+          currentUserId: "user-1",
+          workspacePath: "/workspace",
+          avoidGroupingEdits: false,
+          data,
+          defaultProviderTargetId: "local:codex",
+          providerTargets: [
+            {
+              targetId: "local:codex",
+              agentTargetId: "local:codex",
+              provider: "codex",
+              ref: { kind: "local-provider", provider: "codex" },
+              label: "Codex"
+            },
+            {
+              targetId: "local:claude-code",
+              agentTargetId: "local:claude-code",
+              provider: "claude-code",
+              ref: { kind: "local-provider", provider: "claude-code" },
+              label: "Claude Code"
+            }
+          ],
+          providerReadinessGates: {
+            "claude-code": { status: "auth_required" }
+          },
+          onDataChange
+        }),
+      { initialProps: { data: renderedData } }
+    );
+
+    act(() => {
+      result.current.actions.selectConversationFilterTarget({
+        provider: "claude-code",
+        providerTargetId: "local:claude-code"
+      });
+    });
+
+    await waitFor(() => {
+      expect(result.current.viewModel.conversationFilter).toEqual({
+        kind: "agentTarget",
+        agentTargetId: "local:claude-code"
+      });
+    });
+    expect(result.current.viewModel.selectedProviderTarget.provider).toBe(
+      "claude-code"
+    );
+    expect(result.current.viewModel.providerReadinessGate?.status).toBe(
+      "auth_required"
+    );
+
+    renderedData = onDataChange.mock.calls.reduce(
+      (data, [updater]) => updater(data),
+      renderedData
+    );
+    rerender({ data: renderedData });
+    await waitFor(() => {
+      expect(result.current.viewModel.data.provider).toBe("claude-code");
+    });
+    onDataChange.mockClear();
+
+    act(() => {
+      result.current.actions.updateConversationFilter({ kind: "all" });
+    });
+
+    await waitFor(() => {
+      expect(result.current.viewModel.conversationFilter).toEqual({
+        kind: "all"
+      });
+    });
+    expect(result.current.viewModel.selectedProviderTarget.provider).toBe(
+      "codex"
+    );
+    expect(result.current.viewModel.data).toMatchObject({
+      provider: "codex",
+      agentTargetId: "local:codex",
+      lastActiveAgentSessionId: null
+    });
+    expect(result.current.viewModel.providerReadinessGate).toBeNull();
+  });
+
+  it("keeps the active conversation target stable while an empty rail target transition starts", async () => {
     const unactivate = vi.fn();
     installAgentHostApi({
       list: vi.fn(async () => ({
@@ -541,6 +652,7 @@ describe("useAgentGUINodeController", () => {
       expect(result.current.viewModel.activeConversationId).toBe(
         "codex-session"
       );
+      expect(result.current.viewModel.isLoadingConversations).toBe(false);
     });
     onDataChange.mockClear();
 
@@ -562,15 +674,110 @@ describe("useAgentGUINodeController", () => {
     expect(result.current.viewModel.selectedProviderTarget.provider).toBe(
       "codex"
     );
-    expect(unactivate).not.toHaveBeenCalled();
+    await waitFor(() => {
+      expect(unactivate).toHaveBeenCalledWith({
+        workspaceId: "room-1",
+        agentSessionId: "codex-session"
+      });
+    });
     const appliedData = onDataChange.mock.calls.reduce(
       (data, [updater]) => updater(data),
       initialData
     );
     expect(appliedData).toMatchObject({
-      provider: "codex",
-      agentTargetId: "local:codex",
-      lastActiveAgentSessionId: "codex-session"
+      provider: "claude-code",
+      agentTargetId: "local:claude-code",
+      lastActiveAgentSessionId: null
+    });
+  });
+
+  it("opens the target empty composer when an active conversation switches to an agent with no conversations", async () => {
+    const unactivate = vi.fn();
+    installAgentHostApi({
+      list: vi.fn(async () => ({
+        presences: [],
+        sessions: [
+          workspaceAgentSession("codex-session", {
+            agentTargetId: "local:codex",
+            provider: "codex",
+            title: "Codex session",
+            updatedAtUnixMs: 3
+          })
+        ]
+      })),
+      listSessionTimeline: vi.fn(async () => ({ timelineItems: [] })),
+      subscribeEvents: vi.fn(() => vi.fn()),
+      unactivate
+    });
+    const onDataChange = vi.fn();
+    const initialData = agentGuiData("codex-session", "codex", {
+      agentTargetId: "local:codex"
+    });
+
+    const { result } = renderHook(() =>
+      useAgentGUINodeController({
+        workspaceId: "room-1",
+        currentUserId: "user-1",
+        workspacePath: "/workspace",
+        avoidGroupingEdits: false,
+        data: initialData,
+        providerTargets: [
+          {
+            targetId: "local:codex",
+            agentTargetId: "local:codex",
+            provider: "codex",
+            ref: { kind: "local-provider", provider: "codex" },
+            label: "Codex"
+          },
+          {
+            targetId: "local:claude-code",
+            agentTargetId: "local:claude-code",
+            provider: "claude-code",
+            ref: { kind: "local-provider", provider: "claude-code" },
+            label: "Claude Code"
+          }
+        ],
+        onDataChange
+      })
+    );
+
+    await waitFor(() => {
+      expect(result.current.viewModel.activeConversationId).toBe(
+        "codex-session"
+      );
+      expect(result.current.viewModel.isLoadingConversations).toBe(false);
+    });
+    onDataChange.mockClear();
+
+    act(() => {
+      result.current.actions.selectConversationFilterTarget({
+        provider: "claude-code",
+        providerTargetId: "local:claude-code"
+      });
+    });
+
+    await waitFor(() => {
+      expect(result.current.viewModel.activeConversationId).toBeNull();
+    });
+    expect(result.current.viewModel.conversationFilter).toEqual({
+      kind: "agentTarget",
+      agentTargetId: "local:claude-code"
+    });
+    expect(result.current.viewModel.selectedProviderTarget.provider).toBe(
+      "claude-code"
+    );
+    const appliedData = onDataChange.mock.calls.reduce(
+      (data, [updater]) => updater(data),
+      initialData
+    );
+    expect(appliedData).toMatchObject({
+      provider: "claude-code",
+      agentTargetId: "local:claude-code",
+      lastActiveAgentSessionId: null
+    });
+    expect(unactivate).toHaveBeenCalledWith({
+      workspaceId: "room-1",
+      agentSessionId: "codex-session"
     });
   });
 
@@ -640,6 +847,88 @@ describe("useAgentGUINodeController", () => {
     await waitFor(() => {
       expect(result.current.viewModel.conversationFilter).toEqual({
         kind: "all"
+      });
+    });
+    expect(result.current.viewModel.selectedProviderTarget.provider).toBe(
+      "claude-code"
+    );
+  });
+
+  it("syncs a scoped rail target when switching the empty composer provider", async () => {
+    installAgentHostApi({
+      list: vi.fn(async () => ({
+        presences: [],
+        sessions: [
+          workspaceAgentSession("codex-session", {
+            provider: "codex",
+            title: "Codex session",
+            updatedAtUnixMs: 3
+          }),
+          workspaceAgentSession("claude-session", {
+            provider: "claude-code",
+            title: "Claude session",
+            updatedAtUnixMs: 2
+          })
+        ]
+      })),
+      listSessionTimeline: vi.fn(async () => ({ timelineItems: [] })),
+      subscribeEvents: vi.fn(() => vi.fn())
+    });
+
+    const { result } = renderHook(() =>
+      useAgentGUINodeController({
+        workspaceId: "room-1",
+        currentUserId: "user-1",
+        workspacePath: "/workspace",
+        avoidGroupingEdits: false,
+        data: agentGuiData(null, "codex", {
+          agentTargetId: "local:codex"
+        }),
+        providerTargets: [
+          {
+            targetId: "local:codex",
+            agentTargetId: "local:codex",
+            provider: "codex",
+            ref: { kind: "local-provider", provider: "codex" },
+            label: "Codex"
+          },
+          {
+            targetId: "local:claude-code",
+            agentTargetId: "local:claude-code",
+            provider: "claude-code",
+            ref: { kind: "local-provider", provider: "claude-code" },
+            label: "Claude Code"
+          }
+        ],
+        onDataChange: vi.fn()
+      })
+    );
+
+    act(() => {
+      result.current.actions.selectConversationFilterTarget({
+        provider: "codex",
+        providerTargetId: "local:codex"
+      });
+    });
+
+    await waitFor(() => {
+      expect(result.current.viewModel.conversationFilter).toEqual({
+        kind: "agentTarget",
+        agentTargetId: "local:codex"
+      });
+    });
+
+    act(() => {
+      result.current.actions.selectHomeComposerAgentTarget({
+        provider: "claude-code",
+        providerTargetId: "local:claude-code"
+      });
+    });
+
+    await waitFor(() => {
+      expect(result.current.viewModel.conversationFilter).toEqual({
+        kind: "agentTarget",
+        agentTargetId: "local:claude-code"
       });
     });
     expect(result.current.viewModel.selectedProviderTarget.provider).toBe(
@@ -759,6 +1048,71 @@ describe("useAgentGUINodeController", () => {
     });
   });
 
+  it("selects disabled placeholder rail targets for the empty composer", async () => {
+    installAgentHostApi({
+      list: vi.fn(async () => ({ presences: [], sessions: [] })),
+      listSessionTimeline: vi.fn(async () => ({ timelineItems: [] })),
+      subscribeEvents: vi.fn(() => vi.fn())
+    });
+    const onDataChange = vi.fn();
+    const initialData = agentGuiData(null, "codex", {
+      agentTargetId: "local:codex"
+    });
+    const openclawTarget = {
+      targetId: "local:openclaw",
+      agentTargetId: "local:openclaw",
+      provider: "openclaw" as const,
+      ref: { kind: "local", provider: "openclaw" as const },
+      label: "OpenClaw",
+      disabled: true
+    };
+
+    const { result } = renderHook(() =>
+      useAgentGUINodeController({
+        workspaceId: "room-1",
+        currentUserId: "user-1",
+        workspacePath: "/workspace",
+        avoidGroupingEdits: false,
+        data: initialData,
+        providerTargets: [
+          {
+            targetId: "local:codex",
+            agentTargetId: "local:codex",
+            provider: "codex",
+            ref: { kind: "local", provider: "codex" },
+            label: "Codex"
+          },
+          openclawTarget
+        ],
+        onDataChange
+      })
+    );
+
+    act(() => {
+      result.current.actions.selectConversationFilterTarget({
+        provider: "openclaw",
+        providerTargetId: "local:openclaw"
+      });
+    });
+
+    await waitFor(() => {
+      expect(result.current.viewModel.conversationFilter).toEqual({
+        kind: "agentTarget",
+        agentTargetId: "local:openclaw"
+      });
+    });
+    expect(result.current.viewModel.selectedProviderTarget).toMatchObject({
+      provider: "openclaw",
+      targetId: "local:openclaw",
+      disabled: true
+    });
+    expect(result.current.viewModel.data).toMatchObject({
+      provider: "openclaw",
+      agentTargetId: "local:openclaw"
+    });
+    expect(onDataChange).toHaveBeenCalled();
+  });
+
   it("syncs the composer target to an activated conversation from another provider", async () => {
     installAgentHostApi({
       list: vi.fn(async () => ({
@@ -831,7 +1185,7 @@ describe("useAgentGUINodeController", () => {
     });
   });
 
-  it("aligns the home composer target with the filter tab when starting a new conversation", async () => {
+  it("keeps the scoped rail filter aligned when switching the empty composer target before starting a new conversation", async () => {
     installAgentHostApi({
       list: vi.fn(async () => ({ presences: [], sessions: [] })),
       listSessionTimeline: vi.fn(async () => ({ timelineItems: [] })),
@@ -885,21 +1239,23 @@ describe("useAgentGUINodeController", () => {
         "codex"
       );
     });
+    expect(result.current.viewModel.conversationFilter).toEqual({
+      kind: "agentTarget",
+      agentTargetId: "local:codex"
+    });
 
-    // …but "new conversation" composes for the tab the user is looking at.
+    // Starting a new conversation follows the visibly selected tab.
     act(() => {
       result.current.actions.createConversation();
     });
 
     await waitFor(() => {
       expect(result.current.viewModel.selectedProviderTarget.provider).toBe(
-        "claude-code"
+        "codex"
       );
     });
-    expect(result.current.viewModel.data.provider).toBe("claude-code");
-    expect(result.current.viewModel.data.agentTargetId).toBe(
-      "local:claude-code"
-    );
+    expect(result.current.viewModel.data.provider).toBe("codex");
+    expect(result.current.viewModel.data.agentTargetId).toBe("local:codex");
   });
 
   it("moves the conversation filter to the created conversation's target tab", async () => {

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUINodeController.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUINodeController.ts
@@ -78,6 +78,7 @@ import {
 } from "../model/agentGuiConversationModel";
 import {
   createAgentGUIConversationFilterState,
+  filterAgentGUIConversationSummaries,
   normalizeAgentGUIConversationFilter,
   type AgentGUIConversationFilter
 } from "../model/agentGuiConversationFilter";
@@ -10726,11 +10727,86 @@ export function useAgentGUINodeController({
   ]);
   const stableComposerSettings = useStableComposerSettingsVM(composerSettings);
 
+  const resolveDefaultHomeComposerTarget =
+    useCallback((): AgentGUIProviderTarget | null => {
+      const defaultTargetId = defaultProviderTargetId?.trim() ?? "";
+      const explicitDefaultTarget = defaultTargetId
+        ? (normalizedProviderTargets.find(
+            (target) =>
+              target.targetId === defaultTargetId ||
+              target.agentTargetId === defaultTargetId
+          ) ?? null)
+        : null;
+      return (
+        explicitDefaultTarget ??
+        normalizedProviderTargets.find((target) => target.disabled !== true) ??
+        normalizedProviderTargets[0] ??
+        null
+      );
+    }, [defaultProviderTargetId, normalizedProviderTargets]);
+
+  const resetHomeComposerAgentTargetToDefault = useCallback(() => {
+    if (previewMode) {
+      return;
+    }
+    const nextTarget = resolveDefaultHomeComposerTarget();
+    if (!nextTarget) {
+      return;
+    }
+    const nextTargetIsExplicit = normalizedExplicitProviderTargets.some(
+      (target) =>
+        target.provider === nextTarget.provider &&
+        target.targetId === nextTarget.targetId &&
+        agentGUIProviderTargetRefsEqual(target.ref, nextTarget.ref)
+    );
+    const nextTargetData = composerTargetDataFromProviderTarget({
+      current: dataRef.current,
+      isExplicit: nextTargetIsExplicit,
+      target: nextTarget
+    });
+    setHomeComposerTargetOverride(nextTarget);
+    setIntent({ tag: "home" });
+    isComposerHomeRef.current = true;
+    setIsComposerHome(true);
+    onDataChangeRef.current((current) => {
+      const currentNextTargetData = composerTargetDataFromProviderTarget({
+        current,
+        isExplicit: nextTargetIsExplicit,
+        target: nextTarget
+      });
+      const nextData: AgentGUINodeData = {
+        ...currentNextTargetData.data,
+        lastActiveAgentSessionId: null
+      };
+      dataRef.current = nextData;
+      return nextData;
+    });
+    dataRef.current = {
+      ...nextTargetData.data,
+      lastActiveAgentSessionId: null
+    };
+    if (nextTarget.disabled !== true) {
+      loadComposerOptionsForTarget(nextTargetData, { force: true });
+    }
+  }, [
+    loadComposerOptionsForTarget,
+    normalizedExplicitProviderTargets,
+    previewMode,
+    resolveDefaultHomeComposerTarget
+  ]);
+
   const updateConversationFilter = useCallback(
     (filter: AgentGUIConversationFilter) => {
-      setConversationFilter(normalizeAgentGUIConversationFilter(filter));
+      const nextFilter = normalizeAgentGUIConversationFilter(filter);
+      setConversationFilter(nextFilter);
+      if (
+        nextFilter.kind === "all" &&
+        activeConversationIdRef.current === null
+      ) {
+        resetHomeComposerAgentTargetToDefault();
+      }
     },
-    []
+    [resetHomeComposerAgentTargetToDefault]
   );
   const selectHomeComposerAgentTarget = useCallback(
     (input: {
@@ -10762,7 +10838,17 @@ export function useAgentGUINodeController({
         isExplicit: nextTargetIsExplicit,
         target: nextTarget
       });
+      const shouldSyncScopedRailFilter =
+        conversationFilterRef.current.kind === "agentTarget";
       setHomeComposerTargetOverride(nextTarget);
+      if (shouldSyncScopedRailFilter) {
+        const nextAgentTargetId = nextTarget.agentTargetId?.trim() ?? "";
+        setConversationFilter(
+          nextAgentTargetId
+            ? { kind: "agentTarget", agentTargetId: nextAgentTargetId }
+            : { kind: "all" }
+        );
+      }
       const previous = activeConversationIdRef.current;
       if (previous) {
         void activation.unactivate(previous);
@@ -10830,12 +10916,12 @@ export function useAgentGUINodeController({
         providerTargets: normalizedProviderTargets,
         useStaticCatalog: shouldUseStaticProviderTargets
       });
-      if (!nextTarget || nextTarget.disabled === true) {
+      if (!nextTarget) {
         reportAgentGUIConversationFilterTargetUnresolved({
           provider: input.provider,
           providerTargetId: input.providerTargetId ?? null,
           providerTargetCount: normalizedProviderTargets.length,
-          reason: nextTarget ? "disabled" : "unresolved",
+          reason: "unresolved",
           runtime: agentActivityRuntime,
           workspaceId
         });
@@ -10847,8 +10933,8 @@ export function useAgentGUINodeController({
         : { kind: "all" as const };
       setConversationFilter(nextFilter);
       // Keep the home composer chip in sync with the selected tab. Active
-      // conversations keep owning their target and must not be unactivated by a
-      // rail filter click.
+      // conversations keep owning their target until the target-filtered list
+      // has initialized and proven empty.
       if (activeConversationIdRef.current === null) {
         selectHomeComposerAgentTarget(input);
       }
@@ -10862,6 +10948,46 @@ export function useAgentGUINodeController({
       workspaceId
     ]
   );
+  useEffect(() => {
+    if (
+      previewMode ||
+      providerTargetsLoading ||
+      activeConversationId === null ||
+      conversationFilter.kind !== "agentTarget" ||
+      isLoadingConversations ||
+      conversationListState?.initialized !== true
+    ) {
+      return;
+    }
+    if (
+      filterAgentGUIConversationSummaries(conversations, conversationFilter)
+        .length > 0
+    ) {
+      return;
+    }
+    const target = normalizedProviderTargets.find(
+      (candidate) =>
+        (candidate.agentTargetId?.trim() ?? "") ===
+        conversationFilter.agentTargetId
+    );
+    if (!target) {
+      return;
+    }
+    selectHomeComposerAgentTarget({
+      provider: target.provider,
+      providerTargetId: target.targetId
+    });
+  }, [
+    activeConversationId,
+    conversationFilter,
+    conversationListState?.initialized,
+    conversations,
+    isLoadingConversations,
+    normalizedProviderTargets,
+    previewMode,
+    providerTargetsLoading,
+    selectHomeComposerAgentTarget
+  ]);
   const stableCreateConversation =
     useStableControllerEventCallback(createConversation);
   const stableSelectHomeComposerAgentTarget = useStableControllerEventCallback(

--- a/packages/agent/gui/app/renderer/agentactivity.css
+++ b/packages/agent/gui/app/renderer/agentactivity.css
@@ -4728,6 +4728,7 @@ aside.workspace-agents-status-panel
   background: var(--agent-gui-session-sidepanel-background);
   overflow: hidden;
   transition: width 180ms cubic-bezier(0.22, 1, 0.36, 1);
+  -webkit-app-region: no-drag;
 }
 
 .agent-gui-node__provider-rail-panel::after {
@@ -7860,6 +7861,10 @@ html[data-theme="light"] [data-message-center-item-id].agent-gui-edge-glow {
   color: var(--text-primary);
 }
 
+.agent-gui-node__composer-handoff-icon[data-disabled="true"] {
+  color: var(--agent-gui-text-tertiary);
+}
+
 .agent-gui-node__composer-handoff-icon-static,
 .agent-gui-node__composer-handoff-icon-animated {
   width: 18px;
@@ -7887,6 +7892,11 @@ html[data-theme="light"] [data-message-center-item-id].agent-gui-edge-glow {
 
 .agent-gui-node__composer-handoff-icon-animated[data-active="true"] {
   opacity: 1;
+}
+
+.agent-gui-node__composer-handoff-icon[data-disabled="true"]
+  .agent-gui-node__composer-handoff-icon-animated {
+  opacity: 0;
 }
 
 :root[data-theme="dark"] .agent-gui-node__composer-handoff-icon-animated {
@@ -8324,6 +8334,7 @@ html[data-theme="light"] [data-message-center-item-id].agent-gui-edge-glow {
   padding: 0 0 12px;
   overflow-x: hidden;
   overflow-y: auto;
+  -webkit-app-region: no-drag;
 }
 
 .agent-gui-node__provider-rail-tile {
@@ -8341,6 +8352,7 @@ html[data-theme="light"] [data-message-center-item-id].agent-gui-edge-glow {
   font-weight: 600;
   line-height: 14px;
   text-align: center;
+  -webkit-app-region: no-drag;
 }
 
 .agent-gui-node__provider-rail-tile + .agent-gui-node__provider-rail-tile {

--- a/packages/agent/gui/app/renderer/i18n/locales/en.ts
+++ b/packages/agent/gui/app/renderer/i18n/locales/en.ts
@@ -382,7 +382,7 @@ export const en = {
       providerGateComingSoonTitle: "{{provider}} is coming soon",
       providerGateComingSoonDescription:
         "{{provider}} is not available yet. We will enable this agent when it is ready.",
-      providerGateComingSoonAction: "Coming soon",
+      providerGateComingSoonAction: "comming soon",
       providerGateUnavailableTitle: "{{provider}} is not ready yet",
       providerGateUnavailableDescription:
         "We could not confirm that {{provider}} is ready. Try checking again.",

--- a/packages/agent/gui/app/renderer/i18n/locales/zh-CN.ts
+++ b/packages/agent/gui/app/renderer/i18n/locales/zh-CN.ts
@@ -354,7 +354,7 @@ export const zhCN = {
       providerGateComingSoonTitle: "{{provider}} 即将上线",
       providerGateComingSoonDescription:
         "{{provider}} 暂未开放。准备好后即可在这里使用这个 Agent。",
-      providerGateComingSoonAction: "即将上线",
+      providerGateComingSoonAction: "comming soon",
       providerGateUnavailableTitle: "{{provider}} 暂时还不可用",
       providerGateUnavailableDescription:
         "我们还不能确认 {{provider}} 已准备好，可以再检测一次。",

--- a/packages/agent/gui/providerTargets.spec.ts
+++ b/packages/agent/gui/providerTargets.spec.ts
@@ -38,6 +38,11 @@ describe("agent gui provider targets", () => {
       label: "Hermes",
       provider: "hermes"
     });
+    expect(createLocalAgentGUIProviderTarget("openclaw")).toMatchObject({
+      agentTargetId: "local:openclaw",
+      label: "OpenClaw",
+      provider: "openclaw"
+    });
   });
 
   it("can append disabled placeholder targets for unavailable future providers", () => {
@@ -85,7 +90,7 @@ describe("agent gui provider targets", () => {
         provider: "hermes"
       },
       {
-        agentTargetId: null,
+        agentTargetId: "local:openclaw",
         disabled: true,
         label: "OpenClaw",
         provider: "openclaw"

--- a/packages/agent/gui/providerTargets.ts
+++ b/packages/agent/gui/providerTargets.ts
@@ -95,6 +95,8 @@ export function localAgentGUIAgentTargetId(
       return "local:hermes";
     case "nexight":
       return "local:nexight";
+    case "openclaw":
+      return "local:openclaw";
     default:
       return null;
   }

--- a/packages/agent/gui/workbench/contribution.test.ts
+++ b/packages/agent/gui/workbench/contribution.test.ts
@@ -22,6 +22,7 @@ import {
   resolveAgentGuiWorkbenchContributionCopy
 } from "./contribution.ts";
 import {
+  agentGuiWorkbenchPrefillPromptActivationType,
   agentGuiWorkbenchUnifiedDockEntryId,
   agentGuiWorkbenchTypeId
 } from "./launch.ts";
@@ -548,6 +549,48 @@ describe("agent GUI workbench contribution copy", () => {
     );
     expect(screen.queryByText("Codex")).toBeNull();
     expect(screen.queryByTestId("agent-gui-window-title-icon")).toBeNull();
+  });
+
+  it("uses prefill activation provider for handoff body rendering", () => {
+    const renderBody = vi.fn(() => null);
+    const contribution = createTestAgentGuiWorkbenchContribution({
+      renderBody,
+      workspaceId: "workspace-1"
+    });
+
+    contribution.nodes?.[0]?.renderBody?.({
+      activation: {
+        payload: {
+          agentTargetId: "local:codex",
+          draftPrompt: "Continue from this session",
+          provider: "codex"
+        },
+        sequence: 12,
+        type: agentGuiWorkbenchPrefillPromptActivationType
+      },
+      externalNodeState: null,
+      externalWorkspaceState: null,
+      instanceId: "agent-gui:claude-code:panel:handoff-source",
+      instanceKey: null,
+      node: {
+        data: {
+          runtimeNodeState: null
+        },
+        displayMode: "floating",
+        frame: { height: 560, width: 1040, x: 0, y: 0 },
+        id: "agent-gui-node-1",
+        title: "Agent"
+      }
+    } as Parameters<
+      NonNullable<(typeof contribution.nodes)[number]["renderBody"]>
+    >[0]);
+
+    expect(renderBody).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        provider: "codex"
+      })
+    );
   });
 
   it("opens at the default width and 70 percent height when the workbench area can fit the default frame", () => {

--- a/packages/agent/gui/workbench/contribution.ts
+++ b/packages/agent/gui/workbench/contribution.ts
@@ -199,12 +199,13 @@ export function createAgentGuiWorkbenchContribution(
                   typeId: agentGuiWorkbenchTypeId
                 });
               },
-              provider: agentGuiWorkbenchProviderFromInstanceId(
-                context.instanceId
-              )
+              provider:
+                providerFromActivation(context.activation) ??
+                agentGuiWorkbenchProviderFromInstanceId(context.instanceId)
             }
           ),
         renderHeader: ({
+          activation,
           dragHandleProps,
           displayMode,
           externalNodeState,
@@ -214,7 +215,9 @@ export function createAgentGuiWorkbenchContribution(
           surfaceSize,
           windowActions
         }) => {
-          const provider = agentGuiWorkbenchProviderFromInstanceId(instanceId);
+          const provider =
+            providerFromActivation(activation) ??
+            agentGuiWorkbenchProviderFromInstanceId(instanceId);
           const headerTitle = copy.nodeTitle;
           const rawWorkbenchState = (externalNodeState ??
             node.data.runtimeNodeState) as
@@ -702,6 +705,16 @@ function providerFromState(state: unknown): AgentGuiWorkbenchProvider | null {
   }
   const provider = (state as { provider?: unknown }).provider;
   return isAgentGuiWorkbenchProvider(provider) ? provider : null;
+}
+
+function providerFromActivation(
+  activation: unknown
+): AgentGuiWorkbenchProvider | null {
+  if (!activation || typeof activation !== "object") {
+    return null;
+  }
+  const payload = (activation as { payload?: unknown }).payload;
+  return providerFromState(payload);
 }
 
 function resolveAgentGuiWorkbenchLaunchPayload(


### PR DESCRIPTION
## Summary
- keep AgentGUI provider rail interactions clickable by marking rail controls as non-drag regions
- switch provider-target filtering to the selected agent empty composer when that provider has no conversations
- preserve handoff activation payload providers so Claude Code handoff to Codex opens a Codex-targeted new window
- update AgentGUI architecture notes for provider-target switching and handoff prefill behavior

## Validation
- pnpm --filter @tutti-os/agent-gui test -- agent-gui/agentGuiNode/controller/useAgentGUINodeController.spec.tsx workbench/contribution.test.ts
- pnpm check:full (via pre-push)

## Notes
- Local untracked build output under apps/desktop/build/nextopd/ was left uncommitted.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Provider switching now supports smoother handoff behavior with an animated icon when available.
  * Coming-soon provider options can now appear as selectable placeholders, with actions disabled until support is ready.
  * Provider selection is better synchronized between the empty composer and the conversation rail.

* **Bug Fixes**
  * Prevented provider rail clicks near window edges from being treated as drag gestures.
  * Improved handling of disabled provider options so unavailable entries are hidden or clearly disabled as appropriate.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->