### PR TITLE
fix(agent): keep Claude live model cache as last-known-good, scoped by auth

### DIFF
--- a/services/tuttid/service/agent/composer_live_model_auth_scope.go
+++ b/services/tuttid/service/agent/composer_live_model_auth_scope.go
@@ -1,0 +1,82 @@
+package agent
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/tutti-os/tutti/services/tuttid/biz/agentprovider"
+)
+
+// claudeAuthScopeEnvKeys are the environment inputs that select which Claude
+// account / billing context a session runs under — and therefore which model
+// list the SDK advertises. Fingerprinting them into the live-model cache key
+// keeps one auth context's model list from being served after the user switches
+// to another (e.g. OAuth subscription -> ANTHROPIC_API_KEY billing) when no
+// running session is present to correct it via the reuse path.
+//
+// Keychain OAuth accounts are intentionally NOT read here: doing so is
+// credential-touching (the exact operation the hidden-discovery serialization
+// exists to minimize). Two OAuth subscriptions therefore share one scope; that
+// residual case is reconciled the moment a real session runs (running-session
+// first ordering in mergeLiveComposerModelsForComposerOptions).
+var claudeAuthScopeEnvKeys = []string{
+	"ANTHROPIC_API_KEY",
+	"ANTHROPIC_AUTH_TOKEN",
+	"ANTHROPIC_BASE_URL",
+	"ANTHROPIC_API_BASE_URL",
+	"CLAUDE_CONFIG_DIR",
+}
+
+// liveModelAuthScope returns a stable, non-secret fingerprint of the auth
+// context for the provider, or "" when the provider's model list is not
+// auth-sensitive (every non-Claude provider today). The fingerprint is a hash,
+// so raw credentials never enter the cache key.
+func liveModelAuthScope(provider string) string {
+	if agentprovider.Normalize(provider) != agentprovider.ClaudeCode {
+		return ""
+	}
+	settingsEnv := claudeSettingsEnvBlock()
+	var b strings.Builder
+	for _, key := range claudeAuthScopeEnvKeys {
+		value := strings.TrimSpace(os.Getenv(key))
+		if value == "" {
+			value = strings.TrimSpace(settingsEnv[key])
+		}
+		b.WriteString(key)
+		b.WriteByte('=')
+		b.WriteString(value)
+		b.WriteByte('\n')
+	}
+	sum := sha256.Sum256([]byte(b.String()))
+	return hex.EncodeToString(sum[:8])
+}
+
+// claudeSettingsEnvBlock reads the `env` block of ~/.claude/settings.json (or
+// $CLAUDE_CONFIG_DIR/settings.json). Claude Code merges these into the process
+// environment, so an ANTHROPIC_API_KEY declared there is as authoritative as one
+// exported in the shell. Missing file or malformed JSON yields an empty map.
+func claudeSettingsEnvBlock() map[string]string {
+	claudeConfigDir := strings.TrimSpace(os.Getenv("CLAUDE_CONFIG_DIR"))
+	if claudeConfigDir == "" {
+		home, err := os.UserHomeDir()
+		if err != nil {
+			return nil
+		}
+		claudeConfigDir = filepath.Join(home, ".claude")
+	}
+	settings := readJSONRecord(filepath.Join(claudeConfigDir, "settings.json"))
+	envRaw, ok := settings["env"].(map[string]any)
+	if !ok {
+		return nil
+	}
+	result := make(map[string]string, len(envRaw))
+	for key, raw := range envRaw {
+		if value, ok := raw.(string); ok {
+			result[key] = value
+		}
+	}
+	return result
+}

--- a/services/tuttid/service/agent/composer_live_model_cache.go
+++ b/services/tuttid/service/agent/composer_live_model_cache.go
@@ -80,7 +80,7 @@ func (s *Service) liveComposerModelCache() *composerLiveModelCache {
 }
 
 func (s *Service) getLiveComposerModelOptions(provider, workspaceID, cwd string, now time.Time) ([]ComposerConfigOptionValue, bool) {
-	key := composerLiveModelCacheKey(provider, workspaceID, cwd)
+	key := composerLiveModelCacheKey(provider, workspaceID, cwd, liveModelAuthScope(provider))
 	return s.liveComposerModelCache().get(key, now, s.liveModelCacheTTL(provider))
 }
 
@@ -88,15 +88,24 @@ func (s *Service) setLiveComposerModelOptions(provider, workspaceID, cwd string,
 	if len(options) == 0 {
 		return
 	}
-	key := composerLiveModelCacheKey(provider, workspaceID, cwd)
+	key := composerLiveModelCacheKey(provider, workspaceID, cwd, liveModelAuthScope(provider))
 	s.liveComposerModelCache().set(key, now, options)
 }
 
-func composerLiveModelCacheKey(provider, workspaceID, cwd string) string {
-	return "live-model:" +
+// composerLiveModelCacheKey buckets the cache by provider, workspace, cwd, and
+// (for auth-sensitive providers) an auth-context fingerprint. authScope is ""
+// for providers whose model list does not depend on auth, keeping their key
+// format unchanged. The same fingerprint also scopes the once-per-key hidden
+// discovery guard, so switching auth grants the new context its own probe.
+func composerLiveModelCacheKey(provider, workspaceID, cwd, authScope string) string {
+	key := "live-model:" +
 		agentprovider.Normalize(provider) + ":" +
 		strings.TrimSpace(workspaceID) + ":" +
 		strings.TrimSpace(cwd)
+	if authScope = strings.TrimSpace(authScope); authScope != "" {
+		key += ":" + authScope
+	}
+	return key
 }
 
 func cloneComposerConfigOptionValues(options []ComposerConfigOptionValue) []ComposerConfigOptionValue {

--- a/services/tuttid/service/agent/composer_live_model_cache.go
+++ b/services/tuttid/service/agent/composer_live_model_cache.go
@@ -27,7 +27,7 @@ func newComposerLiveModelCache() *composerLiveModelCache {
 }
 
 func (c *composerLiveModelCache) get(key string, now time.Time, ttl time.Duration) ([]ComposerConfigOptionValue, bool) {
-	if c == nil || ttl <= 0 {
+	if c == nil {
 		return nil, false
 	}
 	c.mu.Lock()
@@ -36,7 +36,11 @@ func (c *composerLiveModelCache) get(key string, now time.Time, ttl time.Duratio
 	if !ok {
 		return nil, false
 	}
-	if now.Sub(entry.cachedAt) > ttl {
+	// ttl <= 0 means the entry never expires (last-known-good). Claude Code uses
+	// this: a real session's model list is always better than the static
+	// fallback, and expiring it only decays the picker back to the static list
+	// with no way to re-probe (hidden discovery runs at most once per key).
+	if ttl > 0 && now.Sub(entry.cachedAt) > ttl {
 		delete(c.entries, key)
 		return nil, false
 	}
@@ -55,9 +59,15 @@ func (c *composerLiveModelCache) set(key string, now time.Time, options []Compos
 	}
 }
 
-func (s *Service) liveModelCacheTTL() time.Duration {
+func (s *Service) liveModelCacheTTL(provider string) time.Duration {
 	if s.LiveModelCacheTTL != 0 {
 		return s.LiveModelCacheTTL
+	}
+	// Claude Code advertises a stable, account-level model list that only a real
+	// session (or daemon restart) refreshes; keep the last-known-good entry for
+	// the daemon's lifetime instead of decaying to the static fallback.
+	if agentprovider.Normalize(provider) == agentprovider.ClaudeCode {
+		return 0
 	}
 	return defaultLiveModelCacheTTL
 }
@@ -71,7 +81,7 @@ func (s *Service) liveComposerModelCache() *composerLiveModelCache {
 
 func (s *Service) getLiveComposerModelOptions(provider, workspaceID, cwd string, now time.Time) ([]ComposerConfigOptionValue, bool) {
 	key := composerLiveModelCacheKey(provider, workspaceID, cwd)
-	return s.liveComposerModelCache().get(key, now, s.liveModelCacheTTL())
+	return s.liveComposerModelCache().get(key, now, s.liveModelCacheTTL(provider))
 }
 
 func (s *Service) setLiveComposerModelOptions(provider, workspaceID, cwd string, now time.Time, options []ComposerConfigOptionValue) {

--- a/services/tuttid/service/agent/composer_live_model_cache_test.go
+++ b/services/tuttid/service/agent/composer_live_model_cache_test.go
@@ -11,6 +11,7 @@ import (
 // session's model list must not decay back to the static fallback, because
 // hidden discovery runs at most once per key and cannot re-probe after expiry.
 func TestGetLiveComposerModelOptionsClaudeNeverExpires(t *testing.T) {
+	t.Setenv("CLAUDE_CONFIG_DIR", t.TempDir())
 	service := &Service{}
 	cachedAt := time.Now().UTC()
 	service.setLiveComposerModelOptions("claude-code", "ws-1", "/repo", cachedAt, []ComposerConfigOptionValue{
@@ -42,6 +43,31 @@ func TestGetLiveComposerModelOptionsCursorExpiresAfterTTL(t *testing.T) {
 	}
 	if _, ok := service.getLiveComposerModelOptions("cursor", "ws-1", "/repo", cachedAt.Add(defaultLiveModelCacheTTL+time.Minute)); ok {
 		t.Fatal("cursor cache survived past TTL, want eviction")
+	}
+}
+
+// Switching Claude auth context (e.g. OAuth subscription -> ANTHROPIC_API_KEY
+// billing) must not serve the previous context's cached model list: the auth
+// fingerprint in the cache key buckets them separately.
+func TestGetLiveComposerModelOptionsClaudeAuthScopeIsolatesCache(t *testing.T) {
+	t.Setenv("CLAUDE_CONFIG_DIR", t.TempDir())
+	t.Setenv("ANTHROPIC_API_KEY", "")
+	t.Setenv("ANTHROPIC_AUTH_TOKEN", "")
+	service := &Service{}
+	now := time.Now().UTC()
+	service.setLiveComposerModelOptions("claude-code", "ws-1", "/repo", now, []ComposerConfigOptionValue{
+		{Value: "default", Label: "Default"},
+		{Value: "opus[1m]", Label: "Opus"},
+	})
+
+	if _, ok := service.getLiveComposerModelOptions("claude-code", "ws-1", "/repo", now); !ok {
+		t.Fatal("cache miss under same auth scope, want hit")
+	}
+
+	// Switch to API-key billing: the OAuth-context list must not leak through.
+	t.Setenv("ANTHROPIC_API_KEY", "sk-ant-test")
+	if _, ok := service.getLiveComposerModelOptions("claude-code", "ws-1", "/repo", now); ok {
+		t.Fatal("cache hit across auth switch, want miss (cross-auth isolation)")
 	}
 }
 

--- a/services/tuttid/service/agent/composer_live_model_cache_test.go
+++ b/services/tuttid/service/agent/composer_live_model_cache_test.go
@@ -1,0 +1,109 @@
+package agent
+
+import (
+	"context"
+	"slices"
+	"testing"
+	"time"
+)
+
+// Claude Code keeps its live model cache for the daemon's lifetime: a real
+// session's model list must not decay back to the static fallback, because
+// hidden discovery runs at most once per key and cannot re-probe after expiry.
+func TestGetLiveComposerModelOptionsClaudeNeverExpires(t *testing.T) {
+	service := &Service{}
+	cachedAt := time.Now().UTC()
+	service.setLiveComposerModelOptions("claude-code", "ws-1", "/repo", cachedAt, []ComposerConfigOptionValue{
+		{Value: "default", Label: "Default"},
+		{Value: "claude-fable-5[1m]", Label: "Fable"},
+	})
+
+	got, ok := service.getLiveComposerModelOptions("claude-code", "ws-1", "/repo", cachedAt.Add(24*time.Hour))
+	if !ok {
+		t.Fatal("claude live model cache expired, want last-known-good retained")
+	}
+	if len(got) != 2 {
+		t.Fatalf("cached options = %d, want 2", len(got))
+	}
+}
+
+// Non-Claude providers (Cursor) keep the bounded TTL: a stale entry must be
+// evicted so the picker does not pin a list the running session no longer
+// advertises.
+func TestGetLiveComposerModelOptionsCursorExpiresAfterTTL(t *testing.T) {
+	service := &Service{}
+	cachedAt := time.Now().UTC()
+	service.setLiveComposerModelOptions("cursor", "ws-1", "/repo", cachedAt, []ComposerConfigOptionValue{
+		{Value: "gpt-5", Label: "GPT-5"},
+	})
+
+	if _, ok := service.getLiveComposerModelOptions("cursor", "ws-1", "/repo", cachedAt.Add(defaultLiveModelCacheTTL/2)); !ok {
+		t.Fatal("cursor cache expired inside TTL, want hit")
+	}
+	if _, ok := service.getLiveComposerModelOptions("cursor", "ws-1", "/repo", cachedAt.Add(defaultLiveModelCacheTTL+time.Minute)); ok {
+		t.Fatal("cursor cache survived past TTL, want eviction")
+	}
+}
+
+// A running Claude session's advertised model list is the freshest source and
+// must override a stale cache (and refresh it). Without running-session-first
+// ordering, a never-expiring cache would shadow the live session and freeze the
+// picker at the stale list until daemon restart.
+func TestGetComposerOptionsClaudeRunningSessionOverridesStaleCache(t *testing.T) {
+	t.Setenv("CLAUDE_CONFIG_DIR", t.TempDir())
+	runtime := newFakeRuntime()
+	runtime.sessions["ws-1:session-1"] = RuntimeSession{
+		ID:          "session-1",
+		WorkspaceID: "ws-1",
+		Provider:    "claude-code",
+		Status:      "ready",
+		RuntimeContext: map[string]any{
+			"configOptions": []any{
+				map[string]any{
+					"id":           "model",
+					"currentValue": "default",
+					"options": []any{
+						map[string]any{"name": "Default", "value": "default"},
+						map[string]any{"name": "Opus", "value": "opus[1m]"},
+						map[string]any{"name": "Fable", "value": "claude-fable-5[1m]"},
+					},
+				},
+			},
+		},
+	}
+	service := NewService(runtime)
+	// Seed a stale cache that predates the running session's newer list.
+	service.setLiveComposerModelOptions("claude-code", "ws-1", "/repo", time.Now().UTC().Add(-time.Hour), []ComposerConfigOptionValue{
+		{Value: "default", Label: "Default"},
+		{Value: "sonnet", Label: "Sonnet"},
+	})
+
+	options, err := service.GetComposerOptions(context.Background(), ComposerOptionsInput{
+		Provider:    "claude-code",
+		WorkspaceID: "ws-1",
+		Cwd:         "/repo",
+	})
+	if err != nil {
+		t.Fatalf("GetComposerOptions returned error: %v", err)
+	}
+	if len(runtime.startCalls) != 0 {
+		t.Fatalf("start calls = %d, want no hidden discovery beside running session", len(runtime.startCalls))
+	}
+
+	wantValues := []string{"default", "opus[1m]", "claude-fable-5[1m]"}
+	if got := composerConfigOptionModelValues(options.ModelConfig.Options); !slices.Equal(got, wantValues) {
+		t.Fatalf("model options = %v, want newer running-session list %v", got, wantValues)
+	}
+	if options.RuntimeContext["modelCatalogSource"] != "acp-live-discovery" {
+		t.Fatalf("modelCatalogSource = %#v, want acp-live-discovery", options.RuntimeContext["modelCatalogSource"])
+	}
+
+	// The live session must have refreshed the cache, not the reverse.
+	cached, ok := service.getLiveComposerModelOptions("claude-code", "ws-1", "/repo", time.Now().UTC())
+	if !ok {
+		t.Fatal("cache missing after refresh")
+	}
+	if got := composerConfigOptionModelValues(cached); !slices.Equal(got, wantValues) {
+		t.Fatalf("cache after refresh = %v, want %v", got, wantValues)
+	}
+}

--- a/services/tuttid/service/agent/composer_live_model_discovery.go
+++ b/services/tuttid/service/agent/composer_live_model_discovery.go
@@ -106,7 +106,7 @@ func (s *Service) discoverLiveComposerModels(
 		return nil, ErrInvalidArgument
 	}
 	provider = agentprovider.Normalize(provider)
-	cacheKey := composerLiveModelCacheKey(provider, workspaceID, cwd)
+	cacheKey := composerLiveModelCacheKey(provider, workspaceID, cwd, liveModelAuthScope(provider))
 	resultCh := liveComposerModelDiscoveryGroup.DoChan(cacheKey, func() (any, error) {
 		now := time.Now().UTC()
 		if cached, ok := s.getLiveComposerModelOptions(provider, workspaceID, cwd, now); ok && len(cached) > 0 {

--- a/services/tuttid/service/agent/composer_live_model_discovery.go
+++ b/services/tuttid/service/agent/composer_live_model_discovery.go
@@ -441,26 +441,39 @@ func (s *Service) mergeLiveComposerModelsForComposerOptions(
 	modelSource := "claude-static"
 	if strings.TrimSpace(input.WorkspaceID) != "" {
 		now := time.Now().UTC()
-		cached, ok := s.getLiveComposerModelOptions(provider, input.WorkspaceID, input.Cwd, now)
-		if ok {
-			liveModels = cached
+		reused, hasProviderSession := s.liveModelOptionsFromRunningSession(input.WorkspaceID, provider)
+		switch {
+		case len(reused) > 0:
+			// A running session's advertised list is the freshest source. Use it
+			// and refresh the cache so the last-known-good entry tracks live
+			// changes (this is the only refresh path now that the Claude cache
+			// never expires — do not let a stale cache shadow a live session).
+			liveModels = reused
+			s.setLiveComposerModelOptions(provider, input.WorkspaceID, input.Cwd, now, reused)
 			modelSource = "acp-live-discovery"
-		} else if reused, hasProviderSession := s.liveModelOptionsFromRunningSession(input.WorkspaceID, provider); hasProviderSession {
-			if len(reused) > 0 {
-				liveModels = reused
-				s.setLiveComposerModelOptions(provider, input.WorkspaceID, input.Cwd, now, reused)
+		case hasProviderSession:
+			// A real session exists but has not advertised models yet. Prefer the
+			// last-known-good cache over the static fallback, but never spawn a
+			// hidden discovery session next to a live session.
+			if cached, ok := s.getLiveComposerModelOptions(provider, input.WorkspaceID, input.Cwd, now); ok {
+				liveModels = cached
 				modelSource = "acp-live-discovery"
 			}
-			// If a real provider session exists but has not advertised a model
-			// list yet, do not spawn a hidden discovery session next to it.
-		} else {
-			discovered, err := s.discoverLiveComposerModels(ctx, provider, input.WorkspaceID, input.Cwd, effectiveSettings)
-			if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
-				return ComposerOptions{}, err
-			}
-			if err == nil && len(discovered) > 0 {
-				liveModels = discovered
+		default:
+			// No running session: prefer the cache, else one hidden discovery,
+			// else fall through to the static fallback below.
+			if cached, ok := s.getLiveComposerModelOptions(provider, input.WorkspaceID, input.Cwd, now); ok {
+				liveModels = cached
 				modelSource = "acp-live-discovery"
+			} else {
+				discovered, err := s.discoverLiveComposerModels(ctx, provider, input.WorkspaceID, input.Cwd, effectiveSettings)
+				if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+					return ComposerOptions{}, err
+				}
+				if err == nil && len(discovered) > 0 {
+					liveModels = discovered
+					modelSource = "acp-live-discovery"
+				}
 			}
 		}
 	}


### PR DESCRIPTION
## Problem

Tutti's Claude composer model picker intermittently showed a degraded list — the static fallback (`default / opus / sonnet / haiku`, **missing Fable and the `[1m]` variants**) instead of the real account list — whenever the daemon had been up past ~10 minutes with no running Claude session to reuse.

Root cause is two commits that stopped composing:

- The live-model cache had a **10-minute TTL**, originally paired with periodic re-probing.
- A later credential-stability fix gated hidden discovery to **at most once per cache key** (`markLiveModelDiscoveryAttempted`, never reset for the daemon lifetime).

After that, an expired cache could no longer be re-probed. Once the entry aged out with no running session, composer options decayed to the static fallback until a real session ran again or the daemon restarted. The TTL had lost its freshness role and only caused regressions.

## Fix

**1. Keep the Claude cache as last-known-good (never expires).** Other providers (Cursor) keep the bounded TTL. A real model list is always better than the static fallback, and — given the once-per-key probe guard — expiring it buys no freshness, only decay.

**2. Reorder resolution to running-session-first.** Removing the TTL alone would *freeze* the cache: `mergeLiveComposerModelsForComposerOptions` checked the cache first, so a never-expiring entry would permanently shadow the reuse branch (the only path that refreshes the cache from a live session). New order:

- running session advertises models → use it **and refresh the cache** (authoritative, tracks live changes)
- running session exists but no models yet → fall back to cache, never spawn a hidden probe beside it
- no running session → cache → one hidden discovery → static fallback

All prior invariants hold (no hidden probe beside a live session, discovery only when no session runs, once-per-key credential guard).

**3. Scope the cache key by auth context.** The key was `provider:workspaceID:cwd` with no auth dimension. Claude reports the model list of whichever account is authenticated (OAuth subscription vs `ANTHROPIC_API_KEY` billing can differ), so a never-expiring cache could serve one auth context's list after switching to another. Added an auth-context fingerprint (sha256 of `ANTHROPIC_API_KEY` / `ANTHROPIC_AUTH_TOKEN` / `ANTHROPIC_BASE_URL` / `ANTHROPIC_API_BASE_URL` / `CLAUDE_CONFIG_DIR`, from env + `settings.json`). Raw secrets never enter the key; non-Claude providers pass an empty scope (key format unchanged). The fingerprint also scopes the once-per-key probe guard, so a new auth context earns its own probe.

Deliberately does **not** read the keychain (credential-touching): two OAuth accounts share one scope; that residual case self-heals via the running-session-first ordering.

## Tests

- Claude cache never expires; Cursor cache still evicts past TTL.
- A running Claude session's newer model list overrides a stale cache and refreshes it.
- Switching to `ANTHROPIC_API_KEY` misses the prior auth context's cache (cross-auth isolation).

## Manual validation (dev, clean run)

Fresh daemon, single hidden discovery probe at T+19s seeded the cache, then **~12.5 min with no running Claude session**. Composer picker still showed the full 5-item live list (`default / opus[1m] / claude-fable-5[1m] / sonnet / haiku`). With the old TTL, the cache and the hidden discovery session both expire at the 10-min mark → the picker would have decayed to the static 4-item list in that window. Observed full list = fix confirmed, and only one probe ran (credential-risk surface unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Live model caching now keeps Claude Code results available for the full daemon session, while other providers continue using time-based expiry.
  * Cached live model data is now separated by authentication scope, reducing cross-account or cross-session leakage.

* **Bug Fixes**
  * Running provider sessions now take priority over stale cached model lists.
  * Hidden discovery is avoided when a live session is already available, improving reliability and reducing unnecessary lookups.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->