### PR TITLE
fix(agent): keep image draft remove button clickable

### DIFF
--- a/packages/agent/gui/agent-gui/agentGuiNode/AgentComposer.spec.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/AgentComposer.spec.tsx
@@ -5015,7 +5015,11 @@ describe("AgentComposer", () => {
       );
 
       const drafts = screen.getByTestId("agent-gui-composer-image-drafts");
-      fireEvent.click(within(drafts).getByRole("button", { name: "移除引用" }));
+      const removeButton = within(drafts).getByRole("button", {
+        name: "移除引用"
+      });
+      expect(removeButton).toHaveClass("z-[2]");
+      fireEvent.click(removeButton);
       rerender(renderComposer());
 
       expect(

--- a/packages/agent/gui/agent-gui/agentGuiNode/AgentComposer.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/AgentComposer.tsx
@@ -4520,7 +4520,7 @@ function AgentComposerDraftImagePreview({
       ) : null}
       <button
         type="button"
-        className="absolute right-1 top-1 inline-flex size-5 items-center justify-center rounded-full border border-[color-mix(in_srgb,var(--text-primary)_16%,transparent)] bg-[color-mix(in_srgb,var(--background-fronted)_88%,transparent)] text-[var(--text-primary)] opacity-90 shadow-sm transition hover:opacity-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:color-mix(in_srgb,var(--text-primary)_34%,transparent)]"
+        className="absolute right-1 top-1 z-[2] inline-flex size-5 items-center justify-center rounded-full border border-[color-mix(in_srgb,var(--text-primary)_16%,transparent)] bg-[color-mix(in_srgb,var(--background-fronted)_88%,transparent)] text-[var(--text-primary)] opacity-90 shadow-sm transition hover:opacity-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:color-mix(in_srgb,var(--text-primary)_34%,transparent)]"
         aria-label={removeLabel}
         title={removeLabel}
         onClick={() => onRemove(image.id)}


### PR DESCRIPTION
## Summary

- place the image draft remove button above the zoom trigger overlay
- keep image zoom behavior intact outside the remove control
- add a regression assertion for the stacking order and removal interaction

## Verification

- `pnpm check:full`
- `pnpm --filter @tutti-os/agent-gui exec vitest run agent-gui/agentGuiNode/AgentComposer.spec.tsx --environment jsdom --maxWorkers=3`
- `pnpm --filter @tutti-os/agent-gui typecheck`

Documentation impact: none; this is a local stacking-order correction with no public behavior or architecture change.

## Checklist

- [x] I kept the change focused on one concern.
- [x] I updated documentation when behavior, setup, or contributor workflow changed.
- [x] I updated all README/CONTRIBUTING language variants when changing their English source.
- [x] I ran the lowest meaningful local checks for the changed surface.
- [x] My commits are signed off with DCO when required: `git commit -s`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a stacking issue that made the image draft remove button unclickable under the zoom overlay. The button now has a higher z-index so it stays clickable, zoom behavior is unchanged, and a regression test verifies it.

<sup>Written for commit a0e0b85dfc4bb532c7ee832f4b94fee0586dee27. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tutti-os/tutti/pull/1025?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

