### PR TITLE
feat(agent): copy session links from rail

### DIFF
--- a/apps/desktop/src/renderer/src/features/workspace-agent/services/desktopAgentGUILinkActions.test.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-agent/services/desktopAgentGUILinkActions.test.ts
@@ -144,7 +144,7 @@ test("desktop agent gui link actions launch agent sessions in the same workspace
   const handled = await runDesktopAgentGUILinkAction(
     {
       agentSessionId: "session-1",
-      provider: "claude-code",
+      agentTargetId: "local:claude-code",
       source: "agent-markdown",
       type: "open-agent-session",
       workspaceId: "workspace-1"
@@ -165,7 +165,7 @@ test("desktop agent gui link actions launch agent sessions in the same workspace
   assert.deepEqual(launchedSessions, [
     {
       agentSessionId: "session-1",
-      provider: "claude-code",
+      agentTargetId: "local:claude-code",
       workspaceId: "workspace-1"
     }
   ]);

--- a/apps/desktop/src/renderer/src/features/workspace-agent/services/desktopAgentGUILinkActions.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-agent/services/desktopAgentGUILinkActions.ts
@@ -1,19 +1,19 @@
 import { parseRichTextMentionHref } from "@tutti-os/ui-rich-text/core";
 import type { WorkspaceLinkAction } from "@contexts/workspace/presentation/renderer/actions/workspaceLinkActions";
+import type { DesktopAgentGUIProvider } from "../desktopAgentGUINodeState.ts";
 
 // Value mirror of AGENT_PASTED_TEXT_MENTION_KIND from @tutti-os/agent-gui.
 // Kept as a local literal so this module (loaded by the node --test runner)
 // does not pull the whole agent-gui barrel, whose extensionless internal
 // imports the test runner cannot resolve.
 const AGENT_PASTED_TEXT_MENTION_KIND = "pasted-text";
-import { normalizeDesktopAgentGUIProvider } from "../desktopAgentGUINodeState.ts";
-import type { DesktopAgentGUIProvider } from "../desktopAgentGUINodeState.ts";
 
 export interface DesktopAgentGUILinkActionDependencies {
   homeDirectory?: string | null;
   launchAgentGui(input: {
     agentSessionId: string;
-    provider: DesktopAgentGUIProvider;
+    agentTargetId?: string | null;
+    provider?: DesktopAgentGUIProvider | null;
     workspaceId: string;
   }): Promise<boolean> | boolean;
   launchWorkspaceIssueManager(input: {
@@ -89,7 +89,9 @@ export async function runDesktopAgentGUILinkAction(
       }
       return dependencies.launchAgentGui({
         agentSessionId: action.agentSessionId,
-        provider: normalizeDesktopAgentGUIProvider(action.provider),
+        ...(action.agentTargetId
+          ? { agentTargetId: action.agentTargetId }
+          : {}),
         workspaceId: dependencies.workspaceId
       });
     case "open-workspace-issue": {

--- a/apps/desktop/src/renderer/src/features/workspace-agent/services/workspaceAgentGuiLaunchCoordinator.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-agent/services/workspaceAgentGuiLaunchCoordinator.ts
@@ -6,7 +6,7 @@ export interface WorkspaceAgentGuiLaunchRequest {
   autoSubmit?: boolean;
   draftPrompt?: string;
   openInNewWindow?: boolean;
-  provider: DesktopAgentGUIProvider;
+  provider?: DesktopAgentGUIProvider | null;
   userProjectPath?: string | null;
   workspaceId: string;
 }

--- a/packages/agent/gui/actions/workspaceLinkActions.spec.ts
+++ b/packages/agent/gui/actions/workspaceLinkActions.spec.ts
@@ -423,22 +423,17 @@ describe("resolveWorkspaceMentionLinkAction", () => {
     });
   });
 
-  it("restores the mentioned session's own provider from the agentProvider scope key", () => {
-    // Regression for cross-provider mentions (e.g. a Codex conversation
-    // @-mentioning a Claude Code session) resolving to the WRONG provider:
-    // callers default `provider` from their own viewing context only when
-    // the action doesn't already carry one, so the mention must capture the
-    // target session's real provider here rather than leaving it undefined.
+  it("parses the mentioned session's agent target scope", () => {
     expect(
       resolveWorkspaceMentionLinkAction({
-        href: "mention://agent-session/session-1?agentProvider=claude-code&workspaceId=workspace-1",
+        href: "mention://agent-session/session-1?agentTargetId=local%3Aclaude-code&workspaceId=workspace-1",
         source: "agent-markdown"
       })
     ).toEqual({
       type: "open-agent-session",
       workspaceId: "workspace-1",
       agentSessionId: "session-1",
-      provider: "claude-code",
+      agentTargetId: "local:claude-code",
       source: "agent-markdown"
     });
   });

--- a/packages/agent/gui/actions/workspaceLinkActions.ts
+++ b/packages/agent/gui/actions/workspaceLinkActions.ts
@@ -70,7 +70,7 @@ export interface OpenAgentSessionLinkAction {
   type: "open-agent-session";
   workspaceId: string;
   agentSessionId: string;
-  provider?: string | null;
+  agentTargetId?: string | null;
   source: WorkspaceLinkActionSource;
 }
 
@@ -316,19 +316,12 @@ export function resolveWorkspaceMentionLinkAction({
   }
 
   if (mention.providerId === "agent-session") {
-    // The mentioned session's own agent provider, when the mention captured
-    // one (see buildSessionMentionItem in agentMentionSearchHelpers.ts).
-    // Older mentions created before that provider was captured leave this
-    // undefined; callers fall back to their own viewing context's provider
-    // in that case, but must NOT do so when a provider was actually
-    // recorded — the mentioned session may belong to a different provider
-    // than the one the mention is being opened from.
-    const provider = mention.scope?.agentProvider?.trim() || null;
+    const agentTargetId = mention.scope?.agentTargetId?.trim() || null;
     return {
       type: "open-agent-session",
       workspaceId,
       agentSessionId: targetId,
-      ...(provider ? { provider } : {}),
+      ...(agentTargetId ? { agentTargetId } : {}),
       source
     };
   }

--- a/packages/agent/gui/agent-gui/agentGuiNode/AgentGUINode.spec.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/AgentGUINode.spec.tsx
@@ -77,6 +77,7 @@ const {
 const mockSelectFiles = vi.fn();
 const mockSelectDirectory = vi.fn();
 const mockEnsureDirectory = vi.fn();
+const mockWriteClipboardText = vi.fn();
 const mockRegisterUploadSources = vi.fn();
 const mockInspectUploadSources = vi.fn();
 const mockPreflightUpload = vi.fn();
@@ -770,6 +771,7 @@ describe("AgentGUINode", () => {
     mockSelectFiles.mockReset();
     mockSelectDirectory.mockReset();
     mockEnsureDirectory.mockReset();
+    mockWriteClipboardText.mockReset();
     mockRegisterUploadSources.mockReset();
     mockInspectUploadSources.mockReset();
     mockPreflightUpload.mockReset();
@@ -808,6 +810,7 @@ describe("AgentGUINode", () => {
     });
     mockBatchGetUserInfo.mockResolvedValue({ users: [] });
     mockEnsureDirectory.mockResolvedValue(undefined);
+    mockWriteClipboardText.mockResolvedValue(undefined);
     mockInspectUploadSources.mockResolvedValue({
       hasGitignore: false,
       gitignoreSourceCount: 0
@@ -818,6 +821,9 @@ describe("AgentGUINode", () => {
       value: {
         account: {
           batchGetUserInfo: mockBatchGetUserInfo
+        },
+        clipboard: {
+          writeText: mockWriteClipboardText
         },
         workspace: {
           selectFiles: mockSelectFiles,
@@ -2159,6 +2165,7 @@ describe("AgentGUINode", () => {
       conversations: [
         {
           id: "session-1",
+          agentTargetId: "local:codex",
           provider: "codex",
           title: "Session 1",
           status: "ready",
@@ -2190,6 +2197,7 @@ describe("AgentGUINode", () => {
       conversations: [
         {
           id: "session-1",
+          agentTargetId: "local:codex",
           provider: "codex",
           title: "Project Session",
           status: "ready",
@@ -2578,6 +2586,39 @@ describe("AgentGUINode", () => {
         })
       ).toBeNull();
     });
+  });
+
+  it("copies a conversation mention link from the rail context menu without selecting", async () => {
+    mockViewModel = createViewModel({
+      conversations: [
+        {
+          id: "session-1",
+          agentTargetId: "local:codex",
+          provider: "codex",
+          title: "Session [1] \\ draft",
+          status: "ready",
+          cwd: "/workspace",
+          updatedAtUnixMs: 1
+        }
+      ],
+      activeConversationId: "session-1"
+    });
+    renderAgentGUINode();
+
+    fireEvent.contextMenu(
+      screen.getByTestId("agent-gui-conversation-item-session-1")
+    );
+    const copyLinkMenuItem = await screen.findByRole("menuitem", {
+      name: "agentHost.agentGui.copySessionLink"
+    });
+    fireEvent.pointerUp(copyLinkMenuItem, { button: 0 });
+
+    await waitFor(() =>
+      expect(mockWriteClipboardText).toHaveBeenCalledWith(
+        "[Session \\[1\\] \\\\ draft](mention://agent-session/session-1?agentTargetId=local%3Acodex&workspaceId=room-1)"
+      )
+    );
+    expect(mockSelectConversation).not.toHaveBeenCalled();
   });
 
   it("opens rename dialog from the rail context menu", async () => {
@@ -3829,12 +3870,11 @@ describe("AgentGUINode", () => {
       type: "open-agent-session",
       workspaceId: "room-1",
       agentSessionId: "session-queued",
-      provider: "codex",
       source: "agent-markdown"
     });
   });
 
-  it("forwards composer mention link actions with the mention session provider", async () => {
+  it("forwards composer mention link actions without provider fallback", async () => {
     const onLinkAction = vi.fn<(action: WorkspaceLinkAction) => void>();
     mockViewModel = createViewModel({
       activeConversationId: "session-1",
@@ -3860,7 +3900,6 @@ describe("AgentGUINode", () => {
       type: "open-agent-session",
       workspaceId: "room-1",
       agentSessionId: "session-draft",
-      provider: "codex",
       source: "agent-markdown"
     });
   });
@@ -6928,7 +6967,6 @@ describe("AgentGUINode", () => {
       type: "open-agent-session",
       workspaceId: "room-1",
       agentSessionId: "session-2",
-      provider: "codex",
       source: "agent-markdown"
     });
   });
@@ -7229,6 +7267,7 @@ function createAgentActivitySnapshotFromViewModel(
     sessions: mockViewModel.conversations.map((conversation) => ({
       workspaceId,
       agentSessionId: conversation.id,
+      agentTargetId: conversation.agentTargetId,
       provider: String(conversation.provider),
       userId: conversation.userId,
       cwd: conversation.cwd,

--- a/packages/agent/gui/agent-gui/agentGuiNode/AgentGUINode.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/AgentGUINode.tsx
@@ -772,13 +772,16 @@ export const AgentGUINode = memo(function AgentGUINode({
   );
   const handleLinkAction = useCallback(
     (action: WorkspaceLinkAction) => {
+      const agentTargetId = state.agentTargetId?.trim() || null;
       onLinkAction?.(
-        action.type === "open-agent-session" && !action.provider
-          ? { ...action, provider: state.provider }
+        action.type === "open-agent-session" &&
+          !action.agentTargetId &&
+          agentTargetId
+          ? { ...action, agentTargetId }
           : action
       );
     },
-    [onLinkAction, state.provider]
+    [onLinkAction, state.agentTargetId]
   );
   const handleAgentProviderLogin = useCallback(
     (provider?: string | null) => {
@@ -1387,6 +1390,7 @@ export const AgentGUINode = memo(function AgentGUINode({
       showLessConversations: t("agentHost.agentGui.showLessConversations"),
       deleteSession: t("agentHost.agentGui.deleteSession"),
       pinSession: t("agentHost.agentGui.pinSession"),
+      copySessionLink: t("agentHost.agentGui.copySessionLink"),
       renameSession: t("agentHost.agentGui.renameSession"),
       renameSessionTitle: t("agentHost.agentGui.renameSessionTitle"),
       renameSessionDescription: t(

--- a/packages/agent/gui/agent-gui/agentGuiNode/AgentGUINodeView.layout.spec.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/AgentGUINodeView.layout.spec.tsx
@@ -5262,6 +5262,7 @@ function createLabels(): AgentGUIViewLabels {
     showMoreConversations: "showMoreConversations",
     showLessConversations: "showLessConversations",
     deleteSession: "deleteSession",
+    copySessionLink: "copySessionLink",
     renameSession: "renameSession",
     renameSessionTitle: "renameSessionTitle",
     renameSessionDescription: "renameSessionDescription",

--- a/packages/agent/gui/agent-gui/agentGuiNode/AgentGUINodeView.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/AgentGUINodeView.tsx
@@ -157,7 +157,10 @@ import {
 } from "../../shared/AgentTargetPresentationContext";
 import { AgentInteractivePromptSurface } from "./AgentInteractivePromptSurface";
 import { AgentConversationListSkeleton } from "./AgentConversationListSkeleton";
-import { useAgentHostApi } from "../../agentActivityHost";
+import {
+  useAgentHostApi,
+  useOptionalAgentHostApi
+} from "../../agentActivityHost";
 import {
   useAgentActivityRuntime,
   type AgentActivityRuntimeSessionSection
@@ -183,7 +186,11 @@ import type {
   AgentContextMentionItem,
   AgentMentionWorkspaceReferenceItem
 } from "./agentRichText/agentFileMentionExtension";
-import { formatAgentMentionMarkdown } from "./agentRichText/agentFileMentionExtension";
+import {
+  createAgentSessionMarkdownLink,
+  createAgentSessionMentionHref,
+  formatAgentMentionMarkdown
+} from "./agentRichText/agentFileMentionExtension";
 import { createRichTextMentionHref } from "@tutti-os/ui-rich-text/core";
 import { resolveAgentGuiSessionProviderFlatIconUrl } from "../../agentGuiSessionProviderIconUrls";
 import { agentColorfulUrl } from "../../managedAgentIconAssets";
@@ -513,6 +520,7 @@ export interface AgentGUIViewLabels {
   showLessConversations: string;
   deleteSession: string;
   pinSession: string;
+  copySessionLink: string;
   renameSession: string;
   renameSessionTitle: string;
   renameSessionDescription: string;
@@ -1067,17 +1075,18 @@ function buildAgentConversationHandoffPrompt(input: {
     input.uiLanguage
   );
   const mentionLabel = `${sourceAgentLabel}${title ? ` ${title}` : ""}`.trim();
-  const href = createRichTextMentionHref({
-    providerId: "agent-session",
-    entityId: conversation.id,
+  const href = createAgentSessionMentionHref({
+    agentTargetId: conversation.agentTargetId,
+    agentSessionId: conversation.id,
     label: mentionLabel,
-    scope: { workspaceId: input.workspaceId }
+    workspaceId: input.workspaceId
   });
   return `${formatAgentMentionMarkdown({
     kind: "session",
     href,
     workspaceId: input.workspaceId,
     targetId: conversation.id,
+    agentTargetId: conversation.agentTargetId ?? undefined,
     name: mentionLabel,
     title: title || sourceAgentLabel,
     scope: "my_sessions",
@@ -4961,6 +4970,7 @@ function conversationSummariesRenderEqual(
 ): boolean {
   return (
     left.id === right.id &&
+    left.agentTargetId === right.agentTargetId &&
     left.provider === right.provider &&
     left.title === right.title &&
     left.titleFallback === right.titleFallback &&
@@ -6821,6 +6831,7 @@ const AgentGUIConversationRailPane = memo(
                     section={section}
                     sectionHasMore={sectionHasMore}
                     uiLanguage={uiLanguage}
+                    workspaceId={workspaceId}
                     onCancelDeleteConversation={onCancelDeleteConversation}
                     onConfirmDeleteConversation={onConfirmDeleteConversation}
                     onCreateConversation={onCreateConversation}
@@ -6928,6 +6939,7 @@ interface AgentGUIConversationRailSectionProps {
   currentTimeMs: number;
   labels: AgentGUIViewLabels;
   uiLanguage: UiLanguage;
+  workspaceId: string;
   registerItemElement: (itemId: string, element: HTMLDivElement | null) => void;
   onCreateConversation: (options?: {
     projectPath?: string | null;
@@ -6964,6 +6976,7 @@ const AgentGUIConversationRailSection = memo(
     currentTimeMs,
     labels,
     uiLanguage,
+    workspaceId,
     registerItemElement,
     onCreateConversation,
     onToggleProjectSectionCollapsed,
@@ -7324,6 +7337,7 @@ const AgentGUIConversationRailSection = memo(
                 previewMode={previewMode}
                 registerItemElement={registerItemElement}
                 uiLanguage={uiLanguage}
+                workspaceId={workspaceId}
                 onCancelDeleteConversation={onCancelDeleteConversation}
                 onConfirmDeleteConversation={onConfirmDeleteConversation}
                 onRequestDeleteConversation={onRequestDeleteConversation}
@@ -7373,6 +7387,7 @@ interface AgentGUIConversationRailItemProps {
   labels: AgentGUIViewLabels;
   previewMode: boolean;
   uiLanguage: UiLanguage;
+  workspaceId: string;
   registerItemElement: (itemId: string, element: HTMLDivElement | null) => void;
   onSelectConversation: (agentSessionId: string) => void;
   onToggleConversationPinned: (agentSessionId: string, pinned: boolean) => void;
@@ -7394,6 +7409,7 @@ const AgentGUIConversationRailItem = memo(
     labels,
     previewMode,
     uiLanguage,
+    workspaceId,
     registerItemElement,
     onSelectConversation,
     onToggleConversationPinned,
@@ -7416,6 +7432,8 @@ const AgentGUIConversationRailItem = memo(
     const [contextMenuResetKey, setContextMenuResetKey] = useState(0);
     const contextMenuRenameRequestedRef = useRef(false);
     const contextMenuOpenConversationWindowRequestedRef = useRef(false);
+    const contextMenuCopySessionLinkRequestedRef = useRef(false);
+    const agentHostApi = useOptionalAgentHostApi();
     const handleMouseLeave = useCallback(() => {
       if (isPendingDeleteConversation) {
         onCancelDeleteConversation();
@@ -7472,6 +7490,33 @@ const AgentGUIConversationRailItem = memo(
         contextMenuOpenConversationWindowRequestedRef.current = false;
       }, 0);
     }, [handleOpenConversationWindow]);
+    const handleContextMenuCopySessionLink = useCallback(() => {
+      if (contextMenuCopySessionLinkRequestedRef.current) {
+        return;
+      }
+      contextMenuCopySessionLinkRequestedRef.current = true;
+      setContextMenuResetKey((key) => key + 1);
+      window.setTimeout(() => {
+        if (!agentHostApi?.clipboard?.writeText) {
+          contextMenuCopySessionLinkRequestedRef.current = false;
+          return;
+        }
+        const title = conversationPlainTitle(item, labels, uiLanguage);
+        const markdown = createAgentSessionMarkdownLink({
+          agentSessionId: item.id,
+          agentTargetId: item.agentTargetId,
+          label: title,
+          workspaceId,
+          withAtPrefix: false
+        });
+        void agentHostApi.clipboard
+          .writeText(markdown)
+          .catch(() => undefined)
+          .finally(() => {
+            contextMenuCopySessionLinkRequestedRef.current = false;
+          });
+      }, 0);
+    }, [agentHostApi, item, labels, uiLanguage, workspaceId]);
     const row = (
       <div
         ref={setItemElement}
@@ -7630,6 +7675,18 @@ const AgentGUIConversationRailItem = memo(
               <span>{labels.openConversationWindow}</span>
             </ContextMenuItem>
           ) : null}
+          <ContextMenuItem
+            className={`${styles.composerMenuItem} nodrag [-webkit-app-region:no-drag]`}
+            onClick={handleContextMenuCopySessionLink}
+            onPointerUp={(event) => {
+              if (event.button === 0) {
+                handleContextMenuCopySessionLink();
+              }
+            }}
+            onSelect={handleContextMenuCopySessionLink}
+          >
+            <span>{labels.copySessionLink}</span>
+          </ContextMenuItem>
           <ContextMenuItem
             className={`${styles.composerMenuItem} nodrag [-webkit-app-region:no-drag]`}
             disabled={!canMarkUnread}

--- a/packages/agent/gui/agent-gui/agentGuiNode/agentMentionSearchHelpers.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/agentMentionSearchHelpers.ts
@@ -48,6 +48,7 @@ export function buildSessionMentionItem(input: {
       translate("agentHost.agentGui.mentionCollaboratorFallback")
   );
   const sessionProvider = input.session.provider?.trim() ?? "";
+  const sessionAgentTargetId = input.session.agentTargetId?.trim() ?? "";
   const agentName = workspaceAgentProviderLabel(sessionProvider || "unknown");
   const inputPreview =
     compactText(input.summary?.latestUserRequirement) ||
@@ -81,20 +82,12 @@ export function buildSessionMentionItem(input: {
       label: mentionTitle,
       scope: {
         workspaceId: input.workspaceId,
-        // Captures the mentioned session's OWN agent provider (e.g.
-        // "claude-code") so opening the mention later can restore it. Without
-        // this, resolveWorkspaceMentionLinkAction() has no provider to put on
-        // the resulting open-agent-session action, and callers were falling
-        // back to defaulting it from the CURRENT/viewing node's own provider
-        // — which is wrong whenever a session is mentioned across providers
-        // (e.g. a Codex conversation @-mentioning a Claude Code session) and
-        // could overwrite the target session's stored cwd/visibility with
-        // data reported under the wrong provider context.
-        ...(sessionProvider ? { agentProvider: sessionProvider } : {})
+        ...(sessionAgentTargetId ? { agentTargetId: sessionAgentTargetId } : {})
       }
     }),
     workspaceId: input.workspaceId,
     targetId: input.session.agentSessionId,
+    ...(sessionAgentTargetId ? { agentTargetId: sessionAgentTargetId } : {}),
     name: `${initiatorName} & ${agentName} ${mentionTitle}`.trim(),
     title: mentionTitle,
     scope,

--- a/packages/agent/gui/agent-gui/agentGuiNode/agentRichText/agentFileMentionExtension.spec.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/agentRichText/agentFileMentionExtension.spec.ts
@@ -3,6 +3,8 @@ import type { Editor, Range } from "@tiptap/core";
 import { Schema } from "@tiptap/pm/model";
 import {
   attrsToMentionItem,
+  createAgentSessionMarkdownLink,
+  createAgentSessionMentionHref,
   expandRangeOverMentionPlaceholder,
   formatAgentMentionMarkdown,
   mentionItemToAttrs,
@@ -93,13 +95,14 @@ describe("parseAgentMentionMarkdown", () => {
   it("accepts generic session mention hrefs", () => {
     expect(
       parseAgentMentionMarkdown(
-        "[@Session](mention://agent-session/session-1?workspaceId=workspace-1)"
+        "[@Session](mention://agent-session/session-1?agentTargetId=local%3Aclaude-code&workspaceId=workspace-1)"
       )
     ).toMatchObject({
       item: {
         kind: "session",
         workspaceId: "workspace-1",
         targetId: "session-1",
+        agentTargetId: "local:claude-code",
         name: "Session"
       }
     });
@@ -271,7 +274,7 @@ describe("attrsToMentionItem", () => {
     expect(
       attrsToMentionItem({
         kind: "session",
-        href: "mention://agent-session/session-1?workspaceId=workspace-1",
+        href: "mention://agent-session/session-1?agentTargetId=local%3Aclaude-code&workspaceId=workspace-1",
         workspaceId: "workspace-1",
         targetId: "session-1",
         name: "Session"
@@ -279,7 +282,8 @@ describe("attrsToMentionItem", () => {
     ).toMatchObject({
       kind: "session",
       workspaceId: "workspace-1",
-      targetId: "session-1"
+      targetId: "session-1",
+      agentTargetId: "local:claude-code"
     });
   });
 
@@ -392,6 +396,85 @@ describe("attrsToMentionItem", () => {
       agentProviderId: "claude-code",
       iconUrl: "tutti://agent/claude-code.svg"
     });
+  });
+});
+
+describe("agent session mention links", () => {
+  it("builds the stable agent-session mention href", () => {
+    expect(
+      createAgentSessionMentionHref({
+        agentSessionId: "session-1",
+        agentTargetId: "local:claude-code",
+        label: "Session 1",
+        workspaceId: "room-1"
+      })
+    ).toBe(
+      "mention://agent-session/session-1?agentTargetId=local%3Aclaude-code&workspaceId=room-1"
+    );
+  });
+
+  it("formats composer session mentions with the mention prefix", () => {
+    expect(
+      createAgentSessionMarkdownLink({
+        agentSessionId: "session-1",
+        agentTargetId: "local:codex",
+        label: "Session 1",
+        workspaceId: "room-1",
+        withAtPrefix: true
+      })
+    ).toBe(
+      "[@Session 1](mention://agent-session/session-1?agentTargetId=local%3Acodex&workspaceId=room-1)"
+    );
+  });
+
+  it("formats copied session links without the mention prefix", () => {
+    expect(
+      createAgentSessionMarkdownLink({
+        agentSessionId: "session-1",
+        label: "Session [draft] \\ one",
+        workspaceId: "room-1",
+        withAtPrefix: false
+      })
+    ).toBe(
+      "[Session \\[draft\\] \\\\ one](mention://agent-session/session-1?workspaceId=room-1)"
+    );
+  });
+
+  it("preserves the agent target when formatting a session mention item", () => {
+    expect(
+      formatAgentMentionMarkdown({
+        kind: "session",
+        href: "mention://agent-session/session-1?workspaceId=room-1",
+        workspaceId: "room-1",
+        targetId: "session-1",
+        agentTargetId: "local:claude-code",
+        name: "Session 1",
+        title: "Session 1",
+        scope: "my_sessions",
+        initiatorName: "Taylor",
+        agentName: "Claude Code"
+      })
+    ).toBe(
+      "[@Session 1](mention://agent-session/session-1?agentTargetId=local%3Aclaude-code&workspaceId=room-1)"
+    );
+  });
+
+  it("preserves the agent target from an existing session href", () => {
+    expect(
+      formatAgentMentionMarkdown({
+        kind: "session",
+        href: "mention://agent-session/session-1?agentTargetId=local%3Aclaude-code&workspaceId=room-1",
+        workspaceId: "room-1",
+        targetId: "session-1",
+        name: "Session 1",
+        title: "Session 1",
+        scope: "my_sessions",
+        initiatorName: "Taylor",
+        agentName: "Claude Code"
+      })
+    ).toBe(
+      "[@Session 1](mention://agent-session/session-1?agentTargetId=local%3Aclaude-code&workspaceId=room-1)"
+    );
   });
 });
 

--- a/packages/agent/gui/agent-gui/agentGuiNode/agentRichText/agentFileMentionExtension.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/agentRichText/agentFileMentionExtension.ts
@@ -5,6 +5,8 @@ import Suggestion, { exitSuggestion } from "@tiptap/suggestion";
 import { isRichTextTriggerPrefixBoundary } from "@tutti-os/ui-rich-text/editor";
 import {
   createRichTextLinkMarkdown,
+  createRichTextMarkdownLink,
+  createRichTextMentionHref,
   createRichTextMentionMarkdown,
   isRichTextMentionHref,
   parseRichTextMentionHref
@@ -53,6 +55,7 @@ export interface AgentMentionSessionItem {
   href: string;
   workspaceId: string;
   targetId: string;
+  agentTargetId?: string;
   name: string;
   title: string;
   scope: AgentMentionScope;
@@ -296,6 +299,7 @@ export function createAgentFileMentionExtension(
         directoryPath: { default: "" },
         workspaceId: { default: "" },
         targetId: { default: "" },
+        agentTargetId: { default: "" },
         scope: { default: "" },
         title: { default: "" },
         initiatorName: { default: "" },
@@ -602,6 +606,45 @@ export function formatAgentFileMentionMarkdown(
   });
 }
 
+export function createAgentSessionMentionHref(input: {
+  agentSessionId: string;
+  agentTargetId?: string | null;
+  label: string;
+  workspaceId: string;
+}): string {
+  const label = normalizeAgentSessionMarkdownLabel(input.label);
+  const agentTargetId = input.agentTargetId?.trim() ?? "";
+  return createRichTextMentionHref({
+    providerId: "agent-session",
+    entityId: input.agentSessionId,
+    label,
+    scope: {
+      ...(agentTargetId ? { agentTargetId } : {}),
+      workspaceId: input.workspaceId
+    }
+  });
+}
+
+export function createAgentSessionMarkdownLink(input: {
+  agentSessionId: string;
+  agentTargetId?: string | null;
+  label: string;
+  workspaceId: string;
+  withAtPrefix: boolean;
+}): string {
+  const label = normalizeAgentSessionMarkdownLabel(input.label);
+  const href = createAgentSessionMentionHref({
+    agentSessionId: input.agentSessionId,
+    agentTargetId: input.agentTargetId,
+    label,
+    workspaceId: input.workspaceId
+  });
+  return createRichTextMarkdownLink({
+    href,
+    label: input.withAtPrefix ? `@${label}` : label
+  });
+}
+
 export function formatAgentMentionMarkdown(
   item: AgentContextMentionItem
 ): string {
@@ -630,6 +673,16 @@ export function formatAgentMentionMarkdown(
       }
     });
   }
+  if (item.kind === "session") {
+    return createAgentSessionMarkdownLink({
+      agentSessionId: item.targetId,
+      agentTargetId:
+        item.agentTargetId ?? agentSessionTargetIdFromHref(item.href),
+      label: item.name,
+      workspaceId: item.workspaceId,
+      withAtPrefix: true
+    });
+  }
   if (item.kind === "agent-target") {
     return createRichTextMentionMarkdown({
       providerId: "agent-target",
@@ -640,6 +693,16 @@ export function formatAgentMentionMarkdown(
   }
   const identity = parseRichTextMentionHref(item.href, item.name);
   return identity ? createRichTextMentionMarkdown(identity) : "";
+}
+
+function normalizeAgentSessionMarkdownLabel(value: string): string {
+  return value.trim().replace(/^@+/, "").trim();
+}
+
+function agentSessionTargetIdFromHref(href: string): string | undefined {
+  const mention = parseRichTextMentionHref(href, "");
+  const agentTargetId = mention?.scope?.agentTargetId?.trim() ?? "";
+  return agentTargetId || undefined;
 }
 
 function parseMentionFileCount(value: unknown): number {
@@ -765,6 +828,7 @@ export function parseMentionItemFromHref(input: {
       href,
       workspaceId,
       targetId,
+      agentTargetId: mention.scope?.agentTargetId?.trim() || undefined,
       name,
       title: name,
       scope: "collab_sessions",
@@ -890,6 +954,9 @@ export function mentionItemToAttrs(
       href: item.href,
       ...workspaceMentionAttrs(item.workspaceId),
       targetId: item.targetId,
+      ...(item.agentTargetId?.trim()
+        ? { agentTargetId: item.agentTargetId.trim() }
+        : {}),
       scope: item.scope,
       title: item.title,
       initiatorName: item.initiatorName,
@@ -997,6 +1064,10 @@ export function attrsToMentionItem(
       href,
       workspaceId,
       targetId,
+      agentTargetId:
+        typeof attrs.agentTargetId === "string" && attrs.agentTargetId.trim()
+          ? attrs.agentTargetId.trim()
+          : agentSessionTargetIdFromHref(href),
       name,
       title:
         typeof attrs.title === "string" && attrs.title.trim()

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUINodeController.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUINodeController.ts
@@ -182,10 +182,10 @@ import { createOptimisticPromptMessage } from "./agentGuiController.promptHelper
 import { useAgentGUIActivation } from "./useAgentGUIActivation";
 import { pendingInterruptActionForDisplayStatus } from "./pendingInterrupt";
 import {
+  createAgentSessionMentionHref,
   formatAgentMentionMarkdown,
   normalizeAgentSessionMentionTitle
 } from "../agentRichText/agentFileMentionExtension";
-import { createRichTextMentionHref } from "@tutti-os/ui-rich-text/core";
 import { resolveAgentGUIExplicitConversationTitle } from "../model/agentGuiProviderIdentity";
 import { composerSettingsSupportFromOptions } from "../model/composerSettingsSupport";
 import {
@@ -1416,6 +1416,7 @@ function buildContinueInNewConversationPrompt(input: {
   currentUserId?: string | null;
   userProfilesByUserId: Record<string, { name?: string | null }>;
   provider: string;
+  agentTargetId?: string | null;
   conversationTitle: string;
   existingDraftPrompt: string;
 }): string {
@@ -1440,17 +1441,18 @@ function buildContinueInNewConversationPrompt(input: {
   const mentionLabel = `${initiatorName} & ${providerLabel}${
     normalizedTitle ? ` ${normalizedTitle}` : ""
   }`.trim();
-  const href = createRichTextMentionHref({
-    providerId: "agent-session",
-    entityId: input.agentSessionId,
+  const href = createAgentSessionMentionHref({
+    agentTargetId: input.agentTargetId,
+    agentSessionId: input.agentSessionId,
     label: mentionLabel,
-    scope: { workspaceId: input.workspaceId }
+    workspaceId: input.workspaceId
   });
   const mention = formatAgentMentionMarkdown({
     kind: "session",
     href,
     workspaceId: input.workspaceId,
     targetId: input.agentSessionId,
+    agentTargetId: input.agentTargetId?.trim() || undefined,
     name: mentionLabel,
     title: normalizedTitle || providerLabel,
     scope: "my_sessions",
@@ -8403,6 +8405,7 @@ export function useAgentGUINodeController({
       currentUserId,
       userProfilesByUserId: accountProfilesByUserId,
       provider: activeConversation.provider,
+      agentTargetId: activeConversation.agentTargetId,
       conversationTitle: activeConversation.title,
       existingDraftPrompt: draftBySessionId[currentConversationId]?.prompt ?? ""
     });

--- a/packages/agent/gui/agent-message-center/WorkspaceAgentMessageCenterCard.tsx
+++ b/packages/agent/gui/agent-message-center/WorkspaceAgentMessageCenterCard.tsx
@@ -823,13 +823,16 @@ export function MessageCenterSummary({
   );
   const handleLinkAction = useCallback(
     (action: WorkspaceLinkAction): void => {
+      const agentTargetId = item.agentTargetId?.trim() || null;
       onLinkAction?.(
-        action.type === "open-agent-session" && !action.provider
-          ? { ...action, provider: item.provider }
+        action.type === "open-agent-session" &&
+          !action.agentTargetId &&
+          agentTargetId
+          ? { ...action, agentTargetId }
           : action
       );
     },
-    [item.provider, onLinkAction]
+    [item.agentTargetId, onLinkAction]
   );
 
   useEffect(() => {

--- a/packages/agent/gui/agent-message-center/WorkspaceAgentMessageCenterPanel.spec.tsx
+++ b/packages/agent/gui/agent-message-center/WorkspaceAgentMessageCenterPanel.spec.tsx
@@ -18,6 +18,7 @@ import type {
 const baseItem: WorkspaceAgentMessageCenterItem = {
   id: "message-center-session-1",
   agentSessionId: "session-1",
+  agentTargetId: "local:codex",
   provider: "codex",
   userId: null,
   title: "整理本地文件夹",
@@ -697,12 +698,13 @@ describe("WorkspaceAgentMessageCenterCard", () => {
     });
   });
 
-  it("preserves the card provider for providerless session links", () => {
+  it("preserves the card agent target for targetless session links", () => {
     const onLinkAction = vi.fn();
     render(
       <TooltipProvider>
         <WorkspaceAgentMessageCenterCard
           item={createTestCardItem({
+            agentTargetId: "local:claude-code",
             provider: "claude-code",
             lastAgentMessageSummary:
               "继续 [Claude 会话](mention://agent-session/session-2?workspaceId=workspace-1)"
@@ -721,7 +723,7 @@ describe("WorkspaceAgentMessageCenterCard", () => {
       type: "open-agent-session",
       workspaceId: "workspace-1",
       agentSessionId: "session-2",
-      provider: "claude-code",
+      agentTargetId: "local:claude-code",
       source: "agent-markdown"
     });
   });

--- a/packages/agent/gui/agent-message-center/workspaceAgentMessageCenterModel.ts
+++ b/packages/agent/gui/agent-message-center/workspaceAgentMessageCenterModel.ts
@@ -44,6 +44,7 @@ export interface WorkspaceAgentMessageCenterCounts {
 export interface WorkspaceAgentMessageCenterItem {
   id: string;
   agentSessionId: string;
+  agentTargetId?: string | null;
   provider: string;
   userId: string | null;
   title: string;
@@ -146,6 +147,7 @@ export function buildWorkspaceAgentMessageCenterModel(
       return {
         id: `message-center-${session.agentSessionId}`,
         agentSessionId: session.agentSessionId,
+        agentTargetId: session.agentTargetId?.trim() || null,
         provider: session.provider,
         userId: session.userId?.trim() || null,
         title,

--- a/packages/agent/gui/app/renderer/i18n/locales/en.ts
+++ b/packages/agent/gui/app/renderer/i18n/locales/en.ts
@@ -909,6 +909,7 @@ export const en = {
       showLessConversations: "Show less",
       deleteSession: "Delete session",
       pinSession: "Pin session",
+      copySessionLink: "Copy session link",
       renameSession: "Rename session",
       renameSessionTitle: "Rename conversation",
       renameSessionDescription: "Keep it short and easy to recognize.",

--- a/packages/agent/gui/app/renderer/i18n/locales/zh-CN.ts
+++ b/packages/agent/gui/app/renderer/i18n/locales/zh-CN.ts
@@ -842,6 +842,7 @@ export const zhCN = {
       showLessConversations: "收起",
       deleteSession: "删除会话",
       pinSession: "置顶会话",
+      copySessionLink: "复制会话链接",
       renameSession: "重命名会话",
       renameSessionTitle: "重命名对话",
       renameSessionDescription: "保持简短且易于识别。",

--- a/packages/ui/rich-text/src/core/richTextDocument.test.ts
+++ b/packages/ui/rich-text/src/core/richTextDocument.test.ts
@@ -2,6 +2,7 @@ import assert from "node:assert/strict";
 import test from "node:test";
 import {
   appendRichTextLinksToContent,
+  createRichTextMarkdownLink,
   createRichTextMentionHref,
   createRichTextMentionMarkdown,
   extractRichTextLinksFromContent,
@@ -54,6 +55,16 @@ test("serializes mention markdown with a normalized @ label", () => {
       })
     ),
     "[@Prototype Design](mention://workspace-app/vibe-design?workspaceId=ws_1)"
+  );
+});
+
+test("serializes generic markdown links with escaped label and href", () => {
+  assert.equal(
+    createRichTextMarkdownLink({
+      label: "Session [draft] \\ one",
+      href: "mention://agent-session/session-1?workspaceId=room-(1)"
+    }),
+    "[Session \\[draft\\] \\\\ one](mention://agent-session/session-1?workspaceId=room-\\(1\\))"
   );
 });
 

--- a/packages/ui/rich-text/src/core/richTextDocument.ts
+++ b/packages/ui/rich-text/src/core/richTextDocument.ts
@@ -296,7 +296,7 @@ export function createRichTextMentionMarkdown(
   if (!label || !href) {
     return "";
   }
-  return `[${escapeMarkdownLinkLabel(`@${label}`)}](${escapeMarkdownLinkHref(href)})`;
+  return createRichTextMarkdownLink({ href, label: `@${label}` });
 }
 
 export function parseRichTextMentionHref(
@@ -371,7 +371,19 @@ export function createRichTextLinkMarkdown(input: RichTextLinkInput): string {
   if (!href || !displayName) {
     return "";
   }
-  return `[${escapeMarkdownLinkLabel(displayName)}](${escapeMarkdownLinkHref(href)})`;
+  return createRichTextMarkdownLink({ href, label: displayName });
+}
+
+export function createRichTextMarkdownLink(input: {
+  href: string;
+  label: string;
+}): string {
+  const href = input.href.trim();
+  const label = input.label.trim();
+  if (!href || !label) {
+    return "";
+  }
+  return `[${escapeMarkdownLinkLabel(label)}](${escapeMarkdownLinkHref(href)})`;
 }
 
 export function appendRichTextLinksToContent(

--- a/packages/ui/rich-text/src/index.ts
+++ b/packages/ui/rich-text/src/index.ts
@@ -1,6 +1,7 @@
 export {
   createRichTextMentionHref,
   createRichTextMentionMarkdown,
+  createRichTextMarkdownLink,
   extractPlainTextFromContent,
   extractPlainTextWithoutFilesFromContent,
   extractRichTextMentionsFromContent,


### PR DESCRIPTION
## Summary
- add a session rail context-menu action to copy a stable agent-session mention link
- share markdown link escaping through the rich-text core formatter
- reuse one AgentGUI session mention helper for composer mentions and copied links

## Tests
- pnpm --filter @tutti-os/ui-rich-text test -- --runInBand
- pnpm --filter @tutti-os/agent-gui test -- AgentGUINode.spec.tsx agentFileMentionExtension.spec.ts --runInBand
- pnpm check:ui-boundaries
- pnpm typecheck
- pnpm check:i18n
- pnpm check:full

## Documentation
- No durable documentation impact found; this is a localized AgentGUI menu action using existing mention and clipboard architecture.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a **“Copy session link”** conversation menu action that copies a markdown-formatted session link to the clipboard.
  * Session links now carry the correct **agent target** information when copied/shared/opened.
* **Bug Fixes**
  * Fixed copied/shared session links so the markdown is escaped correctly, including special characters.
  * Fixed session-link actions that could lose target context or require an extra selection step; clipboard write issues no longer break the UI.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->