### PR TITLE
chore: drop corepack integrity hash from packageManager

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "tutti",
   "private": true,
-  "packageManager": "pnpm@10.11.0+sha512.6540583f41cc5f628eb3d9773ecee802f4f9ef9923cc45b69890fb47991d4b092964694ec3a4f738a420c918a333062c8b925d312f42e4f0c263eb603551f977",
+  "packageManager": "pnpm@10.11.0",
   "workspaces": [
     "apps/*",
     "packages/*/*",


### PR DESCRIPTION
## Problem

b2bbf780 (an unrelated workbench commit) checked in a corepack-rewritten `packageManager` value carrying a `+sha512...` integrity suffix. `setup-dev.mjs` compares the pinned version strictly against `pnpm --version`, which never reports the suffix, so `pnpm setup:dev` / `pnpm install:golangci-lint` exit 1 on every fresh checkout of main:

```
FAIL pnpm: expected pnpm 10.11.0+sha512.6540583f41cc5f..., found 10.11.0
```

## Fix

Restore the plain `pnpm@10.11.0` pin as it was before b2bbf780.

Complements #1047 (which makes the script tolerate the suffix): this PR unbreaks any checkout immediately regardless of script version, while #1047 prevents a recurrence the next time someone's corepack rewrites the field.

## Verification

On this branch (original strict-compare script, no #1047), the check now passes:

```
PASS pnpm: found 10.11.0
```

Pre-push `check:full` passed (16 tasks).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-field tooling pin change with no runtime, auth, or application logic impact.
> 
> **Overview**
> Restores **`packageManager`** to plain **`pnpm@10.11.0`** by removing the Corepack **`+sha512...`** suffix that had been checked in on **`package.json`**.
> 
> That suffix made **`setup-dev.mjs`**’s strict pnpm check fail on fresh checkouts, because **`pnpm --version`** reports **`10.11.0`** while the pin included the hash, breaking **`pnpm setup:dev`** and related install checks until the field matched what the CLI prints.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 80a41138571d040fdef141ddf726b1617c72df02. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed the Corepack integrity hash from the `packageManager` field to pin `pnpm@10.11.0` without a suffix, matching `pnpm --version` output.
This fixes false version checks and unblocks `pnpm setup:dev` and `pnpm install:golangci-lint` on fresh checkouts.

<sup>Written for commit 80a41138571d040fdef141ddf726b1617c72df02. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tutti-os/tutti/pull/1048?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

