### PR TITLE
test(agent-gui): trim tool renderer style assertions

### DIFF
--- a/packages/agent/gui/shared/agentConversation/components/AgentToolCallCard.spec.tsx
+++ b/packages/agent/gui/shared/agentConversation/components/AgentToolCallCard.spec.tsx
@@ -232,12 +232,6 @@ describe("Agent specialized tool cards", () => {
 
     expect(screen.getByText("+1")).toBeTruthy();
     expect(screen.getByText("-1")).toBeTruthy();
-    expect(screen.getByText("+1").className).toContain(
-      "workspace-agents-status-panel__detail-tool-diff-added"
-    );
-    expect(screen.getByText("-1").className).toContain(
-      "workspace-agents-status-panel__detail-tool-diff-removed"
-    );
   });
 
   it("does not show edit diff stats on approval tool headers", async () => {

--- a/packages/agent/gui/shared/agentConversation/components/AgentTranscriptItemView.spec.tsx
+++ b/packages/agent/gui/shared/agentConversation/components/AgentTranscriptItemView.spec.tsx
@@ -191,12 +191,7 @@ describe("AgentTranscriptItemView render stability", () => {
     if (!(bubble instanceof HTMLElement)) {
       throw new Error("Expected user message bubble to render.");
     }
-    expect(group).toHaveClass("agent-gui-conversation__message-group");
     expect(group).toHaveAttribute("data-agent-message-speaker", "user");
-    expect(bubble).toHaveClass(
-      "workspace-agents-status-panel__detail-user-message",
-      "agent-gui-conversation__user-message-bubble"
-    );
     expect(group).toHaveTextContent("User asks for a fix");
     expect(
       group.querySelector(".agent-gui-conversation__message-copy-button")
@@ -315,25 +310,6 @@ describe("AgentTranscriptItemView render stability", () => {
     await waitFor(() => {
       const image = screen.getByRole("img", { name: "screen.png" });
       expect(image).toHaveAttribute("src", "data:image/png;base64,aW1hZ2U=");
-      expect(image).toHaveClass("cursor-zoom-in", "max-h-20", "object-contain");
-      const imageBlock = image.closest("div");
-      expect(imageBlock).toBeInstanceOf(HTMLElement);
-      expect(imageBlock).toHaveClass(
-        "agent-gui-conversation__user-image-thumbnail"
-      );
-      const imageGrid = imageBlock?.parentElement;
-      expect(imageGrid).toHaveClass("agent-gui-conversation__user-image-grid");
-      expect(imageGrid).toHaveStyle({
-        gridTemplateColumns: "repeat(1, 160px)"
-      });
-      const imageGridClasses = imageGrid?.className.split(/\s+/) ?? [];
-      expect(
-        imageGridClasses.some((className) => className.startsWith("bg-"))
-      ).toBe(false);
-      expect(
-        imageGridClasses.some((className) => className.startsWith("shadow"))
-      ).toBe(false);
-      expect(imageGridClasses).not.toContain("p-2");
       expect(
         screen.getByRole("button", { name: "common.expandImage" })
       ).toBeTruthy();
@@ -448,7 +424,7 @@ describe("AgentTranscriptItemView render stability", () => {
     expect(store.focus).toBe("auth");
   });
 
-  it("renders transport retry notices as quiet text", () => {
+  it("renders transport retry notice details without the generic title", () => {
     const { getByText, queryByText } = render(
       <AgentMessageBlock
         workspaceRoot="/workspace/demo"
@@ -475,8 +451,6 @@ describe("AgentTranscriptItemView render stability", () => {
     expect(getByText("Reconnecting... 1/5")).toBeTruthy();
     const notice = getByText("Reconnecting... 1/5");
     expect(notice.tagName).toBe("DIV");
-    expect(notice.className).toContain("text-[var(--text-primary)]");
-    expect(notice.className).not.toContain("rounded-[8px]");
     expect(queryByText("agentHost.agentGui.visibleErrorDetails")).toBeNull();
     expect(
       queryByText("Codex connection interrupted. Reconnecting...")
@@ -486,7 +460,7 @@ describe("AgentTranscriptItemView render stability", () => {
     ).toBeNull();
   });
 
-  it("renders transport fallback notices with danger chrome", () => {
+  it("renders transport fallback notices with the localized label", () => {
     const { getByRole, getByText } = render(
       <AgentMessageBlock
         workspaceRoot="/workspace/demo"
@@ -510,16 +484,13 @@ describe("AgentTranscriptItemView render stability", () => {
       />
     );
 
-    const notice = getByRole("status");
-    expect(notice.className).toContain("border-[var(--on-danger-hover)]");
-    expect(notice.className).toContain("bg-[var(--on-danger)]");
-    expect(notice.className).not.toContain("var(--state-warning)_6%");
+    expect(getByRole("status")).toBeTruthy();
     expect(
       getByText("agentHost.agentGui.systemNoticeTransportFallback")
     ).toBeTruthy();
   });
 
-  it("renders fallback warning notices with danger chrome", () => {
+  it("renders fallback warning notices with their title", () => {
     const { getByRole, getByText } = render(
       <AgentMessageBlock
         workspaceRoot="/workspace/demo"
@@ -543,10 +514,7 @@ describe("AgentTranscriptItemView render stability", () => {
       />
     );
 
-    const notice = getByRole("status");
-    expect(notice.className).toContain("border-[var(--on-danger-hover)]");
-    expect(notice.className).toContain("bg-[var(--on-danger)]");
-    expect(notice.className).not.toContain("var(--state-warning)_6%");
+    expect(getByRole("status")).toBeTruthy();
     expect(
       getByText("Falling back from WebSockets to HTTPS transport.")
     ).toBeTruthy();
@@ -577,14 +545,8 @@ describe("AgentTranscriptItemView render stability", () => {
 
     const notice = getByRole("status");
     expect(notice.tagName).toBe("DIV");
-    expect(notice.className).toContain("items-center");
-    expect(notice.className).toContain("text-[var(--text-secondary)]");
-    expect(notice.className).not.toContain("rounded-[8px]");
     const dividers = notice.querySelectorAll('span[aria-hidden="true"]');
     expect(dividers).toHaveLength(2);
-    for (const divider of dividers) {
-      expect(divider.className).toContain("bg-[var(--line-1)]");
-    }
     expect(
       getByText("agentHost.agentGui.contextCompactionCompleted")
     ).toBeTruthy();
@@ -618,8 +580,6 @@ describe("AgentTranscriptItemView render stability", () => {
       );
 
       const notice = getByRole("status");
-      expect(notice.className).toContain("items-center");
-      expect(notice.className).not.toContain("rounded-[8px]");
       const dividers = notice.querySelectorAll('span[aria-hidden="true"]');
       expect(dividers).toHaveLength(2);
       expect(
@@ -659,7 +619,6 @@ describe("AgentTranscriptItemView render stability", () => {
     );
 
     const notice = getByRole("status");
-    expect(notice.className).not.toContain("rounded-[8px]");
     expect(notice.querySelectorAll('span[aria-hidden="true"]')).toHaveLength(2);
     expect(
       getByText("agentHost.agentGui.contextCompactionInterrupted")

--- a/packages/agent/gui/shared/agentConversation/components/tool-renderers/AgentExpandedToolContent.spec.tsx
+++ b/packages/agent/gui/shared/agentConversation/components/tool-renderers/AgentExpandedToolContent.spec.tsx
@@ -5,7 +5,6 @@ import { type WorkspaceAgentSessionDetailToolCall } from "../../../workspaceAgen
 import { projectAgentToolCall } from "../../projection/agentToolProjection";
 import { AgentExpandedToolContent } from "./AgentExpandedToolContent";
 import { AgentSubAgentCard } from "../AgentSubAgentCards";
-import { ToolMarkdownBlock } from "./agentToolContentShared";
 
 describe("AgentExpandedToolContent", () => {
   afterEach(async () => {
@@ -512,17 +511,6 @@ describe("AgentExpandedToolContent", () => {
     expect(screen.getByText("a.ts")).toBeTruthy();
     expect(screen.getByText("const ready = false")).toBeTruthy();
     expect(screen.getByText("const ready = true")).toBeTruthy();
-    expect(
-      screen.getByText("const ready = true").closest(".grid")?.className
-    ).toContain("border-l-[var(--state-success)]");
-    expect(
-      screen.getByText("const ready = true").closest(".grid")?.className
-    ).toContain(
-      "bg-[color:color-mix(in_srgb,var(--state-success)_10%,transparent)]"
-    );
-    expect(
-      screen.getByText("const ready = false").closest(".grid")?.className
-    ).toContain("border-l-[var(--state-danger)]");
   });
 
   it("renders edit old/new string pairs through the patch viewer path", async () => {
@@ -1210,10 +1198,6 @@ describe("AgentExpandedToolContent", () => {
     });
     expect(rawPayloadToggle).toHaveAttribute("aria-expanded", "false");
     expect(rawPayloadToggle.firstElementChild).toHaveTextContent("Raw payload");
-    expect(rawPayloadToggle.querySelector("svg")).toHaveClass("opacity-0");
-    expect(rawPayloadToggle.querySelector("svg")).toHaveClass(
-      "group-hover/raw-payload:opacity-100"
-    );
     expect(screen.queryByText(/"noisy": true/)).toBeNull();
     fireEvent.click(rawPayloadToggle);
     await flushCollapsibleRevealFrames();
@@ -1223,25 +1207,6 @@ describe("AgentExpandedToolContent", () => {
     );
     expect(screen.queryByText("Input")).toBeNull();
     expect(screen.queryByText("Output")).toBeNull();
-  });
-
-  it("renders collapsible tool markdown lists with secondary text color", () => {
-    const { container } = render(
-      <ToolMarkdownBlock
-        content={"- **output:** ./hello-world/README.md\n\n1. exit_code: 0"}
-        collapsible
-      />
-    );
-
-    const markdown = container.querySelector(
-      '[data-workspace-agent-markdown="true"]'
-    );
-    expect(markdown?.className).toContain(
-      "[&_ul]:text-[var(--text-secondary)]"
-    );
-    expect(markdown?.className).toContain(
-      "[&_ol]:text-[var(--text-secondary)]"
-    );
   });
 
   it("routes nested task steps through the mcp renderer when metadata identifies an mcp tool", async () => {

--- a/packages/agent/gui/shared/agentConversation/components/tool-renderers/code/AgentCodeBlock.spec.tsx
+++ b/packages/agent/gui/shared/agentConversation/components/tool-renderers/code/AgentCodeBlock.spec.tsx
@@ -3,27 +3,7 @@ import { describe, expect, it } from "vitest";
 import { AgentCodeBlock } from "./AgentCodeBlock";
 
 describe("AgentCodeBlock", () => {
-  it("renders flat added content without a per-line fill", () => {
-    render(
-      <AgentCodeBlock content="const ready = true" flat showHeader={false} />
-    );
-
-    const addedLine = screen.getByText("const ready = true").closest(".grid");
-
-    expect(addedLine?.className).not.toContain(
-      "bg-[var(--transparency-block)]"
-    );
-    expect(addedLine?.className).toContain("border-l-[var(--state-success)]");
-    expect(addedLine?.className).not.toContain("emerald");
-    expect(addedLine?.parentElement?.className).not.toContain(
-      "bg-[var(--background-fronted)]"
-    );
-    expect(addedLine?.parentElement?.className).toContain(
-      "bg-[var(--background-panel)]"
-    );
-  });
-
-  it("renders the long-content disclosure as a full-width code-block row", () => {
+  it("renders the long-content disclosure inside the code block", () => {
     const content = Array.from(
       { length: 121 },
       (_, index) => `line ${index + 1}`
@@ -37,8 +17,6 @@ describe("AgentCodeBlock", () => {
       name: /show full content/i
     });
 
-    expect(disclosure.className).toContain("w-full");
-    expect(disclosure.className).not.toContain("border-t");
     expect(
       disclosure.closest(".workspace-agents-status-panel__detail-tool-code")
     ).toBeTruthy();

--- a/packages/agent/gui/shared/agentConversation/components/tool-renderers/terminal/AgentTerminalBlock.spec.tsx
+++ b/packages/agent/gui/shared/agentConversation/components/tool-renderers/terminal/AgentTerminalBlock.spec.tsx
@@ -3,7 +3,7 @@ import { describe, expect, it } from "vitest";
 import { AgentTerminalBlock } from "./AgentTerminalBlock";
 
 describe("AgentTerminalBlock", () => {
-  it("renders a command-only call with the same header fill and no divider", () => {
+  it("renders a command-only call without an output body", () => {
     const { container } = render(
       <AgentTerminalBlock
         command="find /home -path '*frontend-design*SKILL.md'"
@@ -21,13 +21,7 @@ describe("AgentTerminalBlock", () => {
     const row = command?.parentElement;
 
     expect(command?.textContent).toContain("frontend-design");
-    expect(
-      container.querySelector(
-        ".workspace-agents-status-panel__detail-tool-terminal"
-      )?.className
-    ).toContain("bg-[var(--background-panel)]");
-    expect(row?.className).toContain("bg-[var(--transparency-block)]");
-    expect(row?.className).not.toContain("border-b");
+    expect(row).toBeTruthy();
     expect(container.querySelector("pre")).toBeNull();
   });
 
@@ -58,11 +52,6 @@ describe("AgentTerminalBlock", () => {
     );
 
     expect(output?.textContent).toContain("line 200");
-    expect(
-      scrollArea?.querySelector(
-        ".workspace-agents-status-panel__detail-scroll-region"
-      )?.className
-    ).toContain("max-h-[160px]");
     expect(disclosure.parentElement).toBe(
       scrollArea?.querySelector(
         ".workspace-agents-status-panel__detail-scroll-region"
@@ -72,40 +61,5 @@ describe("AgentTerminalBlock", () => {
     expect(
       disclosure.closest(".workspace-agents-status-panel__detail-tool-terminal")
     ).toBe(terminalCard);
-  });
-
-  it("wraps long command and output text inside the terminal card", () => {
-    const longCommand =
-      "sed -n '1,220p' /home/tsh-runtime/.codex/skills/.system/imagegen/SKILL.md";
-    const longOutput =
-      "thread 'main' panicked at /home/runner/.cargo/git/checkouts/codex-9eee5d47/bubblewrap is unavailable";
-
-    const { container } = render(
-      <AgentTerminalBlock
-        command={longCommand}
-        stdout=""
-        stderr={longOutput}
-        exitCode={1}
-        durationMs={1000}
-        status="failed"
-      />
-    );
-
-    const command = container.querySelector(
-      '[data-agent-terminal-command="true"]'
-    );
-    const output = container.querySelector("pre");
-
-    expect(command?.className).toContain("whitespace-pre-wrap");
-    expect(command?.className).toContain("[overflow-wrap:anywhere]");
-    expect(command?.className).not.toContain("truncate");
-    expect(output?.className).toContain("max-w-full");
-    expect(output?.className).toContain("whitespace-pre-wrap");
-    expect(output?.className).toContain("[overflow-wrap:anywhere]");
-    expect(output?.className).not.toContain("min-w-max");
-    expect(
-      output?.closest(".workspace-agents-status-panel__detail-scroll-region")
-        ?.className
-    ).toContain("text-[var(--state-danger)]");
   });
 });


### PR DESCRIPTION
## Summary
- trim Agent transcript item tests that asserted visual class names instead of rendered behavior
- remove pure visual assertions from terminal/code/tool renderer specs while keeping content and disclosure behavior checks
- keep structural and interaction checks that still protect user-facing behavior

## Validation
- pnpm check:changed --tail-lines 120 --max-parallel 1
- pnpm check:full (pre-push)

## Documentation
- no documentation impact; test-only cleanup

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated UI test coverage to better match current rendering and content checks.
  * Reduced reliance on specific styling class names in favor of verifying visible text, structure, and controls.
  * Refined coverage for tool calls, message transcripts, code blocks, terminal output, and raw payload views.
  * No user-facing functionality changes are included in this update.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->