### PR TITLE
refactor(agent-gui): remove legacy workspace file-drop paths

### DIFF
--- a/packages/agent/gui/agent-gui/agentGuiNode/agentRichText/AgentRichTextEditor.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/agentRichText/AgentRichTextEditor.tsx
@@ -936,9 +936,7 @@ export const AgentRichTextEditor = forwardRef<
           if (!hasWorkspaceFileDropData(dataTransfer)) {
             return false;
           }
-          const entries = readWorkspaceFileDropEntries(dataTransfer, {
-            includeLegacyPaths: false
-          });
+          const entries = readWorkspaceFileDropEntries(dataTransfer);
           if (entries.length === 0) {
             return false;
           }
@@ -1010,9 +1008,7 @@ export const AgentRichTextEditor = forwardRef<
           if (!currentEditor || currentEditor.isDestroyed) {
             return true;
           }
-          const entries = readWorkspaceFileDropEntries(dataTransfer, {
-            includeLegacyPaths: false
-          });
+          const entries = readWorkspaceFileDropEntries(dataTransfer);
           if (entries.length === 0) {
             return true;
           }

--- a/packages/agent/gui/agent-gui/terminalNode/workspaceFileDrop.spec.ts
+++ b/packages/agent/gui/agent-gui/terminalNode/workspaceFileDrop.spec.ts
@@ -69,31 +69,6 @@ describe("workspaceFileDrop", () => {
     );
   });
 
-  it("reads legacy path-only payloads as unknown-kind entries when requested", () => {
-    const dataTransfer = createDataTransferStub();
-
-    writeWorkspaceFileDropData(dataTransfer, [
-      "/workspace/src/App.tsx",
-      "/workspace/src/README.md"
-    ]);
-
-    expect(readWorkspaceFileDropEntries(dataTransfer)).toEqual([
-      {
-        path: "/workspace/src/App.tsx",
-        name: "App.tsx",
-        kind: "unknown"
-      },
-      {
-        path: "/workspace/src/README.md",
-        name: "README.md",
-        kind: "unknown"
-      }
-    ]);
-    expect(
-      readWorkspaceFileDropEntries(dataTransfer, { includeLegacyPaths: false })
-    ).toEqual([]);
-  });
-
   it("shell-quotes paths for terminal insertion", () => {
     expect(quoteWorkspacePathForTerminal("/workspace/it's here.txt")).toBe(
       "'/workspace/it'\"'\"'s here.txt'"

--- a/packages/agent/gui/agent-gui/terminalNode/workspaceFileDrop.ts
+++ b/packages/agent/gui/agent-gui/terminalNode/workspaceFileDrop.ts
@@ -11,7 +11,6 @@ export interface WorkspaceFileDropEntry {
 
 interface WorkspaceFileDropPayload {
   entries?: unknown;
-  paths?: unknown;
 }
 
 function normalizeWorkspaceFileDropEntryKind(
@@ -58,32 +57,20 @@ function normalizeWorkspaceFileDropPaths(paths: readonly string[]): string[] {
 
 export function writeWorkspaceFileDropData(
   dataTransfer: DataTransfer,
-  entriesOrPaths: readonly WorkspaceFileDropEntry[] | readonly string[]
+  entries: readonly WorkspaceFileDropEntry[]
 ): void {
-  if (entriesOrPaths.length === 0) {
+  if (entries.length === 0) {
     return;
   }
-  const firstItem = entriesOrPaths[0];
-  const writeStructuredEntries = typeof firstItem !== "string";
-  const normalizedEntries = writeStructuredEntries
-    ? normalizeWorkspaceFileDropEntries(
-        entriesOrPaths as readonly WorkspaceFileDropEntry[]
-      )
-    : [];
-  const normalizedPaths = writeStructuredEntries
-    ? normalizedEntries.map((entry) => entry.path)
-    : normalizeWorkspaceFileDropPaths(entriesOrPaths as readonly string[]);
-  if (normalizedPaths.length === 0) {
+  const normalizedEntries = normalizeWorkspaceFileDropEntries(entries);
+  if (normalizedEntries.length === 0) {
     return;
   }
+  const normalizedPaths = normalizedEntries.map((entry) => entry.path);
   dataTransfer.effectAllowed = "copy";
   dataTransfer.setData(
     WORKSPACE_FILE_DROP_MIME_TYPE,
-    JSON.stringify(
-      writeStructuredEntries
-        ? { entries: normalizedEntries }
-        : { paths: normalizedPaths }
-    )
+    JSON.stringify({ entries: normalizedEntries })
   );
   dataTransfer.setData("text/plain", normalizedPaths.join("\n"));
 }
@@ -106,8 +93,7 @@ export function readWorkspaceFileDropPaths(
 }
 
 export function readWorkspaceFileDropEntries(
-  dataTransfer: DataTransfer | null | undefined,
-  options: { includeLegacyPaths?: boolean } = {}
+  dataTransfer: DataTransfer | null | undefined
 ): WorkspaceFileDropEntry[] {
   if (!hasWorkspaceFileDropData(dataTransfer)) {
     return [];
@@ -135,18 +121,7 @@ export function readWorkspaceFileDropEntries(
         })
       );
     }
-    if (options.includeLegacyPaths === false || !Array.isArray(parsed.paths)) {
-      return [];
-    }
-    return normalizeWorkspaceFileDropEntries(
-      parsed.paths
-        .filter((value): value is string => typeof value === "string")
-        .map((path) => ({
-          path,
-          name: basenameWorkspacePath(path),
-          kind: "unknown"
-        }))
-    );
+    return [];
   } catch {
     return [];
   }


### PR DESCRIPTION
CC-18

## Summary
- Remove legacy path-only workspace file-drop payload parsing and writer support.
- Keep workspace file drops structured-only via `entries`.
- Update the two direct Agent rich text reader call sites after removing the compatibility option.

## Validation
- pnpm --filter @tutti-os/agent-gui typecheck
- pnpm exec oxfmt --check packages/agent/gui/agent-gui/terminalNode/workspaceFileDrop.ts packages/agent/gui/agent-gui/terminalNode/workspaceFileDrop.spec.ts packages/agent/gui/agent-gui/agentGuiNode/agentRichText/AgentRichTextEditor.tsx
- pnpm --filter @tutti-os/agent-gui exec vitest run --environment jsdom --maxWorkers=3 agent-gui/terminalNode/workspaceFileDrop.spec.ts agent-gui/agentGuiNode/agentRichText/AgentRichTextEditor.spec.tsx
- pnpm --filter @tutti-os/agent-gui exec vitest run --environment jsdom --maxWorkers=1 agent-gui/agentGuiNode/AgentGUINode.spec.tsx --testNamePattern "workspace entr"
- pnpm check:changed --tail-lines 80
- pnpm check:full

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved workspace file drag-and-drop handling so only supported file entries are accepted.
  * Dropped items that rely on older path-only formats are no longer treated as valid mentions, helping avoid inconsistent drop behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->