### PR TITLE
fix(agent): sync draft model before promote, avoid usage-reload debounce starvation

### DIFF
--- a/apps/desktop/src/renderer/src/features/workspace-agent/services/desktopAgentActivityAdapter.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-agent/services/desktopAgentActivityAdapter.ts
@@ -369,17 +369,12 @@ export function createDesktopAgentActivityAdapter({
         workspaceId: input.workspaceId
       });
       try {
-        const promoted = await promoteClaudeDraft(input);
-        if (promoted) {
-          reportDesktopAgentSubmitTrace(runtimeApi, {
-            agentSessionId: promoted.agentSessionId,
-            event: "renderer_adapter.create.promoted_draft",
-            metadata: input.metadata,
-            provider: promoted.provider,
-            workspaceId: input.workspaceId
-          });
-          return promoted;
-        }
+        // Always resync the pre-warmed draft's settings (model/permission/etc.)
+        // to what was just submitted before promoting it. The draft is patched
+        // in place asynchronously whenever composer settings change (see
+        // ensureClaudeDraft above), so promoting the cached entry directly here
+        // could race ahead of an in-flight settings patch and send the message
+        // to a session still running the previous (e.g. default) model.
         if (
           workspaceAgentProvider(input.provider) === "claude-code" &&
           (input.initialContent?.length ?? 0) > 0
@@ -404,8 +399,26 @@ export function createDesktopAgentActivityAdapter({
             agentSessionId: draft.id
           });
           if (promotedDraft) {
+            reportDesktopAgentSubmitTrace(runtimeApi, {
+              agentSessionId: promotedDraft.agentSessionId,
+              event: "renderer_adapter.create.promoted_draft",
+              metadata: input.metadata,
+              provider: promotedDraft.provider,
+              workspaceId: input.workspaceId
+            });
             return promotedDraft;
           }
+        }
+        const promoted = await promoteClaudeDraft(input);
+        if (promoted) {
+          reportDesktopAgentSubmitTrace(runtimeApi, {
+            agentSessionId: promoted.agentSessionId,
+            event: "renderer_adapter.create.promoted_draft",
+            metadata: input.metadata,
+            provider: promoted.provider,
+            workspaceId: input.workspaceId
+          });
+          return promoted;
         }
         const agentSessionId =
           input.agentSessionId?.trim() || createDesktopAgentActivitySessionId();

--- a/apps/desktop/src/renderer/src/features/workspace-agent/services/internal/workspaceAgentActivityService.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-agent/services/internal/workspaceAgentActivityService.ts
@@ -1436,6 +1436,12 @@ export class WorkspaceAgentActivityService implements IWorkspaceAgentActivitySer
       return true;
     }
     const entry = this.controllerEntry(input.workspaceId);
+    const beforeSession =
+      entry.controller
+        .getSnapshot()
+        .sessions.find(
+          (session) => session.agentSessionId === input.agentSessionId
+        ) ?? null;
     const result = entry.controller.applyActivityUpdatedEvent({
       agentSessionId: input.agentSessionId,
       data: input.data,
@@ -1447,19 +1453,40 @@ export class WorkspaceAgentActivityService implements IWorkspaceAgentActivitySer
         agentSessionId: input.agentSessionId,
         traceEvent: "inline.not_applied",
         workspaceId: input.workspaceId,
-        fields: { eventType: input.eventType }
+        fields: {
+          beforeSession:
+            agentActivitySessionReconcileDiagnosticDetails(beforeSession),
+          dataSummary: agentActivityUpdateDataReconcileDiagnosticDetails(
+            input.data
+          ),
+          eventType: input.eventType
+        }
       });
       return false;
     }
+    const afterSession =
+      entry.controller
+        .getSnapshot()
+        .sessions.find(
+          (session) => session.agentSessionId === input.agentSessionId
+        ) ?? null;
     this.reportReconcileTrace({
       agentSessionId: input.agentSessionId,
       traceEvent: "inline.applied",
       workspaceId: input.workspaceId,
       fields: {
+        afterSession:
+          agentActivitySessionReconcileDiagnosticDetails(afterSession),
+        beforeSession:
+          agentActivitySessionReconcileDiagnosticDetails(beforeSession),
+        dataSummary: agentActivityUpdateDataReconcileDiagnosticDetails(
+          input.data
+        ),
         eventType: input.eventType,
         incomingSession: agentActivitySessionReconcileDiagnosticDetails(
           result.session
         ),
+        messageUpdateCount: result.messages.length,
         statePatch: agentActivityStatePatchReconcileDiagnosticDetails(
           result.statePatch
         )
@@ -1574,6 +1601,24 @@ function agentActivityStatePatchReconcileDiagnosticDetails(
     turnPhase: patch.turn?.phase ?? null,
     turnSubmitAvailabilityState: patch.turn?.submitAvailability?.state ?? null,
     updatedAtUnixMs: patch.occurredAtUnixMs ?? null
+  };
+}
+
+function agentActivityUpdateDataReconcileDiagnosticDetails(
+  data: unknown
+): Record<string, unknown> {
+  const source = recordValue(data);
+  const runtimeContext = recordValue(source?.runtimeContext);
+  return {
+    hasCurrentPhase: source?.currentPhase !== undefined,
+    hasInlineMessages: hasInlineMessagesData(data),
+    hasLifecycleStatus: source?.lifecycleStatus !== undefined,
+    hasRuntimeContext: runtimeContext !== null,
+    hasRuntimeContextUsage: recordValue(runtimeContext?.usage) !== null,
+    hasSubmitAvailability: source?.submitAvailability !== undefined,
+    hasTurn: source?.turn !== undefined,
+    inlineMessageCount: inlineMessagesFromActivityUpdateData(data).length,
+    isTerminalMessageUpdate: isTerminalActivityMessageUpdate(data)
   };
 }
 

--- a/docs/architecture/agent-gui-node.md
+++ b/docs/architecture/agent-gui-node.md
@@ -721,6 +721,13 @@ Inline state patches are fast-path updates; message and session updates may
 require a fetch so the controller snapshot remains authoritative. UI code
 should debug both the event payload and the reconcile fetch before treating a
 missing transcript row as a rendering-only bug.
+Active-conversation control state, including `runtimeContext.usage`, is a
+separate session-state read layered over the transcript stream. Both
+`state_patch` and `message_update` activity events must be treated as signals
+to refresh that state for the active AgentGuiNode, because provider usage can
+advance while assistant text or tool calls are streaming and before a terminal
+session-state patch arrives. Debounce these refreshes, but do not filter out
+message updates just because the transcript projection already consumed them.
 
 Live display-only clocks in transcript rows, such as running sub-agent elapsed
 time, are UI-local interaction state. Do not derive a running timer solely from
@@ -983,6 +990,10 @@ User-visible rules:
 - Active session settings are session state. Opening, restoring, or editing an
   active session must not promote that session's model, permission mode, or
   reasoning setting into user defaults.
+- Claude Code model aliases must stay explicit end to end. Treat `default` as
+  the runtime's mutable default choice, not as an alias for Opus or any other
+  tier; if an Opus selection is submitted, daemon validation, session settings,
+  runtime prepare, and runtime start should all carry `opus`.
 - Workbench node `composerOverrides` are UI-local home/new composer draft state,
   not an authoritative source for desktop preferences.
 - Draft clearing happens only after the submitted content still matches the

--- a/docs/conventions/troubleshooting.md
+++ b/docs/conventions/troubleshooting.md
@@ -67,22 +67,31 @@ Use this shape for new entries:
   map keyed by model id, for example
   `modelUsage["claude-sonnet-5"].contextWindow`. If either sidecar or daemon
   only parses array-shaped `modelUsage`, the context-window total is missing and
-  daemon normalization falls back to 200k.
+  daemon normalization falls back to 200k. Streaming `message_delta` usage can
+  also arrive before the result `modelUsage`; in that phase, the live SDK
+  context snapshot may not reach the daemon before the user inspects usage, so
+  daemon normalization still needs a model-option context-window fallback.
 - Fix:
   Parse `modelUsage` recursively as both arrays and maps before using fallback
   context-window values. Track the model associated with a cached context
   window, and only reuse the previous total for the same model or when the model
   is unknown. Treat `runtimeContext.usage` as incremental telemetry in AgentGUI
   reload races: a full session-control snapshot that omits usage should not
-  clear the previous usage display. Do not hard-code alias-to-model mappings in
-  Tutti.
+  clear the previous usage display. Trigger one best-effort context-usage
+  snapshot when stream usage first appears for a turn, and read
+  `rawMaxTokens` before falling back to `maxTokens`. In the daemon, use explicit
+  context-window fallbacks for canonical Claude Code model options such as
+  `sonnet` only when the payload has no total and there is no model-specific
+  `modelUsage` value. Do not hard-code alias-to-model-id mappings in Tutti.
 - Validation:
   Add sidecar and daemon coverage with map-shaped `modelUsage` carrying
   `contextWindow: 1_000_000`, plus daemon coverage for Haiku -> Sonnet5 -> Haiku
-  usage updates where the last payload lacks `totalTokens`. Add AgentGUI
-  coverage for session-control reloads that omit `runtimeContext.usage`. Then
-  run the Claude SDK sidecar tests, daemon Go tests, AgentGUI tests, and
-  typechecks.
+  usage updates where the last payload lacks `totalTokens`. Add daemon coverage
+  for stream `sonnet` usage with no total resolving to the 1M context window.
+  Add sidecar coverage for stream usage that emits a context snapshot with
+  `rawMaxTokens` before `turn_completed`, and AgentGUI coverage for
+  session-control reloads that omit `runtimeContext.usage`. Then run the Claude
+  SDK sidecar tests, daemon Go tests, AgentGUI tests, and typechecks.
 - References:
   [main.ts](../../packages/agent/claude-sdk-sidecar/src/main.ts)
   [main.test.ts](../../packages/agent/claude-sdk-sidecar/src/main.test.ts)

--- a/packages/agent/claude-sdk-sidecar/src/main.test.ts
+++ b/packages/agent/claude-sdk-sidecar/src/main.test.ts
@@ -336,6 +336,61 @@ test("context usage prefers result modelUsage window over SDK maxTokens", async 
   }
 });
 
+test("stream usage requests context window snapshot before result", async () => {
+  const events: Array<{ type: string; payload?: Record<string, unknown> }> = [];
+  const restoreSink = withSidecarEventSinkForTest((event) =>
+    events.push(event)
+  );
+  try {
+    const session = new SessionRuntime(
+      "provider-session-1",
+      "/repo",
+      {},
+      false,
+      false,
+      {
+        model: "sonnet",
+        permissionModeId: "default",
+        planMode: false,
+        effort: "",
+        speed: ""
+      },
+      sidecarClaudeOptionsFromPayload({}),
+      undefined,
+      ({ prompt }) => fakeStreamUsageContextQuery(prompt)
+    );
+
+    await session.start();
+    session.exec("turn-1", "hi");
+    await waitForMatchingEvent(
+      events,
+      (event) =>
+        event.type === "usage_updated" && isRecord(event.payload?.contextWindow)
+    );
+    await waitForEvent(events, "turn_completed");
+
+    const usage = events.find(
+      (event) =>
+        event.type === "usage_updated" && isRecord(event.payload?.contextWindow)
+    );
+    const contextWindow = isRecord(usage?.payload?.contextWindow)
+      ? usage.payload.contextWindow
+      : undefined;
+    assert.equal(contextWindow?.usedTokens, 36_664);
+    assert.equal(contextWindow?.totalTokens, 1_000_000);
+    const contextIndex = events.findIndex(
+      (event) =>
+        event.type === "usage_updated" && isRecord(event.payload?.contextWindow)
+    );
+    const completionIndex = events.findIndex(
+      (event) => event.type === "turn_completed"
+    );
+    assert(contextIndex >= 0 && contextIndex < completionIndex);
+  } finally {
+    restoreSink();
+  }
+});
+
 test("late compact boundary still attaches to slash compact turn", async () => {
   const events: Array<{ type: string; payload?: Record<string, unknown> }> = [];
   const restoreSink = withSidecarEventSinkForTest((event) =>
@@ -1399,6 +1454,56 @@ function fakeContextUsageQuery(
     async getContextUsage() {
       return {
         totalTokens: 36_092,
+        maxTokens: 200_000,
+        rawMaxTokens: 1_000_000
+      };
+    },
+    close() {}
+  };
+}
+
+function fakeStreamUsageContextQuery(
+  prompt: AsyncIterable<SDKUserMessage>
+): AsyncIterable<SDKMessage> & {
+  getContextUsage: () => Promise<unknown>;
+  close: () => void;
+} {
+  return {
+    async *[Symbol.asyncIterator]() {
+      const firstPrompt = await prompt[Symbol.asyncIterator]().next();
+      const promptMessage = firstPrompt.value as SDKUserMessage & {
+        uuid?: string;
+      };
+      yield {
+        ...promptMessage,
+        uuid: promptMessage.uuid,
+        type: "user",
+        parent_tool_use_id: null,
+        session_id: "provider-session-1"
+      } as SDKMessage;
+      yield {
+        type: "stream_event",
+        uuid: "stream-message-delta",
+        parent_tool_use_id: null,
+        session_id: "provider-session-1",
+        event: {
+          type: "message_delta",
+          usage: {
+            input_tokens: 2,
+            output_tokens: 18,
+            cache_read_input_tokens: 18_000,
+            cache_creation_input_tokens: 600
+          }
+        }
+      } as unknown as SDKMessage;
+      yield {
+        type: "result",
+        subtype: "success"
+      } as unknown as SDKMessage;
+    },
+    async getContextUsage() {
+      return {
+        totalTokens: 36_664,
         maxTokens: 200_000,
         rawMaxTokens: 1_000_000
       };
@@ -2784,5 +2889,24 @@ async function waitForEvent(
   }
   assert.fail(
     `timed out waiting for ${type}; events=${JSON.stringify(events)}`
+  );
+}
+
+async function waitForMatchingEvent(
+  events: Array<{ type: string; payload?: Record<string, unknown> }>,
+  predicate: (event: {
+    type: string;
+    payload?: Record<string, unknown>;
+  }) => boolean
+): Promise<void> {
+  const deadline = Date.now() + 1000;
+  while (Date.now() < deadline) {
+    if (events.some(predicate)) {
+      return;
+    }
+    await new Promise((resolve) => setTimeout(resolve, 10));
+  }
+  assert.fail(
+    `timed out waiting for matching event; events=${JSON.stringify(events)}`
   );
 }

--- a/packages/agent/claude-sdk-sidecar/src/main.ts
+++ b/packages/agent/claude-sdk-sidecar/src/main.ts
@@ -264,6 +264,7 @@ export class SessionRuntime {
   private compactionInProgress = false;
   private compactCommandTurnId = "";
   private readonly completedCompactTurnIds = new Set<string>();
+  private readonly contextUsageSnapshotTurnIds = new Set<string>();
   private pendingOrphanResults = 0;
   private consuming = false;
   private initialized = false;
@@ -1166,6 +1167,7 @@ export class SessionRuntime {
               usage
             }
           });
+          this.requestContextUsageSnapshot(this.activeTurnId);
         }
         return;
       }
@@ -1873,6 +1875,7 @@ export class SessionRuntime {
       const usedTokens = numberValue(contextUsage.totalTokens);
       const contextWindowTokens =
         contextWindowTokensFromModelUsage(options.modelUsage) ||
+        numberValue(contextUsage.rawMaxTokens) ||
         numberValue(contextUsage.maxTokens);
       if (usedTokens <= 0 && contextWindowTokens <= 0) {
         return;
@@ -1889,6 +1892,14 @@ export class SessionRuntime {
     } catch {
       // Context usage is best-effort; result usage remains available.
     }
+  }
+
+  private requestContextUsageSnapshot(turnId: string): void {
+    if (!turnId || this.contextUsageSnapshotTurnIds.has(turnId)) {
+      return;
+    }
+    this.contextUsageSnapshotTurnIds.add(turnId);
+    void this.emitContextUsageSnapshot(turnId);
   }
 
   private appendAssistantSegmentDelta(

--- a/packages/agent/daemon/runtime/claude_sdk_adapter_test.go
+++ b/packages/agent/daemon/runtime/claude_sdk_adapter_test.go
@@ -1952,6 +1952,42 @@ func TestClaudeCodeSDKAdapterMapsUsageUpdatedIntoRuntimeContext(t *testing.T) {
 	}
 }
 
+func TestClaudeCodeSDKAdapterUsesSonnetContextWindowForStreamUsage(t *testing.T) {
+	adapter := NewClaudeCodeSDKAdapter(nil)
+	session := standardTestSession(ProviderClaudeCode)
+	adapterSession := &claudeSDKAdapterSession{liveState: newClaudeSDKLiveState()}
+	adapter.storeSession(session.AgentSessionID, adapterSession)
+	adapterSession.applyConfigOption("model", "sonnet")
+
+	events, terminal, err := adapter.sidecarTurnEvents(adapterSession, session, "turn-1", claudeSDKSidecarEvent{
+		Type: "usage_updated",
+		Payload: map[string]any{
+			"turnId": "turn-1",
+			"usage": map[string]any{
+				"input_tokens":                2,
+				"output_tokens":               145,
+				"cache_read_input_tokens":     18_622,
+				"cache_creation_input_tokens": 17_688,
+			},
+		},
+	})
+	if err != nil || terminal {
+		t.Fatalf("usage_updated terminal=%v err=%v", terminal, err)
+	}
+	if len(events) != 1 || events[0].Type != activityshared.EventSessionUpdated {
+		t.Fatalf("usage events = %#v, want session.updated", events)
+	}
+	state := adapter.SessionState(session)
+	usage, _ := state.RuntimeContext["usage"].(map[string]any)
+	contextWindow, _ := usage["contextWindow"].(map[string]any)
+	if got, ok := acpInt64Value(contextWindow["usedTokens"]); !ok || got != 36_457 {
+		t.Fatalf("usedTokens = %#v, want 36457", contextWindow["usedTokens"])
+	}
+	if got, ok := acpInt64Value(contextWindow["totalTokens"]); !ok || got != claudeSDKLargeContextWindow {
+		t.Fatalf("totalTokens = %#v, want large context window", contextWindow["totalTokens"])
+	}
+}
+
 func TestClaudeCodeSDKAdapterMapsModelUsageContextWindowMap(t *testing.T) {
 	adapter := NewClaudeCodeSDKAdapter(nil)
 	session := standardTestSession(ProviderClaudeCode)

--- a/packages/agent/daemon/runtime/controller.go
+++ b/packages/agent/daemon/runtime/controller.go
@@ -2999,7 +2999,7 @@ func (c *Controller) publish(session Session, events []activityshared.Event) {
 		return
 	}
 	projected := ProjectActivityEventsToStreamEvents(session, events)
-	c.enrichStreamStateEventsWithSessionSnapshot(session, projected)
+	c.enrichStreamStateEventsWithSessionSnapshot(session, projected, events)
 	slog.Debug(
 		"agent session publish events",
 		"event", "agent_session.publish",
@@ -3262,7 +3262,7 @@ func cloneAgentSessionCommands(commands []AgentSessionCommand) []AgentSessionCom
 
 func (c *Controller) enqueueSessionReport(ctx context.Context, session Session, events []activityshared.Event) {
 	report := reportActivityInput(session, events)
-	c.enrichReportStatePatchesWithSessionSnapshot(session, &report)
+	c.enrichReportStatePatchesWithSessionSnapshot(session, &report, events)
 	c.enqueueReport(ctx, report)
 }
 
@@ -3315,6 +3315,7 @@ func (c *Controller) enrichReportWithSessionSnapshot(session Session, report *ag
 func (c *Controller) enrichReportStatePatchesWithSessionSnapshot(
 	session Session,
 	report *agentsessionstore.ReportActivityInput,
+	events []activityshared.Event,
 ) {
 	if report == nil || len(report.StatePatches) == 0 {
 		return
@@ -3323,12 +3324,18 @@ func (c *Controller) enrichReportStatePatchesWithSessionSnapshot(
 	if snapshot.AgentSessionID == "" {
 		return
 	}
-	enrichReportStatePatches(report, statePatchFromSessionStateSnapshot(snapshot))
+	snapshotPatch := statePatchFromSessionStateSnapshot(snapshot)
+	if activityEventsAreMetadataOnlySessionUpdates(events) {
+		enrichReportMetadataStatePatches(report, snapshotPatch)
+		return
+	}
+	enrichReportStatePatches(report, snapshotPatch)
 }
 
 func (c *Controller) enrichStreamStateEventsWithSessionSnapshot(
 	session Session,
 	events []StreamEvent,
+	activityEvents []activityshared.Event,
 ) {
 	if c == nil || len(events) == 0 {
 		return
@@ -3338,6 +3345,7 @@ func (c *Controller) enrichStreamStateEventsWithSessionSnapshot(
 		return
 	}
 	snapshotPatch := statePatchFromSessionStateSnapshot(snapshot)
+	metadataOnly := activityEventsAreMetadataOnlySessionUpdates(activityEvents)
 	for index := range events {
 		if events[index].EventType != StreamEventStatePatch {
 			continue
@@ -3349,8 +3357,34 @@ func (c *Controller) enrichStreamStateEventsWithSessionSnapshot(
 		tmp := agentsessionstore.ReportActivityInput{
 			StatePatches: []agentsessionstore.WorkspaceAgentStatePatch{patch},
 		}
-		enrichReportStatePatches(&tmp, snapshotPatch)
+		if metadataOnly {
+			enrichReportMetadataStatePatches(&tmp, snapshotPatch)
+		} else {
+			enrichReportStatePatches(&tmp, snapshotPatch)
+		}
 		events[index].Data = tmp.StatePatches[0]
+	}
+}
+
+func activityEventsAreMetadataOnlySessionUpdates(events []activityshared.Event) bool {
+	if len(events) == 0 {
+		return false
+	}
+	for _, event := range events {
+		if event.Type != activityshared.EventSessionUpdated || !isMetadataOnlyACPSessionUpdate(event) {
+			return false
+		}
+	}
+	return true
+}
+
+func isMetadataOnlyACPSessionUpdate(event activityshared.Event) bool {
+	updateType := strings.TrimSpace(asString(event.Payload.Metadata["acpSessionUpdate"]))
+	switch updateType {
+	case "usage_update", "config_option_update", "thread_goal_update", "thread_goal_cleared":
+		return true
+	default:
+		return false
 	}
 }
 
@@ -3358,16 +3392,33 @@ func enrichReportStatePatches(
 	report *agentsessionstore.ReportActivityInput,
 	patch agentsessionstore.WorkspaceAgentStatePatch,
 ) {
+	enrichReportStatePatchesWithMode(report, patch, false)
+}
+
+func enrichReportMetadataStatePatches(
+	report *agentsessionstore.ReportActivityInput,
+	patch agentsessionstore.WorkspaceAgentStatePatch,
+) {
+	enrichReportStatePatchesWithMode(report, patch, true)
+}
+
+func enrichReportStatePatchesWithMode(
+	report *agentsessionstore.ReportActivityInput,
+	patch agentsessionstore.WorkspaceAgentStatePatch,
+	metadataOnly bool,
+) {
 	if report == nil {
 		return
 	}
 	for index := range report.StatePatches {
 		report.StatePatches[index].Settings = clonePayload(patch.Settings)
 		report.StatePatches[index].RuntimeContext = clonePayload(patch.RuntimeContext)
-		report.StatePatches[index].TurnLifecycle = cloneTurnLifecycle(patch.TurnLifecycle)
-		report.StatePatches[index].SubmitAvailability = cloneSubmitAvailability(patch.SubmitAvailability)
-		report.StatePatches[index].PendingInteractive = cloneInteractivePrompt(patch.PendingInteractive)
-		report.StatePatches[index].PendingInteractivePresent = patch.PendingInteractivePresent
+		if !metadataOnly {
+			report.StatePatches[index].TurnLifecycle = cloneTurnLifecycle(patch.TurnLifecycle)
+			report.StatePatches[index].SubmitAvailability = cloneSubmitAvailability(patch.SubmitAvailability)
+			report.StatePatches[index].PendingInteractive = cloneInteractivePrompt(patch.PendingInteractive)
+			report.StatePatches[index].PendingInteractivePresent = patch.PendingInteractivePresent
+		}
 		if report.StatePatches[index].Provider == "" {
 			report.StatePatches[index].Provider = patch.Provider
 		}

--- a/packages/agent/daemon/runtime/controller_test.go
+++ b/packages/agent/daemon/runtime/controller_test.go
@@ -4492,7 +4492,7 @@ func TestEnrichStreamStateEventsWithSessionSnapshotFillsRuntimeContext(t *testin
 		},
 	}}
 
-	controller.enrichStreamStateEventsWithSessionSnapshot(session, events)
+	controller.enrichStreamStateEventsWithSessionSnapshot(session, events, nil)
 
 	patch, ok := events[0].Data.(agentsessionstore.WorkspaceAgentStatePatch)
 	if !ok {
@@ -4520,6 +4520,131 @@ func TestEnrichStreamStateEventsWithSessionSnapshotFillsRuntimeContext(t *testin
 	if patch.PendingInteractive == nil || patch.PendingInteractive.RequestID != "request-1" {
 		t.Fatalf("pending interactive = %#v, want request-1", patch.PendingInteractive)
 	}
+}
+
+func TestEnrichStreamStateEventsWithSessionSnapshotKeepsUsageUpdateMetadataOnly(t *testing.T) {
+	t.Parallel()
+
+	adapter := &statefulInteractiveAdapter{
+		provider: ProviderClaudeCode,
+		snapshot: SessionStateSnapshot{
+			AgentSessionID: "agent-session-1",
+			Provider:       ProviderClaudeCode,
+			TurnLifecycle: &TurnLifecycle{
+				ActiveTurnID: stringPtr("synthetic-turn-1"),
+				Phase:        "running",
+			},
+			SubmitAvailability: blockedSubmitAvailability("active_turn"),
+			RuntimeContext: map[string]any{
+				"usage": map[string]any{
+					"contextWindow": map[string]any{
+						"usedTokens":  int64(38414),
+						"totalTokens": int64(200000),
+					},
+				},
+			},
+		},
+	}
+	controller := NewController([]Adapter{adapter}, nil)
+	session := Session{
+		RoomID:         "room-1",
+		AgentSessionID: "agent-session-1",
+		Provider:       ProviderClaudeCode,
+	}
+	controller.store(session)
+	events := []StreamEvent{{
+		EventType: StreamEventStatePatch,
+		Data: agentsessionstore.WorkspaceAgentStatePatch{
+			AgentSessionID: "agent-session-1",
+		},
+	}}
+
+	controller.enrichStreamStateEventsWithSessionSnapshot(
+		session,
+		events,
+		[]activityshared.Event{acpSessionUpdateEventForTest(session, "usage_update")},
+	)
+
+	patch, ok := events[0].Data.(agentsessionstore.WorkspaceAgentStatePatch)
+	if !ok {
+		t.Fatalf("stream patch type = %T, want WorkspaceAgentStatePatch", events[0].Data)
+	}
+	usage, _ := patch.RuntimeContext["usage"].(map[string]any)
+	contextWindow, _ := usage["contextWindow"].(map[string]any)
+	if got, _ := acpInt64Value(contextWindow["totalTokens"]); got != 200000 {
+		t.Fatalf("runtime context usage = %#v, want totalTokens=200000", patch.RuntimeContext["usage"])
+	}
+	if patch.TurnLifecycle != nil {
+		t.Fatalf("turn lifecycle = %#v, want nil for usage update", patch.TurnLifecycle)
+	}
+	if patch.SubmitAvailability != nil {
+		t.Fatalf("submit availability = %#v, want nil for usage update", patch.SubmitAvailability)
+	}
+}
+
+func TestEnrichReportStatePatchesWithSessionSnapshotKeepsUsageUpdateMetadataOnly(t *testing.T) {
+	t.Parallel()
+
+	adapter := &statefulInteractiveAdapter{
+		provider: ProviderClaudeCode,
+		snapshot: SessionStateSnapshot{
+			AgentSessionID:     "agent-session-1",
+			Provider:           ProviderClaudeCode,
+			TurnLifecycle:      &TurnLifecycle{ActiveTurnID: stringPtr("synthetic-turn-1"), Phase: "running"},
+			SubmitAvailability: blockedSubmitAvailability("active_turn"),
+			PendingInteractive: &SessionInteractivePrompt{RequestID: "request-1"},
+			RuntimeContext: map[string]any{
+				"usage": map[string]any{
+					"contextWindow": map[string]any{
+						"usedTokens":  int64(38414),
+						"totalTokens": int64(200000),
+					},
+				},
+			},
+		},
+	}
+	controller := NewController([]Adapter{adapter}, nil)
+	session := Session{
+		RoomID:         "room-1",
+		AgentSessionID: "agent-session-1",
+		Provider:       ProviderClaudeCode,
+	}
+	controller.store(session)
+	report := &agentsessionstore.ReportActivityInput{
+		StatePatches: []agentsessionstore.WorkspaceAgentStatePatch{{
+			AgentSessionID: "agent-session-1",
+		}},
+	}
+
+	controller.enrichReportStatePatchesWithSessionSnapshot(
+		session,
+		report,
+		[]activityshared.Event{acpSessionUpdateEventForTest(session, "usage_update")},
+	)
+
+	patch := report.StatePatches[0]
+	usage, _ := patch.RuntimeContext["usage"].(map[string]any)
+	contextWindow, _ := usage["contextWindow"].(map[string]any)
+	if got, _ := acpInt64Value(contextWindow["totalTokens"]); got != 200000 {
+		t.Fatalf("runtime context usage = %#v, want totalTokens=200000", patch.RuntimeContext["usage"])
+	}
+	if patch.TurnLifecycle != nil {
+		t.Fatalf("turn lifecycle = %#v, want nil for usage update", patch.TurnLifecycle)
+	}
+	if patch.SubmitAvailability != nil {
+		t.Fatalf("submit availability = %#v, want nil for usage update", patch.SubmitAvailability)
+	}
+	if patch.PendingInteractivePresent || patch.PendingInteractive != nil {
+		t.Fatalf("pending interactive = (%v, %#v), want omitted for usage update", patch.PendingInteractivePresent, patch.PendingInteractive)
+	}
+}
+
+func acpSessionUpdateEventForTest(session Session, updateType string) activityshared.Event {
+	event := newSessionActivityEvent(session, EventSessionUpdated, SessionStatusReady, map[string]any{
+		"acpSessionUpdate": updateType,
+	})
+	event.Payload.EffectiveStatus = ""
+	return event
 }
 
 func TestDeriveSessionStatusFromEvents(t *testing.T) {

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUINodeController.spec.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUINodeController.spec.tsx
@@ -8114,6 +8114,76 @@ describe("useAgentGUINodeController", () => {
     expect(getState).toHaveBeenCalledTimes(2);
   });
 
+  it("reloads session state after streamed message updates", async () => {
+    vi.useFakeTimers();
+    let activityListener:
+      | ((event: AgentHostAgentActivityStreamEvent) => void)
+      | undefined;
+    const subscribeEvents = vi.fn((_payload, listener) => {
+      activityListener = listener;
+      return vi.fn();
+    });
+    const getState = vi.fn(
+      async ({ agentSessionId }: { agentSessionId: string }) =>
+        agentSessionState(agentSessionId)
+    );
+    installAgentHostApi({
+      list: vi.fn(async () => snapshotWithSession("session-1")),
+      listSessionTimeline: vi.fn(async () => ({ timelineItems: [] })),
+      subscribeEvents,
+      getState
+    });
+
+    const { result } = renderHook(() =>
+      useAgentGUINodeController({
+        workspaceId: "room-1",
+        currentUserId: "user-1",
+        workspacePath: "/workspace",
+        avoidGroupingEdits: false,
+        data: agentGuiData("session-1"),
+        onDataChange: vi.fn()
+      })
+    );
+
+    act(() => {
+      result.current.actions.retryActivation();
+    });
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+    expect(activityListener).toBeDefined();
+    expect(getState).toHaveBeenCalledTimes(1);
+
+    act(() => {
+      activityListener?.({
+        eventType: "message_update",
+        data: {
+          agentSessionId: "session-1",
+          messageId: "message-1",
+          seq: 20,
+          turnId: "turn-1",
+          role: "assistant",
+          kind: "message",
+          status: "completed",
+          payload: { text: "Done" },
+          occurredAtUnixMs: 20,
+          completedAtUnixMs: 20
+        }
+      });
+      vi.advanceTimersByTime(149);
+    });
+
+    expect(getState).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      vi.advanceTimersByTime(1);
+      await Promise.resolve();
+    });
+
+    expect(getState).toHaveBeenCalledTimes(2);
+  });
+
   it("does not reload session list or timeline for streamed state patches", async () => {
     vi.useFakeTimers();
     let activityListener:

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUINodeController.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUINodeController.ts
@@ -7183,10 +7183,7 @@ export function useAgentGUINodeController({
         ) {
           continue;
         }
-        if (
-          event.eventType === "message_update" ||
-          event.eventType === "available_commands_update"
-        ) {
+        if (event.eventType === "available_commands_update") {
           continue;
         }
         scheduleActivityStreamStateReload(activeConversationId, {

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUINodeController.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUINodeController.ts
@@ -204,6 +204,7 @@ import {
 const EMPTY_AGENT_GUI_MESSAGES: readonly WorkspaceAgentActivityMessage[] = [];
 const EMPTY_AGENT_GUI_AVAILABLE_COMMANDS: AgentSessionCommand[] = [];
 const ACTIVITY_STREAM_STATE_RELOAD_DEBOUNCE_MS = 150;
+const ACTIVITY_STREAM_STATE_RELOAD_MAX_WAIT_MS = 1000;
 const AGENT_GUI_DETAIL_MESSAGES_PAGE_SIZE = 100;
 const AGENT_GUI_DETAIL_MISSING_USER_BACKFILL_PAGE_LIMIT = 3;
 const AGENT_GUI_SUBMIT_RETARGET_EARLY_MESSAGE_TOLERANCE_MS = 5_000;
@@ -6531,7 +6532,13 @@ export function useAgentGUINodeController({
           }
           void loadSessionState(agentSessionId, cause);
         },
-        ACTIVITY_STREAM_STATE_RELOAD_DEBOUNCE_MS
+        ACTIVITY_STREAM_STATE_RELOAD_DEBOUNCE_MS,
+        // Without a maxWait, a turn that keeps emitting qualifying events
+        // (tool calls, usage updates, ...) faster than the debounce window
+        // never gets a quiet gap to fire, so the control-state reload (and
+        // with it the usage/limit display) silently stalls until the turn
+        // settles instead of refreshing throughout the reply.
+        { maxWait: ACTIVITY_STREAM_STATE_RELOAD_MAX_WAIT_MS }
       ),
     [loadSessionState]
   );

--- a/services/tuttid/service/agent/composer_options.go
+++ b/services/tuttid/service/agent/composer_options.go
@@ -389,10 +389,10 @@ func normalizeComposerModelForProvider(provider string, model string) string {
 		return strings.TrimSpace(model)
 	}
 	switch strings.TrimSpace(model) {
-	case "opus", "opusplan":
-		// Retired Claude Code aliases; Opus tier is exposed as "default" in
-		// newer claude-agent-acp builds.
-		return "default"
+	case "opusplan":
+		// Retired Claude Code alias; keep it on the explicit Opus tier instead
+		// of falling back to the runtime's mutable Default choice.
+		return "opus"
 	default:
 		return strings.TrimSpace(model)
 	}

--- a/services/tuttid/service/agent/composer_options_test.go
+++ b/services/tuttid/service/agent/composer_options_test.go
@@ -112,8 +112,14 @@ func TestNormalizeComposerSettingsClampsByProviderSupport(t *testing.T) {
 	claude := normalizeComposerSettingsForProvider("claude-code", ComposerSettings{
 		Model: "opus",
 	})
-	if claude.Model != "default" {
-		t.Fatalf("claude legacy opus model = %q, want default", claude.Model)
+	if claude.Model != "opus" {
+		t.Fatalf("claude opus model = %q, want opus", claude.Model)
+	}
+	claudeLegacy := normalizeComposerSettingsForProvider("claude-code", ComposerSettings{
+		Model: "opusplan",
+	})
+	if claudeLegacy.Model != "opus" {
+		t.Fatalf("claude legacy opusplan model = %q, want opus", claudeLegacy.Model)
 	}
 }
 

--- a/services/tuttid/service/agent/service_test.go
+++ b/services/tuttid/service/agent/service_test.go
@@ -1599,6 +1599,45 @@ func TestServiceCreateUsesProviderDefaultModelWhenModelOmitted(t *testing.T) {
 	}
 }
 
+func TestServiceCreatePreservesClaudeOpusAlias(t *testing.T) {
+	t.Setenv("CLAUDE_CONFIG_DIR", t.TempDir())
+	runtime := newFakeRuntime()
+	service := newTestService(runtime)
+	service.setLiveComposerModelOptions("claude-code", "ws-1", "/repo", time.Now().UTC(), []ComposerConfigOptionValue{
+		{Value: "default", Label: "Default"},
+		{Value: "opus", Label: "Opus"},
+		{Value: "haiku", Label: "Haiku"},
+	})
+	var prepareInput agentsidecarservice.PrepareInput
+	service.RuntimePreparer = fakeRuntimePreparer{
+		input: &prepareInput,
+	}
+
+	session, err := service.Create(context.Background(), "ws-1", CreateSessionInput{
+		AgentSessionID: "44444444-4444-4444-8444-444444444444",
+		AgentTargetID:  agenttargetbiz.IDLocalClaudeCode,
+		Provider:       "claude-code",
+		Model:          stringRef("opus"),
+		Cwd:            stringRef("/repo"),
+		InitialContent: TextPromptContent("hello"),
+	})
+	if err != nil {
+		t.Fatalf("Create returned error: %v", err)
+	}
+	if len(runtime.startCalls) != 1 {
+		t.Fatalf("start calls = %d, want 1", len(runtime.startCalls))
+	}
+	if runtime.startCalls[0].Model != "opus" {
+		t.Fatalf("runtime model = %q, want opus", runtime.startCalls[0].Model)
+	}
+	if prepareInput.Model != "opus" {
+		t.Fatalf("prepare model = %q, want opus", prepareInput.Model)
+	}
+	if session.Settings == nil || session.Settings.Model != "opus" {
+		t.Fatalf("session settings = %#v, want opus model", session.Settings)
+	}
+}
+
 func TestServiceCreatePassesPlanModeToRuntime(t *testing.T) {
 	t.Setenv("CLAUDE_CONFIG_DIR", t.TempDir())
 	runtime := newFakeRuntime()


### PR DESCRIPTION
## Summary
- New Claude Code sessions promote a pre-warmed draft directly, which can race ahead of an in-flight settings patch (e.g. model selection) and send the first message to a session still running the previous/default model. Resync the draft's settings via `ensureClaudeDraft` before promoting to close that race.
- Agent GUI's activity-stream control-state reload used a plain `lodash.debounce` with no `maxWait`, so a sustained burst of qualifying events during a turn kept resetting the timer and delayed the usage/limit display refresh until the turn went idle (i.e. until the reply finished). Added `maxWait: 1000ms` so it flushes periodically during long replies.

## Test plan
- [x] `tsc --noEmit` clean for `packages/agent/gui` and `apps/desktop`
- [x] `node --test` desktop adapter suite: 22/22 passing
- [x] `vitest` agent-gui controller suite: 218/218 passing

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Session activity updates now refresh the workspace control state more reliably, including streamed message events.
  * Claude sessions better preserve model selections and context-window information during streaming and reloads.

* **Bug Fixes**
  * Fixed delayed or missed usage/limits refreshes when activity events continue streaming.
  * Improved draft session promotion so existing pre-warmed drafts are reused more consistently.
  * Corrected handling of usage-only session updates so they no longer overwrite active session state.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->