### PR TITLE
feat(agent): add shared agent shell support

### DIFF
--- a/docs/architecture/agent-activity-packages.md
+++ b/docs/architecture/agent-activity-packages.md
@@ -248,6 +248,14 @@ ownership or ordering fields, but those gaps must be filled before events enter
 `agent-activity-core` or `@tutti-os/agent-gui`. Session-level notices and
 statuses should use state patches or explicit notice semantics; they should not
 be published as ordinary assistant transcript messages without a turn scope.
+Activity reports may carry a host-defined user id in the activity source before
+they reach durable session projection. Local single-user hosts should leave the
+field empty instead of deriving it from account login state; cloud
+collaboration hosts may inject real account user ids so downstream views can
+distinguish self-owned and peer-owned sessions. Reporters run on the streaming
+persistence hot path, so identity enrichment there must use host-provided local
+state; it must not call account refresh or user-info APIs that perform network
+round-trips or write refreshed auth state.
 
 ## Stream Lifecycle
 

--- a/docs/architecture/agent-gui-node.md
+++ b/docs/architecture/agent-gui-node.md
@@ -205,6 +205,13 @@ Provider-scoped rail footer affordances, such as usage limits and environment
 setup, follow the rail's active provider filter target in multi-provider scope;
 when the rail filter is `All`, they should stay hidden because there is no
 single provider target to inspect.
+AgentGuiNode may also receive a neutral `renderSidebarFooter` slot for host or
+product affordances that belong at the bottom of the conversation rail. This
+slot must stay outside the controller view model and conversation rail valtio
+store: pass it as a direct function prop and give it only existing neutral
+context such as `currentUserId` and `activeConversation`. Product concepts such
+as sharing, ownership, availability, quota, or authorization live entirely
+inside the React node supplied by the host.
 Unified empty-home provider readiness is a host-projected, provider-scoped gate,
 not a durable session rule. Desktop may subscribe to its
 `agentProviderStatusService` and pass a narrow readiness map plus install,

--- a/packages/agent/daemon/activity/projection/projection.go
+++ b/packages/agent/daemon/activity/projection/projection.go
@@ -6,6 +6,7 @@ type SessionSnapshot struct {
 	WorkspaceID       string
 	AgentSessionID    string
 	Origin            string
+	UserID            string
 	AgentTargetID     string
 	Provider          string
 	ProviderSessionID string
@@ -30,6 +31,7 @@ type SessionStateReport struct {
 	WorkspaceID       string
 	AgentSessionID    string
 	Origin            string
+	UserID            string
 	AgentTargetID     string
 	Provider          string
 	ProviderSessionID string
@@ -73,6 +75,7 @@ func ProjectSessionState(
 		WorkspaceID:       strings.TrimSpace(report.WorkspaceID),
 		AgentSessionID:    strings.TrimSpace(report.AgentSessionID),
 		Origin:            strings.TrimSpace(report.Origin),
+		UserID:            strings.TrimSpace(report.UserID),
 		AgentTargetID:     strings.TrimSpace(report.AgentTargetID),
 		Provider:          strings.TrimSpace(report.Provider),
 		ProviderSessionID: strings.TrimSpace(report.ProviderSessionID),
@@ -98,6 +101,9 @@ func ProjectSessionState(
 		}
 		if session.Origin == "" {
 			session.Origin = existing.Origin
+		}
+		if session.UserID == "" {
+			session.UserID = existing.UserID
 		}
 		if session.AgentTargetID == "" {
 			session.AgentTargetID = existing.AgentTargetID

--- a/packages/agent/gui/agent-gui/agentGuiNode/AgentGUINode.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/AgentGUINode.tsx
@@ -1,4 +1,4 @@
-import { memo, useCallback, useEffect, useMemo } from "react";
+import { memo, type ReactNode, useCallback, useEffect, useMemo } from "react";
 import { createWorkspaceUserProjectI18nRuntime } from "@tutti-os/workspace-user-project/i18n";
 import { createWorkspaceFileManagerI18nRuntime } from "@tutti-os/workspace-file-manager";
 import type { WorkspaceFileEntry } from "@tutti-os/workspace-file-manager/services";
@@ -46,6 +46,7 @@ import type {
 import {
   AgentGUINodeView,
   type AgentGUIViewLabels,
+  type AgentGUISidebarFooterContext,
   type AgentMentionReferenceTargetResolver,
   type AgentWorkspaceReferenceInitialTargetResolver
 } from "./AgentGUINodeView";
@@ -191,6 +192,7 @@ export interface AgentGUINodeProps {
   onAgentProviderLogin?: (provider: AgentProvider) => void;
   providerTargets?: readonly AgentGUIProviderTarget[];
   providerTargetsLoading?: boolean;
+  renderSidebarFooter?: (ctx: AgentGUISidebarFooterContext) => ReactNode;
   comingSoonProviders?: readonly AgentGUIProvider[];
   providerReadinessGates?: Partial<
     Record<AgentGUIProvider, AgentGUIProviderReadinessGate | null>
@@ -570,6 +572,7 @@ function areAgentGUINodePropsEqual(
     previous.onAgentProviderLogin === next.onAgentProviderLogin &&
     previous.providerTargets === next.providerTargets &&
     previous.providerTargetsLoading === next.providerTargetsLoading &&
+    previous.renderSidebarFooter === next.renderSidebarFooter &&
     previous.comingSoonProviders === next.comingSoonProviders &&
     previous.providerReadinessGates === next.providerReadinessGates &&
     previous.defaultProviderTargetId === next.defaultProviderTargetId &&
@@ -628,6 +631,7 @@ export const AgentGUINode = memo(function AgentGUINode({
   onAgentProviderLogin,
   providerTargets,
   providerTargetsLoading = false,
+  renderSidebarFooter,
   comingSoonProviders,
   providerReadinessGates = null,
   defaultProviderTargetId = null,
@@ -1677,6 +1681,7 @@ export const AgentGUINode = memo(function AgentGUINode({
         return (
           <AgentGUINodeView
             viewModel={viewModel}
+            renderSidebarFooter={renderSidebarFooter}
             actions={viewActions}
             isActive={isActive}
             composerFocusRequestSequence={composerFocusRequestSequence}

--- a/packages/agent/gui/agent-gui/agentGuiNode/AgentGUINodeView.layout.spec.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/AgentGUINodeView.layout.spec.tsx
@@ -246,6 +246,42 @@ describe("AgentGUINodeView layout persistence", () => {
     );
   });
 
+  it("renders an injected conversation rail footer with neutral context", () => {
+    const activeConversation = createConversationSummary("session-1", {
+      title: "Active conversation"
+    });
+    const renderSidebarFooter = vi.fn(
+      ({
+        currentUserId,
+        activeConversation
+      }: Parameters<
+        NonNullable<AgentGUINodeViewProps["renderSidebarFooter"]>
+      >[0]) => (
+        <button type="button">
+          Footer {currentUserId} {activeConversation?.id}
+        </button>
+      )
+    );
+
+    renderAgentGUINodeView({
+      renderSidebarFooter,
+      viewModel: createViewModel({
+        currentUserId: "user-1",
+        activeConversation,
+        activeConversationId: activeConversation.id,
+        conversations: [activeConversation]
+      })
+    });
+
+    expect(
+      screen.getByTestId("agent-gui-sidebar-footer-slot")
+    ).toHaveTextContent("Footer user-1 session-1");
+    expect(renderSidebarFooter).toHaveBeenCalledWith({
+      currentUserId: "user-1",
+      activeConversation
+    });
+  });
+
   it("ignores rail pointer moves that do not come from the resize handle drag", () => {
     const onConversationRailWidthChanged = vi.fn();
 
@@ -3804,6 +3840,7 @@ interface RenderAgentGUINodeViewOptions {
   actions?: AgentGUINodeViewProps["actions"];
   labels?: AgentGUIViewLabels;
   onOpenConversationWindow?: AgentGUINodeViewProps["onOpenConversationWindow"];
+  renderSidebarFooter?: AgentGUINodeViewProps["renderSidebarFooter"];
   slashStatusLimits?: AgentGUINodeViewProps["slashStatusLimits"];
 }
 
@@ -3819,12 +3856,14 @@ function buildAgentGUINodeViewElement({
   actions = createActions(),
   labels = createLabels(),
   onOpenConversationWindow,
+  renderSidebarFooter,
   slashStatusLimits = []
 }: RenderAgentGUINodeViewOptions = {}) {
   return (
     <AgentActivityRuntimeProvider runtime={activityRuntime}>
       <AgentGUINodeView
         viewModel={viewModel}
+        renderSidebarFooter={renderSidebarFooter}
         onLinkAction={onLinkAction}
         isActive={isActive}
         isAgentProviderReady={isAgentProviderReady}

--- a/packages/agent/gui/agent-gui/agentGuiNode/AgentGUINodeView.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/AgentGUINodeView.tsx
@@ -4,6 +4,7 @@ import {
   type CSSProperties,
   type KeyboardEvent,
   type PointerEvent,
+  type ReactNode,
   useCallback,
   useEffect,
   useLayoutEffect,
@@ -550,6 +551,7 @@ export interface AgentGUIViewLabels {
 
 interface AgentGUINodeViewProps {
   viewModel: AgentGUINodeViewModel;
+  renderSidebarFooter?: AgentGUISidebarFooterRenderer;
   onLinkAction?: (action: WorkspaceLinkAction) => void;
   onHandoffConversation?: (input: {
     agentTargetId?: string | null;
@@ -991,8 +993,18 @@ function handoffProjectPathForConversation(
   );
 }
 
+export interface AgentGUISidebarFooterContext {
+  currentUserId?: string | null;
+  activeConversation: AgentGUINodeViewModel["activeConversation"];
+}
+
+export type AgentGUISidebarFooterRenderer = (
+  ctx: AgentGUISidebarFooterContext
+) => ReactNode;
+
 export function AgentGUINodeView({
   viewModel,
+  renderSidebarFooter,
   onLinkAction,
   onHandoffConversation,
   capabilityMenuState,
@@ -1612,6 +1624,9 @@ export function AgentGUINodeView({
         >
           <AgentGUIConversationRailStorePane
             conversations={viewModel.conversations}
+            currentUserId={viewModel.currentUserId}
+            activeConversation={viewModel.activeConversation}
+            renderSidebarFooter={renderSidebarFooter}
             store={conversationRailStore}
             storeState={conversationRailStoreState}
             userProjects={viewModel.userProjects}
@@ -3939,6 +3954,9 @@ interface AgentGUIConversationRailPaneProps {
   workspaceUserProjectI18n: WorkspaceUserProjectI18nRuntime;
   uiLanguage: UiLanguage;
   previewMode: boolean;
+  currentUserId?: string | null;
+  activeConversation: AgentGUINodeViewModel["activeConversation"];
+  renderSidebarFooter?: AgentGUISidebarFooterRenderer;
   createConversationDisabled: boolean;
   openclawGateway: OpenclawGatewayViewModel | null;
   isCollapsed: boolean;
@@ -4002,7 +4020,12 @@ type OpenclawGatewayViewModel =
 
 type AgentGUIConversationRailDataProps = Pick<
   AgentGUIConversationRailPaneProps,
-  "conversations" | "userProjects" | "workspaceId"
+  | "activeConversation"
+  | "conversations"
+  | "currentUserId"
+  | "renderSidebarFooter"
+  | "userProjects"
+  | "workspaceId"
 >;
 
 type AgentGUIConversationRailStoreSnapshot = Omit<
@@ -4077,7 +4100,10 @@ function agentGUIConversationRailStoreSnapshotsEqual(
 }
 
 interface AgentGUIConversationRailStorePaneProps {
+  activeConversation: AgentGUINodeViewModel["activeConversation"];
   conversations: AgentGUINodeViewModel["conversations"];
+  currentUserId?: string | null;
+  renderSidebarFooter?: AgentGUISidebarFooterRenderer;
   store: AgentGUIConversationRailStore;
   storeState: AgentGUIConversationRailStoreSnapshot;
   userProjects: AgentGUINodeViewModel["userProjects"];
@@ -4086,7 +4112,10 @@ interface AgentGUIConversationRailStorePaneProps {
 
 const AgentGUIConversationRailStorePane = memo(
   function AgentGUIConversationRailStorePane({
+    activeConversation,
     conversations,
+    currentUserId,
+    renderSidebarFooter,
     store,
     storeState: _storeState,
     userProjects,
@@ -4097,7 +4126,10 @@ const AgentGUIConversationRailStorePane = memo(
     return (
       <AgentGUIConversationRailPane
         {...state}
+        activeConversation={activeConversation}
         conversations={conversations}
+        currentUserId={currentUserId}
+        renderSidebarFooter={renderSidebarFooter}
         userProjects={userProjects}
         workspaceId={workspaceId}
       />
@@ -5147,6 +5179,9 @@ const AgentGUIConversationRailPane = memo(
     conversations,
     workspaceId,
     userProjects,
+    currentUserId,
+    activeConversation,
+    renderSidebarFooter,
     activeConversationId,
     pendingDeleteConversationId,
     isLoadingConversations,
@@ -5591,6 +5626,17 @@ const AgentGUIConversationRailPane = memo(
             </Popover>
           </div>
         )}
+        {renderSidebarFooter ? (
+          <div
+            className="shrink-0 px-2 py-1.5"
+            data-testid="agent-gui-sidebar-footer-slot"
+          >
+            {renderSidebarFooter({
+              currentUserId,
+              activeConversation
+            })}
+          </div>
+        ) : null}
         <ConfirmationDialog
           cancelLabel={labels.cancel}
           className={AGENT_GUI_CONFIRMATION_DIALOG_CLASS_NAME}

--- a/packages/agent/gui/index.ts
+++ b/packages/agent/gui/index.ts
@@ -19,6 +19,7 @@ export {
   agentGUIDefaultTargetProviders,
   createLocalAgentGUIProviderTarget,
   createLocalAgentGUIProviderTargets,
+  createSharedAgentGUIProviderTarget,
   localAgentGUIAgentTargetId,
   localAgentGUIProviderTargetId,
   normalizeAgentGUIProviderTargets,
@@ -43,6 +44,10 @@ export {
   resolveAgentGUIExpandedWindowFrame,
   shouldAutoCollapseAgentGUIConversationRail
 } from "./agent-gui/agentGuiNode/model/agentGuiRailLayout";
+export type {
+  AgentGUISidebarFooterContext,
+  AgentGUISidebarFooterRenderer
+} from "./agent-gui/agentGuiNode/AgentGUINodeView";
 export {
   AGENT_CONTEXT_MENTION_PROVIDER_IDS,
   type AgentContextMentionProviderId,

--- a/packages/agent/gui/providerTargets.spec.ts
+++ b/packages/agent/gui/providerTargets.spec.ts
@@ -3,6 +3,7 @@ import {
   agentGUIProviderTargetRefsEqual,
   createLocalAgentGUIProviderTarget,
   createLocalAgentGUIProviderTargets,
+  createSharedAgentGUIProviderTarget,
   normalizeAgentGUIProviderTargets,
   resolveAgentGUIProviderTarget
 } from "./providerTargets";
@@ -134,6 +135,72 @@ describe("agent gui provider targets", () => {
         label: "Alice's Codex"
       }
     ]);
+  });
+
+  it("creates shared agent targets with owner and availability metadata", () => {
+    expect(
+      createSharedAgentGUIProviderTarget({
+        provider: "codex",
+        sharedAgentId: " agent-1 ",
+        agentTargetId: " cp-target-1 ",
+        label: "Alice's Codex",
+        ownerLabel: " Alice ",
+        iconUrl: " app://alice.png ",
+        unavailableReason: " owner_offline ",
+        disabled: true,
+        ref: {
+          ownerUserId: "user-1"
+        }
+      })
+    ).toEqual({
+      targetId: "shared-agent:agent-1",
+      agentTargetId: "cp-target-1",
+      provider: "codex",
+      ref: {
+        kind: "shared-agent",
+        provider: "codex",
+        sharedAgentId: "agent-1",
+        ownerUserId: "user-1"
+      },
+      label: "Alice's Codex",
+      ownerLabel: "Alice",
+      iconUrl: "app://alice.png",
+      unavailableReason: "owner_offline",
+      disabled: true
+    });
+  });
+
+  it("drops whitespace-only optional target metadata during normalization", () => {
+    const [target] = normalizeAgentGUIProviderTargets(
+      [
+        {
+          targetId: " shared-agent:agent-1 ",
+          provider: "codex",
+          ref: {
+            kind: " shared-agent ",
+            provider: "codex",
+            sharedAgentId: "agent-1"
+          },
+          label: " Alice's Codex ",
+          description: " ",
+          ownerLabel: " ",
+          iconUrl: " ",
+          unavailableReason: " "
+        }
+      ],
+      { useStaticCatalog: false }
+    );
+
+    expect(target).toEqual({
+      targetId: "shared-agent:agent-1",
+      provider: "codex",
+      ref: {
+        kind: "shared-agent",
+        provider: "codex",
+        sharedAgentId: "agent-1"
+      },
+      label: "Alice's Codex"
+    });
   });
 
   it("keeps same target ids for different real providers", () => {

--- a/packages/agent/gui/providerTargets.ts
+++ b/packages/agent/gui/providerTargets.ts
@@ -55,6 +55,43 @@ export function createDisabledPlaceholderAgentGUIProviderTarget(
   };
 }
 
+export function createSharedAgentGUIProviderTarget(input: {
+  provider: AgentGUIProvider;
+  sharedAgentId: string;
+  label: string;
+  agentTargetId?: string | null;
+  ownerLabel?: string | null;
+  iconUrl?: string | null;
+  unavailableReason?: string | null;
+  disabled?: boolean;
+  ref?: Record<string, unknown> | null;
+}): AgentGUIProviderTarget {
+  const sharedAgentId = input.sharedAgentId.trim();
+  const targetId = `shared-agent:${sharedAgentId}`;
+  return {
+    targetId,
+    ...(input.agentTargetId?.trim()
+      ? { agentTargetId: input.agentTargetId.trim() }
+      : {}),
+    provider: input.provider,
+    ref: {
+      ...(input.ref ?? {}),
+      kind: "shared-agent",
+      provider: input.provider,
+      sharedAgentId
+    },
+    label: input.label,
+    ...(input.ownerLabel?.trim()
+      ? { ownerLabel: input.ownerLabel.trim() }
+      : {}),
+    ...(input.iconUrl?.trim() ? { iconUrl: input.iconUrl.trim() } : {}),
+    ...(input.unavailableReason?.trim()
+      ? { unavailableReason: input.unavailableReason.trim() }
+      : {}),
+    ...(input.disabled === true ? { disabled: true } : {})
+  };
+}
+
 export function createLocalAgentGUIProviderTargets(
   providers: readonly AgentGUIProvider[] = agentGUIDefaultTargetProviders
 ): AgentGUIProviderTarget[] {
@@ -206,6 +243,18 @@ export function agentGUIProviderTargetRefsEqual(
 function normalizeAgentGUIProviderTarget(
   target: AgentGUIProviderTarget
 ): AgentGUIProviderTarget | null {
+  const {
+    targetId: _targetId,
+    agentTargetId: _agentTargetId,
+    provider: _provider,
+    ref: _ref,
+    label: _label,
+    description,
+    iconUrl,
+    ownerLabel,
+    unavailableReason,
+    ...rest
+  } = target;
   const targetId = target.targetId.trim();
   const agentTargetId = target.agentTargetId?.trim();
   const label = target.label.trim();
@@ -215,7 +264,7 @@ function normalizeAgentGUIProviderTarget(
     return null;
   }
   return {
-    ...target,
+    ...rest,
     targetId,
     ...(agentTargetId ? { agentTargetId } : {}),
     provider: target.provider,
@@ -225,14 +274,11 @@ function normalizeAgentGUIProviderTarget(
       provider: target.provider
     },
     label,
-    ...(target.description?.trim()
-      ? { description: target.description.trim() }
-      : {}),
-    ...(target.ownerLabel?.trim()
-      ? { ownerLabel: target.ownerLabel.trim() }
-      : {}),
-    ...(target.unavailableReason?.trim()
-      ? { unavailableReason: target.unavailableReason.trim() }
+    ...(description?.trim() ? { description: description.trim() } : {}),
+    ...(iconUrl?.trim() ? { iconUrl: iconUrl.trim() } : {}),
+    ...(ownerLabel?.trim() ? { ownerLabel: ownerLabel.trim() } : {}),
+    ...(unavailableReason?.trim()
+      ? { unavailableReason: unavailableReason.trim() }
       : {})
   };
 }

--- a/packages/agent/store-sqlite/activity.go
+++ b/packages/agent/store-sqlite/activity.go
@@ -137,7 +137,7 @@ func (s *Store) GetSession(
 	}
 	row := s.db.QueryRowContext(ctx, `
 SELECT workspace_id, agent_session_id, origin, agent_target_id, provider, provider_session_id, model,
-       settings_json, runtime_context_json, cwd,
+       user_id, settings_json, runtime_context_json, cwd,
        title, status, current_phase, last_error, message_version, last_event_at_unix_ms,
        started_at_unix_ms, ended_at_unix_ms, pinned_at_unix_ms,
        created_at_unix_ms, updated_at_unix_ms
@@ -167,7 +167,7 @@ func (s *Store) ListSessions(
 	}
 	rows, err := s.db.QueryContext(ctx, `
 SELECT workspace_id, agent_session_id, origin, agent_target_id, provider, provider_session_id, model,
-       settings_json, runtime_context_json, cwd,
+       user_id, settings_json, runtime_context_json, cwd,
        title, status, current_phase, last_error, message_version, last_event_at_unix_ms,
        started_at_unix_ms, ended_at_unix_ms, pinned_at_unix_ms,
        created_at_unix_ms, updated_at_unix_ms
@@ -602,6 +602,7 @@ func (s *Store) upsertAgentSessionTx(
 			WorkspaceID:       workspaceID,
 			AgentSessionID:    agentSessionID,
 			Origin:            input.Origin,
+			UserID:            input.UserID,
 			AgentTargetID:     input.AgentTargetID,
 			Provider:          input.Provider,
 			ProviderSessionID: input.ProviderSessionID,
@@ -646,13 +647,14 @@ func (s *Store) upsertAgentSessionTx(
 	}
 	result, err := tx.ExecContext(ctx, `
 INSERT INTO workspace_agent_sessions (
-  workspace_id, agent_session_id, origin, agent_target_id, provider, provider_session_id, model,
+  workspace_id, agent_session_id, origin, user_id, agent_target_id, provider, provider_session_id, model,
   settings_json, runtime_context_json, cwd, rail_section_kind, rail_project_path, rail_section_key,
   title, status, current_phase, last_error, last_event_at_unix_ms, started_at_unix_ms,
   ended_at_unix_ms, created_at_unix_ms, updated_at_unix_ms
-) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 ON CONFLICT(workspace_id, agent_session_id) DO UPDATE SET
   origin = excluded.origin,
+  user_id = excluded.user_id,
   agent_target_id = excluded.agent_target_id,
   provider = excluded.provider,
   provider_session_id = excluded.provider_session_id,
@@ -673,7 +675,7 @@ ON CONFLICT(workspace_id, agent_session_id) DO UPDATE SET
   deleted_at_unix_ms = 0,
   updated_at_unix_ms = excluded.updated_at_unix_ms
 WHERE workspace_agent_sessions.deleted_at_unix_ms = 0
-`, session.WorkspaceID, session.AgentSessionID, session.Origin, nullString(session.AgentTargetID), session.Provider,
+`, session.WorkspaceID, session.AgentSessionID, session.Origin, session.UserID, nullString(session.AgentTargetID), session.Provider,
 		session.ProviderSessionID, session.Model, settingsJSON, runtimeContextJSON,
 		session.CWD, railSection.Kind, railSection.ProjectPath, railSection.Key, session.Title,
 		session.Status, session.CurrentPhase, session.LastError, session.LastEventUnixMS,
@@ -697,7 +699,7 @@ func getAgentSessionForUpdate(
 ) (agentactivityprojection.SessionSnapshot, bool, error) {
 	row := tx.QueryRowContext(ctx, `
 SELECT workspace_id, agent_session_id, origin, agent_target_id, provider, provider_session_id, model,
-       settings_json, runtime_context_json, cwd,
+       user_id, settings_json, runtime_context_json, cwd,
        title, status, current_phase, last_error, message_version, last_event_at_unix_ms,
        started_at_unix_ms, ended_at_unix_ms, created_at_unix_ms, updated_at_unix_ms,
        deleted_at_unix_ms
@@ -716,6 +718,7 @@ WHERE workspace_id = ? AND agent_session_id = ?
 		&session.Provider,
 		&session.ProviderSessionID,
 		&session.Model,
+		&session.UserID,
 		&settingsJSON,
 		&runtimeContextJSON,
 		&session.CWD,
@@ -760,6 +763,7 @@ func scanAgentSession(scanner rowScanner) (Session, error) {
 		&session.Provider,
 		&session.ProviderSessionID,
 		&session.Model,
+		&session.UserID,
 		&settingsJSON,
 		&runtimeContextJSON,
 		&session.Cwd,

--- a/packages/agent/store-sqlite/activity_projection.go
+++ b/packages/agent/store-sqlite/activity_projection.go
@@ -26,6 +26,7 @@ func projectionSessionToDTO(session agentactivityprojection.SessionSnapshot) Ses
 		ID:                session.AgentSessionID,
 		WorkspaceID:       session.WorkspaceID,
 		Origin:            session.Origin,
+		UserID:            session.UserID,
 		AgentTargetID:     session.AgentTargetID,
 		Provider:          session.Provider,
 		ProviderSessionID: session.ProviderSessionID,

--- a/packages/agent/store-sqlite/activity_sections.go
+++ b/packages/agent/store-sqlite/activity_sections.go
@@ -28,7 +28,7 @@ func (s *Store) ListSessionSection(
 	}
 	query := `
 SELECT workspace_id, agent_session_id, origin, agent_target_id, provider, provider_session_id, model,
-       settings_json, runtime_context_json, cwd,
+       user_id, settings_json, runtime_context_json, cwd,
        title, status, current_phase, last_error, message_version, last_event_at_unix_ms,
        started_at_unix_ms, ended_at_unix_ms, pinned_at_unix_ms,
        created_at_unix_ms, updated_at_unix_ms

--- a/packages/agent/store-sqlite/migrations.go
+++ b/packages/agent/store-sqlite/migrations.go
@@ -25,6 +25,7 @@ const schemaMigrationWorkspaceAgentActivityV2 = "workspace_agent_activity_v2"
 const schemaMigrationWorkspaceAgentActivityV3 = "workspace_agent_activity_v3"
 const schemaMigrationWorkspaceAgentActivityV4 = "workspace_agent_activity_v4"
 const schemaMigrationWorkspaceAgentActivityV5 = "workspace_agent_activity_v5"
+const schemaMigrationWorkspaceAgentActivityV6 = "workspace_agent_activity_v6"
 const schemaMigrationWorkspaceAgentActivityRailV1 = "workspace_agent_activity_rail_v1"
 const schemaMigrationAgentTargetsV1 = "agent_targets_v1"
 
@@ -36,6 +37,7 @@ var claimableMigrationIDs = []string{
 	schemaMigrationWorkspaceAgentActivityV3,
 	schemaMigrationWorkspaceAgentActivityV4,
 	schemaMigrationWorkspaceAgentActivityV5,
+	schemaMigrationWorkspaceAgentActivityV6,
 	schemaMigrationWorkspaceAgentActivityRailV1,
 	schemaMigrationAgentTargetsV1,
 }
@@ -74,6 +76,9 @@ CREATE TABLE IF NOT EXISTS `+schemaMigrationsTable+` (
 		return err
 	}
 	if err := s.applyWorkspaceAgentActivityV5(ctx); err != nil {
+		return err
+	}
+	if err := s.applyWorkspaceAgentActivityV6(ctx); err != nil {
 		return err
 	}
 	if err := s.applyAgentTargetsV1(ctx); err != nil {

--- a/packages/agent/store-sqlite/migrations_activity.go
+++ b/packages/agent/store-sqlite/migrations_activity.go
@@ -23,6 +23,7 @@ CREATE TABLE IF NOT EXISTS workspace_agent_sessions (
   workspace_id TEXT NOT NULL,
   agent_session_id TEXT NOT NULL,
   origin TEXT NOT NULL DEFAULT '',
+  user_id TEXT NOT NULL DEFAULT '',
   agent_target_id TEXT,
   provider TEXT NOT NULL DEFAULT '',
   provider_session_id TEXT NOT NULL DEFAULT '',
@@ -174,6 +175,28 @@ func (s *Store) applyWorkspaceAgentActivityV5(ctx context.Context) error {
 	}
 
 	return s.recordMigration(ctx, schemaMigrationWorkspaceAgentActivityV5)
+}
+
+func (s *Store) applyWorkspaceAgentActivityV6(ctx context.Context) error {
+	applied, err := s.hasMigration(ctx, schemaMigrationWorkspaceAgentActivityV6)
+	if err != nil {
+		return err
+	}
+
+	hasUserID, err := s.hasColumn(ctx, "workspace_agent_sessions", "user_id")
+	if err != nil {
+		return err
+	}
+
+	if !hasUserID {
+		if _, err := s.db.ExecContext(ctx, `ALTER TABLE workspace_agent_sessions ADD COLUMN user_id TEXT NOT NULL DEFAULT '';`); err != nil {
+			return fmt.Errorf("migrate workspace agent activity to v6 user id: %w", err)
+		}
+	}
+	if applied {
+		return nil
+	}
+	return s.recordMigration(ctx, schemaMigrationWorkspaceAgentActivityV6)
 }
 
 func (s *Store) backfillSystemAgentTargetIDs(ctx context.Context) error {

--- a/packages/agent/store-sqlite/repository.go
+++ b/packages/agent/store-sqlite/repository.go
@@ -85,6 +85,7 @@ type Session struct {
 	ID                string
 	WorkspaceID       string
 	Origin            string
+	UserID            string
 	AgentTargetID     string
 	Provider          string
 	ProviderSessionID string
@@ -109,6 +110,7 @@ type SessionStateReport struct {
 	WorkspaceID       string
 	AgentSessionID    string
 	Origin            string
+	UserID            string
 	AgentTargetID     string
 	Provider          string
 	ProviderSessionID string

--- a/packages/agent/store-sqlite/store_test.go
+++ b/packages/agent/store-sqlite/store_test.go
@@ -140,6 +140,7 @@ func TestStoreReportAndListSessionLifecycle(t *testing.T) {
 		WorkspaceID:       "ws-1",
 		AgentSessionID:    "session-1",
 		Origin:            "runtime",
+		UserID:            "user-1",
 		Provider:          "codex",
 		ProviderSessionID: "provider-1",
 		Cwd:               "/workspace",
@@ -152,6 +153,9 @@ func TestStoreReportAndListSessionLifecycle(t *testing.T) {
 	}
 	if !state.Accepted || state.LastEventUnixMS != 100 {
 		t.Fatalf("state result = %#v", state)
+	}
+	if state.Session.UserID != "user-1" {
+		t.Fatalf("state session user id = %q", state.Session.UserID)
 	}
 
 	first, err := store.ReportSessionMessages(ctx, SessionMessageReport{
@@ -202,6 +206,10 @@ func TestStoreReportAndListSessionLifecycle(t *testing.T) {
 	}
 	if len(page.Messages) != 1 || page.LatestVersion != 2 || page.Messages[0].Payload["text"] != "hello" {
 		t.Fatalf("page = %#v, want merged message payload", page)
+	}
+	session, ok, err := store.GetSession(ctx, "ws-1", "session-1")
+	if err != nil || !ok || session.UserID != "user-1" {
+		t.Fatalf("GetSession() = %#v ok=%v error=%v, want user id", session, ok, err)
 	}
 
 	pinned, ok, err := store.UpdateSessionPinned(ctx, "ws-1", "session-1", true)

--- a/services/tuttid/service/agent/activity_projection.go
+++ b/services/tuttid/service/agent/activity_projection.go
@@ -118,9 +118,12 @@ func (p *ActivityProjection) ReportSessionState(
 	input.SessionOrigin = sessionOrigin
 	input.Source = source
 	result, err := p.repo.ReportSessionState(ctx, agentactivitybiz.SessionStateReport{
-		WorkspaceID:       strings.TrimSpace(input.WorkspaceID),
-		AgentSessionID:    strings.TrimSpace(input.AgentSessionID),
-		Origin:            strings.TrimSpace(input.SessionOrigin),
+		WorkspaceID:    strings.TrimSpace(input.WorkspaceID),
+		AgentSessionID: strings.TrimSpace(input.AgentSessionID),
+		Origin:         strings.TrimSpace(input.SessionOrigin),
+		// Tutti local workspaces intentionally leave Source.UserID empty. Cloud
+		// collaboration hosts may provide real account user ids on this wire.
+		UserID:            strings.TrimSpace(input.Source.UserID),
 		AgentTargetID:     strings.TrimSpace(firstNonEmptyString(input.State.AgentTargetID, input.Source.AgentTargetID)),
 		Provider:          strings.TrimSpace(firstNonEmptyString(input.State.Provider, input.Source.Provider)),
 		ProviderSessionID: strings.TrimSpace(firstNonEmptyString(input.State.ProviderSessionID, input.Source.ProviderSessionID)),

--- a/services/tuttid/service/agent/activity_projection_session.go
+++ b/services/tuttid/service/agent/activity_projection_session.go
@@ -12,6 +12,7 @@ func persistedSessionFromActivity(session agentactivitybiz.Session) PersistedSes
 		ID:                strings.TrimSpace(session.ID),
 		WorkspaceID:       strings.TrimSpace(session.WorkspaceID),
 		Origin:            strings.TrimSpace(session.Origin),
+		UserID:            strings.TrimSpace(session.UserID),
 		AgentTargetID:     strings.TrimSpace(session.AgentTargetID),
 		Provider:          strings.TrimSpace(session.Provider),
 		ProviderSessionID: strings.TrimSpace(session.ProviderSessionID),

--- a/services/tuttid/service/agent/service_session.go
+++ b/services/tuttid/service/agent/service_session.go
@@ -78,6 +78,7 @@ func serviceSession(session RuntimeSession, resumable bool) Session {
 	)
 	return Session{
 		ID:                 strings.TrimSpace(session.ID),
+		UserID:             strings.TrimSpace(session.UserID),
 		AgentTargetID:      strings.TrimSpace(session.AgentTargetID),
 		Provider:           normalizedProvider,
 		ProviderSessionID:  strings.TrimSpace(session.ProviderSessionID),
@@ -122,6 +123,7 @@ func sessionFromPersisted(session PersistedSession, resumable bool) Session {
 	return serviceSession(RuntimeSession{
 		ID:                strings.TrimSpace(session.ID),
 		WorkspaceID:       strings.TrimSpace(session.WorkspaceID),
+		UserID:            strings.TrimSpace(session.UserID),
 		AgentTargetID:     strings.TrimSpace(session.AgentTargetID),
 		Provider:          strings.TrimSpace(session.Provider),
 		ProviderSessionID: strings.TrimSpace(session.ProviderSessionID),
@@ -152,6 +154,9 @@ func importedSessionDisplayUpdatedAtUnixMS(session PersistedSession) int64 {
 }
 
 func mergePersistedSessionState(session Session, persisted PersistedSession) Session {
+	if strings.TrimSpace(session.UserID) == "" {
+		session.UserID = strings.TrimSpace(persisted.UserID)
+	}
 	if strings.TrimSpace(session.AgentTargetID) == "" {
 		session.AgentTargetID = strings.TrimSpace(persisted.AgentTargetID)
 	}

--- a/services/tuttid/service/agent/service_test.go
+++ b/services/tuttid/service/agent/service_test.go
@@ -4043,6 +4043,7 @@ func TestServiceListsActivePeersFromCanonicalSessionStatus(t *testing.T) {
 			"ws-1:session-1": {
 				ID:              "session-1",
 				WorkspaceID:     "ws-1",
+				UserID:          "user-1",
 				Provider:        "codex",
 				Status:          "working",
 				Title:           "Active work",
@@ -4052,6 +4053,7 @@ func TestServiceListsActivePeersFromCanonicalSessionStatus(t *testing.T) {
 			"ws-1:session-2": {
 				ID:              "session-2",
 				WorkspaceID:     "ws-1",
+				UserID:          "user-2",
 				Provider:        "claude",
 				Status:          "completed",
 				Title:           "Done",
@@ -4065,11 +4067,11 @@ func TestServiceListsActivePeersFromCanonicalSessionStatus(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ListActivePeers returned error: %v", err)
 	}
-	if len(peers.Agents) != 1 || peers.Agents[0].Session.ID != "session-1" {
+	if len(peers.Agents) != 1 {
 		t.Fatalf("peers = %#v", peers)
 	}
-	if peers.Agents[0].SelfRelation != "unknown" {
-		t.Fatalf("self relation = %q", peers.Agents[0].SelfRelation)
+	if peers.Agents[0].Session.ID != "session-1" || peers.Agents[0].SelfRelation != "unknown" {
+		t.Fatalf("peers = %#v", peers)
 	}
 	if peers.SelfKnown || !peers.MayIncludeSelf || peers.Warning != "SELF_IDENTITY_UNAVAILABLE" {
 		t.Fatalf("peer identity metadata = %#v", peers)

--- a/services/tuttid/service/agent/session_types.go
+++ b/services/tuttid/service/agent/session_types.go
@@ -74,6 +74,7 @@ type ComposerCapabilityLister interface {
 
 type Session struct {
 	ID                 string
+	UserID             string
 	AgentTargetID      string
 	Provider           string
 	ProviderSessionID  string
@@ -149,6 +150,7 @@ type PersistedSession struct {
 	ID                string
 	WorkspaceID       string
 	Origin            string
+	UserID            string
 	AgentTargetID     string
 	Provider          string
 	ProviderSessionID string
@@ -219,6 +221,7 @@ type SessionPinUpdater interface {
 type RuntimeSession struct {
 	ID                 string
 	WorkspaceID        string
+	UserID             string
 	AgentTargetID      string
 	Provider           string
 	ProviderSessionID  string

--- a/services/tuttid/wiring.go
+++ b/services/tuttid/wiring.go
@@ -246,6 +246,7 @@ func buildDaemonAPI(ctx context.Context, store workspacedata.CatalogStore, analy
 		ManagedRuntime:    managedRuntimeResolver,
 		RunOutcomes:       runOutcomes,
 	}
+	accountService := accountservice.NewService("")
 	agentRuntime, err := agentdaemon.NewRuntime(agentdaemon.Config{
 		Reporter: agentRunOutcomeReporter{
 			inner: agentActivityProjection,
@@ -398,7 +399,7 @@ func buildDaemonAPI(ctx context.Context, store workspacedata.CatalogStore, analy
 	terminalService := &workspaceservice.TerminalService{}
 
 	return tuttiapi.DaemonAPI{
-		AccountService:            accountservice.NewService(""),
+		AccountService:            accountService,
 		UserProjectService:        userProjectService,
 		AgentTargetService:        agentTargets,
 		PreferencesService:        preferences,


### PR DESCRIPTION
## Summary
- add a neutral AgentGUI conversation-rail footer slot for host-provided React content
- add shared-agent provider target factory support without adding tuttid agent_targets persistence
- carry additive activity/session userId through projection and sqlite storage; Tutti local workspaces intentionally leave it empty, while cloud collaboration hosts may inject real account user ids

## Validation
- pnpm check:changed --tail-lines 80
- pnpm check:full
- targeted Go/Vitest checks during development

## Notes
- Tutti personal edition does not use account login state for agent session display, and does not filter local conversations by userId.
- Documentation updated in `docs/architecture/agent-gui-node.md` and `docs/architecture/agent-activity-packages.md`.
