### PR TITLE
fix(workspace-account): gate account menu by agent switch

### DIFF
--- a/apps/desktop/src/renderer/src/features/workspace-workbench/ui/WorkspaceAccountMenu.test.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/ui/WorkspaceAccountMenu.test.ts
@@ -1,0 +1,24 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+
+const source = readFileSync(
+  resolve(dirname(fileURLToPath(import.meta.url)), "WorkspaceAccountMenu.tsx"),
+  "utf8"
+);
+
+test("workspace account menu is gated by Tutti Agent Switch", () => {
+  assert.match(source, /useWorkspaceSettingsService/);
+  assert.match(
+    source,
+    /workspaceSettingsState\.tuttiAgentSwitchEnabled !== true[\s\S]*return null/
+  );
+});
+
+test("workspace account menu does not expose the credits entry", () => {
+  assert.doesNotMatch(source, /data-account-credits-chip/);
+  assert.doesNotMatch(source, /CreditsIcon/);
+  assert.doesNotMatch(source, /links\.usageUrl/);
+});

--- a/apps/desktop/src/renderer/src/features/workspace-workbench/ui/WorkspaceAccountMenu.tsx
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/ui/WorkspaceAccountMenu.tsx
@@ -4,7 +4,6 @@ import {
   BillingIcon,
   Button,
   CloseIcon,
-  CreditsIcon,
   OpenLinkLinedIcon,
   Popover,
   PopoverContent,
@@ -15,6 +14,7 @@ import {
 import { useTranslation } from "@renderer/i18n";
 import { cn } from "@renderer/lib/format";
 import { useAccountService } from "./useAccountService";
+import { useWorkspaceSettingsService } from "./useWorkspaceSettingsService";
 import { useWorkspaceWorkbenchHostService } from "./useWorkspaceWorkbenchHostService";
 
 const PLAN_ICON_SOURCES = {
@@ -41,6 +41,16 @@ const debugRegistrationCreditsToastID =
 const registrationCreditsToastAutoDismissMs = 120_000;
 
 export function WorkspaceAccountMenu() {
+  const { state: workspaceSettingsState } = useWorkspaceSettingsService();
+
+  if (workspaceSettingsState.tuttiAgentSwitchEnabled !== true) {
+    return null;
+  }
+
+  return <WorkspaceAccountMenuEnabled />;
+}
+
+function WorkspaceAccountMenuEnabled() {
   const accountMenuState = useWorkspaceAccountMenuState();
   const labels = useWorkspaceAccountMenuLabels();
 
@@ -179,13 +189,10 @@ function useWorkspaceAccountMenuState(): WorkspaceAccountMenuState {
 interface WorkspaceAccountMenuLabels {
   title: string;
   member: string;
-  creditsBalance: string;
   accountCenter: string;
   free: string;
   signIn: string;
   signOut: string;
-  loading: string;
-  unavailable: string;
   dataUnavailable: string;
   rewardToastTitle: string;
   rewardToastDescription: string;
@@ -198,13 +205,10 @@ function useWorkspaceAccountMenuLabels(): WorkspaceAccountMenuLabels {
   return {
     title: t("workspace.accountMenu.title"),
     member: t("workspace.accountMenu.member"),
-    creditsBalance: t("workspace.accountMenu.creditsBalance"),
     accountCenter: t("workspace.accountMenu.accountCenter"),
     free: t("workspace.accountMenu.free"),
     signIn: t("workspace.accountMenu.signIn"),
     signOut: t("workspace.accountMenu.signOut"),
-    loading: t("workspace.accountMenu.loading"),
-    unavailable: t("workspace.accountMenu.unavailable"),
     dataUnavailable: t("workspace.accountMenu.dataUnavailable"),
     rewardToastTitle: t("workspace.accountMenu.rewardToastTitle"),
     rewardToastDescription: t("workspace.accountMenu.rewardToastDescription"),
@@ -229,10 +233,6 @@ const WorkspaceAccountMenuView = memo(function WorkspaceAccountMenuView({
     accountMenuState.membershipTierKey,
     membershipLabel
   );
-  const creditsLabel =
-    accountMenuState.loading && !accountMenuState.creditsLabel
-      ? labels.loading
-      : (accountMenuState.creditsLabel ?? labels.unavailable);
   const errorLabel =
     accountMenuState.error ||
     (accountMenuState.partialError ? labels.dataUnavailable : null);
@@ -278,19 +278,6 @@ const WorkspaceAccountMenuView = memo(function WorkspaceAccountMenuView({
           aria-hidden="true"
           className="h-4 w-px shrink-0 bg-[color-mix(in_srgb,var(--workbench-chrome-foreground)_24%,transparent)]"
         />
-      ) : null}
-      {accountMenuState.user ? (
-        <button
-          type="button"
-          aria-label={`${labels.creditsBalance}: ${creditsLabel}`}
-          title={labels.creditsBalance}
-          onClick={() => openExternal(accountMenuState.links.usageUrl)}
-          className="flex h-7 cursor-pointer items-center gap-1 rounded-full border-none bg-transparent px-1 text-[12px] font-semibold text-[var(--workbench-chrome-foreground)] opacity-90 transition-opacity hover:bg-transparent hover:opacity-100 [-webkit-app-region:no-drag]"
-          data-account-credits-chip="true"
-        >
-          <CreditsIcon aria-hidden="true" className="shrink-0" size={14} />
-          <span className="tabular-nums leading-none">{creditsLabel}</span>
-        </button>
       ) : null}
       <Popover onOpenChange={accountMenuState.onOpenChange}>
         <PopoverTrigger asChild>
@@ -362,23 +349,6 @@ const WorkspaceAccountMenuView = memo(function WorkspaceAccountMenuView({
             />
             {accountMenuState.user ? (
               <>
-                <button
-                  type="button"
-                  className="flex h-8 items-center gap-2 rounded-[6px] px-2 text-[13px] text-[var(--text-primary)] hover:bg-[var(--transparency-hover)] [-webkit-app-region:no-drag]"
-                  onClick={() => openExternal(accountMenuState.links.usageUrl)}
-                >
-                  <CreditsIcon
-                    aria-hidden="true"
-                    className="shrink-0"
-                    size={15}
-                  />
-                  <span className="min-w-0 flex-1 truncate text-left">
-                    {labels.creditsBalance}
-                  </span>
-                  <span className="truncate text-[var(--text-secondary)]">
-                    {creditsLabel}
-                  </span>
-                </button>
                 <button
                   type="button"
                   className="flex h-8 items-center gap-2 rounded-[6px] px-2 text-[13px] text-[var(--text-primary)] hover:bg-[var(--transparency-hover)] [-webkit-app-region:no-drag]"


### PR DESCRIPTION
## Summary
- Hide the workspace account/sign-in entry unless Tutti Agent Switch is enabled.
- Remove the top-right credits chip and credits balance row from the account menu for now.
- Add a regression test covering the switch gate and hidden credits entry.

## Tests
- node --import ./apps/desktop/test/register-asset-stub.mjs --test --experimental-strip-types apps/desktop/src/renderer/src/features/workspace-workbench/ui/WorkspaceAccountMenu.test.ts
- pnpm --filter @tutti-os/desktop typecheck
- git diff --check -- apps/desktop/src/renderer/src/features/workspace-workbench/ui/WorkspaceAccountMenu.tsx apps/desktop/src/renderer/src/features/workspace-workbench/ui/WorkspaceAccountMenu.test.ts
- PATH=/Users/wwcome/go/bin:/Users/wwcome/Library/pnpm/store/v11/links/@openai/codex/0.142.5-darwin-arm64/b01cbf72671f584be7439a64b6841f3ad0a150bef8279a6c3292a671627a0b10/node_modules/@openai/codex/vendor/aarch64-apple-darwin/codex-path:/Users/wwcome/Library/pnpm/store/v11/links/@openai/codex/0.142.5-darwin-arm64/b01cbf72671f584be7439a64b6841f3ad0a150bef8279a6c3292a671627a0b10/node_modules/@openai/codex/vendor/aarch64-apple-darwin/codex-path:/Users/wwcome/.tutti/agent/runs/5a5776a7-27c5-4661-a7b9-d90bbc2b3f31/codex-home/tmp/arg0/codex-arg089L4Vq:/Users/wwcome/.tutti/bin:/Users/wwcome/.homebrew/bin:/Users/wwcome/.homebrew/sbin:/Users/wwcome/.local/bin:/usr/local/bin:/System/Cryptexes/App/usr/bin:/usr/bin:/bin:/usr/sbin:/sbin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/local/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/appleinternal/bin:/opt/pmk/env/global/bin:/Users/wwcome/bin:/Users/wwcome/.npm-global/bin:/Users/wwcome/.n/bin:/Users/wwcome/n/bin:/Users/wwcome/.volta/bin:/Users/wwcome/.asdf/shims:/Users/wwcome/.mise/shims:/Users/wwcome/.bun/bin:/Users/wwcome/Library/pnpm:/opt/homebrew/bin pnpm lint:go
- PATH=/Users/wwcome/go/bin:/Users/wwcome/Library/pnpm/store/v11/links/@openai/codex/0.142.5-darwin-arm64/b01cbf72671f584be7439a64b6841f3ad0a150bef8279a6c3292a671627a0b10/node_modules/@openai/codex/vendor/aarch64-apple-darwin/codex-path:/Users/wwcome/Library/pnpm/store/v11/links/@openai/codex/0.142.5-darwin-arm64/b01cbf72671f584be7439a64b6841f3ad0a150bef8279a6c3292a671627a0b10/node_modules/@openai/codex/vendor/aarch64-apple-darwin/codex-path:/Users/wwcome/.tutti/agent/runs/5a5776a7-27c5-4661-a7b9-d90bbc2b3f31/codex-home/tmp/arg0/codex-arg089L4Vq:/Users/wwcome/.tutti/bin:/Users/wwcome/.homebrew/bin:/Users/wwcome/.homebrew/sbin:/Users/wwcome/.local/bin:/usr/local/bin:/System/Cryptexes/App/usr/bin:/usr/bin:/bin:/usr/sbin:/sbin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/local/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/appleinternal/bin:/opt/pmk/env/global/bin:/Users/wwcome/bin:/Users/wwcome/.npm-global/bin:/Users/wwcome/.n/bin:/Users/wwcome/n/bin:/Users/wwcome/.volta/bin:/Users/wwcome/.asdf/shims:/Users/wwcome/.mise/shims:/Users/wwcome/.bun/bin:/Users/wwcome/Library/pnpm:/opt/homebrew/bin git push -u origin fix/workspace-account-menu-switch (pre-push ran pnpm check:full and passed)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the workspace account menu to show only when the workspace feature is enabled.
  * Removed credits-related visibility from the menu, keeping the remaining account, plan, and sign-out actions intact.

* **Tests**
  * Added coverage to verify the menu’s feature gating and confirm credits UI is no longer exposed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->