### PR TITLE
fix(desktop-packaging): target GOOS per variant and smoke-check packaged binaries

### DIFF
--- a/tools/scripts/build-desktop-package.sh
+++ b/tools/scripts/build-desktop-package.sh
@@ -131,6 +131,32 @@ build_macos_universal_go_binary() {
   rm -rf "${staging_dir}"
 }
 
+# Smoke-checks that a packaged Go binary matches the variant's executable
+# format, so a mis-targeted build fails packaging instead of shipping inside
+# an installer. Uses the format magic bytes rather than file(1), which is not
+# guaranteed to exist and whose output wording varies across platforms.
+assert_packaged_binary_format() {
+  local binary_path="$1"
+  local magic
+  magic="$(od -An -N4 -tx1 "${binary_path}" | tr -d ' \n')"
+
+  case "${VARIANT}" in
+    win)
+      # Windows executables are PE files, which start with the "MZ" DOS header.
+      if [[ "${magic}" != 4d5a* ]]; then
+        echo "Packaged binary ${binary_path} is not a Windows PE executable (magic: ${magic:-unreadable})." >&2
+        return 1
+      fi
+      ;;
+    linux)
+      if [[ "${magic}" != "7f454c46" ]]; then
+        echo "Packaged binary ${binary_path} is not a Linux ELF executable (magic: ${magic:-unreadable})." >&2
+        return 1
+      fi
+      ;;
+  esac
+}
+
 prepare_packaged_daemon() {
   rm -rf "${DAEMON_BUNDLE_DIR}" "${CLI_BUNDLE_DIR}"
   mkdir -p "${DAEMON_BUNDLE_DIR}" "${CLI_BUNDLE_DIR}"
@@ -157,14 +183,29 @@ prepare_packaged_daemon() {
     return
   fi
 
+  # Force the Go target OS to match the packaging variant so that running
+  # build:win / build:linux on another host OS cross-compiles instead of
+  # silently bundling a host-OS binary under the target name. GOARCH is
+  # inherited from the environment so it stays aligned with the arch
+  # electron-builder targets by default (the host arch) and remains
+  # overridable.
+  local go_target_os
+  case "${VARIANT}" in
+    win) go_target_os="windows" ;;
+    linux) go_target_os="linux" ;;
+    *) go_target_os="$(go env GOOS)" ;;
+  esac
+
   (
     cd "${ROOT_DIR}/services/tuttid"
-    go build -o "${DAEMON_BUNDLE_DIR}/${daemon_output_name}" .
-  )
+    GOOS="${go_target_os}" go build -o "${DAEMON_BUNDLE_DIR}/${daemon_output_name}" .
+  ) || return
   (
     cd "${ROOT_DIR}/apps/cli"
-    go build -o "${CLI_BUNDLE_DIR}/${cli_output_name}" ./cmd/tutti
-  )
+    GOOS="${go_target_os}" go build -o "${CLI_BUNDLE_DIR}/${cli_output_name}" ./cmd/tutti
+  ) || return
+  assert_packaged_binary_format "${DAEMON_BUNDLE_DIR}/${daemon_output_name}" || return
+  assert_packaged_binary_format "${CLI_BUNDLE_DIR}/${cli_output_name}"
 }
 
 prepare_builtin_apps() {


### PR DESCRIPTION
## Summary

`build:win` / `build:linux` renamed the packaged Go outputs (`tuttid.exe`, `tutti.exe`) but ran a bare `go build`, inheriting the **host** `GOOS`:

- On macOS, `pnpm --filter @tutti-os/desktop build:win` produced a Mach-O binary named `tuttid.exe` and electron-builder packaged it into the NSIS installer with no error — an installer whose daemon/CLI cannot run.
- The macOS variants already do this right (`GOOS=darwin GOARCH=arm64/amd64` + `lipo -verify_arch`); the win/linux path had neither the explicit target nor any artifact verification.
- This is currently a local/manual footgun: `desktop-release.yml` only builds the mac variants, so `build:win`/`build:linux` runs happen on whatever machine a developer uses.

Changes to `prepare_packaged_daemon`:

- Set `GOOS` from the packaging variant (`win` → `windows`, `linux` → `linux`, otherwise the host default). `GOARCH` stays inherited so it keeps matching the arch electron-builder targets by default (the host arch) and remains overridable from the environment.
- Add `assert_packaged_binary_format`: a magic-byte smoke check (PE `MZ` for win, ELF `\x7fELF` for linux) so a mis-targeted binary fails the packaging step instead of shipping inside an installer. Magic bytes via `od` rather than `file(1)`, which is not guaranteed to exist on minimal runners and whose output wording varies across platforms.
- Add `|| return` to the two `go build` subshells, matching the mac branch: `run_timed_phase` disables `errexit` around the phase, so a failed daemon build previously fell through to the CLI build and could be masked.

## Testing

Exercised `prepare_packaged_daemon` + the assertion directly (bash harness that sources the script's functions, pointing the bundle dirs at a temp dir), on a Windows x64 host:

- `VARIANT=win` (native): artifacts are PE (`4d5a…`), assertion passes.
- `VARIANT=linux` (cross-compile from Windows): artifacts are ELF (`7f454c46`), assertion passes — confirms forcing `GOOS` cross-compiles cleanly (no CGO blocker; the same mechanics as macOS → win).
- Negative: under `VARIANT=linux` the assertion rejects a PE binary with a clear error.
- `VARIANT=unpack`: unchanged host-targeted build, no assertion applied.

## Documentation

- No documentation impact found. No durable docs describe the win/linux desktop packaging flow's cross-compilation behavior.
