### PR TITLE
fix(agent-gui): clamp composer palette against virtual node windows too

### DIFF
--- a/packages/agent/gui/agent-gui/agentGuiNode/composerFloatingMenu/ComposerFloatingMenuSurface.spec.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/composerFloatingMenu/ComposerFloatingMenuSurface.spec.tsx
@@ -5,23 +5,30 @@ import { describe, expect, it, vi } from "vitest";
 import { DESKTOP_WINDOW_TOP_MARGIN } from "../../workspaceDesktop/constants";
 import { ComposerFloatingMenuSurface } from "./ComposerFloatingMenuSurface";
 
+function mockRect(rect: {
+  bottom: number;
+  height: number;
+  left: number;
+  right: number;
+  top: number;
+  width: number;
+}): DOMRect {
+  return { ...rect, x: rect.left, y: rect.top, toJSON: () => ({}) } as DOMRect;
+}
+
 describe("ComposerFloatingMenuSurface", () => {
   it("keeps a fixed-height menu clear of the workspace window's traffic-light header even when the anchor sits near the top of the viewport", () => {
     const anchorRef = createRef<HTMLDivElement>();
     const anchor = document.createElement("div");
-    anchor.getBoundingClientRect = vi.fn(
-      () =>
-        ({
-          bottom: 90,
-          height: 30,
-          left: 12,
-          right: 200,
-          top: 60,
-          width: 188,
-          x: 12,
-          y: 60,
-          toJSON: () => ({})
-        }) as DOMRect
+    anchor.getBoundingClientRect = vi.fn(() =>
+      mockRect({
+        bottom: 90,
+        height: 30,
+        left: 12,
+        right: 200,
+        top: 60,
+        width: 188
+      })
     );
     document.body.appendChild(anchor);
     anchorRef.current = anchor;
@@ -43,5 +50,149 @@ describe("ComposerFloatingMenuSurface", () => {
     expect(top).toBeGreaterThanOrEqual(DESKTOP_WINDOW_TOP_MARGIN);
 
     anchor.remove();
+  });
+
+  it("clamps the menu against a compact virtual node window's own header, not just the real viewport's 52px margin", () => {
+    // Simulate a short WorkspaceNodeWindow (well under COMPOSER_MENU_MIN_HEIGHT_PX
+    // of 280px) parked in the middle of the workspace canvas, far from the real
+    // screen's top edge. Its own decorative header sits at, say, 400-436px in
+    // viewport coordinates -- nowhere near the real-window 52px safe area, so the
+    // 52px floor alone can't protect it.
+    const nodeRoot = document.createElement("div");
+    nodeRoot.setAttribute("data-workspace-node-window-root", "true");
+    nodeRoot.getBoundingClientRect = vi.fn(() =>
+      mockRect({
+        bottom: 570,
+        height: 170,
+        left: 300,
+        right: 600,
+        top: 400,
+        width: 300
+      })
+    );
+
+    const header = document.createElement("header");
+    header.setAttribute("data-workspace-node-window-header", "true");
+    header.getBoundingClientRect = vi.fn(() =>
+      mockRect({
+        bottom: 436,
+        height: 36,
+        left: 300,
+        right: 600,
+        top: 400,
+        width: 300
+      })
+    );
+    nodeRoot.appendChild(header);
+
+    const anchorRef = createRef<HTMLDivElement>();
+    const anchor = document.createElement("div");
+    // Composer sits directly below the header, near the bottom of the short node.
+    anchor.getBoundingClientRect = vi.fn(() =>
+      mockRect({
+        bottom: 560,
+        height: 30,
+        left: 312,
+        right: 588,
+        top: 530,
+        width: 276
+      })
+    );
+    nodeRoot.appendChild(anchor);
+    document.body.appendChild(nodeRoot);
+    anchorRef.current = anchor;
+
+    render(
+      <ComposerFloatingMenuSurface
+        anchorRef={anchorRef}
+        maxHeight={320}
+        open
+        placement="fixed-height"
+        testId="composer-floating-menu-surface-node"
+      >
+        <div>menu content</div>
+      </ComposerFloatingMenuSurface>
+    );
+
+    const surface = screen.getByTestId("composer-floating-menu-surface-node");
+    // The palette must render inside the node (portal target), not document.body.
+    expect(surface.parentElement).toBe(nodeRoot);
+
+    const top = Number.parseFloat(surface.style.top);
+    const minHeight = Number.parseFloat(surface.style.minHeight);
+
+    // The node's own header bottom edge (436) is a far more restrictive floor
+    // here than the real-viewport 52px margin -- the fix must honor it.
+    expect(top).toBeGreaterThanOrEqual(436);
+    // The forced minimum height must never be so large that top + minHeight
+    // pushes back above the node's own header, even though the palette's
+    // "natural" minimum (280px) alone would do exactly that from this anchor.
+    expect(top + minHeight).toBeLessThanOrEqual(560 - 8 + 0.5);
+    expect(minHeight).toBeLessThanOrEqual(280);
+  });
+
+  it("still applies the real-viewport 52px floor when the enclosing node's own header is above it (real window case is unaffected)", () => {
+    const nodeRoot = document.createElement("div");
+    nodeRoot.setAttribute("data-workspace-node-window-root", "true");
+    nodeRoot.getBoundingClientRect = vi.fn(() =>
+      mockRect({
+        bottom: 400,
+        height: 400,
+        left: 0,
+        right: 400,
+        top: 0,
+        width: 400
+      })
+    );
+
+    const header = document.createElement("header");
+    header.setAttribute("data-workspace-node-window-header", "true");
+    // Header bottom edge sits above the real-window 52px safe area (e.g. a
+    // maximized node docked flush with the canvas top).
+    header.getBoundingClientRect = vi.fn(() =>
+      mockRect({
+        bottom: 36,
+        height: 36,
+        left: 0,
+        right: 400,
+        top: 0,
+        width: 400
+      })
+    );
+    nodeRoot.appendChild(header);
+
+    const anchorRef = createRef<HTMLDivElement>();
+    const anchor = document.createElement("div");
+    anchor.getBoundingClientRect = vi.fn(() =>
+      mockRect({
+        bottom: 90,
+        height: 30,
+        left: 12,
+        right: 200,
+        top: 60,
+        width: 188
+      })
+    );
+    nodeRoot.appendChild(anchor);
+    document.body.appendChild(nodeRoot);
+    anchorRef.current = anchor;
+
+    render(
+      <ComposerFloatingMenuSurface
+        anchorRef={anchorRef}
+        maxHeight={320}
+        open
+        placement="fixed-height"
+        testId="composer-floating-menu-surface-real-floor"
+      >
+        <div>menu content</div>
+      </ComposerFloatingMenuSurface>
+    );
+
+    const surface = screen.getByTestId(
+      "composer-floating-menu-surface-real-floor"
+    );
+    const top = Number.parseFloat(surface.style.top);
+    expect(top).toBeGreaterThanOrEqual(DESKTOP_WINDOW_TOP_MARGIN);
   });
 });

--- a/packages/agent/gui/agent-gui/agentGuiNode/composerFloatingMenu/ComposerFloatingMenuSurface.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/composerFloatingMenu/ComposerFloatingMenuSurface.tsx
@@ -29,6 +29,7 @@ export interface ComposerAnchoredMenuFrame {
   bottom: number;
   height: number;
   left: number;
+  minHeight: number;
   portalTarget: Element;
   top: number;
   width: number;
@@ -57,12 +58,17 @@ export interface ComposerFloatingMenuSurfaceProps {
   testId: string;
 }
 
+const COMPOSER_MENU_WINDOW_FRAME_SELECTOR =
+  "[data-workbench-window-id], [data-workspace-node-window-root='true']";
+
+function resolveComposerMenuWindowFrame(anchor: HTMLElement): Element | null {
+  return anchor.closest(COMPOSER_MENU_WINDOW_FRAME_SELECTOR);
+}
+
 function resolveComposerMenuPortalTarget(anchor: HTMLElement): Element {
   return (
     anchor.closest('[data-slot="viewport-menu-boundary"]') ??
-    anchor.closest(
-      "[data-workbench-window-id], [data-workspace-node-window-root='true']"
-    ) ??
+    resolveComposerMenuWindowFrame(anchor) ??
     document.body
   );
 }
@@ -70,11 +76,7 @@ function resolveComposerMenuPortalTarget(anchor: HTMLElement): Element {
 function resolveComposerMenuZIndex(anchor: HTMLElement): number | string {
   let current: HTMLElement | null = anchor;
   while (current) {
-    if (
-      current.matches(
-        "[data-workbench-window-id], [data-workspace-node-window-root='true']"
-      )
-    ) {
+    if (current.matches(COMPOSER_MENU_WINDOW_FRAME_SELECTOR)) {
       const windowZIndex = Number.parseInt(
         window.getComputedStyle(current).zIndex,
         10
@@ -86,6 +88,30 @@ function resolveComposerMenuZIndex(anchor: HTMLElement): number | string {
     current = current.parentElement;
   }
   return "var(--z-popover)";
+}
+
+// Mirrors the real workspace window's `COMPOSER_MENU_TOP_SAFE_AREA_PX` floor,
+// but scoped to a virtual node window on the workspace canvas
+// (`WorkspaceNodeWindow.tsx`). Each node draws its own decorative header with
+// fake traffic-light buttons (`data-workspace-node-window-header="true"`);
+// clamping only against the real viewport's 52px chrome ignores that a
+// compact node's header can sit well below (or, rarer, above) that mark.
+// Falls back to the enclosing frame's own top edge when no explicit header
+// is found, so the menu never renders above the window/node it lives in.
+function resolveComposerMenuTopSafeArea(anchor: HTMLElement): number {
+  const windowFrame = resolveComposerMenuWindowFrame(anchor);
+  if (!windowFrame) {
+    return COMPOSER_MENU_TOP_SAFE_AREA_PX;
+  }
+
+  const header = windowFrame.querySelector(
+    '[data-workspace-node-window-header="true"]'
+  );
+  const localFloor = (header ?? windowFrame).getBoundingClientRect()[
+    header ? "bottom" : "top"
+  ];
+
+  return Math.max(COMPOSER_MENU_TOP_SAFE_AREA_PX, localFloor);
 }
 
 function computeComposerAnchoredMenuFrame(
@@ -106,15 +132,20 @@ function computeComposerAnchoredMenuFrame(
       viewportWidth - COMPOSER_MENU_VIEWPORT_PADDING_PX - width
     )
   );
-  const availableAbove =
-    rect.top - COMPOSER_MENU_GAP_PX - COMPOSER_MENU_TOP_SAFE_AREA_PX;
+  const topSafeArea = resolveComposerMenuTopSafeArea(anchor);
+  const availableAbove = rect.top - COMPOSER_MENU_GAP_PX - topSafeArea;
+  // Never demand more minimum height than the enclosing window/node actually
+  // has room for above its own safe area — otherwise a compact node (as
+  // short as `DESKTOP_WINDOW_MIN_HEIGHT`) is forced to render the menu past
+  // its own header, regardless of the safe-area clamp below.
+  const minHeight = Math.max(
+    0,
+    Math.min(COMPOSER_MENU_MIN_HEIGHT_PX, availableAbove)
+  );
   const height =
     availableAbove >= maxHeight
       ? maxHeight
-      : Math.max(
-          COMPOSER_MENU_MIN_HEIGHT_PX,
-          Math.min(maxHeight, availableAbove)
-        );
+      : Math.max(minHeight, Math.min(maxHeight, availableAbove));
 
   return {
     bottom: Math.max(
@@ -123,9 +154,10 @@ function computeComposerAnchoredMenuFrame(
     ),
     height,
     left,
+    minHeight,
     portalTarget: resolveComposerMenuPortalTarget(anchor),
     top: Math.max(
-      COMPOSER_MENU_TOP_SAFE_AREA_PX,
+      topSafeArea,
       Math.min(
         rect.top - COMPOSER_MENU_GAP_PX - height,
         viewportHeight - COMPOSER_MENU_VIEWPORT_PADDING_PX - height
@@ -148,7 +180,8 @@ function sameComposerAnchoredMenuFrame(
     Math.abs(left.top - right.top) < 0.5 &&
     Math.abs(left.bottom - right.bottom) < 0.5 &&
     Math.abs(left.width - right.width) < 0.5 &&
-    Math.abs(left.height - right.height) < 0.5
+    Math.abs(left.height - right.height) < 0.5 &&
+    Math.abs(left.minHeight - right.minHeight) < 0.5
   );
 }
 
@@ -311,7 +344,7 @@ export const ComposerFloatingMenuSurface = forwardRef<
       return {
         ...baseStyle,
         top: `${frame?.top ?? 0}px`,
-        minHeight: `${COMPOSER_MENU_MIN_HEIGHT_PX}px`,
+        minHeight: `${frame?.minHeight ?? COMPOSER_MENU_MIN_HEIGHT_PX}px`,
         height: `${frame?.height ?? maxHeight}px`,
         maxHeight: `${maxHeight}px`
       };


### PR DESCRIPTION
## Summary

Follow-up to #770 (merged as `2009c563`), which clamped the slash-command palette against the real workspace `BrowserWindow`'s 52px chrome (`DESKTOP_WINDOW_TOP_MARGIN`) so it wouldn't cover the real macOS traffic-light buttons.

That fix was incomplete: the same palette (`ComposerFloatingMenuSurface.tsx`, via `AgentComposer.tsx`) also renders inside **virtual node windows** on the workspace canvas (`WorkspaceNodeWindow.tsx`), each drawing its own decorative header with fake traffic-light buttons. That header can sit anywhere on the canvas — not just near the real screen's top edge — and a compact node (as short as `DESKTOP_WINDOW_MIN_HEIGHT` = 120px) is shorter than the palette's `COMPOSER_MENU_MIN_HEIGHT_PX` (280px) forced minimum height. So for any compact node, the palette still overflowed past *that node's own header*, regardless of the real-viewport 52px clamp being satisfied.

- `ComposerFloatingMenuSurface.tsx`: added `resolveComposerMenuTopSafeArea`, which resolves the enclosing node/window frame via the same `closest()` lookup already used for portal targeting, locates its own header (`[data-workspace-node-window-header="true"]`) or falls back to the frame's own top edge, and takes whichever floor — the real 52px margin or the node's own header bottom edge — is more restrictive.
- Also scaled the palette's minimum height (`minHeight` on the computed frame) down to whatever room is actually available above that floor, since the previous hardcoded `280px` CSS `min-height` silently overrode any position math meant to keep the palette clear.
- Extended `ComposerFloatingMenuSurface.spec.tsx` with two new cases: a compact virtual node window positioned away from the real viewport top (asserts the palette clamps to the node's own header, and its forced minimum height never pushes back past that header), and a node whose header sits above the real 52px floor (asserts the real-window floor still applies unchanged).

## Test plan

- [x] `pnpm exec vitest run --environment jsdom agentGuiNode/composerFloatingMenu/ComposerFloatingMenuSurface.spec.tsx` — 3/3 pass, including the original PR #770 regression case (real window, anchor near real viewport top).
- [x] `pnpm exec vitest run --environment jsdom agentGuiNode/` — 1058/1058 pass.
- [x] `pnpm run typecheck` (agent-gui package) — clean.
- [x] `check:full` pre-push hook — passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Floating composer menus now stay within the visible area of workspace windows, respecting window headers and safe margins.
  * Menu height is now constrained more accurately, preventing it from overlapping protected top areas or jumping above the header.
  * The menu now behaves consistently between windowed and full-viewport layouts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->