### PR TITLE
fix(agent): keep no-project sessions out of project rails

### DIFF
--- a/apps/desktop/src/renderer/src/features/workspace-agent/services/createDesktopAgentHostApi.test.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-agent/services/createDesktopAgentHostApi.test.ts
@@ -1309,6 +1309,7 @@ test("desktop agent host api creates no-project session cwd under user Documents
           planMode: null,
           provider: "codex",
           reasoningEffort: null,
+          runtimeContext: { noProject: true },
           speed: null,
           title: "Scratch",
           visible: true

--- a/apps/desktop/src/renderer/src/features/workspace-agent/services/desktopAgentActivityAdapter.test.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-agent/services/desktopAgentActivityAdapter.test.ts
@@ -299,6 +299,34 @@ test("desktop agent activity adapter forwards submit diagnostic metadata", async
   ]);
 });
 
+test("desktop agent activity adapter marks empty-cwd creates as no-project", async () => {
+  let createBody: unknown = null;
+  const adapter = createDesktopAgentActivityAdapter({
+    tuttidClient: createTuttidClient({
+      async createWorkspaceAgentSession(_workspaceId, body) {
+        createBody = body;
+        return createSession({
+          cwd: "/Users/local/Documents/tutti/session-agent-session-1"
+        });
+      }
+    }),
+    runtimeApi: createRuntimeApi()
+  });
+
+  await adapter.createSession({
+    agentSessionId: "agent-session-1",
+    agentTargetId: "local:codex",
+    initialContent: [{ type: "text", text: "hi" }],
+    provider: "codex",
+    workspaceId
+  });
+
+  assert.deepEqual(
+    (createBody as { runtimeContext?: Record<string, unknown> }).runtimeContext,
+    { noProject: true }
+  );
+});
+
 test("desktop agent activity adapter refreshes provider status and localizes adapter mismatch create failures", async () => {
   const refreshCalls: unknown[] = [];
   const adapter = createDesktopAgentActivityAdapter({
@@ -1118,6 +1146,7 @@ test("desktop agent activity adapter forwards agent target id when creating Clau
       planMode: null,
       provider: "claude-code",
       reasoningEffort: null,
+      runtimeContext: { noProject: true },
       speed: null,
       title: null,
       visible: false

--- a/apps/desktop/src/renderer/src/features/workspace-agent/services/desktopAgentActivityAdapter.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-agent/services/desktopAgentActivityAdapter.ts
@@ -73,8 +73,9 @@ export function createDesktopAgentActivityAdapter({
       createDesktopAgentActivitySessionId();
     const agentTargetId = requiredAgentTargetId(input.agentTargetId);
     const promise = withAbortableRequestTimeout(
-      (signal) =>
-        tuttidClient.createWorkspaceAgentSession(
+      (signal) => {
+        const runtimeContext = createSessionRuntimeContext({ cwd });
+        return tuttidClient.createWorkspaceAgentSession(
           input.workspaceId,
           {
             agentSessionId,
@@ -86,12 +87,14 @@ export function createDesktopAgentActivityAdapter({
             planMode: input.settings.planMode,
             provider: "claude-code",
             reasoningEffort: input.settings.reasoningEffort,
+            ...(runtimeContext ? { runtimeContext } : {}),
             speed: input.settings.speed,
             title: null,
             visible: false
           },
           { signal }
-        ),
+        );
+      },
       {
         signal: input.signal,
         timeoutMessage: "Agent session create request timed out.",
@@ -431,8 +434,9 @@ export function createDesktopAgentActivityAdapter({
         });
         const agentTargetId = requiredAgentTargetId(input.agentTargetId);
         const session = await withAbortableRequestTimeout(
-          (signal) =>
-            tuttidClient.createWorkspaceAgentSession(
+          (signal) => {
+            const runtimeContext = createSessionRuntimeContext(input);
+            return tuttidClient.createWorkspaceAgentSession(
               input.workspaceId,
               {
                 agentSessionId,
@@ -448,12 +452,14 @@ export function createDesktopAgentActivityAdapter({
                 permissionModeId: input.permissionModeId ?? null,
                 provider: workspaceAgentProvider(input.provider),
                 reasoningEffort: input.reasoningEffort ?? null,
+                ...(runtimeContext ? { runtimeContext } : {}),
                 speed: input.speed ?? null,
                 title: input.title ?? null,
                 visible: input.visible ?? null
               },
               { signal }
-            ),
+            );
+          },
           {
             signal: input.signal,
             timeoutMessage: "Agent session create request timed out.",
@@ -773,6 +779,17 @@ function requiredAgentTargetId(value: string | null | undefined): string {
     throw new Error("Agent target id is required to create an agent session.");
   }
   return agentTargetId;
+}
+
+function createSessionRuntimeContext(input: {
+  cwd?: string | null;
+  runtimeContext?: Record<string, unknown> | null;
+}): Record<string, unknown> | undefined {
+  const runtimeContext = { ...(input.runtimeContext ?? {}) };
+  if (!normalizeText(input.cwd)) {
+    runtimeContext.noProject = true;
+  }
+  return Object.keys(runtimeContext).length > 0 ? runtimeContext : undefined;
 }
 
 function providerTargetRefKey(

--- a/apps/desktop/src/renderer/src/features/workspace-agent/services/internal/workspaceAgentActivityService.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-agent/services/internal/workspaceAgentActivityService.ts
@@ -3,6 +3,7 @@ import {
   normalizeAgentActivityDisplayStatus,
   type AgentActivityAdapter,
   type AgentActivityCancelSessionResult,
+  type AgentActivityCreateSessionInput,
   type AgentActivityController,
   type AgentActivityMessage,
   type AgentActivityMessagePage,
@@ -384,9 +385,13 @@ export class WorkspaceAgentActivityService implements IWorkspaceAgentActivitySer
       workspaceId: input.workspaceId,
       fields: { agentTargetId: input.agentTargetId ?? null }
     });
-    const adapterInput = input.agentTargetId
-      ? { ...input, providerTargetRef: null }
-      : input;
+    const sessionInput = withNoProjectRuntimeContext(
+      input,
+      this.dependencies.workspaceUserProjectService
+    );
+    const adapterInput = sessionInput.agentTargetId
+      ? { ...sessionInput, providerTargetRef: null }
+      : sessionInput;
     const session = await entry.adapter.createSession(adapterInput);
     reportAgentSubmitTraceDiagnostic(this.dependencies.runtimeApi, {
       agentSessionId: session.agentSessionId,
@@ -481,6 +486,9 @@ export class WorkspaceAgentActivityService implements IWorkspaceAgentActivitySer
           ? {}
           : { providerTargetRef: input.providerTargetRef ?? null }),
         reasoningEffort: input.settings?.reasoningEffort ?? null,
+        ...(resolvedCwd?.noProject
+          ? { runtimeContext: { noProject: true } }
+          : {}),
         speed: input.settings?.speed ?? null,
         title: input.title ?? null,
         visible: input.visible ?? true
@@ -808,7 +816,7 @@ export class WorkspaceAgentActivityService implements IWorkspaceAgentActivitySer
     agentSessionId: string;
     cwd: string | null | undefined;
     workspaceId: string;
-  }): Promise<{ cwd: string | null }> {
+  }): Promise<{ cwd: string | null; noProject: boolean }> {
     const trimmed = input.cwd?.trim() ?? "";
     if (!trimmed) {
       const directory =
@@ -821,17 +829,17 @@ export class WorkspaceAgentActivityService implements IWorkspaceAgentActivitySer
       this.dependencies.workspaceUserProjectService?.rememberNoProjectPath(
         directory?.path
       );
-      return { cwd: directory?.path ?? null };
+      return { cwd: directory?.path ?? null, noProject: true };
     }
     if (trimmed !== "/") {
-      return { cwd: trimmed };
+      return { cwd: trimmed, noProject: false };
     }
     const response =
       await this.dependencies.tuttidClient.listWorkspaceFileDirectory(
         input.workspaceId,
         {}
       );
-    return { cwd: response.root };
+    return { cwd: response.root, noProject: false };
   }
 
   private async fetchActivitySession(
@@ -1791,6 +1799,27 @@ function hostMessageEventFromCore(message: AgentActivityMessage): unknown {
       workspaceId: message.workspaceId
     },
     eventType: "message_update"
+  };
+}
+
+function withNoProjectRuntimeContext<T extends AgentActivityCreateSessionInput>(
+  input: T,
+  workspaceUserProjectService:
+    | Pick<IWorkspaceUserProjectService, "isNoProjectPath">
+    | undefined
+): T {
+  const cwd = input.cwd?.trim() ?? "";
+  const noProject =
+    !cwd || workspaceUserProjectService?.isNoProjectPath(cwd) === true;
+  if (!noProject) {
+    return input;
+  }
+  return {
+    ...input,
+    runtimeContext: {
+      ...(input.runtimeContext ?? {}),
+      noProject: true
+    }
   };
 }
 

--- a/packages/agent/activity-core/src/types.ts
+++ b/packages/agent/activity-core/src/types.ts
@@ -284,6 +284,7 @@ export interface AgentActivityCreateSessionInput {
    */
   providerTargetRef?: AgentActivityProviderTargetRef | null;
   reasoningEffort?: string | null;
+  runtimeContext?: Record<string, unknown> | null;
   speed?: string | null;
   title?: string | null;
   visible?: boolean | null;

--- a/packages/agent/gui/agent-gui/agentGuiNode/AgentGUINodeView.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/AgentGUINodeView.tsx
@@ -3699,29 +3699,41 @@ export function updateConversationSectionsFromSummaries(
   let changed = false;
   const nextSections = previous.map((section) => {
     let sectionChanged = false;
-    const items = section.items.map((item) => {
-      seenIds.add(item.id);
-      const summary = summariesById.get(item.id);
-      if (!summary) {
-        return item;
-      }
-      const nextItem = {
-        ...summary,
-        project: item.project
-      };
-      if (conversationSummariesRenderEqual(item, nextItem)) {
-        return item;
-      }
-      sectionChanged = true;
-      return nextItem;
-    });
+    const summaryItems = summarySectionItemsById.get(section.id) ?? [];
+    const summaryIdsForSection = new Set(summaryItems.map((item) => item.id));
+    const items = section.items
+      .map((item) => {
+        seenIds.add(item.id);
+        const summary = summariesById.get(item.id);
+        if (!summary) {
+          return item;
+        }
+        const nextItem = section.project
+          ? {
+              ...summary,
+              project: section.project
+            }
+          : summary;
+        if (conversationSummariesRenderEqual(item, nextItem)) {
+          return item;
+        }
+        sectionChanged = true;
+        return nextItem;
+      })
+      .filter((item) => {
+        const summary = summariesById.get(item.id);
+        if (!summary || summaryIdsForSection.has(item.id)) {
+          return true;
+        }
+        sectionChanged = true;
+        return false;
+      });
     const nextSection = sectionChanged
       ? {
           ...section,
           items
         }
       : section;
-    const summaryItems = summarySectionItemsById.get(section.id) ?? [];
     if (section.kind === "pinned" || summaryItems.length === 0) {
       if (sectionChanged) {
         changed = true;
@@ -3730,14 +3742,16 @@ export function updateConversationSectionsFromSummaries(
     }
     const summaryIds = new Set(summaryItems.map((item) => item.id));
     const mergedItems = [
-      ...summaryItems.map((item) => ({
-        ...item,
-        project: section.project
-      })),
+      ...summaryItems.map((item) =>
+        section.project ? { ...item, project: section.project } : item
+      ),
       ...items.filter((item) => !summaryIds.has(item.id))
     ];
-    const stableItems = stabilizeConversationSectionItems(items, mergedItems);
-    if (stableItems === items) {
+    const stableItems = stabilizeConversationSectionItems(
+      section.items,
+      mergedItems
+    );
+    if (stableItems === section.items) {
       if (sectionChanged) {
         changed = true;
       }

--- a/packages/agent/gui/agent-gui/agentGuiNode/agentGuiNodeViewConversationSections.spec.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/agentGuiNodeViewConversationSections.spec.ts
@@ -150,6 +150,39 @@ describe("updateConversationSectionsFromSummaries", () => {
     expect(result?.[0]?.items).toHaveLength(1);
   });
 
+  it("moves a summary to its resolved section instead of leaving a stale copy behind", () => {
+    const appProject = project("/workspace/app", "App");
+    const staleConversation = conversation("moving-convo", 1000);
+    const resolvedConversation = conversation("moving-convo", 2000, {
+      project: appProject
+    });
+    const previous: ConversationSection[] = [
+      {
+        id: "project:/workspace/app",
+        kind: "project",
+        label: "App",
+        project: appProject,
+        items: []
+      },
+      {
+        id: "conversations",
+        kind: "conversations",
+        label: sectionConversationsLabel,
+        project: null,
+        items: [staleConversation]
+      }
+    ];
+
+    const result = updateConversationSectionsFromSummaries(
+      previous,
+      [resolvedConversation],
+      { sectionConversationsLabel }
+    );
+
+    expect(result?.[0]?.items.map((item) => item.id)).toEqual(["moving-convo"]);
+    expect(result?.[1]?.items).toEqual([]);
+  });
+
   it("returns the same reference when there is nothing new and nothing changed", () => {
     const existing = conversation("existing", 1000);
     const previous: ConversationSection[] = [

--- a/packages/agent/gui/agent-gui/agentGuiNode/model/agentGuiConversationModel.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/model/agentGuiConversationModel.ts
@@ -589,7 +589,10 @@ function isExternalImportNoProjectSession(
 ): boolean {
   const runtimeContext =
     session && "runtimeContext" in session ? session.runtimeContext : undefined;
-  return runtimeContext?.externalImportNoProject === true;
+  return (
+    runtimeContext?.noProject === true ||
+    runtimeContext?.externalImportNoProject === true
+  );
 }
 
 function isImportedWorkspaceAgentSession(

--- a/packages/clients/tuttid-ts/src/generated/types.gen.ts
+++ b/packages/clients/tuttid-ts/src/generated/types.gen.ts
@@ -1397,6 +1397,12 @@ export type CreateWorkspaceAgentSessionRequest = {
   permissionModeId?: string | null;
   model?: string | null;
   reasoningEffort?: string | null;
+  /**
+   * Optional durable runtime context hints for session classification and provider startup.
+   */
+  runtimeContext?: {
+    [key: string]: unknown;
+  } | null;
   speed?: string | null;
   planMode?: boolean | null;
   browserUse?: boolean | null;

--- a/services/tuttid/api/daemon_agent_submit_handlers.go
+++ b/services/tuttid/api/daemon_agent_submit_handlers.go
@@ -53,6 +53,7 @@ func (api DaemonAPI) CreateWorkspaceAgentSession(ctx context.Context, request tu
 		BrowserUse:             request.Body.BrowserUse,
 		Provider:               provider,
 		ReasoningEffort:        request.Body.ReasoningEffort,
+		RuntimeContext:         mapValue(request.Body.RuntimeContext),
 		Speed:                  request.Body.Speed,
 		Title:                  request.Body.Title,
 		Visible:                request.Body.Visible,

--- a/services/tuttid/api/generated/types.gen.go
+++ b/services/tuttid/api/generated/types.gen.go
@@ -2402,9 +2402,12 @@ type CreateWorkspaceAgentSessionRequest struct {
 	// ProviderTargetRef Deprecated opaque host-owned provider target reference. It is not launch authority; the daemon derives the trusted provider target ref from the stored agent target identified by agentTargetId.
 	ProviderTargetRef *map[string]interface{} `json:"providerTargetRef,omitempty"`
 	ReasoningEffort   *string                 `json:"reasoningEffort,omitempty"`
-	Speed             *string                 `json:"speed,omitempty"`
-	Title             *string                 `json:"title,omitempty"`
-	Visible           *bool                   `json:"visible,omitempty"`
+
+	// RuntimeContext Optional durable runtime context hints for session classification and provider startup.
+	RuntimeContext *map[string]interface{} `json:"runtimeContext,omitempty"`
+	Speed          *string                 `json:"speed,omitempty"`
+	Title          *string                 `json:"title,omitempty"`
+	Visible        *bool                   `json:"visible,omitempty"`
 }
 
 // CreateWorkspaceAppFactoryJobRequest defines model for CreateWorkspaceAppFactoryJobRequest.

--- a/services/tuttid/api/openapi/tuttid.v1.yaml
+++ b/services/tuttid/api/openapi/tuttid.v1.yaml
@@ -6825,6 +6825,11 @@ components:
         reasoningEffort:
           type: string
           nullable: true
+        runtimeContext:
+          type: object
+          nullable: true
+          additionalProperties: true
+          description: Optional durable runtime context hints for session classification and provider startup.
         speed:
           type: string
           nullable: true

--- a/services/tuttid/data/workspace/agent_session_rail.go
+++ b/services/tuttid/data/workspace/agent_session_rail.go
@@ -197,10 +197,15 @@ func agentSessionRailPathContains(parent string, child string) bool {
 }
 
 func isAgentSessionNoProjectRuntimeContext(runtimeContext map[string]any) bool {
-	value, ok := runtimeContext["externalImportNoProject"]
-	if !ok {
-		return false
+	for _, key := range []string{"noProject", "externalImportNoProject"} {
+		if runtimeContextBool(runtimeContext[key]) {
+			return true
+		}
 	}
+	return false
+}
+
+func runtimeContextBool(value any) bool {
 	switch typed := value.(type) {
 	case bool:
 		return typed

--- a/services/tuttid/data/workspace/sqlite_store_test.go
+++ b/services/tuttid/data/workspace/sqlite_store_test.go
@@ -832,6 +832,11 @@ func TestSQLiteStoreAgentSessionRailNoProjectPrecedesParentProject(t *testing.T)
 			cwd:            importedNoProjectCwd,
 			runtimeContext: map[string]any{"externalImportNoProject": true},
 		},
+		{
+			sessionID:      "session-no-project-marker-under-home",
+			cwd:            importedNoProjectCwd,
+			runtimeContext: map[string]any{"noProject": true},
+		},
 	} {
 		if _, err := store.ReportSessionState(ctx, agentactivitybiz.SessionStateReport{
 			WorkspaceID:      "ws-agent-rail-no-project",

--- a/services/tuttid/service/agent/service.go
+++ b/services/tuttid/service/agent/service.go
@@ -151,6 +151,7 @@ func (s *Service) Create(ctx context.Context, workspaceID string, input CreateSe
 			BrowserUse:        input.BrowserUse,
 			ComputerUse:       input.ComputerUse,
 			ProviderTargetRef: clonePayload(input.ProviderTargetRef),
+			RuntimeContext:    clonePayload(input.RuntimeContext),
 			Speed: normalizeSpeedForProvider(
 				provider,
 				value(input.Speed),

--- a/services/tuttid/service/agent/service_session.go
+++ b/services/tuttid/service/agent/service_session.go
@@ -166,6 +166,53 @@ func mergePersistedSessionState(session Session, persisted PersistedSession) Ses
 	return session
 }
 
+// importRuntimeContextFields are the import-classification markers written
+// once at import time (see external_import.go's ReportSessionState call).
+// They are a Tutti-app-level annotation, not part of the underlying provider
+// adapter's own runtime bookkeeping, so a live RuntimeSession's RuntimeContext
+// never sets them itself.
+var importRuntimeContextFields = []string{
+	"imported",
+	"externalImportNoProject",
+	"externalSourcePath",
+	"noProject",
+}
+
+// mergeImportRuntimeContextFields carries the import-classification markers
+// forward onto a live runtime session's RuntimeContext. Without this, once an
+// imported session is opened/resumed into a live RuntimeSession, its live
+// RuntimeContext is non-empty (it carries the adapter's own bookkeeping), so
+// the all-or-nothing swap above never runs — silently dropping
+// "imported": true from the projected Session. The frontend's unread-badge
+// guard depends on that flag staying set, so losing it made a read imported
+// Codex session's unread badge reappear once its runtime session activated.
+func mergeImportRuntimeContextFields(live map[string]any, persisted map[string]any) map[string]any {
+	if len(persisted) == 0 {
+		return live
+	}
+	merged := live
+	cloned := false
+	for _, key := range importRuntimeContextFields {
+		if _, ok := merged[key]; ok {
+			continue
+		}
+		value, ok := persisted[key]
+		if !ok {
+			continue
+		}
+		if !cloned {
+			next := make(map[string]any, len(live)+len(importRuntimeContextFields))
+			for k, v := range live {
+				next[k] = v
+			}
+			merged = next
+			cloned = true
+		}
+		merged[key] = clonePayloadValue(value)
+	}
+	return merged
+}
+
 func permissionModeIDFromSettings(settings *ComposerSettings) string {
 	if settings == nil {
 		return ""

--- a/services/tuttid/service/agent/session_types.go
+++ b/services/tuttid/service/agent/session_types.go
@@ -394,6 +394,7 @@ type CreateSessionInput struct {
 	ComputerUse            *bool
 	ProviderTargetRef      map[string]any
 	ReasoningEffort        *string
+	RuntimeContext         map[string]any
 	Speed                  *string
 	ConversationDetailMode string
 	Visible                *bool


### PR DESCRIPTION
## Summary
- backport the no-project agent session rail classification fix
- persist no-project session intent through runtimeContext during session creation
- remove stale conversation copies when summaries move between rail sections

## Validation
- cd apps/desktop && node --import ./test/register-asset-stub.mjs --test --experimental-strip-types src/renderer/src/features/workspace-agent/services/desktopAgentActivityAdapter.test.ts src/renderer/src/features/workspace-agent/services/internal/workspaceAgentActivityService.test.ts src/renderer/src/features/workspace-agent/services/createDesktopAgentHostApi.test.ts
- pnpm --filter @tutti-os/agent-gui exec vitest run --environment jsdom --maxWorkers=1 agent-gui/agentGuiNode/agentGuiNodeViewConversationSections.spec.ts
- cd services/tuttid && go test ./data/workspace ./api ./service/agent
- pnpm check:api-generated
- pnpm lint:ts
- pnpm typecheck

## Backport Notes
- Resolved conflicts in workspaceAgentActivityService.ts and service_session.go.
- The release branch lacked the runtimeContext import-field helper already present on main, so this backport carries that helper plus the noProject marker.
