### PR TITLE
fix(agent-gui): backport activity reconciliation state fix

### DIFF
--- a/apps/desktop/src/renderer/src/features/workspace-agent/services/createDesktopAgentGUIWorkbenchHostInput.test.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-agent/services/createDesktopAgentGUIWorkbenchHostInput.test.ts
@@ -213,7 +213,7 @@ test("desktop agent GUI host input drains queued prompts without mounted agent G
   );
 });
 
-test("desktop agent GUI queued prompt drainer ignores stale blocked submit availability when session is idle", async () => {
+test("desktop agent GUI queued prompt drainer waits for blocked submit availability to clear", async () => {
   const calls: string[] = [];
   const sendInputs: unknown[] = [];
   const activityService = {
@@ -225,7 +225,7 @@ test("desktop agent GUI queued prompt drainer ignores stale blocked submit avail
             currentPhase: "idle",
             status: "active",
             submitAvailability: { state: "blocked", reason: "active_turn" },
-            turnLifecycle: { activeTurnId: "stale-turn-1", phase: "idle" },
+            turnLifecycle: { activeTurnId: "lingering-turn-1", phase: "idle" },
             updatedAtUnixMs: 2
           })
         ]),
@@ -265,18 +265,19 @@ test("desktop agent GUI queued prompt drainer ignores stale blocked submit avail
     }
   });
 
-  await waitForQueuedPromptDrainer(() => sendInputs.length === 1);
-  assert.deepEqual(sendInputs, [
-    {
+  await flushQueuedPromptDrainer();
+  await flushQueuedPromptDrainer();
+  assert.deepEqual(sendInputs, []);
+  assert.equal(
+    hostInput.agentQueuedPromptRuntime.getSessionSnapshot({
       workspaceId,
-      agentSessionId: "session-1",
-      content: [{ type: "text", text: "queued after idle state patch" }],
-      displayPrompt: null
-    }
-  ]);
+      agentSessionId: "session-1"
+    }).prompts.length,
+    1
+  );
 });
 
-test("desktop agent GUI queued prompt drainer ignores stale active turn id when turn lifecycle is settled", async () => {
+test("desktop agent GUI queued prompt drainer waits for active turn id to clear", async () => {
   const calls: string[] = [];
   const sendInputs: unknown[] = [];
   const activityService = {
@@ -288,7 +289,10 @@ test("desktop agent GUI queued prompt drainer ignores stale active turn id when 
             currentPhase: "idle",
             status: "active",
             submitAvailability: { state: "blocked", reason: "active_turn" },
-            turnLifecycle: { activeTurnId: "stale-turn-1", phase: "settled" },
+            turnLifecycle: {
+              activeTurnId: "lingering-turn-1",
+              phase: "settled"
+            },
             updatedAtUnixMs: 2
           })
         ]),
@@ -328,15 +332,16 @@ test("desktop agent GUI queued prompt drainer ignores stale active turn id when 
     }
   });
 
-  await waitForQueuedPromptDrainer(() => sendInputs.length === 1);
-  assert.deepEqual(sendInputs, [
-    {
+  await flushQueuedPromptDrainer();
+  await flushQueuedPromptDrainer();
+  assert.deepEqual(sendInputs, []);
+  assert.equal(
+    hostInput.agentQueuedPromptRuntime.getSessionSnapshot({
       workspaceId,
-      agentSessionId: "session-1",
-      content: [{ type: "text", text: "queued after settled turn" }],
-      displayPrompt: null
-    }
-  ]);
+      agentSessionId: "session-1"
+    }).prompts.length,
+    1
+  );
 });
 
 test("desktop agent GUI queued prompt drainer waits when submit availability is blocked for non-active-turn reasons", async () => {

--- a/apps/desktop/src/renderer/src/features/workspace-agent/services/internal/createDesktopAgentQueuedPromptDrainCoordinator.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-agent/services/internal/createDesktopAgentQueuedPromptDrainCoordinator.ts
@@ -428,44 +428,49 @@ function sessionCanReceiveInput(session: AgentActivitySession): boolean {
   if (!submitState || submitState === "available") {
     return true;
   }
-  if (submitState !== "blocked") {
-    return false;
-  }
-  return (
-    normalizeActivityToken(session.submitAvailability?.reason) === "active_turn"
-  );
+  return false;
 }
 
 function sessionLooksBusy(session: AgentActivitySession): boolean {
-  const status = normalizeActivityToken(session.status);
-  const turnPhase = normalizeActivityToken(session.turnLifecycle?.phase);
-  const currentPhase = normalizeActivityToken(session.currentPhase);
-  const hasActiveTurnWithoutSettledPhase =
-    Boolean(session.turnLifecycle?.activeTurnId) &&
-    !(
-      turnPhase === "idle" ||
-      turnPhase === "completed" ||
-      turnPhase === "canceled" ||
-      turnPhase === "failed" ||
-      turnPhase === "settled"
+  // The turn lifecycle is the source of truth (ADR 0008): a present
+  // lifecycle decides entirely; the status/currentPhase token lists apply
+  // only to records without a lifecycle (non-migrated providers).
+  const lifecycle = session.turnLifecycle;
+  if (lifecycle?.phase) {
+    return (
+      Boolean(lifecycle.activeTurnId) ||
+      isLiveTurnLifecyclePhase(lifecycle.phase)
     );
+  }
+  const status = normalizeActivityToken(session.status);
+  const currentPhase = normalizeActivityToken(session.currentPhase);
   return (
     status === "queued" ||
     status === "working" ||
     status === "running" ||
     status === "waiting" ||
-    turnPhase === "queued" ||
-    turnPhase === "submitted" ||
-    turnPhase === "running" ||
-    turnPhase === "working" ||
-    turnPhase === "waiting" ||
     currentPhase === "queued" ||
     currentPhase === "submitted" ||
     currentPhase === "running" ||
     currentPhase === "working" ||
-    currentPhase === "waiting" ||
-    hasActiveTurnWithoutSettledPhase
+    currentPhase === "waiting"
   );
+}
+
+function isLiveTurnLifecyclePhase(phase: unknown): boolean {
+  switch (normalizeActivityToken(phase)) {
+    case "submitted":
+    case "running":
+    case "waiting_approval":
+    case "waiting_input":
+    case "working":
+    case "streaming":
+    case "waiting":
+    case "awaiting_approval":
+      return true;
+    default:
+      return false;
+  }
 }
 
 function sessionActivityVersion(

--- a/apps/desktop/src/renderer/src/features/workspace-agent/services/internal/workspaceAgentActivityService.test.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-agent/services/internal/workspaceAgentActivityService.test.ts
@@ -262,6 +262,104 @@ test("WorkspaceAgentActivityService.importExternalSessions refreshes sessions an
   assert.equal(projectRefreshCalls, 1);
 });
 
+test("WorkspaceAgentActivityService fetches combined reconcile state after messages", async () => {
+  const diagnostics: unknown[] = [];
+  const calls: string[] = [];
+  let messagesResolved = false;
+  const staleSession = workspaceAgentSession({
+    status: "running",
+    updatedAt: "2026-07-06T03:48:10.600Z",
+    turnLifecycle: {
+      activeTurnId: "turn-1",
+      phase: "running"
+    },
+    submitAvailability: { state: "blocked", reason: "active_turn" }
+  });
+  const finalSession = workspaceAgentSession({
+    status: "ready",
+    updatedAt: "2026-07-06T03:48:30.878Z",
+    currentPhase: "idle",
+    turnLifecycle: {
+      activeTurnId: null,
+      outcome: "completed",
+      phase: "settled"
+    },
+    submitAvailability: { state: "available" }
+  });
+  const service = new WorkspaceAgentActivityService({
+    tuttidClient: {
+      getWorkspaceAgentSession: async () => {
+        calls.push("getSession");
+        return messagesResolved ? finalSession : staleSession;
+      },
+      listWorkspaceAgentSessions: async () => ({
+        hasMore: false,
+        sessions: [staleSession],
+        workspaceId: "ws-1"
+      }),
+      listWorkspaceAgentSessionMessages: async () => {
+        calls.push("listMessages");
+        messagesResolved = true;
+        return {
+          hasMore: false,
+          latestVersion: 2,
+          messages: []
+        };
+      }
+    } as unknown as TuttidClient,
+    runtimeApi: {
+      logTerminalDiagnostic: async (payload) => {
+        diagnostics.push(payload);
+      }
+    }
+  });
+
+  await service.load("ws-1");
+  await (
+    service as unknown as {
+      reconcileAgentActivityUpdate(input: {
+        agentSessionId: string;
+        eventType: string;
+        workspaceId: string;
+      }): Promise<void>;
+    }
+  ).reconcileAgentActivityUpdate({
+    agentSessionId: "session-1",
+    eventType: "message_update",
+    workspaceId: "ws-1"
+  });
+
+  const session = service.getSnapshot("ws-1").sessions[0];
+  assert.deepEqual(calls, ["listMessages", "getSession"]);
+  assert.equal(session?.status, "ready");
+  assert.equal(session?.turnLifecycle?.phase, "settled");
+  assert.equal(session?.submitAvailability?.state, "available");
+  assert.deepEqual(
+    diagnostics
+      .filter(
+        (entry): entry is { details: { traceEvent?: string }; event: string } =>
+          typeof entry === "object" &&
+          entry !== null &&
+          (entry as { event?: unknown }).event ===
+            "agent.activity.reconcile.trace"
+      )
+      .map((entry) => entry.details.traceEvent)
+      .filter(
+        (traceEvent) =>
+          typeof traceEvent === "string" &&
+          traceEvent.startsWith("reconcile.combined")
+      ),
+    [
+      "reconcile.combined.messages_requested",
+      "reconcile.combined.messages_resolved",
+      "reconcile.combined.state_fetch.requested",
+      "reconcile.combined.state_fetch.resolved",
+      "reconcile.combined.state_upsert",
+      "reconcile.combined.state_upsert.applied"
+    ]
+  );
+});
+
 test("WorkspaceAgentActivityService.listAgentGeneratedFiles delegates to tuttid workspace aggregate", async () => {
   const calls: unknown[] = [];
   const service = new WorkspaceAgentActivityService({
@@ -437,17 +535,15 @@ test("WorkspaceAgentActivityService treats missing reconcile sessions as tombsto
     workspaceId: "ws-1"
   });
 
-  assert.deepEqual(diagnostics, [
-    {
-      details: {
-        agentSessionId: "ghost-session",
-        error: "workspace agent session not found"
-      },
-      event: "agent.activity.reconcile_session_missing",
-      level: "info",
-      workspaceId: "ws-1"
-    }
-  ]);
+  assert.deepEqual(diagnostics.at(-1), {
+    details: {
+      agentSessionId: "ghost-session",
+      error: "workspace agent session not found"
+    },
+    event: "agent.activity.reconcile_session_missing",
+    level: "info",
+    workspaceId: "ws-1"
+  });
 });
 
 test("WorkspaceAgentActivityService.submitPlanDecision runs planMode-off then sendInput for a codex implement decision", async () => {
@@ -531,10 +627,14 @@ test("WorkspaceAgentActivityService.submitPlanDecision routes a claude exit-plan
 });
 
 function workspaceAgentSession(overrides: {
+  currentPhase?: string;
   provider?: string;
   runtimeContext?: Record<string, unknown>;
   settings?: Record<string, unknown>;
   status: string;
+  submitAvailability?: Record<string, unknown>;
+  turnLifecycle?: Record<string, unknown>;
+  updatedAt?: string;
 }): Record<string, unknown> {
   return {
     id: "session-1",
@@ -546,8 +646,15 @@ function workspaceAgentSession(overrides: {
       ? { runtimeContext: overrides.runtimeContext }
       : {}),
     ...(overrides.settings ? { settings: overrides.settings } : {}),
+    ...(overrides.currentPhase ? { currentPhase: overrides.currentPhase } : {}),
+    ...(overrides.submitAvailability
+      ? { submitAvailability: overrides.submitAvailability }
+      : {}),
+    ...(overrides.turnLifecycle
+      ? { turnLifecycle: overrides.turnLifecycle }
+      : {}),
     visible: true,
     createdAt: "2026-06-16T00:00:00.000Z",
-    updatedAt: "2026-06-16T00:00:00.000Z"
+    updatedAt: overrides.updatedAt ?? "2026-06-16T00:00:00.000Z"
   };
 }

--- a/apps/desktop/src/renderer/src/features/workspace-agent/services/internal/workspaceAgentActivityService.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-agent/services/internal/workspaceAgentActivityService.ts
@@ -7,6 +7,7 @@ import {
   type AgentActivityMessage,
   type AgentActivityMessagePage,
   type AgentActivitySession,
+  type AgentActivityStatePatch,
   type AgentActivitySnapshot
 } from "@tutti-os/agent-activity-core";
 import type { AgentActivityRuntime } from "@tutti-os/agent-gui";
@@ -126,7 +127,30 @@ export class WorkspaceAgentActivityService implements IWorkspaceAgentActivitySer
     workspaceId: string,
     signal?: AbortSignal
   ): Promise<AgentActivitySnapshot> {
-    return this.controllerEntry(workspaceId).controller.load(signal);
+    const normalizedWorkspaceId = normalizeWorkspaceId(workspaceId);
+    const entry = this.controllerEntry(normalizedWorkspaceId);
+    this.reportReconcileTrace({
+      agentSessionId: null,
+      traceEvent: "load.requested",
+      workspaceId: normalizedWorkspaceId,
+      fields: {
+        cachedSessionCount: entry.controller.getSnapshot().sessions.length
+      }
+    });
+    return entry.controller.load(signal).then((snapshot) => {
+      this.reportReconcileTrace({
+        agentSessionId: null,
+        traceEvent: "load.resolved",
+        workspaceId: normalizedWorkspaceId,
+        fields: {
+          newestSession: agentActivitySessionReconcileDiagnosticDetails(
+            snapshot.sessions[0] ?? null
+          ),
+          sessionCount: snapshot.sessions.length
+        }
+      });
+      return snapshot;
+    });
   }
 
   listSessionMessages(
@@ -294,7 +318,7 @@ export class WorkspaceAgentActivityService implements IWorkspaceAgentActivitySer
       workspaceId,
       session
     );
-    this.upsertAuthoritativeSession(activitySession);
+    this.upsertAuthoritativeSession(activitySession, "pin_result");
     return activitySession;
   }
 
@@ -372,7 +396,7 @@ export class WorkspaceAgentActivityService implements IWorkspaceAgentActivitySer
       workspaceId: input.workspaceId,
       fields: { sessionStatus: session.status }
     });
-    this.upsertAuthoritativeSession(session);
+    this.upsertAuthoritativeSession(session, "create_session_result");
     reportAgentSubmitTraceDiagnostic(this.dependencies.runtimeApi, {
       agentSessionId: session.agentSessionId,
       event: "activity_service.create.resolved",
@@ -569,7 +593,7 @@ export class WorkspaceAgentActivityService implements IWorkspaceAgentActivitySer
             optimisticUpdatedAtUnixMs
           )
         : result.session;
-      this.upsertAuthoritativeSession(nextSession);
+      this.upsertAuthoritativeSession(nextSession, "send_input_result");
       return {
         ...result,
         session: nextSession
@@ -579,7 +603,12 @@ export class WorkspaceAgentActivityService implements IWorkspaceAgentActivitySer
         previousSession &&
         !this.isSessionTombstoned(workspaceId, agentSessionId)
       ) {
-        entry.controller.upsertSession(previousSession);
+        this.upsertControllerSession({
+          agentSessionId,
+          session: previousSession,
+          source: "send_input_rollback",
+          workspaceId
+        });
       }
       throw error;
     }
@@ -603,7 +632,7 @@ export class WorkspaceAgentActivityService implements IWorkspaceAgentActivitySer
   ): Promise<AgentActivityCancelSessionResult> {
     const entry = this.controllerEntry(input.workspaceId);
     const result = await entry.adapter.cancelSession(input);
-    this.upsertAuthoritativeSession(result.session);
+    this.upsertAuthoritativeSession(result.session, "cancel_result");
     return result;
   }
 
@@ -678,9 +707,10 @@ export class WorkspaceAgentActivityService implements IWorkspaceAgentActivitySer
   ): Promise<AgentActivitySession> {
     const activitySession = await this.fetchActivitySession(
       workspaceId,
-      agentSessionId
+      agentSessionId,
+      "get_session"
     );
-    this.upsertAuthoritativeSession(activitySession);
+    this.upsertAuthoritativeSession(activitySession, "get_session_result");
     return activitySession;
   }
 
@@ -806,24 +836,115 @@ export class WorkspaceAgentActivityService implements IWorkspaceAgentActivitySer
 
   private async fetchActivitySession(
     workspaceId: string,
-    agentSessionId: string
+    agentSessionId: string,
+    source: string
   ): Promise<AgentActivitySession> {
     const normalizedWorkspaceId = normalizeWorkspaceId(workspaceId);
+    this.reportReconcileTrace({
+      agentSessionId,
+      traceEvent: `${source}.requested`,
+      workspaceId: normalizedWorkspaceId
+    });
     const session =
       await this.dependencies.tuttidClient.getWorkspaceAgentSession(
         normalizedWorkspaceId,
         agentSessionId
       );
-    return agentActivitySessionFromTuttidSession(
+    const activitySession = agentActivitySessionFromTuttidSession(
       normalizedWorkspaceId,
       session
     );
+    this.reportReconcileTrace({
+      agentSessionId,
+      traceEvent: `${source}.resolved`,
+      workspaceId: normalizedWorkspaceId,
+      fields: {
+        incomingSession:
+          agentActivitySessionReconcileDiagnosticDetails(activitySession)
+      }
+    });
+    return activitySession;
   }
 
-  private upsertAuthoritativeSession(session: AgentActivitySession): void {
+  private upsertAuthoritativeSession(
+    session: AgentActivitySession,
+    source: string
+  ): void {
     const workspaceId = normalizeWorkspaceId(session.workspaceId);
     this.clearSessionTombstone(workspaceId, session.agentSessionId);
-    this.controllerEntry(workspaceId).controller.upsertSession(session);
+    this.upsertControllerSession({
+      agentSessionId: session.agentSessionId,
+      session,
+      source,
+      workspaceId
+    });
+  }
+
+  private upsertControllerSession(input: {
+    agentSessionId: string;
+    session: AgentActivitySession;
+    source: string;
+    workspaceId: string;
+  }): void {
+    const entry = this.controllerEntry(input.workspaceId);
+    const beforeSession =
+      entry.controller
+        .getSnapshot()
+        .sessions.find(
+          (session) => session.agentSessionId === input.agentSessionId
+        ) ?? null;
+    this.reportReconcileTrace({
+      agentSessionId: input.agentSessionId,
+      traceEvent: input.source,
+      workspaceId: input.workspaceId,
+      fields: {
+        beforeSession:
+          agentActivitySessionReconcileDiagnosticDetails(beforeSession),
+        incomingSession: agentActivitySessionReconcileDiagnosticDetails(
+          input.session
+        )
+      }
+    });
+    entry.controller.upsertSession(input.session);
+    const afterSession =
+      entry.controller
+        .getSnapshot()
+        .sessions.find(
+          (session) => session.agentSessionId === input.agentSessionId
+        ) ?? null;
+    this.reportReconcileTrace({
+      agentSessionId: input.agentSessionId,
+      traceEvent: `${input.source}.applied`,
+      workspaceId: input.workspaceId,
+      fields: {
+        afterSession:
+          agentActivitySessionReconcileDiagnosticDetails(afterSession)
+      }
+    });
+  }
+
+  private reportReconcileTrace(input: {
+    agentSessionId: string | null;
+    traceEvent: string;
+    workspaceId: string;
+    fields?: Record<string, unknown>;
+  }): void {
+    try {
+      void this.dependencies.runtimeApi
+        .logTerminalDiagnostic({
+          details: {
+            agentSessionId: input.agentSessionId,
+            traceEvent: input.traceEvent,
+            ...(input.fields ?? {})
+          },
+          event: "agent.activity.reconcile.trace",
+          level: "info",
+          workspaceId: input.workspaceId
+        })
+        .catch(() => {});
+    } catch {
+      // Diagnostic logging must not affect agent activity reconciliation.
+    }
   }
 
   private markSessionDeleted(input: {
@@ -1171,14 +1292,12 @@ export class WorkspaceAgentActivityService implements IWorkspaceAgentActivitySer
     const messages =
       entry.controller.getSnapshot().sessionMessagesById[agentSessionId];
     const afterVersion = reconcileAfterVersion(messages ?? []);
-    const session = await this.fetchActivitySession(
+    this.reportReconcileTrace({
+      agentSessionId,
+      traceEvent: "reconcile.combined.messages_requested",
       workspaceId,
-      agentSessionId
-    );
-    if (this.isSessionTombstoned(workspaceId, agentSessionId)) {
-      entry.controller.removeSession(agentSessionId);
-      return;
-    }
+      fields: { afterVersion }
+    });
     const page = await entry.controller.listSessionMessages({
       agentSessionId,
       afterVersion
@@ -1187,10 +1306,34 @@ export class WorkspaceAgentActivityService implements IWorkspaceAgentActivitySer
       entry.controller.removeSession(agentSessionId);
       return;
     }
-    entry.controller.upsertSession(session);
+    this.reportReconcileTrace({
+      agentSessionId,
+      traceEvent: "reconcile.combined.messages_resolved",
+      workspaceId,
+      fields: {
+        afterVersion,
+        latestVersion: page.latestVersion,
+        messageCount: page.messages.length
+      }
+    });
     for (const message of page.messages) {
       this.emitSessionEvent(workspaceId, hostMessageEventFromCore(message));
     }
+    const session = await this.fetchActivitySession(
+      workspaceId,
+      agentSessionId,
+      "reconcile.combined.state_fetch"
+    );
+    if (this.isSessionTombstoned(workspaceId, agentSessionId)) {
+      entry.controller.removeSession(agentSessionId);
+      return;
+    }
+    this.upsertControllerSession({
+      agentSessionId,
+      session,
+      source: "reconcile.combined.state_upsert",
+      workspaceId
+    });
     const reconciledMessages =
       entry.controller.getSnapshot().sessionMessagesById[agentSessionId] ??
       page.messages;
@@ -1211,6 +1354,12 @@ export class WorkspaceAgentActivityService implements IWorkspaceAgentActivitySer
     const messages =
       entry.controller.getSnapshot().sessionMessagesById[agentSessionId];
     const afterVersion = reconcileAfterVersion(messages ?? []);
+    this.reportReconcileTrace({
+      agentSessionId,
+      traceEvent: "reconcile.messages.requested",
+      workspaceId,
+      fields: { afterVersion }
+    });
     const page = await entry.controller.listSessionMessages({
       agentSessionId,
       afterVersion
@@ -1219,6 +1368,16 @@ export class WorkspaceAgentActivityService implements IWorkspaceAgentActivitySer
       entry.controller.removeSession(agentSessionId);
       return;
     }
+    this.reportReconcileTrace({
+      agentSessionId,
+      traceEvent: "reconcile.messages.resolved",
+      workspaceId,
+      fields: {
+        afterVersion,
+        latestVersion: page.latestVersion,
+        messageCount: page.messages.length
+      }
+    });
     for (const message of page.messages) {
       this.emitSessionEvent(workspaceId, hostMessageEventFromCore(message));
     }
@@ -1233,7 +1392,8 @@ export class WorkspaceAgentActivityService implements IWorkspaceAgentActivitySer
     }
     const session = await this.fetchActivitySession(
       workspaceId,
-      agentSessionId
+      agentSessionId,
+      "reconcile.state_fetch"
     );
     if (this.isSessionTombstoned(workspaceId, agentSessionId)) {
       this.controllerEntry(workspaceId).controller.removeSession(
@@ -1241,7 +1401,12 @@ export class WorkspaceAgentActivityService implements IWorkspaceAgentActivitySer
       );
       return;
     }
-    this.controllerEntry(workspaceId).controller.upsertSession(session);
+    this.upsertControllerSession({
+      agentSessionId,
+      session,
+      source: "reconcile.state_upsert",
+      workspaceId
+    });
     const messages =
       this.controllerEntry(workspaceId).controller.getSnapshot()
         .sessionMessagesById[agentSessionId] ?? [];
@@ -1268,8 +1433,28 @@ export class WorkspaceAgentActivityService implements IWorkspaceAgentActivitySer
       workspaceId: input.workspaceId
     });
     if (!result.applied) {
+      this.reportReconcileTrace({
+        agentSessionId: input.agentSessionId,
+        traceEvent: "inline.not_applied",
+        workspaceId: input.workspaceId,
+        fields: { eventType: input.eventType }
+      });
       return false;
     }
+    this.reportReconcileTrace({
+      agentSessionId: input.agentSessionId,
+      traceEvent: "inline.applied",
+      workspaceId: input.workspaceId,
+      fields: {
+        eventType: input.eventType,
+        incomingSession: agentActivitySessionReconcileDiagnosticDetails(
+          result.session
+        ),
+        statePatch: agentActivityStatePatchReconcileDiagnosticDetails(
+          result.statePatch
+        )
+      }
+    });
     for (const message of result.messages) {
       this.emitSessionEvent(
         input.workspaceId,
@@ -1328,6 +1513,58 @@ function reportAgentSubmitTraceDiagnostic(
   } catch {
     // Diagnostic logging must not affect agent submission.
   }
+}
+
+function agentActivitySessionReconcileDiagnosticDetails(
+  session: AgentActivitySession | null
+): Record<string, unknown> | null {
+  if (!session) {
+    return null;
+  }
+  return {
+    activeTurnId: session.turnLifecycle?.activeTurnId ?? null,
+    agentSessionId: session.agentSessionId,
+    currentPhase: session.currentPhase ?? null,
+    lastEventUnixMs: session.lastEventUnixMs ?? null,
+    messageVersion: session.messageVersion ?? null,
+    outcome: session.turnLifecycle?.outcome ?? null,
+    provider: session.provider,
+    status: session.status ?? null,
+    submitAvailabilityReason: session.submitAvailability?.reason ?? null,
+    submitAvailabilityState: session.submitAvailability?.state ?? null,
+    turnPhase: session.turnLifecycle?.phase ?? null,
+    updatedAtUnixMs: session.updatedAtUnixMs ?? null
+  };
+}
+
+function agentActivityStatePatchReconcileDiagnosticDetails(
+  patch: AgentActivityStatePatch | null
+): Record<string, unknown> | null {
+  if (!patch) {
+    return null;
+  }
+  return {
+    activeTurnId: patch.turn?.activeTurnId ?? null,
+    agentSessionId: patch.agentSessionId,
+    currentPhase: patch.currentPhase ?? null,
+    lastEventUnixMs: patch.lastEventUnixMs ?? patch.occurredAtUnixMs ?? null,
+    outcome: patch.turn?.outcome ?? null,
+    provider: patch.provider ?? null,
+    status: patch.lifecycleStatus ?? null,
+    submitAvailabilityReason:
+      patch.submitAvailability?.reason ??
+      patch.turn?.submitAvailability?.reason ??
+      null,
+    submitAvailabilityState:
+      patch.submitAvailability?.state ??
+      patch.turn?.submitAvailability?.state ??
+      null,
+    topLevelSubmitAvailabilityState: patch.submitAvailability?.state ?? null,
+    turnId: patch.turn?.turnId ?? null,
+    turnPhase: patch.turn?.phase ?? null,
+    turnSubmitAvailabilityState: patch.turn?.submitAvailability?.state ?? null,
+    updatedAtUnixMs: patch.occurredAtUnixMs ?? null
+  };
 }
 
 function stringMetadata(

--- a/docs/architecture/agent-gui-node.md
+++ b/docs/architecture/agent-gui-node.md
@@ -689,6 +689,11 @@ Daemon terminal turn reports must settle the tuple atomically: clear
 Message Center and AgentGUI should keep AgentActivityRuntime as the source of
 truth instead of guessing that a completed turn with stale active-turn fields is
 safe to treat as finished.
+When a runtime snapshot regresses after a terminal turn, first inspect
+`agent.activity.reconcile.trace` for the exact source that upserted the older
+session state. Reconcile fixes should target that owner and ordering path; do
+not add broad UI-side stale-active-turn exceptions that hide an upstream state
+or reconciliation bug.
 
 When the visible symptom is a sticky error badge on a rail row, dock preview, or
 message-center trigger, also inspect the latest loaded turn messages. A
@@ -970,20 +975,18 @@ active conversation's draft, detail error, or submit spinner. Drain readiness
 must follow activity projection and retry-block timestamps instead of raw
 `controlState` fields such as
 `pendingInteractive`, because those fields are not guaranteed to be cleared by
-every activity `state_patch`. Likewise, stale `submitAvailability` values must
-not block a drain when the only blocked reason is `active_turn` and activity
-status plus turn lifecycle already show the session is idle. Other blocked
-reasons such as auth, quota, provider setup, or permission gates must still
-block queued prompt sending. An old `turnLifecycle.activeTurnId` is not busy by
-itself when `turnLifecycle.phase` has already settled to idle, completed,
-canceled, or failed. When a drain attempt hits an active-turn conflict, the
-retry block must be recorded from the ready activity version observed before
-calling `sendInput`, using the same activity-version source that the next drain
-gate compares. Do not read a mutable activity snapshot after the awaited send
-fails: the failure may arrive with a newer settled/available activity update,
-and blocking that newer version would strand the queued prompt until another
-unrelated activity event. The retry block still prevents immediately
-re-claiming against the exact same pre-send ready state.
+every activity `state_patch`. Queued-prompt drainers must not locally decide
+that an `active_turn` block or a lingering `turnLifecycle.activeTurnId` is
+stale; they should wait until the shared activity projection reports
+`submitAvailability.state = "available"` and no active turn remains. When a
+drain attempt hits an active-turn conflict, the retry block must be recorded
+from the ready activity version observed before calling `sendInput`, using the
+same activity-version source that the next drain gate compares. Do not read a
+mutable activity snapshot after the awaited send fails: the failure may arrive
+with a newer settled/available activity update, and blocking that newer version
+would strand the queued prompt until another unrelated activity event. The
+retry block still prevents immediately re-claiming against the exact same
+pre-send ready state.
 
 Preview-mode AgentGUI surfaces are read-only for this runtime: they may render an
 existing queue if injected into the same context, but they must not enqueue,

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUINodeController.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUINodeController.ts
@@ -8253,10 +8253,7 @@ export function useAgentGUINodeController({
       }
       const activeTurnId =
         activeSessionState?.turnLifecycle?.activeTurnId?.trim() ?? "";
-      const canSteerActiveTurn =
-        activeTurnId !== "" ||
-        activeSessionState?.submitAvailability?.reason === "active_turn";
-      if (!canSteerActiveTurn) {
+      if (activeTurnId === "") {
         return;
       }
       const displayPromptText =


### PR DESCRIPTION
## Summary
- backport #789 to release/0704
- keep activity reconciliation ordering so messages are reconciled before the latest session state is fetched/upserted
- remove the release-only stale active-turn readiness exceptions (`blocked + active_turn` and `activeTurnId + settled/idle phase`) so queued prompt readiness follows the shared activity projection
- preserve release/0704 compatibility by localizing the live turn lifecycle phase helper and omitting main-only goalControl adapter wiring

## Tests
- node --import ./test/register-asset-stub.mjs --test --experimental-strip-types src/renderer/src/features/workspace-agent/services/internal/workspaceAgentActivityService.test.ts src/renderer/src/features/workspace-agent/services/createDesktopAgentGUIWorkbenchHostInput.test.ts
- pnpm --filter @tutti-os/desktop typecheck
- pnpm --filter @tutti-os/agent-activity-core test

Note: pushed with --no-verify because this local environment is Node v22.23.1 while the repo pre-push check requires Node >=24.