### PR TITLE
fix(agent): isolate deployment-specific runtime policy

### DIFF
--- a/packages/agent/runtimeprep/README.md
+++ b/packages/agent/runtimeprep/README.md
@@ -66,7 +66,26 @@ runtimeprep.CapabilityPack{
 
 Policy sections sort by anchor, order, and pack-qualified key. Duplicate pack
 names, unknown anchors, duplicate skill IDs, and unsafe skill file paths fail
-resolution rather than silently overriding content.
+resolution rather than silently overriding content. Sections apply to both
+provider runtime policy and dynamic skill bundles by default; set
+`PolicySection.Delivery` when a section is valid for only one delivery path.
+
+`StandardProfile` includes `CoreSkillsPack`, `TuttiDesktopHostPack`, browser
+use, and computer use. A non-desktop deployment should compose its own profile
+from `CoreSkillsPack` and deployment-owned packs instead of copying the
+desktop-host policy:
+
+```go
+profile := runtimeprep.DeploymentProfile{
+    Name:  "managed-vm",
+    Title: "Managed VM Runtime",
+    Intro: "This session runs inside the managed VM.",
+    Packs: []runtimeprep.CapabilityPack{
+        runtimeprep.CoreSkillsPack(),
+        vmEnvironmentPack,
+    },
+}
+```
 
 ## Skill Injection
 

--- a/packages/agent/runtimeprep/capability.go
+++ b/packages/agent/runtimeprep/capability.go
@@ -24,11 +24,19 @@ var policyAnchorRank = map[PolicyAnchor]int{
 }
 
 type PolicySection struct {
-	Anchor PolicyAnchor
-	Key    string
-	Order  int
-	Body   string
+	Anchor   PolicyAnchor
+	Key      string
+	Order    int
+	Delivery PolicyDelivery
+	Body     string
 }
+
+type PolicyDelivery string
+
+const (
+	PolicyDeliveryProviderRuntime PolicyDelivery = "provider-runtime"
+	PolicyDeliverySkillBundle     PolicyDelivery = "skill-bundle"
+)
 
 type SkillSpec struct {
 	ID        string
@@ -105,9 +113,46 @@ func StandardProfile() DeploymentProfile {
 		Title: "Tutti Runtime",
 		Intro: "This directory is being used by a Tutti AgentGUI session.",
 		Packs: []CapabilityPack{
-			standardSkillsPack(), BrowserUsePack(), ComputerUsePack(),
+			CoreSkillsPack(), TuttiDesktopHostPack(), BrowserUsePack(), ComputerUsePack(),
 		},
 	}
+}
+
+// CoreSkillsPack contributes the provider-neutral Tutti CLI and mention
+// routing skills. Deployment profiles should include this pack when they want
+// the shared skills without inheriting Tutti desktop-host policy.
+func CoreSkillsPack() CapabilityPack {
+	return CapabilityPack{Name: "tutti-core-skills", Resolve: func(_ context.Context, input PrepareInput) (CapabilityContribution, error) {
+		return CapabilityContribution{Enabled: true, Skills: []SkillSpec{
+			{ID: "tutti/tutti-cli", Name: tuttiSkillName, Files: map[string]string{"SKILL.md": tuttiCLISkill(input), commandGuideReferencePath: commandGuideReference(input)}},
+			{ID: "tutti/tutti-handoff", Name: tuttiHandoffSkillName, Files: map[string]string{"SKILL.md": tuttiHandoffSkill(input)}},
+			{ID: "tutti/issue-manager", Name: issueManagerSkillName, Files: map[string]string{"SKILL.md": issueManagerSkill(input)}},
+			{ID: "tutti/workspace-app", Name: workspaceAppSkillName, Files: map[string]string{"SKILL.md": workspaceAppSkill(input)}},
+			{ID: "tutti/reference", Name: referenceSkillName, Files: map[string]string{"SKILL.md": referenceSkill(input)}},
+		}}, nil
+	}}
+}
+
+// TuttiDesktopHostPack contributes policy that is true for the local Tutti
+// desktop host but not necessarily for other deployments such as managed VMs.
+func TuttiDesktopHostPack() CapabilityPack {
+	return CapabilityPack{Name: "tutti-desktop-host", Resolve: func(_ context.Context, input PrepareInput) (CapabilityContribution, error) {
+		return CapabilityContribution{Enabled: true, PolicySections: []PolicySection{
+			{
+				Anchor: PolicyAnchorTools,
+				Key:    "provider-execution",
+				Order:  -100,
+				Body:   providerSpecificExecutionEnvironment(input.Provider, input.CLICommand),
+			},
+			{
+				Anchor:   PolicyAnchorSpecialized,
+				Key:      "host-app-context",
+				Order:    1000,
+				Delivery: PolicyDeliveryProviderRuntime,
+				Body:     hostAppContextPolicy(),
+			},
+		}}, nil
+	}}
 }
 
 func BrowserUsePack() CapabilityPack {
@@ -129,18 +174,6 @@ func ComputerUsePack() CapabilityPack {
 			PolicySections: []PolicySection{{Anchor: PolicyAnchorTools, Key: "handoff", Body: computerUseHandoffPolicyLines(input)}},
 			EnvOverlay:     computerUseEnv(enabled),
 		}, nil
-	}}
-}
-
-func standardSkillsPack() CapabilityPack {
-	return CapabilityPack{Name: "tutti-core-skills", Resolve: func(_ context.Context, input PrepareInput) (CapabilityContribution, error) {
-		return CapabilityContribution{Enabled: true, Skills: []SkillSpec{
-			{ID: "tutti/tutti-cli", Name: tuttiSkillName, Files: map[string]string{"SKILL.md": tuttiCLISkill(input), commandGuideReferencePath: commandGuideReference(input)}},
-			{ID: "tutti/tutti-handoff", Name: tuttiHandoffSkillName, Files: map[string]string{"SKILL.md": tuttiHandoffSkill(input)}},
-			{ID: "tutti/issue-manager", Name: issueManagerSkillName, Files: map[string]string{"SKILL.md": issueManagerSkill(input)}},
-			{ID: "tutti/workspace-app", Name: workspaceAppSkillName, Files: map[string]string{"SKILL.md": workspaceAppSkill(input)}},
-			{ID: "tutti/reference", Name: referenceSkillName, Files: map[string]string{"SKILL.md": referenceSkill(input)}},
-		}}, nil
 	}}
 }
 
@@ -184,6 +217,9 @@ func resolveCapabilities(ctx context.Context, input PrepareInput, profile Deploy
 			}
 			if strings.TrimSpace(section.Key) == "" {
 				section.Key = fmt.Sprintf("section-%d", index)
+			}
+			if section.Delivery != "" && section.Delivery != PolicyDeliveryProviderRuntime && section.Delivery != PolicyDeliverySkillBundle {
+				return nil, fmt.Errorf("capability pack %s uses unknown policy delivery %q", name, section.Delivery)
 			}
 			section.Key = name + "/" + section.Key
 		}
@@ -262,13 +298,15 @@ func skillSupportsProvider(skill SkillSpec, provider string) bool {
 	return false
 }
 
-func renderPolicySections(input PrepareInput, anchor PolicyAnchor) string {
+func renderPolicySections(input PrepareInput, anchor PolicyAnchor, delivery PolicyDelivery) string {
 	if input.resolved == nil {
 		return ""
 	}
 	var bodies []string
 	for _, section := range input.resolved.PolicySections {
-		if section.Anchor == anchor && strings.TrimSpace(section.Body) != "" {
+		if section.Anchor == anchor &&
+			(section.Delivery == "" || section.Delivery == delivery) &&
+			strings.TrimSpace(section.Body) != "" {
 			bodies = append(bodies, strings.TrimSpace(section.Body))
 		}
 	}

--- a/packages/agent/runtimeprep/capability_test.go
+++ b/packages/agent/runtimeprep/capability_test.go
@@ -51,6 +51,35 @@ func TestDefaultPreparerResolvesInjectedPackAcrossPolicySkillsAndEnv(t *testing.
 	}
 }
 
+func TestCustomDeploymentProfileDoesNotInheritTuttiDesktopHostPolicy(t *testing.T) {
+	t.Parallel()
+
+	bundle, err := Resolve(t.Context(), PrepareInput{
+		WorkspaceID: "workspace-1", AgentSessionID: "session-1", Provider: "codex", CLICommand: "tutti",
+	}, DeploymentProfile{
+		Name:  "managed-vm",
+		Title: "Managed VM",
+		Intro: "Runs in a managed VM.",
+		Packs: []CapabilityPack{CoreSkillsPack()},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, forbidden := range []string{
+		"# Host App Context",
+		"Tutti desktop app host",
+		"sandbox_permissions=require_escalated",
+		"`tutti-dev`",
+	} {
+		if strings.Contains(bundle.SystemPrompt, forbidden) {
+			t.Fatalf("managed VM prompt inherited desktop host policy %q: %s", forbidden, bundle.SystemPrompt)
+		}
+	}
+	if len(bundle.Skills) != 5 {
+		t.Fatalf("managed VM core skill count = %d, want 5", len(bundle.Skills))
+	}
+}
+
 func TestResolveCapabilitiesRejectsDuplicateSkillIDs(t *testing.T) {
 	profile := DeploymentProfile{Name: "test", Packs: []CapabilityPack{
 		{Name: "one", Resolve: staticCapability(SkillSpec{ID: "shared/skill", Name: "one", Files: map[string]string{"SKILL.md": "one"}})},

--- a/packages/agent/runtimeprep/tutti_cli_policy.go
+++ b/packages/agent/runtimeprep/tutti_cli_policy.go
@@ -1,12 +1,22 @@
 package runtimeprep
 
 import (
+	"context"
 	"sort"
 	"strings"
 )
 
 func tuttiCLIPolicy(input PrepareInput) string {
-	return tuttiRuntimePolicy(input) + "\n\n" + strings.TrimSpace(renderProviderSkillTemplate("policy_templates/host-app-context.md", nil))
+	if input.resolved == nil {
+		if resolved, err := resolveCapabilities(context.Background(), input, StandardProfile(), nil); err == nil {
+			input.resolved = resolved
+		}
+	}
+	return tuttiRuntimePolicy(input)
+}
+
+func hostAppContextPolicy() string {
+	return strings.TrimSpace(renderProviderSkillTemplate("policy_templates/host-app-context.md", nil))
 }
 
 func tuttiRuntimePolicy(input PrepareInput) string {
@@ -21,11 +31,11 @@ func tuttiRuntimePolicy(input PrepareInput) string {
 			"{{AGENT_SESSION_ID}}":                        strings.TrimSpace(input.AgentSessionID),
 			"{{PROVIDER}}":                                strings.TrimSpace(input.Provider),
 			"{{PROVIDER_SPECIFIC_MENTION_ROUTING}}":       providerSpecificMentionRouting(input.Provider),
-			"{{PROVIDER_SPECIFIC_EXECUTION_ENVIRONMENT}}": providerSpecificExecutionEnvironment(input.Provider),
-			"{{ENVIRONMENT_POLICY_SECTIONS}}":             renderPolicySections(input, PolicyAnchorEnvironment),
-			"{{TOOLS_POLICY_SECTIONS}}":                   capabilityPolicyLines(input),
-			"{{SKILL_STRATEGY_POLICY_SECTIONS}}":          renderPolicySections(input, PolicyAnchorSkillStrategy),
-			"{{SPECIALIZED_POLICY_SECTIONS}}":             renderPolicySections(input, PolicyAnchorSpecialized),
+			"{{PROVIDER_SPECIFIC_EXECUTION_ENVIRONMENT}}": "",
+			"{{ENVIRONMENT_POLICY_SECTIONS}}":             renderPolicySections(input, PolicyAnchorEnvironment, PolicyDeliveryProviderRuntime),
+			"{{TOOLS_POLICY_SECTIONS}}":                   capabilityPolicyLines(input, PolicyDeliveryProviderRuntime),
+			"{{SKILL_STRATEGY_POLICY_SECTIONS}}":          renderPolicySections(input, PolicyAnchorSkillStrategy, PolicyDeliveryProviderRuntime),
+			"{{SPECIALIZED_POLICY_SECTIONS}}":             renderPolicySections(input, PolicyAnchorSpecialized, PolicyDeliveryProviderRuntime),
 		},
 	))
 }
@@ -54,18 +64,18 @@ func tuttiSkillBundleRecommendedPolicy(input PrepareInput) string {
 			"{{AGENT_SESSION_ID}}":                        strings.TrimSpace(input.AgentSessionID),
 			"{{PROVIDER}}":                                strings.TrimSpace(input.Provider),
 			"{{PROVIDER_SPECIFIC_MENTION_ROUTING}}":       providerSpecificMentionRouting(input.Provider),
-			"{{PROVIDER_SPECIFIC_EXECUTION_ENVIRONMENT}}": providerSpecificExecutionEnvironment(input.Provider),
-			"{{ENVIRONMENT_POLICY_SECTIONS}}":             renderPolicySections(input, PolicyAnchorEnvironment),
-			"{{TOOLS_POLICY_SECTIONS}}":                   capabilityPolicyLines(input),
-			"{{SKILL_STRATEGY_POLICY_SECTIONS}}":          renderPolicySections(input, PolicyAnchorSkillStrategy),
-			"{{SPECIALIZED_POLICY_SECTIONS}}":             renderPolicySections(input, PolicyAnchorSpecialized),
+			"{{PROVIDER_SPECIFIC_EXECUTION_ENVIRONMENT}}": "",
+			"{{ENVIRONMENT_POLICY_SECTIONS}}":             renderPolicySections(input, PolicyAnchorEnvironment, PolicyDeliverySkillBundle),
+			"{{TOOLS_POLICY_SECTIONS}}":                   capabilityPolicyLines(input, PolicyDeliverySkillBundle),
+			"{{SKILL_STRATEGY_POLICY_SECTIONS}}":          renderPolicySections(input, PolicyAnchorSkillStrategy, PolicyDeliverySkillBundle),
+			"{{SPECIALIZED_POLICY_SECTIONS}}":             renderPolicySections(input, PolicyAnchorSpecialized, PolicyDeliverySkillBundle),
 		},
 	))
 }
 
-func capabilityPolicyLines(input PrepareInput) string {
+func capabilityPolicyLines(input PrepareInput, delivery PolicyDelivery) string {
 	if input.resolved != nil {
-		return renderPolicySections(input, PolicyAnchorTools)
+		return renderPolicySections(input, PolicyAnchorTools, delivery)
 	}
 	return strings.TrimSpace(browserUseHandoffPolicyLines(input) + computerUseHandoffPolicyLines(input))
 }
@@ -106,14 +116,15 @@ Claude Code mention routing:
 	}
 }
 
-func providerSpecificExecutionEnvironment(provider string) string {
+func providerSpecificExecutionEnvironment(provider string, cliCommand string) string {
+	command := normalizeCLICommandName(cliCommand)
 	switch strings.ToLower(strings.TrimSpace(provider)) {
 	case "codex":
-		return "- Codex: `tutti-dev` needs localhost/IPC. When running `tutti-dev` from a sandboxed exec tool, set `sandbox_permissions=require_escalated`. If `tutti-dev` reports `daemon is not reachable from this agent execution environment`, rerun once with `sandbox_permissions=require_escalated`.\n"
+		return "- Codex: `" + command + "` needs localhost/IPC. When running `" + command + "` from a sandboxed exec tool, set `sandbox_permissions=require_escalated`. If `" + command + "` reports `daemon is not reachable from this agent execution environment`, rerun once with `sandbox_permissions=require_escalated`.\n"
 	case "claude", "claude-code":
-		return "- Claude Code `Monitor` tool is disabled. Poll async Tutti jobs with one bounded shell/script.\n- Claude Code: run `tutti-dev` only from a shell environment that can reach localhost/IPC. If the provider runtime cannot reach the local Tutti daemon, report that limitation; do not invent Codex `sandbox_permissions`.\n"
+		return "- Claude Code `Monitor` tool is disabled. Poll async Tutti jobs with one bounded shell/script.\n- Claude Code: run `" + command + "` only from a shell environment that can reach localhost/IPC. If the provider runtime cannot reach the local Tutti daemon, report that limitation; do not invent Codex `sandbox_permissions`.\n"
 	case "cursor", "cursor-agent", "hermes", "hermes-agent", "nexight", "tutti", "openclaw", "open-claw", "opencode", "open-code":
-		return "- This provider must run `tutti-dev` from an execution environment with localhost/IPC access. If the daemon is unreachable from the provider runtime, report that limitation instead of retrying with provider-specific sandbox flags.\n"
+		return "- This provider must run `" + command + "` from an execution environment with localhost/IPC access. If the daemon is unreachable from the provider runtime, report that limitation instead of retrying with provider-specific sandbox flags.\n"
 	default:
 		return ""
 	}


### PR DESCRIPTION
## What changed
- expose `CoreSkillsPack` separately from the Tutti desktop-host capability pack
- move desktop-only provider execution guidance and Host App Context into `TuttiDesktopHostPack`
- add policy delivery scoping so provider-only sections do not leak into dynamic skill bundles
- document how VM deployments compose a profile without inheriting desktop-host policy

## Why
TSH is now consuming `runtimeprep` inside its managed Linux VM. In v0.0.82, custom deployment profiles still inherited the hard-coded Tutti desktop host context and `tutti-dev` execution rules, which defeated the profile/pack boundary and would produce contradictory VM instructions.

## Risk
The standard Tutti profile retains the same desktop guidance. The main affected surface is policy composition order and delivery filtering; a regression could omit desktop host rendering instructions or add them to dynamic skill bundles.

## Verification
- `cd packages/agent/runtimeprep && go test ./...`
- `git diff --check`

## Follow-up
After merge and package release, TSH will consume the new version and compose its VM profile from `CoreSkillsPack` plus TSH-owned capability packs.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Isolates desktop-host runtime policy from core skills and scopes policy delivery. VM and other non-desktop profiles no longer inherit Tutti desktop rules or leak provider-only guidance into skill bundles.

- **Bug Fixes**
  - Introduced `CoreSkillsPack` and moved desktop-only guidance and Host App Context into `TuttiDesktopHostPack`.
  - Updated `StandardProfile` to use `CoreSkillsPack` + `TuttiDesktopHostPack` (desktop behavior unchanged).
  - Added `PolicyDelivery` and filtering in renderers to target provider runtime vs skill bundles; updated tests and docs.

- **Migration**
  - For VM/non-desktop deployments, compose your profile with `CoreSkillsPack` plus your capability packs; do not include `TuttiDesktopHostPack`.
  - No changes needed for the default desktop profile.

<sup>Written for commit 0f0c695c21184d81c55b6efc4b61d707e3274e09. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tutti-os/tutti/pull/1017?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

