### PR TITLE
fix(agent): add codex managed node fallback

### DIFF
--- a/docs/conventions/troubleshooting.md
+++ b/docs/conventions/troubleshooting.md
@@ -150,21 +150,24 @@ Use this shape for new entries:
   when an optional dependency fetch failed, which leaves the launcher installed
   but unable to start. A registry can also be reachable but too slow for the
   platform tarball, so retrying the same source burns the install timeout before
-  mirrors are tried. The launcher itself uses `#!/usr/bin/env node`, so every
-  daemon-run Codex command (`--version`, `login status`, and `app-server`) must
-  run with the Tutti-managed Node bin directory on `PATH`; fixing only the npm
-  install command leaves post-install probes broken on machines without system
-  Node.
+  mirrors are tried. The launcher itself uses `#!/usr/bin/env node`, so
+  daemon-run Codex commands (`--version`, `login status`, and `app-server`) need
+  a usable Node on `PATH`. Tutti should prefer the user's Node environment, but
+  fall back to the managed Node runtime when the visible `codex` shim exists and
+  no user Node is resolvable.
 - Fix:
   Keep Codex installs on the Tutti-managed Node/npm runtime, install with
   optional dependencies included, and rank configured npm registries with a
   lightweight package metadata probe before attempting the install. Preserve
   `TUTTI_AGENT_NPM_REGISTRY` as an explicit single-registry pin with no mirror
-  fallback. Also pass the same managed Node `PATH` through provider command
-  resolution, version checks, auth-status checks, and adapter probes. If the
-  CLI path exists but `codex app-server` cannot launch, treat the failed probe
-  as a repair trigger so the install action does not clear immediately without
-  running an installer.
+  fallback. Provider command resolution should leave the user's Node first when
+  it is available, and only append managed Node runtime env (`TUTTI_APP_NODE`,
+  `TUTTI_APP_NPM`, managed `PATH`) when user Node is missing. Ensure the Codex
+  app-server adapter consumes that provider command resolution; otherwise status
+  probes can pass while session startup still fails with `env: node: No such
+  file or directory`. If the CLI path exists but `codex app-server` cannot
+  launch, treat the failed probe as a repair trigger so the install action does
+  not clear immediately without running an installer.
 - Validation:
   Reproduce in a temporary prefix/cache using the Tutti-managed npm. Confirm
   `codex --version`, the platform package metadata and vendor binary, and a
@@ -175,6 +178,8 @@ Use this shape for new entries:
   [npm_registry.go](../../services/tuttid/service/agentstatus/npm_registry.go)
   [installer_codex_cli.go](../../services/tuttid/service/agentstatus/installer_codex_cli.go)
   [codex_platform.go](../../services/tuttid/service/agentstatus/codex_platform.go)
+  [provider_resolution.go](../../services/tuttid/service/agentstatus/provider_resolution.go)
+  [codex_appserver_adapter.go](../../packages/agent/daemon/runtime/codex_appserver_adapter.go)
 
 ### Dynamic CLI input rejects plausible flags
 

--- a/packages/agent/daemon/runtime/codex_appserver_adapter.go
+++ b/packages/agent/daemon/runtime/codex_appserver_adapter.go
@@ -115,13 +115,14 @@ const defaultCodexAppServerTurnSteerTimeout = 10 * time.Second
 const startupModelSteadyRetryCount = 36
 
 type CodexAppServerAdapter struct {
-	transport   ProcessTransport
-	host        HostMetadata
-	mu          sync.Mutex
-	sessions    map[string]*codexAppServerSession
-	commandSink CommandSnapshotSink
-	eventSink   SessionEventSink
-	configSink  ConfigOptionsUpdateSink
+	transport       ProcessTransport
+	host            HostMetadata
+	commandResolver ProviderCommandResolver
+	mu              sync.Mutex
+	sessions        map[string]*codexAppServerSession
+	commandSink     CommandSnapshotSink
+	eventSink       SessionEventSink
+	configSink      ConfigOptionsUpdateSink
 	// lifecycleMu guards lifecycleLocks; the per-session locks serialize
 	// Start/Resume/Close/ReleaseLiveSession per agent session so concurrent
 	// lifecycle calls can never leave two live app-server processes for the
@@ -237,9 +238,18 @@ func NewCodexAppServerAdapter(transport ProcessTransport) *CodexAppServerAdapter
 }
 
 func NewCodexAppServerAdapterWithHostMetadata(transport ProcessTransport, host HostMetadata) *CodexAppServerAdapter {
+	return NewCodexAppServerAdapterWithHostMetadataAndCommandResolver(transport, host, nil)
+}
+
+func NewCodexAppServerAdapterWithHostMetadataAndCommandResolver(
+	transport ProcessTransport,
+	host HostMetadata,
+	commandResolver ProviderCommandResolver,
+) *CodexAppServerAdapter {
 	return &CodexAppServerAdapter{
 		transport:         transport,
 		host:              host,
+		commandResolver:   commandResolver,
 		sessions:          make(map[string]*codexAppServerSession),
 		lifecycleLocks:    make(map[string]*codexAppServerSessionLock),
 		cancelGraceWindow: defaultCodexAppServerCancelGraceWindow,
@@ -673,18 +683,29 @@ func (a *CodexAppServerAdapter) startInitializedClient(
 	if a == nil || a.transport == nil {
 		return nil, nil, errors.New("app-server process transport is unavailable")
 	}
+	command := []string{codexAppServerCommand, codexAppServerSubcmd}
+	spawnEnv := append(codexACPEnv(session, a.host), session.Env...)
+	if a.commandResolver != nil {
+		resolved, err := a.commandResolver(ctx, ProviderCodex)
+		if err != nil {
+			return nil, nil, err
+		}
+		if len(resolved.Command) > 0 {
+			command = append([]string(nil), resolved.Command...)
+		}
+		spawnEnv = append(spawnEnv, resolved.Env...)
+	}
 	trace.Log("process.start.begin", map[string]any{
-		"command": strings.Join([]string{codexAppServerCommand, codexAppServerSubcmd}, " "),
+		"command": strings.Join(command, " "),
 		"cwd":     a.sessionCWD(session),
 	})
 	processStartedAt := time.Now()
-	spawnEnv := append(codexACPEnv(session, a.host), session.Env...)
 	conn, err := a.transport.Start(ctx, ProcessSpec{
 		Provider:       ProviderCodex,
 		AgentSessionID: session.AgentSessionID,
 		RoomID:         session.RoomID,
 		CWD:            a.sessionCWD(session),
-		Command:        []string{codexAppServerCommand, codexAppServerSubcmd},
+		Command:        command,
 		Env:            spawnEnv,
 	})
 	if err != nil {

--- a/packages/agent/daemon/runtime/codex_appserver_lifecycle_test.go
+++ b/packages/agent/daemon/runtime/codex_appserver_lifecycle_test.go
@@ -3,6 +3,7 @@ package agentruntime
 import (
 	"context"
 	"errors"
+	"reflect"
 	"sync"
 	"testing"
 )
@@ -79,6 +80,41 @@ func connClosed(conn *scriptedAppServerConnection) bool {
 	conn.mu.Lock()
 	defer conn.mu.Unlock()
 	return conn.closeCount > 0
+}
+
+func TestCodexAppServerAdapterStartUsesInjectedProviderCommand(t *testing.T) {
+	t.Parallel()
+
+	transport := newScriptedAppServerTransport()
+	adapter := NewCodexAppServerAdapterWithHostMetadataAndCommandResolver(
+		transport,
+		LegacyHostMetadata(),
+		func(_ context.Context, provider string) (ProviderCommand, error) {
+			if provider != ProviderCodex {
+				t.Fatalf("provider = %q, want %q", provider, ProviderCodex)
+			}
+			return ProviderCommand{
+				Command: []string{"/user/bin/codex", "app-server"},
+				Env:     []string{"PATH=/managed/node/bin:/user/bin", "TUTTI_APP_NODE=/managed/node/bin/node"},
+			}, nil
+		},
+	)
+	session := testAppServerSession()
+	session.Env = []string{"SESSION_ENV=1"}
+
+	if _, err := adapter.Start(context.Background(), session); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	if len(transport.specs) != 1 {
+		t.Fatalf("process starts = %d, want 1", len(transport.specs))
+	}
+	spec := transport.specs[0]
+	if !reflect.DeepEqual(spec.Command, []string{"/user/bin/codex", "app-server"}) {
+		t.Fatalf("Command = %#v", spec.Command)
+	}
+	if !containsString(spec.Env, "SESSION_ENV=1") || !containsString(spec.Env, "TUTTI_APP_NODE=/managed/node/bin/node") {
+		t.Fatalf("Env = %#v, want session and managed runtime env", spec.Env)
+	}
 }
 
 // --- single-live-process invariant tests ---

--- a/packages/agent/daemon/runtime/controller.go
+++ b/packages/agent/daemon/runtime/controller.go
@@ -154,7 +154,7 @@ func NewDefaultControllerWithOptions(
 	return NewController(
 		[]Adapter{
 			newDefaultClaudeCodeAdapter(transport, host, options.ProviderCommandResolver),
-			NewCodexAppServerAdapterWithHostMetadata(transport, host),
+			NewCodexAppServerAdapterWithHostMetadataAndCommandResolver(transport, host, options.ProviderCommandResolver),
 			NewNexightAdapterWithHostMetadata(transport, host),
 			NewGeminiAdapterWithHostMetadata(transport, host),
 			NewHermesAdapterWithHostMetadata(transport, host),

--- a/services/tuttid/service/agentstatus/provider_resolution.go
+++ b/services/tuttid/service/agentstatus/provider_resolution.go
@@ -199,6 +199,9 @@ func (s Service) resolveStaticProviderSpec(ctx context.Context, spec ProviderSpe
 	if spec.Provider != agentprovider.Codex {
 		return spec
 	}
+	if s.userNodeRuntimeAvailable(spec.AdapterEnv) {
+		return spec
+	}
 	appRuntime, ok := s.resolveManagedNodeRuntimeForProvider(ctx, requireManagedRuntime)
 	if !ok {
 		if requireManagedRuntime {
@@ -208,6 +211,30 @@ func (s Service) resolveStaticProviderSpec(ctx context.Context, spec ProviderSpe
 	}
 	spec.AdapterEnv = append(s.managedRuntimeAdapterEnv(appRuntime), spec.AdapterEnv...)
 	return spec
+}
+
+func (s Service) userNodeRuntimeAvailable(overrides []string) bool {
+	return s.userNodeRuntimePath(overrides) != ""
+}
+
+func (s Service) userNodeRuntimePath(overrides []string) string {
+	env := []string(nil)
+	if s.Environ != nil {
+		env = s.Environ()
+	} else {
+		env = os.Environ()
+	}
+	env = append(cloneStrings(env), overrides...)
+	for _, dir := range filepath.SplitList(managedruntime.EnvValue(env, "PATH")) {
+		if strings.TrimSpace(dir) == "" {
+			continue
+		}
+		candidate := filepath.Join(dir, nodeBinaryName())
+		if s.executableFile(candidate) {
+			return candidate
+		}
+	}
+	return ""
 }
 
 func (s Service) resolveExternalRegistryNPMSpec(

--- a/services/tuttid/service/agentstatus/service.go
+++ b/services/tuttid/service/agentstatus/service.go
@@ -687,7 +687,7 @@ func (s Service) statusForSpec(ctx context.Context, spec ProviderSpec, now time.
 	}
 	if spec.Provider == agentprovider.Codex {
 		status.CLI.MinVersion = MinSupportedCodexVersion
-		status.Checks = codexProviderChecks(status, codexPlatformOK)
+		status.Checks = codexProviderChecks(status, codexPlatformOK, s.codexNodeRuntimeCheck(spec))
 		status.LastError = codexProviderLastError(status)
 		slog.Info(
 			"codex agent provider status checked",

--- a/services/tuttid/service/agentstatus/service_helpers.go
+++ b/services/tuttid/service/agentstatus/service_helpers.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/tutti-os/tutti/packages/agentactivity/daemon/runtimecmd"
 	"github.com/tutti-os/tutti/services/tuttid/biz/agentprovider"
+	managedruntime "github.com/tutti-os/tutti/services/tuttid/service/managedruntime"
 )
 
 func (s Service) probeCommandWithReadyAfter(
@@ -341,7 +342,7 @@ func (s Service) codexPlatformBinaryOK(binaryPath string) bool {
 	return ok
 }
 
-func codexProviderChecks(status ProviderStatus, platformBinaryOK bool) []ProviderCheck {
+func codexProviderChecks(status ProviderStatus, platformBinaryOK bool, nodeRuntime ProviderCheck) []ProviderCheck {
 	return []ProviderCheck{
 		{
 			Name:   "cli_present",
@@ -358,11 +359,34 @@ func codexProviderChecks(status ProviderStatus, platformBinaryOK bool) []Provide
 			Passed: codexVersionMeetsMinimum(status.CLI.Version),
 			Detail: firstNonBlank(status.CLI.Version, "version unknown"),
 		},
+		nodeRuntime,
 		{
 			Name:   "auth",
 			Passed: status.Auth.Status == AuthAuthenticated,
 			Detail: providerAvailabilityAuthDetailForStatus(status.Auth),
 		},
+	}
+}
+
+func (s Service) codexNodeRuntimeCheck(spec ProviderSpec) ProviderCheck {
+	if nodePath := strings.TrimSpace(managedruntime.EnvValue(spec.AdapterEnv, "TUTTI_APP_NODE")); nodePath != "" {
+		return ProviderCheck{
+			Name:   "node_runtime",
+			Passed: true,
+			Detail: "Using Tutti managed Node fallback: " + nodePath,
+		}
+	}
+	if resolved := s.userNodeRuntimePath(spec.AdapterEnv); resolved != "" {
+		return ProviderCheck{
+			Name:   "node_runtime",
+			Passed: true,
+			Detail: "Using user Node from PATH: " + resolved,
+		}
+	}
+	return ProviderCheck{
+		Name:   "node_runtime",
+		Passed: false,
+		Detail: "Node runtime not found",
 	}
 }
 

--- a/services/tuttid/service/agentstatus/service_test.go
+++ b/services/tuttid/service/agentstatus/service_test.go
@@ -1828,6 +1828,57 @@ func TestServiceResolveProviderCommandUsesInstalledExternalRegistryNPMBin(t *tes
 	}
 }
 
+func TestServiceResolveProviderCommandPrefersUserNodeForCodex(t *testing.T) {
+	home := t.TempDir()
+	binDir := filepath.Join(home, "bin")
+	writeExecutable(t, filepath.Join(binDir, "codex"), "#!/usr/bin/env node\n")
+	writeExecutable(t, filepath.Join(binDir, nodeBinaryNameForTest()), "#!/bin/sh\nexit 0\n")
+	runtimeRoot := fakeManagedRuntimeRoot(t)
+
+	service := probeTestService(home)
+	service.Environ = func() []string {
+		return []string{"PATH=" + binDir}
+	}
+	service.ManagedRuntime = fakeManagedRuntimeResolver(t, runtimeRoot)
+
+	result, err := service.ResolveProviderCommand(context.Background(), "codex")
+	if err != nil {
+		t.Fatalf("ResolveProviderCommand() error = %v", err)
+	}
+	if !slices.Equal(result.Command, []string{"codex", "app-server"}) {
+		t.Fatalf("Command = %#v, want codex app-server", result.Command)
+	}
+	managedNode := filepath.Join(runtimeRoot, "node", "bin", nodeBinaryNameForTest())
+	if slices.Contains(result.Env, "TUTTI_APP_NODE="+managedNode) {
+		t.Fatalf("Env = %#v, must not inject managed node when user node is available", result.Env)
+	}
+}
+
+func TestServiceResolveProviderCommandFallsBackToManagedNodeForCodex(t *testing.T) {
+	home := t.TempDir()
+	binDir := filepath.Join(home, "bin")
+	writeExecutable(t, filepath.Join(binDir, "codex"), "#!/usr/bin/env node\n")
+	runtimeRoot := fakeManagedRuntimeRoot(t)
+
+	service := probeTestService(home)
+	service.Environ = func() []string {
+		return []string{"PATH=" + binDir}
+	}
+	service.ManagedRuntime = fakeManagedRuntimeResolver(t, runtimeRoot)
+
+	result, err := service.ResolveProviderCommand(context.Background(), "codex")
+	if err != nil {
+		t.Fatalf("ResolveProviderCommand() error = %v", err)
+	}
+	if !slices.Equal(result.Command, []string{"codex", "app-server"}) {
+		t.Fatalf("Command = %#v, want codex app-server", result.Command)
+	}
+	managedNode := filepath.Join(runtimeRoot, "node", "bin", nodeBinaryNameForTest())
+	if !slices.Contains(result.Env, "TUTTI_APP_NODE="+managedNode) {
+		t.Fatalf("Env = %#v, want managed node fallback", result.Env)
+	}
+}
+
 func TestServiceResolveProviderCommandDefaultsClaudeCodeToSDKSidecar(t *testing.T) {
 	t.Setenv(claudeCodeRuntimeEnv, "")
 


### PR DESCRIPTION
## Summary
- Backport Codex app-server provider command resolver wiring to release/0704
- Prefer user PATH Node for Codex, and inject Tutti managed Node only when user Node is missing
- Add Codex node_runtime environment check and troubleshooting notes

## Validation
- PASS: cd services/tuttid && go test ./service/agentstatus
- BLOCKED: cd packages/agent/daemon && go test ./runtime -run TestCodexAppServerAdapterStartUsesInjectedProviderCommand (release/0704 existing build failure: runtime/submit_availability_parity_test.go:96:20 undefined: submitAvailabilityForAuthoritySession)

Cherry-picked-from: 8e1d5e2c fix(agent): add codex managed node fallback