### PR TITLE
refactor(desktop): remove unused main helper exports

### DIFF
--- a/apps/desktop/src/main/developerLogs.ts
+++ b/apps/desktop/src/main/developerLogs.ts
@@ -429,9 +429,7 @@ async function discoverDeveloperDiagnosticsArtifacts(
   return artifacts;
 }
 
-export function createDefaultDeveloperLogsExportFileName(
-  now = new Date()
-): string {
+function createDefaultDeveloperLogsExportFileName(now = new Date()): string {
   const pad = (value: number): string => String(value).padStart(2, "0");
   const stamp = `${now.getFullYear()}${pad(now.getMonth() + 1)}${pad(now.getDate())}-${pad(
     now.getHours()

--- a/apps/desktop/src/main/host/workspaceAppFolderPaths.ts
+++ b/apps/desktop/src/main/host/workspaceAppFolderPaths.ts
@@ -49,7 +49,7 @@ export function workspaceAppScopeSegment(
     .slice(0, 16);
 }
 
-export function safeWorkspaceAppPathSegment(value: string): string {
+function safeWorkspaceAppPathSegment(value: string): string {
   const trimmed = value.trim();
   if (!trimmed) {
     return "_";

--- a/apps/desktop/src/main/host/workspaceFileEntryIcon.ts
+++ b/apps/desktop/src/main/host/workspaceFileEntryIcon.ts
@@ -227,7 +227,7 @@ function isImageThumbnailEntry(
   );
 }
 
-export function isApplicationBundleName(name: string): boolean {
+function isApplicationBundleName(name: string): boolean {
   return name.trim().toLowerCase().endsWith(".app");
 }
 


### PR DESCRIPTION
## Summary
- remove the unused `createDefaultDeveloperLogsExportFileName` export from `developerLogs.ts`
- remove the unused `safeWorkspaceAppPathSegment` export from `workspaceAppFolderPaths.ts`
- remove the unused `isApplicationBundleName` export from `workspaceFileEntryIcon.ts`

## Historical role
- `createDefaultDeveloperLogsExportFileName` was introduced in `e2120fb2` (`feat: init project for tutti open source`) as the internal helper that stamps the default developer-log archive filename during export.
- `safeWorkspaceAppPathSegment` was introduced in `e2120fb2` and remained through `f2bb0679` (`Update local state layout and provider checks`) as the internal path-segment sanitizer used while resolving workspace app state folders.
- `isApplicationBundleName` was introduced in `b4d38958` (`feat(workspace): cache file manager icons`) as the local `.app` bundle detector for workspace file icon resolution.

## Reverification
- I re-ran exact-word search for these three symbols across the current repository and the local sibling `tsh` repository: `rg -n -w "createDefaultDeveloperLogsExportFileName|safeWorkspaceAppPathSegment|isApplicationBundleName" . /Users/ccr/tsh-project/tsh`
- The only matches are their definitions and same-file call sites; there are no imports, cross-file calls, or `tsh` consumers.
- I also rechecked nearby helpers before editing. For example, `workspaceAppScopeSegment` still has real consumers in desktop tests, Go code, and migration scripts, so it stays exported.

## Validation
- `pnpm --filter @tutti-os/desktop typecheck`
- `pnpm --filter @tutti-os/desktop test`
- `pnpm --filter @tutti-os/desktop build`
- `pnpm check:changed --tail-lines 80`
- `pnpm check:full`

## Docs impact
- discard (no durable documentation impact)