### PR TITLE
fix(tuttid): delete user projects by path, not a recomputed id

### DIFF
--- a/services/tuttid/data/workspace/sqlite_user_projects.go
+++ b/services/tuttid/data/workspace/sqlite_user_projects.go
@@ -61,6 +61,26 @@ WHERE id = ?
 	return nil
 }
 
+// DeleteUserProjectByPath removes a user project by its unique path rather
+// than by a recomputed id. The `path` column carries the table's UNIQUE
+// constraint (see applyUserProjectsV1), so it is the durable lookup key for a
+// caller-supplied path; deleting by an id that gets recomputed from the path
+// on every call can silently miss the row if that derivation ever drifts from
+// what was actually stored, leaving the "removed" project in place.
+func (s *SQLiteStore) DeleteUserProjectByPath(ctx context.Context, path string) error {
+	if s == nil || s.db == nil {
+		return errors.New("workspace database is not initialized")
+	}
+	_, err := s.db.ExecContext(ctx, `
+DELETE FROM user_projects
+WHERE path = ?
+`, path)
+	if err != nil {
+		return fmt.Errorf("delete user project by path: %w", err)
+	}
+	return nil
+}
+
 func (s *SQLiteStore) PutUserProject(ctx context.Context, project userprojectbiz.Project) (userprojectbiz.Project, error) {
 	if s == nil || s.db == nil {
 		return userprojectbiz.Project{}, errors.New("workspace database is not initialized")

--- a/services/tuttid/data/workspace/sqlite_user_projects_test.go
+++ b/services/tuttid/data/workspace/sqlite_user_projects_test.go
@@ -90,3 +90,34 @@ func TestSQLiteStoreDeleteUserProjectRemovesRecentProject(t *testing.T) {
 		t.Fatalf("ListUserProjects() len = %d, want 0", len(projects))
 	}
 }
+
+// TestSQLiteStoreDeleteUserProjectByPathRemovesRowWithMismatchedID guards
+// against the "remove project" no-op regression: the `path` column is the
+// table's UNIQUE key (see applyUserProjectsV1), so deleting by path must
+// still remove the row even if the stored `id` doesn't match whatever a
+// caller would recompute from the path. Deleting by a recomputed id instead
+// is exactly the bug this store method exists to avoid.
+func TestSQLiteStoreDeleteUserProjectByPathRemovesRowWithMismatchedID(t *testing.T) {
+	ctx := context.Background()
+	store := openTestSQLiteStore(t)
+
+	_, err := store.PutUserProject(ctx, userprojectbiz.Project{
+		ID:    "user_project_stale-mismatched-id",
+		Path:  "/workspace/mismatched",
+		Label: "mismatched",
+	})
+	if err != nil {
+		t.Fatalf("PutUserProject() error = %v", err)
+	}
+
+	if err := store.DeleteUserProjectByPath(ctx, "/workspace/mismatched"); err != nil {
+		t.Fatalf("DeleteUserProjectByPath() error = %v", err)
+	}
+	projects, err := store.ListUserProjects(ctx)
+	if err != nil {
+		t.Fatalf("ListUserProjects() error = %v", err)
+	}
+	if len(projects) != 0 {
+		t.Fatalf("ListUserProjects() len = %d, want 0", len(projects))
+	}
+}

--- a/services/tuttid/data/workspace/store.go
+++ b/services/tuttid/data/workspace/store.go
@@ -66,6 +66,7 @@ type ManagedCredentialsStore interface {
 
 type UserProjectStore interface {
 	DeleteUserProject(context.Context, string) error
+	DeleteUserProjectByPath(context.Context, string) error
 	ListUserProjects(context.Context) ([]userprojectbiz.Project, error)
 	PutUserProject(context.Context, userprojectbiz.Project) (userprojectbiz.Project, error)
 	TouchUserProject(context.Context, string, int64) error

--- a/services/tuttid/service/userproject/service.go
+++ b/services/tuttid/service/userproject/service.go
@@ -124,7 +124,14 @@ func (s Service) Delete(ctx context.Context, input DeleteInput) error {
 	if err != nil {
 		return err
 	}
-	return s.Store.DeleteUserProject(ctx, projectID(projectPath))
+	// Delete by the normalized path rather than a recomputed id: `path` is
+	// the table's durable UNIQUE key, while `projectID(projectPath)` is
+	// derived fresh on every call and is only guaranteed to match the id that
+	// was stored at registration time. If that derivation ever drifts (e.g.
+	// symlink resolution behaves differently the second time around), a
+	// delete keyed on the recomputed id silently affects zero rows and the
+	// "removed" project never actually goes away.
+	return s.Store.DeleteUserProjectByPath(ctx, projectPath)
 }
 
 func normalizeDirectoryPath(path string) (string, error) {

--- a/services/tuttid/service/userproject/service_test.go
+++ b/services/tuttid/service/userproject/service_test.go
@@ -90,8 +90,45 @@ func TestServiceDeleteNormalizesPathAndRemovesRecentProject(t *testing.T) {
 		t.Fatalf("Delete() error = %v", err)
 	}
 
-	if strings.Join(store.deletedIDs, ",") != projectID(expectedPath) {
-		t.Fatalf("deleted IDs = %#v, want %q", store.deletedIDs, projectID(expectedPath))
+	if strings.Join(store.deletedPaths, ",") != expectedPath {
+		t.Fatalf("deleted paths = %#v, want %q", store.deletedPaths, expectedPath)
+	}
+}
+
+// TestServiceDeleteDoesNotDependOnRecomputedID guards against a regression
+// where Delete looked a project up by re-deriving projectID(path) instead of
+// using the table's actual UNIQUE path key. If a stored row's id ever ends up
+// out of sync with a freshly recomputed hash of its path (for example because
+// id derivation changed, or drifted for any other reason), deleting by that
+// recomputed id silently affects zero rows and the "removed" project never
+// goes away. Deleting by path sidesteps that entire class of mismatch.
+func TestServiceDeleteDoesNotDependOnRecomputedID(t *testing.T) {
+	ctx := context.Background()
+	root := t.TempDir()
+	projectDir := filepath.Join(root, "tutti")
+	if err := os.MkdirAll(projectDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll() error = %v", err)
+	}
+	expectedPath, err := filepath.EvalSymlinks(projectDir)
+	if err != nil {
+		t.Fatalf("EvalSymlinks() error = %v", err)
+	}
+	store := &recordingUserProjectStore{
+		projects: []userprojectbiz.Project{
+			{ID: "user_project_stale-mismatched-id", Path: expectedPath, Label: "tutti"},
+		},
+	}
+	service := Service{Store: store}
+
+	if err := service.Delete(ctx, DeleteInput{Path: projectDir}); err != nil {
+		t.Fatalf("Delete() error = %v", err)
+	}
+
+	if len(store.deletedIDs) != 0 {
+		t.Fatalf("deleted IDs = %#v, want none (delete must key off path)", store.deletedIDs)
+	}
+	if strings.Join(store.deletedPaths, ",") != expectedPath {
+		t.Fatalf("deleted paths = %#v, want %q", store.deletedPaths, expectedPath)
 	}
 }
 
@@ -178,15 +215,21 @@ func TestServiceCheckPathReportsDirectoryStatusWithoutStore(t *testing.T) {
 }
 
 type recordingUserProjectStore struct {
-	projects   []userprojectbiz.Project
-	deletedIDs []string
-	put        struct {
+	projects     []userprojectbiz.Project
+	deletedIDs   []string
+	deletedPaths []string
+	put          struct {
 		Project userprojectbiz.Project
 	}
 }
 
 func (s *recordingUserProjectStore) DeleteUserProject(_ context.Context, id string) error {
 	s.deletedIDs = append(s.deletedIDs, id)
+	return nil
+}
+
+func (s *recordingUserProjectStore) DeleteUserProjectByPath(_ context.Context, path string) error {
+	s.deletedPaths = append(s.deletedPaths, path)
 	return nil
 }
 


### PR DESCRIPTION
## What was broken

Ricky reported that the desktop app's "移除" (remove project) action sometimes doesn't actually work — the project reappears later even after clicking remove.

I dug through a diagnostic log export (`tutti-logs-20260706-002027.zip`, `tuttid.log`/`tutti-desktop.log` for 2026-07-01 through 07-05). There is **zero logging anywhere in this feature's call chain** — I verified no `slog`/log statements exist in `services/tuttid/api/daemon_user_projects.go`, `services/tuttid/service/userproject/service.go`, or `services/tuttid/data/workspace/sqlite_user_projects.go` — so a failure here is invisible in the logs; grepping for "user_project"/"移除"/"remove"/"delete" across the entire export returns nothing relevant. That absence is itself diagnostic: whatever the failure mode, it's silent by construction.

## Root cause

`DELETE /v1/user-projects` sends only a `path` (`services/tuttid/api/openapi/tuttid.v1.yaml` `DeleteUserProject` request body). `Service.Delete` (`services/tuttid/service/userproject/service.go:119-128`, before this change) re-derived the row's `id` from that path (`sha256(normalizeDirectoryPath(path))`) and issued `DELETE FROM user_projects WHERE id = ?` (`services/tuttid/data/workspace/sqlite_user_projects.go:50-62`).

The table's actual durable, `UNIQUE` key is `path`, not this recomputed id (`services/tuttid/data/workspace/migrations.go:580-587`: `id TEXT PRIMARY KEY`, `path TEXT NOT NULL UNIQUE`). If the freshly recomputed id for a given path ever fails to match the id that's actually stored for that row, the `DELETE` silently affects **zero rows** — `database/sql` doesn't error on that, so the handler still returns `204`. The desktop UI (`apps/desktop/.../desktopWorkspaceUserProjectService.ts`) treats a non-error response as success and removes the project from its own in-memory list — a `Map` that only lives for the process lifetime and is never persisted. So the project vanishes from view, but is never actually gone from the daemon's SQLite store, and reappears the next time the project list is reloaded from the daemon (e.g. after restarting the app).

## The fix

Minimal, scoped change:
- Add `UserProjectStore.DeleteUserProjectByPath(ctx, path)` and a SQLite implementation that does `DELETE FROM user_projects WHERE path = ?`.
- `Service.Delete` now calls this instead of recomputing and matching on `id`. This removes the entire class of id-recomputation-mismatch bugs for the user-initiated remove path.
- `Service.List`'s separate auto-pruning path is untouched — it already deletes by the real `id` read back from the row, so it isn't affected by this issue.

## Tests

- Updated `TestServiceDeleteNormalizesPathAndRemovesRecentProject` to assert deletion now happens by path.
- Added `TestServiceDeleteDoesNotDependOnRecomputedID` (service-level) and `TestSQLiteStoreDeleteUserProjectByPathRemovesRowWithMismatchedID` (real SQLite-level): both seed a stored row whose `id` deliberately does **not** match `projectID(path)`, then confirm `Delete`/`DeleteUserProjectByPath` still removes the row — reproducing and fixing the exact silent-no-op failure mode.
- `go build ./...` and `go test ./service/userproject/... ./data/workspace/... ./api/...` pass in `services/tuttid`. (Unrelated pre-existing failures in `service/workspace` — missing generated embedded app archive fixtures — reproduce identically on `origin/main` without this change.)

## Test plan
- [x] `go build ./...` (services/tuttid module)
- [x] `go test ./service/userproject/... ./data/workspace/... ./api/...` — all pass, including new regression tests
- [x] Confirmed pre-existing unrelated failures in `service/workspace` also occur on main (not caused by this change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Deleting a user project now uses its normalized path, making removals reliable even when IDs differ or drift over time.
  * Improved delete handling for projects stored with symlinks or other path-normalization differences.
* **Tests**
  * Added coverage for deleting projects by path and for cases where stored IDs do not match the computed value.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->