### PR TITLE
fix(agent): assume 1M context window for [1m] models before result lands

### DIFF
--- a/packages/agent/daemon/runtime/claude_sdk_adapter.go
+++ b/packages/agent/daemon/runtime/claude_sdk_adapter.go
@@ -31,6 +31,7 @@ const (
 	claudeSDKSidecarAdapterName    = "claude-agent-sdk"
 	claudeSDKSidecarDefaultNodeArg = "--experimental-strip-types"
 	claudeSDKDefaultContextWindow  = int64(200000)
+	claudeSDK1MContextWindow       = int64(1000000)
 	claudeSDKAuthRefreshLogPrefix  = "CLAUDE_CODE_AUTH_REFRESH_DEBUG"
 )
 
@@ -1769,7 +1770,7 @@ func claudeSDKUsageUpdate(payload map[string]any, previous acpUsageState, contex
 				total = previous.contextWindowTokens
 			}
 			if total <= 0 {
-				total = claudeSDKDefaultContextWindow
+				total = claudeSDKAssumedContextWindow(contextModel)
 			}
 			contextWindow = clonePayload(contextWindow)
 			contextWindow["totalTokens"] = total
@@ -1798,7 +1799,7 @@ func claudeSDKUsageUpdate(payload map[string]any, previous acpUsageState, contex
 		total = previous.contextWindowTokens
 	}
 	if total <= 0 {
-		total = claudeSDKDefaultContextWindow
+		total = claudeSDKAssumedContextWindow(contextModel)
 	}
 	return map[string]any{
 		"sessionUpdate": "usage_update",
@@ -1807,6 +1808,26 @@ func claudeSDKUsageUpdate(payload map[string]any, previous acpUsageState, contex
 			"totalTokens": total,
 		},
 	}
+}
+
+// claudeSDKAssumedContextWindow picks the context-window size to assume when
+// the Claude Agent SDK hasn't yet reported an authoritative per-model window
+// for this turn (claudeSDKContextWindowTokens returns 0, e.g. every streamed
+// usage delta before the turn's final "result" message carries modelUsage)
+// and there's no matching previously-known window to carry forward
+// (claudeSDKCanReusePreviousContextWindow). Model IDs/aliases across the
+// Claude Code ecosystem mark 1M-context variants with a "[1m]" suffix (see
+// claudeCodeACPModelAliases's "sonnet[1m]" and
+// claudeCodeLegacyACPModelCandidates's "opus[1m]" in standard_acp_adapter.go,
+// and user-configured aliases such as "claude-fable-5[1m]"). Honor that
+// convention here too, so a brand-new session/turn on a 1M-context model
+// doesn't render the usage popover against the base 200k denominator for the
+// entire duration of the turn.
+func claudeSDKAssumedContextWindow(contextModel string) int64 {
+	if strings.Contains(strings.ToLower(claudeSDKCanonicalModel(contextModel)), "[1m]") {
+		return claudeSDK1MContextWindow
+	}
+	return claudeSDKDefaultContextWindow
 }
 
 func claudeSDKCanReusePreviousContextWindow(previous acpUsageState, contextModel string) bool {

--- a/packages/agent/daemon/runtime/claude_sdk_adapter_test.go
+++ b/packages/agent/daemon/runtime/claude_sdk_adapter_test.go
@@ -1996,6 +1996,86 @@ func TestClaudeCodeSDKAdapterMapsModelUsageContextWindowMap(t *testing.T) {
 	}
 }
 
+// TestClaudeCodeSDKAdapterAssumes1MWindowForOneMillionModelAliasBeforeResult
+// reproduces the context-usage popover bug reported after PR #749: on a
+// "[1m]" (1M-context) model alias, every usage_updated delta streamed before
+// the turn's final result message (the only one carrying an authoritative
+// modelUsage.contextWindow) used to fall back to the flat 200k default,
+// so the popover showed e.g. "38,551 / 200,000 (19%)" for a model whose real
+// window is 1,000,000 — for the entire duration of the turn. Once the final
+// message with modelUsage landed, the total would jump to 1,000,000, only to
+// reset back to the wrong 200k default on the next turn/session. This test
+// pins the fix: even the very first, modelUsage-less delta on a "[1m]" alias
+// must assume the 1,000,000 window, not the flat 200k default.
+func TestClaudeCodeSDKAdapterAssumes1MWindowForOneMillionModelAliasBeforeResult(t *testing.T) {
+	adapter := NewClaudeCodeSDKAdapter(nil)
+	session := standardTestSession(ProviderClaudeCode)
+	adapterSession := &claudeSDKAdapterSession{liveState: newClaudeSDKLiveState()}
+	adapter.storeSession(session.AgentSessionID, adapterSession)
+	// Mirrors a user-configured custom model alias such as the reported
+	// "claude-fable-5[1m]", following the same "[1m]" suffix convention as
+	// the built-in "opus[1m]"/"sonnet[1m]" aliases.
+	adapterSession.applyConfigOption("model", "claude-fable-5[1m]")
+
+	// First streamed usage delta of a brand-new turn/session: no
+	// modelUsage yet (previous.contextKnown is false), matching the
+	// "agent session Claude SDK usage update" log lines observed at
+	// current_context_known=false in the field report.
+	events, terminal, err := adapter.sidecarTurnEvents(adapterSession, session, "turn-1", claudeSDKSidecarEvent{
+		Type: "usage_updated",
+		Payload: map[string]any{
+			"turnId": "turn-1",
+			"usage": map[string]any{
+				"input_tokens":  30_000,
+				"output_tokens": 8_551,
+			},
+		},
+	})
+	if err != nil || terminal {
+		t.Fatalf("usage_updated terminal=%v err=%v", terminal, err)
+	}
+	if len(events) != 1 || events[0].Type != activityshared.EventSessionUpdated {
+		t.Fatalf("usage events = %#v, want session.updated", events)
+	}
+	state := adapter.SessionState(session)
+	usage, _ := state.RuntimeContext["usage"].(map[string]any)
+	contextWindow, _ := usage["contextWindow"].(map[string]any)
+	if got, ok := acpInt64Value(contextWindow["totalTokens"]); !ok || got != 1_000_000 {
+		t.Fatalf("totalTokens = %#v, want assumed 1,000,000 window for a [1m] model alias before modelUsage is known", contextWindow["totalTokens"])
+	}
+
+	// The turn's final result message now reports the authoritative
+	// modelUsage window: it must agree with the assumed value, not flip
+	// the denominator mid-turn.
+	events, terminal, err = adapter.sidecarTurnEvents(adapterSession, session, "turn-1", claudeSDKSidecarEvent{
+		Type: "usage_updated",
+		Payload: map[string]any{
+			"turnId": "turn-1",
+			"usage": map[string]any{
+				"input_tokens":  32_000,
+				"output_tokens": 8_859,
+			},
+			"modelUsage": map[string]any{
+				"claude-fable-5[1m]": map[string]any{
+					"contextWindow": 1_000_000,
+				},
+			},
+		},
+	})
+	if err != nil || terminal {
+		t.Fatalf("usage_updated (final) terminal=%v err=%v", terminal, err)
+	}
+	if len(events) != 1 {
+		t.Fatalf("usage events (final) = %#v", events)
+	}
+	state = adapter.SessionState(session)
+	usage, _ = state.RuntimeContext["usage"].(map[string]any)
+	contextWindow, _ = usage["contextWindow"].(map[string]any)
+	if got, ok := acpInt64Value(contextWindow["totalTokens"]); !ok || got != 1_000_000 {
+		t.Fatalf("totalTokens (final) = %#v, want 1,000,000 from modelUsage", contextWindow["totalTokens"])
+	}
+}
+
 func TestClaudeCodeSDKAdapterDoesNotCarryContextWindowAcrossModelChange(t *testing.T) {
 	adapter := NewClaudeCodeSDKAdapter(nil)
 	session := standardTestSession(ProviderClaudeCode)


### PR DESCRIPTION
## Summary

The context-usage popover ("上下文用量") still shows the wrong denominator after PR #749 — e.g. `38,551 / 200,000 (19%)` for a model whose real window is 1,000,000, for the entire duration of a turn.

## Log evidence

From a fresh diagnostic export (`tuttid.log`), the exact scenario in the screenshot (`38,551 / 200,000`, model `claude-fable-5[1m]`, spinner active = mid-turn):

```
time=2026-07-06T01:14:34.552+08:00 level=INFO msg="agent session Claude SDK usage update" ... turn_id=5da5361f-1102-4ffb-a0df-aa6b59ac5623 normalized_used_tokens=38551 normalized_total_tokens=200000 previous_context_known=false current_context_known=true current_used_tokens=38551 current_total_tokens=200000 current_context_model=claude-fable-5[1m] applied=true
```

69ms after the turn's final SDK message lands (the one carrying `modelUsage`/`totalCostUsd`), the same turn flips to the correct total:

```
... payload_keys="[modelUsage totalCostUsd turnId usage]" raw_total_tokens=1000000 current_total_tokens=1000000 current_context_model=claude-fable-5[1m]
```

This flip-flop (200,000 → 1,000,000) repeats identically for every turn on this `[1m]` model across 4 different agent sessions in the log.

## Root cause

`packages/agent/daemon/runtime/claude_sdk_adapter.go`:
- The Claude Agent SDK only reports the authoritative per-model `contextWindow` via `modelUsage` on a turn's **final** result message (`claudeSDKContextWindowTokens`). Every streamed `usage` delta before that has no such data.
- `claudeSDKUsageUpdate` falls back to `previous.contextWindowTokens` if a matching model was already learned in this session (`claudeSDKCanReusePreviousContextWindow`), otherwise to the flat `claudeSDKDefaultContextWindow` (200,000) — regardless of whether the model is actually a 1M-context variant.
- There was no static, name-based fallback for `[1m]`-suffixed models (the closed PR #683 explicitly moved away from name-sniffing in favor of the typed SDK field, but that left this gap: before the first turn completes, or in any brand-new session where `previous.contextKnown` is false, the denominator is simply wrong).

## Why this differs from PR #749

PR #749 ("用量彈層不刷新+失敗探測顯示空白") fixed two separate issues in the **provider usage & environment-check popover** ("用量&环境检测" — `AgentUsageMeter` / `AgentProbeInfoPopover`): the rail config popover not refreshing on open, and a failed probe rendering nothing instead of a placeholder. That popover shows Claude Code/Codex account-level quota, fetched via an explicit probe.

This bug is in a **different** surface entirely — the composer's **context-window usage meter** ("上下文用量" — `38,551 / 200,000`), which is pushed passively from Claude SDK stream events, not fetched via any probe. #749's fix is unrelated and does not touch this code path at all. This bug reproduces identically with #749 merged.

## Fix

Add `claudeSDKAssumedContextWindow(contextModel)`: when no modelUsage-derived total is available and there's no matching previously-learned window to reuse, assume 1,000,000 for `[1m]`-suffixed model aliases (the same naming convention already used for `opus[1m]`/`sonnet[1m]` in `standard_acp_adapter.go`) instead of the flat 200,000 default. Used at both fallback sites in `claudeSDKUsageUpdate`.

## Test plan
- [x] New regression test `TestClaudeCodeSDKAdapterAssumes1MWindowForOneMillionModelAliasBeforeResult`: reproduces the exact reported scenario — a `[1m]`-aliased model's first usage delta (no `modelUsage` yet) must show 1,000,000 as the total, and the subsequent final-result delta (with `modelUsage`) must agree, not flip-flop.
- [x] `go test ./...` in `packages/agent/daemon` (all packages pass)
- [x] `go vet ./...` in `packages/agent/daemon`

🤖 Generated with [Claude Code](https://claude.com/claude-code)