### PR TITLE
fix(agent-gui): preserve active turn busy state

### DIFF
--- a/apps/desktop/src/renderer/src/features/workspace-issue-manager/internal/adapters/desktopIssueManagerAgentRunner.test.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-issue-manager/internal/adapters/desktopIssueManagerAgentRunner.test.ts
@@ -28,6 +28,7 @@ test("desktop issue-manager agent runner opens execute prompt as an agent draft"
   assert.equal(capturedCreate, undefined);
   assert.equal(capturedLaunch?.agentSessionId, undefined);
   assert.equal(capturedLaunch?.agentTargetId, "local:codex");
+  assert.equal(capturedLaunch?.openInNewWindow, true);
   assert.equal(capturedLaunch?.provider, "codex");
   assert.equal(capturedLaunch?.userProjectPath, undefined);
   assert.equal(capturedLaunch?.workspaceId, "workspace-1");
@@ -118,6 +119,7 @@ test("desktop issue-manager agent runner passes selected execution directory to 
   const prompt = capturedLaunch?.draftPrompt ?? "";
 
   assert.equal(capturedCreate, undefined);
+  assert.equal(capturedLaunch?.openInNewWindow, true);
   assert.equal(capturedLaunch?.userProjectPath, "/Users/example/project/tutti");
   assert.doesNotMatch(prompt, /\/Users\/example\/project\/tutti/);
   assert.match(prompt, /mention:\/\/workspace-issue/);
@@ -171,6 +173,7 @@ test("desktop issue-manager agent breakdown launcher opens breakdown prompt as a
   assert.equal(capturedCreate, undefined);
   assert.equal(capturedLaunch?.agentSessionId, undefined);
   assert.equal(capturedLaunch?.agentTargetId, "remote:openclaw");
+  assert.equal(capturedLaunch?.openInNewWindow, true);
   assert.match(
     capturedLaunch?.draftPrompt ?? "",
     /Break this task reference down into executable tasks/

--- a/apps/desktop/src/renderer/src/features/workspace-issue-manager/internal/adapters/desktopIssueManagerAgentRunner.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-issue-manager/internal/adapters/desktopIssueManagerAgentRunner.ts
@@ -34,6 +34,7 @@ export interface DesktopIssueManagerAgentGuiLaunchInput {
   agentSessionId?: string;
   agentTargetId?: string | null;
   draftPrompt?: string;
+  openInNewWindow?: boolean;
   provider: string;
   userProjectPath?: string | null;
   workspaceId: string;
@@ -107,6 +108,7 @@ function openIssueManagerAgentDraft(input: {
       launchAgentGui({
         agentTargetId: input.agentTargetId,
         draftPrompt: input.draftPrompt,
+        openInNewWindow: true,
         provider: input.provider,
         userProjectPath: input.userProjectPath,
         workspaceId: input.workspaceId

--- a/apps/desktop/src/renderer/src/features/workspace-workbench/services/internal/workspaceIssueManagerContribution.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/services/internal/workspaceIssueManagerContribution.ts
@@ -94,6 +94,7 @@ export function createWorkspaceIssueManagerContribution(input: {
         agentSessionId: request.agentSessionId,
         draftPrompt: request.draftPrompt,
         agentTargetId: request.agentTargetId,
+        openInNewWindow: request.openInNewWindow,
         provider: normalizeDesktopAgentGUIProvider(request.provider),
         userProjectPath: request.userProjectPath,
         workspaceId: request.workspaceId

--- a/docs/architecture/agent-gui-node.md
+++ b/docs/architecture/agent-gui-node.md
@@ -180,6 +180,11 @@ a Codex panel before the draft prefill effect runs. The prefilled handoff panel
 must also scope the conversation rail to the selected target instead of opening
 on `All`; the target-specific rail selection is part of the handoff activation
 state, not a later user filter choice.
+External draft-prefill launchers that start separate work, such as Issue
+Manager task execution and task breakdown, must request a new AgentGUI window
+and must not reuse an existing dock-entry node. Reusing the dock entry can focus
+or restore the previous active conversation before the new draft composer is
+visible.
 The handoff menu is a launch surface, so its options must come from the
 host-provided, enabled provider targets. It must not use the provider rail's
 static catalog fallback or coming-soon placeholders, which are display chrome
@@ -712,6 +717,15 @@ dispatch to provider-specific active-turn guidance without opening a normal next
 turn. Codex app-server maps this to `turn/steer`; Claude SDK maps it through the
 sidecar live prompt queue. `Shift+Enter` remains the multiline composer shortcut
 and must not submit either a normal prompt or guidance.
+Active composer state must prefer a live `AgentActivityRuntime` turn lifecycle
+over the selected session view/control state. `getState` and legacy state patch
+paths can temporarily report a settled or available control state while the
+runtime snapshot still has `turnLifecycle.activeTurnId` with a live phase. In
+that split state, AgentGuiNode must keep the transcript/loading projection busy,
+set normal `canSubmit` false, and let ordinary composer sends enter the local
+queue. Only explicit guidance actions bypass that queue and steer the active
+turn. Legacy `idle` turn patches clear `activeTurnId`; they must not leave a
+stale active-turn block behind.
 
 The submit target is not just a render detail. A detail-page composer must not
 fall back to `startConversation` because a UI-local active conversation ref is

--- a/docs/conventions/troubleshooting.md
+++ b/docs/conventions/troubleshooting.md
@@ -106,6 +106,84 @@ Use this shape for new entries:
   [controller.go](../../packages/agent/daemon/runtime/controller.go)
   [controller_test.go](../../packages/agent/daemon/runtime/controller_test.go)
 
+### AgentGUI send blocked by active_turn after settled snapshot
+
+- Symptom:
+  AgentGUI shows `turnPhase = settled` and no `activeTurnId`, but a follow-up
+  prompt fails with `agent session already has an active turn`, or the runtime
+  snapshot still reports `submitAvailabilityState = blocked` with
+  `reason = active_turn`.
+- Quick checks:
+  Compare renderer state with `tuttid.log` submit traces. If `api.send.failed`
+  reports `agent session already has an active turn` after a settled/available
+  state patch, inspect whether the controller still has an in-memory `c.turns`
+  entry while the adapter lifecycle snapshot has already settled.
+- Root cause:
+  The controller's async turn registry is separate from adapter lifecycle
+  projection. Async execution must clear `c.turns` when the owning adapter
+  publishes a non-live `TurnLifecycleSnapshot`, even if the event type is not a
+  terminal `turn.completed`/`turn.failed` event.
+- Fix:
+  Treat same-turn non-live lifecycle snapshots as async turn completion, in
+  addition to terminal event types and steered prompt messages.
+- Validation:
+  Add controller coverage where an async adapter emits only a settled lifecycle
+  snapshot for the turn and no terminal event, then verify a follow-up `Exec`
+  no longer returns `ErrSessionActiveTurn`. Run
+  `go test ./packages/agent/daemon/runtime`.
+- References:
+  [controller.go](../../packages/agent/daemon/runtime/controller.go)
+  [controller_test.go](../../packages/agent/daemon/runtime/controller_test.go)
+
+### AgentGUI loading disappears before active turn settles
+
+- Symptom:
+  AgentGUI loses the in-progress/loading affordance while the app-server turn is
+  still active, normal composer sends hit the active-turn guard instead of
+  queueing, or a later terminal event arrives for a turn that the runtime
+  already cleared.
+- Quick checks:
+  First compare the renderer `runtimeSession` and `sessionState` diagnostics.
+  If `runtimeSession.turnLifecycle.activeTurnId` is non-empty with a live phase
+  but `sessionState.turnLifecycle.phase = settled` and
+  `submitAvailabilityState = available`, the bug is in AgentGUI derived state:
+  the active composer/projection is trusting stale selected-session control
+  state over the runtime snapshot. Separately inspect app-server terminal
+  payloads. A `turn/completed` or `turn/failed` notification with an empty
+  provider turn id must not settle a bound active turn unless that turn was
+  explicitly adopted from a preceding goal-continuation `turn/started`.
+- Root cause:
+  There are two distinct failure modes. In AgentGUI, the runtime activity
+  snapshot can be live while the selected session view/control state is stale;
+  composer loading, projection turn lifecycle, `canSubmit`, and local queue
+  decisions must prefer the runtime live lifecycle. In the Codex app-server
+  adapter, `settleActiveTurn` is allowed to adopt a mismatched provider turn id
+  only for the steer case where `turn/start` returned an unconfirmed stub id and
+  codex later completes the running turn with a non-empty provider id. Treating
+  an empty terminal id as a wildcard clears active turn state too early and
+  removes loading.
+- Fix:
+  In AgentGUI, drive active projection, active live state, submit blocking, and
+  queue decisions from a live `AgentActivityRuntime` lifecycle before falling
+  back to `activeSessionState`. Keep guidance/steer as the explicit queue
+  bypass path; ordinary composer sends while busy should queue. In the daemon,
+  keep the steer exception, but require the terminal provider id to be non-empty
+  and drop empty-id terminal notifications for bound active turns. Keep the
+  narrow exception for goal-adopted turns whose ownership came from
+  `turn/started`.
+- Validation:
+  Keep tests for both sides: a stale settled `sessionState` plus live runtime
+  lifecycle should still render processing/loading, set `canSubmit = false`,
+  allow local queueing, and avoid direct `exec`; steered stub turns must settle
+  on the running turn's non-empty completion id; empty-id terminal notifications
+  must not settle confirmed or unconfirmed active turns; goal continuation must
+  still complete its adopted turn.
+- References:
+  [useAgentGUINodeController.ts](../../packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUINodeController.ts)
+  [useAgentGUINodeController.spec.tsx](../../packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUINodeController.spec.tsx)
+  [codex_appserver_turn_machine.go](../../packages/agent/daemon/runtime/codex_appserver_turn_machine.go)
+  [codex_appserver_adapter_test.go](../../packages/agent/daemon/runtime/codex_appserver_adapter_test.go)
+
 ### Renderer tile memory warnings from hidden autoplay animation
 
 - Symptom:
@@ -2086,7 +2164,8 @@ target app`. Compare `/Applications/Tutti.app/Contents/Info.plist` with the
   line switches.
 - Fix:
   Prefer CDP `Tracing.start` with `transferMode: "ReturnAsStream"` for large
-  captures instead of DevTools UI export. Record only the smallest repro window.
+  captures instead of DevTools UI export. The repository helper uses that path:
+  `pnpm trace:desktop -- --duration 15`. Record only the smallest repro window.
 - Validation:
   Restart the desktop app, confirm the remote debugging endpoint responds, record
   a short trace, and verify the trace JSON is written without opening the

--- a/package.json
+++ b/package.json
@@ -69,6 +69,7 @@
     "review:architecture": "node ./.codex/skills/tutti-architecture-review/scripts/plan-review.mjs --format summary",
     "review:architecture:package": "node ./.codex/skills/tutti-architecture-review/scripts/plan-review.mjs --format json --output-temp",
     "review:architecture:test": "node --test ./.codex/skills/tutti-architecture-review/scripts/plan-review.test.mjs ./.codex/skills/tutti-architecture-review/scripts/build-review-scope.test.mjs",
+    "trace:desktop": "node ./tools/scripts/capture-electron-trace.mjs",
     "patch:claude-agent-acp": "node ./services/tuttid/service/agentstatus/assets/patch-claude-agent-acp.mjs",
     "setup:dev": "node ./tools/scripts/setup-dev.mjs",
     "smoke:desktop-transport": "node ./tools/scripts/smoke-desktop-transport.mjs",

--- a/packages/agent/daemon/runtime/codex_appserver_adapter.go
+++ b/packages/agent/daemon/runtime/codex_appserver_adapter.go
@@ -2132,10 +2132,12 @@ func (a *CodexAppServerAdapter) execSlashCommand(
 					terminalEvents = append(terminalEvents, newTurnActivityEvent(session, EventTurnFailed, turnID, SessionStatusFailed, "", "", acpFailureMetadata(finishErr)))
 					emitTerminal(terminalEvents)
 				}
+				a.scheduleGoalContinuationNudge(session)
 				return true, nil
 			}
 			normalizer.ApplyAssistantFinalText(appServerTurnFinalAssistantText(finalTurn))
 			emitTerminal(appServerTurnTerminalEvents(session, turnID, finalTurn, normalizer))
+			a.scheduleGoalContinuationNudge(session)
 			return true, nil
 		}
 		terminalEvents := []activityshared.Event{}

--- a/packages/agent/daemon/runtime/codex_appserver_adapter_test.go
+++ b/packages/agent/daemon/runtime/codex_appserver_adapter_test.go
@@ -1683,6 +1683,71 @@ func TestCodexAppServerAdapterExecSteeredTurnSettlesOnRunningTurnCompletion(t *t
 	}
 }
 
+func TestCodexAppServerAdapterDropsEmptyTerminalIDForBoundActiveTurn(t *testing.T) {
+	t.Parallel()
+
+	adapter, _, session := startedAppServerAdapter(t)
+	appTurn := &codexAppServerActiveTurn{
+		turnID:     "turn-local-1",
+		session:    session,
+		normalizer: newACPTurnNormalizer(),
+		phase:      codexAppServerTurnPhaseRunning,
+		terminal:   make(chan codexAppServerTurnTerminal, 1),
+		terminated: make(chan struct{}),
+	}
+	if !adapter.beginActiveTurn(session.AgentSessionID, appTurn) {
+		t.Fatal("beginActiveTurn failed")
+	}
+	adapter.setSessionActiveTurnID(session.AgentSessionID, "turn-real")
+	adapter.confirmSessionActiveTurnStarted(session.AgentSessionID, "turn-real")
+
+	adapter.completeActiveTurn(session.AgentSessionID, map[string]any{"status": "completed"})
+
+	if got := adapter.sessionActiveTurnID(session.AgentSessionID); got != "turn-real" {
+		t.Fatalf("active turn id = %q, want turn-real after empty terminal id", got)
+	}
+	if active := adapter.sessionActiveTurn(session.AgentSessionID); active != appTurn {
+		t.Fatalf("active turn = %#v, want original appTurn", active)
+	}
+	select {
+	case terminal := <-appTurn.terminal:
+		t.Fatalf("empty terminal id delivered terminal %#v, want drop", terminal)
+	default:
+	}
+}
+
+func TestCodexAppServerAdapterDropsEmptyTerminalIDForUnconfirmedActiveTurn(t *testing.T) {
+	t.Parallel()
+
+	adapter, _, session := startedAppServerAdapter(t)
+	appTurn := &codexAppServerActiveTurn{
+		turnID:     "turn-local-1",
+		session:    session,
+		normalizer: newACPTurnNormalizer(),
+		phase:      codexAppServerTurnPhaseRunning,
+		terminal:   make(chan codexAppServerTurnTerminal, 1),
+		terminated: make(chan struct{}),
+	}
+	if !adapter.beginActiveTurn(session.AgentSessionID, appTurn) {
+		t.Fatal("beginActiveTurn failed")
+	}
+	adapter.setSessionActiveTurnID(session.AgentSessionID, "turn-steer-stub")
+
+	adapter.completeActiveTurn(session.AgentSessionID, map[string]any{"status": "completed"})
+
+	if got := adapter.sessionActiveTurnID(session.AgentSessionID); got != "turn-steer-stub" {
+		t.Fatalf("active turn id = %q, want turn-steer-stub after empty terminal id", got)
+	}
+	if active := adapter.sessionActiveTurn(session.AgentSessionID); active != appTurn {
+		t.Fatalf("active turn = %#v, want original appTurn", active)
+	}
+	select {
+	case terminal := <-appTurn.terminal:
+		t.Fatalf("empty terminal id delivered terminal %#v, want drop", terminal)
+	default:
+	}
+}
+
 func TestCodexAppServerAdapterConfirmActiveTurnStartedScopedToBoundID(t *testing.T) {
 	t.Parallel()
 

--- a/packages/agent/daemon/runtime/codex_appserver_turn_machine.go
+++ b/packages/agent/daemon/runtime/codex_appserver_turn_machine.go
@@ -86,18 +86,19 @@ func (a *CodexAppServerAdapter) failActiveTurnFromAppServerError(agentSessionID 
 }
 
 // settleActiveTurn owns the shared settle sequence — lock, session lookup,
-// provider-turn-id match (empty ids are wildcards), phase transition,
-// activeTurnID clear, non-blocking terminal send — so the completion and
-// failure paths cannot diverge on the guards. terminalFor runs under the
-// adapter lock with the matched active turn.
+// provider-turn-id match, phase transition, activeTurnID clear, non-blocking
+// terminal send — so the completion and failure paths cannot diverge on the
+// guards. terminalFor runs under the adapter lock with the matched active turn.
 //
-// A mismatched provider turn id settles anyway when the recorded id was
-// never confirmed by turn/started: a turn/start issued while another turn is
-// already running responds with a stub id that codex never starts — the
-// input is steered into the running turn, so that turn's same-thread
-// terminal is this turn's terminal (live-verified against codex 0.142.5,
+// A mismatched non-empty provider turn id settles anyway when the recorded id
+// was never confirmed by turn/started: a turn/start issued while another turn
+// is already running responds with a stub id that codex never starts — the
+// input is steered into the running turn, so that turn's same-thread terminal
+// is this turn's terminal (live-verified against codex 0.142.5,
 // TestLiveProtocolTurnStartDuringActiveTurn). Requiring an exact match there
-// wedged awaitTurnCompletion forever.
+// wedged awaitTurnCompletion forever. Goal-adopted turns are the only active
+// turns allowed to settle from an empty terminal id because their ownership was
+// established by the preceding turn/started notification.
 func (a *CodexAppServerAdapter) settleActiveTurn(
 	agentSessionID string,
 	providerTurnID string,
@@ -118,8 +119,9 @@ func (a *CodexAppServerAdapter) settleActiveTurn(
 			expected := strings.TrimSpace(appSession.activeTurnID)
 			actual := strings.TrimSpace(providerTurnID)
 			switch {
-			case expected == "" || actual == "" || expected == actual:
-			case !appSession.activeTurnStartConfirmed:
+			case expected == "" || actual == expected:
+			case actual == "" && activeTurn.kind == codexAppServerTurnKindGoalAdopted:
+			case actual != "" && !appSession.activeTurnStartConfirmed:
 				steerAdoptedTurnID = expected
 			default:
 				droppedTurnID = expected

--- a/packages/agent/daemon/runtime/controller.go
+++ b/packages/agent/daemon/runtime/controller.go
@@ -1258,7 +1258,9 @@ func (c *Controller) runAsyncExecTurn(ctx context.Context, session Session, adap
 			"session_status":       session.Status,
 			"turn_phase":           turnLifecyclePhaseFromEvents(events),
 		})
-		if turnHasTerminalEvent(events, turnID) || turnSteeredIntoActiveTurn(events, turnID) {
+		if turnHasTerminalEvent(events, turnID) ||
+			turnLifecycleSnapshotSettledTurn(events, turnID) ||
+			turnSteeredIntoActiveTurn(events, turnID) {
 			finish(session)
 		}
 	}
@@ -1293,6 +1295,24 @@ func turnHasTerminalEvent(events []activityshared.Event, turnID string) bool {
 			if string(event.Type) == EventTurnCanceled {
 				return true
 			}
+		}
+	}
+	return false
+}
+
+func turnLifecycleSnapshotSettledTurn(events []activityshared.Event, turnID string) bool {
+	turnID = strings.TrimSpace(turnID)
+	if turnID == "" {
+		return false
+	}
+	for _, event := range events {
+		snapshot, ok := activityshared.TurnLifecycleSnapshotFromEvent(event)
+		if !ok || strings.TrimSpace(snapshot.Phase) != string(activityshared.TurnPhaseSettled) {
+			continue
+		}
+		if strings.TrimSpace(event.Payload.TurnID) == turnID ||
+			strings.TrimSpace(snapshot.ActiveTurnID) == turnID {
+			return true
 		}
 	}
 	return false

--- a/packages/agent/daemon/runtime/controller_test.go
+++ b/packages/agent/daemon/runtime/controller_test.go
@@ -2599,6 +2599,45 @@ func (a *asyncExecTestAdapter) calls() (bool, bool) {
 	return a.execCalled, a.asyncCalled
 }
 
+type lifecycleSnapshotAsyncExecAdapter struct {
+	execDone chan struct{}
+}
+
+func (*lifecycleSnapshotAsyncExecAdapter) Provider() string { return ProviderCodex }
+
+func (*lifecycleSnapshotAsyncExecAdapter) Start(context.Context, Session) ([]activityshared.Event, error) {
+	return nil, nil
+}
+
+func (*lifecycleSnapshotAsyncExecAdapter) Resume(context.Context, Session) error { return nil }
+
+func (*lifecycleSnapshotAsyncExecAdapter) Close(context.Context, Session) error { return nil }
+
+func (*lifecycleSnapshotAsyncExecAdapter) Exec(context.Context, Session, []PromptContentBlock, string, string, EventSink, CommandSnapshotSink) ([]activityshared.Event, error) {
+	return nil, nil
+}
+
+func (a *lifecycleSnapshotAsyncExecAdapter) ExecAsync(_ context.Context, session Session, _ []PromptContentBlock, _ string, turnID string, emit EventSink, _ CommandSnapshotSink) error {
+	if emit != nil {
+		event := newTurnActivityEventWithID(session, "turn-settled-snapshot-async", EventTurnUpdated, turnID, SessionStatusReady, "", "", map[string]any{
+			"phase": string(activityshared.TurnPhaseIdle),
+		})
+		activityshared.StampTurnLifecycleSnapshot(&event, activityshared.TurnLifecycleSnapshot{
+			Origin:  activityshared.TurnLifecycleOriginAdapter,
+			Seq:     1,
+			Phase:   string(activityshared.TurnPhaseSettled),
+			Outcome: string(activityshared.TurnOutcomeCompleted),
+		})
+		emit([]activityshared.Event{event})
+	}
+	a.execDone <- struct{}{}
+	return nil
+}
+
+func (*lifecycleSnapshotAsyncExecAdapter) Cancel(context.Context, Session, string) ([]activityshared.Event, error) {
+	return nil, nil
+}
+
 // steeringAsyncExecAdapter mirrors CodexAppServerAdapter.steerActiveTurn: the
 // prompt is steered into an already-running provider turn, so ExecAsync emits
 // only the steered user message for the new turn id and no terminal event ever
@@ -3200,6 +3239,44 @@ func TestControllerExecSteerSettlesTurnRecordWithoutTerminalEvent(t *testing.T) 
 		Content:        textPrompt("follow-up prompt"),
 	}); err != nil {
 		t.Fatalf("Exec after steer: %v", err)
+	}
+}
+
+func TestControllerExecSettledLifecycleSnapshotClearsAsyncTurnRecord(t *testing.T) {
+	t.Parallel()
+
+	adapter := &lifecycleSnapshotAsyncExecAdapter{execDone: make(chan struct{}, 1)}
+	controller := NewController([]Adapter{adapter}, nil)
+	started, err := controller.Start(context.Background(), StartInput{
+		RoomID:         "room-1",
+		AgentSessionID: "agent-session-1",
+		Provider:       ProviderCodex,
+		Title:          "Test",
+	})
+	if err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	if _, err := controller.Exec(context.Background(), ExecInput{
+		RoomID:         "room-1",
+		AgentSessionID: started.Session.AgentSessionID,
+		Content:        textPrompt("run"),
+	}); err != nil {
+		t.Fatalf("Exec: %v", err)
+	}
+	select {
+	case <-adapter.execDone:
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for snapshot ExecAsync")
+	}
+	waitForCondition(t, func() bool {
+		return !controller.HasActiveTurn("room-1", started.Session.AgentSessionID)
+	})
+	if _, err := controller.Exec(context.Background(), ExecInput{
+		RoomID:         "room-1",
+		AgentSessionID: started.Session.AgentSessionID,
+		Content:        textPrompt("follow-up prompt"),
+	}); err != nil {
+		t.Fatalf("Exec after settled snapshot: %v", err)
 	}
 }
 

--- a/packages/agent/gui/agent-gui/agentGuiNode/AgentGUINode.spec.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/AgentGUINode.spec.tsx
@@ -7541,6 +7541,7 @@ function createViewModel(
     activeLiveState: "active",
     activationError: null,
     openclawGateway: null,
+    activeConversationBusy: false,
     canSubmit: true,
     canQueueWhileBusy: false,
     hasSentUserMessage: false,

--- a/packages/agent/gui/agent-gui/agentGuiNode/AgentGUINodeView.layout.spec.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/AgentGUINodeView.layout.spec.tsx
@@ -3993,6 +3993,29 @@ describe("AgentGUINodeView layout persistence", () => {
     });
   });
 
+  it("keeps the composer busy from the controller active-turn state when rows are stale", () => {
+    const activeConversation = createConversationSummary("session-1");
+
+    renderAgentGUINodeView({
+      viewModel: {
+        ...createViewModel(),
+        activeConversation,
+        activeConversationId: activeConversation.id,
+        activeConversationBusy: true,
+        canSubmit: false,
+        canQueueWhileBusy: true,
+        conversation: null,
+        conversationDetail: null,
+        isSubmitting: false
+      }
+    });
+
+    expect(composerMock.calls.at(-1)).toMatchObject({
+      isSendingTurn: true,
+      showStopButton: true
+    });
+  });
+
   it("keeps the selected transient conversation ahead of the latest runtime rail page", () => {
     const project = { id: "ryan", label: "ryan", path: "/Users/ryan" };
     const existingSection = {
@@ -5132,6 +5155,7 @@ function createViewModel(
     activeLiveState: "inactive",
     activationError: null,
     openclawGateway: null,
+    activeConversationBusy: false,
     canSubmit: true,
     hasSentUserMessage: false,
     composerSettings: {

--- a/packages/agent/gui/agent-gui/agentGuiNode/AgentGUINodeView.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/AgentGUINodeView.tsx
@@ -2403,7 +2403,9 @@ const AgentGUIDetailPane = memo(function AgentGUIDetailPane({
     conversation
   });
   const activeConversationTurnBusy =
-    viewModel.isSubmitting || derivedBusyStatus !== null;
+    viewModel.isSubmitting ||
+    viewModel.activeConversationBusy ||
+    derivedBusyStatus !== null;
   const isComposerSending =
     viewModel.isSubmitting ||
     activeConversationTurnBusy ||

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUINodeController.spec.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUINodeController.spec.tsx
@@ -17145,6 +17145,206 @@ describe("useAgentGUINodeController", () => {
     expect(result.current.viewModel.queuedPrompts).toEqual([]);
   });
 
+  it("keeps composer busy from runtime lifecycle when session state is stale settled", async () => {
+    const exec = vi.fn(async () => ({
+      agentSessionId: "session-1",
+      turnId: "turn-2",
+      accepted: true,
+      sessionStatus: "working" as const,
+      events: []
+    }));
+    let activityListener:
+      | ((event: AgentHostAgentActivityStreamEvent) => void)
+      | undefined;
+    installAgentHostApi({
+      list: vi.fn(async () => snapshotWithSession("session-1")),
+      listSessionTimeline: vi.fn(async () => ({
+        timelineItems: [
+          {
+            ...timelineMessage({
+              agentSessionId: "session-1",
+              id: 1,
+              eventId: "assistant-1",
+              role: "assistant",
+              content: "Still working",
+              turnId: "turn-1",
+              occurredAtUnixMs: 20
+            }),
+            itemType: "message.assistant",
+            status: "completed"
+          }
+        ]
+      })),
+      subscribeEvents: vi.fn((_payload, listener) => {
+        activityListener = listener;
+        return vi.fn();
+      }),
+      getState: vi.fn(async () =>
+        agentSessionState("session-1", {
+          status: "ready",
+          turnLifecycle: {
+            activeTurnId: null,
+            phase: "settled",
+            outcome: "completed"
+          },
+          submitAvailability: { state: "available" }
+        })
+      ),
+      exec
+    });
+
+    const { result } = renderHook(() =>
+      useAgentGUINodeController({
+        workspaceId: "room-1",
+        currentUserId: "user-1",
+        workspacePath: "/workspace",
+        avoidGroupingEdits: false,
+        data: agentGuiData("session-1"),
+        onDataChange: vi.fn()
+      })
+    );
+
+    await waitFor(() => {
+      expect(activityListener).toBeDefined();
+    });
+
+    act(() => {
+      activityListener?.({
+        eventType: "state_patch",
+        data: {
+          workspaceId: "room-1",
+          agentSessionId: "session-1",
+          lifecycleStatus: "active",
+          currentPhase: "idle",
+          turnLifecycle: { activeTurnId: "turn-1", phase: "running" },
+          occurredAtUnixMs: 20
+        } as AgentHostWorkspaceAgentStatePatch & {
+          turnLifecycle: { activeTurnId: string; phase: string };
+        }
+      });
+    });
+
+    await waitFor(() => {
+      expect(result.current.viewModel.activeLiveState).toBe("active");
+    });
+    expect(result.current.viewModel.canSubmit).toBe(false);
+    expect(result.current.viewModel.canQueueWhileBusy).toBe(true);
+    await waitFor(() => {
+      expect(
+        result.current.viewModel.conversation?.rows.some(
+          (row) => row.kind === "processing"
+        )
+      ).toBe(true);
+    });
+
+    act(() => {
+      result.current.actions.submitPrompt(promptBlocks("queue while running"));
+    });
+
+    await waitFor(() => {
+      expect(queuedPromptTexts(result.current.viewModel.queuedPrompts)).toEqual(
+        ["queue while running"]
+      );
+    });
+    expect(exec).not.toHaveBeenCalled();
+  });
+
+  it("keeps composer busy from timeline working status when lifecycle is stale settled", async () => {
+    const exec = vi.fn(async () => ({
+      agentSessionId: "session-1",
+      turnId: "turn-2",
+      accepted: true,
+      sessionStatus: "working" as const,
+      events: []
+    }));
+    let activityListener:
+      | ((event: AgentHostAgentActivityStreamEvent) => void)
+      | undefined;
+    installAgentHostApi({
+      list: vi.fn(async () =>
+        snapshotWithSession("session-1", {
+          effectiveStatus: "ready",
+          turnPhase: "settled"
+        })
+      ),
+      listSessionTimeline: vi.fn(async () => ({ timelineItems: [] })),
+      subscribeEvents: vi.fn((_payload, listener) => {
+        activityListener = listener;
+        return vi.fn();
+      }),
+      getState: vi.fn(async () =>
+        agentSessionState("session-1", {
+          status: "ready",
+          turnLifecycle: {
+            activeTurnId: null,
+            phase: "settled",
+            outcome: "completed"
+          },
+          submitAvailability: { state: "available" }
+        })
+      ),
+      exec
+    });
+
+    const { result } = renderHook(() =>
+      useAgentGUINodeController({
+        workspaceId: "room-1",
+        currentUserId: "user-1",
+        workspacePath: "/workspace",
+        avoidGroupingEdits: false,
+        data: agentGuiData("session-1"),
+        onDataChange: vi.fn()
+      })
+    );
+
+    await waitFor(() => {
+      expect(result.current.viewModel.activeConversationId).toBe("session-1");
+    });
+    await waitFor(() => {
+      expect(activityListener).toBeDefined();
+    });
+
+    act(() => {
+      activityListener?.({
+        eventType: "message_update",
+        data: {
+          workspaceId: "room-1",
+          agentSessionId: "session-1",
+          messageId: "call-1",
+          seq: 2,
+          turnId: "turn-1",
+          role: "assistant",
+          kind: "tool_call",
+          status: "working",
+          callId: "call-1",
+          payload: { status: "working", toolName: "shell" },
+          occurredAtUnixMs: 21
+        }
+      });
+    });
+
+    await waitFor(() => {
+      expect(result.current.viewModel.activeConversation?.status).toBe(
+        "working"
+      );
+    });
+    await waitFor(() => {
+      expect(result.current.viewModel.canSubmit).toBe(false);
+      expect(result.current.viewModel.canQueueWhileBusy).toBe(true);
+    });
+
+    act(() => {
+      result.current.actions.submitPrompt(promptBlocks("queue from timeline"));
+    });
+
+    await waitFor(() => {
+      expect(queuedPromptTexts(result.current.viewModel.queuedPrompts)).toEqual(
+        ["queue from timeline"]
+      );
+    });
+    expect(exec).not.toHaveBeenCalled();
+  });
+
   it("clears the goal with a visible /goal clear prompt that bypasses the queue", async () => {
     const exec = vi.fn(async () => ({
       agentSessionId: "session-1",
@@ -19008,17 +19208,24 @@ function installAgentActivityRuntimeForHostMocks({
         typeof result?.sessionStatus === "string"
           ? result.sessionStatus
           : "working";
-      const session = upsertRuntimeSession(setSnapshot, input.workspaceId, {
-        agentSessionId: input.agentSessionId,
-        status
-      });
       const turnId =
         typeof result?.turnId === "string" ? result.turnId : "turn-1";
+      const turnLifecycle = { activeTurnId: turnId, phase: "submitted" };
+      const submitAvailability = {
+        state: "blocked",
+        reason: "active_turn"
+      };
+      const session = upsertRuntimeSession(setSnapshot, input.workspaceId, {
+        agentSessionId: input.agentSessionId,
+        status,
+        turnLifecycle,
+        submitAvailability
+      });
       return {
         session,
         turnId,
-        turnLifecycle: { activeTurnId: turnId, phase: "submitted" },
-        submitAvailability: { state: "blocked", reason: "active_turn" }
+        turnLifecycle,
+        submitAvailability
       };
     },
     async setSessionPinned(input) {
@@ -19660,6 +19867,14 @@ function upsertRuntimeSession(
         (existing as { sessionOrigin?: string } | undefined)?.sessionOrigin ??
         AGENT_GUI_RUNTIME_SESSION_ORIGIN,
       currentPhase: input.currentPhase ?? existing?.currentPhase ?? null,
+      turnLifecycle:
+        input.turnLifecycle !== undefined
+          ? input.turnLifecycle
+          : (existing?.turnLifecycle ?? null),
+      submitAvailability:
+        input.submitAvailability !== undefined
+          ? input.submitAvailability
+          : (existing?.submitAvailability ?? null),
       pinnedAtUnixMs:
         input.pinnedAtUnixMs !== undefined
           ? input.pinnedAtUnixMs
@@ -19714,6 +19929,54 @@ function applyRuntimeStreamEvent({
     if (!agentSessionId) {
       return;
     }
+    const turn = recordValue(data.turn) ?? {};
+    const turnLifecycleSource = recordValue(data.turnLifecycle) ?? turn;
+    const turnPhase = normalizeConfigOptionValue(turnLifecycleSource.phase);
+    const currentPhase = normalizeConfigOptionValue(data.currentPhase);
+    const clearsTurnLifecycle = !turnPhase && currentPhase === "idle";
+    const turnId = normalizeConfigOptionValue(turnLifecycleSource.turnId);
+    const hasActiveTurnId = Object.prototype.hasOwnProperty.call(
+      turnLifecycleSource,
+      "activeTurnId"
+    );
+    const activeTurnId = hasActiveTurnId
+      ? normalizeConfigOptionValue(turnLifecycleSource.activeTurnId)
+      : turnPhase === "settled" || turnPhase === "idle"
+        ? null
+        : turnId;
+    const completedCommandSource = recordValue(
+      turnLifecycleSource.completedCommand
+    );
+    const completedCommandKind = normalizeConfigOptionValue(
+      completedCommandSource?.kind
+    );
+    const completedCommandStatus = normalizeConfigOptionValue(
+      completedCommandSource?.status
+    );
+    const completedCommand =
+      completedCommandKind && completedCommandStatus
+        ? { kind: completedCommandKind, status: completedCommandStatus }
+        : null;
+    const turnLifecycle = turnPhase
+      ? {
+          activeTurnId,
+          phase: turnPhase,
+          settling:
+            typeof turnLifecycleSource.settling === "boolean"
+              ? turnLifecycleSource.settling
+              : undefined,
+          outcome: normalizeConfigOptionValue(turnLifecycleSource.outcome),
+          completedCommand
+        }
+      : clearsTurnLifecycle
+        ? null
+        : undefined;
+    const submitAvailabilitySource =
+      recordValue(data.submitAvailability) ??
+      recordValue(turnLifecycleSource.submitAvailability);
+    const submitAvailabilityState = normalizeConfigOptionValue(
+      submitAvailabilitySource?.state
+    );
     upsertRuntimeSession(setSnapshot, workspaceId, {
       agentSessionId,
       provider: normalizeConfigOptionValue(data.provider) ?? undefined,
@@ -19725,7 +19988,18 @@ function applyRuntimeStreamEvent({
         lifecycleStatus: normalizeConfigOptionValue(data.lifecycleStatus),
         currentPhase: normalizeConfigOptionValue(data.currentPhase)
       }),
-      currentPhase: normalizeConfigOptionValue(data.currentPhase) ?? undefined,
+      currentPhase: currentPhase ?? undefined,
+      turnLifecycle,
+      submitAvailability: submitAvailabilityState
+        ? {
+            state: submitAvailabilityState,
+            reason:
+              normalizeConfigOptionValue(submitAvailabilitySource?.reason) ??
+              undefined
+          }
+        : clearsTurnLifecycle
+          ? { state: "available" }
+          : undefined,
       updatedAtUnixMs:
         typeof data.occurredAtUnixMs === "number"
           ? data.occurredAtUnixMs

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUINodeController.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUINodeController.ts
@@ -21,6 +21,7 @@ import {
 import { useAgentHostApi } from "../../../agentActivityHost";
 import {
   resolveSubmitAvailability,
+  isLiveTurnLifecyclePhase,
   resolveAgentActivityCapability,
   resolveAgentActivityUsage,
   selectSessionDisplayStatuses
@@ -3190,6 +3191,17 @@ function conversationBusyStatusFromAgentActivityDisplayStatus(
   return null;
 }
 
+function agentActivitySessionHasLiveTurn(
+  session: AgentActivitySession | null | undefined
+): boolean {
+  const lifecycle = session?.turnLifecycle;
+  if (!lifecycle || lifecycle.settling === true) {
+    return false;
+  }
+  const activeTurnId = lifecycle.activeTurnId?.trim() ?? "";
+  return activeTurnId !== "" || isLiveTurnLifecyclePhase(lifecycle.phase);
+}
+
 function reuseAgentActivityDisplayStatusesIfUnchanged(
   previous: ReadonlyMap<string, AgentActivityDisplayStatus> | null,
   next: Map<string, AgentActivityDisplayStatus>
@@ -3650,7 +3662,7 @@ function mergeSessionControlStatePatch(
       activeTurnId:
         patch.turn.activeTurnId !== undefined
           ? patch.turn.activeTurnId
-          : patch.turn.phase === "settled"
+          : patch.turn.phase === "settled" || patch.turn.phase === "idle"
             ? null
             : patch.turn.turnId,
       phase: patch.turn.phase,
@@ -4448,6 +4460,8 @@ export function useAgentGUINodeController({
       ),
     [agentActivitySnapshot.sessions]
   );
+  const activeRuntimeSession =
+    runtimeSessionsBySessionId.get(activeConversationId ?? "") ?? null;
   const stableRuntimeSyncStateBySessionId = useMemo(() => {
     const current = stableRuntimeSyncStateBySessionIdRef.current;
     let next = current;
@@ -8889,14 +8903,31 @@ export function useAgentGUINodeController({
       if (sessionState?.pendingInteractive) {
         return true;
       }
+      const runtimeSession =
+        runtimeSessionsBySessionId.get(normalizedAgentSessionId) ?? null;
+      if (
+        runtimeSession &&
+        resolveSubmitAvailability(runtimeSession).state === "blocked"
+      ) {
+        return true;
+      }
+      const conversationStatus =
+        conversations.find(
+          (conversation) => conversation.id === normalizedAgentSessionId
+        )?.status ?? null;
+      if (conversationBusyStatus(conversationStatus)) {
+        return true;
+      }
       return agentActivityDisplayStatusBusy(
         agentActivityDisplayStatuses.get(normalizedAgentSessionId)
       );
     },
     [
       agentActivityDisplayStatuses,
+      conversations,
       isRespondingApproval,
       isSubmitting,
+      runtimeSessionsBySessionId,
       sessionViewRef
     ]
   );
@@ -9116,7 +9147,9 @@ export function useAgentGUINodeController({
         return;
       }
       const activeTurnId =
-        activeSessionState?.turnLifecycle?.activeTurnId?.trim() ?? "";
+        activeRuntimeSession?.turnLifecycle?.activeTurnId?.trim() ||
+        activeSessionState?.turnLifecycle?.activeTurnId?.trim() ||
+        "";
       if (activeTurnId === "") {
         return;
       }
@@ -9129,7 +9162,13 @@ export function useAgentGUINodeController({
         { bypassLocalQueue: true, guidance: true }
       );
     },
-    [activeSessionState, promptImagesSupported, submitExistingPrompt, translate]
+    [
+      activeRuntimeSession,
+      activeSessionState,
+      promptImagesSupported,
+      submitExistingPrompt,
+      translate
+    ]
   );
 
   useEffect(() => {
@@ -10865,6 +10904,11 @@ export function useAgentGUINodeController({
   }, [conversationUserIds, ensureAccountProfiles]);
   const projectionConversationRef =
     useRef<AgentGUIConversationProjectionSource | null>(null);
+  const activeRuntimeSessionLiveTurn =
+    agentActivitySessionHasLiveTurn(activeRuntimeSession);
+  const activeRuntimeTurnLifecycle = activeRuntimeSessionLiveTurn
+    ? (activeRuntimeSession?.turnLifecycle ?? null)
+    : null;
   const projectionConversation =
     useMemo<AgentGUIConversationProjectionSource | null>(() => {
       if (!activeConversation) {
@@ -10873,9 +10917,10 @@ export function useAgentGUINodeController({
       }
       const previous = projectionConversationRef.current;
       const turnLifecycle =
-        activeSessionState?.agentSessionId === activeConversation.id
+        activeRuntimeTurnLifecycle ??
+        (activeSessionState?.agentSessionId === activeConversation.id
           ? (activeSessionState.turnLifecycle ?? null)
-          : null;
+          : null);
       if (
         previous &&
         previous.id === activeConversation.id &&
@@ -10920,6 +10965,9 @@ export function useAgentGUINodeController({
       activeConversation?.title,
       activeConversation?.titleFallback,
       activeConversation?.userId,
+      activeRuntimeTurnLifecycle?.activeTurnId,
+      activeRuntimeTurnLifecycle?.phase,
+      activeRuntimeTurnLifecycle?.settling,
       activeSessionState?.agentSessionId,
       activeSessionState?.turnLifecycle?.activeTurnId,
       activeSessionState?.turnLifecycle?.phase,
@@ -11032,7 +11080,10 @@ export function useAgentGUINodeController({
     conversation,
     workspaceId
   ]);
-  const activeLiveState = activeConversationLiveState;
+  const activeLiveState =
+    activeConversationLiveState === "inactive" && activeRuntimeSessionLiveTurn
+      ? "active"
+      : activeConversationLiveState;
   const activationError = activation.errorFor(activeConversationId);
   const activationErrorCode = activation.codeFor(activeConversationId);
   const hasProviderSessionNotFoundError =
@@ -11276,8 +11327,6 @@ export function useAgentGUINodeController({
       : null;
   const pendingInteractivePrompt =
     serverInteractivePrompt ?? planImplementationPromptVM;
-  const activeRuntimeSession =
-    runtimeSessionsBySessionId.get(activeConversationId ?? "") ?? null;
   useEffect(() => {
     const provider = normalizeOptionalText(
       activeRuntimeSession?.provider ?? activeConversation?.provider
@@ -11309,11 +11358,17 @@ export function useAgentGUINodeController({
     : false;
   // Derive from the turn lifecycle when present (ADR 0008); trust the wire
   // submitAvailability only for lifecycle-less control states.
-  const activeSubmitBlocked = activeSessionState
+  const activeSessionStateSubmitBlocked = activeSessionState
     ? resolveSubmitAvailability(activeSessionState).state === "blocked"
     : false;
+  const activeRuntimeSubmitBlocked = activeRuntimeSession
+    ? resolveSubmitAvailability(activeRuntimeSession).state === "blocked"
+    : false;
+  const activeSubmitBlocked =
+    activeSessionStateSubmitBlocked || activeRuntimeSubmitBlocked;
   const activeConversationBusy =
     agentActivityDisplayStatusBusy(activeActivityDisplayStatus) ||
+    conversationBusyStatus(activeConversation?.status ?? null) ||
     activeHasPendingSubmittedTurn ||
     activeSubmitBlocked;
   const activeSessionResumable =
@@ -11413,6 +11468,7 @@ export function useAgentGUINodeController({
     pendingApproval === null &&
     pendingInteractivePrompt === null &&
     sessionChrome.auth === null &&
+    !activeConversationBusy &&
     !isCreatingConversation &&
     !isSubmitting &&
     !isInterrupting;
@@ -12262,6 +12318,7 @@ export function useAgentGUINodeController({
         activeLiveState,
         activationError,
         openclawGateway,
+        activeConversationBusy,
         canSubmit,
         composerSettings: stableComposerSettings,
         queuedPrompts,

--- a/packages/agent/gui/agent-gui/agentGuiNode/model/agentGuiNodeTypes.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/model/agentGuiNodeTypes.ts
@@ -305,6 +305,7 @@ export interface AgentGUINodeViewModel {
   activeLiveState: "inactive" | "activating" | "active" | "failed";
   activationError: string | null;
   openclawGateway: OpenclawGatewayViewState | null;
+  activeConversationBusy: boolean;
   canSubmit: boolean;
   composerSettings: AgentGUIComposerSettingsVM;
   queuedPrompts: AgentGUIQueuedPromptVM[];

--- a/packages/agent/gui/shared/agentConversation/projection/agentProcessingProjection.ts
+++ b/packages/agent/gui/shared/agentConversation/projection/agentProcessingProjection.ts
@@ -9,10 +9,6 @@ export function projectAgentProcessingRow(
   if (!detail.showProcessingIndicator) {
     return null;
   }
-  const status = detail.session.status?.trim().toLowerCase() ?? "";
-  if (!isWorkingSessionStatus(status)) {
-    return null;
-  }
   if (hasSpecificProgressRow(rows)) {
     return null;
   }
@@ -24,10 +20,6 @@ export function projectAgentProcessingRow(
     occurredAtUnixMs:
       detail.session.updatedAtUnixMs ?? detail.session.createdAtUnixMs ?? null
   };
-}
-
-function isWorkingSessionStatus(status: string): boolean {
-  return status === "working";
 }
 
 function hasSpecificProgressRow(

--- a/packages/agent/gui/shared/agentConversation/projection/workspaceAgentTimelineProjection.spec.ts
+++ b/packages/agent/gui/shared/agentConversation/projection/workspaceAgentTimelineProjection.spec.ts
@@ -518,6 +518,39 @@ describe("projectWorkspaceAgentTimelineToConversationVM", () => {
     );
   });
 
+  it("keeps processing when session status is stale ready but turn lifecycle is still running", () => {
+    const completedToolTimelineItems = timelineItems().slice(0, 5);
+    const staleReadySession = {
+      ...session({
+        status: "ready",
+        effectiveStatus: "ready",
+        turnPhase: "idle"
+      }),
+      turnLifecycle: {
+        activeTurnId: "turn-1",
+        phase: "running"
+      }
+    };
+
+    const detail = buildCanonicalWorkspaceAgentDetailView({
+      activity: activity(),
+      session: staleReadySession,
+      workspaceRoot: "/workspace/demo",
+      timelineItems: completedToolTimelineItems
+    });
+    const conversation = projectWorkspaceAgentTimelineToConversationVM({
+      activity: activity(),
+      session: staleReadySession,
+      workspaceRoot: "/workspace/demo",
+      timelineItems: completedToolTimelineItems
+    });
+
+    expect(detail.showProcessingIndicator).toBe(true);
+    expect(conversation.rows.some((row) => row.kind === "processing")).toBe(
+      true
+    );
+  });
+
   it("does not append processing after a terminal assistant message once the turn lifecycle is settling", () => {
     const settlingReplyTimelineItems: AgentHostWorkspaceAgentTimelineItem[] = [
       timelineItems()[0]!,

--- a/packages/agent/gui/workbench/contribution.test.ts
+++ b/packages/agent/gui/workbench/contribution.test.ts
@@ -326,6 +326,62 @@ describe("agent GUI workbench contribution copy", () => {
     });
   });
 
+  it("clears the active session when prefill launches reuse an agent node", () => {
+    const contribution = createTestAgentGuiWorkbenchContribution({
+      renderBody: () => null,
+      workspaceId: "workspace-1"
+    });
+    const baseRequest = {
+      dockEntryId: "agent-gui",
+      layoutConstraints: testLaunchLayout.layoutConstraints,
+      reason: "host" as const,
+      surfaceSize: testLaunchLayout.surfaceSize,
+      typeId: agentGuiWorkbenchTypeId,
+      workspaceId: "workspace-1"
+    };
+
+    const sessionLaunch = contribution.onLaunchRequest?.({
+      ...baseRequest,
+      payload: {
+        agentSessionId: "session-codex-1",
+        agentTargetId: "local:codex",
+        provider: "codex"
+      }
+    }) as
+      | {
+          instanceId: string;
+        }
+      | null
+      | undefined;
+
+    const prefillLaunch = contribution.onLaunchRequest?.({
+      ...baseRequest,
+      payload: {
+        agentTargetId: "local:codex",
+        draftPrompt: "Handle this issue",
+        provider: "codex"
+      }
+    }) as
+      | {
+          instanceId: string;
+        }
+      | null
+      | undefined;
+
+    expect(prefillLaunch?.instanceId).toBe(sessionLaunch?.instanceId);
+    expect(
+      contribution.externalStateSource?.getSnapshotNodeState?.({
+        instanceId: prefillLaunch?.instanceId ?? "",
+        typeId: agentGuiWorkbenchTypeId
+      } as never)
+    ).toEqual({
+      agentTargetId: "local:codex",
+      conversationRailCollapsed: false,
+      conversationRailWidthPx: null,
+      lastActiveAgentSessionId: null
+    });
+  });
+
   it("resolves unified empty dock launches lazily from current provider availability", () => {
     const claudeTarget = createLocalAgentGUIProviderTarget("claude-code");
     const contribution = createTestAgentGuiWorkbenchContribution({

--- a/packages/agent/gui/workbench/contribution.ts
+++ b/packages/agent/gui/workbench/contribution.ts
@@ -483,6 +483,7 @@ export function createAgentGuiWorkbenchContribution(
           instanceId,
           state: {
             ...normalizeAgentGuiWorkbenchState(previousState),
+            lastActiveAgentSessionId: null,
             ...(providerTarget.agentTargetId
               ? { agentTargetId: providerTarget.agentTargetId }
               : {}),

--- a/packages/agent/gui/workbench/launch.test.ts
+++ b/packages/agent/gui/workbench/launch.test.ts
@@ -238,7 +238,7 @@ describe("agent gui workbench launch contract", () => {
       dockEntryId: "agent-gui",
       openInNewWindow: true,
       provider: "codex",
-      reuseDockEntryNode: true,
+      reuseDockEntryNode: false,
       reuseExistingSessionNode: false,
       targetAgentSessionId: null
     });

--- a/packages/agent/gui/workbench/launch.ts
+++ b/packages/agent/gui/workbench/launch.ts
@@ -227,10 +227,12 @@ export function createAgentGuiWorkbenchLaunchDescriptor(
       }),
       openInNewWindow,
       provider,
-      reuseDockEntryNode: shouldReuseAgentGuiWorkbenchDockEntryNode({
-        dockEntryId,
-        launchKind: "prefill"
-      }),
+      reuseDockEntryNode:
+        !openInNewWindow &&
+        shouldReuseAgentGuiWorkbenchDockEntryNode({
+          dockEntryId,
+          launchKind: "prefill"
+        }),
       reuseExistingSessionNode: !openInNewWindow,
       targetAgentSessionId: null
     };

--- a/tools/scripts/README.md
+++ b/tools/scripts/README.md
@@ -26,6 +26,9 @@ Current examples include:
 - `build-tutti-app-release.mjs` for packaging an external Tutti app into a zip plus `release.json` and `latest.json`
 - `build-tutti-app-catalog.mjs` for merging app `release.json` files into the App Center remote catalog
 - `build-tutti-app-runtime-catalog.mjs` for merging managed app runtime artifact metadata into the runtime download catalog
+- `capture-electron-trace.mjs` for recording desktop Electron performance
+  traces through CDP stream mode without opening the DevTools Performance export
+  UI
 - `lark-log-tool.mjs` for fetching Feishu/Lark message file attachments or Base bug-record attachments with `lark-cli`, extracting Tutti log bundles, summarizing repeated log failures around an anchor time, and optionally watching appended warn/error lines in real time
 
   ```bash
@@ -56,3 +59,14 @@ Current examples include:
   ```
 
 Core product behavior should graduate into Go services or first-class tools rather than remain in shell scripts indefinitely.
+
+Example desktop trace capture:
+
+```bash
+TUTTI_ELECTRON_REMOTE_DEBUGGING_PORT=9223 \
+TUTTI_ELECTRON_JS_FLAGS=--max-old-space-size=8192 \
+VITE_TUTTI_WHY_DID_YOU_RENDER=0 \
+make dev-gui
+
+pnpm trace:desktop -- --duration 15
+```

--- a/tools/scripts/capture-electron-trace.mjs
+++ b/tools/scripts/capture-electron-trace.mjs
@@ -1,0 +1,389 @@
+#!/usr/bin/env node
+import { createWriteStream } from "node:fs";
+import { mkdir } from "node:fs/promises";
+import { homedir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import { setTimeout as delay } from "node:timers/promises";
+
+const defaultPort = 9223;
+const defaultCategories = [
+  "devtools.timeline",
+  "disabled-by-default-devtools.timeline",
+  "disabled-by-default-devtools.timeline.frame",
+  "toplevel",
+  "blink.user_timing",
+  "loading",
+  "v8",
+  "disabled-by-default-v8.cpu_profiler",
+  "disabled-by-default-v8.cpu_profiler.hires",
+  "disabled-by-default-renderer.scheduler"
+].join(",");
+
+if (isMainModule()) {
+  main(process.argv.slice(2)).catch((error) => {
+    process.stderr.write(`${error.message}\n`);
+    process.exitCode = 1;
+  });
+}
+
+export async function main(argv) {
+  const options = parseArgs(argv);
+  if (options.help) {
+    printUsage();
+    return;
+  }
+
+  const port = positiveInteger(options.port, "--port");
+  const durationMs =
+    options.duration == null
+      ? null
+      : Math.round(positiveNumber(options.duration, "--duration") * 1000);
+  const outputPath = resolve(
+    expandHome(options.output ?? defaultOutputPath(new Date()))
+  );
+  const categories = options.categories ?? defaultCategories;
+  if (durationMs == null && !process.stdin.isTTY) {
+    throw new Error("stdin is not interactive; pass --duration <seconds>");
+  }
+
+  const websocketUrl = await resolveBrowserWebSocketUrl(port);
+  await mkdir(dirname(outputPath), { recursive: true });
+
+  const client = await CdpClient.connect(websocketUrl);
+  try {
+    log(`connected ${websocketUrl}`);
+    log(`writing ${outputPath}`);
+    log(`categories ${categories}`);
+
+    await client.send("Tracing.start", {
+      categories,
+      options: "sampling-frequency=10000",
+      transferMode: "ReturnAsStream"
+    });
+
+    log("recording started");
+    if (durationMs == null) {
+      log("press Enter to stop");
+      await waitForEnter();
+    } else {
+      log(`stopping after ${(durationMs / 1000).toFixed(1)}s`);
+      await delay(durationMs);
+    }
+
+    const complete = client.waitForEvent("Tracing.tracingComplete");
+    await client.send("Tracing.end");
+    const event = await complete;
+    const stream = event.params?.stream;
+    if (!stream) {
+      throw new Error(
+        "Tracing.tracingComplete did not include a stream handle"
+      );
+    }
+
+    const bytes = await writeStreamToFile(client, stream, outputPath);
+    log(`saved ${outputPath} (${formatBytes(bytes)})`);
+  } finally {
+    client.close();
+  }
+}
+
+async function resolveBrowserWebSocketUrl(port) {
+  const baseUrl = `http://127.0.0.1:${port}`;
+  const version = await fetchJson(`${baseUrl}/json/version`).catch((error) => {
+    throw new Error(
+      `cannot reach Electron CDP at ${baseUrl}: ${error.message}\n` +
+        "Launch with: TUTTI_ELECTRON_REMOTE_DEBUGGING_PORT=9223 TUTTI_ELECTRON_JS_FLAGS=--max-old-space-size=8192 VITE_TUTTI_WHY_DID_YOU_RENDER=0 make dev-gui"
+    );
+  });
+  if (typeof version.webSocketDebuggerUrl === "string") {
+    return version.webSocketDebuggerUrl;
+  }
+
+  const targets = await fetchJson(`${baseUrl}/json/list`);
+  const pageTarget = Array.isArray(targets)
+    ? targets.find(
+        (target) =>
+          target?.type === "page" &&
+          typeof target.webSocketDebuggerUrl === "string"
+      )
+    : null;
+  if (pageTarget) {
+    return pageTarget.webSocketDebuggerUrl;
+  }
+
+  throw new Error(`no browser or page websocket found at ${baseUrl}`);
+}
+
+async function fetchJson(url) {
+  const response = await fetch(url);
+  if (!response.ok) {
+    throw new Error(`${url} returned HTTP ${response.status}`);
+  }
+  return await response.json();
+}
+
+async function writeStreamToFile(client, stream, outputPath) {
+  const file = createWriteStream(outputPath, { flags: "w" });
+  let bytes = 0;
+
+  try {
+    while (true) {
+      const result = await client.send("IO.read", { handle: stream });
+      const data = String(result.data ?? "");
+      if (data.length > 0) {
+        const buffer = Buffer.from(
+          data,
+          result.base64Encoded ? "base64" : "utf8"
+        );
+        bytes += buffer.byteLength;
+        if (!file.write(buffer)) {
+          await once(file, "drain");
+        }
+      }
+      if (result.eof) {
+        break;
+      }
+    }
+  } finally {
+    await client.send("IO.close", { handle: stream }).catch(() => {});
+    await new Promise((resolveClose, rejectClose) => {
+      file.end((error) => {
+        if (error) {
+          rejectClose(error);
+        } else {
+          resolveClose();
+        }
+      });
+    });
+  }
+
+  return bytes;
+}
+
+class CdpClient {
+  static async connect(url) {
+    const socket = new WebSocket(url);
+    const client = new CdpClient(socket);
+    await onceSocketOpen(socket);
+    return client;
+  }
+
+  constructor(socket) {
+    this.socket = socket;
+    this.nextId = 1;
+    this.pending = new Map();
+    this.eventWaiters = new Map();
+
+    socket.addEventListener("message", (event) => {
+      this.handleMessage(event.data);
+    });
+    socket.addEventListener("close", () => {
+      const error = new Error("CDP websocket closed");
+      for (const { reject } of this.pending.values()) {
+        reject(error);
+      }
+      this.pending.clear();
+    });
+  }
+
+  send(method, params = {}) {
+    const id = this.nextId++;
+    const payload = JSON.stringify({ id, method, params });
+    const promise = new Promise((resolveSend, rejectSend) => {
+      this.pending.set(id, { resolve: resolveSend, reject: rejectSend });
+    });
+    this.socket.send(payload);
+    return promise;
+  }
+
+  waitForEvent(method) {
+    return new Promise((resolveEvent) => {
+      const waiters = this.eventWaiters.get(method) ?? [];
+      waiters.push(resolveEvent);
+      this.eventWaiters.set(method, waiters);
+    });
+  }
+
+  close() {
+    this.socket.close();
+  }
+
+  handleMessage(raw) {
+    const text =
+      typeof raw === "string"
+        ? raw
+        : Buffer.from(raw instanceof ArrayBuffer ? raw : []).toString("utf8");
+    const message = JSON.parse(text);
+
+    if (message.id != null) {
+      const pending = this.pending.get(message.id);
+      if (!pending) {
+        return;
+      }
+      this.pending.delete(message.id);
+      if (message.error) {
+        pending.reject(
+          new Error(
+            `${message.error.message ?? "CDP error"} (${message.error.code ?? "unknown"})`
+          )
+        );
+      } else {
+        pending.resolve(message.result ?? {});
+      }
+      return;
+    }
+
+    if (message.method) {
+      const waiters = this.eventWaiters.get(message.method);
+      if (!waiters?.length) {
+        return;
+      }
+      this.eventWaiters.set(message.method, []);
+      for (const resolveEvent of waiters) {
+        resolveEvent(message);
+      }
+    }
+  }
+}
+
+function parseArgs(argv) {
+  const options = {
+    port: String(defaultPort)
+  };
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    if (arg === "--") {
+      continue;
+    }
+    if (arg === "--help" || arg === "-h") {
+      options.help = true;
+      continue;
+    }
+    if (arg === "--port") {
+      options.port = requiredValue(argv, (index += 1), arg);
+      continue;
+    }
+    if (arg === "--duration") {
+      options.duration = requiredValue(argv, (index += 1), arg);
+      continue;
+    }
+    if (arg === "--output" || arg === "-o") {
+      options.output = requiredValue(argv, (index += 1), arg);
+      continue;
+    }
+    if (arg === "--categories") {
+      options.categories = requiredValue(argv, (index += 1), arg);
+      continue;
+    }
+    throw new Error(`Unknown option: ${arg}`);
+  }
+
+  return options;
+}
+
+function requiredValue(argv, index, option) {
+  const value = argv[index];
+  if (!value || value.startsWith("--")) {
+    throw new Error(`${option} requires a value`);
+  }
+  return value;
+}
+
+function positiveInteger(value, option) {
+  const number = Number(value);
+  if (!Number.isInteger(number) || number <= 0) {
+    throw new Error(`${option} must be a positive integer`);
+  }
+  return number;
+}
+
+function positiveNumber(value, option) {
+  const number = Number(value);
+  if (!Number.isFinite(number) || number <= 0) {
+    throw new Error(`${option} must be a positive number`);
+  }
+  return number;
+}
+
+function defaultOutputPath(date) {
+  const stamp = date
+    .toISOString()
+    .replace(/[-:]/g, "")
+    .replace(/\.\d{3}Z$/, "");
+  return join(homedir(), "Downloads", `TuttiTrace-${stamp}.json`);
+}
+
+function expandHome(path) {
+  if (path === "~") {
+    return homedir();
+  }
+  if (path.startsWith("~/")) {
+    return join(homedir(), path.slice(2));
+  }
+  return path;
+}
+
+function waitForEnter() {
+  process.stdin.resume();
+  process.stdin.setEncoding("utf8");
+  return new Promise((resolveEnter) => {
+    process.stdin.once("data", () => {
+      resolveEnter();
+    });
+  });
+}
+
+function once(emitter, eventName) {
+  return new Promise((resolveOnce) => {
+    emitter.once(eventName, resolveOnce);
+  });
+}
+
+function onceSocketOpen(socket) {
+  return new Promise((resolveOpen, rejectOpen) => {
+    socket.addEventListener("open", resolveOpen, { once: true });
+    socket.addEventListener(
+      "error",
+      () => rejectOpen(new Error("CDP websocket connection failed")),
+      { once: true }
+    );
+  });
+}
+
+function formatBytes(bytes) {
+  if (bytes < 1024) {
+    return `${bytes} B`;
+  }
+  if (bytes < 1024 * 1024) {
+    return `${(bytes / 1024).toFixed(1)} KiB`;
+  }
+  return `${(bytes / 1024 / 1024).toFixed(1)} MiB`;
+}
+
+function isMainModule() {
+  return import.meta.url === `file://${process.argv[1]}`;
+}
+
+function log(message) {
+  process.stderr.write(`[capture-electron-trace] ${message}\n`);
+}
+
+function printUsage() {
+  process.stdout.write(`Capture an Electron performance trace through CDP.
+
+Usage:
+  pnpm trace:desktop -- --duration 15
+  pnpm trace:desktop -- --output ~/Downloads/tutti-trace.json
+
+Options:
+  --port <port>           CDP remote debugging port. Default: ${defaultPort}
+  --duration <seconds>    Stop automatically after this many seconds.
+  -o, --output <path>     Output trace JSON path. Default: ~/Downloads/TuttiTrace-<timestamp>.json
+  --categories <list>     Comma-separated CDP trace categories.
+  -h, --help              Show this help.
+
+Launch Tutti first:
+  TUTTI_ELECTRON_REMOTE_DEBUGGING_PORT=9223 TUTTI_ELECTRON_JS_FLAGS=--max-old-space-size=8192 VITE_TUTTI_WHY_DID_YOU_RENDER=0 make dev-gui
+`);
+}


### PR DESCRIPTION
## Summary
- Preserve active turn busy/runtime state while Agent GUI runtime items stream in.
- Keep /goal continuation lifecycle consistent across notification and blocking fallback paths.
- Add regression coverage and trace capture helper for Agent GUI debugging.

## Validation
- pre-push `pnpm check:full` passed during `git push`
- `pnpm lint:go` passed separately after the first hook run hit a transient concurrent lint failure


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Draft launches now open in a new window when requested.
  * Added a desktop Electron performance trace capture command.

* **Bug Fixes**
  * Improved agent busy/processing state so the UI stays responsive and shows accurate sending/stop behavior.
  * Fixed continuation handling after turn completion so follow-up actions are not missed.

* **Documentation**
  * Added guidance for troubleshooting stuck send states.
  * Expanded trace-capture instructions and examples.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->