### PR TITLE
refactor(workbench): introduce private host session kernel

### DIFF
--- a/apps/desktop/src/renderer/src/features/workspace-workbench/services/internal/workbenchHostCoordinator.test.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/services/internal/workbenchHostCoordinator.test.ts
@@ -13,6 +13,8 @@ import {
   type WorkbenchSnapshotPartition
 } from "./workbenchHostSession.ts";
 
+const owner = {};
+
 test("workbench host coordinator leases one session for the same partition", () => {
   const coordinator = new WorkbenchHostCoordinator();
   const partition = workspacePartition("workspace-1");
@@ -22,10 +24,12 @@ test("workbench host coordinator leases one session for the same partition", () 
       createCount += 1;
       return createSession(sessionPartition);
     },
+    owner,
     partition
   });
   const second = coordinator.open({
     createSession: () => assert.fail("same partition must reuse the session"),
+    owner,
     partition
   });
 
@@ -46,6 +50,7 @@ test("workbench host coordinator replaces a scope when its principal snapshot ch
   const secondPartition = roomPartition("room-1", "user-2");
   const first = coordinator.open({
     createSession,
+    owner,
     partition: firstPartition
   });
   const events: string[] = [];
@@ -55,6 +60,7 @@ test("workbench host coordinator replaces a scope when its principal snapshot ch
 
   const second = coordinator.open({
     createSession,
+    owner,
     partition: secondPartition
   });
 
@@ -73,10 +79,12 @@ test("workbench host coordinator keeps different scopes independent", () => {
   const coordinator = new WorkbenchHostCoordinator();
   const first = coordinator.open({
     createSession,
+    owner,
     partition: workspacePartition("workspace-1")
   });
   const second = coordinator.open({
     createSession,
+    owner,
     partition: workspacePartition("workspace-2")
   });
 
@@ -92,6 +100,7 @@ test("workbench host coordinator keeps different scopes independent", () => {
     () =>
       coordinator.open({
         createSession,
+        owner,
         partition: workspacePartition("workspace-3")
       }),
     /coordinator is disposed/
@@ -106,12 +115,63 @@ test("workbench host coordinator rejects a session for another partition", () =>
     () =>
       coordinator.open({
         createSession: () => mismatchedSession,
+        owner,
         partition: workspacePartition("workspace-1")
       }),
     /partition does not match/
   );
   assert.equal(mismatchedSession.isDisposed, true);
   assert.equal(coordinator.get(workspacePartition("workspace-1")), null);
+});
+
+test("workbench host coordinator rejects another owner for the same partition", () => {
+  const coordinator = new WorkbenchHostCoordinator();
+  const first = coordinator.open({
+    createSession,
+    owner: {},
+    partition: workspacePartition("workspace-1")
+  });
+
+  assert.throws(
+    () =>
+      coordinator.open({
+        createSession,
+        owner: {},
+        partition: workspacePartition("workspace-1")
+      }),
+    /owned by another configuration/
+  );
+  assert.equal(
+    coordinator.get(workspacePartition("workspace-1")),
+    first.session
+  );
+  first.release();
+});
+
+test("workbench host coordinator continues disposing sessions after one throws", () => {
+  const errors: unknown[] = [];
+  const coordinator = new WorkbenchHostCoordinator({
+    onDisposalError(error) {
+      errors.push(error);
+    }
+  });
+  const first = coordinator.open({
+    createSession: (partition) => createThrowingSession(partition),
+    owner,
+    partition: workspacePartition("workspace-1")
+  });
+  const second = coordinator.open({
+    createSession,
+    owner,
+    partition: workspacePartition("workspace-2")
+  });
+
+  coordinator.dispose();
+
+  assert.equal(first.session.isDisposed, true);
+  assert.equal(second.session.isDisposed, true);
+  assert.equal(errors.length, 1);
+  assert.match(String(errors[0]), /session cleanup failed/);
 });
 
 test("renderer DI owns one coordinator and disposes all of its sessions", () => {
@@ -125,6 +185,7 @@ test("renderer DI owns one coordinator and disposes all of its sessions", () => 
   const sameCoordinator = getService(container, IWorkbenchHostCoordinator);
   const lease = coordinator.open({
     createSession,
+    owner,
     partition: workspacePartition("workspace-1")
   });
 
@@ -136,6 +197,20 @@ test("renderer DI owns one coordinator and disposes all of its sessions", () => 
 
 function createSession(partition: WorkbenchSnapshotPartition) {
   return new WorkbenchHostSession<string, string, undefined>({
+    partition,
+    resolve(update) {
+      return { hostInput: update, state: undefined };
+    }
+  });
+}
+
+function createThrowingSession(partition: WorkbenchSnapshotPartition) {
+  return new (class extends WorkbenchHostSession<string, string, undefined> {
+    override dispose(): void {
+      super.dispose();
+      throw new Error("session cleanup failed");
+    }
+  })({
     partition,
     resolve(update) {
       return { hostInput: update, state: undefined };

--- a/apps/desktop/src/renderer/src/features/workspace-workbench/services/internal/workbenchHostCoordinator.test.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/services/internal/workbenchHostCoordinator.test.ts
@@ -1,0 +1,160 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  getService,
+  InstantiationService,
+  ServiceRegistry,
+  SyncDescriptor
+} from "@tutti-os/infra/di";
+import { IWorkbenchHostCoordinator } from "../workbenchHostCoordinator.interface.ts";
+import { WorkbenchHostCoordinator } from "./workbenchHostCoordinator.ts";
+import {
+  WorkbenchHostSession,
+  type WorkbenchSnapshotPartition
+} from "./workbenchHostSession.ts";
+
+test("workbench host coordinator leases one session for the same partition", () => {
+  const coordinator = new WorkbenchHostCoordinator();
+  const partition = workspacePartition("workspace-1");
+  let createCount = 0;
+  const first = coordinator.open({
+    createSession: (sessionPartition) => {
+      createCount += 1;
+      return createSession(sessionPartition);
+    },
+    partition
+  });
+  const second = coordinator.open({
+    createSession: () => assert.fail("same partition must reuse the session"),
+    partition
+  });
+
+  assert.equal(first.session, second.session);
+  assert.equal(createCount, 1);
+  first.release();
+  first.release();
+  assert.equal(first.session.isDisposed, false);
+  assert.equal(coordinator.get(partition), first.session);
+  second.release();
+  assert.equal(first.session.isDisposed, true);
+  assert.equal(coordinator.get(partition), null);
+});
+
+test("workbench host coordinator replaces a scope when its principal snapshot changes", () => {
+  const coordinator = new WorkbenchHostCoordinator();
+  const firstPartition = roomPartition("room-1", "user-1");
+  const secondPartition = roomPartition("room-1", "user-2");
+  const first = coordinator.open({
+    createSession,
+    partition: firstPartition
+  });
+  const events: string[] = [];
+  first.session.registerDisposable(() => {
+    events.push("first-disposed");
+  });
+
+  const second = coordinator.open({
+    createSession,
+    partition: secondPartition
+  });
+
+  assert.deepEqual(events, ["first-disposed"]);
+  assert.equal(first.session.isDisposed, true);
+  assert.notEqual(first.session, second.session);
+  assert.equal(coordinator.get(firstPartition), null);
+  assert.equal(coordinator.get(secondPartition), second.session);
+  first.release();
+  assert.equal(second.session.isDisposed, false);
+  second.release();
+  assert.equal(second.session.isDisposed, true);
+});
+
+test("workbench host coordinator keeps different scopes independent", () => {
+  const coordinator = new WorkbenchHostCoordinator();
+  const first = coordinator.open({
+    createSession,
+    partition: workspacePartition("workspace-1")
+  });
+  const second = coordinator.open({
+    createSession,
+    partition: workspacePartition("workspace-2")
+  });
+
+  assert.notEqual(first.session, second.session);
+  first.release();
+  assert.equal(first.session.isDisposed, true);
+  assert.equal(second.session.isDisposed, false);
+  coordinator.dispose();
+  coordinator.dispose();
+  assert.equal(second.session.isDisposed, true);
+  assert.equal(coordinator.get(workspacePartition("workspace-2")), null);
+  assert.throws(
+    () =>
+      coordinator.open({
+        createSession,
+        partition: workspacePartition("workspace-3")
+      }),
+    /coordinator is disposed/
+  );
+});
+
+test("workbench host coordinator rejects a session for another partition", () => {
+  const coordinator = new WorkbenchHostCoordinator();
+  const mismatchedSession = createSession(workspacePartition("workspace-2"));
+
+  assert.throws(
+    () =>
+      coordinator.open({
+        createSession: () => mismatchedSession,
+        partition: workspacePartition("workspace-1")
+      }),
+    /partition does not match/
+  );
+  assert.equal(mismatchedSession.isDisposed, true);
+  assert.equal(coordinator.get(workspacePartition("workspace-1")), null);
+});
+
+test("renderer DI owns one coordinator and disposes all of its sessions", () => {
+  const registry = new ServiceRegistry();
+  registry.register(
+    IWorkbenchHostCoordinator,
+    new SyncDescriptor(WorkbenchHostCoordinator)
+  );
+  const container = new InstantiationService(registry.makeCollection());
+  const coordinator = getService(container, IWorkbenchHostCoordinator);
+  const sameCoordinator = getService(container, IWorkbenchHostCoordinator);
+  const lease = coordinator.open({
+    createSession,
+    partition: workspacePartition("workspace-1")
+  });
+
+  assert.equal(coordinator, sameCoordinator);
+  container.dispose();
+  assert.equal(lease.session.isDisposed, true);
+  lease.release();
+});
+
+function createSession(partition: WorkbenchSnapshotPartition) {
+  return new WorkbenchHostSession<string, string, undefined>({
+    partition,
+    resolve(update) {
+      return { hostInput: update, state: undefined };
+    }
+  });
+}
+
+function roomPartition(
+  roomId: string,
+  principalId: string
+): WorkbenchSnapshotPartition {
+  return {
+    principal: { id: principalId },
+    scope: { id: roomId, kind: "room" }
+  };
+}
+
+function workspacePartition(workspaceId: string): WorkbenchSnapshotPartition {
+  return {
+    scope: { id: workspaceId, kind: "workspace" }
+  };
+}

--- a/apps/desktop/src/renderer/src/features/workspace-workbench/services/internal/workbenchHostCoordinator.test.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/services/internal/workbenchHostCoordinator.test.ts
@@ -7,29 +7,35 @@ import {
   SyncDescriptor
 } from "@tutti-os/infra/di";
 import { IWorkbenchHostCoordinator } from "../workbenchHostCoordinator.interface.ts";
-import { WorkbenchHostCoordinator } from "./workbenchHostCoordinator.ts";
+import {
+  createWorkbenchHostSessionConfiguration,
+  WorkbenchHostCoordinator
+} from "./workbenchHostCoordinator.ts";
 import {
   WorkbenchHostSession,
   type WorkbenchSnapshotPartition
 } from "./workbenchHostSession.ts";
 
-const owner = {};
+const configuration = createWorkbenchHostSessionConfiguration({
+  createSession
+});
 
 test("workbench host coordinator leases one session for the same partition", () => {
   const coordinator = new WorkbenchHostCoordinator();
   const partition = workspacePartition("workspace-1");
   let createCount = 0;
-  const first = coordinator.open({
+  const countingConfiguration = createWorkbenchHostSessionConfiguration({
     createSession: (sessionPartition) => {
       createCount += 1;
       return createSession(sessionPartition);
-    },
-    owner,
+    }
+  });
+  const first = coordinator.open({
+    configuration: countingConfiguration,
     partition
   });
   const second = coordinator.open({
-    createSession: () => assert.fail("same partition must reuse the session"),
-    owner,
+    configuration: countingConfiguration,
     partition
   });
 
@@ -38,10 +44,13 @@ test("workbench host coordinator leases one session for the same partition", () 
   first.release();
   first.release();
   assert.equal(first.session.isDisposed, false);
-  assert.equal(coordinator.get(partition), first.session);
+  assert.equal(
+    coordinator.get(countingConfiguration, partition),
+    first.session
+  );
   second.release();
   assert.equal(first.session.isDisposed, true);
-  assert.equal(coordinator.get(partition), null);
+  assert.equal(coordinator.get(countingConfiguration, partition), null);
 });
 
 test("workbench host coordinator replaces a scope when its principal snapshot changes", () => {
@@ -49,8 +58,7 @@ test("workbench host coordinator replaces a scope when its principal snapshot ch
   const firstPartition = roomPartition("room-1", "user-1");
   const secondPartition = roomPartition("room-1", "user-2");
   const first = coordinator.open({
-    createSession,
-    owner,
+    configuration,
     partition: firstPartition
   });
   const events: string[] = [];
@@ -59,16 +67,15 @@ test("workbench host coordinator replaces a scope when its principal snapshot ch
   });
 
   const second = coordinator.open({
-    createSession,
-    owner,
+    configuration,
     partition: secondPartition
   });
 
   assert.deepEqual(events, ["first-disposed"]);
   assert.equal(first.session.isDisposed, true);
   assert.notEqual(first.session, second.session);
-  assert.equal(coordinator.get(firstPartition), null);
-  assert.equal(coordinator.get(secondPartition), second.session);
+  assert.equal(coordinator.get(configuration, firstPartition), null);
+  assert.equal(coordinator.get(configuration, secondPartition), second.session);
   first.release();
   assert.equal(second.session.isDisposed, false);
   second.release();
@@ -78,13 +85,11 @@ test("workbench host coordinator replaces a scope when its principal snapshot ch
 test("workbench host coordinator keeps different scopes independent", () => {
   const coordinator = new WorkbenchHostCoordinator();
   const first = coordinator.open({
-    createSession,
-    owner,
+    configuration,
     partition: workspacePartition("workspace-1")
   });
   const second = coordinator.open({
-    createSession,
-    owner,
+    configuration,
     partition: workspacePartition("workspace-2")
   });
 
@@ -95,12 +100,14 @@ test("workbench host coordinator keeps different scopes independent", () => {
   coordinator.dispose();
   coordinator.dispose();
   assert.equal(second.session.isDisposed, true);
-  assert.equal(coordinator.get(workspacePartition("workspace-2")), null);
+  assert.equal(
+    coordinator.get(configuration, workspacePartition("workspace-2")),
+    null
+  );
   assert.throws(
     () =>
       coordinator.open({
-        createSession,
-        owner,
+        configuration,
         partition: workspacePartition("workspace-3")
       }),
     /coordinator is disposed/
@@ -110,39 +117,45 @@ test("workbench host coordinator keeps different scopes independent", () => {
 test("workbench host coordinator rejects a session for another partition", () => {
   const coordinator = new WorkbenchHostCoordinator();
   const mismatchedSession = createSession(workspacePartition("workspace-2"));
-
-  assert.throws(
-    () =>
-      coordinator.open({
-        createSession: () => mismatchedSession,
-        owner,
-        partition: workspacePartition("workspace-1")
-      }),
-    /partition does not match/
-  );
-  assert.equal(mismatchedSession.isDisposed, true);
-  assert.equal(coordinator.get(workspacePartition("workspace-1")), null);
-});
-
-test("workbench host coordinator rejects another owner for the same partition", () => {
-  const coordinator = new WorkbenchHostCoordinator();
-  const first = coordinator.open({
-    createSession,
-    owner: {},
-    partition: workspacePartition("workspace-1")
+  const mismatchedConfiguration = createWorkbenchHostSessionConfiguration({
+    createSession: () => mismatchedSession
   });
 
   assert.throws(
     () =>
       coordinator.open({
-        createSession,
-        owner: {},
+        configuration: mismatchedConfiguration,
+        partition: workspacePartition("workspace-1")
+      }),
+    /partition does not match/
+  );
+  assert.equal(mismatchedSession.isDisposed, true);
+  assert.equal(
+    coordinator.get(mismatchedConfiguration, workspacePartition("workspace-1")),
+    null
+  );
+});
+
+test("workbench host coordinator rejects another configuration for the same partition", () => {
+  const coordinator = new WorkbenchHostCoordinator();
+  const first = coordinator.open({
+    configuration,
+    partition: workspacePartition("workspace-1")
+  });
+  const anotherConfiguration = createWorkbenchHostSessionConfiguration({
+    createSession
+  });
+
+  assert.throws(
+    () =>
+      coordinator.open({
+        configuration: anotherConfiguration,
         partition: workspacePartition("workspace-1")
       }),
     /owned by another configuration/
   );
   assert.equal(
-    coordinator.get(workspacePartition("workspace-1")),
+    coordinator.get(configuration, workspacePartition("workspace-1")),
     first.session
   );
   first.release();
@@ -155,14 +168,15 @@ test("workbench host coordinator continues disposing sessions after one throws",
       errors.push(error);
     }
   });
+  const throwingConfiguration = createWorkbenchHostSessionConfiguration({
+    createSession: (partition) => createThrowingSession(partition)
+  });
   const first = coordinator.open({
-    createSession: (partition) => createThrowingSession(partition),
-    owner,
+    configuration: throwingConfiguration,
     partition: workspacePartition("workspace-1")
   });
   const second = coordinator.open({
-    createSession,
-    owner,
+    configuration,
     partition: workspacePartition("workspace-2")
   });
 
@@ -184,8 +198,7 @@ test("renderer DI owns one coordinator and disposes all of its sessions", () => 
   const coordinator = getService(container, IWorkbenchHostCoordinator);
   const sameCoordinator = getService(container, IWorkbenchHostCoordinator);
   const lease = coordinator.open({
-    createSession,
-    owner,
+    configuration,
     partition: workspacePartition("workspace-1")
   });
 

--- a/apps/desktop/src/renderer/src/features/workspace-workbench/services/internal/workbenchHostCoordinator.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/services/internal/workbenchHostCoordinator.ts
@@ -1,0 +1,144 @@
+import {
+  areWorkbenchSnapshotPartitionsEqual,
+  createWorkbenchScopeKey,
+  WorkbenchHostSession,
+  type WorkbenchSnapshotPartition
+} from "./workbenchHostSession.ts";
+
+export interface WorkbenchHostSessionOpenInput<TUpdate, THostInput, TState> {
+  readonly createSession: (
+    partition: WorkbenchSnapshotPartition
+  ) => WorkbenchHostSession<TUpdate, THostInput, TState>;
+  readonly partition: WorkbenchSnapshotPartition;
+}
+
+export interface WorkbenchHostSessionLease<TUpdate, THostInput, TState> {
+  readonly release: () => void;
+  readonly session: WorkbenchHostSession<TUpdate, THostInput, TState>;
+}
+
+interface WorkbenchHostCoordinatorEntry {
+  leaseCount: number;
+  readonly session: WorkbenchHostSession<unknown, unknown, unknown>;
+}
+
+export class WorkbenchHostCoordinator {
+  readonly _serviceBrand = undefined;
+  private disposed = false;
+  private readonly sessionsByScope = new Map<
+    string,
+    WorkbenchHostCoordinatorEntry
+  >();
+
+  open<TUpdate, THostInput, TState>(
+    input: WorkbenchHostSessionOpenInput<TUpdate, THostInput, TState>
+  ): WorkbenchHostSessionLease<TUpdate, THostInput, TState> {
+    this.assertActive();
+    const scopeKey = createWorkbenchScopeKey(input.partition.scope);
+    let entry = this.sessionsByScope.get(scopeKey);
+    if (
+      entry &&
+      !areWorkbenchSnapshotPartitionsEqual(
+        entry.session.partition,
+        input.partition
+      )
+    ) {
+      this.sessionsByScope.delete(scopeKey);
+      entry.session.dispose();
+      entry = undefined;
+    }
+
+    if (!entry || entry.session.isDisposed) {
+      const session = input.createSession(input.partition);
+      if (
+        !areWorkbenchSnapshotPartitionsEqual(session.partition, input.partition)
+      ) {
+        session.dispose();
+        throw new Error(
+          "Workbench host session partition does not match the open request."
+        );
+      }
+      entry = {
+        leaseCount: 0,
+        session: session as WorkbenchHostSession<unknown, unknown, unknown>
+      };
+      this.sessionsByScope.set(scopeKey, entry);
+    }
+
+    entry.leaseCount += 1;
+    const leasedEntry = entry;
+    const session = entry.session as WorkbenchHostSession<
+      TUpdate,
+      THostInput,
+      TState
+    >;
+    let released = false;
+    return {
+      release: () => {
+        if (released) {
+          return;
+        }
+        released = true;
+        this.release(scopeKey, leasedEntry);
+      },
+      session
+    };
+  }
+
+  get<TUpdate, THostInput, TState>(
+    partition: WorkbenchSnapshotPartition
+  ): WorkbenchHostSession<TUpdate, THostInput, TState> | null {
+    if (this.disposed) {
+      return null;
+    }
+    const scopeKey = createWorkbenchScopeKey(partition.scope);
+    const entry = this.sessionsByScope.get(scopeKey);
+    if (!entry) {
+      return null;
+    }
+    if (entry.session.isDisposed) {
+      this.sessionsByScope.delete(scopeKey);
+      return null;
+    }
+    if (
+      !areWorkbenchSnapshotPartitionsEqual(entry.session.partition, partition)
+    ) {
+      return null;
+    }
+    return entry.session as WorkbenchHostSession<TUpdate, THostInput, TState>;
+  }
+
+  dispose(): void {
+    if (this.disposed) {
+      return;
+    }
+    this.disposed = true;
+    const entries = Array.from(this.sessionsByScope.values());
+    this.sessionsByScope.clear();
+    for (const entry of entries) {
+      entry.session.dispose();
+    }
+  }
+
+  private assertActive(): void {
+    if (this.disposed) {
+      throw new Error("Workbench host coordinator is disposed.");
+    }
+  }
+
+  private release(
+    scopeKey: string,
+    leasedEntry: WorkbenchHostCoordinatorEntry
+  ): void {
+    const currentEntry = this.sessionsByScope.get(scopeKey);
+    if (currentEntry !== leasedEntry) {
+      return;
+    }
+    leasedEntry.leaseCount -= 1;
+    if (leasedEntry.leaseCount > 0) {
+      return;
+    }
+    this.sessionsByScope.delete(scopeKey);
+    leasedEntry.session.dispose();
+  }
+}

--- a/apps/desktop/src/renderer/src/features/workspace-workbench/services/internal/workbenchHostCoordinator.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/services/internal/workbenchHostCoordinator.ts
@@ -9,6 +9,7 @@ export interface WorkbenchHostSessionOpenInput<TUpdate, THostInput, TState> {
   readonly createSession: (
     partition: WorkbenchSnapshotPartition
   ) => WorkbenchHostSession<TUpdate, THostInput, TState>;
+  readonly owner: object;
   readonly partition: WorkbenchSnapshotPartition;
 }
 
@@ -19,16 +20,26 @@ export interface WorkbenchHostSessionLease<TUpdate, THostInput, TState> {
 
 interface WorkbenchHostCoordinatorEntry {
   leaseCount: number;
+  readonly owner: object;
   readonly session: WorkbenchHostSession<unknown, unknown, unknown>;
+}
+
+export interface WorkbenchHostCoordinatorOptions {
+  readonly onDisposalError?: (error: unknown) => void;
 }
 
 export class WorkbenchHostCoordinator {
   readonly _serviceBrand = undefined;
   private disposed = false;
+  private readonly options: WorkbenchHostCoordinatorOptions;
   private readonly sessionsByScope = new Map<
     string,
     WorkbenchHostCoordinatorEntry
   >();
+
+  constructor(options: WorkbenchHostCoordinatorOptions = {}) {
+    this.options = options;
+  }
 
   open<TUpdate, THostInput, TState>(
     input: WorkbenchHostSessionOpenInput<TUpdate, THostInput, TState>
@@ -44,8 +55,14 @@ export class WorkbenchHostCoordinator {
       )
     ) {
       this.sessionsByScope.delete(scopeKey);
-      entry.session.dispose();
+      this.disposeSession(entry.session);
       entry = undefined;
+    }
+
+    if (entry && entry.owner !== input.owner) {
+      throw new Error(
+        "Workbench host session partition is already owned by another configuration."
+      );
     }
 
     if (!entry || entry.session.isDisposed) {
@@ -53,13 +70,14 @@ export class WorkbenchHostCoordinator {
       if (
         !areWorkbenchSnapshotPartitionsEqual(session.partition, input.partition)
       ) {
-        session.dispose();
+        this.disposeSession(session);
         throw new Error(
           "Workbench host session partition does not match the open request."
         );
       }
       entry = {
         leaseCount: 0,
+        owner: input.owner,
         session: session as WorkbenchHostSession<unknown, unknown, unknown>
       };
       this.sessionsByScope.set(scopeKey, entry);
@@ -116,7 +134,7 @@ export class WorkbenchHostCoordinator {
     const entries = Array.from(this.sessionsByScope.values());
     this.sessionsByScope.clear();
     for (const entry of entries) {
-      entry.session.dispose();
+      this.disposeSession(entry.session);
     }
   }
 
@@ -139,6 +157,24 @@ export class WorkbenchHostCoordinator {
       return;
     }
     this.sessionsByScope.delete(scopeKey);
-    leasedEntry.session.dispose();
+    this.disposeSession(leasedEntry.session);
+  }
+
+  private disposeSession<TUpdate, THostInput, TState>(
+    session: WorkbenchHostSession<TUpdate, THostInput, TState>
+  ): void {
+    try {
+      session.dispose();
+    } catch (error) {
+      this.reportDisposalError(error);
+    }
+  }
+
+  private reportDisposalError(error: unknown): void {
+    try {
+      this.options.onDisposalError?.(error);
+    } catch {
+      // Disposal must continue even when diagnostics fail.
+    }
   }
 }

--- a/apps/desktop/src/renderer/src/features/workspace-workbench/services/internal/workbenchHostCoordinator.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/services/internal/workbenchHostCoordinator.ts
@@ -5,11 +5,29 @@ import {
   type WorkbenchSnapshotPartition
 } from "./workbenchHostSession.ts";
 
-export interface WorkbenchHostSessionOpenInput<TUpdate, THostInput, TState> {
+declare const workbenchHostSessionConfigurationBrand: unique symbol;
+
+export interface WorkbenchHostSessionConfiguration<
+  TUpdate,
+  THostInput,
+  TState
+> {
+  readonly [workbenchHostSessionConfigurationBrand]: {
+    readonly hostInput: THostInput;
+    readonly state: TState;
+    readonly update: TUpdate;
+  };
   readonly createSession: (
     partition: WorkbenchSnapshotPartition
   ) => WorkbenchHostSession<TUpdate, THostInput, TState>;
-  readonly owner: object;
+}
+
+export interface WorkbenchHostSessionOpenInput<TUpdate, THostInput, TState> {
+  readonly configuration: WorkbenchHostSessionConfiguration<
+    TUpdate,
+    THostInput,
+    TState
+  >;
   readonly partition: WorkbenchSnapshotPartition;
 }
 
@@ -19,13 +37,29 @@ export interface WorkbenchHostSessionLease<TUpdate, THostInput, TState> {
 }
 
 interface WorkbenchHostCoordinatorEntry {
+  readonly configuration: object;
   leaseCount: number;
-  readonly owner: object;
   readonly session: WorkbenchHostSession<unknown, unknown, unknown>;
 }
 
 export interface WorkbenchHostCoordinatorOptions {
-  readonly onDisposalError?: (error: unknown) => void;
+  readonly onDisposalError?: (error: unknown) => Promise<void> | void;
+}
+
+export function createWorkbenchHostSessionConfiguration<
+  TUpdate,
+  THostInput,
+  TState
+>(input: {
+  readonly createSession: (
+    partition: WorkbenchSnapshotPartition
+  ) => WorkbenchHostSession<TUpdate, THostInput, TState>;
+}): WorkbenchHostSessionConfiguration<TUpdate, THostInput, TState> {
+  return input as WorkbenchHostSessionConfiguration<
+    TUpdate,
+    THostInput,
+    TState
+  >;
 }
 
 export class WorkbenchHostCoordinator {
@@ -59,14 +93,14 @@ export class WorkbenchHostCoordinator {
       entry = undefined;
     }
 
-    if (entry && entry.owner !== input.owner) {
+    if (entry && entry.configuration !== input.configuration) {
       throw new Error(
         "Workbench host session partition is already owned by another configuration."
       );
     }
 
     if (!entry || entry.session.isDisposed) {
-      const session = input.createSession(input.partition);
+      const session = input.configuration.createSession(input.partition);
       if (
         !areWorkbenchSnapshotPartitionsEqual(session.partition, input.partition)
       ) {
@@ -76,8 +110,8 @@ export class WorkbenchHostCoordinator {
         );
       }
       entry = {
+        configuration: input.configuration,
         leaseCount: 0,
-        owner: input.owner,
         session: session as WorkbenchHostSession<unknown, unknown, unknown>
       };
       this.sessionsByScope.set(scopeKey, entry);
@@ -104,6 +138,11 @@ export class WorkbenchHostCoordinator {
   }
 
   get<TUpdate, THostInput, TState>(
+    configuration: WorkbenchHostSessionConfiguration<
+      TUpdate,
+      THostInput,
+      TState
+    >,
     partition: WorkbenchSnapshotPartition
   ): WorkbenchHostSession<TUpdate, THostInput, TState> | null {
     if (this.disposed) {
@@ -112,6 +151,9 @@ export class WorkbenchHostCoordinator {
     const scopeKey = createWorkbenchScopeKey(partition.scope);
     const entry = this.sessionsByScope.get(scopeKey);
     if (!entry) {
+      return null;
+    }
+    if (entry.configuration !== configuration) {
       return null;
     }
     if (entry.session.isDisposed) {
@@ -172,7 +214,8 @@ export class WorkbenchHostCoordinator {
 
   private reportDisposalError(error: unknown): void {
     try {
-      this.options.onDisposalError?.(error);
+      const result = this.options.onDisposalError?.(error);
+      void result?.catch(() => undefined);
     } catch {
       // Disposal must continue even when diagnostics fail.
     }

--- a/apps/desktop/src/renderer/src/features/workspace-workbench/services/internal/workbenchHostSession.test.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/services/internal/workbenchHostSession.test.ts
@@ -108,6 +108,36 @@ test("workbench host session disposable registrations can be released", () => {
   assert.equal(disposeCount, 0);
 });
 
+test("workbench host session continues cleanup after a disposer throws", () => {
+  const events: string[] = [];
+  const errors: unknown[] = [];
+  const session = new WorkbenchHostSession<string, string, undefined>({
+    onDisposalError(error) {
+      errors.push(error);
+    },
+    partition: workspacePartition("workspace-1"),
+    resolve(update) {
+      return { hostInput: update, state: undefined };
+    }
+  });
+  session.update("ready");
+  session.registerDisposable(() => {
+    events.push("first");
+  });
+  session.registerDisposable(() => {
+    events.push("throwing");
+    throw new Error("cleanup failed");
+  });
+
+  session.dispose();
+  session.dispose();
+
+  assert.deepEqual(events, ["throwing", "first"]);
+  assert.equal(errors.length, 1);
+  assert.match(String(errors[0]), /cleanup failed/);
+  assert.equal(session.isDisposed, true);
+});
+
 function createSession(
   partition: WorkbenchSnapshotPartition
 ): WorkbenchHostSession<string, string, undefined> {

--- a/apps/desktop/src/renderer/src/features/workspace-workbench/services/internal/workbenchHostSession.test.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/services/internal/workbenchHostSession.test.ts
@@ -64,6 +64,24 @@ test("workbench host session publishes only referential host input changes", () 
   assert.deepEqual(previousStates, [null, "first", "second"]);
 });
 
+test("workbench host session keeps one stable subscriber batch per update", () => {
+  const session = createSession(workspacePartition("workspace-1"));
+  let notificationCount = 0;
+  let unsubscribe = () => {};
+  const listener = () => {
+    notificationCount += 1;
+    unsubscribe();
+    unsubscribe = session.subscribe(listener);
+  };
+  unsubscribe = session.subscribe(listener);
+
+  session.update("first");
+  assert.equal(notificationCount, 1);
+
+  session.update("second");
+  assert.equal(notificationCount, 2);
+});
+
 test("workbench host session detaches its surface and disposes resources once", () => {
   const events: string[] = [];
   const session = createSession(workspacePartition("workspace-1"));

--- a/apps/desktop/src/renderer/src/features/workspace-workbench/services/internal/workbenchHostSession.test.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/services/internal/workbenchHostSession.test.ts
@@ -67,7 +67,8 @@ test("workbench host session publishes only referential host input changes", () 
 test("workbench host session detaches its surface and disposes resources once", () => {
   const events: string[] = [];
   const session = createSession(workspacePartition("workspace-1"));
-  session.attachSurface({} as WorkbenchHostHandle);
+  const surfaceOwner = {};
+  session.attachSurface({} as WorkbenchHostHandle, surfaceOwner);
   session.subscribe(() => {
     events.push("listener");
   });
@@ -91,7 +92,25 @@ test("workbench host session detaches its surface and disposes resources once", 
   assert.equal(disposedListenerCalled, false);
   assert.throws(() => session.update("late"), /session is disposed/);
   assert.throws(() => session.getHostInput(), /session is disposed/);
-  assert.throws(() => session.attachSurface(null), /session is disposed/);
+  assert.throws(
+    () => session.attachSurface(null, surfaceOwner),
+    /session is disposed/
+  );
+});
+
+test("workbench host session ignores detach from a stale surface owner", () => {
+  const session = createSession(workspacePartition("workspace-1"));
+  const firstOwner = {};
+  const secondOwner = {};
+  const firstHandle = {} as WorkbenchHostHandle;
+  const secondHandle = {} as WorkbenchHostHandle;
+
+  session.attachSurface(firstHandle, firstOwner);
+  session.attachSurface(secondHandle, secondOwner);
+  session.attachSurface(null, firstOwner);
+  assert.equal(session.getAttachedSurface(), secondHandle);
+  session.attachSurface(null, secondOwner);
+  assert.equal(session.getAttachedSurface(), null);
 });
 
 test("workbench host session disposable registrations can be released", () => {
@@ -135,6 +154,26 @@ test("workbench host session continues cleanup after a disposer throws", () => {
   assert.deepEqual(events, ["throwing", "first"]);
   assert.equal(errors.length, 1);
   assert.match(String(errors[0]), /cleanup failed/);
+  assert.equal(session.isDisposed, true);
+});
+
+test("workbench host session isolates rejected async disposal diagnostics", async () => {
+  const session = new WorkbenchHostSession<string, string, undefined>({
+    async onDisposalError() {
+      throw new Error("diagnostics failed");
+    },
+    partition: workspacePartition("workspace-1"),
+    resolve(update) {
+      return { hostInput: update, state: undefined };
+    }
+  });
+  session.registerDisposable(() => {
+    throw new Error("cleanup failed");
+  });
+
+  session.dispose();
+  await new Promise<void>((resolve) => setImmediate(resolve));
+
   assert.equal(session.isDisposed, true);
 });
 

--- a/apps/desktop/src/renderer/src/features/workspace-workbench/services/internal/workbenchHostSession.test.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/services/internal/workbenchHostSession.test.ts
@@ -1,0 +1,129 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import type { WorkbenchHostHandle } from "@tutti-os/workbench-surface";
+import {
+  WorkbenchHostSession,
+  type WorkbenchSnapshotPartition
+} from "./workbenchHostSession.ts";
+
+test("workbench host session captures an immutable partition snapshot", () => {
+  const partition = {
+    principal: { id: "user-1" },
+    scope: { id: "room-1", kind: "room" as const }
+  };
+  const session = createSession(partition);
+
+  partition.principal.id = "user-2";
+  partition.scope.id = "room-2";
+
+  assert.deepEqual(session.partition, {
+    principal: { id: "user-1" },
+    scope: { id: "room-1", kind: "room" }
+  });
+  assert.equal(Object.isFrozen(session.partition), true);
+  assert.equal(Object.isFrozen(session.partition.scope), true);
+  assert.equal(Object.isFrozen(session.partition.principal), true);
+});
+
+test("workbench host session publishes only referential host input changes", () => {
+  const firstHostInput = { revision: 1 };
+  const secondHostInput = { revision: 2 };
+  const previousStates: Array<string | null> = [];
+  const session = new WorkbenchHostSession<
+    { hostInput: { revision: number }; state: string },
+    { revision: number },
+    string
+  >({
+    partition: workspacePartition("workspace-1"),
+    resolve(update, current) {
+      previousStates.push(current?.state ?? null);
+      return update;
+    }
+  });
+  let notificationCount = 0;
+  session.subscribe(() => {
+    notificationCount += 1;
+  });
+
+  assert.equal(
+    session.update({ hostInput: firstHostInput, state: "first" }),
+    firstHostInput
+  );
+  assert.equal(notificationCount, 1);
+  assert.equal(
+    session.update({ hostInput: firstHostInput, state: "second" }),
+    firstHostInput
+  );
+  assert.equal(notificationCount, 1);
+  assert.equal(
+    session.update({ hostInput: secondHostInput, state: "third" }),
+    secondHostInput
+  );
+  assert.equal(notificationCount, 2);
+  assert.equal(session.getHostInput(), secondHostInput);
+  assert.deepEqual(previousStates, [null, "first", "second"]);
+});
+
+test("workbench host session detaches its surface and disposes resources once", () => {
+  const events: string[] = [];
+  const session = createSession(workspacePartition("workspace-1"));
+  session.attachSurface({} as WorkbenchHostHandle);
+  session.subscribe(() => {
+    events.push("listener");
+  });
+  session.registerDisposable(() => {
+    events.push("first-disposable");
+  });
+  session.registerDisposable(() => {
+    events.push("second-disposable");
+  });
+
+  session.dispose();
+  session.dispose();
+
+  assert.deepEqual(events, ["second-disposable", "first-disposable"]);
+  assert.equal(session.isDisposed, true);
+  assert.equal(session.getAttachedSurface(), null);
+  let disposedListenerCalled = false;
+  session.subscribe(() => {
+    disposedListenerCalled = true;
+  })();
+  assert.equal(disposedListenerCalled, false);
+  assert.throws(() => session.update("late"), /session is disposed/);
+  assert.throws(() => session.getHostInput(), /session is disposed/);
+  assert.throws(() => session.attachSurface(null), /session is disposed/);
+});
+
+test("workbench host session disposable registrations can be released", () => {
+  let disposeCount = 0;
+  const session = createSession(workspacePartition("workspace-1"));
+  const unregister = session.registerDisposable(() => {
+    disposeCount += 1;
+  });
+
+  unregister();
+  unregister();
+  session.dispose();
+
+  assert.equal(disposeCount, 0);
+});
+
+function createSession(
+  partition: WorkbenchSnapshotPartition
+): WorkbenchHostSession<string, string, undefined> {
+  return new WorkbenchHostSession({
+    partition,
+    resolve(update) {
+      return { hostInput: update, state: undefined };
+    }
+  });
+}
+
+function workspacePartition(workspaceId: string): WorkbenchSnapshotPartition {
+  return {
+    scope: {
+      id: workspaceId,
+      kind: "workspace"
+    }
+  };
+}

--- a/apps/desktop/src/renderer/src/features/workspace-workbench/services/internal/workbenchHostSession.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/services/internal/workbenchHostSession.ts
@@ -1,0 +1,166 @@
+import type { WorkbenchHostHandle } from "@tutti-os/workbench-surface";
+
+export interface WorkbenchScope {
+  readonly id: string;
+  readonly kind: "room" | "workspace";
+}
+
+export interface WorkbenchAuthenticatedPrincipalSnapshot {
+  readonly id: string;
+}
+
+export interface WorkbenchSnapshotPartition {
+  readonly principal?: WorkbenchAuthenticatedPrincipalSnapshot;
+  readonly scope: WorkbenchScope;
+}
+
+export interface WorkbenchHostSessionResolution<THostInput, TState> {
+  readonly hostInput: THostInput;
+  readonly state: TState;
+}
+
+export interface WorkbenchHostSessionOptions<TUpdate, THostInput, TState> {
+  readonly partition: WorkbenchSnapshotPartition;
+  readonly resolve: (
+    update: TUpdate,
+    current: WorkbenchHostSessionResolution<THostInput, TState> | null
+  ) => WorkbenchHostSessionResolution<THostInput, TState>;
+}
+
+export class WorkbenchHostSession<TUpdate, THostInput, TState> {
+  readonly partition: WorkbenchSnapshotPartition;
+  private current: WorkbenchHostSessionResolution<THostInput, TState> | null =
+    null;
+  private disposed = false;
+  private readonly disposalCallbacks: Array<() => void> = [];
+  private readonly listeners = new Set<() => void>();
+  private readonly resolve: WorkbenchHostSessionOptions<
+    TUpdate,
+    THostInput,
+    TState
+  >["resolve"];
+  private surfaceHandle: WorkbenchHostHandle | null = null;
+
+  constructor(
+    options: WorkbenchHostSessionOptions<TUpdate, THostInput, TState>
+  ) {
+    this.partition = freezeWorkbenchSnapshotPartition(options.partition);
+    this.resolve = options.resolve;
+  }
+
+  get isDisposed(): boolean {
+    return this.disposed;
+  }
+
+  attachSurface(handle: WorkbenchHostHandle | null): void {
+    this.assertActive();
+    this.surfaceHandle = handle;
+  }
+
+  getAttachedSurface(): WorkbenchHostHandle | null {
+    return this.surfaceHandle;
+  }
+
+  getHostInput(): THostInput {
+    this.assertActive();
+    if (!this.current) {
+      throw new Error("Workbench host session has not received an update.");
+    }
+    return this.current.hostInput;
+  }
+
+  registerDisposable(dispose: () => void): () => void {
+    this.assertActive();
+    let registered = true;
+    this.disposalCallbacks.push(dispose);
+    return () => {
+      if (!registered || this.disposed) {
+        return;
+      }
+      registered = false;
+      const index = this.disposalCallbacks.indexOf(dispose);
+      if (index >= 0) {
+        this.disposalCallbacks.splice(index, 1);
+      }
+    };
+  }
+
+  subscribe(listener: () => void): () => void {
+    if (this.disposed) {
+      return noop;
+    }
+    this.listeners.add(listener);
+    return () => {
+      this.listeners.delete(listener);
+    };
+  }
+
+  update(update: TUpdate): THostInput {
+    this.assertActive();
+    const hadCurrent = this.current !== null;
+    const previousHostInput = this.current?.hostInput;
+    const next = this.resolve(update, this.current);
+    this.current = next;
+    if (!hadCurrent || previousHostInput !== next.hostInput) {
+      for (const listener of this.listeners) {
+        listener();
+      }
+    }
+    return next.hostInput;
+  }
+
+  dispose(): void {
+    if (this.disposed) {
+      return;
+    }
+    this.disposed = true;
+    this.surfaceHandle = null;
+    this.listeners.clear();
+    for (
+      let index = this.disposalCallbacks.length - 1;
+      index >= 0;
+      index -= 1
+    ) {
+      this.disposalCallbacks[index]?.();
+    }
+    this.disposalCallbacks.length = 0;
+    this.current = null;
+  }
+
+  private assertActive(): void {
+    if (this.disposed) {
+      throw new Error("Workbench host session is disposed.");
+    }
+  }
+}
+
+export function areWorkbenchSnapshotPartitionsEqual(
+  left: WorkbenchSnapshotPartition,
+  right: WorkbenchSnapshotPartition
+): boolean {
+  return (
+    left.scope.kind === right.scope.kind &&
+    left.scope.id === right.scope.id &&
+    left.principal?.id === right.principal?.id
+  );
+}
+
+export function createWorkbenchScopeKey(scope: WorkbenchScope): string {
+  return `${scope.kind.length}:${scope.kind}${scope.id.length}:${scope.id}`;
+}
+
+function freezeWorkbenchSnapshotPartition(
+  partition: WorkbenchSnapshotPartition
+): WorkbenchSnapshotPartition {
+  return Object.freeze({
+    ...(partition.principal
+      ? { principal: Object.freeze({ id: partition.principal.id }) }
+      : {}),
+    scope: Object.freeze({
+      id: partition.scope.id,
+      kind: partition.scope.kind
+    })
+  });
+}
+
+function noop(): void {}

--- a/apps/desktop/src/renderer/src/features/workspace-workbench/services/internal/workbenchHostSession.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/services/internal/workbenchHostSession.ts
@@ -20,7 +20,7 @@ export interface WorkbenchHostSessionResolution<THostInput, TState> {
 }
 
 export interface WorkbenchHostSessionOptions<TUpdate, THostInput, TState> {
-  readonly onDisposalError?: (error: unknown) => void;
+  readonly onDisposalError?: (error: unknown) => Promise<void> | void;
   readonly partition: WorkbenchSnapshotPartition;
   readonly resolve: (
     update: TUpdate,
@@ -35,13 +35,14 @@ export class WorkbenchHostSession<TUpdate, THostInput, TState> {
   private disposed = false;
   private readonly disposalCallbacks: Array<() => void> = [];
   private readonly listeners = new Set<() => void>();
-  private readonly onDisposalError?: (error: unknown) => void;
+  private readonly onDisposalError?: (error: unknown) => Promise<void> | void;
   private readonly resolve: WorkbenchHostSessionOptions<
     TUpdate,
     THostInput,
     TState
   >["resolve"];
   private surfaceHandle: WorkbenchHostHandle | null = null;
+  private surfaceOwner: object | null = null;
 
   constructor(
     options: WorkbenchHostSessionOptions<TUpdate, THostInput, TState>
@@ -55,9 +56,17 @@ export class WorkbenchHostSession<TUpdate, THostInput, TState> {
     return this.disposed;
   }
 
-  attachSurface(handle: WorkbenchHostHandle | null): void {
+  attachSurface(handle: WorkbenchHostHandle | null, owner: object): void {
     this.assertActive();
+    if (handle === null) {
+      if (this.surfaceOwner === owner) {
+        this.surfaceHandle = null;
+        this.surfaceOwner = null;
+      }
+      return;
+    }
     this.surfaceHandle = handle;
+    this.surfaceOwner = owner;
   }
 
   getAttachedSurface(): WorkbenchHostHandle | null {
@@ -118,6 +127,7 @@ export class WorkbenchHostSession<TUpdate, THostInput, TState> {
     }
     this.disposed = true;
     this.surfaceHandle = null;
+    this.surfaceOwner = null;
     this.listeners.clear();
     const disposalCallbacks = this.disposalCallbacks.splice(0);
     this.disposalCallbacks.length = 0;
@@ -139,7 +149,8 @@ export class WorkbenchHostSession<TUpdate, THostInput, TState> {
 
   private reportDisposalError(error: unknown): void {
     try {
-      this.onDisposalError?.(error);
+      const result = this.onDisposalError?.(error);
+      void result?.catch(() => undefined);
     } catch {
       // Disposal must continue even when diagnostics fail.
     }

--- a/apps/desktop/src/renderer/src/features/workspace-workbench/services/internal/workbenchHostSession.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/services/internal/workbenchHostSession.ts
@@ -20,6 +20,7 @@ export interface WorkbenchHostSessionResolution<THostInput, TState> {
 }
 
 export interface WorkbenchHostSessionOptions<TUpdate, THostInput, TState> {
+  readonly onDisposalError?: (error: unknown) => void;
   readonly partition: WorkbenchSnapshotPartition;
   readonly resolve: (
     update: TUpdate,
@@ -34,6 +35,7 @@ export class WorkbenchHostSession<TUpdate, THostInput, TState> {
   private disposed = false;
   private readonly disposalCallbacks: Array<() => void> = [];
   private readonly listeners = new Set<() => void>();
+  private readonly onDisposalError?: (error: unknown) => void;
   private readonly resolve: WorkbenchHostSessionOptions<
     TUpdate,
     THostInput,
@@ -45,6 +47,7 @@ export class WorkbenchHostSession<TUpdate, THostInput, TState> {
     options: WorkbenchHostSessionOptions<TUpdate, THostInput, TState>
   ) {
     this.partition = freezeWorkbenchSnapshotPartition(options.partition);
+    this.onDisposalError = options.onDisposalError;
     this.resolve = options.resolve;
   }
 
@@ -116,20 +119,29 @@ export class WorkbenchHostSession<TUpdate, THostInput, TState> {
     this.disposed = true;
     this.surfaceHandle = null;
     this.listeners.clear();
-    for (
-      let index = this.disposalCallbacks.length - 1;
-      index >= 0;
-      index -= 1
-    ) {
-      this.disposalCallbacks[index]?.();
-    }
+    const disposalCallbacks = this.disposalCallbacks.splice(0);
     this.disposalCallbacks.length = 0;
     this.current = null;
+    for (let index = disposalCallbacks.length - 1; index >= 0; index -= 1) {
+      try {
+        disposalCallbacks[index]?.();
+      } catch (error) {
+        this.reportDisposalError(error);
+      }
+    }
   }
 
   private assertActive(): void {
     if (this.disposed) {
       throw new Error("Workbench host session is disposed.");
+    }
+  }
+
+  private reportDisposalError(error: unknown): void {
+    try {
+      this.onDisposalError?.(error);
+    } catch {
+      // Disposal must continue even when diagnostics fail.
     }
   }
 }

--- a/apps/desktop/src/renderer/src/features/workspace-workbench/services/internal/workbenchHostSession.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/services/internal/workbenchHostSession.ts
@@ -114,7 +114,7 @@ export class WorkbenchHostSession<TUpdate, THostInput, TState> {
     const next = this.resolve(update, this.current);
     this.current = next;
     if (!hadCurrent || previousHostInput !== next.hostInput) {
-      for (const listener of this.listeners) {
+      for (const listener of Array.from(this.listeners)) {
         listener();
       }
     }

--- a/apps/desktop/src/renderer/src/features/workspace-workbench/services/internal/workspaceWorkbenchHostService.test.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/services/internal/workspaceWorkbenchHostService.test.ts
@@ -26,6 +26,10 @@ const workspaceWorkbenchShellHookSource = readFileSync(
   new URL("../../ui/useWorkspaceWorkbenchShellRuntime.tsx", import.meta.url),
   "utf8"
 );
+const workspaceWorkbenchSource = readFileSync(
+  new URL("../../ui/WorkspaceWorkbench.tsx", import.meta.url),
+  "utf8"
+);
 
 test("workspace workbench host keeps deterministic composition and close preparation wiring", () => {
   assert.match(
@@ -49,29 +53,31 @@ test("workspace workbench host keeps deterministic composition and close prepara
 test("workspace workbench host delegates workspace lifecycle to the DI coordinator", () => {
   assert.match(
     workspaceWorkbenchHostServiceSource,
-    /this\.workbenchHostCoordinator\.get<[\s\S]*?>\(createWorkspaceWorkbenchPartition\(workspaceId\)\)/
+    /openHostSession\([\s\S]*?this\.workbenchHostCoordinator\.open<[\s\S]*?>\(\{[\s\S]*?new WorkbenchHostSession<[\s\S]*?>\(\{[\s\S]*?partition: sessionPartition/
   );
   assert.match(
     workspaceWorkbenchHostServiceSource,
-    /this\.workbenchHostCoordinator\.open<[\s\S]*?>\(\{[\s\S]*?new WorkbenchHostSession<[\s\S]*?>\(\{[\s\S]*?partition: sessionPartition/
-  );
-  assert.match(
-    workspaceWorkbenchHostServiceSource,
-    /this\.hostSessionLeases\.add\(lease\);\s+session = lease\.session;[\s\S]*?return session\.update\(input\)/
+    /owner: this\.hostSessionOwner,[\s\S]*?return createWorkspaceWorkbenchHostSessionBinding\(\{[\s\S]*?bindingId: this\.hostSessionBindingSequence,[\s\S]*?lease,[\s\S]*?workspaceId/
   );
   assert.doesNotMatch(workspaceWorkbenchHostServiceSource, /cachedHostInputs/);
+  assert.doesNotMatch(workspaceWorkbenchHostServiceSource, /hostSessionLeases/);
   assert.match(
     workspaceWorkbenchRegistrationSource,
     /IWorkbenchHostCoordinator,\s+new SyncDescriptor\(WorkbenchHostCoordinator\)/
   );
   assert.match(
     workspaceWorkbenchShellHookSource,
-    /workbenchHostService\.attachHostSurface\(state\.workspace\.id, host\)/
+    /createHostInput: hostSession\.createHostInput/
   );
   assert.match(
     workspaceWorkbenchShellHookSource,
-    /workbenchHostService\.releaseHostSession\(state\.workspace\.id\)/
+    /hostSession\.attachSurface\(host\)/
   );
+  assert.match(
+    workspaceWorkbenchSource,
+    /useLayoutEffect\(\(\) => \{\s+const binding = workbenchHostService\.openHostSession\(workspaceId\);[\s\S]*?binding\.release\(\)/
+  );
+  assert.match(workspaceWorkbenchSource, /key=\{hostSession\.bindingId\}/);
 });
 
 test("workspace workbench host session resolution keeps stable refs and isolates dynamic dock updates", () => {

--- a/apps/desktop/src/renderer/src/features/workspace-workbench/services/internal/workspaceWorkbenchHostService.test.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/services/internal/workspaceWorkbenchHostService.test.ts
@@ -84,6 +84,13 @@ test("workspace workbench host delegates workspace lifecycle to the DI coordinat
   assert.match(workspaceWorkbenchSource, /key=\{hostSession\.bindingId\}/);
 });
 
+test("workspace workbench host releases owned wallpaper URLs on disposal", () => {
+  assert.match(
+    workspaceWorkbenchHostServiceSource,
+    /dispose\(\): void \{\s+this\.wallpaperListeners\.clear\(\);\s+this\.clearCustomWallpaperUrls\(\);\s+\}/
+  );
+});
+
 test("workspace workbench host session resolution keeps stable refs and isolates dynamic dock updates", () => {
   assert.match(
     workspaceWorkbenchHostServiceSource,

--- a/apps/desktop/src/renderer/src/features/workspace-workbench/services/internal/workspaceWorkbenchHostService.test.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/services/internal/workspaceWorkbenchHostService.test.ts
@@ -18,6 +18,14 @@ const workspaceWorkbenchHostServiceSource = readFileSync(
   new URL("./workspaceWorkbenchHostService.ts", import.meta.url),
   "utf8"
 );
+const workspaceWorkbenchRegistrationSource = readFileSync(
+  new URL("../registerWorkspaceWorkbenchServices.ts", import.meta.url),
+  "utf8"
+);
+const workspaceWorkbenchShellHookSource = readFileSync(
+  new URL("../../ui/useWorkspaceWorkbenchShellRuntime.tsx", import.meta.url),
+  "utf8"
+);
 
 test("workspace workbench host keeps deterministic composition and close preparation wiring", () => {
   assert.match(
@@ -38,18 +46,42 @@ test("workspace workbench host keeps deterministic composition and close prepara
   );
 });
 
-test("workspace workbench host caches stable host input and isolates dynamic dock updates", () => {
+test("workspace workbench host delegates workspace lifecycle to the DI coordinator", () => {
   assert.match(
     workspaceWorkbenchHostServiceSource,
-    /private readonly cachedHostInputs = new Map<\s+string,\s+CachedWorkspaceWorkbenchHostInput\s+>\(\)/
+    /this\.workbenchHostCoordinator\.get<[\s\S]*?>\(createWorkspaceWorkbenchPartition\(workspaceId\)\)/
   );
   assert.match(
     workspaceWorkbenchHostServiceSource,
-    /const cached = this\.cachedHostInputs\.get\(input\.workspaceId\)/
+    /this\.workbenchHostCoordinator\.open<[\s\S]*?>\(\{[\s\S]*?new WorkbenchHostSession<[\s\S]*?>\(\{[\s\S]*?partition: sessionPartition/
   );
   assert.match(
     workspaceWorkbenchHostServiceSource,
-    /cached\.renderFilesNodeBodyRef\.current = input\.renderFilesNodeBody;\s+return this\.createHostInputWithDynamicDockEntries\(/
+    /this\.hostSessionLeases\.add\(lease\);\s+session = lease\.session;[\s\S]*?return session\.update\(input\)/
+  );
+  assert.doesNotMatch(workspaceWorkbenchHostServiceSource, /cachedHostInputs/);
+  assert.match(
+    workspaceWorkbenchRegistrationSource,
+    /IWorkbenchHostCoordinator,\s+new SyncDescriptor\(WorkbenchHostCoordinator\)/
+  );
+  assert.match(
+    workspaceWorkbenchShellHookSource,
+    /workbenchHostService\.attachHostSurface\(state\.workspace\.id, host\)/
+  );
+  assert.match(
+    workspaceWorkbenchShellHookSource,
+    /workbenchHostService\.releaseHostSession\(state\.workspace\.id\)/
+  );
+});
+
+test("workspace workbench host session resolution keeps stable refs and isolates dynamic dock updates", () => {
+  assert.match(
+    workspaceWorkbenchHostServiceSource,
+    /const cached = current\?\.state/
+  );
+  assert.match(
+    workspaceWorkbenchHostServiceSource,
+    /cached\.renderFilesNodeBodyRef\.current = input\.renderFilesNodeBody;[\s\S]*?hostInput: this\.createHostInputWithDynamicDockEntries\(/
   );
   assert.match(
     workspaceWorkbenchHostServiceSource,

--- a/apps/desktop/src/renderer/src/features/workspace-workbench/services/internal/workspaceWorkbenchHostService.test.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/services/internal/workspaceWorkbenchHostService.test.ts
@@ -53,11 +53,15 @@ test("workspace workbench host keeps deterministic composition and close prepara
 test("workspace workbench host delegates workspace lifecycle to the DI coordinator", () => {
   assert.match(
     workspaceWorkbenchHostServiceSource,
-    /openHostSession\([\s\S]*?this\.workbenchHostCoordinator\.open<[\s\S]*?>\(\{[\s\S]*?new WorkbenchHostSession<[\s\S]*?>\(\{[\s\S]*?partition: sessionPartition/
+    /this\.hostSessionConfiguration = createWorkbenchHostSessionConfiguration\(\{[\s\S]*?new WorkbenchHostSession<[\s\S]*?>\(\{[\s\S]*?partition,/
   );
   assert.match(
     workspaceWorkbenchHostServiceSource,
-    /owner: this\.hostSessionOwner,[\s\S]*?return createWorkspaceWorkbenchHostSessionBinding\(\{[\s\S]*?bindingId: this\.hostSessionBindingSequence,[\s\S]*?lease,[\s\S]*?workspaceId/
+    /openHostSession\([\s\S]*?configuration: this\.hostSessionConfiguration,[\s\S]*?return createWorkspaceWorkbenchHostSessionBinding\(\{[\s\S]*?bindingId: this\.hostSessionBindingSequence,[\s\S]*?lease,[\s\S]*?workspaceId/
+  );
+  assert.match(
+    workspaceWorkbenchHostServiceSource,
+    /\.logRendererDiagnostic\([\s\S]*?\)\s+\.catch\(\(\) => undefined\)/
   );
   assert.doesNotMatch(workspaceWorkbenchHostServiceSource, /cachedHostInputs/);
   assert.doesNotMatch(workspaceWorkbenchHostServiceSource, /hostSessionLeases/);

--- a/apps/desktop/src/renderer/src/features/workspace-workbench/services/internal/workspaceWorkbenchHostService.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/services/internal/workspaceWorkbenchHostService.ts
@@ -124,7 +124,11 @@ import {
   type IAgentsService as AgentsService
 } from "../../../workspace-agent/services/agentsService.interface.ts";
 import { AgentGuiAgentsLoader } from "./agentGuiAgentsLoader.ts";
-import { WorkbenchHostCoordinator } from "./workbenchHostCoordinator.ts";
+import {
+  createWorkbenchHostSessionConfiguration,
+  WorkbenchHostCoordinator,
+  type WorkbenchHostSessionConfiguration
+} from "./workbenchHostCoordinator.ts";
 import {
   WorkbenchHostSession,
   type WorkbenchHostSessionResolution,
@@ -198,7 +202,11 @@ export class WorkspaceWorkbenchHostService implements IWorkspaceWorkbenchHostSer
   readonly _serviceBrand = undefined;
   private readonly dependencies: WorkspaceWorkbenchHostServiceDependencies;
   private hostSessionBindingSequence = 0;
-  private readonly hostSessionOwner = {};
+  private readonly hostSessionConfiguration: WorkbenchHostSessionConfiguration<
+    WorkspaceWorkbenchHostSessionUpdate,
+    WorkspaceWorkbenchHostInput,
+    CachedWorkspaceWorkbenchHostInput
+  >;
   private readonly pendingWallpaperDisplayModes = new Map<
     string,
     WorkspaceWallpaperDisplayMode
@@ -268,6 +276,27 @@ export class WorkspaceWorkbenchHostService implements IWorkspaceWorkbenchHostSer
       runtimeApi: externalDependencies.runtimeApi,
       wallpaperApi: externalDependencies.wallpaperApi
     };
+    this.hostSessionConfiguration = createWorkbenchHostSessionConfiguration({
+      createSession: (partition) =>
+        new WorkbenchHostSession<
+          WorkspaceWorkbenchHostSessionUpdate,
+          WorkspaceWorkbenchHostInput,
+          CachedWorkspaceWorkbenchHostInput
+        >({
+          onDisposalError: (error) =>
+            this.dependencies.runtimeApi
+              .logRendererDiagnostic({
+                details: { error: formatDiagnosticError(error) },
+                event: "workbench.host.session.dispose_failed",
+                level: "warn",
+                source: "workbench-host-session",
+                workspaceId: partition.scope.id
+              })
+              .catch(() => undefined),
+          partition,
+          resolve: (update, current) => this.resolveHostInput(update, current)
+        })
+    });
     this.agentGuiAgentsLoader = new AgentGuiAgentsLoader(() =>
       this.dependencies.agentsService.load().then((snapshot) => snapshot.agents)
     );
@@ -752,30 +781,8 @@ export class WorkspaceWorkbenchHostService implements IWorkspaceWorkbenchHostSer
   }
 
   openHostSession(workspaceId: string): WorkspaceWorkbenchHostSessionBinding {
-    const lease = this.workbenchHostCoordinator.open<
-      WorkspaceWorkbenchHostSessionUpdate,
-      WorkspaceWorkbenchHostInput,
-      CachedWorkspaceWorkbenchHostInput
-    >({
-      createSession: (sessionPartition) =>
-        new WorkbenchHostSession<
-          WorkspaceWorkbenchHostSessionUpdate,
-          WorkspaceWorkbenchHostInput,
-          CachedWorkspaceWorkbenchHostInput
-        >({
-          onDisposalError: (error) => {
-            void this.dependencies.runtimeApi.logRendererDiagnostic({
-              details: { error: formatDiagnosticError(error) },
-              event: "workbench.host.session.dispose_failed",
-              level: "warn",
-              source: "workbench-host-session",
-              workspaceId
-            });
-          },
-          partition: sessionPartition,
-          resolve: (update, current) => this.resolveHostInput(update, current)
-        }),
-      owner: this.hostSessionOwner,
+    const lease = this.workbenchHostCoordinator.open({
+      configuration: this.hostSessionConfiguration,
       partition: createWorkspaceWorkbenchPartition(workspaceId)
     });
     this.hostSessionBindingSequence += 1;

--- a/apps/desktop/src/renderer/src/features/workspace-workbench/services/internal/workspaceWorkbenchHostService.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/services/internal/workspaceWorkbenchHostService.ts
@@ -22,6 +22,7 @@ import type {
   WorkspaceWorkbenchBodyRendererContext,
   WorkspaceWorkbenchCapabilitySettingsTarget,
   WorkspaceWorkbenchHostInput,
+  WorkspaceWorkbenchHostSessionBinding,
   WorkspaceWorkbenchHostSessionUpdate
 } from "../workspaceWorkbenchHostService.interface";
 import type {
@@ -123,16 +124,14 @@ import {
   type IAgentsService as AgentsService
 } from "../../../workspace-agent/services/agentsService.interface.ts";
 import { AgentGuiAgentsLoader } from "./agentGuiAgentsLoader.ts";
-import {
-  WorkbenchHostCoordinator,
-  type WorkbenchHostSessionLease
-} from "./workbenchHostCoordinator.ts";
+import { WorkbenchHostCoordinator } from "./workbenchHostCoordinator.ts";
 import {
   WorkbenchHostSession,
   type WorkbenchHostSessionResolution,
   type WorkbenchSnapshotPartition
 } from "./workbenchHostSession.ts";
 import { IWorkbenchHostCoordinator } from "../workbenchHostCoordinator.interface.ts";
+import { createWorkspaceWorkbenchHostSessionBinding } from "./workspaceWorkbenchHostSessionBinding.ts";
 const workspaceDockNativePreviewMaxWidthPx = 260;
 const workspaceDockNativePreviewMaxHeightPx = 170;
 const workspaceDockNativePreviewTimeoutMs = 2_500;
@@ -198,8 +197,8 @@ export interface WorkspaceWorkbenchHostExternalDependencies {
 export class WorkspaceWorkbenchHostService implements IWorkspaceWorkbenchHostService {
   readonly _serviceBrand = undefined;
   private readonly dependencies: WorkspaceWorkbenchHostServiceDependencies;
-  private readonly hostSessionLeases =
-    new Set<WorkspaceWorkbenchHostSessionLease>();
+  private hostSessionBindingSequence = 0;
+  private readonly hostSessionOwner = {};
   private readonly pendingWallpaperDisplayModes = new Map<
     string,
     WorkspaceWallpaperDisplayMode
@@ -286,13 +285,6 @@ export class WorkspaceWorkbenchHostService implements IWorkspaceWorkbenchHostSer
 
   approveWindowClose(): Promise<void> {
     return this.dependencies.hostWindowApi.approveClose();
-  }
-
-  attachHostSurface(
-    workspaceId: string,
-    handle: WorkbenchHostHandle | null
-  ): void {
-    this.getHostSession(workspaceId)?.attachSurface(handle);
   }
 
   loadAgentGuiAgents(): Promise<readonly AgentGUIAgent[]> {
@@ -658,21 +650,7 @@ export class WorkspaceWorkbenchHostService implements IWorkspaceWorkbenchHostSer
     this.dependencies.hostWorkspaceApi.broadcastAgentStatus(payload);
   }
 
-  releaseHostSession(workspaceId: string): void {
-    for (const lease of this.hostSessionLeases) {
-      if (lease.session.partition.scope.id !== workspaceId) {
-        continue;
-      }
-      this.hostSessionLeases.delete(lease);
-      lease.release();
-    }
-  }
-
   dispose(): void {
-    for (const lease of this.hostSessionLeases) {
-      lease.release();
-    }
-    this.hostSessionLeases.clear();
     this.wallpaperListeners.clear();
   }
 
@@ -773,42 +751,39 @@ export class WorkspaceWorkbenchHostService implements IWorkspaceWorkbenchHostSer
     }
   }
 
-  createHostInput(
-    input: WorkspaceWorkbenchHostSessionUpdate
-  ): WorkspaceWorkbenchHostInput {
-    const partition = createWorkspaceWorkbenchPartition(input.workspaceId);
-    let session = this.getHostSession(input.workspaceId);
-    if (!session) {
-      const lease = this.workbenchHostCoordinator.open<
-        WorkspaceWorkbenchHostSessionUpdate,
-        WorkspaceWorkbenchHostInput,
-        CachedWorkspaceWorkbenchHostInput
-      >({
-        createSession: (sessionPartition) =>
-          new WorkbenchHostSession<
-            WorkspaceWorkbenchHostSessionUpdate,
-            WorkspaceWorkbenchHostInput,
-            CachedWorkspaceWorkbenchHostInput
-          >({
-            partition: sessionPartition,
-            resolve: (update, current) => this.resolveHostInput(update, current)
-          }),
-        partition
-      });
-      this.hostSessionLeases.add(lease);
-      session = lease.session;
-    }
-    return session.update(input);
-  }
-
-  private getHostSession(
-    workspaceId: string
-  ): WorkspaceWorkbenchHostSession | null {
-    return this.workbenchHostCoordinator.get<
+  openHostSession(workspaceId: string): WorkspaceWorkbenchHostSessionBinding {
+    const lease = this.workbenchHostCoordinator.open<
       WorkspaceWorkbenchHostSessionUpdate,
       WorkspaceWorkbenchHostInput,
       CachedWorkspaceWorkbenchHostInput
-    >(createWorkspaceWorkbenchPartition(workspaceId));
+    >({
+      createSession: (sessionPartition) =>
+        new WorkbenchHostSession<
+          WorkspaceWorkbenchHostSessionUpdate,
+          WorkspaceWorkbenchHostInput,
+          CachedWorkspaceWorkbenchHostInput
+        >({
+          onDisposalError: (error) => {
+            void this.dependencies.runtimeApi.logRendererDiagnostic({
+              details: { error: formatDiagnosticError(error) },
+              event: "workbench.host.session.dispose_failed",
+              level: "warn",
+              source: "workbench-host-session",
+              workspaceId
+            });
+          },
+          partition: sessionPartition,
+          resolve: (update, current) => this.resolveHostInput(update, current)
+        }),
+      owner: this.hostSessionOwner,
+      partition: createWorkspaceWorkbenchPartition(workspaceId)
+    });
+    this.hostSessionBindingSequence += 1;
+    return createWorkspaceWorkbenchHostSessionBinding({
+      bindingId: this.hostSessionBindingSequence,
+      lease,
+      workspaceId
+    });
   }
 
   private resolveHostInput(
@@ -1403,18 +1378,6 @@ interface CachedWorkspaceWorkbenchHostInput {
   };
   themeAppearance: DesktopThemeAppearance;
 }
-
-type WorkspaceWorkbenchHostSession = WorkbenchHostSession<
-  WorkspaceWorkbenchHostSessionUpdate,
-  WorkspaceWorkbenchHostInput,
-  CachedWorkspaceWorkbenchHostInput
->;
-
-type WorkspaceWorkbenchHostSessionLease = WorkbenchHostSessionLease<
-  WorkspaceWorkbenchHostSessionUpdate,
-  WorkspaceWorkbenchHostInput,
-  CachedWorkspaceWorkbenchHostInput
->;
 
 function createWorkspaceWorkbenchPartition(
   workspaceId: string

--- a/apps/desktop/src/renderer/src/features/workspace-workbench/services/internal/workspaceWorkbenchHostService.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/services/internal/workspaceWorkbenchHostService.ts
@@ -21,7 +21,8 @@ import type {
   WorkspaceCustomWallpaperStatus,
   WorkspaceWorkbenchBodyRendererContext,
   WorkspaceWorkbenchCapabilitySettingsTarget,
-  WorkspaceWorkbenchHostInput
+  WorkspaceWorkbenchHostInput,
+  WorkspaceWorkbenchHostSessionUpdate
 } from "../workspaceWorkbenchHostService.interface";
 import type {
   DesktopBrowserApi,
@@ -122,6 +123,16 @@ import {
   type IAgentsService as AgentsService
 } from "../../../workspace-agent/services/agentsService.interface.ts";
 import { AgentGuiAgentsLoader } from "./agentGuiAgentsLoader.ts";
+import {
+  WorkbenchHostCoordinator,
+  type WorkbenchHostSessionLease
+} from "./workbenchHostCoordinator.ts";
+import {
+  WorkbenchHostSession,
+  type WorkbenchHostSessionResolution,
+  type WorkbenchSnapshotPartition
+} from "./workbenchHostSession.ts";
+import { IWorkbenchHostCoordinator } from "../workbenchHostCoordinator.interface.ts";
 const workspaceDockNativePreviewMaxWidthPx = 260;
 const workspaceDockNativePreviewMaxHeightPx = 170;
 const workspaceDockNativePreviewTimeoutMs = 2_500;
@@ -186,11 +197,9 @@ export interface WorkspaceWorkbenchHostExternalDependencies {
 
 export class WorkspaceWorkbenchHostService implements IWorkspaceWorkbenchHostService {
   readonly _serviceBrand = undefined;
-  private readonly cachedHostInputs = new Map<
-    string,
-    CachedWorkspaceWorkbenchHostInput
-  >();
   private readonly dependencies: WorkspaceWorkbenchHostServiceDependencies;
+  private readonly hostSessionLeases =
+    new Set<WorkspaceWorkbenchHostSessionLease>();
   private readonly pendingWallpaperDisplayModes = new Map<
     string,
     WorkspaceWallpaperDisplayMode
@@ -217,6 +226,7 @@ export class WorkspaceWorkbenchHostService implements IWorkspaceWorkbenchHostSer
 
   constructor(
     externalDependencies: WorkspaceWorkbenchHostExternalDependencies,
+    private readonly workbenchHostCoordinator: WorkbenchHostCoordinator,
     richTextAtService: IDesktopRichTextAtService,
     agentsService: AgentsService,
     agentProviderStatusService: AgentProviderStatusService,
@@ -276,6 +286,13 @@ export class WorkspaceWorkbenchHostService implements IWorkspaceWorkbenchHostSer
 
   approveWindowClose(): Promise<void> {
     return this.dependencies.hostWindowApi.approveClose();
+  }
+
+  attachHostSurface(
+    workspaceId: string,
+    handle: WorkbenchHostHandle | null
+  ): void {
+    this.getHostSession(workspaceId)?.attachSurface(handle);
   }
 
   loadAgentGuiAgents(): Promise<readonly AgentGUIAgent[]> {
@@ -641,6 +658,24 @@ export class WorkspaceWorkbenchHostService implements IWorkspaceWorkbenchHostSer
     this.dependencies.hostWorkspaceApi.broadcastAgentStatus(payload);
   }
 
+  releaseHostSession(workspaceId: string): void {
+    for (const lease of this.hostSessionLeases) {
+      if (lease.session.partition.scope.id !== workspaceId) {
+        continue;
+      }
+      this.hostSessionLeases.delete(lease);
+      lease.release();
+    }
+  }
+
+  dispose(): void {
+    for (const lease of this.hostSessionLeases) {
+      lease.release();
+    }
+    this.hostSessionLeases.clear();
+    this.wallpaperListeners.clear();
+  }
+
   private subscribeWorkbenchNodeLaunchRequests(): void {
     const eventStreamClient = this.dependencies.eventStreamClient;
     if (!eventStreamClient) {
@@ -738,30 +773,55 @@ export class WorkspaceWorkbenchHostService implements IWorkspaceWorkbenchHostSer
     }
   }
 
-  createHostInput(input: {
-    appI18n: I18nRuntime<string>;
-    appLocale: DesktopLocale;
-    confirmCloseGuard: (
-      request: WorkbenchHostCloseDialogRequest
-    ) => Promise<boolean> | boolean;
-    i18n: WorkspaceWorkbenchDesktopI18nRuntime;
-    appCenterRevision?: number;
-    dockIconStyle: DesktopDockIconStyle;
-    themeAppearance: DesktopThemeAppearance;
-    defaultAgentProvider?: string | null;
-    defaultAgentTargetId?: string | null;
-    onCapabilitySettingsRequest?: (
-      target: WorkspaceWorkbenchCapabilitySettingsTarget
-    ) => void;
-    agents?: readonly AgentGUIAgent[];
-    agentsLoading?: boolean;
-    comingSoonAgentProviders?: readonly AgentGUIProvider[];
-    renderFilesNodeBody: (
-      context: WorkspaceWorkbenchBodyRendererContext
-    ) => ReactNode;
-    workspaceId: string;
-  }): WorkspaceWorkbenchHostInput {
-    const cached = this.cachedHostInputs.get(input.workspaceId);
+  createHostInput(
+    input: WorkspaceWorkbenchHostSessionUpdate
+  ): WorkspaceWorkbenchHostInput {
+    const partition = createWorkspaceWorkbenchPartition(input.workspaceId);
+    let session = this.getHostSession(input.workspaceId);
+    if (!session) {
+      const lease = this.workbenchHostCoordinator.open<
+        WorkspaceWorkbenchHostSessionUpdate,
+        WorkspaceWorkbenchHostInput,
+        CachedWorkspaceWorkbenchHostInput
+      >({
+        createSession: (sessionPartition) =>
+          new WorkbenchHostSession<
+            WorkspaceWorkbenchHostSessionUpdate,
+            WorkspaceWorkbenchHostInput,
+            CachedWorkspaceWorkbenchHostInput
+          >({
+            partition: sessionPartition,
+            resolve: (update, current) => this.resolveHostInput(update, current)
+          }),
+        partition
+      });
+      this.hostSessionLeases.add(lease);
+      session = lease.session;
+    }
+    return session.update(input);
+  }
+
+  private getHostSession(
+    workspaceId: string
+  ): WorkspaceWorkbenchHostSession | null {
+    return this.workbenchHostCoordinator.get<
+      WorkspaceWorkbenchHostSessionUpdate,
+      WorkspaceWorkbenchHostInput,
+      CachedWorkspaceWorkbenchHostInput
+    >(createWorkspaceWorkbenchPartition(workspaceId));
+  }
+
+  private resolveHostInput(
+    input: WorkspaceWorkbenchHostSessionUpdate,
+    current: WorkbenchHostSessionResolution<
+      WorkspaceWorkbenchHostInput,
+      CachedWorkspaceWorkbenchHostInput
+    > | null
+  ): WorkbenchHostSessionResolution<
+    WorkspaceWorkbenchHostInput,
+    CachedWorkspaceWorkbenchHostInput
+  > {
+    const cached = current?.state;
     if (
       cached &&
       cached.appI18n === input.appI18n &&
@@ -779,14 +839,17 @@ export class WorkspaceWorkbenchHostService implements IWorkspaceWorkbenchHostSer
         input.onCapabilitySettingsRequest;
       cached.confirmCloseGuardRef.current = input.confirmCloseGuard;
       cached.renderFilesNodeBodyRef.current = input.renderFilesNodeBody;
-      return this.createHostInputWithDynamicDockEntries(
-        cached,
-        cached.baseHostInput,
-        {
-          appI18n: input.appI18n,
-          desktopI18n: cached.i18n
-        }
-      );
+      return {
+        hostInput: this.createHostInputWithDynamicDockEntries(
+          cached,
+          cached.baseHostInput,
+          {
+            appI18n: input.appI18n,
+            desktopI18n: cached.i18n
+          }
+        ),
+        state: cached
+      };
     }
 
     const renderFilesNodeBodyRef = {
@@ -926,15 +989,17 @@ export class WorkspaceWorkbenchHostService implements IWorkspaceWorkbenchHostSer
       renderFilesNodeBodyRef,
       themeAppearance: input.themeAppearance
     };
-    this.cachedHostInputs.set(input.workspaceId, cachedHostInput);
-    return this.createHostInputWithDynamicDockEntries(
-      cachedHostInput,
-      baseHostInput,
-      {
-        appI18n: input.appI18n,
-        desktopI18n: input.i18n
-      }
-    );
+    return {
+      hostInput: this.createHostInputWithDynamicDockEntries(
+        cachedHostInput,
+        baseHostInput,
+        {
+          appI18n: input.appI18n,
+          desktopI18n: input.i18n
+        }
+      ),
+      state: cachedHostInput
+    };
   }
 
   private createHostInputWithDynamicDockEntries(
@@ -1253,18 +1318,19 @@ function resolveWorkspaceNodeCaptureTarget(nodeId: string): {
 }
 
 // Avoid decorator syntax so the renderer Babel pass can parse this file.
-IDesktopRichTextAtService(WorkspaceWorkbenchHostService, undefined, 1);
-IAgentsService(WorkspaceWorkbenchHostService, undefined, 2);
-IAgentProviderStatusService(WorkspaceWorkbenchHostService, undefined, 3);
-IWorkspaceAgentActivityService(WorkspaceWorkbenchHostService, undefined, 4);
+IWorkbenchHostCoordinator(WorkspaceWorkbenchHostService, undefined, 1);
+IDesktopRichTextAtService(WorkspaceWorkbenchHostService, undefined, 2);
+IAgentsService(WorkspaceWorkbenchHostService, undefined, 3);
+IAgentProviderStatusService(WorkspaceWorkbenchHostService, undefined, 4);
+IWorkspaceAgentActivityService(WorkspaceWorkbenchHostService, undefined, 5);
 IWorkspaceAgentPromptSessionService(
   WorkspaceWorkbenchHostService,
   undefined,
-  5
+  6
 );
-IWorkspaceAppCenterService(WorkspaceWorkbenchHostService, undefined, 6);
-IWorkspaceFileManagerService(WorkspaceWorkbenchHostService, undefined, 7);
-IWorkspaceUserProjectService(WorkspaceWorkbenchHostService, undefined, 8);
+IWorkspaceAppCenterService(WorkspaceWorkbenchHostService, undefined, 7);
+IWorkspaceFileManagerService(WorkspaceWorkbenchHostService, undefined, 8);
+IWorkspaceUserProjectService(WorkspaceWorkbenchHostService, undefined, 9);
 
 export function createWorkspaceAppExternalUserProjectApi(
   service: IWorkspaceUserProjectService
@@ -1336,6 +1402,29 @@ interface CachedWorkspaceWorkbenchHostInput {
     current: (context: WorkspaceWorkbenchBodyRendererContext) => ReactNode;
   };
   themeAppearance: DesktopThemeAppearance;
+}
+
+type WorkspaceWorkbenchHostSession = WorkbenchHostSession<
+  WorkspaceWorkbenchHostSessionUpdate,
+  WorkspaceWorkbenchHostInput,
+  CachedWorkspaceWorkbenchHostInput
+>;
+
+type WorkspaceWorkbenchHostSessionLease = WorkbenchHostSessionLease<
+  WorkspaceWorkbenchHostSessionUpdate,
+  WorkspaceWorkbenchHostInput,
+  CachedWorkspaceWorkbenchHostInput
+>;
+
+function createWorkspaceWorkbenchPartition(
+  workspaceId: string
+): WorkbenchSnapshotPartition {
+  return {
+    scope: {
+      id: workspaceId,
+      kind: "workspace"
+    }
+  };
 }
 
 function noop(): void {}

--- a/apps/desktop/src/renderer/src/features/workspace-workbench/services/internal/workspaceWorkbenchHostService.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/services/internal/workspaceWorkbenchHostService.ts
@@ -681,6 +681,7 @@ export class WorkspaceWorkbenchHostService implements IWorkspaceWorkbenchHostSer
 
   dispose(): void {
     this.wallpaperListeners.clear();
+    this.clearCustomWallpaperUrls();
   }
 
   private subscribeWorkbenchNodeLaunchRequests(): void {

--- a/apps/desktop/src/renderer/src/features/workspace-workbench/services/internal/workspaceWorkbenchHostSessionBinding.test.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/services/internal/workspaceWorkbenchHostSessionBinding.test.ts
@@ -5,42 +5,49 @@ import type {
   WorkspaceWorkbenchHostInput,
   WorkspaceWorkbenchHostSessionUpdate
 } from "../workspaceWorkbenchHostService.interface.ts";
-import { WorkbenchHostCoordinator } from "./workbenchHostCoordinator.ts";
+import {
+  createWorkbenchHostSessionConfiguration,
+  WorkbenchHostCoordinator,
+  type WorkbenchHostSessionConfiguration
+} from "./workbenchHostCoordinator.ts";
 import { WorkbenchHostSession } from "./workbenchHostSession.ts";
 import { createWorkspaceWorkbenchHostSessionBinding } from "./workspaceWorkbenchHostSessionBinding.ts";
 
 test("workspace session bindings release only their own lease", () => {
   const coordinator = new WorkbenchHostCoordinator();
-  const owner = {};
-  const first = createBinding(coordinator, owner);
-  const second = createBinding(coordinator, owner);
+  const configuration = createConfiguration();
+  const first = createBinding(coordinator, configuration);
+  const second = createBinding(coordinator, configuration);
   const firstHandle = {} as WorkbenchHostHandle;
   const secondHandle = {} as WorkbenchHostHandle;
+  let staleNotificationCount = 0;
 
   first.attachSurface(firstHandle);
+  first.subscribe(() => {
+    staleNotificationCount += 1;
+  });
   second.attachSurface(secondHandle);
+  first.attachSurface(null);
   first.release();
   first.release();
   first.attachSurface(firstHandle);
+  second.createHostInput(createUpdate("workspace-1"));
 
   assert.equal(first.isActive, false);
   assert.equal(second.isActive, true);
-  const session = coordinator.get<
-    WorkspaceWorkbenchHostSessionUpdate,
-    WorkspaceWorkbenchHostInput,
-    undefined
-  >(workspacePartition());
+  const session = coordinator.get(configuration, workspacePartition());
   assert.ok(session);
   assert.equal(session.getAttachedSurface(), secondHandle);
+  assert.equal(staleNotificationCount, 0);
 
   second.release();
   assert.equal(session.isDisposed, true);
-  assert.equal(coordinator.get(workspacePartition()), null);
+  assert.equal(coordinator.get(configuration, workspacePartition()), null);
 });
 
 test("workspace session bindings reject cross-workspace and released updates", () => {
   const coordinator = new WorkbenchHostCoordinator();
-  const binding = createBinding(coordinator, {});
+  const binding = createBinding(coordinator, createConfiguration());
 
   assert.throws(
     () => binding.createHostInput(createUpdate("workspace-2")),
@@ -55,8 +62,7 @@ test("workspace session bindings reject cross-workspace and released updates", (
 
 test("a failed initial update remains owned by its exact binding", () => {
   const coordinator = new WorkbenchHostCoordinator();
-  const owner = {};
-  const lease = coordinator.open<
+  const configuration = createWorkbenchHostSessionConfiguration<
     WorkspaceWorkbenchHostSessionUpdate,
     WorkspaceWorkbenchHostInput,
     undefined
@@ -67,8 +73,10 @@ test("a failed initial update remains owned by its exact binding", () => {
         resolve() {
           throw new Error("resolution failed");
         }
-      }),
-    owner,
+      })
+  });
+  const lease = coordinator.open({
+    configuration,
     partition: workspacePartition()
   });
   const binding = createWorkspaceWorkbenchHostSessionBinding({
@@ -81,14 +89,47 @@ test("a failed initial update remains owned by its exact binding", () => {
     () => binding.createHostInput(createUpdate("workspace-1")),
     /resolution failed/
   );
-  assert.equal(coordinator.get(workspacePartition()), lease.session);
+  assert.equal(
+    coordinator.get(configuration, workspacePartition()),
+    lease.session
+  );
   binding.release();
   assert.equal(lease.session.isDisposed, true);
-  assert.equal(coordinator.get(workspacePartition()), null);
+  assert.equal(coordinator.get(configuration, workspacePartition()), null);
 });
 
-function createBinding(coordinator: WorkbenchHostCoordinator, owner: object) {
-  const lease = coordinator.open<
+test("a binding releases safely after coordinator-first disposal", () => {
+  const coordinator = new WorkbenchHostCoordinator();
+  const binding = createBinding(coordinator, createConfiguration());
+
+  coordinator.dispose();
+  binding.attachSurface(null);
+  binding.release();
+
+  assert.equal(binding.isActive, false);
+});
+
+function createBinding(
+  coordinator: WorkbenchHostCoordinator,
+  configuration: WorkbenchHostSessionConfiguration<
+    WorkspaceWorkbenchHostSessionUpdate,
+    WorkspaceWorkbenchHostInput,
+    undefined
+  >
+) {
+  const lease = coordinator.open({
+    configuration,
+    partition: workspacePartition()
+  });
+  return createWorkspaceWorkbenchHostSessionBinding({
+    bindingId: 1,
+    lease,
+    workspaceId: "workspace-1"
+  });
+}
+
+function createConfiguration() {
+  return createWorkbenchHostSessionConfiguration<
     WorkspaceWorkbenchHostSessionUpdate,
     WorkspaceWorkbenchHostInput,
     undefined
@@ -106,14 +147,7 @@ function createBinding(coordinator: WorkbenchHostCoordinator, owner: object) {
             state: undefined
           };
         }
-      }),
-    owner,
-    partition: workspacePartition()
-  });
-  return createWorkspaceWorkbenchHostSessionBinding({
-    bindingId: 1,
-    lease,
-    workspaceId: "workspace-1"
+      })
   });
 }
 

--- a/apps/desktop/src/renderer/src/features/workspace-workbench/services/internal/workspaceWorkbenchHostSessionBinding.test.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/services/internal/workspaceWorkbenchHostSessionBinding.test.ts
@@ -1,0 +1,133 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import type { WorkbenchHostHandle } from "@tutti-os/workbench-surface";
+import type {
+  WorkspaceWorkbenchHostInput,
+  WorkspaceWorkbenchHostSessionUpdate
+} from "../workspaceWorkbenchHostService.interface.ts";
+import { WorkbenchHostCoordinator } from "./workbenchHostCoordinator.ts";
+import { WorkbenchHostSession } from "./workbenchHostSession.ts";
+import { createWorkspaceWorkbenchHostSessionBinding } from "./workspaceWorkbenchHostSessionBinding.ts";
+
+test("workspace session bindings release only their own lease", () => {
+  const coordinator = new WorkbenchHostCoordinator();
+  const owner = {};
+  const first = createBinding(coordinator, owner);
+  const second = createBinding(coordinator, owner);
+  const firstHandle = {} as WorkbenchHostHandle;
+  const secondHandle = {} as WorkbenchHostHandle;
+
+  first.attachSurface(firstHandle);
+  second.attachSurface(secondHandle);
+  first.release();
+  first.release();
+  first.attachSurface(firstHandle);
+
+  assert.equal(first.isActive, false);
+  assert.equal(second.isActive, true);
+  const session = coordinator.get<
+    WorkspaceWorkbenchHostSessionUpdate,
+    WorkspaceWorkbenchHostInput,
+    undefined
+  >(workspacePartition());
+  assert.ok(session);
+  assert.equal(session.getAttachedSurface(), secondHandle);
+
+  second.release();
+  assert.equal(session.isDisposed, true);
+  assert.equal(coordinator.get(workspacePartition()), null);
+});
+
+test("workspace session bindings reject cross-workspace and released updates", () => {
+  const coordinator = new WorkbenchHostCoordinator();
+  const binding = createBinding(coordinator, {});
+
+  assert.throws(
+    () => binding.createHostInput(createUpdate("workspace-2")),
+    /does not match its binding/
+  );
+  binding.release();
+  assert.throws(
+    () => binding.createHostInput(createUpdate("workspace-1")),
+    /binding is released/
+  );
+});
+
+test("a failed initial update remains owned by its exact binding", () => {
+  const coordinator = new WorkbenchHostCoordinator();
+  const owner = {};
+  const lease = coordinator.open<
+    WorkspaceWorkbenchHostSessionUpdate,
+    WorkspaceWorkbenchHostInput,
+    undefined
+  >({
+    createSession: (partition) =>
+      new WorkbenchHostSession({
+        partition,
+        resolve() {
+          throw new Error("resolution failed");
+        }
+      }),
+    owner,
+    partition: workspacePartition()
+  });
+  const binding = createWorkspaceWorkbenchHostSessionBinding({
+    bindingId: 1,
+    lease,
+    workspaceId: "workspace-1"
+  });
+
+  assert.throws(
+    () => binding.createHostInput(createUpdate("workspace-1")),
+    /resolution failed/
+  );
+  assert.equal(coordinator.get(workspacePartition()), lease.session);
+  binding.release();
+  assert.equal(lease.session.isDisposed, true);
+  assert.equal(coordinator.get(workspacePartition()), null);
+});
+
+function createBinding(coordinator: WorkbenchHostCoordinator, owner: object) {
+  const lease = coordinator.open<
+    WorkspaceWorkbenchHostSessionUpdate,
+    WorkspaceWorkbenchHostInput,
+    undefined
+  >({
+    createSession: (partition) =>
+      new WorkbenchHostSession({
+        partition,
+        resolve(update) {
+          return {
+            hostInput: {
+              snapshotRepository:
+                {} as WorkspaceWorkbenchHostInput["snapshotRepository"],
+              workspaceId: update.workspaceId
+            },
+            state: undefined
+          };
+        }
+      }),
+    owner,
+    partition: workspacePartition()
+  });
+  return createWorkspaceWorkbenchHostSessionBinding({
+    bindingId: 1,
+    lease,
+    workspaceId: "workspace-1"
+  });
+}
+
+function createUpdate(
+  workspaceId: string
+): WorkspaceWorkbenchHostSessionUpdate {
+  return { workspaceId } as WorkspaceWorkbenchHostSessionUpdate;
+}
+
+function workspacePartition() {
+  return {
+    scope: {
+      id: "workspace-1",
+      kind: "workspace" as const
+    }
+  };
+}

--- a/apps/desktop/src/renderer/src/features/workspace-workbench/services/internal/workspaceWorkbenchHostSessionBinding.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/services/internal/workspaceWorkbenchHostSessionBinding.ts
@@ -15,17 +15,19 @@ export function createWorkspaceWorkbenchHostSessionBinding<TState>(input: {
   workspaceId: string;
 }): WorkspaceWorkbenchHostSessionBinding {
   let active = true;
+  const subscriptions = new Set<() => void>();
+  const surfaceOwner = {};
   return {
     bindingId: input.bindingId,
     get isActive() {
-      return active;
+      return active && !input.lease.session.isDisposed;
     },
     workspaceId: input.workspaceId,
     attachSurface(handle) {
-      if (!active) {
+      if (!active || input.lease.session.isDisposed) {
         return;
       }
-      input.lease.session.attachSurface(handle);
+      input.lease.session.attachSurface(handle, surfaceOwner);
     },
     createHostInput(update) {
       if (!active) {
@@ -45,13 +47,40 @@ export function createWorkspaceWorkbenchHostSessionBinding<TState>(input: {
         return;
       }
       active = false;
-      input.lease.release();
+      const disposeSubscriptions = Array.from(subscriptions);
+      subscriptions.clear();
+      for (const dispose of disposeSubscriptions) {
+        try {
+          dispose();
+        } catch {
+          // Releasing the lease must continue after subscription cleanup fails.
+        }
+      }
+      try {
+        if (!input.lease.session.isDisposed) {
+          input.lease.session.attachSurface(null, surfaceOwner);
+        }
+      } finally {
+        input.lease.release();
+      }
     },
     subscribe(listener) {
-      if (!active) {
+      if (!active || input.lease.session.isDisposed) {
         return noop;
       }
-      return input.lease.session.subscribe(listener);
+      const disposeSessionSubscription =
+        input.lease.session.subscribe(listener);
+      let subscribed = true;
+      const dispose = () => {
+        if (!subscribed) {
+          return;
+        }
+        subscribed = false;
+        subscriptions.delete(dispose);
+        disposeSessionSubscription();
+      };
+      subscriptions.add(dispose);
+      return dispose;
     }
   };
 }

--- a/apps/desktop/src/renderer/src/features/workspace-workbench/services/internal/workspaceWorkbenchHostSessionBinding.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/services/internal/workspaceWorkbenchHostSessionBinding.ts
@@ -1,0 +1,59 @@
+import type {
+  WorkspaceWorkbenchHostInput,
+  WorkspaceWorkbenchHostSessionBinding,
+  WorkspaceWorkbenchHostSessionUpdate
+} from "../workspaceWorkbenchHostService.interface.ts";
+import type { WorkbenchHostSessionLease } from "./workbenchHostCoordinator.ts";
+
+export function createWorkspaceWorkbenchHostSessionBinding<TState>(input: {
+  bindingId: number;
+  lease: WorkbenchHostSessionLease<
+    WorkspaceWorkbenchHostSessionUpdate,
+    WorkspaceWorkbenchHostInput,
+    TState
+  >;
+  workspaceId: string;
+}): WorkspaceWorkbenchHostSessionBinding {
+  let active = true;
+  return {
+    bindingId: input.bindingId,
+    get isActive() {
+      return active;
+    },
+    workspaceId: input.workspaceId,
+    attachSurface(handle) {
+      if (!active) {
+        return;
+      }
+      input.lease.session.attachSurface(handle);
+    },
+    createHostInput(update) {
+      if (!active) {
+        throw new Error(
+          "Workspace Workbench host session binding is released."
+        );
+      }
+      if (update.workspaceId !== input.workspaceId) {
+        throw new Error(
+          "Workspace Workbench host session update does not match its binding."
+        );
+      }
+      return input.lease.session.update(update);
+    },
+    release() {
+      if (!active) {
+        return;
+      }
+      active = false;
+      input.lease.release();
+    },
+    subscribe(listener) {
+      if (!active) {
+        return noop;
+      }
+      return input.lease.session.subscribe(listener);
+    }
+  };
+}
+
+function noop(): void {}

--- a/apps/desktop/src/renderer/src/features/workspace-workbench/services/registerWorkspaceWorkbenchServices.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/services/registerWorkspaceWorkbenchServices.ts
@@ -20,8 +20,10 @@ import type { IReporterService } from "../../analytics/services/reporterService.
 import { createDesktopWorkspaceSettingsClient } from "./internal/adapters/desktopWorkspaceSettingsClient";
 import { AccountService } from "./internal/accountService";
 import { WorkspaceWorkbenchHostService } from "./internal/workspaceWorkbenchHostService";
+import { WorkbenchHostCoordinator } from "./internal/workbenchHostCoordinator.ts";
 import { WorkspaceSettingsService } from "./internal/workspaceSettingsService";
 import { IAccountService } from "./accountService.interface";
+import { IWorkbenchHostCoordinator } from "./workbenchHostCoordinator.interface.ts";
 import { IWorkspaceWorkbenchHostService } from "./workspaceWorkbenchHostService.interface";
 import { IWorkspaceSettingsService } from "./workspaceSettingsService.interface";
 
@@ -62,6 +64,10 @@ export function registerWorkspaceWorkbenchServices(
         tuttidClient: input.tuttidClient
       }
     ])
+  );
+  registry.register(
+    IWorkbenchHostCoordinator,
+    new SyncDescriptor(WorkbenchHostCoordinator)
   );
   registry.register(
     IWorkspaceWorkbenchHostService,

--- a/apps/desktop/src/renderer/src/features/workspace-workbench/services/workbenchHostCoordinator.interface.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/services/workbenchHostCoordinator.interface.ts
@@ -1,0 +1,5 @@
+import { createDecorator } from "@tutti-os/infra/di";
+import type { WorkbenchHostCoordinator } from "./internal/workbenchHostCoordinator.ts";
+
+export const IWorkbenchHostCoordinator =
+  createDecorator<WorkbenchHostCoordinator>("workbench-host-coordinator");

--- a/apps/desktop/src/renderer/src/features/workspace-workbench/services/workspaceWorkbenchHostService.interface.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/services/workspaceWorkbenchHostService.interface.ts
@@ -108,33 +108,41 @@ export interface WorkspaceWorkbenchHostInput {
   readonly workspaceId: string;
 }
 
+export interface WorkspaceWorkbenchHostSessionUpdate {
+  appI18n: I18nRuntime<string>;
+  appLocale: DesktopLocale;
+  appCenterRevision?: number;
+  confirmCloseGuard: (
+    request: WorkbenchHostCloseDialogRequest
+  ) => Promise<boolean> | boolean;
+  defaultAgentProvider?: string | null;
+  defaultAgentTargetId?: string | null;
+  dockIconStyle: DesktopDockIconStyle;
+  i18n: WorkspaceWorkbenchDesktopI18nRuntime;
+  onCapabilitySettingsRequest?: (
+    target: WorkspaceWorkbenchCapabilitySettingsTarget
+  ) => void;
+  agents?: readonly AgentGUIAgent[];
+  agentsLoading?: boolean;
+  comingSoonAgentProviders?: readonly AgentGUIProvider[];
+  renderFilesNodeBody: (
+    context: WorkspaceWorkbenchBodyRendererContext
+  ) => ReactNode;
+  themeAppearance: DesktopThemeAppearance;
+  workspaceId: string;
+}
+
 export interface IWorkspaceWorkbenchHostService {
   readonly _serviceBrand: undefined;
 
   approveWindowClose(): Promise<void>;
-  createHostInput(input: {
-    appI18n: I18nRuntime<string>;
-    appLocale: DesktopLocale;
-    appCenterRevision?: number;
-    confirmCloseGuard: (
-      request: WorkbenchHostCloseDialogRequest
-    ) => Promise<boolean> | boolean;
-    defaultAgentProvider?: string | null;
-    defaultAgentTargetId?: string | null;
-    dockIconStyle: DesktopDockIconStyle;
-    i18n: WorkspaceWorkbenchDesktopI18nRuntime;
-    onCapabilitySettingsRequest?: (
-      target: WorkspaceWorkbenchCapabilitySettingsTarget
-    ) => void;
-    agents?: readonly AgentGUIAgent[];
-    agentsLoading?: boolean;
-    comingSoonAgentProviders?: readonly AgentGUIProvider[];
-    renderFilesNodeBody: (
-      context: WorkspaceWorkbenchBodyRendererContext
-    ) => ReactNode;
-    themeAppearance: DesktopThemeAppearance;
-    workspaceId: string;
-  }): WorkspaceWorkbenchHostInput;
+  attachHostSurface(
+    workspaceId: string,
+    handle: WorkbenchHostHandle | null
+  ): void;
+  createHostInput(
+    input: WorkspaceWorkbenchHostSessionUpdate
+  ): WorkspaceWorkbenchHostInput;
   loadAgentGuiAgents(): Promise<readonly AgentGUIAgent[]>;
   createWorkspaceAppExternalFileReferenceAdapter(
     workspaceId: string
@@ -164,6 +172,7 @@ export interface IWorkspaceWorkbenchHostService {
   markWorkspaceOnboardingAutoOpened(workspaceId: string): Promise<void>;
   readWallpaperDisplayMode(workspaceId: string): WorkspaceWallpaperDisplayMode;
   readWallpaperId(workspaceId: string): WorkspaceWallpaperId;
+  releaseHostSession(workspaceId: string): void;
   resolveWindowCloseRequest(input: {
     outcome: "approved" | "blocked";
     requestId: string;

--- a/apps/desktop/src/renderer/src/features/workspace-workbench/services/workspaceWorkbenchHostService.interface.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/services/workspaceWorkbenchHostService.interface.ts
@@ -132,17 +132,23 @@ export interface WorkspaceWorkbenchHostSessionUpdate {
   workspaceId: string;
 }
 
+export interface WorkspaceWorkbenchHostSessionBinding {
+  readonly bindingId: number;
+  readonly isActive: boolean;
+  readonly workspaceId: string;
+  attachSurface(handle: WorkbenchHostHandle | null): void;
+  createHostInput(
+    input: WorkspaceWorkbenchHostSessionUpdate
+  ): WorkspaceWorkbenchHostInput;
+  release(): void;
+  subscribe(listener: () => void): () => void;
+}
+
 export interface IWorkspaceWorkbenchHostService {
   readonly _serviceBrand: undefined;
 
   approveWindowClose(): Promise<void>;
-  attachHostSurface(
-    workspaceId: string,
-    handle: WorkbenchHostHandle | null
-  ): void;
-  createHostInput(
-    input: WorkspaceWorkbenchHostSessionUpdate
-  ): WorkspaceWorkbenchHostInput;
+  openHostSession(workspaceId: string): WorkspaceWorkbenchHostSessionBinding;
   loadAgentGuiAgents(): Promise<readonly AgentGUIAgent[]>;
   createWorkspaceAppExternalFileReferenceAdapter(
     workspaceId: string
@@ -172,7 +178,6 @@ export interface IWorkspaceWorkbenchHostService {
   markWorkspaceOnboardingAutoOpened(workspaceId: string): Promise<void>;
   readWallpaperDisplayMode(workspaceId: string): WorkspaceWallpaperDisplayMode;
   readWallpaperId(workspaceId: string): WorkspaceWallpaperId;
-  releaseHostSession(workspaceId: string): void;
   resolveWindowCloseRequest(input: {
     outcome: "approved" | "blocked";
     requestId: string;

--- a/apps/desktop/src/renderer/src/features/workspace-workbench/services/workspaceWorkbenchShellRuntimeController.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/services/workspaceWorkbenchShellRuntimeController.ts
@@ -27,6 +27,7 @@ import type {
   IWorkspaceWorkbenchHostService,
   WorkspaceWorkbenchBodyRendererContext,
   WorkspaceWorkbenchCapabilitySettingsTarget,
+  WorkspaceWorkbenchHostSessionBinding,
   WorkspaceWorkbenchHostInput
 } from "./workspaceWorkbenchHostService.interface";
 import type { WorkbenchSurfaceWallpaperFit } from "@tutti-os/workbench-surface";
@@ -126,7 +127,7 @@ export interface WorkspaceWorkbenchShellHostInput {
   appI18n: I18nRuntime<string>;
   appLocale: DesktopLocale;
   appCenterRevision?: number;
-  createHostInput: IWorkspaceWorkbenchHostService["createHostInput"];
+  createHostInput: WorkspaceWorkbenchHostSessionBinding["createHostInput"];
   defaultAgentProvider?: string | null;
   defaultAgentTargetId?: string | null;
   dockIconStyle: DesktopDockIconStyle;

--- a/apps/desktop/src/renderer/src/features/workspace-workbench/ui/WorkspaceWorkbench.tsx
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/ui/WorkspaceWorkbench.tsx
@@ -1,5 +1,12 @@
 import type * as React from "react";
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import {
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+  useState
+} from "react";
 import type {
   WorkspaceAgentProvider,
   WorkspaceSummary
@@ -103,6 +110,8 @@ import {
   type StandaloneAgentWindowProps
 } from "./StandaloneAgentWindow.tsx";
 import { useWorkspaceWorkbenchShellRuntime } from "./useWorkspaceWorkbenchShellRuntime";
+import { useWorkspaceWorkbenchHostService } from "./useWorkspaceWorkbenchHostService.ts";
+import type { WorkspaceWorkbenchHostSessionBinding } from "../services/workspaceWorkbenchHostService.interface.ts";
 import { useWorkspaceOnboardingAutoOpen } from "./useWorkspaceOnboardingAutoOpen.ts";
 import { resolveWorkspaceWorkbenchLayoutConstraints } from "./workspaceWorkbenchLayoutConstraints.ts";
 import type { DesktopWorkspaceAppExternalHostApi } from "@preload/types";
@@ -189,12 +198,7 @@ export function WorkspaceWorkbench({
   );
 }
 
-function ReadyWorkspaceWorkbench({
-  enableWindowCloseGuard,
-  headerSlot,
-  state,
-  workspaceAppExternalApi
-}: {
+interface ReadyWorkspaceWorkbenchProps {
   enableWindowCloseGuard: boolean;
   headerSlot?: React.ReactNode;
   state: {
@@ -202,11 +206,54 @@ function ReadyWorkspaceWorkbench({
     workspace: WorkspaceSummary;
   };
   workspaceAppExternalApi?: DesktopWorkspaceAppExternalHostApi;
+}
+
+function ReadyWorkspaceWorkbench(props: ReadyWorkspaceWorkbenchProps) {
+  const workbenchHostService = useWorkspaceWorkbenchHostService();
+  const workspaceId = props.state.workspace.id;
+  const [hostSession, setHostSession] =
+    useState<WorkspaceWorkbenchHostSessionBinding | null>(null);
+
+  useLayoutEffect(() => {
+    const binding = workbenchHostService.openHostSession(workspaceId);
+    setHostSession(binding);
+    return () => {
+      binding.attachSurface(null);
+      binding.release();
+    };
+  }, [workbenchHostService, workspaceId]);
+
+  if (
+    !hostSession ||
+    !hostSession.isActive ||
+    hostSession.workspaceId !== workspaceId
+  ) {
+    return <main className="h-screen min-h-0 bg-background" />;
+  }
+
+  return (
+    <ReadyWorkspaceWorkbenchWithSession
+      {...props}
+      key={hostSession.bindingId}
+      hostSession={hostSession}
+    />
+  );
+}
+
+function ReadyWorkspaceWorkbenchWithSession({
+  enableWindowCloseGuard,
+  headerSlot,
+  hostSession,
+  state,
+  workspaceAppExternalApi
+}: ReadyWorkspaceWorkbenchProps & {
+  hostSession: WorkspaceWorkbenchHostSessionBinding;
 }) {
   const { service: appCenterService } = useWorkspaceAppCenterService();
   const agentProviderStatusService = useService(IAgentProviderStatusService);
   const runtime = useWorkspaceWorkbenchShellRuntime({
     enableWindowCloseGuard,
+    hostSession,
     state
   });
   const hostInput = runtime.hostInput;

--- a/apps/desktop/src/renderer/src/features/workspace-workbench/ui/WorkspaceWorkbench.tsx
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/ui/WorkspaceWorkbench.tsx
@@ -218,7 +218,6 @@ function ReadyWorkspaceWorkbench(props: ReadyWorkspaceWorkbenchProps) {
     const binding = workbenchHostService.openHostSession(workspaceId);
     setHostSession(binding);
     return () => {
-      binding.attachSurface(null);
       binding.release();
     };
   }, [workbenchHostService, workspaceId]);

--- a/apps/desktop/src/renderer/src/features/workspace-workbench/ui/useWorkspaceWorkbenchShellRuntime.tsx
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/ui/useWorkspaceWorkbenchShellRuntime.tsx
@@ -53,7 +53,10 @@ import {
   createWorkspaceWorkbenchShellRuntimeController,
   type WorkspaceWorkbenchShellRuntimeController
 } from "../services/workspaceWorkbenchShellRuntimeController";
-import type { WorkspaceWorkbenchCapabilitySettingsTarget } from "../services/workspaceWorkbenchHostService.interface";
+import type {
+  WorkspaceWorkbenchCapabilitySettingsTarget,
+  WorkspaceWorkbenchHostSessionBinding
+} from "../services/workspaceWorkbenchHostService.interface";
 import type {
   WorkspaceMissionControlOpenRequest,
   WorkspaceMissionControlTrigger
@@ -121,9 +124,11 @@ export interface WorkspaceWorkbenchShellRuntime {
 
 export function useWorkspaceWorkbenchShellRuntime({
   enableWindowCloseGuard,
+  hostSession,
   state
 }: {
   enableWindowCloseGuard: boolean;
+  hostSession: WorkspaceWorkbenchHostSessionBinding;
   state: {
     platform: NodeJS.Platform;
     workspace: WorkspaceSummary;
@@ -203,8 +208,7 @@ export function useWorkspaceWorkbenchShellRuntime({
           appI18n,
           appLocale: locale,
           appCenterRevision: appCenterState.revision,
-          createHostInput: (hostInput) =>
-            workbenchHostService.createHostInput(hostInput),
+          createHostInput: hostSession.createHostInput,
           defaultAgentProvider: desktopPreferencesState.defaultAgentProvider,
           defaultAgentTargetId: defaultAgentTargetId,
           agents: resolvedAgentGuiAgents,
@@ -349,8 +353,7 @@ export function useWorkspaceWorkbenchShellRuntime({
       appI18n,
       appLocale: locale,
       appCenterRevision: appCenterState.revision,
-      createHostInput: (hostInput) =>
-        workbenchHostService.createHostInput(hostInput),
+      createHostInput: hostSession.createHostInput,
       defaultAgentProvider: desktopPreferencesState.defaultAgentProvider,
       defaultAgentTargetId: defaultAgentTargetId,
       agents: resolvedAgentGuiAgents,
@@ -376,6 +379,7 @@ export function useWorkspaceWorkbenchShellRuntime({
     desktopPreferencesState.dockIconStyle,
     desktopPreferencesState.theme.appearance,
     handleCapabilitySettingsRequest,
+    hostSession,
     locale,
     shellRuntimeController,
     state.workspace.id,
@@ -403,13 +407,6 @@ export function useWorkspaceWorkbenchShellRuntime({
   useEffect(() => {
     return shellRuntimeController.dispose;
   }, [shellRuntimeController.dispose]);
-
-  useEffect(() => {
-    return () => {
-      workbenchHostService.attachHostSurface(state.workspace.id, null);
-      workbenchHostService.releaseHostSession(state.workspace.id);
-    };
-  }, [state.workspace.id, workbenchHostService]);
 
   useEffect(() => {
     return () => {
@@ -444,7 +441,7 @@ export function useWorkspaceWorkbenchShellRuntime({
   const handleWorkbenchHostReady = useCallback(
     (host: WorkbenchHostHandle | null) => {
       workbenchHostRef.current = host;
-      workbenchHostService.attachHostSurface(state.workspace.id, host);
+      hostSession.attachSurface(host);
       shellRuntimeController.setWorkbenchHost(host);
       syncWorkspaceAppWebviewNodes({
         apps: appCenterState.apps,
@@ -501,11 +498,11 @@ export function useWorkspaceWorkbenchShellRuntime({
       appCenterState.apps,
       appCenterState.loadStatus,
       appCenterState.workspaceId,
+      hostSession,
       locale,
       shellRuntimeController,
       state.workspace.id,
-      workspaceFileManagerService,
-      workbenchHostService
+      workspaceFileManagerService
     ]
   );
 

--- a/apps/desktop/src/renderer/src/features/workspace-workbench/ui/useWorkspaceWorkbenchShellRuntime.tsx
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/ui/useWorkspaceWorkbenchShellRuntime.tsx
@@ -406,6 +406,13 @@ export function useWorkspaceWorkbenchShellRuntime({
 
   useEffect(() => {
     return () => {
+      workbenchHostService.attachHostSurface(state.workspace.id, null);
+      workbenchHostService.releaseHostSession(state.workspace.id);
+    };
+  }, [state.workspace.id, workbenchHostService]);
+
+  useEffect(() => {
+    return () => {
       workspaceFileManagerService.setCanvasFilePreviewLauncher(
         state.workspace.id,
         null
@@ -437,6 +444,7 @@ export function useWorkspaceWorkbenchShellRuntime({
   const handleWorkbenchHostReady = useCallback(
     (host: WorkbenchHostHandle | null) => {
       workbenchHostRef.current = host;
+      workbenchHostService.attachHostSurface(state.workspace.id, host);
       shellRuntimeController.setWorkbenchHost(host);
       syncWorkspaceAppWebviewNodes({
         apps: appCenterState.apps,
@@ -496,7 +504,8 @@ export function useWorkspaceWorkbenchShellRuntime({
       locale,
       shellRuntimeController,
       state.workspace.id,
-      workspaceFileManagerService
+      workspaceFileManagerService,
+      workbenchHostService
     ]
   );
 

--- a/docs/specs/2026-07-11-workbench-host-kernel-phase-0-to-stable.md
+++ b/docs/specs/2026-07-11-workbench-host-kernel-phase-0-to-stable.md
@@ -69,8 +69,9 @@ The approved Tutti-private proof keeps the extraction boundary reviewable:
   and
 - focused unit tests cover DI singleton ownership, lease reuse, multi-scope
   isolation, principal-partition replacement, referential publication,
-  attachment cleanup, failed initial resolution ownership, owner mismatch,
-  exception-safe teardown, and idempotent disposal.
+  per-binding attachment/subscription cleanup, failed initial resolution
+  ownership, branded-configuration mismatch, sync/async exception-safe
+  teardown, and idempotent disposal.
 
 This proof does not introduce Product Profile or Ports, move product adapters,
 create a package, change public Workbench contracts, or authorize any release or

--- a/docs/specs/2026-07-11-workbench-host-kernel-phase-0-to-stable.md
+++ b/docs/specs/2026-07-11-workbench-host-kernel-phase-0-to-stable.md
@@ -1,7 +1,7 @@
 # Workbench Host Kernel: Phase 0 To Stable
 
 - Date: 2026-07-11
-- Status: Active; ADR accepted and PR 1 characterization approved
+- Status: Active; ADR accepted, PR 1 merged, and PR 2 private kernel approved
 - Architecture decision:
   [ADR 0009](../adr/0009-cross-product-workbench-host-kernel.md)
 - Scope: Tutti-first implementation, npm beta, read-only/downstream TSH
@@ -31,21 +31,48 @@ an explicit approval gate.
 
 ## Approval state
 
-Approval recorded on 2026-07-11 is deliberately narrow:
+Approval recorded on 2026-07-11 remains deliberately incremental:
 
 | Scope                                     | Approval                    |
 | ----------------------------------------- | --------------------------- |
 | ADR 0009 architecture boundary            | Accepted                    |
-| PR 1 characterization fixtures/tests      | Approved for implementation |
-| PR 2 private coordinator/session          | Not approved                |
+| PR 1 characterization fixtures/tests      | Merged in #1043             |
+| PR 2 private coordinator/session          | Approved for implementation |
 | PR 3 Product Profile/Ports/adapters split | Not approved                |
 | Public package extraction                 | Not approved                |
 | npm beta publication                      | Not approved                |
 | TSH renderer DI/host migration            | Not approved                |
 | Stable publication                        | Not approved                |
 
-Completing PR 1 produces evidence for the next review; it does not implicitly
-authorize PR 2 or any later step.
+Completing PR 2 produces evidence for the next review; it does not implicitly
+authorize PR 3 or any later step.
+
+### PR 2 implementation evidence
+
+The approved Tutti-private proof keeps the extraction boundary reviewable:
+
+- `workbenchHostCoordinator.ts` owns renderer-local scope indexing, same-
+  partition lease reuse, immutable-partition replacement, and coordinator-wide
+  disposal;
+- `workbenchHostSession.ts` owns the immutable partition snapshot, stable host-
+  input publication, surface attachment, subscriptions, resource cleanup, and
+  idempotent disposal;
+- Tutti registers one coordinator in its existing `@tutti-os/infra/di`
+  renderer root and injects it into the existing product host service;
+- `WorkspaceWorkbenchHostService` remains the Tutti facade and product adapter:
+  it supplies the workspace partition and retains all existing contribution,
+  preload, tuttid, wallpaper, onboarding, dock, diagnostics, and business-
+  service wiring;
+- the React shell continues to render the existing surface and controllers,
+  while attaching the surface handle to the class session and releasing the
+  workspace session during effect cleanup; and
+- focused unit tests cover DI singleton ownership, lease reuse, multi-scope
+  isolation, principal-partition replacement, referential publication,
+  attachment cleanup, and idempotent disposal.
+
+This proof does not introduce Product Profile or Ports, move product adapters,
+create a package, change public Workbench contracts, or authorize any release or
+TSH change.
 
 ## Baseline evidence
 
@@ -498,10 +525,10 @@ The TSH PR must report:
 
 ## Approval gates
 
-ADR 0009 and PR 1 are approved. After PR 1 evidence is reviewed, the recommended
-next approval is PR 2 only. PR 3 remains a separate subsequent approval after
-PR 2 proves the private coordinator/session boundary.
+ADR 0009 is accepted, PR 1 merged as #1043, and PR 2 is approved for
+implementation. After PR 2 evidence is reviewed, the recommended next approval
+is PR 3 only.
 
 Package extraction, npm beta, TSH changes, and stable publication remain four
-additional separate approvals. None is implied by the accepted ADR or PR 1
-approval.
+additional separate approvals. None is implied by the accepted ADR or the PR 1
+and PR 2 approvals.

--- a/docs/specs/2026-07-11-workbench-host-kernel-phase-0-to-stable.md
+++ b/docs/specs/2026-07-11-workbench-host-kernel-phase-0-to-stable.md
@@ -63,12 +63,14 @@ The approved Tutti-private proof keeps the extraction boundary reviewable:
   it supplies the workspace partition and retains all existing contribution,
   preload, tuttid, wallpaper, onboarding, dock, diagnostics, and business-
   service wiring;
-- the React shell continues to render the existing surface and controllers,
-  while attaching the surface handle to the class session and releasing the
-  workspace session during effect cleanup; and
+- a committed React effect acquires an opaque binding to one exact lease before
+  rendering the session-backed shell; host-input projection never acquires a
+  lease, and stale bindings cannot attach to or release a replacement session;
+  and
 - focused unit tests cover DI singleton ownership, lease reuse, multi-scope
   isolation, principal-partition replacement, referential publication,
-  attachment cleanup, and idempotent disposal.
+  attachment cleanup, failed initial resolution ownership, owner mismatch,
+  exception-safe teardown, and idempotent disposal.
 
 This proof does not introduce Product Profile or Ports, move product adapters,
 create a package, change public Workbench contracts, or authorize any release or


### PR DESCRIPTION
## Summary

- introduce Tutti-private, product-neutral WorkbenchHostCoordinator and WorkbenchHostSession classes behind the existing desktop DI service
- register one coordinator per renderer DI root and manage disposable sessions by immutable workspace/room partition
- preserve stable host-input composition while moving session indexing, lease reuse, replacement, attachment, subscription, and disposal ownership out of the product facade
- attach the existing Workbench surface handle to the class session and release the workspace session during React effect cleanup
- update the active Phase 0 spec to record that PR 1 merged as #1043 and PR 2 alone was approved

## PR 2 lifecycle invariants

- the same immutable partition shares one leased session
- the same scope with a different authenticated-principal snapshot disposes and replaces the old session before publication
- different workspace/room scopes remain isolated
- host-input subscribers are notified only when the published reference changes
- session and coordinator disposal are idempotent
- renderer DI disposal disposes every owned session
- disposed sessions detach the surface and cannot publish later updates

## Scope boundaries

This PR is the approved PR 2 private-kernel proof only.

It does not introduce Product Profile or Ports, create packages/workbench/host, change WorkbenchContribution or snapshot contracts, move Tutti product adapters, modify daemon APIs, change release configuration or lockfiles, publish packages, or modify TSH. PR 3 and every later gate still require separate approval.

## Verification

- focused desktop Workbench host/registry/repository/shell/kernel tests: 68 passed
- private coordinator/session/facade tests: 20 passed
- pnpm --filter @tutti-os/workbench-surface test: 201 passed
- pnpm --filter @tutti-os/desktop typecheck
- pnpm check:renderer-boundaries
- pnpm check:electron-runtime-boundaries
- pnpm check:changed --tail-lines 80: 6 lanes passed
- Oxfmt and Prettier checks for changed files
- local Markdown link check
- git diff --check
- pnpm check:full: 16 tasks passed

## Checklist

- [x] I kept the change focused on one concern.
- [x] I updated documentation when behavior, setup, or contributor workflow changed.
- [x] I updated all README/CONTRIBUTING language variants when changing their English source (not applicable; none changed).
- [x] I ran the lowest meaningful local checks for the changed surface.
- [x] My commits are signed off with DCO when required: git commit -s.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Introduces a private host session kernel with a DI-scoped `WorkbenchHostCoordinator` and per-lease workspace bindings. Closes lifecycle gaps by isolating session ownership, cleanup, and UI attachment while keeping public Workbench contracts unchanged.

- **Refactors**
  - Added `WorkbenchHostCoordinator` (one per renderer via `@tutti-os/infra/di`) and `WorkbenchHostSession`; reuses leases per immutable partition and replaces on principal change; optional disposal diagnostics; exported as `IWorkbenchHostCoordinator`.
  - Added `WorkspaceWorkbenchHostSessionBinding` to wrap one lease and expose `attachSurface`, `createHostInput`, `subscribe`, `release`.
  - Injected `IWorkbenchHostCoordinator` into `WorkspaceWorkbenchHostService`; new `openHostSession(workspaceId)` returns a binding; host-input resolution moved into session `resolve`; removed internal host-input cache; `dispose()` now clears wallpaper listeners and custom wallpaper URLs.
  - UI wired to sessions: `WorkspaceWorkbench` opens/releases a binding in a layout effect and attaches the surface; `useWorkspaceWorkbenchShellRuntime` uses the binding’s `createHostInput` and `attachSurface`. Spec updated with PR 2 approval; public Workbench packages/contracts unchanged.

- **Bug Fixes**
  - Enforced exact lease/partition ownership and branded-configuration checks; rejected cross-workspace updates and mismatched partitions; failed initial resolution remains owned by its original binding.
  - Isolated shared resources and ownership per binding: surfaces detach only by the current owner; per-binding subscription cleanup; bindings release only their own lease and are safe after coordinator-first disposal.
  - Robust, idempotent disposal: DI singleton disposal closes all sessions; coordinator/session cleanup continues after sync/async errors; stable referential host-input publication with one subscriber batch per update.

<sup>Written for commit cb0b85448533e149b0fea89028015c93ce8026e7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tutti-os/tutti/pull/1044?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

