### PR TITLE
fix(agent): prevent stale session loading state

### DIFF
--- a/docs/conventions/troubleshooting.md
+++ b/docs/conventions/troubleshooting.md
@@ -106,6 +106,40 @@ Use this shape for new entries:
   [controller.go](../../packages/agent/daemon/runtime/controller.go)
   [controller_test.go](../../packages/agent/daemon/runtime/controller_test.go)
 
+### Agent session stays loading after a completed turn
+
+- Symptom:
+  AgentGUI shows the assistant response as completed, but the conversation or
+  sidebar remains in a loading/running state. Desktop logs may contain
+  `agent.activity.store.session_version_regression` where the previous session
+  is `settled`/`available` and the next session is older
+  `running`/`active_turn`.
+- Quick checks:
+  Compare the desktop `reconcile.state_fetch.resolved` session timestamp with
+  the latest inline `state_patch` timestamp. In `tuttid.log`, check whether
+  runtime emitted a terminal `turn_phase=settled` event before the fetch
+  response was applied.
+- Root cause:
+  Activity projection can accept and broadcast a newer completed state while
+  `GetWorkspaceAgentSession` still prefers an older live runtime snapshot for
+  the same session. The projection store has timestamp regression protection,
+  but the service read path can bypass it when a runtime session is present.
+- Fix:
+  In service read paths, compare persisted projection freshness against the
+  runtime snapshot. If persisted state is newer, return the projected session
+  state and synthesize non-live turn lifecycle/submit availability instead of
+  exposing the stale runtime active turn.
+- Validation:
+  Add service coverage where runtime reports `working/running/active_turn` with
+  an older `UpdatedAtUnixMS`, while persisted state reports
+  `completed/idle/available` with a newer `LastEventUnixMS`. Validate both
+  `Get` and `List` do not return the old active turn. Run
+  `go test ./services/tuttid/service/agent`.
+- References:
+  [service_session.go](../../services/tuttid/service/agent/service_session.go)
+  [service.go](../../services/tuttid/service/agent/service.go)
+  [service_session_list.go](../../services/tuttid/service/agent/service_session_list.go)
+
 ### Claude composer model list stays stale after credential switch
 
 - Symptom:

--- a/packages/agent/activity-core/src/controller.test.ts
+++ b/packages/agent/activity-core/src/controller.test.ts
@@ -1,7 +1,10 @@
 import assert from "node:assert/strict";
 import { test } from "node:test";
 import type { AgentActivityAdapter } from "./adapter.ts";
-import { createAgentActivityController } from "./controller.ts";
+import {
+  createAgentActivityController,
+  setAgentActivityStoreDiagnosticSink
+} from "./controller.ts";
 import type {
   AgentActivityComposerOptions,
   AgentActivityMessage,
@@ -110,6 +113,53 @@ test("controller snapshot reference is stable until data changes", async () => {
   assert.equal(controller.getSnapshot(), loadedSnapshot);
 
   unsubscribe();
+});
+
+test("controller rejects stale session upserts after newer activity state", () => {
+  const diagnostics: Array<{
+    details: Record<string, unknown>;
+    event: string;
+  }> = [];
+  setAgentActivityStoreDiagnosticSink((event, details) => {
+    diagnostics.push({ event, details });
+  });
+  try {
+    const controller = createAgentActivityController({
+      adapter: fakeAdapter(),
+      workspaceId: "workspace-1"
+    });
+    controller.upsertSession(
+      createSession({
+        status: "completed",
+        updatedAtUnixMs: 2000,
+        turnLifecycle: {
+          activeTurnId: null,
+          phase: "settled",
+          outcome: "completed"
+        },
+        submitAvailability: { state: "available" }
+      })
+    );
+    controller.upsertSession(
+      createSession({
+        status: "working",
+        updatedAtUnixMs: 1000,
+        turnLifecycle: { activeTurnId: "turn-1", phase: "running" },
+        submitAvailability: { state: "blocked", reason: "active_turn" }
+      })
+    );
+
+    const session = controller.getSnapshot().sessions[0];
+    assert.equal(session?.status, "completed");
+    assert.equal(session?.turnLifecycle?.phase, "settled");
+    assert.equal(session?.submitAvailability?.state, "available");
+    assert.equal(diagnostics.length, 1);
+    assert.equal(diagnostics[0]?.event, "session_version_regression");
+    assert.equal(diagnostics[0]?.details.previousKey, 2000);
+    assert.equal(diagnostics[0]?.details.nextKey, 1000);
+  } finally {
+    setAgentActivityStoreDiagnosticSink(null);
+  }
 });
 
 test("controller can list session messages without caching them", async () => {

--- a/packages/agent/activity-core/src/controller.ts
+++ b/packages/agent/activity-core/src/controller.ts
@@ -125,39 +125,39 @@ export function createAgentActivityController({
       const nextSessions = response.sessions;
       const nextPresences = response.presences ?? [];
       const nextSnapshot = updateSnapshot((current) => {
-        let mergedSessions = nextSessions;
         const sessionDataUnchanged =
           areShallowObjectArraysEqual(current.sessions, nextSessions) &&
           areShallowObjectArraysEqual(current.presences, nextPresences);
+        let reconciledSessions = nextSessions;
         if (!sessionDataUnchanged) {
-          mergedSessions = nextSessions.map((nextSession) => {
+          reconciledSessions = nextSessions.map((nextSession) => {
             const existing = current.sessions.find(
               (item) => item.agentSessionId === nextSession.agentSessionId
             );
-            if (!existing) {
-              return nextSession;
+            if (
+              existing &&
+              isSessionVersionRegression("load", existing, nextSession)
+            ) {
+              return existing;
             }
-            reportSessionVersionRegression("load", existing, nextSession);
-            // A load response is a point-in-time snapshot; if a fresher pushed
-            // state already landed for this session, keep it (same guard as
-            // upsertSnapshotSession).
-            return sessionVersionRegressed(existing, nextSession)
-              ? existing
-              : nextSession;
+            return nextSession;
           });
         }
-        const source = sessionDataUnchanged
+        const reconciledDataUnchanged =
+          areShallowObjectArraysEqual(current.sessions, reconciledSessions) &&
+          areShallowObjectArraysEqual(current.presences, nextPresences);
+        const source = reconciledDataUnchanged
           ? current
           : {
               ...current,
               presences: nextPresences,
-              sessions: mergedSessions
+              sessions: reconciledSessions
             };
         const canonical = canonicalizeSnapshotMessageBuckets(source);
         if (canonical !== source) {
           return canonical;
         }
-        return sessionDataUnchanged ? current : source;
+        return reconciledDataUnchanged ? current : source;
       });
       if (autoRetainSessionEvents) {
         reconcileAutoRetainedSessionStreams(nextSnapshot.sessions, signal);
@@ -1006,24 +1006,15 @@ function sessionVersionKey(session: AgentActivitySession): number | null {
   return session.lastEventUnixMs ?? session.updatedAtUnixMs ?? null;
 }
 
-function sessionVersionRegressed(
+function isSessionVersionRegression(
+  source: string,
   existing: AgentActivitySession,
   incoming: AgentActivitySession
 ): boolean {
   const previousKey = sessionVersionKey(existing);
   const nextKey = sessionVersionKey(incoming);
-  return previousKey !== null && nextKey !== null && nextKey < previousKey;
-}
-
-function reportSessionVersionRegression(
-  source: string,
-  existing: AgentActivitySession,
-  incoming: AgentActivitySession
-): void {
-  const previousKey = sessionVersionKey(existing);
-  const nextKey = sessionVersionKey(incoming);
   if (previousKey === null || nextKey === null || nextKey >= previousKey) {
-    return;
+    return false;
   }
   reportAgentActivityStoreDiagnostic("session_version_regression", {
     agentSessionId: incoming.agentSessionId,
@@ -1036,6 +1027,7 @@ function reportSessionVersionRegression(
     previousSubmitAvailability: existing.submitAvailability ?? null,
     nextSubmitAvailability: incoming.submitAvailability ?? null
   });
+  return true;
 }
 
 function upsertSnapshotSession(
@@ -1053,15 +1045,11 @@ function upsertSnapshotSession(
     });
   }
   const existingSession = snapshot.sessions[index];
-  if (existingSession) {
-    reportSessionVersionRegression(source, existingSession, session);
-    // A slow fetch can resolve after a fresher pushed state landed (e.g. a
-    // reconcile snapshot requested mid-turn arriving after the settle patch).
-    // Overwriting would freeze the session on a stale running/blocked view
-    // with no later event to correct it, so drop the stale upsert instead.
-    if (sessionVersionRegressed(existingSession, session)) {
-      return snapshot;
-    }
+  if (
+    existingSession &&
+    isSessionVersionRegression(source, existingSession, session)
+  ) {
+    return snapshot;
   }
   const sessions = [...snapshot.sessions];
   sessions[index] = session;

--- a/services/tuttid/service/agent/service.go
+++ b/services/tuttid/service/agent/service.go
@@ -421,13 +421,11 @@ func (s *Service) get(ctx context.Context, workspaceID string, agentSessionID st
 				}
 			}
 		}
-		service := serviceSession(
-			session,
-			s.controller().CanResume(runtimeResumeInputFromRuntimeSession(session)),
-		)
+		resumable := s.controller().CanResume(runtimeResumeInputFromRuntimeSession(session))
+		service := serviceSession(session, resumable)
 		if s.SessionReader != nil {
 			if persisted, ok := s.SessionReader.GetSession(workspaceID, agentSessionID); ok {
-				service = mergePersistedSessionState(service, persisted)
+				service = serviceSessionWithPersistedFreshness(session, persisted, resumable)
 			}
 		}
 		return service, nil

--- a/services/tuttid/service/agent/service_session.go
+++ b/services/tuttid/service/agent/service_session.go
@@ -220,6 +220,66 @@ func mergeImportRuntimeContextFields(live map[string]any, persisted map[string]a
 	return merged
 }
 
+func serviceSessionWithPersistedFreshness(session RuntimeSession, persisted PersistedSession, resumable bool) Session {
+	if !persistedSessionIsNewerThanRuntime(persisted, session) {
+		return mergePersistedSessionState(serviceSession(session, resumable), persisted)
+	}
+	service := sessionFromPersisted(persisted, resumable)
+	if strings.TrimSpace(service.ProviderSessionID) == "" {
+		service.ProviderSessionID = strings.TrimSpace(session.ProviderSessionID)
+	}
+	if service.Settings == nil {
+		service.Settings = normalizeComposerSettingsPointerForProvider(session.Provider, session.Settings)
+	}
+	if len(service.RuntimeContext) == 0 {
+		service.RuntimeContext = clonePayload(session.RuntimeContext)
+	}
+	service.PermissionConfig = composerPermissionConfig(service.Provider, permissionModeIDFromSettings(service.Settings), preferencesbiz.DefaultDesktopLocale)
+	service.TurnLifecycle = persistedSessionTurnLifecycle(persisted)
+	service.SubmitAvailability = persistedSessionSubmitAvailability(persisted)
+	return service
+}
+
+func persistedSessionIsNewerThanRuntime(persisted PersistedSession, session RuntimeSession) bool {
+	persistedUpdatedAtUnixMS := firstNonZeroInt64(persisted.LastEventUnixMS, persisted.UpdatedAtUnixMS)
+	return persistedUpdatedAtUnixMS > 0 &&
+		session.UpdatedAtUnixMS > 0 &&
+		persistedUpdatedAtUnixMS > session.UpdatedAtUnixMS
+}
+
+func persistedSessionTurnLifecycle(session PersistedSession) *TurnLifecycle {
+	status := strings.TrimSpace(session.Status)
+	phase := strings.TrimSpace(session.CurrentPhase)
+	switch {
+	case status == "completed":
+		outcome := "completed"
+		return &TurnLifecycle{Phase: "settled", Outcome: &outcome}
+	case status == "failed" || phase == "failed":
+		outcome := "failed"
+		return &TurnLifecycle{Phase: "settled", Outcome: &outcome}
+	case status == "canceled":
+		outcome := "canceled"
+		return &TurnLifecycle{Phase: "settled", Outcome: &outcome}
+	case phase == "idle":
+		outcome := "completed"
+		return &TurnLifecycle{Phase: "settled", Outcome: &outcome}
+	default:
+		return nil
+	}
+}
+
+func persistedSessionSubmitAvailability(session PersistedSession) *SubmitAvailability {
+	if lifecycle := persistedSessionTurnLifecycle(session); lifecycle != nil && strings.TrimSpace(lifecycle.Phase) == "settled" {
+		return &SubmitAvailability{State: "available"}
+	}
+	switch strings.TrimSpace(session.Status) {
+	case "working", "waiting":
+		return &SubmitAvailability{State: "blocked", Reason: "active_turn"}
+	default:
+		return nil
+	}
+}
+
 func permissionModeIDFromSettings(settings *ComposerSettings) string {
 	if settings == nil {
 		return ""

--- a/services/tuttid/service/agent/service_session_list.go
+++ b/services/tuttid/service/agent/service_session_list.go
@@ -68,13 +68,11 @@ func (s *Service) listFilteredSortedSessions(ctx context.Context, workspaceID st
 	}
 	sessions := s.controller().Sessions(workspaceID)
 	for _, session := range sessions {
-		service := serviceSession(
-			session,
-			s.controller().CanResume(runtimeResumeInputFromRuntimeSession(session)),
-		)
+		resumable := s.controller().CanResume(runtimeResumeInputFromRuntimeSession(session))
+		service := serviceSession(session, resumable)
 		if s.SessionReader != nil {
 			if persisted, ok := s.SessionReader.GetSession(workspaceID, session.ID); ok {
-				service = mergePersistedSessionState(service, persisted)
+				service = serviceSessionWithPersistedFreshness(session, persisted, resumable)
 			}
 		}
 		sessionByID[strings.TrimSpace(session.ID)] = service

--- a/services/tuttid/service/agent/service_test.go
+++ b/services/tuttid/service/agent/service_test.go
@@ -3955,6 +3955,100 @@ func TestServiceFallsBackToPersistedSessions(t *testing.T) {
 	}
 }
 
+func TestServiceGetUsesNewerPersistedStateOverStaleRuntimeSession(t *testing.T) {
+	runtime := newFakeRuntime()
+	activeTurnID := "turn-1"
+	runtime.sessions["ws-1:session-1"] = RuntimeSession{
+		ID:                "session-1",
+		WorkspaceID:       "ws-1",
+		Provider:          "claude-code",
+		ProviderSessionID: "provider-session-1",
+		Status:            "working",
+		TurnLifecycle: &TurnLifecycle{
+			ActiveTurnID: &activeTurnID,
+			Phase:        "running",
+		},
+		SubmitAvailability: &SubmitAvailability{State: "blocked", Reason: "active_turn"},
+		UpdatedAtUnixMS:    1000,
+	}
+	service := NewService(runtime)
+	service.SessionReader = fakeSessionReader{
+		sessions: map[string]PersistedSession{
+			"ws-1:session-1": {
+				ID:                "session-1",
+				WorkspaceID:       "ws-1",
+				Provider:          "claude-code",
+				ProviderSessionID: "provider-session-1",
+				Status:            "completed",
+				CurrentPhase:      "idle",
+				LastEventUnixMS:   2000,
+				UpdatedAtUnixMS:   2000,
+			},
+		},
+	}
+
+	got, err := service.Get(context.Background(), "ws-1", "session-1")
+	if err != nil {
+		t.Fatalf("Get returned error: %v", err)
+	}
+	if got.Status != "completed" {
+		t.Fatalf("status = %q, want completed", got.Status)
+	}
+	if got.TurnLifecycle == nil || got.TurnLifecycle.ActiveTurnID != nil || got.TurnLifecycle.Phase != "settled" {
+		t.Fatalf("turn lifecycle = %#v, want settled without active turn", got.TurnLifecycle)
+	}
+	if got.SubmitAvailability == nil || got.SubmitAvailability.State != "available" {
+		t.Fatalf("submit availability = %#v, want available", got.SubmitAvailability)
+	}
+
+	list, err := service.List(context.Background(), "ws-1")
+	if err != nil {
+		t.Fatalf("List returned error: %v", err)
+	}
+	if len(list) != 1 || list[0].Status != "completed" {
+		t.Fatalf("list = %#v, want completed persisted state", list)
+	}
+}
+
+func TestServiceGetKeepsRuntimeStateWhenPersistedStateIsNotNewer(t *testing.T) {
+	runtime := newFakeRuntime()
+	activeTurnID := "turn-1"
+	runtime.sessions["ws-1:session-1"] = RuntimeSession{
+		ID:                 "session-1",
+		WorkspaceID:        "ws-1",
+		Provider:           "claude-code",
+		Status:             "working",
+		TurnLifecycle:      &TurnLifecycle{ActiveTurnID: &activeTurnID, Phase: "running"},
+		UpdatedAtUnixMS:    2000,
+		SubmitAvailability: &SubmitAvailability{State: "blocked", Reason: "active_turn"},
+	}
+	service := NewService(runtime)
+	service.SessionReader = fakeSessionReader{
+		sessions: map[string]PersistedSession{
+			"ws-1:session-1": {
+				ID:              "session-1",
+				WorkspaceID:     "ws-1",
+				Provider:        "claude-code",
+				Status:          "completed",
+				CurrentPhase:    "idle",
+				LastEventUnixMS: 1000,
+				UpdatedAtUnixMS: 1000,
+			},
+		},
+	}
+
+	got, err := service.Get(context.Background(), "ws-1", "session-1")
+	if err != nil {
+		t.Fatalf("Get returned error: %v", err)
+	}
+	if got.Status != "running" {
+		t.Fatalf("status = %q, want runtime running", got.Status)
+	}
+	if got.TurnLifecycle == nil || got.TurnLifecycle.ActiveTurnID == nil || *got.TurnLifecycle.ActiveTurnID != activeTurnID {
+		t.Fatalf("turn lifecycle = %#v, want live runtime turn", got.TurnLifecycle)
+	}
+}
+
 func TestServiceListFilteredMatchesSearchVisibilityLimitAndUpdatedOrder(t *testing.T) {
 	runtime := newFakeRuntime()
 	olderUpdatedAt := time.UnixMilli(2000)


### PR DESCRIPTION
## Summary
- cherry-pick the stale AgentGUI session loading-state fix from #879 to `main`
- preserve `main`'s imported-session runtime context handling while adding persisted-projection freshness checks
- keep activity-core stale session regression protection for load/upsert paths

## Validation
- go test ./services/tuttid/service/agent
- corepack pnpm --filter @tutti-os/agent-activity-core test
- corepack pnpm --filter @tutti-os/agent-activity-core typecheck
- git diff --check

## Notes
- Cherry-pick conflicts were resolved in `docs/conventions/troubleshooting.md`, `packages/agent/activity-core/src/controller.ts`, and `services/tuttid/service/agent/service_session.go`.
- Local hooks were bypassed because the hook runner invokes pnpm 11.7.0 while this repo requires pnpm 10.11.0; targeted validation above passed with `corepack pnpm 10.11.0`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Session and conversation status now reflect the latest completed turn instead of staying in a loading or running state.
  * Resuming a session now prefers newer saved progress, preventing older live state from overwriting completed results.
  * Session lists and details are more consistent when a completed session is reopened or refreshed.
* **Documentation**
  * Added a troubleshooting note for sessions that appear stuck loading after completion, with guidance on what to check.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->