### PR TITLE
fix(agent): index pinned session pagination

### DIFF
--- a/packages/agent/store-sqlite/migrations.go
+++ b/packages/agent/store-sqlite/migrations.go
@@ -27,6 +27,7 @@ const schemaMigrationWorkspaceAgentActivityV4 = "workspace_agent_activity_v4"
 const schemaMigrationWorkspaceAgentActivityV5 = "workspace_agent_activity_v5"
 const schemaMigrationWorkspaceAgentActivityV6 = "workspace_agent_activity_v6"
 const schemaMigrationWorkspaceAgentActivityV7 = "workspace_agent_activity_v7"
+const schemaMigrationWorkspaceAgentActivityV8 = "workspace_agent_activity_v8"
 const schemaMigrationWorkspaceAgentActivityRailV1 = "workspace_agent_activity_rail_v1"
 const schemaMigrationAgentTargetsV1 = "agent_targets_v1"
 
@@ -83,6 +84,9 @@ CREATE TABLE IF NOT EXISTS `+schemaMigrationsTable+` (
 		return err
 	}
 	if err := s.applyWorkspaceAgentActivityV7(ctx); err != nil {
+		return err
+	}
+	if err := s.applyWorkspaceAgentActivityV8(ctx); err != nil {
 		return err
 	}
 	if err := s.applyAgentTargetsV1(ctx); err != nil {

--- a/packages/agent/store-sqlite/migrations_activity.go
+++ b/packages/agent/store-sqlite/migrations_activity.go
@@ -230,6 +230,25 @@ func (s *Store) applyWorkspaceAgentActivityV7(ctx context.Context) error {
 	return s.recordMigration(ctx, schemaMigrationWorkspaceAgentActivityV7)
 }
 
+func (s *Store) applyWorkspaceAgentActivityV8(ctx context.Context) error {
+	applied, err := s.hasMigration(ctx, schemaMigrationWorkspaceAgentActivityV8)
+	if err != nil {
+		return err
+	}
+	if applied {
+		return nil
+	}
+
+	if _, err := s.db.ExecContext(ctx, `
+CREATE INDEX IF NOT EXISTS idx_workspace_agent_sessions_pinned_page
+  ON workspace_agent_sessions(workspace_id, deleted_at_unix_ms, pinned_at_unix_ms DESC, agent_session_id ASC);
+`); err != nil {
+		return fmt.Errorf("migrate workspace agent activity to v8 pinned pagination index: %w", err)
+	}
+
+	return s.recordMigration(ctx, schemaMigrationWorkspaceAgentActivityV8)
+}
+
 func (s *Store) backfillSystemAgentTargetIDs(ctx context.Context) error {
 	providers := make([]string, 0, len(s.opts.TargetIDBackfillByProvider))
 	for provider := range s.opts.TargetIDBackfillByProvider {

--- a/packages/agent/store-sqlite/store_test.go
+++ b/packages/agent/store-sqlite/store_test.go
@@ -130,6 +130,60 @@ func TestStoreFreshMigrateCreatesTablesWithoutHostForeignKeys(t *testing.T) {
 	}
 }
 
+func TestStoreMigrateCreatesPinnedPaginationIndex(t *testing.T) {
+	t.Parallel()
+
+	store := openTestStore(t, testOptions(&staticProjectPaths{}))
+	ctx := context.Background()
+
+	rows, err := store.db.QueryContext(ctx, `PRAGMA index_xinfo(idx_workspace_agent_sessions_pinned_page)`)
+	if err != nil {
+		t.Fatalf("index_xinfo error = %v", err)
+	}
+	defer rows.Close()
+
+	type indexedColumn struct {
+		name string
+		desc int
+	}
+	var columns []indexedColumn
+	for rows.Next() {
+		var (
+			seqno int
+			cid   int
+			name  sql.NullString
+			desc  int
+			coll  sql.NullString
+			key   int
+		)
+		if err := rows.Scan(&seqno, &cid, &name, &desc, &coll, &key); err != nil {
+			t.Fatalf("scan index_xinfo: %v", err)
+		}
+		if key == 0 {
+			continue
+		}
+		columns = append(columns, indexedColumn{name: name.String, desc: desc})
+	}
+	if err := rows.Err(); err != nil {
+		t.Fatalf("iterate index_xinfo: %v", err)
+	}
+
+	want := []indexedColumn{
+		{name: "workspace_id", desc: 0},
+		{name: "deleted_at_unix_ms", desc: 0},
+		{name: "pinned_at_unix_ms", desc: 1},
+		{name: "agent_session_id", desc: 0},
+	}
+	if len(columns) != len(want) {
+		t.Fatalf("pinned pagination index columns = %+v, want %+v", columns, want)
+	}
+	for i := range want {
+		if columns[i] != want[i] {
+			t.Fatalf("pinned pagination index column[%d] = %+v, want %+v", i, columns[i], want[i])
+		}
+	}
+}
+
 func TestStoreReportAndListSessionLifecycle(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary
- add a dedicated SQLite migration for the pinned-session pagination index
- cover the index column order with a store migration test

## Tests
- go test ./packages/agent/store-sqlite
- pnpm check:changed --tail-lines 80
- pnpm check:full