### PR TITLE
refactor(desktop): remove unused internal helpers

### DIFF
--- a/apps/desktop/src/main/host/workspaceFileEntryIcon.ts
+++ b/apps/desktop/src/main/host/workspaceFileEntryIcon.ts
@@ -231,13 +231,6 @@ export function isApplicationBundleName(name: string): boolean {
   return name.trim().toLowerCase().endsWith(".app");
 }
 
-export function isMacOSApplicationBundle(
-  entry: Pick<WorkspaceFileEntryIconInput, "kind" | "name">,
-  platform: NodeJS.Platform = process.platform
-): boolean {
-  return platform === "darwin" && isApplicationBundleEntry(entry);
-}
-
 function dataUrlToPngBytes(dataUrl: string | null): Buffer | null {
   if (!dataUrl) {
     return null;

--- a/apps/desktop/src/main/windows/workspaceWindow.ts
+++ b/apps/desktop/src/main/windows/workspaceWindow.ts
@@ -1,4 +1,4 @@
-import { BrowserWindow, app, ipcMain, session, shell } from "electron";
+import { BrowserWindow, app, session, shell } from "electron";
 import {
   installBrowserWebviewSecurity,
   isBrowserNodeWebviewAttach
@@ -18,8 +18,7 @@ import {
 } from "../../shared/contracts/windowIntent";
 import {
   desktopIpcChannels,
-  type DesktopHostWindowCloseRequestPayload,
-  type DesktopHostWindowCloseRequestResolutionPayload
+  type DesktopHostWindowCloseRequestPayload
 } from "../../shared/contracts/ipc";
 import { installWorkspaceWindowDevelopmentReloadShortcut } from "./workspaceWindowReload.ts";
 import { resolvePackagedWorkspaceRendererIndexPath } from "./workspaceWindowPaths.ts";
@@ -38,8 +37,6 @@ export interface CreateWorkspaceWindowOptions {
 }
 
 const workspaceWindows = new Set<BrowserWindow>();
-const workspaceWindowQuitCloseTimeoutMs = 5_000;
-let workspaceWindowQuitCloseRequestSequence = 0;
 const workspaceWindowHeaderHeightPx = 52;
 const workspaceWindowMacTrafficLightInsetPx = 16;
 const workspaceWindowMacTrafficLightSizePx = 12;
@@ -247,80 +244,6 @@ export function requestWorkspaceWindowCloseFromCommandShortcut(
   sendWorkspaceWindowCloseRequest(workspaceWindow, { reason: "window-close" });
 }
 
-export async function requestWorkspaceWindowsClose(
-  payload: DesktopHostWindowCloseRequestPayload
-): Promise<"approved" | "blocked"> {
-  const results = await Promise.all(
-    Array.from(workspaceWindows).map((workspaceWindow) =>
-      requestWorkspaceWindowClose(workspaceWindow, payload)
-    )
-  );
-  return results.every((result) => result === "approved")
-    ? "approved"
-    : "blocked";
-}
-
-function requestWorkspaceWindowClose(
-  workspaceWindow: BrowserWindow,
-  payload: DesktopHostWindowCloseRequestPayload
-): Promise<"approved" | "blocked"> {
-  if (
-    workspaceWindow.isDestroyed() ||
-    workspaceWindow.webContents.isDestroyed()
-  ) {
-    return Promise.resolve("approved");
-  }
-
-  return new Promise((resolve) => {
-    let settled = false;
-    let timeout: ReturnType<typeof setTimeout> | null = null;
-    const requestId = createWorkspaceWindowQuitCloseRequestId();
-    const finish = (outcome: "approved" | "blocked") => {
-      if (settled) {
-        return;
-      }
-      settled = true;
-      if (timeout) {
-        clearTimeout(timeout);
-      }
-      ipcMain.removeListener(
-        desktopIpcChannels.host.window.closeRequestResolved,
-        handleResolution
-      );
-      resolve(outcome);
-    };
-    const handleResolution = (
-      event: Electron.IpcMainEvent,
-      resolution?: DesktopHostWindowCloseRequestResolutionPayload
-    ) => {
-      if (
-        event.sender !== workspaceWindow.webContents ||
-        resolution?.requestId !== requestId
-      ) {
-        return;
-      }
-
-      finish(resolution.outcome === "approved" ? "approved" : "blocked");
-    };
-
-    workspaceWindow.once("closed", () => finish("approved"));
-    ipcMain.on(
-      desktopIpcChannels.host.window.closeRequestResolved,
-      handleResolution
-    );
-    timeout = setTimeout(() => {
-      if (payload.reason !== "quit" && !workspaceWindow.isDestroyed()) {
-        workspaceWindow.destroy();
-      }
-      finish(payload.reason === "quit" ? "blocked" : "approved");
-    }, workspaceWindowQuitCloseTimeoutMs);
-    sendWorkspaceWindowCloseRequest(workspaceWindow, {
-      ...payload,
-      requestId
-    });
-  });
-}
-
 function sendWorkspaceWindowCloseRequest(
   workspaceWindow: BrowserWindow,
   payload: DesktopHostWindowCloseRequestPayload
@@ -336,11 +259,6 @@ function sendWorkspaceWindowCloseRequest(
     desktopIpcChannels.host.window.closeRequest,
     payload
   );
-}
-
-function createWorkspaceWindowQuitCloseRequestId(): string {
-  workspaceWindowQuitCloseRequestSequence += 1;
-  return `workspace-window-close-${workspaceWindowQuitCloseRequestSequence}`;
 }
 
 function isWorkspaceAppSessionPartition(

--- a/apps/desktop/src/renderer/src/features/workspace-workbench/services/workspaceSettingsTypes.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/services/workspaceSettingsTypes.ts
@@ -90,14 +90,6 @@ export interface WorkspaceSettingsDeveloperLogsMutableState {
   logs: DesktopDeveloperLogsState | null;
 }
 
-export interface WorkspaceSettingsDeveloperLogsState {
-  readonly clearing: boolean;
-  readonly clearingConversationHistory: boolean;
-  readonly exporting: boolean;
-  readonly loading: boolean;
-  readonly logs: DesktopDeveloperLogsState | null;
-}
-
 export interface WorkspaceSettingsDeveloperLogsSnapshotState {
   readonly clearing: boolean;
   readonly clearingConversationHistory: boolean;

--- a/apps/desktop/src/renderer/src/lib/reactDiagnostics.ts
+++ b/apps/desktop/src/renderer/src/lib/reactDiagnostics.ts
@@ -137,10 +137,6 @@ export function createRenderStormTracker(
   };
 }
 
-export const reactRootErrorLogger = createReactRootErrorLogger();
-
-export const renderStormTracker = createRenderStormTracker();
-
 export function installBrowserCrashLogging(
   options: BrowserCrashLoggerOptions = {}
 ): () => void {
@@ -203,24 +199,6 @@ export function installBrowserCrashLogging(
       handleUnhandledRejection
     );
   };
-}
-
-export function recordReactRenderCommit(
-  id: string,
-  phase: "mount" | "nested-update" | "update",
-  actualDuration: number,
-  baseDuration: number,
-  startTime: number,
-  commitTime: number
-): void {
-  renderStormTracker.record({
-    actualDuration,
-    baseDuration,
-    commitTime,
-    id,
-    phase,
-    startTime
-  });
 }
 
 function formatErrorSummary(error: unknown): string {

--- a/apps/desktop/src/renderer/src/theme/runtime.ts
+++ b/apps/desktop/src/renderer/src/theme/runtime.ts
@@ -5,8 +5,6 @@ import {
   type DesktopThemeState
 } from "../../../shared/theme/index.ts";
 
-const themeListeners = new Set<(theme: DesktopThemeState) => void>();
-
 function readInitialThemeAppearance(): DesktopThemeAppearance {
   return resolveWindowThemeAppearance();
 }
@@ -72,18 +70,6 @@ function setActiveTheme(theme: DesktopThemeState): void {
 
   activeTheme = theme;
   syncDocumentTheme(theme);
-  themeListeners.forEach((listener) => {
-    listener(theme);
-  });
-}
-
-export function subscribeTheme(
-  listener: (theme: DesktopThemeState) => void
-): () => void {
-  themeListeners.add(listener);
-  return () => {
-    themeListeners.delete(listener);
-  };
 }
 
 export function getActiveTheme(): DesktopThemeState {

--- a/services/tuttid/service/agent/provider_auth_watcher_test.go
+++ b/services/tuttid/service/agent/provider_auth_watcher_test.go
@@ -120,7 +120,11 @@ func TestProviderAuthWatcherIgnoresNonAuthClaudeStateChurn(t *testing.T) {
 	statePath := filepath.Join(dir, ".claude.json")
 	writeState := func(content string) {
 		t.Helper()
-		if err := os.WriteFile(statePath, []byte(content), 0o600); err != nil {
+		tempPath := filepath.Join(dir, ".claude.json.next")
+		if err := os.WriteFile(tempPath, []byte(content), 0o600); err != nil {
+			t.Fatalf("write staged claude state file: %v", err)
+		}
+		if err := os.Rename(tempPath, statePath); err != nil {
 			t.Fatalf("write claude state file: %v", err)
 		}
 	}


### PR DESCRIPTION
## Summary
- remove unused desktop-internal helper exports across theme, React diagnostics, workspace window close handling, file icons, and workspace settings types
- keep the active runtime paths and public shared IPC contracts intact
- merge current `main` and include one narrow test stabilization so the branch no longer inherits a flaky unrelated Go test failure

## Historical role
- `subscribeTheme` and `themeListeners` were an initial renderer theme runtime subscription hook, but the current preferences/theme flow reads `getActiveTheme` and applies changes through `applyTheme` / `connectDesktopThemeSource` directly.
- `reactRootErrorLogger`, the default `renderStormTracker` singleton, and `recordReactRenderCommit` were convenience wrappers from the React diagnostics work; the connected renderer now creates scoped loggers/trackers in `main.tsx` via `createReactRootErrorLogger` and `createRenderStormTracker`.
- `requestWorkspaceWindowsClose` was an older main-process batch close-request path with request ids/timeouts; the active close flow is the renderer/workbench coordinator plus `requestWorkspaceWindowCloseFromCommandShortcut` for command shortcuts.
- `isMacOSApplicationBundle` was a wrapper around the file-icon bundle predicate from icon-view work; the active resolver uses the private `isApplicationBundleEntry` path directly.
- `WorkspaceSettingsDeveloperLogsState` duplicated the developer logs state shape, while current code uses mutable store state internally and `WorkspaceSettingsDeveloperLogsSnapshotState` for readable UI state.
- `TestProviderAuthWatcherIgnoresNonAuthClaudeStateChurn` was intended to verify auth-relevant Claude state fingerprinting, but its original in-place `os.WriteFile` rewrite could expose a transient half-written file to the polling watcher and intermittently trip the conservative "content fingerprint missing" path.

## Reverification
- Exact symbol search after deletion returns no hits in the product repo or local external `tsh` checkout:
  `rg -n "subscribeTheme|themeListeners|reactRootErrorLogger|recordReactRenderCommit|requestWorkspaceWindowsClose|workspaceWindowQuitCloseTimeoutMs|workspaceWindowQuitCloseRequestSequence|createWorkspaceWindowQuitCloseRequestId|isMacOSApplicationBundle|WorkspaceSettingsDeveloperLogsState|export const renderStormTracker" apps/desktop packages services /Users/ccr/tsh-project/tsh -g '*.ts' -g '*.tsx' -g '*.go'`
- The remaining `renderStormTracker` name is only a local variable in `main.tsx`'s active profiler path; the removed default singleton export is gone.
- These files live under `apps/desktop/src`; none of the removed symbols are published `@tutti-os/*` package API, and shared IPC/window-intent contracts were intentionally left untouched.
- `git log -S` confirms these came from the initial desktop runtime import, React diagnostics addition, workspace UI polish, or file-icon work; no later active call sites were found.
- The prior CI failure on this branch was `Go Tests` in `services/tuttid/service/agent` at `TestProviderAuthWatcherIgnoresNonAuthClaudeStateChurn`; rewriting the test fixture through a temp file + rename removes the transient partial-write window and repeated local runs now pass.

## Validation
- `pnpm --filter @tutti-os/desktop typecheck`
- `pnpm check:changed`
- `pnpm --filter @tutti-os/desktop test`
- `pnpm --filter @tutti-os/desktop build`
- `cd services/tuttid && go test ./service/agent -run TestProviderAuthWatcherIgnoresNonAuthClaudeStateChurn -count=50`
- `cd services/tuttid && go test ./service/agent`
- `pnpm check:full`
- pre-push `pnpm check:full`

## Documentation impact
- No durable docs update needed: the desktop cleanup still removes only private unused implementation helpers, and the extra test change only stabilizes fixture writing for an existing auth-watcher check. There is no public API, CLI, config, user-visible workflow, ownership, or troubleshooting behavior change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified desktop window close handling and removed some unused theme/diagnostics and developer-log state plumbing.
  * Cleaned up application bundle and theme-related internals for a leaner runtime.

* **Tests**
  * Updated provider auth watcher coverage to better match atomic file update behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->