### PR TITLE
refactor(desktop): remove unused renderer helper exports

### DIFF
--- a/apps/desktop/src/renderer/src/features/analytics/reporters/agent-error-fields.ts
+++ b/apps/desktop/src/renderer/src/features/analytics/reporters/agent-error-fields.ts
@@ -53,7 +53,7 @@ export function agentAnalyticsErrorFields(
   };
 }
 
-export function errorMessageOf(error: unknown): string {
+function errorMessageOf(error: unknown): string {
   if (error instanceof Error && error.message.trim()) {
     return error.message.trim();
   }

--- a/apps/desktop/src/renderer/src/features/analytics/reporters/openedSource.ts
+++ b/apps/desktop/src/renderer/src/features/analytics/reporters/openedSource.ts
@@ -29,7 +29,7 @@ export function createAnalyticsOpenedSourceParams(
   };
 }
 
-export function toAnalyticsOpenTrigger(
+function toAnalyticsOpenTrigger(
   source: AnalyticsOpenSource
 ): AnalyticsOpenTrigger {
   return source === "restore" || source === "agent_command"

--- a/apps/desktop/src/renderer/src/features/workspace-file-manager/services/desktopWorkspaceFileLocations.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-file-manager/services/desktopWorkspaceFileLocations.ts
@@ -75,7 +75,7 @@ export function resolveDesktopWorkspaceFileDefaultLocationId(input: {
     : DESKTOP_WORKSPACE_FILE_HOME_LOCATION_ID;
 }
 
-export function desktopWorkspaceFileProjectLocationId(
+function desktopWorkspaceFileProjectLocationId(
   project: Pick<WorkspaceUserProject, "id">
 ): string {
   return `project:${project.id}`;

--- a/apps/desktop/src/renderer/src/features/workspace-workbench/services/workspaceFilePreviewSaveRequests.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/services/workspaceFilePreviewSaveRequests.ts
@@ -1,4 +1,4 @@
-export const workspaceFilePreviewSaveRequestEvent =
+const workspaceFilePreviewSaveRequestEvent =
   "tutti:workspace-file-preview-save-request";
 
 export interface WorkspaceFilePreviewSaveRequestDetail {


### PR DESCRIPTION
## Summary
- remove the unused `errorMessageOf` export from `agent-error-fields.ts`
- remove the unused `toAnalyticsOpenTrigger` export from `openedSource.ts`
- remove the unused `desktopWorkspaceFileProjectLocationId` export from `desktopWorkspaceFileLocations.ts`
- remove the unused `workspaceFilePreviewSaveRequestEvent` export from `workspaceFilePreviewSaveRequests.ts`

## Historical role
- `errorMessageOf` was introduced in `8ecfac31` (`feat(agent): report node results across flows`) as the local error-message normalizer used while building analytics error fields.
- `toAnalyticsOpenTrigger` was introduced in `e2120fb2` (`feat: init project for tutti open source`) as the local source-to-trigger mapper for opened-source analytics payloads.
- `desktopWorkspaceFileProjectLocationId` was introduced in `2fb135bc` (`feat(workspace-files): share file locations`) as the local helper that formats project-backed file-location ids.
- `workspaceFilePreviewSaveRequestEvent` was introduced in `e2120fb2` as the internal window event name used by the workspace file preview save-request bridge.

## Reverification
- I re-ran exact-word code search for these symbols across the current code roots and the local sibling `tsh` repository: `rg -n -w "errorMessageOf|toAnalyticsOpenTrigger|desktopWorkspaceFileProjectLocationId|workspaceFilePreviewSaveRequestEvent" apps packages services /Users/ccr/tsh-project/tsh`
- The only code matches are the definitions and same-file call sites; there are no imports, cross-file calls, package consumers, or `tsh` consumers.
- `errorMessageOf` also appears in `docs/specs/2026-06-29-agent-node-result-analytics-plan.md`, but that is a design-spec snippet rather than a runtime code consumer, so it does not change the code-usage result.

## Validation
- `pnpm --filter @tutti-os/desktop typecheck`
- `pnpm --filter @tutti-os/desktop test`
- `pnpm --filter @tutti-os/desktop build`
- `pnpm check:changed --tail-lines 80`
- `pnpm check:full`

## Docs impact
- discard (no durable documentation impact)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Tightened internal visibility for several analytics, workspace, and file-management helpers.
  * Kept existing behavior unchanged while reducing what’s exposed for external use.
  * Improved module encapsulation around error handling, open-trigger mapping, workspace location IDs, and preview-save request events.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->