### PR TITLE
refactor(desktop): remove dead agent host projections

### DIFF
--- a/apps/desktop/src/renderer/src/features/workspace-agent/services/internal/desktopAgentHostProjection.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-agent/services/internal/desktopAgentHostProjection.ts
@@ -1,8 +1,5 @@
 import type { WorkspaceAgentSession } from "@tutti-os/client-tuttid-ts";
-import type {
-  AgentActivityMessage,
-  AgentActivitySession
-} from "@tutti-os/agent-activity-core";
+import type { AgentActivitySession } from "@tutti-os/agent-activity-core";
 import type {
   AgentHostAgentSession,
   AgentHostAgentSessionComposerSettings as SharedAgentHostAgentSessionComposerSettings
@@ -12,22 +9,6 @@ import {
   normalizeDesktopAgentGUIProvider,
   type DesktopAgentGUIProvider
 } from "../../desktopAgentGUINodeState.ts";
-
-export interface AgentHostWorkspaceAgentMessage {
-  agentSessionId: string;
-  completedAtUnixMs?: number;
-  id: number;
-  kind: string;
-  messageId: string;
-  occurredAtUnixMs: number;
-  payload: Record<string, unknown>;
-  role: string;
-  startedAtUnixMs?: number;
-  status?: string;
-  turnId: string;
-  version: number;
-  workspaceId: string;
-}
 
 export type AgentHostAgentSessionComposerSettings =
   SharedAgentHostAgentSessionComposerSettings;
@@ -46,35 +27,6 @@ export interface AgentHostAgentSessionStateDefaults {
 }
 
 const unsupportedDesktopAgentGUIProviderCode = "agent.provider_unsupported";
-
-export function agentMessageFromCore(
-  message: AgentActivityMessage
-): AgentHostWorkspaceAgentMessage {
-  return {
-    agentSessionId: message.agentSessionId,
-    completedAtUnixMs: message.completedAtUnixMs ?? undefined,
-    id: message.id ?? message.version,
-    kind: message.kind,
-    messageId: message.messageId,
-    occurredAtUnixMs: message.occurredAtUnixMs,
-    payload: recordValue(message.payload) ?? {},
-    role: message.role,
-    startedAtUnixMs: message.startedAtUnixMs ?? undefined,
-    status: message.status ?? undefined,
-    turnId: message.turnId,
-    version: message.version,
-    workspaceId: message.workspaceId ?? ""
-  };
-}
-
-export function cloneAgentMessage(
-  message: AgentHostWorkspaceAgentMessage
-): AgentHostWorkspaceAgentMessage {
-  return {
-    ...message,
-    payload: { ...message.payload }
-  };
-}
 
 export function pathFromFileReadPayload(payload: {
   path?: string;
@@ -118,16 +70,6 @@ export function resolveComposerPermissionMode(
   settings: AgentHostAgentSessionComposerSettingsInput | null | undefined
 ): string | null {
   return normalizedOptionalString(settings?.permissionModeId);
-}
-
-export function toTuttidComposerSettings(
-  settings: AgentHostAgentSessionComposerSettings | null | undefined
-): AgentHostAgentSessionComposerSettings {
-  const normalizedSettings = normalizeComposerSettings(settings);
-  return {
-    ...normalizedSettings,
-    permissionModeId: resolveComposerPermissionMode(settings)
-  };
 }
 
 export function resolveDesktopAgentGUIProvider(
@@ -238,51 +180,6 @@ function agentSessionStateSettings(
   return settings;
 }
 
-export function agentHostWorkspaceSessionFromCore(
-  workspaceId: string,
-  session: AgentActivitySession,
-  id: number,
-  options: { agentSessionId?: string | null } = {}
-) {
-  const agentSessionId =
-    options.agentSessionId?.trim() || session.agentSessionId;
-  return {
-    agentSessionId,
-    agentTargetId: session.agentTargetId ?? null,
-    createdAtUnixMs: session.createdAtUnixMs,
-    cwd: session.cwd ?? "/",
-    endedAtUnixMs: session.endedAtUnixMs,
-    effectiveStatus: toAgentHostWorkspaceAgentEffectiveStatus(session.status),
-    id,
-    lifecycleStatus:
-      session.status === "failed"
-        ? "failed"
-        : session.status === "completed" || session.status === "canceled"
-          ? "ended"
-          : "active",
-    presenceId: 1,
-    pinnedAtUnixMs: session.pinnedAtUnixMs,
-    provider: session.provider,
-    providerSessionId: session.providerSessionId ?? session.agentSessionId,
-    resumable: session.resumable ?? false,
-    sessionOrigin: "WORKSPACE_AGENT_SESSION_ORIGIN_RUNTIME",
-    startedAtUnixMs: session.startedAtUnixMs,
-    status: toAgentHostAgentSessionStatus(session.status),
-    turnPhase: toAgentHostWorkspaceAgentTurnPhase(session.status),
-    workspaceId,
-    ...(session.lastError
-      ? {
-          syncState: failedAgentSyncStateFromCore(workspaceId, session, {
-            agentSessionId
-          })
-        }
-      : {}),
-    title: session.title ?? undefined,
-    updatedAtUnixMs: session.updatedAtUnixMs ?? session.lastEventUnixMs,
-    userId: "local"
-  };
-}
-
 export function agentSessionActivationError(
   session: Pick<
     AgentActivitySession | WorkspaceAgentSession,
@@ -317,12 +214,6 @@ export function toAgentHostAgentSessionStatus(status: string): string {
     default:
       return status;
   }
-}
-
-export function isDenyPermissionOption(optionId: string): boolean {
-  return /^(abort|cancel|cancelled|canceled|deny|denied|reject|rejected|no)$/i.test(
-    optionId.trim()
-  );
 }
 
 export function stringifyError(error: unknown): string {
@@ -404,57 +295,7 @@ function normalizedOptionalString(
   return typeof value === "string" && value.trim() ? value.trim() : null;
 }
 
-function failedAgentSyncStateFromCore(
-  workspaceId: string,
-  session: AgentActivitySession,
-  options: { agentSessionId?: string | null } = {}
-) {
-  const agentSessionId =
-    options.agentSessionId?.trim() || session.agentSessionId;
-  return {
-    agentSessionId,
-    lastError: session.lastError?.trim(),
-    status: "failed",
-    updatedAtUnixMs: session.updatedAtUnixMs ?? session.lastEventUnixMs,
-    workspaceId
-  };
-}
-
-function toAgentHostWorkspaceAgentEffectiveStatus(status: string): string {
-  switch (status) {
-    case "created":
-      return "ready";
-    case "running":
-      return "working";
-    case "waiting":
-      return "waiting";
-    default:
-      return status;
-  }
-}
-
-function toAgentHostWorkspaceAgentTurnPhase(status: string): string {
-  switch (status) {
-    case "running":
-      return "working";
-    case "waiting":
-      return "waiting";
-    case "failed":
-      return "failed";
-    default:
-      return "idle";
-  }
-}
-
 function toUnixMs(value: string): number {
   const parsed = Date.parse(value);
   return Number.isFinite(parsed) ? parsed : Date.now();
-}
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === "object" && value !== null && !Array.isArray(value);
-}
-
-function recordValue(value: unknown): Record<string, unknown> {
-  return isRecord(value) ? { ...value } : {};
 }


### PR DESCRIPTION
## Summary
- remove unused desktop AgentHost projection helpers from `desktopAgentHostProjection.ts`
- drop their now-private message/session projection types and helper functions

## Historical role
- `agentMessageFromCore` and `cloneAgentMessage` projected `@tutti-os/agent-activity-core` messages back into the legacy AgentHost workspace-message DTO shape.
- `agentHostWorkspaceSessionFromCore` projected activity-core sessions into the older workspace-session DTO shape, including legacy effective status, turn phase, and failed sync-state fields.
- `toTuttidComposerSettings` was an older composer-settings normalization shim from the Nextop/Tutti naming transition.
- `isDenyPermissionOption` matched deny/cancel-style permission decisions for an older host-side permission path.

## Reverification
- Exact symbol search after deletion returns no hits in the product repo or local external `tsh` checkout:
  `rg -n "agentMessageFromCore|cloneAgentMessage|toTuttidComposerSettings|agentHostWorkspaceSessionFromCore|isDenyPermissionOption|failedAgentSyncStateFromCore|toAgentHostWorkspaceAgentEffectiveStatus|toAgentHostWorkspaceAgentTurnPhase" apps/desktop packages services /Users/ccr/tsh-project/tsh -g '*.ts' -g '*.tsx' -g '*.go'`
- The removed code lived in `apps/desktop/src/renderer/src/features/workspace-agent/services/internal`, so it was desktop-internal implementation code, not a published `@tutti-os/*` package API.
- `git log -S` shows the message/session projection helpers and deny matcher came from the initial OSS import; `toTuttidComposerSettings` only survived the Nextop/Tutti rename and had no active call site.
- The current active session path still uses `toAgentHostAgentSessionFromCore`, `toAgentHostAgentSessionState`, `normalizeComposerSettings`, and `resolveDesktopAgentGUIProvider`; this PR removes only the unreferenced legacy projection variants.

## Validation
- `pnpm --filter @tutti-os/desktop typecheck`
- `pnpm --filter @tutti-os/desktop test`
- `pnpm check:changed`
- `pnpm --filter @tutti-os/desktop build`
- `pnpm check:full`
- pre-push `pnpm check:full`

## Documentation impact
- No durable docs update needed: this removes private unused desktop projection code only, with no public API, CLI, config, user-visible workflow, ownership, or troubleshooting behavior change.