### PR TITLE
fix(agent-gui): stop idle handoff lottie playback

### DIFF
--- a/docs/conventions/troubleshooting.md
+++ b/docs/conventions/troubleshooting.md
@@ -106,6 +106,32 @@ Use this shape for new entries:
   [controller.go](../../packages/agent/daemon/runtime/controller.go)
   [controller_test.go](../../packages/agent/daemon/runtime/controller_test.go)
 
+### Renderer tile memory warnings from hidden autoplay animation
+
+- Symptom:
+  Electron or Chromium logs repeatedly print
+  `tile memory limits exceeded, some content may not draw`. DevTools
+  performance traces show continuous `FireAnimationFrame`, `Layerize`, and
+  `Commit` activity while the visible UI looks mostly idle.
+- Quick checks:
+  In the trace, group `FunctionCall` or `v8.callFunction` events by `url` and
+  `functionName`. Hidden animation players often still appear as repeated
+  `requestAnimationFrame` callbacks even when their DOM node has
+  `opacity: 0`.
+- Root cause:
+  CSS-hidden animation elements are still live renderers. An autoplay/looping
+  Lottie, canvas, or WebGL player can keep scheduling frames and force layer
+  updates across every mounted instance.
+- Fix:
+  Mount animation players only while the animation is actually visible, and
+  defer loading third-party animation runtimes until an active state needs
+  them. Do not rely on `opacity`, `visibility`, or off-screen placement to stop
+  playback.
+- Validation:
+  Re-record a short DevTools trace after the fix. Idle UI should no longer show
+  the hidden player's function as a high-frequency `requestAnimationFrame`
+  source, and Chromium tile memory warnings should stop during idle.
+
 ### Agent session stays loading after a completed turn
 
 - Symptom:

--- a/packages/agent/gui/agent-gui/agentGuiNode/AgentComposer.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/AgentComposer.tsx
@@ -965,8 +965,12 @@ function AgentComposerHandoffIcon({
   isPlaying: boolean;
 }): JSX.Element {
   const [isLottieReady, setIsLottieReady] = useState(false);
+  const shouldLoadAnimation = !disabled && isPlaying;
 
   useEffect(() => {
+    if (!shouldLoadAnimation) {
+      return;
+    }
     let isMounted = true;
     void loadHandoffLottiePlayer().then((isReady) => {
       if (isMounted) {
@@ -976,9 +980,9 @@ function AgentComposerHandoffIcon({
     return () => {
       isMounted = false;
     };
-  }, []);
+  }, [shouldLoadAnimation]);
 
-  const shouldShowAnimation = !disabled && isPlaying && isLottieReady;
+  const shouldShowAnimation = shouldLoadAnimation && isLottieReady;
 
   return (
     <span
@@ -1000,13 +1004,15 @@ function AgentComposerHandoffIcon({
           maskSize: "contain"
         }}
       />
-      <dotlottie-wc
-        autoplay
-        className={styles.composerHandoffAnimatedIcon}
-        data-active={shouldShowAnimation ? "true" : undefined}
-        loop
-        src={HANDOFF_LOTTIE_ANIMATION_SRC}
-      />
+      {shouldShowAnimation ? (
+        <dotlottie-wc
+          autoplay
+          className={styles.composerHandoffAnimatedIcon}
+          data-active="true"
+          loop
+          src={HANDOFF_LOTTIE_ANIMATION_SRC}
+        />
+      ) : null}
     </span>
   );
 }


### PR DESCRIPTION
## Summary
- mount the AgentGUI handoff Lottie player only while the handoff animation is active
- defer loading the third-party dotlottie runtime until playback is needed
- document the hidden autoplay animation trace pattern in troubleshooting

## Validation
- pnpm --filter @tutti-os/agent-gui typecheck
- pnpm --filter @tutti-os/agent-gui test
- pnpm check:full

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Reduced background/hidden animation activity so disabled animations no longer keep running and triggering resource warnings.
  * Animation rendering now loads and displays only when actively needed (and is fully ready), improving idle behavior.

* **Documentation**
  * Added troubleshooting guidance for recurring Electron/Chromium “tile memory limits exceeded” warnings, including symptom details, quick trace-based checks, mitigation steps, and validation recommendations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->