### PR TITLE
refactor(desktop): remove unused workspace wallpaper exports

### DIFF
--- a/apps/desktop/src/renderer/src/features/workspace-workbench/services/workspaceWallpaper.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/services/workspaceWallpaper.ts
@@ -15,7 +15,7 @@ export type WorkspaceWallpaperId =
 
 export const customWorkspaceWallpaperId: WorkspaceWallpaperId = "custom";
 export const defaultWorkspaceWallpaperId: WorkspaceWallpaperId = "tutti";
-export const customWorkspaceWallpaperTitleKey: DesktopI18nKey =
+const customWorkspaceWallpaperTitleKey: DesktopI18nKey =
   "workspace.wallpaper.options.custom";
 
 export type WorkspaceWallpaperAppearance = "light" | "dark";
@@ -31,10 +31,10 @@ export type WorkspaceWallpaperDisplayMode =
   | (typeof workspaceWallpaperDisplayModes)[number]
   | "fill";
 
-export const defaultWorkspaceWallpaperDisplayMode: WorkspaceWallpaperDisplayMode =
+const defaultWorkspaceWallpaperDisplayMode: WorkspaceWallpaperDisplayMode =
   "original";
 
-export function isWorkspaceWallpaperDisplayMode(
+function isWorkspaceWallpaperDisplayMode(
   value: string
 ): value is WorkspaceWallpaperDisplayMode {
   return (
@@ -169,9 +169,7 @@ export const workspaceWallpaperOptions: WorkspaceWallpaperOption[] = [
   }
 ];
 
-export function isWorkspaceWallpaperId(
-  value: string
-): value is WorkspaceWallpaperId {
+function isWorkspaceWallpaperId(value: string): value is WorkspaceWallpaperId {
   return (
     value === customWorkspaceWallpaperId ||
     workspaceWallpaperOptions.some((option) => option.id === value)
@@ -206,7 +204,7 @@ export function getWorkspaceWallpaperOption(
   return resolveWorkspaceWallpaperOption(fallback, appearance);
 }
 
-export function resolveWorkspaceWallpaperOption(
+function resolveWorkspaceWallpaperOption(
   option: WorkspaceWallpaperOption,
   appearance: WorkspaceWallpaperAppearance
 ): WorkspaceWallpaperOption {


### PR DESCRIPTION
## Summary
- remove five stale `export` seams from `workspaceWallpaper.ts`
- keep the wallpaper runtime behavior unchanged and restrict those helpers/constants to file-local scope

## Historical role
These exports came in with the original desktop wallpaper module in `e2120fb2` (`feat: init project for tutti open source`). At that point the file exposed a wider surface while wallpaper state, snapshot metadata, and option resolution were first being laid down.

What remains today is narrower:
- `customWorkspaceWallpaperTitleKey`
- `defaultWorkspaceWallpaperDisplayMode`
- `isWorkspaceWallpaperDisplayMode`
- `isWorkspaceWallpaperId`
- `resolveWorkspaceWallpaperOption`

All five now only serve internal logic inside `workspaceWallpaper.ts`; no later production caller or external repository consumer was added.

## Reverification
I rechecked each symbol with exact-word searches across:
- `apps`
- `packages`
- `services`
- `/Users/ccr/tsh-project/tsh`

Result:
- each symbol matched only its definition and same-file internal uses inside `apps/desktop/src/renderer/src/features/workspace-workbench/services/workspaceWallpaper.ts`
- `workspaceWallpaper.test.ts` does not import any of these five symbols; it still imports only the actual public wallpaper API that remains exported
- no `tsh` caller depends on these exports

## Validation
- `pnpm --filter @tutti-os/desktop typecheck`
- `pnpm --filter @tutti-os/desktop test`
- `pnpm --filter @tutti-os/desktop build`
- `pnpm check:changed --tail-lines 80`
- `pnpm check:full`

## Docs impact
- `discard` — no module ownership, public contract, runtime behavior, or troubleshooting flow changed