### PR TITLE
fix(agent): complete Codex custom provider support

### DIFF
--- a/.changeset/codex-api-key-auth-without-login.md
+++ b/.changeset/codex-api-key-auth-without-login.md
@@ -2,4 +2,4 @@
 "@tutti-os/desktop": patch
 ---
 
-Treat Codex API-key billing as authenticated in the environment wizard. Codex can run with `OPENAI_API_KEY` or a `config.toml` `api_key` without a ChatGPT login; `codex login status` only reflects the OAuth session and reports "Not logged in" for API-key users, so the provider status probe now detects those credentials the same way Claude Code API Usage Billing does and reports the provider as ready instead of blocking on "未登录". A bare custom base URL without a credential is still not treated as API billing.
+Improve Codex custom-provider support: treat API keys from the environment, `config.toml`, or `auth.json` as authenticated without a ChatGPT login; expose only the configured model for custom `model_provider` endpoints; suppress non-actionable model-metadata warnings; and avoid duplicate assistant replies when Codex replays polished final text.

--- a/docs/conventions/troubleshooting.md
+++ b/docs/conventions/troubleshooting.md
@@ -1508,26 +1508,30 @@ delimited by ---`, and the composer skill picker may show partial or
 
 - Symptom:
   The environment wizard / dock marks Codex as needing login ("未登录") even
-  though `OPENAI_API_KEY` is set or `~/.codex/config.toml` declares `api_key`,
-  and Codex sessions can already run successfully.
+  though an API key is configured and Codex sessions can already run
+  successfully. Common sources are `OPENAI_API_KEY` in the environment,
+  `api_key` in `~/.codex/config.toml`, or `OPENAI_API_KEY` inside
+  `~/.codex/auth.json` as written by custom-provider switchers.
 - Quick checks:
   Run `codex login status` (often prints `Not logged in`). Confirm an API
-  credential exists via `echo $OPENAI_API_KEY` or
-  `grep -E 'api_key' ~/.codex/config.toml`.
+  credential exists via `echo $OPENAI_API_KEY`,
+  `grep -E 'api_key' ~/.codex/config.toml`, or a non-empty
+  `OPENAI_API_KEY` field in `~/.codex/auth.json`.
 - Root cause:
   `codex login status` only reflects a ChatGPT OAuth session. API-key billing
-  is invisible to that command, so tuttid used to treat the provider as
-  `auth_required` and block the wizard even though the runtime can authenticate
-  with the key.
+  from the environment, config, or `auth.json` is invisible to that command,
+  so tuttid used to treat the provider as `auth_required` and block the wizard
+  even though the runtime can authenticate with the key.
 - Fix:
   Provider status should call `providerHasAPICredential` for Codex the same way
-  it does for Claude Code. When an API key is present (env or config.toml),
-  report auth as authenticated with method `apiKey` / label
+  it does for Claude Code, including `auth.json` `OPENAI_API_KEY`. When an API
+  key is present, report auth as authenticated with method `apiKey` / label
   `API Usage Billing` instead of requiring login. A bare custom base URL
   without a credential must not trigger this override.
 - Validation:
-  Add or update `agentstatus` tests for Codex API-key-without-login readiness,
-  then run `cd services/tuttid && go test ./service/agentstatus`.
+  Add or update `agentstatus` tests for environment, config.toml, and auth.json
+  API-key-without-login readiness, then run
+  `cd services/tuttid && go test ./service/agentstatus`.
 
 ### Codex session fails with not connected when model_catalog_json is relative
 
@@ -1562,6 +1566,39 @@ delimited by ---`, and the composer skill picker may show partial or
 - References:
   [codex.go](../../packages/agent/runtimeprep/codex.go)
   [preparer_test.go](../../packages/agent/runtimeprep/preparer_test.go)
+
+### Codex custom model_provider mixes models, duplicates replies, or shows metadata warnings
+
+- Symptom:
+  With `model_provider` set to a custom endpoint and `model` set to a vendor
+  model id, the composer mixes official GPT ids with the configured model, a
+  turn may show the same assistant reply twice, or the transcript repeatedly
+  displays `Model metadata for ... not found. Defaulting to fallback metadata`.
+- Quick checks:
+  Inspect top-level `model_provider` and `model` in `~/.codex/config.toml`.
+  In persisted session messages, look for two completed assistant rows with
+  equivalent text but different message ids in one turn. The composer model
+  options should contain only the configured model after the fix.
+- Root cause:
+  The model catalog appended the configured custom model to Codex's official
+  `model/list`, even though the custom endpoint cannot serve those official
+  ids. Separately, Codex can finalize an assistant item after an early stream
+  boundary and replay the answer again in `turn/completed`, sometimes with
+  whitespace polish; treating each report as a new segment creates duplicate
+  bubbles. The model-metadata warning is runtime diagnostic noise rather than
+  an actionable user error.
+- Fix:
+  When a non-default `model_provider` and a top-level `model` are configured,
+  expose only that model in the Codex catalog. Preserve the assistant message
+  id for whitespace-equivalent item-finalization text and ignore turn-final
+  text after an assistant segment has already completed. Filter the metadata
+  fallback warning through the same AgentGUI diagnostic-notice projection used
+  for skills-context-budget warnings.
+- Validation:
+  Run
+  `go test ./packages/agent/daemon/runtime -run 'TestApplyAssistantFinalText|TestApplyAssistantTurnFinalText|TestCodexAppServerAdapterExecStreamsTurn'`,
+  `cd services/tuttid && go test ./service/agent -run TestAgentModelCatalog`,
+  and the focused AgentGUI projection test.
 
 ### Codex app-server subagent output appears as the parent reply
 

--- a/packages/agent/daemon/runtime/acp_turn_normalizer.go
+++ b/packages/agent/daemon/runtime/acp_turn_normalizer.go
@@ -146,12 +146,46 @@ func (n *acpTurnNormalizer) ApplyAssistantFinalText(finalText string) {
 	if finalText == "" {
 		return
 	}
+	// Codex may close a streamed assistant segment before item/completed
+	// redelivers the same answer with whitespace polish. Preserve the message id
+	// for equivalent text so the replay updates one bubble instead of opening a
+	// duplicate.
+	if n.assistantSegmentCompleted && n.assistantMessageID != "" {
+		previous := strings.TrimSpace(n.assistantContent.String())
+		if previous == finalText {
+			return
+		}
+		if assistantTextEquivalent(previous, finalText) {
+			n.assistantContent.Reset()
+			_, _ = n.assistantContent.WriteString(finalText)
+			n.assistantSegmentCompleted = false
+			return
+		}
+	}
 	if n.assistantMessageID == "" || n.assistantSegmentCompleted {
 		n.assistantMessageID = newID()
 		n.assistantSegmentCompleted = false
 	}
 	n.assistantContent.Reset()
 	_, _ = n.assistantContent.WriteString(finalText)
+}
+
+func assistantTextEquivalent(left, right string) bool {
+	return normalizeAssistantCompareText(left) == normalizeAssistantCompareText(right)
+}
+
+func normalizeAssistantCompareText(text string) string {
+	return strings.Join(strings.Fields(strings.TrimSpace(text)), "")
+}
+
+// ApplyAssistantTurnFinalText uses turn/completed text only when no assistant
+// segment has already completed. item/completed is authoritative once shown;
+// the turn payload commonly replays the same answer with minor polish.
+func (n *acpTurnNormalizer) ApplyAssistantTurnFinalText(finalText string) {
+	if n == nil || n.assistantSegmentCompleted {
+		return
+	}
+	n.ApplyAssistantFinalText(finalText)
 }
 
 func (n *acpTurnNormalizer) AppendAssistantSnapshot(

--- a/packages/agent/daemon/runtime/acp_turn_normalizer_test.go
+++ b/packages/agent/daemon/runtime/acp_turn_normalizer_test.go
@@ -69,6 +69,104 @@ func TestAppendAssistantChunkIgnoresDuplicateSnapshotChunk(t *testing.T) {
 	}
 }
 
+func TestApplyAssistantFinalTextIgnoresIdenticalReplayAfterCompletedSegment(t *testing.T) {
+	t.Parallel()
+
+	session := testSession()
+	normalizer := newACPTurnNormalizer()
+	finalText := "你好！有什么我可以帮你的吗？"
+
+	normalizer.ApplyAssistantFinalText(finalText)
+	first := normalizer.Finish(session, "turn-1", messageStreamStateCompleted)
+	if got := len(activityMessagesWithRole(first, activityshared.MessageRoleAssistant)); got != 1 {
+		t.Fatalf("item/completed assistant messages = %d, want 1", got)
+	}
+
+	normalizer.ApplyAssistantFinalText(finalText)
+	completed := normalizer.FinishCompleted(session, "turn-1")
+	if duplicates := activityMessagesWithRole(completed, activityshared.MessageRoleAssistant); len(duplicates) != 0 {
+		t.Fatalf("turn/completed assistant messages = %#v, want none", duplicates)
+	}
+}
+
+func TestApplyAssistantFinalTextKeepsDistinctFollowUpSegment(t *testing.T) {
+	t.Parallel()
+
+	session := testSession()
+	normalizer := newACPTurnNormalizer()
+
+	normalizer.ApplyAssistantFinalText("First answer.")
+	if got := len(activityMessagesWithRole(normalizer.Finish(session, "turn-1", messageStreamStateCompleted), activityshared.MessageRoleAssistant)); got != 1 {
+		t.Fatalf("first segment assistant messages = %d, want 1", got)
+	}
+
+	normalizer.ApplyAssistantFinalText("Second answer.")
+	messages := activityMessagesWithRole(normalizer.FinishCompleted(session, "turn-1"), activityshared.MessageRoleAssistant)
+	if len(messages) != 1 || messages[0].Payload.Content != "Second answer." {
+		t.Fatalf("follow-up assistant messages = %#v, want exactly one second answer", messages)
+	}
+}
+
+func TestApplyAssistantFinalTextUpdatesWhitespacePolishInPlace(t *testing.T) {
+	t.Parallel()
+
+	session := testSession()
+	normalizer := newACPTurnNormalizer()
+	streamed := "哈囉！看起來你有點困惑😂需要幫忙什麼嗎？可以在這邊問我問題、討論程式碼，或請我幫忙。"
+	polished := "哈囉！看起來你有點困惑😂 \n\n需要幫忙什麼嗎？可以在這邊問我問題、討論程式碼，或請我幫忙。"
+
+	if events := normalizer.AppendAssistantChunk(session, "turn-1", streamed); len(events) != 1 {
+		t.Fatalf("stream events = %d, want 1", len(events))
+	}
+	first := activityMessagesWithRole(normalizer.Finish(session, "turn-1", messageStreamStateCompleted), activityshared.MessageRoleAssistant)
+	if len(first) != 1 {
+		t.Fatalf("early finish assistant messages = %d, want 1", len(first))
+	}
+
+	normalizer.ApplyAssistantFinalText(polished)
+	messages := activityMessagesWithRole(normalizer.Finish(session, "turn-1", messageStreamStateCompleted), activityshared.MessageRoleAssistant)
+	if len(messages) != 1 {
+		t.Fatalf("polished assistant messages = %#v, want one updated snapshot", messages)
+	}
+	if messages[0].EventID != first[0].EventID {
+		t.Fatalf("message id = %q, want reused %q", messages[0].EventID, first[0].EventID)
+	}
+	if messages[0].Payload.Content != polished {
+		t.Fatalf("content = %q, want polished snapshot", messages[0].Payload.Content)
+	}
+}
+
+func TestApplyAssistantTurnFinalTextIgnoresReplayAfterCompletedSegment(t *testing.T) {
+	t.Parallel()
+
+	session := testSession()
+	normalizer := newACPTurnNormalizer()
+
+	normalizer.ApplyAssistantFinalText("你好！我是 Codex助手。")
+	first := normalizer.Finish(session, "turn-1", messageStreamStateCompleted)
+	if got := len(activityMessagesWithRole(first, activityshared.MessageRoleAssistant)); got != 1 {
+		t.Fatalf("item/completed assistant messages = %d, want 1", got)
+	}
+
+	normalizer.ApplyAssistantTurnFinalText("你好！我是 Codex 助手。")
+	completed := normalizer.FinishCompleted(session, "turn-1")
+	if duplicates := activityMessagesWithRole(completed, activityshared.MessageRoleAssistant); len(duplicates) != 0 {
+		t.Fatalf("turn/completed assistant messages = %#v, want none", duplicates)
+	}
+}
+
+func TestApplyAssistantTurnFinalTextFillsMissingAnswer(t *testing.T) {
+	t.Parallel()
+
+	session := testSession()
+	normalizer := newACPTurnNormalizer()
+	normalizer.ApplyAssistantTurnFinalText("I'll check the repo.")
+	messages := activityMessagesWithRole(normalizer.FinishCompleted(session, "turn-1"), activityshared.MessageRoleAssistant)
+	if len(messages) != 1 || messages[0].Payload.Content != "I'll check the repo." {
+		t.Fatalf("assistant messages = %#v, want one final answer", messages)
+	}
+}
+
 func TestApplyAssistantFinalTextReplacesEditedSnapshot(t *testing.T) {
 	t.Parallel()
 

--- a/packages/agent/daemon/runtime/codex_appserver_adapter.go
+++ b/packages/agent/daemon/runtime/codex_appserver_adapter.go
@@ -1479,7 +1479,7 @@ func (a *CodexAppServerAdapter) finalizeSettledTurn(agentSessionID string, appTu
 			appTurn.emitTerminal(terminalEvents)
 		}
 	} else {
-		appTurn.normalizer.ApplyAssistantFinalText(appServerTurnFinalAssistantText(terminal.turn))
+		appTurn.normalizer.ApplyAssistantTurnFinalText(appServerTurnFinalAssistantText(terminal.turn))
 		appTurn.emitTerminal(appServerTurnTerminalEvents(session, turnID, terminal.turn, appTurn.normalizer))
 	}
 	a.endActiveTurn(agentSessionID, appTurn)
@@ -1758,7 +1758,7 @@ func (a *CodexAppServerAdapter) execBlocking(
 		}
 		return snapshotEvents(), nil
 	}
-	normalizer.ApplyAssistantFinalText(appServerTurnFinalAssistantText(finalTurn))
+	normalizer.ApplyAssistantTurnFinalText(appServerTurnFinalAssistantText(finalTurn))
 	emitTerminal(appServerTurnTerminalEvents(session, turnID, finalTurn, normalizer))
 	return snapshotEvents(), nil
 }
@@ -2156,7 +2156,7 @@ func (a *CodexAppServerAdapter) execSlashCommand(
 				a.scheduleGoalContinuationNudge(session)
 				return true, nil
 			}
-			normalizer.ApplyAssistantFinalText(appServerTurnFinalAssistantText(finalTurn))
+			normalizer.ApplyAssistantTurnFinalText(appServerTurnFinalAssistantText(finalTurn))
 			emitTerminal(appServerTurnTerminalEvents(session, turnID, finalTurn, normalizer))
 			a.scheduleGoalContinuationNudge(session)
 			return true, nil

--- a/packages/agent/daemon/runtime/codex_appserver_adapter_test.go
+++ b/packages/agent/daemon/runtime/codex_appserver_adapter_test.go
@@ -439,6 +439,13 @@ func (c *scriptedAppServerConnection) Send(data []byte) error {
 			c.notify(appServerNotifyAgentMessageDelta, map[string]any{
 				"threadId": "codex-thread-1", "turnId": "turn-1", "itemId": "item-msg", "delta": "the repo.",
 			})
+			// Codex finalizes the assistant item and later repeats the text in
+			// turn/completed. Keep the scripted protocol faithful so this test
+			// catches duplicate completed assistant messages.
+			c.notify(appServerNotifyItemCompleted, map[string]any{
+				"threadId": "codex-thread-1", "turnId": "turn-1",
+				"item": map[string]any{"type": "agentMessage", "id": "item-msg", "text": "I'll check the repo."},
+			})
 			c.notify(appServerNotifyItemStarted, map[string]any{
 				"threadId": "codex-thread-1", "turnId": "turn-1", "startedAtMs": 1750000000000,
 				"item": map[string]any{
@@ -1246,18 +1253,20 @@ func TestCodexAppServerAdapterExecStreamsTurn(t *testing.T) {
 		t.Fatalf("turn/start responsesapiClientMetadata = %#v", turnStart["responsesapiClientMetadata"])
 	}
 
-	messages := eventsOfType(events, activityshared.EventMessageAppended)
-	var assistantText, thinkingText string
-	for _, event := range messages {
+	var completedAssistant []string
+	var thinkingText string
+	for _, event := range eventsOfType(events, activityshared.EventMessageAppended) {
 		switch event.Payload.Role {
 		case activityshared.MessageRoleAssistant:
-			assistantText = event.Payload.Content
+			if event.Payload.Metadata["streamState"] == messageStreamStateCompleted {
+				completedAssistant = append(completedAssistant, event.Payload.Content)
+			}
 		case activityshared.MessageRole(RoleAssistantThinking):
 			thinkingText = event.Payload.Content
 		}
 	}
-	if assistantText != "I'll check the repo." {
-		t.Fatalf("assistant content = %q, want streamed message", assistantText)
+	if len(completedAssistant) != 1 || completedAssistant[0] != "I'll check the repo." {
+		t.Fatalf("completed assistant messages = %#v, want exactly one final answer", completedAssistant)
 	}
 	if thinkingText != "Need context." {
 		t.Fatalf("thinking content = %q", thinkingText)

--- a/packages/agent/daemon/runtime/codex_appserver_review.go
+++ b/packages/agent/daemon/runtime/codex_appserver_review.go
@@ -138,7 +138,7 @@ func (a *CodexAppServerAdapter) execReviewSlashCommand(
 		}
 		return true, nil
 	}
-	normalizer.ApplyAssistantFinalText(appServerTurnFinalAssistantText(finalTurn))
+	normalizer.ApplyAssistantTurnFinalText(appServerTurnFinalAssistantText(finalTurn))
 	emitTerminal(appServerTurnTerminalEvents(session, turnID, finalTurn, normalizer))
 	return true, nil
 }

--- a/packages/agent/gui/shared/agentConversation/projection/agentConversationProjection.spec.ts
+++ b/packages/agent/gui/shared/agentConversation/projection/agentConversationProjection.spec.ts
@@ -412,6 +412,63 @@ describe("projectAgentConversationVM", () => {
     expect(assistantRows[0]?.messages[0]?.systemNotice).toBeNull();
   });
 
+  it("drops Codex model metadata fallback runtime warning notices", () => {
+    const metadataWarning =
+      "Model metadata for `minimax/minimax-m2.5` not found. Defaulting to fallback metadata; this can degrade performance and cause issues.";
+    const conversation = projectAgentConversationVM(
+      detailViewModel({
+        turns: [
+          {
+            id: "turn-1",
+            userMessage: { id: "user-1", body: "你好" },
+            userMessages: [{ id: "user-1", body: "你好" }],
+            agentMessages: [],
+            toolCalls: [],
+            toolCallCount: 0,
+            hasFailedToolCall: false,
+            agentItems: [
+              {
+                kind: "message",
+                message: {
+                  id: "assistant-warning-1",
+                  body: metadataWarning,
+                  systemNotice: {
+                    noticeKind: "warning",
+                    severity: "warning",
+                    source: "runtime",
+                    title: metadataWarning,
+                    detail: metadataWarning,
+                    retryable: null
+                  }
+                }
+              },
+              {
+                kind: "message",
+                message: {
+                  id: "assistant-1",
+                  body: "你好！有什么我可以帮你的吗？"
+                }
+              }
+            ]
+          }
+        ],
+        showProcessingIndicator: false
+      })
+    );
+
+    const assistantRows = conversation.rows.filter(
+      (
+        row
+      ): row is Extract<
+        (typeof conversation.rows)[number],
+        { kind: "message" }
+      > => row.kind === "message" && row.speaker === "assistant"
+    );
+    expect(assistantRows).toHaveLength(1);
+    expect(assistantRows[0]?.messages[0]?.id).toBe("assistant-1");
+    expect(assistantRows[0]?.messages[0]?.systemNotice).toBeNull();
+  });
+
   it("groups bridge thinking inside completed tool disclosures", () => {
     const conversation = projectAgentConversationVM(
       detailViewModel({

--- a/packages/agent/gui/shared/agentConversation/projection/agentConversationProjection.ts
+++ b/packages/agent/gui/shared/agentConversation/projection/agentConversationProjection.ts
@@ -32,6 +32,8 @@ export interface AgentConversationProjectionOptions {
 const RENDER_IRRELEVANT_TRANSCRIPT_ROW_FIELDS = new Set(["occurredAtUnixMs"]);
 const CODEX_SKILLS_CONTEXT_BUDGET_NOTICE_FRAGMENT =
   "skill descriptions were shortened to fit the 2% skills context budget";
+const CODEX_MODEL_METADATA_FALLBACK_NOTICE_FRAGMENT =
+  "defaulting to fallback metadata";
 
 export function projectAgentConversationVM(
   detail: WorkspaceAgentSessionDetailViewModel,
@@ -267,7 +269,7 @@ function dropCodexRuntimeDiagnosticNotices(
       continue;
     }
     const messages = row.messages.filter(
-      (message) => !isCodexSkillsContextBudgetNotice(message)
+      (message) => !isCodexRuntimeDiagnosticNotice(message)
     );
     if (messages.length === 0 && row.thinking.length === 0) {
       continue;
@@ -281,7 +283,7 @@ function dropCodexRuntimeDiagnosticNotices(
   return filteredRows;
 }
 
-function isCodexSkillsContextBudgetNotice(
+function isCodexRuntimeDiagnosticNotice(
   message: AgentMessageContentVM
 ): boolean {
   const notice = message.systemNotice;
@@ -295,7 +297,10 @@ function isCodexSkillsContextBudgetNotice(
     .filter(Boolean)
     .join("\n")
     .toLowerCase();
-  return text.includes(CODEX_SKILLS_CONTEXT_BUDGET_NOTICE_FRAGMENT);
+  return (
+    text.includes(CODEX_SKILLS_CONTEXT_BUDGET_NOTICE_FRAGMENT) ||
+    text.includes(CODEX_MODEL_METADATA_FALLBACK_NOTICE_FRAGMENT)
+  );
 }
 
 function dropRedundantErrorWarningNotices(

--- a/services/tuttid/service/agent/model_catalog.go
+++ b/services/tuttid/service/agent/model_catalog.go
@@ -153,15 +153,22 @@ func (c *CachedAgentModelCatalog) ListModels(ctx context.Context, provider strin
 		return cached.result, cached.err
 	}
 	listResult, err := spec.lister(c).ListModels(ctx)
-	models := applyConfiguredDefaultModel(
-		listResult.Models,
-		spec.configuredDefaultModel(),
-		spec.missingDefaultDescription,
-	)
+	configuredDefaultModel := spec.configuredDefaultModel()
+	models := applyConfiguredDefaultModel(listResult.Models, configuredDefaultModel, spec.missingDefaultDescription)
+	source := spec.source
+	if provider == agentprovider.Codex && configuredDefaultModel != "" && codexUsesCustomModelProvider() {
+		models = []AgentModelOption{{
+			ID:          configuredDefaultModel,
+			DisplayName: configuredDefaultModel,
+			Description: spec.missingDefaultDescription,
+			IsDefault:   true,
+		}}
+		source = "codex-configured-model"
+	}
 	models = enrichAgentModelOptions(ctx, provider, models, c.ModelCapabilities)
 	result := AgentModelCatalogResult{
 		Provider:  provider,
-		Source:    spec.source,
+		Source:    source,
 		FetchedAt: now,
 		Models:    models,
 	}

--- a/services/tuttid/service/agent/model_catalog_test.go
+++ b/services/tuttid/service/agent/model_catalog_test.go
@@ -13,6 +13,79 @@ import (
 	"time"
 )
 
+func writeCodexModelCatalogConfig(t *testing.T, contents string) {
+	t.Helper()
+	codexHome := t.TempDir()
+	t.Setenv("CODEX_HOME", codexHome)
+	if err := os.WriteFile(filepath.Join(codexHome, codexConfigFileName), []byte(contents), 0o600); err != nil {
+		t.Fatalf("write codex config.toml: %v", err)
+	}
+}
+
+// A custom model_provider cannot serve the official Codex model/list ids. The
+// composer must expose only the model configured for that provider.
+func TestAgentModelCatalogCustomModelProviderExposesOnlyConfiguredModel(t *testing.T) {
+	writeCodexModelCatalogConfig(t,
+		"model_provider = \"openrouter\"\n"+
+			"model = \"minimax/minimax-m2.5\"\n\n"+
+			"[model_providers.openrouter]\n"+
+			"base_url = \"https://openrouter.ai/api/v1\"\n")
+	lister := &fakeAgentModelLister{
+		models: []AgentModelOption{
+			{ID: "gpt-5.5", DisplayName: "GPT-5.5", IsDefault: true},
+			{ID: "gpt-5.4", DisplayName: "GPT-5.4"},
+			{ID: "gpt-5.2", DisplayName: "GPT-5.2"},
+		},
+	}
+	catalog := &CachedAgentModelCatalog{
+		Codex: lister,
+		Now: func() time.Time {
+			return time.UnixMilli(1000)
+		},
+	}
+
+	result, err := catalog.ListModels(context.Background(), "codex")
+	if err != nil {
+		t.Fatalf("ListModels returned error: %v", err)
+	}
+	if len(result.Models) != 1 {
+		t.Fatalf("models = %#v, want only the configured custom-provider model", result.Models)
+	}
+	if result.Models[0].ID != "minimax/minimax-m2.5" || !result.Models[0].IsDefault {
+		t.Fatalf("model = %#v, want configured minimax/minimax-m2.5 as default", result.Models[0])
+	}
+	if result.Source != "codex-configured-model" {
+		t.Fatalf("source = %q, want codex-configured-model", result.Source)
+	}
+}
+
+func TestAgentModelCatalogDefaultProviderKeepsOfficialListWithConfiguredDefault(t *testing.T) {
+	writeCodexModelCatalogConfig(t, "model = \"gpt-5.5\"\n")
+	lister := &fakeAgentModelLister{
+		models: []AgentModelOption{
+			{ID: "gpt-5.5", DisplayName: "GPT-5.5"},
+			{ID: "gpt-5.4", DisplayName: "GPT-5.4"},
+		},
+	}
+	catalog := &CachedAgentModelCatalog{
+		Codex: lister,
+		Now: func() time.Time {
+			return time.UnixMilli(1000)
+		},
+	}
+
+	result, err := catalog.ListModels(context.Background(), "codex")
+	if err != nil {
+		t.Fatalf("ListModels returned error: %v", err)
+	}
+	if len(result.Models) != 2 {
+		t.Fatalf("models = %#v, want official catalog untouched", result.Models)
+	}
+	if !result.Models[0].IsDefault || result.Models[0].ID != "gpt-5.5" {
+		t.Fatalf("models = %#v, want configured gpt-5.5 marked default", result.Models)
+	}
+}
+
 func TestAgentModelCatalogDoesNotReturnClaudeStaticModels(t *testing.T) {
 	catalog := &CachedAgentModelCatalog{
 		Now: func() time.Time {

--- a/services/tuttid/service/agent/model_config.go
+++ b/services/tuttid/service/agent/model_config.go
@@ -12,6 +12,22 @@ const (
 )
 
 func readCodexConfiguredDefaultModel() string {
+	return readCodexTopLevelConfigString("model")
+}
+
+func readCodexConfiguredModelProvider() string {
+	return readCodexTopLevelConfigString("model_provider")
+}
+
+// codexUsesCustomModelProvider reports whether config.toml routes Codex
+// through a non-default model_provider. Empty and "openai" keep the official
+// model/list catalog; any other provider can only serve its configured model.
+func codexUsesCustomModelProvider() bool {
+	provider := strings.ToLower(strings.TrimSpace(readCodexConfiguredModelProvider()))
+	return provider != "" && provider != "openai"
+}
+
+func readCodexTopLevelConfigString(key string) string {
 	codexHome := strings.TrimSpace(os.Getenv("CODEX_HOME"))
 	if codexHome == "" {
 		home, err := os.UserHomeDir()
@@ -20,7 +36,7 @@ func readCodexConfiguredDefaultModel() string {
 		}
 		codexHome = filepath.Join(home, ".codex")
 	}
-	return readTopLevelTomlString(filepath.Join(codexHome, codexConfigFileName), "model")
+	return readTopLevelTomlString(filepath.Join(codexHome, codexConfigFileName), key)
 }
 
 func readClaudeCodeConfiguredDefaultModel() string {

--- a/services/tuttid/service/agentstatus/provider_custom_config.go
+++ b/services/tuttid/service/agentstatus/provider_custom_config.go
@@ -44,7 +44,7 @@ func (s Service) providerUsesCustomConfig(provider string) bool {
 	}
 	switch provider {
 	case agentprovider.Codex:
-		return s.codexConfigDeclares("base_url", "chatgpt_base_url", "api_key")
+		return s.codexConfigDeclares("base_url", "chatgpt_base_url", "api_key") || s.codexAuthJSONHasAPIKey()
 	case agentprovider.ClaudeCode:
 		return s.claudeSettingsDeclares(claudeCustomConfigKeys, true)
 	default:
@@ -67,7 +67,7 @@ func (s Service) providerHasAPICredential(provider string) bool {
 	}
 	switch provider {
 	case agentprovider.Codex:
-		return s.codexConfigDeclares("api_key")
+		return s.codexConfigDeclares("api_key") || s.codexAuthJSONHasAPIKey()
 	case agentprovider.ClaudeCode:
 		return s.claudeSettingsDeclares(claudeAPICredentialKeys, true)
 	default:
@@ -169,6 +169,32 @@ func (s Service) codexConfigDeclares(keys ...string) bool {
 		}
 	}
 	return false
+}
+
+// codexAuthJSONHasAPIKey reports whether ~/.codex/auth.json (or $CODEX_HOME)
+// stores a non-empty OPENAI_API_KEY. Tools such as cc-switch write custom
+// provider keys there instead of config.toml; Codex can use that key without a
+// ChatGPT OAuth session.
+func (s Service) codexAuthJSONHasAPIKey() bool {
+	codexHome := strings.TrimSpace(s.lookupEnv("CODEX_HOME"))
+	if codexHome == "" {
+		home, err := s.homeDir()
+		if err != nil || strings.TrimSpace(home) == "" {
+			return false
+		}
+		codexHome = filepath.Join(home, ".codex")
+	}
+	content, err := os.ReadFile(filepath.Join(codexHome, "auth.json"))
+	if err != nil {
+		return false
+	}
+	var parsed struct {
+		OpenAIAPIKey string `json:"OPENAI_API_KEY"`
+	}
+	if err := json.Unmarshal(content, &parsed); err != nil {
+		return false
+	}
+	return strings.TrimSpace(parsed.OpenAIAPIKey) != ""
 }
 
 // claudeSettingsDeclares reports whether the Claude settings.json sets any of

--- a/services/tuttid/service/agentstatus/provider_custom_config_test.go
+++ b/services/tuttid/service/agentstatus/provider_custom_config_test.go
@@ -211,6 +211,24 @@ func TestProviderHasAPICredentialCodexConfigTomlInlineKey(t *testing.T) {
 	}
 }
 
+func TestProviderHasAPICredentialCodexAuthJSONAPIKey(t *testing.T) {
+	home := t.TempDir()
+	writeFile(t, filepath.Join(home, ".codex", "auth.json"), `{"OPENAI_API_KEY":"sk-test"}`)
+	svc := customConfigService(home)
+	if !svc.providerHasAPICredential(agentprovider.Codex) {
+		t.Fatal("expected codex auth.json OPENAI_API_KEY to count as an API credential")
+	}
+}
+
+func TestProviderHasAPICredentialCodexAuthJSONEmptyKeyIsNotCredential(t *testing.T) {
+	home := t.TempDir()
+	writeFile(t, filepath.Join(home, ".codex", "auth.json"), `{"OPENAI_API_KEY":"","tokens":{"access_token":"x"}}`)
+	svc := customConfigService(home)
+	if svc.providerHasAPICredential(agentprovider.Codex) {
+		t.Fatal("empty OPENAI_API_KEY in auth.json must not count as an API credential")
+	}
+}
+
 func TestProviderHasAPICredentialCodexConfigTomlEndpointOnlyIsNotCredential(t *testing.T) {
 	home := t.TempDir()
 	writeFile(t, filepath.Join(home, ".codex", "config.toml"), `

--- a/services/tuttid/service/agentstatus/service_test.go
+++ b/services/tuttid/service/agentstatus/service_test.go
@@ -2993,6 +2993,47 @@ func TestServiceListReportsReadyForCodexConfigTomlAPIKeyWithoutLogin(t *testing.
 	}
 }
 
+// Tools such as cc-switch store OpenRouter/custom-provider keys in
+// ~/.codex/auth.json as OPENAI_API_KEY (not config.toml api_key). Codex can
+// run with that file alone while `codex login status` still prints
+// "Not logged in".
+func TestServiceListReportsReadyForCodexAuthJSONAPIKeyWithoutLogin(t *testing.T) {
+	home := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(home, ".codex"), 0o755); err != nil {
+		t.Fatalf("mkdir .codex: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(home, ".codex", "auth.json"), []byte(`{"OPENAI_API_KEY":"sk-test"}`), 0o600); err != nil {
+		t.Fatalf("write auth.json: %v", err)
+	}
+	service := testService(func(name string) (string, error) {
+		return "/usr/local/bin/" + name, nil
+	}, map[string]bool{})
+	service.HomeDir = func() (string, error) { return home, nil }
+	service.Environ = func() []string { return []string{} }
+	service.RunAuthStatusCommand = func(context.Context, ProviderSpec, string) (AuthInfo, bool) {
+		return parseCodexAuthStatusOutput([]byte("Not logged in"))
+	}
+
+	snapshot, err := service.List(context.Background(), ListInput{Providers: []string{"codex"}})
+	if err != nil {
+		t.Fatalf("List() error = %v", err)
+	}
+
+	status := onlyStatus(t, snapshot)
+	if status.Availability.Status != AvailabilityReady {
+		t.Fatalf("Availability.Status = %q, want %q", status.Availability.Status, AvailabilityReady)
+	}
+	if status.Auth.Status != AuthAuthenticated {
+		t.Fatalf("Auth.Status = %q, want %q", status.Auth.Status, AuthAuthenticated)
+	}
+	if status.Auth.AuthMethod != "apiKey" {
+		t.Fatalf("Auth.AuthMethod = %q, want apiKey", status.Auth.AuthMethod)
+	}
+	if status.Auth.AccountLabel != "API Usage Billing" {
+		t.Fatalf("Auth.AccountLabel = %q, want %q", status.Auth.AccountLabel, "API Usage Billing")
+	}
+}
+
 // A bare custom endpoint (no API credential) must NOT be mislabeled as API
 // Usage Billing. The user may be on an OAuth/subscription session against that
 // endpoint, so the CLI-reported auth status and label must be preserved.


### PR DESCRIPTION
## Summary

- recognize Codex API keys stored in `~/.codex/auth.json` so custom-provider users are not blocked by ChatGPT OAuth status
- expose only the configured model when `model_provider` points at a custom endpoint
- deduplicate assistant final-text replays across `item/completed` and `turn/completed`, including whitespace-polished text
- suppress non-actionable Codex model-metadata fallback warnings in AgentGUI
- add regression coverage, update the existing changeset, and document the troubleshooting path

## Root cause

The main-branch API-key fix covered environment variables and `config.toml`, but not custom-provider keys written to `auth.json`. The model catalog also appended the configured custom model to Codex's official model list even though a custom endpoint cannot serve those official ids.

Separately, Codex can finalize an assistant item and replay the same answer in the terminal turn payload. Treating both reports as new segments produced duplicate bubbles, while the related model-metadata warning was surfaced even though users could not act on it.

## Impact

Codex custom-provider sessions are recognized as ready, show a usable model menu, render one final assistant reply, and avoid repeated internal metadata warnings.

## Validation

- `pnpm check:full`
- `pnpm --filter @tutti-os/agent-gui test` — 125 files / 2,202 tests passed
- `pnpm --filter @tutti-os/desktop build`
- focused agent runtime, model catalog, agentstatus, and AgentGUI projection regression tests

Follow-up to #990.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Codex custom-provider support: API-key auth works without ChatGPT login, the model menu shows only the configured model, and the UI avoids duplicate final replies and noisy metadata warnings. This makes provider switching smoother and less confusing.

- **Bug Fixes**
  - Treat Codex API keys from env, `config.toml`, and `~/.codex/auth.json` as authenticated; do not block on "未登录".
  - When `model_provider` is custom, expose only the configured `model`; do not mix in official GPT ids.
  - De-duplicate assistant final text across `item/completed` and `turn/completed` (preserve message id when text differs only by whitespace).
  - Suppress non-actionable "defaulting to fallback metadata" runtime warnings in the conversation UI.

<sup>Written for commit 1886377291ad3c38b627ee4b0414ef4820d53418. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tutti-os/tutti/pull/1021?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches agent auth readiness, model catalog selection, and transcript event shaping for Codex; behavior is scoped to Codex/custom providers with broad test coverage but affects user-visible chat and setup flows.
> 
> **Overview**
> Extends **Codex custom-provider** handling across provider status, model catalog, runtime transcript normalization, and AgentGUI projection.
> 
> **Auth / wizard:** Provider status now treats **`OPENAI_API_KEY` in `~/.codex/auth.json`** (e.g. CC Switch) as an API credential alongside env and `config.toml`, so users are not blocked as “未登录” when `codex login status` only reflects OAuth.
> 
> **Model picker:** When `model_provider` is non-default (not `openai`) and a top-level `model` is set, the composer catalog exposes **only that configured model** instead of mixing official GPT ids from `model/list`.
> 
> **Transcript:** The ACP turn normalizer **reuses assistant message ids** for whitespace-equivalent replays from `item/completed`, and **`ApplyAssistantTurnFinalText`** ignores `turn/completed` text after a segment already completed—reducing duplicate assistant bubbles. Codex app-server paths call the new turn-final helper.
> 
> **UI:** AgentGUI drops runtime **“defaulting to fallback metadata”** warnings using the same diagnostic-notice filter as skills-context-budget noise.
> 
> Docs/changeset and regression tests cover agentstatus, model catalog, normalizer, adapter streaming, and projection.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1886377291ad3c38b627ee4b0414ef4820d53418. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->