### PR TITLE
feat(agent-gui): allow live permission-mode switching mid-turn

### DIFF
--- a/packages/agent/daemon/runtime/codex_appserver_adapter_test.go
+++ b/packages/agent/daemon/runtime/codex_appserver_adapter_test.go
@@ -3707,6 +3707,67 @@ func TestCodexAppServerAdapterApplyPermissionModeUpdatesState(t *testing.T) {
 	}
 }
 
+// TestCodexAppServerAdapterApplyPermissionModeSucceedsMidTurnAndAppliesNextTurn
+// locks in the contract the composer UI's live permission-mode switch now
+// relies on: the app-server protocol has no RPC to change approval/sandbox
+// policy for a turn that's already running, so ApplyPermissionMode must still
+// succeed while a turn is in flight (rather than error or block), and the
+// new policy must only take effect starting with the *next* turn/start --
+// matching the "applies starting with your next message" copy shown to the
+// user when they change permission mode mid-turn.
+func TestCodexAppServerAdapterApplyPermissionModeSucceedsMidTurnAndAppliesNextTurn(t *testing.T) {
+	t.Parallel()
+
+	adapter, transport, session := startedAppServerAdapter(t)
+	session.PermissionModeID = "read-only"
+	transport.conn.holdTurn = true
+
+	execDone := make(chan struct{})
+	go func() {
+		_, _ = adapter.Exec(context.Background(), session, []PromptContentBlock{{
+			Type: "text", Text: "go",
+		}}, "", "turn-local-1", nil, nil)
+		close(execDone)
+	}()
+	waitForCondition(t, func() bool {
+		return adapter.sessionActiveTurnID(session.AgentSessionID) == "turn-1"
+	})
+
+	firstTurnStart := appServerRequestParams(t, transport.conn, appServerMethodTurnStart)
+	if asString(firstTurnStart["approvalPolicy"]) != "on-request" {
+		t.Fatalf("first turn/start approvalPolicy = %#v, want on-request", firstTurnStart["approvalPolicy"])
+	}
+
+	session.PermissionModeID = "full-access"
+	if err := adapter.ApplyPermissionMode(context.Background(), session); err != nil {
+		t.Fatalf("ApplyPermissionMode mid-turn: %v", err)
+	}
+
+	transport.conn.completePendingTurn()
+	<-execDone
+
+	// The turn that was already running is unaffected by the change: exactly
+	// one turn/start was sent for it.
+	if turnStarts := appServerRequestParamsList(t, transport.conn, appServerMethodTurnStart); len(turnStarts) != 1 {
+		t.Fatalf("turn/start calls = %d, want 1 before the next turn", len(turnStarts))
+	}
+
+	transport.conn.holdTurn = false
+	if _, err := adapter.Exec(context.Background(), session, []PromptContentBlock{{
+		Type: "text", Text: "go again",
+	}}, "", "turn-local-2", nil, nil); err != nil {
+		t.Fatalf("Exec (second turn): %v", err)
+	}
+
+	turnStarts := appServerRequestParamsList(t, transport.conn, appServerMethodTurnStart)
+	if len(turnStarts) != 2 {
+		t.Fatalf("turn/start calls = %d, want 2 after the next turn", len(turnStarts))
+	}
+	if asString(turnStarts[1]["approvalPolicy"]) != "never" {
+		t.Fatalf("second turn/start approvalPolicy = %#v, want never", turnStarts[1]["approvalPolicy"])
+	}
+}
+
 func TestCodexAppServerAdapterCloseShutsDownSession(t *testing.T) {
 	t.Parallel()
 

--- a/packages/agent/gui/agent-gui/agentGuiNode/AgentComposer.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/AgentComposer.tsx
@@ -158,6 +158,7 @@ import handoffLinedIconUrl from "../../app/renderer/assets/icons/handoff-lined.s
 import { useOptionalAgentActivityRuntime } from "../../agentActivityRuntime";
 import { useOptionalAgentHostApi } from "../../agentActivityHost";
 import type { AgentDroppedFileReferenceResolver } from "./model/agentDroppedFileReferences";
+import { resolvePermissionModeControlsDisabled } from "./model/composerModeSelection";
 import {
   MANAGED_AGENT_ICON_FALLBACK_URL,
   MANAGED_AGENT_ICON_URLS
@@ -1434,6 +1435,12 @@ export function AgentComposer({
 
   const settingsControlsDisabled =
     isSendingTurn || isSubmittingPrompt || showStopButton;
+  const permissionModeControlsDisabled = resolvePermissionModeControlsDisabled({
+    provider,
+    isSendingTurn,
+    isSubmittingPrompt,
+    showStopButton
+  });
   const composerControlsHardDisabled =
     isSelectedProjectMissing ||
     isSubmittingPrompt ||
@@ -3833,7 +3840,7 @@ export function AgentComposer({
               {composerSettings.supportsPermissionMode ? (
                 <AgentPermissionModeDropdown
                   composerSettings={composerSettings}
-                  disabled={settingsControlsDisabled}
+                  disabled={permissionModeControlsDisabled}
                   previewMode={previewMode}
                   labels={{
                     permissionLabel: labels.permissionLabel,

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUINodeController.spec.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUINodeController.spec.tsx
@@ -10987,6 +10987,184 @@ describe("useAgentGUINodeController", () => {
     });
   });
 
+  it("tells the user a codex permission-mode change will apply on the next message when a turn is in flight", async () => {
+    const updateSettings = vi.fn(
+      async ({ settings }: { settings: { permissionModeId?: string } }) => ({
+        settings: {
+          model: "gpt-5.4",
+          reasoningEffort: "high",
+          speed: null,
+          planMode: false,
+          permissionModeId: settings.permissionModeId ?? "auto"
+        }
+      })
+    );
+    const onShowMessage = vi.fn();
+    installAgentHostApi({
+      list: vi.fn(async () => ({
+        presences: [],
+        sessions: [
+          workspaceAgentSession("session-1", {
+            provider: "codex",
+            title: "Codex"
+          })
+        ]
+      })),
+      listSessionTimeline: vi.fn(async () => ({ timelineItems: [] })),
+      subscribeEvents: vi.fn(() => vi.fn()),
+      getState: vi.fn(async () =>
+        agentSessionState("session-1", {
+          provider: "codex",
+          permissionModeId: "auto",
+          turnLifecycle: { activeTurnId: "turn-1", phase: "running" },
+          settings: {
+            model: "gpt-5.4",
+            reasoningEffort: "high",
+            speed: null,
+            planMode: false,
+            permissionModeId: "auto"
+          }
+        })
+      ),
+      updateSettings
+    });
+
+    const { result } = renderHook(() =>
+      useAgentGUINodeController({
+        workspaceId: "room-1",
+        currentUserId: "user-1",
+        workspacePath: "/workspace",
+        avoidGroupingEdits: false,
+        data: agentGuiData("session-1", "codex", {
+          composerOverrides: {
+            model: "gpt-5.4",
+            reasoningEffort: "high",
+            permissionModeId: "auto"
+          }
+        }),
+        onDataChange: vi.fn(),
+        onShowMessage
+      })
+    );
+
+    await waitFor(() => {
+      expect(result.current.viewModel.activeConversationId).toBe("session-1");
+    });
+    await waitFor(() => {
+      expect(result.current.viewModel.sessionChrome.rawState).not.toBeNull();
+    });
+
+    act(() => {
+      result.current.actions.updateComposerSettings({
+        permissionModeId: "full-access"
+      });
+    });
+
+    await waitFor(() => {
+      expect(updateSettings).toHaveBeenCalledWith({
+        workspaceId: "room-1",
+        agentSessionId: "session-1",
+        settings: {
+          permissionModeId: "full-access"
+        }
+      });
+    });
+    await waitFor(() => {
+      expect(onShowMessage).toHaveBeenCalledWith(
+        "Permission mode will apply starting with your next message.",
+        "info"
+      );
+    });
+  });
+
+  it("does not show the deferred-apply tip for claude-code, which applies permission mode live mid-turn", async () => {
+    const updateSettings = vi.fn(
+      async ({ settings }: { settings: { permissionModeId?: string } }) => ({
+        settings: {
+          model: "sonnet",
+          reasoningEffort: "medium",
+          speed: null,
+          planMode: false,
+          permissionModeId: settings.permissionModeId ?? "default"
+        }
+      })
+    );
+    const onShowMessage = vi.fn();
+    installAgentHostApi({
+      list: vi.fn(async () => ({
+        presences: [],
+        sessions: [
+          workspaceAgentSession("session-1", {
+            provider: "claude-code",
+            title: "Claude Code"
+          })
+        ]
+      })),
+      listSessionTimeline: vi.fn(async () => ({ timelineItems: [] })),
+      subscribeEvents: vi.fn(() => vi.fn()),
+      getState: vi.fn(async () =>
+        agentSessionState("session-1", {
+          provider: "claude-code",
+          permissionModeId: "default",
+          turnLifecycle: { activeTurnId: "turn-1", phase: "running" },
+          settings: {
+            model: "sonnet",
+            reasoningEffort: "medium",
+            speed: null,
+            planMode: false,
+            permissionModeId: "default"
+          }
+        })
+      ),
+      updateSettings
+    });
+
+    const { result } = renderHook(() =>
+      useAgentGUINodeController({
+        workspaceId: "room-1",
+        currentUserId: "user-1",
+        workspacePath: "/workspace",
+        avoidGroupingEdits: false,
+        data: agentGuiData("session-1", "claude-code", {
+          composerOverrides: {
+            model: "sonnet",
+            reasoningEffort: "medium",
+            permissionModeId: "default"
+          }
+        }),
+        onDataChange: vi.fn(),
+        onShowMessage
+      })
+    );
+
+    await waitFor(() => {
+      expect(result.current.viewModel.activeConversationId).toBe("session-1");
+    });
+    await waitFor(() => {
+      expect(result.current.viewModel.sessionChrome.rawState).not.toBeNull();
+    });
+
+    act(() => {
+      result.current.actions.updateComposerSettings({
+        permissionModeId: "acceptEdits"
+      });
+    });
+
+    await waitFor(() => {
+      expect(updateSettings).toHaveBeenCalledWith({
+        workspaceId: "room-1",
+        agentSessionId: "session-1",
+        settings: {
+          permissionModeId: "acceptEdits"
+        }
+      });
+    });
+    expect(onShowMessage).not.toHaveBeenCalledWith(
+      "Permission mode will apply starting with your next message.",
+      "info"
+    );
+  });
+
   it("uses active ACP model options for live sessions", async () => {
     const listModels = vi.fn();
     const getComposerOptions = vi.fn(async () => ({

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUINodeController.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUINodeController.ts
@@ -8949,6 +8949,22 @@ export function useAgentGUINodeController({
       ) {
         sessionSettingsPatch.permissionModeId =
           normalizePermissionModeId(nextPermission);
+        // Codex has no live mid-turn RPC for approval/sandbox policy: the
+        // daemon only re-derives it fresh on the *next* turn/start call, so a
+        // change made while a turn is actively running won't affect that
+        // turn. Claude Code applies it immediately via query.setPermissionMode
+        // even mid-turn, so no such gap exists there. Surface the deferral
+        // honestly instead of letting the optimistic UI update imply the
+        // change is already in effect.
+        const turnPhase = activeSessionState.turnLifecycle?.phase;
+        const isTurnInFlight =
+          turnPhase === "running" || turnPhase === "submitted";
+        if (dataRef.current.provider === "codex" && isTurnInFlight) {
+          onShowMessageRef.current?.(
+            translate("messages.agentPermissionModeAppliesNextTurn"),
+            "info"
+          );
+        }
       }
       if (
         Object.keys(sessionSettingsPatch).length > 0 &&

--- a/packages/agent/gui/agent-gui/agentGuiNode/model/composerModeSelection.spec.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/model/composerModeSelection.spec.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it } from "vitest";
-import { permissionModeSelectionPatch } from "./composerModeSelection";
+import {
+  permissionModeSelectionPatch,
+  resolvePermissionModeControlsDisabled
+} from "./composerModeSelection";
 
 describe("permissionModeSelectionPatch", () => {
   it("clears plan mode for mutually-exclusive providers (claude-code)", () => {
@@ -17,5 +20,62 @@ describe("permissionModeSelectionPatch", () => {
     ).toEqual({
       permissionModeId: "read-only"
     });
+  });
+});
+
+describe("resolvePermissionModeControlsDisabled", () => {
+  it("stays enabled mid-turn for claude-code, since the SDK applies the change live", () => {
+    expect(
+      resolvePermissionModeControlsDisabled({
+        provider: "claude-code",
+        isSendingTurn: true,
+        isSubmittingPrompt: false,
+        showStopButton: true
+      })
+    ).toBe(false);
+  });
+
+  it("stays enabled mid-turn for codex, which re-derives the policy on the next turn/start regardless", () => {
+    expect(
+      resolvePermissionModeControlsDisabled({
+        provider: "codex",
+        isSendingTurn: true,
+        isSubmittingPrompt: false,
+        showStopButton: true
+      })
+    ).toBe(false);
+  });
+
+  it("still blocks claude-code/codex during the brief prompt-submission race", () => {
+    expect(
+      resolvePermissionModeControlsDisabled({
+        provider: "claude-code",
+        isSendingTurn: false,
+        isSubmittingPrompt: true,
+        showStopButton: false
+      })
+    ).toBe(true);
+  });
+
+  it("keeps the broader turn-in-flight gate for other ACP-backed providers", () => {
+    expect(
+      resolvePermissionModeControlsDisabled({
+        provider: "nexight",
+        isSendingTurn: false,
+        isSubmittingPrompt: false,
+        showStopButton: true
+      })
+    ).toBe(true);
+  });
+
+  it("leaves ACP-backed providers enabled once no turn is in flight", () => {
+    expect(
+      resolvePermissionModeControlsDisabled({
+        provider: "gemini",
+        isSendingTurn: false,
+        isSubmittingPrompt: false,
+        showStopButton: false
+      })
+    ).toBe(false);
   });
 });

--- a/packages/agent/gui/agent-gui/agentGuiNode/model/composerModeSelection.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/model/composerModeSelection.ts
@@ -16,3 +16,37 @@ export function permissionModeSelectionPatch(
     ? { permissionModeId, planMode: false }
     : { permissionModeId };
 }
+
+/**
+ * Decides whether the composer's permission-mode control should be disabled
+ * while a turn is in flight.
+ *
+ * Claude Code's Agent SDK genuinely applies a permission-mode change mid-turn
+ * (`query.setPermissionMode` is documented as safe while the query is
+ * streaming), and Codex has no notion of "mid-turn" for it at all -- the
+ * daemon re-derives approvalPolicy/sandboxPolicy fresh from the session's
+ * permissionModeId on every `turn/start` regardless of when the user picked
+ * it, so leaving the control open mid-turn only lets the user queue their
+ * choice sooner. Other ACP-backed providers (Nexight/Gemini/Hermes/OpenClaw)
+ * apply the change via a JSON-RPC call over the same connection a turn
+ * streams on, which hasn't been verified safe to interleave mid-turn, so they
+ * keep the broader turn-in-flight gate that blocks all composer settings
+ * while a turn is sending or the stop button is showing.
+ */
+export function resolvePermissionModeControlsDisabled(options: {
+  provider: string;
+  isSendingTurn: boolean;
+  isSubmittingPrompt: boolean;
+  showStopButton: boolean;
+}): boolean {
+  const liveDuringTurn =
+    options.provider === "claude-code" || options.provider === "codex";
+  if (liveDuringTurn) {
+    return options.isSubmittingPrompt;
+  }
+  return (
+    options.isSendingTurn ||
+    options.isSubmittingPrompt ||
+    options.showStopButton
+  );
+}

--- a/packages/agent/gui/app/renderer/i18n/locales/en.messages.ts
+++ b/packages/agent/gui/app/renderer/i18n/locales/en.messages.ts
@@ -7,6 +7,8 @@ export const enMessages = {
     "This session cannot be resumed on this device. Start a new session and @this session to keep going.",
   agentSettingsRequireNewSession:
     "This model can only be used in a new session to preserve context.",
+  agentPermissionModeAppliesNextTurn:
+    "Permission mode will apply starting with your next message.",
   agentThisSessionMentionLabel: "this session",
   terminalLaunchFailed: "Terminal launch failed: {{message}}",
   fallbackTerminalFailed: "Fallback terminal launch also failed: {{message}}",

--- a/packages/agent/gui/app/renderer/i18n/locales/zh-CN.messages.ts
+++ b/packages/agent/gui/app/renderer/i18n/locales/zh-CN.messages.ts
@@ -6,6 +6,7 @@ export const zhCNMessages = {
   agentResumeSessionNotLocal:
     "这个会话没法在当前设备里直接恢复，你可以在新会话里 @这段对话，接着继续聊。",
   agentSettingsRequireNewSession: "为了保留上下文，这个模型只能在新会话中使用",
+  agentPermissionModeAppliesNextTurn: "权限模式将从你的下一条消息开始生效。",
   agentThisSessionMentionLabel: "本 session",
   terminalLaunchFailed: "终端启动失败：{{message}}",
   fallbackTerminalFailed: "兜底终端启动也失败了：{{message}}",


### PR DESCRIPTION
## Summary

Fixes Ta6Dp7: users could previously only change permission mode (e.g. read-only vs full-access) *before* starting a turn — the composer's permission-mode dropdown was unconditionally disabled whenever a turn was in flight (`isSendingTurn || isSubmittingPrompt || showStopButton`).

This was purely a frontend gap: the daemon's `ApplyPermissionMode` RPC already exists and is exercised live for every adapter (`claude_sdk_adapter.go`, `codex_appserver_adapter.go`, `standard_acp_adapter.go`), and `TestClaudeCodeSDKAdapterApplyPermissionModeSendsSidecar` already proved Claude Code applies it mid-turn. The composer UI just never let the user reach it while a turn was running.

## Behavior per provider

- **Claude Code**: the Agent SDK genuinely applies `setPermissionMode` while a query is streaming, so the dropdown now stays enabled during a turn and the change takes effect immediately.
- **Codex**: the app-server protocol has no RPC to change approval/sandbox policy for a turn that's already running — the daemon only re-derives it fresh on the next `turn/start`. The dropdown stays enabled, but an info toast ("Permission mode will apply starting with your next message.") tells the user the change is deferred rather than letting the optimistic UI update imply it's already in effect.
- **Other ACP-backed providers** (Nexight/Gemini/Hermes/OpenClaw): unchanged — the dropdown still locks during a turn, since applying the mode change over the same connection a turn streams on hasn't been verified safe to interleave mid-turn for these providers.

## Changes

- `composerModeSelection.ts`: new `resolvePermissionModeControlsDisabled()` resolver encoding the per-provider gating above.
- `AgentComposer.tsx`: wires the permission dropdown's `disabled` prop to the new resolver instead of the blanket `settingsControlsDisabled`.
- `useAgentGUINodeController.ts`: shows the new `agentPermissionModeAppliesNextTurn` toast when the provider is Codex and a turn is in flight. Confirmed there's no analogous backend-send gate to relax for Claude Code — `updateComposerSettings` already always forwards the patch to the daemon regardless of turn state; only the UI's `disabled` prop was blocking interaction.
- `codex_appserver_adapter_test.go`: new `TestCodexAppServerAdapterApplyPermissionModeSucceedsMidTurnAndAppliesNextTurn` locks in the contract — `ApplyPermissionMode` succeeds mid-turn, the in-flight turn is unaffected, and the next turn picks up the new policy.
- New/updated unit tests for the resolver (`composerModeSelection.spec.ts`) and the per-provider toast behavior (`useAgentGUINodeController.spec.tsx`).

## Test plan

- [x] `go build ./...` and `go test ./runtime/...` in `packages/agent/daemon` — all pass, including the new mid-turn test
- [x] `pnpm vitest run --environment jsdom agentGuiNode` in `packages/agent/gui` — 1023 tests pass
- [x] Full TS typecheck (`run-tsgo-typecheck.mjs`) — clean
- [x] `git push` pre-push hook (`check:full`, full Go + TS suite) — passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Permission mode changes now behave more predictably during an active turn, with updates applying on the next message where needed.
  * The permission-mode control is now disabled only in the appropriate states, improving availability during normal use.
  * Users now see a clearer message when a permission change will take effect on the next turn.

* **Tests**
  * Expanded automated coverage for mid-turn permission-mode changes and provider-specific behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->