### PR TITLE
refactor(agent-gui): remove unused managed toolchain helpers

### DIFF
--- a/packages/agent/gui/shared/utils/managedToolchainAgents.ts
+++ b/packages/agent/gui/shared/utils/managedToolchainAgents.ts
@@ -127,12 +127,6 @@ function hasHostConfig(
   return Boolean(item?.hostConfigDetected);
 }
 
-export function getAgentHostManagedToolchainAgentActionAgentId(
-  agent: AgentHostManagedToolchainAgent
-): string {
-  return agent.actionAgentId ?? agent.id;
-}
-
 export function findAgentHostManagedAgentsStateItemIndex(
   agent: AgentHostManagedToolchainAgent,
   managedAgentsState: AgentHostManagedAgentsState | null
@@ -151,19 +145,6 @@ export function findAgentHostManagedAgentsStateItemIndex(
   });
 }
 
-export function resolveAgentHostManagedAgentsStateItem(
-  agent: AgentHostManagedToolchainAgent,
-  managedAgentsState: AgentHostManagedAgentsState | null
-): AgentHostManagedAgentsStateItem | undefined {
-  const stateItemIndex = findAgentHostManagedAgentsStateItemIndex(
-    agent,
-    managedAgentsState
-  );
-  return stateItemIndex >= 0
-    ? managedAgentsState?.items[stateItemIndex]
-    : undefined;
-}
-
 /** Managed toolchain agent action used by runtime/home projections. */
 export function resolveAgentHostManagedToolchainAgentAction(
   agent: AgentHostManagedToolchainAgent,
@@ -180,41 +161,6 @@ export function resolveAgentHostManagedToolchainAgentAction(
     pendingStateItem,
     managedAgentsState
   );
-}
-
-/** 与 Manage Agents 中标记为 Installed 的行数一致（最多为托管 agents 种类数）。 */
-export function countAgentHostInstalledManagedAgents(
-  managedAgentsState: AgentHostManagedAgentsState | null
-): number {
-  let installed = 0;
-  for (const agent of AGENT_HOST_MANAGED_TOOLCHAIN_AGENTS) {
-    if (
-      resolveAgentHostManagedToolchainAgentAction(agent, managedAgentsState) ===
-      "installed"
-    ) {
-      installed++;
-    }
-  }
-  return installed;
-}
-
-/** Host-side config was synced into the VM for this managed agent (see managedAgentsState.configSyncedAgentIds). */
-export function isAgentHostManagedAgentHostConfigSynced(
-  agent: AgentHostManagedToolchainAgent,
-  managedAgentsState: AgentHostManagedAgentsState | null
-): boolean {
-  const ids = managedAgentsState?.configSyncedAgentIds;
-  if (!ids?.length) {
-    return false;
-  }
-  const synced = new Set(ids.map(normalizeKey));
-  const actionId = normalizeKey(
-    getAgentHostManagedToolchainAgentActionAgentId(agent)
-  );
-  if (synced.has(actionId)) {
-    return true;
-  }
-  return agent.agentIds.some((id) => synced.has(normalizeKey(id)));
 }
 
 export function resolveAgentHostManagedToolchainAction(
@@ -249,17 +195,6 @@ export function resolveAgentHostManagedToolchainAction(
   return "install";
 }
 
-export function getAgentHostManagedToolchainAgentById(
-  id: string
-): AgentHostManagedToolchainAgent | null {
-  const normalized = normalizeKey(id);
-  return (
-    AGENT_HOST_MANAGED_TOOLCHAIN_AGENTS.find(
-      (agent) => normalizeKey(agent.id) === normalized
-    ) ?? null
-  );
-}
-
 export function getAgentHostManagedToolchainAgentByName(
   name: string
 ): AgentHostManagedToolchainAgent | null {
@@ -278,11 +213,5 @@ export function getAgentHostManagedToolchainAgentByName(
         ...(agent.aliases ?? [])
       ].some((candidate) => normalizeKey(candidate) === normalized)
     ) ?? null
-  );
-}
-
-export function listAgentHostGameManagedToolchainAgents(): readonly AgentHostManagedToolchainAgent[] {
-  return AGENT_HOST_MANAGED_TOOLCHAIN_AGENTS.filter(
-    (agent) => !!agent.helperProvider
   );
 }


### PR DESCRIPTION
## Summary
- remove unused internal managed toolchain helper exports from `packages/agent/gui/shared/utils/managedToolchainAgents.ts`
- keep the active provider-name lookup and managed action resolver used by `AgentGUINode`

## Dead-code verification
- Exact symbol search across `apps`, `packages`, `services`, and local `/Users/ccr/tsh-project/tsh` has zero callers for the removed helpers:
  - `getAgentHostManagedToolchainAgentActionAgentId`
  - `resolveAgentHostManagedAgentsStateItem`
  - `countAgentHostInstalledManagedAgents`
  - `isAgentHostManagedAgentHostConfigSynced`
  - `getAgentHostManagedToolchainAgentById`
  - `listAgentHostGameManagedToolchainAgents`
- `@tutti-os/agent-gui` is a published package, so I checked the public surface: `shared/utils/managedToolchainAgents.ts` is not listed in `exports`, not listed in `publishConfig.exports`, and not re-exported from `index.ts`.
- Local `tsh` only imports supported `@tutti-os/agent-gui` public subpaths and has no deep import of this internal utility file or these symbols.
- `git log -S` shows these helpers came from the initial OSS import (`e2120fb2 feat: init project for tutti open source`), not from recent provider work.

## Original role
These helpers belonged to the older managed-agent/toolchain projection model: state item lookup, installed count, host config sync detection, id lookup, helper-provider listing, and an action-agent-id indirection. Current runtime behavior only still uses `getAgentHostManagedToolchainAgentByName` and `resolveAgentHostManagedToolchainAgentAction`, which are retained.

## Validation
- `rg` exact-symbol sweep across main repo and `/Users/ccr/tsh-project/tsh`
- `pnpm --filter @tutti-os/agent-gui typecheck`
- `pnpm --filter @tutti-os/agent-gui test` (initial parallel run had one unrelated `useAgentGUINodeController` failure; targeted rerun passed, then full package rerun passed)
- `pnpm --filter @tutti-os/agent-gui build`
- `pnpm check:agent-activity-runtime-boundaries`
- `pnpm check:changed`
- `pnpm check:full`
- pre-push `pnpm check:full`

## Documentation impact
No durable documentation update needed: this only removes private, unreferenced helper exports from an internal utility file. It does not change public package exports, runtime/data flow, user-visible behavior, API/CLI behavior, env/config overrides, or troubleshooting paths.