### PR TITLE
[codex] update license copyright attribution

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,3 @@
-
                                  Apache License
                            Version 2.0, January 2004
                         http://www.apache.org/licenses/
@@ -187,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright [yyyy] [name of copyright owner]
+   Copyright 2025-2026 The Tutti Authors
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/NOTICE
+++ b/NOTICE
@@ -1,5 +1,8 @@
 Tutti
-Copyright 2026 Nexight
+Copyright 2025-2026 The Tutti Authors
+
+"The Tutti Authors" refers to the contributors listed in the repository's
+revision history.
 
 This product includes software developed at Nexight (https://tutti.sh).
 


### PR DESCRIPTION
## Summary

- Replace the Apache-2.0 appendix placeholder with `Copyright 2025-2026 The Tutti Authors`.
- Update the project copyright line in `NOTICE` from `Nexight` to `The Tutti Authors`.
- Define `The Tutti Authors` as contributors listed in the repository revision history.
- Preserve the existing Nexight and cc-switch attribution notices.

## Why

The Apache-2.0 license file still had the example placeholder copyright line, and the project attribution should reflect the contributor-based authorship model.

## Impact

This is a documentation/licensing metadata change only. It does not change runtime behavior, package contents beyond the top-level notice files, or third-party attribution obligations.

## Validation

Not run; change is limited to top-level license and notice text.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated project copyright notices in the license and notice files.
  * Replaced placeholder and previous attribution text with the current project authorship wording.
  * No licensing terms or user-facing functionality changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->