### PR TITLE
fix(desktop): package Claude sidecar for target architecture

### DIFF
--- a/apps/desktop/scripts/claude-sdk-sidecar-packaging.mjs
+++ b/apps/desktop/scripts/claude-sdk-sidecar-packaging.mjs
@@ -1,0 +1,91 @@
+import { execFileSync } from "node:child_process";
+import { existsSync, rmSync } from "node:fs";
+import { join } from "node:path";
+
+export const DARWIN_CLAUDE_NATIVE_PACKAGES = [
+  {
+    name: "@anthropic-ai/claude-agent-sdk-darwin-arm64",
+    lipoArch: "arm64"
+  },
+  {
+    name: "@anthropic-ai/claude-agent-sdk-darwin-x64",
+    lipoArch: "x86_64"
+  }
+];
+
+export function resolveDarwinClaudeNativePackageSpecs(agentSdkPackage) {
+  const optionalDependencies = agentSdkPackage.optionalDependencies ?? {};
+  return DARWIN_CLAUDE_NATIVE_PACKAGES.map(({ name }) => {
+    const version = optionalDependencies[name];
+    if (typeof version !== "string" || version.length === 0) {
+      throw new Error(
+        `Claude Agent SDK does not declare required optional dependency: ${name}`
+      );
+    }
+    return `${name}@${version}`;
+  });
+}
+
+export function resolveDarwinClaudeNativePackagesForPackContext(context) {
+  // electron-builder creates both architecture-specific temporary apps before
+  // merging a universal app. Their file lists must stay identical, so both
+  // native packages are required in those intermediates.
+  if (/-universal-(?:x64|arm64)-temp$/.test(context.appOutDir)) {
+    return DARWIN_CLAUDE_NATIVE_PACKAGES;
+  }
+
+  // AfterPackContext.arch uses builder-util's numeric Arch enum.
+  switch (context.arch) {
+    case 1:
+    case "x64":
+      return DARWIN_CLAUDE_NATIVE_PACKAGES.filter(({ name }) =>
+        name.endsWith("-x64")
+      );
+    case 3:
+    case "arm64":
+      return DARWIN_CLAUDE_NATIVE_PACKAGES.filter(({ name }) =>
+        name.endsWith("-arm64")
+      );
+    case 4:
+    case "universal":
+      return DARWIN_CLAUDE_NATIVE_PACKAGES;
+    default:
+      throw new Error(
+        `unsupported macOS package architecture: ${context.arch}`
+      );
+  }
+}
+
+export function pruneDarwinClaudeNativePackages(
+  nodeModulesDir,
+  packagesToKeep
+) {
+  const keep = new Set(packagesToKeep.map(({ name }) => name));
+  for (const { name } of DARWIN_CLAUDE_NATIVE_PACKAGES) {
+    if (!keep.has(name)) {
+      rmSync(join(nodeModulesDir, name), { recursive: true, force: true });
+    }
+  }
+}
+
+export function verifyDarwinClaudeNativePackages(
+  nodeModulesDir,
+  packagesToVerify = DARWIN_CLAUDE_NATIVE_PACKAGES
+) {
+  for (const { name, lipoArch } of packagesToVerify) {
+    const binary = join(nodeModulesDir, name, "claude");
+    if (!existsSync(binary)) {
+      throw new Error(`vendored Claude native binary missing: ${binary}`);
+    }
+    try {
+      execFileSync("lipo", [binary, "-verify_arch", lipoArch], {
+        stdio: "pipe"
+      });
+    } catch (error) {
+      throw new Error(
+        `vendored Claude native binary does not contain ${lipoArch}: ${binary}`,
+        { cause: error }
+      );
+    }
+  }
+}

--- a/apps/desktop/scripts/copy-vendored-node-resources-after-pack.mjs
+++ b/apps/desktop/scripts/copy-vendored-node-resources-after-pack.mjs
@@ -8,6 +8,11 @@ import {
 } from "node:fs";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
+import {
+  pruneDarwinClaudeNativePackages,
+  resolveDarwinClaudeNativePackagesForPackContext,
+  verifyDarwinClaudeNativePackages
+} from "./claude-sdk-sidecar-packaging.mjs";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const desktopDir = join(__dirname, "..");
@@ -41,6 +46,7 @@ function copyNodeModules(resourcesDir, bundleName) {
   rmSync(join(destination, ".bin"), { recursive: true, force: true });
   removeSymlinks(destination);
   log(`copied ${bundleName} node_modules to ${destination}`);
+  return destination;
 }
 
 function removeSymlinks(root) {
@@ -60,5 +66,19 @@ function removeSymlinks(root) {
 export default async function copyVendoredNodeResourcesAfterPack(context) {
   const resourcesDir = resourcesDirForContext(context);
   copyNodeModules(resourcesDir, "browser-mcp");
-  copyNodeModules(resourcesDir, "claude-sdk-sidecar");
+  const claudeNodeModulesDir = copyNodeModules(
+    resourcesDir,
+    "claude-sdk-sidecar"
+  );
+  if (context.electronPlatformName === "darwin") {
+    const nativePackages =
+      resolveDarwinClaudeNativePackagesForPackContext(context);
+    pruneDarwinClaudeNativePackages(claudeNodeModulesDir, nativePackages);
+    verifyDarwinClaudeNativePackages(claudeNodeModulesDir, nativePackages);
+    log(
+      `kept Claude native packages for arch=${context.arch}: ${nativePackages
+        .map(({ name }) => name)
+        .join(", ")}`
+    );
+  }
 }

--- a/apps/desktop/scripts/vendor-claude-sdk-sidecar.mjs
+++ b/apps/desktop/scripts/vendor-claude-sdk-sidecar.mjs
@@ -3,9 +3,11 @@
 // apps/desktop/build/claude-sdk-sidecar so packaged desktop can launch it
 // without relying on repository sources.
 import { execFileSync } from "node:child_process";
+import { tmpdir } from "node:os";
 import {
   cpSync,
   existsSync,
+  mkdtempSync,
   mkdirSync,
   readFileSync,
   rmSync,
@@ -13,6 +15,11 @@ import {
 } from "node:fs";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
+import {
+  DARWIN_CLAUDE_NATIVE_PACKAGES,
+  resolveDarwinClaudeNativePackageSpecs,
+  verifyDarwinClaudeNativePackages
+} from "./claude-sdk-sidecar-packaging.mjs";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const desktopDir = join(__dirname, "..");
@@ -23,6 +30,9 @@ const sourcePackage = JSON.parse(
 );
 const outDir = join(desktopDir, "build", "claude-sdk-sidecar");
 const entryRelPath = join("src", "main.ts");
+const includeDarwinNativePackages = process.argv.includes(
+  "--include-darwin-native-packages"
+);
 
 function log(msg) {
   process.stderr.write(`[vendor-claude-sdk-sidecar] ${msg}\n`);
@@ -53,6 +63,65 @@ execFileSync(
   ["install", "--omit=dev", "--no-audit", "--no-fund", "--ignore-scripts"],
   { cwd: outDir, stdio: "inherit" }
 );
+
+if (includeDarwinNativePackages) {
+  const installedAgentSdkPackage = JSON.parse(
+    readFileSync(
+      join(
+        outDir,
+        "node_modules",
+        "@anthropic-ai",
+        "claude-agent-sdk",
+        "package.json"
+      ),
+      "utf8"
+    )
+  );
+  const nativePackageSpecs = resolveDarwinClaudeNativePackageSpecs(
+    installedAgentSdkPackage
+  );
+  const stagingDir = mkdtempSync(join(tmpdir(), "tutti-claude-native-"));
+  log(`vendoring macOS native packages: ${nativePackageSpecs.join(", ")}`);
+  try {
+    for (const [index, packageSpec] of nativePackageSpecs.entries()) {
+      const packOutput = execFileSync(
+        "npm",
+        ["pack", packageSpec, "--json", "--pack-destination", stagingDir],
+        {
+          cwd: outDir,
+          encoding: "utf8",
+          stdio: ["ignore", "pipe", "inherit"]
+        }
+      );
+      const packResult = JSON.parse(packOutput);
+      const filename = packResult[0]?.filename;
+      if (typeof filename !== "string" || filename.length === 0) {
+        throw new Error(
+          `npm pack did not return a filename for ${packageSpec}`
+        );
+      }
+
+      const packageName = DARWIN_CLAUDE_NATIVE_PACKAGES[index].name;
+      const destination = join(outDir, "node_modules", packageName);
+      rmSync(destination, { recursive: true, force: true });
+      mkdirSync(destination, { recursive: true });
+      execFileSync(
+        "tar",
+        [
+          "-xzf",
+          join(stagingDir, filename),
+          "--strip-components=1",
+          "-C",
+          destination
+        ],
+        { stdio: "inherit" }
+      );
+    }
+  } finally {
+    rmSync(stagingDir, { recursive: true, force: true });
+  }
+  verifyDarwinClaudeNativePackages(join(outDir, "node_modules"));
+}
 
 const entry = join(outDir, entryRelPath);
 if (!existsSync(entry)) {

--- a/docs/conventions/desktop-release.md
+++ b/docs/conventions/desktop-release.md
@@ -99,7 +99,7 @@ apps/desktop/build/tuttid/
 
 For macOS packages, the bundled `tuttid` daemon and `tutti` CLI must be universal binaries. Build both `darwin/arm64` and `darwin/amd64`, merge them with `lipo`, and verify the resulting binary contains `arm64` and `x86_64` slices before packaging.
 
-Vendored Node runtimes that bring their own Mach-O binaries, such as `claude-sdk-sidecar`, must be compatible with Electron's universal merge. If the same packaged binary is copied into both the x64 and arm64 app bundles, cover that path with `build.mac.x64ArchFiles` so `@electron/universal` can skip `lipo` for the duplicate resource.
+Vendored Node runtimes that bring their own Mach-O binaries, such as `claude-sdk-sidecar`, must not inherit the build runner architecture through npm optional dependency selection. macOS packaging must vendor and verify both Claude native packages before `electron-builder` runs. Keep only the matching package in x64 and arm64 artifacts, keep both in universal merge inputs and artifacts, and cover their paths with `build.mac.x64ArchFiles` so `@electron/universal` can skip merging duplicate resources.
 
 `electron-builder` then packages that daemon into the desktop app as:
 

--- a/tools/scripts/build-desktop-package.sh
+++ b/tools/scripts/build-desktop-package.sh
@@ -184,7 +184,14 @@ prepare_browser_mcp() {
 prepare_claude_sdk_sidecar() {
   # Vendors the Claude SDK sidecar into build/claude-sdk-sidecar so packaged
   # Claude SDK sessions do not depend on repository source paths at runtime.
-  node "${ROOT_DIR}/apps/desktop/scripts/vendor-claude-sdk-sidecar.mjs"
+  local args=()
+  if is_macos_package_variant; then
+    # Release packaging cross-builds x64, arm64, and universal apps on one
+    # runner. Vendor both native Claude CLIs instead of inheriting the runner's
+    # architecture through npm optional dependency selection.
+    args+=(--include-darwin-native-packages)
+  fi
+  node "${ROOT_DIR}/apps/desktop/scripts/vendor-claude-sdk-sidecar.mjs" "${args[@]}"
 }
 
 run_pnpm_build() {

--- a/tools/scripts/desktop-release-config.test.mjs
+++ b/tools/scripts/desktop-release-config.test.mjs
@@ -1,6 +1,11 @@
 import test from "node:test";
 import assert from "node:assert/strict";
 import { access, readFile } from "node:fs/promises";
+import {
+  DARWIN_CLAUDE_NATIVE_PACKAGES,
+  resolveDarwinClaudeNativePackageSpecs,
+  resolveDarwinClaudeNativePackagesForPackContext
+} from "../../apps/desktop/scripts/claude-sdk-sidecar-packaging.mjs";
 
 const desktopPackagePath = new URL(
   "../../apps/desktop/package.json",
@@ -13,6 +18,10 @@ const workflowPath = new URL(
 );
 const buildScriptPath = new URL(
   "../../tools/scripts/build-desktop-package.sh",
+  import.meta.url
+);
+const claudeSidecarVendorScriptPath = new URL(
+  "../../apps/desktop/scripts/vendor-claude-sdk-sidecar.mjs",
   import.meta.url
 );
 const electronViteConfigPath = new URL(
@@ -475,6 +484,10 @@ test("desktop release workflow materializes macOS signing certificate before pac
 
 test("desktop macOS packaging builds architecture-specific and universal artifacts", async () => {
   const buildScript = await readFile(buildScriptPath, "utf8");
+  const claudeSidecarVendorScript = await readFile(
+    claudeSidecarVendorScriptPath,
+    "utf8"
+  );
   const packageJson = JSON.parse(await readFile(desktopPackagePath, "utf8"));
 
   assert.match(packageJson.build.artifactName, /\$\{arch\}/);
@@ -486,10 +499,61 @@ test("desktop macOS packaging builds architecture-specific and universal artifac
     /lipo\s+"\$\{output_path\}"\s+-verify_arch\s+arm64\s+x86_64\s+\|\|\s+\{/
   );
   assert.match(buildScript, /electron-builder --mac --x64 --arm64 --universal/);
+  assert.match(buildScript, /--include-darwin-native-packages/);
+  assert.match(claudeSidecarVendorScript, /"npm",\s*\n\s*\["pack"/);
+  assert.match(
+    claudeSidecarVendorScript,
+    /verifyDarwinClaudeNativePackages\(join\(outDir, "node_modules"\)\)/
+  );
+  assert.deepEqual(
+    DARWIN_CLAUDE_NATIVE_PACKAGES.map(({ name, lipoArch }) => [name, lipoArch]),
+    [
+      ["@anthropic-ai/claude-agent-sdk-darwin-arm64", "arm64"],
+      ["@anthropic-ai/claude-agent-sdk-darwin-x64", "x86_64"]
+    ]
+  );
+  assert.deepEqual(
+    resolveDarwinClaudeNativePackageSpecs({
+      optionalDependencies: {
+        "@anthropic-ai/claude-agent-sdk-darwin-arm64": "1.2.3",
+        "@anthropic-ai/claude-agent-sdk-darwin-x64": "1.2.3"
+      }
+    }),
+    [
+      "@anthropic-ai/claude-agent-sdk-darwin-arm64@1.2.3",
+      "@anthropic-ai/claude-agent-sdk-darwin-x64@1.2.3"
+    ]
+  );
+  assert.deepEqual(
+    resolveDarwinClaudeNativePackagesForPackContext({
+      appOutDir: "/tmp/dist/mac",
+      arch: 1
+    }).map(({ name }) => name),
+    ["@anthropic-ai/claude-agent-sdk-darwin-x64"]
+  );
+  assert.deepEqual(
+    resolveDarwinClaudeNativePackagesForPackContext({
+      appOutDir: "/tmp/dist/mac-arm64",
+      arch: 3
+    }).map(({ name }) => name),
+    ["@anthropic-ai/claude-agent-sdk-darwin-arm64"]
+  );
+  for (const context of [
+    { appOutDir: "/tmp/dist/mac-universal-x64-temp", arch: 1 },
+    { appOutDir: "/tmp/dist/mac-universal-arm64-temp", arch: 3 },
+    { appOutDir: "/tmp/dist/mac-universal", arch: 4 }
+  ]) {
+    assert.deepEqual(
+      resolveDarwinClaudeNativePackagesForPackContext(context).map(
+        ({ name }) => name
+      ),
+      DARWIN_CLAUDE_NATIVE_PACKAGES.map(({ name }) => name)
+    );
+  }
   assert.equal(
     packageJson.build.mac.x64ArchFiles,
     "Contents/Resources/bin/claude-sdk-sidecar/node_modules/@anthropic-ai/claude-agent-sdk-darwin-*/claude",
-    "Claude SDK sidecar arch-specific binary must be covered for electron-builder universal merges"
+    "Claude SDK sidecar native binaries must be covered for electron-builder universal merges"
   );
 });
 


### PR DESCRIPTION
## Summary

Ports the validated release-branch fix from #1015 to `main`.

- vendor both macOS Claude Agent SDK native packages explicitly instead of inheriting the build runner architecture
- verify each vendored Mach-O binary with `lipo` and validate again after `afterPack`
- keep only the matching native package in x64/arm64 artifacts while preserving both packages for universal merge inputs and artifacts
- document the packaging invariant and extend release configuration tests

## Root cause

The desktop release flow prepares `claude-sdk-sidecar/node_modules` once before cross-building x64, arm64, and universal apps. On an ARM64 runner, npm selected only `@anthropic-ai/claude-agent-sdk-darwin-arm64`; the `afterPack` hook then copied that same dependency tree into the mac-x64 artifact.

## Impact

x64 builds contain the x64 Claude CLI, arm64 builds contain the arm64 CLI, and universal builds contain both. This restores Claude Code sessions on x64 Macs without adding the unused architecture to single-architecture artifacts.

## Validation

- `pnpm check:changed --tail-lines 100` — 6 lanes passed
- `pnpm check:full` — passed
- `pnpm test:tools` — 184 tests passed
- vendored both SDK native packages on current main and verified their Mach-O architectures with `file`
- the equivalent release-branch change completed unsigned x64, arm64, and universal packaging in #1015

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix macOS desktop packaging to include the correct Claude sidecar binary for the target architecture. Restores Claude Code sessions on x64 Macs while keeping single-arch artifacts lean and universal builds correct.

- **Bug Fixes**
  - Vendor and verify both macOS native packages (`@anthropic-ai/claude-agent-sdk-darwin-arm64`, `@anthropic-ai/claude-agent-sdk-darwin-x64`) for `claude-sdk-sidecar` using `npm pack` and `lipo`.
  - During `afterPack` on macOS, keep only the matching native package for x64/arm64; keep both for universal inputs and artifacts.
  - Add packaging helpers to resolve/prune/verify native packages and pass `--include-darwin-native-packages` from the build script.
  - Update docs to document the invariant and tests to cover arch selection and `@electron/universal` merge config.

<sup>Written for commit eb365c2741c672ab49e59324c63d627df552e406. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tutti-os/tutti/pull/1020?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes affect release packaging for Claude Code sessions on macOS; failures are fail-closed via lipo verification, but a mistake in arch pruning could still break x64 or universal builds.
> 
> **Overview**
> Fixes macOS desktop releases where **Intel builds could ship the arm64-only Claude Agent SDK native CLI** because npm optional deps were resolved once on the build runner before x64, arm64, and universal apps were packaged.
> 
> Adds **`claude-sdk-sidecar-packaging.mjs`** helpers to resolve both `@anthropic-ai/claude-agent-sdk-darwin-*` packages from the SDK’s optional dependency versions, **prune** the wrong slice per artifact, and **`lipo -verify_arch`** the vendored `claude` binary. **`vendor-claude-sdk-sidecar.mjs`** gains `--include-darwin-native-packages` (used from **`build-desktop-package.sh`** on mac variants) to **`npm pack`** and extract both native packages explicitly instead of relying on runner architecture. **`copy-vendored-node-resources-after-pack.mjs`** applies the same keep/verify rules after copy (x64/arm64 keep one package; universal and universal temp dirs keep both). **Desktop release docs** and **`desktop-release-config.test.mjs`** document and lock in the invariant.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit eb365c2741c672ab49e59324c63d627df552e406. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->