### PR TITLE
fix(agent): materialize Codex config dependencies

### DIFF
--- a/docs/conventions/troubleshooting/agent-provider-setup.md
+++ b/docs/conventions/troubleshooting/agent-provider-setup.md
@@ -393,39 +393,53 @@ file or directory`. If the CLI path exists but `codex app-server` cannot
   API-key-without-login readiness, then run
   `cd services/tuttid && go test ./service/agentstatus`.
 
-### Codex session fails with not connected when model_catalog_json is relative
+### Codex session fails when a config-relative dependency is unavailable
 
 - Symptom:
-  Codex is installed and `codex login status` reports logged in, but Tutti
-  chat fails with `agent session is not connected`. Daemon logs show
-  `thread/start` failing with
+  Codex is installed and authenticated, but session creation reports that its
+  configuration references an unavailable file. Older builds may instead
+  continue into the initial prompt and show `agent session is not connected`,
+  while daemon logs show `thread/start` failing with
   `failed to load configuration: No such file or directory (os error 2)`.
-  Tools such as CC Switch often set
-  `model_catalog_json = "cc-switch-model-catalog.json"` in `~/.codex/config.toml`.
-  If that catalog file is missing entirely, the same config error can also make
-  provider status show login required (`auth_unknown`) even though OAuth tokens
-  exist.
+  Configuration switchers commonly write relative `model_catalog_json` or
+  `model_instructions_file` values beside `~/.codex/config.toml`.
 - Quick checks:
-  `grep model_catalog_json ~/.codex/config.toml` and confirm the referenced
-  file exists under `~/.codex/`. Inspect the run-scoped
+  Run `rg '^(model_catalog_json|model_instructions_file)' ~/.codex/config.toml`
+  and confirm each referenced file exists and is a readable regular file.
+  Inspect the run-scoped
   `~/.tutti-dev/agent/runs/<session>/codex-home/` (or `~/.tutti/...` in prod):
-  `config.toml` is copied, but a relative catalog must also be present there.
+  `config.toml` is copied, and every relative dependency must be present at the
+  same relative path. Search the API/renderer diagnostic for
+  `agent.config_dependency_unavailable`; its params identify the provider,
+  config key, safe dependency path, and failure kind without exposing the
+  absolute user-home parent path.
 - Root cause:
-  Tutti prepares a run-scoped `CODEX_HOME` and copies only `config.toml` (plus
-  auth/plugin/skill exposure). Relative `model_catalog_json` paths resolve
-  against that sandbox home, so the catalog is missing unless Tutti mirrors it.
+  Tutti still launches the user's Codex CLI executable, but intentionally gives
+  it a run-scoped `CODEX_HOME`. Copying `config.toml` changes the base directory
+  used by Codex to resolve relative file references. A config dependency that
+  exists beside the user's real config is therefore unavailable unless Tutti
+  preserves the same relative layout in the run-scoped home.
 - Fix:
-  After copying `config.toml`, resolve top-level `model_catalog_json`. For
-  relative paths under `~/.codex`, symlink (or copy) the catalog into the
-  run-scoped `CODEX_HOME` at the same relative path. Absolute catalog paths
-  need no mirror. Do not mutate the user's global config.
+  Route provider-declared file references through the runtime-preparation
+  config-dependency materializer. Codex extracts top-level
+  `model_catalog_json` and `model_instructions_file`; relative paths are
+  validated against the real config root and symlinked (or copied) into the
+  run-scoped `CODEX_HOME`, while absolute paths are validated in place. Reject
+  empty, traversing, missing, non-regular, or unreadable dependencies before
+  starting the runtime. Do not mutate the user's global config and do not call
+  `Exec` after a failed `Start`. A session-level failure without a turn id is a
+  state patch only; never synthesize a turnless transcript message.
 - Validation:
-  Add or update `runtimeprep` tests that set a relative catalog beside
-  `config.toml` and assert the sandbox exposes it. Run
-  `cd packages/agent/runtimeprep && go test ./...`.
+  Cover relative and absolute dependencies, missing files, traversal rejection,
+  idempotent materialization, start-error short-circuiting, and turnless
+  session-failure projection. Run `cd packages/agent/runtimeprep && go test ./...`,
+  `cd packages/agent/daemon && go test ./runtime`, and the focused AgentGUI
+  controller/error-helper tests.
 - References:
+  [config_dependency.go](../../../packages/agent/runtimeprep/config_dependency.go)
   [codex.go](../../../packages/agent/runtimeprep/codex.go)
-  [preparer_test.go](../../../packages/agent/runtimeprep/preparer_test.go)
+  [visible_error.go](../../../packages/agent/daemon/runtime/visible_error.go)
+  [agent_runtime_adapter.go](../../../services/tuttid/agent_runtime_adapter.go)
 
 ### Codex custom model_provider mixes models, duplicates replies, or shows metadata warnings
 

--- a/docs/conventions/troubleshooting/agent-runtime.md
+++ b/docs/conventions/troubleshooting/agent-runtime.md
@@ -19,7 +19,7 @@ Provider discovery, installation, authentication, models, configuration, and run
 - [Cursor sessions create project `.cursor/skills` or `AGENTS.md` changes](./agent-provider-setup.md#cursor-sessions-create-project-cursorskills-or-agentsmd-changes)
 - [Codex provider shows login required when global service tier is legacy](./agent-provider-setup.md#codex-provider-shows-login-required-when-global-service-tier-is-legacy)
 - [Codex provider shows login required when only an API key is configured](./agent-provider-setup.md#codex-provider-shows-login-required-when-only-an-api-key-is-configured)
-- [Codex session fails with not connected when model_catalog_json is relative](./agent-provider-setup.md#codex-session-fails-with-not-connected-when-modelcatalogjson-is-relative)
+- [Codex session fails when a config-relative dependency is unavailable](./agent-provider-setup.md#codex-session-fails-when-a-config-relative-dependency-is-unavailable)
 - [Codex custom model_provider mixes models, duplicates replies, or shows metadata warnings](./agent-provider-setup.md#codex-custom-modelprovider-mixes-models-duplicates-replies-or-shows-metadata-warnings)
 - [Claude SDK Grep or Glob unavailable despite Claude Code preset](./agent-provider-setup.md#claude-sdk-grep-or-glob-unavailable-despite-claude-code-preset)
 - [Concurrent agent CLI installs corrupt shared npm global state](./agent-provider-setup.md#concurrent-agent-cli-installs-corrupt-shared-npm-global-state)

--- a/packages/agent/daemon/runtime/activity_projection_test.go
+++ b/packages/agent/daemon/runtime/activity_projection_test.go
@@ -67,6 +67,24 @@ func TestActivitySessionStatusFromControllerStatusPreservesWaiting(t *testing.T)
 	}
 }
 
+func TestProjectActivityEventsKeepsTurnlessSessionFailureStateOnly(t *testing.T) {
+	t.Parallel()
+
+	session := reportTestSession()
+	event := newSessionActivityEvent(session, EventSessionFailed, SessionStatusFailed, map[string]any{
+		"error":      "provider configuration is invalid",
+		"startError": true,
+	})
+
+	streamEvents := ProjectActivityEventsToStreamEvents(session, []activityshared.Event{event})
+	if len(streamEvents) != 1 {
+		t.Fatalf("stream events = %#v, want one state patch", streamEvents)
+	}
+	if streamEvents[0].EventType != StreamEventStatePatch {
+		t.Fatalf("stream event type = %q, want %q", streamEvents[0].EventType, StreamEventStatePatch)
+	}
+}
+
 func TestReportableActivityEventsReportsFailedAssistantFinalSnapshots(t *testing.T) {
 	t.Parallel()
 

--- a/packages/agent/daemon/runtime/controller_test.go
+++ b/packages/agent/daemon/runtime/controller_test.go
@@ -59,7 +59,7 @@ func (r *recordingReporter) waitForCalls(t *testing.T, count int) []reportCall {
 	}
 }
 
-func TestControllerStartFailureCreatesFailedSessionAndVisibleErrorReport(t *testing.T) {
+func TestControllerStartFailureCreatesFailedSessionAndStateOnlyReport(t *testing.T) {
 	t.Parallel()
 
 	reporter := &recordingReporter{}
@@ -95,14 +95,8 @@ func TestControllerStartFailureCreatesFailedSessionAndVisibleErrorReport(t *test
 	if len(reports[0].report.StatePatches) != 1 {
 		t.Fatalf("state patches = %#v, want failed session patch", reports[0].report.StatePatches)
 	}
-	if len(reports[0].report.MessageUpdates) != 1 {
-		t.Fatalf("message updates = %#v, want visible failure message", reports[0].report.MessageUpdates)
-	}
-	item := reports[0].report.MessageUpdates[0]
-	if item.Payload["kind"] != visibleErrorKind ||
-		item.Payload["phase"] != "start" ||
-		item.Payload["detail"] != "acp process exited with code 1: Config invalid" {
-		t.Fatalf("visible start failure item = %#v", item)
+	if len(reports[0].report.MessageUpdates) != 0 {
+		t.Fatalf("message updates = %#v, want none without a turn id", reports[0].report.MessageUpdates)
 	}
 }
 

--- a/packages/agent/daemon/runtime/reporter_test.go
+++ b/packages/agent/daemon/runtime/reporter_test.go
@@ -1239,6 +1239,43 @@ func TestReporterProjectsTurnFailureErrorToStatePatch(t *testing.T) {
 	}
 }
 
+func TestReporterProjectsTurnlessSessionFailureWithoutMessageUpdate(t *testing.T) {
+	t.Parallel()
+
+	session := reportTestSession()
+	client := &retryingActivityClient{}
+	reporter := Reporter{
+		ClientProvider: func() ActivityClient { return client },
+		MaxAttempts:    1,
+	}
+	event := newSessionActivityEvent(session, EventSessionFailed, SessionStatusFailed, map[string]any{
+		"error":      "provider configuration is invalid",
+		"startError": true,
+	})
+
+	input := reportActivityInput(session, []activityshared.Event{event})
+	if err := reporter.Report(context.Background(), input); err != nil {
+		t.Fatalf("Report: %v", err)
+	}
+	if len(input.StatePatches) != 1 {
+		t.Fatalf("state patches = %#v, want one session failure patch", input.StatePatches)
+	}
+	if input.StatePatches[0].LastError == "" {
+		t.Fatalf("state patch = %#v, want last error", input.StatePatches[0])
+	}
+	if len(input.MessageUpdates) != 0 {
+		t.Fatalf("message updates = %#v, want none without a turn id", input.MessageUpdates)
+	}
+	if client.calls != 1 || len(client.stateInputs) != 1 || len(client.messageInputs) != 0 {
+		t.Fatalf(
+			"client reports = calls:%d state:%d messages:%d, want state only",
+			client.calls,
+			len(client.stateInputs),
+			len(client.messageInputs),
+		)
+	}
+}
+
 func TestReporterDoesNotSendEmptyOrUnreportableBatches(t *testing.T) {
 	t.Parallel()
 

--- a/packages/agent/daemon/runtime/visible_error.go
+++ b/packages/agent/daemon/runtime/visible_error.go
@@ -85,7 +85,8 @@ func visibleFailureMessageUpdate(
 		return agentsessionstore.WorkspaceAgentMessageUpdate{}, false
 	}
 	eventID := strings.TrimSpace(event.EventID)
-	if strings.TrimSpace(sessionID) == "" || eventID == "" {
+	turnID := strings.TrimSpace(event.Payload.TurnID)
+	if strings.TrimSpace(sessionID) == "" || eventID == "" || turnID == "" {
 		return agentsessionstore.WorkspaceAgentMessageUpdate{}, false
 	}
 	phase := "turn"
@@ -115,7 +116,7 @@ func visibleFailureMessageUpdate(
 		AgentSessionID:   strings.TrimSpace(sessionID),
 		MessageID:        "visible-error:" + eventID,
 		Seq:              uint64(timestamp),
-		TurnID:           strings.TrimSpace(event.Payload.TurnID),
+		TurnID:           turnID,
 		Role:             string(activityshared.MessageRoleAssistant),
 		Kind:             "text",
 		Status:           messageStreamStateFailed,

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/agentGuiController.errorHelpers.spec.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/agentGuiController.errorHelpers.spec.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from "vitest";
+import {
+  AGENT_CONFIG_DEPENDENCY_UNAVAILABLE_REASON,
+  getAgentGUIConfigDependencyErrorDetails
+} from "./agentGuiController.errorHelpers";
+
+describe("agentGuiController.errorHelpers", () => {
+  it("extracts only safe config dependency diagnostics", () => {
+    expect(
+      getAgentGUIConfigDependencyErrorDetails({
+        code: "workspace_operation_failed",
+        reason: AGENT_CONFIG_DEPENDENCY_UNAVAILABLE_REASON,
+        params: {
+          provider: " codex ",
+          configKey: "model_instructions_file",
+          dependencyPath: "profiles/instructions.md",
+          failureKind: "missing",
+          sourcePath: "/Users/example/.codex/profiles/instructions.md"
+        }
+      })
+    ).toEqual({
+      provider: "codex",
+      configKey: "model_instructions_file",
+      dependencyPath: "profiles/instructions.md",
+      failureKind: "missing"
+    });
+  });
+
+  it("ignores unrelated protocol errors", () => {
+    expect(
+      getAgentGUIConfigDependencyErrorDetails({
+        reason: "workspace_operation_failed"
+      })
+    ).toBeNull();
+  });
+});

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/agentGuiController.errorHelpers.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/agentGuiController.errorHelpers.ts
@@ -1,0 +1,35 @@
+export const AGENT_CONFIG_DEPENDENCY_UNAVAILABLE_REASON =
+  "agent.config_dependency_unavailable";
+
+export interface AgentGUIConfigDependencyErrorDetails {
+  provider: string;
+  configKey: string;
+  dependencyPath: string;
+  failureKind: string;
+}
+
+export function getAgentGUIConfigDependencyErrorDetails(
+  error: unknown
+): AgentGUIConfigDependencyErrorDetails | null {
+  if (!error || typeof error !== "object") {
+    return null;
+  }
+  const record = error as Record<string, unknown>;
+  if (record.reason !== AGENT_CONFIG_DEPENDENCY_UNAVAILABLE_REASON) {
+    return null;
+  }
+  const params =
+    record.params && typeof record.params === "object"
+      ? (record.params as Record<string, unknown>)
+      : {};
+  return {
+    provider: normalizedString(params.provider),
+    configKey: normalizedString(params.configKey),
+    dependencyPath: normalizedString(params.dependencyPath),
+    failureKind: normalizedString(params.failureKind)
+  };
+}
+
+function normalizedString(value: unknown): string {
+  return typeof value === "string" ? value.trim() : "";
+}

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUINodeController.spec.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUINodeController.spec.tsx
@@ -11161,6 +11161,90 @@ describe("useAgentGUINodeController", () => {
     expect(toast.error).not.toHaveBeenCalled();
   });
 
+  it("localizes config dependency failures and keeps safe diagnostics", async () => {
+    await setAgentGuiI18nTestLocale("en");
+    const configError = Object.assign(
+      new Error(
+        "codex configuration dependency model_instructions_file is unavailable"
+      ),
+      {
+        code: "workspace_operation_failed",
+        reason: "agent.config_dependency_unavailable",
+        params: {
+          provider: "codex",
+          configKey: "model_instructions_file",
+          dependencyPath: "profiles/instructions.md",
+          failureKind: "missing",
+          sourcePath: "/Users/example/.codex/profiles/instructions.md"
+        },
+        retryable: false,
+        statusCode: 502
+      }
+    );
+    const activate = vi.fn(
+      async (_input: AgentHostActivateAgentSessionInput) => {
+        throw configError;
+      }
+    );
+    installAgentHostApi({
+      list: vi.fn(async () => ({ presences: [], sessions: [] })),
+      listSessionTimeline: vi.fn(async () => ({ timelineItems: [] })),
+      subscribeEvents: vi.fn(() => vi.fn()),
+      activate
+    });
+    const reportDiagnostic = vi.fn();
+    (
+      window as unknown as { agentActivityRuntime: AgentActivityRuntime }
+    ).agentActivityRuntime.reportDiagnostic = reportDiagnostic;
+
+    const { result } = renderHook(() =>
+      useAgentGUINodeController({
+        workspaceId: "room-1",
+        currentUserId: "user-1",
+        workspacePath: "/workspace",
+        avoidGroupingEdits: false,
+        data: agentGuiData(null),
+        onDataChange: vi.fn()
+      })
+    );
+
+    act(() => {
+      result.current.actions.submitPrompt(promptBlocks("create one"));
+    });
+    await waitFor(() => {
+      expect(result.current.viewModel.isCreatingConversation).toBe(false);
+    });
+
+    expect(result.current.viewModel.detailError).toBe(
+      "Codex configuration references a file that is unavailable. Check its local configuration and try again."
+    );
+    const diagnosticPayload = reportDiagnostic.mock.calls.find(
+      ([payload]) => payload?.event === "agent.gui.caught_error"
+    )?.[0];
+    expect(diagnosticPayload).toEqual({
+      details: expect.objectContaining({
+        error: expect.objectContaining({
+          code: "workspace_operation_failed",
+          configKey: "model_instructions_file",
+          dependencyPath: "profiles/instructions.md",
+          dependencyProvider: "codex",
+          failureKind: "missing",
+          reason: "agent.config_dependency_unavailable",
+          retryable: false,
+          statusCode: 502
+        }),
+        errorCode: null,
+        phase: "create_conversation",
+        provider: "codex"
+      }),
+      event: "agent.gui.caught_error",
+      level: "error",
+      source: "agent-gui",
+      workspaceId: "room-1"
+    });
+    expect(JSON.stringify(diagnosticPayload)).not.toContain("/Users/example");
+  });
+
   it("clears the per-session messages-loading flag when a new conversation activation fails", async () => {
     const activate = vi.fn(
       async (_input: AgentHostActivateAgentSessionInput) => {

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUINodeController.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUINodeController.ts
@@ -184,6 +184,7 @@ import {
 } from "../../../contexts/workspace/presentation/renderer/agentGuiConversationList/agentGuiConversationListStore";
 import { useAgentGuiConversationList } from "../../../contexts/workspace/presentation/renderer/agentGuiConversationList/useAgentGuiConversationList";
 import { createOptimisticPromptMessage } from "./agentGuiController.promptHelpers";
+import { getAgentGUIConfigDependencyErrorDetails } from "./agentGuiController.errorHelpers";
 import { useAgentGUIActivation } from "./useAgentGUIActivation";
 import { pendingInterruptActionForDisplayStatus } from "./pendingInterrupt";
 import {
@@ -1276,6 +1277,7 @@ function normalizeAgentGUIDiagnosticError(
       ? (error as Record<string, unknown>)
       : null;
   const appErrorCode = getAgentGUIErrorCode(error);
+  const configDependency = getAgentGUIConfigDependencyErrorDetails(error);
   const explicitCode = typeof record?.code === "string" ? record.code : null;
   const hasStructuredCode = appErrorCode !== null || explicitCode !== null;
   const nativeRuntimeError =
@@ -1292,6 +1294,14 @@ function normalizeAgentGUIDiagnosticError(
     ...(typeof record?.reason === "string" ? { reason: record.reason } : {}),
     ...(typeof record?.retryable === "boolean"
       ? { retryable: record.retryable }
+      : {}),
+    ...(configDependency
+      ? {
+          configKey: configDependency.configKey,
+          dependencyPath: configDependency.dependencyPath,
+          dependencyProvider: configDependency.provider,
+          failureKind: configDependency.failureKind
+        }
       : {})
   };
   if (nativeRuntimeError) {
@@ -1466,6 +1476,18 @@ function buildResumeSessionNotLocalActivationError(message?: string | null): {
 }
 
 function getAgentGUIErrorMessage(error: unknown): string {
+  const configDependency = getAgentGUIConfigDependencyErrorDetails(error);
+  if (configDependency) {
+    const provider =
+      AGENT_PROVIDER_LABEL[
+        configDependency.provider as keyof typeof AGENT_PROVIDER_LABEL
+      ] ||
+      configDependency.provider ||
+      translate("sidebar.fallbackAgentLabel");
+    return translate("messages.agentConfigDependencyUnavailable", {
+      provider
+    });
+  }
   if (isProviderSessionNotFoundErrorCode(getAgentGUIErrorCode(error))) {
     return translate("messages.agentProviderSessionNotFound");
   }

--- a/packages/agent/gui/app/renderer/i18n/locales/en.messages.ts
+++ b/packages/agent/gui/app/renderer/i18n/locales/en.messages.ts
@@ -9,6 +9,8 @@ export const enMessages = {
     "This session cannot be resumed on this device. Start a new session and @this session to keep going.",
   agentSettingsRequireNewSession:
     "This model can only be used in a new session to preserve context.",
+  agentConfigDependencyUnavailable:
+    "{{provider}} configuration references a file that is unavailable. Check its local configuration and try again.",
   agentPermissionModeAppliesNextTurn:
     "Permission mode will apply starting with your next message.",
   agentThisSessionMentionLabel: "this session",

--- a/packages/agent/gui/app/renderer/i18n/locales/zh-CN.messages.ts
+++ b/packages/agent/gui/app/renderer/i18n/locales/zh-CN.messages.ts
@@ -7,6 +7,8 @@ export const zhCNMessages = {
   agentResumeSessionNotLocal:
     "这个会话没法在当前设备里直接恢复，你可以在新会话里 @这段对话，接着继续聊。",
   agentSettingsRequireNewSession: "为了保留上下文，这个模型只能在新会话中使用",
+  agentConfigDependencyUnavailable:
+    "{{provider}} 的配置引用了当前不可用的文件。请检查本机配置后重试。",
   agentPermissionModeAppliesNextTurn: "权限模式将从你的下一条消息开始生效。",
   agentThisSessionMentionLabel: "本 session",
   terminalLaunchFailed: "终端启动失败：{{message}}",

--- a/packages/agent/runtimeprep/codex.go
+++ b/packages/agent/runtimeprep/codex.go
@@ -23,7 +23,7 @@ func (CodexPreparer) Provider() string {
 func (CodexPreparer) Prepare(_ context.Context, input ProviderPrepareInput) (ProviderPrepareResult, error) {
 	codexHome := filepath.Join(input.RuntimeRoot, "codex-home")
 	logRuntimePrepareTrace("runtime_prepare.codex.entered", input.PrepareInput, nil)
-	if err := prepareCodexHome(codexHome, input.PrepareInput); err != nil {
+	if err := prepareCodexHome(codexHome, input.PrepareInput, input.Manifest); err != nil {
 		return ProviderPrepareResult{}, err
 	}
 	logRuntimePrepareTrace("runtime_prepare.codex.home_prepared", input.PrepareInput, nil)
@@ -49,14 +49,14 @@ func (CodexPreparer) Prepare(_ context.Context, input ProviderPrepareInput) (Pro
 	}, nil
 }
 
-func prepareCodexHome(codexHome string, input PrepareInput) error {
+func prepareCodexHome(codexHome string, input PrepareInput, manifest *Manifest) error {
 	logRuntimePrepareTrace("runtime_prepare.codex.home_dir_requested", input, nil)
 	if err := os.MkdirAll(codexHome, 0o700); err != nil {
 		return fmt.Errorf("create codex home: %w", err)
 	}
 	logRuntimePrepareTrace("runtime_prepare.codex.home_dir_resolved", input, nil)
 	logRuntimePrepareTrace("runtime_prepare.codex.user_files_requested", input, nil)
-	if err := exposeUserCodexFiles(codexHome); err != nil {
+	if err := exposeUserCodexFiles(codexHome, manifest); err != nil {
 		return err
 	}
 	logRuntimePrepareTrace("runtime_prepare.codex.user_files_resolved", input, nil)
@@ -108,7 +108,7 @@ func codexApprovalRules(cliCommand string) string {
 	return "prefix_rule(pattern=[" + strconv.Quote(command) + "], decision=\"allow\")\n"
 }
 
-func exposeUserCodexFiles(codexHome string) error {
+func exposeUserCodexFiles(codexHome string, manifest *Manifest) error {
 	userHome, err := os.UserHomeDir()
 	if err != nil || strings.TrimSpace(userHome) == "" {
 		return nil
@@ -135,7 +135,7 @@ func exposeUserCodexFiles(codexHome string) error {
 	if err := exposeUserCodexConfig(codexHome, userCodexHome); err != nil {
 		return err
 	}
-	return exposeUserCodexModelCatalog(codexHome, userCodexHome)
+	return exposeUserCodexConfigDependencies(codexHome, userCodexHome, manifest)
 }
 
 // exposeCodexImportedRolloutFile symlinks the single Codex CLI rollout
@@ -236,25 +236,46 @@ func exposeUserCodexConfig(codexHome string, userCodexHome string) error {
 	return nil
 }
 
-// exposeUserCodexModelCatalog mirrors a relative model_catalog_json path into
-// the run-scoped CODEX_HOME. Tutti copies config.toml alone; tools such as
-// CC Switch write model_catalog_json = "cc-switch-model-catalog.json", which
-// Codex resolves against CODEX_HOME. Without the catalog file, thread/start
-// fails with ENOENT and Tutti surfaces "agent session is not connected".
-//
-// Absolute catalog paths stay readable from the host filesystem and need no
-// mirror. Missing keys or missing source files are no-ops.
-func exposeUserCodexModelCatalog(codexHome string, userCodexHome string) error {
+// exposeUserCodexConfigDependencies preserves file references that Codex
+// resolves relative to CODEX_HOME. Tutti copies config.toml into a run-scoped
+// home, so every configured relative dependency must be mirrored with the same
+// relative path before the user's CLI starts.
+func exposeUserCodexConfigDependencies(codexHome string, userCodexHome string, manifest *Manifest) error {
 	configPath := filepath.Join(codexHome, "config.toml")
 	contentBytes, err := os.ReadFile(configPath)
 	if err != nil {
 		if os.IsNotExist(err) {
 			return nil
 		}
-		return fmt.Errorf("read codex config for model catalog path: %w", err)
+		return fmt.Errorf("read codex config dependencies: %w", err)
 	}
-	lines := strings.Split(strings.ReplaceAll(string(contentBytes), "\r\n", "\n"), "\n")
-	for _, line := range lines {
+	content := string(contentBytes)
+	for _, configKey := range []string{"model_catalog_json", "model_instructions_file"} {
+		value, found, valid := codexTopLevelStringConfigValue(content, configKey)
+		if !found {
+			continue
+		}
+		input := configDependencyMaterializeInput{
+			Provider:   "codex",
+			ConfigKey:  configKey,
+			RawPath:    value,
+			SourceRoot: userCodexHome,
+			TargetRoot: codexHome,
+			Manifest:   manifest,
+		}
+		if !valid {
+			return configDependencyError(input, "", ConfigDependencyFailureInvalid, nil)
+		}
+		if err := materializeConfigDependency(input); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func codexTopLevelStringConfigValue(content string, key string) (string, bool, bool) {
+	lines := strings.Split(strings.ReplaceAll(content, "\r\n", "\n"), "\n")
+	for index, line := range lines {
 		trimmed := strings.TrimSpace(line)
 		if trimmed == "" || strings.HasPrefix(trimmed, "#") {
 			continue
@@ -262,39 +283,13 @@ func exposeUserCodexModelCatalog(codexHome string, userCodexHome string) error {
 		if strings.HasPrefix(trimmed, "[") {
 			break
 		}
-		value, ok := codexConfigStringAssignmentValue(trimmed, "model_catalog_json")
-		if !ok {
+		if !codexConfigLineHasKey(trimmed, key) {
 			continue
 		}
-		value = strings.TrimSpace(value)
-		if value == "" || filepath.IsAbs(value) {
-			return nil
-		}
-		cleanRel := filepath.Clean(value)
-		if cleanRel == "." || cleanRel == ".." || strings.HasPrefix(cleanRel, ".."+string(filepath.Separator)) {
-			return nil
-		}
-		source := filepath.Join(userCodexHome, cleanRel)
-		if info, err := os.Stat(source); err != nil || info.IsDir() {
-			return nil
-		}
-		target := filepath.Join(codexHome, cleanRel)
-		if _, err := os.Lstat(target); err == nil {
-			return nil
-		} else if !os.IsNotExist(err) {
-			return fmt.Errorf("inspect codex model catalog: %w", err)
-		}
-		if err := os.MkdirAll(filepath.Dir(target), 0o700); err != nil {
-			return fmt.Errorf("create codex model catalog parent: %w", err)
-		}
-		if err := os.Symlink(source, target); err != nil {
-			if copyErr := copyFile(source, target, 0o600); copyErr != nil {
-				return fmt.Errorf("expose codex model catalog %s: symlink failed: %v; copy failed: %w", cleanRel, err, copyErr)
-			}
-		}
-		return nil
+		value, _, ok := codexConfigStringAssignmentValueAt(lines, index, key)
+		return value, true, ok
 	}
-	return nil
+	return "", false, false
 }
 
 func ensureCodexSessionConfig(configPath string, input PrepareInput) error {

--- a/packages/agent/runtimeprep/config_dependency.go
+++ b/packages/agent/runtimeprep/config_dependency.go
@@ -1,0 +1,214 @@
+package runtimeprep
+
+import (
+	"errors"
+	"fmt"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+const (
+	ConfigDependencyFailureInvalid           = "invalid"
+	ConfigDependencyFailureMissing           = "missing"
+	ConfigDependencyFailureMaterializeFailed = "materialize_failed"
+)
+
+// ConfigDependencyUnavailableError describes a provider configuration file
+// reference that cannot be preserved inside a run-scoped provider home.
+// DependencyPath is safe to expose over the local API; it never contains the
+// parent directory of an absolute user path.
+type ConfigDependencyUnavailableError struct {
+	Provider       string
+	ConfigKey      string
+	DependencyPath string
+	FailureKind    string
+	cause          error
+}
+
+func (e *ConfigDependencyUnavailableError) Error() string {
+	if e == nil {
+		return ""
+	}
+	provider := strings.TrimSpace(e.Provider)
+	if provider == "" {
+		provider = "agent"
+	}
+	key := strings.TrimSpace(e.ConfigKey)
+	if key == "" {
+		key = "configuration"
+	}
+	return fmt.Sprintf("%s configuration dependency %s is unavailable", provider, key)
+}
+
+func (e *ConfigDependencyUnavailableError) Unwrap() error {
+	if e == nil {
+		return nil
+	}
+	return e.cause
+}
+
+type configDependencyMaterializeInput struct {
+	Provider   string
+	ConfigKey  string
+	RawPath    string
+	SourceRoot string
+	TargetRoot string
+	Manifest   *Manifest
+}
+
+func materializeConfigDependency(input configDependencyMaterializeInput) error {
+	rawPath := strings.TrimSpace(input.RawPath)
+	if rawPath == "" || strings.ContainsAny(rawPath, "\x00\r\n") {
+		return configDependencyError(input, "", ConfigDependencyFailureInvalid, nil)
+	}
+
+	if filepath.IsAbs(rawPath) {
+		if err := validateConfigDependencyFile(rawPath); err != nil {
+			return configDependencyFileError(input, rawPath, err)
+		}
+		return nil
+	}
+
+	cleanPath := filepath.Clean(rawPath)
+	if cleanPath == "." || configDependencyPathHasTraversal(rawPath) {
+		return configDependencyError(input, filepath.Join(input.SourceRoot, cleanPath), ConfigDependencyFailureInvalid, nil)
+	}
+	sourcePath := filepath.Join(input.SourceRoot, cleanPath)
+	if err := validateConfigDependencyFile(sourcePath); err != nil {
+		return configDependencyFileError(input, sourcePath, err)
+	}
+
+	targetPath := filepath.Join(input.TargetRoot, cleanPath)
+	if !pathWithinRoot(input.TargetRoot, targetPath) {
+		return configDependencyError(input, sourcePath, ConfigDependencyFailureInvalid, nil)
+	}
+	created, err := exposeConfigDependencyFile(sourcePath, targetPath)
+	if err != nil {
+		return configDependencyError(input, sourcePath, ConfigDependencyFailureMaterializeFailed, err)
+	}
+	if input.Manifest != nil {
+		input.Manifest.RecordManagedFile(targetPath, "provider-config-dependency", created)
+	}
+	return nil
+}
+
+func configDependencyPathHasTraversal(path string) bool {
+	for _, segment := range strings.Split(path, string(filepath.Separator)) {
+		if segment == "." || segment == ".." {
+			return true
+		}
+	}
+	return false
+}
+
+func pathWithinRoot(root string, path string) bool {
+	rel, err := filepath.Rel(root, path)
+	return err == nil && rel != ".." && !strings.HasPrefix(rel, ".."+string(filepath.Separator))
+}
+
+func validateConfigDependencyFile(path string) error {
+	info, err := os.Stat(path)
+	if err != nil {
+		return err
+	}
+	if !info.Mode().IsRegular() {
+		return errConfigDependencyNotRegular
+	}
+	file, err := os.Open(path)
+	if err != nil {
+		return err
+	}
+	return file.Close()
+}
+
+var errConfigDependencyNotRegular = errors.New("configuration dependency is not a regular file")
+
+func configDependencyFileError(input configDependencyMaterializeInput, sourcePath string, err error) error {
+	failureKind := ConfigDependencyFailureMaterializeFailed
+	if os.IsNotExist(err) {
+		failureKind = ConfigDependencyFailureMissing
+	} else if errors.Is(err, errConfigDependencyNotRegular) {
+		failureKind = ConfigDependencyFailureInvalid
+	}
+	return configDependencyError(input, sourcePath, failureKind, err)
+}
+
+func configDependencyError(
+	input configDependencyMaterializeInput,
+	sourcePath string,
+	failureKind string,
+	cause error,
+) error {
+	err := &ConfigDependencyUnavailableError{
+		Provider:       strings.TrimSpace(input.Provider),
+		ConfigKey:      strings.TrimSpace(input.ConfigKey),
+		DependencyPath: safeConfigDependencyPath(input.RawPath),
+		FailureKind:    failureKind,
+		cause:          cause,
+	}
+	args := []any{
+		"provider", err.Provider,
+		"config_key", err.ConfigKey,
+		"dependency_path", err.DependencyPath,
+		"failure_kind", err.FailureKind,
+	}
+	if strings.TrimSpace(sourcePath) != "" {
+		args = append(args, "source_path", sourcePath)
+	}
+	if cause != nil {
+		args = append(args, "error", cause)
+	}
+	slog.Error("agent configuration dependency unavailable", args...)
+	return err
+}
+
+func safeConfigDependencyPath(path string) string {
+	path = strings.TrimSpace(path)
+	if path == "" {
+		return ""
+	}
+	if filepath.IsAbs(path) {
+		return filepath.Base(filepath.Clean(path))
+	}
+	return filepath.Clean(path)
+}
+
+func exposeConfigDependencyFile(source string, target string) (bool, error) {
+	if info, err := os.Lstat(target); err == nil {
+		if info.Mode()&os.ModeSymlink != 0 {
+			linkTarget, readErr := os.Readlink(target)
+			if readErr != nil {
+				return false, readErr
+			}
+			if !filepath.IsAbs(linkTarget) {
+				linkTarget = filepath.Join(filepath.Dir(target), linkTarget)
+			}
+			if filepath.Clean(linkTarget) != filepath.Clean(source) {
+				if removeErr := os.Remove(target); removeErr != nil {
+					return false, removeErr
+				}
+			} else {
+				return false, nil
+			}
+		} else {
+			if validateErr := validateConfigDependencyFile(target); validateErr != nil {
+				return false, validateErr
+			}
+			return false, nil
+		}
+	} else if !os.IsNotExist(err) {
+		return false, err
+	}
+
+	if err := os.MkdirAll(filepath.Dir(target), 0o700); err != nil {
+		return false, err
+	}
+	if err := os.Symlink(source, target); err != nil {
+		if copyErr := copyFile(source, target, 0o600); copyErr != nil {
+			return false, fmt.Errorf("symlink failed: %v; copy failed: %w", err, copyErr)
+		}
+	}
+	return true, nil
+}

--- a/packages/agent/runtimeprep/config_dependency_test.go
+++ b/packages/agent/runtimeprep/config_dependency_test.go
@@ -1,0 +1,62 @@
+package runtimeprep
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestMaterializeConfigDependencyIsIdempotentAndRecordsTarget(t *testing.T) {
+	sourceRoot := t.TempDir()
+	targetRoot := t.TempDir()
+	source := filepath.Join(sourceRoot, "nested", "instructions.md")
+	writeSidecarTestFile(t, source, "instructions\n")
+	manifest := NewManifest(ManifestInput{})
+	input := configDependencyMaterializeInput{
+		Provider:   "codex",
+		ConfigKey:  "model_instructions_file",
+		RawPath:    filepath.Join("nested", "instructions.md"),
+		SourceRoot: sourceRoot,
+		TargetRoot: targetRoot,
+		Manifest:   manifest,
+	}
+
+	if err := materializeConfigDependency(input); err != nil {
+		t.Fatalf("first materialization error = %v", err)
+	}
+	if err := materializeConfigDependency(input); err != nil {
+		t.Fatalf("second materialization error = %v", err)
+	}
+	target := filepath.Join(targetRoot, "nested", "instructions.md")
+	content, err := os.ReadFile(target)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(content) != "instructions\n" {
+		t.Fatalf("target content = %q", string(content))
+	}
+	if len(manifest.ManagedFiles) != 1 || manifest.ManagedFiles[0].Path != target || !manifest.ManagedFiles[0].Created {
+		t.Fatalf("managed files = %#v", manifest.ManagedFiles)
+	}
+}
+
+func TestMaterializeConfigDependencyKeepsAbsoluteParentPathPrivate(t *testing.T) {
+	missing := filepath.Join(t.TempDir(), "private", "missing.md")
+	err := materializeConfigDependency(configDependencyMaterializeInput{
+		Provider:  "codex",
+		ConfigKey: "model_instructions_file",
+		RawPath:   missing,
+	})
+	var dependencyErr *ConfigDependencyUnavailableError
+	if !errors.As(err, &dependencyErr) {
+		t.Fatalf("error = %T %v, want ConfigDependencyUnavailableError", err, err)
+	}
+	if dependencyErr.DependencyPath != "missing.md" {
+		t.Fatalf("dependency path = %q, want basename", dependencyErr.DependencyPath)
+	}
+	if strings.Contains(err.Error(), filepath.Dir(missing)) {
+		t.Fatalf("public error leaks absolute parent path: %q", err.Error())
+	}
+}

--- a/packages/agent/runtimeprep/preparer_test.go
+++ b/packages/agent/runtimeprep/preparer_test.go
@@ -24,6 +24,7 @@ func TestDefaultPreparerCodexWritesInstructionsSkillManifestAndEnv(t *testing.T)
 		`notify = ["say", "done"]`,
 		`model_provider = "proxy"`,
 		`model_catalog_json = "cc-switch-model-catalog.json"`,
+		`model_instructions_file = "instructions/gpt-5.5.md"`,
 		`service_tier = "default"`,
 		"",
 		"[model_providers.proxy]",
@@ -36,6 +37,7 @@ func TestDefaultPreparerCodexWritesInstructionsSkillManifestAndEnv(t *testing.T)
 	if err := os.WriteFile(filepath.Join(userCodexHome, "cc-switch-model-catalog.json"), []byte(`{"models":[]}`), 0o600); err != nil {
 		t.Fatal(err)
 	}
+	writeSidecarTestFile(t, filepath.Join(userCodexHome, "instructions", "gpt-5.5.md"), "Use the custom model instructions.\n")
 	writeSidecarTestFile(t, filepath.Join(userCodexHome, "plugins", "cache", "sample", "plugin.txt"), "plugin cache")
 	writeSidecarTestFile(t, filepath.Join(userCodexHome, "plugins", "data", "sample", "state.txt"), "plugin state")
 	writeSidecarTestFile(t, filepath.Join(userCodexHome, "plugins", ".plugin-appserver", "codex"), "plugin server")
@@ -124,6 +126,13 @@ func TestDefaultPreparerCodexWritesInstructionsSkillManifestAndEnv(t *testing.T)
 	}
 	if catalogLink.Mode()&os.ModeSymlink == 0 {
 		t.Fatalf("codex model catalog should be a symlink, got mode %v", catalogLink.Mode())
+	}
+	instructionsLink, err := os.Lstat(filepath.Join(codexHome, "instructions", "gpt-5.5.md"))
+	if err != nil {
+		t.Fatalf("codex model instructions not exposed: %v", err)
+	}
+	if instructionsLink.Mode()&os.ModeSymlink == 0 {
+		t.Fatalf("codex model instructions should be a symlink, got mode %v", instructionsLink.Mode())
 	}
 	for _, rel := range []string{
 		filepath.Join("plugins", "cache"),
@@ -394,6 +403,133 @@ func TestDefaultPreparerCodexExposesRelativeModelCatalogJSON(t *testing.T) {
 	}
 	if string(got) != catalogBody {
 		t.Fatalf("sandbox catalog body = %q, want %q", string(got), catalogBody)
+	}
+}
+
+func TestDefaultPreparerCodexExposesRelativeModelInstructionsFile(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	userCodexHome := filepath.Join(home, ".codex")
+	writeSidecarTestFile(t, filepath.Join(userCodexHome, "profiles", "gpt-5.5.md"), "Custom instructions\n")
+	writeSidecarTestFile(
+		t,
+		filepath.Join(userCodexHome, "config.toml"),
+		`model_instructions_file = "profiles/gpt-5.5.md"`+"\n",
+	)
+
+	prepared, err := NewDefaultPreparer(t.TempDir()).Prepare(t.Context(), PrepareInput{
+		WorkspaceID:    "workspace-1",
+		AgentSessionID: "session-instructions",
+		AgentTargetID:  "local:codex",
+		Provider:       "codex",
+		Cwd:            t.TempDir(),
+	})
+	if err != nil {
+		t.Fatalf("Prepare() error = %v", err)
+	}
+	codexHome := envValue(prepared.Env, "CODEX_HOME")
+	target := filepath.Join(codexHome, "profiles", "gpt-5.5.md")
+	info, err := os.Lstat(target)
+	if err != nil {
+		t.Fatalf("relative model instructions not exposed: %v", err)
+	}
+	if info.Mode()&os.ModeSymlink == 0 {
+		t.Fatalf("model instructions mode = %v, want symlink", info.Mode())
+	}
+	content, err := os.ReadFile(target)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(content) != "Custom instructions\n" {
+		t.Fatalf("model instructions = %q", string(content))
+	}
+}
+
+func TestDefaultPreparerCodexFailsFastForMissingConfigDependency(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	userCodexHome := filepath.Join(home, ".codex")
+	writeSidecarTestFile(
+		t,
+		filepath.Join(userCodexHome, "config.toml"),
+		`model_instructions_file = "profiles/missing.md"`+"\n",
+	)
+
+	_, err := NewDefaultPreparer(t.TempDir()).Prepare(t.Context(), PrepareInput{
+		WorkspaceID:    "workspace-1",
+		AgentSessionID: "session-missing-instructions",
+		AgentTargetID:  "local:codex",
+		Provider:       "codex",
+		Cwd:            t.TempDir(),
+	})
+	if err == nil {
+		t.Fatal("Prepare() error = nil, want missing config dependency")
+	}
+	var dependencyErr *ConfigDependencyUnavailableError
+	if !errors.As(err, &dependencyErr) {
+		t.Fatalf("Prepare() error = %T %v, want ConfigDependencyUnavailableError", err, err)
+	}
+	if dependencyErr.Provider != "codex" ||
+		dependencyErr.ConfigKey != "model_instructions_file" ||
+		dependencyErr.DependencyPath != filepath.Join("profiles", "missing.md") ||
+		dependencyErr.FailureKind != ConfigDependencyFailureMissing {
+		t.Fatalf("dependency error = %#v", dependencyErr)
+	}
+	if strings.Contains(err.Error(), home) {
+		t.Fatalf("public error leaks user home path: %q", err.Error())
+	}
+}
+
+func TestDefaultPreparerCodexRejectsTraversingConfigDependency(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	userCodexHome := filepath.Join(home, ".codex")
+	writeSidecarTestFile(
+		t,
+		filepath.Join(userCodexHome, "config.toml"),
+		`model_catalog_json = "../catalog.json"`+"\n",
+	)
+
+	_, err := NewDefaultPreparer(t.TempDir()).Prepare(t.Context(), PrepareInput{
+		WorkspaceID:    "workspace-1",
+		AgentSessionID: "session-invalid-catalog",
+		AgentTargetID:  "local:codex",
+		Provider:       "codex",
+		Cwd:            t.TempDir(),
+	})
+	var dependencyErr *ConfigDependencyUnavailableError
+	if !errors.As(err, &dependencyErr) {
+		t.Fatalf("Prepare() error = %T %v, want ConfigDependencyUnavailableError", err, err)
+	}
+	if dependencyErr.FailureKind != ConfigDependencyFailureInvalid {
+		t.Fatalf("failure kind = %q, want %q", dependencyErr.FailureKind, ConfigDependencyFailureInvalid)
+	}
+}
+
+func TestDefaultPreparerCodexAcceptsAbsoluteConfigDependencyWithoutMirroring(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	userCodexHome := filepath.Join(home, ".codex")
+	absoluteInstructions := filepath.Join(t.TempDir(), "absolute-instructions.md")
+	writeSidecarTestFile(t, absoluteInstructions, "Absolute instructions\n")
+	writeSidecarTestFile(
+		t,
+		filepath.Join(userCodexHome, "config.toml"),
+		`model_instructions_file = `+strconv.Quote(absoluteInstructions)+"\n",
+	)
+
+	prepared, err := NewDefaultPreparer(t.TempDir()).Prepare(t.Context(), PrepareInput{
+		WorkspaceID:    "workspace-1",
+		AgentSessionID: "session-absolute-instructions",
+		AgentTargetID:  "local:codex",
+		Provider:       "codex",
+		Cwd:            t.TempDir(),
+	})
+	if err != nil {
+		t.Fatalf("Prepare() error = %v", err)
+	}
+	if codexHome := envValue(prepared.Env, "CODEX_HOME"); codexHome == "" {
+		t.Fatalf("prepared env = %#v, want CODEX_HOME", prepared.Env)
 	}
 }
 

--- a/services/tuttid/agent_runtime_adapter.go
+++ b/services/tuttid/agent_runtime_adapter.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"errors"
+	"strings"
 
 	agentruntime "github.com/tutti-os/tutti/packages/agent/daemon/runtime"
 	agentservice "github.com/tutti-os/tutti/services/tuttid/service/agent"
@@ -304,6 +305,19 @@ func (a agentRuntimeAdapter) Start(ctx context.Context, input agentservice.Runti
 	})
 	if err != nil {
 		return agentservice.RuntimeSession{}, mapAgentRuntimeError(err)
+	}
+	if result.Error != nil {
+		message := strings.TrimSpace(result.Error.DebugMessage)
+		if message == "" {
+			message = strings.TrimSpace(result.Error.Message)
+		}
+		if message == "" {
+			message = strings.TrimSpace(result.Error.Code)
+		}
+		if message == "" {
+			message = "agent runtime failed to start"
+		}
+		return agentservice.RuntimeSession{}, errors.New(message)
 	}
 	return a.runtimeSessionWithState(result.Session), nil
 }

--- a/services/tuttid/agent_runtime_adapter_test.go
+++ b/services/tuttid/agent_runtime_adapter_test.go
@@ -2,12 +2,65 @@ package main
 
 import (
 	"context"
+	"errors"
+	"strings"
 	"testing"
 	"time"
 
+	activityevents "github.com/tutti-os/tutti/packages/agent/daemon/activity/events"
 	agentruntime "github.com/tutti-os/tutti/packages/agent/daemon/runtime"
 	agentservice "github.com/tutti-os/tutti/services/tuttid/service/agent"
 )
+
+type failingRuntimeStartAdapter struct{}
+
+func (failingRuntimeStartAdapter) Provider() string { return "failing-start" }
+
+func (failingRuntimeStartAdapter) Start(context.Context, agentruntime.Session) ([]activityevents.Event, error) {
+	return nil, errors.New("provider configuration is invalid")
+}
+
+func (failingRuntimeStartAdapter) Resume(context.Context, agentruntime.Session) error { return nil }
+
+func (failingRuntimeStartAdapter) Close(context.Context, agentruntime.Session) error { return nil }
+
+func (failingRuntimeStartAdapter) Exec(
+	context.Context,
+	agentruntime.Session,
+	[]agentruntime.PromptContentBlock,
+	string,
+	string,
+	agentruntime.EventSink,
+	agentruntime.CommandSnapshotSink,
+) ([]activityevents.Event, error) {
+	return nil, nil
+}
+
+func (failingRuntimeStartAdapter) Cancel(context.Context, agentruntime.Session, string) ([]activityevents.Event, error) {
+	return nil, nil
+}
+
+func TestAgentRuntimeAdapterReturnsEmbeddedStartFailure(t *testing.T) {
+	controller := agentruntime.NewController([]agentruntime.Adapter{failingRuntimeStartAdapter{}}, nil)
+	adapter := newAgentRuntimeAdapter(controller)
+
+	_, err := adapter.Start(t.Context(), agentservice.RuntimeStartInput{
+		WorkspaceID:    "workspace-1",
+		AgentSessionID: "agent-session-failed",
+		Provider:       "failing-start",
+		Cwd:            t.TempDir(),
+	})
+	if err == nil || !strings.Contains(err.Error(), "provider configuration is invalid") {
+		t.Fatalf("Start() error = %v, want provider start failure", err)
+	}
+	session, ok := controller.Session("workspace-1", "agent-session-failed")
+	if !ok {
+		t.Fatal("failed runtime session was not retained")
+	}
+	if session.Status != agentruntime.SessionStatusFailed {
+		t.Fatalf("session status = %q, want failed", session.Status)
+	}
+}
 
 func TestAgentRuntimeAdapterReturnsClaudeSDKModelConfigOptions(t *testing.T) {
 	t.Setenv("TUTTI_CLAUDE_SDK_SIDECAR_TEST_DRIVER", "1")

--- a/services/tuttid/api/openapi/tuttid.v1.yaml
+++ b/services/tuttid/api/openapi/tuttid.v1.yaml
@@ -3893,6 +3893,18 @@ components:
                   code: workspace_operation_failed
                   reason: workspace_operation_failed
                   developerMessage: workspace operation failed
+            agentConfigDependencyUnavailable:
+              value:
+                error:
+                  code: workspace_operation_failed
+                  reason: agent.config_dependency_unavailable
+                  params:
+                    provider: codex
+                    configKey: model_instructions_file
+                    dependencyPath: instructions.md
+                    failureKind: missing
+                  retryable: false
+                  developerMessage: codex configuration dependency model_instructions_file is unavailable
     PreferencesOperationError:
       description: Desktop preferences operation failed in an upstream adapter or command
       content:

--- a/services/tuttid/apierrors/apierrors.go
+++ b/services/tuttid/apierrors/apierrors.go
@@ -72,6 +72,7 @@ const (
 	ReasonWorkspaceFileServiceUnavailable                = "workspace_file_service_unavailable"
 	ReasonWorkspaceAgentSessionNotFound                  = "workspace_agent_session_not_found"
 	ReasonWorkspaceAgentSessionUnavailable               = "workspace_agent_session_service_unavailable"
+	ReasonAgentConfigDependencyUnavailable               = "agent.config_dependency_unavailable"
 	ReasonAgentProviderUnavailable                       = "agent_provider_unavailable"
 	ReasonWorkspaceAppNotFound                           = "workspace_app_not_found"
 	ReasonWorkspaceAppDeleteForbidden                    = "workspace_app_delete_forbidden"
@@ -275,6 +276,23 @@ func AgentProviderUnavailable(err *agentservice.ProviderUnavailableError) *Proto
 	)
 }
 
+func AgentConfigDependencyUnavailable(err *runtimeprep.ConfigDependencyUnavailableError) *ProtocolError {
+	params := map[string]any{}
+	if err != nil {
+		params["provider"] = strings.TrimSpace(err.Provider)
+		params["configKey"] = strings.TrimSpace(err.ConfigKey)
+		params["dependencyPath"] = strings.TrimSpace(err.DependencyPath)
+		params["failureKind"] = strings.TrimSpace(err.FailureKind)
+	}
+	return New(
+		StatusWorkspaceOperationFailed,
+		tuttigenerated.WorkspaceOperationFailed,
+		ReasonAgentConfigDependencyUnavailable,
+		WithCause(err),
+		WithParams(params),
+	)
+}
+
 func PreferencesOperationFailed(options ...Option) *ProtocolError {
 	return New(StatusPreferencesOperationFailed, tuttigenerated.PreferencesOperationFailed, ReasonPreferencesOperationFailed, options...)
 }
@@ -298,6 +316,10 @@ func Classify(err error) *ProtocolError {
 	var providerUnavailableErr *agentservice.ProviderUnavailableError
 	if errors.As(err, &providerUnavailableErr) {
 		return AgentProviderUnavailable(providerUnavailableErr)
+	}
+	var configDependencyErr *runtimeprep.ConfigDependencyUnavailableError
+	if errors.As(err, &configDependencyErr) {
+		return AgentConfigDependencyUnavailable(configDependencyErr)
 	}
 	var invalidModelErr *agentservice.InvalidModelError
 	if errors.As(err, &invalidModelErr) {

--- a/services/tuttid/apierrors/apierrors_test.go
+++ b/services/tuttid/apierrors/apierrors_test.go
@@ -1,0 +1,39 @@
+package apierrors
+
+import (
+	"fmt"
+	"reflect"
+	"testing"
+
+	runtimeprep "github.com/tutti-os/tutti/packages/agent/runtimeprep"
+	tuttigenerated "github.com/tutti-os/tutti/services/tuttid/api/generated"
+)
+
+func TestClassifyAgentConfigDependencyUnavailable(t *testing.T) {
+	source := &runtimeprep.ConfigDependencyUnavailableError{
+		Provider:       "codex",
+		ConfigKey:      "model_instructions_file",
+		DependencyPath: "profiles/instructions.md",
+		FailureKind:    runtimeprep.ConfigDependencyFailureMissing,
+	}
+	got := Classify(fmt.Errorf("prepare runtime: %w", source))
+
+	if got.Code != tuttigenerated.WorkspaceOperationFailed {
+		t.Fatalf("code = %q, want workspace_operation_failed", got.Code)
+	}
+	if got.Reason != ReasonAgentConfigDependencyUnavailable {
+		t.Fatalf("reason = %q, want %q", got.Reason, ReasonAgentConfigDependencyUnavailable)
+	}
+	wantParams := map[string]any{
+		"provider":       "codex",
+		"configKey":      "model_instructions_file",
+		"dependencyPath": "profiles/instructions.md",
+		"failureKind":    runtimeprep.ConfigDependencyFailureMissing,
+	}
+	if !reflect.DeepEqual(got.Params, wantParams) {
+		t.Fatalf("params = %#v, want %#v", got.Params, wantParams)
+	}
+	if got.Retryable {
+		t.Fatal("retryable = true, want false")
+	}
+}

--- a/services/tuttid/service/agent/service_test.go
+++ b/services/tuttid/service/agent/service_test.go
@@ -1739,6 +1739,9 @@ func TestServiceCreateCleansPreparedRuntimeWhenStartFails(t *testing.T) {
 		cleanupCalls[0].AgentSessionID != "session-1" {
 		t.Fatalf("cleanup calls = %#v", cleanupCalls)
 	}
+	if len(runtime.execCalls) != 0 {
+		t.Fatalf("exec calls = %d, want 0 after start failure", len(runtime.execCalls))
+	}
 }
 
 func TestServiceCreateRejectsInvalidContentBeforePreparingRuntime(t *testing.T) {


### PR DESCRIPTION
## What
- materialize provider-declared Codex config-relative files into the run-scoped CODEX_HOME
- fail fast with `agent.config_dependency_unavailable` and a safe diagnostic payload
- short-circuit failed runtime starts before initial Exec and keep turnless session failures state-only
- localize the AgentGUI error and document the troubleshooting invariant

## Why
Tutti invokes the user's Codex CLI executable with a run-scoped CODEX_HOME. Copying `config.toml` changes the base used for relative `model_catalog_json` and `model_instructions_file` references, so Codex could fail `thread/start`; the old flow then attempted Exec and surfaced `agent session is not connected`. The activity reporter also tried to post a turnless visible message, which was rejected because message updates require `turnId`.

## Impact
The user config is never mutated. Relative dependencies are symlinked (copy fallback) at the same path, absolute dependencies are validated in place, and missing/invalid dependencies stop before provider startup. API details retain only provider, config key, safe dependency path, and failure kind.

## Checks
- `pnpm typecheck`
- `pnpm lint:ts`
- `pnpm check:i18n`
- `pnpm check:api-generated`
- `pnpm check:agent-activity-runtime-boundaries`
- AgentGUI controller/error-helper tests (279 passed)
- `go test ./...` and `go build ./...` in `services/tuttid`
- `go test ./...` in `packages/agent/runtimeprep`
- runtime tests and changed-aware checks

## Docs
Improved `docs/conventions/troubleshooting/agent-provider-setup.md` and its runtime index entry.

Backport: pending release/0704 Draft PR.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Materializes Codex config file dependencies into the run-scoped CODEX_HOME and validates them before startup. Fails fast with a safe `agent.config_dependency_unavailable` error to prevent “not connected” sessions and provides a localized AgentGUI message.

- **Bug Fixes**
  - Mirror relative `model_catalog_json` and `model_instructions_file` via symlink (copy fallback) inside the run-scoped home; validate absolute paths in place. Reject empty, traversal, missing, non-regular, or unreadable files; record managed files in the manifest.
  - Short-circuit runtime start on dependency errors and do not call Exec after a failed Start. Propagate start failures from the adapter and keep turnless session failures state-only (no message updates without a `turnId`).
  - Localize the AgentGUI error and report only safe diagnostics (provider, config key, dependency path, failure kind). Adds i18n strings and focused tests.
  - Classify and surface the error as `workspace_operation_failed` with reason `agent.config_dependency_unavailable` and update OpenAPI examples.
  - Update troubleshooting docs to reflect the new behavior and invariant.

<sup>Written for commit ba27139c6c13cd911c9be97b76ed7118be91bc3f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tutti-os/tutti/pull/1032?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

