### PR TITLE
fix(agent-gui): keep slash command palette clear of the traffic lights

### DIFF
--- a/packages/agent/gui/agent-gui/agentGuiNode/composerFloatingMenu/ComposerFloatingMenuSurface.spec.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/composerFloatingMenu/ComposerFloatingMenuSurface.spec.tsx
@@ -1,0 +1,47 @@
+import "@testing-library/jest-dom/vitest";
+import { render, screen } from "@testing-library/react";
+import { createRef } from "react";
+import { describe, expect, it, vi } from "vitest";
+import { DESKTOP_WINDOW_TOP_MARGIN } from "../../workspaceDesktop/constants";
+import { ComposerFloatingMenuSurface } from "./ComposerFloatingMenuSurface";
+
+describe("ComposerFloatingMenuSurface", () => {
+  it("keeps a fixed-height menu clear of the workspace window's traffic-light header even when the anchor sits near the top of the viewport", () => {
+    const anchorRef = createRef<HTMLDivElement>();
+    const anchor = document.createElement("div");
+    anchor.getBoundingClientRect = vi.fn(
+      () =>
+        ({
+          bottom: 90,
+          height: 30,
+          left: 12,
+          right: 200,
+          top: 60,
+          width: 188,
+          x: 12,
+          y: 60,
+          toJSON: () => ({})
+        }) as DOMRect
+    );
+    document.body.appendChild(anchor);
+    anchorRef.current = anchor;
+
+    render(
+      <ComposerFloatingMenuSurface
+        anchorRef={anchorRef}
+        maxHeight={320}
+        open
+        placement="fixed-height"
+        testId="composer-floating-menu-surface"
+      >
+        <div>menu content</div>
+      </ComposerFloatingMenuSurface>
+    );
+
+    const surface = screen.getByTestId("composer-floating-menu-surface");
+    const top = Number.parseFloat(surface.style.top);
+    expect(top).toBeGreaterThanOrEqual(DESKTOP_WINDOW_TOP_MARGIN);
+
+    anchor.remove();
+  });
+});

--- a/packages/agent/gui/agent-gui/agentGuiNode/composerFloatingMenu/ComposerFloatingMenuSurface.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/composerFloatingMenu/ComposerFloatingMenuSurface.tsx
@@ -11,9 +11,18 @@ import {
 } from "react";
 import { createPortal } from "react-dom";
 import { cn } from "../../../app/renderer/lib/utils";
+import { DESKTOP_WINDOW_TOP_MARGIN } from "../../workspaceDesktop/constants";
 
 const COMPOSER_MENU_GAP_PX = 8;
 const COMPOSER_MENU_VIEWPORT_PADDING_PX = 8;
+// Keep the menu clear of the workspace window's own header, where the macOS
+// traffic lights live (see `workspaceWindowHeaderHeightPx` in
+// apps/desktop/src/main/windows/workspaceWindow.ts and the matching
+// `DESKTOP_WINDOW_TOP_MARGIN` reserve used to place node windows below that
+// header). Anchors near the top of the canvas otherwise collapse this menu's
+// top offset down to the bare viewport padding, landing it on top of the
+// traffic lights and drag region.
+const COMPOSER_MENU_TOP_SAFE_AREA_PX = DESKTOP_WINDOW_TOP_MARGIN;
 const COMPOSER_MENU_MIN_HEIGHT_PX = 280;
 
 export interface ComposerAnchoredMenuFrame {
@@ -98,7 +107,7 @@ function computeComposerAnchoredMenuFrame(
     )
   );
   const availableAbove =
-    rect.top - COMPOSER_MENU_GAP_PX - COMPOSER_MENU_VIEWPORT_PADDING_PX;
+    rect.top - COMPOSER_MENU_GAP_PX - COMPOSER_MENU_TOP_SAFE_AREA_PX;
   const height =
     availableAbove >= maxHeight
       ? maxHeight
@@ -116,7 +125,7 @@ function computeComposerAnchoredMenuFrame(
     left,
     portalTarget: resolveComposerMenuPortalTarget(anchor),
     top: Math.max(
-      COMPOSER_MENU_VIEWPORT_PADDING_PX,
+      COMPOSER_MENU_TOP_SAFE_AREA_PX,
       Math.min(
         rect.top - COMPOSER_MENU_GAP_PX - height,
         viewportHeight - COMPOSER_MENU_VIEWPORT_PADDING_PX - height


### PR DESCRIPTION
## Summary
- A screenshot from the desktop app showed the composer's slash command palette ("命令" group header, entries like 状态/status, 快速/fast, 目标/goal, 审查/review, 计划/plan) rendering at the very top-left of the workspace window, overlapping the native macOS traffic lights and the draggable title bar.
- Root cause: `ComposerFloatingMenuSurface`'s `computeComposerAnchoredMenuFrame` (in `packages/agent/gui/agent-gui/agentGuiNode/composerFloatingMenu/ComposerFloatingMenuSurface.tsx`) positions the "fixed-height" placement (used by the slash palette) above the composer anchor with `position: fixed`, but clamps the vertical `top` offset to a flat `COMPOSER_MENU_VIEWPORT_PADDING_PX` (8px) floor whenever there isn't enough room above the anchor. When the composer sits near the top of the workspace window (e.g. a compact conversation near the canvas top), the palette's min-height guarantee (280px) pushes its computed position all the way up to that bare 8px floor — squarely inside the workspace window's reserved header, where the real macOS traffic lights live.
- The workspace already reserves that exact header height (52px) consistently in three places: `DESKTOP_WINDOW_TOP_MARGIN` (`packages/agent/gui/agent-gui/workspaceDesktop/constants.ts:7`, used to keep node windows from being placed above the header), the matching `--workspace-room-top-bar-safe-area: 52px` CSS token, and `workspaceWindowHeaderHeightPx = 52` in `apps/desktop/src/main/windows/workspaceWindow.ts`, which drives the actual Electron `trafficLightPosition` for the native traffic lights. The fix reuses `DESKTOP_WINDOW_TOP_MARGIN` as the floor for the palette's top offset instead of the generic viewport padding, so it can never render above the header/traffic-light region.

## Test plan
- [x] `pnpm typecheck` in `packages/agent/gui`
- [x] `pnpm test` in `packages/agent/gui` (121 files / 1979 tests pass; one unrelated intermittent flake in `useAgentGUINodeController.spec.tsx` seen once under full-suite parallelism, reproduced as pre-existing on unmodified `origin/main` and passes on repeat runs — unrelated to this change)
- [x] Added `ComposerFloatingMenuSurface.spec.tsx` asserting the palette's computed `top` never goes below `DESKTOP_WINDOW_TOP_MARGIN` when the anchor sits near the top of the viewport
- [x] `git push` pre-push hook (`check:full`, including `test:go`) passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Adjusted the composer floating menu so it stays below the top safe area of the window and avoids overlapping the header controls.
  * Improved vertical placement when the anchor is near the top of the screen, keeping the menu within a readable and usable position.
* **Tests**
  * Added coverage to verify the menu respects the minimum top offset and cleans up test DOM elements properly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->