### PR TITLE
fix(browser-node): hide minimized webviews

### DIFF
--- a/apps/desktop/src/renderer/src/features/workspace-app-center/services/internal/workspaceAppCenterContribution.tsx
+++ b/apps/desktop/src/renderer/src/features/workspace-app-center/services/internal/workspaceAppCenterContribution.tsx
@@ -440,6 +440,7 @@ function WorkspaceAppWebviewBody({
       <BrowserNode
         defaultUrl={defaultUrl}
         feature={browserFeature}
+        hidden={context.node.isMinimized}
         navigationPolicy={navigationPolicy}
         nodeId={context.node.id}
         onFocusRequest={context.isFocused ? undefined : () => context.focus()}

--- a/packages/browser/workbench-node/src/react/BrowserNode.tsx
+++ b/packages/browser/workbench-node/src/react/BrowserNode.tsx
@@ -24,6 +24,7 @@ import type {
 } from "../core/types.ts";
 import { useBrowserNodeController } from "./useBrowserNodeController.ts";
 import { useBrowserNodeWebview } from "./useBrowserNodeWebview.ts";
+import { shouldHideBrowserNodeWebview } from "./webviewVisibility.ts";
 
 // Electron needs the serialized string attribute for dynamically created webviews.
 const browserNodeAllowPopupsAttribute = "true" as unknown as boolean;
@@ -59,6 +60,7 @@ function useHostWindowMinimizing(): boolean {
 export interface BrowserNodeProps {
   defaultUrl: string;
   feature: BrowserNodeFeature;
+  hidden?: boolean;
   navigationPolicy?: BrowserNodeNavigationPolicy | null;
   nodeId: string;
   onFocusRequest?: () => void;
@@ -73,6 +75,7 @@ export interface BrowserNodeProps {
 export function BrowserNode({
   defaultUrl,
   feature,
+  hidden = false,
   navigationPolicy = null,
   nodeId,
   onFocusRequest,
@@ -191,7 +194,8 @@ export function BrowserNode({
             className={cn(
               "absolute inset-0 h-full w-full border-0 bg-[var(--background-panel)]",
               isShowingLoadError ? "hidden pointer-events-none" : "visible",
-              isHostMinimizing && "invisible"
+              shouldHideBrowserNodeWebview({ hidden, isHostMinimizing }) &&
+                "invisible"
             )}
             data-browser-node-webview="true"
             partition={webviewPartition}

--- a/packages/browser/workbench-node/src/react/webviewVisibility.ts
+++ b/packages/browser/workbench-node/src/react/webviewVisibility.ts
@@ -1,0 +1,6 @@
+export function shouldHideBrowserNodeWebview(input: {
+  hidden: boolean;
+  isHostMinimizing: boolean;
+}): boolean {
+  return input.hidden || input.isHostMinimizing;
+}

--- a/packages/browser/workbench-node/src/workbench/index.ts
+++ b/packages/browser/workbench-node/src/workbench/index.ts
@@ -96,6 +96,7 @@ export function createBrowserNodeDefinition({
           externalNodeState: context.externalNodeState
         }),
         feature,
+        hidden: context.node.isMinimized,
         nodeId: context.node.id,
         onFocusRequest: context.isFocused ? undefined : () => context.focus(),
         onNavigated: onNavigated

--- a/packages/browser/workbench-node/src/workbench/minimizedWebviewVisibility.test.ts
+++ b/packages/browser/workbench-node/src/workbench/minimizedWebviewVisibility.test.ts
@@ -1,0 +1,53 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import test from "node:test";
+import { shouldHideBrowserNodeWebview } from "../react/webviewVisibility.ts";
+
+test("BrowserNode hides webviews for node-level and host-window minimization", () => {
+  assert.equal(
+    shouldHideBrowserNodeWebview({
+      hidden: false,
+      isHostMinimizing: false
+    }),
+    false
+  );
+  assert.equal(
+    shouldHideBrowserNodeWebview({
+      hidden: true,
+      isHostMinimizing: false
+    }),
+    true
+  );
+  assert.equal(
+    shouldHideBrowserNodeWebview({
+      hidden: false,
+      isHostMinimizing: true
+    }),
+    true
+  );
+});
+
+test("browser workbench nodes pass minimized state to BrowserNode", () => {
+  const workbenchSource = readFileSync(
+    new URL("./index.ts", import.meta.url),
+    "utf8"
+  );
+  const workspaceAppSource = readFileSync(
+    new URL(
+      "../../../../../apps/desktop/src/renderer/src/features/workspace-app-center/services/internal/workspaceAppCenterContribution.tsx",
+      import.meta.url
+    ),
+    "utf8"
+  );
+  const browserNodeSource = readFileSync(
+    new URL("../react/BrowserNode.tsx", import.meta.url),
+    "utf8"
+  );
+
+  assert.match(workbenchSource, /hidden:\s*context\.node\.isMinimized/);
+  assert.match(workspaceAppSource, /hidden=\{context\.node\.isMinimized\}/);
+  assert.match(
+    browserNodeSource,
+    /shouldHideBrowserNodeWebview\(\{\s*hidden,\s*isHostMinimizing\s*\}\)\s*&&\s*"invisible"/
+  );
+});


### PR DESCRIPTION
## Summary

- Pass workbench minimized state into BrowserNode for browser nodes and workspace app webviews.
- Hide the underlying Electron webview directly when the workbench node is minimized.
- Add coverage for node-level webview hiding and minimized-state wiring.

## Why

workspace-app-webview nodes can stay mounted after minimization. For keep-mounted webview apps such as onboarding, hiding only the outer workbench shell is not a reliable visibility boundary for the Electron guest view. This can leave stale app content painted at the old window position.

## Validation

- pnpm --filter @tutti-os/browser-node test
- pnpm --filter @tutti-os/browser-node typecheck
- pnpm --filter @tutti-os/desktop typecheck
- pnpm check:changed --tail-lines 80
- git diff --check
- PATH="/Users/wwcome/go/bin:/Users/wwcome/Library/pnpm/store/v11/links/@openai/codex/0.142.5-darwin-arm64/b01cbf72671f584be7439a64b6841f3ad0a150bef8279a6c3292a671627a0b10/node_modules/@openai/codex/vendor/aarch64-apple-darwin/codex-path:/Users/wwcome/Library/pnpm/store/v11/links/@openai/codex/0.142.5-darwin-arm64/b01cbf72671f584be7439a64b6841f3ad0a150bef8279a6c3292a671627a0b10/node_modules/@openai/codex/vendor/aarch64-apple-darwin/codex-path:/Users/wwcome/.tutti/agent/runs/5a5776a7-27c5-4661-a7b9-d90bbc2b3f31/codex-home/tmp/arg0/codex-arg089L4Vq:/Users/wwcome/.tutti/bin:/Users/wwcome/.homebrew/bin:/Users/wwcome/.homebrew/sbin:/Users/wwcome/.local/bin:/usr/local/bin:/System/Cryptexes/App/usr/bin:/usr/bin:/bin:/usr/sbin:/sbin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/local/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/appleinternal/bin:/opt/pmk/env/global/bin:/Users/wwcome/bin:/Users/wwcome/.npm-global/bin:/Users/wwcome/.n/bin:/Users/wwcome/n/bin:/Users/wwcome/.volta/bin:/Users/wwcome/.asdf/shims:/Users/wwcome/.mise/shims:/Users/wwcome/.bun/bin:/Users/wwcome/Library/pnpm:/opt/homebrew/bin" pnpm lint:go
- PATH="/Users/wwcome/go/bin:/Users/wwcome/Library/pnpm/store/v11/links/@openai/codex/0.142.5-darwin-arm64/b01cbf72671f584be7439a64b6841f3ad0a150bef8279a6c3292a671627a0b10/node_modules/@openai/codex/vendor/aarch64-apple-darwin/codex-path:/Users/wwcome/Library/pnpm/store/v11/links/@openai/codex/0.142.5-darwin-arm64/b01cbf72671f584be7439a64b6841f3ad0a150bef8279a6c3292a671627a0b10/node_modules/@openai/codex/vendor/aarch64-apple-darwin/codex-path:/Users/wwcome/.tutti/agent/runs/5a5776a7-27c5-4661-a7b9-d90bbc2b3f31/codex-home/tmp/arg0/codex-arg089L4Vq:/Users/wwcome/.tutti/bin:/Users/wwcome/.homebrew/bin:/Users/wwcome/.homebrew/sbin:/Users/wwcome/.local/bin:/usr/local/bin:/System/Cryptexes/App/usr/bin:/usr/bin:/bin:/usr/sbin:/sbin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/local/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/appleinternal/bin:/opt/pmk/env/global/bin:/Users/wwcome/bin:/Users/wwcome/.npm-global/bin:/Users/wwcome/.n/bin:/Users/wwcome/n/bin:/Users/wwcome/.volta/bin:/Users/wwcome/.asdf/shims:/Users/wwcome/.mise/shims:/Users/wwcome/.bun/bin:/Users/wwcome/Library/pnpm:/opt/homebrew/bin" git push -u origin fix/browser-node-minimized-webview (pre-push ran pnpm check:full and passed)

## Notes

No durable documentation update: this change keeps behavior inside the internal webview visibility boundary and does not alter public API, CLI, persisted contracts, or user-visible copy.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Browser views now stay hidden when their workspace node is minimized, improving minimized-state behavior.
  * Visibility handling now accounts for both host-window minimizing and an explicit hidden state.

* **Bug Fixes**
  * Prevents embedded browser content from remaining visible when a workspace item is minimized.

* **Tests**
  * Added coverage for hidden and minimizing visibility behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->