### PR TITLE
fix(agent-gui): preserve unsent home draft when starting a new session

### DIFF
--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUINodeController.spec.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUINodeController.spec.tsx
@@ -6507,6 +6507,61 @@ describe("useAgentGUINodeController", () => {
     });
   });
 
+  it("preserves an unsent home draft when starting a new session from an existing conversation", async () => {
+    const activate = vi.fn((input: AgentHostActivateAgentSessionInput) =>
+      Promise.resolve({
+        session: agentSession(input.agentSessionId),
+        activation: { mode: input.mode, status: "attached" as const }
+      })
+    );
+    installAgentHostApi({
+      list: vi.fn(async () => snapshotWithSession("session-1")),
+      listSessionTimeline: vi.fn(async () => ({ timelineItems: [] })),
+      subscribeEvents: vi.fn(() => vi.fn()),
+      activate,
+      exec: vi.fn(async () => ({ turnId: "turn-1" }))
+    });
+
+    const { result } = renderHook(() =>
+      useAgentGUINodeController({
+        workspaceId: "room-1",
+        currentUserId: "user-1",
+        workspacePath: "/workspace",
+        avoidGroupingEdits: false,
+        data: agentGuiData("session-1"),
+        onDataChange: vi.fn()
+      })
+    );
+
+    await waitFor(() => {
+      expect(result.current.viewModel.activeConversationId).toBe("session-1");
+    });
+
+    // Go to the home composer and type something without sending it.
+    act(() => {
+      result.current.actions.createConversation();
+    });
+    act(() => {
+      result.current.actions.updateDraftContent(draftContent("unsent draft"));
+    });
+    expect(result.current.viewModel.draftPrompt).toBe("unsent draft");
+
+    // Navigate into an existing conversation, then start a brand-new session.
+    act(() => {
+      result.current.actions.selectConversation("session-1");
+    });
+    await waitFor(() => {
+      expect(result.current.viewModel.activeConversationId).toBe("session-1");
+    });
+    act(() => {
+      result.current.actions.createConversation();
+    });
+
+    // The never-sent draft must still be waiting in the fresh composer.
+    expect(result.current.viewModel.activeConversationId).toBeNull();
+    expect(result.current.viewModel.draftPrompt).toBe("unsent draft");
+  });
+
   it("renders live assistant messages for a newly created session with only an optimistic prompt in detail", async () => {
     let resolveActivation:
       | ((value: AgentHostActivateAgentSessionResult) => void)

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUINodeController.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUINodeController.ts
@@ -4219,6 +4219,14 @@ export function useAgentGUINodeController({
     Record<string, AgentComposerDraft>
   >({});
   const draftBySessionIdRef = useRef(draftBySessionId);
+  // Home drafts that were just submitted and are still visible in the composer
+  // during the async session-create round trip (their eager clear is skipped so
+  // the box isn't left blank mid-flight). Keyed by the same home draft key. This
+  // lets `createConversation` distinguish already-sent leftover text (safe to
+  // clear) from genuinely unsent content the user still wants to keep.
+  const pendingSubmittedHomeDraftRef = useRef<
+    Record<string, AgentComposerDraft>
+  >({});
   const [draftSettingsBySessionId, setDraftSettingsBySessionId] = useState<
     Record<string, AgentSessionComposerSettings>
   >({});
@@ -7636,6 +7644,14 @@ export function useAgentGUINodeController({
       const submittedHomeDraft =
         draftBySessionIdRef.current[submittedHomeDraftKey] ??
         EMPTY_AGENT_COMPOSER_DRAFT;
+      // Remember the just-submitted home draft so a `createConversation` fired
+      // mid-flight clears only this leftover sent text, not later unsent edits.
+      if (agentComposerDraftHasContent(submittedHomeDraft)) {
+        pendingSubmittedHomeDraftRef.current = {
+          ...pendingSubmittedHomeDraftRef.current,
+          [submittedHomeDraftKey]: submittedHomeDraft
+        };
+      }
       isCreatingConversationRef.current = true;
       setLocalIsCreatingConversation(true);
       setDetailError(null);
@@ -8209,6 +8225,16 @@ export function useAgentGUINodeController({
         .finally(() => {
           isCreatingConversationRef.current = false;
           setLocalIsCreatingConversation(false);
+          // The create has settled (success cleared the draft; failure kept it
+          // as a real unsent draft). Either way the submitted home draft is no
+          // longer in-flight leftover text, so drop its pending marker — a
+          // subsequent createConversation must treat any home content as unsent
+          // and preserve it.
+          if (pendingSubmittedHomeDraftRef.current[submittedHomeDraftKey]) {
+            const nextPending = { ...pendingSubmittedHomeDraftRef.current };
+            delete nextPending[submittedHomeDraftKey];
+            pendingSubmittedHomeDraftRef.current = nextPending;
+          }
         });
     },
     [
@@ -8322,10 +8348,21 @@ export function useAgentGUINodeController({
         let next: Record<string, AgentComposerDraft> | null = null;
         for (const key of homeDraftKeysToClear) {
           const existing = current[key];
-          if (existing && agentComposerDraftHasContent(existing)) {
-            next = next ?? { ...current };
-            next[key] = emptyAgentComposerDraft();
+          if (!existing || !agentComposerDraftHasContent(existing)) {
+            continue;
           }
+          // Only wipe leftover text from a submission still in-flight (the eager
+          // clear was skipped so the box wasn't blank mid-round-trip). Genuinely
+          // unsent content the user typed must survive starting a new session.
+          const pendingSubmitted = pendingSubmittedHomeDraftRef.current[key];
+          if (
+            !pendingSubmitted ||
+            !areAgentComposerDraftsEqual(existing, pendingSubmitted)
+          ) {
+            continue;
+          }
+          next = next ?? { ...current };
+          next[key] = emptyAgentComposerDraft();
         }
         return next ?? current;
       };


### PR DESCRIPTION
## 问题

新建会话时，输入框会丢失「之前输入但未发送」的内容。

离开一个已有会话去开新会话时，home composer 的草稿会被**无条件清空**。这段清空逻辑原本只用于处理一个特例：用户刚发送后，异步建立会话期间输入框仍残留已发送文字，需要清掉以免带入新输入框。但它连带把用户**真正未发送**的草稿也一起丢弃了。

## 修改

用一个 ref (`pendingSubmittedHomeDraftRef`) 精准区分两种情况：

- 发送时记录「正在异步建立途中」的 home 草稿内容；建立流程 settle 后（成功/失败）在 `finally` 清除标记。
- `createConversation` 只在当前 home 草稿内容**仍等于该待发送标记**时才清空；否则保留 —— 真正未发送的草稿因此得以保留。

## 测试

- 新增测试：`preserves an unsent home draft when starting a new session from an existing conversation`。
- 原有 mid-flight 清理测试仍通过。
- `@tutti-os/agent-gui` 全部 267 个测试通过，类型检查无错误。

## 备注

草稿仅存于内存（React state），**app 重启后不保留**；跨重启保留需额外序列化，超出本次范围。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Preserves an unsent home composer draft when navigating into a conversation and then starting a new session.
  * Prevents newly submitted text from being cleared too early during session creation, so the composer stays in the expected state after navigation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->