### PR TITLE
fix(agentstatus): treat Codex API key as authenticated without login

### DIFF
--- a/.changeset/codex-api-key-auth-without-login.md
+++ b/.changeset/codex-api-key-auth-without-login.md
@@ -1,0 +1,5 @@
+---
+"@tutti-os/desktop": patch
+---
+
+Treat Codex API-key billing as authenticated in the environment wizard. Codex can run with `OPENAI_API_KEY` or a `config.toml` `api_key` without a ChatGPT login; `codex login status` only reflects the OAuth session and reports "Not logged in" for API-key users, so the provider status probe now detects those credentials the same way Claude Code API Usage Billing does and reports the provider as ready instead of blocking on "未登录". A bare custom base URL without a credential is still not treated as API billing.

--- a/docs/conventions/troubleshooting.md
+++ b/docs/conventions/troubleshooting.md
@@ -1427,6 +1427,31 @@ delimited by ---`, and the composer skill picker may show partial or
   Add or update `agentstatus` tests for the Codex status/login command shape,
   then run `cd services/tuttid && go test ./service/agentstatus`.
 
+### Codex provider shows login required when only an API key is configured
+
+- Symptom:
+  The environment wizard / dock marks Codex as needing login ("未登录") even
+  though `OPENAI_API_KEY` is set or `~/.codex/config.toml` declares `api_key`,
+  and Codex sessions can already run successfully.
+- Quick checks:
+  Run `codex login status` (often prints `Not logged in`). Confirm an API
+  credential exists via `echo $OPENAI_API_KEY` or
+  `grep -E 'api_key' ~/.codex/config.toml`.
+- Root cause:
+  `codex login status` only reflects a ChatGPT OAuth session. API-key billing
+  is invisible to that command, so tuttid used to treat the provider as
+  `auth_required` and block the wizard even though the runtime can authenticate
+  with the key.
+- Fix:
+  Provider status should call `providerHasAPICredential` for Codex the same way
+  it does for Claude Code. When an API key is present (env or config.toml),
+  report auth as authenticated with method `apiKey` / label
+  `API Usage Billing` instead of requiring login. A bare custom base URL
+  without a credential must not trigger this override.
+- Validation:
+  Add or update `agentstatus` tests for Codex API-key-without-login readiness,
+  then run `cd services/tuttid && go test ./service/agentstatus`.
+
 ### Codex app-server subagent output appears as the parent reply
 
 - Symptom:

--- a/services/tuttid/service/agentstatus/provider_custom_config.go
+++ b/services/tuttid/service/agentstatus/provider_custom_config.go
@@ -57,7 +57,8 @@ func (s Service) providerUsesCustomConfig(provider string) bool {
 // via env vars or on-disk config. This is the signal that usage is billed to an
 // API account rather than a Console/subscription session, and it overrides
 // whatever `claude auth status` reports (which only reflects the stored OAuth
-// session, not env/settings credentials).
+// session, not env/settings credentials). Used for Claude Code and Codex today;
+// other providers return false until credential env/config detection is added.
 func (s Service) providerHasAPICredential(provider string) bool {
 	for _, key := range providerCredentialEnvVars(provider) {
 		if strings.TrimSpace(s.lookupEnv(key)) != "" {

--- a/services/tuttid/service/agentstatus/service.go
+++ b/services/tuttid/service/agentstatus/service.go
@@ -624,16 +624,17 @@ func (s Service) statusForSpec(ctx context.Context, spec ProviderSpec, now time.
 	} else {
 		actions = append(actions, terminalAction(ActionLogin, loginCommandForRuntime(spec, runtimeResolution)))
 
-		// Claude Code can run in API Usage Billing mode — an API key, an auth
+		// Providers can run in API Usage Billing mode — an API key, an auth
 		// token, or an apiKeyHelper — which bills usage to an API account and
-		// overrides any stored OAuth/subscription session. `claude auth status`
-		// only reflects the stored session, so it is blind to these env/settings
-		// credentials; detect them directly and prefer that signal over whatever
-		// the CLI reports, so the wizard shows "已配置 API 计费" instead of a
-		// stale OAuth label or "未登录". A bare custom endpoint without a
-		// credential is NOT API billing (the user may still be on an OAuth
-		// session), so it does not trigger this override.
-		if spec.Provider == agentprovider.ClaudeCode && s.providerHasAPICredential(agentprovider.ClaudeCode) {
+		// overrides any stored OAuth/subscription session. CLI auth-status
+		// commands (e.g. `claude auth status`, `codex login status`) only
+		// reflect the stored session, so they are blind to these env/config
+		// credentials; detect them directly and prefer that signal over
+		// whatever the CLI reports, so the wizard shows "已配置 API 计费"
+		// instead of a stale OAuth label or "未登录". A bare custom endpoint
+		// without a credential is NOT API billing (the user may still be on
+		// an OAuth session), so it does not trigger this override.
+		if s.providerHasAPICredential(spec.Provider) {
 			auth.Status = AuthAuthenticated
 			auth.AccountLabel = "API Usage Billing"
 			auth.AuthMethod = "apiKey"

--- a/services/tuttid/service/agentstatus/service_test.go
+++ b/services/tuttid/service/agentstatus/service_test.go
@@ -2915,6 +2915,84 @@ func TestServiceListReportsReadyForClaudeAPIBillingDespiteOauthTokenStatus(t *te
 	}
 }
 
+// Codex can run with OPENAI_API_KEY (or config.toml api_key) without a ChatGPT
+// login. `codex login status` only reflects the OAuth session, so an API-key
+// user is reported as "Not logged in" even though the CLI can already run.
+// Detect the credential and treat the provider as ready instead of blocking.
+func TestServiceListReportsReadyForCodexAPIKeyWithoutLogin(t *testing.T) {
+	service := testService(func(name string) (string, error) {
+		return "/usr/local/bin/" + name, nil
+	}, map[string]bool{})
+	service.Environ = func() []string {
+		return []string{"OPENAI_API_KEY=sk-test"}
+	}
+	service.RunAuthStatusCommand = func(_ context.Context, spec ProviderSpec, binaryPath string) (AuthInfo, bool) {
+		if spec.Provider != "codex" {
+			t.Fatalf("Provider = %q, want codex", spec.Provider)
+		}
+		if binaryPath != "/usr/local/bin/codex" {
+			t.Fatalf("binaryPath = %q, want /usr/local/bin/codex", binaryPath)
+		}
+		return parseCodexAuthStatusOutput([]byte("Not logged in"))
+	}
+
+	snapshot, err := service.List(context.Background(), ListInput{Providers: []string{"codex"}})
+	if err != nil {
+		t.Fatalf("List() error = %v", err)
+	}
+
+	status := onlyStatus(t, snapshot)
+	if status.Availability.Status != AvailabilityReady {
+		t.Fatalf("Availability.Status = %q, want %q", status.Availability.Status, AvailabilityReady)
+	}
+	if status.Auth.Status != AuthAuthenticated {
+		t.Fatalf("Auth.Status = %q, want %q", status.Auth.Status, AuthAuthenticated)
+	}
+	if status.Auth.AuthMethod != "apiKey" {
+		t.Fatalf("Auth.AuthMethod = %q, want %q", status.Auth.AuthMethod, "apiKey")
+	}
+	if status.Auth.AccountLabel != "API Usage Billing" {
+		t.Fatalf("Auth.AccountLabel = %q, want %q", status.Auth.AccountLabel, "API Usage Billing")
+	}
+}
+
+func TestServiceListReportsReadyForCodexConfigTomlAPIKeyWithoutLogin(t *testing.T) {
+	home := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(home, ".codex"), 0o755); err != nil {
+		t.Fatalf("mkdir .codex: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(home, ".codex", "config.toml"), []byte("api_key = \"sk-inline\"\n"), 0o600); err != nil {
+		t.Fatalf("write config.toml: %v", err)
+	}
+	service := testService(func(name string) (string, error) {
+		return "/usr/local/bin/" + name, nil
+	}, map[string]bool{})
+	service.HomeDir = func() (string, error) { return home, nil }
+	service.Environ = func() []string { return []string{} }
+	service.RunAuthStatusCommand = func(context.Context, ProviderSpec, string) (AuthInfo, bool) {
+		return parseCodexAuthStatusOutput([]byte("Not logged in"))
+	}
+
+	snapshot, err := service.List(context.Background(), ListInput{Providers: []string{"codex"}})
+	if err != nil {
+		t.Fatalf("List() error = %v", err)
+	}
+
+	status := onlyStatus(t, snapshot)
+	if status.Availability.Status != AvailabilityReady {
+		t.Fatalf("Availability.Status = %q, want %q", status.Availability.Status, AvailabilityReady)
+	}
+	if status.Auth.Status != AuthAuthenticated {
+		t.Fatalf("Auth.Status = %q, want %q", status.Auth.Status, AuthAuthenticated)
+	}
+	if status.Auth.AuthMethod != "apiKey" {
+		t.Fatalf("Auth.AuthMethod = %q, want apiKey", status.Auth.AuthMethod)
+	}
+	if status.Auth.AccountLabel != "API Usage Billing" {
+		t.Fatalf("Auth.AccountLabel = %q, want %q", status.Auth.AccountLabel, "API Usage Billing")
+	}
+}
+
 // A bare custom endpoint (no API credential) must NOT be mislabeled as API
 // Usage Billing. The user may be on an OAuth/subscription session against that
 // endpoint, so the CLI-reported auth status and label must be preserved.


### PR DESCRIPTION
Codex can run with OPENAI_API_KEY or config.toml api_key while login status still reports not logged in; prefer the credential signal so the wizard does not block on 未登录.

## Summary

<!-- What changed and why? -->

## Verification

<!-- Commands run, manual checks, or why verification is not applicable. -->

## Checklist

- [ ] I kept the change focused on one concern.
- [ ] I updated documentation when behavior, setup, or contributor workflow changed.
- [ ] I updated all README/CONTRIBUTING language variants when changing their English source.
- [ ] I ran the lowest meaningful local checks for the changed surface.
- [ ] My commits are signed off with DCO when required: `git commit -s`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to provider status/auth labeling in tuttid agentstatus; runtime auth behavior is unchanged and the pattern already exists for Claude Code.
> 
> **Overview**
> The environment wizard and dock no longer mark Codex as **auth required** when only API billing is configured. **`codex login status`** still reflects ChatGPT OAuth and can say not logged in even when **`OPENAI_API_KEY`** or **`~/.codex/config.toml`** **`api_key`** is set.
> 
> Provider status now applies the same **API Usage Billing** override used for Claude Code: if **`providerHasAPICredential`** finds a credential for the current provider, auth is reported as authenticated with **`apiKey`** instead of trusting the CLI login probe alone. A custom base URL without a credential still does not count as API billing.
> 
> Adds **`agentstatus`** tests for Codex env and config.toml keys, a troubleshooting entry, and a desktop patch changeset.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fb52cb81ebc55ad24a3167df4dd94ae0f8e7db5b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Codex is now recognized as authenticated when an API key is configured, even if the CLI shows “Not logged in.”
  * The environment wizard now correctly shows API-based billing for supported providers when an API key is present.
  * Custom base URLs without any configured credential still won’t be treated as authenticated.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->