### PR TITLE
test(agent): promote daemon suite to blocking gate

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -222,15 +222,6 @@ jobs:
       - name: Run Go workspace tests
         run: pnpm test:go:prepared
 
-      - name: Run agent daemon tests (non-blocking)
-        id: agent-daemon-tests
-        continue-on-error: true
-        run: pnpm test:go:agent-daemon
-
-      - name: Report unstable agent daemon tests
-        if: steps.agent-daemon-tests.outcome == 'failure'
-        run: echo "::warning::Agent daemon tests remain non-blocking while known timing-sensitive cases are stabilized."
-
   go-lint:
     name: Go Lint
     runs-on: ubuntu-latest

--- a/docs/conventions/local-git-hooks.md
+++ b/docs/conventions/local-git-hooks.md
@@ -85,8 +85,9 @@ Rules:
 
 TypeScript package tests and Go workspace tests use discovery-based runners
 instead of root package/module whitelists. Successful runs print compact
-summaries; complete lane logs are stored under `.tmp/test-runs`. The current
-agent daemon test lane is intentionally non-blocking in pull-request CI and is
+summaries; complete lane logs are stored under `.tmp/test-runs`. Every `go.work`
+module, including `packages/agent/daemon`, participates in the blocking Go test
+gate. The focused agent daemon command and its stabilization expectations are
 documented in [Testing](./testing.md).
 
 For PR branches that often need rebasing or force-pushing, use

--- a/docs/conventions/testing.md
+++ b/docs/conventions/testing.md
@@ -58,6 +58,12 @@ failure identifies the missing transition. Protocol mocks should also cover
 valid response/notification reorderings; an RPC response must not be assumed to
 arrive before the notifications caused by that request.
 
+Protocol fixtures must answer every synchronous startup/capability probe they
+can receive. Return an empty supported result or an explicit method-not-found
+error for unsupported probes; never rely on the production RPC timeout as mock
+behavior, because one missing response can add tens of seconds to every test
+that starts the adapter.
+
 ## Output and Logs
 
 Root test runners execute independent lanes with bounded concurrency. Successful

--- a/docs/conventions/testing.md
+++ b/docs/conventions/testing.md
@@ -8,7 +8,7 @@ This document defines the repository-managed test discovery and gate policy.
 - `pnpm test:tools`: repository tool tests only
 - `pnpm test:go`: generate builtin app assets, then run the blocking Go workspace test set
 - `pnpm test:go:prepared`: run the blocking Go workspace test set when builtin app assets are already prepared
-- `pnpm test:go:agent-daemon`: run the currently non-blocking agent daemon lane
+- `pnpm test:go:agent-daemon`: run the blocking agent daemon module as a focused lane
 
 `pnpm check:full` prepares builtin app assets once, then uses the prepared Go
 lint and test entrypoints. This prevents concurrent validation lanes from
@@ -30,25 +30,26 @@ tests that exercise package release helpers remain tool-owned instead of being
 duplicated through a package-level test script.
 
 Go tests are discovered from the modules declared in `go.work`. The blocking
-lane includes every module except `packages/agent/daemon`; additions to
-`go.work` therefore join the root test gate without a second registry.
+lane includes every module, so additions to `go.work` join the root test gate
+without a second registry.
 
 Changed-aware validation must recognize every current `go.work` module so a Go
 file change selects the matching package lint and test lanes.
 
-## Agent Daemon Soft Gate
+## Agent Daemon Blocking Gate
 
-`packages/agent/daemon` remains an explicit soft gate while its runtime suite
-contains scheduler-sensitive asynchronous cases. Pull-request CI runs
-`pnpm test:go:agent-daemon` with non-blocking failure semantics and emits a
-workflow warning when it fails.
+`packages/agent/daemon` is part of the blocking Go workspace test set. A failure
+from this module fails `pnpm test:go`, `pnpm check:full`, the pre-push hook, and
+the pull-request Go Tests job. Use `pnpm test:go:agent-daemon` when iterating on
+the module without running the other Go workspace lanes.
 
-Promote this lane into the blocking Go set only after the timing-sensitive
-tests are event-driven or otherwise stable under repeated and concurrent runs.
-Do not hide failures with retries as a substitute for stabilization.
+The module was promoted after its known timing-sensitive cases were converted
+to event-driven synchronization and the full module passed repeated shuffled
+runs. Do not add retries to preserve a green gate; reproduce and stabilize a
+failing lifecycle transition instead.
 
-Direct changes to the agent daemon should still run the lane locally. Use a
-repeated focused run when changing asynchronous lifecycle behavior.
+Direct changes to the agent daemon should run the focused lane locally. Use a
+repeated shuffled run when changing asynchronous lifecycle behavior.
 
 For asynchronous runtime tests, prefer request/event channels and the session
 event sink over fixed-interval polling of mutex-protected slices. Wait for the

--- a/docs/conventions/troubleshooting/agent-session-lifecycle.md
+++ b/docs/conventions/troubleshooting/agent-session-lifecycle.md
@@ -159,6 +159,31 @@ Turn state, loading, cancel, restore, rail projection, event updates, imports, a
   [codex_appserver_adapter.go](../../../packages/agent/daemon/runtime/codex_appserver_adapter.go)
   [codex_appserver_adapter_test.go](../../../packages/agent/daemon/runtime/codex_appserver_adapter_test.go)
 
+### Codex goal reappears after pause, edit, or clear
+
+- Symptom:
+  A goal control succeeds, but the banner shortly returns to an older objective
+  or status; a cleared goal can reappear as paused.
+- Quick checks:
+  Compare the startup background `thread/goal/get` with later goal-control RPCs.
+  If the get began before the control and completed afterwards, inspect whether
+  its older snapshot was applied unconditionally.
+- Root cause:
+  Startup restores the persisted thread goal asynchronously. Its response can
+  race with newer user controls or provider goal notifications, so arrival
+  order is not a safe freshness signal.
+- Fix:
+  Version the session goal state. Capture the session identity and revision
+  before the startup fetch, and apply its result only when both are unchanged;
+  increment the revision on every update and clear.
+- Validation:
+  Capture a startup refresh guard, clear the goal, then attempt to apply the
+  older paused snapshot and verify it is rejected.
+- References:
+  [codex_appserver_adapter.go](../../../packages/agent/daemon/runtime/codex_appserver_adapter.go)
+  [codex_appserver_events.go](../../../packages/agent/daemon/runtime/codex_appserver_events.go)
+  [codex_appserver_adapter_test.go](../../../packages/agent/daemon/runtime/codex_appserver_adapter_test.go)
+
 ### Agent session stays loading after a completed turn
 
 - Symptom:

--- a/docs/conventions/troubleshooting/agent-session-lifecycle.md
+++ b/docs/conventions/troubleshooting/agent-session-lifecycle.md
@@ -44,23 +44,39 @@ Turn state, loading, cancel, restore, rail projection, event updates, imports, a
   Compare renderer state with `tuttid.log` submit traces. If `api.send.failed`
   reports `agent session already has an active turn` after a settled/available
   state patch, inspect whether the controller still has an in-memory `c.turns`
-  entry while the adapter lifecycle snapshot has already settled.
+  entry while the adapter lifecycle snapshot has already settled. For Codex
+  app-server sessions, also compare `turn/completed` notification timing with
+  the triggering `turn/start` RPC result; a stale provider turn id with no
+  active turn object indicates that the late result rebound an already-settled
+  slot.
 - Root cause:
   The controller's async turn registry is separate from adapter lifecycle
   projection. Async execution must clear `c.turns` when the owning adapter
   publishes a non-live `TurnLifecycleSnapshot`, even if the event type is not a
-  terminal `turn.completed`/`turn.failed` event.
+  terminal `turn.completed`/`turn.failed` event. The settled session and the
+  registry cleanup must also become visible together; storing `ready` first
+  leaves a follow-up rejection window. Separately, app-server notifications can
+  settle a turn before the `turn/start` response is applied, so binding that
+  response without checking turn identity can recreate a stale active id.
 - Fix:
   Treat same-turn non-live lifecycle snapshots as async turn completion, in
-  addition to terminal event types and steered prompt messages.
+  addition to terminal event types and steered prompt messages. Clear the
+  matching controller turn record before publishing/storing the terminal
+  session view. Bind a provider turn id only while the exact active-turn object
+  that issued the request still owns the adapter slot.
 - Validation:
   Add controller coverage where an async adapter emits only a settled lifecycle
   snapshot for the turn and no terminal event, then verify a follow-up `Exec`
-  no longer returns `ErrSessionActiveTurn`. Run
+  no longer returns `ErrSessionActiveTurn`. Also cover a terminal snapshot that
+  waits for an open call and assert `ready` is never observable with an active
+  controller turn. For Codex, deliver `turn/completed` before the `turn/start`
+  result and verify the late result cannot restore the provider turn id. Run
   `go test ./packages/agent/daemon/runtime`.
 - References:
   [controller.go](../../../packages/agent/daemon/runtime/controller.go)
   [controller_test.go](../../../packages/agent/daemon/runtime/controller_test.go)
+  [codex_appserver_adapter.go](../../../packages/agent/daemon/runtime/codex_appserver_adapter.go)
+  [codex_appserver_adapter_test.go](../../../packages/agent/daemon/runtime/codex_appserver_adapter_test.go)
 
 ### AgentGUI loading disappears before active turn settles
 

--- a/packages/agent/daemon/runtime/acp_scripted_transport_test.go
+++ b/packages/agent/daemon/runtime/acp_scripted_transport_test.go
@@ -369,6 +369,9 @@ func (c *scriptedACPConnection) handleAppServerMessage(line string, id json.RawM
 	case appServerMethodModelList:
 		c.sendJSON(map[string]any{"id": id, "result": map[string]any{"data": []any{}}})
 		return true
+	case appServerMethodCollaborationModeList:
+		c.sendJSON(map[string]any{"id": id, "result": map[string]any{"data": []any{}}})
+		return true
 	case appServerMethodRateLimitsRead:
 		c.sendJSON(map[string]any{"id": id, "result": map[string]any{"rateLimits": map[string]any{}}})
 		return true

--- a/packages/agent/daemon/runtime/codex_appserver_adapter.go
+++ b/packages/agent/daemon/runtime/codex_appserver_adapter.go
@@ -187,12 +187,16 @@ type codexAppServerSessionLock struct {
 }
 
 type codexAppServerSession struct {
-	client                 *codexAppServerClient
-	threadID               string
-	serverInfo             map[string]any
-	account                map[string]any
-	rateLimits             map[string]any
-	goal                   map[string]any
+	client     *codexAppServerClient
+	threadID   string
+	serverInfo map[string]any
+	account    map[string]any
+	rateLimits map[string]any
+	goal       map[string]any
+	// goalRevision prevents a slow startup thread/goal/get response from
+	// overwriting a newer user control or provider notification. Guarded by
+	// the adapter mutex and incremented on every local goal mutation.
+	goalRevision           uint64
 	startupModelsReady     bool
 	startupRateLimitsReady bool
 	// lifecycleSeq numbers the adapter's TurnLifecycle snapshots (ADR 0008):
@@ -1230,10 +1234,11 @@ func (a *CodexAppServerAdapter) refreshStartupMetadataAsync(
 		// The goal lives in codex's thread state; restore it after start or
 		// resume so the banner survives daemon restarts and adopted
 		// continuation turns find the goal status they gate on.
-		if appSession := a.getSession(agentSessionID); appSession != nil && appSession.client != nil {
+		if appSession, goalRevision := a.goalRefreshGuard(agentSessionID); appSession != nil && appSession.client != nil {
 			if goal := a.fetchGoal(ctx, appSession.client, appSession.threadID, trace); len(goal) > 0 {
-				a.applyGoalUpdate(agentSessionID, goal)
-				a.emitStartupMetadataRefreshEvent(session, agentSessionID)
+				if a.applyStartupGoalRefresh(agentSessionID, appSession, goalRevision, goal) {
+					a.emitStartupMetadataRefreshEvent(session, agentSessionID)
+				}
 			}
 		}
 	}()

--- a/packages/agent/daemon/runtime/codex_appserver_adapter.go
+++ b/packages/agent/daemon/runtime/codex_appserver_adapter.go
@@ -1719,7 +1719,7 @@ func (a *CodexAppServerAdapter) execBlocking(
 	// arrives with the turn/completed notification.
 	initialTurn := appServerTurnFromResult(result)
 	if providerTurnID := asString(initialTurn["id"]); providerTurnID != "" {
-		if a.setSessionActiveTurnID(session.AgentSessionID, providerTurnID) {
+		if a.setSessionActiveTurnID(session.AgentSessionID, appTurn, providerTurnID) {
 			a.interruptActiveTurnAsync(appSession, session, appTurn, providerTurnID, "queued cancel")
 		}
 	}
@@ -2122,7 +2122,7 @@ func (a *CodexAppServerAdapter) execSlashCommand(
 			// so goal progress never depends on this Exec staying alive.
 			initialTurn := appServerTurnFromResult(result)
 			if providerTurnID := asString(initialTurn["id"]); providerTurnID != "" {
-				if a.setSessionActiveTurnID(session.AgentSessionID, providerTurnID) {
+				if a.setSessionActiveTurnID(session.AgentSessionID, appTurn, providerTurnID) {
 					a.interruptActiveTurnAsync(appSession, session, appTurn, providerTurnID, "queued cancel")
 				}
 			}
@@ -2259,7 +2259,7 @@ func (a *CodexAppServerAdapter) adoptServerInitiatedTurn(session Session, provid
 		// A registered turn won the race; leave tracking to it.
 		return
 	}
-	a.setSessionActiveTurnID(session.AgentSessionID, providerTurnID)
+	a.setSessionActiveTurnID(session.AgentSessionID, appTurn, providerTurnID)
 	// The adopted id comes from the turn/started notification itself.
 	a.confirmSessionActiveTurnStarted(session.AgentSessionID, providerTurnID)
 	slog.Info("agent session app-server goal turn adopted",
@@ -3208,14 +3208,21 @@ func (a *CodexAppServerAdapter) requestActiveTurnCancel(agentSessionID string) (
 	return "", true
 }
 
-func (a *CodexAppServerAdapter) setSessionActiveTurnID(agentSessionID string, turnID string) bool {
+func (a *CodexAppServerAdapter) setSessionActiveTurnID(
+	agentSessionID string,
+	expectedTurn *codexAppServerActiveTurn,
+	turnID string,
+) bool {
 	if a == nil {
 		return false
 	}
 	a.mu.Lock()
 	defer a.mu.Unlock()
 	appSession := a.sessions[strings.TrimSpace(agentSessionID)]
-	if appSession != nil {
+	// A fast terminal notification can settle and clear this turn before the
+	// turn/start RPC result reaches its caller. Do not let that stale result
+	// rebind the provider id after the slot is already empty or reused.
+	if appSession != nil && appSession.activeTurn == expectedTurn {
 		appSession.activeTurnID = strings.TrimSpace(turnID)
 		// The binding starts unconfirmed; a matching turn/started notification
 		// confirms it via confirmSessionActiveTurnStarted.

--- a/packages/agent/daemon/runtime/codex_appserver_adapter_test.go
+++ b/packages/agent/daemon/runtime/codex_appserver_adapter_test.go
@@ -3605,6 +3605,28 @@ func TestControllerGoalControl(t *testing.T) {
 	transport.conn.completePendingTurn()
 }
 
+func TestCodexAppServerAdapterStaleStartupGoalRefreshDoesNotRestoreClearedGoal(t *testing.T) {
+	t.Parallel()
+
+	adapter, _, session := startedAppServerAdapter(t)
+	adapter.applyGoalUpdate(session.AgentSessionID, map[string]any{
+		"objective": "ship it",
+		"status":    "paused",
+	})
+	expectedSession, revision := adapter.goalRefreshGuard(session.AgentSessionID)
+	adapter.applyGoalClear(session.AgentSessionID)
+
+	if applied := adapter.applyStartupGoalRefresh(session.AgentSessionID, expectedSession, revision, map[string]any{
+		"objective": "ship it",
+		"status":    "paused",
+	}); applied {
+		t.Fatal("stale startup goal refresh applied after clear")
+	}
+	if goal := adapter.sessionGoal(session.AgentSessionID); len(goal) != 0 {
+		t.Fatalf("stale startup refresh restored goal: %#v", goal)
+	}
+}
+
 // thread/goal/updated notifications must reach the GUI as session events even
 // while no turn is running (the banner refreshes off this signal).
 func TestCodexAppServerAdapterGoalUpdateNotificationEmitsSessionEvent(t *testing.T) {

--- a/packages/agent/daemon/runtime/codex_appserver_adapter_test.go
+++ b/packages/agent/daemon/runtime/codex_appserver_adapter_test.go
@@ -75,6 +75,7 @@ type scriptedAppServerConnection struct {
 	turnStatus                   string // completed (default) | failed | interrupted
 	turnError                    map[string]any
 	holdTurn                     bool              // do not finish the turn until released
+	turnResponseAfterCompletion  bool              // deliver turn/start result after terminal notifications
 	steeredTurnStart             bool              // turn/start returns a queued stub turn (input steered into the running turn): no turn/started, no auto-completion
 	ignoreInterrupt              bool              // ack turn/interrupt but never complete the turn (wedged codex)
 	hangInterrupt                bool              // never even acknowledge the turn/interrupt RPC (fully wedged codex)
@@ -327,6 +328,7 @@ func (c *scriptedAppServerConnection) Send(data []byte) error {
 		case appServerMethodTurnStart:
 			c.mu.Lock()
 			hold := c.holdTurn
+			turnResponseAfterCompletion := c.turnResponseAfterCompletion
 			steered := c.steeredTurnStart
 			approval := c.commandApproval
 			userInput := c.userInputRequest
@@ -358,14 +360,20 @@ func (c *scriptedAppServerConnection) Send(data []byte) error {
 				})
 				continue
 			}
-			// Mirror the real app-server: the RPC responds immediately with
-			// the inProgress turn; output streams as notifications.
-			c.sendJSON(map[string]any{
-				"id": message.ID,
-				"result": map[string]any{
-					"turn": map[string]any{"id": "turn-1", "status": "inProgress", "items": []any{}},
-				},
-			})
+			respond := func() {
+				c.sendJSON(map[string]any{
+					"id": message.ID,
+					"result": map[string]any{
+						"turn": map[string]any{"id": "turn-1", "status": "inProgress", "items": []any{}},
+					},
+				})
+			}
+			// The real app-server normally responds immediately, but response
+			// dispatch and notifications can still be applied in either order.
+			delayTurnResponse := turnResponseAfterCompletion && !hold && !approval && !userInput
+			if !delayTurnResponse {
+				respond()
+			}
 			c.notify(appServerNotifyTurnStarted, map[string]any{
 				"threadId": "codex-thread-1",
 				"turn":     map[string]any{"id": "turn-1", "status": "inProgress", "items": []any{}},
@@ -501,6 +509,9 @@ func (c *scriptedAppServerConnection) Send(data []byte) error {
 				continue
 			}
 			c.completePendingTurn()
+			if delayTurnResponse {
+				respond()
+			}
 		case appServerMethodThreadRead:
 			c.mu.Lock()
 			nickname := c.childNicknames[asString(message.Params["threadId"])]
@@ -1642,15 +1653,19 @@ func TestCodexAppServerAdapterFetchesChildThreadNickname(t *testing.T) {
 	transport.conn.mu.Lock()
 	transport.conn.childNicknames = map[string]string{"child-thread-1": "Euclid"}
 	transport.conn.mu.Unlock()
-	var mu sync.Mutex
-	var markers []activityshared.Event
-	adapter.SetSessionEventSink(func(_ string, events []activityshared.Event) {
-		mu.Lock()
-		defer mu.Unlock()
-		markers = append(markers, events...)
-	})
-	adapter.setSessionActiveTurnID(session.AgentSessionID, "turn-1")
-
+	appTurn := &codexAppServerActiveTurn{
+		turnID:     "turn-1",
+		session:    session,
+		normalizer: newACPTurnNormalizer(),
+		terminal:   make(chan codexAppServerTurnTerminal, 1),
+		terminated: make(chan struct{}),
+	}
+	if !adapter.beginActiveTurn(session.AgentSessionID, appTurn) {
+		t.Fatal("beginActiveTurn failed")
+	}
+	defer adapter.endActiveTurn(session.AgentSessionID, appTurn)
+	adapter.setSessionActiveTurnID(session.AgentSessionID, appTurn, "turn-1")
+	markers := captureSessionEvents(adapter)
 	// Registering a child (parent collab item/started) must trigger an async
 	// thread/read: codex assigns spawned agents an agentNickname on the Thread
 	// object but never pushes it (no thread/name/updated for children).
@@ -1670,19 +1685,12 @@ func TestCodexAppServerAdapterFetchesChildThreadNickname(t *testing.T) {
 		}),
 	}, newACPTurnNormalizer(), nil)
 
-	waitForCondition(t, func() bool {
-		mu.Lock()
-		defer mu.Unlock()
-		for _, event := range markers {
-			if event.Payload.Metadata["messageKind"] == "subAgentName" &&
-				event.Payload.Metadata["subAgentName"] == "Euclid" &&
-				event.OwnerThreadID == "child-thread-1" &&
-				event.OwnerCallID == "spawn-child-1" &&
-				event.Payload.TurnID != "" {
-				return true
-			}
-		}
-		return false
+	waitForSessionEvent(t, markers, "child thread nickname marker", func(event activityshared.Event) bool {
+		return event.Payload.Metadata["messageKind"] == "subAgentName" &&
+			event.Payload.Metadata["subAgentName"] == "Euclid" &&
+			event.OwnerThreadID == "child-thread-1" &&
+			event.OwnerCallID == "spawn-child-1" &&
+			event.Payload.TurnID == "turn-1"
 	})
 }
 
@@ -1782,7 +1790,7 @@ func TestCodexAppServerAdapterDropsEmptyTerminalIDForBoundActiveTurn(t *testing.
 	if !adapter.beginActiveTurn(session.AgentSessionID, appTurn) {
 		t.Fatal("beginActiveTurn failed")
 	}
-	adapter.setSessionActiveTurnID(session.AgentSessionID, "turn-real")
+	adapter.setSessionActiveTurnID(session.AgentSessionID, appTurn, "turn-real")
 	adapter.confirmSessionActiveTurnStarted(session.AgentSessionID, "turn-real")
 
 	adapter.completeActiveTurn(session.AgentSessionID, map[string]any{"status": "completed"})
@@ -1815,7 +1823,7 @@ func TestCodexAppServerAdapterDropsEmptyTerminalIDForUnconfirmedActiveTurn(t *te
 	if !adapter.beginActiveTurn(session.AgentSessionID, appTurn) {
 		t.Fatal("beginActiveTurn failed")
 	}
-	adapter.setSessionActiveTurnID(session.AgentSessionID, "turn-steer-stub")
+	adapter.setSessionActiveTurnID(session.AgentSessionID, appTurn, "turn-steer-stub")
 
 	adapter.completeActiveTurn(session.AgentSessionID, map[string]any{"status": "completed"})
 
@@ -1836,7 +1844,12 @@ func TestCodexAppServerAdapterConfirmActiveTurnStartedScopedToBoundID(t *testing
 	t.Parallel()
 
 	adapter, _, session := startedAppServerAdapter(t)
-	adapter.setSessionActiveTurnID(session.AgentSessionID, "turn-bound")
+	appTurn := &codexAppServerActiveTurn{}
+	if !adapter.beginActiveTurn(session.AgentSessionID, appTurn) {
+		t.Fatal("beginActiveTurn failed")
+	}
+	defer adapter.endActiveTurn(session.AgentSessionID, appTurn)
+	adapter.setSessionActiveTurnID(session.AgentSessionID, appTurn, "turn-bound")
 
 	// A turn/started for a different turn (e.g. racing with a steered
 	// turn/start rebinding the id in between) must not confirm the current
@@ -1949,6 +1962,9 @@ func TestCodexAppServerAdapterCancelInterruptsLinkedChildThreads(t *testing.T) {
 
 func TestCodexAppServerAdapterCancelAfterTurnCompletedStillMarksChildrenCanceled(t *testing.T) {
 	adapter, transport, session := startedAppServerAdapter(t)
+	// A terminal notification may be applied before the turn/start RPC result.
+	// A stale result must not recreate the provider turn id after settle.
+	transport.conn.turnResponseAfterCompletion = true
 	adapter.rememberAppServerChildThreads(session.AgentSessionID, "codex-thread-1", map[string]any{
 		"type":              "collabAgentToolCall",
 		"id":                "spawn-child-1",
@@ -1962,9 +1978,6 @@ func TestCodexAppServerAdapterCancelAfterTurnCompletedStillMarksChildrenCanceled
 	}}, "", "turn-local-1", nil, nil); err != nil {
 		t.Fatalf("Exec: %v", err)
 	}
-	waitForCondition(t, func() bool {
-		return adapter.sessionActiveTurnID(session.AgentSessionID) == ""
-	})
 	if got := adapter.sessionActiveTurnID(session.AgentSessionID); got != "" {
 		t.Fatalf("active turn id after completion = %q, want empty", got)
 	}

--- a/packages/agent/daemon/runtime/codex_appserver_events.go
+++ b/packages/agent/daemon/runtime/codex_appserver_events.go
@@ -985,6 +985,7 @@ func (a *CodexAppServerAdapter) applyGoalUpdate(agentSessionID string, goal map[
 	}
 	oldStatus = strings.TrimSpace(asString(appSession.goal["status"]))
 	appSession.goal = clonePayload(goal)
+	appSession.goalRevision++
 	newStatus = strings.TrimSpace(asString(appSession.goal["status"]))
 	if oldStatus != newStatus {
 		slog.Info("agent session app-server goal status changed",
@@ -1012,6 +1013,50 @@ func (a *CodexAppServerAdapter) applyGoalClear(agentSessionID string) {
 		)
 	}
 	appSession.goal = nil
+	appSession.goalRevision++
+}
+
+func (a *CodexAppServerAdapter) goalRefreshGuard(agentSessionID string) (*codexAppServerSession, uint64) {
+	if a == nil {
+		return nil, 0
+	}
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	appSession := a.sessions[strings.TrimSpace(agentSessionID)]
+	if appSession == nil {
+		return nil, 0
+	}
+	return appSession, appSession.goalRevision
+}
+
+func (a *CodexAppServerAdapter) applyStartupGoalRefresh(
+	agentSessionID string,
+	expectedSession *codexAppServerSession,
+	expectedRevision uint64,
+	goal map[string]any,
+) bool {
+	if a == nil || expectedSession == nil || len(goal) == 0 {
+		return false
+	}
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	appSession := a.sessions[strings.TrimSpace(agentSessionID)]
+	if appSession != expectedSession || appSession.goalRevision != expectedRevision {
+		return false
+	}
+	oldStatus := strings.TrimSpace(asString(appSession.goal["status"]))
+	appSession.goal = clonePayload(goal)
+	appSession.goalRevision++
+	newStatus := strings.TrimSpace(asString(appSession.goal["status"]))
+	if oldStatus != newStatus {
+		slog.Info("agent session app-server goal status changed",
+			"event", "agent_session.app_server.goal.status_changed",
+			"agent_session_id", agentSessionID,
+			"old_status", oldStatus,
+			"new_status", newStatus,
+		)
+	}
+	return true
 }
 
 func appServerRateLimitQuotas(snapshot map[string]any) []map[string]any {

--- a/packages/agent/daemon/runtime/codex_appserver_reducer.go
+++ b/packages/agent/daemon/runtime/codex_appserver_reducer.go
@@ -75,7 +75,7 @@ func (r codexAppServerReducer) ReduceNotification(
 				if recorded := a.sessionActiveTurnID(session.AgentSessionID); recorded != "" && recorded != providerTurnID {
 					return codexAppServerReduction{}
 				}
-				if a.setSessionActiveTurnID(session.AgentSessionID, providerTurnID) {
+				if a.setSessionActiveTurnID(session.AgentSessionID, activeTurn, providerTurnID) {
 					a.interruptActiveTurnAsync(&codexAppServerSession{
 						client:   client,
 						threadID: firstNonEmpty(asString(params["threadId"]), session.ProviderSessionID),

--- a/packages/agent/daemon/runtime/codex_appserver_review.go
+++ b/packages/agent/daemon/runtime/codex_appserver_review.go
@@ -118,7 +118,7 @@ func (a *CodexAppServerAdapter) execReviewSlashCommand(
 	}
 	initialTurn := appServerTurnFromResult(result)
 	if providerTurnID := asString(initialTurn["id"]); providerTurnID != "" {
-		a.setSessionActiveTurnID(session.AgentSessionID, providerTurnID)
+		a.setSessionActiveTurnID(session.AgentSessionID, appTurn, providerTurnID)
 	}
 	finalTurn, finishErr := a.awaitTurnCompletion(ctx, appSession, appTurn, initialTurn)
 	if finishErr != nil {

--- a/packages/agent/daemon/runtime/controller.go
+++ b/packages/agent/daemon/runtime/controller.go
@@ -1233,13 +1233,13 @@ func (c *Controller) runAsyncExecTurn(ctx context.Context, session Session, adap
 	var mu sync.Mutex
 	finished := false
 	var emittedSummary agentSubmitRuntimeEventSummary
-	finish := func(next Session) {
+	finish := func(next Session) Session {
 		if finished {
-			return
+			return next
 		}
 		finished = true
 		emittedSummary.log("runtime.async_events_emitted.summary", next, turnID, metadata)
-		c.finishTurn(next, turnID)
+		return c.finishTurn(next, turnID)
 	}
 	emit := func(events []activityshared.Event) {
 		if len(events) == 0 {
@@ -1256,14 +1256,25 @@ func (c *Controller) runAsyncExecTurn(ctx context.Context, session Session, adap
 			session.UpdatedAtUnixMS = unixMS(now())
 		}
 		session = c.preserveCurrentSessionSettings(session)
-		c.store(session)
+		emittedSummary.observe(events, session)
+		terminal := turnHasTerminalEvent(events, turnID) ||
+			turnLifecycleSnapshotSettledTurn(events, turnID) ||
+			turnSteeredIntoActiveTurn(events, turnID)
+		finishBeforePublish := terminal && !sessionNeedsSettledTurnFallback(session, turnID)
+		if finishBeforePublish {
+			// Make the settled session and cleared turn registry visible as one
+			// transition. Otherwise a follow-up can observe status=ready while
+			// HasActiveTurn still rejects it.
+			session = finish(session)
+		} else {
+			c.store(session)
+		}
 		c.publish(session, events)
 		c.enqueueSessionReport(ctx, session, events)
-		emittedSummary.observe(events, session)
-		if turnHasTerminalEvent(events, turnID) ||
-			turnLifecycleSnapshotSettledTurn(events, turnID) ||
-			turnSteeredIntoActiveTurn(events, turnID) {
-			finish(session)
+		if terminal && !finishBeforePublish {
+			// Preserve the established event order when finishTurn must publish a
+			// controller-origin fallback snapshot after this adapter batch.
+			session = finish(session)
 		}
 	}
 	emitCommands := func(snapshot AgentSessionCommandSnapshot) {
@@ -2042,9 +2053,9 @@ func activityEventIdentity(event activityshared.Event) string {
 	)
 }
 
-func (c *Controller) finishTurn(session Session, turnID string) {
+func (c *Controller) finishTurn(session Session, turnID string) Session {
 	if c == nil {
-		return
+		return session
 	}
 	key := sessionKey(session.RoomID, session.AgentSessionID)
 	c.mu.Lock()
@@ -2053,7 +2064,7 @@ func (c *Controller) finishTurn(session Session, turnID string) {
 	}
 	if current, ok := c.sessions[key]; ok && sessionHasDifferentLiveTurn(current, turnID) {
 		c.mu.Unlock()
-		return
+		return current
 	}
 	session = c.preserveCurrentSessionSettingsLocked(key, session)
 	if session.LifecycleAuthority {
@@ -2062,21 +2073,30 @@ func (c *Controller) finishTurn(session Session, turnID string) {
 		// absorption, adapter death before settle) publish a controller-origin
 		// settled snapshot so even the fallback flows through the single copy
 		// pipeline — and reaches reporter/GUI, unlike the old silent write.
-		needsFallback := session.TurnLifecycle != nil &&
-			session.TurnLifecycle.ActiveTurnID != nil &&
-			strings.TrimSpace(*session.TurnLifecycle.ActiveTurnID) == strings.TrimSpace(turnID) &&
-			runtimeTurnLifecyclePhaseIsLive(session.TurnLifecycle.Phase)
+		needsFallback := sessionNeedsSettledTurnFallback(session, turnID)
 		c.sessions[key] = session
 		c.mu.Unlock()
 		if needsFallback {
 			c.applySessionEventsByAgentSessionID(session.AgentSessionID, settledFallbackTurnEvents(session, turnID))
+			if settled, ok := c.get(session.RoomID, session.AgentSessionID); ok {
+				return settled
+			}
 		}
-		return
+		return session
 	}
 	session = settleFinishedTurnLifecycle(session, turnID)
 	session = c.reconcileSessionStatusLocked(key, session)
 	c.sessions[key] = session
 	c.mu.Unlock()
+	return session
+}
+
+func sessionNeedsSettledTurnFallback(session Session, turnID string) bool {
+	return session.LifecycleAuthority &&
+		session.TurnLifecycle != nil &&
+		session.TurnLifecycle.ActiveTurnID != nil &&
+		strings.TrimSpace(*session.TurnLifecycle.ActiveTurnID) == strings.TrimSpace(turnID) &&
+		runtimeTurnLifecyclePhaseIsLive(session.TurnLifecycle.Phase)
 }
 
 // sessionViewHasUnsettledTurn reports whether the GUI-facing session view still

--- a/packages/agent/daemon/runtime/controller_test.go
+++ b/packages/agent/daemon/runtime/controller_test.go
@@ -4,6 +4,7 @@ package agentruntime
 import (
 	"context"
 	"errors"
+	"fmt"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -15,8 +16,9 @@ import (
 )
 
 type recordingReporter struct {
-	mu    sync.Mutex
-	calls []reportCall
+	mu      sync.Mutex
+	calls   []reportCall
+	updates chan struct{}
 }
 
 type reportCall struct {
@@ -35,6 +37,12 @@ func (r *recordingReporter) Report(_ context.Context, report agentsessionstore.R
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	r.calls = append(r.calls, reportCall{report: report})
+	if r.updates != nil {
+		select {
+		case r.updates <- struct{}{}:
+		default:
+		}
+	}
 	return nil
 }
 
@@ -46,16 +54,36 @@ func (r *recordingReporter) snapshot() []reportCall {
 
 func (r *recordingReporter) waitForCalls(t *testing.T, count int) []reportCall {
 	t.Helper()
-	deadline := time.Now().Add(2 * time.Second)
+	return r.waitForReports(t, fmt.Sprintf("at least %d report calls", count), func(calls []reportCall) bool {
+		return len(calls) >= count
+	})
+}
+
+func (r *recordingReporter) waitForReports(
+	t *testing.T,
+	description string,
+	matches func([]reportCall) bool,
+) []reportCall {
+	t.Helper()
+	timer := time.NewTimer(10 * time.Second)
+	defer timer.Stop()
 	for {
-		calls := r.snapshot()
-		if len(calls) >= count {
+		r.mu.Lock()
+		calls := append([]reportCall(nil), r.calls...)
+		if matches(calls) {
+			r.mu.Unlock()
 			return calls
 		}
-		if time.Now().After(deadline) {
-			t.Fatalf("report calls = %d, want at least %d", len(calls), count)
+		if r.updates == nil {
+			r.updates = make(chan struct{}, 1)
 		}
-		time.Sleep(10 * time.Millisecond)
+		updates := r.updates
+		r.mu.Unlock()
+		select {
+		case <-updates:
+		case <-timer.C:
+			t.Fatalf("timed out waiting for %s; report calls = %d", description, len(calls))
+		}
 	}
 }
 
@@ -768,11 +796,11 @@ func TestControllerStartExecCancelPublishesAndReports(t *testing.T) {
 	if cancelResult.Canceled {
 		t.Fatalf("Cancel result = %#v, want no active turn cancel", cancelResult)
 	}
-	reporter.waitForCalls(t, 2)
-	waitForCondition(t, func() bool {
-		return len(reportsWithTimelineItem(reportInputs(reporter.snapshot()), "message.assistant")) > 0
+	reportCalls := reporter.waitForReports(t, "assistant and turn completion reports", func(calls []reportCall) bool {
+		reports := reportInputs(calls)
+		return len(reportsWithTimelineItem(reports, "message.assistant")) > 0 &&
+			hasTurnCompletionPatchInReports(reports, execResult.TurnID)
 	})
-	reportCalls := reporter.snapshot()
 	if len(reportCalls[0].report.StatePatches) == 0 ||
 		reportCalls[0].report.StatePatches[0].LifecycleStatus != string(activityshared.SessionLifecycleStatusActive) {
 		t.Fatalf("first report = %#v, want session started state patch", reportCalls[0].report)

--- a/packages/agent/daemon/runtime/standard_acp_adapter_test.go
+++ b/packages/agent/daemon/runtime/standard_acp_adapter_test.go
@@ -1160,11 +1160,10 @@ func TestClaudeCodeAdapterPermissionRequestAcceptsInteractiveSelection(t *testin
 }
 
 func TestClaudeCodeAdapterExecTreatsContextCanceledAsInterrupted(t *testing.T) {
-	t.Parallel()
-
 	transport := newStandardACPTransport("Claude Agent", "claude-session-1")
 	gate := make(chan struct{})
 	transport.conn.pauseBeforeToolCallCompletion = gate
+	transport.conn.abortPromptAfterToolCallStart = true
 	adapter := NewClaudeCodeAdapter(transport)
 	session := standardTestSession(ProviderClaudeCode)
 	if _, err := adapter.Start(context.Background(), session); err != nil {
@@ -1175,21 +1174,42 @@ func TestClaudeCodeAdapterExecTreatsContextCanceledAsInterrupted(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	var releaseGate sync.Once
-	time.AfterFunc(200*time.Millisecond, func() {
-		releaseGate.Do(func() { close(gate) })
-	})
+	release := func() { releaseGate.Do(func() { close(gate) }) }
+	defer release()
 
 	var mu sync.Mutex
 	var emittedActivity []activityshared.Event
-	_, err := adapter.Exec(ctx, session, textPrompt("review workspace"), "", "turn-1", func(events []activityshared.Event) {
-		mu.Lock()
-		emittedActivity = append(emittedActivity, events...)
-		mu.Unlock()
-		if len(activityEventsWithType(events, activityshared.EventCallStarted)) > 0 {
-			cancel()
-			releaseGate.Do(func() { close(gate) })
-		}
-	}, nil)
+	callStarted := make(chan struct{}, 1)
+	execDone := make(chan error, 1)
+	go func() {
+		_, err := adapter.Exec(ctx, session, textPrompt("review workspace"), "", "turn-1", func(events []activityshared.Event) {
+			mu.Lock()
+			emittedActivity = append(emittedActivity, events...)
+			mu.Unlock()
+			if len(activityEventsWithType(events, activityshared.EventCallStarted)) > 0 {
+				select {
+				case callStarted <- struct{}{}:
+				default:
+				}
+			}
+		}, nil)
+		execDone <- err
+	}()
+
+	select {
+	case <-callStarted:
+		cancel()
+		release()
+	case <-time.After(10 * time.Second):
+		t.Fatal("timed out waiting for tool call start")
+	}
+
+	var err error
+	select {
+	case err = <-execDone:
+	case <-time.After(10 * time.Second):
+		t.Fatal("timed out waiting for canceled Exec")
+	}
 	if err != nil {
 		t.Fatalf("Exec: %v", err)
 	}
@@ -5161,6 +5181,7 @@ type standardACPConnection struct {
 	promptKind                    string
 	pauseBeforePromptResult       chan struct{}
 	pauseBeforeToolCallCompletion chan struct{}
+	abortPromptAfterToolCallStart bool
 	pendingPermissionCallID       json.RawMessage
 	selectedPermissionOption      string
 	selectedInteractiveResult     map[string]any
@@ -5527,6 +5548,9 @@ func (c *standardACPConnection) streamPromptResult(promptID json.RawMessage) {
 	}
 	if c.pauseBeforeToolCallCompletion != nil {
 		<-c.pauseBeforeToolCallCompletion
+	}
+	if c.abortPromptAfterToolCallStart {
+		return
 	}
 	c.sendJSON(map[string]any{
 		"jsonrpc": "2.0",

--- a/tools/scripts/run-go-tests.mjs
+++ b/tools/scripts/run-go-tests.mjs
@@ -10,10 +10,8 @@ const scriptDirectory = dirname(fileURLToPath(import.meta.url));
 const workspaceRoot = join(scriptDirectory, "..", "..");
 const agentDaemonModule = "packages/agent/daemon";
 const agentDaemonOnly = process.argv.includes("--agent-daemon-only");
-const moduleRoots = loadGoWorkspaceModuleRoots().filter((moduleRoot) =>
-  agentDaemonOnly
-    ? moduleRoot === agentDaemonModule
-    : moduleRoot !== agentDaemonModule
+const moduleRoots = loadGoWorkspaceModuleRoots().filter(
+  (moduleRoot) => !agentDaemonOnly || moduleRoot === agentDaemonModule
 );
 
 if (agentDaemonOnly && moduleRoots.length === 0) {


### PR DESCRIPTION
## Summary

- include every `go.work` module, including `packages/agent/daemon`, in the blocking Go workspace test runner
- remove the duplicate non-blocking agent-daemon PR step while keeping `pnpm test:go:agent-daemon` as a focused local command
- stabilize lifecycle orderings exposed by repeated shuffled and full-gate runs before promotion
- remove a hidden 30-second startup timeout from the shared app-server fixture

## Stabilization found during soak

- make the Claude context-cancel test event-driven so its mock stops after `tool_call started` instead of racing a synthetic `completed + end_turn` response against cancellation
- bind a Codex provider turn id only while the exact active-turn object that issued the request still owns the slot; a late `turn/start` result can no longer recreate an id after an earlier terminal notification settled the turn
- clear the controller turn registry before a settled/ready async session becomes externally visible, preventing the transient `ready` plus `HasActiveTurn=true` state that rejects immediate follow-up prompts
- version local goal state so a slow startup `thread/goal/get` response cannot restore an older paused goal after a newer resume, edit, or clear
- wait for asynchronous reporter output through event notifications instead of assuming session-ready means the report queue has drained

The Codex regression mock deterministically delivers `turn/completed` before the `turn/start` result, so the stale-result path is covered without relying on scheduler luck. Async nickname and reporter assertions use event channels instead of polling shared slices.

## Runtime test performance

The shared scripted app-server transport did not answer `collaborationMode/list`. Every controller test that started Codex waited for the real 30-second RPC timeout before gracefully downgrading.

After returning an immediate empty capability result:

- five affected Controller tests: 30.37s → 0.56s test time
- runtime single run: about 30.1s → 3.1s
- full Agent daemon shuffled `-count=5`: about 164s → 17.5s
- `pnpm check:changed`: about 33.6s → 4.0s for this change set

Protocol fixtures now explicitly document that startup/capability probes must receive a result or method-not-found response rather than relying on production timeouts.

## Gate behavior

`pnpm test:go`, `pnpm test:go:prepared`, `pnpm check:full`, pre-push, and the PR Go Tests job now fail when the agent daemon module fails. The root summary increased from 10 to 11 Go lanes.

## Validation

- focused lifecycle and goal-control cases with shuffled `-count=100`/`-count=200`
- focused lifecycle cases under `go test -race ... -count=20`
- full module: `go test ./... -shuffle=on -count=5`
- `pnpm test:go:prepared` → 11/11 lanes passed
- `pnpm check:changed` → 7 lanes passed in about 4s
- `pnpm check:full` → passed locally and again in pre-push, with 11 Go lanes

## Documentation

- promote the Agent Daemon section from soft to blocking in the testing convention
- document immediate responses for synchronous protocol probes
- align the local hook documentation with the all-`go.work` blocking gate
- record stale provider-id, ready/active-turn visibility, and stale startup-goal refresh traps in agent session lifecycle troubleshooting
