### PR TITLE
fix(agent-gui): defer project list update until remove confirms

### DIFF
--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUINodeController.spec.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUINodeController.spec.tsx
@@ -2282,6 +2282,71 @@ describe("useAgentGUINodeController", () => {
     });
   });
 
+  it("keeps a removed project visible until the backend confirms deletion, then drops it without a remount", async () => {
+    let resolveRemove: (() => void) | null = null;
+    const removeProject = vi.fn(
+      () =>
+        new Promise<void>((resolve) => {
+          resolveRemove = resolve;
+        })
+    );
+    installAgentHostApi({
+      list: vi.fn(async () => ({ presences: [], sessions: [] })),
+      listSessionTimeline: vi.fn(async () => ({ timelineItems: [] })),
+      subscribeEvents: vi.fn(() => vi.fn()),
+      userProjects: {
+        list: vi.fn(async () => ({
+          projects: [
+            { id: "app", path: "/workspace/app", label: "App" },
+            { id: "web", path: "/workspace/web", label: "Web" }
+          ]
+        })),
+        remove: removeProject,
+        subscribe: vi.fn(() => vi.fn()),
+        use: vi.fn()
+      }
+    });
+
+    const { result } = renderHook(() =>
+      useAgentGUINodeController({
+        workspaceId: "room-1",
+        currentUserId: "user-1",
+        workspacePath: "/workspace",
+        avoidGroupingEdits: false,
+        data: agentGuiData("session-1"),
+        onDataChange: vi.fn()
+      })
+    );
+
+    await waitFor(() => {
+      expect(result.current.viewModel.userProjects).toHaveLength(2);
+    });
+
+    await act(async () => {
+      result.current.actions.removeProject("/workspace/app");
+      await Promise.resolve();
+    });
+
+    expect(removeProject).toHaveBeenCalledWith({ path: "/workspace/app" });
+    // The backend delete has not resolved yet: the project must still be
+    // present. Filtering it out before the backend confirms is what let a
+    // concurrent, in-flight section-list refetch race the delete and
+    // reinstate the row with nothing left to re-sync it afterwards.
+    expect(result.current.viewModel.userProjects).toHaveLength(2);
+
+    await act(async () => {
+      resolveRemove?.();
+      await Promise.resolve();
+    });
+
+    await waitFor(() => {
+      expect(result.current.viewModel.userProjects).toHaveLength(1);
+    });
+    expect(result.current.viewModel.userProjects[0]?.path).toBe(
+      "/workspace/web"
+    );
+  });
+
   it("ignores stale user project list responses after a newer refresh completes", async () => {
     let userProjectListener: (() => void) | null = null;
     const pendingUserProjectLoads: Array<

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUINodeController.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUINodeController.ts
@@ -9245,21 +9245,31 @@ export function useAgentGUINodeController({
       if (!normalizedPath || !remove) {
         return;
       }
-      const previousProjects = userProjectsRef.current;
       setListError(null);
-      setUserProjectsSnapshot(
-        previousProjects.filter((project) => project.path !== normalizedPath)
-      );
+      // Filter the visible list only after the backend confirms the delete
+      // (mirroring registerProjectPath's "backend confirm -> local store
+      // update" ordering). Filtering optimistically before the delete
+      // resolves would flip userProjectPathKey early and race the runtime
+      // rail sections refetch against the in-flight backend delete: if the
+      // section list query lands before the delete commits, it still
+      // reports the removed project's section, and nothing re-triggers a
+      // refetch afterwards, so the row stays visible until an unrelated
+      // remount forces a fresh fetch.
       const handleRemoveError = (error: unknown) => {
         const message = getAgentGUIErrorMessage(error);
-        setUserProjectsSnapshot(previousProjects);
         setListError(message);
         toast.error(message);
       };
       try {
-        void Promise.resolve(remove({ path: normalizedPath })).catch(
-          handleRemoveError
-        );
+        void Promise.resolve(remove({ path: normalizedPath }))
+          .then(() => {
+            setUserProjectsSnapshot(
+              userProjectsRef.current.filter(
+                (project) => project.path !== normalizedPath
+              )
+            );
+          })
+          .catch(handleRemoveError);
       } catch (error) {
         handleRemoveError(error);
       }


### PR DESCRIPTION
## Summary

Follow-up to #769. That PR fixed a backend persistence bug (delete matched by a recomputed id instead of path, so it could silently delete 0 rows and the project reappeared after restart). After verifying that fix live, a **separate** frontend bug surfaced: clicking 移除 (remove) on a project does not remove it from the visible list immediately — it stays until the user navigates away and back.

## Root cause

`removeProject` in `useAgentGUINodeController.ts` filtered the local `userProjects` state **optimistically, before** awaiting the backend `remove()` call. That state flip changes `userProjectPathKey`, which is a dependency of the runtime rail sections refetch effect in `AgentGUINodeView.tsx` (`useAgentGUIConversationRail`). This fires a new `listSessionSections` backend call racing against the still in-flight `DeleteUserProjectByPath` request. Both are independent, unordered network/filesystem round trips:

- If `listSessionSections` responds *before* the delete commits, it still reports a section for the just-removed project, and `setRuntimeRailSections` reinstates the row that had just been optimistically hidden.
- Nothing re-triggers another `listSessionSections` fetch afterward, because `userProjectPathKey` doesn't change again (the optimistic value already matched the eventual backend-confirmed value). Only a full remount (navigating away and back) re-runs the initial fetch, by which point the delete has certainly committed, so the row finally disappears correctly.

## Fix

Reorder `removeProject` so the local list is filtered only **after** `remove()` resolves successfully, matching the existing "backend confirm → local store update" ordering already used by `registerProjectPath` (the add-project path). This removes the race by construction: the refetch effect only fires once the backend delete has committed.

## Test plan

- [x] Added a regression test in `useAgentGUINodeController.spec.tsx` that renders with 2 projects, invokes `removeProject`, asserts the project is *still present* while the backend call is pending (guarding the ordering the fix relies on), then resolves the call and asserts it drops to 1 project with no remount involved. Verified this test fails against the pre-fix code and passes with the fix.
- [x] `pnpm run typecheck` in `packages/agent/gui` — clean.
- [x] `vitest run` in `packages/agent/gui` — 230/230 passing.
- [x] Full `check:full` pre-push hook (lint/typecheck/test across TS + Go) passed.