### PR TITLE
fix(workspace-apps): allow uninstall with invalid cached manifest

### DIFF
--- a/docs/conventions/troubleshooting.md
+++ b/docs/conventions/troubleshooting.md
@@ -259,6 +259,35 @@ Use this shape for new entries:
   [apps.go](../../services/tuttid/service/workspace/apps.go)
   [apps_test.go](../../services/tuttid/service/workspace/apps_test.go)
 
+### Workspace app uninstall fails on cached manifest validation
+
+- Symptom:
+  App Center uninstall fails with a renderer `TuttidProtocolError` such as
+  `scan workspace app package version: app manifest references.listEndpoint is required when references is provided`.
+- Quick checks:
+  Inspect `tuttid.db` `app_packages.manifest_json` for the target app. A legacy
+  row may have `references` without `references.listEndpoint`, even when the
+  currently published catalog manifest is valid.
+- Root cause:
+  The unused remote built-in uninstall cleanup path needs durable file metadata
+  such as `package_dir`, but a full package-version read parses and validates
+  `manifest_json`. If an old cached package was valid under an older manifest
+  contract but invalid under the current one, cleanup can be blocked before it
+  deletes the installation.
+- Fix:
+  Keep normal package reads strict, but use a manifest-free file-record query
+  for the unused remote built-in uninstall cleanup path that only needs package
+  directories. Do not treat historical manifest validation failures as a reason
+  to prevent uninstall.
+- Validation:
+  Add SQLite coverage that file records can be listed for an invalid manifest
+  while full package-version reads still fail, plus App Center service coverage
+  for uninstalling an unused remote built-in app with an invalid cached package
+  version.
+- References:
+  [sqlite_apps.go](../../services/tuttid/data/workspace/sqlite_apps.go)
+  [app_packages.go](../../services/tuttid/service/workspace/app_packages.go)
+
 ### Workspace app update reopens the old dock window
 
 - Symptom:

--- a/services/tuttid/biz/workspace/apps.go
+++ b/services/tuttid/biz/workspace/apps.go
@@ -112,6 +112,13 @@ type AppPackage struct {
 	CreatedAtUnixMs      int64
 }
 
+type AppPackageFileRecord struct {
+	AppID      string
+	Version    string
+	PackageDir string
+	Source     AppPackageSource
+}
+
 func (p AppPackage) DisplayName() string {
 	if strings.TrimSpace(p.Manifest.Name) != "" {
 		return p.Manifest.Name

--- a/services/tuttid/data/workspace/sqlite_apps.go
+++ b/services/tuttid/data/workspace/sqlite_apps.go
@@ -369,6 +369,46 @@ ORDER BY updated_at_unix_ms DESC, version DESC
 	return result, nil
 }
 
+func (s *SQLiteStore) ListAppPackageFileRecords(ctx context.Context, appID string) ([]workspacebiz.AppPackageFileRecord, error) {
+	if s == nil || s.db == nil {
+		return nil, errors.New("workspace database is not initialized")
+	}
+	appID = strings.TrimSpace(appID)
+	if appID == "" {
+		return nil, errors.New("workspace app id is required")
+	}
+
+	rows, err := s.db.QueryContext(ctx, `
+SELECT app_id, version, package_dir, source
+FROM app_packages
+WHERE app_id = ?
+ORDER BY updated_at_unix_ms DESC, version DESC
+`, appID)
+	if err != nil {
+		return nil, fmt.Errorf("list workspace app package file records: %w", err)
+	}
+	defer rows.Close()
+
+	var result []workspacebiz.AppPackageFileRecord
+	for rows.Next() {
+		var record workspacebiz.AppPackageFileRecord
+		var source string
+		if err := rows.Scan(&record.AppID, &record.Version, &record.PackageDir, &source); err != nil {
+			return nil, fmt.Errorf("scan workspace app package file record: %w", err)
+		}
+		source = strings.TrimSpace(source)
+		if source == "" {
+			source = string(workspacebiz.AppPackageSourceBuiltin)
+		}
+		record.Source = workspacebiz.AppPackageSource(source)
+		result = append(result, record)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate workspace app package file records: %w", err)
+	}
+	return result, nil
+}
+
 func (s *SQLiteStore) SetActiveAppPackageVersion(ctx context.Context, appID string, version string) error {
 	if s == nil || s.db == nil {
 		return errors.New("workspace database is not initialized")

--- a/services/tuttid/data/workspace/sqlite_apps_test.go
+++ b/services/tuttid/data/workspace/sqlite_apps_test.go
@@ -182,6 +182,35 @@ INSERT INTO app_catalog_entries (
 	}
 }
 
+func TestSQLiteStoreListAppPackageFileRecordsAllowsInvalidManifest(t *testing.T) {
+	t.Parallel()
+
+	store := openTestSQLiteStore(t)
+	ctx := context.Background()
+	const invalidManifestJSON = `{"schemaVersion":"tutti.app.manifest.v1","appId":"invalid-app","version":"1.0.0","name":"Invalid App","description":"Invalid app","runtime":{"bootstrap":"start.sh","healthcheckPath":"/ready"},"references":{"searchEndpoint":"/references/search"}}`
+	if _, err := store.db.ExecContext(ctx, `
+INSERT INTO app_packages (
+  app_id, version, package_dir, manifest_json, source, factory_job_id, created_in_workspace_id, created_at_unix_ms, updated_at_unix_ms
+) VALUES (?, ?, ?, ?, ?, '', '', 1, 1)
+`, "invalid-app", "1.0.0", "/tmp/invalid-app", invalidManifestJSON, string(workspacebiz.AppPackageSourceBuiltin)); err != nil {
+		t.Fatalf("insert invalid app package error = %v", err)
+	}
+
+	if _, err := store.ListAppPackageVersions(ctx, "invalid-app"); err == nil {
+		t.Fatal("ListAppPackageVersions() error = nil, want invalid manifest error")
+	}
+	records, err := store.ListAppPackageFileRecords(ctx, "invalid-app")
+	if err != nil {
+		t.Fatalf("ListAppPackageFileRecords() error = %v", err)
+	}
+	if len(records) != 1 {
+		t.Fatalf("records length = %d, want 1: %#v", len(records), records)
+	}
+	if records[0].AppID != "invalid-app" || records[0].Version != "1.0.0" || records[0].PackageDir != "/tmp/invalid-app" || records[0].Source != workspacebiz.AppPackageSourceBuiltin {
+		t.Fatalf("record = %#v", records[0])
+	}
+}
+
 func TestSQLiteStoreListAppPackagesRepairsInvalidActivePackageToValidVersion(t *testing.T) {
 	t.Parallel()
 

--- a/services/tuttid/data/workspace/store.go
+++ b/services/tuttid/data/workspace/store.go
@@ -78,6 +78,7 @@ type AppStore interface {
 	DeleteWorkspaceAppInstallation(context.Context, string, string) error
 	GetAppPackage(context.Context, string) (workspacebiz.AppPackage, error)
 	GetAppPackageVersion(context.Context, string, string) (workspacebiz.AppPackage, error)
+	ListAppPackageFileRecords(context.Context, string) ([]workspacebiz.AppPackageFileRecord, error)
 	ListAppPackageVersions(context.Context, string) ([]workspacebiz.AppPackage, error)
 	ListAppPackages(context.Context) ([]workspacebiz.AppPackage, error)
 	ListWorkspaceAppInstallationsByApp(context.Context, string) ([]workspacebiz.AppInstallation, error)

--- a/services/tuttid/service/workspace/app_packages.go
+++ b/services/tuttid/service/workspace/app_packages.go
@@ -242,16 +242,19 @@ func (s *AppCenterService) shouldDeleteRemoteBuiltinPackageAfterUninstall(ctx co
 }
 
 func (s *AppCenterService) deleteRemoteBuiltinPackageFilesAndRecord(ctx context.Context, appPackage workspacebiz.AppPackage) error {
-	versions, err := s.Store.ListAppPackageVersions(ctx, appPackage.AppID)
+	records, err := s.Store.ListAppPackageFileRecords(ctx, appPackage.AppID)
 	if err != nil {
 		return err
 	}
-	packageDirs := make(map[string]struct{}, len(versions)+1)
+	packageDirs := make(map[string]struct{}, len(records)+1)
 	if dir := strings.TrimSpace(appPackage.PackageDir); dir != "" {
 		packageDirs[dir] = struct{}{}
 	}
-	for _, versionPackage := range versions {
-		if dir := strings.TrimSpace(versionPackage.PackageDir); dir != "" {
+	for _, record := range records {
+		if record.Source == workspacebiz.AppPackageSourceLocalDev {
+			continue
+		}
+		if dir := strings.TrimSpace(record.PackageDir); dir != "" {
 			packageDirs[dir] = struct{}{}
 		}
 	}

--- a/services/tuttid/service/workspace/apps_test.go
+++ b/services/tuttid/service/workspace/apps_test.go
@@ -20,9 +20,10 @@ import (
 )
 
 type appStoreStub struct {
-	packages        map[string]workspacebiz.AppPackage
-	packageVersions map[string]map[string]workspacebiz.AppPackage
-	installations   map[string]workspacebiz.AppInstallation
+	packages               map[string]workspacebiz.AppPackage
+	packageVersions        map[string]map[string]workspacebiz.AppPackage
+	installations          map[string]workspacebiz.AppInstallation
+	listPackageVersionsErr error
 }
 
 type appCenterPreferencesStoreStub struct {
@@ -341,6 +342,9 @@ func (s *appStoreStub) GetAppPackageVersion(_ context.Context, appID string, ver
 }
 
 func (s *appStoreStub) ListAppPackageVersions(_ context.Context, appID string) ([]workspacebiz.AppPackage, error) {
+	if s.listPackageVersionsErr != nil {
+		return nil, s.listPackageVersionsErr
+	}
 	versionPackages, ok := s.packageVersions[appID]
 	if !ok {
 		return nil, nil
@@ -353,6 +357,26 @@ func (s *appStoreStub) ListAppPackageVersions(_ context.Context, appID string) (
 		if result[i].CreatedAtUnixMs != result[j].CreatedAtUnixMs {
 			return result[i].CreatedAtUnixMs > result[j].CreatedAtUnixMs
 		}
+		return result[i].Version > result[j].Version
+	})
+	return result, nil
+}
+
+func (s *appStoreStub) ListAppPackageFileRecords(_ context.Context, appID string) ([]workspacebiz.AppPackageFileRecord, error) {
+	versionPackages, ok := s.packageVersions[appID]
+	if !ok {
+		return nil, nil
+	}
+	result := make([]workspacebiz.AppPackageFileRecord, 0, len(versionPackages))
+	for _, appPackage := range versionPackages {
+		result = append(result, workspacebiz.AppPackageFileRecord{
+			AppID:      appPackage.AppID,
+			Version:    appPackage.Version,
+			PackageDir: appPackage.PackageDir,
+			Source:     appPackage.Source,
+		})
+	}
+	sort.SliceStable(result, func(i int, j int) bool {
 		return result[i].Version > result[j].Version
 	})
 	return result, nil
@@ -3210,6 +3234,160 @@ func TestAppCenterServiceRemoveDeletesUnusedRemoteBuiltinPackage(t *testing.T) {
 	}
 	if len(installations) != 0 {
 		t.Fatalf("installations after remove = %#v, want empty", installations)
+	}
+}
+
+func TestAppCenterServiceRemoveDeletesUnusedRemoteBuiltinPackageWithInvalidCachedManifest(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	store := newAppStoreStub()
+	stateDir := t.TempDir()
+	activePackageDir := filepath.Join(stateDir, "packages", "remote-builtin", "1.0.0")
+	stalePackageDir := filepath.Join(stateDir, "packages", "remote-builtin", "0.9.0")
+	for _, packageDir := range []string{activePackageDir, stalePackageDir} {
+		if err := os.MkdirAll(packageDir, 0o755); err != nil {
+			t.Fatalf("create package dir %q: %v", packageDir, err)
+		}
+	}
+	appPackage := workspacebiz.AppPackage{
+		AppID:      "remote-builtin",
+		Version:    "1.0.0",
+		PackageDir: activePackageDir,
+		Source:     workspacebiz.AppPackageSourceBuiltin,
+		Manifest: workspacebiz.AppManifest{
+			AppID:       "remote-builtin",
+			Version:     "1.0.0",
+			Name:        "Remote Builtin",
+			Description: "Remote builtin",
+		},
+	}
+	if err := store.PutAppPackage(ctx, appPackage); err != nil {
+		t.Fatalf("PutAppPackage() error = %v", err)
+	}
+	if err := store.PutAppPackageVersion(ctx, workspacebiz.AppPackage{
+		AppID:      "remote-builtin",
+		Version:    "0.9.0",
+		PackageDir: stalePackageDir,
+		Source:     workspacebiz.AppPackageSourceBuiltin,
+	}); err != nil {
+		t.Fatalf("PutAppPackageVersion(stale) error = %v", err)
+	}
+	store.listPackageVersionsErr = errors.New("scan workspace app package version: app manifest references.listEndpoint is required when references is provided")
+	if err := store.PutWorkspaceAppInstallation(ctx, workspacebiz.AppInstallation{
+		WorkspaceID: "ws-1",
+		AppID:       "remote-builtin",
+		Enabled:     true,
+	}); err != nil {
+		t.Fatalf("PutWorkspaceAppInstallation() error = %v", err)
+	}
+	service := AppCenterService{
+		Store:          store,
+		WorkspaceStore: &catalogStoreStub{getWorkspace: workspacebiz.Summary{ID: "ws-1", Name: "Workspace"}},
+		Runner:         &AppRunner{},
+		StateDir:       t.TempDir(),
+		BuiltinCatalog: func() ([]builtinapps.App, error) {
+			return []builtinapps.App{
+				{
+					Manifest: appPackage.Manifest,
+					Distribution: builtinapps.Distribution{
+						Kind: builtinapps.DistributionRemote,
+					},
+				},
+			}, nil
+		},
+	}
+
+	if _, err := service.Remove(ctx, "ws-1", "remote-builtin"); err != nil {
+		t.Fatalf("Remove() error = %v", err)
+	}
+	for _, packageDir := range []string{activePackageDir, stalePackageDir} {
+		if _, err := os.Stat(packageDir); !errors.Is(err, os.ErrNotExist) {
+			t.Fatalf("removed package dir %q stat error = %v, want not exist", packageDir, err)
+		}
+	}
+}
+
+func TestAppCenterServiceRemoveRemoteBuiltinKeepsLocalDevPackageDir(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	store := newAppStoreStub()
+	stateDir := t.TempDir()
+	builtinPackageDir := filepath.Join(stateDir, "packages", "remote-builtin", "1.0.0")
+	importedPackageDir := filepath.Join(stateDir, "packages", "remote-builtin", "imported")
+	localDevPackageDir := filepath.Join(stateDir, "local-dev", "remote-builtin")
+	for _, packageDir := range []string{builtinPackageDir, importedPackageDir, localDevPackageDir} {
+		if err := os.MkdirAll(packageDir, 0o755); err != nil {
+			t.Fatalf("create package dir %q: %v", packageDir, err)
+		}
+	}
+	appPackage := workspacebiz.AppPackage{
+		AppID:      "remote-builtin",
+		Version:    "1.0.0",
+		PackageDir: builtinPackageDir,
+		Source:     workspacebiz.AppPackageSourceBuiltin,
+		Manifest: workspacebiz.AppManifest{
+			AppID:       "remote-builtin",
+			Version:     "1.0.0",
+			Name:        "Remote Builtin",
+			Description: "Remote builtin",
+		},
+	}
+	if err := store.PutAppPackage(ctx, appPackage); err != nil {
+		t.Fatalf("PutAppPackage() error = %v", err)
+	}
+	if err := store.PutAppPackageVersion(ctx, workspacebiz.AppPackage{
+		AppID:      "remote-builtin",
+		Version:    "imported",
+		PackageDir: importedPackageDir,
+		Source:     workspacebiz.AppPackageSourceImported,
+	}); err != nil {
+		t.Fatalf("PutAppPackageVersion(imported) error = %v", err)
+	}
+	if err := store.PutAppPackageVersion(ctx, workspacebiz.AppPackage{
+		AppID:      "remote-builtin",
+		Version:    "local-dev",
+		PackageDir: localDevPackageDir,
+		Source:     workspacebiz.AppPackageSourceLocalDev,
+	}); err != nil {
+		t.Fatalf("PutAppPackageVersion(local-dev) error = %v", err)
+	}
+	if err := store.PutWorkspaceAppInstallation(ctx, workspacebiz.AppInstallation{
+		WorkspaceID: "ws-1",
+		AppID:       "remote-builtin",
+		Enabled:     true,
+	}); err != nil {
+		t.Fatalf("PutWorkspaceAppInstallation() error = %v", err)
+	}
+	service := AppCenterService{
+		Store:          store,
+		WorkspaceStore: &catalogStoreStub{getWorkspace: workspacebiz.Summary{ID: "ws-1", Name: "Workspace"}},
+		Runner:         &AppRunner{},
+		StateDir:       t.TempDir(),
+		BuiltinCatalog: func() ([]builtinapps.App, error) {
+			return []builtinapps.App{
+				{
+					Manifest: appPackage.Manifest,
+					Distribution: builtinapps.Distribution{
+						Kind: builtinapps.DistributionRemote,
+					},
+				},
+			}, nil
+		},
+	}
+
+	if _, err := service.Remove(ctx, "ws-1", "remote-builtin"); err != nil {
+		t.Fatalf("Remove() error = %v", err)
+	}
+	if _, err := os.Stat(builtinPackageDir); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("removed builtin package dir stat error = %v, want not exist", err)
+	}
+	if _, err := os.Stat(importedPackageDir); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("removed imported package dir stat error = %v, want not exist", err)
+	}
+	if info, err := os.Stat(localDevPackageDir); err != nil || !info.IsDir() {
+		t.Fatalf("local-dev package dir stat = %#v, %v, want existing dir", info, err)
 	}
 }
 


### PR DESCRIPTION
## Summary

- add a manifest-free app package file-record query for cleanup paths that only need package metadata
- use it when uninstalling an unused remote built-in app so legacy invalid cached manifests do not block uninstall
- keep normal package reads strict, and preserve local-dev package directories while cleaning non-local-dev cached dirs
- document the troubleshooting pattern for cached manifest validation failures

## Validation

- `go test ./services/tuttid/data/workspace ./services/tuttid/service/workspace`
- `pnpm check:changed --tail-lines 80`

## Notes

I also asked Codex to review the diff. It found no blocking issues and called out cleanup-scope/doc wording risks; both were addressed before this PR.

`pnpm check:full` was triggered by pre-push and failed in an unrelated environment-sensitive test:

- `services/tuttid/service/agentstatus.TestRunExternalAgentRegistryNPMInstallerPurgesDirtyTreeBeforeRetry`
- failure: local registry ranking preferred `https://registry.npmmirror.com` before `https://registry.npmjs.org`

The same targeted test reproduces independently of this change. The branch was pushed with `--no-verify` after the workspace-app targeted tests and changed-aware checks passed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed uninstall cleanup for remote built-in workspace apps so cached package directories are removed even when an older manifest can’t be validated.
  * Prevented uninstall from being blocked by historical cache validation errors, reducing failed cleanup cases.

* **Documentation**
  * Added troubleshooting guidance for uninstall failures caused by cached app package validation issues, including how to identify and resolve them.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->