### PR TITLE
fix(agent): accept path-backed prompt images in preflight

### DIFF
--- a/docs/architecture/agent-gui-node.md
+++ b/docs/architecture/agent-gui-node.md
@@ -847,6 +847,15 @@ persists the normalized `attachmentId`. The managed source path must live under
 the daemon state root's `agent-prompt-assets` directory, and the daemon must
 re-check the resolved source path, symlink target, file type, and size before
 copying it into the session attachment store.
+Image validation is intentionally two-phase. The preflight that runs before
+attachment persistence may accept a managed `path` as an ingress source so it
+can check provider image capability without writing files. That does not make
+the path valid provider content. After the daemon copies and hydrates the
+source, `Controller.Exec` applies the strict runtime validator to the resulting
+`data`, `url`, or `attachmentId` representation. Keep runtime execution strict,
+and do not move attachment persistence ahead of capability preflight merely to
+make path-backed drafts pass validation; unsupported providers must still fail
+without creating session attachment files.
 Shared callers may instead supply a URL-backed image block when they already
 uploaded the image. That source must be an absolute HTTPS URL without embedded
 userinfo and must retain a supported PNG, JPEG, or WebP MIME type. `data` and

--- a/docs/conventions/troubleshooting/agent-runtime.md
+++ b/docs/conventions/troubleshooting/agent-runtime.md
@@ -37,6 +37,7 @@ Turn state, loading, cancel, restore, rail projection, event updates, imports, a
 
 - [AgentGUI Stop reports no active turn after cancel succeeds](./agent-session-lifecycle.md#agentgui-stop-reports-no-active-turn-after-cancel-succeeds)
 - [AgentGUI send blocked by active_turn after settled snapshot](./agent-session-lifecycle.md#agentgui-send-blocked-by-activeturn-after-settled-snapshot)
+- [AgentGUI rejects a pasted image as unsupported before send](./agent-session-lifecycle.md#agentgui-rejects-a-pasted-image-as-unsupported-before-send)
 - [AgentGUI loading disappears before active turn settles](./agent-session-lifecycle.md#agentgui-loading-disappears-before-active-turn-settles)
 - [Agent session stays loading after a completed turn](./agent-session-lifecycle.md#agent-session-stays-loading-after-a-completed-turn)
 - [AgentGUI model switch changes defaults but not the active session](./agent-session-lifecycle.md#agentgui-model-switch-changes-defaults-but-not-the-active-session)

--- a/docs/conventions/troubleshooting/agent-session-lifecycle.md
+++ b/docs/conventions/troubleshooting/agent-session-lifecycle.md
@@ -4,6 +4,41 @@
 
 Turn state, loading, cancel, restore, rail projection, event updates, imports, and performance.
 
+### AgentGUI rejects a pasted image as unsupported before send
+
+- Symptom:
+  Pasting or dropping a supported PNG, JPEG, or WebP into a provider that
+  advertises `imageInput` fails with
+  `agent prompt image input is unsupported`. Desktop diagnostics may show
+  `agent.gui.composer.image_upload.resolved` with `hasPath = true`, followed by
+  a daemon failure at `service.send.prompt_validated`; no provider turn starts.
+- Quick checks:
+  Confirm the submitted image block is path-backed after the desktop host
+  archives the draft. If the block has `path` but no `data`, `url`, or
+  `attachmentId`, verify the controller is using preflight validation rather
+  than the strict runtime validator before `PersistRequestContent` runs.
+- Root cause:
+  A managed desktop path is an ingress staging source. The daemon must accept
+  it during capability preflight, then copy and hydrate it before runtime
+  execution. Applying the strict provider-content validator during preflight
+  rejects the path before the attachment store can canonicalize it.
+- Fix:
+  Keep separate preflight and runtime image validators. Preflight accepts and
+  preserves the managed path for adapter capability checks. Runtime execution
+  remains strict and receives only the hydrated image representation. Do not
+  retain base64 in the renderer or move attachment persistence before provider
+  capability checks.
+- Validation:
+  Cover the full path-backed chain: controller preflight accepts the path,
+  service execution receives hydrated data without a path, direct runtime
+  execution still rejects path-only content, and unsupported providers create
+  no attachment files. Run `go test ./packages/agent/daemon/runtime
+./services/tuttid/service/agent`.
+- References:
+  [prompt_content.go](../../../packages/agent/daemon/runtime/prompt_content.go)
+  [controller.go](../../../packages/agent/daemon/runtime/controller.go)
+  [service_send_input.go](../../../services/tuttid/service/agent/service_send_input.go)
+
 ### AgentGUI Stop reports no active turn after cancel succeeds
 
 - Symptom:

--- a/packages/agent/daemon/runtime/claude_sdk_adapter.go
+++ b/packages/agent/daemon/runtime/claude_sdk_adapter.go
@@ -276,7 +276,7 @@ func (a *ClaudeCodeSDKAdapter) Close(_ context.Context, session Session) error {
 }
 
 func (*ClaudeCodeSDKAdapter) ValidatePromptContent(_ Session, content []PromptContentBlock) error {
-	return validateRuntimePromptContentImages(content)
+	return validatePromptContentImagesForPreflight(content)
 }
 
 func (a *ClaudeCodeSDKAdapter) Exec(

--- a/packages/agent/daemon/runtime/claude_sdk_adapter_test.go
+++ b/packages/agent/daemon/runtime/claude_sdk_adapter_test.go
@@ -1677,6 +1677,11 @@ func TestClaudeCodeSDKAdapterAcceptsImagePromptContent(t *testing.T) {
 		t.Fatalf("ValidatePromptContent URL image = %v, want nil", err)
 	}
 	if err := adapter.ValidatePromptContent(session, []PromptContentBlock{
+		{Type: "image", MimeType: "image/png", Path: "/managed/agent-prompt-assets/screen.png"},
+	}); err != nil {
+		t.Fatalf("ValidatePromptContent path-backed image = %v, want nil", err)
+	}
+	if err := adapter.ValidatePromptContent(session, []PromptContentBlock{
 		{Type: "image", MimeType: "image/gif", Data: "aW1hZ2U="},
 	}); !errors.Is(err, ErrPromptImageUnsupported) {
 		t.Fatalf("ValidatePromptContent unsupported image = %v, want ErrPromptImageUnsupported", err)

--- a/packages/agent/daemon/runtime/codex_appserver_adapter.go
+++ b/packages/agent/daemon/runtime/codex_appserver_adapter.go
@@ -432,7 +432,7 @@ func (a *CodexAppServerAdapter) SetProviderLaunchPreparer(preparer ProviderLaunc
 
 func (*CodexAppServerAdapter) ValidatePromptContent(_ Session, content []PromptContentBlock) error {
 	// Codex app-server accepts text, image, and localImage user input items.
-	return validateRuntimePromptContentImages(content)
+	return validatePromptContentImagesForPreflight(content)
 }
 
 func (a *CodexAppServerAdapter) commandString() string {

--- a/packages/agent/daemon/runtime/codex_appserver_adapter_test.go
+++ b/packages/agent/daemon/runtime/codex_appserver_adapter_test.go
@@ -1550,6 +1550,11 @@ func TestCodexAppServerAdapterExecImagePrompt(t *testing.T) {
 	t.Parallel()
 
 	adapter, transport, session := startedAppServerAdapter(t)
+	if err := adapter.ValidatePromptContent(session, []PromptContentBlock{{
+		Type: "image", MimeType: "image/png", Path: "/managed/agent-prompt-assets/screen.png",
+	}}); err != nil {
+		t.Fatalf("ValidatePromptContent path-backed image: %v", err)
+	}
 	if err := adapter.ValidatePromptContent(session, []PromptContentBlock{{Type: "image", MimeType: "image/png", Data: "aGk="}}); err != nil {
 		t.Fatalf("ValidatePromptContent: %v", err)
 	}

--- a/packages/agent/daemon/runtime/controller.go
+++ b/packages/agent/daemon/runtime/controller.go
@@ -1136,7 +1136,7 @@ func (c *Controller) ValidatePromptContent(_ context.Context, input ExecInput) e
 	if err != nil {
 		return err
 	}
-	if err := validateRuntimePromptContentImages(input.Content); err != nil {
+	if err := validatePromptContentImagesForPreflight(input.Content); err != nil {
 		return err
 	}
 	content := normalizeRuntimePromptContentForValidation(input.Content)

--- a/packages/agent/daemon/runtime/controller_test.go
+++ b/packages/agent/daemon/runtime/controller_test.go
@@ -164,6 +164,46 @@ func TestControllerStartPassesProviderTargetRefToAdapterSession(t *testing.T) {
 	}
 }
 
+func TestControllerPreflightsPathBackedImageButExecRequiresHydratedContent(t *testing.T) {
+	t.Parallel()
+
+	adapter := &recordingPromptAdapter{
+		recordingStartAdapter: recordingStartAdapter{provider: ProviderCodex},
+	}
+	controller := NewController([]Adapter{adapter}, nil)
+	_, err := controller.Start(context.Background(), StartInput{
+		RoomID:         "room-1",
+		AgentSessionID: "agent-session-1",
+		Provider:       ProviderCodex,
+		CWD:            "/workspace",
+	})
+	if err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	content := []PromptContentBlock{{
+		Type:     "image",
+		MimeType: "image/png",
+		Path:     "/managed/agent-prompt-assets/screen.png",
+	}}
+	if err := controller.ValidatePromptContent(context.Background(), ExecInput{
+		RoomID:         "room-1",
+		AgentSessionID: "agent-session-1",
+		Content:        content,
+	}); err != nil {
+		t.Fatalf("ValidatePromptContent: %v", err)
+	}
+	if len(adapter.validated) != 1 || adapter.validated[0].Path != content[0].Path {
+		t.Fatalf("adapter validated content = %#v, want path-backed image", adapter.validated)
+	}
+	if _, err := controller.Exec(context.Background(), ExecInput{
+		RoomID:         "room-1",
+		AgentSessionID: "agent-session-1",
+		Content:        content,
+	}); !errors.Is(err, ErrPromptImageUnsupported) {
+		t.Fatalf("Exec error = %v, want ErrPromptImageUnsupported", err)
+	}
+}
+
 func TestControllerSetTitleUpdatesLiveSession(t *testing.T) {
 	t.Parallel()
 
@@ -2003,6 +2043,16 @@ func (streamingMessageOnlyAdapter) Cancel(context.Context, Session, string) ([]a
 type recordingStartAdapter struct {
 	provider string
 	started  Session
+}
+
+type recordingPromptAdapter struct {
+	recordingStartAdapter
+	validated []PromptContentBlock
+}
+
+func (a *recordingPromptAdapter) ValidatePromptContent(_ Session, content []PromptContentBlock) error {
+	a.validated = append([]PromptContentBlock(nil), content...)
+	return validatePromptContentImagesForPreflight(content)
 }
 
 func (a *recordingStartAdapter) Provider() string { return a.provider }

--- a/packages/agent/daemon/runtime/prompt_content.go
+++ b/packages/agent/daemon/runtime/prompt_content.go
@@ -81,8 +81,10 @@ func normalizeRuntimePromptContentForValidation(content []PromptContentBlock) []
 			mimeType := strings.TrimSpace(block.MimeType)
 			data := strings.TrimSpace(block.Data)
 			imageURL := strings.TrimSpace(block.URL)
+			attachmentID := strings.TrimSpace(block.AttachmentID)
+			path := strings.TrimSpace(block.Path)
 			if !runtimePromptImageMimeTypeSupported(mimeType) ||
-				(data == "" && imageURL == "" && strings.TrimSpace(block.AttachmentID) == "") ||
+				(data == "" && imageURL == "" && attachmentID == "" && path == "") ||
 				(data != "" && imageURL != "") ||
 				(imageURL != "" && !runtimePromptImageURLSafe(imageURL)) {
 				continue
@@ -92,8 +94,9 @@ func normalizeRuntimePromptContentForValidation(content []PromptContentBlock) []
 				MimeType:     mimeType,
 				Data:         data,
 				URL:          imageURL,
-				AttachmentID: strings.TrimSpace(block.AttachmentID),
+				AttachmentID: attachmentID,
 				Name:         strings.TrimSpace(block.Name),
+				Path:         path,
 			})
 		case "skill", "mention":
 			name := strings.TrimSpace(block.Name)
@@ -111,7 +114,15 @@ func normalizeRuntimePromptContentForValidation(content []PromptContentBlock) []
 	return out
 }
 
+func validatePromptContentImagesForPreflight(content []PromptContentBlock) error {
+	return validatePromptContentImages(content, true)
+}
+
 func validateRuntimePromptContentImages(content []PromptContentBlock) error {
+	return validatePromptContentImages(content, false)
+}
+
+func validatePromptContentImages(content []PromptContentBlock, allowPathOnly bool) error {
 	for _, block := range content {
 		if strings.TrimSpace(block.Type) != "image" {
 			continue
@@ -119,8 +130,10 @@ func validateRuntimePromptContentImages(content []PromptContentBlock) error {
 		data := strings.TrimSpace(block.Data)
 		imageURL := strings.TrimSpace(block.URL)
 		attachmentID := strings.TrimSpace(block.AttachmentID)
+		path := strings.TrimSpace(block.Path)
+		hasSource := data != "" || imageURL != "" || attachmentID != "" || (allowPathOnly && path != "")
 		if !runtimePromptImageMimeTypeSupported(block.MimeType) ||
-			(data == "" && imageURL == "" && attachmentID == "") ||
+			!hasSource ||
 			(data != "" && imageURL != "") ||
 			(imageURL != "" && !runtimePromptImageURLSafe(imageURL)) {
 			return ErrPromptImageUnsupported

--- a/packages/agent/daemon/runtime/prompt_content_test.go
+++ b/packages/agent/daemon/runtime/prompt_content_test.go
@@ -3,6 +3,7 @@ package agentruntime
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -90,6 +91,27 @@ func TestValidateRuntimePromptContentImagesRejectsUnsafeOrAmbiguousURL(t *testin
 		if err := validateRuntimePromptContentImages([]PromptContentBlock{block}); err != ErrPromptImageUnsupported {
 			t.Fatalf("validateRuntimePromptContentImages(%#v) = %v, want ErrPromptImageUnsupported", block, err)
 		}
+	}
+}
+
+func TestPromptContentPreflightAcceptsPathBackedImageBeforeRuntimeHydration(t *testing.T) {
+	t.Parallel()
+
+	content := []PromptContentBlock{{
+		Type:     "image",
+		MimeType: " image/png ",
+		Path:     " /managed/agent-prompt-assets/screen.png ",
+		Name:     " screen.png ",
+	}}
+	if err := validatePromptContentImagesForPreflight(content); err != nil {
+		t.Fatalf("validatePromptContentImagesForPreflight() error = %v, want nil", err)
+	}
+	normalized := normalizeRuntimePromptContentForValidation(content)
+	if len(normalized) != 1 || normalized[0].Path != "/managed/agent-prompt-assets/screen.png" {
+		t.Fatalf("normalized content = %#v, want path-backed image", normalized)
+	}
+	if err := validateRuntimePromptContentImages(content); !errors.Is(err, ErrPromptImageUnsupported) {
+		t.Fatalf("validateRuntimePromptContentImages() error = %v, want ErrPromptImageUnsupported", err)
 	}
 }
 

--- a/packages/agent/daemon/runtime/standard_acp_adapter.go
+++ b/packages/agent/daemon/runtime/standard_acp_adapter.go
@@ -181,7 +181,7 @@ func (a *standardACPAdapter) ValidatePromptContent(session Session, content []Pr
 	if !promptContentHasImage(content) {
 		return nil
 	}
-	if err := validateRuntimePromptContentImages(content); err != nil {
+	if err := validatePromptContentImagesForPreflight(content); err != nil {
 		return err
 	}
 	acpSession := a.getSession(session.AgentSessionID)

--- a/packages/agent/daemon/runtime/standard_acp_adapter_test.go
+++ b/packages/agent/daemon/runtime/standard_acp_adapter_test.go
@@ -1016,7 +1016,7 @@ func TestClaudeCodeAdapterAllowsImagePromptWithoutInitializeCapability(t *testin
 	}, {
 		Type:     "image",
 		MimeType: "image/png",
-		Data:     "aW1hZ2U=",
+		Path:     "/managed/agent-prompt-assets/screen.png",
 	}}
 	if err := adapter.ValidatePromptContent(session, content); err != nil {
 		t.Fatalf("ValidatePromptContent error = %v, want nil", err)
@@ -1100,7 +1100,7 @@ func TestStandardACPAdapterRejectsImagePromptWithoutCapability(t *testing.T) {
 	content := []PromptContentBlock{{
 		Type:     "image",
 		MimeType: "image/png",
-		Data:     "aW1hZ2U=",
+		Path:     "/managed/agent-prompt-assets/screen.png",
 	}}
 	if err := adapter.ValidatePromptContent(session, content); !errors.Is(err, ErrPromptImageUnsupported) {
 		t.Fatalf("ValidatePromptContent error = %v, want ErrPromptImageUnsupported", err)

--- a/services/tuttid/service/agent/service_test.go
+++ b/services/tuttid/service/agent/service_test.go
@@ -1922,6 +1922,50 @@ func TestServiceSendInputRejectsUnsupportedImageBeforePersistingAttachment(t *te
 	}
 }
 
+func TestServiceSendInputHydratesPathBackedImageAfterPreflight(t *testing.T) {
+	runtime := newFakeRuntime()
+	service := NewService(runtime)
+	stateRoot := t.TempDir()
+	sourceRoot := filepath.Join(stateRoot, promptAttachmentSourceDirName)
+	if err := os.MkdirAll(sourceRoot, 0o700); err != nil {
+		t.Fatalf("mkdir source root: %v", err)
+	}
+	sourcePath := filepath.Join(sourceRoot, "screen.png")
+	if err := os.WriteFile(sourcePath, []byte("image-bytes"), 0o600); err != nil {
+		t.Fatalf("write source image: %v", err)
+	}
+	service.PromptAttachmentStore = PromptAttachmentStore{RootDir: stateRoot}
+	runtime.sessions["ws-1:session-1"] = RuntimeSession{
+		ID:          "session-1",
+		WorkspaceID: "ws-1",
+		Provider:    "codex",
+		Status:      "ready",
+		Visible:     true,
+	}
+
+	_, err := service.SendInput(context.Background(), "ws-1", "session-1", SendInput{
+		Content: []PromptContentBlock{{
+			Type:     "image",
+			MimeType: "image/png",
+			Path:     sourcePath,
+			Name:     "screen.png",
+		}},
+	})
+	if err != nil {
+		t.Fatalf("SendInput error = %v, want nil", err)
+	}
+	if len(runtime.validateCalls) != 1 || len(runtime.validateCalls[0].Content) != 1 || runtime.validateCalls[0].Content[0].Path != sourcePath {
+		t.Fatalf("validate calls = %#v, want path-backed preflight content", runtime.validateCalls)
+	}
+	if len(runtime.execCalls) != 1 || len(runtime.execCalls[0].Content) != 1 {
+		t.Fatalf("exec calls = %#v, want one hydrated image", runtime.execCalls)
+	}
+	execImage := runtime.execCalls[0].Content[0]
+	if execImage.Data != "aW1hZ2UtYnl0ZXM=" || execImage.AttachmentID == "" || execImage.Path != "" {
+		t.Fatalf("exec image = %#v, want hydrated data+attachment without path", execImage)
+	}
+}
+
 func TestServiceSendInputRejectsInvalidImageURLBeforeResumingRuntime(t *testing.T) {
 	runtime := newFakeRuntime()
 	service := newTestService(runtime)


### PR DESCRIPTION
## Summary

- preserve managed path-backed image parts during capability and preflight validation
- keep execution-time validation strict so providers only receive loaded image data with a MIME type
- add regression coverage for the controller, Codex app-server, Claude SDK, standard ACP, and service flow
- document the two-stage prompt-image contract and troubleshooting guidance

## Motivation

AgentGUI sends managed attachment paths before the daemon hydrates their bytes and MIME type. Capability validation incorrectly applied the execution-time contract too early, returning agent prompt image input is unsupported before the attachment loader could run.

## Validation

- pnpm check:full
- pre-push pnpm check:full
- independent Codex review: no findings

## Documentation

Updated the AgentGUI architecture and agent-runtime/session-lifecycle troubleshooting documentation.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Accepts managed path-backed prompt images during capability preflight to stop early “unsupported image” errors, while keeping runtime strict so providers only receive hydrated image data with a MIME type.

- **Bug Fixes**
  - Preflight validators now allow `Path`-only image blocks in `controller` and adapters (`Claude SDK`, `Codex app-server`, `standard ACP`).
  - Runtime validator remains strict; `Exec` rejects path-only images and only forwards hydrated `data/url/attachmentId`.
  - Centralized image validation with separate preflight vs runtime paths in `packages/agent/daemon/runtime/prompt_content.go`.
  - Added regression tests across `controller`, `Claude SDK`, `Codex app-server`, `standard ACP`, and `services/tuttid/service/agent`.
  - Updated docs to explain the two-stage prompt-image contract and add troubleshooting guidance.

<sup>Written for commit a9b02b0ad46b1a5cc39ab687ce3e31846d2164ed. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tutti-os/tutti/pull/1075?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

