### PR TITLE
[codex] Use colorful Cursor avatars

### DIFF
--- a/packages/agent/gui/agentGuiSessionProviderIconUrls.spec.ts
+++ b/packages/agent/gui/agentGuiSessionProviderIconUrls.spec.ts
@@ -1,17 +1,22 @@
 import { describe, expect, it } from "vitest";
 import {
+  cursorColorfulUrl,
   cursorFlatFilledIconUrl,
   resolveAgentGuiSessionProviderIconUrl
 } from "./agentGuiSessionProviderIconUrls.ts";
 
 describe("resolveAgentGuiSessionProviderIconUrl", () => {
-  it("returns the flat filled cursor icon for cursor sessions", () => {
+  it("returns the colorful cursor icon for cursor sessions", () => {
     expect(resolveAgentGuiSessionProviderIconUrl("cursor")).toBe(
-      cursorFlatFilledIconUrl
+      cursorColorfulUrl
     );
   });
 
-  it("returns null for providers without a flat filled session icon", () => {
+  it("keeps the legacy flat filled cursor icon available for older callers", () => {
+    expect(cursorFlatFilledIconUrl).toEqual(expect.any(String));
+  });
+
+  it("returns null for providers without a session icon override", () => {
     expect(resolveAgentGuiSessionProviderIconUrl("hermes")).toBeNull();
   });
 });

--- a/packages/agent/gui/agentGuiSessionProviderIconUrls.ts
+++ b/packages/agent/gui/agentGuiSessionProviderIconUrls.ts
@@ -1,11 +1,13 @@
 import claudeCodeFlatFilledIconUrl from "./app/renderer/assets/icons/agents/claudecode-flat-filled.svg";
 import codexFlatFilledIconUrl from "./app/renderer/assets/icons/agents/codex-flat-filled.svg";
 import cursorFlatFilledIconUrl from "./app/renderer/assets/icons/agents/cursor-flat-filled.svg";
+import { cursorColorfulUrl } from "./managedAgentIconAssets";
 import { normalizeManagedAgentProvider } from "./shared/managedAgentProviders";
 
 export {
   claudeCodeFlatFilledIconUrl,
   codexFlatFilledIconUrl,
+  cursorColorfulUrl,
   cursorFlatFilledIconUrl
 };
 
@@ -18,7 +20,7 @@ export function resolveAgentGuiSessionProviderIconUrl(
     case "codex":
       return codexFlatFilledIconUrl;
     case "cursor":
-      return cursorFlatFilledIconUrl;
+      return cursorColorfulUrl;
     default:
       return null;
   }

--- a/packages/agent/gui/managedAgentIconAssets.spec.ts
+++ b/packages/agent/gui/managedAgentIconAssets.spec.ts
@@ -57,11 +57,11 @@ describe("managed agent icon assets", () => {
     expect(agentGuiDockIconUrls.openclaw).toBe(openclawRoundedUrl);
   });
 
-  it("uses Cursor colorful artwork only for the provider rail", () => {
+  it("uses Cursor colorful artwork for rail and shared rounded avatars", () => {
     expect(MANAGED_AGENT_PROVIDER_RAIL_ICON_URLS.cursor).toBe(
       cursorColorfulUrl
     );
     expect(MANAGED_AGENT_ICON_URLS.cursor).not.toBe(cursorColorfulUrl);
-    expect(MANAGED_AGENT_ICON_ROUNDED_URLS.cursor).not.toBe(cursorColorfulUrl);
+    expect(MANAGED_AGENT_ICON_ROUNDED_URLS.cursor).toBe(cursorColorfulUrl);
   });
 });

--- a/packages/agent/gui/shared/managedAgentIcons.ts
+++ b/packages/agent/gui/shared/managedAgentIcons.ts
@@ -44,7 +44,7 @@ export const MANAGED_AGENT_PROVIDER_RAIL_ICON_URLS: Record<string, string> = {
 export const MANAGED_AGENT_ICON_ROUNDED_URLS: Record<string, string> = {
   "claude-code": claudeRoundedUrl,
   codex: codexRoundedUrl,
-  cursor: cursorRoundedUrl,
+  cursor: cursorColorfulUrl,
   gemini: geminiRoundedUrl,
   hermes: hermesRoundedUrl,
   tutti: tuttiDocRoundedUrl,


### PR DESCRIPTION
## Summary
- Use Cursor colorful artwork for AgentGUI session/provider icon overrides.
- Use the same Cursor colorful artwork for shared rounded avatar fallbacks, including Agent messages.
- Update icon asset tests for the new Cursor avatar routing.

## Validation
- pnpm --filter @tutti-os/agent-gui exec vitest run agentGuiSessionProviderIconUrls.spec.ts managedAgentIconAssets.spec.ts --environment jsdom --maxWorkers=3
- pnpm check:full attempted via pre-push, but local environment failed: Node v20 lacks the Node 24 test flag support, golangci-lint is not installed, and one agentstatus Go registry-order test failed under local registry ranking.