### PR TITLE
fix(agent): avoid cursor readiness false setup notice

### DIFF
--- a/apps/desktop/src/renderer/src/features/workspace-agent/services/internal/desktopManagedAgentProviders.test.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-agent/services/internal/desktopManagedAgentProviders.test.ts
@@ -8,6 +8,7 @@ import type { IAgentProviderStatusService } from "../agentProviderStatusService.
 import {
   desktopManagedAgentProviders,
   ensureDesktopManagedAgentProviderStatuses,
+  hasRequiredDesktopManagedAgentProviderStatuses,
   isDesktopManagedAgentProvider,
   projectDesktopManagedAgentsStateForAgentGUI
 } from "./desktopManagedAgentProviders.ts";
@@ -186,6 +187,36 @@ test("projectDesktopManagedAgentsStateForAgentGUI projects captured provider sta
   });
 
   assert.deepEqual(state?.readyAgentIds, ["codex"]);
+});
+
+test("hasRequiredDesktopManagedAgentProviderStatuses waits for required provider", () => {
+  const snapshot = createProviderStatusSnapshot([
+    createProviderStatus({
+      adapterInstalled: true,
+      availability: "ready",
+      cliInstalled: true,
+      provider: "codex"
+    })
+  ]);
+
+  assert.equal(
+    hasRequiredDesktopManagedAgentProviderStatuses(snapshot, ["cursor"]),
+    false
+  );
+  assert.equal(
+    hasRequiredDesktopManagedAgentProviderStatuses(snapshot, ["codex"]),
+    true
+  );
+});
+
+test("hasRequiredDesktopManagedAgentProviderStatuses keeps empty snapshot loading", () => {
+  assert.equal(
+    hasRequiredDesktopManagedAgentProviderStatuses(
+      createProviderStatusSnapshot([]),
+      ["cursor"]
+    ),
+    false
+  );
 });
 
 test("isDesktopManagedAgentProvider accepts only desktop managed providers", () => {

--- a/apps/desktop/src/renderer/src/features/workspace-agent/services/internal/desktopManagedAgentProviders.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-agent/services/internal/desktopManagedAgentProviders.ts
@@ -143,6 +143,23 @@ export function projectDesktopManagedAgentsStateForAgentGUI(
   };
 }
 
+export function hasRequiredDesktopManagedAgentProviderStatuses(
+  snapshot: AgentProviderStatusSnapshot,
+  requiredProviders: readonly WorkspaceAgentProvider[] | undefined
+): boolean {
+  if (!requiredProviders || requiredProviders.length === 0) {
+    return true;
+  }
+  if (!snapshot.capturedAt) {
+    return false;
+  }
+
+  const knownProviders = new Set(
+    snapshot.statuses.map((status) => status.provider)
+  );
+  return requiredProviders.every((provider) => knownProviders.has(provider));
+}
+
 export function isDesktopManagedAgentProvider(
   value: unknown
 ): value is WorkspaceAgentProvider {

--- a/apps/desktop/src/renderer/src/features/workspace-agent/ui/DesktopAgentGUIWorkbenchBody.tsx
+++ b/apps/desktop/src/renderer/src/features/workspace-agent/ui/DesktopAgentGUIWorkbenchBody.tsx
@@ -347,9 +347,10 @@ function DesktopAgentGUIWorkbenchBodyImpl({
     contextMentionProviders,
     workspaceAppMentionProvider
   ]);
+  const provider = desktopAgentGUIProviderFromInstanceId(context.instanceId);
   const managedAgentsState = useDesktopManagedAgentsState(
     agentProviderStatusService,
-    { ensureLoaded: !previewMode }
+    { ensureLoaded: !previewMode, requiredProviders: [provider] }
   );
   const providerStatusSnapshot = useSyncExternalStore(
     agentProviderStatusService && !previewMode
@@ -360,7 +361,6 @@ function DesktopAgentGUIWorkbenchBodyImpl({
       : getEmptyProviderStatusSnapshot,
     getEmptyProviderStatusSnapshot
   );
-  const provider = desktopAgentGUIProviderFromInstanceId(context.instanceId);
   // Activation funnel stage ③ "saw a chattable surface": the agent workbench
   // body is mounted (not a dock preview) and the active provider is ready, so
   // the composer is interactive. reportProviderReady (stage ②) can fire while

--- a/apps/desktop/src/renderer/src/features/workspace-agent/ui/DesktopAgentGUIWorkbenchBody.tsx
+++ b/apps/desktop/src/renderer/src/features/workspace-agent/ui/DesktopAgentGUIWorkbenchBody.tsx
@@ -348,9 +348,10 @@ function DesktopAgentGUIWorkbenchBodyImpl({
     workspaceAppMentionProvider
   ]);
   const provider = desktopAgentGUIProviderFromInstanceId(context.instanceId);
+  const requiredProviders = useMemo(() => [provider], [provider]);
   const managedAgentsState = useDesktopManagedAgentsState(
     agentProviderStatusService,
-    { ensureLoaded: !previewMode, requiredProviders: [provider] }
+    { ensureLoaded: !previewMode, requiredProviders }
   );
   const providerStatusSnapshot = useSyncExternalStore(
     agentProviderStatusService && !previewMode

--- a/apps/desktop/src/renderer/src/features/workspace-agent/ui/useDesktopManagedAgentsState.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-agent/ui/useDesktopManagedAgentsState.ts
@@ -4,8 +4,10 @@ import type {
   AgentProviderStatusSnapshot,
   IAgentProviderStatusService
 } from "../services/agentProviderStatusService.interface";
+import type { WorkspaceAgentProvider } from "@tutti-os/client-tuttid-ts";
 import {
   ensureDesktopManagedAgentProviderStatuses,
+  hasRequiredDesktopManagedAgentProviderStatuses,
   projectDesktopManagedAgentsStateForAgentGUI
 } from "../services/internal/desktopManagedAgentProviders.ts";
 
@@ -20,9 +22,13 @@ const EMPTY_AGENT_PROVIDER_STATUS_SNAPSHOT: AgentProviderStatusSnapshot = {
 
 export function useDesktopManagedAgentsState(
   agentProviderStatusService: IAgentProviderStatusService | undefined,
-  options?: { ensureLoaded?: boolean }
+  options?: {
+    ensureLoaded?: boolean;
+    requiredProviders?: readonly WorkspaceAgentProvider[];
+  }
 ): AgentHostManagedAgentsState | null {
   const shouldEnsureLoaded = options?.ensureLoaded !== false;
+  const requiredProviders = options?.requiredProviders;
   const snapshot = useSyncExternalStore(
     agentProviderStatusService
       ? (listener) => agentProviderStatusService.subscribe(listener)
@@ -43,10 +49,14 @@ export function useDesktopManagedAgentsState(
 
   return useMemo(
     () =>
-      agentProviderStatusService
+      agentProviderStatusService &&
+      hasRequiredDesktopManagedAgentProviderStatuses(
+        snapshot,
+        requiredProviders
+      )
         ? projectDesktopManagedAgentsStateForAgentGUI(snapshot)
         : null,
-    [agentProviderStatusService, snapshot]
+    [agentProviderStatusService, requiredProviders, snapshot]
   );
 }
 

--- a/docs/architecture/agent-gui-node.md
+++ b/docs/architecture/agent-gui-node.md
@@ -253,6 +253,11 @@ remaining providers in the background. When the empty-home rail is still on
 is still gated, AgentGUI may move the home composer to that first ready target
 so the user can start typing without waiting for every provider to finish
 detection.
+Progressive detection snapshots are partial by design. A provider missing from
+the current snapshot means "not checked yet", not "install or login required".
+Desktop AgentGUI hosts that project managed-agent readiness for an already-open
+provider panel must wait until that provider appears in the status snapshot
+before replacing the composer with setup UI or disabling active-session sends.
 Auth-required local providers should remain selectable; product surfaces may
 label the setup affordance as `Connect`, but the host action should still
 dispatch the provider's `login` operation when that is the daemon-reported


### PR DESCRIPTION
## Summary
- wait for the active AgentGUI provider to appear in managed-agent status snapshots before projecting readiness
- avoid treating progressive startup partial snapshots as Cursor setup failures
- document partial provider snapshot semantics for AgentGUI readiness

## Tests
- pnpm --filter @tutti-os/desktop test -- desktopManagedAgentProviders
- pnpm --filter @tutti-os/desktop typecheck
- pnpm check:changed --tail-lines 80
- env -u TUTTI_ENV go test ./apps/cli/internal/app
- env -u TUTTI_ENV git push -u origin fix/cursor-readiness-snapshot (pre-push ran pnpm check:full)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Desktop agent loading now waits for the relevant provider to be detected before showing setup or active-session controls.
  * Added support for requiring specific provider readiness when fetching managed-agent state.

* **Bug Fixes**
  * Prevented false "missing provider" states when the provider list is still being populated.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->