### PR TITLE
fix(agent): stale-state clobber, queue/send race, and auth-watcher invalidation churn

### DIFF
--- a/packages/agent/activity-core/src/controller.test.ts
+++ b/packages/agent/activity-core/src/controller.test.ts
@@ -1672,3 +1672,77 @@ async function waitFor(assertion: () => void): Promise<void> {
     throw lastError;
   }
 }
+
+test("stale session upsert does not regress a fresher pushed state", async () => {
+  const controller = createAgentActivityController({
+    adapter: fakeAdapter({
+      listSessions: () =>
+        Promise.resolve({
+          sessions: [
+            createSession({
+              turnLifecycle: { phase: "running", activeTurnId: "turn-1" },
+              updatedAtUnixMs: 1000
+            })
+          ]
+        } satisfies AgentActivitySessionList)
+    }),
+    workspaceId: "workspace-1"
+  });
+  await controller.load();
+
+  // Fresher settled state lands (e.g. from a pushed state patch).
+  controller.upsertSession(
+    createSession({
+      turnLifecycle: { phase: "settled", activeTurnId: null },
+      updatedAtUnixMs: 2000
+    })
+  );
+  // A reconcile fetch that resolved late carries a stale running view; it
+  // must not overwrite the settled state (the session would freeze busy).
+  controller.upsertSession(
+    createSession({
+      turnLifecycle: { phase: "running", activeTurnId: "turn-1" },
+      updatedAtUnixMs: 1500
+    })
+  );
+
+  const session = controller
+    .getSnapshot()
+    .sessions.find((item) => item.agentSessionId === "session-1");
+  assert.equal(session?.turnLifecycle?.phase, "settled");
+  assert.equal(session?.updatedAtUnixMs, 2000);
+});
+
+test("load keeps sessions that are fresher than the list response", async () => {
+  let listCalls = 0;
+  const controller = createAgentActivityController({
+    adapter: fakeAdapter({
+      listSessions: () => {
+        listCalls += 1;
+        return Promise.resolve({
+          sessions: [
+            createSession({
+              turnLifecycle:
+                listCalls === 1
+                  ? { phase: "settled", activeTurnId: null }
+                  : { phase: "running", activeTurnId: "turn-1" },
+              updatedAtUnixMs: listCalls === 1 ? 2000 : 1500
+            })
+          ]
+        } satisfies AgentActivitySessionList);
+      }
+    }),
+    workspaceId: "workspace-1"
+  });
+
+  await controller.load();
+  // Second load returns a stale point-in-time snapshot (e.g. an in-flight
+  // request that resolved after a fresher push already landed).
+  await controller.load();
+
+  const session = controller
+    .getSnapshot()
+    .sessions.find((item) => item.agentSessionId === "session-1");
+  assert.equal(session?.turnLifecycle?.phase, "settled");
+  assert.equal(session?.updatedAtUnixMs, 2000);
+});

--- a/packages/agent/activity-core/src/controller.ts
+++ b/packages/agent/activity-core/src/controller.ts
@@ -125,25 +125,33 @@ export function createAgentActivityController({
       const nextSessions = response.sessions;
       const nextPresences = response.presences ?? [];
       const nextSnapshot = updateSnapshot((current) => {
+        let mergedSessions = nextSessions;
         const sessionDataUnchanged =
           areShallowObjectArraysEqual(current.sessions, nextSessions) &&
           areShallowObjectArraysEqual(current.presences, nextPresences);
         if (!sessionDataUnchanged) {
-          for (const nextSession of nextSessions) {
+          mergedSessions = nextSessions.map((nextSession) => {
             const existing = current.sessions.find(
               (item) => item.agentSessionId === nextSession.agentSessionId
             );
-            if (existing) {
-              reportSessionVersionRegression("load", existing, nextSession);
+            if (!existing) {
+              return nextSession;
             }
-          }
+            reportSessionVersionRegression("load", existing, nextSession);
+            // A load response is a point-in-time snapshot; if a fresher pushed
+            // state already landed for this session, keep it (same guard as
+            // upsertSnapshotSession).
+            return sessionVersionRegressed(existing, nextSession)
+              ? existing
+              : nextSession;
+          });
         }
         const source = sessionDataUnchanged
           ? current
           : {
               ...current,
               presences: nextPresences,
-              sessions: nextSessions
+              sessions: mergedSessions
             };
         const canonical = canonicalizeSnapshotMessageBuckets(source);
         if (canonical !== source) {
@@ -998,6 +1006,15 @@ function sessionVersionKey(session: AgentActivitySession): number | null {
   return session.lastEventUnixMs ?? session.updatedAtUnixMs ?? null;
 }
 
+function sessionVersionRegressed(
+  existing: AgentActivitySession,
+  incoming: AgentActivitySession
+): boolean {
+  const previousKey = sessionVersionKey(existing);
+  const nextKey = sessionVersionKey(incoming);
+  return previousKey !== null && nextKey !== null && nextKey < previousKey;
+}
+
 function reportSessionVersionRegression(
   source: string,
   existing: AgentActivitySession,
@@ -1038,6 +1055,13 @@ function upsertSnapshotSession(
   const existingSession = snapshot.sessions[index];
   if (existingSession) {
     reportSessionVersionRegression(source, existingSession, session);
+    // A slow fetch can resolve after a fresher pushed state landed (e.g. a
+    // reconcile snapshot requested mid-turn arriving after the settle patch).
+    // Overwriting would freeze the session on a stale running/blocked view
+    // with no later event to correct it, so drop the stale upsert instead.
+    if (sessionVersionRegressed(existingSession, session)) {
+      return snapshot;
+    }
   }
   const sessions = [...snapshot.sessions];
   sessions[index] = session;

--- a/packages/agent/daemon/runtime/claude_sdk_adapter.go
+++ b/packages/agent/daemon/runtime/claude_sdk_adapter.go
@@ -2079,7 +2079,7 @@ func logClaudeSDKSidecarDebugStderr(content []byte) {
 		if payloadJSON == "" {
 			payloadJSON = "{}"
 		}
-		slog.Warn(claudeSDKAuthRefreshLogPrefix,
+		slog.Debug(claudeSDKAuthRefreshLogPrefix,
 			"event", "agent_session.claude_sdk.auth_refresh_debug",
 			"payload_json", payloadJSON,
 		)

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUINodeController.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUINodeController.ts
@@ -8539,10 +8539,21 @@ export function useAgentGUINodeController({
         );
         return;
       }
+      // Read the queue before resuming: resumeQueue wakes the drain
+      // coordinator, which immediately races to send the queued head. A
+      // direct send issued alongside that drain loses the daemon's
+      // single-active-turn slot and the prompt is dropped, so when prompts
+      // are already queued the explicit send must join the queue behind them
+      // instead of racing the drain.
+      const hasQueuedPrompts =
+        agentQueuedPromptRuntime.getSessionSnapshot({
+          workspaceId,
+          agentSessionId
+        }).prompts.length > 0;
       // Any explicit user send lifts a user-stop hold on the queue.
       agentQueuedPromptRuntime.resumeQueue({ workspaceId, agentSessionId });
       if (
-        shouldQueuePromptLocally(agentSessionId) &&
+        (hasQueuedPrompts || shouldQueuePromptLocally(agentSessionId)) &&
         options?.bypassLocalQueue !== true
       ) {
         queuePromptLocally(

--- a/services/tuttid/service/agent/composer_live_model_discovery.go
+++ b/services/tuttid/service/agent/composer_live_model_discovery.go
@@ -32,7 +32,7 @@ func logClaudeModelCatalogInvalidationDebug(stage string, payload map[string]any
 			"marshalError": err.Error(),
 		})
 	}
-	slog.Warn(claudeModelCatalogInvalidationDebugPrefix, "payload_json", string(encoded))
+	slog.Debug(claudeModelCatalogInvalidationDebugPrefix, "payload_json", string(encoded))
 }
 
 // claudeStartupSerializer serializes credential-touching Claude startups so that

--- a/services/tuttid/service/agent/provider_auth_watcher.go
+++ b/services/tuttid/service/agent/provider_auth_watcher.go
@@ -1,8 +1,12 @@
 package agent
 
 import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 	"sync"
 	"time"
@@ -12,11 +16,23 @@ import (
 
 const defaultProviderAuthWatchInterval = 2 * time.Second
 
+// providerAuthFileMaxContentBytes caps how much of a watched file the watcher
+// is willing to read per change when computing a content fingerprint. Files
+// larger than this fall back to mtime+size semantics.
+const providerAuthFileMaxContentBytes = 32 << 20
+
 // ProviderAuthWatchEntry describes the on-disk auth/config files whose changes
 // invalidate the cached model catalog of one provider.
 type ProviderAuthWatchEntry struct {
 	Provider string
 	Paths    []string
+	// ContentFingerprint optionally reduces a watched file's bytes to the
+	// auth-relevant fingerprint for the given path. When set, a file whose
+	// mtime/size changed only reports a provider change if this fingerprint
+	// changed too. Claude Code needs this: ~/.claude.json is the CLI's general
+	// state file and is rewritten continuously while any session runs, but its
+	// auth-relevant fields only change on a real credential switch.
+	ContentFingerprint func(path string, data []byte) string
 }
 
 // DefaultProviderAuthWatchEntries returns the auth/config marker files for the
@@ -52,22 +68,73 @@ func DefaultProviderAuthWatchEntries() []ProviderAuthWatchEntry {
 			filepath.Join(claudeConfigDir, "settings.json"),
 			filepath.Join(claudeConfigDir, "auth.json"),
 		}
+		claudeStatePath := ""
 		if home != "" {
-			claudePaths = append(claudePaths, filepath.Join(home, ".claude.json"))
+			claudeStatePath = filepath.Join(home, ".claude.json")
+			claudePaths = append(claudePaths, claudeStatePath)
 		}
 		entries = append(entries, ProviderAuthWatchEntry{
-			Provider: agentprovider.ClaudeCode,
-			Paths:    claudePaths,
+			Provider:           agentprovider.ClaudeCode,
+			Paths:              claudePaths,
+			ContentFingerprint: claudeProviderAuthContentFingerprint(claudeStatePath),
 		})
 	}
 	return entries
+}
+
+// claudeAuthRelevantStateKeys lists the top-level ~/.claude.json fields that
+// identify the active credentials. Everything else in that file (history,
+// per-project state, telemetry counters, ...) churns while a session runs and
+// must not invalidate the model catalog.
+var claudeAuthRelevantStateKeys = []string{
+	"customApiKeyResponses",
+	"oauthAccount",
+	"primaryApiKey",
+	"userID",
+}
+
+// claudeProviderAuthContentFingerprint fingerprints ~/.claude.json by its
+// auth-relevant fields only, and every other watched Claude file by its full
+// contents (so a touch that rewrites identical bytes stays quiet).
+func claudeProviderAuthContentFingerprint(
+	claudeStatePath string,
+) func(path string, data []byte) string {
+	return func(path string, data []byte) string {
+		if claudeStatePath != "" && path == claudeStatePath {
+			if fingerprint, ok := jsonSubsetFingerprint(data, claudeAuthRelevantStateKeys); ok {
+				return fingerprint
+			}
+		}
+		sum := sha256.Sum256(data)
+		return hex.EncodeToString(sum[:])
+	}
+}
+
+// jsonSubsetFingerprint hashes the raw values of the given top-level keys of a
+// JSON object. Returns false when the payload is not a JSON object.
+func jsonSubsetFingerprint(data []byte, keys []string) (string, bool) {
+	var topLevel map[string]json.RawMessage
+	if err := json.Unmarshal(data, &topLevel); err != nil {
+		return "", false
+	}
+	sorted := append([]string(nil), keys...)
+	sort.Strings(sorted)
+	hasher := sha256.New()
+	for _, key := range sorted {
+		hasher.Write([]byte(key))
+		hasher.Write([]byte{0})
+		hasher.Write(topLevel[key])
+		hasher.Write([]byte{0})
+	}
+	return hex.EncodeToString(hasher.Sum(nil)), true
 }
 
 // ProviderAuthWatcher polls provider auth/config marker files and reports the
 // providers whose files changed since the previous poll. Polling (rather than
 // fsnotify) keeps the watcher robust against atomic rename rewrites, files
 // that do not exist yet, and directories created after startup; the per-tick
-// cost is a handful of stat calls.
+// cost is a handful of stat calls (file contents are only re-read when
+// mtime/size moved).
 type ProviderAuthWatcher struct {
 	Entries  []ProviderAuthWatchEntry
 	Interval time.Duration
@@ -85,6 +152,15 @@ type providerAuthFileFingerprint struct {
 	exists  bool
 	modTime time.Time
 	size    int64
+	// contentKey is the auth-relevant content fingerprint for paths with a
+	// ContentFingerprint, "" otherwise (or when reading failed).
+	contentKey string
+}
+
+func (f providerAuthFileFingerprint) statEqual(other providerAuthFileFingerprint) bool {
+	return f.exists == other.exists &&
+		f.modTime.Equal(other.modTime) &&
+		f.size == other.size
 }
 
 // Start begins polling in a background goroutine. The first poll only records
@@ -118,7 +194,7 @@ func (w *ProviderAuthWatcher) interval() time.Duration {
 
 func (w *ProviderAuthWatcher) run() {
 	defer close(w.done)
-	fingerprints := w.collectFingerprints()
+	fingerprints := w.collectFingerprints(nil)
 	ticker := time.NewTicker(w.interval())
 	defer ticker.Stop()
 	for {
@@ -126,7 +202,7 @@ func (w *ProviderAuthWatcher) run() {
 		case <-w.stop:
 			return
 		case <-ticker.C:
-			next := w.collectFingerprints()
+			next := w.collectFingerprints(fingerprints)
 			changed := changedProviders(w.Entries, fingerprints, next)
 			fingerprints = next
 			if len(changed) > 0 {
@@ -136,17 +212,49 @@ func (w *ProviderAuthWatcher) run() {
 	}
 }
 
-func (w *ProviderAuthWatcher) collectFingerprints() map[string]providerAuthFileFingerprint {
+func (w *ProviderAuthWatcher) collectFingerprints(
+	previous map[string]providerAuthFileFingerprint,
+) map[string]providerAuthFileFingerprint {
 	fingerprints := make(map[string]providerAuthFileFingerprint)
 	for _, entry := range w.Entries {
 		for _, path := range entry.Paths {
 			if _, ok := fingerprints[path]; ok {
 				continue
 			}
-			fingerprints[path] = statProviderAuthFile(path)
+			fingerprint := statProviderAuthFile(path)
+			if entry.ContentFingerprint != nil && fingerprint.exists {
+				prev, hasPrev := previous[path]
+				if hasPrev && fingerprint.statEqual(prev) {
+					// File untouched since last poll: keep the known content key
+					// without re-reading.
+					fingerprint.contentKey = prev.contentKey
+				} else {
+					fingerprint.contentKey = readProviderAuthContentKey(
+						path,
+						fingerprint.size,
+						entry.ContentFingerprint,
+					)
+				}
+			}
+			fingerprints[path] = fingerprint
 		}
 	}
 	return fingerprints
+}
+
+func readProviderAuthContentKey(
+	path string,
+	size int64,
+	contentFingerprint func(path string, data []byte) string,
+) string {
+	if size > providerAuthFileMaxContentBytes {
+		return ""
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return ""
+	}
+	return contentFingerprint(path, data)
 }
 
 func statProviderAuthFile(path string) providerAuthFileFingerprint {
@@ -177,7 +285,7 @@ func changedProviders(
 			continue
 		}
 		for _, path := range entry.Paths {
-			if previous[path] == next[path] {
+			if !providerAuthFileChanged(previous[path], next[path]) {
 				continue
 			}
 			seen[provider] = struct{}{}
@@ -186,4 +294,13 @@ func changedProviders(
 		}
 	}
 	return changed
+}
+
+func providerAuthFileChanged(previous, next providerAuthFileFingerprint) bool {
+	// When both polls produced a content fingerprint, it alone decides: the
+	// file body churning without an auth-relevant change must stay quiet.
+	if previous.contentKey != "" && next.contentKey != "" {
+		return previous.contentKey != next.contentKey
+	}
+	return previous != next
 }

--- a/services/tuttid/service/agent/provider_auth_watcher_test.go
+++ b/services/tuttid/service/agent/provider_auth_watcher_test.go
@@ -115,6 +115,105 @@ func TestDefaultProviderAuthWatchEntriesCoverCodexAndClaude(t *testing.T) {
 	}
 }
 
+func TestProviderAuthWatcherIgnoresNonAuthClaudeStateChurn(t *testing.T) {
+	dir := t.TempDir()
+	statePath := filepath.Join(dir, ".claude.json")
+	writeState := func(content string) {
+		t.Helper()
+		if err := os.WriteFile(statePath, []byte(content), 0o600); err != nil {
+			t.Fatalf("write claude state file: %v", err)
+		}
+	}
+	writeState(`{"oauthAccount":{"emailAddress":"a@b.c"},"history":["one"]}`)
+
+	changes := make(chan []string, 8)
+	watcher := &ProviderAuthWatcher{
+		Entries: []ProviderAuthWatchEntry{
+			{
+				Provider:           agentprovider.ClaudeCode,
+				Paths:              []string{statePath},
+				ContentFingerprint: claudeProviderAuthContentFingerprint(statePath),
+			},
+		},
+		Interval: 5 * time.Millisecond,
+		OnChange: func(providers []string) {
+			changes <- providers
+		},
+	}
+	watcher.Start()
+	defer watcher.Close()
+
+	// Non-auth churn (history grows, mtime/size change) must stay quiet.
+	time.Sleep(20 * time.Millisecond)
+	writeState(`{"oauthAccount":{"emailAddress":"a@b.c"},"history":["one","two","three"]}`)
+	select {
+	case providers := <-changes:
+		t.Fatalf("watcher reported %v for non-auth state churn", providers)
+	case <-time.After(100 * time.Millisecond):
+	}
+
+	// A credential switch (oauthAccount changes) must fire.
+	writeState(`{"oauthAccount":{"emailAddress":"other@b.c"},"history":["one","two","three"]}`)
+	select {
+	case providers := <-changes:
+		if len(providers) != 1 || providers[0] != agentprovider.ClaudeCode {
+			t.Fatalf("OnChange providers = %v, want [claude-code]", providers)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("watcher did not report the credential switch")
+	}
+}
+
+func TestProviderAuthFileChangedPrefersContentKey(t *testing.T) {
+	previous := providerAuthFileFingerprint{
+		exists: true, modTime: time.UnixMilli(1000), size: 10, contentKey: "same",
+	}
+	next := providerAuthFileFingerprint{
+		exists: true, modTime: time.UnixMilli(2000), size: 99, contentKey: "same",
+	}
+	if providerAuthFileChanged(previous, next) {
+		t.Fatal("identical content keys must suppress mtime/size churn")
+	}
+	next.contentKey = "different"
+	if !providerAuthFileChanged(previous, next) {
+		t.Fatal("content key change must report")
+	}
+	// Missing content keys (no fingerprinter or read failure) keep the
+	// conservative mtime/size semantics.
+	previous.contentKey = ""
+	next.contentKey = ""
+	if !providerAuthFileChanged(previous, next) {
+		t.Fatal("stat change without content keys must report")
+	}
+}
+
+func TestJSONSubsetFingerprintTracksOnlySelectedKeys(t *testing.T) {
+	base, ok := jsonSubsetFingerprint(
+		[]byte(`{"oauthAccount":{"a":1},"history":[1,2,3]}`),
+		claudeAuthRelevantStateKeys,
+	)
+	if !ok {
+		t.Fatal("expected fingerprint for JSON object")
+	}
+	churned, ok := jsonSubsetFingerprint(
+		[]byte(`{"oauthAccount":{"a":1},"history":[1,2,3,4,5]}`),
+		claudeAuthRelevantStateKeys,
+	)
+	if !ok || churned != base {
+		t.Fatalf("non-auth churn changed fingerprint: %q vs %q", churned, base)
+	}
+	switched, ok := jsonSubsetFingerprint(
+		[]byte(`{"oauthAccount":{"a":2},"history":[1,2,3]}`),
+		claudeAuthRelevantStateKeys,
+	)
+	if !ok || switched == base {
+		t.Fatal("auth change did not change fingerprint")
+	}
+	if _, ok := jsonSubsetFingerprint([]byte(`not-json`), claudeAuthRelevantStateKeys); ok {
+		t.Fatal("expected failure for non-JSON payload")
+	}
+}
+
 func cloneFingerprints(fingerprints map[string]providerAuthFileFingerprint) map[string]providerAuthFileFingerprint {
 	cloned := make(map[string]providerAuthFileFingerprint, len(fingerprints))
 	for key, value := range fingerprints {


### PR DESCRIPTION
## 背景

对主链路做了一轮 computer-use 端到端测试（CDP 驱动真实 GUI：会话/多轮/turn 生命周期/队列/项目/provider/dock，19 个场景），发现 4 个确认问题并逐一修复，全部通过原操作序列复验。完整报告（现象/复现/根因/验证时间线）见会话 Artifact。

## 修复

**1. activity-core：过期快照覆盖更新的推送状态（2 个高严重度卡死的共同根因）**
- 现象 A：turn 运行中切走再切回会话，settle 后 composer 永久卡「停止回复」+「1 个运行中」角标不消失（30 分钟不自愈，必现）。
- 现象 B：取消 turn 时有排队消息，会话伪「运行中」卡死约 5 分钟直到 live-session reaper 兜底。
- 根因：`reconcile.state_fetch` 晚到的过期快照经 `upsertSnapshotSession` 无版本守卫覆盖了已应用的 settled state_patch（日志时间线：settle patch 17:56:26.648 应用 → 过期 upsert 17:56:26.683 覆盖）。inline patch 路径有 `isStaleStatePatch` 守卫，upsert/load 路径只上报 `session_version_regression` 不拦截。
- 修复：`upsertSnapshotSession` 与 `load()` 拒绝版本键回退的覆盖，与 inline patch 守卫对齐。+2 单测。

**2. agent-gui：显式发送与队列 drain 竞态导致消息丢失（中）**
- 现象：停止挂起队列（B 在队）后手动发 C：drain 被 `resumeQueue` 唤醒抢先直发 B，C 撞 `ErrSessionActiveTurn` 502 后被 `executePrompt` catch 删除乐观消息且不回填——C 彻底丢失。
- 修复：显式发送在队列非空时入队（保序 B→C），由 drain 串行发送；steer 的 `bypassLocalQueue` 语义不变。

**3. tuttid：provider auth watcher 误报循环 + 日志洪水（性能）**
- 现象：任何 claude 会话运行期间（CLI 持续改写 `~/.claude.json`），mtime+size 指纹每 2s 误判「凭证切换」→ catalog 失效 → 推送 → GUI 重拉循环；叠加 WARN 级调试日志 = 2.5 小时 260MB daemon 日志。
- 修复：`~/.claude.json` 改为只对 auth 相关顶层字段（oauthAccount/primaryApiKey/customApiKeyResponses/userID）做内容指纹，其余 Claude 监视文件全文哈希（mtime/size 未变不重读）；两处 WARN 调试日志降为 Debug。真实 cc-switch 凭证切换仍即时触发（有单测覆盖）。+3 单测。
- 效果：修复后失效事件零新增；流式压测渲染进程 long task 172→3。

## 验证
- 三个修复均重启环境后用原复现序列过验证脚本（verify-bugA / verify-bugBC）：PASS。
- activity-core 37/37、agent-gui 2027/2027、tuttid service/agent 全包、check:full 全绿。

## 未修复的观察项（低，见报告）
Escape 不停止 turn（疑似设计）、cancel 日志 returnedStatus 竞态、创建期 404 噪音、drain 消息缺 submit trace、排队气泡无过渡态标识。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented session state from reverting to older data when delayed updates arrive.
  * Improved prompt submission so queued prompts are handled safely and don’t race with direct sends.
  * Reduced false change notifications for auth state by ignoring unrelated file churn.
* **Chores**
  * Lowered some routine debug log noise from warning to debug level.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->