### PR TITLE
fix(agent-gui,agent-daemon): sub-agent countdown ticks while queued; rejected delegations stuck queued

### DIFF
--- a/packages/agent/daemon/runtime/acp_turn_normalizer.go
+++ b/packages/agent/daemon/runtime/acp_turn_normalizer.go
@@ -230,7 +230,16 @@ func (n *acpTurnNormalizer) FinalizeThinkingItem(session Session, turnID string,
 
 func (n *acpTurnNormalizer) FinishCompleted(session Session, turnID string) []activityshared.Event {
 	events := n.Finish(session, turnID, messageStreamStateCompleted)
-	events = append(events, n.completedToolCallEvents(session, turnID)...)
+	// A tool call still pending when its own turn reaches a normal terminal
+	// state never received its own item/completed (for example codex silently
+	// declining a spawnAgent call for a schema conflict, with no further
+	// notification tied to that item id for the rest of the turn - confirmed
+	// via exported session transcripts). It must not be reported as a
+	// successful completion: that would paint a rejected/never-run tool call
+	// as having succeeded. Close it out the same way an interrupted or failed
+	// turn already does - as a failure - so the GUI can render a clear
+	// failed/rejected state instead of an indefinite "running"/"queued" one.
+	events = append(events, n.terminalToolCallEvents(session, turnID, messageStreamStateFailed, "turn_completed_without_call_result")...)
 	// A turn that completed normally implies the compaction it ran finished;
 	// no-op in the usual flow because item/completed already cleared the id.
 	events = append(events, n.settlePendingCompactionEvents(session, turnID, appServerContextCompactedTitle)...)
@@ -389,41 +398,6 @@ func (n *acpTurnNormalizer) terminalToolCallEvents(
 			EventCallFailed,
 			turnID,
 			toolStatus,
-			"",
-			payloadString(payload, "name"),
-			payload,
-		))
-		delete(n.pendingToolCalls, key)
-	}
-	return events
-}
-
-func (n *acpTurnNormalizer) completedToolCallEvents(
-	session Session,
-	turnID string,
-) []activityshared.Event {
-	if n == nil || len(n.pendingToolCalls) == 0 {
-		return nil
-	}
-	keys := make([]string, 0, len(n.pendingToolCalls))
-	for key := range n.pendingToolCalls {
-		keys = append(keys, key)
-	}
-	sort.Strings(keys)
-	events := make([]activityshared.Event, 0, len(keys))
-	for _, key := range keys {
-		snapshot := n.pendingToolCalls[key]
-		payload := clonePayload(snapshot.payload)
-		if payload == nil {
-			payload = map[string]any{}
-		}
-		payload["status"] = messageStreamStateCompleted
-		events = append(events, newTurnActivityEventWithID(
-			session,
-			snapshot.eventID,
-			EventCallCompleted,
-			turnID,
-			messageStreamStateCompleted,
 			"",
 			payloadString(payload, "name"),
 			payload,

--- a/packages/agent/daemon/runtime/acp_turn_normalizer_test.go
+++ b/packages/agent/daemon/runtime/acp_turn_normalizer_test.go
@@ -112,6 +112,63 @@ func TestAppendAssistantChunkReplacesCumulativeSnapshotChunk(t *testing.T) {
 	}
 }
 
+// TestFinishCompletedFailsDanglingToolCall reproduces the sub-agent
+// "permanently queued" bug: codex can send tool_call item/started for a
+// spawnAgent-style delegation and then reject it out-of-band (a schema
+// conflict resolved as plain model-visible text, confirmed via exported
+// session transcripts), with no item/completed ever following for that call
+// id. Before this fix, a turn that otherwise completed normally silently
+// reported such a still-pending call as EventCallCompleted (a false
+// success); the GUI has no way to tell that apart from a genuine result, so
+// a rejected/never-run delegation rendered as stuck "running"/"queued"
+// forever instead of failed. FinishCompleted must close it out as
+// EventCallFailed, the same terminal shape an interrupted/failed turn
+// already uses.
+func TestFinishCompletedFailsDanglingToolCall(t *testing.T) {
+	t.Parallel()
+
+	session := testSession()
+	normalizer := newACPTurnNormalizer()
+
+	started, ok := normalizer.ToolCallEvents(session, "turn-1", map[string]any{
+		"sessionUpdate": "tool_call",
+		"toolCallId":    "call_rejected_spawn",
+		"status":        "in_progress",
+		"title":         "spawnAgent",
+		"kind":          "execute",
+	})
+	if !ok {
+		t.Fatalf("ToolCallEvents(started) ok = false")
+	}
+	var startedEvent *activityshared.Event
+	for i := range started {
+		if started[i].Type == EventCallStarted {
+			startedEvent = &started[i]
+		}
+	}
+	if startedEvent == nil {
+		t.Fatalf("expected an EventCallStarted event, got %+v", started)
+	}
+
+	completed := normalizer.FinishCompleted(session, "turn-1")
+
+	var callEvent *activityshared.Event
+	for i := range completed {
+		if completed[i].EventID == startedEvent.EventID {
+			callEvent = &completed[i]
+		}
+	}
+	if callEvent == nil {
+		t.Fatalf("FinishCompleted did not emit any event for the dangling call %q: %+v", startedEvent.EventID, completed)
+	}
+	if callEvent.Type != EventCallFailed {
+		t.Fatalf("dangling call event type = %q, want %q (a call with no item/completed must never be reported as a successful completion)", callEvent.Type, EventCallFailed)
+	}
+	if got := callEvent.Payload.Metadata["status"]; got != messageStreamStateFailed {
+		t.Fatalf("dangling call payload status = %#v, want %q", got, messageStreamStateFailed)
+	}
+}
+
 func TestAppendThinkingChunkStillStreamsWithoutReviewPresentation(t *testing.T) {
 	t.Parallel()
 

--- a/packages/agent/daemon/runtime/activity_projection_test.go
+++ b/packages/agent/daemon/runtime/activity_projection_test.go
@@ -131,7 +131,18 @@ func TestReportableActivityEventsReportsInterruptedOpenToolCalls(t *testing.T) {
 	}
 }
 
-func TestReportableActivityEventsReportsCompletedOpenToolCalls(t *testing.T) {
+// TestReportableActivityEventsReportsFailedOpenToolCalls covers a tool call
+// that is still open (no item/completed ever arrived for it) when its own
+// turn otherwise reaches a normal terminal state - for example codex
+// silently declining a spawnAgent delegation for a schema conflict, with no
+// further notification tied to that call id for the rest of the turn
+// (confirmed via exported session transcripts). Reporting it as a
+// successful completion would paint a rejected/never-run call as having
+// succeeded, which is exactly what previously left rejected sub-agent
+// delegations rendered as stuck "running"/"queued" forever instead of
+// failed. It must close out as failed, matching how an interrupted/failed
+// turn already handles dangling calls.
+func TestReportableActivityEventsReportsFailedOpenToolCalls(t *testing.T) {
 	t.Parallel()
 
 	session := reportTestSession()
@@ -153,21 +164,21 @@ func TestReportableActivityEventsReportsCompletedOpenToolCalls(t *testing.T) {
 	report := reportActivityInput(session, events)
 	completedCalls := messageUpdatesWithKind(report, "tool_call")
 	if len(completedCalls) != 2 {
-		t.Fatalf("completed call message updates = %#v, want start and completed final", completedCalls)
+		t.Fatalf("completed call message updates = %#v, want start and failed final", completedCalls)
 	}
 	if completedCalls[1].MessageID != completedCalls[0].MessageID ||
 		completedCalls[1].CallID != completedCalls[0].CallID {
 		t.Fatalf("completed call identity = start:%#v completed:%#v, want same message and call IDs", completedCalls[0], completedCalls[1])
 	}
 	completedCall := completedCalls[1]
-	if completedCall.Status != messageStreamStateCompleted {
-		t.Fatalf("completed call status = %q, want completed", completedCall.Status)
+	if completedCall.Status != messageStreamStateFailed {
+		t.Fatalf("dangling call status = %q, want failed", completedCall.Status)
 	}
-	if got := payloadString(completedCall.Payload, "status"); got != messageStreamStateCompleted {
-		t.Fatalf("completed call payload status = %q, want completed", got)
+	if got := payloadString(completedCall.Payload, "status"); got != messageStreamStateFailed {
+		t.Fatalf("dangling call payload status = %q, want failed", got)
 	}
-	if got := payloadMap(completedCall.Payload, "error"); got != nil {
-		t.Fatalf("completed call payload error = %#v, want nil", got)
+	if got := payloadMap(completedCall.Payload, "error"); got == nil {
+		t.Fatalf("dangling call payload error = %#v, want a non-nil error detail", got)
 	}
 }
 

--- a/packages/agent/gui/shared/agentConversation/components/AgentSubAgentCards.spec.tsx
+++ b/packages/agent/gui/shared/agentConversation/components/AgentSubAgentCards.spec.tsx
@@ -40,6 +40,80 @@ describe("AgentSubAgentCard", () => {
     expect(screen.getByText(/11s · Running/)).toBeInTheDocument();
   });
 
+  it("does not tick while queued for a concurrency slot, even as time passes", async () => {
+    setAgentGuiI18nTestLocale("en");
+    vi.useFakeTimers();
+    vi.setSystemTime(1_000);
+
+    render(
+      <AgentSubAgentCard
+        subAgent={subAgent({
+          status: "running",
+          queued: true,
+          startedAtUnixMs: 1_000,
+          latestActivityAtUnixMs: 1_000
+        })}
+      />
+    );
+
+    expect(
+      screen.getByText("Queued — waiting for an agent slot…")
+    ).toBeInTheDocument();
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(11_000);
+    });
+
+    // A queued sub-agent has not been dispatched yet: startedAtUnixMs is the
+    // spawn call's own (dispatch) time, not a real run-start time, so no
+    // elapsed clock must appear or tick while queued=true.
+    expect(screen.queryByText(/\d+(\.\d+)?s ·/)).not.toBeInTheDocument();
+    expect(
+      screen.getByText("Queued — waiting for an agent slot…")
+    ).toBeInTheDocument();
+  });
+
+  it("starts ticking only once dispatch clears the queue", async () => {
+    setAgentGuiI18nTestLocale("en");
+    vi.useFakeTimers();
+    vi.setSystemTime(1_000);
+
+    const { rerender } = render(
+      <AgentSubAgentCard
+        subAgent={subAgent({
+          status: "running",
+          queued: true,
+          startedAtUnixMs: 1_000,
+          latestActivityAtUnixMs: 1_000
+        })}
+      />
+    );
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(9_000);
+    });
+    expect(screen.queryByText(/\d+(\.\d+)?s ·/)).not.toBeInTheDocument();
+
+    // The sub-agent clears the queue at t=10_000 and actually starts running.
+    vi.setSystemTime(10_000);
+    rerender(
+      <AgentSubAgentCard
+        subAgent={subAgent({
+          status: "running",
+          queued: false,
+          startedAtUnixMs: 10_000,
+          latestActivityAtUnixMs: 10_000
+        })}
+      />
+    );
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(2_000);
+    });
+
+    expect(screen.getByText(/2\.0s · Running/)).toBeInTheDocument();
+  });
+
   it("freezes terminal elapsed time instead of following Date.now", async () => {
     setAgentGuiI18nTestLocale("en");
     vi.useFakeTimers();

--- a/packages/agent/gui/shared/agentConversation/components/AgentSubAgentCards.tsx
+++ b/packages/agent/gui/shared/agentConversation/components/AgentSubAgentCards.tsx
@@ -248,11 +248,24 @@ function subAgentStatusLabel(status: AgentTaskSubAgentVM["status"]): string {
   }
 }
 
+// A sub-agent that is merely `queued` has been accepted but has not been
+// dispatched to a provider yet (codex caps concurrent sub-agents and queues
+// spawns beyond the cap - see AgentTaskSubAgentVM.queued). Its `status` still
+// reads "running" (there is no child lifecycle yet to say otherwise) and its
+// `startedAtUnixMs` is stamped from the spawn call itself, i.e. dispatch/
+// queued time, not from when the sub-agent actually started running. Ticking
+// a live clock off that timestamp would count queued wait time as elapsed
+// run time, so the clock must stay off until the sub-agent is no longer
+// queued.
+function isSubAgentActivelyRunning(subAgent: AgentTaskSubAgentVM): boolean {
+  return subAgent.status === "running" && !subAgent.queued;
+}
+
 function useRunningSubAgentNowUnixMs(
   subAgent: AgentTaskSubAgentVM
 ): number | null {
   const shouldTick =
-    subAgent.status === "running" &&
+    isSubAgentActivelyRunning(subAgent) &&
     typeof subAgent.startedAtUnixMs === "number";
   const [nowUnixMs, setNowUnixMs] = useState<number | null>(() =>
     shouldTick ? Date.now() : null
@@ -287,7 +300,8 @@ function subAgentElapsedText(
   const ended =
     typeof terminal === "number"
       ? terminal
-      : subAgent.status === "running" && typeof runningNowUnixMs === "number"
+      : isSubAgentActivelyRunning(subAgent) &&
+          typeof runningNowUnixMs === "number"
         ? Math.max(latest ?? started, runningNowUnixMs)
         : latest;
   if (typeof ended !== "number" || ended <= started) {


### PR DESCRIPTION
## Summary

Two related sub-agent delegation UI bugs, diagnosed from a diagnostic log bundle plus code inspection. They turned out to have **independent root causes** (one GUI-only, one daemon-only) despite both surfacing through the same "queued" sub-agent card.

### Bug 1: countdown ticks while queued (not yet dispatched)

PR #681 (`b040a0c9`, "keep sub-agent elapsed timers live") made the sub-agent header's elapsed-time clock tick every second while `status === "running"`. But a sub-agent can be `status: "running"` *and* `queued: true` at the same time - accepted by the parent but still waiting for a concurrency slot, not yet dispatched to a provider (`AgentTaskSubAgentVM.queued`, see `packages/agent/gui/shared/agentConversation/projection/subAgentTimelinePartition.ts:150-160`). For a queued placeholder, `startedAtUnixMs` is stamped from the spawn call itself (dispatch/queued time), not a real run-start time - so the live tick was counting queued wait time as elapsed run time, while the card body simultaneously showed "Queued — waiting for an agent slot…". Contradictory UI.

**Fix**: `packages/agent/gui/shared/agentConversation/components/AgentSubAgentCards.tsx` - gate both the live-tick effect and the elapsed-time computation on `!subAgent.queued`, so the clock stays off until the sub-agent is no longer queued.

### Bug 2: a rejected/denied delegation renders as a permanently-stuck "queued" card

Log evidence (`agent-sessions/codex/.../3a885427-.../messages.jsonl`, session `3a885427-3416-4b14-917e-69d91600ab12`): 5 `spawnAgent` tool_call items are created (ids `call_C63RLN6...`, `call_UoLVavBqiG...`, `call_TQJ4FLtN...`, `call_xP4aNguLmV9AGqpknBm5Y9wd`, `call_pBL3Os1iQJ2mbEg73ZaxkoNZ`, all `status: "running"`), followed moments later by the assistant's own text explaining the dispatch **was rejected** ("剛才的派發因為「完整上下文 fork」與指定 explorer 角色互斥被拒絕" - rejected because "full context fork" conflicts with specifying an explorer role) and a retry with 5 new call ids that do succeed. None of the original 5 items ever receive a completion event for the rest of the exported transcript (74+s / 170+ more messages) - they stay `status: "running"` forever.

Code trace (`packages/agent/daemon/runtime/acp_turn_normalizer.go`): codex's app-server sends `item/started` for the rejected calls but never a matching `item/completed` - the rejection is apparently surfaced to the model out-of-band from the item lifecycle. The daemon does have an end-of-turn safety net for exactly this (`pendingToolCalls` + `terminalToolCallEvents`/`completedToolCallEvents`, invoked from `FinishFailed`/`FinishInterrupted`/`FinishCompleted`), but `FinishCompleted` (a turn ending *normally*) used `completedToolCallEvents`, which reported any still-pending call as `EventCallCompleted` - a false success - instead of failed. Combined with the GUI's `subAgentTimelinePartition.ts` (`queued: card.callStatus === "running"` for a receiver-less spawn card), a rejected delegation had no path to a terminal state for as long as its turn kept running, rendering as one permanently-"queued" placeholder card per rejected attempt.

**Fix**: `packages/agent/daemon/runtime/acp_turn_normalizer.go` - `FinishCompleted` now closes out any still-pending call via `terminalToolCallEvents(..., messageStreamStateFailed, ...)`, the same path `FinishFailed`/`FinishInterrupted` already use. Removed the now-dead `completedToolCallEvents`. A call that never received its own completion cannot be truthfully reported as successful, regardless of tool type - this is a general correctness fix, not spawnAgent-specific.

### Root cause relationship

Independent, not shared: Bug 1 is a pure GUI oversight in PR #681 (`AgentSubAgentCards.tsx`, ignoring the `queued` flag); Bug 2 is a daemon-side event-normalization bug (`acp_turn_normalizer.go`, mislabeling dangling calls as successes). Bug 2's fix (turning dangling calls into a clear `failed` status) is what lets the GUI's existing failed-card rendering (`AlertCircle` icon, `failureDetail` body, no more "queued") take over correctly - no further GUI change was needed for Bug 2.

## Tests

- `packages/agent/daemon/runtime/acp_turn_normalizer_test.go`: new `TestFinishCompletedFailsDanglingToolCall` reproduces a dangling call at normal turn completion and asserts `EventCallFailed`, not `EventCallCompleted`.
- `packages/agent/daemon/runtime/activity_projection_test.go`: `TestReportableActivityEventsReportsCompletedOpenToolCalls` renamed to `TestReportableActivityEventsReportsFailedOpenToolCalls` and updated to assert the corrected (failed) behavior - it previously encoded the buggy assumption being fixed here.
- `packages/agent/gui/shared/agentConversation/components/AgentSubAgentCards.spec.tsx`: two new tests - a queued sub-agent's clock never ticks/shows elapsed text even as time passes, and it starts ticking correctly once dispatch clears the queue.

## Test plan

- [x] `go test ./packages/agent/daemon/runtime/...` - all pass
- [x] `go build`/`go vet` on `packages/agent/daemon` - clean
- [x] `vitest run` on `packages/agent/gui/shared/agentConversation` (413 tests) - all pass
- [x] `pnpm run typecheck` in `packages/agent/gui` - clean
- [x] Pre-push `check:full` hook (full go/ts suite) - passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)