### PR TITLE
fix(app-factory): stop trusting session status for completion mid-turn

### DIFF
--- a/services/tuttid/service/workspace/app_factory.go
+++ b/services/tuttid/service/workspace/app_factory.go
@@ -49,6 +49,12 @@ type AppFactoryService struct {
 	Publisher             WorkspaceAppFactoryEventPublisher
 
 	publishLocks keyedOperationLocks
+
+	// liveTurnAgentSessions tracks, per agent session, whether the most
+	// recently observed TurnLifecycle snapshot (see ObserveAgentSessionState)
+	// reports a live turn. See agentSessionHasLiveTurn in
+	// app_factory_agent_state.go for why this exists.
+	liveTurnAgentSessions sync.Map
 }
 
 type keyedOperationLocks struct {

--- a/services/tuttid/service/workspace/app_factory_agent_state.go
+++ b/services/tuttid/service/workspace/app_factory_agent_state.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	agentsessionstore "github.com/tutti-os/tutti/packages/agent/daemon/activity"
+	activityshared "github.com/tutti-os/tutti/packages/agent/daemon/activity/events"
 	agentactivitybiz "github.com/tutti-os/tutti/services/tuttid/biz/agentactivity"
 	workspacebiz "github.com/tutti-os/tutti/services/tuttid/biz/workspace"
 )
@@ -38,8 +39,12 @@ func (s *AppFactoryService) ObserveAgentSessionState(_ context.Context, input ag
 	}
 	workspaceID := strings.TrimSpace(input.WorkspaceID)
 	agentSessionID := strings.TrimSpace(input.AgentSessionID)
+	if workspaceID == "" || agentSessionID == "" {
+		return
+	}
+	s.trackAgentSessionTurnLifecycle(workspaceID, agentSessionID, input.State.TurnLifecycle)
 	status := factoryAgentTerminalStatus(input.State)
-	if workspaceID == "" || agentSessionID == "" || status == "" {
+	if status == "" {
 		return
 	}
 	lastError := strings.TrimSpace(input.State.LastError)
@@ -123,6 +128,17 @@ func (s *AppFactoryService) reconcileFromPersistedAgentSession(ctx context.Conte
 		return false, nil
 	}
 	if status := normalizePersistedFactoryAgentSessionStatus(session.Status); status != "" {
+		if status == "completed" && s.agentSessionHasLiveTurn(workspaceID, agentSessionID) {
+			// The persisted session status says "completed", but a
+			// TurnLifecycle snapshot we observed independently (see
+			// trackAgentSessionTurnLifecycle) says a turn is still live for
+			// this session. Trust the snapshot: it is copied verbatim from
+			// the provider (ADR 0008) rather than folded/re-derived from
+			// discrete events, so it is immune to the false-"completed"
+			// class of bug this guard exists for. Leave the job alone; a
+			// later reconcile pass will pick up the real terminal state.
+			return true, nil
+		}
 		return true, s.handleAgentSessionTerminalState(ctx, workspaceID, agentSessionID, status, session.LastError)
 	}
 	if strings.ToLower(strings.TrimSpace(session.CurrentPhase)) == "failed" {
@@ -142,8 +158,74 @@ func (s *AppFactoryService) reconcileCompletedAgentSessionMessages(ctx context.C
 	return true, s.handleAgentSessionTerminalState(ctx, workspaceID, agentSessionID, "completed", "")
 }
 
+// trackAgentSessionTurnLifecycle records whether an agent session currently
+// has a live turn in flight, using the ADR 0008 TurnLifecycle snapshot
+// (packages/agent/daemon/activity/events/turn_lifecycle_snapshot.go) that
+// accompanies every session state report. It exists to close a gap PR #774
+// only partly covered: a single codex turn commonly emits several
+// role=assistant/kind=text/status=completed message segments before it
+// actually finishes -- e.g. a short plan-announcement sentence ("I'll follow
+// the app-factory skill; let me read its docs first...") streamed seconds
+// before the agent's first tool call in the very same turn. PR #774 stopped
+// treating tagged system-notice messages as a completion signal, but a plain
+// narration segment like that is not a system notice, and the persisted
+// session's own folded/derived Status can still misreport "completed" for
+// it (see agentSessionHasCompletedFactoryOutput below, and the "天气查询"
+// diagnostic bundle this guard was written from: job
+// e6e70f6a-802e-4ac5-9275-ea6272f32b97 was failed at the exact millisecond
+// its first narration message completed, while the codex session's own
+// TurnLifecycle kept reporting phase "running" for the same turn ID for
+// another 44+ seconds). The TurnLifecycle snapshot is copied verbatim by
+// design (never re-derived from discrete events), so cross-checking it here
+// catches this whole class of premature completion regardless of which
+// message shape triggers it.
+func (s *AppFactoryService) trackAgentSessionTurnLifecycle(workspaceID string, agentSessionID string, lifecycle *agentsessionstore.WorkspaceAgentTurnLifecycle) {
+	if s == nil {
+		return
+	}
+	key := agentSessionTurnTrackerKey(workspaceID, agentSessionID)
+	if agentSessionTurnLifecycleIsLive(lifecycle) {
+		s.liveTurnAgentSessions.Store(key, struct{}{})
+		return
+	}
+	s.liveTurnAgentSessions.Delete(key)
+}
+
+// agentSessionHasLiveTurn reports whether the last TurnLifecycle snapshot
+// observed for this agent session (via ObserveAgentSessionState) says a turn
+// is still running. See trackAgentSessionTurnLifecycle for why this is
+// tracked independently of the message- and session-status-based completion
+// heuristics below.
+func (s *AppFactoryService) agentSessionHasLiveTurn(workspaceID string, agentSessionID string) bool {
+	if s == nil {
+		return false
+	}
+	_, ok := s.liveTurnAgentSessions.Load(agentSessionTurnTrackerKey(workspaceID, agentSessionID))
+	return ok
+}
+
+func agentSessionTurnTrackerKey(workspaceID string, agentSessionID string) string {
+	return strings.TrimSpace(workspaceID) + "\x00" + strings.TrimSpace(agentSessionID)
+}
+
+func agentSessionTurnLifecycleIsLive(lifecycle *agentsessionstore.WorkspaceAgentTurnLifecycle) bool {
+	if lifecycle == nil {
+		return false
+	}
+	if lifecycle.ActiveTurnID == nil || strings.TrimSpace(*lifecycle.ActiveTurnID) == "" {
+		return false
+	}
+	if lifecycle.Outcome != nil && strings.TrimSpace(*lifecycle.Outcome) != "" {
+		return false
+	}
+	return activityshared.TurnLifecyclePhaseIsLive(lifecycle.Phase)
+}
+
 func (s *AppFactoryService) agentSessionHasCompletedFactoryOutput(workspaceID string, agentSessionID string) bool {
 	if s == nil || s.AgentMessageReader == nil {
+		return false
+	}
+	if s.agentSessionHasLiveTurn(workspaceID, agentSessionID) {
 		return false
 	}
 	if s.AgentSessionReader != nil {

--- a/services/tuttid/service/workspace/app_factory_test.go
+++ b/services/tuttid/service/workspace/app_factory_test.go
@@ -2115,3 +2115,132 @@ func TestAppFactoryServiceObserveAgentSessionMessagesIgnoresSystemNoticeForCompl
 		t.Fatalf("published updates = %d, want 0", len(publisher.published))
 	}
 }
+
+// TestAppFactoryServiceIgnoresCompletedTextMidLiveTurn reproduces the
+// "天气查询" false-failure sequence found in diagnostic bundle
+// tutti-logs-20260706-092357.zip: job e6e70f6a-802e-4ac5-9275-ea6272f32b97
+// went generating -> preparing -> validating -> failed within 1ms of its
+// *first* assistant message completing (tuttid.log 09:23:32.658+08:00 ->
+// 09:23:32.659+08:00), with the exact failureReason PR #774 fixed ("read app
+// manifest: ... no such file or directory" -- validation ran before the
+// agent had written any files).
+//
+// Unlike PR #774's "答案之书" case, the triggering message here was not a
+// system notice: it was the codex agent's ordinary opening narration ("我会
+// 按 `$tutti-workspace-app-factory` 的流程来做...先读它的本地说明，然后检查
+// 当前草稿目录的结构再实现。"), a plain role=assistant/kind=text/
+// status=completed message with no payload.kind tag at all, sent ~2.5s
+// before its first tool call in the very same turn (turnId
+// 596f2132-32e5-4bfb-8e13-e4a60063ac5a in the exported agent session). PR
+// #774's payload.kind=="agent_system_notice" exclusion does not, and cannot,
+// catch this: the message carries no such tag, so
+// isCompletedAssistantTextMessage still reports it as a completed answer
+// and agentSessionHasCompletedFactoryOutput still trusted the (racy)
+// persisted session status.
+//
+// This asserts the additional TurnLifecycle-based guard: an ADR 0008
+// TurnLifecycle snapshot (copied verbatim from the provider, never
+// re-derived from discrete events) reported via ObserveAgentSessionState is
+// tracked independently and, while it still says the turn is live, blocks
+// the message-triggered completion path regardless of which message shape
+// triggered it -- then gets out of the way once the turn genuinely settles.
+func TestAppFactoryServiceIgnoresCompletedTextMidLiveTurn(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	store := newAppFactoryStoreStub()
+	draftDir := t.TempDir()
+	if err := store.PutAppFactoryJob(ctx, workspacebiz.AppFactoryJob{
+		AgentSessionID: "session-1",
+		AppID:          "app_1",
+		DraftDir:       draftDir,
+		JobID:          "job-1",
+		Status:         workspacebiz.AppFactoryJobStatusGenerating,
+		WorkspaceID:    "ws-1",
+	}); err != nil {
+		t.Fatalf("PutAppFactoryJob() error = %v", err)
+	}
+	publisher := &workspaceAppFactoryPublisherStub{}
+	service := AppFactoryService{
+		Store:     store,
+		AppStore:  newAppStoreStub(),
+		Publisher: publisher,
+		// Even if the persisted session's canonical status momentarily
+		// reads "completed" (the same suspected upstream race PR #774
+		// called out), the observer must not act on it while the turn's
+		// own TurnLifecycle snapshot still says the turn is running.
+		AgentSessionReader: factoryAgentSessionReaderStub{
+			sessions: map[string]agentservice.PersistedSession{
+				appFactoryJobStoreKey("ws-1", "session-1"): {
+					ID:          "session-1",
+					WorkspaceID: "ws-1",
+					Status:      "completed",
+				},
+			},
+		},
+		AgentMessageReader: factoryAgentMessageReaderStub{},
+	}
+
+	activeTurnID := "596f2132-32e5-4bfb-8e13-e4a60063ac5a"
+	service.ObserveAgentSessionState(ctx, agentsessionstore.ReportSessionStateInput{
+		WorkspaceID:    "ws-1",
+		AgentSessionID: "session-1",
+		State: agentsessionstore.WorkspaceAgentSessionStateUpdate{
+			LifecycleStatus: "active",
+			CurrentPhase:    "working",
+			TurnLifecycle: &agentsessionstore.WorkspaceAgentTurnLifecycle{
+				ActiveTurnID: &activeTurnID,
+				Phase:        "running",
+			},
+		},
+	}, agentsessionstore.ReportSessionStateReply{Accepted: true, StateApplied: true})
+
+	// The agent's ordinary opening narration completes mid-turn. This is the
+	// same call ObserveAgentSessionMessages's goroutine would make; calling
+	// it directly keeps the test synchronous.
+	if err := service.handleAgentSessionCompletedMessage(ctx, "ws-1", "session-1"); err != nil {
+		t.Fatalf("handleAgentSessionCompletedMessage() error = %v", err)
+	}
+
+	job, err := store.GetAppFactoryJob(ctx, "ws-1", "job-1")
+	if err != nil {
+		t.Fatalf("GetAppFactoryJob() error = %v", err)
+	}
+	if job.Status != workspacebiz.AppFactoryJobStatusGenerating {
+		t.Fatalf("status = %q, want generating (job must not fail on interim narration mid-turn)", job.Status)
+	}
+	if strings.TrimSpace(job.FailureReason) != "" {
+		t.Fatalf("failure reason = %q, want empty", job.FailureReason)
+	}
+	if len(publisher.published) != 0 {
+		t.Fatalf("published updates = %d, want 0", len(publisher.published))
+	}
+
+	// Once the turn genuinely settles (TurnLifecycle reports a real
+	// outcome), the same completed-session-status signal must be trusted
+	// again so the job does not get stuck forever.
+	service.ObserveAgentSessionState(ctx, agentsessionstore.ReportSessionStateInput{
+		WorkspaceID:    "ws-1",
+		AgentSessionID: "session-1",
+		State: agentsessionstore.WorkspaceAgentSessionStateUpdate{
+			LifecycleStatus: "active",
+			CurrentPhase:    "idle",
+			TurnLifecycle: &agentsessionstore.WorkspaceAgentTurnLifecycle{
+				ActiveTurnID: &activeTurnID,
+				Phase:        "settled",
+				Outcome:      stringPtr("completed"),
+			},
+		},
+	}, agentsessionstore.ReportSessionStateReply{Accepted: true, StateApplied: true})
+
+	if err := service.handleAgentSessionCompletedMessage(ctx, "ws-1", "session-1"); err != nil {
+		t.Fatalf("handleAgentSessionCompletedMessage() error = %v", err)
+	}
+	job, err = store.GetAppFactoryJob(ctx, "ws-1", "job-1")
+	if err != nil {
+		t.Fatalf("GetAppFactoryJob() error = %v", err)
+	}
+	if job.Status != workspacebiz.AppFactoryJobStatusFailed {
+		t.Fatalf("status = %q, want failed once the turn genuinely settles (validation runs and fails against the still-empty draft)", job.Status)
+	}
+}


### PR DESCRIPTION
## Summary

- PR #774 excluded `agent_system_notice`-tagged messages from the "completed assistant text" heuristic `ObserveAgentSessionMessages` uses to decide an App Factory job's agent session finished. That fix only covers one specific message shape; the same underlying bug still fires when the triggering message is ordinary assistant narration.
- Diagnostic bundle `tutti-logs-20260706-092357.zip` shows the "天气查询" job (`e6e70f6a-802e-4ac5-9275-ea6272f32b97`) going `generating -> preparing -> validating -> failed` within 1ms of its **first** assistant message completing (`tuttid.log` `09:23:32.658+08:00 -> 09:23:32.659+08:00`), with the exact `failureReason` PR #774 fixed: `read app manifest: .../draft/package/tutti.app.json: no such file or directory` — validation ran before the agent had written any files.
- The triggering message here was **not** a system notice: it was the codex agent's plain opening narration ("我会按 `$tutti-workspace-app-factory` 的流程来做...先读它的本地说明，然后检查当前草稿目录的结构再实现。"), a genuine `role=assistant/kind=text/status=completed` message with no `payload.kind` tag, sent ~2.5s before its first tool call in the very same turn (`turnId 596f2132-32e5-4bfb-8e13-e4a60063ac5a`). PR #774's `payload.kind=="agent_system_notice"` exclusion cannot catch this.
- The exported session's own `TurnLifecycle` kept reporting `phase: "running"` for that same turn ID for another 44+ seconds after the job was already marked failed — confirming `agentSessionHasCompletedFactoryOutput`'s trust in the persisted session's folded/derived `Status` is exactly the "suspected upstream race" PR #774's own commit message and test comments flagged, but did not close.

## Fix

Track the ADR 0008 `TurnLifecycle` snapshot reported alongside every `ObserveAgentSessionState` update (copied verbatim from the provider, never re-derived from discrete events — see `packages/agent/daemon/activity/events/turn_lifecycle_snapshot.go`) in a small in-memory map on `AppFactoryService`, and use it to gate both places that currently trust a bare "session says completed" reading:

- `agentSessionHasCompletedFactoryOutput` (used by the `ObserveAgentSessionMessages` fast path)
- the `"completed"` branch of `reconcileFromPersistedAgentSession` (used by every App Factory job list poll)

While a turn is still live, neither path treats the session as done. Once `TurnLifecycle` genuinely settles (a real outcome is reported), the existing behavior resumes so a truly finished job is never stuck. `failed`/`canceled` handling is untouched.

This is a different, more general fix than PR #774's: instead of excluding one more message shape from the heuristic, it stops trusting the racy derived session status at all while a turn is provably still running, using a signal (`TurnLifecycle`) the daemon already produces specifically to be race-free.

## Test plan

- [x] Added `TestAppFactoryServiceIgnoresCompletedTextMidLiveTurn`, reproducing the exact "天气查询" sequence from the log bundle (ordinary narration text arriving mid-turn, session status racily reporting "completed"); verified it fails without the fix and passes with it.
- [x] `go build ./...` and `go vet ./...` in `services/tuttid`.
- [x] `go test ./service/workspace/... -run AppFactory` — all pass, including the existing PR #774 regression test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved session tracking so in-progress turns are no longer mistaken for completed work.
  * Prevented premature status changes when a session reports completion while a turn is still running.
  * Added a safeguard so completion updates are only applied once the turn has fully settled.

* **Tests**
  * Added coverage for a mid-turn completion scenario to verify the job stays active until the turn finishes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->