### PR TITLE
feat(agent-gui): add interactive vinyl hero carousel

### DIFF
--- a/docs/architecture/agent-gui-node.md
+++ b/docs/architecture/agent-gui-node.md
@@ -1565,6 +1565,31 @@ The public directory entry owns its presentation and availability:
 - show no aggregate `All` entry when exactly one agent exists
 - show `All` plus the host-ordered rail and home carousel when multiple agents
   exist
+- keep the multi-agent home carousel mounted when the selected agent changes;
+  move the selected directory-owned node into the center without reordering the
+  host array, including when the selected target enters or leaves a readiness
+  gate; keep the carousel canvas outside the ready/gated body branch so its
+  scroll position and animation are not reset; rotate the centered record by
+  default, temporarily give playback to the record under the pointer, return
+  playback to the current center when hover leaves, preserve each record's
+  stopped angle when playback moves elsewhere, and fade records progressively
+  by distance from the center while keeping the next outer record partially
+  visible on each side; target
+  changes should prime the wheel spring with an immediate directional impulse
+  and avoid duplicate WebGL submissions from playback and wheel animation; use
+  a shallow lit cylinder beneath the icon texture when rendering the record so
+  thickness, rim reflection, and side perspective remain part of the same
+  mounted Three.js scene instead of pre-rendered replacement assets; keep
+  one-shot redraw and spring animation RAF handles separate so a pending resize
+  or texture render cannot suppress a new interaction, let the spring frame own
+  the single pose/render pass during movement, share record geometry, and cull
+  repeated records outside the visible center range; start pointer-driven
+  carousel movement on primary `pointerdown`, then suppress the matching click
+  activation so the spring begins on press without double-selecting the target;
+  selection updates the title, composer, and controls below the carousel;
+  respect reduced motion by suppressing record playback animation; keep the
+  empty-home content on a fixed top anchor so readiness and composer height
+  changes grow downward instead of vertically re-centering the whole hero
 - persist and pass only `agentTargetId` for target selection and launch
 - use `agentTargetId` as the opaque activity-core composer `targetKey`; never
   derive a cache key from provider

--- a/packages/agent/gui/agent-gui/agentGuiNode/AgentGUIHeroAgentCarousel.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/AgentGUIHeroAgentCarousel.tsx
@@ -117,7 +117,7 @@ function useAgentGUIHeroCarouselImages(
 }
 
 // Empty-hero agent switcher for the "All" tab: a ring of same-sized agent
-// tiles rendered with three.js (see agentGuiHeroCarouselScene) so tiles
+// records rendered with three.js (see agentGuiHeroCarouselScene) so records
 // farther around the ring genuinely shrink and fade with perspective.
 // Wheel, drag, and arrow keys spin the ring; the centered agent commits once
 // the spin settles; clicking a tile (canvas raycast or the visually-hidden
@@ -218,7 +218,9 @@ export const AgentGUIHeroAgentCarousel = memo(
       // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [carouselImages.images, carouselImages.ready, iconKey]);
 
-    // Follow external agent switches (left rail, hero title dropdown).
+    // Provider selection can also come from the rail or title control. Keep
+    // that selected agent in the carousel's center so the spinning record and
+    // the composer below always describe the same target.
     useEffect(() => {
       if (activeIconIndex >= 0 && activeIconIndex !== centerIndexRef.current) {
         centerIndexRef.current = activeIconIndex;
@@ -283,6 +285,7 @@ export const AgentGUIHeroAgentCarousel = memo(
       null
     );
     const suppressClickRef = useRef(false);
+    const pointerActivatedIndexRef = useRef<number | null>(null);
     const handlePointerDown = (
       event: ReactPointerEvent<HTMLDivElement>
     ): void => {
@@ -308,6 +311,7 @@ export const AgentGUIHeroAgentCarousel = memo(
       }
       drag.anchorX = event.clientX;
       suppressClickRef.current = true;
+      pointerActivatedIndexRef.current = null;
       // Dragging left pulls the next agent (to the right) into the center.
       stepBy(deltaX < 0 ? 1 : -1);
     };
@@ -323,6 +327,7 @@ export const AgentGUIHeroAgentCarousel = memo(
         return;
       }
       suppressClickRef.current = false;
+      pointerActivatedIndexRef.current = null;
       event.preventDefault();
       event.stopPropagation();
     };
@@ -361,23 +366,67 @@ export const AgentGUIHeroAgentCarousel = memo(
       );
     };
 
+    const activateOnPointerDown = (
+      index: number,
+      event: ReactPointerEvent
+    ): void => {
+      if (event.button !== 0) {
+        return;
+      }
+      pointerActivatedIndexRef.current = index;
+      handleItemClick(index);
+    };
+
+    const activateOnClick = (index: number): void => {
+      if (pointerActivatedIndexRef.current === index) {
+        pointerActivatedIndexRef.current = null;
+        return;
+      }
+      pointerActivatedIndexRef.current = null;
+      handleItemClick(index);
+    };
+
+    const handleCanvasPointerDown = (
+      event: ReactPointerEvent<HTMLCanvasElement>
+    ): void => {
+      const index = pickAt(event);
+      if (index !== null) {
+        activateOnPointerDown(index, event);
+      }
+    };
+
     const handleCanvasClick = (
       event: ReactMouseEvent<HTMLCanvasElement>
     ): void => {
       const index = pickAt(event);
       if (index !== null) {
-        handleItemClick(index);
+        activateOnClick(index);
       }
     };
 
     const handleCanvasHover = (
       event: ReactPointerEvent<HTMLCanvasElement>
     ): void => {
+      const scene = sceneRef.current;
       const canvas = canvasRef.current;
-      if (!canvas) {
+      if (!scene || !canvas) {
         return;
       }
-      canvas.style.cursor = pickAt(event) !== null ? "pointer" : "";
+      const rect = canvas.getBoundingClientRect();
+      const hoveredIndex = scene.hover(
+        event.clientX - rect.left,
+        event.clientY - rect.top,
+        rect.width,
+        rect.height
+      );
+      canvas.style.cursor = hoveredIndex !== null ? "pointer" : "";
+    };
+
+    const handleCanvasLeave = (): void => {
+      sceneRef.current?.clearHover();
+      if (canvasRef.current) {
+        canvasRef.current.style.cursor = "";
+      }
     };
 
     return (
@@ -400,7 +449,9 @@ export const AgentGUIHeroAgentCarousel = memo(
           aria-hidden="true"
           className={styles.emptyHeroCarouselCanvas}
           onClick={interactive ? handleCanvasClick : undefined}
+          onPointerDown={interactive ? handleCanvasPointerDown : undefined}
           onPointerMove={interactive ? handleCanvasHover : undefined}
+          onPointerLeave={interactive ? handleCanvasLeave : undefined}
         />
         {items.map((item, index) => {
           // Visually-hidden switchers keep the ring reachable by keyboard,
@@ -425,7 +476,8 @@ export const AgentGUIHeroAgentCarousel = memo(
                 aria-label={label}
                 aria-pressed={isCenter}
                 title={item.label}
-                onClick={() => handleItemClick(index)}
+                onPointerDown={(event) => activateOnPointerDown(index, event)}
+                onClick={() => activateOnClick(index)}
               >
                 {item.label}
               </button>

--- a/packages/agent/gui/agent-gui/agentGuiNode/AgentGUINode.spec.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/AgentGUINode.spec.tsx
@@ -18,10 +18,7 @@ import type {
 import type { ReferenceSourceAggregator } from "@tutti-os/workspace-file-reference/core";
 import type { WorkspaceLinkAction } from "../../actions/workspaceLinkActions";
 import type { AgentActivitySnapshot } from "@tutti-os/agent-activity-core";
-import {
-  MANAGED_AGENT_ICON_URLS,
-  MANAGED_AGENT_PROVIDER_RAIL_ICON_URLS
-} from "../../shared/managedAgentIcons";
+import { MANAGED_AGENT_ICON_URLS } from "../../shared/managedAgentIcons";
 import { AgentActivityHostProvider } from "../../agentActivityHost";
 import type { AgentActivityRuntime } from "../../agentActivityRuntime";
 import { AgentGUINode } from "./AgentGUINode";
@@ -2033,13 +2030,14 @@ describe("AgentGUINode", () => {
         name: "agentHost.agentGui.providerSwitchLabel"
       })
     ).toHaveTextContent("Claude Code");
-    const iconEffect = document.querySelector(
-      ".agent-gui-node__empty-hero-icon-effect .agent-gui-node__agent-avatar-image"
+    const heroCarousel = document.querySelector(
+      ".agent-gui-node__empty-hero-carousel"
     );
-    expect(iconEffect).toHaveAttribute(
-      "src",
-      MANAGED_AGENT_PROVIDER_RAIL_ICON_URLS["claude-code"]
+    const activeClaudeItem = heroCarousel?.querySelector(
+      '[data-provider="claude-code"][data-provider-active="true"]'
     );
+    expect(heroCarousel).not.toBeNull();
+    expect(activeClaudeItem).not.toBeNull();
   });
 
   it("resolves provider-specific hero icon artwork", () => {

--- a/packages/agent/gui/agent-gui/agentGuiNode/AgentGUINode.styles.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/AgentGUINode.styles.ts
@@ -121,6 +121,10 @@ const styles = {
   emptyHeroCarousel: "agent-gui-node__empty-hero-carousel",
   emptyHeroCarouselCanvas: "agent-gui-node__empty-hero-carousel-canvas",
   emptyHeroCarouselItem: "agent-gui-node__empty-hero-carousel-item",
+  emptyHeroCarouselLayer: "agent-gui-node__empty-hero-carousel-layer",
+  emptyHeroCarouselPlaceholder:
+    "agent-gui-node__empty-hero-carousel-placeholder",
+  emptyHeroCarouselStage: "agent-gui-node__empty-hero-carousel-stage",
   emptyHeroIconEffect: "agent-gui-node__empty-hero-icon-effect",
   emptyHeroIconRail: "agent-gui-node__empty-hero-icon-rail",
   emptyHeroIconRailItem: "agent-gui-node__empty-hero-icon-rail-item",

--- a/packages/agent/gui/agent-gui/agentGuiNode/AgentGUINodeView.layout.spec.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/AgentGUINodeView.layout.spec.tsx
@@ -1253,7 +1253,7 @@ describe("AgentGUINodeView layout persistence", () => {
     expect(activeItem).toHaveAccessibleName(/Codex, Owner avatar/u);
   });
 
-  it("remounts the empty hero icon when switching provider targets", () => {
+  it("keeps the empty hero agent nodes mounted and centers the selected target", () => {
     const codexTarget = createLocalAgentGUIAgentTarget("codex");
     const claudeTarget = createLocalAgentGUIAgentTarget("claude-code");
     const { container, rerender } = renderAgentGUINodeView({
@@ -1268,13 +1268,21 @@ describe("AgentGUINodeView layout persistence", () => {
       }
     });
 
-    const initialIcon = container.querySelector<HTMLImageElement>(
-      ".agent-gui-node__empty-hero-icon-effect .agent-gui-node__agent-avatar-image"
+    const initialCarousel = container.querySelector(
+      ".agent-gui-node__empty-hero-carousel"
     );
-    expect(initialIcon).not.toBeNull();
-    expect(initialIcon?.getAttribute("src")).toBe(
-      MANAGED_AGENT_PROVIDER_RAIL_ICON_URLS.codex
+    const initialItems = Array.from(
+      initialCarousel?.querySelectorAll(
+        ".agent-gui-node__empty-hero-carousel-item"
+      ) ?? []
     );
+    expect(initialCarousel).not.toBeNull();
+    expect(initialItems).toHaveLength(2);
+    expect(
+      initialItems
+        .find((item) => item.getAttribute("data-provider-active") === "true")
+        ?.getAttribute("data-provider")
+    ).toBe("codex");
 
     rerender(
       buildAgentGUINodeViewElement({
@@ -1289,14 +1297,91 @@ describe("AgentGUINodeView layout persistence", () => {
       })
     );
 
-    const nextIcon = container.querySelector<HTMLImageElement>(
-      ".agent-gui-node__empty-hero-icon-effect .agent-gui-node__agent-avatar-image"
+    const nextCarousel = container.querySelector(
+      ".agent-gui-node__empty-hero-carousel"
     );
-    expect(nextIcon).not.toBeNull();
-    expect(nextIcon).not.toBe(initialIcon);
-    expect(nextIcon?.getAttribute("src")).toBe(
-      MANAGED_AGENT_PROVIDER_RAIL_ICON_URLS["claude-code"]
+    const nextItems = Array.from(
+      nextCarousel?.querySelectorAll(
+        ".agent-gui-node__empty-hero-carousel-item"
+      ) ?? []
     );
+    expect(nextCarousel).toBe(initialCarousel);
+    expect(nextItems).toEqual(initialItems);
+    expect(
+      nextItems
+        .find((item) => item.getAttribute("data-provider-active") === "true")
+        ?.getAttribute("data-provider")
+    ).toBe("claude-code");
+  });
+
+  it("starts carousel target selection on pointer down without double-selecting on click", () => {
+    const actions = createActions();
+    const codexTarget = createLocalAgentGUIAgentTarget("codex");
+    const claudeTarget = createLocalAgentGUIAgentTarget("claude-code");
+    const { container } = renderAgentGUINodeView({
+      actions,
+      viewModel: createViewModel({
+        selectedAgentTarget: codexTarget,
+        agentTargets: [codexTarget, claudeTarget]
+      })
+    });
+    const claudeItem = container.querySelector<HTMLButtonElement>(
+      '.agent-gui-node__empty-hero-carousel-item[data-provider="claude-code"]'
+    );
+    expect(claudeItem).not.toBeNull();
+
+    fireEvent.pointerDown(claudeItem!, { button: 0, pointerId: 1 });
+
+    expect(actions.selectHomeComposerAgentTarget).toHaveBeenCalledTimes(1);
+    expect(actions.selectHomeComposerAgentTarget).toHaveBeenCalledWith({
+      provider: "claude-code",
+      agentTargetId: claudeTarget.targetId
+    });
+
+    fireEvent.click(claudeItem!);
+    expect(actions.selectHomeComposerAgentTarget).toHaveBeenCalledTimes(1);
+  });
+
+  it("preserves the hero carousel canvas when the selected target enters a readiness gate", () => {
+    const codexTarget = createLocalAgentGUIAgentTarget("codex");
+    const claudeTarget = createLocalAgentGUIAgentTarget("claude-code");
+    const agentTargets = [codexTarget, claudeTarget];
+    const { container, rerender } = renderAgentGUINodeView({
+      viewModel: createViewModel({
+        selectedAgentTarget: codexTarget,
+        agentTargets
+      })
+    });
+    const initialCarousel = container.querySelector(
+      ".agent-gui-node__empty-hero-carousel"
+    );
+    const initialCanvas = initialCarousel?.querySelector("canvas");
+    expect(initialCarousel).not.toBeNull();
+    expect(initialCanvas).not.toBeNull();
+
+    rerender(
+      buildAgentGUINodeViewElement({
+        viewModel: createViewModel({
+          providerReadinessGate: { status: "not_installed" },
+          selectedAgentTarget: claudeTarget,
+          agentTargets
+        })
+      })
+    );
+
+    const nextCarousel = container.querySelector(
+      ".agent-gui-node__empty-hero-carousel"
+    );
+    expect(nextCarousel).toBe(initialCarousel);
+    expect(nextCarousel?.querySelector("canvas")).toBe(initialCanvas);
+    expect(
+      nextCarousel?.querySelector(
+        '[data-provider="claude-code"][data-provider-active="true"]'
+      )
+    ).not.toBeNull();
+    expect(
+      screen.getByTestId("agent-gui-provider-readiness-gate")
+    ).toBeInTheDocument();
   });
 
   it("renders the selected agent badge in the single-agent empty hero", () => {
@@ -1816,7 +1901,7 @@ describe("AgentGUINodeView layout persistence", () => {
     ).toHaveAttribute("src", "app://old-cursor-target-icon.png");
   });
 
-  it("uses the host-provided Cursor icon in the empty hero icon", () => {
+  it("keeps the host-provided Cursor target in the empty hero carousel", () => {
     const agentTargets = [
       createLocalAgentGUIAgentTarget("codex"),
       {
@@ -1845,11 +1930,11 @@ describe("AgentGUINodeView layout persistence", () => {
       }
     });
 
-    expect(
-      document.querySelector(
-        ".agent-gui-node__empty-hero-icon-effect .agent-gui-node__agent-avatar-image"
-      )
-    ).toHaveAttribute("src", "app://old-cursor-target-icon.png");
+    const cursorItem = document.querySelector(
+      `.agent-gui-node__empty-hero-carousel-item[data-agent-target-id="${agentTargets[1]!.agentTargetId}"]`
+    );
+    expect(cursorItem).not.toBeNull();
+    expect(cursorItem).toHaveAttribute("data-provider", "cursor");
   });
 
   it("renders the composer from the selected provider target", () => {
@@ -5196,12 +5281,18 @@ describe("AgentGUINodeView provider readiness gate", () => {
   });
 
   it("renders the aggregate agents checking gate when the All tab is active", () => {
-    renderAgentGUINodeView({
+    const codexTarget = createLocalAgentGUIAgentTarget("codex");
+    const { container } = renderAgentGUINodeView({
       viewModel: createViewModel({
         conversationFilter: { kind: "all" },
         providerReadinessGate: {
           status: "checking"
-        }
+        },
+        selectedAgentTarget: codexTarget,
+        agentTargets: [
+          codexTarget,
+          createLocalAgentGUIAgentTarget("claude-code")
+        ]
       })
     });
 
@@ -5210,8 +5301,14 @@ describe("AgentGUINodeView provider readiness gate", () => {
     expect(gate).toHaveTextContent("providerGateCheckingTitle");
     expect(gate).toHaveTextContent("providerGateCheckingAgentsDescription");
     expect(
-      gate.querySelector(".agent-gui-node__empty-hero-carousel")
+      container.querySelector(".agent-gui-node__empty-hero-carousel-stage")
     ).not.toBeNull();
+    expect(
+      container.querySelector(".agent-gui-node__empty-hero-carousel")
+    ).not.toBeNull();
+    expect(
+      gate.querySelector(".agent-gui-node__empty-hero-carousel")
+    ).toBeNull();
     expect(
       gate.querySelector("img.agent-gui-node__empty-hero-icon-effect")
     ).toBeNull();

--- a/packages/agent/gui/agent-gui/agentGuiNode/AgentGUINodeView.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/AgentGUINodeView.tsx
@@ -3244,7 +3244,7 @@ const AgentGUIDetailPane = memo(function AgentGUIDetailPane({
     : emptyHeroBaseLabel;
   const emptyHeroAvatarPresentations = useMemo(
     () =>
-      viewModel.conversationFilter.kind === "all"
+      viewModel.agentTargets.length > 0
         ? viewModel.agentTargets.map(projectAgentGUIAgentTargetAvatar)
         : viewModel.selectedAgentTarget
           ? [projectAgentGUIAgentTargetAvatar(viewModel.selectedAgentTarget)]
@@ -3258,7 +3258,6 @@ const AgentGUIDetailPane = memo(function AgentGUIDetailPane({
     [
       emptyHeroProvider,
       emptyHeroProviderLabel,
-      viewModel.conversationFilter.kind,
       viewModel.agentTargets,
       viewModel.selectedAgentTarget
     ]
@@ -3761,67 +3760,89 @@ const AgentGUIDetailPane = memo(function AgentGUIDetailPane({
                 unavailableReason: disabledAgentTarget.unavailableReason ?? null
               })}
             </>
-          ) : emptyProviderReadinessGate ? (
+          ) : emptyProviderReadinessGate &&
             shouldRenderProviderReadinessGateState ? (
-              <>
-                {renderProviderReadinessGateState?.({
-                  provider: emptyHeroProvider,
-                  providerLabel:
-                    emptyHeroProviderLabel ||
-                    resolveAgentGuiWorkbenchProviderLabel(emptyHeroProvider),
-                  target: viewModel.selectedAgentTarget ?? null,
-                  iconUrl: resolveAgentGUIHeroIconUrl(emptyHeroProvider),
-                  gate: emptyProviderReadinessGate,
-                  showAllProviders: viewModel.conversationFilter.kind === "all"
-                })}
-              </>
-            ) : (
-              <AgentGUIProviderReadinessGatePane
-                provider={emptyHeroProvider}
-                gate={emptyProviderReadinessGate}
-                showAllProviders={viewModel.conversationFilter.kind === "all"}
-                emptyLabel={emptyHeroLabel}
-                emptyProvider={emptyHeroProviderLabel}
-                agentTargets={composerAgentTargets}
-                selectedAgentTarget={viewModel.selectedAgentTarget}
-                onProviderSelect={
-                  canSwitchComposerProvider &&
-                  viewModel.activeConversationId === null
-                    ? selectHomeComposerAgentTargetAndFocus
-                    : undefined
-                }
-                providerSelectLabel={labels.providerSwitchLabel}
-                labels={labels}
-              />
-            )
+            <>
+              {renderProviderReadinessGateState?.({
+                provider: emptyHeroProvider,
+                providerLabel:
+                  emptyHeroProviderLabel ||
+                  resolveAgentGuiWorkbenchProviderLabel(emptyHeroProvider),
+                target: viewModel.selectedAgentTarget ?? null,
+                iconUrl: resolveAgentGUIHeroIconUrl(emptyHeroProvider),
+                gate: emptyProviderReadinessGate,
+                showAllProviders: viewModel.conversationFilter.kind === "all"
+              })}
+            </>
           ) : (
-            <AgentGUIEmptyHeroPane
-              provider={emptyHeroProvider}
-              emptyLabel={emptyHeroLabel}
-              emptyProvider={emptyHeroProviderLabel}
-              avatarPresentations={emptyHeroAvatarPresentations}
-              inlineNoticeChrome={inlineNoticeChrome}
-              isRespondingApproval={viewModel.isRespondingApproval}
-              onSubmitApprovalOption={submitApprovalOption}
-              onRetryActivation={retryActivation}
-              onAuthLogin={authLogin}
-              onContinueInNewConversation={continueInNewConversation}
+            <AgentGUIEmptyHeroCarouselStage
+              activeAgentTargetId={
+                viewModel.selectedAgentTarget?.agentTargetId ??
+                viewModel.selectedAgentTarget?.targetId
+              }
+              items={emptyHeroAvatarPresentations}
               onProviderSelect={
                 canSwitchComposerProvider &&
                 viewModel.activeConversationId === null
                   ? selectHomeComposerAgentTargetAndFocus
                   : undefined
               }
-              agentTargets={composerAgentTargets}
-              selectedAgentTarget={viewModel.selectedAgentTarget}
-              chromeLabels={chromeLabels}
-              composerProps={emptyHeroComposerProps}
               providerSelectLabel={labels.providerSwitchLabel}
-              suggestions={labels.homeSuggestions ?? EMPTY_HOME_SUGGESTIONS}
-              suggestionsCloseLabel={labels.homeSuggestionsClose}
-              onSelectSuggestion={handleSelectHomeSuggestion}
-              onSelectSuggestionAction={handleHomeSuggestionAction}
-            />
+            >
+              {emptyProviderReadinessGate ? (
+                <AgentGUIProviderReadinessGatePane
+                  provider={emptyHeroProvider}
+                  gate={emptyProviderReadinessGate}
+                  showAllProviders={viewModel.conversationFilter.kind === "all"}
+                  carouselMountedExternally={
+                    emptyHeroAvatarPresentations.length > 1
+                  }
+                  emptyLabel={emptyHeroLabel}
+                  emptyProvider={emptyHeroProviderLabel}
+                  agentTargets={composerAgentTargets}
+                  selectedAgentTarget={viewModel.selectedAgentTarget}
+                  onProviderSelect={
+                    canSwitchComposerProvider &&
+                    viewModel.activeConversationId === null
+                      ? selectHomeComposerAgentTargetAndFocus
+                      : undefined
+                  }
+                  providerSelectLabel={labels.providerSwitchLabel}
+                  labels={labels}
+                />
+              ) : (
+                <AgentGUIEmptyHeroPane
+                  provider={emptyHeroProvider}
+                  emptyLabel={emptyHeroLabel}
+                  emptyProvider={emptyHeroProviderLabel}
+                  avatarPresentations={emptyHeroAvatarPresentations}
+                  carouselMountedExternally={
+                    emptyHeroAvatarPresentations.length > 1
+                  }
+                  inlineNoticeChrome={inlineNoticeChrome}
+                  isRespondingApproval={viewModel.isRespondingApproval}
+                  onSubmitApprovalOption={submitApprovalOption}
+                  onRetryActivation={retryActivation}
+                  onAuthLogin={authLogin}
+                  onContinueInNewConversation={continueInNewConversation}
+                  onProviderSelect={
+                    canSwitchComposerProvider &&
+                    viewModel.activeConversationId === null
+                      ? selectHomeComposerAgentTargetAndFocus
+                      : undefined
+                  }
+                  agentTargets={composerAgentTargets}
+                  selectedAgentTarget={viewModel.selectedAgentTarget}
+                  chromeLabels={chromeLabels}
+                  composerProps={emptyHeroComposerProps}
+                  providerSelectLabel={labels.providerSwitchLabel}
+                  suggestions={labels.homeSuggestions ?? EMPTY_HOME_SUGGESTIONS}
+                  suggestionsCloseLabel={labels.homeSuggestionsClose}
+                  onSelectSuggestion={handleSelectHomeSuggestion}
+                  onSelectSuggestionAction={handleHomeSuggestionAction}
+                />
+              )}
+            </AgentGUIEmptyHeroCarouselStage>
           )
         ) : (
           <AgentGUIConversationTimelinePane
@@ -4025,11 +4046,50 @@ function useOptionalStableEventCallback<Args extends unknown[], Result>(
 const EMPTY_HOME_SUGGESTIONS: readonly AgentHomeSuggestionCategory[] =
   Object.freeze([]);
 
+interface AgentGUIEmptyHeroCarouselStageProps {
+  activeAgentTargetId?: string | null;
+  children: ReactNode;
+  items: readonly AgentGUIAgentAvatarPresentation[];
+  onProviderSelect?: AgentGUINodeViewProps["actions"]["selectHomeComposerAgentTarget"];
+  providerSelectLabel: string;
+}
+
+// The carousel sits above the ready/gated body branch so target readiness
+// changes never replace its canvas or reset the wheel's scroll position.
+const AgentGUIEmptyHeroCarouselStage = memo(
+  function AgentGUIEmptyHeroCarouselStage({
+    activeAgentTargetId,
+    children,
+    items,
+    onProviderSelect,
+    providerSelectLabel
+  }: AgentGUIEmptyHeroCarouselStageProps): React.JSX.Element {
+    "use memo";
+
+    return (
+      <div className={styles.emptyHeroCarouselStage}>
+        {items.length > 1 ? (
+          <div className={styles.emptyHeroCarouselLayer}>
+            <AgentGUIHeroAgentCarousel
+              activeAgentTargetId={activeAgentTargetId}
+              items={items}
+              onProviderSelect={onProviderSelect}
+              providerSelectLabel={providerSelectLabel}
+            />
+          </div>
+        ) : null}
+        {children}
+      </div>
+    );
+  }
+);
+
 interface AgentGUIEmptyHeroPaneProps {
   provider: AgentGUINodeViewModel["data"]["provider"];
   emptyLabel: string;
   emptyProvider: string;
   avatarPresentations: readonly AgentGUIAgentAvatarPresentation[];
+  carouselMountedExternally?: boolean;
   inlineNoticeChrome: AgentGUISessionChrome | null;
   isRespondingApproval: boolean;
   onSubmitApprovalOption: AgentGUINodeViewProps["actions"]["submitApprovalOption"];
@@ -4053,6 +4113,7 @@ const AgentGUIEmptyHeroPane = memo(function AgentGUIEmptyHeroPane({
   emptyLabel,
   emptyProvider,
   avatarPresentations,
+  carouselMountedExternally = false,
   inlineNoticeChrome,
   isRespondingApproval,
   onSubmitApprovalOption,
@@ -4091,10 +4152,13 @@ const AgentGUIEmptyHeroPane = memo(function AgentGUIEmptyHeroPane({
   return (
     <div className={styles.emptyHero}>
       <div className={styles.emptyHeroBody}>
-        <div className={styles.emptyHeroIconSlot}>
-          {heroAvatarPresentations.length > 1 ? (
+        <div
+          className={styles.emptyHeroIconSlot}
+          data-carousel-placeholder={carouselMountedExternally || undefined}
+        >
+          {carouselMountedExternally ? null : heroAvatarPresentations.length >
+            1 ? (
             <AgentGUIHeroAgentCarousel
-              key={heroIconAnimationKey}
               activeAgentTargetId={
                 selectedAgentTarget?.agentTargetId ??
                 selectedAgentTarget?.targetId
@@ -4156,6 +4220,7 @@ interface AgentGUIProviderReadinessGatePaneProps {
   selectedAgentTarget: AgentGUIAgentTarget | null;
   onProviderSelect?: AgentGUINodeViewProps["actions"]["selectHomeComposerAgentTarget"];
   providerSelectLabel: string;
+  carouselMountedExternally?: boolean;
   labels: Pick<
     AgentGUIViewLabels,
     | "providerGateCheckingTitle"
@@ -4190,6 +4255,7 @@ const AgentGUIProviderReadinessGatePane = memo(
     selectedAgentTarget,
     onProviderSelect,
     providerSelectLabel,
+    carouselMountedExternally = false,
     labels
   }: AgentGUIProviderReadinessGatePaneProps): React.JSX.Element {
     "use memo";
@@ -4229,7 +4295,12 @@ const AgentGUIProviderReadinessGatePane = memo(
           data-testid="agent-gui-provider-readiness-gate"
           role="status"
         >
-          {showAllProviders ? (
+          {carouselMountedExternally ? (
+            <div
+              aria-hidden="true"
+              className={styles.emptyHeroCarouselPlaceholder}
+            />
+          ) : showAllProviders ? (
             <AgentGUIHeroAgentCarousel
               activeAgentTargetId={
                 selectedAgentTarget?.agentTargetId ??

--- a/packages/agent/gui/agent-gui/agentGuiNode/agentGuiHeroCarouselScene.spec.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/agentGuiHeroCarouselScene.spec.ts
@@ -14,8 +14,10 @@ interface FakeMaterial extends FakeDisposable {
 
 interface FakeMesh {
   children: FakeMesh[];
-  geometry: FakeDisposable & { kind: "badge" | "icon" };
+  geometry: FakeDisposable & { kind: "badge" | "edge" | "icon" };
   material: FakeMaterial;
+  position: { set: ReturnType<typeof vi.fn>; z: number };
+  rotation: { set: ReturnType<typeof vi.fn>; x: number; z: number };
   userData: { agentIndex?: number };
 }
 
@@ -30,9 +32,9 @@ const threeState = vi.hoisted(() => ({
 vi.mock("three", () => {
   class FakeGeometry implements FakeDisposable {
     disposed = false;
-    readonly kind: "badge" | "icon";
+    readonly kind: "badge" | "edge" | "icon";
 
-    constructor(kind: "badge" | "icon") {
+    constructor(kind: "badge" | "edge" | "icon") {
       this.kind = kind;
     }
 
@@ -53,6 +55,12 @@ vi.mock("three", () => {
     }
   }
 
+  class CylinderGeometry extends FakeGeometry {
+    constructor() {
+      super("edge");
+    }
+  }
+
   class MeshBasicMaterial implements FakeMaterial {
     disposed = false;
     map?: FakeDisposable;
@@ -70,21 +78,30 @@ vi.mock("three", () => {
     }
   }
 
-  class Mesh implements FakeMesh {
-    readonly children: FakeMesh[] = [];
-    readonly position = { set: vi.fn() };
-    readonly rotation = { z: 0 };
-    readonly userData: { agentIndex?: number } = {};
+  class MeshStandardMaterial extends MeshBasicMaterial {}
 
+  class Group {
+    readonly children: FakeMesh[] = [];
+    readonly position = { set: vi.fn(), z: 0 };
+    readonly rotation = { set: vi.fn(), x: 0, z: 0 };
+    readonly scale = { setScalar: vi.fn() };
+    readonly userData: { agentIndex?: number } = {};
+    visible = true;
+
+    add(...children: FakeMesh[]): void {
+      this.children.push(...children);
+    }
+  }
+
+  class Mesh extends Group implements FakeMesh {
     constructor(
-      readonly geometry: FakeDisposable & { kind: "badge" | "icon" },
+      readonly geometry: FakeDisposable & {
+        kind: "badge" | "edge" | "icon";
+      },
       readonly material: FakeMaterial
     ) {
+      super();
       threeState.meshes.push(this);
-    }
-
-    add(child: FakeMesh): void {
-      this.children.push(child);
     }
   }
 
@@ -135,15 +152,28 @@ vi.mock("three", () => {
 
   class Vector2 {}
 
+  class AmbientLight {}
+
+  class DirectionalLight {
+    readonly position = { set: vi.fn() };
+  }
+
   return {
+    AmbientLight,
     CanvasTexture,
     CircleGeometry,
+    CylinderGeometry,
+    DirectionalLight,
+    Group,
     MathUtils: {
       clamp: (value: number, min: number, max: number) =>
-        Math.min(Math.max(value, min), max)
+        Math.min(Math.max(value, min), max),
+      smoothstep: (value: number, min: number, max: number) =>
+        Math.min(Math.max((value - min) / (max - min), 0), 1)
     },
     Mesh,
     MeshBasicMaterial,
+    MeshStandardMaterial,
     PerspectiveCamera,
     PlaneGeometry,
     Raycaster,
@@ -198,10 +228,21 @@ describe("AgentGuiHeroCarouselScene", () => {
     getContextSpy = vi
       .spyOn(HTMLCanvasElement.prototype, "getContext")
       .mockReturnValue({
+        arc: vi.fn(),
         beginPath: vi.fn(),
+        clearRect: vi.fn(),
         clip: vi.fn(),
+        createLinearGradient: vi.fn(() => ({ addColorStop: vi.fn() })),
+        createRadialGradient: vi.fn(() => ({ addColorStop: vi.fn() })),
         drawImage: vi.fn(),
-        roundRect: vi.fn()
+        fill: vi.fn(),
+        fillRect: vi.fn(),
+        restore: vi.fn(),
+        rotate: vi.fn(),
+        roundRect: vi.fn(),
+        save: vi.fn(),
+        stroke: vi.fn(),
+        translate: vi.fn()
       } as unknown as CanvasRenderingContext2D);
   });
 
@@ -257,10 +298,16 @@ describe("AgentGuiHeroCarouselScene", () => {
     const iconMeshes = threeState.meshes.filter(
       (mesh) => mesh.geometry.kind === "icon"
     );
-    expect(iconMeshes[0]?.material.opacity).toBe(1);
-    expect(iconMeshes[0]?.children[0]?.material.opacity).toBe(1);
-    expect(iconMeshes[1]?.material.opacity).toBe(0.55);
-    expect(iconMeshes[1]?.children[0]?.material.opacity).toBe(0.55);
+    const centeredIcon = iconMeshes.find(
+      (mesh) => mesh.userData.agentIndex === 0 && mesh.material.opacity === 1
+    );
+    const centeredBadge = badgeMeshes.find(
+      (mesh) => mesh.userData.agentIndex === 0 && mesh.material.visible
+    );
+    expect(centeredIcon).toBeDefined();
+    expect(centeredBadge?.material.opacity).toBe(
+      centeredIcon?.material.opacity
+    );
 
     expect(scene?.pick(50, 50, 100, 100)).toBe(0);
     expect(

--- a/packages/agent/gui/agent-gui/agentGuiNode/agentGuiHeroCarouselScene.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/agentGuiHeroCarouselScene.ts
@@ -2,7 +2,7 @@ import * as THREE from "three";
 import type { AgentGUIAgentAvatarPresentation } from "./model/agentGuiAgentAvatarPresentation";
 
 // Three.js scene behind the empty-hero agent carousel, modelled after
-// animos.app's "Wheel Carousel": same-sized flat tiles ride the rim of a
+// animos.app's "Wheel Carousel": same-sized vinyl records ride the rim of a
 // giant wheel whose hub sits far below the stage. The focused agent stands
 // upright at the top of the wheel; neighbours tilt tangentially and sink down
 // the sides, and the wheel ticks forward with a springy overshoot. The wheel
@@ -12,30 +12,51 @@ const CAMERA_FOV_DEG = 14;
 const CAMERA_Z = 7.5;
 // The wheel aims for about this many slots around its full rim; the icon
 // sequence repeats as often as needed to get close, which also fixes the
-// slot angle (2*PI / slots) and keeps neighbour tilts gentle (~17deg).
-const WHEEL_TARGET_SLOTS = 21;
+// slot angle (2*PI / slots). A broad virtual wheel keeps the visible records
+// on a shallow arc instead of exposing an obvious circular silhouette.
+const WHEEL_TARGET_SLOTS = 40;
 // Center-to-center distance between neighbouring tiles along the rim; tiles
 // are 1 unit wide, so the remainder is the visible gap. The wheel radius is
 // derived from this, so wider spacing also grows the wheel itself.
-const TILE_SPACING = 1.35;
+const TILE_SPACING = 1.55;
+// Compress the visible portion of the wheel into a shallow arc. Horizontal
+// spacing still follows the circular loop, while vertical drop and tangent
+// tilt are reduced so the records read as a row rather than a ring.
+const VISIBLE_ARC_CURVATURE = 0.9;
 // Side fade-out is a CSS gradient mask on the canvas element (see
 // agentactivity.css): tiles dissolve spatially as they approach the stage
 // edges instead of fading per-tile by angle.
-// On top of that, only the focused tile is fully opaque — every other tile
-// rests at this opacity (the transition interpolates while the wheel spins).
-const UNFOCUSED_OPACITY = 0.55;
-// Underdamped spring for the wheel's "tick": stiffness sets the pace, and a
-// damping ratio below 1 gives the anticipation-and-overshoot landing.
-const SPRING_STIFFNESS = 90;
-const SPRING_DAMPING_RATIO = 0.62;
+// Opacity fades continuously with distance from the focused slot. The CSS mask
+// still softens the physical canvas edges, while this range fade makes every
+// record step down progressively as it moves away from the center.
+const MIN_RECORD_OPACITY = 0.22;
+const RECORD_FADE_RANGE_SLOTS = 4.5;
+const RECORD_FADE_CURVE = 1.45;
+// A lightly underdamped spring keeps the wheel tactile without the delayed,
+// low-velocity ramp that made clicks feel unresponsive.
+const SPRING_STIFFNESS = 120;
+const SPRING_DAMPING_RATIO = 0.78;
+const SPRING_MIN_LAUNCH_VELOCITY = 2.6;
 const SPRING_SETTLE_EPSILON = 0.001;
 const SPRING_SETTLE_VELOCITY = 0.02;
+const MAX_FRAME_DELTA_SECONDS = 0.032;
 const TEXTURE_SIZE = 256;
-const TEXTURE_CORNER_RADIUS = 0.05;
 const BADGE_CORNER_RADIUS = 0.5;
 const BADGE_DIAMETER = 0.36;
 const BADGE_OFFSET = 0.4;
 const MAX_PIXEL_RATIO = 2;
+const RECORD_RADIUS_RATIO = 0.47;
+const RECORD_LABEL_RADIUS_RATIO = 0.41;
+const RECORD_SPINDLE_RADIUS_RATIO = 0.035;
+const RECORD_SPIN_SECONDS = 7;
+const RECORD_MODEL_SCALE = 1.3;
+const RECORD_MODEL_RADIUS = 0.475;
+const RECORD_MODEL_THICKNESS = 0.065;
+const RECORD_MODEL_TILT_X = -0.11;
+const RECORD_MODEL_SIDE_TILT_FACTOR = 0.18;
+const RECORD_MODEL_MAX_SIDE_TILT = 0.16;
+const RECORD_RENDER_RANGE_SLOTS = 3.4;
+const RECORD_EDGE_SEGMENTS = 48;
 
 // Signed ring offset of tile `index` for a continuous scroll position, in
 // (-count / 2, count / 2].
@@ -53,12 +74,145 @@ function ringOffset(index: number, scroll: number, count: number): number {
   return offset;
 }
 
-// Draws the icon into a rounded-rect canvas so square, full-bleed PNGs get
-// rounded tiles without custom shaders.
+// Composites each host-provided agent icon into the paper label of a shared
+// vinyl-record treatment. The monochrome groove/rim palette is intentionally
+// material-specific; the label keeps the host artwork and brand color intact.
+function vinylRecordTexture(
+  image: HTMLImageElement,
+  onReadyRender: () => void
+): THREE.CanvasTexture {
+  const canvas = document.createElement("canvas");
+  canvas.width = TEXTURE_SIZE;
+  canvas.height = TEXTURE_SIZE;
+  const context = canvas.getContext("2d");
+  if (context) {
+    const center = TEXTURE_SIZE / 2;
+    const recordRadius = TEXTURE_SIZE * RECORD_RADIUS_RATIO;
+    const labelRadius = recordRadius * RECORD_LABEL_RADIUS_RATIO;
+
+    context.clearRect(0, 0, TEXTURE_SIZE, TEXTURE_SIZE);
+    context.save();
+    context.beginPath();
+    context.arc(center, center, recordRadius, 0, Math.PI * 2);
+    context.clip();
+
+    const recordFill = context.createRadialGradient(
+      center * 0.92,
+      center * 0.88,
+      labelRadius,
+      center,
+      center,
+      recordRadius
+    );
+    recordFill.addColorStop(0, "rgb(26 26 27)");
+    recordFill.addColorStop(0.54, "rgb(5 5 6)");
+    recordFill.addColorStop(0.82, "rgb(18 18 19)");
+    recordFill.addColorStop(1, "rgb(3 3 4)");
+    context.fillStyle = recordFill;
+    context.fillRect(0, 0, TEXTURE_SIZE, TEXTURE_SIZE);
+
+    // Closely spaced low-contrast rings read as pressed vinyl grooves without
+    // competing with the center artwork at the small carousel size.
+    for (
+      let radius = labelRadius + 4;
+      radius < recordRadius - 3;
+      radius += 3.5
+    ) {
+      const grooveIndex = Math.round((radius - labelRadius) / 3.5);
+      context.beginPath();
+      context.arc(center, center, radius, 0, Math.PI * 2);
+      context.strokeStyle =
+        grooveIndex % 3 === 0
+          ? "rgb(255 255 255 / 0.12)"
+          : "rgb(255 255 255 / 0.055)";
+      context.lineWidth = grooveIndex % 3 === 0 ? 0.7 : 0.45;
+      context.stroke();
+    }
+
+    // A narrow diagonal sheen makes the grooves visible on both light and
+    // dark application themes while leaving most of the record near-black.
+    context.save();
+    context.translate(center, center);
+    context.rotate(-Math.PI / 4);
+    const sheen = context.createLinearGradient(
+      -recordRadius,
+      0,
+      recordRadius,
+      0
+    );
+    sheen.addColorStop(0, "rgb(255 255 255 / 0)");
+    sheen.addColorStop(0.42, "rgb(255 255 255 / 0.02)");
+    sheen.addColorStop(0.5, "rgb(255 255 255 / 0.18)");
+    sheen.addColorStop(0.58, "rgb(255 255 255 / 0.02)");
+    sheen.addColorStop(1, "rgb(255 255 255 / 0)");
+    context.fillStyle = sheen;
+    context.fillRect(
+      -recordRadius,
+      -recordRadius,
+      recordRadius * 2,
+      recordRadius * 2
+    );
+    context.restore();
+    context.restore();
+
+    // Crop the existing provider artwork into a circular paper label. Cover
+    // fit preserves the bold center mark of square/full-bleed app icons.
+    context.save();
+    context.beginPath();
+    context.arc(center, center, labelRadius, 0, Math.PI * 2);
+    context.clip();
+    const scale = Math.max(
+      (labelRadius * 2) / image.width,
+      (labelRadius * 2) / image.height
+    );
+    const width = image.width * scale;
+    const height = image.height * scale;
+    context.drawImage(
+      image,
+      center - width / 2,
+      center - height / 2,
+      width,
+      height
+    );
+    context.restore();
+
+    context.beginPath();
+    context.arc(center, center, labelRadius, 0, Math.PI * 2);
+    context.strokeStyle = "rgb(255 255 255 / 0.2)";
+    context.lineWidth = 1;
+    context.stroke();
+
+    context.beginPath();
+    context.arc(
+      center,
+      center,
+      recordRadius * RECORD_SPINDLE_RADIUS_RATIO,
+      0,
+      Math.PI * 2
+    );
+    context.fillStyle = "rgb(5 5 6)";
+    context.fill();
+    context.strokeStyle = "rgb(255 255 255 / 0.18)";
+    context.lineWidth = 0.75;
+    context.stroke();
+
+    context.beginPath();
+    context.arc(center, center, recordRadius - 0.75, 0, Math.PI * 2);
+    context.strokeStyle = "rgb(255 255 255 / 0.32)";
+    context.lineWidth = 1.25;
+    context.stroke();
+  }
+  const texture = new THREE.CanvasTexture(canvas);
+  texture.colorSpace = THREE.SRGBColorSpace;
+  texture.anisotropy = 4;
+  onReadyRender();
+  return texture;
+}
+
 function roundedIconTexture(
   image: HTMLImageElement,
   onReadyRender: () => void,
-  cornerRadius = TEXTURE_CORNER_RADIUS
+  cornerRadius: number
 ): THREE.CanvasTexture {
   const canvas = document.createElement("canvas");
   canvas.width = TEXTURE_SIZE;
@@ -69,7 +223,6 @@ function roundedIconTexture(
     context.beginPath();
     context.roundRect(0, 0, TEXTURE_SIZE, TEXTURE_SIZE, radius);
     context.clip();
-    // Cover-fit so non-square icons fill the tile.
     const scale = Math.max(
       TEXTURE_SIZE / image.width,
       TEXTURE_SIZE / image.height
@@ -92,8 +245,15 @@ function roundedIconTexture(
 }
 
 interface AgentGuiHeroCarouselTile {
-  mesh: THREE.Mesh<THREE.PlaneGeometry, THREE.MeshBasicMaterial>;
   badgeMesh: THREE.Mesh<THREE.CircleGeometry, THREE.MeshBasicMaterial>;
+  edgeMaterial: THREE.MeshStandardMaterial;
+  edgeMesh: THREE.Mesh<THREE.CylinderGeometry, THREE.MeshStandardMaterial>;
+  faceMaterial: THREE.MeshBasicMaterial;
+  faceMesh: THREE.Mesh<THREE.PlaneGeometry, THREE.MeshBasicMaterial>;
+  poseGroup: THREE.Group;
+  ready: boolean;
+  recordGroup: THREE.Group;
+  rotation: number;
 }
 
 export interface AgentGuiHeroCarouselSceneOptions {
@@ -120,8 +280,11 @@ export class AgentGuiHeroCarouselScene {
   private readonly renderer: THREE.WebGLRenderer;
   private readonly scene: THREE.Scene;
   private readonly camera: THREE.PerspectiveCamera;
+  private readonly edgeGeometry: THREE.CylinderGeometry;
+  private readonly faceGeometry: THREE.PlaneGeometry;
   private readonly raycaster = new THREE.Raycaster();
   private readonly tiles: AgentGuiHeroCarouselTile[] = [];
+  private readonly textures = new Set<THREE.Texture>();
   // Number of distinct agents; the wheel holds agentCount * repeats tiles
   // (the icon sequence repeated), and scroll/target count TILE slots.
   private readonly agentCount: number;
@@ -133,8 +296,12 @@ export class AgentGuiHeroCarouselScene {
   private scroll = 0;
   private target = 0;
   private velocity = 0;
-  private frameHandle: number | null = null;
+  private renderFrameHandle: number | null = null;
+  private springFrameHandle: number | null = null;
+  private recordSpinFrameHandle: number | null = null;
   private lastFrameAt: number | null = null;
+  private lastRecordSpinFrameAt: number | null = null;
+  private hoveredTile: AgentGuiHeroCarouselTile | null = null;
   private disposed = false;
 
   private constructor(options: AgentGuiHeroCarouselSceneOptions) {
@@ -157,17 +324,56 @@ export class AgentGuiHeroCarouselScene {
     this.camera = new THREE.PerspectiveCamera(CAMERA_FOV_DEG, 1, 0.1, 50);
     this.camera.position.set(0, 0, CAMERA_Z);
 
+    // The label artwork remains color-stable on an unlit face plane. These
+    // lights shape the thin cylinder underneath so its rim and side wall react
+    // like a real pressed record as it moves around the wheel.
+    this.scene.add(new THREE.AmbientLight(0xffffff, 1.25));
+    const keyLight = new THREE.DirectionalLight(0xffffff, 2.4);
+    keyLight.position.set(-2.5, 3.5, 5);
+    this.scene.add(keyLight);
+    const rimLight = new THREE.DirectionalLight(0x9fb7ff, 0.9);
+    rimLight.position.set(4, -1.5, 2.5);
+    this.scene.add(rimLight);
+
+    // Every repeated record has the same shape. Share the GPU vertex buffers
+    // and keep the edge tessellation above the pixel density visible here.
+    this.faceGeometry = new THREE.PlaneGeometry(1, 1);
+    this.edgeGeometry = new THREE.CylinderGeometry(
+      RECORD_MODEL_RADIUS,
+      RECORD_MODEL_RADIUS,
+      RECORD_MODEL_THICKNESS,
+      RECORD_EDGE_SEGMENTS,
+      1,
+      true
+    );
+
     // The icon sequence repeats around the wheel; every copy of an agent's
-    // tile shares one texture but keeps its own material (per-tile fade).
+    // record shares one face texture but keeps its own materials (per-record
+    // fade). A shallow cylinder supplies actual thickness beneath the face.
     for (let slot = 0; slot < this.tileCount; slot++) {
-      const geometry = new THREE.PlaneGeometry(1, 1);
-      const material = new THREE.MeshBasicMaterial({
+      const agentIndex = slot % this.agentCount;
+      const poseGroup = new THREE.Group();
+      const recordGroup = new THREE.Group();
+      recordGroup.scale.setScalar(RECORD_MODEL_SCALE);
+      const faceMaterial = new THREE.MeshBasicMaterial({
         transparent: true,
         depthWrite: false,
         visible: false
       });
-      const mesh = new THREE.Mesh(geometry, material);
-      mesh.userData.agentIndex = slot % this.agentCount;
+      const faceMesh = new THREE.Mesh(this.faceGeometry, faceMaterial);
+      faceMesh.position.z = RECORD_MODEL_THICKNESS / 2 + 0.002;
+      faceMesh.userData.agentIndex = agentIndex;
+
+      const edgeMaterial = new THREE.MeshStandardMaterial({
+        color: 0x070708,
+        metalness: 0.42,
+        roughness: 0.28,
+        transparent: true,
+        depthWrite: false
+      });
+      const edgeMesh = new THREE.Mesh(this.edgeGeometry, edgeMaterial);
+      edgeMesh.rotation.x = Math.PI / 2;
+
       const badgeMaterial = new THREE.MeshBasicMaterial({
         transparent: true,
         depthWrite: false,
@@ -177,11 +383,29 @@ export class AgentGuiHeroCarouselScene {
         new THREE.CircleGeometry(BADGE_DIAMETER / 2, 32),
         badgeMaterial
       );
-      badgeMesh.position.set(BADGE_OFFSET, -BADGE_OFFSET, 0.01);
-      badgeMesh.userData.agentIndex = slot % this.agentCount;
-      mesh.add(badgeMesh);
-      this.scene.add(mesh);
-      this.tiles.push({ badgeMesh, mesh });
+      badgeMesh.position.set(
+        BADGE_OFFSET,
+        -BADGE_OFFSET,
+        RECORD_MODEL_THICKNESS / 2 + 0.01
+      );
+      badgeMesh.userData.agentIndex = agentIndex;
+
+      recordGroup.add(edgeMesh, faceMesh);
+      poseGroup.add(recordGroup, badgeMesh);
+      poseGroup.visible = false;
+      poseGroup.userData.agentIndex = agentIndex;
+      this.scene.add(poseGroup);
+      this.tiles.push({
+        badgeMesh,
+        edgeMaterial,
+        edgeMesh,
+        faceMaterial,
+        faceMesh,
+        poseGroup,
+        ready: false,
+        recordGroup,
+        rotation: 0
+      });
     }
     options.items.forEach((item, agentIndex) => {
       const loadedImage = options.loadedImages?.[agentIndex] ?? null;
@@ -210,6 +434,7 @@ export class AgentGuiHeroCarouselScene {
     });
 
     this.applyPoses();
+    this.startRecordSpin();
   }
 
   setSize(width: number, height: number): void {
@@ -237,6 +462,7 @@ export class AgentGuiHeroCarouselScene {
   // icon sequence repeats); returns the normalized agent index.
   stepBy(direction: 1 | -1): number {
     this.target += direction;
+    this.primeSpringMotion();
     this.animate();
     return this.targetIndex();
   }
@@ -268,6 +494,7 @@ export class AgentGuiHeroCarouselScene {
     }
     this.target += best ?? 0;
     if (animateMove) {
+      this.primeSpringMotion();
       this.animate();
       return;
     }
@@ -279,6 +506,34 @@ export class AgentGuiHeroCarouselScene {
 
   // Canvas-relative pointer coordinates -> agent index, or null.
   pick(x: number, y: number, width: number, height: number): number | null {
+    const tile = this.pickTile(x, y, width, height);
+    const index = tile?.poseGroup.userData.agentIndex;
+    return typeof index === "number" ? index : null;
+  }
+
+  // Gives playback to the record beneath the pointer. When no record is
+  // hovered, playback returns to the record nearest the center.
+  hover(x: number, y: number, width: number, height: number): number | null {
+    const tile = this.pickTile(x, y, width, height);
+    if (tile !== this.hoveredTile) {
+      this.hoveredTile = tile;
+      this.startRecordSpin();
+    }
+    const index = tile?.poseGroup.userData.agentIndex;
+    return typeof index === "number" ? index : null;
+  }
+
+  clearHover(): void {
+    this.hoveredTile = null;
+    this.startRecordSpin();
+  }
+
+  private pickTile(
+    x: number,
+    y: number,
+    width: number,
+    height: number
+  ): AgentGuiHeroCarouselTile | null {
     if (this.disposed || width <= 0 || height <= 0) {
       return null;
     }
@@ -290,23 +545,39 @@ export class AgentGuiHeroCarouselScene {
     const meshes = this.tiles
       .filter(
         (tile) =>
-          tile.mesh.material.visible && tile.mesh.material.opacity > 0.05
+          tile.poseGroup.visible &&
+          tile.faceMaterial.visible &&
+          tile.faceMaterial.opacity > 0.05
       )
       .flatMap((tile) =>
         tile.badgeMesh.material.visible
-          ? [tile.mesh, tile.badgeMesh]
-          : [tile.mesh]
+          ? [tile.faceMesh, tile.badgeMesh]
+          : [tile.faceMesh]
       );
     const hit = this.raycaster.intersectObjects(meshes, false)[0];
-    const index = hit?.object.userData.agentIndex;
-    return typeof index === "number" ? index : null;
+    if (!hit) {
+      return null;
+    }
+    return (
+      this.tiles.find(
+        (tile) => tile.faceMesh === hit.object || tile.badgeMesh === hit.object
+      ) ?? null
+    );
   }
 
   dispose(): void {
     this.disposed = true;
-    if (this.frameHandle !== null) {
-      cancelAnimationFrame(this.frameHandle);
-      this.frameHandle = null;
+    if (this.renderFrameHandle !== null) {
+      cancelAnimationFrame(this.renderFrameHandle);
+      this.renderFrameHandle = null;
+    }
+    if (this.springFrameHandle !== null) {
+      cancelAnimationFrame(this.springFrameHandle);
+      this.springFrameHandle = null;
+    }
+    if (this.recordSpinFrameHandle !== null) {
+      cancelAnimationFrame(this.recordSpinFrameHandle);
+      this.recordSpinFrameHandle = null;
     }
     for (const image of this.images) {
       image.onload = null;
@@ -316,13 +587,17 @@ export class AgentGuiHeroCarouselScene {
     }
     this.ownedImages.clear();
     for (const tile of this.tiles) {
-      tile.mesh.geometry.dispose();
-      tile.mesh.material.map?.dispose();
-      tile.mesh.material.dispose();
       tile.badgeMesh.geometry.dispose();
-      tile.badgeMesh.material.map?.dispose();
       tile.badgeMesh.material.dispose();
+      tile.faceMaterial.dispose();
+      tile.edgeMaterial.dispose();
     }
+    for (const texture of this.textures) {
+      texture.dispose();
+    }
+    this.textures.clear();
+    this.faceGeometry.dispose();
+    this.edgeGeometry.dispose();
     // Do NOT force a context loss here: React StrictMode replays the mount
     // effect on the SAME canvas element, and a forced loss would hand the
     // second scene a dead context (white "sad canvas"). Disposing the
@@ -350,21 +625,41 @@ export class AgentGuiHeroCarouselScene {
       this.onSettle(this.targetIndex());
       return;
     }
-    if (this.frameHandle === null) {
+    if (this.springFrameHandle === null) {
+      // A one-shot resize/texture render must never masquerade as an active
+      // spring. Cancel it and let the interaction frame render immediately.
+      if (this.renderFrameHandle !== null) {
+        cancelAnimationFrame(this.renderFrameHandle);
+        this.renderFrameHandle = null;
+      }
       this.lastFrameAt = null;
-      this.frameHandle = requestAnimationFrame(this.frame);
+      this.springFrameHandle = requestAnimationFrame(this.frame);
+    }
+  }
+
+  private primeSpringMotion(): void {
+    const delta = this.target - this.scroll;
+    const direction = Math.sign(delta);
+    if (direction === 0) {
+      return;
+    }
+    // Preserve an already-fast motion in the correct direction. Fresh clicks
+    // and reversals receive a small impulse so visible movement begins on the
+    // first animation frame instead of waiting for the spring to accelerate.
+    if (this.velocity * direction < SPRING_MIN_LAUNCH_VELOCITY) {
+      this.velocity = direction * SPRING_MIN_LAUNCH_VELOCITY;
     }
   }
 
   private readonly frame = (now: number): void => {
-    this.frameHandle = null;
+    this.springFrameHandle = null;
     if (this.disposed) {
       return;
     }
     const dt =
       this.lastFrameAt === null
         ? 1 / 60
-        : Math.min((now - this.lastFrameAt) / 1000, 0.05);
+        : Math.min((now - this.lastFrameAt) / 1000, MAX_FRAME_DELTA_SECONDS);
     this.lastFrameAt = now;
     const delta = this.target - this.scroll;
     if (
@@ -384,15 +679,73 @@ export class AgentGuiHeroCarouselScene {
     this.scroll += this.velocity * dt;
     this.applyPoses();
     this.renderer.render(this.scene, this.camera);
-    this.frameHandle = requestAnimationFrame(this.frame);
+    this.springFrameHandle = requestAnimationFrame(this.frame);
   };
 
-  private requestRender(): void {
-    if (this.disposed || this.frameHandle !== null) {
+  private startRecordSpin(): void {
+    if (
+      this.disposed ||
+      this.prefersReducedMotion() ||
+      this.recordSpinFrameHandle !== null
+    ) {
       return;
     }
-    this.frameHandle = requestAnimationFrame(() => {
-      this.frameHandle = null;
+    this.lastRecordSpinFrameAt = null;
+    this.recordSpinFrameHandle = requestAnimationFrame(this.recordSpinFrame);
+  }
+
+  private readonly recordSpinFrame = (now: number): void => {
+    this.recordSpinFrameHandle = null;
+    const spinningTile = this.hoveredTile ?? this.centerTile();
+    if (this.disposed || !spinningTile || this.prefersReducedMotion()) {
+      return;
+    }
+    const dt =
+      this.lastRecordSpinFrameAt === null
+        ? 1 / 60
+        : Math.min(
+            (now - this.lastRecordSpinFrameAt) / 1000,
+            MAX_FRAME_DELTA_SECONDS
+          );
+    this.lastRecordSpinFrameAt = now;
+    spinningTile.rotation =
+      (spinningTile.rotation + (Math.PI * 2 * dt) / RECORD_SPIN_SECONDS) %
+      (Math.PI * 2);
+    // While the spring is moving it owns the single pose/render pass. The spin
+    // loop only advances its scalar angle, avoiding duplicate transforms.
+    if (this.springFrameHandle === null) {
+      this.applyPoses();
+      this.renderer.render(this.scene, this.camera);
+    }
+    this.recordSpinFrameHandle = requestAnimationFrame(this.recordSpinFrame);
+  };
+
+  private centerTile(): AgentGuiHeroCarouselTile | null {
+    let centeredTile: AgentGuiHeroCarouselTile | null = null;
+    let centeredOffset = Number.POSITIVE_INFINITY;
+    this.tiles.forEach((tile, index) => {
+      if (!tile.ready) {
+        return;
+      }
+      const offset = Math.abs(ringOffset(index, this.scroll, this.tileCount));
+      if (offset < centeredOffset) {
+        centeredTile = tile;
+        centeredOffset = offset;
+      }
+    });
+    return centeredTile;
+  }
+
+  private requestRender(): void {
+    if (
+      this.disposed ||
+      this.renderFrameHandle !== null ||
+      this.springFrameHandle !== null
+    ) {
+      return;
+    }
+    this.renderFrameHandle = requestAnimationFrame(() => {
+      this.renderFrameHandle = null;
       if (!this.disposed) {
         this.renderer.render(this.scene, this.camera);
       }
@@ -403,14 +756,18 @@ export class AgentGuiHeroCarouselScene {
     if (this.disposed) {
       return;
     }
-    const texture = roundedIconTexture(image, () => this.requestRender());
+    const texture = vinylRecordTexture(image, () => this.requestRender());
+    this.textures.add(texture);
     for (const tile of this.tiles) {
-      if (tile.mesh.userData.agentIndex === agentIndex) {
-        tile.mesh.material.map = texture;
-        tile.mesh.material.visible = true;
-        tile.mesh.material.needsUpdate = true;
+      if (tile.poseGroup.userData.agentIndex === agentIndex) {
+        tile.faceMaterial.map = texture;
+        tile.faceMaterial.visible = true;
+        tile.faceMaterial.needsUpdate = true;
+        tile.ready = true;
       }
     }
+    this.applyPoses();
+    this.startRecordSpin();
   }
 
   private loadBadgeImage(badgeUrl: string, agentIndex: number): void {
@@ -428,8 +785,9 @@ export class AgentGuiHeroCarouselScene {
         () => this.requestRender(),
         BADGE_CORNER_RADIUS
       );
+      this.textures.add(texture);
       for (const tile of this.tiles) {
-        if (tile.mesh.userData.agentIndex === agentIndex) {
+        if (tile.poseGroup.userData.agentIndex === agentIndex) {
           tile.badgeMesh.material.map = texture;
           tile.badgeMesh.material.visible = true;
           tile.badgeMesh.material.needsUpdate = true;
@@ -446,19 +804,48 @@ export class AgentGuiHeroCarouselScene {
       // Angle from the top of the wheel; the focused tile (offset 0) stands
       // upright at 12 o'clock, neighbours ride down the rim.
       const offset = ringOffset(index, this.scroll, this.tileCount);
+      const visible =
+        tile.ready && Math.abs(offset) <= RECORD_RENDER_RANGE_SLOTS;
+      tile.poseGroup.visible = visible;
+      if (!visible) {
+        return;
+      }
       const angle = offset * step;
       const x = this.wheelRadius * Math.sin(angle);
-      const y = this.wheelRadius * (Math.cos(angle) - 1);
-      tile.mesh.position.set(x, y, 0);
+      const y =
+        this.wheelRadius * (Math.cos(angle) - 1) * VISIBLE_ARC_CURVATURE;
+      tile.poseGroup.position.set(x, y, 0);
       // Tangent to the rim: the tile's top edge keeps pointing away from the
       // wheel's hub.
-      tile.mesh.rotation.z = -angle;
-      // Only the focused slot is fully opaque; a tile brightens as it
-      // approaches the top and dims as it leaves.
-      const focus = THREE.MathUtils.clamp(1 - Math.abs(offset), 0, 1);
-      tile.mesh.material.opacity =
-        UNFOCUSED_OPACITY + (1 - UNFOCUSED_OPACITY) * focus;
-      tile.badgeMesh.material.opacity = tile.mesh.material.opacity;
+      // The focused slot is fully opaque and records fade progressively by
+      // distance, restoring the wheel's visible center-to-edge range gradient.
+      const fadeProgress = THREE.MathUtils.clamp(
+        1 - Math.abs(offset) / RECORD_FADE_RANGE_SLOTS,
+        0,
+        1
+      );
+      const rangeOpacity = Math.pow(
+        THREE.MathUtils.smoothstep(fadeProgress, 0, 1),
+        RECORD_FADE_CURVE
+      );
+      // The tile tangent still follows the wheel. Record playback rotation is
+      // independent, so only the currently hovered record advances while all
+      // others retain the angle where their previous hover ended.
+      tile.poseGroup.rotation.set(
+        RECORD_MODEL_TILT_X,
+        THREE.MathUtils.clamp(
+          -angle * RECORD_MODEL_SIDE_TILT_FACTOR,
+          -RECORD_MODEL_MAX_SIDE_TILT,
+          RECORD_MODEL_MAX_SIDE_TILT
+        ),
+        -angle * VISIBLE_ARC_CURVATURE
+      );
+      tile.recordGroup.rotation.z = -tile.rotation;
+      const opacity =
+        MIN_RECORD_OPACITY + (1 - MIN_RECORD_OPACITY) * rangeOpacity;
+      tile.faceMaterial.opacity = opacity;
+      tile.edgeMaterial.opacity = opacity;
+      tile.badgeMesh.material.opacity = opacity;
     });
   }
 }

--- a/packages/agent/gui/app/renderer/agentactivity.css
+++ b/packages/agent/gui/app/renderer/agentactivity.css
@@ -6644,7 +6644,7 @@ button.agent-gui-node__conversation-section-toggle:hover
 
 .agent-gui-node__timeline-centered {
   display: flex;
-  align-items: center;
+  align-items: stretch;
   justify-content: center;
 }
 
@@ -8967,7 +8967,7 @@ html[data-theme="light"] [data-message-center-item-id].agent-gui-edge-glow {
   display: flex;
   width: 100%;
   min-height: 100%;
-  align-items: center;
+  align-items: flex-start;
   justify-content: center;
   padding: 24px clamp(32px, 4vw, 48px) 40px;
 }
@@ -8992,9 +8992,38 @@ html[data-theme="light"] [data-message-center-item-id].agent-gui-edge-glow {
    slot; keep it centered in the hero column. */
 .agent-gui-node__empty-hero-icon-slot:has(
   > .agent-gui-node__empty-hero-carousel
-) {
+),
+.agent-gui-node__empty-hero-icon-slot[data-carousel-placeholder="true"] {
   width: min(400px, 100%);
-  height: auto;
+  height: 112px;
+}
+
+.agent-gui-node__empty-hero-carousel-stage {
+  position: relative;
+  width: 100%;
+  min-height: 100%;
+}
+
+.agent-gui-node__empty-hero-carousel-layer {
+  position: absolute;
+  z-index: 1;
+  top: 24px;
+  left: 50%;
+  width: min(400px, calc(100% - 64px));
+  transform: translateX(-50%);
+}
+
+.agent-gui-node__empty-hero-carousel-placeholder {
+  width: min(400px, 100%);
+  height: 112px;
+  flex: 0 0 auto;
+}
+
+/* Keep the overlayed carousel interactive while the ready/gated body below it
+   changes independently. */
+.agent-gui-node__empty-hero-carousel-layer
+  > .agent-gui-node__empty-hero-carousel {
+  pointer-events: auto;
 }
 
 .agent-gui-node__empty-hero-icon-effect {
@@ -9067,7 +9096,7 @@ html[data-theme="light"] [data-message-center-item-id].agent-gui-edge-glow {
 }
 
 /* Empty-hero agent carousel ("All" tab): a three.js ring of same-sized agent
-   tiles (see agentGuiHeroCarouselScene.ts). Tiles farther around the ring
+   records (see agentGuiHeroCarouselScene.ts). Records farther around the ring
    genuinely shrink and fade with perspective; visuals live on the canvas,
    while visually-hidden buttons keep the switcher reachable by keyboard,
    screen readers, and DOM tests. */
@@ -9098,13 +9127,7 @@ html[data-theme="light"] [data-message-center-item-id].agent-gui-edge-glow {
      the canvas edges), intersected with a vertical band so tiles sinking
      down the wheel melt away instead of being cut by the canvas bottom. */
   mask-image:
-    linear-gradient(
-      90deg,
-      transparent 12%,
-      #000 36%,
-      #000 64%,
-      transparent 88%
-    ),
+    linear-gradient(90deg, transparent 4%, #000 30%, #000 70%, transparent 96%),
     linear-gradient(180deg, #000 0%, #000 70%, transparent 96%);
   mask-composite: intersect;
 }
@@ -9150,7 +9173,9 @@ html[data-theme="light"] [data-message-center-item-id].agent-gui-edge-glow {
 
 /* Gate gap is 8px; add 16px so the icon-to-title spacing is 24px. */
 .agent-gui-node__empty-provider-gate > .agent-gui-node__empty-hero-icon-effect,
-.agent-gui-node__empty-provider-gate > .agent-gui-node__empty-hero-carousel {
+.agent-gui-node__empty-provider-gate > .agent-gui-node__empty-hero-carousel,
+.agent-gui-node__empty-provider-gate
+  > .agent-gui-node__empty-hero-carousel-placeholder {
   margin-bottom: 16px;
 }
 


### PR DESCRIPTION
## Summary
- render the multi-agent empty hero as a persistent Three.js vinyl carousel
- add shallow-arc layout, lit record depth, distance fading, and spring navigation
- rotate the centered record by default and transfer playback to the hovered record
- preserve agent avatar badges as a non-rotating record overlay
- keep the carousel mounted across target and readiness-state changes

## Validation
- `pnpm check:changed` (6 lanes passed)
- AgentGUI typecheck passed
- focused AgentGUI scene/layout tests: 136 passed
- `pnpm check:full` attempted twice; both runs were blocked only by the same three unrelated `services/tuttid/service/agentstatus` auth-isolation tests under full concurrency; the three tests pass when rerun directly

## Documentation
- updated `docs/architecture/agent-gui-node.md` with the durable carousel interaction and rendering contract

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an interactive vinyl-style agent carousel to the empty hero, replacing icon tiles with a persistent Three.js carousel that stays mounted across agent switches and readiness gates. Improves responsiveness and visuals with record depth, hover playback, and optimized rendering.

- **New Features**
  - Vinyl record carousel with a shallow arc, lit edge depth, and progressive distance fading; badges render as a non-rotating overlay.
  - Playback and motion: the centered record spins by default; hover transfers playback; respects reduced motion; wheel/drag/arrow spring navigation with a primed launch for snappier clicks.
  - Input and a11y: pointer-down activates selection and suppresses the matching click to avoid double-selects; canvas hover updates the cursor and clears on leave; visually-hidden buttons keep keyboard access.
  - Layout and performance: the carousel is staged above gated/ready content and preserved across target/readiness changes; external selection recenters the wheel; shared geometries, visible-range culling, and separate RAF loops for render, spring, and spin.

<sup>Written for commit a43768fa354955fed4aeb7f5bfeed06995f5401a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tutti-os/tutti/pull/1070?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

