### PR TITLE
fix(codex): expose imported session's rollout file so thread/resume actually restores history

### DIFF
--- a/services/tuttid/service/agent/composer_settings_payload.go
+++ b/services/tuttid/service/agent/composer_settings_payload.go
@@ -125,5 +125,8 @@ func createSessionInputFromPersisted(session PersistedSession) CreateSessionInpu
 		input.Speed = &normalizedSpeed
 	}
 	input.ConversationDetailMode = preferencesbiz.NormalizeDesktopAgentConversationDetailMode(settings.ConversationDetailMode)
+	if sourcePath, ok := session.RuntimeContext["externalSourcePath"].(string); ok {
+		input.ExternalRolloutSourcePath = strings.TrimSpace(sourcePath)
+	}
 	return input
 }

--- a/services/tuttid/service/agent/composer_settings_payload_test.go
+++ b/services/tuttid/service/agent/composer_settings_payload_test.go
@@ -78,3 +78,27 @@ func TestCreateSessionInputFromPersistedPreservesBrowserUse(t *testing.T) {
 		t.Fatalf("Model = %#v, want gpt-5", input.Model)
 	}
 }
+
+func TestCreateSessionInputFromPersistedCarriesExternalRolloutSourcePath(t *testing.T) {
+	input := createSessionInputFromPersisted(PersistedSession{
+		ID:       "session-1",
+		Provider: "codex",
+		RuntimeContext: map[string]any{
+			"imported":           true,
+			"externalSourcePath": "/home/user/.codex/sessions/2026/07/04/rollout-abc.jsonl",
+		},
+	})
+	if input.ExternalRolloutSourcePath != "/home/user/.codex/sessions/2026/07/04/rollout-abc.jsonl" {
+		t.Fatalf("ExternalRolloutSourcePath = %q, want imported source path preserved", input.ExternalRolloutSourcePath)
+	}
+}
+
+func TestCreateSessionInputFromPersistedLeavesExternalRolloutSourcePathEmptyForNonImportedSession(t *testing.T) {
+	input := createSessionInputFromPersisted(PersistedSession{
+		ID:       "session-1",
+		Provider: "codex",
+	})
+	if input.ExternalRolloutSourcePath != "" {
+		t.Fatalf("ExternalRolloutSourcePath = %q, want empty for a session with no RuntimeContext", input.ExternalRolloutSourcePath)
+	}
+}

--- a/services/tuttid/service/agent/service.go
+++ b/services/tuttid/service/agent/service.go
@@ -322,9 +322,10 @@ func (s *Service) prepareRuntime(ctx context.Context, workspaceID string, cwd st
 			provider,
 			value(input.ReasoningEffort),
 		),
-		ConversationDetailMode: input.ConversationDetailMode,
-		ExtraSkills:            sessionSkillBundlesToProviderSkillBundles(input.ExtraSkills),
-		Metadata:               input.Metadata,
+		ConversationDetailMode:    input.ConversationDetailMode,
+		ExtraSkills:               sessionSkillBundlesToProviderSkillBundles(input.ExtraSkills),
+		Metadata:                  input.Metadata,
+		ExternalRolloutSourcePath: input.ExternalRolloutSourcePath,
 	})
 	if err != nil {
 		return preparedRuntime{}, err

--- a/services/tuttid/service/agent/session_types.go
+++ b/services/tuttid/service/agent/session_types.go
@@ -411,6 +411,12 @@ type CreateSessionInput struct {
 	ConversationDetailMode string
 	Visible                *bool
 	ExtraSkills            []SessionSkillBundle
+	// ExternalRolloutSourcePath is the absolute path to the original provider
+	// CLI rollout/transcript file this session was imported from, when known.
+	// Populated from the persisted session's RuntimeContext when resuming an
+	// imported conversation (see createSessionInputFromPersisted); empty for
+	// brand-new sessions.
+	ExternalRolloutSourcePath string
 }
 
 type SessionSkillBundle struct {

--- a/services/tuttid/service/agentsidecar/codex.go
+++ b/services/tuttid/service/agentsidecar/codex.go
@@ -60,6 +60,11 @@ func prepareCodexHome(codexHome string, input PrepareInput) error {
 		return err
 	}
 	logRuntimePrepareTrace("runtime_prepare.codex.user_files_resolved", input, nil)
+	logRuntimePrepareTrace("runtime_prepare.codex.imported_rollout_requested", input, nil)
+	if err := exposeCodexImportedRolloutFile(codexHome, input.ExternalRolloutSourcePath); err != nil {
+		return err
+	}
+	logRuntimePrepareTrace("runtime_prepare.codex.imported_rollout_resolved", input, nil)
 	logRuntimePrepareTrace("runtime_prepare.codex.session_config_requested", input, nil)
 	if err := ensureCodexSessionConfig(filepath.Join(codexHome, "config.toml"), input); err != nil {
 		return err
@@ -128,6 +133,58 @@ func exposeUserCodexFiles(codexHome string) error {
 		return err
 	}
 	return exposeUserCodexConfig(codexHome, userCodexHome)
+}
+
+// exposeCodexImportedRolloutFile symlinks the single Codex CLI rollout
+// (conversation transcript) file that an imported session was read from into
+// the sandboxed CODEX_HOME, at the same path it has relative to the real
+// `~/.codex` tree (e.g. `sessions/2026/07/04/rollout-...jsonl` or
+// `archived_sessions/...`). Codex CLI resolves rollouts for `thread/resume`
+// relative to CODEX_HOME, so mirroring the real relative layout lets it find
+// the transcript by thread id without needing this code to know or guess
+// Codex's internal sharding/naming scheme, and without exposing any other
+// unrelated conversation under ~/.codex/sessions into a sandbox scoped to
+// this one session/run.
+//
+// sourcePath is empty for every non-imported session, so this is a no-op for
+// the overwhelming majority of sessions. When it is set but the file can't be
+// resolved or no longer exists (moved, pruned by the user's own Codex CLI
+// retention, or a custom CODEX_HOME was in effect on another device at import
+// time), this intentionally returns nil rather than an error: resume still
+// falls back to the existing documented "recreatable" path (a fresh thread
+// with a visible notice) exactly as it did before this file existed.
+func exposeCodexImportedRolloutFile(codexHome string, sourcePath string) error {
+	sourcePath = strings.TrimSpace(sourcePath)
+	if sourcePath == "" {
+		return nil
+	}
+	userHome, err := os.UserHomeDir()
+	if err != nil || strings.TrimSpace(userHome) == "" {
+		return nil
+	}
+	userCodexHome := filepath.Join(userHome, ".codex")
+	rel, err := filepath.Rel(userCodexHome, sourcePath)
+	if err != nil || rel == ".." || rel == "." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+		// Not under the real ~/.codex tree we know how to mirror - leave it to
+		// the recreate fallback rather than guessing at a different layout.
+		return nil
+	}
+	if info, err := os.Stat(sourcePath); err != nil || info.IsDir() {
+		// Original rollout is gone or was never a real file - fall back to
+		// recreate, same as before this fix.
+		return nil
+	}
+	target := filepath.Join(codexHome, rel)
+	if _, err := os.Lstat(target); err == nil {
+		return nil
+	}
+	if err := os.MkdirAll(filepath.Dir(target), 0o700); err != nil {
+		return fmt.Errorf("create codex imported rollout parent dir: %w", err)
+	}
+	if err := os.Symlink(sourcePath, target); err != nil {
+		return fmt.Errorf("expose codex imported rollout file: %w", err)
+	}
+	return nil
 }
 
 func exposeUserCodexPluginState(codexHome string, userCodexHome string) error {

--- a/services/tuttid/service/agentsidecar/preparer_test.go
+++ b/services/tuttid/service/agentsidecar/preparer_test.go
@@ -1207,6 +1207,142 @@ func TestCodexPreparerSkipsUserBrowserSkillWhenBrowserUseEnabled(t *testing.T) {
 	}
 }
 
+func TestExposeCodexImportedRolloutFileSymlinksMatchingRelativePath(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	rel := filepath.Join("sessions", "2026", "07", "04", "rollout-abc.jsonl")
+	sourcePath := filepath.Join(home, ".codex", rel)
+	writeSidecarTestFile(t, sourcePath, `{"type":"session_meta"}`)
+
+	codexHome := t.TempDir()
+	if err := exposeCodexImportedRolloutFile(codexHome, sourcePath); err != nil {
+		t.Fatalf("exposeCodexImportedRolloutFile() error = %v", err)
+	}
+
+	target := filepath.Join(codexHome, rel)
+	info, err := os.Lstat(target)
+	if err != nil {
+		t.Fatalf("imported rollout file not exposed: %v", err)
+	}
+	if info.Mode()&os.ModeSymlink == 0 {
+		t.Fatalf("imported rollout file mode = %v, want symlink", info.Mode())
+	}
+	linkTarget, err := os.Readlink(target)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if linkTarget != sourcePath {
+		t.Fatalf("symlink target = %q, want %q", linkTarget, sourcePath)
+	}
+}
+
+func TestExposeCodexImportedRolloutFileNoopWhenSourcePathEmpty(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	codexHome := t.TempDir()
+	if err := exposeCodexImportedRolloutFile(codexHome, ""); err != nil {
+		t.Fatalf("exposeCodexImportedRolloutFile() error = %v", err)
+	}
+	entries, err := os.ReadDir(codexHome)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(entries) != 0 {
+		t.Fatalf("codexHome entries = %#v, want none created for empty source path", entries)
+	}
+}
+
+func TestExposeCodexImportedRolloutFileGracefulWhenSourceFileMissing(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	sourcePath := filepath.Join(home, ".codex", "sessions", "2026", "07", "04", "rollout-gone.jsonl")
+
+	codexHome := t.TempDir()
+	if err := exposeCodexImportedRolloutFile(codexHome, sourcePath); err != nil {
+		t.Fatalf("exposeCodexImportedRolloutFile() error = %v, want graceful nil when source is gone", err)
+	}
+	if _, err := os.Lstat(filepath.Join(codexHome, "sessions", "2026", "07", "04", "rollout-gone.jsonl")); !os.IsNotExist(err) {
+		t.Fatalf("expected no symlink for a missing source rollout, err = %v", err)
+	}
+}
+
+func TestExposeCodexImportedRolloutFileGracefulWhenSourceOutsideRealCodexHome(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	outsidePath := filepath.Join(t.TempDir(), "rollout.jsonl")
+	writeSidecarTestFile(t, outsidePath, `{"type":"session_meta"}`)
+
+	codexHome := t.TempDir()
+	if err := exposeCodexImportedRolloutFile(codexHome, outsidePath); err != nil {
+		t.Fatalf("exposeCodexImportedRolloutFile() error = %v, want graceful nil for a path outside ~/.codex", err)
+	}
+	entries, err := os.ReadDir(codexHome)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(entries) != 0 {
+		t.Fatalf("codexHome entries = %#v, want none created for a source path outside ~/.codex", entries)
+	}
+}
+
+func TestDefaultPreparerCodexExposesImportedRolloutFileFromPrepareInput(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	rel := filepath.Join("sessions", "2026", "07", "04", "rollout-abc.jsonl")
+	sourcePath := filepath.Join(home, ".codex", rel)
+	writeSidecarTestFile(t, sourcePath, `{"type":"session_meta"}`)
+
+	stateDir := t.TempDir()
+	cwd := t.TempDir()
+	prepared, err := NewDefaultPreparer(stateDir).Prepare(t.Context(), PrepareInput{
+		WorkspaceID:               "workspace-1",
+		AgentSessionID:            "session-1",
+		AgentTargetID:             "local:codex",
+		Provider:                  "codex",
+		Cwd:                       cwd,
+		ExternalRolloutSourcePath: sourcePath,
+	})
+	if err != nil {
+		t.Fatalf("Prepare() error = %v", err)
+	}
+	codexHome := envValue(prepared.Env, "CODEX_HOME")
+	if codexHome == "" {
+		t.Fatalf("prepared env = %#v, want CODEX_HOME", prepared.Env)
+	}
+	target := filepath.Join(codexHome, rel)
+	info, err := os.Lstat(target)
+	if err != nil {
+		t.Fatalf("imported rollout file not exposed via Prepare(): %v", err)
+	}
+	if info.Mode()&os.ModeSymlink == 0 {
+		t.Fatalf("imported rollout file mode = %v, want symlink", info.Mode())
+	}
+}
+
+func TestDefaultPreparerCodexSkipsRolloutExposureForNonImportedSession(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	stateDir := t.TempDir()
+	cwd := t.TempDir()
+	prepared, err := NewDefaultPreparer(stateDir).Prepare(t.Context(), PrepareInput{
+		WorkspaceID:    "workspace-1",
+		AgentSessionID: "session-1",
+		AgentTargetID:  "local:codex",
+		Provider:       "codex",
+		Cwd:            cwd,
+	})
+	if err != nil {
+		t.Fatalf("Prepare() error = %v", err)
+	}
+	codexHome := envValue(prepared.Env, "CODEX_HOME")
+	if codexHome == "" {
+		t.Fatalf("prepared env = %#v, want CODEX_HOME", prepared.Env)
+	}
+	if _, err := os.Stat(filepath.Join(codexHome, "sessions")); !os.IsNotExist(err) {
+		t.Fatalf("non-imported session should not create a sessions dir, err = %v", err)
+	}
+}
+
 func envValue(env []string, key string) string {
 	prefix := key + "="
 	for _, item := range env {

--- a/services/tuttid/service/agentsidecar/types.go
+++ b/services/tuttid/service/agentsidecar/types.go
@@ -34,6 +34,15 @@ type PrepareInput struct {
 	ConversationDetailMode string
 	ExtraSkills            []ProviderSkillBundle
 	Metadata               map[string]any
+	// ExternalRolloutSourcePath is the absolute path to the original provider
+	// CLI rollout/transcript file this session was imported from (Codex CLI's
+	// own on-disk conversation transcript under the user's real
+	// `~/.codex/sessions/...`), when known. It lets a provider preparer expose
+	// that one specific file into the sandboxed provider home so a native
+	// `thread/resume` can find it, without exposing any other unrelated
+	// conversation. Empty for non-imported sessions or when the source path
+	// wasn't captured at import time.
+	ExternalRolloutSourcePath string
 }
 
 type PreparedRuntime struct {


### PR DESCRIPTION
## Problem

Every conversation imported from native Codex CLI failed real `thread/resume` on its first continuation message: `exposeUserCodexFiles` never symlinked the Codex CLI rollout transcript into the sandboxed `CODEX_HOME`, so the app-server always returned `-32600 "no rollout found for thread id ..."`, and the existing recreatable fallback silently started a fresh, memory-less thread instead. PR #773 already added a visible notice for this path, but did not fix the underlying inability to resume with real memory.

Confirmed via investigation this session: this is systemic, not intermittent — every Codex CLI import hits this on its very first continuation message, 100% of the time. Claude Code CLI imports are unaffected (different sandbox design, never isolates the home directory).

## Fix

The import scanner already captures the exact source rollout path at import time (`external_import_parse.go`'s `SourcePath`, persisted into `RuntimeContext["externalSourcePath"]`). This threads that captured path through resume's existing per-attempt prep step instead of re-deriving it from a naming convention:

```
PersistedSession.RuntimeContext["externalSourcePath"]
  -> createSessionInputFromPersisted (composer_settings_payload.go)
  -> CreateSessionInput.ExternalRolloutSourcePath (session_types.go)
  -> agentsidecarservice.PrepareInput.ExternalRolloutSourcePath (service.go, types.go)
  -> CodexPreparer.Prepare -> exposeCodexImportedRolloutFile (codex.go)
```

`exposeCodexImportedRolloutFile` symlinks only that one rollout file into `CODEX_HOME`, at the same relative path it has under the real `~/.codex` tree — so Codex CLI's own `thread/resume` lookup finds it without this code needing to know Codex's internal sharding scheme, and without exposing any other unrelated conversation's history into a sandbox scoped to one session/run.

When the source path is empty (non-imported sessions), unresolvable, or the file no longer exists (pruned by the user's own Codex CLI retention), this is a no-op — resume falls back to the existing documented recreate-with-notice path unchanged.

## Test plan
- [x] `go build ./...` (services/tuttid)
- [x] `go test ./service/agent/... ./service/agentsidecar/...` — all pass, including new tests in `composer_settings_payload_test.go` and `preparer_test.go`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>