### PR TITLE
refactor(agent-gui): require session synchronization runtime

### DIFF
--- a/packages/agent/gui/agentActivityRuntime.tsx
+++ b/packages/agent/gui/agentActivityRuntime.tsx
@@ -387,11 +387,11 @@ export interface AgentActivityRuntime {
     workspaceId: string,
     signal?: AbortSignal
   ): Promise<AgentActivitySnapshot>;
-  ensureSessionSynchronized?(
+  ensureSessionSynchronized(
     input: AgentActivityRuntimeEnsureSessionSynchronizedInput
   ): () => void;
   /** @deprecated Use ensureSessionSynchronized. */
-  retainSessionEvents(
+  retainSessionEvents?(
     input: AgentActivityRuntimeRetainSessionEventsInput
   ): () => void;
   sendInput(

--- a/packages/agent/gui/contexts/workspace/presentation/renderer/agentSessions/agentSessionViewStore.spec.ts
+++ b/packages/agent/gui/contexts/workspace/presentation/renderer/agentSessions/agentSessionViewStore.spec.ts
@@ -24,7 +24,7 @@ describe("agentSessionViewStore", () => {
     const reportDiagnostic = vi.fn();
     setAgentActivityRuntimeForTests({
       reportDiagnostic,
-      retainSessionEvents: () => () => {},
+      ensureSessionSynchronized: () => () => {},
       subscribeSessionEvents: (_workspaceId, listener) => {
         streamListener = listener;
         return () => {};
@@ -90,7 +90,7 @@ describe("agentSessionViewStore", () => {
     vi.useFakeTimers();
     let streamListener: ((event: unknown) => void) | undefined;
     setAgentActivityRuntimeForTests({
-      retainSessionEvents: () => () => {},
+      ensureSessionSynchronized: () => () => {},
       subscribeSessionEvents: (_workspaceId, listener) => {
         streamListener = listener;
         return () => {};
@@ -143,7 +143,7 @@ describe("agentSessionViewStore", () => {
     vi.useFakeTimers();
     let streamListener: ((event: unknown) => void) | undefined;
     setAgentActivityRuntimeForTests({
-      retainSessionEvents: () => () => {},
+      ensureSessionSynchronized: () => () => {},
       subscribeSessionEvents: (_workspaceId, listener) => {
         streamListener = listener;
         return () => {};
@@ -190,7 +190,7 @@ describe("agentSessionViewStore", () => {
   it("does not request durable control-state refreshes for inline state patches", async () => {
     let streamListener: ((event: unknown) => void) | undefined;
     setAgentActivityRuntimeForTests({
-      retainSessionEvents: () => () => {},
+      ensureSessionSynchronized: () => () => {},
       subscribeSessionEvents: (_workspaceId, listener) => {
         streamListener = listener;
         return () => {};

--- a/packages/agent/gui/contexts/workspace/presentation/renderer/agentSessions/agentSessionViewStore.ts
+++ b/packages/agent/gui/contexts/workspace/presentation/renderer/agentSessions/agentSessionViewStore.ts
@@ -620,9 +620,7 @@ function ensureActivityStreamUpstream(
   const runtime = getAgentActivityRuntimeByOrigin(entry.payload.origin);
   if (runtime) {
     try {
-      const ensureSessionSynchronized =
-        runtime.ensureSessionSynchronized ?? runtime.retainSessionEvents;
-      entry.releaseRuntimeEvents = ensureSessionSynchronized({
+      entry.releaseRuntimeEvents = runtime.ensureSessionSynchronized({
         workspaceId: entry.payload.workspaceId,
         agentSessionId: entry.payload.agentSessionId,
         onError: (error) => {


### PR DESCRIPTION
## Summary
- Use ensureSessionSynchronized directly in the Agent session view store instead of falling back to deprecated retainSessionEvents.
- Update focused session view store tests to stub the canonical runtime method.
- Make ensureSessionSynchronized required on AgentActivityRuntime; keep deprecated retainSessionEvents optional as public compatibility because full typecheck still has out-of-scope compiled references.

## Validation
- pnpm --filter @tutti-os/agent-gui exec vitest run --environment jsdom --maxWorkers=3 contexts/workspace/presentation/renderer/agentSessions/agentSessionViewStore.spec.ts
- pnpm typecheck
- pnpm check:agent-activity-runtime-boundaries
- pnpm check:changed --tail-lines 80
- pnpm check:full (pre-push)

## Documentation
Documentation impact check: no durable docs update needed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved session synchronization handling for agent activity views.
  * Agent sessions now rely on the current synchronization method consistently, reducing mismatches that could prevent live updates.
  * If synchronization fails, the session view will now more clearly stop live behavior and surface an error state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->