### PR TITLE
refactor(agent-gui): remove redundant title fallback

### DIFF
--- a/packages/agent/gui/shared/workspaceAgentActivityListViewModel.ts
+++ b/packages/agent/gui/shared/workspaceAgentActivityListViewModel.ts
@@ -423,27 +423,10 @@ export function resolveWorkspaceAgentActivityTitle(
 ): string {
   const sessionTitle = resolveDisplayableWorkspaceAgentSessionTitle(session);
   const userMessageTitle = firstUserMessageText(messages);
-  if (
-    sessionTitle &&
-    !isProviderPlaceholderTitleForSession(sessionTitle, session)
-  ) {
+  if (sessionTitle) {
     return sessionTitle;
   }
   return userMessageTitle || sessionTitle || workspaceAgentUntitledTaskLabel();
-}
-
-function isProviderPlaceholderTitleForSession(
-  title: string,
-  session: WorkspaceAgentActivitySession
-): boolean {
-  const provider = normalizeProvider(session.provider);
-  if (!provider) {
-    return false;
-  }
-  const normalizedTitle = title.trim().toLowerCase();
-  return (
-    workspaceAgentProviderLabel(provider).toLowerCase() === normalizedTitle
-  );
 }
 
 function resolveLatestActivity(


### PR DESCRIPTION
## Summary
- Remove a redundant conversation-title provider-placeholder fallback in `packages/agent/gui/shared/workspaceAgentActivityListViewModel.ts`.
- `resolveDisplayableWorkspaceAgentSessionTitle` already normalizes provider-label placeholders to an empty title, so the second shared-layer check was unreachable compatibility residue.

## Findings
- cleanup-now: redundant provider-placeholder title fallback in shared activity-list title projection. Removed in this PR.
- required-compat: snapshot-to-host DTO projection, imported/history tool-call snake_case canonicalization, live ACP opaque-tool fallbacks, rawInput/rawOutput render extraction, and first-user-message title fallback remain required by existing projection tests and migration docs.
- follow-up: the `buildWorkspaceAgentSessionDetailViewModel` wrapper still exists as a legacy-named compatibility entrypoint used by AgentGuiNode model code outside this task scope; remove/rename only in a controller/model follow-up.

## Validation
- `pnpm --filter @tutti-os/agent-gui test`
- `pnpm check:agent-activity-runtime-boundaries`
- `pnpm typecheck`
- pre-push `pnpm check:full`

## Documentation
- No durable documentation update: this is a narrow cleanup of unreachable shared projection fallback, with no ownership, data-flow, public API, runtime/config, or troubleshooting behavior change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Workspace activity titles now show the available session title more consistently, instead of sometimes hiding it when it matched a placeholder-style label.
  * This makes session entries easier to identify in the workspace activity list.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->