### PR TITLE
fix(agent): preserve goal continuation across response races

### DIFF
--- a/docs/conventions/testing.md
+++ b/docs/conventions/testing.md
@@ -50,6 +50,13 @@ Do not hide failures with retries as a substitute for stabilization.
 Direct changes to the agent daemon should still run the lane locally. Use a
 repeated focused run when changing asynchronous lifecycle behavior.
 
+For asynchronous runtime tests, prefer request/event channels and the session
+event sink over fixed-interval polling of mutex-protected slices. Wait for the
+specific protocol request or lifecycle event with a descriptive timeout so a
+failure identifies the missing transition. Protocol mocks should also cover
+valid response/notification reorderings; an RPC response must not be assumed to
+arrive before the notifications caused by that request.
+
 ## Output and Logs
 
 Root test runners execute independent lanes with bounded concurrency. Successful

--- a/docs/conventions/troubleshooting/agent-session-lifecycle.md
+++ b/docs/conventions/troubleshooting/agent-session-lifecycle.md
@@ -111,6 +111,38 @@ Turn state, loading, cancel, restore, rail projection, event updates, imports, a
   [codex_appserver_turn_machine.go](../../../packages/agent/daemon/runtime/codex_appserver_turn_machine.go)
   [codex_appserver_adapter_test.go](../../../packages/agent/daemon/runtime/codex_appserver_adapter_test.go)
 
+### Codex goal stops after a turn while the goal remains active
+
+- Symptom:
+  A `/goal` completes or fails one turn, remains `active`, but never starts a
+  continuation turn. The conversation looks idle even though the goal banner
+  still says it is running.
+- Quick checks:
+  Enable `TUTTI_TEST_LOGS=1` for a focused runtime reproduction and compare
+  `agent_session.app_server.goal.status_changed` with
+  `agent_session.app_server.goal.continuation_nudge`. If the first turn settles
+  before the initial `thread/goal/set` response records the active goal, an
+  eager scheduling check can return without ever creating the continuation
+  timer.
+- Root cause:
+  App-server notifications and the response for their triggering RPC do not
+  have a safe application-order guarantee. A `turn/completed` notification may
+  settle the first goal turn while `thread/goal/set` is still in flight, so
+  local goal state can still be empty when the settle path schedules its nudge.
+- Fix:
+  Always create the continuation grace timer for a settled goal-driven turn.
+  After the grace window, re-read both the active turn and goal state; send the
+  nudge only when no turn has continued and the goal is then `active`. Do not
+  gate timer creation on the immediate local goal snapshot.
+- Validation:
+  Keep a scripted protocol test that deliberately delivers goal turn
+  notifications before the `thread/goal/set` result, then verify the next turn
+  is adopted. Cover both a clean first turn and a failed mid-goal turn with
+  repeated focused runs; use event channels rather than polling shared slices.
+- References:
+  [codex_appserver_adapter.go](../../../packages/agent/daemon/runtime/codex_appserver_adapter.go)
+  [codex_appserver_adapter_test.go](../../../packages/agent/daemon/runtime/codex_appserver_adapter_test.go)
+
 ### Agent session stays loading after a completed turn
 
 - Symptom:

--- a/packages/agent/daemon/runtime/codex_appserver_adapter.go
+++ b/packages/agent/daemon/runtime/codex_appserver_adapter.go
@@ -2279,7 +2279,9 @@ func (a *CodexAppServerAdapter) adoptServerInitiatedTurn(session Session, provid
 // scheduleGoalContinuationNudge re-sends thread/goal/set {status: active}
 // when a goal turn settled but codex did not auto-start the next turn within
 // the grace window. It is a safety net: the primary continuation driver is
-// codex itself (whose turns are adopted on turn/started).
+// codex itself (whose turns are adopted on turn/started). Goal state is only
+// checked after the grace window because turn notifications can settle before
+// the in-flight thread/goal/set response records the goal as active locally.
 func (a *CodexAppServerAdapter) scheduleGoalContinuationNudge(session Session) {
 	agentSessionID := session.AgentSessionID
 	appSession := a.getSession(agentSessionID)
@@ -2288,9 +2290,6 @@ func (a *CodexAppServerAdapter) scheduleGoalContinuationNudge(session Session) {
 	}
 	client := appSession.client
 	threadID := appSession.threadID
-	if strings.TrimSpace(asString(a.sessionGoal(agentSessionID)["status"])) != "active" {
-		return
-	}
 	grace := a.goalContinuationGraceWindow
 	if grace <= 0 {
 		grace = defaultCodexAppServerGoalContinuationGraceWindow

--- a/packages/agent/daemon/runtime/codex_appserver_adapter_test.go
+++ b/packages/agent/daemon/runtime/codex_appserver_adapter_test.go
@@ -38,6 +38,11 @@ type scriptedAppServerTransport struct {
 	conn  *scriptedAppServerConnection
 }
 
+type scriptedAppServerRequest struct {
+	method string
+	params map[string]any
+}
+
 func newScriptedAppServerTransport() *scriptedAppServerTransport {
 	return &scriptedAppServerTransport{conn: newScriptedAppServerConnection()}
 }
@@ -45,6 +50,7 @@ func newScriptedAppServerTransport() *scriptedAppServerTransport {
 func newScriptedAppServerConnection() *scriptedAppServerConnection {
 	return &scriptedAppServerConnection{
 		recv:                     make(chan ProcessFrame, 128),
+		requests:                 make(chan scriptedAppServerRequest, 1024),
 		goalCompletionAfterTurns: 1,
 	}
 }
@@ -57,9 +63,10 @@ func (t *scriptedAppServerTransport) Start(_ context.Context, spec ProcessSpec) 
 }
 
 type scriptedAppServerConnection struct {
-	mu   sync.Mutex
-	sent [][]byte
-	recv chan ProcessFrame
+	mu       sync.Mutex
+	sent     [][]byte
+	recv     chan ProcessFrame
+	requests chan scriptedAppServerRequest
 
 	requiresAuth                 bool
 	collaborationModeUnsupported bool
@@ -88,6 +95,7 @@ type scriptedAppServerConnection struct {
 	approvalResponse             map[string]any
 	goal                         map[string]any
 	goalStartsTurn               bool
+	goalResponseAfterTurn        bool // deliver goal/set result after its turn notifications
 	goalTurnsStarted             int
 	goalCompletionAfterTurns     int
 	goalTurnFailAtTurn           int // goal-driven turn number (1-based) that settles as "failed" instead of "completed"
@@ -164,6 +172,10 @@ func (c *scriptedAppServerConnection) Send(data []byte) error {
 			Error  json.RawMessage `json:"error"`
 		}
 		_ = json.Unmarshal([]byte(line), &message)
+		c.requests <- scriptedAppServerRequest{
+			method: message.Method,
+			params: clonePayload(message.Params),
+		}
 		switch message.Method {
 		case appServerMethodInitialize:
 			c.sendJSON(map[string]any{
@@ -568,6 +580,7 @@ func (c *scriptedAppServerConnection) Send(data []byte) error {
 			c.mu.Lock()
 			previousGoal := clonePayload(c.goal)
 			goalStartsTurn := c.goalStartsTurn
+			goalResponseAfterTurn := c.goalResponseAfterTurn
 			goalTurnNumber := c.goalTurnsStarted
 			if goalStartsTurn && strings.TrimSpace(asString(message.Params["objective"])) != "" {
 				c.goalTurnsStarted++
@@ -594,10 +607,15 @@ func (c *scriptedAppServerConnection) Send(data []byte) error {
 			}
 			c.goal = clonePayload(goal)
 			c.mu.Unlock()
-			c.sendJSON(map[string]any{
-				"id":     message.ID,
-				"result": map[string]any{"goal": goal},
-			})
+			respond := func() {
+				c.sendJSON(map[string]any{
+					"id":     message.ID,
+					"result": map[string]any{"goal": goal},
+				})
+			}
+			if !goalResponseAfterTurn {
+				respond()
+			}
 			if goalStartsTurn && goalTurnNumber > 0 {
 				turnID := fmt.Sprintf("turn-goal-%d", goalTurnNumber)
 				itemID := fmt.Sprintf("item-goal-%d", goalTurnNumber)
@@ -626,21 +644,24 @@ func (c *scriptedAppServerConnection) Send(data []byte) error {
 							"error":  map[string]any{"message": "transient tool failure"},
 						},
 					})
-					continue
-				}
-				c.notify(appServerNotifyAgentMessageDelta, map[string]any{
-					"threadId": "codex-thread-1", "turnId": turnID, "itemId": itemID, "delta": messageText,
-				})
-				c.notify(appServerNotifyTurnCompleted, map[string]any{
-					"threadId": "codex-thread-1",
-					"turn": map[string]any{
-						"id":     turnID,
-						"status": "completed",
-						"items": []any{
-							map[string]any{"type": "agentMessage", "id": itemID, "text": messageText},
+				} else {
+					c.notify(appServerNotifyAgentMessageDelta, map[string]any{
+						"threadId": "codex-thread-1", "turnId": turnID, "itemId": itemID, "delta": messageText,
+					})
+					c.notify(appServerNotifyTurnCompleted, map[string]any{
+						"threadId": "codex-thread-1",
+						"turn": map[string]any{
+							"id":     turnID,
+							"status": "completed",
+							"items": []any{
+								map[string]any{"type": "agentMessage", "id": itemID, "text": messageText},
+							},
 						},
-					},
-				})
+					})
+				}
+			}
+			if goalResponseAfterTurn {
+				respond()
 			}
 		case appServerMethodThreadGoalGet:
 			c.mu.Lock()
@@ -781,6 +802,60 @@ func appServerRequestParams(t *testing.T, conn *scriptedAppServerConnection, met
 		t.Fatalf("missing app-server request method %q", method)
 	}
 	return requests[0]
+}
+
+func waitForAppServerRequests(
+	t *testing.T,
+	conn *scriptedAppServerConnection,
+	method string,
+	want int,
+) []map[string]any {
+	t.Helper()
+	timer := time.NewTimer(10 * time.Second)
+	defer timer.Stop()
+	requests := make([]map[string]any, 0, want)
+	for len(requests) < want {
+		select {
+		case request := <-conn.requests:
+			if request.method == method {
+				requests = append(requests, request.params)
+			}
+		case <-timer.C:
+			t.Fatalf("timed out waiting for %d %s requests; received %d", want, method, len(requests))
+		}
+	}
+	return requests
+}
+
+func captureSessionEvents(adapter *CodexAppServerAdapter) <-chan activityshared.Event {
+	events := make(chan activityshared.Event, 128)
+	adapter.SetSessionEventSink(func(_ string, emitted []activityshared.Event) {
+		for _, event := range emitted {
+			events <- event
+		}
+	})
+	return events
+}
+
+func waitForSessionEvent(
+	t *testing.T,
+	events <-chan activityshared.Event,
+	description string,
+	matches func(activityshared.Event) bool,
+) activityshared.Event {
+	t.Helper()
+	timer := time.NewTimer(10 * time.Second)
+	defer timer.Stop()
+	for {
+		select {
+		case event := <-events:
+			if matches(event) {
+				return event
+			}
+		case <-timer.C:
+			t.Fatalf("timed out waiting for %s", description)
+		}
+	}
 }
 
 func startedAppServerAdapter(t *testing.T) (*CodexAppServerAdapter, *scriptedAppServerTransport, Session) {
@@ -1813,8 +1888,6 @@ func TestCodexAppServerAdapterClientDeathSettlesTurn(t *testing.T) {
 }
 
 func TestCodexAppServerAdapterCancelInterruptsLinkedChildThreads(t *testing.T) {
-	t.Parallel()
-
 	adapter, transport, session := startedAppServerAdapter(t)
 	transport.conn.holdTurn = true
 	adapter.rememberAppServerChildThreads(session.AgentSessionID, "codex-thread-1", map[string]any{
@@ -1855,10 +1928,7 @@ func TestCodexAppServerAdapterCancelInterruptsLinkedChildThreads(t *testing.T) {
 			t.Fatalf("cancel child event turn id = %q, want turn-1", event.Payload.TurnID)
 		}
 	}
-	waitForCondition(t, func() bool {
-		return len(appServerRequestParamsList(t, transport.conn, appServerMethodTurnInterrupt)) == 3
-	})
-	requests := appServerRequestParamsList(t, transport.conn, appServerMethodTurnInterrupt)
+	requests := waitForAppServerRequests(t, transport.conn, appServerMethodTurnInterrupt, 3)
 	byThread := map[string]map[string]any{}
 	for _, request := range requests {
 		byThread[asString(request["threadId"])] = request
@@ -1878,8 +1948,6 @@ func TestCodexAppServerAdapterCancelInterruptsLinkedChildThreads(t *testing.T) {
 }
 
 func TestCodexAppServerAdapterCancelAfterTurnCompletedStillMarksChildrenCanceled(t *testing.T) {
-	t.Parallel()
-
 	adapter, transport, session := startedAppServerAdapter(t)
 	adapter.rememberAppServerChildThreads(session.AgentSessionID, "codex-thread-1", map[string]any{
 		"type":              "collabAgentToolCall",
@@ -2948,20 +3016,15 @@ func TestCodexAppServerAdapterSlashGoalSetsObjective(t *testing.T) {
 }
 
 func TestCodexAppServerAdapterSlashGoalContinuesUntilTerminalGoal(t *testing.T) {
-	t.Parallel()
-
 	adapter, transport, session := startedAppServerAdapter(t)
 	adapter.goalContinuationGraceWindow = 50 * time.Millisecond
 	transport.conn.goalStartsTurn = true
+	// Codex may settle the first turn before the goal/set RPC result is
+	// applied locally. Continuation scheduling must survive that ordering.
+	transport.conn.goalResponseAfterTurn = true
 	transport.conn.goalCompletionAfterTurns = 2
 
-	var sinkMu sync.Mutex
-	sinkEvents := []activityshared.Event{}
-	adapter.SetSessionEventSink(func(_ string, events []activityshared.Event) {
-		sinkMu.Lock()
-		defer sinkMu.Unlock()
-		sinkEvents = append(sinkEvents, events...)
-	})
+	sinkEvents := captureSessionEvents(adapter)
 
 	events, err := adapter.Exec(context.Background(), session, []PromptContentBlock{{
 		Type: "text", Text: "/goal finish the DrawingML pass",
@@ -2989,30 +3052,15 @@ func TestCodexAppServerAdapterSlashGoalContinuesUntilTerminalGoal(t *testing.T) 
 
 	// The continuation nudge re-sends goal/set; the mock then starts the
 	// second turn, which must be adopted and stream through the session sink.
-	deadline := time.Now().Add(5 * time.Second)
-	for {
-		sinkMu.Lock()
-		adoptedCompleted := ""
-		adoptedStarted := false
-		for _, event := range sinkEvents {
-			if event.Type == activityshared.EventTurnStarted && event.Payload.Metadata["goalContinuation"] == true {
-				adoptedStarted = true
-			}
-			if event.Type == activityshared.EventMessageAppended &&
-				event.Payload.Role == activityshared.MessageRoleAssistant &&
-				event.Payload.Metadata["streamState"] == messageStreamStateCompleted {
-				adoptedCompleted = event.Payload.Content
-			}
-		}
-		sinkMu.Unlock()
-		if adoptedStarted && adoptedCompleted == "Goal complete." {
-			break
-		}
-		if time.Now().After(deadline) {
-			t.Fatalf("adopted continuation turn did not complete; started=%v message=%q", adoptedStarted, adoptedCompleted)
-		}
-		time.Sleep(10 * time.Millisecond)
-	}
+	waitForSessionEvent(t, sinkEvents, "adopted goal continuation turn start", func(event activityshared.Event) bool {
+		return event.Type == activityshared.EventTurnStarted && event.Payload.Metadata["goalContinuation"] == true
+	})
+	waitForSessionEvent(t, sinkEvents, "adopted goal continuation completion", func(event activityshared.Event) bool {
+		return event.Type == activityshared.EventMessageAppended &&
+			event.Payload.Role == activityshared.MessageRoleAssistant &&
+			event.Payload.Metadata["streamState"] == messageStreamStateCompleted &&
+			event.Payload.Content == "Goal complete."
+	})
 
 	goalSets := appServerRequestParamsList(t, transport.conn, appServerMethodThreadGoalSet)
 	if len(goalSets) != 2 {
@@ -3032,21 +3080,13 @@ func TestCodexAppServerAdapterSlashGoalContinuesUntilTerminalGoal(t *testing.T) 
 // does on a clean completion, or the goal stops advancing for good with no
 // further signal ("goal 执行一半不动了").
 func TestCodexAppServerAdapterGoalContinuesAfterMidGoalTurnFailure(t *testing.T) {
-	t.Parallel()
-
 	adapter, transport, session := startedAppServerAdapter(t)
 	adapter.goalContinuationGraceWindow = 50 * time.Millisecond
 	transport.conn.goalStartsTurn = true
 	transport.conn.goalTurnFailAtTurn = 2
 	transport.conn.goalCompletionAfterTurns = 3
 
-	var sinkMu sync.Mutex
-	sinkEvents := []activityshared.Event{}
-	adapter.SetSessionEventSink(func(_ string, events []activityshared.Event) {
-		sinkMu.Lock()
-		defer sinkMu.Unlock()
-		sinkEvents = append(sinkEvents, events...)
-	})
+	sinkEvents := captureSessionEvents(adapter)
 
 	events, err := adapter.Exec(context.Background(), session, []PromptContentBlock{{
 		Type: "text", Text: "/goal finish the DrawingML pass",
@@ -3062,47 +3102,18 @@ func TestCodexAppServerAdapterGoalContinuesAfterMidGoalTurnFailure(t *testing.T)
 	// fix, finalizeSettledTurn only nudged on a clean completion, so this
 	// failed settle would never schedule a continuation and the goal would
 	// hang here forever.
-	deadline := time.Now().Add(5 * time.Second)
-	for {
-		sinkMu.Lock()
-		failedSeen := false
-		for _, event := range sinkEvents {
-			if event.Type == activityshared.EventTurnFailed {
-				failedSeen = true
-			}
-		}
-		sinkMu.Unlock()
-		if failedSeen {
-			break
-		}
-		if time.Now().After(deadline) {
-			t.Fatalf("adopted continuation turn did not settle failed")
-		}
-		time.Sleep(10 * time.Millisecond)
-	}
+	waitForSessionEvent(t, sinkEvents, "adopted continuation failure", func(event activityshared.Event) bool {
+		return event.Type == activityshared.EventTurnFailed
+	})
 
 	// The nudge must still fire after the failed settle and drive the goal to
 	// its third, successful turn.
-	deadline = time.Now().Add(5 * time.Second)
-	for {
-		sinkMu.Lock()
-		adoptedCompleted := ""
-		for _, event := range sinkEvents {
-			if event.Type == activityshared.EventMessageAppended &&
-				event.Payload.Role == activityshared.MessageRoleAssistant &&
-				event.Payload.Metadata["streamState"] == messageStreamStateCompleted {
-				adoptedCompleted = event.Payload.Content
-			}
-		}
-		sinkMu.Unlock()
-		if adoptedCompleted == "Goal complete." {
-			break
-		}
-		if time.Now().After(deadline) {
-			t.Fatalf("goal did not continue past the failed turn to completion")
-		}
-		time.Sleep(10 * time.Millisecond)
-	}
+	waitForSessionEvent(t, sinkEvents, "goal completion after failed turn", func(event activityshared.Event) bool {
+		return event.Type == activityshared.EventMessageAppended &&
+			event.Payload.Role == activityshared.MessageRoleAssistant &&
+			event.Payload.Metadata["streamState"] == messageStreamStateCompleted &&
+			event.Payload.Content == "Goal complete."
+	})
 
 	// initial /goal (turn 1) + nudge after turn 1 (turn 2, fails) + nudge
 	// after turn 2's failure (turn 3, completes the goal). The nudge

--- a/packages/agent/daemon/runtime/process_transport_test.go
+++ b/packages/agent/daemon/runtime/process_transport_test.go
@@ -10,6 +10,8 @@ import (
 	"time"
 )
 
+const localProcessTestTimeout = 10 * time.Second
+
 func TestLocalProcessTransportOutlivesStartContext(t *testing.T) {
 	catPath, err := exec.LookPath("cat")
 	if err != nil {
@@ -50,7 +52,7 @@ func TestLocalProcessTransportOutlivesStartContext(t *testing.T) {
 		}
 	case err := <-errs:
 		t.Fatalf("recv after start context cancel: %v", err)
-	case <-time.After(2 * time.Second):
+	case <-time.After(localProcessTestTimeout):
 		t.Fatal("timed out waiting for process stdout")
 	}
 }
@@ -106,7 +108,7 @@ func TestLocalProcessTransportCloseKillsProcessAfterGracefulShutdownFails(t *tes
 		if err != nil {
 			t.Fatalf("Close: %v", err)
 		}
-	case <-time.After(4 * time.Second):
+	case <-time.After(localProcessTestTimeout):
 		t.Fatal("Close did not force-kill process after graceful shutdown failed")
 	}
 	if elapsed := time.Since(startedAt); elapsed < 900*time.Millisecond {
@@ -151,7 +153,7 @@ func TestProcessStartEnvDiagnosticsSummarizesFinalPath(t *testing.T) {
 
 func receiveRuntimeStdoutFrame(t *testing.T, conn ProcessConnection) ProcessFrame {
 	t.Helper()
-	deadline := time.After(2 * time.Second)
+	deadline := time.After(localProcessTestTimeout)
 	for {
 		done := make(chan ProcessFrame, 1)
 		errs := make(chan error, 1)


### PR DESCRIPTION
## Summary

- preserve the goal continuation timer when a goal turn settles before the in-flight `thread/goal/set` response records the active goal locally
- replace polling-based app-server request and session-event assertions with event channels, and add deterministic response/notification reordering coverage
- give local subprocess tests a CI-safe deadline and document the reusable async testing and troubleshooting guidance

## Root cause

Codex app-server notifications can be applied before the RPC response that caused them. The first goal turn could therefore settle while the local goal snapshot was still empty. `scheduleGoalContinuationNudge` checked that snapshot before starting its grace timer, returned early, and left an otherwise active goal permanently idle.

The scheduler now always starts the grace timer for the settled goal-driven turn, then re-checks both active-turn ownership and the latest goal status after the grace window before sending a nudge.

## Validation

- `go test ./runtime -run 'TestCodexAppServerAdapter(SlashGoalContinuesUntilTerminalGoal|GoalContinuesAfterMidGoalTurnFailure)$' -count=50`
- five historically flaky Goal/Cancel/process cases together with `-count=50`
- focused Goal cases with `go test -race ... -count=10`
- `go test ./runtime -count=3`
- `pnpm test:go:agent-daemon`
- `pnpm check:changed`
- `pnpm check:full` (also passed from the pre-push hook)

## Documentation

- recorded the response/notification ordering trap in the agent session lifecycle troubleshooting guide
- documented channel-based async assertions and protocol reordering coverage in the testing convention


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes stalled goals by always starting the goal continuation grace timer on turn settle, then re-checking turn and goal state before nudging. Stabilizes async tests with event/request channels and adds deterministic response/notification reordering coverage, plus CI-safe timeouts and docs.

- **Bug Fixes**
  - Start the goal continuation timer unconditionally; after the grace window, nudge only if no turn continued and the goal is still active.
  - Handles Codex races where `turn/*` notifications arrive before the `thread/goal/set` response.

- **Refactors**
  - Replace polling in app-server tests with request/event channels and precise wait helpers; add ordering-coverage for goal continuation (clean and failed turns).
  - Add CI-safe timeouts for local subprocess tests; document the notification/response ordering trap and channel-based async testing.

<sup>Written for commit 091d076dbf455fa1e1ca9aa5df77daaf34dbb717. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tutti-os/tutti/pull/1035?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

