### PR TITLE
feat(agent): resolve generic starts through targets

### DIFF
--- a/services/tuttid/service/cli/providers/agentcontext/provider.go
+++ b/services/tuttid/service/cli/providers/agentcontext/provider.go
@@ -95,6 +95,7 @@ func (p Provider) Commands() []cliservice.Command {
 		commands = append(commands,
 			p.newProvidersCommand(),
 			p.newComposerOptionsCommand(),
+			p.newStartCommand(),
 		)
 	}
 	commands = append(commands,
@@ -129,7 +130,6 @@ func (p Provider) Commands() []cliservice.Command {
 			AgentTargetID: agenttargetbiz.IDLocalTuttiAgent,
 			Summary:       "Start a Tutti Agent session",
 		}),
-		p.newStartCommand(),
 		p.newGetCommand(),
 		p.newOpenCommand(),
 		p.newSendCommand(),

--- a/services/tuttid/service/cli/providers/agentcontext/provider_test.go
+++ b/services/tuttid/service/cli/providers/agentcontext/provider_test.go
@@ -116,7 +116,7 @@ func TestProviderWithoutAgentTargetsDoesNotAdvertiseCatalogCommands(t *testing.T
 	provider := NewProviderWithLaunchPublisher(nil, nil, nil)
 	for _, command := range provider.Commands() {
 		path := strings.Join(command.Capability.Path, " ")
-		if path == "agent providers" || path == "agent composer-options" {
+		if path == "agent providers" || path == "agent composer-options" || path == "agent start" {
 			t.Fatalf("command %q requires AgentTargetLister", path)
 		}
 	}
@@ -821,16 +821,50 @@ func TestStartCommandRequiresProviderAndPrompt(t *testing.T) {
 	_, err := command.Handler(context.Background(), cliservice.InvokeRequest{
 		Input: map[string]any{"provider": "codex", "prompt": "do work"},
 	})
-	if !errors.Is(err, cliservice.ErrInvalidInput) {
-		t.Fatalf("err = %v, want ErrInvalidInput", err)
+	if err != nil {
+		t.Fatalf("Handler: %v", err)
 	}
-	if !strings.Contains(err.Error(), "tutti codex start") ||
-		!strings.Contains(err.Error(), "tutti claude start") ||
-		!strings.Contains(err.Error(), "tutti tutti-agent start") {
-		t.Fatalf("err = %v, want provider command guidance", err)
+	if sessions.createCallCount != 1 {
+		t.Fatalf("createCallCount = %d, want 1", sessions.createCallCount)
 	}
-	if sessions.createCallCount != 0 {
-		t.Fatalf("createCallCount = %d, want 0", sessions.createCallCount)
+	if sessions.createInput.Provider != "codex" || sessions.createInput.AgentTargetID != agenttargetbiz.IDLocalCodex {
+		t.Fatalf("create input = %#v", sessions.createInput)
+	}
+}
+
+func TestGenericStartCanonicalizesLegacyProviderAndRejectsDisabledProvider(t *testing.T) {
+	sessions := &fakeAgentSessions{}
+	command := newTestProvider(
+		fakeWorkspaceCatalog{startup: workspacebiz.Summary{ID: "workspace-1"}},
+		sessions,
+	).newStartCommand()
+	if _, err := command.Handler(context.Background(), cliservice.InvokeRequest{
+		Input: map[string]any{"provider": "claude", "prompt": "do work"},
+	}); err != nil {
+		t.Fatalf("legacy provider Handler: %v", err)
+	}
+	if sessions.createInput.Provider != "claude-code" || sessions.createInput.AgentTargetID != agenttargetbiz.IDLocalClaudeCode {
+		t.Fatalf("create input = %#v", sessions.createInput)
+	}
+
+	targets := agenttargetbiz.DefaultSystemTargets(1)
+	targets[0].Enabled = false
+	disabledSessions := &fakeAgentSessions{}
+	disabledCommand := NewProviderWithAgentTargets(
+		fakeWorkspaceCatalog{startup: workspacebiz.Summary{ID: "workspace-1"}},
+		disabledSessions,
+		nil,
+		fakeAgentTargetLister{targets: targets},
+	).newStartCommand()
+	_, err := disabledCommand.Handler(context.Background(), cliservice.InvokeRequest{
+		Input: map[string]any{"provider": "codex", "prompt": "do work"},
+	})
+	var unavailable *agentservice.ProviderUnavailableError
+	if !errors.As(err, &unavailable) || unavailable.ReasonCode != "agent_provider_not_enabled" {
+		t.Fatalf("err = %v, want agent_provider_not_enabled", err)
+	}
+	if disabledSessions.createCallCount != 0 {
+		t.Fatalf("createCallCount = %d, want 0", disabledSessions.createCallCount)
 	}
 }
 

--- a/services/tuttid/service/cli/providers/agentcontext/session_commands.go
+++ b/services/tuttid/service/cli/providers/agentcontext/session_commands.go
@@ -10,6 +10,8 @@ import (
 	"strings"
 
 	"github.com/tutti-os/tutti/services/tuttid/biz/agentgui"
+	agentproviderbiz "github.com/tutti-os/tutti/services/tuttid/biz/agentprovider"
+	agenttargetbiz "github.com/tutti-os/tutti/services/tuttid/biz/agenttarget"
 	agentservice "github.com/tutti-os/tutti/services/tuttid/service/agent"
 	cliservice "github.com/tutti-os/tutti/services/tuttid/service/cli"
 	"github.com/tutti-os/tutti/services/tuttid/service/cli/framework"
@@ -72,14 +74,18 @@ func (p Provider) newStartCommand() cliservice.Command {
 		ID:          appID + ".agent.start",
 		Path:        []string{"agent", "start"},
 		Summary:     "Start an agent session with a provider shortcut",
-		Description: "Generic provider start is target-aware and no longer creates sessions directly. Use `tutti codex start`, `tutti claude start`, or `tutti tutti-agent start`.",
+		Description: "Start an agent session by canonical provider id. Tutti resolves the provider through the enabled Agent Target catalog.",
 		Kind:        framework.KindAction,
 		Workspace:   framework.WorkspaceRequired,
 		Workspaces:  p.workspaces,
 		Inputs:      framework.FromStruct[startInput](),
 		Output:      sessionActionOutputSpec(),
 		Run: func(ctx context.Context, invoke framework.InvokeContext, input startInput) (any, error) {
-			return p.runStart(ctx, invoke, input.Provider, "", startFields{
+			target, err := p.resolveGenericStartTarget(ctx, input.Provider)
+			if err != nil {
+				return nil, err
+			}
+			return p.runStart(ctx, invoke, target.Provider, target.ID, startFields{
 				Cwd:             input.Cwd,
 				DisplayPrompt:   input.DisplayPrompt,
 				Hidden:          input.Hidden,
@@ -94,6 +100,26 @@ func (p Provider) newStartCommand() cliservice.Command {
 			})
 		},
 	})
+}
+
+func (p Provider) resolveGenericStartTarget(ctx context.Context, provider string) (agenttargetbiz.Target, error) {
+	canonicalProvider := agentproviderbiz.Normalize(provider)
+	if canonicalProvider == "" {
+		return agenttargetbiz.Target{}, fmt.Errorf("%w: unsupported agent provider %q", cliservice.ErrInvalidInput, provider)
+	}
+	targets, err := p.enabledAgentTargets(ctx)
+	if err != nil {
+		return agenttargetbiz.Target{}, err
+	}
+	target, ok := agenttargetbiz.EnabledTargetForProvider(targets, canonicalProvider)
+	if !ok {
+		return agenttargetbiz.Target{}, &agentservice.ProviderUnavailableError{
+			Provider:   canonicalProvider,
+			ReasonCode: "agent_provider_not_enabled",
+			Message:    "agent provider is not enabled",
+		}
+	}
+	return target, nil
 }
 
 type providerStartCommandSpec struct {
@@ -150,7 +176,7 @@ func (p Provider) runStart(ctx context.Context, invoke framework.InvokeContext, 
 	}
 	agentTargetID = strings.TrimSpace(agentTargetID)
 	if agentTargetID == "" {
-		return nil, fmt.Errorf("%w: generic agent start cannot create a provider-only session; use `tutti codex start --prompt ...`, `tutti claude start --prompt ...`, or `tutti tutti-agent start --prompt ...` instead, or run `tutti agent start --help` to inspect the legacy command shape", cliservice.ErrInvalidInput)
+		return nil, fmt.Errorf("%w: agent target id is required", cliservice.ErrInvalidInput)
 	}
 	cwd, err := p.resolveStartCwd(ctx, invoke.WorkspaceID, input.Cwd, invoke.Request.Context)
 	if err != nil {


### PR DESCRIPTION
## Summary
- make `tutti --json agent start --provider <canonical-id>` resolve the enabled Agent Target instead of requiring app-owned provider command maps
- canonicalize legacy provider input only at CLI ingress and pass the canonical provider/target pair to session creation
- reject unknown and disabled providers before session creation
- hide target-dependent generic start when a provider is constructed without an AgentTargetLister

## Why
Daemon-session workspace apps consume the open provider catalog. Without a generic target-aware start path, each app must still hard-code Codex/Claude command aliases and cannot safely support future enabled targets. This keeps target resolution in Tutti instead of every app.

## Validation
- `go test ./services/tuttid/service/cli/providers/agentcontext ./services/tuttid/service/cli -count=1`
- repository pre-push `pnpm check:full`

## Rollout
Merge before migrating daemon-session apps (Automation, Omni Catcher, and Design Review Python path) away from provider start maps.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes generic `agent start` target-aware by resolving the provider to an enabled Agent Target and validating it before session creation. This removes app-owned provider start maps and prepares daemon-session apps for future targets.

- **New Features**
  - `tutti agent start --provider <canonical-id>` resolves via the enabled Agent Target catalog.
  - Canonicalizes legacy provider input at CLI ingress (e.g., `claude` -> `claude-code`).
  - Rejects unknown or disabled providers before session creation (`agent_provider_not_enabled`).
  - Hides `agent start` when the provider is constructed without an `AgentTargetLister`.

- **Migration**
  - Use `tutti agent start --provider <canonical-id> --prompt ...` instead of app-specific start maps.
  - Remove hard-coded provider aliases in daemon-session apps.

<sup>Written for commit 95fb71f9c9f6a6dac912a927cf800a9ebd49230b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tutti-os/tutti/pull/1027?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

