### PR TITLE
fix(agent-gui): accept remote image upload URLs

### DIFF
--- a/docs/architecture/agent-gui-node.md
+++ b/docs/architecture/agent-gui-node.md
@@ -868,7 +868,10 @@ Composer diagnostics expose this chain without recording prompt bytes or signed
 URLs: `agent.gui.composer.image_upload.requested`, `.resolved`, and `.failed`
 report upload availability and safe reference-shape flags, while
 `agent.gui.composer.submit_state_changed` reports the exact send-button blocker
-such as `submit_disabled`, `image_uploading`, or `image_upload_failed`.
+such as `submit_disabled`, `image_uploading`, or `image_upload_failed`. These
+composer events use the same development console fallback as controller
+diagnostics when the host runtime implements uploads but omits
+`reportDiagnostic`.
 Claude Code runtime options follow the same parity rule. The legacy ACP adapter
 and the Claude SDK adapter must derive system prompt append text, Tutti detail
 mode instructions, plan-mode instructions, plugin directory, custom model args,
@@ -1474,8 +1477,8 @@ UI affordance. `canUploadAttachment` applies to prompt attachment upload paths
 (pasted images, pasted large text, dropped/host-local files) and must not hide
 ordinary `@` references or workspace-reference mention selection.
 When `reportDiagnostic` is omitted, development builds use a low-cost console
-sink for AgentGUI diagnostics such as message page requests/resolutions,
-render-state changes, and caught errors. Hosts can set
+sink for AgentGUI diagnostics such as composer upload/submit state, message page
+requests/resolutions, render-state changes, and caught errors. Hosts can set
 `devDiagnosticConsoleSink: false` to keep a development runtime silent;
 production remains silent by default.
 

--- a/docs/architecture/agent-gui-node.md
+++ b/docs/architecture/agent-gui-node.md
@@ -856,6 +856,14 @@ type without recording base64 data or full signed URLs. UI-local composer
 drafts and optimistic overlays may retain the URL when needed for preview and
 submission; they must not convert it to base64 or persist it as a local prompt
 attachment.
+Provider transport adapters may materialize that HTTPS resource into inline
+image data only at their final request boundary when the upstream protocol does
+not accept remote image URLs. Codex app-server, standard ACP, and the Claude SDK
+sidecar currently do this immediately before their turn/prompt request; the
+AgentGUI draft, submitted content, and durable activity payload remain
+URL-backed. When a provider gains native remote-image support, remove the
+compatibility conversion only from that provider adapter rather than changing
+the shared composer contract.
 When `uploadPromptContent` returns an image, the composer upload continuation
 must accept every normalized image reference shape: `url`, `attachmentId`,
 `path`, or `data`. A URL-backed result replaces the pre-upload base64 runtime

--- a/docs/architecture/agent-gui-node.md
+++ b/docs/architecture/agent-gui-node.md
@@ -864,6 +864,11 @@ UI rendering. Submitted-draft reconciliation must compare normalized URLs so
 an in-flight edit to a URL-backed image cannot be mistaken for the submitted
 draft and cleared. Validate this handoff with the focused `AgentComposer` and
 `useAgentGUINodeController` test suites listed under Boundary Checks.
+Composer diagnostics expose this chain without recording prompt bytes or signed
+URLs: `agent.gui.composer.image_upload.requested`, `.resolved`, and `.failed`
+report upload availability and safe reference-shape flags, while
+`agent.gui.composer.submit_state_changed` reports the exact send-button blocker
+such as `submit_disabled`, `image_uploading`, or `image_upload_failed`.
 Claude Code runtime options follow the same parity rule. The legacy ACP adapter
 and the Claude SDK adapter must derive system prompt append text, Tutti detail
 mode instructions, plan-mode instructions, plugin directory, custom model args,

--- a/docs/architecture/agent-gui-node.md
+++ b/docs/architecture/agent-gui-node.md
@@ -847,15 +847,13 @@ Shared callers may instead supply a URL-backed image block when they already
 uploaded the image. That source must be an absolute HTTPS URL without embedded
 userinfo and must retain a supported PNG, JPEG, or WebP MIME type. `data` and
 `url` are mutually exclusive; ambiguous blocks are rejected. URL-backed images
-bypass the prompt attachment store and owner-side hydration. Capable adapters
-forward the URL as a structured image source, while protocols without a URL
-image variant fail capability validation instead of downloading, converting to
-text, or silently dropping the block. Durable activity reports and diagnostic
-logs should retain safe image metadata such as attachment id, name, and MIME
-type without recording base64 data or full signed URLs. UI-local composer
-drafts and optimistic overlays may retain the URL when needed for preview and
-submission; they must not convert it to base64 or persist it as a local prompt
-attachment.
+bypass the prompt attachment store and owner-side hydration. Until uploaded
+images carry a stable read identity end to end, user-message activity content
+retains the HTTPS URL so reloaded transcripts can render the resource directly;
+diagnostics must still record only safe shape flags and never log prompt bytes
+or the URL itself. UI-local composer drafts and optimistic overlays retain the
+same URL for preview and submission; they must not convert it to base64 or
+persist it as a local prompt attachment.
 Provider transport adapters may materialize that HTTPS resource into inline
 image data only at their final request boundary when the upstream protocol does
 not accept remote image URLs. Codex app-server, standard ACP, and the Claude SDK

--- a/docs/architecture/agent-gui-node.md
+++ b/docs/architecture/agent-gui-node.md
@@ -856,6 +856,14 @@ type without recording base64 data or full signed URLs. UI-local composer
 drafts and optimistic overlays may retain the URL when needed for preview and
 submission; they must not convert it to base64 or persist it as a local prompt
 attachment.
+When `uploadPromptContent` returns an image, the composer upload continuation
+must accept every normalized image reference shape: `url`, `attachmentId`,
+`path`, or `data`. A URL-backed result replaces the pre-upload base64 runtime
+source with the trimmed URL while retaining the original `previewUrl` only for
+UI rendering. Submitted-draft reconciliation must compare normalized URLs so
+an in-flight edit to a URL-backed image cannot be mistaken for the submitted
+draft and cleared. Validate this handoff with the focused `AgentComposer` and
+`useAgentGUINodeController` test suites listed under Boundary Checks.
 Claude Code runtime options follow the same parity rule. The legacy ACP adapter
 and the Claude SDK adapter must derive system prompt append text, Tutti detail
 mode instructions, plan-mode instructions, plugin directory, custom model args,

--- a/packages/agent/daemon/runtime/claude_sdk_adapter.go
+++ b/packages/agent/daemon/runtime/claude_sdk_adapter.go
@@ -294,6 +294,10 @@ func (a *ClaudeCodeSDKAdapter) Exec(
 	}
 	session.ProviderSessionID = adapterSession.providerSessionID
 	explicitDisplayPrompt, visibleText := explicitAndVisiblePromptText(content, displayPrompt)
+	providerContent, err := materializeProviderPromptImages(ctx, content)
+	if err != nil {
+		return nil, err
+	}
 	events := make([]activityshared.Event, 0, 4)
 	emitEvents := func(next []activityshared.Event) {
 		if len(next) == 0 {
@@ -335,7 +339,7 @@ func (a *ClaudeCodeSDKAdapter) Exec(
 			"turnId":         turnID,
 			// Keep prompt as a short-lived text fallback for older sidecars.
 			"prompt":  promptTextForClaudeSDK(content, visibleText),
-			"content": promptContentForClaudeSDK(content, visibleText),
+			"content": promptContentForClaudeSDK(providerContent, visibleText),
 		},
 	}); err != nil {
 		a.unregisterClaudeSDKTurn(adapterSession, turnID, waiter)
@@ -369,6 +373,10 @@ func (a *ClaudeCodeSDKAdapter) GuideActiveTurn(
 	}
 	session.ProviderSessionID = adapterSession.providerSessionID
 	explicitDisplayPrompt, visibleText := explicitAndVisiblePromptText(content, displayPrompt)
+	providerContent, err := materializeProviderPromptImages(ctx, content)
+	if err != nil {
+		return nil, err
+	}
 	events := []activityshared.Event{
 		newTurnActivityEvent(session, EventMessage, turnID, "", RoleUser, visibleText, userPromptActivityPayload(content, explicitDisplayPrompt, userPromptActivityPayloadExtraFromExecMetadata(ctx, map[string]any{
 			"adapter":  claudeSDKSidecarAdapterName,
@@ -387,7 +395,7 @@ func (a *ClaudeCodeSDKAdapter) GuideActiveTurn(
 		Payload: map[string]any{
 			"agentSessionId": session.AgentSessionID,
 			"prompt":         promptTextForClaudeSDK(content, visibleText),
-			"content":        promptContentForClaudeSDK(content, visibleText),
+			"content":        promptContentForClaudeSDK(providerContent, visibleText),
 		},
 	}); err != nil {
 		return events, err

--- a/packages/agent/daemon/runtime/claude_sdk_adapter_test.go
+++ b/packages/agent/daemon/runtime/claude_sdk_adapter_test.go
@@ -1701,7 +1701,6 @@ func TestClaudeCodeSDKAdapterAcceptsImagePromptContent(t *testing.T) {
 }
 
 func TestClaudeCodeSDKAdapterExecSendsStructuredPromptContent(t *testing.T) {
-	signedURL := "https://bucket.example/image.webp?token=secret"
 	conn := &scriptedClaudeSDKConnection{
 		frames: []ProcessFrame{{
 			Stdout: []byte(`{"type":"turn_completed","payload":{"turnId":"turn-image","stopReason":"end_turn"}}` + "\n"),
@@ -1723,7 +1722,6 @@ func TestClaudeCodeSDKAdapterExecSendsStructuredPromptContent(t *testing.T) {
 		[]PromptContentBlock{
 			{Type: "text", Text: "what is in this image?"},
 			{Type: "image", MimeType: "image/png", Data: "aW1hZ2U="},
-			{Type: "image", MimeType: "image/webp", URL: signedURL},
 		},
 		"what is in this image?",
 		"turn-image",
@@ -1741,8 +1739,8 @@ func TestClaudeCodeSDKAdapterExecSendsStructuredPromptContent(t *testing.T) {
 		t.Fatalf("exec prompt = %#v, want legacy text prompt", sent[0].Payload["prompt"])
 	}
 	content, ok := sent[0].Payload["content"].([]any)
-	if !ok || len(content) != 3 {
-		t.Fatalf("exec content = %#v, want text, data image, and URL image blocks", sent[0].Payload["content"])
+	if !ok || len(content) != 2 {
+		t.Fatalf("exec content = %#v, want text and data image blocks", sent[0].Payload["content"])
 	}
 	textBlock, _ := content[0].(map[string]any)
 	if textBlock["type"] != "text" || textBlock["text"] != "what is in this image?" {
@@ -1751,10 +1749,6 @@ func TestClaudeCodeSDKAdapterExecSendsStructuredPromptContent(t *testing.T) {
 	imageBlock, _ := content[1].(map[string]any)
 	if imageBlock["type"] != "image" || imageBlock["mimeType"] != "image/png" || imageBlock["data"] != "aW1hZ2U=" {
 		t.Fatalf("image block = %#v", imageBlock)
-	}
-	urlImageBlock, _ := content[2].(map[string]any)
-	if urlImageBlock["type"] != "image" || urlImageBlock["mimeType"] != "image/webp" || urlImageBlock["url"] != signedURL {
-		t.Fatalf("URL image block = %#v", urlImageBlock)
 	}
 }
 

--- a/packages/agent/daemon/runtime/codex_appserver_adapter.go
+++ b/packages/agent/daemon/runtime/codex_appserver_adapter.go
@@ -1436,6 +1436,10 @@ func (a *CodexAppServerAdapter) GuideActiveTurn(
 	if mentionRoutingApplied {
 		providerContent = appendTuttiMentionRoutingContent(providerContent, mentionRoutingSkills)
 	}
+	providerContent, err := materializeProviderPromptImages(ctx, providerContent)
+	if err != nil {
+		return nil, err
+	}
 	return a.steerActiveTurn(ctx, appSession, session, content, providerContent, explicitDisplayPrompt, visibleText, turnID, activeTurnID, emit)
 }
 
@@ -1574,6 +1578,10 @@ func (a *CodexAppServerAdapter) execBlocking(
 	providerContent := content
 	if mentionRoutingApplied {
 		providerContent = appendTuttiMentionRoutingContent(providerContent, mentionRoutingSkills)
+	}
+	providerContent, err := materializeProviderPromptImages(ctx, providerContent)
+	if err != nil {
+		return nil, err
 	}
 
 	if activeTurnID := a.sessionActiveTurnID(session.AgentSessionID); activeTurnID != "" {

--- a/packages/agent/daemon/runtime/prompt_content.go
+++ b/packages/agent/daemon/runtime/prompt_content.go
@@ -2,15 +2,25 @@ package agentruntime
 
 import (
 	"context"
+	"encoding/base64"
 	"encoding/json"
 	"errors"
+	"fmt"
+	"io"
+	"mime"
+	"net/http"
 	"net/url"
 	"strings"
+	"time"
+
+	"github.com/tutti-os/tutti/packages/agent/daemon/httpx"
 )
 
 var ErrPromptImageUnsupported = errors.New("agent prompt image input is unsupported")
 
 const clientSubmitUserMessageIDPrefix = "client-submit:user:"
+
+const maxProviderPromptImageBytes int64 = 20 << 20
 
 func normalizeRuntimePromptContent(content []PromptContentBlock) []PromptContentBlock {
 	out := make([]PromptContentBlock, 0, len(content))
@@ -219,6 +229,86 @@ func promptContentForACP(content []PromptContentBlock) []map[string]any {
 		}
 	}
 	return out
+}
+
+// materializeProviderPromptImages converts remote HTTPS image references at
+// the provider boundary, immediately before Codex app-server or ACP receives
+// the prompt. Current Codex and Claude transports reject remote image URLs and
+// require inline image data. AgentGUI and durable activity state intentionally
+// keep the uploaded URL; when a provider gains native URL support, only its
+// final adapter needs to stop calling this compatibility conversion.
+func materializeProviderPromptImages(ctx context.Context, content []PromptContentBlock) ([]PromptContentBlock, error) {
+	return materializeProviderPromptImagesWithClient(ctx, content, httpx.NewClient(30*time.Second))
+}
+
+func materializeProviderPromptImagesWithClient(ctx context.Context, content []PromptContentBlock, client *http.Client) ([]PromptContentBlock, error) {
+	requestClient := *client
+	existingRedirectCheck := client.CheckRedirect
+	requestClient.CheckRedirect = func(request *http.Request, via []*http.Request) error {
+		if !runtimePromptImageURLSafe(request.URL.String()) {
+			return ErrPromptImageUnsupported
+		}
+		if existingRedirectCheck != nil {
+			return existingRedirectCheck(request, via)
+		}
+		return nil
+	}
+	out := append([]PromptContentBlock(nil), content...)
+	for index := range out {
+		block := out[index]
+		imageURL := strings.TrimSpace(block.URL)
+		if block.Type != "image" || imageURL == "" {
+			continue
+		}
+		if !runtimePromptImageURLSafe(imageURL) {
+			return nil, ErrPromptImageUnsupported
+		}
+		request, err := http.NewRequestWithContext(ctx, http.MethodGet, imageURL, nil)
+		if err != nil {
+			return nil, fmt.Errorf("prepare remote prompt image: %w", err)
+		}
+		response, err := requestClient.Do(request)
+		if err != nil {
+			if ctxErr := ctx.Err(); ctxErr != nil {
+				return nil, ctxErr
+			}
+			return nil, errors.New("download remote prompt image: request failed")
+		}
+		data, readErr := readProviderPromptImage(response, block.MimeType)
+		if closeErr := response.Body.Close(); readErr == nil && closeErr != nil {
+			readErr = closeErr
+		}
+		if readErr != nil {
+			return nil, readErr
+		}
+		block.Data = base64.StdEncoding.EncodeToString(data)
+		block.URL = ""
+		out[index] = block
+	}
+	return out, nil
+}
+
+func readProviderPromptImage(response *http.Response, expectedMimeType string) ([]byte, error) {
+	if response.StatusCode < http.StatusOK || response.StatusCode >= http.StatusMultipleChoices {
+		return nil, fmt.Errorf("download remote prompt image: unexpected HTTP status %d", response.StatusCode)
+	}
+	if response.ContentLength > maxProviderPromptImageBytes {
+		return nil, fmt.Errorf("download remote prompt image: image exceeds %d bytes", maxProviderPromptImageBytes)
+	}
+	if contentType := strings.TrimSpace(response.Header.Get("Content-Type")); contentType != "" {
+		mediaType, _, err := mime.ParseMediaType(contentType)
+		if err != nil || mediaType != strings.TrimSpace(expectedMimeType) {
+			return nil, ErrPromptImageUnsupported
+		}
+	}
+	data, err := io.ReadAll(io.LimitReader(response.Body, maxProviderPromptImageBytes+1))
+	if err != nil {
+		return nil, fmt.Errorf("download remote prompt image: %w", err)
+	}
+	if len(data) == 0 || int64(len(data)) > maxProviderPromptImageBytes {
+		return nil, fmt.Errorf("download remote prompt image: invalid image size %d", len(data))
+	}
+	return data, nil
 }
 
 func promptContentForActivity(content []PromptContentBlock) []map[string]any {

--- a/packages/agent/daemon/runtime/prompt_content.go
+++ b/packages/agent/daemon/runtime/prompt_content.go
@@ -326,6 +326,9 @@ func promptContentForActivity(content []PromptContentBlock) []map[string]any {
 				"mimeType":     block.MimeType,
 				"attachmentId": block.AttachmentID,
 			}
+			if imageURL := strings.TrimSpace(block.URL); imageURL != "" {
+				item["url"] = imageURL
+			}
 			if strings.TrimSpace(block.Name) != "" {
 				item["name"] = strings.TrimSpace(block.Name)
 			}

--- a/packages/agent/daemon/runtime/prompt_content_test.go
+++ b/packages/agent/daemon/runtime/prompt_content_test.go
@@ -3,6 +3,8 @@ package agentruntime
 import (
 	"context"
 	"encoding/json"
+	"net/http"
+	"net/http/httptest"
 	"strings"
 	"testing"
 )
@@ -16,6 +18,66 @@ func TestNormalizeRuntimePromptContentPreservesURLOnlyImage(t *testing.T) {
 	content := normalizeRuntimePromptContent([]PromptContentBlock{{Type: "image", MimeType: " image/webp ", URL: " " + signedURL + " ", Name: " image.webp "}})
 	if len(content) != 1 || content[0].URL != signedURL || content[0].Data != "" {
 		t.Fatalf("content = %#v, want normalized URL-only image", content)
+	}
+}
+
+func TestMaterializeProviderPromptImagesInlinesRemoteURLForProviderPayloads(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewTLSServer(http.HandlerFunc(func(response http.ResponseWriter, request *http.Request) {
+		if request.Method != http.MethodGet || request.URL.Path != "/image.png" {
+			t.Fatalf("request = %s %s, want GET /image.png", request.Method, request.URL.Path)
+		}
+		response.Header().Set("Content-Type", "image/png")
+		_, _ = response.Write([]byte("hi"))
+	}))
+	defer server.Close()
+
+	content, err := materializeProviderPromptImagesWithClient(context.Background(), []PromptContentBlock{
+		{Type: "text", Text: "look"},
+		{Type: "image", MimeType: "image/png", URL: server.URL + "/image.png", Name: "image.png"},
+	}, server.Client())
+	if err != nil {
+		t.Fatalf("materializeProviderPromptImagesWithClient: %v", err)
+	}
+	if content[1].URL != "" || content[1].Data != "aGk=" || content[1].Name != "image.png" {
+		t.Fatalf("materialized image = %#v", content[1])
+	}
+
+	codexInput := appServerUserInput(content)
+	if got := asString(codexInput[1]["url"]); got != "data:image/png;base64,aGk=" {
+		t.Fatalf("Codex image URL = %q", got)
+	}
+	acpInput := promptContentForACP(content)
+	if got := asString(acpInput[1]["data"]); got != "aGk=" {
+		t.Fatalf("ACP image data = %q", got)
+	}
+	if got := asString(acpInput[1]["mimeType"]); got != "image/png" {
+		t.Fatalf("ACP image mimeType = %q", got)
+	}
+	claudeSDKInput := promptContentForClaudeSDK(content, "look")
+	if got := asString(claudeSDKInput[1]["data"]); got != "aGk=" {
+		t.Fatalf("Claude SDK image data = %q", got)
+	}
+	if got := asString(claudeSDKInput[1]["url"]); got != "" {
+		t.Fatalf("Claude SDK image URL = %q, want empty", got)
+	}
+}
+
+func TestMaterializeProviderPromptImagesRejectsMismatchedResponseMimeType(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewTLSServer(http.HandlerFunc(func(response http.ResponseWriter, _ *http.Request) {
+		response.Header().Set("Content-Type", "text/html")
+		_, _ = response.Write([]byte("not an image"))
+	}))
+	defer server.Close()
+
+	_, err := materializeProviderPromptImagesWithClient(context.Background(), []PromptContentBlock{{
+		Type: "image", MimeType: "image/png", URL: server.URL,
+	}}, server.Client())
+	if err != ErrPromptImageUnsupported {
+		t.Fatalf("materialize error = %v, want ErrPromptImageUnsupported", err)
 	}
 }
 

--- a/packages/agent/daemon/runtime/prompt_content_test.go
+++ b/packages/agent/daemon/runtime/prompt_content_test.go
@@ -93,7 +93,7 @@ func TestValidateRuntimePromptContentImagesRejectsUnsafeOrAmbiguousURL(t *testin
 	}
 }
 
-func TestUserPromptActivityPayloadRedactsImageSources(t *testing.T) {
+func TestUserPromptActivityPayloadPreservesRemoteURLWithoutInlineData(t *testing.T) {
 	signedURL := "https://bucket.example/image.png?token=bearer-secret"
 	payload := userPromptActivityPayload([]PromptContentBlock{{Type: "image", MimeType: "image/png", URL: signedURL, Data: "base64-secret", AttachmentID: "attachment-1", Name: "screen.png"}}, "", nil)
 	encoded, err := json.Marshal(payload)
@@ -101,8 +101,11 @@ func TestUserPromptActivityPayloadRedactsImageSources(t *testing.T) {
 		t.Fatal(err)
 	}
 	serialized := string(encoded)
-	if strings.Contains(serialized, signedURL) || strings.Contains(serialized, "base64-secret") {
-		t.Fatalf("activity payload leaked image source: %s", serialized)
+	if !strings.Contains(serialized, signedURL) {
+		t.Fatalf("activity payload lost remote image URL: %s", serialized)
+	}
+	if strings.Contains(serialized, "base64-secret") {
+		t.Fatalf("activity payload leaked inline image data: %s", serialized)
 	}
 	if !strings.Contains(serialized, "attachment-1") || !strings.Contains(serialized, "screen.png") {
 		t.Fatalf("activity payload lost safe metadata: %s", serialized)

--- a/packages/agent/daemon/runtime/standard_acp_adapter.go
+++ b/packages/agent/daemon/runtime/standard_acp_adapter.go
@@ -184,13 +184,6 @@ func (a *standardACPAdapter) ValidatePromptContent(session Session, content []Pr
 	if err := validateRuntimePromptContentImages(content); err != nil {
 		return err
 	}
-	for _, block := range content {
-		if block.Type == "image" && strings.TrimSpace(block.URL) != "" {
-			// ACP image prompt blocks carry inline base64 data and have no URL
-			// source variant. Never download or rewrite the remote image here.
-			return ErrPromptImageUnsupported
-		}
-	}
 	acpSession := a.getSession(session.AgentSessionID)
 	if acpSession != nil && acpSession.promptImage {
 		return nil
@@ -830,7 +823,11 @@ func (a *standardACPAdapter) Exec(
 	a.rememberSessionTurn(session.AgentSessionID, turnID)
 	explicitDisplayPrompt, visibleText := explicitAndVisiblePromptText(content, displayPrompt)
 	mentionRoutingApplied, mentionRoutingSkills := tuttiMentionRoutingSkills(visibleText)
-	acpPromptContent := promptContentForACP(content)
+	providerContent, err := materializeProviderPromptImages(ctx, content)
+	if err != nil {
+		return nil, err
+	}
+	acpPromptContent := promptContentForACP(providerContent)
 	if mentionRoutingApplied {
 		acpPromptContent = appendTuttiMentionRoutingPrompt(acpPromptContent, mentionRoutingSkills)
 	}

--- a/packages/agent/daemon/runtime/standard_acp_adapter_test.go
+++ b/packages/agent/daemon/runtime/standard_acp_adapter_test.go
@@ -1112,7 +1112,7 @@ func TestStandardACPAdapterRejectsImagePromptWithoutCapability(t *testing.T) {
 	}
 }
 
-func TestStandardACPAdapterRejectsURLImageEvenWithImageCapability(t *testing.T) {
+func TestStandardACPAdapterAcceptsURLImageWithImageCapability(t *testing.T) {
 	t.Parallel()
 
 	transport := newStandardACPTransport("Claude Agent", "claude-session-url")
@@ -1125,8 +1125,8 @@ func TestStandardACPAdapterRejectsURLImageEvenWithImageCapability(t *testing.T) 
 	content := []PromptContentBlock{{
 		Type: "image", MimeType: "image/png", URL: "https://bucket.example/image.png?token=secret",
 	}}
-	if err := adapter.ValidatePromptContent(session, content); !errors.Is(err, ErrPromptImageUnsupported) {
-		t.Fatalf("ValidatePromptContent URL image error = %v, want ErrPromptImageUnsupported", err)
+	if err := adapter.ValidatePromptContent(session, content); err != nil {
+		t.Fatalf("ValidatePromptContent URL image error = %v, want nil", err)
 	}
 }
 

--- a/packages/agent/gui/agent-gui/agentGuiNode/AgentComposer.spec.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/AgentComposer.spec.tsx
@@ -4512,7 +4512,7 @@ describe("AgentComposer", () => {
     ]);
   });
 
-  it("uses the development console diagnostic sink when the upload runtime omits reportDiagnostic", async () => {
+  it("uses the development console diagnostic sink even when the upload runtime has a reporter", async () => {
     vi.stubEnv("AGENT_GUI_DEV_DIAGNOSTIC_CONSOLE", "1");
     const consoleInfo = vi.spyOn(console, "info").mockImplementation(() => {});
     const uploadPromptContent = vi.fn(async () => ({
@@ -4526,7 +4526,8 @@ describe("AgentComposer", () => {
       ]
     }));
     setAgentActivityRuntimeForTests({
-      uploadPromptContent
+      uploadPromptContent,
+      reportDiagnostic: vi.fn()
     } as unknown as AgentActivityRuntime);
 
     let draftContent = createDraft("");

--- a/packages/agent/gui/agent-gui/agentGuiNode/AgentComposer.spec.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/AgentComposer.spec.tsx
@@ -4512,6 +4512,87 @@ describe("AgentComposer", () => {
     ]);
   });
 
+  it("uses the development console diagnostic sink when the upload runtime omits reportDiagnostic", async () => {
+    vi.stubEnv("AGENT_GUI_DEV_DIAGNOSTIC_CONSOLE", "1");
+    const consoleInfo = vi.spyOn(console, "info").mockImplementation(() => {});
+    const uploadPromptContent = vi.fn(async () => ({
+      content: [
+        {
+          type: "image" as const,
+          mimeType: "image/png" as const,
+          url: "https://objects.example.test/signed/screen.png",
+          name: "screen.png"
+        }
+      ]
+    }));
+    setAgentActivityRuntimeForTests({
+      uploadPromptContent
+    } as unknown as AgentActivityRuntime);
+
+    let draftContent = createDraft("");
+    const onDraftContentChange = vi.fn((nextDraft: AgentComposerDraft) => {
+      draftContent = nextDraft;
+    });
+    const renderComposer = () => (
+      <AgentComposer
+        workspaceId="workspace-1"
+        currentUserId="user-1"
+        provider="codex"
+        draftContent={draftContent}
+        availableCommands={[] satisfies readonly AgentHostAgentSessionCommand[]}
+        disabled={false}
+        submitDisabled={false}
+        placeholder="placeholder"
+        composerSettings={createComposerSettings()}
+        queuedPrompts={[]}
+        drainingQueuedPromptId={null}
+        canQueueWhileBusy={false}
+        showStopButton={false}
+        activePrompt={null}
+        isInterrupting={false}
+        isSendingTurn={false}
+        isSubmittingPrompt={false}
+        labels={createLabels()}
+        workspaceUserProjectI18n={workspaceUserProjectI18n}
+        onDraftContentChange={onDraftContentChange}
+        onSettingsChange={vi.fn()}
+        onSubmit={vi.fn()}
+        onSendQueuedPromptNext={vi.fn()}
+        onRemoveQueuedPrompt={vi.fn()}
+        onEditQueuedPrompt={vi.fn()}
+        onInterruptCurrentTurn={vi.fn()}
+        onSubmitInteractivePrompt={vi.fn()}
+      />
+    );
+    const { rerender } = render(renderComposer());
+
+    fireEvent.click(screen.getByTestId("mock-paste-image"));
+    await waitFor(() =>
+      expect(draftContent.images[0]).toMatchObject({
+        url: "https://objects.example.test/signed/screen.png",
+        uploading: false
+      })
+    );
+    rerender(renderComposer());
+
+    expect(
+      consoleInfo.mock.calls.some(
+        ([prefix, event, payload]) =>
+          prefix === "[agent-gui]" &&
+          event === "agent.gui.composer.image_upload.resolved" &&
+          payload?.details?.hasUrl === true
+      )
+    ).toBe(true);
+    expect(
+      consoleInfo.mock.calls.some(
+        ([prefix, event, payload]) =>
+          prefix === "[agent-gui]" &&
+          event === "agent.gui.composer.submit_state_changed" &&
+          payload?.details?.sendDisabledReason === null
+      )
+    ).toBe(true);
+  });
+
   it("marks uploaded images without usable references as failed", async () => {
     const uploadPromptContent = vi.fn(async () => ({
       content: [

--- a/packages/agent/gui/agent-gui/agentGuiNode/AgentComposer.spec.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/AgentComposer.spec.tsx
@@ -4402,10 +4402,12 @@ describe("AgentComposer", () => {
     );
     const createSession = vi.fn();
     const sendInput = vi.fn();
+    const reportDiagnostic = vi.fn();
     setAgentActivityRuntimeForTests({
       uploadPromptContent,
       createSession,
-      sendInput
+      sendInput,
+      reportDiagnostic
     } as unknown as AgentActivityRuntime);
 
     let draftContent = createDraft("");
@@ -4450,7 +4452,12 @@ describe("AgentComposer", () => {
     rerender(renderComposer());
     fireEvent.click(screen.getByRole("button", { name: "发送" }));
 
-    expect(screen.getByRole("button", { name: "发送" })).toBeDisabled();
+    const uploadingSendButton = screen.getByRole("button", { name: "发送" });
+    expect(uploadingSendButton).toBeDisabled();
+    expect(uploadingSendButton).toHaveAttribute(
+      "data-disabled-reason",
+      "image_uploading"
+    );
     expect(onSubmit).not.toHaveBeenCalled();
     expect(createSession).not.toHaveBeenCalled();
     expect(sendInput).not.toHaveBeenCalled();
@@ -4474,10 +4481,26 @@ describe("AgentComposer", () => {
     );
     expect(draftContent.images[0]?.data).toBeUndefined();
     expect(draftContent.images[0]?.uploadError).toBeUndefined();
+    expect(reportDiagnostic).toHaveBeenCalledWith(
+      expect.objectContaining({
+        event: "agent.gui.composer.image_upload.requested",
+        details: expect.objectContaining({ uploadFunctionAvailable: true })
+      })
+    );
+    expect(reportDiagnostic).toHaveBeenCalledWith(
+      expect.objectContaining({
+        event: "agent.gui.composer.image_upload.resolved",
+        details: expect.objectContaining({
+          hasData: false,
+          hasUrl: true
+        })
+      })
+    );
     rerender(renderComposer());
 
     const sendButton = screen.getByRole("button", { name: "发送" });
     expect(sendButton).not.toBeDisabled();
+    expect(sendButton).not.toHaveAttribute("data-disabled-reason");
     fireEvent.click(sendButton);
     expect(onSubmit).toHaveBeenCalledWith([
       {

--- a/packages/agent/gui/agent-gui/agentGuiNode/AgentComposer.spec.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/AgentComposer.spec.tsx
@@ -4391,6 +4391,104 @@ describe("AgentComposer", () => {
     ]);
   });
 
+  it("accepts URL-only image uploads and submits the remote URL", async () => {
+    type UploadResult = AgentActivityRuntimeUploadPromptContentResult;
+    let resolveUpload: (result: UploadResult) => void = () => undefined;
+    const uploadPromptContent = vi.fn(
+      () =>
+        new Promise<UploadResult>((resolve) => {
+          resolveUpload = resolve;
+        })
+    );
+    const createSession = vi.fn();
+    const sendInput = vi.fn();
+    setAgentActivityRuntimeForTests({
+      uploadPromptContent,
+      createSession,
+      sendInput
+    } as unknown as AgentActivityRuntime);
+
+    let draftContent = createDraft("");
+    const onDraftContentChange = vi.fn((nextDraft: AgentComposerDraft) => {
+      draftContent = nextDraft;
+    });
+    const onSubmit = vi.fn();
+    const renderComposer = () => (
+      <AgentComposer
+        workspaceId="workspace-1"
+        currentUserId="user-1"
+        provider="codex"
+        draftContent={draftContent}
+        availableCommands={[] satisfies readonly AgentHostAgentSessionCommand[]}
+        disabled={false}
+        submitDisabled={false}
+        placeholder="placeholder"
+        composerSettings={createComposerSettings()}
+        queuedPrompts={[]}
+        drainingQueuedPromptId={null}
+        canQueueWhileBusy={false}
+        showStopButton={false}
+        activePrompt={null}
+        isInterrupting={false}
+        isSendingTurn={false}
+        isSubmittingPrompt={false}
+        labels={createLabels()}
+        workspaceUserProjectI18n={workspaceUserProjectI18n}
+        onDraftContentChange={onDraftContentChange}
+        onSettingsChange={vi.fn()}
+        onSubmit={onSubmit}
+        onSendQueuedPromptNext={vi.fn()}
+        onRemoveQueuedPrompt={vi.fn()}
+        onEditQueuedPrompt={vi.fn()}
+        onInterruptCurrentTurn={vi.fn()}
+        onSubmitInteractivePrompt={vi.fn()}
+      />
+    );
+    const { rerender } = render(renderComposer());
+
+    fireEvent.click(screen.getByTestId("mock-paste-image"));
+    rerender(renderComposer());
+    fireEvent.click(screen.getByRole("button", { name: "发送" }));
+
+    expect(screen.getByRole("button", { name: "发送" })).toBeDisabled();
+    expect(onSubmit).not.toHaveBeenCalled();
+    expect(createSession).not.toHaveBeenCalled();
+    expect(sendInput).not.toHaveBeenCalled();
+
+    resolveUpload({
+      content: [
+        {
+          type: "image",
+          mimeType: "image/png",
+          url: "  https://objects.example.test/signed/screen.png  ",
+          name: "screen.png"
+        }
+      ]
+    });
+    await waitFor(() =>
+      expect(draftContent.images[0]).toMatchObject({
+        url: "https://objects.example.test/signed/screen.png",
+        previewUrl: "data:image/png;base64,aW1hZ2U=",
+        uploading: false
+      })
+    );
+    expect(draftContent.images[0]?.data).toBeUndefined();
+    expect(draftContent.images[0]?.uploadError).toBeUndefined();
+    rerender(renderComposer());
+
+    const sendButton = screen.getByRole("button", { name: "发送" });
+    expect(sendButton).not.toBeDisabled();
+    fireEvent.click(sendButton);
+    expect(onSubmit).toHaveBeenCalledWith([
+      {
+        type: "image",
+        mimeType: "image/png",
+        url: "https://objects.example.test/signed/screen.png",
+        name: "screen.png"
+      }
+    ]);
+  });
+
   it("marks uploaded images without usable references as failed", async () => {
     const uploadPromptContent = vi.fn(async () => ({
       content: [

--- a/packages/agent/gui/agent-gui/agentGuiNode/AgentComposer.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/AgentComposer.tsx
@@ -218,7 +218,6 @@ function reportAgentComposerDiagnostic(
       void Promise.resolve(reportDiagnostic.call(runtime, input)).catch(
         () => {}
       );
-      return;
     }
     if (!runtime || !agentComposerDevConsoleDiagnosticSinkEnabled(runtime)) {
       return;

--- a/packages/agent/gui/agent-gui/agentGuiNode/AgentComposer.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/AgentComposer.tsx
@@ -213,14 +213,40 @@ function reportAgentComposerDiagnostic(
   input: AgentActivityRuntimeDiagnosticInput
 ): void {
   const reportDiagnostic = runtime?.reportDiagnostic;
-  if (!reportDiagnostic) {
-    return;
-  }
   try {
-    void Promise.resolve(reportDiagnostic.call(runtime, input)).catch(() => {});
+    if (reportDiagnostic && runtime) {
+      void Promise.resolve(reportDiagnostic.call(runtime, input)).catch(
+        () => {}
+      );
+      return;
+    }
+    if (!runtime || !agentComposerDevConsoleDiagnosticSinkEnabled(runtime)) {
+      return;
+    }
+    const level = input.level ?? "info";
+    const consoleMethod =
+      level === "error"
+        ? console.error
+        : level === "warn"
+          ? console.warn
+          : level === "debug"
+            ? console.debug
+            : console.info;
+    consoleMethod.call(console, "[agent-gui]", input.event, input);
   } catch {
     // Diagnostics must never affect composer behavior.
   }
+}
+
+function agentComposerDevConsoleDiagnosticSinkEnabled(
+  runtime: AgentActivityRuntime
+): boolean {
+  return (
+    runtime.devDiagnosticConsoleSink !== false &&
+    typeof process !== "undefined" &&
+    (process.env.NODE_ENV === "development" ||
+      process.env.AGENT_GUI_DEV_DIAGNOSTIC_CONSOLE === "1")
+  );
 }
 
 function agentComposerTextByteLength(text: string): number {

--- a/packages/agent/gui/agent-gui/agentGuiNode/AgentComposer.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/AgentComposer.tsx
@@ -156,7 +156,11 @@ import {
 import addLinedIconUrl from "../../app/renderer/assets/icons/add-lined-bold.svg";
 import atLinedIconUrl from "../../app/renderer/assets/icons/@-bold-lined.svg";
 import handoffLinedIconUrl from "../../app/renderer/assets/icons/handoff-lined.svg";
-import { useOptionalAgentActivityRuntime } from "../../agentActivityRuntime";
+import {
+  useOptionalAgentActivityRuntime,
+  type AgentActivityRuntime,
+  type AgentActivityRuntimeDiagnosticInput
+} from "../../agentActivityRuntime";
 import { useOptionalAgentHostApi } from "../../agentActivityHost";
 import type { AgentDroppedFileReferenceResolver } from "./model/agentDroppedFileReferences";
 import { resolvePermissionModeControlsDisabled } from "./model/composerModeSelection";
@@ -203,6 +207,21 @@ const DOCK_COMPOSER_INPUT_PADDING_BLOCK_HEIGHT = 24;
 const AGENT_COMPOSER_PASTED_TEXT_FILE_PREFIX = "pasted-text";
 
 const AGENT_COMPOSER_PASTED_TEXT_MIME = "text/plain";
+
+function reportAgentComposerDiagnostic(
+  runtime: AgentActivityRuntime | null,
+  input: AgentActivityRuntimeDiagnosticInput
+): void {
+  const reportDiagnostic = runtime?.reportDiagnostic;
+  if (!reportDiagnostic) {
+    return;
+  }
+  try {
+    void Promise.resolve(reportDiagnostic.call(runtime, input)).catch(() => {});
+  } catch {
+    // Diagnostics must never affect composer behavior.
+  }
+}
 
 function agentComposerTextByteLength(text: string): number {
   if (typeof TextEncoder !== "undefined") {
@@ -2311,6 +2330,21 @@ export function AgentComposer({
         (agentActivityRuntime.promptContentUploadSupport?.image ?? true)
           ? agentActivityRuntime.uploadPromptContent
           : undefined;
+      reportAgentComposerDiagnostic(agentActivityRuntime, {
+        details: {
+          imageCount: Math.min(images.length, remainingSlots),
+          promptImagesSupported,
+          runtimeAvailable: Boolean(agentActivityRuntime),
+          uploadCapabilityEnabled: canUploadAttachment,
+          uploadFunctionAvailable: Boolean(uploadPromptContent),
+          uploadSupportDeclared:
+            agentActivityRuntime?.promptContentUploadSupport?.image ?? null
+        },
+        event: "agent.gui.composer.image_upload.requested",
+        level: "info",
+        source: "agent-gui",
+        workspaceId
+      });
       const nextImages = images.slice(0, remainingSlots).map((image) => ({
         id: `${Date.now().toString(36)}-${Math.random().toString(36).slice(2)}`,
         name: image.name,
@@ -2347,6 +2381,20 @@ export function AgentComposer({
               (block) => block.type === "image"
             );
             const uploadedUrl = uploadedImage?.url?.trim();
+            reportAgentComposerDiagnostic(agentActivityRuntime, {
+              details: {
+                foundImageBlock: Boolean(uploadedImage),
+                hasAttachmentId: Boolean(uploadedImage?.attachmentId?.trim()),
+                hasData: Boolean(uploadedImage?.data?.trim()),
+                hasPath: Boolean(uploadedImage?.path?.trim()),
+                hasUrl: Boolean(uploadedUrl),
+                imageId: draftImage.id
+              },
+              event: "agent.gui.composer.image_upload.resolved",
+              level: "info",
+              source: "agent-gui",
+              workspaceId
+            });
             if (
               !uploadedImage ||
               (!uploadedUrl &&
@@ -2389,6 +2437,16 @@ export function AgentComposer({
           .catch((error: unknown) => {
             const message =
               error instanceof Error ? error.message : String(error);
+            reportAgentComposerDiagnostic(agentActivityRuntime, {
+              details: {
+                error: message.slice(0, 500),
+                imageId: draftImage.id
+              },
+              event: "agent.gui.composer.image_upload.failed",
+              level: "warn",
+              source: "agent-gui",
+              workspaceId
+            });
             const failedDraftImages = draftImagesRef.current.map((image) =>
               image.id === draftImage.id
                 ? {
@@ -3390,6 +3448,67 @@ export function AgentComposer({
         ? "loading"
         : "send";
   const sendButtonBusy = isSendingTurn && !isQueueMode;
+  const sendDisabledReasons = [
+    isSelectedProjectMissing ? "project_missing" : null,
+    submitDisabled ? "submit_disabled" : null,
+    !hasDraftContent ? "draft_empty" : null,
+    hasUploadingDraftImages ? "image_uploading" : null,
+    hasFailedDraftImages ? "image_upload_failed" : null,
+    hasUploadingDraftFiles ? "file_uploading" : null,
+    hasFailedDraftFiles ? "file_upload_failed" : null,
+    hasUploadingDraftLargeTexts ? "large_text_uploading" : null,
+    hasFailedDraftLargeTexts ? "large_text_upload_failed" : null,
+    sendButtonBusy ? "send_busy" : null
+  ].filter((reason): reason is string => reason !== null);
+  const sendDisabledReasonKey = sendDisabledReasons.join(",");
+  useEffect(() => {
+    reportAgentComposerDiagnostic(agentActivityRuntime, {
+      details: {
+        canUploadAttachment,
+        draftFileCount: draftFiles.length,
+        draftImageCount: draftImages.length,
+        draftLargeTextCount: draftLargeTexts.length,
+        hasDraftContent,
+        hasFailedDraftFiles,
+        hasFailedDraftImages,
+        hasFailedDraftLargeTexts,
+        hasUploadingDraftFiles,
+        hasUploadingDraftImages,
+        hasUploadingDraftLargeTexts,
+        isSelectedProjectMissing,
+        promptImagesSupported,
+        sendButtonBusy,
+        sendDisabledReason: sendDisabledReasonKey || null,
+        submitDisabled,
+        uploadFunctionAvailable: Boolean(
+          agentActivityRuntime?.uploadPromptContent
+        )
+      },
+      event: "agent.gui.composer.submit_state_changed",
+      level: "info",
+      source: "agent-gui",
+      workspaceId
+    });
+  }, [
+    agentActivityRuntime,
+    canUploadAttachment,
+    draftFiles.length,
+    draftImages.length,
+    draftLargeTexts.length,
+    hasDraftContent,
+    hasFailedDraftFiles,
+    hasFailedDraftImages,
+    hasFailedDraftLargeTexts,
+    hasUploadingDraftFiles,
+    hasUploadingDraftImages,
+    hasUploadingDraftLargeTexts,
+    isSelectedProjectMissing,
+    promptImagesSupported,
+    sendButtonBusy,
+    sendDisabledReasonKey,
+    submitDisabled,
+    workspaceId
+  ]);
   const activePromptRequestId = activePrompt?.requestId ?? null;
   const [dismissedPromptRequestId, setDismissedPromptRequestId] = useState<
     string | null
@@ -3463,6 +3582,7 @@ export function AgentComposer({
       type="submit"
       className={styles.composerSendButton}
       data-state={sendButtonState}
+      data-disabled-reason={sendDisabledReasonKey || undefined}
       disabled={
         isSelectedProjectMissing ||
         submitDisabled ||

--- a/packages/agent/gui/agent-gui/agentGuiNode/AgentComposer.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/AgentComposer.tsx
@@ -2346,9 +2346,11 @@ export function AgentComposer({
             const uploadedImage = result.content.find(
               (block) => block.type === "image"
             );
+            const uploadedUrl = uploadedImage?.url?.trim();
             if (
               !uploadedImage ||
-              (!uploadedImage.attachmentId &&
+              (!uploadedUrl &&
+                !uploadedImage.attachmentId &&
                 !uploadedImage.path &&
                 !uploadedImage.data)
             ) {
@@ -2365,7 +2367,11 @@ export function AgentComposer({
                     ...(uploadedImage.attachmentId
                       ? { attachmentId: uploadedImage.attachmentId }
                       : {}),
-                    ...(uploadedImage.data ? { data: uploadedImage.data } : {}),
+                    ...(uploadedUrl
+                      ? { url: uploadedUrl }
+                      : uploadedImage.data
+                        ? { data: uploadedImage.data }
+                        : {}),
                     ...(uploadedImage.path ? { path: uploadedImage.path } : {}),
                     previewUrl: image.previewUrl,
                     uploading: false

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUINodeController.spec.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUINodeController.spec.tsx
@@ -19210,6 +19210,104 @@ describe("useAgentGUINodeController", () => {
     expect(result.current.viewModel.draftContent.images).toEqual([]);
   });
 
+  it("keeps a URL image draft changed while prompt submission settles", async () => {
+    const submittedUrl = "https://objects.example.test/signed/panel-a.png";
+    const changedUrl = "https://objects.example.test/signed/panel-b.png";
+    const imagePromptContent: AgentPromptContentBlock[] = [
+      { type: "text", text: "describe this" },
+      {
+        type: "image",
+        mimeType: "image/png",
+        url: submittedUrl,
+        name: "panel.png"
+      }
+    ];
+    let resolveExec:
+      | ((result: {
+          accepted: boolean;
+          agentSessionId: string;
+          turnId: string;
+          sessionStatus: string;
+        }) => void)
+      | undefined;
+    const exec = vi.fn(
+      () =>
+        new Promise<{
+          accepted: boolean;
+          agentSessionId: string;
+          turnId: string;
+          sessionStatus: string;
+        }>((resolve) => {
+          resolveExec = resolve;
+        })
+    );
+    installAgentHostApi({
+      list: vi.fn(async () => snapshotWithSession("session-1")),
+      listSessionTimeline: vi.fn(async () => ({ timelineItems: [] })),
+      subscribeEvents: vi.fn(() => vi.fn()),
+      getComposerOptions: vi.fn(async () => imageCapableComposerOptions()),
+      exec
+    });
+
+    const { result } = renderHook(() =>
+      useAgentGUINodeController({
+        workspaceId: "room-1",
+        currentUserId: "user-1",
+        workspacePath: "/workspace",
+        avoidGroupingEdits: false,
+        data: agentGuiData("session-1"),
+        onDataChange: vi.fn()
+      })
+    );
+
+    await waitFor(() => {
+      expect(result.current.viewModel.activeConversationId).toBe("session-1");
+    });
+
+    const imageDraft = (url: string) => ({
+      prompt: "describe this",
+      images: [
+        {
+          id: "draft-image-1",
+          name: "panel.png",
+          mimeType: "image/png" as const,
+          url,
+          previewUrl: "data:image/png;base64,aW1hZ2U="
+        }
+      ]
+    });
+
+    act(() => {
+      result.current.actions.updateDraftContent(imageDraft(submittedUrl));
+      result.current.actions.submitPrompt(imagePromptContent);
+    });
+
+    await waitFor(() => {
+      expect(exec).toHaveBeenCalledWith({
+        workspaceId: "room-1",
+        agentSessionId: "session-1",
+        content: imagePromptContent
+      });
+    });
+
+    act(() => {
+      result.current.actions.updateDraftContent(imageDraft(changedUrl));
+      resolveExec?.({
+        accepted: true,
+        agentSessionId: "session-1",
+        turnId: "turn-1",
+        sessionStatus: "working"
+      });
+    });
+
+    await waitFor(() => {
+      expect(result.current.viewModel.isSubmitting).toBe(false);
+    });
+    expect(result.current.viewModel.draftContent.images).toEqual([
+      expect.objectContaining({ url: changedUrl })
+    ]);
+  });
+
   it("edits a local queued prompt back into the draft", async () => {
     installAgentHostApi({
       list: vi.fn(async () => snapshotWithWaitingSession("session-1")),

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUINodeController.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUINodeController.ts
@@ -828,12 +828,19 @@ function reportAgentGUIRenderStateDiagnostic(input: {
   activeRuntimeSession: AgentActivitySession | null;
   activeSessionState: AgentSessionState | null;
   activeSubmitBlocked: boolean;
+  activeConversationResumeUnavailable: boolean;
   canQueueWhileBusy: boolean;
   canSubmit: boolean;
   conversation: AgentConversationVM | null;
   isCreatingConversation: boolean;
   isLoadingMessages: boolean;
+  isInterrupting: boolean;
   isSubmitting: boolean;
+  providerTargetsLoading: boolean;
+  selectedProviderTargetDisabled: boolean;
+  selectedProviderTargetId: string | null;
+  selectedProviderTargetIsExplicit: boolean;
+  sessionAuthBlocked: boolean;
   pendingApproval: AgentGUIApprovalRequest | null;
   pendingInteractivePrompt: AgentGUIInteractivePrompt | null;
   runtime: AgentActivityRuntime;
@@ -848,18 +855,26 @@ function reportAgentGUIRenderStateDiagnostic(input: {
       activeHasPendingSubmittedTurn: input.activeHasPendingSubmittedTurn,
       activeLiveState: input.activeLiveState,
       activeSubmitBlocked: input.activeSubmitBlocked,
+      activeConversationResumeUnavailable:
+        input.activeConversationResumeUnavailable,
       canQueueWhileBusy: input.canQueueWhileBusy,
       canSubmit: input.canSubmit,
       conversation: agentGUIConversationDiagnosticDetails(input.conversation),
       isCreatingConversation: input.isCreatingConversation,
+      isInterrupting: input.isInterrupting,
       isLoadingMessages: input.isLoadingMessages,
       isSubmitting: input.isSubmitting,
+      providerTargetsLoading: input.providerTargetsLoading,
       pendingApprovalRequestId: input.pendingApproval?.requestId ?? null,
       pendingInteractivePromptKind:
         input.pendingInteractivePrompt?.kind ?? null,
       pendingInteractivePromptRequestId: promptRequestId(
         input.pendingInteractivePrompt
       ),
+      selectedProviderTargetDisabled: input.selectedProviderTargetDisabled,
+      selectedProviderTargetId: input.selectedProviderTargetId,
+      selectedProviderTargetIsExplicit: input.selectedProviderTargetIsExplicit,
+      sessionAuthBlocked: input.sessionAuthBlocked,
       runtimeSession: agentGUIRuntimeSessionDiagnosticDetails(
         input.activeRuntimeSession
       ),
@@ -4064,6 +4079,9 @@ export function useAgentGUINodeController({
   );
   const effectiveSelectedProviderTarget =
     homeComposerTargetOverride ?? selectedProviderTarget;
+  const effectiveSelectedProviderTargetIsExplicit = homeComposerTargetOverride
+    ? homeComposerTargetOverrideIsExplicit
+    : selectedProviderTargetIsExplicit;
   const firstReadyHomeComposerProviderTarget = useMemo(() => {
     if (!providerReadinessGates) {
       return null;
@@ -4664,13 +4682,10 @@ export function useAgentGUINodeController({
   const selectedProviderTargetRef = useRef(effectiveSelectedProviderTarget);
   selectedProviderTargetRef.current = effectiveSelectedProviderTarget;
   const selectedProviderTargetIsExplicitRef = useRef(
-    homeComposerTargetOverride
-      ? homeComposerTargetOverrideIsExplicit
-      : selectedProviderTargetIsExplicit
+    effectiveSelectedProviderTargetIsExplicit
   );
-  selectedProviderTargetIsExplicitRef.current = homeComposerTargetOverride
-    ? homeComposerTargetOverrideIsExplicit
-    : selectedProviderTargetIsExplicit;
+  selectedProviderTargetIsExplicitRef.current =
+    effectiveSelectedProviderTargetIsExplicit;
   const providerTargetsProvidedRef = useRef(providerTargets !== undefined);
   providerTargetsProvidedRef.current = providerTargets !== undefined;
   const selectedComposerTargetDataRef = useRef(selectedComposerTargetData);
@@ -11788,9 +11803,7 @@ export function useAgentGUINodeController({
     !activeConversationResumeUnavailable &&
     (activeConversationId !== null ||
       (effectiveSelectedProviderTarget.disabled !== true &&
-        (homeComposerTargetOverride
-          ? homeComposerTargetOverrideIsExplicit
-          : selectedProviderTargetIsExplicit))) &&
+        effectiveSelectedProviderTargetIsExplicit)) &&
     (composerTargetData.provider !== "openclaw" ||
       openclawGateway?.status === "ready") &&
     pendingApproval === null &&
@@ -11855,15 +11868,25 @@ export function useAgentGUINodeController({
       activeRuntimeSession,
       activeSessionState,
       activeSubmitBlocked,
+      activeConversationResumeUnavailable,
       canQueueWhileBusy,
       canSubmit,
       conversation,
       isCreatingConversation,
+      isInterrupting,
       isLoadingMessages,
       isSubmitting,
       pendingApproval,
       pendingInteractivePrompt,
+      providerTargetsLoading,
       runtime: agentActivityRuntime,
+      selectedProviderTargetDisabled:
+        effectiveSelectedProviderTarget.disabled === true,
+      selectedProviderTargetId:
+        effectiveSelectedProviderTarget.agentTargetId ?? null,
+      selectedProviderTargetIsExplicit:
+        effectiveSelectedProviderTargetIsExplicit,
+      sessionAuthBlocked: sessionChrome.auth !== null,
       workspaceId
     });
   }, [
@@ -11876,16 +11899,22 @@ export function useAgentGUINodeController({
     activeRuntimeSession,
     activeSessionState,
     activeSubmitBlocked,
+    activeConversationResumeUnavailable,
     agentActivityRuntime,
     canQueueWhileBusy,
     canSubmit,
     conversation,
+    effectiveSelectedProviderTarget.agentTargetId,
+    effectiveSelectedProviderTarget.disabled,
+    effectiveSelectedProviderTargetIsExplicit,
     isCreatingConversation,
+    isInterrupting,
     isLoadingMessages,
     isSubmitting,
     pendingApproval,
     pendingInteractivePrompt,
     providerTargetsLoading,
+    sessionChrome.auth,
     workspaceId
   ]);
   const activeSessionReasoningSelection = useMemo(

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUINodeController.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUINodeController.ts
@@ -1191,7 +1191,7 @@ function toRuntimeSendContent(
   });
 }
 
-function shouldClearSubmittedDraft(input: {
+function promptSubmissionMatchesCurrentDraft(input: {
   currentDraft: AgentComposerDraft | undefined;
   submittedContent: readonly AgentPromptContentBlock[];
 }): boolean {
@@ -1223,11 +1223,14 @@ function shouldClearSubmittedDraft(input: {
     const submittedPath = submittedImage.path?.trim() ?? "";
     const draftData = image.data?.trim() ?? "";
     const submittedData = submittedImage.data?.trim() ?? "";
+    const draftUrl = image.url?.trim() ?? "";
+    const submittedUrl = submittedImage.url?.trim() ?? "";
     const draftName = image.name.trim();
     const submittedName = submittedImage.name?.trim() ?? "";
     return (
       draftPath === submittedPath &&
       draftData === submittedData &&
+      draftUrl === submittedUrl &&
       draftName === submittedName
     );
   });
@@ -3393,6 +3396,7 @@ function areAgentComposerDraftsEqual(
         image.name === other.name &&
         image.mimeType === other.mimeType &&
         image.data === other.data &&
+        image.url === other.url &&
         image.path === other.path &&
         image.previewUrl === other.previewUrl &&
         image.uploading === other.uploading &&
@@ -8855,7 +8859,7 @@ export function useAgentGUINodeController({
           setDraftBySessionId((current) => {
             const currentDraft = current[agentSessionId];
             if (
-              !shouldClearSubmittedDraft({
+              !promptSubmissionMatchesCurrentDraft({
                 currentDraft,
                 submittedContent: normalizedContent
               })

--- a/packages/agent/gui/shared/agentConversation/components/AgentMessageBlock.tsx
+++ b/packages/agent/gui/shared/agentConversation/components/AgentMessageBlock.tsx
@@ -347,7 +347,7 @@ function AgentUserImageGrid({
       }}
     >
       {images.map((image) => {
-        const src = loadedImages.get(image.id) ?? imageDataUrl(image);
+        const src = loadedImages.get(image.id) ?? imageSource(image);
         const loading = !src && loadingIds.has(image.id);
         return (
           <div key={image.id} className={styles.userImageThumbnail}>
@@ -391,7 +391,7 @@ function useAgentMessageImageSources(images: readonly AgentMessageImageVM[]): {
     () =>
       images.filter(
         (image) =>
-          !imageDataUrl(image) &&
+          !imageSource(image) &&
           !sources.has(image.id) &&
           image.workspaceId &&
           image.agentSessionId &&
@@ -473,7 +473,22 @@ function useAgentMessageImageSources(images: readonly AgentMessageImageVM[]): {
   return { loadingIds, sources };
 }
 
-function imageDataUrl(image: AgentMessageImageVM): string | null {
+function imageSource(image: AgentMessageImageVM): string | null {
+  const remoteUrl = image.url?.trim() ?? "";
+  if (remoteUrl) {
+    try {
+      const parsed = new URL(remoteUrl);
+      if (
+        parsed.protocol === "https:" &&
+        !parsed.username &&
+        !parsed.password
+      ) {
+        return parsed.toString();
+      }
+    } catch {
+      return null;
+    }
+  }
   const data = image.data?.trim() ?? "";
   const mimeType = image.mimeType.trim();
   if (!data || !mimeType) {

--- a/packages/agent/gui/shared/agentConversation/components/AgentTranscriptItemView.spec.tsx
+++ b/packages/agent/gui/shared/agentConversation/components/AgentTranscriptItemView.spec.tsx
@@ -318,6 +318,50 @@ describe("AgentTranscriptItemView render stability", () => {
     delete (window as { agentActivityRuntime?: unknown }).agentActivityRuntime;
   });
 
+  it("renders a user prompt image directly from its remote HTTPS URL", () => {
+    const readPromptAsset = vi.fn();
+    Object.defineProperty(window, "agentActivityRuntime", {
+      configurable: true,
+      value: {
+        readPromptAsset
+      } as Partial<AgentActivityRuntime>
+    });
+
+    render(
+      <AgentMessageBlock
+        workspaceRoot="/workspace/demo"
+        basePath="/workspace/demo"
+        row={userMessageRow({
+          kind: "message-content",
+          id: "user-images-url-1",
+          turnId: "turn-1",
+          body: "",
+          contentKind: "image-grid",
+          images: [
+            {
+              id: "remote-image-1",
+              workspaceId: "room-1",
+              agentSessionId: "session-1",
+              mimeType: "image/png",
+              name: "screen.png",
+              url: "https://objects.example.test/signed/screen.png"
+            }
+          ],
+          occurredAtUnixMs: 1
+        })}
+        thinkingLabel="Thought process"
+      />
+    );
+
+    expect(screen.getByRole("img", { name: "screen.png" })).toHaveAttribute(
+      "src",
+      "https://objects.example.test/signed/screen.png"
+    );
+    expect(readPromptAsset).not.toHaveBeenCalled();
+
+    delete (window as { agentActivityRuntime?: unknown }).agentActivityRuntime;
+  });
+
   it("shows a loading spinner while a user prompt image is being read", async () => {
     const readController: {
       resolve: (value: {

--- a/packages/agent/gui/shared/agentConversation/contracts/agentMessageRowVM.ts
+++ b/packages/agent/gui/shared/agentConversation/contracts/agentMessageRowVM.ts
@@ -37,6 +37,7 @@ export interface AgentMessageImageVM {
   mimeType: string;
   name?: string | null;
   data?: string | null;
+  url?: string | null;
   path?: string | null;
 }
 

--- a/packages/agent/gui/shared/agentConversation/projection/agentConversationProjection.spec.ts
+++ b/packages/agent/gui/shared/agentConversation/projection/agentConversationProjection.spec.ts
@@ -1197,6 +1197,7 @@ describe("projectAgentConversationVM", () => {
                           type: "image",
                           mimeType: "image/png",
                           attachmentId: "attachment-1",
+                          url: "https://objects.example.test/signed/screen.png",
                           name: "screen.png"
                         }
                       ]
@@ -1233,6 +1234,7 @@ describe("projectAgentConversationVM", () => {
       workspaceId: "room-1",
       agentSessionId: "session-1",
       attachmentId: "attachment-1",
+      url: "https://objects.example.test/signed/screen.png",
       mimeType: "image/png",
       name: "screen.png"
     });

--- a/packages/agent/gui/shared/agentConversation/projection/agentConversationProjection.ts
+++ b/packages/agent/gui/shared/agentConversation/projection/agentConversationProjection.ts
@@ -682,6 +682,7 @@ function projectUserMessageContentParts(
         mimeType: image.mimeType,
         name: image.name,
         data: image.data,
+        url: image.url,
         path: image.path
       })),
       occurredAtUnixMs: message.occurredAtUnixMs ?? null,
@@ -737,6 +738,7 @@ interface UserPromptImageBlock {
   mimeType: string;
   name?: string | null;
   data?: string | null;
+  url?: string | null;
   path?: string | null;
 }
 
@@ -805,6 +807,10 @@ function userPromptContentBlocks(
         data:
           typeof block.data === "string" && block.data.trim()
             ? block.data.trim()
+            : null,
+        url:
+          typeof block.url === "string" && block.url.trim()
+            ? block.url.trim()
             : null,
         path:
           typeof block.path === "string" && block.path.trim()


### PR DESCRIPTION
## Summary

- accept HTTPS URL-only image results from `uploadPromptContent`, retain `previewUrl` for local preview, and submit the returned URL instead of the original base64 payload
- reconcile submitted drafts using normalized image URLs so URL-only images cannot match or clear the wrong draft
- materialize remote HTTPS images only at the final Codex app-server, standard ACP, and Claude SDK provider boundaries
- preserve remote image URLs in activity projection and render them in the user-message timeline
- expose upload/send blocker diagnostics and mirror them to the development console even when the host supplies a diagnostic reporter
- document the AgentGUI upload handoff, provider-boundary conversion, and activity-rendering invariants

## Verification

- `pnpm --filter @tutti-os/agent-gui test` — 126 files, 2222 tests passed
- `pnpm --filter @tutti-os/agent-gui typecheck`
- focused Oxlint for the changed AgentComposer files
- `pnpm check:agent-activity-runtime-boundaries`
- `go test ./...`, `go build ./...`, and `go vet ./...` in `packages/agent/daemon`
- focused projection/transcript and provider image-materialization tests
- built `@tutti-os/agent-gui` and temporarily replaced only the original TSH pnpm virtual-store package's `dist`, preserving dependency adjacency
- TSH Electron/Vite production bundle — 6993 modules transformed, preload verification passed, and no `Could not resolve` errors
- TSH shared-runtime focused tests and local `desktopd` build against the Tutti daemon module
- real TSH shared-Agent GUI manual verification passed for URL-only upload, send enablement, provider delivery, and image display

`pnpm check:full` could not enter its checks locally because the preparation runner cannot spawn the unavailable `corepack` binary (`spawn corepack ENOENT`). The changed-surface checks above were run directly with `pnpm`; CI is running the full repository checks.

## Documentation impact

- updated `docs/architecture/agent-gui-node.md` for the durable upload, provider-boundary, rendering, and diagnostic behavior
- no README/CONTRIBUTING language updates were needed

## Checklist

- [x] Change is focused on AgentGUI remote image handling.
- [x] Durable architecture documentation is updated.
- [x] Relevant TypeScript, Go, runtime-boundary, cross-repository bundle, and manual checks passed.
- [x] Commits include DCO sign-off.
