### PR TITLE
refactor(desktop): remove unused workspace app logging exports

### DIFF
--- a/apps/desktop/src/main/ipc/workspaceAppFrontendLogging.ts
+++ b/apps/desktop/src/main/ipc/workspaceAppFrontendLogging.ts
@@ -13,7 +13,7 @@ export interface WorkspaceAppFrontendLogRecord extends TuttiExternalLogInput {
   webSource?: string;
 }
 
-export const workspaceAppFrontendLogRateLimitPerSecond = 50;
+const workspaceAppFrontendLogRateLimitPerSecond = 50;
 
 export function resolveWorkspaceAppWebLogPath(
   stateRootDir: string,
@@ -116,7 +116,7 @@ export class WorkspaceAppFrontendLogWriter {
   }
 }
 
-export function resolveWorkspaceAppFrontendLogLevel(
+function resolveWorkspaceAppFrontendLogLevel(
   event: string
 ): DesktopRuntimeLogLevel {
   return event.includes("failed") ? "warn" : "info";


### PR DESCRIPTION
## Summary
- remove two stale `export` seams from the workspace app frontend logging helper
- keep workspace app log formatting, rate limiting, and payload normalization behavior unchanged

## Historical role
These exports were introduced together in `3ed6fe55` (`feat(desktop): add tuttiExternal.logs.write for workspace app web.log (#93)`). At that stage the new workspace-app web diagnostic path exposed a wider helper surface while the feature was first being wired into desktop.

The stale exports were:
- `workspaceAppFrontendLogRateLimitPerSecond`
- `resolveWorkspaceAppFrontendLogLevel`

Today both are only used internally inside `apps/desktop/src/main/ipc/workspaceAppFrontendLogging.ts`:
- the rate-limit constant only feeds `WorkspaceAppGuestLogRateLimiter.allow(...)`
- the log-level helper only feeds `normalizeWorkspaceAppDiagnosticLogRecord(...)`

No later production caller, test seam, or external `tsh` dependency was added.

## Reverification
I rechecked both symbols with exact-word searches across:
- `apps`
- `packages`
- `services`
- `/Users/ccr/tsh-project/tsh`

Result:
- both symbols matched only their definition and same-file internal uses
- `workspaceAppFrontendLogging.test.ts` imports the still-public runtime API (`WorkspaceAppFrontendLogWriter`, `WorkspaceAppGuestLogRateLimiter`, `formatWorkspaceAppWebLogLine`, `normalizeWorkspaceAppDiagnosticLogRecord`, `resolveWorkspaceAppWebLogPath`) and does not import either removed export
- no `tsh` caller depends on these exports

## Validation
- `pnpm --filter @tutti-os/desktop typecheck`
- `pnpm --filter @tutti-os/desktop test`
- `pnpm --filter @tutti-os/desktop build`
- `pnpm check:changed --tail-lines 80`
- `pnpm check:full`

## Docs impact
- `discard` — no public contract, runtime behavior, ownership boundary, or troubleshooting flow changed