### PR TITLE
refactor(cli): remove dead convenience aliases

### DIFF
--- a/apps/cli/internal/app/run.go
+++ b/apps/cli/internal/app/run.go
@@ -20,10 +20,6 @@ type options struct {
 	json bool
 }
 
-func Run(ctx context.Context, args []string, stdout io.Writer, stderr io.Writer) int {
-	return RunWithProgram(ctx, "tutti", args, stdout, stderr)
-}
-
 func RunWithProgram(ctx context.Context, program string, args []string, stdout io.Writer, stderr io.Writer) int {
 	commandName := displayCommandName(program)
 	opts, rest, err := parseOptions(args)

--- a/apps/cli/internal/app/run_test.go
+++ b/apps/cli/internal/app/run_test.go
@@ -13,10 +13,15 @@ import (
 	"github.com/tutti-os/tutti/apps/cli/internal/daemon"
 )
 
+func runDefaultProgram(t *testing.T, args []string, stdout *bytes.Buffer, stderr *bytes.Buffer) int {
+	t.Helper()
+	return RunWithProgram(t.Context(), "tutti", args, stdout, stderr)
+}
+
 func TestRunHelpUsesDefaultCommandName(t *testing.T) {
 	var stdout bytes.Buffer
 	var stderr bytes.Buffer
-	if code := Run(t.Context(), []string{}, &stdout, &stderr); code != 0 {
+	if code := runDefaultProgram(t, []string{}, &stdout, &stderr); code != 0 {
 		t.Fatalf("code = %d, stderr = %s", code, stderr.String())
 	}
 	if !strings.Contains(stdout.String(), "Usage: tutti [--json] <command>") {
@@ -135,7 +140,7 @@ func TestRunHelpIncludesIntegrationCapabilitiesInsideAppRuntime(t *testing.T) {
 
 	var stdout bytes.Buffer
 	var stderr bytes.Buffer
-	if code := Run(t.Context(), []string{"--help"}, &stdout, &stderr); code != 0 {
+	if code := runDefaultProgram(t, []string{"--help"}, &stdout, &stderr); code != 0 {
 		t.Fatalf("code = %d, stderr = %s", code, stderr.String())
 	}
 	if !sawCapabilitiesRequest {
@@ -168,7 +173,7 @@ func TestRunHelpDoesNotIncludeIntegrationCapabilitiesWithoutAppCLIContract(t *te
 
 	var stdout bytes.Buffer
 	var stderr bytes.Buffer
-	if code := Run(t.Context(), []string{"--help"}, &stdout, &stderr); code != 0 {
+	if code := runDefaultProgram(t, []string{"--help"}, &stdout, &stderr); code != 0 {
 		t.Fatalf("code = %d, stderr = %s", code, stderr.String())
 	}
 }
@@ -190,7 +195,7 @@ func TestRunStatusJSON(t *testing.T) {
 
 	var stdout bytes.Buffer
 	var stderr bytes.Buffer
-	if code := Run(t.Context(), []string{"status", "--json"}, &stdout, &stderr); code != 0 {
+	if code := runDefaultProgram(t, []string{"status", "--json"}, &stdout, &stderr); code != 0 {
 		t.Fatalf("code = %d, stderr = %s", code, stderr.String())
 	}
 
@@ -216,7 +221,7 @@ func TestRunStatusAuthFailure(t *testing.T) {
 
 	var stdout bytes.Buffer
 	var stderr bytes.Buffer
-	if code := Run(t.Context(), []string{"status"}, &stdout, &stderr); code != 1 {
+	if code := runDefaultProgram(t, []string{"status"}, &stdout, &stderr); code != 1 {
 		t.Fatalf("code = %d, want 1", code)
 	}
 	if !strings.Contains(stderr.String(), "daemon authentication failed") {
@@ -242,7 +247,7 @@ func TestRunDynamicCommandRendersTable(t *testing.T) {
 
 	var stdout bytes.Buffer
 	var stderr bytes.Buffer
-	if code := Run(t.Context(), []string{"issue", "list", "--status", "open"}, &stdout, &stderr); code != 0 {
+	if code := runDefaultProgram(t, []string{"issue", "list", "--status", "open"}, &stdout, &stderr); code != 0 {
 		t.Fatalf("code = %d, stderr = %s", code, stderr.String())
 	}
 	if !strings.Contains(stdout.String(), "ISS-1") || !strings.Contains(stdout.String(), "Fix startup") {
@@ -268,7 +273,7 @@ func TestRunDynamicCommandRendersJSONRows(t *testing.T) {
 
 	var stdout bytes.Buffer
 	var stderr bytes.Buffer
-	if code := Run(t.Context(), []string{"--json", "issue", "list"}, &stdout, &stderr); code != 0 {
+	if code := runDefaultProgram(t, []string{"--json", "issue", "list"}, &stdout, &stderr); code != 0 {
 		t.Fatalf("code = %d, stderr = %s", code, stderr.String())
 	}
 	if !strings.Contains(stdout.String(), `"id": "ISS-1"`) {
@@ -298,7 +303,7 @@ func TestRunDynamicCommandMatchesMultiSegmentPath(t *testing.T) {
 
 	var stdout bytes.Buffer
 	var stderr bytes.Buffer
-	code := Run(t.Context(), []string{"--json", "issue", "task", "run", "complete", "--issue-id", "ISS-1", "--task-id=TASK-1", "--run-id", "RUN-1", "--status", "completed"}, &stdout, &stderr)
+	code := runDefaultProgram(t, []string{"--json", "issue", "task", "run", "complete", "--issue-id", "ISS-1", "--task-id=TASK-1", "--run-id", "RUN-1", "--status", "completed"}, &stdout, &stderr)
 	if code != 0 {
 		t.Fatalf("code = %d, stderr = %s", code, stderr.String())
 	}
@@ -333,7 +338,7 @@ func TestRunDynamicCommandAggregatesRepeatedFlags(t *testing.T) {
 
 	var stdout bytes.Buffer
 	var stderr bytes.Buffer
-	code := Run(t.Context(), []string{"app", "open", "--app-id", "docs", "--route", "/files", "--param", "path=/tmp/a", "--param", "mode=preview"}, &stdout, &stderr)
+	code := runDefaultProgram(t, []string{"app", "open", "--app-id", "docs", "--route", "/files", "--param", "path=/tmp/a", "--param", "mode=preview"}, &stdout, &stderr)
 	if code != 0 {
 		t.Fatalf("code = %d, stderr = %s", code, stderr.String())
 	}
@@ -366,7 +371,7 @@ func TestRunDynamicAgentSendAggregatesRepeatedImageFlags(t *testing.T) {
 
 	var stdout bytes.Buffer
 	var stderr bytes.Buffer
-	code := Run(t.Context(), []string{"agent", "send", "SESSION-1", "--prompt", "look", "--image", "/tmp/a.png", "--image", "/tmp/b.jpg"}, &stdout, &stderr)
+	code := runDefaultProgram(t, []string{"agent", "send", "SESSION-1", "--prompt", "look", "--image", "/tmp/a.png", "--image", "/tmp/b.jpg"}, &stdout, &stderr)
 	if code != 0 {
 		t.Fatalf("code = %d, stderr = %s", code, stderr.String())
 	}
@@ -402,7 +407,7 @@ func TestRunDynamicAgentSendSplitsPositionalPromptBeforeImageFlags(t *testing.T)
 
 	var stdout bytes.Buffer
 	var stderr bytes.Buffer
-	code := Run(t.Context(), []string{"agent", "send", "SESSION-1", "look", "here", "--image", "/tmp/a.png"}, &stdout, &stderr)
+	code := runDefaultProgram(t, []string{"agent", "send", "SESSION-1", "look", "here", "--image", "/tmp/a.png"}, &stdout, &stderr)
 	if code != 0 {
 		t.Fatalf("code = %d, stderr = %s", code, stderr.String())
 	}
@@ -438,7 +443,7 @@ func TestRunDynamicAgentSendSplitsPositionalPromptBeforeGuidanceFlag(t *testing.
 
 	var stdout bytes.Buffer
 	var stderr bytes.Buffer
-	code := Run(t.Context(), []string{"agent", "send", "SESSION-1", "guide", "current", "turn", "--guidance"}, &stdout, &stderr)
+	code := runDefaultProgram(t, []string{"agent", "send", "SESSION-1", "guide", "current", "turn", "--guidance"}, &stdout, &stderr)
 	if code != 0 {
 		t.Fatalf("code = %d, stderr = %s", code, stderr.String())
 	}
@@ -470,7 +475,7 @@ func TestRunDynamicAgentSendKeepsFlagLikeTokensInPositionalPrompt(t *testing.T) 
 
 	var stdout bytes.Buffer
 	var stderr bytes.Buffer
-	code := Run(t.Context(), []string{"agent", "send", "SESSION-1", "please", "run", "--help"}, &stdout, &stderr)
+	code := runDefaultProgram(t, []string{"agent", "send", "SESSION-1", "please", "run", "--help"}, &stdout, &stderr)
 	if code != 0 {
 		t.Fatalf("code = %d, stderr = %s", code, stderr.String())
 	}
@@ -500,7 +505,7 @@ func TestRunDynamicCommandHelpRendersInputSchema(t *testing.T) {
 
 	var stdout bytes.Buffer
 	var stderr bytes.Buffer
-	code := Run(t.Context(), []string{"issue", "task", "create", "--help"}, &stdout, &stderr)
+	code := runDefaultProgram(t, []string{"issue", "task", "create", "--help"}, &stdout, &stderr)
 	if code != 0 {
 		t.Fatalf("code = %d, stderr = %s", code, stderr.String())
 	}
@@ -555,7 +560,7 @@ func TestRunDynamicScopeHelpListsCommandsAndDocumentation(t *testing.T) {
 
 	var stdout bytes.Buffer
 	var stderr bytes.Buffer
-	code := Run(t.Context(), []string{"automation", "--help"}, &stdout, &stderr)
+	code := runDefaultProgram(t, []string{"automation", "--help"}, &stdout, &stderr)
 	if code != 0 {
 		t.Fatalf("code = %d, stderr = %s", code, stderr.String())
 	}
@@ -607,7 +612,7 @@ func TestRunDynamicScopeHelpShowsRequiredFlagsForBuiltinCommands(t *testing.T) {
 
 	var stdout bytes.Buffer
 	var stderr bytes.Buffer
-	code := Run(t.Context(), []string{"issue", "--help"}, &stdout, &stderr)
+	code := runDefaultProgram(t, []string{"issue", "--help"}, &stdout, &stderr)
 	if code != 0 {
 		t.Fatalf("code = %d, stderr = %s", code, stderr.String())
 	}
@@ -652,7 +657,7 @@ func TestRunDynamicCommandGroupWithoutSubcommandShowsPrefixHelp(t *testing.T) {
 
 	var stdout bytes.Buffer
 	var stderr bytes.Buffer
-	code := Run(t.Context(), []string{"issue", "topic"}, &stdout, &stderr)
+	code := runDefaultProgram(t, []string{"issue", "topic"}, &stdout, &stderr)
 	if code != 2 {
 		t.Fatalf("code = %d, stderr = %s", code, stderr.String())
 	}
@@ -693,7 +698,7 @@ func TestRunDynamicScopeHelpLimitsGroupedCommandPreview(t *testing.T) {
 
 	var stdout bytes.Buffer
 	var stderr bytes.Buffer
-	code := Run(t.Context(), []string{"issue", "--help"}, &stdout, &stderr)
+	code := runDefaultProgram(t, []string{"issue", "--help"}, &stdout, &stderr)
 	if code != 0 {
 		t.Fatalf("code = %d, stderr = %s", code, stderr.String())
 	}
@@ -731,7 +736,7 @@ func TestRunRootHelpListsDynamicCommandScopes(t *testing.T) {
 
 	var stdout bytes.Buffer
 	var stderr bytes.Buffer
-	code := Run(t.Context(), []string{"--help"}, &stdout, &stderr)
+	code := runDefaultProgram(t, []string{"--help"}, &stdout, &stderr)
 	if code != 0 {
 		t.Fatalf("code = %d, stderr = %s", code, stderr.String())
 	}
@@ -767,7 +772,7 @@ func TestRunDynamicCommandPrefersLongestMatchingPath(t *testing.T) {
 
 	var stdout bytes.Buffer
 	var stderr bytes.Buffer
-	code := Run(t.Context(), []string{"agent", "session", "messages", "--session-id", "SESSION-1", "--json"}, &stdout, &stderr)
+	code := runDefaultProgram(t, []string{"agent", "session", "messages", "--session-id", "SESSION-1", "--json"}, &stdout, &stderr)
 	if code != 0 {
 		t.Fatalf("code = %d, stderr = %s", code, stderr.String())
 	}
@@ -791,7 +796,7 @@ func TestRunDynamicCommandRejectsUnexpectedPositionalArgument(t *testing.T) {
 
 	var stdout bytes.Buffer
 	var stderr bytes.Buffer
-	if code := Run(t.Context(), []string{"issue", "get", "ISS-1"}, &stdout, &stderr); code != 2 {
+	if code := runDefaultProgram(t, []string{"issue", "get", "ISS-1"}, &stdout, &stderr); code != 2 {
 		t.Fatalf("code = %d, want 2", code)
 	}
 	if !strings.Contains(stderr.String(), `unexpected argument "ISS-1"`) {

--- a/apps/cli/internal/daemon/client.go
+++ b/apps/cli/internal/daemon/client.go
@@ -132,18 +132,6 @@ func (client *Client) GetHealth(ctx context.Context) (HealthStatus, error) {
 	return result, nil
 }
 
-func (client *Client) ListCapabilities(ctx context.Context) (CapabilityList, error) {
-	return client.ListCapabilitiesForWorkspace(ctx, "")
-}
-
-func (client *Client) ListCapabilitiesForWorkspace(ctx context.Context, workspaceID string) (CapabilityList, error) {
-	return client.ListCapabilitiesForWorkspaceWithHidden(ctx, workspaceID, false)
-}
-
-func (client *Client) ListCapabilitiesForWorkspaceWithHidden(ctx context.Context, workspaceID string, includeHidden bool) (CapabilityList, error) {
-	return client.ListCapabilitiesForWorkspaceWithOptions(ctx, workspaceID, CapabilityListOptions{IncludeHidden: includeHidden})
-}
-
 func (client *Client) ListCapabilitiesForWorkspaceWithOptions(ctx context.Context, workspaceID string, options CapabilityListOptions) (CapabilityList, error) {
 	var result CapabilityList
 	path := cliCapabilitiesPath

--- a/services/tuttid/service/cli/appcli/manifest.go
+++ b/services/tuttid/service/cli/appcli/manifest.go
@@ -22,10 +22,6 @@ func ReadManifest(path string) (Manifest, error) {
 	return appclicore.ReadManifest(path)
 }
 
-func ValidateManifest(manifest Manifest) error {
-	return appclicore.ValidateManifest(manifest)
-}
-
 func CLIManifestPath(packageDir string, manifestPath string) (string, error) {
 	return appclicore.PackageRelativePath(packageDir, manifestPath)
 }

--- a/services/tuttid/service/cli/appcli/registry_test.go
+++ b/services/tuttid/service/cli/appcli/registry_test.go
@@ -10,6 +10,7 @@ import (
 	"path/filepath"
 	"testing"
 
+	appclicore "github.com/tutti-os/tutti/packages/appcli/core"
 	workspacebiz "github.com/tutti-os/tutti/services/tuttid/biz/workspace"
 	cliservice "github.com/tutti-os/tutti/services/tuttid/service/cli"
 )
@@ -310,7 +311,7 @@ func TestRegistryInvokeRejectsUndeclaredOutput(t *testing.T) {
 }
 
 func TestValidateManifestRejectsReservedHandlerPath(t *testing.T) {
-	err := ValidateManifest(Manifest{
+	err := appclicore.ValidateManifest(Manifest{
 		SchemaVersion: ManifestSchemaVersion,
 		Scope:         "automation",
 		Commands: []ManifestCommand{{

--- a/services/tuttid/service/cli/builtin_compliance_test.go
+++ b/services/tuttid/service/cli/builtin_compliance_test.go
@@ -17,7 +17,7 @@ func TestBuiltinProviderCapabilitiesAreFrameworkCompliant(t *testing.T) {
 	providers := []cliservice.Provider{
 		diagnostics.NewProvider(),
 		issuemanager.NewProvider(nil, nil, nil),
-		agentcontext.NewProvider(nil, nil),
+		agentcontext.NewProviderWithLaunchPublisher(nil, nil, nil),
 		browser.NewProvider(nil, nil),
 		computer.NewProvider(nil, nil),
 	}

--- a/services/tuttid/service/cli/providers/agentcontext/provider.go
+++ b/services/tuttid/service/cli/providers/agentcontext/provider.go
@@ -48,10 +48,6 @@ type Provider struct {
 	preferences     DesktopPreferencesReader
 }
 
-func NewProvider(workspaces cliservice.WorkspaceCatalog, sessions AgentSessions) Provider {
-	return Provider{workspaces: workspaces, sessions: sessions}
-}
-
 func NewProviderWithLaunchPublisher(
 	workspaces cliservice.WorkspaceCatalog,
 	sessions AgentSessions,

--- a/services/tuttid/service/cli/providers/agentcontext/provider_test.go
+++ b/services/tuttid/service/cli/providers/agentcontext/provider_test.go
@@ -64,6 +64,10 @@ type fakeAgentSessions struct {
 	availabilityIn  []agentservice.ProviderAvailabilityInput
 }
 
+func newTestProvider(workspaces cliservice.WorkspaceCatalog, sessions AgentSessions) Provider {
+	return NewProviderWithLaunchPublisher(workspaces, sessions, nil)
+}
+
 func newTestCodexStartCommand(provider Provider) cliservice.Command {
 	return provider.newProviderStartCommand(providerStartCommandSpec{
 		AppID:         codexAgentAppID,
@@ -394,7 +398,7 @@ func equalStrings(left []string, right []string) bool {
 
 func TestSessionSummaryCommandUsesLimitAndAfterVersion(t *testing.T) {
 	sessions := &fakeAgentSessions{}
-	command := NewProvider(fakeWorkspaceCatalog{startup: workspacebiz.Summary{ID: "workspace-1"}}, sessions).newSessionSummaryCommand()
+	command := newTestProvider(fakeWorkspaceCatalog{startup: workspacebiz.Summary{ID: "workspace-1"}}, sessions).newSessionSummaryCommand()
 
 	output, err := command.Handler(context.Background(), cliservice.InvokeRequest{
 		Input:      map[string]any{"session-id": "SESSION-1", "limit": "20", "after-version": "3"},
@@ -455,7 +459,7 @@ func TestSessionSummaryCommandIncludesImageCompactMetadata(t *testing.T) {
 			Version: 2,
 		}},
 	}
-	command := NewProvider(fakeWorkspaceCatalog{startup: workspacebiz.Summary{ID: "workspace-1"}}, sessions).newSessionSummaryCommand()
+	command := newTestProvider(fakeWorkspaceCatalog{startup: workspacebiz.Summary{ID: "workspace-1"}}, sessions).newSessionSummaryCommand()
 
 	output, err := command.Handler(context.Background(), cliservice.InvokeRequest{
 		Input:      map[string]any{"session-id": "SESSION-1"},
@@ -530,7 +534,7 @@ func TestTurnResourcesCommandReturnsImagesGroupedByUserMessage(t *testing.T) {
 			},
 		},
 	}
-	command := NewProvider(fakeWorkspaceCatalog{startup: workspacebiz.Summary{ID: "workspace-1"}}, sessions).newTurnResourcesCommand()
+	command := newTestProvider(fakeWorkspaceCatalog{startup: workspacebiz.Summary{ID: "workspace-1"}}, sessions).newTurnResourcesCommand()
 
 	output, err := command.Handler(context.Background(), cliservice.InvokeRequest{
 		Input:      map[string]any{"session-id": "SESSION-1", "turn-id": "turn-2"},
@@ -562,7 +566,7 @@ func TestTurnResourcesCommandReturnsImagesGroupedByUserMessage(t *testing.T) {
 
 func TestTurnResourcesCommandRejectsBlankTurnID(t *testing.T) {
 	sessions := &fakeAgentSessions{}
-	command := NewProvider(fakeWorkspaceCatalog{startup: workspacebiz.Summary{ID: "workspace-1"}}, sessions).newTurnResourcesCommand()
+	command := newTestProvider(fakeWorkspaceCatalog{startup: workspacebiz.Summary{ID: "workspace-1"}}, sessions).newTurnResourcesCommand()
 
 	_, err := command.Handler(context.Background(), cliservice.InvokeRequest{
 		Input:      map[string]any{"session-id": "SESSION-1", "turn-id": "   "},
@@ -578,7 +582,7 @@ func TestTurnResourcesCommandRejectsBlankTurnID(t *testing.T) {
 
 func TestSessionSummaryCommandUsesDescendingBeforeVersion(t *testing.T) {
 	sessions := &fakeAgentSessions{}
-	command := NewProvider(fakeWorkspaceCatalog{startup: workspacebiz.Summary{ID: "workspace-1"}}, sessions).newSessionSummaryCommand()
+	command := newTestProvider(fakeWorkspaceCatalog{startup: workspacebiz.Summary{ID: "workspace-1"}}, sessions).newSessionSummaryCommand()
 
 	_, err := command.Handler(context.Background(), cliservice.InvokeRequest{
 		Input:      map[string]any{"session-id": "SESSION-1", "limit": "50", "order": "desc", "before-version": "99"},
@@ -599,7 +603,7 @@ func TestSessionSummaryCommandUsesDescendingBeforeVersion(t *testing.T) {
 
 func TestSessionSummaryCommandRejectsInvalidOrder(t *testing.T) {
 	sessions := &fakeAgentSessions{}
-	command := NewProvider(fakeWorkspaceCatalog{startup: workspacebiz.Summary{ID: "workspace-1"}}, sessions).newSessionSummaryCommand()
+	command := newTestProvider(fakeWorkspaceCatalog{startup: workspacebiz.Summary{ID: "workspace-1"}}, sessions).newSessionSummaryCommand()
 
 	_, err := command.Handler(context.Background(), cliservice.InvokeRequest{
 		Input: map[string]any{"session-id": "SESSION-1", "order": "sideways"},
@@ -611,7 +615,7 @@ func TestSessionSummaryCommandRejectsInvalidOrder(t *testing.T) {
 
 func TestStartCommandPassesDisplayPrompt(t *testing.T) {
 	sessions := &fakeAgentSessions{}
-	command := newTestCodexStartCommand(NewProvider(fakeWorkspaceCatalog{startup: workspacebiz.Summary{ID: "workspace-1"}}, sessions))
+	command := newTestCodexStartCommand(newTestProvider(fakeWorkspaceCatalog{startup: workspacebiz.Summary{ID: "workspace-1"}}, sessions))
 
 	_, err := command.Handler(context.Background(), cliservice.InvokeRequest{
 		Input: map[string]any{
@@ -636,7 +640,7 @@ func TestStartCommandPassesDisplayPrompt(t *testing.T) {
 
 func TestStartCommandRequiresProviderAndPrompt(t *testing.T) {
 	sessions := &fakeAgentSessions{}
-	command := NewProvider(fakeWorkspaceCatalog{startup: workspacebiz.Summary{ID: "workspace-1"}}, sessions).newStartCommand()
+	command := newTestProvider(fakeWorkspaceCatalog{startup: workspacebiz.Summary{ID: "workspace-1"}}, sessions).newStartCommand()
 	required, ok := command.Capability.InputSchema["required"].([]string)
 	if !ok {
 		t.Fatalf("required schema = %#v", command.Capability.InputSchema["required"])
@@ -711,7 +715,7 @@ func TestStartCommandUsesComposerDefaults(t *testing.T) {
 
 func TestProvidersCommandReturnsAvailability(t *testing.T) {
 	sessions := &fakeAgentSessions{}
-	command := NewProvider(fakeWorkspaceCatalog{startup: workspacebiz.Summary{ID: "workspace-1"}}, sessions).newProvidersCommand()
+	command := newTestProvider(fakeWorkspaceCatalog{startup: workspacebiz.Summary{ID: "workspace-1"}}, sessions).newProvidersCommand()
 
 	output, err := command.Handler(context.Background(), cliservice.InvokeRequest{
 		Input:      map[string]any{"provider": "codex"},
@@ -757,7 +761,7 @@ func TestProvidersCommandReturnsDefaultProviderFromPreferences(t *testing.T) {
 
 func TestComposerOptionsCommandReturnsProviderOptions(t *testing.T) {
 	sessions := &fakeAgentSessions{}
-	command := NewProvider(fakeWorkspaceCatalog{startup: workspacebiz.Summary{ID: "workspace-1"}}, sessions).newComposerOptionsCommand()
+	command := newTestProvider(fakeWorkspaceCatalog{startup: workspacebiz.Summary{ID: "workspace-1"}}, sessions).newComposerOptionsCommand()
 
 	output, err := command.Handler(context.Background(), cliservice.InvokeRequest{
 		Input: map[string]any{
@@ -804,7 +808,7 @@ func TestComposerOptionsCommandReturnsProviderOptions(t *testing.T) {
 
 func TestComposerOptionsCommandCanDisableCapabilityCatalog(t *testing.T) {
 	sessions := &fakeAgentSessions{}
-	command := NewProvider(fakeWorkspaceCatalog{startup: workspacebiz.Summary{ID: "workspace-1"}}, sessions).newComposerOptionsCommand()
+	command := newTestProvider(fakeWorkspaceCatalog{startup: workspacebiz.Summary{ID: "workspace-1"}}, sessions).newComposerOptionsCommand()
 
 	_, err := command.Handler(context.Background(), cliservice.InvokeRequest{
 		Input: map[string]any{
@@ -861,7 +865,7 @@ func TestComposerOptionsCommandUsesComposerDefaultsFromPreferences(t *testing.T)
 
 func TestSkillBundleCommandReturnsAgentACPKitShape(t *testing.T) {
 	sessions := &fakeAgentSessions{}
-	command := NewProvider(fakeWorkspaceCatalog{startup: workspacebiz.Summary{ID: "workspace-1"}}, sessions).newSkillBundleCommand()
+	command := newTestProvider(fakeWorkspaceCatalog{startup: workspacebiz.Summary{ID: "workspace-1"}}, sessions).newSkillBundleCommand()
 	if command.Capability.ID != appID+".agent.tutti-cli-skill-bundle" ||
 		strings.Join(command.Capability.Path, " ") != "agent tutti-cli-skill-bundle" {
 		t.Fatalf("command capability = %#v", command.Capability)
@@ -980,7 +984,7 @@ func TestStartCommandDefaultsHeadlessAndShowPublishesLaunch(t *testing.T) {
 
 func TestStartCommandPassesComposerSettings(t *testing.T) {
 	sessions := &fakeAgentSessions{}
-	command := newTestCodexStartCommand(NewProvider(fakeWorkspaceCatalog{startup: workspacebiz.Summary{ID: "workspace-1"}}, sessions))
+	command := newTestCodexStartCommand(newTestProvider(fakeWorkspaceCatalog{startup: workspacebiz.Summary{ID: "workspace-1"}}, sessions))
 
 	if _, err := command.Handler(context.Background(), cliservice.InvokeRequest{
 		Input: map[string]any{
@@ -1009,7 +1013,7 @@ func TestStartCommandPassesComposerSettings(t *testing.T) {
 
 func TestStartCommandConvertsImageFilesToPromptContentBlocks(t *testing.T) {
 	sessions := &fakeAgentSessions{}
-	command := newTestCodexStartCommand(NewProvider(fakeWorkspaceCatalog{startup: workspacebiz.Summary{ID: "workspace-1"}}, sessions))
+	command := newTestCodexStartCommand(newTestProvider(fakeWorkspaceCatalog{startup: workspacebiz.Summary{ID: "workspace-1"}}, sessions))
 	imagePath := filepath.Join(t.TempDir(), "shot.png")
 	if err := os.WriteFile(imagePath, []byte("png-bytes"), 0o600); err != nil {
 		t.Fatalf("write image: %v", err)
@@ -1043,7 +1047,7 @@ func TestStartCommandConvertsImageFilesToPromptContentBlocks(t *testing.T) {
 
 func TestStartCommandRejectsUnsupportedImageExtension(t *testing.T) {
 	sessions := &fakeAgentSessions{}
-	command := newTestCodexStartCommand(NewProvider(fakeWorkspaceCatalog{startup: workspacebiz.Summary{ID: "workspace-1"}}, sessions))
+	command := newTestCodexStartCommand(newTestProvider(fakeWorkspaceCatalog{startup: workspacebiz.Summary{ID: "workspace-1"}}, sessions))
 
 	_, err := command.Handler(context.Background(), cliservice.InvokeRequest{
 		Input: map[string]any{
@@ -1062,7 +1066,7 @@ func TestStartCommandRejectsUnsupportedImageExtension(t *testing.T) {
 
 func TestStartCommandPreservesCommaInImagePath(t *testing.T) {
 	sessions := &fakeAgentSessions{}
-	command := newTestCodexStartCommand(NewProvider(fakeWorkspaceCatalog{startup: workspacebiz.Summary{ID: "workspace-1"}}, sessions))
+	command := newTestCodexStartCommand(newTestProvider(fakeWorkspaceCatalog{startup: workspacebiz.Summary{ID: "workspace-1"}}, sessions))
 	imagePath := filepath.Join(t.TempDir(), "shot,one.png")
 	if err := os.WriteFile(imagePath, []byte("comma-path-bytes"), 0o600); err != nil {
 		t.Fatalf("write image: %v", err)
@@ -1092,7 +1096,7 @@ func TestStartCommandInheritsCallerSessionCwd(t *testing.T) {
 	sessions := &fakeAgentSessions{
 		getSession: agentservice.Session{ID: "CALLER-1", Cwd: "/workspace/a"},
 	}
-	command := newTestClaudeStartCommand(NewProvider(fakeWorkspaceCatalog{startup: workspacebiz.Summary{ID: "workspace-1"}}, sessions))
+	command := newTestClaudeStartCommand(newTestProvider(fakeWorkspaceCatalog{startup: workspacebiz.Summary{ID: "workspace-1"}}, sessions))
 
 	_, err := command.Handler(context.Background(), cliservice.InvokeRequest{
 		Input: map[string]any{"model": "sonnet", "prompt": "do work"},
@@ -1115,7 +1119,7 @@ func TestStartCommandExplicitCwdOverridesCallerSessionCwd(t *testing.T) {
 	sessions := &fakeAgentSessions{
 		getSession: agentservice.Session{ID: "CALLER-1", Cwd: "/workspace/a"},
 	}
-	command := newTestCodexStartCommand(NewProvider(fakeWorkspaceCatalog{startup: workspacebiz.Summary{ID: "workspace-1"}}, sessions))
+	command := newTestCodexStartCommand(newTestProvider(fakeWorkspaceCatalog{startup: workspacebiz.Summary{ID: "workspace-1"}}, sessions))
 
 	_, err := command.Handler(context.Background(), cliservice.InvokeRequest{
 		Input: map[string]any{
@@ -1140,7 +1144,7 @@ func TestStartCommandExplicitCwdOverridesCallerSessionCwd(t *testing.T) {
 
 func TestStartCommandWithoutCallerSessionLeavesCwdForAllocator(t *testing.T) {
 	sessions := &fakeAgentSessions{}
-	command := newTestCodexStartCommand(NewProvider(fakeWorkspaceCatalog{startup: workspacebiz.Summary{ID: "workspace-1"}}, sessions))
+	command := newTestCodexStartCommand(newTestProvider(fakeWorkspaceCatalog{startup: workspacebiz.Summary{ID: "workspace-1"}}, sessions))
 
 	_, err := command.Handler(context.Background(), cliservice.InvokeRequest{
 		Input: map[string]any{"model": "gpt-5", "prompt": "do work"},
@@ -1155,7 +1159,7 @@ func TestStartCommandWithoutCallerSessionLeavesCwdForAllocator(t *testing.T) {
 
 func TestStartCommandMissingCallerSessionLeavesCwdForAllocator(t *testing.T) {
 	sessions := &fakeAgentSessions{getErr: agentservice.ErrSessionNotFound}
-	command := newTestCodexStartCommand(NewProvider(fakeWorkspaceCatalog{startup: workspacebiz.Summary{ID: "workspace-1"}}, sessions))
+	command := newTestCodexStartCommand(newTestProvider(fakeWorkspaceCatalog{startup: workspacebiz.Summary{ID: "workspace-1"}}, sessions))
 
 	_, err := command.Handler(context.Background(), cliservice.InvokeRequest{
 		Input: map[string]any{"model": "gpt-5", "prompt": "do work"},
@@ -1172,7 +1176,7 @@ func TestStartCommandMissingCallerSessionLeavesCwdForAllocator(t *testing.T) {
 }
 
 func TestProviderStartCommandsExposeAgentAppsAndFixProvider(t *testing.T) {
-	provider := NewProvider(fakeWorkspaceCatalog{startup: workspacebiz.Summary{ID: "workspace-1"}}, &fakeAgentSessions{})
+	provider := newTestProvider(fakeWorkspaceCatalog{startup: workspacebiz.Summary{ID: "workspace-1"}}, &fakeAgentSessions{})
 	commands := provider.Commands()
 	codex := commandByID(t, commands, "agent-context.codex.start")
 	claude := commandByID(t, commands, "agent-context.claude.start")
@@ -1203,7 +1207,7 @@ func TestProviderStartCommandsExposeAgentAppsAndFixProvider(t *testing.T) {
 		"claude": {commandID: "agent-context.claude.start", want: "claude-code", wantTarget: agenttargetbiz.IDLocalClaudeCode},
 	} {
 		sessions := &fakeAgentSessions{}
-		command := commandByID(t, NewProvider(fakeWorkspaceCatalog{startup: workspacebiz.Summary{ID: "workspace-1"}}, sessions).Commands(), tc.commandID)
+		command := commandByID(t, newTestProvider(fakeWorkspaceCatalog{startup: workspacebiz.Summary{ID: "workspace-1"}}, sessions).Commands(), tc.commandID)
 		_, err := command.Handler(context.Background(), cliservice.InvokeRequest{
 			Input: map[string]any{"model": "model-1", "prompt": "do work"},
 		})
@@ -1270,7 +1274,7 @@ func TestProviderCapabilitiesFilterAgentAppsByAvailability(t *testing.T) {
 				availabilityErr: tc.availabilityErr,
 			}
 			registry, err := cliservice.NewRegistryFromProviders(
-				NewProvider(fakeWorkspaceCatalog{startup: workspacebiz.Summary{ID: "workspace-1"}}, sessions),
+				newTestProvider(fakeWorkspaceCatalog{startup: workspacebiz.Summary{ID: "workspace-1"}}, sessions),
 			)
 			if err != nil {
 				t.Fatalf("NewRegistryFromProviders: %v", err)
@@ -1292,7 +1296,7 @@ func TestProviderCapabilitiesFilterAgentAppsByAvailability(t *testing.T) {
 
 func TestProviderCapabilitiesHideAgentAppsWithoutSessions(t *testing.T) {
 	registry, err := cliservice.NewRegistryFromProviders(
-		NewProvider(fakeWorkspaceCatalog{startup: workspacebiz.Summary{ID: "workspace-1"}}, nil),
+		newTestProvider(fakeWorkspaceCatalog{startup: workspacebiz.Summary{ID: "workspace-1"}}, nil),
 	)
 	if err != nil {
 		t.Fatalf("NewRegistryFromProviders: %v", err)
@@ -1308,7 +1312,7 @@ func TestProviderCapabilitiesHideAgentAppsWithoutSessions(t *testing.T) {
 }
 
 func TestProviderCapabilityFilterKeepsGenericAndNonAgentAppCapabilities(t *testing.T) {
-	provider := NewProvider(fakeWorkspaceCatalog{startup: workspacebiz.Summary{ID: "workspace-1"}}, &fakeAgentSessions{
+	provider := newTestProvider(fakeWorkspaceCatalog{startup: workspacebiz.Summary{ID: "workspace-1"}}, &fakeAgentSessions{
 		availability: []agentservice.ProviderAvailability{
 			providerAvailability("codex", agentservice.ProviderAvailabilityUnavailable),
 			providerAvailability("claude-code", agentservice.ProviderAvailabilityUnavailable),
@@ -1344,7 +1348,7 @@ func TestProviderHiddenAgentAppCapabilityRemainsInvokable(t *testing.T) {
 		},
 	}
 	registry, err := cliservice.NewRegistryFromProviders(
-		NewProvider(fakeWorkspaceCatalog{startup: workspacebiz.Summary{ID: "workspace-1"}}, sessions),
+		newTestProvider(fakeWorkspaceCatalog{startup: workspacebiz.Summary{ID: "workspace-1"}}, sessions),
 	)
 	if err != nil {
 		t.Fatalf("NewRegistryFromProviders: %v", err)
@@ -1377,7 +1381,7 @@ func TestProviderHiddenAgentAppCapabilityRemainsInvokable(t *testing.T) {
 
 func TestProviderStartCommandRequiresPrompt(t *testing.T) {
 	sessions := &fakeAgentSessions{}
-	command := newTestCodexStartCommand(NewProvider(fakeWorkspaceCatalog{startup: workspacebiz.Summary{ID: "workspace-1"}}, sessions))
+	command := newTestCodexStartCommand(newTestProvider(fakeWorkspaceCatalog{startup: workspacebiz.Summary{ID: "workspace-1"}}, sessions))
 	required, ok := command.Capability.InputSchema["required"].([]string)
 	if !ok {
 		t.Fatalf("required schema = %#v", command.Capability.InputSchema["required"])
@@ -1474,7 +1478,7 @@ func TestOpenCommandPublishesLaunchIntent(t *testing.T) {
 
 func TestGetCommandReturnsSession(t *testing.T) {
 	sessions := &fakeAgentSessions{}
-	command := NewProvider(
+	command := newTestProvider(
 		fakeWorkspaceCatalog{startup: workspacebiz.Summary{ID: "workspace-1"}},
 		sessions,
 	).newGetCommand()
@@ -1500,7 +1504,7 @@ func TestGetCommandReturnsSession(t *testing.T) {
 
 func TestSendCommandConvertsImageFilesToPromptContentBlocks(t *testing.T) {
 	sessions := &fakeAgentSessions{}
-	command := NewProvider(
+	command := newTestProvider(
 		fakeWorkspaceCatalog{startup: workspacebiz.Summary{ID: "workspace-1"}},
 		sessions,
 	).newSendCommand()
@@ -1541,7 +1545,7 @@ func TestSendCommandConvertsImageFilesToPromptContentBlocks(t *testing.T) {
 }
 
 func TestSendCommandExposesGuidanceFlagInSchema(t *testing.T) {
-	command := NewProvider(
+	command := newTestProvider(
 		fakeWorkspaceCatalog{startup: workspacebiz.Summary{ID: "workspace-1"}},
 		&fakeAgentSessions{},
 	).newSendCommand()
@@ -1565,7 +1569,7 @@ func TestSendCommandExposesGuidanceFlagInSchema(t *testing.T) {
 
 func TestCancelCommandCancelsSession(t *testing.T) {
 	sessions := &fakeAgentSessions{}
-	command := NewProvider(
+	command := newTestProvider(
 		fakeWorkspaceCatalog{startup: workspacebiz.Summary{ID: "workspace-1"}},
 		sessions,
 	).newCancelCommand()
@@ -1586,7 +1590,7 @@ func TestCancelCommandCancelsSession(t *testing.T) {
 
 func TestSessionSummaryIncludesCompactSession(t *testing.T) {
 	sessions := &fakeAgentSessions{}
-	command := NewProvider(fakeWorkspaceCatalog{startup: workspacebiz.Summary{ID: "workspace-1"}}, sessions).newSessionSummaryCommand()
+	command := newTestProvider(fakeWorkspaceCatalog{startup: workspacebiz.Summary{ID: "workspace-1"}}, sessions).newSessionSummaryCommand()
 
 	output, err := command.Handler(context.Background(), cliservice.InvokeRequest{
 		Input:      map[string]any{"session-id": "SESSION-1"},
@@ -1605,7 +1609,7 @@ func TestSessionSummaryIncludesCompactSession(t *testing.T) {
 }
 
 func TestProviderCommandsExcludeRemovedSessionAliases(t *testing.T) {
-	commands := NewProvider(fakeWorkspaceCatalog{startup: workspacebiz.Summary{ID: "workspace-1"}}, &fakeAgentSessions{}).Commands()
+	commands := newTestProvider(fakeWorkspaceCatalog{startup: workspacebiz.Summary{ID: "workspace-1"}}, &fakeAgentSessions{}).Commands()
 	for _, command := range commands {
 		switch command.Capability.ID {
 		case "agent-context.agent.list", "agent-context.agent.session.messages":
@@ -1615,7 +1619,7 @@ func TestProviderCommandsExcludeRemovedSessionAliases(t *testing.T) {
 }
 
 func TestActivePeersReturnsServiceProjection(t *testing.T) {
-	command := NewProvider(fakeWorkspaceCatalog{startup: workspacebiz.Summary{ID: "workspace-1"}}, &fakeAgentSessions{}).newActivePeersCommand()
+	command := newTestProvider(fakeWorkspaceCatalog{startup: workspacebiz.Summary{ID: "workspace-1"}}, &fakeAgentSessions{}).newActivePeersCommand()
 
 	output, err := command.Handler(context.Background(), cliservice.InvokeRequest{})
 	if err != nil {

--- a/services/tuttid/service/cli/registry.go
+++ b/services/tuttid/service/cli/registry.go
@@ -89,16 +89,6 @@ type DynamicCommandRegistry interface {
 	Invoke(context.Context, InvokeRequest) (CommandOutput, error)
 }
 
-func NewRegistry(commands ...Command) (*Registry, error) {
-	registry := newRegistry()
-	for _, command := range commands {
-		if err := registry.Register(command); err != nil {
-			return nil, err
-		}
-	}
-	return registry, nil
-}
-
 func NewRegistryFromProviders(providers ...Provider) (*Registry, error) {
 	registry := newRegistry()
 	for _, provider := range providers {

--- a/services/tuttid/service/cli/registry_test.go
+++ b/services/tuttid/service/cli/registry_test.go
@@ -6,12 +6,19 @@ import (
 	"testing"
 )
 
-func TestRegistryListsCapabilities(t *testing.T) {
-	registry, err := NewRegistry(testCommand("doctor.ping"))
-	if err != nil {
-		t.Fatalf("NewRegistry: %v", err)
+func newTestRegistry(t *testing.T, commands ...Command) *Registry {
+	t.Helper()
+	registry := newRegistry()
+	for _, command := range commands {
+		if err := registry.Register(command); err != nil {
+			t.Fatalf("Register: %v", err)
+		}
 	}
+	return registry
+}
 
+func TestRegistryListsCapabilities(t *testing.T) {
+	registry := newTestRegistry(t, testCommand("doctor.ping"))
 	capabilities := registry.Capabilities(context.Background(), InvokeContext{Source: "cli"})
 	if len(capabilities) != 1 {
 		t.Fatalf("len(capabilities) = %d, want 1", len(capabilities))
@@ -22,11 +29,7 @@ func TestRegistryListsCapabilities(t *testing.T) {
 }
 
 func TestRegistryInvokesCommand(t *testing.T) {
-	registry, err := NewRegistry(testCommand("doctor.ping"))
-	if err != nil {
-		t.Fatalf("NewRegistry: %v", err)
-	}
-
+	registry := newTestRegistry(t, testCommand("doctor.ping"))
 	output, err := registry.Invoke(context.Background(), InvokeRequest{
 		CommandID: "doctor.ping",
 		Context:   InvokeContext{Source: "cli"},
@@ -40,19 +43,17 @@ func TestRegistryInvokesCommand(t *testing.T) {
 }
 
 func TestRegistryReturnsCommandNotFound(t *testing.T) {
-	registry, err := NewRegistry(testCommand("doctor.ping"))
-	if err != nil {
-		t.Fatalf("NewRegistry: %v", err)
-	}
-
-	_, err = registry.Invoke(context.Background(), InvokeRequest{CommandID: "missing"})
+	registry := newTestRegistry(t, testCommand("doctor.ping"))
+	_, err := registry.Invoke(context.Background(), InvokeRequest{CommandID: "missing"})
 	if !errors.Is(err, ErrCommandNotFound) {
 		t.Fatalf("err = %v, want ErrCommandNotFound", err)
 	}
 }
 
 func TestRegistryRejectsDuplicateCommandID(t *testing.T) {
-	_, err := NewRegistry(testCommand("doctor.ping"), testCommand("doctor.ping"))
+	registry := newRegistry()
+	_ = registry.Register(testCommand("doctor.ping"))
+	err := registry.Register(testCommand("doctor.ping"))
 	if !errors.Is(err, ErrInvalidCommand) {
 		t.Fatalf("err = %v, want ErrInvalidCommand", err)
 	}
@@ -86,14 +87,11 @@ func TestRegistryFromProviders(t *testing.T) {
 }
 
 func TestRegistryCapabilitiesKeepRegistrationOrder(t *testing.T) {
-	registry, err := NewRegistry(
+	registry := newTestRegistry(
+		t,
 		testCommandWithPath("diagnostics.second", []string{"second"}),
 		testCommandWithPath("diagnostics.first", []string{"first"}),
 	)
-	if err != nil {
-		t.Fatalf("NewRegistry: %v", err)
-	}
-
 	capabilities := registry.Capabilities(context.Background(), InvokeContext{Source: "cli"})
 	if len(capabilities) != 2 {
 		t.Fatalf("len(capabilities) = %d, want 2", len(capabilities))
@@ -180,7 +178,8 @@ func TestRegistryCapabilitiesCanSkipProviderFilters(t *testing.T) {
 }
 
 func TestRegistryHidesIntegrationCapabilitiesFromDefaultList(t *testing.T) {
-	registry, err := NewRegistry(
+	registry := newTestRegistry(
+		t,
 		testCommandWithPath("diagnostics.visible", []string{"visible"}),
 		Command{
 			Capability: Capability{
@@ -201,10 +200,6 @@ func TestRegistryHidesIntegrationCapabilitiesFromDefaultList(t *testing.T) {
 			},
 		},
 	)
-	if err != nil {
-		t.Fatalf("NewRegistry: %v", err)
-	}
-
 	capabilities := registry.Capabilities(context.Background(), InvokeContext{Source: "cli"})
 	if got, want := capabilityIDs(capabilities), []string{"diagnostics.visible"}; !stringSlicesEqual(got, want) {
 		t.Fatalf("capability ids = %#v, want %#v", got, want)


### PR DESCRIPTION
## Summary
- remove dead internal-only CLI convenience aliases from apps/cli and the daemon CLI framework
- update tests to call the active entrypoints directly instead of the removed wrappers

## Why this is safe
- repo-wide search plus local tsh search found no production callers for these aliases, only tests or their definitions
- production already uses `RunWithProgram`, `ListCapabilitiesForWorkspaceWithOptions`, `NewRegistryFromProviders`, `appclicore.ValidateManifest`, and `NewProviderWithLaunchPublisher`
- the published `packages/appcli/core` package was intentionally left unchanged because it is released and consumed externally

## Validation
- `cd apps/cli && go test ./...`
- `cd services/tuttid && pnpm generate:builtin-apps >/dev/null && go test ./service/cli/...`
- `pnpm check:changed -- --tail-lines 80`
- `pnpm lint:go`
- `pnpm check:full`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved CLI capability handling and command registration, helping the app list and invoke commands more reliably.
  * Added support for optional desktop preferences in agent context flows, enabling richer startup behavior when available.
* **Refactor**
  * Simplified several internal entry points and test setups while keeping CLI behavior consistent for end users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->