### PR TITLE
fix(agent-gui): preserve all conversation filter

### DIFF
--- a/packages/agent/gui/agent-gui/agentGuiNode/AgentGUINodeView.layout.spec.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/AgentGUINodeView.layout.spec.tsx
@@ -786,6 +786,36 @@ describe("AgentGUINodeView layout persistence", () => {
     });
   });
 
+  it("selects All without selecting a fallback target from a disabled target", () => {
+    const actions = createActions();
+    const disabledCodexTarget = {
+      ...createLocalAgentGUIAgentTarget("codex"),
+      disabled: true
+    };
+    renderAgentGUINodeView({
+      actions,
+      viewModel: {
+        ...createViewModel(),
+        conversationFilter: {
+          kind: "agentTarget",
+          agentTargetId: disabledCodexTarget.agentTargetId ?? ""
+        },
+        selectedAgentTarget: disabledCodexTarget,
+        agentTargets: [
+          disabledCodexTarget,
+          createLocalAgentGUIAgentTarget("claude-code")
+        ]
+      }
+    });
+
+    fireEvent.click(screen.getByRole("tab", { name: "All" }));
+
+    expect(actions.updateConversationFilter).toHaveBeenCalledWith({
+      kind: "all"
+    });
+    expect(actions.selectConversationFilterTarget).not.toHaveBeenCalled();
+  });
+
   it("keeps unavailable provider rail targets visually disabled but selectable", () => {
     const actions = createActions();
     const tuttiTarget = {
@@ -1142,13 +1172,17 @@ describe("AgentGUINodeView layout persistence", () => {
   });
 
   it("selects only the All tile for all-conversation mode", () => {
+    const disabledCodexTarget = {
+      ...createLocalAgentGUIAgentTarget("codex"),
+      disabled: true
+    };
     renderAgentGUINodeView({
       viewModel: {
         ...createViewModel(),
         conversationFilter: { kind: "all" },
-        selectedAgentTarget: createLocalAgentGUIAgentTarget("codex"),
+        selectedAgentTarget: disabledCodexTarget,
         agentTargets: [
-          createLocalAgentGUIAgentTarget("codex"),
+          disabledCodexTarget,
           createLocalAgentGUIAgentTarget("claude-code")
         ]
       }

--- a/packages/agent/gui/agent-gui/agentGuiNode/AgentGUINodeView.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/AgentGUINodeView.tsx
@@ -1850,7 +1850,6 @@ export function AgentGUINodeView({
               labels={labels}
               previewMode={previewMode}
               workspaceId={viewModel.workspaceId}
-              selectedAgentTarget={viewModel.selectedAgentTarget}
               agentTargets={viewModel.agentTargets}
               agentTargetsLoading={viewModel.agentTargetsLoading}
               renderProviderRailEmpty={renderProviderRailEmpty}
@@ -5538,7 +5537,6 @@ interface AgentGUIProviderRailProps {
   labels: AgentGUIViewLabels;
   previewMode: boolean;
   workspaceId: string;
-  selectedAgentTarget: AgentGUINodeViewModel["selectedAgentTarget"];
   agentTargets: AgentGUINodeViewModel["agentTargets"];
   agentTargetsLoading: AgentGUINodeViewModel["agentTargetsLoading"];
   renderProviderRailEmpty?: AgentGUIProviderRailEmptyRenderer;
@@ -5563,7 +5561,6 @@ const AgentGUIProviderRail = memo(function AgentGUIProviderRail({
   labels,
   previewMode,
   workspaceId,
-  selectedAgentTarget,
   agentTargets,
   agentTargetsLoading,
   renderProviderRailEmpty,
@@ -5621,30 +5618,11 @@ const AgentGUIProviderRail = memo(function AgentGUIProviderRail({
     return applyAgentGUIProviderRailOrder(railAgentTargets, providerRailOrder);
   }, [providerRailOrder, railAgentTargets]);
   const visibleProviderTiles = providerTiles;
-  const selectedAgentTargetIsPlaceholder =
-    selectedAgentTarget?.disabled === true;
-  const allTileSelected =
-    conversationFilter.kind === "all" && !selectedAgentTargetIsPlaceholder;
+  const allTileSelected = conversationFilter.kind === "all";
   const selectAllProviders = useCallback(() => {
     onUpdateConversationFilter({ kind: "all" });
-    if (selectedAgentTargetIsPlaceholder) {
-      const fallbackTarget =
-        railAgentTargets.find((target) => target.disabled !== true) ?? null;
-      if (fallbackTarget) {
-        onSelectConversationFilterTarget({
-          provider: fallbackTarget.provider,
-          agentTargetId: fallbackTarget.targetId
-        });
-      }
-    }
     onRequestComposerFocus();
-  }, [
-    onSelectConversationFilterTarget,
-    onRequestComposerFocus,
-    onUpdateConversationFilter,
-    railAgentTargets,
-    selectedAgentTargetIsPlaceholder
-  ]);
+  }, [onRequestComposerFocus, onUpdateConversationFilter]);
   const selectAgentTargetTile = useCallback(
     (target: AgentGUINodeViewModel["agentTargets"][number]) => {
       onSelectConversationFilterTarget({
@@ -5937,13 +5915,10 @@ const AgentGUIProviderRail = memo(function AgentGUIProviderRail({
           const providerSelected =
             visibleProviderTiles.length === 1
               ? true
-              : target.disabled === true
-                ? selectedAgentTarget?.provider === target.provider &&
-                  selectedAgentTarget?.targetId === target.targetId
-                : agentGUIAgentTargetMatchesConversationFilter(
-                    target,
-                    conversationFilter
-                  );
+              : agentGUIAgentTargetMatchesConversationFilter(
+                  target,
+                  conversationFilter
+                );
           const label = agentGUIProviderRailLabel(
             target.provider,
             target.label,

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUINodeController.spec.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUINodeController.spec.tsx
@@ -775,7 +775,7 @@ describe("useAgentGUINodeController", () => {
     });
   });
 
-  it("resets the empty composer provider when switching the rail filter back to All", async () => {
+  it("keeps the All filter while resetting a disabled empty composer target", async () => {
     installAgentHostApi({
       list: vi.fn(async () => ({
         presences: [],
@@ -825,7 +825,8 @@ describe("useAgentGUINodeController", () => {
               agentTargetId: "local:claude-code",
               provider: "claude-code",
               ref: { kind: "local-provider", provider: "claude-code" },
-              label: "Claude Code"
+              label: "Claude Code",
+              disabled: true
             }
           ],
           providerReadinessGates: {


### PR DESCRIPTION
## Summary

- make the conversation filter the sole source of truth for provider rail selection
- keep the All action limited to selecting the aggregate filter and focusing the composer
- remove the disabled-target fallback that could overwrite All with an agent-target filter
- add regressions for disabled targets and default composer-target repair

## Verification

- `pnpm check:full`
- `pnpm --filter @tutti-os/agent-gui exec vitest run agent-gui/agentGuiNode/AgentGUINodeView.layout.spec.tsx --maxWorkers=1`
- `pnpm --filter @tutti-os/agent-gui exec vitest run agent-gui/agentGuiNode/controller/useAgentGUINodeController.spec.tsx --maxWorkers=1`
- `pnpm --filter @tutti-os/agent-gui typecheck`
- `pnpm check:agent-activity-runtime-boundaries`

## Checklist

- [x] I kept the change focused on one concern.
- [x] I checked documentation impact; the existing AgentGuiNode architecture already documents the filter/composer ownership boundary, so no update is needed.
- [x] README/CONTRIBUTING language variants are not affected.
- [x] I ran the lowest meaningful local checks for the changed surface.
- [x] My commit is signed off with DCO.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Preserves the "All" conversation filter and makes it the single source of truth for provider rail selection. Prevents auto-switching to a fallback agent when the previous target is disabled.

- **Bug Fixes**
  - "All" now only updates the filter and focuses the composer; no fallback target selection.
  - Provider rail stops using `selectedAgentTarget`; selection comes from the conversation filter.
  - Added tests for disabled targets and empty-composer repair to enforce the new behavior.

<sup>Written for commit b5a1385aabd194be00fc7a79f6b7faa37d63f139. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tutti-os/tutti/pull/1072?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

