### PR TITLE
refactor(agent-gui): remove queued prompt owner release compat

### DIFF
--- a/packages/agent/gui/agentQueuedPromptRuntime.spec.ts
+++ b/packages/agent/gui/agentQueuedPromptRuntime.spec.ts
@@ -201,27 +201,30 @@ describe("AgentQueuedPromptRuntime", () => {
     ).toEqual([]);
   });
 
-  it("keeps deprecated owner-wide claim release for compatibility", () => {
+  it("releases only the exact claimed queue for a shared owner", () => {
     const runtime = createAgentQueuedPromptRuntime();
     enqueue(runtime, "workspace-1", "session-1", ["p1"]);
     enqueue(runtime, "workspace-1", "session-2", ["p2"]);
 
+    const first = runtime.claimNextToDrain({
+      workspaceId: "workspace-1",
+      agentSessionId: "session-1",
+      ownerId: "owner-1"
+    })!;
+    const second = runtime.claimNextToDrain({
+      workspaceId: "workspace-1",
+      agentSessionId: "session-2",
+      ownerId: "owner-1"
+    })!;
+
     expect(
-      runtime.claimNextToDrain({
+      runtime.releaseClaim({
         workspaceId: "workspace-1",
         agentSessionId: "session-1",
-        ownerId: "owner-1"
+        ownerId: "owner-1",
+        claimId: first.claim.claimId
       })
-    ).not.toBeNull();
-    expect(
-      runtime.claimNextToDrain({
-        workspaceId: "workspace-1",
-        agentSessionId: "session-2",
-        ownerId: "owner-1"
-      })
-    ).not.toBeNull();
-
-    runtime.releaseOwner("owner-1");
+    ).toBe(true);
 
     expect(
       runtime.getSessionSnapshot({
@@ -234,7 +237,7 @@ describe("AgentQueuedPromptRuntime", () => {
         workspaceId: "workspace-1",
         agentSessionId: "session-2"
       }).claim
-    ).toBeNull();
+    ).toEqual(second.claim);
   });
 
   it("does not remove or promote a prompt while it is claimed", () => {

--- a/packages/agent/gui/agentQueuedPromptRuntimeCore.ts
+++ b/packages/agent/gui/agentQueuedPromptRuntimeCore.ts
@@ -85,8 +85,6 @@ export interface AgentQueuedPromptRuntime {
     ownerId: string;
     workspaceId: string;
   }): boolean;
-  /** @deprecated Queue drain owners should release exact claims by claim id. */
-  releaseOwner(ownerId: string): void;
   removePrompt(input: {
     agentSessionId: string;
     promptId: string;
@@ -425,23 +423,6 @@ export function createAgentQueuedPromptRuntime(): AgentQueuedPromptRuntime {
         return { ...queue, claim: null };
       });
       return released;
-    },
-    releaseOwner(ownerId) {
-      const normalizedOwnerId = ownerId.trim();
-      if (!normalizedOwnerId) {
-        return;
-      }
-      for (const queue of Object.values(snapshot.queuesByKey)) {
-        if (queue.claim?.ownerId === normalizedOwnerId) {
-          updateQueue(queue.workspaceId, queue.agentSessionId, (current) => ({
-            ...current,
-            claim:
-              current.claim?.ownerId === normalizedOwnerId
-                ? null
-                : current.claim
-          }));
-        }
-      }
     },
     removePrompt(input) {
       const promptId = input.promptId.trim();


### PR DESCRIPTION
## Summary
- remove deprecated queued-prompt `releaseOwner(ownerId)` compatibility API
- tighten queued-prompt runtime coverage around exact claim release semantics

## Validation
- `pnpm --filter @tutti-os/agent-gui exec vitest run agentQueuedPromptRuntime.spec.ts --environment jsdom --maxWorkers=3`
- `pnpm --filter @tutti-os/agent-gui typecheck`
- `pnpm check:agent-activity-runtime-boundaries`
- `pnpm check:changed --tail-lines 40`
- `pnpm check:full` (pre-push)

## Documentation
- Documentation impact check: no durable documentation update needed; exact claim release semantics are already covered in `docs/architecture/agent-gui-node.md`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Releasing a prompt claim now only affects the specific session/claim you release, instead of clearing other active claims for the same owner.
  * Improved prompt queue behavior when one owner has multiple active sessions, preventing unintended loss of other queued work.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->