### PR TITLE
refactor(agentstatus): remove dead codex installer wrappers

### DIFF
--- a/services/tuttid/service/agentstatus/codex_platform.go
+++ b/services/tuttid/service/agentstatus/codex_platform.go
@@ -66,16 +66,6 @@ func codexPlatformTargetTriple(goos, goarch string) (string, bool) {
 	return "", false
 }
 
-// codexPlatformBinaryPath returns the absolute path to the platform-specific
-// codex binary inside an installed @openai/codex package directory.
-func codexPlatformBinaryPath(codexPkgDir, goos, goarch string) (string, bool) {
-	paths := codexPlatformBinaryCandidatePaths(codexPkgDir, goos, goarch)
-	if len(paths) == 0 {
-		return "", false
-	}
-	return paths[0], true
-}
-
 func codexPlatformBinaryCandidatePaths(codexPkgDir, goos, goarch string) []string {
 	binName := "codex"
 	if goos == "windows" {
@@ -118,19 +108,6 @@ func codexPackageDirForBinary(binaryPath string) string {
 	return filepath.Dir(packageJSONPath)
 }
 
-// codexNPMPrefixFromPackageDir derives the npm global prefix that owns an
-// installed @openai/codex package directory, so an incomplete install can be
-// repaired in place instead of duplicated in a lower-priority directory.
-//
-// npm lays out global packages as <prefix>/lib/node_modules/@openai/codex on
-// Unix and <prefix>/node_modules/@openai/codex on Windows. The prefix is the
-// directory above the node_modules dir, skipping the intermediate "lib" on Unix.
-// Returns "" when pkgDir does not match that layout (e.g. a pnpm content store
-// or a standalone binary), in which case the caller falls back to ~/.local.
-func codexNPMPrefixFromPackageDir(pkgDir string) string {
-	return npmGlobalPrefixFromPackageDir(pkgDir)
-}
-
 func npmGlobalPrefixFromPackageDir(pkgDir string) string {
 	pkgDir = strings.TrimSpace(pkgDir)
 	if pkgDir == "" {
@@ -155,27 +132,6 @@ func npmGlobalPrefixFromPackageDir(pkgDir string) string {
 		return ""
 	}
 	return parent
-}
-
-// codexRepairInstallPrefix returns the npm global prefix owning the existing
-// (incomplete or outdated) @openai/codex installation, so it can be repaired in
-// place. ok is false when there is no existing install, its package directory
-// cannot be located, or it does not match npm's global package layout — in all
-// those cases the caller installs a fresh copy in ~/.local instead.
-func codexRepairInstallPrefix(existingCLIPath string) (string, bool) {
-	existingCLIPath = strings.TrimSpace(existingCLIPath)
-	if existingCLIPath == "" {
-		return "", false
-	}
-	pkgDir := codexPackageDirForBinary(existingCLIPath)
-	if pkgDir == "" {
-		return "", false
-	}
-	prefix := codexNPMPrefixFromPackageDir(pkgDir)
-	if prefix == "" {
-		return "", false
-	}
-	return prefix, true
 }
 
 // codexPlatformPackageMissingPath returns the platform-specific binary path we

--- a/services/tuttid/service/agentstatus/codex_platform_test.go
+++ b/services/tuttid/service/agentstatus/codex_platform_test.go
@@ -3,6 +3,7 @@ package agentstatus
 import (
 	"os"
 	"path/filepath"
+	"runtime"
 	"testing"
 )
 
@@ -28,21 +29,30 @@ func TestCodexNpmPlatformDir(t *testing.T) {
 	}
 }
 
-func TestCodexPlatformBinaryPath(t *testing.T) {
+func TestCodexPlatformBinaryCandidatePaths(t *testing.T) {
 	pkg := "/home/u/.npm/lib/node_modules/@openai/codex"
-	got, ok := codexPlatformBinaryPath(pkg, "darwin", "arm64")
+	got := codexPlatformBinaryCandidatePaths(pkg, "darwin", "arm64")
 	want := filepath.Join(pkg, "node_modules", "@openai", "codex-darwin-arm64", "vendor", "aarch64-apple-darwin", "bin", "codex")
-	if !ok || got != want {
-		t.Fatalf("codexPlatformBinaryPath darwin/arm64 = (%q,%v), want (%q,true)", got, ok, want)
+	if len(got) != 1 || got[0] != want {
+		t.Fatalf("codexPlatformBinaryCandidatePaths darwin/arm64 = %#v, want [%q]", got, want)
 	}
-	winGot, ok := codexPlatformBinaryPath(pkg, "windows", "amd64")
+	winGot := codexPlatformBinaryCandidatePaths(pkg, "windows", "amd64")
 	winWant := filepath.Join(pkg, "node_modules", "@openai", "codex-win32-x64", "vendor", "x86_64-pc-windows-msvc", "bin", "codex.exe")
-	if !ok || winGot != winWant {
-		t.Fatalf("codexPlatformBinaryPath windows = (%q,%v), want (%q,true)", winGot, ok, winWant)
+	if len(winGot) != 1 || winGot[0] != winWant {
+		t.Fatalf("codexPlatformBinaryCandidatePaths windows = %#v, want [%q]", winGot, winWant)
 	}
-	if _, ok := codexPlatformBinaryPath(pkg, "plan9", "mips"); ok {
-		t.Fatalf("codexPlatformBinaryPath unsupported platform should be ok=false")
+	if got := codexPlatformBinaryCandidatePaths(pkg, "plan9", "mips"); len(got) != 0 {
+		t.Fatalf("codexPlatformBinaryCandidatePaths unsupported platform = %#v, want empty", got)
 	}
+}
+
+func requireTestCodexPlatformBinaryPath(t *testing.T, pkgDir string) string {
+	t.Helper()
+	paths := codexPlatformBinaryCandidatePaths(pkgDir, runtime.GOOS, runtime.GOARCH)
+	if len(paths) == 0 {
+		t.Skipf("codex platform package unavailable for %s/%s", runtime.GOOS, runtime.GOARCH)
+	}
+	return paths[0]
 }
 
 func TestServiceCodexPlatformBinaryComplete(t *testing.T) {

--- a/services/tuttid/service/agentstatus/installer_codex_cli_test.go
+++ b/services/tuttid/service/agentstatus/installer_codex_cli_test.go
@@ -45,8 +45,8 @@ func TestCodexNPMPrefixFromPackageDir(t *testing.T) {
 		"/node_modules/@openai/codex":          "",
 	}
 	for in, want := range cases {
-		if got := codexNPMPrefixFromPackageDir(in); got != want {
-			t.Errorf("codexNPMPrefixFromPackageDir(%q) = %q, want %q", in, got, want)
+		if got := npmGlobalPrefixFromPackageDir(in); got != want {
+			t.Errorf("npmGlobalPrefixFromPackageDir(%q) = %q, want %q", in, got, want)
 		}
 	}
 }
@@ -80,7 +80,7 @@ func TestRunCodexCLILatestInstallerRepairsInPlace(t *testing.T) {
 	service.IsExecutableFile = isTestExecutableUnderHome(home)
 
 	existingCLIPath := filepath.Join(binDir, "codex")
-	wantPrefix, wantPrefixOK := codexRepairInstallPrefix(existingCLIPath)
+	wantPrefix, wantPrefixOK := managedNPMRepairInstallPrefix(existingCLIPath, "@openai/codex")
 	if !wantPrefixOK {
 		t.Fatalf("expected repair prefix to be derivable for %s", existingCLIPath)
 	}
@@ -122,7 +122,7 @@ func TestRunCodexCLILatestInstallerFallsBackToLocalBin(t *testing.T) {
 	service.Environ = func() []string { return []string{"PATH=" + binDir} }
 	service.IsExecutableFile = isTestExecutableUnderHome(home)
 
-	if _, ok := codexRepairInstallPrefix(standalone); ok {
+	if _, ok := managedNPMRepairInstallPrefix(standalone, "@openai/codex"); ok {
 		t.Fatalf("standalone codex should not yield a repair prefix")
 	}
 

--- a/services/tuttid/service/agentstatus/service_test.go
+++ b/services/tuttid/service/agentstatus/service_test.go
@@ -455,10 +455,7 @@ func TestServiceListReportsCodexChecksVersionAndLastError(t *testing.T) {
 	if err := os.Symlink(codexPath, visiblePath); err != nil {
 		t.Fatalf("symlink codex: %v", err)
 	}
-	platformPath, ok := codexPlatformBinaryPath(pkgDir, runtime.GOOS, runtime.GOARCH)
-	if !ok {
-		t.Skipf("codex platform package unavailable for %s/%s", runtime.GOOS, runtime.GOARCH)
-	}
+	platformPath := requireTestCodexPlatformBinaryPath(t, pkgDir)
 	writeExecutable(t, platformPath, "#!/bin/sh\nexit 0\n")
 
 	service := probeTestService(home)
@@ -504,10 +501,7 @@ func TestServiceListRunsCodexLauncherWithManagedNodePath(t *testing.T) {
 	if err := os.Symlink(codexPath, filepath.Join(binDir, "codex")); err != nil {
 		t.Fatalf("symlink codex: %v", err)
 	}
-	platformPath, ok := codexPlatformBinaryPath(pkgDir, runtime.GOOS, runtime.GOARCH)
-	if !ok {
-		t.Skipf("codex platform package unavailable for %s/%s", runtime.GOOS, runtime.GOARCH)
-	}
+	platformPath := requireTestCodexPlatformBinaryPath(t, pkgDir)
 	writeExecutable(t, platformPath, "#!/bin/sh\nexit 0\n")
 
 	runtimeRoot := fakeManagedRuntimeRoot(t)
@@ -589,10 +583,7 @@ func TestServiceRunActionReinstallsCodexWhenPlatformPackageIncomplete(t *testing
 	if err := os.Symlink(codexPath, filepath.Join(binDir, "codex")); err != nil {
 		t.Fatalf("symlink codex: %v", err)
 	}
-	platformBinary, ok := codexPlatformBinaryPath(pkgDir, runtime.GOOS, runtime.GOARCH)
-	if !ok {
-		t.Skipf("codex platform package is unsupported for %s/%s", runtime.GOOS, runtime.GOARCH)
-	}
+	platformBinary := requireTestCodexPlatformBinaryPath(t, pkgDir)
 
 	service := probeTestService(home)
 	service.Environ = func() []string {
@@ -606,7 +597,7 @@ func TestServiceRunActionReinstallsCodexWhenPlatformPackageIncomplete(t *testing
 	// must install at the npm global prefix that owns it — not duplicate the
 	// package in ~/.local. Derive the expected prefix the same way production does
 	// (via EvalSymlinks, so it matches on macOS where /var -> /private/var).
-	wantPrefix, wantPrefixOK := codexRepairInstallPrefix(filepath.Join(binDir, "codex"))
+	wantPrefix, wantPrefixOK := managedNPMRepairInstallPrefix(filepath.Join(binDir, "codex"), "@openai/codex")
 	if !wantPrefixOK {
 		t.Fatalf("expected repair prefix to be derivable for %s", filepath.Join(binDir, "codex"))
 	}
@@ -660,10 +651,7 @@ func TestServiceRunActionRepairsCodexWhenAppServerLaunchFails(t *testing.T) {
 	if err := os.Symlink(codexPath, filepath.Join(binDir, "codex")); err != nil {
 		t.Fatalf("symlink codex: %v", err)
 	}
-	platformBinary, ok := codexPlatformBinaryPath(pkgDir, runtime.GOOS, runtime.GOARCH)
-	if !ok {
-		t.Skipf("codex platform package is unsupported for %s/%s", runtime.GOOS, runtime.GOARCH)
-	}
+	platformBinary := requireTestCodexPlatformBinaryPath(t, pkgDir)
 	writeExecutable(t, platformBinary, "#!/bin/sh\nexit 0\n")
 
 	service := probeTestService(home)
@@ -1437,7 +1425,7 @@ func TestServiceRunCodexInstallerReportsManagedNPMActiveAction(t *testing.T) {
 		writeExecutable(t, codexPath, "#!/bin/sh\nif [ \"$1\" = \"--version\" ]; then echo 'codex "+MinSupportedCodexVersion+"'; exit 0; fi\nsleep 5\n")
 		// Platform support was already checked on the test goroutine below, so ok
 		// is true here.
-		platformPath, _ := codexPlatformBinaryPath(pkgDir, runtime.GOOS, runtime.GOARCH)
+		platformPath := requireTestCodexPlatformBinaryPath(t, pkgDir)
 		writeExecutable(t, platformPath, "#!/bin/sh\nexit 0\n")
 		if err := os.Symlink(codexPath, filepath.Join(binDir, "codex-test")); err != nil {
 			t.Errorf("symlink codex: %v", err)
@@ -1445,9 +1433,7 @@ func TestServiceRunCodexInstallerReportsManagedNPMActiveAction(t *testing.T) {
 		}
 		return InstallCommandResult{ExitCode: 0, Stdout: "installed"}, nil
 	}
-	if _, ok := codexPlatformBinaryPath(pkgDir, runtime.GOOS, runtime.GOARCH); !ok {
-		t.Skipf("codex platform package unavailable for %s/%s", runtime.GOOS, runtime.GOARCH)
-	}
+	_ = requireTestCodexPlatformBinaryPath(t, pkgDir)
 	go func() {
 		result, err := service.RunAction(context.Background(), RunActionInput{
 			Provider: "codex",


### PR DESCRIPTION
## Summary
- remove three dead codex-specific installer/platform convenience wrappers from `services/tuttid/service/agentstatus`
- update tests to use the active generic managed npm and candidate-path helpers directly

## Why this is safe
These helpers came from the early Codex-only installer / platform-package repair path. After the agentstatus flow moved onto the generic managed npm helpers, production code stopped calling them and only tests still referenced the wrappers.

Reverification for this batch:
- `deadcode` reported `codexPlatformBinaryPath`, `codexNPMPrefixFromPackageDir`, and `codexRepairInstallPrefix` as unreachable
- repo-wide search and local `tsh` cross-repo search only found test references plus their definitions
- current production paths already use `codexPlatformBinaryCandidatePaths`, `npmGlobalPrefixFromPackageDir`, and `managedNPMRepairInstallPrefix`

## Validation
- `cd services/tuttid && go test ./service/agentstatus`
- `pnpm check:changed -- --tail-lines 80`
- `pnpm check:full`