### PR TITLE
feat(agent): forward remote image URLs

### DIFF
--- a/apps/desktop/src/renderer/src/features/workspace-agent/services/desktopAgentActivityAdapter.test.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-agent/services/desktopAgentActivityAdapter.test.ts
@@ -328,6 +328,48 @@ test("desktop agent activity adapter marks empty-cwd creates as no-project", asy
   );
 });
 
+test("desktop agent activity adapter forwards HTTPS image URLs structurally", async () => {
+  let createBody: unknown = null;
+  const url = "https://bucket.example/image.png?X-Amz-Signature=secret";
+  const adapter = createDesktopAgentActivityAdapter({
+    tuttidClient: createTuttidClient({
+      async createWorkspaceAgentSession(_workspaceId, body) {
+        createBody = body;
+        return createSession({ id: body.agentSessionId, status: "created" });
+      }
+    }),
+    runtimeApi: createRuntimeApi()
+  });
+
+  await adapter.createSession({
+    agentSessionId: "22222222-2222-4222-8222-222222222222",
+    agentTargetId: "local:codex",
+    initialContent: [
+      {
+        type: "image",
+        mimeType: "image/png",
+        url,
+        attachmentId: "remote-image",
+        name: "image.png"
+      }
+    ],
+    workspaceId
+  });
+
+  assert.deepEqual(
+    (createBody as { initialContent?: unknown }).initialContent,
+    [
+      {
+        type: "image",
+        mimeType: "image/png",
+        url,
+        attachmentId: "remote-image",
+        name: "image.png"
+      }
+    ]
+  );
+});
+
 test("desktop agent activity adapter localizes adapter mismatch create failures", async () => {
   const adapter = createDesktopAgentActivityAdapter({
     tuttidClient: createTuttidClient({

--- a/apps/desktop/src/renderer/src/features/workspace-agent/services/desktopAgentActivityAdapter.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-agent/services/desktopAgentActivityAdapter.ts
@@ -545,6 +545,9 @@ function toTuttidPromptContentBlocks(
     if (block.data !== undefined) {
       nextBlock.data = block.data;
     }
+    if (block.url !== undefined) {
+      nextBlock.url = block.url;
+    }
     if (block.mimeType !== undefined) {
       nextBlock.mimeType =
         block.mimeType as TuttidAgentPromptContentBlock["mimeType"];

--- a/docs/architecture/agent-gui-node.md
+++ b/docs/architecture/agent-gui-node.md
@@ -848,6 +848,16 @@ persists the normalized `attachmentId`. The managed source path must live under
 the daemon state root's `agent-prompt-assets` directory, and the daemon must
 re-check the resolved source path, symlink target, file type, and size before
 copying it into the session attachment store.
+Shared callers may instead supply a URL-backed image block when they already
+uploaded the image. That source must be an absolute HTTPS URL without embedded
+userinfo and must retain a supported PNG, JPEG, or WebP MIME type. `data` and
+`url` are mutually exclusive; ambiguous blocks are rejected. URL-backed images
+bypass the prompt attachment store and owner-side hydration. Capable adapters
+forward the URL as a structured image source, while protocols without a URL
+image variant fail capability validation instead of downloading, converting to
+text, or silently dropping the block. Activity projection may retain safe image
+metadata such as attachment id, name, and MIME type, but must omit both base64
+data and the full URL because signed URLs are bearer credentials.
 Claude Code runtime options follow the same parity rule. The legacy ACP adapter
 and the Claude SDK adapter must derive system prompt append text, Tutti detail
 mode instructions, plan-mode instructions, plugin directory, custom model args,
@@ -1274,12 +1284,14 @@ existing queue if injected into the same context, but they must not enqueue,
 claim, drain, promote, edit, or delete queued prompts.
 
 Queued prompt previews must treat prompt image blocks as the same send contract
-used by the composer and runtime: an image may be inline `data` or a staged
-`path`. Do not cast queued images to data-only blocks or build thumbnail URLs
-from `image.data` without checking it. Path-backed queued prompt thumbnails
-should use the activity runtime prompt-asset reader when workspace/session
-context is available, and otherwise avoid rendering a broken image while
-keeping the queued content unchanged for sending.
+used by the composer and runtime: an image may be inline `data`, a staged
+`path`, or an HTTPS `url`. Do not cast queued images to data-only blocks or build
+thumbnail URLs from `image.data` without checking it. URL-backed queued images
+must preserve the structured URL until submission without copying it into
+activity state. Path-backed queued prompt thumbnails should use the activity
+runtime prompt-asset reader when workspace/session context is available, and
+otherwise avoid rendering a broken image while keeping the queued content
+unchanged for sending.
 
 ### Approval And Ask-User Prompts
 

--- a/docs/architecture/agent-gui-node.md
+++ b/docs/architecture/agent-gui-node.md
@@ -855,9 +855,12 @@ userinfo and must retain a supported PNG, JPEG, or WebP MIME type. `data` and
 bypass the prompt attachment store and owner-side hydration. Capable adapters
 forward the URL as a structured image source, while protocols without a URL
 image variant fail capability validation instead of downloading, converting to
-text, or silently dropping the block. Activity projection may retain safe image
-metadata such as attachment id, name, and MIME type, but must omit both base64
-data and the full URL because signed URLs are bearer credentials.
+text, or silently dropping the block. Durable activity reports and diagnostic
+logs should retain safe image metadata such as attachment id, name, and MIME
+type without recording base64 data or full signed URLs. UI-local composer
+drafts and optimistic overlays may retain the URL when needed for preview and
+submission; they must not convert it to base64 or persist it as a local prompt
+attachment.
 Claude Code runtime options follow the same parity rule. The legacy ACP adapter
 and the Claude SDK adapter must derive system prompt append text, Tutti detail
 mode instructions, plan-mode instructions, plugin directory, custom model args,
@@ -1287,11 +1290,12 @@ Queued prompt previews must treat prompt image blocks as the same send contract
 used by the composer and runtime: an image may be inline `data`, a staged
 `path`, or an HTTPS `url`. Do not cast queued images to data-only blocks or build
 thumbnail URLs from `image.data` without checking it. URL-backed queued images
-must preserve the structured URL until submission without copying it into
-activity state. Path-backed queued prompt thumbnails should use the activity
-runtime prompt-asset reader when workspace/session context is available, and
-otherwise avoid rendering a broken image while keeping the queued content
-unchanged for sending.
+must preserve the structured URL through edit and submission and may use it
+directly for preview; they must not hydrate it through the prompt-asset reader.
+Path-backed queued prompt thumbnails should use the activity runtime
+prompt-asset reader when workspace/session context is available, and otherwise
+avoid rendering a broken image while keeping the queued content unchanged for
+sending.
 
 ### Approval And Ask-User Prompts
 

--- a/packages/agent/claude-sdk-sidecar/src/normalizer.test.ts
+++ b/packages/agent/claude-sdk-sidecar/src/normalizer.test.ts
@@ -74,6 +74,37 @@ test("sdkContentFromPromptBlocks embeds Claude image prompt blocks", () => {
   );
 });
 
+test("sdkContentFromPromptBlocks maps HTTPS URL image sources", () => {
+  const url = "https://bucket.example/image.webp?token=secret";
+  assert.deepEqual(
+    sdkContentFromPromptBlocks(
+      [{ type: "image", mimeType: "image/webp", url }],
+      "fallback"
+    ),
+    [{ type: "image", source: { type: "url", url } }]
+  );
+  assert.deepEqual(
+    sdkContentFromPromptBlocks(
+      [
+        {
+          type: "image",
+          mimeType: "image/webp",
+          url: "http://example.com/image.webp"
+        }
+      ],
+      "fallback"
+    ),
+    [{ type: "text", text: "fallback" }]
+  );
+  assert.deepEqual(
+    sdkContentFromPromptBlocks(
+      [{ type: "image", mimeType: "image/webp", url, data: "ambiguous" }],
+      "fallback"
+    ),
+    [{ type: "text", text: "fallback" }]
+  );
+});
+
 test("sdkContentFromPromptBlocks falls back to legacy prompt text", () => {
   assert.deepEqual(sdkContentFromPromptBlocks(undefined, "hello"), [
     { type: "text", text: "hello" }

--- a/packages/agent/claude-sdk-sidecar/src/normalizer.ts
+++ b/packages/agent/claude-sdk-sidecar/src/normalizer.ts
@@ -66,7 +66,22 @@ export function sdkContentFromPromptBlocks(
       if (record.type === "image") {
         const mimeType = stringValue(record.mimeType);
         const data = stringValue(record.data);
-        if (isSupportedClaudeImageMimeType(mimeType) && data) {
+        const url = stringValue(record.url);
+        if (
+          !data &&
+          isSupportedClaudeImageMimeType(mimeType) &&
+          isSafeImageUrl(url)
+        ) {
+          content.push({
+            type: "image",
+            source: {
+              type: "url",
+              url
+            }
+          });
+          continue;
+        }
+        if (isSupportedClaudeImageMimeType(mimeType) && data && !url) {
           content.push({
             type: "image",
             source: {
@@ -86,6 +101,20 @@ export function sdkContentFromPromptBlocks(
     }
   }
   return content;
+}
+
+function isSafeImageUrl(value: string): boolean {
+  try {
+    const url = new URL(value);
+    return (
+      url.protocol === "https:" &&
+      Boolean(url.hostname) &&
+      !url.username &&
+      !url.password
+    );
+  } catch {
+    return false;
+  }
 }
 
 export function parseJSONObject(

--- a/packages/agent/daemon/runtime/claude_sdk_adapter.go
+++ b/packages/agent/daemon/runtime/claude_sdk_adapter.go
@@ -276,19 +276,7 @@ func (a *ClaudeCodeSDKAdapter) Close(_ context.Context, session Session) error {
 }
 
 func (*ClaudeCodeSDKAdapter) ValidatePromptContent(_ Session, content []PromptContentBlock) error {
-	if !promptContentHasImage(content) {
-		return nil
-	}
-	for _, block := range content {
-		if strings.TrimSpace(block.Type) != "image" {
-			continue
-		}
-		if !runtimePromptImageMimeTypeSupported(strings.TrimSpace(block.MimeType)) ||
-			(strings.TrimSpace(block.Data) == "" && strings.TrimSpace(block.AttachmentID) == "") {
-			return ErrPromptImageUnsupported
-		}
-	}
-	return nil
+	return validateRuntimePromptContentImages(content)
 }
 
 func (a *ClaudeCodeSDKAdapter) Exec(
@@ -2696,7 +2684,16 @@ func promptContentForClaudeSDK(content []PromptContentBlock, fallback string) []
 		case "image":
 			mimeType := strings.TrimSpace(block.MimeType)
 			data := strings.TrimSpace(block.Data)
-			if !runtimePromptImageMimeTypeSupported(mimeType) || data == "" {
+			imageURL := strings.TrimSpace(block.URL)
+			if !runtimePromptImageMimeTypeSupported(mimeType) || (data == "" && imageURL == "") {
+				continue
+			}
+			if imageURL != "" {
+				blocks = append(blocks, map[string]any{
+					"type":     "image",
+					"mimeType": mimeType,
+					"url":      imageURL,
+				})
 				continue
 			}
 			blocks = append(blocks, map[string]any{

--- a/packages/agent/daemon/runtime/claude_sdk_adapter_test.go
+++ b/packages/agent/daemon/runtime/claude_sdk_adapter_test.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"reflect"
 	"runtime"
 	"slices"
 	"strings"
@@ -1662,6 +1663,7 @@ func TestClaudeCodeSDKAdapterSessionStateProjectsSettings(t *testing.T) {
 func TestClaudeCodeSDKAdapterAcceptsImagePromptContent(t *testing.T) {
 	adapter := NewClaudeCodeSDKAdapter(nil)
 	session := standardTestSession(ProviderClaudeCode)
+	signedURL := "https://bucket.example/image.webp?token=secret"
 
 	if err := adapter.ValidatePromptContent(session, []PromptContentBlock{
 		{Type: "text", Text: "what is in this image?"},
@@ -1670,9 +1672,31 @@ func TestClaudeCodeSDKAdapterAcceptsImagePromptContent(t *testing.T) {
 		t.Fatalf("ValidatePromptContent supported image = %v, want nil", err)
 	}
 	if err := adapter.ValidatePromptContent(session, []PromptContentBlock{
+		{Type: "image", MimeType: "image/webp", URL: signedURL},
+	}); err != nil {
+		t.Fatalf("ValidatePromptContent URL image = %v, want nil", err)
+	}
+	if err := adapter.ValidatePromptContent(session, []PromptContentBlock{
 		{Type: "image", MimeType: "image/gif", Data: "aW1hZ2U="},
 	}); !errors.Is(err, ErrPromptImageUnsupported) {
 		t.Fatalf("ValidatePromptContent unsupported image = %v, want ErrPromptImageUnsupported", err)
+	}
+	if err := adapter.ValidatePromptContent(session, []PromptContentBlock{
+		{Type: "image", MimeType: "image/png", Data: "aW1hZ2U=", URL: signedURL},
+	}); !errors.Is(err, ErrPromptImageUnsupported) {
+		t.Fatalf("ValidatePromptContent ambiguous image = %v, want ErrPromptImageUnsupported", err)
+	}
+
+	got := promptContentForClaudeSDK([]PromptContentBlock{
+		{Type: "image", MimeType: "image/png", Data: "aW1hZ2U="},
+		{Type: "image", MimeType: "image/webp", URL: signedURL},
+	}, "")
+	want := []map[string]any{
+		{"type": "image", "mimeType": "image/png", "data": "aW1hZ2U="},
+		{"type": "image", "mimeType": "image/webp", "url": signedURL},
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("promptContentForClaudeSDK = %#v, want %#v", got, want)
 	}
 }
 

--- a/packages/agent/daemon/runtime/claude_sdk_adapter_test.go
+++ b/packages/agent/daemon/runtime/claude_sdk_adapter_test.go
@@ -1701,6 +1701,7 @@ func TestClaudeCodeSDKAdapterAcceptsImagePromptContent(t *testing.T) {
 }
 
 func TestClaudeCodeSDKAdapterExecSendsStructuredPromptContent(t *testing.T) {
+	signedURL := "https://bucket.example/image.webp?token=secret"
 	conn := &scriptedClaudeSDKConnection{
 		frames: []ProcessFrame{{
 			Stdout: []byte(`{"type":"turn_completed","payload":{"turnId":"turn-image","stopReason":"end_turn"}}` + "\n"),
@@ -1722,6 +1723,7 @@ func TestClaudeCodeSDKAdapterExecSendsStructuredPromptContent(t *testing.T) {
 		[]PromptContentBlock{
 			{Type: "text", Text: "what is in this image?"},
 			{Type: "image", MimeType: "image/png", Data: "aW1hZ2U="},
+			{Type: "image", MimeType: "image/webp", URL: signedURL},
 		},
 		"what is in this image?",
 		"turn-image",
@@ -1739,8 +1741,8 @@ func TestClaudeCodeSDKAdapterExecSendsStructuredPromptContent(t *testing.T) {
 		t.Fatalf("exec prompt = %#v, want legacy text prompt", sent[0].Payload["prompt"])
 	}
 	content, ok := sent[0].Payload["content"].([]any)
-	if !ok || len(content) != 2 {
-		t.Fatalf("exec content = %#v, want text and image blocks", sent[0].Payload["content"])
+	if !ok || len(content) != 3 {
+		t.Fatalf("exec content = %#v, want text, data image, and URL image blocks", sent[0].Payload["content"])
 	}
 	textBlock, _ := content[0].(map[string]any)
 	if textBlock["type"] != "text" || textBlock["text"] != "what is in this image?" {
@@ -1749,6 +1751,10 @@ func TestClaudeCodeSDKAdapterExecSendsStructuredPromptContent(t *testing.T) {
 	imageBlock, _ := content[1].(map[string]any)
 	if imageBlock["type"] != "image" || imageBlock["mimeType"] != "image/png" || imageBlock["data"] != "aW1hZ2U=" {
 		t.Fatalf("image block = %#v", imageBlock)
+	}
+	urlImageBlock, _ := content[2].(map[string]any)
+	if urlImageBlock["type"] != "image" || urlImageBlock["mimeType"] != "image/webp" || urlImageBlock["url"] != signedURL {
+		t.Fatalf("URL image block = %#v", urlImageBlock)
 	}
 }
 

--- a/packages/agent/daemon/runtime/codex_appserver_adapter.go
+++ b/packages/agent/daemon/runtime/codex_appserver_adapter.go
@@ -426,9 +426,9 @@ func (a *CodexAppServerAdapter) SetProviderLaunchPreparer(preparer ProviderLaunc
 	a.preparer = preparer
 }
 
-func (*CodexAppServerAdapter) ValidatePromptContent(Session, []PromptContentBlock) error {
+func (*CodexAppServerAdapter) ValidatePromptContent(_ Session, content []PromptContentBlock) error {
 	// Codex app-server accepts text, image, and localImage user input items.
-	return nil
+	return validateRuntimePromptContentImages(content)
 }
 
 func (a *CodexAppServerAdapter) commandString() string {

--- a/packages/agent/daemon/runtime/codex_appserver_events.go
+++ b/packages/agent/daemon/runtime/codex_appserver_events.go
@@ -1685,9 +1685,13 @@ func appServerUserInput(content []PromptContentBlock) []map[string]any {
 				"text": block.Text,
 			})
 		case "image":
+			imageURL := strings.TrimSpace(block.URL)
+			if imageURL == "" {
+				imageURL = "data:" + firstNonEmpty(block.MimeType, "image/png") + ";base64," + block.Data
+			}
 			out = append(out, map[string]any{
 				"type": "image",
-				"url":  "data:" + firstNonEmpty(block.MimeType, "image/png") + ";base64," + block.Data,
+				"url":  imageURL,
 			})
 		case "skill", "mention":
 			item := map[string]any{

--- a/packages/agent/daemon/runtime/codex_appserver_events_test.go
+++ b/packages/agent/daemon/runtime/codex_appserver_events_test.go
@@ -160,6 +160,22 @@ func TestAppServerUserInputIncludesSkillAndMentionItems(t *testing.T) {
 	}
 }
 
+func TestAppServerUserInputMapsImageDataAndURLSources(t *testing.T) {
+	t.Parallel()
+	signedURL := "https://bucket.example/image.webp?token=secret"
+	got := appServerUserInput([]PromptContentBlock{
+		{Type: "image", MimeType: "image/png", Data: "aGk="},
+		{Type: "image", MimeType: "image/webp", URL: signedURL},
+	})
+	want := []map[string]any{
+		{"type": "image", "url": "data:image/png;base64,aGk="},
+		{"type": "image", "url": signedURL},
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("appServerUserInput = %#v, want %#v", got, want)
+	}
+}
+
 func TestCodexAppServerAdapterRoutesLinkedChildThreadEvents(t *testing.T) {
 	t.Parallel()
 

--- a/packages/agent/daemon/runtime/controller.go
+++ b/packages/agent/daemon/runtime/controller.go
@@ -633,6 +633,9 @@ func (c *Controller) Exec(ctx context.Context, input ExecInput) (ExecResult, err
 	if refreshed, ok := c.get(session.RoomID, session.AgentSessionID); ok {
 		session = refreshed
 	}
+	if err := validateRuntimePromptContentImages(input.Content); err != nil {
+		return ExecResult{}, err
+	}
 	content := normalizeRuntimePromptContent(input.Content)
 	if len(content) == 0 {
 		return ExecResult{}, fmt.Errorf("prompt is required")
@@ -1131,6 +1134,9 @@ func sessionRecreatedNoticeEvent(session Session) (activityshared.Event, bool) {
 func (c *Controller) ValidatePromptContent(_ context.Context, input ExecInput) error {
 	session, adapter, err := c.sessionAndAdapter(input.RoomID, input.AgentSessionID)
 	if err != nil {
+		return err
+	}
+	if err := validateRuntimePromptContentImages(input.Content); err != nil {
 		return err
 	}
 	content := normalizeRuntimePromptContentForValidation(input.Content)

--- a/packages/agent/daemon/runtime/prompt_content.go
+++ b/packages/agent/daemon/runtime/prompt_content.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"net/url"
 	"strings"
 )
 
@@ -24,14 +25,19 @@ func normalizeRuntimePromptContent(content []PromptContentBlock) []PromptContent
 		case "image":
 			mimeType := strings.TrimSpace(block.MimeType)
 			data := strings.TrimSpace(block.Data)
+			imageURL := strings.TrimSpace(block.URL)
 			attachmentID := strings.TrimSpace(block.AttachmentID)
-			if !runtimePromptImageMimeTypeSupported(mimeType) || (data == "" && attachmentID == "") {
+			if !runtimePromptImageMimeTypeSupported(mimeType) ||
+				(data == "" && imageURL == "" && attachmentID == "") ||
+				(data != "" && imageURL != "") ||
+				(imageURL != "" && !runtimePromptImageURLSafe(imageURL)) {
 				continue
 			}
 			out = append(out, PromptContentBlock{
 				Type:         "image",
 				MimeType:     mimeType,
 				Data:         data,
+				URL:          imageURL,
 				AttachmentID: attachmentID,
 				Name:         strings.TrimSpace(block.Name),
 			})
@@ -63,14 +69,19 @@ func normalizeRuntimePromptContentForValidation(content []PromptContentBlock) []
 			out = append(out, PromptContentBlock{Type: "text", Text: text})
 		case "image":
 			mimeType := strings.TrimSpace(block.MimeType)
+			data := strings.TrimSpace(block.Data)
+			imageURL := strings.TrimSpace(block.URL)
 			if !runtimePromptImageMimeTypeSupported(mimeType) ||
-				(strings.TrimSpace(block.Data) == "" && strings.TrimSpace(block.AttachmentID) == "") {
+				(data == "" && imageURL == "" && strings.TrimSpace(block.AttachmentID) == "") ||
+				(data != "" && imageURL != "") ||
+				(imageURL != "" && !runtimePromptImageURLSafe(imageURL)) {
 				continue
 			}
 			out = append(out, PromptContentBlock{
 				Type:         "image",
 				MimeType:     mimeType,
-				Data:         strings.TrimSpace(block.Data),
+				Data:         data,
+				URL:          imageURL,
 				AttachmentID: strings.TrimSpace(block.AttachmentID),
 				Name:         strings.TrimSpace(block.Name),
 			})
@@ -88,6 +99,29 @@ func normalizeRuntimePromptContentForValidation(content []PromptContentBlock) []
 		}
 	}
 	return out
+}
+
+func validateRuntimePromptContentImages(content []PromptContentBlock) error {
+	for _, block := range content {
+		if strings.TrimSpace(block.Type) != "image" {
+			continue
+		}
+		data := strings.TrimSpace(block.Data)
+		imageURL := strings.TrimSpace(block.URL)
+		attachmentID := strings.TrimSpace(block.AttachmentID)
+		if !runtimePromptImageMimeTypeSupported(block.MimeType) ||
+			(data == "" && imageURL == "" && attachmentID == "") ||
+			(data != "" && imageURL != "") ||
+			(imageURL != "" && !runtimePromptImageURLSafe(imageURL)) {
+			return ErrPromptImageUnsupported
+		}
+	}
+	return nil
+}
+
+func runtimePromptImageURLSafe(value string) bool {
+	parsed, err := url.ParseRequestURI(strings.TrimSpace(value))
+	return err == nil && parsed.Scheme == "https" && parsed.Host != "" && parsed.User == nil && parsed.Opaque == ""
 }
 
 func runtimePromptImageMimeTypeSupported(mimeType string) bool {

--- a/packages/agent/daemon/runtime/prompt_content_test.go
+++ b/packages/agent/daemon/runtime/prompt_content_test.go
@@ -2,11 +2,49 @@ package agentruntime
 
 import (
 	"context"
+	"encoding/json"
+	"strings"
 	"testing"
 )
 
 func textPrompt(text string) []PromptContentBlock {
 	return []PromptContentBlock{{Type: "text", Text: text}}
+}
+
+func TestNormalizeRuntimePromptContentPreservesURLOnlyImage(t *testing.T) {
+	signedURL := "https://bucket.example/image.webp?token=secret"
+	content := normalizeRuntimePromptContent([]PromptContentBlock{{Type: "image", MimeType: " image/webp ", URL: " " + signedURL + " ", Name: " image.webp "}})
+	if len(content) != 1 || content[0].URL != signedURL || content[0].Data != "" {
+		t.Fatalf("content = %#v, want normalized URL-only image", content)
+	}
+}
+
+func TestValidateRuntimePromptContentImagesRejectsUnsafeOrAmbiguousURL(t *testing.T) {
+	for _, block := range []PromptContentBlock{
+		{Type: "image", MimeType: "image/png", URL: "http://bucket.example/image.png"},
+		{Type: "image", MimeType: "image/png", URL: "https://user:pass@bucket.example/image.png"},
+		{Type: "image", MimeType: "image/png", URL: "https://bucket.example/image.png", Data: "aW1hZ2U="},
+	} {
+		if err := validateRuntimePromptContentImages([]PromptContentBlock{block}); err != ErrPromptImageUnsupported {
+			t.Fatalf("validateRuntimePromptContentImages(%#v) = %v, want ErrPromptImageUnsupported", block, err)
+		}
+	}
+}
+
+func TestUserPromptActivityPayloadRedactsImageSources(t *testing.T) {
+	signedURL := "https://bucket.example/image.png?token=bearer-secret"
+	payload := userPromptActivityPayload([]PromptContentBlock{{Type: "image", MimeType: "image/png", URL: signedURL, Data: "base64-secret", AttachmentID: "attachment-1", Name: "screen.png"}}, "", nil)
+	encoded, err := json.Marshal(payload)
+	if err != nil {
+		t.Fatal(err)
+	}
+	serialized := string(encoded)
+	if strings.Contains(serialized, signedURL) || strings.Contains(serialized, "base64-secret") {
+		t.Fatalf("activity payload leaked image source: %s", serialized)
+	}
+	if !strings.Contains(serialized, "attachment-1") || !strings.Contains(serialized, "screen.png") {
+		t.Fatalf("activity payload lost safe metadata: %s", serialized)
+	}
 }
 
 func TestNormalizeRuntimePromptContentAcceptsAttachmentOnlyImage(t *testing.T) {

--- a/packages/agent/daemon/runtime/standard_acp_adapter.go
+++ b/packages/agent/daemon/runtime/standard_acp_adapter.go
@@ -181,6 +181,16 @@ func (a *standardACPAdapter) ValidatePromptContent(session Session, content []Pr
 	if !promptContentHasImage(content) {
 		return nil
 	}
+	if err := validateRuntimePromptContentImages(content); err != nil {
+		return err
+	}
+	for _, block := range content {
+		if block.Type == "image" && strings.TrimSpace(block.URL) != "" {
+			// ACP image prompt blocks carry inline base64 data and have no URL
+			// source variant. Never download or rewrite the remote image here.
+			return ErrPromptImageUnsupported
+		}
+	}
 	acpSession := a.getSession(session.AgentSessionID)
 	if acpSession != nil && acpSession.promptImage {
 		return nil

--- a/packages/agent/daemon/runtime/standard_acp_adapter_test.go
+++ b/packages/agent/daemon/runtime/standard_acp_adapter_test.go
@@ -1112,6 +1112,24 @@ func TestStandardACPAdapterRejectsImagePromptWithoutCapability(t *testing.T) {
 	}
 }
 
+func TestStandardACPAdapterRejectsURLImageEvenWithImageCapability(t *testing.T) {
+	t.Parallel()
+
+	transport := newStandardACPTransport("Claude Agent", "claude-session-url")
+	adapter := NewClaudeCodeAdapter(transport)
+	session := standardTestSession(ProviderClaudeCode)
+	if _, err := adapter.Start(context.Background(), session); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	session.ProviderSessionID = "claude-session-url"
+	content := []PromptContentBlock{{
+		Type: "image", MimeType: "image/png", URL: "https://bucket.example/image.png?token=secret",
+	}}
+	if err := adapter.ValidatePromptContent(session, content); !errors.Is(err, ErrPromptImageUnsupported) {
+		t.Fatalf("ValidatePromptContent URL image error = %v, want ErrPromptImageUnsupported", err)
+	}
+}
+
 func TestClaudeCodeAdapterPermissionRequestAcceptsInteractiveSelection(t *testing.T) {
 	t.Parallel()
 

--- a/packages/agent/daemon/runtime/types.go
+++ b/packages/agent/daemon/runtime/types.go
@@ -160,6 +160,7 @@ type PromptContentBlock struct {
 	Text         string `json:"text,omitempty"`
 	MimeType     string `json:"mimeType,omitempty"`
 	Data         string `json:"data,omitempty"`
+	URL          string `json:"url,omitempty"`
 	AttachmentID string `json:"attachmentId,omitempty"`
 	Name         string `json:"name,omitempty"`
 	Path         string `json:"path,omitempty"`

--- a/packages/agent/gui/agent-gui/agentGuiNode/AgentQueuedPromptPanel.spec.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/AgentQueuedPromptPanel.spec.tsx
@@ -402,6 +402,43 @@ describe("AgentQueuedPromptPanel", () => {
     ).toBeInTheDocument();
   });
 
+  it("does not hydrate or fetch queued HTTPS image URLs in the owner", () => {
+    const readSessionAttachment = vi.fn();
+    const url = "https://bucket.example/image.webp?token=secret";
+    setAgentActivityRuntimeForTests({ readSessionAttachment } as never);
+    const { container } = render(
+      <AgentQueuedPromptPanel
+        queuedPrompts={[
+          {
+            id: "queued-url",
+            content: [
+              {
+                type: "image",
+                mimeType: "image/webp",
+                url,
+                attachmentId: "remote-image",
+                name: "image.webp"
+              }
+            ],
+            createdAtUnixMs: 1
+          }
+        ]}
+        drainingQueuedPromptId={null}
+        labels={labels}
+        onSendQueuedPromptNext={vi.fn()}
+        onRemoveQueuedPrompt={vi.fn()}
+        onEditQueuedPrompt={vi.fn()}
+        agentSessionId="session-1"
+        workspaceId="workspace-1"
+      />
+    );
+
+    expect(
+      container.querySelector(".agent-gui-node__composer-queued-prompt-image")
+    ).not.toBeInTheDocument();
+    expect(readSessionAttachment).not.toHaveBeenCalled();
+  });
+
   it("emits queued mention link clicks without toggling the queue panel", () => {
     const onLinkClick = vi.fn();
     const { container } = render(

--- a/packages/agent/gui/agent-gui/agentGuiNode/AgentQueuedPromptPanel.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/AgentQueuedPromptPanel.tsx
@@ -43,6 +43,7 @@ type QueuedPromptImageBlock = AgentPromptContentBlock & {
   mimeType: "image/png" | "image/jpeg" | "image/webp";
   attachmentId?: string;
   data?: string;
+  url?: string;
   path?: string;
 };
 
@@ -82,6 +83,23 @@ function queuedPromptImageDataUrl(
   return data.startsWith("data:") ? data : `data:${mimeType};base64,${data}`;
 }
 
+function queuedPromptImageHasSafeRemoteUrl(
+  image: QueuedPromptImageBlock
+): boolean {
+  const value = image.url?.trim() ?? "";
+  try {
+    const url = new URL(value);
+    return (
+      url.protocol === "https:" &&
+      Boolean(url.hostname) &&
+      !url.username &&
+      !url.password
+    );
+  } catch {
+    return false;
+  }
+}
+
 function queuedPromptImageKey(
   queuedPrompt: AgentGUIQueuedPromptVM,
   image: QueuedPromptImageBlock,
@@ -116,6 +134,7 @@ function useQueuedPromptImageSources(input: {
         const path = image.path?.trim() ?? "";
         return (
           !queuedPromptImageDataUrl(image) &&
+          !queuedPromptImageHasSafeRemoteUrl(image) &&
           !sources.has(key) &&
           Boolean(attachmentId || path) &&
           Boolean(workspaceId)

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/agentGuiController.promptHelpers.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/agentGuiController.promptHelpers.ts
@@ -109,8 +109,11 @@ export function normalizePromptContentBlocks(
     if (block.type === "image") {
       const mimeType = block.mimeType?.trim();
       const data = block.data?.trim();
+      const url = block.url?.trim();
       if (
-        !data ||
+        (!data && !url) ||
+        (data && url) ||
+        (url && !isSafePromptImageUrl(url)) ||
         (mimeType !== "image/png" &&
           mimeType !== "image/jpeg" &&
           mimeType !== "image/webp")
@@ -120,7 +123,10 @@ export function normalizePromptContentBlocks(
       result.push({
         type: "image",
         mimeType,
-        data,
+        ...(url ? { url } : { data }),
+        ...(block.attachmentId?.trim()
+          ? { attachmentId: block.attachmentId.trim() }
+          : {}),
         ...(block.name?.trim() ? { name: block.name.trim() } : {})
       });
       continue;
@@ -134,6 +140,20 @@ export function normalizePromptContentBlocks(
     }
   }
   return result;
+}
+
+function isSafePromptImageUrl(value: string): boolean {
+  try {
+    const url = new URL(value);
+    return (
+      url.protocol === "https:" &&
+      Boolean(url.hostname) &&
+      !url.username &&
+      !url.password
+    );
+  } catch {
+    return false;
+  }
 }
 
 export function promptContentDisplayText(

--- a/packages/agent/gui/agent-gui/agentGuiNode/model/agentComposerDraft.spec.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/model/agentComposerDraft.spec.ts
@@ -8,10 +8,49 @@ import {
   agentPromptContentToComposerDraft,
   emptyAgentComposerDraft,
   extractPastedTextArchivePaths,
-  linkifyPastedTextReferences
+  linkifyPastedTextReferences,
+  normalizeAgentPromptContentBlocks
 } from "./agentComposerDraft";
 
 describe("agentComposerDraft", () => {
+  it("preserves safe URL-only image blocks and rejects unsafe or ambiguous sources", () => {
+    const signedUrl = "https://bucket.example/image.png?token=secret";
+    expect(
+      normalizeAgentPromptContentBlocks([
+        {
+          type: "image",
+          mimeType: "image/png",
+          url: ` ${signedUrl} `,
+          attachmentId: " attachment-1 ",
+          name: " screenshot.png "
+        }
+      ])
+    ).toEqual([
+      {
+        type: "image",
+        mimeType: "image/png",
+        url: signedUrl,
+        attachmentId: "attachment-1",
+        name: "screenshot.png"
+      }
+    ]);
+    expect(
+      normalizeAgentPromptContentBlocks([
+        {
+          type: "image",
+          mimeType: "image/png",
+          url: "http://example.com/a.png"
+        },
+        {
+          type: "image",
+          mimeType: "image/png",
+          url: signedUrl,
+          data: "aW1hZ2U="
+        }
+      ])
+    ).toEqual([]);
+  });
+
   it("normalizes empty drafts", () => {
     const draft = emptyAgentComposerDraft();
 
@@ -241,6 +280,48 @@ describe("agentComposerDraft", () => {
         mimeType: "image/png",
         data: "aW1hZ2U=",
         name: "screen.png"
+      }
+    ]);
+  });
+
+  it("round-trips HTTPS URL image drafts without hydration", () => {
+    const url = "https://bucket.example/screen.webp?X-Amz-Signature=secret";
+    const draft = agentPromptContentToComposerDraft(
+      [
+        {
+          type: "image",
+          mimeType: "image/webp",
+          url,
+          attachmentId: "attachment-remote",
+          name: "screen.webp"
+        }
+      ],
+      "remote"
+    );
+
+    expect(draft.images).toEqual([
+      {
+        id: "remote:image:0",
+        name: "screen.webp",
+        mimeType: "image/webp",
+        attachmentId: "attachment-remote",
+        url,
+        previewUrl: url
+      }
+    ]);
+    expect(
+      agentComposerDraftToPromptContent({
+        draft,
+        provider: "codex",
+        skills: []
+      })
+    ).toEqual([
+      {
+        type: "image",
+        mimeType: "image/webp",
+        attachmentId: "attachment-remote",
+        url,
+        name: "screen.webp"
       }
     ]);
   });

--- a/packages/agent/gui/agent-gui/agentGuiNode/model/agentComposerDraft.spec.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/model/agentComposerDraft.spec.ts
@@ -326,6 +326,45 @@ describe("agentComposerDraft", () => {
     ]);
   });
 
+  it("round-trips URL-only image drafts when editing queued content", () => {
+    const url = "https://bucket.example/queued.png?X-Amz-Signature=secret";
+    const draft = agentPromptContentToComposerDraft(
+      [
+        {
+          type: "image",
+          mimeType: "image/png",
+          url,
+          name: "queued.png"
+        }
+      ],
+      "queued"
+    );
+
+    expect(draft.images).toEqual([
+      {
+        id: "queued:image:0",
+        name: "queued.png",
+        mimeType: "image/png",
+        url,
+        previewUrl: url
+      }
+    ]);
+    expect(
+      agentComposerDraftToPromptContent({
+        draft,
+        provider: "codex",
+        skills: []
+      })
+    ).toEqual([
+      {
+        type: "image",
+        mimeType: "image/png",
+        url,
+        name: "queued.png"
+      }
+    ]);
+  });
+
   it("converts attachment-backed image-only drafts into prompt content", () => {
     expect(
       agentComposerDraftToPromptContent({

--- a/packages/agent/gui/agent-gui/agentGuiNode/model/agentComposerDraft.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/model/agentComposerDraft.ts
@@ -123,9 +123,12 @@ export function normalizeAgentPromptContentBlocks(
       const mimeType = block.mimeType?.trim();
       const attachmentId = block.attachmentId?.trim();
       const data = block.data?.trim();
+      const url = block.url?.trim();
       const imagePath = block.path?.trim();
       if (
-        (!attachmentId && !data && !imagePath) ||
+        (!attachmentId && !data && !url && !imagePath) ||
+        (data && url) ||
+        (url && !isSafePromptImageUrl(url)) ||
         (mimeType !== "image/png" &&
           mimeType !== "image/jpeg" &&
           mimeType !== "image/webp")
@@ -135,11 +138,14 @@ export function normalizeAgentPromptContentBlocks(
       result.push({
         type: "image",
         mimeType,
-        ...(attachmentId
-          ? { attachmentId }
-          : imagePath
-            ? { path: imagePath }
-            : { data }),
+        ...(attachmentId ? { attachmentId } : {}),
+        ...(url
+          ? { url }
+          : data
+            ? { data }
+            : imagePath
+              ? { path: imagePath }
+              : {}),
         ...(block.name?.trim() ? { name: block.name.trim() } : {})
       });
       continue;
@@ -180,6 +186,20 @@ export function normalizeAgentPromptContentBlocks(
     }
   }
   return result;
+}
+
+function isSafePromptImageUrl(value: string): boolean {
+  try {
+    const url = new URL(value);
+    return (
+      url.protocol === "https:" &&
+      Boolean(url.hostname) &&
+      !url.username &&
+      !url.password
+    );
+  } catch {
+    return false;
+  }
 }
 
 export function agentPromptContentDisplayText(
@@ -276,8 +296,9 @@ export function agentComposerDraftToPromptContent(input: {
       .map((image) => ({
         type: "image" as const,
         mimeType: image.mimeType,
-        ...(image.attachmentId
-          ? { attachmentId: image.attachmentId }
+        ...(image.attachmentId ? { attachmentId: image.attachmentId } : {}),
+        ...(image.url
+          ? { url: image.url }
           : image.path
             ? { path: image.path }
             : { data: image.data }),
@@ -598,11 +619,12 @@ function agentPromptImageBlockToDraftImage(
     mimeType: image.mimeType,
     ...(image.attachmentId ? { attachmentId: image.attachmentId } : {}),
     ...(image.data ? { data: image.data } : {}),
+    ...(image.url ? { url: image.url } : {}),
     ...(image.path ? { path: image.path } : {}),
     previewUrl:
       typeof image.data === "string" && image.data
         ? `data:${image.mimeType};base64,${image.data}`
-        : (image.path ?? "")
+        : (image.url ?? image.path ?? "")
   };
 }
 

--- a/packages/agent/gui/agent-gui/agentGuiNode/model/agentComposerDraft.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/model/agentComposerDraft.ts
@@ -232,6 +232,7 @@ export function agentPromptContentImageBlocks(
       block.type === "image" &&
       (typeof block.attachmentId === "string" ||
         typeof block.data === "string" ||
+        typeof block.url === "string" ||
         typeof block.path === "string") &&
       typeof block.mimeType === "string"
   );

--- a/packages/agent/gui/agent-gui/agentGuiNode/model/agentGuiNodeTypes.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/model/agentGuiNodeTypes.ts
@@ -91,6 +91,7 @@ export interface AgentComposerDraftImage {
   mimeType: "image/png" | "image/jpeg" | "image/webp";
   attachmentId?: string;
   data?: string;
+  url?: string;
   path?: string;
   previewUrl: string;
   uploading?: boolean;

--- a/packages/clients/tuttid-ts/src/generated/types.gen.ts
+++ b/packages/clients/tuttid-ts/src/generated/types.gen.ts
@@ -1574,7 +1574,14 @@ export type AgentPromptContentBlock = {
   type: "text" | "image" | "skill" | "mention";
   text?: string;
   mimeType?: "image/png" | "image/jpeg" | "image/webp";
+  /**
+   * Base64-encoded image bytes. Mutually exclusive with url.
+   */
   data?: string;
+  /**
+   * HTTPS image URL fetched directly by a capable provider. Mutually exclusive with data.
+   */
+  url?: string;
   attachmentId?: string;
   name?: string;
   path?: string;

--- a/services/tuttid/agent_runtime_adapter.go
+++ b/services/tuttid/agent_runtime_adapter.go
@@ -181,6 +181,7 @@ func runtimePromptContentFromService(content []agentservice.PromptContentBlock) 
 			Text:         block.Text,
 			MimeType:     block.MimeType,
 			Data:         block.Data,
+			URL:          block.URL,
 			AttachmentID: block.AttachmentID,
 			Name:         block.Name,
 			Path:         block.Path,

--- a/services/tuttid/api/daemon_agent_sessions.go
+++ b/services/tuttid/api/daemon_agent_sessions.go
@@ -617,6 +617,9 @@ func agentPromptContentFromGenerated(content []tuttigenerated.AgentPromptContent
 		if block.Data != nil {
 			item.Data = *block.Data
 		}
+		if block.Url != nil {
+			item.URL = *block.Url
+		}
 		if block.AttachmentId != nil {
 			item.AttachmentID = *block.AttachmentId
 		}

--- a/services/tuttid/api/generated/types.gen.go
+++ b/services/tuttid/api/generated/types.gen.go
@@ -1916,13 +1916,18 @@ type AgentActivityTurnLifecycle struct {
 
 // AgentPromptContentBlock defines model for AgentPromptContentBlock.
 type AgentPromptContentBlock struct {
-	AttachmentId *string                          `json:"attachmentId,omitempty"`
-	Data         *string                          `json:"data,omitempty"`
-	MimeType     *AgentPromptContentBlockMimeType `json:"mimeType,omitempty"`
-	Name         *string                          `json:"name,omitempty"`
-	Path         *string                          `json:"path,omitempty"`
-	Text         *string                          `json:"text,omitempty"`
-	Type         AgentPromptContentBlockType      `json:"type"`
+	AttachmentId *string `json:"attachmentId,omitempty"`
+
+	// Data Base64-encoded image bytes. Mutually exclusive with url.
+	Data     *string                          `json:"data,omitempty"`
+	MimeType *AgentPromptContentBlockMimeType `json:"mimeType,omitempty"`
+	Name     *string                          `json:"name,omitempty"`
+	Path     *string                          `json:"path,omitempty"`
+	Text     *string                          `json:"text,omitempty"`
+	Type     AgentPromptContentBlockType      `json:"type"`
+
+	// Url HTTPS image URL fetched directly by a capable provider. Mutually exclusive with data.
+	Url *string `json:"url,omitempty"`
 }
 
 // AgentPromptContentBlockMimeType defines model for AgentPromptContentBlock.MimeType.

--- a/services/tuttid/api/openapi/tuttid.v1.yaml
+++ b/services/tuttid/api/openapi/tuttid.v1.yaml
@@ -7600,6 +7600,12 @@ components:
             - image/webp
         data:
           type: string
+          description: Base64-encoded image bytes. Mutually exclusive with url.
+        url:
+          type: string
+          format: uri
+          pattern: ^https://
+          description: HTTPS image URL fetched directly by a capable provider. Mutually exclusive with data.
         attachmentId:
           type: string
         name:

--- a/services/tuttid/api/openapi/tuttid.v1.yaml
+++ b/services/tuttid/api/openapi/tuttid.v1.yaml
@@ -7604,7 +7604,7 @@ components:
         url:
           type: string
           format: uri
-          pattern: ^https://
+          pattern: '^https://[^@/?#\s]+([/?#]|$)'
           description: HTTPS image URL fetched directly by a capable provider. Mutually exclusive with data.
         attachmentId:
           type: string

--- a/services/tuttid/service/agent/prompt_content.go
+++ b/services/tuttid/service/agent/prompt_content.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"net/url"
 	"os"
 	"path/filepath"
 	"strings"
@@ -59,8 +60,12 @@ func normalizePromptContent(content []PromptContentBlock) ([]PromptContentBlock,
 				return nil, "", ErrInvalidArgument
 			}
 			data := strings.TrimSpace(block.Data)
+			imageURL := strings.TrimSpace(block.URL)
 			path := strings.TrimSpace(block.Path)
-			if data == "" && strings.TrimSpace(block.AttachmentID) == "" && path == "" {
+			if data != "" && imageURL != "" {
+				return nil, "", ErrInvalidArgument
+			}
+			if data == "" && imageURL == "" && strings.TrimSpace(block.AttachmentID) == "" && path == "" {
 				return nil, "", ErrInvalidArgument
 			}
 			if data != "" {
@@ -68,11 +73,15 @@ func normalizePromptContent(content []PromptContentBlock) ([]PromptContentBlock,
 					return nil, "", ErrInvalidArgument
 				}
 			}
+			if imageURL != "" && !safePromptImageURL(imageURL) {
+				return nil, "", ErrInvalidArgument
+			}
 			hasInput = true
 			normalized = append(normalized, PromptContentBlock{
 				Type:         "image",
 				MimeType:     mimeType,
 				Data:         data,
+				URL:          imageURL,
 				AttachmentID: strings.TrimSpace(block.AttachmentID),
 				Name:         strings.TrimSpace(block.Name),
 				Path:         path,
@@ -98,6 +107,14 @@ func normalizePromptContent(content []PromptContentBlock) ([]PromptContentBlock,
 	return normalized, strings.Join(textParts, "\n"), nil
 }
 
+func safePromptImageURL(value string) bool {
+	parsed, err := url.ParseRequestURI(strings.TrimSpace(value))
+	if err != nil || parsed.Scheme != "https" || parsed.Host == "" || parsed.User != nil {
+		return false
+	}
+	return parsed.Opaque == ""
+}
+
 func supportedPromptImageMimeType(mimeType string) bool {
 	switch strings.TrimSpace(mimeType) {
 	case "image/png", "image/jpeg", "image/webp":
@@ -114,8 +131,9 @@ func (s PromptAttachmentStore) PersistRequestContent(workspaceID, agentSessionID
 	out := make([]PromptContentBlock, 0, len(content))
 	for _, block := range content {
 		dataBase64 := strings.TrimSpace(block.Data)
+		imageURL := strings.TrimSpace(block.URL)
 		sourcePath := strings.TrimSpace(block.Path)
-		if block.Type != "image" || (dataBase64 == "" && sourcePath == "") {
+		if block.Type != "image" || imageURL != "" || (dataBase64 == "" && sourcePath == "") {
 			out = append(out, block)
 			continue
 		}
@@ -244,6 +262,10 @@ func (s PromptAttachmentStore) HydrateRuntimeContent(workspaceID, agentSessionID
 			continue
 		}
 		if strings.TrimSpace(block.Data) != "" {
+			out = append(out, block)
+			continue
+		}
+		if strings.TrimSpace(block.URL) != "" {
 			out = append(out, block)
 			continue
 		}

--- a/services/tuttid/service/agent/prompt_content_test.go
+++ b/services/tuttid/service/agent/prompt_content_test.go
@@ -30,6 +30,44 @@ func TestNormalizePromptContentAcceptsImagePath(t *testing.T) {
 	}
 }
 
+func TestNormalizePromptContentAcceptsHTTPSImageURL(t *testing.T) {
+	signedURL := "https://bucket.example/image.png?X-Amz-Signature=secret"
+	content, _, err := normalizePromptContent([]PromptContentBlock{{
+		Type: "image", MimeType: "image/png", URL: " " + signedURL + " ", AttachmentID: "attachment-1", Name: "screen.png",
+	}})
+	if err != nil {
+		t.Fatalf("normalizePromptContent() error = %v, want nil", err)
+	}
+	if len(content) != 1 || content[0].URL != signedURL || content[0].AttachmentID != "attachment-1" {
+		t.Fatalf("content = %#v, want URL-backed image metadata", content)
+	}
+
+	store := PromptAttachmentStore{RootDir: t.TempDir()}
+	persisted, err := store.PersistRequestContent("workspace-1", "session-1", content)
+	if err != nil {
+		t.Fatalf("PersistRequestContent() error = %v", err)
+	}
+	hydrated, err := store.HydrateRuntimeContent("workspace-1", "session-1", persisted)
+	if err != nil {
+		t.Fatalf("HydrateRuntimeContent() error = %v", err)
+	}
+	if hydrated[0].URL != signedURL || hydrated[0].Data != "" {
+		t.Fatalf("hydrated image = %#v, want URL without owner hydration", hydrated[0])
+	}
+}
+
+func TestNormalizePromptContentRejectsUnsafeOrAmbiguousImageURL(t *testing.T) {
+	for _, block := range []PromptContentBlock{
+		{Type: "image", MimeType: "image/png", URL: "http://bucket.example/image.png"},
+		{Type: "image", MimeType: "image/png", URL: "https://user:pass@bucket.example/image.png"},
+		{Type: "image", MimeType: "image/png", URL: "https://bucket.example/image.png", Data: "aW1hZ2U="},
+	} {
+		if _, _, err := normalizePromptContent([]PromptContentBlock{block}); !errors.Is(err, ErrInvalidArgument) {
+			t.Fatalf("normalizePromptContent(%#v) error = %v, want ErrInvalidArgument", block, err)
+		}
+	}
+}
+
 func TestPromptAttachmentStoreRejectsDotPathSegments(t *testing.T) {
 	store := PromptAttachmentStore{RootDir: t.TempDir()}
 	for _, input := range []struct {

--- a/services/tuttid/service/agent/service_send_input.go
+++ b/services/tuttid/service/agent/service_send_input.go
@@ -9,6 +9,16 @@ import (
 func (s *Service) SendInput(ctx context.Context, workspaceID string, agentSessionID string, input SendInput) (SendInputResult, error) {
 	logAgentSubmitTrace("service.send.entered", workspaceID, agentSessionID, input.Metadata, nil)
 	nodeStartedAt := time.Now()
+	normalizedContent, _, err := normalizePromptContent(input.Content)
+	if err != nil {
+		s.reportAgentServiceNodeFailure(ctx, agentSessionID, "message_send", "content_normalized", "", nodeStartedAt, err)
+		return SendInputResult{}, err
+	}
+	s.reportAgentServiceNodeSuccess(ctx, agentSessionID, "message_send", "content_normalized", "", nodeStartedAt)
+	logAgentSubmitTrace("service.send.content_normalized", workspaceID, agentSessionID, input.Metadata, map[string]any{
+		"content_block_count": len(normalizedContent),
+	})
+	nodeStartedAt = time.Now()
 	runtimeSession, err := s.ensureRuntimeSession(ctx, workspaceID, agentSessionID)
 	if err != nil {
 		s.reportAgentServiceNodeFailure(ctx, agentSessionID, "message_send", "runtime_session_ready", "", nodeStartedAt, err)
@@ -17,16 +27,6 @@ func (s *Service) SendInput(ctx context.Context, workspaceID string, agentSessio
 	provider := strings.TrimSpace(runtimeSession.Provider)
 	s.reportAgentServiceNodeSuccess(ctx, agentSessionID, "message_send", "runtime_session_ready", provider, nodeStartedAt)
 	logAgentSubmitTrace("service.send.runtime_session_ready", workspaceID, agentSessionID, input.Metadata, nil)
-	nodeStartedAt = time.Now()
-	normalizedContent, _, err := normalizePromptContent(input.Content)
-	if err != nil {
-		s.reportAgentServiceNodeFailure(ctx, agentSessionID, "message_send", "content_normalized", provider, nodeStartedAt, err)
-		return SendInputResult{}, err
-	}
-	s.reportAgentServiceNodeSuccess(ctx, agentSessionID, "message_send", "content_normalized", provider, nodeStartedAt)
-	logAgentSubmitTrace("service.send.content_normalized", workspaceID, agentSessionID, input.Metadata, map[string]any{
-		"content_block_count": len(normalizedContent),
-	})
 	nodeStartedAt = time.Now()
 	if err := s.validatePromptContentForExec(ctx, workspaceID, agentSessionID, normalizedContent); err != nil {
 		s.reportAgentServiceNodeFailure(ctx, agentSessionID, "message_send", "prompt_validated", provider, nodeStartedAt, err)

--- a/services/tuttid/service/agent/service_test.go
+++ b/services/tuttid/service/agent/service_test.go
@@ -1922,6 +1922,41 @@ func TestServiceSendInputRejectsUnsupportedImageBeforePersistingAttachment(t *te
 	}
 }
 
+func TestServiceSendInputRejectsInvalidImageURLBeforeResumingRuntime(t *testing.T) {
+	runtime := newFakeRuntime()
+	service := newTestService(runtime)
+	service.SessionReader = fakeSessionReader{
+		sessions: map[string]PersistedSession{
+			"ws-1:session-1": {
+				ID:                "session-1",
+				WorkspaceID:       "ws-1",
+				Provider:          "codex",
+				ProviderSessionID: "thread-1",
+				Status:            "completed",
+				CreatedAtUnixMS:   1000,
+				UpdatedAtUnixMS:   2000,
+			},
+		},
+	}
+
+	_, err := service.SendInput(context.Background(), "ws-1", "session-1", SendInput{
+		Content: []PromptContentBlock{{
+			Type:     "image",
+			MimeType: "image/png",
+			URL:      "http://bucket.example/image.png",
+		}},
+	})
+	if !errors.Is(err, ErrInvalidArgument) {
+		t.Fatalf("SendInput error = %v, want ErrInvalidArgument", err)
+	}
+	if len(runtime.resumeCalls) != 0 {
+		t.Fatalf("resume calls = %d, want 0", len(runtime.resumeCalls))
+	}
+	if len(runtime.execCalls) != 0 {
+		t.Fatalf("exec calls = %d, want 0", len(runtime.execCalls))
+	}
+}
+
 func TestServiceLocalAttachmentPathRequiresWorkspaceSession(t *testing.T) {
 	runtime := newFakeRuntime()
 	runtime.sessions["ws-1:session-1"] = RuntimeSession{
@@ -5167,8 +5202,8 @@ func TestServiceSendInputReportsNodeResults(t *testing.T) {
 	}
 
 	assertAgentNodeSequence(t, reporter.events, []string{
-		"runtime_session_ready",
 		"content_normalized",
+		"runtime_session_ready",
 		"prompt_validated",
 		"prompt_prepared",
 		"runtime_exec",

--- a/services/tuttid/service/agent/session_types.go
+++ b/services/tuttid/service/agent/session_types.go
@@ -520,6 +520,7 @@ type PromptContentBlock struct {
 	Text         string `json:"text,omitempty"`
 	MimeType     string `json:"mimeType,omitempty"`
 	Data         string `json:"data,omitempty"`
+	URL          string `json:"url,omitempty"`
 	AttachmentID string `json:"attachmentId,omitempty"`
 	Name         string `json:"name,omitempty"`
 	Path         string `json:"path,omitempty"`


### PR DESCRIPTION
## Summary

- add HTTPS URL sources to structured AgentGUI image prompt blocks while preserving existing base64 and attachment paths
- pass remote image URLs directly to Codex app-server and Claude SDK, and explicitly reject them for ACP adapters that cannot represent URL images
- reject unsafe or ambiguous image sources and keep signed URLs/base64 out of activity reporting and traces
- update AgentGUI draft/queue handling, generated API contracts, tests, and architecture documentation

## Verification

- `pnpm check:full`
- `pnpm check:changed`
- focused AgentGUI, Claude sidecar, runtime adapter, service/API, and activity redaction tests

## Checklist

- [x] I kept the change focused on one concern.
- [x] I updated documentation when behavior, setup, or contributor workflow changed.
- [x] I updated all README/CONTRIBUTING language variants when changing their English source. (Not applicable; no README/CONTRIBUTING changes.)
- [x] I ran the lowest meaningful local checks for the changed surface.
- [x] My commits are signed off with DCO when required: `git commit -s`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds support for HTTPS image URLs in agent prompts and forwards them end-to-end. URL images are validated early, used for Claude SDK and Codex app-server, rejected for ACP, and sources are redacted from activity and traces.

- **New Features**
  - Added `url` to `AgentPromptContentBlock` in `tuttid` OpenAPI and `tuttid-ts` client; mutually exclusive with `data`.
  - AgentGUI composer and queue preserve HTTPS URLs; validate https-only with no credentials; preview uses the URL and does not hydrate.
  - Controller and service validate image blocks upfront; reject ambiguous or unsafe `data`+`url` mixes and non-HTTPS/userinfo URLs.
  - `claude-sdk-sidecar` maps safe URL images to structured SDK blocks; unsafe or ambiguous image blocks fall back to text.
  - Codex app-server sends URL images directly; falls back to `data:` URLs for base64 images.
  - Prompt attachment store bypasses persistence and hydration for URL images; activity/logs keep only safe metadata (no base64 or full URLs).

- **Migration**
  - If you generate clients from the OpenAPI, pull the updated spec to get the `url` field.
  - Send either `data` or `url` (never both). Only HTTPS URLs without userinfo are allowed.
  - For ACP targets, continue sending base64 `data`; URL images are not supported.

<sup>Written for commit ef19a04112574db8966b0a16b20b1473e546cdc6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tutti-os/tutti/pull/1042?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

