### PR TITLE
refactor(desktop): remove unused runtime exports

### DIFF
--- a/apps/desktop/src/main/desktopLocale.ts
+++ b/apps/desktop/src/main/desktopLocale.ts
@@ -4,7 +4,7 @@ import {
   type DesktopLocale
 } from "@shared/i18n";
 
-export function resolveDesktopLocaleFromElectron(input: {
+function resolveDesktopLocaleFromElectron(input: {
   appLocale?: string | null;
   preferredSystemLanguages?: readonly string[] | null;
 }): DesktopLocale {

--- a/apps/desktop/src/main/desktopTheme.ts
+++ b/apps/desktop/src/main/desktopTheme.ts
@@ -11,11 +11,11 @@ const desktopWindowBackgroundColors: Record<DesktopThemeAppearance, string> = {
   light: "#f7f4ee"
 };
 
-export function resolveDesktopThemeAppearance(): DesktopThemeAppearance {
+function resolveDesktopThemeAppearance(): DesktopThemeAppearance {
   return nativeTheme.shouldUseDarkColors ? "dark" : "light";
 }
 
-export function resolveDesktopThemeSource(): DesktopThemeSource {
+function resolveDesktopThemeSource(): DesktopThemeSource {
   const source = nativeTheme.themeSource;
   return source === "dark" || source === "light" || source === "system"
     ? source


### PR DESCRIPTION
## Summary
- remove three stale `export` seams from the desktop runtime bootstrap helpers
- keep locale and theme behavior unchanged while restricting those helpers to file-local scope

## Historical role
These exports were introduced with the original open-source desktop bootstrap in `e2120fb2` (`feat: init project for tutti open source`). At that stage the locale/theme helpers exposed a wider surface while the Electron startup layer was first being laid down.

The remaining stale exports were:
- `resolveDesktopLocaleFromElectron` in `apps/desktop/src/main/desktopLocale.ts`
- `resolveDesktopThemeAppearance` in `apps/desktop/src/main/desktopTheme.ts`
- `resolveDesktopThemeSource` in `apps/desktop/src/main/desktopTheme.ts`

Today all three only support same-file runtime assembly:
- `getSystemDesktopLocale()` delegates to `resolveDesktopLocaleFromElectron(...)`
- `getDesktopThemeState()` and `resolveDesktopWindowBackgroundColor()` delegate to the theme helpers internally

No later production caller, test seam, or external `tsh` dependency was added.

## Reverification
I rechecked each symbol with exact-word searches across:
- `apps`
- `packages`
- `services`
- `/Users/ccr/tsh-project/tsh`

Result:
- each symbol matched only its definition and same-file internal uses
- no desktop test file imports these helpers
- no `tsh` caller depends on these exports

## Validation
- `pnpm --filter @tutti-os/desktop typecheck`
- `pnpm --filter @tutti-os/desktop test`
- `pnpm --filter @tutti-os/desktop build`
- `pnpm check:changed --tail-lines 80`
- `pnpm check:full`

## Docs impact
- `discard` — no public contract, runtime behavior, ownership boundary, or troubleshooting flow changed