### PR TITLE
[codex] Add desktop download worker analytics

### DIFF
--- a/docs/conventions/desktop-release.md
+++ b/docs/conventions/desktop-release.md
@@ -211,20 +211,43 @@ The `latest.json` metadata must include stable-identifying fields:
 - a stable `tag`, such as `v1.12.20`
 - `preferredDownloads.macosUniversalDmg`
 
-External download workers should treat these fields as a fail-closed contract. If the metadata is missing, malformed, or points at an RC or beta tag, the worker must not return that package as the public download.
+External download workers should treat these fields as a guarded public contract. If mirrored stable metadata is missing, malformed, or points at an RC or beta tag, the worker may fall back to GitHub's latest stable release. It must not return an RC or beta package as the public stable download.
 
 The download worker may expose `channel=preview` and `channel=beta` query parameters for internal links. Missing `channel` must default to `stable`. `channel=preview` must read RC metadata only; it must not fall back to beta.
 
-The `tutti-desktop-download` Worker is currently maintained directly in the Cloudflare Dashboard production editor, not in this repository. Update the production Worker there and keep this document aligned with the public contract.
+The `tutti-desktop-download` Worker is maintained in this repository under:
+
+```text
+workers/tutti-desktop-download
+```
+
+Deploy it to the Cloudflare production Worker after release download contract changes, and keep this document aligned with the public contract. The production Worker URL in Cloudflare is:
+
+```text
+https://dash.cloudflare.com/39fe2eae2688546b97e5d7e8da81cceb/workers/services/view/tutti-desktop-download/production
+```
 
 The Worker supports:
 
 ```text
-/desktop/download?platform=macos&arch=universal&format=dmg
-/desktop/download?channel=stable&platform=macos&arch=universal&format=dmg
-/desktop/download?channel=preview&platform=macos&arch=universal&format=dmg
-/desktop/download?channel=beta&platform=macos&arch=universal&format=dmg
+/desktop/latest.json
+/desktop/latest.json?channel=preview
+/desktop/download?platform=macos&arch=universal&format=dmg&source=readme
+/desktop/download?channel=stable&platform=macos&arch=universal&format=dmg&source=readme
+/desktop/download?channel=preview&platform=macos&arch=universal&format=dmg&source=qa
+/desktop/download?channel=beta&platform=macos&arch=universal&format=dmg&source=qa
 ```
+
+`channel=rc` is accepted as an alias for `channel=preview`.
+`/desktop/latest.json` returns metadata with asset `url` fields rewritten to
+public `/desktop/download` URLs while preserving original artifact URLs in
+`cdnUrl`.
+
+Successful GET download redirects should report the DataFinder Tea event
+`desktop_download.clicked` with normalized `platform`, `arch`, `format`,
+`release_channel`, release metadata, selected asset metadata, and `source`.
+`source` is provided by the download URL query string and defaults to
+`unknown` when absent. Analytics failures must not block the download redirect.
 
 Stable mirrored releases also update the aggregate changelog feed:
 

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "packageManager": "pnpm@10.11.0+sha512.6540583f41cc5f628eb3d9773ecee802f4f9ef9923cc45b69890fb47991d4b092964694ec3a4f738a420c918a333062c8b925d312f42e4f0c263eb603551f977",
   "workspaces": [
     "apps/*",
+    "workers/*",
     "packages/*/*",
     "services/tuttid/builtin-apps/tutti-onboarding",
     "tools/fixtures/*"
@@ -77,7 +78,7 @@
     "sync:workbench-go-contract": "node ./tools/scripts/generate-workbench-go-contract.mjs",
     "test:tools": "node --test ./tools/scripts/check-tutti-names.test.mjs ./tools/scripts/check-renderer-feature-boundaries.test.mjs ./tools/scripts/check-electron-runtime-boundaries.test.mjs ./tools/scripts/check-i18n.test.mjs ./tools/scripts/desktop-build-version.test.mjs ./tools/scripts/desktop-dmg-notarization.test.mjs ./tools/scripts/desktop-release-changelog.test.mjs ./tools/scripts/desktop-release-config.test.mjs ./tools/scripts/desktop-release-download-links.test.mjs ./tools/scripts/desktop-release-feishu-card.test.mjs ./tools/scripts/desktop-release-latest.test.mjs ./tools/scripts/desktop-release-reservation.test.mjs ./tools/scripts/desktop-release-summary.test.mjs ./tools/scripts/desktop-release-versioning.test.mjs ./tools/scripts/dev-web.test.mjs ./tools/scripts/generate-defaults.test.mjs ./tools/scripts/lark-log-tool.test.mjs ./tools/scripts/migrate-local-state-layout.test.mjs ./tools/scripts/npm-release-packages.test.mjs ./tools/scripts/package-release-version.test.mjs ./tools/scripts/publish-packages.test.mjs ./tools/scripts/build-tutti-app-release.test.mjs ./tools/scripts/build-tutti-app-runtime-catalog.test.mjs ./tools/scripts/run-check-changed-targets.test.mjs",
     "test:go": "pnpm generate:builtin-apps && cd packages/appcli/core && go test ./... && cd ../../workspace/files && go test ./... && cd ../../workbench/service && go test ./... && cd ../../../services/tuttid && go test ./... && cd ../../apps/cli && go test ./...",
-    "test:ts": "pnpm --filter @tutti-os/desktop test && pnpm --filter @tutti-os/browser-node test && pnpm --filter @tutti-os/client-tuttid-ts test && pnpm --filter @tutti-os/workbench-snapshot test && pnpm --filter @tutti-os/workbench-surface test && pnpm --filter @tutti-os/workspace-file-preview test && pnpm --filter @tutti-os/workspace-file-manager test && pnpm test:tools",
+    "test:ts": "pnpm --filter @tutti-os/desktop test && pnpm --filter @tutti-os/desktop-download-worker test && pnpm --filter @tutti-os/browser-node test && pnpm --filter @tutti-os/client-tuttid-ts test && pnpm --filter @tutti-os/workbench-snapshot test && pnpm --filter @tutti-os/workbench-surface test && pnpm --filter @tutti-os/workspace-file-preview test && pnpm --filter @tutti-os/workspace-file-manager test && pnpm test:tools",
     "typecheck": "node ./tools/scripts/run-typecheck.mjs"
   },
   "lint-staged": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -187,6 +187,8 @@ importers:
         specifier: ^6.3.5
         version: 6.4.2(@types/node@24.12.4)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.22.3)(yaml@2.9.0)
 
+  workers/tutti-desktop-download: {}
+
   apps/ui-storyboard:
     dependencies:
       "@tutti-os/ui-system":

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,5 +1,6 @@
 packages:
   - "apps/*"
+  - "workers/*"
   - "packages/*/*"
   - "services/tuttid/builtin-apps/tutti-onboarding"
   - "tools/fixtures/*"

--- a/tools/scripts/desktop-release-config.test.mjs
+++ b/tools/scripts/desktop-release-config.test.mjs
@@ -511,6 +511,7 @@ test("workspace root declares package workspaces for electron-builder fallback d
 
   assert.deepEqual(packageJson.workspaces, [
     "apps/*",
+    "workers/*",
     "packages/*/*",
     "services/tuttid/builtin-apps/tutti-onboarding",
     "tools/fixtures/*"

--- a/workers/tutti-desktop-download/README.md
+++ b/workers/tutti-desktop-download/README.md
@@ -1,0 +1,92 @@
+# Tutti Desktop Download Worker
+
+This Worker owns the public desktop download endpoint:
+
+```text
+https://tutti.sh/desktop/download
+```
+
+It reads desktop release metadata from the mirrored release asset prefix and
+redirects to a validated asset URL. The production Cloudflare service is
+`tutti-desktop-download` under account `39fe2eae2688546b97e5d7e8da81cceb`.
+
+## Configuration
+
+The production asset base URL defaults to:
+
+```text
+https://d1x7gb6wqsqmnm.cloudfront.net/tutti-desktop-release-assets
+```
+
+Set this Worker variable only when overriding the production asset prefix:
+
+```text
+TUTTI_DESKTOP_RELEASE_ASSETS_BASE_URL=https://<asset-base-url>
+```
+
+Set these Worker variables to enable DataFinder Tea reporting:
+
+```text
+TUTTI_ANALYTICS_APP_ID=20004134
+TUTTI_ANALYTICS_APP_KEY=<tea-app-key>
+TUTTI_ANALYTICS_CHANNEL_DOMAIN=https://gator.uba.ap-southeast-1.volces.com
+TUTTI_ANALYTICS_APP_VERSION=0.0.0
+```
+
+The base URL must expose:
+
+```text
+latest.json
+channels/preview/latest.json
+channels/rc/latest.json
+channels/beta/latest.json
+```
+
+Stable requests read `latest.json`. Preview requests read
+`channels/preview/latest.json`. Beta requests read `channels/beta/latest.json`.
+If stable mirrored metadata is malformed or points at a prerelease, the Worker
+falls back to GitHub's latest stable release.
+
+## Endpoints
+
+```text
+/desktop/latest.json
+/desktop/download
+```
+
+`/desktop/latest.json` rewrites asset `url` fields to public
+`/desktop/download` URLs and keeps the original artifact URL in `cdnUrl`.
+
+## Analytics
+
+Successful `GET /desktop/download` redirects report a best-effort DataFinder
+Tea event:
+
+```text
+desktop_download.clicked
+```
+
+The event includes normalized `platform`, `arch`, `format`, `release_channel`,
+`release_tag`, `release_version`, `asset_name`, `download_url`, and `source`.
+The `source` field comes from the download URL query string:
+
+```text
+/desktop/download?platform=macos&arch=universal&format=dmg&source=readme
+```
+
+When `source` is absent or empty, the Worker reports `source: "unknown"`.
+Analytics failures are ignored so download redirects are not blocked.
+
+## Local Checks
+
+```bash
+node --test workers/tutti-desktop-download/src/worker.test.mjs
+```
+
+## Deployment
+
+Deploy from this package after confirming the production Worker variable:
+
+```bash
+pnpm --filter @tutti-os/desktop-download-worker deploy:production
+```

--- a/workers/tutti-desktop-download/package.json
+++ b/workers/tutti-desktop-download/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "@tutti-os/desktop-download-worker",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "deploy:production": "pnpm dlx wrangler@4.24.3 deploy --env production",
+    "test": "node --test ./src/worker.test.mjs"
+  }
+}

--- a/workers/tutti-desktop-download/src/worker.mjs
+++ b/workers/tutti-desktop-download/src/worker.mjs
@@ -1,0 +1,487 @@
+const DEFAULT_ASSET_BASE_URL =
+  "https://d1x7gb6wqsqmnm.cloudfront.net/tutti-desktop-release-assets";
+const PUBLIC_DOWNLOAD_URL = "https://tutti.sh/desktop/download";
+const GITHUB_LATEST_RELEASE_URL =
+  "https://api.github.com/repos/tutti-os/tutti/releases/latest";
+const releaseLatestSchemaVersion = "tutti.desktop.release.latest.v1";
+const analyticsEventName = "desktop_download.clicked";
+const publicDownloadUserId = "public-download";
+
+const CHANNEL_LATEST_PATHS = {
+  stable: "latest.json",
+  preview: "channels/preview/latest.json",
+  beta: "channels/beta/latest.json"
+};
+
+class HttpError extends Error {
+  constructor(message, status) {
+    super(message);
+    this.status = status;
+  }
+}
+
+function createAnalyticsEvent(name, params) {
+  return {
+    clientTs: Date.now(),
+    name,
+    params
+  };
+}
+
+function normalizeBaseUrl(value) {
+  return String(value ?? "").trim().replace(/\/+$/, "");
+}
+
+function normalizeSource(value) {
+  const normalized = String(value ?? "").trim();
+  return normalized || "unknown";
+}
+
+function normalizeChannel(value) {
+  if (!value) {
+    return "stable";
+  }
+  const channel = value.trim().toLowerCase();
+  if (channel === "stable") {
+    return "stable";
+  }
+  if (channel === "preview" || channel === "rc") {
+    return "preview";
+  }
+  if (channel === "beta") {
+    return "beta";
+  }
+  throw new HttpError(`unsupported channel: ${value}`, 400);
+}
+
+function resolveAssetBaseUrl(env = {}) {
+  return (
+    normalizeBaseUrl(env.TUTTI_DESKTOP_RELEASE_ASSETS_BASE_URL) ||
+    DEFAULT_ASSET_BASE_URL
+  );
+}
+
+function resolveAnalyticsConfig(env) {
+  const appId = Number.parseInt(String(env.TUTTI_ANALYTICS_APP_ID ?? ""), 10);
+  const appKey = String(env.TUTTI_ANALYTICS_APP_KEY ?? "").trim();
+  const channelDomain = normalizeBaseUrl(
+    env.TUTTI_ANALYTICS_CHANNEL_DOMAIN ?? ""
+  );
+  if (
+    !Number.isSafeInteger(appId) ||
+    appId <= 0 ||
+    !appKey ||
+    !isSupportedHttpsUrl(channelDomain)
+  ) {
+    return null;
+  }
+  return {
+    appId,
+    appKey,
+    appVersion:
+      String(env.TUTTI_ANALYTICS_APP_VERSION ?? "0.0.0").trim() || "0.0.0",
+    channelDomain
+  };
+}
+
+function isSupportedHttpsUrl(value) {
+  try {
+    const url = new URL(value);
+    return url.protocol === "https:";
+  } catch {
+    return false;
+  }
+}
+
+async function handleDesktopDownloadRequest(
+  request,
+  env = {},
+  options = {}
+) {
+  const fetchImpl = options.fetch ?? fetch;
+  try {
+    const url = new URL(request.url);
+    const channel = normalizeChannel(url.searchParams.get("channel"));
+    const assetBaseUrl = resolveAssetBaseUrl(env);
+
+    if (url.pathname === "/desktop/latest.json") {
+      const latest = await resolveLatest(channel, {
+        assetBaseUrl,
+        fetchImpl
+      });
+      return Response.json(rewriteLatest(latest, channel), {
+        headers: {
+          "cache-control": "public, max-age=60"
+        }
+      });
+    }
+
+    if (url.pathname === "/desktop/download") {
+      const latest = await resolveLatest(channel, {
+        assetBaseUrl,
+        fetchImpl
+      });
+      const asset = findAsset(latest.assets, url.searchParams);
+      if (!asset) {
+        return Response.json(
+          {
+            error: "asset_not_found",
+            assets: rewriteAssets(latest.assets, channel)
+          },
+          {
+            status: 404,
+            headers: {
+              "cache-control": "no-store"
+            }
+          }
+        );
+      }
+
+      const redirectUrl = asset.cdnUrl || asset.url;
+      if (request.method === "GET") {
+        trackDownloadClicked({
+          analytics: resolveAnalyticsConfig(env),
+          asset,
+          fetchImpl,
+          latest,
+          releaseChannel: channel,
+          redirectUrl,
+          source: normalizeSource(url.searchParams.get("source")),
+          waitUntil: options.waitUntil
+        });
+      }
+
+      return Response.redirect(redirectUrl, 302);
+    }
+
+    return Response.json(
+      {
+        error: "not_found"
+      },
+      {
+        status: 404,
+        headers: {
+          "cache-control": "no-store"
+        }
+      }
+    );
+  } catch (error) {
+    const status = error instanceof HttpError ? error.status : 502;
+    return Response.json(
+      {
+        error:
+          status === 400 ? "bad_request" : "desktop_download_unavailable",
+        message: error instanceof Error ? error.message : String(error)
+      },
+      {
+        status,
+        headers: {
+          "cache-control": "no-store"
+        }
+      }
+    );
+  }
+}
+
+async function resolveLatest(channel, { assetBaseUrl, fetchImpl }) {
+  const latest = await fetchChannelLatest(channel, { assetBaseUrl, fetchImpl });
+  if (channel === "stable") {
+    try {
+      validateLatest(latest, "stable");
+      return latest;
+    } catch {
+      return fetchGitHubStableLatest(fetchImpl);
+    }
+  }
+  validateLatest(latest, channel);
+  return latest;
+}
+
+async function fetchChannelLatest(channel, { assetBaseUrl, fetchImpl }) {
+  const latestUrl = new URL(CHANNEL_LATEST_PATHS[channel], `${assetBaseUrl}/`);
+  const response = await fetchImpl(latestUrl.href, {
+    cf: {
+      cacheEverything: true,
+      cacheTtl: 60
+    }
+  });
+  if (!response.ok) {
+    throw new Error(
+      `failed to fetch ${latestUrl.pathname}: ${response.status}`
+    );
+  }
+  return response.json();
+}
+
+async function fetchGitHubStableLatest(fetchImpl) {
+  const response = await fetchImpl(GITHUB_LATEST_RELEASE_URL, {
+    headers: {
+      accept: "application/vnd.github+json",
+      "user-agent": "tutti-desktop-download-worker"
+    },
+    cf: {
+      cacheEverything: true,
+      cacheTtl: 60
+    }
+  });
+  if (!response.ok) {
+    throw new Error(`failed to fetch GitHub latest release: ${response.status}`);
+  }
+  const release = await response.json();
+  if (
+    release.prerelease === true ||
+    release.draft === true ||
+    !/^v\d+\.\d+\.\d+$/.test(String(release.tag_name || ""))
+  ) {
+    throw new Error("GitHub latest release is not a stable desktop release");
+  }
+  const assets = Array.isArray(release.assets)
+    ? release.assets.map(githubAssetToLatestAsset)
+    : [];
+  return {
+    schemaVersion: releaseLatestSchemaVersion,
+    tag: release.tag_name,
+    version: String(release.tag_name).replace(/^v/, ""),
+    channel: "stable",
+    prerelease: false,
+    releasedAt:
+      release.published_at || release.created_at || new Date().toISOString(),
+    gitSha: release.target_commitish || null,
+    sourceRef: release.target_commitish || null,
+    baseUrl: release.html_url,
+    preferredDownloads: {
+      macosUniversalDmg:
+        assets.find(
+          (asset) =>
+            asset.platform === "macos" &&
+            asset.arch === "universal" &&
+            asset.format === "dmg"
+        )?.url || null
+    },
+    assets
+  };
+}
+
+function githubAssetToLatestAsset(asset) {
+  const metadata = parseAssetName(String(asset.name || ""));
+  return {
+    ...metadata,
+    name: asset.name,
+    sizeBytes: asset.size || 0,
+    url: asset.browser_download_url
+  };
+}
+
+function parseAssetName(name) {
+  let format = name.split(".").pop() || "unknown";
+  if (name.endsWith(".zip.blockmap")) {
+    format = "blockmap";
+  }
+  const metadata = {
+    arch: "unknown",
+    format,
+    platform: "unknown"
+  };
+  const macMatch = name.match(/-mac-(x64|arm64|universal)\.(dmg|zip)$/);
+  if (macMatch) {
+    metadata.platform = "macos";
+    metadata.arch = macMatch[1];
+    metadata.format = macMatch[2];
+  }
+  return metadata;
+}
+
+function validateLatest(latest, channel) {
+  if (!latest || typeof latest !== "object") {
+    throw new Error("latest metadata is not an object");
+  }
+  if (!Array.isArray(latest.assets)) {
+    throw new Error("latest metadata is missing assets");
+  }
+  const version = String(latest.version || "");
+  const tag = String(latest.tag || "");
+  if (channel === "stable") {
+    if (
+      (latest.channel != null && latest.channel !== "stable") ||
+      latest.prerelease === true ||
+      !/^\d+\.\d+\.\d+$/.test(version) ||
+      !/^v\d+\.\d+\.\d+$/.test(tag)
+    ) {
+      throw new Error("stable latest metadata must point to a stable release");
+    }
+    return;
+  }
+  if (channel === "preview") {
+    if (
+      latest.channel !== "rc" ||
+      latest.prerelease !== true ||
+      !/^\d+\.\d+\.\d+-rc\.\d+$/.test(version) ||
+      !/^v\d+\.\d+\.\d+-rc\.\d+$/.test(tag)
+    ) {
+      throw new Error("preview latest metadata must point to an RC release");
+    }
+    return;
+  }
+  if (
+    latest.channel !== "beta" ||
+    latest.prerelease !== true ||
+    !/^\d+\.\d+\.\d+-beta\.\d+$/.test(version) ||
+    !/^v\d+\.\d+\.\d+-beta\.\d+$/.test(tag)
+  ) {
+    throw new Error("beta latest metadata must point to a beta release");
+  }
+}
+
+function rewriteLatest(latest, channel) {
+  return {
+    ...latest,
+    downloadChannel: channel,
+    assets: rewriteAssets(latest.assets, channel)
+  };
+}
+
+function rewriteAssets(assets, channel) {
+  return assets.map((asset) => ({
+    ...asset,
+    cdnUrl: asset.cdnUrl || asset.url,
+    url: publicDownloadUrl(asset, channel)
+  }));
+}
+
+function publicDownloadUrl(asset, channel) {
+  const url = new URL(PUBLIC_DOWNLOAD_URL);
+  if (channel !== "stable") {
+    url.searchParams.set("channel", channel);
+  }
+  url.searchParams.set("platform", asset.platform);
+  url.searchParams.set("arch", asset.arch);
+  url.searchParams.set("format", asset.format);
+  return url.href;
+}
+
+function findAsset(assets, params) {
+  const platform = params.get("platform");
+  const arch = params.get("arch");
+  const format = params.get("format");
+  return assets.find(
+    (asset) =>
+      asset.platform === platform &&
+      asset.arch === arch &&
+      asset.format === format
+  );
+}
+
+function createDesktopDownloadClickedEvent({
+  asset,
+  latest,
+  releaseChannel,
+  redirectUrl,
+  source
+}) {
+  return createAnalyticsEvent(analyticsEventName, {
+    arch: asset.arch,
+    asset_name: asset.name ?? "",
+    download_url: redirectUrl,
+    format: asset.format,
+    platform: asset.platform,
+    release_channel: releaseChannel,
+    release_tag: latest.tag,
+    release_version: latest.version,
+    source
+  });
+}
+
+function buildTeaEventPayload({ analytics, event }) {
+  return {
+    app_type: "app",
+    user_unique_id: publicDownloadUserId,
+    header: {
+      custom: {
+        app_version: analytics.appVersion,
+        os: "cloudflare_worker",
+        surface: "desktop_download_worker"
+      },
+      user_unique_id: publicDownloadUserId
+    },
+    event_v3: [
+      {
+        event: event.name,
+        local_time_ms: event.clientTs,
+        params: event.params
+      }
+    ]
+  };
+}
+
+async function sendTeaDownloadEvent(fetchImpl, analytics, payload) {
+  const response = await fetchImpl(`${analytics.channelDomain}/sdk/log`, {
+    body: JSON.stringify(payload),
+    headers: {
+      "content-type": "application/json",
+      "x-mcs-appkey": analytics.appKey
+    },
+    method: "POST"
+  });
+  if (!response.ok) {
+    throw new Error(`analytics request failed with ${response.status}`);
+  }
+}
+
+function trackDownloadClicked({
+  analytics,
+  asset,
+  fetchImpl,
+  latest,
+  releaseChannel,
+  redirectUrl,
+  source,
+  waitUntil
+}) {
+  if (!analytics) {
+    return;
+  }
+  const event = createDesktopDownloadClickedEvent({
+    asset,
+    latest,
+    releaseChannel,
+    redirectUrl,
+    source
+  });
+  const payload = buildTeaEventPayload({ analytics, event });
+  const promise = sendTeaDownloadEvent(fetchImpl, analytics, payload).catch(
+    () => undefined
+  );
+  if (typeof waitUntil === "function") {
+    waitUntil(promise);
+    return;
+  }
+  void promise;
+}
+
+export default {
+  fetch(request, env, ctx) {
+    return handleDesktopDownloadRequest(request, env, {
+      waitUntil: ctx?.waitUntil?.bind(ctx)
+    });
+  }
+};
+
+export {
+  HttpError,
+  buildTeaEventPayload,
+  createAnalyticsEvent,
+  createDesktopDownloadClickedEvent,
+  fetchGitHubStableLatest,
+  findAsset,
+  handleDesktopDownloadRequest,
+  normalizeBaseUrl,
+  normalizeChannel,
+  normalizeSource,
+  parseAssetName,
+  publicDownloadUrl,
+  resolveAnalyticsConfig,
+  resolveLatest,
+  rewriteAssets,
+  rewriteLatest,
+  validateLatest
+};

--- a/workers/tutti-desktop-download/src/worker.test.mjs
+++ b/workers/tutti-desktop-download/src/worker.test.mjs
@@ -1,0 +1,353 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { handleDesktopDownloadRequest } from "./worker.mjs";
+
+const baseUrl = "https://downloads.example.com/desktop-release-assets";
+
+function createMetadata(overrides = {}) {
+  return {
+    schemaVersion: "tutti.desktop.release.latest.v1",
+    tag: "v1.2.3",
+    version: "1.2.3",
+    channel: "stable",
+    prerelease: false,
+    baseUrl,
+    preferredDownloads: {
+      macosUniversalDmg: `${baseUrl}/v1.2.3/Tutti-1.2.3-mac-universal.dmg`
+    },
+    assets: [
+      {
+        name: "Tutti-1.2.3-mac-universal.dmg",
+        platform: "macos",
+        arch: "universal",
+        format: "dmg",
+        url: `${baseUrl}/v1.2.3/Tutti-1.2.3-mac-universal.dmg`
+      },
+      {
+        name: "Tutti-1.2.3-mac-arm64.dmg",
+        platform: "macos",
+        arch: "arm64",
+        format: "dmg",
+        url: `${baseUrl}/v1.2.3/Tutti-1.2.3-mac-arm64.dmg`
+      }
+    ],
+    ...overrides
+  };
+}
+
+function createFetch(metadataByPath, options = {}) {
+  const requests = [];
+  const analyticsRequests = [];
+  const fetchImpl = async (url, init = undefined) => {
+    const request = url instanceof Request ? url : new Request(url, init);
+    const parsed = new URL(request.url);
+    if (parsed.pathname === "/sdk/log") {
+      analyticsRequests.push({
+        body: await request.json(),
+        headers: Object.fromEntries(request.headers.entries()),
+        url: parsed.href
+      });
+      if (options.analyticsStatus && options.analyticsStatus >= 400) {
+        return new Response("analytics failed", {
+          status: options.analyticsStatus
+        });
+      }
+      return Response.json({ ok: true });
+    }
+
+    requests.push(request.url);
+    const metadata = metadataByPath[`${parsed.host}${parsed.pathname}`] ?? metadataByPath[parsed.pathname];
+    if (!metadata) {
+      return new Response("not found", { status: 404 });
+    }
+    return Response.json(metadata);
+  };
+  fetchImpl.requests = requests;
+  fetchImpl.analyticsRequests = analyticsRequests;
+  return fetchImpl;
+}
+
+async function download(path, metadataByPath, options = {}) {
+  const fetchImpl = createFetch(metadataByPath, options);
+  const waitUntilPromises = [];
+  const response = await handleDesktopDownloadRequest(
+    new Request(`https://tutti.sh${path}`, {
+      method: options.method ?? "GET"
+    }),
+    {
+      TUTTI_ANALYTICS_APP_ID: "20004134",
+      TUTTI_ANALYTICS_APP_KEY: "test-app-key",
+      TUTTI_ANALYTICS_APP_VERSION: "0.0.0",
+      TUTTI_ANALYTICS_CHANNEL_DOMAIN: "https://analytics.example.com",
+      TUTTI_DESKTOP_RELEASE_ASSETS_BASE_URL: baseUrl,
+      ...options.env
+    },
+    {
+      fetch: fetchImpl,
+      waitUntil: (promise) => waitUntilPromises.push(promise)
+    }
+  );
+  await Promise.allSettled(waitUntilPromises);
+  return {
+    analyticsRequests: fetchImpl.analyticsRequests,
+    fetchRequests: fetchImpl.requests,
+    response
+  };
+}
+
+test("stable download redirects to the macOS universal DMG from root latest metadata", async () => {
+  const { analyticsRequests, fetchRequests, response } = await download(
+    "/desktop/download?platform=macos&arch=universal&format=dmg&source=readme",
+    {
+      "/desktop-release-assets/latest.json": createMetadata()
+    }
+  );
+
+  assert.equal(response.status, 302);
+  assert.equal(
+    response.headers.get("location"),
+    `${baseUrl}/v1.2.3/Tutti-1.2.3-mac-universal.dmg`
+  );
+  assert.deepEqual(fetchRequests, [`${baseUrl}/latest.json`]);
+  assert.equal(analyticsRequests.length, 1);
+  assert.equal(
+    analyticsRequests[0].url,
+    "https://analytics.example.com/sdk/log"
+  );
+  assert.equal(analyticsRequests[0].headers["x-mcs-appkey"], "test-app-key");
+  assert.equal(analyticsRequests[0].body.app_type, "app");
+  assert.equal(analyticsRequests[0].body.user_unique_id, "public-download");
+  assert.equal(analyticsRequests[0].body.header.custom.app_version, "0.0.0");
+  assert.deepEqual(analyticsRequests[0].body.event_v3, [
+    {
+      event: "desktop_download.clicked",
+      local_time_ms: analyticsRequests[0].body.event_v3[0].local_time_ms,
+      params: {
+        arch: "universal",
+        asset_name: "Tutti-1.2.3-mac-universal.dmg",
+        download_url:
+          "https://downloads.example.com/desktop-release-assets/v1.2.3/Tutti-1.2.3-mac-universal.dmg",
+        format: "dmg",
+        platform: "macos",
+        release_channel: "stable",
+        release_tag: "v1.2.3",
+        release_version: "1.2.3",
+        source: "readme"
+      }
+    }
+  ]);
+});
+
+test("download analytics defaults source to unknown when query omits source", async () => {
+  const { analyticsRequests, response } = await download(
+    "/desktop/download?platform=macos&arch=universal&format=dmg",
+    {
+      "/desktop-release-assets/latest.json": createMetadata()
+    }
+  );
+
+  assert.equal(response.status, 302);
+  assert.equal(analyticsRequests[0].body.event_v3[0].params.source, "unknown");
+});
+
+test("download analytics defaults empty source to unknown", async () => {
+  const { analyticsRequests, response } = await download(
+    "/desktop/download?platform=macos&arch=universal&format=dmg&source=",
+    {
+      "/desktop-release-assets/latest.json": createMetadata()
+    }
+  );
+
+  assert.equal(response.status, 302);
+  assert.equal(analyticsRequests[0].body.event_v3[0].params.source, "unknown");
+});
+
+test("download still redirects when analytics reporting fails", async () => {
+  const { analyticsRequests, response } = await download(
+    "/desktop/download?platform=macos&arch=universal&format=dmg&source=readme",
+    {
+      "/desktop-release-assets/latest.json": createMetadata()
+    },
+    { analyticsStatus: 500 }
+  );
+
+  assert.equal(response.status, 302);
+  assert.equal(analyticsRequests.length, 1);
+});
+
+test("HEAD download redirect does not report analytics", async () => {
+  const { analyticsRequests, response } = await download(
+    "/desktop/download?platform=macos&arch=universal&format=dmg&source=readme",
+    {
+      "/desktop-release-assets/latest.json": createMetadata()
+    },
+    { method: "HEAD" }
+  );
+
+  assert.equal(response.status, 302);
+  assert.equal(analyticsRequests.length, 0);
+});
+
+test("latest endpoint rewrites assets to public download URLs", async () => {
+  const { response } = await download(
+    "/desktop/latest.json?channel=preview",
+    {
+      "/desktop-release-assets/channels/preview/latest.json": createMetadata({
+        tag: "v1.2.4-rc.1",
+        version: "1.2.4-rc.1",
+        channel: "rc",
+        prerelease: true,
+        preferredDownloads: {
+          macosUniversalDmg: `${baseUrl}/v1.2.4-rc.1/Tutti-1.2.4-rc.1-mac-universal.dmg`
+        },
+        assets: [
+          {
+            name: "Tutti-1.2.4-rc.1-mac-universal.dmg",
+            platform: "macos",
+            arch: "universal",
+            format: "dmg",
+            url: `${baseUrl}/v1.2.4-rc.1/Tutti-1.2.4-rc.1-mac-universal.dmg`
+          }
+        ]
+      })
+    }
+  );
+  const body = await response.json();
+
+  assert.equal(response.status, 200);
+  assert.equal(body.downloadChannel, "preview");
+  assert.equal(
+    body.assets[0].cdnUrl,
+    `${baseUrl}/v1.2.4-rc.1/Tutti-1.2.4-rc.1-mac-universal.dmg`
+  );
+  assert.equal(
+    body.assets[0].url,
+    "https://tutti.sh/desktop/download?channel=preview&platform=macos&arch=universal&format=dmg"
+  );
+});
+
+test("preview channel reads preview latest metadata and requires an rc package", async () => {
+  const metadata = createMetadata({
+    tag: "v1.2.4-rc.1",
+    version: "1.2.4-rc.1",
+    channel: "rc",
+    prerelease: true,
+    preferredDownloads: {
+      macosUniversalDmg: `${baseUrl}/v1.2.4-rc.1/Tutti-1.2.4-rc.1-mac-universal.dmg`
+    },
+    assets: [
+      {
+        name: "Tutti-1.2.4-rc.1-mac-universal.dmg",
+        platform: "macos",
+        arch: "universal",
+        format: "dmg",
+        url: `${baseUrl}/v1.2.4-rc.1/Tutti-1.2.4-rc.1-mac-universal.dmg`
+      }
+    ]
+  });
+
+  const { fetchRequests, response } = await download(
+    "/desktop/download?channel=preview&platform=macos&arch=universal&format=dmg",
+    {
+      "/desktop-release-assets/channels/preview/latest.json": metadata
+    }
+  );
+
+  assert.equal(response.status, 302);
+  assert.equal(
+    response.headers.get("location"),
+    `${baseUrl}/v1.2.4-rc.1/Tutti-1.2.4-rc.1-mac-universal.dmg`
+  );
+  assert.deepEqual(fetchRequests, [
+    `${baseUrl}/channels/preview/latest.json`
+  ]);
+});
+
+test("rc channel alias reads preview latest metadata", async () => {
+  const metadata = createMetadata({
+    tag: "v1.2.4-rc.1",
+    version: "1.2.4-rc.1",
+    channel: "rc",
+    prerelease: true,
+    preferredDownloads: {
+      macosUniversalDmg: `${baseUrl}/v1.2.4-rc.1/Tutti-1.2.4-rc.1-mac-universal.dmg`
+    },
+    assets: [
+      {
+        name: "Tutti-1.2.4-rc.1-mac-universal.dmg",
+        platform: "macos",
+        arch: "universal",
+        format: "dmg",
+        url: `${baseUrl}/v1.2.4-rc.1/Tutti-1.2.4-rc.1-mac-universal.dmg`
+      }
+    ]
+  });
+
+  const { fetchRequests, response } = await download(
+    "/desktop/download?channel=rc&platform=macos&arch=universal&format=dmg",
+    {
+      "/desktop-release-assets/channels/preview/latest.json": metadata
+    }
+  );
+
+  assert.equal(response.status, 302);
+  assert.deepEqual(fetchRequests, [
+    `${baseUrl}/channels/preview/latest.json`
+  ]);
+});
+
+test("stable channel falls back to GitHub latest when mirrored metadata points at a prerelease", async () => {
+  const { analyticsRequests, response } = await download(
+    "/desktop/download?platform=macos&arch=universal&format=dmg",
+    {
+      "/desktop-release-assets/latest.json": createMetadata({
+        tag: "v1.2.4-rc.1",
+        version: "1.2.4-rc.1",
+        channel: "rc",
+        prerelease: true
+      }),
+      "api.github.com/repos/tutti-os/tutti/releases/latest": {
+        tag_name: "v1.2.3",
+        prerelease: false,
+        draft: false,
+        published_at: "2026-07-06T00:00:00.000Z",
+        created_at: "2026-07-06T00:00:00.000Z",
+        target_commitish: "main",
+        html_url: "https://github.com/tutti-os/tutti/releases/tag/v1.2.3",
+        assets: [
+          {
+            name: "Tutti-1.2.3-mac-universal.dmg",
+            size: 123,
+            browser_download_url:
+              "https://github.com/tutti-os/tutti/releases/download/v1.2.3/Tutti-1.2.3-mac-universal.dmg"
+          }
+        ]
+      }
+    }
+  );
+
+  assert.equal(response.status, 302);
+  assert.equal(
+    response.headers.get("location"),
+    "https://github.com/tutti-os/tutti/releases/download/v1.2.3/Tutti-1.2.3-mac-universal.dmg"
+  );
+  assert.equal(analyticsRequests.length, 1);
+});
+
+test("unsupported asset combinations return not found instead of redirecting", async () => {
+  const { analyticsRequests, response } = await download(
+    "/desktop/download?platform=windows&arch=arm64&format=exe",
+    {
+      "/desktop-release-assets/latest.json": createMetadata()
+    }
+  );
+
+  assert.equal(response.status, 404);
+  const body = await response.json();
+  assert.equal(
+    body.assets[0].url,
+    "https://tutti.sh/desktop/download?platform=macos&arch=universal&format=dmg"
+  );
+  assert.equal(analyticsRequests.length, 0);
+});

--- a/workers/tutti-desktop-download/wrangler.toml
+++ b/workers/tutti-desktop-download/wrangler.toml
@@ -1,0 +1,14 @@
+name = "tutti-desktop-download"
+main = "src/worker.mjs"
+compatibility_date = "2025-07-01"
+account_id = "39fe2eae2688546b97e5d7e8da81cceb"
+
+routes = [
+  { pattern = "tutti.sh/desktop/download*", zone_name = "tutti.sh" }
+]
+
+[env.production]
+name = "tutti-desktop-download"
+routes = [
+  { pattern = "tutti.sh/desktop/download*", zone_name = "tutti.sh" }
+]


### PR DESCRIPTION
## Summary
- add the `tutti-desktop-download` Cloudflare Worker under `workers/`
- redirect desktop download requests from validated release metadata with stable/preview/beta channel handling
- report best-effort DataFinder Tea event `desktop_download.clicked` for successful GET downloads, including platform, arch, format, source, release, and asset fields
- document Worker configuration, deployment, and the `source` query parameter

## Validation
- `pnpm --filter @tutti-os/desktop-download-worker test`
- `git diff --check`
