### PR TITLE
fix(workspace-files): save absolute preview paths via daemon

### DIFF
--- a/apps/desktop/src/renderer/src/features/workspace-workbench/services/internal/workspaceFilePreviewNodeController.test.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/services/internal/workspaceFilePreviewNodeController.test.ts
@@ -1,0 +1,17 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import test from "node:test";
+
+const source = readFileSync(
+  new URL("./workspaceFilePreviewNodeController.ts", import.meta.url),
+  "utf8"
+);
+
+test("workspace file preview controller saves every text file through tuttid", () => {
+  assert.match(source, /await saveWorkspaceFilePreviewText\(\{/);
+  assert.doesNotMatch(
+    source,
+    /if \(isAbsoluteFilesystemPath\(target\.path\)\) \{\s*return;\s*\}/
+  );
+  assert.doesNotMatch(source, /writeLocalFileText/);
+});

--- a/apps/desktop/src/renderer/src/features/workspace-workbench/services/internal/workspaceFilePreviewNodeController.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/services/internal/workspaceFilePreviewNodeController.ts
@@ -17,6 +17,7 @@ import {
   workspaceFilePreviewNodeFileKey,
   type WorkspaceFilePreviewTextHeaderState
 } from "../../ui/workspaceFilePreviewNodeState.ts";
+import { saveWorkspaceFilePreviewText } from "./workspaceFilePreviewTextSave.ts";
 
 export type WorkspaceFilePreviewTextSaveStatus =
   | "error"
@@ -88,25 +89,37 @@ class WorkspaceFilePreviewNodeControllerImpl implements WorkspaceFilePreviewNode
   private loadGeneration = 0;
   private objectUrl: string | null = null;
   private readonly listeners = new Set<() => void>();
+  private readonly input: {
+    appI18n: I18nRuntime<string>;
+    hostFilesApi: Pick<DesktopHostFilesApi, "readLocalPreviewFile">;
+    i18n: WorkspaceWorkbenchDesktopI18nRuntime;
+    initialFile: WorkspaceFileActivationTarget | null;
+    tuttidClient: Pick<
+      TuttidClient,
+      "readWorkspaceFilePreview" | "writeWorkspaceFileText"
+    >;
+    onRuntimeStateChange(state: unknown): void;
+    onSnapshotStateChange(state: unknown): void;
+    workspaceID: string;
+  };
   private runtimeStateKey: string | null = null;
   private snapshotStateKey: string | null = null;
   private state: WorkspaceFilePreviewNodeControllerState;
 
-  constructor(
-    private readonly input: {
-      appI18n: I18nRuntime<string>;
-      hostFilesApi: Pick<DesktopHostFilesApi, "readLocalPreviewFile">;
-      i18n: WorkspaceWorkbenchDesktopI18nRuntime;
-      initialFile: WorkspaceFileActivationTarget | null;
-      tuttidClient: Pick<
-        TuttidClient,
-        "readWorkspaceFilePreview" | "writeWorkspaceFileText"
-      >;
-      onRuntimeStateChange(state: unknown): void;
-      onSnapshotStateChange(state: unknown): void;
-      workspaceID: string;
-    }
-  ) {
+  constructor(input: {
+    appI18n: I18nRuntime<string>;
+    hostFilesApi: Pick<DesktopHostFilesApi, "readLocalPreviewFile">;
+    i18n: WorkspaceWorkbenchDesktopI18nRuntime;
+    initialFile: WorkspaceFileActivationTarget | null;
+    tuttidClient: Pick<
+      TuttidClient,
+      "readWorkspaceFilePreview" | "writeWorkspaceFileText"
+    >;
+    onRuntimeStateChange(state: unknown): void;
+    onSnapshotStateChange(state: unknown): void;
+    workspaceID: string;
+  }) {
+    this.input = input;
     this.state = input.initialFile
       ? { entry: input.initialFile, status: "loading" }
       : { status: "empty" };
@@ -142,9 +155,6 @@ class WorkspaceFilePreviewNodeControllerImpl implements WorkspaceFilePreviewNode
     }
 
     const target = this.state.entry;
-    if (isAbsoluteFilesystemPath(target.path)) {
-      return;
-    }
     const targetKey = workspaceFilePreviewNodeFileKey(target);
     const content = this.state.draft;
 
@@ -156,13 +166,12 @@ class WorkspaceFilePreviewNodeControllerImpl implements WorkspaceFilePreviewNode
     );
 
     try {
-      await this.input.tuttidClient.writeWorkspaceFileText(
-        this.input.workspaceID,
-        {
-          content,
-          path: target.path
-        }
-      );
+      await saveWorkspaceFilePreviewText({
+        content,
+        path: target.path,
+        tuttidClient: this.input.tuttidClient,
+        workspaceID: this.input.workspaceID
+      });
       this.updateState((current) =>
         current.status === "text" &&
         workspaceFilePreviewNodeFileKey(current.entry) === targetKey

--- a/apps/desktop/src/renderer/src/features/workspace-workbench/services/internal/workspaceFilePreviewTextSave.test.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/services/internal/workspaceFilePreviewTextSave.test.ts
@@ -1,0 +1,35 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { saveWorkspaceFilePreviewText } from "./workspaceFilePreviewTextSave.ts";
+
+test("workspace file preview text save sends absolute paths through tuttid", async () => {
+  const writes: Array<{
+    content: string;
+    path: string;
+    workspaceID: string;
+  }> = [];
+  const absolutePath = "/Users/example/Downloads/skills/SKILL.md";
+
+  await saveWorkspaceFilePreviewText({
+    content: "updated",
+    path: absolutePath,
+    tuttidClient: {
+      async writeWorkspaceFileText(workspaceID, request) {
+        writes.push({
+          content: request.content,
+          path: request.path,
+          workspaceID
+        });
+      }
+    },
+    workspaceID: "workspace-1"
+  });
+
+  assert.deepEqual(writes, [
+    {
+      content: "updated",
+      path: absolutePath,
+      workspaceID: "workspace-1"
+    }
+  ]);
+});

--- a/apps/desktop/src/renderer/src/features/workspace-workbench/services/internal/workspaceFilePreviewTextSave.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/services/internal/workspaceFilePreviewTextSave.ts
@@ -1,0 +1,21 @@
+export interface WorkspaceFilePreviewTextSaveClient {
+  writeWorkspaceFileText(
+    workspaceID: string,
+    request: {
+      content: string;
+      path: string;
+    }
+  ): Promise<unknown>;
+}
+
+export async function saveWorkspaceFilePreviewText(input: {
+  content: string;
+  path: string;
+  tuttidClient: WorkspaceFilePreviewTextSaveClient;
+  workspaceID: string;
+}): Promise<void> {
+  await input.tuttidClient.writeWorkspaceFileText(input.workspaceID, {
+    content: input.content,
+    path: input.path
+  });
+}


### PR DESCRIPTION
Backport of #713 to release/0704.\n\nSource commit: c3aca64ef050d6b18c57cd4394080a681c700f8c\nBackport commit: ced011ece69fd6eb83cc55a587ecc0c35180c91f\n\nValidation:\n- pnpm --filter @tutti-os/desktop test\n- pnpm --filter @tutti-os/desktop typecheck\n- pnpm check:changed --tail-lines 80 (initial run hit parallel golangci-lint, failed-only rerun passed)\n- pnpm check:full (via pre-push)