### PR TITLE
fix(agent-gui): keep explicit agent targets exact

### DIFF
--- a/.changeset/agent-gui-exact-missing-target.md
+++ b/.changeset/agent-gui-exact-missing-target.md
@@ -1,0 +1,7 @@
+---
+"@tutti-os/agent-gui": patch
+---
+
+Keep explicit agent target selection exact while the host directory is loading
+or missing the requested agent, preventing fallback launches through a sibling
+directory entry.

--- a/packages/agent/gui/agent-gui/agentGuiNode/AgentGUINode.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/AgentGUINode.tsx
@@ -60,7 +60,8 @@ import {
 } from "./AgentGUINodeView";
 import {
   normalizeAgentGUIAgents,
-  projectAgentGUIAgentsToInternalTargets
+  projectAgentGUIAgentsToInternalTargets,
+  resolveAgentGUISelectedDirectoryAgent
 } from "../../agents";
 import type { AgentGUIAccountMenuState } from "./accountMenuState";
 import {
@@ -790,18 +791,15 @@ export const AgentGUINode = memo(function AgentGUINode({
       ),
     [normalizedAgents]
   );
-  const selectedDirectoryAgent = useMemo(() => {
-    const selectedAgentTargetId =
-      state.agentTargetId?.trim() || defaultAgentTargetId?.trim() || "";
-    return (
-      agentByTargetId.get(selectedAgentTargetId) ?? normalizedAgents[0] ?? null
-    );
-  }, [
-    agentByTargetId,
-    defaultAgentTargetId,
-    normalizedAgents,
-    state.agentTargetId
-  ]);
+  const selectedDirectoryAgent = useMemo(
+    () =>
+      resolveAgentGUISelectedDirectoryAgent({
+        agents: normalizedAgents,
+        agentTargetId: state.agentTargetId,
+        defaultAgentTargetId
+      }),
+    [defaultAgentTargetId, normalizedAgents, state.agentTargetId]
+  );
   const internalProviderReadinessGates = useMemo<
     Partial<Record<AgentGUIProvider, AgentGUIProviderReadinessGate | null>>
   >(() => {
@@ -841,7 +839,7 @@ export const AgentGUINode = memo(function AgentGUINode({
   const renderInternalAgentReadinessState = useMemo<
     AgentGUIProviderReadinessGateStateRenderer | undefined
   >(() => {
-    if (!renderAgentReadinessState) {
+    if (!renderAgentReadinessState || !selectedDirectoryAgent) {
       return undefined;
     }
     return ({ target, showAllProviders }) => {

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUINodeController.spec.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUINodeController.spec.tsx
@@ -3481,6 +3481,7 @@ describe("useAgentGUINodeController", () => {
       activate
     });
     const onDataChange = vi.fn();
+    const initialData = agentGuiData(null, "codex", { agentTargetId: null });
 
     const { result } = renderHook(() =>
       useAgentGUINodeController({
@@ -3488,7 +3489,7 @@ describe("useAgentGUINodeController", () => {
         currentUserId: "user-1",
         workspacePath: "/workspace",
         avoidGroupingEdits: false,
-        data: agentGuiData(null),
+        data: initialData,
         providerTargets: [
           {
             targetId: "shared-agent:agent-1",
@@ -3498,7 +3499,7 @@ describe("useAgentGUINodeController", () => {
             label: "Alice's Codex"
           }
         ],
-        defaultAgentTargetId: "shared-agent:agent-1",
+        defaultAgentTargetId: "agent-target-1",
         onDataChange
       })
     );
@@ -3522,10 +3523,10 @@ describe("useAgentGUINodeController", () => {
     });
     expect(onDataChange).toHaveBeenCalled();
     const persistTargetUpdate = onDataChange.mock.calls.find(([updater]) => {
-      const next = updater(agentGuiData(null));
+      const next = updater(initialData);
       return next.agentTargetId === "agent-target-1";
     })?.[0];
-    expect(persistTargetUpdate?.(agentGuiData(null))).toMatchObject({
+    expect(persistTargetUpdate?.(initialData)).toMatchObject({
       provider: "codex",
       agentTargetId: "agent-target-1"
     });
@@ -3801,7 +3802,7 @@ describe("useAgentGUINodeController", () => {
     });
   });
 
-  it("falls back to the first explicit agent when persisted selection is stale", async () => {
+  it("keeps a stale explicit target missing instead of falling back to the first agent", async () => {
     const activate = vi.fn(
       async (input: AgentHostActivateAgentSessionInput) => ({
         session: agentSession(input.agentSessionId, {
@@ -3843,16 +3844,115 @@ describe("useAgentGUINodeController", () => {
       })
     );
 
-    expect(result.current.viewModel.canSubmit).toBe(true);
+    expect(result.current.viewModel.canSubmit).toBe(false);
+    expect(result.current.viewModel.selectedProviderTarget).toMatchObject({
+      agentTargetId: "local:claude-code",
+      disabled: true,
+      provider: "claude-code",
+      ref: { kind: "missing-agent" }
+    });
+    expect(result.current.viewModel.providerReadinessGate).toEqual({
+      status: "unavailable"
+    });
 
     act(() => {
       result.current.actions.submitPrompt(promptBlocks("start local claude"));
     });
+    await Promise.resolve();
+    expect(activate).not.toHaveBeenCalled();
+  });
 
+  it("keeps a delayed explicit target exact across same-provider siblings", async () => {
+    const activate = vi.fn(
+      async (input: AgentHostActivateAgentSessionInput) => ({
+        session: agentSession(input.agentSessionId),
+        activation: { mode: input.mode, status: "attached" as const }
+      })
+    );
+    installAgentHostApi({
+      list: vi.fn(async () => ({ presences: [], sessions: [] })),
+      listSessionTimeline: vi.fn(async () => ({ timelineItems: [] })),
+      subscribeEvents: vi.fn(() => vi.fn()),
+      activate
+    });
+    const targetA = {
+      targetId: "codex-a",
+      agentTargetId: "codex-a",
+      provider: "codex" as const,
+      ref: { kind: "agent-directory", provider: "codex" as const },
+      label: "Codex A"
+    };
+    const targetB = {
+      targetId: "codex-b",
+      agentTargetId: "codex-b",
+      provider: "codex" as const,
+      ref: { kind: "agent-directory", provider: "codex" as const },
+      label: "Codex B"
+    };
+    const { result, rerender } = renderHook(
+      (props: {
+        providerTargets: readonly (typeof targetA)[];
+        providerTargetsLoading: boolean;
+      }) =>
+        useAgentGUINodeController({
+          workspaceId: "room-1",
+          currentUserId: "user-1",
+          workspacePath: "/workspace",
+          avoidGroupingEdits: false,
+          data: agentGuiData(null, "codex", { agentTargetId: "codex-b" }),
+          onDataChange: vi.fn(),
+          ...props
+        }),
+      {
+        initialProps: {
+          providerTargets: [targetA],
+          providerTargetsLoading: true
+        }
+      }
+    );
+
+    expect(result.current.viewModel.selectedProviderTarget).toMatchObject({
+      agentTargetId: "codex-b",
+      disabled: true,
+      ref: { kind: "loading" }
+    });
+    expect(result.current.viewModel.providerReadinessGate).toEqual({
+      status: "checking"
+    });
+    expect(result.current.viewModel.canSubmit).toBe(false);
+
+    rerender({ providerTargets: [targetA], providerTargetsLoading: false });
+    expect(result.current.viewModel.selectedProviderTarget).toMatchObject({
+      agentTargetId: "codex-b",
+      disabled: true,
+      ref: { kind: "missing-agent" }
+    });
+    expect(result.current.viewModel.providerReadinessGate).toEqual({
+      status: "unavailable"
+    });
+    expect(result.current.viewModel.canSubmit).toBe(false);
+
+    rerender({
+      providerTargets: [targetA, targetB],
+      providerTargetsLoading: false
+    });
+    await waitFor(() => {
+      expect(result.current.viewModel.selectedProviderTarget).toMatchObject({
+        agentTargetId: "codex-b"
+      });
+      expect(
+        result.current.viewModel.selectedProviderTarget?.disabled
+      ).toBeUndefined();
+      expect(result.current.viewModel.canSubmit).toBe(true);
+    });
+
+    act(() => {
+      result.current.actions.submitPrompt(promptBlocks("start exact B"));
+    });
     await waitFor(() => {
       expect(activate).toHaveBeenCalledWith(
         expect.objectContaining({
-          agentTargetId: "shared-agent:codex-1",
+          agentTargetId: "codex-b",
           mode: "new"
         })
       );
@@ -4127,6 +4227,59 @@ describe("useAgentGUINodeController", () => {
         agentTargetId: "codex-b"
       });
     });
+  });
+
+  it("does not apply an exact-target prefill to a same-provider sibling", async () => {
+    const activate = vi.fn();
+    const unactivate = vi.fn(async () => undefined);
+    installAgentHostApi({
+      list: vi.fn(async () =>
+        snapshotWithSession("session-1", {
+          agentTargetId: "codex-a",
+          provider: "codex"
+        })
+      ),
+      listSessionTimeline: vi.fn(async () => ({ timelineItems: [] })),
+      subscribeEvents: vi.fn(() => vi.fn()),
+      activate,
+      unactivate
+    });
+
+    const { result } = renderHook(() =>
+      useAgentGUINodeController({
+        workspaceId: "room-1",
+        currentUserId: "user-1",
+        workspacePath: "/workspace",
+        avoidGroupingEdits: false,
+        data: agentGuiData("session-1", "codex", {
+          agentTargetId: "codex-a"
+        }),
+        providerTargets: [
+          {
+            targetId: "codex-a",
+            agentTargetId: "codex-a",
+            provider: "codex",
+            ref: { kind: "agent-directory", provider: "codex" },
+            label: "Codex A"
+          }
+        ],
+        prefillPromptRequest: {
+          agentTargetId: "codex-b",
+          autoSubmit: true,
+          draftPrompt: "must stay on B",
+          provider: "codex",
+          sequence: 12
+        },
+        onDataChange: vi.fn()
+      })
+    );
+
+    await waitFor(() => {
+      expect(result.current.viewModel.activeConversationId).toBe("session-1");
+    });
+    expect(result.current.viewModel.draftPrompt).not.toBe("must stay on B");
+    expect(unactivate).not.toHaveBeenCalled();
+    expect(activate).not.toHaveBeenCalled();
   });
 
   it("tracks active conversation project setting changes through the host reporter", async () => {

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUINodeController.spec.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUINodeController.spec.tsx
@@ -1496,6 +1496,121 @@ describe("useAgentGUINodeController", () => {
     expect(result.current.viewModel.providerReadinessGate).toBeNull();
   });
 
+  it("does not replace an explicit default target with the first ready provider", async () => {
+    installAgentHostApi({
+      list: vi.fn(async () => ({ presences: [], sessions: [] })),
+      listSessionTimeline: vi.fn(async () => ({ timelineItems: [] })),
+      subscribeEvents: vi.fn(() => vi.fn())
+    });
+    const onDataChange = vi.fn();
+    const initialData = agentGuiData(null, "codex", { agentTargetId: null });
+
+    const { result } = renderHook(() =>
+      useAgentGUINodeController({
+        workspaceId: "room-1",
+        currentUserId: "user-1",
+        workspacePath: "/workspace",
+        avoidGroupingEdits: false,
+        data: initialData,
+        defaultAgentTargetId: "local:codex",
+        providerTargets: [
+          {
+            targetId: "local:codex",
+            agentTargetId: "local:codex",
+            provider: "codex",
+            ref: { kind: "local", provider: "codex" },
+            label: "Codex"
+          },
+          {
+            targetId: "local:claude-code",
+            agentTargetId: "local:claude-code",
+            provider: "claude-code",
+            ref: { kind: "local", provider: "claude-code" },
+            label: "Claude Code"
+          }
+        ],
+        providerReadinessGates: {
+          codex: { status: "checking" },
+          "claude-code": null
+        },
+        onDataChange
+      })
+    );
+
+    await waitFor(() => {
+      expect(result.current.viewModel.selectedProviderTarget).toMatchObject({
+        agentTargetId: "local:codex",
+        provider: "codex"
+      });
+      expect(result.current.viewModel.providerReadinessGate).toEqual({
+        status: "checking"
+      });
+    });
+    const nextData = onDataChange.mock.calls.reduce(
+      (current, [updater]) => updater(current),
+      initialData
+    );
+    expect(nextData.agentTargetId).not.toBe("local:claude-code");
+  });
+
+  it("keeps a missing explicit default unavailable instead of choosing a ready provider", async () => {
+    installAgentHostApi({
+      list: vi.fn(async () => ({ presences: [], sessions: [] })),
+      listSessionTimeline: vi.fn(async () => ({ timelineItems: [] })),
+      subscribeEvents: vi.fn(() => vi.fn())
+    });
+    const onDataChange = vi.fn();
+    const initialData = agentGuiData(null, "codex", { agentTargetId: null });
+
+    const { result } = renderHook(() =>
+      useAgentGUINodeController({
+        workspaceId: "room-1",
+        currentUserId: "user-1",
+        workspacePath: "/workspace",
+        avoidGroupingEdits: false,
+        data: initialData,
+        defaultAgentTargetId: "missing-codex",
+        providerTargets: [
+          {
+            targetId: "local:codex",
+            agentTargetId: "local:codex",
+            provider: "codex",
+            ref: { kind: "local", provider: "codex" },
+            label: "Codex"
+          },
+          {
+            targetId: "local:claude-code",
+            agentTargetId: "local:claude-code",
+            provider: "claude-code",
+            ref: { kind: "local", provider: "claude-code" },
+            label: "Claude Code"
+          }
+        ],
+        providerReadinessGates: {
+          codex: { status: "checking" },
+          "claude-code": null
+        },
+        onDataChange
+      })
+    );
+
+    await waitFor(() => {
+      expect(result.current.viewModel.selectedProviderTarget).toMatchObject({
+        agentTargetId: "missing-codex",
+        disabled: true,
+        ref: { kind: "missing-agent" }
+      });
+      expect(result.current.viewModel.providerReadinessGate).toEqual({
+        status: "unavailable"
+      });
+    });
+    const nextData = onDataChange.mock.calls.reduce(
+      (current, [updater]) => updater(current),
+      initialData
+    );
+    expect(nextData.agentTargetId).not.toBe("local:claude-code");
+  });
+
   it("selects target-backed rail targets for the empty composer", async () => {
     installAgentHostApi({
       list: vi.fn(async () => ({ presences: [], sessions: [] })),

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUINodeController.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUINodeController.ts
@@ -385,6 +385,11 @@ interface AgentGUIComposerTargetResolution {
   missingAgentTargetId: string | null;
 }
 
+interface AgentGUIHomeDirectorySelection {
+  status: AgentGUIComposerTargetResolutionStatus;
+  target: AgentGUIProviderTarget;
+}
+
 function isExplicitAgentGUIProviderTarget(
   target: AgentGUIProviderTarget,
   explicitTargets: readonly AgentGUIProviderTarget[]
@@ -425,6 +430,57 @@ function resolveAgentGUIDirectorySelection(input: {
     input.targets[0] ??
     null
   );
+}
+
+function resolveAgentGUIHomeDirectorySelection(input: {
+  data: AgentGUINodeData;
+  defaultAgentTargetId?: string | null;
+  directory: readonly AgentGUIProviderTarget[];
+  directoryLoading: boolean;
+}): AgentGUIHomeDirectorySelection {
+  const explicitAgentTargetId =
+    normalizeOptionalText(input.data.agentTargetId) ??
+    normalizeOptionalText(input.defaultAgentTargetId);
+  if (explicitAgentTargetId) {
+    const exact = findAgentGUIDirectoryTarget(
+      input.directory,
+      explicitAgentTargetId
+    );
+    if (exact) {
+      return { status: "resolved", target: exact };
+    }
+    return {
+      status: input.directoryLoading ? "loading" : "missing",
+      target: {
+        targetId: explicitAgentTargetId,
+        agentTargetId: explicitAgentTargetId,
+        provider: input.data.provider,
+        ref: {
+          kind: input.directoryLoading ? "loading" : "missing-agent",
+          provider: input.data.provider,
+          agentTargetId: explicitAgentTargetId
+        },
+        label: input.data.provider,
+        disabled: true
+      }
+    };
+  }
+
+  const fallback =
+    input.directory.find((target) => target.disabled !== true) ??
+    input.directory[0];
+  return {
+    status: input.directoryLoading ? "loading" : "resolved",
+    target:
+      fallback ??
+      ({
+        targetId: "__loading__",
+        provider: input.data.provider,
+        ref: { kind: "loading", provider: input.data.provider },
+        label: input.data.provider,
+        disabled: true
+      } satisfies AgentGUIProviderTarget)
+  };
 }
 
 // The node/session carries `agentTargetId` only as a foreign key. When a
@@ -3958,34 +4014,20 @@ export function useAgentGUINodeController({
           ),
     [normalizedExplicitProviderTargets, providerTargetsLoading]
   );
-  const selectedProviderTarget = useMemo(() => {
-    const selectedAgentTargetId =
-      normalizeOptionalText(data.agentTargetId) ??
-      normalizeOptionalText(defaultAgentTargetId);
-    const resolved =
-      normalizedProviderTargets.find(
-        (target) => target.agentTargetId === selectedAgentTargetId
-      ) ??
-      normalizedProviderTargets.find((target) => target.disabled !== true) ??
-      normalizedProviderTargets[0];
-    return (
-      resolved ?? {
-        targetId: data.agentTargetId ?? "__loading__",
-        provider: data.provider,
-        ref: {
-          kind: "loading",
-          provider: data.provider
-        },
-        label: data.provider,
-        disabled: true
-      }
-    );
+  const homeDirectorySelection = useMemo(() => {
+    return resolveAgentGUIHomeDirectorySelection({
+      data,
+      defaultAgentTargetId,
+      directory: normalizedProviderTargets,
+      directoryLoading: providerTargetsLoading
+    });
   }, [
-    data.agentTargetId,
-    data.provider,
+    data,
     defaultAgentTargetId,
-    normalizedProviderTargets
+    normalizedProviderTargets,
+    providerTargetsLoading
   ]);
+  const selectedProviderTarget = homeDirectorySelection.target;
   const selectedProviderTargetIsExplicit = useMemo(
     () =>
       normalizedExplicitProviderTargets.some(
@@ -12454,10 +12496,18 @@ export function useAgentGUINodeController({
   );
   const viewData =
     activeConversationId === null ? selectedComposerTargetData.data : data;
-  const providerReadinessGate =
+  const effectiveHomeDirectorySelectionStatus = homeComposerTargetOverride
+    ? "resolved"
+    : homeDirectorySelection.status;
+  const providerReadinessGate: AgentGUIProviderReadinessGate | null =
     activeConversationId === null
-      ? (providerReadinessGates?.[effectiveSelectedProviderTarget.provider] ??
-        null)
+      ? effectiveHomeDirectorySelectionStatus === "loading"
+        ? { status: "checking" }
+        : effectiveHomeDirectorySelectionStatus === "missing"
+          ? { status: "unavailable" }
+          : (providerReadinessGates?.[
+              effectiveSelectedProviderTarget.provider
+            ] ?? null)
       : null;
   const controllerActions = useMemo(
     () => ({

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUINodeController.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUINodeController.ts
@@ -386,6 +386,7 @@ interface AgentGUIComposerTargetResolution {
 }
 
 interface AgentGUIHomeDirectorySelection {
+  source: "explicit-data" | "explicit-default" | "implicit";
   status: AgentGUIComposerTargetResolutionStatus;
   target: AgentGUIProviderTarget;
 }
@@ -438,18 +439,26 @@ function resolveAgentGUIHomeDirectorySelection(input: {
   directory: readonly AgentGUIProviderTarget[];
   directoryLoading: boolean;
 }): AgentGUIHomeDirectorySelection {
-  const explicitAgentTargetId =
-    normalizeOptionalText(input.data.agentTargetId) ??
-    normalizeOptionalText(input.defaultAgentTargetId);
+  const dataAgentTargetId = normalizeOptionalText(input.data.agentTargetId);
+  const defaultAgentTargetId = normalizeOptionalText(
+    input.defaultAgentTargetId
+  );
+  const explicitAgentTargetId = dataAgentTargetId ?? defaultAgentTargetId;
+  const source = dataAgentTargetId
+    ? "explicit-data"
+    : defaultAgentTargetId
+      ? "explicit-default"
+      : "implicit";
   if (explicitAgentTargetId) {
     const exact = findAgentGUIDirectoryTarget(
       input.directory,
       explicitAgentTargetId
     );
     if (exact) {
-      return { status: "resolved", target: exact };
+      return { source, status: "resolved", target: exact };
     }
     return {
+      source,
       status: input.directoryLoading ? "loading" : "missing",
       target: {
         targetId: explicitAgentTargetId,
@@ -470,6 +479,7 @@ function resolveAgentGUIHomeDirectorySelection(input: {
     input.directory.find((target) => target.disabled !== true) ??
     input.directory[0];
   return {
+    source,
     status: input.directoryLoading ? "loading" : "resolved",
     target:
       fallback ??
@@ -12044,15 +12054,15 @@ export function useAgentGUINodeController({
   const resolveDefaultHomeComposerTarget =
     useCallback((): AgentGUIProviderTarget | null => {
       const defaultTargetId = defaultAgentTargetId?.trim() ?? "";
-      const explicitDefaultTarget = defaultTargetId
-        ? (normalizedProviderTargets.find(
-            (target) =>
-              target.targetId === defaultTargetId ||
-              target.agentTargetId === defaultTargetId
-          ) ?? null)
-        : null;
+      if (defaultTargetId) {
+        return (
+          findAgentGUIDirectoryTarget(
+            normalizedProviderTargets,
+            defaultTargetId
+          ) ?? null
+        );
+      }
       return (
-        explicitDefaultTarget ??
         normalizedProviderTargets.find((target) => target.disabled !== true) ??
         normalizedProviderTargets[0] ??
         null
@@ -12251,6 +12261,7 @@ export function useAgentGUINodeController({
       conversationFilter.kind !== "all" ||
       homeComposerTargetOverride !== null ||
       agentGUINodeDataHasComposerTarget(data) ||
+      homeDirectorySelection.source !== "implicit" ||
       !providerReadinessGates ||
       !firstReadyHomeComposerProviderTarget
     ) {
@@ -12290,6 +12301,7 @@ export function useAgentGUINodeController({
     data,
     effectiveSelectedProviderTarget,
     firstReadyHomeComposerProviderTarget,
+    homeDirectorySelection.source,
     homeComposerTargetOverride,
     previewMode,
     providerReadinessGates,

--- a/packages/agent/gui/agents.test.ts
+++ b/packages/agent/gui/agents.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it } from "vitest";
-import { normalizeAgentGUIAgents } from "./agents";
+import {
+  normalizeAgentGUIAgents,
+  resolveAgentGUISelectedDirectoryAgent
+} from "./agents";
 import type { AgentGUIAgent } from "./types";
 
 function createAgent(
@@ -56,5 +59,37 @@ describe("normalizeAgentGUIAgents", () => {
         provider: "codex"
       }
     ]);
+  });
+});
+
+describe("resolveAgentGUISelectedDirectoryAgent", () => {
+  const unavailable = createAgent("agent-a");
+  unavailable.availability = { status: "unavailable" };
+  const ready = createAgent("agent-b");
+
+  it("requires an exact match for an explicit target", () => {
+    expect(
+      resolveAgentGUISelectedDirectoryAgent({
+        agents: [unavailable, ready],
+        agentTargetId: "missing-agent"
+      })
+    ).toBeNull();
+  });
+
+  it("keeps a missing default target exact", () => {
+    expect(
+      resolveAgentGUISelectedDirectoryAgent({
+        agents: [unavailable, ready],
+        defaultAgentTargetId: "delayed-agent"
+      })
+    ).toBeNull();
+  });
+
+  it("uses the first ready agent only when no explicit target exists", () => {
+    expect(
+      resolveAgentGUISelectedDirectoryAgent({
+        agents: [unavailable, ready]
+      })?.agentTargetId
+    ).toBe("agent-b");
   });
 });

--- a/packages/agent/gui/agents.ts
+++ b/packages/agent/gui/agents.ts
@@ -59,6 +59,27 @@ export function agentGUIAgentIsReady(agent: AgentGUIAgent): boolean {
   return agent.availability.status === "ready";
 }
 
+export function resolveAgentGUISelectedDirectoryAgent(input: {
+  agents: readonly AgentGUIAgent[];
+  agentTargetId?: string | null;
+  defaultAgentTargetId?: string | null;
+}): AgentGUIAgent | null {
+  const explicitAgentTargetId =
+    input.agentTargetId?.trim() || input.defaultAgentTargetId?.trim() || "";
+  if (explicitAgentTargetId) {
+    return (
+      input.agents.find(
+        (agent) => agent.agentTargetId === explicitAgentTargetId
+      ) ?? null
+    );
+  }
+  return (
+    input.agents.find((agent) => agentGUIAgentIsReady(agent)) ??
+    input.agents[0] ??
+    null
+  );
+}
+
 /** Package-internal bridge while the carried node is migrated to agent names. */
 export function projectAgentGUIAgentsToInternalTargets(
   agents: readonly AgentGUIAgent[]


### PR DESCRIPTION
## Summary

- require exact directory matches for explicit `agentTargetId` selections
- preserve loading and missing states instead of falling back to a sibling agent
- prevent exact-target prefills from activating or mutating the wrong same-provider agent
- add regression coverage and a patch changeset for `@tutti-os/agent-gui`

## Validation

- `pnpm --filter @tutti-os/agent-gui build`
- `pnpm typecheck`
- focused AgentGUI tests (controller: 279/279; agents: 5/5)
- `pnpm check:changed` (all lanes passed after retrying one existing concurrent timing-flake lane)
- commit hooks: formatting, lint, Electron/UI/renderer boundaries

`pnpm check:full` could not complete locally because the installed Go linter is v1.64.8 while the repository requires v2.12.0; no Go files are changed. Remote CI will run the full pinned toolchain.

Fixes #1046

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Keep explicit agent target selections exact, including defaults. The UI now shows loading or missing placeholders instead of falling back to a ready/sibling agent, preventing accidental activations or prefills.

- **Bug Fixes**
  - Preserve explicit `agentTargetId` (including default) without auto-fallback to first/ready provider; show disabled `loading`/`missing-agent` placeholders and map readiness to `checking`/`unavailable`.
  - Block submits while the explicit target is loading or missing; enable once the exact target appears.
  - Prevent exact-target prefills from applying to same-provider siblings or mutating active sessions.
  - Introduce `resolveAgentGUISelectedDirectoryAgent` and `resolveAgentGUIHomeDirectorySelection`; integrate into the controller and `AgentGUINode`.
  - Add regression tests and a patch changeset for `@tutti-os/agent-gui`.

<sup>Written for commit f24870d9d895391e0fd5718f189ad16e016ad787. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tutti-os/tutti/pull/1051?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

