### PR TITLE
fix(agent): backport Codex config dependency handling

### DIFF
--- a/packages/agent/daemon/runtime/controller_test.go
+++ b/packages/agent/daemon/runtime/controller_test.go
@@ -59,7 +59,7 @@ func (r *recordingReporter) waitForCalls(t *testing.T, count int) []reportCall {
 	}
 }
 
-func TestControllerStartFailureCreatesFailedSessionAndVisibleErrorReport(t *testing.T) {
+func TestControllerStartFailureCreatesFailedSessionAndStateOnlyReport(t *testing.T) {
 	t.Parallel()
 
 	reporter := &recordingReporter{}
@@ -95,14 +95,8 @@ func TestControllerStartFailureCreatesFailedSessionAndVisibleErrorReport(t *test
 	if len(reports[0].report.StatePatches) != 1 {
 		t.Fatalf("state patches = %#v, want failed session patch", reports[0].report.StatePatches)
 	}
-	if len(reports[0].report.MessageUpdates) != 1 {
-		t.Fatalf("message updates = %#v, want visible failure message", reports[0].report.MessageUpdates)
-	}
-	item := reports[0].report.MessageUpdates[0]
-	if item.Payload["kind"] != visibleErrorKind ||
-		item.Payload["phase"] != "start" ||
-		item.Payload["detail"] != "acp process exited with code 1: Config invalid" {
-		t.Fatalf("visible start failure item = %#v", item)
+	if len(reports[0].report.MessageUpdates) != 0 {
+		t.Fatalf("message updates = %#v, want none without a turn id", reports[0].report.MessageUpdates)
 	}
 }
 

--- a/packages/agent/daemon/runtime/visible_error.go
+++ b/packages/agent/daemon/runtime/visible_error.go
@@ -33,7 +33,8 @@ func visibleFailureTimelineItem(
 		return agentsessionstore.WorkspaceAgentTimelineItem{}, false
 	}
 	eventID := strings.TrimSpace(event.EventID)
-	if strings.TrimSpace(sessionID) == "" || eventID == "" {
+	turnID := strings.TrimSpace(event.Payload.TurnID)
+	if strings.TrimSpace(sessionID) == "" || eventID == "" || turnID == "" {
 		return agentsessionstore.WorkspaceAgentTimelineItem{}, false
 	}
 	phase := "turn"
@@ -61,7 +62,7 @@ func visibleFailureTimelineItem(
 	return agentsessionstore.WorkspaceAgentTimelineItem{
 		RoomID:           strings.TrimSpace(roomID),
 		AgentSessionID:   strings.TrimSpace(sessionID),
-		TurnID:           strings.TrimSpace(event.Payload.TurnID),
+		TurnID:           turnID,
 		EventSource:      "runtime",
 		EventID:          "visible-error:" + eventID,
 		ActorType:        "agent",

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/agentGuiController.errorHelpers.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/agentGuiController.errorHelpers.ts
@@ -1,0 +1,35 @@
+export const AGENT_CONFIG_DEPENDENCY_UNAVAILABLE_REASON =
+  "agent.config_dependency_unavailable";
+
+export interface AgentGUIConfigDependencyErrorDetails {
+  provider: string;
+  configKey: string;
+  dependencyPath: string;
+  failureKind: string;
+}
+
+export function getAgentGUIConfigDependencyErrorDetails(
+  error: unknown
+): AgentGUIConfigDependencyErrorDetails | null {
+  if (!error || typeof error !== "object") {
+    return null;
+  }
+  const record = error as Record<string, unknown>;
+  if (record.reason !== AGENT_CONFIG_DEPENDENCY_UNAVAILABLE_REASON) {
+    return null;
+  }
+  const params =
+    record.params && typeof record.params === "object"
+      ? (record.params as Record<string, unknown>)
+      : {};
+  return {
+    provider: normalizedString(params.provider),
+    configKey: normalizedString(params.configKey),
+    dependencyPath: normalizedString(params.dependencyPath),
+    failureKind: normalizedString(params.failureKind)
+  };
+}
+
+function normalizedString(value: unknown): string {
+  return typeof value === "string" ? value.trim() : "";
+}

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUINodeController.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUINodeController.ts
@@ -170,6 +170,7 @@ import {
 } from "../../../contexts/workspace/presentation/renderer/agentGuiConversationList/agentGuiConversationListStore";
 import { useAgentGuiConversationList } from "../../../contexts/workspace/presentation/renderer/agentGuiConversationList/useAgentGuiConversationList";
 import { createOptimisticPromptMessage } from "./agentGuiController.promptHelpers";
+import { getAgentGUIConfigDependencyErrorDetails } from "./agentGuiController.errorHelpers";
 import { useAgentGUIActivation } from "./useAgentGUIActivation";
 import { pendingInterruptActionForDisplayStatus } from "./pendingInterrupt";
 import {
@@ -1084,6 +1085,7 @@ function normalizeAgentGUIDiagnosticError(
       ? (error as Record<string, unknown>)
       : null;
   const appErrorCode = getAgentGUIErrorCode(error);
+  const configDependency = getAgentGUIConfigDependencyErrorDetails(error);
   const explicitCode = typeof record?.code === "string" ? record.code : null;
   const hasStructuredCode = appErrorCode !== null || explicitCode !== null;
   const nativeRuntimeError =
@@ -1100,6 +1102,14 @@ function normalizeAgentGUIDiagnosticError(
     ...(typeof record?.reason === "string" ? { reason: record.reason } : {}),
     ...(typeof record?.retryable === "boolean"
       ? { retryable: record.retryable }
+      : {}),
+    ...(configDependency
+      ? {
+          configKey: configDependency.configKey,
+          dependencyPath: configDependency.dependencyPath,
+          dependencyProvider: configDependency.provider,
+          failureKind: configDependency.failureKind
+        }
       : {})
   };
   if (nativeRuntimeError) {
@@ -1254,6 +1264,16 @@ function buildResumeSessionNotLocalActivationError(message?: string | null): {
 }
 
 function getAgentGUIErrorMessage(error: unknown): string {
+  const configDependency = getAgentGUIConfigDependencyErrorDetails(error);
+  if (configDependency) {
+    const provider =
+      AGENT_PROVIDER_LABEL[
+        configDependency.provider as keyof typeof AGENT_PROVIDER_LABEL
+      ] ||
+      configDependency.provider ||
+      translate("sidebar.fallbackAgentLabel");
+    return translate("messages.agentConfigDependencyUnavailable", { provider });
+  }
   if (isProviderSessionNotFoundErrorCode(getAgentGUIErrorCode(error))) {
     return translate("messages.agentProviderSessionNotFound");
   }

--- a/packages/agent/gui/app/renderer/i18n/locales/en.messages.ts
+++ b/packages/agent/gui/app/renderer/i18n/locales/en.messages.ts
@@ -7,6 +7,8 @@ export const enMessages = {
     "This session cannot be resumed on this device. Start a new session and @this session to keep going.",
   agentSettingsRequireNewSession:
     "This model can only be used in a new session to preserve context.",
+  agentConfigDependencyUnavailable:
+    "{{provider}} configuration references a file that is unavailable. Check its local configuration and try again.",
   agentPermissionModeAppliesNextTurn:
     "Permission mode will apply starting with your next message.",
   agentThisSessionMentionLabel: "this session",

--- a/packages/agent/gui/app/renderer/i18n/locales/zh-CN.messages.ts
+++ b/packages/agent/gui/app/renderer/i18n/locales/zh-CN.messages.ts
@@ -6,6 +6,8 @@ export const zhCNMessages = {
   agentResumeSessionNotLocal:
     "这个会话没法在当前设备里直接恢复，你可以在新会话里 @这段对话，接着继续聊。",
   agentSettingsRequireNewSession: "为了保留上下文，这个模型只能在新会话中使用",
+  agentConfigDependencyUnavailable:
+    "{{provider}} 的配置引用了当前不可用的文件。请检查本机配置后重试。",
   agentPermissionModeAppliesNextTurn: "权限模式将从你的下一条消息开始生效。",
   agentThisSessionMentionLabel: "本 session",
   terminalLaunchFailed: "终端启动失败：{{message}}",

--- a/services/tuttid/agent_runtime_adapter.go
+++ b/services/tuttid/agent_runtime_adapter.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"errors"
+	"strings"
 
 	agentruntime "github.com/tutti-os/tutti/packages/agentactivity/daemon/runtime"
 	agentservice "github.com/tutti-os/tutti/services/tuttid/service/agent"
@@ -279,6 +280,19 @@ func (a agentRuntimeAdapter) Start(ctx context.Context, input agentservice.Runti
 	})
 	if err != nil {
 		return agentservice.RuntimeSession{}, mapAgentRuntimeError(err)
+	}
+	if result.Error != nil {
+		message := strings.TrimSpace(result.Error.DebugMessage)
+		if message == "" {
+			message = strings.TrimSpace(result.Error.Message)
+		}
+		if message == "" {
+			message = strings.TrimSpace(result.Error.Code)
+		}
+		if message == "" {
+			message = "agent runtime failed to start"
+		}
+		return agentservice.RuntimeSession{}, errors.New(message)
 	}
 	return a.runtimeSessionWithState(result.Session), nil
 }

--- a/services/tuttid/api/openapi/tuttid.v1.yaml
+++ b/services/tuttid/api/openapi/tuttid.v1.yaml
@@ -3518,6 +3518,18 @@ components:
                   code: workspace_operation_failed
                   reason: workspace_operation_failed
                   developerMessage: workspace operation failed
+            agentConfigDependencyUnavailable:
+              value:
+                error:
+                  code: workspace_operation_failed
+                  reason: agent.config_dependency_unavailable
+                  params:
+                    provider: codex
+                    configKey: model_instructions_file
+                    dependencyPath: instructions.md
+                    failureKind: missing
+                  retryable: false
+                  developerMessage: codex configuration dependency model_instructions_file is unavailable
     PreferencesOperationError:
       description: Desktop preferences operation failed in an upstream adapter or command
       content:

--- a/services/tuttid/apierrors/apierrors.go
+++ b/services/tuttid/apierrors/apierrors.go
@@ -72,6 +72,7 @@ const (
 	ReasonWorkspaceFileServiceUnavailable                = "workspace_file_service_unavailable"
 	ReasonWorkspaceAgentSessionNotFound                  = "workspace_agent_session_not_found"
 	ReasonWorkspaceAgentSessionUnavailable               = "workspace_agent_session_service_unavailable"
+	ReasonAgentConfigDependencyUnavailable               = "agent.config_dependency_unavailable"
 	ReasonAgentProviderUnavailable                       = "agent_provider_unavailable"
 	ReasonWorkspaceAppNotFound                           = "workspace_app_not_found"
 	ReasonWorkspaceAppDeleteForbidden                    = "workspace_app_delete_forbidden"
@@ -291,6 +292,23 @@ func AgentProviderUnavailable(err *agentservice.ProviderUnavailableError) *Proto
 	)
 }
 
+func AgentConfigDependencyUnavailable(err *agentsidecarservice.ConfigDependencyUnavailableError) *ProtocolError {
+	params := map[string]any{}
+	if err != nil {
+		params["provider"] = strings.TrimSpace(err.Provider)
+		params["configKey"] = strings.TrimSpace(err.ConfigKey)
+		params["dependencyPath"] = strings.TrimSpace(err.DependencyPath)
+		params["failureKind"] = strings.TrimSpace(err.FailureKind)
+	}
+	return New(
+		StatusWorkspaceOperationFailed,
+		tuttigenerated.WorkspaceOperationFailed,
+		ReasonAgentConfigDependencyUnavailable,
+		WithCause(err),
+		WithParams(params),
+	)
+}
+
 func PreferencesOperationFailed(options ...Option) *ProtocolError {
 	return New(StatusPreferencesOperationFailed, tuttigenerated.PreferencesOperationFailed, ReasonPreferencesOperationFailed, options...)
 }
@@ -314,6 +332,10 @@ func Classify(err error) *ProtocolError {
 	var providerUnavailableErr *agentservice.ProviderUnavailableError
 	if errors.As(err, &providerUnavailableErr) {
 		return AgentProviderUnavailable(providerUnavailableErr)
+	}
+	var configDependencyErr *agentsidecarservice.ConfigDependencyUnavailableError
+	if errors.As(err, &configDependencyErr) {
+		return AgentConfigDependencyUnavailable(configDependencyErr)
 	}
 	var invalidModelErr *agentservice.InvalidModelError
 	if errors.As(err, &invalidModelErr) {

--- a/services/tuttid/apierrors/apierrors_test.go
+++ b/services/tuttid/apierrors/apierrors_test.go
@@ -1,0 +1,30 @@
+package apierrors
+
+import (
+	"fmt"
+	"reflect"
+	"testing"
+
+	tuttigenerated "github.com/tutti-os/tutti/services/tuttid/api/generated"
+	agentsidecar "github.com/tutti-os/tutti/services/tuttid/service/agentsidecar"
+)
+
+func TestClassifyAgentConfigDependencyUnavailable(t *testing.T) {
+	source := &agentsidecar.ConfigDependencyUnavailableError{
+		Provider:       "codex",
+		ConfigKey:      "model_instructions_file",
+		DependencyPath: "profiles/instructions.md",
+		FailureKind:    agentsidecar.ConfigDependencyFailureMissing,
+	}
+	got := Classify(fmt.Errorf("prepare runtime: %w", source))
+	if got.Code != tuttigenerated.WorkspaceOperationFailed || got.Reason != ReasonAgentConfigDependencyUnavailable {
+		t.Fatalf("protocol error = %#v", got)
+	}
+	want := map[string]any{
+		"provider": "codex", "configKey": "model_instructions_file",
+		"dependencyPath": "profiles/instructions.md", "failureKind": agentsidecar.ConfigDependencyFailureMissing,
+	}
+	if !reflect.DeepEqual(got.Params, want) || got.Retryable {
+		t.Fatalf("params/retryable = %#v/%v, want %#v/false", got.Params, got.Retryable, want)
+	}
+}

--- a/services/tuttid/service/agentsidecar/codex.go
+++ b/services/tuttid/service/agentsidecar/codex.go
@@ -8,6 +8,8 @@ import (
 	"path/filepath"
 	"strconv"
 	"strings"
+
+	agentsidecarbiz "github.com/tutti-os/tutti/services/tuttid/biz/agentsidecar"
 )
 
 const (
@@ -23,7 +25,7 @@ func (CodexPreparer) Provider() string {
 func (CodexPreparer) Prepare(_ context.Context, input ProviderPrepareInput) (ProviderPrepareResult, error) {
 	codexHome := filepath.Join(input.RuntimeRoot, "codex-home")
 	logRuntimePrepareTrace("runtime_prepare.codex.entered", input.PrepareInput, nil)
-	if err := prepareCodexHome(codexHome, input.PrepareInput); err != nil {
+	if err := prepareCodexHome(codexHome, input.PrepareInput, input.Manifest); err != nil {
 		return ProviderPrepareResult{}, err
 	}
 	logRuntimePrepareTrace("runtime_prepare.codex.home_prepared", input.PrepareInput, nil)
@@ -49,14 +51,14 @@ func (CodexPreparer) Prepare(_ context.Context, input ProviderPrepareInput) (Pro
 	}, nil
 }
 
-func prepareCodexHome(codexHome string, input PrepareInput) error {
+func prepareCodexHome(codexHome string, input PrepareInput, manifest *agentsidecarbiz.Manifest) error {
 	logRuntimePrepareTrace("runtime_prepare.codex.home_dir_requested", input, nil)
 	if err := os.MkdirAll(codexHome, 0o700); err != nil {
 		return fmt.Errorf("create codex home: %w", err)
 	}
 	logRuntimePrepareTrace("runtime_prepare.codex.home_dir_resolved", input, nil)
 	logRuntimePrepareTrace("runtime_prepare.codex.user_files_requested", input, nil)
-	if err := exposeUserCodexFiles(codexHome); err != nil {
+	if err := exposeUserCodexFiles(codexHome, manifest); err != nil {
 		return err
 	}
 	logRuntimePrepareTrace("runtime_prepare.codex.user_files_resolved", input, nil)
@@ -108,7 +110,7 @@ func codexApprovalRules(cliCommand string) string {
 	return "prefix_rule(pattern=[" + strconv.Quote(command) + "], decision=\"allow\")\n"
 }
 
-func exposeUserCodexFiles(codexHome string) error {
+func exposeUserCodexFiles(codexHome string, manifest *agentsidecarbiz.Manifest) error {
 	userHome, err := os.UserHomeDir()
 	if err != nil || strings.TrimSpace(userHome) == "" {
 		return nil
@@ -135,7 +137,7 @@ func exposeUserCodexFiles(codexHome string) error {
 	if err := exposeUserCodexConfig(codexHome, userCodexHome); err != nil {
 		return err
 	}
-	return exposeUserCodexModelCatalog(codexHome, userCodexHome)
+	return exposeUserCodexConfigDependencies(codexHome, userCodexHome, manifest)
 }
 
 // exposeCodexImportedRolloutFile symlinks the single Codex CLI rollout
@@ -236,25 +238,40 @@ func exposeUserCodexConfig(codexHome string, userCodexHome string) error {
 	return nil
 }
 
-// exposeUserCodexModelCatalog mirrors a relative model_catalog_json path into
-// the run-scoped CODEX_HOME. Tutti copies config.toml alone; tools such as
-// CC Switch write model_catalog_json = "cc-switch-model-catalog.json", which
-// Codex resolves against CODEX_HOME. Without the catalog file, thread/start
-// fails with ENOENT and Tutti surfaces "agent session is not connected".
-//
-// Absolute catalog paths stay readable from the host filesystem and need no
-// mirror. Missing keys or missing source files are no-ops.
-func exposeUserCodexModelCatalog(codexHome string, userCodexHome string) error {
+// exposeUserCodexConfigDependencies preserves file references Codex resolves
+// relative to CODEX_HOME after Tutti copies config.toml into a run-scoped home.
+func exposeUserCodexConfigDependencies(codexHome string, userCodexHome string, manifest *agentsidecarbiz.Manifest) error {
 	configPath := filepath.Join(codexHome, "config.toml")
 	contentBytes, err := os.ReadFile(configPath)
 	if err != nil {
 		if os.IsNotExist(err) {
 			return nil
 		}
-		return fmt.Errorf("read codex config for model catalog path: %w", err)
+		return fmt.Errorf("read codex config dependencies: %w", err)
 	}
-	lines := strings.Split(strings.ReplaceAll(string(contentBytes), "\r\n", "\n"), "\n")
-	for _, line := range lines {
+	content := string(contentBytes)
+	for _, configKey := range []string{"model_catalog_json", "model_instructions_file"} {
+		value, found, valid := codexTopLevelStringConfigValue(content, configKey)
+		if !found {
+			continue
+		}
+		input := configDependencyMaterializeInput{
+			Provider: "codex", ConfigKey: configKey, RawPath: value,
+			SourceRoot: userCodexHome, TargetRoot: codexHome, Manifest: manifest,
+		}
+		if !valid {
+			return configDependencyError(input, "", ConfigDependencyFailureInvalid, nil)
+		}
+		if err := materializeConfigDependency(input); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func codexTopLevelStringConfigValue(content string, key string) (string, bool, bool) {
+	lines := strings.Split(strings.ReplaceAll(content, "\r\n", "\n"), "\n")
+	for index, line := range lines {
 		trimmed := strings.TrimSpace(line)
 		if trimmed == "" || strings.HasPrefix(trimmed, "#") {
 			continue
@@ -262,39 +279,13 @@ func exposeUserCodexModelCatalog(codexHome string, userCodexHome string) error {
 		if strings.HasPrefix(trimmed, "[") {
 			break
 		}
-		value, ok := codexConfigStringAssignmentValue(trimmed, "model_catalog_json")
-		if !ok {
+		if !codexConfigLineHasKey(trimmed, key) {
 			continue
 		}
-		value = strings.TrimSpace(value)
-		if value == "" || filepath.IsAbs(value) {
-			return nil
-		}
-		cleanRel := filepath.Clean(value)
-		if cleanRel == "." || cleanRel == ".." || strings.HasPrefix(cleanRel, ".."+string(filepath.Separator)) {
-			return nil
-		}
-		source := filepath.Join(userCodexHome, cleanRel)
-		if info, err := os.Stat(source); err != nil || info.IsDir() {
-			return nil
-		}
-		target := filepath.Join(codexHome, cleanRel)
-		if _, err := os.Lstat(target); err == nil {
-			return nil
-		} else if !os.IsNotExist(err) {
-			return fmt.Errorf("inspect codex model catalog: %w", err)
-		}
-		if err := os.MkdirAll(filepath.Dir(target), 0o700); err != nil {
-			return fmt.Errorf("create codex model catalog parent: %w", err)
-		}
-		if err := os.Symlink(source, target); err != nil {
-			if copyErr := copyFile(source, target, 0o600); copyErr != nil {
-				return fmt.Errorf("expose codex model catalog %s: symlink failed: %v; copy failed: %w", cleanRel, err, copyErr)
-			}
-		}
-		return nil
+		value, _, ok := codexConfigStringAssignmentValueAt(lines, index, key)
+		return value, true, ok
 	}
-	return nil
+	return "", false, false
 }
 
 func ensureCodexSessionConfig(configPath string, input PrepareInput) error {

--- a/services/tuttid/service/agentsidecar/config_dependency.go
+++ b/services/tuttid/service/agentsidecar/config_dependency.go
@@ -1,0 +1,182 @@
+package agentsidecar
+
+import (
+	"errors"
+	"fmt"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"strings"
+
+	agentsidecarbiz "github.com/tutti-os/tutti/services/tuttid/biz/agentsidecar"
+)
+
+const (
+	ConfigDependencyFailureInvalid           = "invalid"
+	ConfigDependencyFailureMissing           = "missing"
+	ConfigDependencyFailureMaterializeFailed = "materialize_failed"
+)
+
+type ConfigDependencyUnavailableError struct {
+	Provider       string
+	ConfigKey      string
+	DependencyPath string
+	FailureKind    string
+	cause          error
+}
+
+func (e *ConfigDependencyUnavailableError) Error() string {
+	if e == nil {
+		return ""
+	}
+	return fmt.Sprintf("%s configuration dependency %s is unavailable", strings.TrimSpace(e.Provider), strings.TrimSpace(e.ConfigKey))
+}
+
+func (e *ConfigDependencyUnavailableError) Unwrap() error {
+	if e == nil {
+		return nil
+	}
+	return e.cause
+}
+
+type configDependencyMaterializeInput struct {
+	Provider   string
+	ConfigKey  string
+	RawPath    string
+	SourceRoot string
+	TargetRoot string
+	Manifest   *agentsidecarbiz.Manifest
+}
+
+func materializeConfigDependency(input configDependencyMaterializeInput) error {
+	rawPath := strings.TrimSpace(input.RawPath)
+	if rawPath == "" || strings.ContainsAny(rawPath, "\x00\r\n") {
+		return configDependencyError(input, "", ConfigDependencyFailureInvalid, nil)
+	}
+	if filepath.IsAbs(rawPath) {
+		if err := validateConfigDependencyFile(rawPath); err != nil {
+			return configDependencyFileError(input, rawPath, err)
+		}
+		return nil
+	}
+	cleanPath := filepath.Clean(rawPath)
+	if cleanPath == "." || configDependencyPathHasTraversal(rawPath) {
+		return configDependencyError(input, filepath.Join(input.SourceRoot, cleanPath), ConfigDependencyFailureInvalid, nil)
+	}
+	sourcePath := filepath.Join(input.SourceRoot, cleanPath)
+	if err := validateConfigDependencyFile(sourcePath); err != nil {
+		return configDependencyFileError(input, sourcePath, err)
+	}
+	targetPath := filepath.Join(input.TargetRoot, cleanPath)
+	rel, err := filepath.Rel(input.TargetRoot, targetPath)
+	if err != nil || rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+		return configDependencyError(input, sourcePath, ConfigDependencyFailureInvalid, nil)
+	}
+	created, err := exposeConfigDependencyFile(sourcePath, targetPath)
+	if err != nil {
+		return configDependencyError(input, sourcePath, ConfigDependencyFailureMaterializeFailed, err)
+	}
+	if input.Manifest != nil {
+		input.Manifest.RecordManagedFile(targetPath, "provider-config-dependency", created)
+	}
+	return nil
+}
+
+func configDependencyPathHasTraversal(path string) bool {
+	for _, segment := range strings.Split(path, string(filepath.Separator)) {
+		if segment == "." || segment == ".." {
+			return true
+		}
+	}
+	return false
+}
+
+var errConfigDependencyNotRegular = errors.New("configuration dependency is not a regular file")
+
+func validateConfigDependencyFile(path string) error {
+	info, err := os.Stat(path)
+	if err != nil {
+		return err
+	}
+	if !info.Mode().IsRegular() {
+		return errConfigDependencyNotRegular
+	}
+	file, err := os.Open(path)
+	if err != nil {
+		return err
+	}
+	return file.Close()
+}
+
+func configDependencyFileError(input configDependencyMaterializeInput, sourcePath string, err error) error {
+	kind := ConfigDependencyFailureMaterializeFailed
+	if os.IsNotExist(err) {
+		kind = ConfigDependencyFailureMissing
+	} else if errors.Is(err, errConfigDependencyNotRegular) {
+		kind = ConfigDependencyFailureInvalid
+	}
+	return configDependencyError(input, sourcePath, kind, err)
+}
+
+func configDependencyError(input configDependencyMaterializeInput, sourcePath string, failureKind string, cause error) error {
+	err := &ConfigDependencyUnavailableError{
+		Provider:       strings.TrimSpace(input.Provider),
+		ConfigKey:      strings.TrimSpace(input.ConfigKey),
+		DependencyPath: safeConfigDependencyPath(input.RawPath),
+		FailureKind:    failureKind,
+		cause:          cause,
+	}
+	args := []any{"provider", err.Provider, "config_key", err.ConfigKey, "dependency_path", err.DependencyPath, "failure_kind", err.FailureKind}
+	if sourcePath != "" {
+		args = append(args, "source_path", sourcePath)
+	}
+	if cause != nil {
+		args = append(args, "error", cause)
+	}
+	slog.Error("agent configuration dependency unavailable", args...)
+	return err
+}
+
+func safeConfigDependencyPath(path string) string {
+	path = strings.TrimSpace(path)
+	if filepath.IsAbs(path) {
+		return filepath.Base(filepath.Clean(path))
+	}
+	return filepath.Clean(path)
+}
+
+func exposeConfigDependencyFile(source string, target string) (bool, error) {
+	if info, err := os.Lstat(target); err == nil {
+		if info.Mode()&os.ModeSymlink != 0 {
+			linkTarget, readErr := os.Readlink(target)
+			if readErr != nil {
+				return false, readErr
+			}
+			if !filepath.IsAbs(linkTarget) {
+				linkTarget = filepath.Join(filepath.Dir(target), linkTarget)
+			}
+			if filepath.Clean(linkTarget) == filepath.Clean(source) {
+				return false, nil
+			}
+			if err := os.Remove(target); err != nil {
+				return false, err
+			}
+		} else {
+			if err := validateConfigDependencyFile(target); err != nil {
+				return false, err
+			}
+			return false, nil
+		}
+	} else if !os.IsNotExist(err) {
+		return false, err
+	}
+	if err := os.MkdirAll(filepath.Dir(target), 0o700); err != nil {
+		return false, err
+	}
+	if err := os.Symlink(source, target); err != nil {
+		if copyErr := copyFile(source, target, 0o600); copyErr != nil {
+			return false, fmt.Errorf("symlink failed: %v; copy failed: %w", err, copyErr)
+		}
+	}
+	return true, nil
+}

--- a/services/tuttid/service/agentsidecar/preparer_test.go
+++ b/services/tuttid/service/agentsidecar/preparer_test.go
@@ -400,6 +400,33 @@ func TestDefaultPreparerCodexExposesRelativeModelCatalogJSON(t *testing.T) {
 	}
 }
 
+func TestDefaultPreparerCodexFailsForMissingModelInstructionsFile(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	userCodexHome := filepath.Join(home, ".codex")
+	if err := os.MkdirAll(userCodexHome, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(userCodexHome, "config.toml"), []byte(`model_instructions_file = "profiles/missing.md"`+"\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err := NewDefaultPreparer(t.TempDir()).Prepare(t.Context(), PrepareInput{
+		WorkspaceID:    "workspace-1",
+		AgentSessionID: "session-missing-instructions",
+		AgentTargetID:  "local:codex",
+		Provider:       "codex",
+		Cwd:            t.TempDir(),
+	})
+	var dependencyErr *ConfigDependencyUnavailableError
+	if !errors.As(err, &dependencyErr) {
+		t.Fatalf("Prepare() error = %T %v, want ConfigDependencyUnavailableError", err, err)
+	}
+	if dependencyErr.FailureKind != ConfigDependencyFailureMissing || dependencyErr.DependencyPath != filepath.Join("profiles", "missing.md") {
+		t.Fatalf("dependency error = %#v", dependencyErr)
+	}
+}
+
 func TestDefaultPreparerCodexUserSkillNameWinsBeforeTuttiInjection(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)


### PR DESCRIPTION
## Summary

Backport #1032 to `release/0704`.

Codex config entries such as `model_catalog_json` and `model_instructions_file` may be relative to the user's Codex home. The release branch now materializes those dependencies into the prepared runtime home, validates missing/traversal cases, preserves diagnostics without leaking host paths, and stops startup before execution when preparation fails. Turnless failures remain state-only and AgentGUI receives a localized actionable error.

## Validation

- `cd services/tuttid && go test ./...`
- `cd services/tuttid && go build ./...`
- `git diff --check`

The generated onboarding archive was restored locally for the builtin-app test; it is ignored and not part of this PR.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Backports Codex config dependency handling to `release/0704`. Relative Codex files are materialized and validated during preparation; failures stop startup and show a clear, localized GUI error.

- Materialize and validate `model_catalog_json` and `model_instructions_file` from the user’s Codex home into the prepared `CODEX_HOME` (checks traversal, non-regular, missing).
- Emit `ConfigDependencyUnavailableError` with safe paths; preparation aborts and does not leak host paths.
- Map to API reason `agent.config_dependency_unavailable` with params; OpenAPI example added; runtime adapter now returns start errors from result.Error.
- GUI parses the new error shape, shows a localized message (en, zh-CN), and includes dependency details in diagnostics.
- Runtime only emits visible error timeline items when a turn ID exists; startup failures are state-only.
- Tests added for API error classification and Codex preparation.

<sup>Written for commit fcbb26eb7d1cb634e47b8fac0a413e82b4047954. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tutti-os/tutti/pull/1033?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

