### PR TITLE
refactor(desktop): remove dead agent host workspace state

### DIFF
--- a/apps/desktop/src/renderer/src/features/workspace-agent/services/internal/desktopAgentHostWorkspaceState.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-agent/services/internal/desktopAgentHostWorkspaceState.ts
@@ -1,5 +1,3 @@
-import type { AgentActivitySession } from "@tutti-os/agent-activity-core";
-import type { WorkspaceAgentSession } from "@tutti-os/client-tuttid-ts";
 import {
   agentSessionStateDefaultsFromSettings,
   type AgentHostAgentSessionComposerSettingsInput,
@@ -7,16 +5,10 @@ import {
 } from "./desktopAgentHostProjection.ts";
 
 export interface DesktopAgentHostWorkspaceState {
-  defaultProjectSelection: DesktopAgentHostProjectSelection | null;
-  hiddenAgentSessionIds: Set<string>;
   sessionStateDefaultsByAgentSessionId: Map<
     string,
     AgentHostAgentSessionStateDefaults
   >;
-}
-
-export interface DesktopAgentHostProjectSelection {
-  path: string | null;
 }
 
 const agentHostWorkspaceStateByWorkspaceId = new Map<
@@ -31,8 +23,6 @@ export function desktopAgentHostWorkspaceState(
   let state = agentHostWorkspaceStateByWorkspaceId.get(normalizedWorkspaceId);
   if (!state) {
     state = {
-      defaultProjectSelection: null,
-      hiddenAgentSessionIds: new Set(),
       sessionStateDefaultsByAgentSessionId: new Map<
         string,
         AgentHostAgentSessionStateDefaults
@@ -41,23 +31,6 @@ export function desktopAgentHostWorkspaceState(
     agentHostWorkspaceStateByWorkspaceId.set(normalizedWorkspaceId, state);
   }
   return state;
-}
-
-export function rememberDefaultProjectSelection(
-  state: DesktopAgentHostWorkspaceState,
-  selection: DesktopAgentHostProjectSelection | null
-): void {
-  state.defaultProjectSelection = selection
-    ? { path: normalizeOptionalPath(selection.path) }
-    : null;
-}
-
-export function resolveDefaultProjectSelection(
-  state: DesktopAgentHostWorkspaceState
-): DesktopAgentHostProjectSelection | null {
-  return state.defaultProjectSelection
-    ? { path: state.defaultProjectSelection.path }
-    : null;
 }
 
 export function rememberAgentSessionStateDefaults(
@@ -87,50 +60,6 @@ export function resolveAgentSessionStateDefaults(
   );
 }
 
-export function rememberAgentSessionVisibility(
-  state: DesktopAgentHostWorkspaceState,
-  tuttidSessionId: string,
-  visible: boolean | null | undefined
-): void {
-  if (visible === undefined || visible === null) {
-    return;
-  }
-  const normalizedTuttidSessionId = normalizeAgentSessionId(tuttidSessionId);
-  if (!normalizedTuttidSessionId) {
-    return;
-  }
-  if (visible) {
-    state.hiddenAgentSessionIds.delete(normalizedTuttidSessionId);
-    return;
-  }
-  state.hiddenAgentSessionIds.add(normalizedTuttidSessionId);
-}
-
-export function forgetHiddenAgentSession(
-  state: DesktopAgentHostWorkspaceState,
-  agentSessionId: string
-): void {
-  state.hiddenAgentSessionIds.delete(normalizeAgentSessionId(agentSessionId));
-}
-
-export function isHiddenAgentSession(
-  state: DesktopAgentHostWorkspaceState,
-  session: WorkspaceAgentSession | AgentActivitySession
-): boolean {
-  const tuttidSessionId = normalizeAgentSessionId(
-    "agentSessionId" in session ? session.agentSessionId : session.id
-  );
-  const daemonVisible =
-    "visible" in session && typeof session.visible === "boolean"
-      ? session.visible
-      : true;
-  return !daemonVisible || state.hiddenAgentSessionIds.has(tuttidSessionId);
-}
-
 function normalizeAgentSessionId(agentSessionId: string): string {
   return agentSessionId.trim();
-}
-
-function normalizeOptionalPath(path: string | null | undefined): string | null {
-  return path?.trim() || null;
 }

--- a/apps/desktop/src/renderer/src/features/workspace-agent/services/internal/workspaceAgentActivityService.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-agent/services/internal/workspaceAgentActivityService.ts
@@ -33,8 +33,7 @@ import {
 } from "./desktopAgentHostProjection.ts";
 import {
   desktopAgentHostWorkspaceState,
-  rememberAgentSessionStateDefaults,
-  rememberAgentSessionVisibility
+  rememberAgentSessionStateDefaults
 } from "./desktopAgentHostWorkspaceState.ts";
 import { loadWorkspaceAgentSessionControlState } from "./workspaceAgentSessionControlState.ts";
 import type {
@@ -540,11 +539,6 @@ export class WorkspaceAgentActivityService implements IWorkspaceAgentActivitySer
       workspaceState,
       session.agentSessionId,
       input.settings
-    );
-    rememberAgentSessionVisibility(
-      workspaceState,
-      session.agentSessionId,
-      input.visible
     );
     const hostSession = toAgentHostAgentSessionFromCore(workspaceId, session, {
       cwd: resolvedCwd?.cwd ?? input.cwd ?? session.cwd,


### PR DESCRIPTION
## Summary
- remove the unused desktop Agent host default-project selection cache
- remove the unused hidden-session local cache and the no-op visibility write

## Historical role
- `defaultProjectSelection` was introduced with the initial OSS desktop Agent host workspace state as a workspace-local cache for a default project path selection.
- `hiddenAgentSessionIds` and its visibility helpers were also initial desktop-local state intended to remember hidden Agent sessions in the old host-adapter flow.
- Current session creation still passes `visible` through to the session payload; the removed write only updated an unread local Set.

## Reverification
- Exact symbol search after deletion returns no hits in the product repo or local external `tsh` checkout:
  `rg -n "rememberDefaultProjectSelection|resolveDefaultProjectSelection|DesktopAgentHostProjectSelection|defaultProjectSelection|rememberAgentSessionVisibility|forgetHiddenAgentSession|isHiddenAgentSession|hiddenAgentSessionIds" apps/desktop packages/agent/gui /Users/ccr/tsh-project/tsh -g '*.ts' -g '*.tsx'`
- These symbols lived under `apps/desktop/src/renderer/src/features/workspace-agent/services/internal`, so they are desktop-internal implementation details rather than published `@tutti-os/*` package API.
- `git log -S` shows both state groups came from the initial OSS import and had no later active call-site additions.

## Validation
- `pnpm --filter @tutti-os/desktop typecheck`
- `pnpm --filter @tutti-os/desktop test`
- `pnpm check:changed`
- `pnpm --filter @tutti-os/desktop build`
- `pnpm check:full`

## Documentation impact
- No durable docs update needed: this removes private unread desktop state only, with no public API, CLI, config, user-visible workflow, ownership, or troubleshooting behavior change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Simplified workspace state handling to rely on the currently active agent session, reducing stale or inconsistent workspace selections.
  * Improved session activation behavior so the app restores the right session-specific settings when switching agents.
  * Removed unused visibility and project-selection tracking, which may help prevent unexpected workspace state issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->