### PR TITLE
feat(agent): centralize workspace app integration

### DIFF
--- a/.github/workflows/sync-tutti-agent-skills.yml
+++ b/.github/workflows/sync-tutti-agent-skills.yml
@@ -64,11 +64,25 @@ jobs:
         id: changes
         working-directory: tutti-agent-skills
         run: |
+          versions_aligned="$(python3 - <<'PY'
+          import json
+          import pathlib
+
+          paths = [
+              pathlib.Path(".codex-plugin/plugin.json"),
+              pathlib.Path("plugins/tutti/.codex-plugin/plugin.json"),
+              pathlib.Path("plugins/tutti/.claude-plugin/plugin.json"),
+          ]
+          versions = [json.loads(path.read_text()).get("version") for path in paths]
+          print("true" if len(set(versions)) == 1 else "false")
+          PY
+          )"
           if git diff --quiet -- \
             skills/tutti-workspace-app-factory \
             skills/tutti-agent-workspace-app \
             plugins/tutti/skills/tutti-workspace-app-factory \
-            plugins/tutti/skills/tutti-agent-workspace-app; then
+            plugins/tutti/skills/tutti-agent-workspace-app \
+            && [[ "$versions_aligned" == "true" ]]; then
             echo "has_changes=false" >> "$GITHUB_OUTPUT"
           else
             echo "has_changes=true" >> "$GITHUB_OUTPUT"
@@ -92,13 +106,15 @@ jobs:
               parts[2] = str(int(parts[2]) + 1)
               return ".".join(parts)
 
-          for manifest_path in [
+          manifest_paths = [
               pathlib.Path(".codex-plugin/plugin.json"),
               pathlib.Path("plugins/tutti/.codex-plugin/plugin.json"),
-          ]:
+              pathlib.Path("plugins/tutti/.claude-plugin/plugin.json"),
+          ]
+          root_manifest = json.loads(manifest_paths[0].read_text())
+          next_version = bump_patch(root_manifest.get("version", "0.1.0"))
+          for manifest_path in manifest_paths:
               text = manifest_path.read_text()
-              manifest = json.loads(text)
-              next_version = bump_patch(manifest.get("version", "0.1.0"))
               text = re.sub(
                   r'("version"\s*:\s*")[^"]+(")',
                   rf"\g<1>{next_version}\2",
@@ -115,7 +131,7 @@ jobs:
           git diff --name-only > /tmp/tutti-agent-skills-changed-files.txt
           while IFS= read -r path; do
             case "$path" in
-              skills/tutti-workspace-app-factory/*|skills/tutti-workspace-app-factory/**|skills/tutti-agent-workspace-app/*|skills/tutti-agent-workspace-app/**|plugins/tutti/skills/tutti-workspace-app-factory/*|plugins/tutti/skills/tutti-workspace-app-factory/**|plugins/tutti/skills/tutti-agent-workspace-app/*|plugins/tutti/skills/tutti-agent-workspace-app/**|.codex-plugin/plugin.json|plugins/tutti/.codex-plugin/plugin.json)
+              skills/tutti-workspace-app-factory/*|skills/tutti-workspace-app-factory/**|skills/tutti-agent-workspace-app/*|skills/tutti-agent-workspace-app/**|plugins/tutti/skills/tutti-workspace-app-factory/*|plugins/tutti/skills/tutti-workspace-app-factory/**|plugins/tutti/skills/tutti-agent-workspace-app/*|plugins/tutti/skills/tutti-agent-workspace-app/**|.codex-plugin/plugin.json|plugins/tutti/.codex-plugin/plugin.json|plugins/tutti/.claude-plugin/plugin.json)
                 ;;
               *)
                 echo "Unexpected changed path: $path" >&2
@@ -139,6 +155,7 @@ jobs:
           python3 - <<'PY'
           import json
           import pathlib
+          import re
           import sys
 
           marketplace = json.loads(pathlib.Path(".agents/plugins/marketplace.json").read_text())
@@ -161,6 +178,24 @@ jobs:
               for skill_name in ["tutti-workspace-app-factory", "tutti-agent-workspace-app"]:
                   if not (root / f"skills/{skill_name}/SKILL.md").exists():
                       sys.exit(f"{root} is missing {skill_name}")
+
+          root_codex = json.loads(pathlib.Path(".codex-plugin/plugin.json").read_text())
+          plugin_codex = json.loads(pathlib.Path("plugins/tutti/.codex-plugin/plugin.json").read_text())
+          if root_codex.get("version") != plugin_codex.get("version"):
+              sys.exit("root and marketplace Codex plugin versions must match")
+
+          claude = json.loads(pathlib.Path("plugins/tutti/.claude-plugin/plugin.json").read_text())
+          if root_codex.get("version") != claude.get("version"):
+              sys.exit("Codex and Claude plugin versions must match")
+          if claude.get("name") != "tutti":
+              sys.exit("Claude plugin name must be tutti")
+          if claude.get("skills") != "./skills/":
+              sys.exit("Claude plugin skills path must be ./skills/")
+          if claude.get("hooks") != "./hooks/claude-hooks.json":
+              sys.exit("Claude plugin hooks path must be ./hooks/claude-hooks.json")
+          for label, manifest in (("Codex", root_codex), ("Claude", claude)):
+              if not re.fullmatch(r"\d+\.\d+\.\d+", str(manifest.get("version", ""))):
+                  sys.exit(f"{label} plugin version must be numeric semver")
           PY
 
       - name: Validate skill frontmatter
@@ -211,7 +246,8 @@ jobs:
             plugins/tutti/skills/tutti-workspace-app-factory \
             plugins/tutti/skills/tutti-agent-workspace-app \
             .codex-plugin/plugin.json \
-            plugins/tutti/.codex-plugin/plugin.json
+            plugins/tutti/.codex-plugin/plugin.json \
+            plugins/tutti/.claude-plugin/plugin.json
           git commit -m "Sync Tutti agent skills from Tutti main repository"
           git push "https://x-access-token:${TOKEN}@github.com/${SKILLS_REPO}.git" "$SYNC_BRANCH" --force
 

--- a/.github/workflows/sync-tutti-agent-skills.yml
+++ b/.github/workflows/sync-tutti-agent-skills.yml
@@ -67,6 +67,7 @@ jobs:
           versions_aligned="$(python3 - <<'PY'
           import json
           import pathlib
+          import re
 
           paths = [
               pathlib.Path(".codex-plugin/plugin.json"),
@@ -74,7 +75,8 @@ jobs:
               pathlib.Path("plugins/tutti/.claude-plugin/plugin.json"),
           ]
           versions = [json.loads(path.read_text()).get("version") for path in paths]
-          print("true" if len(set(versions)) == 1 else "false")
+          valid = all(re.fullmatch(r"\d+\.\d+\.\d+", str(version or "")) for version in versions)
+          print("true" if valid and len(set(versions)) == 1 else "false")
           PY
           )"
           if git diff --quiet -- \

--- a/docs/conventions/README.md
+++ b/docs/conventions/README.md
@@ -10,6 +10,7 @@ Current documents:
 - [Desktop Layering](./desktop-layering.md)
 - [Desktop Release](./desktop-release.md)
 - [Desktop Visual Language](./desktop-visual-language.md)
+- [Deprecated Workspace App Agent APIs](./deprecated-workspace-app-agent-apis.md)
 - [Local Git Hooks](./local-git-hooks.md)
 - [Local State Storage](./local-state-storage.md)
 - [Logging](./logging.md)

--- a/docs/conventions/deprecated-workspace-app-agent-apis.md
+++ b/docs/conventions/deprecated-workspace-app-agent-apis.md
@@ -17,7 +17,10 @@ response contracts until the removal gate below is satisfied.
 Every authenticated request that resolves to an installed app emits
 `deprecated_workspace_app_agent_api_used` with:
 
-- `route`: one of the three stable route identifiers above;
+- `route`: one of the stable telemetry identifiers `preferences/agent`,
+  `agent-providers/status`, or
+  `agent-providers/{provider}/composer-options` (these are suffix identifiers,
+  not the full HTTP route templates above);
 - `app_id`: the installed app package id, used to identify the migration owner;
 - `workspace_app_version`: the installed workspace app package version (or
   `unknown` for a legacy package without version metadata);

--- a/docs/conventions/deprecated-workspace-app-agent-apis.md
+++ b/docs/conventions/deprecated-workspace-app-agent-apis.md
@@ -1,0 +1,51 @@
+# Deprecated Workspace App Agent APIs
+
+Three workspace-app-scoped Agent HTTP routes remain as compatibility aliases
+while apps migrate to `@tutti-os/agent-acp-kit/tutti` and the Tutti CLI facade:
+
+| Route                                                                                        | Replacement                       |
+| -------------------------------------------------------------------------------------------- | --------------------------------- |
+| `GET /v1/workspaces/{workspaceID}/apps/{appID}/preferences/agent`                            | `loadTuttiAgentProviderCatalog()` |
+| `GET /v1/workspaces/{workspaceID}/apps/{appID}/agent-providers/status`                       | `loadTuttiAgentProviderCatalog()` |
+| `POST /v1/workspaces/{workspaceID}/apps/{appID}/agent-providers/{provider}/composer-options` | `loadTuttiAgentComposerOptions()` |
+
+Do not add new consumers. The compatibility routes keep their current auth and
+response contracts until the removal gate below is satisfied.
+
+## Usage telemetry
+
+Every authenticated request that resolves to an installed app emits
+`deprecated_workspace_app_agent_api_used` with:
+
+- `route`: one of the three stable route identifiers above;
+- `app_id`: the installed app package id, used to identify the migration owner;
+- `workspace_app_version`: the installed workspace app package version (or
+  `unknown` for a legacy package without version metadata);
+- `migration_target`: `agent-acp-kit-tutti-cli-facade`.
+
+The reporter's normal `app_version` dimension is the Tutti daemon version, not
+the workspace app package version. It also adds OS, device, and
+analytics-session dimensions. Never add workspace ids, credentials, cwd values,
+request bodies, provider selections, or other run data to this event.
+
+Release owners must review a rolling 30-day production count grouped by
+`route`, `app_id`, and `workspace_app_version`. A missing dashboard or disabled
+telemetry is unknown usage, not zero usage.
+
+## Removal gate
+
+The tracking milestone is `workspace-app-agent-http-removal`. The routes may be
+removed in the first breaking daemon API release on or after **2026-09-01** only
+when all of these conditions are recorded in that release's tracking issue:
+
+1. `@tutti-os/agent-acp-kit/tutti` has shipped in at least two consecutive
+   stable Tutti releases.
+2. Each route has zero production events for 30 consecutive days across all
+   supported stable app versions.
+3. Repository and organization-wide searches find no route consumers; every
+   previously observed `app_id` has migrated or has an approved retirement.
+4. The OpenAPI operations, generated handlers, route registrations, tests, and
+   this document are removed together.
+
+Any observed event resets the 30-day zero-usage window for that route. Until
+all four gates pass, retain the routes and continue emitting telemetry.

--- a/packages/clients/tuttid-ts/src/generated/sdk.gen.ts
+++ b/packages/clients/tuttid-ts/src/generated/sdk.gen.ts
@@ -1120,7 +1120,7 @@ export const reloadLocalWorkspaceApp = <ThrowOnError extends boolean = false>(
 /**
  * Get workspace-app agent preference projection
  *
- * Read-only subset of desktop agent preferences for one workspace app runtime. Intended for workspace app server tokens; exposes default provider selection and developer-gated provider visibility only. Deprecated for Agent integrations: use `tutti --json agent providers` through `@tutti-os/agent-acp-kit/tutti`. This compatibility route remains available for one stable release window.
+ * Read-only subset of desktop agent preferences for one workspace app runtime. Intended for workspace app server tokens; exposes default provider selection and developer-gated provider visibility only. Deprecated for Agent integrations: use `tutti --json agent providers` through `@tutti-os/agent-acp-kit/tutti`. Removal is gated by the production-usage telemetry and release criteria in `docs/conventions/deprecated-workspace-app-agent-apis.md`.
  *
  *
  * @deprecated
@@ -1143,7 +1143,7 @@ export const getWorkspaceAppAgentPreferences = <
 /**
  * Get agent provider availability for one workspace app
  *
- * Workspace-app scoped alias of `GET /v1/agent-providers/status` for app server tokens. When `providers` is omitted, returns provider statuses for enabled daemon-owned Agent Targets visible to Agent GUI. When `providers` is supplied, it narrows that Agent Target set and cannot expose providers outside it. Deprecated for Agent integrations: use `tutti --json agent providers` through `@tutti-os/agent-acp-kit/tutti`. This compatibility route remains available for one stable release window.
+ * Workspace-app scoped alias of `GET /v1/agent-providers/status` for app server tokens. When `providers` is omitted, returns provider statuses for enabled daemon-owned Agent Targets visible to Agent GUI. When `providers` is supplied, it narrows that Agent Target set and cannot expose providers outside it. Deprecated for Agent integrations: use `tutti --json agent providers` through `@tutti-os/agent-acp-kit/tutti`. Removal is gated by the production-usage telemetry and release criteria in `docs/conventions/deprecated-workspace-app-agent-apis.md`.
  *
  *
  * @deprecated
@@ -1166,7 +1166,7 @@ export const getWorkspaceAppAgentProviderStatuses = <
 /**
  * Get agent provider composer options for one workspace app
  *
- * Workspace-app scoped alias of `POST /v1/agent-providers/{provider}/composer-options` for app server tokens. Deprecated for Agent integrations: use `tutti --json agent composer-options --provider <providerId>` through `@tutti-os/agent-acp-kit/tutti`. This compatibility route remains available for one stable release window.
+ * Workspace-app scoped alias of `POST /v1/agent-providers/{provider}/composer-options` for app server tokens. Deprecated for Agent integrations: use `tutti --json agent composer-options --provider <providerId>` through `@tutti-os/agent-acp-kit/tutti`. Removal is gated by the production-usage telemetry and release criteria in `docs/conventions/deprecated-workspace-app-agent-apis.md`.
  *
  *
  * @deprecated

--- a/services/tuttid/api/daemon_workspace_app_agent.go
+++ b/services/tuttid/api/daemon_workspace_app_agent.go
@@ -22,9 +22,11 @@ func (api DaemonAPI) GetWorkspaceAppAgentPreferences(
 			InvalidRequestErrorJSONResponse: *errResponse,
 		}, nil
 	}
-	if err := api.ensureWorkspaceAppInstalled(ctx, workspaceID, appID); err != nil {
+	workspaceAppVersion, err := api.ensureWorkspaceAppInstalled(ctx, workspaceID, appID)
+	if err != nil {
 		return writeGetWorkspaceAppAgentPreferencesError(err), nil
 	}
+	api.trackDeprecatedWorkspaceAppAgentAPI(ctx, "preferences/agent", appID, workspaceAppVersion)
 	if api.PreferencesService == nil {
 		return tuttigenerated.GetWorkspaceAppAgentPreferences503JSONResponse{
 			ServiceUnavailableErrorJSONResponse: serviceUnavailableError(
@@ -61,9 +63,11 @@ func (api DaemonAPI) GetWorkspaceAppAgentProviderStatuses(
 			InvalidRequestErrorJSONResponse: *errResponse,
 		}, nil
 	}
-	if err := api.ensureWorkspaceAppInstalled(ctx, workspaceID, appID); err != nil {
+	workspaceAppVersion, err := api.ensureWorkspaceAppInstalled(ctx, workspaceID, appID)
+	if err != nil {
 		return writeGetWorkspaceAppAgentProviderStatusesError(err), nil
 	}
+	api.trackDeprecatedWorkspaceAppAgentAPI(ctx, "agent-providers/status", appID, workspaceAppVersion)
 
 	providers, err := api.workspaceAppAgentStatusProviders(ctx, request.Params.Providers)
 	if err != nil {
@@ -151,9 +155,11 @@ func (api DaemonAPI) GetWorkspaceAppAgentProviderComposerOptions(
 			InvalidRequestErrorJSONResponse: *errResponse,
 		}, nil
 	}
-	if err := api.ensureWorkspaceAppInstalled(ctx, workspaceID, appID); err != nil {
+	workspaceAppVersion, err := api.ensureWorkspaceAppInstalled(ctx, workspaceID, appID)
+	if err != nil {
 		return writeGetWorkspaceAppAgentProviderComposerOptionsError(err), nil
 	}
+	api.trackDeprecatedWorkspaceAppAgentAPI(ctx, "agent-providers/{provider}/composer-options", appID, workspaceAppVersion)
 	requestedProviders := []tuttigenerated.WorkspaceAgentProvider{request.Provider}
 	visibleProviders, err := api.workspaceAppAgentStatusProviders(ctx, &requestedProviders)
 	if err != nil {
@@ -186,23 +192,23 @@ func (api DaemonAPI) GetWorkspaceAppAgentProviderComposerOptions(
 	return mapGetAgentProviderComposerOptionsToWorkspaceApp(response), nil
 }
 
-func (api DaemonAPI) ensureWorkspaceAppInstalled(ctx context.Context, workspaceID string, appID string) error {
+func (api DaemonAPI) ensureWorkspaceAppInstalled(ctx context.Context, workspaceID string, appID string) (string, error) {
 	if api.AppCenterService == nil {
-		return apierrors.ServiceUnavailable(
+		return "", apierrors.ServiceUnavailable(
 			"workspace_app_service_unavailable",
 			apierrors.WithDeveloperMessage("workspace app service is unavailable"),
 		)
 	}
 	apps, err := api.AppCenterService.List(ctx, workspaceID)
 	if err != nil {
-		return err
+		return "", err
 	}
 	for _, app := range apps {
 		if app.Package.AppID == appID && app.Installation != nil {
-			return nil
+			return app.Package.Version, nil
 		}
 	}
-	return workspacedata.ErrWorkspaceAppNotFound
+	return "", workspacedata.ErrWorkspaceAppNotFound
 }
 
 func writeGetWorkspaceAppAgentPreferencesError(err error) tuttigenerated.GetWorkspaceAppAgentPreferencesResponseObject {

--- a/services/tuttid/api/daemon_workspace_app_agent_deprecation.go
+++ b/services/tuttid/api/daemon_workspace_app_agent_deprecation.go
@@ -3,9 +3,8 @@ package api
 import (
 	"context"
 	"strings"
-	"time"
 
-	reporterservice "github.com/tutti-os/tutti/services/tuttid/service/reporter"
+	reporterevents "github.com/tutti-os/tutti/services/tuttid/service/reporter/events"
 )
 
 const deprecatedWorkspaceAppAgentAPIUsedEvent = "deprecated_workspace_app_agent_api_used"
@@ -16,9 +15,6 @@ func (api DaemonAPI) trackDeprecatedWorkspaceAppAgentAPI(
 	appID string,
 	workspaceAppVersion string,
 ) {
-	if api.AnalyticsReporter == nil {
-		return
-	}
 	route = strings.TrimSpace(route)
 	appID = strings.TrimSpace(appID)
 	workspaceAppVersion = strings.TrimSpace(workspaceAppVersion)
@@ -28,14 +24,10 @@ func (api DaemonAPI) trackDeprecatedWorkspaceAppAgentAPI(
 	if workspaceAppVersion == "" {
 		workspaceAppVersion = "unknown"
 	}
-	api.AnalyticsReporter.Track(ctx, reporterservice.Event{
-		Name:     deprecatedWorkspaceAppAgentAPIUsedEvent,
-		ClientTS: time.Now().UnixMilli(),
-		Params: map[string]any{
-			"app_id":                appID,
-			"migration_target":      "agent-acp-kit-tutti-cli-facade",
-			"route":                 route,
-			"workspace_app_version": workspaceAppVersion,
-		},
+	reporterevents.Track(ctx, api.AnalyticsReporter, deprecatedWorkspaceAppAgentAPIUsedEvent, map[string]any{
+		"app_id":                appID,
+		"migration_target":      "agent-acp-kit-tutti-cli-facade",
+		"route":                 route,
+		"workspace_app_version": workspaceAppVersion,
 	})
 }

--- a/services/tuttid/api/daemon_workspace_app_agent_deprecation.go
+++ b/services/tuttid/api/daemon_workspace_app_agent_deprecation.go
@@ -1,0 +1,41 @@
+package api
+
+import (
+	"context"
+	"strings"
+	"time"
+
+	reporterservice "github.com/tutti-os/tutti/services/tuttid/service/reporter"
+)
+
+const deprecatedWorkspaceAppAgentAPIUsedEvent = "deprecated_workspace_app_agent_api_used"
+
+func (api DaemonAPI) trackDeprecatedWorkspaceAppAgentAPI(
+	ctx context.Context,
+	route string,
+	appID string,
+	workspaceAppVersion string,
+) {
+	if api.AnalyticsReporter == nil {
+		return
+	}
+	route = strings.TrimSpace(route)
+	appID = strings.TrimSpace(appID)
+	workspaceAppVersion = strings.TrimSpace(workspaceAppVersion)
+	if route == "" || appID == "" {
+		return
+	}
+	if workspaceAppVersion == "" {
+		workspaceAppVersion = "unknown"
+	}
+	api.AnalyticsReporter.Track(ctx, reporterservice.Event{
+		Name:     deprecatedWorkspaceAppAgentAPIUsedEvent,
+		ClientTS: time.Now().UnixMilli(),
+		Params: map[string]any{
+			"app_id":                appID,
+			"migration_target":      "agent-acp-kit-tutti-cli-facade",
+			"route":                 route,
+			"workspace_app_version": workspaceAppVersion,
+		},
+	})
+}

--- a/services/tuttid/api/daemon_workspace_app_agent_deprecation_test.go
+++ b/services/tuttid/api/daemon_workspace_app_agent_deprecation_test.go
@@ -1,0 +1,92 @@
+package api
+
+import (
+	"context"
+	"testing"
+
+	tuttigenerated "github.com/tutti-os/tutti/services/tuttid/api/generated"
+)
+
+func TestTrackDeprecatedWorkspaceAppAgentAPIRecordsMigrationDimensions(t *testing.T) {
+	reporter := &recordingAnalyticsReporter{}
+	api := DaemonAPI{AnalyticsReporter: reporter}
+
+	api.trackDeprecatedWorkspaceAppAgentAPI(
+		context.Background(),
+		"agent-providers/status",
+		"canvas",
+		"0.1.0",
+	)
+
+	if len(reporter.events) != 1 {
+		t.Fatalf("events = %#v, want one", reporter.events)
+	}
+	event := reporter.events[0]
+	if event.Name != deprecatedWorkspaceAppAgentAPIUsedEvent {
+		t.Fatalf("event name = %q", event.Name)
+	}
+	if event.Params["route"] != "agent-providers/status" ||
+		event.Params["app_id"] != "canvas" ||
+		event.Params["workspace_app_version"] != "0.1.0" ||
+		event.Params["migration_target"] != "agent-acp-kit-tutti-cli-facade" {
+		t.Fatalf("event params = %#v", event.Params)
+	}
+	for _, forbidden := range []string{"workspace_id", "provider", "cwd", "credential"} {
+		if _, ok := event.Params[forbidden]; ok {
+			t.Fatalf("event contains forbidden %q: %#v", forbidden, event.Params)
+		}
+	}
+}
+
+func TestTrackDeprecatedWorkspaceAppAgentAPIIgnoresIncompleteDimensions(t *testing.T) {
+	reporter := &recordingAnalyticsReporter{}
+	api := DaemonAPI{AnalyticsReporter: reporter}
+
+	api.trackDeprecatedWorkspaceAppAgentAPI(context.Background(), "", "canvas", "0.1.0")
+	api.trackDeprecatedWorkspaceAppAgentAPI(context.Background(), "preferences/agent", "", "0.1.0")
+
+	if len(reporter.events) != 0 {
+		t.Fatalf("events = %#v, want none", reporter.events)
+	}
+}
+
+func TestDeprecatedWorkspaceAppAgentHandlersEmitUsageAfterAppValidation(t *testing.T) {
+	reporter := &recordingAnalyticsReporter{}
+	api := DaemonAPI{
+		AnalyticsReporter: reporter,
+		AppCenterService:  installedWorkspaceAppCenter("canvas"),
+	}
+	ctx := context.Background()
+
+	_, _ = api.GetWorkspaceAppAgentPreferences(ctx, tuttigenerated.GetWorkspaceAppAgentPreferencesRequestObject{
+		WorkspaceID: "ws-1",
+		AppID:       "canvas",
+	})
+	_, _ = api.GetWorkspaceAppAgentProviderStatuses(ctx, tuttigenerated.GetWorkspaceAppAgentProviderStatusesRequestObject{
+		WorkspaceID: "ws-1",
+		AppID:       "canvas",
+		Params:      tuttigenerated.GetWorkspaceAppAgentProviderStatusesParams{},
+	})
+	_, _ = api.GetWorkspaceAppAgentProviderComposerOptions(ctx, tuttigenerated.GetWorkspaceAppAgentProviderComposerOptionsRequestObject{
+		WorkspaceID: "ws-1",
+		AppID:       "canvas",
+		Provider:    "codex",
+	})
+
+	if len(reporter.events) != 3 {
+		t.Fatalf("events = %#v, want one per deprecated route", reporter.events)
+	}
+	wantRoutes := []string{
+		"preferences/agent",
+		"agent-providers/status",
+		"agent-providers/{provider}/composer-options",
+	}
+	for index, wantRoute := range wantRoutes {
+		if got := reporter.events[index].Params["route"]; got != wantRoute {
+			t.Fatalf("event %d route = %#v, want %q", index, got, wantRoute)
+		}
+		if got := reporter.events[index].Params["workspace_app_version"]; got != "0.1.0" {
+			t.Fatalf("event %d workspace_app_version = %#v, want %q", index, got, "0.1.0")
+		}
+	}
+}

--- a/services/tuttid/api/openapi/tuttid.v1.yaml
+++ b/services/tuttid/api/openapi/tuttid.v1.yaml
@@ -989,8 +989,9 @@ paths:
         runtime. Intended for workspace app server tokens; exposes default
         provider selection and developer-gated provider visibility only. Deprecated
         for Agent integrations: use `tutti --json agent providers` through
-        `@tutti-os/agent-acp-kit/tutti`. This compatibility route remains available
-        for one stable release window.
+        `@tutti-os/agent-acp-kit/tutti`. Removal is gated by the production-usage
+        telemetry and release criteria in
+        `docs/conventions/deprecated-workspace-app-agent-apis.md`.
       responses:
         "200":
           description: Workspace app agent preferences
@@ -1027,7 +1028,8 @@ paths:
         `providers` is supplied, it narrows that Agent Target set and cannot
         expose providers outside it. Deprecated for Agent integrations: use
         `tutti --json agent providers` through `@tutti-os/agent-acp-kit/tutti`.
-        This compatibility route remains available for one stable release window.
+        Removal is gated by the production-usage telemetry and release criteria
+        in `docs/conventions/deprecated-workspace-app-agent-apis.md`.
       parameters:
         - name: providers
           in: query
@@ -1082,8 +1084,9 @@ paths:
         `POST /v1/agent-providers/{provider}/composer-options` for app server
         tokens. Deprecated for Agent integrations: use
         `tutti --json agent composer-options --provider <providerId>` through
-        `@tutti-os/agent-acp-kit/tutti`. This compatibility route remains available
-        for one stable release window.
+        `@tutti-os/agent-acp-kit/tutti`. Removal is gated by the production-usage
+        telemetry and release criteria in
+        `docs/conventions/deprecated-workspace-app-agent-apis.md`.
       requestBody:
         required: false
         content:

--- a/services/tuttid/service/cli/providers/agentcontext/composer_options.go
+++ b/services/tuttid/service/cli/providers/agentcontext/composer_options.go
@@ -10,13 +10,12 @@ import (
 )
 
 type composerOptionsInput struct {
-	Provider                 string `cli:"provider" validate:"required"`
-	Cwd                      string `cli:"cwd"`
-	Locale                   string `cli:"locale"`
-	Model                    string `cli:"model"`
-	PermissionMode           string `cli:"permission-mode"`
-	ReasoningEffort          string `cli:"reasoning-effort"`
-	IncludeCapabilityCatalog *bool  `cli:"include-capability-catalog"`
+	Provider        string `cli:"provider" validate:"required"`
+	Cwd             string `cli:"cwd"`
+	Locale          string `cli:"locale"`
+	Model           string `cli:"model"`
+	PermissionMode  string `cli:"permission-mode"`
+	ReasoningEffort string `cli:"reasoning-effort"`
 }
 
 func (p Provider) newComposerOptionsCommand() cliservice.Command {
@@ -68,12 +67,15 @@ func (p Provider) runComposerOptions(ctx context.Context, invoke framework.Invok
 	if reasoningEffort == "" {
 		reasoningEffort = defaults.ReasoningEffort
 	}
+	// The app-facing composer facade does not return CapabilityCatalog. Keep
+	// discovery off here so a catalog scan is never paid for and discarded.
+	includeCapabilityCatalog := false
 	return p.sessions.GetComposerOptions(ctx, agentservice.ComposerOptionsInput{
 		Cwd:                      input.Cwd,
 		Locale:                   locale,
 		Provider:                 canonicalProvider,
 		WorkspaceID:              invoke.WorkspaceID,
-		IncludeCapabilityCatalog: input.IncludeCapabilityCatalog,
+		IncludeCapabilityCatalog: &includeCapabilityCatalog,
 		Settings: agentservice.ComposerSettings{
 			Model:            model,
 			PermissionModeID: permissionModeID,

--- a/services/tuttid/service/cli/providers/agentcontext/provider.go
+++ b/services/tuttid/service/cli/providers/agentcontext/provider.go
@@ -95,11 +95,11 @@ func (p Provider) Commands() []cliservice.Command {
 		commands = append(commands,
 			p.newProvidersCommand(),
 			p.newComposerOptionsCommand(),
+			p.newSkillBundleCommand(),
 			p.newStartCommand(),
 		)
 	}
 	commands = append(commands,
-		p.newSkillBundleCommand(),
 		p.newProviderStartCommand(providerStartCommandSpec{
 			AppID:         codexAgentAppID,
 			AppName:       "Codex",

--- a/services/tuttid/service/cli/providers/agentcontext/provider_test.go
+++ b/services/tuttid/service/cli/providers/agentcontext/provider_test.go
@@ -1091,8 +1091,8 @@ func TestComposerOptionsCommandReturnsProviderOptions(t *testing.T) {
 	if sessions.composerInput.Locale != "zh-CN" || sessions.composerInput.Provider != "codex" || sessions.composerInput.Settings.Model != "gpt-5" || sessions.composerInput.Settings.PermissionModeID != "auto" || sessions.composerInput.Settings.ReasoningEffort != "high" {
 		t.Fatalf("composer input = %#v", sessions.composerInput)
 	}
-	if sessions.composerInput.IncludeCapabilityCatalog != nil {
-		t.Fatalf("include capability catalog = %#v, want nil default", *sessions.composerInput.IncludeCapabilityCatalog)
+	if sessions.composerInput.IncludeCapabilityCatalog == nil || *sessions.composerInput.IncludeCapabilityCatalog {
+		t.Fatalf("include capability catalog = %#v, want fixed false", sessions.composerInput.IncludeCapabilityCatalog)
 	}
 	if output.Value["provider"] != "codex" {
 		t.Fatalf("output = %#v", output.Value)

--- a/services/tuttid/service/workspace/agent_workspace_app_reference/references/agent-acp-kit.md
+++ b/services/tuttid/service/workspace/agent_workspace_app_reference/references/agent-acp-kit.md
@@ -57,9 +57,12 @@ For each run:
 1. Generate a stable run ID and use the canonical provider ID returned by the facade.
 2. Await `createManagedAgentRunContextFromHeaders(...)` directly. It reads and validates the managed credential, canonicalizes supported legacy input internally, creates a safe managed cwd, and rejects unsupported managed providers. The app must not pre-read the credential or perform a separate provider-support precheck.
 3. When no managed header exists, use an app-owned local cwd.
-4. Load Tutti skill context when platform skills are useful, passing browser/computer capability flags from trusted app policy.
+4. Load Tutti skill context when platform skills are useful. Omit browser/computer capability flags unless the app actually wires those tools and trusted server-side policy enables them.
 5. Create a run-scoped MCP/tool gateway and prompt envelope.
-6. Call the local runtime with the same canonical provider ID.
+6. Call the local runtime with the same canonical provider ID. Omit `permission`
+   for the standard App behavior: the SDK owns the `full-access` default and
+   provider-specific bypass mapping. Pass a permission only when the product
+   deliberately offers a narrower per-run choice.
 7. Adapt events to the app stream and persist only session/resume metadata.
 8. Revoke gateway tokens and clean app-owned temporary files in `finally`.
 
@@ -86,8 +89,6 @@ const tuttiContext = await loadTuttiAgentSkillContext({
   provider: providerId,
   agentSessionId: runId,
   cwd,
-  browserUse: appPolicyAllowsBrowser,
-  computerUse: appPolicyAllowsComputer,
   signal
 });
 
@@ -122,6 +123,36 @@ for await (const event of localAgentRuntime.run({
 `recommendedSystemPrompt` is advisory content. The app decides whether and where to merge it. Do not append it invisibly in a generic transport layer.
 
 Derive `appLocalRunCwd` from trusted server-side app policy. Never accept a browser-provided cwd for a managed run. Never put a credential or managed cwd in request bodies, browser state, DTOs, logs, persistence, or error text.
+
+The runtime call intentionally omits `permission`. Workspace Apps default to
+SDK-owned `full-access`: Claude receives `bypassPermissions`, Codex receives its
+unrestricted mode, and ACP permission requests are approved. Do not reproduce
+those mappings or inject a default mode in app code. If the app exposes an
+explicit lower-permission choice, pass the composer's typed `mode.id` and
+`mode.semantic`; that explicit selection overrides the SDK default.
+
+### Optional browser and computer capabilities
+
+Most apps should use the minimal skill-context call above. If an app really
+provides browser or computer-use tools, it may declare those capabilities to
+the Skill bundle loader:
+
+```ts
+const tuttiContext = await loadTuttiAgentSkillContext({
+  provider: providerId,
+  agentSessionId: runId,
+  cwd,
+  browserUse: browserToolsAreWiredAndAllowed,
+  computerUse: computerToolsAreWiredAndAllowed,
+  signal
+});
+```
+
+Only pass `true` from trusted server-side capability policy. These booleans
+filter the Skill guidance returned by Tutti; they do **not** install a tool,
+grant an OS permission, launch a browser, or bypass the app's authorization.
+Omit the fields when the capability is unavailable. Do not add placeholder
+policy variables merely to satisfy this example.
 
 ## Event mapping
 

--- a/services/tuttid/service/workspace/agent_workspace_app_reference/references/agent-acp-kit.md
+++ b/services/tuttid/service/workspace/agent_workspace_app_reference/references/agent-acp-kit.md
@@ -59,10 +59,9 @@ For each run:
 3. When no managed header exists, use an app-owned local cwd.
 4. Load Tutti skill context when platform skills are useful. Omit browser/computer capability flags unless the app actually wires those tools and trusted server-side policy enables them.
 5. Create a run-scoped MCP/tool gateway and prompt envelope.
-6. Call the local runtime with the same canonical provider ID. Omit `permission`
-   for the standard App behavior: the SDK owns the `full-access` default and
-   provider-specific bypass mapping. Pass a permission only when the product
-   deliberately offers a narrower per-run choice.
+6. Call the local runtime with the same canonical provider ID. Always omit
+   `permission`: Workspace Apps do not expose a permission selector. The SDK
+   owns the `full-access` default and provider-specific bypass mapping.
 7. Adapt events to the app stream and persist only session/resume metadata.
 8. Revoke gateway tokens and clean app-owned temporary files in `finally`.
 
@@ -127,9 +126,10 @@ Derive `appLocalRunCwd` from trusted server-side app policy. Never accept a brow
 The runtime call intentionally omits `permission`. Workspace Apps default to
 SDK-owned `full-access`: Claude receives `bypassPermissions`, Codex receives its
 unrestricted mode, and ACP permission requests are approved. Do not reproduce
-those mappings or inject a default mode in app code. If the app exposes an
-explicit lower-permission choice, pass the composer's typed `mode.id` and
-`mode.semantic`; that explicit selection overrides the SDK default.
+those mappings or inject a default mode in app code. If an App exposes a
+permission selector, remove it. Provider permission modes belong to Tutti's
+host-owned Agent GUI and manual CLI flows, not the Workspace App integration
+contract.
 
 ### Optional browser and computer capabilities
 

--- a/services/tuttid/service/workspace/app_factory_test.go
+++ b/services/tuttid/service/workspace/app_factory_test.go
@@ -371,6 +371,8 @@ func TestAppFactoryServiceCreateUsesDraftDirAndReferenceContext(t *testing.T) {
 		"await createManagedAgentRunContextFromHeaders",
 		"browserUse",
 		"computerUse",
+		"do **not** install a tool",
+		"Omit the fields when the capability is unavailable",
 	} {
 		if !strings.Contains(agentACPReference, want) {
 			t.Fatalf("agent-acp-kit reference missing %q:\n%s", want, agentACPReference)
@@ -384,6 +386,8 @@ func TestAppFactoryServiceCreateUsesDraftDirAndReferenceContext(t *testing.T) {
 		"managedCredential &&",
 		"agent-providers/status",
 		"TUTTI_APP_SERVER_TOKEN",
+		"appPolicyAllowsBrowser",
+		"appPolicyAllowsComputer",
 	} {
 		if strings.Contains(agentACPReference, forbidden) {
 			t.Fatalf("agent-acp-kit reference contains obsolete guidance %q:\n%s", forbidden, agentACPReference)


### PR DESCRIPTION
## Summary

- rebase the remaining Workspace App integration closeout onto current `origin/main`, preserving the Agent Target resolver and no-permission-selector policy from #1045/#1055
- add authenticated usage telemetry and an explicit removal gate for the three deprecated app-scoped Agent HTTP compatibility routes
- remove the discarded composer capability-catalog input and keep that discovery disabled for the App CLI facade
- register the Skill bundle command only when the canonical Agent Target resolver is available
- make Tutti Skill synchronization detect version drift, bump Codex and Claude plugin manifests together, and validate their shared numeric version and paths
- keep Workspace Apps on SDK-owned full access by always omitting `permission`; `auto` and other permission choices remain host/manual-CLI behavior

## Why

Most of the original PR was subsequently covered by main. The rebased diff keeps only work that is still missing: safe compatibility-route retirement telemetry, avoided discarded discovery, conditional Skill command registration, and repair of the real external plugin drift (`0.2.30 / 0.2.30 / 0.2.1`).

## Validation

- `corepack pnpm check:full` — 16/16 tasks passed against current main
- GitHub PR Checks — TypeScript/Go tests, lint, typecheck, package pack, tooling consistency all passed
- Skill sync preview and external review gate passed
- targeted API, CLI agentcontext, and Workspace Skill tests passed
- generated OpenAPI check passed
- one unrelated parallel Agent GUI timeout was reproduced as a load flake; its exact test then passed three consecutive isolated runs and the following full run passed

## Rollout

- merging triggers the existing automatic `tutti-agent-skills` sync; the next sync aligns all three plugin manifests on one patch version
- deprecated HTTP aliases remain available until the documented production telemetry gate is satisfied
- this PR does not publish a Workspace App or trigger any App production release

AI assistance was used for implementation, reconciliation, and review.
