### PR TITLE
chore(claude-sdk-sidecar): make package publishable to npm

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -18,6 +18,7 @@
       "@tutti-os/workspace-terminal",
       "@tutti-os/agent-activity-core",
       "@tutti-os/agent-gui",
+      "@tutti-os/claude-sdk-sidecar",
       "@tutti-os/browser-node",
       "@tutti-os/workspace-file-preview",
       "@tutti-os/workbench-snapshot",

--- a/packages/agent/claude-sdk-sidecar/README.md
+++ b/packages/agent/claude-sdk-sidecar/README.md
@@ -1,0 +1,22 @@
+# @tutti-os/claude-sdk-sidecar
+
+Sidecar process that bridges the Tutti agent runtime to the
+[`@anthropic-ai/claude-agent-sdk`](https://www.npmjs.com/package/@anthropic-ai/claude-agent-sdk).
+
+Unlike the other `@tutti-os/*` release packages, this package ships **raw
+TypeScript** under `src/` rather than a compiled `dist/`. It is executed
+directly with Node's type-stripping loader:
+
+```sh
+node --experimental-strip-types ./src/main.ts
+```
+
+Consumers (the Tutti daemon, the desktop bundle, and `tsh`'s `npm-bundle-dir`)
+pull this package into `node_modules`, install its runtime `dependencies`, and
+launch `src/main.ts` with `--experimental-strip-types`. There is therefore no
+build step and no bundled entry point beyond the source files.
+
+## Runtime dependencies
+
+- `@anthropic-ai/claude-agent-sdk`
+- `zod`

--- a/packages/agent/claude-sdk-sidecar/package.json
+++ b/packages/agent/claude-sdk-sidecar/package.json
@@ -1,10 +1,26 @@
 {
   "name": "@tutti-os/claude-sdk-sidecar",
   "version": "0.1.0",
-  "private": true,
+  "private": false,
   "type": "module",
+  "files": [
+    "src/main.ts",
+    "src/normalizer.ts",
+    "src/options.ts",
+    "src/taskNotification.ts",
+    "README.md"
+  ],
+  "publishConfig": {
+    "access": "public"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/tutti-os/tutti.git",
+    "directory": "packages/agent/claude-sdk-sidecar"
+  },
   "scripts": {
     "start": "node --experimental-strip-types ./src/main.ts",
+    "build": "node -e \"process.stdout.write('claude-sdk-sidecar ships raw TypeScript; no build step\\n')\"",
     "test": "node --test --experimental-strip-types ./src/**/*.test.ts",
     "typecheck": "node ../../../tools/scripts/run-tsgo-typecheck.mjs"
   },

--- a/tools/scripts/check-package-packs.mjs
+++ b/tools/scripts/check-package-packs.mjs
@@ -14,6 +14,11 @@ const forbiddenPrefixes = [
   "package/tsup.config"
 ];
 
+// Packages that intentionally publish their raw TypeScript sources instead of a
+// compiled dist/ output. @tutti-os/claude-sdk-sidecar is executed directly with
+// `node --experimental-strip-types src/main.ts`, so it ships src/ on purpose.
+const sourcePublishingPackages = new Set(["@tutti-os/claude-sdk-sidecar"]);
+
 const packages = await getNpmReleasePackages();
 const tempDirectory = await mkdtemp(join(tmpdir(), "tutti-pack-check-"));
 
@@ -41,6 +46,11 @@ async function checkPackage(packageConfig, destination) {
   const entrySet = new Set(entries);
   const violations = [];
   const requiredFiles = getRequiredFiles(packageConfig.manifest);
+  const packageForbiddenPrefixes = sourcePublishingPackages.has(
+    packageConfig.name
+  )
+    ? forbiddenPrefixes.filter((prefix) => prefix !== "package/src/")
+    : forbiddenPrefixes;
 
   for (const requiredFile of requiredFiles) {
     if (!entrySet.has(requiredFile)) {
@@ -49,7 +59,7 @@ async function checkPackage(packageConfig, destination) {
   }
 
   for (const entry of entries) {
-    if (forbiddenPrefixes.some((prefix) => entry.startsWith(prefix))) {
+    if (packageForbiddenPrefixes.some((prefix) => entry.startsWith(prefix))) {
       violations.push(`unexpected ${entry}`);
     }
   }


### PR DESCRIPTION
## What

Make `@tutti-os/claude-sdk-sidecar` publishable to public npm so tsh's `npm-bundle-dir` (and any external consumer) can pull it and its runtime dependencies (`@anthropic-ai/claude-agent-sdk`, `zod`).

## Why it isn't just a `private: false` flip

The sidecar is executed as **raw TypeScript** via `node --experimental-strip-types src/main.ts` in three places (the Go adapter default, the desktop vendor script, and tsh). It has no build/`dist`. But this repo's npm release pipeline:

- forbids `package/src/` in published tarballs (`check-package-packs.mjs`), and
- forces any `private:false` + `publishConfig.access:public` package into the `.changeset/config.json` fixed release group (else the whole release flow throws).

So the package is integrated by **keeping raw TS and opening a scoped hole in the pack-check**, rather than rewiring the runtime to a `dist` build (which would touch the Go adapter, vendor script, and tsh across packages/repos).

## Changes

- **`package.json`**: drop `private`, add `publishConfig.access=public`, `repository`, and a no-op `build` script (`build-npm-packages` runs `build` per release package). `files` ships the four raw `.ts` sources (tests excluded) + `README.md`. Runtime `dependencies` preserved; `@tutti-os/config-tsconfig` stays a devDep (not installed by consumers).
- **`README.md`**: added (pack-check requires it); documents the raw-TS design.
- **`.changeset/config.json`**: add the package to the fixed release group.
- **`check-package-packs.mjs`**: `sourcePublishingPackages` allowlist exempts this one package from the `src/` ban; all other packages still forbid `src/`, and `tsconfig.json`/`tsup.config` remain forbidden for everyone.

## Verification

- `pnpm build` runs (no-op); tarball contains `package.json` + `README.md` + 4 `.ts` only (no tests, no tsconfig).
- Release-selection guard resolves 23 packages with the sidecar public.

## Releasing

The `npm Package Release` workflow is **`workflow_dispatch` only** — merging this does not auto-publish. After merge, dispatch `npm-package-release.yml` against `main` (it resolves the next version, applies it, runs pack-check, then publishes). No changeset `.md` is needed; the version is auto-resolved.

> Note: change #4 relaxes shared release policy tooling (a per-package `src/` allowlist) — worth a release/agent owner's eyes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for publishing and running the `@tutti-os/claude-sdk-sidecar` package as a sidecar process.
  * The package is now included in the fixed-release group.

* **Documentation**
  * Added package documentation explaining setup, runtime behavior, and required dependencies.

* **Chores**
  * Updated packaging metadata so the package can be published publicly.
  * Adjusted package validation to allow source files in the published package where needed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->