### PR TITLE
refactor(agent-gui): remove legacy settings normalization

### DIFF
--- a/packages/agent/gui/contexts/settings/domain/agentSettings.spec.ts
+++ b/packages/agent/gui/contexts/settings/domain/agentSettings.spec.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  DEFAULT_AGENT_SETTINGS,
+  MAX_UI_FONT_SIZE,
+  MIN_UI_FONT_SIZE,
+  normalizeAgentSettings
+} from "./agentSettings";
+
+describe("normalizeAgentSettings", () => {
+  it("ignores removed legacy settings keys", () => {
+    const provider = DEFAULT_AGENT_SETTINGS.defaultProvider;
+
+    const normalized = normalizeAgentSettings({
+      modelByProvider: {
+        [provider]: "legacy-model"
+      },
+      normalizeZoomOnTerminalClick: !DEFAULT_AGENT_SETTINGS.focusNodeOnClick,
+      uiFontScalePercent: 140
+    });
+
+    expect(normalized.customModelByProvider[provider]).toBe(
+      DEFAULT_AGENT_SETTINGS.customModelByProvider[provider]
+    );
+    expect(normalized.customModelEnabledByProvider[provider]).toBe(
+      DEFAULT_AGENT_SETTINGS.customModelEnabledByProvider[provider]
+    );
+    expect(normalized.focusNodeOnClick).toBe(
+      DEFAULT_AGENT_SETTINGS.focusNodeOnClick
+    );
+    expect(normalized.uiFontSize).toBe(DEFAULT_AGENT_SETTINGS.uiFontSize);
+  });
+
+  it("normalizes current settings keys", () => {
+    const provider = DEFAULT_AGENT_SETTINGS.defaultProvider;
+    const uiFontSize =
+      DEFAULT_AGENT_SETTINGS.uiFontSize === MIN_UI_FONT_SIZE
+        ? MAX_UI_FONT_SIZE
+        : MIN_UI_FONT_SIZE;
+
+    const normalized = normalizeAgentSettings({
+      customModelEnabledByProvider: {
+        [provider]: true
+      },
+      customModelByProvider: {
+        [provider]: "current-model"
+      },
+      focusNodeOnClick: !DEFAULT_AGENT_SETTINGS.focusNodeOnClick,
+      uiFontSize
+    });
+
+    expect(normalized.customModelEnabledByProvider[provider]).toBe(true);
+    expect(normalized.customModelByProvider[provider]).toBe("current-model");
+    expect(normalized.focusNodeOnClick).toBe(
+      !DEFAULT_AGENT_SETTINGS.focusNodeOnClick
+    );
+    expect(normalized.uiFontSize).toBe(uiFontSize);
+  });
+});

--- a/packages/agent/gui/contexts/settings/domain/agentSettings.ts
+++ b/packages/agent/gui/contexts/settings/domain/agentSettings.ts
@@ -87,9 +87,6 @@ export const MAX_TERMINAL_FONT_SIZE = 22;
 export const MIN_UI_FONT_SIZE = 14;
 export const MAX_UI_FONT_SIZE = 24;
 
-const MIN_LEGACY_UI_FONT_SCALE_PERCENT = 85;
-const MAX_LEGACY_UI_FONT_SCALE_PERCENT = 140;
-
 export {
   AGENT_PROVIDER_CAPABILITIES,
   AGENT_PROVIDER_LABEL,
@@ -176,19 +173,14 @@ export function normalizeAgentSettings(value: unknown): AgentSettings {
     ? value.customModelByProvider
     : {};
 
-  const legacyModelInput = isRecord(value.modelByProvider)
-    ? value.modelByProvider
-    : {};
-
   const customModelEnabledByProvider = AGENT_PROVIDERS.reduce<
     AgentCustomModelEnabledByProvider<AgentProvider>
   >(
     (acc, provider) => {
       const normalizedEnabled = normalizeBoolean(enabledInput[provider]);
-      const legacyModel = normalizeTextValue(legacyModelInput[provider]);
 
       acc[provider] =
-        normalizedEnabled === null ? legacyModel.length > 0 : normalizedEnabled;
+        normalizedEnabled === null ? acc[provider] : normalizedEnabled;
 
       return acc;
     },
@@ -199,8 +191,7 @@ export function normalizeAgentSettings(value: unknown): AgentSettings {
     AgentCustomModelByProvider<AgentProvider>
   >(
     (acc, provider) => {
-      const current = customModelInput[provider] ?? legacyModelInput[provider];
-      acc[provider] = normalizeTextValue(current);
+      acc[provider] = normalizeTextValue(customModelInput[provider]);
       return acc;
     },
     { ...DEFAULT_AGENT_SETTINGS.customModelByProvider }
@@ -242,7 +233,6 @@ export function normalizeAgentSettings(value: unknown): AgentSettings {
   );
   const focusNodeOnClick =
     normalizeBoolean(value.focusNodeOnClick) ??
-    normalizeBoolean(value.normalizeZoomOnTerminalClick) ??
     DEFAULT_AGENT_SETTINGS.focusNodeOnClick;
   const focusNodeTargetZoom = normalizeFocusNodeTargetZoom(
     value.focusNodeTargetZoom,
@@ -302,16 +292,9 @@ export function normalizeAgentSettings(value: unknown): AgentSettings {
     value.terminalFontFamily.trim().length > 0
       ? value.terminalFontFamily.trim()
       : DEFAULT_AGENT_SETTINGS.terminalFontFamily;
-  const legacyUiFontScalePercent = normalizeIntegerInRange(
-    value.uiFontScalePercent,
-    Math.round((DEFAULT_AGENT_SETTINGS.uiFontSize / 16) * 100),
-    MIN_LEGACY_UI_FONT_SCALE_PERCENT,
-    MAX_LEGACY_UI_FONT_SCALE_PERCENT
-  );
-  const fallbackUiFontSize = Math.round((legacyUiFontScalePercent / 100) * 16);
   const uiFontSize = normalizeIntegerInRange(
     value.uiFontSize,
-    fallbackUiFontSize,
+    DEFAULT_AGENT_SETTINGS.uiFontSize,
     MIN_UI_FONT_SIZE,
     MAX_UI_FONT_SIZE
   );


### PR DESCRIPTION
## Summary
- Remove legacy `modelByProvider` fallback from agent settings normalization
- Remove legacy `normalizeZoomOnTerminalClick` fallback for `focusNodeOnClick`
- Remove legacy `uiFontScalePercent` mapping and keep `uiFontSize` as the normalized source
- Add focused settings-domain coverage for ignored legacy keys and current-key normalization

## Validation
- `pnpm --filter @tutti-os/agent-gui exec vitest run contexts/settings/domain/agentSettings.spec.ts --environment jsdom --maxWorkers=3`
- `pnpm exec oxfmt --check packages/agent/gui/contexts/settings/domain/agentSettings.ts packages/agent/gui/contexts/settings/domain/agentSettings.spec.ts`
- `git diff --check`
- `pnpm check:changed --tail-lines 80`
- `pnpm check:full` (pre-push)

## Notes
- Documentation impact check: no durable documentation update needed; this is an internal settings normalizer cleanup without public API, user-visible copy, runtime override, or ownership changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved settings handling so only the current preference values are applied.
  * Legacy settings no longer override custom model, click-focus, or font-size preferences.
  * User interface font size now falls back more predictably to the default value when needed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->