### PR TITLE
fix(agent-gui): keep opened sessions selected in rail

### DIFF
--- a/apps/desktop/src/renderer/src/features/workspace-agent/services/desktopAgentGUIOpenSessionActivation.test.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-agent/services/desktopAgentGUIOpenSessionActivation.test.ts
@@ -143,6 +143,46 @@ test("consumeDesktopAgentGUIOpenSessionActivation activates and selects the requ
   ]);
 });
 
+test("consumeDesktopAgentGUIOpenSessionActivation clears stale cross-provider targets", async () => {
+  let nodeState: DesktopAgentGUINodeState = {
+    agentTargetId: "local:claude-code",
+    provider: "claude-code",
+    lastActiveAgentSessionId: "session-claude-1"
+  };
+  const agentActivityRuntime = {
+    async activateSession() {
+      return {};
+    }
+  } as unknown as Pick<AgentActivityRuntime, "activateSession">;
+
+  const consumed = consumeDesktopAgentGUIOpenSessionActivation({
+    activation: {
+      payload: { agentSessionId: "session-codex-1" },
+      sequence: 12,
+      type: desktopAgentGUIOpenSessionActivationType
+    },
+    agentActivityRuntime,
+    handledSequence: null,
+    markHandled: () => {},
+    nodeId: "node-1",
+    onStateChange: () => {},
+    provider: "codex",
+    resolveAgentTargetProvider: (agentTargetId) =>
+      agentTargetId === "local:claude-code" ? "claude-code" : null,
+    workspaceId: "workspace-1",
+    updateNodeState: (updater) => {
+      nodeState = updater(nodeState);
+    }
+  });
+
+  await Promise.resolve();
+
+  assert.equal(consumed, true);
+  assert.equal(nodeState.lastActiveAgentSessionId, "session-codex-1");
+  assert.equal(nodeState.provider, "codex");
+  assert.equal(nodeState.agentTargetId, null);
+});
+
 test("consumeDesktopAgentGUIOpenSessionActivation reports activation errors after selecting the session", async () => {
   const error = new Error("session not found");
   const activationErrors: unknown[] = [];

--- a/apps/desktop/src/renderer/src/features/workspace-agent/services/desktopAgentGUIOpenSessionActivation.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-agent/services/desktopAgentGUIOpenSessionActivation.ts
@@ -28,6 +28,10 @@ export interface ConsumeDesktopAgentGUIOpenSessionActivationInput {
   ): void;
   onStateChange(this: void, state: DesktopAgentGUIWorkbenchState): void;
   provider: DesktopAgentGUIProvider;
+  resolveAgentTargetProvider?(
+    this: void,
+    agentTargetId: string | null
+  ): DesktopAgentGUIProvider | null;
   workspaceId: string;
   updateNodeState(
     this: void,
@@ -46,6 +50,7 @@ export function consumeDesktopAgentGUIOpenSessionActivation({
   onOpenSessionRequest,
   onStateChange,
   provider,
+  resolveAgentTargetProvider,
   workspaceId,
   updateNodeState
 }: ConsumeDesktopAgentGUIOpenSessionActivationInput): boolean {
@@ -67,9 +72,24 @@ export function consumeDesktopAgentGUIOpenSessionActivation({
       onActivationError?.({ agentSessionId: request.agentSessionId, error });
     });
   updateNodeState((current) => {
+    const currentAgentTargetId =
+      current.agentTargetId?.trim() || current.providerTargetId?.trim() || null;
+    const currentAgentTargetProvider = currentAgentTargetId
+      ? (resolveAgentTargetProvider?.(currentAgentTargetId) ?? null)
+      : null;
+    const shouldClearAgentTarget =
+      currentAgentTargetProvider !== null &&
+      currentAgentTargetProvider !== provider;
     const next = normalizeDesktopAgentGUINodeState(
       {
         ...current,
+        ...(shouldClearAgentTarget
+          ? {
+              agentTargetId: null,
+              providerTargetId: null,
+              providerTargetRef: null
+            }
+          : {}),
         lastActiveAgentSessionId: request.agentSessionId,
         provider
       },

--- a/apps/desktop/src/renderer/src/features/workspace-agent/ui/DesktopAgentGUIWorkbenchBody.tsx
+++ b/apps/desktop/src/renderer/src/features/workspace-agent/ui/DesktopAgentGUIWorkbenchBody.tsx
@@ -811,6 +811,12 @@ function DesktopAgentGUIWorkbenchBodyImpl({
       // Persistence is owned by handleUpdateNode (the single writer).
       onStateChange: DESKTOP_AGENT_GUI_NOOP,
       provider,
+      resolveAgentTargetProvider: (agentTargetId) =>
+        resolveDesktopAgentGUIProviderForAgentTarget(
+          agentTargetId,
+          providerTargets,
+          provider
+        ),
       workspaceId,
       updateNodeState: handleUpdateNode
     });
@@ -822,6 +828,7 @@ function DesktopAgentGUIWorkbenchBodyImpl({
     handleOpenSessionActivationError,
     handleUpdateNode,
     provider,
+    providerTargets,
     workspaceId
   ]);
 

--- a/apps/desktop/src/renderer/src/features/workspace-workbench/services/internal/workspaceWorkbenchComposition.test.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/services/internal/workspaceWorkbenchComposition.test.ts
@@ -134,7 +134,7 @@ test("workspaceAgentGuiProviderFromLaunchRequest prefers launch payloads before 
   );
 });
 
-test("workspace agent GUI session launches target exact session instances", () => {
+test("workspace agent GUI session launches use container instances", () => {
   const descriptor = createWorkspaceAgentGuiLaunchDescriptor({
     dockEntryId: "agent-gui",
     payload: {
@@ -147,7 +147,7 @@ test("workspace agent GUI session launches target exact session instances", () =
   assert.equal(descriptor.provider, "codex");
   assert.equal(descriptor.targetAgentSessionId, "session-2");
   assert.equal(descriptor.dockEntryId, "agent-gui");
-  assert.equal(descriptor.instanceId, "agent-gui:codex:session:session-2");
+  assert.match(descriptor.instanceId, /^agent-gui:codex:panel:/);
   assert.equal(descriptor.reuseDockEntryNode, false);
   assert.deepEqual(descriptor.activation, {
     payload: {

--- a/apps/desktop/src/renderer/src/features/workspace-workbench/ui/WorkspaceWorkbench.tsx
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/ui/WorkspaceWorkbench.tsx
@@ -346,6 +346,7 @@ function ReadyWorkspaceWorkbench({
                     userProjectPath
                   })
                 : createWorkspaceAgentGuiSessionLaunchRequest({
+                    agentTargetId,
                     agentSessionId,
                     openInNewWindow,
                     provider

--- a/docs/architecture/agent-gui-node.md
+++ b/docs/architecture/agent-gui-node.md
@@ -228,9 +228,29 @@ the current Tutti workspace surface: `DesktopAgentGUIWorkbenchBody` calls
 `requestWorkspaceAgentGuiLaunch`, the workspace launch handler calls
 `host.launchNode`, and AgentGUI opens the requested session through an
 `agent-gui:open-session` activation. Normal session launches may reuse an
-already-open node showing that session; the explicit new-window action must pass
-`openInNewWindow` so the descriptor creates a fresh panel-scoped AgentGUI
-instance while still activating the same durable session.
+already-open node only when workbench node state says that node is currently
+showing the requested session. A session-keyed instance id from older snapshots
+is only a legacy window identity hint, not proof of the node's current session.
+If no current-session match exists, the launch should use a provider target or
+panel-scoped AgentGUI container and then activate the durable session. The
+explicit new-window action must pass `openInNewWindow` so the descriptor creates
+a fresh panel-scoped AgentGUI instance while still activating the same durable
+session.
+Opening an existing session is session-authoritative. If the launch payload has
+no `agentTargetId` or provider target id, workbench node state must clear any
+previous target constraint instead of inheriting it from the reused node. When a
+stale target resolves to a different provider than the launched session node,
+desktop activation must drop that target before persisting `lastActiveAgentSessionId`;
+otherwise the node can open the requested session while the conversation rail
+stays scoped to the old provider and cannot select the active row.
+The selected-session state must also honor an explicit open-session request
+even when that session is outside the currently loaded rail page or section.
+Missing from the visible rail is not proof the session is gone. AgentGUI should
+project the requested session metadata into a node-local transient rail row and
+run the normal cwd/user-project grouping so the selected row remains visible in
+the matching project group. This overlay must stay out of canonical pagination
+state and be de-duplicated by conversation id when the real paginated row later
+arrives; session detail/state load owns true not-found handling.
 
 ## Runtime Data Chain
 

--- a/packages/agent/gui/agent-gui/agentGuiNode/AgentGUINodeView.layout.spec.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/AgentGUINodeView.layout.spec.tsx
@@ -13,7 +13,11 @@ import type { AgentActivitySnapshot } from "@tutti-os/agent-activity-core";
 import type { WorkspaceAgentSessionDetailViewModel } from "../../shared/workspaceAgentSessionDetailViewModel";
 import type { AgentPromptContentBlock } from "../../shared/contracts/dto";
 import type { AgentGUINodeViewModel } from "./model/agentGuiNodeTypes";
-import { AgentGUINodeView, type AgentGUIViewLabels } from "./AgentGUINodeView";
+import {
+  AgentGUINodeView,
+  updateConversationSectionsFromSummaries,
+  type AgentGUIViewLabels
+} from "./AgentGUINodeView";
 import {
   createLocalAgentGUIProviderTarget,
   createLocalAgentGUIProviderTargets
@@ -1751,6 +1755,72 @@ describe("AgentGUINodeView layout persistence", () => {
     ).not.toBeInTheDocument();
   });
 
+  it("applies selected conversation overlays when runtime rail sections finish loading", async () => {
+    const project = {
+      id: "project-home",
+      path: "/Users/ryan",
+      label: "ryan"
+    };
+    const listSessionSections = vi.fn<
+      NonNullable<AgentActivityRuntime["listSessionSections"]>
+    >(async (input) => ({
+      workspaceId: input.workspaceId,
+      sections: [
+        createRuntimeProjectSection({
+          project,
+          sessions: [20, 19, 18, 17, 16].map((index) => ({
+            ...createRuntimeSession(
+              input.workspaceId,
+              `session-${index}`,
+              "/Users/ryan"
+            ),
+            updatedAtUnixMs: index
+          })),
+          hasMore: true,
+          nextCursor: "16|session-16",
+          workspaceId: input.workspaceId
+        })
+      ]
+    }));
+
+    renderAgentGUINodeView({
+      activityRuntime: {
+        ...createNoopAgentActivityRuntime(),
+        listSessionSections,
+        listSessionSectionPage: async (input) => ({
+          kind: "project",
+          sectionKey: input.sectionKey,
+          userProject: createRuntimeUserProject(project),
+          sessions: [],
+          hasMore: false
+        })
+      },
+      viewModel: {
+        ...createViewModel(),
+        activeConversationId: "session-5",
+        userProjects: [project],
+        conversations: [5, 20, 19, 18, 17].map((index) =>
+          createConversationSummary(`session-${index}`, {
+            project,
+            updatedAtUnixMs: index
+          })
+        )
+      }
+    });
+
+    await waitFor(() => {
+      expect(
+        screen.getByTestId("agent-gui-conversation-item-session-5")
+      ).toBeInTheDocument();
+    });
+    expect(
+      screen.getByTestId("agent-gui-conversation-item-session-20")
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByTestId("agent-gui-conversation-item-session-16")
+    ).not.toBeInTheDocument();
+  });
+
   it("opens a conversation from the rail with the external-link action", () => {
     const actions = createActions();
     const onOpenConversationWindow = vi.fn();
@@ -1847,6 +1917,63 @@ describe("AgentGUINodeView layout persistence", () => {
     ).not.toBeInTheDocument();
     expect(
       screen.getByRole("button", { name: "Show less" })
+    ).toBeInTheDocument();
+  });
+
+  it("keeps the active conversation visible when a section is collapsed back to its first page", () => {
+    renderAgentGUINodeView({
+      labels: {
+        ...createLabels(),
+        showMoreConversations: "Show more",
+        showLessConversations: "Show less"
+      },
+      viewModel: {
+        ...createViewModel(),
+        activeConversationId: "session-12",
+        conversations: Array.from({ length: 10 }, (_, index) =>
+          createConversationSummary(`session-${20 - index}`)
+        )
+      }
+    });
+
+    expect(
+      screen.getByTestId("agent-gui-conversation-item-session-20")
+    ).toBeInTheDocument();
+    expect(
+      screen.getByTestId("agent-gui-conversation-item-session-16")
+    ).toBeInTheDocument();
+    expect(
+      screen.getByTestId("agent-gui-conversation-item-session-12")
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByTestId("agent-gui-conversation-item-session-15")
+    ).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "Show more" }));
+
+    expect(
+      screen.getByTestId("agent-gui-conversation-item-session-13")
+    ).toBeInTheDocument();
+    expect(
+      screen.getByTestId("agent-gui-conversation-item-session-12")
+    ).toBeInTheDocument();
+    expect(
+      screen.getByTestId("agent-gui-conversation-item-session-11")
+    ).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "Show less" }));
+
+    expect(
+      screen.getByTestId("agent-gui-conversation-item-session-16")
+    ).toBeInTheDocument();
+    expect(
+      screen.getByTestId("agent-gui-conversation-item-session-12")
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByTestId("agent-gui-conversation-item-session-15")
+    ).not.toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "Show more" })
     ).toBeInTheDocument();
   });
 
@@ -2963,6 +3090,45 @@ describe("AgentGUINodeView layout persistence", () => {
       isSendingTurn: true,
       showStopButton: true
     });
+  });
+
+  it("keeps the selected transient conversation ahead of the latest runtime rail page", () => {
+    const project = { id: "ryan", label: "ryan", path: "/Users/ryan" };
+    const existingSection = {
+      id: "project:/Users/ryan",
+      kind: "project" as const,
+      label: "ryan",
+      project,
+      items: [5, 4, 3, 2, 1].map((index) =>
+        createConversationSummary(`session-${index}`, {
+          project,
+          updatedAtUnixMs: index
+        })
+      )
+    };
+
+    const updated = updateConversationSectionsFromSummaries(
+      [existingSection],
+      [5, 20, 19, 18, 17].map((index) =>
+        createConversationSummary(`session-${index}`, {
+          project,
+          updatedAtUnixMs: index
+        })
+      ),
+      { sectionConversationsLabel: "Conversations" }
+    );
+
+    expect(updated?.[0]?.items.map((item) => item.id)).toEqual([
+      "session-5",
+      "session-20",
+      "session-19",
+      "session-18",
+      "session-17",
+      "session-4",
+      "session-3",
+      "session-2",
+      "session-1"
+    ]);
   });
 
   it("shows the active conversation as working while a prompt submit is pending", () => {

--- a/packages/agent/gui/agent-gui/agentGuiNode/AgentGUINodeView.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/AgentGUINodeView.tsx
@@ -4247,6 +4247,21 @@ export function updateConversationSectionsFromSummaries(
   const summariesById = new Map(
     conversations.map((conversation) => [conversation.id, conversation])
   );
+  const summarySectionItemsById = new Map<
+    string,
+    AgentGUINodeViewModel["conversations"]
+  >();
+  for (const conversation of conversations) {
+    if ((conversation.pinnedAtUnixMs ?? 0) > 0) {
+      continue;
+    }
+    const sectionId = conversation.project
+      ? `project:${normalizeConversationProjectPath(conversation.project.path)}`
+      : "conversations";
+    const items = summarySectionItemsById.get(sectionId) ?? [];
+    items.push(conversation);
+    summarySectionItemsById.set(sectionId, items);
+  }
   const seenIds = new Set<string>();
   let changed = false;
   const nextSections = previous.map((section) => {
@@ -4267,13 +4282,38 @@ export function updateConversationSectionsFromSummaries(
       sectionChanged = true;
       return nextItem;
     });
-    if (!sectionChanged) {
-      return section;
+    const nextSection = sectionChanged
+      ? {
+          ...section,
+          items
+        }
+      : section;
+    const summaryItems = summarySectionItemsById.get(section.id) ?? [];
+    if (section.kind === "pinned" || summaryItems.length === 0) {
+      if (sectionChanged) {
+        changed = true;
+      }
+      return nextSection;
+    }
+    const summaryIds = new Set(summaryItems.map((item) => item.id));
+    const mergedItems = [
+      ...summaryItems.map((item) => ({
+        ...item,
+        project: section.project
+      })),
+      ...items.filter((item) => !summaryIds.has(item.id))
+    ];
+    const stableItems = stabilizeConversationSectionItems(items, mergedItems);
+    if (stableItems === items) {
+      if (sectionChanged) {
+        changed = true;
+      }
+      return nextSection;
     }
     changed = true;
     return {
-      ...section,
-      items
+      ...nextSection,
+      items: stableItems
     };
   });
 
@@ -4285,9 +4325,12 @@ export function updateConversationSectionsFromSummaries(
   // appear in the sidebar until the next full runtimeListSessionSections
   // refetch happens to include it, which -- because that refetch is keyed
   // off conversation membership -- may never happen again for the same id.
-  const newConversations = conversations.filter(
-    (conversation) =>
-      !seenIds.has(conversation.id) && (conversation.pinnedAtUnixMs ?? 0) <= 0
+  const existingSectionIds = new Set(nextSections.map((section) => section.id));
+  const newConversations = [...summarySectionItemsById.entries()].flatMap(
+    ([sectionId, items]) =>
+      existingSectionIds.has(sectionId)
+        ? []
+        : items.filter((conversation) => !seenIds.has(conversation.id))
   );
   if (newConversations.length === 0) {
     return changed ? nextSections : previous;
@@ -4306,7 +4349,7 @@ export function updateConversationSectionsFromSummaries(
     if (targetIndex !== -1 && target) {
       sectionsWithInsertions[targetIndex] = {
         ...target,
-        items: [conversation, ...target.items]
+        items: [...target.items, conversation]
       };
       continue;
     }
@@ -4797,6 +4840,7 @@ function useAgentGUIConversationRail({
   const [sectionPageStates, setSectionPageStates] = useState<
     ReadonlyMap<string, ConversationRailSectionPageState>
   >(() => new Map());
+  const conversationsRef = useRef(conversations);
   const pagingRequestSequenceRef = useRef(0);
   const pagingAbortControllersRef = useRef(new Map<string, AbortController>());
   const runtimeListSessionSections = agentActivityRuntime.listSessionSections;
@@ -4828,6 +4872,10 @@ function useAgentGUIConversationRail({
     }),
     [labels.sectionConversations, labels.sectionPinned]
   );
+
+  useEffect(() => {
+    conversationsRef.current = conversations;
+  }, [conversations]);
 
   useEffect(() => {
     pagingRequestSequenceRef.current += 1;
@@ -4882,8 +4930,16 @@ function useAgentGUIConversationRail({
           sections: page.sections,
           workspaceId: page.workspaceId
         });
+        const sectionsWithSummaries = updateConversationSectionsFromSummaries(
+          sections,
+          conversationsRef.current,
+          { sectionConversationsLabel: labels.sectionConversations }
+        );
         setRuntimeRailSections((current) =>
-          stabilizeConversationSections(current, sections)
+          stabilizeConversationSections(
+            current,
+            sectionsWithSummaries ?? sections
+          )
         );
         setSectionPageStates(() => {
           const next = new Map<string, ConversationRailSectionPageState>();
@@ -4912,6 +4968,7 @@ function useAgentGUIConversationRail({
   }, [
     conversationFilter,
     conversationMembershipKey,
+    labels.sectionConversations,
     runtimeListSessionSections,
     runtimeSectionsEnabled,
     sectionProjectionLabels,
@@ -5649,9 +5706,23 @@ const AgentGUIConversationRailSection = memo(
     const visibleItemCount = isSectionCollapsed
       ? 0
       : Math.min(visibleItemLimit, section.items.length);
-    const visibleItems = isSectionCollapsed
-      ? []
-      : section.items.slice(0, visibleItemCount);
+    const visibleItems = useMemo(() => {
+      if (isSectionCollapsed) {
+        return [];
+      }
+      const baseItems = section.items.slice(0, visibleItemCount);
+      const activeId = activeConversationId?.trim() ?? "";
+      if (!activeId || baseItems.some((item) => item.id === activeId)) {
+        return baseItems;
+      }
+      const activeItem = section.items.find((item) => item.id === activeId);
+      return activeItem ? [...baseItems, activeItem] : baseItems;
+    }, [
+      activeConversationId,
+      isSectionCollapsed,
+      section.items,
+      visibleItemCount
+    ]);
     const canShowMore =
       !isSectionCollapsed &&
       (visibleItemCount < section.items.length || sectionHasMore);

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUINodeController.spec.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUINodeController.spec.tsx
@@ -4044,6 +4044,183 @@ describe("useAgentGUINodeController", () => {
     });
   });
 
+  it("keeps an explicit open-session request even when the session is outside the loaded rail", async () => {
+    installAgentHostApi({
+      list: vi.fn(async () => ({
+        presences: [],
+        sessions: [workspaceAgentSession("recent-session")]
+      })),
+      listSessionTimeline: vi.fn(
+        async ({ agentSessionId }: { agentSessionId: string }) => ({
+          timelineItems:
+            agentSessionId === "old-session"
+              ? [
+                  timelineMessage({
+                    agentSessionId,
+                    id: 1,
+                    eventId: "old-session-message",
+                    role: "user",
+                    content: "open old session"
+                  })
+                ]
+              : []
+        })
+      ),
+      getState: vi.fn(async ({ agentSessionId }: { agentSessionId: string }) =>
+        agentSessionState(agentSessionId)
+      ),
+      subscribeEvents: vi.fn(() => vi.fn()),
+      userProjects: {
+        list: vi.fn(async () => ({
+          projects: [
+            {
+              id: "workspace-project",
+              label: "Workspace",
+              path: "/workspace"
+            }
+          ]
+        })),
+        subscribe: vi.fn(() => vi.fn())
+      }
+    });
+
+    const { result, rerender } = renderHook(
+      (props) =>
+        useAgentGUINodeController({
+          workspaceId: "room-1",
+          currentUserId: "user-1",
+          workspacePath: "/workspace",
+          avoidGroupingEdits: false,
+          ...props
+        }),
+      {
+        initialProps: {
+          data: agentGuiData("recent-session"),
+          onDataChange: vi.fn(),
+          openSessionRequest: null as {
+            agentSessionId: string;
+            sequence: number;
+          } | null
+        }
+      }
+    );
+
+    await waitFor(() => {
+      expect(result.current.viewModel.activeConversationId).toBe(
+        "recent-session"
+      );
+    });
+
+    rerender({
+      data: agentGuiData("recent-session"),
+      onDataChange: vi.fn(),
+      openSessionRequest: {
+        agentSessionId: "old-session",
+        sequence: 1
+      }
+    });
+
+    await waitFor(() => {
+      expect(result.current.viewModel.activeConversationId).toBe("old-session");
+    });
+
+    await new Promise((resolve) => window.setTimeout(resolve, 0));
+    expect(result.current.viewModel.activeConversationId).toBe("old-session");
+    expect(result.current.viewModel.activeConversation?.id).toBe("old-session");
+    await waitFor(() => {
+      expect(
+        result.current.viewModel.conversations.filter(
+          (conversation) => conversation.id === "old-session"
+        )
+      ).toHaveLength(1);
+    });
+    expect(
+      result.current.viewModel.conversations.find(
+        (conversation) => conversation.id === "old-session"
+      )?.project
+    ).toEqual({
+      id: "workspace-project",
+      label: "Workspace",
+      path: "/workspace"
+    });
+
+    rerender({
+      data: agentGuiData("recent-session"),
+      onDataChange: vi.fn(),
+      openSessionRequest: {
+        agentSessionId: "old-session",
+        sequence: 1
+      }
+    });
+    expect(
+      result.current.viewModel.conversations.some(
+        (conversation) => conversation.id === "old-session"
+      )
+    ).toBe(true);
+  });
+
+  it("keeps an explicit open-session request when restored state points at another session", async () => {
+    installAgentHostApi({
+      list: vi.fn(async () => ({
+        presences: [],
+        sessions: [workspaceAgentSession("gobang-session")]
+      })),
+      listSessionTimeline: vi.fn(async () => ({ timelineItems: [] })),
+      getState: vi.fn(async ({ agentSessionId }: { agentSessionId: string }) =>
+        agentSessionState(agentSessionId)
+      ),
+      subscribeEvents: vi.fn(() => vi.fn())
+    });
+
+    const { result, rerender } = renderHook(
+      (props) =>
+        useAgentGUINodeController({
+          workspaceId: "room-1",
+          currentUserId: "user-1",
+          workspacePath: "/workspace",
+          avoidGroupingEdits: false,
+          ...props
+        }),
+      {
+        initialProps: {
+          data: agentGuiData("gobang-session"),
+          onDataChange: vi.fn(),
+          openSessionRequest: null as {
+            agentSessionId: string;
+            sequence: number;
+          } | null
+        }
+      }
+    );
+
+    await waitFor(() => {
+      expect(result.current.viewModel.activeConversationId).toBe(
+        "gobang-session"
+      );
+    });
+
+    rerender({
+      data: agentGuiData("gobang-session"),
+      onDataChange: vi.fn(),
+      openSessionRequest: {
+        agentSessionId: "news-session",
+        sequence: 1
+      }
+    });
+
+    await waitFor(() => {
+      expect(result.current.viewModel.activeConversationId).toBe(
+        "news-session"
+      );
+    });
+
+    await new Promise((resolve) => window.setTimeout(resolve, 0));
+    expect(result.current.viewModel.activeConversationId).toBe("news-session");
+    expect(result.current.viewModel.activeConversation?.id).toBe(
+      "news-session"
+    );
+  });
+
   it("keeps a switched conversation loading while its timeline request is pending", async () => {
     const session2TimelineResolvers: Array<
       (value: { timelineItems: AgentHostWorkspaceAgentTimelineItem[] }) => void

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUINodeController.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUINodeController.ts
@@ -41,6 +41,7 @@ import type {
   AgentModelCatalogInvalidatedEvent,
   AgentActivityStreamEvent,
   AgentActivityMessageUpdate,
+  AgentSession,
   AgentSessionCommand,
   AgentSessionComposerSettings,
   AgentSessionPermissionConfig,
@@ -4397,6 +4398,8 @@ export function useAgentGUINodeController({
   const handledOpenSessionSequenceRef = useRef<number | null>(null);
   const pendingOpenSessionRequestRef =
     useRef<AgentGUIOpenSessionRequest | null>(null);
+  const explicitlyOpenedConversationIdsRef = useRef(new Set<string>());
+  const railPinnedTransientConversationIdsRef = useRef(new Set<string>());
   const selectedConversationNotFoundRetryIdsRef = useRef(new Set<string>());
   const selectedConversationNotFoundRetryTimerRef = useRef<number | null>(null);
   const sessionStateSnapshotCauseBySessionIdRef = useRef<
@@ -4552,6 +4555,93 @@ export function useAgentGUINodeController({
       setTransientConversationState(next);
     },
     []
+  );
+
+  const conversationSummaryFromRuntimeSession = useCallback(
+    (session: AgentActivitySession): AgentGUIConversationSummary => {
+      const updatedAtUnixMs = session.updatedAtUnixMs ?? Date.now();
+      const projectedSession: AgentSession = {
+        workspaceId: session.workspaceId,
+        agentSessionId: session.agentSessionId,
+        agentTargetId: session.agentTargetId ?? null,
+        provider: session.provider as AgentSession["provider"],
+        providerSessionId: session.providerSessionId ?? session.agentSessionId,
+        resumable: session.resumable,
+        cwd: session.cwd,
+        status: session.status,
+        title: session.title,
+        pinnedAtUnixMs: session.pinnedAtUnixMs ?? null,
+        createdAtUnixMs: session.createdAtUnixMs ?? updatedAtUnixMs,
+        updatedAtUnixMs
+      };
+      return conversationSummaryFromAgentSession(projectedSession, {
+        isNoProjectPath: isNoProjectPathRef.current,
+        userProjects: userProjectsRef.current
+      });
+    },
+    []
+  );
+
+  const ensureTransientOpenSessionConversation = useCallback(
+    (agentSessionId: string) => {
+      const normalizedAgentSessionId = agentSessionId.trim();
+      if (!normalizedAgentSessionId) {
+        return;
+      }
+      if (
+        resolveConversationSummaryById(
+          conversationsRef.current,
+          normalizedAgentSessionId,
+          transientConversationRef.current
+        )
+      ) {
+        return;
+      }
+      const snapshotSession = agentActivitySnapshotRef.current.sessions.find(
+        (session) =>
+          session.agentSessionId.trim() === normalizedAgentSessionId &&
+          session.visible !== false
+      );
+      if (snapshotSession) {
+        setTransientConversation(
+          conversationSummaryFromRuntimeSession(snapshotSession)
+        );
+        return;
+      }
+      void agentActivityRuntime
+        .getSession(workspaceId, normalizedAgentSessionId)
+        .then((session) => {
+          const shouldKeepTransient =
+            explicitlyOpenedConversationIdsRef.current.has(
+              normalizedAgentSessionId
+            ) ||
+            railPinnedTransientConversationIdsRef.current.has(
+              normalizedAgentSessionId
+            );
+          if (
+            !isMountedRef.current ||
+            activeConversationIdRef.current !== normalizedAgentSessionId ||
+            !shouldKeepTransient ||
+            resolveConversationSummaryById(
+              conversationsRef.current,
+              normalizedAgentSessionId,
+              transientConversationRef.current
+            )
+          ) {
+            return;
+          }
+          setTransientConversation(
+            conversationSummaryFromRuntimeSession(session)
+          );
+        })
+        .catch(() => {});
+    },
+    [
+      agentActivityRuntime,
+      conversationSummaryFromRuntimeSession,
+      setTransientConversation,
+      workspaceId
+    ]
   );
 
   // NOTE: project metadata is intentionally NOT written back into the shared
@@ -5069,6 +5159,8 @@ export function useAgentGUINodeController({
             ? { ...current, hasUnreadCompletion: false }
             : current
         );
+      } else if (transientConversationRef.current) {
+        setTransientConversation(null);
       }
       persistActiveConversation(normalized);
     },
@@ -5077,7 +5169,8 @@ export function useAgentGUINodeController({
       clearSelectedConversationNotFoundRetry,
       conversationListQuery,
       markSelectedConversationDetailPending,
-      persistActiveConversation
+      persistActiveConversation,
+      setTransientConversation
     ]
   );
 
@@ -5231,6 +5324,8 @@ export function useAgentGUINodeController({
         id,
         transientConversationRef.current
       ) !== null;
+    const resolveCanonicalId = (id: string) =>
+      resolveConversationSummaryById(conversations, id, null) !== null;
 
     const inSnapshot = (id: string) =>
       agentActivitySnapshotRef.current.sessions.some(
@@ -5240,30 +5335,12 @@ export function useAgentGUINodeController({
     // Open session request takes highest priority
     if (hasExplicitOpenSessionRequest) {
       const requestedId = pendingOpenSessionRequest!.agentSessionId.trim();
-      if (resolveId(requestedId)) {
-        pendingOpenSessionRequestRef.current = null;
-        selectConversation(requestedId, { reloadConversations: false });
-        return;
-      }
       if (!hasLoadedConversations) return;
-      if (inSnapshot(requestedId)) return;
-      if (intent.tag !== "resolving" || intent.id !== requestedId) {
-        setIntent({ tag: "resolving", id: requestedId });
-        void syncConversationListProjection(requestedId);
-        return;
-      }
-      if (!isAgentGUIConversationListRefreshing(conversationListQuery)) {
-        pendingOpenSessionRequestRef.current = null;
-        const fallback = selectAgentGUIConversationId(
-          conversations,
-          activeConversationIdRef.current
-        );
-        if (fallback) {
-          selectConversation(fallback, { reloadConversations: false });
-        } else {
-          setIntent({ tag: "home" });
-        }
-      }
+      explicitlyOpenedConversationIdsRef.current.add(requestedId);
+      railPinnedTransientConversationIdsRef.current.add(requestedId);
+      pendingOpenSessionRequestRef.current = null;
+      selectConversation(requestedId, { reloadConversations: false });
+      ensureTransientOpenSessionConversation(requestedId);
       return;
     }
 
@@ -5274,7 +5351,29 @@ export function useAgentGUINodeController({
 
       case "active":
         // Only demote when list is fully loaded, to avoid races during reload.
-        if (resolveId(intent.id) || !hasLoadedConversations) return;
+        if (resolveCanonicalId(intent.id)) {
+          explicitlyOpenedConversationIdsRef.current.delete(intent.id);
+          railPinnedTransientConversationIdsRef.current.delete(intent.id);
+          return;
+        }
+        if (resolveId(intent.id)) {
+          return;
+        }
+        if (!hasLoadedConversations) return;
+        if (
+          inSnapshot(intent.id) &&
+          activeConversationIdRef.current === intent.id
+        ) {
+          railPinnedTransientConversationIdsRef.current.add(intent.id);
+          ensureTransientOpenSessionConversation(intent.id);
+          return;
+        }
+        if (
+          explicitlyOpenedConversationIdsRef.current.has(intent.id) &&
+          activeConversationIdRef.current === intent.id
+        ) {
+          return;
+        }
         // Session was removed from list after load — re-check
         setIntent({ tag: "requested", id: intent.id });
         return;
@@ -5291,7 +5390,14 @@ export function useAgentGUINodeController({
           selectConversation(intent.id, { reloadConversations: false });
           return;
         }
-        if (inSnapshot(intent.id)) return;
+        if (inSnapshot(intent.id)) {
+          if (activeConversationIdRef.current === intent.id) {
+            railPinnedTransientConversationIdsRef.current.add(intent.id);
+            ensureTransientOpenSessionConversation(intent.id);
+            setIntent({ tag: "active", id: intent.id });
+          }
+          return;
+        }
         setIntent({ tag: "resolving", id: intent.id });
         void syncConversationListProjection(intent.id);
         return;
@@ -5319,6 +5425,7 @@ export function useAgentGUINodeController({
     intent,
     conversations,
     hasLoadedConversations,
+    ensureTransientOpenSessionConversation,
     openSessionRequest,
     previewMode,
     syncConversationListProjection,
@@ -10168,19 +10275,14 @@ export function useAgentGUINodeController({
     null
   );
   const visibleConversations = useMemo(() => {
-    // Merge in the transient (optimistic pre-activation, or not-yet-synced)
-    // conversation unconditionally, not just while the initial conversation
-    // list is still loading: activeConversation (see
-    // resolveConversationSummaryById) already falls back to it
-    // unconditionally, and the sidebar must stay in sync with the main pane
-    // so a newly started conversation appears in both at once instead of
-    // only after the real backend record lands in `conversations`.
-    // mergeVisibleConversations already no-ops once the real conversation
-    // with a matching id is present, so this never duplicates an entry.
-    const source = mergeVisibleConversations(
-      conversations,
-      transientConversationRef.current
-    );
+    const transient = transientConversationRef.current;
+    const source =
+      transient &&
+      (isLoadingConversations ||
+        explicitlyOpenedConversationIdsRef.current.has(transient.id) ||
+        railPinnedTransientConversationIdsRef.current.has(transient.id))
+        ? mergeVisibleConversations(conversations, transient)
+        : conversations;
     const mapped = source.map((conversation) => {
       const withRuntime = mergeConversationSummaryWithRuntimeSession({
         conversation,

--- a/packages/agent/gui/workbench/contribution.test.ts
+++ b/packages/agent/gui/workbench/contribution.test.ts
@@ -26,6 +26,7 @@ import {
   agentGuiWorkbenchUnifiedDockEntryId,
   agentGuiWorkbenchTypeId
 } from "./launch.ts";
+import type { AgentGuiWorkbenchState } from "./types.ts";
 
 function readDockEntryIconImageSrcs(icon: ReactNode): string[] {
   if (!isValidElement(icon)) {
@@ -256,8 +257,72 @@ describe("agent GUI workbench contribution copy", () => {
         type: "agent-gui:open-session"
       },
       dockEntryId: agentGuiWorkbenchUnifiedDockEntryId(),
-      instanceId: "agent-gui:claude-code:session:session-claude-1",
       title: "Agent"
+    });
+    expect(launchResult?.instanceId).toContain("agent-gui:claude-code:panel:");
+  });
+
+  it("clears stale target state when opening a session without a target payload", () => {
+    const contribution = createTestAgentGuiWorkbenchContribution({
+      renderBody: () => null,
+      workspaceId: "workspace-1"
+    });
+    const baseRequest = {
+      dockEntryId: agentGuiWorkbenchUnifiedDockEntryId(),
+      layoutConstraints: testLaunchLayout.layoutConstraints,
+      reason: "host" as const,
+      surfaceSize: testLaunchLayout.surfaceSize,
+      typeId: agentGuiWorkbenchTypeId,
+      workspaceId: "workspace-1"
+    };
+
+    const seededLaunch = contribution.onLaunchRequest?.({
+      ...baseRequest,
+      payload: {
+        agentSessionId: "session-codex-1",
+        agentTargetId: "local:claude-code",
+        provider: "codex"
+      }
+    }) as
+      | {
+          instanceId: string;
+        }
+      | null
+      | undefined;
+
+    expect(
+      contribution.externalStateSource?.getSnapshotNodeState?.({
+        instanceId: seededLaunch?.instanceId ?? "",
+        typeId: agentGuiWorkbenchTypeId
+      } as never)
+    ).toMatchObject({
+      agentTargetId: "local:claude-code",
+      lastActiveAgentSessionId: "session-codex-1"
+    });
+
+    const relaunch = contribution.onLaunchRequest?.({
+      ...baseRequest,
+      payload: {
+        agentSessionId: "session-codex-1",
+        provider: "codex"
+      }
+    }) as
+      | {
+          instanceId: string;
+        }
+      | null
+      | undefined;
+
+    expect(relaunch?.instanceId).toBe(seededLaunch?.instanceId);
+    expect(
+      contribution.externalStateSource?.getSnapshotNodeState?.({
+        instanceId: relaunch?.instanceId ?? "",
+        typeId: agentGuiWorkbenchTypeId
+      } as never)
+    ).toEqual({
+      conversationRailCollapsed: false,
+      conversationRailWidthPx: null,
+      lastActiveAgentSessionId: "session-codex-1"
     });
   });
 
@@ -762,9 +827,7 @@ describe("agent GUI workbench contribution copy", () => {
       }
     });
 
-    expect(existingLaunch?.instanceId).toBe(
-      "agent-gui:codex:session:session-1"
-    );
+    expect(existingLaunch?.instanceId).toContain("agent-gui:codex:panel:");
     expect(newWindowLaunch?.instanceId).toContain("agent-gui:codex:panel:");
     expect(newWindowLaunch?.instanceId).not.toBe(existingLaunch?.instanceId);
     expect(existingLaunch?.cascadeOffset).toBeUndefined();
@@ -818,10 +881,62 @@ describe("agent GUI workbench contribution copy", () => {
       payload
     });
 
-    expect(firstLaunch?.instanceId).toBe("agent-gui:codex:session:session-1");
+    expect(firstLaunch?.instanceId).toContain("agent-gui:codex:panel:");
     expect(relaunch?.instanceId).toBe(firstLaunch?.instanceId);
     expect(firstLaunch?.preserveExistingNodeFrame).not.toBe(true);
     expect(relaunch?.preserveExistingNodeFrame).toBe(true);
+  });
+
+  it("does not treat a drifted session-keyed window as the requested session", async () => {
+    let rememberState: ((state: AgentGuiWorkbenchState) => void) | null = null;
+    const contribution = createTestAgentGuiWorkbenchContribution({
+      renderBody: (_context, helpers) => {
+        rememberState = helpers.onStateChange;
+        return null;
+      },
+      workspaceId: "workspace-1"
+    });
+
+    contribution.nodes?.[0]?.renderBody?.({
+      activation: null,
+      externalNodeState: null,
+      externalWorkspaceState: null,
+      instanceId: "agent-gui:codex:session:session-1",
+      instanceKey: null,
+      node: {
+        data: {
+          runtimeNodeState: null
+        },
+        displayMode: "floating",
+        frame: { height: 560, width: 1040, x: 0, y: 0 },
+        id: "legacy-session-node",
+        title: "Agent"
+      }
+    } as Parameters<
+      NonNullable<(typeof contribution.nodes)[number]["renderBody"]>
+    >[0]);
+    expect(rememberState).not.toBeNull();
+    (rememberState as unknown as (state: AgentGuiWorkbenchState) => void)({
+      conversationRailCollapsed: false,
+      conversationRailWidthPx: null,
+      lastActiveAgentSessionId: "session-2"
+    });
+
+    const relaunch = await contribution.onLaunchRequest?.({
+      layoutConstraints: testLaunchLayout.layoutConstraints,
+      payload: {
+        agentSessionId: "session-1",
+        provider: "codex"
+      },
+      reason: "host",
+      surfaceSize: testLaunchLayout.surfaceSize,
+      typeId: "agent-gui",
+      workspaceId: "workspace-1"
+    });
+
+    expect(relaunch?.instanceId).not.toBe("agent-gui:codex:session:session-1");
+    expect(relaunch?.instanceId).toContain("agent-gui:codex:panel:");
+    expect(relaunch?.preserveExistingNodeFrame).not.toBe(true);
   });
 
   it("keeps compact new-window session launches on the cascade policy", async () => {

--- a/packages/agent/gui/workbench/contribution.ts
+++ b/packages/agent/gui/workbench/contribution.ts
@@ -412,6 +412,8 @@ export function createAgentGuiWorkbenchContribution(
         launchPayload,
         provider
       );
+      const launchAgentTargetId =
+        providerTarget.agentTargetId ?? providerTarget.providerTargetId;
       if (targetAgentSessionId) {
         const previousState = nodeStateSource.readNodeState({
           instanceId,
@@ -424,12 +426,7 @@ export function createAgentGuiWorkbenchContribution(
             ...(targetAgentSessionId
               ? { lastActiveAgentSessionId: targetAgentSessionId }
               : {}),
-            ...(providerTarget.agentTargetId
-              ? { agentTargetId: providerTarget.agentTargetId }
-              : {}),
-            ...(providerTarget.providerTargetId
-              ? { agentTargetId: providerTarget.providerTargetId }
-              : {})
+            agentTargetId: launchAgentTargetId ?? null
           },
           typeId: agentGuiWorkbenchTypeId
         });

--- a/packages/agent/gui/workbench/launch.test.ts
+++ b/packages/agent/gui/workbench/launch.test.ts
@@ -85,17 +85,17 @@ describe("agent gui workbench launch contract", () => {
     ).toEqual({ kind: "legacyProvider", provider: "claude-code" });
   });
 
-  it("launches existing sessions into exact session instances", () => {
-    expect(
-      createAgentGuiWorkbenchLaunchDescriptor({
-        dockEntryId: "agent-gui",
-        payload: {
-          agentSessionId: "session-2",
-          provider: "codex"
-        },
-        typeId: "agent-gui"
-      })
-    ).toEqual({
+  it("launches sessions into provider panels until current session state can reuse a node", () => {
+    const descriptor = createAgentGuiWorkbenchLaunchDescriptor({
+      dockEntryId: "agent-gui",
+      payload: {
+        agentSessionId: "session-2",
+        provider: "codex"
+      },
+      typeId: "agent-gui"
+    });
+
+    expect(descriptor).toMatchObject({
       activation: {
         payload: {
           agentSessionId: "session-2"
@@ -103,10 +103,29 @@ describe("agent gui workbench launch contract", () => {
         type: "agent-gui:open-session"
       },
       dockEntryId: "agent-gui",
-      instanceId: "agent-gui:codex:session:session-2",
       openInNewWindow: false,
       provider: "codex",
       reuseDockEntryNode: false,
+      reuseExistingSessionNode: true,
+      targetAgentSessionId: "session-2"
+    });
+    expect(descriptor.instanceId).toContain("agent-gui:codex:panel:");
+  });
+
+  it("launches sessions with target metadata into target panels", () => {
+    expect(
+      createAgentGuiWorkbenchLaunchDescriptor({
+        dockEntryId: "agent-gui",
+        payload: {
+          agentSessionId: "session-2",
+          agentTargetId: "local:codex",
+          provider: "codex"
+        },
+        typeId: "agent-gui"
+      })
+    ).toMatchObject({
+      instanceId: "agent-gui:codex:target:local%3Acodex",
+      openInNewWindow: false,
       reuseExistingSessionNode: true,
       targetAgentSessionId: "session-2"
     });

--- a/packages/agent/gui/workbench/launch.ts
+++ b/packages/agent/gui/workbench/launch.ts
@@ -130,6 +130,7 @@ export function agentGuiWorkbenchProviderFromLaunchRequest(
 }
 
 export function createAgentGuiWorkbenchSessionLaunchRequest(input: {
+  agentTargetId?: string | null;
   agentSessionId?: string;
   openInNewWindow?: boolean;
   provider: unknown;
@@ -138,6 +139,9 @@ export function createAgentGuiWorkbenchSessionLaunchRequest(input: {
   return {
     dockEntryId: agentGuiWorkbenchDockEntryId(provider),
     payload: {
+      ...(input.agentTargetId?.trim()
+        ? { agentTargetId: input.agentTargetId.trim() }
+        : {}),
       ...(input.agentSessionId ? { agentSessionId: input.agentSessionId } : {}),
       ...(input.openInNewWindow ? { openInNewWindow: true } : {}),
       provider
@@ -235,7 +239,7 @@ export function createAgentGuiWorkbenchLaunchDescriptor(
   const targetAgentSessionId = agentSessionIdFromLaunchPayload(request.payload);
   const openInNewWindow = openInNewWindowFromLaunchPayload(request.payload);
   const instanceId = createAgentGuiWorkbenchInstanceId({
-    agentSessionId: openInNewWindow ? null : targetAgentSessionId,
+    agentSessionId: null,
     agentTargetId: openInNewWindow
       ? null
       : agentTargetIdFromLaunchPayload(request.payload),

--- a/services/tuttid/service/agentstatus/npm_registry_test.go
+++ b/services/tuttid/service/agentstatus/npm_registry_test.go
@@ -91,6 +91,7 @@ func TestRunExternalAgentRegistryNPMInstallerPurgesDirtyTreeBeforeRetry(t *testi
 	service := Service{
 		ManagedRuntime: fakeManagedRuntimeResolver(t, runtimeRoot),
 		Environ:        func() []string { return []string{"PATH=/usr/bin:/bin"} },
+		HTTPClient:     agentNPMRegistryProbeHTTPClient(nil),
 	}
 	spec := npmInstallerSpec(t)
 	nodeModules := filepath.Join(spec.RegistryNPM.PrefixDir, "node_modules")


### PR DESCRIPTION
## Summary
- make AgentGUI session launches session-authoritative so stale workbench instance ids do not reopen the wrong session
- keep explicitly opened sessions visible and selected in the rail even when they are outside the loaded page/section
- isolate the agentstatus npm registry purge-retry test from live registry ranking

## Validation
- pnpm check:changed --tail-lines 80
- pnpm check:full (pre-push)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved session-opening and reuse so the correct panel is opened even when sessions are already present or only partially loaded.
  * Active conversations remain visible during rail paging and when collapsing/expanding sections.

* **Bug Fixes**
  * Fixed stale targeting by clearing outdated provider/target constraints when opening sessions without matching target payloads.
  * Improved instance-id handling and rail transient behavior to prevent drift between requested and visible sessions.

* **Documentation**
  * Expanded architecture guidance for session-authoritative handling, new-window propagation, and rail projection semantics.  

* **Tests**
  * Added/updated coverage for stale targeting cleanup, transient rail selection, and session/panel instance-id behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->