### PR TITLE
fix(agent-gui): close session context menu actions

### DIFF
--- a/packages/agent/gui/agent-gui/agentGuiNode/AgentGUINode.spec.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/AgentGUINode.spec.tsx
@@ -2434,6 +2434,50 @@ describe("AgentGUINode", () => {
     expect(mockSelectConversation).not.toHaveBeenCalled();
   });
 
+  it("opens a conversation in a new window from the rail context menu without selecting", async () => {
+    const onOpenConversationWindow =
+      vi.fn<
+        NonNullable<
+          React.ComponentProps<typeof AgentGUINode>["onOpenConversationWindow"]
+        >
+      >();
+    mockViewModel = createViewModel({
+      conversations: [
+        {
+          id: "session-1",
+          provider: "codex",
+          title: "Session 1",
+          status: "ready",
+          cwd: "/workspace",
+          updatedAtUnixMs: 1
+        }
+      ],
+      activeConversationId: "session-1"
+    });
+    renderAgentGUINode({ onOpenConversationWindow });
+
+    fireEvent.contextMenu(
+      screen.getByTestId("agent-gui-conversation-item-session-1")
+    );
+    const openWindowMenuItem = await screen.findByRole("menuitem", {
+      name: "agentHost.agentGui.openConversationWindow"
+    });
+    fireEvent.pointerUp(openWindowMenuItem, { button: 0 });
+
+    await waitFor(() =>
+      expect(
+        screen.queryByRole("menuitem", {
+          name: "agentHost.agentGui.openConversationWindow"
+        })
+      ).not.toBeInTheDocument()
+    );
+
+    await waitFor(() =>
+      expect(onOpenConversationWindow).toHaveBeenCalledWith("session-1")
+    );
+    expect(mockSelectConversation).not.toHaveBeenCalled();
+  });
+
   it("opens rename dialog from rail double-click and saves through controller action", async () => {
     mockRenameConversation.mockResolvedValue(undefined);
     mockViewModel = createViewModel({
@@ -2557,6 +2601,14 @@ describe("AgentGUINode", () => {
       name: "agentHost.agentGui.renameSession"
     });
     fireEvent.pointerUp(renameMenuItem, { button: 0 });
+
+    await waitFor(() =>
+      expect(
+        screen.queryByRole("menuitem", {
+          name: "agentHost.agentGui.renameSession"
+        })
+      ).not.toBeInTheDocument()
+    );
 
     expect(
       await screen.findByRole("textbox", {

--- a/packages/agent/gui/agent-gui/agentGuiNode/AgentGUINodeView.layout.spec.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/AgentGUINodeView.layout.spec.tsx
@@ -2458,6 +2458,44 @@ describe("AgentGUINodeView layout persistence", () => {
     expect(actions.selectConversation).not.toHaveBeenCalled();
   });
 
+  it("opens a conversation from the rail context menu without selecting", async () => {
+    const actions = createActions();
+    const onOpenConversationWindow = vi.fn();
+
+    renderAgentGUINodeView({
+      actions,
+      onOpenConversationWindow,
+      viewModel: {
+        ...createViewModel(),
+        activeConversationId: "session-1",
+        conversations: [
+          createConversationSummary("session-1"),
+          createConversationSummary("session-2")
+        ]
+      }
+    });
+
+    fireEvent.contextMenu(
+      screen.getByTestId("agent-gui-conversation-item-session-2")
+    );
+    const openWindowMenuItem = await screen.findByRole("menuitem", {
+      name: "openConversationWindow"
+    });
+    fireEvent.pointerUp(openWindowMenuItem, { button: 0 });
+
+    await waitFor(() =>
+      expect(
+        screen.queryByRole("menuitem", { name: "openConversationWindow" })
+      ).not.toBeInTheDocument()
+    );
+
+    await waitFor(() =>
+      expect(onOpenConversationWindow).toHaveBeenCalledTimes(1)
+    );
+    expect(onOpenConversationWindow).toHaveBeenCalledWith("session-2");
+    expect(actions.selectConversation).not.toHaveBeenCalled();
+  });
+
   it("pages each conversation rail section five sessions at a time", () => {
     renderAgentGUINodeView({
       labels: {

--- a/packages/agent/gui/agent-gui/agentGuiNode/AgentGUINodeView.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/AgentGUINodeView.tsx
@@ -7349,6 +7349,9 @@ const AgentGUIConversationRailItem = memo(
       },
       [item.id, registerItemElement]
     );
+    const [contextMenuResetKey, setContextMenuResetKey] = useState(0);
+    const contextMenuRenameRequestedRef = useRef(false);
+    const contextMenuOpenConversationWindowRequestedRef = useRef(false);
     const handleMouseLeave = useCallback(() => {
       if (isPendingDeleteConversation) {
         onCancelDeleteConversation();
@@ -7370,12 +7373,29 @@ const AgentGUIConversationRailItem = memo(
       onRequestRenameConversation(item.id);
     }, [item.id, onRequestRenameConversation]);
     const handleContextMenuRename = useCallback(() => {
+      if (contextMenuRenameRequestedRef.current) {
+        return;
+      }
+      contextMenuRenameRequestedRef.current = true;
+      setContextMenuResetKey((key) => key + 1);
       window.setTimeout(() => {
         handleRequestRename();
+        contextMenuRenameRequestedRef.current = false;
       }, 0);
     }, [handleRequestRename]);
+    const handleContextMenuOpenConversationWindow = useCallback(() => {
+      if (contextMenuOpenConversationWindowRequestedRef.current) {
+        return;
+      }
+      contextMenuOpenConversationWindowRequestedRef.current = true;
+      setContextMenuResetKey((key) => key + 1);
+      window.setTimeout(() => {
+        handleOpenConversationWindow();
+        contextMenuOpenConversationWindowRequestedRef.current = false;
+      }, 0);
+    }, [handleOpenConversationWindow]);
     return (
-      <ContextMenu>
+      <ContextMenu key={contextMenuResetKey}>
         <ContextMenuTrigger asChild>
           <div
             ref={setItemElement}
@@ -7519,6 +7539,20 @@ const AgentGUIConversationRailItem = memo(
             >
               {labels.renameSession}
             </ContextMenuItem>
+            {onOpenConversationWindow ? (
+              <ContextMenuItem
+                className={styles.composerMenuItem}
+                onClick={handleContextMenuOpenConversationWindow}
+                onPointerUp={(event) => {
+                  if (event.button === 0) {
+                    handleContextMenuOpenConversationWindow();
+                  }
+                }}
+                onSelect={handleContextMenuOpenConversationWindow}
+              >
+                {labels.openConversationWindow}
+              </ContextMenuItem>
+            ) : null}
           </ContextMenuContent>
         )}
       </ContextMenu>


### PR DESCRIPTION
## Summary
- add a session rail context-menu action to open the selected session in a new AgentGUI window/node
- reset the session row context menu before launching or renaming so the menu closes reliably
- cover both open-window and rename context-menu flows without selecting the current node session

## Validation
- pnpm --filter @tutti-os/agent-gui test -- AgentGUINode
- pnpm check:changed
- pnpm check:full

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a conversation menu action to open a conversation in a new window from the conversation row.
* **Bug Fixes**
  * Improved context menu behavior so actions can be triggered without first selecting the conversation.
  * Prevented duplicate action triggers when menu items are clicked rapidly.
  * Updated menu interactions to close cleanly before the next action is handled.
* **Tests**
  * Added coverage for the new conversation-window action and updated existing menu interaction tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->