### PR TITLE
fix(tuttid): seed create-session permission mode from remembered defaults

### DIFF
--- a/services/tuttid/api/daemon_agent_sessions.go
+++ b/services/tuttid/api/daemon_agent_sessions.go
@@ -507,6 +507,23 @@ func (api DaemonAPI) composerDefaultsForProvider(ctx context.Context, provider s
 	}
 }
 
+func (api DaemonAPI) composerDefaultsForAgentTarget(ctx context.Context, agentTargetID string) agentservice.ComposerSettings {
+	if api.PreferencesService == nil {
+		return agentservice.ComposerSettings{}
+	}
+	preferences, err := api.PreferencesService.Get(ctx)
+	if err != nil {
+		return agentservice.ComposerSettings{}
+	}
+	defaults := preferences.AgentComposerDefaultsByAgentTarget[strings.TrimSpace(agentTargetID)]
+	return agentservice.ComposerSettings{
+		Model:            defaults.Model,
+		PermissionModeID: defaults.PermissionModeID,
+		ReasoningEffort:  defaults.ReasoningEffort,
+		Speed:            defaults.Speed,
+	}
+}
+
 func (api DaemonAPI) composerDefaultLocale(ctx context.Context) string {
 	if api.PreferencesService == nil {
 		return ""

--- a/services/tuttid/api/daemon_agent_submit_handlers.go
+++ b/services/tuttid/api/daemon_agent_submit_handlers.go
@@ -39,6 +39,17 @@ func (api DaemonAPI) CreateWorkspaceAgentSession(ctx context.Context, request tu
 	}
 	metadata := mapValue(request.Body.Metadata)
 	provider := workspaceAgentProviderString(request.Body.Provider)
+	// A request without an explicit permission mode falls back to the
+	// remembered per-target default, mirroring GetAgentProviderComposerOptions
+	// (which seeds the composer display) and the CLI start path. Otherwise the
+	// composer shows the remembered mode but the session silently starts on
+	// the provider default.
+	permissionModeID := request.Body.PermissionModeId
+	if strings.TrimSpace(stringPtrValue(permissionModeID)) == "" {
+		if fallback := strings.TrimSpace(api.composerDefaultsForAgentTarget(ctx, agentTargetID).PermissionModeID); fallback != "" {
+			permissionModeID = &fallback
+		}
+	}
 	logCreateAgentSubmitTrace("api.create.received", string(request.WorkspaceID), agentSessionID, metadata, provider, "", nil)
 	session, err := api.AgentSessionService.Create(ctx, string(request.WorkspaceID), agentservice.CreateSessionInput{
 		AgentSessionID:         agentSessionID,
@@ -48,7 +59,7 @@ func (api DaemonAPI) CreateWorkspaceAgentSession(ctx context.Context, request tu
 		InitialDisplayPrompt:   stringPtrValue(request.Body.InitialDisplayPrompt),
 		Metadata:               metadata,
 		Model:                  request.Body.Model,
-		PermissionModeID:       request.Body.PermissionModeId,
+		PermissionModeID:       permissionModeID,
 		PlanMode:               request.Body.PlanMode,
 		BrowserUse:             request.Body.BrowserUse,
 		Provider:               provider,

--- a/services/tuttid/api/daemon_test.go
+++ b/services/tuttid/api/daemon_test.go
@@ -1107,6 +1107,85 @@ func TestDaemonAPIGeneratedRoutesCreateAgentSessionAllowsTargetOnlyRequest(t *te
 	}
 }
 
+func TestDaemonAPIGeneratedRoutesCreateAgentSessionFillsPermissionModeFromPreferences(t *testing.T) {
+	createdAt := time.Date(2026, 5, 30, 8, 0, 0, 0, time.UTC)
+	mux := http.NewServeMux()
+	RegisterRoutes(mux, NewRoutes(DaemonAPI{
+		AgentSessionService: stubAgentSessionService{
+			createFn: func(_ context.Context, _ string, input agentservice.CreateSessionInput) (agentservice.Session, error) {
+				if input.PermissionModeID == nil || *input.PermissionModeID != "bypassPermissions" {
+					t.Fatalf("permissionModeID = %v, want bypassPermissions", stringPtrValue(input.PermissionModeID))
+				}
+				return agentservice.Session{
+					ID:            input.AgentSessionID,
+					AgentTargetID: input.AgentTargetID,
+					Provider:      "claude-code",
+					Status:        "created",
+					CreatedAt:     createdAt,
+				}, nil
+			},
+		},
+		PreferencesService: stubPreferencesService{
+			getFn: func(context.Context) (preferencesbiz.DesktopPreferences, error) {
+				return preferencesbiz.DesktopPreferences{
+					AgentComposerDefaultsByAgentTarget: map[string]preferencesbiz.AgentComposerDefaults{
+						agenttargetbiz.IDLocalClaudeCode: {PermissionModeID: "bypassPermissions"},
+					},
+				}, nil
+			},
+		},
+	}))
+
+	recorder := performGeneratedRouteRequest(t, mux, http.MethodPost, "/v1/workspaces/ws-1/agent-sessions", map[string]any{
+		"agentSessionId": "22222222-2222-4222-8222-222222222222",
+		"agentTargetId":  agenttargetbiz.IDLocalClaudeCode,
+		"provider":       "claude-code",
+	})
+	if recorder.Code != http.StatusCreated {
+		t.Fatalf("status = %d, want %d; body: %s", recorder.Code, http.StatusCreated, recorder.Body.String())
+	}
+}
+
+func TestDaemonAPIGeneratedRoutesCreateAgentSessionExplicitPermissionModeWinsOverPreferences(t *testing.T) {
+	createdAt := time.Date(2026, 5, 30, 8, 0, 0, 0, time.UTC)
+	mux := http.NewServeMux()
+	RegisterRoutes(mux, NewRoutes(DaemonAPI{
+		AgentSessionService: stubAgentSessionService{
+			createFn: func(_ context.Context, _ string, input agentservice.CreateSessionInput) (agentservice.Session, error) {
+				if input.PermissionModeID == nil || *input.PermissionModeID != "default" {
+					t.Fatalf("permissionModeID = %v, want default", stringPtrValue(input.PermissionModeID))
+				}
+				return agentservice.Session{
+					ID:            input.AgentSessionID,
+					AgentTargetID: input.AgentTargetID,
+					Provider:      "claude-code",
+					Status:        "created",
+					CreatedAt:     createdAt,
+				}, nil
+			},
+		},
+		PreferencesService: stubPreferencesService{
+			getFn: func(context.Context) (preferencesbiz.DesktopPreferences, error) {
+				return preferencesbiz.DesktopPreferences{
+					AgentComposerDefaultsByAgentTarget: map[string]preferencesbiz.AgentComposerDefaults{
+						agenttargetbiz.IDLocalClaudeCode: {PermissionModeID: "bypassPermissions"},
+					},
+				}, nil
+			},
+		},
+	}))
+
+	recorder := performGeneratedRouteRequest(t, mux, http.MethodPost, "/v1/workspaces/ws-1/agent-sessions", map[string]any{
+		"agentSessionId":   "33333333-3333-4333-8333-333333333333",
+		"agentTargetId":    agenttargetbiz.IDLocalClaudeCode,
+		"permissionModeId": "default",
+		"provider":         "claude-code",
+	})
+	if recorder.Code != http.StatusCreated {
+		t.Fatalf("status = %d, want %d; body: %s", recorder.Code, http.StatusCreated, recorder.Body.String())
+	}
+}
+
 func TestDaemonAPIGeneratedRoutesUpdateAgentSessionPin(t *testing.T) {
 	createdAt := time.Date(2026, 5, 30, 8, 0, 0, 0, time.UTC)
 	mux := http.NewServeMux()


### PR DESCRIPTION
## 问题

Claude Code 新建会话时 composer 显示"绕过权限"（记住的默认值），但会话实际以"默认权限"创建；乐观更新完成后选择器跳回"默认权限"。

## 根因

记住的 composer 默认值由 daemon preferences 持有，三条消费路径不对称：

- `GetAgentProviderComposerOptions`（composer 显示来源）：用 preferences 填充 settings ✅
- CLI `runStart`：同样填充 ✅
- HTTP `CreateWorkspaceAgentSession`（GUI 新建会话）：直接透传 body，`permissionModeId` 为空时落到 provider 硬编码默认 ❌

dock 新开的 workbench 节点 `state.agentTargetId` 为 null，渲染层记住默认值 overlay 不生效，草稿 permissionModeId 保持 null → 创建请求不带权限模式 → 会话以 `default` 创建，而 UI 显示兜底到 daemon 回显的 `permissionConfig.defaultValue`（bypass），造成"所见非所得"。

日志证据（tutti-logs-20260706-164508）：同一 daemon 进程 16:44:26 预热 draft `query_create.begin` 为 `"permissionMode":"bypassPermissions"`，16:44:37 真正创建的会话为 `"permissionMode":"default"`；提交窗口（pid 85940）无任何 `composer_settings.changed` 事件。

## 修复

- `CreateWorkspaceAgentSession`：请求未显式携带 `permissionModeId` 时，用按 `agentTargetId` 记住的默认值填充；显式值（包括显式选 default）优先，行为不变。
- 新增 `composerDefaultsForAgentTarget` helper（按请求必带的 agentTargetID 直查 preferences，覆盖非本地 target）。
- 有意只填充权限模式：权限模式 id 会被 `normalizePermissionModeIDForProvider` 安全钳制；不填 model 以避免过期记住值触发 `validateComposerModelForCreate` 失败（GUI 总是显式传 model）。

## 测试

- `TestDaemonAPIGeneratedRoutesCreateAgentSessionFillsPermissionModeFromPreferences`（先失败后通过）
- `TestDaemonAPIGeneratedRoutesCreateAgentSessionExplicitPermissionModeWinsOverPreferences`
- `go build` / `go vet` / `go test ./api/` 全部通过

⚠️ 先不要合入，待本地重现验证通过后再处理。

🤖 Generated with [Claude Code](https://claude.com/claude-code)