### PR TITLE
fix(agent): claude turn-state desyncs — cancel reason-as-turnID + missing SubmitAvailability on live phases

### DIFF
--- a/packages/agent/daemon/activity/service.go
+++ b/packages/agent/daemon/activity/service.go
@@ -1607,12 +1607,19 @@ func explicitTurnLifecycleOutcomeFromActivityEvent(event activityshared.Event) s
 }
 
 func submitAvailabilityForTurnLifecyclePhase(phase string) *WorkspaceAgentSubmitAvailability {
-	switch phase {
-	case "settled":
+	// Classify the phase the same way reporter.go's
+	// submitAvailabilityPatchForSnapshotPhase does. Hardcoding only
+	// "submitted"/"running" missed the other live phases (working, streaming,
+	// waiting_*): those fell through to nil, which drops SubmitAvailability from
+	// the pushed state patch, so the GUI kept its previous "available" value
+	// while a turn was actually running and let the user submit — the daemon
+	// then rejected the send with "agent session already has an active turn".
+	switch {
+	case phase == "settled":
 		return &WorkspaceAgentSubmitAvailability{State: "available"}
-	case "waiting":
+	case activityshared.TurnLifecyclePhaseIsWaiting(phase):
 		return &WorkspaceAgentSubmitAvailability{State: "blocked", Reason: "waiting"}
-	case "submitted", "running":
+	case activityshared.TurnLifecyclePhaseIsLive(phase):
 		return &WorkspaceAgentSubmitAvailability{State: "blocked", Reason: "active_turn"}
 	default:
 		return nil

--- a/packages/agent/daemon/activity/service_test.go
+++ b/packages/agent/daemon/activity/service_test.go
@@ -2651,3 +2651,34 @@ func (f *fakeInterruptReporter) ReportSessionMessages(_ context.Context, input R
 	f.workspaceID = input.WorkspaceID
 	return ReportSessionMessagesReply{AcceptedCount: len(input.Updates)}, nil
 }
+
+// Every live turn-lifecycle phase must map to blocked(active_turn), not nil.
+// Returning nil for a live phase drops SubmitAvailability from the pushed state
+// patch, so the GUI keeps a stale "available" and lets the user submit into an
+// active turn (which the daemon then rejects with "already has an active turn").
+func TestSubmitAvailabilityForTurnLifecyclePhaseCoversLivePhases(t *testing.T) {
+	blockedActive := &WorkspaceAgentSubmitAvailability{State: "blocked", Reason: "active_turn"}
+	blockedWaiting := &WorkspaceAgentSubmitAvailability{State: "blocked", Reason: "waiting"}
+	available := &WorkspaceAgentSubmitAvailability{State: "available"}
+
+	cases := []struct {
+		phase string
+		want  *WorkspaceAgentSubmitAvailability
+	}{
+		{"settled", available},
+		{"submitted", blockedActive},
+		{"running", blockedActive},
+		{"working", blockedActive},   // regression: used to fall through to nil
+		{"streaming", blockedActive}, // regression: used to fall through to nil
+		{string(activityshared.TurnPhaseWaitingApproval), blockedWaiting},
+		{string(activityshared.TurnPhaseWaitingInput), blockedWaiting},
+		{"idle", nil},
+		{"", nil},
+	}
+	for _, tc := range cases {
+		got := submitAvailabilityForTurnLifecyclePhase(tc.phase)
+		if !reflect.DeepEqual(got, tc.want) {
+			t.Fatalf("phase %q: got %#v, want %#v", tc.phase, got, tc.want)
+		}
+	}
+}

--- a/packages/agent/daemon/runtime/claude_sdk_adapter.go
+++ b/packages/agent/daemon/runtime/claude_sdk_adapter.go
@@ -410,7 +410,7 @@ func (a *ClaudeCodeSDKAdapter) GuideActiveTurn(
 	return events, nil
 }
 
-func (a *ClaudeCodeSDKAdapter) Cancel(_ context.Context, session Session, turnID string) ([]activityshared.Event, error) {
+func (a *ClaudeCodeSDKAdapter) Cancel(_ context.Context, session Session, _ string) ([]activityshared.Event, error) {
 	adapterSession := a.getSession(session.AgentSessionID)
 	if adapterSession == nil {
 		return nil, nil
@@ -422,12 +422,26 @@ func (a *ClaudeCodeSDKAdapter) Cancel(_ context.Context, session Session, turnID
 			"agentSessionId": session.AgentSessionID,
 		},
 	})
-	events := a.claudeSDKPendingRequestFailureEvents(adapterSession, session, turnID, errPermissionRequestCanceled)
-	// Only synthesize a terminal transition for a turn that is still live; a
-	// cancel racing the turn's own settle otherwise emits a second,
-	// contradicting terminal event (the stuck-view class ADR 0008 removes).
-	if trimmed := strings.TrimSpace(turnID); trimmed != "" && !a.turnAlreadySettled(adapterSession, trimmed) {
-		events = append(events, newTurnActivityEvent(session, EventTurnCanceled, trimmed, SessionStatusCanceled, "", "", map[string]any{
+	events := a.claudeSDKPendingRequestFailureEvents(adapterSession, session, "", errPermissionRequestCanceled)
+	// The Adapter.Cancel interface passes the cancel *reason* here, not a turnID:
+	// the controller calls adapter.Cancel(ctx, session, reason). This adapter used
+	// to treat the argument as a turnID and synthesize a terminal for it, so a
+	// controller stop (reason "user") stamped a bogus turn "user" and, when no
+	// turn was live, still fabricated an event that made the controller log
+	// "reconciled runtime work without a turn record" for work that did not
+	// exist. Derive the live turns from our own registry instead, and stamp a
+	// settle-guarded terminal for each real turnID. The waiter is deliberately
+	// left registered: the sidecar's own turn_canceled still settles it (and a
+	// controller stop separately cancels the turn context, which unblocks Exec) —
+	// removing it here would drop that natural settle and break /goal clear.
+	for _, turnID := range a.liveClaudeSDKTurnIDs(adapterSession) {
+		// Skip a turn that already settled on its own, so a cancel racing the
+		// turn's own terminal does not emit a second, contradicting terminal
+		// event (the stuck-view class ADR 0008 removes).
+		if a.turnAlreadySettled(adapterSession, turnID) {
+			continue
+		}
+		events = append(events, newTurnActivityEvent(session, EventTurnCanceled, turnID, SessionStatusCanceled, "", "", map[string]any{
 			"reason": "user",
 		}))
 	}

--- a/packages/agent/daemon/runtime/claude_sdk_adapter_test.go
+++ b/packages/agent/daemon/runtime/claude_sdk_adapter_test.go
@@ -733,6 +733,11 @@ func TestClaudeCodeSDKAdapterCancelClearsPendingInteractive(t *testing.T) {
 	}
 	adapter.storeSession(session.AgentSessionID, adapterSession)
 
+	// A turn parked on an approval has a live Exec waiter in the registry; the
+	// interrupted terminal is stamped for that registered turnID, not for the
+	// cancel argument (which is the reason).
+	adapter.registerClaudeSDKTurn(adapterSession, "turn-cancel", nil)
+
 	if _, _, err := adapter.sidecarTurnEvents(adapterSession, session, "turn-cancel", claudeSDKSidecarEvent{
 		Type: "approval_requested",
 		Payload: map[string]any{
@@ -748,7 +753,7 @@ func TestClaudeCodeSDKAdapterCancelClearsPendingInteractive(t *testing.T) {
 		t.Fatal("pending prompt missing before cancel")
 	}
 
-	events, err := adapter.Cancel(context.Background(), session, "turn-cancel")
+	events, err := adapter.Cancel(context.Background(), session, "user")
 	if err != nil {
 		t.Fatalf("Cancel: %v", err)
 	}

--- a/packages/agent/daemon/runtime/claude_sdk_goal_lifecycle_test.go
+++ b/packages/agent/daemon/runtime/claude_sdk_goal_lifecycle_test.go
@@ -116,9 +116,14 @@ func TestClaudeSDKCancelLiveTurnEmitsStampedTerminal(t *testing.T) {
 
 	adapter := NewClaudeCodeSDKAdapter(nil)
 	conn := &recordingClaudeSDKConnection{}
-	session, _ := newClaudeSDKLifecycleTestSession(t, adapter, conn)
+	session, adapterSession := newClaudeSDKLifecycleTestSession(t, adapter, conn)
 
-	events, err := adapter.Cancel(context.Background(), session, "turn-live")
+	// The live turn is identified by the adapter's own registry, not by the
+	// Cancel argument (which is the cancel reason). Register a live turn and pass
+	// an unrelated reason to prove the terminal is stamped for the real turnID.
+	adapter.registerClaudeSDKTurn(adapterSession, "turn-live", nil)
+
+	events, err := adapter.Cancel(context.Background(), session, "user")
 	if err != nil {
 		t.Fatalf("Cancel: %v", err)
 	}
@@ -126,12 +131,54 @@ func TestClaudeSDKCancelLiveTurnEmitsStampedTerminal(t *testing.T) {
 	// event construction.
 	snapshot := claudeSDKSnapshotForEvent(t, events, activityshared.EventTurnCompleted)
 	if snapshot.Phase != string(activityshared.TurnPhaseSettled) ||
-		snapshot.Outcome != string(activityshared.TurnOutcomeInterrupted) {
+		snapshot.Outcome != string(activityshared.TurnOutcomeInterrupted) ||
+		snapshot.ActiveTurnID != "" {
 		t.Fatalf("cancel snapshot = %#v", snapshot)
 	}
 	sent := conn.sentRequests()
 	if len(sent) != 1 || sent[0].Type != "cancel" {
 		t.Fatalf("sent requests = %#v, want one cancel", sent)
+	}
+}
+
+// The controller calls adapter.Cancel(ctx, session, reason) — the third argument
+// is the cancel reason ("user"), not a turnID. Cancel must stamp the interrupted
+// terminal for the real live turnID taken from its own registry, never for the
+// reason string, and must leave the waiter registered so the sidecar's own
+// turn_canceled can still settle it (removing it would break /goal clear and
+// drop the natural settle).
+func TestClaudeSDKCancelUsesRegistryTurnNotReasonArg(t *testing.T) {
+	t.Parallel()
+
+	adapter := NewClaudeCodeSDKAdapter(nil)
+	conn := &recordingClaudeSDKConnection{}
+	session, adapterSession := newClaudeSDKLifecycleTestSession(t, adapter, conn)
+
+	adapter.registerClaudeSDKTurn(adapterSession, "turn-live", nil)
+
+	// Reason is the free-form stop reason the controller passes, not a turnID.
+	events, err := adapter.Cancel(context.Background(), session, "user")
+	if err != nil {
+		t.Fatalf("Cancel: %v", err)
+	}
+
+	var canceledTurnIDs []string
+	for _, event := range events {
+		if event.Type == activityshared.EventTurnCompleted {
+			canceledTurnIDs = append(canceledTurnIDs, event.Payload.TurnID)
+		}
+		if event.Payload.TurnID == "user" {
+			t.Fatalf("Cancel stamped a terminal for the reason string as a turnID: %#v", event)
+		}
+	}
+	if len(canceledTurnIDs) != 1 || canceledTurnIDs[0] != "turn-live" {
+		t.Fatalf("canceled turn ids = %#v, want [turn-live]", canceledTurnIDs)
+	}
+	// The waiter must survive so the sidecar's natural turn_canceled still settles
+	// it (the /goal clear contract; the controller separately cancels the turn
+	// context to unblock Exec).
+	if adapter.claudeSDKTurnWaiter(adapterSession, "turn-live") == nil {
+		t.Fatal("Cancel removed the live turn waiter; the sidecar settle would be dropped")
 	}
 }
 


### PR DESCRIPTION
Two independent claude-code turn-lifecycle state desyncs, both surfacing to users as a stuck/blocked composer. Found while analysing exported Tutti log bundles.

---

## Fix 1 — `Cancel` read the cancel *reason* as a turnID  (commit 1)

`Adapter.Cancel(ctx, session, reason)` passes the cancel **reason** (e.g. `"user"`), but the Claude SDK adapter treated the third argument as a **turnID**:
- a controller stop stamped a bogus terminal for a turn literally named `"user"`;
- when no turn was live it still fabricated a terminal, making the controller log the false-positive `agent_session.cancel.reconciled` (*"reconciled runtime work without a turn record"*) for work that never existed.

**Fix:** derive the live turns from the adapter's own waiter registry (`liveClaudeSDKTurnIDs`) and stamp a settle-guarded terminal for each **real** turnID. The waiter is intentionally left registered so the sidecar's own `turn_canceled` still settles it and `/goal clear` keeps working. Keeps the ADR-0008 idempotency guard.

Tests: new `TestClaudeSDKCancelUsesRegistryTurnNotReasonArg`; two tests that previously only passed because they passed the turnID *as* the reason are corrected; `/goal clear` + idempotency still green under `-race`.

---

## Fix 2 — live turn phases dropped `SubmitAvailability` from the state patch  (commit 2)

`submitAvailabilityForTurnLifecyclePhase` (activity/service.go) only recognised `submitted`/`running` as active. Other live phases — `working`, `streaming`, `waiting_*` — fell through to `nil`, which **drops `SubmitAvailability` from the pushed state patch**. The GUI then kept its previous `available` value while a turn was actually running, showed the composer as submittable, and the user's send was rejected by the daemon with **"agent session already has an active turn"**.

Confirmed in a `0.1.16-rc.0` log bundle: the renderer showed `currentPhase:"working"` (correct) alongside `submitAvailability:"available"` (stale) during a turn that was continuously producing tool calls.

**Fix:** classify the phase the same way `reporter.go`'s `submitAvailabilityPatchForSnapshotPhase` already does (`TurnLifecyclePhaseIsWaiting` / `TurnLifecyclePhaseIsLive`), so every live phase pushes `blocked(active_turn)`. This just brings the two near-duplicate mappers back to parity.

Tests: new `TestSubmitAvailabilityForTurnLifecyclePhaseCoversLivePhases` covering `working`/`streaming`/`waiting_*`; full `activity` package green.

---

### Not included — the deeper "dropped terminal strands the waiter" hazard
`dispatchClaudeSDKEvent` drops a terminal with no matching waiter (added by `51bd1f69` to prevent Rkyo8B double-toasts). If a live Exec turn's terminal ever arrived under a mismatched sidecar turnId it would strand the waiter, but none of the exported bundles actually reproduced that (each "already active turn" had another cause: pre-`#810` build, GUI stale-snapshot clobber already fixed by `dbe4a9cd`, or Fix 2 above). The sidecar emits no reliable marker to tell a phantom queued/steered terminal (must stay dropped) from a real one, so fixing it blind risks reintroducing Rkyo8B. Left out pending a repro.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Cancellation now targets the adapter-registered live turn, not the cancel “reason” text.
  - Interrupted terminal events are synthesized to prevent duplicate or contradictory terminal transitions.
  - Permission-request failures are surfaced when a cancel stops an in-progress interaction.
  - Turn availability submission now correctly classifies additional “live” lifecycle phases as blocked (active_turn) and “waiting” phases as blocked (waiting).

- **Tests**
  - Updated and expanded adapter cancel tests to verify registry-based stamping and correct event emission.
  - Added unit coverage for availability classification across multiple live phases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->