### PR TITLE
fix(agentstatus): give each Cursor auth probe its own timeout budget

### DIFF
--- a/services/tuttid/service/agentstatus/cursor_auth.go
+++ b/services/tuttid/service/agentstatus/cursor_auth.go
@@ -7,31 +7,56 @@ import (
 	"os/exec"
 	"regexp"
 	"strings"
+	"time"
 
 	"github.com/tutti-os/tutti/packages/agent/daemon/runtimecmd"
 )
 
+const cursorAuthStatusProbeCount = 3
+
 func runCursorAuthStatusCommand(ctx context.Context, binaryPath string, env []string) (AuthInfo, bool) {
-	commandCtx, cancel := context.WithTimeout(ctx, authStatusCommandTimeout)
-	defer cancel()
 	proxyEnv := runtimecmd.InjectSystemProxyEnv(env)
 
-	if auth, ok := runCursorCLICommand(commandCtx, binaryPath, []string{"about", "--format", "json"}, proxyEnv); ok {
-		if parsed, ok := parseCursorAboutOutput(auth); ok {
-			return parsed, true
-		}
+	attempts := []struct {
+		args  []string
+		parse func([]byte) (AuthInfo, bool)
+	}{
+		{
+			args:  []string{"about", "--format", "json"},
+			parse: parseCursorAboutOutput,
+		},
+		{
+			args:  []string{"about"},
+			parse: parseCursorAboutOutput,
+		},
+		{
+			args:  []string{"status"},
+			parse: parseCursorAuthStatusOutput,
+		},
 	}
-	if auth, ok := runCursorCLICommand(commandCtx, binaryPath, []string{"about"}, proxyEnv); ok {
-		if parsed, ok := parseCursorAboutOutput(auth); ok {
-			return parsed, true
+	for _, attempt := range attempts {
+		attemptCtx, cancel := cursorAuthStatusAttemptContext(ctx)
+		auth, ok := runCursorCLICommand(attemptCtx, binaryPath, attempt.args, proxyEnv)
+		cancel()
+		if !ok {
+			continue
 		}
-	}
-	if auth, ok := runCursorCLICommand(commandCtx, binaryPath, []string{"status"}, proxyEnv); ok {
-		if parsed, ok := parseCursorAuthStatusOutput(auth); ok {
+		if parsed, ok := attempt.parse(auth); ok {
 			return parsed, true
 		}
 	}
 	return AuthInfo{}, false
+}
+
+func cursorAuthStatusAttemptContext(parent context.Context) (context.Context, context.CancelFunc) {
+	if parent == nil {
+		parent = context.Background()
+	}
+	return context.WithTimeout(parent, cursorAuthStatusAttemptTimeout())
+}
+
+func cursorAuthStatusAttemptTimeout() time.Duration {
+	return authStatusCommandTimeout / cursorAuthStatusProbeCount
 }
 
 func runCursorCLICommand(

--- a/services/tuttid/service/agentstatus/cursor_auth_test.go
+++ b/services/tuttid/service/agentstatus/cursor_auth_test.go
@@ -1,0 +1,42 @@
+package agentstatus
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+func TestCursorAuthStatusAttemptTimeout(t *testing.T) {
+	want := authStatusCommandTimeout / cursorAuthStatusProbeCount
+	if got := cursorAuthStatusAttemptTimeout(); got != want {
+		t.Fatalf("cursorAuthStatusAttemptTimeout() = %s, want %s", got, want)
+	}
+}
+
+func TestCursorAuthStatusAttemptContextsAreIndependent(t *testing.T) {
+	parent, cancel := context.WithTimeout(context.Background(), authStatusCommandTimeout)
+	defer cancel()
+
+	ctx1, cancel1 := cursorAuthStatusAttemptContext(parent)
+	deadline1, ok1 := ctx1.Deadline()
+	cancel1()
+
+	time.Sleep(20 * time.Millisecond)
+
+	ctx2, cancel2 := cursorAuthStatusAttemptContext(parent)
+	deadline2, ok2 := ctx2.Deadline()
+	cancel2()
+
+	if !ok1 || !ok2 {
+		t.Fatalf("expected attempt deadlines: ok1=%v ok2=%v", ok1, ok2)
+	}
+	if !deadline2.After(deadline1) {
+		t.Fatalf("second attempt deadline %v should be after first %v", deadline2, deadline1)
+	}
+
+	remaining := time.Until(deadline2)
+	wantRemaining := cursorAuthStatusAttemptTimeout()
+	if remaining < wantRemaining-50*time.Millisecond || remaining > wantRemaining+50*time.Millisecond {
+		t.Fatalf("second attempt remaining %s, want ~%s", remaining, wantRemaining)
+	}
+}


### PR DESCRIPTION
Split the shared 5s auth-status context across about/status fallbacks so a slow first probe no longer cancels later attempts before they can run.

## Summary

<!-- What changed and why? -->

## Verification

<!-- Commands run, manual checks, or why verification is not applicable. -->

## Checklist

- [ ] I kept the change focused on one concern.
- [ ] I updated documentation when behavior, setup, or contributor workflow changed.
- [ ] I updated all README/CONTRIBUTING language variants when changing their English source.
- [ ] I ran the lowest meaningful local checks for the changed surface.
- [ ] My commits are signed off with DCO when required: `git commit -s`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Cursor auth status detection to try multiple checks and stop at the first successful result.
  * Updated timeout handling so each auth status attempt gets its own shorter time window, reducing the chance of one slow check blocking others.
  * Added coverage to verify timeout calculations and that each attempt uses an independent deadline.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->