### PR TITLE
fix(agent): ignore successful turn stop reasons as errors

### DIFF
--- a/packages/agent/daemon/activity/compat.go
+++ b/packages/agent/daemon/activity/compat.go
@@ -1,4 +1,3 @@
-//nolint:unused // Retain migrated helpers until the next agent-daemon decomposition pass.
 package agentsessionstore
 
 import (
@@ -198,6 +197,7 @@ func sessionStateUpdateFromPatch(patch WorkspaceAgentStatePatch) WorkspaceAgentS
 		Title:              strings.TrimSpace(patch.Title),
 		LifecycleStatus:    strings.TrimSpace(patch.LifecycleStatus),
 		CurrentPhase:       currentPhase,
+		LastError:          strings.TrimSpace(patch.LastError),
 		OccurredAtUnixMS:   patch.OccurredAtUnixMS,
 	}
 	if patch.Turn != nil {

--- a/packages/agent/daemon/activity/service.go
+++ b/packages/agent/daemon/activity/service.go
@@ -1509,15 +1509,8 @@ func statePatchFromActivityEvent(source EventSource, event activityshared.Event,
 }
 
 func statePatchLastError(event activityshared.Event) string {
-	switch event.Type {
-	case activityshared.EventSessionUpdated:
-		if strings.TrimSpace(event.Payload.EffectiveStatus) == string(activityshared.SessionStatusPaused) {
-			return ""
-		}
-	case activityshared.EventTurnCompleted:
-		if strings.TrimSpace(event.Payload.TurnOutcome) == string(activityshared.TurnOutcomeInterrupted) {
-			return ""
-		}
+	if event.Type != activityshared.EventSessionFailed && event.Type != activityshared.EventTurnFailed {
+		return ""
 	}
 	return activityshared.BestEffortErrorMessage(event.Payload)
 }

--- a/packages/agent/daemon/activity/service_test.go
+++ b/packages/agent/daemon/activity/service_test.go
@@ -964,6 +964,29 @@ func TestStoreAppliesRuntimeStatusEventsImmediately(t *testing.T) {
 	}
 }
 
+func TestStatePatchFromActivityEventIgnoresCompletedTurnLastError(t *testing.T) {
+	event := activityshared.NewTurnCompleted(activityshared.EventContext{
+		EventID:           "turn-completed",
+		Provider:          activityshared.ProviderClaudeCode,
+		ProviderSessionID: "provider-session",
+		AgentSessionID:    "agent-session",
+		CWD:               "/workspace/room-1",
+		OccurredAtUnixMS:  1710000000200,
+	}, "turn-1", activityshared.TurnOutcomeCompleted)
+	event.Payload.Metadata = map[string]any{
+		"lastError":  "end_turn",
+		"stopReason": "end_turn",
+	}
+
+	patch, ok := statePatchFromActivityEvent(EventSource{}, event, "agent-session", event.OccurredAtUnixMS)
+	if !ok {
+		t.Fatal("statePatchFromActivityEvent ok = false, want true")
+	}
+	if patch.LastError != "" {
+		t.Fatalf("last error = %q, want empty for completed turn", patch.LastError)
+	}
+}
+
 func TestStoreDoesNotAdvanceUpdatedAtForPassiveSessionUpdateEvent(t *testing.T) {
 	svc := New(nil)
 	svc.TrackRoom("room-1")

--- a/packages/agent/daemon/activity/sync_state_persistence_test.go
+++ b/packages/agent/daemon/activity/sync_state_persistence_test.go
@@ -67,7 +67,7 @@ func newBlockingSyncStateStore() *blockingSyncStateStore {
 	}
 }
 
-func (s *blockingSyncStateStore) LoadRoomSyncStates(_ context.Context, _ string) (map[string]WorkspaceAgentSyncState, error) {
+func (*blockingSyncStateStore) LoadRoomSyncStates(_ context.Context, _ string) (map[string]WorkspaceAgentSyncState, error) {
 	return nil, nil
 }
 

--- a/packages/agent/daemon/activity/types.go
+++ b/packages/agent/daemon/activity/types.go
@@ -2,10 +2,7 @@ package agentsessionstore
 
 import (
 	"encoding/json"
-	"errors"
-	"fmt"
 	"net/http"
-	"strings"
 	"time"
 )
 
@@ -742,24 +739,6 @@ func (s *WorkspaceAgentSession) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
-func firstNonZeroFlexibleInt64(values ...flexibleInt64) flexibleInt64 {
-	for _, value := range values {
-		if value != 0 {
-			return value
-		}
-	}
-	return 0
-}
-
-func firstNonZeroFlexibleUint64(values ...flexibleUint64) flexibleUint64 {
-	for _, value := range values {
-		if value != 0 {
-			return value
-		}
-	}
-	return 0
-}
-
 func (i *WorkspaceAgentTimelineItem) UnmarshalJSON(data []byte) error {
 	var raw struct {
 		ID               flexibleUint64 `json:"id"`
@@ -803,81 +782,4 @@ func (i *WorkspaceAgentTimelineItem) UnmarshalJSON(data []byte) error {
 		CreatedAtUnixMS:  int64(raw.CreatedAtUnixMS),
 	}
 	return nil
-}
-
-type HTTPError struct {
-	StatusCode int
-	Body       string
-	Header     http.Header
-}
-
-func (e HTTPError) Error() string {
-	if strings.TrimSpace(e.Body) == "" {
-		return fmt.Sprintf("agent activity request failed (%d)", e.StatusCode)
-	}
-	return fmt.Sprintf("agent activity request failed (%d): %s", e.StatusCode, e.Body)
-}
-
-type requestBodySizedError struct {
-	err              error
-	requestBodyBytes int
-}
-
-func (e requestBodySizedError) Error() string {
-	return e.err.Error()
-}
-
-func (e requestBodySizedError) Unwrap() error {
-	return e.err
-}
-
-func (e requestBodySizedError) RequestBodyBytes() int {
-	return e.requestBodyBytes
-}
-
-func WithRequestBodyBytes(err error, requestBodyBytes int) error {
-	if err == nil || requestBodyBytes <= 0 {
-		return err
-	}
-	var sized interface{ RequestBodyBytes() int }
-	if errors.As(err, &sized) && sized.RequestBodyBytes() > 0 {
-		return err
-	}
-	return requestBodySizedError{
-		err:              err,
-		requestBodyBytes: requestBodyBytes,
-	}
-}
-
-func RequestBodyBytesFromError(err error) (int, bool) {
-	if err == nil {
-		return 0, false
-	}
-	var sized interface{ RequestBodyBytes() int }
-	if !errors.As(err, &sized) {
-		return 0, false
-	}
-	requestBodyBytes := sized.RequestBodyBytes()
-	if requestBodyBytes <= 0 {
-		return 0, false
-	}
-	return requestBodyBytes, true
-}
-
-func firstNonEmptyString(values ...string) string {
-	for _, value := range values {
-		if trimmed := strings.TrimSpace(value); trimmed != "" {
-			return trimmed
-		}
-	}
-	return ""
-}
-
-func firstNonZeroInt(values ...int) int {
-	for _, value := range values {
-		if value != 0 {
-			return value
-		}
-	}
-	return 0
 }

--- a/packages/agent/daemon/activity/types_helpers.go
+++ b/packages/agent/daemon/activity/types_helpers.go
@@ -1,0 +1,103 @@
+package agentsessionstore
+
+import (
+	"errors"
+	"fmt"
+	"net/http"
+	"strings"
+)
+
+func firstNonZeroFlexibleInt64(values ...flexibleInt64) flexibleInt64 {
+	for _, value := range values {
+		if value != 0 {
+			return value
+		}
+	}
+	return 0
+}
+
+func firstNonZeroFlexibleUint64(values ...flexibleUint64) flexibleUint64 {
+	for _, value := range values {
+		if value != 0 {
+			return value
+		}
+	}
+	return 0
+}
+
+type HTTPError struct {
+	StatusCode int
+	Body       string
+	Header     http.Header
+}
+
+func (e HTTPError) Error() string {
+	if strings.TrimSpace(e.Body) == "" {
+		return fmt.Sprintf("agent activity request failed (%d)", e.StatusCode)
+	}
+	return fmt.Sprintf("agent activity request failed (%d): %s", e.StatusCode, e.Body)
+}
+
+type requestBodySizedError struct {
+	err              error
+	requestBodyBytes int
+}
+
+func (e requestBodySizedError) Error() string {
+	return e.err.Error()
+}
+
+func (e requestBodySizedError) Unwrap() error {
+	return e.err
+}
+
+func (e requestBodySizedError) RequestBodyBytes() int {
+	return e.requestBodyBytes
+}
+
+func WithRequestBodyBytes(err error, requestBodyBytes int) error {
+	if err == nil || requestBodyBytes <= 0 {
+		return err
+	}
+	var sized interface{ RequestBodyBytes() int }
+	if errors.As(err, &sized) && sized.RequestBodyBytes() > 0 {
+		return err
+	}
+	return requestBodySizedError{
+		err:              err,
+		requestBodyBytes: requestBodyBytes,
+	}
+}
+
+func RequestBodyBytesFromError(err error) (int, bool) {
+	if err == nil {
+		return 0, false
+	}
+	var sized interface{ RequestBodyBytes() int }
+	if !errors.As(err, &sized) {
+		return 0, false
+	}
+	requestBodyBytes := sized.RequestBodyBytes()
+	if requestBodyBytes <= 0 {
+		return 0, false
+	}
+	return requestBodyBytes, true
+}
+
+func firstNonEmptyString(values ...string) string {
+	for _, value := range values {
+		if trimmed := strings.TrimSpace(value); trimmed != "" {
+			return trimmed
+		}
+	}
+	return ""
+}
+
+func firstNonZeroInt(values ...int) int {
+	for _, value := range values {
+		if value != 0 {
+			return value
+		}
+	}
+	return 0
+}

--- a/packages/agent/daemon/runtime/claude_sdk_goal.go
+++ b/packages/agent/daemon/runtime/claude_sdk_goal.go
@@ -247,7 +247,7 @@ func (a *ClaudeCodeSDKAdapter) applyLocalGoal(adapterSession *claudeSDKAdapterSe
 	adapterSession.liveState.goal = clonePayload(goal)
 }
 
-func (a *ClaudeCodeSDKAdapter) goalMirrorEvents(session Session, updateType string) []activityshared.Event {
+func (*ClaudeCodeSDKAdapter) goalMirrorEvents(session Session, updateType string) []activityshared.Event {
 	if event, ok := acpGoalUpdatedEvent(session, updateType); ok {
 		return []activityshared.Event{event}
 	}

--- a/packages/agent/daemon/runtime/codex_appserver_adapter.go
+++ b/packages/agent/daemon/runtime/codex_appserver_adapter.go
@@ -890,7 +890,7 @@ func (*CodexAppServerAdapter) fetchRateLimitsNoHandler(
 // fetchGoal reads the thread's persisted goal. Best effort: any error means
 // the in-memory goal stays as-is. NoHandler: this runs in the background and
 // must not claim the message handler slot away from a streaming turn.
-func (a *CodexAppServerAdapter) fetchGoal(
+func (*CodexAppServerAdapter) fetchGoal(
 	ctx context.Context,
 	client *codexAppServerClient,
 	threadID string,

--- a/packages/agent/daemon/runtime/codex_appserver_adapter_test.go
+++ b/packages/agent/daemon/runtime/codex_appserver_adapter_test.go
@@ -2577,7 +2577,7 @@ func TestCodexAppServerAdapterSlashGoalContinuesUntilTerminalGoal(t *testing.T) 
 
 	var sinkMu sync.Mutex
 	sinkEvents := []activityshared.Event{}
-	adapter.SetSessionEventSink(func(agentSessionID string, events []activityshared.Event) {
+	adapter.SetSessionEventSink(func(_ string, events []activityshared.Event) {
 		sinkMu.Lock()
 		defer sinkMu.Unlock()
 		sinkEvents = append(sinkEvents, events...)
@@ -2654,7 +2654,7 @@ func TestCodexAppServerAdapterUnownedTurnIgnoredWithoutGoal(t *testing.T) {
 	adapter, _, session := startedAppServerAdapter(t)
 	var sinkMu sync.Mutex
 	sinkEvents := []activityshared.Event{}
-	adapter.SetSessionEventSink(func(agentSessionID string, events []activityshared.Event) {
+	adapter.SetSessionEventSink(func(_ string, events []activityshared.Event) {
 		sinkMu.Lock()
 		defer sinkMu.Unlock()
 		sinkEvents = append(sinkEvents, events...)
@@ -3121,7 +3121,7 @@ func TestCodexAppServerAdapterGoalUpdateNotificationEmitsSessionEvent(t *testing
 	adapter, _, session := startedAppServerAdapter(t)
 	var sinkMu sync.Mutex
 	sinkEvents := []activityshared.Event{}
-	adapter.SetSessionEventSink(func(agentSessionID string, events []activityshared.Event) {
+	adapter.SetSessionEventSink(func(_ string, events []activityshared.Event) {
 		sinkMu.Lock()
 		defer sinkMu.Unlock()
 		sinkEvents = append(sinkEvents, events...)

--- a/packages/agent/daemon/runtime/controller.go
+++ b/packages/agent/daemon/runtime/controller.go
@@ -1809,7 +1809,7 @@ func settledFallbackTurnEvents(session Session, turnID string) []activityshared.
 //     a concurrent event already moved past).
 //
 // Returns true when a reconciliation was performed.
-func (c *Controller) reconcileStuckTurnView(ctx context.Context, session Session, reason string) bool {
+func (c *Controller) reconcileStuckTurnView(_ context.Context, session Session, reason string) bool {
 	if c == nil || !sessionViewHasUnsettledTurn(session) {
 		return false
 	}

--- a/packages/agent/daemon/runtime/reporter.go
+++ b/packages/agent/daemon/runtime/reporter.go
@@ -1093,15 +1093,8 @@ func codexSubmitAvailabilityForLifecyclePhase(phase string) *agentsessionstore.W
 }
 
 func statePatchLastError(event activityshared.Event) string {
-	switch event.Type {
-	case activityshared.EventSessionUpdated:
-		if strings.TrimSpace(event.Payload.EffectiveStatus) == string(activityshared.SessionStatusPaused) {
-			return ""
-		}
-	case activityshared.EventTurnCompleted:
-		if strings.TrimSpace(event.Payload.TurnOutcome) == string(activityshared.TurnOutcomeInterrupted) {
-			return ""
-		}
+	if event.Type != activityshared.EventSessionFailed && event.Type != activityshared.EventTurnFailed {
+		return ""
 	}
 	detail := visibleFailureDetail(event)
 	if detail == "" {

--- a/packages/agent/daemon/runtime/reporter_test.go
+++ b/packages/agent/daemon/runtime/reporter_test.go
@@ -1040,7 +1040,9 @@ func TestReporterProjectsSessionAndTurnLifecycleToStatePatches(t *testing.T) {
 	input := reportActivityInput(session, []activityshared.Event{
 		newSessionActivityEvent(session, EventSessionStarted, SessionStatusReady, nil),
 		newTurnActivityEventWithID(session, "turn-start-1", EventTurnStarted, "turn-1", SessionStatusWorking, "", "", nil),
-		newTurnActivityEventWithID(session, "turn-done-1", EventTurnCompleted, "turn-1", SessionStatusReady, "", "", nil),
+		newTurnActivityEventWithID(session, "turn-done-1", EventTurnCompleted, "turn-1", SessionStatusReady, "", "", map[string]any{
+			"stopReason": "end_turn",
+		}),
 	})
 	err := reporter.Report(context.Background(), input)
 	if err != nil {
@@ -1048,6 +1050,9 @@ func TestReporterProjectsSessionAndTurnLifecycleToStatePatches(t *testing.T) {
 	}
 	if client.calls != 3 {
 		t.Fatalf("calls = %d, want 3 state reports", client.calls)
+	}
+	if len(client.stateInputs) != 3 {
+		t.Fatalf("state inputs = %#v, want 3", client.stateInputs)
 	}
 	if len(input.TimelineItems) != 0 {
 		t.Fatalf("timeline items = %#v, want none for lifecycle-only report", input.TimelineItems)
@@ -1080,6 +1085,12 @@ func TestReporterProjectsSessionAndTurnLifecycleToStatePatches(t *testing.T) {
 		input.StatePatches[2].SubmitAvailability.State != "available" ||
 		input.StatePatches[2].CurrentPhase != string(activityshared.TurnPhaseIdle) {
 		t.Fatalf("turn completed patch = %#v", input.StatePatches[2])
+	}
+	if input.StatePatches[2].LastError != "" {
+		t.Fatalf("turn completed last error = %q, want empty", input.StatePatches[2].LastError)
+	}
+	if client.stateInputs[2].State.LastError != "" {
+		t.Fatalf("reported turn completed last error = %q, want empty", client.stateInputs[2].State.LastError)
 	}
 }
 
@@ -1189,6 +1200,9 @@ func TestReporterProjectsTurnFailureErrorToStatePatch(t *testing.T) {
 	}
 	if input.StatePatches[0].LastError != "Codex request failed because a quota or rate limit was reached." {
 		t.Fatalf("last error = %q, want projected failure reason", input.StatePatches[0].LastError)
+	}
+	if client.stateInputs[0].State.LastError != "Codex request failed because a quota or rate limit was reached." {
+		t.Fatalf("reported last error = %q, want projected failure reason", client.stateInputs[0].State.LastError)
 	}
 	if len(input.MessageUpdates) != 1 {
 		t.Fatalf("message updates = %#v, want visible failure message", input.MessageUpdates)


### PR DESCRIPTION
## Summary
- restrict agent activity `lastError` projection to real session/turn failure events
- preserve failed-turn `lastError` through the legacy session-state compatibility path
- add regression coverage for `turn.completed` with `stopReason=end_turn` and reported payloads
- clean up agent daemon Go lint issues exposed by the PR validation path

## Verification
- `go test ./packages/agent/daemon/activity`
- `go test ./packages/agent/daemon/runtime -count=1`
- `go test ./packages/agent/daemon/activity ./packages/agent/daemon/runtime -count=1`
- `PATH="/Users/liying/go/bin:$PATH" pnpm check:changed --tail-lines 80`
- pre-push `pnpm check:full` passed during `git push`

## Documentation
- No durable documentation impact found; this is internal state projection and lint cleanup.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved how session and turn errors are recorded, so failure messages now appear only when a session or turn actually fails.
  * Prevented completed turns from showing an error message when they end normally.
  * Improved consistency in reported state updates and error handling for agent activity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->