### PR TITLE
fix(agent-gui): let an imported session's persisted model win over a stale live config option

### DIFF
--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUINodeController.spec.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUINodeController.spec.tsx
@@ -11508,6 +11508,84 @@ describe("useAgentGUINodeController", () => {
     );
   });
 
+  it("prefers an imported session's persisted model over a differing live config option", async () => {
+    // Regression test: an imported Codex conversation persists the model
+    // (and reasoning effort) the user's local CLI actually used
+    // (`services/tuttid/service/agent/external_import.go`,
+    // `TestServiceImportPreservesLocalCodexModelAndReasoningEffort`). That
+    // persisted value must win in the composer even if the live
+    // app-server-reported "model" config option differs — e.g. because the
+    // provider session hasn't resumed yet, or reports a different session's
+    // config. Before this fix, `draftModel` in useAgentGUINodeController.ts
+    // unconditionally preferred the live config option's `currentValue`
+    // over the persisted session settings, silently discarding the carried
+    // over model.
+    const getState = vi.fn(async () =>
+      agentSessionState("session-1", {
+        provider: "codex",
+        settings: {
+          model: "gpt-5.4",
+          reasoningEffort: "xhigh",
+          speed: null,
+          planMode: false,
+          permissionModeId: "auto"
+        },
+        runtimeContext: {
+          cwd: "/workspace",
+          configOptions: [
+            {
+              id: "model",
+              name: "Model",
+              currentValue: "gpt-5-codex",
+              options: [
+                { value: "gpt-5-codex", name: "GPT-5 Codex" },
+                { value: "gpt-5.4", name: "GPT-5.4" }
+              ]
+            }
+          ]
+        }
+      })
+    );
+    installAgentHostApi({
+      list: vi.fn(async () => ({
+        presences: [],
+        sessions: [
+          workspaceAgentSession("session-1", {
+            provider: "codex",
+            title: "Imported Codex conversation"
+          })
+        ]
+      })),
+      listSessionTimeline: vi.fn(async () => ({ timelineItems: [] })),
+      subscribeEvents: vi.fn(() => vi.fn()),
+      getComposerOptions: vi.fn(async () => ({
+        provider: "codex",
+        runtimeContext: { configOptions: [] }
+      })),
+      getState
+    });
+
+    const { result } = renderHook(() =>
+      useAgentGUINodeController({
+        workspaceId: "room-1",
+        currentUserId: "user-1",
+        workspacePath: "/workspace",
+        avoidGroupingEdits: false,
+        data: agentGuiData("session-1", "codex"),
+        onDataChange: vi.fn()
+      })
+    );
+
+    await waitFor(() => {
+      expect(result.current.viewModel.composerSettings.selectedModelValue).toBe(
+        "gpt-5.4"
+      );
+    });
+    expect(
+      result.current.viewModel.composerSettings.selectedReasoningEffortValue
+    ).toBe("xhigh");
+  });
+
   it("reloads active ACP options after switching the live model", async () => {
     const getState = vi
       .fn()

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUINodeController.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUINodeController.ts
@@ -10342,12 +10342,27 @@ export function useAgentGUINodeController({
   const draftSettings = activeConversationId
     ? (sessionSettings ?? defaultConversationDraftSettings)
     : homeComposerSettings;
+  const persistedDraftModel = normalizeOptionalText(draftSettings.model);
+  // "default" is Claude Code's own placeholder for "no explicit model
+  // pinned" (claudeSDKModelConfigOption); an unset value normalizes to
+  // null for every provider. Only in those "nothing meaningful persisted
+  // yet" cases do we prefer the live app-server-reported current model
+  // (kept fresh across an in-flight settings-refresh race, see the "keep
+  // Claude model selection stable" fix). Once a session has a real,
+  // concrete persisted model — e.g. one carried over from an imported
+  // conversation (2U74Ri) — that value must win outright: it is the
+  // authoritative source of what will actually run on the next turn, and
+  // a live config option can legitimately lag or reflect a different
+  // session's default while this one hasn't resumed yet.
+  const usesPlaceholderDraftModel =
+    persistedDraftModel === null || persistedDraftModel === "default";
   const liveConfigModel =
-    activeConversationId !== null
+    activeConversationId !== null && usesPlaceholderDraftModel
       ? configOptionCurrentValue(activeSessionRuntimeContext, ["model"])
       : null;
-  const draftModel =
-    liveConfigModel ?? normalizeOptionalText(draftSettings.model);
+  const draftModel = usesPlaceholderDraftModel
+    ? (liveConfigModel ?? persistedDraftModel)
+    : persistedDraftModel;
   const draftReasoningEffort = normalizeOptionalText(
     draftSettings.reasoningEffort
   ) as AgentSessionReasoningEffort | null;


### PR DESCRIPTION
## Problem

Ricky retested PR #697 ("導入歷史對話未沿用本地Codex模型/推理強度設置", Feishu bug 2U74Ri) in the acceptance branch and marked it FAILED again: importing a historical conversation still doesn't carry over the user's locally-configured Codex/Claude Code model + reasoning-effort settings.

## Root cause

PR #697 is not broken — this is a regression from an unrelated, later fix.

- PR #697 (`services/tuttid/service/agent/external_import.go`, `external_import_parse.go`) correctly captures the local CLI's model/reasoning-effort at import time and persists it on the session (`SessionStateReport.Model`/`.Settings`). This data reaches the desktop GUI correctly end-to-end (traced `ReportSessionState` → `ProjectSessionState` → the `WorkspaceAgentSession` API response → `toAgentHostAgentSessionState` → `activeSessionState.settings` in `useAgentGUINodeController.ts`).
- A **later** fix, "keep Claude model selection stable" (merged into `main` via PR #727, commit `f2b70a19`/`61f16b43`), changed the composer's `draftModel` computation in `packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUINodeController.ts` to **unconditionally** prefer the live app-server-reported "model" config option's `currentValue` over the persisted session settings:

  ```ts
  const liveConfigModel = activeConversationId !== null
    ? configOptionCurrentValue(activeSessionRuntimeContext, ["model"])
    : null;
  const draftModel = liveConfigModel ?? normalizeOptionalText(draftSettings.model);
  ```

  That change's own regression test shows its actual intent: keep a *just-submitted* model selection from flickering back to Claude Code's `"default"` placeholder while an async settings refresh is in flight. Applied unconditionally to every active conversation, though, it also silently discards an already-correct **persisted** model any time the live config option reports something else — e.g. an imported session's carried-over model, whenever the live app-server's reported "current" model doesn't happen to match (different resolved/canonical model id, a not-yet-resumed provider session, etc.). That's a straight-up regression of 2U74Ri, without PR #697's own import code changing at all — which is why re-testing #697 in isolation still "works" (the persistence is correct) while the composer visibly shows/uses the wrong model.

## Fix

Only fall back to the live config option when the persisted model is genuinely a placeholder (unset, or Claude Code's `"default"` sentinel). A concrete persisted model — imported or otherwise — now wins outright, since it's the authoritative value that will actually run on the next turn:

```ts
const usesPlaceholderDraftModel =
  persistedDraftModel === null || persistedDraftModel === "default";
const liveConfigModel =
  activeConversationId !== null && usesPlaceholderDraftModel
    ? configOptionCurrentValue(activeSessionRuntimeContext, ["model"])
    : null;
const draftModel = usesPlaceholderDraftModel
  ? (liveConfigModel ?? persistedDraftModel)
  : persistedDraftModel;
```

This keeps PR #727's original fix intact (its own test still passes unmodified) while restoring PR #697's behavior for imported sessions.

## Test

Added a regression test in `useAgentGUINodeController.spec.tsx`: an imported Codex session with persisted `settings.model: "gpt-5.4"` but a runtime-context "model" config option reporting a different `currentValue: "gpt-5-codex"` now correctly shows `"gpt-5.4"` (and the persisted `reasoningEffort: "xhigh"`) in the composer. Verified this test fails with the exact reported symptom (`expected 'gpt-5-codex' to be 'gpt-5.4'`) when the fix is reverted, confirming it reproduces the regression.

- `pnpm --filter @tutti-os/agent-gui test` (full package, 121 files / 1980 tests) — pass.
- `node tools/scripts/run-tsgo-typecheck.mjs` (agent-gui package) — clean.
- `oxfmt --check` / `oxlint` on touched files — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved model selection behavior so imported sessions keep their saved model and reasoning settings, even if the current runtime configuration differs.
  * Fixed draft model handling so live session settings are used when no concrete saved model exists, while saved model choices are no longer unexpectedly overwritten.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->