### PR TITLE
fix(agent-gui): drop redundant workbench target refs

### DIFF
--- a/packages/agent/gui/workbench/contribution.test.ts
+++ b/packages/agent/gui/workbench/contribution.test.ts
@@ -513,6 +513,84 @@ describe("agent GUI workbench contribution copy", () => {
     ).toBeNull();
   });
 
+  it("drops unresolved dock target payloads back to an unscoped launch", () => {
+    const contribution = createTestAgentGuiWorkbenchContribution({
+      providerTargets: [createLocalAgentGUIProviderTarget("codex")],
+      renderBody: () => null,
+      resolveDockLaunchPayload: () => ({
+        agentTargetId: "shared-agent:missing"
+      }),
+      workspaceId: "workspace-1"
+    });
+    const [dockEntry] = contribution.dockEntries ?? [];
+
+    const launchResult = contribution.onLaunchRequest?.({
+      dockEntryId: dockEntry?.id,
+      layoutConstraints: testLaunchLayout.layoutConstraints,
+      payload: dockEntry?.launchPayload,
+      reason: "dock",
+      surfaceSize: testLaunchLayout.surfaceSize,
+      typeId: agentGuiWorkbenchTypeId,
+      workspaceId: "workspace-1"
+    }) as
+      | {
+          instanceId: string;
+        }
+      | null
+      | undefined;
+
+    expect(launchResult?.instanceId).toContain("agent-gui:codex:panel:");
+    expect(launchResult?.instanceId).not.toContain(":target:");
+    expect(
+      contribution.externalStateSource?.getSnapshotNodeState?.({
+        instanceId: launchResult?.instanceId ?? "",
+        typeId: agentGuiWorkbenchTypeId
+      } as never)
+    ).toBeNull();
+  });
+
+  it("keeps target-only dock payloads while provider targets are still loading", () => {
+    const contribution = createTestAgentGuiWorkbenchContribution({
+      providerTargets: [],
+      providerTargetsLoading: true,
+      renderBody: () => null,
+      resolveDockLaunchPayload: () => ({
+        agentTargetId: "shared-agent:pending"
+      }),
+      workspaceId: "workspace-1"
+    });
+    const [dockEntry] = contribution.dockEntries ?? [];
+
+    const launchResult = contribution.onLaunchRequest?.({
+      dockEntryId: dockEntry?.id,
+      layoutConstraints: testLaunchLayout.layoutConstraints,
+      payload: dockEntry?.launchPayload,
+      reason: "dock",
+      surfaceSize: testLaunchLayout.surfaceSize,
+      typeId: agentGuiWorkbenchTypeId,
+      workspaceId: "workspace-1"
+    }) as
+      | {
+          instanceId: string;
+        }
+      | null
+      | undefined;
+
+    expect(launchResult?.instanceId).toContain("agent-gui:codex:panel:");
+    expect(launchResult?.instanceId).not.toContain(":target:");
+    expect(
+      contribution.externalStateSource?.getSnapshotNodeState?.({
+        instanceId: launchResult?.instanceId ?? "",
+        typeId: agentGuiWorkbenchTypeId
+      } as never)
+    ).toEqual({
+      agentTargetId: "shared-agent:pending",
+      conversationRailCollapsed: false,
+      conversationRailWidthPx: null,
+      lastActiveAgentSessionId: null
+    });
+  });
+
   it("uses package defaults when the host does not provide copy", () => {
     expect(resolveAgentGuiWorkbenchContributionCopy()).toEqual(
       agentGuiWorkbenchDefaultCopy

--- a/packages/agent/gui/workbench/contribution.test.ts
+++ b/packages/agent/gui/workbench/contribution.test.ts
@@ -10,7 +10,10 @@ import {
   type ReactNode
 } from "react";
 import { agentGuiDockIconUrls } from "../dockIcons.ts";
-import { createLocalAgentGUIProviderTarget } from "../providerTargets.ts";
+import {
+  createLocalAgentGUIProviderTarget,
+  createSharedAgentGUIProviderTarget
+} from "../providerTargets.ts";
 import {
   AGENT_GUI_WORKBENCH_NEW_CONVERSATION_EVENT,
   agentGuiWorkbenchDefaultCopy,
@@ -94,9 +97,7 @@ describe("agent GUI workbench contribution copy", () => {
     expect(entries[0]?.label).toBe("Agent");
     expect(entries[0]?.launchPayload).toEqual({
       agentTargetId: "local:claude-code",
-      provider: "claude-code",
-      providerTargetId: "local:claude-code",
-      providerTargetRef: claudeTarget.ref
+      provider: "claude-code"
     });
   });
 
@@ -154,9 +155,7 @@ describe("agent GUI workbench contribution copy", () => {
 
     expect(entries[0]?.launchPayload).toEqual({
       agentTargetId: "daemon-claude",
-      provider: "claude-code",
-      providerTargetId: "daemon-claude",
-      providerTargetRef: enabledClaudeTarget.ref
+      provider: "claude-code"
     });
   });
 
@@ -178,9 +177,28 @@ describe("agent GUI workbench contribution copy", () => {
 
     expect(entries[0]?.launchPayload).toEqual({
       agentTargetId: "daemon-codex",
-      provider: "codex",
-      providerTargetId: "daemon-codex",
-      providerTargetRef: daemonCodexTarget.ref
+      provider: "codex"
+    });
+  });
+
+  it("keeps a legacy provider target id only when no agent target id exists", () => {
+    const sharedTarget = createSharedAgentGUIProviderTarget({
+      label: "Shared Claude",
+      provider: "claude-code",
+      sharedAgentId: "shared-claude"
+    });
+    const entries = buildAgentGuiDockEntries({
+      defaultProvider: "claude-code",
+      label: "Agent",
+      providerAvailability: {
+        "claude-code": true
+      },
+      targets: [sharedTarget]
+    });
+
+    expect(entries[0]?.launchPayload).toEqual({
+      provider: "claude-code",
+      providerTargetId: "shared-agent:shared-claude"
     });
   });
 

--- a/packages/agent/gui/workbench/contribution.test.ts
+++ b/packages/agent/gui/workbench/contribution.test.ts
@@ -96,8 +96,7 @@ describe("agent GUI workbench contribution copy", () => {
     expect(entries[0]?.id).toBe(agentGuiWorkbenchUnifiedDockEntryId());
     expect(entries[0]?.label).toBe("Agent");
     expect(entries[0]?.launchPayload).toEqual({
-      agentTargetId: "local:claude-code",
-      provider: "claude-code"
+      agentTargetId: "local:claude-code"
     });
   });
 
@@ -122,8 +121,8 @@ describe("agent GUI workbench contribution copy", () => {
     expect(readDockEntryIconImageSrcs(entries[0]?.icon)).toEqual([
       "app://icons/agent-unified.png"
     ]);
-    expect(entries[0]?.launchPayload).toMatchObject({
-      provider: "codex"
+    expect(entries[0]?.launchPayload).toEqual({
+      agentTargetId: "local:codex"
     });
   });
 
@@ -154,8 +153,7 @@ describe("agent GUI workbench contribution copy", () => {
     });
 
     expect(entries[0]?.launchPayload).toEqual({
-      agentTargetId: "daemon-claude",
-      provider: "claude-code"
+      agentTargetId: "daemon-claude"
     });
   });
 
@@ -176,8 +174,7 @@ describe("agent GUI workbench contribution copy", () => {
     });
 
     expect(entries[0]?.launchPayload).toEqual({
-      agentTargetId: "daemon-codex",
-      provider: "codex"
+      agentTargetId: "daemon-codex"
     });
   });
 
@@ -197,7 +194,6 @@ describe("agent GUI workbench contribution copy", () => {
     });
 
     expect(entries[0]?.launchPayload).toEqual({
-      provider: "claude-code",
       providerTargetId: "shared-agent:shared-claude"
     });
   });
@@ -356,16 +352,14 @@ describe("agent GUI workbench contribution copy", () => {
       renderBody: () => null,
       resolveDockLaunchPayload: () => ({
         agentTargetId: claudeTarget.agentTargetId,
-        provider: "claude-code",
-        providerTargetId: claudeTarget.targetId,
-        providerTargetRef: claudeTarget.ref
+        providerTargetId: claudeTarget.targetId
       }),
       workspaceId: "workspace-1"
     });
     const [dockEntry] = contribution.dockEntries ?? [];
 
-    expect(dockEntry?.launchPayload).toMatchObject({
-      provider: "codex"
+    expect(dockEntry?.launchPayload).toEqual({
+      agentTargetId: "local:codex"
     });
 
     const launchResult = contribution.onLaunchRequest?.({

--- a/packages/agent/gui/workbench/contribution.ts
+++ b/packages/agent/gui/workbench/contribution.ts
@@ -415,8 +415,15 @@ export function createAgentGuiWorkbenchContribution(
       const launchPayload = resolveAgentGuiWorkbenchLaunchPayload(request, {
         resolveDockLaunchPayload: input.resolveDockLaunchPayload
       });
-      const descriptorPayload = withResolvedProviderInLaunchPayload(
+      const scopedLaunchPayload = withoutUnresolvedTargetLaunchPayload(
         launchPayload,
+        {
+          targets: input.providerTargets,
+          providerTargetsLoading: input.providerTargetsLoading
+        }
+      );
+      const descriptorPayload = withResolvedProviderInLaunchPayload(
+        scopedLaunchPayload,
         {
           targets: input.providerTargets,
           providerTargetsLoading: input.providerTargetsLoading
@@ -444,7 +451,7 @@ export function createAgentGuiWorkbenchContribution(
       const instanceId = existingInstanceId ?? descriptorInstanceId;
       const title = copy.nodeTitle;
       const providerTarget = providerTargetLaunchPayloadFromRequest(
-        launchPayload
+        scopedLaunchPayload
       );
       const launchAgentTargetId =
         providerTarget.agentTargetId ?? providerTarget.providerTargetId;
@@ -1034,6 +1041,39 @@ function withResolvedProviderInLaunchPayload(
     input
   );
   return provider ? { ...typedPayload, provider } : payload;
+}
+
+function withoutUnresolvedTargetLaunchPayload(
+  payload: unknown,
+  input: Pick<
+    BuildAgentGuiDockEntriesInput,
+    "providerTargetsLoading" | "targets"
+  >
+): unknown {
+  if (!payload || typeof payload !== "object" || Array.isArray(payload)) {
+    return payload;
+  }
+  if (input.providerTargetsLoading === true || input.targets == null) {
+    return payload;
+  }
+  const target = providerTargetLaunchPayloadFromRequest(payload);
+  if (!target.agentTargetId && !target.providerTargetId) {
+    return payload;
+  }
+  if (
+    resolveWorkbenchLaunchProviderFromTargetPayload(payload, {
+      providerTargetsLoading: false,
+      targets: input.targets
+    })
+  ) {
+    return payload;
+  }
+  const {
+    agentTargetId: _agentTargetId,
+    providerTargetId: _providerTargetId,
+    ...rest
+  } = payload as Record<string, unknown>;
+  return rest;
 }
 
 function createAgentGuiWorkbenchPreviewContent(input: {

--- a/packages/agent/gui/workbench/contribution.ts
+++ b/packages/agent/gui/workbench/contribution.ts
@@ -420,7 +420,6 @@ export function createAgentGuiWorkbenchContribution(
         dockEntryId,
         instanceId: descriptorInstanceId,
         openInNewWindow,
-        provider,
         reuseDockEntryNode,
         reuseExistingSessionNode,
         targetAgentSessionId

--- a/packages/agent/gui/workbench/contribution.ts
+++ b/packages/agent/gui/workbench/contribution.ts
@@ -415,6 +415,13 @@ export function createAgentGuiWorkbenchContribution(
       const launchPayload = resolveAgentGuiWorkbenchLaunchPayload(request, {
         resolveDockLaunchPayload: input.resolveDockLaunchPayload
       });
+      const descriptorPayload = withResolvedProviderInLaunchPayload(
+        launchPayload,
+        {
+          targets: input.providerTargets,
+          providerTargetsLoading: input.providerTargetsLoading
+        }
+      );
       const {
         activation,
         dockEntryId,
@@ -425,7 +432,7 @@ export function createAgentGuiWorkbenchContribution(
         targetAgentSessionId
       } = createAgentGuiWorkbenchLaunchDescriptor({
         ...request,
-        payload: launchPayload
+        payload: descriptorPayload
       });
       // Locate an already-open node currently showing this session (its launch
       // instanceId may differ from the session-keyed one, e.g. a conversation
@@ -544,7 +551,10 @@ export function buildAgentGuiDockEntries(
 ): WorkbenchHostDockEntry[] {
   const sectionId = input.sectionId ?? "agents";
   const launchPayload = resolveAgentGuiUnifiedDockLaunchPayload(input);
-  const provider = launchPayload.provider;
+  const provider =
+    explicitProviderFromLaunchPayload(launchPayload) ??
+    resolveWorkbenchLaunchProviderFromTargetPayload(launchPayload, input) ??
+    resolveUnifiedAgentGuiDockProvider(input);
   const unifiedTileIconUrls = resolveAgentGuiUnifiedDockTileIconUrls(
     input.dockIconUrls
   );
@@ -581,14 +591,13 @@ export function resolveAgentGuiUnifiedDockLaunchPayload(
     | "targets"
   >
 ): {
-  provider: AgentGuiWorkbenchProvider;
   agentTargetId?: string;
   providerTargetId?: string;
+  provider?: AgentGuiWorkbenchProvider;
 } {
   const target = resolveUnifiedAgentGuiDockTarget(input);
   if (target) {
     return {
-      provider: target.provider,
       ...(target.agentTargetId ? { agentTargetId: target.agentTargetId } : {}),
       ...(target.agentTargetId ? {} : { providerTargetId: target.targetId })
     };
@@ -968,6 +977,63 @@ function providerTargetLaunchPayloadFromRequest(
         ? providerTargetId.trim()
         : null
   };
+}
+
+function explicitProviderFromLaunchPayload(
+  payload: unknown
+): AgentGuiWorkbenchProvider | null {
+  if (!payload || typeof payload !== "object" || Array.isArray(payload)) {
+    return null;
+  }
+  const provider = (payload as { provider?: unknown }).provider;
+  return isAgentGuiWorkbenchProvider(provider) ? provider : null;
+}
+
+function resolveWorkbenchLaunchProviderFromTargetPayload(
+  payload: unknown,
+  input: Pick<
+    BuildAgentGuiDockEntriesInput,
+    "providerTargetsLoading" | "targets"
+  >
+): AgentGuiWorkbenchProvider | null {
+  const providerTarget = providerTargetLaunchPayloadFromRequest(payload);
+  const targetId =
+    providerTarget.agentTargetId ?? providerTarget.providerTargetId ?? null;
+  if (!targetId) {
+    return null;
+  }
+  const targets = normalizeAgentGUIProviderTargets(input.targets, {
+    useStaticCatalog:
+      input.providerTargetsLoading !== true && input.targets == null
+  });
+  const target =
+    targets.find((item) => item.agentTargetId === targetId) ??
+    targets.find((item) => item.targetId === targetId) ??
+    null;
+  return target && isAgentGuiWorkbenchProvider(target.provider)
+    ? target.provider
+    : null;
+}
+
+function withResolvedProviderInLaunchPayload(
+  payload: unknown,
+  input: Pick<
+    BuildAgentGuiDockEntriesInput,
+    "providerTargetsLoading" | "targets"
+  >
+): unknown {
+  if (!payload || typeof payload !== "object" || Array.isArray(payload)) {
+    return payload;
+  }
+  if (explicitProviderFromLaunchPayload(payload)) {
+    return payload;
+  }
+  const typedPayload = payload as Record<string, unknown>;
+  const provider = resolveWorkbenchLaunchProviderFromTargetPayload(
+    payload,
+    input
+  );
+  return provider ? { ...typedPayload, provider } : payload;
 }
 
 function createAgentGuiWorkbenchPreviewContent(input: {

--- a/packages/agent/gui/workbench/contribution.ts
+++ b/packages/agent/gui/workbench/contribution.ts
@@ -43,10 +43,7 @@ import type {
   AgentGuiWorkbenchState
 } from "./types.ts";
 import { normalizeAgentGUIProviderTargets } from "../providerTargets.ts";
-import type {
-  AgentGUIProviderTarget,
-  AgentGUIProviderTargetRef
-} from "../types.ts";
+import type { AgentGUIProviderTarget } from "../types.ts";
 
 export const agentGuiWorkbenchDefaultNodeFrame: WorkbenchFrame = {
   height: 560,
@@ -441,8 +438,7 @@ export function createAgentGuiWorkbenchContribution(
       const instanceId = existingInstanceId ?? descriptorInstanceId;
       const title = copy.nodeTitle;
       const providerTarget = providerTargetLaunchPayloadFromRequest(
-        launchPayload,
-        provider
+        launchPayload
       );
       const launchAgentTargetId =
         providerTarget.agentTargetId ?? providerTarget.providerTargetId;
@@ -464,8 +460,7 @@ export function createAgentGuiWorkbenchContribution(
         });
       } else if (
         providerTarget.agentTargetId ||
-        providerTarget.providerTargetId ||
-        providerTarget.providerTargetRef
+        providerTarget.providerTargetId
       ) {
         const previousState = nodeStateSource.readNodeState({
           instanceId,
@@ -590,15 +585,13 @@ export function resolveAgentGuiUnifiedDockLaunchPayload(
   provider: AgentGuiWorkbenchProvider;
   agentTargetId?: string;
   providerTargetId?: string;
-  providerTargetRef?: AgentGUIProviderTargetRef;
 } {
   const target = resolveUnifiedAgentGuiDockTarget(input);
   if (target) {
     return {
       provider: target.provider,
       ...(target.agentTargetId ? { agentTargetId: target.agentTargetId } : {}),
-      providerTargetId: target.targetId,
-      providerTargetRef: target.ref
+      ...(target.agentTargetId ? {} : { providerTargetId: target.targetId })
     };
   }
   return {
@@ -952,25 +945,20 @@ function isAgentGuiProviderAvailable(
 }
 
 function providerTargetLaunchPayloadFromRequest(
-  payload: unknown,
-  expectedProvider: AgentGuiWorkbenchProvider
+  payload: unknown
 ): {
   agentTargetId: string | null;
   providerTargetId: string | null;
-  providerTargetRef: AgentGUIProviderTargetRef | null;
 } {
   if (!payload || typeof payload !== "object" || Array.isArray(payload)) {
     return {
       agentTargetId: null,
-      providerTargetId: null,
-      providerTargetRef: null
+      providerTargetId: null
     };
   }
   const agentTargetId = (payload as { agentTargetId?: unknown }).agentTargetId;
   const providerTargetId = (payload as { providerTargetId?: unknown })
     .providerTargetId;
-  const providerTargetRef = (payload as { providerTargetRef?: unknown })
-    .providerTargetRef;
   return {
     agentTargetId:
       typeof agentTargetId === "string" && agentTargetId.trim()
@@ -979,20 +967,6 @@ function providerTargetLaunchPayloadFromRequest(
     providerTargetId:
       typeof providerTargetId === "string" && providerTargetId.trim()
         ? providerTargetId.trim()
-        : null,
-    providerTargetRef:
-      providerTargetRef &&
-      typeof providerTargetRef === "object" &&
-      !Array.isArray(providerTargetRef) &&
-      (providerTargetRef as { provider?: unknown }).provider ===
-        expectedProvider &&
-      typeof (providerTargetRef as { kind?: unknown }).kind === "string" &&
-      (providerTargetRef as { kind: string }).kind.trim()
-        ? {
-            ...(providerTargetRef as AgentGUIProviderTargetRef),
-            kind: (providerTargetRef as { kind: string }).kind.trim(),
-            provider: expectedProvider
-          }
         : null
   };
 }

--- a/packages/agent/gui/workbench/launch.test.ts
+++ b/packages/agent/gui/workbench/launch.test.ts
@@ -169,6 +169,21 @@ describe("agent gui workbench launch contract", () => {
     expect(descriptor.provider).toBe("claude-code");
   });
 
+  it("keeps unified aggregate target-only launches unscoped until provider is explicit", () => {
+    const descriptor = createAgentGuiWorkbenchLaunchDescriptor({
+      dockEntryId: agentGuiWorkbenchUnifiedDockEntryId(),
+      payload: {
+        agentTargetId: "shared-agent:missing"
+      },
+      typeId: "agent-gui"
+    });
+
+    expect(descriptor.dockEntryId).toBe("agent-gui:unified");
+    expect(descriptor.instanceId).toContain("agent-gui:codex:panel:");
+    expect(descriptor.instanceId).not.toContain(":target:");
+    expect(descriptor.provider).toBe("codex");
+  });
+
   it("creates draft prompt launch requests for provider dock entries", () => {
     expect(
       createAgentGuiWorkbenchDraftLaunchRequest({

--- a/packages/agent/gui/workbench/launch.ts
+++ b/packages/agent/gui/workbench/launch.ts
@@ -210,6 +210,7 @@ export function createAgentGuiWorkbenchLaunchDescriptor(
     provider,
     requestedDockEntryId: request.dockEntryId
   });
+  const scopedAgentTargetId = scopedAgentTargetIdFromLaunchRequest(request);
   const prefillPrompt = prefillPromptFromLaunchPayload(request.payload);
   if (prefillPrompt) {
     const openInNewWindow = openInNewWindowFromLaunchPayload(request.payload);
@@ -220,9 +221,7 @@ export function createAgentGuiWorkbenchLaunchDescriptor(
       },
       dockEntryId,
       instanceId: createAgentGuiWorkbenchInstanceId({
-        agentTargetId: openInNewWindow
-          ? null
-          : agentTargetIdFromLaunchPayload(request.payload),
+        agentTargetId: openInNewWindow ? null : scopedAgentTargetId,
         provider
       }),
       openInNewWindow,
@@ -240,9 +239,7 @@ export function createAgentGuiWorkbenchLaunchDescriptor(
   const openInNewWindow = openInNewWindowFromLaunchPayload(request.payload);
   const instanceId = createAgentGuiWorkbenchInstanceId({
     agentSessionId: null,
-    agentTargetId: openInNewWindow
-      ? null
-      : agentTargetIdFromLaunchPayload(request.payload),
+    agentTargetId: openInNewWindow ? null : scopedAgentTargetId,
     provider
   });
 
@@ -328,6 +325,22 @@ function prefillPromptFromLaunchPayload(
   };
 }
 
+function scopedAgentTargetIdFromLaunchRequest(
+  request: AgentGuiWorkbenchLaunchRequestInput
+): string | null {
+  const agentTargetId = agentTargetIdFromLaunchPayload(request.payload);
+  if (!agentTargetId) {
+    return null;
+  }
+  if (explicitProviderFromLaunchPayload(request.payload)) {
+    return agentTargetId;
+  }
+  return agentGuiWorkbenchDockIdentityFromIdentifier(request.dockEntryId)
+    ?.kind === "legacyProvider"
+    ? agentTargetId
+    : null;
+}
+
 function normalizeAgentGuiWorkbenchUserProjectPath(
   value: string | null | undefined
 ): string | null {
@@ -354,6 +367,16 @@ function agentTargetIdFromLaunchPayload(payload: unknown): string | null {
   return typeof agentTargetId === "string" && agentTargetId.trim()
     ? agentTargetId.trim()
     : null;
+}
+
+function explicitProviderFromLaunchPayload(
+  payload: unknown
+): AgentGuiWorkbenchProvider | null {
+  if (!payload || typeof payload !== "object" || Array.isArray(payload)) {
+    return null;
+  }
+  const provider = (payload as { provider?: unknown }).provider;
+  return isAgentGuiWorkbenchProvider(provider) ? provider : null;
 }
 
 function openInNewWindowFromLaunchPayload(payload: unknown): boolean {


### PR DESCRIPTION
## Summary
- stop emitting redundant `providerTargetRef` values in unified workbench dock launch payloads
- keep `providerTargetId` only as a fallback for targets that still lack `agentTargetId`
- update workbench tests to cover the narrowed payload contract

## Validation
- `pnpm check:agent-activity-runtime-boundaries`
- `pnpm --filter @tutti-os/agent-gui test` *(fails: `vitest` missing because workspace `node_modules` is absent)*
- `pnpm typecheck` *(fails: `tsgo` missing because workspace `node_modules` is absent)*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Unified dock launches now support target-only payloads, automatically resolving the best matching provider when available.

* **Bug Fixes**
  * Improved handling of incomplete launch payloads so unresolved targeting is dropped instead of being carried into the session.
  * Preserved legacy targeting behavior only when no agent target can be scoped, reducing unexpected targeting changes.
  * Instance identifiers now consistently reflect the intended scope across launch scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->