### PR TITLE
fix(codex): retry turn/interrupt against codex's reported active turn id

### DIFF
--- a/packages/agent/daemon/runtime/codex_appserver_adapter.go
+++ b/packages/agent/daemon/runtime/codex_appserver_adapter.go
@@ -2433,12 +2433,32 @@ func (*CodexAppServerAdapter) sendThreadInterrupt(
 	if client == nil || threadID == "" {
 		return
 	}
-	interruptCtx, cancel := context.WithTimeout(context.Background(), acpPermissionModeTimeout)
-	defer cancel()
-	if _, err := client.TurnInterruptNoHandler(interruptCtx, acpPermissionModeTimeout, map[string]any{
-		"threadId": threadID,
-		"turnId":   strings.TrimSpace(turnID),
-	}); err != nil {
+	turnID = strings.TrimSpace(turnID)
+	err := codexSendTurnInterruptOnce(client, threadID, turnID)
+	if err != nil {
+		// Our own turn bookkeeping settles a turn locally as soon as its Go
+		// context is canceled (see Cancel/interruptActiveTurn), without
+		// waiting for the app-server to actually confirm the turn stopped.
+		// When a slow-to-terminate tool call (for example wait_agent on
+		// several dispatched sub-agents) keeps the app-server's real turn
+		// alive past that point, a subsequent interrupt aimed at the turn id
+		// we *think* is active gets rejected with "expected active turn id X
+		// but found Y". Retry once against Y so the real, still-running turn
+		// actually gets interrupted instead of being abandoned to die on its
+		// own — which otherwise can leave it running for minutes.
+		if foundTurnID, ok := codexExpectedActiveTurnIDMismatch(err); ok && foundTurnID != turnID {
+			slog.Warn("agent session app-server interrupt turn id stale, retrying",
+				"event", "agent_session.app_server.interrupt.turn_id_stale",
+				"agent_session_id", session.AgentSessionID,
+				"provider_session_id", threadID,
+				"requested_turn_id", turnID,
+				"actual_turn_id", foundTurnID,
+				"reason", reason,
+			)
+			err = codexSendTurnInterruptOnce(client, threadID, foundTurnID)
+		}
+	}
+	if err != nil {
 		slog.Warn("agent session app-server interrupt failed",
 			"event", "agent_session.app_server.interrupt.failed",
 			"agent_session_id", session.AgentSessionID,
@@ -2448,6 +2468,49 @@ func (*CodexAppServerAdapter) sendThreadInterrupt(
 			"error", err.Error(),
 		)
 	}
+}
+
+func codexSendTurnInterruptOnce(client *codexAppServerClient, threadID, turnID string) error {
+	interruptCtx, cancel := context.WithTimeout(context.Background(), acpPermissionModeTimeout)
+	defer cancel()
+	_, err := client.TurnInterruptNoHandler(interruptCtx, acpPermissionModeTimeout, map[string]any{
+		"threadId": threadID,
+		"turnId":   turnID,
+	})
+	return err
+}
+
+// codexExpectedActiveTurnIDMismatch recognizes the codex app-server's
+// turn/interrupt rejection for a stale expected turn id: "expected active
+// turn id <requested> but found <actual>". It reports actual so the caller
+// can retry against the turn codex itself considers active. JSON-RPC -32600
+// is the generic "invalid request" code the app-server reuses for several
+// distinct rejections (see isACPProviderSessionNotFound), so this keys off
+// the distinctive message text rather than the code.
+func codexExpectedActiveTurnIDMismatch(err error) (string, bool) {
+	var callErr *acpCallError
+	if !errors.As(err, &callErr) || callErr == nil {
+		return "", false
+	}
+	message := strings.TrimSpace(callErr.Err.Message)
+	lower := strings.ToLower(message)
+	if !strings.Contains(lower, "expected active turn id") {
+		return "", false
+	}
+	const marker = "but found "
+	idx := strings.LastIndex(lower, marker)
+	if idx < 0 {
+		return "", false
+	}
+	rest := strings.TrimSpace(message[idx+len(marker):])
+	if sp := strings.IndexAny(rest, " \t\n"); sp >= 0 {
+		rest = rest[:sp]
+	}
+	rest = strings.Trim(rest, ".,;")
+	if rest == "" {
+		return "", false
+	}
+	return rest, true
 }
 
 func (a *CodexAppServerAdapter) interruptLinkedChildThreads(

--- a/packages/agent/daemon/runtime/codex_appserver_adapter_test.go
+++ b/packages/agent/daemon/runtime/codex_appserver_adapter_test.go
@@ -71,6 +71,8 @@ type scriptedAppServerConnection struct {
 	steeredTurnStart             bool              // turn/start returns a queued stub turn (input steered into the running turn): no turn/started, no auto-completion
 	ignoreInterrupt              bool              // ack turn/interrupt but never complete the turn (wedged codex)
 	hangInterrupt                bool              // never even acknowledge the turn/interrupt RPC (fully wedged codex)
+	interruptTurnIDMismatch      string            // reject the first turn/interrupt with "expected active turn id X but found <this>"; a retry against the reported id succeeds
+	interruptAttempts            []string          // turnId requested on every turn/interrupt call, in order
 	childNicknames               map[string]string // thread/read agentNickname responses by threadId
 	turnStartEntered             chan struct{}
 	turnStartRelease             chan struct{}
@@ -494,9 +496,30 @@ func (c *scriptedAppServerConnection) Send(data []byte) error {
 			c.turnStatus = "interrupted"
 			ignore := c.ignoreInterrupt
 			hang := c.hangInterrupt
+			mismatchTurnID := c.interruptTurnIDMismatch
+			requestedTurnID := asString(message.Params["turnId"])
+			c.interruptAttempts = append(c.interruptAttempts, requestedTurnID)
 			c.mu.Unlock()
 			if hang {
 				// Fully wedged codex: never even acknowledge the interrupt RPC.
+				continue
+			}
+			if mismatchTurnID != "" && requestedTurnID != mismatchTurnID {
+				// Mirror codex rejecting a stale expected turn id (live
+				// -32600 "invalid request" shape): the client's own turn
+				// bookkeeping raced ahead of what codex still considers
+				// active (e.g. a slow-to-terminate wait_agent call kept the
+				// real turn alive past our local cancel). Only the retry
+				// against the reported id (mismatchTurnID) is honored.
+				c.sendJSON(map[string]any{
+					"id": message.ID,
+					"error": map[string]any{
+						"code": -32600,
+						"message": fmt.Sprintf(
+							"expected active turn id %s but found %s", requestedTurnID, mismatchTurnID,
+						),
+					},
+				})
 				continue
 			}
 			c.sendJSON(map[string]any{"id": message.ID, "result": map[string]any{}})
@@ -1893,6 +1916,79 @@ func TestCodexAppServerAdapterCancelForceCloseIsBoundedByGrace(t *testing.T) {
 	case <-execDone:
 	case <-time.After(2 * time.Second):
 		t.Fatalf("Exec did not finish after force cancel")
+	}
+}
+
+// TestCodexAppServerAdapterCancelRetriesInterruptOnStaleTurnID reproduces a
+// real production incident: our own turn bookkeeping settles a turn locally
+// as soon as its Go context is canceled (Cancel/interruptActiveTurn), without
+// waiting for the app-server to confirm the turn actually stopped. When a
+// slow-to-terminate tool call (live case: wait_agent blocking on several
+// dispatched sub-agents) keeps the real app-server turn alive past that
+// point, the *next* interrupt we send — aimed at the turn id we believe is
+// active — gets rejected with "expected active turn id X but found Y"
+// (live-captured, codex 0.142.5, JSON-RPC -32600). Left unhandled, the real
+// stale turn is never actually interrupted and keeps running/emitting items
+// on its own timeline, which is what left a session stuck reporting "regulat-
+// ing next step" long after the visible conversation looked finished. The
+// adapter must retry the interrupt against the turn id codex reports as
+// actually active.
+func TestCodexAppServerAdapterCancelRetriesInterruptOnStaleTurnID(t *testing.T) {
+	t.Parallel()
+
+	adapter, transport, session := startedAppServerAdapter(t)
+	transport.conn.holdTurn = true
+	// codex reports "turn-stale" as its real active turn, not the "turn-1" id
+	// our own bookkeeping expects — mirrors the daemon racing ahead of the
+	// app-server's turn teardown.
+	transport.conn.interruptTurnIDMismatch = "turn-stale"
+
+	execDone := make(chan []activityshared.Event, 1)
+	go func() {
+		events, _ := adapter.Exec(context.Background(), session, []PromptContentBlock{{
+			Type: "text", Text: "long task",
+		}}, "", "turn-local-1", nil, nil)
+		execDone <- events
+	}()
+	waitForCondition(t, func() bool {
+		return adapter.sessionActiveTurnID(session.AgentSessionID) == "turn-1"
+	})
+
+	cancelReturned := make(chan error, 1)
+	go func() {
+		_, err := adapter.Cancel(context.Background(), session, "user requested")
+		cancelReturned <- err
+	}()
+	select {
+	case err := <-cancelReturned:
+		if err != nil {
+			t.Fatalf("Cancel: %v", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatalf("Cancel did not return")
+	}
+
+	waitForCondition(t, func() bool {
+		transport.conn.mu.Lock()
+		defer transport.conn.mu.Unlock()
+		return len(transport.conn.interruptAttempts) >= 2
+	})
+	transport.conn.mu.Lock()
+	attempts := append([]string(nil), transport.conn.interruptAttempts...)
+	transport.conn.mu.Unlock()
+	if len(attempts) != 2 || attempts[0] != "turn-1" || attempts[1] != "turn-stale" {
+		t.Fatalf("interrupt attempts = %#v, want [turn-1 turn-stale]", attempts)
+	}
+
+	select {
+	case events := <-execDone:
+		completed := eventsOfType(events, activityshared.EventTurnCompleted)
+		if len(completed) != 1 ||
+			completed[0].Payload.TurnOutcome != string(activityshared.TurnOutcomeInterrupted) {
+			t.Fatalf("expected interrupted outcome, got %#v", events)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatalf("Exec did not finish after retried interrupt")
 	}
 }
 


### PR DESCRIPTION
## Summary
- Root-caused a live production incident: a Codex conversation ignored a "stop" message for ~3 minutes and then got stuck reporting "regulating next step" (turn never settled). Log analysis shows our `Cancel`/`interruptActiveTurn` path marks a turn "canceled" locally as soon as its Go context is canceled, without waiting for the app-server to actually confirm the turn stopped — it just fires the `turn/interrupt` RPC in the background and moves on. When a slow-to-terminate tool call (here: `wait_agent` blocking on several dispatched sub-agents) keeps the *real* app-server turn alive past that point, the next interrupt we send targets the turn id we believe is active and codex rejects it with `expected active turn id X but found Y` (JSON-RPC -32600, codex 0.142.5, captured live in production logs). The rejection was previously only logged — the real, still-running turn was never actually interrupted and kept emitting items on its own until codex's internal teardown eventually finished.
- Adds `codexExpectedActiveTurnIDMismatch` to recognize this specific rejection shape and retries `turn/interrupt` once against the turn id codex reports as actually active, so the real turn gets stopped instead of being abandoned to die on its own.
- This is a different failure mode than PR #763 (steer-settle-miss, already on main) and the hand-written `turn/steer` 10s timeout (currently only on `release/0704-hotfix-20260706`, not main): those address terminal-notification routing and RPC hang bounds respectively; this addresses the *interrupt request itself* being rejected due to stale turn-id bookkeeping.

## Test plan
- [x] New regression test `TestCodexAppServerAdapterCancelRetriesInterruptOnStaleTurnID` reproduces the exact rejection shape and asserts the adapter retries with the corrected turn id and the turn reaches a genuine `interrupted` terminal state.
- [x] `go test ./packages/agent/daemon/runtime/...` passes (full package, no regressions).
- [x] `go vet ./packages/agent/daemon/runtime/...` clean.
- [x] `gofmt -l` clean on changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cancel handling so interruptions are retried automatically when the app server reports a stale active turn.
  * Fixed cases where a cancel request could fail if the active turn ID changed between request and execution.
  * Added stronger validation to ensure the interruption uses the current active turn before settling the request.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->