### PR TITLE
fix(app-release): make workspace app archives reproducible

### DIFF
--- a/docs/conventions/workspace-app-catalog.md
+++ b/docs/conventions/workspace-app-catalog.md
@@ -218,9 +218,11 @@ catalog workflows provide the same repair path when a caller workflow does not
 expose catalog-only dispatch.
 
 Retrying a release version is allowed only when the existing immutable
-`release.json` matches the newly generated release metadata. In that case the
-workflow repairs mutable state such as `latest.json`, catalog metadata, and
-CloudFront invalidation without re-uploading immutable artifacts.
+`release.json` matches the newly generated release metadata. Release archives
+normalize entry order, timestamps, and optional zip metadata so rebuilding the
+same package produces the same artifact SHA-256. In that case the workflow
+repairs mutable state such as `latest.json`, catalog metadata, and CloudFront
+invalidation without re-uploading immutable artifacts.
 
 Each app uploads under:
 

--- a/packages/workspace/app-release-tools/README.md
+++ b/packages/workspace/app-release-tools/README.md
@@ -13,11 +13,14 @@ verify-tutti-app-release-artifacts --release-file ./apps/vibe-design/latest.json
 verify-tutti-app-release-artifacts --catalog-file ./catalog.json --versions-file ./apps/vibe-design/versions.json
 ```
 
-The release command validates a complete Tutti app package, creates a zip,
-writes immutable `release.json`, and writes mutable `latest.json`. When the
-manifest declares `localizationInfo`, the release metadata includes the
-referenced manifest locale files so App Center can localize uninstalled remote
-apps without downloading the package.
+The release command validates a complete Tutti app package, creates a
+reproducible zip with stable entry ordering and timestamps, writes immutable
+`release.json`, and writes mutable `latest.json`. Rebuilding the same package
+version produces the same artifact SHA-256, so an interrupted release can
+safely verify and reuse its immutable upload. When the manifest declares
+`localizationInfo`, the release metadata includes the referenced manifest
+locale files so App Center can localize uninstalled remote apps without
+downloading the package.
 
 The versions command maintains one mutable `tutti.app.versions.v1` index per
 app. Every catalog-eligible release has an explicit minimum Tutti version and

--- a/packages/workspace/app-release-tools/bin/build-tutti-app-release.mjs
+++ b/packages/workspace/app-release-tools/bin/build-tutti-app-release.mjs
@@ -2,7 +2,18 @@
 import { spawnSync } from "node:child_process";
 import { createHash } from "node:crypto";
 import { pathToFileURL } from "node:url";
-import { cp, mkdir, readFile, stat, writeFile } from "node:fs/promises";
+import {
+  cp,
+  mkdir,
+  mkdtemp,
+  readFile,
+  readdir,
+  rm,
+  stat,
+  utimes,
+  writeFile
+} from "node:fs/promises";
+import { tmpdir } from "node:os";
 import path from "node:path";
 
 import { requireSemver } from "./tutti-app-versioning.mjs";
@@ -75,7 +86,7 @@ export async function buildTuttiAppRelease(options) {
 
   const artifactName = `${appId}-${version}.zip`;
   const artifactPath = path.join(releaseDir, artifactName);
-  createZip(packageDir, artifactPath);
+  await createZip(packageDir, artifactPath);
   const artifact = await fileDigestAndSize(artifactPath);
 
   const iconName = path.basename(sourceIconPath);
@@ -623,17 +634,71 @@ function validateReleaseLocalizations(localizations, sourceLabel) {
   }
 }
 
-function createZip(packageDir, artifactPath) {
-  const result = spawnSync("zip", ["-qr", artifactPath, "."], {
-    cwd: packageDir,
-    encoding: "utf8"
+async function createZip(packageDir, artifactPath) {
+  const stagingDir = await mkdtemp(
+    path.join(tmpdir(), "tutti-app-release-archive-")
+  );
+  const archiveRoot = path.join(stagingDir, "package");
+  try {
+    await cp(packageDir, archiveRoot, {
+      recursive: true,
+      dereference: true
+    });
+    const entries = await normalizeArchiveEntries(archiveRoot);
+    await rm(artifactPath, { force: true });
+    const result = spawnSync("zip", ["-X", "-q", artifactPath, "-@"], {
+      cwd: archiveRoot,
+      encoding: "utf8",
+      env: {
+        ...process.env,
+        LC_ALL: "C",
+        TZ: "UTC"
+      },
+      input: `${entries.join("\n")}\n`
+    });
+    if (result.error) {
+      throw result.error;
+    }
+    if (result.status !== 0) {
+      throw new Error(
+        result.stderr || `zip exited with status ${result.status}`
+      );
+    }
+  } finally {
+    await rm(stagingDir, { recursive: true, force: true });
+  }
+}
+
+async function normalizeArchiveEntries(rootDir, relativeDir = "") {
+  const fixedTimestamp = new Date("1980-01-01T00:00:00.000Z");
+  const directoryEntries = await readdir(path.join(rootDir, relativeDir), {
+    withFileTypes: true
   });
-  if (result.error) {
-    throw result.error;
+  directoryEntries.sort((left, right) =>
+    left.name < right.name ? -1 : left.name > right.name ? 1 : 0
+  );
+
+  const result = [];
+  for (const entry of directoryEntries) {
+    if (entry.name.includes("\n") || entry.name.includes("\r")) {
+      throw new Error(
+        `package path contains an unsupported newline: ${path.join(relativeDir, entry.name)}`
+      );
+    }
+    const relativePath = path.join(relativeDir, entry.name);
+    const absolutePath = path.join(rootDir, relativePath);
+    await utimes(absolutePath, fixedTimestamp, fixedTimestamp);
+    if (entry.isDirectory()) {
+      result.push(`${relativePath}/`);
+      result.push(...(await normalizeArchiveEntries(rootDir, relativePath)));
+      continue;
+    }
+    if (!entry.isFile()) {
+      throw new Error(`unsupported package entry type: ${relativePath}`);
+    }
+    result.push(relativePath);
   }
-  if (result.status !== 0) {
-    throw new Error(result.stderr || `zip exited with status ${result.status}`);
-  }
+  return result;
 }
 
 async function fileDigestAndSize(filePath) {

--- a/tools/scripts/build-tutti-app-release.test.mjs
+++ b/tools/scripts/build-tutti-app-release.test.mjs
@@ -1,6 +1,13 @@
 import assert from "node:assert/strict";
 import { createHash } from "node:crypto";
-import { mkdtemp, readFile, writeFile, chmod, mkdir } from "node:fs/promises";
+import {
+  chmod,
+  mkdir,
+  mkdtemp,
+  readFile,
+  utimes,
+  writeFile
+} from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import test from "node:test";
@@ -117,6 +124,45 @@ test("buildTuttiAppRelease includes package manifest localizations", async () =>
       tags: ["本地化", "工作区"]
     }
   ]);
+});
+
+test("buildTuttiAppRelease creates reproducible archives", async () => {
+  const packageDir = await createPackageForTest("reproducible-app");
+  const firstOutputDir = await mkdtemp(
+    path.join(tmpdir(), "tutti-release-first-")
+  );
+  const secondOutputDir = await mkdtemp(
+    path.join(tmpdir(), "tutti-release-second-")
+  );
+  const options = {
+    appId: "reproducible-app",
+    packageDir,
+    baseUrl: "https://cdn.example.test/tutti-apps",
+    version: "1.2.3",
+    gitSha: "abc123",
+    publishedAt: "2026-06-04T00:00:00Z"
+  };
+
+  const first = await buildTuttiAppRelease({
+    ...options,
+    outputDir: firstOutputDir
+  });
+  const changedTimestamp = new Date("2030-01-02T03:04:06.000Z");
+  await utimes(
+    path.join(packageDir, "AGENTS.md"),
+    changedTimestamp,
+    changedTimestamp
+  );
+  const second = await buildTuttiAppRelease({
+    ...options,
+    outputDir: secondOutputDir
+  });
+
+  assert.equal(first.release.artifactSha256, second.release.artifactSha256);
+  assert.deepEqual(
+    await readFile(first.artifactPath),
+    await readFile(second.artifactPath)
+  );
 });
 
 test("buildTuttiAppCatalog merges release files into remote catalog", async () => {


### PR DESCRIPTION
## Summary\n\n- build workspace app archives from an isolated staging directory\n- normalize archive entry ordering, timestamps, locale, timezone, and zip metadata\n- verify repeated builds are byte-for-byte identical\n- document the immutable release retry contract\n\n## Validation\n\n- pnpm check:changed\n- pnpm check:full (pre-push)\n- repeated real Omni Catcher 0.2.82 builds produced identical SHA-256: 81572d4e5dc82f409e793433321f0f6a5ecaca9dc0f98ad85af4b61368c4d812\n\nSigned-off-by: HugoZhou <hugozhou0638@gmail.com>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make workspace app release archives reproducible. Rebuilding the same package now yields identical zip bytes and SHA-256, enabling safe release retries without re-uploading immutable artifacts.

- **Bug Fixes**
  - Build zips from an isolated staging directory and dereference symlinks.
  - Normalize archive contents: sorted entries, fixed timestamps, `LC_ALL=C`, `TZ=UTC`, and `zip -X`.
  - Generate an explicit file list (including directories) and reject unsupported paths to keep input deterministic.
  - Add a test that builds twice and asserts identical bytes and SHA-256.
  - Update docs to document reproducible archives and the immutable release retry contract.

<sup>Written for commit 507990be3dce9994ed0ea1f7b6a1736589199f8e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tutti-os/tutti/pull/1006?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

