### PR TITLE
fix(agent): stabilize agent activity updates

### DIFF
--- a/apps/desktop/src/renderer/src/features/workspace-workbench/ui/WorkspaceChrome.test.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/ui/WorkspaceChrome.test.ts
@@ -47,6 +47,22 @@ test("workspace chrome does not call updateSessionSettings or sendInput from the
   assert.match(source, /onSubmitPrompt=\{handleMessageCenterSubmitPrompt\}/);
 });
 
+test("workspace chrome coalesces agent activity snapshot notifications before notifying React", () => {
+  assert.match(
+    source,
+    /function createCoalescedWorkspaceAgentActivityListener\(listener: \(\) => void\)/
+  );
+  assert.match(
+    source,
+    /frameId = requestAnimationFrame\(flush\);\s*timeoutId = setTimeout\(\s*flush,\s*WORKSPACE_AGENT_ACTIVITY_LISTENER_MAX_DELAY_MS\s*\);/
+  );
+  assert.match(source, /coalescedListener\.schedule\(\);/);
+  assert.doesNotMatch(
+    source,
+    /workspaceAgentActivityService\.subscribe\(\s*workspace\.id,\s*\(nextSnapshot\) => \{[\s\S]*?listener\(\);[\s\S]*?\}\s*\)/
+  );
+});
+
 test("workspace chrome gates the agent decision toast on window focus, message center visibility, and the session's own AgentGUI window", () => {
   // The decision toast must consult message-center visibility, window focus,
   // and whether the session's own AgentGUI window is already open (via

--- a/apps/desktop/src/renderer/src/features/workspace-workbench/ui/WorkspaceChrome.tsx
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/ui/WorkspaceChrome.tsx
@@ -97,6 +97,7 @@ const WORKSPACE_CHROME_MAC_TRAFFIC_LIGHT_GUTTER_PX = 64;
 const WORKSPACE_CHROME_MAC_TRAFFIC_LIGHT_RESERVED_WIDTH_PX =
   WORKSPACE_CHROME_MAC_TRAFFIC_LIGHT_INSET_PX +
   WORKSPACE_CHROME_MAC_TRAFFIC_LIGHT_GUTTER_PX;
+const WORKSPACE_AGENT_ACTIVITY_LISTENER_MAX_DELAY_MS = 50;
 const workspaceAgentDecisionToastClassName = "workspace-agent-decision-toast";
 const AGENT_STATUS_PET_SOURCES = {
   failed: new URL(
@@ -125,6 +126,55 @@ const AGENT_STATUS_PET_SOURCES = {
 
 type AgentStatusPetMood = WorkspaceAgentStatusPetMood &
   keyof typeof AGENT_STATUS_PET_SOURCES;
+
+function createCoalescedWorkspaceAgentActivityListener(listener: () => void): {
+  cancel(): void;
+  schedule(): void;
+} {
+  let frameId: number | null = null;
+  let timeoutId: ReturnType<typeof setTimeout> | null = null;
+  let canceled = false;
+
+  const clearScheduled = (): void => {
+    if (frameId !== null) {
+      cancelAnimationFrame(frameId);
+      frameId = null;
+    }
+    if (timeoutId !== null) {
+      clearTimeout(timeoutId);
+      timeoutId = null;
+    }
+  };
+
+  const flush = (): void => {
+    if (canceled) {
+      return;
+    }
+    clearScheduled();
+    listener();
+  };
+
+  return {
+    cancel() {
+      canceled = true;
+      clearScheduled();
+    },
+    schedule() {
+      if (frameId !== null || timeoutId !== null) {
+        return;
+      }
+      if (typeof requestAnimationFrame === "function") {
+        frameId = requestAnimationFrame(flush);
+        timeoutId = setTimeout(
+          flush,
+          WORKSPACE_AGENT_ACTIVITY_LISTENER_MAX_DELAY_MS
+        );
+        return;
+      }
+      timeoutId = setTimeout(flush, 0);
+    }
+  };
+}
 
 export function WorkspaceChrome({
   headerSlot,
@@ -314,15 +364,29 @@ function WorkspaceAgentMessageCenterAction({
     null
   );
   const messageCenterModelWorkspaceIdRef = useRef<string | null>(null);
+  const subscribeSnapshot = useCallback(
+    (listener: () => void) => {
+      const coalescedListener =
+        createCoalescedWorkspaceAgentActivityListener(listener);
+      const unsubscribe = workspaceAgentActivityService.subscribe(
+        workspace.id,
+        (nextSnapshot) => {
+          snapshotRef.current = {
+            snapshot: nextSnapshot,
+            workspaceId: workspace.id
+          };
+          coalescedListener.schedule();
+        }
+      );
+      return () => {
+        coalescedListener.cancel();
+        unsubscribe();
+      };
+    },
+    [workspace.id, workspaceAgentActivityService]
+  );
   const snapshot = useSyncExternalStore(
-    (listener) =>
-      workspaceAgentActivityService.subscribe(workspace.id, (nextSnapshot) => {
-        snapshotRef.current = {
-          snapshot: nextSnapshot,
-          workspaceId: workspace.id
-        };
-        listener();
-      }),
+    subscribeSnapshot,
     () => {
       if (snapshotRef.current?.workspaceId === workspace.id) {
         return snapshotRef.current.snapshot;

--- a/docs/architecture/agent-gui-node.md
+++ b/docs/architecture/agent-gui-node.md
@@ -679,12 +679,14 @@ composer submit with no activeConversationId
   -> projection + UI refresh
 ```
 
-For normal first-message creation, the UI stays on the home composer while
-activation is pending. The home composer uses its existing busy/send-button
-state; it does not show a separate "creating session" text and it does not enter
-conversation detail just to show "connecting conversation". After activation
-succeeds, the controller attaches the conversation and records the optimistic
-user message before loading runtime projection. For Claude Code,
+For normal first-message creation, the controller creates an optimistic
+conversation id and enters that conversation surface immediately while
+activation is pending. The optimistic session is not durable yet, so any
+ordinary follow-up submit targeting `startingConversationIdRef.current` must
+enter the local queued-prompt runtime instead of calling `sendInput` directly.
+After activation succeeds, the controller attaches the durable conversation and
+reconciles the optimistic user message before loading runtime projection. For
+Claude Code,
 `desktopAgentActivityAdapter.createSession` may promote a pre-warmed hidden draft
 session before calling `sendWorkspaceAgentSessionInput`. Create-time-only launch
 options must opt out of that promotion path because the hidden draft has already
@@ -1208,6 +1210,14 @@ never inferred from the cancel outcome.
 Preview-mode AgentGUI surfaces are read-only for this runtime: they may render an
 existing queue if injected into the same context, but they must not enqueue,
 claim, drain, promote, edit, or delete queued prompts.
+
+Queued prompt previews must treat prompt image blocks as the same send contract
+used by the composer and runtime: an image may be inline `data` or a staged
+`path`. Do not cast queued images to data-only blocks or build thumbnail URLs
+from `image.data` without checking it. Path-backed queued prompt thumbnails
+should use the activity runtime prompt-asset reader when workspace/session
+context is available, and otherwise avoid rendering a broken image while
+keeping the queued content unchanged for sending.
 
 ### Approval And Ask-User Prompts
 

--- a/packages/agent/daemon/runtime/controller.go
+++ b/packages/agent/daemon/runtime/controller.go
@@ -50,8 +50,10 @@ type sessionLifecycleLock struct {
 }
 
 type activeTurn struct {
-	turnID string
-	cancel context.CancelFunc
+	turnID                string
+	cancel                context.CancelFunc
+	openCallIDs           map[string]struct{}
+	pendingTerminalEvents []activityshared.Event
 }
 
 type reportRequest struct {
@@ -1245,6 +1247,10 @@ func (c *Controller) runAsyncExecTurn(ctx context.Context, session Session, adap
 		}
 		mu.Lock()
 		defer mu.Unlock()
+		events = c.asyncTurnEventsReadyForFold(session, turnID, events)
+		if len(events) == 0 {
+			return
+		}
 		session = c.foldTurnSessionEvents(session, events, turnID)
 		if shouldAdvanceSessionUpdatedAtFromEvents(events) {
 			session.UpdatedAtUnixMS = unixMS(now())
@@ -1280,6 +1286,91 @@ func (c *Controller) runAsyncExecTurn(ctx context.Context, session Session, adap
 		}
 		emit(events)
 	}
+}
+
+func (c *Controller) asyncTurnEventsReadyForFold(session Session, turnID string, events []activityshared.Event) []activityshared.Event {
+	turnID = strings.TrimSpace(turnID)
+	if c == nil || turnID == "" || len(events) == 0 {
+		return events
+	}
+	key := sessionKey(session.RoomID, session.AgentSessionID)
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	turn, ok := c.turns[key]
+	if !ok || strings.TrimSpace(turn.turnID) != turnID {
+		return events
+	}
+	if turn.openCallIDs == nil {
+		turn.openCallIDs = make(map[string]struct{})
+	}
+	for _, event := range events {
+		trackAsyncTurnCallEvent(turn.openCallIDs, event, turnID)
+	}
+	var ready []activityshared.Event
+	var terminal []activityshared.Event
+	for _, event := range events {
+		if asyncEventCompletesTurnSuccessfully(event, turnID) {
+			terminal = append(terminal, event)
+			continue
+		}
+		ready = append(ready, event)
+	}
+	if len(terminal) > 0 && len(turn.openCallIDs) > 0 {
+		turn.pendingTerminalEvents = append(turn.pendingTerminalEvents, terminal...)
+	} else {
+		ready = events
+	}
+	if len(turn.openCallIDs) == 0 && len(turn.pendingTerminalEvents) > 0 {
+		ready = append(ready, turn.pendingTerminalEvents...)
+		turn.pendingTerminalEvents = nil
+	}
+	c.turns[key] = turn
+	return ready
+}
+
+func trackAsyncTurnCallEvent(openCallIDs map[string]struct{}, event activityshared.Event, turnID string) {
+	if len(openCallIDs) == 0 && event.Type != activityshared.EventCallStarted {
+		return
+	}
+	if strings.TrimSpace(event.Payload.TurnID) != turnID {
+		return
+	}
+	callID := asyncTurnCallTrackingID(event)
+	if callID == "" {
+		return
+	}
+	switch event.Type {
+	case activityshared.EventCallStarted:
+		openCallIDs[callID] = struct{}{}
+	case activityshared.EventCallCompleted, activityshared.EventCallFailed:
+		delete(openCallIDs, callID)
+	}
+}
+
+func asyncTurnCallTrackingID(event activityshared.Event) string {
+	if callID := strings.TrimSpace(event.Payload.CallID); callID != "" {
+		return callID
+	}
+	return strings.TrimSpace(event.EventID)
+}
+
+func asyncEventCompletesTurnSuccessfully(event activityshared.Event, turnID string) bool {
+	if strings.TrimSpace(event.Payload.TurnID) == turnID {
+		if event.Type == activityshared.EventTurnCompleted {
+			outcome := strings.TrimSpace(event.Payload.TurnOutcome)
+			return outcome == "" || outcome == string(activityshared.TurnOutcomeCompleted)
+		}
+	}
+	snapshot, ok := activityshared.TurnLifecycleSnapshotFromEvent(event)
+	if !ok || strings.TrimSpace(snapshot.Phase) != string(activityshared.TurnPhaseSettled) {
+		return false
+	}
+	outcome := strings.TrimSpace(snapshot.Outcome)
+	if outcome != "" && outcome != string(activityshared.TurnOutcomeCompleted) {
+		return false
+	}
+	return strings.TrimSpace(event.Payload.TurnID) == turnID ||
+		strings.TrimSpace(snapshot.ActiveTurnID) == turnID
 }
 
 func turnHasTerminalEvent(events []activityshared.Event, turnID string) bool {

--- a/packages/agent/daemon/runtime/controller_test.go
+++ b/packages/agent/daemon/runtime/controller_test.go
@@ -2623,10 +2623,11 @@ func (a *lifecycleSnapshotAsyncExecAdapter) ExecAsync(_ context.Context, session
 			"phase": string(activityshared.TurnPhaseIdle),
 		})
 		activityshared.StampTurnLifecycleSnapshot(&event, activityshared.TurnLifecycleSnapshot{
-			Origin:  activityshared.TurnLifecycleOriginAdapter,
-			Seq:     1,
-			Phase:   string(activityshared.TurnPhaseSettled),
-			Outcome: string(activityshared.TurnOutcomeCompleted),
+			Origin:       activityshared.TurnLifecycleOriginAdapter,
+			Seq:          1,
+			ActiveTurnID: turnID,
+			Phase:        string(activityshared.TurnPhaseSettled),
+			Outcome:      string(activityshared.TurnOutcomeCompleted),
 		})
 		emit([]activityshared.Event{event})
 	}
@@ -2635,6 +2636,66 @@ func (a *lifecycleSnapshotAsyncExecAdapter) ExecAsync(_ context.Context, session
 }
 
 func (*lifecycleSnapshotAsyncExecAdapter) Cancel(context.Context, Session, string) ([]activityshared.Event, error) {
+	return nil, nil
+}
+
+type terminalBeforeCallCompleteAsyncAdapter struct {
+	callStarted      chan struct{}
+	terminalReturned chan struct{}
+	releaseCall      chan struct{}
+}
+
+func (*terminalBeforeCallCompleteAsyncAdapter) Provider() string { return ProviderCodex }
+
+func (*terminalBeforeCallCompleteAsyncAdapter) Start(context.Context, Session) ([]activityshared.Event, error) {
+	return nil, nil
+}
+
+func (*terminalBeforeCallCompleteAsyncAdapter) Resume(context.Context, Session) error { return nil }
+
+func (*terminalBeforeCallCompleteAsyncAdapter) Close(context.Context, Session) error { return nil }
+
+func (*terminalBeforeCallCompleteAsyncAdapter) Exec(context.Context, Session, []PromptContentBlock, string, string, EventSink, CommandSnapshotSink) ([]activityshared.Event, error) {
+	return nil, nil
+}
+
+func (a *terminalBeforeCallCompleteAsyncAdapter) ExecAsync(_ context.Context, session Session, _ []PromptContentBlock, _ string, turnID string, emit EventSink, _ CommandSnapshotSink) error {
+	if emit != nil {
+		emit([]activityshared.Event{
+			newTurnActivityEventWithID(session, "call-1-start", EventCallStarted, turnID, messageStreamStateStreaming, "", "Run command", map[string]any{
+				"callId": "call-1",
+			}),
+		})
+	}
+	a.callStarted <- struct{}{}
+	if emit != nil {
+		event := newTurnActivityEventWithID(session, "turn-1-settled", EventTurnUpdated, turnID, SessionStatusReady, "", "", map[string]any{
+			"phase": string(activityshared.TurnPhaseIdle),
+		})
+		activityshared.StampTurnLifecycleSnapshot(&event, activityshared.TurnLifecycleSnapshot{
+			Origin:       activityshared.TurnLifecycleOriginAdapter,
+			Seq:          1,
+			ActiveTurnID: turnID,
+			Phase:        string(activityshared.TurnPhaseSettled),
+			Outcome:      string(activityshared.TurnOutcomeCompleted),
+		})
+		emit([]activityshared.Event{event})
+	}
+	a.terminalReturned <- struct{}{}
+	go func() {
+		<-a.releaseCall
+		if emit != nil {
+			emit([]activityshared.Event{
+				newTurnActivityEventWithID(session, "call-1-complete", EventCallCompleted, turnID, messageStreamStateCompleted, "", "Run command", map[string]any{
+					"callId": "call-1",
+				}),
+			})
+		}
+	}()
+	return nil
+}
+
+func (*terminalBeforeCallCompleteAsyncAdapter) Cancel(context.Context, Session, string) ([]activityshared.Event, error) {
 	return nil, nil
 }
 
@@ -3194,6 +3255,67 @@ func TestControllerExecUsesAsyncAdapterAndFinalizesFromTerminalEvent(t *testing.
 	session := waitForSessionStatus(t, controller, "room-1", started.Session.AgentSessionID, SessionStatusReady)
 	if controller.HasActiveTurn("room-1", started.Session.AgentSessionID) {
 		t.Fatal("HasActiveTurn = true after async terminal event")
+	}
+	if session.TurnLifecycle == nil || session.TurnLifecycle.Phase != "settled" {
+		t.Fatalf("turn lifecycle = %#v, want settled", session.TurnLifecycle)
+	}
+}
+
+func TestControllerExecDefersAsyncTerminalEventUntilOpenCallCompletes(t *testing.T) {
+	t.Parallel()
+
+	adapter := &terminalBeforeCallCompleteAsyncAdapter{
+		callStarted:      make(chan struct{}, 1),
+		terminalReturned: make(chan struct{}, 1),
+		releaseCall:      make(chan struct{}),
+	}
+	controller := NewController([]Adapter{adapter}, nil)
+	started, err := controller.Start(context.Background(), StartInput{
+		RoomID:         "room-1",
+		AgentSessionID: "agent-session-1",
+		Provider:       ProviderCodex,
+		Title:          "Test",
+	})
+	if err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	if _, err := controller.Exec(context.Background(), ExecInput{
+		RoomID:         "room-1",
+		AgentSessionID: started.Session.AgentSessionID,
+		Content:        textPrompt("run"),
+	}); err != nil {
+		t.Fatalf("Exec: %v", err)
+	}
+	select {
+	case <-adapter.callStarted:
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for call start")
+	}
+	select {
+	case <-adapter.terminalReturned:
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for terminal event")
+	}
+	session, ok := controller.get("room-1", started.Session.AgentSessionID)
+	if !ok {
+		t.Fatal("session missing")
+	}
+	if session.Status != SessionStatusWorking {
+		t.Fatalf("session status = %q, want working while call is open", session.Status)
+	}
+	if session.SubmitAvailability == nil ||
+		session.SubmitAvailability.State != "blocked" ||
+		session.SubmitAvailability.Reason != "active_turn" {
+		t.Fatalf("submit availability = %#v, want blocked active_turn", session.SubmitAvailability)
+	}
+	if !controller.HasActiveTurn("room-1", started.Session.AgentSessionID) {
+		t.Fatal("HasActiveTurn = false before open call completes")
+	}
+
+	close(adapter.releaseCall)
+	session = waitForSessionStatus(t, controller, "room-1", started.Session.AgentSessionID, SessionStatusReady)
+	if controller.HasActiveTurn("room-1", started.Session.AgentSessionID) {
+		t.Fatal("HasActiveTurn = true after open call completes")
 	}
 	if session.TurnLifecycle == nil || session.TurnLifecycle.Phase != "settled" {
 		t.Fatalf("turn lifecycle = %#v, want settled", session.TurnLifecycle)

--- a/packages/agent/gui/agent-gui/agentGuiNode/AgentComposer.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/AgentComposer.tsx
@@ -3573,7 +3573,9 @@ export function AgentComposer({
             onSendQueuedPromptNext={onSendQueuedPromptNext}
             onRemoveQueuedPrompt={onRemoveQueuedPrompt}
             onEditQueuedPrompt={onEditQueuedPrompt}
+            agentSessionId={slashStatusAgentSessionId}
             onLinkClick={handleLinkClick}
+            workspaceId={workspaceId}
             workspaceAppIcons={workspaceAppIcons}
           />
         </div>

--- a/packages/agent/gui/agent-gui/agentGuiNode/AgentGUINodeView.layout.spec.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/AgentGUINodeView.layout.spec.tsx
@@ -279,6 +279,40 @@ describe("AgentGUINodeView layout persistence", () => {
     );
   });
 
+  it("keeps the conversation rail stable when the active conversation object refreshes", () => {
+    const actions = createActions();
+    const labels = createLabels();
+    const conversation = createConversationSummary("session-1", {
+      title: "Stable conversation"
+    });
+    const viewModel = createViewModel({
+      activeConversationId: "session-1",
+      activeConversation: conversation,
+      conversations: [conversation]
+    });
+    const { rerender } = renderAgentGUINodeView({
+      actions,
+      labels,
+      viewModel
+    });
+
+    expect(conversationMetaMock.calls).toContain("session-1");
+    conversationMetaMock.calls = [];
+
+    rerender(
+      buildAgentGUINodeViewElement({
+        actions,
+        labels,
+        viewModel: {
+          ...viewModel,
+          activeConversation: { ...conversation }
+        }
+      })
+    );
+
+    expect(conversationMetaMock.calls).toEqual([]);
+  });
+
   it("renders an injected provider rail footer with neutral context", () => {
     const activeConversation = createConversationSummary("session-1", {
       title: "Active conversation"

--- a/packages/agent/gui/agent-gui/agentGuiNode/AgentGUINodeView.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/AgentGUINodeView.tsx
@@ -193,6 +193,7 @@ import {
   createAgentSessionMentionHref,
   formatAgentMentionMarkdown
 } from "./agentRichText/agentFileMentionExtension";
+import { AgentMentionTooltipProviderScope } from "./agentRichText/AgentMentionNodeView";
 import { createRichTextMentionHref } from "@tutti-os/ui-rich-text/core";
 import { resolveAgentGuiSessionProviderFlatIconUrl } from "../../agentGuiSessionProviderIconUrls";
 import { agentColorfulUrl } from "../../managedAgentIconAssets";
@@ -1675,7 +1676,7 @@ export function AgentGUINodeView({
   >(null);
   const [renameConversationDialogOpen, setRenameConversationDialogOpen] =
     useState(false);
-  const requestRenameConversation = useCallback(
+  const requestRenameConversation = useStableEventCallback(
     (agentSessionId: string) => {
       const target =
         viewModel.conversations.find(
@@ -1688,8 +1689,7 @@ export function AgentGUINodeView({
         setRenameConversationTarget(target);
         setRenameConversationDialogOpen(true);
       }
-    },
-    [viewModel.activeConversation, viewModel.conversations]
+    }
   );
   const conversationRailStoreState =
     useMemo<AgentGUIConversationRailStoreSnapshot>(
@@ -2020,7 +2020,13 @@ export function AgentGUINodeView({
     </AgentTargetPresentationProvider>
   );
 
-  return previewMode ? content : <TooltipProvider>{content}</TooltipProvider>;
+  return (
+    <TooltipProvider>
+      <AgentMentionTooltipProviderScope withTooltipProvider={false}>
+        {content}
+      </AgentMentionTooltipProviderScope>
+    </TooltipProvider>
+  );
 }
 
 interface AgentGUIRenameConversationDialogProps {

--- a/packages/agent/gui/agent-gui/agentGuiNode/AgentQueuedPromptPanel.spec.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/AgentQueuedPromptPanel.spec.tsx
@@ -1,6 +1,11 @@
 import "@testing-library/jest-dom/vitest";
-import { fireEvent, render, screen } from "@testing-library/react";
-import { describe, expect, it, vi } from "vitest";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  resetAgentActivityRuntimeForTests,
+  setAgentActivityRuntimeForTests,
+  type AgentActivityRuntime
+} from "../../agentActivityRuntime";
 import { AgentQueuedPromptPanel } from "./AgentQueuedPromptPanel";
 
 const labels = {
@@ -10,6 +15,10 @@ const labels = {
   deleteQueuedPrompt: "Delete",
   queuedPromptMoreActions: "More"
 };
+
+afterEach(() => {
+  resetAgentActivityRuntimeForTests();
+});
 
 function textQueuedPrompt(id: string, text: string, createdAtUnixMs = 1) {
   return {
@@ -228,6 +237,59 @@ describe("AgentQueuedPromptPanel", () => {
     expect(editItem).not.toHaveAttribute("aria-disabled", "true");
     fireEvent.click(editItem);
     expect(onEditQueuedPrompt).toHaveBeenCalledWith("queued-1");
+  });
+
+  it("loads path-backed queued image prompt previews without rendering undefined data urls", async () => {
+    const readPromptAsset = vi.fn(async () => ({
+      data: "c3RhZ2VkLWltYWdl",
+      mimeType: "image/png",
+      name: "staged.png",
+      path: "/agent-prompt-assets/staged.png"
+    }));
+    setAgentActivityRuntimeForTests({
+      readPromptAsset
+    } as unknown as AgentActivityRuntime);
+
+    const { container } = render(
+      <AgentQueuedPromptPanel
+        workspaceId="workspace-1"
+        agentSessionId="session-1"
+        queuedPrompts={[
+          {
+            id: "queued-1",
+            content: [
+              {
+                type: "image",
+                mimeType: "image/png",
+                path: "/agent-prompt-assets/staged.png",
+                name: "staged.png"
+              }
+            ],
+            createdAtUnixMs: 1
+          }
+        ]}
+        drainingQueuedPromptId={null}
+        labels={labels}
+        onSendQueuedPromptNext={vi.fn()}
+        onRemoveQueuedPrompt={vi.fn()}
+        onEditQueuedPrompt={vi.fn()}
+      />
+    );
+
+    expect(container.innerHTML).not.toContain("base64,undefined");
+
+    await waitFor(() => {
+      expect(readPromptAsset).toHaveBeenCalledWith({
+        workspaceId: "workspace-1",
+        agentSessionId: "session-1",
+        mimeType: "image/png",
+        name: "staged.png",
+        path: "/agent-prompt-assets/staged.png"
+      });
+      expect(
+        container.querySelector(".agent-gui-node__composer-queued-prompt-image")
+      ).toHaveAttribute("src", "data:image/png;base64,c3RhZ2VkLWltYWdl");
+    });
   });
 
   it("allows queued image prompt previews to zoom", () => {

--- a/packages/agent/gui/agent-gui/agentGuiNode/AgentQueuedPromptPanel.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/AgentQueuedPromptPanel.tsx
@@ -1,5 +1,7 @@
 import {
+  useEffect,
   useLayoutEffect,
+  useMemo,
   useRef,
   useState,
   type CSSProperties,
@@ -17,6 +19,7 @@ import {
   AgentMessageMarkdown,
   type AgentMessageMarkdownWorkspaceAppIcon
 } from "../../shared/AgentMessageMarkdown";
+import { useOptionalAgentActivityRuntime } from "../../agentActivityRuntime";
 import type { AgentPromptContentBlock } from "../../shared/contracts/dto/agentSession";
 import type { AgentGUIQueuedPromptVM } from "./model/agentGuiNodeTypes";
 import {
@@ -38,7 +41,8 @@ const EMPTY_WORKSPACE_APP_ICONS: readonly AgentMessageMarkdownWorkspaceAppIcon[]
 type QueuedPromptImageBlock = AgentPromptContentBlock & {
   type: "image";
   mimeType: "image/png" | "image/jpeg" | "image/webp";
-  data: string;
+  data?: string;
+  path?: string;
 };
 
 interface AgentQueuedPromptPanelProps {
@@ -54,16 +58,108 @@ interface AgentQueuedPromptPanelProps {
   onSendQueuedPromptNext: (queuedPromptId: string) => void;
   onRemoveQueuedPrompt: (queuedPromptId: string) => void;
   onEditQueuedPrompt: (queuedPromptId: string) => void;
+  agentSessionId?: string | null;
   onLinkClick?: (href: string) => void;
+  workspaceId?: string | null;
   workspaceAppIcons?: readonly AgentMessageMarkdownWorkspaceAppIcon[];
 }
 
 function queuedPromptImages(
   queuedPrompt: AgentGUIQueuedPromptVM
 ): QueuedPromptImageBlock[] {
-  return agentPromptContentImageBlocks(
-    queuedPrompt.content
-  ) as QueuedPromptImageBlock[];
+  return agentPromptContentImageBlocks(queuedPrompt.content);
+}
+
+function queuedPromptImageDataUrl(
+  image: QueuedPromptImageBlock
+): string | null {
+  const data = image.data?.trim() ?? "";
+  const mimeType = image.mimeType.trim();
+  if (!data || !mimeType) {
+    return null;
+  }
+  return data.startsWith("data:") ? data : `data:${mimeType};base64,${data}`;
+}
+
+function queuedPromptImageKey(
+  queuedPrompt: AgentGUIQueuedPromptVM,
+  image: QueuedPromptImageBlock,
+  index: number
+): string {
+  return [
+    queuedPrompt.id,
+    index,
+    image.path?.trim() ?? "",
+    image.name?.trim() ?? "",
+    image.mimeType
+  ].join(":");
+}
+
+function useQueuedPromptImageSources(input: {
+  agentSessionId?: string | null;
+  images: readonly {
+    image: QueuedPromptImageBlock;
+    key: string;
+  }[];
+  workspaceId?: string | null;
+}): ReadonlyMap<string, string> {
+  const runtime = useOptionalAgentActivityRuntime();
+  const [sources, setSources] = useState<Map<string, string>>(() => new Map());
+  const workspaceId = input.workspaceId?.trim() ?? "";
+  const agentSessionId = input.agentSessionId?.trim() ?? "";
+  const missingImages = useMemo(
+    () =>
+      input.images.filter(({ image, key }) => {
+        const path = image.path?.trim() ?? "";
+        return (
+          !queuedPromptImageDataUrl(image) &&
+          !sources.has(key) &&
+          Boolean(path) &&
+          Boolean(workspaceId)
+        );
+      }),
+    [input.images, sources, workspaceId]
+  );
+
+  useEffect(() => {
+    if (!runtime?.readPromptAsset || missingImages.length === 0) {
+      return;
+    }
+    let canceled = false;
+    for (const { image, key } of missingImages) {
+      const path = image.path?.trim() ?? "";
+      if (!path) {
+        continue;
+      }
+      void runtime
+        .readPromptAsset({
+          workspaceId,
+          agentSessionId,
+          mimeType: image.mimeType,
+          name: image.name,
+          path
+        })
+        .then((asset) => {
+          if (canceled) {
+            return;
+          }
+          setSources((current) => {
+            if (current.has(key)) {
+              return current;
+            }
+            const next = new Map(current);
+            next.set(key, `data:${asset.mimeType};base64,${asset.data}`);
+            return next;
+          });
+        })
+        .catch(() => {});
+    }
+    return () => {
+      canceled = true;
+    };
+  }, [agentSessionId, missingImages, runtime, workspaceId]);
+
+  return sources;
 }
 
 /**
@@ -97,7 +193,9 @@ export function AgentQueuedPromptPanel({
   onSendQueuedPromptNext,
   onRemoveQueuedPrompt,
   onEditQueuedPrompt,
+  agentSessionId = null,
   onLinkClick,
+  workspaceId = null,
   workspaceAppIcons = EMPTY_WORKSPACE_APP_ICONS
 }: AgentQueuedPromptPanelProps): React.JSX.Element {
   "use memo";
@@ -108,6 +206,23 @@ export function AgentQueuedPromptPanel({
   const [isSinglePromptOverflowing, setIsSinglePromptOverflowing] =
     useState(false);
   const [expandedListMaxHeightPx, setExpandedListMaxHeightPx] = useState(280);
+  const queuedPromptImageEntries = useMemo(
+    () =>
+      queuedPrompts.flatMap((queuedPrompt) =>
+        queuedPromptImages(queuedPrompt)
+          .slice(0, 3)
+          .map((image, index) => ({
+            image,
+            key: queuedPromptImageKey(queuedPrompt, image, index)
+          }))
+      ),
+    [queuedPrompts]
+  );
+  const queuedPromptImageSources = useQueuedPromptImageSources({
+    agentSessionId,
+    images: queuedPromptImageEntries,
+    workspaceId
+  });
   const singlePromptHasImages =
     queuedPrompts.length === 1 &&
     queuedPromptImages(queuedPrompts[0]!).length > 0;
@@ -293,10 +408,20 @@ export function AgentQueuedPromptPanel({
                   {images.length > 0 ? (
                     <div className={styles.composerQueuedPromptImages}>
                       {images.slice(0, 3).map((image, index) => {
-                        const src = `data:${image.mimeType};base64,${image.data}`;
+                        const imageKey = queuedPromptImageKey(
+                          queuedPrompt,
+                          image,
+                          index
+                        );
+                        const src =
+                          queuedPromptImageSources.get(imageKey) ??
+                          queuedPromptImageDataUrl(image);
+                        if (!src) {
+                          return null;
+                        }
                         return (
                           <ZoomableImage
-                            key={`${queuedPrompt.id}:image:${index}`}
+                            key={imageKey}
                             alt={image.name?.trim() || ""}
                             className={styles.composerQueuedPromptImage}
                             draggable={false}

--- a/packages/agent/gui/agent-gui/agentGuiNode/agentRichText/AgentMentionNodeView.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/agentRichText/AgentMentionNodeView.tsx
@@ -1,4 +1,12 @@
-import { useEffect, useState, type JSX, type MouseEvent } from "react";
+import {
+  createContext,
+  useContext,
+  useEffect,
+  useState,
+  type JSX,
+  type MouseEvent,
+  type ReactNode
+} from "react";
 import { NodeViewWrapper, type NodeViewProps } from "@tiptap/react";
 import {
   MentionPill,
@@ -44,6 +52,22 @@ interface AgentMentionNodeViewModel {
   thumbnailUrl?: string;
   /** 引用文件数量(workspace-reference 专用)。 */
   fileCount?: number;
+}
+
+const AgentMentionTooltipProviderContext = createContext(true);
+
+export function AgentMentionTooltipProviderScope({
+  children,
+  withTooltipProvider
+}: {
+  children: ReactNode;
+  withTooltipProvider: boolean;
+}): JSX.Element {
+  return (
+    <AgentMentionTooltipProviderContext value={withTooltipProvider}>
+      {children}
+    </AgentMentionTooltipProviderContext>
+  );
 }
 
 function attrString(attrs: Record<string, unknown>, key: string): string {
@@ -418,6 +442,7 @@ function AgentMentionLegacyFileNodeView({
 export function AgentMentionNodeView(props: NodeViewProps): JSX.Element {
   const { deleteNode, editor, extension, node, selected } = props;
   const { t } = useTranslation();
+  const withTooltipProvider = useContext(AgentMentionTooltipProviderContext);
   const mention = mentionViewModel(node.attrs ?? {}, t);
   const [isEditable, setIsEditable] = useState(editor.isEditable);
   const extensionOptions = extension.options as {
@@ -520,7 +545,10 @@ export function AgentMentionNodeView(props: NodeViewProps): JSX.Element {
               </button>
             ) : null}
           </span>
-          <TruncatingPillLabel tooltip={mention.label}>
+          <TruncatingPillLabel
+            tooltip={mention.label}
+            withTooltipProvider={withTooltipProvider}
+          >
             {mention.label}
           </TruncatingPillLabel>
         </span>
@@ -627,6 +655,7 @@ export function AgentMentionNodeView(props: NodeViewProps): JSX.Element {
             : undefined
         }
         summary={mention.summary}
+        withTooltipProvider={withTooltipProvider}
       />
     </NodeViewWrapper>
   );

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUINodeController.spec.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUINodeController.spec.tsx
@@ -6940,6 +6940,65 @@ describe("useAgentGUINodeController", () => {
     expect(exec).not.toHaveBeenCalled();
   });
 
+  it("queues a follow-up prompt while the first conversation is still being created", async () => {
+    const activate = vi.fn((input: AgentHostActivateAgentSessionInput) => {
+      if (input.mode === "new") {
+        return new Promise<AgentHostActivateAgentSessionResult>(() => {
+          // Keep creation pending so the optimistic session is not durable yet.
+        });
+      }
+      return Promise.resolve({
+        session: agentSession(input.agentSessionId),
+        activation: { mode: input.mode, status: "attached" as const }
+      });
+    });
+    const exec = vi.fn(async () => ({ turnId: "turn-1" }));
+    installAgentHostApi({
+      list: vi.fn(async () => ({ presences: [], sessions: [] })),
+      listSessionTimeline: vi.fn(async () => ({ timelineItems: [] })),
+      subscribeEvents: vi.fn(() => vi.fn()),
+      activate,
+      exec
+    });
+
+    const { result } = renderHook(() =>
+      useAgentGUINodeController({
+        workspaceId: "room-1",
+        currentUserId: "user-1",
+        workspacePath: "/workspace",
+        avoidGroupingEdits: false,
+        data: agentGuiData(null),
+        onDataChange: vi.fn()
+      })
+    );
+
+    act(() => {
+      result.current.actions.submitPrompt(promptBlocks("first prompt"));
+    });
+
+    await waitFor(() => {
+      expect(activate).toHaveBeenCalledWith(
+        expect.objectContaining({ mode: "new" })
+      );
+    });
+    const createdId = activate.mock.calls[0]![0].agentSessionId;
+    expect(result.current.viewModel.activeConversationId).toBe(createdId);
+    expect(result.current.viewModel.isCreatingConversation).toBe(true);
+    expect(result.current.viewModel.canQueueWhileBusy).toBe(true);
+
+    act(() => {
+      result.current.actions.updateDraftContent(draftContent("second prompt"));
+      result.current.actions.submitPrompt(promptBlocks("second prompt"));
+    });
+
+    await waitFor(() => {
+      expect(queuedPromptTexts(result.current.viewModel.queuedPrompts)).toEqual(
+        ["second prompt"]
+      );
+    });
+    expect(exec).not.toHaveBeenCalled();
+  });
+
   it("restores the original home draft when first conversation activation fails after pending", async () => {
     let rejectActivation: ((error: unknown) => void) | undefined;
     const activate = vi.fn((input: AgentHostActivateAgentSessionInput) => {
@@ -17405,6 +17464,35 @@ describe("useAgentGUINodeController", () => {
       });
     });
     expect(result.current.viewModel.queuedPrompts).toEqual([]);
+  });
+
+  it("keeps the empty queued prompts reference stable across active session rerenders", async () => {
+    installAgentHostApi({
+      list: vi.fn(async () => snapshotWithSession("session-1")),
+      listSessionTimeline: vi.fn(async () => ({ timelineItems: [] })),
+      subscribeEvents: vi.fn(() => vi.fn())
+    });
+
+    const { rerender, result } = renderHook(() =>
+      useAgentGUINodeController({
+        workspaceId: "room-1",
+        currentUserId: "user-1",
+        workspacePath: "/workspace",
+        avoidGroupingEdits: false,
+        data: agentGuiData("session-1"),
+        onDataChange: vi.fn()
+      })
+    );
+
+    await waitFor(() => {
+      expect(result.current.viewModel.activeConversationId).toBe("session-1");
+    });
+    expect(result.current.viewModel.queuedPrompts).toHaveLength(0);
+    const firstQueuedPrompts = result.current.viewModel.queuedPrompts;
+
+    rerender();
+
+    expect(result.current.viewModel.queuedPrompts).toBe(firstQueuedPrompts);
   });
 
   it("queues image prompts locally while busy without draining from the controller", async () => {

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUINodeController.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUINodeController.ts
@@ -8894,6 +8894,12 @@ export function useAgentGUINodeController({
       if (!normalizedAgentSessionId) {
         return false;
       }
+      if (
+        isCreatingConversationRef.current &&
+        startingConversationIdRef.current === normalizedAgentSessionId
+      ) {
+        return true;
+      }
       if (pendingTurnIdBySessionIdRef.current[normalizedAgentSessionId]) {
         return true;
       }
@@ -11184,7 +11190,9 @@ export function useAgentGUINodeController({
   const isCancelPending =
     activeConversationId !== null &&
     Boolean(pendingInterruptSessionIds[activeConversationId]);
-  const queuedPrompts = activeConversationId ? [...activeQueuedPrompts] : [];
+  const queuedPrompts = activeConversationId
+    ? activeQueuedPrompts
+    : EMPTY_QUEUED_PROMPTS;
   const drainingQueuedPromptId = activeQueuedPromptClaim?.promptId ?? null;
   const sessionSettings = useStableComposerSettings(
     cloneComposerSettings(activeSessionState?.settings ?? null)
@@ -11472,9 +11480,14 @@ export function useAgentGUINodeController({
     !isCreatingConversation &&
     !isSubmitting &&
     !isInterrupting;
+  const activeConversationCreatePending =
+    Boolean(activeConversationId) &&
+    isCreatingConversation &&
+    startingConversationIdRef.current === activeConversationId;
   const canQueueWhileBusy =
     Boolean(activeConversationId) &&
-    (activeConversationBusy ||
+    (activeConversationCreatePending ||
+      activeConversationBusy ||
       isSubmitting ||
       Boolean(activeSessionState?.pendingInteractive));
   useEffect(() => {

--- a/packages/agent/gui/agent-gui/agentGuiNode/model/agentGuiNodeTypes.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/model/agentGuiNodeTypes.ts
@@ -308,7 +308,7 @@ export interface AgentGUINodeViewModel {
   activeConversationBusy: boolean;
   canSubmit: boolean;
   composerSettings: AgentGUIComposerSettingsVM;
-  queuedPrompts: AgentGUIQueuedPromptVM[];
+  queuedPrompts: readonly AgentGUIQueuedPromptVM[];
   drainingQueuedPromptId: string | null;
   canQueueWhileBusy: boolean;
   hasSentUserMessage: boolean;

--- a/packages/agent/gui/agent-message-center/workspaceAgentMessageCenterDigest.spec.ts
+++ b/packages/agent/gui/agent-message-center/workspaceAgentMessageCenterDigest.spec.ts
@@ -383,6 +383,38 @@ describe("buildWorkspaceAgentMessageCenterDigest", () => {
       }).primary.summary
     ).toBe("Fallback title");
   });
+
+  it("refreshes a cached agent summary when the message payload identity changes", () => {
+    const item = message({
+      payload: { text: "First summary" }
+    });
+
+    expect(
+      resolveWorkspaceAgentMessageCenterDigestAgentMessageSummary(item)
+    ).toBe("First summary");
+
+    item.payload = { text: "Second summary" };
+
+    expect(
+      resolveWorkspaceAgentMessageCenterDigestAgentMessageSummary(item)
+    ).toBe("Second summary");
+  });
+
+  it("refreshes a cached agent summary when the message version changes", () => {
+    const payload = { text: "First summary" };
+    const item = message({ payload });
+
+    expect(
+      resolveWorkspaceAgentMessageCenterDigestAgentMessageSummary(item)
+    ).toBe("First summary");
+
+    payload.text = "Second summary";
+    item.version += 1;
+
+    expect(
+      resolveWorkspaceAgentMessageCenterDigestAgentMessageSummary(item)
+    ).toBe("Second summary");
+  });
 });
 
 type DigestSpecInput = Omit<

--- a/packages/agent/gui/agent-message-center/workspaceAgentMessageCenterDigest.ts
+++ b/packages/agent/gui/agent-message-center/workspaceAgentMessageCenterDigest.ts
@@ -36,6 +36,20 @@ export interface BuildWorkspaceAgentMessageCenterDigestInput {
   status: WorkspaceAgentActivityStatus;
 }
 
+interface DigestAgentMessageSummaryCacheEntry {
+  kind: string;
+  payload: AgentActivityMessage["payload"];
+  role: string;
+  status: string | null | undefined;
+  summary: string;
+  version: number;
+}
+
+const digestAgentMessageSummaryByMessage = new WeakMap<
+  AgentActivityMessage,
+  DigestAgentMessageSummaryCacheEntry
+>();
+
 export function buildWorkspaceAgentMessageCenterDigest(
   input: BuildWorkspaceAgentMessageCenterDigestInput
 ): WorkspaceAgentMessageCenterDigest {
@@ -108,13 +122,41 @@ export function buildWorkspaceAgentMessageCenterDigest(
 export function resolveWorkspaceAgentMessageCenterDigestAgentMessageSummary(
   message: AgentActivityMessage
 ): string {
+  const cached = digestAgentMessageSummaryByMessage.get(message);
+  if (
+    cached &&
+    cached.role === message.role &&
+    cached.kind === message.kind &&
+    cached.status === message.status &&
+    cached.payload === message.payload &&
+    cached.version === message.version
+  ) {
+    return cached.summary;
+  }
   if (
     !isAgentMessageRole(message.role) ||
     isReasoningMessageKind(message.kind)
   ) {
+    digestAgentMessageSummaryByMessage.set(message, {
+      kind: message.kind,
+      payload: message.payload,
+      role: message.role,
+      status: message.status,
+      summary: "",
+      version: message.version
+    });
     return "";
   }
-  return meaningfulMessageSummary(message);
+  const summary = meaningfulMessageSummary(message);
+  digestAgentMessageSummaryByMessage.set(message, {
+    kind: message.kind,
+    payload: message.payload,
+    role: message.role,
+    status: message.status,
+    summary,
+    version: message.version
+  });
+  return summary;
 }
 
 function pendingPromptSummary(

--- a/packages/agent/gui/agent-message-center/workspaceAgentMessageCenterModel.spec.ts
+++ b/packages/agent/gui/agent-message-center/workspaceAgentMessageCenterModel.spec.ts
@@ -1124,6 +1124,40 @@ describe("buildWorkspaceAgentMessageCenterModel", () => {
     );
     expect(model.items[0]?.pendingPrompt).toBeNull();
   });
+
+  it("refreshes cached message analysis when a reused messages array grows", () => {
+    const activitySnapshot = snapshot({
+      messages: [
+        message({
+          agentSessionId: "session-1",
+          messageId: "assistant-1",
+          payload: { text: "First summary" },
+          occurredAtUnixMs: 10
+        })
+      ],
+      sessions: [
+        session({
+          agentSessionId: "session-1",
+          status: "completed"
+        })
+      ]
+    });
+    const first = buildWorkspaceAgentMessageCenterModel(activitySnapshot);
+
+    activitySnapshot.sessionMessagesById["session-1"]?.push(
+      message({
+        agentSessionId: "session-1",
+        messageId: "assistant-2",
+        version: 2,
+        payload: { text: "Second summary" },
+        occurredAtUnixMs: 20
+      })
+    );
+    const second = buildWorkspaceAgentMessageCenterModel(activitySnapshot);
+
+    expect(first.items[0]?.lastAgentMessageSummary).toBe("First summary");
+    expect(second.items[0]?.lastAgentMessageSummary).toBe("Second summary");
+  });
 });
 
 describe("stabilizeWorkspaceAgentMessageCenterModel", () => {

--- a/packages/agent/gui/agent-message-center/workspaceAgentMessageCenterModel.ts
+++ b/packages/agent/gui/agent-message-center/workspaceAgentMessageCenterModel.ts
@@ -308,6 +308,42 @@ interface MessageCenterSessionMessageAnalysis {
   pendingPrompt: AgentConversationPromptVM | null;
 }
 
+interface MessageCenterSessionMessageAnalysisCacheEntry {
+  messages: MessageCenterMessageCacheKey[];
+  result: MessageCenterSessionMessageAnalysis;
+}
+
+interface CodexPlanImplementationPromptCacheEntry {
+  messages: MessageCenterMessageCacheKey[];
+  provider: string;
+  result: AgentConversationPromptVM | null;
+  status: WorkspaceAgentActivityStatus;
+}
+
+interface MessageCenterMessageCacheKey {
+  completedAtUnixMs: number | undefined;
+  kind: string;
+  message: AgentActivityMessage;
+  messageId: string;
+  occurredAtUnixMs: number;
+  payload: AgentActivityMessage["payload"];
+  role: string;
+  startedAtUnixMs: number | undefined;
+  status: string | null | undefined;
+  turnId: string;
+  version: number;
+}
+
+const messageAnalysisByMessages = new WeakMap<
+  readonly AgentActivityMessage[],
+  Map<string, MessageCenterSessionMessageAnalysisCacheEntry>
+>();
+
+const codexPlanImplementationPromptByMessages = new WeakMap<
+  readonly AgentActivityMessage[],
+  CodexPlanImplementationPromptCacheEntry
+>();
+
 interface PendingPromptCandidate {
   message: AgentActivityMessage;
   prompt: AgentConversationPromptVM;
@@ -319,6 +355,30 @@ interface TurnOutcomeCandidate {
 }
 
 function analyzeMessageCenterSessionMessages(
+  agentSessionId: string,
+  messages: readonly AgentActivityMessage[]
+): MessageCenterSessionMessageAnalysis {
+  let bySessionId = messageAnalysisByMessages.get(messages);
+  if (!bySessionId) {
+    bySessionId = new Map();
+    messageAnalysisByMessages.set(messages, bySessionId);
+  }
+  const cached = bySessionId.get(agentSessionId);
+  if (cached && isMessageArrayCacheEntryCurrent(cached, messages)) {
+    return cached.result;
+  }
+  const result = analyzeMessageCenterSessionMessagesUncached(
+    agentSessionId,
+    messages
+  );
+  bySessionId.set(agentSessionId, {
+    messages: messageCenterMessageCacheKeys(messages),
+    result
+  });
+  return result;
+}
+
+function analyzeMessageCenterSessionMessagesUncached(
   agentSessionId: string,
   messages: readonly AgentActivityMessage[]
 ): MessageCenterSessionMessageAnalysis {
@@ -575,6 +635,34 @@ function codexPlanImplementationPrompt(
   status: WorkspaceAgentActivityStatus,
   messages: readonly AgentActivityMessage[]
 ): AgentConversationPromptVM | null {
+  const cached = codexPlanImplementationPromptByMessages.get(messages);
+  if (
+    cached &&
+    cached.provider === session.provider &&
+    cached.status === status &&
+    isMessageArrayCacheEntryCurrent(cached, messages)
+  ) {
+    return cached.result;
+  }
+  const result = codexPlanImplementationPromptUncached(
+    session,
+    status,
+    messages
+  );
+  codexPlanImplementationPromptByMessages.set(messages, {
+    messages: messageCenterMessageCacheKeys(messages),
+    provider: session.provider,
+    result,
+    status
+  });
+  return result;
+}
+
+function codexPlanImplementationPromptUncached(
+  session: AgentActivitySession,
+  status: WorkspaceAgentActivityStatus,
+  messages: readonly AgentActivityMessage[]
+): AgentConversationPromptVM | null {
   if (session.provider.trim().toLowerCase() !== "codex") {
     return null;
   }
@@ -599,6 +687,58 @@ function codexPlanImplementationPrompt(
   );
   const title = planMessage ? messageSummary(planMessage) : "";
   return planImplementationPromptFromPlanTurn(planTurnId, title);
+}
+
+function isMessageArrayCacheEntryCurrent(
+  entry: {
+    messages: readonly MessageCenterMessageCacheKey[];
+  },
+  messages: readonly AgentActivityMessage[]
+): boolean {
+  if (entry.messages.length !== messages.length) {
+    return false;
+  }
+  return entry.messages.every((key, index) =>
+    messageCenterMessageCacheKeyMatches(key, messages[index])
+  );
+}
+
+function messageCenterMessageCacheKeys(
+  messages: readonly AgentActivityMessage[]
+): MessageCenterMessageCacheKey[] {
+  return messages.map((message) => ({
+    completedAtUnixMs: message.completedAtUnixMs,
+    kind: message.kind,
+    message,
+    messageId: message.messageId,
+    occurredAtUnixMs: message.occurredAtUnixMs,
+    payload: message.payload,
+    role: message.role,
+    startedAtUnixMs: message.startedAtUnixMs,
+    status: message.status,
+    turnId: message.turnId,
+    version: message.version
+  }));
+}
+
+function messageCenterMessageCacheKeyMatches(
+  key: MessageCenterMessageCacheKey,
+  message: AgentActivityMessage | undefined
+): boolean {
+  return (
+    message !== undefined &&
+    key.message === message &&
+    key.messageId === message.messageId &&
+    key.version === message.version &&
+    key.turnId === message.turnId &&
+    key.role === message.role &&
+    key.kind === message.kind &&
+    key.status === message.status &&
+    key.payload === message.payload &&
+    key.occurredAtUnixMs === message.occurredAtUnixMs &&
+    key.startedAtUnixMs === message.startedAtUnixMs &&
+    key.completedAtUnixMs === message.completedAtUnixMs
+  );
 }
 
 function turnOutcomeFromMessage(

--- a/packages/agent/gui/agent-message-center/workspaceAgentMessageCenterModelStability.ts
+++ b/packages/agent/gui/agent-message-center/workspaceAgentMessageCenterModelStability.ts
@@ -9,6 +9,10 @@ import type { WorkspaceAgentMessageCenterDigest } from "./workspaceAgentMessageC
 
 type WorkspaceAgentMessageCenterPrompt =
   WorkspaceAgentMessageCenterItem["pendingPrompt"];
+type WorkspaceAgentMessageCenterAskUserQuestions = Extract<
+  NonNullable<WorkspaceAgentMessageCenterPrompt>,
+  { kind: "ask-user" }
+>["questions"];
 
 export function stabilizeWorkspaceAgentMessageCenterModel(
   previous: WorkspaceAgentMessageCenterModel | null,
@@ -150,5 +154,156 @@ function messageCenterPromptEqual(
   if (!left || !right || left.kind !== right.kind) {
     return false;
   }
-  return JSON.stringify(left) === JSON.stringify(right);
+  switch (left.kind) {
+    case "approval":
+      return (
+        right.kind === "approval" &&
+        left.id === right.id &&
+        left.turnId === right.turnId &&
+        left.requestId === right.requestId &&
+        left.callId === right.callId &&
+        left.title === right.title &&
+        left.toolName === right.toolName &&
+        left.status === right.status &&
+        left.occurredAtUnixMs === right.occurredAtUnixMs &&
+        messageCenterJsonValueEqual(left.input, right.input) &&
+        messageCenterJsonValueEqual(
+          left.output ?? null,
+          right.output ?? null
+        ) &&
+        messageCenterApprovalOptionsEqual(left.options, right.options)
+      );
+    case "ask-user":
+      return (
+        right.kind === "ask-user" &&
+        left.requestId === right.requestId &&
+        left.title === right.title &&
+        messageCenterAskUserQuestionsEqual(left.questions, right.questions)
+      );
+    case "exit-plan":
+      return (
+        right.kind === "exit-plan" &&
+        left.requestId === right.requestId &&
+        left.title === right.title &&
+        left.keepPlanningOptionId === right.keepPlanningOptionId &&
+        messageCenterApprovalOptionsEqual(left.options, right.options)
+      );
+    case "plan-implementation":
+      return (
+        right.kind === "plan-implementation" &&
+        left.requestId === right.requestId &&
+        left.title === right.title
+      );
+  }
+}
+
+function messageCenterApprovalOptionsEqual(
+  left: readonly {
+    description?: string;
+    id: string;
+    kind: string;
+    label: string;
+  }[],
+  right: readonly {
+    description?: string;
+    id: string;
+    kind: string;
+    label: string;
+  }[]
+): boolean {
+  if (left.length !== right.length) {
+    return false;
+  }
+  return left.every((option, index) => {
+    const rightOption = right[index];
+    return (
+      rightOption &&
+      option.id === rightOption.id &&
+      option.label === rightOption.label &&
+      option.kind === rightOption.kind &&
+      option.description === rightOption.description
+    );
+  });
+}
+
+function messageCenterAskUserQuestionsEqual(
+  left: WorkspaceAgentMessageCenterAskUserQuestions,
+  right: WorkspaceAgentMessageCenterAskUserQuestions
+): boolean {
+  if (left.length !== right.length) {
+    return false;
+  }
+  return left.every((question, index) => {
+    const rightQuestion = right[index];
+    return (
+      rightQuestion &&
+      question.id === rightQuestion.id &&
+      question.header === rightQuestion.header &&
+      question.question === rightQuestion.question &&
+      question.multiSelect === rightQuestion.multiSelect &&
+      messageCenterAnswerEqual(
+        question.answer ?? null,
+        rightQuestion.answer ?? null
+      ) &&
+      question.options.length === rightQuestion.options.length &&
+      question.options.every((option, optionIndex) => {
+        const rightOption = rightQuestion.options[optionIndex];
+        return (
+          rightOption &&
+          option.label === rightOption.label &&
+          option.description === rightOption.description
+        );
+      })
+    );
+  });
+}
+
+function messageCenterAnswerEqual(
+  left: string | string[] | null,
+  right: string | string[] | null
+): boolean {
+  if (left === right) {
+    return true;
+  }
+  if (!Array.isArray(left) || !Array.isArray(right)) {
+    return false;
+  }
+  return (
+    left.length === right.length &&
+    left.every((value, index) => value === right[index])
+  );
+}
+
+function messageCenterJsonValueEqual(left: unknown, right: unknown): boolean {
+  if (left === right) {
+    return true;
+  }
+  if (
+    !left ||
+    !right ||
+    typeof left !== "object" ||
+    typeof right !== "object"
+  ) {
+    return false;
+  }
+  if (Array.isArray(left) || Array.isArray(right)) {
+    if (!Array.isArray(left) || !Array.isArray(right)) {
+      return false;
+    }
+    return (
+      left.length === right.length &&
+      left.every((value, index) =>
+        messageCenterJsonValueEqual(value, right[index])
+      )
+    );
+  }
+  const leftRecord = left as Record<string, unknown>;
+  const rightRecord = right as Record<string, unknown>;
+  const leftKeys = Object.keys(leftRecord);
+  if (leftKeys.length !== Object.keys(rightRecord).length) {
+    return false;
+  }
+  return leftKeys.every((key) =>
+    messageCenterJsonValueEqual(leftRecord[key], rightRecord[key])
+  );
 }

--- a/packages/ui/system/src/components/mention-pill/mention-pill.spec.tsx
+++ b/packages/ui/system/src/components/mention-pill/mention-pill.spec.tsx
@@ -1,0 +1,32 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { TooltipProvider } from "../tooltip/tooltip";
+import { MentionPill } from "./mention-pill";
+
+describe("MentionPill", () => {
+  it("keeps standalone tooltip context by default", () => {
+    render(<MentionPill kind="file" label="README.md" />);
+
+    expect(screen.getByText("README.md")).toBeInTheDocument();
+    expect(
+      document.querySelector('[data-slot="tooltip-trigger"]')
+    ).toBeInTheDocument();
+  });
+
+  it("can reuse an ancestor tooltip provider", () => {
+    render(
+      <TooltipProvider>
+        <MentionPill
+          kind="file"
+          label="README.md"
+          withTooltipProvider={false}
+        />
+      </TooltipProvider>
+    );
+
+    expect(screen.getByText("README.md")).toBeInTheDocument();
+    expect(
+      document.querySelector('[data-slot="tooltip-trigger"]')
+    ).toBeInTheDocument();
+  });
+});

--- a/packages/ui/system/src/components/mention-pill/mention-pill.tsx
+++ b/packages/ui/system/src/components/mention-pill/mention-pill.tsx
@@ -39,6 +39,7 @@ export interface MentionPillProps extends Omit<
   removable?: boolean;
   removeButtonProps?: React.ComponentProps<"button">;
   summary?: React.ReactNode;
+  withTooltipProvider?: boolean;
 }
 
 function MentionPill({
@@ -51,6 +52,7 @@ function MentionPill({
   removeButtonProps,
   style,
   summary,
+  withTooltipProvider = true,
   ...props
 }: MentionPillProps): React.JSX.Element {
   const isFile = kind === "file";
@@ -137,7 +139,10 @@ function MentionPill({
           </button>
         ) : null}
       </span>
-      <TruncatingPillLabel tooltip={tooltipText}>
+      <TruncatingPillLabel
+        tooltip={tooltipText}
+        withTooltipProvider={withTooltipProvider}
+      >
         <span>{label}</span>
         {summary ? <span className="text-current"> {summary}</span> : null}
       </TruncatingPillLabel>

--- a/packages/ui/system/src/components/mention-pill/truncating-pill-label.tsx
+++ b/packages/ui/system/src/components/mention-pill/truncating-pill-label.tsx
@@ -40,6 +40,7 @@ export interface TruncatingPillLabelProps {
   tooltip: string;
   className?: string;
   children: React.ReactNode;
+  withTooltipProvider?: boolean;
 }
 
 /**
@@ -51,7 +52,8 @@ export interface TruncatingPillLabelProps {
 export function TruncatingPillLabel({
   tooltip,
   className,
-  children
+  children,
+  withTooltipProvider = true
 }: TruncatingPillLabelProps): React.JSX.Element {
   const { ref: labelRef, overflowing } =
     useTextOverflow<HTMLSpanElement>(tooltip);
@@ -72,18 +74,19 @@ export function TruncatingPillLabel({
     return label;
   }
 
-  // 自带 TooltipProvider:使本组件不依赖上层 Provider,可在任意 MentionPill 使用处工作
-  // (嵌套 Provider 在 Radix 中安全,就近配置生效)。
-  return (
-    <TooltipProvider delayDuration={200}>
-      <Tooltip>
-        <TooltipTrigger asChild>{label}</TooltipTrigger>
-        {overflowing ? (
-          <TooltipContent className="max-w-[min(420px,calc(100vw-32px))] whitespace-normal text-left [overflow-wrap:anywhere]">
-            {tooltip}
-          </TooltipContent>
-        ) : null}
-      </Tooltip>
-    </TooltipProvider>
+  const tooltipElement = (
+    <Tooltip>
+      <TooltipTrigger asChild>{label}</TooltipTrigger>
+      {overflowing ? (
+        <TooltipContent className="max-w-[min(420px,calc(100vw-32px))] whitespace-normal text-left [overflow-wrap:anywhere]">
+          {tooltip}
+        </TooltipContent>
+      ) : null}
+    </Tooltip>
+  );
+  return withTooltipProvider ? (
+    <TooltipProvider delayDuration={200}>{tooltipElement}</TooltipProvider>
+  ) : (
+    tooltipElement
   );
 }


### PR DESCRIPTION
## Summary
- coalesce workspace agent activity snapshot notifications before React updates
- keep async turns active until open calls finish, and support queued prompt image previews from staged paths
- stabilize AgentGUI/message-center memoization and mention tooltip provider usage

## Validation
- pnpm check:full

## Notes
- Branch was rebased onto latest origin/main (55b3bb5b) before push.
- Documentation impact: updated docs/architecture/agent-gui-node.md for optimistic conversation queuing and queued image previews.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Queued prompts can now load and display staged image previews from workspace/session context.
  * Mention pills and related mention views now handle tooltip context more consistently.

* **Bug Fixes**
  * New conversations can keep accepting follow-up prompts while activation is still pending.
  * Conversation and message-center views are more stable during refreshes, reducing unnecessary UI rerenders.
  * Activity updates and async turn events now update the UI more smoothly, avoiding premature state changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->