### PR TITLE
fix(agentcontext): default launcher sessions to visible

### DIFF
--- a/docs/conventions/tutti-cli-contract.md
+++ b/docs/conventions/tutti-cli-contract.md
@@ -161,6 +161,10 @@ targets (`local:codex` and `local:claude-code`). Generic provider-shaped launch
 commands such as `agent start --provider ...` must not create a provider-only
 session when no agent target is available; return a CLI invalid-input error that
 points callers to the provider launcher commands or a target-first launch path.
+`--show` on provider launchers requests AgentGUI activation only; it must not
+change the created session's visibility. User-started sessions should stay on
+the normal visible default; only an explicit `--hidden` launcher input should
+create a hidden session.
 
 ## Naming Rules
 

--- a/services/tuttid/service/cli/providers/agentcontext/provider_test.go
+++ b/services/tuttid/service/cli/providers/agentcontext/provider_test.go
@@ -941,7 +941,7 @@ func TestSkillBundleSkillsValuePreservesMaterializedPathWhenPresent(t *testing.T
 	}
 }
 
-func TestStartCommandDefaultsHeadlessAndShowPublishesLaunch(t *testing.T) {
+func TestStartCommandLeavesVisibilityUnsetAndShowPublishesLaunch(t *testing.T) {
 	sessions := &fakeAgentSessions{}
 	publisher := &fakeAgentGUILaunchPublisher{}
 	provider := NewProviderWithLaunchPublisher(
@@ -957,10 +957,10 @@ func TestStartCommandDefaultsHeadlessAndShowPublishesLaunch(t *testing.T) {
 			Source: "cli",
 		},
 	}); err != nil {
-		t.Fatalf("Handler headless: %v", err)
+		t.Fatalf("Handler default visibility: %v", err)
 	}
-	if sessions.createInput.Visible == nil || *sessions.createInput.Visible {
-		t.Fatalf("Visible = %#v, want false", sessions.createInput.Visible)
+	if sessions.createInput.Visible != nil {
+		t.Fatalf("Visible = %#v, want nil", sessions.createInput.Visible)
 	}
 	if len(publisher.requests) != 0 {
 		t.Fatalf("launch requests = %#v, want none", publisher.requests)
@@ -974,11 +974,65 @@ func TestStartCommandDefaultsHeadlessAndShowPublishesLaunch(t *testing.T) {
 	}); err != nil {
 		t.Fatalf("Handler show: %v", err)
 	}
-	if sessions.createInput.Visible == nil || !*sessions.createInput.Visible {
-		t.Fatalf("Visible = %#v, want true", sessions.createInput.Visible)
+	if sessions.createInput.Visible != nil {
+		t.Fatalf("Visible = %#v, want nil", sessions.createInput.Visible)
 	}
 	if len(publisher.requests) != 1 || publisher.requests[0].AgentSessionID != "SESSION-NEW" || publisher.requests[0].Source != "cli" {
 		t.Fatalf("launch requests = %#v", publisher.requests)
+	}
+}
+
+func TestStartCommandShowDoesNotHideSession(t *testing.T) {
+	sessions := &fakeAgentSessions{}
+	publisher := &fakeAgentGUILaunchPublisher{}
+	provider := NewProviderWithLaunchPublisher(
+		fakeWorkspaceCatalog{startup: workspacebiz.Summary{ID: "workspace-1"}},
+		sessions,
+		publisher,
+	)
+	command := newTestCodexStartCommand(provider)
+
+	if _, err := command.Handler(context.Background(), cliservice.InvokeRequest{
+		Input: map[string]any{
+			"model":  "gpt-5",
+			"prompt": "do work",
+			"show":   "true",
+		},
+		Context: cliservice.InvokeContext{
+			Source: "cli",
+		},
+	}); err != nil {
+		t.Fatalf("Handler show: %v", err)
+	}
+	if sessions.createInput.Visible != nil {
+		t.Fatalf("Visible = %#v, want nil", sessions.createInput.Visible)
+	}
+	if len(publisher.requests) != 1 || publisher.requests[0].Reason != "start_show" {
+		t.Fatalf("launch requests = %#v", publisher.requests)
+	}
+}
+
+func TestStartCommandHiddenCreatesHiddenSession(t *testing.T) {
+	sessions := &fakeAgentSessions{}
+	command := newTestCodexStartCommand(newTestProvider(
+		fakeWorkspaceCatalog{startup: workspacebiz.Summary{ID: "workspace-1"}},
+		sessions,
+	))
+
+	if _, err := command.Handler(context.Background(), cliservice.InvokeRequest{
+		Input: map[string]any{
+			"model":  "gpt-5",
+			"prompt": "do work",
+			"hidden": "true",
+		},
+		Context: cliservice.InvokeContext{
+			Source: "cli",
+		},
+	}); err != nil {
+		t.Fatalf("Handler hidden: %v", err)
+	}
+	if sessions.createInput.Visible == nil || *sessions.createInput.Visible {
+		t.Fatalf("Visible = %#v, want false", sessions.createInput.Visible)
 	}
 }
 

--- a/services/tuttid/service/cli/providers/agentcontext/session_commands.go
+++ b/services/tuttid/service/cli/providers/agentcontext/session_commands.go
@@ -461,7 +461,3 @@ func optionalStringPointer(value string) *string {
 	}
 	return &value
 }
-
-func boolPointer(value bool) *bool {
-	return &value
-}

--- a/services/tuttid/service/cli/providers/agentcontext/session_commands.go
+++ b/services/tuttid/service/cli/providers/agentcontext/session_commands.go
@@ -26,6 +26,7 @@ type startInput struct {
 	Provider        string   `cli:"provider" validate:"required"`
 	Cwd             string   `cli:"cwd"`
 	DisplayPrompt   string   `cli:"display-prompt"`
+	Hidden          bool     `cli:"hidden"`
 	Images          []string `cli:"image" description:"Image file to attach to the initial prompt. May be passed multiple times."`
 	Model           string   `cli:"model"`
 	PermissionMode  string   `cli:"permission-mode"`
@@ -34,12 +35,12 @@ type startInput struct {
 	Show            bool     `cli:"show"`
 	Speed           string   `cli:"speed"`
 	Title           string   `cli:"title"`
-	Visible         bool     `cli:"visible"`
 }
 
 type providerStartInput struct {
 	Cwd             string   `cli:"cwd"`
 	DisplayPrompt   string   `cli:"display-prompt"`
+	Hidden          bool     `cli:"hidden"`
 	Images          []string `cli:"image" description:"Image file to attach to the initial prompt. May be passed multiple times."`
 	Model           string   `cli:"model"`
 	PermissionMode  string   `cli:"permission-mode"`
@@ -48,7 +49,6 @@ type providerStartInput struct {
 	Show            bool     `cli:"show"`
 	Speed           string   `cli:"speed"`
 	Title           string   `cli:"title"`
-	Visible         bool     `cli:"visible"`
 }
 
 type sessionIDInput struct {
@@ -82,6 +82,7 @@ func (p Provider) newStartCommand() cliservice.Command {
 			return p.runStart(ctx, invoke, input.Provider, "", startFields{
 				Cwd:             input.Cwd,
 				DisplayPrompt:   input.DisplayPrompt,
+				Hidden:          input.Hidden,
 				Images:          input.Images,
 				Model:           input.Model,
 				PermissionMode:  input.PermissionMode,
@@ -90,7 +91,6 @@ func (p Provider) newStartCommand() cliservice.Command {
 				Show:            input.Show,
 				Speed:           input.Speed,
 				Title:           input.Title,
-				Visible:         input.Visible,
 			})
 		},
 	})
@@ -133,6 +133,7 @@ func (p Provider) newProviderStartCommand(spec providerStartCommandSpec) cliserv
 type startFields struct {
 	Cwd             string
 	DisplayPrompt   string
+	Hidden          bool
 	Images          []string
 	Model           string
 	PermissionMode  string
@@ -141,7 +142,6 @@ type startFields struct {
 	Show            bool
 	Speed           string
 	Title           string
-	Visible         bool
 }
 
 func (p Provider) runStart(ctx context.Context, invoke framework.InvokeContext, provider string, agentTargetID string, input startFields) (any, error) {
@@ -152,7 +152,6 @@ func (p Provider) runStart(ctx context.Context, invoke framework.InvokeContext, 
 	if agentTargetID == "" {
 		return nil, fmt.Errorf("%w: generic agent start cannot create a provider-only session; use `tutti codex start --prompt ...` or `tutti claude start --prompt ...` instead, or run `tutti agent start --help` to inspect the legacy command shape", cliservice.ErrInvalidInput)
 	}
-	visible := input.Visible || input.Show
 	cwd, err := p.resolveStartCwd(ctx, invoke.WorkspaceID, input.Cwd, invoke.Request.Context)
 	if err != nil {
 		return nil, err
@@ -185,7 +184,7 @@ func (p Provider) runStart(ctx context.Context, invoke framework.InvokeContext, 
 		ReasoningEffort:        optionalStringPointer(reasoningEffort),
 		Speed:                  optionalStringPointer(input.Speed),
 		Title:                  optionalStringPointer(input.Title),
-		Visible:                boolPointer(visible),
+		Visible:                hiddenVisibleOverride(input.Hidden),
 		ConversationDetailMode: defaults.ConversationDetailMode,
 	})
 	if err != nil {
@@ -199,6 +198,14 @@ func (p Provider) runStart(ctx context.Context, invoke framework.InvokeContext, 
 		launchRequested = true
 	}
 	return sessionActionResult{Session: session, LaunchRequested: launchRequested}, nil
+}
+
+func hiddenVisibleOverride(hidden bool) *bool {
+	if !hidden {
+		return nil
+	}
+	visible := false
+	return &visible
 }
 
 func (p Provider) resolveStartCwd(


### PR DESCRIPTION
## Summary
- decouple `--show` from launcher session visibility so showing AgentGUI no longer changes durable session visibility
- default CLI-launched agent sessions to the normal visible behavior and add an explicit `--hidden` opt-in for hidden launches
- cover the launcher visibility semantics in provider tests and document the CLI contract

## Testing
- go test ./services/tuttid/service/cli/providers/agentcontext ./services/tuttid/service/cli/framework ./services/tuttid/service/agent
- pnpm lint:go
- pnpm check:full


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Behavior Changes**
  * Updated the agent start flow so session visibility is no longer changed by the `--show` option.
  * Sessions started normally keep their default visibility.
  * Sessions are created as hidden only when the explicit hidden option is used.

* **Bug Fixes**
  * Improved launch behavior so opening the GUI does not unintentionally affect whether a session is visible.
  * Strengthened test coverage for show/hidden session behavior and launch publishing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->