### PR TITLE
fix(agent-daemon): notice when a resumed session is silently recreated

### DIFF
--- a/packages/agent/daemon/runtime/controller.go
+++ b/packages/agent/daemon/runtime/controller.go
@@ -930,6 +930,14 @@ func isResumeRecreatableError(err error) bool {
 // agent session, clearing the stale provider session id so the adapter mints a
 // fresh one. The new provider session id is captured from the started events and
 // persisted via the session report, keeping the conversation continuable.
+//
+// The freshly started provider session has no memory of anything said before
+// this point (e.g. an externally-imported conversation whose rollout only
+// ever existed on another device, or local history retention pruning it) even
+// though the transcript keeps showing the old messages joined seamlessly with
+// new ones. Without an explicit notice this looks to the user like the agent
+// silently forgot the conversation, so a visible system notice is appended
+// alongside the started events.
 func (c *Controller) recreateAdapterSession(ctx context.Context, session Session, adapter Adapter) error {
 	fresh := session
 	fresh.ProviderSessionID = ""
@@ -943,6 +951,9 @@ func (c *Controller) recreateAdapterSession(ctx context.Context, session Session
 	fresh = applySessionEvents(fresh, events)
 	fresh.Status = SessionStatusReady
 	fresh.UpdatedAtUnixMS = unixMS(now())
+	if notice, ok := sessionRecreatedNoticeEvent(fresh); ok {
+		events = append(events, notice)
+	}
 	c.store(fresh)
 	c.publish(fresh, events)
 	c.publishPendingConfigOptionsUpdates(fresh)
@@ -951,6 +962,22 @@ func (c *Controller) recreateAdapterSession(ctx context.Context, session Session
 	}
 	c.enqueueSessionReport(ctx, fresh, events)
 	return nil
+}
+
+// sessionRecreatedNoticeEvent builds the visible system notice that
+// accompanies a recreated provider session (see recreateAdapterSession). It
+// reuses the same synthetic "agent_system_notice" message shape the ACP
+// adapters already use for compaction/goal/transport notices
+// (acpSystemNoticeEvent), so it renders through the existing generic notice
+// card with no GUI changes required.
+func sessionRecreatedNoticeEvent(session Session) (activityshared.Event, bool) {
+	return acpSystemNoticeEvent(session, "", map[string]any{
+		"sessionUpdate": "system_notice",
+		"kind":          "agent_system_notice",
+		"noticeKind":    "warning",
+		"title":         "Conversation history could not be restored",
+		"detail":        "The assistant could not resume this conversation's earlier messages locally (for example, if it was imported from another device or the local session data is no longer available), so this reply is starting fresh without that context.",
+	}, "system_notice", true)
 }
 
 func (c *Controller) ValidatePromptContent(_ context.Context, input ExecInput) error {

--- a/packages/agent/daemon/runtime/controller_test.go
+++ b/packages/agent/daemon/runtime/controller_test.go
@@ -1457,7 +1457,8 @@ func TestControllerResumeRecreatesMissingProviderSessionWhenOptedIn(t *testing.T
 	t.Run("with opt-in a fresh provider session is created in place", func(t *testing.T) {
 		t.Parallel()
 		adapter := newRecreatableResumeAdapter(restoreErr)
-		controller := NewController([]Adapter{adapter}, nil)
+		reporter := &recordingReporter{}
+		controller := NewController([]Adapter{adapter}, reporter)
 		session, err := controller.Resume(context.Background(), ResumeInput{
 			RoomID:            "room-1",
 			AgentSessionID:    "imported-1",
@@ -1478,6 +1479,29 @@ func TestControllerResumeRecreatesMissingProviderSessionWhenOptedIn(t *testing.T
 		}
 		if session.ProviderSessionID != "fresh-provider-session" {
 			t.Fatalf("provider session id = %q, want fresh-provider-session", session.ProviderSessionID)
+		}
+		// A silently recreated provider session has no memory of anything the
+		// user said before this point, even though the transcript still shows
+		// the old (imported) messages seamlessly joined with new ones. Without
+		// a visible notice this looks exactly like the agent forgot the
+		// conversation, so recreation must surface a system notice message.
+		reports := reporter.waitForCalls(t, 1)
+		var notice *agentsessionstore.WorkspaceAgentMessageUpdate
+		for _, call := range reports {
+			for i, update := range call.report.MessageUpdates {
+				if update.AgentSessionID != "imported-1" {
+					continue
+				}
+				if asString(update.Payload["kind"]) == "agent_system_notice" {
+					notice = &call.report.MessageUpdates[i]
+				}
+			}
+		}
+		if notice == nil {
+			t.Fatalf("no agent_system_notice message reported for recreated session; reports = %#v", reports)
+		}
+		if title := asString(notice.Payload["title"]); title == "" {
+			t.Fatalf("recreated-session notice has empty title: %#v", notice.Payload)
 		}
 		// The recreated session must be live so a turn can run on it.
 		result, err := controller.Exec(context.Background(), ExecInput{


### PR DESCRIPTION
## Summary
- Diagnosed a user report ("分析 MBTI 類型" conversation): a native codex CLI session imported into tutti (agent session `imported-codex-e03e925597aadf5eb78f7fc7`, provider session `019f2c32-3034-7ac2-b7c9-855ff0a18137`) had its earlier history displayed in the transcript but was completely invisible to the model on the next turn — the agent behaved as if it had never seen the conversation.
- Root cause, traced with log citations: `thread/resume` against the sandboxed per-run `CODEX_HOME` fails with JSON-RPC `-32600 "no rollout found for thread id 019f2c32-..."` (the rollout only ever existed under the user's real `~/.codex` / the external CLI run — `exposeUserCodexFiles` in `services/tuttid/service/agentsidecar/codex.go` only symlinks `auth.json`, plugin state, and `config.toml`, never the `sessions/` rollout directory). `packages/agent/daemon/runtime/acp_restore_errors.go` classifies this specific message as `AppErrorProviderSessionNotFound`, which `controller.go`'s `isResumeRecreatableError` treats as recreatable *by design*, so `Controller.recreateAdapterSession` (`controller.go:933`) silently starts a brand-new provider thread (`thread/start`, minting a new `provider_session_id`) with zero memory of anything before that point — while the GUI keeps showing the old imported messages seamlessly joined with new turns, and `session.LastError` stays empty the whole time. This is an intentional "keep imported conversations continuable" fallback, but it fails silently: nothing tells the user the model's context was just wiped.
- Fix: `recreateAdapterSession` now appends a visible `agent_system_notice` message (the same synthetic notice mechanism already used for compaction/goal/transport notices via `acpSystemNoticeEvent`) whenever a session is recreated this way, so a clear warning shows up in the transcript instead of silently pretending continuity. No GUI changes needed — the generic notice card already renders any `noticeKind: "warning"` payload.

## Test plan
- [x] `go test ./packages/agent/daemon/runtime/...` (all pass)
- [x] Verified via a temporary revert that `TestControllerResumeRecreatesMissingProviderSessionWhenOptedIn/with_opt-in_...` fails without the fix and passes with it
- [x] `go vet ./packages/agent/daemon/runtime/...`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added a visible system notice when a resumed conversation must start a fresh session, letting users know their prior history could not be restored.
  * Improved resumed-session behavior so the app now surfaces a clearer warning alongside the recreated session.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->