### PR TITLE
fix(release): gate patch RC workflow branch

### DIFF
--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -70,7 +70,7 @@ jobs:
           ref: ${{ steps.target.outputs.release_target }}
           fetch-depth: 0
 
-      - name: Validate stable release branch
+      - name: Validate release dispatch branch
         shell: bash
         env:
           RELEASE_EVENT_NAME: ${{ github.event_name }}
@@ -83,7 +83,7 @@ jobs:
           fi
 
           case "${RELEASE_MODE:-}" in
-            patch_release|minor_release|major_release)
+            patch_rc_release|patch_release|minor_release|major_release)
               ;;
             *)
               exit 0
@@ -91,7 +91,7 @@ jobs:
           esac
 
           if [[ "${RELEASE_REF_TYPE}" != "branch" ]]; then
-            echo "Stable desktop release modes must be run from main or a release/* branch." >&2
+            echo "Manual desktop release mode ${RELEASE_MODE} must be run from main or a release/* branch." >&2
             exit 1
           fi
 
@@ -99,8 +99,16 @@ jobs:
             main|release/*)
               ;;
             *)
-              echo "Stable desktop release modes must be run from main or a release/* branch, not ${RELEASE_REF_NAME}." >&2
+              echo "Manual desktop release mode ${RELEASE_MODE} must be run from main or a release/* branch, not ${RELEASE_REF_NAME}." >&2
               exit 1
+              ;;
+          esac
+
+          case "${RELEASE_MODE:-}" in
+            patch_release|minor_release|major_release)
+              ;;
+            *)
+              exit 0
               ;;
           esac
 

--- a/docs/conventions/desktop-release.md
+++ b/docs/conventions/desktop-release.md
@@ -58,7 +58,7 @@ Supported manual modes:
 - `explicit_version_release`: publish an explicit release semver such as `0.1.0`, `0.1.0-beta.0`, `0.1.0-rc.0`, `1.13.0-rc.0`, or `2.0.0`
 - `unsigned_dry_run`: build unsigned artifacts without publishing a GitHub Release
 
-Manual stable release modes (`patch_release`, `minor_release`, and `major_release`) are branch-gated before tag resolution or artifact builds:
+Manual RC and stable release modes (`patch_rc_release`, `patch_release`, `minor_release`, and `major_release`) are branch-gated before tag resolution or artifact builds:
 
 - the workflow dispatch branch must be `main` or `release/*`
 - if any remote `release/*` branch exists, stable releases must be dispatched from a `release/*` branch instead of `main`

--- a/tools/scripts/desktop-release-config.test.mjs
+++ b/tools/scripts/desktop-release-config.test.mjs
@@ -85,10 +85,10 @@ test("desktop release workflow publishes rc tags as prereleases and keeps stable
   assert.match(workflow, /patch_beta_release\)\s*\n\s*strategy=patch_beta/);
 });
 
-test("desktop release workflow gates manual stable modes by release branch", async () => {
+test("desktop release workflow gates manual rc and stable modes by release branch", async () => {
   const workflow = await readFile(workflowPath, "utf8");
 
-  assert.match(workflow, /name:\s+Validate stable release branch/);
+  assert.match(workflow, /name:\s+Validate release dispatch branch/);
   assert.match(
     workflow,
     /RELEASE_EVENT_NAME:\s+\${{\s*github\.event_name\s*}}/
@@ -98,6 +98,10 @@ test("desktop release workflow gates manual stable modes by release branch", asy
   assert.match(
     workflow,
     /if \[\[ "\$\{RELEASE_EVENT_NAME\}" != "workflow_dispatch" \]\]; then/
+  );
+  assert.match(
+    workflow,
+    /patch_rc_release\|patch_release\|minor_release\|major_release\)/
   );
   assert.match(workflow, /patch_release\|minor_release\|major_release\)/);
   assert.match(workflow, /main\|release\/\*/);


### PR DESCRIPTION
## Summary
- require manual patch_rc_release dispatches to run from main or release/* branches
- keep the stricter stable-release rule that prefers release/* when release branches exist
- update desktop release conventions for the RC branch gate

## Validation
- pnpm check:changed --tail-lines 80
- prettier --check .github/workflows/desktop-release.yml docs/conventions/desktop-release.md
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated desktop release validation so manual release runs now correctly require a branch-based trigger from `main` or a `release/*` branch.
  * Added support for the manual RC release path, preventing it from being blocked by stable-release-only checks.
* **Documentation**
  * Aligned the desktop release guide with the updated manual release rules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->