### PR TITLE
feat(agent-gui): compact pasted long text in composer

### DIFF
--- a/packages/agent/gui/agent-gui/agentGuiNode/AgentComposer.spec.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/AgentComposer.spec.tsx
@@ -52,9 +52,12 @@ const workspaceUserProjectI18n = createWorkspaceUserProjectI18nRuntime(
 function createDraft(
   prompt: string,
   images: AgentComposerDraft["images"] = [],
-  files: AgentComposerDraft["files"] = []
+  files: AgentComposerDraft["files"] = [],
+  largeTexts?: AgentComposerDraft["largeTexts"]
 ): AgentComposerDraft {
-  return { prompt, images, files };
+  return largeTexts
+    ? { prompt, images, files, largeTexts }
+    : { prompt, images, files };
 }
 
 function createFileDataTransfer(files: readonly File[]): DataTransfer {
@@ -177,6 +180,7 @@ vi.mock("./agentRichText/AgentRichTextEditor", async () => {
           disabled,
           onChange,
           onPasteImages,
+          onPasteLargeText,
           onFileMentionSuggestionChange,
           onKeyDownForPalette,
           onSubmit,
@@ -190,6 +194,7 @@ vi.mock("./agentRichText/AgentRichTextEditor", async () => {
           onChange: (value: string) => void;
           onFileMentionSuggestionChange?: (state: any) => void;
           onPasteImages?: (images: unknown[]) => void;
+          onPasteLargeText?: (text: string) => void;
           onKeyDownForPalette?: (event: KeyboardEvent) => boolean;
           onSubmit?: () => void;
           onSubmitGuidance?: () => void;
@@ -304,6 +309,15 @@ vi.mock("./agentRichText/AgentRichTextEditor", async () => {
               }
             >
               paste image
+            </button>
+            <button
+              type="button"
+              data-testid="mock-paste-large-text"
+              onClick={() =>
+                onPasteLargeText?.("first pasted line\nsecond pasted line")
+              }
+            >
+              paste large text
             </button>
           </>
         );
@@ -3780,6 +3794,81 @@ describe("AgentComposer", () => {
     expect(
       screen.queryByTestId("agent-gui-composer-image-drafts")
     ).not.toBeInTheDocument();
+  });
+
+  it("keeps pasted large text compact and submits the full text", () => {
+    let draftContent = createDraft("");
+    const onDraftContentChange = vi.fn((nextDraft: AgentComposerDraft) => {
+      draftContent = nextDraft;
+    });
+    const onSubmit = vi.fn();
+    const renderComposer = () => (
+      <AgentComposer
+        workspaceId="workspace-1"
+        currentUserId="user-1"
+        provider="codex"
+        draftContent={draftContent}
+        availableCommands={[] satisfies readonly AgentHostAgentSessionCommand[]}
+        disabled={false}
+        submitDisabled={false}
+        placeholder="placeholder"
+        composerSettings={createComposerSettings()}
+        queuedPrompts={[]}
+        drainingQueuedPromptId={null}
+        canQueueWhileBusy={false}
+        showStopButton={false}
+        activePrompt={null}
+        isInterrupting={false}
+        isSendingTurn={false}
+        isSubmittingPrompt={false}
+        labels={createLabels()}
+        workspaceUserProjectI18n={workspaceUserProjectI18n}
+        onDraftContentChange={onDraftContentChange}
+        onSettingsChange={vi.fn()}
+        onSubmit={onSubmit}
+        onSendQueuedPromptNext={vi.fn()}
+        onRemoveQueuedPrompt={vi.fn()}
+        onEditQueuedPrompt={vi.fn()}
+        onInterruptCurrentTurn={vi.fn()}
+        onSubmitInteractivePrompt={vi.fn()}
+      />
+    );
+    const { rerender } = render(renderComposer());
+
+    fireEvent.click(screen.getByTestId("mock-paste-large-text"));
+    rerender(renderComposer());
+
+    expect(draftContent).toEqual(
+      createDraft(
+        "",
+        [],
+        [],
+        [
+          {
+            id: "pasted-text-1",
+            name: "pasted-text-1.txt",
+            text: "first pasted line\nsecond pasted line",
+            sizeBytes: 36
+          }
+        ]
+      )
+    );
+    expect(
+      screen.getByTestId("agent-gui-composer-large-text-draft")
+    ).toHaveTextContent("pasted-text-1.txt");
+
+    fireEvent.click(screen.getByRole("button", { name: "发送" }));
+
+    expect(onSubmit).toHaveBeenCalledWith(
+      [
+        {
+          type: "text",
+          text: "Pasted text attachment: pasted-text-1.txt\n\nfirst pasted line\nsecond pasted line"
+        }
+      ],
+      "[pasted-text-1.txt · 36 B]"
+    );
+    expect(onDraftContentChange).toHaveBeenLastCalledWith(createDraft(""));
   });
 
   it("uploads pasted images immediately and submits the staged path", async () => {

--- a/packages/agent/gui/agent-gui/agentGuiNode/AgentComposer.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/AgentComposer.tsx
@@ -18,6 +18,7 @@ import type {
   AgentComposerDraft,
   AgentComposerDraftFile,
   AgentComposerDraftImage,
+  AgentComposerDraftLargeText,
   AgentGUIComposerSettingsVM,
   AgentGUIProviderSkillOption,
   AgentGUIQueuedPromptVM
@@ -68,6 +69,7 @@ import {
 } from "./model/agentComposerTriggerQueries";
 import {
   agentComposerDraftHasContent,
+  agentComposerDraftDisplayPrompt,
   agentComposerDraftToPromptContent,
   emptyAgentComposerDraft,
   MAX_AGENT_COMPOSER_DRAFT_IMAGES,
@@ -195,6 +197,14 @@ const DOCK_COMPOSER_INPUT_MAX_HEIGHT =
   DOCK_COMPOSER_TEXT_VIEWPORT_MAX_HEIGHT;
 const DOCK_COMPOSER_INPUT_BORDER_HEIGHT = 2;
 const DOCK_COMPOSER_INPUT_PADDING_BLOCK_HEIGHT = 24;
+const AGENT_COMPOSER_PASTED_TEXT_FILE_PREFIX = "pasted-text";
+
+function agentComposerTextByteLength(text: string): number {
+  if (typeof TextEncoder !== "undefined") {
+    return new TextEncoder().encode(text).byteLength;
+  }
+  return text.length;
+}
 
 /**
  * 引用 picker 的确认结果:松散文件按 file mention 插入;mentionItems(如文件夹 bundle)
@@ -1049,6 +1059,7 @@ export function AgentComposer({
   const isGoalModeActive = goalDraftObjective !== null;
   const draftImages = draftContent.images;
   const draftFiles = draftContent.files ?? [];
+  const draftLargeTexts = draftContent.largeTexts ?? [];
   const agentActivityRuntime = useOptionalAgentActivityRuntime();
   const agentHostApi = useOptionalAgentHostApi();
   const getReferenceForFile = agentHostApi?.workspace.getReferenceForFile;
@@ -1104,6 +1115,9 @@ export function AgentComposer({
   const draftPromptRef = useRef(draftPrompt);
   const draftImagesRef = useRef<AgentComposerDraftImage[]>(draftImages);
   const draftFilesRef = useRef<AgentComposerDraftFile[]>(draftFiles);
+  const draftLargeTextsRef =
+    useRef<AgentComposerDraftLargeText[]>(draftLargeTexts);
+  const nextDraftLargeTextIndexRef = useRef(draftLargeTexts.length);
   const promptTipRef = useRef<HTMLSpanElement | null>(null);
   const mentionControllerRef = useRef<AgentMentionSearchController | null>(
     null
@@ -1413,6 +1427,14 @@ export function AgentComposer({
   }, [draftFiles]);
 
   useEffect(() => {
+    draftLargeTextsRef.current = draftLargeTexts;
+    nextDraftLargeTextIndexRef.current = Math.max(
+      nextDraftLargeTextIndexRef.current,
+      draftLargeTexts.length
+    );
+  }, [draftLargeTexts]);
+
+  useEffect(() => {
     if (
       previousSlashStatusAgentSessionIdRef.current === slashStatusAgentSessionId
     ) {
@@ -1647,6 +1669,7 @@ export function AgentComposer({
       const canSubmitWhileSending = canQueueWhileBusy && isSendingTurn;
       const currentDraftImages = draftImagesRef.current;
       const currentDraftFiles = draftFilesRef.current;
+      const currentDraftLargeTexts = draftLargeTextsRef.current;
       const hasUploadingImages = currentDraftImages.some(
         (image) => image.uploading
       );
@@ -1674,7 +1697,8 @@ export function AgentComposer({
         ...draftContent,
         prompt: nextPrompt,
         images: currentDraftImages,
-        files: currentDraftFiles
+        files: currentDraftFiles,
+        largeTexts: currentDraftLargeTexts
       };
       if (!agentComposerDraftHasContent(nextDraftContent)) {
         return;
@@ -1711,13 +1735,23 @@ export function AgentComposer({
         provider,
         skills: availableSkills
       });
+      const submitDisplayPrompt =
+        agentComposerDraftDisplayPrompt(nextDraftContent);
       if (options?.guidance === true) {
         if (!onSubmitGuidance) {
           return;
         }
-        onSubmitGuidance(submitContent);
+        if (submitDisplayPrompt) {
+          onSubmitGuidance(submitContent, submitDisplayPrompt);
+        } else {
+          onSubmitGuidance(submitContent);
+        }
       } else {
-        onSubmit(submitContent);
+        if (submitDisplayPrompt) {
+          onSubmit(submitContent, submitDisplayPrompt);
+        } else {
+          onSubmit(submitContent);
+        }
       }
       // Starting a brand-new conversation (no active conversation yet) is
       // async — session creation + activation round trip — before the view
@@ -1731,6 +1765,7 @@ export function AgentComposer({
         draftPromptRef.current = "";
         draftImagesRef.current = [];
         draftFilesRef.current = [];
+        draftLargeTextsRef.current = [];
         setPaletteDraftPrompt("");
         onDraftContentChange(emptyAgentComposerDraft());
       }
@@ -2209,7 +2244,8 @@ export function AgentComposer({
       onDraftContentChange({
         prompt: draftPromptRef.current,
         images: nextDraftImages,
-        files: draftFilesRef.current
+        files: draftFilesRef.current,
+        largeTexts: draftLargeTextsRef.current
       });
       if (!uploadPromptContent) {
         return;
@@ -2250,7 +2286,8 @@ export function AgentComposer({
             onDraftContentChange({
               prompt: draftPromptRef.current,
               images: uploadedDraftImages,
-              files: draftFilesRef.current
+              files: draftFilesRef.current,
+              largeTexts: draftLargeTextsRef.current
             });
           })
           .catch((error: unknown) => {
@@ -2269,7 +2306,8 @@ export function AgentComposer({
             onDraftContentChange({
               prompt: draftPromptRef.current,
               images: failedDraftImages,
-              files: draftFilesRef.current
+              files: draftFilesRef.current,
+              largeTexts: draftLargeTextsRef.current
             });
           });
       }
@@ -2292,7 +2330,8 @@ export function AgentComposer({
       onDraftContentChange({
         prompt: draftPromptRef.current,
         images: nextDraftImages,
-        files: draftFilesRef.current
+        files: draftFilesRef.current,
+        largeTexts: draftLargeTextsRef.current
       });
     },
     [onDraftContentChange]
@@ -2307,7 +2346,52 @@ export function AgentComposer({
       onDraftContentChange({
         prompt: draftPromptRef.current,
         images: draftImagesRef.current,
-        files: nextDraftFiles
+        files: nextDraftFiles,
+        largeTexts: draftLargeTextsRef.current
+      });
+    },
+    [onDraftContentChange]
+  );
+
+  const removeDraftLargeText = useCallback(
+    (id: string): void => {
+      const nextDraftLargeTexts = draftLargeTextsRef.current.filter(
+        (item) => item.id !== id
+      );
+      draftLargeTextsRef.current = nextDraftLargeTexts;
+      onDraftContentChange({
+        prompt: draftPromptRef.current,
+        images: draftImagesRef.current,
+        files: draftFilesRef.current,
+        largeTexts: nextDraftLargeTexts
+      });
+    },
+    [onDraftContentChange]
+  );
+
+  const handlePastedLargeText = useCallback(
+    (text: string): void => {
+      const normalizedText = text.replace(/\r\n/g, "\n").replace(/\r/g, "\n");
+      if (!normalizedText.trim()) {
+        return;
+      }
+      const nextIndex = nextDraftLargeTextIndexRef.current + 1;
+      nextDraftLargeTextIndexRef.current = nextIndex;
+      const nextDraftLargeTexts = [
+        ...draftLargeTextsRef.current,
+        {
+          id: `${AGENT_COMPOSER_PASTED_TEXT_FILE_PREFIX}-${nextIndex}`,
+          name: `${AGENT_COMPOSER_PASTED_TEXT_FILE_PREFIX}-${nextIndex}.txt`,
+          text: normalizedText,
+          sizeBytes: agentComposerTextByteLength(normalizedText)
+        }
+      ];
+      draftLargeTextsRef.current = nextDraftLargeTexts;
+      onDraftContentChange({
+        prompt: draftPromptRef.current,
+        images: draftImagesRef.current,
+        files: draftFilesRef.current,
+        largeTexts: nextDraftLargeTexts
       });
     },
     [onDraftContentChange]
@@ -2950,7 +3034,13 @@ export function AgentComposer({
       resizeObserver?.disconnect();
       window.removeEventListener("resize", measure);
     };
-  }, [draftFiles.length, draftImages.length, isHeroLayout, paletteDraftPrompt]);
+  }, [
+    draftFiles.length,
+    draftImages.length,
+    draftLargeTexts.length,
+    isHeroLayout,
+    paletteDraftPrompt
+  ]);
   const inputShellStyle = useMemo<CSSProperties | undefined>(
     () =>
       showFileMentionPalette || showFloatingCommandMenu
@@ -3007,6 +3097,7 @@ export function AgentComposer({
   const disabledReasonText = disabledReason?.trim() ?? "";
   const effectivePlaceholder = disabledReasonText || placeholder;
   const visibleDraftFiles = draftFiles;
+  const visibleDraftLargeTexts = draftLargeTexts;
   useEffect(() => {
     if (previousSelectedProjectPathRef.current === selectedProjectPath) {
       return;
@@ -3269,11 +3360,37 @@ export function AgentComposer({
                     ))}
                   </div>
                 ) : null}
-                {visibleDraftFiles.length > 0 ? (
+                {visibleDraftFiles.length > 0 ||
+                visibleDraftLargeTexts.length > 0 ? (
                   <div
                     className="mb-2 flex max-w-[520px] flex-wrap gap-2"
                     data-testid="agent-gui-composer-file-drafts"
                   >
+                    {visibleDraftLargeTexts.map((item) => (
+                      <div
+                        key={item.id}
+                        className="group inline-flex max-w-full items-center gap-2 rounded-[6px] border border-[var(--line-1)] bg-[var(--background-fronted)] px-2 py-1 text-xs text-[var(--text-primary)]"
+                        data-testid="agent-gui-composer-large-text-draft"
+                        title={item.name}
+                      >
+                        <span
+                          className="size-2 shrink-0 rounded-full bg-[var(--text-tertiary)]"
+                          aria-hidden
+                        />
+                        <span className="min-w-0 max-w-[220px] truncate">
+                          {item.name}
+                        </span>
+                        <button
+                          type="button"
+                          className="inline-flex size-5 shrink-0 items-center justify-center rounded-full text-[var(--text-secondary)] transition hover:bg-[var(--transparency-hover)] hover:text-[var(--text-primary)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:color-mix(in_srgb,var(--text-primary)_34%,transparent)]"
+                          aria-label={labels.removeMention}
+                          title={labels.removeMention}
+                          onClick={() => removeDraftLargeText(item.id)}
+                        >
+                          <X size={12} strokeWidth={2.4} aria-hidden />
+                        </button>
+                      </div>
+                    ))}
                     {visibleDraftFiles.map((file) => (
                       <div
                         key={file.id}
@@ -3348,6 +3465,7 @@ export function AgentComposer({
                     promptImagesSupported={promptImagesSupported}
                     onPromptImagesUnsupported={onPromptImagesUnsupported}
                     onPasteImages={handlePastedImages}
+                    onPasteLargeText={handlePastedLargeText}
                     getReferenceForFile={getReferenceForFile}
                     onDropFiles={
                       promptFilesSupported

--- a/packages/agent/gui/agent-gui/agentGuiNode/agentRichText/AgentRichTextEditor.spec.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/agentRichText/AgentRichTextEditor.spec.tsx
@@ -11,6 +11,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import { EditorView } from "@tiptap/pm/view";
 import {
   AgentRichTextEditor,
+  isAgentRichTextLargeTextPaste,
   type AgentRichTextEditorHandle
 } from "./AgentRichTextEditor";
 import { AgentGuiI18nProvider } from "../../../i18n/index";
@@ -340,6 +341,62 @@ describe("AgentRichTextEditor", () => {
         "[@package-lock.json](/workspace/package-lock.json) 继续输入"
       )
     );
+  });
+
+  it("detects long pasted text without inserting it inline", async () => {
+    const onChange = vi.fn();
+    const onPasteLargeText = vi.fn();
+    const pastedText = Array.from({ length: 14 }, (_, index) => {
+      return `line ${index + 1}`;
+    }).join("\n");
+    render(
+      <AgentRichTextEditor
+        value="before "
+        disabled={false}
+        placeholder="Prompt"
+        onChange={onChange}
+        onSubmit={vi.fn()}
+        onPasteLargeText={onPasteLargeText}
+      />
+    );
+
+    fireEvent.paste(await screen.findByRole("textbox", { name: "Prompt" }), {
+      clipboardData: clipboard(pastedText)
+    });
+
+    expect(onPasteLargeText).toHaveBeenCalledWith(pastedText);
+    expect(onChange).not.toHaveBeenCalledWith(
+      expect.stringContaining("line 1")
+    );
+  });
+
+  it("keeps short pasted text inline when large text handling is available", async () => {
+    const onChange = vi.fn();
+    const onPasteLargeText = vi.fn();
+    render(
+      <AgentRichTextEditor
+        value="before "
+        disabled={false}
+        placeholder="Prompt"
+        onChange={onChange}
+        onSubmit={vi.fn()}
+        onPasteLargeText={onPasteLargeText}
+      />
+    );
+
+    fireEvent.paste(await screen.findByRole("textbox", { name: "Prompt" }), {
+      clipboardData: clipboard("short paste")
+    });
+
+    expect(onPasteLargeText).not.toHaveBeenCalled();
+    await waitFor(() =>
+      expect(onChange).toHaveBeenLastCalledWith("before short paste")
+    );
+  });
+
+  it("treats very long single-line paste as large text", () => {
+    expect(isAgentRichTextLargeTextPaste("x".repeat(2_000))).toBe(true);
+    expect(isAgentRichTextLargeTextPaste("x".repeat(1_999))).toBe(false);
   });
 
   it("copies selected reference mentions as prompt markdown", async () => {

--- a/packages/agent/gui/agent-gui/agentGuiNode/agentRichText/AgentRichTextEditor.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/agentRichText/AgentRichTextEditor.tsx
@@ -77,6 +77,7 @@ export interface AgentRichTextEditorProps {
   promptImagesSupported?: boolean;
   onPromptImagesUnsupported?: () => void;
   onPasteImages?: (images: AgentRichTextPastedImage[]) => void;
+  onPasteLargeText?: (text: string) => void;
   getReferenceForFile?: (file: File) => WorkspaceFileReference | null;
   onDropFiles?: (files: readonly File[]) => void;
 }
@@ -100,6 +101,18 @@ interface AgentRichTextContextMenuState {
   selectionTo: number;
   x: number;
   y: number;
+}
+
+const AGENT_RICH_TEXT_LARGE_PASTE_MIN_CHARS = 2_000;
+const AGENT_RICH_TEXT_LARGE_PASTE_MIN_LINES = 12;
+
+export function isAgentRichTextLargeTextPaste(text: string): boolean {
+  const trimmed = text.trim();
+  if (trimmed.length < AGENT_RICH_TEXT_LARGE_PASTE_MIN_CHARS) {
+    const lineCount = trimmed ? trimmed.split(/\r\n|\r|\n/).length : 0;
+    return lineCount >= AGENT_RICH_TEXT_LARGE_PASTE_MIN_LINES;
+  }
+  return true;
 }
 
 function buildWorkspaceFileMentionDropContent(
@@ -475,6 +488,7 @@ export const AgentRichTextEditor = forwardRef<
     promptImagesSupported = true,
     onPromptImagesUnsupported,
     onPasteImages,
+    onPasteLargeText,
     getReferenceForFile,
     onDropFiles
   },
@@ -497,6 +511,7 @@ export const AgentRichTextEditor = forwardRef<
   const onLinkClickRef = useRef(onLinkClick);
   const onPromptImagesUnsupportedRef = useRef(onPromptImagesUnsupported);
   const onPasteImagesRef = useRef(onPasteImages);
+  const onPasteLargeTextRef = useRef(onPasteLargeText);
   const onDropFilesRef = useRef(onDropFiles);
   const promptImagesSupportedRef = useRef(promptImagesSupported);
   const getReferenceForFileRef = useRef(getReferenceForFile);
@@ -516,6 +531,10 @@ export const AgentRichTextEditor = forwardRef<
   const insertPlainText = useCallback((text: string): void => {
     const currentEditor = editorRef.current;
     if (!currentEditor || currentEditor.isDestroyed || !text) {
+      return;
+    }
+    if (onPasteLargeTextRef.current && isAgentRichTextLargeTextPaste(text)) {
+      onPasteLargeTextRef.current(text);
       return;
     }
     suppressPastedAtSuggestionRef.current =
@@ -649,6 +668,7 @@ export const AgentRichTextEditor = forwardRef<
   onLinkClickRef.current = onLinkClick;
   onPromptImagesUnsupportedRef.current = onPromptImagesUnsupported;
   onPasteImagesRef.current = onPasteImages;
+  onPasteLargeTextRef.current = onPasteLargeText;
   onDropFilesRef.current = onDropFiles;
   promptImagesSupportedRef.current = promptImagesSupported;
   getReferenceForFileRef.current = getReferenceForFile;
@@ -827,6 +847,13 @@ export const AgentRichTextEditor = forwardRef<
             return false;
           }
           event.preventDefault();
+          if (
+            onPasteLargeTextRef.current &&
+            isAgentRichTextLargeTextPaste(text)
+          ) {
+            onPasteLargeTextRef.current(text);
+            return true;
+          }
           const currentEditor = editorRef.current;
           if (!currentEditor) {
             return true;

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUINodeController.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUINodeController.ts
@@ -102,6 +102,7 @@ import type {
 } from "../model/agentGuiNodeTypes";
 import {
   agentComposerDraftHasContent,
+  agentComposerDraftSubmittedText,
   agentPromptContentDisplayText,
   agentPromptContentHasImage,
   agentPromptContentToComposerDraft,
@@ -1020,7 +1021,9 @@ function shouldClearSubmittedDraft(input: {
   const submittedPrompt = agentPromptContentDisplayText(
     input.submittedContent
   ).trim();
-  if (currentDraft.prompt.trim() !== submittedPrompt) {
+  if (
+    agentComposerDraftSubmittedText(currentDraft).trim() !== submittedPrompt
+  ) {
     return false;
   }
   const submittedImages = input.submittedContent.filter(
@@ -3186,6 +3189,8 @@ function areAgentComposerDraftsEqual(
 ): boolean {
   const leftFiles = left.files ?? [];
   const rightFiles = right.files ?? [];
+  const leftLargeTexts = left.largeTexts ?? [];
+  const rightLargeTexts = right.largeTexts ?? [];
   return (
     left.prompt === right.prompt &&
     left.images.length === right.images.length &&
@@ -3221,6 +3226,19 @@ function areAgentComposerDraftsEqual(
         file.sizeBytes === other.sizeBytes &&
         file.uploading === other.uploading &&
         file.uploadError === other.uploadError
+      );
+    }) &&
+    leftLargeTexts.length === rightLargeTexts.length &&
+    leftLargeTexts.every((item, index) => {
+      const other = rightLargeTexts[index];
+      if (!other) {
+        return false;
+      }
+      return (
+        item.id === other.id &&
+        item.name === other.name &&
+        item.text === other.text &&
+        item.sizeBytes === other.sizeBytes
       );
     })
   );

--- a/packages/agent/gui/agent-gui/agentGuiNode/model/agentComposerDraft.spec.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/model/agentComposerDraft.spec.ts
@@ -1,6 +1,8 @@
 import { describe, expect, it } from "vitest";
 import {
+  agentComposerDraftDisplayPrompt,
   agentComposerDraftHasContent,
+  agentComposerDraftSubmittedText,
   agentComposerDraftToPromptContent,
   agentPromptContentDisplayText,
   agentPromptContentToComposerDraft,
@@ -29,6 +31,42 @@ describe("agentComposerDraft", () => {
         skills: []
       })
     ).toEqual([{ type: "text", text: "run tests" }]);
+  });
+
+  it("converts pasted large text drafts into compact display and submitted text", () => {
+    const draft = {
+      prompt: "Summarize this",
+      images: [],
+      largeTexts: [
+        {
+          id: "pasted-text-1",
+          name: "pasted-text-1.txt",
+          text: "first line\nsecond line",
+          sizeBytes: 22
+        }
+      ]
+    };
+
+    expect(agentComposerDraftHasContent(draft)).toBe(true);
+    expect(agentComposerDraftDisplayPrompt(draft)).toBe(
+      "Summarize this\n[pasted-text-1.txt · 22 B]"
+    );
+    expect(
+      agentComposerDraftToPromptContent({
+        draft,
+        provider: "codex",
+        skills: []
+      })
+    ).toEqual([
+      { type: "text", text: "Summarize this" },
+      {
+        type: "text",
+        text: "Pasted text attachment: pasted-text-1.txt\n\nfirst line\nsecond line"
+      }
+    ]);
+    expect(agentComposerDraftSubmittedText(draft)).toBe(
+      "Summarize this\nPasted text attachment: pasted-text-1.txt\n\nfirst line\nsecond line"
+    );
   });
 
   it("adds codex app-server prompt items for referenced skills and connectors", () => {

--- a/packages/agent/gui/agent-gui/agentGuiNode/model/agentComposerDraft.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/model/agentComposerDraft.ts
@@ -1,7 +1,9 @@
 import type { AgentPromptContentBlock } from "../../../shared/contracts/dto";
+import { translate } from "../../../i18n/index";
 import type {
   AgentComposerDraft,
   AgentComposerDraftFile,
+  AgentComposerDraftLargeText,
   AgentComposerDraftImage,
   AgentGUIProviderSkillOption
 } from "./agentGuiNodeTypes";
@@ -29,7 +31,8 @@ export function agentComposerDraftHasContent(
   return (
     draft.prompt.trim() !== "" ||
     draft.images.length > 0 ||
-    (draft.files?.length ?? 0) > 0
+    (draft.files?.length ?? 0) > 0 ||
+    (draft.largeTexts?.some((item) => item.text.trim() !== "") ?? false)
   );
 }
 
@@ -188,8 +191,43 @@ export function agentComposerDraftToPromptContent(input: {
         ...(file.sizeBytes ? { sizeBytes: file.sizeBytes } : {}),
         name: file.name,
         kind: "file"
-      }))
+      })),
+    ...largeTextPromptContent(input.draft.largeTexts ?? [])
   ]);
+}
+
+export function agentComposerDraftSubmittedText(
+  draft: AgentComposerDraft
+): string {
+  return agentPromptContentDisplayText(
+    normalizeAgentPromptContentBlocks([
+      ...textPromptContent(draft.prompt),
+      ...largeTextPromptContent(draft.largeTexts ?? [])
+    ])
+  );
+}
+
+export function agentComposerDraftDisplayPrompt(
+  draft: AgentComposerDraft
+): string | undefined {
+  const largeTexts = draft.largeTexts?.filter(
+    (item) => item.text.trim() !== ""
+  );
+  if (!largeTexts?.length) {
+    return undefined;
+  }
+  const parts = [draft.prompt.trim()].filter(Boolean);
+  parts.push(
+    ...largeTexts.map((item, index) => {
+      const name = item.name.trim() || `pasted-text-${index + 1}.txt`;
+      const sizeLabel =
+        typeof item.sizeBytes === "number" && Number.isFinite(item.sizeBytes)
+          ? ` · ${formatAgentComposerDraftBytes(item.sizeBytes)}`
+          : "";
+      return `[${name}${sizeLabel}]`;
+    })
+  );
+  return parts.join("\n");
 }
 
 function agentPromptFileBlocks(
@@ -240,6 +278,34 @@ function escapeRegExp(value: string): string {
 export function textPromptContent(prompt: string): AgentPromptContentBlock[] {
   const text = prompt.trim();
   return text ? [{ type: "text", text }] : [];
+}
+
+function largeTextPromptContent(
+  largeTexts: readonly AgentComposerDraftLargeText[]
+): AgentPromptContentBlock[] {
+  return largeTexts
+    .filter((item) => item.text.trim() !== "")
+    .map((item, index) => {
+      const name = item.name.trim() || `pasted-text-${index + 1}.txt`;
+      return {
+        type: "text" as const,
+        text: `${translate("agentHost.agentGui.pastedTextPromptAttachment", {
+          name
+        })}\n\n${item.text}`
+      };
+    });
+}
+
+function formatAgentComposerDraftBytes(sizeBytes: number): string {
+  if (sizeBytes < 1024) {
+    return `${sizeBytes} B`;
+  }
+  const kib = sizeBytes / 1024;
+  if (kib < 1024) {
+    return `${kib.toFixed(kib >= 10 ? 0 : 1)} KB`;
+  }
+  const mib = kib / 1024;
+  return `${mib.toFixed(mib >= 10 ? 0 : 1)} MB`;
 }
 
 function agentPromptImageBlockToDraftImage(

--- a/packages/agent/gui/agent-gui/agentGuiNode/model/agentGuiNodeTypes.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/model/agentGuiNodeTypes.ts
@@ -103,10 +103,18 @@ export interface AgentComposerDraftFile {
   uploadError?: string;
 }
 
+export interface AgentComposerDraftLargeText {
+  id: string;
+  name: string;
+  text: string;
+  sizeBytes?: number;
+}
+
 export interface AgentComposerDraft {
   prompt: string;
   images: AgentComposerDraftImage[];
   files?: AgentComposerDraftFile[];
+  largeTexts?: AgentComposerDraftLargeText[];
 }
 
 export interface AgentGUIComposerSettingsVM {

--- a/packages/agent/gui/app/renderer/i18n/locales/en.ts
+++ b/packages/agent/gui/app/renderer/i18n/locales/en.ts
@@ -596,6 +596,7 @@ export const en = {
       planImplementationSkip: "Stay in Plan Mode",
       noRunningResponse: "No running response to stop.",
       composerTextMenu: "Composer text actions",
+      pastedTextPromptAttachment: "Pasted text attachment: {{name}}",
       copyMessage: "Copy message",
       copyImage: "Copy image",
       messageCopied: "Copied",

--- a/packages/agent/gui/app/renderer/i18n/locales/zh-CN.ts
+++ b/packages/agent/gui/app/renderer/i18n/locales/zh-CN.ts
@@ -551,6 +551,7 @@ export const zhCN = {
       planImplementationSkip: "留在计划模式",
       noRunningResponse: "当前没有正在运行的回复。",
       composerTextMenu: "输入框文本操作",
+      pastedTextPromptAttachment: "粘贴的文本附件：{{name}}",
       copyMessage: "复制消息",
       copyImage: "复制图片",
       messageCopied: "已复制",


### PR DESCRIPTION
## Summary

- Detect long plain-text paste in the Agent GUI composer and show it as a compact pasted-text draft item.
- Keep short paste behavior unchanged while submitting the full pasted content to the agent without data loss.
- Include large pasted text in draft comparison, submitted-draft cleanup, and localized prompt attachment labeling.

Closes #632

## Verification

- `corepack pnpm exec oxfmt --write packages/agent/gui/agent-gui/agentGuiNode/AgentComposer.spec.tsx packages/agent/gui/agent-gui/agentGuiNode/AgentComposer.tsx packages/agent/gui/agent-gui/agentGuiNode/agentRichText/AgentRichTextEditor.spec.tsx packages/agent/gui/agent-gui/agentGuiNode/agentRichText/AgentRichTextEditor.tsx packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUINodeController.ts packages/agent/gui/agent-gui/agentGuiNode/model/agentComposerDraft.spec.ts packages/agent/gui/agent-gui/agentGuiNode/model/agentComposerDraft.ts packages/agent/gui/agent-gui/agentGuiNode/model/agentGuiNodeTypes.ts packages/agent/gui/app/renderer/i18n/locales/en.ts packages/agent/gui/app/renderer/i18n/locales/zh-CN.ts`
- `corepack pnpm exec oxlint --deny-warnings --no-error-on-unmatched-pattern packages/agent/gui/agent-gui/agentGuiNode/AgentComposer.spec.tsx packages/agent/gui/agent-gui/agentGuiNode/AgentComposer.tsx packages/agent/gui/agent-gui/agentGuiNode/agentRichText/AgentRichTextEditor.spec.tsx packages/agent/gui/agent-gui/agentGuiNode/agentRichText/AgentRichTextEditor.tsx packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUINodeController.ts packages/agent/gui/agent-gui/agentGuiNode/model/agentComposerDraft.spec.ts packages/agent/gui/agent-gui/agentGuiNode/model/agentComposerDraft.ts packages/agent/gui/agent-gui/agentGuiNode/model/agentGuiNodeTypes.ts packages/agent/gui/app/renderer/i18n/locales/en.ts packages/agent/gui/app/renderer/i18n/locales/zh-CN.ts`
- `PATH="/Users/bytedance/Documents/Codex/2026-07-06/bhw/work/corepack-bin:$PATH" pnpm check:i18n`
- `corepack pnpm --filter @tutti-os/agent-gui typecheck`
- `corepack pnpm --filter @tutti-os/agent-gui exec vitest run --environment jsdom --maxWorkers=3 agent-gui/agentGuiNode/model/agentComposerDraft.spec.ts agent-gui/agentGuiNode/agentRichText/AgentRichTextEditor.spec.tsx agent-gui/agentGuiNode/AgentComposer.spec.tsx`
- `git diff --check`
- `PATH="/Users/bytedance/Documents/Codex/2026-07-06/bhw/work/corepack-bin:$PATH" pnpm check:full` was attempted; local preflight is blocked because this machine does not have `go`/`gofmt` on PATH. The i18n issue surfaced by that run was fixed and `pnpm check:i18n` now passes.

## Checklist

- [x] I kept the change focused on one concern.
- [x] Documentation update is not applicable; this composer UX change has no docs surface.
- [x] README/CONTRIBUTING language variants are not applicable; none were changed.
- [x] I ran the lowest meaningful local checks for the changed surface.
- [x] My commits are signed off with DCO when required: `git commit -s`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for pasting “large” text blocks as compact draft attachments in the composer, shown as removable chips.
  * Submission now includes the pasted large-text attachment content (while keeping the draft preview concise).
* **Bug Fixes**
  * Large-text drafts are now preserved correctly across editing and when starting a new conversation.
  * Improved paste handling: short text still inserts inline, while large text is routed to the attachment flow.
  * Draft comparison and clearing behavior now correctly accounts for large-text attachments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->