### PR TITLE
refactor(workspace-agent): remove retain shim

### DIFF
--- a/apps/desktop/src/renderer/src/features/workspace-agent/services/createDesktopAgentActivityRuntime.test.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-agent/services/createDesktopAgentActivityRuntime.test.ts
@@ -346,7 +346,6 @@ function createWorkspaceAgentActivityService(): IWorkspaceAgentActivityService {
       throw new Error("not implemented");
     },
     ensureSessionSynchronized: () => () => {},
-    retainSessionEvents: () => () => {},
     sendInput: async () => {
       throw new Error("not implemented");
     },

--- a/apps/desktop/src/renderer/src/features/workspace-agent/services/createDesktopAgentActivityRuntime.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-agent/services/createDesktopAgentActivityRuntime.ts
@@ -324,7 +324,7 @@ export function createDesktopAgentActivityRuntime(
       return workspaceAgentActivityService.ensureSessionSynchronized(input);
     },
     retainSessionEvents: (input) =>
-      workspaceAgentActivityService.retainSessionEvents(input),
+      workspaceAgentActivityService.ensureSessionSynchronized(input),
     async sendInput(input) {
       reportAgentSubmitTraceDiagnostic({
         agentSessionId: input.agentSessionId,

--- a/apps/desktop/src/renderer/src/features/workspace-agent/services/createDesktopAgentGUIWorkbenchHostInput.test.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-agent/services/createDesktopAgentGUIWorkbenchHostInput.test.ts
@@ -2166,9 +2166,6 @@ function createWorkspaceAgentActivityService(
     ensureSessionSynchronized() {
       return () => {};
     },
-    retainSessionEvents() {
-      return () => {};
-    },
     async sendInput(input) {
       return {
         session: {

--- a/apps/desktop/src/renderer/src/features/workspace-agent/services/internal/workspaceAgentActivityService.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-agent/services/internal/workspaceAgentActivityService.ts
@@ -40,7 +40,6 @@ import type {
   IWorkspaceAgentActivityService,
   WorkspaceAgentActivityListMessagesInput,
   WorkspaceAgentActivityEnsureSessionSynchronizedInput,
-  WorkspaceAgentActivityRetainSessionInput,
   WorkspaceAgentModelCatalogInvalidatedEvent
 } from "../workspaceAgentActivityService.interface.ts";
 import type { IAgentProviderStatusService } from "../agentProviderStatusService.interface.ts";
@@ -404,12 +403,6 @@ export class WorkspaceAgentActivityService implements IWorkspaceAgentActivitySer
       }).catch(input.onError ?? (() => {}));
     }
     return () => {};
-  }
-
-  retainSessionEvents(
-    input: WorkspaceAgentActivityRetainSessionInput
-  ): () => void {
-    return this.ensureSessionSynchronized(input);
   }
 
   onSessionEvent(

--- a/apps/desktop/src/renderer/src/features/workspace-agent/services/workspaceAgentActivityService.interface.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-agent/services/workspaceAgentActivityService.interface.ts
@@ -95,9 +95,6 @@ export interface WorkspaceAgentActivityEnsureSessionSynchronizedInput {
   workspaceId: string;
 }
 
-export type WorkspaceAgentActivityRetainSessionInput =
-  WorkspaceAgentActivityEnsureSessionSynchronizedInput;
-
 export interface WorkspaceAgentActivityAttachment {
   attachmentId: string;
   mimeType: string;
@@ -200,10 +197,6 @@ export interface IWorkspaceAgentActivityService {
   }): Promise<void>;
   ensureSessionSynchronized(
     input: WorkspaceAgentActivityEnsureSessionSynchronizedInput
-  ): () => void;
-  /** @deprecated Use ensureSessionSynchronized. */
-  retainSessionEvents(
-    input: WorkspaceAgentActivityRetainSessionInput
   ): () => void;
   sendInput(
     input: AgentActivitySendInput


### PR DESCRIPTION
CC-16

## Summary
- Removed the redundant workspace activity service `retainSessionEvents` compatibility alias and type.
- Kept the package-required `AgentActivityRuntime.retainSessionEvents` adapter, now delegating directly to `ensureSessionSynchronized`.
- Updated in-scope service test stubs.

## Validation
- pnpm exec node --import ./test/register-asset-stub.mjs --test --experimental-strip-types src/renderer/src/features/workspace-agent/services/createDesktopAgentActivityRuntime.test.ts src/renderer/src/features/workspace-agent/services/createDesktopAgentGUIWorkbenchHostInput.test.ts src/renderer/src/features/workspace-agent/services/internal/workspaceAgentActivityService.test.ts
- pnpm --filter @tutti-os/desktop typecheck
- pnpm lint:ts
- pnpm check:changed --tail-lines 80
- git push pre-push hook: pnpm check:full


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Workspace agent sessions now use the updated synchronization flow, improving consistency when reconnecting or resuming activity.
  * Removed an outdated session-retention path to align behavior with the current session handling experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->