### PR TITLE
fix(app-center): surface app factory create failures instead of throwing uncaught

### DIFF
--- a/packages/workspace/app-center/src/core/appCenterController.test.ts
+++ b/packages/workspace/app-center/src/core/appCenterController.test.ts
@@ -192,6 +192,44 @@ test("WorkspaceAppCenterController sorts factory jobs and reports snapshot appli
   );
 });
 
+test("WorkspaceAppCenterController reports a create-factory-job failure instead of throwing", async () => {
+  const failures: Array<{
+    error: unknown;
+    toastMessage: string;
+  }> = [];
+  const controller = createWorkspaceAppCenterController({
+    formatError: formatError,
+    gateway: createGateway({
+      async createWorkspaceAppFactoryJob() {
+        throw new Error("agent target id is required for agent session launch");
+      }
+    }),
+    hooks: {
+      onOperationFailure(input) {
+        failures.push({ error: input.error, toastMessage: input.toastMessage });
+      }
+    }
+  });
+
+  await controller.createFactoryJob({
+    agentTargetId: "local:codex",
+    displayName: "My App",
+    prompt: "build me an app",
+    workspaceId: "workspace-1"
+  });
+
+  assert.equal(controller.store.factoryJobs.length, 0);
+  assert.equal(
+    controller.store.error,
+    "agent target id is required for agent session launch"
+  );
+  assert.equal(failures.length, 1);
+  assert.equal(
+    failures[0]?.toastMessage,
+    "agent target id is required for agent session launch"
+  );
+});
+
 test("WorkspaceAppCenterController prepares app launch through launch gateway", async () => {
   const launchCalls: Array<{ appId: string; workspaceId: string }> = [];
   const controller = createWorkspaceAppCenterController({

--- a/packages/workspace/app-center/src/core/appCenterController.ts
+++ b/packages/workspace/app-center/src/core/appCenterController.ts
@@ -159,26 +159,34 @@ export class WorkspaceAppCenterController extends WorkspaceAppCenterControllerSt
     const previousJobIds = new Set(
       this.store.factoryJobs.map((job) => job.jobId)
     );
-    const snapshot =
-      await this.dependencies.gateway.createWorkspaceAppFactoryJob(
-        input.workspaceId,
-        {
-          agentTargetId: input.agentTargetId,
-          displayName: input.displayName,
-          ...(input.model?.trim() ? { model: input.model.trim() } : {}),
-          ...(input.permissionModeId?.trim()
-            ? { permissionModeId: input.permissionModeId.trim() }
-            : {}),
-          prompt: input.prompt,
-          ...(input.reasoningEffort?.trim()
-            ? { reasoningEffort: input.reasoningEffort.trim() }
-            : {})
-        }
+    try {
+      const snapshot =
+        await this.dependencies.gateway.createWorkspaceAppFactoryJob(
+          input.workspaceId,
+          {
+            agentTargetId: input.agentTargetId,
+            displayName: input.displayName,
+            ...(input.model?.trim() ? { model: input.model.trim() } : {}),
+            ...(input.permissionModeId?.trim()
+              ? { permissionModeId: input.permissionModeId.trim() }
+              : {}),
+            prompt: input.prompt,
+            ...(input.reasoningEffort?.trim()
+              ? { reasoningEffort: input.reasoningEffort.trim() }
+              : {})
+          }
+        );
+      this.applyFactorySnapshot(input.workspaceId, snapshot);
+      this.dependencies.hooks?.onFactoryJobCreated?.(
+        snapshot.jobs.find((job) => !previousJobIds.has(job.jobId)) ?? null
       );
-    this.applyFactorySnapshot(input.workspaceId, snapshot);
-    this.dependencies.hooks?.onFactoryJobCreated?.(
-      snapshot.jobs.find((job) => !previousJobIds.has(job.jobId)) ?? null
-    );
+    } catch (error) {
+      this.setOperationError(error, {
+        operation: "app_factory.create",
+        uiAction: "create_factory_job",
+        workspaceId: input.workspaceId
+      });
+    }
   }
 
   async cancelFactoryJob(input: {

--- a/packages/workspace/app-center/src/core/appCenterControllerTypes.ts
+++ b/packages/workspace/app-center/src/core/appCenterControllerTypes.ts
@@ -15,6 +15,7 @@ export type WorkspaceAppCenterOperation =
   | "app_center.refresh"
   | "app_center.refresh_catalog"
   | "app_center.start_workspace_updates"
+  | "app_factory.create"
   | "app_factory.prepare_modification"
   | "app_factory.publish"
   | "workspace_app.delete"
@@ -33,6 +34,7 @@ export type WorkspaceAppCenterOperation =
   | "workspace_app.update";
 
 export type WorkspaceAppCenterUiAction =
+  | "create_factory_job"
   | "delete_app"
   | "export_app"
   | "import_app"


### PR DESCRIPTION
## Background

PR #682 fixed App Factory ("create app" in App Center) failing instantly with `invalid agent session request: agent target id is required for agent session launch` by wiring `AgentTargetID` through the backend `Create` call.

Ricky retested "create app" in the acceptance branch (which has #682 merged) and it still marked FAILED: clicking create still shows an immediate failure.

## Investigation

I traced the full create-app path end to end:

- Backend (`services/tuttid/service/workspace/app_factory.go` `Create`, `services/tuttid/service/agent/service.go` `Service.Create` / `resolveCreateSessionLaunch`, `services/tuttid/biz/agenttarget/model.go`): all of this resolves and validates `AgentTargetID` consistently. All existing app-factory and agent-service Go tests pass, and I ran the exact tests PR #682 added (`TestAppFactoryServiceCreateLaunchesSessionsWithAgentTargetID`) plus adjacent ones (`TestServiceCreatePassesExtraSkillsToRuntimePreparer`, `TestServiceCreateResolvesAgentTargetID`) — all green, no regression found there.
- Frontend wiring (`apps/desktop/.../WorkspaceAppCenterPane.tsx`, `appFactoryProviderDefaults.ts`) added by the later `ea2e3f62` "migrate app factory and issue manager flows" commit correctly threads `agentTargetId` through to the create request.

What I did find: `packages/workspace/app-center/src/core/appCenterController.ts`'s `createFactoryJob` is the **only** factory-job/app-center mutating action that has no `try/catch`. Every sibling action (`installApp`, `deleteApp`, `prepareAppLaunch`, `restartAndOpenApp`, ...) wraps its gateway call and reports failures via `setOperationError`/`onOperationFailure`, which is what drives the `WorkspaceAppCenterErrorToast` in the desktop app. `createFactoryJob` does not — so when the backend `createWorkspaceAppFactoryJob` call rejects for *any* reason, the rejection propagates out of the `void actions.createFactoryJob?.(...)` fire-and-forget call in `AppCenterPanel.tsx`'s `submitCreate` as an unhandled promise rejection: no toast, no `store.error`, no diagnosable signal — just a dialog that closes and nothing happening. That is exactly what "click create → immediately looks like a failure with no useful info" looks like from the user's side, and it's a real gap independent of whatever specific backend error is (still) occurring in Ricky's environment.

## Fix

Wrap `createFactoryJob`'s gateway call in try/catch and report through `setOperationError`, matching every other action in the controller. Added `app_factory.create` / `create_factory_job` to the operation/ui-action unions to match existing naming conventions.

## Tests

- Added `WorkspaceAppCenterController reports a create-factory-job failure instead of throwing` in `appCenterController.test.ts`, asserting a rejected create call now surfaces via `store.error` / `onOperationFailure` instead of throwing.
- `packages/workspace/app-center`: `npm run test` (95/95 pass), `npm run typecheck` (clean).
- `apps/desktop`: workspace-app-center feature tests (86/86 pass), `npm run typecheck` (clean).

## Note for the reviewer / Ricky

This closes a real, verified gap (missing error surfacing), but I could not reproduce a *new* synchronous backend failure in the create path via code tracing + existing/extended test coverage — everything Go-side checks out given a properly seeded `AgentTargetStore`. If create still fails after this lands, the fix here will at least surface the actual backend error message in a toast instead of nothing, which should make the next repro immediately diagnosable. If it's still opaque, the most useful next info would be: the exact toast/error text now shown, which provider (Codex vs Claude Code) was selected, and whether this is a fresh workspace or one that predates the `local:codex`/`local:claude-code` agent-target migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)