### PR TITLE
fix(agent): mirror relative Codex model_catalog_json into sandbox

### DIFF
--- a/.changeset/codex-relative-model-catalog-sandbox.md
+++ b/.changeset/codex-relative-model-catalog-sandbox.md
@@ -1,0 +1,5 @@
+---
+"@tutti-os/desktop": patch
+---
+
+Mirror relative Codex `model_catalog_json` files into the run-scoped sandbox `CODEX_HOME`. CC Switch and similar tools write `model_catalog_json = "cc-switch-model-catalog.json"`; Tutti previously copied only `config.toml`, so Codex `thread/start` failed with ENOENT and the UI showed "agent session is not connected".

--- a/docs/conventions/troubleshooting.md
+++ b/docs/conventions/troubleshooting.md
@@ -1052,6 +1052,40 @@ delimited by ---`, and the composer skill picker may show partial or
   (env, config.toml, and auth.json), then run
   `cd services/tuttid && go test ./service/agentstatus`.
 
+### Codex session fails with not connected when model_catalog_json is relative
+
+- Symptom:
+  Codex is installed and `codex login status` reports logged in, but Tutti
+  chat fails with `agent session is not connected`. Daemon logs show
+  `thread/start` failing with
+  `failed to load configuration: No such file or directory (os error 2)`.
+  Tools such as CC Switch often set
+  `model_catalog_json = "cc-switch-model-catalog.json"` in `~/.codex/config.toml`.
+  If that catalog file is missing entirely, the same config error can also make
+  provider status show login required (`auth_unknown`) even though OAuth tokens
+  exist.
+- Quick checks:
+  `grep model_catalog_json ~/.codex/config.toml` and confirm the referenced
+  file exists under `~/.codex/`. Inspect the run-scoped
+  `~/.tutti-dev/agent/runs/<session>/codex-home/` (or `~/.tutti/...` in prod):
+  `config.toml` is copied, but a relative catalog must also be present there.
+- Root cause:
+  Tutti prepares a run-scoped `CODEX_HOME` and copies only `config.toml` (plus
+  auth/plugin/skill exposure). Relative `model_catalog_json` paths resolve
+  against that sandbox home, so the catalog is missing unless Tutti mirrors it.
+- Fix:
+  After copying `config.toml`, resolve top-level `model_catalog_json`. For
+  relative paths under `~/.codex`, symlink (or copy) the catalog into the
+  run-scoped `CODEX_HOME` at the same relative path. Absolute catalog paths
+  need no mirror. Do not mutate the user's global config.
+- Validation:
+  Add or update `agentsidecar` tests that set a relative catalog beside
+  `config.toml` and assert the sandbox exposes it. Run
+  `cd services/tuttid && go test ./service/agentsidecar`.
+- References:
+  [codex.go](../../services/tuttid/service/agentsidecar/codex.go)
+  [preparer_test.go](../../services/tuttid/service/agentsidecar/preparer_test.go)
+
 ### Codex custom model_provider mixes official models, duplicates replies, or shows metadata warnings
 
 - Symptom:

--- a/services/tuttid/service/agentsidecar/codex.go
+++ b/services/tuttid/service/agentsidecar/codex.go
@@ -132,7 +132,10 @@ func exposeUserCodexFiles(codexHome string) error {
 	if err := exposeUserCodexPluginState(codexHome, userCodexHome); err != nil {
 		return err
 	}
-	return exposeUserCodexConfig(codexHome, userCodexHome)
+	if err := exposeUserCodexConfig(codexHome, userCodexHome); err != nil {
+		return err
+	}
+	return exposeUserCodexModelCatalog(codexHome, userCodexHome)
 }
 
 // exposeCodexImportedRolloutFile symlinks the single Codex CLI rollout
@@ -229,6 +232,67 @@ func exposeUserCodexConfig(codexHome string, userCodexHome string) error {
 	}
 	if err := copyFile(source, target, 0o600); err != nil {
 		return fmt.Errorf("copy codex config: %w", err)
+	}
+	return nil
+}
+
+// exposeUserCodexModelCatalog mirrors a relative model_catalog_json path into
+// the run-scoped CODEX_HOME. Tutti copies config.toml alone; tools such as
+// CC Switch write model_catalog_json = "cc-switch-model-catalog.json", which
+// Codex resolves against CODEX_HOME. Without the catalog file, thread/start
+// fails with ENOENT and Tutti surfaces "agent session is not connected".
+//
+// Absolute catalog paths stay readable from the host filesystem and need no
+// mirror. Missing keys or missing source files are no-ops.
+func exposeUserCodexModelCatalog(codexHome string, userCodexHome string) error {
+	configPath := filepath.Join(codexHome, "config.toml")
+	contentBytes, err := os.ReadFile(configPath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return fmt.Errorf("read codex config for model catalog path: %w", err)
+	}
+	lines := strings.Split(strings.ReplaceAll(string(contentBytes), "\r\n", "\n"), "\n")
+	for _, line := range lines {
+		trimmed := strings.TrimSpace(line)
+		if trimmed == "" || strings.HasPrefix(trimmed, "#") {
+			continue
+		}
+		if strings.HasPrefix(trimmed, "[") {
+			break
+		}
+		value, ok := codexConfigStringAssignmentValue(trimmed, "model_catalog_json")
+		if !ok {
+			continue
+		}
+		value = strings.TrimSpace(value)
+		if value == "" || filepath.IsAbs(value) {
+			return nil
+		}
+		cleanRel := filepath.Clean(value)
+		if cleanRel == "." || cleanRel == ".." || strings.HasPrefix(cleanRel, ".."+string(filepath.Separator)) {
+			return nil
+		}
+		source := filepath.Join(userCodexHome, cleanRel)
+		if info, err := os.Stat(source); err != nil || info.IsDir() {
+			return nil
+		}
+		target := filepath.Join(codexHome, cleanRel)
+		if _, err := os.Lstat(target); err == nil {
+			return nil
+		} else if !os.IsNotExist(err) {
+			return fmt.Errorf("inspect codex model catalog: %w", err)
+		}
+		if err := os.MkdirAll(filepath.Dir(target), 0o700); err != nil {
+			return fmt.Errorf("create codex model catalog parent: %w", err)
+		}
+		if err := os.Symlink(source, target); err != nil {
+			if copyErr := copyFile(source, target, 0o600); copyErr != nil {
+				return fmt.Errorf("expose codex model catalog %s: symlink failed: %v; copy failed: %w", cleanRel, err, copyErr)
+			}
+		}
+		return nil
 	}
 	return nil
 }

--- a/services/tuttid/service/agentsidecar/preparer_test.go
+++ b/services/tuttid/service/agentsidecar/preparer_test.go
@@ -26,6 +26,7 @@ func TestDefaultPreparerCodexWritesInstructionsSkillManifestAndEnv(t *testing.T)
 	userCodexConfig := strings.Join([]string{
 		`notify = ["say", "done"]`,
 		`model_provider = "proxy"`,
+		`model_catalog_json = "cc-switch-model-catalog.json"`,
 		`service_tier = "default"`,
 		"",
 		"[model_providers.proxy]",
@@ -33,6 +34,9 @@ func TestDefaultPreparerCodexWritesInstructionsSkillManifestAndEnv(t *testing.T)
 		"",
 	}, "\n")
 	if err := os.WriteFile(filepath.Join(userCodexHome, "config.toml"), []byte(userCodexConfig), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(userCodexHome, "cc-switch-model-catalog.json"), []byte(`{"models":[]}`), 0o600); err != nil {
 		t.Fatal(err)
 	}
 	writeSidecarTestFile(t, filepath.Join(userCodexHome, "plugins", "cache", "sample", "plugin.txt"), "plugin cache")
@@ -116,6 +120,13 @@ func TestDefaultPreparerCodexWritesInstructionsSkillManifestAndEnv(t *testing.T)
 	}
 	if _, err := os.Lstat(filepath.Join(codexHome, "auth.json")); err != nil {
 		t.Fatalf("codex auth not exposed: %v", err)
+	}
+	catalogLink, err := os.Lstat(filepath.Join(codexHome, "cc-switch-model-catalog.json"))
+	if err != nil {
+		t.Fatalf("codex model catalog not exposed: %v", err)
+	}
+	if catalogLink.Mode()&os.ModeSymlink == 0 {
+		t.Fatalf("codex model catalog should be a symlink, got mode %v", catalogLink.Mode())
 	}
 	for _, rel := range []string{
 		filepath.Join("plugins", "cache"),
@@ -319,6 +330,73 @@ func TestDefaultPreparerCodexWritesInstructionsSkillManifestAndEnv(t *testing.T)
 	}
 	if envValue(prepared.Env, "TUTTI_WORKSPACE_ID") != "workspace-1" {
 		t.Fatalf("prepared env = %#v, want workspace id", prepared.Env)
+	}
+}
+
+func TestDefaultPreparerCodexExposesRelativeModelCatalogJSON(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	userCodexHome := filepath.Join(home, ".codex")
+	if err := os.MkdirAll(userCodexHome, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(userCodexHome, "auth.json"), []byte(`{"token":"test"}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	catalogName := "cc-switch-model-catalog.json"
+	catalogBody := `{"models":[{"slug":"gpt-5.5","display_name":"gpt-5.5"}]}`
+	if err := os.WriteFile(filepath.Join(userCodexHome, catalogName), []byte(catalogBody), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	userCodexConfig := strings.Join([]string{
+		`model_catalog_json = "cc-switch-model-catalog.json"`,
+		`model_provider = "proxy"`,
+		"",
+		"[model_providers.proxy]",
+		`base_url = "https://openai.proxy.test/v1"`,
+		"",
+	}, "\n")
+	if err := os.WriteFile(filepath.Join(userCodexHome, "config.toml"), []byte(userCodexConfig), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	stateDir := t.TempDir()
+	cwd := t.TempDir()
+	prepared, err := NewDefaultPreparer(stateDir).Prepare(t.Context(), PrepareInput{
+		WorkspaceID:    "workspace-1",
+		AgentSessionID: "session-catalog",
+		AgentTargetID:  "local:codex",
+		Provider:       "codex",
+		Cwd:            cwd,
+	})
+	if err != nil {
+		t.Fatalf("Prepare() error = %v", err)
+	}
+	codexHome := envValue(prepared.Env, "CODEX_HOME")
+	if codexHome == "" {
+		t.Fatalf("prepared env = %#v, want CODEX_HOME", prepared.Env)
+	}
+	sandboxCatalog := filepath.Join(codexHome, catalogName)
+	info, err := os.Lstat(sandboxCatalog)
+	if err != nil {
+		t.Fatalf("relative model catalog not exposed into sandbox: %v", err)
+	}
+	if info.Mode()&os.ModeSymlink == 0 {
+		t.Fatalf("sandbox model catalog mode = %v, want symlink", info.Mode())
+	}
+	linkTarget, err := os.Readlink(sandboxCatalog)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if linkTarget != filepath.Join(userCodexHome, catalogName) {
+		t.Fatalf("sandbox catalog symlink target = %q, want user catalog", linkTarget)
+	}
+	got, err := os.ReadFile(sandboxCatalog)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != catalogBody {
+		t.Fatalf("sandbox catalog body = %q, want %q", string(got), catalogBody)
 	}
 }
 


### PR DESCRIPTION
## Summary
- Backport for `release/0704`: mirror relative `model_catalog_json` files into the run-scoped Codex sandbox `CODEX_HOME`.
- Fixes user-facing `agent session is not connected` when Codex `thread/start` fails with `failed to load configuration: No such file or directory (os error 2)`.
- Adds agentsidecar coverage and a troubleshooting note.

## Why
User log pack `tutti-logs-20260709-221832` (Tutti 0.1.17) shows repeated `thread/start` failures with bare ENOENT and zero successful starts. CC Switch writes relative `model_catalog_json`; Tutti previously copied only `config.toml` into the sandbox.

## Test plan
- [x] `cd services/tuttid && go test ./service/agentsidecar -run 'TestDefaultPreparerCodexWritesInstructionsSkillManifestAndEnv|TestDefaultPreparerCodexExposesRelativeModelCatalogJSON'`
- [ ] With `model_catalog_json = "cc-switch-model-catalog.json"` and the catalog file under `~/.codex`, start a Codex session and confirm `thread/start` succeeds
- [ ] Confirm sandbox `~/.tutti(-dev)/agent/runs/<session>/codex-home/` contains the catalog symlink/copy


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Mirrors relative Codex `model_catalog_json` into the run-scoped `CODEX_HOME` to prevent `thread/start` ENOENT and fix the “agent session is not connected” error. Backport for `release/0704`.

- **Bug Fixes**
  - When `model_catalog_json` is a relative path, symlink (fallback to copy) the catalog from `~/.codex` into the sandbox; absolute paths are unchanged.
  - Leave the user’s `config.toml` untouched; only mirror the referenced file into the run-scoped `CODEX_HOME`.
  - Added `agentsidecar` tests for relative catalog exposure and updated troubleshooting docs.

<sup>Written for commit 6d59c496057b1cd47d8617ca137dc7e22b0c3e54. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tutti-os/tutti/pull/1004?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

