### PR TITLE
fix(agent): resolve imported sessions inside a git worktree to their main checkout

### DIFF
--- a/services/tuttid/service/agent/external_import_parse.go
+++ b/services/tuttid/service/agent/external_import_parse.go
@@ -358,6 +358,18 @@ func normalizeExternalParsedSession(session externalImportedSession) (externalIm
 // cwd (never recorded) is rejected.
 func resolveExternalImportSessionCwd(raw string) (string, bool) {
 	if canonical, ok := canonicalExistingDir(raw); ok {
+		// A session that ran inside a linked git worktree (e.g. a coding
+		// agent's own per-task checkout under ~/.codex/worktrees/<id>/<repo>)
+		// still has its own `.git` file, so left unresolved it looks like an
+		// independent project rooted at the worktree instead of lining up
+		// with the main checkout the user actually registered as their
+		// project. Resolve it upfront so every downstream consumer of this
+		// cwd (project-path grouping, selection matching, and the persisted
+		// session record the GUI groups conversations by) agrees on the same
+		// canonical project identity.
+		if resolved, ok := resolveExternalImportWorktreeCwd(canonical); ok {
+			return resolved, true
+		}
 		return canonical, true
 	}
 	trimmed := strings.TrimSpace(raw)

--- a/services/tuttid/service/agent/external_import_projects.go
+++ b/services/tuttid/service/agent/external_import_projects.go
@@ -99,7 +99,19 @@ func externalImportNoProjectBucketPath() (string, bool) {
 func nearestExternalImportGitRoot(cwd string) (string, bool) {
 	current := filepath.Clean(cwd)
 	for current != "" {
-		if _, err := os.Stat(filepath.Join(current, ".git")); err == nil {
+		gitPath := filepath.Join(current, ".git")
+		if info, err := os.Lstat(gitPath); err == nil {
+			if !info.IsDir() {
+				// A `.git` *file* (rather than directory) at the nearest git
+				// root means current is a linked worktree, not the main
+				// checkout — resolve back to the main checkout so callers
+				// never treat an ephemeral per-task worktree as its own
+				// independent project. Fall back to current, unresolved, if
+				// that fails for any reason (e.g. malformed metadata).
+				if mainRoot, ok := resolveGitWorktreeMainRoot(gitPath); ok {
+					return mainRoot, true
+				}
+			}
 			return current, true
 		}
 		parent := filepath.Dir(current)
@@ -109,6 +121,97 @@ func nearestExternalImportGitRoot(cwd string) (string, bool) {
 		current = parent
 	}
 	return "", false
+}
+
+// resolveExternalImportWorktreeCwd walks up from cwd looking for the nearest
+// git root — a directory containing a `.git` entry, whether a real
+// directory (a normal/main checkout) or a `.git` *file* (the pointer git
+// leaves at the root of a linked worktree created via `git worktree add`).
+// When the nearest root turns out to be a linked worktree, it resolves back
+// to the *main* checkout's working-tree root and maps cwd onto the
+// equivalent path under that root, preserving any subdirectory depth.
+//
+// This matters because a coding agent (Codex, in particular) commonly runs
+// each task inside its own throwaway worktree, e.g.
+// ~/.codex/worktrees/8db5/tsh. That directory has its own `.git` file, so
+// naively it looks like its own independent git root/project — but it is
+// not the directory the user actually registered as their "tsh" project;
+// the main checkout is. Without this resolution, every session imported
+// from such a worktree gets grouped under (and, if registered, creates a
+// brand-new project card for) the ephemeral worktree path instead of lining
+// up with the user's real, already-registered project — leaving the real
+// project empty and the imported sessions stranded in the no-project
+// bucket.
+//
+// Returns ok=false whenever there's nothing to resolve — no git root found,
+// the root is a normal checkout, or the worktree's metadata can't be read
+// for any reason (malformed, main checkout since removed) — so callers can
+// safely keep using cwd unchanged.
+func resolveExternalImportWorktreeCwd(cwd string) (string, bool) {
+	current := filepath.Clean(cwd)
+	for current != "" {
+		gitPath := filepath.Join(current, ".git")
+		info, err := os.Lstat(gitPath)
+		if err != nil {
+			parent := filepath.Dir(current)
+			if parent == current {
+				return "", false
+			}
+			current = parent
+			continue
+		}
+		if info.IsDir() {
+			return "", false
+		}
+		mainRoot, ok := resolveGitWorktreeMainRoot(gitPath)
+		if !ok {
+			return "", false
+		}
+		rel, err := filepath.Rel(current, filepath.Clean(cwd))
+		if err != nil {
+			return "", false
+		}
+		return filepath.Clean(filepath.Join(mainRoot, rel)), true
+	}
+	return "", false
+}
+
+// resolveGitWorktreeMainRoot resolves a linked worktree's `.git` pointer
+// file (gitFilePath) back to the main checkout's working-tree root. It
+// follows the same two-step lookup git itself uses: the pointer file's
+// "gitdir: <path>" line names the worktree's private metadata directory
+// (<main>/.git/worktrees/<name>), and that directory's `commondir` file
+// names the shared .git directory it's relative to (normally "../.."). The
+// main checkout's root is that shared directory's parent.
+func resolveGitWorktreeMainRoot(gitFilePath string) (string, bool) {
+	data, err := os.ReadFile(gitFilePath)
+	if err != nil {
+		return "", false
+	}
+	const prefix = "gitdir:"
+	line := strings.TrimSpace(string(data))
+	if !strings.HasPrefix(line, prefix) {
+		return "", false
+	}
+	worktreeGitDir := strings.TrimSpace(strings.TrimPrefix(line, prefix))
+	if worktreeGitDir == "" {
+		return "", false
+	}
+	if !filepath.IsAbs(worktreeGitDir) {
+		worktreeGitDir = filepath.Join(filepath.Dir(gitFilePath), worktreeGitDir)
+	}
+	commonDirRaw, err := os.ReadFile(filepath.Join(worktreeGitDir, "commondir"))
+	if err != nil {
+		return "", false
+	}
+	commonDir := strings.TrimSpace(string(commonDirRaw))
+	if commonDir == "" {
+		return "", false
+	}
+	if !filepath.IsAbs(commonDir) {
+		commonDir = filepath.Join(worktreeGitDir, commonDir)
+	}
+	return canonicalExistingDir(filepath.Dir(filepath.Clean(commonDir)))
 }
 
 func externalImportSessionSummary(session externalImportedSession, projectPath string) ExternalImportSession {

--- a/services/tuttid/service/agent/service_test.go
+++ b/services/tuttid/service/agent/service_test.go
@@ -702,6 +702,168 @@ func TestExternalSessionProjectPathUsesGitRoot(t *testing.T) {
 	}
 }
 
+// writeExternalImportGitWorktreeFixture creates a fake main git checkout and
+// a linked worktree of it, matching the on-disk layout `git worktree add`
+// produces (a `.git` *file* at the worktree root pointing at
+// "<main>/.git/worktrees/<name>", whose own `commondir` file points back at
+// the shared/main .git directory), so tests can exercise worktree-to-main
+// resolution without shelling out to a real git binary.
+func writeExternalImportGitWorktreeFixture(t *testing.T, root string, name string) (mainRoot string, worktreeRoot string) {
+	t.Helper()
+	mainRoot = filepath.Join(root, "main-checkout")
+	worktreeRoot = filepath.Join(root, "worktrees", name)
+	worktreeMetaDir := filepath.Join(mainRoot, ".git", "worktrees", name)
+	if err := os.MkdirAll(filepath.Join(mainRoot, ".git"), 0o755); err != nil {
+		t.Fatalf("create main .git dir error = %v", err)
+	}
+	if err := os.MkdirAll(worktreeMetaDir, 0o755); err != nil {
+		t.Fatalf("create worktree metadata dir error = %v", err)
+	}
+	if err := os.MkdirAll(worktreeRoot, 0o755); err != nil {
+		t.Fatalf("create worktree root error = %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(worktreeMetaDir, "commondir"), []byte("../..\n"), 0o644); err != nil {
+		t.Fatalf("write commondir error = %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(worktreeMetaDir, "gitdir"), []byte(filepath.Join(worktreeRoot, ".git")+"\n"), 0o644); err != nil {
+		t.Fatalf("write gitdir error = %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(worktreeRoot, ".git"), []byte("gitdir: "+worktreeMetaDir+"\n"), 0o644); err != nil {
+		t.Fatalf("write worktree .git pointer error = %v", err)
+	}
+	if canonical, ok := canonicalExistingDir(mainRoot); ok {
+		mainRoot = canonical
+	}
+	if canonical, ok := canonicalExistingDir(worktreeRoot); ok {
+		worktreeRoot = canonical
+	}
+	return mainRoot, worktreeRoot
+}
+
+func TestResolveExternalImportWorktreeCwdResolvesToMainCheckout(t *testing.T) {
+	root := t.TempDir()
+	mainRoot, worktreeRoot := writeExternalImportGitWorktreeFixture(t, root, "8db5-tsh")
+	nested := filepath.Join(worktreeRoot, "apps", "foo")
+	if err := os.MkdirAll(nested, 0o755); err != nil {
+		t.Fatalf("create nested worktree dir error = %v", err)
+	}
+
+	resolvedRoot, ok := resolveExternalImportWorktreeCwd(worktreeRoot)
+	if !ok || resolvedRoot != mainRoot {
+		t.Fatalf("resolveExternalImportWorktreeCwd(root) = %q, %v; want main checkout %q", resolvedRoot, ok, mainRoot)
+	}
+
+	resolvedNested, ok := resolveExternalImportWorktreeCwd(nested)
+	wantNested := filepath.Join(mainRoot, "apps", "foo")
+	if !ok || resolvedNested != wantNested {
+		t.Fatalf("resolveExternalImportWorktreeCwd(nested) = %q, %v; want %q", resolvedNested, ok, wantNested)
+	}
+
+	// A normal (non-worktree) checkout must be left unresolved: its `.git`
+	// is a real directory, not a worktree pointer file.
+	normalRoot := filepath.Join(root, "normal-repo")
+	if err := os.MkdirAll(filepath.Join(normalRoot, ".git"), 0o755); err != nil {
+		t.Fatalf("create normal repo .git dir error = %v", err)
+	}
+	if _, ok := resolveExternalImportWorktreeCwd(normalRoot); ok {
+		t.Fatalf("resolveExternalImportWorktreeCwd(normalRoot) resolved a normal checkout, want unresolved")
+	}
+}
+
+func TestExternalSessionProjectPathResolvesLinkedWorktreeToMainCheckout(t *testing.T) {
+	root := t.TempDir()
+	mainRoot, worktreeRoot := writeExternalImportGitWorktreeFixture(t, root, "8db5-tsh")
+
+	got, ok := externalSessionProjectPath(externalImportedSession{
+		Provider: "codex",
+		Cwd:      worktreeRoot,
+	})
+	if !ok || got != mainRoot {
+		t.Fatalf(
+			"externalSessionProjectPath() = %q, %v; want the main checkout root %q, not the ephemeral worktree path %q",
+			got, ok, mainRoot, worktreeRoot,
+		)
+	}
+}
+
+// TestServiceImportedCodexWorktreeSessionGroupsUnderExistingMainCheckoutProject
+// reproduces the reported bug: a Codex session that ran inside a per-task
+// worktree of the user's "tsh" project (e.g.
+// ~/.codex/worktrees/8db5/tsh, a linked worktree of ~/Documents/New
+// project/tsh) got imported and stranded in the ungrouped "对话" bucket
+// instead of being grouped under the already-registered "tsh" project,
+// because the worktree checkout's own `.git` file made it look like an
+// independent project root distinct from the main checkout. Once resolved,
+// the imported session's project path — and its persisted cwd, which the
+// GUI uses to group conversations under project folders — must match the
+// main checkout, not the worktree.
+func TestServiceImportedCodexWorktreeSessionGroupsUnderExistingMainCheckoutProject(t *testing.T) {
+	ctx := context.Background()
+	store := openAgentServiceSQLiteStore(t)
+	if err := store.Create(ctx, workspacebiz.Summary{ID: "ws-1", Name: "Workspace One"}); err != nil {
+		t.Fatalf("Create workspace error = %v", err)
+	}
+	root := t.TempDir()
+	mainRoot, worktreeRoot := writeExternalImportGitWorktreeFixture(t, root, "8db5-tsh")
+
+	home := filepath.Join(root, "home")
+	if err := os.MkdirAll(home, 0o755); err != nil {
+		t.Fatalf("create home error = %v", err)
+	}
+	codexHome := filepath.Join(root, "codex-home")
+	t.Setenv("HOME", home)
+	t.Setenv("CODEX_HOME", codexHome)
+	t.Setenv("CLAUDE_CONFIG_DIR", filepath.Join(root, "claude-home"))
+	now := time.Now().UTC().Format(time.RFC3339Nano)
+	writeAgentServiceJSONL(t, filepath.Join(codexHome, "sessions", "worktree-session.jsonl"),
+		map[string]any{
+			"timestamp": now,
+			"type":      "session_meta",
+			"payload":   map[string]any{"id": "worktree-session", "cwd": worktreeRoot},
+		},
+		map[string]any{"timestamp": now, "type": "response_item", "payload": map[string]any{
+			"type": "message", "id": "worktree-session-1", "role": "user",
+			"content": []any{map[string]any{"type": "input_text", "text": "Send greeting"}},
+		}},
+	)
+
+	service := NewService(newFakeRuntime())
+	projection := NewActivityProjection(store)
+	service.SessionReader = projection
+	service.MessageReader = projection
+	service.ExternalImportStore = store
+
+	// The user already has "tsh" registered as a project at the main
+	// checkout — the same setup as the report, where the real project
+	// existed and stayed empty ("暂无对话") while the worktree-run session
+	// surfaced in the general conversations list instead.
+	result, err := service.ImportExternalSessions(ctx, "ws-1", ExternalImportInput{
+		Projects: []ExternalImportProjectSelection{{Path: mainRoot}},
+	})
+	if err != nil {
+		t.Fatalf("ImportExternalSessions error = %v", err)
+	}
+	if result.ImportedSessions != 1 {
+		t.Fatalf("import result = %#v, want one imported session", result)
+	}
+	if len(result.ProjectPaths) != 1 || result.ProjectPaths[0] != mainRoot {
+		t.Fatalf(
+			"import result ProjectPaths = %#v, want [%q] (the main checkout), not the ephemeral worktree path %q",
+			result.ProjectPaths, mainRoot, worktreeRoot,
+		)
+	}
+	session, err := service.Get(ctx, "ws-1", externalImportedSessionID("codex", "worktree-session"))
+	if err != nil {
+		t.Fatalf("Get imported worktree session error = %v", err)
+	}
+	if session.Cwd != mainRoot {
+		t.Fatalf(
+			"session.Cwd = %q, want it resolved to the main checkout %q so the GUI groups the conversation under the existing project instead of the ungrouped bucket",
+			session.Cwd, mainRoot,
+		)
+	}
+}
+
 func TestServiceImportsHomeCwdAsNoProjectWithoutRegisteringUserHome(t *testing.T) {
 	ctx := context.Background()
 	store := openAgentServiceSQLiteStore(t)


### PR DESCRIPTION
## Bug report

Importing a Codex session that had run inside project "tsh" left the real "tsh" project folder empty ("暂无对话") in the sidebar, while the imported conversations ("发送问候" / "搜索苹果与微软历史事件") showed up in the generic 对话 (ungrouped conversations) list instead.

## Root cause (log + code evidence)

From the user's diagnostic bundle (`tutti-logs-20260706-144546.zip`):

- `agent-sessions/codex/.../imported-codex-e99c43cf412c8932bb2de7aa/session.json` records `"cwd": "/Users/asdf/.codex/worktrees/8db5/tsh"` for the "发送问候" session — a per-task **git worktree** Codex created for that task, not the user's actual "tsh" checkout.
- Verified on disk: `/Users/asdf/.codex/worktrees/8db5/tsh/.git` is a worktree *pointer file* (`gitdir: /Users/asdf/Documents/New project/tsh/.git/worktrees/tsh`), not a real `.git` directory. `/Users/asdf/Documents/New project/tsh` is the real, registered "tsh" checkout (`git worktree list` confirms it as the main worktree).
- `nearestExternalImportGitRoot` (`services/tuttid/service/agent/external_import_projects.go`) walks up from a session's cwd looking for the nearest `.git` entry via `os.Stat`, which succeeds for **both** a `.git` directory and a `.git` file — so a linked worktree's own pointer file made it look like its own independent project root, distinct from the main checkout.
- The GUI groups conversations purely by walking up each session's *persisted* `cwd` looking for an ancestor match against the registered project paths (`packages/agent/gui/agent-gui/agentGuiNode/model/agentGuiConversationProjectResolver.ts`) — an ephemeral worktree path is never a filesystem ancestor of the main checkout it was branched from, so no amount of prefix-matching bridges the two, regardless of whether/where a project got registered for the worktree path.

Net effect: the worktree-run session's cwd never resolves to the user's real, already-registered "tsh" project, and the real project has no sessions whose cwd fall under it.

(A second report from the same investigation — a "整理 Codex Spark 对话" import — turned out to have a genuinely different root cause: its recorded cwd, `~/Documents/Codex/2026-07-06/zhe`, is a plain Codex scratch directory with no `.git` at all, correctly classified `NoProject` by existing, intentional design (see `isExternalImportCodexScratchCwd`). That case is not covered by this fix and needs separate investigation if it's still considered a bug.)

## Fix

Resolve a session's cwd through any linked git worktree back to the main checkout's working-tree root, upfront, in `resolveExternalImportSessionCwd` (`external_import_parse.go`) — using the same two-step lookup git itself uses (the `.git` file's `gitdir:` pointer, then that metadata directory's `commondir` file). This makes every downstream consumer (import-picker project grouping, selection matching, and the persisted session cwd the GUI groups conversations by) agree on the same canonical project identity. Also hardened `nearestExternalImportGitRoot` itself with the same resolution as defense in depth. Falls back to the original (unresolved) path whenever there's nothing to resolve, so non-worktree sessions are unaffected.

## Test plan
- [x] `go test ./services/tuttid/service/agent/...` — added `TestServiceImportedCodexWorktreeSessionGroupsUnderExistingMainCheckoutProject` (full import pipeline, reproduces the exact bug against a synthetic git-worktree fixture and confirms the session's project path/cwd resolves to the main checkout), plus focused unit tests `TestResolveExternalImportWorktreeCwdResolvesToMainCheckout` and `TestExternalSessionProjectPathResolvesLinkedWorktreeToMainCheckout`.
- [x] `go test ./services/tuttid/api/... ./services/tuttid/service/userproject/... ./services/tuttid/biz/userproject/...`
- [x] `go vet ./services/tuttid/...`
- [x] `gofmt -l` on changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Imported sessions now recognize linked Git worktrees and map them to the main repository checkout.
  * Session grouping is more consistent when worktree-based runs belong to an existing project.

* **Bug Fixes**
  * Fixed incorrect path handling for existing directories in linked worktree setups.
  * Improved project detection so imported conversations appear under the expected repository root.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->