### PR TITLE
feat(tuttid): sync dynamic agent provider skill references

### DIFF
--- a/services/tuttid/service/workspace/agent_workspace_app_reference/SKILL.md
+++ b/services/tuttid/service/workspace/agent_workspace_app_reference/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: tutti-agent-workspace-app
-description: "Build or evolve a complex agent-enabled Tutti workspace app repository. Use for Tutti apps with web/server/shared monorepos, @tutti-os/agent-acp-kit local agent runtimes, Codex or Claude provider detection, run-scoped MCP tool gateways, app-owned package builders, Tutti CLI/reference surfaces, web-first debugging, i18n harnesses, and production package validation. For simple package creation or repair, use tutti-workspace-app-factory instead."
+description: "Build or evolve a complex agent-enabled Tutti workspace app repository. Use for Tutti apps with web/server/shared monorepos, @tutti-os/agent-acp-kit local agent runtimes, dynamic Tutti agent provider detection (Codex, Claude Code, Cursor, OpenCode, and future kit providers), run-scoped MCP tool gateways, app-owned package builders, Tutti CLI/reference surfaces, web-first debugging, i18n harnesses, and production package validation. For simple package creation or repair, use tutti-workspace-app-factory instead."
 ---
 
 # Tutti Agent Workspace App
@@ -15,7 +15,7 @@ Use this skill for:
 
 - New agent-enabled Tutti app repositories.
 - Existing web/server apps being converted into maintainable Tutti app repos.
-- Apps that need `@tutti-os/agent-acp-kit` for local Codex or Claude runtime execution.
+- Apps that need `@tutti-os/agent-acp-kit` for local Tutti agent runtime execution.
 - App-specific MCP or command gateways that expose domain tools to local agents.
 - Multi-package `pnpm` workspaces with `apps/web`, `apps/server`, and `packages/shared`.
 - App-owned packaging, smoke tests, i18n enforcement, and CLI/reference endpoints.
@@ -28,7 +28,8 @@ Use `$tutti-workspace-app-factory` instead for a small standalone package, packa
 Read only the references needed for the task:
 
 - `references/app-architecture.md` for repository layout, web/server/shared boundaries, and dependency choices.
-- `references/agent-acp-kit.md` when implementing local agent providers, provider detection, ACP event mapping, or run-scoped MCP tools.
+- `references/agent-acp-kit.md` when implementing local agent providers, ACP event mapping, or run-scoped MCP tools.
+- `references/dynamic-agent-providers.md` when implementing provider detection, provider pickers, default provider selection, provider ID normalization, or optional Tutti daemon status enrichment. Read this before hard-coding any provider list.
 - `references/package-builder.md` when adding `scripts/package-tutti-app.mjs`, `bootstrap.sh`, Tutti CLI output docs, or package validation.
 - `references/github-actions-release.md` when creating or changing `.github/workflows/publish-tutti-app.yml`, `.github/workflows/publish-tutti-app-staging.yml`, release variables, or catalog publishing.
 - `references/i18n-and-web-debugging.md` when changing UI copy, language handling, web-first debug flow, or smoke/e2e checks.
@@ -41,8 +42,8 @@ Also read `$tutti-workspace-app-factory` before changing final package files or 
 2. Choose the smallest architecture that can stay maintainable: do not add local agents, WebSocket, MCP, CLI, or background workers unless the product needs them.
 3. Define shared contracts before wiring web/server calls. Keep domain DTOs, WebSocket messages, CLI-visible shapes, and runtime profile types in `packages/shared`.
 4. Build the web UI as the primary development surface. Keep the server as local API/static host and app orchestration layer.
-5. If agents are needed, add `@tutti-os/agent-acp-kit`, provider detection, runtime provider abstraction, event normalization, and a run-scoped tool gateway.
-   The main app flow must offer at least Claude Code and Codex as provider options when they are detected as available. Pick one available provider as the default; do not hard-code a single provider.
+5. If agents are needed, add `@tutti-os/agent-acp-kit`, dynamic provider detection, runtime provider abstraction, event normalization, and a run-scoped tool gateway.
+   Follow `references/dynamic-agent-providers.md`: discover providers through `createDefaultLocalAgentProviderPlugins()` plus `localAgentRuntime.detect(...)`, expose the detected catalog from an app-owned backend endpoint, render all detected providers in the UI, and choose a usable default from available detection results. Never hard-code Codex/Claude-only provider lists.
    For apps that must run both locally and in cloud/managed Tutti, follow `references/agent-acp-kit.md` exactly: managed credentials come from request headers on the server, never from browser JSB fallback or request body fields.
 6. Add package generation only after the local dev app runs. Package the built web assets, bundled server, `tutti.app.json`, optional `tutti.cli.json`, executable `bootstrap.sh`, assets, locales, and package-local `AGENTS.md`.
 7. If the user asks to connect to the Tutti app ecosystem, treat ecosystem integration as required: expose app capabilities through `tutti.cli.json`, make the app callable by other Tutti apps and agents, and use `TUTTI_CLI` for any calls to other installed Tutti apps.

--- a/services/tuttid/service/workspace/agent_workspace_app_reference/references/agent-acp-kit.md
+++ b/services/tuttid/service/workspace/agent_workspace_app_reference/references/agent-acp-kit.md
@@ -1,6 +1,6 @@
 # Agent ACP Kit Integration
 
-Use this reference only when the app needs local Codex/Claude execution or a local agent runtime.
+Use this reference only when the app needs local Tutti agent execution or a local agent runtime.
 
 ## Rule
 
@@ -20,7 +20,9 @@ Application use-case
         -> run-scoped MCP/tool gateway
 ```
 
-Use provider IDs from the kit or an explicit allowlist such as `codex` and `claude`. Detect providers before showing them as available. The app's primary agent flow must support both Claude Code and Codex as provider choices when available, hide or disable unavailable providers, and choose a usable default from the detected providers.
+Use provider IDs from kit detection. Do not maintain a static allowlist such as `codex` and `claude` only. Read `references/dynamic-agent-providers.md` for the full discovery, normalization, UI, and optional Tutti daemon enrichment rules.
+
+Detect providers before showing them as available. The app's primary agent flow must expose every detected kit provider, hide or disable unavailable ones, and choose a usable default from available detection results.
 
 ## Provider Detection
 
@@ -45,7 +47,7 @@ export async function detectLocalAgents(
 }
 ```
 
-Map detected provider models to app model IDs with a provider prefix, such as `codex:gpt-5.1` or `claude:sonnet`.
+Map detected provider models to app model IDs with a provider prefix, such as `cursor:default` or `codex:gpt-5.1`. Build prefixes from the detected `provider` value; do not assume only Codex/Claude models exist.
 
 Do not call a browser JSB API to fetch credentials for detection. Do not accept a credential field in the request body. If no managed credential header is present, the helper returns a local-compatible context and detection continues through the normal local path.
 
@@ -183,6 +185,7 @@ Package builders should bundle the MCP entrypoint and expose its path through an
 
 Add tests for:
 
+- dynamic provider catalog exposure and default selection (see `references/dynamic-agent-providers.md`)
 - provider filtering and model mapping
 - SSR/server provider detection using `createManagedAgentDetectContextFromHeaders(...)`
 - model-list detection using request-header managed context

--- a/services/tuttid/service/workspace/agent_workspace_app_reference/references/app-architecture.md
+++ b/services/tuttid/service/workspace/agent_workspace_app_reference/references/app-architecture.md
@@ -47,7 +47,7 @@ Use `pnpm` workspaces by default. Common choices:
 
 - Server: Node built-ins for tiny apps; Fastify, `@fastify/static`, `@fastify/websocket`, zod or ajv for larger API servers. Express is acceptable when the existing project already uses it.
 - Web: React with Vite, Next, or TanStack Start, matching the repo's current stack. For React/Tailwind apps, use shadcn/ui components and Tailwind CSS utilities as the default UI/component styling system.
-- Agent runtime: `@tutti-os/agent-acp-kit` when local Codex/Claude execution is required.
+- Agent runtime: `@tutti-os/agent-acp-kit` when local Tutti agent execution is required. Discover providers dynamically; do not hard-code Codex/Claude-only catalogs.
 - I18n: `i18next`, `react-i18next`, and `i18next-cli` for larger web apps.
 - Tests: Vitest or Node test runner for packages, Playwright only for cross-boundary UI flows.
 

--- a/services/tuttid/service/workspace/agent_workspace_app_reference/references/dynamic-agent-providers.md
+++ b/services/tuttid/service/workspace/agent_workspace_app_reference/references/dynamic-agent-providers.md
@@ -1,0 +1,210 @@
+# Dynamic Agent Provider Integration
+
+Use this reference whenever an app exposes agent provider pickers, runtime profiles, default provider selection, or provider-specific UI.
+
+## Rule
+
+Never hard-code an agent provider catalog such as `codex` and `claude` only. Tutti host and `@tutti-os/agent-acp-kit` evolve together: new local providers such as `cursor` and `opencode` should appear in workspace apps automatically when the installed kit and machine environment support them.
+
+The app owns presentation and policy, but provider registration and discovery come from the kit and optional Tutti daemon status APIs.
+
+## Architecture
+
+```text
+createDefaultLocalAgentProviderPlugins()
+  -> createLocalAgentRuntime({ providers })
+    -> localAgentRuntime.detect(context)          // availability + models
+    -> optional merge with tuttid provider status // cloud/managed enrichment
+      -> app API: GET /api/agents/providers
+        -> web UI renders detected providers dynamically
+          -> user selects providerId from detection response
+            -> localAgentRuntime.run({ provider: providerId, ... })
+```
+
+Do not maintain a parallel static provider list in web, shared, or server code unless the app has a documented, provider-specific capability gap.
+
+## Registration
+
+Always register providers from the kit default plugin set unless the app adds a documented custom ACP provider:
+
+```ts
+import {
+  createDefaultLocalAgentProviderPlugins,
+  createLocalAgentRuntime
+} from "@tutti-os/agent-acp-kit";
+
+const localAgentRuntime = createLocalAgentRuntime({
+  providers: createDefaultLocalAgentProviderPlugins()
+});
+```
+
+Upgrade `@tutti-os/agent-acp-kit` when Tutti adds providers. Do not copy provider IDs into the app repository to "stay compatible".
+
+## Discovery
+
+Expose one app-owned backend endpoint (for example `GET /api/agents/providers`) that returns the detected provider catalog. Build it from kit detection:
+
+```ts
+import { createManagedAgentDetectContextFromHeaders } from "@tutti-os/agent-acp-kit";
+
+export async function listAppAgentProviders(
+  headers: Headers | Record<string, string | string[] | undefined>
+) {
+  const context = createManagedAgentDetectContextFromHeaders(headers);
+  const detections = await localAgentRuntime.detect(context);
+
+  return detections.map(({ provider, displayName, result }) => ({
+    provider,
+    displayName: displayName ?? provider,
+    available: Boolean(result && result.supported !== false),
+    authState: result?.authState ?? "unknown",
+    executablePath: result?.executablePath ?? "",
+    version: result?.version ?? "not-installed",
+    models: (result?.models ?? []).map((model) => ({
+      id: `${provider}:${model.id}`,
+      label: model.label,
+      providerModelId: model.id
+    })),
+    reason:
+      result && result.supported !== false
+        ? undefined
+        : (result?.unsupportedReason ??
+          `${displayName ?? provider} is not installed or not discoverable.`)
+  }));
+}
+```
+
+UI rules:
+
+- Render every detected provider from the API response.
+- Show unavailable providers as disabled with the server-provided `reason`.
+- Do not filter the list down to Codex/Claude in frontend code.
+- Use `displayName` from detection for labels. Allowlist product names in i18n checks; do not hard-code label maps such as `if (provider === "codex")`.
+
+Default provider selection:
+
+- Prefer the user's last valid selection stored in app state/preferences.
+- Otherwise choose the first available detected provider.
+- Do not default to `codex` or `claude`.
+
+Persisted runtime profiles must store the kit `provider` string from detection, not a fixed union such as `"codex" | "claude"`.
+
+## Provider ID Normalization
+
+Tutti daemon/OpenAPI IDs and kit runtime IDs can differ. Normalize at boundaries only:
+
+| Tutti daemon / OpenAPI                              | Kit runtime ID | Notes                               |
+| --------------------------------------------------- | -------------- | ----------------------------------- |
+| `claude-code`                                       | `claude`       | common alias                        |
+| `tutti-agent`                                       | `nexight`      | only when the kit exposes `nexight` |
+| `codex`, `cursor`, `opencode`, `hermes`, `openclaw` | same           | usually identical                   |
+
+Use one small helper instead of scattered `if (provider === "codex")` branches:
+
+```ts
+const KIT_TO_DAEMON_PROVIDER: Record<string, string> = {
+  claude: "claude-code",
+  nexight: "tutti-agent"
+};
+
+export function toDaemonAgentProviderId(kitProviderId: string) {
+  return KIT_TO_DAEMON_PROVIDER[kitProviderId] ?? kitProviderId;
+}
+
+export function toKitAgentProviderId(daemonProviderId: string) {
+  const normalized = daemonProviderId.trim().toLowerCase();
+  if (normalized === "claude-code") return "claude";
+  if (normalized === "tutti-agent") return "nexight";
+  return normalized;
+}
+```
+
+Extend this map when Tutti documents a new alias. Do not rebuild a full static provider catalog in the app.
+
+## Optional Tutti Daemon Enrichment
+
+In cloud/managed Tutti, the app server may receive `TUTTI_API_BASE_URL` and `TUTTI_APP_SERVER_TOKEN`. When both are present, enrich kit detection with daemon provider status instead of replacing discovery with a hard-coded provider query.
+
+Derive the query list from registered kit providers:
+
+```ts
+const registered = localAgentRuntime.listProviders().map((item) => item.id);
+const url = new URL("/v1/agent-providers/status", baseUrl);
+for (const providerId of registered.map(toDaemonAgentProviderId)) {
+  url.searchParams.append("providers", providerId);
+}
+```
+
+Merge daemon status back onto kit detection by normalized provider ID. Keep any kit-only provider that the daemon did not return. When daemon credentials are absent, return kit detection only.
+
+Do not query only `providers=codex&providers=claude-code`.
+
+## Optional Capability Filtering
+
+Some apps need provider-specific stream adapters (for example Claude `<reasoning>` splitting or Codex tagged reasoning). That is allowed, but it must be explicit:
+
+```ts
+function createAppLocalAgentProviderPlugins() {
+  return createDefaultLocalAgentProviderPlugins().map((provider) => {
+    if (provider.id === "claude")
+      return withClaudeStreamCompatibility(provider);
+    if (provider.id === "codex") return withCodexStreamCompatibility(provider);
+    return provider;
+  });
+}
+```
+
+Rules:
+
+- Add compatibility wrappers per provider ID; do not `.filter()` the default plugin list unless the product truly cannot run other providers.
+- If the app must temporarily exclude a provider, document the gap in app `AGENTS.md` and remove the filter once the adapter exists.
+- Never exclude `cursor`, `opencode`, or future kit providers by default.
+
+## Host Bridge Integration
+
+When opening Tutti host features such as `window.tuttiExternal?.workspace?.openFeature({ feature: "agent-chat", provider })`, pass the daemon/OpenAPI provider ID derived from the user's current selection:
+
+```ts
+openFeature({
+  feature: "agent-chat",
+  provider: toDaemonAgentProviderId(selectedProviderId)
+});
+```
+
+Do not type the bridge provider as `"codex" | "claude-code"` only. Accept `string` and validate against the latest detected catalog when needed.
+
+Host-owned provider lists are not injected into workspace apps. Do not expect desktop default-provider preferences to expand an app UI that still hard-codes Codex/Claude.
+
+## Model IDs
+
+Use provider-prefixed app model IDs built from detection output:
+
+```ts
+const appModelId = `${provider}:${model.id}`;
+```
+
+Resolve the provider runtime model by stripping the prefix or by storing `providerModelId` separately. Do not assume only `codex:*` and `claude:*` exist.
+
+## Anti-Patterns
+
+Do not:
+
+- hard-code `["codex", "claude"]`, `Set(["codex", "claude"])`, or TypeScript unions limited to those providers for runtime state
+- require "at least Claude Code and Codex" in UI copy or validation
+- map display names with only Codex/Claude branches when detection already returns `displayName`
+- query `/v1/agent-providers/status` with a fixed provider subset
+- filter `createDefaultLocalAgentProviderPlugins()` to Codex/Claude unless documented as a temporary product constraint
+- shell out to `$TUTTI_CLI agent ...` for provider discovery
+
+## Verification
+
+Add tests for:
+
+- detection endpoint returns every registered kit provider entry
+- UI/provider picker renders all detected providers and disables unavailable ones
+- default provider comes from persisted preference or first available detection result
+- provider ID normalization covers `claude-code` <-> `claude` and daemon-only IDs such as `cursor` / `opencode`
+- optional daemon enrichment uses registered providers, not a static query list
+- run creation accepts any detected available `providerId`
+
+For smoke tests, run detection first, then execute one narrow turn on whichever provider is available. Do not assume Codex or Claude is installed.

--- a/services/tuttid/service/workspace/agent_workspace_app_reference/references/i18n-and-web-debugging.md
+++ b/services/tuttid/service/workspace/agent_workspace_app_reference/references/i18n-and-web-debugging.md
@@ -58,5 +58,5 @@ When local agents are involved:
 
 1. Run provider detection.
 2. Verify the web settings/runtime panel or equivalent status UI.
-3. Run isolated smoke tests for real Codex/Claude turns.
+3. Run isolated smoke tests for one available detected provider turn.
 4. Inspect run events, tool calls, generated files, and package-local data writes.

--- a/services/tuttid/service/workspace/app_factory_prompts.go
+++ b/services/tuttid/service/workspace/app_factory_prompts.go
@@ -74,8 +74,8 @@ func writeAppFactoryMentionContext(workspace workspacebiz.Summary, physicalRoot 
 			"Do not assume hidden Tutti daemon internals, preload APIs, tokens, or desktop APIs.",
 			"Validate against the App Factory skill before finishing.",
 			"Default new apps to a Node server; use Python only for existing Python projects or explicit Python requests.",
-			"If the app needs local agent or local LLM execution, Codex, Claude, or app-owned MCP/tooling, follow the tutti-agent-workspace-app skill and use @tutti-os/agent-acp-kit instead of TUTTI_CLI agent/codex/session polling.",
-			"Agent-enabled app main flows must detect and offer available Claude Code and Codex provider options, then choose one available provider by default.",
+			"If the app needs local agent or local LLM execution, Tutti agent providers, or app-owned MCP/tooling, follow the tutti-agent-workspace-app skill and use @tutti-os/agent-acp-kit instead of TUTTI_CLI agent/codex/session polling.",
+			"Agent-enabled app main flows must discover providers dynamically through @tutti-os/agent-acp-kit and references/dynamic-agent-providers.md; expose every detected provider, disable unavailable ones, and choose one available provider by default. Do not hard-code Codex/Claude-only provider catalogs.",
 		},
 		Metadata: appFactoryMentionMetadata{
 			AppID:       strings.TrimSpace(job.AppID),

--- a/services/tuttid/service/workspace/app_factory_reference/SKILL.md
+++ b/services/tuttid/service/workspace/app_factory_reference/SKILL.md
@@ -12,9 +12,9 @@ Use this skill to create, convert, or repair one Tutti workspace app. Choose one
 
 When the user selected a directory in App Center and Tutti reports that it cannot be loaded, treat the task as local debug repair. Adapt the selected project by creating or fixing `.tutti/dev-app/`; do not create a zip wrapper or copy the repository into `package/` unless the user explicitly asks for release packaging.
 
-For a full agent-enabled Tutti app repository with `apps/web`, `apps/server`, `packages/shared`, `@tutti-os/agent-acp-kit`, local Codex/Claude runtimes, MCP tool gateways, and an app-owned package builder, use `$tutti-agent-workspace-app` first. Return to this skill for the final package contract and validation. Do not invent managed-agent credential, cwd, JSB fallback, request-body credential, or `CODEX_HOME` behavior in this factory skill; the agent app skill owns that migration checklist and should keep those concerns in server-side kit calls.
+For a full agent-enabled Tutti app repository with `apps/web`, `apps/server`, `packages/shared`, `@tutti-os/agent-acp-kit`, dynamic local agent runtimes, MCP tool gateways, and an app-owned package builder, use `$tutti-agent-workspace-app` first. Return to this skill for the final package contract and validation. Do not invent managed-agent credential, cwd, JSB fallback, request-body credential, or `CODEX_HOME` behavior in this factory skill; the agent app skill owns that migration checklist and should keep those concerns in server-side kit calls.
 
-If the user request needs local agent or local LLM execution, Codex, Claude, or app-owned MCP/tooling, treat `$tutti-agent-workspace-app` and its `references/agent-acp-kit.md` as mandatory architecture guidance. Agent-enabled apps must use a Node server and `@tutti-os/agent-acp-kit`; do not implement app-owned local agent execution by shelling out to `$TUTTI_CLI agent ...`, `$TUTTI_CLI codex ...`, or session polling.
+If the user request needs local agent or local LLM execution, Tutti agent providers, or app-owned MCP/tooling, treat `$tutti-agent-workspace-app`, `references/dynamic-agent-providers.md`, and `references/agent-acp-kit.md` as mandatory architecture guidance. Agent-enabled apps must use a Node server and `@tutti-os/agent-acp-kit`; do not implement app-owned local agent execution by shelling out to `$TUTTI_CLI agent ...`, `$TUTTI_CLI codex ...`, or session polling.
 
 ## Version Check And Update Reminder
 
@@ -136,13 +136,13 @@ For a full agent-enabled app repository, prefer `$tutti-agent-workspace-app` fir
 
 - Keep the generic `@tutti-os/agent-acp-kit` runtime path product-neutral. Tutti-specific behavior should stay behind the explicit `@tutti-os/agent-acp-kit/tutti` subpath and app-owned policy.
 - Use a Node server for the app host process. Do not start with a Python server and plan to migrate later.
-- To give the app's local Codex or Claude run access to Tutti's dynamic CLI skills, prefer the `@tutti-os/agent-acp-kit/tutti` helper instead of hand-writing `$TUTTI_CLI agent tutti-cli-skill-bundle` execution and response parsing in each app.
+- To give the app's local agent runs access to Tutti's dynamic CLI skills, prefer the `@tutti-os/agent-acp-kit/tutti` helper instead of hand-writing `$TUTTI_CLI agent tutti-cli-skill-bundle` execution and response parsing in each app.
 - Use `loadTuttiAgentSkillContext(...)` from the app host process. Pass the selected provider, run id, workspace cwd, and optional Tutti CLI command configuration such as `commandEnvNames`.
 - Pass `tuttiContext.skillManifest` into `runtime.run({ ..., skillManifest })`, merging it with app-owned skills when needed.
 - Treat `tuttiContext.recommendedSystemPrompt?.content` as advisory raw prompt content. The app may merge it into its own `systemPrompt`, edit it, place it elsewhere, or ignore it. Do not inject it silently, and do not reintroduce duplicated CLI parsing unless the installed kit lacks the helper.
 - Keep run-scoped app tools and MCP credentials app-owned. Do not pass broad Tutti daemon credentials or app secrets directly to the agent process.
 
-Agent app main flows should expose provider choices for at least Claude Code and Codex. Detect available providers through `@tutti-os/agent-acp-kit`, show only available choices as selectable, and choose a usable default when at least one provider is available.
+Agent app main flows must discover providers dynamically through `@tutti-os/agent-acp-kit` and `references/dynamic-agent-providers.md`. Show every detected provider, disable unavailable ones, and choose a usable default when at least one provider is available. Do not hard-code Codex/Claude-only provider catalogs.
 
 Do not assume a Tutti API token, browser extension, daemon internals, or broad desktop APIs. The only browser-side host surface a generated app may optionally consume is the app context described in `references/runtime-env.md`.
 

--- a/services/tuttid/service/workspace/app_factory_reference/references/runtime-env.md
+++ b/services/tuttid/service/workspace/app_factory_reference/references/runtime-env.md
@@ -56,7 +56,7 @@ function subscribeHostLocale(listener) {
 }
 ```
 
-`subscribe` replays the latest context after registration, so apps do not need host-injected DOM events for initial locale delivery. Provider lists, default provider, and agent composer options are not part of browser external context. Agent-enabled apps should expose an app-owned backend endpoint backed by `@tutti-os/agent-acp-kit` detection for those choices; use `TUTTI_CLI` only for non-agent Tutti platform or app-to-app capabilities. The context is optional so generated apps continue to run in a normal browser during development.
+`subscribe` replays the latest context after registration, so apps do not need host-injected DOM events for initial locale delivery. Provider lists, default provider, and agent composer options are not part of browser external context. Agent-enabled apps should expose an app-owned backend endpoint backed by `@tutti-os/agent-acp-kit` detection and `references/dynamic-agent-providers.md`; use `TUTTI_CLI` only for non-agent Tutti platform or app-to-app capabilities. The context is optional so generated apps continue to run in a normal browser during development.
 
 For theme, use CSS media queries and `matchMedia`:
 

--- a/services/tuttid/service/workspace/app_factory_reference/references/tutti-cli-commands.md
+++ b/services/tuttid/service/workspace/app_factory_reference/references/tutti-cli-commands.md
@@ -4,7 +4,7 @@ This reference is for code inside a generated workspace app at runtime. It is no
 
 Workspace apps may call local Tutti capabilities through the bundled Tutti CLI.
 
-Do not use `$TUTTI_CLI agent ...`, `$TUTTI_CLI codex ...`, or agent session polling to implement app-owned local agent execution. Apps that need local agent or local LLM execution, Codex, Claude, or app-owned MCP/tooling must load and follow `$tutti-agent-workspace-app`, read its `references/agent-acp-kit.md`, and use `@tutti-os/agent-acp-kit` from a Node server:
+Do not use `$TUTTI_CLI agent ...`, `$TUTTI_CLI codex ...`, or agent session polling to implement app-owned local agent execution. Apps that need local agent or local LLM execution, Tutti agent providers, or app-owned MCP/tooling must load and follow `$tutti-agent-workspace-app`, read its `references/dynamic-agent-providers.md` and `references/agent-acp-kit.md`, and use `@tutti-os/agent-acp-kit` from a Node server:
 
 ```ts
 import {
@@ -18,6 +18,8 @@ const localAgentRuntime = createLocalAgentRuntime({
 
 const detectedProviders = await localAgentRuntime.detect();
 ```
+
+Return the full detected catalog to the app UI. Do not filter it down to Codex/Claude in application code.
 
 For non-agent app-to-app capability calls, always use the command path from `TUTTI_CLI`. `TUTTI_CLI` is the stable app-runtime contract across development and packaged production.
 

--- a/services/tuttid/service/workspace/app_factory_test.go
+++ b/services/tuttid/service/workspace/app_factory_test.go
@@ -347,9 +347,12 @@ func TestAppFactoryServiceCreateUsesDraftDirAndReferenceContext(t *testing.T) {
 	if !ok {
 		t.Fatalf("agent workspace app skill missing agent-acp-kit reference: %#v", agentWorkspaceAppSkill.Files)
 	}
+	if _, ok := agentWorkspaceAppSkill.Files["references/dynamic-agent-providers.md"]; !ok {
+		t.Fatalf("agent workspace app skill missing dynamic-agent-providers reference: %#v", agentWorkspaceAppSkill.Files)
+	}
 	for _, want := range []string{
 		"Do not hand-roll provider detection",
-		"Claude Code and Codex",
+		"dynamic-agent-providers.md",
 		"localAgentRuntime.detect",
 	} {
 		if !strings.Contains(agentACPReference, want) {
@@ -476,7 +479,7 @@ func TestAppFactoryServiceCreateUsesDraftDirAndReferenceContext(t *testing.T) {
 		"Default new apps to a Node server",
 		"@tutti-os/agent-acp-kit",
 		"TUTTI_CLI agent/codex/session polling",
-		"Claude Code and Codex provider options",
+		"dynamic-agent-providers.md",
 	} {
 		if !strings.Contains(constraints, want) {
 			t.Fatalf("context constraints missing %q: %#v", want, mentionContext.Constraints)


### PR DESCRIPTION
## Summary
- Sync embedded agent workspace app and App Factory skill references with dynamic provider discovery guidance.
- Update App Factory mention constraints and tests for the new skill contract.

## Test plan
- [ ] `go test ./service/workspace/...`
- [ ] Generate an App Factory app and confirm provider guidance is not Codex/Claude-only.

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated agent workspace and app factory guidance to support dynamic detection of available AI providers.
  * Clarified that apps should show all detected providers, hide or disable unavailable options, and choose a valid default automatically.
  * Added guidance for provider ID normalization, backend exposure of detected providers, and updated smoke-test recommendations for any available provider.
  * Refined local agent runtime instructions to use the Tutti agent runtime integration instead of fixed provider-specific assumptions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->