### PR TITLE
fix(tools): restore check:changed lane execution

### DIFF
--- a/tools/scripts/run-check-changed.mjs
+++ b/tools/scripts/run-check-changed.mjs
@@ -78,7 +78,7 @@ export async function main() {
   writeFileSync(latestSummaryPath, `${JSON.stringify(summary, null, 2)}\n`);
 
   const failures = results.filter((result) => result.exitCode !== 0);
-  printSummary(results, failures, durationMs);
+  printSummary(results, failures, durationMs, runDirectory);
 
   if (failures.length > 0) {
     process.exitCode = 1;
@@ -264,7 +264,7 @@ function readFailedLanes() {
     }));
 }
 
-async function runLanes(inputLanes, runDirectory) {
+export async function runLanes(inputLanes, runDirectory) {
   const results = [];
   let nextIndex = 0;
   const workerCount = Math.max(1, Math.min(maxParallel, inputLanes.length));
@@ -272,8 +272,9 @@ async function runLanes(inputLanes, runDirectory) {
   await Promise.all(
     Array.from({ length: workerCount }, async () => {
       while (nextIndex < inputLanes.length) {
-        const lane = inputLanes[nextIndex++];
-        results.push(await runLane(lane, runDirectory));
+        const laneIndex = nextIndex++;
+        const lane = inputLanes[laneIndex];
+        results.push(await runLane(lane, laneIndex, runDirectory));
       }
     })
   );
@@ -281,8 +282,7 @@ async function runLanes(inputLanes, runDirectory) {
   return results.sort((left, right) => left.index - right.index);
 }
 
-function runLane(lane, runDirectory) {
-  const index = lanes.indexOf(lane);
+function runLane(lane, index, runDirectory) {
   const logPath = join(runDirectory, `${sanitizeFileName(lane.key)}.log`);
   const logStream = createWriteStream(logPath, { flags: "w" });
   const startedAt = Date.now();
@@ -343,7 +343,7 @@ function printPlan(inputLanes) {
   }
 }
 
-function printSummary(results, failures, durationMs) {
+export function printSummary(results, failures, durationMs, runDirectory) {
   if (failures.length === 0) {
     console.log(
       `check:changed passed ${results.length} lane(s) in ${formatDuration(durationMs)}`

--- a/tools/scripts/run-check-changed.test.mjs
+++ b/tools/scripts/run-check-changed.test.mjs
@@ -1,6 +1,13 @@
 import assert from "node:assert/strict";
+import { mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import test from "node:test";
-import { selectExistingLintFiles } from "./run-check-changed.mjs";
+import {
+  printSummary,
+  runLanes,
+  selectExistingLintFiles
+} from "./run-check-changed.mjs";
 
 test("selectExistingLintFiles drops deleted lint targets", () => {
   const changedFiles = [
@@ -26,4 +33,77 @@ test("selectExistingLintFiles keeps existing lintable paths", () => {
   const lintFiles = selectExistingLintFiles(changedFiles, () => true);
 
   assert.deepEqual(lintFiles, changedFiles);
+});
+
+test("runLanes preserves lane indexes without relying on outer scope", async () => {
+  const runDirectory = mkdtempSync(join(tmpdir(), "run-check-changed-"));
+  const lanes = [
+    {
+      key: "lane-b",
+      label: "lane-b",
+      command: [process.execPath, "-e", "setTimeout(() => {}, 10)"]
+    },
+    {
+      key: "lane-a",
+      label: "lane-a",
+      command: [process.execPath, "-e", ""]
+    }
+  ];
+
+  const results = await runLanes(lanes, runDirectory);
+
+  assert.deepEqual(
+    results.map((result) => result.index),
+    [0, 1]
+  );
+  assert.deepEqual(
+    results.map((result) => result.key),
+    ["lane-b", "lane-a"]
+  );
+});
+
+test("printSummary includes rerun hint for failures", () => {
+  const errors = [];
+  const originalError = console.error;
+  console.error = (...args) => {
+    errors.push(args.join(" "));
+  };
+
+  try {
+    printSummary(
+      [
+        {
+          command: ["pnpm", "lint"],
+          durationMs: 10,
+          exitCode: 1,
+          index: 0,
+          key: "lint:changed",
+          label: "lint:changed",
+          logPath: "/tmp/lint.log",
+          logPathRelative: ".tmp/check-runs/example/lint.log"
+        }
+      ],
+      [
+        {
+          command: ["pnpm", "lint"],
+          durationMs: 10,
+          exitCode: 1,
+          index: 0,
+          key: "lint:changed",
+          label: "lint:changed",
+          logPath: "/tmp/lint.log",
+          logPathRelative: ".tmp/check-runs/example/lint.log"
+        }
+      ],
+      10,
+      "/tmp/check-runs/example"
+    );
+  } finally {
+    console.error = originalError;
+  }
+
+  assert.match(
+    errors.at(-1) ?? "",
+    /Rerun failed lanes with: pnpm check:changed -- --failed-only/u
+  );
 });


### PR DESCRIPTION
## Summary
- fix `run-check-changed` lane execution so it no longer crashes on an undefined `lanes` variable
- pass the run directory into failure summary output so failed runs can print the rerun hint instead of throwing a second scope error
- add regression tests for lane execution ordering and failure summary rendering

## Validation
- `node --test tools/scripts/run-check-changed.test.mjs`
- `pnpm check:changed -- --tail-lines 80`
- `pnpm check:full`

## Docs
- No documentation impact found.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved failure messages to include the correct “full logs” rerun location, making it easier to retry failed checks.
  * Made check results display in a stable, predictable order when multiple tasks run in parallel.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->