### PR TITLE
fix(ui-system): polish storyboard notification and switch states

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -40,6 +40,7 @@ DCO sign-off, PR workflow, review gates, and multilingual documentation updates.
 ## Hard Rules
 
 - Published workspace packages use `@tutti-os/*`; keep manifests, imports, docs, and release config aligned.
+- All new requirements and features across Tutti projects must first reuse existing `@tutti-os/ui-system` components, semantic color tokens, typography, spacing, and other established UI conventions. Before introducing bespoke UI or raw color values, inspect the existing UI System exports and tokens; if the required capability is missing, prefer extending the shared UI System with a reusable primitive or token and document the rationale.
 - User-visible copy must go through the relevant i18n layer. Do not hardcode UI text, dialog text, status labels, empty states, or user-facing errors.
 - Change `services/tuttid/api/openapi/tuttid.v1.yaml` before daemon HTTP request/response contracts.
 - Document new supported runtime/env overrides in the matching durable convention doc.

--- a/apps/ui-storyboard/src/App.tsx
+++ b/apps/ui-storyboard/src/App.tsx
@@ -1797,23 +1797,26 @@ function CheckboxStoryboard() {
 function StorySwitch({
   checked,
   disabled = false,
+  loading = false,
   label,
   onCheckedChange
 }: {
   checked: boolean;
   disabled?: boolean;
+  loading?: boolean;
   label: string;
   onCheckedChange?: (checked: boolean) => void;
 }) {
   return (
     <label
       className={`inline-flex items-center gap-3 text-left text-[13px] font-normal text-[rgb(0,0,0)] ${
-        disabled ? "cursor-not-allowed opacity-50" : ""
+        disabled || loading ? "cursor-not-allowed opacity-50" : ""
       }`}
     >
       <Switch
         checked={checked}
         disabled={disabled}
+        loading={loading}
         onCheckedChange={onCheckedChange}
       />
       <span>{label}</span>
@@ -1836,6 +1839,7 @@ function SwitchStoryboard() {
           <div className="grid gap-3">
             <StorySwitch checked label="Checked" />
             <StorySwitch checked={false} label="Unchecked" />
+            <StorySwitch checked loading label="Loading" />
             <StorySwitch checked disabled label="Disabled checked" />
             <StorySwitch checked={false} disabled label="Disabled unchecked" />
           </div>
@@ -3425,16 +3429,16 @@ function SonnerStoryboard() {
         >
           <div className="flex min-h-[128px] items-start justify-end p-4">
             <div
-              className="grid w-[min(360px,100%)] gap-1.5 rounded-[8px] border border-[var(--line-2)] bg-[var(--background-fronted)] px-3.5 py-3 text-left text-[var(--text-primary)] shadow-[0_14px_40px_var(--shadow-elevated)]"
+              className="grid w-[min(360px,100%)] gap-1.5 rounded-[8px] border border-[var(--line-2)] bg-[var(--background-fronted)] p-3 text-left text-[var(--text-primary)] shadow-[0_14px_40px_var(--shadow-elevated)]"
               role="status"
             >
               <div className="flex min-w-0 items-start gap-2">
                 <WarningLinedIcon className="mt-0.5 size-4 shrink-0 text-[var(--accent)]" />
                 <div className="min-w-0 flex-1">
-                  <p className="m-0 text-[13px] font-semibold leading-5 text-[var(--text-primary)]">
+                  <p className="m-0 text-[13px] font-medium leading-5 text-[var(--text-primary)]">
                     Agent needs your decision
                   </p>
-                  <p className="m-0 mt-0.5 text-[11px] leading-5 text-[var(--text-secondary)]">
+                  <p className="m-0 mt-0.5 text-[11px] leading-[1.3] text-[var(--text-secondary)]">
                     Review the waiting session in Agent messages.
                   </p>
                 </div>
@@ -3545,7 +3549,7 @@ export function App() {
 
   return (
     <div
-      className="min-h-screen bg-[var(--storyboard-canvas)] font-[var(--font-ui)] text-[var(--storyboard-ink)] transition-colors duration-200"
+      className="min-h-screen bg-[var(--background-1)] font-[var(--font-ui)] text-[var(--storyboard-ink)] transition-colors duration-200"
       data-storyboard-language={language}
       data-storyboard-theme={themeMode}
       style={themeVars}

--- a/packages/ui/system/src/components/sonner/sonner.tsx
+++ b/packages/ui/system/src/components/sonner/sonner.tsx
@@ -43,11 +43,10 @@ function Toaster({ toastOptions, style, ...props }: ToasterProps) {
         ...toastOptions,
         classNames: {
           toast:
-            "group pointer-events-auto min-h-14 rounded-[8px] border border-[var(--line-2)] bg-[var(--background-fronted)] px-3.5 py-3 text-[var(--text-primary)] shadow-[0_14px_40px_var(--shadow-elevated)]",
-          title:
-            "text-[13px] font-semibold leading-5 text-[var(--text-primary)]",
+            "group pointer-events-auto min-h-14 rounded-[8px] border border-[var(--line-2)] bg-[var(--background-fronted)] p-3 text-[var(--text-primary)] shadow-[0_14px_40px_var(--shadow-elevated)]",
+          title: "text-[13px] font-medium leading-5 text-[var(--text-primary)]",
           description:
-            "mt-0.5 text-[11px] leading-5 text-[var(--text-secondary)]",
+            "mt-0.5 text-[11px] leading-[1.3] text-[var(--text-secondary)]",
           actionButton:
             "h-7 rounded-[6px] bg-[var(--text-primary)] px-2.5 text-[11px] font-normal text-[var(--text-inverted)] transition-colors hover:bg-[var(--text-primary-hover)]",
           cancelButton:

--- a/packages/ui/system/src/components/switch/switch.tsx
+++ b/packages/ui/system/src/components/switch/switch.tsx
@@ -1,29 +1,43 @@
 import * as React from "react";
 import { Switch as SwitchPrimitive } from "radix-ui";
 
+import { LoadingIcon } from "#icons/system-icons";
 import { cn } from "#lib/utils";
 
 function Switch({
   className,
+  disabled,
+  loading = false,
   size = "default",
   ...props
 }: React.ComponentProps<typeof SwitchPrimitive.Root> & {
+  loading?: boolean;
   size?: "sm" | "default";
 }) {
   return (
     <SwitchPrimitive.Root
       data-slot="switch"
       data-size={size}
+      data-loading={loading ? "true" : "false"}
+      aria-busy={loading || undefined}
+      disabled={loading || disabled}
       className={cn(
-        "peer group/switch relative inline-flex shrink-0 items-center rounded-full border border-transparent transition-[background-color,border-color,box-shadow] outline-none focus-visible:border-[var(--border-focus)] focus-visible:ring-2 focus-visible:ring-[color-mix(in_srgb,var(--border-focus)_30%,transparent)] aria-invalid:border-[var(--state-danger)] aria-invalid:ring-2 aria-invalid:ring-[color-mix(in_srgb,var(--state-danger)_20%,transparent)] data-[size=default]:h-[18px] data-[size=default]:w-[32px] data-[size=sm]:h-[14px] data-[size=sm]:w-[24px] data-[state=checked]:bg-[var(--tutti-purple)] data-[state=unchecked]:bg-[var(--text-disabled)] data-disabled:cursor-not-allowed data-disabled:opacity-100",
+        "peer group/switch relative inline-flex shrink-0 items-center rounded-full border border-transparent transition-[background-color,border-color,box-shadow] outline-none focus-visible:border-[var(--border-focus)] focus-visible:ring-2 focus-visible:ring-[color-mix(in_srgb,var(--border-focus)_30%,transparent)] aria-invalid:border-[var(--state-danger)] aria-invalid:ring-2 aria-invalid:ring-[color-mix(in_srgb,var(--state-danger)_20%,transparent)] data-[size=default]:h-[18px] data-[size=default]:w-[32px] data-[size=sm]:h-[14px] data-[size=sm]:w-[24px] data-[state=checked]:bg-[var(--tutti-purple)] data-[state=unchecked]:bg-[var(--text-disabled)] data-disabled:cursor-not-allowed data-disabled:opacity-100 data-[loading=true]:cursor-wait",
         className
       )}
       {...props}
     >
       <SwitchPrimitive.Thumb
         data-slot="switch-thumb"
-        className="pointer-events-none block rounded-full bg-[var(--white-stationary)] ring-0 transition-transform group-data-[size=default]/switch:size-4 group-data-[size=sm]/switch:size-3 group-data-[size=default]/switch:data-[state=checked]:translate-x-[14px] group-data-[size=sm]/switch:data-[state=checked]:translate-x-[10px] group-data-[size=default]/switch:data-[state=unchecked]:translate-x-0 group-data-[size=sm]/switch:data-[state=unchecked]:translate-x-0"
-      />
+        className="pointer-events-none inline-flex items-center justify-center rounded-full bg-[var(--white-stationary)] ring-0 transition-transform group-data-[size=default]/switch:size-4 group-data-[size=sm]/switch:size-3 group-data-[size=default]/switch:data-[state=checked]:translate-x-[14px] group-data-[size=sm]/switch:data-[state=checked]:translate-x-[10px] group-data-[size=default]/switch:data-[state=unchecked]:translate-x-0 group-data-[size=sm]/switch:data-[state=unchecked]:translate-x-0"
+      >
+        {loading ? (
+          <LoadingIcon
+            aria-hidden="true"
+            className="size-3 animate-spin text-[var(--tutti-purple)] group-data-[size=sm]/switch:size-2.5"
+          />
+        ) : null}
+      </SwitchPrimitive.Thumb>
     </SwitchPrimitive.Root>
   );
 }


### PR DESCRIPTION
## What changed

- Align the UI Storyboard page background with `--background-1`.
- Polish Sonner spacing and typography: 12px padding, medium-weight titles, and 130% description line-height.
- Add a reusable Switch loading state with disabled interaction, `aria-busy`, and a centered spinner in the thumb, plus Storyboard coverage.

## Why

The Storyboard screenshots exposed visual mismatches in notification spacing and typography, and the Switch inventory did not cover the loading state needed during async preference updates.

## Validation

- `pnpm --filter @tutti-os/ui-storyboard build`
- `pnpm --filter @tutti-os/ui-system typecheck`
- `pnpm check:ui-boundaries`
- Commit hooks: formatting, lint, Electron/UI/Renderer boundary checks

The full check was started, but unrelated client event-stream tests are blocked under the current Node 22 runtime by `CloseEvent is not defined`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Polished notification styles and added a reusable Switch loading state for async preference updates. Also aligned the Storyboard canvas with the app background for accurate screenshots.

- **New Features**
  - `@tutti-os/ui-system` Switch: added `loading` prop. Disables interaction, sets `aria-busy`, shows a centered spinner, and exposes `data-loading`. Storyboard example included.

- **Refactors**
  - `@tutti-os/ui-system` Sonner: 12px padding, medium-weight title, 1.3 description line-height.
  - `@tutti-os/ui-storyboard`: canvas background now uses `--background-1`.
  - `AGENTS.md`: added a hard rule to reuse `@tutti-os/ui-system` components/tokens before introducing custom UI.

<sup>Written for commit 6619d86ae7be9f3de2c7720427e0369b8ec70e0d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tutti-os/tutti/pull/1014?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

