### PR TITLE
fix(agent-gui): sync model reasoning options

### DIFF
--- a/apps/desktop/src/renderer/src/features/workspace-agent/services/desktopAgentActivityAdapter.test.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-agent/services/desktopAgentActivityAdapter.test.ts
@@ -757,7 +757,10 @@ test("desktop agent activity adapter normalizes legacy runtime config options", 
           },
           reasoningConfig: {
             configurable: true,
-            options: []
+            options: [
+              { id: "low", value: "low", label: "Low" },
+              { id: "ultra", value: "ultra", label: "Ultra" }
+            ]
           },
           runtimeContext: {
             configOptions: [
@@ -769,7 +772,10 @@ test("desktop agent activity adapter normalizes legacy runtime config options", 
               {
                 id: "reasoning_effort",
                 currentValue: "high",
-                options: [{ value: "medium", name: "中" }]
+                options: [
+                  { value: "medium", name: "中" },
+                  { value: "ultra", name: "ultra" }
+                ]
               }
             ]
           },
@@ -792,6 +798,7 @@ test("desktop agent activity adapter normalizes legacy runtime config options", 
   ]);
   assert.deepEqual(options.reasoningEfforts, [
     { value: "medium", label: "中" },
+    { value: "ultra", label: "Ultra" },
     { value: "high", label: "high" }
   ]);
 });

--- a/apps/desktop/src/renderer/src/features/workspace-agent/services/desktopAgentActivityAdapter.test.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-agent/services/desktopAgentActivityAdapter.test.ts
@@ -803,6 +803,47 @@ test("desktop agent activity adapter normalizes legacy runtime config options", 
   ]);
 });
 
+test("desktop agent activity adapter preserves ACP labels over synthesized config labels", async () => {
+  const adapter = createDesktopAgentActivityAdapter({
+    tuttidClient: createTuttidClient({
+      async getAgentProviderComposerOptions(provider) {
+        return {
+          provider,
+          effectiveSettings: {},
+          modelConfig: { configurable: true, options: [] },
+          permissionConfig: { configurable: false, modes: [] },
+          reasoningConfig: {
+            configurable: true,
+            currentValue: "ultra",
+            options: []
+          },
+          runtimeContext: {
+            configOptions: [
+              {
+                id: "reasoning_effort",
+                currentValue: "ultra",
+                options: [{ value: "ultra", name: "ACP Ultra" }]
+              }
+            ]
+          },
+          skills: [],
+          capabilityCatalog: []
+        };
+      }
+    }),
+    runtimeApi: createRuntimeApi()
+  });
+
+  const options = await adapter.loadComposerOptions({
+    workspaceId,
+    provider: "codex"
+  });
+
+  assert.deepEqual(options.reasoningEfforts, [
+    { value: "ultra", label: "ACP Ultra" }
+  ]);
+});
+
 test("desktop agent activity adapter uses Claude draft live model list", async () => {
   const calls: unknown[] = [];
   const adapter = createDesktopAgentActivityAdapter({

--- a/apps/desktop/src/renderer/src/features/workspace-agent/services/internal/desktopAgentHostProjection.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-agent/services/internal/desktopAgentHostProjection.ts
@@ -353,7 +353,9 @@ function composerRuntimeContextFromSettings(
       {
         currentValue: reasoningEffort,
         id: "reasoning_effort",
-        options: reasoningEffortOptions(reasoningEffort)
+        options: reasoningEffort
+          ? [{ name: reasoningEffort, value: reasoningEffort }]
+          : []
       },
       {
         currentValue: speed,
@@ -366,36 +368,6 @@ function composerRuntimeContextFromSettings(
     reasoningEffort,
     speed
   };
-}
-
-function reasoningEffortOptions(
-  selected: string | null
-): Array<{ name: string; value: string }> {
-  const values = ["minimal", "low", "medium", "high", "xhigh"];
-  const options = values.map((value) => ({
-    name: reasoningEffortLabel(value),
-    value
-  }));
-  return selected && !values.includes(selected)
-    ? [...options, { name: reasoningEffortLabel(selected), value: selected }]
-    : options;
-}
-
-function reasoningEffortLabel(value: string): string {
-  switch (value) {
-    case "minimal":
-      return "Minimal";
-    case "low":
-      return "Low";
-    case "medium":
-      return "Medium";
-    case "high":
-      return "High";
-    case "xhigh":
-      return "X-High";
-    default:
-      return value;
-  }
 }
 
 function normalizedOptionalString(

--- a/apps/desktop/src/renderer/src/lib/agentComposerOptionsProjection.ts
+++ b/apps/desktop/src/renderer/src/lib/agentComposerOptionsProjection.ts
@@ -99,7 +99,10 @@ function settingOptionsWithLocalizedPresentation(
     }
     const localizedOption = {
       ...option,
-      label: localized.label
+      label:
+        localized.label !== localized.value || option.label === option.value
+          ? localized.label
+          : option.label
     };
     return localized.description
       ? { ...localizedOption, description: localized.description }

--- a/apps/desktop/src/renderer/src/lib/agentComposerOptionsProjection.ts
+++ b/apps/desktop/src/renderer/src/lib/agentComposerOptionsProjection.ts
@@ -53,9 +53,12 @@ export function agentActivityComposerOptionsFromTuttidResult(
     models:
       modelsFromLiveConfig.length > 0 ? modelsFromLiveConfig : modelsFromConfig,
     reasoningEfforts:
-      reasoningEffortsFromConfig.length > 0
-        ? reasoningEffortsFromConfig
-        : reasoningEffortsFromLiveConfig,
+      reasoningEffortsFromLiveConfig.length > 0
+        ? settingOptionsWithLocalizedPresentation(
+            reasoningEffortsFromLiveConfig,
+            reasoningEffortsFromConfig
+          )
+        : reasoningEffortsFromConfig,
     speeds:
       speedsFromConfig.length > 0 ? speedsFromConfig : speedsFromLiveConfig,
     modelConfigurable:
@@ -77,6 +80,31 @@ export function agentActivityComposerOptionsFromTuttidResult(
     capabilityCatalog,
     loadedAtUnixMs: Date.now()
   };
+}
+
+function settingOptionsWithLocalizedPresentation(
+  options: AgentActivityComposerSettingOption[],
+  localizedOptions: AgentActivityComposerSettingOption[]
+): AgentActivityComposerSettingOption[] {
+  if (options.length === 0 || localizedOptions.length === 0) {
+    return options;
+  }
+  const localizedByValue = new Map(
+    localizedOptions.map((option) => [option.value, option] as const)
+  );
+  return options.map((option) => {
+    const localized = localizedByValue.get(option.value);
+    if (!localized) {
+      return option;
+    }
+    const localizedOption = {
+      ...option,
+      label: localized.label
+    };
+    return localized.description
+      ? { ...localizedOption, description: localized.description }
+      : localizedOption;
+  });
 }
 
 function settingOptionsFromComposerConfig(

--- a/docs/architecture/agent-gui-node.md
+++ b/docs/architecture/agent-gui-node.md
@@ -920,6 +920,16 @@ User-visible rules:
 - Model, permission, plan mode, reasoning, speed, project, branch, prompt image,
   file mention, and skill/capability controls must read from composer settings
   and provider options. They should not be reconstructed from transcript rows.
+- Reasoning options are model capabilities, not provider-wide constants. The
+  daemon model catalog must preserve each model's advertised effort values and
+  default, pre-session composer options must use the selected model's catalog
+  entry, and active sessions must prefer the runtime's current model-specific
+  options. Compatibility projections that only know persisted settings must not
+  synthesize a full reasoning catalog. Composer-option cache freshness must
+  include the requested settings as well as target and cwd, and an active model
+  change must reload options with the active session settings. ACP owns option
+  values and ordering; the relevant locale catalog owns user-visible labels and
+  descriptions, including when live runtime options are the fresher source.
 - Browser/computer capability controls come from daemon composer options and
   live runtime capabilities. `computerUse` must not be advertised or injected
   unless the daemon can reach the local `cua-driver` and its read-only

--- a/packages/agent/activity-core/src/controller.test.ts
+++ b/packages/agent/activity-core/src/controller.test.ts
@@ -1529,6 +1529,34 @@ test("loadComposerOptions refetches when cwd changes and caches per cwd", async 
   void afterSwitch;
 });
 
+test("loadComposerOptions refetches when composer settings change", async () => {
+  const requestedModels: Array<string | null | undefined> = [];
+  const controller = createAgentActivityController({
+    adapter: fakeAdapter({
+      loadComposerOptions: async (input) => {
+        requestedModels.push(input.settings?.model);
+        return createComposerOptions({ provider: input.provider });
+      }
+    }),
+    workspaceId: "workspace-1"
+  });
+
+  await controller.loadComposerOptions({
+    provider: "codex",
+    settings: { model: "gpt-5.6-sol" }
+  });
+  await controller.loadComposerOptions({
+    provider: "codex",
+    settings: { model: "gpt-5.6-sol" }
+  });
+  await controller.loadComposerOptions({
+    provider: "codex",
+    settings: { model: "gpt-5.6-luna" }
+  });
+
+  assert.deepEqual(requestedModels, ["gpt-5.6-sol", "gpt-5.6-luna"]);
+});
+
 function fakeAdapter(
   overrides: {
     listSessions?: AgentActivityAdapter["listSessions"];

--- a/packages/agent/activity-core/src/controller.test.ts
+++ b/packages/agent/activity-core/src/controller.test.ts
@@ -1557,6 +1557,71 @@ test("loadComposerOptions refetches when composer settings change", async () => 
   assert.deepEqual(requestedModels, ["gpt-5.6-sol", "gpt-5.6-luna"]);
 });
 
+test("loadComposerOptions refetches when an agent target switches provider", async () => {
+  const requestedProviders: string[] = [];
+  const controller = createAgentActivityController({
+    adapter: fakeAdapter({
+      loadComposerOptions: async (input) => {
+        requestedProviders.push(input.provider);
+        return createComposerOptions({ provider: input.provider });
+      }
+    }),
+    workspaceId: "workspace-1"
+  });
+
+  await controller.loadComposerOptions({
+    agentTargetId: "shared-target",
+    provider: "codex"
+  });
+  await controller.loadComposerOptions({
+    agentTargetId: "shared-target",
+    provider: "claude-code"
+  });
+
+  assert.deepEqual(requestedProviders, ["codex", "claude-code"]);
+});
+
+test("invalidateComposerOptions keeps an in-flight load stale", async () => {
+  const resolvers: Array<(options: AgentActivityComposerOptions) => void> = [];
+  const controller = createAgentActivityController({
+    adapter: fakeAdapter({
+      loadComposerOptions: async () =>
+        new Promise<AgentActivityComposerOptions>((resolve) => {
+          resolvers.push(resolve);
+        })
+    }),
+    workspaceId: "workspace-1"
+  });
+
+  const staleLoad = controller.loadComposerOptions({ provider: "codex" });
+  await waitFor(() => assert.equal(resolvers.length, 1));
+  controller.invalidateComposerOptions({ providers: ["codex"] });
+  const freshLoad = controller.loadComposerOptions({ provider: "codex" });
+  await waitFor(() => assert.equal(resolvers.length, 2));
+
+  resolvers[0]?.(
+    createComposerOptions({
+      models: [{ value: "stale", label: "Stale" }]
+    })
+  );
+  await staleLoad;
+  assert.equal(
+    controller.getSnapshot().composerOptionsByProvider?.codex,
+    undefined
+  );
+
+  resolvers[1]?.(
+    createComposerOptions({
+      models: [{ value: "fresh", label: "Fresh" }]
+    })
+  );
+  await freshLoad;
+  assert.equal(
+    controller.getSnapshot().composerOptionsByProvider?.codex?.models[0]?.value,
+    "fresh"
+  );
+});
+
 function fakeAdapter(
   overrides: {
     listSessions?: AgentActivityAdapter["listSessions"];

--- a/packages/agent/activity-core/src/controller.ts
+++ b/packages/agent/activity-core/src/controller.ts
@@ -80,10 +80,27 @@ export function createAgentActivityController({
     Promise<AgentActivityComposerOptions>
   >();
   const composerOptionsLoadVersions = new Map<string, number>();
-  const composerOptionsCwdByCacheKey = new Map<string, string>();
-  const activeComposerOptionsLoadCwds = new Map<string, string>();
+  const composerOptionsRequestKeyByCacheKey = new Map<string, string>();
+  const activeComposerOptionsLoadRequestKeys = new Map<string, string>();
   const normalizeComposerCwd = (cwd: string | null | undefined): string =>
     (cwd ?? "").trim();
+  const normalizeComposerSetting = (
+    value: string | null | undefined
+  ): string | null => {
+    const normalized = value?.trim() ?? "";
+    return normalized || null;
+  };
+  const composerOptionsRequestKey = (
+    input: Omit<AgentActivityLoadComposerOptionsInput, "workspaceId">
+  ): string =>
+    JSON.stringify([
+      normalizeComposerCwd(input.cwd),
+      normalizeComposerSetting(input.settings?.model),
+      normalizeComposerSetting(input.settings?.reasoningEffort),
+      normalizeComposerSetting(input.settings?.speed),
+      input.settings?.planMode ?? null,
+      normalizeComposerSetting(input.settings?.permissionModeId)
+    ]);
   const composerOptionsProviderCacheKey = (provider: string): string =>
     `provider:${provider}`;
   const composerOptionsTargetCacheKey = (agentTargetId: string): string =>
@@ -168,14 +185,15 @@ export function createAgentActivityController({
       const primaryCacheKey = agentTargetId
         ? composerOptionsTargetCacheKey(agentTargetId)
         : composerOptionsProviderCacheKey(provider);
-      const requestedCwd = normalizeComposerCwd(input.cwd);
+      const requestedRequestKey = composerOptionsRequestKey(input);
       if (!input.force) {
         const cached = agentTargetId
           ? snapshot.composerOptionsByAgentTargetId?.[agentTargetId]
           : snapshot.composerOptionsByProvider?.[provider];
         if (
           cached &&
-          composerOptionsCwdByCacheKey.get(primaryCacheKey) === requestedCwd
+          composerOptionsRequestKeyByCacheKey.get(primaryCacheKey) ===
+            requestedRequestKey
         ) {
           return cloneAgentActivityComposerOptions(cached);
         }
@@ -184,7 +202,8 @@ export function createAgentActivityController({
       if (
         existingLoad &&
         !input.force &&
-        activeComposerOptionsLoadCwds.get(primaryCacheKey) === requestedCwd
+        activeComposerOptionsLoadRequestKeys.get(primaryCacheKey) ===
+          requestedRequestKey
       ) {
         return existingLoad.then(cloneAgentActivityComposerOptions);
       }
@@ -211,7 +230,10 @@ export function createAgentActivityController({
           ) {
             return cloneAgentActivityComposerOptions(normalizedOptions);
           }
-          composerOptionsCwdByCacheKey.set(primaryCacheKey, requestedCwd);
+          composerOptionsRequestKeyByCacheKey.set(
+            primaryCacheKey,
+            requestedRequestKey
+          );
           updateSnapshot((current) => {
             const currentOptions = agentTargetId
               ? current.composerOptionsByAgentTargetId?.[agentTargetId]
@@ -244,11 +266,14 @@ export function createAgentActivityController({
         .finally(() => {
           if (activeComposerOptionsLoads.get(primaryCacheKey) === load) {
             activeComposerOptionsLoads.delete(primaryCacheKey);
-            activeComposerOptionsLoadCwds.delete(primaryCacheKey);
+            activeComposerOptionsLoadRequestKeys.delete(primaryCacheKey);
           }
         });
       activeComposerOptionsLoads.set(primaryCacheKey, load);
-      activeComposerOptionsLoadCwds.set(primaryCacheKey, requestedCwd);
+      activeComposerOptionsLoadRequestKeys.set(
+        primaryCacheKey,
+        requestedRequestKey
+      );
       return load.then(cloneAgentActivityComposerOptions);
     },
     invalidateComposerOptions(input) {
@@ -275,7 +300,7 @@ export function createAgentActivityController({
           staleCacheKeys.add(composerOptionsTargetCacheKey(agentTargetId));
         }
       }
-      for (const cacheKey of composerOptionsCwdByCacheKey.keys()) {
+      for (const cacheKey of composerOptionsRequestKeyByCacheKey.keys()) {
         // Provider cache keys may have no snapshot entry yet (load in flight);
         // match them directly so those are invalidated too.
         if (providers === null) {
@@ -289,7 +314,7 @@ export function createAgentActivityController({
         }
       }
       for (const cacheKey of staleCacheKeys) {
-        composerOptionsCwdByCacheKey.delete(cacheKey);
+        composerOptionsRequestKeyByCacheKey.delete(cacheKey);
       }
     },
     async listSessionMessages({

--- a/packages/agent/activity-core/src/controller.ts
+++ b/packages/agent/activity-core/src/controller.ts
@@ -94,6 +94,7 @@ export function createAgentActivityController({
     input: Omit<AgentActivityLoadComposerOptionsInput, "workspaceId">
   ): string =>
     JSON.stringify([
+      input.provider.trim(),
       normalizeComposerCwd(input.cwd),
       normalizeComposerSetting(input.settings?.model),
       normalizeComposerSetting(input.settings?.reasoningEffort),
@@ -101,6 +102,18 @@ export function createAgentActivityController({
       input.settings?.planMode ?? null,
       normalizeComposerSetting(input.settings?.permissionModeId)
     ]);
+  const composerOptionsProviderFromRequestKey = (
+    requestKey: string
+  ): string | null => {
+    try {
+      const values = JSON.parse(requestKey) as unknown;
+      return Array.isArray(values) && typeof values[0] === "string"
+        ? values[0]
+        : null;
+    } catch {
+      return null;
+    }
+  };
   const composerOptionsProviderCacheKey = (provider: string): string =>
     `provider:${provider}`;
   const composerOptionsTargetCacheKey = (agentTargetId: string): string =>
@@ -313,8 +326,23 @@ export function createAgentActivityController({
           }
         }
       }
+      for (const [
+        cacheKey,
+        requestKey
+      ] of activeComposerOptionsLoadRequestKeys) {
+        if (
+          matchesProvider(composerOptionsProviderFromRequestKey(requestKey))
+        ) {
+          staleCacheKeys.add(cacheKey);
+        }
+      }
       for (const cacheKey of staleCacheKeys) {
         composerOptionsRequestKeyByCacheKey.delete(cacheKey);
+        activeComposerOptionsLoadRequestKeys.delete(cacheKey);
+        composerOptionsLoadVersions.set(
+          cacheKey,
+          (composerOptionsLoadVersions.get(cacheKey) ?? 0) + 1
+        );
       }
     },
     async listSessionMessages({

--- a/packages/agent/gui/agent-gui/agentGuiNode/AgentComposer.spec.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/AgentComposer.spec.tsx
@@ -4266,6 +4266,7 @@ function createLabels(): Parameters<typeof AgentComposer>[0]["labels"] {
     reasoningOptionHigh: "高",
     reasoningOptionXHigh: "超高",
     reasoningOptionMax: "最高",
+    reasoningOptionUltra: "极致",
     speedLabel: "Speed",
     speedSelectionLabel: "Speed",
     speedOptionStandard: "Standard",

--- a/packages/agent/gui/agent-gui/agentGuiNode/AgentComposer.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/AgentComposer.tsx
@@ -255,6 +255,7 @@ export interface AgentComposerProps {
     reasoningOptionHigh: string;
     reasoningOptionXHigh: string;
     reasoningOptionMax: string;
+    reasoningOptionUltra: string;
     speedLabel: string;
     speedSelectionLabel: string;
     speedOptionStandard: string;
@@ -3564,6 +3565,7 @@ export function AgentComposer({
                     reasoningOptionHigh: labels.reasoningOptionHigh,
                     reasoningOptionXHigh: labels.reasoningOptionXHigh,
                     reasoningOptionMax: labels.reasoningOptionMax,
+                    reasoningOptionUltra: labels.reasoningOptionUltra,
                     speedLabel: labels.speedLabel,
                     speedSelectionLabel: labels.speedSelectionLabel,
                     speedOptionStandard: labels.speedOptionStandard,

--- a/packages/agent/gui/agent-gui/agentGuiNode/AgentComposerSettingsMenus.spec.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/AgentComposerSettingsMenus.spec.tsx
@@ -1828,6 +1828,7 @@ const labels = {
   reasoningOptionHigh: "High",
   reasoningOptionXHigh: "X High",
   reasoningOptionMax: "Max",
+  reasoningOptionUltra: "Ultra",
   speedLabel: "Speed",
   speedSelectionLabel: "Speed",
   speedOptionStandard: "Standard",

--- a/packages/agent/gui/agent-gui/agentGuiNode/AgentGUINode.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/AgentGUINode.tsx
@@ -986,6 +986,7 @@ export const AgentGUINode = memo(function AgentGUINode({
       reasoningOptionHigh: t("agentHost.agentGui.reasoningOptionHigh"),
       reasoningOptionXHigh: t("agentHost.agentGui.reasoningOptionXHigh"),
       reasoningOptionMax: t("agentHost.agentGui.reasoningOptionMax"),
+      reasoningOptionUltra: t("agentHost.agentGui.reasoningOptionUltra"),
       speedLabel: t("agentHost.agentGui.speedLabel"),
       speedSelectionLabel: t("agentHost.agentGui.speedSelectionLabel"),
       speedOptionStandard: t("agentHost.agentGui.speedOptionStandard"),

--- a/packages/agent/gui/agent-gui/agentGuiNode/AgentGUINodeView.layout.spec.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/AgentGUINodeView.layout.spec.tsx
@@ -3526,6 +3526,7 @@ function createLabels(): AgentGUIViewLabels {
     reasoningOptionHigh: "reasoningOptionHigh",
     reasoningOptionXHigh: "reasoningOptionXHigh",
     reasoningOptionMax: "reasoningOptionMax",
+    reasoningOptionUltra: "reasoningOptionUltra",
     speedLabel: "Speed",
     speedSelectionLabel: "Speed",
     speedOptionStandard: "Standard",

--- a/packages/agent/gui/agent-gui/agentGuiNode/AgentGUINodeView.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/AgentGUINodeView.tsx
@@ -279,6 +279,7 @@ export interface AgentGUIViewLabels {
   reasoningOptionHigh: string;
   reasoningOptionXHigh: string;
   reasoningOptionMax: string;
+  reasoningOptionUltra: string;
   speedLabel: string;
   speedSelectionLabel: string;
   speedOptionStandard: string;
@@ -2003,6 +2004,7 @@ const AgentGUIDetailPane = memo(function AgentGUIDetailPane({
       reasoningOptionHigh: labels.reasoningOptionHigh,
       reasoningOptionXHigh: labels.reasoningOptionXHigh,
       reasoningOptionMax: labels.reasoningOptionMax,
+      reasoningOptionUltra: labels.reasoningOptionUltra,
       speedLabel: labels.speedLabel,
       speedSelectionLabel: labels.speedSelectionLabel,
       speedOptionStandard: labels.speedOptionStandard,
@@ -2153,6 +2155,7 @@ const AgentGUIDetailPane = memo(function AgentGUIDetailPane({
       labels.reasoningOptionMax,
       labels.reasoningOptionMedium,
       labels.reasoningOptionMinimal,
+      labels.reasoningOptionUltra,
       labels.reasoningOptionXHigh,
       labels.speedLabel,
       labels.speedSelectionLabel,

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/agentGuiController.composerHelpers.spec.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/agentGuiController.composerHelpers.spec.ts
@@ -1,4 +1,5 @@
 import { afterEach, describe, expect, it } from "vitest";
+import type { AgentActivityComposerOptions } from "@tutti-os/agent-activity-core";
 import { setAgentGuiI18nTestLocale } from "../../../i18n/testUtils";
 import type { AgentSessionPermissionConfig } from "../../../shared/agentSessionTypes";
 import type { AgentGUINodeData } from "../../../types";
@@ -7,7 +8,8 @@ import {
   nodeDataFromComposerSettings,
   permissionModeOptions,
   readNodeDefaultDraftPrompt,
-  readNodeDefaultDraftSettings
+  readNodeDefaultDraftSettings,
+  reasoningSelectionFromComposerOptions
 } from "./agentGuiController.composerHelpers";
 
 describe("permissionModeOptions", () => {
@@ -38,6 +40,99 @@ describe("permissionModeOptions", () => {
         description: "仅对检测到的风险操作请求批准"
       }
     ]);
+  });
+});
+
+describe("model reasoning options", () => {
+  afterEach(() => {
+    setAgentGuiI18nTestLocale("en");
+  });
+
+  const composerOptions = {
+    provider: "codex",
+    models: [
+      { value: "gpt-5.6-sol", label: "GPT-5.6-Sol" },
+      { value: "gpt-5.6-luna", label: "GPT-5.6-Luna" }
+    ],
+    reasoningEfforts: [{ value: "high", label: "High" }],
+    speeds: [],
+    skills: [],
+    runtimeContext: {
+      modelReasoningOptionsByModel: {
+        "gpt-5.6-sol": {
+          defaultValue: "low",
+          options: [
+            { value: "low", name: "Low" },
+            { value: "ultra", name: "ultra" }
+          ]
+        },
+        "gpt-5.6-luna": {
+          defaultValue: "medium",
+          options: [
+            { value: "low", name: "Low" },
+            { value: "medium", name: "Medium" }
+          ]
+        }
+      }
+    },
+    loadedAtUnixMs: 1
+  } as unknown as AgentActivityComposerOptions;
+
+  it("switches the list by model without another catalog request", () => {
+    expect(
+      reasoningSelectionFromComposerOptions(
+        composerOptions,
+        "high",
+        "gpt-5.6-sol"
+      )
+    ).toEqual({
+      currentValue: "low",
+      options: [
+        { value: "low", label: "Low" },
+        { value: "ultra", label: "ultra" }
+      ]
+    });
+    expect(
+      reasoningSelectionFromComposerOptions(
+        composerOptions,
+        "ultra",
+        "gpt-5.6-luna"
+      )
+    ).toEqual({
+      currentValue: "medium",
+      options: [
+        { value: "low", label: "Low" },
+        { value: "medium", label: "Medium" }
+      ]
+    });
+  });
+
+  it("prefers the active ACP config options over the home catalog profile", () => {
+    expect(
+      reasoningSelectionFromComposerOptions(
+        composerOptions,
+        "xhigh",
+        "gpt-5.6-sol",
+        {
+          configOptions: [
+            {
+              id: "reasoning_effort",
+              currentValue: "xhigh",
+              options: [
+                { value: "high", name: "High" },
+                { value: "xhigh", name: "X High" }
+              ]
+            }
+          ]
+        }
+      )
+    ).toEqual({
+      currentValue: "xhigh",
+      options: [
+        { value: "high", label: "High" },
+        { value: "xhigh", label: "X High" }
+      ]
+    });
   });
 });
 

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/agentGuiController.composerHelpers.spec.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/agentGuiController.composerHelpers.spec.ts
@@ -72,6 +72,10 @@ describe("model reasoning options", () => {
             { value: "low", name: "Low" },
             { value: "medium", name: "Medium" }
           ]
+        },
+        "no-reasoning": {
+          defaultValue: null,
+          options: []
         }
       }
     },
@@ -128,6 +132,44 @@ describe("model reasoning options", () => {
       )
     ).toEqual({
       currentValue: "xhigh",
+      options: [
+        { value: "high", label: "High" },
+        { value: "xhigh", label: "X High" }
+      ]
+    });
+  });
+
+  it("preserves an authoritative empty model reasoning list", () => {
+    expect(
+      reasoningSelectionFromComposerOptions(
+        composerOptions,
+        "high",
+        "no-reasoning"
+      )
+    ).toEqual({ currentValue: null, options: [] });
+  });
+
+  it("rejects a stale live current value outside the advertised list", () => {
+    expect(
+      reasoningSelectionFromComposerOptions(
+        composerOptions,
+        "ultra",
+        "gpt-5.6-sol",
+        {
+          configOptions: [
+            {
+              id: "reasoning_effort",
+              currentValue: "ultra",
+              options: [
+                { value: "high", name: "High" },
+                { value: "xhigh", name: "X High" }
+              ]
+            }
+          ]
+        }
+      )
+    ).toEqual({
+      currentValue: "high",
       options: [
         { value: "high", label: "High" },
         { value: "xhigh", label: "X High" }

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/agentGuiController.composerHelpers.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/agentGuiController.composerHelpers.ts
@@ -43,6 +43,118 @@ export function composerSettingOptionsFromActivity(
   return options.map((option) => ({ ...option }));
 }
 
+function reasoningOptionsFromRuntimeConfig(
+  runtimeContext: Record<string, unknown> | null | undefined
+): {
+  currentValue: string | null;
+  options: AgentGUIComposerSettingOption[];
+} | null {
+  const configOptions = runtimeContext?.configOptions;
+  if (!Array.isArray(configOptions)) {
+    return null;
+  }
+  for (const rawOption of configOptions) {
+    const option = recordValue(rawOption);
+    const id = normalizeConfigOptionValue(option?.id);
+    if (
+      !option ||
+      !id ||
+      !["reasoning_effort", "model_reasoning_effort", "effort"].includes(id)
+    ) {
+      continue;
+    }
+    const rawEntries = option.options;
+    if (!Array.isArray(rawEntries)) {
+      return null;
+    }
+    const options: AgentGUIComposerSettingOption[] = [];
+    for (const rawEntry of rawEntries) {
+      const entry = recordValue(rawEntry);
+      const value = normalizeConfigOptionValue(entry?.value);
+      if (
+        !entry ||
+        !value ||
+        options.some((candidate) => candidate.value === value)
+      ) {
+        continue;
+      }
+      const label =
+        normalizeConfigOptionValue(entry.name) ??
+        normalizeConfigOptionValue(entry.label) ??
+        value;
+      const description = normalizeConfigOptionValue(entry.description);
+      options.push({
+        value,
+        label,
+        ...(description ? { description } : {})
+      });
+    }
+    return {
+      currentValue: normalizeConfigOptionValue(
+        option.currentValue ?? option.current_value
+      ),
+      options
+    };
+  }
+  return null;
+}
+
+function reasoningProfileForModel(
+  options: AgentActivityComposerOptions | null,
+  model: string | null
+): {
+  defaultValue: string | null;
+  options: AgentGUIComposerSettingOption[];
+} | null {
+  if (!options || !model) {
+    return null;
+  }
+  const profiles = recordValue(
+    options.runtimeContext?.modelReasoningOptionsByModel
+  );
+  const profile = recordValue(profiles?.[model]);
+  if (!profile || !Array.isArray(profile.options)) {
+    return null;
+  }
+  const runtime = reasoningOptionsFromRuntimeConfig({
+    configOptions: [
+      {
+        id: "reasoning_effort",
+        currentValue: profile.defaultValue,
+        options: profile.options
+      }
+    ]
+  });
+  return runtime
+    ? {
+        defaultValue: normalizeConfigOptionValue(profile.defaultValue),
+        options: runtime.options
+      }
+    : null;
+}
+
+export function reasoningSelectionForModelFromComposerOptions(
+  options: AgentActivityComposerOptions | null,
+  currentValue: AgentSessionReasoningEffort | null,
+  selectedModel: string | null
+): ACPConfigOptionSelection | null {
+  const modelProfile = reasoningProfileForModel(options, selectedModel);
+  if (!modelProfile) {
+    return null;
+  }
+  const supportedValues = new Set(
+    modelProfile.options.map((option) => option.value)
+  );
+  return {
+    options: modelProfile.options,
+    currentValue: ((currentValue && supportedValues.has(currentValue)
+      ? currentValue
+      : null) ??
+      modelProfile.defaultValue ??
+      modelProfile.options[0]?.value ??
+      null) as AgentSessionReasoningEffort | null
+  };
+}
 export function modelSelectionFromComposerOptions(
   options: AgentActivityComposerOptions | null,
   currentValue: string | null
@@ -58,14 +170,36 @@ export function modelSelectionFromComposerOptions(
 
 export function reasoningSelectionFromComposerOptions(
   options: AgentActivityComposerOptions | null,
-  currentValue: AgentSessionReasoningEffort | null
+  currentValue: AgentSessionReasoningEffort | null,
+  selectedModel: string | null = null,
+  sessionRuntimeContext: Record<string, unknown> | null = null
 ): ACPConfigOptionSelection | null {
-  if (!options) {
+  const liveConfig = reasoningOptionsFromRuntimeConfig(sessionRuntimeContext);
+  const modelSelection = reasoningSelectionForModelFromComposerOptions(
+    options,
+    currentValue,
+    selectedModel
+  );
+  const sourceOptions = liveConfig?.options.length
+    ? liveConfig.options
+    : modelSelection?.options.length
+      ? modelSelection.options
+      : options
+        ? composerSettingOptionsFromActivity(options.reasoningEfforts)
+        : [];
+  if (!options && sourceOptions.length === 0) {
     return null;
   }
+  const supportedValues = new Set(sourceOptions.map((option) => option.value));
+  const resolvedCurrentValue =
+    (currentValue && supportedValues.has(currentValue) ? currentValue : null) ??
+    liveConfig?.currentValue ??
+    modelSelection?.currentValue ??
+    sourceOptions[0]?.value ??
+    null;
   return {
-    options: composerSettingOptionsFromActivity(options.reasoningEfforts),
-    currentValue
+    options: sourceOptions,
+    currentValue: resolvedCurrentValue as AgentSessionReasoningEffort | null
   };
 }
 

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/agentGuiController.composerHelpers.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/agentGuiController.composerHelpers.ts
@@ -180,22 +180,28 @@ export function reasoningSelectionFromComposerOptions(
     currentValue,
     selectedModel
   );
-  const sourceOptions = liveConfig?.options.length
+  const sourceOptions = liveConfig
     ? liveConfig.options
-    : modelSelection?.options.length
+    : modelSelection
       ? modelSelection.options
       : options
         ? composerSettingOptionsFromActivity(options.reasoningEfforts)
         : [];
-  if (!options && sourceOptions.length === 0) {
+  if (!options && !liveConfig && !modelSelection) {
     return null;
   }
   const supportedValues = new Set(sourceOptions.map((option) => option.value));
+  const supportedValue = (
+    value: AgentSessionReasoningEffort | string | null | undefined
+  ): AgentSessionReasoningEffort | null =>
+    value && supportedValues.has(value)
+      ? (value as AgentSessionReasoningEffort)
+      : null;
   const resolvedCurrentValue =
-    (currentValue && supportedValues.has(currentValue) ? currentValue : null) ??
-    liveConfig?.currentValue ??
-    modelSelection?.currentValue ??
-    sourceOptions[0]?.value ??
+    supportedValue(currentValue) ??
+    supportedValue(liveConfig?.currentValue) ??
+    supportedValue(modelSelection?.currentValue) ??
+    (sourceOptions[0]?.value as AgentSessionReasoningEffort | undefined) ??
     null;
   return {
     options: sourceOptions,

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUINodeController.spec.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUINodeController.spec.tsx
@@ -10368,6 +10368,123 @@ describe("useAgentGUINodeController", () => {
     expect(onDataChange).toHaveBeenCalled();
   });
 
+  it("switches pre-launch reasoning options and draft defaults with the selected model", async () => {
+    const getComposerOptions = vi.fn(async () => ({
+      provider: "codex",
+      effectiveSettings: {
+        model: "gpt-5.6-sol",
+        reasoningEffort: "ultra",
+        speed: null,
+        planMode: false,
+        permissionModeId: "auto"
+      },
+      modelConfig: {
+        configurable: true,
+        options: [
+          { value: "gpt-5.6-sol", name: "GPT-5.6-Sol" },
+          { value: "gpt-5.6-luna", name: "GPT-5.6-Luna" }
+        ]
+      },
+      reasoningConfig: {
+        configurable: true,
+        currentValue: "ultra",
+        options: [
+          { value: "low", name: "Low" },
+          { value: "medium", name: "Medium" },
+          { value: "high", name: "High" },
+          { value: "xhigh", name: "X-High" },
+          { value: "max", name: "Max" },
+          { value: "ultra", name: "ultra" }
+        ]
+      },
+      runtimeContext: {
+        modelReasoningOptionsByModel: {
+          "gpt-5.6-sol": {
+            defaultValue: "low",
+            options: [
+              { value: "low", name: "Low" },
+              { value: "medium", name: "Medium" },
+              { value: "high", name: "High" },
+              { value: "xhigh", name: "X-High" },
+              { value: "max", name: "Max" },
+              { value: "ultra", name: "ultra" }
+            ]
+          },
+          "gpt-5.6-luna": {
+            defaultValue: "medium",
+            options: [
+              { value: "low", name: "Low" },
+              { value: "medium", name: "Medium" },
+              { value: "high", name: "High" },
+              { value: "xhigh", name: "X-High" },
+              { value: "max", name: "Max" }
+            ]
+          }
+        }
+      }
+    }));
+    installAgentHostApi({
+      list: vi.fn(async () => ({ presences: [], sessions: [] })),
+      listSessionTimeline: vi.fn(async () => ({ timelineItems: [] })),
+      subscribeEvents: vi.fn(() => vi.fn()),
+      getComposerOptions
+    });
+
+    const { result } = renderHook(() =>
+      useAgentGUINodeController({
+        workspaceId: "room-1",
+        currentUserId: "user-1",
+        workspacePath: "/workspace",
+        avoidGroupingEdits: false,
+        data: agentGuiData(null, "codex", {
+          composerOverrides: {
+            model: "gpt-5.6-sol",
+            reasoningEffort: "ultra"
+          }
+        }),
+        onDataChange: vi.fn()
+      })
+    );
+
+    await waitFor(() => {
+      expect(
+        result.current.viewModel.composerSettings.availableReasoningEfforts
+      ).toHaveLength(6);
+      expect(
+        result.current.viewModel.composerSettings.availableReasoningEfforts[5]
+      ).toEqual({ value: "ultra", label: "ultra" });
+    });
+
+    act(() => {
+      result.current.actions.updateComposerSettings({
+        model: "gpt-5.6-luna"
+      });
+    });
+
+    await waitFor(() => {
+      expect(
+        result.current.viewModel.composerSettings.availableReasoningEfforts
+      ).toEqual([
+        { value: "low", label: "Low" },
+        { value: "medium", label: "Medium" },
+        { value: "high", label: "High" },
+        { value: "xhigh", label: "X-High" },
+        { value: "max", label: "Max" }
+      ]);
+      expect(
+        result.current.viewModel.composerSettings.draftSettings.reasoningEffort
+      ).toBe("medium");
+      expect(
+        result.current.viewModel.composerSettings.selectedReasoningEffortValue
+      ).toBe("medium");
+    });
+    expect(getComposerOptions).toHaveBeenCalledWith(
+      expect.objectContaining({
+        settings: expect.objectContaining({ model: "gpt-5.6-luna" })
+      })
+    );
+  });
+
   it("keeps pre-launch model options loading until ACP config options are available", async () => {
     installAgentHostApi({
       list: vi.fn(async () => ({ presences: [], sessions: [] })),
@@ -11538,41 +11655,49 @@ describe("useAgentGUINodeController", () => {
         permissionModeId: "preset"
       }
     }));
-    const getComposerOptions = vi.fn(async () => ({
-      provider: "claude-code",
-      runtimeContext: {
-        configOptions: [
-          {
-            id: "model",
-            options: [
-              {
-                value: "default",
-                name: "Default (recommended)",
-                description: "Sonnet 4.6 · Best for everyday tasks"
-              },
-              {
-                value: "opus",
-                name: "Opus",
-                description:
-                  "Opus 4.7 · Most capable for complex work · ~2x usage vs Sonnet"
-              },
-              {
-                value: "haiku",
-                name: "Haiku",
-                description: "Haiku 4.5 · Fastest for quick answers"
-              }
-            ]
-          },
-          {
-            id: "effort",
-            options: [
-              { value: "high", name: "High" },
-              { value: "xhigh", name: "X High" }
-            ]
-          }
-        ]
-      }
-    }));
+    const getComposerOptions = vi.fn(
+      async (input: { settings?: { model?: string | null } }) => ({
+        provider: "claude-code",
+        runtimeContext: {
+          configOptions: [
+            {
+              id: "model",
+              options: [
+                {
+                  value: "default",
+                  name: "Default (recommended)",
+                  description: "Sonnet 4.6 · Best for everyday tasks"
+                },
+                {
+                  value: "opus",
+                  name: "Opus",
+                  description:
+                    "Opus 4.7 · Most capable for complex work · ~2x usage vs Sonnet"
+                },
+                {
+                  value: "haiku",
+                  name: "Haiku",
+                  description: "Haiku 4.5 · Fastest for quick answers"
+                }
+              ]
+            },
+            {
+              id: "effort",
+              options:
+                input.settings?.model === "opus"
+                  ? [
+                      { value: "high", name: "High" },
+                      { value: "xhigh", name: "X High" }
+                    ]
+                  : [
+                      { value: "low", name: "Low" },
+                      { value: "medium", name: "Medium" }
+                    ]
+            }
+          ]
+        }
+      })
+    );
     installAgentHostApi({
       list: vi.fn(async () => ({
         presences: [],
@@ -11631,8 +11756,8 @@ describe("useAgentGUINodeController", () => {
       expect(
         result.current.viewModel.composerSettings.availableReasoningEfforts
       ).toEqual([
-        { value: "high", label: "High" },
-        { value: "xhigh", label: "X High" }
+        { value: "low", label: "Low" },
+        { value: "medium", label: "Medium" }
       ]);
     });
 
@@ -11655,6 +11780,11 @@ describe("useAgentGUINodeController", () => {
         { value: "high", label: "High" },
         { value: "xhigh", label: "X High" }
       ]);
+      expect(getComposerOptions).toHaveBeenCalledWith(
+        expect.objectContaining({
+          settings: expect.objectContaining({ model: "opus" })
+        })
+      );
     });
     expect(result.current.viewModel.composerSettings.selectedModelValue).toBe(
       "opus"
@@ -12490,34 +12620,31 @@ describe("useAgentGUINodeController", () => {
           }
         })
       );
-    const getComposerOptions = vi
-      .fn()
-      .mockResolvedValueOnce({
+    const getComposerOptions = vi.fn(
+      async (input: { settings?: { model?: string | null } }) => ({
         provider: "codex",
         runtimeContext: {
-          configOptions: [
-            {
-              id: "model",
-              options: [{ value: "gpt-old", name: "GPT old" }]
-            }
-          ]
+          configOptions:
+            input.settings?.model === "gpt-new"
+              ? [
+                  {
+                    id: "model",
+                    options: [{ value: "gpt-new", name: "GPT new" }]
+                  },
+                  {
+                    id: "reasoning_effort",
+                    options: [{ value: "medium", name: "Medium" }]
+                  }
+                ]
+              : [
+                  {
+                    id: "model",
+                    options: [{ value: "gpt-old", name: "GPT old" }]
+                  }
+                ]
         }
       })
-      .mockResolvedValue({
-        provider: "codex",
-        runtimeContext: {
-          configOptions: [
-            {
-              id: "model",
-              options: [{ value: "gpt-new", name: "GPT new" }]
-            },
-            {
-              id: "reasoning_effort",
-              options: [{ value: "medium", name: "Medium" }]
-            }
-          ]
-        }
-      });
+    );
     installAgentHostApi({
       list: vi.fn(async () => ({
         presences: [],

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUINodeController.spec.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUINodeController.spec.tsx
@@ -11600,7 +11600,9 @@ describe("useAgentGUINodeController", () => {
         agentSessionState("session-1", {
           provider: "claude-code",
           settings: {
-            model: "opus",
+            // Simulate the control-state settings lagging behind ACP's live
+            // model config after the switch.
+            model: "haiku",
             reasoningEffort: "xhigh",
             speed: null,
             planMode: false,

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUINodeController.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUINodeController.ts
@@ -187,6 +187,8 @@ import {
   nodeDataFromComposerSettings,
   normalizeConfigOptionValue,
   normalizePermissionModeId,
+  reasoningSelectionForModelFromComposerOptions,
+  reasoningSelectionFromComposerOptions,
   resolveEffectiveComposerSettings,
   sameComposerSettings
 } from "./agentGuiController.composerHelpers";
@@ -437,13 +439,22 @@ function sanitizeComposerSettingsForOptions(
     return settings;
   }
   const modelValues = composerOptionValues(options.models);
-  const reasoningValues = composerOptionValues(options.reasoningEfforts);
+  const model = normalizeOptionalText(settings.model);
+  const reasoningEffort = normalizeOptionalText(
+    settings.reasoningEffort
+  ) as AgentSessionReasoningEffort | null;
+  const modelReasoningSelection = reasoningSelectionForModelFromComposerOptions(
+    options,
+    reasoningEffort,
+    model
+  );
+  const reasoningValues = composerOptionValues(
+    modelReasoningSelection?.options ?? options.reasoningEfforts
+  );
   const speedValues = composerOptionValues(options.speeds ?? []);
   const permissionValues = new Set(
     options.permissionConfig?.modes.map((mode) => mode.id) ?? []
   );
-  const model = normalizeOptionalText(settings.model);
-  const reasoningEffort = normalizeOptionalText(settings.reasoningEffort);
   const speed = normalizeOptionalText(settings.speed);
   const permissionModeId = normalizePermissionModeId(settings.permissionModeId);
   const modelOptionsAreAuthoritative = options.provider === "claude-code";
@@ -460,7 +471,7 @@ function sanitizeComposerSettingsForOptions(
       reasoningEffort &&
       reasoningValues.size > 0 &&
       !reasoningValues.has(reasoningEffort)
-        ? null
+        ? (modelReasoningSelection?.currentValue ?? null)
         : (reasoningEffort as AgentSessionReasoningEffort | null),
     speed:
       speed && speedValues.size > 0 && !speedValues.has(speed)
@@ -2480,19 +2491,6 @@ function configOptionCurrentValue(
     );
   }
   return null;
-}
-
-function reasoningSelectionFromComposerOptions(
-  options: AgentActivityComposerOptions | null,
-  currentValue: AgentSessionReasoningEffort | null
-): ACPConfigOptionSelection | null {
-  if (!options) {
-    return null;
-  }
-  return {
-    options: composerSettingOptionsFromActivity(options.reasoningEfforts),
-    currentValue
-  };
 }
 
 function speedSelectionFromComposerOptions(
@@ -6276,11 +6274,17 @@ export function useAgentGUINodeController({
       if (isCreatingConversationRef.current) {
         return;
       }
-      const settings = readNodeDefaultDraftSettings({
+      const defaultDraftSettings = readNodeDefaultDraftSettings({
         data: targetData.data,
         defaultReasoningEffort,
         drafts: draftSettingsBySessionIdRef.current
       });
+      const activeAgentSessionId = activeConversationIdRef.current;
+      const activeSessionSettings = activeAgentSessionId
+        ? (getAgentSessionView(sessionViewRef(activeAgentSessionId))
+            ?.controlState?.settings ?? null)
+        : null;
+      const settings = activeSessionSettings ?? defaultDraftSettings;
       const composerOptionsCwd =
         selectedProjectPathRef.current?.trim() || workspacePath.trim() || "";
       void Promise.resolve(
@@ -6294,7 +6298,13 @@ export function useAgentGUINodeController({
         })
       ).catch(() => undefined);
     },
-    [agentActivityRuntime, defaultReasoningEffort, workspaceId, workspacePath]
+    [
+      agentActivityRuntime,
+      defaultReasoningEffort,
+      sessionViewRef,
+      workspaceId,
+      workspacePath
+    ]
   );
   const loadDraftComposerOptions = useCallback(
     (options?: { force?: boolean }): void => {
@@ -6389,6 +6399,7 @@ export function useAgentGUINodeController({
     );
   }, [
     activeConversationId,
+    activeSessionState?.settings?.model,
     composerTargetData.agentTargetId,
     composerTargetData.provider,
     isComposerHome,
@@ -10701,9 +10712,16 @@ export function useAgentGUINodeController({
     () =>
       reasoningSelectionFromComposerOptions(
         providerComposerOptions,
-        draftReasoningEffort
+        draftReasoningEffort,
+        draftModel,
+        activeSessionRuntimeContext ?? null
       ),
-    [draftReasoningEffort, providerComposerOptions]
+    [
+      activeSessionRuntimeContext,
+      draftModel,
+      draftReasoningEffort,
+      providerComposerOptions
+    ]
   );
   const activeSessionModelSelection = useMemo(
     () =>
@@ -10743,7 +10761,7 @@ export function useAgentGUINodeController({
     );
     const selectedModelValue = draftModel;
     const selectedReasoningEffortValue =
-      draftReasoningEffort as AgentSessionReasoningEffort | null;
+      activeSessionReasoningSelection?.currentValue ?? draftReasoningEffort;
     const selectedSpeedValue = draftSpeed as AgentSessionSpeed | null;
     const selectedPermissionModeValue =
       normalizePermissionModeId(draftSettings.permissionModeId) ??

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUINodeController.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUINodeController.ts
@@ -3996,6 +3996,10 @@ export function useAgentGUINodeController({
     sessionRuntimeContext: activeSessionState?.runtimeContext
   });
   const activeSessionRuntimeContext = activeSessionState?.runtimeContext;
+  const activeSessionRuntimeModel = configOptionCurrentValue(
+    activeSessionRuntimeContext,
+    ["model"]
+  );
   const backgroundAgentCount = useMemo(
     () => activeBackgroundAgentCount(activeSessionRuntimeContext),
     [activeSessionRuntimeContext]
@@ -6280,11 +6284,21 @@ export function useAgentGUINodeController({
         drafts: draftSettingsBySessionIdRef.current
       });
       const activeAgentSessionId = activeConversationIdRef.current;
-      const activeSessionSettings = activeAgentSessionId
+      const activeControlState = activeAgentSessionId
         ? (getAgentSessionView(sessionViewRef(activeAgentSessionId))
-            ?.controlState?.settings ?? null)
+            ?.controlState ?? null)
         : null;
-      const settings = activeSessionSettings ?? defaultDraftSettings;
+      const activeSessionSettings = activeControlState?.settings ?? null;
+      const activeRuntimeModel = configOptionCurrentValue(
+        activeControlState?.runtimeContext,
+        ["model"]
+      );
+      const settings = activeSessionSettings
+        ? {
+            ...activeSessionSettings,
+            ...(activeRuntimeModel ? { model: activeRuntimeModel } : {})
+          }
+        : defaultDraftSettings;
       const composerOptionsCwd =
         selectedProjectPathRef.current?.trim() || workspacePath.trim() || "";
       void Promise.resolve(
@@ -6399,7 +6413,12 @@ export function useAgentGUINodeController({
     );
   }, [
     activeConversationId,
+    activeSessionRuntimeModel,
     activeSessionState?.settings?.model,
+    activeSessionState?.settings?.permissionModeId,
+    activeSessionState?.settings?.planMode,
+    activeSessionState?.settings?.reasoningEffort,
+    activeSessionState?.settings?.speed,
     composerTargetData.agentTargetId,
     composerTargetData.provider,
     isComposerHome,

--- a/packages/agent/gui/agent-gui/agentGuiNode/model/composerSettingsMenuModel.spec.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/model/composerSettingsMenuModel.spec.ts
@@ -23,6 +23,7 @@ const labels: AgentComposerSettingsMenuLabels = {
   reasoningOptionHigh: "High",
   reasoningOptionXHigh: "X-High",
   reasoningOptionMax: "Max",
+  reasoningOptionUltra: "Ultra",
   speedLabel: "Speed",
   speedSelectionLabel: "Speed",
   speedOptionStandard: "Standard",
@@ -73,7 +74,8 @@ function vm(
       { value: "default", label: "Default" },
       { value: "low", label: "Low" },
       { value: "high", label: "High" },
-      { value: "max", label: "Max" }
+      { value: "max", label: "Max" },
+      { value: "ultra", label: "ultra" }
     ],
     ...overrides
   };
@@ -105,7 +107,8 @@ describe("buildComposerModelMenuModel", () => {
       { value: "default", label: "Default" },
       { value: "low", label: "Low" },
       { value: "high", label: "High" },
-      { value: "max", label: "Max" }
+      { value: "max", label: "Max" },
+      { value: "ultra", label: "Ultra" }
     ]);
 
     expect(menu.speed.show).toBe(true);
@@ -118,6 +121,26 @@ describe("buildComposerModelMenuModel", () => {
       },
       { value: "fast", label: "Fast", description: "Fast localized" }
     ]);
+  });
+
+  it("localizes ultra in the final menu presentation", () => {
+    const menu = buildComposerModelMenuModel(
+      vm({
+        draftSettings: {
+          model: "gpt-5.5",
+          reasoningEffort: "ultra",
+          speed: "standard",
+          planMode: false,
+          permissionModeId: "preset"
+        },
+        selectedReasoningEffortValue: "ultra",
+        availableReasoningEfforts: [{ value: "ultra", label: "ultra" }]
+      }),
+      { ...labels, reasoningOptionUltra: "极致" }
+    );
+
+    expect(menu.reasoning.selectedLabel).toBe("极致");
+    expect(menu.reasoning.options).toEqual([{ value: "ultra", label: "极致" }]);
   });
 
   it("marks the trigger as fast and localizes model descriptions", () => {

--- a/packages/agent/gui/agent-gui/agentGuiNode/model/composerSettingsMenuModel.spec.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/model/composerSettingsMenuModel.spec.ts
@@ -143,6 +143,27 @@ describe("buildComposerModelMenuModel", () => {
     expect(menu.reasoning.options).toEqual([{ value: "ultra", label: "极致" }]);
   });
 
+  it("localizes ultra effort in model summaries", () => {
+    const menu = buildComposerModelMenuModel(
+      vm({
+        availableModels: [
+          {
+            value: "gpt-5.6-sol",
+            label: "GPT-5.6-Sol",
+            description: "GPT-5.6 Sol · ultra effort"
+          }
+        ],
+        selectedModelValue: "gpt-5.6-sol"
+      }),
+      labels
+    );
+
+    expect(menu.model.options[0]).toMatchObject({
+      summary: ["Ultra"],
+      tooltip: { version: "Version: ultra effort" }
+    });
+  });
+
   it("marks the trigger as fast and localizes model descriptions", () => {
     const menu = buildComposerModelMenuModel(
       vm({

--- a/packages/agent/gui/agent-gui/agentGuiNode/model/composerSettingsMenuModel.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/model/composerSettingsMenuModel.ts
@@ -20,6 +20,7 @@ export type AgentComposerSettingsMenuLabels = {
   reasoningOptionHigh: string;
   reasoningOptionXHigh: string;
   reasoningOptionMax: string;
+  reasoningOptionUltra: string;
   speedLabel: string;
   speedSelectionLabel: string;
   speedOptionStandard: string;
@@ -206,6 +207,7 @@ function modelOptionPresentation(input: {
     | "reasoningOptionHigh"
     | "reasoningOptionXHigh"
     | "reasoningOptionMax"
+    | "reasoningOptionUltra"
     | "speedOptionFast"
   >;
 }): {
@@ -270,6 +272,7 @@ function reasoningSummaryLabel(
     | "reasoningOptionHigh"
     | "reasoningOptionXHigh"
     | "reasoningOptionMax"
+    | "reasoningOptionUltra"
   >
 ): string {
   return resolveReasoningOptionLabel(effort, labels);
@@ -479,6 +482,7 @@ export function resolveReasoningOptionLabel(
     | "reasoningOptionHigh"
     | "reasoningOptionXHigh"
     | "reasoningOptionMax"
+    | "reasoningOptionUltra"
   >
 ): string {
   switch (value) {
@@ -496,6 +500,8 @@ export function resolveReasoningOptionLabel(
       return labels.reasoningOptionXHigh;
     case "max":
       return labels.reasoningOptionMax;
+    case "ultra":
+      return labels.reasoningOptionUltra;
     default:
       return value;
   }

--- a/packages/agent/gui/agent-gui/agentGuiNode/model/composerSettingsMenuModel.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/model/composerSettingsMenuModel.ts
@@ -350,7 +350,7 @@ function effortFromText(
 ): { summaryValue: string; version: string } | undefined {
   const effortMatch = text
     .toLowerCase()
-    .match(/\b(minimal|low|medium|high|x[-\s]?high)\s+effort\b/);
+    .match(/\b(minimal|low|medium|high|x[-\s]?high|max|ultra)\s+effort\b/);
   if (!effortMatch?.[1]) {
     return undefined;
   }

--- a/packages/agent/gui/app/renderer/i18n/locales/en.ts
+++ b/packages/agent/gui/app/renderer/i18n/locales/en.ts
@@ -401,6 +401,7 @@ export const en = {
       reasoningOptionHigh: "High",
       reasoningOptionXHigh: "X-High",
       reasoningOptionMax: "Max",
+      reasoningOptionUltra: "Ultra",
       speedLabel: "Speed",
       speedSelectionLabel: "Speed",
       speedOptionStandard: "Standard",

--- a/packages/agent/gui/app/renderer/i18n/locales/zh-CN.ts
+++ b/packages/agent/gui/app/renderer/i18n/locales/zh-CN.ts
@@ -372,6 +372,7 @@ export const zhCN = {
       reasoningOptionHigh: "高",
       reasoningOptionXHigh: "超高",
       reasoningOptionMax: "最高",
+      reasoningOptionUltra: "极致",
       speedLabel: "速度",
       speedSelectionLabel: "速度",
       speedOptionStandard: "标准",

--- a/services/tuttid/service/agent/codex_model_catalog.go
+++ b/services/tuttid/service/agent/codex_model_catalog.go
@@ -247,11 +247,45 @@ func normalizeCodexModel(raw json.RawMessage) (AgentModelOption, bool) {
 		displayName = id
 	}
 	return AgentModelOption{
-		ID:          id,
-		DisplayName: displayName,
-		Description: stringMapValue(object, "description"),
-		IsDefault:   boolMapValue(object, "isDefault") || boolMapValue(object, "is_default"),
+		ID:                        id,
+		DisplayName:               displayName,
+		Description:               stringMapValue(object, "description"),
+		DefaultReasoningEffort:    firstNonEmptyString(stringMapValue(object, "defaultReasoningEffort"), stringMapValue(object, "default_reasoning_effort")),
+		IsDefault:                 boolMapValue(object, "isDefault") || boolMapValue(object, "is_default"),
+		SupportedReasoningEfforts: normalizeCodexReasoningEfforts(object["supportedReasoningEfforts"]),
 	}, true
+}
+
+func normalizeCodexReasoningEfforts(value any) []AgentModelReasoningEffortOption {
+	rawOptions, ok := value.([]any)
+	if !ok {
+		return nil
+	}
+	options := make([]AgentModelReasoningEffortOption, 0, len(rawOptions))
+	seen := make(map[string]struct{}, len(rawOptions))
+	for _, rawOption := range rawOptions {
+		var option AgentModelReasoningEffortOption
+		switch typed := rawOption.(type) {
+		case string:
+			option.Value = strings.TrimSpace(typed)
+		case map[string]any:
+			option.Value = firstNonEmptyString(
+				stringMapValue(typed, "reasoningEffort"),
+				stringMapValue(typed, "effort"),
+				stringMapValue(typed, "value"),
+			)
+			option.Description = stringMapValue(typed, "description")
+		}
+		if option.Value == "" {
+			continue
+		}
+		if _, exists := seen[option.Value]; exists {
+			continue
+		}
+		seen[option.Value] = struct{}{}
+		options = append(options, option)
+	}
+	return options
 }
 
 func stringMapValue(object map[string]any, key string) string {

--- a/services/tuttid/service/agent/codex_model_catalog.go
+++ b/services/tuttid/service/agent/codex_model_catalog.go
@@ -246,13 +246,18 @@ func normalizeCodexModel(raw json.RawMessage) (AgentModelOption, bool) {
 	if displayName == "" {
 		displayName = id
 	}
+	reasoningEffortsValue, reasoningEffortsAdvertised := object["supportedReasoningEfforts"]
+	if !reasoningEffortsAdvertised {
+		reasoningEffortsValue, reasoningEffortsAdvertised = object["supported_reasoning_efforts"]
+	}
 	return AgentModelOption{
-		ID:                        id,
-		DisplayName:               displayName,
-		Description:               stringMapValue(object, "description"),
-		DefaultReasoningEffort:    firstNonEmptyString(stringMapValue(object, "defaultReasoningEffort"), stringMapValue(object, "default_reasoning_effort")),
-		IsDefault:                 boolMapValue(object, "isDefault") || boolMapValue(object, "is_default"),
-		SupportedReasoningEfforts: normalizeCodexReasoningEfforts(object["supportedReasoningEfforts"]),
+		ID:                         id,
+		DisplayName:                displayName,
+		Description:                stringMapValue(object, "description"),
+		DefaultReasoningEffort:     firstNonEmptyString(stringMapValue(object, "defaultReasoningEffort"), stringMapValue(object, "default_reasoning_effort")),
+		IsDefault:                  boolMapValue(object, "isDefault") || boolMapValue(object, "is_default"),
+		ReasoningEffortsAdvertised: reasoningEffortsAdvertised,
+		SupportedReasoningEfforts:  normalizeCodexReasoningEfforts(reasoningEffortsValue),
 	}, true
 }
 

--- a/services/tuttid/service/agent/codex_model_catalog_test.go
+++ b/services/tuttid/service/agent/codex_model_catalog_test.go
@@ -14,7 +14,7 @@ func TestCodexCLIModelListerReadsModelListFromAppServer(t *testing.T) {
 while IFS= read -r line; do
   case "$line" in
     *model/list*)
-      echo '{"id":"2","result":{"data":[{"id":"gpt-5","displayName":"GPT-5","description":"default","isDefault":true},{"model":"gpt-5.1"}]}}'
+      echo '{"id":"2","result":{"data":[{"id":"gpt-5","displayName":"GPT-5","description":"default","isDefault":true,"defaultReasoningEffort":"medium","supportedReasoningEfforts":[{"reasoningEffort":"medium","description":"Balanced"},{"reasoningEffort":"ultra","description":"Maximum reasoning with automatic task delegation"}]},{"model":"gpt-5.1"}]}}'
       sleep 10
       exit 0
       ;;
@@ -38,6 +38,14 @@ done
 	}
 	if models[0].ID != "gpt-5" || models[0].DisplayName != "GPT-5" || !models[0].IsDefault {
 		t.Fatalf("first model = %#v", models[0])
+	}
+	if models[0].DefaultReasoningEffort != "medium" {
+		t.Fatalf("first model default reasoning effort = %q, want medium", models[0].DefaultReasoningEffort)
+	}
+	if len(models[0].SupportedReasoningEfforts) != 2 ||
+		models[0].SupportedReasoningEfforts[1].Value != "ultra" ||
+		models[0].SupportedReasoningEfforts[1].Description != "Maximum reasoning with automatic task delegation" {
+		t.Fatalf("first model reasoning efforts = %#v", models[0].SupportedReasoningEfforts)
 	}
 	if models[1].ID != "gpt-5.1" || models[1].DisplayName != "gpt-5.1" {
 		t.Fatalf("second model = %#v", models[1])

--- a/services/tuttid/service/agent/codex_model_catalog_test.go
+++ b/services/tuttid/service/agent/codex_model_catalog_test.go
@@ -42,6 +42,9 @@ done
 	if models[0].DefaultReasoningEffort != "medium" {
 		t.Fatalf("first model default reasoning effort = %q, want medium", models[0].DefaultReasoningEffort)
 	}
+	if !models[0].ReasoningEffortsAdvertised {
+		t.Fatal("first model reasoning efforts advertised = false, want true")
+	}
 	if len(models[0].SupportedReasoningEfforts) != 2 ||
 		models[0].SupportedReasoningEfforts[1].Value != "ultra" ||
 		models[0].SupportedReasoningEfforts[1].Description != "Maximum reasoning with automatic task delegation" {
@@ -49,6 +52,22 @@ done
 	}
 	if models[1].ID != "gpt-5.1" || models[1].DisplayName != "gpt-5.1" {
 		t.Fatalf("second model = %#v", models[1])
+	}
+	if models[1].ReasoningEffortsAdvertised {
+		t.Fatal("second model reasoning efforts advertised = true, want false")
+	}
+}
+
+func TestNormalizeCodexModelPreservesAdvertisedEmptyReasoningEfforts(t *testing.T) {
+	model, ok := normalizeCodexModel([]byte(`{"id":"no-reasoning","supportedReasoningEfforts":[]}`))
+	if !ok {
+		t.Fatal("normalizeCodexModel ok = false")
+	}
+	if !model.ReasoningEffortsAdvertised {
+		t.Fatal("ReasoningEffortsAdvertised = false, want true")
+	}
+	if model.SupportedReasoningEfforts == nil || len(model.SupportedReasoningEfforts) != 0 {
+		t.Fatalf("SupportedReasoningEfforts = %#v, want advertised empty list", model.SupportedReasoningEfforts)
 	}
 }
 

--- a/services/tuttid/service/agent/composer_options.go
+++ b/services/tuttid/service/agent/composer_options.go
@@ -146,12 +146,13 @@ func (s *Service) GetComposerOptions(ctx context.Context, input ComposerOptionsI
 	locale := normalizeComposerLocale(input.Locale)
 	permissionConfig := composerPermissionConfig(provider, effectiveSettings.PermissionModeID, locale)
 	modelOptions := composerSelectedModelOptions(effectiveSettings.Model)
+	reasoningOptions := composerReasoningOptionValues(provider, effectiveSettings.ReasoningEffort, locale)
 	if provider == agentprovider.ClaudeCode {
 		modelOptions = []map[string]string{}
 	}
 	runtimeContext := map[string]any{
 		"capabilities":     composerProviderCapabilities(provider),
-		"configOptions":    composerConfigOptions(provider, effectiveSettings, modelOptions),
+		"configOptions":    composerConfigOptions(provider, effectiveSettings, modelOptions, reasoningOptions),
 		"model":            nullableString(effectiveSettings.Model),
 		"permissionModeId": nullableString(effectiveSettings.PermissionModeID),
 		"reasoningEffort":  nullableString(effectiveSettings.ReasoningEffort),
@@ -172,17 +173,48 @@ func (s *Service) GetComposerOptions(ctx context.Context, input ComposerOptionsI
 		runtimeContext["capabilityCatalogErrors"] = capabilityErrors
 	}
 	if composerOptionsProviderUsesModelCatalog(provider) {
-		if catalogOptions, source, ok := composerModelOptionsFromCatalog(ctx, s.ModelCatalog, provider, effectiveSettings.Model); ok {
-			modelOptions = catalogOptions
-			runtimeContext["configOptions"] = composerConfigOptions(provider, effectiveSettings, catalogOptions)
-			runtimeContext["modelCatalogSource"] = source
+		if catalogOptions, ok := composerModelOptionsFromCatalog(ctx, s.ModelCatalog, provider, effectiveSettings.Model); ok {
+			modelOptions = catalogOptions.ModelOptions
+			if modelReasoningOptions := composerModelReasoningOptionsRuntimeContext(
+				provider,
+				locale,
+				catalogOptions.ReasoningProfiles,
+			); len(modelReasoningOptions) > 0 {
+				runtimeContext["modelReasoningOptionsByModel"] = modelReasoningOptions
+			}
+			if len(catalogOptions.ReasoningEfforts) > 0 {
+				requestedReasoningEffort := effectiveSettings.ReasoningEffort
+				if settings.ReasoningEffort == "" {
+					requestedReasoningEffort = ""
+				}
+				effectiveSettings.ReasoningEffort = resolveAdvertisedReasoningEffort(
+					provider,
+					requestedReasoningEffort,
+					catalogOptions.DefaultReasoningEffort,
+					catalogOptions.ReasoningEfforts,
+				)
+				reasoningOptions = composerAdvertisedReasoningOptionValues(
+					provider,
+					effectiveSettings.ReasoningEffort,
+					locale,
+					catalogOptions.ReasoningEfforts,
+				)
+			}
+			runtimeContext["reasoningEffort"] = nullableString(effectiveSettings.ReasoningEffort)
+			runtimeContext["configOptions"] = composerConfigOptions(
+				provider,
+				effectiveSettings,
+				modelOptions,
+				reasoningOptions,
+			)
+			runtimeContext["modelCatalogSource"] = catalogOptions.Source
 		}
 	}
 	options := ComposerOptions{
 		Provider:          provider,
 		ModelConfig:       composerModelConfig(provider, effectiveSettings.Model, modelOptions),
 		PermissionConfig:  permissionConfig,
-		ReasoningConfig:   composerReasoningConfig(provider, effectiveSettings.ReasoningEffort, locale),
+		ReasoningConfig:   composerReasoningConfigFromOptions(provider, effectiveSettings.ReasoningEffort, reasoningOptions),
 		SpeedConfig:       composerSpeedConfig(provider, effectiveSettings.Speed, locale),
 		EffectiveSettings: effectiveSettings,
 		RuntimeContext:    runtimeContext,
@@ -318,7 +350,12 @@ func composerDefaultModel(
 	}
 }
 
-func composerConfigOptions(provider string, settings ComposerSettings, modelOptions []map[string]string) []map[string]any {
+func composerConfigOptions(
+	provider string,
+	settings ComposerSettings,
+	modelOptions []map[string]string,
+	reasoningOptions []ComposerConfigOptionValue,
+) []map[string]any {
 	if !composerOptionsProviderSupportsSettings(provider) {
 		return []map[string]any{}
 	}
@@ -336,7 +373,7 @@ func composerConfigOptions(provider string, settings ComposerSettings, modelOpti
 	options = append(options, map[string]any{
 		"currentValue": nullableString(settings.ReasoningEffort),
 		"id":           reasoningConfigOptionID(provider),
-		"options":      reasoningEffortOptions(provider, settings.ReasoningEffort),
+		"options":      composerReasoningOptionValuesToRuntimeOptions(reasoningOptions),
 	})
 	if speedProviderSupportsSpeed(provider) {
 		options = append(options, map[string]any{
@@ -596,39 +633,22 @@ func composerModelConfig(provider string, selected string, options []map[string]
 	}
 }
 
-func composerReasoningConfig(provider string, selected string, locale string) ComposerConfigOption {
-	values := reasoningEffortValuesForProvider(provider)
-	options := make([]ComposerConfigOptionValue, 0, len(values)+1)
-	containsSelected := false
-	for _, value := range values {
-		if value == selected {
-			containsSelected = true
-		}
-		options = append(options, ComposerConfigOptionValue{
-			ID:    value,
-			Label: reasoningEffortLabel(value, locale),
-			Value: value,
-		})
-	}
-	selected = normalizeReasoningEffortForProvider(provider, selected)
-	if selected != "" && !containsSelected {
-		options = append(options, ComposerConfigOptionValue{
-			ID:    selected,
-			Label: reasoningEffortLabel(selected, locale),
-			Value: selected,
-		})
-	}
-	return ComposerConfigOption{
-		Configurable: composerOptionsProviderSupportsSettings(provider),
-		CurrentValue: selected,
-		DefaultValue: selected,
-		Options:      options,
-	}
+type composerModelCatalogOptions struct {
+	DefaultReasoningEffort string
+	ModelOptions           []map[string]string
+	ReasoningProfiles      map[string]composerModelReasoningProfile
+	ReasoningEfforts       []AgentModelReasoningEffortOption
+	Source                 string
 }
 
-func composerModelOptionsFromCatalog(ctx context.Context, catalog AgentModelCatalog, provider string, selectedModel string) ([]map[string]string, string, bool) {
+func composerModelOptionsFromCatalog(
+	ctx context.Context,
+	catalog AgentModelCatalog,
+	provider string,
+	selectedModel string,
+) (composerModelCatalogOptions, bool) {
 	if catalog == nil {
-		return nil, "", false
+		return composerModelCatalogOptions{}, false
 	}
 	result, err := catalog.ListModels(ctx, provider)
 	if err != nil {
@@ -639,9 +659,11 @@ func composerModelOptionsFromCatalog(ctx context.Context, catalog AgentModelCata
 			"provider", provider,
 			"error", err,
 		)
-		return nil, "", false
+		return composerModelCatalogOptions{}, false
 	}
 	options := make([]map[string]string, 0, len(result.Models)+1)
+	reasoningProfiles := make(map[string]composerModelReasoningProfile)
+	var selectedCatalogModel *AgentModelOption
 	for _, model := range result.Models {
 		id := strings.TrimSpace(model.ID)
 		if id == "" {
@@ -658,12 +680,37 @@ func composerModelOptionsFromCatalog(ctx context.Context, catalog AgentModelCata
 			"name":  name,
 			"value": id,
 		})
+		if len(model.SupportedReasoningEfforts) > 0 {
+			reasoningProfiles[id] = composerModelReasoningProfile{
+				DefaultReasoningEffort: strings.TrimSpace(model.DefaultReasoningEffort),
+				ReasoningEfforts: append(
+					[]AgentModelReasoningEffortOption(nil),
+					model.SupportedReasoningEfforts...,
+				),
+			}
+		}
+		if id == strings.TrimSpace(selectedModel) {
+			selected := model
+			selectedCatalogModel = &selected
+		}
 	}
 	selected := strings.TrimSpace(selectedModel)
 	if selected != "" && !containsModelOption(options, selected) {
 		options = append(options, map[string]string{"name": selected, "value": selected})
 	}
-	return options, strings.TrimSpace(result.Source), true
+	catalogOptions := composerModelCatalogOptions{
+		ModelOptions:      options,
+		ReasoningProfiles: reasoningProfiles,
+		Source:            strings.TrimSpace(result.Source),
+	}
+	if selectedCatalogModel != nil {
+		catalogOptions.DefaultReasoningEffort = strings.TrimSpace(selectedCatalogModel.DefaultReasoningEffort)
+		catalogOptions.ReasoningEfforts = append(
+			[]AgentModelReasoningEffortOption(nil),
+			selectedCatalogModel.SupportedReasoningEfforts...,
+		)
+	}
+	return catalogOptions, true
 }
 
 func containsModelOption(options []map[string]string, value string) bool {
@@ -773,46 +820,4 @@ func composerSpeedConfig(provider string, selected string, locale string) Compos
 		DefaultValue: selected,
 		Options:      options,
 	}
-}
-
-func reasoningEffortOptions(provider string, selected string) []map[string]string {
-	values := reasoningEffortValuesForProvider(provider)
-	options := make([]map[string]string, 0, len(values)+1)
-	containsSelected := false
-	for _, value := range values {
-		if value == selected {
-			containsSelected = true
-		}
-		options = append(options, map[string]string{
-			"name":  reasoningEffortLabel(value, preferencesbiz.DefaultDesktopLocale),
-			"value": value,
-		})
-	}
-	selected = normalizeReasoningEffortForProvider(provider, selected)
-	if selected != "" && !containsSelected {
-		options = append(options, map[string]string{
-			"name":  reasoningEffortLabel(selected, preferencesbiz.DefaultDesktopLocale),
-			"value": selected,
-		})
-	}
-	return options
-}
-
-func reasoningEffortValuesForProvider(provider string) []string {
-	if provider == agentprovider.Codex || provider == agentprovider.ClaudeCode {
-		return []string{"low", "medium", "high", "xhigh"}
-	}
-	return []string{"minimal", "low", "medium", "high", "xhigh"}
-}
-
-func normalizeReasoningEffortForProvider(provider string, value string) string {
-	provider = agentprovider.Normalize(provider)
-	if !agentprovider.SupportsComposerSettings(provider) {
-		return ""
-	}
-	normalized := strings.TrimSpace(value)
-	if (provider == agentprovider.Codex || provider == agentprovider.ClaudeCode) && normalized == "minimal" {
-		return "high"
-	}
-	return normalized
 }

--- a/services/tuttid/service/agent/composer_options.go
+++ b/services/tuttid/service/agent/composer_options.go
@@ -182,7 +182,7 @@ func (s *Service) GetComposerOptions(ctx context.Context, input ComposerOptionsI
 			); len(modelReasoningOptions) > 0 {
 				runtimeContext["modelReasoningOptionsByModel"] = modelReasoningOptions
 			}
-			if len(catalogOptions.ReasoningEfforts) > 0 {
+			if catalogOptions.ReasoningEffortsAdvertised {
 				requestedReasoningEffort := effectiveSettings.ReasoningEffort
 				if settings.ReasoningEffort == "" {
 					requestedReasoningEffort = ""
@@ -634,11 +634,12 @@ func composerModelConfig(provider string, selected string, options []map[string]
 }
 
 type composerModelCatalogOptions struct {
-	DefaultReasoningEffort string
-	ModelOptions           []map[string]string
-	ReasoningProfiles      map[string]composerModelReasoningProfile
-	ReasoningEfforts       []AgentModelReasoningEffortOption
-	Source                 string
+	DefaultReasoningEffort     string
+	ModelOptions               []map[string]string
+	ReasoningEffortsAdvertised bool
+	ReasoningProfiles          map[string]composerModelReasoningProfile
+	ReasoningEfforts           []AgentModelReasoningEffortOption
+	Source                     string
 }
 
 func composerModelOptionsFromCatalog(
@@ -680,7 +681,7 @@ func composerModelOptionsFromCatalog(
 			"name":  name,
 			"value": id,
 		})
-		if len(model.SupportedReasoningEfforts) > 0 {
+		if model.ReasoningEffortsAdvertised {
 			reasoningProfiles[id] = composerModelReasoningProfile{
 				DefaultReasoningEffort: strings.TrimSpace(model.DefaultReasoningEffort),
 				ReasoningEfforts: append(
@@ -705,6 +706,7 @@ func composerModelOptionsFromCatalog(
 	}
 	if selectedCatalogModel != nil {
 		catalogOptions.DefaultReasoningEffort = strings.TrimSpace(selectedCatalogModel.DefaultReasoningEffort)
+		catalogOptions.ReasoningEffortsAdvertised = selectedCatalogModel.ReasoningEffortsAdvertised
 		catalogOptions.ReasoningEfforts = append(
 			[]AgentModelReasoningEffortOption(nil),
 			selectedCatalogModel.SupportedReasoningEfforts...,

--- a/services/tuttid/service/agent/composer_options_locale.go
+++ b/services/tuttid/service/agent/composer_options_locale.go
@@ -28,12 +28,25 @@ type composerOptionDisplayText struct {
 var composerOptionLocaleCatalogs sync.Map
 
 func reasoningEffortLabel(value string, locale string) string {
+	label, _ := reasoningEffortDisplay(value, locale, "")
+	return label
+}
+
+func reasoningEffortDisplay(value string, locale string, fallbackDescription string) (string, string) {
 	value = strings.TrimSpace(value)
 	catalog := composerOptionLocaleCatalogFor(locale)
-	if text, ok := catalog.Reasoning[value]; ok && strings.TrimSpace(text.Label) != "" {
-		return strings.TrimSpace(text.Label)
+	text, ok := catalog.Reasoning[value]
+	label := value
+	description := strings.TrimSpace(fallbackDescription)
+	if ok {
+		if localizedLabel := strings.TrimSpace(text.Label); localizedLabel != "" {
+			label = localizedLabel
+		}
+		if localizedDescription := strings.TrimSpace(text.Description); localizedDescription != "" {
+			description = localizedDescription
+		}
 	}
-	return value
+	return label, description
 }
 
 func speedDisplay(value string, locale string) (string, string) {

--- a/services/tuttid/service/agent/composer_options_test.go
+++ b/services/tuttid/service/agent/composer_options_test.go
@@ -155,3 +155,41 @@ func TestComposerConfigConfigurableTruthTable(t *testing.T) {
 		}
 	}
 }
+
+func TestNormalizeRuntimeContextPreservesCodexModelReasoningOptions(t *testing.T) {
+	t.Parallel()
+	runtimeContext := map[string]any{
+		"configOptions": []any{
+			map[string]any{
+				"id":           "reasoning_effort",
+				"currentValue": "ultra",
+				"options": []any{
+					map[string]any{"name": "High", "value": "high"},
+					map[string]any{"name": "Ultra", "value": "ultra"},
+				},
+			},
+		},
+	}
+
+	normalized := normalizeRuntimeContextForProvider(
+		"codex",
+		ComposerSettings{ReasoningEffort: "ultra"},
+		runtimeContext,
+	)
+	configOptions, ok := normalized["configOptions"].([]any)
+	if !ok || len(configOptions) != 1 {
+		t.Fatalf("configOptions = %#v", normalized["configOptions"])
+	}
+	reasoningOption, ok := configOptions[0].(map[string]any)
+	if !ok {
+		t.Fatalf("reasoning option = %#v", configOptions[0])
+	}
+	options, ok := reasoningOption["options"].([]any)
+	if !ok || len(options) != 2 {
+		t.Fatalf("reasoning options = %#v", reasoningOption["options"])
+	}
+	ultra, ok := options[1].(map[string]any)
+	if !ok || ultra["value"] != "ultra" {
+		t.Fatalf("reasoning options = %#v, want runtime-advertised ultra preserved", options)
+	}
+}

--- a/services/tuttid/service/agent/composer_options_test.go
+++ b/services/tuttid/service/agent/composer_options_test.go
@@ -193,3 +193,14 @@ func TestNormalizeRuntimeContextPreservesCodexModelReasoningOptions(t *testing.T
 		t.Fatalf("reasoning options = %#v, want runtime-advertised ultra preserved", options)
 	}
 }
+
+func TestResolveAdvertisedReasoningEffortPreservesAuthoritativeMinimalDefault(t *testing.T) {
+	advertised := []AgentModelReasoningEffortOption{{Value: "minimal"}}
+	if got := resolveAdvertisedReasoningEffort("codex", "", "minimal", advertised); got != "minimal" {
+		t.Fatalf("resolveAdvertisedReasoningEffort = %q, want minimal", got)
+	}
+	options := composerAdvertisedReasoningOptionValues("codex", "minimal", "en", advertised)
+	if len(options) != 1 || options[0].Value != "minimal" {
+		t.Fatalf("composer advertised options = %#v, want only minimal", options)
+	}
+}

--- a/services/tuttid/service/agent/composer_reasoning_options.go
+++ b/services/tuttid/service/agent/composer_reasoning_options.go
@@ -1,0 +1,199 @@
+package agent
+
+import (
+	"strings"
+
+	"github.com/tutti-os/tutti/services/tuttid/biz/agentprovider"
+	preferencesbiz "github.com/tutti-os/tutti/services/tuttid/biz/preferences"
+)
+
+type composerModelReasoningProfile struct {
+	DefaultReasoningEffort string
+	ReasoningEfforts       []AgentModelReasoningEffortOption
+}
+
+func composerModelReasoningOptionsRuntimeContext(
+	provider string,
+	locale string,
+	profiles map[string]composerModelReasoningProfile,
+) map[string]any {
+	result := make(map[string]any, len(profiles))
+	for model, profile := range profiles {
+		model = strings.TrimSpace(model)
+		if model == "" || len(profile.ReasoningEfforts) == 0 {
+			continue
+		}
+		defaultValue := resolveAdvertisedReasoningEffort(
+			provider,
+			"",
+			profile.DefaultReasoningEffort,
+			profile.ReasoningEfforts,
+		)
+		options := composerAdvertisedReasoningOptionValues(
+			provider,
+			"",
+			locale,
+			profile.ReasoningEfforts,
+		)
+		result[model] = map[string]any{
+			"defaultValue": defaultValue,
+			"options":      composerReasoningOptionValuesToRuntimeOptions(options),
+		}
+	}
+	return result
+}
+
+func composerReasoningConfig(provider string, selected string, locale string) ComposerConfigOption {
+	return composerReasoningConfigFromOptions(
+		provider,
+		selected,
+		composerReasoningOptionValues(provider, selected, locale),
+	)
+}
+
+func composerReasoningConfigFromOptions(
+	provider string,
+	selected string,
+	options []ComposerConfigOptionValue,
+) ComposerConfigOption {
+	selected = normalizeReasoningEffortForProvider(provider, selected)
+	return ComposerConfigOption{
+		Configurable: composerOptionsProviderSupportsSettings(provider),
+		CurrentValue: selected,
+		DefaultValue: selected,
+		Options:      cloneComposerConfigOptionValues(options),
+	}
+}
+
+func reasoningEffortOptions(provider string, selected string) []map[string]string {
+	return composerReasoningOptionValuesToRuntimeOptions(
+		composerReasoningOptionValues(
+			provider,
+			selected,
+			preferencesbiz.DefaultDesktopLocale,
+		),
+	)
+}
+
+func reasoningEffortValuesForProvider(provider string) []string {
+	if provider == agentprovider.Codex {
+		return nil
+	}
+	if provider == agentprovider.ClaudeCode {
+		return []string{"low", "medium", "high", "xhigh"}
+	}
+	return []string{"minimal", "low", "medium", "high", "xhigh"}
+}
+
+func composerReasoningOptionValues(provider string, selected string, locale string) []ComposerConfigOptionValue {
+	values := reasoningEffortValuesForProvider(provider)
+	advertised := make([]AgentModelReasoningEffortOption, 0, len(values))
+	for _, value := range values {
+		advertised = append(advertised, AgentModelReasoningEffortOption{Value: value})
+	}
+	return composerAdvertisedReasoningOptionValues(provider, selected, locale, advertised)
+}
+
+func composerAdvertisedReasoningOptionValues(
+	provider string,
+	selected string,
+	locale string,
+	advertised []AgentModelReasoningEffortOption,
+) []ComposerConfigOptionValue {
+	selected = normalizeReasoningEffortForProvider(provider, selected)
+	options := make([]ComposerConfigOptionValue, 0, len(advertised)+1)
+	containsSelected := false
+	for _, advertisedOption := range advertised {
+		value := strings.TrimSpace(advertisedOption.Value)
+		if value == "" {
+			continue
+		}
+		if value == selected {
+			containsSelected = true
+		}
+		label, description := reasoningEffortDisplay(
+			value,
+			locale,
+			advertisedOption.Description,
+		)
+		options = append(options, ComposerConfigOptionValue{
+			Description: description,
+			ID:          value,
+			Label:       label,
+			Value:       value,
+		})
+	}
+	if selected != "" && !containsSelected {
+		options = append(options, ComposerConfigOptionValue{
+			ID:    selected,
+			Label: reasoningEffortLabel(selected, locale),
+			Value: selected,
+		})
+	}
+	return options
+}
+
+func resolveAdvertisedReasoningEffort(
+	provider string,
+	selected string,
+	advertisedDefault string,
+	advertised []AgentModelReasoningEffortOption,
+) string {
+	selected = normalizeReasoningEffortForProvider(provider, selected)
+	advertisedDefault = normalizeReasoningEffortForProvider(provider, advertisedDefault)
+	firstValue := ""
+	defaultSupported := false
+	for _, option := range advertised {
+		value := normalizeReasoningEffortForProvider(provider, option.Value)
+		if value == "" {
+			continue
+		}
+		if firstValue == "" {
+			firstValue = value
+		}
+		if value == selected {
+			return selected
+		}
+		if value == advertisedDefault {
+			defaultSupported = true
+		}
+	}
+	if defaultSupported {
+		return advertisedDefault
+	}
+	return firstValue
+}
+
+func composerReasoningOptionValuesToRuntimeOptions(
+	options []ComposerConfigOptionValue,
+) []map[string]string {
+	result := make([]map[string]string, 0, len(options))
+	for _, option := range options {
+		value := strings.TrimSpace(option.Value)
+		if value == "" {
+			continue
+		}
+		runtimeOption := map[string]string{
+			"name":  strings.TrimSpace(option.Label),
+			"value": value,
+		}
+		if description := strings.TrimSpace(option.Description); description != "" {
+			runtimeOption["description"] = description
+		}
+		result = append(result, runtimeOption)
+	}
+	return result
+}
+
+func normalizeReasoningEffortForProvider(provider string, value string) string {
+	provider = agentprovider.Normalize(provider)
+	if !composerOptionsProviderSupportsSettings(provider) {
+		return ""
+	}
+	normalized := strings.TrimSpace(value)
+	if (provider == agentprovider.Codex || provider == agentprovider.ClaudeCode) &&
+		(normalized == "minimal" || normalized == "none") {
+		return "high"
+	}
+	return normalized
+}

--- a/services/tuttid/service/agent/composer_reasoning_options.go
+++ b/services/tuttid/service/agent/composer_reasoning_options.go
@@ -20,7 +20,7 @@ func composerModelReasoningOptionsRuntimeContext(
 	result := make(map[string]any, len(profiles))
 	for model, profile := range profiles {
 		model = strings.TrimSpace(model)
-		if model == "" || len(profile.ReasoningEfforts) == 0 {
+		if model == "" {
 			continue
 		}
 		defaultValue := resolveAdvertisedReasoningEffort(
@@ -56,7 +56,7 @@ func composerReasoningConfigFromOptions(
 	selected string,
 	options []ComposerConfigOptionValue,
 ) ComposerConfigOption {
-	selected = normalizeReasoningEffortForProvider(provider, selected)
+	selected = strings.TrimSpace(selected)
 	return ComposerConfigOption{
 		Configurable: composerOptionsProviderSupportsSettings(provider),
 		CurrentValue: selected,
@@ -100,7 +100,7 @@ func composerAdvertisedReasoningOptionValues(
 	locale string,
 	advertised []AgentModelReasoningEffortOption,
 ) []ComposerConfigOptionValue {
-	selected = normalizeReasoningEffortForProvider(provider, selected)
+	selected = strings.TrimSpace(selected)
 	options := make([]ComposerConfigOptionValue, 0, len(advertised)+1)
 	containsSelected := false
 	for _, advertisedOption := range advertised {
@@ -134,17 +134,17 @@ func composerAdvertisedReasoningOptionValues(
 }
 
 func resolveAdvertisedReasoningEffort(
-	provider string,
+	_ string,
 	selected string,
 	advertisedDefault string,
 	advertised []AgentModelReasoningEffortOption,
 ) string {
-	selected = normalizeReasoningEffortForProvider(provider, selected)
-	advertisedDefault = normalizeReasoningEffortForProvider(provider, advertisedDefault)
+	selected = strings.TrimSpace(selected)
+	advertisedDefault = strings.TrimSpace(advertisedDefault)
 	firstValue := ""
 	defaultSupported := false
 	for _, option := range advertised {
-		value := normalizeReasoningEffortForProvider(provider, option.Value)
+		value := strings.TrimSpace(option.Value)
 		if value == "" {
 			continue
 		}

--- a/services/tuttid/service/agent/composer_reasoning_options.go
+++ b/services/tuttid/service/agent/composer_reasoning_options.go
@@ -95,7 +95,7 @@ func composerReasoningOptionValues(provider string, selected string, locale stri
 }
 
 func composerAdvertisedReasoningOptionValues(
-	provider string,
+	_ string,
 	selected string,
 	locale string,
 	advertised []AgentModelReasoningEffortOption,

--- a/services/tuttid/service/agent/locales/en.json
+++ b/services/tuttid/service/agent/locales/en.json
@@ -87,21 +87,31 @@
   },
   "reasoning": {
     "high": {
+      "description": "Greater reasoning depth for complex problems",
       "label": "High"
     },
     "low": {
+      "description": "Fast responses with lighter reasoning",
       "label": "Low"
     },
     "max": {
+      "description": "Maximum reasoning depth for the hardest problems",
       "label": "Max"
     },
     "medium": {
+      "description": "Balances speed and reasoning depth for everyday tasks",
       "label": "Medium"
     },
     "minimal": {
+      "description": "Uses the least reasoning for the fastest responses",
       "label": "Minimal"
     },
+    "ultra": {
+      "description": "Maximum reasoning with automatic task delegation",
+      "label": "Ultra"
+    },
     "xhigh": {
+      "description": "Extra-high reasoning depth for complex problems",
       "label": "X-High"
     }
   },

--- a/services/tuttid/service/agent/locales/zh-CN.json
+++ b/services/tuttid/service/agent/locales/zh-CN.json
@@ -87,21 +87,31 @@
   },
   "reasoning": {
     "high": {
+      "description": "为复杂问题提供更深入的推理",
       "label": "高"
     },
     "low": {
+      "description": "推理较少，响应更快",
       "label": "低"
     },
     "max": {
+      "description": "为最困难的问题提供最高强度推理",
       "label": "最高"
     },
     "medium": {
+      "description": "兼顾日常任务的响应速度和推理深度",
       "label": "中"
     },
     "minimal": {
+      "description": "使用最少推理，以获得最快响应",
       "label": "最低"
     },
+    "ultra": {
+      "description": "最高强度推理，并自动委派任务",
+      "label": "极致"
+    },
     "xhigh": {
+      "description": "为复杂问题提供超高强度推理",
       "label": "超高"
     }
   },

--- a/services/tuttid/service/agent/model_catalog.go
+++ b/services/tuttid/service/agent/model_catalog.go
@@ -16,10 +16,17 @@ const (
 )
 
 type AgentModelOption struct {
-	ID          string
-	DisplayName string
+	ID                        string
+	DisplayName               string
+	Description               string
+	DefaultReasoningEffort    string
+	IsDefault                 bool
+	SupportedReasoningEfforts []AgentModelReasoningEffortOption
+}
+
+type AgentModelReasoningEffortOption struct {
 	Description string
-	IsDefault   bool
+	Value       string
 }
 
 type AgentModelCatalogResult struct {
@@ -236,6 +243,12 @@ func cloneAgentModelOptions(models []AgentModelOption) []AgentModelOption {
 	}
 	result := make([]AgentModelOption, len(models))
 	copy(result, models)
+	for index := range result {
+		result[index].SupportedReasoningEfforts = append(
+			[]AgentModelReasoningEffortOption(nil),
+			models[index].SupportedReasoningEfforts...,
+		)
+	}
 	return result
 }
 

--- a/services/tuttid/service/agent/model_catalog.go
+++ b/services/tuttid/service/agent/model_catalog.go
@@ -16,12 +16,13 @@ const (
 )
 
 type AgentModelOption struct {
-	ID                        string
-	DisplayName               string
-	Description               string
-	DefaultReasoningEffort    string
-	IsDefault                 bool
-	SupportedReasoningEfforts []AgentModelReasoningEffortOption
+	ID                         string
+	DisplayName                string
+	Description                string
+	DefaultReasoningEffort     string
+	IsDefault                  bool
+	ReasoningEffortsAdvertised bool
+	SupportedReasoningEfforts  []AgentModelReasoningEffortOption
 }
 
 type AgentModelReasoningEffortOption struct {

--- a/services/tuttid/service/agent/service_helpers.go
+++ b/services/tuttid/service/agent/service_helpers.go
@@ -289,7 +289,12 @@ func normalizeRuntimeConfigOptionsForProvider(
 				runtimeConfigOptionString(record, "currentValue", "current_value"),
 			)
 		}
-		nextRecord["options"] = reasoningEffortOptions(provider, currentValue)
+		// Codex advertises reasoning efforts for the currently selected model.
+		// Preserve that authoritative list so model-specific values such as max
+		// and ultra are not replaced by a provider-wide compatibility catalog.
+		if agentprovider.Normalize(provider) != agentprovider.Codex {
+			nextRecord["options"] = reasoningEffortOptions(provider, currentValue)
+		}
 		if currentValue == "" {
 			nextRecord["currentValue"] = nil
 			delete(nextRecord, "current_value")

--- a/services/tuttid/service/agent/service_test.go
+++ b/services/tuttid/service/agent/service_test.go
@@ -2464,7 +2464,20 @@ func TestServiceGetsComposerOptionsWithResolvedCodexDefaultModel(t *testing.T) {
 			Provider: "codex",
 			Source:   "codex-cli",
 			Models: []AgentModelOption{
-				{ID: "gpt-5.5", DisplayName: "GPT-5.5", IsDefault: true},
+				{
+					ID:                     "gpt-5.6-sol",
+					DisplayName:            "GPT-5.6-Sol",
+					DefaultReasoningEffort: "low",
+					IsDefault:              true,
+					SupportedReasoningEfforts: []AgentModelReasoningEffortOption{
+						{Value: "low", Description: "Fast responses with lighter reasoning"},
+						{Value: "medium"},
+						{Value: "high"},
+						{Value: "xhigh"},
+						{Value: "max"},
+						{Value: "ultra", Description: "Maximum reasoning with automatic task delegation"},
+					},
+				},
 				{ID: "gpt-5.4", DisplayName: "GPT-5.4"},
 			},
 		},
@@ -2472,25 +2485,114 @@ func TestServiceGetsComposerOptionsWithResolvedCodexDefaultModel(t *testing.T) {
 
 	options, err := service.GetComposerOptions(context.Background(), ComposerOptionsInput{
 		Provider: "codex",
+		Locale:   "zh-CN",
 	})
 	if err != nil {
 		t.Fatalf("GetComposerOptions returned error: %v", err)
 	}
-	if options.EffectiveSettings.Model != "gpt-5.5" {
-		t.Fatalf("effectiveSettings.model = %q, want gpt-5.5", options.EffectiveSettings.Model)
+	if options.EffectiveSettings.Model != "gpt-5.6-sol" {
+		t.Fatalf("effectiveSettings.model = %q, want gpt-5.6-sol", options.EffectiveSettings.Model)
 	}
-	if options.EffectiveSettings.ReasoningEffort != "high" {
-		t.Fatalf("effectiveSettings.reasoningEffort = %q, want high", options.EffectiveSettings.ReasoningEffort)
+	if options.EffectiveSettings.ReasoningEffort != "low" {
+		t.Fatalf("effectiveSettings.reasoningEffort = %q, want low", options.EffectiveSettings.ReasoningEffort)
 	}
 	configOptions, ok := options.RuntimeContext["configOptions"].([]map[string]any)
 	if !ok || len(configOptions) == 0 {
 		t.Fatalf("configOptions = %#v", options.RuntimeContext["configOptions"])
 	}
-	if configOptions[0]["currentValue"] != "gpt-5.5" {
+	if configOptions[0]["currentValue"] != "gpt-5.6-sol" {
 		t.Fatalf("model option = %#v", configOptions[0])
 	}
-	if len(configOptions) < 2 || configOptions[1]["currentValue"] != "high" {
+	if len(configOptions) < 2 || configOptions[1]["currentValue"] != "low" {
 		t.Fatalf("reasoning option = %#v", configOptions)
+	}
+	reasoningRuntimeOptions, ok := configOptions[1]["options"].([]map[string]string)
+	if !ok || len(reasoningRuntimeOptions) != 6 || reasoningRuntimeOptions[5]["value"] != "ultra" {
+		t.Fatalf("reasoning runtime options = %#v, want model-advertised ultra", configOptions[1]["options"])
+	}
+	if len(options.ReasoningConfig.Options) != 6 ||
+		options.ReasoningConfig.Options[5].Value != "ultra" ||
+		options.ReasoningConfig.Options[5].Label != "极致" ||
+		options.ReasoningConfig.Options[5].Description != "最高强度推理，并自动委派任务" {
+		t.Fatalf("reasoningConfig = %#v, want model-advertised ultra", options.ReasoningConfig)
+	}
+	profiles, ok := options.RuntimeContext["modelReasoningOptionsByModel"].(map[string]any)
+	if !ok {
+		t.Fatalf("modelReasoningOptionsByModel = %#v", options.RuntimeContext["modelReasoningOptionsByModel"])
+	}
+	solProfile, ok := profiles["gpt-5.6-sol"].(map[string]any)
+	if !ok || solProfile["defaultValue"] != "low" {
+		t.Fatalf("sol reasoning profile = %#v, want low default", profiles["gpt-5.6-sol"])
+	}
+	solOptions, ok := solProfile["options"].([]map[string]string)
+	if !ok || len(solOptions) != 6 || solOptions[5]["name"] != "极致" {
+		t.Fatalf("sol reasoning profile options = %#v, want localized ultra", solProfile["options"])
+	}
+}
+
+func TestServiceGetsComposerOptionsUsesSelectedCodexModelReasoningEfforts(t *testing.T) {
+	runtime := newFakeRuntime()
+	service := NewService(runtime)
+	service.ModelCatalog = fakeModelCatalog{
+		result: AgentModelCatalogResult{
+			Provider: "codex",
+			Source:   "codex-cli",
+			Models: []AgentModelOption{
+				{
+					ID:                     "gpt-5.6-sol",
+					DisplayName:            "GPT-5.6-Sol",
+					DefaultReasoningEffort: "low",
+					IsDefault:              true,
+					SupportedReasoningEfforts: []AgentModelReasoningEffortOption{
+						{Value: "low"},
+						{Value: "ultra"},
+					},
+				},
+				{
+					ID:                     "gpt-5.6-luna",
+					DisplayName:            "GPT-5.6-Luna",
+					DefaultReasoningEffort: "medium",
+					SupportedReasoningEfforts: []AgentModelReasoningEffortOption{
+						{Value: "low"},
+						{Value: "medium"},
+						{Value: "high"},
+						{Value: "xhigh"},
+						{Value: "max"},
+					},
+				},
+			},
+		},
+	}
+
+	options, err := service.GetComposerOptions(context.Background(), ComposerOptionsInput{
+		Provider: "codex",
+		Settings: ComposerSettings{
+			Model:           "gpt-5.6-luna",
+			ReasoningEffort: "ultra",
+		},
+	})
+	if err != nil {
+		t.Fatalf("GetComposerOptions returned error: %v", err)
+	}
+	if options.EffectiveSettings.ReasoningEffort != "medium" {
+		t.Fatalf("effectiveSettings.reasoningEffort = %q, want medium", options.EffectiveSettings.ReasoningEffort)
+	}
+	values := make([]string, 0, len(options.ReasoningConfig.Options))
+	for _, option := range options.ReasoningConfig.Options {
+		values = append(values, option.Value)
+	}
+	if !slices.Equal(values, []string{"low", "medium", "high", "xhigh", "max"}) {
+		t.Fatalf("reasoningConfig values = %#v, want selected Luna model capabilities", values)
+	}
+	profiles, ok := options.RuntimeContext["modelReasoningOptionsByModel"].(map[string]any)
+	if !ok {
+		t.Fatalf("modelReasoningOptionsByModel = %#v", options.RuntimeContext["modelReasoningOptionsByModel"])
+	}
+	solProfile := profiles["gpt-5.6-sol"].(map[string]any)
+	lunaProfile := profiles["gpt-5.6-luna"].(map[string]any)
+	if len(solProfile["options"].([]map[string]string)) != 2 ||
+		len(lunaProfile["options"].([]map[string]string)) != 5 {
+		t.Fatalf("reasoning profiles = %#v, want model-specific option counts", profiles)
 	}
 }
 

--- a/services/tuttid/service/agent/service_test.go
+++ b/services/tuttid/service/agent/service_test.go
@@ -2465,10 +2465,11 @@ func TestServiceGetsComposerOptionsWithResolvedCodexDefaultModel(t *testing.T) {
 			Source:   "codex-cli",
 			Models: []AgentModelOption{
 				{
-					ID:                     "gpt-5.6-sol",
-					DisplayName:            "GPT-5.6-Sol",
-					DefaultReasoningEffort: "low",
-					IsDefault:              true,
+					ID:                         "gpt-5.6-sol",
+					DisplayName:                "GPT-5.6-Sol",
+					DefaultReasoningEffort:     "low",
+					IsDefault:                  true,
+					ReasoningEffortsAdvertised: true,
 					SupportedReasoningEfforts: []AgentModelReasoningEffortOption{
 						{Value: "low", Description: "Fast responses with lighter reasoning"},
 						{Value: "medium"},
@@ -2539,19 +2540,21 @@ func TestServiceGetsComposerOptionsUsesSelectedCodexModelReasoningEfforts(t *tes
 			Source:   "codex-cli",
 			Models: []AgentModelOption{
 				{
-					ID:                     "gpt-5.6-sol",
-					DisplayName:            "GPT-5.6-Sol",
-					DefaultReasoningEffort: "low",
-					IsDefault:              true,
+					ID:                         "gpt-5.6-sol",
+					DisplayName:                "GPT-5.6-Sol",
+					DefaultReasoningEffort:     "low",
+					IsDefault:                  true,
+					ReasoningEffortsAdvertised: true,
 					SupportedReasoningEfforts: []AgentModelReasoningEffortOption{
 						{Value: "low"},
 						{Value: "ultra"},
 					},
 				},
 				{
-					ID:                     "gpt-5.6-luna",
-					DisplayName:            "GPT-5.6-Luna",
-					DefaultReasoningEffort: "medium",
+					ID:                         "gpt-5.6-luna",
+					DisplayName:                "GPT-5.6-Luna",
+					DefaultReasoningEffort:     "medium",
+					ReasoningEffortsAdvertised: true,
 					SupportedReasoningEfforts: []AgentModelReasoningEffortOption{
 						{Value: "low"},
 						{Value: "medium"},
@@ -2593,6 +2596,87 @@ func TestServiceGetsComposerOptionsUsesSelectedCodexModelReasoningEfforts(t *tes
 	if len(solProfile["options"].([]map[string]string)) != 2 ||
 		len(lunaProfile["options"].([]map[string]string)) != 5 {
 		t.Fatalf("reasoning profiles = %#v, want model-specific option counts", profiles)
+	}
+}
+
+func TestServiceGetsComposerOptionsPreservesAdvertisedEmptyReasoningEfforts(t *testing.T) {
+	runtime := newFakeRuntime()
+	service := NewService(runtime)
+	service.ModelCatalog = fakeModelCatalog{
+		result: AgentModelCatalogResult{
+			Provider: "codex",
+			Source:   "codex-cli",
+			Models: []AgentModelOption{
+				{
+					ID:                         "no-reasoning",
+					DisplayName:                "No Reasoning",
+					IsDefault:                  true,
+					ReasoningEffortsAdvertised: true,
+					SupportedReasoningEfforts:  []AgentModelReasoningEffortOption{},
+				},
+			},
+		},
+	}
+
+	options, err := service.GetComposerOptions(context.Background(), ComposerOptionsInput{
+		Provider: "codex",
+	})
+	if err != nil {
+		t.Fatalf("GetComposerOptions returned error: %v", err)
+	}
+	if options.EffectiveSettings.ReasoningEffort != "" || len(options.ReasoningConfig.Options) != 0 {
+		t.Fatalf("reasoningConfig = %#v, want authoritative empty options", options.ReasoningConfig)
+	}
+	profiles, ok := options.RuntimeContext["modelReasoningOptionsByModel"].(map[string]any)
+	if !ok {
+		t.Fatalf("modelReasoningOptionsByModel = %#v", options.RuntimeContext["modelReasoningOptionsByModel"])
+	}
+	profile, ok := profiles["no-reasoning"].(map[string]any)
+	if !ok {
+		t.Fatalf("no-reasoning profile = %#v", profiles["no-reasoning"])
+	}
+	profileOptions, ok := profile["options"].([]map[string]string)
+	if !ok || len(profileOptions) != 0 {
+		t.Fatalf("no-reasoning profile options = %#v, want empty", profile["options"])
+	}
+}
+
+func TestServiceGetsComposerOptionsPreservesAdvertisedMinimalReasoningEffort(t *testing.T) {
+	runtime := newFakeRuntime()
+	service := NewService(runtime)
+	service.ModelCatalog = fakeModelCatalog{
+		result: AgentModelCatalogResult{
+			Provider: "codex",
+			Source:   "codex-cli",
+			Models: []AgentModelOption{
+				{
+					ID:                         "minimal-only",
+					DisplayName:                "Minimal Only",
+					DefaultReasoningEffort:     "minimal",
+					IsDefault:                  true,
+					ReasoningEffortsAdvertised: true,
+					SupportedReasoningEfforts: []AgentModelReasoningEffortOption{
+						{Value: "minimal"},
+					},
+				},
+			},
+		},
+	}
+
+	options, err := service.GetComposerOptions(context.Background(), ComposerOptionsInput{
+		Provider: "codex",
+	})
+	if err != nil {
+		t.Fatalf("GetComposerOptions returned error: %v", err)
+	}
+	if options.EffectiveSettings.ReasoningEffort != "minimal" {
+		t.Fatalf("effectiveSettings.reasoningEffort = %q, want minimal", options.EffectiveSettings.ReasoningEffort)
+	}
+	if options.ReasoningConfig.CurrentValue != "minimal" {
+		t.Fatalf("reasoningConfig.currentValue = %q, want minimal", options.ReasoningConfig.CurrentValue)
+	}
+	if len(options.ReasoningConfig.Options) != 1 || options.ReasoningConfig.Options[0].Value != "minimal" {
+		t.Fatalf("reasoningConfig.options = %#v, want only minimal", options.ReasoningConfig.Options)
 	}
 }
 


### PR DESCRIPTION
## Summary

Backport of #1012 to `release/0704`.

- preserve ACP-advertised reasoning defaults and supported effort lists per model
- refresh composer option caches when model/settings change and switch home or live reasoning menus to the selected model capabilities
- localize the Ultra reasoning label in English and Chinese while keeping ACP value/order authoritative
- adapt the fix to the release branch provider/agent-target cache and model option contracts without bringing main-only refactors into the release

## Testing

- `go test ./service/agent`
- `pnpm --filter @tutti-os/agent-activity-core test` (76 tests)
- AgentGUI targeted tests (247 tests)
- desktop AgentActivity adapter tests (22 tests)
- `pnpm check:i18n`
- pre-commit Electron/UI/renderer boundary checks
- full GUI/desktop typecheck is blocked on the release branch by the existing missing `react-medium-image-zoom` dependency; local pre-push is also blocked by Node 22 lacking global `CloseEvent` and the pinned `golangci-lint` not being installed

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Sync model-specific reasoning options end-to-end so the Agent GUI reflects each `codex` model’s advertised efforts and default (including `ultra`), with localized labels and descriptions. Tightens cache keys and runtime sourcing to prevent stale or mismatched menus.

- **Bug Fixes**
  - Preserve per-model advertised defaults and lists from the catalog/runtime; accept authoritative empty lists and `minimal` defaults.
  - Prefer active session ACP options; keep ACP values/order, overlay locale labels/descriptions; preserve ACP labels over synthesized ones in the desktop adapter.
  - Refresh composer options on provider/cwd/settings/model changes; cache keyed by full request; invalidate stales and discard in-flight loads; sanitize selections to supported values.

- **New Features**
  - Expose `modelReasoningOptionsByModel` in runtime context and switch menus instantly per model without extra requests.
  - Parse `supportedReasoningEfforts` and `defaultReasoningEffort` from the `codex` catalog; localize Ultra and reasoning descriptions in `en` and `zh-CN`; show Ultra in model summaries.

<sup>Written for commit c4601e2d2937dc3dcc3d45351800a0ccf50452e9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tutti-os/tutti/pull/1013?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

