### PR TITLE
fix(agent-sidecar): forward Claude settings.json env on release/0704

### DIFF
--- a/docs/conventions/troubleshooting.md
+++ b/docs/conventions/troubleshooting.md
@@ -2123,3 +2123,48 @@ invalid_grant`. Daemon logs may also show an extra `claude-code` process start
 - References:
   [composer_live_model_discovery.go](../../services/tuttid/service/agent/composer_live_model_discovery.go)
   [model_validation.go](../../services/tuttid/service/agent/model_validation.go)
+
+### Claude Code sessions fail with `effectiveSource: "none"` when CC-Switch or similar proxy tools are used
+
+- Symptom:
+  Tutti desktop sessions for the `claude-code` provider never connect. The UI
+  reports `agent session is not connected` even though the same Claude CLI
+  works fine when run from a terminal session that loaded CC-Switch (or a
+  similar `~/.claude/settings.json` proxy).
+- Quick checks:
+  In `tuttid.log` search for `CLAUDE_CODE_AUTH_REFRESH_DEBUG`. If
+  `credentials.effectiveSource` is `"none"` and both `keychain.found` and
+  `plaintext.found` are `false`, but `~/.claude/settings.json` contains an
+  `env` block with `ANTHROPIC_AUTH_TOKEN` and `ANTHROPIC_BASE_URL`, the
+  sidecar never propagated the file's `env` to the Claude SDK.
+- Root cause:
+  CC-Switch writes proxy credentials into `~/.claude/settings.json`'s
+  `env` field. The native Claude CLI picks them up because the user shell
+  exports them into `process.env`, but the Tutti
+  `claude-sdk-sidecar` is launched directly without going through a shell,
+  so those variables are missing. The sidecar previously only merged
+  `process.env` with the ACP payload `env` and never read the file.
+- Fix:
+  Read the Claude settings files in the sidecar and merge their `env`
+  blocks into the Claude SDK query options, between `process.env` (lower
+  priority) and the ACP payload `env` (higher priority). The merge covers
+  `${CLAUDE_CONFIG_DIR}/settings.json` (defaulting to `~/.claude`) plus
+  project-level `.claude/settings.json` / `.claude/settings.local.json`
+  walking from the filesystem root to the session `cwd`, matching the
+  native CLI's layering. See `claudeSettingsEnv` and `ensureQuery` in
+  [claude-sdk-sidecar main.ts](../../packages/agent/claude-sdk-sidecar/src/main.ts).
+  The agentstatus probe reads the same `$CLAUDE_CONFIG_DIR`-aware location
+  (`claudeSettingsDeclares` in
+  [provider_custom_config.go](../../services/tuttid/service/agentstatus/provider_custom_config.go))
+  so the environment wizard and the runtime agree on whether credentials
+  exist.
+- Validation:
+  Run `pnpm --filter @tutti-os/claude-sdk-sidecar test` and
+  `cd services/tuttid && go test ./service/agentstatus/`. Unit tests cover
+  reading, non-string value skipping, missing file, malformed JSON, missing
+  `env` field, user/project/local layering, and `CLAUDE_CONFIG_DIR`
+  resolution.
+- Note:
+  `credentials.effectiveSource` only tracks OAuth material (keychain or
+  `.credentials.json`). For API-key/proxy users it stays `"none"` even
+  after the fix; a connected session is the success signal, not that field.

--- a/packages/agent/claude-sdk-sidecar/README.md
+++ b/packages/agent/claude-sdk-sidecar/README.md
@@ -1,0 +1,50 @@
+# @tutti-os/claude-sdk-sidecar
+
+Sidecar process that bridges the Tutti agent runtime to the
+[`@anthropic-ai/claude-agent-sdk`](https://www.npmjs.com/package/@anthropic-ai/claude-agent-sdk).
+
+Unlike the other `@tutti-os/*` release packages, this package ships **raw
+TypeScript** under `src/` rather than a compiled `dist/`. It is executed
+directly with Node's type-stripping loader:
+
+```sh
+node --experimental-strip-types ./src/main.ts
+```
+
+Consumers (the Tutti daemon, the desktop bundle, and `tsh`'s `npm-bundle-dir`)
+pull this package into `node_modules`, install its runtime `dependencies`, and
+launch `src/main.ts` with `--experimental-strip-types`. There is therefore no
+build step and no bundled entry point beyond the source files.
+
+## Runtime dependencies
+
+- `@anthropic-ai/claude-agent-sdk`
+- `zod`
+
+## Environment propagation
+
+The sidecar is launched directly without a shell, so user shell hooks (such
+as CC-Switch) that inject proxy credentials into `process.env` never reach
+the Claude SDK. To preserve parity with the native `claude` CLI, the sidecar
+reads Claude settings files and merges their `env` blocks into the SDK query
+options.
+
+Merge precedence (lowest to highest):
+
+1. `process.env` at sidecar start
+2. `env` entries from `${CLAUDE_CONFIG_DIR}/settings.json` (defaulting to
+   `~/.claude/settings.json`)
+3. `env` entries from project-level `.claude/settings.json` and
+   `.claude/settings.local.json`, walking from the filesystem root down to
+   the session `cwd` (deeper directories win, `settings.local.json`
+   overrides `settings.json` in the same directory)
+4. ACP payload `env` injected by tuttid for the active session
+
+Only string-typed entries from the settings files are forwarded; non-string
+values are skipped. A missing file, malformed JSON, or absent `env` block
+contributes nothing and never blocks session start.
+
+This is the same pattern that the native Claude CLI uses, so credentials
+configured by tools such as CC-Switch (e.g. `ANTHROPIC_AUTH_TOKEN`,
+`ANTHROPIC_BASE_URL`) flow through to the Claude SDK exactly as they would
+in a terminal session.

--- a/packages/agent/claude-sdk-sidecar/src/main.test.ts
+++ b/packages/agent/claude-sdk-sidecar/src/main.test.ts
@@ -5,7 +5,12 @@ import type {
   SDKMessage,
   SDKUserMessage
 } from "@anthropic-ai/claude-agent-sdk";
-import { SessionRuntime, withSidecarEventSinkForTest } from "./main.ts";
+import {
+  claudeSettingsEnv,
+  loadClaudeSettingsEnv,
+  SessionRuntime,
+  withSidecarEventSinkForTest
+} from "./main.ts";
 import { sidecarClaudeOptionsFromPayload } from "./options.ts";
 
 test("late delegated task notification keeps original parent turn id", async () => {
@@ -2796,3 +2801,186 @@ async function waitForMatchingEvent(
     `timed out waiting for matching event; events=${JSON.stringify(events)}`
   );
 }
+
+test("loadClaudeSettingsEnv reads env from ~/.claude/settings.json", async () => {
+  const { mkdirSync, writeFileSync, rmSync } = await import("node:fs");
+  const { tmpdir } = await import("node:os");
+  const { join } = await import("node:path");
+  const tempDir = join(tmpdir(), `tutti-claude-settings-merge-${Date.now()}`);
+  mkdirSync(tempDir, { recursive: true });
+  writeFileSync(
+    join(tempDir, "settings.json"),
+    JSON.stringify({
+      env: {
+        ANTHROPIC_AUTH_TOKEN: "PROXY_MANAGED",
+        ANTHROPIC_BASE_URL: "http://127.0.0.1:15721"
+      }
+    })
+  );
+  try {
+    const result = loadClaudeSettingsEnv(tempDir);
+    assert.equal(result.ANTHROPIC_AUTH_TOKEN, "PROXY_MANAGED");
+    assert.equal(result.ANTHROPIC_BASE_URL, "http://127.0.0.1:15721");
+  } finally {
+    rmSync(tempDir, { recursive: true, force: true });
+  }
+});
+
+test("loadClaudeSettingsEnv skips non-string env values", async () => {
+  const { mkdirSync, writeFileSync, rmSync } = await import("node:fs");
+  const { tmpdir } = await import("node:os");
+  const { join } = await import("node:path");
+  const tempDir = join(tmpdir(), `tutti-claude-settings-skip-${Date.now()}`);
+  mkdirSync(tempDir, { recursive: true });
+  writeFileSync(
+    join(tempDir, "settings.json"),
+    JSON.stringify({
+      env: {
+        ANTHROPIC_AUTH_TOKEN: "valid-token",
+        ANTHROPIC_BASE_URL: 12345,
+        DISABLED: null
+      }
+    })
+  );
+  try {
+    const result = loadClaudeSettingsEnv(tempDir);
+    assert.equal(result.ANTHROPIC_AUTH_TOKEN, "valid-token");
+    assert.equal(result.ANTHROPIC_BASE_URL, undefined);
+    assert.equal(result.DISABLED, undefined);
+  } finally {
+    rmSync(tempDir, { recursive: true, force: true });
+  }
+});
+
+test("loadClaudeSettingsEnv returns empty object when settings.json missing", async () => {
+  const { mkdirSync, rmSync } = await import("node:fs");
+  const { tmpdir } = await import("node:os");
+  const { join } = await import("node:path");
+  const tempDir = join(tmpdir(), `tutti-claude-settings-empty-${Date.now()}`);
+  mkdirSync(tempDir, { recursive: true });
+  try {
+    const result = loadClaudeSettingsEnv(tempDir);
+    assert.deepEqual(result, {});
+  } finally {
+    rmSync(tempDir, { recursive: true, force: true });
+  }
+});
+
+test("loadClaudeSettingsEnv returns empty object for malformed settings.json", async () => {
+  const { mkdirSync, writeFileSync, rmSync } = await import("node:fs");
+  const { tmpdir } = await import("node:os");
+  const { join } = await import("node:path");
+  const tempDir = join(
+    tmpdir(),
+    `tutti-claude-settings-malformed-${Date.now()}`
+  );
+  mkdirSync(tempDir, { recursive: true });
+  writeFileSync(join(tempDir, "settings.json"), "{ not valid json");
+  try {
+    const result = loadClaudeSettingsEnv(tempDir);
+    assert.deepEqual(result, {});
+  } finally {
+    rmSync(tempDir, { recursive: true, force: true });
+  }
+});
+
+test("loadClaudeSettingsEnv returns empty object when env field absent", async () => {
+  const { mkdirSync, writeFileSync, rmSync } = await import("node:fs");
+  const { tmpdir } = await import("node:os");
+  const { join } = await import("node:path");
+  const tempDir = join(tmpdir(), `tutti-claude-settings-noenv-${Date.now()}`);
+  mkdirSync(tempDir, { recursive: true });
+  writeFileSync(
+    join(tempDir, "settings.json"),
+    JSON.stringify({ mcpServers: {} })
+  );
+  try {
+    const result = loadClaudeSettingsEnv(tempDir);
+    assert.deepEqual(result, {});
+  } finally {
+    rmSync(tempDir, { recursive: true, force: true });
+  }
+});
+
+test("claudeSettingsEnv layers user, project, and local settings", async () => {
+  const { mkdirSync, writeFileSync, rmSync } = await import("node:fs");
+  const { tmpdir } = await import("node:os");
+  const { join } = await import("node:path");
+  const tempDir = join(tmpdir(), `tutti-claude-settings-layered-${Date.now()}`);
+  const configDir = join(tempDir, "config");
+  const projectDir = join(tempDir, "project");
+  mkdirSync(join(configDir), { recursive: true });
+  mkdirSync(join(projectDir, ".claude"), { recursive: true });
+  writeFileSync(
+    join(configDir, "settings.json"),
+    JSON.stringify({
+      env: {
+        ANTHROPIC_AUTH_TOKEN: "user-token",
+        ANTHROPIC_BASE_URL: "https://user.example",
+        USER_ONLY: "user"
+      }
+    })
+  );
+  writeFileSync(
+    join(projectDir, ".claude", "settings.json"),
+    JSON.stringify({
+      env: {
+        ANTHROPIC_BASE_URL: "https://project.example",
+        PROJECT_ONLY: "project"
+      }
+    })
+  );
+  writeFileSync(
+    join(projectDir, ".claude", "settings.local.json"),
+    JSON.stringify({
+      env: { ANTHROPIC_BASE_URL: "https://local.example" }
+    })
+  );
+  const previousConfigDir = process.env.CLAUDE_CONFIG_DIR;
+  process.env.CLAUDE_CONFIG_DIR = configDir;
+  try {
+    const result = claudeSettingsEnv(projectDir);
+    assert.equal(result.ANTHROPIC_AUTH_TOKEN, "user-token");
+    assert.equal(result.USER_ONLY, "user");
+    assert.equal(result.PROJECT_ONLY, "project");
+    assert.equal(result.ANTHROPIC_BASE_URL, "https://local.example");
+  } finally {
+    if (previousConfigDir === undefined) {
+      delete process.env.CLAUDE_CONFIG_DIR;
+    } else {
+      process.env.CLAUDE_CONFIG_DIR = previousConfigDir;
+    }
+    rmSync(tempDir, { recursive: true, force: true });
+  }
+});
+
+test("claudeSettingsEnv works without project settings", async () => {
+  const { mkdirSync, writeFileSync, rmSync } = await import("node:fs");
+  const { tmpdir } = await import("node:os");
+  const { join } = await import("node:path");
+  const tempDir = join(
+    tmpdir(),
+    `tutti-claude-settings-useronly-${Date.now()}`
+  );
+  const configDir = join(tempDir, "config");
+  const projectDir = join(tempDir, "project");
+  mkdirSync(configDir, { recursive: true });
+  mkdirSync(projectDir, { recursive: true });
+  writeFileSync(
+    join(configDir, "settings.json"),
+    JSON.stringify({ env: { ANTHROPIC_AUTH_TOKEN: "user-token" } })
+  );
+  const previousConfigDir = process.env.CLAUDE_CONFIG_DIR;
+  process.env.CLAUDE_CONFIG_DIR = configDir;
+  try {
+    const result = claudeSettingsEnv(projectDir);
+    assert.equal(result.ANTHROPIC_AUTH_TOKEN, "user-token");
+  } finally {
+    if (previousConfigDir === undefined) {
+      delete process.env.CLAUDE_CONFIG_DIR;
+    } else {
+      process.env.CLAUDE_CONFIG_DIR = previousConfigDir;
+    }
+    rmSync(tempDir, { recursive: true, force: true });
+  }
+});

--- a/packages/agent/claude-sdk-sidecar/src/main.ts
+++ b/packages/agent/claude-sdk-sidecar/src/main.ts
@@ -2,6 +2,7 @@ import { execFileSync } from "node:child_process";
 import { createHash } from "node:crypto";
 import { readFileSync, statSync } from "node:fs";
 import { homedir, userInfo } from "node:os";
+import { dirname, join, resolve } from "node:path";
 import * as readline from "node:readline/promises";
 import { stdin, stdout, stderr } from "node:process";
 import { pathToFileURL } from "node:url";
@@ -977,6 +978,7 @@ export class SessionRuntime {
       cwd: this.cwd || process.cwd(),
       env: {
         ...process.env,
+        ...claudeSettingsEnv(this.cwd || process.cwd()),
         ...this.env,
         CLAUDE_CODE_EMIT_SESSION_STATE_EVENTS: "1"
       },
@@ -3606,6 +3608,74 @@ function credentialProbeErrorPayload(error: unknown): Record<string, unknown> {
 
 function claudeConfigDir(): string {
   return process.env.CLAUDE_CONFIG_DIR || `${homedir()}/.claude`;
+}
+
+export function loadClaudeSettingsEnv(
+  configDir: string
+): Record<string, string> {
+  return claudeSettingsEnvFromFile(join(configDir, "settings.json"));
+}
+
+// claudeSettingsEnv merges the `env` blocks the native Claude CLI would apply
+// for a session in `cwd`: user settings first, then project settings walking
+// from the filesystem root down to `cwd` (deeper directories win), with each
+// directory's `settings.local.json` overriding its `settings.json`. Mirrors
+// the daemon's claudeProjectSettingsPaths in provider_endpoint.go.
+export function claudeSettingsEnv(cwd: string): Record<string, string> {
+  const merged = loadClaudeSettingsEnv(claudeConfigDir());
+  for (const path of claudeProjectSettingsPaths(cwd)) {
+    Object.assign(merged, claudeSettingsEnvFromFile(path));
+  }
+  return merged;
+}
+
+function claudeProjectSettingsPaths(cwd: string): string[] {
+  const trimmed = cwd.trim();
+  if (!trimmed) {
+    return [];
+  }
+  const dirs: string[] = [];
+  let current = resolve(trimmed);
+  for (;;) {
+    dirs.push(current);
+    const parent = dirname(current);
+    if (parent === current) {
+      break;
+    }
+    current = parent;
+  }
+  dirs.reverse();
+  const paths: string[] = [];
+  for (const dir of dirs) {
+    paths.push(
+      join(dir, ".claude", "settings.json"),
+      join(dir, ".claude", "settings.local.json")
+    );
+  }
+  return paths;
+}
+
+function claudeSettingsEnvFromFile(path: string): Record<string, string> {
+  try {
+    const content = readFileSync(path, "utf8");
+    const parsed = parseJSONObject(content);
+    if (
+      !parsed?.env ||
+      typeof parsed.env !== "object" ||
+      Array.isArray(parsed.env)
+    ) {
+      return {};
+    }
+    const result: Record<string, string> = {};
+    for (const [key, value] of Object.entries(parsed.env)) {
+      if (typeof key === "string" && typeof value === "string") {
+        result[key] = value;
+      }
+    }
+    return result;
+  } catch {
+    return {};
+  }
 }
 
 function claudeKeychainAccount(): string {

--- a/services/tuttid/service/agentstatus/provider_custom_config.go
+++ b/services/tuttid/service/agentstatus/provider_custom_config.go
@@ -194,15 +194,21 @@ func (s Service) codexAuthJSONHasAPIKey() bool {
 	return strings.TrimSpace(parsed.OpenAIAPIKey) != ""
 }
 
-// claudeSettingsDeclares reports whether ~/.claude/settings.json sets any of
+// claudeSettingsDeclares reports whether the Claude settings.json sets any of
 // the given env keys to a non-blank value, or — when withAPIKeyHelper is true —
-// declares a non-blank apiKeyHelper.
+// declares a non-blank apiKeyHelper. The settings file lives under
+// $CLAUDE_CONFIG_DIR when set (matching the claude-sdk-sidecar), otherwise
+// ~/.claude.
 func (s Service) claudeSettingsDeclares(keys []string, withAPIKeyHelper bool) bool {
-	home, err := s.homeDir()
-	if err != nil || strings.TrimSpace(home) == "" {
-		return false
+	configDir := strings.TrimSpace(s.lookupEnv("CLAUDE_CONFIG_DIR"))
+	if configDir == "" {
+		home, err := s.homeDir()
+		if err != nil || strings.TrimSpace(home) == "" {
+			return false
+		}
+		configDir = filepath.Join(home, ".claude")
 	}
-	content, err := os.ReadFile(filepath.Join(home, ".claude", "settings.json"))
+	content, err := os.ReadFile(filepath.Join(configDir, "settings.json"))
 	if err != nil {
 		return false
 	}

--- a/services/tuttid/service/agentstatus/provider_custom_config_test.go
+++ b/services/tuttid/service/agentstatus/provider_custom_config_test.go
@@ -153,6 +153,29 @@ func TestProviderHasAPICredentialSettingsApiKeyHelper(t *testing.T) {
 	}
 }
 
+// The claude-sdk-sidecar resolves settings.json under $CLAUDE_CONFIG_DIR when
+// set; the status probe must look at the same file or the wizard and the
+// runtime would disagree about whether credentials exist.
+func TestProviderHasAPICredentialRespectsClaudeConfigDir(t *testing.T) {
+	home := t.TempDir()
+	configDir := filepath.Join(home, "custom-claude-config")
+	writeFile(t, filepath.Join(configDir, "settings.json"),
+		`{"env":{"ANTHROPIC_AUTH_TOKEN":"sk-test"}}`)
+	svc := customConfigService(home)
+	svc.Environ = func() []string { return []string{"CLAUDE_CONFIG_DIR=" + configDir} }
+	if !svc.providerHasAPICredential(agentprovider.ClaudeCode) {
+		t.Fatal("expected CLAUDE_CONFIG_DIR settings.json credential to be detected")
+	}
+	// The default ~/.claude location must not be consulted when the override
+	// is set.
+	writeFile(t, filepath.Join(home, ".claude", "settings.json"),
+		`{"env":{"ANTHROPIC_AUTH_TOKEN":"sk-ignored"}}`)
+	svc.Environ = func() []string { return []string{"CLAUDE_CONFIG_DIR=" + filepath.Join(home, "empty-dir")} }
+	if svc.providerHasAPICredential(agentprovider.ClaudeCode) {
+		t.Fatal("expected empty CLAUDE_CONFIG_DIR to hide the default settings.json")
+	}
+}
+
 // A bare custom endpoint without any API credential must NOT be reported as an
 // API credential: the user may still be on an OAuth/subscription session against
 // that endpoint, so labeling them "API Usage Billing" would be wrong.


### PR DESCRIPTION
## Summary
- Backport [#988](https://github.com/tutti-os/tutti/pull/988) onto `release/0704`: merge Claude `settings.json` `env` (user + project/local layering) into the SDK sidecar query options so CC-Switch / proxy credentials work without a shell.
- Align `agentstatus` Claude credential detection with `$CLAUDE_CONFIG_DIR`, matching the sidecar.
- Conflict resolution kept the existing Codex `auth.json` API-key detection already on `release/0704`, and restored the release-branch `waitForMatchingEvent` helper alongside the new settings-env tests. Also adds the package README that was absent on this branch.

## Test plan
- [x] `pnpm --filter @tutti-os/claude-sdk-sidecar test`
- [x] `cd services/tuttid && go test ./service/agentstatus/ -count=1 -run 'Claude|CustomConfig|APICredential|AuthJSON'`
- [ ] With CC-Switch `~/.claude/settings.json` env (`ANTHROPIC_AUTH_TOKEN` / `ANTHROPIC_BASE_URL`), start a Claude Code session from a `release/0704` build and confirm it connects
- [ ] Confirm Codex API-key-without-login behavior from #990 is unchanged


Made with [Cursor](https://cursor.com)