### PR TITLE
fix(agent): classify claude-code sidecar signal-kill exits as interrupted

### DIFF
--- a/packages/agent/daemon/runtime/claude_sdk_adapter.go
+++ b/packages/agent/daemon/runtime/claude_sdk_adapter.go
@@ -119,6 +119,15 @@ type claudeSDKSidecarEvent struct {
 type claudeSDKLineReader struct {
 	conn   ProcessConnection
 	buffer string
+	// stderrTail keeps the most recent bytes of the sidecar's stderr, bounded
+	// to acpClientOutputTailLimit. Unlike stdout (a line-delimited event
+	// protocol), stderr from the Node sidecar has no contract at all — it is
+	// whatever the process (or something it imports) happened to write, e.g.
+	// an uncaught exception's stack trace. It exists solely so that when the
+	// sidecar's process exits, the resulting error can quote it instead of a
+	// bare exit code, mirroring acpClient.readLoop's stderrTail handling for
+	// the Codex ACP transport.
+	stderrTail []byte
 }
 
 func NewClaudeCodeSDKAdapter(transport ProcessTransport) *ClaudeCodeSDKAdapter {
@@ -2024,15 +2033,40 @@ func (r *claudeSDKLineReader) next(ctx context.Context) (claudeSDKSidecarEvent, 
 		}
 		if len(frame.Stderr) > 0 {
 			logClaudeSDKSidecarDebugStderr(frame.Stderr)
+			r.appendStderrTail(frame.Stderr)
 			continue
 		}
 		if frame.ExitCode != nil {
-			return claudeSDKSidecarEvent{}, fmt.Errorf("claude sdk sidecar exited with code %d", *frame.ExitCode)
+			return claudeSDKSidecarEvent{}, claudeSDKSidecarExitError(*frame.ExitCode, r.stderrTail)
 		}
 		if len(frame.Stdout) > 0 {
 			r.buffer += string(frame.Stdout)
 		}
 	}
+}
+
+// appendStderrTail records a chunk of raw sidecar stderr, bounded to
+// acpClientOutputTailLimit (see acp_client.go), so a subsequent process exit
+// can quote the tail instead of reporting a bare exit code.
+func (r *claudeSDKLineReader) appendStderrTail(content []byte) {
+	r.stderrTail = append(r.stderrTail, content...)
+	if len(r.stderrTail) > acpClientOutputTailLimit {
+		r.stderrTail = r.stderrTail[len(r.stderrTail)-acpClientOutputTailLimit:]
+	}
+}
+
+// claudeSDKSidecarExitError builds the error surfaced when the sidecar
+// process exits mid-session. It quotes the captured stderr tail (if any) so
+// an uncaught exception or crash reason is visible in logs and in the
+// resulting visible-error card instead of being silently discarded — see
+// claudeSDKLineReader.stderrTail and codexExitLooksInterrupted (visible_error.go)
+// for how -1 (Go's os/exec signal-termination convention) is classified once
+// this reaches the GUI.
+func claudeSDKSidecarExitError(exitCode int, stderrTail []byte) error {
+	if tail := strings.TrimSpace(string(stderrTail)); tail != "" {
+		return fmt.Errorf("claude sdk sidecar exited with code %d: %s", exitCode, tail)
+	}
+	return fmt.Errorf("claude sdk sidecar exited with code %d", exitCode)
 }
 
 func logClaudeSDKSidecarDebugStderr(content []byte) {

--- a/packages/agent/daemon/runtime/claude_sdk_adapter_test.go
+++ b/packages/agent/daemon/runtime/claude_sdk_adapter_test.go
@@ -2539,6 +2539,49 @@ func TestClaudeCodeSDKAdapterMapsToolLifecycleAndFileMetadata(t *testing.T) {
 	}
 }
 
+func TestClaudeSDKLineReaderExitErrorIncludesCapturedStderrTail(t *testing.T) {
+	// Regression: previously, any sidecar stderr not matching the
+	// auth-refresh-debug marker was silently discarded (logClaudeSDKSidecarDebugStderr),
+	// so if the sidecar crashed with an uncaught exception, its stack trace
+	// never reached the resulting error or the logs — the exit surfaced as a
+	// bare "claude sdk sidecar exited with code N" black box. The reader must
+	// now quote the captured stderr tail, mirroring acpClient.readLoop's
+	// handling of the Codex ACP transport.
+	exitCode := 1
+	conn := &scriptedClaudeSDKConnection{
+		frames: []ProcessFrame{
+			{Stderr: []byte("TypeError: something went wrong\n    at main (main.ts:1:1)\n")},
+			{ExitCode: &exitCode},
+		},
+	}
+	reader := &claudeSDKLineReader{conn: conn}
+
+	_, err := reader.next(context.Background())
+	if err == nil {
+		t.Fatal("next() err = nil, want exit error")
+	}
+	if !strings.Contains(err.Error(), "exited with code 1") {
+		t.Fatalf("next() err = %q, want it to mention the exit code", err.Error())
+	}
+	if !strings.Contains(err.Error(), "TypeError: something went wrong") {
+		t.Fatalf("next() err = %q, want it to quote the captured stderr tail", err.Error())
+	}
+}
+
+func TestClaudeSDKLineReaderExitErrorOmitsColonWhenNoStderr(t *testing.T) {
+	exitCode := -1
+	conn := &scriptedClaudeSDKConnection{
+		frames: []ProcessFrame{{ExitCode: &exitCode}},
+	}
+	reader := &claudeSDKLineReader{conn: conn}
+
+	_, err := reader.next(context.Background())
+	want := "claude sdk sidecar exited with code -1"
+	if err == nil || err.Error() != want {
+		t.Fatalf("next() err = %v, want %q", err, want)
+	}
+}
+
 func TestClaudeCodeSDKAdapterMapsToolFailed(t *testing.T) {
 	adapter := NewClaudeCodeSDKAdapter(nil)
 	session := standardTestSession(ProviderClaudeCode)

--- a/packages/agent/daemon/runtime/visible_error.go
+++ b/packages/agent/daemon/runtime/visible_error.go
@@ -300,8 +300,11 @@ func codexErrorLooksLikeMissingBinary(lower string) bool {
 
 // codexExitCodeFromDetail extracts the numeric process exit code from a
 // "process exited" style detail (e.g. "...exited with code 137...",
-// "exit status 1"). It returns ok=false when no numeric code is present (a bare
-// "process exited"), in which case the caller must not assume anything about it.
+// "exit status 1", "...exited with code -1..." — the negative form Go's
+// os/exec reports for a signal-terminated process, see
+// codexExitLooksInterrupted). It returns ok=false when no numeric code is
+// present (a bare "process exited"), in which case the caller must not assume
+// anything about it.
 func codexExitCodeFromDetail(normalized string) (int, bool) {
 	for _, marker := range []string{"exited with code ", "exit status "} {
 		idx := strings.Index(normalized, marker)
@@ -310,10 +313,14 @@ func codexExitCodeFromDetail(normalized string) (int, bool) {
 		}
 		rest := normalized[idx+len(marker):]
 		end := 0
+		if end < len(rest) && rest[end] == '-' {
+			end++
+		}
+		digitsStart := end
 		for end < len(rest) && rest[end] >= '0' && rest[end] <= '9' {
 			end++
 		}
-		if end == 0 {
+		if end == digitsStart {
 			continue
 		}
 		if code, err := strconv.Atoi(rest[:end]); err == nil {
@@ -324,17 +331,29 @@ func codexExitCodeFromDetail(normalized string) (int, bool) {
 }
 
 // codexExitLooksInterrupted reports whether a process-exit detail describes a
-// clean shutdown (code 0) or a signal-termination (128+N, signals 1..31) rather
-// than Codex itself erroring out. Such exits mean the app-server was stopped or
-// killed externally, so the session was interrupted — not "Codex failed". When
-// no numeric code is present it returns false (stay with the generic
-// process_exited classification rather than guess).
+// clean shutdown (code 0), a signal-termination (128+N, signals 1..31), or a
+// Go os/exec signal-termination (-1) rather than the provider process itself
+// erroring out. Such exits mean the process was stopped or killed externally,
+// so the session was interrupted — not "request failed". When no numeric code
+// is present it returns false (stay with the generic process_exited
+// classification rather than guess).
+//
+// The -1 case covers the claude-code sidecar's process wrapper
+// (localProcessConnection in process_transport.go), which reports exit codes
+// via Go's exec.ExitError.ExitCode(): per its docs, that returns -1 "if the
+// process ... was terminated by a signal" — a different convention than the
+// 128+N one Node-based app-servers (e.g. codex's) use for the same event. Seen
+// in the field: tuttid's own graceful-shutdown path (CloseAllLiveSessions)
+// calls Close() on a live claude-code session, which sends SIGTERM to the
+// sidecar; the in-flight turn's reader observed the resulting exit and (before
+// this fix) reported it as a hard "Claude Code request failed" instead of a
+// calm, retryable interruption.
 func codexExitLooksInterrupted(normalized string) bool {
 	code, ok := codexExitCodeFromDetail(normalized)
 	if !ok {
 		return false
 	}
-	return code == 0 || (code >= 129 && code <= 159)
+	return code == 0 || code == -1 || (code >= 129 && code <= 159)
 }
 
 // codexErrorLooksLikeNetwork reports whether the detail describes a DNS or

--- a/packages/agent/daemon/runtime/visible_error_test.go
+++ b/packages/agent/daemon/runtime/visible_error_test.go
@@ -104,6 +104,28 @@ func TestVisibleFailureCodeClassifiesSignalKillAsInterrupted(t *testing.T) {
 	}
 }
 
+func TestVisibleFailureCodeClassifiesGoSignalExitAsInterrupted(t *testing.T) {
+	// Regression: the claude-code sidecar's process wrapper
+	// (localProcessConnection in process_transport.go) reports a
+	// signal-terminated exit via Go's exec.ExitError.ExitCode(), which
+	// returns -1 — not the 128+N convention codex's own app-server uses for
+	// the same event. Seen in the field: tuttid's graceful-shutdown path
+	// (CloseAllLiveSessions) sends SIGTERM to a live claude-code sidecar
+	// mid-turn, and the resulting "exited with code -1" must read as a calm,
+	// retryable interruption rather than "Claude Code request failed".
+	for _, detail := range []string{
+		"claude sdk sidecar exited with code -1",
+		"claude sdk sidecar exited with code -1: ",
+	} {
+		if got := visibleFailureCode(detail); got != "session_interrupted" {
+			t.Fatalf("visibleFailureCode(%q) = %q, want session_interrupted", detail, got)
+		}
+	}
+	if !visibleFailureRetryable("session_interrupted", "claude sdk sidecar exited with code -1") {
+		t.Fatal("session_interrupted should be retryable")
+	}
+}
+
 func TestVisibleFailureCodeClassifiesUsageLimitAsQuota(t *testing.T) {
 	// The most common real codex failure in the field is the ChatGPT usage cap,
 	// delivered as plain text (no structured codexErrorInfo). It must read as a


### PR DESCRIPTION
## Summary

- A user hit a "Claude Code request failed" / "claude sdk sidecar exited with code -1" error card mid-conversation. Log analysis (diagnostic bundle `tuttid-logs-20260706-152735.zip`) traces it to an entirely intentional event, not a crash: the desktop app restarted (`desktop app before quit` in `tutti-desktop.log` at `07:26:48.244Z`), tuttid received SIGTERM and ran its graceful-shutdown path (`Controller.CloseAllLiveSessions`), which called `Close()` on the live claude-code session — sending SIGTERM to the sidecar. The in-flight turn's reader observed the resulting process exit and reported it as a hard failure instead of a calm interruption.
- Root cause: `codexExitLooksInterrupted` in `visible_error.go` only recognizes exit code `0` or the Node `128+signal` convention (129-159) as "interrupted, not a crash". The claude-code sidecar's process wrapper (`localProcessConnection` in `process_transport.go`) reports exits via Go's `exec.ExitError.ExitCode()`, which returns **-1** for a signal-terminated process — a different convention entirely. Worse, `codexExitCodeFromDetail` couldn't even parse a negative number (no `-` handling), so `-1` was never recognized as a valid exit code in the first place and fell through to the generic `process_exited` → "request failed" bucket.
- Secondary finding: any sidecar stderr not matching the auth-refresh-debug marker was silently discarded (`logClaudeSDKSidecarDebugStderr`), unlike the parallel Codex ACP client (`acp_client.go`), which already captures and quotes a stderr tail on process exit. So if the sidecar does crash for a genuine, unknown reason in the future, there'd be zero visibility into why — just a bare exit code.

## Changes

- `visible_error.go`: `codexExitCodeFromDetail` now parses an optional leading `-`; `codexExitLooksInterrupted` now also treats `-1` as an interrupted exit (with a comment explaining the Go `os/exec` convention vs. the Node 128+N one).
- `claude_sdk_adapter.go`: `claudeSDKLineReader` now captures a bounded stderr tail (mirroring `acpClientOutputTailLimit`/`acpClient.readLoop`) and quotes it in the exit error, instead of silently discarding all non-auth-refresh-debug stderr.
- Added regression tests: `TestVisibleFailureCodeClassifiesGoSignalExitAsInterrupted`, `TestClaudeSDKLineReaderExitErrorIncludesCapturedStderrTail`, `TestClaudeSDKLineReaderExitErrorOmitsColonWhenNoStderr`.

## Log evidence

- `tuttid.log` (local time, +08:00): `15:26:48.250 tuttid received signal, shutting down` (pid 15578) → new tuttid (pid 96213) starts at `15:27:00.155`.
- `tutti-desktop.log` (UTC): `07:26:48.244Z desktop app before quit` (pid 15118) → `07:26:59.842Z starting managed tuttid` (pid 95741/96213).
- Agent session `97ebfd52-ff1d-4bde-a891-90fc2798c0e4`, message id 1032 (`visible-error`): `"code":"process_exited","detail":"claude sdk sidecar exited with code -1"`, timestamped ~7.6s after the shutdown signal — i.e. the shutdown-triggered kill, not an unrelated network/proxy issue (the "網路代理" conversation topic was coincidental timing).

## Test plan

- [x] `go build ./...` and `go vet ./...` in `packages/agent/daemon`
- [x] `go test ./...` in `packages/agent/daemon` (full pass, ×2 to rule out the known regenerate-race flake)
- [x] New regression tests pass: `TestVisibleFailureCodeClassifiesGoSignalExitAsInterrupted`, `TestClaudeSDKLineReaderExitErrorIncludesCapturedStderrTail`, `TestClaudeSDKLineReaderExitErrorOmitsColonWhenNoStderr`
- [x] `gofmt -l` clean; `golangci-lint run` shows no new issues (pre-existing errcheck findings in an untouched test file only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)