### PR TITLE
fix(setup-dev): compare pnpm version without corepack integrity hash

### DIFF
--- a/tools/scripts/setup-dev.mjs
+++ b/tools/scripts/setup-dev.mjs
@@ -237,7 +237,9 @@ function parsePnpmVersion(packageManager) {
   if (!match) {
     throw new Error(`unsupported packageManager value: ${packageManager}`);
   }
-  return match[1];
+  // corepack may pin an integrity suffix (pnpm@x.y.z+sha512....) that
+  // `pnpm --version` never reports, so compare on the bare version only.
+  return match[1].split("+")[0];
 }
 
 function parseGoVersionPrefix(goMod) {


### PR DESCRIPTION
## Problem

`pnpm setup:dev` / `pnpm install:golangci-lint` exit 1 on every fresh checkout of main:

```
FAIL pnpm: expected pnpm 10.11.0+sha512.6540583f41cc5f..., found 10.11.0
```

b2bbf780 (an unrelated workbench commit) checked in a corepack-rewritten `packageManager` field carrying a `+sha512...` integrity suffix. `checkPnpm` in `tools/scripts/setup-dev.mjs` compares that whole string against `pnpm --version` output with strict equality — but pnpm only ever reports the bare version, so the check can never pass while the suffix is present.

## Fix

Strip the integrity suffix in `parsePnpmVersion` so the pinned version is the bare `x.y.z`. Keeping the hash in `package.json` is intentional — it's corepack's standard integrity-pinning format — so the script tolerates it instead of reverting the field.

## Verification

On a clean worktree of origin/main, reproduced the exact failure, then re-ran after the fix:

```
PASS pnpm: found 10.11.0
```

Pre-push `check:full` passed (16 tasks).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-line change in dev setup script only; no runtime, auth, or production paths affected.
> 
> **Overview**
> **Fixes `pnpm setup:dev` failing** when `package.json`'s `packageManager` includes corepack's `+sha512...` integrity suffix (e.g. `pnpm@10.11.0+sha512....`).
> 
> `parsePnpmVersion` now returns only the bare semver (`split("+")[0]`) before `checkPnpm` compares it to `pnpm --version`, which never includes the hash. The integrity pin in `package.json` is left unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 51dc57dd9f22dcc642233f4b578cc44f2aaca132. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the `pnpm` version check in `tools/scripts/setup-dev.mjs` by stripping the `corepack` `+sha512...` integrity suffix from `packageManager` before comparison. This prevents false failures on fresh checkouts and lets `pnpm setup:dev` and `pnpm install:golangci-lint` run successfully.

<sup>Written for commit 51dc57dd9f22dcc642233f4b578cc44f2aaca132. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tutti-os/tutti/pull/1047?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

