### PR TITLE
fix(agent): require agent targets for session creation

### DIFF
--- a/apps/desktop/src/renderer/src/features/workspace-agent/services/createDesktopAgentActivityRuntime.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-agent/services/createDesktopAgentActivityRuntime.ts
@@ -163,7 +163,7 @@ export function createDesktopAgentActivityRuntime(
         workspaceId: input.workspaceId,
         fields: {
           mode: input.mode,
-          provider: resolveDesktopAgentGUIProvider(input.provider)
+          provider: null
         }
       });
       const flow = "session_create" as const;
@@ -184,7 +184,7 @@ export function createDesktopAgentActivityRuntime(
           fallbackErrorCode,
           flow,
           node,
-          provider: resolveDesktopAgentGUIProvider(input.provider),
+          provider: null,
           success: false
         });
         throw error;

--- a/apps/desktop/src/renderer/src/features/workspace-agent/services/createDesktopAgentGUIWorkbenchHostInput.test.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-agent/services/createDesktopAgentGUIWorkbenchHostInput.test.ts
@@ -1181,10 +1181,10 @@ test("desktop agent GUI workbench host input tracks runtime new session activati
   await hostInput.agentActivityRuntime.activateSession({
     workspaceId,
     agentSessionId: "session-runtime-start-1",
+    agentTargetId: "local:codex",
     cwd: "/workspace",
     initialContent: [{ type: "text", text: "Track initial prompt" }],
     mode: "new",
-    provider: "codex",
     settings: {
       model: "gpt-5",
       permissionModeId: "auto"
@@ -2064,7 +2064,8 @@ function createWorkspaceAgentActivityService(
       return {
         ...emptySession(),
         agentSessionId: input.agentSessionId ?? "session-1",
-        provider: input.provider
+        provider:
+          input.agentTargetId === "local:claude-code" ? "claude-code" : "codex"
       };
     },
     async deleteSession() {

--- a/apps/desktop/src/renderer/src/features/workspace-agent/services/desktopAgentActivityAdapter.test.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-agent/services/desktopAgentActivityAdapter.test.ts
@@ -319,7 +319,6 @@ test("desktop agent activity adapter marks empty-cwd creates as no-project", asy
     agentSessionId: "agent-session-1",
     agentTargetId: "local:codex",
     initialContent: [{ type: "text", text: "hi" }],
-    provider: "codex",
     workspaceId
   });
 
@@ -329,14 +328,8 @@ test("desktop agent activity adapter marks empty-cwd creates as no-project", asy
   );
 });
 
-test("desktop agent activity adapter refreshes provider status and localizes adapter mismatch create failures", async () => {
-  const refreshCalls: unknown[] = [];
+test("desktop agent activity adapter localizes adapter mismatch create failures", async () => {
   const adapter = createDesktopAgentActivityAdapter({
-    agentProviderStatusService: {
-      async refresh(providers) {
-        refreshCalls.push(providers);
-      }
-    },
     tuttidClient: createTuttidClient({
       async createWorkspaceAgentSession() {
         throw new TuttidProtocolError({
@@ -354,23 +347,14 @@ test("desktop agent activity adapter refreshes provider status and localizes ada
     adapter.createSession({
       agentSessionId: "agent-session-1",
       agentTargetId: "local:claude-code",
-      provider: "claude-code",
       workspaceId
     }),
     /Claude Code's local adapter is unavailable or version-mismatched/
   );
-
-  assert.deepEqual(refreshCalls, [["claude-code"]]);
 });
 
-test("desktop agent activity adapter does not refresh provider status for unrelated create failures", async () => {
-  const refreshCalls: unknown[] = [];
+test("desktop agent activity adapter passes through unrelated create failures", async () => {
   const adapter = createDesktopAgentActivityAdapter({
-    agentProviderStatusService: {
-      async refresh(providers) {
-        refreshCalls.push(providers);
-      }
-    },
     tuttidClient: createTuttidClient({
       async createWorkspaceAgentSession() {
         throw new TuttidProtocolError({
@@ -388,13 +372,10 @@ test("desktop agent activity adapter does not refresh provider status for unrela
     adapter.createSession({
       agentSessionId: "agent-session-1",
       agentTargetId: "local:claude-code",
-      provider: "claude-code",
       workspaceId
     }),
     /service_unavailable|TuttidProtocolError|tuttid unavailable/
   );
-
-  assert.deepEqual(refreshCalls, []);
 });
 
 test("desktop agent activity adapter requires an injected session event subscription", async () => {
@@ -667,12 +648,6 @@ test("desktop agent activity adapter sends plan mode when creating sessions", as
     model: "gpt-5.5-codex-spark",
     permissionModeId: "read-only",
     planMode: true,
-    provider: "codex",
-    providerTargetRef: {
-      kind: "sharedAgent",
-      provider: "codex",
-      sharedAgentId: "agent-1"
-    },
     reasoningEffort: "high",
     speed: null,
     title: "Plan",
@@ -697,7 +672,6 @@ test("desktop agent activity adapter sends plan mode when creating sessions", as
         model: "gpt-5.5-codex-spark",
         permissionModeId: "read-only",
         planMode: true,
-        provider: "codex",
         reasoningEffort: "high",
         speed: null,
         title: "Plan",
@@ -730,7 +704,6 @@ test("desktop agent activity adapter times out create session requests", async (
       agentTargetId: "local:claude-code",
       initialContent: [],
       model: "claude-sonnet-4-20250514",
-      provider: "claude-code",
       workspaceId
     }),
     (error) =>
@@ -754,6 +727,7 @@ test("desktop agent activity adapter rejects unuploaded file prompt blocks", asy
   await assert.rejects(
     adapter.createSession({
       agentSessionId: "22222222-2222-4222-8222-222222222222",
+      agentTargetId: "local:codex",
       initialContent: [
         {
           type: "file",
@@ -763,7 +737,6 @@ test("desktop agent activity adapter rejects unuploaded file prompt blocks", asy
           kind: "file"
         }
       ],
-      provider: "codex",
       workspaceId
     }),
     /File prompt blocks must be uploaded before desktop submission/
@@ -1002,7 +975,7 @@ test("desktop agent activity adapter loads Claude models via composer options re
   ]);
 });
 
-test("desktop agent activity adapter promotes Claude draft on first prompt", async () => {
+test("desktop agent activity adapter creates a visible target-backed Claude session on first prompt", async () => {
   const calls: string[] = [];
   const adapter = createDesktopAgentActivityAdapter({
     tuttidClient: createTuttidClient({
@@ -1055,34 +1028,21 @@ test("desktop agent activity adapter promotes Claude draft on first prompt", asy
     }),
     runtimeApi: createRuntimeApi()
   });
-  const options = await adapter.loadComposerOptions({
-    agentTargetId: "local:claude-code",
-    provider: "claude-code",
-    workspaceId
-  });
-  const draftAgentSessionId = String(
-    options.runtimeContext?.draftAgentSessionId
-  );
 
   const session = await adapter.createSession({
-    agentSessionId: draftAgentSessionId,
+    agentSessionId: "22222222-2222-4222-8222-222222222222",
     agentTargetId: "local:claude-code",
     initialContent: [{ type: "text", text: "hello" }],
-    provider: "claude-code",
     workspaceId
   });
 
-  assert.deepEqual(calls, [
-    "create:hidden",
-    `visibility:${draftAgentSessionId}:true`,
-    `send:${draftAgentSessionId}:hello`
-  ]);
-  assert.equal(session.agentSessionId, draftAgentSessionId);
+  assert.deepEqual(calls, ["create:visible"]);
+  assert.equal(session.agentSessionId, "22222222-2222-4222-8222-222222222222");
   assert.equal(session.status, "running");
-  assert.equal(session.visible, true);
+  assert.equal(session.visible, false);
 });
 
-test("desktop agent activity adapter forwards agent target id when creating Claude drafts", async () => {
+test("desktop agent activity adapter forwards agent target id when creating Claude sessions", async () => {
   const createRequests: unknown[] = [];
   const calls: string[] = [];
   const adapter = createDesktopAgentActivityAdapter({
@@ -1133,7 +1093,6 @@ test("desktop agent activity adapter forwards agent target id when creating Clau
     agentSessionId: "22222222-2222-4222-8222-222222222222",
     agentTargetId: "shared-agent:claude-1",
     initialContent: [{ type: "text", text: "hello" }],
-    provider: "claude-code",
     workspaceId
   });
 
@@ -1142,101 +1101,52 @@ test("desktop agent activity adapter forwards agent target id when creating Clau
       agentSessionId: "22222222-2222-4222-8222-222222222222",
       agentTargetId: "shared-agent:claude-1",
       cwd: null,
-      initialContent: [],
+      initialContent: [{ type: "text", text: "hello" }],
+      initialDisplayPrompt: null,
       model: null,
       permissionModeId: null,
       planMode: null,
-      provider: "claude-code",
       reasoningEffort: null,
       runtimeContext: { noProject: true },
       speed: null,
       title: null,
-      visible: false
+      visible: null
     }
   ]);
-  assert.deepEqual(calls, [
-    "create:hidden",
-    "visibility:22222222-2222-4222-8222-222222222222:true",
-    "send:22222222-2222-4222-8222-222222222222:hello"
-  ]);
+  assert.deepEqual(calls, ["create:visible"]);
   assert.equal(session.agentSessionId, "22222222-2222-4222-8222-222222222222");
 });
 
-test("desktop agent activity adapter uses a fresh Claude draft id after target switches", async () => {
+test("desktop agent activity adapter preserves requested session ids across target switches", async () => {
   const fixedAgentSessionId = "22222222-2222-4222-8222-222222222222";
   const createRequests: unknown[] = [];
-  const calls: string[] = [];
   const firstAgentTargetId = "shared-agent:claude-1";
   const secondAgentTargetId = "shared-agent:claude-2";
-  let resolveFirstDraft: ((session: WorkspaceAgentSession) => void) | undefined;
-  const firstDraft = new Promise<WorkspaceAgentSession>((resolve) => {
-    resolveFirstDraft = resolve;
-  });
   const adapter = createDesktopAgentActivityAdapter({
     tuttidClient: createTuttidClient({
       async createWorkspaceAgentSession(_workspaceId, request) {
         createRequests.push(request);
-        if (createRequests.length === 1) {
-          return await firstDraft;
-        }
         return createSession({
           id: request.agentSessionId,
           provider: "claude-code",
-          visible: false
+          visible: true
         });
-      },
-      async deleteWorkspaceAgentSession(_workspaceId, agentSessionId) {
-        calls.push(`delete:${agentSessionId}`);
-        return { removed: true };
-      },
-      async updateWorkspaceAgentSessionVisibility(
-        _workspaceId,
-        agentSessionId,
-        request
-      ) {
-        calls.push(`visibility:${agentSessionId}:${request.visible}`);
-        return createSession({
-          id: agentSessionId,
-          provider: "claude-code",
-          visible: request.visible
-        });
-      },
-      async sendWorkspaceAgentSessionInput(
-        _workspaceId,
-        agentSessionId,
-        request
-      ) {
-        calls.push(`send:${agentSessionId}:${request.content[0]?.text}`);
-        return createSendInputResponse(
-          createSession({
-            id: agentSessionId,
-            provider: "claude-code",
-            status: "running",
-            visible: true
-          })
-        );
       }
     }),
     runtimeApi: createRuntimeApi()
   });
 
-  const firstSubmission = adapter.createSession({
+  const firstSession = await adapter.createSession({
     agentSessionId: fixedAgentSessionId,
     agentTargetId: firstAgentTargetId,
     initialContent: [{ type: "text", text: "first" }],
-    provider: "claude-code",
     workspaceId
   });
-  await waitForCondition(
-    () => createRequests.length === 1,
-    "expected the first Claude draft request to start"
-  );
 
-  const session = await adapter.createSession({
+  const secondSession = await adapter.createSession({
     agentSessionId: fixedAgentSessionId,
     agentTargetId: secondAgentTargetId,
     initialContent: [{ type: "text", text: "second" }],
-    provider: "claude-code",
     workspaceId
   });
 
@@ -1245,32 +1155,16 @@ test("desktop agent activity adapter uses a fresh Claude draft id after target s
     (createRequests[0] as { agentSessionId?: string }).agentSessionId,
     fixedAgentSessionId
   );
-  const replacementAgentSessionId = (
-    createRequests[1] as { agentSessionId?: string }
-  ).agentSessionId;
-  assert.notEqual(replacementAgentSessionId, fixedAgentSessionId);
+  assert.equal(
+    (createRequests[1] as { agentSessionId?: string }).agentSessionId,
+    fixedAgentSessionId
+  );
   assert.deepEqual(
     (createRequests[1] as { agentTargetId?: unknown }).agentTargetId,
     secondAgentTargetId
   );
-  assert.deepEqual(calls, [
-    `visibility:${replacementAgentSessionId}:true`,
-    `send:${replacementAgentSessionId}:second`
-  ]);
-  assert.equal(session.agentSessionId, replacementAgentSessionId);
-
-  resolveFirstDraft?.(
-    createSession({
-      id: fixedAgentSessionId,
-      provider: "claude-code",
-      visible: false
-    })
-  );
-  await firstSubmission;
-  await waitForCondition(
-    () => calls.includes(`delete:${fixedAgentSessionId}`),
-    "expected the stale Claude draft from the previous target to be deleted"
-  );
+  assert.equal(firstSession.agentSessionId, fixedAgentSessionId);
+  assert.equal(secondSession.agentSessionId, fixedAgentSessionId);
 });
 
 test("desktop agent activity adapter loads Claude options without mutating draft sessions", async () => {
@@ -1420,19 +1314,6 @@ function createRuntimeApi(diagnostics: unknown[] = []) {
 
 function unknownPermissionModeSemantic(value: string): PermissionModeSemantic {
   return value as unknown as PermissionModeSemantic;
-}
-
-async function waitForCondition(
-  condition: () => boolean,
-  message: string
-): Promise<void> {
-  for (let attempt = 0; attempt < 20; attempt += 1) {
-    if (condition()) {
-      return;
-    }
-    await new Promise((resolve) => setTimeout(resolve, 0));
-  }
-  assert.fail(message);
 }
 
 function createSession(

--- a/apps/desktop/src/renderer/src/features/workspace-agent/services/desktopAgentActivityAdapter.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-agent/services/desktopAgentActivityAdapter.ts
@@ -1,7 +1,6 @@
 import type {
   AgentActivityAdapter,
   AgentActivityMessage,
-  AgentActivityProviderTargetRef,
   AgentActivitySession,
   AgentPromptContentBlock
 } from "@tutti-os/agent-activity-core";
@@ -13,10 +12,8 @@ import type {
   WorkspaceAgentSessionMessage
 } from "@tutti-os/client-tuttid-ts";
 import type { DesktopRuntimeApi } from "@preload/types";
-import type { IAgentProviderStatusService } from "./agentProviderStatusService.interface";
 import { getActiveLocale } from "../../../i18n/runtime.ts";
 import { wrapLocalizedTuttidErrorIfSpecific } from "../../../lib/desktopErrors.ts";
-import { shouldRefreshProviderStatusAfterSessionError } from "./internal/desktopAgentProviderStatusSync.ts";
 import {
   normalizedTuttidMessageOccurredAtUnixMs,
   normalizedTuttidMessageTurnId
@@ -24,7 +21,6 @@ import {
 import { agentActivityComposerOptionsFromTuttidResult } from "../../../lib/agentComposerOptionsProjection.ts";
 
 export interface CreateDesktopAgentActivityAdapterInput {
-  agentProviderStatusService?: Pick<IAgentProviderStatusService, "refresh">;
   agentSessionCreateRequestTimeoutMs?: number;
   composerOptionsRequestTimeoutMs?: number;
   tuttidClient: TuttidClient;
@@ -36,7 +32,6 @@ const defaultComposerOptionsRequestTimeoutMs = 15_000;
 const agentActivitySessionListLimit = 100;
 
 export function createDesktopAgentActivityAdapter({
-  agentProviderStatusService,
   agentSessionCreateRequestTimeoutMs = defaultAgentSessionCreateRequestTimeoutMs,
   composerOptionsRequestTimeoutMs = defaultComposerOptionsRequestTimeoutMs,
   tuttidClient,
@@ -47,170 +42,6 @@ export function createDesktopAgentActivityAdapter({
   // down and creating a brand new hidden session on every toggle.
   const claudeDrafts = new Map<string, ClaudeDraftSessionEntry>();
 
-  const deleteClaudeDraft = (entry: ClaudeDraftSessionEntry): void => {
-    if (entry.status === "promoted") {
-      return;
-    }
-    entry.status = "disposed";
-    if (claudeDrafts.get(entry.cacheKey) === entry) {
-      claudeDrafts.delete(entry.cacheKey);
-    }
-    void entry.promise
-      .then((session) =>
-        tuttidClient.deleteWorkspaceAgentSession(entry.workspaceId, session.id)
-      )
-      .catch(() => undefined);
-  };
-
-  const createClaudeDraft = (
-    input: ClaudeDraftInput,
-    cwd: string | null,
-    settingsKey: string
-  ): Promise<WorkspaceAgentSession> => {
-    const draftKey = claudeDraftKey({ ...input, cwd });
-    const agentSessionId =
-      normalizeText(input.agentSessionId) ??
-      createDesktopAgentActivitySessionId();
-    const agentTargetId = requiredAgentTargetId(input.agentTargetId);
-    const promise = withAbortableRequestTimeout(
-      (signal) => {
-        const runtimeContext = createSessionRuntimeContext({ cwd });
-        return tuttidClient.createWorkspaceAgentSession(
-          input.workspaceId,
-          {
-            agentSessionId,
-            agentTargetId,
-            cwd,
-            initialContent: [],
-            model: input.settings.model,
-            permissionModeId: input.settings.permissionModeId,
-            planMode: input.settings.planMode,
-            provider: "claude-code",
-            reasoningEffort: input.settings.reasoningEffort,
-            ...(runtimeContext ? { runtimeContext } : {}),
-            speed: input.settings.speed,
-            title: null,
-            visible: false
-          },
-          { signal }
-        );
-      },
-      {
-        signal: input.signal,
-        timeoutMessage: "Agent session create request timed out.",
-        timeoutMs: agentSessionCreateRequestTimeoutMs
-      }
-    ).then((session) => sessionWithClaudeDraftContext(session, draftKey));
-    const entry: ClaudeDraftSessionEntry = {
-      cacheKey: claudeDraftCacheKey(input),
-      cwd,
-      promise,
-      providerTargetKey: claudeDraftTargetKey(input),
-      sessionId: agentSessionId,
-      settingsKey,
-      status: "starting",
-      workspaceId: input.workspaceId
-    };
-    claudeDrafts.set(entry.cacheKey, entry);
-    void promise.then(
-      (session) => {
-        if (entry.status === "starting") {
-          entry.status = "ready";
-          entry.sessionId = session.id;
-        }
-      },
-      () => {
-        entry.status = "failed";
-        if (claudeDrafts.get(entry.cacheKey) === entry) {
-          claudeDrafts.delete(entry.cacheKey);
-        }
-      }
-    );
-    return promise;
-  };
-
-  const ensureClaudeDraft = (
-    input: ClaudeDraftInput
-  ): Promise<WorkspaceAgentSession> => {
-    const cwd = input.cwd ?? null;
-    const settingsKey = JSON.stringify(input.settings);
-    const providerTargetKey = claudeDraftTargetKey(input);
-    const existing = claudeDrafts.get(claudeDraftCacheKey(input));
-    if (
-      existing &&
-      existing.status !== "disposed" &&
-      existing.status !== "failed" &&
-      existing.cwd === cwd &&
-      existing.providerTargetKey === providerTargetKey &&
-      (!input.agentSessionId || existing.sessionId === input.agentSessionId)
-    ) {
-      if (existing.settingsKey === settingsKey) {
-        return existing.promise;
-      }
-      // Settings changed (e.g. plan/permission mode toggled): patch the live
-      // draft in place rather than recreating a session. The returned session
-      // carries the refreshed permissionConfig/runtimeContext.
-      const draftKey = claudeDraftKey({ ...input, cwd });
-      existing.settingsKey = settingsKey;
-      const updated = existing.promise.then((session) =>
-        tuttidClient
-          .updateWorkspaceAgentSessionSettings(input.workspaceId, session.id, {
-            model: input.settings.model,
-            permissionModeId: input.settings.permissionModeId,
-            planMode: input.settings.planMode,
-            reasoningEffort: input.settings.reasoningEffort,
-            speed: input.settings.speed
-          })
-          .then((next) => sessionWithClaudeDraftContext(next, draftKey))
-      );
-      existing.promise = updated;
-      void updated.then(
-        (session) => {
-          if (existing.status === "starting" || existing.status === "ready") {
-            existing.status = "ready";
-            existing.sessionId = session.id;
-          }
-        },
-        () => {
-          // Keep the existing draft if the in-place update fails; the final
-          // settings are applied again when the draft is promoted on send.
-        }
-      );
-      return updated;
-    }
-    const requestedAgentSessionId = normalizeText(input.agentSessionId);
-    const existingSameRequestedSession = requestedAgentSessionId
-      ? Array.from(claudeDrafts.values()).find(
-          (entry) =>
-            entry.workspaceId === input.workspaceId &&
-            entry.sessionId === requestedAgentSessionId &&
-            entry.providerTargetKey !== providerTargetKey &&
-            !isDeadDraftStatus(entry.status)
-        )
-      : undefined;
-    const shouldCreateFreshDraftSession =
-      (existing &&
-        existing.providerTargetKey !== providerTargetKey &&
-        requestedAgentSessionId === existing.sessionId) ||
-      existingSameRequestedSession !== undefined;
-    if (existing) {
-      deleteClaudeDraft(existing);
-    }
-    if (
-      existingSameRequestedSession &&
-      existingSameRequestedSession !== existing
-    ) {
-      deleteClaudeDraft(existingSameRequestedSession);
-    }
-    return createClaudeDraft(
-      shouldCreateFreshDraftSession
-        ? { ...input, agentSessionId: null }
-        : input,
-      cwd,
-      settingsKey
-    );
-  };
-
   const promoteClaudeDraft = async (
     input: Parameters<AgentActivityAdapter["createSession"]>[0]
   ): Promise<AgentActivitySession | null> => {
@@ -218,11 +49,7 @@ export function createDesktopAgentActivityAdapter({
     const initialContent = toTuttidPromptContentBlocks(
       input.initialContent ?? []
     );
-    if (
-      workspaceAgentProvider(input.provider) !== "claude-code" ||
-      !agentSessionId ||
-      initialContent.length === 0
-    ) {
+    if (!agentSessionId || initialContent.length === 0) {
       return null;
     }
     const entry = claudeDrafts.get(claudeDraftCacheKey(input));
@@ -368,7 +195,7 @@ export function createDesktopAgentActivityAdapter({
         agentSessionId: input.agentSessionId?.trim() ?? null,
         event: "renderer_adapter.create.entered",
         metadata: input.metadata,
-        provider: input.provider,
+        provider: null,
         workspaceId: input.workspaceId
       });
       try {
@@ -383,40 +210,13 @@ export function createDesktopAgentActivityAdapter({
           });
           return promoted;
         }
-        if (
-          workspaceAgentProvider(input.provider) === "claude-code" &&
-          (input.initialContent?.length ?? 0) > 0
-        ) {
-          const draft = await ensureClaudeDraft({
-            agentSessionId: input.agentSessionId?.trim() ?? null,
-            agentTargetId: input.agentTargetId ?? null,
-            cwd: input.cwd ?? null,
-            settings: normalizedClaudeDraftSettings({
-              model: input.model,
-              permissionModeId: input.permissionModeId,
-              planMode: input.planMode,
-              reasoningEffort: input.reasoningEffort,
-              speed: input.speed
-            }),
-            providerTargetRef: input.providerTargetRef ?? null,
-            signal: input.signal,
-            workspaceId: input.workspaceId
-          });
-          const promotedDraft = await promoteClaudeDraft({
-            ...input,
-            agentSessionId: draft.id
-          });
-          if (promotedDraft) {
-            return promotedDraft;
-          }
-        }
         const agentSessionId =
           input.agentSessionId?.trim() || createDesktopAgentActivitySessionId();
         reportDesktopAgentSubmitTrace(runtimeApi, {
           agentSessionId,
           event: "renderer_adapter.create.http_requested",
           metadata: input.metadata,
-          provider: input.provider,
+          provider: null,
           workspaceId: input.workspaceId
         });
         const agentTargetId = requiredAgentTargetId(input.agentTargetId);
@@ -437,7 +237,6 @@ export function createDesktopAgentActivityAdapter({
                 model: input.model ?? null,
                 planMode: input.planMode ?? null,
                 permissionModeId: input.permissionModeId ?? null,
-                provider: workspaceAgentProvider(input.provider),
                 reasoningEffort: input.reasoningEffort ?? null,
                 ...(runtimeContext ? { runtimeContext } : {}),
                 speed: input.speed ?? null,
@@ -466,10 +265,6 @@ export function createDesktopAgentActivityAdapter({
           session
         );
       } catch (error) {
-        const provider = workspaceAgentProvider(input.provider);
-        if (shouldRefreshProviderStatusAfterSessionError(error)) {
-          void agentProviderStatusService?.refresh([provider]).catch(() => {});
-        }
         throw wrapLocalizedTuttidErrorIfSpecific(error, getActiveLocale());
       }
     },
@@ -690,94 +485,32 @@ export function createDesktopAgentActivitySessionId(): string {
   return `00000000-0000-4000-8000-${fallbackHex.slice(0, 12)}`;
 }
 
-type ClaudeDraftStatus =
-  | "starting"
-  | "ready"
-  | "failed"
-  | "promoted"
-  | "disposed";
-
-interface ClaudeDraftSettings {
-  model: string | null;
-  permissionModeId: string | null;
-  planMode: boolean | null;
-  reasoningEffort: string | null;
-  speed: string | null;
-}
-
-interface ClaudeDraftInput {
-  agentSessionId?: string | null;
-  agentTargetId?: string | null;
-  cwd: string | null;
-  providerTargetRef?: AgentActivityProviderTargetRef | null;
-  settings: ClaudeDraftSettings;
-  signal?: AbortSignal;
-  workspaceId: string;
-}
+type ClaudeDraftStatus = "starting" | "ready" | "failed" | "promoted";
 
 interface ClaudeDraftSessionEntry {
   cacheKey: string;
-  cwd: string | null;
   providerTargetKey: string;
-  settingsKey: string;
   promise: Promise<WorkspaceAgentSession>;
   sessionId: string;
   status: ClaudeDraftStatus;
-  workspaceId: string;
-}
-
-function normalizedClaudeDraftSettings(
-  settings:
-    | {
-        model?: string | null;
-        permissionModeId?: string | null;
-        planMode?: boolean | null;
-        reasoningEffort?: string | null;
-        speed?: string | null;
-      }
-    | null
-    | undefined
-): ClaudeDraftSettings {
-  return {
-    model: normalizeText(settings?.model) ?? null,
-    permissionModeId: normalizeText(settings?.permissionModeId) ?? null,
-    planMode: settings?.planMode ?? null,
-    reasoningEffort: normalizeText(settings?.reasoningEffort) ?? null,
-    speed: normalizeText(settings?.speed) ?? null
-  };
 }
 
 function isDeadDraftStatus(status: ClaudeDraftStatus): boolean {
-  return status === "disposed" || status === "failed";
+  return status === "failed";
 }
 
-function claudeDraftKey(input: ClaudeDraftInput): string {
-  return JSON.stringify({
-    agentTargetId: normalizeText(input.agentTargetId) ?? "",
-    cwd: input.cwd ?? "",
-    providerTargetRef: sortProviderTargetRefValue(input.providerTargetRef),
-    settings: input.settings,
-    workspaceId: input.workspaceId
-  });
-}
-
-function claudeDraftCacheKey(
-  input: Pick<
-    ClaudeDraftInput,
-    "agentTargetId" | "providerTargetRef" | "workspaceId"
-  >
-): string {
+function claudeDraftCacheKey(input: {
+  agentTargetId?: string | null;
+  workspaceId: string;
+}): string {
   return `${input.workspaceId}:${claudeDraftTargetKey(input)}`;
 }
 
-function claudeDraftTargetKey(
-  input: Pick<ClaudeDraftInput, "agentTargetId" | "providerTargetRef">
-): string {
+function claudeDraftTargetKey(input: {
+  agentTargetId?: string | null;
+}): string {
   const agentTargetId = normalizeText(input.agentTargetId);
-  if (agentTargetId) {
-    return `agentTarget:${agentTargetId}`;
-  }
-  return `providerTarget:${providerTargetRefKey(input.providerTargetRef)}`;
+  return `agentTarget:${agentTargetId ?? ""}`;
 }
 
 function requiredAgentTargetId(value: string | null | undefined): string {
@@ -797,40 +530,6 @@ function createSessionRuntimeContext(input: {
     runtimeContext.noProject = true;
   }
   return Object.keys(runtimeContext).length > 0 ? runtimeContext : undefined;
-}
-
-function providerTargetRefKey(
-  value: AgentActivityProviderTargetRef | null | undefined
-): string {
-  return JSON.stringify(sortProviderTargetRefValue(value ?? null));
-}
-
-function sortProviderTargetRefValue(value: unknown): unknown {
-  if (Array.isArray(value)) {
-    return value.map(sortProviderTargetRefValue);
-  }
-  if (!isRecord(value)) {
-    return value;
-  }
-  return Object.fromEntries(
-    Object.entries(value)
-      .sort(([left], [right]) => left.localeCompare(right))
-      .map(([key, entryValue]) => [key, sortProviderTargetRefValue(entryValue)])
-  );
-}
-
-function sessionWithClaudeDraftContext(
-  session: WorkspaceAgentSession,
-  draftKey: string
-): WorkspaceAgentSession {
-  return {
-    ...session,
-    runtimeContext: {
-      ...recordValue(session.runtimeContext),
-      draftAgentSessionId: session.id,
-      draftKey
-    }
-  };
 }
 
 function toTuttidPromptContentBlocks(

--- a/apps/desktop/src/renderer/src/features/workspace-agent/services/internal/workspaceAgentActivityService.test.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-agent/services/internal/workspaceAgentActivityService.test.ts
@@ -46,7 +46,7 @@ test("WorkspaceAgentActivityService.sendInput keeps activity snapshot working wh
   assert.equal(snapshotSession?.currentPhase, "working");
 });
 
-test("WorkspaceAgentActivityService.activateSession omits provider target refs for target-backed create", async () => {
+test("WorkspaceAgentActivityService.activateSession creates target-backed sessions without provider input", async () => {
   const createCalls: unknown[] = [];
   const service = new WorkspaceAgentActivityService({
     tuttidClient: {
@@ -69,12 +69,6 @@ test("WorkspaceAgentActivityService.activateSession omits provider target refs f
     cwd: "/workspace",
     initialContent: [{ type: "text", text: "hello" }],
     mode: "new",
-    provider: "codex",
-    providerTargetRef: {
-      kind: "sharedAgent",
-      provider: "codex",
-      sharedAgentId: "agent-1"
-    },
     title: "Shared Codex",
     visible: true,
     workspaceId: "ws-1"
@@ -92,7 +86,6 @@ test("WorkspaceAgentActivityService.activateSession omits provider target refs f
       model: null,
       permissionModeId: null,
       planMode: null,
-      provider: "codex",
       reasoningEffort: null,
       speed: null,
       title: "Shared Codex",
@@ -130,7 +123,6 @@ test("WorkspaceAgentActivityService keeps explicit Claude model display over def
     cwd: "/workspace",
     initialContent: [{ type: "text", text: "hi" }],
     mode: "new",
-    provider: "claude-code",
     settings: { model: "opus" },
     title: "Claude",
     visible: true,

--- a/apps/desktop/src/renderer/src/features/workspace-agent/services/internal/workspaceAgentActivityService.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-agent/services/internal/workspaceAgentActivityService.ts
@@ -405,7 +405,7 @@ export class WorkspaceAgentActivityService implements IWorkspaceAgentActivitySer
       agentSessionId: input.agentSessionId?.trim() ?? null,
       event: "activity_service.create.entered",
       metadata: input.metadata,
-      provider: input.provider,
+      provider: null,
       workspaceId: input.workspaceId,
       fields: { agentTargetId: input.agentTargetId ?? null }
     });
@@ -414,7 +414,7 @@ export class WorkspaceAgentActivityService implements IWorkspaceAgentActivitySer
       agentSessionId: input.agentSessionId?.trim() ?? null,
       event: "activity_service.create.adapter_requested",
       metadata: input.metadata,
-      provider: input.provider,
+      provider: null,
       workspaceId: input.workspaceId,
       fields: { agentTargetId: input.agentTargetId ?? null }
     });
@@ -422,10 +422,7 @@ export class WorkspaceAgentActivityService implements IWorkspaceAgentActivitySer
       input,
       this.dependencies.workspaceUserProjectService
     );
-    const adapterInput = sessionInput.agentTargetId
-      ? { ...sessionInput, providerTargetRef: null }
-      : sessionInput;
-    const session = await entry.adapter.createSession(adapterInput);
+    const session = await entry.adapter.createSession(sessionInput);
     reportAgentSubmitTraceDiagnostic(this.dependencies.runtimeApi, {
       agentSessionId: session.agentSessionId,
       event: "activity_service.create.adapter_resolved",
@@ -451,13 +448,12 @@ export class WorkspaceAgentActivityService implements IWorkspaceAgentActivitySer
   ): ReturnType<IWorkspaceAgentActivityService["activateSession"]> {
     const workspaceId = normalizeWorkspaceId(input.workspaceId);
     const requestedAgentSessionId = input.agentSessionId.trim();
-    const provider = resolveDesktopAgentGUIProvider(input.provider);
     const workspaceState = desktopAgentHostWorkspaceState(workspaceId);
     reportAgentSubmitTraceDiagnostic(this.dependencies.runtimeApi, {
       agentSessionId: requestedAgentSessionId,
       event: "activity_service.activate.entered",
       metadata: input.metadata,
-      provider,
+      provider: null,
       workspaceId,
       fields: { agentTargetId: input.agentTargetId ?? null, mode: input.mode }
     });
@@ -466,7 +462,7 @@ export class WorkspaceAgentActivityService implements IWorkspaceAgentActivitySer
         agentSessionId: requestedAgentSessionId,
         event: "activity_service.activate.cwd_resolve_requested",
         metadata: input.metadata,
-        provider,
+        provider: null,
         workspaceId
       });
     }
@@ -483,7 +479,7 @@ export class WorkspaceAgentActivityService implements IWorkspaceAgentActivitySer
         agentSessionId: requestedAgentSessionId,
         event: "activity_service.activate.cwd_resolved",
         metadata: input.metadata,
-        provider,
+        provider: null,
         workspaceId,
         fields: {
           agentTargetId: input.agentTargetId ?? null,
@@ -499,14 +495,14 @@ export class WorkspaceAgentActivityService implements IWorkspaceAgentActivitySer
         agentSessionId: requestedAgentSessionId,
         event: "activity_service.activate.create_requested",
         metadata: input.metadata,
-        provider,
+        provider: null,
         workspaceId,
         fields: { agentTargetId: input.agentTargetId ?? null }
       });
       session = await this.createSession({
         workspaceId,
         agentSessionId: requestedAgentSessionId,
-        ...(input.agentTargetId ? { agentTargetId: input.agentTargetId } : {}),
+        agentTargetId: input.agentTargetId,
         cwd: resolvedCwd?.cwd ?? null,
         initialContent: input.initialContent ?? [],
         initialDisplayPrompt: input.initialDisplayPrompt ?? null,
@@ -514,10 +510,6 @@ export class WorkspaceAgentActivityService implements IWorkspaceAgentActivitySer
         model: input.settings?.model ?? null,
         planMode: input.settings?.planMode ?? null,
         permissionModeId: resolveComposerPermissionMode(input.settings),
-        provider,
-        ...(input.agentTargetId
-          ? {}
-          : { providerTargetRef: input.providerTargetRef ?? null }),
         reasoningEffort: input.settings?.reasoningEffort ?? null,
         ...(resolvedCwd?.noProject
           ? { runtimeContext: { noProject: true } }
@@ -834,8 +826,7 @@ export class WorkspaceAgentActivityService implements IWorkspaceAgentActivitySer
 
     const adapter = createDesktopAgentActivityAdapter({
       tuttidClient: this.dependencies.tuttidClient,
-      runtimeApi: this.dependencies.runtimeApi,
-      agentProviderStatusService: this.dependencies.agentProviderStatusService
+      runtimeApi: this.dependencies.runtimeApi
     });
     const controller = createAgentActivityController({
       adapter,

--- a/apps/desktop/src/renderer/src/features/workspace-agent/services/internal/workspaceAgentPromptSessionService.test.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-agent/services/internal/workspaceAgentPromptSessionService.test.ts
@@ -49,7 +49,7 @@ test("workspace agent prompt session service creates a new session with initial 
           session: {
             agentSessionId: input.agentSessionId,
             cwd: input.cwd,
-            provider: input.provider ?? "codex",
+            provider: "codex",
             status: "running"
           }
         };
@@ -59,9 +59,9 @@ test("workspace agent prompt session service creates a new session with initial 
 
   const result = await service.createSession({
     agentSessionId: "session-1",
+    agentTargetId: "local:codex",
     cwd: "/workspace/project",
     prompt: "  Build the feature  ",
-    provider: "codex",
     source: "issue_manager",
     title: "Build feature",
     workspaceId: "workspace-1"
@@ -69,10 +69,10 @@ test("workspace agent prompt session service creates a new session with initial 
 
   assert.deepEqual(capturedActivation, {
     agentSessionId: "session-1",
+    agentTargetId: "local:codex",
     cwd: "/workspace/project",
     initialContent: [{ type: "text", text: "Build the feature" }],
     mode: "new",
-    provider: "codex",
     title: "Build feature",
     visible: true,
     workspaceId: "workspace-1"
@@ -131,7 +131,7 @@ test("workspace agent prompt session service reports successful node results", a
           session: {
             agentSessionId: input.agentSessionId,
             cwd: input.cwd,
-            provider: input.provider ?? "codex",
+            provider: "codex",
             status: "running"
           }
         };
@@ -141,8 +141,8 @@ test("workspace agent prompt session service reports successful node results", a
 
   await service.createSession({
     agentSessionId: "session-1",
+    agentTargetId: "local:codex",
     prompt: "Build the feature",
-    provider: "codex",
     workspaceId: "workspace-1"
   });
 
@@ -208,7 +208,7 @@ test("workspace agent prompt session service rejects failed activation", async (
           error: { message: "provider unavailable" },
           session: {
             agentSessionId: input.agentSessionId,
-            provider: input.provider ?? "codex",
+            provider: "codex",
             status: "failed"
           }
         };
@@ -219,8 +219,8 @@ test("workspace agent prompt session service rejects failed activation", async (
   await assert.rejects(
     () =>
       service.createSession({
+        agentTargetId: "local:codex",
         prompt: "Build",
-        provider: "codex",
         workspaceId: "workspace-1"
       }),
     /provider unavailable/
@@ -239,7 +239,7 @@ test("workspace agent prompt session service maps user project selection to cwd"
           session: {
             agentSessionId: input.agentSessionId,
             cwd: input.cwd,
-            provider: input.provider ?? "codex",
+            provider: "codex",
             status: "running"
           }
         };
@@ -254,9 +254,9 @@ test("workspace agent prompt session service maps user project selection to cwd"
 
   await service.createSession({
     agentSessionId: "session-2",
+    agentTargetId: "local:codex",
     cwd: "/workspace/fallback",
     prompt: "Build",
-    provider: "codex",
     userProjectPath: "/workspace/project",
     workspaceId: "workspace-1"
   });
@@ -268,9 +268,9 @@ test("workspace agent prompt session service maps user project selection to cwd"
 
   await service.createSession({
     agentSessionId: "session-3",
+    agentTargetId: "local:codex",
     cwd: "/workspace/fallback",
     prompt: "Build",
-    provider: "codex",
     userProjectPath: "/workspace/no-project",
     workspaceId: "workspace-1"
   });

--- a/apps/desktop/src/renderer/src/features/workspace-agent/services/internal/workspaceAgentPromptSessionService.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-agent/services/internal/workspaceAgentPromptSessionService.ts
@@ -1,7 +1,6 @@
 import type { AgentActivitySendInput } from "@tutti-os/agent-activity-core";
 import type { IReporterService } from "../../../analytics/services/reporterService.interface.ts";
 import type { IWorkspaceUserProjectService } from "../../../workspace-user-project/index.ts";
-import { normalizeDesktopAgentGUIProvider } from "../../desktopAgentGUINodeState.ts";
 import { createAgentMessageSentTracker } from "./agentMessageSentAnalytics.ts";
 import {
   AgentAnalyticsErrorCode,
@@ -72,13 +71,25 @@ export class WorkspaceAgentPromptSessionService implements IWorkspaceAgentPrompt
         fallbackErrorCode: AgentAnalyticsErrorCode.PromptValidateFailed,
         flow: "session_create",
         node: "prompt_validated",
-        provider: input.provider ?? null,
+        provider: null,
         success: false
       });
       throw new Error("workspace_agent.prompt_session_prompt_required");
     }
 
-    const provider = normalizeDesktopAgentGUIProvider(input.provider);
+    const agentTargetId = input.agentTargetId.trim();
+    if (!agentTargetId) {
+      await safeTrackAgentNodeResult(this.nodeResultTracker, {
+        error: "workspace_agent.prompt_session_agent_target_required",
+        fallbackErrorCode: AgentAnalyticsErrorCode.PromptValidateFailed,
+        flow: "session_create",
+        node: "prompt_validated",
+        provider: null,
+        success: false
+      });
+      throw new Error("workspace_agent.prompt_session_agent_target_required");
+    }
+
     const agentSessionId =
       input.agentSessionId?.trim() || createWorkspaceAgentSessionId();
     const cwd = resolveWorkspaceAgentPromptSessionCwd(
@@ -90,7 +101,7 @@ export class WorkspaceAgentPromptSessionService implements IWorkspaceAgentPrompt
       agentSessionId,
       flow: "session_create",
       node: "prompt_validated",
-      provider,
+      provider: null,
       success: true
     });
     let activation: Awaited<
@@ -100,10 +111,10 @@ export class WorkspaceAgentPromptSessionService implements IWorkspaceAgentPrompt
       activation =
         await this.dependencies.workspaceAgentActivityService.activateSession({
           agentSessionId,
+          agentTargetId,
           ...(cwd ? { cwd } : {}),
           initialContent: textPromptContent(prompt),
           mode: "new",
-          provider,
           title,
           visible: input.visible ?? true,
           workspaceId: input.workspaceId
@@ -115,7 +126,7 @@ export class WorkspaceAgentPromptSessionService implements IWorkspaceAgentPrompt
         fallbackErrorCode: AgentAnalyticsErrorCode.SessionCreateFailed,
         flow: "session_create",
         node: "activate_session",
-        provider,
+        provider: null,
         success: false
       });
       throw error;
@@ -134,7 +145,7 @@ export class WorkspaceAgentPromptSessionService implements IWorkspaceAgentPrompt
         fallbackErrorCode: AgentAnalyticsErrorCode.SessionCreateFailed,
         flow: "session_create",
         node: "activate_session",
-        provider: activation.session.provider || provider,
+        provider: activation.session.provider,
         success: false
       });
       throw new Error(activationError);
@@ -144,14 +155,14 @@ export class WorkspaceAgentPromptSessionService implements IWorkspaceAgentPrompt
       agentSessionId: activation.session.agentSessionId,
       flow: "session_create",
       node: "activate_session",
-      provider: activation.session.provider || provider,
+      provider: activation.session.provider,
       success: true
     });
     await this.sessionStartedTracker.track({
       agentSessionId: activation.session.agentSessionId,
       hasProject: Boolean(activation.session.cwd?.trim()),
       permissionMode: null,
-      provider: activation.session.provider || provider,
+      provider: activation.session.provider,
       source: resolveAgentSessionSource({
         mode: "new",
         source: input.source ?? undefined
@@ -161,25 +172,25 @@ export class WorkspaceAgentPromptSessionService implements IWorkspaceAgentPrompt
       agentSessionId: activation.session.agentSessionId,
       flow: "session_create",
       node: "session_started_reported",
-      provider: activation.session.provider || provider,
+      provider: activation.session.provider,
       success: true
     });
     await this.messageSentTracker.track({
       agentSessionId: activation.session.agentSessionId,
       prompt,
-      provider: activation.session.provider || provider
+      provider: activation.session.provider
     });
     await safeTrackAgentNodeResult(this.nodeResultTracker, {
       agentSessionId: activation.session.agentSessionId,
       flow: "session_create",
       node: "message_sent_reported",
-      provider: activation.session.provider || provider,
+      provider: activation.session.provider,
       success: true
     });
 
     return {
       agentSessionId: activation.session.agentSessionId,
-      provider: activation.session.provider || provider,
+      provider: activation.session.provider,
       status: activation.session.status ?? null
     };
   }

--- a/apps/desktop/src/renderer/src/features/workspace-agent/services/workspaceAgentPromptSessionService.interface.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-agent/services/workspaceAgentPromptSessionService.interface.ts
@@ -2,9 +2,9 @@ import { createDecorator } from "@tutti-os/infra/di";
 
 export interface WorkspaceAgentPromptSessionCreateInput {
   agentSessionId?: string | null;
+  agentTargetId: string;
   cwd?: string | null;
   prompt: string;
-  provider?: string | null;
   source?: string | null;
   title?: string | null;
   userProjectPath?: string | null;

--- a/apps/desktop/src/renderer/src/features/workspace-app-center/ui/WorkspaceAppCenterPane.tsx
+++ b/apps/desktop/src/renderer/src/features/workspace-app-center/ui/WorkspaceAppCenterPane.tsx
@@ -19,10 +19,7 @@ import type {
   AppCenterHostActions
 } from "@tutti-os/workspace-app-center/ui";
 import { AppCenterPanel } from "@tutti-os/workspace-app-center/ui";
-import {
-  agentGuiDockIconUrls,
-  localAgentGUIAgentTargetId
-} from "@tutti-os/agent-gui";
+import { agentGuiDockIconUrls } from "@tutti-os/agent-gui";
 import type { AgentProviderStatus } from "@tutti-os/client-tuttid-ts";
 import { useService } from "@tutti-os/infra/di";
 import {
@@ -552,28 +549,6 @@ function resolveAppCenterReadyAgentProviderOptions(
       .filter((status) => status.availability.status === "ready")
       .map((status) => status.provider)
   );
-
-  if (agentTargets.length === 0) {
-    return workspaceAgentGuiProviders.flatMap((provider) => {
-      const agentTargetId = localAgentGUIAgentTargetId(provider);
-      if (
-        !agentTargetId ||
-        !readyProviders.has(provider) ||
-        hiddenProviders?.has(provider) === true ||
-        isWorkspaceAgentGuiComingSoonProvider(provider)
-      ) {
-        return [];
-      }
-      return [
-        {
-          agentTargetId,
-          iconUrl: agentGuiDockIconUrls[provider],
-          label: resolveWorkspaceAgentGuiLabel(provider),
-          provider
-        }
-      ];
-    });
-  }
 
   return agentTargets
     .filter(

--- a/apps/desktop/src/renderer/src/features/workspace-issue-manager/internal/adapters/desktopIssueManagerAgentRunner.test.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-issue-manager/internal/adapters/desktopIssueManagerAgentRunner.test.ts
@@ -27,6 +27,7 @@ test("desktop issue-manager agent runner opens execute prompt as an agent draft"
   const capturedPrompt = capturedLaunch?.draftPrompt ?? "";
   assert.equal(capturedCreate, undefined);
   assert.equal(capturedLaunch?.agentSessionId, undefined);
+  assert.equal(capturedLaunch?.agentTargetId, "local:codex");
   assert.equal(capturedLaunch?.provider, "codex");
   assert.equal(capturedLaunch?.userProjectPath, undefined);
   assert.equal(capturedLaunch?.workspaceId, "workspace-1");
@@ -59,7 +60,23 @@ test("desktop issue-manager agent runner reports unavailable agent GUI launcher"
   const result = await runner.runTask(createRunRequest());
 
   assert.deepEqual(result, {
-    errorMessage: "issue_manager.agent_gui_launch_unavailable",
+    errorMessage: "Agent session drafting is unavailable.",
+    status: "failed"
+  });
+});
+
+test("desktop issue-manager agent runner rejects provider-only execute launch", async () => {
+  const runner = createDesktopIssueManagerAgentRunner({
+    launchAgentGui() {
+      throw new Error("launch should not be called");
+    },
+    workspaceId: "workspace-1"
+  });
+
+  const result = await runner.runTask(createRunRequest({ agentTargetId: " " }));
+
+  assert.deepEqual(result, {
+    errorMessage: "Select an available agent target first.",
     status: "failed"
   });
 });
@@ -145,6 +162,7 @@ test("desktop issue-manager agent breakdown launcher opens breakdown prompt as a
       tasks: []
     },
     executionDirectory: "/Users/example/project/tutti",
+    agentTargetId: "remote:gemini",
     provider: "gemini",
     workspaceId: "workspace-1"
   });
@@ -152,6 +170,7 @@ test("desktop issue-manager agent breakdown launcher opens breakdown prompt as a
   assert.deepEqual(result, { status: "opened" });
   assert.equal(capturedCreate, undefined);
   assert.equal(capturedLaunch?.agentSessionId, undefined);
+  assert.equal(capturedLaunch?.agentTargetId, "remote:gemini");
   assert.match(
     capturedLaunch?.draftPrompt ?? "",
     /Break this task reference down into executable tasks/
@@ -192,6 +211,7 @@ test("desktop issue-manager agent breakdown launcher sends localized prompt", as
       },
       tasks: []
     },
+    agentTargetId: "remote:gemini",
     provider: "gemini",
     workspaceId: "workspace-1"
   });
@@ -223,8 +243,13 @@ function createAgentSessionCreator(
   };
 }
 
-function createRunRequest(input?: { executionDirectory?: string | null }) {
+function createRunRequest(input?: {
+  agentTargetId?: string;
+  executionDirectory?: string | null;
+}) {
   return {
+    agentTargetId:
+      input && "agentTargetId" in input ? input.agentTargetId : "local:codex",
     ...(input?.executionDirectory
       ? { executionDirectory: input.executionDirectory }
       : {}),

--- a/apps/desktop/src/renderer/src/features/workspace-issue-manager/internal/adapters/desktopIssueManagerAgentRunner.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-issue-manager/internal/adapters/desktopIssueManagerAgentRunner.ts
@@ -1,6 +1,7 @@
 import {
   buildIssueManagerRunPrompt,
   buildIssueManagerTaskBreakdownPrompt,
+  createIssueManagerAgentLaunchMessages,
   createIssueManagerI18nRuntime
 } from "@tutti-os/workspace-issue-manager";
 import type { I18nRuntime } from "@tutti-os/ui-i18n-runtime";
@@ -14,6 +15,7 @@ import type {
 export interface DesktopIssueManagerAgentSessionCreator {
   createSession(input: {
     agentSessionId: string;
+    agentTargetId: string;
     cwd?: string | null;
     prompt: string;
     provider: string;
@@ -47,18 +49,26 @@ export function createDesktopIssueManagerAgentRunner(input: {
 }): IssueManagerAgentRunner {
   return {
     async runTask(request): Promise<IssueManagerAgentRunResult> {
-      const agentTargetId = resolveIssueManagerRequestAgentTargetId(
-        request.agentTargetId,
-        request.provider
+      const copy = createIssueManagerI18nRuntime(input.i18n);
+      const messages = createIssueManagerAgentLaunchMessages(copy);
+      const agentTargetId = resolveIssueManagerRequestAgentTargetIdOrError(
+        request.agentTargetId
       );
+      if (!agentTargetId) {
+        return {
+          errorMessage: messages.agentTargetRequired,
+          status: "failed"
+        };
+      }
       const prompt = buildIssueManagerRunPrompt({
-        copy: createIssueManagerI18nRuntime(input.i18n),
+        copy,
         issue: request.issue,
         task: request.task,
         workspaceRoot: "."
       });
       return openIssueManagerAgentDraft({
         agentTargetId,
+        agentGuiLaunchUnavailableMessage: messages.agentGuiLaunchUnavailable,
         draftPrompt: prompt,
         launchAgentGui: input.launchAgentGui,
         provider: request.provider,
@@ -71,6 +81,7 @@ export function createDesktopIssueManagerAgentRunner(input: {
 
 function openIssueManagerAgentDraft(input: {
   agentTargetId: string;
+  agentGuiLaunchUnavailableMessage: string;
   draftPrompt: string;
   launchAgentGui?: (
     input: DesktopIssueManagerAgentGuiLaunchInput
@@ -86,7 +97,7 @@ function openIssueManagerAgentDraft(input: {
   const launchAgentGui = input.launchAgentGui;
   if (!launchAgentGui) {
     return Promise.resolve({
-      errorMessage: "issue_manager.agent_gui_launch_unavailable",
+      errorMessage: input.agentGuiLaunchUnavailableMessage,
       status: "failed"
     });
   }
@@ -116,8 +127,19 @@ export function createDesktopIssueManagerAgentBreakdownLauncher(input: {
 }): IssueManagerAgentBreakdownLauncher {
   return {
     async startBreakdown(request): Promise<IssueManagerAgentBreakdownResult> {
+      const copy = createIssueManagerI18nRuntime(input.i18n);
+      const messages = createIssueManagerAgentLaunchMessages(copy);
+      const agentTargetId = resolveIssueManagerRequestAgentTargetIdOrError(
+        request.agentTargetId
+      );
+      if (!agentTargetId) {
+        return {
+          errorMessage: messages.agentTargetRequired,
+          status: "failed"
+        };
+      }
       const prompt = buildIssueManagerTaskBreakdownPrompt({
-        copy: createIssueManagerI18nRuntime(input.i18n),
+        copy,
         issueDetail: {
           contextRefs: [...request.issueDetail.contextRefs],
           issue: request.issueDetail.issue,
@@ -126,10 +148,8 @@ export function createDesktopIssueManagerAgentBreakdownLauncher(input: {
         workspaceId: input.workspaceId
       });
       const session = await openIssueManagerAgentDraft({
-        agentTargetId: resolveIssueManagerRequestAgentTargetId(
-          request.agentTargetId,
-          request.provider
-        ),
+        agentTargetId,
+        agentGuiLaunchUnavailableMessage: messages.agentGuiLaunchUnavailable,
         draftPrompt: prompt,
         launchAgentGui: input.launchAgentGui,
         provider: request.provider,
@@ -143,24 +163,12 @@ export function createDesktopIssueManagerAgentBreakdownLauncher(input: {
   };
 }
 
-function resolveIssueManagerRequestAgentTargetId(
-  agentTargetId: string | null | undefined,
-  provider: string
-): string {
+function resolveIssueManagerRequestAgentTargetIdOrError(
+  agentTargetId: string | null | undefined
+): string | null {
   const normalizedAgentTargetId = agentTargetId?.trim();
   if (normalizedAgentTargetId) {
     return normalizedAgentTargetId;
   }
-  switch (provider.trim()) {
-    case "codex":
-      return "local:codex";
-    case "claude-code":
-      return "local:claude-code";
-    case "cursor":
-      return "local:cursor";
-    case "opencode":
-      return "local:opencode";
-    default:
-      return "";
-  }
+  return null;
 }

--- a/apps/desktop/src/renderer/src/features/workspace-issue-manager/internal/desktopIssueManagerNodeState.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-issue-manager/internal/desktopIssueManagerNodeState.ts
@@ -23,7 +23,6 @@ type DesktopIssueManagerLiveNodeState = DesktopIssueManagerRestorableNodeState &
   Pick<IssueManagerNodeState, "selectedTaskId">;
 
 export function createDesktopIssueManagerNodeStateSource(input: {
-  defaultAgentProvider?: string | null;
   workspaceId: string;
 }): {
   externalStateSource: WorkbenchHostExternalStateSource<
@@ -56,9 +55,7 @@ export function createDesktopIssueManagerNodeStateSource(input: {
           return null;
         }
         const state = nodeStateByInstanceId.get(request.instanceId);
-        return state
-          ? { ...state }
-          : defaultIssueManagerNodeState(input.defaultAgentProvider);
+        return state ? { ...state } : null;
       },
       getSnapshotNodeState(request) {
         if (request.typeId !== "issue-manager") {
@@ -92,13 +89,6 @@ export function createDesktopIssueManagerNodeStateSource(input: {
       notify();
     }
   };
-}
-
-function defaultIssueManagerNodeState(
-  defaultAgentProvider: string | null | undefined
-): Partial<IssueManagerNodeState> | null {
-  const provider = defaultAgentProvider?.trim() ?? "";
-  return provider ? { selectedAgentTargetId: `local:${provider}` } : null;
 }
 
 function liveIssueManagerNodeState(

--- a/apps/desktop/src/renderer/src/features/workspace-workbench/services/internal/workspaceIssueManagerContribution.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/services/internal/workspaceIssueManagerContribution.ts
@@ -46,10 +46,7 @@ import { requestWorkspaceBrowserLaunch } from "../workspaceBrowserLaunchCoordina
 import { requestWorkspaceFilesLaunch } from "../workspaceFilesLaunchCoordinator.ts";
 import { requestWorkspaceIssueManagerLaunch } from "../workspaceIssueManagerLaunchCoordinator.ts";
 import { createWorkspaceIssueManagerRichTextTriggerProviderRequestFromIdentity } from "./workspaceIssueManagerRichTextTriggerProviderRequest.ts";
-import {
-  resolveWorkspaceAgentGuiLabel,
-  workspaceAgentGuiProviders
-} from "./workspaceAgentProviderCatalog.ts";
+import { resolveWorkspaceAgentGuiLabel } from "./workspaceAgentProviderCatalog.ts";
 import { renderIssueManagerLatestRunMessageCenterCard } from "../../ui/IssueManagerLatestRunMessageCenterCard.tsx";
 import { workspaceTaskDockSectionId } from "./workspaceDockSections.ts";
 
@@ -148,7 +145,6 @@ export function createWorkspaceIssueManagerContribution(input: {
     workspaceId: input.workspaceId
   });
   const nodeStateSource = createDesktopIssueManagerNodeStateSource({
-    defaultAgentProvider: input.defaultAgentProvider,
     workspaceId: input.workspaceId
   });
   const identityAdapter = createDesktopIssueManagerIdentityAdapter();
@@ -245,17 +241,7 @@ function resolveIssueManagerReadyAgentTargetOptions(
       .map((status) => status.provider)
   );
 
-  const targetSource =
-    providerTargets && providerTargets.length > 0
-      ? providerTargets
-      : workspaceAgentGuiProviders.map((provider) => ({
-          agentTargetId: `local:${provider}`,
-          disabled: false,
-          iconUrl: agentGuiDockIconUrls[provider],
-          label: resolveWorkspaceAgentGuiLabel(provider),
-          provider
-        }));
-  const options = targetSource
+  const options = (providerTargets ?? [])
     .filter(
       (target) =>
         target.disabled !== true &&

--- a/docs/architecture/agent-activity-packages.md
+++ b/docs/architecture/agent-activity-packages.md
@@ -213,14 +213,14 @@ export interface AgentActivityAdapter {
 }
 ```
 
-`AgentActivityCreateSessionInput.agentTargetId` is the preferred authority for
-new target-backed launches. Shared UI passes it through unchanged; trusted host
-or daemon code resolves it against `agent_targets`, validates enabled state and
-launch ref shape, and derives the execution `provider` and runtime
-`providerTargetRef` from the resolved target. Target-backed create requests may
-omit `provider`; if both fields are present, the daemon rejects provider
-mismatches. Client-provided `providerTargetRef` is not allowed to override the
-daemon-derived runtime ref when `agentTargetId` is present. The resulting
+`AgentActivityRuntime.activateSession` requires `agentTargetId` for
+`mode: "new"`. Shared UI passes it through unchanged; trusted host or daemon code
+resolves it against `agent_targets`, validates enabled state and launch ref
+shape, and derives the execution `provider` and runtime `providerTargetRef`
+from the resolved target. Target-backed create requests may omit `provider`; if
+both fields are present, the daemon rejects provider mismatches. Client-provided
+`providerTargetRef` is not allowed to override the daemon-derived runtime ref
+when `agentTargetId` is present. The resulting
 `AgentActivitySession` and session events should preserve `agentTargetId` when
 present. State patch reducers must update the session when an event includes
 `agentTargetId`, but a patch that omits the field must not clear an existing
@@ -234,11 +234,12 @@ but target-backed loads must not reuse or overwrite the provider cache.
 `AgentActivityCreateSessionInput.providerTargetRef` is an optional opaque
 host-owned legacy reference for selecting which target under the real provider
 should launch the session. It is not authority, a credential, or an invocation
-plan. It remains a provider-only compatibility hint; target-backed launches use
+plan. New runtime launches must provide `agentTargetId`; `providerTargetRef`
+must not be used as a provider-only launch fallback. Target-backed launches use
 the daemon-derived ref shape from `agent_targets` instead. Adapters and trusted
-launchers must re-authenticate and resolve it before using any concrete
-provider invocation. UI packages must keep `provider` as the real provider
-identity and must not synthesize providers for shared or remote targets.
+launchers must re-authenticate and resolve it before using any concrete provider
+invocation. UI packages must keep `provider` as the real provider identity and
+must not synthesize providers for shared or remote targets.
 
 The adapter decides how to connect. The controller decides when to connect,
 when to disconnect, and how to merge the resulting events.

--- a/docs/architecture/agent-gui-node.md
+++ b/docs/architecture/agent-gui-node.md
@@ -1295,7 +1295,7 @@ activity data source:
 ### Provider Targets
 
 AgentGUI distinguishes launch authority, real provider identity, and legacy
-provider-target compatibility. `agentTargetId` is the authority for new
+provider-target state recovery. `agentTargetId` is required authority for new
 session launches, workbench target selection, and AgentGUI node state. The
 daemon resolves that id against `agent_targets` and derives the execution
 provider and runtime `providerTargetRef` from the trusted target `launchRef`.
@@ -1320,8 +1320,13 @@ AgentGUI owns only target display and passthrough:
 - read legacy `providerTargetId` / `providerTargetRef` from old workbench node
   state to recover the selected target
 - pass `agentTargetId` through `AgentActivityRuntime.activateSession`
-- pass `providerTargetRef` only as a legacy opaque compatibility hint for
-  provider-only launches
+- pass `providerTargetRef` only as legacy opaque state for selection recovery;
+  it must not authorize or replace `agentTargetId` for new launches
+
+New-session surfaces, including the composer, batch runner, App Center, and
+issue-manager launchers, must fail or disable launch when no `agentTargetId` is
+available. They must not synthesize `local:<provider>` from a provider-only
+selection as a compatibility fallback.
 
 `providerTargetId` and `providerTargetRef` are transition fields, not daemon
 authority. AgentGUI must not interpret `ref.kind`, mint invocation-control

--- a/packages/agent/activity-core/src/controller.test.ts
+++ b/packages/agent/activity-core/src/controller.test.ts
@@ -1613,7 +1613,7 @@ function fakeAdapter(
     createSession: async (input) => ({
       workspaceId: input.workspaceId,
       agentSessionId: "session-1",
-      provider: input.provider,
+      provider: "codex",
       cwd: input.cwd ?? "",
       title: input.title ?? "",
       status: "working"

--- a/packages/agent/activity-core/src/index.ts
+++ b/packages/agent/activity-core/src/index.ts
@@ -64,7 +64,6 @@ export type {
   AgentActivityComposerSettings,
   AgentActivityComposerSkillOption,
   AgentActivityCreateSessionInput,
-  AgentActivityProviderTargetRef,
   AgentActivityDeleteSessionInput,
   AgentActivityDeleteSessionResult,
   AgentActivityCompletedCommand,

--- a/packages/agent/activity-core/src/types.ts
+++ b/packages/agent/activity-core/src/types.ts
@@ -259,16 +259,10 @@ export interface AgentActivityUpdatedApplyResult {
   statePatch: AgentActivityStatePatch | null;
 }
 
-export interface AgentActivityProviderTargetRef {
-  kind: string;
-  provider: string;
-  [key: string]: unknown;
-}
-
 export interface AgentActivityCreateSessionInput {
   workspaceId: string;
   agentSessionId?: string | null;
-  agentTargetId?: string | null;
+  agentTargetId: string;
   cwd?: string | null;
   initialContent?: AgentPromptContentBlock[] | null;
   /** 仅展示用的首轮文本(bundle 折叠成一个 chip);initialContent 仍带展开后的文件。 */
@@ -277,12 +271,6 @@ export interface AgentActivityCreateSessionInput {
   model?: string | null;
   planMode?: boolean | null;
   permissionModeId?: string | null;
-  provider: string;
-  /**
-   * Opaque host-owned launch target reference. It is not authority; adapters
-   * must re-authenticate and resolve it before using any concrete invocation.
-   */
-  providerTargetRef?: AgentActivityProviderTargetRef | null;
   reasoningEffort?: string | null;
   runtimeContext?: Record<string, unknown> | null;
   speed?: string | null;

--- a/packages/agent/gui/README.md
+++ b/packages/agent/gui/README.md
@@ -90,12 +90,11 @@ export interface AgentGUIProviderTarget {
 
 AgentGUI does not interpret `ref.kind` and does not treat `targetId` or `ref`
 as authority. It displays `target.label`, keeps provider logic keyed by the
-real `target.provider`, and passes `providerTargetRef` through activation.
-Trusted host code must re-authenticate the current user/workspace and resolve
-any invocation plan before launching.
+real `target.provider`, and starts new sessions with the selected
+`agentTargetId`. Trusted host code must re-authenticate the current
+user/workspace and resolve any invocation plan before launching.
 
 If `providerTargets` is omitted or empty, AgentGUI creates local targets such as
 `local:codex` and `local:claude-code` from the static provider catalog for
 display/backward compatibility. Those static catalog targets are not persisted
-or sent as `providerTargetRef`; legacy hosts continue to receive only the real
-`provider`.
+or sent as session creation authority.

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUIActivation.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUIActivation.ts
@@ -7,7 +7,6 @@ import {
 import type { AgentSessionComposerSettings } from "../../../shared/agentSessionTypes";
 import { getAppErrorCode } from "../../../shared/errors/appError";
 import { useAgentActivityRuntime } from "../../../agentActivityRuntime";
-import type { AgentGUIProviderTargetRef } from "../../../types";
 
 type AgentGUILiveState = "inactive" | "activating" | "active" | "failed";
 interface AgentGUIActivateInput {
@@ -19,8 +18,6 @@ interface AgentGUIActivateInput {
   metadata?: Record<string, unknown>;
   mode: "existing" | "new";
   openclawGatewayReady?: boolean;
-  provider?: string;
-  providerTargetRef?: AgentGUIProviderTargetRef | null;
   settings?: AgentSessionComposerSettings;
   title?: string;
   visible?: boolean;
@@ -65,20 +62,22 @@ export function useAgentGUIActivation({
         [agentSessionId]: null
       }));
       try {
+        const agentTargetId = input.agentTargetId?.trim() ?? "";
+        if (input.mode === "new" && !agentTargetId) {
+          throw new Error("agent_target_required");
+        }
         const request =
           input.mode === "new"
             ? {
                 mode: input.mode,
                 workspaceId,
                 agentSessionId,
-                agentTargetId: input.agentTargetId,
-                provider: input.provider,
+                agentTargetId,
                 cwd: input.cwd,
                 initialContent: input.initialContent,
                 initialDisplayPrompt: input.initialDisplayPrompt,
                 metadata: input.metadata,
                 title: input.title,
-                providerTargetRef: input.providerTargetRef,
                 settings: input.settings,
                 visible: input.visible,
                 openclawGatewayReady: input.openclawGatewayReady
@@ -122,7 +121,7 @@ export function useAgentGUIActivation({
         throw error;
       }
     },
-    [agentActivityRuntime, getErrorMessage, workspaceId]
+    [agentActivityRuntime, getErrorCode, getErrorMessage, workspaceId]
   );
 
   const unactivate = useCallback(

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUINodeController.spec.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUINodeController.spec.tsx
@@ -1190,7 +1190,7 @@ describe("useAgentGUINodeController", () => {
     expect(result.current.viewModel.providerReadinessGate).toBeNull();
   });
 
-  it("selects provider-only rail targets for the empty composer", async () => {
+  it("selects target-backed rail targets for the empty composer", async () => {
     installAgentHostApi({
       list: vi.fn(async () => ({ presences: [], sessions: [] })),
       listSessionTimeline: vi.fn(async () => ({ timelineItems: [] })),
@@ -1537,8 +1537,7 @@ describe("useAgentGUINodeController", () => {
       expect(activate).toHaveBeenCalledWith(
         expect.objectContaining({
           mode: "new",
-          agentTargetId: "local:codex",
-          provider: "codex"
+          agentTargetId: "local:codex"
         })
       );
     });
@@ -2891,9 +2890,7 @@ describe("useAgentGUINodeController", () => {
       expect(activate).toHaveBeenCalledWith(
         expect.objectContaining({
           mode: "new",
-          agentTargetId: "agent-target-1",
-          provider: "codex",
-          providerTargetRef: null
+          agentTargetId: "agent-target-1"
         })
       );
     });
@@ -3006,7 +3003,7 @@ describe("useAgentGUINodeController", () => {
     });
   });
 
-  it("falls back to local provider targets for new conversation submit when provider targets are explicitly empty", async () => {
+  it("blocks new conversation submit when provider targets fall back to the static catalog", async () => {
     const activate = vi.fn(
       async (input: AgentHostActivateAgentSessionInput) => ({
         session: agentSession(input.agentSessionId, {
@@ -3034,20 +3031,14 @@ describe("useAgentGUINodeController", () => {
       })
     );
 
-    expect(result.current.viewModel.canSubmit).toBe(true);
-
     act(() => {
       result.current.actions.submitPrompt(promptBlocks("start without target"));
     });
 
     await waitFor(() => {
-      expect(activate).toHaveBeenCalledWith(
-        expect.objectContaining({
-          agentTargetId: "local:codex",
-          mode: "new",
-          provider: "codex",
-          providerTargetRef: null
-        })
+      expect(activate).not.toHaveBeenCalled();
+      expect(result.current.viewModel.detailError).toBe(
+        "Select an available agent target before starting a session."
       );
     });
   });
@@ -3202,9 +3193,7 @@ describe("useAgentGUINodeController", () => {
       expect(activate).toHaveBeenCalledWith(
         expect.objectContaining({
           mode: "new",
-          agentTargetId: "local:codex",
-          provider: "codex",
-          providerTargetRef: null
+          agentTargetId: "local:codex"
         })
       );
     });
@@ -7001,7 +6990,6 @@ describe("useAgentGUINodeController", () => {
 
     expect(activate).toHaveBeenCalledWith(
       expect.objectContaining({
-        provider: "codex",
         title: "hello from hero"
       })
     );
@@ -11362,7 +11350,6 @@ describe("useAgentGUINodeController", () => {
         expect.objectContaining({
           mode: "new",
           workspaceId: "room-1",
-          provider: "codex",
           ...initialPromptContent("first prompt"),
           settings: {
             model: "gpt-5",
@@ -18296,9 +18283,7 @@ function installAgentActivityRuntimeForHostMocks({
         agentSessionId: input.agentSessionId,
         ...(input.mode === "new"
           ? {
-              provider: input.provider,
               agentTargetId: input.agentTargetId,
-              providerTargetRef: input.providerTargetRef,
               cwd: input.cwd,
               initialContent: input.initialContent,
               title: input.title,
@@ -18355,7 +18340,8 @@ function installAgentActivityRuntimeForHostMocks({
         mode: "new",
         workspaceId: input.workspaceId,
         agentSessionId: input.agentSessionId ?? createTestAgentSessionId(),
-        provider: input.provider,
+        provider:
+          input.agentTargetId === "local:claude-code" ? "claude-code" : "codex",
         agentTargetId: input.agentTargetId,
         cwd: input.cwd ?? undefined,
         title: input.title ?? undefined,
@@ -18671,7 +18657,10 @@ function installNoopAgentActivityRuntimeForTests(): void {
           input.workspaceId,
           {
             agentSessionId: input.agentSessionId ?? createTestAgentSessionId(),
-            provider: input.provider,
+            provider:
+              input.agentTargetId === "local:claude-code"
+                ? "claude-code"
+                : "codex",
             status: "ready"
           }
         ),

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUINodeController.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUINodeController.ts
@@ -3879,9 +3879,6 @@ export function useAgentGUINodeController({
   );
   const effectiveSelectedProviderTarget =
     homeComposerTargetOverride ?? selectedProviderTarget;
-  const effectiveSelectedProviderTargetIsExplicit = homeComposerTargetOverride
-    ? homeComposerTargetOverrideIsExplicit
-    : selectedProviderTargetIsExplicit;
   const firstReadyHomeComposerProviderTarget = useMemo(() => {
     if (!providerReadinessGates) {
       return null;
@@ -4437,10 +4434,15 @@ export function useAgentGUINodeController({
   const selectedProviderTargetRef = useRef(effectiveSelectedProviderTarget);
   selectedProviderTargetRef.current = effectiveSelectedProviderTarget;
   const selectedProviderTargetIsExplicitRef = useRef(
-    effectiveSelectedProviderTargetIsExplicit
+    homeComposerTargetOverride
+      ? homeComposerTargetOverrideIsExplicit
+      : selectedProviderTargetIsExplicit
   );
-  selectedProviderTargetIsExplicitRef.current =
-    effectiveSelectedProviderTargetIsExplicit;
+  selectedProviderTargetIsExplicitRef.current = homeComposerTargetOverride
+    ? homeComposerTargetOverrideIsExplicit
+    : selectedProviderTargetIsExplicit;
+  const providerTargetsProvidedRef = useRef(providerTargets !== undefined);
+  providerTargetsProvidedRef.current = providerTargets !== undefined;
   const selectedComposerTargetDataRef = useRef(selectedComposerTargetData);
   selectedComposerTargetDataRef.current = selectedComposerTargetData;
   const draftSettingsBySessionIdRef = useRef(draftSettingsBySessionId);
@@ -7356,7 +7358,11 @@ export function useAgentGUINodeController({
         return;
       }
       const agentTargetId = targetData.agentTargetId ?? "";
-      if (!agentTargetId && selectedProviderTargetIsExplicitRef.current) {
+      if (
+        !agentTargetId ||
+        (providerTargetsProvidedRef.current &&
+          !selectedProviderTargetIsExplicitRef.current)
+      ) {
         setDetailError(translate("agentHost.agentGui.agentTargetRequired"));
         return;
       }
@@ -7589,8 +7595,6 @@ export function useAgentGUINodeController({
           mode: "new",
           agentSessionId,
           agentTargetId: agentTargetId || null,
-          provider,
-          providerTargetRef: targetData.providerTargetRef,
           cwd: selectedProjectPath ?? "",
           initialContent: normalizedInitialContent,
           initialDisplayPrompt,

--- a/packages/agent/gui/agentActivityRuntime.tsx
+++ b/packages/agent/gui/agentActivityRuntime.tsx
@@ -31,7 +31,6 @@ import type {
   AgentHostUnactivateAgentSessionResult,
   AgentHostAgentSessionState
 } from "./shared/contracts/dto";
-import type { AgentGUIProviderTargetRef } from "./types";
 import { WORKSPACE_AGENT_ACTIVITY_RUNTIME_SESSION_ORIGIN } from "./shared/workspaceAgentActivityTypes";
 
 export interface AgentActivityRuntimeListSessionMessagesInput {
@@ -179,27 +178,29 @@ export interface AgentActivityRuntimeDiagnosticInput {
   workspaceId?: string | null;
 }
 
-export interface AgentActivityRuntimeActivateSessionInput {
+interface AgentActivityRuntimeActivateSessionInputBase {
   agentSessionId: string;
-  agentTargetId?: string | null;
   cwd?: string;
   initialContent?: AgentActivitySendInput["content"];
   /** 仅展示用首轮文本(bundle 折叠成一个 chip);initialContent 仍带展开后的文件。 */
   initialDisplayPrompt?: string | null;
   metadata?: Record<string, unknown>;
-  mode: "existing" | "new";
   openclawGatewayReady?: boolean;
-  provider?: string;
-  /**
-   * Opaque host-owned target reference. AgentGUI passes this through only; hosts
-   * must not treat it as authority and must re-authenticate before launch.
-   */
-  providerTargetRef?: AgentGUIProviderTargetRef | null;
   settings?: AgentHostAgentSessionComposerSettings;
   title?: string;
   visible?: boolean;
   workspaceId: string;
 }
+
+export type AgentActivityRuntimeActivateSessionInput =
+  | (AgentActivityRuntimeActivateSessionInputBase & {
+      agentTargetId: string;
+      mode: "new";
+    })
+  | (AgentActivityRuntimeActivateSessionInputBase & {
+      agentTargetId?: string | null;
+      mode: "existing";
+    });
 
 export interface AgentActivityRuntimeUnactivateSessionInput {
   agentSessionId: string;

--- a/packages/workspace/issue-manager/src/i18n/index.ts
+++ b/packages/workspace/issue-manager/src/i18n/index.ts
@@ -1,4 +1,5 @@
 export {
+  createIssueManagerAgentLaunchMessages,
   createIssueManagerI18nRuntime,
   issueManagerI18nModule,
   issueManagerI18nNamespace,

--- a/packages/workspace/issue-manager/src/i18n/issueManagerI18n.test.ts
+++ b/packages/workspace/issue-manager/src/i18n/issueManagerI18n.test.ts
@@ -2,6 +2,7 @@ import assert from "node:assert/strict";
 import test from "node:test";
 import { createI18nRuntime } from "@tutti-os/ui-i18n-runtime";
 import {
+  createIssueManagerAgentLaunchMessages,
   createIssueManagerI18nRuntime,
   issueManagerI18nResources
 } from "./issueManagerI18n.ts";
@@ -47,6 +48,18 @@ test("zh-CN task terminology and status labels use requested copy", () => {
   assert.equal(copy.t("labels.taskCount", { count: 7 }), "7 个子任务");
   assert.equal(copy.t("labels.taskDetails"), "任务详情");
   assert.equal(copy.t("labels.taskList"), "任务");
+  assert.equal(
+    copy.t("messages.agentTargetRequired"),
+    "请先选择可用的 Agent 目标。"
+  );
+  assert.equal(
+    copy.t("messages.agentGuiLaunchUnavailable"),
+    "当前环境无法创建 Agent 草稿。"
+  );
+  assert.deepEqual(createIssueManagerAgentLaunchMessages(copy), {
+    agentGuiLaunchUnavailable: "当前环境无法创建 Agent 草稿。",
+    agentTargetRequired: "请先选择可用的 Agent 目标。"
+  });
   assert.equal(copy.t("messages.noIssues"), "还没有任务");
   assert.equal(copy.t("messages.noTasks"), "还没有任务");
   assert.equal(copy.t("status.notStarted"), "待开始");
@@ -101,6 +114,18 @@ test("en task terminology and status labels use requested copy", () => {
   assert.equal(copy.t("labels.taskCount", { count: 7 }), "7 subtasks");
   assert.equal(copy.t("labels.taskDetails"), "Task details");
   assert.equal(copy.t("labels.taskList"), "Tasks");
+  assert.equal(
+    copy.t("messages.agentTargetRequired"),
+    "Select an available agent target first."
+  );
+  assert.equal(
+    copy.t("messages.agentGuiLaunchUnavailable"),
+    "Agent session drafting is unavailable."
+  );
+  assert.deepEqual(createIssueManagerAgentLaunchMessages(copy), {
+    agentGuiLaunchUnavailable: "Agent session drafting is unavailable.",
+    agentTargetRequired: "Select an available agent target first."
+  });
   assert.equal(copy.t("messages.noIssues"), "No tasks yet");
   assert.equal(copy.t("messages.noTasks"), "No tasks yet");
   assert.equal(copy.t("status.notStarted"), "Todo");

--- a/packages/workspace/issue-manager/src/i18n/issueManagerI18n.ts
+++ b/packages/workspace/issue-manager/src/i18n/issueManagerI18n.ts
@@ -125,6 +125,8 @@ const issueManagerEn = {
   },
   messages: {
     clipboardUnavailable: "Clipboard is unavailable.",
+    agentTargetRequired: "Select an available agent target first.",
+    agentGuiLaunchUnavailable: "Agent session drafting is unavailable.",
     agentSessionOpenFailed: "Couldn't open the agent session.",
     breakdownOpenFailed: "Couldn't open the agent task breakdown.",
     breakdownUnavailable: "Agent task breakdown is unavailable.",
@@ -361,6 +363,8 @@ const issueManagerZhCN = {
   },
   messages: {
     clipboardUnavailable: "当前环境无法访问剪贴板。",
+    agentTargetRequired: "请先选择可用的 Agent 目标。",
+    agentGuiLaunchUnavailable: "当前环境无法创建 Agent 草稿。",
     agentSessionOpenFailed: "打开 Agent 会话失败。",
     breakdownOpenFailed: "打开 Agent 任务拆解失败。",
     breakdownUnavailable: "当前环境暂不支持 Agent 任务拆解。",
@@ -518,4 +522,16 @@ export function createIssueManagerI18nRuntime(
     runtime ?? defaultIssueManagerI18n,
     issueManagerI18nNamespace
   );
+}
+
+export function createIssueManagerAgentLaunchMessages(
+  copy: IssueManagerI18nRuntime
+): {
+  agentGuiLaunchUnavailable: string;
+  agentTargetRequired: string;
+} {
+  return {
+    agentGuiLaunchUnavailable: copy.t("messages.agentGuiLaunchUnavailable"),
+    agentTargetRequired: copy.t("messages.agentTargetRequired")
+  };
 }

--- a/packages/workspace/issue-manager/src/services/internal/controllerActionTestHarness.ts
+++ b/packages/workspace/issue-manager/src/services/internal/controllerActionTestHarness.ts
@@ -3,6 +3,7 @@ import type {
   IssueManagerContextRef,
   IssueManagerIssueDetail,
   IssueManagerIssueSummary,
+  IssueManagerAgentTargetOption,
   IssueManagerAnalyticsAdapter,
   IssueManagerNodeState,
   IssueManagerRun,
@@ -26,6 +27,7 @@ export function createControllerActionsHarness(input?: {
     NonNullable<IssueManagerFeature["agentSessionOpener"]>
   >;
   analytics?: IssueManagerAnalyticsAdapter;
+  agentTargetOptions?: readonly IssueManagerAgentTargetOption[];
   agentRunner?: Partial<IssueManagerFeature["agentRunner"]>;
   backend?: Partial<IssueManagerFeature["backend"]>;
   executionDirectoryPicker?: Partial<
@@ -110,6 +112,11 @@ export function createControllerActionsHarness(input?: {
           ...input.agentSessionOpener
         }
       : undefined,
+    agentTargetOptions: {
+      getOptions() {
+        return input?.agentTargetOptions ?? defaultAgentTargetOptions;
+      }
+    },
     backend: {
       addContextRefs() {
         return resolved([]);
@@ -283,6 +290,24 @@ export function createControllerActionsHarness(input?: {
     taskEditorModeState
   };
 }
+
+const defaultAgentTargetOptions: readonly IssueManagerAgentTargetOption[] = [
+  {
+    agentTargetId: "local:codex",
+    label: "Codex",
+    provider: "codex"
+  },
+  {
+    agentTargetId: "local:claude-code",
+    label: "Claude Code",
+    provider: "claude-code"
+  },
+  {
+    agentTargetId: "local:gemini",
+    label: "Gemini",
+    provider: "gemini"
+  }
+];
 
 function resolved<TValue>(value: TValue): Promise<TValue> {
   return Promise.resolve(value);

--- a/packages/workspace/issue-manager/src/services/internal/controllerActions.test.ts
+++ b/packages/workspace/issue-manager/src/services/internal/controllerActions.test.ts
@@ -1455,12 +1455,98 @@ test("controller actions report unavailable agent task breakdown", async () => {
   ]);
 });
 
+test("controller actions notify when running without an available agent target", async () => {
+  let runCalls = 0;
+  const harness = createControllerActionsHarness({
+    agentRunner: {
+      async runTask() {
+        runCalls += 1;
+        return {
+          status: "completed"
+        };
+      }
+    },
+    agentTargetOptions: [],
+    issueDetail: {
+      contextRefs: [],
+      issue: createIssueSummary({
+        issueId: "issue-1",
+        title: "Plan migration"
+      }),
+      latestOutputs: [],
+      recentRuns: [],
+      tasks: [
+        createTaskSummary({
+          issueId: "issue-1",
+          taskId: "task-1",
+          title: "Port renderer"
+        })
+      ]
+    },
+    nodeState: {
+      issueSearchQuery: "",
+      issueStatusFilter: "all",
+      selectedAgentTargetId: "local:codex",
+      selectedIssueId: "issue-1",
+      selectedTaskId: "task-1"
+    }
+  });
+
+  await harness.actions.runTask();
+
+  assert.equal(runCalls, 0);
+  assert.deepEqual(harness.notificationState.history, [
+    "messages.agentTargetRequired"
+  ]);
+  assert.deepEqual(harness.isRunningTaskState.history, []);
+});
+
+test("controller actions notify when breaking down without an available agent target", async () => {
+  let breakdownCalls = 0;
+  const harness = createControllerActionsHarness({
+    agentBreakdownLauncher: {
+      async startBreakdown() {
+        breakdownCalls += 1;
+        return {
+          status: "opened"
+        };
+      }
+    },
+    agentTargetOptions: [],
+    issueDetail: {
+      contextRefs: [],
+      issue: createIssueSummary({
+        issueId: "issue-1",
+        title: "Plan migration"
+      }),
+      latestOutputs: [],
+      recentRuns: [],
+      tasks: []
+    },
+    nodeState: {
+      issueSearchQuery: "",
+      issueStatusFilter: "all",
+      selectedAgentTargetId: "local:codex",
+      selectedIssueId: "issue-1",
+      selectedTaskId: null
+    }
+  });
+
+  await harness.actions.startTaskBreakdown();
+
+  assert.equal(breakdownCalls, 0);
+  assert.deepEqual(harness.notificationState.history, [
+    "messages.agentTargetRequired"
+  ]);
+  assert.deepEqual(harness.isRunningTaskState.history, []);
+});
+
 test("controller actions report run result error messages", async () => {
   const harness = createControllerActionsHarness({
     agentRunner: {
       async runTask() {
         return {
-          errorMessage: "issue_manager.agent_gui_launch_unavailable",
+          errorMessage: "Agent session drafting is unavailable.",
           status: "failed"
         };
       }
@@ -1503,7 +1589,7 @@ test("controller actions report run result error messages", async () => {
   await harness.actions.runTask();
 
   assert.deepEqual(harness.notificationState.history, [
-    "issue_manager.agent_gui_launch_unavailable"
+    "Agent session drafting is unavailable."
   ]);
   assert.deepEqual(harness.isRunningTaskState.history, [true, false]);
   assert.equal(harness.refreshDetailsCount, 1);

--- a/packages/workspace/issue-manager/src/services/internal/controllerActions.ts
+++ b/packages/workspace/issue-manager/src/services/internal/controllerActions.ts
@@ -687,6 +687,10 @@ export function createIssueManagerControllerActions(
         selectedAgentTargetId: nodeState.selectedAgentTargetId,
         taskDetail: taskDetail.value
       });
+      if (runPlan.kind === "blocked") {
+        notifyTip(copy.t(runPlan.notificationKey));
+        return;
+      }
       if (runPlan.kind !== "ready") {
         return;
       }
@@ -751,6 +755,10 @@ export function createIssueManagerControllerActions(
         selectedAgentTargetId: nodeState.selectedAgentTargetId,
         taskDetail: taskDetail.value
       });
+      if (breakdownPlan.kind === "blocked") {
+        notifyTip(copy.t(breakdownPlan.notificationKey));
+        return;
+      }
       if (breakdownPlan.kind !== "ready") {
         return;
       }

--- a/packages/workspace/issue-manager/src/services/internal/controllerPlans.test.ts
+++ b/packages/workspace/issue-manager/src/services/internal/controllerPlans.test.ts
@@ -18,8 +18,22 @@ import {
 } from "./controllerActionTestHarness.ts";
 
 test("controllerPlans create run-task plans from detail and agent target intent", () => {
+  const agentTargetOptions = [
+    {
+      agentTargetId: "local:codex",
+      label: "Codex",
+      provider: "codex"
+    },
+    {
+      agentTargetId: "local:claude-code",
+      label: "Claude Code",
+      provider: "claude-code"
+    }
+  ];
+
   assert.deepEqual(
     createIssueManagerRunTaskPlan({
+      agentTargetOptions,
       issueDetail: null,
       selectedAgentTargetId: "local:codex",
       taskDetail: createTaskDetail()
@@ -28,6 +42,7 @@ test("controllerPlans create run-task plans from detail and agent target intent"
   );
   assert.deepEqual(
     createIssueManagerRunTaskPlan({
+      agentTargetOptions,
       issueDetail: createIssueDetail(),
       agentTargetIdOverride: " local:claude-code ",
       selectedAgentTargetId: "local:codex",
@@ -42,6 +57,7 @@ test("controllerPlans create run-task plans from detail and agent target intent"
   );
   assert.deepEqual(
     createIssueManagerRunTaskPlan({
+      agentTargetOptions,
       issueDetail: createIssueDetail(),
       agentTargetIdOverride: "   ",
       selectedAgentTargetId: "local:codex",
@@ -52,6 +68,39 @@ test("controllerPlans create run-task plans from detail and agent target intent"
       kind: "ready",
       provider: "codex",
       shouldUpdateSelectedAgentTargetId: false
+    }
+  );
+});
+
+test("controllerPlans block run-task plans when the selected agent target is unavailable", () => {
+  assert.deepEqual(
+    createIssueManagerRunTaskPlan({
+      agentTargetOptions: [],
+      issueDetail: createIssueDetail(),
+      selectedAgentTargetId: "local:codex",
+      taskDetail: createTaskDetail()
+    }),
+    {
+      kind: "blocked",
+      notificationKey: "messages.agentTargetRequired"
+    }
+  );
+  assert.deepEqual(
+    createIssueManagerRunTaskPlan({
+      agentTargetOptions: [
+        {
+          agentTargetId: "local:codex",
+          label: "Codex",
+          provider: "   "
+        }
+      ],
+      issueDetail: createIssueDetail(),
+      selectedAgentTargetId: "local:codex",
+      taskDetail: createTaskDetail()
+    }),
+    {
+      kind: "blocked",
+      notificationKey: "messages.agentTargetRequired"
     }
   );
 });

--- a/packages/workspace/issue-manager/src/services/internal/controllerPlans.ts
+++ b/packages/workspace/issue-manager/src/services/internal/controllerPlans.ts
@@ -25,6 +25,10 @@ export function createIssueManagerRunTaskPlan(input: {
       provider: string;
       shouldUpdateSelectedAgentTargetId: boolean;
     }
+  | {
+      kind: "blocked";
+      notificationKey: "messages.agentTargetRequired";
+    }
   | { kind: "skip" } {
   if (!input.issueDetail) {
     return { kind: "skip" };
@@ -33,13 +37,27 @@ export function createIssueManagerRunTaskPlan(input: {
   const agentTargetId =
     input.agentTargetIdOverride?.trim() || input.selectedAgentTargetId.trim();
   if (!agentTargetId) {
-    return { kind: "skip" };
+    return {
+      kind: "blocked",
+      notificationKey: "messages.agentTargetRequired"
+    };
   }
   const option = input.agentTargetOptions?.find(
     (candidate) => candidate.agentTargetId?.trim() === agentTargetId
   );
-  const provider =
-    option?.provider.trim() || legacyProviderFromTargetId(agentTargetId);
+  if (!option) {
+    return {
+      kind: "blocked",
+      notificationKey: "messages.agentTargetRequired"
+    };
+  }
+  const provider = option.provider.trim();
+  if (!provider) {
+    return {
+      kind: "blocked",
+      notificationKey: "messages.agentTargetRequired"
+    };
+  }
 
   return {
     agentTargetId,
@@ -48,14 +66,6 @@ export function createIssueManagerRunTaskPlan(input: {
     shouldUpdateSelectedAgentTargetId:
       agentTargetId !== input.selectedAgentTargetId
   };
-}
-
-function legacyProviderFromTargetId(agentTargetId: string): string {
-  const targetId = agentTargetId.trim();
-  if (targetId.startsWith("local:")) {
-    return targetId.slice("local:".length);
-  }
-  return targetId.includes(":") ? "" : targetId;
 }
 
 export function createIssueManagerSaveIssuePlan(input: {

--- a/packages/workspace/issue-manager/src/services/internal/controllerUtils.ts
+++ b/packages/workspace/issue-manager/src/services/internal/controllerUtils.ts
@@ -86,6 +86,9 @@ export function resolveIssueManagerErrorMessage(
   if (raw === "issue_manager.workspace_path_unavailable") {
     return copy.t("messages.workspacePathUnavailable");
   }
+  if (raw === "issue_manager.agent_gui_launch_unavailable") {
+    return copy.t("messages.agentGuiLaunchUnavailable");
+  }
   if (raw === "issue_manager.run_status_missing") {
     return copy.t("messages.runStatusMissing");
   }

--- a/packages/workspace/issue-manager/src/ui/react/internal/controller/IssueManagerControllerCapabilities.test.ts
+++ b/packages/workspace/issue-manager/src/ui/react/internal/controller/IssueManagerControllerCapabilities.test.ts
@@ -93,7 +93,7 @@ test("controller capabilities detect execution directory support from the projec
   );
 });
 
-test("agent target options default to Codex only when no host adapter is configured", () => {
+test("agent target options are empty when no host adapter is configured", () => {
   assert.deepEqual(
     resolveIssueManagerAgentTargetOptions(
       createFeature({
@@ -104,7 +104,7 @@ test("agent target options default to Codex only when no host adapter is configu
         }
       })
     ),
-    [{ agentTargetId: "local:codex", label: "Codex", provider: "codex" }]
+    []
   );
 });
 

--- a/packages/workspace/issue-manager/src/ui/react/internal/controller/IssueManagerControllerCapabilities.ts
+++ b/packages/workspace/issue-manager/src/ui/react/internal/controller/IssueManagerControllerCapabilities.ts
@@ -4,19 +4,11 @@ import type {
 } from "../../../../contracts/index.ts";
 import type { IssueManagerFeature } from "../../../../core/index.ts";
 
-export const defaultIssueManagerAgentTargetOptions = [
-  {
-    agentTargetId: "local:codex",
-    label: "Codex",
-    provider: "codex"
-  }
-] as const satisfies readonly IssueManagerAgentTargetOption[];
-
 export function resolveIssueManagerAgentTargetOptions(
   feature: IssueManagerFeature
 ): readonly IssueManagerAgentTargetOption[] {
   if (!feature.agentTargetOptions) {
-    return defaultIssueManagerAgentTargetOptions;
+    return [];
   }
 
   const configuredOptions = feature.agentTargetOptions.getOptions();


### PR DESCRIPTION
## Summary
- require new agent sessions to be created through an explicit agentTargetId and remove provider-only compatibility paths
- make Issue Manager/App Center/batch runner use real agent targets only, with localized Toast feedback when no valid target exists
- update AgentGUI/activity docs and tests for the agentTargetId-only contract

## Validation
- pnpm check:changed --tail-lines 80
- pnpm check:i18n
- package/app typechecks for workspace-issue-manager, agent-gui, activity-core, and desktop
- targeted issue-manager, AgentGUI, activity-core, and desktop tests
- git diff --check

## Note
- A local pre-push pnpm check:full run reached the Go lint lane but could not complete because this machine does not have golangci-lint installed. Installing the pinned tool was not performed because it would install software outside the repo. The branch was pushed with --no-verify after the changed-aware and targeted checks passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Session creation now requires choosing an agent target, with clearer prompts when one isn’t selected.
  * Issue Manager and Agent GUI now support target-based launches more consistently across new sessions and task breakdowns.

* **Bug Fixes**
  * Removed fallback behaviors that could create confusing provider-based defaults.
  * Improved error handling so unavailable launches and missing targets show clearer messages.
  * Empty target lists now correctly show no launch options instead of defaulting to a built-in choice.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->