### PR TITLE
fix(release): pass draft release URL to Feishu

### DIFF
--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -379,6 +379,8 @@ jobs:
     needs: [resolve, build-macos]
     if: ${{ github.event_name == 'push' || needs.resolve.outputs.release_dry_run != 'true' }}
     runs-on: ubuntu-latest
+    outputs:
+      release_url: ${{ steps.stage-release.outputs.url }}
     env:
       AWS_REGION: ${{ vars.AWS_REGION }}
       TUTTI_DESKTOP_RELEASE_TAG: ${{ needs.resolve.outputs.release_tag }}
@@ -449,7 +451,8 @@ jobs:
             echo "TUTTI_DESKTOP_RELEASE_ASSETS_BASE_URL=https://${TUTTI_DESKTOP_RELEASE_ASSETS_S3_BUCKET}.s3-accelerate.amazonaws.com/${TUTTI_DESKTOP_RELEASE_ASSETS_S3_PREFIX%/}" >> "$GITHUB_ENV"
           fi
 
-      - name: Stage GitHub release assets
+      - id: stage-release
+        name: Stage GitHub release assets
         uses: softprops/action-gh-release@v2
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
@@ -718,7 +721,7 @@ jobs:
       RELEASE_BRANCH: ${{ github.ref_type == 'branch' && github.ref_name || '' }}
       RELEASE_TAG: ${{ needs.resolve.outputs.release_tag }}
       RELEASE_TARGET: ${{ needs.resolve.outputs.release_target }}
-      RELEASE_URL: ${{ github.server_url }}/${{ github.repository }}/releases/tag/${{ needs.resolve.outputs.release_tag }}
+      RELEASE_URL: ${{ needs.publish.outputs.release_url }}
       RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
 
     steps:

--- a/apps/desktop/scripts/send-release-feishu-card.mjs
+++ b/apps/desktop/scripts/send-release-feishu-card.mjs
@@ -389,8 +389,16 @@ async function main() {
       "TUTTI_DESKTOP_RELEASE_ASSETS_S3_PREFIX"
     )
   });
-  const release = await loadRelease(repository, tag, resolveGithubToken());
   const mirroredAssetNames = await listAssetNames(releaseAssetDirectory);
+  const mirroredMacUrl = resolveMirroredAssetUrl(
+    mirroredAssetNames,
+    /\.dmg$/i,
+    releaseAssetBaseUrl,
+    tag
+  );
+  const release = mirroredMacUrl
+    ? null
+    : await loadRelease(repository, tag, resolveGithubToken());
   const summary = await loadReleaseSummary(
     readOption(args, "summary", "RELEASE_SUMMARY_PATH")
   );
@@ -398,12 +406,7 @@ async function main() {
     actor,
     branch,
     macUrl:
-      resolveMirroredAssetUrl(
-        mirroredAssetNames,
-        /\.dmg$/i,
-        releaseAssetBaseUrl,
-        tag
-      ) || findAssetUrl(release, /\.dmg$/i, releaseAssetBaseUrl),
+      mirroredMacUrl || findAssetUrl(release, /\.dmg$/i, releaseAssetBaseUrl),
     releaseUrl,
     runUrl,
     summary,

--- a/tools/scripts/desktop-release-config.test.mjs
+++ b/tools/scripts/desktop-release-config.test.mjs
@@ -178,11 +178,17 @@ test("desktop release workflow passes tsh-aligned Feishu card context", async ()
     workflow,
     /TUTTI_DESKTOP_RELEASE_ASSETS_BASE_URL:\s+\${{\s*vars\.TUTTI_DESKTOP_RELEASE_ASSETS_BASE_URL\s*}}/
   );
-  assert.ok(
-    workflow.includes(
-      "RELEASE_URL: ${{ github.server_url }}/${{ github.repository }}/releases/tag/${{ needs.resolve.outputs.release_tag }}"
-    ),
-    "Feishu cards should link to the matching release, including authorized RC and beta drafts"
+  assert.match(
+    workflow,
+    /outputs:\s*\n\s*release_url:\s*\${{\s*steps\.stage-release\.outputs\.url\s*}}/
+  );
+  assert.match(
+    workflow,
+    /id:\s+stage-release\s*\n\s*name:\s+Stage GitHub release assets/
+  );
+  assert.match(
+    workflow,
+    /RELEASE_URL:\s+\${{\s*needs\.publish\.outputs\.release_url\s*}}/
   );
   assert.match(workflow, /RELEASE_ASSET_DIRECTORY:\s+release-assets/);
 });


### PR DESCRIPTION
## What changed

- Capture the real Release URL emitted by `softprops/action-gh-release@v2`.
- Expose that URL as a `publish` job output and pass it to the Feishu notification job.
- Build S3-backed Feishu cards directly from downloaded artifact names, without a follow-up GitHub Release lookup.

## Root cause

A Draft Release exists as a release record but GitHub returns 404 from the release-by-tag endpoint. The old notification job reconstructed a tag URL and then queried that endpoint.

## Why this is deterministic

The release creation action owns the Draft Release and emits its exact HTML URL (`untagged-...`). Passing that output across jobs avoids both tag lookup and release-list pagination/order assumptions.

## Validation

- `node --test tools/scripts/desktop-release-feishu-card.test.mjs tools/scripts/desktop-release-config.test.mjs`
- `pnpm lint`
- Confirmed `softprops/action-gh-release@v2` declares `url` and `id` outputs; inspected current Draft `v0.1.20-rc.3` record and its real HTML URL.