### PR TITLE
fix(claude-sdk): sub-agent lane parity with codex + stop fabricating background agents from tool output

### DIFF
--- a/docs/specs/2026-07-07-claude-subagent-lanes.md
+++ b/docs/specs/2026-07-07-claude-subagent-lanes.md
@@ -1,0 +1,98 @@
+# Claude Code sub-agents render as sub-agent lanes
+
+Date: 2026-07-07 · Extends ADR 0007 (owner-stamped lane attachment) to the
+Claude Code provider.
+
+## Problem
+
+Codex collab sub-agents render as first-class sub-agent lane cards
+(`AgentSubAgentCards`: live status, elapsed timer, latest activity), while
+Claude Code delegations (Task/Agent tool) rendered as a static
+`AgentTaskCallCard` with a metadata-driven step list. Same concept, two
+different visual treatments.
+
+Claude Code's delegation semantics also differ from codex in two ways the
+rendering must absorb:
+
+1. The main agent can keep messaging a running sub-agent (SendMessage /
+   continued child streams). Follow-up activity must land in the original
+   lane, never spawn a duplicate card.
+2. Sub-agents can spawn their own sub-agents (nesting depth > 1). The GUI
+   attaches lanes only to main-transcript cards, so nested delegation
+   activity must flatten into the root lane instead of getting lost.
+
+## Approach
+
+Per ADR 0007: the daemon stamps the edge, the GUI looks it up exactly. The
+Claude adapter now emits the same owner-stamped rows the codex adapter does,
+so the existing GUI lane pipeline (`partitionSubAgentTimelineItems` →
+`buildSubAgentLanesByCallId` → `attachSubAgentLanesToConversationVM` →
+`AgentSubAgentCards`) picks Claude delegations up without new GUI machinery.
+
+Claude Code has no provider child-thread ids; the lane identity is synthetic:
+`ownerThreadId = "claude-subagent:<root tool_use id>"`,
+`ownerCallId = <root tool_use id>` (matches the Task card's `payload.callId`).
+
+## Changes
+
+### Daemon (`packages/agent/daemon/runtime/claude_sdk_adapter.go`)
+
+- `claudeSDKAdapterSession.subagentToolParents`: tool_use id →
+  `parentToolUseId` registry, fed by every sidecar tool event. Lives for the
+  session, so late child streams (follow-up messages to a running agent)
+  keep resolving to the original lane.
+- `subagentRootToolID`: walks the parent chain to the top-level delegate
+  call. Grandchild tool rows stamp the **root** lane (nested delegations
+  flatten). Self-referential parent ids (the sidecar's delegated-task parent
+  updates echo the call's own id) are ignored.
+- `claudeSDKToolEvents`: child tool events (non-empty
+  `metadata.parentToolUseId`) get `OwnerThreadID`/`OwnerCallID`; the generic
+  reporter path (`withOwnerThreadID`) persists them as
+  `payload.ownerThreadId`/`payload.ownerCallId` rows exactly like codex.
+- Lane markers (same payload contract as codex, reporter.go:390-400):
+  - `claudeSDKSubAgentNameEvent` (`messageKind: subAgentName`): from the
+    delegate call's `input.description` (fallback `subagent_type`), emitted
+    on change only.
+  - `claudeSDKSubAgentLifecycleEvent` (`messageKind: subAgentLifecycle`):
+    "started" at delegate `tool_started` (the lane renders immediately, like
+    a codex spawn card), terminal status from the delegate call's own
+    completion (sync) or from `task_completed` lifecycle events (async).
+    An async launch result (`subagentStatus: running`) emits no terminal.
+    Single marker row per lane (stable message id) so later states overwrite
+    earlier ones.
+  - `claudeSDKSubAgentProgressEvent`: `task_progress` summaries stream into
+    the lane as its latest-activity text.
+- Only depth-1 delegated tasks drive lane lifecycle; a nested task's
+  terminal state must not settle its root lane
+  (`claudeSDKSubagentTaskMarkerEvents` guard).
+- `claudeSDKSubagentInterruptEvents`: on `turn_canceled`/`turn_failed`,
+  still-running lanes launched by that turn get a "stopped" marker so no
+  lane ticks forever. A sub-agent that survives the interrupt self-heals:
+  its later task events update the same marker row.
+
+### GUI (`packages/agent/gui`)
+
+- `subAgentTimelinePartition.ts` `collectCollabCards`: the lane task strip
+  falls back `input.task` → `input.prompt` → `input.description` (Claude
+  delegate calls carry prompt/description, not task).
+- Everything else is reused as-is. `AgentToolGroupRow` already short-circuits
+  any task-VM call with attached lanes to `AgentSubAgentCards`.
+
+## Compatibility
+
+- Old recordings (no owner stamps) keep the legacy path: child calls nest
+  into the Task card's step list via `nestDelegatedToolCallsAcrossTurns`.
+- The sidecar still aggregates `metadata.steps` onto the parent Task call,
+  so static surfaces that render the task VM keep their step list.
+- No event-schema changes: the payload keys (`ownerThreadId`, `ownerCallId`,
+  `subAgentName`, `subAgentLifecycleStatus`, `detail`, `messageKind`) are the
+  ones codex already publishes.
+
+## Tests
+
+- Go: `TestClaudeCodeSDKAdapterEmitsSubagentLaneMarkersOnTaskStart`,
+  `TestClaudeCodeSDKAdapterFlattensNestedSubagentsIntoRootLane`,
+  `TestClaudeCodeSDKAdapterSettlesRunningLanesOnTurnCancel`, plus owner
+  assertions in `TestClaudeCodeSDKAdapterPreservesSubagentParentToolUseID`
+  and updated background-agent tests.
+- GUI: `subAgentTimelinePartition.spec.ts` "claude code delegate lanes".

--- a/packages/agent/claude-sdk-sidecar/src/normalizer.test.ts
+++ b/packages/agent/claude-sdk-sidecar/src/normalizer.test.ts
@@ -281,6 +281,79 @@ test("toolPayload extracts async subagent launch metadata", () => {
   });
 });
 
+test("toolPayload never marks a known non-delegate tool as a subagent launch", () => {
+  // A Read/Bash result can quote a launch confirmation verbatim (reading a
+  // test fixture, dumping test logs). That must not fabricate a background
+  // agent - phantom "running" agents never complete and wedge the
+  // "waiting for N background agents" banner.
+  const payload = toolPayload(
+    "turn-1",
+    {
+      id: "toolu-read",
+      name: "Read",
+      input: { file_path: "/repo/adapter_test.go" },
+      partialInputJson: "",
+      started: true
+    },
+    "completed",
+    {
+      content:
+        'fixture: "Async agent launched successfully\nagentId: agent-1" quoted mid-file'
+    }
+  );
+
+  const metadata = payload.metadata as Record<string, unknown>;
+  assert.equal(metadata.subagentAsync, undefined);
+  assert.equal(metadata.agentId, undefined);
+});
+
+test("toolPayload ignores a launch phrase buried inside longer output", () => {
+  const payload = toolPayload(
+    "turn-1",
+    {
+      id: "toolu-agent-2",
+      name: "Agent",
+      input: { prompt: "Inspect workspace" },
+      partialInputJson: "",
+      started: true
+    },
+    "completed",
+    {
+      content:
+        "--- FAIL: TestAdapter (0.00s)\n  output: Async agent launched successfully\nagentId: agent-1"
+    }
+  );
+
+  assert.equal(
+    (payload.metadata as Record<string, unknown>).subagentAsync,
+    undefined
+  );
+});
+
+test("toolPayload keeps launch detection for tools without a known name", () => {
+  // Nested launches can stream through the parent query without a locally
+  // observed tool_use block; the anchored launch text stays authoritative.
+  const payload = toolPayload(
+    "turn-1",
+    {
+      id: "toolu-nested",
+      name: "",
+      input: {},
+      partialInputJson: "",
+      started: true
+    },
+    "completed",
+    {
+      content:
+        "Async agent launched successfully\nagentId: agent-9\noutput_file: /tmp/agent-9.output"
+    }
+  );
+
+  const metadata = payload.metadata as Record<string, unknown>;
+  assert.equal(metadata.subagentAsync, true);
+  assert.equal(metadata.agentId, "agent-9");
+});
+
 test("toolPayload ignores Claude async subagent agentId suffix", () => {
   const payload = toolPayload(
     "turn-1",

--- a/packages/agent/claude-sdk-sidecar/src/normalizer.ts
+++ b/packages/agent/claude-sdk-sidecar/src/normalizer.ts
@@ -400,10 +400,19 @@ function subagentLaunchMetadata(
   result?: Record<string, unknown>
 ): Record<string, unknown> | undefined {
   // Nested agent launches stream through the parent query without a locally
-  // observed tool_use block, so the tool name may be unknown here. The launch
-  // result text is the authoritative signal, not the tool call type.
+  // observed tool_use block, so the tool name may be unknown here — an
+  // unknown name stays eligible. A known non-delegate tool (Read, Bash, …)
+  // never launches an agent: its output can quote a launch confirmation
+  // verbatim (test fixtures, logs) without being one, and treating it as a
+  // launch fabricates a background agent that never completes.
+  const toolName = stringValue(tool.name);
+  if (toolName && toolCallType(toolName) !== "subagent") {
+    return undefined;
+  }
+  // The launch confirmation IS the whole result text; anchored so a phrase
+  // buried inside longer output never counts.
   const text = toolResultText(result);
-  if (!/Async agent launched successfully/i.test(text)) {
+  if (!/^\s*Async agent launched successfully/i.test(text)) {
     return undefined;
   }
   const agentID =

--- a/packages/agent/daemon/runtime/claude_sdk_adapter.go
+++ b/packages/agent/daemon/runtime/claude_sdk_adapter.go
@@ -75,6 +75,18 @@ type claudeSDKAdapterSession struct {
 	// that has not settled yet; until it does, other turns settling must not
 	// be read as goal completion. Guarded by the adapter mutex.
 	goalArmTurnID string
+	// subagentToolParents maps a streamed tool_use id to its
+	// parentToolUseId. Lane ownership resolves through this chain to the
+	// top-level delegate (Task/Agent) call, so a sub-agent spawning its own
+	// sub-agent still attributes all activity to the root lane (ADR 0007).
+	// The registry lives for the session so follow-up messages to a running
+	// sub-agent keep landing in the original lane. Only touched from the
+	// sidecar event goroutine.
+	subagentToolParents map[string]string
+	// subagentLaneNames remembers the lane name last emitted per root
+	// delegate call so repeated tool/lifecycle updates do not re-emit
+	// identical subAgentName markers.
+	subagentLaneNames map[string]string
 }
 
 type claudeSDKBackgroundAgent struct {
@@ -652,6 +664,7 @@ func (a *ClaudeCodeSDKAdapter) sidecarTurnEvents(adapterSession *claudeSDKAdapte
 		events := []activityshared.Event{newTurnActivityEvent(session, EventTurnCanceled, turnID, SessionStatusCanceled, "", "", map[string]any{
 			"adapter": claudeSDKSidecarAdapterName,
 		})}
+		events = append(events, adapterSession.claudeSDKSubagentInterruptEvents(session, turnID)...)
 		events = append(events, a.goalEventsOnTurnSettled(adapterSession, session, turnID, false)...)
 		return events, true, nil
 	case "turn_failed":
@@ -659,6 +672,7 @@ func (a *ClaudeCodeSDKAdapter) sidecarTurnEvents(adapterSession *claudeSDKAdapte
 			"adapter": claudeSDKSidecarAdapterName,
 			"error":   payloadString(event.Payload, "error"),
 		})}
+		events = append(events, adapterSession.claudeSDKSubagentInterruptEvents(session, turnID)...)
 		events = append(events, a.goalEventsOnTurnSettled(adapterSession, session, turnID, false)...)
 		return events, true, nil
 	default:
@@ -1025,12 +1039,170 @@ func (s *claudeSDKAdapterSession) claudeSDKToolEvents(session Session, turnID st
 		return []activityshared.Event{claudeSDKToolActivityEvent(session, turnID, payload, eventType, status)}
 	}
 	effectiveTurnID := s.backgroundAgentTurnID(payload, turnID)
+	callID := firstNonEmptyString(payloadString(payload, "toolCallId"), payloadString(payload, "callId"), payloadString(payload, "id"))
+	parentToolUseID := strings.TrimSpace(payloadString(payloadMap(payload, "metadata"), "parentToolUseId"))
+	if parentToolUseID == callID {
+		// The sidecar's delegated-task parent updates echo the Task call's
+		// own id as parentToolUseId; the call is the lane owner, not a child.
+		parentToolUseID = ""
+	}
+	if callID != "" && parentToolUseID != "" {
+		if s.subagentToolParents == nil {
+			s.subagentToolParents = make(map[string]string)
+		}
+		s.subagentToolParents[callID] = parentToolUseID
+	}
 	var events []activityshared.Event
 	if strings.TrimSpace(effectiveTurnID) != "" {
-		events = append(events, claudeSDKToolActivityEvent(session, effectiveTurnID, payload, eventType, status))
+		toolEvent := claudeSDKToolActivityEvent(session, effectiveTurnID, payload, eventType, status)
+		if parentToolUseID != "" {
+			root := s.subagentRootToolID(parentToolUseID)
+			toolEvent.OwnerThreadID = claudeSDKSubagentLaneID(root)
+			toolEvent.OwnerCallID = root
+		}
+		events = append(events, toolEvent)
+		if parentToolUseID == "" {
+			events = append(events, s.claudeSDKSubagentSpawnMarkerEvents(session, effectiveTurnID, payload, callID, eventType, sidecarType)...)
+		}
 	}
 	backgroundEvents := s.updateClaudeSDKBackgroundAgentFromTool(session, turnID, payload, eventType, sidecarType)
 	return append(events, backgroundEvents...)
+}
+
+// claudeSDKSubagentLaneID names the synthetic owner thread for one delegated
+// agent. Claude Code has no provider child-thread ids; the root delegate call
+// id is the lane identity, prefixed so it can never collide with a real
+// provider thread id.
+func claudeSDKSubagentLaneID(rootCallID string) string {
+	return "claude-subagent:" + strings.TrimSpace(rootCallID)
+}
+
+// subagentRootToolID walks the parentToolUseId chain up to the top-level
+// delegate call. Nested delegations (a sub-agent's own Task calls) flatten
+// into the root lane because the GUI attaches lanes only to main-transcript
+// cards.
+func (s *claudeSDKAdapterSession) subagentRootToolID(toolID string) string {
+	toolID = strings.TrimSpace(toolID)
+	for depth := 0; depth < 32; depth++ {
+		parent := strings.TrimSpace(s.subagentToolParents[toolID])
+		if parent == "" || parent == toolID {
+			return toolID
+		}
+		toolID = parent
+	}
+	return toolID
+}
+
+func claudeSDKDelegateToolName(name string) bool {
+	switch strings.ToLower(strings.TrimSpace(name)) {
+	case "task", "subagent", "delegatetask", "delegateagent", "agent":
+		return true
+	default:
+		return false
+	}
+}
+
+// claudeSDKSubagentSpawnMarkerEvents derives sub-agent lane markers from the
+// root delegate (Task/Agent) call's own tool events, mirroring the codex
+// collab lane contract: hidden ownerThreadId rows carrying subAgentName and
+// subAgentLifecycleStatus that the GUI settles lane identity/status from.
+func (s *claudeSDKAdapterSession) claudeSDKSubagentSpawnMarkerEvents(session Session, turnID string, payload map[string]any, callID string, eventType string, sidecarType string) []activityshared.Event {
+	if callID == "" {
+		return nil
+	}
+	metadata := payloadMap(payload, "metadata")
+	name := firstNonEmptyString(payloadString(payload, "toolName"), payloadString(payload, "name"))
+	if !claudeSDKDelegateToolName(name) && metadata["subagentAsync"] != true && payloadString(payload, "callType") != "subagent" {
+		return nil
+	}
+	var events []activityshared.Event
+	input := payloadMap(payload, "input")
+	if label := firstNonEmptyString(payloadString(input, "description"), payloadString(payload, "description"), payloadString(input, "subagent_type")); label != "" {
+		if event, ok := s.claudeSDKSubagentNameMarker(session, callID, turnID, label); ok {
+			events = append(events, event)
+		}
+	}
+	status := claudeSDKNormalizeTaskStatus(firstNonEmptyString(payloadString(metadata, "subagentStatus"), payloadString(metadata, "taskStatus")))
+	switch {
+	case claudeSDKBackgroundAgentStatusIsTerminal(status):
+		detail := ""
+		if status != string(activityshared.ActivityStatusCompleted) {
+			detail = claudeSDKToolFailureDetail(payload)
+		}
+		events = append(events, claudeSDKSubAgentLifecycleEvent(session, callID, turnID, status, detail))
+	case status == "" && eventType == EventCallCompleted:
+		events = append(events, claudeSDKSubAgentLifecycleEvent(session, callID, turnID, string(activityshared.ActivityStatusCompleted), ""))
+	case status == "" && eventType == EventCallFailed:
+		events = append(events, claudeSDKSubAgentLifecycleEvent(session, callID, turnID, string(activityshared.ActivityStatusFailed), claudeSDKToolFailureDetail(payload)))
+	case sidecarType == "tool_started":
+		// The lane exists from the moment the delegate call starts; the GUI
+		// renders it as a running sub-agent card, matching codex spawn cards.
+		events = append(events, claudeSDKSubAgentLifecycleEvent(session, callID, turnID, "started", ""))
+	}
+	return events
+}
+
+func (s *claudeSDKAdapterSession) claudeSDKSubagentNameMarker(session Session, rootCallID string, turnID string, label string) (activityshared.Event, bool) {
+	if s.subagentLaneNames == nil {
+		s.subagentLaneNames = make(map[string]string)
+	}
+	if s.subagentLaneNames[rootCallID] == label {
+		return activityshared.Event{}, false
+	}
+	s.subagentLaneNames[rootCallID] = label
+	return claudeSDKSubAgentNameEvent(session, rootCallID, turnID, label), true
+}
+
+func claudeSDKToolFailureDetail(payload map[string]any) string {
+	errorPayload := payloadMap(payload, "error")
+	return firstNonEmptyString(
+		payloadString(errorPayload, "message"),
+		payloadString(errorPayload, "text"),
+		payloadString(errorPayload, "error"),
+		payloadString(payloadMap(payload, "output"), "text"),
+	)
+}
+
+func claudeSDKSubAgentNameEvent(session Session, rootCallID string, turnID string, name string) activityshared.Event {
+	messageID := "claude-subagent-name:" + rootCallID
+	event := newTurnActivityEventWithID(session, messageID, EventMessage, strings.TrimSpace(turnID), "completed", RoleAssistant, "", map[string]any{
+		"messageId":    messageID,
+		"contentMode":  messageContentModeSnapshot,
+		"messageKind":  "subAgentName",
+		"subAgentName": name,
+	})
+	event.OwnerThreadID = claudeSDKSubagentLaneID(rootCallID)
+	event.OwnerCallID = rootCallID
+	return event
+}
+
+func claudeSDKSubAgentLifecycleEvent(session Session, rootCallID string, turnID string, status string, detail string) activityshared.Event {
+	messageID := "claude-subagent-lifecycle:" + rootCallID
+	payload := map[string]any{
+		"messageId":               messageID,
+		"contentMode":             messageContentModeSnapshot,
+		"streamState":             status,
+		"messageKind":             "subAgentLifecycle",
+		"subAgentLifecycleStatus": status,
+	}
+	if detail != "" {
+		payload["detail"] = detail
+	}
+	event := newTurnActivityEventWithID(session, messageID, EventMessage, strings.TrimSpace(turnID), status, RoleAssistant, "", payload)
+	event.OwnerThreadID = claudeSDKSubagentLaneID(rootCallID)
+	event.OwnerCallID = rootCallID
+	return event
+}
+
+func claudeSDKSubAgentProgressEvent(session Session, rootCallID string, turnID string, summary string) activityshared.Event {
+	messageID := "claude-subagent-progress:" + rootCallID
+	event := newTurnActivityEventWithID(session, messageID, EventMessage, strings.TrimSpace(turnID), messageStreamStateStreaming, RoleAssistant, summary, map[string]any{
+		"messageId":   messageID,
+		"contentMode": messageContentModeSnapshot,
+	})
+	event.OwnerThreadID = claudeSDKSubagentLaneID(rootCallID)
+	event.OwnerCallID = rootCallID
+	return event
 }
 
 func (s *claudeSDKAdapterSession) claudeSDKTaskLifecycleEvents(session Session, turnID string, sidecarType string, payload map[string]any) []activityshared.Event {
@@ -1052,7 +1224,81 @@ func (s *claudeSDKAdapterSession) claudeSDKTaskLifecycleEvents(session Session, 
 	if !ok {
 		return nil
 	}
-	return claudeSDKBackgroundAgentEvents(session, agent, runtimeContext, sidecarType)
+	events := claudeSDKBackgroundAgentEvents(session, agent, runtimeContext, sidecarType)
+	return append(events, s.claudeSDKSubagentTaskMarkerEvents(session, turnID, sidecarType, payload, agent)...)
+}
+
+// claudeSDKSubagentTaskMarkerEvents projects delegated-task lifecycle events
+// (task_started/task_progress/task_completed) onto the sub-agent lane owned
+// by the launching delegate call. Only depth-1 tasks drive lane lifecycle:
+// a nested task's terminal state must not settle its root lane, though its
+// activity still flattens into that lane via owner-stamped tool rows.
+func (s *claudeSDKAdapterSession) claudeSDKSubagentTaskMarkerEvents(session Session, turnID string, sidecarType string, payload map[string]any, agent claudeSDKBackgroundAgent) []activityshared.Event {
+	root := strings.TrimSpace(firstNonEmptyString(
+		payloadString(payload, "parentToolUseId"),
+		payloadString(payload, "toolCallId"),
+		payloadString(payload, "callId"),
+		agent.ParentToolUseID,
+	))
+	if root == "" || strings.TrimSpace(s.subagentToolParents[root]) != "" {
+		return nil
+	}
+	markerTurnID := firstNonEmptyString(strings.TrimSpace(turnID), agent.TurnID)
+	var events []activityshared.Event
+	if label := firstNonEmptyString(payloadString(payload, "description"), agent.Description); label != "" {
+		if event, ok := s.claudeSDKSubagentNameMarker(session, root, markerTurnID, label); ok {
+			events = append(events, event)
+		}
+	}
+	status := claudeSDKTaskStatus(sidecarType, payloadString(payload, "status"))
+	switch {
+	case claudeSDKBackgroundAgentStatusIsTerminal(status):
+		detail := ""
+		if status != string(activityshared.ActivityStatusCompleted) {
+			detail = firstNonEmptyString(payloadString(payload, "summary"), payloadString(payload, "error"))
+		}
+		events = append(events, claudeSDKSubAgentLifecycleEvent(session, root, markerTurnID, status, detail))
+	case sidecarType == "task_started":
+		events = append(events, claudeSDKSubAgentLifecycleEvent(session, root, markerTurnID, "started", ""))
+	case sidecarType == "task_progress":
+		if summary := payloadString(payload, "summary"); summary != "" {
+			events = append(events, claudeSDKSubAgentProgressEvent(session, root, markerTurnID, summary))
+		}
+	}
+	return events
+}
+
+// claudeSDKSubagentInterruptEvents settles lanes that were still running when
+// their launching turn was canceled or failed: without a terminal marker the
+// lane card would keep ticking as "running" forever. A sub-agent that in fact
+// survives the interrupt self-heals — its later task events update the same
+// lifecycle marker row.
+func (s *claudeSDKAdapterSession) claudeSDKSubagentInterruptEvents(session Session, turnID string) []activityshared.Event {
+	if s == nil || len(s.backgroundAgents) == 0 {
+		return nil
+	}
+	turnID = strings.TrimSpace(turnID)
+	keys := make([]string, 0, len(s.backgroundAgents))
+	for key := range s.backgroundAgents {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	var events []activityshared.Event
+	for _, key := range keys {
+		agent := s.backgroundAgents[key]
+		root := strings.TrimSpace(agent.ParentToolUseID)
+		if root == "" || claudeSDKBackgroundAgentStatusIsTerminal(agent.Status) {
+			continue
+		}
+		if strings.TrimSpace(s.subagentToolParents[root]) != "" {
+			continue
+		}
+		if turnID != "" && strings.TrimSpace(agent.TurnID) != "" && agent.TurnID != turnID {
+			continue
+		}
+		events = append(events, claudeSDKSubAgentLifecycleEvent(session, root, turnID, "stopped", ""))
+	}
+	return events
 }
 
 func (s *claudeSDKAdapterSession) updateClaudeSDKBackgroundAgentFromTool(session Session, turnID string, payload map[string]any, eventType string, sidecarType string) []activityshared.Event {

--- a/packages/agent/daemon/runtime/claude_sdk_adapter.go
+++ b/packages/agent/daemon/runtime/claude_sdk_adapter.go
@@ -2496,9 +2496,16 @@ func claudeSDKRuntimeContext(session Session, adapterSession *claudeSDKAdapterSe
 		context["usage"] = usage
 	}
 	if adapterSession != nil {
-		if backgroundAgents := claudeSDKBackgroundAgentsRuntimeContext(adapterSession.backgroundAgents); len(backgroundAgents) > 0 {
-			context["backgroundAgents"] = backgroundAgents
+		backgroundAgents := claudeSDKBackgroundAgentsRuntimeContext(adapterSession.backgroundAgents)
+		if backgroundAgents == nil {
+			// Session runtimeContext merges per-key (mergeRuntimeContextPatch):
+			// omitting the key would keep a stale persisted backgroundAgents
+			// snapshot alive forever (a "waiting for N background agents"
+			// banner that survives restarts). An explicit empty state on
+			// session start/resume clears it.
+			backgroundAgents = map[string]any{"count": 0, "items": []any{}}
 		}
+		context["backgroundAgents"] = backgroundAgents
 	}
 	if resumeCursor := claudeSDKResumeCursor(session, adapterSession); len(resumeCursor) > 0 {
 		context["resumeCursor"] = resumeCursor

--- a/packages/agent/daemon/runtime/claude_sdk_adapter_test.go
+++ b/packages/agent/daemon/runtime/claude_sdk_adapter_test.go
@@ -343,6 +343,193 @@ func TestClaudeCodeSDKAdapterPreservesSubagentParentToolUseID(t *testing.T) {
 	if metadata["parentToolUseId"] != "toolu-task" {
 		t.Fatalf("message update payload = %#v, want nested metadata parentToolUseId", update.Payload)
 	}
+	if events[0].OwnerThreadID != "claude-subagent:toolu-task" || events[0].OwnerCallID != "toolu-task" {
+		t.Fatalf("child tool owner = %q/%q, want lane owner ids for sub-agent lane attachment", events[0].OwnerThreadID, events[0].OwnerCallID)
+	}
+	if update.Payload["ownerThreadId"] != "claude-subagent:toolu-task" || update.Payload["ownerCallId"] != "toolu-task" {
+		t.Fatalf("message update payload = %#v, want persisted ownerThreadId/ownerCallId", update.Payload)
+	}
+}
+
+func TestClaudeCodeSDKAdapterEmitsSubagentLaneMarkersOnTaskStart(t *testing.T) {
+	adapter := NewClaudeCodeSDKAdapter(nil)
+	session := standardTestSession(ProviderClaudeCode)
+	adapterSession := &claudeSDKAdapterSession{
+		conn:            &recordingClaudeSDKConnection{},
+		pendingRequests: make(map[string]*pendingACPRequest),
+		liveState:       newClaudeSDKLiveState(),
+	}
+	adapter.storeSession(session.AgentSessionID, adapterSession)
+
+	events, terminal, err := adapter.sidecarTurnEvents(adapterSession, session, "turn-task", claudeSDKSidecarEvent{
+		Type: "tool_started",
+		Payload: map[string]any{
+			"turnId":     "turn-task",
+			"toolCallId": "toolu-task",
+			"toolName":   "Task",
+			"input": map[string]any{
+				"description":   "Map render paths",
+				"prompt":        "Find all render call sites",
+				"subagent_type": "Explore",
+			},
+		},
+	})
+	if err != nil || terminal {
+		t.Fatalf("tool_started terminal=%v err=%v", terminal, err)
+	}
+	if len(events) != 3 {
+		t.Fatalf("events = %#v, want tool row + name marker + started lifecycle marker", events)
+	}
+	if events[0].OwnerThreadID != "" || events[0].OwnerCallID != "" {
+		t.Fatalf("spawn card owner = %q/%q, want unstamped main-transcript row", events[0].OwnerThreadID, events[0].OwnerCallID)
+	}
+	name, lifecycle := events[1], events[2]
+	if name.Payload.Metadata["messageKind"] != "subAgentName" || name.Payload.Metadata["subAgentName"] != "Map render paths" {
+		t.Fatalf("name marker = %#v, want description as lane name", name.Payload.Metadata)
+	}
+	if lifecycle.Payload.Metadata["messageKind"] != "subAgentLifecycle" || lifecycle.Payload.Metadata["subAgentLifecycleStatus"] != "started" {
+		t.Fatalf("lifecycle marker = %#v, want started marker so the lane renders immediately", lifecycle.Payload.Metadata)
+	}
+	for _, marker := range []activityshared.Event{name, lifecycle} {
+		if marker.OwnerThreadID != "claude-subagent:toolu-task" || marker.OwnerCallID != "toolu-task" {
+			t.Fatalf("marker owner = %q/%q, want lane owner ids", marker.OwnerThreadID, marker.OwnerCallID)
+		}
+	}
+
+	// A repeated update with the same description must not re-emit the name
+	// marker; a sync completion without task status settles the lane.
+	completed, terminal, err := adapter.sidecarTurnEvents(adapterSession, session, "turn-task", claudeSDKSidecarEvent{
+		Type: "tool_completed",
+		Payload: map[string]any{
+			"turnId":     "turn-task",
+			"toolCallId": "toolu-task",
+			"toolName":   "Task",
+			"input": map[string]any{
+				"description":   "Map render paths",
+				"prompt":        "Find all render call sites",
+				"subagent_type": "Explore",
+			},
+			"output": map[string]any{"text": "Done"},
+		},
+	})
+	if err != nil || terminal {
+		t.Fatalf("tool_completed terminal=%v err=%v", terminal, err)
+	}
+	if len(completed) != 2 {
+		t.Fatalf("completed events = %#v, want tool row + completed lifecycle marker", completed)
+	}
+	if completed[1].Payload.Metadata["subAgentLifecycleStatus"] != "completed" {
+		t.Fatalf("completed lifecycle marker = %#v, want completed status", completed[1].Payload.Metadata)
+	}
+}
+
+func TestClaudeCodeSDKAdapterFlattensNestedSubagentsIntoRootLane(t *testing.T) {
+	adapter := NewClaudeCodeSDKAdapter(nil)
+	session := standardTestSession(ProviderClaudeCode)
+	adapterSession := &claudeSDKAdapterSession{
+		conn:            &recordingClaudeSDKConnection{},
+		pendingRequests: make(map[string]*pendingACPRequest),
+		liveState:       newClaudeSDKLiveState(),
+	}
+	adapter.storeSession(session.AgentSessionID, adapterSession)
+
+	// The sub-agent launched by toolu-root spawns its own sub-agent via a
+	// nested Task call (toolu-nested); the grandchild's tools reference the
+	// nested call as parent.
+	_, _, err := adapter.sidecarTurnEvents(adapterSession, session, "turn-task", claudeSDKSidecarEvent{
+		Type: "tool_started",
+		Payload: map[string]any{
+			"turnId":     "turn-task",
+			"toolCallId": "toolu-nested",
+			"toolName":   "Task",
+			"input":      map[string]any{"description": "Nested delegate", "prompt": "Dig deeper"},
+			"metadata":   map[string]any{"parentToolUseId": "toolu-root"},
+		},
+	})
+	if err != nil {
+		t.Fatalf("nested task tool_started err=%v", err)
+	}
+	grandchild, _, err := adapter.sidecarTurnEvents(adapterSession, session, "turn-task", claudeSDKSidecarEvent{
+		Type: "tool_completed",
+		Payload: map[string]any{
+			"turnId":     "turn-task",
+			"toolCallId": "toolu-grandchild-read",
+			"toolName":   "Read",
+			"input":      map[string]any{"file_path": "/repo/a.go"},
+			"output":     map[string]any{"text": "ok"},
+			"metadata":   map[string]any{"parentToolUseId": "toolu-nested"},
+		},
+	})
+	if err != nil || len(grandchild) != 1 {
+		t.Fatalf("grandchild events = %#v err=%v, want single owner-stamped tool row", grandchild, err)
+	}
+	if grandchild[0].OwnerThreadID != "claude-subagent:toolu-root" || grandchild[0].OwnerCallID != "toolu-root" {
+		t.Fatalf("grandchild owner = %q/%q, want root lane (nested delegations flatten)", grandchild[0].OwnerThreadID, grandchild[0].OwnerCallID)
+	}
+
+	// The nested task's lifecycle must not settle the root lane.
+	nestedLifecycle, _, err := adapter.sidecarTurnEvents(adapterSession, session, "turn-task", claudeSDKSidecarEvent{
+		Type: "task_completed",
+		Payload: map[string]any{
+			"turnId":          "turn-task",
+			"taskId":          "task-nested",
+			"parentToolUseId": "toolu-nested",
+			"status":          "completed",
+			"summary":         "Nested done",
+		},
+	})
+	if err != nil {
+		t.Fatalf("nested task_completed err=%v", err)
+	}
+	for _, event := range nestedLifecycle {
+		if event.Payload.Metadata["messageKind"] == "subAgentLifecycle" {
+			t.Fatalf("nested task lifecycle emitted lane marker %#v; must not settle the root lane", event.Payload.Metadata)
+		}
+	}
+}
+
+func TestClaudeCodeSDKAdapterSettlesRunningLanesOnTurnCancel(t *testing.T) {
+	adapter := NewClaudeCodeSDKAdapter(nil)
+	session := standardTestSession(ProviderClaudeCode)
+	adapterSession := &claudeSDKAdapterSession{
+		conn:            &recordingClaudeSDKConnection{},
+		pendingRequests: make(map[string]*pendingACPRequest),
+		liveState:       newClaudeSDKLiveState(),
+	}
+	adapter.storeSession(session.AgentSessionID, adapterSession)
+
+	_, _, err := adapter.sidecarTurnEvents(adapterSession, session, "turn-task", claudeSDKSidecarEvent{
+		Type: "task_started",
+		Payload: map[string]any{
+			"turnId":          "turn-task",
+			"taskId":          "task-1",
+			"parentToolUseId": "toolu-agent",
+			"description":     "Long running research",
+			"status":          "running",
+		},
+	})
+	if err != nil {
+		t.Fatalf("task_started err=%v", err)
+	}
+	canceled, terminal, err := adapter.sidecarTurnEvents(adapterSession, session, "turn-task", claudeSDKSidecarEvent{
+		Type:    "turn_canceled",
+		Payload: map[string]any{"turnId": "turn-task"},
+	})
+	if err != nil || !terminal {
+		t.Fatalf("turn_canceled terminal=%v err=%v", terminal, err)
+	}
+	var stopped *activityshared.Event
+	for index := range canceled {
+		if canceled[index].Payload.Metadata["messageKind"] == "subAgentLifecycle" {
+			stopped = &canceled[index]
+		}
+	}
+	if stopped == nil {
+		t.Fatalf("turn_canceled events = %#v, want stopped lane lifecycle marker", canceled)
+	}
+	if stopped.Payload.Metadata["subAgentLifecycleStatus"] != "stopped" || stopped.OwnerCallID != "toolu-agent" {
+		t.Fatalf("stopped marker = %#v owner=%q, want stopped status on the running lane", stopped.Payload.Metadata, stopped.OwnerCallID)
+	}
 }
 
 func TestClaudeCodeSDKAdapterTracksSDKBackgroundAgents(t *testing.T) {
@@ -378,8 +565,15 @@ func TestClaudeCodeSDKAdapterTracksSDKBackgroundAgents(t *testing.T) {
 	if err != nil || terminal {
 		t.Fatalf("tool_completed terminal=%v err=%v", terminal, err)
 	}
-	if len(started) != 3 {
-		t.Fatalf("started events = %#v, want call + activity + session update", started)
+	if len(started) != 4 {
+		t.Fatalf("started events = %#v, want call + lane name marker + activity + session update", started)
+	}
+	nameMarker := started[1]
+	if nameMarker.OwnerThreadID != "claude-subagent:toolu-agent" || nameMarker.OwnerCallID != "toolu-agent" {
+		t.Fatalf("name marker owner = %q/%q, want lane owner ids", nameMarker.OwnerThreadID, nameMarker.OwnerCallID)
+	}
+	if nameMarker.Payload.Metadata["messageKind"] != "subAgentName" || nameMarker.Payload.Metadata["subAgentName"] != "Explore codebase structure" {
+		t.Fatalf("name marker metadata = %#v, want subAgentName marker", nameMarker.Payload.Metadata)
 	}
 	backgroundAgents := sdkBackgroundAgentsFromEvents(t, started)
 	if backgroundAgents["count"] != 1 {
@@ -399,11 +593,21 @@ func TestClaudeCodeSDKAdapterTracksSDKBackgroundAgents(t *testing.T) {
 	if err != nil || terminal {
 		t.Fatalf("task_completed terminal=%v err=%v", terminal, err)
 	}
-	if len(completed) != 2 {
-		t.Fatalf("completed events = %#v, want activity + session update", completed)
+	if len(completed) != 3 {
+		t.Fatalf("completed events = %#v, want activity + session update + lane lifecycle marker", completed)
 	}
 	if completed[0].Payload.TurnID != "turn-task" {
 		t.Fatalf("task completed turnID = %q, want fallback to parent turn", completed[0].Payload.TurnID)
+	}
+	lifecycle := completed[2]
+	if lifecycle.OwnerThreadID != "claude-subagent:toolu-agent" || lifecycle.OwnerCallID != "toolu-agent" {
+		t.Fatalf("lifecycle marker owner = %q/%q, want lane owner ids", lifecycle.OwnerThreadID, lifecycle.OwnerCallID)
+	}
+	if lifecycle.Payload.Metadata["messageKind"] != "subAgentLifecycle" || lifecycle.Payload.Metadata["subAgentLifecycleStatus"] != "completed" {
+		t.Fatalf("lifecycle marker metadata = %#v, want completed subAgentLifecycle marker", lifecycle.Payload.Metadata)
+	}
+	if lifecycle.Payload.TurnID != "turn-task" {
+		t.Fatalf("lifecycle marker turnID = %q, want launching turn", lifecycle.Payload.TurnID)
 	}
 	backgroundAgents = sdkBackgroundAgentsFromEvents(t, completed)
 	if backgroundAgents["count"] != 0 {
@@ -625,8 +829,8 @@ func TestClaudeCodeSDKAdapterKeepsLateBackgroundAgentEventsWithPayloadTurnID(t *
 	if err != nil || terminal {
 		t.Fatalf("late task_completed terminal=%v err=%v", terminal, err)
 	}
-	if len(completed) != 2 {
-		t.Fatalf("late task_completed events = %#v, want activity + session update", completed)
+	if len(completed) != 3 {
+		t.Fatalf("late task_completed events = %#v, want activity + session update + lane lifecycle marker", completed)
 	}
 	if completed[0].Payload.TurnID != "turn-task" {
 		t.Fatalf("late task_completed turnID = %q, want payload turn", completed[0].Payload.TurnID)

--- a/packages/agent/daemon/runtime/claude_sdk_adapter_test.go
+++ b/packages/agent/daemon/runtime/claude_sdk_adapter_test.go
@@ -488,6 +488,22 @@ func TestClaudeCodeSDKAdapterFlattensNestedSubagentsIntoRootLane(t *testing.T) {
 	}
 }
 
+func TestClaudeCodeSDKRuntimeContextWritesEmptyBackgroundAgents(t *testing.T) {
+	session := standardTestSession(ProviderClaudeCode)
+	adapterSession := &claudeSDKAdapterSession{liveState: newClaudeSDKLiveState()}
+
+	// runtimeContext merges per-key into the persisted session record; the
+	// empty state must be written explicitly or a stale "waiting for N
+	// background agents" snapshot survives restarts forever.
+	backgroundAgents, ok := claudeSDKRuntimeContext(session, adapterSession)["backgroundAgents"].(map[string]any)
+	if !ok {
+		t.Fatal("runtimeContext omitted backgroundAgents; stale persisted state would never clear")
+	}
+	if backgroundAgents["count"] != 0 {
+		t.Fatalf("backgroundAgents = %#v, want explicit empty state", backgroundAgents)
+	}
+}
+
 func TestClaudeCodeSDKAdapterSettlesRunningLanesOnTurnCancel(t *testing.T) {
 	adapter := NewClaudeCodeSDKAdapter(nil)
 	session := standardTestSession(ProviderClaudeCode)

--- a/packages/agent/gui/shared/agentConversation/projection/subAgentTimelinePartition.spec.ts
+++ b/packages/agent/gui/shared/agentConversation/projection/subAgentTimelinePartition.spec.ts
@@ -747,6 +747,97 @@ describe("subAgentTimelinePartition", () => {
     });
   });
 
+  describe("claude code delegate lanes", () => {
+    // The Claude adapter stamps child rows with the synthetic lane thread
+    // "claude-subagent:<root call id>" and ownerCallId = the Task call's
+    // tool_use id, so Claude delegations ride the same lane pipeline as
+    // codex collab spawns.
+    const claudeTaskCard = (status: string, occurredAtUnixMs: number) =>
+      timelineItem({
+        id: 10,
+        eventId: "claude-sdk:tool:toolu-task",
+        itemType: "call.started",
+        callType: "subagent",
+        callId: "toolu-task",
+        name: "Task",
+        status,
+        payload: {
+          callId: "toolu-task",
+          name: "Task",
+          toolName: "Task",
+          status,
+          input: {
+            description: "Map render paths",
+            prompt: "Find all render call sites in the GUI",
+            subagent_type: "Explore"
+          }
+        },
+        occurredAtUnixMs,
+        createdAtUnixMs: occurredAtUnixMs
+      });
+
+    it("attaches a claude child lane to its Task card by ownerCallId", () => {
+      const partition = partitionSubAgentTimelineItems([
+        claudeTaskCard("running", 100),
+        timelineItem({
+          id: 11,
+          eventId: "claude-subagent-name:toolu-task",
+          itemType: "message.assistant",
+          role: "assistant",
+          payload: {
+            ownerThreadId: "claude-subagent:toolu-task",
+            ownerCallId: "toolu-task",
+            messageKind: "subAgentName",
+            subAgentName: "Map render paths"
+          },
+          occurredAtUnixMs: 120
+        }),
+        childCallItem({
+          id: 12,
+          eventId: "child-read-1",
+          ownerThreadId: "claude-subagent:toolu-task",
+          ownerCallId: "toolu-task",
+          name: "Read file",
+          occurredAtUnixMs: 150
+        })
+      ]);
+
+      const lane = buildSubAgentLanesByCallId(partition).get("toolu-task")?.[0];
+
+      expect(lane).toEqual(
+        expect.objectContaining({
+          ownerThreadId: "claude-subagent:toolu-task",
+          status: "running",
+          name: "Map render paths",
+          // Claude Task input has no `task`; the lane task strip falls back
+          // to the delegate prompt.
+          task: "Find all render call sites in the GUI",
+          latestActivity: "Read file",
+          latestActivityKind: "tool"
+        })
+      );
+    });
+
+    it("settles a claude lane from the lifecycle marker", () => {
+      const partition = partitionSubAgentTimelineItems([
+        claudeTaskCard("running", 100),
+        childLifecycleItem({
+          id: 11,
+          eventId: "claude-subagent-lifecycle:toolu-task",
+          ownerThreadId: "claude-subagent:toolu-task",
+          ownerCallId: "toolu-task",
+          status: "completed",
+          occurredAtUnixMs: 300
+        })
+      ]);
+
+      const lane = buildSubAgentLanesByCallId(partition).get("toolu-task")?.[0];
+
+      expect(lane?.status).toBe("completed");
+      expect(lane?.terminalAtUnixMs).toBe(300);
+    });
+  });
+
   describe("attachSubAgentLanesToConversationVM", () => {
     it("returns the conversation untouched when there are no lanes", () => {
       const conversation = { rows: [] } as unknown as AgentConversationVM;

--- a/packages/agent/gui/shared/agentConversation/projection/subAgentTimelinePartition.ts
+++ b/packages/agent/gui/shared/agentConversation/projection/subAgentTimelinePartition.ts
@@ -492,7 +492,13 @@ function collectCollabCards(
       return {
         callId: card.callId,
         startedAtUnixMs: card.startedAtUnixMs,
-        task: stringValue(input?.task),
+        // Codex collab spawns carry `task`; Claude Code delegate (Task/Agent)
+        // calls carry `prompt` + `description` instead.
+        task: firstString(
+          stringValue(input?.task),
+          stringValue(input?.prompt),
+          stringValue(input?.description)
+        ),
         agentName: stringValue(input?.agentName),
         callStatus: subAgentStatusFromCallStatus(card.latestCallStatus),
         receiverThreadIds: card.receiverThreadIds,


### PR DESCRIPTION
## Summary

Two related changes on the Claude Code sub-agent pipeline, from one investigation (log bundle `tutti-logs-20260707-004856`):

### 1. Claude Code sub-agents render as sub-agent lanes (parity with codex)

Codex collab sub-agents render as live lane cards (`AgentSubAgentCards`); Claude Code delegations rendered as a static task card + step list. The Claude adapter now emits the same owner-stamped child rows and lane markers as codex (ADR 0007: daemon stamps the edge, GUI does exact lookup), so both providers ride the identical GUI lane pipeline.

- Synthetic lane identity (Claude has no provider child-thread ids): `ownerThreadId = "claude-subagent:<root tool_use id>"`, `ownerCallId = <root tool_use id>`.
- `subagentToolParents` registry resolves `parentToolUseId` chains to the root delegate call: follow-up messages to a running sub-agent stay in its lane; nested delegations (sub-agent spawning sub-agent) flatten into the root lane; only depth-1 tasks drive lane lifecycle.
- Lifecycle markers: `started` at spawn (lane renders immediately), terminal from sync completion or async `task_completed` (launch results never settle), `stopped` fallback on turn cancel/failure with self-healing single marker row; `task_progress` summaries stream in as latest activity.
- GUI: lane task strip falls back `task` → `prompt` → `description`; old recordings without owner stamps keep the legacy nested step list.

Spec: `docs/specs/2026-07-07-claude-subagent-lanes.md`.

### 2. Stop fabricating background agents from tool output text

Root cause of a stuck "waiting for 3 background agents" banner (`submitAvailabilityReason: background_agent` after the turn settled): `subagentLaunchMetadata` matched `/Async agent launched successfully/i` anywhere in **any** tool's result text. A `Read` of a test fixture or a `Bash` run dumping test logs that merely *quoted* the phrase fabricated background agents that never complete.

Evidence (session `b0884403` in the log bundle): persisted `runtimeContext.backgroundAgents count=3`, items described `Read` / `Run Claude SDK adapter tests` with raw tool output as summary, while `turnLifecycle` was `settled/completed`.

- sidecar: launch detection now requires a delegate tool (`toolCallType === "subagent"`) or a locally unknown tool name (nested launches), and the phrase must anchor the result text.
- adapter: `claudeSDKRuntimeContext` always writes `backgroundAgents` (explicit `{count:0, items:[]}` when empty) — session runtimeContext merges per-key, so an omitted key kept the stale persisted snapshot (and the banner) alive across restarts.

## Tests

- Go `runtime` package full pass: new tests for owner stamping, nested flattening, spawn-time lane markers, cancel settling, and the explicit empty backgroundAgents state.
- Sidecar: 3 new normalizer regressions (quoted phrase in Read output, phrase buried in longer output, unknown-name nested launch still detected); full sidecar suite + typecheck pass.
- GUI: new "claude code delegate lanes" specs; agentConversation suites (456 tests) pass.
- `check:full` passed on push.

**Please do not merge yet** — held for review/acceptance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)