### PR TITLE
fix(desktop): wire AgentGUI onShowMessage to a real toast, not a no-op

### DIFF
--- a/apps/desktop/src/renderer/src/features/workspace-agent/ui/DesktopAgentGUIWorkbenchBody.showMessage.test.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-agent/ui/DesktopAgentGUIWorkbenchBody.showMessage.test.ts
@@ -1,0 +1,32 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import test from "node:test";
+
+// Regression test for a bug where AgentGUINode's onShowMessage callback (used
+// e.g. to tell the user a Codex permission-mode change will only apply
+// starting with their next message, see
+// useAgentGUINodeController's "messages.agentPermissionModeAppliesNextTurn"
+// path) was wired to a no-op on desktop, so the message was computed and
+// handed to the callback but never actually shown to the user anywhere.
+const workbenchBodySource = readFileSync(
+  new URL("./DesktopAgentGUIWorkbenchBody.tsx", import.meta.url),
+  "utf8"
+);
+
+test("desktop AgentGUI onShowMessage is wired to a real toast, not the shared no-op", () => {
+  assert.doesNotMatch(
+    workbenchBodySource,
+    /onShowMessage=\{DESKTOP_AGENT_GUI_NOOP\}/
+  );
+  assert.match(
+    workbenchBodySource,
+    /onShowMessage=\{handleDesktopAgentGUIShowMessage\}/
+  );
+});
+
+test("handleDesktopAgentGUIShowMessage routes error tone to Toast.Error and other tones to Toast.tips", () => {
+  assert.match(
+    workbenchBodySource,
+    /function handleDesktopAgentGUIShowMessage\(\s*message: string,\s*tone\?: "info" \| "warning" \| "error"\s*\): void \{\s*if \(tone === "error"\) \{\s*Toast\.Error\(message\);\s*return;\s*\}\s*Toast\.tips\(message\);\s*\}/
+  );
+});

--- a/apps/desktop/src/renderer/src/features/workspace-agent/ui/DesktopAgentGUIWorkbenchBody.tsx
+++ b/apps/desktop/src/renderer/src/features/workspace-agent/ui/DesktopAgentGUIWorkbenchBody.tsx
@@ -141,6 +141,16 @@ const DESKTOP_AGENT_GUI_AGENT_SETTINGS = {
   avoidGroupingEdits: false
 } satisfies NonNullable<AgentGUIProps["agentSettings"]>;
 const DESKTOP_AGENT_GUI_NOOP = (): void => {};
+function handleDesktopAgentGUIShowMessage(
+  message: string,
+  tone?: "info" | "warning" | "error"
+): void {
+  if (tone === "error") {
+    Toast.Error(message);
+    return;
+  }
+  Toast.tips(message);
+}
 const AGENT_PROBE_REFRESH_DEBOUNCE_MS = 300;
 const DESKTOP_AGENT_GUI_EMPTY_CONTEXT_MENTION_PROVIDERS =
   [] satisfies NonNullable<AgentGUIProps["contextMentionProviders"]>;
@@ -1115,7 +1125,7 @@ function DesktopAgentGUIWorkbenchBodyImpl({
               }
         }
         onResize={DESKTOP_AGENT_GUI_NOOP}
-        onShowMessage={DESKTOP_AGENT_GUI_NOOP}
+        onShowMessage={handleDesktopAgentGUIShowMessage}
         onUpdateNode={handleUpdateNode}
         onRememberComposerDefaults={handleRememberComposerDefaults}
         onOpenConversationWindow={


### PR DESCRIPTION
## Summary
- `DesktopAgentGUIWorkbenchBody` wired AgentGUI's `onShowMessage` callback to `DESKTOP_AGENT_GUI_NOOP`, so every message routed through it was silently swallowed on desktop — including the "this setting requires a new session" warning and, as of the live-permission-mode-switch fix, the info toast telling the user a Codex permission-mode change made mid-turn will only apply starting with their next message.
- Found while doing live e2e verification of `acceptance/ricky-goal-batch-20260705` item 3 (Codex permission-mode switch mid-turn should show an info toast): switching modes mid-turn produced no visible toast at all, even though the controller computed the right message and called the callback.
- Fix: route `onShowMessage` through the same desktop `Toast` module already used elsewhere in this file, mapping `"error"` to `Toast.Error` and everything else to `Toast.tips`.

## Test plan
- [x] New regression test asserting `onShowMessage` is not wired to the shared no-op and is wired to the new handler, plus a test for the tone-mapping logic
- [x] `useAgentGUINodeController.spec.tsx`'s existing permission-mode-toast tests still pass
- [x] Live Playwright e2e against an isolated Electron/tuttid instance: before the fix, switching Codex's permission mode mid-turn showed no toast; after the fix (and rebuilding the desktop app), the correct "权限模式将从你的下一条消息开始生效" toast renders

Note: this PR is for record-keeping only per explicit instruction for this e2e-verification pass — it is not being merged here; the fix has been cherry-picked directly onto `acceptance/ricky-goal-batch-20260705` for a human to merge from there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Agent messages are now shown in the desktop workspace instead of being ignored.
  * Error messages display with an error toast, while other message tones use a standard tip toast.
* **Tests**
  * Added regression coverage to verify message handling is wired correctly and routes tones to the right notification style.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->