### PR TITLE
refactor(agent-gui): remove unused session helpers

### DIFF
--- a/packages/agent/gui/agentActivityHost.tsx
+++ b/packages/agent/gui/agentActivityHost.tsx
@@ -60,19 +60,6 @@ export function useOptionalAgentHostApi(): AgentHostRuntimeApi | null {
   return useContext(AgentActivityHostContext) ?? getTestAgentHostApi();
 }
 
-export function getAgentHostApi(): AgentHostRuntimeApi {
-  const agentHostApi =
-    getExplicitWindowTestAgentHostApi() ??
-    currentAgentHostApi ??
-    getTestAgentHostApi();
-  if (!agentHostApi) {
-    throw new Error(
-      "AgentActivityHostProvider is missing an agentHostApi instance."
-    );
-  }
-  return agentHostApi;
-}
-
 export function getOptionalAgentHostApi(): AgentHostRuntimeApi | null {
   return (
     getExplicitWindowTestAgentHostApi() ??

--- a/packages/agent/gui/contexts/workspace/presentation/renderer/agentSessions/agentSessionViewStore.ts
+++ b/packages/agent/gui/contexts/workspace/presentation/renderer/agentSessions/agentSessionViewStore.ts
@@ -108,14 +108,6 @@ const runtimeSessionEventUnsubscribeByWorkspaceId = new Map<
   () => void
 >();
 
-export function useAgentSessionViewStoreSnapshot(): AgentSessionViewStoreSnapshot {
-  return useSyncExternalStore(
-    subscribeAgentSessionViewStore,
-    getAgentSessionViewStoreSnapshot,
-    getAgentSessionViewStoreSnapshot
-  );
-}
-
 export function getAgentSessionViewStoreSnapshot(): AgentSessionViewStoreSnapshot {
   return snapshot;
 }
@@ -405,20 +397,6 @@ export function hydrateAgentSessionViewOverlayMessages(
   }
 }
 
-export function setAgentSessionViewControlCommands(
-  ref: AgentSessionViewRef,
-  commands: readonly AgentHostAgentSessionCommand[]
-): void {
-  const normalized = normalizeAgentSessionViewRef(ref);
-  if (!normalized) {
-    return;
-  }
-  updateAgentSessionView(normalized, (current) => ({
-    ...current,
-    controlCommands: [...commands]
-  }));
-}
-
 export function setAgentSessionViewControlState(
   ref: AgentSessionViewRef,
   controlState: AgentHostAgentSessionState | null
@@ -517,23 +495,6 @@ export function deleteAgentSessionView(ref: AgentSessionViewRef): void {
     sessionViewsBySessionKey: nextSessionViewsBySessionKey
   };
   emitAgentSessionViewStoreChange();
-}
-
-export function getAgentSessionActivityStreamStateForTests(): Array<{
-  key: string;
-  listenerCount: number;
-  hasUpstreamSubscription: boolean;
-  isLingering: boolean;
-  leaseId: string | null;
-}> {
-  return [...activityStreamEntries.values()].map((entry) => ({
-    key: entry.key,
-    listenerCount: entry.batchListeners.size,
-    hasUpstreamSubscription:
-      entry.releaseRuntimeEvents !== null || entry.retainPromise !== null,
-    isLingering: entry.lingerTimer !== null,
-    leaseId: null
-  }));
 }
 
 export function resetAgentSessionViewStoreForTests(): void {

--- a/packages/agent/gui/contexts/workspace/presentation/renderer/agentSessions/useAgentSessionView.ts
+++ b/packages/agent/gui/contexts/workspace/presentation/renderer/agentSessions/useAgentSessionView.ts
@@ -1,7 +1,6 @@
-import { useEffect, useMemo, useRef } from "react";
+import { useEffect, useRef } from "react";
 import type { AgentHostAgentActivityStreamEvent } from "../../../../../shared/contracts/dto";
 import {
-  createAgentSessionViewKey,
   getAgentSessionView,
   watchAgentSession,
   type AgentSessionViewRef,
@@ -120,16 +119,4 @@ export function useWatchAgentSessions(input: {
     input.enabled,
     input.workspaceId
   ]);
-}
-
-export function useAgentSessionViewSnapshot(ref: AgentSessionViewRef) {
-  const sessionView = useStoreAgentSessionView(ref);
-  return useMemo(
-    () => ({
-      sessionView,
-      hasSessionView:
-        Boolean(createAgentSessionViewKey(ref)) && Boolean(sessionView)
-    }),
-    [ref, sessionView]
-  );
 }


### PR DESCRIPTION
## Summary

- Remove unused internal AgentGUI helper exports for imperative host access and session-view snapshots.
- Remove unused session-view control-command setter and activity-stream inspection helper.
- Keep the active `controlCommands` state field, stream-event reducer updates, and overlay hydration helper because they still have real callers or tests.

## Verification

Confirmed the removed helpers have no callers before deletion:

```sh
rg -n "getAgentHostApi\b|useAgentSessionViewStoreSnapshot\b|setAgentSessionViewControlCommands\b|getAgentSessionActivityStreamStateForTests\b|useAgentSessionViewSnapshot\b" apps packages services /Users/ccr/tsh-project/tsh -g '*.ts' -g '*.tsx'
```

That exact search had only the five definition hits before deletion and no hits after deletion.

External/package checks:

- `@tutti-os/agent-gui` is published, so I checked `packages/agent/gui/package.json` `exports`, `publishConfig.exports`, and `index.ts`; none of these helpers are package root exports or published subpath exports.
- Searched local `/Users/ccr/tsh-project/tsh`; it uses only public `@tutti-os/agent-gui` entrypoints/subpaths and has no deep import or symbol usage for the removed helpers.
- `hydrateAgentSessionViewOverlayMessages` was not removed because `agentGuiConversationListStore.spec.ts` still imports it for overlay test setup.
- `controlCommands` state was not removed because `useAgentGUINodeController.ts` still reads it and `agentSessionViewStore.ts` still updates it from stream events.

Historical role:

- These helpers were introduced in the initial open-source import (`e2120fb2 feat: init project for tutti open source`).
- They appear to be legacy/convenience AgentGUI internals for whole-store subscription, direct host API access, control-command mutation, stream-state test inspection, and a wrapper snapshot hook. Current production paths use `useAgentHostApi` / `useOptionalAgentHostApi`, `useAgentSessionView`, runtime stream events, and `AgentActivityRuntime`-driven controller state.

## Validation

- `pnpm --filter @tutti-os/agent-gui typecheck`
- `pnpm --filter @tutti-os/agent-gui test -- contexts/workspace/presentation/renderer/agentSessions contexts/workspace/presentation/renderer/agentGuiConversationList`
- `pnpm check:agent-activity-runtime-boundaries`
- `pnpm --filter @tutti-os/agent-gui build`
- `pnpm check:changed --tail-lines 80`
- `pnpm check:full`

## Documentation Impact

- `discard`: no durable documentation update needed. This removes private, unreferenced helpers only; it does not change module ownership, runtime data flow, public package API, user-visible behavior, validation commands, or troubleshooting guidance.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified several agent session and host access patterns by removing older snapshot and update helpers.
  * Added a safer optional way to access the agent host, returning no value when it isn’t available instead of failing.
  * Reduced unused React hook usage and streamlined session state access paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->