### PR TITLE
refactor(workspace-agent): remove retained session event alias

### DIFF
--- a/apps/desktop/src/renderer/src/features/workspace-agent/services/createDesktopAgentActivityRuntime.test.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-agent/services/createDesktopAgentActivityRuntime.test.ts
@@ -266,6 +266,39 @@ test("desktop agent activity runtime reads archived prompt assets", async () => 
   });
 });
 
+test("desktop agent activity runtime delegates canonical session synchronization only", () => {
+  const calls: unknown[] = [];
+  const runtime = createDesktopAgentActivityRuntime({
+    ...createWorkspaceAgentActivityService(),
+    ensureSessionSynchronized(input) {
+      calls.push(input);
+      return () => {
+        calls.push("dispose");
+      };
+    }
+  });
+
+  const dispose = runtime.ensureSessionSynchronized?.({
+    workspaceId: "workspace-1",
+    agentSessionId: "session-1",
+    afterVersion: 42
+  });
+  dispose?.();
+
+  assert.deepEqual(calls, [
+    {
+      workspaceId: "workspace-1",
+      agentSessionId: "session-1",
+      afterVersion: 42
+    },
+    "dispose"
+  ]);
+  assert.equal(
+    (runtime as { retainSessionEvents?: unknown }).retainSessionEvents,
+    undefined
+  );
+});
+
 function createWorkspaceAgentActivityService(): IWorkspaceAgentActivityService {
   return {
     _serviceBrand: undefined,

--- a/apps/desktop/src/renderer/src/features/workspace-agent/services/createDesktopAgentActivityRuntime.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-agent/services/createDesktopAgentActivityRuntime.ts
@@ -342,8 +342,6 @@ export function createDesktopAgentActivityRuntime(
       });
       return workspaceAgentActivityService.ensureSessionSynchronized(input);
     },
-    retainSessionEvents: (input) =>
-      workspaceAgentActivityService.ensureSessionSynchronized(input),
     async sendInput(input) {
       reportAgentSubmitTraceDiagnostic({
         agentSessionId: input.agentSessionId,


### PR DESCRIPTION
## Summary
- remove the desktop AgentActivityRuntime retainSessionEvents compatibility alias
- keep ensureSessionSynchronized as the sole session synchronization runtime surface
- add focused runtime coverage for canonical synchronization delegation and legacy alias absence

## Validation
- node --import ./test/register-asset-stub.mjs --test --experimental-strip-types src/renderer/src/features/workspace-agent/services/createDesktopAgentActivityRuntime.test.ts
- pnpm --filter @tutti-os/desktop typecheck
- pnpm lint:ts
- pnpm check:changed --tail-lines 80
- pnpm check:full