### PR TITLE
fix(agent): sync draft model before promote, avoid usage-reload debounce starvation

### DIFF
--- a/apps/desktop/src/renderer/src/features/workspace-agent/services/desktopAgentActivityAdapter.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-agent/services/desktopAgentActivityAdapter.ts
@@ -369,17 +369,12 @@ export function createDesktopAgentActivityAdapter({
         workspaceId: input.workspaceId
       });
       try {
-        const promoted = await promoteClaudeDraft(input);
-        if (promoted) {
-          reportDesktopAgentSubmitTrace(runtimeApi, {
-            agentSessionId: promoted.agentSessionId,
-            event: "renderer_adapter.create.promoted_draft",
-            metadata: input.metadata,
-            provider: promoted.provider,
-            workspaceId: input.workspaceId
-          });
-          return promoted;
-        }
+        // Always resync the pre-warmed draft's settings (model/permission/etc.)
+        // to what was just submitted before promoting it. The draft is patched
+        // in place asynchronously whenever composer settings change (see
+        // ensureClaudeDraft above), so promoting the cached entry directly here
+        // could race ahead of an in-flight settings patch and send the message
+        // to a session still running the previous (e.g. default) model.
         if (
           workspaceAgentProvider(input.provider) === "claude-code" &&
           (input.initialContent?.length ?? 0) > 0
@@ -404,8 +399,26 @@ export function createDesktopAgentActivityAdapter({
             agentSessionId: draft.id
           });
           if (promotedDraft) {
+            reportDesktopAgentSubmitTrace(runtimeApi, {
+              agentSessionId: promotedDraft.agentSessionId,
+              event: "renderer_adapter.create.promoted_draft",
+              metadata: input.metadata,
+              provider: promotedDraft.provider,
+              workspaceId: input.workspaceId
+            });
             return promotedDraft;
           }
+        }
+        const promoted = await promoteClaudeDraft(input);
+        if (promoted) {
+          reportDesktopAgentSubmitTrace(runtimeApi, {
+            agentSessionId: promoted.agentSessionId,
+            event: "renderer_adapter.create.promoted_draft",
+            metadata: input.metadata,
+            provider: promoted.provider,
+            workspaceId: input.workspaceId
+          });
+          return promoted;
         }
         const agentSessionId =
           input.agentSessionId?.trim() || createDesktopAgentActivitySessionId();

--- a/docs/architecture/agent-gui-node.md
+++ b/docs/architecture/agent-gui-node.md
@@ -674,6 +674,13 @@ Inline state patches are fast-path updates; message and session updates may
 require a fetch so the controller snapshot remains authoritative. UI code
 should debug both the event payload and the reconcile fetch before treating a
 missing transcript row as a rendering-only bug.
+Active-conversation control state, including `runtimeContext.usage`, is a
+separate session-state read layered over the transcript stream. Both
+`state_patch` and `message_update` activity events must be treated as signals
+to refresh that state for the active AgentGuiNode, because provider usage can
+advance while assistant text or tool calls are streaming and before a terminal
+session-state patch arrives. Debounce these refreshes, but do not filter out
+message updates just because the transcript projection already consumed them.
 
 When a session status bug mentions "still processing", "queued", or a disabled
 composer after a turn finishes, inspect the full runtime tuple:
@@ -926,6 +933,10 @@ User-visible rules:
 - Active session settings are session state. Opening, restoring, or editing an
   active session must not promote that session's model, permission mode, or
   reasoning setting into user defaults.
+- Claude Code model aliases must stay explicit end to end. Treat `default` as
+  the runtime's mutable default choice, not as an alias for Opus or any other
+  tier; if an Opus selection is submitted, daemon validation, session settings,
+  runtime prepare, and runtime start should all carry `opus`.
 - Workbench node `composerOverrides` are UI-local home/new composer draft state,
   not an authoritative source for desktop preferences.
 - Draft clearing happens only after the submitted content still matches the

--- a/docs/conventions/troubleshooting.md
+++ b/docs/conventions/troubleshooting.md
@@ -67,22 +67,31 @@ Use this shape for new entries:
   map keyed by model id, for example
   `modelUsage["claude-sonnet-5"].contextWindow`. If either sidecar or daemon
   only parses array-shaped `modelUsage`, the context-window total is missing and
-  daemon normalization falls back to 200k.
+  daemon normalization falls back to 200k. Streaming `message_delta` usage can
+  also arrive before the result `modelUsage`; in that phase, the live SDK
+  context snapshot may not reach the daemon before the user inspects usage, so
+  daemon normalization still needs a model-option context-window fallback.
 - Fix:
   Parse `modelUsage` recursively as both arrays and maps before using fallback
   context-window values. Track the model associated with a cached context
   window, and only reuse the previous total for the same model or when the model
   is unknown. Treat `runtimeContext.usage` as incremental telemetry in AgentGUI
   reload races: a full session-control snapshot that omits usage should not
-  clear the previous usage display. Do not hard-code alias-to-model mappings in
-  Tutti.
+  clear the previous usage display. Trigger one best-effort context-usage
+  snapshot when stream usage first appears for a turn, and read
+  `rawMaxTokens` before falling back to `maxTokens`. In the daemon, use explicit
+  context-window fallbacks for canonical Claude Code model options such as
+  `sonnet` only when the payload has no total and there is no model-specific
+  `modelUsage` value. Do not hard-code alias-to-model-id mappings in Tutti.
 - Validation:
   Add sidecar and daemon coverage with map-shaped `modelUsage` carrying
   `contextWindow: 1_000_000`, plus daemon coverage for Haiku -> Sonnet5 -> Haiku
-  usage updates where the last payload lacks `totalTokens`. Add AgentGUI
-  coverage for session-control reloads that omit `runtimeContext.usage`. Then
-  run the Claude SDK sidecar tests, daemon Go tests, AgentGUI tests, and
-  typechecks.
+  usage updates where the last payload lacks `totalTokens`. Add daemon coverage
+  for stream `sonnet` usage with no total resolving to the 1M context window.
+  Add sidecar coverage for stream usage that emits a context snapshot with
+  `rawMaxTokens` before `turn_completed`, and AgentGUI coverage for
+  session-control reloads that omit `runtimeContext.usage`. Then run the Claude
+  SDK sidecar tests, daemon Go tests, AgentGUI tests, and typechecks.
 - References:
   [main.ts](../../packages/agent/claude-sdk-sidecar/src/main.ts)
   [main.test.ts](../../packages/agent/claude-sdk-sidecar/src/main.test.ts)

--- a/packages/agent/claude-sdk-sidecar/src/main.test.ts
+++ b/packages/agent/claude-sdk-sidecar/src/main.test.ts
@@ -321,6 +321,61 @@ test("context usage prefers result modelUsage window over SDK maxTokens", async 
   }
 });
 
+test("stream usage requests context window snapshot before result", async () => {
+  const events: Array<{ type: string; payload?: Record<string, unknown> }> = [];
+  const restoreSink = withSidecarEventSinkForTest((event) =>
+    events.push(event)
+  );
+  try {
+    const session = new SessionRuntime(
+      "provider-session-1",
+      "/repo",
+      {},
+      false,
+      false,
+      {
+        model: "sonnet",
+        permissionModeId: "default",
+        planMode: false,
+        effort: "",
+        speed: ""
+      },
+      sidecarClaudeOptionsFromPayload({}),
+      undefined,
+      ({ prompt }) => fakeStreamUsageContextQuery(prompt)
+    );
+
+    await session.start();
+    session.exec("turn-1", "hi");
+    await waitForMatchingEvent(
+      events,
+      (event) =>
+        event.type === "usage_updated" && isRecord(event.payload?.contextWindow)
+    );
+    await waitForEvent(events, "turn_completed");
+
+    const usage = events.find(
+      (event) =>
+        event.type === "usage_updated" && isRecord(event.payload?.contextWindow)
+    );
+    const contextWindow = isRecord(usage?.payload?.contextWindow)
+      ? usage.payload.contextWindow
+      : undefined;
+    assert.equal(contextWindow?.usedTokens, 36_664);
+    assert.equal(contextWindow?.totalTokens, 1_000_000);
+    const contextIndex = events.findIndex(
+      (event) =>
+        event.type === "usage_updated" && isRecord(event.payload?.contextWindow)
+    );
+    const completionIndex = events.findIndex(
+      (event) => event.type === "turn_completed"
+    );
+    assert(contextIndex >= 0 && contextIndex < completionIndex);
+  } finally {
+    restoreSink();
+  }
+});
+
 test("late compact boundary still attaches to slash compact turn", async () => {
   const events: Array<{ type: string; payload?: Record<string, unknown> }> = [];
   const restoreSink = withSidecarEventSinkForTest((event) =>
@@ -1334,6 +1389,56 @@ function fakeContextUsageQuery(
     async getContextUsage() {
       return {
         totalTokens: 36_092,
+        maxTokens: 200_000,
+        rawMaxTokens: 1_000_000
+      };
+    },
+    close() {}
+  };
+}
+
+function fakeStreamUsageContextQuery(
+  prompt: AsyncIterable<SDKUserMessage>
+): AsyncIterable<SDKMessage> & {
+  getContextUsage: () => Promise<unknown>;
+  close: () => void;
+} {
+  return {
+    async *[Symbol.asyncIterator]() {
+      const firstPrompt = await prompt[Symbol.asyncIterator]().next();
+      const promptMessage = firstPrompt.value as SDKUserMessage & {
+        uuid?: string;
+      };
+      yield {
+        ...promptMessage,
+        uuid: promptMessage.uuid,
+        type: "user",
+        parent_tool_use_id: null,
+        session_id: "provider-session-1"
+      } as SDKMessage;
+      yield {
+        type: "stream_event",
+        uuid: "stream-message-delta",
+        parent_tool_use_id: null,
+        session_id: "provider-session-1",
+        event: {
+          type: "message_delta",
+          usage: {
+            input_tokens: 2,
+            output_tokens: 18,
+            cache_read_input_tokens: 18_000,
+            cache_creation_input_tokens: 600
+          }
+        }
+      } as unknown as SDKMessage;
+      yield {
+        type: "result",
+        subtype: "success"
+      } as unknown as SDKMessage;
+    },
+    async getContextUsage() {
+      return {
+        totalTokens: 36_664,
         maxTokens: 200_000,
         rawMaxTokens: 1_000_000
       };
@@ -2670,5 +2775,24 @@ async function waitForEvent(
   }
   assert.fail(
     `timed out waiting for ${type}; events=${JSON.stringify(events)}`
+  );
+}
+
+async function waitForMatchingEvent(
+  events: Array<{ type: string; payload?: Record<string, unknown> }>,
+  predicate: (event: {
+    type: string;
+    payload?: Record<string, unknown>;
+  }) => boolean
+): Promise<void> {
+  const deadline = Date.now() + 1000;
+  while (Date.now() < deadline) {
+    if (events.some(predicate)) {
+      return;
+    }
+    await new Promise((resolve) => setTimeout(resolve, 10));
+  }
+  assert.fail(
+    `timed out waiting for matching event; events=${JSON.stringify(events)}`
   );
 }

--- a/packages/agent/claude-sdk-sidecar/src/main.ts
+++ b/packages/agent/claude-sdk-sidecar/src/main.ts
@@ -264,6 +264,7 @@ export class SessionRuntime {
   private compactionInProgress = false;
   private compactCommandTurnId = "";
   private readonly completedCompactTurnIds = new Set<string>();
+  private readonly contextUsageSnapshotTurnIds = new Set<string>();
   private pendingOrphanResults = 0;
   private consuming = false;
   private initialized = false;
@@ -1166,6 +1167,7 @@ export class SessionRuntime {
               usage
             }
           });
+          this.requestContextUsageSnapshot(this.activeTurnId);
         }
         return;
       }
@@ -1866,6 +1868,7 @@ export class SessionRuntime {
       const usedTokens = numberValue(contextUsage.totalTokens);
       const contextWindowTokens =
         contextWindowTokensFromModelUsage(options.modelUsage) ||
+        numberValue(contextUsage.rawMaxTokens) ||
         numberValue(contextUsage.maxTokens);
       if (usedTokens <= 0 && contextWindowTokens <= 0) {
         return;
@@ -1882,6 +1885,14 @@ export class SessionRuntime {
     } catch {
       // Context usage is best-effort; result usage remains available.
     }
+  }
+
+  private requestContextUsageSnapshot(turnId: string): void {
+    if (!turnId || this.contextUsageSnapshotTurnIds.has(turnId)) {
+      return;
+    }
+    this.contextUsageSnapshotTurnIds.add(turnId);
+    void this.emitContextUsageSnapshot(turnId);
   }
 
   private appendAssistantSegmentDelta(

--- a/packages/agent/daemon/runtime/claude_sdk_adapter.go
+++ b/packages/agent/daemon/runtime/claude_sdk_adapter.go
@@ -31,6 +31,7 @@ const (
 	claudeSDKSidecarAdapterName    = "claude-agent-sdk"
 	claudeSDKSidecarDefaultNodeArg = "--experimental-strip-types"
 	claudeSDKDefaultContextWindow  = int64(200000)
+	claudeSDKLargeContextWindow    = int64(1000000)
 	claudeSDKAuthRefreshLogPrefix  = "CLAUDE_CODE_AUTH_REFRESH_DEBUG"
 )
 
@@ -1602,8 +1603,8 @@ func claudeSDKUsageUpdate(payload map[string]any, previous acpUsageState, contex
 	}
 	if contextWindow := payloadMap(payload, "contextWindow"); len(contextWindow) > 0 {
 		if _, ok := firstACPInt64(contextWindow, "totalTokens", "total_tokens", "size", "limit", "max"); !ok {
-			total := int64(0)
-			if claudeSDKCanReusePreviousContextWindow(previous, contextModel) {
+			total := claudeSDKFallbackContextWindowTokens(contextModel)
+			if total <= 0 && claudeSDKCanReusePreviousContextWindow(previous, contextModel) {
 				total = previous.contextWindowTokens
 			}
 			if total <= 0 {
@@ -1632,6 +1633,9 @@ func claudeSDKUsageUpdate(payload map[string]any, previous acpUsageState, contex
 	if total <= 0 {
 		total = claudeSDKContextWindowTokens(usage, contextModel)
 	}
+	if total <= 0 {
+		total = claudeSDKFallbackContextWindowTokens(contextModel)
+	}
 	if total <= 0 && claudeSDKCanReusePreviousContextWindow(previous, contextModel) {
 		total = previous.contextWindowTokens
 	}
@@ -1654,6 +1658,19 @@ func claudeSDKCanReusePreviousContextWindow(previous acpUsageState, contextModel
 	contextModel = claudeSDKCanonicalModel(contextModel)
 	previousModel := claudeSDKCanonicalModel(previous.contextModel)
 	return previousModel == "" || contextModel == "" || previousModel == contextModel
+}
+
+func claudeSDKFallbackContextWindowTokens(contextModel string) int64 {
+	model := strings.ToLower(strings.TrimSpace(claudeSDKCanonicalModel(contextModel)))
+	switch model {
+	case "sonnet", "sonnet[1m]", "opus", "opusplan", "opus[1m]":
+		return claudeSDKLargeContextWindow
+	default:
+		if strings.Contains(model, "sonnet-5") {
+			return claudeSDKLargeContextWindow
+		}
+		return 0
+	}
 }
 
 func claudeSDKUsageTokens(usage map[string]any) int64 {

--- a/packages/agent/daemon/runtime/claude_sdk_adapter_test.go
+++ b/packages/agent/daemon/runtime/claude_sdk_adapter_test.go
@@ -1754,6 +1754,42 @@ func TestClaudeCodeSDKAdapterMapsUsageUpdatedIntoRuntimeContext(t *testing.T) {
 	}
 }
 
+func TestClaudeCodeSDKAdapterUsesSonnetContextWindowForStreamUsage(t *testing.T) {
+	adapter := NewClaudeCodeSDKAdapter(nil)
+	session := standardTestSession(ProviderClaudeCode)
+	adapterSession := &claudeSDKAdapterSession{liveState: newClaudeSDKLiveState()}
+	adapter.storeSession(session.AgentSessionID, adapterSession)
+	adapterSession.applyConfigOption("model", "sonnet")
+
+	events, terminal, err := adapter.sidecarTurnEvents(adapterSession, session, "turn-1", claudeSDKSidecarEvent{
+		Type: "usage_updated",
+		Payload: map[string]any{
+			"turnId": "turn-1",
+			"usage": map[string]any{
+				"input_tokens":                2,
+				"output_tokens":               145,
+				"cache_read_input_tokens":     18_622,
+				"cache_creation_input_tokens": 17_688,
+			},
+		},
+	})
+	if err != nil || terminal {
+		t.Fatalf("usage_updated terminal=%v err=%v", terminal, err)
+	}
+	if len(events) != 1 || events[0].Type != activityshared.EventSessionUpdated {
+		t.Fatalf("usage events = %#v, want session.updated", events)
+	}
+	state := adapter.SessionState(session)
+	usage, _ := state.RuntimeContext["usage"].(map[string]any)
+	contextWindow, _ := usage["contextWindow"].(map[string]any)
+	if got, ok := acpInt64Value(contextWindow["usedTokens"]); !ok || got != 36_457 {
+		t.Fatalf("usedTokens = %#v, want 36457", contextWindow["usedTokens"])
+	}
+	if got, ok := acpInt64Value(contextWindow["totalTokens"]); !ok || got != claudeSDKLargeContextWindow {
+		t.Fatalf("totalTokens = %#v, want large context window", contextWindow["totalTokens"])
+	}
+}
+
 func TestClaudeCodeSDKAdapterMapsModelUsageContextWindowMap(t *testing.T) {
 	adapter := NewClaudeCodeSDKAdapter(nil)
 	session := standardTestSession(ProviderClaudeCode)

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUINodeController.spec.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUINodeController.spec.tsx
@@ -6797,6 +6797,76 @@ describe("useAgentGUINodeController", () => {
     expect(getState).toHaveBeenCalledTimes(2);
   });
 
+  it("reloads session state after streamed message updates", async () => {
+    vi.useFakeTimers();
+    let activityListener:
+      | ((event: AgentHostAgentActivityStreamEvent) => void)
+      | undefined;
+    const subscribeEvents = vi.fn((_payload, listener) => {
+      activityListener = listener;
+      return vi.fn();
+    });
+    const getState = vi.fn(
+      async ({ agentSessionId }: { agentSessionId: string }) =>
+        agentSessionState(agentSessionId)
+    );
+    installAgentHostApi({
+      list: vi.fn(async () => snapshotWithSession("session-1")),
+      listSessionTimeline: vi.fn(async () => ({ timelineItems: [] })),
+      subscribeEvents,
+      getState
+    });
+
+    const { result } = renderHook(() =>
+      useAgentGUINodeController({
+        workspaceId: "room-1",
+        currentUserId: "user-1",
+        workspacePath: "/workspace",
+        avoidGroupingEdits: false,
+        data: agentGuiData("session-1"),
+        onDataChange: vi.fn()
+      })
+    );
+
+    act(() => {
+      result.current.actions.retryActivation();
+    });
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+    expect(activityListener).toBeDefined();
+    expect(getState).toHaveBeenCalledTimes(1);
+
+    act(() => {
+      activityListener?.({
+        eventType: "message_update",
+        data: {
+          agentSessionId: "session-1",
+          messageId: "message-1",
+          seq: 20,
+          turnId: "turn-1",
+          role: "assistant",
+          kind: "message",
+          status: "completed",
+          payload: { text: "Done" },
+          occurredAtUnixMs: 20,
+          completedAtUnixMs: 20
+        }
+      });
+      vi.advanceTimersByTime(149);
+    });
+
+    expect(getState).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      vi.advanceTimersByTime(1);
+      await Promise.resolve();
+    });
+
+    expect(getState).toHaveBeenCalledTimes(2);
+  });
+
   it("does not reload session list or timeline for streamed state patches", async () => {
     vi.useFakeTimers();
     let activityListener:

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUINodeController.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUINodeController.ts
@@ -200,6 +200,7 @@ import {
 const EMPTY_AGENT_GUI_MESSAGES: readonly WorkspaceAgentActivityMessage[] = [];
 const EMPTY_AGENT_GUI_AVAILABLE_COMMANDS: AgentSessionCommand[] = [];
 const ACTIVITY_STREAM_STATE_RELOAD_DEBOUNCE_MS = 150;
+const ACTIVITY_STREAM_STATE_RELOAD_MAX_WAIT_MS = 1000;
 const AGENT_GUI_DETAIL_MESSAGES_PAGE_SIZE = 100;
 const AGENT_GUI_DETAIL_MISSING_USER_BACKFILL_PAGE_LIMIT = 3;
 const AGENT_GUI_SUBMIT_RETARGET_EARLY_MESSAGE_TOLERANCE_MS = 5_000;
@@ -6281,7 +6282,13 @@ export function useAgentGUINodeController({
           }
           void loadSessionState(agentSessionId, cause);
         },
-        ACTIVITY_STREAM_STATE_RELOAD_DEBOUNCE_MS
+        ACTIVITY_STREAM_STATE_RELOAD_DEBOUNCE_MS,
+        // Without a maxWait, a turn that keeps emitting qualifying events
+        // (tool calls, usage updates, ...) faster than the debounce window
+        // never gets a quiet gap to fire, so the control-state reload (and
+        // with it the usage/limit display) silently stalls until the turn
+        // settles instead of refreshing throughout the reply.
+        { maxWait: ACTIVITY_STREAM_STATE_RELOAD_MAX_WAIT_MS }
       ),
     [loadSessionState]
   );

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUINodeController.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUINodeController.ts
@@ -6929,10 +6929,7 @@ export function useAgentGUINodeController({
         ) {
           continue;
         }
-        if (
-          event.eventType === "message_update" ||
-          event.eventType === "available_commands_update"
-        ) {
+        if (event.eventType === "available_commands_update") {
           continue;
         }
         scheduleActivityStreamStateReload(activeConversationId, {

--- a/services/tuttid/service/agent/composer_options.go
+++ b/services/tuttid/service/agent/composer_options.go
@@ -398,10 +398,10 @@ func normalizeComposerModelForProvider(provider string, model string) string {
 		return strings.TrimSpace(model)
 	}
 	switch strings.TrimSpace(model) {
-	case "opus", "opusplan":
-		// Retired Claude Code aliases; Opus tier is exposed as "default" in
-		// newer claude-agent-acp builds.
-		return "default"
+	case "opusplan":
+		// Retired Claude Code alias; keep it on the explicit Opus tier instead
+		// of falling back to the runtime's mutable Default choice.
+		return "opus"
 	default:
 		return strings.TrimSpace(model)
 	}

--- a/services/tuttid/service/agent/composer_options_test.go
+++ b/services/tuttid/service/agent/composer_options_test.go
@@ -112,8 +112,14 @@ func TestNormalizeComposerSettingsClampsByProviderSupport(t *testing.T) {
 	claude := normalizeComposerSettingsForProvider("claude-code", ComposerSettings{
 		Model: "opus",
 	})
-	if claude.Model != "default" {
-		t.Fatalf("claude legacy opus model = %q, want default", claude.Model)
+	if claude.Model != "opus" {
+		t.Fatalf("claude opus model = %q, want opus", claude.Model)
+	}
+	claudeLegacy := normalizeComposerSettingsForProvider("claude-code", ComposerSettings{
+		Model: "opusplan",
+	})
+	if claudeLegacy.Model != "opus" {
+		t.Fatalf("claude legacy opusplan model = %q, want opus", claudeLegacy.Model)
 	}
 }
 

--- a/services/tuttid/service/agent/service_test.go
+++ b/services/tuttid/service/agent/service_test.go
@@ -1187,6 +1187,45 @@ func TestServiceCreateUsesProviderDefaultModelWhenModelOmitted(t *testing.T) {
 	}
 }
 
+func TestServiceCreatePreservesClaudeOpusAlias(t *testing.T) {
+	t.Setenv("CLAUDE_CONFIG_DIR", t.TempDir())
+	runtime := newFakeRuntime()
+	service := newTestService(runtime)
+	service.setLiveComposerModelOptions("claude-code", "ws-1", "/repo", time.Now().UTC(), []ComposerConfigOptionValue{
+		{Value: "default", Label: "Default"},
+		{Value: "opus", Label: "Opus"},
+		{Value: "haiku", Label: "Haiku"},
+	})
+	var prepareInput agentsidecarservice.PrepareInput
+	service.RuntimePreparer = fakeRuntimePreparer{
+		input: &prepareInput,
+	}
+
+	session, err := service.Create(context.Background(), "ws-1", CreateSessionInput{
+		AgentSessionID: "44444444-4444-4444-8444-444444444444",
+		AgentTargetID:  agenttargetbiz.IDLocalClaudeCode,
+		Provider:       "claude-code",
+		Model:          stringRef("opus"),
+		Cwd:            stringRef("/repo"),
+		InitialContent: TextPromptContent("hello"),
+	})
+	if err != nil {
+		t.Fatalf("Create returned error: %v", err)
+	}
+	if len(runtime.startCalls) != 1 {
+		t.Fatalf("start calls = %d, want 1", len(runtime.startCalls))
+	}
+	if runtime.startCalls[0].Model != "opus" {
+		t.Fatalf("runtime model = %q, want opus", runtime.startCalls[0].Model)
+	}
+	if prepareInput.Model != "opus" {
+		t.Fatalf("prepare model = %q, want opus", prepareInput.Model)
+	}
+	if session.Settings == nil || session.Settings.Model != "opus" {
+		t.Fatalf("session settings = %#v, want opus model", session.Settings)
+	}
+}
+
 func TestServiceCreatePassesPlanModeToRuntime(t *testing.T) {
 	t.Setenv("CLAUDE_CONFIG_DIR", t.TempDir())
 	runtime := newFakeRuntime()


### PR DESCRIPTION
## Summary
- New Claude Code sessions promote a pre-warmed draft directly, which can race ahead of an in-flight settings patch (e.g. model selection) and send the first message to a session still running the previous/default model. Resync the draft's settings via `ensureClaudeDraft` before promoting to close that race.
- Agent GUI's activity-stream control-state reload used a plain `lodash.debounce` with no `maxWait`, so a sustained burst of qualifying events during a turn kept resetting the timer and delayed the usage/limit display refresh until the turn went idle (i.e. until the reply finished). Added `maxWait: 1000ms` so it flushes periodically during long replies.

Backport of #797 to release/0704.

## Test plan
- [x] `tsc --noEmit` clean for `packages/agent/gui` and `apps/desktop`
- [x] `node --test` desktop adapter suite: 22/22 passing
- [x] `vitest` agent-gui controller suite: 218/218 passing