### PR TITLE
fix(agent): recover cursor session state

### DIFF
--- a/docs/conventions/troubleshooting.md
+++ b/docs/conventions/troubleshooting.md
@@ -830,6 +830,43 @@ delimited by ---`, and the composer skill picker may show partial or
   [desktopRichTextAtService.ts](../../apps/desktop/src/renderer/src/features/rich-text-at/services/internal/desktopRichTextAtService.ts)
   [desktopAgentProviderStatusService.ts](../../apps/desktop/src/renderer/src/features/workspace-agent/services/internal/desktopAgentProviderStatusService.ts)
 
+### Agent GUI provider tab shows fused or stale conversations
+
+- Symptom:
+  Switching the Agent GUI aggregation rail between All, Cursor, Codex, or Claude
+  leaves the middle list and right detail panel out of sync. A provider tab can
+  still show other providers' sessions, or the right panel keeps the previous
+  agent after the middle list already changed.
+- Quick checks:
+  Inspect `workspace_agent_sessions.agent_target_id` for legacy Cursor rows. Old
+  Cursor imports may be missing `agent_target_id` while still carrying
+  `provider=cursor`. Confirm the active `conversationFilter` in the controller
+  and the per-query `agentGuiConversationListStore` projection for the selected
+  `local:<provider>` target.
+- Root cause:
+  Conversation retention in `agentGuiConversationListStore` previously kept
+  every targetless session under any agent-target tab. The rail also merged
+  unfiltered store conversations into runtime sections, and filter switches did
+  not always re-project the shared list or clear an active conversation outside
+  the new filter.
+- Fix:
+  Match agent-target tabs with `matchesAgentGUIConversationSummaryFilter`, using
+  `session.provider` as a fallback for legacy `local:<provider>` targets.
+  Backfill Cursor `agent_target_id` in daemon storage, re-project the list store
+  when `conversationFilter` changes, filter rail merges in `AgentGUINodeView`,
+  and open the selected target home composer when the active conversation no
+  longer matches the tab.
+- Validation:
+  Run
+  `pnpm --dir packages/agent/gui exec vitest run --environment jsdom agent-gui/agentGuiNode/model/agentGuiConversationFilter.spec.ts contexts/workspace/presentation/renderer/agentGuiConversationList/agentGuiConversationListStore.spec.ts agent-gui/agentGuiNode/controller/useAgentGUINodeController.spec.tsx -t "opens the selected target home composer when the active conversation is outside the new rail filter"`,
+  then `cd services/tuttid && go test ./data/workspace/...`.
+- References:
+  [agentGuiConversationFilter.ts](../../packages/agent/gui/agent-gui/agentGuiNode/model/agentGuiConversationFilter.ts)
+  [agentGuiConversationListStore.ts](../../packages/agent/gui/contexts/workspace/presentation/renderer/agentGuiConversationList/agentGuiConversationListStore.ts)
+  [useAgentGUINodeController.ts](../../packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUINodeController.ts)
+  [AgentGUINodeView.tsx](../../packages/agent/gui/agent-gui/agentGuiNode/AgentGUINodeView.tsx)
+  [agent_store.go](../../services/tuttid/data/workspace/agent_store.go)
+
 ### Agent GUI no-project sessions appear under a user project
 
 - Symptom:

--- a/packages/agent/daemon/runtime/acp_auto_continue.go
+++ b/packages/agent/daemon/runtime/acp_auto_continue.go
@@ -1,0 +1,80 @@
+package agentruntime
+
+import (
+	"fmt"
+	"strings"
+
+	activityshared "github.com/tutti-os/tutti/packages/agent/daemon/activity/events"
+)
+
+// Cursor's ACP agent surfaces transient upstream failures (its HTTP/2 stream
+// to the Cursor backend getting cut) as a plain trailing text chunk such as
+//
+//	Error: RetriableError: [canceled] http/2 stream closed with error code CANCEL (0x8)
+//
+// followed by a NORMAL session/prompt result — protocol-wise the turn looks
+// successful, so the conversation silently stops mid-task and the user has to
+// prod the agent to continue. cursor-agent classifies these as retriable
+// itself; when a provider opts in (config.autoContinueRetriableTurnError) the
+// adapter resumes the turn with a synthetic continue prompt a bounded number
+// of times, and marks the turn failed once the retries are also cut short.
+const acpAutoContinueMaxAttempts = 2
+
+var acpRetriableTurnTailPrefixes = []string{
+	"Error: RetriableError:",
+	"Error: ConnectError:",
+}
+
+// acpRetriableTurnTailError returns the transient-error line when the turn's
+// trailing assistant text ends with one.
+func acpRetriableTurnTailError(text string) (string, bool) {
+	trimmed := strings.TrimSpace(text)
+	if trimmed == "" {
+		return "", false
+	}
+	lines := strings.Split(trimmed, "\n")
+	last := strings.TrimSpace(lines[len(lines)-1])
+	for _, prefix := range acpRetriableTurnTailPrefixes {
+		if strings.HasPrefix(last, prefix) {
+			return last, true
+		}
+	}
+	return "", false
+}
+
+// acpStopReasonEndsTurnNormally reports whether the stop reason would take
+// Exec's default (turn-completed) branch — the only state worth auto-continuing
+// from. Canceled and hard-failure stop reasons keep their existing handling.
+func acpStopReasonEndsTurnNormally(stopReason string) bool {
+	switch stopReason {
+	case "canceled", "refusal", "max_tokens", "max_turn_requests":
+		return false
+	default:
+		return true
+	}
+}
+
+// acpAutoContinuePromptContent is the synthetic prompt that resumes a turn cut
+// short by a transient network error. It is deliberately not emitted as a
+// user message: the provider session retains the full prior context, so the
+// transcript shows the agent simply picking the work back up.
+func acpAutoContinuePromptContent() []map[string]any {
+	return []map[string]any{{
+		"type": "text",
+		"text": "The previous response was interrupted by a transient network error. Continue exactly where you left off; do not repeat work that already completed.",
+	}}
+}
+
+// acpAutoContinueNoticeEvent renders the in-transcript banner that separates
+// the error tail from the auto-continued output, so the retry is visible
+// instead of the agent appearing to stutter.
+func acpAutoContinueNoticeEvent(session Session, turnID string, errLine string, attempt int) (activityshared.Event, bool) {
+	return acpSystemNoticeEvent(session, turnID, map[string]any{
+		"kind":       "agent_system_notice",
+		"noticeKind": "transport_retry",
+		"severity":   "warning",
+		"title":      fmt.Sprintf("Connection to the agent backend dropped; continuing automatically (%d/%d).", attempt, acpAutoContinueMaxAttempts),
+		"detail":     errLine,
+		"retryable":  true,
+	}, "system_notice", true)
+}

--- a/packages/agent/daemon/runtime/acp_auto_continue_test.go
+++ b/packages/agent/daemon/runtime/acp_auto_continue_test.go
@@ -1,0 +1,239 @@
+package agentruntime
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	activityshared "github.com/tutti-os/tutti/packages/agent/daemon/activity/events"
+)
+
+func TestACPRetriableTurnTailError(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name     string
+		text     string
+		wantLine string
+		want     bool
+	}{
+		{
+			name:     "cursor retriable tail",
+			text:     "\n\nError: RetriableError: [canceled] http/2 stream closed with error code CANCEL (0x8)",
+			wantLine: "Error: RetriableError: [canceled] http/2 stream closed with error code CANCEL (0x8)",
+			want:     true,
+		},
+		{
+			name:     "connect error tail after normal text",
+			text:     "Checking the repo.\nError: ConnectError: [unavailable] upstream connect error",
+			wantLine: "Error: ConnectError: [unavailable] upstream connect error",
+			want:     true,
+		},
+		{
+			name: "error line followed by recovery is not a tail",
+			text: "Error: RetriableError: hiccup\nall good now",
+			want: false,
+		},
+		{
+			name: "plain completion",
+			text: "Done. The PR is open.",
+			want: false,
+		},
+		{
+			name: "empty",
+			text: "",
+			want: false,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			line, ok := acpRetriableTurnTailError(tc.text)
+			if ok != tc.want || line != tc.wantLine {
+				t.Fatalf("acpRetriableTurnTailError(%q) = %q, %v; want %q, %v", tc.text, line, ok, tc.wantLine, tc.want)
+			}
+		})
+	}
+}
+
+func acpTestPromptText(params map[string]any) string {
+	blocks, _ := params["prompt"].([]any)
+	var b strings.Builder
+	for _, raw := range blocks {
+		block, _ := raw.(map[string]any)
+		if asString(block["type"]) == "text" {
+			b.WriteString(asString(block["text"]))
+		}
+	}
+	return b.String()
+}
+
+// A cursor turn that ends "successfully" right after streaming a transient
+// network error must be resumed automatically with a synthetic continue
+// prompt, and the recovered turn must complete normally.
+func TestCursorAdapterAutoContinuesAfterRetriableTurnError(t *testing.T) {
+	t.Parallel()
+
+	transport := newStandardACPTransport("Cursor Agent", "cursor-session-1")
+	transport.conn.retriableErrorPrompts = 1
+	adapter := newCursorAdapterWithHostMetadata(transport, LegacyHostMetadata(), nil)
+	session := standardTestSession(ProviderCursor)
+	if _, err := adapter.Start(context.Background(), session); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	session.ProviderSessionID = "cursor-session-1"
+
+	events, err := adapter.Exec(context.Background(), session, textPrompt("build the report"), "", "turn-1", nil, nil)
+	if err != nil {
+		t.Fatalf("Exec: %v", err)
+	}
+
+	transport.conn.mu.Lock()
+	promptCalls := transport.conn.promptCallCount
+	snapshots := append([]map[string]any(nil), transport.conn.promptParamsSnapshots...)
+	transport.conn.mu.Unlock()
+	if promptCalls != 2 {
+		t.Fatalf("prompt calls = %d, want the auto-continue to send a second prompt", promptCalls)
+	}
+	if text := acpTestPromptText(snapshots[1]); !strings.Contains(text, "transient network error") {
+		t.Fatalf("continue prompt = %q, want the synthetic continue text", text)
+	}
+
+	var sawRetryNotice, sawCompleted, sawFailed bool
+	for _, event := range events {
+		if event.Type == activityshared.EventMessageAppended &&
+			asString(event.Payload.Metadata["noticeKind"]) == "transport_retry" {
+			sawRetryNotice = true
+		}
+		if event.Type == activityshared.EventTurnCompleted {
+			sawCompleted = true
+		}
+		if event.Type == activityshared.EventTurnFailed {
+			sawFailed = true
+		}
+	}
+	if !sawRetryNotice {
+		t.Fatalf("events = %#v, want a transport_retry system notice", activityEventTypeCounts(events))
+	}
+	if !sawCompleted || sawFailed {
+		t.Fatalf("turn terminal events completed=%v failed=%v, want completed only", sawCompleted, sawFailed)
+	}
+}
+
+// A continuation attempt that recovers with tool calls only (no new assistant
+// text) must not re-detect the previous attempt's error tail: the turn
+// completes after a single auto-continue instead of burning the remaining
+// retries on stale text and surfacing a false failure.
+func TestCursorAdapterAutoContinueToolOnlyContinuationCompletes(t *testing.T) {
+	t.Parallel()
+
+	transport := newStandardACPTransport("Cursor Agent", "cursor-session-1")
+	transport.conn.retriableErrorPrompts = 1
+	transport.conn.omitAssistantTextInPromptResults = true
+	adapter := newCursorAdapterWithHostMetadata(transport, LegacyHostMetadata(), nil)
+	session := standardTestSession(ProviderCursor)
+	if _, err := adapter.Start(context.Background(), session); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	session.ProviderSessionID = "cursor-session-1"
+
+	events, err := adapter.Exec(context.Background(), session, textPrompt("build the report"), "", "turn-1", nil, nil)
+	if err != nil {
+		t.Fatalf("Exec: %v", err)
+	}
+
+	transport.conn.mu.Lock()
+	promptCalls := transport.conn.promptCallCount
+	transport.conn.mu.Unlock()
+	if promptCalls != 2 {
+		t.Fatalf("prompt calls = %d, want exactly one auto-continue for a tool-only recovery", promptCalls)
+	}
+
+	var sawCompleted, sawFailed bool
+	for _, event := range events {
+		if event.Type == activityshared.EventTurnCompleted {
+			sawCompleted = true
+		}
+		if event.Type == activityshared.EventTurnFailed {
+			sawFailed = true
+		}
+	}
+	if !sawCompleted || sawFailed {
+		t.Fatalf("turn terminal events completed=%v failed=%v, want completed only", sawCompleted, sawFailed)
+	}
+}
+
+// When every continue attempt is also cut short, the turn must surface as
+// failed instead of a silent "completed" that strands the conversation.
+func TestCursorAdapterAutoContinueExhaustedMarksTurnFailed(t *testing.T) {
+	t.Parallel()
+
+	transport := newStandardACPTransport("Cursor Agent", "cursor-session-1")
+	transport.conn.retriableErrorPrompts = 100
+	adapter := newCursorAdapterWithHostMetadata(transport, LegacyHostMetadata(), nil)
+	session := standardTestSession(ProviderCursor)
+	if _, err := adapter.Start(context.Background(), session); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	session.ProviderSessionID = "cursor-session-1"
+
+	events, err := adapter.Exec(context.Background(), session, textPrompt("build the report"), "", "turn-1", nil, nil)
+	if err != nil {
+		t.Fatalf("Exec: %v", err)
+	}
+
+	transport.conn.mu.Lock()
+	promptCalls := transport.conn.promptCallCount
+	transport.conn.mu.Unlock()
+	if want := 1 + acpAutoContinueMaxAttempts; promptCalls != want {
+		t.Fatalf("prompt calls = %d, want %d (original + bounded retries)", promptCalls, want)
+	}
+
+	var failedError string
+	var sawCompleted bool
+	for _, event := range events {
+		if event.Type == activityshared.EventTurnFailed {
+			failedError = asString(event.Payload.Metadata["error"])
+		}
+		if event.Type == activityshared.EventTurnCompleted {
+			sawCompleted = true
+		}
+	}
+	if !strings.Contains(failedError, "RetriableError") {
+		t.Fatalf("turn failed error = %q, want the retriable error line", failedError)
+	}
+	if sawCompleted {
+		t.Fatal("turn must not also report completion after exhausting retries")
+	}
+}
+
+// Providers without the auto-continue opt-in must keep the old behavior: the
+// error tail stays a plain completed turn and no synthetic prompt is sent.
+func TestStandardACPAdapterWithoutOptInDoesNotAutoContinue(t *testing.T) {
+	t.Parallel()
+
+	transport := newStandardACPTransport("Gemini CLI", "gemini-session-1")
+	transport.conn.retriableErrorPrompts = 1
+	adapter := NewGeminiAdapter(transport)
+	session := standardTestSession(ProviderGemini)
+	if _, err := adapter.Start(context.Background(), session); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	session.ProviderSessionID = "gemini-session-1"
+
+	events, err := adapter.Exec(context.Background(), session, textPrompt("build the report"), "", "turn-1", nil, nil)
+	if err != nil {
+		t.Fatalf("Exec: %v", err)
+	}
+
+	transport.conn.mu.Lock()
+	promptCalls := transport.conn.promptCallCount
+	transport.conn.mu.Unlock()
+	if promptCalls != 1 {
+		t.Fatalf("prompt calls = %d, want no auto-continue without the opt-in", promptCalls)
+	}
+	for _, event := range events {
+		if event.Type == activityshared.EventTurnFailed {
+			t.Fatalf("event = %#v, want the legacy completed turn", event)
+		}
+	}
+}

--- a/packages/agent/daemon/runtime/acp_provider_cursor.go
+++ b/packages/agent/daemon/runtime/acp_provider_cursor.go
@@ -111,6 +111,10 @@ func newCursorAdapterWithHostMetadata(
 			// full-access auto-approves permission requests live; all tiers
 			// switch without a respawn.
 			autoApprovePermissionDecision: cursorAutoApprovePermissionDecision,
+			// cursor-agent ends the turn "successfully" after streaming
+			// transient upstream failures (RetriableError/ConnectError) as
+			// plain text; auto-continue instead of stalling the conversation.
+			autoContinueRetriableTurnError: true,
 		},
 		transport: transport,
 		host:      host,

--- a/packages/agent/daemon/runtime/acp_turn_normalizer.go
+++ b/packages/agent/daemon/runtime/acp_turn_normalizer.go
@@ -110,6 +110,20 @@ func (n *acpTurnNormalizer) AppendThinkingChunk(session Session, turnID string, 
 	return []activityshared.Event{n.thinkingSnapshotEvent(session, turnID, messageStreamStateStreaming)}
 }
 
+// CurrentAssistantText returns the text of the assistant segment currently
+// accumulating (the turn's most recent one). Exec uses it to inspect the
+// trailing output when a turn ends right after an in-band error line. A
+// finalized segment returns "": once Finish closed it out (as the
+// auto-continue path does before retrying), its text must not leak into the
+// next attempt's inspection — a continuation that streams no new assistant
+// text would otherwise re-detect the previous attempt's error tail.
+func (n *acpTurnNormalizer) CurrentAssistantText() string {
+	if n == nil || n.assistantSegmentCompleted {
+		return ""
+	}
+	return n.assistantContent.String()
+}
+
 func (n *acpTurnNormalizer) ApplyAssistantFinalText(finalText string) {
 	if n == nil {
 		return

--- a/packages/agent/daemon/runtime/standard_acp_adapter.go
+++ b/packages/agent/daemon/runtime/standard_acp_adapter.go
@@ -55,6 +55,10 @@ type standardACPConfig struct {
 	// token ("approved" / "denied") to apply automatically, or "" to prompt
 	// the user as usual. Nil (the default) always prompts.
 	autoApprovePermissionDecision func(permissionModeID string) string
+	// autoContinueRetriableTurnError resumes turns the agent ends "normally"
+	// right after streaming a transient network error as plain text (Cursor's
+	// "Error: RetriableError: ..." tail). See acp_auto_continue.go.
+	autoContinueRetriableTurnError bool
 }
 
 type standardACPAdapter struct {
@@ -844,103 +848,157 @@ func (a *standardACPAdapter) Exec(
 		)
 	}
 
-	result, err := acpSession.client.Call(ctx, acpMethodPrompt, map[string]any{
-		"sessionId": acpSession.providerSessionID,
-		"prompt":    acpPromptContent,
-	}, func(ctx context.Context, message acpMessage) error {
-		slog.Info("agent session ACP exec received message",
-			"event", "agent_session.acp.exec.message",
-			"provider", a.config.provider,
-			"adapter", a.config.adapterName,
-			"room_id", session.RoomID,
-			"agent_session_id", session.AgentSessionID,
-			"provider_session_id", session.ProviderSessionID,
-			"turn_id", turnID,
-			"message_method", message.Method,
-			"message_id", rawMessageLogValue(message.ID),
-		)
-		next, err := a.handleACPMessage(ctx, acpSession.client, session, turnID, message, normalizer, emitEvents, emitCommands)
-		slog.Info("agent session ACP exec handled message",
-			"event", "agent_session.acp.exec.message_handled",
-			"provider", a.config.provider,
-			"adapter", a.config.adapterName,
-			"room_id", session.RoomID,
-			"agent_session_id", session.AgentSessionID,
-			"provider_session_id", session.ProviderSessionID,
-			"turn_id", turnID,
-			"message_method", message.Method,
-			"event_count", len(next),
-			"event_type_counts", activityEventTypeCounts(next),
-			"error", errString(err),
-		)
-		emitEvents(next)
+	promptParams := acpPromptContent
+	autoContinueAttempts := 0
+execLoop:
+	for {
+		result, err := acpSession.client.Call(ctx, acpMethodPrompt, map[string]any{
+			"sessionId": acpSession.providerSessionID,
+			"prompt":    promptParams,
+		}, func(ctx context.Context, message acpMessage) error {
+			slog.Info("agent session ACP exec received message",
+				"event", "agent_session.acp.exec.message",
+				"provider", a.config.provider,
+				"adapter", a.config.adapterName,
+				"room_id", session.RoomID,
+				"agent_session_id", session.AgentSessionID,
+				"provider_session_id", session.ProviderSessionID,
+				"turn_id", turnID,
+				"message_method", message.Method,
+				"message_id", rawMessageLogValue(message.ID),
+			)
+			next, err := a.handleACPMessage(ctx, acpSession.client, session, turnID, message, normalizer, emitEvents, emitCommands)
+			slog.Info("agent session ACP exec handled message",
+				"event", "agent_session.acp.exec.message_handled",
+				"provider", a.config.provider,
+				"adapter", a.config.adapterName,
+				"room_id", session.RoomID,
+				"agent_session_id", session.AgentSessionID,
+				"provider_session_id", session.ProviderSessionID,
+				"turn_id", turnID,
+				"message_method", message.Method,
+				"event_count", len(next),
+				"event_type_counts", activityEventTypeCounts(next),
+				"error", errString(err),
+			)
+			emitEvents(next)
+			if err != nil {
+				return err
+			}
+			return nil
+		})
 		if err != nil {
-			return err
+			slog.Warn("agent session ACP exec call failed",
+				"event", "agent_session.acp.exec.call_failed",
+				"provider", a.config.provider,
+				"adapter", a.config.adapterName,
+				"room_id", session.RoomID,
+				"agent_session_id", session.AgentSessionID,
+				"provider_session_id", session.ProviderSessionID,
+				"turn_id", turnID,
+				"emitted_event_count", len(events),
+				"emitted_event_type_counts", activityEventTypeCounts(events),
+				"error", err.Error(),
+			)
+			if errors.Is(err, context.Canceled) || errors.Is(err, errPermissionRequestCanceled) {
+				terminalEvents := normalizer.FinishInterrupted(session, turnID, "interrupted")
+				terminalEvents = append(terminalEvents, newTurnActivityEvent(session, EventTurnCanceled, turnID, SessionStatusCanceled, "", "", map[string]any{
+					"error": err.Error(),
+				}))
+				emitEvents(terminalEvents)
+			} else {
+				terminalEvents := normalizer.FinishFailed(session, turnID)
+				terminalEvents = append(terminalEvents, newTurnActivityEvent(session, EventTurnFailed, turnID, SessionStatusFailed, "", "", map[string]any{
+					"error": err.Error(),
+				}))
+				emitEvents(terminalEvents)
+			}
+			return events, nil
 		}
-		return nil
-	})
-	if err != nil {
-		slog.Warn("agent session ACP exec call failed",
-			"event", "agent_session.acp.exec.call_failed",
+
+		stopReason := acpStopReason(result)
+		normalizer.ApplyAssistantFinalText(acpPromptResultAssistantText(result))
+		slog.Info("agent session ACP exec call completed",
+			"event", "agent_session.acp.exec.call_completed",
 			"provider", a.config.provider,
 			"adapter", a.config.adapterName,
 			"room_id", session.RoomID,
 			"agent_session_id", session.AgentSessionID,
 			"provider_session_id", session.ProviderSessionID,
 			"turn_id", turnID,
+			"stop_reason", firstNonEmpty(stopReason, "end_turn"),
+			"auto_continue_attempts", autoContinueAttempts,
 			"emitted_event_count", len(events),
 			"emitted_event_type_counts", activityEventTypeCounts(events),
-			"error", err.Error(),
 		)
-		if errors.Is(err, context.Canceled) || errors.Is(err, errPermissionRequestCanceled) {
-			terminalEvents := normalizer.FinishInterrupted(session, turnID, "interrupted")
+		if a.config.autoContinueRetriableTurnError && acpStopReasonEndsTurnNormally(stopReason) {
+			if errLine, ok := acpRetriableTurnTailError(normalizer.CurrentAssistantText()); ok {
+				if autoContinueAttempts < acpAutoContinueMaxAttempts {
+					autoContinueAttempts++
+					// Close out the error-text segment so the continuation
+					// streams into a fresh message instead of appending to it.
+					emitEvents(normalizer.Finish(session, turnID, messageStreamStateCompleted))
+					if notice, ok := acpAutoContinueNoticeEvent(session, turnID, errLine, autoContinueAttempts); ok {
+						emitEvents([]activityshared.Event{notice})
+					}
+					slog.Warn("agent session ACP auto-continue after retriable turn error",
+						"event", "agent_session.acp.exec.auto_continue",
+						"provider", a.config.provider,
+						"adapter", a.config.adapterName,
+						"room_id", session.RoomID,
+						"agent_session_id", session.AgentSessionID,
+						"provider_session_id", session.ProviderSessionID,
+						"turn_id", turnID,
+						"attempt", autoContinueAttempts,
+						"max_attempts", acpAutoContinueMaxAttempts,
+						"error_line", errLine,
+					)
+					promptParams = acpAutoContinuePromptContent()
+					continue execLoop
+				}
+				// The retries were cut short too: surface the turn as failed
+				// instead of a silent "completed" that strands the conversation.
+				terminalEvents := normalizer.FinishFailed(session, turnID)
+				terminalEvents = append(terminalEvents, newTurnActivityEvent(session, EventTurnFailed, turnID, SessionStatusFailed, "", "", map[string]any{
+					"error":      errLine,
+					"stopReason": firstNonEmpty(stopReason, "end_turn"),
+				}))
+				emitEvents(terminalEvents)
+				slog.Warn("agent session ACP auto-continue attempts exhausted",
+					"event", "agent_session.acp.exec.auto_continue_exhausted",
+					"provider", a.config.provider,
+					"adapter", a.config.adapterName,
+					"room_id", session.RoomID,
+					"agent_session_id", session.AgentSessionID,
+					"provider_session_id", session.ProviderSessionID,
+					"turn_id", turnID,
+					"attempts", autoContinueAttempts,
+					"error_line", errLine,
+				)
+				break execLoop
+			}
+		}
+		switch stopReason {
+		case "canceled":
+			terminalEvents := normalizer.FinishInterrupted(session, turnID, stopReason)
 			terminalEvents = append(terminalEvents, newTurnActivityEvent(session, EventTurnCanceled, turnID, SessionStatusCanceled, "", "", map[string]any{
-				"error": err.Error(),
+				"stopReason": stopReason,
 			}))
 			emitEvents(terminalEvents)
-		} else {
+		case "refusal", "max_tokens", "max_turn_requests":
 			terminalEvents := normalizer.FinishFailed(session, turnID)
 			terminalEvents = append(terminalEvents, newTurnActivityEvent(session, EventTurnFailed, turnID, SessionStatusFailed, "", "", map[string]any{
-				"error": err.Error(),
+				"stopReason": stopReason,
+			}))
+			emitEvents(terminalEvents)
+		default:
+			terminalEvents := normalizer.FinishCompleted(session, turnID)
+			terminalEvents = append(terminalEvents, newTurnActivityEvent(session, EventTurnCompleted, turnID, SessionStatusReady, "", "", map[string]any{
+				"stopReason": firstNonEmpty(stopReason, "end_turn"),
 			}))
 			emitEvents(terminalEvents)
 		}
-		return events, nil
-	}
-
-	stopReason := acpStopReason(result)
-	normalizer.ApplyAssistantFinalText(acpPromptResultAssistantText(result))
-	slog.Info("agent session ACP exec call completed",
-		"event", "agent_session.acp.exec.call_completed",
-		"provider", a.config.provider,
-		"adapter", a.config.adapterName,
-		"room_id", session.RoomID,
-		"agent_session_id", session.AgentSessionID,
-		"provider_session_id", session.ProviderSessionID,
-		"turn_id", turnID,
-		"stop_reason", firstNonEmpty(stopReason, "end_turn"),
-		"emitted_event_count", len(events),
-		"emitted_event_type_counts", activityEventTypeCounts(events),
-	)
-	switch stopReason {
-	case "canceled":
-		terminalEvents := normalizer.FinishInterrupted(session, turnID, stopReason)
-		terminalEvents = append(terminalEvents, newTurnActivityEvent(session, EventTurnCanceled, turnID, SessionStatusCanceled, "", "", map[string]any{
-			"stopReason": stopReason,
-		}))
-		emitEvents(terminalEvents)
-	case "refusal", "max_tokens", "max_turn_requests":
-		terminalEvents := normalizer.FinishFailed(session, turnID)
-		terminalEvents = append(terminalEvents, newTurnActivityEvent(session, EventTurnFailed, turnID, SessionStatusFailed, "", "", map[string]any{
-			"stopReason": stopReason,
-		}))
-		emitEvents(terminalEvents)
-	default:
-		terminalEvents := normalizer.FinishCompleted(session, turnID)
-		terminalEvents = append(terminalEvents, newTurnActivityEvent(session, EventTurnCompleted, turnID, SessionStatusReady, "", "", map[string]any{
-			"stopReason": firstNonEmpty(stopReason, "end_turn"),
-		}))
-		emitEvents(terminalEvents)
+		break execLoop
 	}
 	slog.Info("agent session ACP exec finished",
 		"event", "agent_session.acp.exec.finished",

--- a/packages/agent/daemon/runtime/standard_acp_adapter_test.go
+++ b/packages/agent/daemon/runtime/standard_acp_adapter_test.go
@@ -4527,8 +4527,17 @@ type standardACPConnection struct {
 	lastLoadSessionParams         map[string]any
 	lastCloseSessionParams        map[string]any
 	lastPromptParamsSnapshot      map[string]any
-	setConfigOptionSnapshots      []map[string]any
-	configOptions                 []map[string]any
+	promptParamsSnapshots         []map[string]any
+	promptCallCount               int
+	// retriableErrorPrompts makes the first N session/prompt calls emulate
+	// cursor-agent's transient-failure shape: an "Error: RetriableError: ..."
+	// text chunk followed by a normal end_turn result.
+	retriableErrorPrompts int
+	// omitAssistantTextInPromptResults drops the agent_message_chunk from
+	// normal prompt results, emulating a tool-calls-only turn.
+	omitAssistantTextInPromptResults bool
+	setConfigOptionSnapshots         []map[string]any
+	configOptions                    []map[string]any
 }
 
 func (c *standardACPConnection) Send(data []byte) error {
@@ -4740,8 +4749,33 @@ func (c *standardACPConnection) Send(data []byte) error {
 			c.mu.Lock()
 			if request.Params != nil {
 				c.lastPromptParamsSnapshot = maps.Clone(request.Params)
+				c.promptParamsSnapshots = append(c.promptParamsSnapshots, maps.Clone(request.Params))
 			}
+			c.promptCallCount++
+			promptCall := c.promptCallCount
 			c.mu.Unlock()
+			if promptCall <= c.retriableErrorPrompts {
+				c.sendJSON(map[string]any{
+					"jsonrpc": "2.0",
+					"method":  acpMethodUpdate,
+					"params": map[string]any{
+						"sessionId": c.sessionID,
+						"update": map[string]any{
+							"sessionUpdate": "agent_message_chunk",
+							"content": map[string]any{
+								"type": "text",
+								"text": "\n\nError: RetriableError: [canceled] http/2 stream closed with error code CANCEL (0x8)",
+							},
+						},
+					},
+				})
+				c.sendJSON(map[string]any{
+					"jsonrpc": "2.0",
+					"id":      message.ID,
+					"result":  map[string]any{"stopReason": "end_turn"},
+				})
+				return nil
+			}
 			if c.promptPermission || c.promptKind != "" {
 				c.mu.Lock()
 				c.pendingPermissionCallID = append(json.RawMessage(nil), message.ID...)
@@ -4830,20 +4864,22 @@ func (c *standardACPConnection) streamPromptResult(promptID json.RawMessage) {
 			},
 		},
 	})
-	c.sendJSON(map[string]any{
-		"jsonrpc": "2.0",
-		"method":  acpMethodUpdate,
-		"params": map[string]any{
-			"sessionId": c.sessionID,
-			"update": map[string]any{
-				"sessionUpdate": "agent_message_chunk",
-				"content": map[string]any{
-					"type": "text",
-					"text": "Inspecting files.",
+	if !c.omitAssistantTextInPromptResults {
+		c.sendJSON(map[string]any{
+			"jsonrpc": "2.0",
+			"method":  acpMethodUpdate,
+			"params": map[string]any{
+				"sessionId": c.sessionID,
+				"update": map[string]any{
+					"sessionUpdate": "agent_message_chunk",
+					"content": map[string]any{
+						"type": "text",
+						"text": "Inspecting files.",
+					},
 				},
 			},
-		},
-	})
+		})
+	}
 	if c.pauseBeforeToolCallCompletion != nil {
 		<-c.pauseBeforeToolCallCompletion
 	}

--- a/packages/agent/gui/agent-gui/agentGuiNode/AgentGUINodeView.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/AgentGUINodeView.tsx
@@ -154,6 +154,7 @@ import {
   type ConversationSection
 } from "./agentGuiNodeViewConversation";
 import { buildAgentGUIConversationSummaries } from "./model/agentGuiConversationModel";
+import { filterAgentGUIConversationSummaries } from "./model/agentGuiConversationFilter";
 import styles from "./AgentGUINode.styles";
 import type { AgentContextMentionProvider } from "./agentContextMentionProvider";
 import type {
@@ -5025,12 +5026,21 @@ function useAgentGUIConversationRail({
     if (!runtimeSectionsEnabled) {
       return;
     }
+    const filteredConversations = filterAgentGUIConversationSummaries(
+      conversations,
+      conversationFilter
+    );
     setRuntimeRailSections((current) =>
-      updateConversationSectionsFromSummaries(current, conversations, {
+      updateConversationSectionsFromSummaries(current, filteredConversations, {
         sectionConversationsLabel: labels.sectionConversations
       })
     );
-  }, [conversations, labels.sectionConversations, runtimeSectionsEnabled]);
+  }, [
+    conversationFilter,
+    conversations,
+    labels.sectionConversations,
+    runtimeSectionsEnabled
+  ]);
 
   const loadMoreSectionConversations = useCallback(
     (section: ConversationSection) => {

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUINodeController.spec.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUINodeController.spec.tsx
@@ -592,7 +592,7 @@ describe("useAgentGUINodeController", () => {
     expect(result.current.viewModel.providerReadinessGate).toBeNull();
   });
 
-  it("keeps the active conversation target stable while an empty rail target transition starts", async () => {
+  it("opens the selected target home composer when the active conversation is outside the new rail filter", async () => {
     const unactivate = vi.fn();
     installAgentHostApi({
       list: vi.fn(async () => ({
@@ -669,10 +669,11 @@ describe("useAgentGUINodeController", () => {
         agentTargetId: "local:claude-code"
       });
     });
-    expect(result.current.viewModel.activeConversationId).toBe("codex-session");
-    expect(result.current.viewModel.data.provider).toBe("codex");
+    await waitFor(() => {
+      expect(result.current.viewModel.activeConversationId).toBeNull();
+    });
     expect(result.current.viewModel.selectedProviderTarget.provider).toBe(
-      "codex"
+      "claude-code"
     );
     await waitFor(() => {
       expect(unactivate).toHaveBeenCalledWith({
@@ -3762,9 +3763,18 @@ describe("useAgentGUINodeController", () => {
       list: vi.fn(async () => ({
         presences: [],
         sessions: [
-          workspaceAgentSession("session-1", { title: "2132" }),
-          workspaceAgentSession("session-2", { title: "hi" }),
-          workspaceAgentSession("session-3", { title: "这是什么?" })
+          workspaceAgentSession("session-1", {
+            title: "2132",
+            updatedAtUnixMs: 3_000
+          }),
+          workspaceAgentSession("session-2", {
+            title: "hi",
+            updatedAtUnixMs: 2_000
+          }),
+          workspaceAgentSession("session-3", {
+            title: "这是什么?",
+            updatedAtUnixMs: 1_000
+          })
         ]
       })),
       listSessionTimeline: vi.fn(async () => ({ timelineItems: [] })),

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUINodeController.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUINodeController.ts
@@ -81,6 +81,7 @@ import {
 import {
   createAgentGUIConversationFilterState,
   filterAgentGUIConversationSummaries,
+  matchesAgentGUIConversationSummaryFilter,
   normalizeAgentGUIConversationFilter,
   type AgentGUIConversationFilter
 } from "../model/agentGuiConversationFilter";
@@ -7128,6 +7129,7 @@ export function useAgentGUINodeController({
       dataRef.current.lastActiveAgentSessionId
     );
   }, [
+    conversationFilter,
     currentUserId,
     data.provider,
     previewMode,
@@ -11375,12 +11377,22 @@ export function useAgentGUINodeController({
         ? { kind: "agentTarget" as const, agentTargetId }
         : { kind: "all" as const };
       setConversationFilter(nextFilter);
-      // Keep the home composer chip in sync with the selected tab. Active
-      // conversations keep owning their target until the target-filtered list
-      // has initialized and proven empty.
-      if (activeConversationIdRef.current === null) {
-        selectHomeComposerAgentTarget(input);
+      const activeId = activeConversationIdRef.current;
+      if (activeId) {
+        const activeSummary = resolveConversationSummaryById(
+          conversationsRef.current,
+          activeId,
+          transientConversationRef.current
+        );
+        if (
+          activeSummary &&
+          !matchesAgentGUIConversationSummaryFilter(activeSummary, nextFilter)
+        ) {
+          selectHomeComposerAgentTarget(input);
+        }
+        return;
       }
+      selectHomeComposerAgentTarget(input);
     },
     [
       agentActivityRuntime,

--- a/packages/agent/gui/agent-gui/agentGuiNode/model/agentGuiConversationFilter.spec.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/model/agentGuiConversationFilter.spec.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import type { WorkspaceAgentActivitySession } from "../../../shared/workspaceAgentActivityTypes.ts";
 import type { AgentGUIConversationSummary } from "./agentGuiConversationModel.ts";
+import type { AgentGUIResolvedProvider } from "../../../shared/agentConversationTitleProjection.ts";
 import {
   createAgentGUIConversationFilterState,
   filterAgentGUIConversationSummaries,
@@ -25,13 +26,26 @@ describe("agentGuiConversationFilter", () => {
     expect(
       filterAgentGUIConversationSummaries(
         [
-          conversation("codex-local", "local:codex"),
-          conversation("codex-shared", "shared:codex"),
-          conversation("targetless", null)
+          conversation("codex-local", "local:codex", "codex"),
+          conversation("codex-shared", "shared:codex", "codex"),
+          conversation("targetless", null, "codex")
         ],
         { kind: "agentTarget", agentTargetId: "local:codex" }
       ).map((item) => item.id)
-    ).toEqual(["codex-local"]);
+    ).toEqual(["codex-local", "targetless"]);
+  });
+
+  it("matches legacy provider-only sessions to local system agent targets", () => {
+    expect(
+      filterAgentGUIConversationSummaries(
+        [
+          conversation("cursor-legacy", null, "cursor"),
+          conversation("codex-legacy", null, "codex"),
+          conversation("cursor-tagged", "local:cursor", "cursor")
+        ],
+        { kind: "agentTarget", agentTargetId: "local:cursor" }
+      ).map((item) => item.id)
+    ).toEqual(["cursor-legacy", "cursor-tagged"]);
   });
 
   it("keeps the filter model independent from composer state", () => {
@@ -78,13 +92,14 @@ function session(
 
 function conversation(
   id: string,
-  agentTargetId: string | null
+  agentTargetId: string | null,
+  provider: AgentGUIResolvedProvider = "codex"
 ): AgentGUIConversationSummary {
   return {
     id,
     agentTargetId,
     cwd: "/repo",
-    provider: "codex",
+    provider,
     status: "completed",
     title: id,
     updatedAtUnixMs: 1

--- a/packages/agent/gui/agent-gui/agentGuiNode/model/agentGuiConversationFilter.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/model/agentGuiConversationFilter.ts
@@ -42,6 +42,7 @@ export function filterAgentGUIConversationSummaries(
   return conversations.filter((conversation) =>
     matchesAgentGUIConversationFilterAgentTarget(
       conversation.agentTargetId,
+      conversation.provider,
       normalizedFilter
     )
   );
@@ -55,17 +56,54 @@ export function filterWorkspaceAgentActivitySessionsForConversations(
   return sessions.filter((session) =>
     matchesAgentGUIConversationFilterAgentTarget(
       session.agentTargetId,
+      session.provider,
       normalizedFilter
     )
   );
 }
 
+export function matchesAgentGUIConversationSummaryFilter(
+  conversation: {
+    agentTargetId?: string | null;
+    provider?: string | null;
+  },
+  filter: AgentGUIConversationFilter
+): boolean {
+  return matchesAgentGUIConversationFilterAgentTarget(
+    conversation.agentTargetId,
+    conversation.provider,
+    normalizeAgentGUIConversationFilter(filter)
+  );
+}
+
+function providerForLocalAgentTargetFilter(
+  agentTargetId: string
+): string | null {
+  const normalized = agentTargetId.trim();
+  if (!normalized.startsWith("local:")) {
+    return null;
+  }
+  const provider = normalized.slice("local:".length).trim();
+  return provider.length > 0 ? provider : null;
+}
+
 function matchesAgentGUIConversationFilterAgentTarget(
   agentTargetId: string | null | undefined,
+  provider: string | null | undefined,
   filter: AgentGUIConversationFilter
 ): boolean {
   if (filter.kind === "all") {
     return true;
   }
-  return (agentTargetId?.trim() ?? "") === filter.agentTargetId;
+  const sessionTargetId = agentTargetId?.trim() ?? "";
+  if (sessionTargetId.length > 0) {
+    return sessionTargetId === filter.agentTargetId;
+  }
+  const filterProvider = providerForLocalAgentTargetFilter(
+    filter.agentTargetId
+  );
+  if (!filterProvider) {
+    return false;
+  }
+  return (provider?.trim() ?? "") === filterProvider;
 }

--- a/packages/agent/gui/contexts/workspace/presentation/renderer/agentGuiConversationList/agentGuiConversationListStore.spec.ts
+++ b/packages/agent/gui/contexts/workspace/presentation/renderer/agentGuiConversationList/agentGuiConversationListStore.spec.ts
@@ -165,6 +165,53 @@ describe("agentGuiConversationListStore", () => {
     });
   });
 
+  it("does not retain other-provider legacy sessions under a cursor agent target filter", async () => {
+    const cursorQuery: AgentGUIConversationListQuery = {
+      conversationFilter: {
+        kind: "agentTarget",
+        agentTargetId: "local:cursor"
+      },
+      workspaceId: "workspace-1",
+      userId: "user-1",
+      provider: "codex",
+      sessionOrigin: "WORKSPACE_AGENT_SESSION_ORIGIN_RUNTIME"
+    };
+    const snapshot: WorkspaceAgentActivitySnapshot = {
+      ...emptySnapshot(),
+      sessions: [
+        runtimeSession("cursor-tagged", 3_000, {
+          agentTargetId: "local:cursor",
+          provider: "cursor",
+          title: "Cursor tagged"
+        }),
+        runtimeSession("cursor-legacy", 2_500, {
+          provider: "cursor",
+          title: "Cursor legacy"
+        }),
+        runtimeSession("codex-legacy", 2_000, {
+          provider: "codex",
+          title: "Codex legacy"
+        })
+      ]
+    };
+    setAgentActivityRuntimeForTests({
+      getSnapshot: () => snapshot,
+      load: async () => snapshot,
+      subscribe: () => () => {}
+    } as Partial<AgentActivityRuntime> as AgentActivityRuntime);
+
+    ensureAgentGUIConversationListQuery(cursorQuery);
+    scheduleAgentGUIConversationListProjection(cursorQuery, "projection-sync");
+
+    await waitFor(() => {
+      expect(
+        getAgentGUIConversationListQuerySnapshot(
+          cursorQuery
+        )?.conversations.map((item) => item.id)
+      ).toEqual(["cursor-tagged", "cursor-legacy"]);
+    });
+  });
+
   it("releases local-created conversations that do not match the query's agent target filter", async () => {
     const codexQuery: AgentGUIConversationListQuery = {
       conversationFilter: { kind: "agentTarget", agentTargetId: "local:codex" },

--- a/packages/agent/gui/contexts/workspace/presentation/renderer/agentGuiConversationList/agentGuiConversationListStore.ts
+++ b/packages/agent/gui/contexts/workspace/presentation/renderer/agentGuiConversationList/agentGuiConversationListStore.ts
@@ -13,6 +13,7 @@ import {
   type AgentGUIConversationSummary
 } from "../../../../../agent-gui/agentGuiNode/model/agentGuiConversationModel";
 import {
+  matchesAgentGUIConversationSummaryFilter,
   normalizeAgentGUIConversationFilter,
   type AgentGUIConversationFilter
 } from "../../../../../agent-gui/agentGuiNode/model/agentGuiConversationFilter";
@@ -169,9 +170,8 @@ function conversationFilterKey(
 
 /**
  * A conversation may only be retained (pinned/carried over) in a query state
- * whose agent-target filter it does not contradict. Conversations without a
- * known summary or without an agentTargetId are kept: we can only prove a
- * mismatch when both sides are known.
+ * whose agent-target filter it matches. Legacy sessions without agentTargetId
+ * may still match a local system target through provider identity.
  */
 function conversationRetainableForQueryFilter(
   conversation: AgentGUIConversationSummary | undefined,
@@ -180,8 +180,7 @@ function conversationRetainableForQueryFilter(
   if (!conversation || !filter || filter.kind !== "agentTarget") {
     return true;
   }
-  const agentTargetId = conversation.agentTargetId?.trim() ?? "";
-  return agentTargetId.length === 0 || agentTargetId === filter.agentTargetId;
+  return matchesAgentGUIConversationSummaryFilter(conversation, filter);
 }
 
 export function createAgentGUIConversationListQueryKey(
@@ -1358,6 +1357,15 @@ async function refreshAgentGUIConversationListQuery(
           : [];
       })
     );
+    const snapshotSessionProviderById = new Map(
+      workspaceAgentSnapshot.sessions.flatMap((session) => {
+        const agentSessionId = session.agentSessionId.trim();
+        const provider = session.provider?.trim() ?? "";
+        return agentSessionId && provider
+          ? [[agentSessionId, provider] as const]
+          : [];
+      })
+    );
     const retainableForQueryFilter = (agentSessionId: string): boolean => {
       const filter = state.query.conversationFilter;
       if (!filter || filter.kind !== "agentTarget") {
@@ -1367,8 +1375,15 @@ async function refreshAgentGUIConversationListQuery(
       // stale current summary.
       const snapshotAgentTargetId =
         snapshotSessionAgentTargetIdById.get(agentSessionId);
-      if (snapshotAgentTargetId) {
-        return snapshotAgentTargetId === filter.agentTargetId;
+      const snapshotProvider = snapshotSessionProviderById.get(agentSessionId);
+      if (snapshotAgentTargetId || snapshotProvider) {
+        return matchesAgentGUIConversationSummaryFilter(
+          {
+            agentTargetId: snapshotAgentTargetId ?? null,
+            provider: snapshotProvider ?? null
+          },
+          filter
+        );
       }
       return conversationRetainableForQueryFilter(
         currentConversationsById.get(agentSessionId),

--- a/packages/agent/gui/vitest.setup.ts
+++ b/packages/agent/gui/vitest.setup.ts
@@ -18,6 +18,9 @@ import type {
 } from "./host/agentHostApi";
 import { installReactRenderLoopConsoleTrap } from "./test/reactRenderLoopConsoleTrap";
 
+// Vitest 4 runs with NODE_ENV=development; agent test harnesses gate on "test".
+process.env.NODE_ENV = "test";
+
 const originalConsoleInfo = console.info.bind(console);
 console.info = (...args: unknown[]) => {
   if (isSuppressedAgentGuiDiagnostic(args)) {

--- a/packages/agent/store-sqlite/migrations.go
+++ b/packages/agent/store-sqlite/migrations.go
@@ -26,6 +26,7 @@ const schemaMigrationWorkspaceAgentActivityV3 = "workspace_agent_activity_v3"
 const schemaMigrationWorkspaceAgentActivityV4 = "workspace_agent_activity_v4"
 const schemaMigrationWorkspaceAgentActivityV5 = "workspace_agent_activity_v5"
 const schemaMigrationWorkspaceAgentActivityV6 = "workspace_agent_activity_v6"
+const schemaMigrationWorkspaceAgentActivityV7 = "workspace_agent_activity_v7"
 const schemaMigrationWorkspaceAgentActivityRailV1 = "workspace_agent_activity_rail_v1"
 const schemaMigrationAgentTargetsV1 = "agent_targets_v1"
 
@@ -79,6 +80,9 @@ CREATE TABLE IF NOT EXISTS `+schemaMigrationsTable+` (
 		return err
 	}
 	if err := s.applyWorkspaceAgentActivityV6(ctx); err != nil {
+		return err
+	}
+	if err := s.applyWorkspaceAgentActivityV7(ctx); err != nil {
 		return err
 	}
 	if err := s.applyAgentTargetsV1(ctx); err != nil {

--- a/packages/agent/store-sqlite/migrations_activity.go
+++ b/packages/agent/store-sqlite/migrations_activity.go
@@ -199,6 +199,37 @@ func (s *Store) applyWorkspaceAgentActivityV6(ctx context.Context) error {
 	return s.recordMigration(ctx, schemaMigrationWorkspaceAgentActivityV6)
 }
 
+// workspaceAgentActivityV7BackfillProviders are the providers whose
+// TargetIDBackfillByProvider entry shipped after the one-time v5 backfill was
+// already recorded on existing databases. v5 never replays (its marker is
+// claimed from the legacy ledger), so without this step legacy sessions of a
+// later-added provider keep an empty agent_target_id forever — and the
+// server-side paged section queries, which filter strictly by
+// agent_target_id, silently exclude them from the provider's tab.
+var workspaceAgentActivityV7BackfillProviders = []string{"cursor"}
+
+func (s *Store) applyWorkspaceAgentActivityV7(ctx context.Context) error {
+	applied, err := s.hasMigration(ctx, schemaMigrationWorkspaceAgentActivityV7)
+	if err != nil {
+		return err
+	}
+	if applied {
+		return nil
+	}
+
+	for _, provider := range workspaceAgentActivityV7BackfillProviders {
+		targetID := s.opts.TargetIDBackfillByProvider[provider]
+		if targetID == "" {
+			continue
+		}
+		if err := s.backfillAgentTargetIDForProvider(ctx, provider, targetID); err != nil {
+			return err
+		}
+	}
+
+	return s.recordMigration(ctx, schemaMigrationWorkspaceAgentActivityV7)
+}
+
 func (s *Store) backfillSystemAgentTargetIDs(ctx context.Context) error {
 	providers := make([]string, 0, len(s.opts.TargetIDBackfillByProvider))
 	for provider := range s.opts.TargetIDBackfillByProvider {
@@ -206,14 +237,21 @@ func (s *Store) backfillSystemAgentTargetIDs(ctx context.Context) error {
 	}
 	sort.Strings(providers)
 	for _, provider := range providers {
-		if _, err := s.db.ExecContext(ctx, `
+		if err := s.backfillAgentTargetIDForProvider(ctx, provider, s.opts.TargetIDBackfillByProvider[provider]); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (s *Store) backfillAgentTargetIDForProvider(ctx context.Context, provider string, targetID string) error {
+	if _, err := s.db.ExecContext(ctx, `
 UPDATE workspace_agent_sessions
 SET agent_target_id = ?
 WHERE (agent_target_id IS NULL OR TRIM(agent_target_id) = '')
   AND provider = ?
-`, s.opts.TargetIDBackfillByProvider[provider], provider); err != nil {
-			return fmt.Errorf("backfill %s agent target ids: %w", provider, err)
-		}
+`, targetID, provider); err != nil {
+		return fmt.Errorf("backfill %s agent target ids: %w", provider, err)
 	}
 	return nil
 }

--- a/packages/agent/store-sqlite/migrations_test.go
+++ b/packages/agent/store-sqlite/migrations_test.go
@@ -243,6 +243,61 @@ WHERE workspace_id = 'ws-legacy' AND agent_session_id = 'session-untargeted'
 	}
 }
 
+// A database that already recorded (claimed) the one-time v5 backfill — which
+// ran before the cursor provider existed — must still backfill legacy cursor
+// sessions: v7 replays the target-id backfill for providers added to
+// TargetIDBackfillByProvider after v5, and only for those.
+func TestStoreMigrateBackfillsCursorTargetsOnClaimedLegacyDatabase(t *testing.T) {
+	t.Parallel()
+
+	db := openTestDB(t)
+	createLegacyTuttidDatabase(t, db)
+	if _, err := db.Exec(`
+INSERT INTO workspace_agent_sessions (
+  workspace_id, agent_session_id, origin, agent_target_id, provider, title, status,
+  created_at_unix_ms, updated_at_unix_ms
+) VALUES ('ws-legacy', 'session-cursor-legacy', 'runtime', '', 'cursor', 'Legacy Cursor', 'completed', 1, 1);
+`); err != nil {
+		t.Fatalf("insert legacy cursor session: %v", err)
+	}
+	options := testOptions(&staticProjectPaths{})
+	options.TargetIDBackfillByProvider["cursor"] = "local:cursor"
+	store := New(db, options)
+	ctx := context.Background()
+
+	if err := store.Migrate(ctx); err != nil {
+		t.Fatalf("Migrate() error = %v", err)
+	}
+
+	var cursorTarget sql.NullString
+	if err := db.QueryRowContext(ctx, `
+SELECT agent_target_id FROM workspace_agent_sessions
+WHERE workspace_id = 'ws-legacy' AND agent_session_id = 'session-cursor-legacy'
+`).Scan(&cursorTarget); err != nil {
+		t.Fatalf("read legacy cursor session: %v", err)
+	}
+	if cursorTarget.String != "local:cursor" {
+		t.Fatalf("legacy cursor agent_target_id = %q, want local:cursor (v7 backfill)", cursorTarget.String)
+	}
+
+	// v7 is scoped to providers added after v5: the untargeted codex session
+	// keeps the claimed-v5 outcome.
+	var codexTarget sql.NullString
+	if err := db.QueryRowContext(ctx, `
+SELECT agent_target_id FROM workspace_agent_sessions
+WHERE workspace_id = 'ws-legacy' AND agent_session_id = 'session-untargeted'
+`).Scan(&codexTarget); err != nil {
+		t.Fatalf("read untargeted codex session: %v", err)
+	}
+	if codexTarget.String != "" {
+		t.Fatalf("untargeted codex agent_target_id = %q, want empty (v7 must not replay the full v5 backfill)", codexTarget.String)
+	}
+
+	if applied, err := store.hasMigration(ctx, schemaMigrationWorkspaceAgentActivityV7); err != nil || !applied {
+		t.Fatalf("v7 marker recorded = %v error = %v, want recorded", applied, err)
+	}
+}
+
 func TestStoreMigrateUpgradesPartiallyMigratedLegacyDatabase(t *testing.T) {
 	t.Parallel()
 

--- a/services/tuttid/data/workspace/agent_store.go
+++ b/services/tuttid/data/workspace/agent_store.go
@@ -33,6 +33,7 @@ func (s *SQLiteStore) newAgentStore() *agentstore.Store {
 		TargetIDBackfillByProvider: map[string]string{
 			"codex":       agenttargetbiz.IDLocalCodex,
 			"claude-code": agenttargetbiz.IDLocalClaudeCode,
+			"cursor":      agenttargetbiz.IDLocalCursor,
 		},
 	})
 }

--- a/services/tuttid/service/agent/composer_live_model_cache.go
+++ b/services/tuttid/service/agent/composer_live_model_cache.go
@@ -104,6 +104,11 @@ func (s *Service) InvalidateLiveComposerModels(provider string) {
 			deletedAttemptMarkers++
 		}
 	}
+	for key := range s.liveModelPersistedScanMissAtUnixMS {
+		if strings.HasPrefix(key, prefix) {
+			delete(s.liveModelPersistedScanMissAtUnixMS, key)
+		}
+	}
 	logClaudeModelCatalogInvalidationDebug("live_composer_models_invalidated", map[string]any{
 		"provider":              normalized,
 		"deletedCacheEntries":   deletedCacheEntries,
@@ -116,10 +121,15 @@ func (s *Service) liveModelCacheTTL(provider string) time.Duration {
 	if s.LiveModelCacheTTL != 0 {
 		return s.LiveModelCacheTTL
 	}
-	// Claude Code advertises a stable, account-level model list that only a real
-	// session (or daemon restart) refreshes; keep the last-known-good entry for
-	// the daemon's lifetime instead of decaying to the static fallback.
-	if agentprovider.Normalize(provider) == agentprovider.ClaudeCode {
+	// Live-discovery providers (Claude Code, Cursor) advertise a stable,
+	// account-level model list that only a real session refreshes; keep the
+	// last-known-good entry for the daemon's lifetime instead of decaying to
+	// the single-entry fallback. Expiry is pure loss here: Cursor has no probe
+	// session at all and Claude's hidden discovery runs at most once per key,
+	// so an expired entry cannot be re-discovered without a running
+	// conversation. A running session's fresher list still overrides a stale
+	// entry (see mergeLiveComposerModelsForComposerOptions ordering).
+	if composerProfileFor(provider).LiveModelDiscovery {
 		return 0
 	}
 	return defaultLiveModelCacheTTL

--- a/services/tuttid/service/agent/composer_live_model_cache_test.go
+++ b/services/tuttid/service/agent/composer_live_model_cache_test.go
@@ -30,21 +30,24 @@ func TestGetLiveComposerModelOptionsClaudeNeverExpires(t *testing.T) {
 	}
 }
 
-// Non-Claude providers (Cursor) keep the bounded TTL: a stale entry must be
-// evicted so the picker does not pin a list the running session no longer
-// advertises.
-func TestGetLiveComposerModelOptionsCursorExpiresAfterTTL(t *testing.T) {
+// Cursor keeps its live model cache for the daemon's lifetime too: it has no
+// probe session at all, so an expired entry could only be re-discovered by a
+// running conversation — until then the picker would collapse to the single
+// selected model. Running sessions still override a stale entry.
+func TestGetLiveComposerModelOptionsCursorNeverExpires(t *testing.T) {
 	service := &Service{}
 	cachedAt := time.Now().UTC()
 	service.setLiveComposerModelOptions("cursor", "ws-1", "/repo", cachedAt, []ComposerConfigOptionValue{
-		{Value: "gpt-5", Label: "GPT-5"},
+		{Value: "composer-2.5[fast=true]", Label: "composer-2.5"},
+		{Value: "gpt-5.2[reasoning=medium,fast=false]", Label: "gpt-5.2"},
 	})
 
-	if _, ok := service.getLiveComposerModelOptions("cursor", "ws-1", "/repo", cachedAt.Add(defaultLiveModelCacheTTL/2)); !ok {
-		t.Fatal("cursor cache expired inside TTL, want hit")
+	got, ok := service.getLiveComposerModelOptions("cursor", "ws-1", "/repo", cachedAt.Add(24*time.Hour))
+	if !ok {
+		t.Fatal("cursor live model cache expired, want last-known-good retained")
 	}
-	if _, ok := service.getLiveComposerModelOptions("cursor", "ws-1", "/repo", cachedAt.Add(defaultLiveModelCacheTTL+time.Minute)); ok {
-		t.Fatal("cursor cache survived past TTL, want eviction")
+	if len(got) != 2 {
+		t.Fatalf("cached options = %d, want 2", len(got))
 	}
 }
 

--- a/services/tuttid/service/agent/composer_live_model_discovery.go
+++ b/services/tuttid/service/agent/composer_live_model_discovery.go
@@ -577,6 +577,9 @@ func (s *Service) mergeLiveComposerModelsForComposerOptions(
 					"modelOptionValues": composerConfigOptionValuesDebugValues(cached),
 					"checkedAtUnixMs":   now.UnixMilli(),
 				})
+			} else if persisted, ok := s.persistedLiveModelFallback(input.WorkspaceID, input.Cwd, provider, now); ok {
+				liveModels = persisted
+				modelSource = "acp-live-discovery"
 			}
 		default:
 			// No running session: prefer the cache, else one hidden discovery,
@@ -599,6 +602,13 @@ func (s *Service) mergeLiveComposerModelsForComposerOptions(
 				}
 				if err == nil && len(discovered) > 0 {
 					liveModels = discovered
+					modelSource = "acp-live-discovery"
+				} else if persisted, ok := s.persistedLiveModelFallback(input.WorkspaceID, input.Cwd, provider, now); ok {
+					// No live session, no cache, and discovery could not run
+					// (Cursor never probes; Claude probes once per key). Restore
+					// the last list a past session persisted so the picker does
+					// not collapse to the single selected model.
+					liveModels = persisted
 					modelSource = "acp-live-discovery"
 				}
 			}

--- a/services/tuttid/service/agent/composer_live_model_discovery_test.go
+++ b/services/tuttid/service/agent/composer_live_model_discovery_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"testing"
+	"time"
 )
 
 // cursorModelRuntimeContext mirrors the configOptions a live cursor-agent
@@ -98,6 +99,146 @@ func TestGetComposerOptionsMergesLiveCursorModels(t *testing.T) {
 	}
 	if options.ModelConfig.CurrentValue != "composer-2.5[fast=true]" {
 		t.Fatalf("model current value = %q", options.ModelConfig.CurrentValue)
+	}
+}
+
+// After a daemon restart the runtime session and the in-memory cache are both
+// gone; the model list a past cursor conversation persisted in its runtime
+// context must restore the picker instead of collapsing it to the single
+// selected model (Cursor has no probe session to re-discover with).
+func TestGetComposerOptionsRestoresCursorModelsFromPersistedSessions(t *testing.T) {
+	t.Parallel()
+	service := NewService(newFakeRuntime())
+	service.SessionReader = fakeSessionReader{
+		sessions: map[string]PersistedSession{
+			"ws-1:cursor-old": {
+				ID:              "cursor-old",
+				WorkspaceID:     "ws-1",
+				Provider:        "cursor",
+				RuntimeContext:  cursorModelRuntimeContext(),
+				UpdatedAtUnixMS: 1000,
+			},
+		},
+	}
+
+	options, err := service.GetComposerOptions(context.Background(), ComposerOptionsInput{
+		Provider:    "cursor",
+		WorkspaceID: "ws-1",
+		Cwd:         "/repo",
+		Settings: ComposerSettings{
+			Model:            "composer-2.5[fast=true]",
+			PermissionModeID: "agent",
+		},
+	})
+	if err != nil {
+		t.Fatalf("GetComposerOptions returned error: %v", err)
+	}
+	if len(options.ModelConfig.Options) != 3 {
+		t.Fatalf("model options = %#v, want the 3 persisted models", options.ModelConfig.Options)
+	}
+	if options.ModelConfig.CurrentValue != "composer-2.5[fast=true]" {
+		t.Fatalf("model current value = %q", options.ModelConfig.CurrentValue)
+	}
+	if options.RuntimeContext["modelCatalogSource"] != "acp-live-discovery" {
+		t.Fatalf("modelCatalogSource = %#v, want acp-live-discovery", options.RuntimeContext["modelCatalogSource"])
+	}
+	// The restored list must seed the cache so later fetches skip the scan.
+	if cached, ok := service.getLiveComposerModelOptions("cursor", "ws-1", "/repo", time.Now().UTC()); !ok || len(cached) != 3 {
+		t.Fatalf("cache after persisted fallback = %#v ok = %v, want 3 entries", cached, ok)
+	}
+}
+
+// countingSessionReader wraps fakeSessionReader to count ListSessions calls:
+// the persisted-session scan reads every session row in the workspace, so a
+// workspace with nothing to restore must not rescan on every fetch.
+type countingSessionReader struct {
+	fakeSessionReader
+	listCalls int
+}
+
+func (r *countingSessionReader) ListSessions(workspaceID string) ([]PersistedSession, bool) {
+	r.listCalls++
+	return r.fakeSessionReader.ListSessions(workspaceID)
+}
+
+func TestPersistedLiveModelFallbackMemoizesScanMisses(t *testing.T) {
+	t.Parallel()
+	service := NewService(newFakeRuntime())
+	reader := &countingSessionReader{}
+	service.SessionReader = reader
+
+	now := time.Now().UTC()
+	if _, ok := service.persistedLiveModelFallback("ws-1", "/repo", "cursor", now); ok {
+		t.Fatal("fallback with no persisted sessions returned options")
+	}
+	if _, ok := service.persistedLiveModelFallback("ws-1", "/repo", "cursor", now.Add(time.Minute)); ok {
+		t.Fatal("fallback with no persisted sessions returned options")
+	}
+	if reader.listCalls != 1 {
+		t.Fatalf("ListSessions calls = %d, want the second miss served from the memo", reader.listCalls)
+	}
+
+	// The memo expires: a later fetch rescans and restores newly persisted
+	// sessions.
+	reader.sessions = map[string]PersistedSession{
+		"ws-1:cursor-new": {
+			ID: "cursor-new", WorkspaceID: "ws-1", Provider: "cursor",
+			RuntimeContext: cursorModelRuntimeContext(), UpdatedAtUnixMS: 900,
+		},
+	}
+	options, ok := service.persistedLiveModelFallback("ws-1", "/repo", "cursor", now.Add(persistedLiveModelScanMissTTL+time.Minute))
+	if !ok || len(options) != 3 {
+		t.Fatalf("fallback after memo expiry = %#v ok = %v, want the 3 persisted models", options, ok)
+	}
+	if reader.listCalls != 2 {
+		t.Fatalf("ListSessions calls = %d, want exactly one rescan after memo expiry", reader.listCalls)
+	}
+}
+
+func TestLiveModelOptionsFromPersistedSessionsPicksNewestAndSkipsStale(t *testing.T) {
+	t.Parallel()
+	service := NewService(newFakeRuntime())
+	oldContext := map[string]any{
+		"configOptions": []any{
+			map[string]any{
+				"id": "model",
+				"options": []any{
+					map[string]any{"value": "composer-2[fast=true]", "name": "composer-2"},
+				},
+			},
+		},
+	}
+	service.SessionReader = fakeSessionReader{
+		sessions: map[string]PersistedSession{
+			"ws-1:older": {
+				ID: "older", WorkspaceID: "ws-1", Provider: "cursor",
+				RuntimeContext: oldContext, UpdatedAtUnixMS: 500,
+			},
+			"ws-1:newer": {
+				ID: "newer", WorkspaceID: "ws-1", Provider: "cursor",
+				RuntimeContext: cursorModelRuntimeContext(), UpdatedAtUnixMS: 900,
+			},
+			"ws-1:hidden": {
+				ID: "hidden", WorkspaceID: "ws-1", Provider: "cursor",
+				RuntimeContext:  map[string]any{"hiddenLiveModelDiscovery": true},
+				UpdatedAtUnixMS: 2000,
+			},
+			"ws-1:other-provider": {
+				ID: "other-provider", WorkspaceID: "ws-1", Provider: "claude-code",
+				RuntimeContext: oldContext, UpdatedAtUnixMS: 3000,
+			},
+		},
+	}
+
+	options := service.liveModelOptionsFromPersistedSessions("ws-1", "cursor")
+	if len(options) != 3 {
+		t.Fatalf("options = %#v, want the newer session's 3 models", options)
+	}
+
+	// Sessions persisted before an auth/config invalidation are stale.
+	service.InvalidateLiveComposerModels("cursor")
+	if got := service.liveModelOptionsFromPersistedSessions("ws-1", "cursor"); got != nil {
+		t.Fatalf("options after invalidation = %#v, want nil", got)
 	}
 }
 

--- a/services/tuttid/service/agent/composer_live_model_persisted.go
+++ b/services/tuttid/service/agent/composer_live_model_persisted.go
@@ -1,0 +1,96 @@
+package agent
+
+import (
+	"time"
+
+	"github.com/tutti-os/tutti/services/tuttid/biz/agentprovider"
+)
+
+// liveModelOptionsFromPersistedSessions returns the most recent model list a
+// past provider session persisted in its runtime context. It restores the
+// composer's model picker when both the live runtime session and the
+// in-memory cache are gone (typically after a daemon restart): providers such
+// as Cursor have no probe session, so without this the picker stays pinned to
+// the single selected model until the user starts a new conversation.
+func (s *Service) liveModelOptionsFromPersistedSessions(workspaceID string, provider string) []ComposerConfigOptionValue {
+	if s.SessionReader == nil {
+		return nil
+	}
+	provider = agentprovider.Normalize(provider)
+	sessions, ok := s.SessionReader.ListSessions(workspaceID)
+	if !ok {
+		return nil
+	}
+	invalidatedAtUnixMS := s.liveModelInvalidatedAtUnixMSForProvider(provider)
+	var best []ComposerConfigOptionValue
+	bestUnixMS := int64(-1)
+	for _, session := range sessions {
+		if agentprovider.Normalize(session.Provider) != provider {
+			continue
+		}
+		if isHiddenLiveModelDiscoveryRuntimeContext(session.RuntimeContext) {
+			continue
+		}
+		sessionUnixMS := firstNonZeroInt64(session.UpdatedAtUnixMS, session.CreatedAtUnixMS)
+		if invalidatedAtUnixMS > 0 && sessionUnixMS <= invalidatedAtUnixMS {
+			continue
+		}
+		if sessionUnixMS <= bestUnixMS {
+			continue
+		}
+		options := extractModelOptionsFromRuntimeContext(session.RuntimeContext)
+		if len(options) == 0 {
+			continue
+		}
+		best = options
+		bestUnixMS = sessionUnixMS
+	}
+	return best
+}
+
+// persistedLiveModelScanMissTTL bounds how long a "nothing to restore" result
+// from the persisted-session scan is memoized. The scan reads every persisted
+// session row in the workspace (unbounded SQLite query plus per-row JSON
+// decoding), so an unmemoized miss would rerun it on every composer-options
+// fetch for workspaces that have nothing to restore.
+const persistedLiveModelScanMissTTL = defaultLiveModelCacheTTL
+
+// persistedLiveModelFallback restores the most recent model list a past
+// provider session persisted, seeding the live-model cache on a hit so later
+// fetches skip the scan entirely. Misses are memoized per cache key for
+// persistedLiveModelScanMissTTL; a session that later advertises models
+// bypasses the memo through the running-session path, which re-seeds the
+// cache directly.
+func (s *Service) persistedLiveModelFallback(workspaceID string, cwd string, provider string, now time.Time) ([]ComposerConfigOptionValue, bool) {
+	cacheKey := composerLiveModelCacheKey(provider, workspaceID, cwd, liveModelAuthScope(provider))
+	s.liveModelDiscoveryMu.Lock()
+	missedAtUnixMS := s.liveModelPersistedScanMissAtUnixMS[cacheKey]
+	s.liveModelDiscoveryMu.Unlock()
+	if missedAtUnixMS > 0 && now.UnixMilli()-missedAtUnixMS < persistedLiveModelScanMissTTL.Milliseconds() {
+		return nil, false
+	}
+	persisted := s.liveModelOptionsFromPersistedSessions(workspaceID, provider)
+	s.liveModelDiscoveryMu.Lock()
+	if len(persisted) == 0 {
+		if s.liveModelPersistedScanMissAtUnixMS == nil {
+			s.liveModelPersistedScanMissAtUnixMS = make(map[string]int64)
+		}
+		s.liveModelPersistedScanMissAtUnixMS[cacheKey] = now.UnixMilli()
+	} else {
+		delete(s.liveModelPersistedScanMissAtUnixMS, cacheKey)
+	}
+	s.liveModelDiscoveryMu.Unlock()
+	if len(persisted) == 0 {
+		return nil, false
+	}
+	s.setLiveComposerModelOptions(provider, workspaceID, cwd, now, persisted)
+	logClaudeModelCatalogInvalidationDebug("composer_options_persisted_session_fallback", map[string]any{
+		"workspaceId":       workspaceID,
+		"provider":          provider,
+		"cwd":               cwd,
+		"modelOptionCount":  len(persisted),
+		"modelOptionValues": composerConfigOptionValuesDebugValues(persisted),
+		"checkedAtUnixMs":   now.UnixMilli(),
+	})
+	return persisted, true
+}

--- a/services/tuttid/service/agent/session_types.go
+++ b/services/tuttid/service/agent/session_types.go
@@ -38,6 +38,10 @@ type Service struct {
 	liveModelDiscoveryMu          sync.Mutex
 	liveModelDiscoveryAttempted   map[string]struct{}
 	liveModelInvalidatedAtUnixMS  map[string]int64
+	// liveModelPersistedScanMissAtUnixMS memoizes, per live-model cache key,
+	// when the persisted-session fallback scan last found nothing, so the
+	// full session scan is not repeated on every composer-options fetch.
+	liveModelPersistedScanMissAtUnixMS map[string]int64
 }
 
 type StaleTurnResumeReconciler interface {


### PR DESCRIPTION
## Summary
- auto-continue Cursor ACP turns after in-band retriable backend errors instead of leaving conversations stalled
- restore Cursor composer model options from persisted session runtime context after daemon restarts
- keep AgentGUI provider filters consistent for legacy targetless Cursor sessions and backfill Cursor agent target IDs
- document the AgentGUI provider-tab troubleshooting path

## Validation
- pnpm --dir packages/agent/gui exec vitest run --environment jsdom agent-gui/agentGuiNode/model/agentGuiConversationFilter.spec.ts contexts/workspace/presentation/renderer/agentGuiConversationList/agentGuiConversationListStore.spec.ts agent-gui/agentGuiNode/controller/useAgentGUINodeController.spec.tsx
- cd services/tuttid && go test ./data/workspace/... ./service/agent/...
- go test ./packages/agent/daemon/runtime -run 'TestACPRetriableTurnTailError|TestCursorAdapterAutoContinuesAfterRetriableTurnError|TestCursorAdapterAutoContinueToolOnlyContinuationCompletes|TestCursorAdapterAutoContinueExhaustedMarksTurnFailed|TestStandardACPAdapterWithoutOptInDoesNotAutoContinue' -count=1 -v\n- go test ./packages/agent/daemon/runtime -run '^TestCodexAppServerAdapterGoalContinuesAfterMidGoalTurnFailure$' -count=1 -v\n- pnpm check:changed -- --failed-only --tail-lines 80\n- env -u TUTTI_ENV pnpm check:full\n

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Agent conversations now stay aligned when switching provider tabs, including legacy sessions.

* **Bug Fixes**
  * Fixed stale or mixed conversation lists/details in the Agent GUI after changing filters.
  * Improved turn recovery so supported agent sessions can automatically continue after transient network errors.
  * Restored composer model choices more reliably after restarts, and kept Cursor model cache entries available longer.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->