### PR TITLE
refactor(workbench): remove deprecated dock preview field

### DIFF
--- a/packages/workbench/surface/src/host/WorkbenchHostDock.tsx
+++ b/packages/workbench/surface/src/host/WorkbenchHostDock.tsx
@@ -2235,17 +2235,10 @@ export function WorkbenchHostDock({
               };
               const descriptor =
                 popupEntry.entry.resolvePopupItem?.(item) ?? {};
-              const descriptorPreviewImageUrl =
-                descriptor.previewImageUrl ?? null;
               const descriptorPreview =
                 descriptor.preview ??
-                (descriptorPreviewImageUrl
-                  ? ({
-                      kind: "image",
-                      revision: descriptor.revision ?? null,
-                      src: descriptorPreviewImageUrl
-                    } as const)
-                  : (popupEntry.entry.providePopupItemPreview?.(item) ?? null));
+                popupEntry.entry.providePopupItemPreview?.(item) ??
+                null;
               return {
                 ...item,
                 preview: descriptorPreview,

--- a/packages/workbench/surface/src/host/types.ts
+++ b/packages/workbench/surface/src/host/types.ts
@@ -243,10 +243,6 @@ export type WorkbenchHostDockPopupPreviewProvider = (
 ) => WorkbenchDockPreviewContent | null;
 
 export interface WorkbenchHostDockPopupItemDescriptor {
-  /**
-   * @deprecated Use preview with kind: "image".
-   */
-  previewImageUrl?: string | null;
   preview?: WorkbenchDockPreviewContent | null;
   revision?: string | null;
   subtitle?: string | null;


### PR DESCRIPTION
## Summary
- remove the deprecated `previewImageUrl` field from `WorkbenchHostDockPopupItemDescriptor`
- simplify dock popup preview resolution to use structured `preview` or `providePopupItemPreview`

## Compatibility scan
- cleanup-now: deprecated dock popup descriptor image field was unused by current workbench/browser hosts and duplicated `preview: { kind: "image" }`
- required-compat: snapshot `adapterState`, host snapshot metadata keys, optional Browser Node Electron channels, host-controlled guest preload resolver, and loopback proxy fallback remain compatibility surfaces
- follow-up: consider scheduling a semver/package release note for the removed deprecated public type field

## Validation
- `pnpm --filter @tutti-os/workbench-surface test`
- `pnpm --filter @tutti-os/browser-node test`
- `pnpm typecheck`
- `pnpm check:changed --tail-lines 80`
- pre-push `pnpm check:full`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Dock popup previews now consistently use the available preview content or fallback preview provider, improving preview behavior.
  * Removed support for the older image-based preview field, simplifying how dock popup items are displayed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->