### PR TITLE
feat(app-center): gate managed model releases by host capability

### DIFF
--- a/.github/workflows/publish-tutti-app-catalog-staging.yml
+++ b/.github/workflows/publish-tutti-app-catalog-staging.yml
@@ -129,6 +129,9 @@ jobs:
               for (const appId of Object.keys(catalog.compatibility?.apps ?? {})) {
                 appIds.add(appId);
               }
+              for (const appId of Object.keys(catalog.compatibility?.capabilityApps ?? {})) {
+                appIds.add(appId);
+              }
               for (const appId of [...appIds].filter(Boolean).map((value) => value.trim()).filter(Boolean).sort()) {
                 console.log(appId);
               }

--- a/.github/workflows/publish-tutti-app-catalog.yml
+++ b/.github/workflows/publish-tutti-app-catalog.yml
@@ -129,6 +129,9 @@ jobs:
               for (const appId of Object.keys(catalog.compatibility?.apps ?? {})) {
                 appIds.add(appId);
               }
+              for (const appId of Object.keys(catalog.compatibility?.capabilityApps ?? {})) {
+                appIds.add(appId);
+              }
               for (const appId of [...appIds].filter(Boolean).map((value) => value.trim()).filter(Boolean).sort()) {
                 console.log(appId);
               }

--- a/.github/workflows/publish-tutti-app-release.yml
+++ b/.github/workflows/publish-tutti-app-release.yml
@@ -118,11 +118,7 @@ jobs:
             echo "release_assets_base_url is required unless catalog_only is true." >&2
             exit 1
           fi
-          if [ -z "${MIN_TUTTI_VERSION}" ]; then
-            echo "min_tutti_version is required unless catalog_only is true." >&2
-            exit 1
-          fi
-          if [[ ! "${MIN_TUTTI_VERSION}" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*)?(\+[0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*)?$ ]]; then
+          if [ -n "${MIN_TUTTI_VERSION}" ] && [[ ! "${MIN_TUTTI_VERSION}" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*)?(\+[0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*)?$ ]]; then
             echo "min_tutti_version must be valid SemVer." >&2
             exit 1
           fi

--- a/apps/cli/internal/app/managed_model.go
+++ b/apps/cli/internal/app/managed_model.go
@@ -1,0 +1,160 @@
+package app
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+
+	"github.com/tutti-os/tutti/apps/cli/internal/daemon"
+)
+
+const managedModelInputLimitBytes = 64 * 1024
+
+const (
+	managedModelExchangeCommandID   = "managed-model.grant.exchange"
+	managedModelModelsCommandID     = "managed-model.models"
+	managedModelCredentialCommandID = "managed-model.credential"
+	managedModelRevokeCommandID     = "managed-model.revoke"
+)
+
+var managedModelInputReader = func() io.Reader { return os.Stdin }
+
+type managedModelExchangeInput struct {
+	ContextToken string `json:"contextToken"`
+	GrantCode    string `json:"grantCode"`
+	Nonce        string `json:"nonce"`
+	State        string `json:"state"`
+}
+
+type managedModelGrantRefInput struct {
+	GrantRef string `json:"grantRef"`
+}
+
+type managedModelCredentialInput struct {
+	Capability string `json:"capability"`
+	GrantRef   string `json:"grantRef"`
+	Model      string `json:"model"`
+	Provider   string `json:"provider"`
+}
+
+func runManagedModel(ctx context.Context, commandName string, _ options, args []string, stdout io.Writer, stderr io.Writer) int {
+	commandID, input, err := parseManagedModelInput(args)
+	if err != nil {
+		fmt.Fprintf(stderr, "%s managed-model: %v\n", commandName, err)
+		return 2
+	}
+	client, err := discoverClient()
+	if err != nil {
+		fmt.Fprintf(stderr, "%s managed-model: %v\n", commandName, err)
+		return 1
+	}
+	response, err := client.Invoke(ctx, commandID, daemon.InvokeRequest{
+		Input:      input,
+		OutputMode: "json",
+		Context:    cliInvokeContextFromEnv(),
+	})
+	if err != nil {
+		fmt.Fprintf(stderr, "%s managed-model: %v\n", commandName, err)
+		return 1
+	}
+	if response.Output == nil {
+		fmt.Fprintf(stderr, "%s managed-model: command returned no output\n", commandName)
+		return 1
+	}
+	return writeDynamicJSON(stdout, stderr, *response.Output)
+}
+
+func parseManagedModelInput(args []string) (string, map[string]any, error) {
+	commandID, payloadArgs, err := managedModelCommand(args)
+	if err != nil {
+		return "", nil, err
+	}
+	if len(payloadArgs) != 2 || payloadArgs[0] != "--input-json" || payloadArgs[1] != "-" {
+		return "", nil, fmt.Errorf("usage: managed-model %s --input-json -", strings.Join(args[:len(args)-len(payloadArgs)], " "))
+	}
+	switch commandID {
+	case managedModelExchangeCommandID:
+		var input managedModelExchangeInput
+		if err := decodeManagedModelInput(&input); err != nil {
+			return "", nil, err
+		}
+		normalized, err := requiredManagedModelFields(map[string]any{
+			"contextToken": input.ContextToken,
+			"grantCode":    input.GrantCode,
+			"nonce":        input.Nonce,
+			"state":        input.State,
+		})
+		return commandID, normalized, err
+	case managedModelModelsCommandID, managedModelRevokeCommandID:
+		var input managedModelGrantRefInput
+		if err := decodeManagedModelInput(&input); err != nil {
+			return "", nil, err
+		}
+		normalized, err := requiredManagedModelFields(map[string]any{"grantRef": input.GrantRef})
+		return commandID, normalized, err
+	case managedModelCredentialCommandID:
+		var input managedModelCredentialInput
+		if err := decodeManagedModelInput(&input); err != nil {
+			return "", nil, err
+		}
+		normalized, err := requiredManagedModelFields(map[string]any{
+			"capability": input.Capability,
+			"grantRef":   input.GrantRef,
+			"model":      input.Model,
+			"provider":   input.Provider,
+		})
+		return commandID, normalized, err
+	default:
+		return "", nil, fmt.Errorf("unsupported managed-model command")
+	}
+}
+
+func managedModelCommand(args []string) (string, []string, error) {
+	if len(args) >= 2 && args[0] == "grant" && args[1] == "exchange" {
+		return managedModelExchangeCommandID, args[2:], nil
+	}
+	if len(args) >= 1 && args[0] == "models" {
+		return managedModelModelsCommandID, args[1:], nil
+	}
+	if len(args) >= 1 && args[0] == "credential" {
+		return managedModelCredentialCommandID, args[1:], nil
+	}
+	if len(args) >= 1 && args[0] == "revoke" {
+		return managedModelRevokeCommandID, args[1:], nil
+	}
+	return "", nil, fmt.Errorf("expected grant exchange, models, credential, or revoke")
+}
+
+func decodeManagedModelInput(target any) error {
+	reader := io.LimitReader(managedModelInputReader(), managedModelInputLimitBytes+1)
+	content, err := io.ReadAll(reader)
+	if err != nil {
+		return fmt.Errorf("read input: %w", err)
+	}
+	if len(content) > managedModelInputLimitBytes {
+		return fmt.Errorf("input exceeds %d bytes", managedModelInputLimitBytes)
+	}
+	decoder := json.NewDecoder(strings.NewReader(string(content)))
+	decoder.DisallowUnknownFields()
+	if err := decoder.Decode(target); err != nil {
+		return fmt.Errorf("invalid input JSON: %w", err)
+	}
+	if decoder.Decode(&struct{}{}) != io.EOF {
+		return fmt.Errorf("input must contain exactly one JSON object")
+	}
+	return nil
+}
+
+func requiredManagedModelFields(input map[string]any) (map[string]any, error) {
+	for key, value := range input {
+		text, ok := value.(string)
+		if !ok || strings.TrimSpace(text) == "" {
+			return nil, fmt.Errorf("%s is required", key)
+		}
+		input[key] = strings.TrimSpace(text)
+	}
+	return input, nil
+}

--- a/apps/cli/internal/app/managed_model_test.go
+++ b/apps/cli/internal/app/managed_model_test.go
@@ -1,0 +1,66 @@
+package app
+
+import (
+	"encoding/json"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestParseManagedModelExchangeInput(t *testing.T) {
+	previous := managedModelInputReader
+	managedModelInputReader = func() io.Reader {
+		return strings.NewReader(`{"contextToken":"context-1","grantCode":"code-1","nonce":"nonce-1","state":"state-1"}`)
+	}
+	t.Cleanup(func() { managedModelInputReader = previous })
+
+	commandID, input, err := parseManagedModelInput([]string{"grant", "exchange", "--input-json", "-"})
+	if err != nil {
+		t.Fatalf("parseManagedModelInput: %v", err)
+	}
+	if commandID != managedModelExchangeCommandID {
+		t.Fatalf("commandID = %q", commandID)
+	}
+	if input["grantCode"] != "code-1" || input["contextToken"] != "context-1" {
+		t.Fatalf("input = %#v", input)
+	}
+}
+
+func TestManagedModelProtocolFixtureParsesExchangeInput(t *testing.T) {
+	raw, err := os.ReadFile(filepath.Join("..", "..", "..", "..", "packages", "appcli", "core", "testdata", "managed-model", "protocol.v1.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var fixture struct {
+		Commands map[string]struct {
+			Input json.RawMessage `json:"input"`
+		} `json:"commands"`
+	}
+	if err := json.Unmarshal(raw, &fixture); err != nil {
+		t.Fatal(err)
+	}
+	previous := managedModelInputReader
+	managedModelInputReader = func() io.Reader {
+		return strings.NewReader(string(fixture.Commands[managedModelExchangeCommandID].Input))
+	}
+	t.Cleanup(func() { managedModelInputReader = previous })
+	commandID, input, err := parseManagedModelInput([]string{"grant", "exchange", "--input-json", "-"})
+	if err != nil || commandID != managedModelExchangeCommandID || input["grantCode"] != "grant-test" {
+		t.Fatalf("parse fixture commandID=%q input=%#v err=%v", commandID, input, err)
+	}
+}
+
+func TestParseManagedModelInputRejectsUnknownFields(t *testing.T) {
+	previous := managedModelInputReader
+	managedModelInputReader = func() io.Reader {
+		return strings.NewReader(`{"grantRef":"grant-1","extra":"no"}`)
+	}
+	t.Cleanup(func() { managedModelInputReader = previous })
+
+	_, _, err := parseManagedModelInput([]string{"models", "--input-json", "-"})
+	if err == nil || !strings.Contains(err.Error(), "unknown field") {
+		t.Fatalf("err = %v", err)
+	}
+}

--- a/apps/cli/internal/app/run.go
+++ b/apps/cli/internal/app/run.go
@@ -38,6 +38,8 @@ func RunWithProgram(ctx context.Context, program string, args []string, stdout i
 			return 2
 		}
 		return runStatus(ctx, commandName, opts, stdout, stderr)
+	case "managed-model":
+		return runManagedModel(ctx, commandName, opts, rest[1:], stdout, stderr)
 	default:
 		return runDynamic(ctx, commandName, opts, rest, stdout, stderr)
 	}
@@ -179,6 +181,7 @@ func includeIntegrationCapabilitiesFromEnv() bool {
 
 func cliInvokeContextFromEnv() daemon.InvokeContext {
 	return daemon.InvokeContext{
+		AppID:           strings.TrimSpace(os.Getenv("TUTTI_APP_ID")),
 		Source:          "cli",
 		WorkspaceID:     strings.TrimSpace(os.Getenv("TUTTI_WORKSPACE_ID")),
 		ParentCommandID: strings.TrimSpace(os.Getenv("TUTTI_APP_CLI_PARENT_COMMAND_ID")),

--- a/apps/cli/internal/app/run_test.go
+++ b/apps/cli/internal/app/run_test.go
@@ -66,12 +66,14 @@ func TestRunWithProgramUsesCommandNameInSubcommandUsage(t *testing.T) {
 }
 
 func TestCliInvokeContextFromEnvIncludesAgentSessionID(t *testing.T) {
+	t.Setenv("TUTTI_APP_ID", " automation-app ")
 	t.Setenv("TUTTI_WORKSPACE_ID", " workspace-1 ")
 	t.Setenv("TUTTI_APP_CLI_PARENT_COMMAND_ID", " parent-1 ")
 	t.Setenv("TUTTI_AGENT_SESSION_ID", " session-1 ")
 
 	context := cliInvokeContextFromEnv()
-	if context.Source != "cli" ||
+	if context.AppID != "automation-app" ||
+		context.Source != "cli" ||
 		context.WorkspaceID != "workspace-1" ||
 		context.ParentCommandID != "parent-1" ||
 		context.AgentSessionID != "session-1" {

--- a/apps/cli/internal/daemon/client.go
+++ b/apps/cli/internal/daemon/client.go
@@ -85,6 +85,7 @@ type InvokeRequest struct {
 }
 
 type InvokeContext struct {
+	AppID           string `json:"appId,omitempty"`
 	Source          string `json:"source"`
 	WorkspaceID     string `json:"workspaceID,omitempty"`
 	ParentCommandID string `json:"parentCommandId,omitempty"`

--- a/packages/appcli/core/testdata/managed-model/protocol.v1.json
+++ b/packages/appcli/core/testdata/managed-model/protocol.v1.json
@@ -1,0 +1,59 @@
+{
+  "version": 1,
+  "commands": {
+    "managed-model.grant.exchange": {
+      "argv": ["managed-model", "grant", "exchange", "--input-json", "-"],
+      "input": {
+        "contextToken": "context-test",
+        "grantCode": "grant-test",
+        "nonce": "nonce-test",
+        "state": "state-test"
+      },
+      "output": {
+        "grantRef": "grant-ref-test",
+        "providers": ["openai"],
+        "models": [
+          { "id": "gpt-test", "name": "GPT Test", "provider": "openai" }
+        ],
+        "expiresAt": "2026-07-12T00:10:00Z"
+      }
+    },
+    "managed-model.models": {
+      "argv": ["managed-model", "models", "--input-json", "-"],
+      "input": { "grantRef": "grant-ref-test" },
+      "output": {
+        "models": [
+          { "id": "gpt-test", "name": "GPT Test", "provider": "openai" }
+        ],
+        "expiresAt": "2026-07-12T00:10:00Z"
+      }
+    },
+    "managed-model.credential": {
+      "argv": ["managed-model", "credential", "--input-json", "-"],
+      "input": {
+        "grantRef": "grant-ref-test",
+        "provider": "openai",
+        "model": "gpt-test",
+        "capability": "agent"
+      },
+      "output": {
+        "credential": {
+          "provider": "openai",
+          "apiKey": "fixture-only-key",
+          "models": [
+            { "id": "gpt-test", "name": "GPT Test", "provider": "openai" }
+          ]
+        },
+        "models": [
+          { "id": "gpt-test", "name": "GPT Test", "provider": "openai" }
+        ],
+        "expiresAt": "2026-07-12T00:05:00Z"
+      }
+    },
+    "managed-model.revoke": {
+      "argv": ["managed-model", "revoke", "--input-json", "-"],
+      "input": { "grantRef": "grant-ref-test" },
+      "output": { "ok": true }
+    }
+  }
+}

--- a/packages/clients/tuttid-ts/src/generated/types.gen.ts
+++ b/packages/clients/tuttid-ts/src/generated/types.gen.ts
@@ -197,6 +197,10 @@ export type CliInvokeContext = {
    * Client source label such as cli. This is not an authorization boundary.
    */
   source: string;
+  /**
+   * Calling workspace app id hint. Managed-model commands validate it against their grant binding.
+   */
+  appId?: string | null;
   workspaceID?: string | null;
   parentCommandId?: string | null;
   /**

--- a/packages/workspace/app-release-tools/bin/build-tutti-app-catalog.mjs
+++ b/packages/workspace/app-release-tools/bin/build-tutti-app-catalog.mjs
@@ -4,6 +4,7 @@ import { pathToFileURL } from "node:url";
 import path from "node:path";
 
 import {
+  normalizeRequiredTuttiCapabilities,
   releaseToCatalogApp,
   validateRelease
 } from "./build-tutti-app-release.mjs";
@@ -30,6 +31,7 @@ export async function buildTuttiAppCatalog(options) {
 
   const appsByID = new Map();
   const compatibilityByAppID = new Map();
+  const capabilityCompatibilityByAppID = new Map();
   if (existingCatalogPath) {
     const existingCatalog = JSON.parse(
       await readFile(existingCatalogPath, "utf8")
@@ -43,6 +45,11 @@ export async function buildTuttiAppCatalog(options) {
     )) {
       compatibilityByAppID.set(appId, entries);
     }
+    for (const [appId, entries] of Object.entries(
+      existingCatalog.compatibility?.capabilityApps ?? {}
+    )) {
+      capabilityCompatibilityByAppID.set(appId, entries);
+    }
   }
 
   const seenVersionsAppIDs = new Set();
@@ -53,7 +60,12 @@ export async function buildTuttiAppCatalog(options) {
       throw new Error(`duplicate versions appId ${versions.appId}`);
     }
     seenVersionsAppIDs.add(versions.appId);
-    applyVersionsDocument(appsByID, compatibilityByAppID, versions);
+    applyVersionsDocument(
+      appsByID,
+      compatibilityByAppID,
+      capabilityCompatibilityByAppID,
+      versions
+    );
   }
 
   const seenReleaseAppIDs = new Set();
@@ -72,7 +84,11 @@ export async function buildTuttiAppCatalog(options) {
     appsByID.set(release.appId, releaseToCatalogApp(release));
   }
 
-  if (appsByID.size === 0 && compatibilityByAppID.size === 0) {
+  if (
+    appsByID.size === 0 &&
+    compatibilityByAppID.size === 0 &&
+    capabilityCompatibilityByAppID.size === 0
+  ) {
     throw new Error(
       "at least one versions file, release file, or existing catalog app is required"
     );
@@ -86,11 +102,24 @@ export async function buildTuttiAppCatalog(options) {
       .filter(([, entries]) => entries.length > 0)
       .sort(([left], [right]) => left.localeCompare(right))
   );
+  const capabilityApps = Object.fromEntries(
+    [...capabilityCompatibilityByAppID.entries()]
+      .filter(([, entries]) => entries.length > 0)
+      .sort(([left], [right]) => left.localeCompare(right))
+  );
   const catalog = {
     schemaVersion: catalogSchemaVersion,
     apps,
-    ...(Object.keys(compatibilityApps).length > 0
-      ? { compatibility: { apps: compatibilityApps } }
+    ...(Object.keys(compatibilityApps).length > 0 ||
+    Object.keys(capabilityApps).length > 0
+      ? {
+          compatibility: {
+            apps: compatibilityApps,
+            ...(Object.keys(capabilityApps).length > 0
+              ? { capabilityApps }
+              : {})
+          }
+        }
       : {})
   };
   validateCatalog(catalog);
@@ -141,7 +170,18 @@ export function validateCatalog(catalog) {
   ) {
     throw new Error("catalog compatibility.apps must be an object");
   }
-  for (const [appId, entries] of Object.entries(compatibility.apps)) {
+  validateCatalogCompatibilityApps(compatibility.apps);
+  if (compatibility.capabilityApps !== undefined) {
+    validateCatalogCapabilityApps(
+      compatibility.capabilityApps,
+      seenLegacyAppIDs
+    );
+  }
+  return catalog;
+}
+
+function validateCatalogCompatibilityApps(compatibilityApps) {
+  for (const [appId, entries] of Object.entries(compatibilityApps)) {
     if (!Array.isArray(entries) || entries.length === 0) {
       throw new Error(`catalog compatibility app ${appId} must be non-empty`);
     }
@@ -169,7 +209,55 @@ export function validateCatalog(catalog) {
       seenVersions.add(version);
     }
   }
-  return catalog;
+}
+
+function validateCatalogCapabilityApps(capabilityApps, legacyAppIDs) {
+  if (
+    !capabilityApps ||
+    typeof capabilityApps !== "object" ||
+    Array.isArray(capabilityApps)
+  ) {
+    throw new Error("catalog compatibility.capabilityApps must be an object");
+  }
+  for (const [rawAppID, entries] of Object.entries(capabilityApps)) {
+    const appId = String(rawAppID).trim();
+    if (appId === "" || !Array.isArray(entries) || entries.length === 0) {
+      throw new Error(
+        `catalog capability compatibility app ${rawAppID} must be non-empty`
+      );
+    }
+    if (!legacyAppIDs.has(appId)) {
+      throw new Error(
+        `catalog capability compatibility app ${appId} requires a legacy fallback app`
+      );
+    }
+    const seenCapabilitySets = new Set();
+    const seenVersions = new Set();
+    for (const [index, entry] of entries.entries()) {
+      const label = `catalog capability compatibility app ${appId}[${index}]`;
+      if (!entry || typeof entry !== "object" || Array.isArray(entry)) {
+        throw new Error(`${label} must be an object`);
+      }
+      const requiredTuttiCapabilities = normalizeRequiredTuttiCapabilities(
+        entry.requiredTuttiCapabilities,
+        `${label}.requiredTuttiCapabilities`
+      );
+      const capabilityKey = requiredTuttiCapabilities.join("\u0000");
+      if (seenCapabilitySets.has(capabilityKey)) {
+        throw new Error(`${label} has duplicate requiredTuttiCapabilities`);
+      }
+      seenCapabilitySets.add(capabilityKey);
+      const entryAppID = validateCatalogApp(entry.app, `${label}.app`);
+      if (entryAppID !== appId) {
+        throw new Error(`${label}.app manifest.appId must match map key`);
+      }
+      const version = entry.app.manifest.version;
+      if (seenVersions.has(version)) {
+        throw new Error(`${label} has duplicate app version ${version}`);
+      }
+      seenVersions.add(version);
+    }
+  }
 }
 
 export function validateCatalogApp(app, label) {
@@ -200,7 +288,12 @@ export function validateCatalogApp(app, label) {
   return appId;
 }
 
-function applyVersionsDocument(appsByID, compatibilityByAppID, versions) {
+function applyVersionsDocument(
+  appsByID,
+  compatibilityByAppID,
+  capabilityCompatibilityByAppID,
+  versions
+) {
   const activeRecords = versions.versions.filter(
     (record) => record.status === "active"
   );
@@ -214,7 +307,9 @@ function applyVersionsDocument(appsByID, compatibilityByAppID, versions) {
     appsByID.delete(versions.appId);
   }
 
-  const entries = compatibilityFrontier(activeRecords).map((record) => ({
+  const entries = compatibilityFrontier(
+    activeRecords.filter((record) => record.minTuttiVersion !== undefined)
+  ).map((record) => ({
     minTuttiVersion: record.minTuttiVersion,
     app: releaseToCatalogApp(record.release)
   }));
@@ -222,6 +317,20 @@ function applyVersionsDocument(appsByID, compatibilityByAppID, versions) {
     compatibilityByAppID.set(versions.appId, entries);
   } else {
     compatibilityByAppID.delete(versions.appId);
+  }
+
+  const capabilityEntries = capabilityCompatibilityFrontier(
+    activeRecords.filter(
+      (record) => record.requiredTuttiCapabilities !== undefined
+    )
+  ).map((record) => ({
+    requiredTuttiCapabilities: record.requiredTuttiCapabilities,
+    app: releaseToCatalogApp(record.release)
+  }));
+  if (capabilityEntries.length > 0) {
+    capabilityCompatibilityByAppID.set(versions.appId, capabilityEntries);
+  } else {
+    capabilityCompatibilityByAppID.delete(versions.appId);
   }
 }
 
@@ -256,6 +365,27 @@ export function compatibilityFrontier(records) {
     }
   }
   return frontier;
+}
+
+export function capabilityCompatibilityFrontier(records) {
+  const highestByCapabilitySet = new Map();
+  for (const record of records) {
+    const capabilityKey = record.requiredTuttiCapabilities.join("\u0000");
+    const existing = highestByCapabilitySet.get(capabilityKey);
+    if (
+      !existing ||
+      compareReleaseVersions(record.release, existing.release) > 0
+    ) {
+      highestByCapabilitySet.set(capabilityKey, record);
+    }
+  }
+  return [...highestByCapabilitySet.values()].sort((left, right) => {
+    const leftKey = left.requiredTuttiCapabilities.join("\u0000");
+    const rightKey = right.requiredTuttiCapabilities.join("\u0000");
+    const keyComparison = leftKey.localeCompare(rightKey);
+    if (keyComparison !== 0) return keyComparison;
+    return compareReleaseVersions(left.release, right.release);
+  });
 }
 
 function highestReleaseRecord(records) {

--- a/packages/workspace/app-release-tools/bin/build-tutti-app-release.mjs
+++ b/packages/workspace/app-release-tools/bin/build-tutti-app-release.mjs
@@ -167,7 +167,61 @@ export function validateManifest(manifest, sourceLabel = "manifest") {
   }
   validateManifestCLI(manifest.cli, sourceLabel);
   validateManifestReferences(manifest.references, sourceLabel);
+  requiredTuttiCapabilitiesForManifest(manifest, sourceLabel);
   validateLocalizationInfo(manifest.localizationInfo, sourceLabel);
+}
+
+export function requiredTuttiCapabilitiesForManifest(
+  manifest,
+  sourceLabel = "manifest"
+) {
+  const compatibility = manifest.hostCompatibility;
+  if (compatibility === undefined) return [];
+  if (
+    !compatibility ||
+    typeof compatibility !== "object" ||
+    Array.isArray(compatibility)
+  ) {
+    throw new Error(`${sourceLabel}.hostCompatibility must be an object`);
+  }
+  const unsupportedKey = Object.keys(compatibility).find(
+    (key) => key !== "requiredTuttiCapabilities"
+  );
+  if (unsupportedKey) {
+    throw new Error(
+      `${sourceLabel}.hostCompatibility.${unsupportedKey} is unsupported`
+    );
+  }
+  return normalizeRequiredTuttiCapabilities(
+    compatibility.requiredTuttiCapabilities,
+    `${sourceLabel}.hostCompatibility.requiredTuttiCapabilities`
+  );
+}
+
+export function normalizeRequiredTuttiCapabilities(value, label) {
+  if (!Array.isArray(value) || value.length === 0) {
+    throw new Error(`${label} must be a non-empty array`);
+  }
+  if (value.length > 32) {
+    throw new Error(`${label} must contain at most 32 capabilities`);
+  }
+  const capabilities = value.map((capability, index) => {
+    if (typeof capability !== "string" || capability.trim() !== capability) {
+      throw new Error(`${label}[${index}] must be a normalized string`);
+    }
+    if (!/^[a-z][a-z0-9-]{0,63}$/u.test(capability)) {
+      throw new Error(`${label}[${index}] is invalid`);
+    }
+    return capability;
+  });
+  const normalized = [...new Set(capabilities)].sort();
+  if (
+    normalized.length !== capabilities.length ||
+    normalized.some((capability, index) => capability !== capabilities[index])
+  ) {
+    throw new Error(`${label} must be sorted and unique`);
+  }
+  return normalized;
 }
 
 function validateManifestCLI(cli, sourceLabel) {

--- a/packages/workspace/app-release-tools/bin/build-tutti-app-versions.mjs
+++ b/packages/workspace/app-release-tools/bin/build-tutti-app-versions.mjs
@@ -3,7 +3,11 @@ import { mkdir, readFile, writeFile } from "node:fs/promises";
 import { pathToFileURL } from "node:url";
 import path from "node:path";
 
-import { validateRelease } from "./build-tutti-app-release.mjs";
+import {
+  normalizeRequiredTuttiCapabilities,
+  requiredTuttiCapabilitiesForManifest,
+  validateRelease
+} from "./build-tutti-app-release.mjs";
 import {
   compareReleaseVersions,
   requireSemver
@@ -40,16 +44,32 @@ export async function buildTuttiAppVersions(options) {
   }
 
   if (releaseFiles.length > 0) {
-    const minTuttiVersion = requireSemver(
-      options.minTuttiVersion,
-      "minTuttiVersion"
-    );
+    const minTuttiVersion = options.minTuttiVersion
+      ? requireSemver(options.minTuttiVersion, "minTuttiVersion")
+      : null;
     const status = normalizeStatus(options.status ?? "active");
     for (const releaseFile of releaseFiles) {
       const release = JSON.parse(await readFile(releaseFile, "utf8"));
       validateRelease(release);
+      const requiredTuttiCapabilities = requiredTuttiCapabilitiesForManifest(
+        release.manifest,
+        "release.manifest"
+      );
+      if (minTuttiVersion && requiredTuttiCapabilities.length > 0) {
+        throw new Error(
+          "a release cannot declare both minTuttiVersion and requiredTuttiCapabilities"
+        );
+      }
+      if (!minTuttiVersion && requiredTuttiCapabilities.length === 0) {
+        throw new Error(
+          "minTuttiVersion or release.manifest.hostCompatibility.requiredTuttiCapabilities is required"
+        );
+      }
       document = addVersionRecord(document, {
-        minTuttiVersion,
+        ...(minTuttiVersion ? { minTuttiVersion } : {}),
+        ...(requiredTuttiCapabilities.length > 0
+          ? { requiredTuttiCapabilities }
+          : {}),
         status,
         release
       });
@@ -104,10 +124,31 @@ export function validateVersionsDocument(document) {
     if (!record || typeof record !== "object" || Array.isArray(record)) {
       throw new Error(`${label} must be an object`);
     }
-    record.minTuttiVersion = requireSemver(
-      record.minTuttiVersion,
-      `${label}.minTuttiVersion`
-    );
+    const hasMinTuttiVersion = record.minTuttiVersion !== undefined;
+    const hasRequiredTuttiCapabilities =
+      record.requiredTuttiCapabilities !== undefined;
+    if (hasMinTuttiVersion && hasRequiredTuttiCapabilities) {
+      throw new Error(
+        `${label} cannot declare both minTuttiVersion and requiredTuttiCapabilities`
+      );
+    }
+    if (!hasMinTuttiVersion && !hasRequiredTuttiCapabilities) {
+      throw new Error(
+        `${label} must declare minTuttiVersion or requiredTuttiCapabilities`
+      );
+    }
+    if (hasMinTuttiVersion) {
+      record.minTuttiVersion = requireSemver(
+        record.minTuttiVersion,
+        `${label}.minTuttiVersion`
+      );
+    }
+    if (hasRequiredTuttiCapabilities) {
+      record.requiredTuttiCapabilities = normalizeRequiredTuttiCapabilities(
+        record.requiredTuttiCapabilities,
+        `${label}.requiredTuttiCapabilities`
+      );
+    }
     record.status = normalizeStatus(record.status);
     validateRelease(record.release);
     if (record.release.appId !== appId) {

--- a/packages/workspace/app-release-tools/bin/publish-tutti-app-metadata.mjs
+++ b/packages/workspace/app-release-tools/bin/publish-tutti-app-metadata.mjs
@@ -7,6 +7,7 @@ import path from "node:path";
 
 import { buildTuttiAppCatalog } from "./build-tutti-app-catalog.mjs";
 import {
+  requiredTuttiCapabilitiesForManifest,
   releaseToCatalogApp,
   validateRelease
 } from "./build-tutti-app-release.mjs";
@@ -37,10 +38,6 @@ export async function publishTuttiAppMetadata(options) {
   if (!catalogOnly && !releasePath) {
     throw new Error("releasePath is required unless catalogOnly is true");
   }
-  if (!catalogOnly && !minTuttiVersion) {
-    throw new Error("minTuttiVersion is required for app releases");
-  }
-
   await mkdir(outputDir, { recursive: true });
   const release = releasePath
     ? JSON.parse(await readFile(releasePath, "utf8"))
@@ -50,6 +47,23 @@ export async function publishTuttiAppMetadata(options) {
     if (release.appId !== appId) {
       throw new Error("release appId must match input appId");
     }
+  }
+  const requiredTuttiCapabilities = release
+    ? requiredTuttiCapabilitiesForManifest(release.manifest, "release.manifest")
+    : [];
+  if (
+    !catalogOnly &&
+    !minTuttiVersion &&
+    requiredTuttiCapabilities.length === 0
+  ) {
+    throw new Error(
+      "minTuttiVersion or release.manifest.hostCompatibility.requiredTuttiCapabilities is required for app releases"
+    );
+  }
+  if (minTuttiVersion && requiredTuttiCapabilities.length > 0) {
+    throw new Error(
+      "an app release cannot declare both minTuttiVersion and requiredTuttiCapabilities"
+    );
   }
 
   const key = (suffix) => (prefix ? `${prefix}/${suffix}` : suffix);
@@ -78,7 +92,7 @@ export async function publishTuttiAppMetadata(options) {
 
       if (releasePath) {
         releaseFiles.push(releasePath);
-      } else if (!existingPath && minTuttiVersion) {
+      } else if (!existingPath) {
         const latest = await getObject({
           bucket,
           key: latestKey,
@@ -100,7 +114,9 @@ export async function publishTuttiAppMetadata(options) {
         existingVersionsPath: existingPath,
         baselineReleaseFiles,
         releaseFiles,
-        ...(releaseFiles.length > 0 ? { minTuttiVersion } : {}),
+        ...(releaseFiles.length > 0 && minTuttiVersion
+          ? { minTuttiVersion }
+          : {}),
         outputPath
       });
       return outputPath;
@@ -173,7 +189,10 @@ async function downloadLegacyBaseline(input) {
   });
   if (!catalog) return null;
   const document = JSON.parse(await readFile(catalog.path, "utf8"));
-  if ((document.compatibility?.apps?.[input.appId] ?? []).length > 0) {
+  if (
+    (document.compatibility?.apps?.[input.appId] ?? []).length > 0 ||
+    (document.compatibility?.capabilityApps?.[input.appId] ?? []).length > 0
+  ) {
     throw new Error(
       `versions index for ${input.appId} is missing but catalog compatibility history exists; restore versions.json before publishing`
     );

--- a/packages/workspace/app-release-tools/bin/verify-tutti-app-release-artifacts.mjs
+++ b/packages/workspace/app-release-tools/bin/verify-tutti-app-release-artifacts.mjs
@@ -70,6 +70,18 @@ export async function verifyTuttiAppReleaseArtifacts(options) {
         );
       }
     }
+    for (const [appId, entries] of Object.entries(
+      catalog.compatibility?.capabilityApps ?? {}
+    )) {
+      for (const entry of entries) {
+        addCatalogAppCheck(
+          checks,
+          releasesByKey,
+          entry.app,
+          `catalog capability compatibility app ${appId}`
+        );
+      }
+    }
   }
 
   if (verifyArtifacts) {

--- a/services/tuttid/api/daemon_cli.go
+++ b/services/tuttid/api/daemon_cli.go
@@ -288,7 +288,12 @@ func serviceCliContext(contextValue *tuttigenerated.CliInvokeContext) cliservice
 	if contextValue.AgentSessionId != nil {
 		agentSessionID = *contextValue.AgentSessionId
 	}
+	appID := ""
+	if contextValue.AppId != nil {
+		appID = *contextValue.AppId
+	}
 	return cliservice.InvokeContext{
+		AppID:           appID,
 		Source:          contextValue.Source,
 		WorkspaceID:     workspaceID,
 		ParentCommandID: parentCommandID,

--- a/services/tuttid/api/generated/types.gen.go
+++ b/services/tuttid/api/generated/types.gen.go
@@ -2422,7 +2422,10 @@ type CliCommandWarning struct {
 // CliInvokeContext Client-supplied invocation context. These fields are hints for routing and audit only; authorization and workspace validation remain daemon-owned.
 type CliInvokeContext struct {
 	// AgentSessionId Caller agent session id hint. This is not an authorization boundary.
-	AgentSessionId  *string `json:"agentSessionId,omitempty"`
+	AgentSessionId *string `json:"agentSessionId,omitempty"`
+
+	// AppId Calling workspace app id hint. Managed-model commands validate it against their grant binding.
+	AppId           *string `json:"appId,omitempty"`
 	ParentCommandId *string `json:"parentCommandId,omitempty"`
 
 	// Source Client source label such as cli. This is not an authorization boundary.

--- a/services/tuttid/api/openapi/tuttid.v1.yaml
+++ b/services/tuttid/api/openapi/tuttid.v1.yaml
@@ -4365,6 +4365,10 @@ components:
           type: string
           description: Client source label such as cli. This is not an authorization boundary.
           minLength: 1
+        appId:
+          type: string
+          description: Calling workspace app id hint. Managed-model commands validate it against their grant binding.
+          nullable: true
         workspaceID:
           type: string
           nullable: true

--- a/services/tuttid/builtin-apps/catalog.go
+++ b/services/tuttid/builtin-apps/catalog.go
@@ -11,6 +11,7 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 	"sync"
 	"time"
@@ -79,11 +80,15 @@ type CatalogSnapshot struct {
 }
 
 func Catalog() ([]App, error) {
-	return CatalogForTuttiVersion("")
+	return CatalogForHost(CatalogHost{})
 }
 
 func CatalogForTuttiVersion(tuttiVersion string) ([]App, error) {
-	snapshot, err := snapshot(false, tuttiVersion)
+	return CatalogForHost(CatalogHost{TuttiVersion: tuttiVersion})
+}
+
+func CatalogForHost(host CatalogHost) ([]App, error) {
+	snapshot, err := snapshot(false, host)
 	if err != nil {
 		return nil, err
 	}
@@ -91,35 +96,51 @@ func CatalogForTuttiVersion(tuttiVersion string) ([]App, error) {
 }
 
 func Snapshot() (CatalogSnapshot, error) {
-	return SnapshotForTuttiVersion("")
+	return SnapshotForHost(CatalogHost{})
 }
 
 func SnapshotForTuttiVersion(tuttiVersion string) (CatalogSnapshot, error) {
-	return snapshot(false, tuttiVersion)
+	return SnapshotForHost(CatalogHost{TuttiVersion: tuttiVersion})
+}
+
+func SnapshotForHost(host CatalogHost) (CatalogSnapshot, error) {
+	return snapshot(false, host)
 }
 
 func SnapshotForRemoteURL(catalogURL string) (CatalogSnapshot, error) {
-	return SnapshotForRemoteURLAndTuttiVersion(catalogURL, "")
+	return SnapshotForRemoteURLAndHost(catalogURL, CatalogHost{})
 }
 
 func SnapshotForRemoteURLAndTuttiVersion(catalogURL string, tuttiVersion string) (CatalogSnapshot, error) {
-	return snapshotWithSource(remoteCatalogSourceForURL(catalogURL, tuttiVersion), false)
+	return SnapshotForRemoteURLAndHost(catalogURL, CatalogHost{TuttiVersion: tuttiVersion})
+}
+
+func SnapshotForRemoteURLAndHost(catalogURL string, host CatalogHost) (CatalogSnapshot, error) {
+	return snapshotWithSource(remoteCatalogSourceForURL(catalogURL, host), false)
 }
 
 func RefreshRemoteCatalogAndWait(ctx context.Context) (CatalogSnapshot, error) {
-	return RefreshRemoteCatalogAndWaitForTuttiVersion(ctx, "")
+	return RefreshRemoteCatalogAndWaitForHost(ctx, CatalogHost{})
 }
 
 func RefreshRemoteCatalogAndWaitForTuttiVersion(ctx context.Context, tuttiVersion string) (CatalogSnapshot, error) {
-	return snapshotAndWaitWithSource(ctx, currentRemoteCatalogSource(tuttiVersion))
+	return RefreshRemoteCatalogAndWaitForHost(ctx, CatalogHost{TuttiVersion: tuttiVersion})
+}
+
+func RefreshRemoteCatalogAndWaitForHost(ctx context.Context, host CatalogHost) (CatalogSnapshot, error) {
+	return snapshotAndWaitWithSource(ctx, currentRemoteCatalogSource(host))
 }
 
 func RefreshRemoteCatalogAndWaitForRemoteURL(ctx context.Context, catalogURL string) (CatalogSnapshot, error) {
-	return RefreshRemoteCatalogAndWaitForRemoteURLAndTuttiVersion(ctx, catalogURL, "")
+	return RefreshRemoteCatalogAndWaitForRemoteURLAndHost(ctx, catalogURL, CatalogHost{})
 }
 
 func RefreshRemoteCatalogAndWaitForRemoteURLAndTuttiVersion(ctx context.Context, catalogURL string, tuttiVersion string) (CatalogSnapshot, error) {
-	return snapshotAndWaitWithSource(ctx, remoteCatalogSourceForURL(catalogURL, tuttiVersion))
+	return RefreshRemoteCatalogAndWaitForRemoteURLAndHost(ctx, catalogURL, CatalogHost{TuttiVersion: tuttiVersion})
+}
+
+func RefreshRemoteCatalogAndWaitForRemoteURLAndHost(ctx context.Context, catalogURL string, host CatalogHost) (CatalogSnapshot, error) {
+	return snapshotAndWaitWithSource(ctx, remoteCatalogSourceForURL(catalogURL, host))
 }
 
 func RemoteCatalogEnvOverrideActive() bool {
@@ -191,8 +212,8 @@ func embeddedCatalog() []App {
 	}
 }
 
-func snapshot(refreshRemote bool, tuttiVersion string) (CatalogSnapshot, error) {
-	return snapshotWithSource(currentRemoteCatalogSource(tuttiVersion), refreshRemote)
+func snapshot(refreshRemote bool, host CatalogHost) (CatalogSnapshot, error) {
+	return snapshotWithSource(currentRemoteCatalogSource(host), refreshRemote)
 }
 
 func snapshotWithSource(source remoteCatalogSource, refreshRemote bool) (CatalogSnapshot, error) {
@@ -342,9 +363,10 @@ const (
 )
 
 type remoteCatalogSource struct {
-	kind         remoteCatalogSourceKind
-	value        string
-	tuttiVersion string
+	kind                 remoteCatalogSourceKind
+	value                string
+	tuttiVersion         string
+	tuttiCapabilitiesKey string
 }
 
 type remoteCatalogResult struct {
@@ -370,7 +392,7 @@ func remoteCatalogSnapshot(source remoteCatalogSource, refresh bool) (remoteCata
 			state: RemoteCatalogLoadState{Status: RemoteCatalogLoadStatusDisabled},
 		}, nil
 	case remoteCatalogSourceFile:
-		apps, err := loadRemoteCatalogFromFile(source.value, source.tuttiVersion)
+		apps, err := loadRemoteCatalogFromFile(source.value, source.catalogHost())
 		if err != nil {
 			return remoteCatalogResult{}, err
 		}
@@ -393,7 +415,7 @@ func remoteCatalogSnapshotAndWait(ctx context.Context, source remoteCatalogSourc
 			state: RemoteCatalogLoadState{Status: RemoteCatalogLoadStatusDisabled},
 		}, nil
 	case remoteCatalogSourceFile:
-		apps, err := loadRemoteCatalogFromFile(source.value, source.tuttiVersion)
+		apps, err := loadRemoteCatalogFromFile(source.value, source.catalogHost())
 		if err != nil {
 			return remoteCatalogResult{}, err
 		}
@@ -406,33 +428,69 @@ func remoteCatalogSnapshotAndWait(ctx context.Context, source remoteCatalogSourc
 	}
 }
 
-func currentRemoteCatalogSource(tuttiVersion string) remoteCatalogSource {
+func currentRemoteCatalogSource(host CatalogHost) remoteCatalogSource {
+	host = normalizeCatalogHost(host)
 	filePath := strings.TrimSpace(os.Getenv(remoteCatalogFileEnv))
 	if filePath != "" {
-		return remoteCatalogSource{kind: remoteCatalogSourceFile, value: filePath, tuttiVersion: tuttiVersion}
+		return remoteCatalogSourceForHost(remoteCatalogSourceFile, filePath, host)
 	}
 
 	catalogURL := remoteCatalogURL()
 	if catalogURL == "" {
 		return remoteCatalogSource{kind: remoteCatalogSourceNone}
 	}
-	return remoteCatalogSource{kind: remoteCatalogSourceURL, value: catalogURL, tuttiVersion: tuttiVersion}
+	return remoteCatalogSourceForHost(remoteCatalogSourceURL, catalogURL, host)
 }
 
-func remoteCatalogSourceForURL(catalogURL string, tuttiVersion string) remoteCatalogSource {
+func remoteCatalogSourceForURL(catalogURL string, host CatalogHost) remoteCatalogSource {
 	catalogURL = strings.TrimSpace(catalogURL)
 	if catalogURL == "" {
 		return remoteCatalogSource{kind: remoteCatalogSourceNone}
 	}
-	return remoteCatalogSource{kind: remoteCatalogSourceURL, value: catalogURL, tuttiVersion: tuttiVersion}
+	return remoteCatalogSourceForHost(remoteCatalogSourceURL, catalogURL, normalizeCatalogHost(host))
 }
 
-func loadRemoteCatalogFromFile(filePath string, tuttiVersion string) ([]App, error) {
+func remoteCatalogSourceForHost(kind remoteCatalogSourceKind, value string, host CatalogHost) remoteCatalogSource {
+	return remoteCatalogSource{
+		kind:                 kind,
+		value:                value,
+		tuttiVersion:         host.TuttiVersion,
+		tuttiCapabilitiesKey: strings.Join(host.Capabilities, "\x00"),
+	}
+}
+
+func (source remoteCatalogSource) catalogHost() CatalogHost {
+	capabilities := []string(nil)
+	if source.tuttiCapabilitiesKey != "" {
+		capabilities = strings.Split(source.tuttiCapabilitiesKey, "\x00")
+	}
+	return CatalogHost{TuttiVersion: source.tuttiVersion, Capabilities: capabilities}
+}
+
+func normalizeCatalogHost(host CatalogHost) CatalogHost {
+	seen := make(map[string]struct{}, len(host.Capabilities))
+	for _, capability := range host.Capabilities {
+		if isCanonicalCatalogCapability(capability) {
+			seen[capability] = struct{}{}
+		}
+	}
+	capabilities := make([]string, 0, len(seen))
+	for capability := range seen {
+		capabilities = append(capabilities, capability)
+	}
+	sort.Strings(capabilities)
+	return CatalogHost{
+		TuttiVersion: strings.TrimSpace(host.TuttiVersion),
+		Capabilities: capabilities,
+	}
+}
+
+func loadRemoteCatalogFromFile(filePath string, host CatalogHost) ([]App, error) {
 	data, err := os.ReadFile(filePath)
 	if err != nil {
 		return nil, fmt.Errorf("read app catalog file: %w", err)
 	}
-	return parseRemoteCatalogForTuttiVersion(data, tuttiVersion)
+	return parseRemoteCatalogForHost(data, host)
 }
 
 func (l *asyncRemoteCatalogLoader) snapshot(source remoteCatalogSource) remoteCatalogResult {
@@ -528,7 +586,7 @@ func (l *asyncRemoteCatalogLoader) startLoadLocked(source remoteCatalogSource) {
 
 func (l *asyncRemoteCatalogLoader) load(source remoteCatalogSource, done chan struct{}) {
 	slog.Info("remote app catalog fetch started", "url", source.value)
-	apps, err := fetchRemoteCatalogWithRetries(source.value, source.tuttiVersion)
+	apps, err := fetchRemoteCatalogWithRetries(source.value, source.catalogHost())
 
 	l.mu.Lock()
 	defer l.mu.Unlock()
@@ -550,10 +608,10 @@ func (l *asyncRemoteCatalogLoader) load(source remoteCatalogSource, done chan st
 	l.state = readyRemoteCatalogLoadState()
 }
 
-func fetchRemoteCatalogWithRetries(catalogURL string, tuttiVersion string) ([]App, error) {
+func fetchRemoteCatalogWithRetries(catalogURL string, host CatalogHost) ([]App, error) {
 	var lastErr error
 	for attempt := 1; attempt <= remoteCatalogFetchAttempts; attempt++ {
-		apps, err := fetchRemoteCatalog(catalogURL, tuttiVersion)
+		apps, err := fetchRemoteCatalog(catalogURL, host)
 		if err == nil {
 			return apps, nil
 		}
@@ -573,7 +631,7 @@ func remoteCatalogRetryDelay(attempt int) time.Duration {
 	return 900 * time.Millisecond
 }
 
-func fetchRemoteCatalog(catalogURL string, tuttiVersion string) ([]App, error) {
+func fetchRemoteCatalog(catalogURL string, host CatalogHost) ([]App, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), remoteCatalogFetchTimeout)
 	defer cancel()
 	request, err := http.NewRequestWithContext(ctx, http.MethodGet, catalogURL, nil)
@@ -592,7 +650,7 @@ func fetchRemoteCatalog(catalogURL string, tuttiVersion string) ([]App, error) {
 	if err != nil {
 		return nil, fmt.Errorf("read app catalog response: %w", err)
 	}
-	return parseRemoteCatalogForTuttiVersion(data, tuttiVersion)
+	return parseRemoteCatalogForHost(data, host)
 }
 
 type remoteCatalogHTTPStatusError struct {

--- a/services/tuttid/builtin-apps/catalog_compatibility.go
+++ b/services/tuttid/builtin-apps/catalog_compatibility.go
@@ -19,12 +19,25 @@ type remoteCatalogDocument struct {
 }
 
 type remoteCatalogCompatibility struct {
-	Apps map[string][]remoteCatalogCompatibilityEntry `json:"apps"`
+	Apps           map[string][]remoteCatalogCompatibilityEntry `json:"apps"`
+	CapabilityApps map[string][]remoteCatalogCapabilityEntry    `json:"capabilityApps,omitempty"`
 }
 
 type remoteCatalogCompatibilityEntry struct {
 	MinTuttiVersion string           `json:"minTuttiVersion"`
 	App             remoteCatalogApp `json:"app"`
+}
+
+type remoteCatalogCapabilityEntry struct {
+	RequiredTuttiCapabilities []string         `json:"requiredTuttiCapabilities"`
+	App                       remoteCatalogApp `json:"app"`
+}
+
+// CatalogHost is the local host contract used to select a remote app release.
+// Capability strings come from the host binary, never from the app process.
+type CatalogHost struct {
+	TuttiVersion string
+	Capabilities []string
 }
 
 type remoteCatalogApp struct {
@@ -41,10 +54,14 @@ type remoteDistribution struct {
 }
 
 func parseRemoteCatalog(data []byte) ([]App, error) {
-	return parseRemoteCatalogForTuttiVersion(data, "")
+	return parseRemoteCatalogForHost(data, CatalogHost{})
 }
 
 func parseRemoteCatalogForTuttiVersion(data []byte, tuttiVersion string) ([]App, error) {
+	return parseRemoteCatalogForHost(data, CatalogHost{TuttiVersion: tuttiVersion})
+}
+
+func parseRemoteCatalogForHost(data []byte, host CatalogHost) ([]App, error) {
 	var document remoteCatalogDocument
 	if err := json.Unmarshal(data, &document); err != nil {
 		return nil, fmt.Errorf("parse app catalog json: %w", err)
@@ -66,7 +83,7 @@ func parseRemoteCatalogForTuttiVersion(data []byte, tuttiVersion string) ([]App,
 		appsByID[appID] = app
 	}
 
-	hostVersion, hostVersionValid := tuttitypes.NormalizeSemver(tuttiVersion)
+	hostVersion, hostVersionValid := tuttitypes.NormalizeSemver(host.TuttiVersion)
 	if document.Compatibility != nil {
 		if document.Compatibility.Apps == nil {
 			return nil, errors.New("app catalog compatibility.apps is required")
@@ -115,6 +132,13 @@ func parseRemoteCatalogForTuttiVersion(data []byte, tuttiVersion string) ([]App,
 				appsByID[appID] = selected
 			}
 		}
+		if err := applyCapabilityCompatibleApps(
+			appsByID,
+			document.Compatibility.CapabilityApps,
+			host.Capabilities,
+		); err != nil {
+			return nil, err
+		}
 	}
 
 	apps := make([]App, 0, len(appsByID))
@@ -125,6 +149,96 @@ func parseRemoteCatalogForTuttiVersion(data []byte, tuttiVersion string) ([]App,
 		return apps[left].Manifest.AppID < apps[right].Manifest.AppID
 	})
 	return apps, nil
+}
+
+func applyCapabilityCompatibleApps(appsByID map[string]App, entriesByAppID map[string][]remoteCatalogCapabilityEntry, capabilities []string) error {
+	hostCapabilities := make(map[string]struct{}, len(capabilities))
+	for _, capability := range capabilities {
+		if isCanonicalCatalogCapability(capability) {
+			hostCapabilities[capability] = struct{}{}
+		}
+	}
+	for rawAppID, entries := range entriesByAppID {
+		appID := strings.TrimSpace(rawAppID)
+		if appID == "" || len(entries) == 0 {
+			continue
+		}
+		seenCapabilitySets := make(map[string]struct{}, len(entries))
+		seenVersions := make(map[string]struct{}, len(entries))
+		selected, hasSelected := appsByID[appID]
+		for _, entry := range entries {
+			capabilityKey, eligible := eligibleCatalogCapabilityEntry(entry.RequiredTuttiCapabilities, hostCapabilities)
+			if !eligible {
+				continue
+			}
+			if _, ok := seenCapabilitySets[capabilityKey]; ok {
+				return fmt.Errorf("app catalog capability compatibility app %q has duplicate requiredTuttiCapabilities", appID)
+			}
+			seenCapabilitySets[capabilityKey] = struct{}{}
+			app, err := parseRemoteCatalogApp(entry.App)
+			if err != nil {
+				return err
+			}
+			if strings.TrimSpace(app.Manifest.AppID) != appID {
+				return fmt.Errorf("app catalog capability compatibility app %q manifest appId mismatch", appID)
+			}
+			version, ok := tuttitypes.NormalizeSemver(app.Manifest.Version)
+			if !ok {
+				return fmt.Errorf("app catalog capability compatibility app %q has invalid version %q", appID, app.Manifest.Version)
+			}
+			if _, ok := seenVersions[version]; ok {
+				return fmt.Errorf("app catalog capability compatibility app %q has duplicate version %q", appID, app.Manifest.Version)
+			}
+			seenVersions[version] = struct{}{}
+			if !hasSelected || compareCatalogAppVersions(app, selected) > 0 {
+				selected = app
+				hasSelected = true
+			}
+		}
+		if hasSelected {
+			appsByID[appID] = selected
+		}
+	}
+	return nil
+}
+
+func eligibleCatalogCapabilityEntry(required []string, hostCapabilities map[string]struct{}) (string, bool) {
+	if len(required) == 0 {
+		return "", false
+	}
+	seen := make(map[string]struct{}, len(required))
+	for _, capability := range required {
+		if !isCanonicalCatalogCapability(capability) {
+			return "", false
+		}
+		if _, ok := seen[capability]; ok {
+			return "", false
+		}
+		seen[capability] = struct{}{}
+		if _, ok := hostCapabilities[capability]; !ok {
+			return "", false
+		}
+	}
+	normalized := make([]string, 0, len(seen))
+	for capability := range seen {
+		normalized = append(normalized, capability)
+	}
+	sort.Strings(normalized)
+	return strings.Join(normalized, "\x00"), true
+}
+
+func isCanonicalCatalogCapability(value string) bool {
+	if len(value) == 0 || len(value) > 64 || value[0] < 'a' || value[0] > 'z' {
+		return false
+	}
+	for _, character := range value[1:] {
+		if (character < 'a' || character > 'z') &&
+			(character < '0' || character > '9') &&
+			character != '-' {
+			return false
+		}
+	}
+	return true
 }
 
 func parseRemoteCatalogApp(entry remoteCatalogApp) (App, error) {

--- a/services/tuttid/builtin-apps/catalog_test.go
+++ b/services/tuttid/builtin-apps/catalog_test.go
@@ -168,7 +168,7 @@ func TestCatalogRetriesRemoteURLFetch(t *testing.T) {
 	t.Cleanup(server.Close)
 	t.Setenv(remoteCatalogURLEnv, server.URL+"/catalog.json")
 
-	snapshot, err := snapshot(true, "")
+	snapshot, err := snapshot(true, CatalogHost{})
 	if err != nil {
 		t.Fatalf("snapshot(true) error = %v", err)
 	}
@@ -500,6 +500,94 @@ func TestParseRemoteCatalogSelectsHighestCompatibleAppVersion(t *testing.T) {
 	}
 	if app := findCatalogAppForTest(highApps, "new-only-app"); app == nil || app.Manifest.Version != "1.0.0" {
 		t.Fatalf("high-version new-only app = %#v, want 1.0.0", app)
+	}
+}
+
+func TestParseRemoteCatalogSelectsCapabilityCompatibleAppVersion(t *testing.T) {
+	legacy := remoteCatalogAppForVersionTest("capability-app", "1.0.0")
+	versionCompatible := remoteCatalogAppForVersionTest("capability-app", "1.1.0")
+	capabilityCompatible := remoteCatalogAppForVersionTest("capability-app", "2.0.0")
+	document := remoteCatalogDocument{
+		SchemaVersion: remoteCatalogSchemaVersionV1,
+		Apps:          []remoteCatalogApp{legacy},
+		Compatibility: &remoteCatalogCompatibility{
+			Apps: map[string][]remoteCatalogCompatibilityEntry{
+				"capability-app": {
+					{MinTuttiVersion: "0.0.0", App: versionCompatible},
+				},
+			},
+			CapabilityApps: map[string][]remoteCatalogCapabilityEntry{
+				"capability-app": {
+					{
+						RequiredTuttiCapabilities: []string{"managed-model-cli-v1"},
+						App:                       capabilityCompatible,
+					},
+				},
+			},
+		},
+	}
+	data, err := json.Marshal(document)
+	if err != nil {
+		t.Fatalf("marshal catalog: %v", err)
+	}
+
+	legacyApps, err := parseRemoteCatalogForTuttiVersion(data, "0.12.0")
+	if err != nil {
+		t.Fatalf("parse legacy wrapper catalog: %v", err)
+	}
+	if app := findCatalogAppForTest(legacyApps, "capability-app"); app == nil || app.Manifest.Version != "1.1.0" {
+		t.Fatalf("legacy capability app = %#v, want 1.1.0", app)
+	}
+
+	unsupportedApps, err := parseRemoteCatalogForHost(data, CatalogHost{
+		TuttiVersion: "0.12.0",
+	})
+	if err != nil {
+		t.Fatalf("parse unsupported capability catalog: %v", err)
+	}
+	if app := findCatalogAppForTest(unsupportedApps, "capability-app"); app == nil || app.Manifest.Version != "1.1.0" {
+		t.Fatalf("unsupported capability app = %#v, want 1.1.0", app)
+	}
+
+	capableApps, err := parseRemoteCatalogForHost(data, CatalogHost{
+		TuttiVersion: "0.12.0",
+		Capabilities: []string{"managed-model-cli-v1"},
+	})
+	if err != nil {
+		t.Fatalf("parse capable catalog: %v", err)
+	}
+	if app := findCatalogAppForTest(capableApps, "capability-app"); app == nil || app.Manifest.Version != "2.0.0" {
+		t.Fatalf("capable app = %#v, want 2.0.0", app)
+	}
+}
+
+func TestParseRemoteCatalogRejectsEligibleMalformedCapabilityPayload(t *testing.T) {
+	legacy := remoteCatalogAppForVersionTest("capability-app", "1.0.0")
+	document := remoteCatalogDocument{
+		SchemaVersion: remoteCatalogSchemaVersionV1,
+		Apps:          []remoteCatalogApp{legacy},
+		Compatibility: &remoteCatalogCompatibility{
+			Apps: map[string][]remoteCatalogCompatibilityEntry{},
+			CapabilityApps: map[string][]remoteCatalogCapabilityEntry{
+				"capability-app": {
+					{
+						RequiredTuttiCapabilities: []string{"managed-model-cli-v1"},
+						App: remoteCatalogApp{
+							Manifest: workspacebiz.AppManifest{Version: "not-a-manifest"},
+						},
+					},
+				},
+			},
+		},
+	}
+	data, err := json.Marshal(document)
+	if err != nil {
+		t.Fatalf("marshal catalog: %v", err)
+	}
+	if _, err := parseRemoteCatalogForHost(data, CatalogHost{
+		Capabilities: []string{"managed-model-cli-v1"},
+	}); err == nil {
+		t.Fatal("parse eligible malformed capability payload error = nil")
 	}
 }
 

--- a/services/tuttid/service/cli/builtin_compliance_test.go
+++ b/services/tuttid/service/cli/builtin_compliance_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/tutti-os/tutti/services/tuttid/service/cli/providers/computer"
 	"github.com/tutti-os/tutti/services/tuttid/service/cli/providers/diagnostics"
 	"github.com/tutti-os/tutti/services/tuttid/service/cli/providers/issuemanager"
+	"github.com/tutti-os/tutti/services/tuttid/service/cli/providers/managedmodels"
 )
 
 func TestBuiltinProviderCapabilitiesAreFrameworkCompliant(t *testing.T) {
@@ -20,6 +21,7 @@ func TestBuiltinProviderCapabilitiesAreFrameworkCompliant(t *testing.T) {
 		agentcontext.NewProviderWithLaunchPublisher(nil, nil, nil),
 		browser.NewProvider(nil, nil),
 		computer.NewProvider(nil, nil),
+		managedmodels.NewProvider(nil),
 	}
 	total := 0
 	for _, provider := range providers {

--- a/services/tuttid/service/cli/providers/managedmodels/provider.go
+++ b/services/tuttid/service/cli/providers/managedmodels/provider.go
@@ -1,0 +1,179 @@
+package managedmodels
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	cliservice "github.com/tutti-os/tutti/services/tuttid/service/cli"
+	managedcredentialsservice "github.com/tutti-os/tutti/services/tuttid/service/managedcredentials"
+)
+
+const providerID = "managed-model"
+
+const (
+	commandGrantExchange = providerID + ".grant.exchange"
+	commandModels        = providerID + ".models"
+	commandCredential    = providerID + ".credential"
+	commandRevoke        = providerID + ".revoke"
+)
+
+type Provider struct {
+	service *managedcredentialsservice.Service
+}
+
+func NewProvider(service *managedcredentialsservice.Service) Provider {
+	return Provider{service: service}
+}
+
+func (Provider) AppID() string {
+	return providerID
+}
+
+func (p Provider) Commands() []cliservice.Command {
+	return []cliservice.Command{
+		p.newExchangeCommand(),
+		p.newModelsCommand(),
+		p.newCredentialCommand(),
+		p.newRevokeCommand(),
+	}
+}
+
+func (p Provider) newExchangeCommand() cliservice.Command {
+	return p.command(commandGrantExchange, []string{"managed-model", "grant", "exchange"}, "Exchange a managed-model grant", []string{"contextToken", "grantCode", "nonce", "state"}, p.exchange)
+}
+
+func (p Provider) newModelsCommand() cliservice.Command {
+	return p.command(commandModels, []string{"managed-model", "models"}, "List managed-model grant models", []string{"grantRef"}, p.models)
+}
+
+func (p Provider) newCredentialCommand() cliservice.Command {
+	return p.command(commandCredential, []string{"managed-model", "credential"}, "Lease a managed-model provider credential", []string{"grantRef", "provider", "model", "capability"}, p.credential)
+}
+
+func (p Provider) newRevokeCommand() cliservice.Command {
+	return p.command(commandRevoke, []string{"managed-model", "revoke"}, "Revoke a managed-model grant", []string{"grantRef"}, p.revoke)
+}
+
+func (p Provider) command(id string, path []string, summary string, required []string, run func(context.Context, cliservice.InvokeRequest) (map[string]any, error)) cliservice.Command {
+	properties := map[string]any{}
+	for _, name := range required {
+		properties[name] = map[string]any{"type": "string"}
+	}
+	return cliservice.Command{
+		Capability: cliservice.Capability{
+			ID:          id,
+			Path:        path,
+			Summary:     summary,
+			Description: summary + ". This integration command is available only from a workspace app CLI context.",
+			Visibility:  cliservice.CapabilityVisibilityIntegration,
+			InputSchema: map[string]any{"type": "object", "required": required, "properties": properties},
+			Output: cliservice.CapabilityOutput{
+				DefaultMode: cliservice.OutputModeJSON,
+				JSON:        true,
+			},
+		},
+		Handler: func(ctx context.Context, request cliservice.InvokeRequest) (cliservice.CommandOutput, error) {
+			if p.service == nil {
+				return cliservice.CommandOutput{}, cliservice.ServiceUnavailableError("managed_model_service_unavailable", fmt.Errorf("managed model service is unavailable"))
+			}
+			if err := requireExactInput(request.Input, required); err != nil {
+				return cliservice.CommandOutput{}, err
+			}
+			if err := requireAppContext(request.Context); err != nil {
+				return cliservice.CommandOutput{}, err
+			}
+			value, err := run(ctx, request)
+			if err != nil {
+				return cliservice.CommandOutput{}, err
+			}
+			return cliservice.CommandOutput{Kind: cliservice.OutputModeJSON, Value: value}, nil
+		},
+	}
+}
+
+func (p Provider) exchange(ctx context.Context, request cliservice.InvokeRequest) (map[string]any, error) {
+	result, err := p.service.Exchange(ctx, managedcredentialsservice.ExchangeInput{
+		AppID:        request.Context.AppID,
+		ContextToken: request.Input["contextToken"].(string),
+		GrantCode:    request.Input["grantCode"].(string),
+		Nonce:        request.Input["nonce"].(string),
+		State:        request.Input["state"].(string),
+		WorkspaceID:  request.Context.WorkspaceID,
+	})
+	if err != nil {
+		return nil, err
+	}
+	return map[string]any{
+		"expiresAt": formatTime(result.ExpiresAt),
+		"grantRef":  result.GrantRef,
+		"models":    result.Models,
+		"providers": result.Providers,
+	}, nil
+}
+
+func (p Provider) models(ctx context.Context, request cliservice.InvokeRequest) (map[string]any, error) {
+	result, err := p.service.ListGrantModels(ctx, request.Context.WorkspaceID, request.Context.AppID, request.Input["grantRef"].(string))
+	if err != nil {
+		return nil, err
+	}
+	return map[string]any{"expiresAt": formatTime(result.ExpiresAt), "models": result.Models}, nil
+}
+
+func (p Provider) credential(ctx context.Context, request cliservice.InvokeRequest) (map[string]any, error) {
+	result, err := p.service.Credential(ctx, managedcredentialsservice.CredentialInput{
+		AppID:       request.Context.AppID,
+		Capability:  request.Input["capability"].(string),
+		GrantRef:    request.Input["grantRef"].(string),
+		Model:       request.Input["model"].(string),
+		Provider:    request.Input["provider"].(string),
+		WorkspaceID: request.Context.WorkspaceID,
+	})
+	if err != nil {
+		return nil, err
+	}
+	return map[string]any{
+		"credential": result.Credential,
+		"expiresAt":  formatTime(result.ExpiresAt),
+		"models":     result.GrantModels,
+	}, nil
+}
+
+func (p Provider) revoke(ctx context.Context, request cliservice.InvokeRequest) (map[string]any, error) {
+	if err := p.service.Revoke(ctx, request.Context.WorkspaceID, request.Context.AppID, request.Input["grantRef"].(string)); err != nil {
+		return nil, err
+	}
+	return map[string]any{"ok": true}, nil
+}
+
+func requireAppContext(context cliservice.InvokeContext) error {
+	if strings.TrimSpace(context.WorkspaceID) == "" || strings.TrimSpace(context.AppID) == "" {
+		return fmt.Errorf("%w: managed-model commands require workspace and app context", cliservice.ErrInvalidInput)
+	}
+	return nil
+}
+
+func requireExactInput(input map[string]any, required []string) error {
+	if input == nil {
+		return fmt.Errorf("%w: command input is required", cliservice.ErrInvalidInput)
+	}
+	allowed := make(map[string]struct{}, len(required))
+	for _, name := range required {
+		allowed[name] = struct{}{}
+		value, ok := input[name].(string)
+		if !ok || strings.TrimSpace(value) == "" {
+			return fmt.Errorf("%w: %s is required", cliservice.ErrInvalidInput, name)
+		}
+	}
+	for name := range input {
+		if _, ok := allowed[name]; !ok {
+			return fmt.Errorf("%w: %s is not supported", cliservice.ErrInvalidInput, name)
+		}
+	}
+	return nil
+}
+
+func formatTime(value time.Time) string {
+	return value.UTC().Format(time.RFC3339)
+}

--- a/services/tuttid/service/cli/types.go
+++ b/services/tuttid/service/cli/types.go
@@ -63,6 +63,7 @@ type Capability struct {
 }
 
 type InvokeContext struct {
+	AppID                          string
 	Source                         string
 	WorkspaceID                    string
 	ParentCommandID                string

--- a/services/tuttid/service/workspace/apps.go
+++ b/services/tuttid/service/workspace/apps.go
@@ -29,10 +29,11 @@ type AppCenterService struct {
 	AppCLIRegistry         *appcliservice.Registry
 	StateDir               string
 	HostTuttiVersion       string
+	HostTuttiCapabilities  []string
 	Publisher              WorkspaceAppEventPublisher
 	BuiltinCatalog         func() ([]builtinapps.App, error)
 	ArtifactFetcher        AppArtifactFetcher
-	RemoteCatalogRefresher func(context.Context, string) (builtinapps.CatalogSnapshot, error)
+	RemoteCatalogRefresher func(context.Context, string, builtinapps.CatalogHost) (builtinapps.CatalogSnapshot, error)
 
 	mu                sync.Mutex
 	stateRevisions    map[string]int64

--- a/services/tuttid/service/workspace/apps_remote_builtin.go
+++ b/services/tuttid/service/workspace/apps_remote_builtin.go
@@ -256,10 +256,14 @@ func (s *AppCenterService) builtinCatalog(ctx context.Context) ([]builtinapps.Ap
 	if s.BuiltinCatalog != nil {
 		return s.BuiltinCatalog()
 	}
-	if builtinapps.RemoteCatalogEnvOverrideActive() {
-		return builtinapps.CatalogForTuttiVersion(s.HostTuttiVersion)
+	host := builtinapps.CatalogHost{
+		TuttiVersion: s.HostTuttiVersion,
+		Capabilities: s.HostTuttiCapabilities,
 	}
-	snapshot, err := builtinapps.SnapshotForRemoteURLAndTuttiVersion(s.appCatalogRemoteURL(ctx), s.HostTuttiVersion)
+	if builtinapps.RemoteCatalogEnvOverrideActive() {
+		return builtinapps.CatalogForHost(host)
+	}
+	snapshot, err := builtinapps.SnapshotForRemoteURLAndHost(s.appCatalogRemoteURL(ctx), host)
 	if err != nil {
 		return nil, err
 	}
@@ -267,14 +271,18 @@ func (s *AppCenterService) builtinCatalog(ctx context.Context) ([]builtinapps.Ap
 }
 
 func (s *AppCenterService) refreshBuiltinCatalogAndWait(ctx context.Context) (builtinapps.CatalogSnapshot, error) {
+	host := builtinapps.CatalogHost{
+		TuttiVersion: s.HostTuttiVersion,
+		Capabilities: s.HostTuttiCapabilities,
+	}
 	if builtinapps.RemoteCatalogEnvOverrideActive() {
-		return builtinapps.RefreshRemoteCatalogAndWaitForTuttiVersion(ctx, s.HostTuttiVersion)
+		return builtinapps.RefreshRemoteCatalogAndWaitForHost(ctx, host)
 	}
 	catalogURL := s.appCatalogRemoteURL(ctx)
 	if s.RemoteCatalogRefresher != nil {
-		return s.RemoteCatalogRefresher(ctx, catalogURL)
+		return s.RemoteCatalogRefresher(ctx, catalogURL, host)
 	}
-	return builtinapps.RefreshRemoteCatalogAndWaitForRemoteURLAndTuttiVersion(ctx, catalogURL, s.HostTuttiVersion)
+	return builtinapps.RefreshRemoteCatalogAndWaitForRemoteURLAndHost(ctx, catalogURL, host)
 }
 
 func (s *AppCenterService) appCatalogRemoteURL(ctx context.Context) string {
@@ -304,9 +312,15 @@ func (s *AppCenterService) CatalogLoadState() workspacebiz.AppCatalogLoadState {
 		err      error
 	)
 	if builtinapps.RemoteCatalogEnvOverrideActive() {
-		snapshot, err = builtinapps.SnapshotForTuttiVersion(s.HostTuttiVersion)
+		snapshot, err = builtinapps.SnapshotForHost(builtinapps.CatalogHost{
+			TuttiVersion: s.HostTuttiVersion,
+			Capabilities: s.HostTuttiCapabilities,
+		})
 	} else {
-		snapshot, err = builtinapps.SnapshotForRemoteURLAndTuttiVersion(s.appCatalogRemoteURL(context.Background()), s.HostTuttiVersion)
+		snapshot, err = builtinapps.SnapshotForRemoteURLAndHost(s.appCatalogRemoteURL(context.Background()), builtinapps.CatalogHost{
+			TuttiVersion: s.HostTuttiVersion,
+			Capabilities: s.HostTuttiCapabilities,
+		})
 	}
 	if err != nil {
 		lastError := err.Error()

--- a/services/tuttid/service/workspace/apps_test.go
+++ b/services/tuttid/service/workspace/apps_test.go
@@ -1534,6 +1534,7 @@ func TestAppCenterServiceStartEnabledRefreshesPreferredCatalogChannel(t *testing
 	fetcher := newBlockingArtifactFetcher()
 	close(fetcher.release)
 	refreshedURLs := make([]string, 0, 1)
+	refreshedHosts := make([]builtinapps.CatalogHost, 0, 1)
 	service := AppCenterService{
 		Store:           store,
 		WorkspaceStore:  &catalogStoreStub{getWorkspace: workspacebiz.Summary{ID: "ws-1", Name: "Workspace"}},
@@ -1545,8 +1546,11 @@ func TestAppCenterServiceStartEnabledRefreshesPreferredCatalogChannel(t *testing
 				AppCatalogChannel: "staging",
 			},
 		},
-		RemoteCatalogRefresher: func(_ context.Context, catalogURL string) (builtinapps.CatalogSnapshot, error) {
+		HostTuttiVersion:      "0.12.0",
+		HostTuttiCapabilities: []string{"managed-model-cli-v1"},
+		RemoteCatalogRefresher: func(_ context.Context, catalogURL string, host builtinapps.CatalogHost) (builtinapps.CatalogSnapshot, error) {
 			refreshedURLs = append(refreshedURLs, catalogURL)
+			refreshedHosts = append(refreshedHosts, host)
 			return builtinapps.CatalogSnapshot{
 				Apps: []builtinapps.App{
 					{
@@ -1580,6 +1584,9 @@ func TestAppCenterServiceStartEnabledRefreshesPreferredCatalogChannel(t *testing
 	}
 	if len(refreshedURLs) != 1 || refreshedURLs[0] != builtinapps.StagingRemoteCatalogURL {
 		t.Fatalf("refreshed catalog URLs = %#v, want %#v", refreshedURLs, []string{builtinapps.StagingRemoteCatalogURL})
+	}
+	if len(refreshedHosts) != 1 || refreshedHosts[0].TuttiVersion != "0.12.0" || len(refreshedHosts[0].Capabilities) != 1 || refreshedHosts[0].Capabilities[0] != "managed-model-cli-v1" {
+		t.Fatalf("refreshed catalog hosts = %#v", refreshedHosts)
 	}
 	app := findWorkspaceAppForTest(apps, "large-builtin")
 	if app == nil || !app.UpdateAvailable || app.AvailableVersion == nil || *app.AvailableVersion != "1.1.0" {
@@ -1642,7 +1649,7 @@ func TestAppCenterServiceStartEnabledFallsBackToCachedCatalogWhenRefreshFails(t 
 		WorkspaceStore: &catalogStoreStub{getWorkspace: workspacebiz.Summary{ID: "ws-1", Name: "Workspace"}},
 		Runner:         runner,
 		StateDir:       t.TempDir(),
-		RemoteCatalogRefresher: func(context.Context, string) (builtinapps.CatalogSnapshot, error) {
+		RemoteCatalogRefresher: func(context.Context, string, builtinapps.CatalogHost) (builtinapps.CatalogSnapshot, error) {
 			refreshCalls += 1
 			return builtinapps.CatalogSnapshot{}, errors.New("catalog unavailable")
 		},

--- a/services/tuttid/types/app_capabilities.go
+++ b/services/tuttid/types/app_capabilities.go
@@ -1,0 +1,15 @@
+package types
+
+import "sort"
+
+// AppCapabilityManagedModelCLI is available only when the built-in Tutti CLI
+// can serve all managed-model grant commands through the local daemon.
+const AppCapabilityManagedModelCLI = "managed-model-cli-v1"
+
+// ResolveAppCapabilities returns the static capabilities of this Tutti build.
+// They are host-owned build contracts, never supplied by a workspace app.
+func ResolveAppCapabilities() []string {
+	capabilities := []string{AppCapabilityManagedModelCLI}
+	sort.Strings(capabilities)
+	return capabilities
+}

--- a/services/tuttid/types/app_capabilities_test.go
+++ b/services/tuttid/types/app_capabilities_test.go
@@ -1,0 +1,10 @@
+package types
+
+import "testing"
+
+func TestResolveAppCapabilitiesIncludesManagedModelCLI(t *testing.T) {
+	capabilities := ResolveAppCapabilities()
+	if len(capabilities) != 1 || capabilities[0] != AppCapabilityManagedModelCLI {
+		t.Fatalf("capabilities = %#v, want %q", capabilities, AppCapabilityManagedModelCLI)
+	}
+}

--- a/services/tuttid/wiring.go
+++ b/services/tuttid/wiring.go
@@ -341,6 +341,7 @@ func buildDaemonAPI(ctx context.Context, store workspacedata.CatalogStore, analy
 		Runner:                &workspaceservice.AppRunner{RuntimeResolver: managedRuntimeResolver},
 		StateDir:              tuttitypes.DefaultStateDir(),
 		HostTuttiVersion:      tuttitypes.ResolveAppVersion(),
+		HostTuttiCapabilities: tuttitypes.ResolveAppCapabilities(),
 		Publisher:             eventstreamservice.WorkspaceAppPublisher{Service: events},
 	}
 	go func() {

--- a/services/tuttid/wiring.go
+++ b/services/tuttid/wiring.go
@@ -28,6 +28,7 @@ import (
 	computercli "github.com/tutti-os/tutti/services/tuttid/service/cli/providers/computer"
 	diagnosticscli "github.com/tutti-os/tutti/services/tuttid/service/cli/providers/diagnostics"
 	issuemanagercli "github.com/tutti-os/tutti/services/tuttid/service/cli/providers/issuemanager"
+	managedmodelscli "github.com/tutti-os/tutti/services/tuttid/service/cli/providers/managedmodels"
 	referencescli "github.com/tutti-os/tutti/services/tuttid/service/cli/providers/references"
 	workbenchappscli "github.com/tutti-os/tutti/services/tuttid/service/cli/providers/workbenchapps"
 	computersvc "github.com/tutti-os/tutti/services/tuttid/service/computer"
@@ -385,6 +386,7 @@ func buildDaemonAPI(ctx context.Context, store workspacedata.CatalogStore, analy
 	}
 	cliProviders := []cliservice.Provider{
 		diagnosticscli.NewProvider(),
+		managedmodelscli.NewProvider(managedCredentials),
 		issuemanagercli.NewProvider(workspaceService, issueService, appCenterService),
 		referencescli.NewProvider(workspaceService, appCenterService, issueService),
 		workbenchappscli.NewProvider(

--- a/tools/scripts/build-tutti-app-release.test.mjs
+++ b/tools/scripts/build-tutti-app-release.test.mjs
@@ -334,6 +334,107 @@ test("buildTuttiAppVersions rejects changed compatibility for an immutable versi
   );
 });
 
+test("capability-gated releases derive immutable metadata from the app manifest", async () => {
+  const fallback = await releaseFileForTest("capability-app", "1.0.0");
+  const capable = await releaseFileForTest("capability-app", "2.0.0", {
+    hostCompatibility: {
+      requiredTuttiCapabilities: ["managed-model-cli-v1"]
+    }
+  });
+  const tempDir = await mkdtemp(path.join(tmpdir(), "tutti-capability-"));
+  const baseline = path.join(tempDir, "baseline.json");
+  const versions = path.join(tempDir, "versions.json");
+
+  await buildTuttiAppVersions({
+    releaseFiles: [fallback],
+    minTuttiVersion: "0.0.0",
+    outputPath: baseline
+  });
+  const result = await buildTuttiAppVersions({
+    existingVersionsPath: baseline,
+    releaseFiles: [capable],
+    outputPath: versions
+  });
+
+  assert.deepEqual(result.versions.versions[1].requiredTuttiCapabilities, [
+    "managed-model-cli-v1"
+  ]);
+  assert.equal(result.versions.versions[1].minTuttiVersion, undefined);
+
+  const catalog = await buildTuttiAppCatalog({
+    versionsFiles: [versions],
+    outputPath: path.join(tempDir, "catalog.json")
+  });
+  assert.equal(catalog.catalog.apps[0].manifest.version, "1.0.0");
+  assert.equal(
+    catalog.catalog.compatibility.apps["capability-app"][0].app.manifest
+      .version,
+    "1.0.0"
+  );
+  assert.deepEqual(
+    catalog.catalog.compatibility.capabilityApps["capability-app"].map(
+      (entry) => [entry.requiredTuttiCapabilities, entry.app.manifest.version]
+    ),
+    [[["managed-model-cli-v1"], "2.0.0"]]
+  );
+});
+
+test("capability-gated releases reject an additional version selector", async () => {
+  const release = await releaseFileForTest("capability-app", "2.0.0", {
+    hostCompatibility: {
+      requiredTuttiCapabilities: ["managed-model-cli-v1"]
+    }
+  });
+
+  await assert.rejects(
+    () =>
+      buildTuttiAppVersions({
+        releaseFiles: [release],
+        minTuttiVersion: "0.12.0",
+        outputPath: path.join(tmpdir(), "capability-selector.json")
+      }),
+    /cannot declare both minTuttiVersion and requiredTuttiCapabilities/
+  );
+});
+
+test("capability declarations are canonical and immutable per release version", async () => {
+  const invalidManifest = manifestForTest("capability-app");
+  invalidManifest.hostCompatibility = {
+    requiredTuttiCapabilities: ["managed-model-cli-v1", "managed-model-cli-v1"]
+  };
+  assert.throws(
+    () => validateManifest(invalidManifest),
+    /must be sorted and unique/
+  );
+
+  const original = await releaseFileForTest("capability-app", "2.0.0", {
+    hostCompatibility: {
+      requiredTuttiCapabilities: ["managed-model-cli-v1"]
+    }
+  });
+  const changed = await releaseFileForTest("capability-app", "2.0.0", {
+    hostCompatibility: {
+      requiredTuttiCapabilities: ["future-host-capability-v1"]
+    }
+  });
+  const tempDir = await mkdtemp(path.join(tmpdir(), "tutti-capability-"));
+  const existing = path.join(tempDir, "versions.json");
+  await buildTuttiAppVersions({
+    releaseFiles: [original],
+    outputPath: existing
+  });
+
+  await assert.rejects(
+    () =>
+      buildTuttiAppVersions({
+        existingVersionsPath: existing,
+        releaseFiles: [changed],
+        outputPath: path.join(tempDir, "changed.json")
+      }),
+    /different compatibility or release metadata/
+  );
+});
+
 test("buildTuttiAppCatalog emits legacy-safe apps and a compact compatibility frontier", async () => {
   const releases = await Promise.all([
     releaseFileForTest("frontier-app", "1.0.0"),
@@ -647,7 +748,8 @@ test("Tutti app release workflow is reusable by external app repositories", asyn
     workflow,
     /release_assets_base_url is required unless catalog_only is true/
   );
-  assert.match(
+  assert.match(workflow, /min_tutti_version must be valid SemVer/);
+  assert.doesNotMatch(
     workflow,
     /min_tutti_version is required unless catalog_only is true/
   );
@@ -718,6 +820,7 @@ test("Tutti app release workflow is reusable by external app repositories", asyn
   assert.match(workflow, /publish-tutti-app-metadata/);
   assert.match(workflow, /CATALOG_ONLY:/);
   assert.match(workflow, /--min-tutti-version "\$\{MIN_TUTTI_VERSION\}"/);
+  assert.doesNotMatch(workflow, /required_tutti_capabilities:/);
   assert.match(workflow, /--versions-file tutti-app-metadata\/versions\.json/);
   assert.doesNotMatch(workflow, /aws s3 cp tutti-app-catalog\/catalog\.json/);
   assert.match(workflow, /Invalidate app catalog/);
@@ -822,6 +925,7 @@ function assertCatalogWorkflowRefreshesExistingAppLatestMetadata(workflow) {
   );
   assert.match(workflow, /existing-catalog\.json/);
   assert.match(workflow, /manifest\??\.appId/);
+  assert.match(workflow, /compatibility\?\.capabilityApps/);
   assert.match(workflow, /app_ids_value="\$\{existing_app_ids\}"/);
 }
 
@@ -848,7 +952,12 @@ async function releaseFileForTest(appId, version = "0.1.0", overrides = {}) {
     version,
     name: appId,
     description: `${appId} description`,
-    manifest: manifestForTest(appId, version),
+    manifest: {
+      ...manifestForTest(appId, version),
+      ...(overrides.hostCompatibility
+        ? { hostCompatibility: overrides.hostCompatibility }
+        : {})
+    },
     ...(overrides.localizations
       ? { localizations: overrides.localizations }
       : {}),


### PR DESCRIPTION
## Summary

Adds four host-managed model commands to `tutti` CLI: grant exchange, models, credential and revoke. Each uses bounded stdin JSON via `--input-json -` and JSON stdout, with `TUTTI_APP_ID` propagated to the daemon invocation context. It reuses the existing managed-credentials service.

## Validation

- Targeted Go tests for CLI, daemon CLI provider and API passed.
- Full repository `check:full` passed: lint, typecheck, TS tests and Go workspace tests.

Draft only: no merge or deployment.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds four managed-model commands to the `tutti` CLI with strict JSON I/O and enforced workspace+app context, and gates app releases by host capabilities so hosts with `managed-model-cli-v1` get the highest compatible version while others fall back to version rules.

- **New Features**
  - CLI: `tutti managed-model grant exchange | models | credential | revoke`.
  - JSON I/O only via `--input-json -`: max 64 KiB, one object, unknown fields rejected.
  - Context: requires `TUTTI_WORKSPACE_ID` + `TUTTI_APP_ID`; CLI sends `appId`; daemon validates and serves through built-in `managedmodels` provider (reuses managed-credentials).
  - Catalog: new `compatibility.capabilityApps` selects by host capabilities; host advertises `managed-model-cli-v1` from the daemon build and otherwise uses version-based compatibility.
  - Tools/Workflows: releases can declare `manifest.hostCompatibility.requiredTuttiCapabilities`; cannot combine with `minTuttiVersion`. `min_tutti_version` is optional and only validated if provided; catalog build/verification handle `capabilityApps`.

- **Migration**
  - For these commands, set `TUTTI_APP_ID` and `TUTTI_WORKSPACE_ID`, and pipe exactly one JSON object to `--input-json -`.
  - App publishers: use `manifest.hostCompatibility.requiredTuttiCapabilities` to gate releases and do not combine with `minTuttiVersion`. Provide a version-based fallback in compatibility for legacy hosts.

<sup>Written for commit 3837ba12cb763ae4975af1b48b3ba4e6a2adb3dc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tutti-os/tutti/pull/1069?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

