### PR TITLE
fix(agent-gui): avoid provider names in handoff titles

### DIFF
--- a/docs/architecture/agent-gui-node.md
+++ b/docs/architecture/agent-gui-node.md
@@ -185,6 +185,10 @@ in-session provider switch: AgentGUI serializes the active session as a single
 `agent-session` mention in a draft prompt, passes the selected provider target
 through the host launch callback, and the desktop workbench opens a new empty
 composer for that target via the existing draft prefill activation path. The
+mention's visible label must use the source conversation title without
+prefixing the source agent or provider name, because the submitted draft also
+becomes the new conversation's initial title. Source agent identity stays in
+the mention metadata instead of being duplicated into title text. The
 prefill activation provider is authoritative for the new workbench panel's
 initial provider chrome, so choosing Codex from a Claude Code session must open
 a Codex panel before the draft prefill effect runs. The prefilled handoff panel

--- a/packages/agent/gui/agent-gui/agentGuiNode/AgentGUINodeView.layout.spec.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/AgentGUINodeView.layout.spec.tsx
@@ -11,6 +11,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import type { AgentActivitySnapshot } from "@tutti-os/agent-activity-core";
 import type { WorkspaceAgentSessionDetailViewModel } from "../../shared/workspaceAgentSessionDetailViewModel";
 import type { AgentPromptContentBlock } from "../../shared/contracts/dto";
+import type { AgentGUIAgentTarget } from "../../types";
 import type { AgentGUINodeViewModel } from "./model/agentGuiNodeTypes";
 import {
   AgentGUINodeView,
@@ -50,6 +51,7 @@ const composerMock = vi.hoisted(() => ({
       content: AgentPromptContentBlock[],
       displayPrompt?: string
     ) => void;
+    onHandoffConversation?: (target: AgentGUIAgentTarget) => void;
     provider?: string;
     showStopButton?: boolean;
     usage?: AgentGUINodeViewModel["usage"];
@@ -153,6 +155,7 @@ vi.mock("./AgentComposer", () => ({
       content: AgentPromptContentBlock[],
       displayPrompt?: string
     ) => void;
+    onHandoffConversation?: (target: AgentGUIAgentTarget) => void;
     provider?: string;
     showStopButton?: boolean;
     usage?: AgentGUINodeViewModel["usage"];
@@ -163,6 +166,7 @@ vi.mock("./AgentComposer", () => ({
       compactSupported: props.compactSupported,
       hasActiveConversation: props.hasActiveConversation,
       isSendingTurn: props.isSendingTurn,
+      onHandoffConversation: props.onHandoffConversation,
       provider: props.provider,
       onSubmit: props.onSubmit,
       showStopButton: props.showStopButton,
@@ -1994,6 +1998,47 @@ describe("AgentGUINodeView layout persistence", () => {
     expect(composerMock.calls.at(-1)).toMatchObject({
       provider: "claude-code"
     });
+  });
+
+  it("uses only the conversation title in the handoff mention label", () => {
+    const sourceTarget = createLocalAgentGUIAgentTarget("codex");
+    const handoffTarget = createLocalAgentGUIAgentTarget("claude-code");
+    const conversation = createConversationSummary("session-1", {
+      agentTargetId: sourceTarget.agentTargetId,
+      title: "Repair login flow"
+    });
+    const onHandoffConversation =
+      vi.fn<NonNullable<AgentGUINodeViewProps["onHandoffConversation"]>>();
+
+    renderAgentGUINodeView({
+      onHandoffConversation,
+      viewModel: {
+        ...createViewModel(),
+        activeConversation: conversation,
+        activeConversationId: conversation.id,
+        conversations: [conversation],
+        selectedAgentTarget: sourceTarget,
+        agentTargets: [sourceTarget, handoffTarget],
+        handoffAgentTargets: [handoffTarget]
+      }
+    });
+
+    act(() => {
+      composerMock.calls.at(-1)?.onHandoffConversation?.(handoffTarget);
+    });
+
+    expect(onHandoffConversation).toHaveBeenCalledTimes(1);
+    expect(onHandoffConversation).toHaveBeenCalledWith(
+      expect.objectContaining({
+        agentTargetId: handoffTarget.agentTargetId,
+        provider: "claude-code"
+      })
+    );
+    const draftPrompt = onHandoffConversation.mock.calls[0]?.[0].draftPrompt;
+    expect(draftPrompt).toMatch(
+      /^\[@Repair login flow\]\(mention:\/\/agent-session\/session-1\?/
+    );
+    expect(draftPrompt).not.toContain("Codex Repair login flow");
   });
 
   it("hides provider switching in the title for an active session", () => {
@@ -5443,6 +5488,7 @@ interface RenderAgentGUINodeViewOptions {
   isAgentProviderReady?: boolean;
   onConversationRailWidthChanged?: (widthPx: number) => void;
   onLinkAction?: AgentGUINodeViewProps["onLinkAction"];
+  onHandoffConversation?: AgentGUINodeViewProps["onHandoffConversation"];
   viewModel?: AgentGUINodeViewModel;
   actions?: AgentGUINodeViewProps["actions"];
   accountMenuState?: AgentGUINodeViewProps["accountMenuState"];
@@ -5463,6 +5509,7 @@ function buildAgentGUINodeViewElement({
   isActive = true,
   isAgentProviderReady = true,
   onConversationRailWidthChanged = vi.fn(),
+  onHandoffConversation,
   onLinkAction,
   viewModel = createViewModel(),
   actions = createActions(),
@@ -5486,6 +5533,7 @@ function buildAgentGUINodeViewElement({
         renderProviderReadinessGateState={renderProviderReadinessGateState}
         providerRailAllPresentation={providerRailAllPresentation}
         onLinkAction={onLinkAction}
+        onHandoffConversation={onHandoffConversation}
         isActive={isActive}
         isAgentProviderReady={isAgentProviderReady}
         slashStatusLimits={slashStatusLimits}

--- a/packages/agent/gui/agent-gui/agentGuiNode/AgentGUINodeView.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/AgentGUINodeView.tsx
@@ -1081,7 +1081,7 @@ function buildAgentConversationHandoffPrompt(input: {
     input.labels,
     input.uiLanguage
   );
-  const mentionLabel = `${sourceAgentLabel}${title ? ` ${title}` : ""}`.trim();
+  const mentionLabel = title || sourceAgentLabel;
   const href = createAgentSessionMentionHref({
     agentTargetId: conversation.agentTargetId,
     agentSessionId: conversation.id,


### PR DESCRIPTION
## Summary

- keep AgentGUI handoff mention labels limited to the source conversation title
- preserve source agent identity in mention metadata without duplicating it into the new conversation title
- add regression coverage and document the handoff title invariant

## Verification

- `pnpm --filter @tutti-os/agent-gui exec vitest run --environment jsdom agent-gui/agentGuiNode/AgentGUINodeView.layout.spec.tsx`
- `pnpm --filter @tutti-os/agent-gui typecheck`
- `pnpm check:agent-activity-runtime-boundaries`
- `pnpm check:changed -- --failed-only`
- `pnpm check:full`

## Checklist

- [x] I kept the change focused on one concern.
- [x] I updated documentation when behavior, setup, or contributor workflow changed.
- [x] I updated all README/CONTRIBUTING language variants when changing their English source.
- [x] I ran the lowest meaningful local checks for the changed surface.
- [x] My commits are signed off with DCO when required: `git commit -s`.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stop including provider names in AgentGUI handoff mention labels. New conversation titles now use only the source conversation title, while the source agent stays in mention metadata.

- **Bug Fixes**
  - Build handoff mention label as `title || sourceAgentLabel`, preventing titles like “Codex Repair login flow”.
  - Added regression test in `AgentGUINodeView.layout.spec.tsx` and documented the invariant in `docs/architecture/agent-gui-node.md`.

<sup>Written for commit ddc83cac6f96b35e50441482f243365d1fae3113. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tutti-os/tutti/pull/1074?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

