### PR TITLE
refactor(agent): remove temporary state sync instrumentation

### DIFF
--- a/apps/desktop/src/renderer/src/features/workspace-agent/services/internal/createDesktopAgentQueuedPromptDrainCoordinator.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-agent/services/internal/createDesktopAgentQueuedPromptDrainCoordinator.ts
@@ -1,8 +1,6 @@
 import {
-  deriveSubmitAvailability,
   isLiveTurnLifecyclePhase,
-  resolveSubmitAvailability,
-  runtimeContextHasLiveBackgroundAgents
+  resolveSubmitAvailability
 } from "@tutti-os/agent-activity-core";
 import type {
   AgentActivityRuntime,
@@ -24,7 +22,6 @@ interface DesktopQueuedPromptReadyQueue {
 interface DesktopQueuedPromptSkipReason {
   agentSessionId: string;
   activeTurnId?: string | null;
-  availabilityProbe?: DesktopQueuedPromptAvailabilityProbe;
   blockedByRetryBlock?: boolean;
   claimOwnerId?: string | null;
   currentPhase?: unknown;
@@ -38,23 +35,6 @@ interface DesktopQueuedPromptSkipReason {
   submitAvailabilityState?: unknown;
   suspendReason?: string | null;
   turnLifecyclePhase?: unknown;
-}
-
-// Diagnostic-only probe (temporary instrumentation): compares the wire
-// submitAvailability with a value derived from turnLifecycle +
-// runtimeContext.backgroundAgents, to validate two hypotheses in the field:
-// (1) the wire value goes stale while the lifecycle stays correct, and
-// (2) backgroundAgents never reaches this record over the push channel.
-interface DesktopQueuedPromptAvailabilityProbe {
-  backgroundAgents: {
-    present: boolean;
-    count: number | null;
-    liveItemCount: number | null;
-  };
-  derivedReason: string | null;
-  derivedState: string | null;
-  wireReason: string | null;
-  wireState: string | null;
 }
 
 interface DesktopQueuedPromptSendNextInterrupt {
@@ -199,17 +179,10 @@ export function createDesktopAgentQueuedPromptDrainCoordinator({
         if (!claimResult) {
           continue;
         }
-        const readySession = findActivitySession(
-          activitySnapshot,
-          readyQueue.queue.agentSessionId
-        );
         logDrainer("send-start", {
           workspaceId,
           ownerId,
           agentSessionId: readyQueue.queue.agentSessionId,
-          availabilityProbe: readySession
-            ? describeSessionAvailabilityProbe(readySession)
-            : null,
           queuedPromptId: claimResult.prompt.id,
           claimId: claimResult.claim.claimId,
           sessionStateUpdatedAtUnixMs: readyQueue.sessionStateUpdatedAtUnixMs
@@ -421,7 +394,6 @@ function findReadyQueue(
       skipped.push({
         agentSessionId: queue.agentSessionId,
         activeTurnId: session.turnLifecycle?.activeTurnId ?? null,
-        availabilityProbe: describeSessionAvailabilityProbe(session),
         currentPhase: session.currentPhase,
         promptId: queuedPrompt.id,
         reason: "session-not-ready",
@@ -508,54 +480,6 @@ function sessionLooksBusy(session: AgentActivitySession): boolean {
     currentPhase === "waiting" ||
     Boolean(lifecycle?.activeTurnId)
   );
-}
-
-// Diagnostic probe (temporary instrumentation): report the wire
-// submitAvailability next to the locally derived value so field logs show
-// where they diverge. Decisions use deriveSubmitAvailability directly.
-function describeSessionAvailabilityProbe(
-  session: AgentActivitySession
-): DesktopQueuedPromptAvailabilityProbe {
-  const derived = deriveSubmitAvailability(session);
-  return {
-    backgroundAgents: backgroundAgentsProbe(session),
-    derivedReason: derived?.reason ?? null,
-    derivedState: derived?.state ?? null,
-    wireReason: session.submitAvailability?.reason ?? null,
-    wireState: session.submitAvailability?.state ?? null
-  };
-}
-
-function backgroundAgentsProbe(
-  session: AgentActivitySession
-): DesktopQueuedPromptAvailabilityProbe["backgroundAgents"] {
-  const runtimeContext = session.runtimeContext as
-    | Record<string, unknown>
-    | undefined;
-  const backgroundAgents = runtimeContext?.backgroundAgents as
-    | { count?: unknown; items?: unknown }
-    | undefined;
-  if (!backgroundAgents || typeof backgroundAgents !== "object") {
-    return { present: false, count: null, liveItemCount: null };
-  }
-  const count =
-    typeof backgroundAgents.count === "number" ? backgroundAgents.count : null;
-  const items = Array.isArray(backgroundAgents.items)
-    ? backgroundAgents.items
-    : null;
-  const liveItemCount =
-    items === null
-      ? null
-      : items.filter(
-          (item) =>
-            !!item &&
-            typeof item === "object" &&
-            Object.keys(item).length > 0 &&
-            runtimeContextHasLiveBackgroundAgents({
-              backgroundAgents: { count: 0, items: [item] }
-            })
-        ).length;
-  return { present: true, count, liveItemCount };
 }
 
 function sessionActivityVersion(

--- a/apps/desktop/src/renderer/src/features/workspace-agent/services/internal/workspaceAgentActivityService.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-agent/services/internal/workspaceAgentActivityService.ts
@@ -1,7 +1,6 @@
 import {
   createAgentActivityController,
   normalizeAgentActivityDisplayStatus,
-  setAgentActivityStoreDiagnosticSink,
   type AgentActivityAdapter,
   type AgentActivityCancelSessionResult,
   type AgentActivityCreateSessionInput,
@@ -115,34 +114,6 @@ export class WorkspaceAgentActivityService implements IWorkspaceAgentActivitySer
   private eventStreamWasDisconnected = false;
 
   constructor(dependencies: WorkspaceAgentActivityServiceDependencies) {
-    // Temporary instrumentation: surface activity-store anomalies (version
-    // regressions on unguarded write paths, stale-patch drops) in the desktop
-    // log so field exports show which channel overwrote what. The sink slot
-    // is process-global, so register once and take the workspace id from the
-    // event details (the store stamps it at the emit site) — a per-workspace
-    // closure would be overwritten by the next workspace and misattribute
-    // diagnostics.
-    setAgentActivityStoreDiagnosticSink((event, details) => {
-      const flatDetails: Record<string, string | number | boolean | null> = {};
-      for (const [key, value] of Object.entries(details)) {
-        flatDetails[key] =
-          value === null ||
-          typeof value === "string" ||
-          typeof value === "number" ||
-          typeof value === "boolean"
-            ? value
-            : JSON.stringify(value);
-      }
-      void dependencies.runtimeApi
-        .logTerminalDiagnostic({
-          details: flatDetails,
-          event: `agent.activity.store.${event}`,
-          level: "warn",
-          workspaceId:
-            typeof details.workspaceId === "string" ? details.workspaceId : null
-        })
-        .catch(() => {});
-    });
     this.dependencies = dependencies;
   }
 

--- a/apps/desktop/src/renderer/src/platform/tuttid/createDesktopTuttidEventStreamClient.ts
+++ b/apps/desktop/src/renderer/src/platform/tuttid/createDesktopTuttidEventStreamClient.ts
@@ -8,18 +8,6 @@ export function createDesktopTuttidEventStreamClient(
   runtimeApi: DesktopRuntimeApi
 ): TuttidEventStreamClient {
   return createTuttidEventStreamClient({
-    resolveUrl: () => runtimeApi.getBusinessEventStreamUrl(),
-    // Frames that fail schema validation are dropped by the transport; the
-    // drop must land in the desktop log or producer/schema drift is invisible
-    // (a dropped state_patch reads as "the update never happened").
-    onInvalidFrame: (error, context) => {
-      void runtimeApi
-        .logTerminalDiagnostic({
-          details: { error: error.message, ready: context.ready },
-          event: "agent.events.stream.invalid_frame",
-          level: "warn"
-        })
-        .catch(() => {});
-    }
+    resolveUrl: () => runtimeApi.getBusinessEventStreamUrl()
   });
 }

--- a/packages/agent/activity-core/src/controller.ts
+++ b/packages/agent/activity-core/src/controller.ts
@@ -137,7 +137,6 @@ export function createAgentActivityController({
             if (!existing) {
               return nextSession;
             }
-            reportSessionVersionRegression("load", existing, nextSession);
             // A load response is a point-in-time snapshot; if a fresher pushed
             // state already landed for this session, keep it (same guard as
             // upsertSnapshotSession).
@@ -341,9 +340,7 @@ export function createAgentActivityController({
       if (session.workspaceId && session.workspaceId !== snapshot.workspaceId) {
         return;
       }
-      updateSnapshot((current) =>
-        upsertSnapshotSession(current, session, "upsert_session")
-      );
+      updateSnapshot((current) => upsertSnapshotSession(current, session));
     },
     applyActivityUpdatedEvent(event) {
       const result = applyActivityUpdatedEvent(snapshot, event);
@@ -838,20 +835,6 @@ function applyActivityUpdatedStatePatch(
     return emptyActivityUpdatedApplyResult(snapshot);
   }
   if (isStaleStatePatch(existingSession, canonicalStatePatch)) {
-    reportAgentActivityStoreDiagnostic("state_patch_dropped_stale", {
-      agentSessionId: canonicalPatchSessionId,
-      workspaceId: input.workspaceId,
-      patchKey:
-        canonicalStatePatch.lastEventUnixMs ??
-        canonicalStatePatch.occurredAtUnixMs ??
-        null,
-      sessionKey:
-        existingSession.lastEventUnixMs ??
-        existingSession.updatedAtUnixMs ??
-        null,
-      patchTurnPhase: canonicalStatePatch.turn?.phase ?? null,
-      patchSubmitAvailability: canonicalStatePatch.submitAvailability ?? null
-    });
     return emptyActivityUpdatedApplyResult(snapshot);
   }
   const session = agentActivitySessionFromInlineStatePatch({
@@ -863,7 +846,7 @@ function applyActivityUpdatedStatePatch(
     applied: true,
     messages: [],
     session,
-    snapshot: upsertSnapshotSession(snapshot, session, "inline_state_patch"),
+    snapshot: upsertSnapshotSession(snapshot, session),
     statePatch: canonicalStatePatch
   };
 }
@@ -898,9 +881,7 @@ function applySessionEvent(
 
   if (event.eventType === "session_update") {
     const session = sessionFromEvent(snapshot.workspaceId, event, data);
-    return session
-      ? upsertSnapshotSession(snapshot, session, "session_update_event")
-      : snapshot;
+    return session ? upsertSnapshotSession(snapshot, session) : snapshot;
   }
 
   return snapshot;
@@ -974,34 +955,6 @@ function mergeSnapshotMessages(
   };
 }
 
-// Diagnostic sink (temporary instrumentation): surfaces store anomalies —
-// version regressions on unguarded write paths and stale-patch drops — to the
-// host's logging so field exports show WHICH channel overwrote WHAT.
-type AgentActivityStoreDiagnosticSink = (
-  event: string,
-  details: Record<string, unknown>
-) => void;
-
-let agentActivityStoreDiagnosticSink: AgentActivityStoreDiagnosticSink | null =
-  null;
-
-export function setAgentActivityStoreDiagnosticSink(
-  sink: AgentActivityStoreDiagnosticSink | null
-): void {
-  agentActivityStoreDiagnosticSink = sink;
-}
-
-function reportAgentActivityStoreDiagnostic(
-  event: string,
-  details: Record<string, unknown>
-): void {
-  try {
-    agentActivityStoreDiagnosticSink?.(event, details);
-  } catch {
-    // Diagnostics must never affect the store.
-  }
-}
-
 function sessionVersionKey(session: AgentActivitySession): number | null {
   return session.lastEventUnixMs ?? session.updatedAtUnixMs ?? null;
 }
@@ -1015,33 +968,9 @@ function sessionVersionRegressed(
   return previousKey !== null && nextKey !== null && nextKey < previousKey;
 }
 
-function reportSessionVersionRegression(
-  source: string,
-  existing: AgentActivitySession,
-  incoming: AgentActivitySession
-): void {
-  const previousKey = sessionVersionKey(existing);
-  const nextKey = sessionVersionKey(incoming);
-  if (previousKey === null || nextKey === null || nextKey >= previousKey) {
-    return;
-  }
-  reportAgentActivityStoreDiagnostic("session_version_regression", {
-    agentSessionId: incoming.agentSessionId,
-    workspaceId: incoming.workspaceId,
-    source,
-    previousKey,
-    nextKey,
-    previousTurnPhase: existing.turnLifecycle?.phase ?? null,
-    nextTurnPhase: incoming.turnLifecycle?.phase ?? null,
-    previousSubmitAvailability: existing.submitAvailability ?? null,
-    nextSubmitAvailability: incoming.submitAvailability ?? null
-  });
-}
-
 function upsertSnapshotSession(
   snapshot: AgentActivitySnapshot,
-  session: AgentActivitySession,
-  source = "unknown"
+  session: AgentActivitySession
 ): AgentActivitySnapshot {
   const index = snapshot.sessions.findIndex(
     (item) => item.agentSessionId === session.agentSessionId
@@ -1054,7 +983,6 @@ function upsertSnapshotSession(
   }
   const existingSession = snapshot.sessions[index];
   if (existingSession) {
-    reportSessionVersionRegression(source, existingSession, session);
     // A slow fetch can resolve after a fresher pushed state landed (e.g. a
     // reconcile snapshot requested mid-turn arriving after the settle patch).
     // Overwriting would freeze the session on a stale running/blocked view

--- a/packages/agent/activity-core/src/index.ts
+++ b/packages/agent/activity-core/src/index.ts
@@ -9,7 +9,6 @@ export {
   cloneAgentActivitySnapshot,
   createAgentActivityController,
   createEmptyAgentActivitySnapshot,
-  setAgentActivityStoreDiagnosticSink,
   type AgentActivityController,
   type AgentActivitySnapshotListener,
   type CreateAgentActivityControllerInput

--- a/packages/clients/tuttid-ts/src/eventStreamClient.ts
+++ b/packages/clients/tuttid-ts/src/eventStreamClient.ts
@@ -32,7 +32,6 @@ export interface CreateTuttidEventStreamClientInput {
   webSocketFactory?: EventStreamSocketFactory;
   heartbeat?: Partial<EventStreamHeartbeatConfig>;
   reconnect?: false | Partial<EventStreamReconnectConfig>;
-  onInvalidFrame?: (error: Error, context: { ready: boolean }) => void;
 }
 
 type ClientEventByTopic = {
@@ -122,7 +121,6 @@ export function createTuttidEventStreamClient(
   >({
     defaultScope: input.defaultScope,
     heartbeat: input.heartbeat,
-    onInvalidFrame: input.onInvalidFrame,
     protocol: tuttiEventStreamProtocol,
     reconnect: input.reconnect,
     resolveUrl: input.resolveUrl,

--- a/packages/events/stream-core/src/eventStreamClient.ts
+++ b/packages/events/stream-core/src/eventStreamClient.ts
@@ -103,12 +103,6 @@ export interface CreateEventStreamClientInput<TClientEvent, TScope> {
   webSocketFactory?: EventStreamSocketFactory;
   heartbeat?: Partial<EventStreamHeartbeatConfig>;
   reconnect?: false | Partial<EventStreamReconnectConfig>;
-  /**
-   * Invoked when a server frame fails parsing or schema validation. After the
-   * ready handshake such frames are dropped without disconnecting; without
-   * this hook the drop is invisible, which hides producer/schema drift.
-   */
-  onInvalidFrame?: (error: Error, context: { ready: boolean }) => void;
 }
 
 export interface EventStreamClient<TServerEvent, TScope> {
@@ -183,7 +177,6 @@ export function createEventStreamClient<
   input: CreateEventStreamClientInput<TClientEvent, TScope>
 ): EventStreamClient<TServerEvent, TScope> {
   const { protocol } = input;
-  const onInvalidFrame = input.onInvalidFrame;
   const webSocketFactory =
     input.webSocketFactory ?? defaultEventStreamSocketFactory;
   const heartbeat = {
@@ -336,11 +329,6 @@ export function createEventStreamClient<
         const messageListener = (event: MessageEvent) => {
           const parsedFrame = parseServerFrame(event.data);
           if (!parsedFrame.ok) {
-            try {
-              onInvalidFrame?.(parsedFrame.error, { ready });
-            } catch {
-              // Diagnostics must never affect the transport.
-            }
             if (!ready) {
               fail(parsedFrame.error);
             }


### PR DESCRIPTION
## Summary
- remove the temporary queued-prompt availability probe logging from the desktop drainer
- remove the temporary activity-store diagnostic sink and stale/older-session regression reporting path
- remove the temporary event-stream invalid-frame logging hook from desktop/client transport bindings

## Historical role
This code came from `e2d41cb1 chore(diagnostics): instrument state-sync hypotheses for field validation` on 2026-07-06.

That change was explicitly temporary instrumentation added ahead of the state-sync refactor so field log exports could confirm or reject three hypotheses:
- invalid server frames were being dropped silently after the event-stream ready handshake
- queued prompt draining needed a wire-vs-derived `submitAvailability` probe in logs
- activity-store writes might overwrite fresher session state, so regressions and stale state-patch drops were logged through a process-global diagnostic sink

A later follow-up (`6aad625a fix(agent-gui): make the activity-store diagnostic sink workspace-agnostic`) maintained the same temporary diagnostic path rather than turning it into a durable product behavior.

## Reverification
I rechecked this as removable instrumentation rather than assuming it was dead code.

- searched `tutti` and the local sibling `tsh` repo for `setAgentActivityStoreDiagnosticSink`, `onInvalidFrame`, `availabilityProbe`, `session_version_regression`, and `agent.events.stream.invalid_frame`; there are no remaining callers outside this same instrumentation chain
- confirmed the remaining transport and state-sync behavior still has its actual guards after removal: handshake failures still fail the stream before `ready`, and stale session/state-patch protection still remains in `activity-core`
- ran `pnpm check:changed -- --tail-lines 80`
- ran `pnpm --filter @tutti-os/desktop build`
- `git push` also passed the repository `pre-push` gate: `pnpm check:full`

## Docs impact
- no durable documentation update needed; this removes temporary diagnostics without changing product behavior or a public contract
