### PR TITLE
fix(app-factory): don't clear live-turn marker on nil TurnLifecycle

### DIFF
--- a/services/tuttid/service/workspace/app_factory_agent_state.go
+++ b/services/tuttid/service/workspace/app_factory_agent_state.go
@@ -183,6 +183,28 @@ func (s *AppFactoryService) trackAgentSessionTurnLifecycle(workspaceID string, a
 	if s == nil {
 		return
 	}
+	if lifecycle == nil {
+		// No TurnLifecycle snapshot accompanied this state report at all.
+		// This is not the same thing as "the turn just settled": plenty of
+		// legitimate session-level state reports carry no turn info
+		// whatsoever, e.g. CodexAppServerAdapter.refreshStartupMetadataAsync
+		// (packages/agent/daemon/runtime/codex_appserver_adapter.go), a
+		// background goroutine that periodically refreshes rate
+		// limits/model list/goal info and emits a plain EventSessionUpdated
+		// with no TurnID on every retry. statePatchFromSessionEvent
+		// (packages/agent/daemon/runtime/reporter.go) only populates
+		// TurnLifecycle when the event carries a TurnID, so such updates
+		// always arrive here with lifecycle == nil, including mid-turn.
+		// Treating that as "clear the live marker" reintroduced the exact
+		// premature-completion bug this guard was built to close (see the
+		// package doc above trackAgentSessionTurnLifecycle): the marker set
+		// by the turn-started update got wiped by the very next unrelated
+		// session-level update, before the turn actually finished. Do
+		// nothing here and leave whatever live/settled state we already
+		// have untouched until an update that actually carries a
+		// TurnLifecycle snapshot says otherwise.
+		return
+	}
 	key := agentSessionTurnTrackerKey(workspaceID, agentSessionID)
 	if agentSessionTurnLifecycleIsLive(lifecycle) {
 		s.liveTurnAgentSessions.Store(key, struct{}{})

--- a/services/tuttid/service/workspace/app_factory_test.go
+++ b/services/tuttid/service/workspace/app_factory_test.go
@@ -2244,3 +2244,151 @@ func TestAppFactoryServiceIgnoresCompletedTextMidLiveTurn(t *testing.T) {
 		t.Fatalf("status = %q, want failed once the turn genuinely settles (validation runs and fails against the still-empty draft)", job.Status)
 	}
 }
+
+// TestAppFactoryServiceKeepsLiveTurnMarkerAcrossNilLifecycleUpdate
+// reproduces the follow-up bug PR #782 itself introduced (confirmed live in
+// diagnostic bundle tutti-logs-20260706-115814.zip against jobs for
+// "答案之书" and "天气查询", including at least one incident timestamped
+// after #782 had already merged): trackAgentSessionTurnLifecycle wrote
+// s.liveTurnAgentSessions.Delete(key) unconditionally whenever
+// agentSessionTurnLifecycleIsLive(lifecycle) was false, including when
+// lifecycle itself was nil. But a nil TurnLifecycle does not mean "the turn
+// settled" -- it means this particular state report simply carries no turn
+// info, which is exactly what
+// CodexAppServerAdapter.refreshStartupMetadataAsync's background rate-limit/
+// model-list refresh reports
+// (packages/agent/daemon/runtime/codex_appserver_adapter.go:1083-1148,
+// emitStartupMetadataRefreshEvent -> EventSessionUpdated with no TurnID ->
+// statePatchFromSessionEvent leaves TurnLifecycle nil,
+// packages/agent/daemon/runtime/reporter.go:751-772). That background
+// goroutine runs on every app-factory session and fires repeatedly (1s, 2s,
+// 5s, 10s... backoff), so it reliably raced the genuine live-turn marker set
+// moments earlier by the turn-started state update, wiping it mid-turn and
+// letting the message-triggered fast path (handleAgentSessionCompletedMessage)
+// trust the persisted session's racy "completed" status again -- the same
+// premature-completion failure mode #782 was supposed to have closed for
+// good.
+func TestAppFactoryServiceKeepsLiveTurnMarkerAcrossNilLifecycleUpdate(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	store := newAppFactoryStoreStub()
+	draftDir := t.TempDir()
+	if err := store.PutAppFactoryJob(ctx, workspacebiz.AppFactoryJob{
+		AgentSessionID: "session-1",
+		AppID:          "app_1",
+		DraftDir:       draftDir,
+		JobID:          "job-1",
+		Status:         workspacebiz.AppFactoryJobStatusGenerating,
+		WorkspaceID:    "ws-1",
+	}); err != nil {
+		t.Fatalf("PutAppFactoryJob() error = %v", err)
+	}
+	publisher := &workspaceAppFactoryPublisherStub{}
+	service := AppFactoryService{
+		Store:     store,
+		AppStore:  newAppStoreStub(),
+		Publisher: publisher,
+		AgentSessionReader: factoryAgentSessionReaderStub{
+			sessions: map[string]agentservice.PersistedSession{
+				appFactoryJobStoreKey("ws-1", "session-1"): {
+					ID:          "session-1",
+					WorkspaceID: "ws-1",
+					Status:      "completed",
+				},
+			},
+		},
+		AgentMessageReader: factoryAgentMessageReaderStub{},
+	}
+
+	activeTurnID := "596f2132-32e5-4bfb-8e13-e4a60063ac5a"
+
+	// The turn genuinely starts: TurnLifecycle reports it live.
+	service.ObserveAgentSessionState(ctx, agentsessionstore.ReportSessionStateInput{
+		WorkspaceID:    "ws-1",
+		AgentSessionID: "session-1",
+		State: agentsessionstore.WorkspaceAgentSessionStateUpdate{
+			LifecycleStatus: "active",
+			CurrentPhase:    "working",
+			TurnLifecycle: &agentsessionstore.WorkspaceAgentTurnLifecycle{
+				ActiveTurnID: &activeTurnID,
+				Phase:        "running",
+			},
+		},
+	}, agentsessionstore.ReportSessionStateReply{Accepted: true, StateApplied: true})
+
+	if !service.agentSessionHasLiveTurn("ws-1", "session-1") {
+		t.Fatalf("agentSessionHasLiveTurn() = false immediately after a live TurnLifecycle update, want true")
+	}
+
+	// A session-level state report arrives mid-turn that carries no turn
+	// info at all -- e.g. the startup-metadata-refresh background goroutine
+	// reporting an updated rate-limit snapshot. This must be a no-op for the
+	// live-turn marker, not an implicit "the turn settled."
+	service.ObserveAgentSessionState(ctx, agentsessionstore.ReportSessionStateInput{
+		WorkspaceID:    "ws-1",
+		AgentSessionID: "session-1",
+		State: agentsessionstore.WorkspaceAgentSessionStateUpdate{
+			LifecycleStatus: "active",
+			CurrentPhase:    "working",
+			TurnLifecycle:   nil,
+		},
+	}, agentsessionstore.ReportSessionStateReply{Accepted: true, StateApplied: true})
+
+	if !service.agentSessionHasLiveTurn("ws-1", "session-1") {
+		t.Fatalf("agentSessionHasLiveTurn() = false after a nil-TurnLifecycle session update mid-turn, want true (nil lifecycle must be a no-op, not an implicit clear)")
+	}
+
+	// The agent's ordinary opening narration completes mid-turn, just like
+	// TestAppFactoryServiceIgnoresCompletedTextMidLiveTurn. With the live
+	// marker intact, this must still be ignored.
+	if err := service.handleAgentSessionCompletedMessage(ctx, "ws-1", "session-1"); err != nil {
+		t.Fatalf("handleAgentSessionCompletedMessage() error = %v", err)
+	}
+
+	job, err := store.GetAppFactoryJob(ctx, "ws-1", "job-1")
+	if err != nil {
+		t.Fatalf("GetAppFactoryJob() error = %v", err)
+	}
+	if job.Status != workspacebiz.AppFactoryJobStatusGenerating {
+		t.Fatalf("status = %q, want generating (a nil-TurnLifecycle update must not wipe the live-turn marker and let stale completed text fail the job mid-turn)", job.Status)
+	}
+	if strings.TrimSpace(job.FailureReason) != "" {
+		t.Fatalf("failure reason = %q, want empty", job.FailureReason)
+	}
+	if len(publisher.published) != 0 {
+		t.Fatalf("published updates = %d, want 0", len(publisher.published))
+	}
+
+	// Once the turn genuinely settles (a present TurnLifecycle reports a
+	// real outcome), the marker must clear and the completed-session-status
+	// signal must be trusted again.
+	service.ObserveAgentSessionState(ctx, agentsessionstore.ReportSessionStateInput{
+		WorkspaceID:    "ws-1",
+		AgentSessionID: "session-1",
+		State: agentsessionstore.WorkspaceAgentSessionStateUpdate{
+			LifecycleStatus: "active",
+			CurrentPhase:    "idle",
+			TurnLifecycle: &agentsessionstore.WorkspaceAgentTurnLifecycle{
+				ActiveTurnID: &activeTurnID,
+				Phase:        "settled",
+				Outcome:      stringPtr("completed"),
+			},
+		},
+	}, agentsessionstore.ReportSessionStateReply{Accepted: true, StateApplied: true})
+
+	if service.agentSessionHasLiveTurn("ws-1", "session-1") {
+		t.Fatalf("agentSessionHasLiveTurn() = true after a settled TurnLifecycle update, want false")
+	}
+
+	if err := service.handleAgentSessionCompletedMessage(ctx, "ws-1", "session-1"); err != nil {
+		t.Fatalf("handleAgentSessionCompletedMessage() error = %v", err)
+	}
+	job, err = store.GetAppFactoryJob(ctx, "ws-1", "job-1")
+	if err != nil {
+		t.Fatalf("GetAppFactoryJob() error = %v", err)
+	}
+	if job.Status != workspacebiz.AppFactoryJobStatusFailed {
+		t.Fatalf("status = %q, want failed once the turn genuinely settles (validation runs and fails against the still-empty draft)", job.Status)
+	}
+}


### PR DESCRIPTION
## Summary

Follow-up fix to #782 ("fix(app-factory): stop trusting session status for completion mid-turn"), which itself was a follow-up to #774. Despite #782, App Factory jobs ("答案之书", "天气查询") were still being marked 失败 (failed) while the underlying agent session was genuinely still working — confirmed via 3 separate incidents in a diagnostic log bundle, at least one of which occurred after #782 was merged.

**Root cause**: `trackAgentSessionTurnLifecycle` in `services/tuttid/service/workspace/app_factory_agent_state.go` (added by #782 to track "is this session's turn still genuinely live") was the sole writer of the `liveTurnAgentSessions` guard map, and it deleted the marker unconditionally whenever `agentSessionTurnLifecycleIsLive(lifecycle)` returned false — including when `lifecycle` itself was `nil`.

A `nil` `TurnLifecycle` does not mean "the turn settled." It means this particular session state report carries no turn info at all. `CodexAppServerAdapter.refreshStartupMetadataAsync` (`packages/agent/daemon/runtime/codex_appserver_adapter.go:1083-1148`) is a background goroutine started at session begin that periodically refreshes rate limits/model list/goal info with retry backoff (1s, 2s, 5s, 10s...). Each success calls `emitStartupMetadataRefreshEvent`, emitting a session-level `EventSessionUpdated` with no turn ID. `statePatchFromSessionEvent` (`packages/agent/daemon/runtime/reporter.go:751-772`) only attaches turn/lifecycle info when `event.Payload.TurnID` is non-empty, so this event's resulting state patch always has `TurnLifecycle == nil` — reliably racing and wiping the live-turn marker the genuine turn-started event had just set, moments earlier, mid-turn.

**Fix**: in `trackAgentSessionTurnLifecycle`, a `nil` lifecycle is now a no-op — it leaves the `liveTurnAgentSessions` marker untouched. The marker is only cleared when a `TurnLifecycle` snapshot is present and `agentSessionTurnLifecycleIsLive` reports it as settled (the case #782 built this guard for, unchanged).

## Test plan

- [x] Added `TestAppFactoryServiceKeepsLiveTurnMarkerAcrossNilLifecycleUpdate`, which reproduces the exact bug: a genuine turn-started `TurnLifecycle` update marks the session live, then a `nil`-lifecycle session-level update arrives mid-turn (modeling the startup-metadata-refresh event), then confirms the session is still considered live and the message-triggered fast path does not prematurely fail the job. Verified this test fails without the fix and passes with it.
- [x] Confirmed the existing `TestAppFactoryServiceIgnoresCompletedTextMidLiveTurn` (the genuine "turn really settled" regression test from #782) still passes unchanged.
- [x] `go build ./...` and `go vet ./...` clean for `services/tuttid`.
- [x] `go test ./service/workspace/... -run AppFactory -v` — all pass.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Preserves the current live-turn status when a session update arrives without lifecycle details, preventing the marker from being cleared too early.
  * Ensures turn-completion handling behaves correctly across mid-turn updates, avoiding premature job failure or state changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->