### PR TITLE
feat(agent-gui): add exact provider-rail mode

### DIFF
--- a/apps/desktop/src/renderer/src/features/workspace-agent/ui/DesktopAgentGUIWorkbenchBody.tsx
+++ b/apps/desktop/src/renderer/src/features/workspace-agent/ui/DesktopAgentGUIWorkbenchBody.tsx
@@ -15,6 +15,8 @@ import type {
   AgentActivityRuntime,
   AgentQueuedPromptRuntime,
   AgentGUIProvider,
+  AgentGUIProviderRailMode,
+  AgentGUIProviderRailEmptyRenderer,
   AgentGUIProviderReadinessGateAction,
   AgentGUIProviderTarget,
   AgentGUIProps,
@@ -108,6 +110,10 @@ interface DesktopAgentGUIWorkbenchBodyProps {
   previewMode?: boolean;
   providerTargets?: readonly AgentGUIProviderTarget[];
   providerTargetsLoading?: boolean;
+  /** "exact" renders only the provided targets (no static catalog). Defaults to "catalog". */
+  providerRailMode?: AgentGUIProviderRailMode;
+  /** Host-owned empty state for the provider rail in "exact" mode. */
+  renderProviderRailEmpty?: AgentGUIProviderRailEmptyRenderer;
   comingSoonAgentProviders?: readonly AgentGUIProvider[];
   defaultProviderTargetId?: string | null;
   contextMentionProviders: NonNullable<
@@ -187,6 +193,8 @@ function areDesktopAgentGUIWorkbenchBodyPropsEqual(
     previous.previewMode === next.previewMode &&
     previous.providerTargets === next.providerTargets &&
     previous.providerTargetsLoading === next.providerTargetsLoading &&
+    previous.providerRailMode === next.providerRailMode &&
+    previous.renderProviderRailEmpty === next.renderProviderRailEmpty &&
     previous.comingSoonAgentProviders === next.comingSoonAgentProviders &&
     previous.defaultProviderTargetId === next.defaultProviderTargetId &&
     previous.contextMentionProviders === next.contextMentionProviders &&
@@ -250,6 +258,8 @@ function DesktopAgentGUIWorkbenchBodyImpl({
   previewMode = false,
   providerTargets,
   providerTargetsLoading = false,
+  providerRailMode = "catalog",
+  renderProviderRailEmpty,
   comingSoonAgentProviders,
   defaultProviderTargetId = null,
   contextMentionProviders,
@@ -1114,6 +1124,8 @@ function DesktopAgentGUIWorkbenchBodyImpl({
         nodeId={context.node.id}
         providerTargets={providerTargetsLoading ? [] : providerTargets}
         providerTargetsLoading={providerTargetsLoading}
+        providerRailMode={providerRailMode}
+        renderProviderRailEmpty={renderProviderRailEmpty}
         comingSoonProviders={comingSoonAgentProviders}
         providerReadinessGates={providerReadinessGates}
         defaultProviderTargetId={defaultProviderTargetId}

--- a/apps/desktop/src/renderer/src/features/workspace-workbench/services/internal/contributions/agentGuiWorkbenchContributionFactory.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/services/internal/contributions/agentGuiWorkbenchContributionFactory.ts
@@ -21,6 +21,8 @@ export const agentGuiWorkbenchContributionFactory: DesktopWorkbenchContributionF
         onCapabilitySettingsRequest: context.onCapabilitySettingsRequest,
         providerTargets: context.providerTargets,
         providerTargetsLoading: context.providerTargetsLoading,
+        providerRailMode: context.providerRailMode,
+        renderProviderRailEmpty: context.renderProviderRailEmpty,
         comingSoonAgentProviders: context.comingSoonAgentProviders,
         tuttidClient: context.tuttidClient,
         platformApi: context.platformApi,

--- a/apps/desktop/src/renderer/src/features/workspace-workbench/services/internal/workspaceAgentGuiContribution.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/services/internal/workspaceAgentGuiContribution.ts
@@ -1,6 +1,8 @@
 import { createElement, type CSSProperties, type ReactNode } from "react";
 import type {
   AgentGUIProvider,
+  AgentGUIProviderRailMode,
+  AgentGUIProviderRailEmptyRenderer,
   AgentGUIProviderTarget
 } from "@tutti-os/agent-gui";
 import { resolveAgentGuiSessionProviderIconUrl } from "@tutti-os/agent-gui/agentGuiSessionProviderIconUrls";
@@ -72,6 +74,10 @@ export function createWorkspaceAgentGuiContribution(input: {
   >[0]["onCapabilitySettingsRequest"];
   providerTargets?: readonly AgentGUIProviderTarget[];
   providerTargetsLoading?: boolean;
+  /** "exact" renders only the provided targets (no static catalog). Defaults to "catalog". */
+  providerRailMode?: AgentGUIProviderRailMode;
+  /** Host-owned empty state for the provider rail in "exact" mode. */
+  renderProviderRailEmpty?: AgentGUIProviderRailEmptyRenderer;
   comingSoonAgentProviders?: readonly AgentGUIProvider[];
   tuttidClient: TuttidClient;
   platformApi: Pick<
@@ -154,6 +160,8 @@ export function createWorkspaceAgentGuiContribution(input: {
       previewMode: options?.previewMode,
       providerTargets: input.providerTargets,
       providerTargetsLoading: input.providerTargetsLoading,
+      providerRailMode: input.providerRailMode,
+      renderProviderRailEmpty: input.renderProviderRailEmpty,
       comingSoonAgentProviders: input.comingSoonAgentProviders,
       defaultProviderTargetId: input.defaultProviderTargetId,
       contextMentionProviders:

--- a/apps/desktop/src/renderer/src/features/workspace-workbench/services/internal/workspaceWorkbenchContributionFactory.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/services/internal/workspaceWorkbenchContributionFactory.ts
@@ -1,6 +1,8 @@
 import type { ReactNode } from "react";
 import type {
   AgentGUIProvider,
+  AgentGUIProviderRailMode,
+  AgentGUIProviderRailEmptyRenderer,
   AgentGUIProviderTarget
 } from "@tutti-os/agent-gui";
 import type {
@@ -65,6 +67,10 @@ export interface DesktopWorkbenchContributionContext {
   ) => void;
   providerTargets?: readonly AgentGUIProviderTarget[];
   providerTargetsLoading?: boolean;
+  /** "exact" renders only the provided targets (no static catalog). Defaults to "catalog". */
+  providerRailMode?: AgentGUIProviderRailMode;
+  /** Host-owned empty state for the provider rail in "exact" mode. */
+  renderProviderRailEmpty?: AgentGUIProviderRailEmptyRenderer;
   comingSoonAgentProviders?: readonly AgentGUIProvider[];
   agentProviderStatusService: AgentProviderStatusService;
   workspaceFileManagerService: IWorkspaceFileManagerService;

--- a/packages/agent/gui/agent-gui/agentGuiNode/AgentGUINode.spec.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/AgentGUINode.spec.tsx
@@ -7166,6 +7166,7 @@ function createViewModel(
     selectedProviderTarget: createLocalAgentGUIProviderTarget("codex"),
     providerTargets: [createLocalAgentGUIProviderTarget("codex")],
     providerTargetsLoading: false,
+    providerRailMode: "catalog",
     comingSoonProviders: [],
     conversations: [],
     userProjects: [],

--- a/packages/agent/gui/agent-gui/agentGuiNode/AgentGUINode.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/AgentGUINode.tsx
@@ -22,6 +22,7 @@ import type { WorkspaceLinkAction } from "../../actions/workspaceLinkActions";
 import type {
   AgentGUINodeData,
   AgentGUIProvider,
+  AgentGUIProviderRailMode,
   AgentGUIProviderReadinessGate,
   AgentGUIProviderTarget,
   NodeFrame,
@@ -47,6 +48,7 @@ import {
   AgentGUINodeView,
   type AgentGUIViewLabels,
   type AgentGUISidebarFooterContext,
+  type AgentGUIProviderRailEmptyRenderer,
   type AgentMentionReferenceTargetResolver,
   type AgentWorkspaceReferenceInitialTargetResolver
 } from "./AgentGUINodeView";
@@ -192,6 +194,14 @@ export interface AgentGUINodeProps {
   onAgentProviderLogin?: (provider: AgentProvider) => void;
   providerTargets?: readonly AgentGUIProviderTarget[];
   providerTargetsLoading?: boolean;
+  /**
+   * Controls how the provider rail composes its list. "catalog" (default) adds
+   * the static local catalog + placeholders + coming-soon; "exact" renders only
+   * the provided targets and shows `renderProviderRailEmpty` when empty.
+   */
+  providerRailMode?: AgentGUIProviderRailMode;
+  /** Host-owned empty state for the provider rail in "exact" mode. */
+  renderProviderRailEmpty?: AgentGUIProviderRailEmptyRenderer;
   renderSidebarFooter?: (ctx: AgentGUISidebarFooterContext) => ReactNode;
   comingSoonProviders?: readonly AgentGUIProvider[];
   providerReadinessGates?: Partial<
@@ -573,6 +583,8 @@ function areAgentGUINodePropsEqual(
     previous.providerTargets === next.providerTargets &&
     previous.providerTargetsLoading === next.providerTargetsLoading &&
     previous.renderSidebarFooter === next.renderSidebarFooter &&
+    previous.providerRailMode === next.providerRailMode &&
+    previous.renderProviderRailEmpty === next.renderProviderRailEmpty &&
     previous.comingSoonProviders === next.comingSoonProviders &&
     previous.providerReadinessGates === next.providerReadinessGates &&
     previous.defaultProviderTargetId === next.defaultProviderTargetId &&
@@ -631,6 +643,8 @@ export const AgentGUINode = memo(function AgentGUINode({
   onAgentProviderLogin,
   providerTargets,
   providerTargetsLoading = false,
+  providerRailMode = "catalog",
+  renderProviderRailEmpty,
   renderSidebarFooter,
   comingSoonProviders,
   providerReadinessGates = null,
@@ -805,6 +819,7 @@ export const AgentGUINode = memo(function AgentGUINode({
     prefillPromptRequest,
     providerTargets,
     providerTargetsLoading,
+    providerRailMode,
     comingSoonProviders,
     providerReadinessGates,
     defaultProviderTargetId,
@@ -1682,6 +1697,7 @@ export const AgentGUINode = memo(function AgentGUINode({
           <AgentGUINodeView
             viewModel={viewModel}
             renderSidebarFooter={renderSidebarFooter}
+            renderProviderRailEmpty={renderProviderRailEmpty}
             actions={viewActions}
             isActive={isActive}
             composerFocusRequestSequence={composerFocusRequestSequence}

--- a/packages/agent/gui/agent-gui/agentGuiNode/AgentGUINodeView.layout.spec.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/AgentGUINodeView.layout.spec.tsx
@@ -1071,6 +1071,103 @@ describe("AgentGUINodeView layout persistence", () => {
     ]);
   });
 
+  it("renders exactly the provided targets in exact rail mode", () => {
+    renderAgentGUINodeView({
+      viewModel: {
+        ...createViewModel(),
+        providerRailMode: "exact",
+        providerTargets: [
+          {
+            targetId: "shared-agent:alice-codex",
+            provider: "codex",
+            ref: {
+              kind: "shared-agent",
+              provider: "codex",
+              sharedAgentId: "alice-codex"
+            },
+            label: "Alice's Codex"
+          },
+          {
+            targetId: "shared-agent:bob-claude",
+            provider: "claude-code",
+            ref: {
+              kind: "shared-agent",
+              provider: "claude-code",
+              sharedAgentId: "bob-claude"
+            },
+            label: "Bob's Claude"
+          }
+        ],
+        providerTargetsLoading: false
+      }
+    });
+
+    // "All" tile + exactly the two shared agents — no placeholders, no padding.
+    expect(
+      screen.getAllByRole("tab").map((tab) => tab.getAttribute("aria-label"))
+    ).toEqual(["All", "Alice's Codex", "Bob's Claude"]);
+    expect(screen.queryByRole("tab", { name: "Cursor" })).toBeNull();
+    expect(screen.queryByRole("tab", { name: "Hermes" })).toBeNull();
+  });
+
+  it("preserves the host-provided target order in exact rail mode", () => {
+    renderAgentGUINodeView({
+      viewModel: {
+        ...createViewModel(),
+        providerRailMode: "exact",
+        // claude-code first, then codex — the built-in provider order would flip
+        // these; exact mode must keep the caller's order.
+        providerTargets: [
+          {
+            targetId: "shared-agent:bob-claude",
+            provider: "claude-code",
+            ref: {
+              kind: "shared-agent",
+              provider: "claude-code",
+              sharedAgentId: "bob-claude"
+            },
+            label: "Bob's Claude"
+          },
+          {
+            targetId: "shared-agent:alice-codex",
+            provider: "codex",
+            ref: {
+              kind: "shared-agent",
+              provider: "codex",
+              sharedAgentId: "alice-codex"
+            },
+            label: "Alice's Codex"
+          }
+        ],
+        providerTargetsLoading: false
+      }
+    });
+
+    expect(
+      screen.getAllByRole("tab").map((tab) => tab.getAttribute("aria-label"))
+    ).toEqual(["All", "Bob's Claude", "Alice's Codex"]);
+  });
+
+  it("renders the host empty state in exact rail mode when no targets are provided", () => {
+    renderAgentGUINodeView({
+      viewModel: {
+        ...createViewModel(),
+        providerRailMode: "exact",
+        providerTargets: [],
+        providerTargetsLoading: false
+      },
+      renderProviderRailEmpty: () => (
+        <div data-testid="exact-rail-empty">No shared agents</div>
+      )
+    });
+
+    expect(screen.getByTestId("exact-rail-empty")).toBeInTheDocument();
+    // No static local catalog fallback.
+    expect(screen.queryByRole("tab", { name: "Codex" })).toBeNull();
+    expect(screen.queryByRole("tab", { name: "Cursor" })).toBeNull();
+    expect(screen.queryByRole("tab", { name: "All" })).toBeNull();
+  });
+
   it("keeps the provider rail to the default agent tiles for static provider catalogs", () => {
     renderAgentGUINodeView({
       viewModel: {
@@ -3818,6 +3915,7 @@ interface RenderAgentGUINodeViewOptions {
   labels?: AgentGUIViewLabels;
   onOpenConversationWindow?: AgentGUINodeViewProps["onOpenConversationWindow"];
   renderSidebarFooter?: AgentGUINodeViewProps["renderSidebarFooter"];
+  renderProviderRailEmpty?: AgentGUINodeViewProps["renderProviderRailEmpty"];
   slashStatusLimits?: AgentGUINodeViewProps["slashStatusLimits"];
 }
 
@@ -3834,6 +3932,7 @@ function buildAgentGUINodeViewElement({
   labels = createLabels(),
   onOpenConversationWindow,
   renderSidebarFooter,
+  renderProviderRailEmpty,
   slashStatusLimits = []
 }: RenderAgentGUINodeViewOptions = {}) {
   return (
@@ -3841,6 +3940,7 @@ function buildAgentGUINodeViewElement({
       <AgentGUINodeView
         viewModel={viewModel}
         renderSidebarFooter={renderSidebarFooter}
+        renderProviderRailEmpty={renderProviderRailEmpty}
         onLinkAction={onLinkAction}
         isActive={isActive}
         isAgentProviderReady={isAgentProviderReady}
@@ -4118,6 +4218,7 @@ function createViewModel(
     selectedProviderTarget: createLocalAgentGUIProviderTarget("codex"),
     providerTargets: [createLocalAgentGUIProviderTarget("codex")],
     providerTargetsLoading: false,
+    providerRailMode: "catalog",
     comingSoonProviders: [],
     conversationFilter: { kind: "all" },
     conversations: [],

--- a/packages/agent/gui/agent-gui/agentGuiNode/AgentGUINodeView.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/AgentGUINodeView.tsx
@@ -547,6 +547,8 @@ export interface AgentGUIViewLabels {
 interface AgentGUINodeViewProps {
   viewModel: AgentGUINodeViewModel;
   renderSidebarFooter?: AgentGUISidebarFooterRenderer;
+  /** Renders the provider rail empty state in "exact" mode. See the type doc. */
+  renderProviderRailEmpty?: AgentGUIProviderRailEmptyRenderer;
   onLinkAction?: (action: WorkspaceLinkAction) => void;
   onHandoffConversation?: (input: {
     agentTargetId?: string | null;
@@ -997,9 +999,18 @@ export type AgentGUISidebarFooterRenderer = (
   ctx: AgentGUISidebarFooterContext
 ) => ReactNode;
 
+/**
+ * Renders the provider rail body when the rail is in "exact" mode and the
+ * host-provided target list is empty (and not loading). Lets the host fully own
+ * the empty state (e.g. a "no shared agents" message or a create-agent prompt)
+ * instead of the library falling back to the static local catalog.
+ */
+export type AgentGUIProviderRailEmptyRenderer = () => ReactNode;
+
 export function AgentGUINodeView({
   viewModel,
   renderSidebarFooter,
+  renderProviderRailEmpty,
   onLinkAction,
   onHandoffConversation,
   capabilityMenuState,
@@ -1605,6 +1616,8 @@ export function AgentGUINodeView({
               selectedProviderTarget={viewModel.selectedProviderTarget}
               providerTargets={viewModel.providerTargets}
               providerTargetsLoading={viewModel.providerTargetsLoading}
+              providerRailMode={viewModel.providerRailMode}
+              renderProviderRailEmpty={renderProviderRailEmpty}
               comingSoonProviders={viewModel.comingSoonProviders}
               onSelectConversationFilterTarget={
                 actions.selectConversationFilterTarget
@@ -4619,10 +4632,16 @@ function agentGUIProviderTargetMatchesConversationFilter(
 function agentGUIProviderRailTargets(
   providerTargets: AgentGUINodeViewModel["providerTargets"],
   providerTargetsLoading: boolean,
-  comingSoonProviders: AgentGUINodeViewModel["comingSoonProviders"]
+  comingSoonProviders: AgentGUINodeViewModel["comingSoonProviders"],
+  providerRailMode: AgentGUINodeViewModel["providerRailMode"]
 ): AgentGUINodeViewModel["providerTargets"] {
   if (providerTargetsLoading) {
     return [];
+  }
+  // Exact mode renders precisely the provided targets — no backfilling to the
+  // default provider catalog, no local/placeholder padding.
+  if (providerRailMode === "exact") {
+    return providerTargets;
   }
   const comingSoon = new Set(comingSoonProviders);
   const source =
@@ -4671,6 +4690,8 @@ interface AgentGUIProviderRailProps {
   selectedProviderTarget: AgentGUINodeViewModel["selectedProviderTarget"];
   providerTargets: AgentGUINodeViewModel["providerTargets"];
   providerTargetsLoading: AgentGUINodeViewModel["providerTargetsLoading"];
+  providerRailMode: AgentGUINodeViewModel["providerRailMode"];
+  renderProviderRailEmpty?: AgentGUIProviderRailEmptyRenderer;
   comingSoonProviders: AgentGUINodeViewModel["comingSoonProviders"];
   onRequestComposerFocus: () => void;
   onSelectConversationFilterTarget: AgentGUINodeViewProps["actions"]["selectConversationFilterTarget"];
@@ -4686,6 +4707,8 @@ const AgentGUIProviderRail = memo(function AgentGUIProviderRail({
   selectedProviderTarget,
   providerTargets,
   providerTargetsLoading,
+  providerRailMode,
+  renderProviderRailEmpty,
   comingSoonProviders,
   onRequestComposerFocus,
   onSelectConversationFilterTarget,
@@ -4697,12 +4720,23 @@ const AgentGUIProviderRail = memo(function AgentGUIProviderRail({
       agentGUIProviderRailTargets(
         providerTargets,
         providerTargetsLoading,
-        comingSoonProviders
+        comingSoonProviders,
+        providerRailMode
       ),
-    [comingSoonProviders, providerTargets, providerTargetsLoading]
+    [
+      comingSoonProviders,
+      providerRailMode,
+      providerTargets,
+      providerTargetsLoading
+    ]
   );
   const providerTiles = useMemo(() => {
     const targets = [...railProviderTargets];
+    // Exact mode is host-orchestrated: preserve the caller's order verbatim
+    // (the built-in provider order would otherwise reshuffle across providers).
+    if (providerRailMode === "exact") {
+      return targets;
+    }
     const originalIndexByTarget = new Map<string, number>();
     targets.forEach((target, index) => {
       originalIndexByTarget.set(
@@ -4725,7 +4759,7 @@ const AgentGUIProviderRail = memo(function AgentGUIProviderRail({
         ) ?? 0)
       );
     });
-  }, [railProviderTargets]);
+  }, [providerRailMode, railProviderTargets]);
   const selectedProviderTargetIsPlaceholder =
     selectedProviderTarget?.disabled === true;
   const allTileSelected =
@@ -4760,6 +4794,27 @@ const AgentGUIProviderRail = memo(function AgentGUIProviderRail({
     },
     [onRequestComposerFocus, onSelectConversationFilterTarget]
   );
+
+  // Exact mode with no targets (and not loading): hand the rail body to the
+  // host-provided empty renderer instead of the static local catalog fallback.
+  if (
+    providerRailMode === "exact" &&
+    !providerTargetsLoading &&
+    providerTiles.length === 0 &&
+    renderProviderRailEmpty
+  ) {
+    return (
+      <div
+        className={styles.providerRail}
+        role="tablist"
+        aria-label={labels.providerSwitchLabel}
+        aria-busy={providerTargetsLoading}
+        data-empty="true"
+      >
+        {renderProviderRailEmpty()}
+      </div>
+    );
+  }
 
   return (
     <div

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUINodeController.spec.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUINodeController.spec.tsx
@@ -2882,6 +2882,77 @@ describe("useAgentGUINodeController", () => {
     expect(result.current.viewModel.providerTargets.length).toBeGreaterThan(1);
   });
 
+  it("renders exactly the provided targets in exact rail mode (no placeholders or catalog padding)", () => {
+    installAgentHostApi({
+      list: vi.fn(async () => ({ presences: [], sessions: [] })),
+      listSessionTimeline: vi.fn(async () => ({ timelineItems: [] })),
+      subscribeEvents: vi.fn(() => vi.fn())
+    });
+
+    const { result } = renderHook(() =>
+      useAgentGUINodeController({
+        workspaceId: "room-1",
+        currentUserId: "user-1",
+        workspacePath: "/workspace",
+        avoidGroupingEdits: false,
+        data: agentGuiData(null),
+        providerRailMode: "exact",
+        providerTargets: [
+          {
+            targetId: "shared-agent:alice-codex",
+            provider: "codex",
+            ref: {
+              kind: "shared-agent",
+              provider: "codex",
+              sharedAgentId: "alice-codex"
+            },
+            label: "Alice's Codex"
+          },
+          {
+            targetId: "shared-agent:bob-claude",
+            provider: "claude-code",
+            ref: {
+              kind: "shared-agent",
+              provider: "claude-code",
+              sharedAgentId: "bob-claude"
+            },
+            label: "Bob's Claude"
+          }
+        ],
+        onDataChange: vi.fn()
+      })
+    );
+
+    expect(result.current.viewModel.providerRailMode).toBe("exact");
+    expect(
+      result.current.viewModel.providerTargets.map((target) => target.targetId)
+    ).toEqual(["shared-agent:alice-codex", "shared-agent:bob-claude"]);
+  });
+
+  it("keeps the provider rail empty in exact mode when no targets are provided", () => {
+    installAgentHostApi({
+      list: vi.fn(async () => ({ presences: [], sessions: [] })),
+      listSessionTimeline: vi.fn(async () => ({ timelineItems: [] })),
+      subscribeEvents: vi.fn(() => vi.fn())
+    });
+
+    const { result } = renderHook(() =>
+      useAgentGUINodeController({
+        workspaceId: "room-1",
+        currentUserId: "user-1",
+        workspacePath: "/workspace",
+        avoidGroupingEdits: false,
+        data: agentGuiData(null),
+        providerRailMode: "exact",
+        providerTargets: [],
+        onDataChange: vi.fn()
+      })
+    );
+
+    expect(result.current.viewModel.providerRailMode).toBe("exact");
+    expect(result.current.viewModel.providerTargets).toEqual([]);
+  });
+
   it("sends fallback local agent target ids without provider target refs when provider targets are omitted", async () => {
     const activate = vi.fn(
       async (input: AgentHostActivateAgentSessionInput) => ({

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUINodeController.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUINodeController.ts
@@ -55,6 +55,7 @@ import { AGENT_PROVIDER_LABEL } from "../../../contexts/settings/domain/agentSet
 import type {
   AgentGUINodeData,
   AgentGUIProvider,
+  AgentGUIProviderRailMode,
   AgentGUIProviderReadinessGate,
   AgentGUIProviderTarget
 } from "../../../types";
@@ -3642,6 +3643,12 @@ interface UseAgentGUINodeControllerInput {
   data: AgentGUINodeData;
   providerTargets?: readonly AgentGUIProviderTarget[];
   providerTargetsLoading?: boolean;
+  /**
+   * Controls how the provider rail composes its list. Defaults to "catalog"
+   * (static local catalog + placeholders + coming-soon). Use "exact" to render
+   * only the provided targets with no static injection or fallback.
+   */
+  providerRailMode?: AgentGUIProviderRailMode;
   /** Providers gated by the host (feature-gated) — rendered as coming-soon placeholders. */
   comingSoonProviders?: readonly AgentGUIProvider[];
   providerReadinessGates?: Partial<
@@ -3686,6 +3693,7 @@ export function useAgentGUINodeController({
   data,
   providerTargets,
   providerTargetsLoading = false,
+  providerRailMode = "catalog",
   comingSoonProviders,
   providerReadinessGates = null,
   defaultProviderTargetId = null,
@@ -3707,24 +3715,31 @@ export function useAgentGUINodeController({
         : emptyComingSoonProviders,
     [comingSoonProviders]
   );
-  const normalizedExplicitProviderTargets = useMemo(
-    () =>
-      applyComingSoonProviderTargets(
-        normalizeAgentGUIProviderTargets(providerTargets, {
-          includeDisabledPlaceholders: true,
-          useStaticCatalog: false
-        }),
-        normalizedComingSoonProviders
-      ),
-    [normalizedComingSoonProviders, providerTargets]
-  );
+  const isExactProviderRailMode = providerRailMode === "exact";
+  const normalizedExplicitProviderTargets = useMemo(() => {
+    // Exact mode: render precisely the provided targets — no disabled
+    // placeholders (nexight/hermes/openclaw) and no coming-soon markers.
+    const normalized = normalizeAgentGUIProviderTargets(providerTargets, {
+      includeDisabledPlaceholders: !isExactProviderRailMode,
+      useStaticCatalog: false
+    });
+    return isExactProviderRailMode
+      ? normalized
+      : applyComingSoonProviderTargets(
+          normalized,
+          normalizedComingSoonProviders
+        );
+  }, [isExactProviderRailMode, normalizedComingSoonProviders, providerTargets]);
   const normalizedProviderTargets = useMemo(() => {
     if (providerTargetsLoading) {
       return [];
     }
+    // Exact mode never falls back to the static local catalog — an empty list
+    // stays empty so the host can render its own empty state.
     if (
-      providerTargets === undefined ||
-      normalizedExplicitProviderTargets.length === 0
+      !isExactProviderRailMode &&
+      (providerTargets === undefined ||
+        normalizedExplicitProviderTargets.length === 0)
     ) {
       return applyComingSoonProviderTargets(
         normalizeAgentGUIProviderTargets(null, {
@@ -3735,12 +3750,14 @@ export function useAgentGUINodeController({
     }
     return normalizedExplicitProviderTargets;
   }, [
+    isExactProviderRailMode,
     normalizedExplicitProviderTargets,
     normalizedComingSoonProviders,
     providerTargets,
     providerTargetsLoading
   ]);
   const shouldUseStaticProviderTargets =
+    !isExactProviderRailMode &&
     !providerTargetsLoading &&
     (providerTargets === undefined ||
       normalizedExplicitProviderTargets.length === 0);
@@ -11604,6 +11621,7 @@ export function useAgentGUINodeController({
         selectedProviderTarget: effectiveSelectedProviderTarget,
         providerTargets: normalizedProviderTargets,
         providerTargetsLoading,
+        providerRailMode,
         comingSoonProviders: normalizedComingSoonProviders,
         conversationFilter,
         conversations: visibleConversations,
@@ -11680,6 +11698,7 @@ export function useAgentGUINodeController({
       effectiveSelectedProviderTarget,
       normalizedComingSoonProviders,
       normalizedProviderTargets,
+      providerRailMode,
       providerReadinessGate,
       providerTargetsLoading,
       detailError,

--- a/packages/agent/gui/agent-gui/agentGuiNode/model/agentGuiNodeTypes.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/model/agentGuiNodeTypes.ts
@@ -2,6 +2,7 @@ import type { AgentActivityUsage } from "@tutti-os/agent-activity-core";
 import type {
   AgentGUINodeData,
   AgentGUIProvider,
+  AgentGUIProviderRailMode,
   AgentGUIProviderReadinessGate,
   AgentGUIProviderTarget
 } from "../../../types";
@@ -171,6 +172,8 @@ export interface AgentGUINodeViewModel {
   selectedProviderTarget: AgentGUIProviderTarget;
   providerTargets: readonly AgentGUIProviderTarget[];
   providerTargetsLoading: boolean;
+  /** How the rail composes its list — "exact" renders targets verbatim with no static injection. */
+  providerRailMode: AgentGUIProviderRailMode;
   /** Providers gated by the host (feature-gated) — rail renders coming-soon placeholders. */
   comingSoonProviders: readonly AgentGUIProvider[];
   conversationFilter: AgentGUIConversationFilter;

--- a/packages/agent/gui/index.ts
+++ b/packages/agent/gui/index.ts
@@ -27,6 +27,7 @@ export {
 } from "./providerTargets";
 export type {
   AgentGUIProvider,
+  AgentGUIProviderRailMode,
   AgentGUIProviderReadinessGate,
   AgentGUIProviderReadinessGateAction,
   AgentGUIProviderReadinessGateStatus,
@@ -45,6 +46,7 @@ export {
   shouldAutoCollapseAgentGUIConversationRail
 } from "./agent-gui/agentGuiNode/model/agentGuiRailLayout";
 export type {
+  AgentGUIProviderRailEmptyRenderer,
   AgentGUISidebarFooterContext,
   AgentGUISidebarFooterRenderer
 } from "./agent-gui/agentGuiNode/AgentGUINodeView";

--- a/packages/agent/gui/types.ts
+++ b/packages/agent/gui/types.ts
@@ -94,6 +94,20 @@ export interface AgentGUIProviderTarget {
   unavailableReason?: string;
 }
 
+/**
+ * How the provider rail composes the target list.
+ * - "catalog" (default): host-provided targets are augmented with the static
+ *   local provider catalog, disabled placeholders (nexight/hermes/openclaw),
+ *   and coming-soon markers. When no targets are provided, the full local
+ *   catalog is shown.
+ * - "exact": the rail renders exactly the provided targets — no static catalog
+ *   fallback, no disabled placeholders, no coming-soon injection. When the list
+ *   is empty (and not loading) the host-provided empty renderer is shown. Use
+ *   this when the list is fully orchestrated externally (e.g. shared agents,
+ *   custom /agents).
+ */
+export type AgentGUIProviderRailMode = "catalog" | "exact";
+
 export type AgentGUIProviderReadinessGateStatus =
   | "checking"
   | "coming_soon"


### PR DESCRIPTION
## What

Adds an opt-in **`providerRailMode: "exact"`** to `AgentGUI` so a host can render **precisely the provider targets it passes in** — no static local catalog, no disabled placeholders (`nexight`/`hermes`/`openclaw`), no coming-soon injection. When the list is empty (and not loading), a host-provided **`renderProviderRailEmpty`** slot is shown instead of the local-catalog fallback.

Default mode is `"catalog"` — **fully backward-compatible**, zero change to existing windows.

This unblocks the externally-orchestrated **shared-agent rail** (render only the room's real shared agents) and the future **custom `/agents`** lists rendered on the left.

## Why the fix touches two sites

The rail was injected from **two** places, not one. Fixing only the controller would not have produced an exact list:

1. **Controller** (`useAgentGUINodeController`) — `includeDisabledPlaceholders` + static-catalog fallback.
2. **View layer** (`agentGUIProviderRailTargets`) — silently **padded the rail back up to the full default provider set** regardless of what the controller produced.

`"exact"` mode bypasses both, skips coming-soon injection, and **preserves the host's target order verbatim** (the built-in provider-order sort is skipped — otherwise `[claude-code, codex]` would render flipped).

## Threading

`providerRailMode` + `renderProviderRailEmpty` flow end-to-end through the desktop workbench registry so a host can actually opt in:

`DesktopWorkbenchContributionContext` → `agentGuiWorkbenchContributionFactory` → `createWorkspaceAgentGuiContribution` → `DesktopAgentGUIWorkbenchBody` → `AgentGUI` → `AgentGUINode` → controller/view → `AgentGUIProviderRail`.

All new props are optional and default to `"catalog"`.

## Tests

New `vitest` coverage (controller + view):
- 2 shared targets in exact mode → rail shows **exactly 2** (no placeholders/padding).
- 0 targets, not loading → **host empty state**, no local-catalog fallback.
- Host-provided **order is preserved** in exact mode.

## Verification

- `@tutti-os/agent-gui` + `@tutti-os/desktop` typecheck: **clean**.
- New exact-mode tests: **pass**.
- Reviewed by Codex (gpt-5.5, high reasoning); both findings (order reordering + incomplete desktop passthrough) confirmed and fixed in this PR.

> Note: local `lint:go` couldn't run (`golangci-lint` not installed on the dev machine); this change is TS-only, so CI runs the full Go/TS suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for more flexible provider rail rendering, including exact provider lists and custom empty-state/footer content.
  * Improved session and activity records to carry user identity information end to end.

* **Bug Fixes**
  * Provider rail lists now preserve the intended order and avoid unexpected fallback items in exact mode.
  * Active peer listings now correctly identify the current user and no longer show unavailable-self warnings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->