### PR TITLE
test(workbench): characterize shared host boundary

### DIFF
--- a/apps/desktop/src/renderer/src/features/workspace-workbench/services/internal/adapters/desktopWorkspaceWorkbenchRepository.test.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/services/internal/adapters/desktopWorkspaceWorkbenchRepository.test.ts
@@ -42,7 +42,7 @@ test("desktop workspace workbench repository preserves wallpaper metadata on hos
         createSnapshot(),
         "sky"
       ),
-      onSave(snapshot) {
+      onSave(_workspaceID, snapshot) {
         savedSnapshot = snapshot;
       }
     })
@@ -62,7 +62,7 @@ test("desktop workspace workbench repository preserves onboarding metadata on ho
         createSnapshot(),
         "2026-06-19T10:00:00.000Z"
       ),
-      onSave(snapshot) {
+      onSave(_workspaceID, snapshot) {
         savedSnapshot = snapshot;
       }
     })
@@ -74,16 +74,60 @@ test("desktop workspace workbench repository preserves onboarding metadata on ho
   assert.equal(hasWorkspaceOnboardingAutoOpened(savedSnapshot), true);
 });
 
+test("desktop workspace workbench repository keeps daemon calls workspace-scoped and preserves product metadata", async () => {
+  const calls: string[] = [];
+  const persistedSnapshots: WorkbenchSnapshot[] = [];
+  const authoritySnapshot = writeWorkspaceOnboardingAutoOpenedToSnapshot(
+    writeWorkspaceWallpaperIdToSnapshot(createSnapshot(), "sky"),
+    "2026-07-11T00:00:00.000Z"
+  );
+  const repository = createDesktopWorkspaceWorkbenchRepository(
+    createTuttidClient({
+      initialSnapshot: authoritySnapshot,
+      onLoad(workspaceID) {
+        calls.push(`get:${workspaceID}`);
+      },
+      onSave(workspaceID, snapshot) {
+        calls.push(`put:${workspaceID}`);
+        persistedSnapshots.push(snapshot);
+      }
+    })
+  );
+  const hostSnapshot: WorkbenchSnapshot = {
+    ...createSnapshot(),
+    metadata: { workbenchHostInitialized: true }
+  };
+
+  await repository.load("workspace-characterization");
+  const saved = await repository.save(
+    "workspace-characterization",
+    hostSnapshot
+  );
+
+  assert.deepEqual(calls, [
+    "get:workspace-characterization",
+    "put:workspace-characterization"
+  ]);
+  const persistedSnapshot = persistedSnapshots[0];
+  assert.ok(persistedSnapshot);
+  assert.equal(readWorkspaceWallpaperIdFromSnapshot(persistedSnapshot), "sky");
+  assert.equal(hasWorkspaceOnboardingAutoOpened(persistedSnapshot), true);
+  assert.equal(persistedSnapshot.metadata?.workbenchHostInitialized, true);
+  assert.equal(repository.readCached("workspace-characterization"), saved);
+});
+
 function createTuttidClient(input: {
   initialSnapshot: WorkbenchSnapshot;
-  onSave?: (snapshot: WorkbenchSnapshot) => void;
+  onLoad?: (workspaceID: string) => void;
+  onSave?: (workspaceID: string, snapshot: WorkbenchSnapshot) => void;
 }): TuttidClient {
   return {
-    async getWorkspaceWorkbench() {
+    async getWorkspaceWorkbench(workspaceID) {
+      input.onLoad?.(workspaceID);
       return input.initialSnapshot;
     },
-    async putWorkspaceWorkbench(_workspaceID, snapshot) {
-      input.onSave?.(snapshot);
+    async putWorkspaceWorkbench(workspaceID, snapshot) {
+      input.onSave?.(workspaceID, snapshot);
       return snapshot;
     }
   } as Partial<TuttidClient> as TuttidClient;

--- a/apps/desktop/src/renderer/src/features/workspace-workbench/services/internal/workspaceFilesContribution.test.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/services/internal/workspaceFilesContribution.test.ts
@@ -8,6 +8,61 @@ import { createWorkspaceFilesContribution } from "./workspaceFilesContribution.t
 import { workspaceFilesNodeID } from "./workspaceWorkbenchComposition.ts";
 const renderTrafficLights = () => null;
 
+test("workspace files contribution keeps its contribution, node, dock, and launch identities", async () => {
+  const contribution = createWorkspaceFilesContribution({
+    filesLabel: "Files",
+    icon: null,
+    renderFilesNodeBody: () => null,
+    renderTrafficLights,
+    workspaceFileManagerService: createFileManagerServiceStub(null),
+    workspaceId: "workspace-1"
+  });
+
+  assert.equal(contribution.id, "workspace-files");
+  assert.deepEqual(
+    contribution.nodes?.map(({ typeId }) => typeId),
+    ["workspace-files"]
+  );
+  assert.deepEqual(
+    contribution.dockEntries?.map(({ id, order, sectionId, typeId }) => ({
+      id,
+      order,
+      sectionId,
+      typeId
+    })),
+    [
+      {
+        id: "workspace-files",
+        order: 10,
+        sectionId: "apps",
+        typeId: "workspace-files"
+      }
+    ]
+  );
+
+  const launch = await Promise.resolve(
+    contribution.onLaunchRequest?.({
+      ...createLaunchRequestContext(),
+      dockEntryId: "workspace-files",
+      reason: "dock",
+      typeId: "workspace-files",
+      workspaceId: "workspace-1"
+    })
+  );
+  assert.deepEqual(
+    launch && {
+      dockEntryId: launch.dockEntryId,
+      instanceId: launch.instanceId,
+      typeId: launch.typeId
+    },
+    {
+      dockEntryId: "workspace-files",
+      instanceId: "workspace-files",
+      typeId: "workspace-files"
+    }
+  );
+});
+
 test("workspace files contribution exposes file manager state through runtime and snapshot node state", () => {
   const snapshotState: WorkspaceFileManagerPersistedState = {
     currentDirectoryPath: "/workspace/docs",

--- a/apps/desktop/src/renderer/src/features/workspace-workbench/services/internal/workspaceWindowCloseCoordinator.test.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/services/internal/workspaceWindowCloseCoordinator.test.ts
@@ -36,6 +36,9 @@ test("confirmWorkspaceWindowClose minimizes focused workbench node before window
       onCloseNode: () => assert.fail("window close should not close nodes"),
       onMinimizeNode: (nodeId) => {
         events.push(`node-minimize:${nodeId}`);
+      },
+      onRequestNodeClose: (nodeId) => {
+        events.push(`node-request-close:${nodeId}`);
       }
     }),
     hostInput,
@@ -128,6 +131,9 @@ test("confirmWorkspaceWindowClose falls back to visible node when focused id is 
       nodeIds: ["live-node"],
       onMinimizeNode: (nodeId) => {
         events.push(`node-minimize:${nodeId}`);
+      },
+      onRequestNodeClose: (nodeId) => {
+        events.push(`node-request-close:${nodeId}`);
       }
     }),
     hostInput,
@@ -220,6 +226,9 @@ test("confirmWorkspaceWindowClose closes the focused workbench node and blocks h
       },
       onMinimizeNode: (nodeId) => {
         events.push(`node-minimize:${nodeId}`);
+      },
+      onRequestNodeClose: (nodeId) => {
+        events.push(`node-request-close:${nodeId}`);
       }
     }),
     hostInput,

--- a/apps/desktop/src/renderer/src/features/workspace-workbench/services/internal/workspaceWorkbenchComposition.test.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/services/internal/workspaceWorkbenchComposition.test.ts
@@ -1,6 +1,14 @@
 import assert from "node:assert/strict";
 import test from "node:test";
-import { defaultIssueManagerNodeFrame } from "@tutti-os/workspace-issue-manager/workbench/constants";
+import {
+  defaultIssueManagerNodeFrame,
+  defaultIssueManagerWorkbenchTypeId
+} from "@tutti-os/workspace-issue-manager/workbench/constants";
+import {
+  workspaceImageFileNodeTypeID,
+  workspaceTextFileNodeTypeID
+} from "../workspaceFilePreviewLaunch.ts";
+import { defaultWorkspaceTerminalWorkbenchTypeId } from "./workspaceTerminalWorkbenchConstants.ts";
 import {
   createWorkspaceAgentGuiDraftLaunchRequest,
   createWorkspaceAgentGuiUnifiedDraftLaunchRequest,
@@ -11,13 +19,38 @@ import {
   toWorkspaceFilesActivation,
   workspaceAgentGuiDockEntryId,
   workspaceAgentGuiInstanceId,
+  workspaceAgentGuiNodeID,
   workspaceAgentGuiNodeFrame,
   workspaceAgentGuiProviderFromIdentifier,
   workspaceAgentGuiProviderFromLaunchRequest,
+  workspaceBrowserNodeID,
   workspaceFilePreviewNodeFrame,
   workspaceFilesNodeFrame,
   workspaceFilesNodeID
 } from "./workspaceWorkbenchComposition.ts";
+
+test("desktop workbench keeps its current stable node type identities", () => {
+  assert.deepEqual(
+    {
+      agentGui: workspaceAgentGuiNodeID,
+      browser: workspaceBrowserNodeID,
+      files: workspaceFilesNodeID,
+      imagePreview: workspaceImageFileNodeTypeID,
+      issueManager: defaultIssueManagerWorkbenchTypeId,
+      terminal: defaultWorkspaceTerminalWorkbenchTypeId,
+      textPreview: workspaceTextFileNodeTypeID
+    },
+    {
+      agentGui: "agent-gui",
+      browser: "browser",
+      files: "workspace-files",
+      imagePreview: "workspace-image-file",
+      issueManager: "issue-manager",
+      terminal: "workspace-terminal",
+      textPreview: "workspace-text-file"
+    }
+  );
+});
 
 test("createWorkspaceFilesDockEntry configures the files dock entry", () => {
   const entry = createWorkspaceFilesDockEntry({

--- a/apps/desktop/src/renderer/src/features/workspace-workbench/services/internal/workspaceWorkbenchContributionRegistry.test.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/services/internal/workspaceWorkbenchContributionRegistry.test.ts
@@ -1,4 +1,5 @@
 import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
 import test from "node:test";
 import type {
   DesktopWorkbenchContributionContext,
@@ -20,6 +21,168 @@ test("workbench contribution registry sorts factories and skips unavailable entr
     registry.contributions.map((contribution) => contribution.id),
     ["files", "terminal"]
   );
+});
+
+test("default desktop workbench contribution factories keep their current ids and resolved order", () => {
+  const expectedFactories = [
+    {
+      exportName: "filesWorkbenchContributionFactory",
+      id: "workspace-files",
+      order: 10
+    },
+    {
+      exportName: "filePreviewWorkbenchContributionFactory",
+      id: "workspace-file-preview",
+      order: 15
+    },
+    {
+      exportName: "appCenterWorkbenchContributionFactory",
+      id: "workspace-app-center",
+      order: 18
+    },
+    {
+      exportName: "browserWorkbenchContributionFactory",
+      id: "workspace-browser",
+      order: 20
+    },
+    {
+      exportName: "agentGuiWorkbenchContributionFactory",
+      id: "workspace-agent-gui",
+      order: 25
+    },
+    {
+      exportName: "issueManagerWorkbenchContributionFactory",
+      id: "workspace-issue-manager",
+      order: 0
+    },
+    {
+      exportName: "terminalWorkbenchContributionFactory",
+      id: "workspace-terminal",
+      order: 40
+    }
+  ] as const;
+  const defaultFactorySource = readFileSync(
+    new URL(
+      "./contributions/defaultWorkspaceWorkbenchContributionFactories.ts",
+      import.meta.url
+    ),
+    "utf8"
+  );
+
+  assert.deepEqual(
+    Array.from(
+      defaultFactorySource.matchAll(
+        /^\s{4}(\w+WorkbenchContributionFactory),?$/gm
+      ),
+      (match) => match[1]
+    ),
+    expectedFactories.map(({ exportName }) => exportName)
+  );
+  for (const expected of expectedFactories) {
+    const factoryFileName = expected.exportName.replace(
+      /WorkbenchContributionFactory$/,
+      "WorkbenchContributionFactory.ts"
+    );
+    const source = readFileSync(
+      new URL(`./contributions/${factoryFileName}`, import.meta.url),
+      "utf8"
+    );
+    assert.match(source, new RegExp(`id: "${expected.id}"`));
+    assert.match(source, new RegExp(`order: ${expected.order}`));
+  }
+
+  const registry = createWorkspaceWorkbenchContributionRegistryResult({
+    context: {} as DesktopWorkbenchContributionContext,
+    factories: expectedFactories.map(({ id, order }) =>
+      createFactory({ id, order })
+    )
+  });
+
+  assert.deepEqual(
+    registry.contributions.map(({ id }) => id),
+    [
+      "workspace-issue-manager",
+      "workspace-files",
+      "workspace-file-preview",
+      "workspace-app-center",
+      "workspace-browser",
+      "workspace-agent-gui",
+      "workspace-terminal"
+    ]
+  );
+});
+
+test("default desktop contribution adapters keep current contribution, node, and fixed dock contracts", () => {
+  const contracts = [
+    {
+      file: "../../../workspace-app-center/services/internal/workspaceAppCenterContribution.tsx",
+      patterns: [
+        /id: "workspace-app-center"/,
+        /id: workspaceAppCenterNodeID,\s+label: title,\s+launchBehavior: "enabled"/,
+        /order: workspaceAppCenterDockOrder/,
+        /typeId: workspaceAppCenterNodeID/
+      ]
+    },
+    {
+      file: "./workspaceBrowserContribution.ts",
+      patterns: [
+        /contributionId: "workspace-browser"/,
+        /id: workspaceBrowserNodeID,\s+order: 20/,
+        /typeId: workspaceBrowserNodeID/
+      ]
+    },
+    {
+      file: "./workspaceIssueManagerContribution.ts",
+      patterns: [
+        /contributionId: "workspace-issue-manager"/,
+        /id: defaultIssueManagerWorkbenchTypeId,\s+order: 0/,
+        /typeId: defaultIssueManagerWorkbenchTypeId/
+      ]
+    },
+    {
+      file: "./workspaceTerminalContribution.ts",
+      patterns: [
+        /contributionId: "workspace-terminal"/,
+        /id: defaultWorkspaceTerminalWorkbenchTypeId,\s+order: 40/,
+        /typeId: defaultWorkspaceTerminalWorkbenchTypeId/
+      ]
+    },
+    {
+      file: "./workspaceAgentGuiContribution.ts",
+      patterns: [
+        /createAgentGuiWorkbenchContribution\(\{/,
+        /workspaceId: input\.workspaceId/
+      ]
+    }
+  ];
+
+  for (const contract of contracts) {
+    const source = readFileSync(
+      new URL(contract.file, import.meta.url),
+      "utf8"
+    );
+    for (const pattern of contract.patterns) {
+      assert.match(source, pattern, `${contract.file} must match ${pattern}`);
+    }
+  }
+
+  const agentGuiPackageSource = readFileSync(
+    new URL(
+      "../../../../../../../../../packages/agent/gui/workbench/contribution.ts",
+      import.meta.url
+    ),
+    "utf8"
+  );
+  assert.match(
+    agentGuiPackageSource,
+    /id: input\.id \?\? "workspace-agent-gui"/
+  );
+  assert.match(
+    agentGuiPackageSource,
+    /id: agentGuiWorkbenchUnifiedDockEntryId\(\)/
+  );
+  assert.match(agentGuiPackageSource, /order: input\.order/);
+  assert.match(agentGuiPackageSource, /typeId: agentGuiWorkbenchTypeId/);
 });
 
 function createFactory(input: {

--- a/apps/desktop/src/renderer/src/features/workspace-workbench/services/internal/workspaceWorkbenchHostInput.test.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/services/internal/workspaceWorkbenchHostInput.test.ts
@@ -11,11 +11,19 @@ import { createWorkspaceWorkbenchHostInputWithDockEntries } from "./workspaceWor
 
 test("createWorkspaceWorkbenchHostInputWithDockEntries updates dock entries without replacing host config references", () => {
   const contributions = [{ id: "workspace-app-center" }];
+  const externalStateSource = {} as NonNullable<
+    WorkspaceWorkbenchHostInput["externalStateSource"]
+  >;
+  const onLaunchRequest = async () => null;
+  const onNodeCloseRequest = async () => undefined;
   const prepareHostClose = async () => true;
   const snapshotRepository =
     {} as WorkspaceWorkbenchHostInput["snapshotRepository"];
   const baseHostInput: WorkspaceWorkbenchHostInput = {
     contributions,
+    externalStateSource,
+    onLaunchRequest,
+    onNodeCloseRequest,
     prepareHostClose,
     snapshotRepository,
     workspaceId: "workspace-1"
@@ -35,6 +43,12 @@ test("createWorkspaceWorkbenchHostInputWithDockEntries updates dock entries with
   assert.notEqual(firstHostInput, secondHostInput);
   assert.equal(firstHostInput.contributions, contributions);
   assert.equal(secondHostInput.contributions, contributions);
+  assert.equal(firstHostInput.externalStateSource, externalStateSource);
+  assert.equal(secondHostInput.externalStateSource, externalStateSource);
+  assert.equal(firstHostInput.onLaunchRequest, onLaunchRequest);
+  assert.equal(secondHostInput.onLaunchRequest, onLaunchRequest);
+  assert.equal(firstHostInput.onNodeCloseRequest, onNodeCloseRequest);
+  assert.equal(secondHostInput.onNodeCloseRequest, onNodeCloseRequest);
   assert.equal(firstHostInput.prepareHostClose, prepareHostClose);
   assert.equal(secondHostInput.prepareHostClose, prepareHostClose);
   assert.equal(firstHostInput.snapshotRepository, snapshotRepository);

--- a/apps/desktop/src/renderer/src/features/workspace-workbench/services/internal/workspaceWorkbenchHostService.test.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/services/internal/workspaceWorkbenchHostService.test.ts
@@ -19,6 +19,48 @@ const workspaceWorkbenchHostServiceSource = readFileSync(
   "utf8"
 );
 
+test("workspace workbench host keeps deterministic composition and close preparation wiring", () => {
+  assert.match(
+    workspaceWorkbenchHostServiceSource,
+    /createWorkspaceWorkbenchContributionRegistryResult\(\{\s+context: \{[\s\S]*?factories: defaultWorkspaceWorkbenchContributionFactories\s+\}\)/
+  );
+  assert.match(
+    workspaceWorkbenchHostServiceSource,
+    /contributions: contributionRegistry\.contributions/
+  );
+  assert.match(
+    workspaceWorkbenchHostServiceSource,
+    /prepareHostClose: resolveWorkbenchHostPrepareClose\(\s+contributionRegistry\.contributions\s+\)/
+  );
+  assert.match(
+    workspaceWorkbenchHostServiceSource,
+    /snapshotRepository: this\.dependencies\.repository/
+  );
+});
+
+test("workspace workbench host caches stable host input and isolates dynamic dock updates", () => {
+  assert.match(
+    workspaceWorkbenchHostServiceSource,
+    /private readonly cachedHostInputs = new Map<\s+string,\s+CachedWorkspaceWorkbenchHostInput\s+>\(\)/
+  );
+  assert.match(
+    workspaceWorkbenchHostServiceSource,
+    /const cached = this\.cachedHostInputs\.get\(input\.workspaceId\)/
+  );
+  assert.match(
+    workspaceWorkbenchHostServiceSource,
+    /cached\.renderFilesNodeBodyRef\.current = input\.renderFilesNodeBody;\s+return this\.createHostInputWithDynamicDockEntries\(/
+  );
+  assert.match(
+    workspaceWorkbenchHostServiceSource,
+    /const dockSignature = createWorkspaceDynamicDockSignature\(\{[\s\S]*?cached\.dynamicDockSignature === dockSignature[\s\S]*?return cached\.dynamicHostInput/
+  );
+  assert.match(
+    workspaceWorkbenchHostServiceSource,
+    /cached\.dynamicHostInput = dynamicHostInput;\s+return dynamicHostInput/
+  );
+});
+
 test("shouldCloseTerminalNodeAfterError closes stale terminal nodes", () => {
   assert.equal(
     shouldCloseTerminalNodeAfterError(

--- a/apps/desktop/src/renderer/src/features/workspace-workbench/services/workspaceWorkbenchShellRuntimeController.test.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/services/workspaceWorkbenchShellRuntimeController.test.ts
@@ -291,6 +291,28 @@ test("workspace workbench shell runtime controller publishes host input updates"
   assert.deepEqual(workspaceIds, ["workspace-2"]);
 });
 
+test("workspace workbench shell runtime controller does not publish when host input identity is stable", () => {
+  const stableHostInput = createHostInput("workspace-stable");
+  const controller = createWorkspaceWorkbenchShellRuntimeController({
+    hostInput: createShellHostInput({ hostInput: stableHostInput }),
+    wallpaperSelection: createWallpaperInput({
+      workspaceId: "workspace-stable",
+      wallpaperId: "default"
+    })
+  });
+  let notificationCount = 0;
+  controller.subscribe(() => {
+    notificationCount += 1;
+  });
+
+  controller.updateHostInput(
+    createShellHostInput({ hostInput: stableHostInput })
+  );
+
+  assert.equal(controller.getSnapshot().hostInput, stableHostInput);
+  assert.equal(notificationCount, 0);
+});
+
 function createWallpaperInput(input: {
   displayMode?: WorkspaceWallpaperDisplayMode;
   wallpaperId: WorkspaceWallpaperId;

--- a/docs/adr/0009-cross-product-workbench-host-kernel.md
+++ b/docs/adr/0009-cross-product-workbench-host-kernel.md
@@ -1,0 +1,444 @@
+# ADR 0009 — Share a class-based Workbench host kernel across Tutti and TSH
+
+- Date: 2026-07-11
+- Status: Accepted
+- Decision owners: Tutti desktop and Workbench maintainers
+- Related:
+  - [Workbench](../conventions/workbench.md)
+  - [Workbench Contributions](../architecture/workbench-contributions.md)
+  - [Workbench Node Lifecycle](../architecture/workbench-node-lifecycle.md)
+  - [Workbench Dock Model](../architecture/workbench-dock-model.md)
+  - [Phase 0 to stable implementation plan](../specs/2026-07-11-workbench-host-kernel-phase-0-to-stable.md)
+
+## Context
+
+Tutti and TSH already share the canonical Workbench snapshot contract, Go
+validation service, surface mechanics, contribution contract, node identity
+helpers, and dock model. Their product hosts still own similar coordination in
+different forms:
+
+- Tutti has a renderer DI singleton class that assembles and caches
+  workspace-specific host input, but the class also contains Tutti product
+  services and policies.
+- TSH has a contribution-first registry and durable room/user snapshot
+  repository, but its host coordination is still implemented as React hooks.
+- `@tutti-os/workbench-surface` has a disposable shell session for layout,
+  projection reconciliation, activation, and snapshot saves. It intentionally
+  does not own product capability assembly or product business policy.
+
+Class-based dependency injection alone does not solve this divergence. DI can
+construct and locate a long-lived service, but it does not define:
+
+- how one renderer owns multiple sequential or concurrent Workbench scopes;
+- which inputs are renderer-singleton state and which are scope-local state;
+- when subscriptions, save queues, caches, and live projections are disposed;
+- how product-neutral contributions are ordered and validated;
+- how a user identity change prevents one user's cached snapshot from leaking
+  into another user's room session;
+- which changes may update a live session and which require replacement.
+
+Without a shared lifecycle owner, a DI service tends to become either a product
+mega-service or a thin wrapper around React lifecycle. Both products then have
+to rediscover the same session, disposal, cache, and conformance rules.
+
+## Decision
+
+Tutti and TSH will share a **class-based, DI-friendly Workbench host kernel**.
+The target public package is `@tutti-os/workbench-host`, subject to the
+extraction gate in the implementation plan.
+
+The kernel has two explicit lifetime levels:
+
+1. one `WorkbenchHostCoordinator` per renderer/window DI root; and
+2. one disposable `WorkbenchHostSession` per open Workbench scope partition.
+
+The coordinator and session are ordinary classes with constructor-injected
+interfaces. The package does not require a particular DI container and does not
+use global service lookup. Both official renderers will use
+`@tutti-os/infra/di` to register their class service/coordinator. Each product
+still owns its service token, registration function, constructor adapters, and
+renderer composition root; none of that registration becomes a responsibility
+of the shared package. DI creates the coordinator, while the coordinator
+creates, indexes, replaces, and disposes scope sessions.
+
+This host session is the product-host coordination layer above the existing
+`@tutti-os/workbench-surface` shell session. The surface remains the owner of
+window mechanics and shell persistence behavior. The host kernel must compose
+the surface contract rather than reimplement its reducer, contribution merge
+rules, snapshot sanitizer, node identity, or dock behavior.
+
+## Dependency direction
+
+The allowed package direction is:
+
+```text
+Tutti renderer ─┬─> @tutti-os/workbench-host
+                └─> @tutti-os/workbench-surface
+
+TSH renderer ───┬─> @tutti-os/workbench-host
+                └─> @tutti-os/workbench-surface
+
+@tutti-os/workbench-host -- type-only/public-contract --> @tutti-os/workbench-surface
+@tutti-os/workbench-surface -X-> @tutti-os/workbench-host
+```
+
+`@tutti-os/workbench-host` may use type-only or declaration-level dependencies
+on public surface contracts such as `WorkbenchContribution`,
+`WorkbenchHostHandle`, snapshot repository seams, and stable host-input types.
+Those declarations may transitively mention React types because the existing
+surface contribution contract contains render functions and React values.
+
+This allowance does not give the host package React runtime ownership. Emitted
+host JavaScript must not import React, mount components, call hooks, own effect
+lifecycle, or implement `WorkbenchHost` rendering. It also must not import
+surface runtime helpers in a way that creates a runtime dependency cycle.
+Surface remains independently usable and must never import host.
+
+If extraction produces a React runtime dependency, a `surface -> host` reverse
+dependency, or any host/surface cycle, the extraction must stop. Maintainers
+must re-review package ownership and move the disputed behavior back behind a
+product adapter or a lower-level neutral contract before continuing.
+
+## Canonical model
+
+### Shared kernel
+
+The shared kernel owns only product-neutral coordination:
+
+- coordinator/session lifecycle and idempotent disposal;
+- immutable scope and authenticated-principal snapshots captured at session
+  creation;
+- deterministic capability-factory ordering and duplicate ownership checks;
+- stable contribution and host-input composition;
+- subscription and resource cleanup;
+- session replacement when an immutable partition changes;
+- forwarding dynamic projections and presentation-state updates without
+  rebuilding the session;
+- diagnostics hooks for lifecycle and invariant violations;
+- a product-neutral conformance harness.
+
+The shared kernel does not own Electron, React runtime lifecycle or components,
+daemon clients, authentication discovery, workspace or room business rules,
+cloud projection, terminal or agent lifecycle, user-visible product copy, or
+product-specific snapshot metadata. Type declarations may reference the public
+surface contracts described above.
+
+### Product Profile
+
+A `WorkbenchProductProfile` describes stable product-level choices. It is data
+and narrow callbacks, not a service bag. A profile includes:
+
+- a stable product ID;
+- supported scope kind (`workspace` for Tutti, `room` for TSH);
+- deterministic capability factory descriptors;
+- host-level compatibility policy that cannot be expressed by a capability;
+- declared snapshot metadata ownership, if any;
+- optional feature flags that are stable for the lifetime of a session.
+
+Profiles must not contain Tutti-or-TSH union fields, transport clients, mutable
+business stores, or optional properties for every product capability.
+
+### Ports
+
+Ports are small interfaces through which the kernel reaches an owner outside
+the kernel. The initial port families are:
+
+- `WorkbenchSnapshotRepositoryPort`: load, cached read, save, and optional
+  change subscription for an opaque snapshot partition;
+- `WorkbenchDiagnosticsPort`: structured lifecycle and invariant diagnostics;
+- `WorkbenchCapabilityRegistryPort`: supplies the factories allowed by the
+  selected profile, if they are not passed directly at composition;
+- `WorkbenchSessionClockPort` only if deterministic time is proven necessary;
+- surface-session attachment/update seams needed to connect the headless host
+  session to `@tutti-os/workbench-surface`.
+
+Ports expose product-neutral values. A port must not grow into a renamed
+`window.tutti`, `window.tshApi`, `TuttidClient`, desktopd client, control-plane
+client, or product service container.
+
+### Capability contributions
+
+The existing `WorkbenchContribution` remains the canonical capability output.
+Feature-owned factories may contribute node definitions, dock entries, external
+state, launch handling, close handling, and close preparation under the current
+contract.
+
+The kernel adds lifecycle and ownership around contribution factories; it does
+not replace `WorkbenchContribution` and does not change its merge semantics.
+Each factory receives:
+
+- a minimal immutable session context (`productId`, scope, partition identity);
+- only the capability-specific ports supplied by the product adapter; and
+- stable presentation inputs that the capability genuinely owns.
+
+A factory must not receive an entire product context and pick optional services
+from it.
+
+### Product adapters
+
+Tutti and TSH each own an adapter layer that:
+
+- obtains the current workspace or room and authenticated user identity;
+- captures an immutable session partition;
+- maps the existing HTTP clients and snapshot repositories to shared ports;
+- supplies product capability factories and their narrow dependencies;
+- owns product copy, feature enablement, launch/reuse/close policy, and
+  business-state projection;
+- registers a product-owned class service/coordinator with
+  `@tutti-os/infra/di` in the product's renderer composition root; and
+- connects the resulting session to the React Workbench surface.
+
+The long-term TSH target is therefore not only to consume the same kernel. Its
+renderer also adopts the same class-DI composition style as Tutti through
+`@tutti-os/infra/di`, replacing hook-owned host lifecycle. This is an official
+renderer integration decision, not a dependency from the host package to the DI
+framework.
+
+The adapters are the only place where `workspaceId` can mean a Tutti workspace
+and where TSH's Workbench `workspaceId` compatibility field can carry a room
+ID. The shared kernel treats these as opaque scope IDs.
+
+## Lifetime and partition rules
+
+### Renderer singleton coordinator
+
+There is exactly one coordinator in each renderer/window DI root. It may manage
+zero or more sessions, but it is not a process-global static and it does not own
+business entities. It owns only the index and lifecycle of sessions created in
+that renderer.
+
+Opening the same immutable partition twice is idempotent or returns an explicit
+lease to the same session. Opening the same scope with a different immutable
+partition must dispose and replace the old session before the new session can
+publish host input.
+
+### Disposable scope session
+
+Each Tutti workspace or TSH room gets a disposable session. The session owns:
+
+- the resolved contribution set and stable host-input projection;
+- scope-local subscriptions and adapter leases;
+- projection and dynamic-presentation bridges;
+- scope-local repository/cache coordination that is not owned by the daemon;
+- the attachment to the surface runtime handle; and
+- cleanup for all resources acquired during session construction.
+
+Disposal is idempotent. After disposal, async completions may not mutate cache,
+publish host input, save a snapshot, or call a detached surface handle.
+
+### Scope and snapshot partitions
+
+The kernel uses two related identities:
+
+- `WorkbenchScope`: product-visible logical scope;
+- `WorkbenchSnapshotPartition`: immutable repository/cache key captured when a
+  session starts.
+
+Canonical mappings are:
+
+| Product | Workbench scope        | Snapshot partition                                                     |
+| ------- | ---------------------- | ---------------------------------------------------------------------- |
+| Tutti   | `workspaceId`          | `workspaceId` under the existing local authenticated desktop authority |
+| TSH     | control-plane `roomId` | `roomId` plus an immutable authenticated-user snapshot                 |
+
+The TSH authenticated-user snapshot contains only stable identity needed for
+partitioning, normally the authenticated user ID. It never contains a token or
+mutable auth client. The user ID continues to be derived by desktopd for the
+HTTP request; it is not accepted from a renderer request body. The renderer
+partition prevents cache reuse, while desktopd's `(room_id, user_id)` key
+remains the durable enforcement boundary.
+
+If Tutti later supports switching durable user authorities within one local
+profile, it must introduce a versioned partition mapping through its product
+adapter. The shared kernel must not infer that policy.
+
+## State ownership
+
+| State                                                                    | Authoritative owner                                                       | Kernel/session role                                          | Forbidden owner             |
+| ------------------------------------------------------------------------ | ------------------------------------------------------------------------- | ------------------------------------------------------------ | --------------------------- |
+| Snapshot schema, migrations, normalization                               | `@tutti-os/workbench-snapshot`                                            | Consume unchanged                                            | Product adapter             |
+| Frame, display mode, restore frame, minimized state, stack, active shell | Workbench surface session plus daemon snapshot repository                 | Coordinate attachment and persistence port                   | Capability business service |
+| Snapshot durability                                                      | `tuttid` for Tutti; desktopd SQLite keyed by `(room_id, user_id)` for TSH | Call repository port; maintain only recoverable client cache | Renderer session            |
+| Node type/instance identity and dock affinity                            | Existing Workbench surface contracts and identity helpers                 | Preserve and validate ownership                              | Product profile remapping   |
+| Contribution ordering and duplicate capability ownership                 | Host kernel using declared factory `order` then `id`                      | Resolve deterministically                                    | React render order          |
+| Projected node presence                                                  | Owning product runtime/business service                                   | Forward live projection into the attached surface session    | Snapshot restore            |
+| Terminal, agent, chat, app, file, transfer, and collaboration state      | Product daemon/control plane/domain service                               | Read/project through capability adapter                      | Host kernel or snapshot     |
+| Dynamic dock badges, availability, and attention                         | Owning capability service/store                                           | Forward through stable state source                          | Static host-input rebuild   |
+| Authenticated principal used for partitioning                            | Product authentication authority                                          | Hold immutable identity snapshot for one session             | Capability contribution     |
+| React-only overlay/dialog/DOM state                                      | Product presentation adapter                                              | None, except commands/events across a narrow seam            | Shared kernel               |
+
+## Invariants
+
+1. A snapshot can restore shell presentation but can never create, delete, or
+   become authoritative for a terminal, agent, chat, app, file, transfer, or
+   collaboration business entity.
+2. At most one live host session exists per immutable snapshot partition in one
+   renderer coordinator, and every session is disposed before its partition is
+   replaced.
+3. TSH cache and persistence access for a room is partitioned by an immutable
+   authenticated-user snapshot; credentials and user IDs are never supplied by
+   capability contributions or persisted inside the Workbench snapshot.
+4. A capability owns each contribution ID, node `typeId`, and dock entry ID
+   exactly once. Resolution is deterministic and independent of React render
+   order.
+5. Dynamic business or dock state may update a stable session but may not
+   recreate the coordinator, session, node definitions, or shell identities.
+6. Session disposal cancels or invalidates all later async writes and callbacks;
+   a disposed session cannot publish or persist state.
+7. Shared code depends on product-neutral ports. Tutti and TSH adapters may
+   depend on the kernel, but the kernel never imports either product.
+8. Current `WorkbenchContribution`, snapshot schema, stable node identity,
+   dock ordering/affinity, daemon API shapes, and business authority remain
+   behaviorally compatible throughout Phase 0.
+9. Host may depend on surface public contracts at type/declaration level;
+   surface never depends on host, and neither a React runtime dependency nor a
+   host/surface cycle is allowed.
+
+## Compatibility constraints
+
+The extraction is a structural change, not a contract redesign:
+
+- no change to `WorkbenchContribution` or the explicit `WorkbenchHost` props;
+- no snapshot schema or migration change;
+- no change to projected/launched node ID helpers or existing IDs;
+- no change to contribution merge precedence or product dock order;
+- no change to Tutti's `/v1/workspaces/{workspaceID}/workbench` API;
+- no change to TSH's `GET/PUT /v1/rooms/{roomId}/workbench` API;
+- no change to daemon-side reconciliation ownership; and
+- no movement of product business policy into a shared package.
+
+Any implementation step that needs one of these changes must stop and propose a
+separate contract decision instead of hiding it inside the host extraction.
+
+## Rejected designs
+
+### Product inheritance
+
+Rejected: a shared base host class with `TuttiWorkbenchHost` and
+`TSHWorkbenchHost` subclasses.
+
+Inheritance would make product-specific lifecycle hooks part of the shared
+contract, encourage protected-state coupling, and make constructor/override
+order an implicit coordination protocol. The products are compositions of
+capabilities, not substitutable host subtypes. Use a final coordinator/session
+implementation with injected profiles and ports.
+
+### Product-union mega-context
+
+Rejected: one context such as `TuttiContext | TSHContext`, or an object with
+dozens of optional Tutti and TSH services.
+
+That shape moves the fork into runtime conditionals, exposes unrelated business
+services to every factory, and makes absence ambiguous. Profiles declare stable
+choices; narrow ports provide shared needs; capability adapters receive only
+their own dependencies.
+
+### Make `@tutti-os/workbench-surface` the product host
+
+Rejected as the stable boundary. Surface owns shell mechanics and React
+presentation. Adding product host coordination there would couple a headless
+lifecycle concern to the UI package and make non-React testing and evolution
+harder.
+
+### Keep two hosts and share only tests
+
+Rejected as the long-term target. A conformance suite is required, but tests
+alone do not create one lifecycle owner. The current Tutti class and TSH hook
+would continue to drift in disposal, partition, cache, and update semantics.
+
+## Public package evaluation
+
+### Preferred: `@tutti-os/workbench-host`
+
+Benefits:
+
+- names the coordination domain explicitly;
+- can remain headless and class-based;
+- can expose a small public API and a conformance test subpath;
+- keeps `workbench-surface` focused on UI/shell mechanics; and
+- gives TSH a release-based dependency rather than copied host code while both
+  official renderers use the same `@tutti-os/infra/di` class composition style.
+
+Costs:
+
+- adds a public compatibility surface and fixed-release-group member;
+- requires pack, beta, downstream, and stable release validation; and
+- requires strict export discipline to avoid publishing Tutti product types.
+
+This is the accepted target if Phase 0 proves that the public seam contains only
+coordinator/session, profiles, ports, capability descriptors, and conformance
+helpers.
+
+### Alternative: `@tutti-os/workbench-surface/host`
+
+This avoids another package and may be useful as a short-lived incubation
+location. It is not preferred for stable because it couples headless host
+coordination to React/surface release and dependency shape. If Phase 0 cannot
+produce an independent package without a React runtime dependency or circular
+dependency, the work must pause and reassess boundaries rather than silently
+make this the permanent API.
+
+### Alternative: Tutti-private kernel plus copied TSH adapter
+
+This has the lowest immediate release cost and is acceptable only for the
+Tutti-first proving step. It is not a completion state: TSH must consume a
+released package for external validation, never a filesystem link or copied
+source.
+
+## Release decision
+
+If extracted, `@tutti-os/workbench-host` joins the existing fixed npm release
+group and uses its single shared version. It does not establish an independent
+version or release workflow.
+
+- Local beta validation uses `pnpm release:beta`, publishes with the `beta`
+  dist-tag, and creates no git tag or manifest commit.
+- Stable publication uses the repository's manual fixed-group workflow and the
+  normal `packages-v<version>` tag.
+- Stable publication also creates the normal tags for every existing
+  `packages/**/go.mod`, including `packages/workbench/service/v<version>`.
+- The TypeScript host package does not need its own `go.mod`; adding one only to
+  obtain a tag is prohibited.
+- If no Go code or contract changes, TSH beta validation continues using the
+  last stable Workbench Go module. A Go beta distribution mechanism is outside
+  this decision.
+
+The durable fixed-group roster and all release automation must be updated in
+one package-extraction PR. Before that edit, the implementation must audit and
+reconcile any existing roster drift between release documentation and config;
+it must not copy one stale list into another.
+
+## Consequences
+
+Positive consequences:
+
+- both products share one lifecycle and partition model;
+- React becomes an adapter rather than the owner of host coordination;
+- product features stay independently contributable;
+- auth and scope isolation become explicit and testable;
+- the public Workbench surface and daemon contracts remain stable.
+
+Costs and constraints:
+
+- Tutti must first separate product policy from its current large host class;
+- TSH must later replace hook-owned lifecycle with an adapter to the released
+  coordinator/session;
+- package API review and downstream beta validation become mandatory; and
+- a coordinator/session abstraction adds value only if its public surface stays
+  smaller than either product host.
+
+## Open questions
+
+1. Should the coordinator allow concurrent sessions in one renderer, or enforce
+   one active session with a map-shaped API for future growth? Default: support
+   a map internally and test multiple partitions without promising multi-view
+   UI behavior.
+2. Should the surface accept an externally created shell session, or should the
+   host session initially expose stable `WorkbenchHost` input and attach the
+   returned handle? Default: attach through the current public surface props and
+   handle until an external-session API is justified independently.
+3. Which Tutti snapshot metadata (currently product-owned wallpaper and
+   onboarding fields) should remain in the snapshot repository adapter versus a
+   dedicated product metadata port? Default: keep compatibility in the Tutti
+   adapter during Phase 0 and extract only after conformance tests prove the
+   ownership boundary.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -12,6 +12,7 @@ implemented now.
 - [ADR 0006: Durable approval resolver projection](./0006-step6-approval-resolver-durable-projection.md)
 - [ADR 0007: Sub-agent lane ownership](./0007-subagent-lane-owner-callid.md)
 - [ADR 0008: Turn lifecycle snapshot authority](./0008-turn-lifecycle-snapshot-authority.md)
+- [ADR 0009: Cross-product Workbench host kernel](./0009-cross-product-workbench-host-kernel.md)
 - [Codex App-Server Refactor Glossary](./glossary.md)
 
 New ADRs should state `Proposed`, `Accepted`, `Superseded`, or `Rejected` near

--- a/docs/specs/2026-07-11-workbench-host-kernel-phase-0-to-stable.md
+++ b/docs/specs/2026-07-11-workbench-host-kernel-phase-0-to-stable.md
@@ -1,0 +1,507 @@
+# Workbench Host Kernel: Phase 0 To Stable
+
+- Date: 2026-07-11
+- Status: Active; ADR accepted and PR 1 characterization approved
+- Architecture decision:
+  [ADR 0009](../adr/0009-cross-product-workbench-host-kernel.md)
+- Scope: Tutti-first implementation, npm beta, read-only/downstream TSH
+  validation, then stable release
+
+## Outcome
+
+Deliver a released, product-neutral `@tutti-os/workbench-host` package that lets
+Tutti local workspaces and TSH collaborative rooms use the same class-based host
+coordinator/session kernel while preserving all current Workbench and daemon
+contracts.
+
+The implementation is complete only after:
+
+1. Tutti runs the shared kernel through its renderer DI composition;
+2. the fixed release group publishes a beta containing the package;
+3. TSH replaces hook-owned host lifecycle with an
+   `@tutti-os/infra/di`-registered class service/coordinator and product adapters
+   against that beta, then passes the shared conformance suite in a separate TSH
+   change;
+4. external findings are resolved in Tutti without product-specific leakage;
+5. the package is published through the stable fixed release group; and
+6. durable current-architecture/convention docs replace this active plan.
+
+This document does not authorize a beta or stable publication. Each release is
+an explicit approval gate.
+
+## Approval state
+
+Approval recorded on 2026-07-11 is deliberately narrow:
+
+| Scope                                     | Approval                    |
+| ----------------------------------------- | --------------------------- |
+| ADR 0009 architecture boundary            | Accepted                    |
+| PR 1 characterization fixtures/tests      | Approved for implementation |
+| PR 2 private coordinator/session          | Not approved                |
+| PR 3 Product Profile/Ports/adapters split | Not approved                |
+| Public package extraction                 | Not approved                |
+| npm beta publication                      | Not approved                |
+| TSH renderer DI/host migration            | Not approved                |
+| Stable publication                        | Not approved                |
+
+Completing PR 1 produces evidence for the next review; it does not implicitly
+authorize PR 2 or any later step.
+
+## Baseline evidence
+
+### Tutti
+
+- `@tutti-os/workbench-surface` already owns the disposable shell session,
+  snapshot sanitation, projected-node reconciliation, activation, and shell
+  persistence scheduling.
+- The desktop uses `@tutti-os/infra/di` and a renderer-scoped
+  `WorkspaceWorkbenchHostService` class.
+- The product host class currently mixes reusable host-input coordination with
+  Tutti adapters, wallpaper/onboarding metadata, preload APIs, daemon clients,
+  dock product policy, and other product services.
+- Tutti's canonical snapshot API remains
+  `GET/PUT /v1/workspaces/{workspaceID}/workbench`.
+
+### TSH (read-only evidence, 2026-07-11)
+
+- TSH has deterministic contribution factories ordered by `order` then `id`
+  and rejects duplicate factory, contribution, node type, and dock entry IDs.
+- TSH's host service is a React hook that owns repository adaptation,
+  contribution caching, projection refs, dock runtime, and restored-focus state.
+- TSH already depends on `@tutti-os/infra` and uses its DI implementation in the
+  Electron main process, but its renderer has not yet established the target
+  Workbench class-service registration and renderer composition root.
+- TSH desktopd durably stores snapshots under `(room_id, user_id)`, derives the
+  user ID from authenticated desktop state, and uses the shared Go Workbench
+  service for canonical validation.
+- TSH's renderer repository additionally partitions its optimistic/cache state
+  by room and authenticated user.
+- TSH keeps terminal and agent reconciliation in an explicit desktopd runtime
+  reconciler and keeps cloud/shared-agent uncertainty out of destructive
+  reconciliation.
+
+These are compatible foundations. The gap is the renderer host lifecycle, not
+the snapshot schema or business authority model.
+
+## Frozen compatibility envelope
+
+All PRs in this plan must preserve:
+
+- the public `WorkbenchContribution` shape and merge precedence;
+- the current snapshot schema, migration behavior, and
+  `snapshotNodeState`/`externalNodeState` distinction;
+- projected and launched node IDs, `typeId`, `instanceId`, `instanceKey`, and
+  `dockEntryId` semantics;
+- current product dock order and duplicate override behavior;
+- Tutti and TSH daemon HTTP request/response shapes;
+- Tutti workspace and TSH room identifiers at existing public call sites;
+- daemon-owned snapshot durability and reconciliation;
+- product-owned terminal, agent, chat, app, file, transfer, and collaboration
+  authority; and
+- existing user-visible behavior, close guards, mission control, launchpad,
+  wallpaper, and shortcuts.
+
+Changing any item above requires a separately reviewed contract proposal and is
+not a hidden prerequisite for this plan.
+
+## Target API sketch
+
+Names may be refined during the package API review, but responsibility and
+lifetime may not move across these boundaries.
+
+```ts
+interface WorkbenchScope {
+  kind: "workspace" | "room";
+  id: string;
+}
+
+interface WorkbenchAuthenticatedPrincipalSnapshot {
+  id: string;
+}
+
+interface WorkbenchSnapshotPartition {
+  scope: WorkbenchScope;
+  principal?: WorkbenchAuthenticatedPrincipalSnapshot;
+}
+
+interface WorkbenchProductProfile {
+  productId: string;
+  scopeKind: WorkbenchScope["kind"];
+  capabilityFactories: readonly WorkbenchCapabilityFactoryDescriptor[];
+}
+
+interface WorkbenchHostCoordinator {
+  open(input: WorkbenchHostSessionOpenInput): WorkbenchHostSessionLease;
+  get(partition: WorkbenchSnapshotPartition): WorkbenchHostSession | null;
+  dispose(): void;
+}
+
+interface WorkbenchHostSession {
+  readonly partition: WorkbenchSnapshotPartition;
+  getHostInput(): StableWorkbenchHostInput;
+  update(update: WorkbenchHostSessionUpdate): void;
+  attachSurface(handle: WorkbenchHostHandle | null): void;
+  subscribe(listener: () => void): () => void;
+  dispose(): void;
+}
+```
+
+The real API should prefer opaque canonical partition keys over exposing string
+concatenation. It must not expose product clients, React hooks, or a generic
+service locator.
+
+## DI and package dependency target
+
+The shared package is DI-neutral: coordinator/session constructors accept
+ordinary interfaces and do not import `@tutti-os/infra/di`. The two official
+renderer products still converge on the same integration framework:
+
+- Tutti keeps `@tutti-os/infra/di` as its renderer service container;
+- TSH adds an `@tutti-os/infra/di` renderer composition root and registers its
+  Workbench class service/coordinator there; and
+- each product owns its decorator/token, registration function, constructor
+  adapters, and window/renderer lifetime wiring.
+
+This is intentional convergence at the official renderer layer, not DI coupling
+inside `@tutti-os/workbench-host`.
+
+The package dependency direction is also fixed:
+
+```text
+product renderer -> @tutti-os/workbench-host
+product renderer -> @tutti-os/workbench-surface
+@tutti-os/workbench-host -- type-only/public-contract --> @tutti-os/workbench-surface
+@tutti-os/workbench-surface -X-> @tutti-os/workbench-host
+```
+
+Host may import surface public contracts such as `WorkbenchContribution` and
+`WorkbenchHostHandle` with `import type`, and its emitted declarations may refer
+to React types carried by those contracts. Host runtime code must not import
+React, call hooks, mount components, own effect lifecycle, or require surface to
+import host. Package extraction stops for architecture review if its emitted
+JavaScript gains a React runtime dependency or if the package graph contains a
+host/surface cycle.
+
+## State owner and restart matrix
+
+| State                                   | Runtime writer                                            | Durable/restart owner                   | Session behavior                                                  |
+| --------------------------------------- | --------------------------------------------------------- | --------------------------------------- | ----------------------------------------------------------------- |
+| Workbench shell layout and stack        | Workbench surface controller                              | Tutti `tuttid`; TSH desktopd SQLite     | Load/save through repository port                                 |
+| Snapshot normalization/schema           | Shared snapshot package and Go service                    | Canonical schema sources                | Never reinterpret                                                 |
+| Contribution set and order              | Profile plus capability factories                         | Source code/package version             | Resolve once per stable configuration; update explicitly          |
+| Dynamic dock presentation               | Capability store/service                                  | Usually recomputed                      | Subscribe without session rebuild                                 |
+| Projected shell presence                | Product runtime/business service                          | Owning daemon/control plane             | Reconcile live; never recreate business entity from snapshot      |
+| Surface handle and activation sequence  | Surface session                                           | None                                    | Attach/detach; discard on session disposal                        |
+| Repository optimistic cache/save queue  | Product repository adapter or session port implementation | Daemon remains authority                | Partitioned; rollback/ignore stale completion on failure/disposal |
+| Authenticated identity partition        | Product auth authority                                    | Product auth/profile state              | Immutable snapshot for one session; replace session on change     |
+| Wallpaper/onboarding snapshot metadata  | Tutti adapter during Phase 0                              | Existing Tutti snapshot repository path | Preserve byte/semantic compatibility                              |
+| Room collaboration, shared agents, chat | TSH control plane/domain adapters                         | TSH authorities                         | Capability projection only                                        |
+
+## Required invariants and conformance assertions
+
+At minimum, implementation tests must prove:
+
+1. the coordinator returns no more than one live session for the same canonical
+   partition and disposes every owned session exactly once;
+2. changing a TSH authenticated-user snapshot changes the canonical partition,
+   never reuses room cache, and invalidates stale async completion from the old
+   session;
+3. contribution order is `order`, then `id`, with duplicate contribution IDs,
+   node type IDs, and dock entry IDs rejected before host input is published;
+4. dynamic projection/dock changes preserve session, contribution identity,
+   node identity, and surface handle;
+5. snapshot load/restore cannot invoke capability launch/create commands;
+6. disposed sessions cannot notify, persist, attach a handle, or accept updates;
+7. product adapters are the only imports of product transport/auth APIs; and
+8. the host kernel produces the same node definitions, dock order, close
+   preparation, and launch routing as the pre-migration Tutti host fixtures.
+9. both official renderers resolve their product-owned Workbench class service
+   through `@tutti-os/infra/di`, while the shared host package has no DI runtime
+   dependency.
+10. the built host package has no React runtime import, surface has no host
+    dependency, and the package graph is acyclic.
+
+## Shared conformance suite
+
+The package will provide a consumer-facing test harness, preferably through an
+explicit `@tutti-os/workbench-host/conformance` development subpath. It may be
+excluded from application runtime bundles, but its contract is public enough
+for TSH to run the same assertions.
+
+The harness accepts:
+
+- a coordinator factory;
+- a product profile fixture;
+- in-memory snapshot, diagnostics, and surface ports;
+- a partition factory;
+- capability fixtures with recorded create/update/dispose calls; and
+- product-specific expected contribution IDs and dock order.
+
+Shared cases cover:
+
+- open/get/lease/release/dispose lifecycle;
+- concurrent distinct partitions;
+- same scope/different principal isolation;
+- deterministic factory order and duplicate rejection;
+- stable host input across dynamic updates;
+- projection updates without launch side effects;
+- load/save failure and stale completion behavior;
+- attach/detach of a surface handle;
+- no callbacks after disposal;
+- snapshot purity using canonical snapshot fixtures; and
+- compatibility of explicit host props and contributions where the kernel
+  delegates to the existing surface resolver.
+
+Each product adds adapter cases:
+
+- Tutti: workspace ID mapping, existing daemon repository adapter,
+  wallpaper/onboarding metadata preservation, current dock order, current node
+  IDs, and DI singleton/session disposal.
+- TSH: room ID mapping, authenticated-user partition, desktopd request bodies
+  without user ID, room/user cache isolation, TSH-only contribution order, and
+  room/shared-agent business authority.
+
+Passing only package unit tests is insufficient for beta or stable promotion.
+
+## Existing-to-target module migration map
+
+Target paths below are part of this plan so ownership does not get decided ad
+hoc during extraction. Minor filename refinements are allowed only when the same
+owner, dependency direction, and PR boundary remain explicit.
+
+### Tutti mapping
+
+| Existing file/module                                                                                                           | Target module and owner                                                                                                                                                                                                                                                                                                                                                                                                                  | PR     | Migration disposition                                                                                                                                                                                                                                                                                                                                        |
+| ------------------------------------------------------------------------------------------------------------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `apps/desktop/src/renderer/src/features/workspace-workbench/services/internal/workspaceWorkbenchHostService.ts`                | Reusable lifecycle moves first to Tutti-private `apps/desktop/src/renderer/src/features/workspace-workbench/services/internal/workbenchHostCoordinator.ts` and `workbenchHostSession.ts` (PR 2), then to `packages/workbench/host/src/coordinator/workbenchHostCoordinator.ts` and `packages/workbench/host/src/session/workbenchHostSession.ts` (PR 4). The existing desktop service becomes a thin Tutti class facade/product adapter. | 2–5    | Move session indexing, replacement, stable host-input publication, leases, and disposal to the kernel. Keep Tutti preload/tuttid adapters, wallpaper/onboarding compatibility, desktop copy, window-close policy, diagnostics wiring, and feature service dependencies product-owned; split unrelated product services rather than exporting them from host. |
+| `apps/desktop/src/renderer/src/features/workspace-workbench/services/internal/workspaceWorkbenchContributionRegistry.ts`       | `packages/workbench/host/src/capabilities/workbenchCapabilityRegistry.ts`; Tutti's ordered factory descriptors move to `apps/desktop/src/renderer/src/features/workspace-workbench/services/internal/tuttiWorkbenchProductProfile.ts`.                                                                                                                                                                                                   | 1, 3–4 | Characterize current order first. Move generic order/duplicate validation to host; retain Tutti factory selection, enablement, and product dependencies in the Product Profile/adapters. Do not change `WorkbenchContribution` merge behavior.                                                                                                               |
+| `apps/desktop/src/renderer/src/features/workspace-workbench/services/internal/adapters/desktopWorkspaceWorkbenchRepository.ts` | Remains a Tutti product adapter implementing `WorkbenchSnapshotRepositoryPort`; optional interface types live in `packages/workbench/host/src/ports/workbenchSnapshotRepositoryPort.ts`.                                                                                                                                                                                                                                                 | 1, 3–5 | Do not move tuttid client calls or wallpaper/onboarding metadata preservation into host. Adapt existing `workspaceId` cache/load/save/subscribe behavior to the port unchanged.                                                                                                                                                                              |
+| `apps/desktop/src/renderer/src/features/workspace-workbench/services/registerWorkspaceWorkbenchServices.ts`                    | Remains the Tutti-owned `@tutti-os/infra/di` registration entry; registers the product service/coordinator and supplies Tutti profile/ports.                                                                                                                                                                                                                                                                                             | 2, 5   | Keep decorator/token and `SyncDescriptor` wiring in desktop. The shared package exports classes/contracts, not a Tutti registration helper or global locator.                                                                                                                                                                                                |
+| `apps/desktop/src/renderer/src/features/workspace-workbench/ui/WorkspaceWorkbench.tsx`                                         | Remains a Tutti React presentation adapter consuming the DI service/session and rendering `WorkbenchHost`.                                                                                                                                                                                                                                                                                                                               | 2, 5   | Remove host construction/business coordination from React. Keep DOM, chrome, overlays, handle attachment, subscriptions, and rendering. It may refer to surface runtime contracts but does not become a kernel module.                                                                                                                                       |
+| `apps/desktop/src/renderer/src/features/workspace-workbench/ui/useWorkspaceWorkbenchShellRuntime.tsx`                          | Remains a focused Tutti React adapter for leasing/subscribing to the DI-owned session; product shell controllers stay under desktop services.                                                                                                                                                                                                                                                                                            | 2, 5   | Replace hook-owned orchestration with calls to the class service. Effect cleanup releases/detaches the session but the host package owns no React effect lifecycle. Preserve mission control, close guards, wallpaper, shortcuts, and host-input identity.                                                                                                   |
+
+### TSH mapping
+
+All TSH changes below belong to a separately approved TSH PR after npm beta;
+this Tutti task does not modify those files.
+
+| Existing file/module                                                                                                                                                                                                                                        | Target module and owner                                                                                                                                                                                                                                                                                                              | PR  | Migration disposition                                                                                                                                                                                                                                                               |
+| ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | --- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `apps/tsh-desktop/src/app/renderer/features/workspace-workbench/services/internal/workspaceWorkbenchHostService.ts` (current hook) and public `apps/tsh-desktop/src/app/renderer/features/workspace-workbench/services/useWorkspaceWorkbenchHostService.ts` | Convert the internal module at the same path to a product-owned class service/facade around `WorkbenchHostCoordinator`; export its DI token from `apps/tsh-desktop/src/app/renderer/features/workspace-workbench/services/workspaceWorkbenchHostService.interface.ts`. Keep the public hook only as `useService(token)` convenience. | 7   | Move lifecycle, partition indexing, contribution resolution, session update/disposal, and stable host input to the shared class kernel. Keep TSH room policy, restored-focus projection, dock business adapters, diagnostics, and capability-specific dependencies in TSH adapters. |
+| `apps/tsh-desktop/src/app/renderer/features/workspace-workbench/services/internal/workspaceWorkbenchContributionRegistry.ts`                                                                                                                                | Generic behavior is consumed from `@tutti-os/workbench-host`; TSH descriptors move to `apps/tsh-desktop/src/app/renderer/features/workspace-workbench/services/internal/tshWorkbenchProductProfile.ts`.                                                                                                                              | 7   | Preserve `order` then `id` and all current duplicate ownership checks. Retain TSH capability availability, room chat/shared-agent inputs, and factory cache keys in capability adapters/profile rather than a product-union context.                                                |
+| `apps/tsh-desktop/src/app/renderer/features/workspace-workbench/services/internal/adapters/desktopWorkspaceWorkbenchRepository.ts`                                                                                                                          | Remains the TSH `WorkbenchSnapshotRepositoryPort` adapter.                                                                                                                                                                                                                                                                           | 7   | Preserve `(roomId, authenticatedUserId)` renderer cache partition, optimistic queue/rollback behavior, initialized marker policy, and existing desktopd GET/PUT bodies. User ID is never added to the request body.                                                                 |
+| `apps/tsh-desktop/src/app/renderer/features/workspace-workbench/ui/WorkspaceWorkbenchHostShell.tsx`                                                                                                                                                         | Remains the TSH React presentation adapter; obtains its class service/session from renderer DI and renders `WorkbenchHost`.                                                                                                                                                                                                          | 7   | Remove hook-owned host construction. Keep DOM/chrome/overlay/dialog providers, surface handle attachment, and TSH presentation wiring. Dynamic status changes update a stable session rather than remounting it.                                                                    |
+| No Workbench renderer DI registration exists today                                                                                                                                                                                                          | Add product-owned `apps/tsh-desktop/src/app/renderer/features/workspace-workbench/services/registerWorkspaceWorkbenchServices.ts`, plus renderer composition root `apps/tsh-desktop/src/app/renderer/bootstrap/createRendererServiceContainer.ts`; provide the container through the renderer app shell.                             | 7   | Use `@tutti-os/infra/di` `ServiceRegistry`, `InstantiationService`, product token, and descriptor wiring, mirroring Tutti's class-service pattern without moving registration into the shared package. Container disposal must dispose the coordinator and all room sessions.       |
+| `apps/tsh-desktop/src/app/renderer/bootstrap/renderApp.tsx` and the `TSHDesktopApp` composition path                                                                                                                                                        | Compose/provide the TSH renderer DI container and register Workbench product adapters before workspace UI renders.                                                                                                                                                                                                                   | 7   | Keep app/bootstrap as composition only. It must not absorb room business rules or construct capability contributions itself.                                                                                                                                                        |
+
+## Delivery sequence
+
+Every PR below is independently mergeable and revertible. A PR may introduce a
+dormant seam or dual-run assertion, but it may not leave two active writers or
+two launch/close authorities.
+
+| PR  | Repository              | Change                                                                                                                                              | Acceptance                                                                                                                                                                                                                             | Minimum verification                                                                                                                                                                                                        | Rollback boundary                                                                                          |
+| --- | ----------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------- |
+| 0   | Tutti                   | Land ADR, this spec, and indexes only                                                                                                               | Docs describe owners, invariants, release gates, risks, and open questions; no runtime files change                                                                                                                                    | Markdown format/link check and diff scope audit                                                                                                                                                                             | Revert docs only                                                                                           |
+| 1   | Tutti                   | Add characterization fixtures/tests around current host composition and lifecycle                                                                   | Current contribution IDs, node IDs, dock order, host-input stability, snapshot metadata, close behavior, and daemon calls are pinned without production behavior change                                                                | Workbench host/registry/repository focused tests; `pnpm --filter @tutti-os/workbench-surface test`; `pnpm check:renderer-boundaries`                                                                                        | Remove tests/fixtures                                                                                      |
+| 2   | Tutti                   | Introduce Tutti-private coordinator/session interfaces and product-neutral classes behind the current DI service                                    | One renderer coordinator creates/disposes per-workspace sessions; existing public service and UI behavior stay unchanged; no product-union context; file migration follows the mapping above                                           | New class unit tests, focused desktop host tests, `pnpm --filter @tutti-os/desktop typecheck`, `pnpm check:renderer-boundaries`                                                                                             | Switch DI registration back to existing service                                                            |
+| 3   | Tutti                   | Move Tutti-only policy into Product Profile, capability adapters, and narrow ports                                                                  | Kernel classes contain no Tutti client, preload, Electron, wallpaper, onboarding, agent, terminal, or app-center imports; existing adapter tests pass                                                                                  | Import-boundary test, characterization suite, desktop typecheck/tests, `pnpm check:electron-runtime-boundaries` where imports move                                                                                          | Restore adapter calls behind unchanged service facade                                                      |
+| 4   | Tutti                   | Extract `packages/workbench/host` as `@tutti-os/workbench-host`; add conformance harness and package docs                                           | Public exports are limited; surface use is type-only/public-contract; emitted JS has no React runtime import; surface does not import host; package graph is acyclic; pack and fixed release roster/config/scripts include the package | Package test/typecheck/build, emitted-import and dependency-cycle checks, conformance tests, `pnpm release:pack:check`, `pnpm lint:ts`, `pnpm typecheck`, `pnpm check:ui-boundaries` if package graph touches UI boundaries | Stop extraction on React runtime/cycle; otherwise revert package extraction and keep private proven kernel |
+| 5   | Tutti                   | Cut Tutti adapter fully to the package and remove private duplicate kernel                                                                          | Exactly one host coordination path; one DI coordinator per renderer/window; sessions dispose on scope/container teardown; all frozen compatibility fixtures match                                                                      | Focused host + workspace shell tests, `pnpm check:changed`, desktop build, Workbench surface tests                                                                                                                          | Revert adapter cutover to private kernel package-equivalent commit                                         |
+| 6   | Tutti release operation | Publish fixed-group npm beta after explicit approval                                                                                                | `@tutti-os/workbench-host@beta` and its exact fixed-group peers are installable; no `latest`, git tags, lockfile edits, or commits are produced                                                                                        | `pnpm release:pack:check`; dry inspection of versions/tarballs; `pnpm release:beta`; verify npm dist-tags and clean worktree                                                                                                | Deprecate bad beta; publish a new beta version, never overwrite                                            |
+| 7   | TSH                     | In a separate TSH PR, upgrade released beta dependencies, add renderer `@tutti-os/infra/di` registration, and adapt the host to coordinator/session | No filesystem links; room/user partition preserved; DI-resolved class service owns lifecycle; hook no longer owns host lifecycle; existing daemon API and business authority unchanged                                                 | Shared conformance suite, renderer DI/container disposal tests, focused TSH Workbench Vitest tests, `pnpm --dir apps/tsh-desktop check`, desktopd focused Go tests if adapters touch repository wiring                      | Revert dependency/DI/adapter PR to last released stable packages                                           |
+| 8   | Tutti                   | Resolve beta findings generically; publish further beta(s) only when approved                                                                       | Fixes are expressed as kernel contract/conformance changes, not `if (productId === ...)`; Tutti and TSH conformance both pass                                                                                                          | Package/Tutti full focused suite; TSH reports exact beta and passing suite                                                                                                                                                  | Revert individual generic fix or use next beta                                                             |
+| 9   | Tutti                   | Promote docs and prepare stable release                                                                                                             | Current Workbench architecture/conventions describe implemented kernel; active spec is removed when rollout is complete; release roster and package entrypoints are durable                                                            | Docs checks, `pnpm check:full`, package pack check, downstream evidence recorded                                                                                                                                            | Revert docs/release-prep PR; stable not yet published                                                      |
+| 10  | Tutti release operation | Publish stable fixed release group after explicit approval                                                                                          | `latest` contains the validated package set; `packages-v<version>` and all existing `packages/**/go.mod` tags are present; TSH can replace beta with exact stable versions                                                             | Stable workflow logs, npm dist-tags, package tarball smoke test, git tag audit, clean main checkout                                                                                                                         | Follow forward with a new fixed-group release; never retag or overwrite                                    |
+
+PR numbers describe dependency order, not a requirement that every concern be a
+large diff. If a PR cannot be reverted without reverting a later PR, the later
+PR must not merge first.
+
+## Phase gates
+
+### Phase 0: Tutti-first proof
+
+Includes PRs 0–3. Exit criteria:
+
+- frozen behavior is characterized;
+- reusable lifecycle code is a class with no React ownership;
+- one coordinator owns disposable workspace sessions;
+- profiles/ports/adapters have no product union or inheritance;
+- the planned host-to-surface dependency is type-only/public-contract and has no
+  reverse edge; and
+- no public package or release change is required to revert the proof.
+
+### Package beta
+
+Includes PRs 4–6. Exit criteria:
+
+- public API review approves every root/subpath export;
+- emitted host JavaScript has no React runtime import and dependency-cycle
+  checks prove surface does not depend on host;
+- pack output and fixed release group are correct;
+- the beta does not change stable tags or Go module versions;
+- Tutti uses the exact code published in the beta.
+
+### TSH external validation
+
+Includes PRs 7–8. TSH remains read-only from this Tutti planning task; its
+implementation requires separate approval and repository workflow.
+
+Exit criteria:
+
+- TSH consumes npm beta from the registry, not a local path;
+- TSH resolves the Workbench class service/coordinator through a product-owned
+  `@tutti-os/infra/di` renderer registration;
+- room ID and immutable authenticated-user partition tests pass;
+- TSH-only capabilities stay in TSH adapters;
+- shared conformance results and exact beta versions are attached to the Tutti
+  stable approval; and
+- no new shared API exists solely to expose TSH control-plane concepts.
+
+### Stable
+
+Includes PRs 9–10. Exit criteria:
+
+- both product adapters pass shared and product conformance suites;
+- no unresolved P0/P1 lifecycle, data isolation, snapshot, or business-authority
+  defect remains;
+- current architecture/convention docs own the implemented truth;
+- release automation and durable package roster agree;
+- stable publication is separately approved.
+
+## Release and versioning details
+
+- Add `@tutti-os/workbench-host` to the one fixed npm release group; do not add
+  an independent version, Changeset-only path, or host-only workflow.
+- Audit the roster in `docs/conventions/npm-package-release.md`,
+  `.changeset/config.json`, root package scripts, package-version application,
+  pack checking, beta publishing, and stable publishing. Reconcile existing
+  drift before adding the new name.
+- Beta is npm-only, uses the `beta` dist-tag, and must restore temporary manifest
+  edits. TSH records the exact prerelease version in its lockfile-generated
+  dependency update.
+- Stable uses the next repository-approved fixed-group version and
+  `packages-v<version>`.
+- Stable also emits submodule tags for every existing `packages/**/go.mod`.
+  `packages/workbench/service/v<version>` continues even when its code did not
+  change because it participates in the shared stable tag sequence.
+- Do not add `packages/workbench/host/go.mod`. If a later Go host contract is
+  justified, it needs its own design and package ownership review.
+
+## Verification strategy
+
+### Documentation-only PR 0
+
+Run the lowest documentation checks available in the repository:
+
+```sh
+pnpm exec prettier --check \
+  docs/adr/0009-cross-product-workbench-host-kernel.md \
+  docs/adr/README.md \
+  docs/specs/2026-07-11-workbench-host-kernel-phase-0-to-stable.md \
+  docs/specs/README.md
+git diff --check
+git diff --name-only
+git diff --stat
+```
+
+Also confirm no TSH file changed:
+
+```sh
+git -C /Users/ryan/dev/tutti-lab/tsh status --short
+```
+
+### Implementation PRs
+
+Use the minimum checks in the PR table first. Before the Tutti cutover or stable
+release, also run:
+
+```sh
+pnpm check:changed
+pnpm --filter @tutti-os/workbench-surface test
+pnpm --filter @tutti-os/workbench-surface typecheck
+pnpm --filter @tutti-os/desktop build
+pnpm release:pack:check
+```
+
+Run `pnpm check:full` for the final stable preparation. Daemon Go tests and API
+generation checks are required only if a separately approved change touches Go
+or OpenAPI; this plan expects no such contract change.
+
+### TSH external validation report
+
+The TSH PR must report:
+
+- exact npm beta versions and lockfile diff;
+- shared conformance cases and results;
+- product adapter tests for `(roomId, authenticatedUserId)` isolation;
+- focused renderer Workbench test results;
+- whether desktopd code changed (expected: no API/schema change); and
+- confirmation that no Tutti filesystem link or copied kernel source exists.
+
+## Risks and mitigations
+
+| Risk                                                             | Effect                                                            | Mitigation / stop condition                                                                       |
+| ---------------------------------------------------------------- | ----------------------------------------------------------------- | ------------------------------------------------------------------------------------------------- |
+| Public kernel becomes a renamed Tutti host                       | TSH cannot consume it without fake adapters                       | Import-boundary tests; reject Tutti product types in package exports                              |
+| Product-union context grows                                      | Every capability sees unrelated optional services                 | Narrow capability ports; API review rejects optional product bags                                 |
+| Session replacement during dynamic status update                 | Open nodes disappear or async actions target stale handle         | Stable update channel and identity assertions; dynamic dock conformance case                      |
+| Auth change reuses a TSH room cache                              | Cross-user layout disclosure or overwrite                         | Immutable principal partition; replacement/disposal tests; desktopd remains enforcement authority |
+| Disposed async save wins later                                   | Old scope overwrites current cache or snapshot                    | Generation/abort guard and queued-write conformance tests                                         |
+| Contribution ordering changes                                    | Dock or launch behavior regresses                                 | Characterization fixtures before extraction; exact expected order per product                     |
+| Snapshot restore creates business entities                       | Duplicate terminals/agents or authority inversion                 | Restore-with-zero-launch assertion and existing projection rules                                  |
+| Surface and host sessions duplicate responsibilities             | Conflicting state owners and teardown                             | Keep surface mechanics in surface; kernel coordinates only product-host lifecycle                 |
+| Host extraction imports React runtime or creates a package cycle | Headless ownership is false and package layering becomes unstable | Stop extraction; retain the private proof and re-review the boundary before beta                  |
+| TSH keeps hook lifecycle beside the DI class service             | Two host owners and incomplete product convergence                | PR 7 removes hook ownership; renderer DI/container disposal is a conformance requirement          |
+| Fixed release roster is already inconsistent                     | Wrong package set published                                       | Mandatory roster audit in extraction PR; fail closed on mismatch                                  |
+| Beta works only through local workspace resolution               | TSH fails after install                                           | Tarball consumer smoke test and registry-based TSH validation                                     |
+| Cross-repo rollout leaves a long-lived dual path                 | Behavior drift continues                                          | One active writer/launcher invariant; each cutover removes its replaced path                      |
+
+## Non-goals
+
+- changing Workbench visuals, interaction mechanics, mission control, or
+  launchpad design;
+- changing the snapshot schema, node identity, dock semantics, or contribution
+  contract;
+- moving daemon persistence or reconciliation into TypeScript;
+- syncing TSH layout through the control plane or across devices;
+- making Tutti and TSH expose the same product capabilities;
+- sharing product authentication, terminal, agent, chat, app, file, transfer,
+  or collaboration services;
+- binding `@tutti-os/workbench-host` itself to a DI framework or exporting
+  product registration from the shared package; both official renderers still
+  intentionally use `@tutti-os/infra/di` through product-owned registration;
+- creating a plugin marketplace or runtime extension loader;
+- publishing beta/stable as part of implementation PRs; or
+- modifying TSH from this Tutti task.
+
+## Open questions requiring an approval or measured evidence
+
+1. **Surface attachment:** keep current `WorkbenchHost` props plus
+   `onHandleReady`, or add an external surface-session input later?
+   Recommendation: preserve current props for Phase 0; measure whether the
+   attachment seam causes duplicate lifecycle.
+2. **Coordinator multiplicity:** officially support concurrent Workbench
+   sessions in one renderer, or keep it an internal capability?
+   Recommendation: test it, but do not promise multi-view UX in the first API.
+3. **Tutti user partition:** is `workspaceId` sufficient under the current local
+   desktop authority for stable, or must account switching be part of the first
+   package contract? Recommendation: keep existing Tutti mapping; require a
+   follow-up ADR before multi-user local durability.
+4. **Product metadata:** should wallpaper/onboarding metadata remain in Tutti's
+   repository adapter or move to a dedicated metadata contribution?
+   Recommendation: preserve current adapter behavior through beta.
+5. **Conformance subpath:** public `./conformance` versus repository-only shared
+   test package? Recommendation: public dev/test subpath so the external TSH
+   repository runs the exact suite shipped with the beta.
+
+## Approval gates
+
+ADR 0009 and PR 1 are approved. After PR 1 evidence is reviewed, the recommended
+next approval is PR 2 only. PR 3 remains a separate subsequent approval after
+PR 2 proves the private coordinator/session boundary.
+
+Package extraction, npm beta, TSH changes, and stable publication remain four
+additional separate approvals. None is implied by the accepted ADR or PR 1
+approval.

--- a/docs/specs/README.md
+++ b/docs/specs/README.md
@@ -9,6 +9,7 @@ Specs are not the source of truth for behavior that has already landed. When a
 spec completes, update the current document that owns the result and delete the
 dated plan.
 
-There is currently one active spec:
+There are currently two active specs:
 
 - [Agent Provider Status Read/Detect Split](./2026-06-28-agent-status-read-detect-split-design.md): pending review.
+- [Workbench Host Kernel: Phase 0 To Stable](./2026-07-11-workbench-host-kernel-phase-0-to-stable.md): pending architecture and implementation approval.


### PR DESCRIPTION
## Summary

- accept ADR 0009 for the cross-product class-DI Workbench host kernel boundary
- record that only PR 1 characterization is approved; PR 2–3, package extraction, beta, TSH migration, and stable remain separately gated
- characterize current Tutti Workbench contribution composition, stable node/dock identity, host-input lifecycle, snapshot metadata preservation, close routing, and daemon client boundaries
- keep production behavior, public contracts, snapshot schema, release configuration, lockfile, and TSH unchanged

This is the approved Phase 0 / PR 1 change only. It does not introduce a coordinator/session implementation or create @tutti-os/workbench-host.

## Verification

- focused desktop Workbench host/registry/repository/shell tests: 56 passed
- pnpm --filter @tutti-os/workbench-surface test: 201 passed
- pnpm check:renderer-boundaries
- pnpm --filter @tutti-os/desktop typecheck
- Oxfmt and Prettier checks for changed files
- local Markdown link check
- git diff --check
- pnpm check:full: 16 tasks passed

## Checklist

- [x] I kept the change focused on one concern.
- [x] I updated documentation when behavior, setup, or contributor workflow changed.
- [x] I updated all README/CONTRIBUTING language variants when changing their English source (not applicable; none changed).
- [x] I ran the lowest meaningful local checks for the changed surface.
- [x] My commits are signed off with DCO when required: git commit -s.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Characterizes the current Workbench host/kernel boundary with tests and docs to lock down behavior before extracting a shared `@tutti-os/workbench-host`. ADR 0009 is accepted and a Phase 0→stable plan is added; tests pin contribution/node IDs and dock order, enforce workspace-scoped daemon calls, preserve Tutti snapshot metadata, verify deterministic host-input caching and dock updates, and confirm close/launch routing—no runtime behavior, public contracts, or `@tutti-os/workbench-surface` schema changed.

<sup>Written for commit 1697c8f0ef7246597c3e3f8b07109c8310631f12. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tutti-os/tutti/pull/1043?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

