### PR TITLE
refactor(agent-gui): drop provider-only conversation filter compat

### DIFF
--- a/packages/agent/gui/contexts/workspace/presentation/renderer/agentGuiConversationList/agentGuiConversationListStore.spec.ts
+++ b/packages/agent/gui/contexts/workspace/presentation/renderer/agentGuiConversationList/agentGuiConversationListStore.spec.ts
@@ -166,7 +166,7 @@ describe("agentGuiConversationListStore", () => {
     });
   });
 
-  it("does not retain other-provider legacy sessions under a cursor agent target filter", async () => {
+  it("does not retain provider-only sessions under an agent target filter", async () => {
     const cursorQuery: AgentGUIConversationListQuery = {
       conversationFilter: {
         kind: "agentTarget",
@@ -185,13 +185,13 @@ describe("agentGuiConversationListStore", () => {
           provider: "cursor",
           title: "Cursor tagged"
         }),
-        runtimeSession("cursor-legacy", 2_500, {
+        runtimeSession("cursor-provider-only", 2_500, {
           provider: "cursor",
-          title: "Cursor legacy"
+          title: "Cursor provider only"
         }),
-        runtimeSession("codex-legacy", 2_000, {
+        runtimeSession("codex-provider-only", 2_000, {
           provider: "codex",
-          title: "Codex legacy"
+          title: "Codex provider only"
         })
       ]
     };
@@ -209,7 +209,7 @@ describe("agentGuiConversationListStore", () => {
         getAgentGUIConversationListQuerySnapshot(
           cursorQuery
         )?.conversations.map((item) => item.id)
-      ).toEqual(["cursor-tagged", "cursor-legacy"]);
+      ).toEqual(["cursor-tagged"]);
     });
   });
 

--- a/packages/agent/gui/contexts/workspace/presentation/renderer/agentGuiConversationList/agentGuiConversationListStore.ts
+++ b/packages/agent/gui/contexts/workspace/presentation/renderer/agentGuiConversationList/agentGuiConversationListStore.ts
@@ -16,7 +16,6 @@ import {
   type AgentGUIConversationSummary
 } from "../../../../../agent-gui/agentGuiNode/model/agentGuiConversationModel";
 import {
-  matchesAgentGUIConversationSummaryFilter,
   normalizeAgentGUIConversationFilter,
   type AgentGUIConversationFilter
 } from "../../../../../agent-gui/agentGuiNode/model/agentGuiConversationFilter";
@@ -172,19 +171,14 @@ function conversationFilterKey(filter: AgentGUIConversationFilter): string {
   return `agent-target:${normalized.agentTargetId}`;
 }
 
-/**
- * A conversation may only be retained (pinned/carried over) in a query state
- * whose agent-target filter it matches. Legacy sessions without agentTargetId
- * may still match a local system target through provider identity.
- */
-function conversationRetainableForQueryFilter(
+function conversationMatchesQueryFilter(
   conversation: AgentGUIConversationSummary | undefined,
   filter: AgentGUIConversationFilter
 ): boolean {
   if (!conversation || filter.kind !== "agentTarget") {
     return true;
   }
-  return matchesAgentGUIConversationSummaryFilter(conversation, filter);
+  return (conversation.agentTargetId?.trim() ?? "") === filter.agentTargetId;
 }
 
 export function createAgentGUIConversationListQueryKey(
@@ -1416,7 +1410,12 @@ async function refreshAgentGUIConversationListQuery(
         : workspaceAgentSnapshot,
       provider: state.query.provider,
       sessionMessagesById: sessionMessagesByIdForSummaries
-    });
+    }).filter((conversation) =>
+      conversationMatchesQueryFilter(
+        conversation,
+        state.query.conversationFilter
+      )
+    );
     const conversationsToDecorate = canApplyDirtySessionProjection
       ? new Set<string>([
           ...dirtySessionIds,
@@ -1438,15 +1437,6 @@ async function refreshAgentGUIConversationListQuery(
           : [];
       })
     );
-    const snapshotSessionProviderById = new Map(
-      workspaceAgentSnapshot.sessions.flatMap((session) => {
-        const agentSessionId = session.agentSessionId.trim();
-        const provider = session.provider?.trim() ?? "";
-        return agentSessionId && provider
-          ? [[agentSessionId, provider] as const]
-          : [];
-      })
-    );
     const retainableForQueryFilter = (agentSessionId: string): boolean => {
       const filter = state.query.conversationFilter;
       if (filter.kind !== "agentTarget") {
@@ -1456,17 +1446,10 @@ async function refreshAgentGUIConversationListQuery(
       // stale current summary.
       const snapshotAgentTargetId =
         snapshotSessionAgentTargetIdById.get(agentSessionId);
-      const snapshotProvider = snapshotSessionProviderById.get(agentSessionId);
-      if (snapshotAgentTargetId || snapshotProvider) {
-        return matchesAgentGUIConversationSummaryFilter(
-          {
-            agentTargetId: snapshotAgentTargetId ?? null,
-            provider: snapshotProvider ?? null
-          },
-          filter
-        );
+      if (snapshotAgentTargetId) {
+        return snapshotAgentTargetId === filter.agentTargetId;
       }
-      return conversationRetainableForQueryFilter(
+      return conversationMatchesQueryFilter(
         currentConversationsById.get(agentSessionId),
         filter
       );


### PR DESCRIPTION
CC-17

## Summary
- Remove provider-only fallback matching from the AgentGUI conversation-list agent-target filter path.
- Keep historical provider-only sessions visible in the All rail while scoped rail filters require matching `agentTargetId`.
- Update the focused conversation-list spec to cover provider-only sessions being excluded from target-filtered rails.

## Validation
- `pnpm exec vitest run --environment jsdom --maxWorkers=3 contexts/workspace/presentation/renderer/agentGuiConversationList/agentGuiConversationListStore.spec.ts`
- `pnpm check:agent-activity-runtime-boundaries`
- `pnpm check:changed --tail-lines 120`
- `pnpm lint:ts -- packages/agent/gui/contexts/workspace/presentation/renderer/agentGuiConversationList/agentGuiConversationListStore.ts packages/agent/gui/contexts/workspace/presentation/renderer/agentGuiConversationList/agentGuiConversationListStore.spec.ts`
- `pnpm check:full` (pre-push)

## Documentation
- No durable documentation update needed; this aligns the slice with the existing AgentGUI `agentTargetId` source-of-truth docs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved conversation list filtering so agent-target filters now match only conversations explicitly tagged for that target.
  * Fixed retention behavior so unrelated or untagged sessions no longer appear under agent-target filtered views.
  * Updated filtering behavior to be more consistent across current and retained conversations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->