### PR TITLE
fix(desktop-release): gate stable releases by branch

### DIFF
--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -70,6 +70,50 @@ jobs:
           ref: ${{ steps.target.outputs.release_target }}
           fetch-depth: 0
 
+      - name: Validate stable release branch
+        shell: bash
+        env:
+          RELEASE_EVENT_NAME: ${{ github.event_name }}
+          RELEASE_MODE: ${{ inputs.release_mode }}
+          RELEASE_REF_NAME: ${{ github.ref_name }}
+          RELEASE_REF_TYPE: ${{ github.ref_type }}
+        run: |
+          if [[ "${RELEASE_EVENT_NAME}" != "workflow_dispatch" ]]; then
+            exit 0
+          fi
+
+          case "${RELEASE_MODE:-}" in
+            patch_release|minor_release|major_release)
+              ;;
+            *)
+              exit 0
+              ;;
+          esac
+
+          if [[ "${RELEASE_REF_TYPE}" != "branch" ]]; then
+            echo "Stable desktop release modes must be run from main or a release/* branch." >&2
+            exit 1
+          fi
+
+          case "${RELEASE_REF_NAME}" in
+            main|release/*)
+              ;;
+            *)
+              echo "Stable desktop release modes must be run from main or a release/* branch, not ${RELEASE_REF_NAME}." >&2
+              exit 1
+              ;;
+          esac
+
+          if [[ "${RELEASE_REF_NAME}" == "main" ]]; then
+            release_branch_refs="$(git ls-remote --heads origin "refs/heads/release/*")"
+            if [[ -n "${release_branch_refs}" ]]; then
+              echo "Stable desktop release modes must run from a release/* branch while release branches exist." >&2
+              echo "Found release branches:" >&2
+              printf "%s\n" "${release_branch_refs}" | sed -E "s#^[[:xdigit:]]+[[:space:]]+refs/heads/#- #" >&2
+              exit 1
+            fi
+          fi
+
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:

--- a/docs/conventions/desktop-release.md
+++ b/docs/conventions/desktop-release.md
@@ -58,6 +58,11 @@ Supported manual modes:
 - `explicit_version_release`: publish an explicit release semver such as `0.1.0`, `0.1.0-beta.0`, `0.1.0-rc.0`, `1.13.0-rc.0`, or `2.0.0`
 - `unsigned_dry_run`: build unsigned artifacts without publishing a GitHub Release
 
+Manual stable release modes (`patch_release`, `minor_release`, and `major_release`) are branch-gated before tag resolution or artifact builds:
+
+- the workflow dispatch branch must be `main` or `release/*`
+- if any remote `release/*` branch exists, stable releases must be dispatched from a `release/*` branch instead of `main`
+
 Less common RC bump shapes are still supported by the release resolver, but the manual workflow form intentionally keeps `minor_rc_release` and `major_rc_release` behind explicit version entry to reduce operator choice overload.
 
 The release tag prefix is:

--- a/tools/scripts/desktop-release-config.test.mjs
+++ b/tools/scripts/desktop-release-config.test.mjs
@@ -85,6 +85,32 @@ test("desktop release workflow publishes rc tags as prereleases and keeps stable
   assert.match(workflow, /patch_beta_release\)\s*\n\s*strategy=patch_beta/);
 });
 
+test("desktop release workflow gates manual stable modes by release branch", async () => {
+  const workflow = await readFile(workflowPath, "utf8");
+
+  assert.match(workflow, /name:\s+Validate stable release branch/);
+  assert.match(
+    workflow,
+    /RELEASE_EVENT_NAME:\s+\${{\s*github\.event_name\s*}}/
+  );
+  assert.match(workflow, /RELEASE_REF_NAME:\s+\${{\s*github\.ref_name\s*}}/);
+  assert.match(workflow, /RELEASE_REF_TYPE:\s+\${{\s*github\.ref_type\s*}}/);
+  assert.match(
+    workflow,
+    /if \[\[ "\$\{RELEASE_EVENT_NAME\}" != "workflow_dispatch" \]\]; then/
+  );
+  assert.match(workflow, /patch_release\|minor_release\|major_release\)/);
+  assert.match(workflow, /main\|release\/\*/);
+  assert.match(
+    workflow,
+    /git ls-remote --heads origin "refs\/heads\/release\/\*"/
+  );
+  assert.match(
+    workflow,
+    /Stable desktop release modes must run from a release\/\* branch while release branches exist\./
+  );
+});
+
 test("desktop release workflow schedules a daily Beijing 4:16am rc release", async () => {
   const workflow = await readFile(workflowPath, "utf8");
 


### PR DESCRIPTION
## Summary
- gate manual stable desktop release modes to main or release/* branches
- block main-triggered stable releases when remote release/* branches exist
- document the stable release branch policy and cover it in workflow config tests

## Tests
- node --test tools/scripts/desktop-release-config.test.mjs
- PATH="/Users/wwcome/go/bin:/Users/wwcome/Library/pnpm/store/v11/links/@openai/codex/0.142.5-darwin-arm64/b01cbf72671f584be7439a64b6841f3ad0a150bef8279a6c3292a671627a0b10/node_modules/@openai/codex/vendor/aarch64-apple-darwin/codex-path:/Users/wwcome/Library/pnpm/store/v11/links/@openai/codex/0.142.5-darwin-arm64/b01cbf72671f584be7439a64b6841f3ad0a150bef8279a6c3292a671627a0b10/node_modules/@openai/codex/vendor/aarch64-apple-darwin/codex-path:/Users/wwcome/.tutti/agent/runs/8f953cf1-aeab-48aa-8d1e-c766e4282807/codex-home/tmp/arg0/codex-arg0JJQoyy:/Users/wwcome/.tutti/bin:/Users/wwcome/.homebrew/bin:/Users/wwcome/.homebrew/sbin:/Users/wwcome/.local/bin:/usr/local/bin:/System/Cryptexes/App/usr/bin:/usr/bin:/bin:/usr/sbin:/sbin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/local/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/appleinternal/bin:/opt/pmk/env/global/bin:/Users/wwcome/bin:/Users/wwcome/.npm-global/bin:/Users/wwcome/.n/bin:/Users/wwcome/n/bin:/Users/wwcome/.volta/bin:/Users/wwcome/.asdf/shims:/Users/wwcome/.mise/shims:/Users/wwcome/.bun/bin:/Users/wwcome/Library/pnpm:/opt/homebrew/bin" pnpm check:changed --tail-lines 80
- PATH="/Users/wwcome/go/bin:/Users/wwcome/Library/pnpm/store/v11/links/@openai/codex/0.142.5-darwin-arm64/b01cbf72671f584be7439a64b6841f3ad0a150bef8279a6c3292a671627a0b10/node_modules/@openai/codex/vendor/aarch64-apple-darwin/codex-path:/Users/wwcome/Library/pnpm/store/v11/links/@openai/codex/0.142.5-darwin-arm64/b01cbf72671f584be7439a64b6841f3ad0a150bef8279a6c3292a671627a0b10/node_modules/@openai/codex/vendor/aarch64-apple-darwin/codex-path:/Users/wwcome/.tutti/agent/runs/8f953cf1-aeab-48aa-8d1e-c766e4282807/codex-home/tmp/arg0/codex-arg0JJQoyy:/Users/wwcome/.tutti/bin:/Users/wwcome/.homebrew/bin:/Users/wwcome/.homebrew/sbin:/Users/wwcome/.local/bin:/usr/local/bin:/System/Cryptexes/App/usr/bin:/usr/bin:/bin:/usr/sbin:/sbin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/local/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/appleinternal/bin:/opt/pmk/env/global/bin:/Users/wwcome/bin:/Users/wwcome/.npm-global/bin:/Users/wwcome/.n/bin:/Users/wwcome/n/bin:/Users/wwcome/.volta/bin:/Users/wwcome/.asdf/shims:/Users/wwcome/.mise/shims:/Users/wwcome/.bun/bin:/Users/wwcome/Library/pnpm:/opt/homebrew/bin" git push -u origin fix/desktop-release-stable-branch-gate (pre-push ran pnpm check:full)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added safeguards for manual stable desktop releases so they can only be started from approved branches.
  * If a stable release is triggered from `main`, it now checks for existing release branches and blocks the run when one should be used instead.
* **Documentation**
  * Clarified the branching rules for stable desktop release workflows in the release guide.
* **Tests**
  * Added automated coverage for the new release-branch validation behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->