### PR TITLE
fix(agent): detached agent window session reuse and provider status hydration

### DIFF
--- a/apps/desktop/src/renderer/src/features/workspace-agent/index.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-agent/index.ts
@@ -6,6 +6,10 @@ export { preloadDesktopAgentGuiMentionBrowse } from "./services/preloadDesktopAg
 export { createDesktopAgentActivityRuntime } from "./services/createDesktopAgentActivityRuntime";
 export { createDesktopAgentHostApi } from "./services/createDesktopAgentHostApi";
 export { createDesktopAgentGeneratedFileMentionProvider } from "./services/internal/createDesktopAgentGeneratedFileMentionProvider";
+export {
+  desktopManagedAgentProviders,
+  ensureAllDesktopManagedAgentProviderStatuses
+} from "./services/internal/desktopManagedAgentProviders";
 export { IWorkspaceAgentActivityService } from "./services/workspaceAgentActivityService.interface";
 export { IWorkspaceAgentPromptSessionService } from "./services/workspaceAgentPromptSessionService.interface";
 export {

--- a/apps/desktop/src/renderer/src/features/workspace-agent/services/agentProviderStatusService.interface.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-agent/services/agentProviderStatusService.interface.ts
@@ -46,6 +46,14 @@ export interface IAgentProviderStatusService {
   getSnapshot(): AgentProviderStatusSnapshot;
   isActionPending(provider: WorkspaceAgentProvider, actionId: string): boolean;
   getStatus(provider: WorkspaceAgentProvider): AgentProviderStatus | null;
+  /**
+   * Seeds the snapshot from another window's already-captured status (e.g. a
+   * detached agent window bootstrapping from the main window's snapshot at
+   * open time) so this instance never has to redo a from-scratch check for
+   * providers that are already known. No-ops once this instance has captured
+   * its own snapshot, so it can never regress fresher local data.
+   */
+  hydrate(snapshot: AgentProviderStatusSnapshot): void;
   ensureLoaded(input?: {
     providers?: WorkspaceAgentProvider[];
     /**

--- a/apps/desktop/src/renderer/src/features/workspace-agent/services/internal/desktopAgentProviderStatusService.test.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-agent/services/internal/desktopAgentProviderStatusService.test.ts
@@ -1127,6 +1127,123 @@ test("ensureLoaded reuses loaded provider statuses and only loads missing provid
   assert.deepEqual(statusCalls, [["codex"], ["claude-code"]]);
 });
 
+test("hydrate seeds the snapshot for an instance that has not captured its own data yet", () => {
+  const service = new DesktopAgentProviderStatusService({
+    tuttidClient: createTuttidClient({ snapshots: [] }),
+    terminalCommandRunner: {
+      async runTerminalCommand() {}
+    }
+  });
+
+  assert.equal(service.getSnapshot().capturedAt, null);
+
+  service.hydrate({
+    capturedAt: "2026-07-08T00:00:00.000Z",
+    defaultProvider: "codex",
+    error: null,
+    isLoading: false,
+    pendingActions: [],
+    statuses: [
+      createProviderStatus({
+        actions: [],
+        availability: "ready",
+        provider: "cursor"
+      })
+    ]
+  });
+
+  assert.equal(service.getStatus("cursor")?.availability.status, "ready");
+});
+
+test("hydrate never regresses a snapshot this instance already captured itself", async () => {
+  const service = new DesktopAgentProviderStatusService({
+    tuttidClient: createTuttidClient({
+      snapshots: [
+        createStatusResponse([
+          createProviderStatus({
+            actions: [],
+            availability: "not_installed",
+            provider: "cursor"
+          })
+        ])
+      ]
+    }),
+    terminalCommandRunner: {
+      async runTerminalCommand() {}
+    }
+  });
+
+  await service.refresh(["cursor"]);
+  assert.equal(
+    service.getStatus("cursor")?.availability.status,
+    "not_installed"
+  );
+
+  service.hydrate({
+    capturedAt: "2026-07-08T00:00:00.000Z",
+    defaultProvider: "cursor",
+    error: null,
+    isLoading: false,
+    pendingActions: [],
+    statuses: [
+      createProviderStatus({
+        actions: [],
+        availability: "ready",
+        provider: "cursor"
+      })
+    ]
+  });
+
+  assert.equal(
+    service.getStatus("cursor")?.availability.status,
+    "not_installed"
+  );
+});
+
+test("a later provider-scoped response merges into a hydrated snapshot instead of dropping it", async () => {
+  const service = new DesktopAgentProviderStatusService({
+    tuttidClient: createTuttidClient({
+      snapshots: [
+        createStatusResponse([
+          createProviderStatus({
+            actions: [],
+            availability: "ready",
+            provider: "codex"
+          })
+        ])
+      ]
+    }),
+    terminalCommandRunner: {
+      async runTerminalCommand() {}
+    }
+  });
+
+  // Simulate a detached window bootstrapping from the opening window's
+  // already-complete snapshot (e.g. Cursor was already confirmed ready there).
+  service.hydrate({
+    capturedAt: "2026-07-08T00:00:00.000Z",
+    defaultProvider: "cursor",
+    error: null,
+    isLoading: false,
+    pendingActions: [],
+    statuses: [
+      createProviderStatus({
+        actions: [],
+        availability: "ready",
+        provider: "cursor"
+      })
+    ]
+  });
+
+  // A live, provider-scoped refresh for a *different* provider (e.g. this
+  // window's own background check for "codex") must not wipe out Cursor's
+  // already-known-good status.
+  await service.refresh(["codex"]);
+
+  assert.equal(service.getStatus("cursor")?.availability.status, "ready");
+  assert.equal(service.getStatus("codex")?.availability.status, "ready");
+});
+
 test("ensureLoaded waits for unrelated in-flight loads before loading missing providers", async () => {
   const calls: Array<readonly WorkspaceAgentProvider[] | undefined> = [];
   const firstStatusRequest = createDeferred<AgentProviderStatusListResponse>();

--- a/apps/desktop/src/renderer/src/features/workspace-agent/services/internal/desktopAgentProviderStatusService.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-agent/services/internal/desktopAgentProviderStatusService.ts
@@ -158,6 +158,16 @@ export class DesktopAgentProviderStatusService implements IAgentProviderStatusSe
     );
   }
 
+  hydrate(snapshot: AgentProviderStatusSnapshot): void {
+    // Only seed from a bootstrap snapshot before this instance has ever
+    // captured its own data — otherwise a stale hand-off (or one that raced
+    // with a real response) could regress already-loaded local state.
+    if (this.snapshot.capturedAt) {
+      return;
+    }
+    this.setSnapshot(snapshot);
+  }
+
   isActionPending(provider: WorkspaceAgentProvider, actionId: string): boolean {
     return this.snapshot.pendingActions.some(
       (action) => action.provider === provider && action.actionId === actionId

--- a/apps/desktop/src/renderer/src/features/workspace-agent/services/internal/desktopManagedAgentProviders.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-agent/services/internal/desktopManagedAgentProviders.ts
@@ -69,7 +69,7 @@ async function ensureFirstReadyDesktopManagedAgentProviderStatus(
   return ensureAllDesktopManagedAgentProviderStatuses(service);
 }
 
-function ensureAllDesktopManagedAgentProviderStatuses(
+export function ensureAllDesktopManagedAgentProviderStatuses(
   service: IAgentProviderStatusService
 ): Promise<AgentProviderStatusListResponse | null> {
   return service.ensureLoaded({

--- a/apps/desktop/src/renderer/src/features/workspace-agent/services/internal/tuttiAgentInstallBootstrap.test.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-agent/services/internal/tuttiAgentInstallBootstrap.test.ts
@@ -137,6 +137,7 @@ function createService(
       statuses: [status]
     }),
     getStatus: () => status,
+    hydrate: () => {},
     isActionPending: () => false,
     refresh: async () => {
       hooks.refresh?.();

--- a/apps/desktop/src/renderer/src/features/workspace-workbench/services/internal/workspaceAgentGuiContribution.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/services/internal/workspaceAgentGuiContribution.ts
@@ -234,7 +234,14 @@ export function createWorkspaceAgentGuiContribution(input: {
       }),
     renderBody: (context, helpers) =>
       renderAgentGuiWorkbenchBody(context, helpers),
-    onOpenDetachedWindow: (request) =>
+    onOpenDetachedWindow: (request) => {
+      // Hand off whatever this window already has cached right now — do not
+      // block the click on a full provider probe (it can take seconds and
+      // makes opening the window feel unresponsive). The detached window
+      // hydrates from this snapshot instantly, then keeps checking any
+      // providers it's still missing in the background (see
+      // StandaloneAgentWindow's own ensureAll effect); hydrate only ever
+      // merges in new data, so a partial hand-off here is safe.
       input.hostWindowApi.openAgentWindow({
         agentSessionId: request.agentSessionId,
         agentTargetId: request.agentTargetId,
@@ -242,7 +249,8 @@ export function createWorkspaceAgentGuiContribution(input: {
         providerTargets: request.providerTargets,
         provider: request.provider,
         workspaceId: request.workspaceId
-      }),
+      });
+    },
     renderPreview: (context, helpers) =>
       createElement(
         DesktopAgentGUIWorkbenchDockPreviewFrame,

--- a/apps/desktop/src/renderer/src/features/workspace-workbench/services/internal/workspaceAgentProviderDockActions.test.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/services/internal/workspaceAgentProviderDockActions.test.ts
@@ -89,6 +89,7 @@ function stubService(
       statuses: []
     }),
     getStatus: () => null,
+    hydrate: () => {},
     isActionPending: () => false,
     ensureLoaded: async () => null,
     refresh: async () => {},

--- a/apps/desktop/src/renderer/src/features/workspace-workbench/services/internal/workspaceAgentProviderDockStateSource.test.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/services/internal/workspaceAgentProviderDockStateSource.test.ts
@@ -618,6 +618,7 @@ function createAgentProviderStatusService(input: {
     }),
     getStatus: (provider) =>
       statuses.find((status) => status.provider === provider) ?? null,
+    hydrate: () => {},
     isActionPending: () => false,
     ensureLoaded: input.onEnsureLoaded ?? (async () => null),
     refresh: async () => {},

--- a/apps/desktop/src/renderer/src/features/workspace-workbench/ui/StandaloneAgentWindow.tsx
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/ui/StandaloneAgentWindow.tsx
@@ -37,6 +37,7 @@ import {
   createDesktopAgentGUIWorkbenchHostInput,
   DesktopAgentGUIWorkbenchBody,
   desktopAgentGUIOpenSessionActivationType,
+  ensureAllDesktopManagedAgentProviderStatuses,
   IAgentsService,
   normalizeDesktopAgentGUIProvider,
   type DesktopAgentGUIProvider,
@@ -119,6 +120,22 @@ export function StandaloneAgentWindow({
     () => readProviderStatusBootstrapSnapshot(params),
     [params]
   );
+  // Seed the live service from the opening window's snapshot synchronously,
+  // during the first render, before any child effect gets a chance to kick
+  // off its own fresh status request. Without this, `agentProviderStatusService`
+  // starts as a brand-new instance with no data (it's a separate process from
+  // the window that opened us), and as soon as its own request returns even a
+  // partial result, the bootstrap snapshot gets abandoned mid-render — which
+  // is what caused providers that were already known-ready to flash back to
+  // "checking"/"unavailable". `hydrate` is a no-op once real data has landed,
+  // so this can never regress fresher local state.
+  const hasHydratedProviderStatusRef = useRef(false);
+  if (!hasHydratedProviderStatusRef.current) {
+    hasHydratedProviderStatusRef.current = true;
+    if (providerStatusBootstrapSnapshot) {
+      agentProviderStatusService.hydrate(providerStatusBootstrapSnapshot);
+    }
+  }
   const [frame, setFrame] = useState(() => readWindowFrameRect());
   const [providerTargets, setProviderTargets] = useState<
     Awaited<ReturnType<typeof agentsService.load>>["providerTargets"] | null
@@ -273,6 +290,17 @@ export function StandaloneAgentWindow({
       disposed = true;
     };
   }, [agentsService]);
+  useEffect(() => {
+    // The main workspace window loads every managed provider's status via its
+    // dock rail (which subscribes on mount and probes all providers). This
+    // standalone window has no dock, so nothing else ever asks for the full
+    // set — without this, only the single provider the window was launched
+    // for gets checked, and every other provider (e.g. switching the "全部"
+    // filter to one that was never probed) stays stuck on "checking".
+    void ensureAllDesktopManagedAgentProviderStatuses(
+      agentProviderStatusService
+    );
+  }, [agentProviderStatusService]);
   const handleConversationRailToggle = useCallback(
     (collapsed: boolean) => {
       setNodeState((current) => ({
@@ -386,6 +414,9 @@ export function StandaloneAgentWindow({
           dockPreviewCache={dockPreviewCache}
           onCapabilitySettingsRequest={handleCapabilitySettingsRequest}
           onOpenAgentConversationWindow={({ agentSessionId, provider }) => {
+            // Hand off whatever is cached right now — see the matching note
+            // in workspaceAgentGuiContribution.ts's onOpenDetachedWindow for
+            // why we don't block this click on a full provider probe.
             void hostWindowApi.openAgentWindow({
               agentSessionId,
               providerStatusSnapshot: agentProviderStatusService.getSnapshot(),

--- a/docs/architecture/agent-gui-node.md
+++ b/docs/architecture/agent-gui-node.md
@@ -163,10 +163,11 @@ resolve an `AgentGUIProviderTarget`, return the node to the home composer when
 switching targets, and preserve the real provider identity used by runtime
 create/send commands. Once a session is active, the composer provider select is
 display-only and must not switch the running session. The conversation rail
-target grid is a list filter first: clicking Codex or Claude Code while a
-session is active may scope the visible rail list, but must not unactivate the
-session or rewrite the session-owned composer target. Only empty-home rail
-target clicks may also sync the home composer launch target.
+target grid is a navigation surface: clicking Codex or Claude Code scopes the
+visible rail list and reopens the first already-loaded conversation matching
+that target. Only when no matching conversation is available should the target
+click enter that target's empty home composer. Empty-home rail target clicks may
+also sync the home composer launch target.
 In an active session, the composer footer may replace the display-only provider
 select with a handoff affordance. Handoff is a workbench launch, not an
 in-session provider switch: AgentGUI serializes the active session as a single

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUINodeController.spec.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUINodeController.spec.tsx
@@ -387,7 +387,7 @@ describe("useAgentGUINodeController", () => {
     expect(onRememberComposerDefaults).not.toHaveBeenCalled();
   });
 
-  it("selects a rail target by updating the filter and empty composer provider", async () => {
+  it("selects a rail target by reopening the latest matching conversation", async () => {
     installAgentHostApi({
       list: vi.fn(async () => ({
         presences: [],
@@ -458,27 +458,209 @@ describe("useAgentGUINodeController", () => {
         agentTargetId: "local:claude-code"
       });
     });
-    expect(result.current.viewModel.data.provider).toBe("claude-code");
-    expect(result.current.viewModel.selectedProviderTarget.provider).toBe(
-      "claude-code"
-    );
-    expect(result.current.viewModel.data.agentTargetId).toBe(
-      "local:claude-code"
-    );
+    await waitFor(() => {
+      expect(result.current.viewModel.activeConversation?.id).toBe(
+        "claude-session"
+      );
+    });
+    expect(result.current.viewModel.data.provider).toBe("codex");
+    expect(result.current.viewModel.data.agentTargetId).toBe("local:codex");
     const currentData = agentGuiData(null, "codex", {
       agentTargetId: "local:codex",
       composerOverrides: { model: "gpt-5" }
     });
-    const nextData = onDataChange.mock.calls
-      .map(([updater]) => updater(currentData))
-      .find((candidate) => candidate.provider === "claude-code");
+    const nextData = onDataChange.mock.calls.reduce(
+      (current, [updater]) => updater(current),
+      currentData
+    );
     expect(nextData).toMatchObject({
       provider: "claude-code",
       agentTargetId: "local:claude-code",
-      composerOverrides: null
+      composerOverrides: null,
+      lastActiveAgentSessionId: "claude-session"
     });
-    expect(nextData?.providerTargetId ?? null).toBeNull();
-    expect(nextData?.providerTargetRef ?? null).toBeNull();
+  });
+
+  it("keeps a fresh empty composer when reselecting the already-active rail target", async () => {
+    installAgentHostApi({
+      list: vi.fn(async () => ({
+        presences: [],
+        sessions: [
+          workspaceAgentSession("codex-session", {
+            provider: "codex",
+            title: "Codex session",
+            updatedAtUnixMs: 3
+          })
+        ]
+      })),
+      listSessionTimeline: vi.fn(async () => ({ timelineItems: [] })),
+      subscribeEvents: vi.fn(() => vi.fn())
+    });
+    const onDataChange = vi.fn();
+
+    const { result } = renderHook(() =>
+      useAgentGUINodeController({
+        workspaceId: "room-1",
+        currentUserId: "user-1",
+        workspacePath: "/workspace",
+        avoidGroupingEdits: false,
+        data: agentGuiData(null, "codex", {
+          agentTargetId: "local:codex"
+        }),
+        providerTargets: [
+          {
+            targetId: "local:codex",
+            agentTargetId: "local:codex",
+            provider: "codex",
+            ref: { kind: "local-provider", provider: "codex" },
+            label: "Codex"
+          },
+          {
+            targetId: "local:claude-code",
+            agentTargetId: "local:claude-code",
+            provider: "claude-code",
+            ref: { kind: "local-provider", provider: "claude-code" },
+            label: "Claude Code"
+          }
+        ],
+        onDataChange
+      })
+    );
+
+    await waitFor(() => {
+      expect(
+        result.current.viewModel.conversations.map((item) => item.id)
+      ).toEqual(["codex-session"]);
+    });
+
+    // Switching into Codex from All reopens its latest conversation.
+    act(() => {
+      result.current.actions.selectConversationFilterTarget({
+        provider: "codex",
+        providerTargetId: "local:codex"
+      });
+    });
+    await waitFor(() => {
+      expect(result.current.viewModel.activeConversation?.id).toBe(
+        "codex-session"
+      );
+    });
+
+    // Starting a fresh conversation under the same, still-selected target
+    // clears the active conversation but keeps the scoped filter.
+    act(() => {
+      result.current.actions.selectHomeComposerAgentTarget({
+        provider: "codex",
+        providerTargetId: "local:codex"
+      });
+    });
+    await waitFor(() => {
+      expect(result.current.viewModel.activeConversationId).toBeNull();
+    });
+    act(() => {
+      result.current.actions.updateDraftContent(
+        draftContent("draft in progress")
+      );
+    });
+    expect(result.current.viewModel.draftPrompt).toBe("draft in progress");
+
+    // Re-clicking the same, already-selected Codex tile must not discard
+    // the fresh composer by jumping back into the old conversation.
+    act(() => {
+      result.current.actions.selectConversationFilterTarget({
+        provider: "codex",
+        providerTargetId: "local:codex"
+      });
+    });
+
+    expect(result.current.viewModel.activeConversationId).toBeNull();
+    expect(result.current.viewModel.draftPrompt).toBe("draft in progress");
+  });
+
+  it("selects an empty composer when a rail target has no matching conversation", async () => {
+    installAgentHostApi({
+      list: vi.fn(async () => ({
+        presences: [],
+        sessions: [
+          workspaceAgentSession("codex-session", {
+            agentTargetId: "local:codex",
+            provider: "codex",
+            title: "Codex session",
+            updatedAtUnixMs: 3
+          })
+        ]
+      })),
+      listSessionTimeline: vi.fn(async () => ({ timelineItems: [] })),
+      subscribeEvents: vi.fn(() => vi.fn())
+    });
+    const onDataChange = vi.fn();
+    const initialData = agentGuiData(null, "codex", {
+      agentTargetId: "local:codex",
+      composerOverrides: { model: "gpt-5" }
+    });
+
+    const { result } = renderHook(() =>
+      useAgentGUINodeController({
+        workspaceId: "room-1",
+        currentUserId: "user-1",
+        workspacePath: "/workspace",
+        avoidGroupingEdits: false,
+        data: initialData,
+        providerTargets: [
+          {
+            targetId: "local:codex",
+            agentTargetId: "local:codex",
+            provider: "codex",
+            ref: { kind: "local-provider", provider: "codex" },
+            label: "Codex"
+          },
+          {
+            targetId: "local:claude-code",
+            agentTargetId: "local:claude-code",
+            provider: "claude-code",
+            ref: { kind: "local-provider", provider: "claude-code" },
+            label: "Claude Code"
+          }
+        ],
+        onDataChange
+      })
+    );
+
+    await waitFor(() => {
+      expect(
+        result.current.viewModel.conversations.map((item) => item.id)
+      ).toEqual(["codex-session"]);
+    });
+    onDataChange.mockClear();
+
+    act(() => {
+      result.current.actions.selectConversationFilterTarget({
+        provider: "claude-code",
+        providerTargetId: "local:claude-code"
+      });
+    });
+
+    await waitFor(() => {
+      expect(result.current.viewModel.conversationFilter).toEqual({
+        kind: "agentTarget",
+        agentTargetId: "local:claude-code"
+      });
+    });
+    expect(result.current.viewModel.activeConversation).toBeNull();
+    expect(result.current.viewModel.data.provider).toBe("claude-code");
+    expect(result.current.viewModel.data.agentTargetId).toBe(
+      "local:claude-code"
+    );
+    const nextData = onDataChange.mock.calls.reduce(
+      (current, [updater]) => updater(current),
+      initialData
+    );
+    expect(nextData).toMatchObject({
+      provider: "claude-code",
+      agentTargetId: "local:claude-code",
+      composerOverrides: null,
+      lastActiveAgentSessionId: null
+    });
   });
 
   it("resets the empty composer provider when switching the rail filter back to All", async () => {
@@ -592,7 +774,7 @@ describe("useAgentGUINodeController", () => {
     expect(result.current.viewModel.providerReadinessGate).toBeNull();
   });
 
-  it("opens the selected target home composer when the active conversation is outside the new rail filter", async () => {
+  it("opens the matching rail target conversation when the active conversation is outside the new rail filter", async () => {
     const unactivate = vi.fn();
     installAgentHostApi({
       list: vi.fn(async () => ({
@@ -670,10 +852,12 @@ describe("useAgentGUINodeController", () => {
       });
     });
     await waitFor(() => {
-      expect(result.current.viewModel.activeConversationId).toBeNull();
+      expect(result.current.viewModel.activeConversationId).toBe(
+        "claude-session"
+      );
     });
     expect(result.current.viewModel.selectedProviderTarget.provider).toBe(
-      "claude-code"
+      "codex"
     );
     await waitFor(() => {
       expect(unactivate).toHaveBeenCalledWith({
@@ -688,7 +872,7 @@ describe("useAgentGUINodeController", () => {
     expect(appliedData).toMatchObject({
       provider: "claude-code",
       agentTargetId: "local:claude-code",
-      lastActiveAgentSessionId: null
+      lastActiveAgentSessionId: "claude-session"
     });
   });
 

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUINodeController.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUINodeController.ts
@@ -11653,6 +11653,12 @@ export function useAgentGUINodeController({
       const nextFilter = agentTargetId
         ? { kind: "agentTarget" as const, agentTargetId }
         : { kind: "all" as const };
+      const previousFilter = conversationFilterRef.current;
+      const isSameFilterTarget =
+        nextFilter.kind === "agentTarget"
+          ? previousFilter.kind === "agentTarget" &&
+            previousFilter.agentTargetId === nextFilter.agentTargetId
+          : previousFilter.kind === "all";
       setConversationFilter(nextFilter);
       const activeId = activeConversationIdRef.current;
       if (activeId) {
@@ -11663,10 +11669,29 @@ export function useAgentGUINodeController({
         );
         if (
           activeSummary &&
-          !matchesAgentGUIConversationSummaryFilter(activeSummary, nextFilter)
+          matchesAgentGUIConversationSummaryFilter(activeSummary, nextFilter)
         ) {
-          selectHomeComposerAgentTarget(input);
+          return;
         }
+      } else if (isSameFilterTarget) {
+        // Re-selecting the already-active target from its empty composer is
+        // not a switch — reopening the last conversation here would discard
+        // an in-progress draft the user just started.
+        selectHomeComposerAgentTarget(input);
+        return;
+      }
+      const recentConversation = agentTargetId
+        ? mergeVisibleConversations(
+            conversationsRef.current,
+            transientConversationRef.current
+          ).find((conversation) =>
+            matchesAgentGUIConversationSummaryFilter(conversation, nextFilter)
+          )
+        : null;
+      if (recentConversation) {
+        selectConversation(recentConversation.id, {
+          reloadConversations: false
+        });
         return;
       }
       selectHomeComposerAgentTarget(input);
@@ -11675,6 +11700,7 @@ export function useAgentGUINodeController({
       agentActivityRuntime,
       defaultProviderTargetId,
       normalizedProviderTargets,
+      selectConversation,
       selectHomeComposerAgentTarget,
       shouldUseStaticProviderTargets,
       workspaceId


### PR DESCRIPTION
## Summary
- Re-clicking a provider rail tile now reopens that agent's most recent matching conversation instead of always starting a new session, while still preserving an in-progress empty-composer draft when re-selecting the already-active target.
- Detached agent windows hydrate their provider status service from the opening window's already-captured snapshot instantly, instead of flashing known-ready providers back to "checking" while they redo their own from-scratch probe; they then background-check any providers the opener hadn't covered.

## Test plan
- [x] `node --test` targeted suites for `desktopAgentProviderStatusService`, `tuttiAgentInstallBootstrap`, `workspaceAgentProviderDockActions`, `workspaceAgentProviderDockStateSource` (59/59 passing)
- [x] `pnpm check:full` (pre-push hook) — full TS/Go test + boundary/generated-code checks passed
- [ ] Manual verification of provider rail reopening the last conversation and detached window status hydration in the running dev app

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Standalone agent windows now load provider status immediately and check all managed providers on open.
  * Opening an agent window now carries cached provider status for a smoother experience.

* **Bug Fixes**
  * Selecting a provider target now reopens the best matching existing conversation instead of switching to an empty composer too early.
  * Provider status no longer briefly appears unavailable before it finishes loading.

* **Documentation**
  * Clarified how target-grid navigation behaves when opening existing conversations or empty home composers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->