### PR TITLE
refactor(desktop): remove test-only internal helper seams

### DIFF
--- a/apps/desktop/src/renderer/src/features/workspace-agent/services/internal/desktopManagedAgentProviders.test.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-agent/services/internal/desktopManagedAgentProviders.test.ts
@@ -9,7 +9,6 @@ import {
   desktopManagedAgentProviders,
   ensureDesktopManagedAgentProviderStatuses,
   isDesktopManagedAgentProvider,
-  projectDesktopManagedAgentsState,
   projectDesktopManagedAgentsStateForAgentGUI
 } from "./desktopManagedAgentProviders.ts";
 
@@ -27,8 +26,8 @@ test("ensureDesktopManagedAgentProviderStatuses delegates managed provider loadi
   assert.deepEqual(calls, [[...desktopManagedAgentProviders]]);
 });
 
-test("projectDesktopManagedAgentsState derives AgentGUI managed state from provider status", () => {
-  const state = projectDesktopManagedAgentsState({
+test("projectDesktopManagedAgentsStateForAgentGUI derives AgentGUI managed state from provider status", () => {
+  const state = projectDesktopManagedAgentsStateForAgentGUI({
     capturedAt: "2026-06-02T08:00:00.000Z",
     defaultProvider: "codex",
     error: null,
@@ -51,12 +50,12 @@ test("projectDesktopManagedAgentsState derives AgentGUI managed state from provi
     ]
   });
 
-  assert.deepEqual(state.readyAgentIds, ["claude-code"]);
-  assert.deepEqual(state.configSyncedAgentIds, ["claude-code", "codex"]);
-  assert.equal(state.metadataSynced, true);
-  assert.equal(state.items[0]?.agentId, "claude-code");
-  assert.equal(state.items[1]?.agentId, "codex");
-  assert.equal(state.items[1]?.decisionReason, "auth_required");
+  assert.deepEqual(state?.readyAgentIds, ["claude-code"]);
+  assert.deepEqual(state?.configSyncedAgentIds, ["claude-code", "codex"]);
+  assert.equal(state?.metadataSynced, true);
+  assert.equal(state?.items[0]?.agentId, "claude-code");
+  assert.equal(state?.items[1]?.agentId, "codex");
+  assert.equal(state?.items[1]?.decisionReason, "auth_required");
 });
 
 test("projectDesktopManagedAgentsStateForAgentGUI keeps provider readiness unknown before first snapshot", () => {

--- a/apps/desktop/src/renderer/src/features/workspace-agent/services/internal/desktopManagedAgentProviders.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-agent/services/internal/desktopManagedAgentProviders.ts
@@ -27,9 +27,13 @@ export function ensureDesktopManagedAgentProviderStatuses(
   });
 }
 
-export function projectDesktopManagedAgentsState(
+export function projectDesktopManagedAgentsStateForAgentGUI(
   snapshot: AgentProviderStatusSnapshot
-): AgentHostManagedAgentsState {
+): AgentHostManagedAgentsState | null {
+  if (!snapshot.capturedAt) {
+    return null;
+  }
+
   const statusByProvider = new Map<WorkspaceAgentProvider, AgentProviderStatus>(
     snapshot.statuses.map((status) => [status.provider, status])
   );
@@ -60,27 +64,17 @@ export function projectDesktopManagedAgentsState(
       toolId: `${provider}-cli`
     };
   });
-  const revision = snapshot.capturedAt ?? "pending";
+  const revision = snapshot.capturedAt;
 
   return {
     agentProfileRevision: `agent-provider-status:${revision}`,
     configSyncedAgentIds,
     readyAgentIds,
     items,
-    metadataSynced: Boolean(snapshot.capturedAt && !snapshot.error),
+    metadataSynced: !snapshot.error,
     toolCatalogRevision: `agent-provider-status:${revision}`,
     totalCount: items.length
   };
-}
-
-export function projectDesktopManagedAgentsStateForAgentGUI(
-  snapshot: AgentProviderStatusSnapshot
-): AgentHostManagedAgentsState | null {
-  if (!snapshot.capturedAt) {
-    return null;
-  }
-
-  return projectDesktopManagedAgentsState(snapshot);
 }
 
 export function isDesktopManagedAgentProvider(

--- a/apps/desktop/src/renderer/src/features/workspace-workbench/services/internal/workspaceIssueManagerRichTextTriggerProviderRequest.test.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/services/internal/workspaceIssueManagerRichTextTriggerProviderRequest.test.ts
@@ -1,14 +1,13 @@
 import assert from "node:assert/strict";
 import test from "node:test";
-import {
-  createWorkspaceIssueManagerRichTextTriggerProviderRequest,
-  createWorkspaceIssueManagerRichTextTriggerProviderRequestFromIdentity
-} from "./workspaceIssueManagerRichTextTriggerProviderRequest.ts";
+import { createWorkspaceIssueManagerRichTextTriggerProviderRequestFromIdentity } from "./workspaceIssueManagerRichTextTriggerProviderRequest.ts";
 
 test("workspace issue manager rich text at provider request enables agent and app mentions", () => {
   assert.deepEqual(
-    createWorkspaceIssueManagerRichTextTriggerProviderRequest({
-      currentUserId: "user-1",
+    createWorkspaceIssueManagerRichTextTriggerProviderRequestFromIdentity({
+      currentUser: () => ({
+        userId: "user-1"
+      }),
       surface: "issue",
       workspaceId: "workspace-1"
     }),

--- a/apps/desktop/src/renderer/src/features/workspace-workbench/services/internal/workspaceIssueManagerRichTextTriggerProviderRequest.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/services/internal/workspaceIssueManagerRichTextTriggerProviderRequest.ts
@@ -1,32 +1,22 @@
 import type { DesktopRichTextAtCapability } from "@renderer/features/rich-text-at";
 
-export const workspaceIssueManagerRichTextTriggerCapabilities = [
+const workspaceIssueManagerRichTextTriggerCapabilities = [
   "agent-target",
   "workspace-app"
 ] as const satisfies readonly DesktopRichTextAtCapability[];
-
-export function createWorkspaceIssueManagerRichTextTriggerProviderRequest(input: {
-  currentUserId: string;
-  surface: string;
-  workspaceId: string;
-}) {
-  return {
-    capabilities: workspaceIssueManagerRichTextTriggerCapabilities,
-    metadata: { currentUserId: input.currentUserId },
-    surface: input.surface,
-    target: "issue-manager",
-    workspaceId: input.workspaceId
-  };
-}
 
 export function createWorkspaceIssueManagerRichTextTriggerProviderRequestFromIdentity(input: {
   currentUser: () => { userId: string };
   surface: string;
   workspaceId: string;
 }) {
-  return createWorkspaceIssueManagerRichTextTriggerProviderRequest({
-    currentUserId: input.currentUser().userId,
+  return {
+    capabilities: workspaceIssueManagerRichTextTriggerCapabilities,
+    metadata: {
+      currentUserId: input.currentUser().userId
+    },
     surface: input.surface,
+    target: "issue-manager",
     workspaceId: input.workspaceId
-  });
+  };
 }


### PR DESCRIPTION
## Summary
- remove `createWorkspaceIssueManagerRichTextTriggerProviderRequest` and keep only the identity-backed request builder that production still uses
- remove `projectDesktopManagedAgentsState` and fold the live projection into `projectDesktopManagedAgentsStateForAgentGUI`
- update the co-located tests to verify the current production entrypoints instead of the retired helper seams

## Historical role
- `createWorkspaceIssueManagerRichTextTriggerProviderRequest`
  - This was the direct payload builder for issue-manager rich-text trigger provider requests.
  - The current production path no longer calls it directly. `workspaceIssueManagerContribution.ts` only uses `createWorkspaceIssueManagerRichTextTriggerProviderRequestFromIdentity`, which already has everything it needs to build the final payload.
  - `git log -S'createWorkspaceIssueManagerRichTextTriggerProviderRequest'` traces the helper to `6aee7a83` (`Refactor rich text mentions around tuttiExternal (#70)`).
- `projectDesktopManagedAgentsState`
  - This was the base projection step for desktop managed-agent readiness before the AgentGUI-facing wrapper applied the first-snapshot gate.
  - The current production path only uses `projectDesktopManagedAgentsStateForAgentGUI` from `useDesktopManagedAgentsState.ts`; the separate base helper remained as a direct test seam.
  - `git log -S'projectDesktopManagedAgentsState'` shows the helper being carried through the current provider-status projection path, with the latest structural change in `4e28ce41` (`fix(agent): stabilize restored session output`).

## Reverification
- Exact cross-repo search now returns no hits for the removed helper symbols:
  - `createWorkspaceIssueManagerRichTextTriggerProviderRequest`
  - `projectDesktopManagedAgentsState`
- I rechecked both this repository and the sibling local `tsh` repository for exact symbol references before deletion, then reran the same exact search after deletion.
- The surviving entrypoints still have real production callers:
  - `createWorkspaceIssueManagerRichTextTriggerProviderRequestFromIdentity` is still used by `workspaceIssueManagerContribution.ts`
  - `projectDesktopManagedAgentsStateForAgentGUI` is still used by `useDesktopManagedAgentsState.ts`
- These changes stay inside private desktop renderer internals under `apps/desktop/src/...`; no published `@tutti-os/*` package API, daemon contract, or external repository dependency surface changes.

## Validation
- `pnpm --filter @tutti-os/desktop typecheck`
- `pnpm --filter @tutti-os/desktop test`
- `pnpm --filter @tutti-os/desktop build`
- `pnpm check:changed --tail-lines 80`
- `pnpm check:full`

## Docs impact
- `discard`
- No durable documentation update needed: this is private desktop internal cleanup only, with no public behavior or ownership change.
