### PR TITLE
harden(workspace-apps): verify app identity on runtime healthcheck

### DIFF
--- a/services/tuttid/service/workspace/app_factory_reference/SKILL.md
+++ b/services/tuttid/service/workspace/app_factory_reference/SKILL.md
@@ -114,7 +114,7 @@ The runtime must:
 
 - Bind `$TUTTI_APP_HOST:$TUTTI_APP_PORT`, defaulting the host to `127.0.0.1` only when the host variable is absent.
 - Fail startup with a clear error when `$TUTTI_APP_PORT` is absent. Do not guess, reserve, or hard-code a fallback port; the daemon owns port allocation.
-- Serve the manifest healthcheck path with a 2xx response.
+- Serve the manifest healthcheck path with a 2xx response, and echo `$TUTTI_APP_INSTANCE_TOKEN` back in the `X-Tutti-App-Instance` response header so the daemon can confirm the responding server is this app and not another local process that grabbed the port.
 - Treat `$TUTTI_APP_PACKAGE_DIR` as read-only after startup.
 - Write durable app data only under `$TUTTI_APP_DATA_DIR`.
 - Write scratch/runtime files only under `$TUTTI_APP_RUNTIME_DIR`.

--- a/services/tuttid/service/workspace/app_factory_reference/references/demos/simple-node-static-app/server.js
+++ b/services/tuttid/service/workspace/app_factory_reference/references/demos/simple-node-static-app/server.js
@@ -6,6 +6,7 @@ const host = process.env.TUTTI_APP_HOST || "127.0.0.1";
 const port = Number.parseInt(process.env.TUTTI_APP_PORT || "", 10);
 const packageDir = process.env.TUTTI_APP_PACKAGE_DIR;
 const dataDir = process.env.TUTTI_APP_DATA_DIR;
+const instanceToken = process.env.TUTTI_APP_INSTANCE_TOKEN || "";
 
 if (!Number.isInteger(port)) {
   throw new Error("TUTTI_APP_PORT is required");
@@ -45,6 +46,9 @@ function readState() {
 const server = http.createServer((request, response) => {
   const url = new URL(request.url || "/", `http://${host}:${port}`);
   if (request.method === "GET" && url.pathname === "/healthz") {
+    if (instanceToken) {
+      response.setHeader("X-Tutti-App-Instance", instanceToken);
+    }
     writeJson(response, { ok: true });
     return;
   }

--- a/services/tuttid/service/workspace/app_factory_reference/references/validation-checklist.md
+++ b/services/tuttid/service/workspace/app_factory_reference/references/validation-checklist.md
@@ -14,7 +14,7 @@ Before finishing:
 - `bootstrap.sh` launches the prepared app and does not install dependencies.
 - `bootstrap.sh` and `prepare.sh`, when present, use `TUTTI_APP_PYTHON`, `TUTTI_APP_NODE`, or `TUTTI_APP_NPM` instead of bare system `python`, `python3`, `node`, or `npm` commands.
 - The server binds `127.0.0.1:$TUTTI_APP_PORT` or `$TUTTI_APP_HOST:$TUTTI_APP_PORT`.
-- The healthcheck endpoint returns a 2xx response.
+- The healthcheck endpoint returns a 2xx response and echoes `$TUTTI_APP_INSTANCE_TOKEN` in the `X-Tutti-App-Instance` response header.
 - If `tutti.app.json` declares `references.listEndpoint`, that endpoint accepts JSON `POST` requests with optional `parentGroupId`, `filterText`, `cursor`, `timeRange`, and returns direct group/reference items using `location`, not host absolute `path`.
 - If `tutti.app.json` declares `references.searchEndpoint`, that endpoint accepts JSON `POST` requests with a required `query` plus optional `cursor`, `limit`, `kinds`, `timeRange`, and returns a flat, relevance-ordered list of reference items (no group items) using `location`, not host absolute `path`.
 - The `searchEndpoint` matches `query` against each file's **own name** only (the `displayName`), never against `location.path`, the containing folder/project, or `parentGroupLabel` — searching `2` must not return a file named `cover.svg` just because it lives in a project named `2222`.

--- a/services/tuttid/service/workspace/apps_runner.go
+++ b/services/tuttid/service/workspace/apps_runner.go
@@ -2,6 +2,9 @@ package workspace
 
 import (
 	"context"
+	"crypto/rand"
+	"crypto/subtle"
+	"encoding/base64"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -26,11 +29,28 @@ import (
 
 const defaultAppHealthcheckTimeout = 30 * time.Second
 
+const (
+	// appInstanceTokenEnv carries a per-start random token to the app process.
+	// The app is expected to echo it back in appInstanceHeader on its
+	// healthcheck response so the daemon can confirm the server answering on
+	// the loopback port is the process it launched, rather than another local
+	// process that grabbed the port during the allocate/bind window.
+	appInstanceTokenEnv = "TUTTI_APP_INSTANCE_TOKEN"
+	appInstanceHeader   = "X-Tutti-App-Instance"
+)
+
 type AppRunner struct {
 	HealthcheckTimeout time.Duration
 	HTTPClient         *http.Client
 	OnStateChanged     AppRunnerStateChanged
 	RuntimeResolver    AppRuntimeResolver
+
+	// RequireInstanceIdentity rejects a healthcheck responder that does not
+	// echo the per-start TUTTI_APP_INSTANCE_TOKEN. It defaults to false so
+	// existing apps that only return 2xx keep working (their identity is
+	// logged as unverified). Enable it once apps echo the token to fully
+	// close the loopback-port hijack window.
+	RequireInstanceIdentity bool
 
 	mu        sync.Mutex
 	processes map[string]*appProcess
@@ -206,6 +226,13 @@ func (r *AppRunner) startProcess(ctx context.Context, key string, input AppStart
 	tuttiCLIShim := tuttiCLIShimPath()
 	tuttiAPIBaseURL := tuttiAPIBaseURLFromEnv()
 	appToolchainRoot := tuttiAppToolchainRoot()
+	instanceToken, err := newAppInstanceToken()
+	if err != nil {
+		_ = logFile.Close()
+		logAppRuntimeControl("workspace_app_runtime_start_failed", input, port, "startup", err)
+		r.setFailed(key, "startup", err)
+		return
+	}
 	envOverrides := []string{
 		"TUTTI_APP_ID=" + input.AppID,
 		"TUTTI_WORKSPACE_ID=" + input.WorkspaceID,
@@ -222,6 +249,7 @@ func (r *AppRunner) startProcess(ctx context.Context, key string, input AppStart
 		"TUTTI_API_BASE_URL=" + tuttiAPIBaseURL,
 		"TUTTI_APP_INSTALLATION_ID=" + input.WorkspaceID + ":" + input.AppID,
 		"TUTTI_APP_SERVER_TOKEN=" + appServerToken(input.WorkspaceID, input.AppID),
+		appInstanceTokenEnv + "=" + instanceToken,
 		"TUTTI_CLI=" + tuttiCLIShim,
 	}
 	envOverrides = append(envOverrides, appRuntime.EnvOverrides...)
@@ -261,7 +289,7 @@ func (r *AppRunner) startProcess(ctx context.Context, key string, input AppStart
 
 	go r.waitForProcess(key, process)
 
-	healthErr := r.waitForHealth(ctx, launchURL, input.HealthcheckPath)
+	identityVerified, healthErr := r.waitForHealth(ctx, launchURL, input.HealthcheckPath, instanceToken)
 	if healthErr != nil {
 		if errors.Is(healthErr, context.Canceled) {
 			_, _ = r.stopProcess(context.Background(), key, process)
@@ -271,6 +299,15 @@ func (r *AppRunner) startProcess(ctx context.Context, key string, input AppStart
 		logAppRuntimeControl("workspace_app_runtime_healthcheck_failed", input, port, "healthcheck", healthErr)
 		r.setFailed(key, "healthcheck", healthErr)
 		return
+	}
+
+	if !identityVerified {
+		slog.Warn("workspace_app_runtime_identity_unverified",
+			"workspaceId", input.WorkspaceID,
+			"appId", input.AppID,
+			"port", port,
+			"detail", "healthcheck responder did not echo TUTTI_APP_INSTANCE_TOKEN; cannot confirm the server on this port is this app",
+		)
 	}
 
 	logAppRuntimeControl("workspace_app_runtime_running", input, port, "", nil)
@@ -635,7 +672,14 @@ func (r *AppRunner) finishStart(key string, ctx context.Context, start *appStart
 	}
 }
 
-func (r *AppRunner) waitForHealth(ctx context.Context, launchURL string, healthcheckPath string) error {
+// waitForHealth polls the app healthcheck until it succeeds, times out, or the
+// context is cancelled. The bool return reports whether the responder proved it
+// is the process we launched by echoing expectedInstanceToken in
+// appInstanceHeader. A responder that returns 2xx with a wrong token is never
+// accepted (a port squatter cannot know the token), and under
+// RequireInstanceIdentity a responder that omits the token is not accepted
+// either.
+func (r *AppRunner) waitForHealth(ctx context.Context, launchURL string, healthcheckPath string, expectedInstanceToken string) (bool, error) {
 	timeout := r.HealthcheckTimeout
 	if timeout <= 0 {
 		timeout = defaultAppHealthcheckTimeout
@@ -645,27 +689,41 @@ func (r *AppRunner) waitForHealth(ctx context.Context, launchURL string, healthc
 
 	for {
 		if time.Now().After(deadline) {
-			return errors.New("app healthcheck timed out")
+			return false, errors.New("app healthcheck timed out")
 		}
 		if err := ctx.Err(); err != nil {
-			return err
+			return false, err
 		}
 
 		request, err := http.NewRequestWithContext(ctx, http.MethodGet, launchURL+healthcheckPath, nil)
 		if err != nil {
-			return fmt.Errorf("create app healthcheck request: %w", err)
+			return false, fmt.Errorf("create app healthcheck request: %w", err)
 		}
 		response, err := r.httpClient().Do(request)
 		if err == nil {
+			instanceEcho := response.Header.Get(appInstanceHeader)
 			_ = response.Body.Close()
 			if response.StatusCode >= 200 && response.StatusCode < 300 {
-				return nil
+				switch {
+				case expectedInstanceToken != "" && subtle.ConstantTimeCompare([]byte(instanceEcho), []byte(expectedInstanceToken)) == 1:
+					// The responder holds the token we handed the app: confirmed identity.
+					return true, nil
+				case instanceEcho == "" && !r.RequireInstanceIdentity:
+					// Legacy app that does not echo the token. Accept for backward
+					// compatibility, but report the identity as unverified.
+					return false, nil
+				default:
+					// A mismatched token (definitely not our app), or a missing
+					// token under strict mode. Keep polling: a squatter cannot
+					// start echoing a secret it never received, so this converges
+					// to a healthcheck timeout.
+				}
 			}
 		}
 
 		select {
 		case <-ctx.Done():
-			return ctx.Err()
+			return false, ctx.Err()
 		case <-time.After(100 * time.Millisecond):
 		}
 	}
@@ -757,6 +815,14 @@ func uniqueRuntimeKeys(keys []string) []string {
 		result = append(result, key)
 	}
 	return result
+}
+
+func newAppInstanceToken() (string, error) {
+	buf := make([]byte, 32)
+	if _, err := rand.Read(buf); err != nil {
+		return "", fmt.Errorf("generate app instance token: %w", err)
+	}
+	return base64.RawURLEncoding.EncodeToString(buf), nil
 }
 
 func allocateLoopbackPort() (int, error) {

--- a/services/tuttid/service/workspace/apps_runner_test.go
+++ b/services/tuttid/service/workspace/apps_runner_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"net/http"
+	"net/http/httptest"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -872,6 +873,71 @@ exit 0
 		t.Fatalf("WriteFile(managed npm) error = %v", err)
 	}
 	return runtimeRoot
+}
+
+func TestAppRunnerWaitForHealthVerifiesInstanceToken(t *testing.T) {
+	const token = "instance-token-abc"
+
+	newServer := func(status int, echo string) *httptest.Server {
+		return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			if echo != "" {
+				w.Header().Set(appInstanceHeader, echo)
+			}
+			w.WriteHeader(status)
+		}))
+	}
+
+	t.Run("verified when app echoes the token", func(t *testing.T) {
+		server := newServer(http.StatusOK, token)
+		defer server.Close()
+		runner := &AppRunner{HealthcheckTimeout: 2 * time.Second}
+		verified, err := runner.waitForHealth(context.Background(), server.URL, "/healthz", token)
+		if err != nil {
+			t.Fatalf("waitForHealth error = %v", err)
+		}
+		if !verified {
+			t.Fatal("verified = false, want true when the app echoes the token")
+		}
+	})
+
+	t.Run("accepts legacy app without token but reports unverified", func(t *testing.T) {
+		server := newServer(http.StatusNoContent, "")
+		defer server.Close()
+		runner := &AppRunner{HealthcheckTimeout: 2 * time.Second}
+		verified, err := runner.waitForHealth(context.Background(), server.URL, "/healthz", token)
+		if err != nil {
+			t.Fatalf("waitForHealth error = %v", err)
+		}
+		if verified {
+			t.Fatal("verified = true, want false for a legacy app that omits the token")
+		}
+	})
+
+	t.Run("times out when responder returns a wrong token", func(t *testing.T) {
+		server := newServer(http.StatusOK, "not-the-token")
+		defer server.Close()
+		runner := &AppRunner{HealthcheckTimeout: 300 * time.Millisecond}
+		verified, err := runner.waitForHealth(context.Background(), server.URL, "/healthz", token)
+		if err == nil {
+			t.Fatal("waitForHealth error = nil, want a timeout for a mismatched token")
+		}
+		if verified {
+			t.Fatal("verified = true, want false for a mismatched token")
+		}
+	})
+
+	t.Run("strict mode rejects a legacy app without token", func(t *testing.T) {
+		server := newServer(http.StatusOK, "")
+		defer server.Close()
+		runner := &AppRunner{HealthcheckTimeout: 300 * time.Millisecond, RequireInstanceIdentity: true}
+		verified, err := runner.waitForHealth(context.Background(), server.URL, "/healthz", token)
+		if err == nil {
+			t.Fatal("waitForHealth error = nil, want a timeout in strict mode")
+		}
+		if verified {
+			t.Fatal("verified = true, want false in strict mode")
+		}
+	})
 }
 
 func pythonAppReadyServerScript(healthcheckPath string, writeProbe bool) string {


### PR DESCRIPTION
## Summary

The workspace app runtime marks an app `running` on **any** `2xx` from the loopback port, with no check that the responder is actually the process we launched:

- `allocateLoopbackPort()` does `net.Listen("127.0.0.1:0")` → `defer Close()` → returns the bare port number. Between that close and the child's `bind`, another local process can grab the port (a classic TOCTOU).
- `waitForHealth()` then GETs `http://127.0.0.1:<port><healthcheckPath>` and returns healthy on `StatusCode` 2xx alone.

So a local process that squats the port and returns `2xx` gets marked `running` while the real app fails to bind — at best a false "running", at worst a local process impersonating the app to the daemon/UI.

This change makes the healthcheck prove identity, backward-compatibly:

- Generate a per-start random `TUTTI_APP_INSTANCE_TOKEN` and pass it to the child process env.
- `waitForHealth` requires the responder to echo it in the `X-Tutti-App-Instance` response header (constant-time compare). A responder returning a **wrong** token is never accepted (a squatter never received the secret), so the healthcheck simply keeps polling to its timeout.
- A responder that **omits** the header is accepted for backward compatibility but reported as identity-unverified, and the runner logs `workspace_app_runtime_identity_unverified`.
- New `AppRunner.RequireInstanceIdentity` (default `false`) flips this to strict — omitting the token is rejected — giving a migration path to fully close the window once apps echo the token.

The reference app skill, the Node demo, and the app-contract/validation docs are updated to echo the token.

### Scope / follow-ups

This is the "at minimum, validate an instance token on the healthcheck" mitigation. It does **not** eliminate the TOCTOU window itself, and in the default backward-compatible mode a squatter that returns a bare `2xx` (no header) is still indistinguishable from a legacy app — that case is surfaced via the `identity_unverified` warning. Fully closing the window needs either strict mode across the fleet (once apps adopt the echo) or a larger change (daemon holds the listener and passes the fd, or the app self-selects the port and reports back over a protected handshake). Those are called out here rather than attempted in this PR.

## Testing

- `go test ./service/workspace/ -run WaitForHealth -v` (new: verified / legacy-unverified / wrong-token-times-out / strict-mode-rejects)
- `go vet ./service/workspace/...`
- `go build ./...`

Note: the pre-existing POSIX-only end-to-end runner tests (`bootstrap.sh`) are skipped on my Windows dev box; they exercise the backward-compatible legacy path (a fake app that returns `2xx` with no header stays `running`).

## Documentation

- Updated `app_factory_reference/SKILL.md`, `references/validation-checklist.md`, and the `simple-node-static-app` demo to document/demonstrate echoing `TUTTI_APP_INSTANCE_TOKEN` in the `X-Tutti-App-Instance` header.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Health checks now verify that the running app responds with the expected instance identity header.
  * Added support for stricter startup validation when instance identity is required.

* **Bug Fixes**
  * Improved detection of the correct local process during app startup checks.
  * Legacy apps without the identity header can still pass health checks when strict verification is not enabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->