### PR TITLE
fix(app-factory): don't treat system notices as job completion signal

### DIFF
--- a/services/tuttid/service/workspace/app_factory_agent_state.go
+++ b/services/tuttid/service/workspace/app_factory_agent_state.go
@@ -168,7 +168,7 @@ func (s *AppFactoryService) agentSessionHasCompletedFactoryOutput(workspaceID st
 		return false
 	}
 	latest := page.Messages[0]
-	return isCompletedAssistantTextMessage(latest.Role, latest.Kind, latest.Status)
+	return isCompletedAssistantTextMessage(latest.Role, latest.Kind, latest.Status, latest.Payload)
 }
 
 func (s *AppFactoryService) runValidation(ctx context.Context, workspaceID string, job workspacebiz.AppFactoryJob) (workspacebiz.AppFactoryJob, error) {
@@ -319,17 +319,40 @@ func factoryAgentTerminalStatus(state agentsessionstore.WorkspaceAgentSessionSta
 
 func factoryAgentMessageUpdatesContainCompletedAssistantText(updates []agentsessionstore.WorkspaceAgentSessionMessageUpdate) bool {
 	for _, update := range updates {
-		if isCompletedAssistantTextMessage(update.Role, update.Kind, update.Status) {
+		if isCompletedAssistantTextMessage(update.Role, update.Kind, update.Status, update.Payload) {
 			return true
 		}
 	}
 	return false
 }
 
-func isCompletedAssistantTextMessage(role string, kind string, status string) bool {
+// isCompletedAssistantTextMessage reports whether a message update looks like
+// the agent's completed final answer text. System notices (skill/context
+// budget warnings, model reroutes, compaction banners, etc.) are reported
+// through the same role=assistant/kind=text/status=completed shape as real
+// task narration — see acpSystemNoticeEvent in
+// packages/agent/daemon/runtime/acp_update_events.go, which always tags its
+// payload with "kind": "agent_system_notice". Treating one of those as the
+// signal that the whole App Factory job finished caused jobs to be marked
+// failed within seconds of creation (validating against a manifest the
+// agent hadn't written yet) while the agent kept working in the background
+// and went on to succeed. Excluding tagged system notices here keeps the
+// heuristic scoped to genuine assistant output.
+func isCompletedAssistantTextMessage(role string, kind string, status string, payload map[string]any) bool {
+	if isAppFactorySystemNoticeMessagePayload(payload) {
+		return false
+	}
 	return strings.ToLower(strings.TrimSpace(role)) == "assistant" &&
 		strings.ToLower(strings.TrimSpace(kind)) == "text" &&
 		strings.ToLower(strings.TrimSpace(status)) == "completed"
+}
+
+func isAppFactorySystemNoticeMessagePayload(payload map[string]any) bool {
+	if len(payload) == 0 {
+		return false
+	}
+	kind, _ := payload["kind"].(string)
+	return strings.EqualFold(strings.TrimSpace(kind), "agent_system_notice")
 }
 
 func firstNonEmptyString(values ...string) string {

--- a/services/tuttid/service/workspace/app_factory_test.go
+++ b/services/tuttid/service/workspace/app_factory_test.go
@@ -1979,3 +1979,139 @@ func appFactoryManifestForMetadataTest(appID string, version string, name string
 	manifest.Description = description
 	return manifest
 }
+
+// systemNoticeMessagePayload reproduces the exact payload shape codex/ACP
+// system notices are persisted with (see acpSystemNoticeEvent in
+// packages/agent/daemon/runtime/acp_update_events.go), e.g. the
+// "Skill descriptions were shortened to fit the 2% skills context budget."
+// warning observed in a real App Factory job (答案之书) that was marked
+// failed within ~6 seconds of creation, before the agent had written any
+// app files.
+func systemNoticeMessagePayload() map[string]any {
+	return map[string]any{
+		"kind":       "agent_system_notice",
+		"noticeKind": "warning",
+		"severity":   "warning",
+		"title":      "Skill descriptions were shortened to fit the 2% skills context budget.",
+		"source":     "runtime",
+	}
+}
+
+func TestIsCompletedAssistantTextMessageIgnoresSystemNotice(t *testing.T) {
+	t.Parallel()
+
+	if isCompletedAssistantTextMessage("assistant", "text", "completed", systemNoticeMessagePayload()) {
+		t.Fatal("system notice message was treated as completed assistant text, want ignored")
+	}
+	if !isCompletedAssistantTextMessage("assistant", "text", "completed", nil) {
+		t.Fatal("genuine completed assistant text message was ignored, want treated as completed")
+	}
+	if !isCompletedAssistantTextMessage("assistant", "text", "completed", map[string]any{"content": "done"}) {
+		t.Fatal("genuine completed assistant text message with unrelated payload was ignored, want treated as completed")
+	}
+}
+
+func TestFactoryAgentMessageUpdatesContainCompletedAssistantTextIgnoresSystemNotice(t *testing.T) {
+	t.Parallel()
+
+	updates := []agentsessionstore.WorkspaceAgentSessionMessageUpdate{
+		{
+			Role:    "assistant",
+			Kind:    "text",
+			Status:  "completed",
+			Payload: systemNoticeMessagePayload(),
+		},
+	}
+	if factoryAgentMessageUpdatesContainCompletedAssistantText(updates) {
+		t.Fatal("system notice update was treated as completed assistant text, want ignored")
+	}
+
+	updates = append(updates, agentsessionstore.WorkspaceAgentSessionMessageUpdate{
+		Role:   "assistant",
+		Kind:   "text",
+		Status: "completed",
+	})
+	if !factoryAgentMessageUpdatesContainCompletedAssistantText(updates) {
+		t.Fatal("genuine completed assistant text update was ignored, want treated as completed")
+	}
+}
+
+// TestAppFactoryServiceObserveAgentSessionMessagesIgnoresSystemNoticeForCompletionDetection
+// reproduces the exact false-failure sequence found in a real diagnostic log
+// bundle (tutti-logs-20260706-012540.zip) for the "答案之书" App Factory job:
+// the codex agent emitted only a "skills context budget" system notice
+// (role=assistant, kind=text, status=completed) a few seconds into a job,
+// long before writing any app files. Before this fix, that notice alone was
+// enough to make the App Factory service believe the agent session had
+// completed and immediately run validation — failing with "read app
+// manifest: ... no such file or directory" while the agent kept working (and
+// went on to succeed) in the background. The job's status then stayed
+// "failed" forever with no way to reconcile once the agent actually
+// finished.
+func TestAppFactoryServiceObserveAgentSessionMessagesIgnoresSystemNoticeForCompletionDetection(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	store := newAppFactoryStoreStub()
+	draftDir := t.TempDir()
+	if err := store.PutAppFactoryJob(ctx, workspacebiz.AppFactoryJob{
+		AgentSessionID: "session-1",
+		AppID:          "app_1",
+		DraftDir:       draftDir,
+		JobID:          "job-1",
+		Status:         workspacebiz.AppFactoryJobStatusGenerating,
+		WorkspaceID:    "ws-1",
+	}); err != nil {
+		t.Fatalf("PutAppFactoryJob() error = %v", err)
+	}
+	publisher := &workspaceAppFactoryPublisherStub{}
+	service := AppFactoryService{
+		Store:     store,
+		AppStore:  newAppStoreStub(),
+		Publisher: publisher,
+		// Even if the session's reported canonical status momentarily reads
+		// "completed" (the suspected upstream race), the observer must not
+		// act on it when the only new message is a system notice.
+		AgentSessionReader: factoryAgentSessionReaderStub{
+			sessions: map[string]agentservice.PersistedSession{
+				appFactoryJobStoreKey("ws-1", "session-1"): {
+					ID:          "session-1",
+					WorkspaceID: "ws-1",
+					Status:      "completed",
+				},
+			},
+		},
+		AgentMessageReader: factoryAgentMessageReaderStub{},
+	}
+
+	service.ObserveAgentSessionMessages(ctx, agentsessionstore.ReportSessionMessagesInput{
+		WorkspaceID:    "ws-1",
+		AgentSessionID: "session-1",
+		Updates: []agentsessionstore.WorkspaceAgentSessionMessageUpdate{
+			{
+				MessageID: "notice-1",
+				Role:      "assistant",
+				Kind:      "text",
+				Status:    "completed",
+				Payload:   systemNoticeMessagePayload(),
+			},
+		},
+	}, agentsessionstore.ReportSessionMessagesReply{AcceptedCount: 1})
+
+	// The guard in ObserveAgentSessionMessages returns synchronously (no
+	// goroutine spawned) when the update slice contains no genuine completed
+	// assistant text, so the job status is safe to assert immediately.
+	job, err := store.GetAppFactoryJob(ctx, "ws-1", "job-1")
+	if err != nil {
+		t.Fatalf("GetAppFactoryJob() error = %v", err)
+	}
+	if job.Status != workspacebiz.AppFactoryJobStatusGenerating {
+		t.Fatalf("status = %q, want generating (job must not fail on a system notice alone)", job.Status)
+	}
+	if strings.TrimSpace(job.FailureReason) != "" {
+		t.Fatalf("failure reason = %q, want empty", job.FailureReason)
+	}
+	if len(publisher.published) != 0 {
+		t.Fatalf("published updates = %d, want 0", len(publisher.published))
+	}
+}


### PR DESCRIPTION
## Summary

App Factory jobs were being marked "失败" (failed) within seconds of creation while the underlying codex/claude agent session kept working in the background and later succeeded on its own. Reported live: the "答案之书" (Book of Answers) app-creation job showed 失败 even though the agent conversation had clearly been dispatched.

## Root cause (from diagnostic bundle `tutti-logs-20260706-012540.zip`)

- `app-center-snapshot.json` shows job `125c82b1-3f1f-491d-9424-0d0e43199e2f` (app `答案之书`) with `status: "failed"` and `failureReason: "read app manifest: open /Users/asdf/.tutti-dev/apps/factory/jobs/125c82b1-3f1f-491d-9424-0d0e43199e2f/draft/package/tutti.app.json: no such file or directory"`.
- `logs/tuttid.log` shows the job flipping `queued -> generating -> preparing -> validating -> failed` in **~6.7 seconds**:
  ```
  01:24:07.078+08:00 status=queued
  01:24:09.534+08:00 status=generating
  01:24:13.757+08:00 status=preparing / validating / failed (all in the same tick)
  ```
  That failure reason is exactly what `validatePackage` (`services/tuttid/service/workspace/app_factory_agent_state.go`) produces when `runValidation` runs before the agent has written any package files.
- The agent session's own message log (`agent-sessions/codex/.../8df341cd-31b7-4fd9-b7cb-f49d1193e9dd/messages.jsonl`) shows the agent was still actively reading skill reference docs **47 seconds later** (`occurredAtUnixMs=1783272300658`), i.e. long after the job had already been marked failed. By the time the job flipped to failed, the only assistant-role message emitted was:
  ```json
  {
    "role": "assistant", "kind": "text", "status": "completed",
    "payload": {
      "kind": "agent_system_notice",
      "detail": "Skill descriptions were shortened to fit the 2% skills context budget. ..."
    }
  }
  ```
  a benign system notice, not real task output.

## The bug

System notices (skill-budget warnings, model reroutes, context-compaction banners, etc.) are reported through the exact same shape as a genuine final assistant answer — `role=assistant`, `kind=text`, `status=completed` (see `acpSystemNoticeEvent` in `packages/agent/daemon/runtime/acp_update_events.go:408`), distinguished only by `payload.kind == "agent_system_notice"`.

`isCompletedAssistantTextMessage` in `services/tuttid/service/workspace/app_factory_agent_state.go` didn't check that tag, so a bare system notice was enough to make `ObserveAgentSessionMessages` believe the whole App Factory job had finished, triggering `runValidation` against a package the agent hadn't written yet. Once the job was marked failed, nothing re-reconciled it against the agent's real, later completion — the job stayed stuck on 失败 forever (until the user manually hits 修复/repair or deletes it), even though the dispatch had genuinely succeeded.

## Fix

Exclude `payload.kind == "agent_system_notice"` messages from the completed-assistant-text heuristic, in both places it's used:
- `factoryAgentMessageUpdatesContainCompletedAssistantText` (message-update fast path)
- the `AgentMessageReader` fallback in `agentSessionHasCompletedFactoryOutput`

## Test plan

- [x] Added `TestIsCompletedAssistantTextMessageIgnoresSystemNotice` and `TestFactoryAgentMessageUpdatesContainCompletedAssistantTextIgnoresSystemNotice` — unit tests for the fixed predicate using the exact payload shape from the log bundle.
- [x] Added `TestAppFactoryServiceObserveAgentSessionMessagesIgnoresSystemNoticeForCompletionDetection` — end-to-end reproduction: job stays `generating` when only a system notice arrives (even if the session's reported canonical status momentarily reads "completed").
- [x] Verified the new tests fail without the fix (reproduces the exact `workspace_app_factory_job_state_persisted ... status=failed failureReason="read app manifest: ... no such file or directory"` log line from the real incident).
- [x] `go build ./services/tuttid/...`, `go vet ./services/tuttid/...`, `gofmt -l` clean.
- [x] `go test ./services/tuttid/service/workspace/...` passes (two pre-existing, unrelated failures — `TestAppCenterServiceInitializesBuiltinCatalogAndInstallState` / `...RemoteCatalogFails` — confirmed failing on `origin/main` too, not touched by this change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved completion detection so system notices are no longer mistaken for a finished assistant response.
  * Prevented false “completed” signals when a status update contains only a warning-style notice.
  * Reduced the chance of jobs failing or publishing updates incorrectly during agent session message handling.

* **Tests**
  * Added coverage for completion checks to ensure genuine responses are recognized while system notices are ignored.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->