### PR TITLE
fix(agent-gui): size first-open agent window from the workbench area

### DIFF
--- a/packages/agent/gui/workbench/contribution.test.ts
+++ b/packages/agent/gui/workbench/contribution.test.ts
@@ -637,7 +637,7 @@ describe("agent GUI workbench contribution copy", () => {
     );
   });
 
-  it("opens at the default width and 70 percent height when the workbench area can fit the default frame", () => {
+  it("opens at 80 percent width and 90 percent height of the visible workbench area", () => {
     const frame = resolveAgentGuiWorkbenchDefaultLaunchFrame({
       frame: { height: 560, width: 1040, x: 140, y: 48 },
       request: {
@@ -660,14 +660,14 @@ describe("agent GUI workbench contribution copy", () => {
     });
 
     expect(frame).toEqual({
-      height: 538,
-      width: 1040,
-      x: 140,
-      y: 48
+      height: 692,
+      width: 1152,
+      x: 144,
+      y: 91
     });
   });
 
-  it("opens at 90 percent of the visible workbench area when the window cannot fit the default frame", () => {
+  it("keeps the 80 percent width on compact visible workbench areas", () => {
     const frame = resolveAgentGuiWorkbenchDefaultLaunchFrame({
       frame: { height: 560, width: 1040, x: 140, y: 48 },
       request: {
@@ -691,8 +691,8 @@ describe("agent GUI workbench contribution copy", () => {
 
     expect(frame).toEqual({
       height: 512,
-      width: 882,
-      x: 49,
+      width: 784,
+      x: 98,
       y: 81
     });
   });
@@ -721,13 +721,13 @@ describe("agent GUI workbench contribution copy", () => {
 
     expect(frame).toEqual({
       height: 554,
-      width: 1040,
-      x: 200,
+      width: 1152,
+      x: 144,
       y: 83
     });
   });
 
-  it("preserves the 90 percent visible-area frame during compact launches", () => {
+  it("preserves the visible-area frame during compact launches", () => {
     const contribution = createTestAgentGuiWorkbenchContribution({
       renderBody: () => null,
       workspaceId: "workspace-1"
@@ -758,8 +758,8 @@ describe("agent GUI workbench contribution copy", () => {
     expect(launchResult).toMatchObject({
       defaultFrame: {
         height: 512,
-        width: 882,
-        x: 49,
+        width: 784,
+        x: 98,
         y: 81
       },
       framePolicy: "absolute"
@@ -956,8 +956,8 @@ describe("agent GUI workbench contribution copy", () => {
       cascadeOffset: agentGuiWorkbenchNewWindowCascadeOffset,
       defaultFrame: {
         height: 512,
-        width: 882,
-        x: 49,
+        width: 784,
+        x: 98,
         y: 81
       },
       framePolicy: "cascade-same-type-centered"

--- a/packages/agent/gui/workbench/contribution.ts
+++ b/packages/agent/gui/workbench/contribution.ts
@@ -56,7 +56,8 @@ export const agentGuiWorkbenchDefaultNodeFrame: WorkbenchFrame = {
   y: 48
 };
 
-export const agentGuiWorkbenchDefaultUsableHeightRatio = 0.7;
+export const agentGuiWorkbenchDefaultUsableWidthRatio = 0.8;
+export const agentGuiWorkbenchDefaultUsableHeightRatio = 0.9;
 export const agentGuiWorkbenchCompactVisibleAreaRatio = 0.9;
 export const agentGuiWorkbenchNewWindowCascadeOffset = { x: 180, y: 88 };
 
@@ -584,30 +585,16 @@ export function resolveAgentGuiWorkbenchDefaultLaunchFrame(input: {
   const defaultHeight = Math.round(
     layoutFrame.height * agentGuiWorkbenchDefaultUsableHeightRatio
   );
-  const shouldUseCompactWidth = layoutFrame.width < input.frame.width;
-  const shouldUseCompactHeight =
-    layoutFrame.height <
-    input.frame.height / agentGuiWorkbenchCompactVisibleAreaRatio;
-
-  if (shouldUseCompactWidth || shouldUseCompactHeight) {
-    const width = shouldUseCompactWidth
-      ? Math.round(layoutFrame.width * agentGuiWorkbenchCompactVisibleAreaRatio)
-      : input.frame.width;
-    const height = Math.round(
-      layoutFrame.height * agentGuiWorkbenchCompactVisibleAreaRatio
-    );
-
-    return {
-      height,
-      width,
-      x: Math.round(layoutFrame.x + (layoutFrame.width - width) / 2),
-      y: Math.round(layoutFrame.y + (layoutFrame.height - height) / 2)
-    };
-  }
+  const defaultWidth = Math.round(
+    layoutFrame.width * agentGuiWorkbenchDefaultUsableWidthRatio
+  );
 
   return {
     ...input.frame,
-    height: defaultHeight
+    height: defaultHeight,
+    width: defaultWidth,
+    x: Math.round(layoutFrame.x + (layoutFrame.width - defaultWidth) / 2),
+    y: Math.round(layoutFrame.y + (layoutFrame.height - defaultHeight) / 2)
   };
 }
 


### PR DESCRIPTION
## Summary

Backport the launch-frame sizing portion of main commit `48739216` to `release/0704`: the default agent GUI launch frame now takes 80% of the visible workbench width and 90% of its height and centers itself, instead of a fixed 1040px width with 70% height plus a separate compact fallback branch.

Only the sizing change is backported — the collapsed-header session identity feature bundled in the same main commit is not included.

## Changes

- `packages/agent/gui/workbench/contribution.ts`: replace `agentGuiWorkbenchDefaultUsableHeightRatio = 0.7` with width 0.8 / height 0.9 ratios and rewrite `resolveAgentGuiWorkbenchDefaultLaunchFrame` to derive both dimensions from the workbench layout frame and center the window (matches main).
- `packages/agent/gui/workbench/contribution.test.ts`: update the five launch-frame expectations to the main versions.

## Testing

- `pnpm vitest run workbench/contribution.test.ts` — 37/37 passed
- `check:full` passed via the pre-push hook

🤖 Generated with [Claude Code](https://claude.com/claude-code)