### PR TITLE
refactor(tuttid): remove dead convenience wrapper shims

### DIFF
--- a/docs/architecture/tutti-agent-integration-plan.md
+++ b/docs/architecture/tutti-agent-integration-plan.md
@@ -143,7 +143,7 @@ Install:            InstallerKindCodexCLILatest（npm @openai/codex + optional-d
 
 - `services/tuttid/service/agent/codex_model_catalog.go`：`CodexCLIModelLister.ListModels` 真实 spawn `codex app-server` → `initialize`（clientInfo `{name:"tuttid", version:"0.1.0"}`）→ `model/list`（limit 200）→ 归一化。
 - `model_catalog.go`：`CachedAgentModelCatalog` 按 provider switch 缓存（codex TTL 30s / error 5s），目前只有 codex/gemini 有 lister。
-- `composer_options.go`：大量 provider switch；composer 设置支持由 `agentprovider.SupportsComposerSettings`（目前 claude-code/codex/gemini）决定。**注意约 line 662、777 存在裸字符串 `provider == "codex"` 比较**，参数化时需一并梳理。
+- `composer_options.go`：大量 provider switch；composer 设置支持目前直接编码在 provider 分支里（claude-code/codex/gemini）。**注意约 line 662、777 存在裸字符串 `provider == "codex"` 比较**，参数化时需一并梳理。
 
 ### 2.9 契约与偏好模型
 
@@ -316,7 +316,7 @@ tutti-agent: command ["tutti-agent","app-server"]  source "tutti-agent-cli"
 
 - `model_catalog.go` 的 `CachedAgentModelCatalog` 加 tutti-agent lister 与缓存分支。
 - **不设静态兜底模型列表**：网关策略当前只放行 `gpt-5.4`，composer 选项必须反映 `model/list` 实时鉴权结果。
-- `agentprovider.SupportsComposerSettings` 加入 `tutti-agent`；`composer_options.go` 各 provider switch（含 line 662/777 的裸 `provider == "codex"` 比较）逐一决策：reasoning effort、plan/permission mode、speed/service-tier 是否对 fork 生效——建议 Phase 0 冒烟后按 fork 实际能力定。
+- `composer_options.go` 各 provider switch 需要加入 `tutti-agent` 决策（含 line 662/777 的裸 `provider == "codex"` 比较）：reasoning effort、plan/permission mode、speed/service-tier 是否对 fork 生效——建议 Phase 0 冒烟后按 fork 实际能力定。
 
 ### 4.6 契约决策：defaultAgentProvider 枚举拆分
 
@@ -456,7 +456,7 @@ daemon 获取宿主登录态 -> account llm-token 签发（legacy account app id
 
 ### WP6 模型目录与 composer
 
-- `services/tuttid/service/agent/`：model lister 泛化、catalog 缓存分支、`SupportsComposerSettings`、`composer_options.go` 各 switch（含裸字符串比较清理）。
+- `services/tuttid/service/agent/`：model lister 泛化、catalog 缓存分支、`composer_options.go` 各 switch（含裸字符串比较清理）。
 
 ### WP7 桌面 workbench 与 AgentGUI
 

--- a/services/tuttid/apierrors/apierrors.go
+++ b/services/tuttid/apierrors/apierrors.go
@@ -158,18 +158,6 @@ func WithParams(params map[string]any) Option {
 	}
 }
 
-func WithRetryable(retryable bool) Option {
-	return func(target *ProtocolError) {
-		target.Retryable = retryable
-	}
-}
-
-func WithCorrelationID(correlationID string) Option {
-	return func(target *ProtocolError) {
-		target.CorrelationID = correlationID
-	}
-}
-
 func New(
 	statusCode int,
 	code tuttigenerated.ApiErrorDetailsCode,
@@ -197,10 +185,6 @@ func EmptyBody(options ...Option) *ProtocolError {
 
 func MalformedRequest(options ...Option) *ProtocolError {
 	return InvalidRequest(ReasonMalformedRequest, options...)
-}
-
-func MethodNotAllowed(options ...Option) *ProtocolError {
-	return New(StatusMethodNotAllowed, tuttigenerated.MethodNotAllowed, ReasonMethodNotAllowed, options...)
 }
 
 func ServiceUnavailable(reason string, options ...Option) *ProtocolError {

--- a/services/tuttid/biz/agentprovider/provider.go
+++ b/services/tuttid/biz/agentprovider/provider.go
@@ -58,12 +58,3 @@ func Normalize(provider string) string {
 func IsSupported(provider string) bool {
 	return Normalize(provider) != ""
 }
-
-func SupportsComposerSettings(provider string) bool {
-	switch Normalize(provider) {
-	case ClaudeCode, Codex, Gemini, TuttiAgent:
-		return true
-	default:
-		return false
-	}
-}

--- a/services/tuttid/builtin-apps/catalog.go
+++ b/services/tuttid/builtin-apps/catalog.go
@@ -113,14 +113,6 @@ func SnapshotForRemoteURL(catalogURL string) (CatalogSnapshot, error) {
 	return snapshotWithSource(remoteCatalogSourceForURL(catalogURL), false)
 }
 
-func RefreshRemoteCatalog() (CatalogSnapshot, error) {
-	return snapshot(true)
-}
-
-func RefreshRemoteCatalogForRemoteURL(catalogURL string) (CatalogSnapshot, error) {
-	return snapshotWithSource(remoteCatalogSourceForURL(catalogURL), true)
-}
-
 func RefreshRemoteCatalogAndWait(ctx context.Context) (CatalogSnapshot, error) {
 	return snapshotAndWait(ctx)
 }

--- a/services/tuttid/builtin-apps/catalog_test.go
+++ b/services/tuttid/builtin-apps/catalog_test.go
@@ -167,9 +167,9 @@ func TestCatalogRetriesRemoteURLFetch(t *testing.T) {
 	t.Cleanup(server.Close)
 	t.Setenv(remoteCatalogURLEnv, server.URL+"/catalog.json")
 
-	snapshot, err := RefreshRemoteCatalog()
+	snapshot, err := snapshot(true)
 	if err != nil {
-		t.Fatalf("RefreshRemoteCatalog() error = %v", err)
+		t.Fatalf("snapshot(true) error = %v", err)
 	}
 	if snapshot.RemoteCatalog.Status != RemoteCatalogLoadStatusLoading {
 		t.Fatalf("remote catalog status = %q, want loading", snapshot.RemoteCatalog.Status)

--- a/services/tuttid/server/server.go
+++ b/services/tuttid/server/server.go
@@ -88,10 +88,6 @@ func isWorkspaceAppServerTokenRoute(method string, segments []string) bool {
 	}
 }
 
-func AddrFromEnv() string {
-	return tuttitypes.ResolveDefaultsFromEnv().Transport.TCPAddr
-}
-
 func ListenerSpecFromEnv() (ListenerSpec, error) {
 	defaults := tuttitypes.ResolveDefaultsFromEnv()
 	accessToken := tuttitypes.EnvOrDefault("TUTTID_ACCESS_TOKEN", "")

--- a/services/tuttid/service/cli/helpers.go
+++ b/services/tuttid/service/cli/helpers.go
@@ -3,7 +3,6 @@ package cli
 import (
 	"context"
 	"fmt"
-	"strconv"
 	"strings"
 
 	workspacebiz "github.com/tutti-os/tutti/services/tuttid/biz/workspace"
@@ -62,28 +61,4 @@ func RequiredStringInput(input map[string]any, key string) (string, error) {
 		return "", MissingRequiredInputError(key)
 	}
 	return value, nil
-}
-
-func IntInput(input map[string]any, key string) (int, bool, error) {
-	raw, ok, err := StringInput(input, key)
-	if err != nil || !ok || raw == "" {
-		return 0, ok, err
-	}
-	value, err := strconv.Atoi(raw)
-	if err != nil {
-		return 0, true, InvalidInputKeyError(key)
-	}
-	return value, true, nil
-}
-
-func Int64Input(input map[string]any, key string) (int64, bool, error) {
-	raw, ok, err := StringInput(input, key)
-	if err != nil || !ok || raw == "" {
-		return 0, ok, err
-	}
-	value, err := strconv.ParseInt(raw, 10, 64)
-	if err != nil {
-		return 0, true, InvalidInputKeyError(key)
-	}
-	return value, true, nil
 }

--- a/services/tuttid/service/cli/helpers_test.go
+++ b/services/tuttid/service/cli/helpers_test.go
@@ -25,13 +25,3 @@ func TestStringInputReportsInvalidKeyType(t *testing.T) {
 		t.Fatalf("err = %q", err.Error())
 	}
 }
-
-func TestIntInputReportsInvalidKey(t *testing.T) {
-	_, _, err := IntInput(map[string]any{"limit": "nope"}, "limit")
-	if !errors.Is(err, ErrInvalidInput) {
-		t.Fatalf("err = %v, want ErrInvalidInput", err)
-	}
-	if !strings.Contains(err.Error(), `invalid input "limit"`) {
-		t.Fatalf("err = %q", err.Error())
-	}
-}

--- a/services/tuttid/types/httputil.go
+++ b/services/tuttid/types/httputil.go
@@ -3,7 +3,6 @@ package types
 import (
 	"crypto/subtle"
 	"encoding/json"
-	"fmt"
 	"net/http"
 	"os"
 	"strings"
@@ -27,23 +26,6 @@ type APIErrorDetails struct {
 
 type APIErrorResponse struct {
 	Error APIErrorDetails `json:"error"`
-}
-
-func DecodeJSON(r *http.Request, dst any) error {
-	if r.Body == nil {
-		return fmt.Errorf("empty body")
-	}
-	defer func() { _ = r.Body.Close() }()
-
-	decoder := json.NewDecoder(r.Body)
-	if err := decoder.Decode(dst); err != nil {
-		if strings.Contains(err.Error(), "EOF") {
-			return fmt.Errorf("empty body")
-		}
-		return fmt.Errorf("decode json: %w", err)
-	}
-
-	return nil
 }
 
 func WriteMethodNotAllowed(w http.ResponseWriter) {
@@ -88,10 +70,6 @@ func WithCORS(next http.Handler) http.Handler {
 }
 
 type BearerTokenAuthorizer func(*http.Request, string) bool
-
-func WithBearerTokenAuth(expectedToken string, next http.Handler) http.Handler {
-	return WithBearerTokenAuthFunc(expectedToken, nil, next)
-}
 
 func WithBearerTokenAuthFunc(expectedToken string, authorizer BearerTokenAuthorizer, next http.Handler) http.Handler {
 	expectedToken = strings.TrimSpace(expectedToken)

--- a/services/tuttid/types/httputil_test.go
+++ b/services/tuttid/types/httputil_test.go
@@ -8,7 +8,7 @@ import (
 
 func TestWithBearerTokenAuthRejectsEmptyExpectedToken(t *testing.T) {
 	called := false
-	handler := WithBearerTokenAuth("", http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+	handler := WithBearerTokenAuthFunc("", nil, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		called = true
 		w.WriteHeader(http.StatusNoContent)
 	}))
@@ -29,7 +29,7 @@ func TestWithBearerTokenAuthRejectsEmptyExpectedToken(t *testing.T) {
 
 func TestWithBearerTokenAuthAllowsMatchingToken(t *testing.T) {
 	called := false
-	handler := WithBearerTokenAuth("desktop-session-token", http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+	handler := WithBearerTokenAuthFunc("desktop-session-token", nil, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		called = true
 		w.WriteHeader(http.StatusNoContent)
 	}))
@@ -50,7 +50,7 @@ func TestWithBearerTokenAuthAllowsMatchingToken(t *testing.T) {
 
 func TestWithBearerTokenAuthAllowsWebSocketQueryToken(t *testing.T) {
 	called := false
-	handler := WithBearerTokenAuth("desktop-session-token", http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+	handler := WithBearerTokenAuthFunc("desktop-session-token", nil, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		called = true
 		w.WriteHeader(http.StatusSwitchingProtocols)
 	}))
@@ -72,7 +72,7 @@ func TestWithBearerTokenAuthAllowsWebSocketQueryToken(t *testing.T) {
 
 func TestWithBearerTokenAuthRejectsQueryTokenWithoutWebSocketUpgrade(t *testing.T) {
 	called := false
-	handler := WithBearerTokenAuth("desktop-session-token", http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+	handler := WithBearerTokenAuthFunc("desktop-session-token", nil, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		called = true
 		w.WriteHeader(http.StatusNoContent)
 	}))


### PR DESCRIPTION
## Summary
- remove unused daemon-only convenience wrappers and aliases in `services/tuttid`
- update the remaining tests to call the live entry points directly
- refresh the agent integration plan doc so it no longer refers to the removed helper

## What these wrappers used to do
- `apierrors.WithRetryable`, `apierrors.WithCorrelationID`, and `apierrors.MethodNotAllowed` were thin option/error constructors kept from an earlier protocol-error helper shape.
- `agentprovider.SupportsComposerSettings` was a boolean helper for an older composer-options gating path before the provider-specific branching settled directly into `composer_options.go`.
- `builtinapps.RefreshRemoteCatalog` and `RefreshRemoteCatalogForRemoteURL` were immediate-refresh aliases over the current snapshot helpers.
- `server.AddrFromEnv` was an older bootstrap convenience that got superseded by `ListenerSpecFromEnv`.
- `service/cli.IntInput` and `Int64Input` were string-parsing wrappers on top of `StringInput` that no current CLI provider still calls.
- `types.DecodeJSON` and `WithBearerTokenAuth` were compatibility wrappers around the current direct JSON decoding paths and `WithBearerTokenAuthFunc`.

## Re-verification
- repo-wide search on latest `main` found no in-repo callers for the removed helpers; the only remaining `MethodNotAllowed` hits are the generated enum values in `services/tuttid/api/generated/types.gen.go`.
- `tsh` and `tsh-server` do not import `github.com/tutti-os/tutti/services/tuttid`, so this daemon-only cleanup has no external Go-package dependents to coordinate.
- `tsh-server` also has no `github.com/tutti-os/tutti` dependency at all.
- tests that previously exercised dead aliases now call the underlying live entry points directly (`snapshot(true)` and `WithBearerTokenAuthFunc`).

## Validation
- `cd services/tuttid && go test ./apierrors ./biz/agentprovider ./builtin-apps ./server ./service/cli ./types`
- `pnpm lint:go`
- `pnpm check:full`

## Docs
- updated `docs/architecture/tutti-agent-integration-plan.md` to remove stale references to `agentprovider.SupportsComposerSettings`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the integration guide to reflect the current configuration approach and clarify how provider-specific behavior should be handled.

* **Refactor**
  * Simplified several internal helper paths and removed older convenience wrappers, while keeping the main user-facing behavior intact.
  * Remote catalog refresh now uses the wait-based flow consistently.

* **Tests**
  * Adjusted test coverage to match the updated refresh and authentication flows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->