### PR TITLE
fix(agent-gui): avoid heavy image zoom dialog

### DIFF
--- a/packages/agent/gui/app/renderer/agentactivity.css
+++ b/packages/agent/gui/app/renderer/agentactivity.css
@@ -1,4 +1,3 @@
-@import "react-medium-image-zoom/dist/styles.css";
 @source "../..";
 
 /* Restored agent activity renderer styles from the TSH desktop source during the GUI migration. */
@@ -79,12 +78,52 @@
   );
 }
 
-.tsh-zoom-dialog[data-rmiz-modal] {
-  z-index: 100300;
+.tsh-zoomable-image {
+  position: relative;
+  display: inline-block;
+  max-width: 100%;
+  vertical-align: top;
+}
+
+.tsh-zoomable-image--block {
+  display: block;
+}
+
+.tsh-zoomable-image__trigger {
+  position: absolute;
+  inset: 0;
+  z-index: 1;
+  border: 0;
+  background: transparent;
+  color: transparent;
+  cursor: zoom-in;
   -webkit-app-region: no-drag;
 }
 
+.tsh-zoom-dialog[data-rmiz-modal] {
+  position: fixed;
+  inset: 0;
+  z-index: 100300;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 24px;
+  -webkit-app-region: no-drag;
+}
+
+.tsh-zoom-dialog [data-rmiz-modal-overlay] {
+  position: absolute;
+  inset: 0;
+}
+
 .tsh-zoom-dialog [data-rmiz-modal-content] {
+  position: relative;
+  z-index: 100300;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  max-width: calc(100vw - 48px);
+  max-height: calc(100vh - 48px);
   -webkit-app-region: no-drag;
 }
 
@@ -98,9 +137,20 @@
 }
 
 .tsh-zoom-dialog [data-rmiz-btn-unzoom] {
+  position: fixed;
   top: max(20px, calc(var(--cove-titlebar-reserve, 0px) + 10px));
   right: 20px;
   inset-inline-end: 20px;
+  z-index: 100301;
+}
+
+.tsh-zoom-dialog__image {
+  display: block;
+  max-width: calc(100vw - 48px);
+  max-height: calc(100vh - 48px);
+  object-fit: contain;
+  transform-origin: center center;
+  cursor: zoom-out;
 }
 
 .tsh-zoom-dialog__image-actions {

--- a/packages/agent/gui/app/renderer/components/ZoomableImage.tsx
+++ b/packages/agent/gui/app/renderer/components/ZoomableImage.tsx
@@ -1,14 +1,13 @@
 import {
-  cloneElement,
-  isValidElement,
   type CSSProperties,
   type ComponentPropsWithoutRef,
   type JSX,
+  type KeyboardEvent,
   type MouseEvent,
-  type ReactElement,
   type WheelEvent,
   useCallback,
   useEffect,
+  useRef,
   useState
 } from "react";
 import { createPortal } from "react-dom";
@@ -23,7 +22,6 @@ import {
   RestoreIcon
 } from "@tutti-os/ui-system";
 import { RotateCcwIcon, ZoomInIcon, ZoomOutIcon } from "lucide-react";
-import Zoom from "react-medium-image-zoom";
 import { useTranslation } from "../../../i18n/index";
 import { cn } from "../lib/utils";
 import { ConversationImageContextMenu } from "../../../shared/agentConversation/components/ConversationImageContextMenu";
@@ -68,6 +66,8 @@ export function ZoomableImage({
   const [imagePreviewZoom, setImagePreviewZoom] = useState(1);
   const [isWheelZooming, setIsWheelZooming] = useState(false);
   const [isImagePreviewOpen, setIsImagePreviewOpen] = useState(false);
+  const [isImagePreviewClosing, setIsImagePreviewClosing] = useState(false);
+  const closePreviewTimerRef = useRef<number | null>(null);
   const imagePreviewZoomPercent = Math.round(imagePreviewZoom * 100);
   const canZoomOut = imagePreviewZoom > IMAGE_PREVIEW_ZOOM_MIN;
   const canZoomIn = imagePreviewZoom < IMAGE_PREVIEW_ZOOM_MAX;
@@ -75,6 +75,56 @@ export function ZoomableImage({
   const closeContextMenu = useCallback(() => {
     setContextMenuPosition(null);
   }, []);
+
+  const finishClosePreviewImage = useCallback((): void => {
+    if (closePreviewTimerRef.current !== null) {
+      window.clearTimeout(closePreviewTimerRef.current);
+      closePreviewTimerRef.current = null;
+    }
+    setIsImagePreviewOpen(false);
+    setIsImagePreviewClosing(false);
+    setIsWheelZooming(false);
+    setImagePreviewZoom(1);
+  }, []);
+
+  const closePreviewImage = useCallback((): void => {
+    if (!isImagePreviewOpen) {
+      return;
+    }
+    if (closePreviewTimerRef.current !== null) {
+      window.clearTimeout(closePreviewTimerRef.current);
+    }
+    setIsImagePreviewClosing(true);
+    setIsWheelZooming(false);
+    setImagePreviewZoom(1);
+    closeContextMenu();
+    closePreviewTimerRef.current = window.setTimeout(
+      finishClosePreviewImage,
+      180
+    );
+  }, [closeContextMenu, finishClosePreviewImage, isImagePreviewOpen]);
+
+  const openPreviewImage = useCallback((): void => {
+    if (!actionSource) {
+      return;
+    }
+    if (closePreviewTimerRef.current !== null) {
+      window.clearTimeout(closePreviewTimerRef.current);
+      closePreviewTimerRef.current = null;
+    }
+    closeContextMenu();
+    setIsImagePreviewClosing(false);
+    setIsImagePreviewOpen(true);
+  }, [actionSource, closeContextMenu]);
+
+  useEffect(
+    () => () => {
+      if (closePreviewTimerRef.current !== null) {
+        window.clearTimeout(closePreviewTimerRef.current);
+      }
+    },
+    []
+  );
 
   useEffect(() => {
     if (!contextMenuPosition) {
@@ -90,6 +140,26 @@ export function ZoomableImage({
   }, [closeContextMenu, contextMenuPosition]);
 
   useEffect(() => {
+    if (!isImagePreviewOpen) {
+      return;
+    }
+
+    const handleKeyDown = (event: globalThis.KeyboardEvent): void => {
+      if (event.key !== "Escape") {
+        return;
+      }
+      event.preventDefault();
+      event.stopPropagation();
+      closePreviewImage();
+    };
+
+    document.addEventListener("keydown", handleKeyDown, true);
+    return () => {
+      document.removeEventListener("keydown", handleKeyDown, true);
+    };
+  }, [closePreviewImage, isImagePreviewOpen]);
+
+  useEffect(() => {
     if (!copyStatus || copyStatus.busy) {
       return;
     }
@@ -98,8 +168,8 @@ export function ZoomableImage({
   }, [copyStatus]);
 
   const handleContextMenu = useCallback(
-    (event: MouseEvent<HTMLImageElement>): void => {
-      onContextMenu?.(event);
+    (event: MouseEvent<HTMLElement>): void => {
+      onContextMenu?.(event as MouseEvent<HTMLImageElement>);
       if (event.defaultPrevented || !actionSource || !hasImageActions) {
         return;
       }
@@ -195,154 +265,83 @@ export function ZoomableImage({
     />
   ) : null;
 
-  const renderZoomContent = ({
-    buttonUnzoom,
-    img,
-    modalState
-  }: {
-    buttonUnzoom: ReactElement<HTMLButtonElement>;
-    img: ReactElement | null;
-    modalState?: "LOADED" | "LOADING" | "UNLOADED" | "UNLOADING";
-  }): JSX.Element => {
-    const typedButtonUnzoom = buttonUnzoom as unknown as ReactElement<
-      ComponentPropsWithoutRef<"button">
-    >;
-    const buttonUnzoomProps =
-      typedButtonUnzoom.props as ComponentPropsWithoutRef<"button">;
-    const zoomSrc =
-      isValidElement(img) &&
-      typeof (img.props as { src?: unknown }).src === "string"
-        ? (img.props as { src: string }).src
-        : null;
-    const isUnzooming = modalState === "UNLOADING";
-    const effectiveImagePreviewZoom = isUnzooming ? 1 : imagePreviewZoom;
-    const renderedImage = img
-      ? cloneImageWithPreviewZoom(
-          img,
-          effectiveImagePreviewZoom,
-          isUnzooming ? false : isWheelZooming,
-          handlePreviewImageWheel
-        )
-      : null;
-    return (
-      <>
-        {actionButtons && renderedImage && zoomSrc ? (
-          cloneElement(
-            renderedImage as ReactElement<ComponentPropsWithoutRef<"img">>,
-            {
-              onContextMenu: handleContextMenu
-            }
-          )
-        ) : !actionButtons && renderedImage && zoomSrc ? (
-          <ConversationImageContextMenu
-            src={zoomSrc}
-            asChild
-            contentStyle={{ zIndex: "var(--z-dialog-popover)" }}
-          >
-            {renderedImage}
-          </ConversationImageContextMenu>
-        ) : (
-          renderedImage
-        )}
-        <ImagePreviewZoomControls
-          canZoomIn={canZoomIn}
-          canZoomOut={canZoomOut}
-          percent={imagePreviewZoomPercent}
-          percentLabel={t("common.imageZoomPercent", {
-            percent: imagePreviewZoomPercent
-          })}
-          reportPercentStatus={!copyStatus}
-          resetLabel={t("common.resetImageZoom")}
-          zoomInLabel={t("common.zoomInImage")}
-          zoomOutLabel={t("common.zoomOutImage")}
-          onReset={resetPreviewImageZoom}
-          onZoomIn={zoomInPreviewImage}
-          onZoomOut={zoomOutPreviewImage}
-          onWheel={handlePreviewImageWheel}
-        />
-        {actionButtons ? (
-          <div className="tsh-zoom-dialog__image-actions nodrag tsh-desktop-no-drag">
-            {actionButtons}
-          </div>
-        ) : null}
-        {contextMenuPosition?.inZoomDialog && actionButtons ? (
-          <div
-            className="tsh-image-context-menu nodrag tsh-desktop-no-drag"
-            style={{
-              left: contextMenuPosition.x,
-              top: contextMenuPosition.y
-            }}
-            role="menu"
-            onClick={(event) => event.stopPropagation()}
-          >
-            <ImageActionButtons
-              copyLabel={t("common.copyImage")}
-              downloadLabel={t("common.downloadImage")}
-              itemRole="menuitem"
-              onCopy={handleCopyImageAction}
-              onDownload={handleDownloadImage}
-            />
-          </div>
-        ) : null}
-        {copyStatus ? (
-          <ImageCopyStatusToast
-            busy={copyStatus.busy}
-            message={copyStatus.message}
-            variant={copyStatus.variant}
-            onOpenChange={(open) => {
-              if (!open) {
-                setCopyStatus(null);
-              }
-            }}
-          />
-        ) : null}
-        <Button
-          asChild
-          className="tsh-zoom-dialog__icon-button nodrag tsh-desktop-no-drag"
-          size="icon"
-          variant="chrome"
-        >
-          {cloneElement(
-            typedButtonUnzoom,
-            {
-              onClick: (event: MouseEvent<HTMLButtonElement>) => {
-                setIsWheelZooming(false);
-                setImagePreviewZoom(1);
-                buttonUnzoomProps.onClick?.(event);
-              }
-            },
-            <RestoreIcon aria-hidden="true" className="size-4" />
-          )}
-        </Button>
-      </>
+  const previewImage =
+    (isImagePreviewOpen || isImagePreviewClosing) && actionSource ? (
+      <img
+        alt={alt}
+        data-rmiz-modal-img=""
+        data-tsh-image-zoom={formatImagePreviewZoom(imagePreviewZoom)}
+        draggable={false}
+        src={actionSource}
+        title={typeof props.title === "string" ? props.title : undefined}
+        className="tsh-zoom-dialog__image nodrag tsh-desktop-no-drag"
+        style={{
+          transform: resolveZoomedImageTransform(
+            undefined,
+            imagePreviewZoom,
+            null,
+            null
+          ),
+          transition: isWheelZooming
+            ? "none"
+            : mergeImagePreviewTransition(undefined)
+        }}
+        onClick={(event) => {
+          event.stopPropagation();
+          closePreviewImage();
+        }}
+        onContextMenu={hasImageActions ? handleContextMenu : onContextMenu}
+        onTransitionEnd={
+          isImagePreviewClosing ? finishClosePreviewImage : undefined
+        }
+        onWheel={handlePreviewImageWheel}
+      />
+    ) : null;
+
+  const previewContent =
+    previewImage && !actionButtons && actionSource ? (
+      <ConversationImageContextMenu
+        src={actionSource}
+        asChild
+        contentStyle={{ zIndex: "var(--z-dialog-popover)" }}
+      >
+        {previewImage}
+      </ConversationImageContextMenu>
+    ) : (
+      previewImage
     );
-  };
+
+  const Wrapper = wrapElement;
 
   return (
     <>
-      <Zoom
-        a11yNameButtonZoom={t("common.expandImage")}
-        a11yNameButtonUnzoom={t("common.minimizeImage")}
-        classDialog="tsh-zoom-dialog nodrag tsh-desktop-no-drag"
-        wrapElement={wrapElement}
-        zoomMargin={24}
-        ZoomContent={renderZoomContent}
-        onZoomChange={(zoomed) => {
-          setIsImagePreviewOpen(zoomed);
-          if (!zoomed) {
-            setIsWheelZooming(false);
-            setImagePreviewZoom(1);
-          }
-        }}
+      <Wrapper
+        className={cn(
+          "tsh-zoomable-image nodrag tsh-desktop-no-drag",
+          wrapElement === "div" && "tsh-zoomable-image--block"
+        )}
       >
         <img
           {...props}
           alt={alt}
           src={src}
+          onClick={(event) => {
+            props.onClick?.(event);
+            if (!event.defaultPrevented) {
+              openPreviewImage();
+            }
+          }}
           onContextMenu={hasImageActions ? handleContextMenu : onContextMenu}
           className={cn("nodrag tsh-desktop-no-drag cursor-zoom-in", className)}
         />
-      </Zoom>
+        <button
+          type="button"
+          aria-label={t("common.expandImage")}
+          className="tsh-zoomable-image__trigger nodrag tsh-desktop-no-drag"
+          onClick={openPreviewImage}
+          onContextMenu={handleContextMenu}
+        />
+      </Wrapper>
       {contextMenuPosition && !contextMenuPosition.inZoomDialog && actionButtons
         ? createPortal(
             <div
@@ -361,6 +360,96 @@ export function ZoomableImage({
                 onCopy={handleCopyImageAction}
                 onDownload={handleDownloadImage}
               />
+            </div>,
+            document.body
+          )
+        : null}
+      {(isImagePreviewOpen || isImagePreviewClosing) && actionSource
+        ? createPortal(
+            <div
+              aria-modal="true"
+              className="tsh-zoom-dialog nodrag tsh-desktop-no-drag"
+              data-rmiz-modal=""
+              role="dialog"
+              tabIndex={-1}
+              onKeyDown={(event: KeyboardEvent<HTMLDivElement>) => {
+                if (event.key === "Escape") {
+                  closePreviewImage();
+                }
+              }}
+            >
+              <div
+                data-rmiz-modal-overlay="visible"
+                onClick={closePreviewImage}
+              />
+              <div data-rmiz-modal-content="true">{previewContent}</div>
+              <ImagePreviewZoomControls
+                canZoomIn={canZoomIn}
+                canZoomOut={canZoomOut}
+                percent={imagePreviewZoomPercent}
+                percentLabel={t("common.imageZoomPercent", {
+                  percent: imagePreviewZoomPercent
+                })}
+                reportPercentStatus={!copyStatus}
+                resetLabel={t("common.resetImageZoom")}
+                zoomInLabel={t("common.zoomInImage")}
+                zoomOutLabel={t("common.zoomOutImage")}
+                onReset={resetPreviewImageZoom}
+                onZoomIn={zoomInPreviewImage}
+                onZoomOut={zoomOutPreviewImage}
+                onWheel={handlePreviewImageWheel}
+              />
+              {actionButtons ? (
+                <div className="tsh-zoom-dialog__image-actions nodrag tsh-desktop-no-drag">
+                  {actionButtons}
+                </div>
+              ) : null}
+              {contextMenuPosition?.inZoomDialog && actionButtons ? (
+                <div
+                  className="tsh-image-context-menu nodrag tsh-desktop-no-drag"
+                  style={{
+                    left: contextMenuPosition.x,
+                    top: contextMenuPosition.y
+                  }}
+                  role="menu"
+                  onClick={(event) => event.stopPropagation()}
+                >
+                  <ImageActionButtons
+                    copyLabel={t("common.copyImage")}
+                    downloadLabel={t("common.downloadImage")}
+                    itemRole="menuitem"
+                    onCopy={handleCopyImageAction}
+                    onDownload={handleDownloadImage}
+                  />
+                </div>
+              ) : null}
+              {copyStatus ? (
+                <ImageCopyStatusToast
+                  busy={copyStatus.busy}
+                  message={copyStatus.message}
+                  variant={copyStatus.variant}
+                  onOpenChange={(open) => {
+                    if (!open) {
+                      setCopyStatus(null);
+                    }
+                  }}
+                />
+              ) : null}
+              <Button
+                asChild
+                className="tsh-zoom-dialog__icon-button nodrag tsh-desktop-no-drag"
+                size="icon"
+                variant="chrome"
+              >
+                <button
+                  type="button"
+                  aria-label={t("common.minimizeImage")}
+                  data-rmiz-btn-unzoom=""
+                  onClick={closePreviewImage}
+                >
+                  <RestoreIcon aria-hidden="true" className="size-4" />
+                </button>
+              </Button>
             </div>,
             document.body
           )
@@ -571,44 +660,6 @@ function ImageActionButtons({
   );
 }
 
-function cloneImageWithPreviewZoom(
-  img: ReactElement,
-  zoom: number,
-  isWheelZooming: boolean,
-  onWheel: (event: WheelEvent<HTMLElement>) => void
-): ReactElement {
-  const props = img.props as {
-    height?: unknown;
-    onWheel?: (event: WheelEvent<HTMLElement>) => void;
-    style?: CSSProperties;
-    width?: unknown;
-  };
-  const style = props.style;
-  const mergedStyle: CSSProperties = {
-    ...style,
-    transform: resolveZoomedImageTransform(
-      style?.transform,
-      zoom,
-      resolveImagePreviewDimension(style?.width ?? props.width),
-      resolveImagePreviewDimension(style?.height ?? props.height)
-    ),
-    transition: isWheelZooming
-      ? "none"
-      : mergeImagePreviewTransition(style?.transition)
-  };
-  if (style?.transformOrigin !== undefined) {
-    mergedStyle.transformOrigin = style.transformOrigin;
-  }
-  return cloneElement(img, {
-    "data-tsh-image-zoom": formatImagePreviewZoom(zoom),
-    onWheel: (event: WheelEvent<HTMLElement>) => {
-      props.onWheel?.(event);
-      onWheel(event);
-    },
-    style: mergedStyle
-  } as Partial<typeof img.props>);
-}
-
 function resolveWheelZoomDelta(event: WheelEvent<HTMLElement>): number {
   return (
     -event.deltaY *
@@ -651,17 +702,6 @@ function resolveImagePreviewZoomTransform(
   const halfWidth = formatCssNumber(width / 2);
   const halfHeight = formatCssNumber(height / 2);
   return `translate(${halfWidth}px,${halfHeight}px) ${scale} translate(-${halfWidth}px,-${halfHeight}px)`;
-}
-
-function resolveImagePreviewDimension(value: unknown): number | null {
-  if (typeof value === "number") {
-    return Number.isFinite(value) && value > 0 ? value : null;
-  }
-  if (typeof value !== "string") {
-    return null;
-  }
-  const dimension = Number.parseFloat(value);
-  return Number.isFinite(dimension) && dimension > 0 ? dimension : null;
 }
 
 function formatCssNumber(value: number): string {

--- a/packages/agent/gui/package.json
+++ b/packages/agent/gui/package.json
@@ -66,7 +66,6 @@
     "framer-motion": "^12.40.0",
     "lucide-react": "^0.511.0",
     "react-markdown": "^10.1.0",
-    "react-medium-image-zoom": "^5.4.5",
     "rehype-sanitize": "^6.0.0",
     "remark-gfm": "^4.0.1",
     "tailwind-merge": "^3.6.0",

--- a/packages/agent/gui/shared/AgentMessageMarkdown.spec.tsx
+++ b/packages/agent/gui/shared/AgentMessageMarkdown.spec.tsx
@@ -707,6 +707,23 @@ describe("AgentMessageMarkdown", () => {
 
     fireEvent.click(
       screen.getByRole("button", {
+        name: /Zoom out image|common\.zoomOutImage/
+      })
+    );
+    await waitFor(() => {
+      expect(modalImage).toHaveAttribute("data-tsh-image-zoom", "1");
+    });
+    expect(screen.getByRole("status")).toHaveTextContent("100%");
+
+    fireEvent.click(
+      screen.getByRole("button", { name: /Zoom in image|common\.zoomInImage/ })
+    );
+    await waitFor(() => {
+      expect(modalImage).toHaveAttribute("data-tsh-image-zoom", "1.25");
+    });
+
+    fireEvent.click(
+      screen.getByRole("button", {
         name: /Reset image zoom|common\.resetImageZoom/
       })
     );
@@ -890,6 +907,85 @@ describe("AgentMessageMarkdown", () => {
     await waitFor(() => {
       expect(screen.queryByRole("dialog")).toBeNull();
     });
+  });
+
+  it("closes the zoom preview when the zoomed image is clicked", async () => {
+    const readFile = vi.fn().mockResolvedValue({
+      bytes: new Uint8Array([137, 80, 78, 71])
+    });
+    window.agentHostApi = {
+      ...(window.agentHostApi ?? {}),
+      workspace: {
+        ...(window.agentHostApi?.workspace ?? {}),
+        readFile
+      }
+    } as typeof window.agentHostApi;
+    Object.defineProperty(URL, "createObjectURL", {
+      configurable: true,
+      value: vi.fn(() => "blob:tsh-markdown-image")
+    });
+    Object.defineProperty(URL, "revokeObjectURL", {
+      configurable: true,
+      value: vi.fn()
+    });
+
+    render(
+      <AgentMessageMarkdown
+        content={"![generated image](/workspace/output/imagegen/dance.png)"}
+        enableImageZoom
+      />
+    );
+
+    fireEvent.click(await screen.findByRole("button", { name: /Zoom image/ }));
+    const dialog = await screen.findByRole("dialog");
+    const modalImage = dialog.querySelector("[data-rmiz-modal-img]");
+    expect(modalImage).toBeInstanceOf(HTMLElement);
+
+    fireEvent.click(modalImage as HTMLElement);
+    fireEvent.transitionEnd(modalImage as HTMLElement);
+
+    await waitFor(() => {
+      expect(screen.queryByRole("dialog")).toBeNull();
+    });
+  });
+
+  it("keeps the zoom preview open when reopened during the close animation", async () => {
+    const readFile = vi.fn().mockResolvedValue({
+      bytes: new Uint8Array([137, 80, 78, 71])
+    });
+    window.agentHostApi = {
+      ...(window.agentHostApi ?? {}),
+      workspace: {
+        ...(window.agentHostApi?.workspace ?? {}),
+        readFile
+      }
+    } as typeof window.agentHostApi;
+    Object.defineProperty(URL, "createObjectURL", {
+      configurable: true,
+      value: vi.fn(() => "blob:tsh-markdown-image")
+    });
+    Object.defineProperty(URL, "revokeObjectURL", {
+      configurable: true,
+      value: vi.fn()
+    });
+
+    render(
+      <AgentMessageMarkdown
+        content={"![generated image](/workspace/output/imagegen/dance.png)"}
+        enableImageZoom
+      />
+    );
+
+    fireEvent.click(await screen.findByRole("button", { name: /Zoom image/ }));
+    const dialog = await screen.findByRole("dialog");
+    const modalImage = dialog.querySelector("[data-rmiz-modal-img]");
+    expect(modalImage).toBeInstanceOf(HTMLElement);
+
+    fireEvent.click(modalImage as HTMLElement);
+    fireEvent.click(screen.getByRole("button", { name: /Zoom image/ }));
+    await new Promise((resolve) => window.setTimeout(resolve, 220));
+
+    expect(screen.getByRole("dialog")).toBeInTheDocument();
   });
 
   it("does not add a zoom trigger when the markdown image is already inside a link", async () => {

--- a/packages/agent/gui/vitest.setup.ts
+++ b/packages/agent/gui/vitest.setup.ts
@@ -1,13 +1,6 @@
 import "@testing-library/jest-dom/vitest";
 import { cleanup } from "@testing-library/react";
-import { createElement, isValidElement, cloneElement, useState } from "react";
-import { createPortal } from "react-dom";
-import type {
-  MouseEvent as ReactMouseEvent,
-  ReactElement,
-  ReactNode
-} from "react";
-import { afterEach, beforeEach, vi } from "vitest";
+import { afterEach, beforeEach } from "vitest";
 import {
   resetAgentHostApiForTests,
   setAgentHostApiForTests
@@ -93,109 +86,6 @@ if (typeof Range !== "undefined") {
 }
 
 let restoreReactRenderLoopConsoleTrap: (() => void) | null = null;
-
-vi.mock("react-medium-image-zoom", () => ({
-  default: function TestZoom({
-    a11yNameButtonZoom,
-    a11yNameButtonUnzoom,
-    children,
-    classDialog,
-    onZoomChange,
-    ZoomContent
-  }: {
-    a11yNameButtonZoom?: string;
-    a11yNameButtonUnzoom?: string;
-    children?: ReactNode;
-    classDialog?: string;
-    onZoomChange?: (
-      value: boolean,
-      data: { event: ReactMouseEvent | Event }
-    ) => void;
-    ZoomContent?: (props: {
-      buttonUnzoom: ReactElement;
-      img: ReactElement | null;
-      modalState?: "LOADED" | "UNLOADING" | "UNLOADED";
-    }) => ReactNode;
-  }) {
-    const [modalState, setModalState] = useState<
-      "LOADED" | "UNLOADING" | "UNLOADED"
-    >("UNLOADED");
-    const isOpen = modalState !== "UNLOADED";
-    const labelZoom = a11yNameButtonZoom ?? "Zoom image";
-    const labelUnzoom = a11yNameButtonUnzoom ?? "Minimize image";
-    const childElement = isValidElement(children)
-      ? (children as ReactElement<{
-          onClick?: (event: ReactMouseEvent) => void;
-        }>)
-      : null;
-    const visibleChildren =
-      childElement !== null
-        ? cloneElement(childElement, {
-            onClick: (event: ReactMouseEvent) => {
-              childElement.props.onClick?.(event);
-              onZoomChange?.(true, { event });
-              setModalState("LOADED");
-            }
-          })
-        : children;
-    const modalImage =
-      childElement !== null
-        ? cloneElement(childElement as ReactElement<Record<string, unknown>>, {
-            "data-rmiz-modal-img": true,
-            onTransitionEnd: () => setModalState("UNLOADED")
-          })
-        : null;
-    const buttonUnzoom = createElement(
-      "button",
-      {
-        type: "button",
-        "aria-label": labelUnzoom,
-        onClick: (event: ReactMouseEvent) => {
-          onZoomChange?.(false, { event });
-          setModalState("UNLOADING");
-        }
-      },
-      labelUnzoom
-    );
-    const modal = isOpen
-      ? createPortal(
-          createElement(
-            "span",
-            { role: "dialog", className: classDialog, "data-rmiz-modal": "" },
-            ZoomContent
-              ? ZoomContent({ buttonUnzoom, img: modalImage, modalState })
-              : [modalImage, buttonUnzoom]
-          ),
-          document.body
-        )
-      : null;
-
-    return createElement(
-      "span",
-      { "data-rmiz": "" },
-      createElement("span", { "data-rmiz-content": "found" }, visibleChildren),
-      createElement(
-        "span",
-        { "data-rmiz-ghost": "" },
-        createElement(
-          "button",
-          {
-            type: "button",
-            "aria-label": labelZoom,
-            "aria-hidden": isOpen ? true : undefined,
-            "data-rmiz-btn-zoom": "",
-            onClick: (event: ReactMouseEvent) => {
-              onZoomChange?.(true, { event });
-              setModalState("LOADED");
-            }
-          },
-          labelZoom
-        )
-      ),
-      modal
-    );
-  }
-}));
 
 beforeEach(() => {
   restoreReactRenderLoopConsoleTrap?.();

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -338,9 +338,6 @@ importers:
       react-markdown:
         specifier: ^10.1.0
         version: 10.1.0(@types/react@19.2.15)(react@19.2.6)
-      react-medium-image-zoom:
-        specifier: ^5.4.5
-        version: 5.4.5(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       rehype-sanitize:
         specifier: ^6.0.0
         version: 6.0.0
@@ -9328,15 +9325,6 @@ packages:
       "@types/react": ">=18"
       react: ">=18"
 
-  react-medium-image-zoom@5.4.5:
-    resolution:
-      {
-        integrity: sha512-58QSIRK6X3uw2fSTejJRnH0JuKTZl7ZJYX+sAMaYx4YTEm33gsNdnP5RuQSCnBiAvisQeErqZWAT31bR89WB6g==
-      }
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
-      react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
-
   react-refresh@0.17.0:
     resolution:
       {
@@ -16329,11 +16317,6 @@ snapshots:
       vfile: 6.0.3
     transitivePeerDependencies:
       - supports-color
-
-  react-medium-image-zoom@5.4.5(react-dom@19.2.6(react@19.2.6))(react@19.2.6):
-    dependencies:
-      react: 19.2.6
-      react-dom: 19.2.6(react@19.2.6)
 
   react-refresh@0.17.0: {}
 


### PR DESCRIPTION
## Summary
- replace `react-medium-image-zoom` in AgentGUI images with a lightweight package-owned portal preview
- keep image preview controls for zoom in/out/reset, click-to-close, ESC close, copy/download, and context menu behavior
- remove the unused dependency and third-party test mock

## Validation
- `pnpm -C packages/agent/gui exec vitest run --environment jsdom --maxWorkers=3 shared/AgentMessageMarkdown.spec.tsx agent-gui/agentGuiNode/AgentComposer.spec.tsx shared/agentConversation/components/AgentTranscriptView.spec.tsx`
- `pnpm lint:ts`
- `pnpm --filter @tutti-os/agent-gui typecheck`
- `pnpm check:full` via pre-push hook

## Documentation impact
- No durable docs updated. This changes an internal AgentGUI image preview implementation without changing public API, data flow, i18n keys, env/config, or directory ownership.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Image previews now use a built-in zoom dialog with a full-screen, centered layout and smoother open/close transitions.
  * Added keyboard support (Escape) and integrated zoom controls, action buttons, and contextual options within the image dialog.

* **Bug Fixes**
  * Improved zoom step/reset behavior for more consistent scaling.
  * Clicking the zoomed image now closes the dialog reliably, including during transition timing.

* **Tests**
  * Updated zoom-preview coverage to validate additional zoom toggling and transition reopening behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->