### PR TITLE
feat(agent): support active-turn guidance sends

### DIFF
--- a/apps/cli/internal/app/run_test.go
+++ b/apps/cli/internal/app/run_test.go
@@ -416,6 +416,38 @@ func TestRunDynamicAgentSendSplitsPositionalPromptBeforeImageFlags(t *testing.T)
 	}
 }
 
+func TestRunDynamicAgentSendSplitsPositionalPromptBeforeGuidanceFlag(t *testing.T) {
+	var invokedBody map[string]any
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/v1/cli/capabilities":
+			_, _ = w.Write([]byte(`{"commands":[{"id":"agent-context.agent.send","path":["agent","send"],"summary":"Send input","inputSchema":{"type":"object","required":["session-id","prompt"],"properties":{"session-id":{"type":"string"},"prompt":{"type":"string"},"guidance":{"type":"boolean"},"image":{"type":"array","items":{"type":"string"}}}},"output":{"defaultMode":"json","json":true}}]}`))
+		case "/v1/cli/commands/agent-context.agent.send/invoke":
+			if err := json.NewDecoder(r.Body).Decode(&invokedBody); err != nil {
+				t.Fatalf("decode body: %v", err)
+			}
+			_, _ = w.Write([]byte(`{"ok":true,"output":{"kind":"json","value":{"ok":true}}}`))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	writeEndpoint(t, server.URL, "token-1")
+
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	code := Run(t.Context(), []string{"agent", "send", "SESSION-1", "guide", "current", "turn", "--guidance"}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("code = %d, stderr = %s", code, stderr.String())
+	}
+	input := invokedBody["input"].(map[string]any)
+	if input["session-id"] != "SESSION-1" || input["prompt"] != "guide current turn" || input["guidance"] != true {
+		t.Fatalf("input = %#v", input)
+	}
+}
+
 func TestRunDynamicAgentSendKeepsFlagLikeTokensInPositionalPrompt(t *testing.T) {
 	var invokedBody map[string]any
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/apps/desktop/src/renderer/src/features/workspace-agent/services/desktopAgentActivityAdapter.test.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-agent/services/desktopAgentActivityAdapter.test.ts
@@ -277,6 +277,7 @@ test("desktop agent activity adapter forwards submit diagnostic metadata", async
     workspaceId,
     agentSessionId: "agent-session-1",
     content: [{ type: "text", text: "hello" }],
+    guidance: true,
     metadata: {
       clientSubmitId: "submit-1",
       clientSubmittedAtUnixMs: 1234
@@ -289,6 +290,7 @@ test("desktop agent activity adapter forwards submit diagnostic metadata", async
       request: {
         content: [{ type: "text", text: "hello" }],
         displayPrompt: null,
+        guidance: true,
         metadata: {
           clientSubmitId: "submit-1",
           clientSubmittedAtUnixMs: 1234

--- a/apps/desktop/src/renderer/src/features/workspace-agent/services/desktopAgentActivityAdapter.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-agent/services/desktopAgentActivityAdapter.ts
@@ -492,6 +492,7 @@ export function createDesktopAgentActivityAdapter({
         {
           content: toTuttidPromptContentBlocks(input.content),
           displayPrompt: input.displayPrompt ?? null,
+          ...(input.guidance === true ? { guidance: true } : {}),
           ...(input.metadata ? { metadata: input.metadata } : {})
         }
       );

--- a/docs/architecture/agent-gui-node.md
+++ b/docs/architecture/agent-gui-node.md
@@ -632,10 +632,11 @@ When an existing conversation is busy, normal composer submits may be captured
 as local queued prompts so the next turn can run after the current one settles.
 Composer guidance is different: `Cmd+Enter` on macOS, or `Ctrl+Enter` on other
 platforms, sends the draft as active-turn guidance and bypasses the local queue.
-For Codex app-server sessions this reaches `RuntimeController.Exec` while an
-active provider turn is registered, so the adapter sends `turn/steer` and emits
-a user message with `steered: true`. `Shift+Enter` remains the multiline
-composer shortcut and must not submit either a normal prompt or guidance.
+The submit request sets the daemon `guidance` flag so runtime handling can
+dispatch to provider-specific active-turn guidance without opening a normal next
+turn. Codex app-server maps this to `turn/steer`; Claude SDK maps it through the
+sidecar live prompt queue. `Shift+Enter` remains the multiline composer shortcut
+and must not submit either a normal prompt or guidance.
 
 The submit target is not just a render detail. A detail-page composer must not
 fall back to `startConversation` because a UI-local active conversation ref is

--- a/docs/conventions/tutti-cli-contract.md
+++ b/docs/conventions/tutti-cli-contract.md
@@ -128,6 +128,11 @@ such as `turnLifecycle` and `submitAvailability` when the daemon has them. Keep
 their field names aligned with the HTTP/OpenAPI session shape so CLI callers can
 reason about active turns without switching transports.
 
+`agent send --guidance` sends a one-shot prompt as active-turn guidance for an
+existing running session. It requires an active turn, does not attach to stdout
+or subscribe to session events, and must fail instead of falling back to a normal
+next-turn send when no active turn is present.
+
 Issue-manager breakdown commands should preserve authored task order in the
 daemon instead of relying on callers to serialize several single-task creates.
 Use `issue task create-batch` for multiple new child tasks. Its `tasks-json`

--- a/packages/agent/activity-core/src/types.ts
+++ b/packages/agent/activity-core/src/types.ts
@@ -297,6 +297,7 @@ export interface AgentActivitySendInput {
   content: AgentPromptContentBlock[];
   /** 仅展示用文本(bundle 折叠成一个 chip);content 仍带展开后的文件。 */
   displayPrompt?: string | null;
+  guidance?: boolean;
   metadata?: Record<string, unknown>;
   signal?: AbortSignal;
 }

--- a/packages/agent/claude-sdk-sidecar/src/main.test.ts
+++ b/packages/agent/claude-sdk-sidecar/src/main.test.ts
@@ -69,6 +69,51 @@ test("late delegated task notification keeps original parent turn id", async () 
   }
 });
 
+test("guidance prompt stays on the active SDK turn", async () => {
+  const events: Array<{ type: string; payload?: Record<string, unknown> }> = [];
+  const prompts: string[] = [];
+  const restoreSink = withSidecarEventSinkForTest((event) =>
+    events.push(event)
+  );
+  try {
+    const session = new SessionRuntime(
+      "provider-session-1",
+      "/repo",
+      {},
+      false,
+      false,
+      {
+        model: "",
+        permissionModeId: "default",
+        planMode: false,
+        effort: "",
+        speed: ""
+      },
+      sidecarClaudeOptionsFromPayload({}),
+      undefined,
+      ({ prompt }) => fakeGuidancePromptQuery(prompt, prompts)
+    );
+
+    await session.start();
+    session.exec("turn-1", "start working");
+    session.guide("prefer the focused path");
+    await waitForEvent(events, "turn_completed");
+
+    assert.deepEqual(prompts, ["start working", "prefer the focused path"]);
+    const completed = events.find((event) => event.type === "turn_completed");
+    assert.equal(completed?.payload?.turnId, "turn-1");
+    assert.equal(
+      events.some(
+        (event) =>
+          event.type === "turn_completed" && event.payload?.turnId !== "turn-1"
+      ),
+      false
+    );
+  } finally {
+    restoreSink();
+  }
+});
+
 test("delegated child result completes background agent, not mid-run child assistant messages", async () => {
   const events: Array<{ type: string; payload?: Record<string, unknown> }> = [];
   const restoreSink = withSidecarEventSinkForTest((event) =>
@@ -1785,6 +1830,68 @@ function fakeQueryWithInitializationModels(
     },
     close() {}
   };
+}
+
+function fakeGuidancePromptQuery(
+  prompt: AsyncIterable<SDKUserMessage>,
+  prompts: string[]
+): AsyncIterable<SDKMessage> {
+  return {
+    async *[Symbol.asyncIterator]() {
+      const iterator = prompt[Symbol.asyncIterator]();
+      const firstPrompt = await iterator.next();
+      const firstPromptMessage = firstPrompt.value as SDKUserMessage & {
+        uuid?: string;
+      };
+      prompts.push(userPromptText(firstPromptMessage));
+      yield {
+        ...firstPromptMessage,
+        uuid: firstPromptMessage.uuid,
+        type: "user",
+        parent_tool_use_id: null,
+        session_id: "provider-session-1"
+      } as SDKMessage;
+
+      const guidancePrompt = await iterator.next();
+      const guidancePromptMessage = guidancePrompt.value as SDKUserMessage & {
+        uuid?: string;
+      };
+      prompts.push(userPromptText(guidancePromptMessage));
+      yield {
+        ...guidancePromptMessage,
+        uuid: guidancePromptMessage.uuid,
+        type: "user",
+        parent_tool_use_id: null,
+        session_id: "provider-session-1"
+      } as SDKMessage;
+      yield consolidatedAssistant("assistant-guided", "msg-guided", [
+        { type: "text", text: "Guided response" }
+      ]);
+      yield {
+        type: "result",
+        subtype: "success"
+      } as unknown as SDKMessage;
+    },
+    close() {}
+  } as AsyncIterable<SDKMessage>;
+}
+
+function userPromptText(message: SDKUserMessage): string {
+  const content = (message as { message?: { content?: unknown } }).message
+    ?.content;
+  if (typeof content === "string") {
+    return content;
+  }
+  if (!Array.isArray(content)) {
+    return "";
+  }
+  return content
+    .map((block) =>
+      isRecord(block) && block.type === "text" && typeof block.text === "string"
+        ? block.text
+        : ""
+    )
+    .join("");
 }
 
 function fakeCompactBoundaryQuery(

--- a/packages/agent/claude-sdk-sidecar/src/main.ts
+++ b/packages/agent/claude-sdk-sidecar/src/main.ts
@@ -482,6 +482,59 @@ export class SessionRuntime {
       });
   }
 
+  guide(prompt: string, content?: unknown): void {
+    if (this.testDriver) {
+      emit({
+        type: "assistant_delta",
+        payload: {
+          turnId: this.activeTurnId,
+          content: `Echo: ${prompt}`,
+          snapshot: `Echo: ${prompt}`
+        }
+      });
+      return;
+    }
+    if (this.queryClosed) {
+      emit({
+        type: "error",
+        payload: {
+          error: "Claude SDK query is closed"
+        }
+      });
+      return;
+    }
+    void this.ensureQuery()
+      .then(() => this.applyPendingFlagSettings())
+      .then(() => {
+        const sdkContent = sdkContentFromPromptBlocks(
+          content,
+          prompt
+        ) as unknown as SDKUserMessage["message"]["content"];
+        this.promptQueue.push({
+          uuid: crypto.randomUUID(),
+          type: "user",
+          session_id: this.providerSessionId,
+          parent_tool_use_id: null,
+          message: {
+            role: "user",
+            content: sdkContent
+          }
+        } as SDKUserMessage);
+      })
+      .then(() => this.consume())
+      .catch((error) => {
+        this.logAuthRefresh("guide.ensure_query_failed", {
+          error: errorPayload(error)
+        });
+        emit({
+          type: "error",
+          payload: {
+            error: errorMessage(error)
+          }
+        });
+      });
+  }
+
   async cancel(): Promise<void> {
     if (this.queryClosed) {
       return;
@@ -2875,6 +2928,17 @@ async function handleRequest(request: RequestEnvelope): Promise<void> {
         const session = requireSession(stringValue(payload.agentSessionId));
         session.exec(
           stringValue(payload.turnId),
+          // Prefer structured content; prompt is the legacy text fallback.
+          stringValue(payload.prompt),
+          payload.content
+        );
+        emit({ id, type: "ok" });
+        return;
+      }
+      case "guide": {
+        const payload = request.payload ?? {};
+        const session = requireSession(stringValue(payload.agentSessionId));
+        session.guide(
           // Prefer structured content; prompt is the legacy text fallback.
           stringValue(payload.prompt),
           payload.content

--- a/packages/agent/daemon/runtime/adapter.go
+++ b/packages/agent/daemon/runtime/adapter.go
@@ -62,6 +62,10 @@ type AsyncExecAdapter interface {
 	ExecAsync(context.Context, Session, []PromptContentBlock, string, string, EventSink, CommandSnapshotSink) error
 }
 
+type ActiveTurnGuidanceAdapter interface {
+	GuideActiveTurn(context.Context, Session, []PromptContentBlock, string, string, EventSink, CommandSnapshotSink) ([]activityshared.Event, error)
+}
+
 type ResumeProbeAdapter interface {
 	CanResume(Session) bool
 }

--- a/packages/agent/daemon/runtime/claude_sdk_adapter.go
+++ b/packages/agent/daemon/runtime/claude_sdk_adapter.go
@@ -366,6 +366,50 @@ func (a *ClaudeCodeSDKAdapter) Exec(
 	}
 }
 
+func (a *ClaudeCodeSDKAdapter) GuideActiveTurn(
+	ctx context.Context,
+	session Session,
+	content []PromptContentBlock,
+	displayPrompt string,
+	turnID string,
+	emit EventSink,
+	_ CommandSnapshotSink,
+) ([]activityshared.Event, error) {
+	adapterSession := a.getSession(session.AgentSessionID)
+	if adapterSession == nil {
+		return nil, ErrSessionDisconnected
+	}
+	session.ProviderSessionID = adapterSession.providerSessionID
+	explicitDisplayPrompt, visibleText := explicitAndVisiblePromptText(content, displayPrompt)
+	events := []activityshared.Event{
+		newTurnActivityEvent(session, EventMessage, turnID, "", RoleUser, visibleText, userPromptActivityPayload(content, explicitDisplayPrompt, userPromptActivityPayloadExtraFromExecMetadata(ctx, map[string]any{
+			"adapter":  claudeSDKSidecarAdapterName,
+			"guidance": true,
+			"steered":  true,
+		}))),
+	}
+	if err := a.startClaudeSDKReader(session.AgentSessionID, adapterSession); err != nil {
+		return events, err
+	}
+	ctx, cancel := context.WithTimeout(ctx, claudeSDKGoalCommandTimeout)
+	defer cancel()
+	if err := a.roundTripClaudeSDK(ctx, session.AgentSessionID, adapterSession, claudeSDKSidecarRequest{
+		ID:   newID(),
+		Type: "guide",
+		Payload: map[string]any{
+			"agentSessionId": session.AgentSessionID,
+			"prompt":         promptTextForClaudeSDK(content, visibleText),
+			"content":        promptContentForClaudeSDK(content, visibleText),
+		},
+	}); err != nil {
+		return events, err
+	}
+	if emit != nil {
+		emit(events)
+	}
+	return events, nil
+}
+
 func (a *ClaudeCodeSDKAdapter) Cancel(_ context.Context, session Session, turnID string) ([]activityshared.Event, error) {
 	adapterSession := a.getSession(session.AgentSessionID)
 	if adapterSession == nil {

--- a/packages/agent/daemon/runtime/claude_sdk_adapter_test.go
+++ b/packages/agent/daemon/runtime/claude_sdk_adapter_test.go
@@ -1751,6 +1751,55 @@ func TestClaudeCodeSDKAdapterApplySessionSettingsSpeedSendsSidecarAndUpdatesRunt
 	}
 }
 
+func TestClaudeCodeSDKAdapterGuideActiveTurnSendsSidecarGuide(t *testing.T) {
+	adapter := NewClaudeCodeSDKAdapter(nil)
+	session := standardTestSession(ProviderClaudeCode)
+	conn := newBlockingClaudeSDKConnection()
+	defer conn.Close()
+	adapterSession := &claudeSDKAdapterSession{
+		conn:             conn,
+		reader:           &claudeSDKLineReader{conn: conn},
+		pendingRequests:  make(map[string]*pendingACPRequest),
+		pendingResponses: make(map[string]chan claudeSDKSidecarEvent),
+		liveState:        newClaudeSDKLiveState(),
+	}
+	adapter.storeSession(session.AgentSessionID, adapterSession)
+
+	type guidanceResult struct {
+		events []activityshared.Event
+		err    error
+	}
+	results := make(chan guidanceResult, 1)
+	go func() {
+		events, err := adapter.GuideActiveTurn(context.Background(), session, textPrompt("guide current turn"), "", "turn-guidance", nil, nil)
+		results <- guidanceResult{events: events, err: err}
+	}()
+
+	request := waitForClaudeSDKSentRequest(t, conn, "guide")
+	if _, ok := request.Payload["turnId"]; ok || request.Payload["prompt"] != "guide current turn" {
+		t.Fatalf("guide payload = %#v", request.Payload)
+	}
+	conn.pushEvent(claudeSDKSidecarEvent{ID: request.ID, Type: "ok"})
+
+	var events []activityshared.Event
+	select {
+	case result := <-results:
+		if result.err != nil {
+			t.Fatalf("GuideActiveTurn: %v", result.err)
+		}
+		events = result.events
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for GuideActiveTurn")
+	}
+	messages := eventsOfType(events, activityshared.EventMessageAppended)
+	if len(messages) != 1 {
+		t.Fatalf("guidance events = %#v, want one message", events)
+	}
+	if guidance, ok := messages[0].Payload.Metadata["guidance"].(bool); !ok || !guidance {
+		t.Fatalf("guidance metadata = %#v, want guidance=true", messages[0].Payload.Metadata)
+	}
+}
+
 func TestClaudeCodeSDKAdapterApplyPermissionModeSendsSidecar(t *testing.T) {
 	adapter := NewClaudeCodeSDKAdapter(nil)
 	session := standardTestSession(ProviderClaudeCode)

--- a/packages/agent/daemon/runtime/codex_appserver_adapter.go
+++ b/packages/agent/daemon/runtime/codex_appserver_adapter.go
@@ -1315,6 +1315,33 @@ func (a *CodexAppServerAdapter) ExecAsync(
 	return nil
 }
 
+func (a *CodexAppServerAdapter) GuideActiveTurn(
+	ctx context.Context,
+	session Session,
+	content []PromptContentBlock,
+	displayPrompt string,
+	turnID string,
+	emit EventSink,
+	_ CommandSnapshotSink,
+) ([]activityshared.Event, error) {
+	appSession := a.getSession(session.AgentSessionID)
+	if appSession == nil || appSession.client == nil {
+		return nil, ErrSessionDisconnected
+	}
+	activeTurnID := a.sessionActiveTurnID(session.AgentSessionID)
+	if activeTurnID == "" {
+		return nil, ErrSessionNoActiveTurn
+	}
+	session.ProviderSessionID = appSession.threadID
+	explicitDisplayPrompt, visibleText := explicitAndVisiblePromptText(content, displayPrompt)
+	mentionRoutingApplied, mentionRoutingSkills := tuttiMentionRoutingSkills(visibleText)
+	providerContent := content
+	if mentionRoutingApplied {
+		providerContent = appendTuttiMentionRoutingContent(providerContent, mentionRoutingSkills)
+	}
+	return a.steerActiveTurn(ctx, appSession, session, content, providerContent, explicitDisplayPrompt, visibleText, turnID, activeTurnID, emit)
+}
+
 func (appTurn *codexAppServerActiveTurn) markTerminated() {
 	appTurn.terminatedOnce.Do(func() { close(appTurn.terminated) })
 }
@@ -1719,7 +1746,8 @@ func (*CodexAppServerAdapter) steerActiveTurn(
 	}
 	events := []activityshared.Event{
 		newTurnActivityEvent(session, EventMessage, turnID, "", RoleUser, displayPrompt, userPromptActivityPayload(content, explicitDisplayPrompt, userPromptActivityPayloadExtraFromExecMetadata(ctx, map[string]any{
-			"steered": true,
+			"guidance": true,
+			"steered":  true,
 		}))),
 	}
 	if emit != nil {

--- a/packages/agent/daemon/runtime/codex_appserver_adapter_test.go
+++ b/packages/agent/daemon/runtime/codex_appserver_adapter_test.go
@@ -2086,12 +2086,54 @@ func TestCodexAppServerAdapterExecSteersActiveTurn(t *testing.T) {
 	if steered, ok := messages[0].Payload.Metadata["steered"].(bool); !ok || !steered {
 		t.Fatalf("steer message metadata = %#v, want steered=true", messages[0].Payload.Metadata)
 	}
+	if guidance, ok := messages[0].Payload.Metadata["guidance"].(bool); !ok || !guidance {
+		t.Fatalf("steer message metadata = %#v, want guidance=true", messages[0].Payload.Metadata)
+	}
 
 	transport.conn.completePendingTurn()
 	select {
 	case <-execDone:
 	case <-time.After(5 * time.Second):
 		t.Fatalf("original Exec did not finish")
+	}
+}
+
+func TestCodexAppServerAdapterGuideActiveTurnUsesTurnSteer(t *testing.T) {
+	t.Parallel()
+
+	adapter, transport, session := startedAppServerAdapter(t)
+	transport.conn.holdTurn = true
+
+	execDone := make(chan struct{})
+	go func() {
+		_, _ = adapter.Exec(context.Background(), session, textPrompt("long task"), "", "turn-local-1", nil, nil)
+		close(execDone)
+	}()
+	waitForCondition(t, func() bool {
+		return adapter.sessionActiveTurnID(session.AgentSessionID) == "turn-1"
+	})
+
+	events, err := adapter.GuideActiveTurn(context.Background(), session, textPrompt("guide current turn"), "", "turn-guidance", nil, nil)
+	if err != nil {
+		t.Fatalf("GuideActiveTurn: %v", err)
+	}
+	steer := appServerRequestParams(t, transport.conn, appServerMethodTurnSteer)
+	if asString(steer["expectedTurnId"]) != "turn-1" {
+		t.Fatalf("turn/steer params = %#v", steer)
+	}
+	messages := eventsOfType(events, activityshared.EventMessageAppended)
+	if len(messages) != 1 {
+		t.Fatalf("guidance events = %#v, want one message", events)
+	}
+	if guidance, ok := messages[0].Payload.Metadata["guidance"].(bool); !ok || !guidance {
+		t.Fatalf("guidance metadata = %#v, want guidance=true", messages[0].Payload.Metadata)
+	}
+
+	transport.conn.completePendingTurn()
+	select {
+	case <-execDone:
+	case <-time.After(5 * time.Second):
+		t.Fatalf("Exec did not finish after guidance")
 	}
 }
 

--- a/packages/agent/daemon/runtime/controller.go
+++ b/packages/agent/daemon/runtime/controller.go
@@ -620,6 +620,9 @@ func (c *Controller) Exec(ctx context.Context, input ExecInput) (ExecResult, err
 			return ExecResult{}, err
 		}
 	}
+	if input.Guidance {
+		return c.guideActiveTurn(ctx, session, adapter, content, displayPrompt, metadata)
+	}
 	turnID := newID()
 	runCtx, cancel := context.WithCancel(context.Background())
 	if len(metadata) > 0 {
@@ -659,6 +662,56 @@ func (c *Controller) Exec(ctx context.Context, input ExecInput) (ExecResult, err
 		TurnLifecycle:      *session.TurnLifecycle,
 		SubmitAvailability: *session.SubmitAvailability,
 	}, nil
+}
+
+func (c *Controller) guideActiveTurn(
+	ctx context.Context,
+	session Session,
+	adapter Adapter,
+	content []PromptContentBlock,
+	displayPrompt string,
+	metadata map[string]any,
+) (ExecResult, error) {
+	guidanceAdapter, ok := adapter.(ActiveTurnGuidanceAdapter)
+	if !ok {
+		return ExecResult{}, ErrActiveTurnGuidanceUnsupported
+	}
+	if !c.HasActiveTurn(session.RoomID, session.AgentSessionID) {
+		return ExecResult{}, ErrSessionNoActiveTurn
+	}
+	turnID := newID()
+	runCtx := ctx
+	if len(metadata) > 0 {
+		runCtx = context.WithValue(ctx, execMetadataContextKey{}, metadata)
+	}
+	events, err := guidanceAdapter.GuideActiveTurn(runCtx, session, content, displayPrompt, turnID, nil, nil)
+	if err != nil {
+		logAgentSubmitTrace("runtime.exec.guidance_failed", session, turnID, metadata, map[string]any{
+			"error": err.Error(),
+		})
+		return ExecResult{}, err
+	}
+	c.applySessionEventsByAgentSessionID(session.AgentSessionID, events)
+	logAgentSubmitTrace("runtime.exec.guidance", session, turnID, metadata, map[string]any{
+		"activity_event_count": len(events),
+	})
+	if refreshed, ok := c.get(session.RoomID, session.AgentSessionID); ok {
+		session = refreshed
+	}
+	result := ExecResult{
+		AgentSessionID: session.AgentSessionID,
+		Status:         ExecStatusStarted,
+		TurnID:         turnID,
+		Accepted:       true,
+		SessionStatus:  session.Status,
+	}
+	if session.TurnLifecycle != nil {
+		result.TurnLifecycle = *session.TurnLifecycle
+	}
+	if session.SubmitAvailability != nil {
+		result.SubmitAvailability = *session.SubmitAvailability
+	}
+	return result, nil
 }
 
 type GoalControlInput struct {

--- a/packages/agent/daemon/runtime/controller_test.go
+++ b/packages/agent/daemon/runtime/controller_test.go
@@ -1016,6 +1016,114 @@ func TestControllerExecRejectsPromptDuringActiveTurn(t *testing.T) {
 	waitForSessionStatus(t, controller, "room-1", started.Session.AgentSessionID, SessionStatusReady)
 }
 
+func TestControllerExecGuidanceDuringActiveTurn(t *testing.T) {
+	t.Parallel()
+
+	adapter := &guidanceBlockingAdapter{blockingExecAdapter: newBlockingExecAdapter()}
+	controller := NewController([]Adapter{adapter}, nil)
+	ctx := context.Background()
+
+	started, err := controller.Start(ctx, StartInput{
+		RoomID:         "room-1",
+		AgentSessionID: "agent-session-1",
+		Provider:       ProviderCodex,
+		CWD:            "/workspace",
+		Title:          "Codex",
+	})
+	if err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	if _, err := controller.Exec(ctx, ExecInput{
+		RoomID:         started.Session.RoomID,
+		AgentSessionID: started.Session.AgentSessionID,
+		Content:        textPrompt("first prompt"),
+	}); err != nil {
+		t.Fatalf("first Exec: %v", err)
+	}
+	adapter.waitForPrompt(t, "first prompt")
+
+	result, err := controller.Exec(ctx, ExecInput{
+		RoomID:         started.Session.RoomID,
+		AgentSessionID: started.Session.AgentSessionID,
+		Content:        textPrompt("guide current turn"),
+		Guidance:       true,
+	})
+	if err != nil {
+		t.Fatalf("guidance Exec: %v", err)
+	}
+	if !result.Accepted || result.TurnID == "" {
+		t.Fatalf("guidance result = %#v, want accepted turn id", result)
+	}
+	if got := adapter.guidanceCalls.Load(); got != 1 {
+		t.Fatalf("guidance calls = %d, want 1", got)
+	}
+	if prompts := adapter.prompts(); len(prompts) != 1 || prompts[0] != "first prompt" {
+		t.Fatalf("adapter prompts after guidance = %#v, want only first prompt running", prompts)
+	}
+
+	adapter.releaseNext()
+	waitForSessionStatus(t, controller, "room-1", started.Session.AgentSessionID, SessionStatusReady)
+}
+
+func TestControllerExecGuidanceRequiresActiveTurn(t *testing.T) {
+	t.Parallel()
+
+	adapter := &guidanceBlockingAdapter{blockingExecAdapter: newBlockingExecAdapter()}
+	controller := NewController([]Adapter{adapter}, nil)
+	started, err := controller.Start(context.Background(), StartInput{
+		RoomID:         "room-1",
+		AgentSessionID: "agent-session-1",
+		Provider:       ProviderCodex,
+		Title:          "Codex",
+	})
+	if err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	if _, err := controller.Exec(context.Background(), ExecInput{
+		RoomID:         started.Session.RoomID,
+		AgentSessionID: started.Session.AgentSessionID,
+		Content:        textPrompt("guide without active turn"),
+		Guidance:       true,
+	}); !errors.Is(err, ErrSessionNoActiveTurn) {
+		t.Fatalf("guidance without active turn error = %v, want %v", err, ErrSessionNoActiveTurn)
+	}
+}
+
+func TestControllerExecGuidanceRequiresProviderSupport(t *testing.T) {
+	t.Parallel()
+
+	adapter := newBlockingExecAdapter()
+	controller := NewController([]Adapter{adapter}, nil)
+	ctx := context.Background()
+	started, err := controller.Start(ctx, StartInput{
+		RoomID:         "room-1",
+		AgentSessionID: "agent-session-1",
+		Provider:       ProviderCodex,
+		Title:          "Codex",
+	})
+	if err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	if _, err := controller.Exec(ctx, ExecInput{
+		RoomID:         started.Session.RoomID,
+		AgentSessionID: started.Session.AgentSessionID,
+		Content:        textPrompt("first prompt"),
+	}); err != nil {
+		t.Fatalf("first Exec: %v", err)
+	}
+	adapter.waitForPrompt(t, "first prompt")
+	if _, err := controller.Exec(ctx, ExecInput{
+		RoomID:         started.Session.RoomID,
+		AgentSessionID: started.Session.AgentSessionID,
+		Content:        textPrompt("guide unsupported provider"),
+		Guidance:       true,
+	}); !errors.Is(err, ErrActiveTurnGuidanceUnsupported) {
+		t.Fatalf("unsupported guidance error = %v, want %v", err, ErrActiveTurnGuidanceUnsupported)
+	}
+	adapter.releaseNext()
+	waitForSessionStatus(t, controller, "room-1", started.Session.AgentSessionID, SessionStatusReady)
+}
+
 func TestControllerCancelCancelsActiveTurnContextWhenAdapterReturnsNoEvents(t *testing.T) {
 	t.Parallel()
 
@@ -2601,6 +2709,25 @@ type blockingExecAdapter struct {
 	releases            chan struct{}
 	provider            string
 	interactiveOptionID string
+}
+
+type guidanceBlockingAdapter struct {
+	*blockingExecAdapter
+	guidanceCalls atomic.Int64
+}
+
+func (a *guidanceBlockingAdapter) GuideActiveTurn(_ context.Context, session Session, content []PromptContentBlock, _ string, turnID string, emit EventSink, _ CommandSnapshotSink) ([]activityshared.Event, error) {
+	a.guidanceCalls.Add(1)
+	events := []activityshared.Event{
+		newTurnActivityEvent(session, EventMessage, turnID, "", RoleUser, promptDisplayText(content), userPromptActivityPayload(content, "", map[string]any{
+			"guidance": true,
+			"steered":  true,
+		})),
+	}
+	if emit != nil {
+		emit(events)
+	}
+	return events, nil
 }
 
 func newBlockingExecAdapter() *blockingExecAdapter {

--- a/packages/agent/daemon/runtime/errors.go
+++ b/packages/agent/daemon/runtime/errors.go
@@ -8,8 +8,9 @@ const (
 )
 
 var (
-	ErrSessionDisconnected = errors.New("agent session is not connected")
-	ErrSessionNoActiveTurn = errors.New("agent session has no active turn")
+	ErrSessionDisconnected           = errors.New("agent session is not connected")
+	ErrSessionNoActiveTurn           = errors.New("agent session has no active turn")
+	ErrActiveTurnGuidanceUnsupported = errors.New("agent provider does not support active-turn guidance")
 )
 
 type AppError struct {

--- a/packages/agent/daemon/runtime/types.go
+++ b/packages/agent/daemon/runtime/types.go
@@ -102,6 +102,7 @@ type ExecInput struct {
 	Content        []PromptContentBlock
 	DisplayPrompt  string
 	Metadata       map[string]any
+	Guidance       bool
 }
 
 type CancelInput struct {

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUINodeController.spec.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUINodeController.spec.tsx
@@ -16265,6 +16265,7 @@ describe("useAgentGUINodeController", () => {
       expect(exec).toHaveBeenCalledWith({
         workspaceId: "room-1",
         agentSessionId: "session-1",
+        guidance: true,
         ...promptContent("steer the current turn")
       });
     });
@@ -18033,7 +18034,8 @@ function installAgentActivityRuntimeForHostMocks({
       const result = await exec({
         workspaceId: input.workspaceId,
         agentSessionId: input.agentSessionId,
-        content: input.content
+        content: input.content,
+        ...(input.guidance === true ? { guidance: true } : {})
       });
       const status =
         typeof result?.sessionStatus === "string"

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUINodeController.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUINodeController.ts
@@ -4426,7 +4426,8 @@ export function useAgentGUINodeController({
     (
       agentSessionId: string,
       content: AgentPromptContentBlock[],
-      displayPrompt?: string
+      displayPrompt?: string,
+      options?: { guidance?: boolean }
     ) => void
   >(() => {});
   const reloadSelectedConversationRef = useRef<
@@ -8142,7 +8143,8 @@ export function useAgentGUINodeController({
     (
       agentSessionId: string,
       content: AgentPromptContentBlock[],
-      displayPrompt?: string
+      displayPrompt?: string,
+      options?: { guidance?: boolean }
     ) => {
       const normalizedContent = normalizeAgentPromptContentBlocks(content);
       if (!agentSessionId || normalizedContent.length === 0) {
@@ -8272,6 +8274,7 @@ export function useAgentGUINodeController({
             content: normalizedContent,
             displayPrompt:
               displayPrompt && displayPrompt.trim() ? displayPrompt : null,
+            ...(options?.guidance === true ? { guidance: true } : {}),
             metadata: agentSubmitTraceMetadata(submitTrace)
           });
         })
@@ -8516,7 +8519,7 @@ export function useAgentGUINodeController({
       agentSessionId: string,
       normalizedContent: AgentPromptContentBlock[],
       displayPromptText?: string,
-      options?: { bypassLocalQueue?: boolean }
+      options?: { bypassLocalQueue?: boolean; guidance?: boolean }
     ) => {
       if (isSessionMarkedNonResumable(agentSessionId)) {
         setDetailError(
@@ -8552,7 +8555,9 @@ export function useAgentGUINodeController({
         );
         return;
       }
-      executePrompt(agentSessionId, normalizedContent, displayPromptText);
+      executePrompt(agentSessionId, normalizedContent, displayPromptText, {
+        guidance: options?.guidance === true
+      });
     },
     [
       activation,
@@ -8710,7 +8715,7 @@ export function useAgentGUINodeController({
         agentSessionId,
         normalizedContent,
         displayPromptText,
-        { bypassLocalQueue: true }
+        { bypassLocalQueue: true, guidance: true }
       );
     },
     [

--- a/packages/clients/tuttid-ts/src/generated/types.gen.ts
+++ b/packages/clients/tuttid-ts/src/generated/types.gen.ts
@@ -1432,6 +1432,10 @@ export type SendWorkspaceAgentSessionInputRequest = {
    */
   displayPrompt?: string | null;
   /**
+   * When true, send this input as guidance to the currently active turn instead of starting a new turn.
+   */
+  guidance?: boolean;
+  /**
    * Optional client-provided diagnostic metadata, such as submit trace ids. This metadata is not provider prompt content.
    */
   metadata?: {

--- a/services/tuttid/agent_runtime_adapter.go
+++ b/services/tuttid/agent_runtime_adapter.go
@@ -101,6 +101,7 @@ func (a agentRuntimeAdapter) Exec(ctx context.Context, input agentservice.Runtim
 		AgentSessionID: input.AgentSessionID,
 		Content:        runtimePromptContentFromService(input.Content),
 		DisplayPrompt:  input.DisplayPrompt,
+		Guidance:       input.Guidance,
 		Metadata:       cloneRuntimeContext(input.Metadata),
 	})
 	if err != nil {
@@ -462,6 +463,12 @@ func mapAgentRuntimeError(err error) error {
 	}
 	if errors.Is(err, agentruntime.ErrSessionNotFound) {
 		return agentservice.ErrSessionNotFound
+	}
+	if errors.Is(err, agentruntime.ErrSessionNoActiveTurn) {
+		return agentservice.ErrSessionNoActiveTurn
+	}
+	if errors.Is(err, agentruntime.ErrActiveTurnGuidanceUnsupported) {
+		return agentservice.ErrActiveTurnGuidanceUnsupported
 	}
 	if errors.Is(err, agentruntime.ErrSessionSettingsRequireNewSession) {
 		return agentservice.ErrSessionSettingsRequireNewSession

--- a/services/tuttid/api/daemon_agent_submit_handlers.go
+++ b/services/tuttid/api/daemon_agent_submit_handlers.go
@@ -92,6 +92,7 @@ func (api DaemonAPI) SendWorkspaceAgentSessionInput(ctx context.Context, request
 	result, err := api.AgentSessionService.SendInput(ctx, string(request.WorkspaceID), string(request.AgentSessionID), agentservice.SendInput{
 		Content:       agentPromptContentFromGenerated(request.Body.Content),
 		DisplayPrompt: stringPtrValue(request.Body.DisplayPrompt),
+		Guidance:      request.Body.Guidance != nil && *request.Body.Guidance,
 		Metadata:      metadata,
 	})
 	if err != nil {

--- a/services/tuttid/api/daemon_test.go
+++ b/services/tuttid/api/daemon_test.go
@@ -81,6 +81,7 @@ type stubAgentSessionService struct {
 	listMessagesFn                  func(context.Context, string, string, agentservice.ListMessagesInput) (agentservice.SessionMessagesPage, error)
 	readAttachmentFn                func(context.Context, string, string, string) (agentservice.PromptAttachment, error)
 	scanExternalFn                  func(context.Context, agentservice.ExternalImportScanInput) (agentservice.ExternalImportScanResult, error)
+	sendInputFn                     func(context.Context, string, string, agentservice.SendInput) (agentservice.SendInputResult, error)
 	listGitBranchesFn               func(context.Context, string, string) (agentservice.GitBranches, error)
 	listGitBranchesForPathFn        func(context.Context, string, string) (agentservice.GitBranches, error)
 	resolveGitPatchSupportForPathFn func(context.Context, string, string) (agentservice.GitPatchSupport, error)
@@ -334,7 +335,10 @@ func (stubAgentSessionService) GoalControl(context.Context, string, string, stri
 	return agentservice.GoalControlSessionResult{}, nil
 }
 
-func (stubAgentSessionService) SendInput(context.Context, string, string, agentservice.SendInput) (agentservice.SendInputResult, error) {
+func (s stubAgentSessionService) SendInput(ctx context.Context, workspaceID string, agentSessionID string, input agentservice.SendInput) (agentservice.SendInputResult, error) {
+	if s.sendInputFn != nil {
+		return s.sendInputFn(ctx, workspaceID, agentSessionID, input)
+	}
 	return agentservice.SendInputResult{}, nil
 }
 
@@ -675,6 +679,54 @@ func TestDaemonAPIGeneratedRoutesListAgentSessionsForwardsQuery(t *testing.T) {
 		http.MethodGet,
 		"/v1/workspaces/ws-1/agent-sessions?searchQuery=mention&limit=30",
 		nil,
+	)
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d; body: %s", recorder.Code, http.StatusOK, recorder.Body.String())
+	}
+}
+
+func TestDaemonAPIGeneratedRoutesSendAgentSessionInputForwardsGuidance(t *testing.T) {
+	mux := http.NewServeMux()
+	updatedAt := time.UnixMilli(1000)
+	RegisterRoutes(mux, NewRoutes(DaemonAPI{
+		AgentSessionService: stubAgentSessionService{
+			sendInputFn: func(_ context.Context, workspaceID string, agentSessionID string, input agentservice.SendInput) (agentservice.SendInputResult, error) {
+				if workspaceID != "ws-1" || agentSessionID != "agent-session-1" {
+					t.Fatalf("workspace/session = %q/%q", workspaceID, agentSessionID)
+				}
+				if !input.Guidance {
+					t.Fatal("input guidance = false, want true")
+				}
+				if len(input.Content) != 1 || input.Content[0].Text != "guide current turn" {
+					t.Fatalf("input content = %#v", input.Content)
+				}
+				return agentservice.SendInputResult{
+					Session: agentservice.Session{
+						ID:        agentSessionID,
+						Provider:  "codex",
+						Status:    "working",
+						Visible:   true,
+						CreatedAt: time.UnixMilli(1000),
+						UpdatedAt: &updatedAt,
+					},
+					TurnID: "turn-guidance",
+				}, nil
+			},
+		},
+	}))
+
+	recorder := performGeneratedRouteRequest(
+		t,
+		mux,
+		http.MethodPost,
+		"/v1/workspaces/ws-1/agent-sessions/agent-session-1/input",
+		map[string]any{
+			"content": []map[string]any{{
+				"type": "text",
+				"text": "guide current turn",
+			}},
+			"guidance": true,
+		},
 	)
 	if recorder.Code != http.StatusOK {
 		t.Fatalf("status = %d, want %d; body: %s", recorder.Code, http.StatusOK, recorder.Body.String())

--- a/services/tuttid/api/generated/types.gen.go
+++ b/services/tuttid/api/generated/types.gen.go
@@ -3161,6 +3161,9 @@ type SendWorkspaceAgentSessionInputRequest struct {
 	// DisplayPrompt Optional display-only text shown in the conversation (e.g. a folder bundle rendered as one chip while content carries the expanded files).
 	DisplayPrompt *string `json:"displayPrompt,omitempty"`
 
+	// Guidance When true, send this input as guidance to the currently active turn instead of starting a new turn.
+	Guidance *bool `json:"guidance,omitempty"`
+
 	// Metadata Optional client-provided diagnostic metadata, such as submit trace ids. This metadata is not provider prompt content.
 	Metadata *map[string]interface{} `json:"metadata,omitempty"`
 }

--- a/services/tuttid/api/openapi/tuttid.v1.yaml
+++ b/services/tuttid/api/openapi/tuttid.v1.yaml
@@ -6926,6 +6926,9 @@ components:
           type: string
           nullable: true
           description: Optional display-only text shown in the conversation (e.g. a folder bundle rendered as one chip while content carries the expanded files).
+        guidance:
+          type: boolean
+          description: When true, send this input as guidance to the currently active turn instead of starting a new turn.
         metadata:
           type: object
           additionalProperties: true

--- a/services/tuttid/apierrors/apierrors.go
+++ b/services/tuttid/apierrors/apierrors.go
@@ -413,6 +413,10 @@ func Classify(err error) *ProtocolError {
 		return InvalidRequest(ReasonMalformedRequest, WithCause(err))
 	case errors.Is(err, agentservice.ErrPromptImageUnsupported):
 		return InvalidRequest("agent.prompt_image_unsupported", WithCause(err))
+	case errors.Is(err, agentservice.ErrSessionNoActiveTurn):
+		return InvalidRequest("agent.no_active_turn", WithCause(err))
+	case errors.Is(err, agentservice.ErrActiveTurnGuidanceUnsupported):
+		return InvalidRequest("agent.active_turn_guidance_unsupported", WithCause(err))
 	case errors.Is(err, agentservice.ErrSessionNotFound):
 		return WorkspaceNotFound(ReasonWorkspaceAgentSessionNotFound, WithCause(err))
 	case errors.Is(err, agentservice.ErrSessionSettingsRequireNewSession):

--- a/services/tuttid/service/agent/service.go
+++ b/services/tuttid/service/agent/service.go
@@ -17,7 +17,9 @@ import (
 
 var (
 	ErrInvalidArgument                  = errors.New("invalid agent session request")
+	ErrActiveTurnGuidanceUnsupported    = errors.New("agent provider does not support active-turn guidance")
 	ErrPromptImageUnsupported           = errors.New("agent prompt image input is unsupported")
+	ErrSessionNoActiveTurn              = errors.New("agent session has no active turn")
 	ErrSessionNotFound                  = errors.New("workspace agent session not found")
 	ErrSkillBundleUnavailable           = errors.New("agent skill bundle renderer is unavailable")
 	ErrSessionSettingsRequireNewSession = errors.New("agent session settings update requires a new session to preserve context")

--- a/services/tuttid/service/agent/service_send_input.go
+++ b/services/tuttid/service/agent/service_send_input.go
@@ -62,6 +62,7 @@ func (s *Service) SendInput(ctx context.Context, workspaceID string, agentSessio
 			AgentSessionID: agentSessionID,
 			Content:        content,
 			DisplayPrompt:  displayPrompt,
+			Guidance:       input.Guidance,
 			Metadata:       cloneMetadata(input.Metadata),
 		})
 	}()

--- a/services/tuttid/service/agent/service_test.go
+++ b/services/tuttid/service/agent/service_test.go
@@ -2080,6 +2080,7 @@ func TestServiceSendInputPassesDisplayPromptToRuntime(t *testing.T) {
 	_, err := service.SendInput(context.Background(), "ws-1", "session-1", SendInput{
 		Content:       TextPromptContent("real repair prompt"),
 		DisplayPrompt: "Fix the app",
+		Guidance:      true,
 		Metadata: map[string]any{
 			"clientSubmitId":             "submit-1",
 			"clientSubmittedAtUnixMs":    int64(1234),
@@ -2099,6 +2100,9 @@ func TestServiceSendInputPassesDisplayPromptToRuntime(t *testing.T) {
 	}
 	if call.DisplayPrompt != "Fix the app" {
 		t.Fatalf("runtime display prompt = %q", call.DisplayPrompt)
+	}
+	if !call.Guidance {
+		t.Fatal("runtime guidance = false, want true")
 	}
 	if call.Metadata["clientSubmitId"] != "submit-1" ||
 		call.Metadata["clientSubmittedAtUnixMs"] != int64(1234) ||

--- a/services/tuttid/service/agent/session_types.go
+++ b/services/tuttid/service/agent/session_types.go
@@ -301,6 +301,7 @@ type RuntimeExecInput struct {
 	Content        []PromptContentBlock
 	DisplayPrompt  string
 	Metadata       map[string]any
+	Guidance       bool
 }
 
 type RuntimeExecResult struct {
@@ -433,6 +434,7 @@ type SendInput struct {
 	Content       []PromptContentBlock
 	DisplayPrompt string
 	Metadata      map[string]any
+	Guidance      bool
 }
 
 type SendInputResult struct {

--- a/services/tuttid/service/cli/providers/agentcontext/provider_test.go
+++ b/services/tuttid/service/cli/providers/agentcontext/provider_test.go
@@ -1511,6 +1511,7 @@ func TestSendCommandConvertsImageFilesToPromptContentBlocks(t *testing.T) {
 
 	output, err := command.Handler(context.Background(), cliservice.InvokeRequest{
 		Input: map[string]any{
+			"guidance":   true,
 			"image":      []any{imagePath},
 			"prompt":     "continue with this",
 			"session-id": "SESSION-1",
@@ -1523,6 +1524,9 @@ func TestSendCommandConvertsImageFilesToPromptContentBlocks(t *testing.T) {
 	if output.Rows[0]["id"] != "SESSION-1" || sessions.workspaceID != "workspace-1" || sessions.sessionID != "SESSION-1" {
 		t.Fatalf("output = %#v sessions = %#v", output.Rows, sessions)
 	}
+	if !sessions.sendInput.Guidance {
+		t.Fatalf("send guidance = false, want true")
+	}
 	content := sessions.sendInput.Content
 	if len(content) != 2 {
 		t.Fatalf("send content = %#v, want text + image", content)
@@ -1533,6 +1537,29 @@ func TestSendCommandConvertsImageFilesToPromptContentBlocks(t *testing.T) {
 	decoded, err := base64.StdEncoding.DecodeString(content[1].Data)
 	if err != nil || string(decoded) != "webp-bytes" {
 		t.Fatalf("image block data decoded = %q err=%v", string(decoded), err)
+	}
+}
+
+func TestSendCommandExposesGuidanceFlagInSchema(t *testing.T) {
+	command := NewProvider(
+		fakeWorkspaceCatalog{startup: workspacebiz.Summary{ID: "workspace-1"}},
+		&fakeAgentSessions{},
+	).newSendCommand()
+
+	properties, ok := command.Capability.InputSchema["properties"].(map[string]any)
+	if !ok {
+		t.Fatalf("input schema properties = %#v", command.Capability.InputSchema["properties"])
+	}
+	guidance, ok := properties["guidance"].(map[string]any)
+	if !ok {
+		t.Fatalf("guidance schema = %#v", properties["guidance"])
+	}
+	if guidance["type"] != "boolean" {
+		t.Fatalf("guidance type = %#v, want boolean", guidance["type"])
+	}
+	description, _ := guidance["description"].(string)
+	if !strings.Contains(description, "currently active turn") {
+		t.Fatalf("guidance description = %#v", guidance["description"])
 	}
 }
 

--- a/services/tuttid/service/cli/providers/agentcontext/session_commands.go
+++ b/services/tuttid/service/cli/providers/agentcontext/session_commands.go
@@ -57,6 +57,7 @@ type sessionIDInput struct {
 
 type sendInput struct {
 	SessionID string   `cli:"session-id" validate:"required"`
+	Guidance  bool     `cli:"guidance" description:"Send this prompt as guidance to the currently active turn instead of starting a new turn."`
 	Images    []string `cli:"image" description:"Image file to attach to this prompt. May be passed multiple times."`
 	Prompt    string   `cli:"prompt" validate:"required"`
 }
@@ -291,7 +292,7 @@ func (p Provider) newSendCommand() cliservice.Command {
 		ID:          appID + ".agent.send",
 		Path:        []string{"agent", "send"},
 		Summary:     "Send input to an agent session",
-		Description: "Send user input to an existing agent session.",
+		Description: "Send user input to an existing agent session. Use --guidance to guide the currently active turn without attaching to output.",
 		Kind:        framework.KindAction,
 		Workspace:   framework.WorkspaceRequired,
 		Workspaces:  p.workspaces,
@@ -310,7 +311,8 @@ func (p Provider) runSend(ctx context.Context, invoke framework.InvokeContext, i
 		return nil, err
 	}
 	result, err := p.sessions.SendInput(ctx, invoke.WorkspaceID, input.SessionID, agentservice.SendInput{
-		Content: content,
+		Content:  content,
+		Guidance: input.Guidance,
 	})
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
## Summary
- add `guidance` support to agent session input so CLI and AgentGUI can steer an active turn without starting a normal new turn
- route active-turn guidance through Codex steering and Claude SDK sidecar `guide` requests
- forward GUI guidance submissions through the desktop activity adapter and document the CLI/AgentGUI behavior

## Validation
- `pnpm check:full`
- `make dev-gui` smoke test for Codex and Claude active-turn guidance
- targeted AgentGUI controller, desktop adapter, Claude sidecar, and runtime tests during development

## Notes
- Claude dev-gui smoke testing needs the local sidecar entry override when the installed Tutti app sidecar is older: `TUTTI_CLAUDE_SDK_SIDECAR_ENTRY_PATH=/Users/ccr/tsh-project/tutti-2/packages/agent/claude-sdk-sidecar/src/main.ts make dev-gui`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a `--guidance` option to `agent send` so prompts can be sent to the currently active turn instead of starting a new one.
  * Guidance requests now flow through the desktop, CLI, API, and agent runtime so the behavior is consistent across surfaces.

* **Bug Fixes**
  * Improved handling for guidance prompts so positional prompt text is parsed correctly before the `--guidance` flag.
  * Added clearer errors when guidance is used without an active turn or when the provider doesn’t support it.

* **Documentation**
  * Updated guidance-related docs and command details to describe the new behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->