### PR TITLE
refactor(issue-manager): remove unused reference picker shim

### DIFF
--- a/packages/workspace/issue-manager/src/ui/react/internal/reference/useIssueManagerReferencePickerView.ts
+++ b/packages/workspace/issue-manager/src/ui/react/internal/reference/useIssueManagerReferencePickerView.ts
@@ -1,5 +1,0 @@
-export {
-  useWorkspaceFileReferencePickerView as useIssueManagerReferencePickerView,
-  type UseWorkspaceFileReferencePickerViewInput as UseIssueManagerReferencePickerViewInput,
-  type WorkspaceFileReferencePreviewState as IssueManagerReferencePreviewState
-} from "@tutti-os/workspace-file-reference/react";


### PR DESCRIPTION
## Summary

- Remove the unused internal `useIssueManagerReferencePickerView` re-export shim.
- Keep the public `src/ui/react/index.ts` export unchanged; it already re-exports the picker hook directly from `@tutti-os/workspace-file-reference/react`.

## Why this is safe

- The removed file was only a five-line internal re-export shim.
- Repo search after deletion only finds the public `src/ui/react/index.ts` re-export; no code imports the deleted internal path.
- `@tutti-os/workspace-issue-manager` package exports, publish exports, and tsup entries do not expose this internal file.
- Latest published `@tutti-os/workspace-issue-manager@0.0.65` only exposes formal `dist` subpaths; `npm pack --dry-run` shows no source internal path in the tarball.
- Local `/Users/ccr/tsh-project/tsh` exact search found no usage of `useIssueManagerReferencePickerView` or the deleted internal path through `@tutti-os/workspace-issue-manager`.
- GitHub code search under `tutti-os` for `@tutti-os/workspace-issue-manager` plus this hook/internal path returned no matches.

## Validation

- `pnpm --filter @tutti-os/workspace-issue-manager typecheck`
- `pnpm --filter @tutti-os/workspace-issue-manager test`
- `pnpm --filter @tutti-os/workspace-issue-manager build`
- `pnpm check:changed` attempted; all relevant lanes passed, but `lint:changed` fails on this deletion-only change with `No files found to lint`.
- `pnpm check:full`
- pre-push `pnpm check:full`

## Docs

No documentation impact: this removes a private, unreferenced internal shim only. Self-evolution decision: `discard`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified the issue manager reference picker’s public interface by removing several re-exports.
  * This may affect integrations that imported those reference picker types or components directly from this module.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->