### PR TITLE
docs(agent): remove obsolete Nexight provider guidance

### DIFF
--- a/services/tuttid/service/workspace/agent_workspace_app_reference/SKILL.md
+++ b/services/tuttid/service/workspace/agent_workspace_app_reference/SKILL.md
@@ -57,7 +57,7 @@ Keep Tutti-hosted and standalone behavior behind the kit's fixed auto facade whi
 1. Pin an exact kit version that exports the auto catalog/composer/skill facade and managed header context helper.
 2. Call `loadTuttiAgentProviderCatalog({ runtime })`; do not pass mode or inspect `TUTTI_CLI`.
 3. Load composer options lazily for one canonical provider and expose only app/domain DTO projections.
-4. Persist canonical provider IDs; migrate legacy `claude` once to `claude-code`, but keep `nexight` and `tutti-agent` distinct.
+4. Persist only canonical provider IDs returned by the facade. Migrate legacy `claude` once to `claude-code`. Treat persisted `nexight` as stale state and select an available catalog provider; never map it to or register it alongside `tutti-agent`.
 5. Await `createManagedAgentRunContextFromHeaders(...)` directly. Do not pre-read credentials or pre-check provider support in app code.
 6. Without a managed header, use an app-owned local cwd. Pass the same canonical provider ID, selected cwd, and optional `managedAgentInvocation` into runtime execution.
 7. Delete raw Agent HTTP/CLI clients, browser credential fallbacks, request-body credential fields, alias maps, and dependency patch scripts.

--- a/services/tuttid/service/workspace/agent_workspace_app_reference/references/dynamic-agent-providers.md
+++ b/services/tuttid/service/workspace/agent_workspace_app_reference/references/dynamic-agent-providers.md
@@ -14,7 +14,7 @@ Tutti CLI owns platform capability and enabled Agent Target visibility
 
 An app must not call workspace-app Agent catalog HTTP routes, build daemon URLs, read an Agent catalog bearer token, pass an app ID to provider discovery, spawn `TUTTI_CLI`, parse CLI JSON, or maintain provider ID mappings. The kit does all of that.
 
-Provider IDs are an open string set. Persist and return the canonical `providerId` supplied by the kit. Do not define a closed `"codex" | "claude-code"` union. The SDK accepts the legacy input `claude` internally and emits `claude-code`; it does not map `nexight`, `tutti`, or `tutti-agent` to each other.
+Provider IDs are an open string set. Persist and return the canonical `providerId` supplied by the kit. Do not define a closed `"codex" | "claude-code"` union. The SDK accepts the legacy input `claude` internally and emits `claude-code`. `tutti-agent` is the canonical Tutti Agent provider ID; Apps must not register, synthesize, or preserve a `nexight` provider.
 
 ## Runtime registration
 
@@ -92,7 +92,7 @@ Do not eagerly load composer options for every provider. A failure belongs to th
 
 ## Persistence and host bridge
 
-Persist the canonical catalog ID. A one-time migration may rewrite `claude` to `claude-code`. Do not migrate `nexight` and `tutti-agent` into each other.
+Persist the canonical catalog ID. A one-time migration may rewrite `claude` to `claude-code`. If persisted legacy state contains `nexight`, treat it as unavailable and select an available catalog provider; never rewrite it to `tutti-agent` or synthesize a compatibility provider.
 
 When invoking a host feature such as:
 
@@ -135,7 +135,7 @@ Add app tests that verify:
 - the app calls the kit facade and does not implement raw CLI/HTTP protocol handling;
 - every facade provider is projected and unavailable providers remain visible but disabled;
 - canonical IDs round-trip through endpoint, persistence, UI selection, host bridge, and runtime input;
-- legacy persisted `claude` migrates once to `claude-code`, while `nexight` and `tutti-agent` remain distinct;
+- legacy persisted `claude` migrates once to `claude-code`, while stale `nexight` state is rejected without synthesizing or aliasing a provider;
 - composer loading is lazy and one-provider failure is isolated;
 - App execution omits `permission` and relies on the kit's full-access Workspace App default;
 - no `mode`, app ID, Agent catalog token, alias helper, or dependency patch script is present.

--- a/services/tuttid/service/workspace/app_factory_test.go
+++ b/services/tuttid/service/workspace/app_factory_test.go
@@ -398,6 +398,8 @@ func TestAppFactoryServiceCreateUsesDraftDirAndReferenceContext(t *testing.T) {
 		"kit_runtime_unavailable",
 		"@tutti-os/agent-acp-kit/tutti/contracts",
 		"claude` to `claude-code",
+		"`tutti-agent` is the canonical Tutti Agent provider ID",
+		"stale `nexight` state is rejected",
 	} {
 		if !strings.Contains(dynamicProviderReference, want) {
 			t.Fatalf("dynamic provider reference missing %q:\n%s", want, dynamicProviderReference)
@@ -410,6 +412,7 @@ func TestAppFactoryServiceCreateUsesDraftDirAndReferenceContext(t *testing.T) {
 		"agent-providers/status",
 		"TUTTI_APP_SERVER_TOKEN",
 		"nexight: \"tutti-agent\"",
+		"`nexight` and `tutti-agent` remain distinct",
 	} {
 		if strings.Contains(dynamicProviderReference, forbidden) {
 			t.Fatalf("dynamic provider reference contains obsolete guidance %q:\n%s", forbidden, dynamicProviderReference)


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Removed obsolete Nexight guidance and clarified canonical provider IDs in the Agent docs. Updated tests to assert `tutti-agent` is canonical and `nexight` is stale with no aliasing.

- **Migration**
  - Migrate `claude` to `claude-code` once, then persist the canonical ID.
  - If legacy state contains `nexight`, drop it and select an available catalog provider; do not alias to `tutti-agent`.

<sup>Written for commit 72bd33d3a115ccfcf5f60d064857b52fee8535b8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tutti-os/tutti/pull/1055?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

