### PR TITLE
feat(agent): backport Claude export conversation import

### DIFF
--- a/apps/desktop/src/main/host/desktopFileDialogAccess.test.ts
+++ b/apps/desktop/src/main/host/desktopFileDialogAccess.test.ts
@@ -52,7 +52,7 @@ test("desktop file dialog access selects app archive zip files", async () => {
     NonNullable<DesktopFileDialogAccessDependencies["showOpenDialog"]>
   >[] = [];
   const dialogAccess = createDesktopFileDialogAccess({
-    getLocale: () => "en",
+    getLocale: () => "zh-CN",
     showOpenDialog: async (...args) => {
       calls.push(args);
       return {
@@ -66,7 +66,12 @@ test("desktop file dialog access selects app archive zip files", async () => {
 
   assert.equal(selectedPath, "/tmp/app.zip");
   assert.deepEqual(calls[0]?.[1], {
-    filters: [{ extensions: ["zip"], name: "Zip Archive" }],
+    filters: [
+      {
+        extensions: ["zip"],
+        name: createTranslator("zh-CN").t("common.zipArchive")
+      }
+    ],
     properties: ["openFile"]
   });
 });
@@ -92,7 +97,12 @@ test("desktop file dialog access selects app archive export path", async () => {
   assert.equal(selectedPath, "/tmp/export.zip");
   assert.deepEqual(calls[0]?.[1], {
     defaultPath: "sample.zip",
-    filters: [{ extensions: ["zip"], name: "Zip Archive" }]
+    filters: [
+      {
+        extensions: ["zip"],
+        name: createTranslator("en").t("common.zipArchive")
+      }
+    ]
   });
 });
 

--- a/apps/desktop/src/main/host/desktopFileDialogAccess.ts
+++ b/apps/desktop/src/main/host/desktopFileDialogAccess.ts
@@ -54,8 +54,14 @@ export function createDesktopFileDialogAccess(
 
   return {
     async selectAppArchive(ownerWindow) {
+      const translator = createTranslator(deps.getLocale());
       const selection = await showOpenDialog(ownerWindow, {
-        filters: [{ extensions: ["zip"], name: "Zip Archive" }],
+        filters: [
+          {
+            extensions: ["zip"],
+            name: translator.t("common.zipArchive")
+          }
+        ],
         properties: ["openFile"]
       });
 
@@ -67,9 +73,15 @@ export function createDesktopFileDialogAccess(
     },
 
     async selectAppArchiveExportPath(defaultPath, ownerWindow) {
+      const translator = createTranslator(deps.getLocale());
       const selection = await showSaveDialog(ownerWindow, {
         defaultPath,
-        filters: [{ extensions: ["zip"], name: "Zip Archive" }]
+        filters: [
+          {
+            extensions: ["zip"],
+            name: translator.t("common.zipArchive")
+          }
+        ]
       });
 
       if (selection.canceled || !selection.filePath) {

--- a/apps/desktop/src/renderer/src/features/workspace-agent/services/createDesktopAgentActivityRuntime.test.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-agent/services/createDesktopAgentActivityRuntime.test.ts
@@ -210,6 +210,7 @@ function createWorkspaceAgentActivityService(): IWorkspaceAgentActivityService {
     importExternalSessions: async () => {
       throw new Error("not implemented");
     },
+    selectExternalSessionImportArchive: async () => null,
     load: async () => {
       throw new Error("not implemented");
     },

--- a/apps/desktop/src/renderer/src/features/workspace-agent/services/createDesktopAgentGUIWorkbenchHostInput.test.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-agent/services/createDesktopAgentGUIWorkbenchHostInput.test.ts
@@ -2121,6 +2121,9 @@ function createWorkspaceAgentActivityService(
     async importExternalSessions() {
       throw new Error("not implemented");
     },
+    async selectExternalSessionImportArchive() {
+      return null;
+    },
     async load(inputWorkspaceId) {
       return { ...snapshot, workspaceId: inputWorkspaceId };
     },

--- a/apps/desktop/src/renderer/src/features/workspace-agent/services/internal/workspaceAgentActivityService.test.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-agent/services/internal/workspaceAgentActivityService.test.ts
@@ -309,15 +309,106 @@ test("WorkspaceAgentActivityService.importExternalSessions refreshes sessions an
   });
 
   const result = await service.importExternalSessions("ws-1", {
+    archivePath: "/tmp/claude-export.zip",
     projects: [{ path: "/repo" }]
   });
 
   assert.deepEqual(importCalls, [
-    { workspaceId: "ws-1", request: { projects: [{ path: "/repo" }] } }
+    {
+      workspaceId: "ws-1",
+      request: {
+        archivePath: "/tmp/claude-export.zip",
+        projects: [{ path: "/repo" }]
+      }
+    }
   ]);
   assert.equal(result.importedMessages, 2);
   assert.equal(listCalls, 1);
   assert.equal(projectRefreshCalls, 1);
+});
+
+test("WorkspaceAgentActivityService selects, scans, and imports the same Claude export archive", async () => {
+  const scanCalls: unknown[] = [];
+  const importCalls: unknown[] = [];
+  const service = new WorkspaceAgentActivityService({
+    hostFilesApi: {
+      async createUserDocumentsProjectDirectory() {
+        return { path: "/tmp/project" };
+      },
+      async selectAppArchive() {
+        return "/tmp/claude-export.zip";
+      }
+    } as never,
+    tuttidClient: {
+      scanWorkspaceExternalAgentSessionImports: async (
+        workspaceId: string,
+        request: Parameters<
+          TuttidClient["scanWorkspaceExternalAgentSessionImports"]
+        >[1]
+      ) => {
+        scanCalls.push({ workspaceId, request });
+        return {
+          errors: [],
+          projects: [],
+          providers: [],
+          scannedMessages: 0,
+          scannedSessions: 0,
+          sessions: [],
+          skippedSessions: 0
+        };
+      },
+      importWorkspaceExternalAgentSessions: async (
+        workspaceId: string,
+        request: Parameters<
+          TuttidClient["importWorkspaceExternalAgentSessions"]
+        >[1]
+      ) => {
+        importCalls.push({ workspaceId, request });
+        return {
+          errors: [],
+          importedMessages: 0,
+          importedProjects: 0,
+          importedSessions: 0,
+          skippedSessions: 0
+        };
+      },
+      listWorkspaceAgentSessions: async () => ({
+        hasMore: false,
+        sessions: [],
+        workspaceId: "ws-1"
+      })
+    } as unknown as TuttidClient,
+    runtimeApi: {
+      logTerminalDiagnostic: async () => {}
+    }
+  });
+
+  const archivePath = await service.selectExternalSessionImportArchive();
+  assert.equal(archivePath, "/tmp/claude-export.zip");
+  assert.ok(archivePath);
+  await service.scanExternalSessionImports("ws-1", {
+    archivePath,
+    days: -1
+  });
+  await service.importExternalSessions("ws-1", {
+    archivePath,
+    projects: [{ path: "/Users/demo", sessionIds: ["session-1"] }]
+  });
+  assert.deepEqual(scanCalls, [
+    {
+      workspaceId: "ws-1",
+      request: { archivePath: "/tmp/claude-export.zip", days: -1 }
+    }
+  ]);
+  assert.deepEqual(importCalls, [
+    {
+      workspaceId: "ws-1",
+      request: {
+        archivePath: "/tmp/claude-export.zip",
+        projects: [{ path: "/Users/demo", sessionIds: ["session-1"] }]
+      }
+    }
+  ]);
 });
 
 test("WorkspaceAgentActivityService fetches combined reconcile state after messages", async () => {

--- a/apps/desktop/src/renderer/src/features/workspace-agent/services/internal/workspaceAgentActivityService.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-agent/services/internal/workspaceAgentActivityService.ts
@@ -50,7 +50,7 @@ export interface WorkspaceAgentActivityServiceDependencies {
   eventStreamClient?: TuttidEventStreamClient;
   hostFilesApi?: Pick<
     DesktopHostFilesApi,
-    "createUserDocumentsProjectDirectory"
+    "createUserDocumentsProjectDirectory" | "selectAppArchive"
   >;
   tuttidClient: TuttidClient;
   runtimeApi: Pick<DesktopRuntimeApi, "logTerminalDiagnostic">;
@@ -333,6 +333,10 @@ export class WorkspaceAgentActivityService implements IWorkspaceAgentActivitySer
       this.dependencies.workspaceUserProjectService?.refresh()
     ]);
     return result;
+  }
+
+  async selectExternalSessionImportArchive(): Promise<string | null> {
+    return (await this.dependencies.hostFilesApi?.selectAppArchive()) ?? null;
   }
 
   async setSessionPinned(input: {

--- a/apps/desktop/src/renderer/src/features/workspace-agent/services/registerWorkspaceAgentServices.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-agent/services/registerWorkspaceAgentServices.ts
@@ -22,7 +22,7 @@ export interface WorkspaceAgentServiceRegistrationInput {
   eventStreamClient?: TuttidEventStreamClient;
   hostFilesApi: Pick<
     DesktopHostFilesApi,
-    "createUserDocumentsProjectDirectory"
+    "createUserDocumentsProjectDirectory" | "selectAppArchive"
   >;
   tuttidClient: TuttidClient;
   reporterService?: Pick<IReporterService, "trackEvents">;

--- a/apps/desktop/src/renderer/src/features/workspace-agent/services/workspaceAgentActivityService.interface.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-agent/services/workspaceAgentActivityService.interface.ts
@@ -158,6 +158,7 @@ export interface IWorkspaceAgentActivityService {
     workspaceId: string,
     request: ImportExternalAgentSessionsRequest
   ): Promise<ExternalAgentImportResultResponse>;
+  selectExternalSessionImportArchive(): Promise<string | null>;
   load(
     workspaceId: string,
     signal?: AbortSignal

--- a/apps/desktop/src/renderer/src/features/workspace-workbench/ui/ExternalAgentSessionImportSourceStep.tsx
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/ui/ExternalAgentSessionImportSourceStep.tsx
@@ -1,0 +1,79 @@
+import type { WorkspaceAgentProvider } from "@tutti-os/client-tuttid-ts";
+import { Button, Checkbox, UploadIcon } from "@tutti-os/ui-system";
+import { useTranslation } from "@renderer/i18n";
+import { resolveWorkspaceAgentGuiLabel } from "../services/workspaceAgentProviderCatalog";
+
+const externalImportListCheckboxClass =
+  "focus-visible:!ring-0 focus-visible:border-[var(--border-1)] data-[state=checked]:focus-visible:border-[var(--text-primary)]";
+
+const externalImportListItemClass =
+  "grid cursor-pointer grid-cols-[auto_minmax(0,1fr)] items-center gap-3 rounded-[8px] bg-[var(--transparency-block)] p-3 transition-colors hover:bg-[var(--transparency-hover)]";
+
+export function ExternalAgentSessionImportSourceStep({
+  disabled,
+  onSelectArchive,
+  onToggle,
+  providers,
+  selectedProviders
+}: {
+  disabled: boolean;
+  onSelectArchive: () => void;
+  onToggle: (provider: WorkspaceAgentProvider, checked: boolean) => void;
+  providers: WorkspaceAgentProvider[];
+  selectedProviders: Set<WorkspaceAgentProvider>;
+}) {
+  const { t } = useTranslation();
+  return (
+    <div className="flex flex-col gap-4">
+      <div className="flex flex-col gap-3">
+        <p className="m-0 text-[13px] leading-[1.4] text-[var(--text-secondary)]">
+          {t("workspace.externalImport.providerDescription")}
+        </p>
+        <div className="flex flex-col gap-2">
+          {providers.map((provider) => {
+            const checked = selectedProviders.has(provider);
+            const label = resolveWorkspaceAgentGuiLabel(provider);
+            return (
+              <label key={provider} className={externalImportListItemClass}>
+                <Checkbox
+                  aria-label={t("workspace.externalImport.selectProvider", {
+                    label
+                  })}
+                  checked={checked}
+                  className={externalImportListCheckboxClass}
+                  disabled={disabled}
+                  onCheckedChange={(value) =>
+                    onToggle(provider, value === true)
+                  }
+                />
+                <span className="min-w-0 text-[13px] font-semibold text-[var(--text-primary)]">
+                  {label}
+                </span>
+              </label>
+            );
+          })}
+        </div>
+      </div>
+      <div className="flex items-center gap-4 rounded-[8px] border border-[var(--border-1)] bg-[var(--transparency-block)] p-3">
+        <div className="min-w-0 flex-1">
+          <strong className="block text-[13px] font-semibold text-[var(--text-primary)]">
+            {t("workspace.externalImport.archiveOptionTitle")}
+          </strong>
+          <p className="mb-0 mt-1 text-[12px] leading-[1.4] text-[var(--text-secondary)]">
+            {t("workspace.externalImport.archiveOptionDescription")}
+          </p>
+        </div>
+        <Button
+          disabled={disabled}
+          size="sm"
+          type="button"
+          variant="outline"
+          onClick={onSelectArchive}
+        >
+          <UploadIcon className="size-4" />
+          {t("workspace.externalImport.chooseArchive")}
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/apps/desktop/src/renderer/src/features/workspace-workbench/ui/ExternalAgentSessionImportStatus.tsx
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/ui/ExternalAgentSessionImportStatus.tsx
@@ -28,6 +28,13 @@ export function ExternalAgentSessionImportResultSummary({
           }
         )}
       />
+      {result.skippedSessions > 0 ? (
+        <p className="m-0 text-center text-[12px] text-[var(--text-secondary)]">
+          {t("workspace.externalImport.resultSkipped", {
+            count: result.skippedSessions
+          })}
+        </p>
+      ) : null}
       {result.errors.length > 0 ? (
         <div className="rounded-[8px] border border-[var(--border-1)] bg-[var(--transparency-block)] p-3">
           <strong className="text-[12px] font-semibold text-[var(--text-primary)]">

--- a/apps/desktop/src/renderer/src/features/workspace-workbench/ui/ExternalAgentSessionImportStatus.tsx
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/ui/ExternalAgentSessionImportStatus.tsx
@@ -1,0 +1,71 @@
+import type * as React from "react";
+import type { ExternalAgentImportResultResponse } from "@tutti-os/client-tuttid-ts";
+import { SuccessFilledIcon } from "@tutti-os/ui-system";
+import { useTranslation } from "@renderer/i18n";
+
+export function ExternalAgentSessionImportResultSummary({
+  archive,
+  result
+}: {
+  archive: boolean;
+  result: ExternalAgentImportResultResponse;
+}) {
+  const { t } = useTranslation();
+  return (
+    <div aria-live="polite" className="flex flex-col gap-4" role="status">
+      <CenteredExternalAgentSessionImportState
+        icon={
+          <SuccessFilledIcon className="size-7 text-[var(--tutti-purple)]" />
+        }
+        text={t(
+          archive
+            ? "workspace.externalImport.archiveResult"
+            : "workspace.externalImport.result",
+          {
+            messages: result.importedMessages,
+            projects: result.importedProjects,
+            sessions: result.importedSessions
+          }
+        )}
+      />
+      {result.errors.length > 0 ? (
+        <div className="rounded-[8px] border border-[var(--border-1)] bg-[var(--transparency-block)] p-3">
+          <strong className="text-[12px] font-semibold text-[var(--text-primary)]">
+            {t("workspace.externalImport.errors")}
+          </strong>
+          <ul className="mt-2 flex flex-col gap-1 p-0 text-[12px] text-[var(--text-secondary)]">
+            {result.errors.map((item, index) => (
+              <li key={`${item.sourcePath ?? "error"}-${index}`}>
+                {item.sourcePath ? `${item.sourcePath}: ` : ""}
+                {item.message}
+              </li>
+            ))}
+          </ul>
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
+export function CenteredExternalAgentSessionImportState({
+  ariaLive,
+  icon,
+  role,
+  text
+}: {
+  ariaLive?: React.AriaAttributes["aria-live"];
+  icon: React.ReactNode;
+  role?: React.AriaRole;
+  text: string;
+}) {
+  return (
+    <div
+      aria-live={ariaLive}
+      className="flex min-h-[220px] flex-col items-center justify-center gap-3 text-center text-[13px] text-[var(--text-secondary)]"
+      role={role}
+    >
+      <div className="text-[var(--text-primary)]">{icon}</div>
+      <p className="m-0 max-w-[360px] leading-[1.4]">{text}</p>
+    </div>
+  );
+}

--- a/apps/desktop/src/renderer/src/features/workspace-workbench/ui/ExternalAgentSessionImportWizard.tsx
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/ui/ExternalAgentSessionImportWizard.tsx
@@ -98,7 +98,7 @@ export function ExternalAgentSessionImportWizard({
     () => (initialProviders ?? []).join("\n"),
     [initialProviders]
   );
-  // Requests are not aborted on close (see isExternalImportWizardBusy), so a
+  // Requests are not aborted on close, so a
   // scan started in a previous dialog lifecycle can settle after the wizard
   // was reset or a newer scan began. Every reset and every new scan bumps this
   // generation; in-flight continuations compare against it before applying
@@ -389,7 +389,7 @@ export function ExternalAgentSessionImportWizard({
                 archive={archiveMode}
                 result={result}
               />
-            ) : error ? (
+            ) : error && step === "select" ? (
               <CenteredExternalAgentSessionImportState
                 ariaLive="assertive"
                 icon={<RefreshIcon className="size-5" />}
@@ -397,15 +397,28 @@ export function ExternalAgentSessionImportWizard({
                 text={error}
               />
             ) : (
-              <ExternalAgentSessionImportSourceStep
-                disabled={loading || importing}
-                providers={externalImportProviderOptions}
-                selectedProviders={selectedProviders}
-                onToggle={toggleProvider}
-                onSelectArchive={() => {
-                  void handleSelectArchive();
-                }}
-              />
+              <>
+                {error ? (
+                  // Picker failures surface inline so the provider and
+                  // archive controls stay reachable for an immediate retry.
+                  <p
+                    aria-live="assertive"
+                    className="mb-3 rounded-[8px] border border-[var(--border-1)] bg-[var(--transparency-block)] px-3 py-2 text-[12px] text-[var(--text-secondary)]"
+                    role="alert"
+                  >
+                    {error}
+                  </p>
+                ) : null}
+                <ExternalAgentSessionImportSourceStep
+                  disabled={loading || importing}
+                  providers={externalImportProviderOptions}
+                  selectedProviders={selectedProviders}
+                  onToggle={toggleProvider}
+                  onSelectArchive={() => {
+                    void handleSelectArchive();
+                  }}
+                />
+              </>
             )}
           </div>
         )}

--- a/apps/desktop/src/renderer/src/features/workspace-workbench/ui/ExternalAgentSessionImportWizard.tsx
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/ui/ExternalAgentSessionImportWizard.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useReducer, useState } from "react";
+import { useEffect, useMemo, useReducer, useRef, useState } from "react";
 import type {
   ExternalAgentImportResultResponse,
   ExternalAgentImportSession,
@@ -98,8 +98,15 @@ export function ExternalAgentSessionImportWizard({
     () => (initialProviders ?? []).join("\n"),
     [initialProviders]
   );
+  // Requests are not aborted on close (see isExternalImportWizardBusy), so a
+  // scan started in a previous dialog lifecycle can settle after the wizard
+  // was reset or a newer scan began. Every reset and every new scan bumps this
+  // generation; in-flight continuations compare against it before applying
+  // their results so a stale scan can never overwrite newer wizard state.
+  const scanGeneration = useRef(0);
 
   useEffect(() => {
+    scanGeneration.current += 1;
     if (!open) {
       return undefined;
     }
@@ -187,6 +194,7 @@ export function ExternalAgentSessionImportWizard({
   };
 
   const runScan = async (nextDays: number, nextArchivePath: string | null) => {
+    const generation = ++scanGeneration.current;
     const source = externalImportScanSource({
       archivePath: nextArchivePath,
       days: nextDays,
@@ -201,6 +209,9 @@ export function ExternalAgentSessionImportWizard({
           workspace.id,
           externalImportScanRequest(source)
         );
+      if (generation !== scanGeneration.current) {
+        return;
+      }
       dispatchScanState({
         type: "scan-succeeded",
         response: nextScan,
@@ -219,6 +230,9 @@ export function ExternalAgentSessionImportWizard({
       });
       setStep("select");
     } catch {
+      if (generation !== scanGeneration.current) {
+        return;
+      }
       dispatchScanState({ type: "scan-failed" });
       setError(
         t(
@@ -229,7 +243,9 @@ export function ExternalAgentSessionImportWizard({
       );
       setStep("select");
     } finally {
-      setLoading(false);
+      if (generation === scanGeneration.current) {
+        setLoading(false);
+      }
     }
   };
 
@@ -247,19 +263,26 @@ export function ExternalAgentSessionImportWizard({
     }
     dispatchScanState({ type: "source-changed" });
     setError(null);
+    // The dialog stays dismissable while the system file picker is open, so
+    // its continuation must not touch a wizard that was reset in the interim.
+    const generation = scanGeneration.current;
     try {
       const nextArchivePath =
         await workspaceAgentActivityService.selectExternalSessionImportArchive();
-      if (!nextArchivePath) {
+      if (generation !== scanGeneration.current || !nextArchivePath) {
         return;
       }
       setArchivePath(nextArchivePath);
       setDays(-1);
       await runScan(-1, nextArchivePath);
     } catch {
+      if (generation !== scanGeneration.current) {
+        return;
+      }
+      // Stay on the providers step: no scan ran, so the select-step chrome
+      // (title, Import/Back footer) would not match the actual wizard state.
       dispatchScanState({ type: "scan-failed" });
       setError(t("workspace.externalImport.archivePickFailed"));
-      setStep("select");
     }
   };
 

--- a/apps/desktop/src/renderer/src/features/workspace-workbench/ui/ExternalAgentSessionImportWizard.tsx
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/ui/ExternalAgentSessionImportWizard.tsx
@@ -1,8 +1,6 @@
-import { useEffect, useMemo, useState } from "react";
-import type * as React from "react";
+import { useEffect, useMemo, useReducer, useState } from "react";
 import type {
   ExternalAgentImportResultResponse,
-  ExternalAgentImportScanResponse,
   ExternalAgentImportSession,
   WorkspaceAgentProvider,
   WorkspaceSummary
@@ -21,14 +19,29 @@ import {
   LoadingIcon,
   RefreshIcon,
   SearchIcon,
-  SuccessFilledIcon,
   UploadIcon,
   formatTuttiShortDateTime
 } from "@tutti-os/ui-system";
 import { useService } from "@tutti-os/infra/di";
 import { IWorkspaceAgentActivityService } from "@renderer/features/workspace-agent";
 import { useTranslation } from "@renderer/i18n";
-import { resolveWorkspaceAgentGuiLabel } from "../services/workspaceAgentProviderCatalog";
+import {
+  externalImportGroupsFromScan,
+  externalImportRequestSource,
+  externalImportScanRequest,
+  externalImportScanSource,
+  externalImportScanStateReducer,
+  externalImportSelectionProjects,
+  externalImportUsableScan,
+  filterExternalImportGroups,
+  isExternalImportArchiveMode,
+  type ExternalImportProjectGroup
+} from "./externalAgentSessionImportWizardModel";
+import { ExternalAgentSessionImportSourceStep } from "./ExternalAgentSessionImportSourceStep";
+import {
+  CenteredExternalAgentSessionImportState,
+  ExternalAgentSessionImportResultSummary
+} from "./ExternalAgentSessionImportStatus";
 
 const externalImportProviderOptions: WorkspaceAgentProvider[] = [
   "codex",
@@ -43,16 +56,6 @@ const externalImportDefaultDays = 30;
 
 const externalImportListCheckboxClass =
   "focus-visible:!ring-0 focus-visible:border-[var(--border-1)] data-[state=checked]:focus-visible:border-[var(--text-primary)]";
-
-const externalImportListItemClass =
-  "grid cursor-pointer grid-cols-[auto_minmax(0,1fr)] items-center gap-3 rounded-[8px] bg-[var(--transparency-block)] p-3 transition-colors hover:bg-[var(--transparency-hover)]";
-
-type ExternalImportProjectGroup = {
-  path: string;
-  label: string;
-  providers: WorkspaceAgentProvider[];
-  sessions: ExternalAgentImportSession[];
-};
 
 export function ExternalAgentSessionImportWizard({
   initialProviders,
@@ -69,7 +72,8 @@ export function ExternalAgentSessionImportWizard({
   const workspaceAgentActivityService = useService(
     IWorkspaceAgentActivityService
   );
-  const [scan, setScan] = useState<ExternalAgentImportScanResponse | null>(
+  const [scanState, dispatchScanState] = useReducer(
+    externalImportScanStateReducer,
     null
   );
   const [result, setResult] =
@@ -79,6 +83,7 @@ export function ExternalAgentSessionImportWizard({
     Set<WorkspaceAgentProvider>
   >(new Set(externalImportProviderOptions));
   const [days, setDays] = useState<number>(externalImportDefaultDays);
+  const [archivePath, setArchivePath] = useState<string | null>(null);
   const [search, setSearch] = useState("");
   // Sessions are selected by default; we only track explicit opt-outs so that
   // widening the day range or re-scanning keeps the user's deselections.
@@ -103,12 +108,13 @@ export function ExternalAgentSessionImportWizard({
       : externalImportProviderOptions;
     setSelectedProviders(new Set(providers));
     setStep("providers");
-    setScan(null);
+    dispatchScanState({ type: "source-changed" });
     setError(null);
     setResult(null);
     setLoading(false);
     setImporting(false);
     setDays(externalImportDefaultDays);
+    setArchivePath(null);
     setSearch("");
     setDeselectedSessionIds(new Set());
     setRegisterProjects(true);
@@ -118,9 +124,23 @@ export function ExternalAgentSessionImportWizard({
   const selectedProviderList = externalImportProviderOptions.filter(
     (provider) => selectedProviders.has(provider)
   );
+  const currentScanSource = externalImportScanSource({
+    archivePath,
+    days,
+    providers: selectedProviderList
+  });
+  const scan = externalImportUsableScan(scanState, currentScanSource);
+  const archiveMode = isExternalImportArchiveMode(archivePath);
   const groups = useMemo(
-    () => externalImportGroupsFromScan(scan, t),
-    [scan, t]
+    () =>
+      externalImportGroupsFromScan(
+        scan,
+        (path) => externalImportProjectLabelFallback(path, t),
+        archiveMode
+          ? t("workspace.externalImport.archiveGroupLabel")
+          : undefined
+      ),
+    [archiveMode, scan, t]
   );
   const filteredGroups = useMemo(
     () => filterExternalImportGroups(groups, search),
@@ -166,16 +186,26 @@ export function ExternalAgentSessionImportWizard({
     });
   };
 
-  const runScan = async (nextDays: number) => {
+  const runScan = async (nextDays: number, nextArchivePath: string | null) => {
+    const source = externalImportScanSource({
+      archivePath: nextArchivePath,
+      days: nextDays,
+      providers: selectedProviderList
+    });
+    dispatchScanState({ type: "scan-started" });
     setLoading(true);
     setError(null);
     try {
       const nextScan =
         await workspaceAgentActivityService.scanExternalSessionImports(
           workspace.id,
-          { providers: selectedProviderList, days: nextDays }
+          externalImportScanRequest(source)
         );
-      setScan(nextScan);
+      dispatchScanState({
+        type: "scan-succeeded",
+        response: nextScan,
+        source
+      });
       // Drop deselections for sessions that no longer exist in the new scan.
       const nextIds = new Set(nextScan.sessions.map((session) => session.id));
       setDeselectedSessionIds((current) => {
@@ -189,7 +219,14 @@ export function ExternalAgentSessionImportWizard({
       });
       setStep("select");
     } catch {
-      setError(t("workspace.externalImport.scanFailed"));
+      dispatchScanState({ type: "scan-failed" });
+      setError(
+        t(
+          nextArchivePath
+            ? "workspace.externalImport.archiveScanFailed"
+            : "workspace.externalImport.scanFailed"
+        )
+      );
       setStep("select");
     } finally {
       setLoading(false);
@@ -200,7 +237,30 @@ export function ExternalAgentSessionImportWizard({
     if (!canScan) {
       return;
     }
-    await runScan(days);
+    setArchivePath(null);
+    await runScan(days, null);
+  };
+
+  const handleSelectArchive = async () => {
+    if (loading || importing) {
+      return;
+    }
+    dispatchScanState({ type: "source-changed" });
+    setError(null);
+    try {
+      const nextArchivePath =
+        await workspaceAgentActivityService.selectExternalSessionImportArchive();
+      if (!nextArchivePath) {
+        return;
+      }
+      setArchivePath(nextArchivePath);
+      setDays(-1);
+      await runScan(-1, nextArchivePath);
+    } catch {
+      dispatchScanState({ type: "scan-failed" });
+      setError(t("workspace.externalImport.archivePickFailed"));
+      setStep("select");
+    }
   };
 
   const handleSelectRange = async (nextDays: number) => {
@@ -208,11 +268,11 @@ export function ExternalAgentSessionImportWizard({
       return;
     }
     setDays(nextDays);
-    await runScan(nextDays);
+    await runScan(nextDays, archivePath);
   };
 
   const handleImport = async () => {
-    if (!canImport || !scan) {
+    if (!canImport || !scan || !scanState) {
       return;
     }
     setImporting(true);
@@ -226,8 +286,13 @@ export function ExternalAgentSessionImportWizard({
         await workspaceAgentActivityService.importExternalSessions(
           workspace.id,
           {
+            ...externalImportRequestSource(
+              scanState.source.kind === "archive"
+                ? scanState.source.archivePath
+                : null,
+              registerProjects
+            ),
             projects,
-            registerUserProjects: registerProjects,
             importSessions: true
           }
         );
@@ -243,7 +308,10 @@ export function ExternalAgentSessionImportWizard({
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="flex max-h-[min(640px,calc(100vh-32px))] flex-col gap-0 overflow-hidden bg-[var(--background-fronted)] p-0 sm:max-w-[640px]">
+      <DialogContent
+        aria-busy={loading || importing}
+        className="flex max-h-[min(640px,calc(100vh-32px))] flex-col gap-0 overflow-hidden bg-[var(--background-fronted)] p-0 sm:max-w-[640px]"
+      >
         <DialogHeader className="shrink-0 border-b border-[var(--border-1)] px-5 py-4">
           <DialogTitle>
             {step === "select"
@@ -252,7 +320,11 @@ export function ExternalAgentSessionImportWizard({
           </DialogTitle>
           <DialogDescription>
             {step === "select"
-              ? t("workspace.externalImport.selectDescription")
+              ? t(
+                  archiveMode
+                    ? "workspace.externalImport.archiveSelectDescription"
+                    : "workspace.externalImport.selectDescription"
+                )
               : t("workspace.externalImport.description")}
           </DialogDescription>
         </DialogHeader>
@@ -272,26 +344,44 @@ export function ExternalAgentSessionImportWizard({
             onToggleRegisterProjects={setRegisterProjects}
             onToggleSessions={setSessionsSelected}
             disabled={importing}
+            archiveMode={archiveMode}
+            showProjectRegistration={!archiveMode}
+            showRange={!archiveMode}
           />
         ) : (
           <div className="min-h-0 flex-1 overflow-y-auto px-5 py-4">
             {loading ? (
-              <CenteredImportState
+              <CenteredExternalAgentSessionImportState
+                ariaLive="polite"
                 icon={<LoadingIcon className="size-5 animate-spin" />}
-                text={t("workspace.externalImport.scanning")}
+                role="status"
+                text={t(
+                  archiveMode
+                    ? "workspace.externalImport.archiveScanning"
+                    : "workspace.externalImport.scanning"
+                )}
               />
             ) : result ? (
-              <ImportResultSummary result={result} />
+              <ExternalAgentSessionImportResultSummary
+                archive={archiveMode}
+                result={result}
+              />
             ) : error ? (
-              <CenteredImportState
+              <CenteredExternalAgentSessionImportState
+                ariaLive="assertive"
                 icon={<RefreshIcon className="size-5" />}
+                role="alert"
                 text={error}
               />
             ) : (
-              <ProviderSelectionList
+              <ExternalAgentSessionImportSourceStep
+                disabled={loading || importing}
                 providers={externalImportProviderOptions}
                 selectedProviders={selectedProviders}
                 onToggle={toggleProvider}
+                onSelectArchive={() => {
+                  void handleSelectArchive();
+                }}
               />
             )}
           </div>
@@ -316,6 +406,9 @@ export function ExternalAgentSessionImportWizard({
                   if (step === "select") {
                     setStep("providers");
                     setError(null);
+                    dispatchScanState({ type: "source-changed" });
+                    setArchivePath(null);
+                    setDays(externalImportDefaultDays);
                     return;
                   }
                   onOpenChange(false);
@@ -338,23 +431,30 @@ export function ExternalAgentSessionImportWizard({
                   {t("workspace.externalImport.scan")}
                 </Button>
               ) : (
-                <Button
-                  disabled={!canImport}
-                  size="dialog"
-                  type="button"
-                  onClick={() => {
-                    void handleImport();
-                  }}
-                >
-                  {importing ? (
-                    <LoadingIcon className="size-4 animate-spin" />
-                  ) : (
-                    <UploadIcon className="size-4" />
-                  )}
-                  {importing
-                    ? t("workspace.externalImport.importing")
-                    : t("workspace.externalImport.import")}
-                </Button>
+                <>
+                  {archiveMode && importing ? (
+                    <span aria-live="polite" className="sr-only" role="status">
+                      {t("workspace.externalImport.importing")}
+                    </span>
+                  ) : null}
+                  <Button
+                    disabled={!canImport}
+                    size="dialog"
+                    type="button"
+                    onClick={() => {
+                      void handleImport();
+                    }}
+                  >
+                    {importing ? (
+                      <LoadingIcon className="size-4 animate-spin" />
+                    ) : (
+                      <UploadIcon className="size-4" />
+                    )}
+                    {importing
+                      ? t("workspace.externalImport.importing")
+                      : t("workspace.externalImport.import")}
+                  </Button>
+                </>
               )}
             </>
           )}
@@ -364,47 +464,8 @@ export function ExternalAgentSessionImportWizard({
   );
 }
 
-function ProviderSelectionList({
-  onToggle,
-  providers,
-  selectedProviders
-}: {
-  onToggle: (provider: WorkspaceAgentProvider, checked: boolean) => void;
-  providers: WorkspaceAgentProvider[];
-  selectedProviders: Set<WorkspaceAgentProvider>;
-}) {
-  const { t } = useTranslation();
-  return (
-    <div className="flex flex-col gap-3">
-      <p className="m-0 text-[13px] leading-[1.4] text-[var(--text-secondary)]">
-        {t("workspace.externalImport.providerDescription")}
-      </p>
-      <div className="flex flex-col gap-2">
-        {providers.map((provider) => {
-          const checked = selectedProviders.has(provider);
-          const label = resolveWorkspaceAgentGuiLabel(provider);
-          return (
-            <label key={provider} className={externalImportListItemClass}>
-              <Checkbox
-                aria-label={t("workspace.externalImport.selectProvider", {
-                  label
-                })}
-                checked={checked}
-                className={externalImportListCheckboxClass}
-                onCheckedChange={(value) => onToggle(provider, value === true)}
-              />
-              <span className="min-w-0 text-[13px] font-semibold text-[var(--text-primary)]">
-                {label}
-              </span>
-            </label>
-          );
-        })}
-      </div>
-    </div>
-  );
-}
-
 function ImportSelectStep({
+  archiveMode,
   days,
   deselectedSessionIds,
   disabled,
@@ -416,8 +477,11 @@ function ImportSelectStep({
   registerProjects,
   search,
   selectedCount,
+  showProjectRegistration,
+  showRange,
   totalCount
 }: {
+  archiveMode: boolean;
   days: number;
   deselectedSessionIds: Set<string>;
   disabled: boolean;
@@ -429,6 +493,8 @@ function ImportSelectStep({
   registerProjects: boolean;
   search: string;
   selectedCount: number;
+  showProjectRegistration: boolean;
+  showRange: boolean;
   totalCount: number;
 }) {
   const { t } = useTranslation();
@@ -440,37 +506,52 @@ function ImportSelectStep({
   const allVisibleSelected =
     visibleIds.length > 0 &&
     visibleIds.every((id) => !deselectedSessionIds.has(id));
+  const searchPlaceholder = t(
+    archiveMode
+      ? "workspace.externalImport.archiveSearchPlaceholder"
+      : "workspace.externalImport.searchPlaceholder"
+  );
 
   return (
     <div className="flex min-h-0 flex-1 flex-col">
+      {archiveMode ? (
+        <p aria-live="polite" className="sr-only" role="status">
+          {t("workspace.externalImport.archiveSelectionReady", {
+            count: totalCount
+          })}
+        </p>
+      ) : null}
       <div className="flex shrink-0 flex-col gap-3 px-5 pb-3 pt-4">
-        <div className="flex items-center gap-1">
-          <span className="mr-1 text-[12px] text-[var(--text-secondary)]">
-            {t("workspace.externalImport.rangeLabel")}
-          </span>
-          {externalImportRangeDays.map((value) => (
-            <button
-              key={value}
-              type="button"
-              disabled={disabled}
-              onClick={() => onSelectRange(value)}
-              className={`rounded-[6px] px-2.5 py-1 text-[12px] transition-colors ${
-                days === value
-                  ? "bg-[var(--text-primary)] text-[var(--text-inverted)]"
-                  : "bg-[var(--transparency-block)] text-[var(--text-secondary)] hover:bg-[var(--transparency-hover)]"
-              }`}
-            >
-              {externalImportRangeLabel(value, t)}
-            </button>
-          ))}
-        </div>
+        {showRange ? (
+          <div className="flex items-center gap-1">
+            <span className="mr-1 text-[12px] text-[var(--text-secondary)]">
+              {t("workspace.externalImport.rangeLabel")}
+            </span>
+            {externalImportRangeDays.map((value) => (
+              <button
+                key={value}
+                type="button"
+                disabled={disabled}
+                onClick={() => onSelectRange(value)}
+                className={`rounded-[6px] px-2.5 py-1 text-[12px] transition-colors ${
+                  days === value
+                    ? "bg-[var(--text-primary)] text-[var(--text-inverted)]"
+                    : "bg-[var(--transparency-block)] text-[var(--text-secondary)] hover:bg-[var(--transparency-hover)]"
+                }`}
+              >
+                {externalImportRangeLabel(value, t)}
+              </button>
+            ))}
+          </div>
+        ) : null}
         <div className="relative">
           <SearchIcon className="pointer-events-none absolute left-3 top-1/2 size-4 -translate-y-1/2 text-[var(--text-placeholder)]" />
           <input
+            aria-label={searchPlaceholder}
             type="text"
             value={search}
             disabled={disabled}
-            placeholder={t("workspace.externalImport.searchPlaceholder")}
+            placeholder={searchPlaceholder}
             onChange={(event) => onSearchChange(event.target.value)}
             className="h-8 w-full min-w-0 appearance-none rounded-md border border-transparent bg-[var(--transparency-block)] pl-9 pr-3 text-[13px] text-[var(--text-primary)] outline-none transition-colors placeholder:text-[var(--text-placeholder)] hover:bg-[var(--transparency-hover)] focus:bg-[var(--transparency-hover)]"
           />
@@ -498,11 +579,15 @@ function ImportSelectStep({
       </div>
       <div className="min-h-0 flex-1 overflow-y-auto px-5">
         {groups.length === 0 ? (
-          <CenteredImportState
+          <CenteredExternalAgentSessionImportState
             icon={<FolderIcon className="size-5" />}
             text={
               totalCount === 0
-                ? t("workspace.externalImport.empty")
+                ? t(
+                    archiveMode
+                      ? "workspace.externalImport.archiveEmpty"
+                      : "workspace.externalImport.empty"
+                  )
                 : t("workspace.externalImport.noResults")
             }
           />
@@ -520,20 +605,22 @@ function ImportSelectStep({
           </div>
         )}
       </div>
-      <div className="shrink-0 border-t border-[var(--border-1)] px-5 py-3">
-        <label className="flex cursor-pointer items-center gap-2 text-[12px] text-[var(--text-secondary)]">
-          <Checkbox
-            aria-label={t("workspace.externalImport.registerProjects")}
-            checked={registerProjects}
-            disabled={disabled}
-            className={externalImportListCheckboxClass}
-            onCheckedChange={(value) =>
-              onToggleRegisterProjects(value === true)
-            }
-          />
-          {t("workspace.externalImport.registerProjects")}
-        </label>
-      </div>
+      {showProjectRegistration ? (
+        <div className="shrink-0 border-t border-[var(--border-1)] px-5 py-3">
+          <label className="flex cursor-pointer items-center gap-2 text-[12px] text-[var(--text-secondary)]">
+            <Checkbox
+              aria-label={t("workspace.externalImport.registerProjects")}
+              checked={registerProjects}
+              disabled={disabled}
+              className={externalImportListCheckboxClass}
+              onCheckedChange={(value) =>
+                onToggleRegisterProjects(value === true)
+              }
+            />
+            {t("workspace.externalImport.registerProjects")}
+          </label>
+        </div>
+      ) : null}
     </div>
   );
 }
@@ -641,48 +728,6 @@ function externalImportSessionMeta(
   return messages;
 }
 
-function externalImportGroupsFromScan(
-  scan: ExternalAgentImportScanResponse | null,
-  t: ReturnType<typeof useTranslation>["t"]
-): ExternalImportProjectGroup[] {
-  if (!scan) {
-    return [];
-  }
-  const labelByPath = new Map(
-    scan.projects.map((project) => [project.path, project.label])
-  );
-  const groupByPath = new Map<string, ExternalImportProjectGroup>();
-  for (const session of scan.sessions) {
-    const path = session.projectPath;
-    let group = groupByPath.get(path);
-    if (!group) {
-      group = {
-        path,
-        label:
-          labelByPath.get(path) ?? externalImportProjectLabelFallback(path, t),
-        providers: [],
-        sessions: []
-      };
-      groupByPath.set(path, group);
-    }
-    if (!group.providers.includes(session.provider)) {
-      group.providers.push(session.provider);
-    }
-    group.sessions.push(session);
-  }
-  return [...groupByPath.values()].sort(
-    (left, right) =>
-      externalImportGroupRecency(right) - externalImportGroupRecency(left)
-  );
-}
-
-function externalImportGroupRecency(group: ExternalImportProjectGroup): number {
-  return group.sessions.reduce(
-    (latest, session) => Math.max(latest, session.lastUpdatedAtUnixMs ?? 0),
-    0
-  );
-}
-
 function externalImportProjectLabelFallback(
   path: string,
   t: ReturnType<typeof useTranslation>["t"]
@@ -692,120 +737,4 @@ function externalImportProjectLabelFallback(
   return base && base.length > 0
     ? base
     : t("workspace.externalImport.projectOptionTitle", { count: 1 });
-}
-
-function filterExternalImportGroups(
-  groups: ExternalImportProjectGroup[],
-  search: string
-): ExternalImportProjectGroup[] {
-  const query = search.trim().toLowerCase();
-  if (!query) {
-    return groups;
-  }
-  const result: ExternalImportProjectGroup[] = [];
-  for (const group of groups) {
-    const labelMatch =
-      group.label.toLowerCase().includes(query) ||
-      group.path.toLowerCase().includes(query);
-    const sessions = labelMatch
-      ? group.sessions
-      : group.sessions.filter((session) =>
-          session.title.toLowerCase().includes(query)
-        );
-    if (sessions.length > 0) {
-      result.push({ ...group, sessions });
-    }
-  }
-  return result;
-}
-
-function externalImportSelectionProjects(
-  sessions: ExternalAgentImportSession[],
-  deselectedSessionIds: Set<string>
-): {
-  path: string;
-  providers?: WorkspaceAgentProvider[];
-  sessionIds?: string[];
-}[] {
-  const byPath = new Map<
-    string,
-    {
-      path: string;
-      providers: Set<WorkspaceAgentProvider>;
-      sessionIds: string[];
-    }
-  >();
-  for (const session of sessions) {
-    if (deselectedSessionIds.has(session.id)) {
-      continue;
-    }
-    let entry = byPath.get(session.projectPath);
-    if (!entry) {
-      entry = {
-        path: session.projectPath,
-        providers: new Set(),
-        sessionIds: []
-      };
-      byPath.set(session.projectPath, entry);
-    }
-    entry.providers.add(session.provider);
-    entry.sessionIds.push(session.id);
-  }
-  return [...byPath.values()].map((entry) => ({
-    path: entry.path,
-    providers: [...entry.providers],
-    sessionIds: entry.sessionIds
-  }));
-}
-
-function ImportResultSummary({
-  result
-}: {
-  result: ExternalAgentImportResultResponse;
-}) {
-  const { t } = useTranslation();
-  return (
-    <div className="flex flex-col gap-4">
-      <CenteredImportState
-        icon={
-          <SuccessFilledIcon className="size-7 text-[var(--tutti-purple)]" />
-        }
-        text={t("workspace.externalImport.result", {
-          messages: result.importedMessages,
-          projects: result.importedProjects,
-          sessions: result.importedSessions
-        })}
-      />
-      {result.errors.length > 0 ? (
-        <div className="rounded-[8px] border border-[var(--border-1)] bg-[var(--transparency-block)] p-3">
-          <strong className="text-[12px] font-semibold text-[var(--text-primary)]">
-            {t("workspace.externalImport.errors")}
-          </strong>
-          <ul className="mt-2 flex flex-col gap-1 p-0 text-[12px] text-[var(--text-secondary)]">
-            {result.errors.map((item, index) => (
-              <li key={`${item.sourcePath ?? "error"}-${index}`}>
-                {item.sourcePath ? `${item.sourcePath}: ` : ""}
-                {item.message}
-              </li>
-            ))}
-          </ul>
-        </div>
-      ) : null}
-    </div>
-  );
-}
-
-function CenteredImportState({
-  icon,
-  text
-}: {
-  icon: React.ReactNode;
-  text: string;
-}) {
-  return (
-    <div className="flex min-h-[220px] flex-col items-center justify-center gap-3 text-center text-[13px] text-[var(--text-secondary)]">
-      <div className="text-[var(--text-primary)]">{icon}</div>
-      <p className="m-0 max-w-[360px] leading-[1.4]">{text}</p>
-    </div>
-  );
 }

--- a/apps/desktop/src/renderer/src/features/workspace-workbench/ui/externalAgentSessionImportWizardModel.test.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/ui/externalAgentSessionImportWizardModel.test.ts
@@ -1,0 +1,192 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  externalImportGroupsFromScan,
+  externalImportRequestSource,
+  externalImportScanRequest,
+  externalImportScanSource,
+  externalImportScanStateReducer,
+  externalImportSelectionProjects,
+  externalImportUsableScan,
+  filterExternalImportGroups,
+  isExternalImportArchiveMode
+} from "./externalAgentSessionImportWizardModel.ts";
+
+test("archive source keeps the same path for scan and disables project registration", () => {
+  assert.equal(isExternalImportArchiveMode(" /tmp/claude-export.zip "), true);
+  const source = externalImportScanSource({
+    archivePath: " /tmp/claude-export.zip ",
+    days: -1,
+    providers: ["codex", "claude-code"]
+  });
+  assert.deepEqual(externalImportScanRequest(source), {
+    archivePath: "/tmp/claude-export.zip",
+    days: -1
+  });
+  assert.deepEqual(
+    externalImportRequestSource(" /tmp/claude-export.zip ", true),
+    {
+      archivePath: "/tmp/claude-export.zip",
+      registerUserProjects: false
+    }
+  );
+});
+
+test("local source keeps providers and the project registration preference", () => {
+  assert.equal(isExternalImportArchiveMode(null), false);
+  assert.deepEqual(
+    externalImportScanRequest(
+      externalImportScanSource({
+        archivePath: null,
+        days: 30,
+        providers: ["codex"]
+      })
+    ),
+    { days: 30, providers: ["codex"] }
+  );
+  assert.deepEqual(externalImportRequestSource(null, false), {
+    registerUserProjects: false
+  });
+});
+
+test("completed scan is usable only for its exact source identity", () => {
+  const response = {
+    errors: [],
+    projects: [],
+    providers: [],
+    scannedMessages: 0,
+    scannedSessions: 0,
+    sessions: [],
+    skippedSessions: 0
+  };
+  const source = externalImportScanSource({
+    archivePath: "/tmp/claude-export-a.zip",
+    days: -1,
+    providers: ["codex", "claude-code"]
+  });
+  const state = externalImportScanStateReducer(null, {
+    type: "scan-succeeded",
+    response,
+    source
+  });
+
+  assert.equal(externalImportUsableScan(state, source), response);
+  assert.equal(
+    externalImportUsableScan(
+      state,
+      externalImportScanSource({
+        archivePath: "/tmp/claude-export-b.zip",
+        days: -1,
+        providers: ["codex", "claude-code"]
+      })
+    ),
+    null
+  );
+  assert.equal(
+    externalImportUsableScan(
+      state,
+      externalImportScanSource({
+        archivePath: null,
+        days: -1,
+        providers: ["codex", "claude-code"]
+      })
+    ),
+    null
+  );
+});
+
+test("starting, failing, or changing source clears the completed scan", () => {
+  const response = {
+    errors: [],
+    projects: [],
+    providers: [],
+    scannedMessages: 0,
+    scannedSessions: 0,
+    sessions: [],
+    skippedSessions: 0
+  };
+  const source = externalImportScanSource({
+    archivePath: "/tmp/claude-export.zip",
+    days: -1,
+    providers: []
+  });
+  const completed = externalImportScanStateReducer(null, {
+    type: "scan-succeeded",
+    response,
+    source
+  });
+
+  assert.equal(
+    externalImportScanStateReducer(completed, { type: "scan-started" }),
+    null
+  );
+  assert.equal(
+    externalImportScanStateReducer(completed, { type: "scan-failed" }),
+    null
+  );
+  assert.equal(
+    externalImportScanStateReducer(completed, { type: "source-changed" }),
+    null
+  );
+});
+
+test("archive groups use their source label and preserve selected session ids", () => {
+  const scan = {
+    errors: [],
+    projects: [
+      {
+        label: "demo",
+        messageCount: 3,
+        path: "/Users/demo",
+        providers: ["claude-code" as const],
+        sessionCount: 2
+      }
+    ],
+    providers: [],
+    scannedMessages: 3,
+    scannedSessions: 2,
+    sessions: [
+      {
+        id: "session-new",
+        lastUpdatedAtUnixMs: 200,
+        messageCount: 2,
+        projectPath: "/Users/demo",
+        provider: "claude-code" as const,
+        sourcePath: "/tmp/claude-export.zip",
+        title: "New conversation"
+      },
+      {
+        id: "session-old",
+        lastUpdatedAtUnixMs: 100,
+        messageCount: 1,
+        projectPath: "/Users/demo",
+        provider: "claude-code" as const,
+        sourcePath: "/tmp/claude-export.zip",
+        title: "Old conversation"
+      }
+    ],
+    skippedSessions: 0
+  };
+  const groups = externalImportGroupsFromScan(
+    scan,
+    () => "fallback",
+    "Claude chats"
+  );
+  assert.equal(groups[0]?.label, "Claude chats");
+  assert.deepEqual(
+    filterExternalImportGroups(groups, "new")[0]?.sessions.map(
+      (session) => session.id
+    ),
+    ["session-new"]
+  );
+  assert.deepEqual(
+    externalImportSelectionProjects(scan.sessions, new Set(["session-old"])),
+    [
+      {
+        path: "/Users/demo",
+        providers: ["claude-code"],
+        sessionIds: ["session-new"]
+      }
+    ]
+  );
+});

--- a/apps/desktop/src/renderer/src/features/workspace-workbench/ui/externalAgentSessionImportWizardModel.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/ui/externalAgentSessionImportWizardModel.ts
@@ -1,0 +1,237 @@
+// Pure decision logic for ExternalAgentSessionImportWizard.tsx, split out so
+// it can be unit tested without mounting the dialog (this app's test runner
+// is plain node:test over *.test.ts and has no React rendering harness).
+
+import type {
+  ExternalAgentImportScanRequest,
+  ExternalAgentImportScanResponse,
+  ExternalAgentImportSession,
+  WorkspaceAgentProvider
+} from "@tutti-os/client-tuttid-ts";
+
+export type ExternalImportProjectGroup = {
+  path: string;
+  label: string;
+  providers: WorkspaceAgentProvider[];
+  sessions: ExternalAgentImportSession[];
+};
+
+export type ExternalImportScanSource =
+  | {
+      kind: "archive";
+      archivePath: string;
+      days: number;
+    }
+  | {
+      kind: "local";
+      days: number;
+      providers: WorkspaceAgentProvider[];
+    };
+
+export type ExternalImportScanState = {
+  response: ExternalAgentImportScanResponse;
+  source: ExternalImportScanSource;
+} | null;
+
+export type ExternalImportScanStateAction =
+  | { type: "scan-started" }
+  | { type: "scan-failed" }
+  | { type: "source-changed" }
+  | {
+      type: "scan-succeeded";
+      response: ExternalAgentImportScanResponse;
+      source: ExternalImportScanSource;
+    };
+
+export function isExternalImportArchiveMode(
+  archivePath: string | null | undefined
+): boolean {
+  return Boolean(archivePath?.trim());
+}
+
+export function externalImportScanSource({
+  archivePath,
+  days,
+  providers
+}: {
+  archivePath: string | null;
+  days: number;
+  providers: WorkspaceAgentProvider[];
+}): ExternalImportScanSource {
+  const normalizedArchivePath = archivePath?.trim();
+  if (normalizedArchivePath) {
+    return {
+      kind: "archive",
+      archivePath: normalizedArchivePath,
+      days
+    };
+  }
+  return {
+    kind: "local",
+    days,
+    providers: [...new Set(providers)]
+  };
+}
+
+export function externalImportScanRequest(
+  source: ExternalImportScanSource
+): ExternalAgentImportScanRequest {
+  return source.kind === "archive"
+    ? { archivePath: source.archivePath, days: source.days }
+    : { days: source.days, providers: source.providers };
+}
+
+export function externalImportScanStateReducer(
+  _current: ExternalImportScanState,
+  action: ExternalImportScanStateAction
+): ExternalImportScanState {
+  if (action.type === "scan-succeeded") {
+    return { response: action.response, source: action.source };
+  }
+  return null;
+}
+
+export function externalImportUsableScan(
+  state: ExternalImportScanState,
+  source: ExternalImportScanSource
+): ExternalAgentImportScanResponse | null {
+  return state && externalImportScanSourcesEqual(state.source, source)
+    ? state.response
+    : null;
+}
+
+function externalImportScanSourcesEqual(
+  left: ExternalImportScanSource,
+  right: ExternalImportScanSource
+): boolean {
+  if (left.kind !== right.kind || left.days !== right.days) {
+    return false;
+  }
+  if (left.kind === "archive" && right.kind === "archive") {
+    return left.archivePath === right.archivePath;
+  }
+  if (left.kind === "local" && right.kind === "local") {
+    return (
+      left.providers.length === right.providers.length &&
+      left.providers.every((provider) => right.providers.includes(provider))
+    );
+  }
+  return false;
+}
+
+export function externalImportRequestSource(
+  archivePath: string | null,
+  registerProjects: boolean
+): { archivePath?: string; registerUserProjects: boolean } {
+  const normalizedArchivePath = archivePath?.trim();
+  return normalizedArchivePath
+    ? { archivePath: normalizedArchivePath, registerUserProjects: false }
+    : { registerUserProjects: registerProjects };
+}
+
+export function externalImportGroupsFromScan(
+  scan: ExternalAgentImportScanResponse | null,
+  projectLabelFallback: (path: string) => string,
+  labelOverride?: string
+): ExternalImportProjectGroup[] {
+  if (!scan) {
+    return [];
+  }
+  const labelByPath = new Map(
+    scan.projects.map((project) => [project.path, project.label])
+  );
+  const groupByPath = new Map<string, ExternalImportProjectGroup>();
+  for (const session of scan.sessions) {
+    const path = session.projectPath;
+    let group = groupByPath.get(path);
+    if (!group) {
+      group = {
+        path,
+        label:
+          labelOverride ?? labelByPath.get(path) ?? projectLabelFallback(path),
+        providers: [],
+        sessions: []
+      };
+      groupByPath.set(path, group);
+    }
+    if (!group.providers.includes(session.provider)) {
+      group.providers.push(session.provider);
+    }
+    group.sessions.push(session);
+  }
+  return [...groupByPath.values()].sort(
+    (left, right) =>
+      externalImportGroupRecency(right) - externalImportGroupRecency(left)
+  );
+}
+
+function externalImportGroupRecency(group: ExternalImportProjectGroup): number {
+  return group.sessions.reduce(
+    (latest, session) => Math.max(latest, session.lastUpdatedAtUnixMs ?? 0),
+    0
+  );
+}
+
+export function filterExternalImportGroups(
+  groups: ExternalImportProjectGroup[],
+  search: string
+): ExternalImportProjectGroup[] {
+  const query = search.trim().toLowerCase();
+  if (!query) {
+    return groups;
+  }
+  const result: ExternalImportProjectGroup[] = [];
+  for (const group of groups) {
+    const labelMatch =
+      group.label.toLowerCase().includes(query) ||
+      group.path.toLowerCase().includes(query);
+    const sessions = labelMatch
+      ? group.sessions
+      : group.sessions.filter((session) =>
+          session.title.toLowerCase().includes(query)
+        );
+    if (sessions.length > 0) {
+      result.push({ ...group, sessions });
+    }
+  }
+  return result;
+}
+
+export function externalImportSelectionProjects(
+  sessions: ExternalAgentImportSession[],
+  deselectedSessionIds: Set<string>
+): {
+  path: string;
+  providers?: WorkspaceAgentProvider[];
+  sessionIds?: string[];
+}[] {
+  const byPath = new Map<
+    string,
+    {
+      path: string;
+      providers: Set<WorkspaceAgentProvider>;
+      sessionIds: string[];
+    }
+  >();
+  for (const session of sessions) {
+    if (deselectedSessionIds.has(session.id)) {
+      continue;
+    }
+    let entry = byPath.get(session.projectPath);
+    if (!entry) {
+      entry = {
+        path: session.projectPath,
+        providers: new Set(),
+        sessionIds: []
+      };
+      byPath.set(session.projectPath, entry);
+    }
+    entry.providers.add(session.provider);
+    entry.sessionIds.push(session.id);
+  }
+  return [...byPath.values()].map((entry) => ({
+    path: entry.path,
+    providers: [...entry.providers],
+    sessionIds: entry.sessionIds
+  }));
+}

--- a/apps/desktop/src/shared/i18n/locales/en.ts
+++ b/apps/desktop/src/shared/i18n/locales/en.ts
@@ -10,7 +10,7 @@ export const en = {
     unknownError: "Unknown error",
     unreachable: "unreachable",
     workspace: "workspace",
-    zipArchive: "Zip Archive"
+    zipArchive: "ZIP Archive"
   },
   dashboard: {
     chooseWorkspaceTitle: "Choose a workspace",
@@ -337,6 +337,8 @@ export const en = {
       promptTitle: "Import existing AI chats",
       result:
         "Imported {{sessions}} sessions and {{messages}} messages from {{projects}} projects",
+      resultSkipped:
+        "Skipped {{count}} conversations that were empty or unsupported",
       scan: "Scan",
       scanFailed: "We couldn't scan external agent history right now.",
       scanning: "Scanning local agent history...",
@@ -344,7 +346,7 @@ export const en = {
       selectImportOption: "Select {{label}}",
       settingsAction: "Import",
       settingsDescription:
-        "Bring local Codex and Claude Code history or Claude export conversations into this workspace",
+        "Bring local Codex and Claude Code history or Claude export conversations into Tutti",
       settingsLabel: "Import AI chats",
       title: "Import from AI apps"
     },

--- a/apps/desktop/src/shared/i18n/locales/en.ts
+++ b/apps/desktop/src/shared/i18n/locales/en.ts
@@ -9,7 +9,8 @@ export const en = {
     selectFolder: "Select folder",
     unknownError: "Unknown error",
     unreachable: "unreachable",
-    workspace: "workspace"
+    workspace: "workspace",
+    zipArchive: "Zip Archive"
   },
   dashboard: {
     chooseWorkspaceTitle: "Choose a workspace",
@@ -280,8 +281,27 @@ export const en = {
       triggerAria: "Join feedback group"
     },
     externalImport: {
+      archiveEmpty:
+        "No supported conversations were found in this Claude export",
+      archiveGroupLabel: "Claude chats",
+      archiveOptionDescription:
+        "Choose the ZIP file downloaded from Claude's data export",
+      archiveOptionTitle: "Import Claude export data",
+      archivePickFailed: "We couldn't open the Claude export file picker.",
+      archiveResult:
+        "Imported {{sessions}} conversations and {{messages}} messages from the Claude export",
+      archiveScanFailed:
+        "This ZIP could not be read as a supported Claude data export.",
+      archiveScanning: "Reading Claude export conversations...",
+      archiveSearchPlaceholder: "Search Claude conversations",
+      archiveSelectionReady:
+        "Claude export scan complete. {{count}} conversations are ready to review.",
+      archiveSelectDescription:
+        "Search and check the Claude conversations to import",
       back: "Back",
-      description: "Import local Codex and Claude Code conversation history",
+      chooseArchive: "Choose ZIP",
+      description:
+        "Import local Codex and Claude Code history or a Claude data export",
       done: "Done",
       empty: "No local Codex or Claude Code project history was found",
       errors: "Skipped items",
@@ -324,7 +344,7 @@ export const en = {
       selectImportOption: "Select {{label}}",
       settingsAction: "Import",
       settingsDescription:
-        "Bring recent local Codex and Claude Code conversation history into this workspace",
+        "Bring local Codex and Claude Code history or Claude export conversations into this workspace",
       settingsLabel: "Import AI chats",
       title: "Import from AI apps"
     },

--- a/apps/desktop/src/shared/i18n/locales/zh-CN.ts
+++ b/apps/desktop/src/shared/i18n/locales/zh-CN.ts
@@ -12,7 +12,7 @@ export const zhCN = {
     unknownError: "未知错误",
     unreachable: "不可达",
     workspace: "工作区",
-    zipArchive: "Zip 压缩包"
+    zipArchive: "ZIP 压缩包"
   },
   dashboard: {
     chooseWorkspaceTitle: "选择一个工作区",
@@ -323,6 +323,7 @@ export const zhCN = {
       promptTitle: "导入已有 AI 聊天",
       result:
         "已从 {{projects}} 个项目导入 {{sessions}} 个会话和 {{messages}} 条消息",
+      resultSkipped: "已跳过 {{count}} 个空的或不支持的对话",
       scan: "扫描",
       scanFailed: "暂时无法扫描外部 Agent 历史。",
       scanning: "正在扫描本机 Agent 历史...",
@@ -330,7 +331,7 @@ export const zhCN = {
       selectImportOption: "选择 {{label}}",
       settingsAction: "导入",
       settingsDescription:
-        "将本机 Codex、Claude Code 历史或 Claude 导出对话导入这个工作区",
+        "将本机 Codex、Claude Code 历史或 Claude 导出对话导入 Tutti",
       settingsLabel: "导入 AI 聊天",
       title: "从 AI 应用导入"
     },

--- a/apps/desktop/src/shared/i18n/locales/zh-CN.ts
+++ b/apps/desktop/src/shared/i18n/locales/zh-CN.ts
@@ -11,7 +11,8 @@ export const zhCN = {
     selectFolder: "选择文件夹",
     unknownError: "未知错误",
     unreachable: "不可达",
-    workspace: "工作区"
+    workspace: "工作区",
+    zipArchive: "Zip 压缩包"
   },
   dashboard: {
     chooseWorkspaceTitle: "选择一个工作区",
@@ -273,8 +274,22 @@ export const zhCN = {
       triggerAria: "加入反馈群"
     },
     externalImport: {
+      archiveEmpty: "这个 Claude 导出中没有找到受支持的对话",
+      archiveGroupLabel: "Claude 对话",
+      archiveOptionDescription: "选择从 Claude 数据导出中下载的 ZIP 文件",
+      archiveOptionTitle: "Claude 导出数据导入",
+      archivePickFailed: "无法打开 Claude 导出文件选择器。",
+      archiveResult:
+        "已从 Claude 导出中导入 {{sessions}} 个对话和 {{messages}} 条消息",
+      archiveScanFailed: "无法将这个 ZIP 读取为支持的 Claude 数据导出。",
+      archiveScanning: "正在读取 Claude 导出对话...",
+      archiveSearchPlaceholder: "搜索 Claude 对话",
+      archiveSelectionReady:
+        "Claude 导出扫描完成，有 {{count}} 个对话可供检查。",
+      archiveSelectDescription: "搜索并勾选要导入的 Claude 对话",
       back: "返回",
-      description: "导入本机 Codex 和 Claude Code 的会话历史",
+      chooseArchive: "选择 ZIP",
+      description: "导入本机 Codex、Claude Code 历史或 Claude 数据导出",
       done: "完成",
       empty: "未找到本机 Codex 或 Claude Code 的项目历史",
       errors: "跳过的项目",
@@ -315,7 +330,7 @@ export const zhCN = {
       selectImportOption: "选择 {{label}}",
       settingsAction: "导入",
       settingsDescription:
-        "将本机 Codex 和 Claude Code 最近的会话历史导入这个工作区",
+        "将本机 Codex、Claude Code 历史或 Claude 导出对话导入这个工作区",
       settingsLabel: "导入 AI 聊天",
       title: "从 AI 应用导入"
     },

--- a/docs/architecture/agent-gui-node.md
+++ b/docs/architecture/agent-gui-node.md
@@ -431,6 +431,57 @@ is not durable state and should not become the source of truth.
 Use these flows when debugging AgentGUI behavior. They are intentionally written
 from the user's action back to the authoritative data source.
 
+### External History Import
+
+```text
+desktop ZIP picker or local-history source selection
+  -> ExternalAgentSessionImportWizard
+  -> WorkspaceAgentActivityService scanExternalSessionImports
+  -> tuttid external-import scan endpoint
+  -> local JSONL scanner or Claude data-export ZIP parser
+  -> selectable import session summaries
+  -> WorkspaceAgentActivityService importExternalSessions
+  -> tuttid external-import import endpoint
+  -> ActivityProjection persisted sessions/messages
+  -> desktop activity load + user-project refresh
+  -> AgentActivityRuntime snapshot
+  -> AgentGUI rail and transcript
+```
+
+The daemon owns archive validation and conversation parsing. Desktop passes the
+absolute path selected through the native picker, and both scan and import must
+carry the same `archivePath`; import reopens and revalidates the archive rather
+than trusting scan-time state. The wizard must bind a completed scan to its
+normalized local/archive source identity and invalidate it before a source
+change or failed rescan, so sessions from one scan cannot be submitted with a
+different archive path. Claude exports are read directly from the exact root
+`conversations.json` ZIP entry. Preflight the ZIP central directory and bound
+conversation JSON depth, container counts, token counts, and retained messages
+before expanding untrusted data. Do not extract the archive, execute tool
+payloads, fetch citation URLs, or treat referenced files as locally available.
+
+Claude export `message.text` is not a safe visible-body source: rich messages
+can include hidden thinking and tool material there. Import only ordered
+`content[type=text]` blocks into visible transcript text, ignore control blocks,
+and retain file-only messages as unavailable references without claiming that
+the ZIP contains their payloads. Stable source message UUIDs make repeat imports
+idempotent even when a later export inserts earlier messages. Claude exports may
+contain mutually exclusive edit/retry branches. Build the parent-message graph
+and import the deterministic latest leaf's root-to-leaf path; never flatten
+sibling branches into one transcript. Namespace the imported session with a
+fingerprint of the selected sibling choices: ordinary appends stay in the same
+session, while a later export that selects a different retry branch lands in a
+separate session instead of accumulating incompatible messages. Preserve the
+branch fingerprint and chosen leaf UUID in message payloads so that branch
+selection remains auditable.
+
+claude.ai exports do not carry a coding-project cwd or a Claude Code runtime
+session id. Persist them in the no-project Chats section with
+`runtimeContext.imported`, `externalImportNoProject`, and a false
+`externalImportResumeSupported` marker. They may use the Claude Code target for
+presentation, but AgentGUI must keep the imported history read-only and route
+continued work through the existing "continue in a new conversation" flow.
+
 ### Conversation List Loading
 
 ```text

--- a/docs/architecture/agent-gui-node.md
+++ b/docs/architecture/agent-gui-node.md
@@ -461,8 +461,10 @@ before expanding untrusted data. Do not extract the archive, execute tool
 payloads, fetch citation URLs, or treat referenced files as locally available.
 
 Claude export `message.text` is not a safe visible-body source: rich messages
-can include hidden thinking and tool material there. Import only ordered
-`content[type=text]` blocks into visible transcript text, ignore control blocks,
+can include hidden thinking and tool material there. Import ordered
+`content[type=text]` blocks into visible transcript text; only legacy user
+messages with no structured content may fall back to `message.text`, and
+assistant messages never may. Ignore control blocks,
 and retain file-only messages as unavailable references without claiming that
 the ZIP contains their payloads. Stable source message UUIDs make repeat imports
 idempotent even when a later export inserts earlier messages. Claude exports may

--- a/packages/agent/gui/agent-gui/agentGuiNode/AgentGUIChrome.styles.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/AgentGUIChrome.styles.ts
@@ -6,6 +6,7 @@ const styles = {
   chromeCardMuted: "agent-gui-chrome__card--muted",
   chromeCardConnecting: "agent-gui-chrome__card--connecting",
   chromeCardDanger: "agent-gui-chrome__card--danger",
+  chromeCardSuccess: "agent-gui-chrome__card--success",
   chromeIcon: "agent-gui-chrome__icon",
   chromeMessageSlot: "agent-gui-chrome__message-slot",
   chromeMessageTooltip: "agent-gui-chrome__message-tooltip",
@@ -18,6 +19,7 @@ const styles = {
   chromeActions: "agent-gui-chrome__actions",
   chromeMetaRow: "agent-gui-chrome__meta-row",
   chromeDangerGhostButton: "agent-gui-chrome__danger-ghost-button",
+  chromeSuccessGhostButton: "agent-gui-chrome__success-ghost-button",
   chromeGoalHint: "agent-gui-chrome__goal-hint"
 } as const;
 

--- a/packages/agent/gui/agent-gui/agentGuiNode/AgentGUINode.spec.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/AgentGUINode.spec.tsx
@@ -6087,16 +6087,19 @@ describe("AgentGUINode", () => {
         auth: null,
         approval: null,
         recovery: {
-          kind: "failed",
+          kind: "resume-unavailable",
           message:
             "This session cannot be resumed on this device. Start a new session and @this session to keep going.",
-          canRetry: false,
           followupAction: "continue-in-new-conversation"
         },
         rawState: null
       }
     });
     renderAgentGUINode();
+
+    // The composer stays fenced off for resume-unavailable sessions even
+    // though the banner is success-toned rather than an error alert.
+    expect(getComposerEditor()).toHaveAttribute("aria-disabled", "true");
 
     fireEvent.click(
       screen.getByRole("button", {

--- a/packages/agent/gui/agent-gui/agentGuiNode/AgentGUINodeView.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/AgentGUINodeView.tsx
@@ -1842,8 +1842,9 @@ const AgentGUIDetailPane = memo(function AgentGUIDetailPane({
     !isAgentProviderReady ||
     (!viewModel.canSubmit && !canQueueWhileBusy);
   const hasNonRetryableRecoveryFailure =
-    sessionChrome.recovery?.kind === "failed" &&
-    sessionChrome.recovery.canRetry === false;
+    (sessionChrome.recovery?.kind === "failed" &&
+      sessionChrome.recovery.canRetry === false) ||
+    sessionChrome.recovery?.kind === "resume-unavailable";
   const composerDisabled =
     hasNonRetryableRecoveryFailure ||
     isCollaboratorConversation ||

--- a/packages/agent/gui/agent-gui/agentGuiNode/AgentGUINodeView.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/AgentGUINodeView.tsx
@@ -1837,14 +1837,18 @@ const AgentGUIDetailPane = memo(function AgentGUIDetailPane({
     !emptyProviderReadinessGate &&
     !isAgentProviderReady &&
     !isCollaboratorConversation;
-  const submitDisabled =
-    isCollaboratorConversation ||
-    !isAgentProviderReady ||
-    (!viewModel.canSubmit && !canQueueWhileBusy);
   const hasNonRetryableRecoveryFailure =
     (sessionChrome.recovery?.kind === "failed" &&
       sessionChrome.recovery.canRetry === false) ||
     sessionChrome.recovery?.kind === "resume-unavailable";
+  // Also fences the queue-while-busy send path: AgentComposer ignores
+  // `disabled` in queue mode, and the controller fence would turn the send
+  // into a silent no-op for a dead-ended session.
+  const submitDisabled =
+    hasNonRetryableRecoveryFailure ||
+    isCollaboratorConversation ||
+    !isAgentProviderReady ||
+    (!viewModel.canSubmit && !canQueueWhileBusy);
   const composerDisabled =
     hasNonRetryableRecoveryFailure ||
     isCollaboratorConversation ||

--- a/packages/agent/gui/agent-gui/agentGuiNode/AgentSessionChrome.spec.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/AgentSessionChrome.spec.tsx
@@ -280,9 +280,8 @@ describe("AgentSessionChrome", () => {
           auth: null,
           approval: null,
           recovery: {
-            kind: "failed",
+            kind: "resume-unavailable",
             message: "This session is not recoverable on this machine.",
-            canRetry: false,
             followupAction: "continue-in-new-conversation"
           },
           rawState: null
@@ -319,7 +318,14 @@ describe("AgentSessionChrome", () => {
     expect(continueButton).toHaveAttribute("data-variant", "ghost");
     expect(continueButton).toHaveAttribute("data-size", "sm");
     expect(continueButton.className).toContain(
-      "agent-gui-chrome__danger-ghost-button"
+      "agent-gui-chrome__success-ghost-button"
+    );
+    expect(
+      continueButton.closest(".agent-gui-chrome__card")?.className
+    ).toContain("agent-gui-chrome__card--success");
+    expect(screen.queryByRole("alert")).toBeNull();
+    expect(screen.getByRole("status")).toBe(
+      continueButton.closest(".agent-gui-chrome__card")
     );
 
     fireEvent.click(continueButton);

--- a/packages/agent/gui/agent-gui/agentGuiNode/AgentSessionChrome.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/AgentSessionChrome.tsx
@@ -150,11 +150,8 @@ export function AgentSessionChrome({
       ? labels.activatingSession
       : (visibleRecovery?.message ?? "");
   const recoveryHasInlineAction =
-    (visibleRecovery?.kind === "resume-unavailable" &&
-      visibleRecovery.followupAction === "continue-in-new-conversation") ||
-    (visibleRecovery?.kind === "failed" &&
-      (visibleRecovery.followupAction === "continue-in-new-conversation" ||
-        visibleRecovery.canRetry !== false));
+    visibleRecovery?.kind === "resume-unavailable" ||
+    (visibleRecovery?.kind === "failed" && visibleRecovery.canRetry !== false);
   const activatingMessage = splitTrailingEllipsis(recoveryMessage);
   const hasContent =
     visibleAuth !== null ||
@@ -290,9 +287,9 @@ export function AgentSessionChrome({
               </ChromeMessageTooltip>
             </div>
             <div className={styles.chromeInlineActions}>
-              {visibleRecovery.kind === "resume-unavailable" &&
-              visibleRecovery.followupAction ===
-                "continue-in-new-conversation" ? (
+              {/* followupAction is required on this variant, so the kind
+                  check alone guarantees the continue action. */}
+              {visibleRecovery.kind === "resume-unavailable" ? (
                 <Button
                   type="button"
                   variant="ghost"

--- a/packages/agent/gui/agent-gui/agentGuiNode/AgentSessionChrome.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/AgentSessionChrome.tsx
@@ -150,7 +150,8 @@ export function AgentSessionChrome({
       ? labels.activatingSession
       : (visibleRecovery?.message ?? "");
   const recoveryHasInlineAction =
-    visibleRecovery?.kind === "resume-unavailable" ||
+    (visibleRecovery?.kind === "resume-unavailable" &&
+      visibleRecovery.followupAction === "continue-in-new-conversation") ||
     (visibleRecovery?.kind === "failed" &&
       (visibleRecovery.followupAction === "continue-in-new-conversation" ||
         visibleRecovery.canRetry !== false));
@@ -289,7 +290,9 @@ export function AgentSessionChrome({
               </ChromeMessageTooltip>
             </div>
             <div className={styles.chromeInlineActions}>
-              {visibleRecovery.kind === "resume-unavailable" ? (
+              {visibleRecovery.kind === "resume-unavailable" &&
+              visibleRecovery.followupAction ===
+                "continue-in-new-conversation" ? (
                 <Button
                   type="button"
                   variant="ghost"

--- a/packages/agent/gui/agent-gui/agentGuiNode/AgentSessionChrome.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/AgentSessionChrome.tsx
@@ -150,9 +150,10 @@ export function AgentSessionChrome({
       ? labels.activatingSession
       : (visibleRecovery?.message ?? "");
   const recoveryHasInlineAction =
-    visibleRecovery?.kind === "failed" &&
-    (visibleRecovery.followupAction === "continue-in-new-conversation" ||
-      visibleRecovery.canRetry !== false);
+    visibleRecovery?.kind === "resume-unavailable" ||
+    (visibleRecovery?.kind === "failed" &&
+      (visibleRecovery.followupAction === "continue-in-new-conversation" ||
+        visibleRecovery.canRetry !== false));
   const activatingMessage = splitTrailingEllipsis(recoveryMessage);
   const hasContent =
     visibleAuth !== null ||
@@ -225,20 +226,32 @@ export function AgentSessionChrome({
 
       {visibleRecovery ? (
         <section
-          role={visibleRecovery.kind === "failed" ? "alert" : undefined}
+          role={
+            visibleRecovery.kind === "failed"
+              ? "alert"
+              : visibleRecovery.kind === "resume-unavailable"
+                ? "status"
+                : undefined
+          }
           aria-live={
-            visibleRecovery.kind === "failed" ? "assertive" : undefined
+            visibleRecovery.kind === "failed"
+              ? "assertive"
+              : visibleRecovery.kind === "resume-unavailable"
+                ? "polite"
+                : undefined
           }
           data-has-inline-actions={recoveryHasInlineAction ? "true" : "false"}
           className={cn(
             styles.chromeCard,
             visibleRecovery.kind === "failed"
               ? styles.chromeCardDanger
-              : visibleRecovery.kind === "warning"
-                ? styles.chromeCardDanger
-                : visibleRecovery.kind === "activating"
-                  ? styles.chromeCardConnecting
-                  : styles.chromeCardMuted
+              : visibleRecovery.kind === "resume-unavailable"
+                ? styles.chromeCardSuccess
+                : visibleRecovery.kind === "warning"
+                  ? styles.chromeCardDanger
+                  : visibleRecovery.kind === "activating"
+                    ? styles.chromeCardConnecting
+                    : styles.chromeCardMuted
           )}
         >
           <div className={styles.chromeMetaRow}>
@@ -276,14 +289,12 @@ export function AgentSessionChrome({
               </ChromeMessageTooltip>
             </div>
             <div className={styles.chromeInlineActions}>
-              {visibleRecovery.kind === "failed" &&
-              visibleRecovery.followupAction ===
-                "continue-in-new-conversation" ? (
+              {visibleRecovery.kind === "resume-unavailable" ? (
                 <Button
                   type="button"
                   variant="ghost"
                   size="sm"
-                  className={styles.chromeDangerGhostButton}
+                  className={styles.chromeSuccessGhostButton}
                   onClick={() => onContinueInNewConversation()}
                 >
                   {labels.continueInNewConversation}

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUINodeController.spec.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUINodeController.spec.tsx
@@ -9932,6 +9932,48 @@ describe("useAgentGUINodeController", () => {
     expect(exec).not.toHaveBeenCalled();
   });
 
+  it("uses the imported-conversation copy for non-resumable imported sessions", async () => {
+    installAgentHostApi({
+      list: vi.fn(async () => ({
+        presences: [],
+        sessions: [
+          workspaceAgentSession("session-1", {
+            resumable: false,
+            runtimeContext: { imported: true }
+          })
+        ]
+      })),
+      listSessionTimeline: vi.fn(async () => ({ timelineItems: [] })),
+      subscribeEvents: vi.fn(() => vi.fn()),
+      getState: vi.fn(async () =>
+        agentSessionState("session-1", {
+          resumable: false,
+          runtimeContext: { imported: true }
+        })
+      )
+    });
+
+    const { result } = renderHook(() =>
+      useAgentGUINodeController({
+        workspaceId: "room-1",
+        currentUserId: "user-1",
+        workspacePath: "/workspace",
+        avoidGroupingEdits: false,
+        data: agentGuiData("session-1"),
+        onDataChange: vi.fn()
+      })
+    );
+
+    await waitFor(() => {
+      expect(result.current.viewModel.sessionChrome.recovery).toEqual(
+        expect.objectContaining({ kind: "resume-unavailable" })
+      );
+    });
+    expect(result.current.viewModel.sessionChrome.recovery?.message).toBe(
+      "This conversation was imported successfully. Start a new session and @this conversation to keep going."
+    );
+  });
+
   it("does not keep reloading durable session state after a non-local resume failure", async () => {
     vi.useFakeTimers();
     let activityListener:

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUINodeController.spec.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUINodeController.spec.tsx
@@ -9823,8 +9823,8 @@ describe("useAgentGUINodeController", () => {
     expect(result.current.viewModel.canSubmit).toBe(false);
     expect(result.current.viewModel.sessionChrome.recovery).toEqual(
       expect.objectContaining({
-        kind: "failed",
-        canRetry: false
+        kind: "resume-unavailable",
+        followupAction: "continue-in-new-conversation"
       })
     );
   });
@@ -9868,8 +9868,7 @@ describe("useAgentGUINodeController", () => {
     expect(result.current.viewModel.canSubmit).toBe(false);
     expect(result.current.viewModel.sessionChrome.recovery).toEqual(
       expect.objectContaining({
-        kind: "failed",
-        canRetry: false,
+        kind: "resume-unavailable",
         followupAction: "continue-in-new-conversation"
       })
     );
@@ -9918,8 +9917,7 @@ describe("useAgentGUINodeController", () => {
     });
     expect(result.current.viewModel.sessionChrome.recovery).toEqual(
       expect.objectContaining({
-        kind: "failed",
-        canRetry: false,
+        kind: "resume-unavailable",
         followupAction: "continue-in-new-conversation"
       })
     );

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUINodeController.spec.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUINodeController.spec.tsx
@@ -9933,15 +9933,12 @@ describe("useAgentGUINodeController", () => {
   });
 
   it("uses the imported-conversation copy for non-resumable imported sessions", async () => {
+    // The list summary deliberately carries no import marker so this
+    // exercises the session-state runtimeContext fallback on its own.
     installAgentHostApi({
       list: vi.fn(async () => ({
         presences: [],
-        sessions: [
-          workspaceAgentSession("session-1", {
-            resumable: false,
-            runtimeContext: { imported: true }
-          })
-        ]
+        sessions: [workspaceAgentSession("session-1", { resumable: false })]
       })),
       listSessionTimeline: vi.fn(async () => ({ timelineItems: [] })),
       subscribeEvents: vi.fn(() => vi.fn()),

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUINodeController.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUINodeController.ts
@@ -10583,9 +10583,15 @@ export function useAgentGUINodeController({
     const isResumeNotLocalRecovery =
       isResumeSessionNotLocalErrorCode(activationErrorCode) ||
       activeConversationResumeUnavailable;
+    // The import marker rides on the conversation summary when the list
+    // snapshot carried runtimeContext, and on the session state's persisted
+    // runtimeContext otherwise (transient summaries drop it).
+    const isImportedConversation =
+      activeConversation?.isImported === true ||
+      runtimeContext?.imported === true;
     const recoveryMessage = isResumeNotLocalRecovery
       ? translate(
-          activeConversation?.isImported
+          isImportedConversation
             ? "messages.agentImportedSessionResumeUnavailable"
             : "messages.agentResumeSessionNotLocal"
         )

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUINodeController.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUINodeController.ts
@@ -10573,14 +10573,23 @@ export function useAgentGUINodeController({
           /auth|sign in|log in|login|unauthorized|authenticated/i.test(
             normalizedError
           )));
-    const recoveryMessage =
-      normalizedError ||
-      (activeConversationResumeUnavailable
-        ? translate("messages.agentResumeSessionNotLocal")
-        : "");
-    const recoveryIsNonRetryable =
-      isNonRetryableResumeErrorCode(activationErrorCode) ||
+    // Resuming a session on this device is impossible whenever the provider
+    // session id was never captured locally (imported conversations) or the
+    // ACP adapter never reported a resume method. Imported conversations are
+    // an expected, successful outcome ("continue in a new conversation"), not
+    // a failure, so they get their own copy and a non-alarming tone; the rare
+    // non-import case (e.g. an ACP agent without resume support) keeps the
+    // original neutral wording.
+    const isResumeNotLocalRecovery =
+      isResumeSessionNotLocalErrorCode(activationErrorCode) ||
       activeConversationResumeUnavailable;
+    const recoveryMessage = isResumeNotLocalRecovery
+      ? translate(
+          activeConversation?.isImported
+            ? "messages.agentImportedSessionResumeUnavailable"
+            : "messages.agentResumeSessionNotLocal"
+        )
+      : normalizedError;
     return {
       auth: hasProviderSessionNotFoundError
         ? null
@@ -10603,21 +10612,24 @@ export function useAgentGUINodeController({
               message: "Reconnecting to the live agent session…"
             }
           : !isAuthError && recoveryMessage
-            ? {
-                kind: "failed",
-                message: recoveryMessage,
-                canRetry: !recoveryIsNonRetryable,
-                ...(isResumeSessionNotLocalErrorCode(activationErrorCode) ||
-                activeConversationResumeUnavailable
-                  ? { followupAction: "continue-in-new-conversation" as const }
-                  : {})
-              }
+            ? isResumeNotLocalRecovery
+              ? {
+                  kind: "resume-unavailable",
+                  message: recoveryMessage,
+                  followupAction: "continue-in-new-conversation" as const
+                }
+              : {
+                  kind: "failed",
+                  message: recoveryMessage,
+                  canRetry: !isNonRetryableResumeErrorCode(activationErrorCode)
+                }
             : null,
       rawState: activeSessionState
     };
   }, [
     activationError,
     activationErrorCode,
+    activeConversation,
     activeLiveState,
     activeConversationId,
     activeConversationResumeUnavailable,

--- a/packages/agent/gui/agent-gui/agentGuiNode/model/agentGuiNodeTypes.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/model/agentGuiNodeTypes.ts
@@ -31,7 +31,7 @@ export interface AgentGUISessionChrome {
   } | null;
   approval: AgentGUIApprovalRequest | null;
   recovery: {
-    kind: "activating" | "failed" | "warning";
+    kind: "activating" | "failed" | "warning" | "resume-unavailable";
     message: string;
     canRetry?: boolean;
     followupAction?: "continue-in-new-conversation";

--- a/packages/agent/gui/agent-gui/agentGuiNode/model/agentGuiNodeTypes.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/model/agentGuiNodeTypes.ts
@@ -35,6 +35,9 @@ export interface AgentGUISessionChrome {
         kind: "activating" | "failed" | "warning";
         message: string;
         canRetry?: boolean;
+        // `never` blocks structurally-typed values (variables, spreads) from
+        // smuggling a continue action onto a failed/warning recovery.
+        followupAction?: never;
       }
     // Discriminated so the continue action cannot be omitted for a
     // resume-unavailable recovery, nor smuggled onto a failed one.
@@ -42,6 +45,7 @@ export interface AgentGUISessionChrome {
         kind: "resume-unavailable";
         message: string;
         followupAction: "continue-in-new-conversation";
+        canRetry?: never;
       }
     | null;
   rawState: AgentSessionState | null;

--- a/packages/agent/gui/agent-gui/agentGuiNode/model/agentGuiNodeTypes.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/model/agentGuiNodeTypes.ts
@@ -30,12 +30,20 @@ export interface AgentGUISessionChrome {
     message: string;
   } | null;
   approval: AgentGUIApprovalRequest | null;
-  recovery: {
-    kind: "activating" | "failed" | "warning" | "resume-unavailable";
-    message: string;
-    canRetry?: boolean;
-    followupAction?: "continue-in-new-conversation";
-  } | null;
+  recovery:
+    | {
+        kind: "activating" | "failed" | "warning";
+        message: string;
+        canRetry?: boolean;
+      }
+    // Discriminated so the continue action cannot be omitted for a
+    // resume-unavailable recovery, nor smuggled onto a failed one.
+    | {
+        kind: "resume-unavailable";
+        message: string;
+        followupAction: "continue-in-new-conversation";
+      }
+    | null;
   rawState: AgentSessionState | null;
 }
 

--- a/packages/agent/gui/app/renderer/agentactivity.css
+++ b/packages/agent/gui/app/renderer/agentactivity.css
@@ -2837,6 +2837,15 @@ aside.workspace-agents-status-panel
 }
 
 .agent-gui-chrome__card--success {
+  /* --state-success alone reads ~2:1 against the light-theme card wash;
+     mixing toward --text-primary keeps the hue while adapting the contrast
+     in both themes. Borders/backgrounds stay on the raw token. */
+  --agent-gui-chrome-success-foreground: color-mix(
+    in srgb,
+    var(--state-success) 62%,
+    var(--text-primary)
+  );
+
   border-color: color-mix(in srgb, var(--state-success) 28%, transparent);
   border-bottom: 0;
   border-top-left-radius: 8px;
@@ -2857,12 +2866,12 @@ aside.workspace-agents-status-panel
 
 .agent-gui-chrome__card--success .agent-gui-chrome__icon,
 .agent-gui-chrome__card--success .agent-gui-chrome__message {
-  color: var(--state-success);
+  color: var(--agent-gui-chrome-success-foreground, var(--state-success));
 }
 
 .agent-gui-chrome__success-ghost-button {
   background: transparent;
-  color: var(--state-success);
+  color: var(--agent-gui-chrome-success-foreground, var(--state-success));
   font-size: 13px;
   font-weight: 400;
 }
@@ -2873,7 +2882,7 @@ aside.workspace-agents-status-panel
 
 .agent-gui-chrome__success-ghost-button:focus-visible {
   border-color: var(--state-success);
-  color: var(--state-success);
+  color: var(--agent-gui-chrome-success-foreground, var(--state-success));
   box-shadow: 0 0 0 2px
     color-mix(in srgb, var(--state-success) 25%, transparent);
 }

--- a/packages/agent/gui/app/renderer/agentactivity.css
+++ b/packages/agent/gui/app/renderer/agentactivity.css
@@ -2839,10 +2839,11 @@ aside.workspace-agents-status-panel
 .agent-gui-chrome__card--success {
   /* --state-success alone reads ~2:1 against the light-theme card wash;
      mixing toward --text-primary keeps the hue while adapting the contrast
-     in both themes. Borders/backgrounds stay on the raw token. */
+     in both themes (45% keeps 13px text past the 4.5:1 target). Borders and
+     backgrounds stay on the raw token. */
   --agent-gui-chrome-success-foreground: color-mix(
     in srgb,
-    var(--state-success) 62%,
+    var(--state-success) 45%,
     var(--text-primary)
   );
 

--- a/packages/agent/gui/app/renderer/agentactivity.css
+++ b/packages/agent/gui/app/renderer/agentactivity.css
@@ -554,6 +554,7 @@
 
   .agent-gui-chrome__card--warning,
   .agent-gui-chrome__card--danger,
+  .agent-gui-chrome__card--success,
   .agent-gui-chrome__card--muted,
   .agent-gui-chrome__card--connecting {
     animation: none !important;
@@ -2920,6 +2921,8 @@ aside.workspace-agents-status-panel
 .agent-gui-chrome__card--warning
   .agent-gui-chrome__message:not(.agent-gui-chrome__notice-message),
 .agent-gui-chrome__card--danger
+  .agent-gui-chrome__message:not(.agent-gui-chrome__notice-message),
+.agent-gui-chrome__card--success
   .agent-gui-chrome__message:not(.agent-gui-chrome__notice-message),
 .agent-gui-chrome__card--muted
   .agent-gui-chrome__message:not(.agent-gui-chrome__notice-message),

--- a/packages/agent/gui/app/renderer/agentactivity.css
+++ b/packages/agent/gui/app/renderer/agentactivity.css
@@ -2669,6 +2669,7 @@ aside.workspace-agents-status-panel
 
 .agent-gui-chrome__card--warning,
 .agent-gui-chrome__card--danger,
+.agent-gui-chrome__card--success,
 .agent-gui-chrome__card--muted,
 .agent-gui-chrome__card--connecting {
   --agent-gui-chrome-card-spring: cubic-bezier(0.22, 1.18, 0.36, 1);
@@ -2832,6 +2833,48 @@ aside.workspace-agents-status-panel
 .agent-gui-chrome__danger-ghost-button:hover:not(:disabled) {
   background: var(--on-danger-hover);
   color: var(--status-danger-hover, var(--state-danger-hover));
+}
+
+.agent-gui-chrome__card--success {
+  border-color: color-mix(in srgb, var(--state-success) 28%, transparent);
+  border-bottom: 0;
+  border-top-left-radius: 8px;
+  border-top-right-radius: 8px;
+  border-bottom-right-radius: 0;
+  border-bottom-left-radius: 0;
+  background: color-mix(
+    in srgb,
+    var(--state-success) 10%,
+    var(--background-fronted)
+  );
+  grid-template-columns: minmax(0, 1fr) auto;
+  align-items: center;
+  min-height: 36px;
+  padding: 6px 16px;
+  cursor: default;
+}
+
+.agent-gui-chrome__card--success .agent-gui-chrome__icon,
+.agent-gui-chrome__card--success .agent-gui-chrome__message {
+  color: var(--state-success);
+}
+
+.agent-gui-chrome__success-ghost-button {
+  background: transparent;
+  color: var(--state-success);
+  font-size: 13px;
+  font-weight: 400;
+}
+
+.agent-gui-chrome__success-ghost-button:hover:not(:disabled) {
+  background: color-mix(in srgb, var(--state-success) 14%, transparent);
+}
+
+.agent-gui-chrome__success-ghost-button:focus-visible {
+  border-color: var(--state-success);
+  color: var(--state-success);
+  box-shadow: 0 0 0 2px
+    color-mix(in srgb, var(--state-success) 25%, transparent);
 }
 
 .agent-gui-chrome__danger-ghost-button:focus-visible {

--- a/packages/agent/gui/app/renderer/i18n/locales/en.messages.ts
+++ b/packages/agent/gui/app/renderer/i18n/locales/en.messages.ts
@@ -5,6 +5,8 @@ export const enMessages = {
     "This session history is still available, but the underlying provider session can no longer be restored.",
   agentResumeSessionNotLocal:
     "This session cannot be resumed on this device. Start a new session and @this session to keep going.",
+  agentImportedSessionResumeUnavailable:
+    "This conversation was imported successfully. Start a new session and @this conversation to keep going.",
   agentSettingsRequireNewSession:
     "This model can only be used in a new session to preserve context.",
   agentPermissionModeAppliesNextTurn:

--- a/packages/agent/gui/app/renderer/i18n/locales/zh-CN.messages.ts
+++ b/packages/agent/gui/app/renderer/i18n/locales/zh-CN.messages.ts
@@ -5,6 +5,8 @@ export const zhCNMessages = {
     "这条会话历史仍可查看，但底层 Provider 会话已经无法恢复。",
   agentResumeSessionNotLocal:
     "这个会话没法在当前设备里直接恢复，你可以在新会话里 @这段对话，接着继续聊。",
+  agentImportedSessionResumeUnavailable:
+    "这段对话已导入成功，新开会话并 @ 这段对话，接着继续聊。",
   agentSettingsRequireNewSession: "为了保留上下文，这个模型只能在新会话中使用",
   agentPermissionModeAppliesNextTurn: "权限模式将从你的下一条消息开始生效。",
   agentThisSessionMentionLabel: "本 session",

--- a/packages/agent/gui/shared/agentActivitySnapshotProjection.ts
+++ b/packages/agent/gui/shared/agentActivitySnapshotProjection.ts
@@ -115,6 +115,12 @@ function agentHostSessionFromCore(
     effectiveStatus: agentHostEffectiveStatusFromDisplay(displayStatus),
     id,
     lifecycleStatus: agentHostLifecycleStatusFromDisplay(displayStatus),
+    // Import-classification markers ride on runtimeContext; dropping them
+    // here would strip `imported`/no-project flags from every projected
+    // snapshot and leave summaries depending on the initial daemon list.
+    ...(session.runtimeContext
+      ? { runtimeContext: session.runtimeContext }
+      : {}),
     presenceId,
     pinnedAtUnixMs: session.pinnedAtUnixMs,
     provider: session.provider,

--- a/packages/agent/gui/shared/contracts/dto/agentHost.ts
+++ b/packages/agent/gui/shared/contracts/dto/agentHost.ts
@@ -926,6 +926,9 @@ export interface AgentHostWorkspaceAgentSession {
   title?: string;
   status?: AgentHostWorkspaceAgentSessionStatus;
   syncState?: AgentHostWorkspaceAgentSyncState;
+  // Tutti-app-level annotations stamped at import time (imported,
+  // externalImportNoProject, ...); conversation summaries read them.
+  runtimeContext?: Record<string, unknown>;
 }
 
 export interface AgentHostWorkspaceAgentSyncState {

--- a/packages/clients/tuttid-ts/src/generated/sdk.gen.ts
+++ b/packages/clients/tuttid-ts/src/generated/sdk.gen.ts
@@ -1564,7 +1564,7 @@ export const listWorkspaceAgentSessionSectionPage = <
   });
 
 /**
- * Scan external local agent session history that can be imported into one workspace
+ * Scan local agent history or a supported provider export that can be imported into one workspace
  */
 export const scanWorkspaceExternalAgentSessionImports = <
   ThrowOnError extends boolean = false
@@ -1586,7 +1586,7 @@ export const scanWorkspaceExternalAgentSessionImports = <
   });
 
 /**
- * Import selected external local agent session history into one workspace
+ * Import selected local agent history or provider-export conversations into one workspace
  */
 export const importWorkspaceExternalAgentSessions = <
   ThrowOnError extends boolean = false

--- a/packages/clients/tuttid-ts/src/generated/types.gen.ts
+++ b/packages/clients/tuttid-ts/src/generated/types.gen.ts
@@ -1280,6 +1280,10 @@ export type WorkspaceAgentSessionSectionPageResponse = {
 };
 
 export type ExternalAgentImportScanRequest = {
+  /**
+   * Absolute path to a supported provider data-export ZIP archive. When supplied, scan the archive instead of local CLI history.
+   */
+  archivePath?: string;
   providers?: Array<WorkspaceAgentProvider>;
   /**
    * Limit the scan to conversations updated within the last N days. Omit or 0 for the default 30-day window; a negative value scans all available history.
@@ -1338,6 +1342,10 @@ export type ExternalAgentImportProjectSelection = {
 };
 
 export type ImportExternalAgentSessionsRequest = {
+  /**
+   * Absolute path to the same provider data-export ZIP archive used for the preceding scan. The daemon revalidates and rereads the archive before importing the selected conversations.
+   */
+  archivePath?: string;
   projects: Array<ExternalAgentImportProjectSelection>;
   registerUserProjects?: boolean;
   importSessions?: boolean;

--- a/services/tuttid/api/daemon_agent_sessions_external_import.go
+++ b/services/tuttid/api/daemon_agent_sessions_external_import.go
@@ -19,6 +19,7 @@ func (api DaemonAPI) ScanWorkspaceExternalAgentSessionImports(ctx context.Contex
 	}
 	input := agentservice.ExternalImportScanInput{}
 	if request.Body != nil {
+		input.ArchivePath = optionalStringValue(request.Body.ArchivePath)
 		input.Providers = externalImportProvidersFromGenerated(request.Body.Providers)
 		if request.Body.Days != nil {
 			input.Days = *request.Body.Days
@@ -45,6 +46,7 @@ func (api DaemonAPI) ImportWorkspaceExternalAgentSessions(ctx context.Context, r
 		}, nil
 	}
 	projects := externalImportProjectSelectionsFromGenerated(request.Body.Projects)
+	archivePath := optionalStringValue(request.Body.ArchivePath)
 	register := request.Body.RegisterUserProjects == nil || *request.Body.RegisterUserProjects
 	importSessions := request.Body.ImportSessions == nil || *request.Body.ImportSessions
 
@@ -57,7 +59,8 @@ func (api DaemonAPI) ImportWorkspaceExternalAgentSessions(ctx context.Context, r
 	if importSessions {
 		var err error
 		result, err = api.AgentSessionService.ImportExternalSessions(ctx, string(request.WorkspaceID), agentservice.ExternalImportInput{
-			Projects: projects,
+			ArchivePath: archivePath,
+			Projects:    projects,
 		})
 		if err != nil {
 			return writeImportWorkspaceExternalAgentSessionsError(err), nil
@@ -66,7 +69,8 @@ func (api DaemonAPI) ImportWorkspaceExternalAgentSessions(ctx context.Context, r
 	} else {
 		var err error
 		validPaths, err = api.AgentSessionService.ExternalImportValidProjectPaths(ctx, agentservice.ExternalImportInput{
-			Projects: projects,
+			ArchivePath: archivePath,
+			Projects:    projects,
 		})
 		if err != nil {
 			return writeImportWorkspaceExternalAgentSessionsError(err), nil

--- a/services/tuttid/api/daemon_agent_sessions_external_import_test.go
+++ b/services/tuttid/api/daemon_agent_sessions_external_import_test.go
@@ -4,10 +4,72 @@ import (
 	"context"
 	"testing"
 
+	tuttigenerated "github.com/tutti-os/tutti/services/tuttid/api/generated"
 	userprojectbiz "github.com/tutti-os/tutti/services/tuttid/biz/userproject"
 	agentservice "github.com/tutti-os/tutti/services/tuttid/service/agent"
 	userprojectservice "github.com/tutti-os/tutti/services/tuttid/service/userproject"
 )
+
+func TestScanExternalImportForwardsArchivePath(t *testing.T) {
+	archivePath := "/tmp/claude-export.zip"
+	var captured agentservice.ExternalImportScanInput
+	api := DaemonAPI{AgentSessionService: stubAgentSessionService{
+		scanExternalFn: func(_ context.Context, input agentservice.ExternalImportScanInput) (agentservice.ExternalImportScanResult, error) {
+			captured = input
+			return agentservice.ExternalImportScanResult{}, nil
+		},
+	}}
+
+	response, err := api.ScanWorkspaceExternalAgentSessionImports(context.Background(), tuttigenerated.ScanWorkspaceExternalAgentSessionImportsRequestObject{
+		WorkspaceID: "ws-1",
+		Body: &tuttigenerated.ExternalAgentImportScanRequest{
+			ArchivePath: &archivePath,
+		},
+	})
+	if err != nil {
+		t.Fatalf("ScanWorkspaceExternalAgentSessionImports error = %v", err)
+	}
+	if _, ok := response.(tuttigenerated.ScanWorkspaceExternalAgentSessionImports200JSONResponse); !ok {
+		t.Fatalf("response = %T, want 200", response)
+	}
+	if captured.ArchivePath != archivePath {
+		t.Fatalf("archive path = %q, want %q", captured.ArchivePath, archivePath)
+	}
+}
+
+func TestImportExternalSessionsForwardsArchivePath(t *testing.T) {
+	archivePath := "/tmp/claude-export.zip"
+	var captured agentservice.ExternalImportInput
+	api := DaemonAPI{AgentSessionService: stubAgentSessionService{
+		importExternalFn: func(_ context.Context, workspaceID string, input agentservice.ExternalImportInput) (agentservice.ExternalImportResult, error) {
+			if workspaceID != "ws-1" {
+				t.Fatalf("workspace id = %q", workspaceID)
+			}
+			captured = input
+			return agentservice.ExternalImportResult{}, nil
+		},
+	}}
+
+	response, err := api.ImportWorkspaceExternalAgentSessions(context.Background(), tuttigenerated.ImportWorkspaceExternalAgentSessionsRequestObject{
+		WorkspaceID: "ws-1",
+		Body: &tuttigenerated.ImportExternalAgentSessionsRequest{
+			ArchivePath: &archivePath,
+			Projects: []tuttigenerated.ExternalAgentImportProjectSelection{{
+				Path:       "/Users/demo",
+				SessionIds: &[]string{"session-1"},
+			}},
+		},
+	})
+	if err != nil {
+		t.Fatalf("ImportWorkspaceExternalAgentSessions error = %v", err)
+	}
+	if _, ok := response.(tuttigenerated.ImportWorkspaceExternalAgentSessions200JSONResponse); !ok {
+		t.Fatalf("response = %T, want 200", response)
+	}
+	if captured.ArchivePath != archivePath || len(captured.Projects) != 1 {
+		t.Fatalf("captured input = %#v", captured)
+	}
+}
 
 func TestRegisterExternalImportUserProjectsPreservesInputOrderInLastUsedTimes(t *testing.T) {
 	var inputs []userprojectservice.UseInput

--- a/services/tuttid/api/generated/server.gen.go
+++ b/services/tuttid/api/generated/server.gen.go
@@ -118,10 +118,10 @@ type ServerInterface interface {
 	// Create an agent session for one workspace
 	// (POST /v1/workspaces/{workspaceID}/agent-sessions)
 	CreateWorkspaceAgentSession(w http.ResponseWriter, r *http.Request, workspaceID WorkspaceID)
-	// Import selected external local agent session history into one workspace
+	// Import selected local agent history or provider-export conversations into one workspace
 	// (POST /v1/workspaces/{workspaceID}/agent-sessions/external-imports/import)
 	ImportWorkspaceExternalAgentSessions(w http.ResponseWriter, r *http.Request, workspaceID WorkspaceID)
-	// Scan external local agent session history that can be imported into one workspace
+	// Scan local agent history or a supported provider export that can be imported into one workspace
 	// (POST /v1/workspaces/{workspaceID}/agent-sessions/external-imports/scan)
 	ScanWorkspaceExternalAgentSessionImports(w http.ResponseWriter, r *http.Request, workspaceID WorkspaceID)
 	// Delete one workspace agent session
@@ -21266,10 +21266,10 @@ type StrictServerInterface interface {
 	// Create an agent session for one workspace
 	// (POST /v1/workspaces/{workspaceID}/agent-sessions)
 	CreateWorkspaceAgentSession(ctx context.Context, request CreateWorkspaceAgentSessionRequestObject) (CreateWorkspaceAgentSessionResponseObject, error)
-	// Import selected external local agent session history into one workspace
+	// Import selected local agent history or provider-export conversations into one workspace
 	// (POST /v1/workspaces/{workspaceID}/agent-sessions/external-imports/import)
 	ImportWorkspaceExternalAgentSessions(ctx context.Context, request ImportWorkspaceExternalAgentSessionsRequestObject) (ImportWorkspaceExternalAgentSessionsResponseObject, error)
-	// Scan external local agent session history that can be imported into one workspace
+	// Scan local agent history or a supported provider export that can be imported into one workspace
 	// (POST /v1/workspaces/{workspaceID}/agent-sessions/external-imports/scan)
 	ScanWorkspaceExternalAgentSessionImports(ctx context.Context, request ScanWorkspaceExternalAgentSessionImportsRequestObject) (ScanWorkspaceExternalAgentSessionImportsResponseObject, error)
 	// Delete one workspace agent session

--- a/services/tuttid/api/generated/types.gen.go
+++ b/services/tuttid/api/generated/types.gen.go
@@ -2670,6 +2670,9 @@ type ExternalAgentImportResultResponse struct {
 
 // ExternalAgentImportScanRequest defines model for ExternalAgentImportScanRequest.
 type ExternalAgentImportScanRequest struct {
+	// ArchivePath Absolute path to a supported provider data-export ZIP archive. When supplied, scan the archive instead of local CLI history.
+	ArchivePath *string `json:"archivePath,omitempty"`
+
 	// Days Limit the scan to conversations updated within the last N days. Omit or 0 for the default 30-day window; a negative value scans all available history.
 	Days      *int                      `json:"days,omitempty"`
 	Providers *[]WorkspaceAgentProvider `json:"providers,omitempty"`
@@ -2729,6 +2732,8 @@ type HealthStatusResponseStatus string
 
 // ImportExternalAgentSessionsRequest defines model for ImportExternalAgentSessionsRequest.
 type ImportExternalAgentSessionsRequest struct {
+	// ArchivePath Absolute path to the same provider data-export ZIP archive used for the preceding scan. The daemon revalidates and rereads the archive before importing the selected conversations.
+	ArchivePath          *string                               `json:"archivePath,omitempty"`
 	ImportSessions       *bool                                 `json:"importSessions,omitempty"`
 	Projects             []ExternalAgentImportProjectSelection `json:"projects"`
 	RegisterUserProjects *bool                                 `json:"registerUserProjects,omitempty"`

--- a/services/tuttid/api/openapi/tuttid.v1.yaml
+++ b/services/tuttid/api/openapi/tuttid.v1.yaml
@@ -1828,7 +1828,7 @@ paths:
       operationId: scanWorkspaceExternalAgentSessionImports
       tags:
         - agent-session
-      summary: Scan external local agent session history that can be imported into one workspace
+      summary: Scan local agent history or a supported provider export that can be imported into one workspace
       requestBody:
         required: false
         content:
@@ -1861,7 +1861,7 @@ paths:
       operationId: importWorkspaceExternalAgentSessions
       tags:
         - agent-session
-      summary: Import selected external local agent session history into one workspace
+      summary: Import selected local agent history or provider-export conversations into one workspace
       requestBody:
         required: true
         content:
@@ -6525,6 +6525,12 @@ components:
       type: object
       additionalProperties: false
       properties:
+        archivePath:
+          type: string
+          minLength: 1
+          description: >-
+            Absolute path to a supported provider data-export ZIP archive.
+            When supplied, scan the archive instead of local CLI history.
         providers:
           type: array
           items:
@@ -6699,6 +6705,13 @@ components:
       required:
         - projects
       properties:
+        archivePath:
+          type: string
+          minLength: 1
+          description: >-
+            Absolute path to the same provider data-export ZIP archive used
+            for the preceding scan. The daemon revalidates and rereads the
+            archive before importing the selected conversations.
         projects:
           type: array
           minItems: 1

--- a/services/tuttid/service/agent/composer_settings_payload.go
+++ b/services/tuttid/service/agent/composer_settings_payload.go
@@ -125,7 +125,8 @@ func createSessionInputFromPersisted(session PersistedSession) CreateSessionInpu
 		input.Speed = &normalizedSpeed
 	}
 	input.ConversationDetailMode = preferencesbiz.NormalizeDesktopAgentConversationDetailMode(settings.ConversationDetailMode)
-	if sourcePath, ok := session.RuntimeContext["externalSourcePath"].(string); ok {
+	if sourcePath, ok := session.RuntimeContext["externalSourcePath"].(string); ok &&
+		externalImportResumeSupported(session.RuntimeContext) {
 		input.ExternalRolloutSourcePath = strings.TrimSpace(sourcePath)
 	}
 	return input

--- a/services/tuttid/service/agent/composer_settings_payload_test.go
+++ b/services/tuttid/service/agent/composer_settings_payload_test.go
@@ -93,6 +93,21 @@ func TestCreateSessionInputFromPersistedCarriesExternalRolloutSourcePath(t *test
 	}
 }
 
+func TestCreateSessionInputFromPersistedDoesNotTreatClaudeExportAsRollout(t *testing.T) {
+	input := createSessionInputFromPersisted(PersistedSession{
+		ID:       "session-1",
+		Provider: "claude-code",
+		RuntimeContext: map[string]any{
+			"imported":                      true,
+			"externalImportResumeSupported": false,
+			"externalSourcePath":            "/home/user/Downloads/claude-export.zip",
+		},
+	})
+	if input.ExternalRolloutSourcePath != "" {
+		t.Fatalf("ExternalRolloutSourcePath = %q, want archive path excluded from provider resume", input.ExternalRolloutSourcePath)
+	}
+}
+
 func TestCreateSessionInputFromPersistedLeavesExternalRolloutSourcePathEmptyForNonImportedSession(t *testing.T) {
 	input := createSessionInputFromPersisted(PersistedSession{
 		ID:       "session-1",

--- a/services/tuttid/service/agent/external_import.go
+++ b/services/tuttid/service/agent/external_import.go
@@ -19,118 +19,11 @@ import (
 	agenttargetbiz "github.com/tutti-os/tutti/services/tuttid/biz/agenttarget"
 )
 
-type ExternalImportScanInput struct {
-	Providers []string
-	// Days limits the scan window to conversations updated within the last N
-	// days. 0 keeps the default 30-day window; a negative value scans all
-	// available history.
-	Days int
-}
-
-type ExternalImportInput struct {
-	Projects []ExternalImportProjectSelection
-}
-
-type ExternalImportProjectSelection struct {
-	Path       string
-	Providers  []string
-	SessionIDs []string
-}
-
-type ExternalImportScanResult struct {
-	Providers       []ExternalImportProvider
-	Projects        []ExternalImportProject
-	Sessions        []ExternalImportSession
-	ScannedSessions int
-	ScannedMessages int
-	SkippedSessions int
-	Errors          []ExternalImportError
-}
-
-type ExternalImportProvider struct {
-	Provider     string
-	Root         string
-	Available    bool
-	SessionCount int
-	MessageCount int
-	Error        string
-}
-
-type ExternalImportProject struct {
-	Path                string
-	Label               string
-	Providers           []string
-	SessionCount        int
-	MessageCount        int
-	LastUpdatedAtUnixMS int64
-}
-
-type ExternalImportSession struct {
-	ID                  string
-	ProjectPath         string
-	Provider            string
-	SourcePath          string
-	Title               string
-	MessageCount        int
-	LastUpdatedAtUnixMS int64
-}
-
-type ExternalImportError struct {
-	Provider   string
-	SourcePath string
-	Message    string
-}
-
-type ExternalImportResult struct {
-	ImportedProjects int
-	ImportedSessions int
-	ImportedMessages int
-	SkippedSessions  int
-	Errors           []ExternalImportError
-	// ProjectPaths lists the selected project paths that matched at least one
-	// valid imported session. Callers use it to avoid registering user projects
-	// that would surface with no sessions underneath them.
-	ProjectPaths []string
-}
-
-type externalImportedSession struct {
-	Provider          string
-	ProviderSessionID string
-	SourcePath        string
-	Cwd               string
-	Title             string
-	// SummaryTitle holds an authoritative, provider-supplied conversation title
-	// (e.g. Claude `custom-title`/`summary` transcript lines or the Codex
-	// app-server `threads.title`). When present it wins over message-derived
-	// titles.
-	SummaryTitle     string
-	NoProject        bool
-	EventUserMessage externalImportedMessage
-	StartedAtUnixMS  int64
-	UpdatedAtUnixMS  int64
-	Messages         []externalImportedMessage
-}
-
-type externalImportedMessage struct {
-	RawID             string
-	MessageIDSeed     string
-	Role              string
-	Kind              string
-	Status            string
-	Text              string
-	Payload           map[string]any
-	OccurredAtUnixMS  int64
-	StartedAtUnixMS   int64
-	CompletedAtUnixMS int64
-}
-
-type externalScanData struct {
-	result   ExternalImportScanResult
-	sessions []externalImportedSession
-}
-
 func (*Service) ScanExternalImports(ctx context.Context, input ExternalImportScanInput) (ExternalImportScanResult, error) {
-	data := scanExternalAgentSessions(ctx, normalizeExternalImportProviders(input.Providers), input.Days)
+	data, err := scanExternalAgentSessions(ctx, normalizeExternalImportProviders(input.Providers), input.Days, input.ArchivePath)
+	if err != nil {
+		return ExternalImportScanResult{}, err
+	}
 	return data.result, nil
 }
 
@@ -149,7 +42,15 @@ func (s *Service) ImportExternalSessions(ctx context.Context, workspaceID string
 	// Scan all available history when importing: the request already filters by
 	// explicit project paths and session ids, and the picker may surface
 	// conversations older than the default 30-day window.
-	data := scanExternalAgentSessions(ctx, providersFromExternalImportSelections(selections), -1)
+	data, err := scanExternalAgentSessions(
+		ctx,
+		providersFromExternalImportSelections(selections),
+		-1,
+		input.ArchivePath,
+	)
+	if err != nil {
+		return ExternalImportResult{}, err
+	}
 	result := ExternalImportResult{
 		SkippedSessions: data.result.SkippedSessions,
 		Errors:          append([]ExternalImportError(nil), data.result.Errors...),
@@ -281,7 +182,10 @@ func externalImportAgentTargetID(provider string) string {
 	}
 }
 
-func scanExternalAgentSessions(ctx context.Context, providers []string, days int) externalScanData {
+func scanExternalAgentSessions(ctx context.Context, providers []string, days int, archivePath string) (externalScanData, error) {
+	if strings.TrimSpace(archivePath) != "" {
+		return scanClaudeExportArchive(ctx, archivePath, externalScanCutoffUnixMS(days))
+	}
 	data := externalScanData{}
 	projects := map[string]*ExternalImportProject{}
 	cutoffUnixMS := externalScanCutoffUnixMS(days)
@@ -321,7 +225,7 @@ func scanExternalAgentSessions(ctx context.Context, providers []string, days int
 		}
 		return data.result.Sessions[left].LastUpdatedAtUnixMS > data.result.Sessions[right].LastUpdatedAtUnixMS
 	})
-	return data
+	return data, nil
 }
 
 // externalScanCutoffUnixMS resolves the "updated since" cutoff for a scan
@@ -483,6 +387,15 @@ func (s *Service) importExternalSession(ctx context.Context, workspaceID string,
 			CompletedAtUnixMS: message.CompletedAtUnixMS,
 		})
 	}
+	runtimeContext := map[string]any{
+		"visible":                 true,
+		"imported":                true,
+		"externalImportNoProject": session.NoProject,
+		"externalSourcePath":      session.SourcePath,
+	}
+	if session.ResumeSupported != nil {
+		runtimeContext["externalImportResumeSupported"] = *session.ResumeSupported
+	}
 	if _, err := s.ExternalImportStore.ReportSessionState(ctx, agentactivitybiz.SessionStateReport{
 		WorkspaceID:       workspaceID,
 		AgentSessionID:    agentSessionID,
@@ -490,19 +403,14 @@ func (s *Service) importExternalSession(ctx context.Context, workspaceID string,
 		AgentTargetID:     externalImportAgentTargetID(session.Provider),
 		Provider:          session.Provider,
 		ProviderSessionID: session.ProviderSessionID,
-		RuntimeContext: map[string]any{
-			"visible":                 true,
-			"imported":                true,
-			"externalImportNoProject": session.NoProject,
-			"externalSourcePath":      session.SourcePath,
-		},
-		Cwd:              session.Cwd,
-		Title:            session.Title,
-		Status:           "completed",
-		CurrentPhase:     "completed",
-		OccurredAtUnixMS: session.UpdatedAtUnixMS,
-		StartedAtUnixMS:  session.StartedAtUnixMS,
-		EndedAtUnixMS:    session.UpdatedAtUnixMS,
+		RuntimeContext:    runtimeContext,
+		Cwd:               session.Cwd,
+		Title:             session.Title,
+		Status:            "completed",
+		CurrentPhase:      "completed",
+		OccurredAtUnixMS:  session.UpdatedAtUnixMS,
+		StartedAtUnixMS:   session.StartedAtUnixMS,
+		EndedAtUnixMS:     session.UpdatedAtUnixMS,
 	}); err != nil {
 		return 0, false, err
 	}

--- a/services/tuttid/service/agent/external_import.go
+++ b/services/tuttid/service/agent/external_import.go
@@ -184,7 +184,19 @@ func externalImportAgentTargetID(provider string) string {
 
 func scanExternalAgentSessions(ctx context.Context, providers []string, days int, archivePath string) (externalScanData, error) {
 	if strings.TrimSpace(archivePath) != "" {
-		return scanClaudeExportArchive(ctx, archivePath, externalScanCutoffUnixMS(days))
+		if len(providers) > 0 && !providersIncludeClaudeCode(providers) {
+			return externalScanData{}, fmt.Errorf(
+				"%w: a Claude export archive scan requires the claude-code provider",
+				ErrInvalidArgument,
+			)
+		}
+		// An export archive is a complete snapshot, so no implicit 30-day
+		// window applies; only an explicit positive day range narrows it.
+		cutoffUnixMS := int64(0)
+		if days > 0 {
+			cutoffUnixMS = externalScanCutoffUnixMS(days)
+		}
+		return scanClaudeExportArchive(ctx, archivePath, cutoffUnixMS)
 	}
 	data := externalScanData{}
 	projects := map[string]*ExternalImportProject{}
@@ -225,7 +237,21 @@ func scanExternalAgentSessions(ctx context.Context, providers []string, days int
 		}
 		return data.result.Sessions[left].LastUpdatedAtUnixMS > data.result.Sessions[right].LastUpdatedAtUnixMS
 	})
+	// The provider loop breaks on cancellation, so surface it instead of
+	// letting a partial scan pass as a complete result.
+	if err := ctx.Err(); err != nil {
+		return externalScanData{}, err
+	}
 	return data, nil
+}
+
+func providersIncludeClaudeCode(providers []string) bool {
+	for _, provider := range providers {
+		if agentproviderbiz.Normalize(provider) == agentproviderbiz.ClaudeCode {
+			return true
+		}
+	}
+	return false
 }
 
 // externalScanCutoffUnixMS resolves the "updated since" cutoff for a scan

--- a/services/tuttid/service/agent/external_import_claude_export.go
+++ b/services/tuttid/service/agent/external_import_claude_export.go
@@ -189,24 +189,36 @@ func openClaudeExportConversations(rawPath string) (string, *zip.File, func(), e
 	if err != nil {
 		return "", nil, func() {}, invalidClaudeExportArchive("resolve archive path: %v", err)
 	}
-	info, err := os.Stat(resolvedPath)
+	// Open the archive once and derive every subsequent check (size, directory
+	// preflight, ZIP parsing) from this one descriptor, so a concurrently
+	// replaced file cannot slip a different archive past the validation.
+	archive, err := os.Open(resolvedPath)
 	if err != nil {
+		return "", nil, func() {}, invalidClaudeExportArchive("open archive: %v", err)
+	}
+	closeArchive := func() { _ = archive.Close() }
+	info, err := archive.Stat()
+	if err != nil {
+		closeArchive()
 		return "", nil, func() {}, invalidClaudeExportArchive("inspect archive: %v", err)
 	}
 	if !info.Mode().IsRegular() {
+		closeArchive()
 		return "", nil, func() {}, invalidClaudeExportArchive("archive is not a regular file")
 	}
 	if info.Size() <= 0 || info.Size() > maxClaudeExportArchiveBytes {
+		closeArchive()
 		return "", nil, func() {}, invalidClaudeExportArchive("archive size exceeds the supported limit")
 	}
-	if err := validateClaudeExportZipDirectory(resolvedPath, info.Size()); err != nil {
+	if err := validateClaudeExportZipDirectory(archive, info.Size()); err != nil {
+		closeArchive()
 		return "", nil, func() {}, err
 	}
-	reader, err := zip.OpenReader(resolvedPath)
+	reader, err := zip.NewReader(archive, info.Size())
 	if err != nil {
+		closeArchive()
 		return "", nil, func() {}, invalidClaudeExportArchive("open ZIP: %v", err)
 	}
-	closeArchive := func() { _ = reader.Close() }
 	if len(reader.File) > maxClaudeExportArchiveEntries {
 		closeArchive()
 		return "", nil, func() {}, invalidClaudeExportArchive("archive entry count exceeds %d", maxClaudeExportArchiveEntries)

--- a/services/tuttid/service/agent/external_import_claude_export.go
+++ b/services/tuttid/service/agent/external_import_claude_export.go
@@ -1,0 +1,596 @@
+package agent
+
+import (
+	"archive/zip"
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	agentproviderbiz "github.com/tutti-os/tutti/services/tuttid/biz/agentprovider"
+)
+
+const (
+	claudeExportConversationsEntry         = "conversations.json"
+	maxClaudeExportArchiveBytes      int64 = 512 << 20
+	maxClaudeExportEntryBytes              = 512 << 20
+	maxClaudeExportConversationBytes       = 64 << 20
+	maxClaudeExportArchiveEntries          = 10_000
+	maxClaudeExportConversations           = 100_000
+	maxClaudeExportMessages                = 100_000
+)
+
+type claudeExportConversation struct {
+	ChatMessages []json.RawMessage `json:"chat_messages"`
+	CreatedAt    string            `json:"created_at"`
+	Name         string            `json:"name"`
+	Summary      string            `json:"summary"`
+	UpdatedAt    string            `json:"updated_at"`
+	UUID         string            `json:"uuid"`
+}
+
+type claudeExportMessage struct {
+	Attachments       []claudeExportAttachment `json:"attachments"`
+	Content           []claudeExportContent    `json:"content"`
+	CreatedAt         string                   `json:"created_at"`
+	Files             []claudeExportFile       `json:"files"`
+	ParentMessageUUID string                   `json:"parent_message_uuid"`
+	Sender            string                   `json:"sender"`
+	Text              string                   `json:"text"`
+	UpdatedAt         string                   `json:"updated_at"`
+	UUID              string                   `json:"uuid"`
+}
+
+type claudeExportContent struct {
+	Text string `json:"text"`
+	Type string `json:"type"`
+}
+
+type claudeExportAttachment struct {
+	FileName string `json:"file_name"`
+	FileSize int64  `json:"file_size"`
+	FileType string `json:"file_type"`
+}
+
+type claudeExportFile struct {
+	FileName string `json:"file_name"`
+	FileUUID string `json:"file_uuid"`
+}
+
+type parsedClaudeExportMessage struct {
+	Source             claudeExportMessage
+	RawID              string
+	ParentID           string
+	Role               string
+	Text               string
+	FilesPayload       []map[string]any
+	OccurredAtUnixMS   int64
+	SourceMessageIndex int
+}
+
+func scanClaudeExportArchive(ctx context.Context, archivePath string, cutoffUnixMS int64) (externalScanData, error) {
+	archivePath, entry, closeArchive, err := openClaudeExportConversations(archivePath)
+	if err != nil {
+		return externalScanData{}, err
+	}
+	defer closeArchive()
+
+	home, ok := externalImportNoProjectBucketPath()
+	if !ok {
+		return externalScanData{}, fmt.Errorf("%w: user home directory is unavailable", ErrInvalidArgument)
+	}
+	entryReader, err := entry.Open()
+	if err != nil {
+		return externalScanData{}, invalidClaudeExportArchive("open conversations.json: %v", err)
+	}
+	defer entryReader.Close()
+
+	data := externalScanData{}
+	data.result.Providers = []ExternalImportProvider{{
+		Provider:  agentproviderbiz.ClaudeCode,
+		Root:      archivePath,
+		Available: true,
+	}}
+	projects := map[string]*ExternalImportProject{}
+	conversationIDs := map[string]struct{}{}
+	messageIDs := map[string]struct{}{}
+	conversationStream, err := newClaudeExportConversationStream(ctx, entryReader)
+	if err != nil {
+		return externalScanData{}, err
+	}
+	totalMessages := 0
+	for index := 0; ; index++ {
+		if err := ctx.Err(); err != nil {
+			return externalScanData{}, err
+		}
+		raw, more, err := conversationStream.Next()
+		if err != nil {
+			return externalScanData{}, err
+		}
+		if !more {
+			break
+		}
+		if index >= maxClaudeExportConversations {
+			return externalScanData{}, invalidClaudeExportArchive("conversation count exceeds %d", maxClaudeExportConversations)
+		}
+		if err := validateClaudeExportConversationJSON(ctx, raw, index+1); err != nil {
+			return externalScanData{}, err
+		}
+		var conversation claudeExportConversation
+		if err := json.Unmarshal(raw, &conversation); err != nil {
+			return externalScanData{}, invalidClaudeExportArchive("decode conversation %d: %v", index+1, err)
+		}
+		conversationID := strings.TrimSpace(conversation.UUID)
+		if conversationID == "" {
+			conversationID = "missing-" + externalStableHash(string(raw))
+		}
+		if _, exists := conversationIDs[conversationID]; exists {
+			return externalScanData{}, invalidClaudeExportArchive("duplicate conversation id %q", conversationID)
+		}
+		conversationIDs[conversationID] = struct{}{}
+		if totalMessages+len(conversation.ChatMessages) > maxClaudeExportMessages {
+			return externalScanData{}, invalidClaudeExportArchive("message count exceeds %d", maxClaudeExportMessages)
+		}
+		totalMessages += len(conversation.ChatMessages)
+		session, valid, err := parseClaudeExportConversation(
+			ctx,
+			archivePath,
+			home,
+			conversationID,
+			conversation,
+			messageIDs,
+		)
+		if err != nil {
+			return externalScanData{}, err
+		}
+		if !valid {
+			data.result.SkippedSessions++
+			continue
+		}
+		if session.UpdatedAtUnixMS < cutoffUnixMS {
+			continue
+		}
+		project, ok := projectFromExternalSession(session)
+		if !ok {
+			data.result.SkippedSessions++
+			continue
+		}
+		data.sessions = append(data.sessions, session)
+		data.result.ScannedSessions++
+		data.result.ScannedMessages += len(session.Messages)
+		data.result.Sessions = append(data.result.Sessions, externalImportSessionSummary(session, project.Path))
+		upsertExternalImportProject(projects, project, session.Provider)
+	}
+
+	for _, project := range projects {
+		sort.Strings(project.Providers)
+		data.result.Projects = append(data.result.Projects, *project)
+	}
+	sort.SliceStable(data.result.Sessions, func(left, right int) bool {
+		if data.result.Sessions[left].LastUpdatedAtUnixMS == data.result.Sessions[right].LastUpdatedAtUnixMS {
+			return data.result.Sessions[left].ID < data.result.Sessions[right].ID
+		}
+		return data.result.Sessions[left].LastUpdatedAtUnixMS > data.result.Sessions[right].LastUpdatedAtUnixMS
+	})
+	data.result.Providers[0].SessionCount = data.result.ScannedSessions
+	data.result.Providers[0].MessageCount = data.result.ScannedMessages
+	return data, nil
+}
+
+func openClaudeExportConversations(rawPath string) (string, *zip.File, func(), error) {
+	archivePath := strings.TrimSpace(rawPath)
+	if archivePath == "" || !filepath.IsAbs(archivePath) || !strings.EqualFold(filepath.Ext(archivePath), ".zip") {
+		return "", nil, func() {}, invalidClaudeExportArchive("archivePath must be an absolute ZIP path")
+	}
+	resolvedPath, err := filepath.EvalSymlinks(archivePath)
+	if err != nil {
+		return "", nil, func() {}, invalidClaudeExportArchive("resolve archive path: %v", err)
+	}
+	info, err := os.Stat(resolvedPath)
+	if err != nil {
+		return "", nil, func() {}, invalidClaudeExportArchive("inspect archive: %v", err)
+	}
+	if !info.Mode().IsRegular() {
+		return "", nil, func() {}, invalidClaudeExportArchive("archive is not a regular file")
+	}
+	if info.Size() <= 0 || info.Size() > maxClaudeExportArchiveBytes {
+		return "", nil, func() {}, invalidClaudeExportArchive("archive size exceeds the supported limit")
+	}
+	if err := validateClaudeExportZipDirectory(resolvedPath, info.Size()); err != nil {
+		return "", nil, func() {}, err
+	}
+	reader, err := zip.OpenReader(resolvedPath)
+	if err != nil {
+		return "", nil, func() {}, invalidClaudeExportArchive("open ZIP: %v", err)
+	}
+	closeArchive := func() { _ = reader.Close() }
+	if len(reader.File) > maxClaudeExportArchiveEntries {
+		closeArchive()
+		return "", nil, func() {}, invalidClaudeExportArchive("archive entry count exceeds %d", maxClaudeExportArchiveEntries)
+	}
+	var conversations *zip.File
+	for _, file := range reader.File {
+		name := filepath.ToSlash(file.Name)
+		if name != claudeExportConversationsEntry {
+			continue
+		}
+		if conversations != nil {
+			closeArchive()
+			return "", nil, func() {}, invalidClaudeExportArchive("archive contains duplicate conversations.json entries")
+		}
+		if file.FileInfo().IsDir() || file.Mode()&os.ModeSymlink != 0 || file.Flags&0x1 != 0 {
+			closeArchive()
+			return "", nil, func() {}, invalidClaudeExportArchive("conversations.json is not a readable regular ZIP entry")
+		}
+		if file.UncompressedSize64 == 0 || file.UncompressedSize64 > maxClaudeExportEntryBytes {
+			closeArchive()
+			return "", nil, func() {}, invalidClaudeExportArchive("conversations.json exceeds the supported size limit")
+		}
+		conversations = file
+	}
+	if conversations == nil {
+		closeArchive()
+		return "", nil, func() {}, invalidClaudeExportArchive("archive does not contain root conversations.json")
+	}
+	return filepath.Clean(resolvedPath), conversations, closeArchive, nil
+}
+
+func parseClaudeExportConversation(
+	ctx context.Context,
+	archivePath string,
+	home string,
+	conversationID string,
+	conversation claudeExportConversation,
+	messageIDs map[string]struct{},
+) (externalImportedSession, bool, error) {
+	resumeSupported := false
+	session := externalImportedSession{
+		Provider:        agentproviderbiz.ClaudeCode,
+		SourcePath:      archivePath,
+		Cwd:             home,
+		SummaryTitle:    firstNonEmptyString(conversation.Name, conversation.Summary),
+		NoProject:       true,
+		ResumeSupported: &resumeSupported,
+	}
+	conversationCreatedAt := unixMSFromAny(conversation.CreatedAt)
+	conversationUpdatedAt := unixMSFromAny(conversation.UpdatedAt)
+	parsedMessages := make([]parsedClaudeExportMessage, 0, len(conversation.ChatMessages))
+	for index, raw := range conversation.ChatMessages {
+		if err := ctx.Err(); err != nil {
+			return externalImportedSession{}, false, err
+		}
+		var source claudeExportMessage
+		if err := json.Unmarshal(raw, &source); err != nil {
+			return externalImportedSession{}, false, invalidClaudeExportArchive(
+				"decode message %d in conversation %q: %v",
+				index+1,
+				conversationID,
+				err,
+			)
+		}
+		rawID := strings.TrimSpace(source.UUID)
+		if rawID == "" {
+			rawID = "missing-" + externalStableHash(conversationID+"\x00"+string(raw))
+		}
+		if _, exists := messageIDs[rawID]; exists {
+			return externalImportedSession{}, false, invalidClaudeExportArchive("duplicate message id %q", rawID)
+		}
+		messageIDs[rawID] = struct{}{}
+		role := claudeExportMessageRole(source.Sender)
+		text := ""
+		var filesPayload []map[string]any
+		if role != "" {
+			var visibleErr error
+			text, filesPayload, visibleErr = claudeExportVisibleMessageText(ctx, source)
+			if visibleErr != nil {
+				return externalImportedSession{}, false, visibleErr
+			}
+		}
+		occurredAt := firstNonZeroInt64(
+			unixMSFromAny(source.CreatedAt),
+			unixMSFromAny(source.UpdatedAt),
+			conversationCreatedAt,
+			conversationUpdatedAt,
+			int64(index+1),
+		)
+		parsedMessages = append(parsedMessages, parsedClaudeExportMessage{
+			Source:             source,
+			RawID:              rawID,
+			ParentID:           strings.TrimSpace(source.ParentMessageUUID),
+			Role:               role,
+			Text:               text,
+			FilesPayload:       filesPayload,
+			OccurredAtUnixMS:   occurredAt,
+			SourceMessageIndex: index,
+		})
+	}
+	parsedByID := make(map[string]*parsedClaudeExportMessage, len(parsedMessages))
+	for index := range parsedMessages {
+		parsedByID[parsedMessages[index].RawID] = &parsedMessages[index]
+	}
+	selectedBranch, err := selectClaudeExportBranch(parsedMessages, parsedByID)
+	if err != nil {
+		return externalImportedSession{}, false, invalidClaudeExportArchive(
+			"invalid parent graph in conversation %q: %v",
+			conversationID,
+			err,
+		)
+	}
+	branchLeafID := ""
+	if len(selectedBranch) > 0 {
+		branchLeafID = selectedBranch[len(selectedBranch)-1].RawID
+	}
+	branchIdentity := claudeExportBranchIdentity(selectedBranch, parsedMessages)
+	session.ProviderSessionID = "claude-export:" + conversationID + ":branch:" + branchIdentity
+	for _, parsed := range selectedBranch {
+		if parsed.Role == "" || parsed.Text == "" {
+			continue
+		}
+		payload := map[string]any{
+			"externalSource":        "claude-data-export",
+			"sourceBranchId":        branchIdentity,
+			"sourceBranchLeafId":    branchLeafID,
+			"sourceCreatedAt":       strings.TrimSpace(parsed.Source.CreatedAt),
+			"sourceMessageId":       parsed.RawID,
+			"sourceParentMessageId": parsed.ParentID,
+		}
+		if len(parsed.FilesPayload) > 0 {
+			payload["files"] = parsed.FilesPayload
+		}
+		session.Messages = append(session.Messages, externalImportedMessage{
+			RawID:             parsed.RawID,
+			MessageIDSeed:     parsed.RawID,
+			Role:              parsed.Role,
+			Kind:              "text",
+			Status:            "completed",
+			Text:              parsed.Text,
+			Payload:           payload,
+			OccurredAtUnixMS:  parsed.OccurredAtUnixMS,
+			StartedAtUnixMS:   parsed.OccurredAtUnixMS,
+			CompletedAtUnixMS: parsed.OccurredAtUnixMS,
+		})
+	}
+	if len(session.Messages) == 0 {
+		return externalImportedSession{}, false, nil
+	}
+	session.StartedAtUnixMS = firstNonZeroInt64(conversationCreatedAt, firstExternalMessageUnixMS(session.Messages))
+	session.UpdatedAtUnixMS = lastExternalMessageUnixMS(session.Messages)
+	if conversationUpdatedAt > session.UpdatedAtUnixMS {
+		session.UpdatedAtUnixMS = conversationUpdatedAt
+	}
+	session.Title = claudeExportConversationTitle(session.SummaryTitle, session.Messages)
+	return session, true, nil
+}
+
+func claudeExportBranchIdentity(
+	selectedBranch []*parsedClaudeExportMessage,
+	messages []parsedClaudeExportMessage,
+) string {
+	childrenByParent := make(map[string]int, len(messages))
+	for index := range messages {
+		childrenByParent[messages[index].ParentID]++
+	}
+	decisions := make([]string, 0, 4)
+	for _, message := range selectedBranch {
+		if childrenByParent[message.ParentID] > 1 {
+			decisions = append(decisions, message.RawID)
+		}
+	}
+	if len(decisions) == 0 {
+		return "main"
+	}
+	return "fork-" + externalStableHash(strings.Join(decisions, "\x00"))[:24]
+}
+
+func selectClaudeExportBranch(
+	messages []parsedClaudeExportMessage,
+	byID map[string]*parsedClaudeExportMessage,
+) ([]*parsedClaudeExportMessage, error) {
+	if len(messages) == 0 {
+		return nil, nil
+	}
+	if err := validateClaudeExportParentGraph(messages, byID); err != nil {
+		return nil, err
+	}
+	parentsWithChildren := make(map[string]struct{}, len(messages))
+	for index := range messages {
+		if _, ok := byID[messages[index].ParentID]; ok {
+			parentsWithChildren[messages[index].ParentID] = struct{}{}
+		}
+	}
+	leaves := make([]*parsedClaudeExportMessage, 0, len(messages))
+	for index := range messages {
+		if _, hasChildren := parentsWithChildren[messages[index].RawID]; !hasChildren {
+			leaves = append(leaves, &messages[index])
+		}
+	}
+	sort.SliceStable(leaves, func(left, right int) bool {
+		if leaves[left].OccurredAtUnixMS != leaves[right].OccurredAtUnixMS {
+			return leaves[left].OccurredAtUnixMS > leaves[right].OccurredAtUnixMS
+		}
+		if leaves[left].SourceMessageIndex != leaves[right].SourceMessageIndex {
+			return leaves[left].SourceMessageIndex > leaves[right].SourceMessageIndex
+		}
+		return leaves[left].RawID > leaves[right].RawID
+	})
+	for _, leaf := range leaves {
+		branch := claudeExportBranchToLeaf(leaf, byID)
+		for _, message := range branch {
+			if message.Role != "" && message.Text != "" {
+				return branch, nil
+			}
+		}
+	}
+	return nil, nil
+}
+
+func validateClaudeExportParentGraph(
+	messages []parsedClaudeExportMessage,
+	byID map[string]*parsedClaudeExportMessage,
+) error {
+	state := make(map[string]uint8, len(messages))
+	for index := range messages {
+		current := &messages[index]
+		path := make([]string, 0, 16)
+		for current != nil && state[current.RawID] == 0 {
+			state[current.RawID] = 1
+			path = append(path, current.RawID)
+			current = byID[current.ParentID]
+		}
+		if current != nil && state[current.RawID] == 1 {
+			return fmt.Errorf("cycle at message %q", current.RawID)
+		}
+		for _, id := range path {
+			state[id] = 2
+		}
+	}
+	return nil
+}
+
+func claudeExportBranchToLeaf(
+	leaf *parsedClaudeExportMessage,
+	byID map[string]*parsedClaudeExportMessage,
+) []*parsedClaudeExportMessage {
+	reversed := make([]*parsedClaudeExportMessage, 0, 16)
+	for current := leaf; current != nil; current = byID[current.ParentID] {
+		reversed = append(reversed, current)
+	}
+	branch := make([]*parsedClaudeExportMessage, len(reversed))
+	for index := range reversed {
+		branch[len(reversed)-1-index] = reversed[index]
+	}
+	return branch
+}
+
+func claudeExportMessageRole(sender string) string {
+	switch strings.TrimSpace(strings.ToLower(sender)) {
+	case "human", "user":
+		return "user"
+	case "assistant":
+		return "assistant"
+	default:
+		return ""
+	}
+}
+
+func claudeExportVisibleMessageText(ctx context.Context, message claudeExportMessage) (string, []map[string]any, error) {
+	parts := make([]string, 0, len(message.Content))
+	for index, block := range message.Content {
+		if index%256 == 0 {
+			if err := ctx.Err(); err != nil {
+				return "", nil, err
+			}
+		}
+		if strings.TrimSpace(strings.ToLower(block.Type)) != "text" {
+			continue
+		}
+		if text := strings.TrimSpace(block.Text); text != "" {
+			parts = append(parts, text)
+		}
+	}
+	// Older human-only exports may omit structured blocks. Never fall back to
+	// assistant message.text: current Claude exports mix hidden thinking and
+	// tool material into that convenience field.
+	if len(message.Content) == 0 && claudeExportMessageRole(message.Sender) == "user" {
+		if text := strings.TrimSpace(message.Text); text != "" {
+			parts = append(parts, text)
+		}
+	}
+	fileLines, filesPayload, err := claudeExportFileReferences(ctx, message)
+	if err != nil {
+		return "", nil, err
+	}
+	parts = append(parts, fileLines...)
+	return strings.TrimSpace(strings.Join(parts, "\n\n")), filesPayload, nil
+}
+
+func claudeExportFileReferences(ctx context.Context, message claudeExportMessage) ([]string, []map[string]any, error) {
+	lines := make([]string, 0, len(message.Attachments)+len(message.Files))
+	payload := make([]map[string]any, 0, len(message.Attachments)+len(message.Files))
+	seenNames := map[string]struct{}{}
+	appendName := func(raw string) {
+		name := claudeExportFileName(raw)
+		if name == "" {
+			return
+		}
+		if _, exists := seenNames[name]; exists {
+			return
+		}
+		seenNames[name] = struct{}{}
+		lines = append(lines, "📎 "+escapeClaudeExportMarkdown(name))
+	}
+	for index, attachment := range message.Attachments {
+		if index%256 == 0 {
+			if err := ctx.Err(); err != nil {
+				return nil, nil, err
+			}
+		}
+		name := claudeExportFileName(attachment.FileName)
+		appendName(name)
+		payload = append(payload, map[string]any{
+			"available": false,
+			"fileName":  name,
+			"fileSize":  attachment.FileSize,
+			"fileType":  strings.TrimSpace(attachment.FileType),
+			"kind":      "legacy_attachment",
+		})
+	}
+	for index, file := range message.Files {
+		if index%256 == 0 {
+			if err := ctx.Err(); err != nil {
+				return nil, nil, err
+			}
+		}
+		name := claudeExportFileName(file.FileName)
+		appendName(name)
+		payload = append(payload, map[string]any{
+			"available": false,
+			"fileName":  name,
+			"fileUuid":  strings.TrimSpace(file.FileUUID),
+			"kind":      "file_reference",
+		})
+	}
+	return lines, payload, nil
+}
+
+func claudeExportFileName(raw string) string {
+	name := strings.Join(strings.Fields(raw), " ")
+	const maxFileNameRunes = 255
+	runes := []rune(name)
+	if len(runes) > maxFileNameRunes {
+		name = string(runes[:maxFileNameRunes])
+	}
+	return strings.TrimSpace(name)
+}
+
+func escapeClaudeExportMarkdown(value string) string {
+	return strings.NewReplacer(
+		"\\", "\\\\",
+		"`", "\\`",
+		"*", "\\*",
+		"_", "\\_",
+		"[", "\\[",
+		"]", "\\]",
+		"<", "\\<",
+		">", "\\>",
+	).Replace(value)
+}
+
+func claudeExportConversationTitle(summaryTitle string, messages []externalImportedMessage) string {
+	if title := strings.TrimSpace(summaryTitle); title != "" {
+		return truncateExternalTitle(title)
+	}
+	for _, message := range messages {
+		if message.Role == "user" && strings.TrimSpace(message.Text) != "" {
+			return truncateExternalTitle(message.Text)
+		}
+	}
+	return externalSessionTitle(messages)
+}
+
+func invalidClaudeExportArchive(format string, args ...any) error {
+	return fmt.Errorf("%w: invalid Claude data export: %s", ErrInvalidArgument, fmt.Sprintf(format, args...))
+}

--- a/services/tuttid/service/agent/external_import_claude_export_test.go
+++ b/services/tuttid/service/agent/external_import_claude_export_test.go
@@ -1,0 +1,600 @@
+package agent
+
+import (
+	"archive/zip"
+	"context"
+	"encoding/binary"
+	"encoding/json"
+	"errors"
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+	"testing"
+
+	agenttargetbiz "github.com/tutti-os/tutti/services/tuttid/biz/agenttarget"
+	workspacebiz "github.com/tutti-os/tutti/services/tuttid/biz/workspace"
+)
+
+func TestExternalImportResumeSupportedDefaultsLegacyButFailsClosedForMalformedMarker(t *testing.T) {
+	if !externalImportResumeSupported(nil) {
+		t.Fatal("legacy import without marker should remain resumable")
+	}
+	if externalImportResumeSupported(map[string]any{"externalImportResumeSupported": "false"}) {
+		t.Fatal("malformed daemon-owned resume marker should fail closed")
+	}
+}
+
+func TestScanClaudeExportArchiveUsesVisibleTextBlocksAndPreservesFileReferences(t *testing.T) {
+	archivePath := writeClaudeExportArchive(t, []map[string]any{
+		claudeExportConversationFixture(
+			"conversation-1",
+			"Visible chat",
+			[]map[string]any{
+				claudeExportMessageFixture("message-user", "human", "2026-06-01T00:00:01.123456Z", []map[string]any{
+					{"type": "text", "text": "Hello from the user"},
+				}),
+				{
+					"attachments": []any{},
+					"content": []map[string]any{
+						{"type": "text", "text": "Visible answer"},
+						{"type": "thinking", "thinking": "SECRET_THINKING"},
+						{"type": "tool_use", "name": "private_tool", "input": map[string]any{"secret": "SECRET_TOOL"}},
+						{"type": "tool_result", "content": []map[string]any{{"type": "text", "text": "SECRET_RESULT"}}},
+						{"type": "token_budget", "remaining": nil},
+						{"type": "text", "text": "Final note"},
+					},
+					"created_at":          "2026-06-01T00:00:02.123456Z",
+					"files":               []any{},
+					"parent_message_uuid": "message-user",
+					"sender":              "assistant",
+					"text":                "Visible answer\nSECRET_THINKING\nSECRET_TOOL\nSECRET_RESULT\nFinal note",
+					"updated_at":          "2026-06-01T00:00:02.123456Z",
+					"uuid":                "message-assistant",
+				},
+				{
+					"attachments": []any{},
+					"content": []map[string]any{
+						{"type": "text", "text": ""},
+					},
+					"created_at":          "2026-06-01T00:00:03.123456Z",
+					"files":               []map[string]any{{"file_name": "notes.txt", "file_uuid": "file-1"}},
+					"parent_message_uuid": "message-assistant",
+					"sender":              "human",
+					"text":                "",
+					"updated_at":          "2026-06-01T00:00:03.123456Z",
+					"uuid":                "message-file",
+				},
+			},
+		),
+		claudeExportConversationFixture("conversation-empty", "Empty", nil),
+	})
+
+	data, err := scanClaudeExportArchive(context.Background(), archivePath, 0)
+	if err != nil {
+		t.Fatalf("scanClaudeExportArchive error = %v", err)
+	}
+	if data.result.ScannedSessions != 1 || data.result.ScannedMessages != 3 || data.result.SkippedSessions != 1 {
+		t.Fatalf("scan result = %#v, want one session, three messages, one skipped empty conversation", data.result)
+	}
+	if len(data.sessions) != 1 {
+		t.Fatalf("sessions = %#v, want one parsed session", data.sessions)
+	}
+	session := data.sessions[0]
+	if session.ProviderSessionID != "claude-export:conversation-1:branch:main" || !session.NoProject {
+		t.Fatalf("session identity = %#v", session)
+	}
+	if session.ResumeSupported == nil || *session.ResumeSupported {
+		t.Fatalf("ResumeSupported = %#v, want false", session.ResumeSupported)
+	}
+	if session.Title != "Visible chat" {
+		t.Fatalf("title = %q, want export name", session.Title)
+	}
+	assistant := session.Messages[1]
+	if assistant.Text != "Visible answer\n\nFinal note" {
+		t.Fatalf("assistant text = %q, want visible text blocks only", assistant.Text)
+	}
+	encodedAssistant, err := json.Marshal(assistant)
+	if err != nil {
+		t.Fatalf("marshal assistant = %v", err)
+	}
+	for _, secret := range []string{"SECRET_THINKING", "SECRET_TOOL", "SECRET_RESULT"} {
+		if strings.Contains(string(encodedAssistant), secret) {
+			t.Fatalf("assistant message leaked hidden content %q: %s", secret, encodedAssistant)
+		}
+	}
+	fileMessage := session.Messages[2]
+	if fileMessage.Text != "📎 notes.txt" {
+		t.Fatalf("file-only message text = %q, want visible unavailable file reference", fileMessage.Text)
+	}
+	files, ok := fileMessage.Payload["files"].([]map[string]any)
+	if !ok || len(files) != 1 || files[0]["fileUuid"] != "file-1" || files[0]["available"] != false {
+		t.Fatalf("file payload = %#v", fileMessage.Payload["files"])
+	}
+	if fileMessage.Payload["sourceParentMessageId"] != "message-assistant" {
+		t.Fatalf("parent message id = %#v", fileMessage.Payload["sourceParentMessageId"])
+	}
+}
+
+func TestScanClaudeExportArchiveSelectsLatestLeafWithoutFlatteningBranches(t *testing.T) {
+	root := claudeExportMessageFixture("message-root", "human", "2026-06-03T00:00:01Z", []map[string]any{{"type": "text", "text": "Question"}})
+	oldAnswer := claudeExportMessageFixture("message-old", "assistant", "2026-06-03T00:00:03Z", []map[string]any{{"type": "text", "text": "Old retry"}})
+	oldAnswer["parent_message_uuid"] = "message-root"
+	currentAnswer := claudeExportMessageFixture("message-current", "assistant", "2026-06-03T00:00:02Z", []map[string]any{{"type": "text", "text": "Current answer"}})
+	currentAnswer["parent_message_uuid"] = "message-root"
+	currentFollowUp := claudeExportMessageFixture("message-follow-up", "human", "2026-06-03T00:00:04Z", []map[string]any{{"type": "text", "text": "Follow up"}})
+	currentFollowUp["parent_message_uuid"] = "message-current"
+	archivePath := writeClaudeExportArchive(t, []map[string]any{
+		claudeExportConversationFixture(
+			"conversation-branch",
+			"Branched conversation",
+			[]map[string]any{root, oldAnswer, currentAnswer, currentFollowUp},
+		),
+	})
+
+	data, err := scanClaudeExportArchive(context.Background(), archivePath, 0)
+	if err != nil {
+		t.Fatalf("scanClaudeExportArchive error = %v", err)
+	}
+	if len(data.sessions) != 1 {
+		t.Fatalf("sessions = %#v, want one", data.sessions)
+	}
+	messages := data.sessions[0].Messages
+	if len(messages) != 3 {
+		t.Fatalf("messages = %#v, want selected three-message branch", messages)
+	}
+	if messages[0].Text != "Question" || messages[1].Text != "Current answer" || messages[2].Text != "Follow up" {
+		t.Fatalf("selected branch texts = %#v", []string{messages[0].Text, messages[1].Text, messages[2].Text})
+	}
+	for _, message := range messages {
+		if message.Text == "Old retry" {
+			t.Fatal("mutually exclusive retry branch was flattened into the selected conversation")
+		}
+		if message.MessageIDSeed != message.RawID {
+			t.Fatalf("message seed = %q, want stable source UUID %q", message.MessageIDSeed, message.RawID)
+		}
+		if message.Payload["sourceBranchLeafId"] != "message-follow-up" {
+			t.Fatalf("branch leaf = %#v, want message-follow-up", message.Payload["sourceBranchLeafId"])
+		}
+	}
+}
+
+func TestClaudeExportArchiveImportIsIdempotentNoProjectAndNonResumable(t *testing.T) {
+	ctx := context.Background()
+	store := openAgentServiceSQLiteStore(t)
+	if err := store.Create(ctx, workspacebiz.Summary{ID: "ws-claude-export", Name: "Claude Export"}); err != nil {
+		t.Fatalf("Create workspace error = %v", err)
+	}
+	archivePath := writeClaudeExportArchive(t, []map[string]any{
+		claudeExportConversationFixture(
+			"conversation-import",
+			"Imported conversation",
+			linkedClaudeExportMessages(
+				claudeExportMessageFixture("message-1", "human", "2026-06-02T00:00:01.123456Z", []map[string]any{{"type": "text", "text": "Question"}}),
+				claudeExportMessageFixture("message-2", "assistant", "2026-06-02T00:00:02.123456Z", []map[string]any{{"type": "text", "text": "Answer"}}),
+			),
+		),
+	})
+	service := NewService(newFakeRuntime())
+	projection := NewActivityProjection(store)
+	service.SessionReader = projection
+	service.MessageReader = projection
+	service.ExternalImportStore = store
+
+	scan, err := service.ScanExternalImports(ctx, ExternalImportScanInput{ArchivePath: archivePath, Days: -1})
+	if err != nil {
+		t.Fatalf("ScanExternalImports error = %v", err)
+	}
+	if len(scan.Sessions) != 1 {
+		t.Fatalf("scan sessions = %#v, want one", scan.Sessions)
+	}
+	home, ok := externalImportNoProjectBucketPath()
+	if !ok {
+		t.Fatal("home bucket unavailable")
+	}
+	selection := ExternalImportInput{
+		ArchivePath: archivePath,
+		Projects: []ExternalImportProjectSelection{{
+			Path:       home,
+			Providers:  []string{"claude-code"},
+			SessionIDs: []string{scan.Sessions[0].ID},
+		}},
+	}
+	result, err := service.ImportExternalSessions(ctx, "ws-claude-export", selection)
+	if err != nil {
+		t.Fatalf("ImportExternalSessions error = %v", err)
+	}
+	if result.ImportedSessions != 1 || result.ImportedMessages != 2 || result.ImportedProjects != 0 || len(result.ProjectPaths) != 0 {
+		t.Fatalf("import result = %#v, want one no-project session and two messages", result)
+	}
+	rerun, err := service.ImportExternalSessions(ctx, "ws-claude-export", selection)
+	if err != nil {
+		t.Fatalf("ImportExternalSessions rerun error = %v", err)
+	}
+	if rerun.ImportedSessions != 0 || rerun.ImportedMessages != 0 {
+		t.Fatalf("rerun result = %#v, want idempotent no-op", rerun)
+	}
+
+	session, err := service.Get(ctx, "ws-claude-export", scan.Sessions[0].ID)
+	if err != nil {
+		t.Fatalf("Get imported session error = %v", err)
+	}
+	if session.AgentTargetID != agenttargetbiz.IDLocalClaudeCode || session.Resumable {
+		t.Fatalf("imported session target/resumable = %#v", session)
+	}
+	if session.RuntimeContext["imported"] != true ||
+		session.RuntimeContext["externalImportNoProject"] != true ||
+		session.RuntimeContext["externalImportResumeSupported"] != false {
+		t.Fatalf("runtime context = %#v", session.RuntimeContext)
+	}
+	if _, err := service.SendInput(ctx, "ws-claude-export", session.ID, SendInput{Content: TextPromptContent("continue")}); !errors.Is(err, ErrSessionNotFound) {
+		t.Fatalf("SendInput error = %v, want archive history to remain non-resumable", err)
+	}
+	messages, err := service.ListMessages(ctx, "ws-claude-export", session.ID, ListMessagesInput{Limit: 10})
+	if err != nil {
+		t.Fatalf("ListMessages error = %v", err)
+	}
+	if len(messages.Messages) != 2 || !slices.ContainsFunc(messages.Messages, func(message SessionMessage) bool {
+		return message.Role == "assistant" && message.Payload["text"] == "Answer"
+	}) {
+		t.Fatalf("imported messages = %#v", messages.Messages)
+	}
+	existingIDs := map[string]string{}
+	for _, message := range messages.Messages {
+		sourceID, _ := message.Payload["sourceMessageId"].(string)
+		existingIDs[sourceID] = message.MessageID
+	}
+	prepend := claudeExportMessageFixture("message-0", "human", "2026-06-02T00:00:00.123456Z", []map[string]any{{"type": "text", "text": "Earlier context"}})
+	question := claudeExportMessageFixture("message-1", "human", "2026-06-02T00:00:01.123456Z", []map[string]any{{"type": "text", "text": "Question"}})
+	answer := claudeExportMessageFixture("message-2", "assistant", "2026-06-02T00:00:02.123456Z", []map[string]any{{"type": "text", "text": "Answer"}})
+	rewriteClaudeExportArchive(t, archivePath, []map[string]any{
+		claudeExportConversationFixture(
+			"conversation-import",
+			"Imported conversation",
+			linkedClaudeExportMessages(prepend, question, answer),
+		),
+	})
+	updated, err := service.ImportExternalSessions(ctx, "ws-claude-export", selection)
+	if err != nil {
+		t.Fatalf("ImportExternalSessions updated export error = %v", err)
+	}
+	if updated.ImportedMessages != 1 {
+		t.Fatalf("updated export result = %#v, want only the prepended message", updated)
+	}
+	updatedMessages, err := service.ListMessages(ctx, "ws-claude-export", session.ID, ListMessagesInput{Limit: 10})
+	if err != nil {
+		t.Fatalf("ListMessages after updated export error = %v", err)
+	}
+	if len(updatedMessages.Messages) != 3 {
+		t.Fatalf("updated messages = %#v, want three unique messages", updatedMessages.Messages)
+	}
+	for _, message := range updatedMessages.Messages {
+		sourceID, _ := message.Payload["sourceMessageId"].(string)
+		if oldID := existingIDs[sourceID]; oldID != "" && oldID != message.MessageID {
+			t.Fatalf("message %q id changed from %q to %q after predecessor insert", sourceID, oldID, message.MessageID)
+		}
+	}
+}
+
+func TestClaudeExportArchiveKeepsChangedRetryBranchesInSeparateSessions(t *testing.T) {
+	ctx := context.Background()
+	store := openAgentServiceSQLiteStore(t)
+	if err := store.Create(ctx, workspacebiz.Summary{ID: "ws-claude-branches", Name: "Claude branches"}); err != nil {
+		t.Fatalf("Create workspace error = %v", err)
+	}
+	root := claudeExportMessageFixture("message-root", "human", "2026-06-04T00:00:01Z", []map[string]any{{"type": "text", "text": "Question"}})
+	oldAnswer := claudeExportMessageFixture("message-old", "assistant", "2026-06-04T00:00:02Z", []map[string]any{{"type": "text", "text": "Old answer"}})
+	archivePath := writeClaudeExportArchive(t, []map[string]any{
+		claudeExportConversationFixture(
+			"conversation-changing-branch",
+			"Changing branch",
+			linkedClaudeExportMessages(root, oldAnswer),
+		),
+	})
+	service := NewService(newFakeRuntime())
+	projection := NewActivityProjection(store)
+	service.SessionReader = projection
+	service.MessageReader = projection
+	service.ExternalImportStore = store
+
+	firstScan, err := service.ScanExternalImports(ctx, ExternalImportScanInput{ArchivePath: archivePath, Days: -1})
+	if err != nil || len(firstScan.Sessions) != 1 {
+		t.Fatalf("first scan = %#v, error = %v", firstScan, err)
+	}
+	selectionFor := func(scan ExternalImportScanResult) ExternalImportInput {
+		return ExternalImportInput{
+			ArchivePath: archivePath,
+			Projects: []ExternalImportProjectSelection{{
+				Path:       scan.Sessions[0].ProjectPath,
+				Providers:  []string{"claude-code"},
+				SessionIDs: []string{scan.Sessions[0].ID},
+			}},
+		}
+	}
+	firstImport, err := service.ImportExternalSessions(ctx, "ws-claude-branches", selectionFor(firstScan))
+	if err != nil || firstImport.ImportedSessions != 1 || firstImport.ImportedMessages != 2 {
+		t.Fatalf("first import = %#v, error = %v", firstImport, err)
+	}
+	oldSessionID := firstScan.Sessions[0].ID
+
+	root = claudeExportMessageFixture("message-root", "human", "2026-06-04T00:00:01Z", []map[string]any{{"type": "text", "text": "Question"}})
+	oldAnswer = claudeExportMessageFixture("message-old", "assistant", "2026-06-04T00:00:02Z", []map[string]any{{"type": "text", "text": "Old answer"}})
+	oldAnswer["parent_message_uuid"] = "message-root"
+	newAnswer := claudeExportMessageFixture("message-new", "assistant", "2026-06-04T00:00:03Z", []map[string]any{{"type": "text", "text": "New answer"}})
+	newAnswer["parent_message_uuid"] = "message-root"
+	rewriteClaudeExportArchive(t, archivePath, []map[string]any{
+		claudeExportConversationFixture(
+			"conversation-changing-branch",
+			"Changing branch",
+			[]map[string]any{root, oldAnswer, newAnswer},
+		),
+	})
+	secondScan, err := service.ScanExternalImports(ctx, ExternalImportScanInput{ArchivePath: archivePath, Days: -1})
+	if err != nil || len(secondScan.Sessions) != 1 {
+		t.Fatalf("second scan = %#v, error = %v", secondScan, err)
+	}
+	newSessionID := secondScan.Sessions[0].ID
+	if newSessionID == oldSessionID {
+		t.Fatalf("changed retry branch reused session id %q", newSessionID)
+	}
+	secondImport, err := service.ImportExternalSessions(ctx, "ws-claude-branches", selectionFor(secondScan))
+	if err != nil || secondImport.ImportedSessions != 1 || secondImport.ImportedMessages != 2 {
+		t.Fatalf("second import = %#v, error = %v", secondImport, err)
+	}
+
+	oldMessages, err := service.ListMessages(ctx, "ws-claude-branches", oldSessionID, ListMessagesInput{Limit: 10})
+	if err != nil {
+		t.Fatalf("list old branch: %v", err)
+	}
+	newMessages, err := service.ListMessages(ctx, "ws-claude-branches", newSessionID, ListMessagesInput{Limit: 10})
+	if err != nil {
+		t.Fatalf("list new branch: %v", err)
+	}
+	if !sessionMessagesContainText(oldMessages.Messages, "Old answer") || sessionMessagesContainText(oldMessages.Messages, "New answer") {
+		t.Fatalf("old branch messages = %#v", oldMessages.Messages)
+	}
+	if !sessionMessagesContainText(newMessages.Messages, "New answer") || sessionMessagesContainText(newMessages.Messages, "Old answer") {
+		t.Fatalf("new branch messages = %#v", newMessages.Messages)
+	}
+}
+
+func sessionMessagesContainText(messages []SessionMessage, text string) bool {
+	return slices.ContainsFunc(messages, func(message SessionMessage) bool {
+		return message.Payload["text"] == text
+	})
+}
+
+func TestScanClaudeExportArchiveRejectsInvalidArchives(t *testing.T) {
+	tests := []struct {
+		name string
+		path func(*testing.T) string
+	}{
+		{
+			name: "relative path",
+			path: func(*testing.T) string { return "export.zip" },
+		},
+		{
+			name: "missing conversations entry",
+			path: func(t *testing.T) string {
+				return writeClaudeExportZipEntries(t, map[string]string{"users.json": `[]`})
+			},
+		},
+		{
+			name: "nested conversations entry",
+			path: func(t *testing.T) string {
+				return writeClaudeExportZipEntries(t, map[string]string{"nested/conversations.json": `[]`})
+			},
+		},
+		{
+			name: "invalid JSON",
+			path: func(t *testing.T) string {
+				return writeClaudeExportZipEntries(t, map[string]string{"conversations.json": `{`})
+			},
+		},
+		{
+			name: "wrong top level",
+			path: func(t *testing.T) string {
+				return writeClaudeExportZipEntries(t, map[string]string{"conversations.json": `{}`})
+			},
+		},
+		{
+			name: "duplicate conversations entry",
+			path: func(t *testing.T) string {
+				return writeClaudeExportZipEntryFixtures(t, []claudeExportZipEntryFixture{
+					{Name: "conversations.json", Content: `[]`},
+					{Name: "conversations.json", Content: `[]`},
+				})
+			},
+		},
+		{
+			name: "symlink conversations entry",
+			path: func(t *testing.T) string {
+				return writeClaudeExportZipEntryFixtures(t, []claudeExportZipEntryFixture{
+					{Name: "conversations.json", Content: `target`, Mode: os.ModeSymlink | 0o777},
+				})
+			},
+		},
+		{
+			name: "excessive nested array items",
+			path: func(t *testing.T) string {
+				objects := strings.TrimSuffix(strings.Repeat(`{},`, maxClaudeExportJSONContainerItems+1), ",")
+				conversation := `{"uuid":"conversation-large","chat_messages":[` + objects + `]}`
+				return writeClaudeExportZipEntries(t, map[string]string{"conversations.json": `[` + conversation + `]`})
+			},
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := scanClaudeExportArchive(context.Background(), tc.path(t), 0)
+			if !errors.Is(err, ErrInvalidArgument) {
+				t.Fatalf("error = %v, want ErrInvalidArgument", err)
+			}
+		})
+	}
+}
+
+func TestScanClaudeExportArchivePreflightsDirectoryLimits(t *testing.T) {
+	tests := []struct {
+		name   string
+		mutate func([]byte, int)
+	}{
+		{
+			name: "entry count",
+			mutate: func(data []byte, endOffset int) {
+				count := uint16(maxClaudeExportArchiveEntries + 1)
+				binary.LittleEndian.PutUint16(data[endOffset+8:], count)
+				binary.LittleEndian.PutUint16(data[endOffset+10:], count)
+			},
+		},
+		{
+			name: "central directory size",
+			mutate: func(data []byte, endOffset int) {
+				binary.LittleEndian.PutUint32(data[endOffset+12:], uint32(maxClaudeZipDirectoryBytes+1))
+			},
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			archivePath := writeClaudeExportArchive(t, nil)
+			data, err := os.ReadFile(archivePath)
+			if err != nil {
+				t.Fatalf("read archive: %v", err)
+			}
+			endOffset := len(data) - 22
+			if endOffset < 0 || binary.LittleEndian.Uint32(data[endOffset:]) != claudeZipEndOfCentralDirectorySignature {
+				t.Fatal("test ZIP does not end with an EOCD record")
+			}
+			tc.mutate(data, endOffset)
+			if err := os.WriteFile(archivePath, data, 0o600); err != nil {
+				t.Fatalf("rewrite archive: %v", err)
+			}
+			_, err = scanClaudeExportArchive(context.Background(), archivePath, 0)
+			if !errors.Is(err, ErrInvalidArgument) {
+				t.Fatalf("error = %v, want ErrInvalidArgument", err)
+			}
+		})
+	}
+}
+
+func TestClaudeExportConversationStreamRejectsElementBeforeExceedingByteBudget(t *testing.T) {
+	stream, err := newClaudeExportConversationStreamWithLimits(
+		context.Background(),
+		strings.NewReader(`[{"uuid":"conversation-too-large","chat_messages":[]}]`),
+		1_024,
+		24,
+	)
+	if err != nil {
+		t.Fatalf("create conversation stream: %v", err)
+	}
+	_, _, err = stream.Next()
+	if !errors.Is(err, ErrInvalidArgument) || !strings.Contains(err.Error(), "conversation 1 exceeds the size limit") {
+		t.Fatalf("error = %v, want per-conversation byte-budget rejection", err)
+	}
+}
+
+func claudeExportConversationFixture(id string, name string, messages []map[string]any) map[string]any {
+	if messages == nil {
+		messages = []map[string]any{}
+	}
+	return map[string]any{
+		"account":       map[string]any{"uuid": "account-1"},
+		"chat_messages": messages,
+		"created_at":    "2026-06-01T00:00:00.123456Z",
+		"name":          name,
+		"summary":       "",
+		"updated_at":    "2026-06-02T00:00:00.123456Z",
+		"uuid":          id,
+	}
+}
+
+func claudeExportMessageFixture(id string, sender string, timestamp string, content []map[string]any) map[string]any {
+	return map[string]any{
+		"attachments":         []any{},
+		"content":             content,
+		"created_at":          timestamp,
+		"files":               []any{},
+		"parent_message_uuid": "00000000-0000-4000-8000-000000000000",
+		"sender":              sender,
+		"text":                "TOP_LEVEL_TEXT_MUST_NOT_WIN",
+		"updated_at":          timestamp,
+		"uuid":                id,
+	}
+}
+
+func linkedClaudeExportMessages(messages ...map[string]any) []map[string]any {
+	for index := 1; index < len(messages); index++ {
+		messages[index]["parent_message_uuid"] = messages[index-1]["uuid"]
+	}
+	return messages
+}
+
+func writeClaudeExportArchive(t *testing.T, conversations []map[string]any) string {
+	t.Helper()
+	archivePath := filepath.Join(t.TempDir(), "claude-export.zip")
+	rewriteClaudeExportArchive(t, archivePath, conversations)
+	return archivePath
+}
+
+func rewriteClaudeExportArchive(t *testing.T, archivePath string, conversations []map[string]any) {
+	t.Helper()
+	data, err := json.Marshal(conversations)
+	if err != nil {
+		t.Fatalf("marshal conversations: %v", err)
+	}
+	writeClaudeExportZipEntryFixturesAt(t, archivePath, []claudeExportZipEntryFixture{
+		{Name: "conversations.json", Content: string(data)},
+		{Name: "users.json", Content: `[]`},
+	})
+}
+
+func writeClaudeExportZipEntries(t *testing.T, entries map[string]string) string {
+	t.Helper()
+	archivePath := filepath.Join(t.TempDir(), "claude-export.zip")
+	fixtures := make([]claudeExportZipEntryFixture, 0, len(entries))
+	for name, content := range entries {
+		fixtures = append(fixtures, claudeExportZipEntryFixture{Name: name, Content: content})
+	}
+	writeClaudeExportZipEntryFixturesAt(t, archivePath, fixtures)
+	return archivePath
+}
+
+type claudeExportZipEntryFixture struct {
+	Name    string
+	Content string
+	Mode    os.FileMode
+}
+
+func writeClaudeExportZipEntryFixtures(t *testing.T, entries []claudeExportZipEntryFixture) string {
+	t.Helper()
+	archivePath := filepath.Join(t.TempDir(), "claude-export.zip")
+	writeClaudeExportZipEntryFixturesAt(t, archivePath, entries)
+	return archivePath
+}
+
+func writeClaudeExportZipEntryFixturesAt(t *testing.T, archivePath string, entries []claudeExportZipEntryFixture) {
+	t.Helper()
+	target, err := os.Create(archivePath)
+	if err != nil {
+		t.Fatalf("create archive: %v", err)
+	}
+	writer := zip.NewWriter(target)
+	for _, fixture := range entries {
+		header := &zip.FileHeader{Name: fixture.Name, Method: zip.Deflate}
+		if fixture.Mode != 0 {
+			header.SetMode(fixture.Mode)
+		}
+		entry, err := writer.CreateHeader(header)
+		if err != nil {
+			t.Fatalf("create ZIP entry %s: %v", fixture.Name, err)
+		}
+		if _, err := entry.Write([]byte(fixture.Content)); err != nil {
+			t.Fatalf("write ZIP entry %s: %v", fixture.Name, err)
+		}
+	}
+	if err := writer.Close(); err != nil {
+		t.Fatalf("close ZIP writer: %v", err)
+	}
+	if err := target.Close(); err != nil {
+		t.Fatalf("close archive: %v", err)
+	}
+}

--- a/services/tuttid/service/agent/external_import_claude_export_test.go
+++ b/services/tuttid/service/agent/external_import_claude_export_test.go
@@ -452,6 +452,19 @@ func TestScanClaudeExportArchivePreflightsDirectoryLimits(t *testing.T) {
 				binary.LittleEndian.PutUint32(data[endOffset+12:], uint32(maxClaudeZipDirectoryBytes+1))
 			},
 		},
+		{
+			name: "ZIP64 directory offset sentinel",
+			mutate: func(data []byte, endOffset int) {
+				binary.LittleEndian.PutUint32(data[endOffset+16:], ^uint32(0))
+			},
+		},
+		{
+			name: "directory span mismatch",
+			mutate: func(data []byte, endOffset int) {
+				directorySize := binary.LittleEndian.Uint32(data[endOffset+12:])
+				binary.LittleEndian.PutUint32(data[endOffset+12:], directorySize-1)
+			},
+		},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
@@ -473,6 +486,53 @@ func TestScanClaudeExportArchivePreflightsDirectoryLimits(t *testing.T) {
 				t.Fatalf("error = %v, want ErrInvalidArgument", err)
 			}
 		})
+	}
+}
+
+func TestScanExternalAgentSessionsArchiveIgnoresDefaultDayWindow(t *testing.T) {
+	// The fixture conversation is dated 2026-06, well past the historical
+	// 30-day default, so it only survives if the archive branch skips the
+	// implicit window.
+	archivePath := writeClaudeExportArchive(t, []map[string]any{
+		claudeExportConversationFixture("conversation-old", "Old", linkedClaudeExportMessages(
+			claudeExportMessageFixture("message-1", "human", "2026-06-01T00:00:00Z", []map[string]any{
+				{"type": "text", "text": "hello"},
+			}),
+		)),
+	})
+	data, err := scanExternalAgentSessions(context.Background(), nil, 0, archivePath)
+	if err != nil {
+		t.Fatalf("scan archive with default days: %v", err)
+	}
+	if data.result.ScannedSessions != 1 {
+		t.Fatalf("ScannedSessions = %d, want 1", data.result.ScannedSessions)
+	}
+	// An explicit positive window still narrows the archive scan.
+	data, err = scanExternalAgentSessions(context.Background(), nil, 7, archivePath)
+	if err != nil {
+		t.Fatalf("scan archive with 7-day window: %v", err)
+	}
+	if data.result.ScannedSessions != 0 {
+		t.Fatalf("ScannedSessions = %d, want 0 for a 7-day window", data.result.ScannedSessions)
+	}
+}
+
+func TestScanExternalAgentSessionsRejectsArchiveWithoutClaudeProvider(t *testing.T) {
+	archivePath := writeClaudeExportArchive(t, []map[string]any{})
+	_, err := scanExternalAgentSessions(context.Background(), []string{"codex"}, 0, archivePath)
+	if !errors.Is(err, ErrInvalidArgument) {
+		t.Fatalf("error = %v, want ErrInvalidArgument for a provider filter excluding claude-code", err)
+	}
+	if _, err := scanExternalAgentSessions(context.Background(), []string{"codex", "claude-code"}, 0, archivePath); err != nil {
+		t.Fatalf("scan with claude-code included: %v", err)
+	}
+}
+
+func TestScanExternalAgentSessionsSurfacesCancellation(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	if _, err := scanExternalAgentSessions(ctx, nil, 0, ""); !errors.Is(err, context.Canceled) {
+		t.Fatalf("error = %v, want context.Canceled", err)
 	}
 }
 

--- a/services/tuttid/service/agent/external_import_claude_export_validation.go
+++ b/services/tuttid/service/agent/external_import_claude_export_validation.go
@@ -1,0 +1,407 @@
+package agent
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"encoding/binary"
+	"encoding/json"
+	"errors"
+	"io"
+	"os"
+)
+
+const (
+	claudeZipEndOfCentralDirectorySignature       = 0x06054b50
+	maxClaudeZipCommentBytes                      = 65_535
+	maxClaudeZipDirectoryBytes              int64 = 4 << 20
+	maxClaudeExportJSONDepth                      = 64
+	maxClaudeExportJSONContainerItems             = 10_000
+	maxClaudeExportJSONTokens                     = 1_000_000
+	maxClaudeExportJSONStringBytes                = 8 << 20
+)
+
+type claudeExportJSONFrame struct {
+	delimiter  json.Delim
+	items      int
+	expectsKey bool
+}
+
+type claudeExportConversationStream struct {
+	ctx                   context.Context
+	reader                *bufio.Reader
+	limited               *io.LimitedReader
+	entryByteLimit        int64
+	conversationByteLimit int64
+	bytesRead             int64
+	elementsRead          int
+	finished              bool
+}
+
+var errClaudeExportEntryByteLimit = errors.New("claude export entry byte limit exceeded")
+
+func newClaudeExportConversationStream(
+	ctx context.Context,
+	reader io.Reader,
+) (*claudeExportConversationStream, error) {
+	return newClaudeExportConversationStreamWithLimits(
+		ctx,
+		reader,
+		maxClaudeExportEntryBytes,
+		maxClaudeExportConversationBytes,
+	)
+}
+
+func newClaudeExportConversationStreamWithLimits(
+	ctx context.Context,
+	reader io.Reader,
+	entryByteLimit int64,
+	conversationByteLimit int64,
+) (*claudeExportConversationStream, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	if entryByteLimit <= 0 || conversationByteLimit <= 0 || conversationByteLimit > entryByteLimit {
+		return nil, invalidClaudeExportArchive("invalid parser byte limits")
+	}
+	limited := &io.LimitedReader{R: reader, N: entryByteLimit + 1}
+	stream := &claudeExportConversationStream{
+		ctx:                   ctx,
+		reader:                bufio.NewReader(limited),
+		limited:               limited,
+		entryByteLimit:        entryByteLimit,
+		conversationByteLimit: conversationByteLimit,
+	}
+	first, err := stream.readNonWhitespaceByte()
+	if err != nil {
+		return nil, wrapClaudeExportStreamReadError("read conversations.json opening array", err)
+	}
+	if first != '[' {
+		return nil, invalidClaudeExportArchive("conversations.json must contain an array")
+	}
+	return stream, nil
+}
+
+func (stream *claudeExportConversationStream) Next() (json.RawMessage, bool, error) {
+	if stream == nil || stream.finished {
+		return nil, false, nil
+	}
+	if err := stream.ctx.Err(); err != nil {
+		return nil, false, err
+	}
+	next, err := stream.readNonWhitespaceByte()
+	if err != nil {
+		return nil, false, wrapClaudeExportStreamReadError("read conversations.json array", err)
+	}
+	if stream.elementsRead > 0 {
+		if next == ']' {
+			if err := stream.finish(); err != nil {
+				return nil, false, err
+			}
+			return nil, false, nil
+		}
+		if next != ',' {
+			return nil, false, invalidClaudeExportArchive("conversations.json entries must be comma-separated")
+		}
+		next, err = stream.readNonWhitespaceByte()
+		if err != nil {
+			return nil, false, wrapClaudeExportStreamReadError("read next conversations.json entry", err)
+		}
+		if next == ']' {
+			return nil, false, invalidClaudeExportArchive("conversations.json has a trailing comma")
+		}
+	} else if next == ']' {
+		if err := stream.finish(); err != nil {
+			return nil, false, err
+		}
+		return nil, false, nil
+	}
+	if next != '{' {
+		return nil, false, invalidClaudeExportArchive(
+			"conversation %d must contain an object",
+			stream.elementsRead+1,
+		)
+	}
+	raw, err := stream.readConversationObject(next, stream.elementsRead+1)
+	if err != nil {
+		return nil, false, err
+	}
+	stream.elementsRead++
+	return raw, true, nil
+}
+
+func (stream *claudeExportConversationStream) readConversationObject(
+	first byte,
+	conversationNumber int,
+) (json.RawMessage, error) {
+	raw := make([]byte, 0, 4096)
+	raw = append(raw, first)
+	stack := []byte{'{'}
+	inString := false
+	escaped := false
+	for len(stack) > 0 {
+		next, err := stream.readByte()
+		if err != nil {
+			return nil, wrapClaudeExportStreamReadError(
+				"read conversation object",
+				err,
+			)
+		}
+		if int64(len(raw)) >= stream.conversationByteLimit {
+			return nil, invalidClaudeExportArchive(
+				"conversation %d exceeds the size limit",
+				conversationNumber,
+			)
+		}
+		raw = append(raw, next)
+		if inString {
+			if escaped {
+				escaped = false
+				continue
+			}
+			switch next {
+			case '\\':
+				escaped = true
+			case '"':
+				inString = false
+			}
+			continue
+		}
+		switch next {
+		case '"':
+			inString = true
+		case '{', '[':
+			if len(stack) >= maxClaudeExportJSONDepth {
+				return nil, claudeExportConversationComplexityError(conversationNumber, "JSON nesting depth")
+			}
+			stack = append(stack, next)
+		case '}', ']':
+			expected := byte('{')
+			if next == ']' {
+				expected = '['
+			}
+			if stack[len(stack)-1] != expected {
+				return nil, invalidClaudeExportArchive(
+					"conversation %d has mismatched JSON delimiters",
+					conversationNumber,
+				)
+			}
+			stack = stack[:len(stack)-1]
+		}
+	}
+	return json.RawMessage(raw), nil
+}
+
+func (stream *claudeExportConversationStream) finish() error {
+	for {
+		next, err := stream.readByte()
+		if errors.Is(err, io.EOF) {
+			stream.finished = true
+			return nil
+		}
+		if err != nil {
+			return wrapClaudeExportStreamReadError("finish conversations.json", err)
+		}
+		if !isClaudeExportJSONWhitespace(next) {
+			return invalidClaudeExportArchive("conversations.json has trailing data")
+		}
+	}
+}
+
+func (stream *claudeExportConversationStream) readNonWhitespaceByte() (byte, error) {
+	for {
+		next, err := stream.readByte()
+		if err != nil {
+			return 0, err
+		}
+		if !isClaudeExportJSONWhitespace(next) {
+			return next, nil
+		}
+	}
+}
+
+func (stream *claudeExportConversationStream) readByte() (byte, error) {
+	if stream.bytesRead%64_000 == 0 {
+		if err := stream.ctx.Err(); err != nil {
+			return 0, err
+		}
+	}
+	next, err := stream.reader.ReadByte()
+	if err != nil {
+		return 0, err
+	}
+	stream.bytesRead++
+	if stream.bytesRead > stream.entryByteLimit || stream.limited.N == 0 {
+		return 0, errClaudeExportEntryByteLimit
+	}
+	return next, nil
+}
+
+func wrapClaudeExportStreamReadError(action string, err error) error {
+	if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+		return err
+	}
+	if errors.Is(err, errClaudeExportEntryByteLimit) {
+		return invalidClaudeExportArchive("conversations.json exceeds the supported size limit")
+	}
+	return invalidClaudeExportArchive("%s: %v", action, err)
+}
+
+func isClaudeExportJSONWhitespace(value byte) bool {
+	return value == ' ' || value == '\t' || value == '\r' || value == '\n'
+}
+
+func validateClaudeExportZipDirectory(archivePath string, archiveSize int64) error {
+	archive, err := os.Open(archivePath)
+	if err != nil {
+		return invalidClaudeExportArchive("open ZIP for directory preflight: %v", err)
+	}
+	defer archive.Close()
+	tailSize := archiveSize
+	const endRecordBytes = int64(22)
+	if maximum := endRecordBytes + maxClaudeZipCommentBytes; tailSize > maximum {
+		tailSize = maximum
+	}
+	tail := make([]byte, tailSize)
+	if _, err := archive.ReadAt(tail, archiveSize-tailSize); err != nil && !errors.Is(err, io.EOF) {
+		return invalidClaudeExportArchive("read ZIP directory: %v", err)
+	}
+	endOffset := -1
+	for offset := len(tail) - int(endRecordBytes); offset >= 0; offset-- {
+		if binary.LittleEndian.Uint32(tail[offset:]) != claudeZipEndOfCentralDirectorySignature {
+			continue
+		}
+		commentLength := int(binary.LittleEndian.Uint16(tail[offset+20:]))
+		if offset+int(endRecordBytes)+commentLength == len(tail) {
+			endOffset = offset
+			break
+		}
+	}
+	if endOffset < 0 {
+		return invalidClaudeExportArchive("ZIP end-of-directory record is missing")
+	}
+	record := tail[endOffset:]
+	if binary.LittleEndian.Uint16(record[4:]) != 0 || binary.LittleEndian.Uint16(record[6:]) != 0 {
+		return invalidClaudeExportArchive("multi-disk ZIP archives are not supported")
+	}
+	entriesOnDisk := binary.LittleEndian.Uint16(record[8:])
+	totalEntries := binary.LittleEndian.Uint16(record[10:])
+	directorySize := binary.LittleEndian.Uint32(record[12:])
+	if entriesOnDisk == ^uint16(0) || totalEntries == ^uint16(0) || directorySize == ^uint32(0) {
+		return invalidClaudeExportArchive("ZIP64 directory metadata is not supported")
+	}
+	if entriesOnDisk != totalEntries {
+		return invalidClaudeExportArchive("ZIP directory entry counts do not match")
+	}
+	if totalEntries > maxClaudeExportArchiveEntries {
+		return invalidClaudeExportArchive("archive entry count exceeds %d", maxClaudeExportArchiveEntries)
+	}
+	if int64(directorySize) > maxClaudeZipDirectoryBytes || int64(directorySize) > archiveSize {
+		return invalidClaudeExportArchive("ZIP directory exceeds the supported size limit")
+	}
+	return nil
+}
+
+func validateClaudeExportConversationJSON(ctx context.Context, raw []byte, conversationNumber int) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	decoder := json.NewDecoder(bytes.NewReader(raw))
+	frames := make([]claudeExportJSONFrame, 0, 8)
+	rootValues := 0
+	for tokenCount := 1; ; tokenCount++ {
+		if tokenCount%1024 == 0 {
+			if err := ctx.Err(); err != nil {
+				return err
+			}
+		}
+		if tokenCount > maxClaudeExportJSONTokens {
+			return claudeExportConversationComplexityError(conversationNumber, "JSON token count")
+		}
+		token, err := decoder.Token()
+		if errors.Is(err, io.EOF) {
+			break
+		}
+		if err != nil {
+			return invalidClaudeExportArchive("decode conversation %d structure: %v", conversationNumber, err)
+		}
+		switch value := token.(type) {
+		case json.Delim:
+			switch value {
+			case '{', '[':
+				if err := consumeClaudeExportJSONValue(frames, &rootValues, conversationNumber); err != nil {
+					return err
+				}
+				if len(frames) >= maxClaudeExportJSONDepth {
+					return claudeExportConversationComplexityError(conversationNumber, "JSON nesting depth")
+				}
+				frames = append(frames, claudeExportJSONFrame{delimiter: value, expectsKey: value == '{'})
+			case '}', ']':
+				if len(frames) == 0 || (value == '}' && frames[len(frames)-1].delimiter != '{') ||
+					(value == ']' && frames[len(frames)-1].delimiter != '[') {
+					return invalidClaudeExportArchive("conversation %d has mismatched JSON delimiters", conversationNumber)
+				}
+				frames = frames[:len(frames)-1]
+			}
+		case string:
+			if len(value) > maxClaudeExportJSONStringBytes {
+				return claudeExportConversationComplexityError(conversationNumber, "JSON string size")
+			}
+			if len(frames) > 0 && frames[len(frames)-1].delimiter == '{' && frames[len(frames)-1].expectsKey {
+				frame := &frames[len(frames)-1]
+				frame.items++
+				if frame.items > maxClaudeExportJSONContainerItems {
+					return claudeExportConversationComplexityError(conversationNumber, "JSON object field count")
+				}
+				frame.expectsKey = false
+				continue
+			}
+			if err := consumeClaudeExportJSONValue(frames, &rootValues, conversationNumber); err != nil {
+				return err
+			}
+		default:
+			if err := consumeClaudeExportJSONValue(frames, &rootValues, conversationNumber); err != nil {
+				return err
+			}
+		}
+	}
+	if len(frames) != 0 || rootValues != 1 {
+		return invalidClaudeExportArchive("conversation %d is not one complete JSON value", conversationNumber)
+	}
+	return nil
+}
+
+func consumeClaudeExportJSONValue(
+	frames []claudeExportJSONFrame,
+	rootValues *int,
+	conversationNumber int,
+) error {
+	if len(frames) == 0 {
+		(*rootValues)++
+		if *rootValues > 1 {
+			return invalidClaudeExportArchive("conversation %d contains trailing JSON data", conversationNumber)
+		}
+		return nil
+	}
+	frame := &frames[len(frames)-1]
+	if frame.delimiter == '{' {
+		if frame.expectsKey {
+			return invalidClaudeExportArchive("conversation %d has an invalid JSON object value", conversationNumber)
+		}
+		frame.expectsKey = true
+		return nil
+	}
+	frame.items++
+	if frame.items > maxClaudeExportJSONContainerItems {
+		return claudeExportConversationComplexityError(conversationNumber, "JSON array item count")
+	}
+	return nil
+}
+
+func claudeExportConversationComplexityError(conversationNumber int, limit string) error {
+	return invalidClaudeExportArchive(
+		"conversation %d exceeds the supported %s limit",
+		conversationNumber,
+		limit,
+	)
+}

--- a/services/tuttid/service/agent/external_import_claude_export_validation.go
+++ b/services/tuttid/service/agent/external_import_claude_export_validation.go
@@ -8,7 +8,6 @@ import (
 	"encoding/json"
 	"errors"
 	"io"
-	"os"
 )
 
 const (
@@ -251,12 +250,7 @@ func isClaudeExportJSONWhitespace(value byte) bool {
 	return value == ' ' || value == '\t' || value == '\r' || value == '\n'
 }
 
-func validateClaudeExportZipDirectory(archivePath string, archiveSize int64) error {
-	archive, err := os.Open(archivePath)
-	if err != nil {
-		return invalidClaudeExportArchive("open ZIP for directory preflight: %v", err)
-	}
-	defer archive.Close()
+func validateClaudeExportZipDirectory(archive io.ReaderAt, archiveSize int64) error {
 	tailSize := archiveSize
 	const endRecordBytes = int64(22)
 	if maximum := endRecordBytes + maxClaudeZipCommentBytes; tailSize > maximum {
@@ -287,7 +281,9 @@ func validateClaudeExportZipDirectory(archivePath string, archiveSize int64) err
 	entriesOnDisk := binary.LittleEndian.Uint16(record[8:])
 	totalEntries := binary.LittleEndian.Uint16(record[10:])
 	directorySize := binary.LittleEndian.Uint32(record[12:])
-	if entriesOnDisk == ^uint16(0) || totalEntries == ^uint16(0) || directorySize == ^uint32(0) {
+	directoryOffset := binary.LittleEndian.Uint32(record[16:])
+	if entriesOnDisk == ^uint16(0) || totalEntries == ^uint16(0) ||
+		directorySize == ^uint32(0) || directoryOffset == ^uint32(0) {
 		return invalidClaudeExportArchive("ZIP64 directory metadata is not supported")
 	}
 	if entriesOnDisk != totalEntries {
@@ -299,6 +295,15 @@ func validateClaudeExportZipDirectory(archivePath string, archiveSize int64) err
 	if int64(directorySize) > maxClaudeZipDirectoryBytes || int64(directorySize) > archiveSize {
 		return invalidClaudeExportArchive("ZIP directory exceeds the supported size limit")
 	}
+	// archive/zip parses central-directory headers from directoryOffset until
+	// they stop parsing, not until the declared count, so a record that
+	// underreports its size could smuggle a much larger directory past the
+	// limits above. Require the declared span to end exactly at the
+	// end-of-directory record.
+	endRecordStart := archiveSize - tailSize + int64(endOffset)
+	if int64(directoryOffset)+int64(directorySize) != endRecordStart {
+		return invalidClaudeExportArchive("ZIP directory span does not match the end-of-directory record")
+	}
 	return nil
 }
 
@@ -309,14 +314,11 @@ func validateClaudeExportConversationJSON(ctx context.Context, raw []byte, conve
 	decoder := json.NewDecoder(bytes.NewReader(raw))
 	frames := make([]claudeExportJSONFrame, 0, 8)
 	rootValues := 0
-	for tokenCount := 1; ; tokenCount++ {
+	for tokenCount := 0; ; {
 		if tokenCount%1024 == 0 {
 			if err := ctx.Err(); err != nil {
 				return err
 			}
-		}
-		if tokenCount > maxClaudeExportJSONTokens {
-			return claudeExportConversationComplexityError(conversationNumber, "JSON token count")
 		}
 		token, err := decoder.Token()
 		if errors.Is(err, io.EOF) {
@@ -324,6 +326,12 @@ func validateClaudeExportConversationJSON(ctx context.Context, raw []byte, conve
 		}
 		if err != nil {
 			return invalidClaudeExportArchive("decode conversation %d structure: %v", conversationNumber, err)
+		}
+		// Count only successfully decoded tokens so a conversation with
+		// exactly maxClaudeExportJSONTokens tokens stays within the limit.
+		tokenCount++
+		if tokenCount > maxClaudeExportJSONTokens {
+			return claudeExportConversationComplexityError(conversationNumber, "JSON token count")
 		}
 		switch value := token.(type) {
 		case json.Delim:

--- a/services/tuttid/service/agent/external_import_projects.go
+++ b/services/tuttid/service/agent/external_import_projects.go
@@ -20,7 +20,15 @@ func (*Service) ExternalImportValidProjectPaths(ctx context.Context, input Exter
 	if len(selections) == 0 {
 		return nil, nil
 	}
-	data := scanExternalAgentSessions(ctx, providersFromExternalImportSelections(selections), -1)
+	data, err := scanExternalAgentSessions(
+		ctx,
+		providersFromExternalImportSelections(selections),
+		-1,
+		input.ArchivePath,
+	)
+	if err != nil {
+		return nil, err
+	}
 	valid := map[string]int64{}
 	for _, session := range data.sessions {
 		if ctx.Err() != nil {
@@ -65,6 +73,17 @@ func externalSessionProjectPath(session externalImportedSession) (string, bool) 
 		return gitRoot, true
 	}
 	return cwd, true
+}
+
+// externalImportNoProjectBucketPath resolves the canonical home-directory
+// bucket used for provider exports that are not associated with a local
+// project directory.
+func externalImportNoProjectBucketPath() (string, bool) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", false
+	}
+	return canonicalExistingDir(home)
 }
 
 func nearestExternalImportGitRoot(cwd string) (string, bool) {

--- a/services/tuttid/service/agent/external_import_types.go
+++ b/services/tuttid/service/agent/external_import_types.go
@@ -1,0 +1,119 @@
+package agent
+
+type ExternalImportScanInput struct {
+	Providers []string
+	// Days limits the scan window to conversations updated within the last N
+	// days. 0 keeps the default 30-day window; a negative value scans all
+	// available history.
+	Days int
+	// ArchivePath selects a supported provider data-export ZIP instead of the
+	// provider's local CLI transcript directory.
+	ArchivePath string
+}
+
+type ExternalImportInput struct {
+	Projects    []ExternalImportProjectSelection
+	ArchivePath string
+}
+
+type ExternalImportProjectSelection struct {
+	Path       string
+	Providers  []string
+	SessionIDs []string
+}
+
+type ExternalImportScanResult struct {
+	Providers       []ExternalImportProvider
+	Projects        []ExternalImportProject
+	Sessions        []ExternalImportSession
+	ScannedSessions int
+	ScannedMessages int
+	SkippedSessions int
+	Errors          []ExternalImportError
+}
+
+type ExternalImportProvider struct {
+	Provider     string
+	Root         string
+	Available    bool
+	SessionCount int
+	MessageCount int
+	Error        string
+}
+
+type ExternalImportProject struct {
+	Path                string
+	Label               string
+	Providers           []string
+	SessionCount        int
+	MessageCount        int
+	LastUpdatedAtUnixMS int64
+}
+
+type ExternalImportSession struct {
+	ID                  string
+	ProjectPath         string
+	Provider            string
+	SourcePath          string
+	Title               string
+	MessageCount        int
+	LastUpdatedAtUnixMS int64
+}
+
+type ExternalImportError struct {
+	Provider   string
+	SourcePath string
+	Message    string
+}
+
+type ExternalImportResult struct {
+	ImportedProjects int
+	ImportedSessions int
+	ImportedMessages int
+	SkippedSessions  int
+	Errors           []ExternalImportError
+	// ProjectPaths lists the selected project paths that matched at least one
+	// valid imported session. Callers use it to avoid registering user projects
+	// that would surface with no sessions underneath them.
+	ProjectPaths []string
+}
+
+type externalImportedSession struct {
+	Provider          string
+	ProviderSessionID string
+	SourcePath        string
+	Cwd               string
+	Title             string
+	// SummaryTitle holds an authoritative, provider-supplied conversation title
+	// (e.g. Claude `custom-title`/`summary` transcript lines or the Codex
+	// app-server `threads.title`). When present it wins over message-derived
+	// titles.
+	SummaryTitle     string
+	NoProject        bool
+	EventUserMessage externalImportedMessage
+	StartedAtUnixMS  int64
+	UpdatedAtUnixMS  int64
+	Messages         []externalImportedMessage
+	// ResumeSupported is nil for legacy/local transcript imports, which remain
+	// continuable. Archive-only histories set it to false because claude.ai
+	// conversation IDs are not Claude Code runtime session IDs.
+	ResumeSupported *bool
+}
+
+type externalImportedMessage struct {
+	RawID             string
+	MessageIDSeed     string
+	Role              string
+	Kind              string
+	Status            string
+	Text              string
+	Payload           map[string]any
+	OccurredAtUnixMS  int64
+	StartedAtUnixMS   int64
+	CompletedAtUnixMS int64
+}
+
+type externalScanData struct {
+	result   ExternalImportScanResult
+	sessions []externalImportedSession
+}

--- a/services/tuttid/service/agent/external_import_types.go
+++ b/services/tuttid/service/agent/external_import_types.go
@@ -4,7 +4,9 @@ type ExternalImportScanInput struct {
 	Providers []string
 	// Days limits the scan window to conversations updated within the last N
 	// days. 0 keeps the default 30-day window; a negative value scans all
-	// available history.
+	// available history. Archive scans (ArchivePath set) are the exception:
+	// the export is a complete snapshot, so 0 also scans the full archive and
+	// only an explicit positive value narrows the window.
 	Days int
 	// ArchivePath selects a supported provider data-export ZIP instead of the
 	// provider's local CLI transcript directory.

--- a/services/tuttid/service/agent/service_resume_helpers.go
+++ b/services/tuttid/service/agent/service_resume_helpers.go
@@ -29,6 +29,13 @@ func (s *Service) ensureRuntimeSessionResult(
 	agentSessionID string,
 ) (ensuredRuntimeSession, error) {
 	if session, ok := s.controller().Session(workspaceID, agentSessionID); ok {
+		// Provider data exports are marked non-resumable at import time.
+		// Enforce the marker on the fast path too, so the opt-out below does
+		// not depend on the resume path being the only way a session can end
+		// up in the runtime registry.
+		if !externalImportResumeSupported(session.RuntimeContext) {
+			return ensuredRuntimeSession{}, ErrSessionNotFound
+		}
 		staleTurnReconciled := false
 		shouldReconcile, err := s.shouldReconcilePersistedStaleTurn(session, workspaceID, agentSessionID)
 		if err != nil {

--- a/services/tuttid/service/agent/service_resume_helpers.go
+++ b/services/tuttid/service/agent/service_resume_helpers.go
@@ -55,13 +55,15 @@ func (s *Service) ensureRuntimeSessionResult(
 		}
 		return ensuredRuntimeSession{}, ErrSessionNotFound
 	}
-	// Imported sessions used to be rejected here, which is what surfaced the
-	// "can't resume on this device, start a new conversation" dead-end. They now
-	// resume in place (same-device) or, when the provider session can't be
-	// restored locally, get a fresh provider session created on demand. The
-	// recreate is opt-in (RecreateIfMissing) so it stays scoped to imported
-	// conversations and doesn't change restore-error handling for normal ones.
+	// Imported local CLI transcripts resume in place (same-device) or, when the
+	// provider session can't be restored locally, get a fresh provider session
+	// created on demand. Provider data exports opt out because their web UUID is
+	// not a runtime session id. RecreateIfMissing stays scoped to the remaining
+	// imported transcripts and does not change normal restore-error handling.
 	imported := strings.TrimSpace(persisted.Origin) == WorkspaceAgentSessionOriginImported
+	if imported && !externalImportResumeSupported(persisted.RuntimeContext) {
+		return ensuredRuntimeSession{}, ErrSessionNotFound
+	}
 	prepared, err := s.prepareRuntimeForResume(ctx, persisted)
 	if err != nil {
 		return ensuredRuntimeSession{}, err

--- a/services/tuttid/service/agent/service_session.go
+++ b/services/tuttid/service/agent/service_session.go
@@ -51,14 +51,26 @@ func persistedSessionCanResume(controller RuntimeController, session PersistedSe
 	if controller == nil {
 		return false
 	}
-	// Imported sessions used to be hard-marked non-resumable, which dead-ended
-	// the user into starting a brand new conversation. They carry the provider
-	// session id captured at import time (codex thread id / claude sessionId), so
-	// they can resume in place on the same device; when the underlying provider
-	// session is missing, the runtime recreates a fresh one on send instead of
-	// blocking (see Controller.ensureLiveAdapterSession). Either way the
-	// conversation is continuable, so defer to the adapter's CanResume.
+	if strings.TrimSpace(session.Origin) == WorkspaceAgentSessionOriginImported &&
+		!externalImportResumeSupported(session.RuntimeContext) {
+		return false
+	}
+	// Imported local CLI transcripts carry the provider session id captured at
+	// import time (Codex thread id / Claude Code sessionId), so they can resume
+	// in place on the same device; when the provider session is missing, the
+	// runtime recreates a fresh one on send. Provider data exports explicitly
+	// opt out above because their web conversation UUID is not a runtime session
+	// id. All other imported and normal sessions defer to the adapter.
 	return controller.CanResume(runtimeResumeInputFromPersistedSession(session))
+}
+
+func externalImportResumeSupported(runtimeContext map[string]any) bool {
+	value, exists := runtimeContext["externalImportResumeSupported"]
+	if !exists {
+		return true
+	}
+	supported, ok := value.(bool)
+	return ok && supported
 }
 
 func serviceSession(session RuntimeSession, resumable bool) Session {


### PR DESCRIPTION
## Summary

Backport of #1063 to `release/0704`.

- add Claude data-export ZIP scanning and conversation import to the release daemon/API
- add the localized desktop archive picker and source-bound scan/import flow
- preserve visible text only, stable message ids, retry-branch isolation, and bounded ZIP/JSON parsing
- keep claude.ai export history in the no-project Chats section and prevent runtime resume
- adapt the implementation to the release branch's older wizard and daemon structures without pulling in unrelated main-only behavior

## Backport notes

- preserves the release branch's existing Dialog close semantics
- regenerates OpenAPI clients from the release schema
- keeps release-absent test/troubleshooting files absent; the durable import invariants are documented in the existing architecture document
- cherry-picked from `11eb397c7f38fded232fbb9061e46ce1188fc519`

## Validation

- 20/22 `pnpm check:changed` lanes passed directly
- the parallel Go lint lane passed on retry
- desktop production build passed
- desktop typecheck, 25 focused desktop tests, i18n, renderer/activity/Electron boundaries passed
- API generated check, client typecheck, and 46/46 client tests passed
- full daemon service tests and API tests passed
- real Claude export fixture: 135 importable conversations, 807 selected-branch visible messages, 1 empty conversation skipped

The remaining desktop test failure is reproducible unchanged on the original `origin/release/0704`: its expected reasoning-effort catalog differs from the current runtime fixture. It is not touched by this backport; CI should rerun it in a clean environment.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Backport: add Claude data‑export ZIP scanning and conversation import to `release/0704`, with strict archive validation, a localized ZIP picker, and a friendlier Agent GUI banner for imported, non‑resumable chats; hardens banner semantics and preserves import markers end‑to‑end. Provider‑export imports are non‑resumable and stay in Chats (no project).

- New Features
  - Desktop: Archive source with a localized ZIP picker (`common.zipArchive`) and scan/search/selection; added `selectExternalSessionImportArchive`; new wizard model and steps with en/zh copy.
  - API/Daemon: `scan`/`import` accept optional `archivePath`; strict ZIP/JSON parser for Claude exports (visible text only, stable IDs); OpenAPI updated and `@tutti-os/client-tuttid-ts` regenerated.
  - Agent GUI: New “resume‑unavailable” state for imported sessions with success‑tone banner, polite status aria, adaptive success foreground, and a “continue in new conversation” action; composer stays disabled; `runtimeContext` now flows through snapshots so imported/no‑project markers are shown.

- Bug Fixes
  - Validation/scan: Single‑FD ZIP checks; reject malformed ZIP/ZIP64 and misaligned central directories; correct JSON token counting; skip the default 30‑day window for archives (only positive values narrow); reject scans that exclude `claude-code`; propagate scan cancellation.
  - Runtime/UX: Enforce the non‑resumable marker on the runtime fast path; preserve import markers in the core→host projection and DTO; guard against stale scan completions; surface archive‑picker errors inline and keep the providers step; completion shows skipped conversation counts; success banner contrast improved; recovery is a discriminated union so “Continue” is only present for resume‑unavailable; fence queue‑while‑busy sends.

<sup>Written for commit 16a987957be41f93089c7c6ae5becd1d50efcd54. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tutti-os/tutti/pull/1065?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Large surface area: untrusted ZIP/JSON parsing, activity persistence, and session resume rules; mistakes could leak hidden content, corrupt transcripts, or allow unsafe archive handling.
> 
> **Overview**
> **Claude data-export ZIP import** extends external agent history import beyond local Codex/Claude Code JSONL: users pick a ZIP via a localized desktop picker; scan/import APIs accept optional `archivePath` and the daemon parses root `conversations.json` with size/depth limits, visible text blocks only, retry-branch selection, and stable message IDs.
> 
> **Desktop** refactors the import wizard with source-bound scan state (local vs archive), new source/result UI pieces, `selectExternalSessionImportArchive` wired to `selectAppArchive`, and archive-specific copy (en/zh). ZIP dialog filter labels use i18n `common.zipArchive`.
> 
> **Runtime behavior** marks Claude export imports as no-project Chats with `externalImportResumeSupported: false` so they are not treated as resumable CLI rollouts; local transcript imports keep prior resume semantics. OpenAPI/client types and architecture docs document the flow.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b77fb417fcf1323b81fd39cbc0f89019ef9ef435. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->