### PR TITLE
[codex] fix Agent GUI conversation provider icon color

### DIFF
--- a/packages/agent/gui/app/renderer/agentactivity.css
+++ b/packages/agent/gui/app/renderer/agentactivity.css
@@ -5722,7 +5722,7 @@ button.agent-gui-node__conversation-section-toggle:hover
   flex: 0 0 14px;
   width: 14px;
   height: 14px;
-  color: var(--text-secondary);
+  color: var(--text-tertiary);
   background-color: currentColor;
   mask: var(--agent-gui-conversation-provider-icon-url) center / contain
     no-repeat;


### PR DESCRIPTION
## Summary
- Update Agent GUI conversation rail provider icons to use text-tertiary instead of text-secondary.
- Keep the visual treatment aligned with muted session metadata in the sidebar.

## Validation
- pnpm check:changed --tail-lines 20
- pnpm check:full

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Updated the conversation provider icon color to a subtler tone for improved visual consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->