### PR TITLE
refactor(desktop): remove workbench test-only helper seams

### DIFF
--- a/apps/desktop/src/renderer/src/features/workspace-app-center/services/internal/workspaceAppCenterDockProjection.test.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-app-center/services/internal/workspaceAppCenterDockProjection.test.ts
@@ -4,10 +4,7 @@ import {
   workspaceAppCenterDockOrder,
   workspaceAppDockOrderStart
 } from "./workspaceAppCenterDockOrdering.ts";
-import {
-  projectWorkspaceAppCenterDockApps,
-  projectWorkspaceAppCenterDockState
-} from "./workspaceAppCenterDockProjection.ts";
+import { projectWorkspaceAppCenterDockApps } from "./workspaceAppCenterDockProjection.ts";
 import { workspaceAppCenterFrame } from "./workspaceAppCenterFrame.ts";
 
 test("workspace app center dock order stays before task and app entries", () => {
@@ -24,82 +21,167 @@ test("workspace app center opens at the shared dialog-sized frame", () => {
   });
 });
 
-test("projectWorkspaceAppCenterDockState maps runtime status to dock state", () => {
+test("projectWorkspaceAppCenterDockApps maps runtime status to dock state", () => {
   assert.deepEqual(
-    projectWorkspaceAppCenterDockState("running", "https://app.local"),
+    projectSingleWorkspaceAppCenterDockApp({
+      launchUrl: "https://app.local",
+      runtimeStatus: "running"
+    }),
     {
+      app: createApp({
+        launchUrl: "https://app.local",
+        runtimeStatus: "running"
+      }),
       launchEnabled: true,
       state: { kind: "enabled" }
     }
   );
   assert.deepEqual(
-    projectWorkspaceAppCenterDockState("installed_pending_restart", null),
+    projectSingleWorkspaceAppCenterDockApp({
+      launchUrl: null,
+      runtimeStatus: "installed_pending_restart"
+    }),
     {
+      app: createApp({
+        launchUrl: null,
+        runtimeStatus: "installed_pending_restart"
+      }),
       clickBehavior: "launch",
       launchEnabled: true,
       state: { kind: "enabled" }
     }
   );
   assert.deepEqual(
-    projectWorkspaceAppCenterDockState("starting", "https://app.local"),
+    projectSingleWorkspaceAppCenterDockApp({
+      launchUrl: "https://app.local",
+      runtimeStatus: "starting"
+    }),
     {
+      app: createApp({
+        launchUrl: "https://app.local",
+        runtimeStatus: "starting"
+      }),
       launchEnabled: false,
       state: { kind: "loading" }
     }
   );
   assert.deepEqual(
-    projectWorkspaceAppCenterDockState("preparing", "https://app.local"),
+    projectSingleWorkspaceAppCenterDockApp({
+      launchUrl: "https://app.local",
+      runtimeStatus: "preparing"
+    }),
     {
+      app: createApp({
+        launchUrl: "https://app.local",
+        runtimeStatus: "preparing"
+      }),
       launchEnabled: false,
       state: { kind: "loading" }
     }
   );
   assert.deepEqual(
-    projectWorkspaceAppCenterDockState("installing", "https://app.local"),
+    projectSingleWorkspaceAppCenterDockApp({
+      launchUrl: "https://app.local",
+      runtimeStatus: "installing"
+    }),
     {
+      app: createApp({
+        launchUrl: "https://app.local",
+        runtimeStatus: "installing"
+      }),
       launchEnabled: false,
       state: { kind: "loading" }
     }
   );
   assert.deepEqual(
-    projectWorkspaceAppCenterDockState("failed", "https://app.local"),
+    projectSingleWorkspaceAppCenterDockApp({
+      launchUrl: "https://app.local",
+      runtimeStatus: "failed"
+    }),
     {
+      app: createApp({
+        launchUrl: "https://app.local",
+        runtimeStatus: "failed"
+      }),
       launchEnabled: false,
       state: { kind: "unavailable" }
     }
   );
-  assert.deepEqual(projectWorkspaceAppCenterDockState("failed", null), {
-    launchEnabled: false,
-    state: { kind: "unavailable" }
-  });
   assert.deepEqual(
-    projectWorkspaceAppCenterDockState("unavailable", "https://app.local"),
+    projectSingleWorkspaceAppCenterDockApp({
+      launchUrl: null,
+      runtimeStatus: "failed"
+    }),
     {
+      app: createApp({
+        launchUrl: null,
+        runtimeStatus: "failed"
+      }),
       launchEnabled: false,
       state: { kind: "unavailable" }
     }
   );
   assert.deepEqual(
-    projectWorkspaceAppCenterDockState("idle", "https://app.local"),
+    projectSingleWorkspaceAppCenterDockApp({
+      launchUrl: "https://app.local",
+      runtimeStatus: "unavailable"
+    }),
     {
+      app: createApp({
+        launchUrl: "https://app.local",
+        runtimeStatus: "unavailable"
+      }),
+      launchEnabled: false,
+      state: { kind: "unavailable" }
+    }
+  );
+  assert.deepEqual(
+    projectSingleWorkspaceAppCenterDockApp({
+      launchUrl: "https://app.local",
+      runtimeStatus: "idle"
+    }),
+    {
+      app: createApp({
+        launchUrl: "https://app.local",
+        runtimeStatus: "idle"
+      }),
       launchEnabled: true,
       state: { kind: "enabled" }
     }
   );
   assert.deepEqual(
-    projectWorkspaceAppCenterDockState("idle", "https://app.local", false),
+    projectSingleWorkspaceAppCenterDockApp({
+      installed: false,
+      launchUrl: "https://app.local",
+      runtimeStatus: "idle"
+    }),
     {
+      app: createApp({
+        installed: false,
+        launchUrl: "https://app.local",
+        runtimeStatus: "idle"
+      }),
       launchEnabled: false,
       state: { kind: "disabled" }
     }
   );
-  assert.deepEqual(projectWorkspaceAppCenterDockState("running", null), {
-    launchEnabled: false,
-    state: {
-      kind: "disabled",
-      reason: "missing-url"
+  assert.deepEqual(
+    projectSingleWorkspaceAppCenterDockApp({
+      launchUrl: null,
+      runtimeStatus: "running"
+    }),
+    {
+      app: createApp({
+        launchUrl: null,
+        runtimeStatus: "running"
+      }),
+      launchEnabled: false,
+      state: {
+        kind: "disabled",
+        reason: "missing-url"
+      }
     }
-  });
+  );
 });
 
 test("projectWorkspaceAppCenterDockApps includes only enabled apps", () => {
@@ -155,3 +237,51 @@ test("projectWorkspaceAppCenterDockApps includes only enabled apps", () => {
   assert.equal(projections[1]?.launchEnabled, false);
   assert.deepEqual(projections[1]?.state, { kind: "disabled" });
 });
+
+function projectSingleWorkspaceAppCenterDockApp(
+  input: Partial<ReturnType<typeof createApp>>
+) {
+  return projectWorkspaceAppCenterDockApps([createApp(input)])[0] ?? null;
+}
+
+function createApp(
+  input: Partial<{
+    appId: string;
+    createdAtUnixMs: number;
+    enabled: boolean;
+    exportable: boolean;
+    installed: boolean;
+    launchUrl: string | null;
+    minimizeBehavior: "keep-mounted";
+    name: string;
+    references: { listSupported: boolean };
+    runtimeStatus:
+      | "idle"
+      | "installing"
+      | "installed_pending_restart"
+      | "running"
+      | "preparing"
+      | "starting"
+      | "stopping"
+      | "failed"
+      | "unavailable";
+    source: "builtin";
+    stateRevision: number;
+  }> = {}
+) {
+  return {
+    appId: "notes",
+    createdAtUnixMs: 1,
+    enabled: true,
+    exportable: false,
+    installed: true,
+    launchUrl: "https://app.local",
+    minimizeBehavior: "keep-mounted" as const,
+    name: "Notes",
+    references: { listSupported: false },
+    runtimeStatus: "idle" as const,
+    source: "builtin" as const,
+    stateRevision: 1,
+    ...input
+  };
+}

--- a/apps/desktop/src/renderer/src/features/workspace-app-center/services/internal/workspaceAppCenterDockProjection.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-app-center/services/internal/workspaceAppCenterDockProjection.ts
@@ -2,10 +2,7 @@ import type {
   WorkbenchHostDockEntry,
   WorkbenchHostDockEntryState
 } from "@tutti-os/workbench-surface";
-import type {
-  WorkspaceAppCenterApp,
-  WorkspaceAppCenterRuntimeStatus
-} from "@tutti-os/workspace-app-center";
+import type { WorkspaceAppCenterApp } from "@tutti-os/workspace-app-center";
 
 export interface WorkspaceAppCenterDockProjection {
   app: WorkspaceAppCenterApp;
@@ -19,84 +16,73 @@ export function projectWorkspaceAppCenterDockApps(
 ): WorkspaceAppCenterDockProjection[] {
   return apps
     .filter((app) => app.enabled)
-    .map((app) => ({
-      app,
-      ...projectWorkspaceAppCenterDockState(
-        app.runtimeStatus,
-        app.launchUrl,
-        app.installed
-      )
-    }));
-}
+    .map((app) => {
+      const status = app.runtimeStatus;
+      const launchUrl = app.launchUrl;
+      const installed = app.installed;
+      let projection: Pick<
+        WorkspaceAppCenterDockProjection,
+        "clickBehavior" | "launchEnabled" | "state"
+      >;
 
-export function projectWorkspaceAppCenterDockState(
-  status: WorkspaceAppCenterRuntimeStatus,
-  launchUrl: string | null | undefined,
-  installed = true
-): Pick<
-  WorkspaceAppCenterDockProjection,
-  "clickBehavior" | "launchEnabled" | "state"
-> {
-  if (status === "installing") {
-    return {
-      launchEnabled: false,
-      state: { kind: "loading" }
-    };
-  }
-  if (!installed) {
-    return {
-      launchEnabled: false,
-      state: { kind: "disabled" }
-    };
-  }
-  if (status === "idle") {
-    return {
-      launchEnabled: true,
-      state: { kind: "enabled" }
-    };
-  }
-  if (status === "installed_pending_restart") {
-    return {
-      clickBehavior: "launch",
-      launchEnabled: true,
-      state: { kind: "enabled" }
-    };
-  }
-  if (status === "running") {
-    if (!launchUrl) {
+      if (status === "installing") {
+        projection = {
+          launchEnabled: false,
+          state: { kind: "loading" }
+        };
+      } else if (!installed) {
+        projection = {
+          launchEnabled: false,
+          state: { kind: "disabled" }
+        };
+      } else if (status === "idle") {
+        projection = {
+          launchEnabled: true,
+          state: { kind: "enabled" }
+        };
+      } else if (status === "installed_pending_restart") {
+        projection = {
+          clickBehavior: "launch",
+          launchEnabled: true,
+          state: { kind: "enabled" }
+        };
+      } else if (status === "running") {
+        projection = launchUrl
+          ? {
+              launchEnabled: true,
+              state: { kind: "enabled" }
+            }
+          : {
+              launchEnabled: false,
+              state: {
+                kind: "disabled",
+                reason: "missing-url"
+              }
+            };
+      } else if (
+        status === "preparing" ||
+        status === "starting" ||
+        status === "stopping"
+      ) {
+        projection = {
+          launchEnabled: false,
+          state: { kind: "loading" }
+        };
+      } else if (status === "failed" || status === "unavailable") {
+        projection = {
+          launchEnabled: false,
+          state: { kind: "unavailable" }
+        };
+      } else {
+        projection = {
+          launchEnabled: false,
+          state: { kind: "disabled" }
+        };
+      }
+
       return {
-        launchEnabled: false,
-        state: {
-          kind: "disabled",
-          reason: "missing-url"
-        }
+        app,
+        ...projection
       };
-    }
-    return {
-      launchEnabled: true,
-      state: { kind: "enabled" }
-    };
-  }
-  if (status === "preparing" || status === "starting") {
-    return {
-      launchEnabled: false,
-      state: { kind: "loading" }
-    };
-  }
-  if (status === "stopping") {
-    return {
-      launchEnabled: false,
-      state: { kind: "loading" }
-    };
-  }
-  if (status === "failed" || status === "unavailable") {
-    return {
-      launchEnabled: false,
-      state: { kind: "unavailable" }
-    };
-  }
-  return {
-    launchEnabled: false,
-    state: { kind: "disabled" }
-  };
+    });
 }

--- a/apps/desktop/src/renderer/src/features/workspace-workbench/services/internal/workspaceAppExternalAtSerialization.test.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/services/internal/workspaceAppExternalAtSerialization.test.ts
@@ -1,11 +1,7 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 import type { RichTextTriggerQueryMatch } from "@tutti-os/ui-rich-text/types";
-import {
-  serializeWorkspaceAppExternalAtInsert,
-  serializeWorkspaceAppExternalAtMatch,
-  toExternalAtProviderId
-} from "./workspaceAppExternalAtSerialization.ts";
+import { serializeWorkspaceAppExternalAtMatch } from "./workspaceAppExternalAtSerialization.ts";
 
 type TestMentionInsert = Extract<
   RichTextTriggerQueryMatch["insertResult"],
@@ -20,15 +16,43 @@ function mentionInsert(mention: Record<string, unknown>): TestMentionInsert {
 }
 
 test("accepts external at provider ids", () => {
-  assert.equal(toExternalAtProviderId("file"), "file");
-  assert.equal(toExternalAtProviderId("workspace-issue"), "workspace-issue");
-  assert.equal(toExternalAtProviderId("agent-target"), "agent-target");
-  assert.equal(toExternalAtProviderId("unsupported"), null);
+  assert.equal(
+    serializeWorkspaceAppExternalAtMatch(
+      createMatch({
+        providerId: "file"
+      })
+    )?.providerId,
+    "file"
+  );
+  assert.equal(
+    serializeWorkspaceAppExternalAtMatch(
+      createMatch({
+        providerId: "workspace-issue"
+      })
+    )?.providerId,
+    "workspace-issue"
+  );
+  assert.equal(
+    serializeWorkspaceAppExternalAtMatch(
+      createMatch({
+        providerId: "agent-target"
+      })
+    )?.providerId,
+    "agent-target"
+  );
+  assert.equal(
+    serializeWorkspaceAppExternalAtMatch(
+      createMatch({
+        providerId: "unsupported"
+      })
+    ),
+    null
+  );
 });
 
 test("serializes mention insert results", () => {
   assert.deepEqual(
-    serializeWorkspaceAppExternalAtInsert(
+    serializeInsert(
       mentionInsert({
         entityId: "issue-1",
         label: "Fix bug",
@@ -62,7 +86,7 @@ test("serializes mention insert results", () => {
 
 test("serializes mention icon presentation as external thumbnail metadata", () => {
   assert.deepEqual(
-    serializeWorkspaceAppExternalAtInsert(
+    serializeInsert(
       mentionInsert({
         entityId: "agent-codex",
         label: "Codex",
@@ -97,7 +121,7 @@ test("serializes mention icon presentation as external thumbnail metadata", () =
 
 test("does not pass legacy mention metadata through to external apps", () => {
   assert.deepEqual(
-    serializeWorkspaceAppExternalAtInsert(
+    serializeInsert(
       mentionInsert({
         entityId: "issue-1",
         href: "mention://workspace-issue?issueId=issue-1",
@@ -120,7 +144,7 @@ test("does not pass legacy mention metadata through to external apps", () => {
 
 test("serializes markdown link and text insert results", () => {
   assert.deepEqual(
-    serializeWorkspaceAppExternalAtInsert({
+    serializeInsert({
       kind: "markdown-link",
       href: "README.md",
       label: "README.md"
@@ -132,7 +156,7 @@ test("serializes markdown link and text insert results", () => {
     }
   );
   assert.deepEqual(
-    serializeWorkspaceAppExternalAtInsert({
+    serializeInsert({
       kind: "text",
       text: "plain text"
     }),
@@ -213,3 +237,31 @@ test("serializes mention item id from insert identity for external restore", () 
     }
   });
 });
+
+function createMatch(
+  input: Partial<RichTextTriggerQueryMatch> = {}
+): RichTextTriggerQueryMatch {
+  return {
+    iconUrl: "tutti://workspace-apps/automation/icon.png",
+    insertResult: {
+      kind: "text",
+      text: "plain text"
+    },
+    item: {},
+    key: "item-key",
+    label: "Label",
+    providerId: "file",
+    trigger: "@",
+    ...input
+  };
+}
+
+function serializeInsert(
+  insertResult: RichTextTriggerQueryMatch["insertResult"]
+) {
+  return serializeWorkspaceAppExternalAtMatch(
+    createMatch({
+      insertResult
+    })
+  )?.insert;
+}

--- a/apps/desktop/src/renderer/src/features/workspace-workbench/services/internal/workspaceAppExternalAtSerialization.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/services/internal/workspaceAppExternalAtSerialization.ts
@@ -2,7 +2,6 @@ import { isTuttiExternalAtProviderId } from "@tutti-os/workspace-external-core/c
 import type {
   TuttiExternalAtInsertResult,
   TuttiExternalAtMentionPresentation,
-  TuttiExternalAtProviderId,
   TuttiExternalAtQueryResult
 } from "@tutti-os/workspace-external-core/contracts";
 import type {
@@ -13,32 +12,56 @@ import type {
 export function serializeWorkspaceAppExternalAtMatch(
   match: RichTextTriggerQueryMatch
 ): TuttiExternalAtQueryResult | null {
-  const providerId = toExternalAtProviderId(match.providerId);
-  if (!providerId) {
+  if (!isTuttiExternalAtProviderId(match.providerId)) {
     return null;
   }
-  const insert = serializeWorkspaceAppExternalAtInsert(match.insertResult);
+  const insert = (() => {
+    switch (match.insertResult.kind) {
+      case "mention": {
+        const mention = match.insertResult.mention;
+        return {
+          kind: "mention" as const,
+          mention: {
+            entityId: mention.entityId,
+            label: mention.label,
+            ...(mention.scope ? { scope: { ...mention.scope } } : {}),
+            ...(mention.presentation
+              ? {
+                  presentation: serializeWorkspaceAppExternalAtPresentation(
+                    mention.presentation
+                  )
+                }
+              : {})
+          }
+        };
+      }
+      case "markdown-link":
+        return {
+          kind: "markdown-link" as const,
+          label: match.insertResult.label,
+          href: match.insertResult.href
+        };
+      case "text":
+        return {
+          kind: "text" as const,
+          text: match.insertResult.text
+        };
+      default:
+        return null;
+    }
+  })();
   if (!insert) {
     return null;
   }
   const itemId = resolveWorkspaceAppExternalAtItemId(match, insert);
   return {
-    providerId,
+    providerId: match.providerId,
     itemId,
     label: match.label,
     ...(match.subtitle ? { subtitle: match.subtitle } : {}),
     ...(match.iconUrl ? { thumbnailUrl: match.iconUrl } : {}),
     insert
   };
-}
-
-export function toExternalAtProviderId(
-  providerId: string
-): TuttiExternalAtProviderId | null {
-  if (isTuttiExternalAtProviderId(providerId)) {
-    return providerId;
-  }
-  return null;
 }
 
 function resolveWorkspaceAppExternalAtItemId(
@@ -49,44 +72,6 @@ function resolveWorkspaceAppExternalAtItemId(
     return insert.mention.entityId;
   }
   return match.key;
-}
-
-export function serializeWorkspaceAppExternalAtInsert(
-  insert: RichTextTriggerInsertResult
-): TuttiExternalAtInsertResult | null {
-  switch (insert.kind) {
-    case "mention": {
-      const mention = insert.mention;
-      return {
-        kind: "mention",
-        mention: {
-          entityId: mention.entityId,
-          label: mention.label,
-          ...(mention.scope ? { scope: { ...mention.scope } } : {}),
-          ...(mention.presentation
-            ? {
-                presentation: serializeWorkspaceAppExternalAtPresentation(
-                  mention.presentation
-                )
-              }
-            : {})
-        }
-      };
-    }
-    case "markdown-link":
-      return {
-        kind: "markdown-link",
-        label: insert.label,
-        href: insert.href
-      };
-    case "text":
-      return {
-        kind: "text",
-        text: insert.text
-      };
-    default:
-      return null;
-  }
 }
 
 function serializeWorkspaceAppExternalAtPresentation(


### PR DESCRIPTION
## Summary
- remove `projectWorkspaceAppCenterDockState` and keep `projectWorkspaceAppCenterDockApps` as the only production dock projection entrypoint
- remove `toExternalAtProviderId` and `serializeWorkspaceAppExternalAtInsert` and fold their logic into `serializeWorkspaceAppExternalAtMatch`
- update the co-located tests to verify the current production entrypoints instead of the retired helper seams

## Historical role
- `projectWorkspaceAppCenterDockState`
  - This was the per-app state projection helper underneath the App Center dock projection list builder.
  - The current production path no longer calls it directly. `workspaceAppCenterContribution.tsx` only consumes `projectWorkspaceAppCenterDockApps`, and the removed helper existed as a direct test seam for individual status cases.
  - `git log -S'projectWorkspaceAppCenterDockState'` traces it back to `e2120fb2` (`feat: init project for tutti open source`).
- `toExternalAtProviderId`
  - This normalized rich-text trigger provider ids into the workspace external-@ contract surface.
  - The current production path only enters through `serializeWorkspaceAppExternalAtMatch`, which already owns the provider-id validation step.
  - `git log -S'toExternalAtProviderId'` traces it to `6aee7a83` (`Refactor rich text mentions around tuttiExternal (#70)`).
- `serializeWorkspaceAppExternalAtInsert`
  - This converted rich-text insert payloads into the workspace external-@ insert contract.
  - The current production path only needs that conversion while building `serializeWorkspaceAppExternalAtMatch` for `workspaceWorkbenchHostService.ts`; the standalone helper survived as a direct test seam.
  - `git log -S'serializeWorkspaceAppExternalAtInsert'` also traces it to `6aee7a83`.

## Reverification
- Exact cross-repo search now returns no hits for the removed helper symbols:
  - `projectWorkspaceAppCenterDockState`
  - `toExternalAtProviderId`
  - `serializeWorkspaceAppExternalAtInsert`
- I rechecked both this repository and the sibling local `tsh` repository for exact symbol references before deletion, then reran the same exact search after deletion.
- The surviving production entrypoints still have live callers:
  - `projectWorkspaceAppCenterDockApps` is still used by `workspaceAppCenterContribution.tsx`
  - `serializeWorkspaceAppExternalAtMatch` is still used by `workspaceWorkbenchHostService.ts`
- All changes stay inside private desktop renderer internals under `apps/desktop/src/...`; no published `@tutti-os/*` package API, daemon contract, or external repository dependency surface changed.

## Validation
- `pnpm --filter @tutti-os/desktop typecheck`
- `pnpm --filter @tutti-os/desktop test`
- `pnpm --filter @tutti-os/desktop build`
- `pnpm check:changed --tail-lines 80`
- `pnpm check:full`

## Docs impact
- `discard`
- No durable documentation update needed: this is private desktop internal cleanup only, with no public behavior, ownership, or contract change.
