### PR TITLE
refactor(desktop): remove unused test-only helpers

### DIFF
--- a/apps/desktop/src/renderer/src/features/workspace-agent/services/internal/desktopAgentComposerDefaultsWriteGate.test.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-agent/services/internal/desktopAgentComposerDefaultsWriteGate.test.ts
@@ -1,34 +1,6 @@
 import assert from "node:assert/strict";
 import test from "node:test";
-import {
-  desktopAgentComposerDefaultsEqual,
-  desktopAgentComposerOverridesToDefaults
-} from "./desktopAgentComposerDefaultsWriteGate.ts";
-
-test("desktopAgentComposerOverridesToDefaults keeps only durable composer defaults", () => {
-  assert.deepEqual(
-    desktopAgentComposerOverridesToDefaults({
-      model: " gpt-5.5 ",
-      permissionModeId: " full-access ",
-      planMode: true,
-      reasoningEffort: " high "
-    }),
-    {
-      model: "gpt-5.5",
-      permissionModeId: "full-access",
-      reasoningEffort: "high"
-    }
-  );
-});
-
-test("desktopAgentComposerOverridesToDefaults returns null for empty defaults", () => {
-  assert.equal(
-    desktopAgentComposerOverridesToDefaults({
-      planMode: true
-    }),
-    null
-  );
-});
+import { desktopAgentComposerDefaultsEqual } from "./desktopAgentComposerDefaultsWriteGate.ts";
 
 test("desktopAgentComposerDefaultsEqual compares normalized default values", () => {
   assert.equal(

--- a/apps/desktop/src/renderer/src/features/workspace-agent/services/internal/desktopAgentComposerDefaultsWriteGate.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-agent/services/internal/desktopAgentComposerDefaultsWriteGate.ts
@@ -1,24 +1,4 @@
 import type { DesktopAgentComposerDefaults } from "@shared/preferences";
-import type { DesktopAgentGUIComposerOverrides } from "../../desktopAgentGUINodeState.ts";
-
-export function desktopAgentComposerOverridesToDefaults(
-  overrides: DesktopAgentGUIComposerOverrides
-): DesktopAgentComposerDefaults | null {
-  const defaults: DesktopAgentComposerDefaults = {};
-  if (overrides.model?.trim()) {
-    defaults.model = overrides.model.trim();
-  }
-  if (overrides.permissionModeId?.trim()) {
-    defaults.permissionModeId = overrides.permissionModeId.trim();
-  }
-  if (overrides.reasoningEffort?.trim()) {
-    defaults.reasoningEffort = overrides.reasoningEffort.trim();
-  }
-  if (overrides.speed?.trim()) {
-    defaults.speed = overrides.speed.trim();
-  }
-  return Object.keys(defaults).length > 0 ? defaults : null;
-}
 
 export function desktopAgentComposerDefaultsEqual(
   left: DesktopAgentComposerDefaults | null | undefined,

--- a/apps/desktop/src/renderer/src/features/workspace-workbench/services/internal/workspaceBrowserAnalytics.test.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/services/internal/workspaceBrowserAnalytics.test.ts
@@ -2,10 +2,7 @@ import assert from "node:assert/strict";
 import test from "node:test";
 import type { BrowserNodeEvent } from "@tutti-os/browser-node";
 import type { ReporterEventInput } from "../../../analytics/services/reporterService.interface.ts";
-import {
-  createWorkspaceBrowserAnalyticsApi,
-  createWorkspaceBrowserAnalyticsTracker
-} from "./workspaceBrowserAnalytics.ts";
+import { createWorkspaceBrowserAnalyticsTracker } from "./workspaceBrowserAnalytics.ts";
 
 test("workspace browser analytics reports open and close without navigation events", async () => {
   const reporterCalls: ReporterEventInput[][] = [];
@@ -237,45 +234,6 @@ test("workspace browser analytics reports open and close from runtime events whe
   ]);
 });
 
-test("workspace browser analytics api observes each raw event once across subscribers", () => {
-  const observedEvents: BrowserNodeEvent[] = [];
-  const listenerEvents: BrowserNodeEvent[] = [];
-  const rawListeners: Array<(event: BrowserNodeEvent) => void> = [];
-  let rawSubscriptionCount = 0;
-  const api = createWorkspaceBrowserAnalyticsApi({
-    browserApi: {
-      ...createBrowserApiStub(),
-      onEvent(listener) {
-        rawSubscriptionCount += 1;
-        rawListeners.push(listener);
-        return () => {
-          rawListeners.length = 0;
-        };
-      }
-    },
-    tracker: {
-      observeEvent(event) {
-        observedEvents.push(event);
-      }
-    }
-  });
-  const firstDispose = api.onEvent((event) => listenerEvents.push(event));
-  const secondDispose = api.onEvent((event) => listenerEvents.push(event));
-  const event = createBrowserStateEvent({ url: "https://example.com/" });
-  assert.ok(rawListeners[0]);
-
-  rawListeners[0](event);
-
-  assert.equal(rawSubscriptionCount, 1);
-  assert.deepEqual(listenerEvents, [event, event]);
-  assert.deepEqual(observedEvents, [event]);
-
-  firstDispose();
-  assert.equal(rawListeners.length, 1);
-  secondDispose();
-  assert.equal(rawListeners.length, 0);
-});
-
 function createBrowserStateEvent(
   overrides: Partial<Extract<BrowserNodeEvent, { type: "state" }>>
 ): Extract<BrowserNodeEvent, { type: "state" }> {
@@ -305,22 +263,5 @@ function createReporterService(calls: ReporterEventInput[][] = []) {
     async trackEvents(events: ReporterEventInput[]) {
       calls.push(events);
     }
-  };
-}
-
-function createBrowserApiStub() {
-  return {
-    activate: async () => undefined,
-    capturePreview: async () => null,
-    close: async () => undefined,
-    goBack: async () => undefined,
-    goForward: async () => undefined,
-    navigate: async () => undefined,
-    onEvent: () => () => undefined,
-    openExternal: async () => undefined,
-    prepareSession: async () => undefined,
-    registerGuest: async () => undefined,
-    reload: async () => undefined,
-    unregisterGuest: async () => undefined
   };
 }

--- a/apps/desktop/src/renderer/src/features/workspace-workbench/services/internal/workspaceBrowserAnalytics.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/services/internal/workspaceBrowserAnalytics.ts
@@ -1,5 +1,4 @@
 import type { BrowserNodeEvent } from "@tutti-os/browser-node";
-import type { DesktopBrowserApi } from "@preload/types";
 import { BrowserClosedReporter } from "../../../analytics/reporters/browser-closed/browserClosedReporter.ts";
 import { BrowserOpenedReporter } from "../../../analytics/reporters/browser-opened/browserOpenedReporter.ts";
 import {
@@ -153,41 +152,4 @@ function resolveBrowserOpenedSource(
     default:
       return "restore";
   }
-}
-
-export function createWorkspaceBrowserAnalyticsApi(input: {
-  browserApi: DesktopBrowserApi;
-  tracker: Pick<WorkspaceBrowserAnalyticsTracker, "observeEvent">;
-}): DesktopBrowserApi {
-  const listeners = new Set<(event: BrowserNodeEvent) => void>();
-  let disconnect: (() => void) | null = null;
-
-  const ensureConnected = () => {
-    if (disconnect) {
-      return;
-    }
-
-    disconnect = input.browserApi.onEvent((event) => {
-      for (const listener of listeners) {
-        listener(event);
-      }
-      input.tracker.observeEvent(event);
-    });
-  };
-
-  return {
-    ...input.browserApi,
-    onEvent(listener) {
-      listeners.add(listener);
-      ensureConnected();
-      return () => {
-        listeners.delete(listener);
-        if (listeners.size > 0) {
-          return;
-        }
-        disconnect?.();
-        disconnect = null;
-      };
-    }
-  };
 }

--- a/apps/desktop/src/renderer/src/features/workspace-workbench/services/internal/workspaceBrowserContributionCore.test.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/services/internal/workspaceBrowserContributionCore.test.ts
@@ -3,7 +3,6 @@ import test from "node:test";
 import type { BrowserNodeRuntimeState } from "@tutti-os/browser-node";
 import {
   createWorkspaceBrowserNodeExternalStateSource,
-  resolveWorkspaceBrowserNavigationAnalyticsParams,
   resolveWorkspaceBrowserSearchUrl
 } from "./workspaceBrowserContributionCore.ts";
 import { workspaceBrowserNodeID } from "./workspaceWorkbenchComposition.ts";
@@ -12,29 +11,6 @@ test("resolveWorkspaceBrowserSearchUrl encodes search queries", () => {
   assert.equal(
     resolveWorkspaceBrowserSearchUrl("tutti browser contribution"),
     "https://www.google.com/search?q=tutti+browser+contribution"
-  );
-});
-
-test("resolveWorkspaceBrowserNavigationAnalyticsParams keeps only navigation host metadata", () => {
-  assert.deepEqual(
-    resolveWorkspaceBrowserNavigationAnalyticsParams(
-      "https://github.com/tutti-os/tutti?token=secret#readme"
-    ),
-    {
-      isLocalhost: false,
-      urlDomain: "github.com"
-    }
-  );
-  assert.deepEqual(
-    resolveWorkspaceBrowserNavigationAnalyticsParams("http://127.0.0.1:5173/"),
-    {
-      isLocalhost: true,
-      urlDomain: "127.0.0.1"
-    }
-  );
-  assert.equal(
-    resolveWorkspaceBrowserNavigationAnalyticsParams("about:blank"),
-    null
   );
 });
 

--- a/apps/desktop/src/renderer/src/features/workspace-workbench/services/internal/workspaceBrowserContributionCore.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/services/internal/workspaceBrowserContributionCore.ts
@@ -7,43 +7,10 @@ import { workspaceBrowserNodeID } from "./workspaceWorkbenchComposition.ts";
 
 const browserNodeSearchBaseUrl = "https://www.google.com/search";
 
-export interface WorkspaceBrowserNavigationAnalyticsParams {
-  isLocalhost: boolean;
-  urlDomain: string;
-}
-
 export function resolveWorkspaceBrowserSearchUrl(query: string): string {
   const searchUrl = new URL(browserNodeSearchBaseUrl);
   searchUrl.searchParams.set("q", query);
   return searchUrl.toString();
-}
-
-export function resolveWorkspaceBrowserNavigationAnalyticsParams(
-  url: string
-): WorkspaceBrowserNavigationAnalyticsParams | null {
-  try {
-    const parsed = new URL(url);
-    const hostname = parsed.hostname.trim().toLowerCase();
-    if (!hostname) {
-      return null;
-    }
-    return {
-      isLocalhost: isWorkspaceBrowserLocalhost(hostname),
-      urlDomain: hostname
-    };
-  } catch {
-    return null;
-  }
-}
-
-function isWorkspaceBrowserLocalhost(hostname: string): boolean {
-  return (
-    hostname === "localhost" ||
-    hostname.endsWith(".localhost") ||
-    hostname.startsWith("127.") ||
-    hostname === "::1" ||
-    hostname === "[::1]"
-  );
 }
 
 export interface WorkspaceBrowserNodeExternalState {


### PR DESCRIPTION
## Summary
- remove `createWorkspaceBrowserAnalyticsApi` from the workspace browser analytics internals
- remove `resolveWorkspaceBrowserNavigationAnalyticsParams` and its private localhost helper from the workspace browser contribution core
- remove `desktopAgentComposerOverridesToDefaults` from the desktop AgentGUI composer-defaults write gate
- trim the now-test-only specs that were covering those dead exports

## Historical role
- `createWorkspaceBrowserAnalyticsApi`
  - This looked like an early convenience wrapper around raw browser feature-host events so multiple listeners could observe the same event stream.
  - The current production path no longer goes through it: `workspaceBrowserContribution.ts` builds the feature host API directly and only uses `createWorkspaceBrowserAnalyticsTracker`.
  - `git log -S'createWorkspaceBrowserAnalyticsApi'` traces it back to `e2120fb2` (`feat: init project for tutti open source`).
- `resolveWorkspaceBrowserNavigationAnalyticsParams`
  - This projected browser navigation state into analytics params, including a localhost/private-network classification helper.
  - There is no remaining production caller in the current browser contribution path.
  - `git log -S'resolveWorkspaceBrowserNavigationAnalyticsParams'` also traces it back to `e2120fb2`.
- `desktopAgentComposerOverridesToDefaults`
  - This converted node-local composer overrides into the durable defaults shape used by desktop AgentGUI persistence.
  - The current production flow only keeps the normalized equality/value helpers; the removed conversion helper was left behind only in its co-located test file.
  - `git log -S'desktopAgentComposerOverridesToDefaults'` traces the helper introduction to `f3a33c73` (`fix(agent-gui): preserve composer permission defaults`).

## Reverification
- Exact cross-repo search now returns no hits for the removed symbols:
  - `createWorkspaceBrowserAnalyticsApi`
  - `resolveWorkspaceBrowserNavigationAnalyticsParams`
  - `desktopAgentComposerOverridesToDefaults`
- I rechecked both this repository and the sibling local `tsh` repository for exact symbol references before deleting, then re-ran the exact search after deletion.
- Neighboring helpers are still live in production code, so this is not a blanket file cleanup:
  - `createWorkspaceBrowserAnalyticsTracker` and `resolveWorkspaceBrowserSearchUrl` are still used by `workspaceBrowserContribution.ts`
  - `desktopAgentComposerDefaultsEqual` is still used by shared desktop preferences
  - `normalizedDesktopAgentComposerDefaultValue` is still used by desktop AgentGUI diagnostics
- All removed code lives under `apps/desktop/src/...` and does not affect any published `@tutti-os/*` package surface or daemon/API contract.

## Validation
- `pnpm --filter @tutti-os/desktop typecheck`
- `pnpm --filter @tutti-os/desktop test`
- `pnpm --filter @tutti-os/desktop build`
- `pnpm check:changed --tail-lines 80`

## Docs impact
- `discard`
- No durable documentation update needed: this is private desktop dead-code removal only, with no public API/CLI/config/runtime ownership change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified desktop workspace browser and agent internals by removing unused helper paths and streamlining the remaining search and analytics logic.
  * Reduced test coverage to match the current behavior, keeping validation focused on active functionality.
* **Bug Fixes**
  * No user-facing behavior changes are expected from this update.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->