### PR TITLE
fix(agent-gui): pin provider rail footer slot

### DIFF
--- a/docs/architecture/agent-gui-node.md
+++ b/docs/architecture/agent-gui-node.md
@@ -206,12 +206,15 @@ setup, follow the rail's active provider filter target in multi-provider scope;
 when the rail filter is `All`, they should stay hidden because there is no
 single provider target to inspect.
 AgentGuiNode may also receive a neutral `renderSidebarFooter` slot for host or
-product affordances that belong at the bottom of the conversation rail. This
-slot must stay outside the controller view model and conversation rail valtio
-store: pass it as a direct function prop and give it only existing neutral
-context such as `currentUserId` and `activeConversation`. Product concepts such
-as sharing, ownership, availability, quota, or authorization live entirely
-inside the React node supplied by the host.
+product affordances that belong at the bottom of the far-left provider/sidebar
+rail, not below the conversation-list configuration footer. This slot must stay
+outside the provider tile scroll area so the footer keeps a fixed bottom
+placeholder while overflowing provider tiles scroll above it with a bottom
+fade. It must also stay outside the controller view model and conversation rail
+valtio store: pass it as a direct function prop and give it only existing
+neutral context such as `currentUserId` and `activeConversation`. Product
+concepts such as sharing, ownership, availability, quota, or authorization live
+entirely inside the React node supplied by the host.
 Unified empty-home provider readiness is a host-projected, provider-scoped gate,
 not a durable session rule. Desktop may subscribe to its
 `agentProviderStatusService` and pass a narrow readiness map plus install,

--- a/packages/agent/gui/agent-gui/agentGuiNode/AgentGUINode.styles.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/AgentGUINode.styles.ts
@@ -143,6 +143,7 @@ const styles = {
   providerRailLaunchpadIcon: "agent-gui-node__provider-rail-launchpad-icon",
   emptyHeroLaunchpadIcon: "agent-gui-node__empty-hero-launchpad-icon",
   providerRailLaunchpadItem: "agent-gui-node__provider-rail-launchpad-item",
+  providerRailFooter: "agent-gui-node__provider-rail-footer",
   providerRailPanel: "agent-gui-node__provider-rail-panel",
   providerRailSeparator: "agent-gui-node__provider-rail-separator",
   providerRailTile: "agent-gui-node__provider-rail-tile",

--- a/packages/agent/gui/agent-gui/agentGuiNode/AgentGUINodeView.layout.spec.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/AgentGUINodeView.layout.spec.tsx
@@ -244,7 +244,7 @@ describe("AgentGUINodeView layout persistence", () => {
     );
   });
 
-  it("renders an injected conversation rail footer with neutral context", () => {
+  it("renders an injected provider rail footer with neutral context", () => {
     const activeConversation = createConversationSummary("session-1", {
       title: "Active conversation"
     });
@@ -261,7 +261,7 @@ describe("AgentGUINodeView layout persistence", () => {
       )
     );
 
-    renderAgentGUINodeView({
+    const { container } = renderAgentGUINodeView({
       renderSidebarFooter,
       viewModel: createViewModel({
         currentUserId: "user-1",
@@ -271,9 +271,19 @@ describe("AgentGUINodeView layout persistence", () => {
       })
     });
 
+    const footer = screen.getByTestId("agent-gui-sidebar-footer-slot");
+    const providerTileScrollArea = screen.getByRole("tablist", {
+      name: "Switch provider"
+    });
+    expect(footer).toHaveTextContent("Footer user-1 session-1");
     expect(
-      screen.getByTestId("agent-gui-sidebar-footer-slot")
-    ).toHaveTextContent("Footer user-1 session-1");
+      container.querySelector(".agent-gui-node__provider-rail-panel")
+    ).toContainElement(footer);
+    expect(providerTileScrollArea).not.toContainElement(footer);
+    expect(providerTileScrollArea.nextElementSibling).toBe(footer);
+    expect(
+      container.querySelector(".agent-gui-node__rail")
+    ).not.toContainElement(footer);
     expect(renderSidebarFooter).toHaveBeenCalledWith({
       currentUserId: "user-1",
       activeConversation

--- a/packages/agent/gui/agent-gui/agentGuiNode/AgentGUINodeView.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/AgentGUINodeView.tsx
@@ -1612,6 +1612,17 @@ export function AgentGUINodeView({
               }
               onUpdateConversationFilter={actions.updateConversationFilter}
             />
+            {renderSidebarFooter ? (
+              <div
+                className={`${styles.providerRailFooter} nodrag tsh-desktop-no-drag`}
+                data-testid="agent-gui-sidebar-footer-slot"
+              >
+                {renderSidebarFooter({
+                  currentUserId: viewModel.currentUserId,
+                  activeConversation: viewModel.activeConversation
+                })}
+              </div>
+            ) : null}
           </aside>
         ) : null}
         <aside
@@ -1624,9 +1635,6 @@ export function AgentGUINodeView({
         >
           <AgentGUIConversationRailStorePane
             conversations={viewModel.conversations}
-            currentUserId={viewModel.currentUserId}
-            activeConversation={viewModel.activeConversation}
-            renderSidebarFooter={renderSidebarFooter}
             store={conversationRailStore}
             storeState={conversationRailStoreState}
             userProjects={viewModel.userProjects}
@@ -3954,9 +3962,6 @@ interface AgentGUIConversationRailPaneProps {
   workspaceUserProjectI18n: WorkspaceUserProjectI18nRuntime;
   uiLanguage: UiLanguage;
   previewMode: boolean;
-  currentUserId?: string | null;
-  activeConversation: AgentGUINodeViewModel["activeConversation"];
-  renderSidebarFooter?: AgentGUISidebarFooterRenderer;
   createConversationDisabled: boolean;
   openclawGateway: OpenclawGatewayViewModel | null;
   isCollapsed: boolean;
@@ -4020,12 +4025,7 @@ type OpenclawGatewayViewModel =
 
 type AgentGUIConversationRailDataProps = Pick<
   AgentGUIConversationRailPaneProps,
-  | "activeConversation"
-  | "conversations"
-  | "currentUserId"
-  | "renderSidebarFooter"
-  | "userProjects"
-  | "workspaceId"
+  "conversations" | "userProjects" | "workspaceId"
 >;
 
 type AgentGUIConversationRailStoreSnapshot = Omit<
@@ -4100,10 +4100,7 @@ function agentGUIConversationRailStoreSnapshotsEqual(
 }
 
 interface AgentGUIConversationRailStorePaneProps {
-  activeConversation: AgentGUINodeViewModel["activeConversation"];
   conversations: AgentGUINodeViewModel["conversations"];
-  currentUserId?: string | null;
-  renderSidebarFooter?: AgentGUISidebarFooterRenderer;
   store: AgentGUIConversationRailStore;
   storeState: AgentGUIConversationRailStoreSnapshot;
   userProjects: AgentGUINodeViewModel["userProjects"];
@@ -4112,10 +4109,7 @@ interface AgentGUIConversationRailStorePaneProps {
 
 const AgentGUIConversationRailStorePane = memo(
   function AgentGUIConversationRailStorePane({
-    activeConversation,
     conversations,
-    currentUserId,
-    renderSidebarFooter,
     store,
     storeState: _storeState,
     userProjects,
@@ -4126,10 +4120,7 @@ const AgentGUIConversationRailStorePane = memo(
     return (
       <AgentGUIConversationRailPane
         {...state}
-        activeConversation={activeConversation}
         conversations={conversations}
-        currentUserId={currentUserId}
-        renderSidebarFooter={renderSidebarFooter}
         userProjects={userProjects}
         workspaceId={workspaceId}
       />
@@ -5179,9 +5170,6 @@ const AgentGUIConversationRailPane = memo(
     conversations,
     workspaceId,
     userProjects,
-    currentUserId,
-    activeConversation,
-    renderSidebarFooter,
     activeConversationId,
     pendingDeleteConversationId,
     isLoadingConversations,
@@ -5626,17 +5614,6 @@ const AgentGUIConversationRailPane = memo(
             </Popover>
           </div>
         )}
-        {renderSidebarFooter ? (
-          <div
-            className="shrink-0 px-2 py-1.5"
-            data-testid="agent-gui-sidebar-footer-slot"
-          >
-            {renderSidebarFooter({
-              currentUserId,
-              activeConversation
-            })}
-          </div>
-        ) : null}
         <ConfirmationDialog
           cancelLabel={labels.cancel}
           className={AGENT_GUI_CONFIRMATION_DIALOG_CLASS_NAME}

--- a/packages/agent/gui/app/renderer/agentactivity.css
+++ b/packages/agent/gui/app/renderer/agentactivity.css
@@ -8360,6 +8360,28 @@ html[data-theme="light"] [data-message-center-item-id].agent-gui-edge-glow {
   padding: 0 0 12px;
   overflow-x: hidden;
   overflow-y: auto;
+  mask-image: linear-gradient(
+    to bottom,
+    #000 0,
+    #000 calc(100% - 24px),
+    transparent 100%
+  );
+  -webkit-mask-image: linear-gradient(
+    to bottom,
+    #000 0,
+    #000 calc(100% - 24px),
+    transparent 100%
+  );
+  -webkit-app-region: no-drag;
+}
+
+.agent-gui-node__provider-rail-footer {
+  display: flex;
+  width: 52px;
+  min-width: 0;
+  flex: 0 0 auto;
+  justify-content: center;
+  padding: 0 0 12px;
   -webkit-app-region: no-drag;
 }
 


### PR DESCRIPTION
## Summary
- move the neutral sidebar footer slot into the far-left provider rail instead of the conversation rail footer
- keep provider tiles in their own scroll area and reserve a fixed bottom slot for the footer
- add a bottom fade mask to the provider tile scroll area to indicate overflow

## Validation
- pnpm exec vitest run --environment jsdom --maxWorkers=3 agent-gui/agentGuiNode/AgentGUINodeView.layout.spec.tsx
- ./node_modules/.bin/oxlint packages/agent/gui/agent-gui/agentGuiNode/AgentGUINodeView.tsx packages/agent/gui/agent-gui/agentGuiNode/AgentGUINodeView.layout.spec.tsx packages/agent/gui/agent-gui/agentGuiNode/AgentGUINode.styles.ts
- PATH=/Users/liying/go/bin:/Users/liying/.codex/packages/standalone/releases/0.142.5-aarch64-apple-darwin/codex-path:/Users/liying/.codex/packages/standalone/releases/0.142.5-aarch64-apple-darwin/codex-path:/Users/liying/.tutti/agent/runs/2938dec7-0b12-4f1b-bbff-f7206529e784/codex-home/tmp/arg0/codex-arg0N3bIeh:/Users/liying/.tutti/bin:/Users/liying/.local/bin:/usr/local/bin:/System/Cryptexes/App/usr/bin:/usr/bin:/bin:/usr/sbin:/sbin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/local/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/appleinternal/bin:/opt/pmk/env/global/bin:/Users/liying/bin:/Users/liying/.npm-global/bin:/Users/liying/.n/bin:/Users/liying/n/bin:/Users/liying/.volta/bin:/Users/liying/.asdf/shims:/Users/liying/.mise/shims:/Users/liying/.bun/bin:/Users/liying/Library/pnpm:/opt/homebrew/bin pnpm check:changed --tail-lines 80
- PATH=/Users/liying/go/bin:/Users/liying/.codex/packages/standalone/releases/0.142.5-aarch64-apple-darwin/codex-path:/Users/liying/.codex/packages/standalone/releases/0.142.5-aarch64-apple-darwin/codex-path:/Users/liying/.tutti/agent/runs/2938dec7-0b12-4f1b-bbff-f7206529e784/codex-home/tmp/arg0/codex-arg0N3bIeh:/Users/liying/.tutti/bin:/Users/liying/.local/bin:/usr/local/bin:/System/Cryptexes/App/usr/bin:/usr/bin:/bin:/usr/sbin:/sbin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/local/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/appleinternal/bin:/opt/pmk/env/global/bin:/Users/liying/bin:/Users/liying/.npm-global/bin:/Users/liying/.n/bin:/Users/liying/n/bin:/Users/liying/.volta/bin:/Users/liying/.asdf/shims:/Users/liying/.mise/shims:/Users/liying/.bun/bin:/Users/liying/Library/pnpm:/opt/homebrew/bin pnpm lint:go

Note: the first push attempted the pre-push check:full hook; it failed at lint:go in the hook run, but rerunning lint:go directly passed.