### PR TITLE
refactor(agent-daemon): remove unused standard acp helpers

### DIFF
--- a/packages/agent/daemon/runtime/standard_acp_adapter.go
+++ b/packages/agent/daemon/runtime/standard_acp_adapter.go
@@ -1,5 +1,4 @@
 //revive:disable:file-length-limit
-//nolint:unused // Retain migrated helpers until the next agent-daemon decomposition pass.
 package agentruntime
 
 import (
@@ -2803,13 +2802,6 @@ func (a *standardACPAdapter) applyACPUpdate(agentSessionID string, raw json.RawM
 	return applyACPUpdateToLiveState(&session.acpLiveState, agentSessionID, raw)
 }
 
-func standardProviderSessionID(session *standardACPSession) string {
-	if session == nil {
-		return ""
-	}
-	return session.providerSessionID
-}
-
 func (a *standardACPAdapter) storePendingApproval(pending *pendingACPApproval) {
 	if a == nil || pending == nil {
 		return
@@ -3338,15 +3330,6 @@ func standardACPClaudeMetaString(value map[string]any, key string) string {
 	meta := payloadMap(value, "_meta")
 	claudeCode := payloadMap(meta, "claudeCode")
 	return strings.TrimSpace(asString(claudeCode[key]))
-}
-
-func isTerminalACPToolStatus(status string) bool {
-	switch normalizedCallStatus(status) {
-	case messageStreamStateCompleted, messageStreamStateFailed:
-		return true
-	default:
-		return false
-	}
 }
 
 func shouldIgnoreStandardACPTitle(config standardACPConfig, currentTitle string, title string) bool {


### PR DESCRIPTION
## Summary
- remove two unexported standard ACP helper wrappers that have no remaining call sites
- remove the now-unused `nolint:unused` directive from `standard_acp_adapter.go`

## Historical role
- `standardProviderSessionID` was a defensive accessor around `standardACPSession.providerSessionID`; the current adapter reads and propagates provider session IDs directly from the live session state.
- `isTerminalACPToolStatus` wrapped `normalizedCallStatus` to classify completed/failed ACP tool statuses; current tool/turn terminal handling uses the ACP tool normalizer and direct normalized status checks instead.
- Git history shows both helpers have existed since the open-source initialization of the standard ACP adapter, with no later call-site additions.

## Reverification
- Both functions are unexported private Go helpers, so published `github.com/tutti-os/tutti/packages/agent/daemon` consumers cannot call them.
- `rg -n "standardProviderSessionID|isTerminalACPToolStatus" packages/agent/daemon services/tuttid apps/cli packages/agent/store-sqlite packages/workspace /Users/ccr/tsh-project/tsh -g "*.go"` returns no hits after deletion.
- `/Users/ccr/tsh-project/tsh` depends on the published agent daemon module, but it has no same-name usage and cannot reference these private helpers.

## Validation
- `go test ./runtime/...` from `packages/agent/daemon`
- `go test ./...` from `packages/agent/daemon`
- `go build ./...` from `packages/agent/daemon`
- `pnpm check:changed`
- `pnpm lint:go`
- `pnpm check:full`
- pre-push `pnpm check:full`

## Documentation impact
No durable documentation impact: this removes private unused helper code only and does not change public API, runtime behavior, CLI behavior, config, user-visible copy, or module ownership.