### PR TITLE
fix(agent-gui): show delete session failures as toast

### DIFF
--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUINodeController.spec.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUINodeController.spec.tsx
@@ -8694,6 +8694,60 @@ describe("useAgentGUINodeController", () => {
     });
   });
 
+  it("shows a host toast without an inline composer error when pinning a conversation fails", async () => {
+    const hostToastError = vi.fn();
+    const setSessionPinned = vi.fn(async () => {
+      throw new Error("pin failed");
+    });
+    installAgentHostApi({
+      list: vi.fn(async () => ({
+        presences: [],
+        sessions: [workspaceAgentSession("session-1")]
+      })),
+      listSessionTimeline: vi.fn(async () => ({ timelineItems: [] })),
+      subscribeEvents: vi.fn(() => vi.fn()),
+      setSessionPinned,
+      toastApi: {
+        error: hostToastError
+      }
+    });
+
+    const { result } = renderHook(() =>
+      useAgentGUINodeController({
+        workspaceId: "room-1",
+        currentUserId: "user-1",
+        workspacePath: "/workspace",
+        avoidGroupingEdits: false,
+        data: agentGuiData("session-1"),
+        onDataChange: vi.fn()
+      })
+    );
+
+    await waitFor(() => {
+      expect(result.current.viewModel.activeConversation?.id).toBe("session-1");
+    });
+
+    act(() => {
+      result.current.actions.toggleConversationPinned("session-1", true);
+    });
+
+    await waitFor(() => {
+      expect(setSessionPinned).toHaveBeenCalledWith({
+        workspaceId: "room-1",
+        agentSessionId: "session-1",
+        pinned: true
+      });
+    });
+    await waitFor(() => {
+      expect(hostToastError).toHaveBeenCalledWith("pin failed");
+    });
+    expect(toast.error).not.toHaveBeenCalled();
+    expect(result.current.viewModel.detailError).toBeNull();
+    expect(
+      result.current.viewModel.activeConversation?.pinnedAtUnixMs
+    ).toBeNull();
+  });
+
   it("keeps a prompt title when session state reports the provider default runtime title", async () => {
     let resolveState:
       | ((
@@ -17763,10 +17817,11 @@ describe("useAgentGUINodeController", () => {
     });
   });
 
-  it("shows a toast when deleting a conversation fails", async () => {
+  it("shows a host toast without an inline composer error when deleting a conversation fails", async () => {
     const deleteSession = vi.fn(async () => {
       throw new Error("delete failed");
     });
+    const hostToastError = vi.fn();
     installAgentHostApi({
       list: vi.fn(async () => ({
         presences: [],
@@ -17774,7 +17829,10 @@ describe("useAgentGUINodeController", () => {
       })),
       listSessionTimeline: vi.fn(async () => ({ timelineItems: [] })),
       subscribeEvents: vi.fn(() => vi.fn()),
-      deleteSession
+      deleteSession,
+      toastApi: {
+        error: hostToastError
+      }
     });
 
     const { result } = renderHook(() =>
@@ -17800,9 +17858,10 @@ describe("useAgentGUINodeController", () => {
     });
 
     await waitFor(() => {
-      expect(toast.error).toHaveBeenCalledWith("delete failed");
+      expect(hostToastError).toHaveBeenCalledWith("delete failed");
     });
-    expect(result.current.viewModel.detailError).toBe("delete failed");
+    expect(toast.error).not.toHaveBeenCalled();
+    expect(result.current.viewModel.detailError).toBeNull();
   });
 
   it("batch deletes all conversations assigned to a project", async () => {
@@ -17986,6 +18045,7 @@ function installAgentHostApi({
   retainEventStream,
   releaseEventStream,
   onSessionEvent,
+  toastApi,
   userProjects,
   trackSettingsProjectChange,
   autoLoadRuntime = false
@@ -18011,6 +18071,11 @@ function installAgentHostApi({
   retainEventStream?: ReturnType<typeof vi.fn> | undefined;
   releaseEventStream?: ReturnType<typeof vi.fn> | undefined;
   onSessionEvent?: ReturnType<typeof vi.fn> | undefined;
+  toastApi?: {
+    error: (title: string, description?: string) => void;
+    info?: (title: string, description?: string) => void;
+    success?: (title: string, description?: string) => void;
+  };
   userProjects?: unknown;
   trackSettingsProjectChange?: ReturnType<typeof vi.fn> | undefined;
 }): void {
@@ -18068,6 +18133,7 @@ function installAgentHostApi({
       runtime: {
         warmupOpenclawGateway
       },
+      ...(toastApi ? { toast: toastApi } : {}),
       ...(userProjects ? { userProjects } : {}),
       workspaceAgents: {
         list,

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUINodeController.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUINodeController.ts
@@ -87,6 +87,7 @@ import {
   type AgentGUIConversationFilter
 } from "../model/agentGuiConversationFilter";
 import type {
+  AgentHostToastApi,
   AgentHostUserProject,
   AgentHostUserProjectsApi
 } from "../../../host/agentHostApi";
@@ -568,6 +569,17 @@ function reportAgentGUIRuntimeError(input: {
   } catch {
     // Diagnostic logging must never affect the Agent GUI recovery path.
   }
+}
+
+function showAgentGUIControllerErrorToast(
+  hostToast: AgentHostToastApi | null | undefined,
+  message: string
+): void {
+  if (hostToast?.error) {
+    hostToast.error(message);
+    return;
+  }
+  toast.error(message);
 }
 
 function reportAgentGUIConversationFilterTargetUnresolved(input: {
@@ -9824,7 +9836,7 @@ export function useAgentGUINodeController({
       const handleRemoveError = (error: unknown) => {
         const message = getAgentGUIErrorMessage(error);
         setListError(message);
-        toast.error(message);
+        showAgentGUIControllerErrorToast(agentHostApi.toast, message);
       };
       try {
         void Promise.resolve(remove({ path: normalizedPath }))
@@ -9840,7 +9852,7 @@ export function useAgentGUINodeController({
         handleRemoveError(error);
       }
     },
-    [agentHostApi.userProjects, setUserProjectsSnapshot]
+    [agentHostApi.toast, agentHostApi.userProjects, setUserProjectsSnapshot]
   );
 
   const requestDeleteProjectConversations = useCallback(
@@ -9966,8 +9978,7 @@ export function useAgentGUINodeController({
           runtime: agentActivityRuntime,
           workspaceId
         });
-        toast.error(message);
-        setDetailError(message);
+        showAgentGUIControllerErrorToast(agentHostApi.toast, message);
         if (activeConversationIdRef.current === target.id) {
           setIsLoadingMessages(false);
           setAgentSessionViewMessagesLoading(sessionViewRef(target.id), false);
@@ -9987,6 +9998,7 @@ export function useAgentGUINodeController({
     workspaceId,
     sessionViewRef,
     agentActivityRuntime,
+    agentHostApi.toast,
     agentQueuedPromptRuntime,
     removeConversations
   ]);
@@ -10146,8 +10158,7 @@ export function useAgentGUINodeController({
             }
           });
           setListError(message);
-          toast.error(message);
-          setDetailError(message);
+          showAgentGUIControllerErrorToast(agentHostApi.toast, message);
           if (
             activeDeletedConversationId &&
             activeConversationIdRef.current === activeDeletedConversationId
@@ -10176,6 +10187,7 @@ export function useAgentGUINodeController({
       sessionViewRef,
       setTransientConversation,
       removeConversations,
+      agentHostApi.toast,
       workspaceId
     ]
   );
@@ -10238,8 +10250,7 @@ export function useAgentGUINodeController({
             }
           });
           setListError(message);
-          toast.error(message);
-          setDetailError(message);
+          showAgentGUIControllerErrorToast(agentHostApi.toast, message);
           if (
             activeDeletedConversationId &&
             activeConversationIdRef.current === activeDeletedConversationId
@@ -10262,6 +10273,7 @@ export function useAgentGUINodeController({
       finalizeConversationBatchDeletion,
       isDeletingProjectConversations,
       sessionViewRef,
+      agentHostApi.toast,
       workspaceId
     ]
   );
@@ -10309,8 +10321,7 @@ export function useAgentGUINodeController({
             runtime: agentActivityRuntime,
             workspaceId
           });
-          toast.error(message);
-          setDetailError(message);
+          showAgentGUIControllerErrorToast(agentHostApi.toast, message);
           // Targeted revert of just this conversation's pin (rather than the
           // whole-list restore the arbitrary updater allowed), so a concurrent
           // update to another conversation is not clobbered on pin failure.
@@ -10327,7 +10338,7 @@ export function useAgentGUINodeController({
           );
         });
     },
-    [agentActivityRuntime, patchConversation, workspaceId]
+    [agentActivityRuntime, agentHostApi.toast, patchConversation, workspaceId]
   );
 
   const activeConversation = useMemo(() => {


### PR DESCRIPTION
## Summary
- route AgentGUI controller error toasts through the host toast API when available
- stop delete-session and pin/unpin failures from writing composer inline detail errors
- cover delete and pin failure paths with host-toast regression tests

## Validation
- pnpm --filter @tutti-os/agent-gui test -- --run agent-gui/agentGuiNode/controller/useAgentGUINodeController.spec.tsx
- pnpm lint:go
- pnpm check:full (pre-push)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Error toasts now consistently prefer the host app’s toast handling when available, with a fallback to the app’s standard toasts.
  * Updated failure behavior for project and conversation actions (delete and pin toggle) so users see toast errors without leaving inline detail errors.
  * Added/expanded regression tests to verify correct toast invocation and state cleanup when pinning or deleting conversations fails.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->