### PR TITLE
feat(agent): add CLI updates to environment checks

### DIFF
--- a/apps/desktop/src/renderer/src/features/analytics/reporters/agent-node-result/types.ts
+++ b/apps/desktop/src/renderer/src/features/analytics/reporters/agent-node-result/types.ts
@@ -41,7 +41,8 @@ export type AgentAnalyticsNode =
   | "runtime_started"
   | "send_input_request"
   | "session_refreshed"
-  | "session_started_reported";
+  | "session_started_reported"
+  | "update_action_requested";
 
 export type AgentAnalyticsNodeStatus = "success" | "failure";
 

--- a/apps/desktop/src/renderer/src/features/workspace-agent/services/internal/agentEnvWizardController.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-agent/services/internal/agentEnvWizardController.ts
@@ -87,6 +87,7 @@ function buildRawViewModel(p: AttachAgentEnvWizardParams) {
     isLoading: snap.isLoading,
     activeAction: readCodexSetupActiveAction(status),
     installActionPending: p.service.isActionPending(p.provider, "install"),
+    updateActionPending: p.service.isActionPending(p.provider, "update"),
     loginPending: p.service.isActionPending(p.provider, "login"),
     revealIndex: REVEAL_ALL,
     stageLabels: ORCHESTRATION_LABELS

--- a/apps/desktop/src/renderer/src/features/workspace-agent/services/internal/desktopAgentProviderStatusService.test.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-agent/services/internal/desktopAgentProviderStatusService.test.ts
@@ -129,7 +129,14 @@ test("a local-only refresh keeps the network the wizard fetched", async () => {
       snapshots: [
         // Wizard fetch (with network).
         createStatusResponse([
-          createProviderStatus({ actions: [], availability: "ready", network })
+          createProviderStatus({
+            actions: [],
+            availability: "ready",
+            cliLatestVersion: "0.200.0",
+            cliUpdateAvailable: true,
+            cliVersion: "0.190.0",
+            network
+          })
         ]),
         // Dock / poll fetch (local-only, no network).
         createStatusResponse([
@@ -144,10 +151,62 @@ test("a local-only refresh keeps the network the wizard fetched", async () => {
 
   await service.refresh(["codex"], { includeNetwork: true });
   assert.deepEqual(service.getStatus("codex")?.network, network);
+  assert.equal(service.getStatus("codex")?.cli.latestVersion, "0.200.0");
+  assert.equal(service.getStatus("codex")?.cli.updateAvailable, true);
 
   // A later local-only poll omits network; it must not wipe the diagnostic.
   await service.refresh(["codex"]);
   assert.deepEqual(service.getStatus("codex")?.network, network);
+  assert.equal(service.getStatus("codex")?.cli.latestVersion, "0.200.0");
+  assert.equal(service.getStatus("codex")?.cli.updateAvailable, true);
+});
+
+test("runAction updates a provider through the daemon and rechecks latest version metadata", async () => {
+  const actionCalls: Array<[WorkspaceAgentProvider, string]> = [];
+  const includeNetworkRequests: Array<boolean | undefined> = [];
+  const pendingSnapshots: boolean[] = [];
+  const service = new DesktopAgentProviderStatusService({
+    tuttidClient: createTuttidClient({
+      onRunActionRequest: (provider, actionID) =>
+        actionCalls.push([provider, actionID]),
+      onStatusRequest: (_providers, includeNetwork) =>
+        includeNetworkRequests.push(includeNetwork),
+      snapshots: [
+        createStatusResponse([
+          createProviderStatus({
+            actions: [{ id: "update", kind: "daemon_action" }],
+            availability: "ready",
+            cliLatestVersion: "2.1.200",
+            cliUpdateAvailable: true,
+            cliVersion: "2.1.100",
+            provider: "claude-code"
+          })
+        ]),
+        createStatusResponse([
+          createProviderStatus({
+            actions: [{ id: "update", kind: "daemon_action" }],
+            availability: "ready",
+            cliLatestVersion: "2.1.200",
+            cliUpdateAvailable: false,
+            cliVersion: "2.1.200",
+            provider: "claude-code"
+          })
+        ])
+      ]
+    }),
+    terminalCommandRunner: { async runTerminalCommand() {} }
+  });
+  service.subscribe(() => {
+    pendingSnapshots.push(service.isActionPending("claude-code", "update"));
+  });
+
+  await service.refresh(["claude-code"]);
+  await service.runAction("claude-code", "update");
+
+  assert.deepEqual(actionCalls, [["claude-code", "update"]]);
+  assert.deepEqual(includeNetworkRequests, [undefined, true]);
+  assert.equal(pendingSnapshots.includes(true), true);
+  assert.equal(service.getStatus("claude-code")?.cli.updateAvailable, false);
 });
 
 test("runAction tracks provider login initiation and successful status result", async () => {
@@ -1834,6 +1893,9 @@ function createProviderStatus(input: {
   adapterInstalled?: boolean;
   availability: AgentProviderStatus["availability"]["status"];
   cliInstalled?: boolean;
+  cliLatestVersion?: string;
+  cliUpdateAvailable?: boolean;
+  cliVersion?: string;
   network?: AgentProviderStatus["network"];
   provider?: WorkspaceAgentProvider;
   reasonCode?: string;
@@ -1859,7 +1921,10 @@ function createProviderStatus(input: {
       status: input.availability
     },
     cli: {
-      installed: cliInstalled
+      installed: cliInstalled,
+      latestVersion: input.cliLatestVersion,
+      updateAvailable: input.cliUpdateAvailable ?? false,
+      version: input.cliVersion
     },
     network: input.network,
     provider: input.provider ?? "codex"

--- a/apps/desktop/src/renderer/src/features/workspace-agent/services/internal/desktopAgentProviderStatusService.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-agent/services/internal/desktopAgentProviderStatusService.ts
@@ -335,15 +335,22 @@ export class DesktopAgentProviderStatusService implements IAgentProviderStatusSe
       this.addPendingAction(provider, actionId);
     }
     try {
-      if (action.id === "install") {
-        await runInstalledProviderAction(
+      if (action.id === "install" || action.id === "update") {
+        await runDaemonProviderAction(
           this.dependencies.tuttidClient,
-          provider
+          provider,
+          action.id
         );
-        await this.refresh([provider]);
+        await this.refresh(
+          [provider],
+          action.id === "update" ? { includeNetwork: true } : undefined
+        );
         await this.reportNodeResult({
           flow: "provider_setup",
-          node: "install_action_requested",
+          node:
+            action.id === "update"
+              ? "update_action_requested"
+              : "install_action_requested",
           provider,
           success: true
         });
@@ -398,6 +405,24 @@ export class DesktopAgentProviderStatusService implements IAgentProviderStatusSe
           fallbackErrorCode: AgentAnalyticsErrorCode.InstallFailed,
           flow: "provider_setup",
           node: "install_action_requested",
+          provider,
+          success: false
+        });
+      }
+      if (action.id === "update") {
+        this.notifications.error({
+          description: translate(
+            "workspace.workbenchDesktop.agentProviders.updateFailedDescription"
+          ),
+          title: translate(
+            "workspace.workbenchDesktop.agentProviders.updateFailed"
+          )
+        });
+        await this.reportNodeResult({
+          error,
+          fallbackErrorCode: AgentAnalyticsErrorCode.InstallFailed,
+          flow: "provider_setup",
+          node: "update_action_requested",
           provider,
           success: false
         });
@@ -561,20 +586,34 @@ export class DesktopAgentProviderStatusService implements IAgentProviderStatusSe
   }
 
   /**
-   * Network reachability is now fetched on-demand (only the wizard requests it),
-   * so a local-only poll (dock / visibility / install / login) returns a status
-   * with no `network`. Carry the last-known network forward so those polls don't
-   * wipe the diagnostic the wizard fetched; a later with-network response replaces
-   * it.
+   * Network reachability and latest CLI release metadata are fetched on-demand
+   * (only the wizard requests them), so a local-only poll returns neither.
+   * Carry the last-known values forward so install/login/update progress polls
+   * do not make diagnostics or the update banner flicker; the next with-network
+   * response replaces them.
    */
   private preserveNetwork(
     previous: AgentProviderStatus | undefined,
     next: AgentProviderStatus
   ): AgentProviderStatus {
-    if (next.network || !previous?.network) {
+    if (
+      (next.network || !previous?.network) &&
+      (next.cli.latestVersion || !previous?.cli.latestVersion)
+    ) {
       return next;
     }
-    return { ...next, network: previous.network };
+    return {
+      ...next,
+      cli:
+        next.cli.latestVersion || !previous?.cli.latestVersion
+          ? next.cli
+          : {
+              ...next.cli,
+              latestVersion: previous.cli.latestVersion,
+              updateAvailable: previous.cli.updateAvailable
+            },
+      network: next.network ?? previous?.network ?? null
+    };
   }
 
   private stabilizeProviderStatus(
@@ -734,7 +773,7 @@ export class DesktopAgentProviderStatusService implements IAgentProviderStatusSe
     provider: WorkspaceAgentProvider,
     actionId: string
   ): void {
-    if (actionId !== "install") {
+    if (actionId !== "install" && actionId !== "update") {
       return;
     }
     this.schedulePendingActionStatusPoll(provider, actionId);
@@ -1106,11 +1145,12 @@ class AgentProviderInstallActionFailedError extends Error {
   }
 }
 
-async function runInstalledProviderAction(
+async function runDaemonProviderAction(
   tuttidClient: TuttidClient,
-  provider: WorkspaceAgentProvider
+  provider: WorkspaceAgentProvider,
+  actionId: "install" | "update"
 ): Promise<void> {
-  const result = await tuttidClient.runAgentProviderAction(provider, "install");
+  const result = await tuttidClient.runAgentProviderAction(provider, actionId);
   if (result.status !== "failed") {
     return;
   }
@@ -1129,7 +1169,7 @@ function resolveAgentProviderActionFailureReason(
     result.stdout?.trim() ||
     result.probe?.message?.trim() ||
     result.probe?.reasonCode?.trim() ||
-    "Agent provider install action failed."
+    "Agent provider action failed."
   );
 }
 
@@ -1253,7 +1293,7 @@ function isTransientProviderStatusDowngrade(
 }
 
 function shouldTrackPendingAction(actionId: string): boolean {
-  return actionId === "install";
+  return actionId === "install" || actionId === "update";
 }
 
 // Avoid decorator syntax so the renderer Babel pass can parse this file.

--- a/apps/desktop/src/renderer/src/features/workspace-agent/ui/AgentEnvSetupTrack.tsx
+++ b/apps/desktop/src/renderer/src/features/workspace-agent/ui/AgentEnvSetupTrack.tsx
@@ -78,7 +78,9 @@ export function AgentEnvSetupTrack({
     blockingStageId,
     manualCommand,
     installPending,
+    updatePending,
     loginPending,
+    cliUpdateNotice,
     redetecting,
     ready,
     busy,
@@ -89,6 +91,39 @@ export function AgentEnvSetupTrack({
     stages.find((entry) => entry.id === "detect")?.status === "running";
   return (
     <div className="flex flex-col gap-4">
+      {cliUpdateNotice ? (
+        <div
+          role="status"
+          className="flex items-start gap-2.5 rounded-[8px] border border-[color-mix(in_srgb,var(--state-warning)_32%,var(--border-1))] bg-[color-mix(in_srgb,var(--state-warning)_10%,transparent)] p-3"
+        >
+          <WarningFilledIcon className="mt-0.5 size-4 shrink-0 text-[var(--state-warning)]" />
+          <p className="m-0 min-w-0 flex-1 text-[12px] leading-5 text-[var(--text-primary)]">
+            {t("workspace.agentEnv.cliUpdateWarning", {
+              provider: providerLabel,
+              current:
+                cliUpdateNotice.currentVersion ??
+                t("workspace.agentEnv.valueUnknown"),
+              latest:
+                cliUpdateNotice.targetVersion ??
+                t("workspace.agentEnv.valueUnknown")
+            })}
+          </p>
+          {blockingStageId !== "install" ? (
+            <Button
+              type="button"
+              size="sm"
+              disabled={updatePending || installPending}
+              onClick={() => actions.runStageAction("update")}
+            >
+              {updatePending ? (
+                <LoadingIcon className="size-4 animate-spin" />
+              ) : null}
+              {t("workspace.agentEnv.actionUpdateCli")}
+            </Button>
+          ) : null}
+        </div>
+      ) : null}
+
       {ready ? null : (
         <p className="m-0 text-[13px] text-[var(--text-secondary)]">
           {busy
@@ -127,11 +162,13 @@ export function AgentEnvSetupTrack({
           const actionPending =
             remediation?.actionId === "login"
               ? loginPending
-              : remediation?.actionId === "redetect"
-                ? // Re-detect stays disabled for the whole install (busy is
-                  // stable, unlike redetecting/isLoading which flickers per poll).
-                  redetecting || busy
-                : installPending;
+              : remediation?.actionId === "update"
+                ? updatePending
+                : remediation?.actionId === "redetect"
+                  ? // Re-detect stays disabled for the whole install (busy is
+                    // stable, unlike redetecting/isLoading which flickers per poll).
+                    redetecting || busy
+                  : installPending;
           return (
             <li
               key={stage.id}

--- a/apps/desktop/src/renderer/src/features/workspace-agent/ui/agentEnvPanelText.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-agent/ui/agentEnvPanelText.ts
@@ -48,14 +48,11 @@ export function describeStageProblem(
         isError: false
       };
     case "install-outdated":
-      // We don't auto-upgrade a present CLI: the headline states it's outdated,
-      // the manual upgrade command is shown below, and the action re-checks
-      // once the user has upgraded it themselves.
       return {
         headline: t("workspace.agentEnv.stageProblemInstallOutdated", {
           provider: providerLabel
         }),
-        actionLabel: t("workspace.agentEnv.stageDoRedetect"),
+        actionLabel: t("workspace.agentEnv.stageDoUpgrade"),
         isError: true
       };
     case "install-platform-incomplete":

--- a/apps/desktop/src/renderer/src/features/workspace-agent/ui/useAgentEnvWizard.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-agent/ui/useAgentEnvWizard.ts
@@ -109,7 +109,7 @@ export function useAgentEnvWizard(input: {
   );
 
   const runProviderAction = useCallback(
-    async (actionId: "install" | "login") => {
+    async (actionId: "install" | "update" | "login") => {
       if (provider === "tutti-agent" && actionId === "login") {
         await accountService.startLogin();
         return;
@@ -172,6 +172,7 @@ export function useAgentEnvWizard(input: {
         isLoading: snapshot.isLoading,
         activeAction: readCodexSetupActiveAction(status),
         installActionPending: service.isActionPending(provider, "install"),
+        updateActionPending: service.isActionPending(provider, "update"),
         loginPending: service.isActionPending(provider, "login"),
         revealIndex: wizard.revealIndex,
         stageLabels

--- a/apps/desktop/src/shared/i18n/locales/en.ts
+++ b/apps/desktop/src/shared/i18n/locales/en.ts
@@ -176,6 +176,9 @@ export const en = {
       ready: "{{provider}} is ready to run.",
       busyInstalling: "Setting up {{provider}}…",
       busyVerifying: "Verifying {{provider}}…",
+      cliUpdateWarning:
+        "{{provider}} CLI {{current}} is behind the latest version {{latest}}. Update it for current features and fixes.",
+      actionUpdateCli: "Update CLI",
       actionDetect: "Re-check",
       redetectDisabledInstalling: "Can't re-check while setting up",
       redetectDisabledChecking: "Checking…",
@@ -886,6 +889,9 @@ export const en = {
         installFailed: "Connection failed",
         installFailedDescription:
           "Unable to connect the local agent right now. Try again in a moment.",
+        updateFailed: "CLI update failed",
+        updateFailedDescription:
+          "Unable to update the local agent CLI right now. Check the setup log and try again.",
         installFailedMissingRuntime:
           "The local agent executable could not be found. Check that it is installed correctly.",
         installFailedOutdatedLocalAgent:

--- a/apps/desktop/src/shared/i18n/locales/zh-CN.ts
+++ b/apps/desktop/src/shared/i18n/locales/zh-CN.ts
@@ -173,6 +173,9 @@ export const zhCN = {
       ready: "{{provider}} 已就绪。",
       busyInstalling: "正在设置 {{provider}}…",
       busyVerifying: "正在校验 {{provider}}…",
+      cliUpdateWarning:
+        "{{provider}} CLI 当前版本为 {{current}}，低于最新版本 {{latest}}。建议更新以获得最新功能与修复。",
+      actionUpdateCli: "更新 CLI",
       actionDetect: "重新检测",
       redetectDisabledInstalling: "安装进行中，暂时无法重新检测",
       redetectDisabledChecking: "正在检测…",
@@ -841,6 +844,9 @@ export const zhCN = {
         install: "连接",
         installFailed: "连接失败",
         installFailedDescription: "暂时无法连接本地 Agent，请稍后重试",
+        updateFailed: "CLI 更新失败",
+        updateFailedDescription:
+          "暂时无法更新本地 Agent CLI，请查看安装日志后重试。",
         installFailedMissingRuntime:
           "找不到本地 Agent 可执行文件，请检查是否已正确安装",
         installFailedOutdatedLocalAgent: "检测到旧版本本地 Agent，自动升级失败",

--- a/docs/architecture/agent-gui-node.md
+++ b/docs/architecture/agent-gui-node.md
@@ -272,6 +272,19 @@ whose runtime command is more authoritative than its lightweight status check
 (for example Cursor), the desktop status service may run a provider-specific
 runtime probe and fold a ready result back into the provider status snapshot
 before projecting the empty-home readiness gate.
+CLI release checks belong to the desktop environment wizard's opt-in network
+path, not startup readiness. `tuttid` may resolve the latest stable Codex or
+Claude Code package version while `includeNetwork` is enabled and publish
+`cli.latestVersion` plus `cli.updateAvailable`; local-only dock and polling
+requests must remain network-free. Desktop should preserve the last fetched
+release metadata across those local polls so an update warning does not
+flicker, then request a fresh network check after an update completes. CLI
+mutation remains daemon-owned: both providers delegate to the resolved CLI's
+official `update` command so the existing installation source is preserved;
+older Codex versions may fall back to the managed npm installer and its
+registry/prefix safeguards. AgentGUI owns neither version comparison nor
+process execution; it only renders the host-projected warning and dispatches
+the reported provider action.
 Startup provider detection should be progressive: desktop may publish the first
 ready managed provider as soon as it is confirmed, then continue detecting the
 remaining providers in the background. When the empty-home rail is still on

--- a/packages/agent/gui/shared/agentEnv/agentEnvViewModel.spec.ts
+++ b/packages/agent/gui/shared/agentEnv/agentEnvViewModel.spec.ts
@@ -25,6 +25,8 @@ function status(
       installed: true,
       binaryPath: "/usr/bin/codex",
       version: "1.2.3",
+      latestVersion: "1.2.3",
+      updateAvailable: false,
       minVersion: "1.0.0"
     },
     adapter: {
@@ -55,6 +57,7 @@ function input(
     isLoading: false,
     activeAction: null,
     installActionPending: false,
+    updateActionPending: false,
     loginPending: false,
     revealIndex: Number.MAX_SAFE_INTEGER,
     stageLabels: LABELS,
@@ -95,6 +98,54 @@ describe("buildAgentEnvWizardViewModel", () => {
       required: "1.0.0"
     });
     expect(install?.status).toBe("error");
+    expect(vm.cliUpdateNotice).toEqual({
+      currentVersion: "0.9.0",
+      targetVersion: "1.0.0"
+    });
+  });
+
+  it("surfaces a non-blocking CLI update notice from the latest registry version", () => {
+    const vm = buildAgentEnvWizardViewModel(
+      input({
+        provider: "claude-code",
+        status: status({
+          provider: "claude-code",
+          cli: {
+            installed: true,
+            version: "2.1.100",
+            latestVersion: "2.1.200",
+            updateAvailable: true,
+            binaryPath: "/usr/bin/claude",
+            minVersion: null
+          }
+        })
+      })
+    );
+    expect(vm.ready).toBe(true);
+    expect(vm.cliUpdateNotice).toEqual({
+      currentVersion: "2.1.100",
+      targetVersion: "2.1.200"
+    });
+  });
+
+  it("treats a pending CLI update as busy and runs the CLI stage", () => {
+    const vm = buildAgentEnvWizardViewModel(
+      input({
+        updateActionPending: true,
+        status: status({
+          availability: {
+            status: "auth_required",
+            reasonCode: "auth_required"
+          },
+          auth: { status: "required", accountLabel: null, authMethod: null }
+        })
+      })
+    );
+    expect(vm.busy).toBe(true);
+    expect(vm.updatePending).toBe(true);
+    expect(
+      vm.displayStages.find((stage) => stage.id === "install")?.status
+    ).toBe("running");
   });
 
   it("does NOT red the install (CLI) stage on an adapter version mismatch", () => {

--- a/packages/agent/gui/shared/agentEnv/agentEnvViewModel.ts
+++ b/packages/agent/gui/shared/agentEnv/agentEnvViewModel.ts
@@ -79,6 +79,7 @@ export interface AgentEnvWizardViewModelInput {
   isLoading: boolean;
   activeAction: CodexSetupActiveAction | null;
   installActionPending: boolean;
+  updateActionPending: boolean;
   loginPending: boolean;
   revealIndex: number;
   stageLabels: AgentSetupStageLabels;
@@ -98,7 +99,12 @@ export interface AgentEnvWizardViewModel {
   error: CodexSetupActiveActionError | null;
   manualCommand: string | null;
   installPending: boolean;
+  updatePending: boolean;
   loginPending: boolean;
+  cliUpdateNotice: {
+    currentVersion: string | null;
+    targetVersion: string | null;
+  } | null;
 }
 
 export function buildAgentEnvWizardViewModel(
@@ -107,9 +113,11 @@ export function buildAgentEnvWizardViewModel(
   const { status, activeAction, provider } = input;
   const ready = status?.availability.status === "ready";
   const installPending = input.installActionPending;
+  const updatePending = input.updateActionPending;
   const loginPending = input.loginPending;
   const busy =
     installPending ||
+    updatePending ||
     activeAction?.phase === "install" ||
     activeAction?.phase === "repair" ||
     activeAction?.phase === "verify";
@@ -211,6 +219,7 @@ export function buildAgentEnvWizardViewModel(
     ready: Boolean(ready),
     activePhase: activeAction?.phase ?? null,
     installActionPending: installPending,
+    updateActionPending: updatePending,
     loginPending,
     networkReachable,
     cliVersionDetail: cliDetail,
@@ -240,6 +249,14 @@ export function buildAgentEnvWizardViewModel(
     blockingStage && input.revealIndex >= blockingIndex
       ? blockingStage.id
       : null;
+  const cliUpdateNotice =
+    status?.cli.updateAvailable === true || versionTooOld
+      ? {
+          currentVersion: status?.cli.version ?? null,
+          targetVersion:
+            status?.cli.latestVersion ?? status?.cli.minVersion ?? null
+        }
+      : null;
 
   return {
     ready: Boolean(ready),
@@ -255,6 +272,8 @@ export function buildAgentEnvWizardViewModel(
     error: activeAction?.error ?? null,
     manualCommand: MANUAL_INSTALL_COMMANDS[provider] ?? null,
     installPending,
+    updatePending,
+    cliUpdateNotice,
     loginPending
   };
 }

--- a/packages/agent/gui/shared/agentEnv/agentEnvWizardFlow.spec.ts
+++ b/packages/agent/gui/shared/agentEnv/agentEnvWizardFlow.spec.ts
@@ -60,6 +60,7 @@ function input(
     ready: false,
     activePhase: null,
     installActionPending: false,
+    updateActionPending: false,
     loginPending: false,
     networkReachable: true,
     cliVersionDetail: null,
@@ -180,6 +181,18 @@ describe("deriveAgentSetupStages", () => {
     );
     expect(stage(stages, "install").status).toBe("ok");
     expect(stage(stages, "adapter").status).toBe("running");
+  });
+
+  it("shows an installed CLI running while its update action is pending", () => {
+    const stages = deriveAgentSetupStages(
+      input({
+        cliInstalled: true,
+        adapterInstalled: true,
+        updateActionPending: true
+      })
+    );
+    expect(stage(stages, "install").status).toBe("running");
+    expect(stage(stages, "adapter").status).toBe("ok");
   });
 
   it("marks adapter ok and error from its own flags", () => {
@@ -386,9 +399,9 @@ describe("stageRemediation", () => {
     });
   });
 
-  it("maps an errored install to install-outdated → redetect (manual upgrade, not auto-install)", () => {
+  it("maps an errored install to install-outdated → update", () => {
     expect(stageRemediation(mk("install", "error"))).toEqual({
-      actionId: "redetect",
+      actionId: "update",
       problem: "install-outdated"
     });
   });
@@ -444,7 +457,7 @@ describe("resolveWizardAutoStartAction", () => {
     );
   });
 
-  it("does NOT auto-start install for upgrade focus (CLI upgrades are user-driven)", () => {
+  it("does NOT auto-start update for upgrade focus (CLI upgrades are user-confirmed)", () => {
     expect(
       resolveWizardAutoStartAction({ ...base, focus: "upgrade" })
     ).toBeNull();

--- a/packages/agent/gui/shared/agentEnv/agentEnvWizardFlow.ts
+++ b/packages/agent/gui/shared/agentEnv/agentEnvWizardFlow.ts
@@ -80,6 +80,8 @@ export interface DeriveAgentSetupStagesInput {
    * would show no spinner.
    */
   installActionPending: boolean;
+  /** Whether an installed CLI is currently updating in place. */
+  updateActionPending: boolean;
   loginPending: boolean;
   /**
    * Active connectivity probe verdict: true (reachable), false (offline), or
@@ -141,8 +143,10 @@ export function deriveAgentSetupStages(
       !input.versionTooOld &&
       !input.platformPackageIncomplete);
   const installStatus: CodexSetupStepStatus = cliOk
-    ? "ok"
-    : installing
+    ? input.updateActionPending
+      ? "running"
+      : "ok"
+    : installing || input.updateActionPending
       ? "running"
       : input.versionTooOld
         ? "error"
@@ -259,7 +263,7 @@ export function shouldAdvanceReveal(
   return cursor.status === "ok" || cursor.status === "skipped";
 }
 
-export type StageActionId = "install" | "login" | "redetect";
+export type StageActionId = "install" | "update" | "login" | "redetect";
 
 /**
  * The problem token a blocked stage represents. The UI maps this to "未xxx"
@@ -307,11 +311,9 @@ export function stageRemediation(
         return { actionId: "install", problem: stage.problem };
       }
       // A genuinely missing CLI is installed for the user; a present-but-
-      // outdated CLI is NOT — we don't silently reinstall a binary the user
-      // manages. Instead the panel shows the manual upgrade command and
-      // re-detection confirms it once they've upgraded.
+      // outdated CLI uses the provider-specific update action.
       return stage.status === "error"
-        ? { actionId: "redetect", problem: "install-outdated" }
+        ? { actionId: "update", problem: "install-outdated" }
         : { actionId: "install", problem: "install-missing" };
     case "adapter":
       return {
@@ -367,9 +369,9 @@ function autoStartCandidate(
     case "repair":
       return "install";
     case "upgrade":
-      // CLI upgrades are user-driven: opening the panel from a version error
-      // shows the manual upgrade command rather than auto-running an install
-      // (which can't upgrade an already-present binary anyway).
+      // CLI upgrades remain user-confirmed: opening the panel from a version
+      // error shows the warning and update action without immediately mutating
+      // the user's installed tool.
       return null;
     case "auth":
       return "login";

--- a/packages/clients/tuttid-ts/src/generated/types.gen.ts
+++ b/packages/clients/tuttid-ts/src/generated/types.gen.ts
@@ -1085,7 +1085,7 @@ export type AgentProviderActionKind =
   | "terminal_command"
   | "refresh";
 
-export type AgentProviderActionId = "install" | "login" | "refresh";
+export type AgentProviderActionId = "install" | "update" | "login" | "refresh";
 
 export type AgentProviderProbeStatus = "ready" | "failed" | "skipped";
 
@@ -1171,6 +1171,14 @@ export type AgentProviderCliStatus = {
   installed: boolean;
   binaryPath?: string | null;
   version?: string | null;
+  /**
+   * The latest stable CLI version reported by the provider's package registry during an opt-in network check. Omitted when the version lookup is unavailable or was not requested.
+   */
+  latestVersion?: string | null;
+  /**
+   * Whether latestVersion is newer than the installed version. False when either version is unavailable or cannot be compared.
+   */
+  updateAvailable?: boolean;
   /**
    * The lowest CLI version this provider supports, when it enforces a floor (currently codex). Lets the UI show "current X, requires >= Y" without duplicating the backend's version gate.
    */

--- a/services/tuttid/api/daemon_agent_statuses.go
+++ b/services/tuttid/api/daemon_agent_statuses.go
@@ -334,10 +334,12 @@ func generatedAgentProviderAvailability(availability agentstatusservice.Availabi
 
 func generatedAgentProviderCLIStatus(status agentstatusservice.CLIStatus) tuttigenerated.AgentProviderCliStatus {
 	return tuttigenerated.AgentProviderCliStatus{
-		BinaryPath: stringPointerIfNotBlank(status.BinaryPath),
-		Installed:  status.Installed,
-		Version:    stringPointerIfNotBlank(status.Version),
-		MinVersion: stringPointerIfNotBlank(status.MinVersion),
+		BinaryPath:      stringPointerIfNotBlank(status.BinaryPath),
+		Installed:       status.Installed,
+		LatestVersion:   stringPointerIfNotBlank(status.LatestVersion),
+		MinVersion:      stringPointerIfNotBlank(status.MinVersion),
+		UpdateAvailable: boolPointer(status.UpdateAvailable),
+		Version:         stringPointerIfNotBlank(status.Version),
 	}
 }
 

--- a/services/tuttid/api/daemon_agent_statuses_test.go
+++ b/services/tuttid/api/daemon_agent_statuses_test.go
@@ -67,7 +67,10 @@ func TestDaemonAPIRoutesAgentProviderStatuses(t *testing.T) {
 							Status: agentstatusservice.AvailabilityUnknown,
 						},
 						CLI: agentstatusservice.CLIStatus{
-							Installed: true,
+							Installed:       true,
+							Version:         "2.1.100",
+							LatestVersion:   "2.1.200",
+							UpdateAvailable: true,
 						},
 						Provider: "claude-code",
 					}},
@@ -91,6 +94,12 @@ func TestDaemonAPIRoutesAgentProviderStatuses(t *testing.T) {
 	}
 	if response.Providers[0].Provider != "claude-code" {
 		t.Fatalf("provider = %q, want claude-code", response.Providers[0].Provider)
+	}
+	if response.Providers[0].Cli.LatestVersion == nil || *response.Providers[0].Cli.LatestVersion != "2.1.200" {
+		t.Fatalf("cli.latestVersion = %#v, want 2.1.200", response.Providers[0].Cli.LatestVersion)
+	}
+	if response.Providers[0].Cli.UpdateAvailable == nil || !*response.Providers[0].Cli.UpdateAvailable {
+		t.Fatalf("cli.updateAvailable = %#v, want true", response.Providers[0].Cli.UpdateAvailable)
 	}
 	activeAction := response.Providers[0].ActiveAction
 	if activeAction == nil {

--- a/services/tuttid/api/generated/types.gen.go
+++ b/services/tuttid/api/generated/types.gen.go
@@ -114,6 +114,7 @@ const (
 	AgentProviderActionIDInstall AgentProviderActionID = "install"
 	AgentProviderActionIDLogin   AgentProviderActionID = "login"
 	AgentProviderActionIDRefresh AgentProviderActionID = "refresh"
+	AgentProviderActionIDUpdate  AgentProviderActionID = "update"
 )
 
 // Valid indicates whether the value is a known member of the AgentProviderActionID enum.
@@ -124,6 +125,8 @@ func (e AgentProviderActionID) Valid() bool {
 	case AgentProviderActionIDLogin:
 		return true
 	case AgentProviderActionIDRefresh:
+		return true
+	case AgentProviderActionIDUpdate:
 		return true
 	default:
 		return false
@@ -2057,9 +2060,15 @@ type AgentProviderCliStatus struct {
 	BinaryPath *string `json:"binaryPath,omitempty"`
 	Installed  bool    `json:"installed"`
 
+	// LatestVersion The latest stable CLI version reported by the provider's package registry during an opt-in network check. Omitted when the version lookup is unavailable or was not requested.
+	LatestVersion *string `json:"latestVersion,omitempty"`
+
 	// MinVersion The lowest CLI version this provider supports, when it enforces a floor (currently codex). Lets the UI show "current X, requires >= Y" without duplicating the backend's version gate.
 	MinVersion *string `json:"minVersion,omitempty"`
-	Version    *string `json:"version,omitempty"`
+
+	// UpdateAvailable Whether latestVersion is newer than the installed version. False when either version is unavailable or cannot be compared.
+	UpdateAvailable *bool   `json:"updateAvailable,omitempty"`
+	Version         *string `json:"version,omitempty"`
 }
 
 // AgentProviderComposerConfig defines model for AgentProviderComposerConfig.

--- a/services/tuttid/api/openapi/tuttid.v1.yaml
+++ b/services/tuttid/api/openapi/tuttid.v1.yaml
@@ -6389,6 +6389,7 @@ components:
       type: string
       enum:
         - install
+        - update
         - login
         - refresh
     AgentProviderProbeStatus:
@@ -6603,6 +6604,18 @@ components:
         version:
           type: string
           nullable: true
+        latestVersion:
+          type: string
+          nullable: true
+          description: >-
+            The latest stable CLI version reported by the provider's package
+            registry during an opt-in network check. Omitted when the version
+            lookup is unavailable or was not requested.
+        updateAvailable:
+          type: boolean
+          description: >-
+            Whether latestVersion is newer than the installed version. False
+            when either version is unavailable or cannot be compared.
         minVersion:
           type: string
           nullable: true

--- a/services/tuttid/service/agentstatus/active_action.go
+++ b/services/tuttid/service/agentstatus/active_action.go
@@ -161,12 +161,15 @@ func activeActionForProvider(provider string) *ActiveAction {
 }
 
 // providerInstallInFlight reports whether the provider currently has a running
-// install action. The network does not change during an install, so List skips
-// the slow connectivity probe for such providers — otherwise the per-second
-// install-progress poll re-probes (and flickers) a flaky proxy on every tick.
+// install or CLI update action. The network does not change during either
+// mutation, so List skips the slow connectivity probe for such providers —
+// otherwise the per-second progress poll re-probes (and flickers) a flaky proxy
+// on every tick.
 func providerInstallInFlight(provider string) bool {
 	action := activeActionForProvider(provider)
-	return action != nil && action.ID == ActionInstall && action.Status == "running"
+	return action != nil &&
+		(action.ID == ActionInstall || action.ID == ActionUpdate) &&
+		action.Status == "running"
 }
 
 func activeActionOutputStats(output string) (int, int) {

--- a/services/tuttid/service/agentstatus/cli_update.go
+++ b/services/tuttid/service/agentstatus/cli_update.go
@@ -1,0 +1,152 @@
+package agentstatus
+
+import (
+	"context"
+	"strings"
+	"time"
+
+	"github.com/tutti-os/tutti/services/tuttid/biz/agentprovider"
+)
+
+func agentProviderCLINPMPackage(provider string) string {
+	switch provider {
+	case agentprovider.Codex:
+		return "@openai/codex"
+	case agentprovider.ClaudeCode:
+		return "@anthropic-ai/claude-code"
+	default:
+		return ""
+	}
+}
+
+func providerSupportsCLIUpdate(provider string) bool {
+	return agentProviderCLINPMPackage(provider) != ""
+}
+
+// runUpdateAction updates an already-installed first-party CLI using the
+// provider-specific safe path. Both providers get the resolved CLI's official
+// self-updater first so native, Homebrew, and npm installations keep their own
+// update semantics. Older Codex versions that lack the update command fall back
+// to Tutti's managed npm installer and its registry/prefix safeguards.
+func (s Service) runUpdateAction(
+	ctx context.Context,
+	spec ProviderSpec,
+	result RunActionResult,
+) (RunActionResult, error) {
+	if result, ok := unsupportedProviderRunActionResult(spec, result); ok {
+		return result, nil
+	}
+	if !providerSupportsCLIUpdate(spec.Provider) {
+		result.Status = RunActionFailed
+		result.ReasonCode = "cli_update_unsupported"
+		result.Message = "Provider CLI update is unsupported"
+		return result, nil
+	}
+
+	runtimeResolution := s.resolveProviderRuntime(ctx, spec)
+	if strings.TrimSpace(runtimeResolution.CLIPath) == "" {
+		result.Status = RunActionFailed
+		result.ReasonCode = "cli_not_found"
+		result.Message = "CLI binary not found"
+		return result, nil
+	}
+
+	updateCtx := withActiveActionToken(baseContext(ctx), nextActiveActionToken())
+	claimActiveAction(updateCtx, spec.Provider, ActiveAction{
+		ID:     ActionUpdate,
+		Status: "running",
+		Step:   "update",
+	})
+	defer clearActiveAction(updateCtx, spec.Provider)
+
+	command, commandResult, err := s.executeCLIUpdateInstaller(
+		updateCtx,
+		spec,
+		&runtimeResolution,
+	)
+	result.Command = command
+	result.ExitCode = intPointer(commandResult.ExitCode)
+	result.Stdout = trimActionOutput(commandResult.Stdout)
+	result.Stderr = trimActionOutput(commandResult.Stderr)
+	if err != nil {
+		return updateActionErrorResult(result, err, s.installTimeout()), nil
+	}
+	if commandResult.ExitCode != 0 {
+		result.Status = RunActionFailed
+		result.ReasonCode = "update_command_failed"
+		result.Message = firstNonBlank(result.Stderr, result.Stdout, "CLI update command failed")
+		return result, nil
+	}
+
+	setActiveAction(updateCtx, spec.Provider, ActiveAction{
+		ID:     ActionUpdate,
+		Status: "running",
+		Step:   "verify",
+		Stdout: commandResult.Stdout,
+	})
+	probe, err := s.Probe(ctx, ProbeInput{Provider: spec.Provider})
+	if err != nil {
+		return RunActionResult{}, err
+	}
+	result.Probe = &probe
+	if probe.Status == ProbeFailed {
+		result.Status = RunActionFailed
+		result.ReasonCode = "post_update_probe_failed"
+		result.Message = firstNonBlank(probe.Message, probe.ReasonCode, "Agent provider runtime probe failed after CLI update")
+		return result, nil
+	}
+	result.Status = RunActionCompleted
+	return result, nil
+}
+
+func (s Service) executeCLIUpdateInstaller(
+	ctx context.Context,
+	spec ProviderSpec,
+	runtimeResolution *providerRuntimeResolution,
+) (string, InstallCommandResult, error) {
+	nativeCommand := joinShellCommand([]string{runtimeResolution.CLIPath, "update"})
+	nativeInstaller := InstallerSpec{
+		Kind:           InstallerKindShellCommand,
+		DisplayCommand: nativeCommand,
+		ShellCommand:   nativeCommand,
+	}
+	command, result, err := s.executeInstaller(ctx, spec.Provider, nativeInstaller, runtimeResolution)
+	if spec.Provider != agentprovider.Codex || (err == nil && result.ExitCode == 0) || spec.Install.Kind == "" {
+		return command, result, err
+	}
+
+	fallbackCommand, fallbackResult, fallbackErr := s.executeInstaller(
+		ctx,
+		spec.Provider,
+		spec.Install,
+		runtimeResolution,
+	)
+	fallbackResult.Stdout = joinUpdateOutputs(result.Stdout, fallbackResult.Stdout)
+	fallbackResult.Stderr = joinUpdateOutputs(result.Stderr, fallbackResult.Stderr)
+	return command + " || " + fallbackCommand, fallbackResult, fallbackErr
+}
+
+func joinUpdateOutputs(outputs ...string) string {
+	nonEmpty := make([]string, 0, len(outputs))
+	for _, output := range outputs {
+		if trimmed := strings.TrimSpace(output); trimmed != "" {
+			nonEmpty = append(nonEmpty, trimmed)
+		}
+	}
+	return strings.Join(nonEmpty, "\n")
+}
+
+func updateActionErrorResult(result RunActionResult, err error, timeout time.Duration) RunActionResult {
+	// Keep the user-facing action result aligned with install failures while
+	// retaining update-specific reason codes for telemetry and diagnostics.
+	installResult := installActionErrorResult(result, err, timeout)
+	switch installResult.ReasonCode {
+	case "install_timed_out":
+		installResult.ReasonCode = "update_timed_out"
+	case "install_canceled":
+		installResult.ReasonCode = "update_canceled"
+	case "install_start_failed":
+		installResult.ReasonCode = "update_start_failed"
+	}
+	return installResult
+}

--- a/services/tuttid/service/agentstatus/cli_update_test.go
+++ b/services/tuttid/service/agentstatus/cli_update_test.go
@@ -1,0 +1,113 @@
+package agentstatus
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestServiceRunActionUpdatesClaudeCodeWithOfficialCLICommand(t *testing.T) {
+	home := t.TempDir()
+	binDir := filepath.Join(home, "bin")
+	claudePath := filepath.Join(binDir, "claude")
+	if err := os.MkdirAll(binDir, 0o755); err != nil {
+		t.Fatalf("mkdir bin: %v", err)
+	}
+	writeExecutable(t, claudePath, `#!/bin/sh
+if [ "$1" = "--version" ]; then echo '2.1.100 (Claude Code)'; exit 0; fi
+sleep 1
+`)
+	t.Setenv(claudeSDKSidecarCommandEnv, claudePath)
+
+	var updateCommand string
+	service := Service{
+		Environ: func() []string { return []string{"PATH=" + binDir} },
+		HomeDir: func() (string, error) { return home, nil },
+		LookPath: func(name string) (string, error) {
+			if name == "claude" || name == claudePath {
+				return claudePath, nil
+			}
+			return "", errors.New("not found")
+		},
+		IsExecutableFile: isTestExecutable,
+		InstallCommand: func(_ context.Context, input InstallCommandInput) (InstallCommandResult, error) {
+			updateCommand = input.Command
+			return InstallCommandResult{ExitCode: 0, Stdout: "updated"}, nil
+		},
+		RunAuthStatusCommand: func(context.Context, ProviderSpec, string) (AuthInfo, bool) {
+			return AuthInfo{Status: AuthAuthenticated}, true
+		},
+		Now:             func() time.Time { return time.Date(2026, 7, 10, 8, 0, 0, 0, time.UTC) },
+		ProbeReadyAfter: 10 * time.Millisecond,
+		ProbeTimeout:    100 * time.Millisecond,
+	}
+
+	result, err := service.RunAction(context.Background(), RunActionInput{
+		Provider: "claude-code",
+		ActionID: ActionUpdate,
+	})
+	if err != nil {
+		t.Fatalf("RunAction() error = %v", err)
+	}
+	if result.Status != RunActionCompleted {
+		t.Fatalf("Status = %q, want completed; result=%#v", result.Status, result)
+	}
+	if !strings.Contains(updateCommand, claudePath) || !strings.HasSuffix(updateCommand, " update") {
+		t.Fatalf("update command = %q, want resolved Claude CLI update", updateCommand)
+	}
+	if result.Probe == nil || result.Probe.Status != ProbeReady {
+		t.Fatalf("Probe = %#v, want ready", result.Probe)
+	}
+	if action := activeActionForProvider("claude-code"); action != nil {
+		t.Fatalf("active action = %#v, want cleared", action)
+	}
+}
+
+func TestCodexUpdateFallsBackToManagedInstallerWhenNativeCommandFails(t *testing.T) {
+	commands := []string{}
+	service := Service{
+		Environ: func() []string { return nil },
+		HomeDir: func() (string, error) { return t.TempDir(), nil },
+		InstallCommand: func(_ context.Context, input InstallCommandInput) (InstallCommandResult, error) {
+			commands = append(commands, input.Command)
+			if strings.Contains(input.Command, " update") {
+				return InstallCommandResult{ExitCode: 2, Stderr: "unknown subcommand update"}, nil
+			}
+			return InstallCommandResult{ExitCode: 0, Stdout: "installed from npm"}, nil
+		},
+	}
+	spec := ProviderSpec{
+		Provider: "codex",
+		Install: InstallerSpec{
+			Kind:           InstallerKindShellCommand,
+			DisplayCommand: "npm install -g @openai/codex",
+			ShellCommand:   "npm install -g @openai/codex",
+		},
+	}
+	runtimeResolution := providerRuntimeResolution{CLIPath: "/opt/homebrew/bin/codex"}
+
+	command, result, err := service.executeCLIUpdateInstaller(
+		context.Background(),
+		spec,
+		&runtimeResolution,
+	)
+	if err != nil {
+		t.Fatalf("executeCLIUpdateInstaller() error = %v", err)
+	}
+	if len(commands) != 2 {
+		t.Fatalf("commands = %#v, want native update then managed fallback", commands)
+	}
+	if !strings.Contains(command, "codex update") || !strings.Contains(command, "npm install") {
+		t.Fatalf("reported command = %q, want both attempts", command)
+	}
+	if result.ExitCode != 0 || !strings.Contains(result.Stdout, "installed from npm") {
+		t.Fatalf("result = %#v, want successful fallback", result)
+	}
+	if !strings.Contains(result.Stderr, "unknown subcommand update") {
+		t.Fatalf("stderr = %q, want native failure retained", result.Stderr)
+	}
+}

--- a/services/tuttid/service/agentstatus/network_probe_test.go
+++ b/services/tuttid/service/agentstatus/network_probe_test.go
@@ -3,9 +3,11 @@ package agentstatus
 import (
 	"context"
 	"errors"
+	"io"
 	"net"
 	"net/http"
 	"net/url"
+	"os"
 	"strings"
 	"testing"
 	"time"
@@ -39,6 +41,53 @@ func TestProbeRegistryReachableReturnsOfficial(t *testing.T) {
 	got := svc.probeRegistry(context.Background(), "@openai/codex")
 	if !got.Reachable || got.Endpoint != officialNPMRegistry {
 		t.Fatalf("probeRegistry() = %#v, want reachable official", got)
+	}
+}
+
+func TestListReportsLatestClaudeCodeVersionAndUpdateAvailability(t *testing.T) {
+	binDir := t.TempDir()
+	claudePath := binDir + "/claude"
+	if err := os.WriteFile(claudePath, []byte("#!/bin/sh\necho '2.1.100 (Claude Code)'\n"), 0o755); err != nil {
+		t.Fatalf("write claude fixture: %v", err)
+	}
+	service := testService(func(name string) (string, error) {
+		if name == "claude" {
+			return claudePath, nil
+		}
+		return "", errors.New("not found")
+	}, map[string]bool{})
+	service.HTTPClient = &http.Client{Transport: networkRoundTripFunc(func(request *http.Request) (*http.Response, error) {
+		var body io.ReadCloser = http.NoBody
+		if request.Method == http.MethodGet && strings.HasSuffix(request.URL.Path, "/latest") {
+			body = io.NopCloser(strings.NewReader(`{"version":"2.1.200"}`))
+		}
+		return &http.Response{StatusCode: http.StatusOK, Body: body}, nil
+	})}
+	service.ResolveProxy = func(*http.Request) (*url.URL, error) { return nil, nil }
+
+	snapshot, err := service.List(context.Background(), ListInput{
+		Providers:      []string{agentprovider.ClaudeCode},
+		IncludeNetwork: true,
+	})
+	if err != nil {
+		t.Fatalf("List() error = %v", err)
+	}
+	status := onlyStatus(t, snapshot)
+	if status.CLI.Version != "2.1.100" {
+		t.Fatalf("CLI.Version = %q, want 2.1.100", status.CLI.Version)
+	}
+	if status.CLI.LatestVersion != "2.1.200" {
+		t.Fatalf("CLI.LatestVersion = %q, want 2.1.200", status.CLI.LatestVersion)
+	}
+	if !status.CLI.UpdateAvailable {
+		t.Fatal("CLI.UpdateAvailable = false, want true")
+	}
+	specs, err := DefaultRegistry().Select([]string{agentprovider.ClaudeCode})
+	if err != nil || len(specs) != 1 {
+		t.Fatalf("select Claude Code spec: specs=%#v err=%v", specs, err)
+	}
+	if got := agentNPMRegistryProbePackage(specs[0]); got != "@anthropic-ai/claude-code" {
+		t.Fatalf("Claude registry probe package = %q, want @anthropic-ai/claude-code", got)
 	}
 }
 

--- a/services/tuttid/service/agentstatus/npm_registry.go
+++ b/services/tuttid/service/agentstatus/npm_registry.go
@@ -2,6 +2,7 @@ package agentstatus
 
 import (
 	"context"
+	"encoding/json"
 	"io"
 	"log/slog"
 	"net/http"
@@ -176,6 +177,37 @@ func npmRegistryPackageEndpoint(registry string, packageName string) string {
 	}
 	escapedPackage := strings.ReplaceAll(packageName, "/", "%2f")
 	return registry + "/" + escapedPackage
+}
+
+// fetchNPMRegistryLatestVersion reads the package registry's stable `latest`
+// manifest. The environment wizard calls this only during its opt-in network
+// check, so normal provider readiness remains local-only and fast.
+func (s Service) fetchNPMRegistryLatestVersion(ctx context.Context, registry string, packageName string) string {
+	endpoint := npmRegistryPackageEndpoint(registry, packageName)
+	if endpoint == "" {
+		return ""
+	}
+	attemptCtx, cancel := context.WithTimeout(ctx, networkProbeAttemptTimeout)
+	defer cancel()
+	request, err := http.NewRequestWithContext(attemptCtx, http.MethodGet, endpoint+"/latest", nil)
+	if err != nil {
+		return ""
+	}
+	response, err := s.httpClient().Do(request)
+	if err != nil {
+		return ""
+	}
+	defer response.Body.Close()
+	if response.StatusCode < http.StatusOK || response.StatusCode >= http.StatusMultipleChoices {
+		return ""
+	}
+	var manifest struct {
+		Version string `json:"version"`
+	}
+	if err := json.NewDecoder(io.LimitReader(response.Body, 256*1024)).Decode(&manifest); err != nil {
+		return ""
+	}
+	return strings.TrimSpace(manifest.Version)
 }
 
 // withAgentNPMRegistry returns env with exactly one npm_config_registry entry.

--- a/services/tuttid/service/agentstatus/service.go
+++ b/services/tuttid/service/agentstatus/service.go
@@ -45,6 +45,7 @@ type ActionID string
 
 const (
 	ActionInstall ActionID = "install"
+	ActionUpdate  ActionID = "update"
 	ActionLogin   ActionID = "login"
 	ActionRefresh ActionID = "refresh"
 )
@@ -154,9 +155,11 @@ type Availability struct {
 }
 
 type CLIStatus struct {
-	Installed  bool
-	BinaryPath string
-	Version    string
+	Installed       bool
+	BinaryPath      string
+	Version         string
+	LatestVersion   string
+	UpdateAvailable bool
 	// MinVersion is the lowest CLI version this provider supports, when it
 	// enforces a floor (codex). Empty for providers with no version gate. Lets
 	// the UI surface "current X, requires >= Y" from the same constant the gate uses.
@@ -292,7 +295,15 @@ func (s Service) List(ctx context.Context, input ListInput) (Snapshot, error) {
 			if installing[i] {
 				continue
 			}
+			cliPackage := agentProviderCLINPMPackage(specs[i].Provider)
 			registry := s.probeRegistry(ctx, agentNPMRegistryProbePackage(specs[i]))
+			if registry.Reachable && cliPackage != "" {
+				latestVersion := s.fetchNPMRegistryLatestVersion(ctx, registry.Endpoint, cliPackage)
+				statuses[i].CLI.LatestVersion = latestVersion
+				if comparison, ok := compareCodexVersions(statuses[i].CLI.Version, latestVersion); ok {
+					statuses[i].CLI.UpdateAvailable = comparison < 0
+				}
+			}
 			api := s.probeProviderAPI(ctx, statuses[i].Provider)
 			statuses[i].Network = &NetworkStatus{
 				Registry:    registry,
@@ -418,6 +429,17 @@ func (s Service) RunAction(ctx context.Context, input RunActionInput) (RunAction
 		s.reportProviderSetupNodeResult(ctx, providerSetupNodeResultInput{
 			Error:     err,
 			Node:      "install_daemon_action",
+			Provider:  spec.Provider,
+			Result:    result,
+			StartedAt: startedAt,
+		})
+		return result, err
+	case ActionUpdate:
+		startedAt := s.now()
+		result, err := s.runUpdateAction(ctx, spec, result)
+		s.reportProviderSetupNodeResult(ctx, providerSetupNodeResultInput{
+			Error:     err,
+			Node:      "update_daemon_action",
 			Provider:  spec.Provider,
 			Result:    result,
 			StartedAt: startedAt,
@@ -620,7 +642,7 @@ func (s Service) statusForSpec(ctx context.Context, spec ProviderSpec, now time.
 	} else if spec.Provider == agentprovider.Codex && !codexVersionMeetsMinimum(cliVersion) {
 		availability.Status = AvailabilityNotInstalled
 		availability.ReasonCode = codexReasonCodeFromErrorCode(string(CodexErrVersionTooOld))
-		actions = append(actions, daemonAction(ActionInstall))
+		actions = append(actions, daemonAction(ActionUpdate))
 	} else {
 		actions = append(actions, terminalAction(ActionLogin, loginCommandForRuntime(spec, runtimeResolution)))
 
@@ -651,6 +673,9 @@ func (s Service) statusForSpec(ctx context.Context, spec ProviderSpec, now time.
 				availability.ReasonCode = "auth_unknown"
 				actions = append(actions, Action{ID: ActionRefresh, Kind: ActionKindRefresh})
 			}
+		}
+		if providerSupportsCLIUpdate(spec.Provider) {
+			actions = append(actions, daemonAction(ActionUpdate))
 		}
 	}
 
@@ -718,6 +743,9 @@ func (s Service) probeReadyAfterForSpec(spec ProviderSpec) time.Duration {
 }
 
 func agentNPMRegistryProbePackage(spec ProviderSpec) string {
+	if packageName := agentProviderCLINPMPackage(spec.Provider); packageName != "" {
+		return packageName
+	}
 	if spec.Provider == agentprovider.Codex {
 		return "@openai/codex"
 	}

--- a/services/tuttid/service/agentstatus/service_test.go
+++ b/services/tuttid/service/agentstatus/service_test.go
@@ -399,8 +399,8 @@ func TestServiceListReportsLoginAndRefreshActionsWhenAuthMarkerMissing(t *testin
 	if status.Auth.Status != AuthRequired {
 		t.Fatalf("Auth.Status = %q, want %q", status.Auth.Status, AuthRequired)
 	}
-	if len(status.Actions) != 2 {
-		t.Fatalf("Actions length = %d, want 2", len(status.Actions))
+	if len(status.Actions) != 3 {
+		t.Fatalf("Actions length = %d, want 3", len(status.Actions))
 	}
 	action := firstAction(t, status.Actions)
 	if action.ID != ActionLogin {
@@ -412,6 +412,9 @@ func TestServiceListReportsLoginAndRefreshActionsWhenAuthMarkerMissing(t *testin
 	}
 	if status.Actions[1].ID != ActionRefresh || status.Actions[1].Kind != ActionKindRefresh {
 		t.Fatalf("second action = %#v, want refresh", status.Actions[1])
+	}
+	if status.Actions[2].ID != ActionUpdate || status.Actions[2].Kind != ActionKindDaemonAction {
+		t.Fatalf("third action = %#v, want daemon update", status.Actions[2])
 	}
 }
 
@@ -524,8 +527,8 @@ func TestServiceListReportsReadyWhenInstalledAndAuthenticated(t *testing.T) {
 	if !status.Adapter.Installed {
 		t.Fatal("Adapter.Installed = false, want true")
 	}
-	if len(status.Actions) != 1 {
-		t.Fatalf("Actions length = %d, want 1", len(status.Actions))
+	if len(status.Actions) != 2 {
+		t.Fatalf("Actions length = %d, want 2", len(status.Actions))
 	}
 	action := firstAction(t, status.Actions)
 	if action.ID != ActionLogin {
@@ -534,6 +537,9 @@ func TestServiceListReportsReadyWhenInstalledAndAuthenticated(t *testing.T) {
 	if action.Command == nil || action.Command.Input != `/usr/local/bin/codex login -c 'service_tier="fast"'
 ` {
 		t.Fatalf("login command = %#v", action.Command)
+	}
+	if status.Actions[1].ID != ActionUpdate || status.Actions[1].Kind != ActionKindDaemonAction {
+		t.Fatalf("second action = %#v, want daemon update", status.Actions[1])
 	}
 }
 
@@ -641,6 +647,9 @@ func TestServiceListReportsCodexChecksVersionAndLastError(t *testing.T) {
 	assertProviderCheck(t, status.Checks, "platform_binary", true)
 	assertProviderCheck(t, status.Checks, "version_floor", false)
 	assertProviderCheck(t, status.Checks, "auth", true)
+	if len(status.Actions) != 1 || status.Actions[0].ID != ActionUpdate {
+		t.Fatalf("Actions = %#v, want daemon CLI update", status.Actions)
+	}
 }
 
 func TestServiceListRunsCodexLauncherWithManagedNodePath(t *testing.T) {
@@ -1191,8 +1200,8 @@ func TestServiceListTreatsUnknownAuthAsAuthRequired(t *testing.T) {
 	if status.Availability.ReasonCode != "auth_unknown" {
 		t.Fatalf("ReasonCode = %q, want auth_unknown", status.Availability.ReasonCode)
 	}
-	if len(status.Actions) != 2 {
-		t.Fatalf("Actions length = %d, want 2", len(status.Actions))
+	if len(status.Actions) != 3 {
+		t.Fatalf("Actions length = %d, want 3", len(status.Actions))
 	}
 	action := firstAction(t, status.Actions)
 	if action.ID != ActionLogin {
@@ -1203,6 +1212,9 @@ func TestServiceListTreatsUnknownAuthAsAuthRequired(t *testing.T) {
 	}
 	if status.Actions[1].ID != ActionRefresh || status.Actions[1].Kind != ActionKindRefresh {
 		t.Fatalf("second action = %#v, want refresh", status.Actions[1])
+	}
+	if status.Actions[2].ID != ActionUpdate || status.Actions[2].Kind != ActionKindDaemonAction {
+		t.Fatalf("third action = %#v, want daemon update", status.Actions[2])
 	}
 }
 


### PR DESCRIPTION
## Summary

- detect the latest stable Claude Code and Codex CLI releases during opt-in environment checks
- show an outdated-version banner and let users update either CLI from the environment panel
- use each provider's native update command, with the existing managed npm installer as a fallback for older Codex releases
- preserve latest-version metadata across local polling, then re-probe and refresh network status after updates
- extend the daemon API, generated clients, analytics, localized copy, tests, and AgentGUI architecture documentation

## Why

The environment panel could identify an unsupported Codex version, but it only offered a re-check and did not surface newer stable Claude Code or Codex releases. Users had to leave Tutti and update the CLI manually.

## Impact

Users can now update Claude Code and Codex directly from their environment panels. Startup readiness remains local-only; latest-version lookups run only when the environment wizard explicitly requests network diagnostics.

## Root cause

CLI readiness and remediation were modeled around installation and authentication only. The status contract had no latest-version metadata or update action, so the UI could neither distinguish an outdated installation nor trigger a provider-aware update flow.

## Validation

- `pnpm check:full`
- `pnpm check:changed` (13 lanes)
- `pnpm --filter @tutti-os/agent-gui test` (2,197 tests)
- desktop provider status service tests (37 tests)
- `pnpm --filter @tutti-os/desktop build`
- `cd services/tuttid && go test ./service/agentstatus ./api`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds latest-version checks and one-click CLI updates for Claude Code and Codex in the environment panel. Uses each CLI’s native update command (Codex falls back to the managed npm installer) and preserves release metadata across local-only polls to avoid flicker.

- **New Features**
  - Environment wizard fetches latest stable versions for `@anthropic-ai/claude-code` and `@openai/codex` during opt-in network diagnostics, exposing `cli.latestVersion` and `cli.updateAvailable`.
  - Environment panel shows an outdated-version banner with an Update CLI button; pending updates are tracked and do not auto-start. Startup readiness stays local-only; network lookups run only when the wizard requests diagnostics.
  - Daemon/API: adds `update` provider action. Runs native `<cli> update`, with Codex falling back to the managed npm installer when needed. After updates, re-checks with `includeNetwork=true`. Skips network probing during in-flight install/update. OpenAPI and generated clients include `update`, `cli.latestVersion`, and `cli.updateAvailable`.
  - Analytics/i18n/docs: adds `update_action_requested`, localized copy for update flows, and architecture notes. Extensive tests added for status preservation, update flow, and registry probing.

<sup>Written for commit b65808547fd65563ebf6b3bac044a69b7653b803. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tutti-os/tutti/pull/1019?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

