### PR TITLE
fix(tuttid-preferences): preserve frozen legacy provider defaults

### DIFF
--- a/services/tuttid/service/preferences/service.go
+++ b/services/tuttid/service/preferences/service.go
@@ -82,8 +82,9 @@ func (s Service) Put(ctx context.Context, input PutInput) (preferencesbiz.Deskto
 	preferences, err := s.Store.PutDesktopPreferences(ctx, preferencesbiz.DesktopPreferences{
 		// The legacy provider-keyed defaults are frozen: client input is
 		// ignored so nothing writes the old field anymore; the stored value
-		// is only kept for downgrade compatibility.
-		AgentComposerDefaultsByProvider:             normalizeAgentComposerDefaultsByProvider(stored.AgentComposerDefaultsByProvider),
+		// is only kept for downgrade compatibility and should pass through
+		// unchanged.
+		AgentComposerDefaultsByProvider:             stored.AgentComposerDefaultsByProvider,
 		AgentComposerDefaultsByAgentTarget:          normalizeAgentComposerDefaultsByAgentTarget(agentComposerDefaultsByAgentTarget),
 		AgentGUIConversationRailCollapsedByProvider: normalizeAgentGUIConversationRailCollapsedByProvider(input.AgentGUIConversationRailCollapsedByProvider),
 		AgentConversationDetailMode:                 preferencesbiz.NormalizeDesktopAgentConversationDetailMode(input.AgentConversationDetailMode),
@@ -205,22 +206,6 @@ func normalizeAgentGUIConversationRailCollapsedByProvider(input map[string]bool)
 			continue
 		}
 		result[normalizedProvider] = collapsed
-	}
-	return result
-}
-
-func normalizeAgentComposerDefaultsByProvider(input map[string]preferencesbiz.AgentComposerDefaults) map[string]preferencesbiz.AgentComposerDefaults {
-	result := map[string]preferencesbiz.AgentComposerDefaults{}
-	for provider, defaults := range input {
-		normalizedProvider := agentproviderbiz.Normalize(provider)
-		if normalizedProvider == "" {
-			continue
-		}
-		normalizedDefaults := normalizeAgentComposerDefaults(defaults)
-		if normalizedDefaults.IsZero() {
-			continue
-		}
-		result[normalizedProvider] = normalizedDefaults
 	}
 	return result
 }

--- a/services/tuttid/service/preferences/service_test.go
+++ b/services/tuttid/service/preferences/service_test.go
@@ -501,7 +501,9 @@ func TestServicePutFreezesLegacyComposerDefaultsByProvider(t *testing.T) {
 	store := &preferencesStoreStub{
 		getResult: preferencesbiz.DesktopPreferences{
 			AgentComposerDefaultsByProvider: map[string]preferencesbiz.AgentComposerDefaults{
-				"codex": {Model: "gpt-5"},
+				"codex":             {Model: "gpt-5"},
+				"legacy-unknown":    {Model: "legacy-model"},
+				" spaced-provider ": {Model: " legacy-whitespace "},
 			},
 			Initialized: true,
 		},
@@ -529,8 +531,11 @@ func TestServicePutFreezesLegacyComposerDefaultsByProvider(t *testing.T) {
 		t.Fatalf("Put() error = %v", err)
 	}
 	stored := store.putInput.AgentComposerDefaultsByProvider
-	if len(stored) != 1 || stored["codex"].Model != "gpt-5" {
-		t.Fatalf("stored provider defaults = %#v, want frozen stored value", stored)
+	if len(stored) != 3 ||
+		stored["codex"].Model != "gpt-5" ||
+		stored["legacy-unknown"].Model != "legacy-model" ||
+		stored[" spaced-provider "].Model != " legacy-whitespace " {
+		t.Fatalf("stored provider defaults = %#v, want frozen stored value passed through verbatim", stored)
 	}
 }
 


### PR DESCRIPTION
## Summary
- preserve frozen legacy provider-keyed composer defaults verbatim during desktop preference writes
- remove the now-unused write-time normalization helper from preferences service
- extend service tests to cover unknown and whitespace-preserving legacy keys

## Validation
- go test ./service/preferences
- go build ./... (from services/tuttid)

## Notes
- pnpm build:go currently fails in this environment before Go compilation because builtin app packaging requires missing frontend deps (`vite` / workspace `node_modules`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Preserved existing provider-based composer defaults exactly as stored, avoiding unintended rewriting during preference updates.
  * Improved downgrade compatibility by keeping legacy provider keys and values unchanged, including whitespace-padded and unknown entries.

* **Tests**
  * Expanded coverage to verify that multiple legacy composer default entries are retained without modification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->