### PR TITLE
fix(agent-gui): preserve carousel owner badges

### DIFF
--- a/docs/architecture/agent-gui-node.md
+++ b/docs/architecture/agent-gui-node.md
@@ -1603,6 +1603,14 @@ the resolved icon, label, and optional owner badge. The DOM rail, single-agent
 empty state, and WebGL empty-home carousel consume that same presentation;
 renderer adapters may differ, but they must not create parallel icon-only
 models that can silently discard badge or identity fields.
+The WebGL adapter owns badge image loading and GPU resource lifecycle. Remote
+badge images must be requested with anonymous CORS before assigning `src`, and
+the asset host must return an origin-clean response. The adapter must keep an
+asset-independent visible owner marker until decode, canvas conversion, and
+texture upload all succeed; any load, decode, conversion, or upload failure
+keeps that fallback instead of leaving the badge material hidden. Scene disposal
+must detach image callbacks, cancel owned loads, and release badge textures,
+materials, and geometry alongside the primary avatar resources.
 
 New-session surfaces, including the composer, batch runner, App Center, and
 issue-manager launchers, must fail or disable launch when no `agentTargetId` is

--- a/packages/agent/gui/README.md
+++ b/packages/agent/gui/README.md
@@ -138,6 +138,11 @@ the WebGL empty-home carousel all project the same agent-target avatar
 presentation, including the owner badge; renderer-specific DOM and WebGL code
 must not rebuild partial icon-only models.
 
+Hosts serving `owner.avatarUrl` from another origin must enable anonymous CORS
+for that asset. The WebGL carousel keeps a local programmatic owner marker when
+the remote image cannot be decoded or uploaded safely, while DOM avatar
+surfaces continue using the same shared presentation.
+
 Use `agentsLoading` for directory hydration and `renderAgentsEmpty` for a
 host-specific loaded-empty state. Use `renderAgentUnavailableState` or
 `renderAgentReadinessState` for host-specific availability presentation, and

--- a/packages/agent/gui/agent-gui/agentGuiNode/agentGuiHeroCarouselScene.spec.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/agentGuiHeroCarouselScene.spec.ts
@@ -22,9 +22,11 @@ interface FakeMesh {
 }
 
 const threeState = vi.hoisted(() => ({
+  failTextureUpload: false,
   materials: [] as FakeMaterial[],
   meshes: [] as FakeMesh[],
   raycastObjects: [] as FakeMesh[],
+  renderCount: 0,
   rendererDisposed: false,
   textures: [] as FakeDisposable[]
 }));
@@ -124,7 +126,15 @@ vi.mock("three", () => {
       threeState.rendererDisposed = true;
     }
 
-    render(): void {}
+    initTexture(): void {
+      if (threeState.failTextureUpload) {
+        throw new Error("texture upload failed");
+      }
+    }
+
+    render(): void {
+      threeState.renderCount += 1;
+    }
     setClearColor(): void {}
     setPixelRatio(): void {}
     setSize(): void {}
@@ -187,14 +197,29 @@ vi.mock("three", () => {
 import { AgentGuiHeroCarouselScene } from "./agentGuiHeroCarouselScene";
 
 class FakeImage {
+  static instances: FakeImage[] = [];
+  static nextDecodeFailure = false;
+  static nextLoadFailure = false;
+
   complete = false;
+  crossOrigin: string | null = null;
+  decode?: () => Promise<void>;
   decoding = "auto";
   height = 100;
   loading = "auto";
   naturalWidth = 100;
+  onerror: (() => void) | null = null;
   onload: (() => void) | null = null;
   width = 100;
   private value = "";
+
+  constructor() {
+    if (FakeImage.nextDecodeFailure) {
+      FakeImage.nextDecodeFailure = false;
+      this.decode = () => Promise.reject(new Error("decode failed"));
+    }
+    FakeImage.instances.push(this);
+  }
 
   get src(): string {
     return this.value;
@@ -203,7 +228,12 @@ class FakeImage {
   set src(value: string) {
     this.value = value;
     if (value) {
-      this.onload?.();
+      if (FakeImage.nextLoadFailure) {
+        FakeImage.nextLoadFailure = false;
+        this.onerror?.();
+      } else {
+        this.onload?.();
+      }
     }
   }
 
@@ -217,11 +247,16 @@ describe("AgentGuiHeroCarouselScene", () => {
   let getContextSpy: ReturnType<typeof vi.spyOn>;
 
   beforeEach(() => {
+    threeState.failTextureUpload = false;
     threeState.materials.length = 0;
     threeState.meshes.length = 0;
     threeState.raycastObjects.length = 0;
+    threeState.renderCount = 0;
     threeState.rendererDisposed = false;
     threeState.textures.length = 0;
+    FakeImage.instances.length = 0;
+    FakeImage.nextDecodeFailure = false;
+    FakeImage.nextLoadFailure = false;
     globalThis.Image = FakeImage as unknown as typeof Image;
     globalThis.requestAnimationFrame = vi.fn(() => 1);
     globalThis.cancelAnimationFrame = vi.fn();
@@ -285,6 +320,7 @@ describe("AgentGuiHeroCarouselScene", () => {
     });
 
     expect(scene).not.toBeNull();
+    expect(FakeImage.instances[0]?.crossOrigin).toBe("anonymous");
     const badgeMeshes = threeState.meshes.filter(
       (mesh) => mesh.geometry.kind === "badge"
     );
@@ -315,10 +351,89 @@ describe("AgentGuiHeroCarouselScene", () => {
     ).toBe(true);
 
     scene?.dispose();
+    expect(FakeImage.instances[0]?.onerror).toBeNull();
+    expect(FakeImage.instances[0]?.src).toBe("");
     expect(threeState.rendererDisposed).toBe(true);
     expect(threeState.materials.every((material) => material.disposed)).toBe(
       true
     );
     expect(threeState.textures.every((texture) => texture.disposed)).toBe(true);
   });
+
+  it("keeps a visible programmatic badge and schedules a scene update when loading fails", () => {
+    FakeImage.nextLoadFailure = true;
+    const requestAnimationFrame = vi.mocked(globalThis.requestAnimationFrame);
+    const scene = createSceneWithBadge();
+    const badgeMaterials = badgeMaterialsForAgent(0);
+
+    expect(FakeImage.instances[0]?.crossOrigin).toBe("anonymous");
+    expect(badgeMaterials.every((material) => material.visible)).toBe(true);
+    expect(badgeMaterials.every((material) => material.map == null)).toBe(true);
+    expect(requestAnimationFrame).toHaveBeenCalled();
+
+    scene?.dispose();
+  });
+
+  it("keeps the fallback when decode fails", async () => {
+    FakeImage.nextDecodeFailure = true;
+    const scene = createSceneWithBadge();
+
+    await Promise.resolve();
+    const badgeMaterials = badgeMaterialsForAgent(0);
+    expect(badgeMaterials.every((material) => material.visible)).toBe(true);
+    expect(badgeMaterials.every((material) => material.map == null)).toBe(true);
+
+    scene?.dispose();
+  });
+
+  it("disposes a rejected texture and keeps the fallback when WebGL upload fails", () => {
+    threeState.failTextureUpload = true;
+    const scene = createSceneWithBadge();
+    const badgeMaterials = badgeMaterialsForAgent(0);
+
+    expect(badgeMaterials.every((material) => material.visible)).toBe(true);
+    expect(badgeMaterials.every((material) => material.map == null)).toBe(true);
+    expect(threeState.textures).toHaveLength(2);
+    expect(threeState.textures.at(-1)?.disposed).toBe(true);
+
+    scene?.dispose();
+  });
 });
+
+function createSceneWithBadge(): AgentGuiHeroCarouselScene | null {
+  const loadedImage = {
+    complete: true,
+    height: 100,
+    naturalWidth: 100,
+    onload: null,
+    width: 100
+  } as unknown as HTMLImageElement;
+  return AgentGuiHeroCarouselScene.create({
+    canvas: document.createElement("canvas"),
+    items: [
+      {
+        targetId: "agent-1",
+        agentTargetId: "agent-1",
+        provider: "codex",
+        label: "Agent 1",
+        iconUrl: "app://agent-1.png",
+        badge: {
+          iconUrl: "https://cdn.example.com/owner-1.png",
+          label: "Owner 1"
+        }
+      }
+    ],
+    loadedImages: [loadedImage],
+    onSettle: vi.fn()
+  });
+}
+
+function badgeMaterialsForAgent(agentIndex: number): FakeMaterial[] {
+  return threeState.meshes
+    .filter(
+      (mesh) =>
+        mesh.geometry.kind === "badge" &&
+        mesh.userData.agentIndex === agentIndex
+    )
+    .map((mesh) => mesh.material);
+}

--- a/packages/agent/gui/agent-gui/agentGuiNode/agentGuiHeroCarouselScene.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/agentGuiHeroCarouselScene.ts
@@ -377,7 +377,10 @@ export class AgentGuiHeroCarouselScene {
       const badgeMaterial = new THREE.MeshBasicMaterial({
         transparent: true,
         depthWrite: false,
-        visible: false
+        // The solid circle is the owner marker's asset-independent fallback.
+        // Keep it visible while the optional remote avatar is loading or when
+        // that avatar cannot safely become a WebGL texture.
+        visible: options.items[slot % this.agentCount]?.badge != null
       });
       const badgeMesh = new THREE.Mesh(
         new THREE.CircleGeometry(BADGE_DIAMETER / 2, 32),
@@ -581,6 +584,7 @@ export class AgentGuiHeroCarouselScene {
     }
     for (const image of this.images) {
       image.onload = null;
+      image.onerror = null;
       if (this.ownedImages.has(image)) {
         image.src = "";
       }
@@ -772,30 +776,83 @@ export class AgentGuiHeroCarouselScene {
 
   private loadBadgeImage(badgeUrl: string, agentIndex: number): void {
     const image = new Image();
+    // CanvasTexture uploads require an origin-clean source. The owning CDN
+    // must answer this anonymous CORS request with an appropriate
+    // Access-Control-Allow-Origin header; otherwise onerror keeps the
+    // programmatic badge fallback visible.
+    image.crossOrigin = "anonymous";
     image.decoding = "async";
     image.loading = "eager";
     this.ownedImages.add(image);
     this.images.push(image);
+    let settled = false;
+    const keepFallback = (): void => {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      this.requestRender();
+    };
+    const applyDecodedImage = (): void => {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      this.applyBadgeImageTexture(image, agentIndex);
+    };
     image.onload = () => {
       if (this.disposed) {
         return;
       }
-      const texture = roundedIconTexture(
+      let decode: Promise<void> | undefined;
+      try {
+        decode = image.decode?.();
+      } catch {
+        keepFallback();
+        return;
+      }
+      if (decode) {
+        void decode.then(applyDecodedImage).catch(keepFallback);
+        return;
+      }
+      applyDecodedImage();
+    };
+    image.onerror = keepFallback;
+    image.src = badgeUrl;
+  }
+
+  private applyBadgeImageTexture(
+    image: HTMLImageElement,
+    agentIndex: number
+  ): void {
+    if (this.disposed) {
+      return;
+    }
+    let texture: THREE.CanvasTexture | null = null;
+    try {
+      texture = roundedIconTexture(
         image,
         () => this.requestRender(),
         BADGE_CORNER_RADIUS
       );
-      this.textures.add(texture);
-      for (const tile of this.tiles) {
-        if (tile.poseGroup.userData.agentIndex === agentIndex) {
-          tile.badgeMesh.material.map = texture;
-          tile.badgeMesh.material.visible = true;
-          tile.badgeMesh.material.needsUpdate = true;
-        }
-      }
+      // Force the upload before replacing the fallback material. This makes
+      // Canvas/WebGL failures transactional instead of leaving a visible
+      // material pointing at a texture that can never upload.
+      this.renderer.initTexture(texture);
+    } catch {
+      texture?.dispose();
       this.requestRender();
-    };
-    image.src = badgeUrl;
+      return;
+    }
+    this.textures.add(texture);
+    for (const tile of this.tiles) {
+      if (tile.poseGroup.userData.agentIndex === agentIndex) {
+        tile.badgeMesh.material.map = texture;
+        tile.badgeMesh.material.visible = true;
+        tile.badgeMesh.material.needsUpdate = true;
+      }
+    }
+    this.requestRender();
   }
 
   private applyPoses(): void {


### PR DESCRIPTION
## Summary

- request WebGL carousel owner avatars with anonymous CORS before assigning the source
- keep an asset-independent owner marker visible until decode, canvas conversion, and texture upload all succeed
- retain the fallback on load, decode, or GPU upload failure and clean up image callbacks plus scene resources
- document the badge asset/render ownership and CDN CORS requirement

## Verification

- `pnpm --filter @tutti-os/agent-gui test` — 128 files, 2229 tests passed
- `pnpm lint:ts`
- `pnpm typecheck`
- `pnpm check:agent-activity-runtime-boundaries`
- `pnpm check:changed --tail-lines 80` — 6 lanes passed
- `pnpm check:full` — 16 tasks passed during pre-push
- focused Go retry: `go test ./runtime -run TestCodexAppServerAdapterCancelInterruptsLinkedChildThreads -count=1`

The first pre-push run hit a timing failure in the unrelated Codex adapter interrupt test. Its focused retry passed, and the subsequent full pre-push run passed all tasks.

## Checklist

- [x] I kept the change focused on one concern.
- [x] I updated documentation when behavior, setup, or contributor workflow changed.
- [x] I updated all README/CONTRIBUTING language variants when changing their English source. No package README variants exist for `packages/agent/gui/README.md`.
- [x] I ran the lowest meaningful local checks for the changed surface.
- [x] My commits are signed off with DCO when required: `git commit -s`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Keeps owner badges visible in the WebGL hero carousel by showing a fallback until the remote image decodes and the texture uploads safely.

- **Bug Fixes**
  - Request badge images with anonymous CORS before setting `src`.
  - Pre-initialize the WebGL texture upload; keep the fallback on load, decode, or upload failure.
  - Schedule a scene render on load/error and, on dispose, detach `onload`/`onerror`, cancel owned loads, and dispose textures/materials.

- **Migration**
  - Hosts serving `owner.avatarUrl` from another origin must enable anonymous CORS so the image can be used for WebGL textures.

<sup>Written for commit a08f75be6526501f1edc43686f40ca5f752927e5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tutti-os/tutti/pull/1071?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

