### PR TITLE
fix(agent-gui): insert brand-new conversations into runtime sidebar sections

### DIFF
--- a/packages/agent/gui/agent-gui/agentGuiNode/AgentGUINodeView.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/AgentGUINodeView.tsx
@@ -147,6 +147,7 @@ import {
 import {
   ConversationMeta,
   groupConversations,
+  normalizeConversationProjectPath,
   type ConversationSection
 } from "./agentGuiNodeViewConversation";
 import { buildAgentGUIConversationSummaries } from "./model/agentGuiConversationModel";
@@ -4208,9 +4209,10 @@ function stabilizeConversationSectionItems(
   return changed ? stable : previous;
 }
 
-function updateConversationSectionsFromSummaries(
+export function updateConversationSectionsFromSummaries(
   previous: ConversationSection[] | null,
-  conversations: readonly AgentGUINodeViewModel["conversations"][number][]
+  conversations: readonly AgentGUINodeViewModel["conversations"][number][],
+  options: { sectionConversationsLabel: string }
 ): ConversationSection[] | null {
   if (!previous || conversations.length === 0) {
     return previous;
@@ -4218,10 +4220,12 @@ function updateConversationSectionsFromSummaries(
   const summariesById = new Map(
     conversations.map((conversation) => [conversation.id, conversation])
   );
+  const seenIds = new Set<string>();
   let changed = false;
   const nextSections = previous.map((section) => {
     let sectionChanged = false;
     const items = section.items.map((item) => {
+      seenIds.add(item.id);
       const summary = summariesById.get(item.id);
       if (!summary) {
         return item;
@@ -4245,7 +4249,49 @@ function updateConversationSectionsFromSummaries(
       items
     };
   });
-  return changed ? nextSections : (previous as ConversationSection[]);
+
+  // A conversation can go from not-existing to existing between two runtime
+  // section fetches (e.g. the optimistic pre-activation entry created by
+  // the first-message flow, whose id never changes once the real backend
+  // session lands). The loop above only patches items that are already
+  // present in some section; without this, such a conversation would never
+  // appear in the sidebar until the next full runtimeListSessionSections
+  // refetch happens to include it, which -- because that refetch is keyed
+  // off conversation membership -- may never happen again for the same id.
+  const newConversations = conversations.filter(
+    (conversation) =>
+      !seenIds.has(conversation.id) && (conversation.pinnedAtUnixMs ?? 0) <= 0
+  );
+  if (newConversations.length === 0) {
+    return changed ? nextSections : previous;
+  }
+
+  const sectionsWithInsertions = [...nextSections];
+  for (const conversation of newConversations) {
+    const targetSectionId = conversation.project
+      ? `project:${normalizeConversationProjectPath(conversation.project.path)}`
+      : "conversations";
+    const targetIndex = sectionsWithInsertions.findIndex(
+      (section) => section.id === targetSectionId
+    );
+    const target =
+      targetIndex !== -1 ? sectionsWithInsertions[targetIndex] : undefined;
+    if (targetIndex !== -1 && target) {
+      sectionsWithInsertions[targetIndex] = {
+        ...target,
+        items: [conversation, ...target.items]
+      };
+      continue;
+    }
+    sectionsWithInsertions.push({
+      id: targetSectionId,
+      kind: conversation.project ? "project" : "conversations",
+      label: conversation.project?.label ?? options.sectionConversationsLabel,
+      project: conversation.project ?? null,
+      items: [conversation]
+    });
+  }
+  return sectionsWithInsertions;
 }
 
 function projectRuntimeSectionsToConversationSections(input: {
@@ -4862,9 +4908,11 @@ function useAgentGUIConversationRail({
       return;
     }
     setRuntimeRailSections((current) =>
-      updateConversationSectionsFromSummaries(current, conversations)
+      updateConversationSectionsFromSummaries(current, conversations, {
+        sectionConversationsLabel: labels.sectionConversations
+      })
     );
-  }, [conversations, runtimeSectionsEnabled]);
+  }, [conversations, labels.sectionConversations, runtimeSectionsEnabled]);
 
   const loadMoreSectionConversations = useCallback(
     (section: ConversationSection) => {

--- a/packages/agent/gui/agent-gui/agentGuiNode/agentGuiNodeViewConversation.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/agentGuiNodeViewConversation.tsx
@@ -244,7 +244,7 @@ function resolveConversationProjectUpdatedAtUnixMs(
   );
 }
 
-function normalizeConversationProjectPath(path: string): string {
+export function normalizeConversationProjectPath(path: string): string {
   return path.trim().replaceAll("\\", "/").replace(/\/+$/, "") || "/";
 }
 

--- a/packages/agent/gui/agent-gui/agentGuiNode/agentGuiNodeViewConversationSections.spec.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/agentGuiNodeViewConversationSections.spec.ts
@@ -1,0 +1,188 @@
+import { describe, expect, it } from "vitest";
+import type { AgentGUIConversationSummary } from "./model/agentGuiConversationModel";
+import type { ConversationSection } from "./agentGuiNodeViewConversation";
+import { updateConversationSectionsFromSummaries } from "./AgentGUINodeView";
+
+function conversation(
+  id: string,
+  updatedAtUnixMs: number,
+  overrides: Partial<AgentGUIConversationSummary> = {}
+): AgentGUIConversationSummary {
+  return {
+    id,
+    provider: "codex",
+    title: id,
+    status: "ready",
+    cwd: "/workspace",
+    updatedAtUnixMs,
+    ...overrides
+  };
+}
+
+function project(
+  path: string,
+  label: string,
+  overrides: Partial<NonNullable<AgentGUIConversationSummary["project"]>> = {}
+) {
+  return {
+    id: path,
+    path,
+    label,
+    ...overrides
+  };
+}
+
+describe("updateConversationSectionsFromSummaries", () => {
+  const sectionConversationsLabel = "Chats";
+
+  it("inserts a brand-new, no-project conversation into the existing empty conversations section", () => {
+    // Mirrors the optimistic-first-message flow: the sidebar's runtime
+    // sections are fetched once (before the new conversation existed on the
+    // backend), producing an empty "conversations" bucket. The conversation
+    // then appears in the client-side conversations list without the
+    // section id ever having changed, so this reconciliation pass is the
+    // only thing that can surface it in the sidebar.
+    const previous: ConversationSection[] = [
+      {
+        id: "conversations",
+        kind: "conversations",
+        label: sectionConversationsLabel,
+        project: null,
+        items: []
+      }
+    ];
+    const newConversation = conversation("new-convo", 1000);
+
+    const result = updateConversationSectionsFromSummaries(
+      previous,
+      [newConversation],
+      { sectionConversationsLabel }
+    );
+
+    expect(result?.[0]?.items.map((item) => item.id)).toEqual(["new-convo"]);
+  });
+
+  it("creates the conversations section from scratch when the runtime fetch returned no sections at all", () => {
+    const previous: ConversationSection[] = [];
+    const newConversation = conversation("first-convo", 1000);
+
+    const result = updateConversationSectionsFromSummaries(
+      previous,
+      [newConversation],
+      { sectionConversationsLabel }
+    );
+
+    expect(result).toHaveLength(1);
+    expect(result?.[0]).toMatchObject({
+      id: "conversations",
+      kind: "conversations",
+      label: sectionConversationsLabel
+    });
+    expect(result?.[0]?.items.map((item) => item.id)).toEqual(["first-convo"]);
+  });
+
+  it("inserts a brand-new project conversation into its matching project section", () => {
+    const appProject = project("/workspace/app", "App");
+    const previous: ConversationSection[] = [
+      {
+        id: "project:/workspace/app",
+        kind: "project",
+        label: "App",
+        project: appProject,
+        items: []
+      }
+    ];
+    const newConversation = conversation("new-project-convo", 1000, {
+      project: appProject
+    });
+
+    const result = updateConversationSectionsFromSummaries(
+      previous,
+      [newConversation],
+      { sectionConversationsLabel }
+    );
+
+    expect(result?.[0]?.items.map((item) => item.id)).toEqual([
+      "new-project-convo"
+    ]);
+  });
+
+  it("still patches fields of conversations that already exist in a section", () => {
+    const existing = conversation("existing", 1000, { status: "ready" });
+    const previous: ConversationSection[] = [
+      {
+        id: "conversations",
+        kind: "conversations",
+        label: sectionConversationsLabel,
+        project: null,
+        items: [existing]
+      }
+    ];
+    const updated = conversation("existing", 2000, { status: "working" });
+
+    const result = updateConversationSectionsFromSummaries(
+      previous,
+      [updated],
+      { sectionConversationsLabel }
+    );
+
+    expect(result?.[0]?.items).toEqual([updated]);
+  });
+
+  it("does not duplicate an item that is already present", () => {
+    const existing = conversation("existing", 1000);
+    const previous: ConversationSection[] = [
+      {
+        id: "conversations",
+        kind: "conversations",
+        label: sectionConversationsLabel,
+        project: null,
+        items: [existing]
+      }
+    ];
+
+    const result = updateConversationSectionsFromSummaries(
+      previous,
+      [existing],
+      { sectionConversationsLabel }
+    );
+
+    expect(result?.[0]?.items).toHaveLength(1);
+  });
+
+  it("returns the same reference when there is nothing new and nothing changed", () => {
+    const existing = conversation("existing", 1000);
+    const previous: ConversationSection[] = [
+      {
+        id: "conversations",
+        kind: "conversations",
+        label: sectionConversationsLabel,
+        project: null,
+        items: [existing]
+      }
+    ];
+
+    const result = updateConversationSectionsFromSummaries(
+      previous,
+      [existing],
+      { sectionConversationsLabel }
+    );
+
+    expect(result).toBe(previous);
+  });
+
+  it("does not insert a pinned conversation that has no matching section (pinned sections are built elsewhere)", () => {
+    const previous: ConversationSection[] = [];
+    const pinnedConversation = conversation("pinned-convo", 1000, {
+      pinnedAtUnixMs: 500
+    });
+
+    const result = updateConversationSectionsFromSummaries(
+      previous,
+      [pinnedConversation],
+      { sectionConversationsLabel }
+    );
+
+    expect(result).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary
- `updateConversationSectionsFromSummaries` (the section-grouped/project sidebar rail's reconciliation pass) only patched fields of conversations already present in some section. A conversation transitioning from not-existing to existing between two runtime section fetches — e.g. the optimistic pre-activation entry created by the first-message flow — was never inserted, so it stayed missing from the sidebar indefinitely.
- This is distinct from the `visibleConversations` path already fixed by e9d1cf99: the real desktop tuttid runtime always uses this section-based path (`runtimeSectionsEnabled` is true whenever the runtime supports `listSessionSections`/`listSessionSectionPage`), so this is a live, default-path bug.
- Found and fixed while doing live e2e verification of the `acceptance/ricky-goal-batch-20260705` batch of fixes (item 2: "sidebar shows the new conversation immediately").

## Test plan
- [x] New `agentGuiNodeViewConversationSections.spec.ts` (7 cases: new no-project conversation into existing/empty section, section-from-scratch, new project conversation, patch existing, no duplicate, reference-stability, pinned conversations excluded)
- [x] `agentGuiNodeViewConversation.spec.ts` and `AgentGUINodeView.layout.spec.tsx` still pass (101 tests)
- [x] Live Playwright e2e against an isolated Electron/tuttid instance confirms the conversation appears in the sidebar immediately after the first message

Note: this PR is for record-keeping only per explicit instruction for this e2e-verification pass — it is not being merged here; the fix has been cherry-picked directly onto `acceptance/ricky-goal-batch-20260705` for a human to merge from there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Conversation sidebars now stay in sync when new conversations appear between updates, including recently created items.
  * Existing conversation entries are updated in place instead of being duplicated.
  * Conversations are inserted into the correct project or general section more reliably, and pinned conversations are kept out of automatic insertion.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->