### PR TITLE
refactor(agent-gui): drop legacy conversation list filter key

### DIFF
--- a/packages/agent/gui/contexts/workspace/presentation/renderer/agentGuiConversationList/agentGuiConversationListStore.spec.ts
+++ b/packages/agent/gui/contexts/workspace/presentation/renderer/agentGuiConversationList/agentGuiConversationListStore.spec.ts
@@ -350,21 +350,23 @@ describe("agentGuiConversationListStore", () => {
         agentTargetId: "local:codex"
       }
     });
-    const legacyQuery: AgentGUIConversationListQuery = {
+    const defaultFilterQuery: AgentGUIConversationListQuery = {
       workspaceId: "workspace-1",
       userId: "user-1",
       provider: "codex",
       sessionOrigin: "WORKSPACE_AGENT_SESSION_ORIGIN_RUNTIME"
     };
-    const legacyCodexKey = createAgentGUIConversationListQueryKey(legacyQuery);
-    const legacyClaudeKey = createAgentGUIConversationListQueryKey({
-      ...legacyQuery,
+    const defaultFilterCodexKey =
+      createAgentGUIConversationListQueryKey(defaultFilterQuery);
+    const defaultFilterClaudeKey = createAgentGUIConversationListQueryKey({
+      ...defaultFilterQuery,
       provider: "claude-code"
     });
 
     expect(allCodexKey).toBe(allClaudeKey);
     expect(targetCodexKey).toBe(targetClaudeKey);
-    expect(legacyCodexKey).not.toBe(legacyClaudeKey);
+    expect(defaultFilterCodexKey).toBe(allCodexKey);
+    expect(defaultFilterClaudeKey).toBe(allCodexKey);
   });
 
   it("splits query keys by sessionOrigin so local and shared runtimes stay isolated", () => {
@@ -429,19 +431,19 @@ describe("agentGuiConversationListStore", () => {
     ensureAgentGUIConversationListQuery(allQuery);
     scheduleAgentGUIConversationListProjection(allQuery, "projection-sync");
     await waitFor(() => {
-      expect(loadCount).toBe(1);
+      expect(loadCount).toBe(0);
       expect(
         getAgentGUIConversationListQuerySnapshot(allQuery)?.conversations.map(
           (item) => item.id
         )
-      ).toEqual(["codex-local"]);
+      ).toEqual(["codex-local", "claude-local"]);
     });
 
     ensureAgentGUIConversationListQuery(codexQuery);
     scheduleAgentGUIConversationListProjection(codexQuery, "projection-sync");
 
     await waitFor(() => {
-      expect(loadCount).toBe(1);
+      expect(loadCount).toBe(0);
       expect(
         getAgentGUIConversationListQuerySnapshot(codexQuery)?.conversations.map(
           (item) => item.id
@@ -496,7 +498,7 @@ describe("agentGuiConversationListStore", () => {
     runtimeListener?.();
 
     await waitFor(() => {
-      expect(loadCount).toBe(1);
+      expect(loadCount).toBe(0);
       expect(
         getAgentGUIConversationListQuerySnapshot(query)?.conversations.map(
           (item) => item.id
@@ -506,7 +508,7 @@ describe("agentGuiConversationListStore", () => {
 
     scheduleAgentGUIConversationListProjection(query, "projection-sync");
     await waitFor(() => {
-      expect(loadCount).toBe(2);
+      expect(loadCount).toBe(0);
       expect(
         getAgentGUIConversationListQuerySnapshot(query)?.conversations.map(
           (item) => item.id
@@ -574,7 +576,7 @@ describe("agentGuiConversationListStore", () => {
     await waitFor(() => {
       const conversations =
         getAgentGUIConversationListQuerySnapshot(query)?.conversations ?? [];
-      expect(loadCount).toBe(1);
+      expect(loadCount).toBe(0);
       expect(conversations).toHaveLength(2);
       expect(conversations[0]).toBe(previousSessionA);
       expect(conversations[1]).not.toBe(previousSessionB);

--- a/packages/agent/gui/contexts/workspace/presentation/renderer/agentGuiConversationList/agentGuiConversationListStore.ts
+++ b/packages/agent/gui/contexts/workspace/presentation/renderer/agentGuiConversationList/agentGuiConversationListStore.ts
@@ -58,7 +58,7 @@ export interface AgentGUIConversationListQuery {
 }
 
 type NormalizedAgentGUIConversationListQuery = {
-  conversationFilter: AgentGUIConversationFilter | null;
+  conversationFilter: AgentGUIConversationFilter;
   provider: AgentGUIProvider;
   sessionOrigin: string;
   userId: string;
@@ -157,20 +157,14 @@ function normalizeQuery(
 
 function normalizeAgentGUIConversationListFilter(
   input: AgentGUIConversationListQuery
-): AgentGUIConversationFilter | null {
+): AgentGUIConversationFilter {
   if (input.conversationFilter) {
     return normalizeAgentGUIConversationFilter(input.conversationFilter);
   }
-  return null;
+  return { kind: "all" };
 }
 
-function conversationFilterKey(
-  filter: AgentGUIConversationFilter | null,
-  provider: AgentGUIProvider
-): string {
-  if (!filter) {
-    return `legacy-provider:${provider}`;
-  }
+function conversationFilterKey(filter: AgentGUIConversationFilter): string {
   const normalized = normalizeAgentGUIConversationFilter(filter);
   if (normalized.kind === "all") {
     return "all";
@@ -185,9 +179,9 @@ function conversationFilterKey(
  */
 function conversationRetainableForQueryFilter(
   conversation: AgentGUIConversationSummary | undefined,
-  filter: AgentGUIConversationFilter | null
+  filter: AgentGUIConversationFilter
 ): boolean {
-  if (!conversation || !filter || filter.kind !== "agentTarget") {
+  if (!conversation || filter.kind !== "agentTarget") {
     return true;
   }
   return matchesAgentGUIConversationSummaryFilter(conversation, filter);
@@ -200,14 +194,11 @@ export function createAgentGUIConversationListQueryKey(
   if (!normalized) {
     return null;
   }
-  const providerScope = normalized.conversationFilter
-    ? "conversation-filter"
-    : normalized.provider;
   const queryKey = [
     normalized.workspaceId,
     normalized.userId,
-    providerScope,
-    conversationFilterKey(normalized.conversationFilter, normalized.provider),
+    "conversation-filter",
+    conversationFilterKey(normalized.conversationFilter),
     normalized.sessionOrigin
   ].join("::");
   return queryKey;
@@ -1341,13 +1332,12 @@ async function refreshAgentGUIConversationListQuery(
     };
     const currentWorkspaceAgentSnapshot =
       getWorkspaceAgentSnapshotForConversations(workspaceAgentsInput);
-    const canProjectExplicitFilterFromCurrentSnapshot =
+    const canProjectFilterFromCurrentSnapshot =
       reason === "projection-sync" &&
-      state.query.conversationFilter !== null &&
       currentWorkspaceAgentSnapshot.sessions.length > 0;
     const workspaceAgentSnapshot =
       shouldUseCurrentWorkspaceAgentSnapshotForRefresh(reason) ||
-      canProjectExplicitFilterFromCurrentSnapshot
+      canProjectFilterFromCurrentSnapshot
         ? currentWorkspaceAgentSnapshot
         : await loadWorkspaceAgentSnapshotForConversations(
             workspaceAgentsInput
@@ -1417,9 +1407,7 @@ async function refreshAgentGUIConversationListQuery(
         })
       : workspaceAgentSnapshot.sessions;
     const baseConversations = buildAgentGUIConversationSummaries({
-      ...(state.query.conversationFilter
-        ? { conversationFilter: state.query.conversationFilter }
-        : {}),
+      conversationFilter: state.query.conversationFilter,
       snapshot: canApplyDirtySessionProjection
         ? {
             ...workspaceAgentSnapshot,
@@ -1461,7 +1449,7 @@ async function refreshAgentGUIConversationListQuery(
     );
     const retainableForQueryFilter = (agentSessionId: string): boolean => {
       const filter = state.query.conversationFilter;
-      if (!filter || filter.kind !== "agentTarget") {
+      if (filter.kind !== "agentTarget") {
         return true;
       }
       // The fresh snapshot session's target is authoritative over a possibly


### PR DESCRIPTION
## Findings

cleanup-now:
- Removed the contexts conversation-list query-key fallback where an omitted filter created provider-scoped `legacy-provider:<provider>` keys. The current AgentGuiNode controller always supplies a conversation filter, so the store now normalizes omitted filters to `all` and keeps query keys provider-independent.

required-compat:
- Kept legacy session matching under agent-target filters: sessions without `agentTargetId` can still match through provider identity for historical activity.
- Kept persisted settings normalization fallbacks for `modelByProvider`, `normalizeZoomOnTerminalClick`, and `uiFontScalePercent`; these are old snapshot/read paths.
- Kept current canvas settings fields and storage normalization.

follow-up:
- None in `packages/agent/gui/contexts/**` from this pass.

## Changes

- Default conversation-list filters now normalize to `{ kind: "all" }`.
- Query keys no longer encode provider identity for missing filters.
- Updated store tests to lock default-filter/all-filter query-key behavior and all-filter projection semantics.

## Validation

- `pnpm --filter @tutti-os/agent-gui test -- contexts/workspace/presentation/renderer/agentGuiConversationList/agentGuiConversationListStore.spec.ts` (package test script ran 125 files / 2124 tests)
- `pnpm --filter @tutti-os/agent-gui typecheck`
- `pnpm check:agent-activity-runtime-boundaries`
- `git diff --check`
- pre-push `pnpm check:full`

## Documentation

No durable documentation update needed; this aligns contexts behavior with the existing AgentGUI conversation-filter architecture notes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Conversation list filters now behave consistently when no filter is selected, using the default “all” view.
  * Projection refreshes can reuse the current workspace snapshot more reliably.

* **Bug Fixes**
  * Fixed conversation lists from unnecessarily reloading sessions during filter changes, incremental updates, and overlay refreshes.
  * Improved filter key handling so equivalent default queries no longer produce mismatched results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->