### PR TITLE
fix(agent-gui): wrap long file-path links so they are not clipped (#421)

### DIFF
--- a/packages/agent/gui/shared/AgentMessageMarkdown.spec.tsx
+++ b/packages/agent/gui/shared/AgentMessageMarkdown.spec.tsx
@@ -104,6 +104,30 @@ describe("AgentMessageMarkdown", () => {
     expect(screen.getByRole("list")).toBeInTheDocument();
     expect(screen.getAllByRole("listitem")).toHaveLength(2);
   });
+  it("lets long inline-code file paths wrap instead of overflowing the message", () => {
+    // Regression for #421: an inline code span holding a long absolute file
+    // path is promoted to a clickable PathLink. That link must keep the same
+    // word-breaking behavior as plain inline code, otherwise the unbreakable
+    // path inflates the markdown container and its tail is clipped.
+    // jsdom cannot lay out overflow, so we guard the break utility classes.
+    const onLinkClick = vi.fn();
+    const longPath =
+      "/Users/sun/.tutti/apps/installations/ai-slide/e7499ff49e24abc4/data/projects/1516ee94-0b47-4d04-a97c-39e08cc124cb/deck.slides/slides/02-contents.html";
+    const { container } = render(
+      <AgentMessageMarkdown
+        content={`路径是 \`${longPath}\``}
+        onLinkClick={onLinkClick}
+      />
+    );
+
+    const link = container.querySelector("[data-agent-link-href]");
+    expect(link).not.toBeNull();
+    expect(link?.getAttribute("data-agent-link-href")).toBe(longPath);
+    expect(link?.className).toMatch(
+      /overflow-wrap|word-break|break-(all|word)/
+    );
+  });
+
   it("renders a copy button on fenced code blocks", () => {
     render(<AgentMessageMarkdown content={"```ts\nconst x = 42;\n```"} />);
 

--- a/packages/agent/gui/shared/AgentMessageMarkdown.tsx
+++ b/packages/agent/gui/shared/AgentMessageMarkdown.tsx
@@ -2003,7 +2003,7 @@ function PathLink({
   "use memo";
   return (
     <a
-      className="cursor-pointer"
+      className="cursor-pointer [overflow-wrap:anywhere] [word-break:break-word]"
       data-agent-link-href={href}
       role="link"
       tabIndex={0}


### PR DESCRIPTION
## Summary

Fixes #421 — "Long file paths in Agent GUI are truncated and cannot be read clearly."

When an agent message contains an inline code span holding an explicit workspace file path (e.g. \`/Users/.../02-contents.html\`), `AgentMessageMarkdown` promotes it to a clickable `PathLink` (`<a>`) rather than a plain `<code>`. `PathLink` only carried `cursor-pointer`, so it lacked the word-breaking utilities that plain inline code already applies via `[&_code]:[overflow-wrap:anywhere] [&_code]:[word-break:break-word]`. The long unbreakable path therefore inflated the markdown container (`overflow-x-auto`) and its tail was clipped, leaving the path unreadable.

This adds the same `[overflow-wrap:anywhere] [word-break:break-word]` utilities to `PathLink`, so path links break across lines exactly like plain inline code.

**Scope:** two files in `packages/agent/gui` — one className addition in `AgentMessageMarkdown.tsx` and one regression test.

## Verification

- New regression test `lets long inline-code file paths wrap instead of overflowing the message` in `AgentMessageMarkdown.spec.tsx`. Verified **RED** before the fix (link `className` was `cursor-pointer`) and **GREEN** after.
- `pnpm --filter @tutti-os/agent-gui test` → full suite green (2187 tests).
- `pnpm check:changed` → 6/6 lanes pass (lint, type/ui/renderer/electron boundaries, agent-gui tests).
- `pnpm typecheck` → pass.
- `pnpm check:full` → every lane green **except** `test:ts`. The `test:ts` failure is environmental and unrelated to this change: 3 tests in `apps/desktop/src/main/agentProviderUsageProbe.test.ts` read this dev machine's `ANTHROPIC_BASE_URL`/`ANTHROPIC_AUTH_TOKEN` (Claude Code is routed through a proxy here) and classify the account as `custom API` instead of `pro`. Re-running `pnpm test:ts` in a clean environment (those vars unset) → **exit 0, all packages green** (desktop 1209, browser-node 75, client-tuttid-ts 46, workbench-snapshot 16, workbench-surface 201, workspace-file-preview 8, workspace-file-manager 129, tools 179). CI runs in a clean environment, so these pass there.

Note: jsdom cannot lay out overflow, so the test guards the break utility classes — consistent with existing className assertions in this suite (e.g. `AgentTurnSummaryRow.spec.tsx`).

## Checklist

- [x] I kept the change focused on one concern.
- [x] I updated documentation when behavior, setup, or contributor workflow changed. *(n/a — pure rendering fix; no public contract, config, or contributor-workflow change.)*
- [x] I updated all README/CONTRIBUTING language variants when changing their English source. *(n/a — no doc change.)*
- [x] I ran the lowest meaningful local checks for the changed surface.
- [x] My commits are signed off with DCO when required: `git commit -s`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Wraps long file-path links in the Agent GUI so they break across lines and stay readable. Adds `[overflow-wrap:anywhere]` and `[word-break:break-word]` to `PathLink` in `AgentMessageMarkdown`, plus a regression test (fixes #421).

<sup>Written for commit c3c79dd6fb7fa6730f077e4d4f5aab9a5755d891. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tutti-os/tutti/pull/1005?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

