### PR TITLE
feat(agent-gui): skip local cwd-missing check for remote runtimes

### DIFF
--- a/packages/agent/gui/agent-gui/agentGuiNode/AgentComposer.spec.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/AgentComposer.spec.tsx
@@ -3048,6 +3048,53 @@ describe("AgentComposer", () => {
     expect(onSubmit).not.toHaveBeenCalled();
   });
 
+  it("skips the missing directory check for remote-cwd runtimes", async () => {
+    mockProjectMissingState.current = true;
+    const onSubmit = vi.fn();
+    const { container } = render(
+      <AgentComposer
+        workspaceId="workspace-1"
+        currentUserId="user-1"
+        provider="codex"
+        draftContent={createDraft("hi")}
+        availableCommands={[] satisfies readonly AgentHostAgentSessionCommand[]}
+        disabled={false}
+        submitDisabled={false}
+        placeholder="placeholder"
+        composerSettings={createComposerSettings({
+          projectLocked: true,
+          selectedProjectPath: "/sandbox/shared",
+          projectPathIsRemote: true
+        })}
+        queuedPrompts={[]}
+        drainingQueuedPromptId={null}
+        canQueueWhileBusy={false}
+        showStopButton={false}
+        activePrompt={null}
+        isInterrupting={false}
+        isSendingTurn={false}
+        isSubmittingPrompt={false}
+        labels={createLabels()}
+        workspaceUserProjectI18n={workspaceUserProjectI18n}
+        onDraftContentChange={vi.fn()}
+        onSettingsChange={vi.fn()}
+        onSubmit={onSubmit}
+        onSendQueuedPromptNext={vi.fn()}
+        onRemoveQueuedPrompt={vi.fn()}
+        onEditQueuedPrompt={vi.fn()}
+        onInterruptCurrentTurn={vi.fn()}
+        onSubmitInteractivePrompt={vi.fn()}
+      />
+    );
+
+    // Even with the probe reporting "missing", a remote-cwd runtime never
+    // mounts it, so no danger notice and the input stays usable.
+    expect(screen.queryByTestId("agent-gui-missing-project-notice")).toBeNull();
+    expect(screen.getByPlaceholderText("placeholder")).not.toBeDisabled();
+    fireEvent.submit(container.querySelector("form")!);
+    expect(onSubmit).toHaveBeenCalledTimes(1);
+  });
+
   it("keeps the project row visible in the hero composer", () => {
     const { container } = render(
       <AgentComposer

--- a/packages/agent/gui/agent-gui/agentGuiNode/AgentComposer.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/AgentComposer.tsx
@@ -2762,7 +2762,10 @@ export function AgentComposer({
   const showProjectMissingProbe =
     !showProjectRow &&
     Boolean(composerSettings.projectLocked) &&
-    selectedProjectPath !== "";
+    selectedProjectPath !== "" &&
+    // Remote runtimes (shared/cloud sandbox) run their cwd off the local
+    // filesystem, so the local existence check would always false-positive.
+    !composerSettings.projectPathIsRemote;
   const activePromptTipId = activePromptTip?.id ?? null;
   const activePromptTipText = activePromptTip
     ? `${labels.promptTipsPrefix}${activePromptTip.label} · ${activePromptTip.prompt}`

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUINodeController.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUINodeController.ts
@@ -2835,6 +2835,7 @@ function areComposerSettingsVMsEqual(
     (left.selectedProjectPath ?? null) ===
       (right.selectedProjectPath ?? null) &&
     Boolean(left.projectLocked) === Boolean(right.projectLocked) &&
+    Boolean(left.projectPathIsRemote) === Boolean(right.projectPathIsRemote) &&
     Boolean(left.modelListCollapsedToLatest) ===
       Boolean(right.modelListCollapsedToLatest) &&
     areComposerSettingOptionListsEqual(
@@ -11271,6 +11272,9 @@ export function useAgentGUINodeController({
           ? (activeConversation?.cwd ?? null)
           : selectedProjectPath,
       projectLocked: activeConversationId !== null,
+      // Remote runtimes (shared/cloud sandbox) run their cwd off the local
+      // filesystem, so the local existence check is skipped downstream.
+      projectPathIsRemote: agentActivityRuntime.projectPathIsRemote,
       // Cursor's live list spans many vendors with several versions each;
       // collapse it to the latest release per model family.
       modelListCollapsedToLatest: composerTargetData.provider === "cursor",
@@ -11303,6 +11307,7 @@ export function useAgentGUINodeController({
     activeSessionReasoningSelection,
     activeSessionSpeedSelection,
     activeSessionRuntimeContext,
+    agentActivityRuntime.projectPathIsRemote,
     composerTargetData.provider,
     draftSettings.permissionModeId,
     draftSettings.planMode,

--- a/packages/agent/gui/agent-gui/agentGuiNode/model/agentGuiNodeTypes.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/model/agentGuiNodeTypes.ts
@@ -146,6 +146,11 @@ export interface AgentGUIComposerSettingsVM {
   permissionConfig?: AgentSessionPermissionConfig | null;
   selectedProjectPath?: string | null;
   projectLocked?: boolean;
+  // Mirrors the injected runtime's `projectPathIsRemote`. When true the session
+  // cwd is not on the local filesystem (e.g. a shared/cloud sandbox), so the
+  // local "working directory missing" existence check is skipped. Project
+  // selection/listing stays available. Absent/false => local (legacy behaviour).
+  projectPathIsRemote?: boolean;
   // Collapse the model list to the latest version per model family (providers
   // whose live lists span many vendors and versions, e.g. Cursor). The
   // currently selected model always stays visible even if older.

--- a/packages/agent/gui/agentActivityRuntime.tsx
+++ b/packages/agent/gui/agentActivityRuntime.tsx
@@ -275,6 +275,14 @@ export interface AgentActivityRuntime {
    * behaviour resolved via the module-global.
    */
   origin?: string;
+  /**
+   * The session cwd is not resolvable on the local filesystem (e.g. a
+   * shared/cloud sandbox not mounted locally), so AgentGUI must not run its
+   * local stat-based "working directory missing" existence check — it would
+   * always false-positive. Absent/false (default) => local, legacy behaviour.
+   * Only that one guard is gated; project selection/listing is unaffected.
+   */
+  projectPathIsRemote?: boolean;
   promptContentUploadSupport?: {
     file?: boolean;
     image?: boolean;


### PR DESCRIPTION
## Problem

The **"Current working directory missing"** notice in the composer is backed by a **local `os.Stat`** on the daemon (`userproject.Service.CheckPath`, `services/tuttid/service/userproject/service.go`). It runs whenever a conversation has a **locked** working directory (`projectLocked` = an already-started session) and a selected path.

For **shared/cloud agents**, the session cwd is an absolute path that lives in a sandbox on the runtime side, **not on the user's local machine**. The local `os.Stat` therefore always reports the directory as missing, so the user gets a red banner and a **disabled composer** for a directory that is perfectly valid on the runtime — a hard block on using a shared agent.

## Approach

Main already models coexisting runtimes via `AgentActivityRuntime.origin` (local vs shared/cloud, #880). This adds a single opt-in capability on that same contract:

- `AgentActivityRuntime.projectPathIsRemote?: boolean` — the runtime declares its cwd is not resolvable on the local filesystem.
- Threaded through `AgentGUIComposerSettingsVM` (controller fills it from the runtime; VM stability comparator + `useMemo` deps updated).
- `AgentComposer` gates `showProjectMissingProbe` on `!projectPathIsRemote`, so the local existence probe never mounts.

When set: no local stat, no danger banner, input stays usable. **Project selection/listing is untouched** — only the local stat-based missing-directory guard is disabled. Absent/false preserves the legacy local behaviour, so existing local runtimes are unaffected.

### Why a boolean fact (not an enum or a `disableXxxCheck` flag)
The gated behaviour is exactly one bit (run the local stat or not), so a single boolean is the parsimonious representation. It lives on the **runtime contract**, so it names a fact the runtime owns (`projectPathIsRemote`) rather than leaking a GUI feature name (`disableProjectMissingCheck`) into the runtime layer. Naming the non-default (remote) case keeps the safe default: absent/false = local = legacy.

## Consumer wiring
SDK consumers that mount a shared/cloud runtime set `projectPathIsRemote: true` on it. Local runtimes need no change.

## Testing
- `pnpm typecheck` clean.
- Added regression test `skips the missing directory check for remote-cwd runtimes` — with the probe reporting "missing", a remote-cwd runtime shows no banner and the composer stays submittable.
- Composer specs: 120 passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling for remote or shared working directories so local “missing project” warnings no longer appear incorrectly.
  * Composer input remains usable in remote sandbox sessions, and submissions continue to work normally.
  
* **Tests**
  * Added coverage for remote runtime behavior to ensure the missing-directory notice stays hidden and form submission still succeeds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->