### PR TITLE
feat(agent): expose workspace app integration through CLI catalog

### DIFF
--- a/packages/clients/tuttid-ts/src/generated/sdk.gen.ts
+++ b/packages/clients/tuttid-ts/src/generated/sdk.gen.ts
@@ -1093,8 +1093,10 @@ export const reloadLocalWorkspaceApp = <ThrowOnError extends boolean = false>(
 /**
  * Get workspace-app agent preference projection
  *
- * Read-only subset of desktop agent preferences for one workspace app runtime. Intended for workspace app server tokens; exposes default provider selection and developer-gated provider visibility only.
+ * Read-only subset of desktop agent preferences for one workspace app runtime. Intended for workspace app server tokens; exposes default provider selection and developer-gated provider visibility only. Deprecated for Agent integrations: use `tutti --json agent providers` through `@tutti-os/agent-acp-kit/tutti`. This compatibility route remains available for one stable release window.
  *
+ *
+ * @deprecated
  */
 export const getWorkspaceAppAgentPreferences = <
   ThrowOnError extends boolean = false
@@ -1114,8 +1116,10 @@ export const getWorkspaceAppAgentPreferences = <
 /**
  * Get agent provider availability for one workspace app
  *
- * Workspace-app scoped alias of `GET /v1/agent-providers/status` for app server tokens. When `providers` is omitted, returns provider statuses for enabled daemon-owned Agent Targets visible to Agent GUI. When `providers` is supplied, it narrows that Agent Target set and cannot expose providers outside it.
+ * Workspace-app scoped alias of `GET /v1/agent-providers/status` for app server tokens. When `providers` is omitted, returns provider statuses for enabled daemon-owned Agent Targets visible to Agent GUI. When `providers` is supplied, it narrows that Agent Target set and cannot expose providers outside it. Deprecated for Agent integrations: use `tutti --json agent providers` through `@tutti-os/agent-acp-kit/tutti`. This compatibility route remains available for one stable release window.
  *
+ *
+ * @deprecated
  */
 export const getWorkspaceAppAgentProviderStatuses = <
   ThrowOnError extends boolean = false
@@ -1135,8 +1139,10 @@ export const getWorkspaceAppAgentProviderStatuses = <
 /**
  * Get agent provider composer options for one workspace app
  *
- * Workspace-app scoped alias of `POST /v1/agent-providers/{provider}/composer-options` for app server tokens.
+ * Workspace-app scoped alias of `POST /v1/agent-providers/{provider}/composer-options` for app server tokens. Deprecated for Agent integrations: use `tutti --json agent composer-options --provider <providerId>` through `@tutti-os/agent-acp-kit/tutti`. This compatibility route remains available for one stable release window.
  *
+ *
+ * @deprecated
  */
 export const getWorkspaceAppAgentProviderComposerOptions = <
   ThrowOnError extends boolean = false

--- a/services/tuttid/api/daemon_workspace_app_agent.go
+++ b/services/tuttid/api/daemon_workspace_app_agent.go
@@ -101,18 +101,12 @@ func (api DaemonAPI) workspaceAppAgentStatusProviders(
 	if err != nil {
 		return nil, err
 	}
+	visibleTargets := agenttargetbiz.EnabledTargetsByProvider(targets)
 	visible := map[string]struct{}{}
-	ordered := make([]string, 0, len(targets))
-	for _, target := range targets {
-		normalized, err := agenttargetbiz.NormalizeTarget(target)
-		if err != nil || !normalized.Enabled {
-			continue
-		}
-		if _, ok := visible[normalized.Provider]; ok {
-			continue
-		}
-		visible[normalized.Provider] = struct{}{}
-		ordered = append(ordered, normalized.Provider)
+	ordered := make([]string, 0, len(visibleTargets))
+	for _, target := range visibleTargets {
+		visible[target.Provider] = struct{}{}
+		ordered = append(ordered, target.Provider)
 	}
 	providers := make([]tuttigenerated.WorkspaceAgentProvider, 0, len(targets))
 	seen := map[string]struct{}{}

--- a/services/tuttid/api/openapi/tuttid.v1.yaml
+++ b/services/tuttid/api/openapi/tuttid.v1.yaml
@@ -943,13 +943,17 @@ paths:
       - $ref: "#/components/parameters/WorkspaceAppID"
     get:
       operationId: getWorkspaceAppAgentPreferences
+      deprecated: true
       tags:
         - app-center
       summary: Get workspace-app agent preference projection
       description: >
         Read-only subset of desktop agent preferences for one workspace app
         runtime. Intended for workspace app server tokens; exposes default
-        provider selection and developer-gated provider visibility only.
+        provider selection and developer-gated provider visibility only. Deprecated
+        for Agent integrations: use `tutti --json agent providers` through
+        `@tutti-os/agent-acp-kit/tutti`. This compatibility route remains available
+        for one stable release window.
       responses:
         "200":
           description: Workspace app agent preferences
@@ -975,6 +979,7 @@ paths:
       - $ref: "#/components/parameters/WorkspaceAppID"
     get:
       operationId: getWorkspaceAppAgentProviderStatuses
+      deprecated: true
       tags:
         - app-center
       summary: Get agent provider availability for one workspace app
@@ -983,7 +988,9 @@ paths:
         server tokens. When `providers` is omitted, returns provider statuses
         for enabled daemon-owned Agent Targets visible to Agent GUI. When
         `providers` is supplied, it narrows that Agent Target set and cannot
-        expose providers outside it.
+        expose providers outside it. Deprecated for Agent integrations: use
+        `tutti --json agent providers` through `@tutti-os/agent-acp-kit/tutti`.
+        This compatibility route remains available for one stable release window.
       parameters:
         - name: providers
           in: query
@@ -1029,13 +1036,17 @@ paths:
           $ref: "#/components/schemas/WorkspaceAgentProvider"
     post:
       operationId: getWorkspaceAppAgentProviderComposerOptions
+      deprecated: true
       tags:
         - app-center
       summary: Get agent provider composer options for one workspace app
       description: >
         Workspace-app scoped alias of
         `POST /v1/agent-providers/{provider}/composer-options` for app server
-        tokens.
+        tokens. Deprecated for Agent integrations: use
+        `tutti --json agent composer-options --provider <providerId>` through
+        `@tutti-os/agent-acp-kit/tutti`. This compatibility route remains available
+        for one stable release window.
       requestBody:
         required: false
         content:

--- a/services/tuttid/biz/agenttarget/model.go
+++ b/services/tuttid/biz/agenttarget/model.go
@@ -112,6 +112,42 @@ func DefaultSystemTargets(nowUnixMS int64) []Target {
 	}
 }
 
+// EnabledTargetsByProvider returns the first valid enabled target for each
+// canonical provider while preserving the target catalog order. Provider
+// visibility is owned by Agent Targets; callers must not rebuild this policy
+// from runtime availability or app-local allowlists.
+func EnabledTargetsByProvider(targets []Target) []Target {
+	result := make([]Target, 0, len(targets))
+	seen := make(map[string]struct{}, len(targets))
+	for _, target := range targets {
+		normalized, err := NormalizeTarget(target)
+		if err != nil || !normalized.Enabled {
+			continue
+		}
+		if _, ok := seen[normalized.Provider]; ok {
+			continue
+		}
+		seen[normalized.Provider] = struct{}{}
+		result = append(result, normalized)
+	}
+	return result
+}
+
+// EnabledTargetForProvider resolves legacy provider input at the ingress but
+// only returns a target carrying the canonical provider id.
+func EnabledTargetForProvider(targets []Target, provider string) (Target, bool) {
+	canonicalProvider := agentproviderbiz.Normalize(provider)
+	if canonicalProvider == "" {
+		return Target{}, false
+	}
+	for _, target := range EnabledTargetsByProvider(targets) {
+		if target.Provider == canonicalProvider {
+			return target, true
+		}
+	}
+	return Target{}, false
+}
+
 func MustLocalCLILaunchRefJSON(provider string) string {
 	raw, err := CanonicalLaunchRefJSON(provider, LaunchRef{
 		Type:     LaunchRefTypeLocalCLI,

--- a/services/tuttid/biz/agenttarget/model_enabled_test.go
+++ b/services/tuttid/biz/agenttarget/model_enabled_test.go
@@ -1,0 +1,40 @@
+package agenttarget
+
+import "testing"
+
+func TestEnabledTargetsByProviderPreservesOrderAndCanonicalizes(t *testing.T) {
+	targets := DefaultSystemTargets(1)
+	targets[0].Provider = "CODEX"
+	targets[1].Enabled = false
+	duplicate := targets[0]
+	duplicate.ID = "user:codex"
+	duplicate.Name = "Other Codex"
+	duplicate.Source = SourceUser
+	targets = append([]Target{targets[2], targets[0], duplicate}, targets[1:]...)
+
+	enabled := EnabledTargetsByProvider(targets)
+	if len(enabled) != 4 {
+		t.Fatalf("len(enabled) = %d, want 4: %#v", len(enabled), enabled)
+	}
+	if enabled[0].Provider != "tutti-agent" || enabled[1].Provider != "codex" {
+		t.Fatalf("enabled order = %#v", enabled)
+	}
+	if enabled[1].ID != IDLocalCodex {
+		t.Fatalf("first codex target = %q, want %q", enabled[1].ID, IDLocalCodex)
+	}
+	for _, target := range enabled {
+		if target.Provider == "claude-code" {
+			t.Fatalf("disabled claude target was returned: %#v", target)
+		}
+	}
+}
+
+func TestEnabledTargetForProviderAcceptsLegacyInputAndReturnsCanonical(t *testing.T) {
+	target, ok := EnabledTargetForProvider(DefaultSystemTargets(1), "claude")
+	if !ok {
+		t.Fatal("EnabledTargetForProvider() = not found")
+	}
+	if target.Provider != "claude-code" {
+		t.Fatalf("provider = %q, want claude-code", target.Provider)
+	}
+}

--- a/services/tuttid/service/cli/providers/agentcontext/composer_options.go
+++ b/services/tuttid/service/cli/providers/agentcontext/composer_options.go
@@ -133,6 +133,7 @@ func (p Provider) composerDefaultsForProvider(ctx context.Context, provider stri
 
 func composerOptionsValue(options agentservice.ComposerOptions) map[string]any {
 	return map[string]any{
+		"schemaVersion":     1,
 		"provider":          options.Provider,
 		"effectiveSettings": agentservice.ComposerSettingsToMap(options.EffectiveSettings),
 		"modelConfig":       composerConfigOptionValue(options.ModelConfig),

--- a/services/tuttid/service/cli/providers/agentcontext/composer_options.go
+++ b/services/tuttid/service/cli/providers/agentcontext/composer_options.go
@@ -3,6 +3,7 @@ package agentcontext
 import (
 	"context"
 
+	agentproviderbiz "github.com/tutti-os/tutti/services/tuttid/biz/agentprovider"
 	preferencesbiz "github.com/tutti-os/tutti/services/tuttid/biz/preferences"
 	agentservice "github.com/tutti-os/tutti/services/tuttid/service/agent"
 	cliservice "github.com/tutti-os/tutti/services/tuttid/service/cli"
@@ -46,7 +47,26 @@ func (p Provider) runComposerOptions(ctx context.Context, invoke framework.Invok
 	if err := p.requireSessions(); err != nil {
 		return nil, err
 	}
-	defaults := p.composerDefaultsForProvider(ctx, input.Provider)
+	canonicalProvider := agentproviderbiz.Normalize(input.Provider)
+	targets, err := p.enabledAgentTargets(ctx)
+	if err != nil {
+		return nil, err
+	}
+	providerEnabled := false
+	for _, target := range targets {
+		if target.Provider == canonicalProvider {
+			providerEnabled = true
+			break
+		}
+	}
+	if canonicalProvider == "" || !providerEnabled {
+		return nil, &agentservice.ProviderUnavailableError{
+			Provider:   input.Provider,
+			ReasonCode: "agent_provider_not_enabled",
+			Message:    "agent provider is not enabled",
+		}
+	}
+	defaults := p.composerDefaultsForProvider(ctx, canonicalProvider)
 	locale := input.Locale
 	if locale == "" {
 		locale = p.composerDefaultLocale(ctx)
@@ -66,7 +86,7 @@ func (p Provider) runComposerOptions(ctx context.Context, invoke framework.Invok
 	return p.sessions.GetComposerOptions(ctx, agentservice.ComposerOptionsInput{
 		Cwd:                      input.Cwd,
 		Locale:                   locale,
-		Provider:                 input.Provider,
+		Provider:                 canonicalProvider,
 		WorkspaceID:              invoke.WorkspaceID,
 		IncludeCapabilityCatalog: input.IncludeCapabilityCatalog,
 		Settings: agentservice.ComposerSettings{

--- a/services/tuttid/service/cli/providers/agentcontext/composer_options.go
+++ b/services/tuttid/service/cli/providers/agentcontext/composer_options.go
@@ -48,6 +48,9 @@ func (p Provider) runComposerOptions(ctx context.Context, invoke framework.Invok
 		return nil, err
 	}
 	canonicalProvider := agentproviderbiz.Normalize(input.Provider)
+	if canonicalProvider == "" {
+		return nil, agentservice.ErrInvalidArgument
+	}
 	targets, err := p.enabledAgentTargets(ctx)
 	if err != nil {
 		return nil, err
@@ -59,7 +62,7 @@ func (p Provider) runComposerOptions(ctx context.Context, invoke framework.Invok
 			break
 		}
 	}
-	if canonicalProvider == "" || !providerEnabled {
+	if !providerEnabled {
 		return nil, &agentservice.ProviderUnavailableError{
 			Provider:   input.Provider,
 			ReasonCode: "agent_provider_not_enabled",

--- a/services/tuttid/service/cli/providers/agentcontext/provider.go
+++ b/services/tuttid/service/cli/providers/agentcontext/provider.go
@@ -90,9 +90,14 @@ func (Provider) AppID() string {
 }
 
 func (p Provider) Commands() []cliservice.Command {
-	return []cliservice.Command{
-		p.newProvidersCommand(),
-		p.newComposerOptionsCommand(),
+	commands := make([]cliservice.Command, 0, 18)
+	if p.agentTargets != nil {
+		commands = append(commands,
+			p.newProvidersCommand(),
+			p.newComposerOptionsCommand(),
+		)
+	}
+	commands = append(commands,
 		p.newSkillBundleCommand(),
 		p.newProviderStartCommand(providerStartCommandSpec{
 			AppID:         codexAgentAppID,
@@ -134,7 +139,8 @@ func (p Provider) Commands() []cliservice.Command {
 		p.newSessionSummaryCommand(),
 		p.newTurnResourcesCommand(),
 		p.newActivePeersCommand(),
-	}
+	)
+	return commands
 }
 
 func (p Provider) FilterCapabilities(ctx context.Context, _ cliservice.InvokeContext, capabilities []cliservice.Capability) []cliservice.Capability {

--- a/services/tuttid/service/cli/providers/agentcontext/provider.go
+++ b/services/tuttid/service/cli/providers/agentcontext/provider.go
@@ -43,11 +43,16 @@ type DesktopPreferencesReader interface {
 	Get(context.Context) (preferencesbiz.DesktopPreferences, error)
 }
 
+type AgentTargetLister interface {
+	List(context.Context) ([]agenttargetbiz.Target, error)
+}
+
 type Provider struct {
 	workspaces      cliservice.WorkspaceCatalog
 	sessions        AgentSessions
 	launchPublisher AgentGUILaunchPublisher
 	preferences     DesktopPreferencesReader
+	agentTargets    AgentTargetLister
 }
 
 func NewProviderWithLaunchPublisher(
@@ -66,6 +71,18 @@ func NewProviderWithLaunchPublisher(
 		launchPublisher: launchPublisher,
 		preferences:     preferencesReader,
 	}
+}
+
+func NewProviderWithAgentTargets(
+	workspaces cliservice.WorkspaceCatalog,
+	sessions AgentSessions,
+	launchPublisher AgentGUILaunchPublisher,
+	agentTargets AgentTargetLister,
+	preferences ...DesktopPreferencesReader,
+) Provider {
+	provider := NewProviderWithLaunchPublisher(workspaces, sessions, launchPublisher, preferences...)
+	provider.agentTargets = agentTargets
+	return provider
 }
 
 func (Provider) AppID() string {
@@ -186,4 +203,15 @@ func (p Provider) requireSessions() error {
 		return agentservice.ErrInvalidArgument
 	}
 	return nil
+}
+
+func (p Provider) enabledAgentTargets(ctx context.Context) ([]agenttargetbiz.Target, error) {
+	if p.agentTargets == nil {
+		return nil, agentservice.ErrInvalidArgument
+	}
+	targets, err := p.agentTargets.List(ctx)
+	if err != nil {
+		return nil, err
+	}
+	return agenttargetbiz.EnabledTargetsByProvider(targets), nil
 }

--- a/services/tuttid/service/cli/providers/agentcontext/provider_test.go
+++ b/services/tuttid/service/cli/providers/agentcontext/provider_test.go
@@ -1036,6 +1036,9 @@ func TestComposerOptionsCommandReturnsProviderOptions(t *testing.T) {
 	if output.Value["provider"] != "codex" {
 		t.Fatalf("output = %#v", output.Value)
 	}
+	if output.Value["schemaVersion"] != 1 {
+		t.Fatalf("schemaVersion = %#v, want 1", output.Value["schemaVersion"])
+	}
 	effectiveSettings := output.Value["effectiveSettings"].(map[string]any)
 	if effectiveSettings["model"] != "gpt-5" || effectiveSettings["reasoningEffort"] != "high" {
 		t.Fatalf("effectiveSettings = %#v", effectiveSettings)

--- a/services/tuttid/service/cli/providers/agentcontext/provider_test.go
+++ b/services/tuttid/service/cli/providers/agentcontext/provider_test.go
@@ -35,6 +35,22 @@ type fakeDesktopPreferencesReader struct {
 	preferences preferencesbiz.DesktopPreferences
 }
 
+type fakeAgentTargetLister struct {
+	targets []agenttargetbiz.Target
+	err     error
+}
+
+func (f fakeAgentTargetLister) List(context.Context) ([]agenttargetbiz.Target, error) {
+	if f.err != nil {
+		return nil, f.err
+	}
+	return append([]agenttargetbiz.Target(nil), f.targets...), nil
+}
+
+func enabledTestAgentTargets() fakeAgentTargetLister {
+	return fakeAgentTargetLister{targets: agenttargetbiz.DefaultSystemTargets(1)}
+}
+
 func (f fakeDesktopPreferencesReader) Get(context.Context) (preferencesbiz.DesktopPreferences, error) {
 	return f.preferences, nil
 }
@@ -67,7 +83,7 @@ type fakeAgentSessions struct {
 }
 
 func newTestProvider(workspaces cliservice.WorkspaceCatalog, sessions AgentSessions) Provider {
-	return NewProviderWithLaunchPublisher(workspaces, sessions, nil)
+	return NewProviderWithAgentTargets(workspaces, sessions, nil, enabledTestAgentTargets())
 }
 
 func newTestCodexStartCommand(provider Provider) cliservice.Command {
@@ -857,20 +873,24 @@ func TestProvidersCommandReturnsAvailability(t *testing.T) {
 		t.Fatalf("Handler: %v", err)
 	}
 	providers := output.Value["providers"].([]any)
-	if len(providers) != 1 || providers[0].(map[string]any)["provider"] != "codex" {
+	if len(providers) != 1 || providers[0].(map[string]any)["providerId"] != "codex" {
 		t.Fatalf("providers = %#v", providers)
 	}
-	if output.Value["defaultProvider"] != "codex" {
-		t.Fatalf("defaultProvider = %#v, want codex", output.Value["defaultProvider"])
+	if output.Value["schemaVersion"] != 2 {
+		t.Fatalf("schemaVersion = %#v, want 2", output.Value["schemaVersion"])
+	}
+	if output.Value["defaultProviderId"] != "codex" {
+		t.Fatalf("defaultProviderId = %#v, want codex", output.Value["defaultProviderId"])
 	}
 }
 
 func TestProvidersCommandReturnsDefaultProviderFromPreferences(t *testing.T) {
 	sessions := &fakeAgentSessions{}
-	command := NewProviderWithLaunchPublisher(
+	command := NewProviderWithAgentTargets(
 		fakeWorkspaceCatalog{startup: workspacebiz.Summary{ID: "workspace-1"}},
 		sessions,
 		nil,
+		enabledTestAgentTargets(),
 		fakeDesktopPreferencesReader{
 			preferences: preferencesbiz.DesktopPreferences{
 				DefaultAgentProvider: "claude-code",
@@ -886,8 +906,98 @@ func TestProvidersCommandReturnsDefaultProviderFromPreferences(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Handler: %v", err)
 	}
-	if output.Value["defaultProvider"] != "claude-code" {
-		t.Fatalf("defaultProvider = %#v, want claude-code", output.Value["defaultProvider"])
+	if output.Value["defaultProviderId"] != "claude-code" {
+		t.Fatalf("defaultProviderId = %#v, want claude-code", output.Value["defaultProviderId"])
+	}
+}
+
+func TestProvidersCommandUsesEnabledTargetOrderAndStructuredAvailability(t *testing.T) {
+	targets := agenttargetbiz.DefaultSystemTargets(1)
+	targets[0].Enabled = false
+	targets = []agenttargetbiz.Target{targets[2], targets[1], targets[0]}
+	sessions := &fakeAgentSessions{availability: []agentservice.ProviderAvailability{
+		availableProvider("claude-code"),
+		{
+			Provider: "tutti-agent",
+			Status:   agentservice.ProviderAvailabilityUnavailable,
+			LastError: &agentservice.ProviderAvailabilityError{
+				Code:    "cli_not_found",
+				Message: "runtime missing",
+			},
+		},
+		availableProvider("codex"),
+	}}
+	command := NewProviderWithAgentTargets(
+		fakeWorkspaceCatalog{startup: workspacebiz.Summary{ID: "workspace-1"}},
+		sessions,
+		nil,
+		fakeAgentTargetLister{targets: targets},
+		fakeDesktopPreferencesReader{preferences: preferencesbiz.DesktopPreferences{DefaultAgentProvider: "codex"}},
+	).newProvidersCommand()
+
+	output, err := command.Handler(context.Background(), cliservice.InvokeRequest{OutputMode: cliservice.OutputModeJSON})
+	if err != nil {
+		t.Fatalf("Handler: %v", err)
+	}
+	providers := output.Value["providers"].([]any)
+	if len(providers) != 2 {
+		t.Fatalf("providers = %#v, want two enabled targets", providers)
+	}
+	first := providers[0].(map[string]any)
+	second := providers[1].(map[string]any)
+	if first["providerId"] != "tutti-agent" || first["agentTargetId"] != agenttargetbiz.IDLocalTuttiAgent || first["displayName"] != "Tutti Agent" {
+		t.Fatalf("first provider = %#v", first)
+	}
+	availability := first["availability"].(map[string]any)
+	if availability["status"] != agentservice.ProviderAvailabilityUnavailable || availability["reasonCode"] != "cli_not_found" || availability["detail"] != "runtime missing" {
+		t.Fatalf("availability = %#v", availability)
+	}
+	if second["providerId"] != "claude-code" {
+		t.Fatalf("second provider = %#v", second)
+	}
+	if output.Value["defaultProviderId"] != "tutti-agent" {
+		t.Fatalf("defaultProviderId = %#v, want first enabled provider", output.Value["defaultProviderId"])
+	}
+}
+
+func TestProvidersCommandAllowsEmptyEnabledTargetCatalog(t *testing.T) {
+	targets := agenttargetbiz.DefaultSystemTargets(1)
+	for index := range targets {
+		targets[index].Enabled = false
+	}
+	command := NewProviderWithAgentTargets(
+		fakeWorkspaceCatalog{startup: workspacebiz.Summary{ID: "workspace-1"}},
+		&fakeAgentSessions{},
+		nil,
+		fakeAgentTargetLister{targets: targets},
+	).newProvidersCommand()
+
+	output, err := command.Handler(context.Background(), cliservice.InvokeRequest{OutputMode: cliservice.OutputModeJSON})
+	if err != nil {
+		t.Fatalf("Handler: %v", err)
+	}
+	if providers := output.Value["providers"].([]any); len(providers) != 0 {
+		t.Fatalf("providers = %#v, want empty", providers)
+	}
+	if output.Value["defaultProviderId"] != "" {
+		t.Fatalf("defaultProviderId = %#v, want empty", output.Value["defaultProviderId"])
+	}
+}
+
+func TestProvidersCommandKeepsTableOutputCompatible(t *testing.T) {
+	command := newTestProvider(
+		fakeWorkspaceCatalog{startup: workspacebiz.Summary{ID: "workspace-1"}},
+		&fakeAgentSessions{},
+	).newProvidersCommand()
+	output, err := command.Handler(context.Background(), cliservice.InvokeRequest{
+		Input:      map[string]any{"provider": "codex"},
+		OutputMode: cliservice.OutputModeTable,
+	})
+	if err != nil {
+		t.Fatalf("Handler: %v", err)
+	}
+	if len(output.Rows) != 1 || output.Rows[0]["provider"] != "codex" || output.Rows[0]["status"] != "available" || output.Rows[0]["detail"] != "codex status" {
+		t.Fatalf("rows = %#v", output.Rows)
 	}
 }
 
@@ -938,6 +1048,42 @@ func TestComposerOptionsCommandReturnsProviderOptions(t *testing.T) {
 	}
 }
 
+func TestComposerOptionsCommandRejectsDisabledProviderBeforeDiscovery(t *testing.T) {
+	targets := agenttargetbiz.DefaultSystemTargets(1)
+	targets[0].Enabled = false
+	sessions := &fakeAgentSessions{}
+	command := NewProviderWithAgentTargets(
+		fakeWorkspaceCatalog{startup: workspacebiz.Summary{ID: "workspace-1"}},
+		sessions,
+		nil,
+		fakeAgentTargetLister{targets: targets},
+	).newComposerOptionsCommand()
+
+	_, err := command.Handler(context.Background(), cliservice.InvokeRequest{Input: map[string]any{"provider": "codex"}})
+	var unavailable *agentservice.ProviderUnavailableError
+	if !errors.As(err, &unavailable) || unavailable.ReasonCode != "agent_provider_not_enabled" {
+		t.Fatalf("err = %v, want agent_provider_not_enabled", err)
+	}
+	if sessions.composerInput.Provider != "" {
+		t.Fatalf("composer discovery was called: %#v", sessions.composerInput)
+	}
+}
+
+func TestComposerOptionsCommandCanonicalizesLegacyProviderInput(t *testing.T) {
+	sessions := &fakeAgentSessions{}
+	command := newTestProvider(
+		fakeWorkspaceCatalog{startup: workspacebiz.Summary{ID: "workspace-1"}},
+		sessions,
+	).newComposerOptionsCommand()
+
+	if _, err := command.Handler(context.Background(), cliservice.InvokeRequest{Input: map[string]any{"provider": "claude"}}); err != nil {
+		t.Fatalf("Handler: %v", err)
+	}
+	if sessions.composerInput.Provider != "claude-code" {
+		t.Fatalf("provider = %q, want claude-code", sessions.composerInput.Provider)
+	}
+}
+
 func TestComposerOptionsCommandCanDisableCapabilityCatalog(t *testing.T) {
 	sessions := &fakeAgentSessions{}
 	command := newTestProvider(fakeWorkspaceCatalog{startup: workspacebiz.Summary{ID: "workspace-1"}}, sessions).newComposerOptionsCommand()
@@ -961,10 +1107,11 @@ func TestComposerOptionsCommandCanDisableCapabilityCatalog(t *testing.T) {
 
 func TestComposerOptionsCommandUsesComposerDefaultsFromPreferences(t *testing.T) {
 	sessions := &fakeAgentSessions{}
-	command := NewProviderWithLaunchPublisher(
+	command := NewProviderWithAgentTargets(
 		fakeWorkspaceCatalog{startup: workspacebiz.Summary{ID: "workspace-1"}},
 		sessions,
 		nil,
+		enabledTestAgentTargets(),
 		fakeDesktopPreferencesReader{
 			preferences: preferencesbiz.DesktopPreferences{
 				AgentComposerDefaultsByAgentTarget: map[string]preferencesbiz.AgentComposerDefaults{

--- a/services/tuttid/service/cli/providers/agentcontext/provider_test.go
+++ b/services/tuttid/service/cli/providers/agentcontext/provider_test.go
@@ -112,6 +112,16 @@ func newTestClaudeStartCommand(provider Provider) cliservice.Command {
 	})
 }
 
+func TestProviderWithoutAgentTargetsDoesNotAdvertiseCatalogCommands(t *testing.T) {
+	provider := NewProviderWithLaunchPublisher(nil, nil, nil)
+	for _, command := range provider.Commands() {
+		path := strings.Join(command.Capability.Path, " ")
+		if path == "agent providers" || path == "agent composer-options" {
+			t.Fatalf("command %q requires AgentTargetLister", path)
+		}
+	}
+}
+
 func (f *fakeAgentSessions) Cancel(_ context.Context, workspaceID string, sessionID string) (agentservice.CancelSessionResult, error) {
 	f.workspaceID = workspaceID
 	f.sessionID = sessionID
@@ -1063,6 +1073,22 @@ func TestComposerOptionsCommandRejectsDisabledProviderBeforeDiscovery(t *testing
 	var unavailable *agentservice.ProviderUnavailableError
 	if !errors.As(err, &unavailable) || unavailable.ReasonCode != "agent_provider_not_enabled" {
 		t.Fatalf("err = %v, want agent_provider_not_enabled", err)
+	}
+	if sessions.composerInput.Provider != "" {
+		t.Fatalf("composer discovery was called: %#v", sessions.composerInput)
+	}
+}
+
+func TestComposerOptionsCommandRejectsUnknownProviderAsInvalidArgument(t *testing.T) {
+	sessions := &fakeAgentSessions{}
+	command := newTestProvider(
+		fakeWorkspaceCatalog{startup: workspacebiz.Summary{ID: "workspace-1"}},
+		sessions,
+	).newComposerOptionsCommand()
+
+	_, err := command.Handler(context.Background(), cliservice.InvokeRequest{Input: map[string]any{"provider": "codxe"}})
+	if !errors.Is(err, agentservice.ErrInvalidArgument) {
+		t.Fatalf("err = %v, want ErrInvalidArgument", err)
 	}
 	if sessions.composerInput.Provider != "" {
 		t.Fatalf("composer discovery was called: %#v", sessions.composerInput)

--- a/services/tuttid/service/cli/providers/agentcontext/providers.go
+++ b/services/tuttid/service/cli/providers/agentcontext/providers.go
@@ -2,13 +2,17 @@ package agentcontext
 
 import (
 	"context"
+	"strings"
 
 	agentproviderbiz "github.com/tutti-os/tutti/services/tuttid/biz/agentprovider"
+	agenttargetbiz "github.com/tutti-os/tutti/services/tuttid/biz/agenttarget"
 	preferencesbiz "github.com/tutti-os/tutti/services/tuttid/biz/preferences"
 	agentservice "github.com/tutti-os/tutti/services/tuttid/service/agent"
 	cliservice "github.com/tutti-os/tutti/services/tuttid/service/cli"
 	"github.com/tutti-os/tutti/services/tuttid/service/cli/framework"
 )
+
+const agentProviderCatalogSchemaVersion = 2
 
 var providerColumns = []cliservice.TableColumn{
 	{Key: "provider", Label: "Provider"},
@@ -20,9 +24,14 @@ type providersInput struct {
 	Provider string `cli:"provider"`
 }
 
+type providerCatalogItem struct {
+	Target       agenttargetbiz.Target
+	Availability agentservice.ProviderAvailability
+}
+
 type providersResult struct {
-	DefaultProvider string
-	Availability    []agentservice.ProviderAvailability
+	DefaultProviderID string
+	Items             []providerCatalogItem
 }
 
 func (p Provider) newProvidersCommand() cliservice.Command {
@@ -30,7 +39,7 @@ func (p Provider) newProvidersCommand() cliservice.Command {
 		ID:          appID + ".agent.providers",
 		Path:        []string{"agent", "providers"},
 		Summary:     "List available agent providers",
-		Description: "List agent providers and whether tuttid can start their local runtime command.",
+		Description: "List enabled Agent Targets and whether tuttid can start their local runtime command.",
 		Kind:        framework.KindList,
 		Workspace:   framework.WorkspaceOptional,
 		Inputs:      framework.FromStruct[providersInput](),
@@ -41,15 +50,16 @@ func (p Provider) newProvidersCommand() cliservice.Command {
 			Table: &framework.TableOutputSpec{
 				Columns: providerColumns,
 				Rows: func(result any) []map[string]any {
-					return providerAvailabilityRows(result.(providersResult).Availability)
+					return providerCatalogRows(result.(providersResult).Items)
 				},
 			},
 			JSONViews: map[framework.OutputView]func(any) map[string]any{
 				framework.ViewSummary: func(result any) map[string]any {
 					providers := result.(providersResult)
 					return map[string]any{
-						"defaultProvider": providers.DefaultProvider,
-						"providers":       providerAvailabilityValues(providers.Availability),
+						"schemaVersion":     agentProviderCatalogSchemaVersion,
+						"defaultProviderId": providers.DefaultProviderID,
+						"providers":         providerCatalogValues(providers.Items),
 					}
 				},
 			},
@@ -63,57 +73,124 @@ func (p Provider) runProviders(ctx context.Context, _ framework.InvokeContext, i
 	if err := p.requireSessions(); err != nil {
 		return nil, err
 	}
-	availability, err := p.sessions.ListProviderAvailability(ctx, agentservice.ProviderAvailabilityInput{
-		Provider: input.Provider,
-	})
+	targets, err := p.enabledAgentTargets(ctx)
 	if err != nil {
 		return nil, err
 	}
-	defaultProvider, err := p.defaultAgentProvider(ctx)
+	requestedProvider := agentproviderbiz.Normalize(input.Provider)
+	if strings.TrimSpace(input.Provider) != "" && requestedProvider == "" {
+		return nil, agentservice.ErrInvalidArgument
+	}
+	if requestedProvider != "" {
+		filtered := make([]agenttargetbiz.Target, 0, 1)
+		for _, target := range targets {
+			if target.Provider == requestedProvider {
+				filtered = append(filtered, target)
+				break
+			}
+		}
+		targets = filtered
+	}
+
+	availabilityInput := agentservice.ProviderAvailabilityInput{}
+	if len(targets) == 1 && requestedProvider != "" {
+		availabilityInput.Provider = requestedProvider
+	}
+	availability, err := p.sessions.ListProviderAvailability(ctx, availabilityInput)
 	if err != nil {
 		return nil, err
 	}
-	return providersResult{DefaultProvider: defaultProvider, Availability: availability}, nil
-}
-
-func (p Provider) defaultAgentProvider(ctx context.Context) (string, error) {
-	if p.preferences == nil {
-		return preferencesbiz.DefaultDesktopPreferences().DefaultAgentProvider, nil
-	}
-	preferences, err := p.preferences.Get(ctx)
+	items := providerCatalogItems(targets, availability)
+	defaultProvider, err := p.defaultAgentProvider(ctx, targets)
 	if err != nil {
-		return "", err
+		return nil, err
 	}
-	defaultProvider := agentproviderbiz.Normalize(preferences.DefaultAgentProvider)
-	if defaultProvider == "" {
-		defaultProvider = preferencesbiz.DefaultDesktopPreferences().DefaultAgentProvider
-	}
-	return defaultProvider, nil
+	return providersResult{DefaultProviderID: defaultProvider, Items: items}, nil
 }
 
-func providerAvailabilityRows(items []agentservice.ProviderAvailability) []map[string]any {
+func (p Provider) defaultAgentProvider(ctx context.Context, targets []agenttargetbiz.Target) (string, error) {
+	defaultProvider := preferencesbiz.DefaultDesktopPreferences().DefaultAgentProvider
+	if p.preferences != nil {
+		preferences, err := p.preferences.Get(ctx)
+		if err != nil {
+			return "", err
+		}
+		if normalized := agentproviderbiz.Normalize(preferences.DefaultAgentProvider); normalized != "" {
+			defaultProvider = normalized
+		}
+	}
+	for _, target := range targets {
+		if target.Provider == defaultProvider {
+			return defaultProvider, nil
+		}
+	}
+	if len(targets) > 0 {
+		return targets[0].Provider, nil
+	}
+	return "", nil
+}
+
+func providerCatalogItems(targets []agenttargetbiz.Target, availability []agentservice.ProviderAvailability) []providerCatalogItem {
+	byProvider := make(map[string]agentservice.ProviderAvailability, len(availability))
+	for _, item := range availability {
+		provider := agentproviderbiz.Normalize(item.Provider)
+		if provider != "" {
+			item.Provider = provider
+			byProvider[provider] = item
+		}
+	}
+	items := make([]providerCatalogItem, 0, len(targets))
+	for _, target := range targets {
+		item, ok := byProvider[target.Provider]
+		if !ok {
+			item = agentservice.ProviderAvailability{
+				Provider: target.Provider,
+				Status:   agentservice.ProviderAvailabilityUnknown,
+				LastError: &agentservice.ProviderAvailabilityError{
+					Code:    "agent_provider_status_unknown",
+					Message: "provider runtime status is unavailable",
+				},
+			}
+		}
+		items = append(items, providerCatalogItem{Target: target, Availability: item})
+	}
+	return items
+}
+
+func providerCatalogRows(items []providerCatalogItem) []map[string]any {
 	rows := make([]map[string]any, 0, len(items))
 	for _, item := range items {
 		rows = append(rows, map[string]any{
-			"provider": item.Provider,
-			"status":   item.Status,
-			"detail":   providerAvailabilityDetail(item),
+			"provider": item.Target.Provider,
+			"status":   item.Availability.Status,
+			"detail":   providerAvailabilityDetail(item.Availability),
 		})
 	}
 	return rows
 }
 
-func providerAvailabilityValues(items []agentservice.ProviderAvailability) []any {
+func providerCatalogValues(items []providerCatalogItem) []any {
 	values := make([]any, 0, len(items))
 	for _, item := range items {
-		value := map[string]any{
-			"provider": item.Provider,
-			"status":   item.Status,
-			"detail":   providerAvailabilityDetail(item),
-		}
-		values = append(values, value)
+		values = append(values, map[string]any{
+			"providerId":    item.Target.Provider,
+			"displayName":   item.Target.Name,
+			"agentTargetId": item.Target.ID,
+			"availability": map[string]any{
+				"status":     item.Availability.Status,
+				"reasonCode": providerAvailabilityReasonCode(item.Availability),
+				"detail":     providerAvailabilityDetail(item.Availability),
+			},
+		})
 	}
 	return values
+}
+
+func providerAvailabilityReasonCode(item agentservice.ProviderAvailability) string {
+	if item.LastError != nil {
+		return strings.TrimSpace(item.LastError.Code)
+	}
+	return ""
 }
 
 func providerAvailabilityDetail(item agentservice.ProviderAvailability) string {

--- a/services/tuttid/service/workspace/agent_workspace_app_reference/SKILL.md
+++ b/services/tuttid/service/workspace/agent_workspace_app_reference/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: tutti-agent-workspace-app
-description: "Build or evolve a complex agent-enabled Tutti workspace app repository. Use for Tutti apps with web/server/shared monorepos, @tutti-os/agent-acp-kit local agent runtimes, Tutti app-scoped agent provider APIs, dynamic provider catalogs (Codex, Claude Code, Cursor, OpenCode, and future supported providers), run-scoped MCP tool gateways, app-owned package builders, Tutti CLI/reference surfaces, web-first debugging, i18n harnesses, and production package validation. For simple package creation or repair, use tutti-workspace-app-factory instead."
+description: "Build or evolve a complex agent-enabled Tutti workspace app repository. Use for Tutti apps with web/server/shared monorepos, @tutti-os/agent-acp-kit local agent runtimes, kit-owned TUTTI_CLI provider/composer discovery, dynamic provider catalogs, run-scoped MCP tool gateways, app-owned package builders, web-first debugging, i18n harnesses, and production package validation. For simple package creation or repair, use tutti-workspace-app-factory instead."
 ---
 
 # Tutti Agent Workspace App
@@ -15,7 +15,7 @@ Use this skill for:
 
 - New agent-enabled Tutti app repositories.
 - Existing web/server apps being converted into maintainable Tutti app repos.
-- Apps that need `@tutti-os/agent-acp-kit` for local agent runtime execution behind Tutti-owned dynamic provider catalog APIs.
+- Apps that need `@tutti-os/agent-acp-kit` for app-owned local Agent execution and `@tutti-os/agent-acp-kit/tutti` for auto CLI-backed/standalone platform context.
 - App-specific MCP or command gateways that expose domain tools to local agents.
 - Multi-package `pnpm` workspaces with `apps/web`, `apps/server`, and `packages/shared`.
 - App-owned packaging, smoke tests, i18n enforcement, and CLI/reference endpoints.
@@ -29,7 +29,7 @@ Read only the references needed for the task:
 
 - `references/app-architecture.md` for repository layout, web/server/shared boundaries, and dependency choices.
 - `references/agent-acp-kit.md` when implementing local agent providers, ACP event mapping, or run-scoped MCP tools.
-- `references/dynamic-agent-providers.md` when implementing the Tutti app-scoped provider catalog, standalone detection, provider pickers, default provider selection, or provider ID normalization. Read this before hard-coding any provider list.
+- `references/dynamic-agent-providers.md` when implementing provider catalog/composer endpoints, standalone behavior, provider pickers, default selection, or canonical provider persistence. Read this before hard-coding any provider list.
 - `references/package-builder.md` when adding `scripts/package-tutti-app.mjs`, `bootstrap.sh`, Tutti CLI output docs, or package validation.
 - `references/github-actions-release.md` when creating or changing `.github/workflows/publish-tutti-app.yml`, `.github/workflows/publish-tutti-app-staging.yml`, release variables, or catalog publishing.
 - `references/i18n-and-web-debugging.md` when changing UI copy, language handling, web-first debug flow, or smoke/e2e checks.
@@ -42,8 +42,8 @@ Also read `$tutti-workspace-app-factory` before changing final package files or 
 2. Choose the smallest architecture that can stay maintainable: do not add local agents, WebSocket, MCP, CLI, or background workers unless the product needs them.
 3. Define shared contracts before wiring web/server calls. Keep domain DTOs, WebSocket messages, CLI-visible shapes, and runtime profile types in `packages/shared`.
 4. Build the web UI as the primary development surface. Keep the server as local API/static host and app orchestration layer.
-5. If agents are needed, add `@tutti-os/agent-acp-kit`, Tutti app-scoped provider catalog integration, dynamic runtime provider registration, event normalization, and a run-scoped tool gateway.
-   Follow `references/dynamic-agent-providers.md`: inside Tutti, derive provider options from the workspace-app scoped `preferences/agent`, `agent-providers/status`, and `agent-providers/{provider}/composer-options` APIs; keep the kit's default plugin set available for runtime execution and standalone detection. Render every provider returned by Tutti, keep unavailable entries disabled with their reason, choose one usable default, and never maintain a Codex/Claude-only app catalog.
+5. If agents are needed, add an exact released `@tutti-os/agent-acp-kit`, use its default app-owned runtime, call the `/tutti` auto facade for catalog/composer/skill context, normalize events, and add a run-scoped tool gateway.
+   Follow `references/dynamic-agent-providers.md`: do not pass mode, check `TUTTI_CLI`, call Agent catalog HTTP routes, read app ID/token/API environment, parse CLI JSON, or maintain provider aliases. Render every facade provider, keep unavailable entries disabled with their reason, choose one usable default, and never maintain a Codex/Claude-only app catalog.
    For apps that must run both locally and in cloud/managed Tutti, follow `references/agent-acp-kit.md` exactly: managed credentials come from request headers on the server, never from browser JSB fallback or request body fields.
 6. Add package generation only after the local dev app runs. Package the built web assets, bundled server, `tutti.app.json`, optional `tutti.cli.json`, executable `bootstrap.sh`, assets, locales, and package-local `AGENTS.md`.
 7. If the user asks to connect to the Tutti app ecosystem, treat ecosystem integration as required: expose app capabilities through `tutti.cli.json`, make the app callable by other Tutti apps and agents, and use `TUTTI_CLI` for any calls to other installed Tutti apps.
@@ -52,20 +52,20 @@ Also read `$tutti-workspace-app-factory` before changing final package files or 
 
 ## Managed and standalone agent checklist
 
-Keep Tutti-hosted and standalone provider discovery separate while sharing the same runtime execution layer:
+Keep Tutti-hosted and standalone behavior behind the kit's fixed auto facade while sharing the same runtime execution layer:
 
-1. Upgrade `@tutti-os/agent-acp-kit` to a version that exports managed-agent header context helpers.
-2. Inside Tutti, load provider choices from the workspace-app scoped daemon APIs. Do not replace that catalog with `localAgentRuntime.detect(...)`.
-3. Outside Tutti, use `localAgentRuntime.detect(...)` with the full default provider plugin set.
-4. Normalize the Tutti provider id to the kit runtime id at the execution boundary.
-5. If a managed credential is present, require `isManagedAgentInvocationProviderId(runtimeProviderId)` before awaiting `createManagedAgentRunContextFromHeaders(...)`. Reject unsupported managed providers instead of silently running them locally.
-6. Without a managed credential, use an app-owned local cwd. Pass the normalized provider id, selected cwd, and optional `managedAgentInvocation` into `localAgentRuntime.run(...)`.
-7. Delete browser JSB credential fallback code and request body credential fields.
+1. Pin an exact kit version that exports the auto catalog/composer/skill facade and managed header context helper.
+2. Call `loadTuttiAgentProviderCatalog({ runtime })`; do not pass mode or inspect `TUTTI_CLI`.
+3. Load composer options lazily for one canonical provider and expose only app/domain DTO projections.
+4. Persist canonical provider IDs; migrate legacy `claude` once to `claude-code`, but keep `nexight` and `tutti-agent` distinct.
+5. Await `createManagedAgentRunContextFromHeaders(...)` directly. Do not pre-read credentials or pre-check provider support in app code.
+6. Without a managed header, use an app-owned local cwd. Pass the same canonical provider ID, selected cwd, and optional `managedAgentInvocation` into runtime execution.
+7. Delete raw Agent HTTP/CLI clients, browser credential fallbacks, request-body credential fields, alias maps, and dependency patch scripts.
 8. Never persist managed credentials or expose managed cwd and credentials through frontend events, logs, status APIs, or stored app state.
-9. Do not hard-code `/workspace`, `.agent-runs`, or `CODEX_HOME` policy in the app business layer. Let the kit derive managed run context from headers and runtime env.
-10. If agent instructions are sent over WebSocket, confirm the Tutti/TSH host injects the managed credential into that WebSocket route too; do not invent a second credential channel inside the app.
+9. Do not hard-code `/workspace`, `.agent-runs`, or `CODEX_HOME`; the kit derives managed context.
+10. If instructions arrive over WebSocket, confirm the host injects the managed credential into that route; do not create a second credential channel.
 11. Package the built server, web assets, MCP/tool entrypoints, and runtime metadata needed by Tutti.
-12. Test Tutti catalog resolution, standalone detection, provider id normalization, managed and local run context creation, and credential non-leakage.
+12. Test CLI-backed auto, standalone auto, configured CLI failure, canonical IDs, managed/local run context, and secret non-leakage.
 
 ## Validation
 

--- a/services/tuttid/service/workspace/agent_workspace_app_reference/references/agent-acp-kit.md
+++ b/services/tuttid/service/workspace/agent_workspace_app_reference/references/agent-acp-kit.md
@@ -1,95 +1,90 @@
 # Agent ACP Kit Integration
 
-Use this reference only when the app needs local agent execution or a local agent runtime behind Tutti-owned dynamic provider catalog APIs.
+Use this reference whenever a workspace app owns local Agent execution.
 
 ## Rule
 
-If the app involves local agents, depend on `@tutti-os/agent-acp-kit`. Do not hand-roll provider detection, ACP stream parsing, or local-agent adapters unless the kit lacks a required capability and the gap is documented.
+Depend on a released exact version of `@tutti-os/agent-acp-kit`. The kit owns provider plugins, detection, canonical provider aliases, managed header handling, ACP lifecycle/event parsing, permission responses, MCP normalization, Tutti CLI execution, timeout/cancellation, and schema validation.
 
-For apps that must work in both local Tutti and cloud/managed Tutti, use an `@tutti-os/agent-acp-kit` version that provides managed-agent header context helpers. The app server should derive managed context from request headers and pass it directly to the kit runtime. The browser, request body, app state, and logs must not carry managed credentials.
+The app owns product orchestration, its backend endpoint, prompt policy, app tools, persistence, and UI. It must not patch kit build output or copy platform protocol code.
 
-## Runtime Shape
+Daemon-owned Agent Session apps are a different execution model: they may use Tutti CLI start/get/cancel commands and must not instantiate an app-owned local runtime merely for consistency.
 
-Keep app domain logic independent from providers:
+## Runtime shape
 
 ```text
-Application use-case
-  -> Agent run service/orchestrator
-    -> Runtime provider interface
-      -> local-agent provider using @tutti-os/agent-acp-kit
-        -> run-scoped MCP/tool gateway
+App use case
+  -> app Agent service
+    -> @tutti-os/agent-acp-kit/tutti catalog/composer/skill facade
+    -> app-owned @tutti-os/agent-acp-kit runtime execution
+      -> run-scoped app MCP/tool gateway
 ```
 
-Use provider IDs from Tutti's workspace-app scoped agent APIs. Do not keep app-local catalog allowlists such as `codex`/`claude` unless the app's product requirements explicitly document that a provider is unsupported. The app should show the provider set returned by Tutti, keep unavailable providers visible as disabled with a reason, and choose a usable default from the Tutti catalog.
+Create the full default runtime once:
 
-Read `references/dynamic-agent-providers.md` for the full discovery, normalization, UI, and runtime rules. Register the complete kit default provider set for execution; use `localAgentRuntime.detect(...)` for standalone operation, not to replace Tutti's app-scoped daemon API inside Tutti.
+```ts
+import { createDefaultLocalAgentRuntime } from "@tutti-os/agent-acp-kit";
 
-## Dynamic Provider Catalog
+export const localAgentRuntime = createDefaultLocalAgentRuntime();
+```
 
-Follow `references/dynamic-agent-providers.md` for the server environment, scoped routes, response mapping, catalog failure behavior, and persisted provider IDs. Tutti controls provider visibility. The kit controls runtime registration and execution.
+Provider IDs are canonical opaque strings. The runtime lists `claude-code`; it accepts legacy `claude` input internally. Apps must not add provider conversion helpers or register compatibility providers.
 
-Use the `@tutti-os/agent-acp-kit/tutti` subpath for Tutti CLI skill context. Do not assume it exports a provider catalog resolver. Keep the app-owned catalog client separate from the kit runtime, then normalize the selected Tutti provider id at the execution boundary.
+Read `references/dynamic-agent-providers.md` for catalog, composer, persistence, UI, and standalone behavior.
 
-## Provider Detection
+## Platform context
 
-Create the shared runtime once with the full default provider set. This snippet only registers execution plugins; each server run endpoint must still derive its managed context with `createManagedAgentRunContextFromHeaders(...)` as shown under Runtime Execution.
+The `@tutti-os/agent-acp-kit/tutti` subpath exposes three auto-detecting server-side functions:
 
 ```ts
 import {
-  createDefaultLocalAgentProviderPlugins,
-  createLocalAgentRuntime
+  loadTuttiAgentComposerOptions,
+  loadTuttiAgentProviderCatalog,
+  loadTuttiAgentSkillContext
+} from "@tutti-os/agent-acp-kit/tutti";
+```
+
+Do not pass a mode. When `TUTTI_CLI` is absent, catalog/composer use standalone runtime discovery and skill context is empty with `source: "standalone"`. When `TUTTI_CLI` exists, the kit uses it. A configured CLI failure is a typed error and never silently falls back.
+
+The app does not use daemon URL, server credential, workspace identity, or app identity for Agent catalog/composer queries. Those values may still be required for unrelated app-scoped resources.
+
+## Runtime execution
+
+For each run:
+
+1. Generate a stable run ID and use the canonical provider ID returned by the facade.
+2. Await `createManagedAgentRunContextFromHeaders(...)` directly. It reads and validates the managed credential, canonicalizes supported legacy input internally, creates a safe managed cwd, and rejects unsupported managed providers. The app must not pre-read the credential or perform a separate provider-support precheck.
+3. When no managed header exists, use an app-owned local cwd.
+4. Load Tutti skill context when platform skills are useful, passing browser/computer capability flags from trusted app policy.
+5. Create a run-scoped MCP/tool gateway and prompt envelope.
+6. Call the local runtime with the same canonical provider ID.
+7. Adapt events to the app stream and persist only session/resume metadata.
+8. Revoke gateway tokens and clean app-owned temporary files in `finally`.
+
+Skeleton:
+
+```ts
+import {
+  createDefaultLocalAgentRuntime,
+  createManagedAgentRunContextFromHeaders
 } from "@tutti-os/agent-acp-kit";
-
-const localAgentRuntime = createLocalAgentRuntime({
-  providers: createDefaultLocalAgentProviderPlugins()
-});
-
-export { localAgentRuntime };
-```
-
-Map Tutti composer models to app model IDs with a provider prefix, such as `codex:gpt-5.1` or `claude-code:sonnet`.
-
-For standalone kit detection, map detected provider models with the same prefix rule, such as `cursor:default` or `codex:gpt-5.1`. Build prefixes from the detected `provider` value; do not assume only Codex/Claude models exist.
-
-When an app customizes provider behavior, transform the full default plugin list instead of filtering it:
-
-```ts
-const providers = createDefaultLocalAgentProviderPlugins().map((provider) =>
-  provider.id === "claude"
-    ? withAppClaudeStreamCompatibility(provider)
-    : provider
-);
-```
-
-Provider-specific wrappers are fine; app-local catalog allowlists are not.
-
-Do not call a browser JSB API to fetch credentials for detection. Do not accept a credential field in the request body. Standalone detection requires no managed credential; call `localAgentRuntime.detect()` without a context unless the app has a trusted local detection context.
-
-## Runtime Execution
-
-For each agent run:
-
-1. Generate a stable app run ID.
-2. Normalize the Tutti provider id to the kit runtime id.
-3. Check for a managed credential on the server. Reject unsupported managed provider ids, then await `createManagedAgentRunContextFromHeaders(...)` only for `isManagedAgentInvocationProviderId(...)` providers. Without a managed credential, use an app-owned local cwd.
-4. Materialize app or workspace skills only when the app needs them, using paths under the selected cwd or app-owned runtime/data paths. Do not invent a separate managed cwd policy.
-5. Build a prompt envelope with conversation identity, current user turn, attachments, current app state, collaboration rules, and tool gateway guidance.
-6. Load Tutti dynamic skill context through `@tutti-os/agent-acp-kit/tutti` when the app runs inside Tutti and needs platform CLI skills.
-7. Create a run-scoped tool gateway session and MCP config.
-8. Call `localAgentRuntime.run(...)` with the normalized provider id and optional managed invocation context.
-9. Normalize ACP events into app stream events.
-10. Persist provider session/resume metadata when the kit returns it, but never persist managed credentials.
-11. Always revoke the gateway token and clean up app-owned temporary files in `finally`.
-
-Tutti dynamic CLI skills should use the kit helper, not per-app subprocess and JSON parsing code:
-
-```ts
 import { loadTuttiAgentSkillContext } from "@tutti-os/agent-acp-kit/tutti";
 
+const localAgentRuntime = createDefaultLocalAgentRuntime();
+
+const runContext = await createManagedAgentRunContextFromHeaders(req.headers, {
+  providerId,
+  runId
+});
+const cwd = runContext?.cwd ?? appLocalRunCwd;
+
 const tuttiContext = await loadTuttiAgentSkillContext({
-  provider,
+  provider: providerId,
   agentSessionId: runId,
-  cwd: workspaceCwd
+  cwd,
+  browserUse: appPolicyAllowsBrowser,
+  computerUse: appPolicyAllowsComputer,
+  signal
 });
 
 const systemPrompt = [
@@ -99,53 +94,20 @@ const systemPrompt = [
   .filter(Boolean)
   .join("\n\n");
 
-const skillManifest = [...appSkillManifest, ...tuttiContext.skillManifest];
-```
-
-The app still owns policy. `tuttiContext.recommendedSystemPrompt?.content` is raw advisory prompt content: merge it, edit it, place it elsewhere, or ignore it according to the app's prompt strategy. Do not silently append the recommended prompt, and do not hand-roll `$TUTTI_CLI agent tutti-cli-skill-bundle --json` parsing unless the installed `@tutti-os/agent-acp-kit` version lacks the helper.
-
-Skeleton:
-
-```ts
-import {
-  createManagedAgentRunContextFromHeaders,
-  getManagedAgentInvocationCredentialFromHeaders,
-  isManagedAgentInvocationProviderId
-} from "@tutti-os/agent-acp-kit";
-import { toKitAgentProviderId } from "./provider-id.js";
-
-const runtimeProviderId = toKitAgentProviderId(provider);
-const managedCredential = getManagedAgentInvocationCredentialFromHeaders(
-  req.headers
-);
-if (
-  managedCredential &&
-  !isManagedAgentInvocationProviderId(runtimeProviderId)
-) {
-  throw new Error(`Managed execution does not support ${runtimeProviderId}`);
-}
-const runContext =
-  managedCredential && isManagedAgentInvocationProviderId(runtimeProviderId)
-    ? await createManagedAgentRunContextFromHeaders(req.headers, {
-        providerId: runtimeProviderId,
-        runId
-      })
-    : undefined;
-const cwd = runContext?.cwd ?? appLocalRunCwd;
-
 for await (const event of localAgentRuntime.run({
   runId,
-  provider: runtimeProviderId,
+  provider: providerId,
+  runtimeProvider: providerId,
+  runtimeKind: "local-agent",
   cwd,
   prompt,
   systemPrompt,
   model,
-  runtimeKind: "local-agent",
-  runtimeProvider: runtimeProviderId,
+  reasoning,
   mcpServers,
   resume,
   signal,
-  skillManifest,
+  skillManifest: [...appSkills, ...tuttiContext.skillManifest],
   timeoutMs,
   managedAgentInvocation: runContext?.managedAgentInvocation
 })) {
@@ -153,42 +115,34 @@ for await (const event of localAgentRuntime.run({
 }
 ```
 
-Derive `appLocalRunCwd` from app-owned local policy. Do not accept a browser-provided cwd for managed runs. Do not claim a file write, canvas edit, image generation, or other side effect happened unless the corresponding tool event succeeded.
+`recommendedSystemPrompt` is advisory content. The app decides whether and where to merge it. Do not append it invisibly in a generic transport layer.
 
-Do not add these managed-agent anti-patterns:
+Derive `appLocalRunCwd` from trusted server-side app policy. Never accept a browser-provided cwd for a managed run. Never put a credential or managed cwd in request bodies, browser state, DTOs, logs, persistence, or error text.
 
-- Browser-side JSB credential fallback.
-- Request body fields such as `credential` or `managedAgentCredential`.
-- Persisted credential state.
-- Frontend events, logs, status APIs, or stored run metadata that expose managed credentials or managed cwd.
-- Business-layer hard-coding of `/workspace`, `.agent-runs`, or `CODEX_HOME` strategy. The kit owns managed run context and Codex home behavior.
-
-If the app sends agent instructions over WebSocket instead of HTTP POST, verify the Tutti/TSH host injects the managed credential header into that WebSocket route. The app should still read the credential from headers; it should not create a parallel credential transport.
-
-## Event Mapping
+## Event mapping
 
 Normalize at least:
 
-- text deltas and final assistant text
-- thinking/reasoning text
-- tool calls and tool results
-- status/progress updates
-- file writes
-- stderr/log events
-- done, canceled, and error terminal events
-- provider session ID or resume token
+- text deltas and final assistant text;
+- thinking/reasoning text;
+- tool calls and tool results;
+- status/progress and usage;
+- file writes;
+- stderr/log events;
+- completed, canceled, and failed terminal events;
+- provider session ID or resume token.
 
-If a provider emits raw events differently, add a provider-specific compatibility adapter near provider setup, not in UI code.
+General ACP lifecycle, Cursor update parsing, permission result shape, config-option/model fallback, prompt content blocks, and MCP env conversion belong in the kit. An app may retain only explicit product-specific presentation or orchestration adapters.
 
-## Tool Gateway
+## Tool gateway
 
 Expose app abilities through a run-scoped gateway:
 
-- Mint one token per run.
-- Pass the token only to the MCP server process or command bridge.
-- Validate token, run, participant/session, tool name, and schema on every call.
-- Revoke the token when the run completes, fails, or is canceled.
-- Keep tools app-level: read context, inspect state, mutate app artifacts, start app jobs, persist outputs, read app-owned files.
+- mint one token per run;
+- pass it only to the MCP server process or command bridge;
+- validate token, run/session identity, tool name, and schema on every call;
+- revoke it when the run completes, fails, or is canceled;
+- keep tools app-level: read app context, inspect state, mutate app artifacts, start app jobs, persist outputs, or read app-owned files.
 
 MCP config pattern:
 
@@ -213,27 +167,20 @@ export function createAppToolsMcpServerConfig(input: {
 }
 ```
 
-Package builders should bundle the MCP entrypoint and expose its path through an app-specific env var such as `AIMC_TOOLS_MCP_PATH`. Development runners may use a project-owned dev command such as `pnpm exec tsx ...` outside the packaged runtime, but package runtime MCP configs must not depend on bare `pnpm`, `node`, or source-tree TypeScript paths.
+Package builders must bundle the MCP entrypoint. Production MCP configs must not depend on bare `pnpm`, system `node`, source-tree TypeScript paths, or runtime dependency installation.
 
 ## Verification
 
 Add tests for:
 
-- Tutti app-scoped provider catalog resolution and model mapping
-- app status queries that omit app-local provider allowlists
-- provider visibility following the app-scoped status API rather than `runtime.listProviders()`
-- catalog failure returning an unavailable state without synthetic providers
-- dynamic provider catalog exposure and default selection (see `references/dynamic-agent-providers.md`)
-- provider plugin transformation and model mapping
-- standalone provider detection with the full default plugin set
-- awaited run context creation using the normalized kit provider id
-- rejection when a managed credential targets an unsupported provider id
-- local run context behavior when no managed header is present
-- credential non-leakage in response DTOs, logs, frontend events, and persisted run state
-- event normalization
-- MCP config env and packaged path
-- tool gateway token validation and revocation
-- run cancellation cleanup
-- resume metadata persistence
+- auto CLI-backed and standalone catalog/composer/skill behavior without a mode input;
+- configured-but-failing CLI returning a typed error without standalone fallback;
+- full dynamic provider projection and lazy composer loading;
+- canonical IDs and one-time `claude -> claude-code` state migration;
+- direct awaited managed run context creation, with no app credential precheck;
+- no managed secret/cwd leakage;
+- event normalization, cancellation, and resume metadata;
+- MCP env/path packaging and gateway token revocation;
+- absence of raw Agent catalog clients, provider alias helpers, and dependency patch scripts.
 
-For real-agent smoke tests inside Tutti, load the scoped catalog before running a narrow prompt. For standalone smoke tests, run detection first. Do not use irreversible side effects.
+For a real smoke test inside Tutti, load the catalog, one provider's composer options, and skill context before running a narrow cancellable prompt with no irreversible side effects.

--- a/services/tuttid/service/workspace/agent_workspace_app_reference/references/app-architecture.md
+++ b/services/tuttid/service/workspace/agent_workspace_app_reference/references/app-architecture.md
@@ -47,7 +47,7 @@ Use `pnpm` workspaces by default. Common choices:
 
 - Server: Node built-ins for tiny apps; Fastify, `@fastify/static`, `@fastify/websocket`, zod or ajv for larger API servers. Express is acceptable when the existing project already uses it.
 - Web: React with Vite, Next, or TanStack Start, matching the repo's current stack. For React/Tailwind apps, use shadcn/ui components and Tailwind CSS utilities as the default UI/component styling system.
-- Agent runtime: `@tutti-os/agent-acp-kit` when local agent execution is required behind Tutti-owned dynamic provider catalog APIs. Register the kit's default providers for execution and do not hard-code Codex/Claude-only catalogs.
+- Agent runtime: `@tutti-os/agent-acp-kit` for app-owned execution and `@tutti-os/agent-acp-kit/tutti` for auto CLI-backed/standalone provider catalog, composer, and skill context. Use the default runtime and do not hard-code provider catalogs, CLI protocol, app ID, token, or aliases.
 - I18n: `i18next`, `react-i18next`, and `i18next-cli` for larger web apps.
 - Tests: Vitest or Node test runner for packages, Playwright only for cross-boundary UI flows.
 

--- a/services/tuttid/service/workspace/agent_workspace_app_reference/references/dynamic-agent-providers.md
+++ b/services/tuttid/service/workspace/agent_workspace_app_reference/references/dynamic-agent-providers.md
@@ -1,266 +1,138 @@
 # Dynamic Agent Provider Integration
 
-Use this reference whenever an app exposes agent provider pickers, runtime profiles, default provider selection, or provider-specific UI.
+Use this reference whenever an app exposes an Agent provider picker, default provider, runtime profile, or provider-specific composer UI.
 
-## Rule
+## Ownership rule
 
-Never hard-code an agent provider catalog such as `codex` and `claude` only. Inside Tutti, the workspace-app scoped daemon API is the provider catalog source of truth. New providers such as `cursor` and `opencode` should appear automatically when Tutti exposes an enabled Agent Target and the installed `@tutti-os/agent-acp-kit` can execute it.
-
-The app owns presentation and policy. Tutti owns provider visibility, preferences, availability, and composer options; the kit owns runtime registration, standalone detection, and execution.
-
-The workspace-app scoped provider APIs first ship in Tutti `0.1.19-rc.0`. Production app releases use stable compatibility floors, so set `min_tutti_version` to at least `0.1.19` for apps that use this integration.
-
-## Architecture
+The integration has three layers:
 
 ```text
-Tutti workspace-app scoped APIs
-  -> preferences/agent                            // preferred provider + gates
-  -> agent-providers/status                       // visible Agent Targets + availability
-  -> agent-providers/{provider}/composer-options  // models + reasoning + speed
-    -> app API: GET /api/agents/providers
-      -> web UI renders the returned catalog dynamically
-        -> user selects providerId from catalog response
-          -> normalize daemon ID to kit runtime ID
-            -> localAgentRuntime.run({ provider: runtimeProviderId, ... })
-
-createDefaultLocalAgentProviderPlugins()
-  -> createLocalAgentRuntime({ providers })       // execution + standalone detection
+Tutti CLI owns platform capability and enabled Agent Target visibility
+  -> @tutti-os/agent-acp-kit/tutti owns execution, parsing, validation, and fallback
+    -> the app owns product policy, API projection, persistence, and UI
 ```
 
-Do not maintain a parallel static provider list in web, shared, or server code unless the app has a documented, provider-specific capability gap.
+An app must not call workspace-app Agent catalog HTTP routes, build daemon URLs, read an Agent catalog bearer token, pass an app ID to provider discovery, spawn `TUTTI_CLI`, parse CLI JSON, or maintain provider ID mappings. The kit does all of that.
 
-## Registration
+Provider IDs are an open string set. Persist and return the canonical `providerId` supplied by the kit. Do not define a closed `"codex" | "claude-code"` union. The SDK accepts the legacy input `claude` internally and emits `claude-code`; it does not map `nexight`, `tutti`, or `tutti-agent` to each other.
 
-Always register providers from the kit default plugin set unless the app adds a documented custom ACP provider:
+## Runtime registration
+
+Create the standard app-owned execution runtime once:
 
 ```ts
-import {
-  createDefaultLocalAgentProviderPlugins,
-  createLocalAgentRuntime
-} from "@tutti-os/agent-acp-kit";
+import { createDefaultLocalAgentRuntime } from "@tutti-os/agent-acp-kit";
 
-const localAgentRuntime = createLocalAgentRuntime({
-  providers: createDefaultLocalAgentProviderPlugins()
-});
+export const localAgentRuntime = createDefaultLocalAgentRuntime();
 ```
 
-Upgrade `@tutti-os/agent-acp-kit` when Tutti adds providers. Do not copy provider IDs into the app repository to "stay compatible".
+Only construct a custom plugin list when the app has a documented provider transport extension. Customization must transform the full default list; it must not silently filter the catalog to Codex and Claude.
 
-## Discovery
+## Provider catalog
 
-Expose one app-owned backend endpoint, such as `GET /api/agents/providers`, that returns the provider catalog. Inside Tutti, build it from the app-scoped daemon APIs. Keep the daemon token in the server process.
-
-Define an app-owned client around the daemon fields used by the app:
+The app server exposes an app-owned endpoint such as `GET /api/agents/providers`. Its implementation calls the SDK facade directly:
 
 ```ts
-type AvailabilityStatus =
-  | "ready"
-  | "not_installed"
-  | "auth_required"
-  | "unsupported"
-  | "unknown";
+import { loadTuttiAgentProviderCatalog } from "@tutti-os/agent-acp-kit/tutti";
+import { localAgentRuntime } from "./local-agent-runtime.js";
 
-interface ProviderStatus {
-  provider: string;
-  availability: { status: AvailabilityStatus; reasonCode?: string | null };
-}
-
-interface TuttiAppAgentCatalogClient {
-  getAgentPreferences(): Promise<{ defaultAgentProvider: string }>;
-  getAgentProviderStatuses(): Promise<{ providers: ProviderStatus[] }>;
-  getAgentProviderComposerOptions(provider: string): Promise<unknown>;
-}
-```
-
-Only request composer options for ready providers. Keep composer failures local to one provider:
-
-```ts
-async function getComposerOptions(
-  tutti: TuttiAppAgentCatalogClient,
-  status: ProviderStatus,
-  available: boolean
-) {
-  if (!available) return null;
-  try {
-    return await tutti.getAgentProviderComposerOptions(status.provider);
-  } catch {
-    return null;
-  }
-}
-```
-
-Use the returned `providers` array and `defaultAgentProvider` field:
-
-```ts
-export async function listAppAgentProviders(
-  tutti: TuttiAppAgentCatalogClient,
-  registeredKitProviderIds: ReadonlySet<string>
-) {
-  const [preferences, snapshot] = await Promise.all([
-    tutti.getAgentPreferences(),
-    tutti.getAgentProviderStatuses()
-  ]);
-
-  return Promise.all(
-    snapshot.providers.map(async (status) => {
-      const runtimeProviderId = toKitAgentProviderId(status.provider);
-      const runtimeSupported = registeredKitProviderIds.has(runtimeProviderId);
-      const available =
-        status.availability.status === "ready" && runtimeSupported;
-      return {
-        ...status,
-        runtimeProviderId,
-        available,
-        reasonCode:
-          status.availability.status === "ready" && !runtimeSupported
-            ? "kit_runtime_unavailable"
-            : (status.availability.reasonCode ?? undefined),
-        preferred: status.provider === preferences.defaultAgentProvider,
-        composerOptions: await getComposerOptions(tutti, status, available)
-      };
-    })
-  );
-}
-```
-
-Build `registeredKitProviderIds` from `localAgentRuntime.listProviders()`. Use it only to disable catalog entries that the installed kit cannot execute; never use it to add or remove entries from Tutti's provider list.
-
-The app-owned client must call these routes with `TUTTI_APP_SERVER_TOKEN` as a bearer credential:
-
-- `GET /v1/workspaces/{workspaceID}/apps/{appID}/preferences/agent`
-- `GET /v1/workspaces/{workspaceID}/apps/{appID}/agent-providers/status`
-- `POST /v1/workspaces/{workspaceID}/apps/{appID}/agent-providers/{provider}/composer-options`
-
-Omit an app-local `providers` filter from the status request. Use `TUTTI_API_BASE_URL`, `TUTTI_WORKSPACE_ID`, and `TUTTI_APP_ID` to build the routes. Never expose the token to browser code.
-
-UI rules:
-
-- Render every provider returned by the API response.
-- Show unavailable providers as disabled. Map the returned `reasonCode` to localized UI copy; do not render the raw code.
-- Do not filter the list down to Codex/Claude in frontend code.
-- Derive display names from provider IDs with an app-owned formatter. Keep brand-casing overrides presentation-only; never use them to decide visibility or runtime support.
-
-Default provider selection:
-
-- Prefer the Tutti default provider when it is present and available, then the user's last valid app selection.
-- Otherwise choose the first available catalog provider.
-- Do not default to `codex` or `claude`.
-
-Persisted runtime profiles must store the Tutti provider ID returned by the catalog, not a fixed union such as `"codex" | "claude-code"`. Normalize to a kit runtime ID only at the execution boundary.
-
-## Provider ID Normalization
-
-Tutti daemon/OpenAPI IDs and kit runtime IDs can differ. Normalize at boundaries only:
-
-| Tutti daemon / OpenAPI                              | Kit runtime ID | Notes                               |
-| --------------------------------------------------- | -------------- | ----------------------------------- |
-| `claude-code`                                       | `claude`       | common alias                        |
-| `tutti-agent`                                       | `nexight`      | only when the kit exposes `nexight` |
-| `codex`, `cursor`, `opencode`, `hermes`, `openclaw` | same           | usually identical                   |
-
-Use one small helper instead of scattered `if (provider === "codex")` branches:
-
-```ts
-const KIT_TO_DAEMON_PROVIDER: Record<string, string> = {
-  claude: "claude-code",
-  nexight: "tutti-agent"
-};
-
-export function toDaemonAgentProviderId(kitProviderId: string) {
-  return KIT_TO_DAEMON_PROVIDER[kitProviderId] ?? kitProviderId;
-}
-
-export function toKitAgentProviderId(daemonProviderId: string) {
-  const normalized = daemonProviderId.trim().toLowerCase();
-  if (normalized === "claude-code") return "claude";
-  if (normalized === "tutti-agent") return "nexight";
-  return normalized;
-}
-```
-
-Extend this map when Tutti documents a new alias. Do not rebuild a full static provider catalog in the app.
-
-## Standalone development
-
-When the app runs inside Tutti, do not replace the app-scoped catalog with `localAgentRuntime.listProviders()` or `localAgentRuntime.detect(...)`. Tutti's catalog controls which Agent Targets are visible to workspace apps.
-
-For standalone development outside Tutti, use the full kit default plugin set and call runtime detection directly:
-
-```ts
-const detections = await localAgentRuntime.detect();
-```
-
-Treat standalone detection as a separate development mode. Inside Tutti, return an unavailable state when a catalog request fails. Show retry guidance and do not invent provider entries. Do not query the app-scoped status route with `providers=codex&providers=claude-code`, and do not treat kit registration as permission to expose a provider that Tutti omitted.
-
-## Optional Capability Filtering
-
-Some apps need provider-specific stream adapters (for example Claude `<reasoning>` splitting or Codex tagged reasoning). That is allowed, but it must be explicit:
-
-```ts
-function createAppLocalAgentProviderPlugins() {
-  return createDefaultLocalAgentProviderPlugins().map((provider) => {
-    if (provider.id === "claude")
-      return withClaudeStreamCompatibility(provider);
-    if (provider.id === "codex") return withCodexStreamCompatibility(provider);
-    return provider;
+export async function getAgentProviderCatalog() {
+  return await loadTuttiAgentProviderCatalog({
+    runtime: localAgentRuntime
   });
 }
 ```
 
-Rules:
+Do not pass `mode` or `required`, and do not check `process.env.TUTTI_CLI` in app code. The facade behavior is fixed:
 
-- Add compatibility wrappers per provider ID; do not `.filter()` the default plugin list unless the product truly cannot run other providers.
-- If the app must temporarily exclude a provider, document the gap in app `AGENTS.md` and remove the filter once the adapter exists.
-- Never exclude `cursor`, `opencode`, or future kit providers by default.
+- if `TUTTI_CLI` resolves, the kit calls `tutti --json agent providers`, validates schema version 2, preserves enabled Agent Target order, and marks catalog entries that this kit cannot execute as `kit_runtime_unavailable`;
+- if `TUTTI_CLI` is absent, the kit automatically builds a `source: "standalone"` catalog from `runtime.listProviders()` and `runtime.detect()`;
+- if `TUTTI_CLI` is configured but execution, timeout, cancellation, or schema validation fails, the kit throws `TuttiIntegrationError`; it does not invent a standalone catalog.
 
-## Host Bridge Integration
-
-When opening Tutti host features such as `window.tuttiExternal?.workspace?.openFeature({ feature: "agent-chat", provider })`, pass the daemon/OpenAPI provider ID derived from the user's current selection:
+The app may project the returned browser-safe DTO into product-specific fields, but it must not copy the Tutti CLI schema. Frontend code may import guards and types without Node dependencies:
 
 ```ts
-openFeature({
-  feature: "agent-chat",
-  provider: toDaemonAgentProviderId(selectedProviderId)
+import {
+  isTuttiAgentProviderCatalog,
+  type TuttiAgentProviderCatalog
+} from "@tutti-os/agent-acp-kit/tutti/contracts";
+```
+
+UI rules:
+
+- render every returned provider;
+- disable entries whose `availability.status` is not `available`;
+- localize `availability.reasonCode` instead of displaying raw codes;
+- prefer an available `defaultProviderId`, then the last persisted available selection, then the first available provider;
+- use `displayName` for presentation, with app-owned icon overrides only;
+- never use kit registration to add a provider omitted by the Tutti CLI catalog.
+
+## Composer options
+
+Load composer options lazily for the selected provider:
+
+```ts
+import { loadTuttiAgentComposerOptions } from "@tutti-os/agent-acp-kit/tutti";
+
+const composer = await loadTuttiAgentComposerOptions({
+  runtime: localAgentRuntime,
+  providerId: selectedProviderId,
+  cwd: appLocalCwd,
+  locale,
+  model,
+  permissionMode,
+  reasoningEffort
 });
 ```
 
-Do not type the bridge provider as `"codex" | "claude-code"` only. Accept `string` and validate against the latest Tutti catalog or standalone detection result when needed.
+The kit first verifies that `providerId` is present in the canonical catalog. In Tutti it calls `tutti --json agent composer-options --provider <providerId>`; standalone mode derives conservative model options from runtime detection and marks unsupported controls `configurable: false`.
 
-Host-owned provider lists are exposed through the workspace-app scoped daemon APIs, not injected through the browser bridge. Desktop preferences cannot expand an app UI that still hard-codes Codex/Claude.
+Do not eagerly load composer options for every provider. A failure belongs to the selected provider UI and must not delete other catalog entries.
+
+## Persistence and host bridge
+
+Persist the canonical catalog ID. A one-time migration may rewrite `claude` to `claude-code`. Do not migrate `nexight` and `tutti-agent` into each other.
+
+When invoking a host feature such as:
+
+```ts
+window.tuttiExternal?.workspace?.openFeature({
+  feature: "agent-chat",
+  provider: selectedProviderId
+});
+```
+
+pass the canonical selected ID unchanged. Browser bridge types must accept `string`, then validate against the latest app endpoint response.
 
 ## Model IDs
 
-Use provider-prefixed app model IDs built from catalog or standalone detection output:
+If an app needs globally unique model IDs, store the canonical provider separately or prefix the provider model:
 
 ```ts
-const appModelId = `${provider}:${model.id}`;
+const appModelId = `${providerId}:${providerModelId}`;
 ```
 
-Resolve the provider runtime model by stripping the prefix or by storing `providerModelId` separately. Do not assume only `codex:*` and `claude:*` exist.
+Do not infer a provider from a model name or assume only Codex and Claude models exist.
 
-## Anti-Patterns
+## Anti-patterns
 
-Do not:
+Do not add:
 
-- hard-code `["codex", "claude"]`, `Set(["codex", "claude"])`, or TypeScript unions limited to those providers for runtime state
-- require "at least Claude Code and Codex" in UI copy or validation
-- map display names with only Codex/Claude branches when detection already returns `displayName`
-- query the workspace-app scoped `agent-providers/status` route with a fixed provider subset
-- synthesize a fixed provider catalog when Tutti catalog loading fails
-- filter `createDefaultLocalAgentProviderPlugins()` to Codex/Claude unless documented as a temporary product constraint
-- shell out to `$TUTTI_CLI agent ...` for provider discovery
+- raw daemon or app-scoped Agent catalog clients;
+- provider conversion helpers, cross-provider aliases, or app-owned alias tables;
+- app-local CLI argv builders, subprocess wrappers, JSON schemas, timeouts, or fallback modes;
+- daemon URL, server credential, workspace identity, or app identity reads for Agent provider catalog/composer discovery;
+- fixed provider allowlists or synthetic fallback catalogs;
+- eager composer requests for all providers;
+- code that patches `node_modules/@tutti-os/agent-acp-kit` or its built `dist` files.
 
 ## Verification
 
-Add tests for:
+Add app tests that verify:
 
-- app status request omits app-local provider filters
-- UI/provider picker renders every provider returned by Tutti and disables daemon-unavailable or kit-unsupported entries
-- default provider comes from Tutti preferences, a valid persisted app selection, or the first available catalog result
-- provider ID normalization covers `claude-code` <-> `claude` and daemon-only IDs such as `cursor` / `opencode`
-- catalog failure exposes an unavailable state without synthetic providers
-- standalone detection returns every registered kit provider entry
-- local run creation accepts catalog providers that map to installed runtime plugins
-- managed run creation accepts only `isManagedAgentInvocationProviderId(...)` providers
-
-For smoke tests, load the Tutti catalog first (or run standalone detection), then execute one narrow turn on whichever provider is available. Do not assume Codex or Claude is installed.
+- the app calls the kit facade and does not implement raw CLI/HTTP protocol handling;
+- every facade provider is projected and unavailable providers remain visible but disabled;
+- canonical IDs round-trip through endpoint, persistence, UI selection, host bridge, and runtime input;
+- legacy persisted `claude` migrates once to `claude-code`, while `nexight` and `tutti-agent` remain distinct;
+- composer loading is lazy and one-provider failure is isolated;
+- no `mode`, app ID, Agent catalog token, alias helper, or dependency patch script is present.

--- a/services/tuttid/service/workspace/agent_workspace_app_reference/references/github-actions-release.md
+++ b/services/tuttid/service/workspace/agent_workspace_app_reference/references/github-actions-release.md
@@ -27,7 +27,7 @@ This reusable workflow builds, publishes, and verifies the app package. It can a
 
 Declare one exact stable SemVer in `min_tutti_version` for every normal release. Choose the earliest Tutti version that contains every host API and runtime contract used by the app. Use `0.0.0` only when the app requires no minimum Tutti version. Publish a new app version when this minimum changes.
 
-The workspace-app scoped provider APIs first ship in `0.1.19-rc.0`. Production apps that use `references/dynamic-agent-providers.md` require the stable floor `min_tutti_version: "0.1.19"` or later.
+The Agent CLI catalog schema v2 and composer visibility contract ship in the `0.1.19` release line. Production apps that use the `@tutti-os/agent-acp-kit/tutti` auto facade require `min_tutti_version: "0.1.19"` or later and must pin the exact stable kit version validated with that Tutti release.
 
 ## Production Workflow Template
 

--- a/services/tuttid/service/workspace/agent_workspace_app_reference/references/i18n-and-web-debugging.md
+++ b/services/tuttid/service/workspace/agent_workspace_app_reference/references/i18n-and-web-debugging.md
@@ -56,7 +56,7 @@ pnpm package:tutti
 
 When local agents are involved:
 
-1. Load the Tutti app-scoped provider catalog, or run kit detection in standalone mode.
+1. Load the provider catalog through `@tutti-os/agent-acp-kit/tutti`; it automatically uses Tutti CLI or standalone detection.
 2. Verify the web settings/runtime panel or equivalent status UI.
 3. Run isolated smoke tests for one available catalog provider turn.
 4. Inspect run events, tool calls, generated files, and package-local data writes.

--- a/services/tuttid/service/workspace/app_factory_reference/SKILL.md
+++ b/services/tuttid/service/workspace/app_factory_reference/SKILL.md
@@ -12,7 +12,7 @@ Use this skill to create, convert, or repair one Tutti workspace app. Choose one
 
 When the user selected a directory in App Center and Tutti reports that it cannot be loaded, treat the task as local debug repair. Adapt the selected project by creating or fixing `.tutti/dev-app/`; do not create a zip wrapper or copy the repository into `package/` unless the user explicitly asks for release packaging.
 
-For a full agent-enabled Tutti app repository with `apps/web`, `apps/server`, `packages/shared`, `@tutti-os/agent-acp-kit`, Tutti app-scoped provider APIs, dynamic local agent runtimes, MCP tool gateways, and an app-owned package builder, use `$tutti-agent-workspace-app` first. Return to this skill for the final package contract and validation. Do not invent managed-agent credential, cwd, JSB fallback, request-body credential, or `CODEX_HOME` behavior in this factory skill; the agent app skill owns that migration checklist and should keep those concerns in server-side kit calls.
+For a full agent-enabled Tutti app repository with `apps/web`, `apps/server`, `packages/shared`, `@tutti-os/agent-acp-kit`, kit-owned `TUTTI_CLI` provider/composer discovery, dynamic local agent runtimes, MCP tool gateways, and an app-owned package builder, use `$tutti-agent-workspace-app` first. Return to this skill for the final package contract and validation. Do not invent managed-agent credential, cwd, JSB fallback, request-body credential, `CODEX_HOME`, CLI argv, app ID, token, or provider alias behavior in this factory skill; the agent app skill keeps those concerns in server-side kit calls.
 
 If the user request needs local agent or local LLM execution, Tutti agent providers, or app-owned MCP/tooling, load `$tutti-agent-workspace-app` and read its `references/dynamic-agent-providers.md` and `references/agent-acp-kit.md`. Agent-enabled apps must use a Node server and `@tutti-os/agent-acp-kit`; do not implement app-owned local agent execution by shelling out to `$TUTTI_CLI agent ...`, `$TUTTI_CLI codex ...`, or session polling.
 
@@ -134,7 +134,7 @@ The runtime must:
 
 For a full agent-enabled app repository, prefer `$tutti-agent-workspace-app` first. When this skill still needs to package or repair an app that already uses `@tutti-os/agent-acp-kit`, keep the app in control of agent policy:
 
-- Keep the generic `@tutti-os/agent-acp-kit` runtime path product-neutral. Tutti-specific behavior should stay behind the explicit `@tutti-os/agent-acp-kit/tutti` subpath and app-owned policy.
+- Keep the generic `@tutti-os/agent-acp-kit` runtime path product-neutral. Tutti-specific provider catalog, composer, and skill discovery stays behind the explicit `@tutti-os/agent-acp-kit/tutti` subpath; app code owns only product policy and DTO projection.
 - Use a Node server for the app host process. Do not start with a Python server and plan to migrate later.
 - To give the app's local agent runs access to Tutti's dynamic CLI skills, prefer the `@tutti-os/agent-acp-kit/tutti` helper instead of hand-writing `$TUTTI_CLI agent tutti-cli-skill-bundle` execution and response parsing in each app.
 - Use `loadTuttiAgentSkillContext(...)` from the app host process. Pass the selected provider, run id, workspace cwd, and optional Tutti CLI command configuration such as `commandEnvNames`.
@@ -142,7 +142,7 @@ For a full agent-enabled app repository, prefer `$tutti-agent-workspace-app` fir
 - Treat `tuttiContext.recommendedSystemPrompt?.content` as advisory raw prompt content. The app may merge it into its own `systemPrompt`, edit it, place it elsewhere, or ignore it. Do not inject it silently, and do not reintroduce duplicated CLI parsing unless the installed kit lacks the helper.
 - Keep run-scoped app tools and MCP credentials app-owned. Do not pass broad Tutti daemon credentials or app secrets directly to the agent process.
 
-Agent app main flows must resolve provider choices through Tutti workspace-app scoped `preferences/agent`, `agent-providers/status`, and `agent-providers/{provider}/composer-options` APIs. Follow `$tutti-agent-workspace-app` and its `references/dynamic-agent-providers.md`. Do not replace the Tutti catalog with app-local allowlists or kit runtime provider lists. Show every returned provider, keep unavailable providers disabled with a reason, and choose a usable default. Treat catalog loading failures as explicit unavailable states; never synthesize a fixed provider catalog.
+Agent app main flows must call `loadTuttiAgentProviderCatalog` and lazy `loadTuttiAgentComposerOptions` from `@tutti-os/agent-acp-kit/tutti`. The kit automatically uses `TUTTI_CLI` inside Tutti and standalone runtime detection when the CLI is absent. App code must not pass a mode, app ID, daemon URL, token, provider alias map, or CLI arguments. Follow `$tutti-agent-workspace-app` and its `references/dynamic-agent-providers.md`. Show every returned provider, keep unavailable providers disabled with a reason, and choose a usable default. A configured CLI failure is explicit; never synthesize a fixed provider catalog.
 
 Do not assume a Tutti API token, browser extension, daemon internals, or broad desktop APIs. The only browser-side host surface a generated app may optionally consume is the app context described in `references/runtime-env.md`.
 

--- a/services/tuttid/service/workspace/app_factory_reference/references/runtime-env.md
+++ b/services/tuttid/service/workspace/app_factory_reference/references/runtime-env.md
@@ -26,7 +26,7 @@ Use these environment variables:
 
 `PATH` includes the managed runtime bin directories, but generated apps must still use the explicit `TUTTI_APP_NODE`, `TUTTI_APP_NPM`, and, when applicable, `TUTTI_APP_PYTHON` variables. Do not rely on system `node`, `npm`, `python`, or `python3` commands.
 
-Read `TUTTI_APP_SERVER_TOKEN` only in the app server process. Never send it to browser code, persist it, or write it to logs. Use it with `TUTTI_API_BASE_URL`, `TUTTI_WORKSPACE_ID`, and `TUTTI_APP_ID` for workspace-app scoped daemon routes.
+Read `TUTTI_APP_SERVER_TOKEN` only in the app server process. Never send it to browser code, persist it, or write it to logs. It remains available for non-Agent app-scoped daemon resources. Agent provider catalog and composer discovery must not use this token, daemon URL, workspace ID, or app ID; call the `@tutti-os/agent-acp-kit/tutti` facade, which owns `TUTTI_CLI` execution.
 
 For local Tutti capabilities, use `TUTTI_CLI`.
 
@@ -63,7 +63,7 @@ function subscribeHostLocale(listener) {
 }
 ```
 
-`subscribe` replays the latest context after registration, so apps do not need host-injected DOM events for initial locale delivery. Provider lists, default provider, and agent composer options are not part of browser external context. Agent-enabled apps should expose an app-owned backend endpoint backed by Tutti workspace-app scoped daemon APIs. Follow `$tutti-agent-workspace-app` and its `references/dynamic-agent-providers.md`; use `@tutti-os/agent-acp-kit` for runtime execution and standalone detection. Use `TUTTI_CLI` only for non-agent Tutti platform or app-to-app capabilities. The context is optional so generated apps continue to run in a normal browser during development.
+`subscribe` replays the latest context after registration, so apps do not need host-injected DOM events for initial locale delivery. Provider lists, default provider, and Agent composer options are not part of browser external context. Agent-enabled apps should expose an app-owned backend endpoint whose implementation calls `@tutti-os/agent-acp-kit/tutti`; the kit automatically uses `TUTTI_CLI` inside Tutti and standalone runtime discovery outside it. App code must not spawn or parse the Agent CLI itself. Follow `$tutti-agent-workspace-app` and its `references/dynamic-agent-providers.md`. The browser context remains optional so generated apps continue to run in a normal browser during development.
 
 For theme, use CSS media queries and `matchMedia`:
 

--- a/services/tuttid/service/workspace/app_factory_reference/references/tutti-cli-commands.md
+++ b/services/tuttid/service/workspace/app_factory_reference/references/tutti-cli-commands.md
@@ -19,7 +19,10 @@ const catalog = await loadTuttiAgentProviderCatalog({
 The facade returns the enabled CLI catalog inside Tutti and automatically returns a standalone runtime catalog when `TUTTI_CLI` is absent. Load composer options lazily for the selected provider:
 
 ```ts
+import { createDefaultLocalAgentRuntime } from "@tutti-os/agent-acp-kit";
 import { loadTuttiAgentComposerOptions } from "@tutti-os/agent-acp-kit/tutti";
+
+const localAgentRuntime = createDefaultLocalAgentRuntime();
 
 export async function loadSelectedProviderOptions(providerId: string) {
   return loadTuttiAgentComposerOptions({

--- a/services/tuttid/service/workspace/app_factory_reference/references/tutti-cli-commands.md
+++ b/services/tuttid/service/workspace/app_factory_reference/references/tutti-cli-commands.md
@@ -4,20 +4,22 @@ This reference is for code inside a generated workspace app at runtime. It is no
 
 Workspace apps may call local Tutti capabilities through the bundled Tutti CLI.
 
-Do not use `$TUTTI_CLI agent ...`, `$TUTTI_CLI codex ...`, or agent session polling to implement app-owned local agent execution. Apps that need local agent or local LLM execution, Tutti agent providers, or app-owned MCP/tooling must load and follow `$tutti-agent-workspace-app`, read its `references/dynamic-agent-providers.md` and `references/agent-acp-kit.md`, and use `@tutti-os/agent-acp-kit` from a Node server:
+Do not use `$TUTTI_CLI agent ...`, `$TUTTI_CLI codex ...`, or Agent session polling to implement app-owned local Agent execution. Apps that need local Agent execution, Tutti provider catalog/composer options, dynamic Tutti skills, or app-owned MCP tooling must load `$tutti-agent-workspace-app` and use `@tutti-os/agent-acp-kit` from a Node server. The kit may invoke Agent CLI commands internally; app code must not construct argv or parse their JSON:
 
 ```ts
+import { createDefaultLocalAgentRuntime } from "@tutti-os/agent-acp-kit";
 import {
-  createDefaultLocalAgentProviderPlugins,
-  createLocalAgentRuntime
-} from "@tutti-os/agent-acp-kit";
+  loadTuttiAgentComposerOptions,
+  loadTuttiAgentProviderCatalog
+} from "@tutti-os/agent-acp-kit/tutti";
 
-const localAgentRuntime = createLocalAgentRuntime({
-  providers: createDefaultLocalAgentProviderPlugins()
+const localAgentRuntime = createDefaultLocalAgentRuntime();
+const catalog = await loadTuttiAgentProviderCatalog({
+  runtime: localAgentRuntime
 });
 ```
 
-Inside Tutti, return the full catalog from the workspace-app scoped daemon APIs to the app UI and use the runtime only to execute the selected provider. Outside Tutti, `localAgentRuntime.detect()` may provide the standalone catalog. Do not filter either catalog down to Codex/Claude in application code.
+The facade returns the enabled CLI catalog inside Tutti and automatically returns a standalone runtime catalog when `TUTTI_CLI` is absent. Load composer options lazily with `loadTuttiAgentComposerOptions`. Do not pass `mode`, read app ID/token/API environment, or filter either catalog down to Codex/Claude.
 
 For non-agent app-to-app capability calls, always use the command path from `TUTTI_CLI`. `TUTTI_CLI` is the stable app-runtime contract across development and packaged production.
 

--- a/services/tuttid/service/workspace/app_factory_reference/references/tutti-cli-commands.md
+++ b/services/tuttid/service/workspace/app_factory_reference/references/tutti-cli-commands.md
@@ -8,10 +8,7 @@ Do not use `$TUTTI_CLI agent ...`, `$TUTTI_CLI codex ...`, or Agent session poll
 
 ```ts
 import { createDefaultLocalAgentRuntime } from "@tutti-os/agent-acp-kit";
-import {
-  loadTuttiAgentComposerOptions,
-  loadTuttiAgentProviderCatalog
-} from "@tutti-os/agent-acp-kit/tutti";
+import { loadTuttiAgentProviderCatalog } from "@tutti-os/agent-acp-kit/tutti";
 
 const localAgentRuntime = createDefaultLocalAgentRuntime();
 const catalog = await loadTuttiAgentProviderCatalog({
@@ -19,7 +16,20 @@ const catalog = await loadTuttiAgentProviderCatalog({
 });
 ```
 
-The facade returns the enabled CLI catalog inside Tutti and automatically returns a standalone runtime catalog when `TUTTI_CLI` is absent. Load composer options lazily with `loadTuttiAgentComposerOptions`. Do not pass `mode`, read app ID/token/API environment, or filter either catalog down to Codex/Claude.
+The facade returns the enabled CLI catalog inside Tutti and automatically returns a standalone runtime catalog when `TUTTI_CLI` is absent. Load composer options lazily for the selected provider:
+
+```ts
+import { loadTuttiAgentComposerOptions } from "@tutti-os/agent-acp-kit/tutti";
+
+export async function loadSelectedProviderOptions(providerId: string) {
+  return loadTuttiAgentComposerOptions({
+    providerId,
+    runtime: localAgentRuntime
+  });
+}
+```
+
+Do not pass `mode`, read app ID/token/API environment, or filter either catalog down to Codex/Claude.
 
 For non-agent app-to-app capability calls, always use the command path from `TUTTI_CLI`. `TUTTI_CLI` is the stable app-runtime contract across development and packaged production.
 

--- a/services/tuttid/service/workspace/app_factory_test.go
+++ b/services/tuttid/service/workspace/app_factory_test.go
@@ -326,8 +326,8 @@ func TestAppFactoryServiceCreateUsesDraftDirAndReferenceContext(t *testing.T) {
 		t.Fatalf("app factory skill missing manifest reference: %#v", appFactorySkill.Files)
 	}
 	runtimeEnvReference := appFactorySkill.Files["references/runtime-env.md"]
-	if !strings.Contains(runtimeEnvReference, "Tutti workspace-app scoped daemon APIs") {
-		t.Fatalf("runtime env reference should route agent provider choices through app-scoped daemon APIs:\n%s", runtimeEnvReference)
+	if !strings.Contains(runtimeEnvReference, "@tutti-os/agent-acp-kit/tutti") {
+		t.Fatalf("runtime env reference should route Agent provider choices through the kit facade:\n%s", runtimeEnvReference)
 	}
 	for _, want := range []string{
 		"TUTTI_API_BASE_URL",
@@ -362,50 +362,54 @@ func TestAppFactoryServiceCreateUsesDraftDirAndReferenceContext(t *testing.T) {
 		t.Fatalf("agent workspace app skill missing dynamic-agent-providers reference: %#v", agentWorkspaceAppSkill.Files)
 	}
 	for _, want := range []string{
-		"Do not hand-roll provider detection",
-		"Tutti's app-scoped daemon API",
-		"catalog failure",
+		"kit owns provider plugins",
 		"dynamic-agent-providers.md",
-		"localAgentRuntime.detect",
+		"loadTuttiAgentProviderCatalog",
+		"loadTuttiAgentComposerOptions",
+		"loadTuttiAgentSkillContext",
+		"Do not pass a mode",
 		"await createManagedAgentRunContextFromHeaders",
-		"toKitAgentProviderId",
-		"getManagedAgentInvocationCredentialFromHeaders",
-		"isManagedAgentInvocationProviderId",
-		"managedCredential && isManagedAgentInvocationProviderId(runtimeProviderId)",
+		"browserUse",
+		"computerUse",
 	} {
 		if !strings.Contains(agentACPReference, want) {
 			t.Fatalf("agent-acp-kit reference missing %q:\n%s", want, agentACPReference)
 		}
 	}
 	for _, forbidden := range []string{
-		"resolveTuttiAgentProviderCatalog",
-		"whole-catalog failure",
-		"Codex/Claude `default` legacy catalog",
+		"toKitAgentProviderId",
+		"toDaemonAgentProviderId",
+		"getManagedAgentInvocationCredentialFromHeaders",
+		"isManagedAgentInvocationProviderId",
+		"managedCredential &&",
+		"agent-providers/status",
+		"TUTTI_APP_SERVER_TOKEN",
 	} {
 		if strings.Contains(agentACPReference, forbidden) {
 			t.Fatalf("agent-acp-kit reference contains obsolete guidance %q:\n%s", forbidden, agentACPReference)
 		}
 	}
 	for _, want := range []string{
-		"defaultAgentProvider",
-		"TuttiAppAgentCatalogClient",
-		"min_tutti_version` to at least `0.1.19",
-		"catalog failure exposes an unavailable state",
+		"loadTuttiAgentProviderCatalog",
+		"loadTuttiAgentComposerOptions",
+		"source: \"standalone\"",
+		"TuttiIntegrationError",
 		"availability.reasonCode",
-		"registeredKitProviderIds",
 		"kit_runtime_unavailable",
-		`status.availability.status === "ready" && !runtimeSupported`,
-		"localAgentRuntime.detect()",
-		"agent-providers/status",
+		"@tutti-os/agent-acp-kit/tutti/contracts",
+		"claude` to `claude-code",
 	} {
 		if !strings.Contains(dynamicProviderReference, want) {
 			t.Fatalf("dynamic provider reference missing %q:\n%s", want, dynamicProviderReference)
 		}
 	}
 	for _, forbidden := range []string{
-		"preferences.defaultProvider",
-		"whole-catalog failure",
-		"server-provided labels",
+		"TuttiAppAgentCatalogClient",
+		"toKitAgentProviderId",
+		"toDaemonAgentProviderId",
+		"agent-providers/status",
+		"TUTTI_APP_SERVER_TOKEN",
+		"nexight: \"tutti-agent\"",
 	} {
 		if strings.Contains(dynamicProviderReference, forbidden) {
 			t.Fatalf("dynamic provider reference contains obsolete guidance %q:\n%s", forbidden, dynamicProviderReference)

--- a/services/tuttid/wiring.go
+++ b/services/tuttid/wiring.go
@@ -392,10 +392,11 @@ func buildDaemonAPI(ctx context.Context, store workspacedata.CatalogStore, analy
 			appCenterService,
 			eventstreamservice.WorkbenchNodeLaunchPublisher{Service: events},
 		),
-		agentcontextcli.NewProviderWithLaunchPublisher(
+		agentcontextcli.NewProviderWithAgentTargets(
 			workspaceService,
 			agentSessionService,
 			eventstreamservice.AgentGUILaunchPublisher{Service: events},
+			agentTargets,
 			preferences,
 		),
 	}


### PR DESCRIPTION
## Summary
- upgrade `agent providers` JSON to schemaVersion 2 using enabled Agent Targets as the visibility source
- share enabled-target selection with compatibility HTTP routes and validate composer providers before discovery
- preserve table output, add structured availability, and deprecate the three workspace-app Agent catalog HTTP routes
- rewrite App Factory Agent guidance around the `agent-acp-kit/tutti` auto facade

## Dependencies
- paired with the agent-acp-kit 0.3.0 PR and tutti-agent-skills documentation PR
- compatibility HTTP routes remain for one stable release window

## Validation
- `pnpm check:full` (all preflight, TS, tool, Go lint, typecheck, and Go tests passed)
- real `pnpm dev:desktop` daemon startup
- `tutti-dev --json agent providers` returned schemaVersion 2 and canonical enabled targets
- table output remained Provider/Status/Detail
- real SDK smoke loaded catalog, Codex composer, and integration-only skill bundle

## Rollout / rollback
Roll out Tutti before publishing agent-acp-kit 0.3.0. Existing app-scoped routes remain compatible. Rollback is the commit revert; consumers must not adopt the strict schema-v2 SDK until this lands.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Exposes workspace-app Agent integration via a CLI-backed provider catalog and composer discovery, upgrades the catalog JSON to schema v2 and composer-options to schema v1, deprecates app-scoped Agent HTTP routes, and gates catalog commands on Agent Target availability. Docs move apps to the `@tutti-os/agent-acp-kit/tutti` auto facade with lazy composer loading and no manual CLI or token handling.

- New Features
  - CLI provider catalog JSON now returns schemaVersion 2 with defaultProviderId and providers [{ providerId, displayName, agentTargetId, availability { status, reasonCode, detail } }]; table output unchanged and order follows enabled Agent Targets.
  - Composer options JSON now includes schemaVersion 1; provider input is canonicalized, unknown providers fail fast, and disabled providers are rejected before discovery.
  - Catalog/composer-options commands are only advertised when an AgentTarget lister is wired; wiring updated accordingly.
  - Marked three workspace-app Agent routes as deprecated in OpenAPI and the TS SDK JSDoc; compatibility remains for one stable release window.

- Migration
  - Update CLI JSON consumers to catalog schema v2 fields (defaultProviderId, providerId, availability.reasonCode/detail) and handle composer-options schemaVersion 1.
  - Switch app code to `loadTuttiAgentProviderCatalog` and `loadTuttiAgentComposerOptions` from `@tutti-os/agent-acp-kit/tutti`; stop calling workspace-app Agent catalog endpoints.
  - Use the facade as-is: do not pass a mode, do not read app ID/token/daemon URL, and load composer options lazily for the selected provider.
  - Pin an exact compatible `@tutti-os/agent-acp-kit` and set a Tutti minimum (0.1.19+). Roll out Tutti before publishing the strict kit release.

<sup>Written for commit 113182adb0e340f4b3f72eda1fb615c74f078ecc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tutti-os/tutti/pull/1024?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

