### PR TITLE
fix(workbench): stabilize mission control presence

### DIFF
--- a/packages/agent/gui/agent-gui/agentGuiNode/AgentGUINode.spec.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/AgentGUINode.spec.tsx
@@ -2031,13 +2031,13 @@ describe("AgentGUINode", () => {
     renderAgentGUINode();
 
     const emptyHeading = screen.getByRole("heading", {
-      name: "What can help you with?"
+      name: "What can Claude Code help you with?"
     });
     expect(
       within(emptyHeading).getByRole("combobox", {
         name: "agentHost.agentGui.providerSwitchLabel"
       })
-    ).toHaveTextContent("Claude Code");
+    ).toHaveValue(claudeTarget.targetId);
     const iconEffect = document.querySelector(
       ".agent-gui-node__empty-hero-icon-effect"
     );

--- a/packages/agent/gui/agent-gui/agentGuiNode/AgentGUINodeView.layout.spec.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/AgentGUINodeView.layout.spec.tsx
@@ -1400,11 +1400,12 @@ describe("AgentGUINodeView layout persistence", () => {
 
     expect(composerMock.calls.at(-1)?.composerFocusRequestSequence).toBeNull();
 
-    fireEvent.keyDown(
+    fireEvent.change(
       screen.getByRole("combobox", { name: "Switch provider" }),
-      { key: "ArrowDown" }
+      {
+        target: { value: claudeTarget.targetId }
+      }
     );
-    fireEvent.click(await screen.findByRole("option", { name: "Claude Code" }));
 
     expect(actions.selectHomeComposerAgentTarget).toHaveBeenCalledWith({
       provider: "claude-code",
@@ -1707,7 +1708,7 @@ describe("AgentGUINodeView layout persistence", () => {
     const trigger = screen.getByRole("combobox", { name: "Switch provider" });
 
     expect(trigger).toHaveClass("agent-gui-node__empty-hero-provider-select");
-    expect(trigger).toHaveTextContent("Codex");
+    expect(trigger).toHaveValue(providerTargets[0]!.targetId);
   });
 
   it("renders provider switching options in the localized title", () => {
@@ -1734,10 +1735,10 @@ describe("AgentGUINodeView layout persistence", () => {
     const trigger = screen.getByRole("combobox", { name: "切换 Provider" });
 
     expect(trigger).toHaveClass("agent-gui-node__empty-hero-provider-select");
-    expect(trigger).toHaveTextContent("Codex");
+    expect(trigger).toHaveValue(providerTargets[0]!.targetId);
   });
 
-  it("uses Cursor colorful artwork in the empty hero provider select", async () => {
+  it("uses Cursor as the selected empty hero provider option", () => {
     const providerTargets = [
       createLocalAgentGUIProviderTarget("codex"),
       {
@@ -1769,13 +1770,11 @@ describe("AgentGUINodeView layout persistence", () => {
     const trigger = screen.getByRole("combobox", {
       name: "Switch provider"
     });
-    fireEvent.keyDown(trigger, { key: "ArrowDown" });
 
-    expect(
-      (await screen.findByRole("option", { name: "Cursor" })).querySelector(
-        "img"
-      )
-    ).toHaveAttribute("src", MANAGED_AGENT_PROVIDER_RAIL_ICON_URLS.cursor);
+    expect(trigger).toHaveValue(providerTargets[1]!.targetId);
+    expect(screen.getByRole("option", { name: "Cursor" })).toHaveValue(
+      providerTargets[1]!.targetId
+    );
   });
 
   it("uses Cursor colorful artwork in the empty hero icon", () => {
@@ -2725,7 +2724,9 @@ describe("AgentGUINodeView layout persistence", () => {
       "agent-gui-conversation-item-newer-pinned-session"
     );
     fireEvent.click(
-      screen.getByRole("button", { name: createLabels().showMoreConversations })
+      screen.getByRole("button", {
+        name: createLabels().showMoreConversations
+      })
     );
 
     await waitFor(() => {

--- a/packages/agent/gui/agent-gui/agentGuiNode/AgentGUINodeView.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/AgentGUINodeView.tsx
@@ -60,10 +60,6 @@ import {
   TooltipContent,
   TooltipProvider,
   TooltipTrigger,
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
   NewWorkspaceLinedIcon,
   ConfirmationDialog,
   ContextMenu,
@@ -4570,11 +4566,11 @@ function EmptyHeroTitle({
     <>
       {label.slice(0, providerStart)}
       {canSwitchProvider ? (
-        <Select
+        <select
           value={selectedProviderTargetId}
-          onValueChange={(nextTargetId) => {
+          onChange={(event) => {
             const target = enabledProviderTargets.find(
-              (candidate) => candidate.targetId === nextTargetId
+              (candidate) => candidate.targetId === event.currentTarget.value
             );
             if (!target) {
               return;
@@ -4584,43 +4580,19 @@ function EmptyHeroTitle({
               providerTargetId: target.targetId
             });
           }}
+          aria-label={providerSelectLabel}
+          title={providerSelectLabel}
+          className={styles.emptyHeroProviderSelect}
         >
-          <SelectTrigger
-            size="sm"
-            aria-label={providerSelectLabel}
-            title={providerSelectLabel}
-            className={styles.emptyHeroProviderSelect}
-          >
-            <span className={styles.emptyHeroProvider}>{providerName}</span>
-          </SelectTrigger>
-          <SelectContent
-            align="center"
-            className={cn(styles.composerMenuContent, "min-w-[190px]")}
-          >
-            {enabledProviderTargets.map((target) => (
-              <SelectItem
-                key={`${target.provider}:${target.targetId}`}
-                value={target.targetId}
-                className={cn(styles.composerMenuItem, "gap-2")}
-              >
-                <span className="flex min-w-0 items-center gap-1.5">
-                  <img
-                    alt=""
-                    aria-hidden="true"
-                    className="size-4 shrink-0 rounded-[4px]"
-                    src={
-                      agentGUIProviderRailIconPresentation(
-                        target.provider,
-                        target.iconUrl
-                      ).iconUrl
-                    }
-                  />
-                  <span className="min-w-0 truncate">{target.label}</span>
-                </span>
-              </SelectItem>
-            ))}
-          </SelectContent>
-        </Select>
+          {enabledProviderTargets.map((target) => (
+            <option
+              key={`${target.provider}:${target.targetId}`}
+              value={target.targetId}
+            >
+              {target.label}
+            </option>
+          ))}
+        </select>
       ) : (
         <span className={styles.emptyHeroProvider}>{providerName}</span>
       )}

--- a/packages/agent/gui/app/renderer/agentactivity.css
+++ b/packages/agent/gui/app/renderer/agentactivity.css
@@ -9236,7 +9236,7 @@ button.agent-gui-node__provider-rail-launchpad-item {
 }
 
 .agent-gui-node__empty-hero-provider-select {
-  display: inline-flex;
+  display: inline-block;
   width: auto;
   min-width: 0;
   height: auto;
@@ -9253,6 +9253,8 @@ button.agent-gui-node__provider-rail-launchpad-item {
   letter-spacing: inherit;
   box-shadow: none;
   white-space: nowrap;
+  appearance: auto;
+  cursor: pointer;
 }
 
 .agent-gui-node__empty-hero-provider-select:hover,

--- a/packages/workbench/surface/src/mission-control/useWorkbenchMissionControlPresence.ts
+++ b/packages/workbench/surface/src/mission-control/useWorkbenchMissionControlPresence.ts
@@ -27,6 +27,9 @@ export function useWorkbenchMissionControlPresence(
   const enterFrameRef = useRef<number | null>(null);
   const setPresencePhase = useCallback(
     (nextPhase: WorkbenchMissionControlPhase) => {
+      if (phaseRef.current === nextPhase) {
+        return;
+      }
       phaseRef.current = nextPhase;
       setPhase(nextPhase);
     },

--- a/packages/workbench/surface/src/mission-control/useWorkbenchMissionControlState.ts
+++ b/packages/workbench/surface/src/mission-control/useWorkbenchMissionControlState.ts
@@ -277,16 +277,25 @@ export function useWorkbenchMissionControlState<TData>({
     };
   }, [mode, onRequestClose]);
 
-  if (mode === null || presentation === null) {
-    return null;
-  }
-
-  return {
-    applyPreset,
-    canApplyPreset,
-    canUsePreset,
-    mode,
-    presentation,
-    selectedCount: orderedSelectedNodeIds.length
-  };
+  return useMemo<WorkbenchMissionControlState | null>(
+    () =>
+      mode === null || presentation === null
+        ? null
+        : {
+            applyPreset,
+            canApplyPreset,
+            canUsePreset,
+            mode,
+            presentation,
+            selectedCount: orderedSelectedNodeIds.length
+          },
+    [
+      applyPreset,
+      canApplyPreset,
+      canUsePreset,
+      mode,
+      orderedSelectedNodeIds.length,
+      presentation
+    ]
+  );
 }


### PR DESCRIPTION
## Summary
- stabilize Mission Control state identity so presence effects do not loop during layout open
- avoid duplicate presence phase updates
- replace the AgentGUI empty hero provider selector with a native select to avoid Radix trigger ref update loops

## Tests
- PATH=/Users/vector/.nvm/versions/node/v24.18.0/bin:$PATH corepack pnpm --dir /Users/vector/Documents/CODES/WORK_SPACE_MAIN/tutti --filter @tutti-os/agent-gui test -- agent-gui/agentGuiNode/AgentGUINodeView.layout.spec.tsx
- PATH=/Users/vector/.nvm/versions/node/v24.18.0/bin:$PATH corepack pnpm --dir /Users/vector/Documents/CODES/WORK_SPACE_MAIN/tutti --filter @tutti-os/agent-gui typecheck
- PATH=/Users/vector/.nvm/versions/node/v24.18.0/bin:$PATH corepack pnpm --dir /Users/vector/Documents/CODES/WORK_SPACE_MAIN/tutti --filter @tutti-os/workbench-surface typecheck
- PATH=/Users/vector/.nvm/versions/node/v24.18.0/bin:$PATH corepack pnpm --dir /Users/vector/Documents/CODES/WORK_SPACE_MAIN/tutti --filter @tutti-os/workbench-surface test
- PATH=/Users/vector/.nvm/versions/node/v24.18.0/bin:$PATH git -C /Users/vector/Documents/CODES/WORK_SPACE_MAIN/tutti push -u origin fix/workbench-mission-control-presence (pre-push check:full passed)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The provider switcher in the empty-state view now uses a native dropdown, making it more consistent and reliable to use.
  * The selected provider is now shown more clearly in the empty-state heading.

* **Bug Fixes**
  * Improved provider selection behavior so the chosen option is tracked more accurately.
  * Reduced unnecessary state updates in mission control for smoother performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->