### PR TITLE
fix(agent): reduce performance diagnostic churn

### DIFF
--- a/apps/desktop/src/renderer/src/features/analytics/services/internal/predefinePageviewAnalytics.test.ts
+++ b/apps/desktop/src/renderer/src/features/analytics/services/internal/predefinePageviewAnalytics.test.ts
@@ -36,6 +36,7 @@ test("predefine pageview analytics reports app opens before focus", () => {
     runtime
   });
   runtime.emitFocus();
+  runtime.flushFocusReports();
 
   assert.deepEqual(reporterCalls, [
     [
@@ -64,6 +65,7 @@ test("predefine pageview analytics reports every explicit focus", () => {
   });
   runtime.emitFocus();
   runtime.emitFocus();
+  runtime.flushFocusReports();
 
   assert.deepEqual(
     reporterCalls.map((call) => call[0]?.name),
@@ -81,12 +83,33 @@ test("predefine pageview analytics reports focus after time changes", () => {
     runtime
   });
   runtime.emitFocus();
+  runtime.flushFocusReports();
   runtime.advanceTo(new Date(2026, 5, 10, 10, 0, 0).getTime());
   runtime.emitFocus();
+  runtime.flushFocusReports();
 
   assert.deepEqual(
     reporterCalls.map((call) => call[0]?.name),
     ["app.pageview", "app.pageview", "app.pageview"]
+  );
+});
+
+test("predefine pageview analytics cancels pending focus reports on dispose", () => {
+  const reporterCalls: ReporterEventInput[][] = [];
+  const runtime = createRuntimeHarness();
+
+  const controller = startPredefinePageviewAnalytics({
+    reporterService: createReporterService(reporterCalls),
+    reporterNow: () => runtime.now(),
+    runtime
+  });
+  runtime.emitFocus();
+  controller.dispose();
+  runtime.flushFocusReports();
+
+  assert.deepEqual(
+    reporterCalls.map((call) => call[0]?.name),
+    ["app.pageview"]
   );
 });
 
@@ -101,9 +124,11 @@ function createReporterService(calls: ReporterEventInput[][] = []) {
 function createRuntimeHarness(input: { now?: number } = {}) {
   let now = input.now ?? new Date(2026, 5, 9, 10, 0, 0).getTime();
   const focusListeners = new Set<() => void>();
+  const focusReports = new Set<() => void>();
   const runtime: PredefinePageviewAnalyticsRuntime & {
     advanceTo(nextNow: number): void;
     emitFocus(): void;
+    flushFocusReports(): void;
     now(): number;
   } = {
     addFocusListener(listener) {
@@ -120,8 +145,21 @@ function createRuntimeHarness(input: { now?: number } = {}) {
         listener();
       }
     },
+    flushFocusReports() {
+      const reports = [...focusReports];
+      focusReports.clear();
+      for (const report of reports) {
+        report();
+      }
+    },
     now() {
       return now;
+    },
+    scheduleFocusReport(listener) {
+      focusReports.add(listener);
+      return () => {
+        focusReports.delete(listener);
+      };
     }
   };
   return runtime;

--- a/apps/desktop/src/renderer/src/features/analytics/services/internal/predefinePageviewAnalytics.ts
+++ b/apps/desktop/src/renderer/src/features/analytics/services/internal/predefinePageviewAnalytics.ts
@@ -9,6 +9,7 @@ export interface PredefinePageviewAnalyticsController {
 
 export interface PredefinePageviewAnalyticsRuntime {
   addFocusListener(listener: () => void): () => void;
+  scheduleFocusReport?(listener: () => void): () => void;
 }
 
 export function startPredefinePageviewAnalytics(input: {
@@ -19,6 +20,7 @@ export function startPredefinePageviewAnalytics(input: {
   const runtime = input.runtime ?? createDocumentPredefinePageviewRuntime();
   const now = input.reporterNow ?? Date.now;
   let disposed = false;
+  const pendingFocusReports = new Set<() => void>();
 
   const reportPageview = () => {
     if (disposed) {
@@ -38,7 +40,15 @@ export function startPredefinePageviewAnalytics(input: {
     if (disposed) {
       return;
     }
-    reportPageview();
+    let cancelFocusReport = () => {};
+    const runFocusReport = () => {
+      pendingFocusReports.delete(cancelFocusReport);
+      reportPageview();
+    };
+    cancelFocusReport =
+      runtime.scheduleFocusReport?.(runFocusReport) ??
+      createTimeoutFocusReport(runFocusReport);
+    pendingFocusReports.add(cancelFocusReport);
   };
 
   const unsubscribeFocus = runtime.addFocusListener(reportFocus);
@@ -51,10 +61,21 @@ export function startPredefinePageviewAnalytics(input: {
         return;
       }
       disposed = true;
+      for (const cancelFocusReport of pendingFocusReports) {
+        cancelFocusReport();
+      }
+      pendingFocusReports.clear();
       unsubscribeFocus();
     },
     reportAppOpen,
     reportFocus
+  };
+}
+
+function createTimeoutFocusReport(listener: () => void): () => void {
+  const timeoutId = window.setTimeout(listener, 0);
+  return () => {
+    window.clearTimeout(timeoutId);
   };
 }
 
@@ -65,6 +86,9 @@ function createDocumentPredefinePageviewRuntime(): PredefinePageviewAnalyticsRun
       return () => {
         window.removeEventListener("focus", listener);
       };
+    },
+    scheduleFocusReport(listener) {
+      return createTimeoutFocusReport(listener);
     }
   };
 }

--- a/apps/desktop/src/renderer/src/features/workspace-agent/services/internal/workspaceAgentActivityService.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-agent/services/internal/workspaceAgentActivityService.ts
@@ -79,11 +79,24 @@ interface PendingActivityUpdateBatch {
   workspaceId: string;
 }
 
+interface InlineActivityAppliedTraceBatch {
+  agentSessionId: string;
+  appliedCount: number;
+  eventTypeCounts: Record<string, number>;
+  latestSession: Record<string, unknown> | null;
+  latestStatePatch: Record<string, unknown> | null;
+  messageCount: number;
+  statePatchCount: number;
+  timer: ReturnType<typeof setTimeout> | null;
+  workspaceId: string;
+}
+
 interface DeletedSessionTombstone {
   deletedAtUnixMs: number;
 }
 
 const ACTIVITY_UPDATE_BATCH_DELAY_MS = 33;
+const INLINE_ACTIVITY_APPLIED_TRACE_DELAY_MS = 1000;
 
 export class WorkspaceAgentActivityService implements IWorkspaceAgentActivityService {
   readonly _serviceBrand = undefined;
@@ -101,6 +114,10 @@ export class WorkspaceAgentActivityService implements IWorkspaceAgentActivitySer
   private readonly pendingActivityUpdateBatches = new Map<
     string,
     PendingActivityUpdateBatch
+  >();
+  private readonly pendingInlineActivityAppliedTraceBatches = new Map<
+    string,
+    InlineActivityAppliedTraceBatch
   >();
   private readonly deletedSessionTombstones = new Map<
     string,
@@ -1652,19 +1669,18 @@ export class WorkspaceAgentActivityService implements IWorkspaceAgentActivitySer
       });
       return false;
     }
-    this.reportReconcileTrace({
+    this.scheduleInlineActivityAppliedTrace({
       agentSessionId: input.agentSessionId,
-      traceEvent: "inline.applied",
-      workspaceId: input.workspaceId,
-      fields: {
-        eventType: input.eventType,
-        incomingSession: agentActivitySessionReconcileDiagnosticDetails(
-          result.session
-        ),
-        statePatch: agentActivityStatePatchReconcileDiagnosticDetails(
-          result.statePatch
-        )
-      }
+      eventType: input.eventType,
+      latestSession: agentActivitySessionReconcileDiagnosticDetails(
+        result.session
+      ),
+      latestStatePatch: agentActivityStatePatchReconcileDiagnosticDetails(
+        result.statePatch
+      ),
+      messageCount: result.messages.length,
+      statePatchCount: result.statePatch ? 1 : 0,
+      workspaceId: input.workspaceId
     });
     for (const message of result.messages) {
       this.emitSessionEvent(
@@ -1679,6 +1695,79 @@ export class WorkspaceAgentActivityService implements IWorkspaceAgentActivitySer
       });
     }
     return true;
+  }
+
+  private scheduleInlineActivityAppliedTrace(input: {
+    agentSessionId: string;
+    eventType: string;
+    latestSession: Record<string, unknown> | null;
+    latestStatePatch: Record<string, unknown> | null;
+    messageCount: number;
+    statePatchCount: number;
+    workspaceId: string;
+  }): void {
+    const key = sessionKey(input.workspaceId, input.agentSessionId);
+    let batch = this.pendingInlineActivityAppliedTraceBatches.get(key);
+    if (!batch) {
+      batch = {
+        agentSessionId: input.agentSessionId,
+        appliedCount: 0,
+        eventTypeCounts: {},
+        latestSession: null,
+        latestStatePatch: null,
+        messageCount: 0,
+        statePatchCount: 0,
+        timer: null,
+        workspaceId: input.workspaceId
+      };
+      this.pendingInlineActivityAppliedTraceBatches.set(key, batch);
+    }
+    batch.appliedCount += 1;
+    batch.eventTypeCounts[input.eventType] =
+      (batch.eventTypeCounts[input.eventType] ?? 0) + 1;
+    batch.latestSession = input.latestSession;
+    batch.latestStatePatch = input.latestStatePatch;
+    batch.messageCount += input.messageCount;
+    batch.statePatchCount += input.statePatchCount;
+    if (batch.timer !== null) {
+      return;
+    }
+    batch.timer = setTimeout(() => {
+      batch.timer = null;
+      this.flushInlineActivityAppliedTrace(
+        batch.agentSessionId,
+        batch.workspaceId
+      );
+    }, INLINE_ACTIVITY_APPLIED_TRACE_DELAY_MS);
+  }
+
+  private flushInlineActivityAppliedTrace(
+    agentSessionId: string,
+    workspaceId: string
+  ): void {
+    const key = sessionKey(workspaceId, agentSessionId);
+    const batch = this.pendingInlineActivityAppliedTraceBatches.get(key);
+    if (!batch) {
+      return;
+    }
+    this.pendingInlineActivityAppliedTraceBatches.delete(key);
+    if (batch.timer !== null) {
+      clearTimeout(batch.timer);
+      batch.timer = null;
+    }
+    this.reportReconcileTrace({
+      agentSessionId: batch.agentSessionId,
+      traceEvent: "inline.applied.summary",
+      workspaceId: batch.workspaceId,
+      fields: {
+        appliedCount: batch.appliedCount,
+        eventTypeCounts: batch.eventTypeCounts,
+        latestSession: batch.latestSession,
+        latestStatePatch: batch.latestStatePatch,
+        messageCount: batch.messageCount,
+        statePatchCount: batch.statePatchCount
+      }
+    });
   }
 }
 

--- a/docs/conventions/troubleshooting.md
+++ b/docs/conventions/troubleshooting.md
@@ -2282,6 +2282,34 @@ target app`. Compare `/Applications/Tutti.app/Contents/Info.plist` with the
   [createDesktopAgentActivityRuntime.ts](../../apps/desktop/src/renderer/src/features/workspace-agent/services/createDesktopAgentActivityRuntime.ts)
   [agent-gui-node.md](../architecture/agent-gui-node.md)
 
+### Agent diagnostics flood while a turn is streaming
+
+- Symptom:
+  Exported developer logs are dominated by agent diagnostics and the app feels
+  sluggish while a streaming turn is active or while switching AgentGUI sessions.
+- Quick checks:
+  Count repeated `agent submit trace`, `agent.activity.reconcile.trace`, and
+  `agent.gui.node.render_state_changed` lines before blaming one visible click.
+  Runtime event emissions should appear as
+  `runtime.events_emitted.summary`/`runtime.async_events_emitted.summary`;
+  successful inline reconciles should appear as `inline.applied.summary`.
+  If the old per-event names dominate a new log, the running app is stale.
+- Root cause:
+  Per-token runtime events and renderer inline reconcile commits can produce
+  thousands of diagnostic writes. Those writes compete with rendering and also
+  inflate trace/log exports enough to obscure the actual session-switch work.
+- Fix:
+  Keep success-path diagnostics aggregated by turn or short time window. Reserve
+  per-event logging for failures or rare state transitions.
+- Validation:
+  Reproduce a streaming turn and confirm the high-volume success paths collapse
+  to summary entries while `inline.not_applied` and submit failures still retain
+  event-level detail.
+- References:
+  [controller.go](../../packages/agent/daemon/runtime/controller.go)
+  [workspaceAgentActivityService.ts](../../apps/desktop/src/renderer/src/features/workspace-agent/services/internal/workspaceAgentActivityService.ts)
+  [useAgentGUINodeController.ts](../../packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUINodeController.ts)
+
 ### Browser Node focus pings miss iframe-hosted editors
 
 - Symptom:

--- a/packages/agent/daemon/runtime/controller.go
+++ b/packages/agent/daemon/runtime/controller.go
@@ -1168,6 +1168,7 @@ func (c *Controller) runExecTurn(ctx context.Context, session Session, adapter A
 		return
 	}
 	var emitted []activityshared.Event
+	var emittedSummary agentSubmitRuntimeEventSummary
 	metadata := execMetadataFromContext(ctx)
 	logAgentSubmitTrace("runtime.turn_goroutine_started", session, turnID, metadata, nil)
 	emit := func(events []activityshared.Event) {
@@ -1183,11 +1184,7 @@ func (c *Controller) runExecTurn(ctx context.Context, session Session, adapter A
 		emitted = append(emitted, events...)
 		c.publish(session, events)
 		c.enqueueSessionReport(ctx, session, events)
-		logAgentSubmitTrace("runtime.events_emitted", session, turnID, metadata, map[string]any{
-			"activity_event_count": len(events),
-			"session_status":       session.Status,
-			"turn_phase":           turnLifecyclePhaseFromEvents(events),
-		})
+		emittedSummary.observe(events, session)
 	}
 	emitCommands := func(snapshot AgentSessionCommandSnapshot) {
 		c.applyCommandSnapshot(session, snapshot)
@@ -1226,6 +1223,7 @@ func (c *Controller) runExecTurn(ctx context.Context, session Session, adapter A
 	if shouldAdvanceSessionUpdatedAtFromEvents(statusEvents) {
 		session.UpdatedAtUnixMS = unixMS(now())
 	}
+	emittedSummary.log("runtime.events_emitted.summary", session, turnID, metadata)
 	c.finishTurn(session, turnID)
 }
 
@@ -1234,11 +1232,13 @@ func (c *Controller) runAsyncExecTurn(ctx context.Context, session Session, adap
 	logAgentSubmitTrace("runtime.async_turn_started", session, turnID, metadata, nil)
 	var mu sync.Mutex
 	finished := false
+	var emittedSummary agentSubmitRuntimeEventSummary
 	finish := func(next Session) {
 		if finished {
 			return
 		}
 		finished = true
+		emittedSummary.log("runtime.async_events_emitted.summary", next, turnID, metadata)
 		c.finishTurn(next, turnID)
 	}
 	emit := func(events []activityshared.Event) {
@@ -1259,11 +1259,7 @@ func (c *Controller) runAsyncExecTurn(ctx context.Context, session Session, adap
 		c.store(session)
 		c.publish(session, events)
 		c.enqueueSessionReport(ctx, session, events)
-		logAgentSubmitTrace("runtime.async_events_emitted", session, turnID, metadata, map[string]any{
-			"activity_event_count": len(events),
-			"session_status":       session.Status,
-			"turn_phase":           turnLifecyclePhaseFromEvents(events),
-		})
+		emittedSummary.observe(events, session)
 		if turnHasTerminalEvent(events, turnID) ||
 			turnLifecycleSnapshotSettledTurn(events, turnID) ||
 			turnSteeredIntoActiveTurn(events, turnID) {
@@ -1371,6 +1367,47 @@ func asyncEventCompletesTurnSuccessfully(event activityshared.Event, turnID stri
 	}
 	return strings.TrimSpace(event.Payload.TurnID) == turnID ||
 		strings.TrimSpace(snapshot.ActiveTurnID) == turnID
+}
+
+type agentSubmitRuntimeEventSummary struct {
+	batchCount         int
+	activityEventCount int
+	eventTypeCounts    map[string]int
+	lastSessionStatus  string
+	lastTurnPhase      string
+}
+
+func (s *agentSubmitRuntimeEventSummary) observe(events []activityshared.Event, session Session) {
+	if len(events) == 0 {
+		return
+	}
+	s.batchCount++
+	s.activityEventCount += len(events)
+	if s.eventTypeCounts == nil {
+		s.eventTypeCounts = make(map[string]int)
+	}
+	for _, event := range events {
+		eventType := strings.TrimSpace(string(event.Type))
+		if eventType == "" {
+			eventType = "unknown"
+		}
+		s.eventTypeCounts[eventType]++
+	}
+	s.lastSessionStatus = strings.TrimSpace(string(session.Status))
+	s.lastTurnPhase = strings.TrimSpace(turnLifecyclePhaseFromEvents(events))
+}
+
+func (s agentSubmitRuntimeEventSummary) log(event string, session Session, turnID string, metadata map[string]any) {
+	if s.batchCount == 0 {
+		return
+	}
+	logAgentSubmitTrace(event, session, turnID, metadata, map[string]any{
+		"activity_event_count": s.activityEventCount,
+		"emit_batch_count":     s.batchCount,
+		"event_type_counts":    s.eventTypeCounts,
+		"session_status":       s.lastSessionStatus,
+		"turn_phase":           s.lastTurnPhase,
+	})
 }
 
 func turnHasTerminalEvent(events []activityshared.Event, turnID string) bool {

--- a/packages/agent/gui/agent-gui/agentGuiNode/AgentGUINodeView.layout.spec.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/AgentGUINodeView.layout.spec.tsx
@@ -61,6 +61,23 @@ const composerMock = vi.hoisted(() => ({
 
 const workspaceUserProjectI18n = createDefaultWorkspaceUserProjectI18nRuntime();
 
+function createRect(
+  input: {
+    bottom?: number;
+    height?: number;
+    left?: number;
+    right?: number;
+    top?: number;
+    width?: number;
+  } = {}
+): DOMRect {
+  const left = input.left ?? 0;
+  const top = input.top ?? 0;
+  const width = input.width ?? Math.max(0, (input.right ?? left) - left);
+  const height = input.height ?? Math.max(0, (input.bottom ?? top) - top);
+  return new DOMRect(left, top, width, height);
+}
+
 const statusDotMock = vi.hoisted(() => ({
   calls: [] as Array<{
     ariaLabel?: string;
@@ -4096,10 +4113,24 @@ describe("AgentGUINodeView layout persistence", () => {
     expect(signal?.aborted).toBe(true);
   });
 
-  it("scrolls the active conversation item into view", () => {
+  it("does not scroll the active conversation item when it is already visible", () => {
     const originalScrollIntoView = HTMLElement.prototype.scrollIntoView;
+    const originalGetBoundingClientRect =
+      HTMLElement.prototype.getBoundingClientRect;
     const scrollIntoView = vi.fn();
     HTMLElement.prototype.scrollIntoView = scrollIntoView;
+    HTMLElement.prototype.getBoundingClientRect = function () {
+      if (this.classList.contains("agent-gui-node__conversation-list")) {
+        return createRect({ bottom: 200, top: 0 });
+      }
+      if (
+        this.getAttribute("data-testid") ===
+        "agent-gui-conversation-item-session-2"
+      ) {
+        return createRect({ bottom: 80, top: 40 });
+      }
+      return createRect();
+    };
 
     try {
       const activeConversation = createConversationSummary("session-2");
@@ -4115,16 +4146,75 @@ describe("AgentGUINodeView layout persistence", () => {
         }
       });
 
-      expect(scrollIntoView).toHaveBeenCalledWith({ block: "nearest" });
+      expect(scrollIntoView).not.toHaveBeenCalled();
     } finally {
       HTMLElement.prototype.scrollIntoView = originalScrollIntoView;
+      HTMLElement.prototype.getBoundingClientRect =
+        originalGetBoundingClientRect;
+    }
+  });
+
+  it("scrolls the active conversation item into view when it is outside the viewport", async () => {
+    const originalScrollIntoView = HTMLElement.prototype.scrollIntoView;
+    const originalGetBoundingClientRect =
+      HTMLElement.prototype.getBoundingClientRect;
+    const scrollIntoView = vi.fn();
+    HTMLElement.prototype.scrollIntoView = scrollIntoView;
+    HTMLElement.prototype.getBoundingClientRect = function () {
+      if (this.classList.contains("agent-gui-node__conversation-list")) {
+        return createRect({ bottom: 200, top: 0 });
+      }
+      if (
+        this.getAttribute("data-testid") ===
+        "agent-gui-conversation-item-session-2"
+      ) {
+        return createRect({ bottom: 280, top: 240 });
+      }
+      return createRect();
+    };
+
+    try {
+      const activeConversation = createConversationSummary("session-2");
+      renderAgentGUINodeView({
+        viewModel: {
+          ...createViewModel(),
+          conversations: [
+            createConversationSummary("session-1"),
+            activeConversation
+          ],
+          activeConversation,
+          activeConversationId: "session-2"
+        }
+      });
+
+      await waitFor(() => {
+        expect(scrollIntoView).toHaveBeenCalledWith({ block: "nearest" });
+      });
+    } finally {
+      HTMLElement.prototype.scrollIntoView = originalScrollIntoView;
+      HTMLElement.prototype.getBoundingClientRect =
+        originalGetBoundingClientRect;
     }
   });
 
   it("does not scroll the active conversation again after loading more rail sessions", async () => {
     const originalScrollIntoView = HTMLElement.prototype.scrollIntoView;
+    const originalGetBoundingClientRect =
+      HTMLElement.prototype.getBoundingClientRect;
     const scrollIntoView = vi.fn();
     HTMLElement.prototype.scrollIntoView = scrollIntoView;
+    HTMLElement.prototype.getBoundingClientRect = function () {
+      if (this.classList.contains("agent-gui-node__conversation-list")) {
+        return createRect({ bottom: 200, top: 0 });
+      }
+      if (
+        this.getAttribute("data-testid") ===
+        "agent-gui-conversation-item-project-session-1"
+      ) {
+        return createRect({ bottom: 280, top: 240 });
+      }
+      return createRect();
+    };
     const project = {
       id: "project-app",
       path: "/workspace/app",
@@ -4222,6 +4312,8 @@ describe("AgentGUINodeView layout persistence", () => {
       expect(scrollIntoView).toHaveBeenCalledTimes(1);
     } finally {
       HTMLElement.prototype.scrollIntoView = originalScrollIntoView;
+      HTMLElement.prototype.getBoundingClientRect =
+        originalGetBoundingClientRect;
     }
   });
 

--- a/packages/agent/gui/agent-gui/agentGuiNode/AgentGUINodeView.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/AgentGUINodeView.tsx
@@ -2,10 +2,13 @@ import {
   Fragment,
   memo,
   type CSSProperties,
+  type Dispatch,
   type DragEvent,
   type KeyboardEvent,
+  type MutableRefObject,
   type PointerEvent,
   type ReactNode,
+  type SetStateAction,
   useCallback,
   useEffect,
   useLayoutEffect,
@@ -227,6 +230,7 @@ const AGENT_GUI_TOP_HISTORY_PREFETCH_THRESHOLD_PX = 240;
 const AGENT_GUI_TOP_MASK_SCROLL_EPSILON_PX = 1;
 const AGENT_GUI_CONVERSATION_RAIL_SECTION_PAGE_SIZE = 5;
 const AGENT_GUI_CONVERSATION_RAIL_LOADING_SKELETON_DELAY_MS = 300;
+const AGENT_GUI_CONVERSATION_RAIL_VISIBILITY_EPSILON_PX = 1;
 const AGENT_GUI_CONVERSATION_RAIL_PROJECTION_PROVIDER: AgentGUIProvider =
   "codex";
 const AGENT_GUI_TIMELINE_SCROLL_AREA_CONTENT_STYLE: CSSProperties = {
@@ -243,6 +247,32 @@ const AGENT_GUI_CONFIRMATION_DIALOG_CLASS_NAME =
   "nodrag tsh-desktop-no-drag [-webkit-app-region:no-drag]";
 const AGENT_GUI_CONFIRMATION_DIALOG_OVERLAY_CLASS_NAME =
   "nodrag tsh-desktop-no-drag [-webkit-app-region:no-drag]";
+
+function isElementFullyVisibleWithin(
+  element: HTMLElement,
+  viewport: HTMLElement
+): boolean {
+  const elementRect = element.getBoundingClientRect();
+  const viewportRect = viewport.getBoundingClientRect();
+  return (
+    elementRect.top >=
+      viewportRect.top - AGENT_GUI_CONVERSATION_RAIL_VISIBILITY_EPSILON_PX &&
+    elementRect.bottom <=
+      viewportRect.bottom + AGENT_GUI_CONVERSATION_RAIL_VISIBILITY_EPSILON_PX
+  );
+}
+
+function setBooleanStateIfChanged(
+  stateRef: MutableRefObject<boolean>,
+  setState: Dispatch<SetStateAction<boolean>>,
+  nextState: boolean
+): void {
+  if (stateRef.current === nextState) {
+    return;
+  }
+  stateRef.current = nextState;
+  setState(nextState);
+}
 
 interface AgentGUIProviderIconPresentation {
   iconUrl: string;
@@ -2344,6 +2374,8 @@ const AgentGUIDetailPane = memo(function AgentGUIDetailPane({
   const [isTimelineScrolledToTop, setIsTimelineScrolledToTop] = useState(true);
   const [isTimelineScrolledToBottom, setIsTimelineScrolledToBottom] =
     useState(true);
+  const isTimelineScrolledToTopRef = useRef(true);
+  const isTimelineScrolledToBottomRef = useRef(true);
   const [
     bottomDockDismissedPromptRequestId,
     setBottomDockDismissedPromptRequestId
@@ -3293,8 +3325,16 @@ const AgentGUIDetailPane = memo(function AgentGUIDetailPane({
       timelineScrollAnchorRef.current = null;
       pendingPrependScrollAnchorRef.current = null;
       submittedPromptScrollConversationRef.current = null;
-      setIsTimelineScrolledToTop(true);
-      setIsTimelineScrolledToBottom(true);
+      setBooleanStateIfChanged(
+        isTimelineScrolledToTopRef,
+        setIsTimelineScrolledToTop,
+        true
+      );
+      setBooleanStateIfChanged(
+        isTimelineScrolledToBottomRef,
+        setIsTimelineScrolledToBottom,
+        true
+      );
       return;
     }
 
@@ -3393,10 +3433,14 @@ const AgentGUIDetailPane = memo(function AgentGUIDetailPane({
       scrollTop: nextScrollTop,
       clientHeight: timeline.clientHeight
     };
-    setIsTimelineScrolledToTop(
+    setBooleanStateIfChanged(
+      isTimelineScrolledToTopRef,
+      setIsTimelineScrolledToTop,
       nextScrollTop <= AGENT_GUI_TOP_MASK_SCROLL_EPSILON_PX
     );
-    setIsTimelineScrolledToBottom(
+    setBooleanStateIfChanged(
+      isTimelineScrolledToBottomRef,
+      setIsTimelineScrolledToBottom,
       maxScrollTop - nextScrollTop <= AGENT_GUI_STICK_TO_BOTTOM_THRESHOLD_PX
     );
   }, [
@@ -3472,10 +3516,16 @@ const AgentGUIDetailPane = memo(function AgentGUIDetailPane({
           scrollTop: maxScrollTop,
           clientHeight: timeline.clientHeight
         };
-        setIsTimelineScrolledToTop(
+        setBooleanStateIfChanged(
+          isTimelineScrolledToTopRef,
+          setIsTimelineScrolledToTop,
           maxScrollTop <= AGENT_GUI_TOP_MASK_SCROLL_EPSILON_PX
         );
-        setIsTimelineScrolledToBottom(true);
+        setBooleanStateIfChanged(
+          isTimelineScrolledToBottomRef,
+          setIsTimelineScrolledToBottom,
+          true
+        );
       });
     };
 
@@ -3530,10 +3580,16 @@ const AgentGUIDetailPane = memo(function AgentGUIDetailPane({
       const atBottom =
         timeline.scrollHeight - scrollTop - timeline.clientHeight <=
         AGENT_GUI_STICK_TO_BOTTOM_THRESHOLD_PX;
-      setIsTimelineScrolledToTop(
+      setBooleanStateIfChanged(
+        isTimelineScrolledToTopRef,
+        setIsTimelineScrolledToTop,
         scrollTop <= AGENT_GUI_TOP_MASK_SCROLL_EPSILON_PX
       );
-      setIsTimelineScrolledToBottom(atBottom);
+      setBooleanStateIfChanged(
+        isTimelineScrolledToBottomRef,
+        setIsTimelineScrolledToBottom,
+        atBottom
+      );
       // Remember where the user left off so returning to this conversation can
       // restore the position. Skip while a deferred restore is pending so the
       // synchronous jump-to-bottom (during skeleton) doesn't clobber it.
@@ -3559,9 +3615,17 @@ const AgentGUIDetailPane = memo(function AgentGUIDetailPane({
       }
     };
 
-    captureScrollAnchor();
+    let initialCaptureFrameId: number | null = window.requestAnimationFrame(
+      () => {
+        initialCaptureFrameId = null;
+        captureScrollAnchor();
+      }
+    );
     timeline.addEventListener("scroll", captureScrollAnchor, { passive: true });
     return () => {
+      if (initialCaptureFrameId !== null) {
+        window.cancelAnimationFrame(initialCaptureFrameId);
+      }
       timeline.removeEventListener("scroll", captureScrollAnchor);
     };
   }, [
@@ -3589,10 +3653,16 @@ const AgentGUIDetailPane = memo(function AgentGUIDetailPane({
       scrollTop: maxScrollTop,
       clientHeight: timeline.clientHeight
     };
-    setIsTimelineScrolledToTop(
+    setBooleanStateIfChanged(
+      isTimelineScrolledToTopRef,
+      setIsTimelineScrolledToTop,
       maxScrollTop <= AGENT_GUI_TOP_MASK_SCROLL_EPSILON_PX
     );
-    setIsTimelineScrolledToBottom(true);
+    setBooleanStateIfChanged(
+      isTimelineScrolledToBottomRef,
+      setIsTimelineScrolledToBottom,
+      true
+    );
   }, [viewModel.activeConversationId]);
 
   return (
@@ -7082,6 +7152,7 @@ const AgentGUIConversationRailPane = memo(
       new Map<string, HTMLDivElement>()
     );
     const activeConversationScrollCompletedRef = useRef<string | null>(null);
+    const activeConversationScrollFrameRef = useRef<number | null>(null);
     const previousActiveConversationIdRef = useRef<string | null>(null);
     const groupedConversationsRef = useRef<ConversationSection[] | null>(null);
     const {
@@ -7232,6 +7303,10 @@ const AgentGUIConversationRailPane = memo(
       if (!activeId) {
         previousActiveConversationIdRef.current = null;
         activeConversationScrollCompletedRef.current = null;
+        if (activeConversationScrollFrameRef.current !== null) {
+          window.cancelAnimationFrame(activeConversationScrollFrameRef.current);
+          activeConversationScrollFrameRef.current = null;
+        }
         return;
       }
       if (previousActiveConversationIdRef.current !== activeId) {
@@ -7245,8 +7320,41 @@ const AgentGUIConversationRailPane = memo(
       if (!activeElement) {
         return;
       }
-      activeElement.scrollIntoView({ block: "nearest" });
-      activeConversationScrollCompletedRef.current = activeId;
+      const viewport = conversationListRef.current ?? railElementRef.current;
+      if (!viewport || isElementFullyVisibleWithin(activeElement, viewport)) {
+        activeConversationScrollCompletedRef.current = activeId;
+        return;
+      }
+
+      const animationFrameId = window.requestAnimationFrame(() => {
+        activeConversationScrollFrameRef.current = null;
+        if (previousActiveConversationIdRef.current !== activeId) {
+          return;
+        }
+        const nextActiveElement =
+          conversationItemElementsRef.current.get(activeId);
+        if (!nextActiveElement) {
+          return;
+        }
+        const nextViewport =
+          conversationListRef.current ?? railElementRef.current;
+        if (
+          nextViewport &&
+          isElementFullyVisibleWithin(nextActiveElement, nextViewport)
+        ) {
+          activeConversationScrollCompletedRef.current = activeId;
+          return;
+        }
+        nextActiveElement.scrollIntoView({ block: "nearest" });
+        activeConversationScrollCompletedRef.current = activeId;
+      });
+      activeConversationScrollFrameRef.current = animationFrameId;
+      return () => {
+        if (activeConversationScrollFrameRef.current === animationFrameId) {
+          window.cancelAnimationFrame(animationFrameId);
+          activeConversationScrollFrameRef.current = null;
+        }
+      };
     }, [activeConversationId, groupedConversationIdentityKey]);
 
     return (

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUINodeController.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUINodeController.ts
@@ -11719,8 +11719,6 @@ export function useAgentGUINodeController({
       isSubmitting ||
       Boolean(activeSessionState?.pendingInteractive));
   useEffect(() => {
-    const firstVersion = minFiniteMessageVersion(activeMessages);
-    const lastVersion = maxFiniteMessageVersion(activeMessages);
     const diagnosticKey = [
       activeConversationId ?? "",
       activeConversation?.status ?? "",
@@ -11742,10 +11740,9 @@ export function useAgentGUINodeController({
       activeSubmitBlocked ? "submit-blocked" : "submit-open",
       pendingApproval?.requestId ?? "",
       promptRequestId(pendingInteractivePrompt) ?? "",
-      conversation?.rows.length ?? "",
-      conversation?.sourceDetail.turns.length ?? "",
-      firstVersion ?? "",
-      lastVersion ?? "",
+      conversation?.activity.status ?? "",
+      conversation?.pendingApproval?.requestId ?? "",
+      promptRequestId(conversation?.pendingInteractivePrompt ?? null) ?? "",
       isCreatingConversation ? "creating" : "",
       isLoadingMessages ? "loading-messages" : "",
       isSubmitting ? "submitting" : "",
@@ -11784,7 +11781,6 @@ export function useAgentGUINodeController({
     activeConversationId,
     activeHasPendingSubmittedTurn,
     activeLiveState,
-    activeMessages,
     activeRuntimeSession,
     activeSessionState,
     activeSubmitBlocked,

--- a/services/tuttid/service/agent/provider_auth_watcher.go
+++ b/services/tuttid/service/agent/provider_auth_watcher.go
@@ -15,6 +15,7 @@ import (
 )
 
 const defaultProviderAuthWatchInterval = 2 * time.Second
+const defaultProviderAuthChangeCoalesceDelay = 1 * time.Second
 
 // providerAuthFileMaxContentBytes caps how much of a watched file the watcher
 // is willing to read per change when computing a content fingerprint. Files
@@ -199,8 +200,9 @@ func jsonSubsetFingerprint(data []byte, keys []string) (string, bool) {
 // cost is a handful of stat calls (file contents are only re-read when
 // mtime/size moved).
 type ProviderAuthWatcher struct {
-	Entries  []ProviderAuthWatchEntry
-	Interval time.Duration
+	Entries       []ProviderAuthWatchEntry
+	Interval      time.Duration
+	CoalesceDelay time.Duration
 	// OnChange receives the normalized provider ids whose marker files changed.
 	// Called from the watcher goroutine; implementations must not block for
 	// long.
@@ -255,24 +257,117 @@ func (w *ProviderAuthWatcher) interval() time.Duration {
 	return defaultProviderAuthWatchInterval
 }
 
+func (w *ProviderAuthWatcher) coalesceDelay() time.Duration {
+	if w.CoalesceDelay < 0 {
+		return 0
+	}
+	if w.CoalesceDelay > 0 {
+		return w.CoalesceDelay
+	}
+	return defaultProviderAuthChangeCoalesceDelay
+}
+
 func (w *ProviderAuthWatcher) run() {
 	defer close(w.done)
 	fingerprints := w.collectFingerprints(nil)
 	ticker := time.NewTicker(w.interval())
 	defer ticker.Stop()
+	pendingProviders := make(map[string]struct{})
+	var coalesceTimer *time.Timer
+	var coalesceTimerC <-chan time.Time
+	stopCoalesceTimer := func() {
+		if coalesceTimer == nil {
+			return
+		}
+		if !coalesceTimer.Stop() {
+			select {
+			case <-coalesceTimer.C:
+			default:
+			}
+		}
+		coalesceTimer = nil
+		coalesceTimerC = nil
+	}
+	flushPendingProviders := func() {
+		if len(pendingProviders) == 0 {
+			return
+		}
+		providers := providerAuthPendingProviders(w.Entries, pendingProviders)
+		pendingProviders = make(map[string]struct{})
+		if len(providers) > 0 {
+			w.OnChange(providers)
+		}
+	}
+	scheduleProviderChanges := func(changed []string) {
+		for _, provider := range changed {
+			if normalized := agentprovider.Normalize(provider); normalized != "" {
+				pendingProviders[normalized] = struct{}{}
+			}
+		}
+		if len(pendingProviders) == 0 {
+			return
+		}
+		delay := w.coalesceDelay()
+		if delay <= 0 {
+			flushPendingProviders()
+			return
+		}
+		if coalesceTimer == nil {
+			coalesceTimer = time.NewTimer(delay)
+			coalesceTimerC = coalesceTimer.C
+		}
+	}
 	for {
 		select {
 		case <-w.stop:
+			stopCoalesceTimer()
 			return
 		case <-ticker.C:
 			next := w.collectFingerprints(fingerprints)
 			changed := changedProviders(w.Entries, fingerprints, next)
 			fingerprints = next
 			if len(changed) > 0 {
-				w.OnChange(changed)
+				scheduleProviderChanges(changed)
 			}
+		case <-coalesceTimerC:
+			coalesceTimer = nil
+			coalesceTimerC = nil
+			flushPendingProviders()
 		}
 	}
+}
+
+func providerAuthPendingProviders(
+	entries []ProviderAuthWatchEntry,
+	pending map[string]struct{},
+) []string {
+	if len(pending) == 0 {
+		return nil
+	}
+	providers := make([]string, 0, len(pending))
+	seen := make(map[string]struct{}, len(pending))
+	for _, entry := range entries {
+		provider := agentprovider.Normalize(entry.Provider)
+		if provider == "" {
+			continue
+		}
+		if _, ok := pending[provider]; !ok {
+			continue
+		}
+		if _, ok := seen[provider]; ok {
+			continue
+		}
+		seen[provider] = struct{}{}
+		providers = append(providers, provider)
+	}
+	for provider := range pending {
+		if _, ok := seen[provider]; ok {
+			continue
+		}
+		providers = append(providers, provider)
+	}
+	sort.Strings(providers[len(seen):])
+	return providers
 }
 
 func (w *ProviderAuthWatcher) collectFingerprints(

--- a/services/tuttid/service/agent/provider_auth_watcher_test.go
+++ b/services/tuttid/service/agent/provider_auth_watcher_test.go
@@ -65,7 +65,8 @@ func TestProviderAuthWatcherReportsFileRewrites(t *testing.T) {
 		Entries: []ProviderAuthWatchEntry{
 			{Provider: agentprovider.Codex, Paths: []string{authPath}},
 		},
-		Interval: 5 * time.Millisecond,
+		Interval:      5 * time.Millisecond,
+		CoalesceDelay: -1,
 		OnChange: func(providers []string) {
 			changes <- providers
 		},
@@ -162,7 +163,8 @@ func TestProviderAuthWatcherIgnoresNonAuthClaudeStateChurn(t *testing.T) {
 				ContentFingerprint: claudeProviderAuthContentFingerprint(statePath),
 			},
 		},
-		Interval: 5 * time.Millisecond,
+		Interval:      5 * time.Millisecond,
+		CoalesceDelay: -1,
 		OnChange: func(providers []string) {
 			changes <- providers
 		},
@@ -207,7 +209,8 @@ func TestProviderAuthWatcherReportsOpenCodeConfigRewrites(t *testing.T) {
 				ContentFingerprint: hashProviderAuthFileContent,
 			},
 		},
-		Interval: 5 * time.Millisecond,
+		Interval:      5 * time.Millisecond,
+		CoalesceDelay: -1,
 		OnChange: func(providers []string) {
 			changes <- providers
 		},
@@ -250,6 +253,58 @@ func TestProviderAuthFileChangedPrefersContentKey(t *testing.T) {
 	next.contentKey = ""
 	if !providerAuthFileChanged(previous, next) {
 		t.Fatal("stat change without content keys must report")
+	}
+}
+
+func TestProviderAuthWatcherCoalescesProviderChanges(t *testing.T) {
+	dir := t.TempDir()
+	codexAuthPath := filepath.Join(dir, "codex-auth.json")
+	claudeAuthPath := filepath.Join(dir, "claude-auth.json")
+	if err := os.WriteFile(codexAuthPath, []byte(`{"mode":"chatgpt"}`), 0o600); err != nil {
+		t.Fatalf("write baseline codex auth file: %v", err)
+	}
+	if err := os.WriteFile(claudeAuthPath, []byte(`{"mode":"claude"}`), 0o600); err != nil {
+		t.Fatalf("write baseline claude auth file: %v", err)
+	}
+
+	changes := make(chan []string, 8)
+	watcher := &ProviderAuthWatcher{
+		Entries: []ProviderAuthWatchEntry{
+			{Provider: agentprovider.Codex, Paths: []string{codexAuthPath}},
+			{Provider: agentprovider.ClaudeCode, Paths: []string{claudeAuthPath}},
+		},
+		Interval:      5 * time.Millisecond,
+		CoalesceDelay: 50 * time.Millisecond,
+		OnChange: func(providers []string) {
+			changes <- providers
+		},
+	}
+	watcher.Start()
+	defer watcher.Close()
+
+	time.Sleep(20 * time.Millisecond)
+	if err := os.WriteFile(codexAuthPath, []byte(`{"mode":"api-key"}`), 0o600); err != nil {
+		t.Fatalf("rewrite codex auth file: %v", err)
+	}
+	time.Sleep(10 * time.Millisecond)
+	if err := os.WriteFile(claudeAuthPath, []byte(`{"mode":"oauth"}`), 0o600); err != nil {
+		t.Fatalf("rewrite claude auth file: %v", err)
+	}
+
+	select {
+	case providers := <-changes:
+		if len(providers) != 2 ||
+			providers[0] != agentprovider.Codex ||
+			providers[1] != agentprovider.ClaudeCode {
+			t.Fatalf("OnChange providers = %v, want [codex claude-code]", providers)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("watcher did not report the coalesced provider changes")
+	}
+	select {
+	case providers := <-changes:
+		t.Fatalf("watcher reported a second coalesced callback: %v", providers)
+	case <-time.After(100 * time.Millisecond):
 	}
 }
 


### PR DESCRIPTION
## Summary
- aggregate high-volume agent runtime submit traces into per-turn summaries
- coalesce provider auth watcher invalidations and batch renderer inline reconcile diagnostics
- narrow AgentGUI render-state diagnostics to key interaction state changes
- document the agent diagnostic flood troubleshooting path

## Validation
- `pnpm typecheck`
- `pnpm lint:ts`
- `go test ./packages/agent/daemon/runtime ./services/tuttid/service/agent -count=1`
- `pnpm --filter @tutti-os/desktop build`
- pre-push `pnpm check:full` passed

## Notes
- installed a user-local `corepack` shim at `~/.local/bin/corepack` so repository hooks can run without replacing the existing `/opt/homebrew/bin/pnpm`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved app responsiveness by grouping several frequent background updates into fewer summaries.
  * Active conversations now scroll into view more reliably, with better handling when items are already visible.

* **Bug Fixes**
  * Reduced duplicate analytics and diagnostic events during focus changes, streaming turns, and timeline updates.
  * Prevented pending focus-related updates from firing after cleanup, improving stability.
  * Provider change notifications are now coalesced to avoid rapid repeated refreshes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->