### PR TITLE
refactor(workspace-issues): require agent target for runs

### DIFF
--- a/packages/workspace/issues/service.go
+++ b/packages/workspace/issues/service.go
@@ -248,9 +248,6 @@ func (s Service) CreateRun(ctx context.Context, input CreateRunInput) (Run, erro
 	actorUserID := strings.TrimSpace(input.ActorUserID)
 	agentTargetID := strings.TrimSpace(input.AgentTargetID)
 	agentProvider := strings.ToLower(strings.TrimSpace(input.AgentProvider))
-	if agentTargetID == "" {
-		agentTargetID = legacyAgentTargetIDForProvider(agentProvider)
-	}
 	if agentProvider == "" {
 		agentProvider = agentProviderForAgentTargetID(agentTargetID)
 	}
@@ -306,21 +303,6 @@ func (s Service) CreateRun(ctx context.Context, input CreateRunInput) (Run, erro
 		return Run{}, err
 	}
 	return created, nil
-}
-
-func legacyAgentTargetIDForProvider(provider string) string {
-	switch strings.TrimSpace(provider) {
-	case "codex":
-		return "local:codex"
-	case "claude-code":
-		return "local:claude-code"
-	case "cursor":
-		return "local:cursor"
-	case "opencode":
-		return "local:opencode"
-	default:
-		return ""
-	}
 }
 
 func agentProviderForAgentTargetID(agentTargetID string) string {

--- a/packages/workspace/issues/service_test.go
+++ b/packages/workspace/issues/service_test.go
@@ -336,6 +336,42 @@ func TestServiceCreateRunDerivesProviderFromAgentTargetID(t *testing.T) {
 	}
 }
 
+func TestServiceCreateRunRequiresAgentTargetID(t *testing.T) {
+	store := newFakeStore()
+	service := testService(store)
+	ctx := context.Background()
+
+	issue, err := service.CreateIssue(ctx, CreateIssueInput{
+		WorkspaceID: "workspace-1",
+		TopicID:     DefaultTopicID,
+		ActorUserID: "user-1",
+		Title:       "Editor polish",
+	})
+	if err != nil {
+		t.Fatalf("CreateIssue() error = %v", err)
+	}
+	task, err := service.CreateTask(ctx, CreateTaskInput{
+		WorkspaceID: "workspace-1",
+		IssueID:     issue.IssueID,
+		ActorUserID: "user-1",
+		Title:       "Fix selection highlight",
+	})
+	if err != nil {
+		t.Fatalf("CreateTask() error = %v", err)
+	}
+
+	_, err = service.CreateRun(ctx, CreateRunInput{
+		WorkspaceID:   "workspace-1",
+		IssueID:       issue.IssueID,
+		TaskID:        task.TaskID,
+		ActorUserID:   "user-1",
+		AgentProvider: "codex",
+	})
+	if err != ErrInvalidArgument {
+		t.Fatalf("CreateRun() error = %v, want %v", err, ErrInvalidArgument)
+	}
+}
+
 func TestServiceGetIssueDetailIncludesOutputsFromAllIssueTasks(t *testing.T) {
 	store := newFakeStore()
 	service := testService(store)

--- a/services/tuttid/service/workspace/issues_test.go
+++ b/services/tuttid/service/workspace/issues_test.go
@@ -178,6 +178,7 @@ func TestIssueManagerServiceReconcilesRunningRunsFromBatchAgentSessions(t *testi
 		t.Fatalf("CreateTask() task-2 error = %v", err)
 	}
 	if _, err := service.CreateRun(ctx, "workspace-1", "issue-1", "task-1", CreateIssueManagerRunInput{
+		AgentTargetID:  "local:codex",
 		AgentProvider:  "codex",
 		AgentSessionID: "session-failed",
 		RunID:          "run-failed",
@@ -185,6 +186,7 @@ func TestIssueManagerServiceReconcilesRunningRunsFromBatchAgentSessions(t *testi
 		t.Fatalf("CreateRun() failed error = %v", err)
 	}
 	if _, err := service.CreateRun(ctx, "workspace-1", "issue-1", "task-2", CreateIssueManagerRunInput{
+		AgentTargetID:  "local:codex",
 		AgentProvider:  "codex",
 		AgentSessionID: "session-canceled",
 		RunID:          "run-canceled",
@@ -240,6 +242,7 @@ func TestIssueManagerServiceHidesIssueRunTaskFromVisibleSubtaskCounts(t *testing
 		t.Fatalf("CreateIssue() error = %v", err)
 	}
 	run, err := service.CreateRun(ctx, "workspace-1", "issue-1", "", CreateIssueManagerRunInput{
+		AgentTargetID: "local:codex",
 		AgentProvider: "codex",
 		RunID:         "run-1",
 	})
@@ -307,6 +310,7 @@ func TestIssueManagerServiceCountsPendingAcceptanceSubtasksAsCompletedProgress(t
 		t.Fatalf("CreateTask() error = %v", err)
 	}
 	run, err := service.CreateRun(ctx, "workspace-1", "issue-1", "task-1", CreateIssueManagerRunInput{
+		AgentTargetID: "local:codex",
 		AgentProvider: "codex",
 		RunID:         "run-1",
 	})


### PR DESCRIPTION
## Summary
- remove the legacy CreateRun fallback that derived agentTargetId from agentProvider
- keep deriving agentProvider from local agentTargetId when provider is omitted
- add regression coverage that provider-only CreateRun input is invalid

## Validation
- go test ./... (from packages/workspace/issues)
- git diff --check -- packages/workspace/issues

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved run creation validation so attempts to start a run without an agent target now return a clear invalid argument error.
  * Updated input normalization behavior: when an agent target is provided, the agent provider is derived accordingly (no legacy fallback).
  * Added automated test coverage for missing agent target handling and updated existing run-creation tests to include the required agent target.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->