### PR TITLE
feat(agent-gui): isolate conversation streams by runtime origin

### DIFF
--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUINodeController.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUINodeController.ts
@@ -3706,6 +3706,10 @@ export function useAgentGUINodeController({
   onShowMessage
 }: UseAgentGUINodeControllerInput) {
   const agentActivityRuntime = useAgentActivityRuntime();
+  // Stable identity of the injected runtime; drives the conversation-list query
+  // key and every session-view ref so local/shared runtimes stay isolated.
+  const agentActivityRuntimeOrigin =
+    agentActivityRuntime.origin?.trim() || AGENT_GUI_RUNTIME_SESSION_ORIGIN;
   const agentQueuedPromptRuntime = useAgentQueuedPromptRuntime();
   const agentHostApi = useAgentHostApi();
   const agentActivitySnapshot = useAgentActivitySnapshot(workspaceId);
@@ -3914,9 +3918,18 @@ export function useAgentGUINodeController({
         workspaceId,
         userId,
         provider: data.provider,
-        sessionOrigin: AGENT_GUI_RUNTIME_SESSION_ORIGIN
+        // Identity derives from the injected runtime so local/shared runtimes
+        // for the same workspace produce distinct query keys. Legacy runtimes
+        // without an origin fall back to the default origin (no key change).
+        sessionOrigin: agentActivityRuntimeOrigin
       };
-    }, [currentUserId, data.provider, conversationFilter, workspaceId]);
+    }, [
+      agentActivityRuntimeOrigin,
+      currentUserId,
+      data.provider,
+      conversationFilter,
+      workspaceId
+    ]);
   const conversationListState = useAgentGuiConversationList(
     conversationListQuery
   );
@@ -4064,9 +4077,10 @@ export function useAgentGUINodeController({
   const sessionViewRef = useCallback(
     (agentSessionId: string | null | undefined) => ({
       workspaceId,
-      agentSessionId
+      agentSessionId,
+      origin: agentActivityRuntimeOrigin
     }),
-    [workspaceId]
+    [agentActivityRuntimeOrigin, workspaceId]
   );
   const activeSessionView = useAgentSessionView(
     sessionViewRef(activeConversationId)
@@ -7180,6 +7194,7 @@ export function useAgentGUINodeController({
   useWatchAgentSession({
     workspaceId,
     agentSessionId: activeConversationId,
+    origin: agentActivityRuntimeOrigin,
     enabled: !previewMode && activeConversationId !== null,
     onSubscribe: () => {
       if (!activeConversationId) {
@@ -7222,6 +7237,7 @@ export function useAgentGUINodeController({
   useWatchAgentSessions({
     workspaceId,
     agentSessionIds: backgroundWatchedConversationIds,
+    origin: agentActivityRuntimeOrigin,
     enabled: backgroundWatchedConversationIds.length > 0,
     onEvents: (events) => {
       handleBackgroundActivityStreamEvents(events);

--- a/packages/agent/gui/agentActivityHost.origin.spec.tsx
+++ b/packages/agent/gui/agentActivityHost.origin.spec.tsx
@@ -1,0 +1,55 @@
+import { cleanup, render } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  AgentActivityHostProvider,
+  getAgentHostApiByOrigin,
+  resetAgentHostApiForTests
+} from "./agentActivityHost";
+import {
+  resetAgentActivityRuntimeForTests,
+  type AgentActivityRuntime
+} from "./agentActivityRuntime";
+import type { AgentHostInputApi } from "./host/agentHostApi";
+
+function createRuntime(origin: string): AgentActivityRuntime {
+  return { origin } as unknown as AgentActivityRuntime;
+}
+
+function createHostApi(persistence: object): AgentHostInputApi {
+  // Only `persistence` matters for read-state routing; the rest of the host
+  // surface is irrelevant here.
+  return { persistence } as unknown as AgentHostInputApi;
+}
+
+afterEach(() => {
+  cleanup();
+  resetAgentHostApiForTests();
+  resetAgentActivityRuntimeForTests();
+});
+
+describe("getAgentHostApiByOrigin", () => {
+  it("routes each origin's persistence to its own host API", () => {
+    const localPersistence = { tag: "local" };
+    const cloudPersistence = { tag: "cloud" };
+
+    render(
+      <>
+        <AgentActivityHostProvider
+          agentActivityRuntime={createRuntime("origin-local")}
+          agentHostApi={createHostApi(localPersistence)}
+        />
+        <AgentActivityHostProvider
+          agentActivityRuntime={createRuntime("origin-cloud")}
+          agentHostApi={createHostApi(cloudPersistence)}
+        />
+      </>
+    );
+
+    expect(getAgentHostApiByOrigin("origin-local")?.persistence).toBe(
+      localPersistence
+    );
+    expect(getAgentHostApiByOrigin("origin-cloud")?.persistence).toBe(
+      cloudPersistence
+    );
+  });
+});

--- a/packages/agent/gui/agentActivityHost.origin.spec.tsx
+++ b/packages/agent/gui/agentActivityHost.origin.spec.tsx
@@ -52,4 +52,16 @@ describe("getAgentHostApiByOrigin", () => {
       cloudPersistence
     );
   });
+
+  it("returns null for an unregistered explicit origin instead of cross-routing", () => {
+    render(
+      <AgentActivityHostProvider
+        agentActivityRuntime={createRuntime("origin-local")}
+        agentHostApi={createHostApi({ tag: "local" })}
+      />
+    );
+
+    // Shared read-state must not be written to the local host's persistence.
+    expect(getAgentHostApiByOrigin("origin-shared")).toBeNull();
+  });
 });

--- a/packages/agent/gui/agentActivityHost.tsx
+++ b/packages/agent/gui/agentActivityHost.tsx
@@ -1,6 +1,7 @@
 import {
   createContext,
   useContext,
+  useEffect,
   useMemo,
   type JSX,
   type PropsWithChildren
@@ -14,12 +15,28 @@ import {
   AgentActivityRuntimeProvider,
   type AgentActivityRuntime
 } from "./agentActivityRuntime";
+import { WORKSPACE_AGENT_ACTIVITY_RUNTIME_SESSION_ORIGIN } from "./shared/workspaceAgentActivityTypes";
 
 const AgentActivityHostContext = createContext<AgentHostRuntimeApi | null>(
   null
 );
 
 let currentAgentHostApi: AgentHostRuntimeApi | null = null;
+
+// Host APIs indexed by their runtime origin, mirroring the runtime registry.
+// Read-state persistence resolves the host API by the query's origin so a
+// local window persists to the local host and a shared/cloud window persists to
+// its own cloud host — each backend keyed by (roomId, userId) with no origin
+// needed on the record itself.
+const hostApiByOrigin = new Map<string, AgentHostRuntimeApi>();
+
+function resolveHostOrigin(
+  runtime: AgentActivityRuntime | null | undefined
+): string {
+  return (
+    runtime?.origin?.trim() || WORKSPACE_AGENT_ACTIVITY_RUNTIME_SESSION_ORIGIN
+  );
+}
 
 export interface AgentActivityHostProviderProps extends PropsWithChildren {
   agentActivityRuntime?: AgentActivityRuntime | null;
@@ -36,6 +53,23 @@ export function AgentActivityHostProvider({
     [agentHostApi]
   );
   currentAgentHostApi = resolvedAgentHostApi;
+  const origin = resolveHostOrigin(agentActivityRuntime);
+  // Register during render to close the gap before the effect runs; the effect
+  // owns cleanup on unmount.
+  if (resolvedAgentHostApi) {
+    hostApiByOrigin.set(origin, resolvedAgentHostApi);
+  }
+  useEffect(() => {
+    if (!resolvedAgentHostApi) {
+      return;
+    }
+    hostApiByOrigin.set(origin, resolvedAgentHostApi);
+    return () => {
+      if (hostApiByOrigin.get(origin) === resolvedAgentHostApi) {
+        hostApiByOrigin.delete(origin);
+      }
+    };
+  }, [origin, resolvedAgentHostApi]);
   return (
     <AgentActivityRuntimeProvider runtime={agentActivityRuntime}>
       <AgentActivityHostContext.Provider value={resolvedAgentHostApi}>
@@ -68,9 +102,28 @@ export function getOptionalAgentHostApi(): AgentHostRuntimeApi | null {
   );
 }
 
+/**
+ * Resolve the host API for a given runtime origin. When the origin is registered
+ * (local vs shared/cloud host), returns that exact host API so its persistence
+ * (read-state, etc.) targets the matching backend; otherwise falls back to
+ * legacy single-host resolution.
+ */
+export function getAgentHostApiByOrigin(
+  origin: string | null | undefined
+): AgentHostRuntimeApi | null {
+  const normalizedOrigin =
+    origin?.trim() || WORKSPACE_AGENT_ACTIVITY_RUNTIME_SESSION_ORIGIN;
+  const hostApi = hostApiByOrigin.get(normalizedOrigin);
+  if (hostApi) {
+    return hostApi;
+  }
+  return getOptionalAgentHostApi();
+}
+
 export function resetAgentHostApiForTests(): void {
   if (process.env.NODE_ENV === "test") {
     currentAgentHostApi = null;
+    hostApiByOrigin.clear();
   }
 }
 

--- a/packages/agent/gui/agentActivityHost.tsx
+++ b/packages/agent/gui/agentActivityHost.tsx
@@ -117,7 +117,14 @@ export function getAgentHostApiByOrigin(
   if (hostApi) {
     return hostApi;
   }
-  return getOptionalAgentHostApi();
+  // Only the default (local) origin falls back to the legacy single-host slot.
+  // An explicit non-default origin that is not registered returns null so its
+  // persistence never lands in a different host's store (e.g. shared read-state
+  // must not be written to the local backend).
+  if (normalizedOrigin === WORKSPACE_AGENT_ACTIVITY_RUNTIME_SESSION_ORIGIN) {
+    return getOptionalAgentHostApi();
+  }
+  return null;
 }
 
 export function resetAgentHostApiForTests(): void {

--- a/packages/agent/gui/agentActivityRuntime.origin.spec.tsx
+++ b/packages/agent/gui/agentActivityRuntime.origin.spec.tsx
@@ -1,0 +1,74 @@
+import { cleanup, render } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  AgentActivityRuntimeProvider,
+  getAgentActivityRuntimeByOrigin,
+  resetAgentActivityRuntimeForTests,
+  type AgentActivityRuntime
+} from "./agentActivityRuntime";
+import { WORKSPACE_AGENT_ACTIVITY_RUNTIME_SESSION_ORIGIN } from "./shared/workspaceAgentActivityTypes";
+
+function createRuntime(origin?: string): AgentActivityRuntime {
+  // Only `origin` participates in registry resolution; the rest of the surface
+  // is irrelevant for this test, so a tagged stub is sufficient.
+  return { origin } as unknown as AgentActivityRuntime;
+}
+
+afterEach(() => {
+  cleanup();
+  resetAgentActivityRuntimeForTests();
+});
+
+describe("getAgentActivityRuntimeByOrigin", () => {
+  it("resolves two coexisting runtimes independently by origin", () => {
+    const localRuntime = createRuntime("origin-local");
+    const sharedRuntime = createRuntime("origin-shared");
+
+    render(
+      <>
+        <AgentActivityRuntimeProvider runtime={localRuntime} />
+        <AgentActivityRuntimeProvider runtime={sharedRuntime} />
+      </>
+    );
+
+    expect(getAgentActivityRuntimeByOrigin("origin-local")).toBe(localRuntime);
+    expect(getAgentActivityRuntimeByOrigin("origin-shared")).toBe(
+      sharedRuntime
+    );
+  });
+
+  it("registers an origin-less runtime under the default origin", () => {
+    const localRuntime = createRuntime();
+
+    render(<AgentActivityRuntimeProvider runtime={localRuntime} />);
+
+    expect(
+      getAgentActivityRuntimeByOrigin(
+        WORKSPACE_AGENT_ACTIVITY_RUNTIME_SESSION_ORIGIN
+      )
+    ).toBe(localRuntime);
+  });
+
+  it("removes an origin from the registry after its provider unmounts", () => {
+    const sharedRuntime = createRuntime("origin-shared");
+    const localRuntime = createRuntime("origin-local");
+
+    // Render shared first, local last, so the module-global fallback settles on
+    // localRuntime — letting us prove origin-shared is gone from the registry by
+    // observing it fall back rather than resolve to sharedRuntime.
+    const view = render(
+      <>
+        <AgentActivityRuntimeProvider runtime={sharedRuntime} />
+        <AgentActivityRuntimeProvider runtime={localRuntime} />
+      </>
+    );
+    expect(getAgentActivityRuntimeByOrigin("origin-shared")).toBe(
+      sharedRuntime
+    );
+
+    view.rerender(<AgentActivityRuntimeProvider runtime={localRuntime} />);
+
+    expect(getAgentActivityRuntimeByOrigin("origin-shared")).toBe(localRuntime);
+    expect(getAgentActivityRuntimeByOrigin("origin-local")).toBe(localRuntime);
+  });
+});

--- a/packages/agent/gui/agentActivityRuntime.origin.spec.tsx
+++ b/packages/agent/gui/agentActivityRuntime.origin.spec.tsx
@@ -49,13 +49,19 @@ describe("getAgentActivityRuntimeByOrigin", () => {
     ).toBe(localRuntime);
   });
 
+  it("returns null for an unregistered explicit origin instead of cross-routing", () => {
+    const localRuntime = createRuntime("origin-local");
+
+    render(<AgentActivityRuntimeProvider runtime={localRuntime} />);
+
+    // A shared query must not silently resolve to the local runtime.
+    expect(getAgentActivityRuntimeByOrigin("origin-shared")).toBeNull();
+  });
+
   it("removes an origin from the registry after its provider unmounts", () => {
     const sharedRuntime = createRuntime("origin-shared");
     const localRuntime = createRuntime("origin-local");
 
-    // Render shared first, local last, so the module-global fallback settles on
-    // localRuntime — letting us prove origin-shared is gone from the registry by
-    // observing it fall back rather than resolve to sharedRuntime.
     const view = render(
       <>
         <AgentActivityRuntimeProvider runtime={sharedRuntime} />
@@ -68,7 +74,9 @@ describe("getAgentActivityRuntimeByOrigin", () => {
 
     view.rerender(<AgentActivityRuntimeProvider runtime={localRuntime} />);
 
-    expect(getAgentActivityRuntimeByOrigin("origin-shared")).toBe(localRuntime);
+    // origin-shared is gone from the registry; an unregistered explicit origin
+    // resolves to null rather than cross-routing to the still-mounted local one.
+    expect(getAgentActivityRuntimeByOrigin("origin-shared")).toBeNull();
     expect(getAgentActivityRuntimeByOrigin("origin-local")).toBe(localRuntime);
   });
 });

--- a/packages/agent/gui/agentActivityRuntime.tsx
+++ b/packages/agent/gui/agentActivityRuntime.tsx
@@ -1,6 +1,7 @@
 import {
   createContext,
   useContext,
+  useEffect,
   useSyncExternalStore,
   type JSX,
   type PropsWithChildren
@@ -31,6 +32,7 @@ import type {
   AgentHostAgentSessionState
 } from "./shared/contracts/dto";
 import type { AgentGUIProviderTargetRef } from "./types";
+import { WORKSPACE_AGENT_ACTIVITY_RUNTIME_SESSION_ORIGIN } from "./shared/workspaceAgentActivityTypes";
 
 export interface AgentActivityRuntimeListSessionMessagesInput {
   afterVersion?: number;
@@ -264,6 +266,15 @@ export interface AgentActivityRuntimePromptAsset {
 }
 
 export interface AgentActivityRuntime {
+  /**
+   * Stable identity of this runtime instance (e.g. a local origin vs a
+   * shared/room origin). When present, the conversation-list and session-view
+   * stores key their query state, runtime resolution, and subscriptions by this
+   * value, so multiple runtimes can coexist for the same workspace without
+   * fighting over a single module-global slot. Absent => legacy single-runtime
+   * behaviour resolved via the module-global.
+   */
+  origin?: string;
   promptContentUploadSupport?: {
     file?: boolean;
     image?: boolean;
@@ -372,6 +383,22 @@ const AgentActivityRuntimeContext = createContext<AgentActivityRuntime | null>(
 
 let currentAgentActivityRuntime: AgentActivityRuntime | null = null;
 
+// Registry of runtimes indexed by their stable `origin`. Non-React module
+// singletons (the conversation-list and session-view stores) resolve the
+// correct runtime for a query's origin from here instead of reading the
+// last-mounted module-global — the single slot two runtimes used to fight over.
+const runtimesByOrigin = new Map<string, AgentActivityRuntime>();
+
+// A runtime without an explicit origin is the default (local) runtime. It
+// registers under this canonical origin — the same value the conversation-list
+// query and session-view refs fall back to — so the local window resolves to it
+// by origin instead of depending on the last-mounted module-global. A shared/
+// room runtime opts in by setting a distinct `origin`; no host wiring needed for
+// the local case.
+function normalizeRuntimeOrigin(origin: string | null | undefined): string {
+  return origin?.trim() || WORKSPACE_AGENT_ACTIVITY_RUNTIME_SESSION_ORIGIN;
+}
+
 export interface AgentActivityRuntimeProviderProps extends PropsWithChildren {
   runtime?: AgentActivityRuntime | null;
 }
@@ -381,6 +408,24 @@ export function AgentActivityRuntimeProvider({
   runtime
 }: AgentActivityRuntimeProviderProps): JSX.Element {
   currentAgentActivityRuntime = runtime ?? null;
+  const origin = normalizeRuntimeOrigin(runtime?.origin);
+  // Register during render to close the gap before the effect runs (parity with
+  // the module-global write above); the effect owns cleanup on unmount.
+  if (origin && runtime) {
+    runtimesByOrigin.set(origin, runtime);
+  }
+  useEffect(() => {
+    if (!origin || !runtime) {
+      return;
+    }
+    runtimesByOrigin.set(origin, runtime);
+    return () => {
+      // Only clear if a newer provider hasn't already re-registered this origin.
+      if (runtimesByOrigin.get(origin) === runtime) {
+        runtimesByOrigin.delete(origin);
+      }
+    };
+  }, [origin, runtime]);
   return (
     <AgentActivityRuntimeContext.Provider value={runtime ?? null}>
       {children}
@@ -438,9 +483,29 @@ export function getOptionalAgentActivityRuntime(): AgentActivityRuntime | null {
   );
 }
 
+/**
+ * Resolve the runtime for a given origin. When the origin is registered (two
+ * runtimes coexisting for one workspace), returns that exact instance; otherwise
+ * falls back to legacy single-runtime resolution so callers without a registered
+ * origin keep working unchanged.
+ */
+export function getAgentActivityRuntimeByOrigin(
+  origin: string | null | undefined
+): AgentActivityRuntime | null {
+  const normalizedOrigin = normalizeRuntimeOrigin(origin);
+  if (normalizedOrigin) {
+    const runtime = runtimesByOrigin.get(normalizedOrigin);
+    if (runtime) {
+      return runtime;
+    }
+  }
+  return getOptionalAgentActivityRuntime();
+}
+
 export function resetAgentActivityRuntimeForTests(): void {
   if (process.env.NODE_ENV === "test") {
     currentAgentActivityRuntime = null;
+    runtimesByOrigin.clear();
   }
 }
 

--- a/packages/agent/gui/agentActivityRuntime.tsx
+++ b/packages/agent/gui/agentActivityRuntime.tsx
@@ -485,21 +485,25 @@ export function getOptionalAgentActivityRuntime(): AgentActivityRuntime | null {
 
 /**
  * Resolve the runtime for a given origin. When the origin is registered (two
- * runtimes coexisting for one workspace), returns that exact instance; otherwise
- * falls back to legacy single-runtime resolution so callers without a registered
- * origin keep working unchanged.
+ * runtimes coexisting for one workspace), returns that exact instance.
+ *
+ * Only the default (local) origin falls back to legacy single-runtime
+ * resolution. An explicit non-default origin that is not registered returns null
+ * rather than cross-routing to a different runtime via the module-global slot —
+ * e.g. a shared query must never silently load from the local runtime.
  */
 export function getAgentActivityRuntimeByOrigin(
   origin: string | null | undefined
 ): AgentActivityRuntime | null {
   const normalizedOrigin = normalizeRuntimeOrigin(origin);
-  if (normalizedOrigin) {
-    const runtime = runtimesByOrigin.get(normalizedOrigin);
-    if (runtime) {
-      return runtime;
-    }
+  const runtime = runtimesByOrigin.get(normalizedOrigin);
+  if (runtime) {
+    return runtime;
   }
-  return getOptionalAgentActivityRuntime();
+  if (normalizedOrigin === WORKSPACE_AGENT_ACTIVITY_RUNTIME_SESSION_ORIGIN) {
+    return getOptionalAgentActivityRuntime();
+  }
+  return null;
 }
 
 export function resetAgentActivityRuntimeForTests(): void {

--- a/packages/agent/gui/contexts/workspace/presentation/renderer/agentGuiConversationList/agentGuiConversationListStore.spec.ts
+++ b/packages/agent/gui/contexts/workspace/presentation/renderer/agentGuiConversationList/agentGuiConversationListStore.spec.ts
@@ -366,6 +366,26 @@ describe("agentGuiConversationListStore", () => {
     expect(legacyCodexKey).not.toBe(legacyClaudeKey);
   });
 
+  it("splits query keys by sessionOrigin so local and shared runtimes stay isolated", () => {
+    const localQuery: AgentGUIConversationListQuery = {
+      workspaceId: "workspace-1",
+      userId: "user-1",
+      provider: "codex",
+      sessionOrigin: "WORKSPACE_AGENT_SESSION_ORIGIN_RUNTIME"
+    };
+    const sharedQuery: AgentGUIConversationListQuery = {
+      ...localQuery,
+      sessionOrigin: "WORKSPACE_AGENT_SESSION_ORIGIN_SHARED"
+    };
+
+    const localKey = createAgentGUIConversationListQueryKey(localQuery);
+    const sharedKey = createAgentGUIConversationListQueryKey(sharedQuery);
+
+    expect(localKey).not.toBeNull();
+    expect(sharedKey).not.toBeNull();
+    expect(localKey).not.toBe(sharedKey);
+  });
+
   it("projects explicit conversation filters from the current runtime snapshot without reloading sessions", async () => {
     const allQuery: AgentGUIConversationListQuery = {
       workspaceId: "workspace-1",

--- a/packages/agent/gui/contexts/workspace/presentation/renderer/agentGuiConversationList/agentGuiConversationListStore.ts
+++ b/packages/agent/gui/contexts/workspace/presentation/renderer/agentGuiConversationList/agentGuiConversationListStore.ts
@@ -1,7 +1,7 @@
 import { mergeAgentActivityMessages } from "@tutti-os/agent-activity-core";
 import {
-  getAgentActivityRuntime,
-  getAgentActivityRuntimeByOrigin
+  getAgentActivityRuntimeByOrigin,
+  type AgentActivityRuntime
 } from "../../../../../agentActivityRuntime";
 import {
   getAgentHostApiByOrigin,
@@ -1220,9 +1220,7 @@ async function loadWorkspaceAgentSnapshotForConversations(input: {
   userId: string;
   workspaceId: string;
 }): Promise<WorkspaceAgentActivitySnapshot> {
-  const runtime =
-    getAgentActivityRuntimeByOrigin(input.sessionOrigin) ??
-    getAgentActivityRuntime();
+  const runtime = resolveRuntimeForOrigin(input.sessionOrigin);
   const snapshot = await runtime.load(input.workspaceId);
   return workspaceAgentSnapshotForConversations(snapshot);
 }
@@ -1231,11 +1229,22 @@ function getWorkspaceAgentSnapshotForConversations(input: {
   sessionOrigin: string;
   workspaceId: string;
 }): WorkspaceAgentActivitySnapshot {
-  const runtime =
-    getAgentActivityRuntimeByOrigin(input.sessionOrigin) ??
-    getAgentActivityRuntime();
+  const runtime = resolveRuntimeForOrigin(input.sessionOrigin);
   const snapshot = runtime.getSnapshot(input.workspaceId);
   return workspaceAgentSnapshotForConversations(snapshot);
+}
+
+// Resolve strictly by origin. A missing runtime for an explicit origin throws
+// (the caller runs inside refreshAgentGUIConversationListQuery's try/catch and
+// surfaces an error state) rather than cross-routing to another runtime's data.
+function resolveRuntimeForOrigin(sessionOrigin: string): AgentActivityRuntime {
+  const runtime = getAgentActivityRuntimeByOrigin(sessionOrigin);
+  if (!runtime) {
+    throw new Error(
+      `No agent activity runtime registered for origin "${sessionOrigin}".`
+    );
+  }
+  return runtime;
 }
 
 function shouldUseCurrentWorkspaceAgentSnapshotForRefresh(

--- a/packages/agent/gui/contexts/workspace/presentation/renderer/agentGuiConversationList/agentGuiConversationListStore.ts
+++ b/packages/agent/gui/contexts/workspace/presentation/renderer/agentGuiConversationList/agentGuiConversationListStore.ts
@@ -1,9 +1,12 @@
 import { mergeAgentActivityMessages } from "@tutti-os/agent-activity-core";
 import {
   getAgentActivityRuntime,
-  getOptionalAgentActivityRuntime
+  getAgentActivityRuntimeByOrigin
 } from "../../../../../agentActivityRuntime";
-import { getOptionalAgentHostApi } from "../../../../../agentActivityHost";
+import {
+  getAgentHostApiByOrigin,
+  getOptionalAgentHostApi
+} from "../../../../../agentActivityHost";
 import type { AgentGUIProvider } from "../types";
 import { getAgentSessionViewStoreSnapshot } from "../agentSessions/agentSessionViewStore";
 import {
@@ -113,7 +116,13 @@ const readStateLoadByQueryKey = new Map<
   string,
   Promise<WorkspaceAgentReadStateSnapshot>
 >();
-const runtimeRefreshUnsubscribeByWorkspaceId = new Map<string, () => void>();
+// Keyed by `${workspaceId}::${sessionOrigin}` so two runtimes (local/shared)
+// serving the same workspace each get their own subscription instead of the
+// first one winning a workspace-only slot.
+const runtimeRefreshUnsubscribeBySubscriptionKey = new Map<
+  string,
+  () => void
+>();
 const activeConversationIdsByQueryKey = new Map<string, Map<string, string>>();
 const updateStormDiagnosticsByQueryKey = new Map<
   string,
@@ -231,7 +240,10 @@ function getOrCreateQueryState(
   if (!normalized) {
     return null;
   }
-  ensureWorkspaceAgentRuntimeRefresh(normalized.workspaceId);
+  ensureWorkspaceAgentRuntimeRefresh(
+    normalized.workspaceId,
+    normalized.sessionOrigin
+  );
   const queryKey = createAgentGUIConversationListQueryKey(normalized)!;
   const existing = snapshot.statesByQueryKey[queryKey];
   if (existing) {
@@ -390,7 +402,9 @@ async function persistCompletedReadState(
   completed: WorkspaceAgentReadStateBucket
 ): Promise<void> {
   try {
-    await getOptionalAgentHostApi()?.persistence?.writeWorkspaceAgentReadState({
+    await getAgentHostApiByOrigin(
+      queryState.query.sessionOrigin
+    )?.persistence?.writeWorkspaceAgentReadState({
       roomId: queryState.query.workspaceId,
       userId: queryState.query.userId,
       kind: "completed",
@@ -415,13 +429,12 @@ async function loadWorkspaceAgentReadState(
   }
   const promise = (async () => {
     try {
-      const loaded =
-        await getOptionalAgentHostApi()?.persistence?.readWorkspaceAgentReadState(
-          {
-            roomId: queryState.query.workspaceId,
-            userId: queryState.query.userId
-          }
-        );
+      const loaded = await getAgentHostApiByOrigin(
+        queryState.query.sessionOrigin
+      )?.persistence?.readWorkspaceAgentReadState({
+        roomId: queryState.query.workspaceId,
+        userId: queryState.query.userId
+      });
       const normalized = normalizeWorkspaceAgentReadState(loaded);
       const current = readStateByQueryKey.get(queryState.queryKey);
       if (current) {
@@ -990,17 +1003,28 @@ function upsertConversationOverlay(
   );
 }
 
-function workspaceSessionViewDataBySessionId(workspaceId: string): Record<
+function workspaceSessionViewDataBySessionId(
+  workspaceId: string,
+  sessionOrigin: string
+): Record<
   string,
   {
     overlayMessages: WorkspaceAgentActivityMessage[];
   }
 > {
   const allViews = getAgentSessionViewStoreSnapshot().sessionViewsBySessionKey;
-  const prefix = `${workspaceId.trim()}:`;
+  const normalizedWorkspaceId = workspaceId.trim();
+  const normalizedOrigin = sessionOrigin.trim();
   return Object.fromEntries(
     Object.values(allViews)
-      .filter((view) => view.sessionKey.startsWith(prefix))
+      // Scope overlays to this query's runtime: match the view's workspace and
+      // origin by value rather than parsing the sessionKey, so a shared-runtime
+      // view never overlays onto the local list (or vice versa).
+      .filter(
+        (view) =>
+          view.workspaceId === normalizedWorkspaceId &&
+          view.origin === normalizedOrigin
+      )
       .map((view) => [
         view.agentSessionId,
         {
@@ -1196,14 +1220,21 @@ async function loadWorkspaceAgentSnapshotForConversations(input: {
   userId: string;
   workspaceId: string;
 }): Promise<WorkspaceAgentActivitySnapshot> {
-  const snapshot = await getAgentActivityRuntime().load(input.workspaceId);
+  const runtime =
+    getAgentActivityRuntimeByOrigin(input.sessionOrigin) ??
+    getAgentActivityRuntime();
+  const snapshot = await runtime.load(input.workspaceId);
   return workspaceAgentSnapshotForConversations(snapshot);
 }
 
 function getWorkspaceAgentSnapshotForConversations(input: {
+  sessionOrigin: string;
   workspaceId: string;
 }): WorkspaceAgentActivitySnapshot {
-  const snapshot = getAgentActivityRuntime().getSnapshot(input.workspaceId);
+  const runtime =
+    getAgentActivityRuntimeByOrigin(input.sessionOrigin) ??
+    getAgentActivityRuntime();
+  const snapshot = runtime.getSnapshot(input.workspaceId);
   return workspaceAgentSnapshotForConversations(snapshot);
 }
 
@@ -1268,7 +1299,8 @@ async function refreshAgentGUIConversationListQuery(
       dirtySessionIds.add(sessionId);
     }
     const sessionViewDataById = workspaceSessionViewDataBySessionId(
-      state.query.workspaceId
+      state.query.workspaceId,
+      state.query.sessionOrigin
     );
     const sessionMessagesByIdForSummaries = mergeSessionMessagesById(
       workspaceAgentSnapshot.sessionMessagesById ?? {},
@@ -1554,30 +1586,35 @@ function scheduleQueryRefresh(
   refreshTimers.set(queryKey, setTimeout(runRefresh, delayMs));
 }
 
-function ensureWorkspaceAgentRuntimeRefresh(workspaceId: string): void {
+function ensureWorkspaceAgentRuntimeRefresh(
+  workspaceId: string,
+  sessionOrigin: string
+): void {
   const normalizedWorkspaceId = workspaceId.trim();
-  if (
-    !normalizedWorkspaceId ||
-    runtimeRefreshUnsubscribeByWorkspaceId.has(normalizedWorkspaceId)
-  ) {
+  const normalizedOrigin = sessionOrigin.trim();
+  if (!normalizedWorkspaceId || !normalizedOrigin) {
     return;
   }
-  const runtime = getOptionalAgentActivityRuntime();
+  const subscriptionKey = `${normalizedWorkspaceId}::${normalizedOrigin}`;
+  if (runtimeRefreshUnsubscribeBySubscriptionKey.has(subscriptionKey)) {
+    return;
+  }
+  const runtime = getAgentActivityRuntimeByOrigin(normalizedOrigin);
   if (!runtime) {
     return;
   }
   const unsubscribe = runtime.subscribe(normalizedWorkspaceId, () => {
     for (const state of Object.values(snapshot.statesByQueryKey)) {
-      if (state.query.workspaceId !== normalizedWorkspaceId) {
+      if (
+        state.query.workspaceId !== normalizedWorkspaceId ||
+        state.query.sessionOrigin !== normalizedOrigin
+      ) {
         continue;
       }
       scheduleQueryRefresh(state.query, "workspace-agent-update");
     }
   });
-  runtimeRefreshUnsubscribeByWorkspaceId.set(
-    normalizedWorkspaceId,
-    unsubscribe
-  );
+  runtimeRefreshUnsubscribeBySubscriptionKey.set(subscriptionKey, unsubscribe);
 }
 
 export function subscribeAgentGUIConversationListStore(
@@ -2135,10 +2172,10 @@ export function setAgentGUIConversationListConversationsForTests(
 }
 
 export function resetAgentGUIConversationListStoreForTests(): void {
-  for (const unsubscribe of runtimeRefreshUnsubscribeByWorkspaceId.values()) {
+  for (const unsubscribe of runtimeRefreshUnsubscribeBySubscriptionKey.values()) {
     unsubscribe();
   }
-  runtimeRefreshUnsubscribeByWorkspaceId.clear();
+  runtimeRefreshUnsubscribeBySubscriptionKey.clear();
   for (const timer of refreshTimers.values()) {
     clearTimeout(timer);
   }

--- a/packages/agent/gui/contexts/workspace/presentation/renderer/agentSessions/agentSessionViewStore.ts
+++ b/packages/agent/gui/contexts/workspace/presentation/renderer/agentSessions/agentSessionViewStore.ts
@@ -7,22 +7,26 @@ import type {
 } from "../../../../../shared/contracts/dto";
 import {
   isWorkspaceAgentActivityOptimisticMessage,
+  WORKSPACE_AGENT_ACTIVITY_RUNTIME_SESSION_ORIGIN,
   type WorkspaceAgentActivityMessage
 } from "../../../../../shared/workspaceAgentActivityTypes";
 import { mergeWorkspaceAgentMessages } from "../../../../../host/workspaceAgentSessionMessages";
-import { getOptionalAgentActivityRuntime } from "../../../../../agentActivityRuntime";
+import { getAgentActivityRuntimeByOrigin } from "../../../../../agentActivityRuntime";
 
 const STREAM_LINGER_MS = 15000;
 
 export interface AgentSessionViewRef {
   workspaceId: string | null | undefined;
   agentSessionId: string | null | undefined;
+  /** Runtime identity (local vs shared). Absent => default runtime origin. */
+  origin?: string | null;
 }
 
 export interface AgentSessionView extends Required<
   Pick<AgentSessionViewRef, "workspaceId" | "agentSessionId">
 > {
   sessionKey: string;
+  origin: string;
   overlayMessages: WorkspaceAgentActivityMessage[];
   detailMessages: WorkspaceAgentActivityMessage[];
   controlCommands: AgentHostAgentSessionCommand[];
@@ -61,17 +65,20 @@ interface NormalizedAgentSessionViewRef {
   sessionKey: string;
   workspaceId: string;
   agentSessionId: string;
+  origin: string;
 }
 
 interface AgentSessionActivityStreamPayload {
   workspaceId: string | null | undefined;
   agentSessionId: string;
+  origin?: string | null;
 }
 
 type NormalizedAgentSessionActivityStreamPayload = Required<
   Pick<AgentHostSubscribeAgentSessionEventsInput, "agentSessionId">
 > & {
   workspaceId: string;
+  origin: string;
 };
 
 interface AgentSessionActivityStreamEntry {
@@ -103,7 +110,10 @@ const activityStreamEntries = new Map<
   string,
   AgentSessionActivityStreamEntry
 >();
-const runtimeSessionEventUnsubscribeByWorkspaceId = new Map<
+// Keyed by `${workspaceId}::${origin}` so local/shared runtimes each get their
+// own session-event subscription instead of the first one winning a
+// workspace-only slot.
+const runtimeSessionEventUnsubscribeBySubscriptionKey = new Map<
   string,
   () => void
 >();
@@ -179,7 +189,10 @@ export function watchAgentSession(
     watcherCount: current.watcherCount + 1,
     error: null
   }));
-  ensureWorkspaceSessionEventListener(normalizedPayload.workspaceId);
+  ensureWorkspaceSessionEventListener(
+    normalizedPayload.workspaceId,
+    normalizedPayload.origin
+  );
   ensureActivityStreamUpstream(entry);
   return () => {
     const currentEntry = activityStreamEntries.get(key);
@@ -498,10 +511,10 @@ export function deleteAgentSessionView(ref: AgentSessionViewRef): void {
 }
 
 export function resetAgentSessionViewStoreForTests(): void {
-  for (const unsubscribe of runtimeSessionEventUnsubscribeByWorkspaceId.values()) {
+  for (const unsubscribe of runtimeSessionEventUnsubscribeBySubscriptionKey.values()) {
     unsubscribe();
   }
-  runtimeSessionEventUnsubscribeByWorkspaceId.clear();
+  runtimeSessionEventUnsubscribeBySubscriptionKey.clear();
   for (const entry of activityStreamEntries.values()) {
     clearPendingMessageBatch(entry);
     clearEntryLingerTimer(entry);
@@ -558,15 +571,20 @@ function emitAgentSessionViewStoreChange(): void {
   }
 }
 
-function ensureWorkspaceSessionEventListener(workspaceId: string): void {
+function ensureWorkspaceSessionEventListener(
+  workspaceId: string,
+  origin: string
+): void {
   const normalizedWorkspaceId = workspaceId.trim();
-  if (!normalizedWorkspaceId) {
+  const normalizedOrigin = origin.trim();
+  if (!normalizedWorkspaceId || !normalizedOrigin) {
     return;
   }
-  if (runtimeSessionEventUnsubscribeByWorkspaceId.has(normalizedWorkspaceId)) {
+  const subscriptionKey = `${normalizedWorkspaceId}::${normalizedOrigin}`;
+  if (runtimeSessionEventUnsubscribeBySubscriptionKey.has(subscriptionKey)) {
     return;
   }
-  const runtime = getOptionalAgentActivityRuntime();
+  const runtime = getAgentActivityRuntimeByOrigin(normalizedOrigin);
   if (!runtime) {
     return;
   }
@@ -576,7 +594,7 @@ function ensureWorkspaceSessionEventListener(workspaceId: string): void {
       if (!isAgentSessionActivityStreamEvent(event)) {
         return;
       }
-      const entries = findEntriesForEvent(event);
+      const entries = findEntriesForEvent(event, normalizedOrigin);
       if (entries.length === 0) {
         return;
       }
@@ -585,8 +603,8 @@ function ensureWorkspaceSessionEventListener(workspaceId: string): void {
       }
     }
   );
-  runtimeSessionEventUnsubscribeByWorkspaceId.set(
-    normalizedWorkspaceId,
+  runtimeSessionEventUnsubscribeBySubscriptionKey.set(
+    subscriptionKey,
     unsubscribe
   );
 }
@@ -597,7 +615,7 @@ function ensureActivityStreamUpstream(
   if (entry.releaseRuntimeEvents || entry.retainPromise) {
     return;
   }
-  const runtime = getOptionalAgentActivityRuntime();
+  const runtime = getAgentActivityRuntimeByOrigin(entry.payload.origin);
   if (runtime) {
     try {
       const ensureSessionSynchronized =
@@ -767,6 +785,10 @@ function upsertCoalescedMessageUpdate(
   events.push(event);
 }
 
+function normalizeRuntimeOrigin(origin: string | null | undefined): string {
+  return origin?.trim() || WORKSPACE_AGENT_ACTIVITY_RUNTIME_SESSION_ORIGIN;
+}
+
 function normalizeSubscribePayload(
   payload: AgentSessionActivityStreamPayload
 ): NormalizedAgentSessionActivityStreamPayload | null {
@@ -777,7 +799,8 @@ function normalizeSubscribePayload(
   }
   return {
     workspaceId,
-    agentSessionId
+    agentSessionId,
+    origin: normalizeRuntimeOrigin(payload.origin)
   };
 }
 
@@ -789,21 +812,27 @@ function normalizeAgentSessionViewRef(
   if (!workspaceId || !agentSessionId) {
     return null;
   }
+  const origin = normalizeRuntimeOrigin(ref.origin);
   return {
     workspaceId,
     agentSessionId,
-    sessionKey: activityStreamKey({ workspaceId, agentSessionId })
+    origin,
+    sessionKey: activityStreamKey({ workspaceId, agentSessionId, origin })
   };
 }
 
 function activityStreamKey(
-  payload: Pick<NormalizedAgentSessionViewRef, "workspaceId" | "agentSessionId">
+  payload: Pick<
+    NormalizedAgentSessionViewRef,
+    "workspaceId" | "agentSessionId" | "origin"
+  >
 ): string {
-  return `${payload.workspaceId}:${payload.agentSessionId}`;
+  return `${payload.origin}::${payload.workspaceId}::${payload.agentSessionId}`;
 }
 
 function findEntriesForEvent(
-  event: AgentHostAgentActivityStreamEvent
+  event: AgentHostAgentActivityStreamEvent,
+  origin: string
 ): AgentSessionActivityStreamEntry[] {
   const agentSessionId = event.data.agentSessionId?.trim();
   if (!agentSessionId) {
@@ -814,13 +843,22 @@ function findEntriesForEvent(
       ? event.data.workspaceId.trim()
       : null;
   if (eventWorkspaceId) {
+    // Events are delivered by a per-origin runtime subscription, so scope the
+    // lookup to that origin — never let one runtime's event drive the other's
+    // session view even if the agentSessionId happens to match.
     const exactEntry = activityStreamEntries.get(
-      `${eventWorkspaceId}:${agentSessionId}`
+      activityStreamKey({
+        workspaceId: eventWorkspaceId,
+        agentSessionId,
+        origin
+      })
     );
     return exactEntry ? [exactEntry] : [];
   }
   return [...activityStreamEntries.values()].filter(
-    (entry) => entry.payload.agentSessionId === agentSessionId
+    (entry) =>
+      entry.payload.agentSessionId === agentSessionId &&
+      entry.payload.origin === origin
   );
 }
 
@@ -891,7 +929,7 @@ function reportMessageBatchDiagnostics(
   if (batch.incomingCount <= 1 && batch.events.length <= 1) {
     return;
   }
-  const runtime = getOptionalAgentActivityRuntime();
+  const runtime = getAgentActivityRuntimeByOrigin(entry.payload.origin);
   try {
     void runtime?.reportDiagnostic?.({
       details: {
@@ -933,6 +971,7 @@ function createEmptySessionView(
 ): AgentSessionView {
   return {
     sessionKey: ref.sessionKey,
+    origin: ref.origin,
     workspaceId: ref.workspaceId,
     agentSessionId: ref.agentSessionId,
     overlayMessages: [],

--- a/packages/agent/gui/contexts/workspace/presentation/renderer/agentSessions/agentSessionViewStore.ts
+++ b/packages/agent/gui/contexts/workspace/presentation/renderer/agentSessions/agentSessionViewStore.ts
@@ -45,6 +45,8 @@ export interface AgentSessionView extends Required<
 export interface AgentSessionOverlayMessageHydrationEntry extends Required<
   Pick<AgentSessionViewRef, "workspaceId" | "agentSessionId">
 > {
+  /** Runtime identity; absent => default runtime origin. */
+  origin?: string | null;
   overlayMessages: readonly WorkspaceAgentActivityMessage[];
 }
 

--- a/packages/agent/gui/contexts/workspace/presentation/renderer/agentSessions/useAgentSessionView.ts
+++ b/packages/agent/gui/contexts/workspace/presentation/renderer/agentSessions/useAgentSessionView.ts
@@ -16,6 +16,7 @@ export function useAgentSessionView(ref: AgentSessionViewRef) {
 export function useWatchAgentSession(input: {
   workspaceId: string;
   agentSessionId: string | null | undefined;
+  origin?: string;
   enabled?: boolean;
   onEvents?: (events: readonly AgentHostAgentActivityStreamEvent[]) => void;
   onSubscribe?: () => void;
@@ -40,7 +41,7 @@ export function useWatchAgentSession(input: {
     }
     onSubscribeRef.current?.();
     const unsubscribe = watchAgentSession(
-      { workspaceId, agentSessionId },
+      { workspaceId, agentSessionId, origin: input.origin },
       {
         ...(hasBatchEventListener
           ? {
@@ -61,6 +62,7 @@ export function useWatchAgentSession(input: {
     hasBatchEventListener,
     input.agentSessionId,
     input.enabled,
+    input.origin,
     input.workspaceId
   ]);
 }
@@ -68,6 +70,7 @@ export function useWatchAgentSession(input: {
 export function useWatchAgentSessions(input: {
   workspaceId: string;
   agentSessionIds: readonly string[];
+  origin?: string;
   enabled?: boolean;
   onEvents?: (events: readonly AgentHostAgentActivityStreamEvent[]) => void;
 }) {
@@ -94,7 +97,7 @@ export function useWatchAgentSessions(input: {
     }
     const unsubscribes = uniqueAgentSessionIds.map((agentSessionId) =>
       watchAgentSession(
-        { workspaceId, agentSessionId },
+        { workspaceId, agentSessionId, origin: input.origin },
         {
           ...(hasBatchEventListener
             ? {
@@ -117,6 +120,7 @@ export function useWatchAgentSessions(input: {
     agentSessionIdsKey,
     hasBatchEventListener,
     input.enabled,
+    input.origin,
     input.workspaceId
   ]);
 }


### PR DESCRIPTION
## 背景 / Problem

同一 workspace(room)内需要并存两个 `AgentActivityRuntime` 实例(local + shared/cloud)。原架构下会话列表与 transcript store 都按 `workspaceId` 建键、并通过**模块级全局单例**解析 runtime(后挂载覆盖前者),导致:

- 同一 room 开 local + shared 两个 AgentGUI 窗口 → query key 相同 → **共用同一份 Chats**;
- 两个 Provider 互抢 `currentAgentActivityRuntime` 全局槽 → store 反复 refresh → **`Maximum update depth exceeded`(白屏)**。

## 方案 / Approach

让 **runtime 自带 `origin`**,身份(query key)、数据解析、订阅、已读态持久化全部从它派生。不是「query key 加维度」和「runtime 解析去全局化」二选一 —— 两者是同一修复的两半,一起做。

- **`agentActivityRuntime`**:`AgentActivityRuntime` 加可选 `origin`;新增按 origin 索引的 registry + `getAgentActivityRuntimeByOrigin`。**无 origin 的 runtime 默认注册到本地 origin 常量并自注册**,local 侧零 host 改动;shared runtime 显式设一个不同的 `origin` 即可接入。
- **控制器**:会话列表 query 的 `sessionOrigin` 与所有 session-view ref 改从注入 runtime 的 origin 派生(去掉硬编码常量)。
- **会话列表 store**:`load`/`getSnapshot`/`subscribe` 按 origin 解析;刷新订阅键升为 `(workspaceId, origin)`;overlay join 按 `(workspaceId, origin)` 收敛。
- **transcript store**:origin 贯穿 ref/payload/sessionKey;session-event 监听与 upstream 保活按 origin 解析;订阅键 `(workspaceId, origin)`。
- **已读态持久化**:host API 也做同款 origin registry(`getAgentHostApiByOrigin`)。local 窗口落 local host、shared/cloud 窗口落它自己那份 —— 各自 `(roomId, userId)` 当 key,**记录无需 origin 维度,不动 host 契约 / daemon**。

全程 **back-compat**:无 origin 的老单 runtime 落默认 origin,query key 与行为不变。

## 验收 / Acceptance

同一 room 同开 local + shared 两个 AgentGUI 窗口:
- 两个 Chats 列表互不串(local 只显本地会话,shared 只显 room 共享会话);
- 不再触发 `Maximum update depth exceeded`。

## 测试 / Verification

- `@tutti-os/agent-gui` typecheck ✅、`@tutti-os/desktop` typecheck ✅
- 全量 **2051** 测试通过,含 3 个新增 origin 隔离用例:
  - runtime 双 origin 独立解析 + 无 origin 落默认 + 卸载后从 registry 移除;
  - host-API 按 origin 分流(local-origin→local persistence、cloud-origin→cloud persistence);
  - query key 按 `sessionOrigin` 拆分。

## 下游接入 / Follow-up (downstream)

构造两个 runtime 时给各自设 `origin`(local 可不设=默认,cloud 设一个不同值,如 `WORKSPACE_AGENT_SESSION_ORIGIN_SHARED`),并在各自的 `AgentActivityHostProvider` 注入对应 host API —— 身份、数据解析、订阅、已读态会全部自动按 origin 分流。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for multiple concurrent agent activities by stable origin, enabling distinct session views and safer routing of updates.
  * Conversation lists and workspace session tracking are now scoped by runtime/session origin.
* **Bug Fixes**
  * Prevented cross-routing between local and shared activity so activity streams and persisted read-state stay in the correct workspace/session context.
  * Improved origin-aware watch/unsubscribe behavior to avoid stale or mixed updates after unmounts/re-renders.
* **Tests**
  * Added coverage for origin-based runtime/host resolution and conversation-list query key isolation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->