### PR TITLE
fix(agentstatus): remove unavailable npm mirror

### DIFF
--- a/docs/architecture/tutti-agent-readiness-bootstrap.md
+++ b/docs/architecture/tutti-agent-readiness-bootstrap.md
@@ -111,7 +111,6 @@ The installer should reuse the existing agent npm registry chain:
    registry and disables fallback.
 2. Otherwise rank and retry:
    - `https://registry.npmjs.org`
-   - `https://registry.npmmirror.com`
    - `https://repo.huaweicloud.com/repository/npm/`
    - `https://mirrors.cloud.tencent.com/npm/`
 
@@ -119,6 +118,9 @@ This is appropriate for `tutti-agent`. The package is first-party, but the npm
 dependency graph still needs reliable access from China and from enterprise
 networks. Ranking should probe metadata for the exact package being installed,
 then attempt install per registry with the existing per-registry timeout.
+Mirrors must carry the aggregate package and its platform optional dependency
+versions; a registry that only syncs the aggregate package can make npm exit
+successfully while leaving the installed launcher unable to start.
 
 The command shape should match Codex's robust behavior:
 

--- a/docs/conventions/troubleshooting.md
+++ b/docs/conventions/troubleshooting.md
@@ -230,6 +230,36 @@ Use this shape for new entries:
   [installer_codex_cli.go](../../services/tuttid/service/agentstatus/installer_codex_cli.go)
   [codex_platform.go](../../services/tuttid/service/agentstatus/codex_platform.go)
 
+### Tutti Agent npm install misses the platform package
+
+- Symptom:
+  The Tutti Agent provider setup reaches the login screen or reports the CLI as
+  installed, but `tutti-agent login` or `tutti-agent app-server` fails with
+  `Missing optional dependency @tutti-os/tutti-agent-<platform>`.
+- Quick checks:
+  Check the selected registry for both `@tutti-os/tutti-agent` and the exact
+  alias target version, such as
+  `@tutti-os/tutti-agent@0.0.1-darwin-arm64`. Do not treat a successful
+  aggregate package metadata fetch as proof that the platform tarball is
+  available.
+- Root cause:
+  `@tutti-os/tutti-agent` follows the Codex npm layout: a JavaScript launcher
+  plus per-platform optional dependencies expressed as npm aliases. npm can
+  complete the aggregate install even when a mirror has not synced the platform
+  optional dependency version.
+- Fix:
+  Keep the package layout aligned with Codex and use registries that carry the
+  platform optional dependency versions. The daemon default chain intentionally
+  excludes mirrors that only sync the aggregate package. Preserve
+  `TUTTI_AGENT_NPM_REGISTRY` as an explicit single-registry pin with no fallback.
+- Validation:
+  Install into a temporary prefix/cache and verify the provider probe, not only
+  npm's exit code. Confirm `tutti-agent app-server` can start far enough to pass
+  the daemon readiness probe.
+- References:
+  [npm_registry.go](../../services/tuttid/service/agentstatus/npm_registry.go)
+  [tutti_agent.go](../../services/tuttid/service/agentsidecar/tutti_agent.go)
+
 ### Dynamic CLI input rejects plausible flags
 
 - Symptom:

--- a/services/tuttid/service/agentstatus/installer.go
+++ b/services/tuttid/service/agentstatus/installer.go
@@ -614,10 +614,10 @@ func (s Service) runExternalAgentRegistryNPMInstaller(ctx context.Context, provi
 	// make every user-mode npm install fail with EACCES before any registry is hit.
 	baseEnv = withAgentNPMCache(baseEnv, filepath.Join(npmSpec.PrefixDir, agentNPMCacheDirName))
 
-	// Try official npm first (fastest when reachable), then fall back through the
-	// CN-available mirrors when it is slow or blocked. Each attempt is bounded so a
-	// blocked registry fails over quickly instead of consuming the whole budget;
-	// the npm_config_registry value selects the source.
+	// Rank official npm and the CN-available mirrors with a lightweight metadata
+	// probe, then install through that order. Each attempt is bounded so a blocked
+	// registry fails over quickly instead of consuming the whole budget; the
+	// npm_config_registry value selects the source.
 	packageName, _ := splitNPMPackageSpec(npmSpec.Package)
 	registries := s.rankedAgentNPMRegistries(ctx, packageName)
 	var result InstallCommandResult

--- a/services/tuttid/service/agentstatus/network_probe_test.go
+++ b/services/tuttid/service/agentstatus/network_probe_test.go
@@ -87,8 +87,8 @@ func TestProbeRegistryReportsRankedMirrorWhenOfficialMetadataIsSlow(t *testing.T
 	})
 
 	got := svc.probeRegistry(context.Background(), "@openai/codex")
-	if !got.Reachable || got.Endpoint != npmmirrorRegistry {
-		t.Fatalf("probeRegistry() = %#v, want ranked mirror %q", got, npmmirrorRegistry)
+	if !got.Reachable || got.Endpoint != huaweiNPMRegistry {
+		t.Fatalf("probeRegistry() = %#v, want ranked mirror %q", got, huaweiNPMRegistry)
 	}
 }
 

--- a/services/tuttid/service/agentstatus/npm_registry.go
+++ b/services/tuttid/service/agentstatus/npm_registry.go
@@ -23,11 +23,9 @@ const (
 	officialNPMRegistry = "https://registry.npmjs.org"
 
 	// CN-available fallback mirrors, used when public npm is slow or blocked.
-	// All three were verified to host the full @agentclientprotocol/claude-agent-acp
-	// dependency tree end-to-end, including the @anthropic-ai/claude-agent-sdk-*
-	// platform binaries (the highest-risk packages). They serve identical tarballs,
-	// so npm integrity verification is unaffected.
-	npmmirrorRegistry  = "https://registry.npmmirror.com"               // Alibaba
+	// These mirrors were verified to host large platform optional-dependency
+	// packages end-to-end. They serve identical tarballs, so npm integrity
+	// verification is unaffected.
 	huaweiNPMRegistry  = "https://repo.huaweicloud.com/repository/npm/" // Huawei Cloud
 	tencentNPMRegistry = "https://mirrors.cloud.tencent.com/npm/"       // Tencent Cloud
 
@@ -68,7 +66,6 @@ func (s Service) agentNPMRegistries() []string {
 	}
 	return []string{
 		officialNPMRegistry,
-		npmmirrorRegistry,
 		huaweiNPMRegistry,
 		tencentNPMRegistry,
 	}

--- a/services/tuttid/service/agentstatus/npm_registry_test.go
+++ b/services/tuttid/service/agentstatus/npm_registry_test.go
@@ -19,7 +19,6 @@ func TestAgentNPMRegistriesDefaultsToOfficialFirstThenMirrors(t *testing.T) {
 	got := service.agentNPMRegistries()
 	want := []string{
 		"https://registry.npmjs.org",
-		"https://registry.npmmirror.com",
 		"https://repo.huaweicloud.com/repository/npm/",
 		"https://mirrors.cloud.tencent.com/npm/",
 	}
@@ -80,7 +79,7 @@ func TestRunExternalAgentRegistryNPMInstallerFallsBackToMirror(t *testing.T) {
 	if _, err := service.runExternalAgentRegistryNPMInstaller(context.Background(), "claude-code", npmInstallerSpec(t)); err != nil {
 		t.Fatalf("runExternalAgentRegistryNPMInstaller() error = %v", err)
 	}
-	want := []string{"https://registry.npmjs.org", "https://registry.npmmirror.com"}
+	want := []string{"https://registry.npmjs.org", "https://repo.huaweicloud.com/repository/npm/"}
 	if !slices.Equal(registriesTried, want) {
 		t.Fatalf("registries tried = %#v, want official then first mirror %#v", registriesTried, want)
 	}
@@ -123,7 +122,7 @@ func TestRunExternalAgentRegistryNPMInstallerPurgesDirtyTreeBeforeRetry(t *testi
 	if result.ExitCode != 0 {
 		t.Fatalf("install exit code = %d (stderr=%q), want a clean retry to succeed after purge", result.ExitCode, result.Stderr)
 	}
-	want := []string{"https://registry.npmjs.org", "https://registry.npmmirror.com"}
+	want := []string{"https://registry.npmjs.org", "https://repo.huaweicloud.com/repository/npm/"}
 	if !slices.Equal(registriesTried, want) {
 		t.Fatalf("registries tried = %#v, want official then mirror after purge %#v", registriesTried, want)
 	}
@@ -175,7 +174,7 @@ func TestResolveExternalRegistryNPMSpecExecEnvUsesRankedRegistry(t *testing.T) {
 	if !slices.Contains(result.Command, "exec") || !slices.Contains(result.Command, prefixDir) {
 		t.Fatalf("Command = %#v, want npm exec fallback under %q", result.Command, prefixDir)
 	}
-	if !slices.Contains(result.Env, "npm_config_registry=https://registry.npmmirror.com") {
+	if !slices.Contains(result.Env, "npm_config_registry=https://repo.huaweicloud.com/repository/npm/") {
 		t.Fatalf("adapter env = %#v, want ranked mirror registry", result.Env)
 	}
 }
@@ -303,7 +302,7 @@ func TestRankedAgentNPMRegistriesMovesUnreachableOfficialBehindReachableMirror(t
 	}
 
 	got := service.rankedAgentNPMRegistries(context.Background(), "@openai/codex")
-	if len(got) == 0 || got[0] != "https://registry.npmmirror.com" {
+	if len(got) == 0 || got[0] != "https://repo.huaweicloud.com/repository/npm/" {
 		t.Fatalf("rankedAgentNPMRegistries()[0] = %q, want first reachable mirror; full order=%#v", got[0], got)
 	}
 }
@@ -325,7 +324,7 @@ func TestRankedAgentNPMRegistriesMovesHTTPErrorBehindSuccessfulMirror(t *testing
 	}
 
 	got := service.rankedAgentNPMRegistries(context.Background(), "@openai/codex")
-	if len(got) == 0 || got[0] != "https://registry.npmmirror.com" {
+	if len(got) == 0 || got[0] != "https://repo.huaweicloud.com/repository/npm/" {
 		t.Fatalf("rankedAgentNPMRegistries()[0] = %q, want first successful mirror; full order=%#v", got[0], got)
 	}
 }

--- a/services/tuttid/service/agentstatus/service_test.go
+++ b/services/tuttid/service/agentstatus/service_test.go
@@ -954,7 +954,7 @@ func TestServiceListExternalAdapterCommandUsesRankedRegistry(t *testing.T) {
 	if err != nil {
 		t.Fatalf("read captured npm registry: %v", err)
 	}
-	if got := string(registryBytes); got != "https://registry.npmmirror.com" {
+	if got := string(registryBytes); got != "https://repo.huaweicloud.com/repository/npm/" {
 		t.Fatalf("npm_config_registry = %q, want ranked mirror registry", got)
 	}
 }


### PR DESCRIPTION
## Summary

- Remove `https://registry.npmmirror.com` from the default agent npm registry chain.
- Keep existing registry ranking behavior: probe candidate registries first, then install from the fastest reachable source.
- Use the remaining default chain: npm official, Huawei Cloud, then Tencent Cloud.
- Update tests and docs for the `tutti-agent` optional platform package missing case.

## Why

`tutti-agent` follows the Codex npm package layout: the aggregate package installs platform optional dependencies through npm aliases. npmmirror currently has aggregate package metadata but is missing required platform versions such as `@tutti-os/tutti-agent@0.0.1-darwin-arm64`. npm can still exit successfully after installing only the launcher, leaving `tutti-agent login` / `tutti-agent app-server` failing with `Missing optional dependency @tutti-os/tutti-agent-<platform>`.

## Validation

- `go test ./services/tuttid/service/agentstatus`
- `git diff --check`
- `PATH="$(go env GOPATH)/bin:$PATH" pnpm lint:go`
- pre-push `pnpm check:full` passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved agent installation fallback behavior by preferring more reliable npm mirrors when the primary registry is slow or unavailable.
  * Reduced setup failures caused by missing platform-specific package files during install.

* **Documentation**
  * Added troubleshooting guidance for failed agent installs and missing optional dependencies.
  * Clarified registry mirror recommendations and updated installer notes for better setup reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->