### PR TITLE
fix(agent-gui): ignore stale active-turn submit blocks

### DIFF
--- a/docs/architecture/agent-gui-node.md
+++ b/docs/architecture/agent-gui-node.md
@@ -999,6 +999,14 @@ would strand the queued prompt until another unrelated activity event. The
 retry block still prevents immediately re-claiming against the exact same
 pre-send ready state.
 
+AgentGuiNode busy state must treat turn lifecycle as the primary proof of live
+work. A stale control-state `submitAvailability.blocked(active_turn)` may arrive
+after the daemon has already published `turnLifecycle.activeTurnId = null` and a
+settled phase; that blocked value alone must not keep the composer loading or
+force follow-up prompts into the local queue. Only count an active-turn submit
+block as busy while the control state's lifecycle still has an active turn or a
+live phase.
+
 Preview-mode AgentGUI surfaces are read-only for this runtime: they may render an
 existing queue if injected into the same context, but they must not enqueue,
 claim, drain, promote, edit, or delete queued prompts.

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUINodeController.spec.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUINodeController.spec.tsx
@@ -14553,6 +14553,66 @@ describe("useAgentGUINodeController", () => {
     expect(result.current.viewModel.queuedPrompts).toEqual([]);
   });
 
+  it("does not queue when a settled control state keeps stale active-turn submit block", async () => {
+    const exec = vi.fn(async () => ({
+      agentSessionId: "session-1",
+      turnId: "turn-1",
+      accepted: true,
+      sessionStatus: "working" as const,
+      events: []
+    }));
+    installAgentHostApi({
+      list: vi.fn(async () =>
+        snapshotWithSession("session-1", {
+          effectiveStatus: "ready",
+          turnPhase: "settled"
+        })
+      ),
+      listSessionTimeline: vi.fn(async () => ({ timelineItems: [] })),
+      subscribeEvents: vi.fn(() => vi.fn()),
+      getState: vi.fn(async () =>
+        agentSessionState("session-1", {
+          status: "working",
+          turnLifecycle: {
+            activeTurnId: null,
+            phase: "settled",
+            outcome: "completed"
+          },
+          submitAvailability: { state: "blocked", reason: "active_turn" }
+        })
+      ),
+      exec
+    });
+
+    const { result } = renderHook(() =>
+      useAgentGUINodeController({
+        workspaceId: "room-1",
+        currentUserId: "user-1",
+        workspacePath: "/workspace",
+        avoidGroupingEdits: false,
+        data: agentGuiData("session-1"),
+        onDataChange: vi.fn()
+      })
+    );
+
+    await waitFor(() => {
+      expect(result.current.viewModel.canQueueWhileBusy).toBe(false);
+    });
+
+    act(() => {
+      result.current.actions.submitPrompt(promptBlocks("send immediately"));
+    });
+
+    await waitFor(() => {
+      expect(exec).toHaveBeenCalledWith({
+        workspaceId: "room-1",
+        agentSessionId: "session-1",
+        ...promptContent("send immediately")
+      });
+    });
+    expect(result.current.viewModel.queuedPrompts).toEqual([]);
+  });
+
   it("reflects pending interactive prompts from state patch events", async () => {
     let emitEvent:
       | ((event: AgentHostAgentActivityStreamEvent) => void)

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUINodeController.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUINodeController.ts
@@ -3017,6 +3017,36 @@ function agentActivityDisplayStatusBusy(
   return status === "working" || status === "waiting";
 }
 
+function agentSessionControlStateHasLiveTurn(
+  state: AgentSessionState | null | undefined
+): boolean {
+  const lifecycle = state?.turnLifecycle;
+  if (lifecycle?.phase) {
+    return (
+      Boolean(lifecycle.activeTurnId) ||
+      isLiveAgentSessionTurnPhase(lifecycle.phase)
+    );
+  }
+  return agentSessionStatusBusy({
+    status: state?.status
+  });
+}
+
+function isLiveAgentSessionTurnPhase(phase: unknown): boolean {
+  const normalized =
+    typeof phase === "string" ? phase.trim().toLowerCase() : "";
+  return (
+    normalized === "submitted" ||
+    normalized === "running" ||
+    normalized === "waiting_approval" ||
+    normalized === "waiting_input" ||
+    normalized === "working" ||
+    normalized === "streaming" ||
+    normalized === "waiting" ||
+    normalized === "awaiting_approval"
+  );
+}
+
 function conversationBusyStatusFromAgentActivityDisplayStatus(
   status: AgentActivityDisplayStatus | null | undefined
 ): "working" | "waiting" | null {
@@ -10183,7 +10213,8 @@ export function useAgentGUINodeController({
     ? Boolean(pendingTurnIdBySessionIdRef.current[activeConversationId])
     : false;
   const activeSubmitBlocked =
-    activeSessionState?.submitAvailability?.state === "blocked";
+    activeSessionState?.submitAvailability?.state === "blocked" &&
+    agentSessionControlStateHasLiveTurn(activeSessionState);
   const activeConversationBusy =
     agentActivityDisplayStatusBusy(activeActivityDisplayStatus) ||
     activeHasPendingSubmittedTurn ||


### PR DESCRIPTION
## Summary

<!-- What changed and why? -->

## Verification

<!-- Commands run, manual checks, or why verification is not applicable. -->

## Checklist

- [ ] I kept the change focused on one concern.
- [ ] I updated documentation when behavior, setup, or contributor workflow changed.
- [ ] I updated all README/CONTRIBUTING language variants when changing their English source.
- [ ] I ran the lowest meaningful local checks for the changed surface.
- [ ] My commits are signed off with DCO when required: `git commit -s`.
