### PR TITLE
feat(agent-gui): add provider target rail badges

### DIFF
--- a/docs/architecture/agent-gui-node.md
+++ b/docs/architecture/agent-gui-node.md
@@ -1311,6 +1311,9 @@ telemetry, and provider execution policy.
 AgentGUI owns only target display and passthrough:
 
 - show `target.label` for new-session surfaces
+- render optional `target.badge` as target presentation metadata on provider
+  rail tiles; product ownership, sharing, avatar, or availability semantics
+  stay in the host-projected target data
 - keep provider behavior keyed by `target.provider`
 - persist `agentTargetId` in new workbench node state when the host target has
   one

--- a/packages/agent/gui/agent-gui/agentGuiNode/AgentGUINode.styles.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/AgentGUINode.styles.ts
@@ -140,6 +140,8 @@ const styles = {
   providerRailAvatar: "agent-gui-node__provider-rail-avatar",
   providerRailAvatarIcon: "agent-gui-node__provider-rail-avatar-icon",
   providerRailAvatarImage: "agent-gui-node__provider-rail-avatar-image",
+  providerRailBadge: "agent-gui-node__provider-rail-badge",
+  providerRailBadgeImage: "agent-gui-node__provider-rail-badge-image",
   providerRailLaunchpadIcon: "agent-gui-node__provider-rail-launchpad-icon",
   emptyHeroIconSlot: "agent-gui-node__empty-hero-icon-slot",
   emptyHeroLaunchpadIcon: "agent-gui-node__empty-hero-launchpad-icon",

--- a/packages/agent/gui/agent-gui/agentGuiNode/AgentGUINodeView.layout.spec.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/AgentGUINodeView.layout.spec.tsx
@@ -1444,6 +1444,46 @@ describe("AgentGUINodeView layout persistence", () => {
     expect(screen.queryByRole("tab", { name: "Hermes" })).toBeNull();
   });
 
+  it("renders provider target badges on rail tiles", () => {
+    const { container } = renderAgentGUINodeView({
+      viewModel: {
+        ...createViewModel(),
+        providerRailMode: "exact",
+        providerTargets: [
+          {
+            targetId: "shared-agent:alice-codex",
+            provider: "codex",
+            ref: {
+              kind: "shared-agent",
+              provider: "codex",
+              sharedAgentId: "alice-codex"
+            },
+            label: "Alice's Codex",
+            badge: {
+              iconUrl: "app://alice-avatar.png",
+              label: "Alice avatar"
+            }
+          }
+        ],
+        providerTargetsLoading: false
+      }
+    });
+
+    expect(
+      screen.getByRole("tab", { name: "Alice's Codex, Alice avatar" })
+    ).toBeInTheDocument();
+    expect(
+      container.querySelector(".agent-gui-node__provider-rail-badge")
+    ).not.toBeNull();
+    expect(
+      container
+        .querySelector<HTMLImageElement>(
+          ".agent-gui-node__provider-rail-badge-image"
+        )
+        ?.getAttribute("src")
+    ).toBe("app://alice-avatar.png");
+  });
+
   it("preserves the host-provided target order in exact rail mode", () => {
     renderAgentGUINodeView({
       viewModel: {

--- a/packages/agent/gui/agent-gui/agentGuiNode/AgentGUINodeView.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/AgentGUINodeView.tsx
@@ -4835,6 +4835,17 @@ function agentGUIProviderRailLabel(
   return targetLabel;
 }
 
+function agentGUIProviderRailAriaLabel(
+  label: string,
+  badgeLabel: string | null | undefined
+): string {
+  const normalizedBadgeLabel = badgeLabel?.trim() ?? "";
+  if (!normalizedBadgeLabel || normalizedBadgeLabel === label) {
+    return label;
+  }
+  return `${label}, ${normalizedBadgeLabel}`;
+}
+
 function agentGUIProviderTargetMatchesConversationFilter(
   target: AgentGUINodeViewModel["providerTargets"][number],
   filter: AgentGUINodeViewModel["conversationFilter"]
@@ -5361,12 +5372,16 @@ const AgentGUIProviderRail = memo(function AgentGUIProviderRail({
             target.label,
             labels
           );
+          const ariaLabel = agentGUIProviderRailAriaLabel(
+            label,
+            target.badge?.label
+          );
           const tile = (
             <button
               key={`${target.provider}:${target.targetId}`}
               type="button"
               role="tab"
-              aria-label={label}
+              aria-label={ariaLabel}
               aria-selected={providerSelected}
               className={styles.providerRailTile}
               data-disabled={target.disabled === true ? "true" : undefined}
@@ -5401,6 +5416,16 @@ const AgentGUIProviderRail = memo(function AgentGUIProviderRail({
                     target.iconUrl
                   )}
                 />
+                {target.badge?.iconUrl ? (
+                  <span aria-hidden="true" className={styles.providerRailBadge}>
+                    <img
+                      alt=""
+                      className={styles.providerRailBadgeImage}
+                      draggable={false}
+                      src={target.badge.iconUrl}
+                    />
+                  </span>
+                ) : null}
               </span>
             </button>
           );

--- a/packages/agent/gui/app/renderer/agentactivity.css
+++ b/packages/agent/gui/app/renderer/agentactivity.css
@@ -8598,6 +8598,7 @@ html[data-theme="light"] [data-message-center-item-id].agent-gui-edge-glow {
 }
 
 .agent-gui-node__provider-rail-avatar {
+  position: relative;
   box-sizing: border-box;
   display: grid;
   width: 32px;
@@ -8671,6 +8672,28 @@ html[data-theme="light"] [data-message-center-item-id].agent-gui-edge-glow {
   height: 28px;
   border-radius: 6px;
   object-fit: contain;
+}
+
+.agent-gui-node__provider-rail-badge {
+  position: absolute;
+  right: -4px;
+  bottom: -4px;
+  box-sizing: border-box;
+  display: grid;
+  width: 16px;
+  height: 16px;
+  place-items: center;
+  overflow: hidden;
+  border: 1px solid #fff;
+  border-radius: 999px;
+  background: #fff;
+  pointer-events: none;
+}
+
+.agent-gui-node__provider-rail-badge-image {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
 }
 
 .agent-gui-node__provider-rail-launchpad-icon {

--- a/packages/agent/gui/index.ts
+++ b/packages/agent/gui/index.ts
@@ -33,6 +33,7 @@ export type {
   AgentGUIProviderReadinessGateAction,
   AgentGUIProviderReadinessGateStatus,
   AgentGUIProviderTarget,
+  AgentGUIProviderTargetBadge,
   AgentGUIProviderTargetRef
 } from "./types";
 export {

--- a/packages/agent/gui/providerTargets.spec.ts
+++ b/packages/agent/gui/providerTargets.spec.ts
@@ -139,6 +139,10 @@ describe("agent gui provider targets", () => {
         sharedAgentId: " agent-1 ",
         agentTargetId: " cp-target-1 ",
         label: "Alice's Codex",
+        badge: {
+          iconUrl: " app://alice-avatar.png ",
+          label: " Alice avatar "
+        },
         ownerLabel: " Alice ",
         iconUrl: " app://alice.png ",
         unavailableReason: " owner_offline ",
@@ -158,6 +162,10 @@ describe("agent gui provider targets", () => {
         ownerUserId: "user-1"
       },
       label: "Alice's Codex",
+      badge: {
+        iconUrl: "app://alice-avatar.png",
+        label: "Alice avatar"
+      },
       ownerLabel: "Alice",
       iconUrl: "app://alice.png",
       unavailableReason: "owner_offline",
@@ -177,6 +185,10 @@ describe("agent gui provider targets", () => {
             sharedAgentId: "agent-1"
           },
           label: " Alice's Codex ",
+          badge: {
+            iconUrl: " ",
+            label: " "
+          },
           description: " ",
           ownerLabel: " ",
           iconUrl: " ",

--- a/packages/agent/gui/providerTargets.ts
+++ b/packages/agent/gui/providerTargets.ts
@@ -1,6 +1,7 @@
 import type {
   AgentGUIProvider,
   AgentGUIProviderTarget,
+  AgentGUIProviderTargetBadge,
   AgentGUIProviderTargetRef
 } from "./types.ts";
 
@@ -62,6 +63,7 @@ export function createSharedAgentGUIProviderTarget(input: {
   sharedAgentId: string;
   label: string;
   agentTargetId?: string | null;
+  badge?: AgentGUIProviderTargetBadge | null;
   ownerLabel?: string | null;
   iconUrl?: string | null;
   unavailableReason?: string | null;
@@ -70,6 +72,7 @@ export function createSharedAgentGUIProviderTarget(input: {
 }): AgentGUIProviderTarget {
   const sharedAgentId = input.sharedAgentId.trim();
   const targetId = `shared-agent:${sharedAgentId}`;
+  const badge = normalizeAgentGUIProviderTargetBadge(input.badge);
   return {
     targetId,
     ...(input.agentTargetId?.trim()
@@ -83,6 +86,7 @@ export function createSharedAgentGUIProviderTarget(input: {
       sharedAgentId
     },
     label: input.label,
+    ...(badge ? { badge } : {}),
     ...(input.ownerLabel?.trim()
       ? { ownerLabel: input.ownerLabel.trim() }
       : {}),
@@ -255,6 +259,7 @@ function normalizeAgentGUIProviderTarget(
     provider: _provider,
     ref: _ref,
     label: _label,
+    badge,
     description,
     iconUrl,
     ownerLabel,
@@ -269,6 +274,7 @@ function normalizeAgentGUIProviderTarget(
   if (!targetId || !label || !kind || target.ref.provider !== target.provider) {
     return null;
   }
+  const normalizedBadge = normalizeAgentGUIProviderTargetBadge(badge);
   return {
     ...rest,
     targetId,
@@ -280,12 +286,27 @@ function normalizeAgentGUIProviderTarget(
       provider: target.provider
     },
     label,
+    ...(normalizedBadge ? { badge: normalizedBadge } : {}),
     ...(description?.trim() ? { description: description.trim() } : {}),
     ...(iconUrl?.trim() ? { iconUrl: iconUrl.trim() } : {}),
     ...(ownerLabel?.trim() ? { ownerLabel: ownerLabel.trim() } : {}),
     ...(unavailableReason?.trim()
       ? { unavailableReason: unavailableReason.trim() }
       : {})
+  };
+}
+
+function normalizeAgentGUIProviderTargetBadge(
+  badge: AgentGUIProviderTargetBadge | null | undefined
+): AgentGUIProviderTargetBadge | null {
+  const iconUrl = badge?.iconUrl?.trim() ?? "";
+  if (!iconUrl) {
+    return null;
+  }
+  const label = badge?.label?.trim() ?? "";
+  return {
+    iconUrl,
+    ...(label ? { label } : {})
   };
 }
 

--- a/packages/agent/gui/types.ts
+++ b/packages/agent/gui/types.ts
@@ -83,6 +83,11 @@ export interface AgentGUIProviderTargetRef {
   [key: string]: unknown;
 }
 
+export interface AgentGUIProviderTargetBadge {
+  iconUrl: string;
+  label?: string;
+}
+
 export interface AgentGUIProviderTarget {
   targetId: string;
   agentTargetId?: string | null;
@@ -91,6 +96,7 @@ export interface AgentGUIProviderTarget {
   label: string;
   description?: string;
   iconUrl?: string | null;
+  badge?: AgentGUIProviderTargetBadge | null;
   ownerLabel?: string;
   disabled?: boolean;
   unavailableReason?: string;


### PR DESCRIPTION
## Summary
- add an optional `badge` presentation field to `AgentGUIProviderTarget`
- render provider rail badges as built-in 16x16 image overlays with a 1px white border
- document that target badges are host-projected presentation metadata, not runtime/session state

## Tests
- `pnpm --filter @tutti-os/agent-gui test -- providerTargets.spec.ts AgentGUINodeView.layout.spec.tsx`
- `pnpm check:changed --tail-lines 40`
- `git diff --check`
- `PATH="/Users/liying/go/bin:/Users/liying/.codex/packages/standalone/releases/0.142.5-aarch64-apple-darwin/codex-path:/Users/liying/.codex/packages/standalone/releases/0.142.5-aarch64-apple-darwin/codex-path:/Users/liying/.tutti/agent/runs/f917c26e-d84d-4320-af13-eeab08dfe176/codex-home/tmp/arg0/codex-arg0Nh0b3F:/Users/liying/.tutti/bin:/Users/liying/.local/bin:/usr/local/bin:/System/Cryptexes/App/usr/bin:/usr/bin:/bin:/usr/sbin:/sbin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/local/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/appleinternal/bin:/opt/pmk/env/global/bin:/Users/liying/.opencode/bin:/Users/liying/bin:/Users/liying/.npm-global/bin:/Users/liying/.n/bin:/Users/liying/n/bin:/Users/liying/.volta/bin:/Users/liying/.asdf/shims:/Users/liying/.mise/shims:/Users/liying/.bun/bin:/Users/liying/Library/pnpm:/opt/homebrew/bin" pnpm lint:go`
- pre-push `pnpm check:full`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Provider rail tiles can now show an optional badge alongside the provider avatar.
  * Badge supports an image URL and optional label (label shown in accessibility text).
  * Added a new exported badge type for consumers to use.
* **Bug Fixes**
  * Badge metadata is normalized so whitespace-only icon/label values are ignored and won’t render.
* **Documentation**
  * Updated architecture documentation to describe the optional badge behavior on provider rail tiles.
* **Tests**
  * Added coverage for badge rendering and accessibility labeling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->