### PR TITLE
fix(managed-credentials): redact provider API keys

### DIFF
--- a/apps/desktop/src/renderer/src/features/workspace-workbench/services/internal/workspaceSettingsService.test.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/services/internal/workspaceSettingsService.test.ts
@@ -179,12 +179,11 @@ test("WorkspaceSettingsService tolerates provider configs with null models", asy
   assert.deepEqual(notifications.items, []);
 });
 
-test("WorkspaceSettingsService echoes saved managed provider API keys", async () => {
+test("WorkspaceSettingsService keeps saved managed provider API keys redacted", async () => {
   const service = new WorkspaceSettingsService({
     client: createWorkspaceSettingsClient({
       listManagedModelProviders: async () => [
         {
-          apiKey: "agnes-secret",
           baseUrl: "https://apihub.agnes-ai.com/v1",
           enabled: true,
           hasApiKey: true,
@@ -201,7 +200,8 @@ test("WorkspaceSettingsService echoes saved managed provider API keys", async ()
   const agnesProvider = service.store.managedModels.providers.find(
     (provider) => provider.provider === "agnes"
   );
-  assert.equal(agnesProvider?.apiKey, "agnes-secret");
+  assert.equal(agnesProvider?.apiKey, "");
+  assert.equal(agnesProvider?.hasApiKey, true);
 });
 
 test("WorkspaceSettingsService fills detected managed provider models", async () => {
@@ -209,7 +209,6 @@ test("WorkspaceSettingsService fills detected managed provider models", async ()
     client: createWorkspaceSettingsClient({
       listManagedModelProviders: async () => [
         {
-          apiKey: "agnes-secret",
           baseUrl: "https://apihub.agnes-ai.com/v1",
           enabled: true,
           hasApiKey: true,

--- a/services/tuttid/biz/managedcredentials/model.go
+++ b/services/tuttid/biz/managedcredentials/model.go
@@ -51,7 +51,6 @@ func PublicProvider(config ProviderConfig) PublicProviderConfig {
 		WorkspaceID: config.WorkspaceID,
 		Provider:    config.Provider,
 		Enabled:     config.Enabled,
-		APIKey:      config.APIKey,
 		HasAPIKey:   config.APIKey != "",
 		BaseURL:     config.BaseURL,
 		Models:      cloneModels(config.Models),

--- a/services/tuttid/service/managedcredentials/service_test.go
+++ b/services/tuttid/service/managedcredentials/service_test.go
@@ -235,7 +235,7 @@ func TestServicePutProviderPreservesOmittedAPIKeyAndClearsBlankAPIKey(t *testing
 	}
 }
 
-func TestServiceListProvidersReturnsEmptyModelArrayAndSavedAPIKey(t *testing.T) {
+func TestServiceListProvidersReturnsEmptyModelArrayAndRedactsSavedAPIKey(t *testing.T) {
 	ctx := context.Background()
 	store := newManagedCredentialsMemoryStore()
 	service := &Service{Store: store}
@@ -260,8 +260,11 @@ func TestServiceListProvidersReturnsEmptyModelArrayAndSavedAPIKey(t *testing.T) 
 	if len(providers[0].Models) != 0 {
 		t.Fatalf("provider Models length = %d, want 0", len(providers[0].Models))
 	}
-	if providers[0].APIKey != "agnes-secret" {
-		t.Fatalf("provider APIKey = %q, want saved key", providers[0].APIKey)
+	if providers[0].APIKey != "" {
+		t.Fatalf("provider APIKey = %q, want redacted key", providers[0].APIKey)
+	}
+	if !providers[0].HasAPIKey {
+		t.Fatal("provider HasAPIKey = false, want true")
 	}
 }
 


### PR DESCRIPTION
## Summary

- stop public managed model provider responses from including saved API keys
- keep `hasApiKey` as the UI/list signal for saved credentials
- update daemon and desktop service tests to lock in redacted list behavior

## Testing

- `go test ./service/managedcredentials`
- `node --import ./test/register-asset-stub.mjs --test --experimental-strip-types ./src/renderer/src/features/workspace-workbench/services/internal/workspaceSettingsService.test.ts`
- `pnpm check:changed`
- `pnpm check:full`

## Documentation

- No documentation impact found. The managed credentials endpoints are not represented in the generated OpenAPI client, and no durable docs describe API key echo behavior.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Provider settings now keep saved API keys hidden when displayed back to users.
  * The app still indicates when a provider has an API key configured, but the secret value is no longer exposed in returned provider details.
  * Updated related checks to match the redacted behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->