### PR TITLE
fix(agent): canonicalize agent target identity and composer options cache key

### DIFF
--- a/apps/desktop/src/renderer/src/features/workspace-agent/services/createDesktopAgentHostApi.test.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-agent/services/createDesktopAgentHostApi.test.ts
@@ -49,6 +49,7 @@ test("desktop agent host api forwards model catalog invalidation as a host event
 
   // The stream subscription starts with the first workspace controller.
   await activityService.getComposerOptions({
+    agentTargetId: "local:codex",
     provider: "codex",
     workspaceId
   });

--- a/apps/desktop/src/renderer/src/features/workspace-agent/services/desktopAgentActivityAdapter.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-agent/services/desktopAgentActivityAdapter.ts
@@ -155,11 +155,13 @@ export function createDesktopAgentActivityAdapter({
     },
     async loadComposerOptions(input) {
       const cwd = input.cwd?.trim();
+      const agentTargetId = input.agentTargetId?.trim();
       const result = await withAbortableRequestTimeout(
         (signal) =>
           tuttidClient.getAgentProviderComposerOptions(
             workspaceAgentProvider(input.provider),
             {
+              ...(agentTargetId ? { agentTargetId } : {}),
               ...(cwd ? { cwd } : {}),
               workspaceId: input.workspaceId,
               settings: input.settings ?? {}

--- a/apps/desktop/src/renderer/src/features/workspace-agent/services/internal/workspaceAgentActivityService.test.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-agent/services/internal/workspaceAgentActivityService.test.ts
@@ -179,18 +179,14 @@ test("WorkspaceAgentActivityService composer options cache is agent target keyed
 
   assert.equal(composerOptionCalls.length, 2);
   assert.equal(
-    service.getSnapshot("ws-1").composerOptionsByAgentTargetId?.["local:codex"]
+    service.getSnapshot("ws-1").composerOptionsByTargetKey?.["local:codex"]
       ?.models[0]?.value,
     "model-1"
   );
   assert.equal(
-    service.getSnapshot("ws-1").composerOptionsByAgentTargetId?.["shared-codex"]
+    service.getSnapshot("ws-1").composerOptionsByTargetKey?.["shared-codex"]
       ?.models[0]?.value,
     "model-2"
-  );
-  assert.equal(
-    service.getSnapshot("ws-1").composerOptionsByProvider?.codex,
-    undefined
   );
   assert.equal(
     (first as { models?: Array<{ value: string }> }).models?.[0]?.value,
@@ -238,8 +234,16 @@ test("WorkspaceAgentActivityService model catalog invalidation drops composer ca
     }
   });
 
-  await service.getComposerOptions({ provider: "codex", workspaceId: "ws-1" });
-  await service.getComposerOptions({ provider: "codex", workspaceId: "ws-1" });
+  await service.getComposerOptions({
+    agentTargetId: "local:codex",
+    provider: "codex",
+    workspaceId: "ws-1"
+  });
+  await service.getComposerOptions({
+    agentTargetId: "local:codex",
+    provider: "codex",
+    workspaceId: "ws-1"
+  });
   assert.equal(composerOptionCalls, 1);
 
   const invalidationHandler = topicHandlers.get(
@@ -260,7 +264,11 @@ test("WorkspaceAgentActivityService model catalog invalidation drops composer ca
   assert.deepEqual(received, [
     { providers: ["codex"], occurredAtUnixMs: 1000 }
   ]);
-  await service.getComposerOptions({ provider: "codex", workspaceId: "ws-1" });
+  await service.getComposerOptions({
+    agentTargetId: "local:codex",
+    provider: "codex",
+    workspaceId: "ws-1"
+  });
   assert.equal(composerOptionCalls, 2);
 });
 

--- a/apps/desktop/src/renderer/src/features/workspace-agent/services/internal/workspaceAgentActivityService.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-agent/services/internal/workspaceAgentActivityService.ts
@@ -888,10 +888,14 @@ export class WorkspaceAgentActivityService implements IWorkspaceAgentActivitySer
     workspaceId: string;
   }): Promise<unknown> {
     const provider = resolveDesktopAgentGUIProvider(input.provider);
+    // The resolved agent target id is the opaque composer-options cache key
+    // inside activity-core (single key space); it is passed through verbatim
+    // as targetKey. Callers must resolve identity first — activity-core
+    // rejects an empty key (no provider-keyed fallback bucket).
     return this.controllerEntry(
       input.workspaceId
     ).controller.loadComposerOptions({
-      agentTargetId: input.agentTargetId,
+      targetKey: (input.agentTargetId ?? "").trim(),
       provider,
       cwd: input.cwd,
       force: input.force,

--- a/docs/specs/2026-07-10-agent-target-identity-canonicalization.md
+++ b/docs/specs/2026-07-10-agent-target-identity-canonicalization.md
@@ -1,0 +1,84 @@
+# Agent Target 身份规范化与 Composer 缓存键修复
+
+- 日期：2026-07-10
+- 状态：待执行（派发给 ops 分工作流落地）
+- 背景 bug：shared 会话携带 owner 域 agentTargetId（形如 `02fc7056...`）泄漏进本地链路，被 agent-gui 当作 composer options 缓存键，与 rail 选中 target 的 id 错位，导致缓存存取错位、各消费方"猜字符串"。
+
+## 终态原则（不变量）
+
+1. **单一铸造权威 + 注册表统一判定 + 域隔离（2026-07-10 终版拍板）**：agent target 是 workspace 作用域资源，一切 agent（本地默认 provider 与外部/自定义/shared 接入）统一注册进本地 runtime 目录（target store，`listAgentTargets()` 的数据源）。session 投影出的 `agentTargetId` 必须存在于注册表，否则置空留痕。**禁止从 session 携带的数据（runtimeContext/providerTargetRef 等）推断身份**——判定的唯一依据是注册表。
+   - **跨域翻译发生在 host 投影层，不在本地 daemon**：owner 域 target id 是 owner 设备命名空间的私有物，不进入 caller 侧存储。host（tsh/tutti-os）的 SharedAgent binding 记录同时持有 `sharedAgentId` 与 owner `agentTargetId`（1:1，room==workspace 作用域内），owner 会话投影进 caller room 时由 host 在过境点把 `agentTargetId` 改写为 caller 本地规范 id。daemon 摄入侧只做存在性判定；`ResolveAlias` 仅作纵深防御兜底（恒 miss，不加别名列）。
+   - shared agent 的本地规范 id **只由 sharedAgentId 派生**：`shared-agent:{sharedAgentId}`（前缀为命名空间卫生，防与 `local:*`/uuid 撞名，与 tsh 既有 `SHARED_AGENT_PROVIDER_TARGET_PREFIX` 约定一致）。owner 域 id 不能做本地主键（owner 分享其 `local:codex` 会与 caller 本机同名 target 撞名）。
+   - 边界情况：owner 取消分享后重新分享会铸出新 sharedAgentId，旧会话按 fail-fast 报"agent 不存在"——分享关系确已断过，属诚实行为。
+2. **agentTargetId 驱动**：agent-gui 一切 composer 身份（options 缓存、overrides、draft key）取自"已在目录中解析成功的 target"的 id。provider 是从 target 派生的元数据，不做身份。
+3. **fail-fast，无兜底**：session 的 agentTargetId 在目录中查不到（且目录已加载完成）→ 会话级错误态"该 agent 不存在或已被移除"，composer 禁用、消息只读。**不回落 provider 维度**（未来分身能力下同 provider 多 target，provider 兜底会合并不同分身的数据，是错误行为）。
+4. **缓存键不透明**：activity-core 的 composer options 键是不透明字符串 `targetKey`，存取 round-trip verbatim，不解析、不改写。
+5. **providerTargetRef 降级为派生物**：不再作为请求字段传递（推翻原方案 step 1 的"加性 ref 字段"）；需要结构化信息时从目录记录反查。
+
+## 分工作流
+
+### WS0（tuttid/daemon）：引用完整性 —— 前置条件
+
+目标：任何持久化/投影的 session，其 `agentTargetId` ∈ 本地 target 目录，或为空。
+
+1. **shared agent 登记为本地 target（tutti-os 侧依赖）**
+   - shared agent 同步到本地时，在 target store 注册（或幂等 upsert）一条本地 target，主键 `shared-agent:{sharedAgentId}`。**不加别名列**——跨域 id 翻译由 host 投影层完成（见终态原则 1），caller 侧存储不认识 owner 域 id。
+   - 【2026-07-10 执行后勘误】WS0 调查确认本仓库**不存在** shared agent 注册路径（`agent_targets` 生产写入方仅系统种子），注册属 tutti-os 侧依赖。
+2. **session 摄入边界判定（存在性校验，非推断）**
+   - 泄漏点：`services/tuttid/service/agent/activity_projection.go:127` —— `AgentTargetID: firstNonEmptyString(input.State.AgentTargetID, input.Source.AgentTargetID)` 未经校验落库。
+   - 改法：摄入时 id 在 target store 中命中 → 原样通过；未命中 → 先过 `ResolveAlias` 纵深防御兜底（正常情况下恒 miss——host 已在投影层完成翻译；命中说明上游漏翻，改写并留痕）→ 仍未命中 → 置空 + 原始值留痕（runtimeContext，仅诊断）。
+   - **禁止**从 session runtimeContext/providerTargetRef 推断身份——判定唯一依据是注册表。
+   - 同类合并路径一并检查：`packages/agent/daemon/activity/runtime_projection.go`、`packages/agent/daemon/activity/client.go` 的 `firstNonEmptyString(...AgentTargetID...)` 合并逻辑（upstream 值须同样过判定）。
+3. **存量数据**
+   - 读时翻译：已落库 session 的 agentTargetId 经同一判定投影；无人认领置空留痕。（host 翻译上线后新数据天然规范。）
+4. **不变量测试**
+   - 新增：投影输出的每个 session，agentTargetId 为空或存在于 target store；喂入注册表别名命中的 id 时改写为主键 id；喂入无人认领的 id 时置空且留痕。
+
+### WS1（agent-gui + desktop renderer）：选中 target 驱动 + fail-fast
+
+目标：composer 身份只来自目录中解析成功的 target；解析失败诚实报错。
+
+1. **解析函数统一**
+   - session/nodeData 携带的 `agentTargetId` 只作为外键，经 `desktopAgentsService.getAgentTarget()`（目录）解析；命中 → 用目录记录驱动（id、provider、label 等全部取目录值）。
+   - 改造点：`packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUINodeController.ts` 的 `composerTargetDataFromNodeData`（:414）与 `composerTargetDataFromProviderTarget`（:337）；砍掉 `agentTargetId ?? providerTargetId` 等猜谜链（如 `packages/agent/gui/workbench/contribution.ts:455-492` 把 providerTargetId 写进 agentTargetId 的兜底）。
+2. **legacy 无 id 会话也走目录解析（2026-07-10 补充拍板）**：nodeData/session 完全没有 agentTargetId 外键的旧会话，不保留"按 provider 驱动"的旁路——解析到目录中该 provider 的本地 target（`local:${provider}`，系统种子恒存在），从而获得规范身份；目录已加载且无对应 local target 则同样 fail-fast。禁止在任何层出现 `agentTargetId ?? provider` 形式的键派生。
+3. **fail-fast 三态**
+   - 目录未加载完成 → loading（不判错，避免启动闪错）；
+   - 目录已加载且查不到 → 会话级错误态：composer 禁用 + 文案"该 agent 不存在或已被移除"，历史消息只读；错误限定在该会话，不打挂整个节点；
+   - 查到 → 正常。
+   - 需要 agentsService 暴露"已加载"状态（目前 `DesktopAgentsService` snapshot 初始为空数组，与"加载完但为空"不可区分——加 `loaded` 标志或以 `capturedAtUnixMs !== null` 判定）。
+4. **overrides / draft key 收敛**
+   - `composerOverridesByAgentTargetId`、`nodeDefaultDraftKey`（`agentGuiController.composerHelpers.ts:454-462、:597-613`）的键来源自动统一到解析后的目录 id；不做单独迁移，owner 域旧键孤儿化（可接受）。
+5. **测试**
+   - 解析命中/未命中/加载中三态各一组；shared 会话（目录 id `shared-agent:x`）与 local 会话行为一致；已删除 agent 的会话呈只读错误态；legacy 无 id 会话解析到 `local:${provider}` 后行为与显式 id 一致。
+
+### WS2（activity-core + desktop adapter + tuttid API）：不透明键 + 单一键空间
+
+目标：缓存键契约显式化，键随请求到达 daemon，provider 变派生。
+
+1. **activity-core 接口**
+   - `loadComposerOptions({ targetKey, ... })`：`targetKey` 必填、不透明，类型注释写明 "round-trip verbatim; do not parse or rewrite"。
+   - 单一键空间：snapshot 改为 `composerOptionsByTargetKey`；删除 `composerOptionsByProvider`、`provider:${provider}` 键、以及 `packages/agent/activity-core/src/controller.ts:263-303` 的双键空间失效逻辑（fail-fast 后每次 load 必有已解析 target，provider 键空间无存在必要）。
+   - `invalidateComposerOptions` 仍按缓存值内的 `options.provider` 过滤，不解析键。
+2. **API 加性字段**
+   - `services/tuttid/api/openapi/tuttid.v1.yaml` 的 `GetAgentProviderComposerOptionsRequest`（:6222）增加可选 `agentTargetId`；重新生成 server/client 代码（`types.gen.go`、`tuttid-ts`）。
+   - handler 将其透传到 `ComposerOptionsInput.AgentTargetID` —— 服务层已支持按 target 解析 provider 并回显 `runtimeContext["agentTargetId"]`（见 `service_test.go:2458` `TestServiceGetComposerOptionsResolvesProviderFromAgentTargetID`、`composer_options.go:162`），不需要新逻辑。
+3. **desktop adapter**
+   - `desktopAgentActivityAdapter.ts:156-179` 的 `loadComposerOptions` 带上 `agentTargetId: targetKey`（目前该字段在请求前被丢弃）。
+4. **测试**
+   - 键 round-trip：存取同键、不同 targetKey 不串桶；同 provider 两个 target（模拟分身）缓存隔离；invalidate 按 provider 过滤仍生效。
+
+## 顺序与发布
+
+- **WS0 → WS1 →（或同批）→ WS2。**
+- 硬约束：WS1 的 fail-fast 不得先于 WS0 的翻译上线——否则存量 shared 会话（携 owner 域 id）会假报"agent 不存在"（该 agent 在本地目录明明存在，只是 id 未翻译）。
+- WS2 依赖 WS1 的"每次 load 必有 targetKey"，可紧随或同批。
+- 迁移成本：composer options 缓存可重取，无迁移；overrides 旧键孤儿化，接受。
+
+## 验收（端到端）
+
+1. rail 选中 shared agent → 加载 composer options → 切到该 agent 活跃会话 → 缓存键前后一致，无重复请求、无错位读取。
+2. 同 provider 两个 target 的 options/overrides 互不污染。
+3. 删除一个 agent 后打开其历史会话：只读 + "该 agent 不存在或已被移除"，节点其余会话正常。
+4. 全链路 grep 无"从 session 取 agentTargetId 直接当键/直接驱动 UI"的残留路径；无 `agentTargetId ?? providerTargetId` 兜底链残留。
+5. daemon 不变量测试：任何 session 投影的 agentTargetId ∈ 本地目录或为空。

--- a/packages/agent/activity-core/README.md
+++ b/packages/agent/activity-core/README.md
@@ -100,6 +100,21 @@ cannot mutate controller state by accident.
 When loaded or upserted session data is unchanged, the controller preserves the
 current snapshot reference and does not notify subscribers.
 
+## Composer Options Cache
+
+`loadComposerOptions({ targetKey, provider, ... })` caches results in a single
+key space, `composerOptionsByTargetKey`. `targetKey` is an **opaque** cache key:
+the controller round-trips it verbatim to the adapter (as `agentTargetId`) and
+uses it as the snapshot key — it never parses, derives meaning from, or rewrites
+it. Callers pass the already-resolved directory target id; two distinct targets
+that share a `provider` therefore keep isolated caches (no provider-dimension
+fallback).
+
+`invalidateComposerOptions({ providers })` drops freshness markers so the next
+non-forced load refetches, while the last known options stay renderable. It
+filters by the `provider` stored inside each cached value, never by inspecting
+the opaque `targetKey`.
+
 ## Submit Availability
 
 Hosts should return `submitAvailability` as the authoritative wire state when a

--- a/packages/agent/activity-core/src/controller.test.ts
+++ b/packages/agent/activity-core/src/controller.test.ts
@@ -1387,12 +1387,15 @@ test("controller maps session update events into complete session snapshots", ()
   assert.equal(session?.lastEventUnixMs, 2000);
 });
 
-test("controller caches composer options by provider and clones snapshots", async () => {
+test("controller round-trips the opaque targetKey verbatim and clones snapshots", async () => {
   let loadCount = 0;
+  const seenTargetKeys: Array<string | null | undefined> = [];
+  const targetKey = "shared-agent:abc/def?weird=1";
   const controller = createAgentActivityController({
     adapter: fakeAdapter({
       loadComposerOptions: async (input) => {
         loadCount += 1;
+        seenTargetKeys.push(input.agentTargetId);
         return createComposerOptions({
           provider: input.provider,
           models: [{ value: "gpt-5.4", label: "GPT-5.4" }],
@@ -1408,27 +1411,48 @@ test("controller caches composer options by provider and clones snapshots", asyn
     workspaceId: "workspace-1"
   });
 
-  const first = await controller.loadComposerOptions({ provider: "codex" });
+  const first = await controller.loadComposerOptions({
+    provider: "codex",
+    targetKey
+  });
   first.models[0]!.label = "mutated";
   first.permissionConfig!.defaultValue = "mutated";
   first.permissionConfig!.modes[0]!.label = "mutated";
   (first.runtimeContext!.promptCapabilities as Record<string, unknown>).image =
     false;
-  const second = await controller.loadComposerOptions({ provider: "codex" });
+  const second = await controller.loadComposerOptions({
+    provider: "codex",
+    targetKey
+  });
 
   assert.equal(loadCount, 1);
+  // The key is round-tripped verbatim to the adapter and used as the snapshot
+  // key without any parsing or prefixing.
+  assert.deepEqual(seenTargetKeys, [targetKey]);
   assert.equal(second.models[0]?.label, "GPT-5.4");
   assert.equal(second.permissionConfig?.defaultValue, "auto");
   assert.equal(second.permissionConfig?.modes[0]?.label, "Auto");
   assert.deepEqual(second.runtimeContext?.promptCapabilities, { image: true });
   assert.equal(
-    controller.getSnapshot().composerOptionsByProvider?.codex?.models[0]?.label,
+    controller.getSnapshot().composerOptionsByTargetKey?.[targetKey]?.models[0]
+      ?.label,
     "GPT-5.4"
   );
   assert.equal(
-    controller.getSnapshot().composerOptionsByProvider?.codex?.permissionConfig
-      ?.defaultValue,
+    controller.getSnapshot().composerOptionsByTargetKey?.[targetKey]
+      ?.permissionConfig?.defaultValue,
     "auto"
+  );
+});
+
+test("controller loadComposerOptions requires a non-empty targetKey", async () => {
+  const controller = createAgentActivityController({
+    adapter: fakeAdapter(),
+    workspaceId: "workspace-1"
+  });
+  await assert.rejects(
+    controller.loadComposerOptions({ provider: "codex", targetKey: "  " }),
+    /targetKey is required/
   );
 });
 
@@ -1447,22 +1471,32 @@ test("controller invalidateComposerOptions makes the next non-forced load refetc
     workspaceId: "workspace-1"
   });
 
-  await controller.loadComposerOptions({ provider: "codex" });
-  await controller.loadComposerOptions({ provider: "codex" });
+  await controller.loadComposerOptions({
+    provider: "codex",
+    targetKey: "local:codex"
+  });
+  await controller.loadComposerOptions({
+    provider: "codex",
+    targetKey: "local:codex"
+  });
   assert.equal(loadCount, 1);
 
   controller.invalidateComposerOptions({ providers: ["codex"] });
   // The stale snapshot stays available for rendering until the refetch lands.
   assert.equal(
-    controller.getSnapshot().composerOptionsByProvider?.codex?.models[0]?.value,
+    controller.getSnapshot().composerOptionsByTargetKey?.["local:codex"]
+      ?.models[0]?.value,
     "model-1"
   );
-  const reloaded = await controller.loadComposerOptions({ provider: "codex" });
+  const reloaded = await controller.loadComposerOptions({
+    provider: "codex",
+    targetKey: "local:codex"
+  });
   assert.equal(loadCount, 2);
   assert.equal(reloaded.models[0]?.value, "model-2");
 });
 
-test("controller invalidateComposerOptions only touches matching providers and their targets", async () => {
+test("controller invalidateComposerOptions filters by cached provider, not by key", async () => {
   let loadCount = 0;
   const controller = createAgentActivityController({
     adapter: fakeAdapter({
@@ -1477,26 +1511,41 @@ test("controller invalidateComposerOptions only touches matching providers and t
     workspaceId: "workspace-1"
   });
 
-  await controller.loadComposerOptions({ provider: "codex" });
-  await controller.loadComposerOptions({ provider: "claude-code" });
+  // Two codex targets and one claude-code target — all in the single key space.
   await controller.loadComposerOptions({
     provider: "codex",
-    agentTargetId: "codex-target"
+    targetKey: "local:codex"
+  });
+  await controller.loadComposerOptions({
+    provider: "claude-code",
+    targetKey: "local:claude-code"
+  });
+  await controller.loadComposerOptions({
+    provider: "codex",
+    targetKey: "shared-agent:codex-1"
   });
   assert.equal(loadCount, 3);
 
   controller.invalidateComposerOptions({ providers: ["codex"] });
-  await controller.loadComposerOptions({ provider: "claude-code" });
+  // claude-code target is untouched → cache hit.
+  await controller.loadComposerOptions({
+    provider: "claude-code",
+    targetKey: "local:claude-code"
+  });
   assert.equal(loadCount, 3);
-  await controller.loadComposerOptions({ provider: "codex" });
+  // Both codex targets refetch.
   await controller.loadComposerOptions({
     provider: "codex",
-    agentTargetId: "codex-target"
+    targetKey: "local:codex"
+  });
+  await controller.loadComposerOptions({
+    provider: "codex",
+    targetKey: "shared-agent:codex-1"
   });
   assert.equal(loadCount, 5);
 });
 
-test("controller caches composer options by agent target without mutating provider cache", async () => {
+test("controller isolates caches for two targetKeys sharing a provider", async () => {
   const adapterCalls: Array<{
     agentTargetId: string | null | undefined;
     provider: string;
@@ -1510,37 +1559,30 @@ test("controller caches composer options by agent target without mutating provid
         });
         return createComposerOptions({
           provider: input.provider,
-          models: [
-            {
-              value: input.agentTargetId
-                ? `${input.agentTargetId}-model`
-                : `${input.provider}-model`,
-              label: "Model"
-            }
-          ]
+          models: [{ value: `${input.agentTargetId}-model`, label: "Model" }]
         });
       }
     }),
     workspaceId: "workspace-1"
   });
 
-  await controller.loadComposerOptions({ provider: "codex" });
+  // Same provider, two distinct targets (impersonation preview): the caches
+  // must not merge into a single provider bucket.
   const targetA = await controller.loadComposerOptions({
     provider: "codex",
-    agentTargetId: "target-a"
+    targetKey: "target-a"
   });
   const targetB = await controller.loadComposerOptions({
     provider: "codex",
-    agentTargetId: "target-b"
+    targetKey: "target-b"
   });
   const targetAAgain = await controller.loadComposerOptions({
     provider: "codex",
-    agentTargetId: "target-a"
+    targetKey: "target-a"
   });
 
-  assert.equal(adapterCalls.length, 3);
+  assert.equal(adapterCalls.length, 2);
   assert.deepEqual(adapterCalls, [
-    { agentTargetId: null, provider: "codex" },
     { agentTargetId: "target-a", provider: "codex" },
     { agentTargetId: "target-b", provider: "codex" }
   ]);
@@ -1548,17 +1590,13 @@ test("controller caches composer options by agent target without mutating provid
   assert.equal(targetB.models[0]?.value, "target-b-model");
   assert.equal(targetAAgain.models[0]?.value, "target-a-model");
   assert.equal(
-    controller.getSnapshot().composerOptionsByProvider?.codex?.models[0]?.value,
-    "codex-model"
-  );
-  assert.equal(
-    controller.getSnapshot().composerOptionsByAgentTargetId?.["target-a"]
-      ?.models[0]?.value,
+    controller.getSnapshot().composerOptionsByTargetKey?.["target-a"]?.models[0]
+      ?.value,
     "target-a-model"
   );
   assert.equal(
-    controller.getSnapshot().composerOptionsByAgentTargetId?.["target-b"]
-      ?.models[0]?.value,
+    controller.getSnapshot().composerOptionsByTargetKey?.["target-b"]?.models[0]
+      ?.value,
     "target-b-model"
   );
 });
@@ -1582,8 +1620,14 @@ test("controller dedupes in-flight composer option loads and supports force relo
     workspaceId: "workspace-1"
   });
 
-  const firstLoad = controller.loadComposerOptions({ provider: "codex" });
-  const secondLoad = controller.loadComposerOptions({ provider: "codex" });
+  const firstLoad = controller.loadComposerOptions({
+    provider: "codex",
+    targetKey: "local:codex"
+  });
+  const secondLoad = controller.loadComposerOptions({
+    provider: "codex",
+    targetKey: "local:codex"
+  });
   (releaseLoad as (() => void) | null)?.();
   const [first, second] = await Promise.all([firstLoad, secondLoad]);
 
@@ -1593,6 +1637,7 @@ test("controller dedupes in-flight composer option loads and supports force relo
 
   const reload = controller.loadComposerOptions({
     provider: "codex",
+    targetKey: "local:codex",
     force: true
   });
   (releaseLoad as (() => void) | null)?.();
@@ -1600,6 +1645,45 @@ test("controller dedupes in-flight composer option loads and supports force relo
 
   assert.equal(loadCount, 2);
   assert.equal(reloaded.models[0]?.value, "gpt-2");
+});
+
+test("controller in-flight dedup is scoped per targetKey", async () => {
+  let loadCount = 0;
+  const releases: Array<() => void> = [];
+  const controller = createAgentActivityController({
+    adapter: fakeAdapter({
+      loadComposerOptions: async (input) => {
+        loadCount += 1;
+        await new Promise<void>((resolve) => {
+          releases.push(resolve);
+        });
+        return createComposerOptions({
+          provider: input.provider,
+          models: [{ value: `${input.agentTargetId}-model`, label: "Model" }]
+        });
+      }
+    }),
+    workspaceId: "workspace-1"
+  });
+
+  // Concurrent loads on distinct targetKeys must not dedup into one another.
+  const loadA = controller.loadComposerOptions({
+    provider: "codex",
+    targetKey: "target-a"
+  });
+  const loadB = controller.loadComposerOptions({
+    provider: "codex",
+    targetKey: "target-b"
+  });
+  await waitFor(() => {
+    assert.equal(loadCount, 2);
+  });
+  for (const release of releases) {
+    release();
+  }
+  const [a, b] = await Promise.all([loadA, loadB]);
+  assert.equal(a.models[0]?.value, "target-a-model");
+  assert.equal(b.models[0]?.value, "target-b-model");
 });
 
 test("controller force reload bypasses stale in-flight composer option loads", async () => {
@@ -1621,13 +1705,17 @@ test("controller force reload bypasses stale in-flight composer option loads", a
     workspaceId: "workspace-1"
   });
 
-  const staleLoad = controller.loadComposerOptions({ provider: "codex" });
+  const staleLoad = controller.loadComposerOptions({
+    provider: "codex",
+    targetKey: "local:codex"
+  });
   await waitFor(() => {
     assert.equal(resolvers.length, 1);
   });
 
   const forceLoad = controller.loadComposerOptions({
     provider: "codex",
+    targetKey: "local:codex",
     force: true
   });
   await waitFor(() => {
@@ -1653,7 +1741,8 @@ test("controller force reload bypasses stale in-flight composer option loads", a
 
   assert.equal(stale.models[0]?.value, "stale");
   assert.equal(
-    controller.getSnapshot().composerOptionsByProvider?.codex?.models[0]?.value,
+    controller.getSnapshot().composerOptionsByTargetKey?.["local:codex"]
+      ?.models[0]?.value,
     "fresh"
   );
 });
@@ -1675,15 +1764,18 @@ test("loadComposerOptions refetches when cwd changes and caches per cwd", async 
 
   const first = await controller.loadComposerOptions({
     provider: "codex",
+    targetKey: "local:codex",
     cwd: "/repo/a"
   });
   const cachedSame = await controller.loadComposerOptions({
     provider: "codex",
+    targetKey: "local:codex",
     cwd: "/repo/a"
   });
   assert.equal(adapterCalls.length, 1); // same cwd → cache hit
   const afterSwitch = await controller.loadComposerOptions({
     provider: "codex",
+    targetKey: "local:codex",
     cwd: "/repo/b"
   });
   assert.equal(adapterCalls.length, 2); // cwd changed → refetch

--- a/packages/agent/activity-core/src/controller.ts
+++ b/packages/agent/activity-core/src/controller.ts
@@ -9,7 +9,7 @@ import {
 import { loadAllAgentSessionMessages } from "./pagination.ts";
 import type {
   AgentActivityComposerOptions,
-  AgentActivityLoadComposerOptionsInput,
+  AgentActivityComposerSettings,
   AgentActivityMessage,
   AgentActivityMessageOrder,
   AgentActivityMessagePage,
@@ -27,14 +27,25 @@ export interface CreateAgentActivityControllerInput {
   workspaceId: string;
 }
 
+export interface AgentActivityLoadComposerOptionsControllerInput {
+  /**
+   * Opaque cache key. Round-trip verbatim; do not parse, derive meaning from,
+   * or rewrite it. Callers pass the already-resolved directory target id here.
+   */
+  targetKey: string;
+  provider: string;
+  cwd?: string | null;
+  settings?: AgentActivityComposerSettings | null;
+  signal?: AbortSignal;
+  force?: boolean;
+}
+
 export interface AgentActivityController {
   getSnapshot(): AgentActivitySnapshot;
   subscribe(listener: AgentActivitySnapshotListener): () => void;
   load(signal?: AbortSignal): Promise<AgentActivitySnapshot>;
   loadComposerOptions(
-    input: Omit<AgentActivityLoadComposerOptionsInput, "workspaceId"> & {
-      force?: boolean;
-    }
+    input: AgentActivityLoadComposerOptionsControllerInput
   ): Promise<AgentActivityComposerOptions>;
   invalidateComposerOptions(input?: { providers?: readonly string[] }): void;
   listSessionMessages(input: {
@@ -81,14 +92,10 @@ export function createAgentActivityController({
     Promise<AgentActivityComposerOptions>
   >();
   const composerOptionsLoadVersions = new Map<string, number>();
-  const composerOptionsCwdByCacheKey = new Map<string, string>();
+  const composerOptionsCwdByTargetKey = new Map<string, string>();
   const activeComposerOptionsLoadCwds = new Map<string, string>();
   const normalizeComposerCwd = (cwd: string | null | undefined): string =>
     (cwd ?? "").trim();
-  const composerOptionsProviderCacheKey = (provider: string): string =>
-    `provider:${provider}`;
-  const composerOptionsTargetCacheKey = (agentTargetId: string): string =>
-    `target:${agentTargetId}`;
   const autoRetainedStreamReleases = new Map<string, () => void>();
   const retainedStreams = new Map<string, RetainedSessionStream>();
   let snapshot: AgentActivitySnapshot =
@@ -170,39 +177,37 @@ export function createAgentActivityController({
       if (!provider) {
         throw new Error("Agent composer options provider is required.");
       }
-      const agentTargetId =
-        typeof input.agentTargetId === "string" && input.agentTargetId.trim()
-          ? input.agentTargetId.trim()
-          : null;
-      const primaryCacheKey = agentTargetId
-        ? composerOptionsTargetCacheKey(agentTargetId)
-        : composerOptionsProviderCacheKey(provider);
+      // Opaque single-key-space cache key. The caller passes the already
+      // resolved directory target id; it is round-tripped verbatim to the
+      // adapter (as agentTargetId) and used as the snapshot/dedup key.
+      const targetKey =
+        typeof input.targetKey === "string" ? input.targetKey.trim() : "";
+      if (!targetKey) {
+        throw new Error("Agent composer options targetKey is required.");
+      }
       const requestedCwd = normalizeComposerCwd(input.cwd);
       if (!input.force) {
-        const cached = agentTargetId
-          ? snapshot.composerOptionsByAgentTargetId?.[agentTargetId]
-          : snapshot.composerOptionsByProvider?.[provider];
+        const cached = snapshot.composerOptionsByTargetKey?.[targetKey];
         if (
           cached &&
-          composerOptionsCwdByCacheKey.get(primaryCacheKey) === requestedCwd
+          composerOptionsCwdByTargetKey.get(targetKey) === requestedCwd
         ) {
           return cloneAgentActivityComposerOptions(cached);
         }
       }
-      const existingLoad = activeComposerOptionsLoads.get(primaryCacheKey);
+      const existingLoad = activeComposerOptionsLoads.get(targetKey);
       if (
         existingLoad &&
         !input.force &&
-        activeComposerOptionsLoadCwds.get(primaryCacheKey) === requestedCwd
+        activeComposerOptionsLoadCwds.get(targetKey) === requestedCwd
       ) {
         return existingLoad.then(cloneAgentActivityComposerOptions);
       }
-      const loadVersion =
-        (composerOptionsLoadVersions.get(primaryCacheKey) ?? 0) + 1;
-      composerOptionsLoadVersions.set(primaryCacheKey, loadVersion);
+      const loadVersion = (composerOptionsLoadVersions.get(targetKey) ?? 0) + 1;
+      composerOptionsLoadVersions.set(targetKey, loadVersion);
       const load = adapter
         .loadComposerOptions({
-          agentTargetId,
+          agentTargetId: targetKey,
           workspaceId,
           provider,
           cwd: input.cwd,
@@ -215,90 +220,70 @@ export function createAgentActivityController({
             provider,
             loadedAtUnixMs: options.loadedAtUnixMs || Date.now()
           });
-          if (
-            composerOptionsLoadVersions.get(primaryCacheKey) !== loadVersion
-          ) {
+          if (composerOptionsLoadVersions.get(targetKey) !== loadVersion) {
             return cloneAgentActivityComposerOptions(normalizedOptions);
           }
-          composerOptionsCwdByCacheKey.set(primaryCacheKey, requestedCwd);
+          composerOptionsCwdByTargetKey.set(targetKey, requestedCwd);
           updateSnapshot((current) => {
-            const currentOptions = agentTargetId
-              ? current.composerOptionsByAgentTargetId?.[agentTargetId]
-              : current.composerOptionsByProvider?.[provider];
+            const currentOptions =
+              current.composerOptionsByTargetKey?.[targetKey];
             if (
               currentOptions &&
               areComposerOptionsEqual(currentOptions, normalizedOptions)
             ) {
               return current;
             }
-            if (agentTargetId) {
-              return {
-                ...current,
-                composerOptionsByAgentTargetId: {
-                  ...current.composerOptionsByAgentTargetId,
-                  [agentTargetId]: normalizedOptions
-                }
-              };
-            }
             return {
               ...current,
-              composerOptionsByProvider: {
-                ...current.composerOptionsByProvider,
-                [provider]: normalizedOptions
+              composerOptionsByTargetKey: {
+                ...current.composerOptionsByTargetKey,
+                [targetKey]: normalizedOptions
               }
             };
           });
           return cloneAgentActivityComposerOptions(normalizedOptions);
         })
         .finally(() => {
-          if (activeComposerOptionsLoads.get(primaryCacheKey) === load) {
-            activeComposerOptionsLoads.delete(primaryCacheKey);
-            activeComposerOptionsLoadCwds.delete(primaryCacheKey);
+          if (activeComposerOptionsLoads.get(targetKey) === load) {
+            activeComposerOptionsLoads.delete(targetKey);
+            activeComposerOptionsLoadCwds.delete(targetKey);
           }
         });
-      activeComposerOptionsLoads.set(primaryCacheKey, load);
-      activeComposerOptionsLoadCwds.set(primaryCacheKey, requestedCwd);
+      activeComposerOptionsLoads.set(targetKey, load);
+      activeComposerOptionsLoadCwds.set(targetKey, requestedCwd);
       return load.then(cloneAgentActivityComposerOptions);
     },
     invalidateComposerOptions(input) {
       // Drop the freshness markers, not the cached options themselves: the
       // composer keeps rendering the last known list while the next
-      // loadComposerOptions call misses the cache and refetches.
+      // loadComposerOptions call misses the cache and refetches. Filter by the
+      // provider stored inside each cached value; the targetKey itself is opaque
+      // and is never parsed.
       const providers = input?.providers?.length
         ? new Set(input.providers)
         : null;
-      const matchesProvider = (provider: string | null | undefined): boolean =>
-        providers === null || (!!provider && providers.has(provider));
-      const staleCacheKeys = new Set<string>();
-      for (const provider of Object.keys(
-        snapshot.composerOptionsByProvider ?? {}
+      const staleTargetKeys = new Set<string>();
+      for (const [targetKey, options] of Object.entries(
+        snapshot.composerOptionsByTargetKey ?? {}
       )) {
-        if (matchesProvider(provider)) {
-          staleCacheKeys.add(composerOptionsProviderCacheKey(provider));
+        if (
+          providers === null ||
+          (!!options?.provider && providers.has(options.provider))
+        ) {
+          staleTargetKeys.add(targetKey);
         }
       }
-      for (const [agentTargetId, options] of Object.entries(
-        snapshot.composerOptionsByAgentTargetId ?? {}
-      )) {
-        if (matchesProvider(options?.provider)) {
-          staleCacheKeys.add(composerOptionsTargetCacheKey(agentTargetId));
+      if (providers === null) {
+        // A full invalidation also clears in-flight freshness markers that have
+        // no snapshot entry yet; those cannot be provider-matched (no cached
+        // value to read the provider from), so only clear them when dropping
+        // everything.
+        for (const targetKey of composerOptionsCwdByTargetKey.keys()) {
+          staleTargetKeys.add(targetKey);
         }
       }
-      for (const cacheKey of composerOptionsCwdByCacheKey.keys()) {
-        // Provider cache keys may have no snapshot entry yet (load in flight);
-        // match them directly so those are invalidated too.
-        if (providers === null) {
-          staleCacheKeys.add(cacheKey);
-          continue;
-        }
-        for (const provider of providers) {
-          if (cacheKey === composerOptionsProviderCacheKey(provider)) {
-            staleCacheKeys.add(cacheKey);
-          }
-        }
-      }
-      for (const cacheKey of staleCacheKeys) {
-        composerOptionsCwdByCacheKey.delete(cacheKey);
+      for (const targetKey of staleTargetKeys) {
+        composerOptionsCwdByTargetKey.delete(targetKey);
       }
     },
     async listSessionMessages({
@@ -545,8 +530,7 @@ export function createEmptyAgentActivitySnapshot(
     sessions: [],
     presences: [],
     sessionMessagesById: {},
-    composerOptionsByProvider: {},
-    composerOptionsByAgentTargetId: {}
+    composerOptionsByTargetKey: {}
   };
 }
 
@@ -557,18 +541,10 @@ export function cloneAgentActivitySnapshot(
     workspaceId: snapshot.workspaceId,
     sessions: snapshot.sessions.map(cloneAgentActivitySession),
     presences: snapshot.presences.map((presence) => ({ ...presence })),
-    composerOptionsByAgentTargetId: Object.fromEntries(
-      Object.entries(snapshot.composerOptionsByAgentTargetId ?? {}).map(
-        ([agentTargetId, options]) => [
-          agentTargetId,
-          cloneAgentActivityComposerOptions(options)
-        ]
-      )
-    ),
-    composerOptionsByProvider: Object.fromEntries(
-      Object.entries(snapshot.composerOptionsByProvider ?? {}).map(
-        ([provider, options]) => [
-          provider,
+    composerOptionsByTargetKey: Object.fromEntries(
+      Object.entries(snapshot.composerOptionsByTargetKey ?? {}).map(
+        ([targetKey, options]) => [
+          targetKey,
           cloneAgentActivityComposerOptions(options)
         ]
       )

--- a/packages/agent/activity-core/src/index.ts
+++ b/packages/agent/activity-core/src/index.ts
@@ -11,6 +11,7 @@ export {
   createEmptyAgentActivitySnapshot,
   setAgentActivityStoreDiagnosticSink,
   type AgentActivityController,
+  type AgentActivityLoadComposerOptionsControllerInput,
   type AgentActivitySnapshotListener,
   type CreateAgentActivityControllerInput
 } from "./controller.ts";

--- a/packages/agent/activity-core/src/selectors.test.ts
+++ b/packages/agent/activity-core/src/selectors.test.ts
@@ -557,7 +557,7 @@ function snapshotWithSessionMessages(
     sessions,
     presences: [],
     sessionMessagesById,
-    composerOptionsByProvider: {}
+    composerOptionsByTargetKey: {}
   };
 }
 

--- a/packages/agent/activity-core/src/types.ts
+++ b/packages/agent/activity-core/src/types.ts
@@ -195,6 +195,13 @@ export interface AgentActivityComposerOptions {
 }
 
 export interface AgentActivityLoadComposerOptionsInput {
+  /**
+   * Agent target id — the daemon-facing identity of the composer target.
+   * activity-core treats it as an opaque targetKey (see the controller's
+   * loadComposerOptions); this field name reflects that to the daemon it is an
+   * agent target id. Optional at the adapter boundary to mirror the daemon's
+   * optional request field; the controller always supplies a non-empty value.
+   */
   agentTargetId?: string | null;
   workspaceId: string;
   provider: string;
@@ -208,8 +215,12 @@ export interface AgentActivitySnapshot {
   sessions: AgentActivitySession[];
   presences: AgentActivityPresence[];
   sessionMessagesById: Record<string, AgentActivityMessage[]>;
-  composerOptionsByAgentTargetId?: Record<string, AgentActivityComposerOptions>;
-  composerOptionsByProvider?: Record<string, AgentActivityComposerOptions>;
+  /**
+   * Composer options cache, keyed by the opaque targetKey passed to
+   * loadComposerOptions. Single key space: the key is round-tripped verbatim and
+   * never parsed or rewritten.
+   */
+  composerOptionsByTargetKey?: Record<string, AgentActivityComposerOptions>;
 }
 
 export interface AgentActivitySessionEventEnvelope {

--- a/packages/agent/gui/agent-gui/agentGuiNode/AgentGUINode.spec.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/AgentGUINode.spec.tsx
@@ -7436,7 +7436,7 @@ function createEmptyAgentActivitySnapshot(
     presences: [],
     sessions: [],
     sessionMessagesById: {},
-    composerOptionsByProvider: {}
+    composerOptionsByTargetKey: {}
   };
 }
 

--- a/packages/agent/gui/agent-gui/agentGuiNode/AgentGUINodeView.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/AgentGUINodeView.tsx
@@ -5352,7 +5352,7 @@ function projectRuntimeSectionsToConversationSections(input: {
         conversationFilter: input.conversationFilter,
         provider: AGENT_GUI_CONVERSATION_RAIL_PROJECTION_PROVIDER,
         snapshot: {
-          composerOptionsByProvider: {},
+          composerOptionsByTargetKey: {},
           presences: [],
           sessionMessagesById: {},
           sessions: input.pinned.sessions,
@@ -5378,7 +5378,7 @@ function projectRuntimeSectionsToConversationSections(input: {
       conversationFilter: input.conversationFilter,
       provider: AGENT_GUI_CONVERSATION_RAIL_PROJECTION_PROVIDER,
       snapshot: {
-        composerOptionsByProvider: {},
+        composerOptionsByTargetKey: {},
         presences: [],
         sessionMessagesById: {},
         sessions: section.sessions,
@@ -6906,7 +6906,7 @@ function useAgentGUIConversationRail({
               conversationFilter,
               provider: AGENT_GUI_CONVERSATION_RAIL_PROJECTION_PROVIDER,
               snapshot: {
-                composerOptionsByProvider: {},
+                composerOptionsByTargetKey: {},
                 presences: [],
                 sessionMessagesById: {},
                 sessions: page.sessions,
@@ -6991,7 +6991,7 @@ function useAgentGUIConversationRail({
             conversationFilter,
             provider: AGENT_GUI_CONVERSATION_RAIL_PROJECTION_PROVIDER,
             snapshot: {
-              composerOptionsByProvider: {},
+              composerOptionsByTargetKey: {},
               presences: [],
               sessionMessagesById: {},
               sessions: pageSection.sessions,

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUINodeController.spec.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUINodeController.spec.tsx
@@ -1516,6 +1516,7 @@ describe("useAgentGUINodeController", () => {
         providerTargets: [
           {
             targetId: "shared-agent:codex-1",
+            agentTargetId: "shared-agent:codex-1",
             provider: "codex",
             ref: {
               kind: "shared-agent",
@@ -1536,16 +1537,21 @@ describe("useAgentGUINodeController", () => {
       });
     });
 
+    // A directory target now carries an agentTargetId, so filtering by it scopes
+    // the rail to that agent rather than falling back to the unscoped "all".
     await waitFor(() => {
       expect(result.current.viewModel.conversationFilter).toEqual({
-        kind: "all"
+        kind: "agentTarget",
+        agentTargetId: "shared-agent:codex-1"
       });
     });
     expect(result.current.viewModel.selectedProviderTarget.targetId).toBe(
       "shared-agent:codex-1"
     );
     expect(result.current.viewModel.data.provider).toBe("codex");
-    expect(result.current.viewModel.data.providerTargetId).toBe(
+    // Identity comes from the directory record's agentTargetId; the deprecated
+    // providerTargetId/providerTargetRef fields are never written anymore.
+    expect(result.current.viewModel.data.agentTargetId).toBe(
       "shared-agent:codex-1"
     );
     const nextData = onDataChange.mock.calls
@@ -1553,13 +1559,9 @@ describe("useAgentGUINodeController", () => {
       .find((candidate) => candidate.provider === "codex");
     expect(nextData).toMatchObject({
       provider: "codex",
-      agentTargetId: null,
-      providerTargetId: "shared-agent:codex-1",
-      providerTargetRef: {
-        kind: "shared-agent",
-        provider: "codex",
-        sharedAgentId: "codex-1"
-      },
+      agentTargetId: "shared-agent:codex-1",
+      providerTargetId: null,
+      providerTargetRef: null,
       composerOverrides: null
     });
   });
@@ -1699,6 +1701,325 @@ describe("useAgentGUINodeController", () => {
         agentTargetId: "local:codex"
       });
     });
+  });
+
+  describe("active session agent-target fail-fast", () => {
+    const localCodexDirectory = [
+      {
+        targetId: "local:codex",
+        agentTargetId: "local:codex",
+        provider: "codex" as const,
+        ref: { kind: "local-provider", provider: "codex" as const },
+        label: "Codex"
+      }
+    ];
+
+    type FailFastProps = Parameters<typeof useAgentGUINodeController>[0];
+
+    // The node's own `agentTargetId` is the active session's foreign key (it is
+    // written from the launched session and re-targeted on switch). The list
+    // projection doesn't surface a per-summary agentTargetId here, so we drive
+    // the FK through node data — the same value production carries.
+    function failFastProps(input: {
+      agentTargetId: string | null;
+      activeSessionId: string;
+      providerTargets?: FailFastProps["providerTargets"];
+      providerTargetsLoading?: boolean;
+    }): FailFastProps {
+      return {
+        workspaceId: "room-1",
+        currentUserId: "user-1",
+        workspacePath: "/workspace",
+        avoidGroupingEdits: false,
+        data: agentGuiData(input.activeSessionId, "codex", {
+          agentTargetId: input.agentTargetId
+        }),
+        providerTargets: input.providerTargets ?? localCodexDirectory,
+        providerTargetsLoading: input.providerTargetsLoading ?? false,
+        onDataChange: vi.fn()
+      };
+    }
+
+    function renderFailFast(input: {
+      sessions: AgentHostWorkspaceAgentSession[];
+      props: FailFastProps;
+    }) {
+      installAgentHostApi({
+        list: vi.fn(async () => ({ presences: [], sessions: input.sessions })),
+        listSessionTimeline: vi.fn(async () => ({ timelineItems: [] })),
+        subscribeEvents: vi.fn(() => vi.fn())
+      });
+      return renderHook(
+        (props: FailFastProps) => useAgentGUINodeController(props),
+        { initialProps: input.props }
+      );
+    }
+
+    it("errors the session read-only when its agent target is missing from the loaded directory", async () => {
+      const { result } = renderFailFast({
+        sessions: [
+          workspaceAgentSession("ghost-session", {
+            provider: "codex",
+            title: "Ghost session"
+          })
+        ],
+        props: failFastProps({
+          agentTargetId: "deleted-agent",
+          activeSessionId: "ghost-session"
+        })
+      });
+
+      await waitFor(() => {
+        expect(result.current.viewModel.sessionChrome.recovery).toMatchObject({
+          kind: "failed",
+          canRetry: false
+        });
+      });
+      expect(
+        result.current.viewModel.sessionChrome.recovery?.message
+      ).toContain("no longer exists");
+      // History stays visible/read-only even while the composer is fenced off.
+      await waitFor(() => {
+        expect(
+          result.current.viewModel.conversations.map((item) => item.id)
+        ).toContain("ghost-session");
+      });
+      expect(result.current.viewModel.listError).toBeNull();
+    });
+
+    it("stays neutral while the directory is still loading", async () => {
+      const { result } = renderFailFast({
+        sessions: [
+          workspaceAgentSession("ghost-session", {
+            provider: "codex",
+            title: "Ghost session"
+          })
+        ],
+        props: failFastProps({
+          agentTargetId: "deleted-agent",
+          activeSessionId: "ghost-session",
+          providerTargets: [],
+          providerTargetsLoading: true
+        })
+      });
+
+      await act(async () => {
+        await Promise.resolve();
+      });
+
+      expect(
+        result.current.viewModel.sessionChrome.recovery?.message ?? ""
+      ).not.toContain("no longer exists");
+    });
+
+    it("treats a resolvable local agent target as a normal session", async () => {
+      const { result } = renderFailFast({
+        sessions: [
+          workspaceAgentSession("codex-session", {
+            provider: "codex",
+            title: "Codex session"
+          })
+        ],
+        props: failFastProps({
+          agentTargetId: "local:codex",
+          activeSessionId: "codex-session"
+        })
+      });
+
+      await act(async () => {
+        await Promise.resolve();
+      });
+
+      expect(
+        result.current.viewModel.sessionChrome.recovery?.message ?? ""
+      ).not.toContain("no longer exists");
+    });
+
+    it("resolves a legacy provider-only session through the directory's local target", async () => {
+      // No foreign key on the node: the provider's canonical local target id is
+      // derived and looked up in the directory (registry lookup, not fallback).
+      const { result } = renderFailFast({
+        sessions: [
+          workspaceAgentSession("legacy-session", {
+            provider: "codex",
+            title: "Legacy session"
+          })
+        ],
+        props: failFastProps({
+          agentTargetId: null,
+          activeSessionId: "legacy-session"
+        })
+      });
+
+      await act(async () => {
+        await Promise.resolve();
+      });
+
+      expect(
+        result.current.viewModel.sessionChrome.recovery?.message ?? ""
+      ).not.toContain("no longer exists");
+    });
+
+    it("errors a legacy provider-only session when the directory has no local target for its provider", async () => {
+      const sharedOnlyDirectory = [
+        {
+          targetId: "shared-agent:codex-1",
+          agentTargetId: "shared-agent:codex-1",
+          provider: "codex" as const,
+          ref: {
+            kind: "shared-agent",
+            provider: "codex" as const,
+            sharedAgentId: "codex-1"
+          },
+          label: "Alice's Codex"
+        }
+      ];
+      const { result } = renderFailFast({
+        sessions: [
+          workspaceAgentSession("legacy-session", {
+            provider: "codex",
+            title: "Legacy session"
+          })
+        ],
+        props: failFastProps({
+          agentTargetId: null,
+          activeSessionId: "legacy-session",
+          providerTargets: sharedOnlyDirectory
+        })
+      });
+
+      await waitFor(() => {
+        expect(result.current.viewModel.sessionChrome.recovery).toMatchObject({
+          kind: "failed",
+          canRetry: false
+        });
+      });
+      expect(
+        result.current.viewModel.sessionChrome.recovery?.message
+      ).toContain("no longer exists");
+    });
+
+    it("treats a resolvable shared agent target the same as a local one", async () => {
+      const sharedDirectory = [
+        {
+          targetId: "shared-agent:codex-1",
+          agentTargetId: "shared-agent:codex-1",
+          provider: "codex" as const,
+          ref: {
+            kind: "shared-agent",
+            provider: "codex" as const,
+            sharedAgentId: "codex-1"
+          },
+          label: "Alice's Codex"
+        }
+      ];
+      const { result } = renderFailFast({
+        sessions: [
+          workspaceAgentSession("shared-session", {
+            provider: "codex",
+            title: "Shared session"
+          })
+        ],
+        props: failFastProps({
+          agentTargetId: "shared-agent:codex-1",
+          activeSessionId: "shared-session",
+          providerTargets: sharedDirectory
+        })
+      });
+
+      await act(async () => {
+        await Promise.resolve();
+      });
+
+      expect(
+        result.current.viewModel.sessionChrome.recovery?.message ?? ""
+      ).not.toContain("no longer exists");
+    });
+
+    it("scopes the removed-agent error to the active session's target only", async () => {
+      // Session A (removed agent) is active: it errors.
+      const { result, rerender } = renderFailFast({
+        sessions: [
+          workspaceAgentSession("ghost-session", {
+            provider: "codex",
+            title: "Ghost session"
+          }),
+          workspaceAgentSession("ok-session", {
+            provider: "codex",
+            title: "Live session"
+          })
+        ],
+        props: failFastProps({
+          agentTargetId: "deleted-agent",
+          activeSessionId: "ghost-session"
+        })
+      });
+
+      await waitFor(() => {
+        expect(result.current.viewModel.sessionChrome.recovery).toMatchObject({
+          kind: "failed",
+          canRetry: false
+        });
+      });
+
+      // Switching to sibling session B (re-targets node data to a resolvable
+      // agent, as the reconcile effect does in production) clears the error —
+      // the error was scoped to session A's target, not the whole node.
+      rerender(
+        failFastProps({
+          agentTargetId: "local:codex",
+          activeSessionId: "ok-session"
+        })
+      );
+      await waitFor(() => {
+        expect(
+          result.current.viewModel.sessionChrome.recovery?.message ?? ""
+        ).not.toContain("no longer exists");
+      });
+      // The node never collapsed — both conversations stay listed.
+      expect(
+        result.current.viewModel.conversations.map((item) => item.id).sort()
+      ).toEqual(["ghost-session", "ok-session"]);
+    });
+  });
+
+  it("loads composer options for a legacy provider-only session under the canonical local target id", async () => {
+    const getComposerOptions = vi.fn(
+      async (_input: { agentTargetId?: string | null }) => ({
+        provider: "codex",
+        modelConfig: {
+          configurable: true,
+          options: [{ value: "gpt-5", name: "GPT-5" }]
+        }
+      })
+    );
+    installAgentHostApi({
+      list: vi.fn(async () => snapshotWithSession("session-1")),
+      listSessionTimeline: vi.fn(async () => ({ timelineItems: [] })),
+      subscribeEvents: vi.fn(() => vi.fn()),
+      getComposerOptions
+    });
+
+    renderHook(() =>
+      useAgentGUINodeController({
+        workspaceId: "room-1",
+        currentUserId: "user-1",
+        workspacePath: "/workspace",
+        avoidGroupingEdits: false,
+        // Legacy node data: provider only, no agentTargetId foreign key. The
+        // controller resolves the canonical local target from the registry and
+        // loads composer options under that id — never a provider-keyed bucket.
+        data: agentGuiData("session-1"),
+        onDataChange: vi.fn()
+      })
+    );
+
+    await waitFor(() => {
+      expect(getComposerOptions).toHaveBeenCalled();
+    });
+    for (const [input] of getComposerOptions.mock.calls) {
+      expect(input.agentTargetId).toBe("local:codex");
+    }
   });
 
   it("keeps the scoped rail filter aligned when switching the empty composer target before starting a new conversation", async () => {
@@ -1928,17 +2249,20 @@ describe("useAgentGUINodeController", () => {
     });
   });
 
-  it("preserves generic composer overrides when normalizing the same provider target", async () => {
+  it("preserves target-keyed composer overrides when re-selecting the same agent target", async () => {
     installAgentHostApi({
       list: vi.fn(async () => ({ presences: [], sessions: [] })),
       listSessionTimeline: vi.fn(async () => ({ timelineItems: [] })),
       subscribeEvents: vi.fn(() => vi.fn())
     });
     const onDataChange = vi.fn();
+    // Identity is the agentTargetId; overrides are keyed by it. Re-selecting the
+    // same directory target must not disturb that target's stored overrides.
     const initialData = agentGuiData(null, "codex", {
-      providerTargetId: "local:codex",
-      providerTargetRef: { kind: "local-provider", provider: "codex" },
-      composerOverrides: { model: "gpt-5.3-codex" }
+      agentTargetId: "local:codex",
+      composerOverridesByAgentTargetId: {
+        "local:codex": { model: "gpt-5.3-codex" }
+      }
     });
 
     const { result } = renderHook(() =>
@@ -1977,7 +2301,9 @@ describe("useAgentGUINodeController", () => {
       agentTargetId: "local:codex",
       providerTargetId: null,
       providerTargetRef: null,
-      composerOverrides: { model: "gpt-5.3-codex" }
+      composerOverridesByAgentTargetId: {
+        "local:codex": { model: "gpt-5.3-codex" }
+      }
     });
   });
 
@@ -20019,26 +20345,21 @@ function installAgentActivityRuntimeForHostMocks({
           input.provider ?? "codex",
           result
         );
-        const agentTargetId =
+        // Strict single key space: the runtime only caches under the resolved
+        // agent target id (the opaque targetKey); no provider-keyed bucket.
+        const targetKey =
           typeof input.agentTargetId === "string" && input.agentTargetId.trim()
             ? input.agentTargetId.trim()
             : null;
-        setSnapshot(input.workspaceId, (current) => ({
-          ...current,
-          ...(agentTargetId
-            ? {
-                composerOptionsByAgentTargetId: {
-                  ...(current.composerOptionsByAgentTargetId ?? {}),
-                  [agentTargetId]: options
-                }
-              }
-            : {
-                composerOptionsByProvider: {
-                  ...(current.composerOptionsByProvider ?? {}),
-                  [options.provider]: options
-                }
-              })
-        }));
+        if (targetKey) {
+          setSnapshot(input.workspaceId, (current) => ({
+            ...current,
+            composerOptionsByTargetKey: {
+              ...(current.composerOptionsByTargetKey ?? {}),
+              [targetKey]: options
+            }
+          }));
+        }
         return options;
       }
       return {};
@@ -20087,13 +20408,9 @@ function installAgentActivityRuntimeForHostMocks({
       const next = agentActivitySnapshotFromHostSnapshot(snapshot, workspaceId);
       const merged = setSnapshot(workspaceId, (current) => ({
         ...next,
-        composerOptionsByProvider:
-          current.composerOptionsByProvider ??
-          next.composerOptionsByProvider ??
-          {},
-        composerOptionsByAgentTargetId:
-          current.composerOptionsByAgentTargetId ??
-          next.composerOptionsByAgentTargetId ??
+        composerOptionsByTargetKey:
+          current.composerOptionsByTargetKey ??
+          next.composerOptionsByTargetKey ??
           {},
         sessionMessagesById: {
           ...next.sessionMessagesById,
@@ -20382,8 +20699,7 @@ function emptyAgentActivitySnapshot(
     presences: [],
     sessions: [],
     sessionMessagesById: {},
-    composerOptionsByAgentTargetId: {},
-    composerOptionsByProvider: {}
+    composerOptionsByTargetKey: {}
   };
 }
 
@@ -20541,18 +20857,10 @@ function cloneAgentActivitySnapshot(
     workspaceId: snapshot.workspaceId,
     presences: snapshot.presences.map((presence) => ({ ...presence })),
     sessions: snapshot.sessions.map((session) => ({ ...session })),
-    composerOptionsByAgentTargetId: Object.fromEntries(
-      Object.entries(snapshot.composerOptionsByAgentTargetId ?? {}).map(
-        ([agentTargetId, options]) => [
-          agentTargetId,
-          cloneComposerOptionsForTest(options)
-        ]
-      )
-    ),
-    composerOptionsByProvider: Object.fromEntries(
-      Object.entries(snapshot.composerOptionsByProvider ?? {}).map(
-        ([provider, options]) => [
-          provider,
+    composerOptionsByTargetKey: Object.fromEntries(
+      Object.entries(snapshot.composerOptionsByTargetKey ?? {}).map(
+        ([targetKey, options]) => [
+          targetKey,
           cloneComposerOptionsForTest(options)
         ]
       )
@@ -20628,18 +20936,12 @@ function agentActivitySnapshotFromHostSnapshot(
       agentActivitySessionFromWorkspaceAgentSession(session, workspaceId)
     ),
     sessionMessagesById,
-    composerOptionsByAgentTargetId:
+    composerOptionsByTargetKey:
       (
         snapshot as {
-          composerOptionsByAgentTargetId?: AgentActivitySnapshot["composerOptionsByAgentTargetId"];
+          composerOptionsByTargetKey?: AgentActivitySnapshot["composerOptionsByTargetKey"];
         }
-      ).composerOptionsByAgentTargetId ?? {},
-    composerOptionsByProvider:
-      (
-        snapshot as {
-          composerOptionsByProvider?: AgentActivitySnapshot["composerOptionsByProvider"];
-        }
-      ).composerOptionsByProvider ?? {}
+      ).composerOptionsByTargetKey ?? {}
   };
 }
 

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUINodeController.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUINodeController.ts
@@ -63,6 +63,7 @@ import type {
 } from "../../../types";
 import {
   agentGUIProviderTargetRefsEqual,
+  localAgentGUIAgentTargetId,
   normalizeAgentGUIProviderTargets,
   resolveAgentGUIProviderTarget
 } from "../../../providerTargets";
@@ -334,29 +335,26 @@ function composerDefaultsPatchFromSettings(
   return Object.keys(patch).length > 0 ? patch : null;
 }
 
+// A provider target from the rail/catalog is the directory record itself, so
+// identity (agentTargetId/provider/targetId/label) is taken verbatim from it.
+// The deprecated providerTargetId/providerTargetRef fields are never written as
+// identity anymore — a target that lacks an agentTargetId simply has no
+// composer identity (submission is gated elsewhere) rather than falling back to
+// a provider-target ref guess. `isExplicit` is retained for call-site
+// compatibility but no longer affects identity.
 function composerTargetDataFromProviderTarget(input: {
   current: AgentGUINodeData;
   isExplicit: boolean;
   target: AgentGUIProviderTarget;
 }): AgentGUIComposerTargetData {
   const agentTargetId = normalizeOptionalText(input.target.agentTargetId);
-  const useLegacyProviderTargetRef = !agentTargetId && input.isExplicit;
-  const providerTargetId = useLegacyProviderTargetRef
-    ? input.target.targetId
-    : null;
-  const providerTargetRef = useLegacyProviderTargetRef
-    ? input.target.ref
-    : null;
   const currentAgentTargetId = normalizeOptionalText(
     input.current.agentTargetId
-  );
-  const currentProviderTargetId = normalizeOptionalText(
-    input.current.providerTargetId
   );
   const canPromoteLegacyComposerOverrides =
     agentTargetId !== null &&
     currentAgentTargetId === null &&
-    currentProviderTargetId === null &&
+    normalizeOptionalText(input.current.providerTargetId) === null &&
     input.current.providerTargetRef == null &&
     input.current.provider === input.target.provider &&
     input.current.composerOverrides != null &&
@@ -369,26 +367,19 @@ function composerTargetDataFromProviderTarget(input: {
     : input.current.composerOverridesByAgentTargetId;
   const currentTargetIdentityChanged =
     input.current.provider !== input.target.provider ||
-    (currentAgentTargetId !== null && currentAgentTargetId !== agentTargetId) ||
-    (currentProviderTargetId !== null &&
-      currentProviderTargetId !== providerTargetId) ||
-    (input.current.providerTargetRef != null &&
-      !agentGUIProviderTargetRefsEqual(
-        input.current.providerTargetRef,
-        providerTargetRef
-      ));
+    (currentAgentTargetId !== null && currentAgentTargetId !== agentTargetId);
   return {
     agentTargetId,
     provider: input.target.provider,
-    providerTargetId,
-    providerTargetRef,
+    providerTargetId: null,
+    providerTargetRef: null,
     targetId: input.target.targetId,
     data: {
       ...input.current,
       provider: input.target.provider,
       agentTargetId,
-      providerTargetId,
-      providerTargetRef,
+      providerTargetId: null,
+      providerTargetRef: null,
       composerOverrides: canPromoteLegacyComposerOverrides
         ? null
         : currentTargetIdentityChanged
@@ -397,6 +388,18 @@ function composerTargetDataFromProviderTarget(input: {
       composerOverridesByAgentTargetId
     }
   };
+}
+
+type AgentGUIComposerTargetResolutionStatus =
+  | "resolved"
+  | "loading"
+  | "missing";
+
+interface AgentGUIComposerTargetResolution {
+  status: AgentGUIComposerTargetResolutionStatus;
+  target: AgentGUIComposerTargetData;
+  /** The unresolved foreign key when status is "missing". */
+  missingAgentTargetId: string | null;
 }
 
 function isExplicitAgentGUIProviderTarget(
@@ -411,19 +414,88 @@ function isExplicitAgentGUIProviderTarget(
   );
 }
 
+function findAgentGUIDirectoryTarget(
+  directory: readonly AgentGUIProviderTarget[] | undefined,
+  agentTargetId: string | null
+): AgentGUIProviderTarget | undefined {
+  if (!agentTargetId || !directory) {
+    return undefined;
+  }
+  return directory.find(
+    (target) => normalizeOptionalText(target.agentTargetId) === agentTargetId
+  );
+}
+
+// The node/session carries `agentTargetId` only as a foreign key. When a
+// directory (rail catalog projection) is supplied, the key is resolved against
+// it and — on a hit — identity (id/provider/label) is taken from the directory
+// record, never from the raw node fields. Legacy provider-only node data (no
+// foreign key) is resolved through the same registry: the provider's canonical
+// local target id (`local:${provider}`) is derived and looked up in the
+// directory, so a hit yields a canonical identity rather than a provider-keyed
+// shell. There is no provider-target-ref fallback: an unresolved key produces
+// an identity-less shell whose caller is responsible for the fail-fast error
+// state.
 function composerTargetDataFromNodeData(
-  data: AgentGUINodeData
+  data: AgentGUINodeData,
+  directory?: readonly AgentGUIProviderTarget[]
 ): AgentGUIComposerTargetData {
-  const agentTargetId = normalizeOptionalText(data.agentTargetId);
-  const providerTargetId = data.providerTargetId ?? null;
+  const foreignKeyAgentTargetId = normalizeOptionalText(data.agentTargetId);
+  const lookupAgentTargetId =
+    foreignKeyAgentTargetId ?? localAgentGUIAgentTargetId(data.provider);
+  const directoryTarget = findAgentGUIDirectoryTarget(
+    directory,
+    lookupAgentTargetId
+  );
+  // Identity comes from the directory record; the raw foreign key is kept only
+  // when it is the node's own (it still names the session's target while the
+  // directory loads). A derived local id is never used without a registry hit.
+  const agentTargetId =
+    normalizeOptionalText(directoryTarget?.agentTargetId) ??
+    foreignKeyAgentTargetId;
+  const provider = directoryTarget?.provider ?? data.provider;
   return {
     agentTargetId,
-    provider: data.provider,
-    providerTargetId,
-    providerTargetRef: data.providerTargetRef ?? null,
-    targetId: agentTargetId ?? providerTargetId ?? `local:${data.provider}`,
-    data
+    provider,
+    providerTargetId: null,
+    providerTargetRef: null,
+    targetId: directoryTarget?.targetId ?? agentTargetId ?? `local:${provider}`,
+    data:
+      directoryTarget && directoryTarget.provider !== data.provider
+        ? { ...data, provider }
+        : data
   };
+}
+
+// Fail-fast resolution for the active session's composer target: the session's
+// foreign-key agentTargetId must resolve inside the loaded directory. Legacy
+// provider-only sessions (no foreign key) resolve through the same registry via
+// the provider's canonical local target id — this is a directory lookup, not a
+// provider fallback. While the directory is still loading we stay neutral
+// ("loading"); once loaded, an unresolved key is an honest error ("missing") —
+// no provider-keyed cache bucket, since sibling targets of the same provider
+// would silently splice in another (possibly cloned) agent's identity.
+function resolveActiveSessionComposerTarget(input: {
+  data: AgentGUINodeData;
+  foreignKeyAgentTargetId: string | null;
+  directory: readonly AgentGUIProviderTarget[];
+  directoryLoading: boolean;
+}): AgentGUIComposerTargetResolution {
+  const foreignKey = normalizeOptionalText(input.foreignKeyAgentTargetId);
+  const target = composerTargetDataFromNodeData(input.data, input.directory);
+  if (input.directoryLoading) {
+    return { status: "loading", target, missingAgentTargetId: null };
+  }
+  const resolveKey =
+    foreignKey ?? localAgentGUIAgentTargetId(input.data.provider);
+  const directoryTarget = findAgentGUIDirectoryTarget(
+    input.directory,
+    resolveKey
+  );
+  if (directoryTarget) {
+    return { status: "resolved", target, missingAgentTargetId: null };
+  }
+  return { status: "missing", target, missingAgentTargetId: resolveKey };
 }
 
 function agentGUINodeDataHasComposerTarget(data: AgentGUINodeData): boolean {
@@ -438,18 +510,15 @@ function composerOptionsForTarget(input: {
   snapshot: AgentActivitySnapshot;
   target: AgentGUIComposerTargetData;
 }): AgentActivityComposerOptions | null {
-  if (input.target.agentTargetId) {
-    const targetOptions =
-      input.snapshot.composerOptionsByAgentTargetId?.[
-        input.target.agentTargetId
-      ] ?? null;
-    if (targetOptions) {
-      return targetOptions;
-    }
+  // Single opaque key space: composer options are cached under the resolved
+  // directory target id (the targetKey), verbatim. A target without a resolved
+  // identity has no cache entry — no provider-keyed fallback bucket.
+  if (!input.target.agentTargetId) {
     return null;
   }
   return (
-    input.snapshot.composerOptionsByProvider?.[input.target.provider] ?? null
+    input.snapshot.composerOptionsByTargetKey?.[input.target.agentTargetId] ??
+    null
   );
 }
 
@@ -4106,7 +4175,7 @@ export function useAgentGUINodeController({
               target: selectedProviderTarget
             })
           : agentGUINodeDataHasComposerTarget(data)
-            ? composerTargetDataFromNodeData(data)
+            ? composerTargetDataFromNodeData(data, normalizedProviderTargets)
             : composerTargetDataFromProviderTarget({
                 current: data,
                 isExplicit: selectedProviderTargetIsExplicit,
@@ -4117,6 +4186,7 @@ export function useAgentGUINodeController({
       homeComposerTargetOverride,
       homeComposerTargetOverrideIsExplicit,
       nodeComposerTargetResolvedByProviderTarget,
+      normalizedProviderTargets,
       selectedProviderTarget,
       selectedProviderTargetIsExplicit
     ]
@@ -4347,7 +4417,7 @@ export function useAgentGUINodeController({
   const composerTargetData =
     activeConversationId === null
       ? selectedComposerTargetData
-      : composerTargetDataFromNodeData(data);
+      : composerTargetDataFromNodeData(data, normalizedProviderTargets);
   const providerComposerOptions = composerOptionsForTarget({
     snapshot: agentActivitySnapshot,
     target: composerTargetData
@@ -4680,6 +4750,8 @@ export function useAgentGUINodeController({
   providerTargetsProvidedRef.current = providerTargets !== undefined;
   const selectedComposerTargetDataRef = useRef(selectedComposerTargetData);
   selectedComposerTargetDataRef.current = selectedComposerTargetData;
+  const normalizedProviderTargetsRef = useRef(normalizedProviderTargets);
+  normalizedProviderTargetsRef.current = normalizedProviderTargets;
   const draftSettingsBySessionIdRef = useRef(draftSettingsBySessionId);
   const onDataChangeRef = useRef(onDataChange);
   const onRememberComposerDefaultsRef = useRef(onRememberComposerDefaults);
@@ -6711,6 +6783,13 @@ export function useAgentGUINodeController({
       // carry the capabilities fallback and the skills list.
       const provider = targetData.provider;
       const agentTargetId = targetData.agentTargetId;
+      // The resolved directory target id is the opaque composer-options cache
+      // key (targetKey). A target without one is unresolved — either the
+      // directory is still loading or the session is in the fail-fast error
+      // state (agent missing) — so there is nothing to load.
+      if (!agentTargetId) {
+        return;
+      }
       if (isCreatingConversationRef.current) {
         return;
       }
@@ -6739,7 +6818,10 @@ export function useAgentGUINodeController({
       const targetData =
         activeConversationIdRef.current === null
           ? selectedComposerTargetDataRef.current
-          : composerTargetDataFromNodeData(dataRef.current);
+          : composerTargetDataFromNodeData(
+              dataRef.current,
+              normalizedProviderTargetsRef.current
+            );
       loadComposerOptionsForTarget(targetData, options);
     },
     [loadComposerOptionsForTarget]
@@ -11101,6 +11183,41 @@ export function useAgentGUINodeController({
     providerTargetsLoading,
     shouldUseStaticProviderTargets
   ]);
+  // Fail-fast resolution of the active session's foreign-key agentTargetId
+  // against the loaded directory. Scoped to the active conversation so a removed
+  // agent only errors its own session, never sibling sessions in the node.
+  const activeSessionTargetResolution =
+    useMemo<AgentGUIComposerTargetResolution>(() => {
+      if (previewMode || activeConversationId === null) {
+        return {
+          status: "resolved",
+          target: composerTargetDataFromNodeData(
+            data,
+            normalizedProviderTargets
+          ),
+          missingAgentTargetId: null
+        };
+      }
+      return resolveActiveSessionComposerTarget({
+        data,
+        // The session record's own agentTargetId is the authoritative foreign
+        // key; the node's persisted agentTargetId can lag when the reconcile
+        // effect declines to overwrite an explicit target with a fallback.
+        foreignKeyAgentTargetId:
+          activeConversation?.agentTargetId ?? data.agentTargetId ?? null,
+        directory: normalizedProviderTargets,
+        directoryLoading: providerTargetsLoading
+      });
+    }, [
+      activeConversation?.agentTargetId,
+      activeConversationId,
+      data,
+      normalizedProviderTargets,
+      previewMode,
+      providerTargetsLoading
+    ]);
+  const activeSessionTargetMissing =
+    activeSessionTargetResolution.status === "missing";
   const visibleConversationsRef = useRef<AgentGUIConversationSummary[] | null>(
     null
   );
@@ -11694,13 +11811,18 @@ export function useAgentGUINodeController({
             ? { message: normalizedError }
             : null,
       approval: pendingApproval,
-      recovery:
-        activeLiveState === "activating" &&
-        // Suppress the "reconnecting" banner during a first-message create:
-        // the user just submitted and is already seeing their optimistic
-        // message, so an activation-in-flight state on the conversation they
-        // just entered is not a recovery event.
-        startingConversationIdRef.current !== activeConversationId
+      recovery: activeSessionTargetMissing
+        ? {
+            kind: "failed",
+            message: translate("messages.agentTargetRemoved"),
+            canRetry: false
+          }
+        : activeLiveState === "activating" &&
+            // Suppress the "reconnecting" banner during a first-message create:
+            // the user just submitted and is already seeing their optimistic
+            // message, so an activation-in-flight state on the conversation they
+            // just entered is not a recovery event.
+            startingConversationIdRef.current !== activeConversationId
           ? {
               kind: "activating",
               // i18n-check-ignore: Legacy recovery fallback copy; localized presentation should move to view labels.
@@ -11726,6 +11848,7 @@ export function useAgentGUINodeController({
     activeConversationId,
     activeConversationResumeUnavailable,
     activeSessionState,
+    activeSessionTargetMissing,
     hasProviderSessionNotFoundError,
     pendingApproval
   ]);
@@ -12175,8 +12298,7 @@ export function useAgentGUINodeController({
           target: nextTarget
         });
         const nextAgentTargetId = currentNextTargetData.agentTargetId;
-        const currentTargetId =
-          current.agentTargetId ?? current.providerTargetId ?? null;
+        const currentTargetId = normalizeOptionalText(current.agentTargetId);
         const nextTargetId = nextAgentTargetId ?? nextTarget.targetId;
         const providerTargetChanged =
           current.provider !== nextProvider ||

--- a/packages/agent/gui/app/renderer/i18n/locales/en.messages.ts
+++ b/packages/agent/gui/app/renderer/i18n/locales/en.messages.ts
@@ -3,6 +3,8 @@ export const enMessages = {
   agentResumeFailed: "Agent resume failed: {{message}}",
   agentProviderSessionNotFound:
     "This session history is still available, but the underlying provider session can no longer be restored.",
+  agentTargetRemoved:
+    "This agent no longer exists or has been removed. Its conversation history stays available to read.",
   agentResumeSessionNotLocal:
     "This session cannot be resumed on this device. Start a new session and @this session to keep going.",
   agentSettingsRequireNewSession:

--- a/packages/agent/gui/app/renderer/i18n/locales/zh-CN.messages.ts
+++ b/packages/agent/gui/app/renderer/i18n/locales/zh-CN.messages.ts
@@ -3,6 +3,7 @@ export const zhCNMessages = {
   agentResumeFailed: "Agent 继续失败：{{message}}",
   agentProviderSessionNotFound:
     "这条会话历史仍可查看，但底层 Provider 会话已经无法恢复。",
+  agentTargetRemoved: "该 agent 不存在或已被移除，历史会话记录仍可查看。",
   agentResumeSessionNotLocal:
     "这个会话没法在当前设备里直接恢复，你可以在新会话里 @这段对话，接着继续聊。",
   agentSettingsRequireNewSession: "为了保留上下文，这个模型只能在新会话中使用",

--- a/packages/agent/gui/shared/agentActivitySnapshotProjection.spec.ts
+++ b/packages/agent/gui/shared/agentActivitySnapshotProjection.spec.ts
@@ -23,7 +23,7 @@ describe("projectCoreSessionStatus", () => {
 describe("agentHostSnapshotFromAgentActivitySnapshot", () => {
   it("projects active runtime phases into host session status", () => {
     const hostSnapshot = agentHostSnapshotFromAgentActivitySnapshot({
-      composerOptionsByProvider: {},
+      composerOptionsByTargetKey: {},
       presences: [],
       sessionMessagesById: {},
       sessions: [

--- a/packages/agent/gui/workbench/contribution.ts
+++ b/packages/agent/gui/workbench/contribution.ts
@@ -452,8 +452,9 @@ export function createAgentGuiWorkbenchContribution(
         launchPayload,
         provider
       );
-      const launchAgentTargetId =
-        providerTarget.agentTargetId ?? providerTarget.providerTargetId;
+      // Identity is the agentTargetId only — a providerTargetId is a deprecated
+      // ref and must never be laundered into the agentTargetId slot.
+      const launchAgentTargetId = providerTarget.agentTargetId;
       if (targetAgentSessionId) {
         const previousState = nodeStateSource.readNodeState({
           instanceId,
@@ -486,9 +487,6 @@ export function createAgentGuiWorkbenchContribution(
             lastActiveAgentSessionId: null,
             ...(providerTarget.agentTargetId
               ? { agentTargetId: providerTarget.agentTargetId }
-              : {}),
-            ...(providerTarget.providerTargetId
-              ? { agentTargetId: providerTarget.providerTargetId }
               : {})
           },
           typeId: agentGuiWorkbenchTypeId

--- a/packages/clients/tuttid-ts/src/generated/types.gen.ts
+++ b/packages/clients/tuttid-ts/src/generated/types.gen.ts
@@ -1003,6 +1003,10 @@ export type AgentProviderComposerConfig = {
 };
 
 export type GetAgentProviderComposerOptionsRequest = {
+  /**
+   * Agent target whose provider and runtime context the composer options resolve against. Optional; when omitted the provider path parameter is used directly.
+   */
+  agentTargetId?: string;
   cwd?: string;
   /**
    * Workspace used for Claude Code live model discovery.

--- a/services/tuttid/api/daemon_agent_sessions.go
+++ b/services/tuttid/api/daemon_agent_sessions.go
@@ -72,6 +72,7 @@ func (api DaemonAPI) GetAgentProviderComposerOptions(ctx context.Context, reques
 		Provider: string(request.Provider),
 	}
 	if request.Body != nil {
+		input.AgentTargetID = optionalStringValue(request.Body.AgentTargetId)
 		input.Cwd = optionalStringValue(request.Body.Cwd)
 		input.WorkspaceID = optionalStringValue(request.Body.WorkspaceId)
 	}

--- a/services/tuttid/api/daemon_test.go
+++ b/services/tuttid/api/daemon_test.go
@@ -1566,6 +1566,30 @@ func TestDaemonAPIGeneratedRoutesGetAgentProviderComposerOptions(t *testing.T) {
 	}
 }
 
+func TestDaemonAPIGeneratedRoutesGetAgentProviderComposerOptionsPassesAgentTargetID(t *testing.T) {
+	var gotAgentTargetID string
+	mux := http.NewServeMux()
+	RegisterRoutes(mux, NewRoutes(DaemonAPI{
+		AgentSessionService: stubAgentSessionService{
+			composerOptionsFn: func(_ context.Context, input agentservice.ComposerOptionsInput) (agentservice.ComposerOptions, error) {
+				gotAgentTargetID = input.AgentTargetID
+				return agentservice.ComposerOptions{Provider: input.Provider}, nil
+			},
+		},
+	}))
+
+	recorder := performGeneratedRouteRequest(t, mux, http.MethodPost, "/v1/agent-providers/codex/composer-options", map[string]any{
+		"agentTargetId": "shared-agent:abc",
+		"workspaceId":   "ws-1",
+	})
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d; body: %s", recorder.Code, http.StatusOK, recorder.Body.String())
+	}
+	if gotAgentTargetID != "shared-agent:abc" {
+		t.Fatalf("agentTargetID = %q, want shared-agent:abc", gotAgentTargetID)
+	}
+}
+
 func TestDaemonAPIGeneratedRoutesGetAgentProviderComposerOptionsUsesPreferencesDefaults(t *testing.T) {
 	mux := http.NewServeMux()
 	RegisterRoutes(mux, NewRoutes(DaemonAPI{

--- a/services/tuttid/api/generated/types.gen.go
+++ b/services/tuttid/api/generated/types.gen.go
@@ -2887,9 +2887,11 @@ type FixWorkspaceAppFactoryJobRequest struct {
 
 // GetAgentProviderComposerOptionsRequest defines model for GetAgentProviderComposerOptionsRequest.
 type GetAgentProviderComposerOptionsRequest struct {
-	Cwd      *string                       `json:"cwd,omitempty"`
-	Locale   *DesktopLocale                `json:"locale,omitempty"`
-	Settings *AgentSessionComposerSettings `json:"settings,omitempty"`
+	// AgentTargetId Agent target whose provider and runtime context the composer options resolve against. Optional; when omitted the provider path parameter is used directly.
+	AgentTargetId *string                       `json:"agentTargetId,omitempty"`
+	Cwd           *string                       `json:"cwd,omitempty"`
+	Locale        *DesktopLocale                `json:"locale,omitempty"`
+	Settings      *AgentSessionComposerSettings `json:"settings,omitempty"`
 
 	// WorkspaceId Workspace used for Claude Code live model discovery.
 	WorkspaceId *string `json:"workspaceId,omitempty"`

--- a/services/tuttid/api/openapi/tuttid.v1.yaml
+++ b/services/tuttid/api/openapi/tuttid.v1.yaml
@@ -6223,6 +6223,12 @@ components:
       type: object
       additionalProperties: false
       properties:
+        agentTargetId:
+          type: string
+          description:
+            Agent target whose provider and runtime context the composer options
+            resolve against. Optional; when omitted the provider path parameter
+            is used directly.
         cwd:
           type: string
         workspaceId:

--- a/services/tuttid/data/workspace/agent_store.go
+++ b/services/tuttid/data/workspace/agent_store.go
@@ -163,6 +163,21 @@ func (s *SQLiteStore) DeleteAgentTarget(ctx context.Context, id string) error {
 	return s.agentStore().DeleteAgentTarget(ctx, id)
 }
 
+// ResolveAgentTargetAlias reverse-looks-up which registered agent target
+// claims the given id as an alias, returning that target's primary id.
+//
+// Contract: cross-domain id translation is owned by the host projection layer
+// (tsh/tutti-os rewrites a shared session's owner-domain agentTargetId to the
+// caller-local `shared-agent:{sharedAgentId}` id at its sync boundary), so
+// owner-domain ids are never expected to reach this store and no alias column
+// is planned. This hook exists purely as defense in depth for the ingestion
+// boundary in services/tuttid/service/agent: a hit means an upstream missed
+// its translation. The store-backed implementation therefore resolves
+// nothing.
+func (*SQLiteStore) ResolveAgentTargetAlias(context.Context, string) (string, bool) {
+	return "", false
+}
+
 func agentTargetToStore(target agenttargetbiz.Target) agentstore.Target {
 	return agentstore.Target{
 		ID:              target.ID,

--- a/services/tuttid/service/agent/activity_projection.go
+++ b/services/tuttid/service/agent/activity_projection.go
@@ -18,6 +18,7 @@ type ActivityProjection struct {
 	publisher              ActivityUpdatePublisher
 	sessionMessageObserver SessionMessageObserver
 	sessionStateObserver   SessionStateObserver
+	agentTargetResolver    AgentTargetResolver
 }
 
 func NewActivityProjection(repo agentactivitybiz.Repository) *ActivityProjection {
@@ -117,6 +118,15 @@ func (p *ActivityProjection) ReportSessionState(
 	}
 	input.SessionOrigin = sessionOrigin
 	input.Source = source
+	// Reference-integrity boundary: an owner-domain agentTargetId carried by a
+	// shared session must never be persisted verbatim. Canonicalize it against
+	// the local target directory here, before it lands in the store, so the
+	// invariant "persisted agentTargetId ∈ local directory or empty" holds.
+	canonicalTargetID, runtimeContext := p.canonicalizeAgentTargetID(
+		ctx,
+		firstNonEmptyString(input.State.AgentTargetID, input.Source.AgentTargetID),
+		input.State.RuntimeContext,
+	)
 	result, err := p.repo.ReportSessionState(ctx, agentactivitybiz.SessionStateReport{
 		WorkspaceID:    strings.TrimSpace(input.WorkspaceID),
 		AgentSessionID: strings.TrimSpace(input.AgentSessionID),
@@ -124,12 +134,12 @@ func (p *ActivityProjection) ReportSessionState(
 		// Tutti local workspaces intentionally leave Source.UserID empty. Cloud
 		// collaboration hosts may provide real account user ids on this wire.
 		UserID:            strings.TrimSpace(input.Source.UserID),
-		AgentTargetID:     strings.TrimSpace(firstNonEmptyString(input.State.AgentTargetID, input.Source.AgentTargetID)),
+		AgentTargetID:     canonicalTargetID,
 		Provider:          strings.TrimSpace(firstNonEmptyString(input.State.Provider, input.Source.Provider)),
 		ProviderSessionID: strings.TrimSpace(firstNonEmptyString(input.State.ProviderSessionID, input.Source.ProviderSessionID)),
 		Model:             strings.TrimSpace(input.State.Model),
 		Settings:          clonePayload(input.State.Settings),
-		RuntimeContext:    clonePayload(input.State.RuntimeContext),
+		RuntimeContext:    clonePayload(runtimeContext),
 		Cwd:               strings.TrimSpace(input.State.CWD),
 		Title:             strings.TrimSpace(sessionStateTitle(input.State)),
 		Status:            strings.TrimSpace(input.State.LifecycleStatus),
@@ -167,7 +177,7 @@ func (p *ActivityProjection) ReportSessionState(
 					input.WorkspaceID,
 					input.AgentSessionID,
 					result.LastEventUnixMS,
-					firstNonEmptyString(input.State.AgentTargetID, input.Source.AgentTargetID),
+					canonicalTargetID,
 				),
 			)
 		}
@@ -330,7 +340,7 @@ func (p *ActivityProjection) GetSession(workspaceID string, agentSessionID strin
 	if !ok {
 		return PersistedSession{}, false
 	}
-	return persistedSessionFromActivity(session), true
+	return p.projectPersistedSession(context.Background(), persistedSessionFromActivity(session)), true
 }
 
 func (p *ActivityProjection) ListSessions(workspaceID string) ([]PersistedSession, bool) {
@@ -349,9 +359,10 @@ func (p *ActivityProjection) ListSessions(workspaceID string) ([]PersistedSessio
 	if !ok {
 		return nil, false
 	}
+	ctx := context.Background()
 	out := make([]PersistedSession, 0, len(sessions))
 	for _, session := range sessions {
-		out = append(out, persistedSessionFromActivity(session))
+		out = append(out, p.projectPersistedSession(ctx, persistedSessionFromActivity(session)))
 	}
 	return out, true
 }

--- a/services/tuttid/service/agent/activity_projection_reference_integrity_test.go
+++ b/services/tuttid/service/agent/activity_projection_reference_integrity_test.go
@@ -1,0 +1,250 @@
+package agent
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	agentsessionstore "github.com/tutti-os/tutti/packages/agent/daemon/activity"
+	agenttargetbiz "github.com/tutti-os/tutti/services/tuttid/biz/agenttarget"
+	workspacebiz "github.com/tutti-os/tutti/services/tuttid/biz/workspace"
+	workspacedata "github.com/tutti-os/tutti/services/tuttid/data/workspace"
+)
+
+// fakeAgentTargetRegistry models the local agent target registry including
+// the alias table a shared agent's registration record will carry (the
+// owner-domain agentTargetId claimed as an alias of the local registration).
+type fakeAgentTargetRegistry struct {
+	targets map[string]agenttargetbiz.Target
+	aliases map[string]string
+}
+
+func (f fakeAgentTargetRegistry) GetAgentTarget(_ context.Context, id string) (agenttargetbiz.Target, error) {
+	target, ok := f.targets[strings.TrimSpace(id)]
+	if !ok {
+		return agenttargetbiz.Target{}, workspacedata.ErrAgentTargetNotFound
+	}
+	return target, nil
+}
+
+func (f fakeAgentTargetRegistry) ResolveAgentTargetAlias(_ context.Context, id string) (string, bool) {
+	canonicalID, ok := f.aliases[strings.TrimSpace(id)]
+	return canonicalID, ok
+}
+
+func testSharedAgentTargetRegistry() fakeAgentTargetRegistry {
+	return fakeAgentTargetRegistry{
+		targets: map[string]agenttargetbiz.Target{
+			agenttargetbiz.IDLocalCodex: {
+				ID:            agenttargetbiz.IDLocalCodex,
+				Provider:      "codex",
+				LaunchRefJSON: agenttargetbiz.MustLocalCLILaunchRefJSON("codex"),
+				Name:          "Codex",
+				Enabled:       true,
+				Source:        agenttargetbiz.SourceSystem,
+			},
+			"shared-agent:codex-1": {
+				ID:            "shared-agent:codex-1",
+				Provider:      "codex",
+				LaunchRefJSON: agenttargetbiz.MustLocalCLILaunchRefJSON("codex"),
+				Name:          "Shared Codex",
+				Enabled:       true,
+				Source:        agenttargetbiz.SourceUser,
+			},
+		},
+		aliases: map[string]string{
+			// The shared-agent registration claims its owner-domain id.
+			"02fc7056aaaa4bbb8cccdddd0000eeee": "shared-agent:codex-1",
+		},
+	}
+}
+
+// TestActivityProjectionReportSessionStateEnforcesTargetReferenceIntegrity
+// pins the WS0 invariant: every persisted session carries an agentTargetId
+// that resolves in the local target registry, or none at all. Owner-domain
+// ids that leak in from shared sessions are rewritten when a registered
+// target claims them as an alias, or dropped, with the original value
+// preserved only for diagnostics. Identity is decided exclusively against
+// the registry — never inferred from session-carried data.
+func TestActivityProjectionReportSessionStateEnforcesTargetReferenceIntegrity(t *testing.T) {
+	ctx := context.Background()
+	store := openAgentServiceSQLiteStore(t)
+	if err := store.Create(ctx, workspacebiz.Summary{ID: "ws-1", Name: "Workspace One"}); err != nil {
+		t.Fatalf("Create workspace error = %v", err)
+	}
+
+	projection := NewActivityProjection(store)
+	projection.SetAgentTargetResolver(testSharedAgentTargetRegistry())
+
+	for _, tc := range []struct {
+		name          string
+		sessionID     string
+		agentTargetID string
+		wantTargetID  string
+		wantStashKey  string
+	}{
+		{
+			name:          "registered id passes through verbatim",
+			sessionID:     "session-local",
+			agentTargetID: agenttargetbiz.IDLocalCodex,
+			wantTargetID:  agenttargetbiz.IDLocalCodex,
+		},
+		{
+			name:          "owner-domain id rewritten via registry alias",
+			sessionID:     "session-shared",
+			agentTargetID: "02fc7056aaaa4bbb8cccdddd0000eeee",
+			wantTargetID:  "shared-agent:codex-1",
+			wantStashKey:  runtimeContextAliasedAgentTargetIDKey,
+		},
+		{
+			name:          "unclaimed id dropped and stashed",
+			sessionID:     "session-orphan",
+			agentTargetID: "02fc7056aaaa4bbb8cccdddd0000ffff",
+			wantTargetID:  "",
+			wantStashKey:  runtimeContextUnresolvedAgentTargetIDKey,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if _, err := projection.ReportSessionState(ctx, agentsessionstore.ReportSessionStateInput{
+				WorkspaceID:    "ws-1",
+				AgentSessionID: tc.sessionID,
+				SessionOrigin:  agentsessionstore.WorkspaceAgentSessionOriginRuntime,
+				State: agentsessionstore.WorkspaceAgentSessionStateUpdate{
+					AgentTargetID:    tc.agentTargetID,
+					Provider:         "codex",
+					CurrentPhase:     "idle",
+					OccurredAtUnixMS: 1000,
+				},
+			}); err != nil {
+				t.Fatalf("ReportSessionState error = %v", err)
+			}
+
+			session, ok := projection.GetSession("ws-1", tc.sessionID)
+			if !ok {
+				t.Fatalf("GetSession(%q) not found", tc.sessionID)
+			}
+			if session.AgentTargetID != tc.wantTargetID {
+				t.Fatalf("persisted agentTargetId = %q, want %q", session.AgentTargetID, tc.wantTargetID)
+			}
+
+			if tc.wantStashKey == "" {
+				for _, key := range []string{runtimeContextAliasedAgentTargetIDKey, runtimeContextUnresolvedAgentTargetIDKey} {
+					if _, present := session.RuntimeContext[key]; present {
+						t.Fatalf("unexpected diagnostic stash %q: %#v", key, session.RuntimeContext)
+					}
+				}
+				return
+			}
+			stashed, _ := session.RuntimeContext[tc.wantStashKey].(string)
+			if stashed != tc.agentTargetID {
+				t.Fatalf("runtimeContext[%q] = %q, want %q", tc.wantStashKey, stashed, tc.agentTargetID)
+			}
+		})
+	}
+}
+
+// TestActivityProjectionProjectsLegacyOwnerDomainTargetIDAtReadTime covers the
+// existing-data strategy: rows persisted before the ingestion boundary was
+// hardened are re-canonicalized at read time (non-destructively), so a legacy
+// owner-domain agentTargetId never reaches the projection surface.
+func TestActivityProjectionProjectsLegacyOwnerDomainTargetIDAtReadTime(t *testing.T) {
+	ctx := context.Background()
+	store := openAgentServiceSQLiteStore(t)
+	if err := store.Create(ctx, workspacebiz.Summary{ID: "ws-1", Name: "Workspace One"}); err != nil {
+		t.Fatalf("Create workspace error = %v", err)
+	}
+
+	// Seed legacy rows through a resolver-less projection: the owner-domain
+	// ids land verbatim, exactly as they would have before this change.
+	legacy := NewActivityProjection(store)
+	const aliasedOwnerDomainID = "02fc7056aaaa4bbb8cccdddd0000eeee"
+	const orphanOwnerDomainID = "02fc7056aaaa4bbb8cccdddd0000ffff"
+	for sessionID, ownerDomainID := range map[string]string{
+		"session-legacy-aliased": aliasedOwnerDomainID,
+		"session-legacy-orphan":  orphanOwnerDomainID,
+	} {
+		if _, err := legacy.ReportSessionState(ctx, agentsessionstore.ReportSessionStateInput{
+			WorkspaceID:    "ws-1",
+			AgentSessionID: sessionID,
+			SessionOrigin:  agentsessionstore.WorkspaceAgentSessionOriginRuntime,
+			State: agentsessionstore.WorkspaceAgentSessionStateUpdate{
+				AgentTargetID:    ownerDomainID,
+				Provider:         "codex",
+				CurrentPhase:     "idle",
+				OccurredAtUnixMS: 1000,
+			},
+		}); err != nil {
+			t.Fatalf("legacy ReportSessionState(%s) error = %v", sessionID, err)
+		}
+	}
+
+	reader := NewActivityProjection(store)
+	reader.SetAgentTargetResolver(testSharedAgentTargetRegistry())
+
+	aliased, ok := reader.GetSession("ws-1", "session-legacy-aliased")
+	if !ok {
+		t.Fatalf("GetSession(aliased) not found")
+	}
+	if aliased.AgentTargetID != "shared-agent:codex-1" {
+		t.Fatalf("projected agentTargetId = %q, want shared-agent:codex-1", aliased.AgentTargetID)
+	}
+
+	orphan, ok := reader.GetSession("ws-1", "session-legacy-orphan")
+	if !ok {
+		t.Fatalf("GetSession(orphan) not found")
+	}
+	if orphan.AgentTargetID != "" {
+		t.Fatalf("projected agentTargetId = %q, want empty for unclaimed legacy id", orphan.AgentTargetID)
+	}
+
+	sessions, ok := reader.ListSessions("ws-1")
+	if !ok {
+		t.Fatalf("ListSessions not found")
+	}
+	for _, session := range sessions {
+		if session.AgentTargetID == aliasedOwnerDomainID || session.AgentTargetID == orphanOwnerDomainID {
+			t.Fatalf("ListSessions projected leaked owner-domain agentTargetId for %q", session.ID)
+		}
+	}
+}
+
+// TestActivityProjectionReportSessionStatePreservesIDsWithoutResolver keeps the
+// projection backward compatible: when no target registry is wired it cannot
+// validate, so ids are persisted untouched.
+func TestActivityProjectionReportSessionStatePreservesIDsWithoutResolver(t *testing.T) {
+	ctx := context.Background()
+	store := openAgentServiceSQLiteStore(t)
+	if err := store.Create(ctx, workspacebiz.Summary{ID: "ws-1", Name: "Workspace One"}); err != nil {
+		t.Fatalf("Create workspace error = %v", err)
+	}
+
+	projection := NewActivityProjection(store)
+
+	const rawID = "02fc7056aaaa4bbb8cccdddd0000eeee"
+	if _, err := projection.ReportSessionState(ctx, agentsessionstore.ReportSessionStateInput{
+		WorkspaceID:    "ws-1",
+		AgentSessionID: "session-no-resolver",
+		SessionOrigin:  agentsessionstore.WorkspaceAgentSessionOriginRuntime,
+		State: agentsessionstore.WorkspaceAgentSessionStateUpdate{
+			AgentTargetID:    rawID,
+			Provider:         "codex",
+			CurrentPhase:     "idle",
+			OccurredAtUnixMS: 1000,
+		},
+	}); err != nil {
+		t.Fatalf("ReportSessionState error = %v", err)
+	}
+
+	session, ok := projection.GetSession("ws-1", "session-no-resolver")
+	if !ok {
+		t.Fatalf("GetSession not found")
+	}
+	if session.AgentTargetID != rawID {
+		t.Fatalf("persisted agentTargetId = %q, want %q (unchanged)", session.AgentTargetID, rawID)
+	}
+	for _, key := range []string{runtimeContextAliasedAgentTargetIDKey, runtimeContextUnresolvedAgentTargetIDKey} {
+		if _, present := session.RuntimeContext[key]; present {
+			t.Fatalf("unexpected diagnostic stash %q without a resolver: %#v", key, session.RuntimeContext)
+		}
+	}
+}

--- a/services/tuttid/service/agent/activity_projection_target_identity.go
+++ b/services/tuttid/service/agent/activity_projection_target_identity.go
@@ -1,0 +1,149 @@
+package agent
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"strings"
+
+	agenttargetbiz "github.com/tutti-os/tutti/services/tuttid/biz/agenttarget"
+	workspacedata "github.com/tutti-os/tutti/services/tuttid/data/workspace"
+)
+
+// runtimeContextAliasedAgentTargetIDKey stores the original, pre-rewrite
+// agentTargetId of a session whose id was resolved through the registry alias
+// table to a locally registered target. Diagnostics only; never identity.
+const runtimeContextAliasedAgentTargetIDKey = "aliasedAgentTargetId"
+
+// runtimeContextUnresolvedAgentTargetIDKey stores the original agentTargetId
+// that resolved neither as a registered target id nor as a registry alias and
+// was therefore dropped. Diagnostics only; never identity.
+const runtimeContextUnresolvedAgentTargetIDKey = "unresolvedAgentTargetId"
+
+// AgentTargetResolver is the local agent target registry (the
+// listAgentTargets data source). Identity decisions are made exclusively
+// against this registry — never inferred from session-carried data.
+type AgentTargetResolver interface {
+	// GetAgentTarget looks a target up by its primary id. A miss must be
+	// reported as workspacedata.ErrAgentTargetNotFound so callers can tell a
+	// definitive absence apart from a transient store failure.
+	GetAgentTarget(ctx context.Context, id string) (agenttargetbiz.Target, error)
+	// ResolveAgentTargetAlias reverse-looks-up which registered target claims
+	// the given id as an alias and returns that target's primary id.
+	// Contract: cross-domain id translation is owned by the host projection
+	// layer (a shared session's owner-domain agentTargetId is rewritten to the
+	// caller-local id before it reaches this daemon), so this lookup is defense
+	// in depth only — a hit means an upstream missed its translation and the
+	// value is rewritten here without trusting anything the session says.
+	ResolveAgentTargetAlias(ctx context.Context, id string) (string, bool)
+}
+
+// SetAgentTargetResolver wires the local agent target registry so the
+// ingestion boundary can enforce the reference-integrity invariant: any
+// persisted agentTargetId must exist locally or be empty. When no resolver is
+// configured the projection cannot validate and leaves ids untouched.
+func (p *ActivityProjection) SetAgentTargetResolver(resolver AgentTargetResolver) {
+	if p == nil {
+		return
+	}
+	p.agentTargetResolver = resolver
+}
+
+// projectPersistedSession applies the reference-integrity invariant when
+// reading a persisted session, so pre-existing rows that were stored before
+// the ingestion boundary was hardened (or that slipped in through another
+// path) never project an owner-domain agentTargetId. It only remaps the
+// projected id; it does not rewrite the stored row.
+func (p *ActivityProjection) projectPersistedSession(ctx context.Context, session PersistedSession) PersistedSession {
+	if p == nil || p.agentTargetResolver == nil {
+		return session
+	}
+	canonical, _ := p.canonicalizeAgentTargetID(ctx, session.AgentTargetID, session.RuntimeContext)
+	session.AgentTargetID = canonical
+	return session
+}
+
+// canonicalizeAgentTargetID enforces the reference-integrity invariant at the
+// session ingestion boundary. It returns the agentTargetId to persist and the
+// runtimeContext to persist alongside it (a diagnostic copy of the original id
+// is stashed into runtimeContext whenever the id is rewritten or dropped).
+//
+// Resolution consults only the local target registry:
+//  1. Empty in → empty out (nothing to validate).
+//  2. No resolver configured → passthrough (cannot validate; preserve
+//     existing behavior for callers that never wired the registry).
+//  3. id is a registered target's primary id → keep verbatim.
+//  4. id is definitively absent as a primary id but a registered target
+//     claims it as an alias → rewrite to that target's primary id.
+//  5. neither → drop to empty.
+//  6. primary-id resolution could not be verified (transient store error) →
+//     keep verbatim rather than destroy a possibly-valid local id.
+func (p *ActivityProjection) canonicalizeAgentTargetID(
+	ctx context.Context,
+	rawID string,
+	runtimeContext map[string]any,
+) (string, map[string]any) {
+	rawID = strings.TrimSpace(rawID)
+	if rawID == "" {
+		return "", runtimeContext
+	}
+	if p == nil || p.agentTargetResolver == nil {
+		return rawID, runtimeContext
+	}
+	exists, verified := p.agentTargetExists(ctx, rawID)
+	if exists || !verified {
+		return rawID, runtimeContext
+	}
+	if canonicalID, ok := p.agentTargetResolver.ResolveAgentTargetAlias(ctx, rawID); ok {
+		canonicalID = strings.TrimSpace(canonicalID)
+		if canonicalID == "" || canonicalID == rawID {
+			return rawID, runtimeContext
+		}
+		slog.Warn("rewrote aliased agent target id to registered target id",
+			"event", "workspace.agent_session.agent_target_id.alias_rewritten",
+			"original_agent_target_id", rawID,
+			"canonical_agent_target_id", canonicalID,
+		)
+		return canonicalID, stashOriginalAgentTargetID(runtimeContext, runtimeContextAliasedAgentTargetIDKey, rawID)
+	}
+	slog.Warn("dropped unresolved agent target id from session",
+		"event", "workspace.agent_session.agent_target_id.dropped",
+		"original_agent_target_id", rawID,
+	)
+	return "", stashOriginalAgentTargetID(runtimeContext, runtimeContextUnresolvedAgentTargetIDKey, rawID)
+}
+
+// agentTargetExists reports whether id resolves in the local target registry.
+// The second return value is false when the store could not be consulted (a
+// transient error distinct from a definitive "not found"), so callers can
+// avoid rewriting an id they merely failed to verify.
+func (p *ActivityProjection) agentTargetExists(ctx context.Context, id string) (bool, bool) {
+	target, err := p.agentTargetResolver.GetAgentTarget(ctx, id)
+	if err == nil {
+		return strings.TrimSpace(target.ID) != "", true
+	}
+	if errors.Is(err, workspacedata.ErrAgentTargetNotFound) {
+		return false, true
+	}
+	slog.Warn("agent target registry lookup failed during session ingestion",
+		"event", "workspace.agent_session.agent_target_id.lookup_failed",
+		"agent_target_id", strings.TrimSpace(id),
+		"error", err,
+	)
+	return false, false
+}
+
+// stashOriginalAgentTargetID records the original id into a diagnostic
+// runtimeContext key without mutating the caller's map.
+func stashOriginalAgentTargetID(runtimeContext map[string]any, key string, rawID string) map[string]any {
+	rawID = strings.TrimSpace(rawID)
+	if rawID == "" {
+		return runtimeContext
+	}
+	next := clonePayload(runtimeContext)
+	if next == nil {
+		next = map[string]any{}
+	}
+	next[key] = rawID
+	return next
+}

--- a/services/tuttid/wiring.go
+++ b/services/tuttid/wiring.go
@@ -240,6 +240,9 @@ func buildDaemonAPI(ctx context.Context, store workspacedata.CatalogStore, analy
 	agentActivityProjection := agentservice.NewActivityProjection(agentActivityRepo)
 	agentActivityProjection.SetAnalyticsReporter(analyticsReporter)
 	agentActivityProjection.SetPublisher(eventstreamservice.AgentActivityPublisher{Service: events})
+	if agentTargetResolver, ok := store.(agentservice.AgentTargetResolver); ok {
+		agentActivityProjection.SetAgentTargetResolver(agentTargetResolver)
+	}
 	managedRuntimeResolver := managedruntime.DefaultResolver{}
 	// Shared so a runtime auth failure (reporter side) surfaces in the status
 	// probe (List side) — see agentRunOutcomeReporter.


### PR DESCRIPTION
## Problem

Shared sessions carry an **owner-domain `agentTargetId`** (e.g. `02fc7056…`) that leaked verbatim into the local identity chain. The agent-gui composer options cache keyed reads by that session-carried id while writes went under the rail-selected target's id, so the two sides missed each other and every consumer resorted to guessing id flavors (see the resolver workaround in tsh `tshSharedAgentQuerySource.ts`).

## Design (see `docs/specs/2026-07-10-agent-target-identity-canonicalization.md`)

- **Registry-driven identity**: every agent (local provider or shared/custom) is judged solely against the local agent-target registry. Identity is never inferred from session-carried data (runtimeContext / providerTargetRef).
- **Domain isolation**: owner-domain target ids never enter caller-side storage. Cross-domain translation is owned by the host projection layer (tsh/tutti-os rewrites a shared session's id to the caller-local `shared-agent:{sharedAgentId}` at its sync boundary); the daemon-side alias hook remains as defense in depth only (a hit means an upstream missed its translation).
- **Fail-fast, no provider fallback**: an id the loaded registry doesn't claim renders the session read-only with "agent no longer exists". A provider-keyed fallback bucket would silently merge sibling targets of the same provider (future agent clones).
- **Opaque cache key**: activity-core keeps a single `composerOptionsByTargetKey` keyspace; the key is round-tripped verbatim.

## Commits

1. `docs(agent)` — design spec.
2. `fix(tuttid)` — ingestion boundary enforces target reference integrity (registered id passes; alias hit rewrites with stash; unclaimed id dropped with stash in runtimeContext); legacy rows canonicalized at read time.
3. `feat(tuttid)` — additive optional `agentTargetId` on `GetAgentProviderComposerOptionsRequest`, handler passes it to the service layer (which already resolves provider from a target id); codegen via `pnpm generate:api`.
4. `fix(agent)` — agent-gui resolves a session's `agentTargetId` as a foreign key against the provider-target directory (legacy provider-only sessions resolve via `local:{provider}`), fail-fast error state on a miss; activity-core single opaque keyspace; desktop adapter forwards the resolved id to the daemon.

## Verification

- Go: `go build` + `go vet` clean; api / service/agent / data/workspace / integration suites all pass; golangci-lint 0 issues.
- activity-core 85/85, agent-gui 2194/2194 (125 files), desktop 1208 pass / 0 fail; `check:api-generated` no drift; pre-push `check:full` passed.

## Follow-ups (tutti-os side, required before shared-agent fail-fast is end-to-end)

1. Register `shared-agent:{sharedAgentId}` as a local target when syncing shared agents.
2. Rewrite shared-session `agentTargetId` to that id at the host projection boundary. Until then, shared sessions carrying owner-domain ids project with an empty target id (stashed as `unresolvedAgentTargetId`) and render the honest "agent no longer exists" state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Canonicalizes agent target identity and fixes composer options caching by using a single opaque target key. Stops owner-domain IDs from leaking into local state and resolves cache misses between session identity and the rail.

- **Bug Fixes**
  - Registry-driven identity: sessions resolve `agentTargetId` against the local directory; alias hit rewrites to the primary id; unclaimed id is dropped and the session becomes read-only with “agent no longer exists”.
  - Domain isolation: owner-domain target ids from shared sessions are never persisted; cross-domain translation is owned by the host projection layer; design spec added.
  - `activity-core`: replaces dual caches with `composerOptionsByTargetKey`; `loadComposerOptions` round-trips an opaque `targetKey` and never falls back by provider.
  - `agent-gui`: treats the session `agentTargetId` as a foreign key to the directory; no provider fallback; new error copy for removed agents; rail scoping now uses the resolved target id.
  - Desktop adapter and `tuttid` API: forwards optional `agentTargetId` to composer-options; OpenAPI, server, and `tuttid-ts` client regenerated.

- **Migration**
  - Hosts: register `shared-agent:{sharedAgentId}` locally and rewrite shared-session `agentTargetId` to that id at the projection boundary.
  - Callers of `activity-core.loadComposerOptions` must pass a non-empty resolved `targetKey` (a directory target id).

<sup>Written for commit 2ac7288cbf6c30b6e97eaf4307baa5e869e93dfd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tutti-os/tutti/pull/1009?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

