### PR TITLE
fix(agent-gui): rename displayed rail sessions

### DIFF
--- a/docs/architecture/agent-gui-node.md
+++ b/docs/architecture/agent-gui-node.md
@@ -596,6 +596,11 @@ page as a local `pinned` group, but pinned is not a daemon section kind and
 must continue to be derived from session `pinnedAtUnixMs`. Pinned Show more
 uses the dedicated pinned page runtime method instead of the section page
 endpoint, because pinned has no daemon `sectionKey`.
+Rail row actions that need row details must use the row from the displayed
+section model, not re-resolve it from the activity snapshot. Section pages can
+include historical sessions that are visible in the rail before they appear in
+the current snapshot, so actions such as rename must carry the displayed
+conversation through to their dialog or local interaction state.
 When the provider rail is scoped to a specific agent target, AgentGUI must pass
 that `agentTargetId` to both section endpoints. The daemon applies that filter
 before `LIMIT` and `hasMore` calculation; frontend filtering after an unscoped

--- a/packages/agent/gui/agent-gui/agentGuiNode/AgentGUINode.spec.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/AgentGUINode.spec.tsx
@@ -2660,6 +2660,66 @@ describe("AgentGUINode", () => {
     ).toHaveValue("Session 1");
   });
 
+  it("opens rename dialog from a runtime section row that is missing from the view model", async () => {
+    mockRenameConversation.mockResolvedValue(undefined);
+    mockViewModel = createViewModel({
+      conversations: [],
+      activeConversation: null,
+      activeConversationId: null
+    });
+    const agentActivityRuntime = {
+      ...createNoopAgentActivityRuntime(),
+      async listSessionSections(input) {
+        return {
+          workspaceId: input.workspaceId,
+          sections: [
+            {
+              kind: "conversations" as const,
+              sectionKey: "conversations",
+              sessions: [
+                {
+                  workspaceId: input.workspaceId,
+                  agentSessionId: "section-session-1",
+                  provider: "codex",
+                  cwd: "/workspace",
+                  title: "Section session",
+                  status: "completed",
+                  visible: true,
+                  updatedAtUnixMs: 1,
+                  lastEventUnixMs: 1
+                }
+              ],
+              hasMore: false
+            }
+          ]
+        };
+      },
+      async listSessionSectionPage(input) {
+        return {
+          kind: "conversations" as const,
+          sectionKey: input.sectionKey,
+          sessions: [],
+          hasMore: false
+        };
+      }
+    } satisfies AgentActivityRuntime;
+    renderAgentGUINode({ agentActivityRuntime });
+
+    fireEvent.contextMenu(
+      await screen.findByTestId("agent-gui-conversation-item-section-session-1")
+    );
+    const renameMenuItem = await screen.findByRole("menuitem", {
+      name: "agentHost.agentGui.renameSession"
+    });
+    fireEvent.pointerUp(renameMenuItem, { button: 0 });
+
+    expect(
+      await screen.findByRole("textbox", {
+        name: "agentHost.agentGui.renameSessionTitle"
+      })
+    ).toHaveValue("Section session");
+  });
+
   it("renders inline delete confirmation and dispatches confirm without a dialog", () => {
     mockViewModel = createViewModel({
       conversations: [

--- a/packages/agent/gui/agent-gui/agentGuiNode/AgentGUINodeView.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/AgentGUINodeView.tsx
@@ -1694,18 +1694,9 @@ export function AgentGUINodeView({
   const [renameConversationDialogOpen, setRenameConversationDialogOpen] =
     useState(false);
   const requestRenameConversation = useStableEventCallback(
-    (agentSessionId: string) => {
-      const target =
-        viewModel.conversations.find(
-          (conversation) => conversation.id === agentSessionId
-        ) ??
-        (viewModel.activeConversation?.id === agentSessionId
-          ? viewModel.activeConversation
-          : null);
-      if (target) {
-        setRenameConversationTarget(target);
-        setRenameConversationDialogOpen(true);
-      }
+    (conversation: AgentGUINodeViewModel["conversations"][number]) => {
+      setRenameConversationTarget(conversation);
+      setRenameConversationDialogOpen(true);
     }
   );
   const conversationRailStoreState =
@@ -4625,7 +4616,9 @@ interface AgentGUIConversationRailPaneProps {
   onCancelDeleteConversations: () => void;
   onConfirmDeleteConversations: () => void;
   onRequestDeleteConversation: (agentSessionId: string) => void;
-  onRequestRenameConversation: (agentSessionId: string) => void;
+  onRequestRenameConversation: (
+    conversation: AgentGUINodeViewModel["conversations"][number]
+  ) => void;
   onCancelDeleteConversation: () => void;
   onConfirmDeleteConversation: () => void;
 }
@@ -7316,7 +7309,9 @@ interface AgentGUIConversationRailSectionProps {
   onRequestDeleteProjectConversations: (path: string) => void;
   onRequestDeleteConversations: () => void;
   onRequestDeleteConversation: (agentSessionId: string) => void;
-  onRequestRenameConversation: (agentSessionId: string) => void;
+  onRequestRenameConversation: (
+    conversation: AgentGUINodeViewModel["conversations"][number]
+  ) => void;
   onCancelDeleteConversation: () => void;
   onConfirmDeleteConversation: () => void;
 }
@@ -7747,7 +7742,9 @@ interface AgentGUIConversationRailItemProps {
   onMarkConversationUnread: (agentSessionId: string) => void;
   onOpenConversationWindow?: (agentSessionId: string) => void;
   onRequestDeleteConversation: (agentSessionId: string) => void;
-  onRequestRenameConversation: (agentSessionId: string) => void;
+  onRequestRenameConversation: (
+    conversation: AgentGUINodeViewModel["conversations"][number]
+  ) => void;
   onCancelDeleteConversation: () => void;
   onConfirmDeleteConversation: () => void;
 }
@@ -7819,8 +7816,8 @@ const AgentGUIConversationRailItem = memo(
       onRequestDeleteConversation(item.id);
     }, [item.id, onRequestDeleteConversation]);
     const handleRequestRename = useCallback(() => {
-      onRequestRenameConversation(item.id);
-    }, [item.id, onRequestRenameConversation]);
+      onRequestRenameConversation(item);
+    }, [item, onRequestRenameConversation]);
     const handleContextMenuRename = useCallback(() => {
       if (contextMenuRenameRequestedRef.current) {
         return;


### PR DESCRIPTION
## Summary

- Use the clicked rail row as the rename dialog target when the session is visible through runtime rail sections but missing from the current activity snapshot.
- Add a regression test for renaming a runtime-section row that is not present in `viewModel.conversations`.
- Document that rail row actions needing row details should use the displayed section model.

## Verification

- `pnpm --filter @tutti-os/agent-gui exec vitest run agent-gui/agentGuiNode/AgentGUINode.spec.tsx --environment jsdom --maxWorkers=3` (passed: 1 file / 177 tests)
- `pnpm typecheck` (passed)
- `pnpm --filter @tutti-os/agent-gui test -- AgentGUINode.spec.tsx --runInBand` (runs the full agent-gui package on this setup; failed on latest `origin/main` with 3 unrelated failures in `useAgentGUINodeController.spec.tsx` and `agentSlashCommandProviderPolicy.spec.ts`)
- `pnpm check:changed --tail-lines 80` (blocked locally: runner fails with `spawn corepack ENOENT`)
- `git push` pre-push `pnpm check:full` (blocked locally for the same `spawn corepack ENOENT`; branch was pushed with `--no-verify` after targeted checks passed)

## Checklist

- [x] I kept the change focused on one concern.
- [x] I updated documentation when behavior, setup, or contributor workflow changed.
- [x] I updated all README/CONTRIBUTING language variants when changing their English source.
- [x] I ran the lowest meaningful local checks for the changed surface.
- [x] My commits are signed off with DCO when required: `git commit -s`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where renaming a conversation from the rail could fail or open with incomplete details when the conversation wasn’t yet present in the current list.
  * Rename actions now consistently open the correct dialog with the selected conversation’s title prefilled, including for historical sessions shown in section views.

* **Documentation**
  * Clarified guidance for conversation list interactions to ensure row actions use the currently displayed row data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->