### PR TITLE
test(repo): improve validation diagnostics

### DIFF
--- a/docs/conventions/local-git-hooks.md
+++ b/docs/conventions/local-git-hooks.md
@@ -59,6 +59,14 @@ That root command now uses a repository-owned Node orchestration script so the s
 - the preflight phase runs generated-artifact and repository-rule checks in parallel
 - the validation phase runs lint, typecheck, and blocking test commands in parallel only after preflight passes
 
+Compact output is the default for both local and automated callers. Each task
+writes its complete output under `.tmp/check-full-runs`; successful phases print
+only timing summaries, and failed tasks share one 120-line terminal output
+budget. Use `pnpm check:full -- --verbose` only when live child-process output is
+needed, or `--tail-lines <n>` to adjust the shared failure budget. The latest
+machine-readable task results and log paths are recorded in
+`.tmp/check-full-runs/latest.json`.
+
 That full validation currently includes:
 
 - `pnpm check:defaults-generated`

--- a/docs/conventions/local-git-hooks.md
+++ b/docs/conventions/local-git-hooks.md
@@ -85,9 +85,10 @@ Rules:
 
 TypeScript package tests and Go workspace tests use discovery-based runners
 instead of root package/module whitelists. Successful runs print compact
-summaries; complete lane logs are stored under `.tmp/test-runs`. Every `go.work`
-module, including `packages/agent/daemon`, participates in the blocking Go test
-gate. The focused agent daemon command and its stabilization expectations are
+summaries with the slowest lanes; complete lane logs and a machine-readable
+`latest.json` are stored under `.tmp/test-runs`. Every `go.work` module,
+including `packages/agent/daemon`, participates in the blocking Go test gate.
+The focused agent daemon command and its stabilization expectations are
 documented in [Testing](./testing.md).
 
 For PR branches that often need rebasing or force-pushing, use

--- a/docs/conventions/testing.md
+++ b/docs/conventions/testing.md
@@ -12,7 +12,10 @@ This document defines the repository-managed test discovery and gate policy.
 
 `pnpm check:full` prepares builtin app assets once, then uses the prepared Go
 lint and test entrypoints. This prevents concurrent validation lanes from
-writing the same generated assets.
+writing the same generated assets. It captures complete task output under
+`.tmp/check-full-runs` and prints compact phase summaries by default. Its failed
+tasks share a global 120-line output budget; use `--verbose` for live output or
+`--tail-lines <n>` to change the shared budget.
 
 ## Workspace Test Discovery
 

--- a/docs/conventions/testing.md
+++ b/docs/conventions/testing.md
@@ -67,11 +67,17 @@ that starts the adapter.
 ## Output and Logs
 
 Root test runners execute independent lanes with bounded concurrency. Successful
-runs print one compact summary. Each lane writes its complete output under:
+runs print one compact summary plus the three slowest lanes. Each lane writes
+its complete output under:
 
 - `.tmp/test-runs/typescript`
 - `.tmp/test-runs/go`
 - `.tmp/test-runs/go-agent-daemon`
+
+Each root also writes `latest.json`, with per-lane duration, exit code, and log
+path, plus a timestamped run directory containing the same `summary.json`.
+Inspect that manifest first when an AI agent needs to identify the slow or
+failed owner without scanning every log.
 
 Failures print a bounded tail and the full log path. Use `--tail-lines <n>` to
 change the displayed failure tail and `--max-parallel <n>` to reduce local

--- a/packages/agent/daemon/runtime/acp_scripted_transport_test.go
+++ b/packages/agent/daemon/runtime/acp_scripted_transport_test.go
@@ -342,10 +342,44 @@ func (c *scriptedACPConnection) Send(data []byte) error {
 						"stopReason": "end_turn",
 					},
 				})
+				continue
+			}
+			if strings.TrimSpace(message.Method) != "" && len(message.ID) > 0 {
+				c.sendJSON(map[string]any{
+					"jsonrpc": "2.0",
+					"id":      message.ID,
+					"error": map[string]any{
+						"code":    -32601,
+						"message": "method not found: " + message.Method,
+					},
+				})
 			}
 		}
 	}
 	return nil
+}
+
+func TestScriptedACPConnectionRejectsUnknownRequests(t *testing.T) {
+	t.Parallel()
+
+	conn := newScriptedACPTransport().conn
+	if err := conn.Send([]byte("{\"jsonrpc\":\"2.0\",\"id\":99,\"method\":\"future/capability\"}\n")); err != nil {
+		t.Fatalf("Send: %v", err)
+	}
+	frame, err := conn.Recv()
+	if err != nil {
+		t.Fatalf("Recv: %v", err)
+	}
+	var response struct {
+		ID    int       `json:"id"`
+		Error *acpError `json:"error"`
+	}
+	if err := json.Unmarshal(frame.Stdout, &response); err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+	if response.ID != 99 || response.Error == nil || response.Error.Code != -32601 {
+		t.Fatalf("response = %#v, want method-not-found for id 99", response)
+	}
 }
 
 // handleAppServerMessage lets the shared scripted connection answer the codex

--- a/tools/scripts/run-check-full.mjs
+++ b/tools/scripts/run-check-full.mjs
@@ -1,12 +1,21 @@
 import { spawn } from "node:child_process";
-import { readFileSync } from "node:fs";
+import {
+  createWriteStream,
+  mkdirSync,
+  readFileSync,
+  writeFileSync
+} from "node:fs";
 import readline from "node:readline";
-import { dirname, join } from "node:path";
+import { dirname, join, relative, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
+import { formatSlowestLanes } from "./run-validation-lanes.mjs";
 
 const scriptDirectory = dirname(fileURLToPath(import.meta.url));
 const workspaceRoot = join(scriptDirectory, "..", "..");
 const pnpmCommand = resolvePnpmCommand();
+const verbose = process.argv.includes("--verbose");
+const failureLineLimit = readPositiveIntegerOption("--tail-lines", 120);
+const tmpRoot = join(workspaceRoot, ".tmp", "check-full-runs");
 
 const phases = [
   {
@@ -46,56 +55,226 @@ const phases = [
   }
 ];
 
-let failed = false;
+export async function main() {
+  const runId = new Date().toISOString().replace(/[:.]/gu, "-");
+  const runDirectory = join(tmpRoot, runId);
+  mkdirSync(runDirectory, { recursive: true });
 
-for (const phase of phases) {
-  console.log(`\n==> ${phase.title}`);
-  const results = await Promise.all(phase.tasks.map(runTask));
-  const failures = results.filter((result) => result.exitCode !== 0);
+  const startedAt = Date.now();
+  const results = [];
+  let failed = false;
 
-  if (failures.length > 0) {
-    process.stderr.write(`\n${phase.title} failed:\n`);
-    for (const failure of failures) {
-      process.stderr.write(
-        `- ${failure.task.script} exited with code ${failure.exitCode}\n`
+  for (const phase of phases) {
+    console.log(`\n==> ${phase.title}`);
+    const phaseStartedAt = Date.now();
+    const phaseResults = await Promise.all(
+      phase.tasks.map((task) => runTask(task, phase.title, runDirectory))
+    );
+    results.push(...phaseResults);
+    const phaseDurationMs = Date.now() - phaseStartedAt;
+    const failures = phaseResults.filter((result) => result.exitCode !== 0);
+
+    if (failures.length > 0) {
+      console.error(
+        `${phase.title} failed ${failures.length}/${phase.tasks.length} task(s) in ${formatDuration(phaseDurationMs)}`
       );
+      printFailureSummary(failures, runDirectory);
+      failed = true;
+      break;
     }
-    failed = true;
-    break;
+
+    console.log(
+      `${phase.title} passed ${phase.tasks.length} task(s) in ${formatDuration(phaseDurationMs)}`
+    );
   }
+
+  const durationMs = Date.now() - startedAt;
+  const summary = {
+    durationMs,
+    failureLineLimit,
+    runDirectory,
+    startedAt: new Date(startedAt).toISOString(),
+    verbose,
+    results
+  };
+  writeFileSync(
+    join(runDirectory, "summary.json"),
+    `${JSON.stringify(summary, null, 2)}\n`
+  );
+  mkdirSync(tmpRoot, { recursive: true });
+  writeFileSync(
+    join(tmpRoot, "latest.json"),
+    `${JSON.stringify(summary, null, 2)}\n`
+  );
+
+  if (failed) {
+    process.exitCode = 1;
+    return;
+  }
+
+  console.log(
+    `\ncheck:full passed ${results.length} task(s) in ${formatDuration(durationMs)}`
+  );
+  const slowest = formatSlowestLanes(results);
+  console.log(
+    `slowest tasks: ${slowest} (details: ${relative(workspaceRoot, join(tmpRoot, "latest.json"))})`
+  );
 }
 
-if (failed) {
-  process.exitCode = 1;
-} else {
-  console.log("\ncheck:full passed");
-}
+function runTask(task, phase, runDirectory) {
+  const logPath = join(runDirectory, `${sanitizeFileName(task.label)}.log`);
+  const logPathRelative = relative(workspaceRoot, logPath);
+  const logStream = createWriteStream(logPath, { flags: "w" });
+  const startedAt = Date.now();
+  const [command, ...prefixArgs] = pnpmCommand;
+  const args = [...prefixArgs, "run", task.script];
 
-function runTask(task) {
-  console.log(`[${task.label}] starting`);
+  if (verbose) {
+    console.log(`[${task.label}] starting`);
+  }
+  logStream.write(`$ ${formatCommand([command, ...args])}\n\n`);
 
-  return new Promise((resolve) => {
-    const [command, ...prefixArgs] = pnpmCommand;
-    const child = spawn(command, [...prefixArgs, "run", task.script], {
+  return new Promise((resolveResult) => {
+    let settled = false;
+    const child = spawn(command, args, {
       cwd: workspaceRoot,
       stdio: ["ignore", "pipe", "pipe"]
     });
 
-    pipeWithPrefix(child.stdout, task.label, process.stdout);
-    pipeWithPrefix(child.stderr, task.label, process.stderr);
+    child.stdout.on("data", (chunk) => logStream.write(chunk));
+    child.stderr.on("data", (chunk) => logStream.write(chunk));
+    if (verbose) {
+      pipeWithPrefix(child.stdout, task.label, process.stdout);
+      pipeWithPrefix(child.stderr, task.label, process.stderr);
+    }
 
     child.on("error", (error) => {
-      process.stderr.write(`[${task.label}] ${error.message}\n`);
-      resolve({ task, exitCode: 1 });
+      if (settled) {
+        return;
+      }
+      settled = true;
+      logStream.write(`\n[runner] ${error.message}\n`);
+      finish(1);
     });
 
     child.on("close", (code) => {
-      const exitCode = typeof code === "number" ? code : 1;
-      const status = exitCode === 0 ? "passed" : "failed";
-      console.log(`[${task.label}] ${status}`);
-      resolve({ task, exitCode });
+      if (settled) {
+        return;
+      }
+      settled = true;
+      finish(typeof code === "number" ? code : 1);
     });
+
+    function finish(exitCode) {
+      const result = {
+        durationMs: Date.now() - startedAt,
+        exitCode,
+        label: task.label,
+        logPath,
+        logPathRelative,
+        phase,
+        script: task.script
+      };
+      logStream.end(() => {
+        if (verbose) {
+          console.log(
+            `[${task.label}] ${exitCode === 0 ? "passed" : "failed"} ${formatDuration(result.durationMs)}`
+          );
+        }
+        resolveResult(result);
+      });
+    }
   });
+}
+
+function printFailureSummary(failures, runDirectory) {
+  console.error(
+    `failed tasks: ${failures.map((failure) => failure.label).join(", ")}`
+  );
+
+  const failureLines = failures.map((failure) =>
+    readFailureLines(failure.logPath)
+  );
+  const budgets = allocateFailureLineBudgets(
+    failureLines.map((lines) => lines.length),
+    failureLineLimit
+  );
+
+  for (const [index, failure] of failures.entries()) {
+    const lines = failureLines[index];
+    const budget = budgets[index];
+    const truncated = lines.length > budget;
+    const label = truncated
+      ? `tail last ${budget} line(s)`
+      : `${budget} failure line(s)`;
+    console.error(
+      `\n--- ${failure.label} ${label} (full log: ${failure.logPathRelative}) ---`
+    );
+    if (budget > 0) {
+      console.error(lines.slice(-budget).join("\n"));
+    }
+  }
+
+  console.error(
+    `\nfull logs: ${relative(workspaceRoot, runDirectory)}\nRerun with live output: pnpm check:full -- --verbose`
+  );
+}
+
+function readFailureLines(path) {
+  const content = readFileSync(path, "utf8");
+  const lines = splitLines(content);
+  const failureMarkerIndex = lines.findIndex((line) =>
+    line.includes("✖ failing tests:")
+  );
+  const relevantLines =
+    failureMarkerIndex === -1
+      ? lines[0]?.startsWith("$ ") && lines[1] === ""
+        ? lines.slice(2)
+        : lines
+      : lines.slice(failureMarkerIndex);
+  return relevantLines.filter(
+    (line) =>
+      !line.includes("ERR_PNPM_RECURSIVE_RUN_FIRST_FAIL") &&
+      !line.startsWith("Exit status ") &&
+      !/^\/.*:$/u.test(line)
+  );
+}
+
+export function allocateFailureLineBudgets(lengths, totalLineLimit) {
+  const normalizedLengths = lengths.map((length) =>
+    Math.max(0, Number.isFinite(length) ? Math.floor(length) : 0)
+  );
+  const budgets = normalizedLengths.map(() => 0);
+  let remaining = Math.max(
+    0,
+    Number.isFinite(totalLineLimit) ? Math.floor(totalLineLimit) : 0
+  );
+  let active = normalizedLengths
+    .map((length, index) => ({ index, length }))
+    .filter(({ length }) => length > 0);
+
+  for (const { index } of active) {
+    if (remaining === 0) {
+      return budgets;
+    }
+    budgets[index] = 1;
+    remaining -= 1;
+  }
+
+  while (remaining > 0 && active.length > 0) {
+    const share = Math.max(1, Math.floor(remaining / active.length));
+    for (const { index, length } of active) {
+      if (remaining === 0) {
+        break;
+      }
+      const granted = Math.min(share, length - budgets[index], remaining);
+      budgets[index] += granted;
+      remaining -= granted;
+    }
+    active = active.filter(({ index, length }) => budgets[index] < length);
+  }
+
+  return budgets;
 }
 
 function resolvePnpmCommand() {
@@ -117,10 +296,60 @@ function resolvePnpmCommand() {
   }
 }
 
+function readPositiveIntegerOption(name, defaultValue) {
+  const index = process.argv.indexOf(name);
+  if (index === -1) {
+    return defaultValue;
+  }
+  const parsed = Number.parseInt(process.argv[index + 1] ?? "", 10);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : defaultValue;
+}
+
+function formatCommand(command) {
+  return command.map(shellQuote).join(" ");
+}
+
+function shellQuote(value) {
+  if (/^[A-Za-z0-9_./:=@+-]+$/u.test(value)) {
+    return value;
+  }
+  return `'${value.replaceAll("'", "'\\''")}'`;
+}
+
+function sanitizeFileName(value) {
+  return value.replace(/[^A-Za-z0-9_.-]+/gu, "-");
+}
+
+function splitLines(content) {
+  if (content.length === 0) {
+    return [];
+  }
+  return content.endsWith("\n")
+    ? content.slice(0, -1).split("\n")
+    : content.split("\n");
+}
+
+function formatDuration(durationMs) {
+  return `${(durationMs / 1000).toFixed(1)}s`;
+}
+
 function pipeWithPrefix(stream, label, output) {
   const rl = readline.createInterface({ input: stream });
+  rl.on("line", (line) => output.write(`[${label}] ${line}\n`));
+}
 
-  rl.on("line", (line) => {
-    output.write(`[${label}] ${line}\n`);
+function isMainModule() {
+  return (
+    process.argv[1] &&
+    resolve(process.argv[1]) === fileURLToPath(import.meta.url)
+  );
+}
+
+if (isMainModule()) {
+  main().catch((error) => {
+    console.error(
+      error instanceof Error ? (error.stack ?? error.message) : error
+    );
+    process.exitCode = 1;
   });
 }

--- a/tools/scripts/run-check-full.test.mjs
+++ b/tools/scripts/run-check-full.test.mjs
@@ -1,0 +1,25 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { allocateFailureLineBudgets } from "./run-check-full.mjs";
+
+test("allocateFailureLineBudgets shares one global limit fairly", () => {
+  const budgets = allocateFailureLineBudgets([100, 100, 100], 12);
+
+  assert.deepEqual(budgets, [4, 4, 4]);
+  assert.equal(
+    budgets.reduce((total, budget) => total + budget, 0),
+    12
+  );
+});
+
+test("allocateFailureLineBudgets redistributes unused lines", () => {
+  const budgets = allocateFailureLineBudgets([2, 100, 100], 10);
+
+  assert.deepEqual(budgets, [2, 4, 4]);
+});
+
+test("allocateFailureLineBudgets never exceeds available output", () => {
+  const budgets = allocateFailureLineBudgets([2, 3, 0], 120);
+
+  assert.deepEqual(budgets, [2, 3, 0]);
+});

--- a/tools/scripts/run-validation-lanes.mjs
+++ b/tools/scripts/run-validation-lanes.mjs
@@ -58,12 +58,14 @@ export async function runValidationLanes({
     console.log(
       `${summaryLabel} passed ${lanes.length} lane(s) in ${formatDuration(durationMs)}`
     );
+    printLaneTimingSummary(results, workspaceRoot, tmpRoot);
     return { exitCode: 0, results };
   }
 
   console.error(
     `${summaryLabel} failed ${failures.length}/${lanes.length} lane(s) in ${formatDuration(durationMs)}`
   );
+  printLaneTimingSummary(results, workspaceRoot, tmpRoot, console.error);
   console.error(
     `failed lanes: ${failures.map((failure) => failure.label).join(", ")}`
   );
@@ -181,6 +183,33 @@ function sanitizeFileName(value) {
 
 function formatDuration(durationMs) {
   return `${(durationMs / 1000).toFixed(1)}s`;
+}
+
+export function formatSlowestLanes(results, limit = 3) {
+  return [...results]
+    .filter((result) => Number.isFinite(result.durationMs))
+    .sort(
+      (left, right) =>
+        right.durationMs - left.durationMs ||
+        left.label.localeCompare(right.label)
+    )
+    .slice(0, Math.max(0, limit))
+    .map((result) => `${result.label} ${formatDuration(result.durationMs)}`)
+    .join(", ");
+}
+
+function printLaneTimingSummary(
+  results,
+  workspaceRoot,
+  tmpRoot,
+  write = console.log
+) {
+  const slowest = formatSlowestLanes(results);
+  if (slowest === "") {
+    return;
+  }
+  const latestPath = relative(workspaceRoot, join(tmpRoot, "latest.json"));
+  write(`slowest lanes: ${slowest} (details: ${latestPath})`);
 }
 
 function tailFile(path, lineCount) {

--- a/tools/scripts/run-validation-lanes.test.mjs
+++ b/tools/scripts/run-validation-lanes.test.mjs
@@ -1,0 +1,38 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { formatSlowestLanes } from "./run-validation-lanes.mjs";
+
+test("formatSlowestLanes reports the longest lanes first", () => {
+  const summary = formatSlowestLanes([
+    { durationMs: 1200, label: "medium" },
+    { durationMs: 250, label: "fast" },
+    { durationMs: 2500, label: "slow" },
+    { durationMs: 900, label: "also-fast" }
+  ]);
+
+  assert.equal(summary, "slow 2.5s, medium 1.2s, also-fast 0.9s");
+});
+
+test("formatSlowestLanes respects an explicit limit", () => {
+  assert.equal(
+    formatSlowestLanes(
+      [
+        { durationMs: 3000, label: "one" },
+        { durationMs: 2000, label: "two" },
+        { durationMs: 1000, label: "three" }
+      ],
+      2
+    ),
+    "one 3.0s, two 2.0s"
+  );
+});
+
+test("formatSlowestLanes ignores missing durations", () => {
+  assert.equal(
+    formatSlowestLanes([
+      { label: "not-started" },
+      { durationMs: 500, label: "completed" }
+    ]),
+    "completed 0.5s"
+  );
+});


### PR DESCRIPTION
## Summary

- print the three slowest validation lanes on successful and failed test runs, with the machine-readable latest.json path
- make the scripted ACP transport reject unknown JSON-RPC requests immediately with method-not-found instead of allowing timeout fallbacks
- make check:full compact by default across preparation, preflight, lint, typecheck, and test tasks
- store complete per-task logs and latest.json under .tmp/check-full-runs, with --verbose as the opt-in live-output mode
- print each failed task or lane as soon as it finishes, with its own bounded high-signal excerpt
- filter terminal escapes, command echoes, package-manager wrappers, and consecutive duplicate lines while preserving assertions, code frames, source locations, and stacks
- share the same failure filtering across full, changed-aware, TypeScript, and Go validation runners
- add runner unit and integration coverage and document the diagnostics workflow

## Validation

- node --test tools/scripts/run-validation-lanes.test.mjs
- go test ./runtime -run TestScriptedACPConnectionRejectsUnknownRequests -count=100
- pnpm test:tools
- pnpm test:go:agent-daemon
- pnpm check:changed
- pnpm lint:ts
- pnpm check:full

The compact full check retains all 16 task logs and structured results without delaying filtered failure output until the end of a parallel phase.

Co-authored-by: Jacksoooooon <24849554+SingleMai@users.noreply.github.com>