### PR TITLE
refactor(agent-daemon): remove legacy message sanitize helper

### DIFF
--- a/packages/agent/daemon/activity/client.go
+++ b/packages/agent/daemon/activity/client.go
@@ -1,5 +1,4 @@
 //revive:disable:file-length-limit
-//nolint:unused // Retain migrated helpers until the next agent-daemon decomposition pass.
 package agentsessionstore
 
 import (
@@ -621,21 +620,6 @@ func sanitizeStatePatchesForUpstream(patches []WorkspaceAgentStatePatch) []Works
 			out[i].Entities[j].Output = sanitizeToolPayloadMap(entity.Output)
 			out[i].Entities[j].Error = sanitizeToolPayloadMap(entity.Error)
 		}
-	}
-	return out
-}
-
-func sanitizeMessageUpdatesForUpstream(updates []WorkspaceAgentMessageUpdate) []WorkspaceAgentMessageUpdate {
-	if len(updates) == 0 {
-		return updates
-	}
-	out := make([]WorkspaceAgentMessageUpdate, len(updates))
-	for i, update := range updates {
-		out[i] = update
-		if len(update.Payload) == 0 {
-			continue
-		}
-		out[i].Payload = sanitizeToolPayloadMap(clonePayloadMap(update.Payload))
 	}
 	return out
 }


### PR DESCRIPTION
## Summary
- remove the private `sanitizeMessageUpdatesForUpstream` helper left behind after the legacy activity message upload path was removed
- remove the now-unused `nolint:unused` directive from `activity/client.go`

## Why this is unused
- `sanitizeMessageUpdatesForUpstream` was only for legacy `WorkspaceAgentMessageUpdate` payload sanitization on the old coarse activity report path.
- Current message uploads go through `ReportSessionMessages`, which uses `sanitizeSessionMessageUpdatesForUpstream` instead.
- The helper is unexported, so published `github.com/tutti-os/tutti/packages/agent/daemon` consumers cannot call it.
- `rg` across this repo found no remaining references after deletion. The local `/Users/ccr/tsh-project/tsh` repo only has its own copied private definition, not a call into this package.

## Validation
- `rg -n "sanitizeMessageUpdatesForUpstream" packages/agent/daemon services/tuttid apps/cli /Users/ccr/tsh-project/tsh -g "*.go"`
- `go test ./activity/...` from `packages/agent/daemon`
- `go test ./...` from `packages/agent/daemon`
- `go build ./...` from `packages/agent/daemon`
- `pnpm check:changed`
- `pnpm check:full`

## Documentation impact
No durable documentation impact: this removes a private unused helper and does not change public API, CLI behavior, runtime config, user-visible behavior, or module ownership.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Cleaned up internal message-processing code and removed an unused directive. No user-facing behavior changes are expected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->