### PR TITLE
fix(desktop): package Claude sidecar for target architecture

### DIFF
--- a/apps/desktop/scripts/claude-sdk-sidecar-packaging.mjs
+++ b/apps/desktop/scripts/claude-sdk-sidecar-packaging.mjs
@@ -1,0 +1,91 @@
+import { execFileSync } from "node:child_process";
+import { existsSync, rmSync } from "node:fs";
+import { join } from "node:path";
+
+export const DARWIN_CLAUDE_NATIVE_PACKAGES = [
+  {
+    name: "@anthropic-ai/claude-agent-sdk-darwin-arm64",
+    lipoArch: "arm64"
+  },
+  {
+    name: "@anthropic-ai/claude-agent-sdk-darwin-x64",
+    lipoArch: "x86_64"
+  }
+];
+
+export function resolveDarwinClaudeNativePackageSpecs(agentSdkPackage) {
+  const optionalDependencies = agentSdkPackage.optionalDependencies ?? {};
+  return DARWIN_CLAUDE_NATIVE_PACKAGES.map(({ name }) => {
+    const version = optionalDependencies[name];
+    if (typeof version !== "string" || version.length === 0) {
+      throw new Error(
+        `Claude Agent SDK does not declare required optional dependency: ${name}`
+      );
+    }
+    return `${name}@${version}`;
+  });
+}
+
+export function resolveDarwinClaudeNativePackagesForPackContext(context) {
+  // electron-builder creates both architecture-specific temporary apps before
+  // merging a universal app. Their file lists must stay identical, so both
+  // native packages are required in those intermediates.
+  if (/-universal-(?:x64|arm64)-temp$/.test(context.appOutDir)) {
+    return DARWIN_CLAUDE_NATIVE_PACKAGES;
+  }
+
+  // AfterPackContext.arch uses builder-util's numeric Arch enum.
+  switch (context.arch) {
+    case 1:
+    case "x64":
+      return DARWIN_CLAUDE_NATIVE_PACKAGES.filter(({ name }) =>
+        name.endsWith("-x64")
+      );
+    case 3:
+    case "arm64":
+      return DARWIN_CLAUDE_NATIVE_PACKAGES.filter(({ name }) =>
+        name.endsWith("-arm64")
+      );
+    case 4:
+    case "universal":
+      return DARWIN_CLAUDE_NATIVE_PACKAGES;
+    default:
+      throw new Error(
+        `unsupported macOS package architecture: ${context.arch}`
+      );
+  }
+}
+
+export function pruneDarwinClaudeNativePackages(
+  nodeModulesDir,
+  packagesToKeep
+) {
+  const keep = new Set(packagesToKeep.map(({ name }) => name));
+  for (const { name } of DARWIN_CLAUDE_NATIVE_PACKAGES) {
+    if (!keep.has(name)) {
+      rmSync(join(nodeModulesDir, name), { recursive: true, force: true });
+    }
+  }
+}
+
+export function verifyDarwinClaudeNativePackages(
+  nodeModulesDir,
+  packagesToVerify = DARWIN_CLAUDE_NATIVE_PACKAGES
+) {
+  for (const { name, lipoArch } of packagesToVerify) {
+    const binary = join(nodeModulesDir, name, "claude");
+    if (!existsSync(binary)) {
+      throw new Error(`vendored Claude native binary missing: ${binary}`);
+    }
+    try {
+      execFileSync("lipo", [binary, "-verify_arch", lipoArch], {
+        stdio: "pipe"
+      });
+    } catch (error) {
+      throw new Error(
+        `vendored Claude native binary does not contain ${lipoArch}: ${binary}`,
+        { cause: error }
+      );
+    }
+  }
+}

--- a/apps/desktop/scripts/copy-vendored-node-resources-after-pack.mjs
+++ b/apps/desktop/scripts/copy-vendored-node-resources-after-pack.mjs
@@ -8,6 +8,11 @@ import {
 } from "node:fs";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
+import {
+  pruneDarwinClaudeNativePackages,
+  resolveDarwinClaudeNativePackagesForPackContext,
+  verifyDarwinClaudeNativePackages
+} from "./claude-sdk-sidecar-packaging.mjs";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const desktopDir = join(__dirname, "..");
@@ -41,6 +46,7 @@ function copyNodeModules(resourcesDir, bundleName) {
   rmSync(join(destination, ".bin"), { recursive: true, force: true });
   removeSymlinks(destination);
   log(`copied ${bundleName} node_modules to ${destination}`);
+  return destination;
 }
 
 function removeSymlinks(root) {
@@ -60,5 +66,19 @@ function removeSymlinks(root) {
 export default async function copyVendoredNodeResourcesAfterPack(context) {
   const resourcesDir = resourcesDirForContext(context);
   copyNodeModules(resourcesDir, "browser-mcp");
-  copyNodeModules(resourcesDir, "claude-sdk-sidecar");
+  const claudeNodeModulesDir = copyNodeModules(
+    resourcesDir,
+    "claude-sdk-sidecar"
+  );
+  if (context.electronPlatformName === "darwin") {
+    const nativePackages =
+      resolveDarwinClaudeNativePackagesForPackContext(context);
+    pruneDarwinClaudeNativePackages(claudeNodeModulesDir, nativePackages);
+    verifyDarwinClaudeNativePackages(claudeNodeModulesDir, nativePackages);
+    log(
+      `kept Claude native packages for arch=${context.arch}: ${nativePackages
+        .map(({ name }) => name)
+        .join(", ")}`
+    );
+  }
 }

--- a/apps/desktop/scripts/vendor-claude-sdk-sidecar.mjs
+++ b/apps/desktop/scripts/vendor-claude-sdk-sidecar.mjs
@@ -3,9 +3,11 @@
 // apps/desktop/build/claude-sdk-sidecar so packaged desktop can launch it
 // without relying on repository sources.
 import { execFileSync } from "node:child_process";
+import { tmpdir } from "node:os";
 import {
   cpSync,
   existsSync,
+  mkdtempSync,
   mkdirSync,
   readFileSync,
   rmSync,
@@ -13,6 +15,11 @@ import {
 } from "node:fs";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
+import {
+  DARWIN_CLAUDE_NATIVE_PACKAGES,
+  resolveDarwinClaudeNativePackageSpecs,
+  verifyDarwinClaudeNativePackages
+} from "./claude-sdk-sidecar-packaging.mjs";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const desktopDir = join(__dirname, "..");
@@ -23,6 +30,9 @@ const sourcePackage = JSON.parse(
 );
 const outDir = join(desktopDir, "build", "claude-sdk-sidecar");
 const entryRelPath = join("src", "main.ts");
+const includeDarwinNativePackages = process.argv.includes(
+  "--include-darwin-native-packages"
+);
 
 function log(msg) {
   process.stderr.write(`[vendor-claude-sdk-sidecar] ${msg}\n`);
@@ -53,6 +63,65 @@ execFileSync(
   ["install", "--omit=dev", "--no-audit", "--no-fund", "--ignore-scripts"],
   { cwd: outDir, stdio: "inherit" }
 );
+
+if (includeDarwinNativePackages) {
+  const installedAgentSdkPackage = JSON.parse(
+    readFileSync(
+      join(
+        outDir,
+        "node_modules",
+        "@anthropic-ai",
+        "claude-agent-sdk",
+        "package.json"
+      ),
+      "utf8"
+    )
+  );
+  const nativePackageSpecs = resolveDarwinClaudeNativePackageSpecs(
+    installedAgentSdkPackage
+  );
+  const stagingDir = mkdtempSync(join(tmpdir(), "tutti-claude-native-"));
+  log(`vendoring macOS native packages: ${nativePackageSpecs.join(", ")}`);
+  try {
+    for (const [index, packageSpec] of nativePackageSpecs.entries()) {
+      const packOutput = execFileSync(
+        "npm",
+        ["pack", packageSpec, "--json", "--pack-destination", stagingDir],
+        {
+          cwd: outDir,
+          encoding: "utf8",
+          stdio: ["ignore", "pipe", "inherit"]
+        }
+      );
+      const packResult = JSON.parse(packOutput);
+      const filename = packResult[0]?.filename;
+      if (typeof filename !== "string" || filename.length === 0) {
+        throw new Error(
+          `npm pack did not return a filename for ${packageSpec}`
+        );
+      }
+
+      const packageName = DARWIN_CLAUDE_NATIVE_PACKAGES[index].name;
+      const destination = join(outDir, "node_modules", packageName);
+      rmSync(destination, { recursive: true, force: true });
+      mkdirSync(destination, { recursive: true });
+      execFileSync(
+        "tar",
+        [
+          "-xzf",
+          join(stagingDir, filename),
+          "--strip-components=1",
+          "-C",
+          destination
+        ],
+        { stdio: "inherit" }
+      );
+    }
+  } finally {
+    rmSync(stagingDir, { recursive: true, force: true });
+  }
+  verifyDarwinClaudeNativePackages(join(outDir, "node_modules"));
+}
 
 const entry = join(outDir, entryRelPath);
 if (!existsSync(entry)) {

--- a/docs/conventions/desktop-release.md
+++ b/docs/conventions/desktop-release.md
@@ -94,7 +94,7 @@ apps/desktop/build/tuttid/
 
 For macOS packages, the bundled `tuttid` daemon and `tutti` CLI must be universal binaries. Build both `darwin/arm64` and `darwin/amd64`, merge them with `lipo`, and verify the resulting binary contains `arm64` and `x86_64` slices before packaging.
 
-Vendored Node runtimes that bring their own Mach-O binaries, such as `claude-sdk-sidecar`, must be compatible with Electron's universal merge. If the same packaged binary is copied into both the x64 and arm64 app bundles, cover that path with `build.mac.x64ArchFiles` so `@electron/universal` can skip `lipo` for the duplicate resource.
+Vendored Node runtimes that bring their own Mach-O binaries, such as `claude-sdk-sidecar`, must not inherit the build runner architecture through npm optional dependency selection. macOS packaging must vendor and verify both Claude native packages before `electron-builder` runs. Keep only the matching package in x64 and arm64 artifacts, keep both in universal merge inputs and artifacts, and cover their paths with `build.mac.x64ArchFiles` so `@electron/universal` can skip merging duplicate resources.
 
 `electron-builder` then packages that daemon into the desktop app as:
 

--- a/tools/scripts/build-desktop-package.sh
+++ b/tools/scripts/build-desktop-package.sh
@@ -184,7 +184,14 @@ prepare_browser_mcp() {
 prepare_claude_sdk_sidecar() {
   # Vendors the Claude SDK sidecar into build/claude-sdk-sidecar so packaged
   # Claude SDK sessions do not depend on repository source paths at runtime.
-  node "${ROOT_DIR}/apps/desktop/scripts/vendor-claude-sdk-sidecar.mjs"
+  local args=()
+  if is_macos_package_variant; then
+    # Release packaging cross-builds x64, arm64, and universal apps on one
+    # runner. Vendor both native Claude CLIs instead of inheriting the runner's
+    # architecture through npm optional dependency selection.
+    args+=(--include-darwin-native-packages)
+  fi
+  node "${ROOT_DIR}/apps/desktop/scripts/vendor-claude-sdk-sidecar.mjs" "${args[@]}"
 }
 
 run_pnpm_build() {

--- a/tools/scripts/desktop-release-config.test.mjs
+++ b/tools/scripts/desktop-release-config.test.mjs
@@ -1,6 +1,11 @@
 import test from "node:test";
 import assert from "node:assert/strict";
 import { access, readFile } from "node:fs/promises";
+import {
+  DARWIN_CLAUDE_NATIVE_PACKAGES,
+  resolveDarwinClaudeNativePackageSpecs,
+  resolveDarwinClaudeNativePackagesForPackContext
+} from "../../apps/desktop/scripts/claude-sdk-sidecar-packaging.mjs";
 
 const desktopPackagePath = new URL(
   "../../apps/desktop/package.json",
@@ -13,6 +18,10 @@ const workflowPath = new URL(
 );
 const buildScriptPath = new URL(
   "../../tools/scripts/build-desktop-package.sh",
+  import.meta.url
+);
+const claudeSidecarVendorScriptPath = new URL(
+  "../../apps/desktop/scripts/vendor-claude-sdk-sidecar.mjs",
   import.meta.url
 );
 const electronViteConfigPath = new URL(
@@ -78,7 +87,10 @@ test("desktop release workflow publishes rc tags as prereleases and keeps stable
     workflow,
     /make_latest:\s+\${{\s*needs\.resolve\.outputs\.release_make_latest\s*==\s*'true'\s*}}/
   );
-  assert.match(workflow, /release_channel:\s+\${{\s*steps\.release\.outputs\.release_channel\s*}}/);
+  assert.match(
+    workflow,
+    /release_channel:\s+\${{\s*steps\.release\.outputs\.release_channel\s*}}/
+  );
   assert.match(workflow, /patch_beta_release\)\s*\n\s*strategy=patch_beta/);
 });
 
@@ -245,10 +257,7 @@ test("desktop release workflow generates summaries and stable changelog metadata
   assert.match(workflow, /secrets\.AGNES_API_KEY/);
   assert.match(workflow, /Upload desktop release summary artifact/);
   assert.match(workflow, /Update release notes with summary/);
-  assert.match(
-    workflow,
-    /apps\/desktop\/scripts\/upsert-release-summary\.mjs/
-  );
+  assert.match(workflow, /apps\/desktop\/scripts\/upsert-release-summary\.mjs/);
   assert.match(workflow, /Update desktop release changelog metadata/);
   assert.match(
     workflow,
@@ -258,13 +267,13 @@ test("desktop release workflow generates summaries and stable changelog metadata
     workflow,
     /grep -Eq "\(404\|NoSuchKey\|Not Found\)" changelog-download\.err/
   );
-  assert.match(
-    workflow,
-    /"schemaVersion":"tutti\.desktop\.changelog\.v1"/
-  );
+  assert.match(workflow, /"schemaVersion":"tutti\.desktop\.changelog\.v1"/);
   assert.match(workflow, /"\$\{s3_root\}\/changelog\.json"/);
   assert.match(workflow, /Download release summary/);
-  assert.match(workflow, /RELEASE_SUMMARY_PATH:\s+release-summary\/release-summary\.json/);
+  assert.match(
+    workflow,
+    /RELEASE_SUMMARY_PATH:\s+release-summary\/release-summary\.json/
+  );
 });
 
 test("desktop release workflow keeps GitHub release draft until assets are ready", async () => {
@@ -351,6 +360,10 @@ test("desktop release workflow materializes macOS signing certificate before pac
 
 test("desktop macOS packaging builds architecture-specific and universal artifacts", async () => {
   const buildScript = await readFile(buildScriptPath, "utf8");
+  const claudeSidecarVendorScript = await readFile(
+    claudeSidecarVendorScriptPath,
+    "utf8"
+  );
   const packageJson = JSON.parse(await readFile(desktopPackagePath, "utf8"));
 
   assert.match(packageJson.build.artifactName, /\$\{arch\}/);
@@ -362,10 +375,61 @@ test("desktop macOS packaging builds architecture-specific and universal artifac
     /lipo\s+"\$\{output_path\}"\s+-verify_arch\s+arm64\s+x86_64\s+\|\|\s+\{/
   );
   assert.match(buildScript, /electron-builder --mac --x64 --arm64 --universal/);
+  assert.match(buildScript, /--include-darwin-native-packages/);
+  assert.match(claudeSidecarVendorScript, /"npm",\s*\n\s*\["pack"/);
+  assert.match(
+    claudeSidecarVendorScript,
+    /verifyDarwinClaudeNativePackages\(join\(outDir, "node_modules"\)\)/
+  );
+  assert.deepEqual(
+    DARWIN_CLAUDE_NATIVE_PACKAGES.map(({ name, lipoArch }) => [name, lipoArch]),
+    [
+      ["@anthropic-ai/claude-agent-sdk-darwin-arm64", "arm64"],
+      ["@anthropic-ai/claude-agent-sdk-darwin-x64", "x86_64"]
+    ]
+  );
+  assert.deepEqual(
+    resolveDarwinClaudeNativePackageSpecs({
+      optionalDependencies: {
+        "@anthropic-ai/claude-agent-sdk-darwin-arm64": "1.2.3",
+        "@anthropic-ai/claude-agent-sdk-darwin-x64": "1.2.3"
+      }
+    }),
+    [
+      "@anthropic-ai/claude-agent-sdk-darwin-arm64@1.2.3",
+      "@anthropic-ai/claude-agent-sdk-darwin-x64@1.2.3"
+    ]
+  );
+  assert.deepEqual(
+    resolveDarwinClaudeNativePackagesForPackContext({
+      appOutDir: "/tmp/dist/mac",
+      arch: 1
+    }).map(({ name }) => name),
+    ["@anthropic-ai/claude-agent-sdk-darwin-x64"]
+  );
+  assert.deepEqual(
+    resolveDarwinClaudeNativePackagesForPackContext({
+      appOutDir: "/tmp/dist/mac-arm64",
+      arch: 3
+    }).map(({ name }) => name),
+    ["@anthropic-ai/claude-agent-sdk-darwin-arm64"]
+  );
+  for (const context of [
+    { appOutDir: "/tmp/dist/mac-universal-x64-temp", arch: 1 },
+    { appOutDir: "/tmp/dist/mac-universal-arm64-temp", arch: 3 },
+    { appOutDir: "/tmp/dist/mac-universal", arch: 4 }
+  ]) {
+    assert.deepEqual(
+      resolveDarwinClaudeNativePackagesForPackContext(context).map(
+        ({ name }) => name
+      ),
+      DARWIN_CLAUDE_NATIVE_PACKAGES.map(({ name }) => name)
+    );
+  }
   assert.equal(
     packageJson.build.mac.x64ArchFiles,
     "Contents/Resources/bin/claude-sdk-sidecar/node_modules/@anthropic-ai/claude-agent-sdk-darwin-*/claude",
-    "Claude SDK sidecar arch-specific binary must be covered for electron-builder universal merges"
+    "Claude SDK sidecar native binaries must be covered for electron-builder universal merges"
   );
 });
 


### PR DESCRIPTION
## Summary

- vendor both macOS Claude Agent SDK native packages explicitly instead of inheriting the GitHub Actions runner architecture
- verify each vendored Mach-O binary with `lipo` and validate again after `afterPack`
- keep only the matching native package in x64/arm64 artifacts while preserving both packages for universal merge inputs and artifacts
- document the packaging invariant and extend release configuration tests

## Root cause

The release workflow prepares `claude-sdk-sidecar/node_modules` once before cross-building x64, arm64, and universal apps. On the ARM64 macOS runner, npm selected only `@anthropic-ai/claude-agent-sdk-darwin-arm64`; the `afterPack` hook then copied that same tree into every artifact, including mac-x64.

## Impact

Official x64 builds now contain the x64 Claude CLI, arm64 builds contain the arm64 CLI, and universal builds contain both. This restores Claude Code sessions on x64 Macs without bloating single-architecture artifacts with the unused CLI.

## Validation

- `pnpm test:tools` — 174 tests passed
- `pnpm lint:go` — passed
- unsigned macOS packaging completed for x64, arm64, and universal
- inspected all generated ZIPs and verified their Claude CLI package sets
- verified packaged binaries with `file`/`lipo`
- executed the packaged arm64 Claude CLI successfully (`2.1.201`)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes macOS desktop packaging to include the correct Claude sidecar binary per target architecture. Restores Claude Code sessions on x64 Macs and keeps universal builds correct without adding unused binaries.

- Bug Fixes
  - Vendor both macOS native packages for `@anthropic-ai/claude-agent-sdk` via `npm pack`, then verify each with `lipo`.
  - On macOS `afterPack`, prune to the target arch for x64/arm64; keep both for universal intermediates and final app; verify again.
  - Add packaging helpers and pass `--include-darwin-native-packages` in the build script; cover native paths in `build.mac.x64ArchFiles` to skip universal merges.
  - Update docs and extend release config tests to enforce the packaging invariant.

<sup>Written for commit 63b9b631adec0a4e18cab8d7fc6fa287218c1f5a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tutti-os/tutti/pull/1015?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes affect release packaging and bundled Claude CLI binaries on macOS; mistakes could break Claude sessions or universal merges, but behavior is guarded by lipo verification and extended release config tests.
> 
> **Overview**
> Fixes **macOS Claude SDK sidecar packaging** when one CI runner prepares `node_modules` once and cross-builds x64, arm64, and universal apps. npm optional deps previously followed the runner arch (e.g. arm64-only on ARM runners), so **x64 artifacts could ship the wrong native `claude` binary**.
> 
> Adds **`claude-sdk-sidecar-packaging.mjs`** with shared logic to resolve both `@anthropic-ai/claude-agent-sdk-darwin-*` packages, **prune** extras per `electron-builder` arch (single slice for x64/arm64; both for universal merge temps and final universal), and **`lipo -verify_arch`** on vendored binaries.
> 
> **Vendor step:** macOS builds pass **`--include-darwin-native-packages`** from `build-desktop-package.sh`, which **`npm pack`s** both native packages from the installed Agent SDK versions and verifies them before packaging.
> 
> **After-pack:** `copy-vendored-node-resources-after-pack.mjs` prunes and re-verifies the copied sidecar `node_modules` for the current pack context.
> 
> **Docs and tests:** `desktop-release.md` documents the invariant; `desktop-release-config.test.mjs` asserts flag usage, pack/verify wiring, and arch-selection behavior. Existing **`build.mac.x64ArchFiles`** glob for sidecar native paths remains the universal-merge escape hatch.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 63b9b631adec0a4e18cab8d7fc6fa287218c1f5a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->