### PR TITLE
feat(agent-gui): render Mermaid diagrams

### DIFF
--- a/docs/architecture/agent-gui-node.md
+++ b/docs/architecture/agent-gui-node.md
@@ -2112,6 +2112,15 @@ that open workspace file nodes should validate explicit agent-command file
 targets before launching the files surface, so a speculative or stale agent
 path does not open a misleading workbench node.
 
+Rendered transcript diagrams follow the same explicit-contract rule. Only
+fenced `mermaid` code blocks are promoted to diagrams; ordinary code blocks and
+plain prose that happen to start with a Mermaid keyword remain text. Diagram
+rendering is lazy-loaded and starts only after response streaming completes so
+token updates do not repeatedly parse and lay out a graph. Mermaid runs with
+strict security, HTML labels disabled, and bounded text/edge limits. A loading
+or parse failure must preserve the original source instead of leaving a blank
+transcript row.
+
 Provider host-app-context prompts should mirror that contract: when agents
 reference code or workspace files in responses, instruct them to emit Markdown
 links with filename labels and absolute filesystem targets such as

--- a/packages/agent/gui/README.md
+++ b/packages/agent/gui/README.md
@@ -3,6 +3,18 @@
 AgentGUI renders workspace agent sessions, timelines, approvals, and composer
 UI. It is a UI package, not a host transport or business-core package.
 
+Transcript Markdown supports Mermaid diagrams in explicit fenced code blocks:
+
+````markdown
+```mermaid
+flowchart TD
+  A[Start] --> B[Finish]
+```
+````
+
+AgentGUI keeps Mermaid source as a fallback when a diagram is still streaming
+or cannot be rendered.
+
 Before changing AgentGUI, AgentGuiNode, or the agent conversation module, read
 [AgentGuiNode Architecture and Troubleshooting](../../../docs/architecture/agent-gui-node.md).
 It records the source-of-truth rules, common chains, debugging playbooks, and

--- a/packages/agent/gui/app/renderer/i18n/locales/en.ts
+++ b/packages/agent/gui/app/renderer/i18n/locales/en.ts
@@ -1336,6 +1336,10 @@ export const en = {
       "This workspace is closing. Your connection will end soon.",
     workspaceClosingStatus: "Workspace shutdown in progress",
     workspaceAgentMessageExpand: "Show all",
+    workspaceAgentMermaidRendering: "Rendering diagram…",
+    workspaceAgentMermaidDiagramLabel: "Mermaid diagram",
+    workspaceAgentMermaidRenderFailed:
+      "Unable to render this diagram. Showing the Mermaid source instead.",
     workspaceAgentActivityStatusWorking: "Running",
     workspaceAgentActivityStatusWaiting: "Waiting",
     workspaceAgentActivityStatusIdle: "Completed",

--- a/packages/agent/gui/app/renderer/i18n/locales/zh-CN.ts
+++ b/packages/agent/gui/app/renderer/i18n/locales/zh-CN.ts
@@ -1252,6 +1252,10 @@ export const zhCN = {
     workspaceClosingBanner: "这个工作区正在关闭，连接即将断开。",
     workspaceClosingStatus: "工作区关闭中",
     workspaceAgentMessageExpand: "展开全部",
+    workspaceAgentMermaidRendering: "正在渲染图表…",
+    workspaceAgentMermaidDiagramLabel: "Mermaid 图表",
+    workspaceAgentMermaidRenderFailed:
+      "无法渲染此图表，已改为显示 Mermaid 源码。",
     workspaceAgentActivityStatusWorking: "运行中",
     workspaceAgentActivityStatusWaiting: "等待中",
     workspaceAgentActivityStatusIdle: "已完成",

--- a/packages/agent/gui/package.json
+++ b/packages/agent/gui/package.json
@@ -65,6 +65,7 @@
     "framer-motion": "^12.40.0",
     "lodash": "^4.17.21",
     "lucide-react": "^0.511.0",
+    "mermaid": "11.16.0",
     "react-markdown": "^10.1.0",
     "rehype-sanitize": "^6.0.0",
     "remark-gfm": "^4.0.1",

--- a/packages/agent/gui/shared/AgentMessageMarkdown.spec.tsx
+++ b/packages/agent/gui/shared/AgentMessageMarkdown.spec.tsx
@@ -17,9 +17,25 @@ import {
   managedAgentRoundedIconUrl
 } from "./managedAgentIcons";
 
+const mermaidMocks = vi.hoisted(() => ({
+  initialize: vi.fn(),
+  render: vi.fn(async () => ({
+    svg: '<svg role="img" aria-label="Rendered Mermaid diagram"><text>Rendered diagram</text></svg>'
+  }))
+}));
+
+vi.mock("mermaid", () => ({
+  default: mermaidMocks
+}));
+
 describe("AgentMessageMarkdown", () => {
   afterEach(() => {
     resetCachedMarkdownImagesForTests();
+    mermaidMocks.initialize.mockClear();
+    mermaidMocks.render.mockClear();
+    mermaidMocks.render.mockImplementation(async () => ({
+      svg: '<svg role="img" aria-label="Rendered Mermaid diagram"><text>Rendered diagram</text></svg>'
+    }));
   });
 
   it("renders a workspace-reference mention as one chip without a file-count badge", () => {
@@ -140,6 +156,72 @@ describe("AgentMessageMarkdown", () => {
     expect(
       screen.getByRole("cell", { name: "统一 API 格式适配不同 LLM 提供商" })
     ).toBeInTheDocument();
+  });
+
+  it("renders fenced Mermaid code blocks as diagrams", async () => {
+    const source = [
+      "flowchart TD",
+      '  U1["用户发送文件"] --> U2["客户端计算 SHA-256"]',
+      '  U2 --> U3{"服务端已有 owner + SHA？"}'
+    ].join("\n");
+    const { container } = render(
+      <AgentMessageMarkdown content={`\`\`\`mermaid\n${source}\n\`\`\``} />
+    );
+
+    expect(
+      await screen.findByRole("img", { name: "Rendered Mermaid diagram" })
+    ).toBeInTheDocument();
+    expect(mermaidMocks.initialize).toHaveBeenCalledWith(
+      expect.objectContaining({
+        htmlLabels: false,
+        securityLevel: "strict",
+        startOnLoad: false,
+        suppressErrorRendering: true
+      })
+    );
+    expect(mermaidMocks.render).toHaveBeenCalledWith(
+      expect.stringMatching(/^agent-mermaid-/),
+      source
+    );
+    expect(
+      container.querySelector('[data-agent-mermaid-diagram="true"]')
+    ).toBeInTheDocument();
+    expect(container.querySelector("pre")).toBeNull();
+  });
+
+  it("keeps Mermaid source visible when diagram rendering fails", async () => {
+    mermaidMocks.render.mockRejectedValueOnce(new Error("Invalid diagram"));
+    const source = "flowchart TD\n  A -->";
+    const { container } = render(
+      <AgentMessageMarkdown content={`\`\`\`mermaid\n${source}\n\`\`\``} />
+    );
+
+    expect(
+      await screen.findByText(
+        "Unable to render this diagram. Showing the Mermaid source instead."
+      )
+    ).toBeInTheDocument();
+    expect(container.querySelector("code")?.textContent).toBe(source);
+  });
+
+  it("defers Mermaid rendering until a streaming response is complete", async () => {
+    const source = "flowchart TD\n  A --> B";
+    const content = `\`\`\`mermaid\n${source}\n\`\`\``;
+    const { container, rerender } = render(
+      <AgentMessageMarkdown content={content} streaming />
+    );
+
+    expect(container.querySelector("code")?.textContent?.trimEnd()).toBe(
+      source
+    );
+    expect(mermaidMocks.render).not.toHaveBeenCalled();
+
+    rerender(<AgentMessageMarkdown content={content} streaming={false} />);
+
+    expect(
+      await screen.findByRole("img", { name: "Rendered Mermaid diagram" })
+    ).toBeInTheDocument();
+    expect(mermaidMocks.render).toHaveBeenCalledTimes(1);
   });
   it("keeps links inert for now", () => {
     render(

--- a/packages/agent/gui/shared/AgentMessageMarkdown.tsx
+++ b/packages/agent/gui/shared/AgentMessageMarkdown.tsx
@@ -8,6 +8,7 @@ import {
   type PointerEvent,
   type ReactNode,
   createContext,
+  isValidElement,
   startTransition,
   useCallback,
   useEffect,
@@ -63,6 +64,7 @@ import {
   useAgentTargetPresentations,
   type AgentMessageMarkdownAgentTarget
 } from "./AgentTargetPresentationContext";
+import { MermaidDiagram } from "./MermaidDiagram";
 
 const COLLAPSED_LINE_LIMIT = 8;
 const APPROX_CHARS_PER_LINE = 34;
@@ -270,6 +272,9 @@ export function AgentMessageMarkdown({
       code: (props: MarkdownDomProps<"code">) => (
         <MarkdownCode {...props} onLinkClick={handleLinkClick} />
       ),
+      pre: (props: MarkdownDomProps<"pre">) => (
+        <MarkdownPre {...props} enableMermaid={!streaming} />
+      ),
       img: (props: MarkdownDomProps<"img">) => (
         <MarkdownMedia {...props} enableZoom={enableImageZoom} />
       ),
@@ -278,8 +283,7 @@ export function AgentMessageMarkdown({
       ),
       ul: MarkdownUnorderedList,
       ol: MarkdownOrderedList,
-      li: MarkdownListItem,
-      pre: MarkdownPre
+      li: MarkdownListItem
     }),
     [
       effectiveAgentTargets,
@@ -287,6 +291,7 @@ export function AgentMessageMarkdown({
       handleLinkClick,
       inline,
       previewMode,
+      streaming,
       workspaceAppIcons
     ]
   );
@@ -997,6 +1002,23 @@ function MarkdownCode({
       {children}
     </code>
   );
+}
+
+function resolveMermaidCodeBlockSource(children: ReactNode): string | null {
+  const child =
+    Array.isArray(children) && children.length === 1 ? children[0] : children;
+  if (!isValidElement<{ className?: unknown; children?: ReactNode }>(child)) {
+    return null;
+  }
+  const className =
+    typeof child.props.className === "string" ? child.props.className : "";
+  const isMermaid = className
+    .split(/\s+/)
+    .some((name) => name.toLowerCase() === "language-mermaid");
+  if (!isMermaid) {
+    return null;
+  }
+  return textFromReactNode(child.props.children).replace(/\n$/, "");
 }
 
 type MarkdownMediaKind = "image" | "video";
@@ -2034,12 +2056,18 @@ function textFromReactNode(node: ReactNode): string {
 
 function MarkdownPre({
   children,
+  enableMermaid,
   ...props
-}: MarkdownDomProps<"pre">): JSX.Element {
+}: MarkdownDomProps<"pre"> & {
+  enableMermaid: boolean;
+}): JSX.Element {
   "use memo";
   const preRef = useRef<HTMLPreElement>(null);
   const [copied, setCopied] = useState(false);
   const copyResetRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const mermaidSource = enableMermaid
+    ? resolveMermaidCodeBlockSource(children)
+    : null;
 
   const handleCopy = useCallback(() => {
     const text = preRef.current?.textContent?.trim();
@@ -2054,6 +2082,10 @@ function MarkdownPre({
       copyResetRef.current = setTimeout(() => setCopied(false), 1500);
     });
   }, []);
+
+  if (mermaidSource !== null) {
+    return <MermaidDiagram source={mermaidSource} />;
+  }
 
   return (
     <div className="group relative">

--- a/packages/agent/gui/shared/MermaidDiagram.tsx
+++ b/packages/agent/gui/shared/MermaidDiagram.tsx
@@ -1,0 +1,109 @@
+import { useEffect, useId, useState, type JSX } from "react";
+import { useTranslation } from "../i18n/index";
+
+type MermaidRenderState =
+  | { status: "rendering" }
+  | { status: "ready"; svg: string }
+  | { status: "error" };
+
+let mermaidRenderQueue: Promise<void> = Promise.resolve();
+
+export function MermaidDiagram({ source }: { source: string }): JSX.Element {
+  "use memo";
+  const { t } = useTranslation();
+  const reactId = useId();
+  const diagramId = `agent-mermaid-${reactId.replace(/[^A-Za-z0-9_-]/g, "")}`;
+  const [state, setState] = useState<MermaidRenderState>({
+    status: "rendering"
+  });
+
+  useEffect(() => {
+    let canceled = false;
+    setState({ status: "rendering" });
+
+    void renderMermaidDiagram(diagramId, source).then(
+      (svg) => {
+        if (!canceled) {
+          setState({ status: "ready", svg });
+        }
+      },
+      () => {
+        if (!canceled) {
+          setState({ status: "error" });
+        }
+      }
+    );
+
+    return () => {
+      canceled = true;
+    };
+  }, [diagramId, source]);
+
+  if (state.status === "error") {
+    return (
+      <div
+        className="my-2 box-border w-full min-w-0 rounded-[8px] border border-[var(--line-2)] bg-[var(--background-panel)] p-3"
+        data-agent-mermaid-diagram="true"
+        data-agent-mermaid-status="error"
+      >
+        <p className="mb-2 text-[12px] text-[var(--text-tertiary)]">
+          {t("agentHost.workspaceAgentMermaidRenderFailed")}
+        </p>
+        <pre className="m-0 overflow-auto rounded-[6px] bg-[var(--transparency-block)] px-2.5 py-2">
+          <code className="language-mermaid">{source}</code>
+        </pre>
+      </div>
+    );
+  }
+
+  if (state.status === "rendering") {
+    return (
+      <div
+        className="my-2 box-border flex min-h-24 w-full min-w-0 items-center justify-center rounded-[8px] border border-[var(--line-2)] bg-[var(--background-panel)] p-3 text-[12px] text-[var(--text-tertiary)]"
+        data-agent-mermaid-diagram="true"
+        data-agent-mermaid-status="rendering"
+        role="status"
+      >
+        {t("agentHost.workspaceAgentMermaidRendering")}
+      </div>
+    );
+  }
+
+  return (
+    <div
+      className="my-2 box-border w-full min-w-0 overflow-x-auto rounded-[8px] border border-[var(--line-2)] bg-[var(--background-panel)] p-3 [&_svg]:mx-auto [&_svg]:block [&_svg]:h-auto [&_svg]:max-w-full"
+      data-agent-mermaid-diagram="true"
+      data-agent-mermaid-status="ready"
+      role="img"
+      aria-label={t("agentHost.workspaceAgentMermaidDiagramLabel")}
+      dangerouslySetInnerHTML={{ __html: state.svg }}
+    />
+  );
+}
+
+function renderMermaidDiagram(id: string, source: string): Promise<string> {
+  const render = mermaidRenderQueue.then(async () => {
+    const { default: mermaid } = await import("mermaid");
+    mermaid.initialize({
+      startOnLoad: false,
+      securityLevel: "strict",
+      suppressErrorRendering: true,
+      theme: "neutral",
+      htmlLabels: false,
+      maxEdges: 500,
+      maxTextSize: 50_000,
+      flowchart: {
+        htmlLabels: false,
+        useMaxWidth: true
+      }
+    });
+    const result = await mermaid.render(id, source);
+    return result.svg;
+  });
+
+  mermaidRenderQueue = render.then(
+    () => undefined,
+    () => undefined
+  );
+  return render;
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -80,7 +80,7 @@ importers:
         version: link:../../packages/configs/tsconfig
       "@tutti-os/infra":
         specifier: 0.1.0
-        version: 0.1.0(react@19.2.6)
+        version: 0.1.0(lodash-es@4.18.1)(react@19.2.6)
       "@tutti-os/rrt-plugin-vite":
         specifier: 0.0.6
         version: 0.0.6(vite@6.4.2(@types/node@24.12.4)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.22.3)(yaml@2.9.0))
@@ -329,6 +329,9 @@ importers:
       lucide-react:
         specifier: ^0.511.0
         version: 0.511.0(react@19.2.6)
+      mermaid:
+        specifier: 11.16.0
+        version: 11.16.0
       react:
         specifier: ^19.1.0
         version: 19.2.6
@@ -515,7 +518,7 @@ importers:
     dependencies:
       "@tutti-os/infra":
         specifier: 0.1.0
-        version: 0.1.0(react@19.2.6)
+        version: 0.1.0(lodash-es@4.18.1)(react@19.2.6)
     devDependencies:
       "@tutti-os/config-tsconfig":
         specifier: workspace:*
@@ -1162,6 +1165,12 @@ packages:
         integrity: sha512-6OzddxPio9UiWTCemp4N8cYLV2ZN1ncRnV1cVGtve7dhPOtRkleRyx32GQCYSwDYgaHU3USMm84tNsvKzRCa1Q==
       }
 
+  "@antfu/install-pkg@1.1.0":
+    resolution:
+      {
+        integrity: sha512-MGQsmw10ZyI+EJo45CdSER4zEb+p31LpDAFp2Z3gkSd1yqVZGi0Ebx++YTEMonJy4oChEMLsxZ64j8FH6sSqtQ==
+      }
+
   "@anthropic-ai/claude-agent-sdk-darwin-arm64@0.3.201":
     resolution:
       {
@@ -1608,6 +1617,12 @@ packages:
       }
     engines: { node: ">=6.9.0" }
 
+  "@braintree/sanitize-url@7.1.2":
+    resolution:
+      {
+        integrity: sha512-jigsZK+sMF/cuiB7sERuo9V7N9jx+dhmHHnQyDSVdpZwVutaBu7WvNYqMDLSgFgfB30n452TP3vjDAvFC973mA==
+      }
+
   "@changesets/apply-release-plan@7.1.1":
     resolution:
       {
@@ -1715,6 +1730,12 @@ packages:
     resolution:
       {
         integrity: sha512-CdTLvIOPiCNuH71pyDu3rA+Q0n65cmAbXnwWH84rKGiFumFzkmHNT8KHTMEchcxN+Kl8I54xGUhJ7l3E7X396Q==
+      }
+
+  "@chevrotain/types@11.1.2":
+    resolution:
+      {
+        integrity: sha512-U+HFai5+zmJCkK86QsaJtoITlboZHBqrVketcO2ROv865xfCMSFpELQoz1GkX5GzME8pTa+3kbKrZHQtI0gdbw==
       }
 
   "@csstools/color-helpers@6.0.2":
@@ -2663,6 +2684,18 @@ packages:
     peerDependencies:
       hono: ^4
 
+  "@iconify/types@2.0.0":
+    resolution:
+      {
+        integrity: sha512-+wluvCrRhXrhyOmRDJ3q8mux9JkKy5SJ/v8ol2tu4FVjyYvtEzkc/3pK15ET6RKg4b4w4BmTk1+gsCUhf21Ykg==
+      }
+
+  "@iconify/utils@3.1.4":
+    resolution:
+      {
+        integrity: sha512-b1S7B1k9ohZ+iNTi2ATxbRYG9fTrJmUT0rc46bvVnNxqNRGW7dyo/vRREwyniI5IRN2RSJHDcm+s3BjWrSAjHw==
+      }
+
   "@inquirer/external-editor@1.0.3":
     resolution:
       {
@@ -2750,6 +2783,12 @@ packages:
     resolution:
       {
         integrity: sha512-fo+QhuU3qE/2TQMQmbVMqaQ6EWbMhi4ABWP+O4AM1NqPBuy0OrApV5LO6BrrgnhtAHS2NH6RrVk9OL181tTi8A==
+      }
+
+  "@mermaid-js/parser@1.2.0":
+    resolution:
+      {
+        integrity: sha512-oYPyv8A4As1yH5Bx+04iQEQxXuIQDe0GKCNSRgao6z8AM9jixXIfP0vsppRLvGf+nKIOb9/LdpWA4YuJiVvESA==
       }
 
   "@modelcontextprotocol/sdk@1.29.0":
@@ -4858,6 +4897,192 @@ packages:
         integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==
       }
 
+  "@types/d3-array@3.2.2":
+    resolution:
+      {
+        integrity: sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw==
+      }
+
+  "@types/d3-axis@3.0.6":
+    resolution:
+      {
+        integrity: sha512-pYeijfZuBd87T0hGn0FO1vQ/cgLk6E1ALJjfkC0oJ8cbwkZl3TpgS8bVBLZN+2jjGgg38epgxb2zmoGtSfvgMw==
+      }
+
+  "@types/d3-brush@3.0.6":
+    resolution:
+      {
+        integrity: sha512-nH60IZNNxEcrh6L1ZSMNA28rj27ut/2ZmI3r96Zd+1jrZD++zD3LsMIjWlvg4AYrHn/Pqz4CF3veCxGjtbqt7A==
+      }
+
+  "@types/d3-chord@3.0.6":
+    resolution:
+      {
+        integrity: sha512-LFYWWd8nwfwEmTZG9PfQxd17HbNPksHBiJHaKuY1XeqscXacsS2tyoo6OdRsjf+NQYeB6XrNL3a25E3gH69lcg==
+      }
+
+  "@types/d3-color@3.1.3":
+    resolution:
+      {
+        integrity: sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==
+      }
+
+  "@types/d3-contour@3.0.6":
+    resolution:
+      {
+        integrity: sha512-BjzLgXGnCWjUSYGfH1cpdo41/hgdWETu4YxpezoztawmqsvCeep+8QGfiY6YbDvfgHz/DkjeIkkZVJavB4a3rg==
+      }
+
+  "@types/d3-delaunay@6.0.4":
+    resolution:
+      {
+        integrity: sha512-ZMaSKu4THYCU6sV64Lhg6qjf1orxBthaC161plr5KuPHo3CNm8DTHiLw/5Eq2b6TsNP0W0iJrUOFscY6Q450Hw==
+      }
+
+  "@types/d3-dispatch@3.0.7":
+    resolution:
+      {
+        integrity: sha512-5o9OIAdKkhN1QItV2oqaE5KMIiXAvDWBDPrD85e58Qlz1c1kI/J0NcqbEG88CoTwJrYe7ntUCVfeUl2UJKbWgA==
+      }
+
+  "@types/d3-drag@3.0.7":
+    resolution:
+      {
+        integrity: sha512-HE3jVKlzU9AaMazNufooRJ5ZpWmLIoc90A37WU2JMmeq28w1FQqCZswHZ3xR+SuxYftzHq6WU6KJHvqxKzTxxQ==
+      }
+
+  "@types/d3-dsv@3.0.7":
+    resolution:
+      {
+        integrity: sha512-n6QBF9/+XASqcKK6waudgL0pf/S5XHPPI8APyMLLUHd8NqouBGLsU8MgtO7NINGtPBtk9Kko/W4ea0oAspwh9g==
+      }
+
+  "@types/d3-ease@3.0.2":
+    resolution:
+      {
+        integrity: sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA==
+      }
+
+  "@types/d3-fetch@3.0.7":
+    resolution:
+      {
+        integrity: sha512-fTAfNmxSb9SOWNB9IoG5c8Hg6R+AzUHDRlsXsDZsNp6sxAEOP0tkP3gKkNSO/qmHPoBFTxNrjDprVHDQDvo5aA==
+      }
+
+  "@types/d3-force@3.0.10":
+    resolution:
+      {
+        integrity: sha512-ZYeSaCF3p73RdOKcjj+swRlZfnYpK1EbaDiYICEEp5Q6sUiqFaFQ9qgoshp5CzIyyb/yD09kD9o2zEltCexlgw==
+      }
+
+  "@types/d3-format@3.0.4":
+    resolution:
+      {
+        integrity: sha512-fALi2aI6shfg7vM5KiR1wNJnZ7r6UuggVqtDA+xiEdPZQwy/trcQaHnwShLuLdta2rTymCNpxYTiMZX/e09F4g==
+      }
+
+  "@types/d3-geo@3.1.0":
+    resolution:
+      {
+        integrity: sha512-856sckF0oP/diXtS4jNsiQw/UuK5fQG8l/a9VVLeSouf1/PPbBE1i1W852zVwKwYCBkFJJB7nCFTbk6UMEXBOQ==
+      }
+
+  "@types/d3-hierarchy@3.1.7":
+    resolution:
+      {
+        integrity: sha512-tJFtNoYBtRtkNysX1Xq4sxtjK8YgoWUNpIiUee0/jHGRwqvzYxkq0hGVbbOGSz+JgFxxRu4K8nb3YpG3CMARtg==
+      }
+
+  "@types/d3-interpolate@3.0.4":
+    resolution:
+      {
+        integrity: sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==
+      }
+
+  "@types/d3-path@3.1.1":
+    resolution:
+      {
+        integrity: sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg==
+      }
+
+  "@types/d3-polygon@3.0.2":
+    resolution:
+      {
+        integrity: sha512-ZuWOtMaHCkN9xoeEMr1ubW2nGWsp4nIql+OPQRstu4ypeZ+zk3YKqQT0CXVe/PYqrKpZAi+J9mTs05TKwjXSRA==
+      }
+
+  "@types/d3-quadtree@3.0.6":
+    resolution:
+      {
+        integrity: sha512-oUzyO1/Zm6rsxKRHA1vH0NEDG58HrT5icx/azi9MF1TWdtttWl0UIUsjEQBBh+SIkrpd21ZjEv7ptxWys1ncsg==
+      }
+
+  "@types/d3-random@3.0.4":
+    resolution:
+      {
+        integrity: sha512-UHYId5WTCx4L4YNel7NU00XUXXgvgpgZOvp10PuvsQENjMDXhh2RyFc0KBjO7B45ne4Ha1yVH7ii0vnzKkuzWA==
+      }
+
+  "@types/d3-scale-chromatic@3.1.0":
+    resolution:
+      {
+        integrity: sha512-iWMJgwkK7yTRmWqRB5plb1kadXyQ5Sj8V/zYlFGMUBbIPKQScw+Dku9cAAMgJG+z5GYDoMjWGLVOvjghDEFnKQ==
+      }
+
+  "@types/d3-scale@4.0.9":
+    resolution:
+      {
+        integrity: sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw==
+      }
+
+  "@types/d3-selection@3.0.11":
+    resolution:
+      {
+        integrity: sha512-bhAXu23DJWsrI45xafYpkQ4NtcKMwWnAC/vKrd2l+nxMFuvOT3XMYTIj2opv8vq8AO5Yh7Qac/nSeP/3zjTK0w==
+      }
+
+  "@types/d3-shape@3.1.8":
+    resolution:
+      {
+        integrity: sha512-lae0iWfcDeR7qt7rA88BNiqdvPS5pFVPpo5OfjElwNaT2yyekbM0C9vK+yqBqEmHr6lDkRnYNoTBYlAgJa7a4w==
+      }
+
+  "@types/d3-time-format@4.0.3":
+    resolution:
+      {
+        integrity: sha512-5xg9rC+wWL8kdDj153qZcsJ0FWiFt0J5RB6LYUNZjwSnesfblqrI/bJ1wBdJ8OQfncgbJG5+2F+qfqnqyzYxyg==
+      }
+
+  "@types/d3-time@3.0.4":
+    resolution:
+      {
+        integrity: sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g==
+      }
+
+  "@types/d3-timer@3.0.2":
+    resolution:
+      {
+        integrity: sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==
+      }
+
+  "@types/d3-transition@3.0.9":
+    resolution:
+      {
+        integrity: sha512-uZS5shfxzO3rGlu0cC3bjmMFKsXv+SmZZcgp0KD22ts4uGXp5EVYGzu/0YdwZeKmddhcAccYtREJKkPfXkZuCg==
+      }
+
+  "@types/d3-zoom@3.0.8":
+    resolution:
+      {
+        integrity: sha512-iqMC4/YlFCSlO8+2Ii1GGGliCAY4XdeG748w5vQUbevlbDu0zSjH/+jojorQVBK/se0j6DUFNPBGSqD3YWYnDw==
+      }
+
+  "@types/d3@7.4.3":
+    resolution:
+      {
+        integrity: sha512-lZXZ9ckh5R8uiFVt8ogUNf+pIrK4EsWrx2Np75WvF/eTpJ0FMHNhjXk8CKEx/+gpHbNQyJWehbFaTvqmHWB3ww==
+      }
+
   "@types/debug@4.1.13":
     resolution:
       {
@@ -4886,6 +5111,12 @@ packages:
     resolution:
       {
         integrity: sha512-nEnwB++1u5lVDM2UI4c1+5R+FYaKfaAzS4OococimjVm3nQw3TuzH5UNsocrcTBbhnerblyHj4A49qXbIiZdpA==
+      }
+
+  "@types/geojson@7946.0.16":
+    resolution:
+      {
+        integrity: sha512-6C8nqWur3j98U6+lXDfTUWIfgvZU+EumvpHKcYjujKH7woYyLj2sUmff0tRhrqM7BohUw7Pz3ZB1jj2gW9Fvmg==
       }
 
   "@types/hast@3.0.4":
@@ -5121,6 +5352,12 @@ packages:
     resolution:
       {
         integrity: sha512-mUFwbeTqrVgDQxFveS+df2yfap6iuP20NAKAsBt5jDEoOTDew+zwLAOilHCeQJOVSvmgCX4ogqIrA0mnyr08yQ==
+      }
+
+  "@upsetjs/venn.js@2.0.0":
+    resolution:
+      {
+        integrity: sha512-WbBhLrooyePuQ1VZxrJjtLvTc4NVfpOyKx0sKqioq9bX1C1m7Jgykkn8gLrtwumBioXIqam8DLxp88Adbue6Hw==
       }
 
   "@vitejs/plugin-react@4.7.0":
@@ -5973,6 +6210,20 @@ packages:
       }
     engines: { node: ">= 6" }
 
+  commander@7.2.0:
+    resolution:
+      {
+        integrity: sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==
+      }
+    engines: { node: ">= 10" }
+
+  commander@8.3.0:
+    resolution:
+      {
+        integrity: sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww==
+      }
+    engines: { node: ">= 12" }
+
   commander@9.5.0:
     resolution:
       {
@@ -6073,6 +6324,18 @@ packages:
       }
     engines: { node: ">= 0.10" }
 
+  cose-base@1.0.3:
+    resolution:
+      {
+        integrity: sha512-s9whTXInMSgAp/NVXVNuVxVKzGH2qck3aQlVHxDCdAEPgtMKwc4Wq6/QKhgdEdgbLSi9rBTAcPoRa6JpiG4ksg==
+      }
+
+  cose-base@2.2.0:
+    resolution:
+      {
+        integrity: sha512-AzlgcsCbUMymkADOJtQm3wO9S3ltPfYOFD5033keQn9NJzIbtnZj+UdBJe7DYml/8TdbtHJW3j58SOnKhWY/5g==
+      }
+
   cosmiconfig@9.0.2:
     resolution:
       {
@@ -6138,6 +6401,279 @@ packages:
         integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==
       }
 
+  cytoscape-cose-bilkent@4.1.0:
+    resolution:
+      {
+        integrity: sha512-wgQlVIUJF13Quxiv5e1gstZ08rnZj2XaLHGoFMYXz7SkNfCDOOteKBE6SYRfA9WxxI/iBc3ajfDoc6hb/MRAHQ==
+      }
+    peerDependencies:
+      cytoscape: ^3.2.0
+
+  cytoscape-fcose@2.2.0:
+    resolution:
+      {
+        integrity: sha512-ki1/VuRIHFCzxWNrsshHYPs6L7TvLu3DL+TyIGEsRcvVERmxokbf5Gdk7mFxZnTdiGtnA4cfSmjZJMviqSuZrQ==
+      }
+    peerDependencies:
+      cytoscape: ^3.2.0
+
+  cytoscape@3.34.0:
+    resolution:
+      {
+        integrity: sha512-62rNSrioXw93uliKFBwjukeQyeWwH2PqDrTac31r2P6464u3AUvTk0xS4LVvT251g7IgkFunrI48ZEZGjywSOg==
+      }
+    engines: { node: ">=0.10" }
+
+  d3-array@2.12.1:
+    resolution:
+      {
+        integrity: sha512-B0ErZK/66mHtEsR1TkPEEkwdy+WDesimkM5gpZr5Dsg54BiTA5RXtYW5qTLIAcekaS9xfZrzBLF/OAkB3Qn1YQ==
+      }
+
+  d3-array@3.2.4:
+    resolution:
+      {
+        integrity: sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==
+      }
+    engines: { node: ">=12" }
+
+  d3-axis@3.0.0:
+    resolution:
+      {
+        integrity: sha512-IH5tgjV4jE/GhHkRV0HiVYPDtvfjHQlQfJHs0usq7M30XcSBvOotpmH1IgkcXsO/5gEQZD43B//fc7SRT5S+xw==
+      }
+    engines: { node: ">=12" }
+
+  d3-brush@3.0.0:
+    resolution:
+      {
+        integrity: sha512-ALnjWlVYkXsVIGlOsuWH1+3udkYFI48Ljihfnh8FZPF2QS9o+PzGLBslO0PjzVoHLZ2KCVgAM8NVkXPJB2aNnQ==
+      }
+    engines: { node: ">=12" }
+
+  d3-chord@3.0.1:
+    resolution:
+      {
+        integrity: sha512-VE5S6TNa+j8msksl7HwjxMHDM2yNK3XCkusIlpX5kwauBfXuyLAtNg9jCp/iHH61tgI4sb6R/EIMWCqEIdjT/g==
+      }
+    engines: { node: ">=12" }
+
+  d3-color@3.1.0:
+    resolution:
+      {
+        integrity: sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==
+      }
+    engines: { node: ">=12" }
+
+  d3-contour@4.0.2:
+    resolution:
+      {
+        integrity: sha512-4EzFTRIikzs47RGmdxbeUvLWtGedDUNkTcmzoeyg4sP/dvCexO47AaQL7VKy/gul85TOxw+IBgA8US2xwbToNA==
+      }
+    engines: { node: ">=12" }
+
+  d3-delaunay@6.0.4:
+    resolution:
+      {
+        integrity: sha512-mdjtIZ1XLAM8bm/hx3WwjfHt6Sggek7qH043O8KEjDXN40xi3vx/6pYSVTwLjEgiXQTbvaouWKynLBiUZ6SK6A==
+      }
+    engines: { node: ">=12" }
+
+  d3-dispatch@3.0.1:
+    resolution:
+      {
+        integrity: sha512-rzUyPU/S7rwUflMyLc1ETDeBj0NRuHKKAcvukozwhshr6g6c5d8zh4c2gQjY2bZ0dXeGLWc1PF174P2tVvKhfg==
+      }
+    engines: { node: ">=12" }
+
+  d3-drag@3.0.0:
+    resolution:
+      {
+        integrity: sha512-pWbUJLdETVA8lQNJecMxoXfH6x+mO2UQo8rSmZ+QqxcbyA3hfeprFgIT//HW2nlHChWeIIMwS2Fq+gEARkhTkg==
+      }
+    engines: { node: ">=12" }
+
+  d3-dsv@3.0.1:
+    resolution:
+      {
+        integrity: sha512-UG6OvdI5afDIFP9w4G0mNq50dSOsXHJaRE8arAS5o9ApWnIElp8GZw1Dun8vP8OyHOZ/QJUKUJwxiiCCnUwm+Q==
+      }
+    engines: { node: ">=12" }
+    hasBin: true
+
+  d3-ease@3.0.1:
+    resolution:
+      {
+        integrity: sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==
+      }
+    engines: { node: ">=12" }
+
+  d3-fetch@3.0.1:
+    resolution:
+      {
+        integrity: sha512-kpkQIM20n3oLVBKGg6oHrUchHM3xODkTzjMoj7aWQFq5QEM+R6E4WkzT5+tojDY7yjez8KgCBRoj4aEr99Fdqw==
+      }
+    engines: { node: ">=12" }
+
+  d3-force@3.0.0:
+    resolution:
+      {
+        integrity: sha512-zxV/SsA+U4yte8051P4ECydjD/S+qeYtnaIyAs9tgHCqfguma/aAQDjo85A9Z6EKhBirHRJHXIgJUlffT4wdLg==
+      }
+    engines: { node: ">=12" }
+
+  d3-format@3.1.2:
+    resolution:
+      {
+        integrity: sha512-AJDdYOdnyRDV5b6ArilzCPPwc1ejkHcoyFarqlPqT7zRYjhavcT3uSrqcMvsgh2CgoPbK3RCwyHaVyxYcP2Arg==
+      }
+    engines: { node: ">=12" }
+
+  d3-geo@3.1.1:
+    resolution:
+      {
+        integrity: sha512-637ln3gXKXOwhalDzinUgY83KzNWZRKbYubaG+fGVuc/dxO64RRljtCTnf5ecMyE1RIdtqpkVcq0IbtU2S8j2Q==
+      }
+    engines: { node: ">=12" }
+
+  d3-hierarchy@3.1.2:
+    resolution:
+      {
+        integrity: sha512-FX/9frcub54beBdugHjDCdikxThEqjnR93Qt7PvQTOHxyiNCAlvMrHhclk3cD5VeAaq9fxmfRp+CnWw9rEMBuA==
+      }
+    engines: { node: ">=12" }
+
+  d3-interpolate@3.0.1:
+    resolution:
+      {
+        integrity: sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==
+      }
+    engines: { node: ">=12" }
+
+  d3-path@1.0.9:
+    resolution:
+      {
+        integrity: sha512-VLaYcn81dtHVTjEHd8B+pbe9yHWpXKZUC87PzoFmsFrJqgFwDe/qxfp5MlfsfM1V5E/iVt0MmEbWQ7FVIXh/bg==
+      }
+
+  d3-path@3.1.0:
+    resolution:
+      {
+        integrity: sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==
+      }
+    engines: { node: ">=12" }
+
+  d3-polygon@3.0.1:
+    resolution:
+      {
+        integrity: sha512-3vbA7vXYwfe1SYhED++fPUQlWSYTTGmFmQiany/gdbiWgU/iEyQzyymwL9SkJjFFuCS4902BSzewVGsHHmHtXg==
+      }
+    engines: { node: ">=12" }
+
+  d3-quadtree@3.0.1:
+    resolution:
+      {
+        integrity: sha512-04xDrxQTDTCFwP5H6hRhsRcb9xxv2RzkcsygFzmkSIOJy3PeRJP7sNk3VRIbKXcog561P9oU0/rVH6vDROAgUw==
+      }
+    engines: { node: ">=12" }
+
+  d3-random@3.0.1:
+    resolution:
+      {
+        integrity: sha512-FXMe9GfxTxqd5D6jFsQ+DJ8BJS4E/fT5mqqdjovykEB2oFbTMDVdg1MGFxfQW+FBOGoB++k8swBrgwSHT1cUXQ==
+      }
+    engines: { node: ">=12" }
+
+  d3-sankey@0.12.3:
+    resolution:
+      {
+        integrity: sha512-nQhsBRmM19Ax5xEIPLMY9ZmJ/cDvd1BG3UVvt5h3WRxKg5zGRbvnteTyWAbzeSvlh3tW7ZEmq4VwR5mB3tutmQ==
+      }
+
+  d3-scale-chromatic@3.1.0:
+    resolution:
+      {
+        integrity: sha512-A3s5PWiZ9YCXFye1o246KoscMWqf8BsD9eRiJ3He7C9OBaxKhAd5TFCdEx/7VbKtxxTsu//1mMJFrEt572cEyQ==
+      }
+    engines: { node: ">=12" }
+
+  d3-scale@4.0.2:
+    resolution:
+      {
+        integrity: sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==
+      }
+    engines: { node: ">=12" }
+
+  d3-selection@3.0.0:
+    resolution:
+      {
+        integrity: sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==
+      }
+    engines: { node: ">=12" }
+
+  d3-shape@1.3.7:
+    resolution:
+      {
+        integrity: sha512-EUkvKjqPFUAZyOlhY5gzCxCeI0Aep04LwIRpsZ/mLFelJiUfnK56jo5JMDSE7yyP2kLSb6LtF+S5chMk7uqPqw==
+      }
+
+  d3-shape@3.2.0:
+    resolution:
+      {
+        integrity: sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==
+      }
+    engines: { node: ">=12" }
+
+  d3-time-format@4.1.0:
+    resolution:
+      {
+        integrity: sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==
+      }
+    engines: { node: ">=12" }
+
+  d3-time@3.1.0:
+    resolution:
+      {
+        integrity: sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==
+      }
+    engines: { node: ">=12" }
+
+  d3-timer@3.0.1:
+    resolution:
+      {
+        integrity: sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==
+      }
+    engines: { node: ">=12" }
+
+  d3-transition@3.0.1:
+    resolution:
+      {
+        integrity: sha512-ApKvfjsSR6tg06xrL434C0WydLr7JewBB3V+/39RMHsaXTOG0zmt/OAXeng5M5LBm0ojmxJrpomQVZ1aPvBL4w==
+      }
+    engines: { node: ">=12" }
+    peerDependencies:
+      d3-selection: 2 - 3
+
+  d3-zoom@3.0.0:
+    resolution:
+      {
+        integrity: sha512-b8AmV3kfQaqWAuacbPuNbL6vahnOJflOhexLzMMNLga62+/nh0JzvJ0aO/5a5MVgUFGS7Hu1P9P03o3fJkDCyw==
+      }
+    engines: { node: ">=12" }
+
+  d3@7.9.0:
+    resolution:
+      {
+        integrity: sha512-e1U46jVP+w7Iut8Jt8ri1YsPOvFpg46k+K8TpCb0P+zjCkjkPnV7WzfDJzMHy1LnA+wj5pLT1wjO901gLXeEhA==
+      }
+    engines: { node: ">=12" }
+
+  dagre-d3-es@7.0.14:
+    resolution:
+      {
+        integrity: sha512-P4rFMVq9ESWqmOgK+dlXvOtLwYg0i7u0HBGJER0LZDJT2VHIPAMZ/riPxqJceWMStH5+E61QxFra9kIS3AqdMg==
+      }
+
   data-uri-to-buffer@4.0.1:
     resolution:
       {
@@ -6151,6 +6687,12 @@ packages:
         integrity: sha512-euIQENZg6x8mj3fO6o9+fOW8MimUI4PpD/fZBhJfeioZVy9TUpM4UY7KjQNVZFlqwJ0UdzRDzkycB997HEq1BQ==
       }
     engines: { node: ">=20" }
+
+  dayjs@1.11.21:
+    resolution:
+      {
+        integrity: sha512-98IT+HOahAisibz/yjKbzuOBwYcjJ7BCLPzARyHiyEBmRz4fatF+KPJszEHXsGYjUG234aH/cOjW1wwTbKUZlA==
+      }
 
   debounce-fn@4.0.0:
     resolution:
@@ -6270,6 +6812,12 @@ packages:
         integrity: sha512-7z22QmUWiQ/2d0KkdYmANbRUVABpZ9SNYyH5vx6PZ+nE5bcC0l7uFvEfHlyld/HcGBFTL536ClDt3DEcSlEJAQ==
       }
 
+  delaunator@5.1.0:
+    resolution:
+      {
+        integrity: sha512-AGrQ4QSgssa1NGmWmLPqN5NY2KajF5MqxetNEO+o0n3ZwZZeTmt7bBnvzHWrmkZFxGgr4HdyFgelzgi06otLuQ==
+      }
+
   delayed-stream@1.0.0:
     resolution:
       {
@@ -6380,6 +6928,12 @@ packages:
     resolution:
       {
         integrity: sha512-WhL/YuveyGXJaerVlMYGWhvQswa7myDG17P7Vu65EWC05o8vfeNbvNf4d/BOvH99+ZW+LlQsc1GDKMa1vNK6dw==
+      }
+
+  dompurify@3.4.12:
+    resolution:
+      {
+        integrity: sha512-zQvGet8Z2sWbQhCmfFz/T5QWH2oBmjnqK3qvOjaqaNLrLEF912WamU+ohnTp0TCep/MFVHpdJuCZEdFOdTnEFg==
       }
 
   dot-prop@6.0.1:
@@ -6603,6 +7157,12 @@ packages:
         integrity: sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==
       }
     engines: { node: ">= 0.4" }
+
+  es-toolkit@1.49.0:
+    resolution:
+      {
+        integrity: sha512-G5iZ6Pc/FNRY/soKZHC+TxGDD83rHUDXxzaWhGCX44vAv/tMs56WMusnm/KMNK+luUPsgA9U28cGr4RDlSzL2g==
+      }
 
   es6-error@4.1.1:
     resolution:
@@ -7144,6 +7704,12 @@ packages:
         integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==
       }
 
+  hachure-fill@0.5.2:
+    resolution:
+      {
+        integrity: sha512-3GKBOn+m2LX9iq+JC1064cSFprJY4jL1jCXTcpnfER5HYE2l/4EfWSGzkPa/ZDBmYI0ZOEj5VHV/eKnPGkHuOg==
+      }
+
   has-flag@4.0.0:
     resolution:
       {
@@ -7345,6 +7911,12 @@ packages:
       }
     engines: { node: ">=6" }
 
+  import-meta-resolve@4.2.0:
+    resolution:
+      {
+        integrity: sha512-Iqv2fzaTQN28s/FwZAoFq0ZSs/7hMAHJVX+w8PZl3cY19Pxk6jFFalxQoIfW2826i/fDLXv8IiEZRIT0lDuWcg==
+      }
+
   indent-string@4.0.0:
     resolution:
       {
@@ -7370,6 +7942,19 @@ packages:
       {
         integrity: sha512-Nb2ctOyNR8DqQoR0OwRG95uNWIC0C1lCgf5Naz5H6Ji72KZ8OcFZLz2P5sNgwlyoJ8Yif11oMuYs5pBQa86csA==
       }
+
+  internmap@1.0.1:
+    resolution:
+      {
+        integrity: sha512-lDB5YccMydFBtasVtxnZ3MRBHuaoE8GKsppq+EchKL2U4nK/DmEpPHNH8MZe5HkMtpSiTSOZwfN0tzYjO/lJEw==
+      }
+
+  internmap@2.0.3:
+    resolution:
+      {
+        integrity: sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==
+      }
+    engines: { node: ">=12" }
 
   ip-address@10.2.0:
     resolution:
@@ -7761,10 +8346,23 @@ packages:
         integrity: sha512-zwOTdL3rFQ/lRdBnntKVOX6k5cKJwEc1HdilT71BWEu7J41gXIB2MRp+vxduPSwZJPWBxEzv4yH1wYLJGUHX4Q==
       }
 
+  katex@0.16.47:
+    resolution:
+      {
+        integrity: sha512-Eeo8Ys1doU1z+x8AZsPpQu+p/QcZBI5PeOo7QGQdy2x2m0MU/hYagBbGOmXwr5KVbEfVuWv9LpnQWeehogurjg==
+      }
+    hasBin: true
+
   keyv@4.5.4:
     resolution:
       {
         integrity: sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==
+      }
+
+  khroma@2.1.0:
+    resolution:
+      {
+        integrity: sha512-Ls993zuzfayK269Svk9hzpeGUKob/sIgZzyHYdjQoAdQetRKpOLj+k/QQQ/6Qi0Yz65mlROrfd+Ev+1+7dz9Kw==
       }
 
   kleur@3.0.3:
@@ -7780,6 +8378,18 @@ packages:
         integrity: sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ==
       }
     engines: { node: ">=6" }
+
+  layout-base@1.0.2:
+    resolution:
+      {
+        integrity: sha512-8h2oVEZNktL4BH2JCOI90iD1yXwL6iNW7KcCKT2QZgQJR2vbqDsldCTPRU9NifTCqHZci57XvQQ15YTu+sTYPg==
+      }
+
+  layout-base@2.0.1:
+    resolution:
+      {
+        integrity: sha512-dp3s92+uNI1hWIpPGH3jK2kxE2lMjdXdr+DH8ynZHpd6PUlH6x6cbuXnoMmiNumznqaNO31xu9e79F0uuZ0JFg==
+      }
 
   lazy-val@1.0.5:
     resolution:
@@ -7948,6 +8558,12 @@ packages:
       }
     engines: { node: ">=8" }
 
+  lodash-es@4.18.1:
+    resolution:
+      {
+        integrity: sha512-J8xewKD/Gk22OZbhpOVSwcs60zhd95ESDwezOFuA3/099925PdHJ7OFHNTGtajL3AlZkykD32HykiMo+BIBI8A==
+      }
+
   lodash.escaperegexp@4.1.2:
     resolution:
       {
@@ -8067,6 +8683,14 @@ packages:
         integrity: sha512-uIj4+faQ+MgHgwUW1l2PsPglZLOLOT1uErt06dAPtx2kjteLAkbsd/0FiYg/MGS+i7ZKLb7w2WClxHkzOOuryQ==
       }
     engines: { node: ">= 18" }
+    hasBin: true
+
+  marked@16.4.2:
+    resolution:
+      {
+        integrity: sha512-TI3V8YYWvkVf3KJe1dRkpnjs68JUPyEa5vjKrp1XEEJUAOaQc+Qj+L1qWbPd0SJuAdQkFU0h73sXXqwDYxsiDA==
+      }
+    engines: { node: ">= 20" }
     hasBin: true
 
   matcher@3.0.0:
@@ -8205,6 +8829,12 @@ packages:
         integrity: sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==
       }
     engines: { node: ">= 8" }
+
+  mermaid@11.16.0:
+    resolution:
+      {
+        integrity: sha512-Zvm3kbstgdpvIJPPItlL7fppIZ3kibvc1oZIGxdvk9t6UFz6flv+Jw7FtRGKwfcI8OckmH04LqG6LlS6X4B1pA==
+      }
 
   meshoptimizer@1.1.1:
     resolution:
@@ -8855,6 +9485,12 @@ packages:
         integrity: sha512-BEnLolu+yuz22S56CU1SUKq3XC3PkwD5wv4ikR4MfGvnRVcmzXR9DwSlW2fEamyTPyXHomBJRzgapeuBvRNzJQ==
       }
 
+  package-manager-detector@1.7.0:
+    resolution:
+      {
+        integrity: sha512-xg1eHpwYL/D/HEdWw2goFZP6vV0FH7W+PZ5rFkGjdIDLtxq7EkzBUeT3m+lndYCt8wKbmofUu1MUdMCXkCk9ZQ==
+      }
+
   parent-module@1.0.1:
     resolution:
       {
@@ -8899,6 +9535,12 @@ packages:
     resolution:
       {
         integrity: sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g==
+      }
+
+  path-data-parser@0.1.0:
+    resolution:
+      {
+        integrity: sha512-NOnmBpt5Y2RWbuv0LMzsayp3lVylAHLPUTut412ZA3l+C4uw4ZVkQbjShYCQ8TCpUMdPapr4YjUqLYD6v68j+w==
       }
 
   path-exists@3.0.0:
@@ -9054,6 +9696,18 @@ packages:
         integrity: sha512-ZIfcLJC+7E7FBFnDxm9MPmt7D+DidyQ26lewieO75AdhA2ayMtsJSES0iWzqJQbcVRSrTufQoy0DR94xHue0oA==
       }
     engines: { node: ">=10.4.0" }
+
+  points-on-curve@0.2.0:
+    resolution:
+      {
+        integrity: sha512-0mYKnYYe9ZcqMCWhUjItv/oHjvgEsfKvnUTg8sAtnHr3GVy7rGkXCb6d5cSyqrWqL4k81b9CPg3urd+T7aop3A==
+      }
+
+  points-on-path@0.2.1:
+    resolution:
+      {
+        integrity: sha512-25ClnWWuw7JbWZcgqY/gJ4FQWadKxGWk+3kR/7kD0tCaDtPPMj7oHu2ToLaVhfpnHrZzYby2w6tUA0eOIuUg8g==
+      }
 
   postcss-load-config@6.0.1:
     resolution:
@@ -9606,6 +10260,12 @@ packages:
       }
     engines: { node: ">=8.0" }
 
+  robust-predicates@3.0.3:
+    resolution:
+      {
+        integrity: sha512-NS3levdsRIUOmiJ8FZWCP7LG3QpJyrs/TE0Zpf1yvZu8cAJJ6QMW92H1c7kWpdIHo8RvmLxN/o2JXTKHp74lUA==
+      }
+
   rollup@4.60.4:
     resolution:
       {
@@ -9618,6 +10278,12 @@ packages:
     resolution:
       {
         integrity: sha512-UT5EDe2cu2E/6O4igUr5PSFs23nvvukicWHx6GnOPlHAiiYbzNuCRQCuiUdHJQcqKalLKlrYJnjY0ySGsXNQXQ==
+      }
+
+  roughjs@4.6.6:
+    resolution:
+      {
+        integrity: sha512-ZUz/69+SYpFN/g/lUlo2FXcIjRkSu3nDarreVdGGndHEBJ6cXPdKguS8JGxwj5HA5xIbVKSmLgr5b3AWxtRfvQ==
       }
 
   router@2.2.0:
@@ -9638,6 +10304,12 @@ packages:
     resolution:
       {
         integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==
+      }
+
+  rw@1.3.3:
+    resolution:
+      {
+        integrity: sha512-PdhdWy89SiZogBLaw42zdeqtRJ//zFd2PgQavcICDUgJT5oW10QCRKbJ6bg4r0/UY2M6BWd5tkxuGFRvCkgfHQ==
       }
 
   safer-buffer@2.1.2:
@@ -10063,6 +10735,12 @@ packages:
         integrity: sha512-LIN7rULI0jBscWQYaSswptyderlarFkjQ+t79nzty8tcIAceVomEVlLzH5VP4Cmsv6MtKhs7qaAiwlcp+Mgaxw==
       }
 
+  stylis@4.4.0:
+    resolution:
+      {
+        integrity: sha512-5Z9ZpRzfuH6l/UAvCPAPUo3665Nk2wLaZU3x+TLHKVzIz33+sbJqbtrYoC3KD4/uVOr2Zp+L0LySezP9OHV9yA==
+      }
+
   sucrase@3.35.1:
     resolution:
       {
@@ -10329,6 +11007,13 @@ packages:
         integrity: sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw==
       }
 
+  ts-dedent@2.3.0:
+    resolution:
+      {
+        integrity: sha512-JfJeIHke7y2egdGGgRAvpCwYFUsHlM2gPcrVOxFkznt/4uzQ7HFmvE63iFHVLBJNDuyDOQgijDK/tXH/f6Msjg==
+      }
+    engines: { node: ">=6.10" }
+
   ts-interface-checker@0.1.13:
     resolution:
       {
@@ -10568,6 +11253,13 @@ packages:
       {
         integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==
       }
+
+  uuid@14.0.1:
+    resolution:
+      {
+        integrity: sha512-6ZxzVpzDXDa3bJWaHilVayA+BH/1zmxCJoVgvmqJnid/gPoKHxUrS/aC/T6LGQtNHT+XHG9fXPJB4d+IrU30Ew==
+      }
+    hasBin: true
 
   validate-npm-package-name@7.0.2:
     resolution:
@@ -11052,6 +11744,11 @@ snapshots:
 
   "@adobe/css-tools@4.5.0": {}
 
+  "@antfu/install-pkg@1.1.0":
+    dependencies:
+      package-manager-detector: 1.7.0
+      tinyexec: 1.1.2
+
   "@anthropic-ai/claude-agent-sdk-darwin-arm64@0.3.201":
     optional: true
 
@@ -11386,6 +12083,8 @@ snapshots:
       "@babel/helper-string-parser": 7.29.7
       "@babel/helper-validator-identifier": 7.29.7
 
+  "@braintree/sanitize-url@7.1.2": {}
+
   "@changesets/apply-release-plan@7.1.1":
     dependencies:
       "@changesets/config": 3.1.4
@@ -11528,6 +12227,8 @@ snapshots:
       fs-extra: 7.0.1
       human-id: 4.1.3
       prettier: 2.8.8
+
+  "@chevrotain/types@11.1.2": {}
 
   "@csstools/color-helpers@6.0.2": {}
 
@@ -11983,6 +12684,14 @@ snapshots:
     dependencies:
       hono: 4.12.26
 
+  "@iconify/types@2.0.0": {}
+
+  "@iconify/utils@3.1.4":
+    dependencies:
+      "@antfu/install-pkg": 1.1.0
+      "@iconify/types": 2.0.0
+      import-meta-resolve: 4.2.0
+
   "@inquirer/external-editor@1.0.3(@types/node@24.12.4)":
     dependencies:
       chardet: 2.1.1
@@ -12045,6 +12754,10 @@ snapshots:
       fs-extra: 8.1.0
       globby: 11.1.0
       read-yaml-file: 1.1.0
+
+  "@mermaid-js/parser@1.2.0":
+    dependencies:
+      "@chevrotain/types": 11.1.2
 
   "@modelcontextprotocol/sdk@1.29.0(zod@3.25.76)":
     dependencies:
@@ -13377,8 +14090,9 @@ snapshots:
       minimatch: 10.2.5
       path-browserify: 1.0.1
 
-  "@tutti-os/infra@0.1.0(react@19.2.6)":
+  "@tutti-os/infra@0.1.0(lodash-es@4.18.1)(react@19.2.6)":
     optionalDependencies:
+      lodash-es: 4.18.1
       react: 19.2.6
 
   "@tutti-os/rrt-app@0.0.6":
@@ -13451,6 +14165,123 @@ snapshots:
       "@types/deep-eql": 4.0.2
       assertion-error: 2.0.1
 
+  "@types/d3-array@3.2.2": {}
+
+  "@types/d3-axis@3.0.6":
+    dependencies:
+      "@types/d3-selection": 3.0.11
+
+  "@types/d3-brush@3.0.6":
+    dependencies:
+      "@types/d3-selection": 3.0.11
+
+  "@types/d3-chord@3.0.6": {}
+
+  "@types/d3-color@3.1.3": {}
+
+  "@types/d3-contour@3.0.6":
+    dependencies:
+      "@types/d3-array": 3.2.2
+      "@types/geojson": 7946.0.16
+
+  "@types/d3-delaunay@6.0.4": {}
+
+  "@types/d3-dispatch@3.0.7": {}
+
+  "@types/d3-drag@3.0.7":
+    dependencies:
+      "@types/d3-selection": 3.0.11
+
+  "@types/d3-dsv@3.0.7": {}
+
+  "@types/d3-ease@3.0.2": {}
+
+  "@types/d3-fetch@3.0.7":
+    dependencies:
+      "@types/d3-dsv": 3.0.7
+
+  "@types/d3-force@3.0.10": {}
+
+  "@types/d3-format@3.0.4": {}
+
+  "@types/d3-geo@3.1.0":
+    dependencies:
+      "@types/geojson": 7946.0.16
+
+  "@types/d3-hierarchy@3.1.7": {}
+
+  "@types/d3-interpolate@3.0.4":
+    dependencies:
+      "@types/d3-color": 3.1.3
+
+  "@types/d3-path@3.1.1": {}
+
+  "@types/d3-polygon@3.0.2": {}
+
+  "@types/d3-quadtree@3.0.6": {}
+
+  "@types/d3-random@3.0.4": {}
+
+  "@types/d3-scale-chromatic@3.1.0": {}
+
+  "@types/d3-scale@4.0.9":
+    dependencies:
+      "@types/d3-time": 3.0.4
+
+  "@types/d3-selection@3.0.11": {}
+
+  "@types/d3-shape@3.1.8":
+    dependencies:
+      "@types/d3-path": 3.1.1
+
+  "@types/d3-time-format@4.0.3": {}
+
+  "@types/d3-time@3.0.4": {}
+
+  "@types/d3-timer@3.0.2": {}
+
+  "@types/d3-transition@3.0.9":
+    dependencies:
+      "@types/d3-selection": 3.0.11
+
+  "@types/d3-zoom@3.0.8":
+    dependencies:
+      "@types/d3-interpolate": 3.0.4
+      "@types/d3-selection": 3.0.11
+
+  "@types/d3@7.4.3":
+    dependencies:
+      "@types/d3-array": 3.2.2
+      "@types/d3-axis": 3.0.6
+      "@types/d3-brush": 3.0.6
+      "@types/d3-chord": 3.0.6
+      "@types/d3-color": 3.1.3
+      "@types/d3-contour": 3.0.6
+      "@types/d3-delaunay": 6.0.4
+      "@types/d3-dispatch": 3.0.7
+      "@types/d3-drag": 3.0.7
+      "@types/d3-dsv": 3.0.7
+      "@types/d3-ease": 3.0.2
+      "@types/d3-fetch": 3.0.7
+      "@types/d3-force": 3.0.10
+      "@types/d3-format": 3.0.4
+      "@types/d3-geo": 3.1.0
+      "@types/d3-hierarchy": 3.1.7
+      "@types/d3-interpolate": 3.0.4
+      "@types/d3-path": 3.1.1
+      "@types/d3-polygon": 3.0.2
+      "@types/d3-quadtree": 3.0.6
+      "@types/d3-random": 3.0.4
+      "@types/d3-scale": 4.0.9
+      "@types/d3-scale-chromatic": 3.1.0
+      "@types/d3-selection": 3.0.11
+      "@types/d3-shape": 3.1.8
+      "@types/d3-time": 3.0.4
+      "@types/d3-time-format": 4.0.3
+      "@types/d3-timer": 3.0.2
+      "@types/d3-transition": 3.0.9
+      "@types/d3-zoom": 3.0.8
+
   "@types/debug@4.1.13":
     dependencies:
       "@types/ms": 2.1.0
@@ -13466,6 +14297,8 @@ snapshots:
   "@types/fs-extra@9.0.13":
     dependencies:
       "@types/node": 24.12.4
+
+  "@types/geojson@7946.0.16": {}
 
   "@types/hast@3.0.4":
     dependencies:
@@ -13587,6 +14420,11 @@ snapshots:
       "@typescript/native-preview-win32-x64": 7.0.0-dev.20260617.2
 
   "@ungap/structured-clone@1.3.1": {}
+
+  "@upsetjs/venn.js@2.0.0":
+    optionalDependencies:
+      d3-selection: 3.0.0
+      d3-transition: 3.0.1(d3-selection@3.0.0)
 
   "@vitejs/plugin-react@4.7.0(vite@6.4.2(@types/node@24.12.4)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.22.3)(yaml@2.9.0))":
     dependencies:
@@ -14105,6 +14943,10 @@ snapshots:
 
   commander@5.1.0: {}
 
+  commander@7.2.0: {}
+
+  commander@8.3.0: {}
+
   commander@9.5.0:
     optional: true
 
@@ -14151,6 +14993,14 @@ snapshots:
       object-assign: 4.1.1
       vary: 1.1.2
 
+  cose-base@1.0.3:
+    dependencies:
+      layout-base: 1.0.2
+
+  cose-base@2.2.0:
+    dependencies:
+      layout-base: 2.0.1
+
   cosmiconfig@9.0.2(typescript@5.9.3):
     dependencies:
       env-paths: 2.2.1
@@ -14192,12 +15042,198 @@ snapshots:
 
   csstype@3.2.3: {}
 
+  cytoscape-cose-bilkent@4.1.0(cytoscape@3.34.0):
+    dependencies:
+      cose-base: 1.0.3
+      cytoscape: 3.34.0
+
+  cytoscape-fcose@2.2.0(cytoscape@3.34.0):
+    dependencies:
+      cose-base: 2.2.0
+      cytoscape: 3.34.0
+
+  cytoscape@3.34.0: {}
+
+  d3-array@2.12.1:
+    dependencies:
+      internmap: 1.0.1
+
+  d3-array@3.2.4:
+    dependencies:
+      internmap: 2.0.3
+
+  d3-axis@3.0.0: {}
+
+  d3-brush@3.0.0:
+    dependencies:
+      d3-dispatch: 3.0.1
+      d3-drag: 3.0.0
+      d3-interpolate: 3.0.1
+      d3-selection: 3.0.0
+      d3-transition: 3.0.1(d3-selection@3.0.0)
+
+  d3-chord@3.0.1:
+    dependencies:
+      d3-path: 3.1.0
+
+  d3-color@3.1.0: {}
+
+  d3-contour@4.0.2:
+    dependencies:
+      d3-array: 3.2.4
+
+  d3-delaunay@6.0.4:
+    dependencies:
+      delaunator: 5.1.0
+
+  d3-dispatch@3.0.1: {}
+
+  d3-drag@3.0.0:
+    dependencies:
+      d3-dispatch: 3.0.1
+      d3-selection: 3.0.0
+
+  d3-dsv@3.0.1:
+    dependencies:
+      commander: 7.2.0
+      iconv-lite: 0.6.3
+      rw: 1.3.3
+
+  d3-ease@3.0.1: {}
+
+  d3-fetch@3.0.1:
+    dependencies:
+      d3-dsv: 3.0.1
+
+  d3-force@3.0.0:
+    dependencies:
+      d3-dispatch: 3.0.1
+      d3-quadtree: 3.0.1
+      d3-timer: 3.0.1
+
+  d3-format@3.1.2: {}
+
+  d3-geo@3.1.1:
+    dependencies:
+      d3-array: 3.2.4
+
+  d3-hierarchy@3.1.2: {}
+
+  d3-interpolate@3.0.1:
+    dependencies:
+      d3-color: 3.1.0
+
+  d3-path@1.0.9: {}
+
+  d3-path@3.1.0: {}
+
+  d3-polygon@3.0.1: {}
+
+  d3-quadtree@3.0.1: {}
+
+  d3-random@3.0.1: {}
+
+  d3-sankey@0.12.3:
+    dependencies:
+      d3-array: 2.12.1
+      d3-shape: 1.3.7
+
+  d3-scale-chromatic@3.1.0:
+    dependencies:
+      d3-color: 3.1.0
+      d3-interpolate: 3.0.1
+
+  d3-scale@4.0.2:
+    dependencies:
+      d3-array: 3.2.4
+      d3-format: 3.1.2
+      d3-interpolate: 3.0.1
+      d3-time: 3.1.0
+      d3-time-format: 4.1.0
+
+  d3-selection@3.0.0: {}
+
+  d3-shape@1.3.7:
+    dependencies:
+      d3-path: 1.0.9
+
+  d3-shape@3.2.0:
+    dependencies:
+      d3-path: 3.1.0
+
+  d3-time-format@4.1.0:
+    dependencies:
+      d3-time: 3.1.0
+
+  d3-time@3.1.0:
+    dependencies:
+      d3-array: 3.2.4
+
+  d3-timer@3.0.1: {}
+
+  d3-transition@3.0.1(d3-selection@3.0.0):
+    dependencies:
+      d3-color: 3.1.0
+      d3-dispatch: 3.0.1
+      d3-ease: 3.0.1
+      d3-interpolate: 3.0.1
+      d3-selection: 3.0.0
+      d3-timer: 3.0.1
+
+  d3-zoom@3.0.0:
+    dependencies:
+      d3-dispatch: 3.0.1
+      d3-drag: 3.0.0
+      d3-interpolate: 3.0.1
+      d3-selection: 3.0.0
+      d3-transition: 3.0.1(d3-selection@3.0.0)
+
+  d3@7.9.0:
+    dependencies:
+      d3-array: 3.2.4
+      d3-axis: 3.0.0
+      d3-brush: 3.0.0
+      d3-chord: 3.0.1
+      d3-color: 3.1.0
+      d3-contour: 4.0.2
+      d3-delaunay: 6.0.4
+      d3-dispatch: 3.0.1
+      d3-drag: 3.0.0
+      d3-dsv: 3.0.1
+      d3-ease: 3.0.1
+      d3-fetch: 3.0.1
+      d3-force: 3.0.0
+      d3-format: 3.1.2
+      d3-geo: 3.1.1
+      d3-hierarchy: 3.1.2
+      d3-interpolate: 3.0.1
+      d3-path: 3.1.0
+      d3-polygon: 3.0.1
+      d3-quadtree: 3.0.1
+      d3-random: 3.0.1
+      d3-scale: 4.0.2
+      d3-scale-chromatic: 3.1.0
+      d3-selection: 3.0.0
+      d3-shape: 3.2.0
+      d3-time: 3.1.0
+      d3-time-format: 4.1.0
+      d3-timer: 3.0.1
+      d3-transition: 3.0.1(d3-selection@3.0.0)
+      d3-zoom: 3.0.0
+
+  dagre-d3-es@7.0.14:
+    dependencies:
+      d3: 7.9.0
+      lodash-es: 4.18.1
+
   data-uri-to-buffer@4.0.1: {}
 
   data-urls@6.0.1:
     dependencies:
       whatwg-mimetype: 5.0.0
       whatwg-url: 15.1.0
+
+  dayjs@1.11.21: {}
 
   debounce-fn@4.0.0:
     dependencies:
@@ -14251,6 +15287,10 @@ snapshots:
     optional: true
 
   defu@6.1.7: {}
+
+  delaunator@5.1.0:
+    dependencies:
+      robust-predicates: 3.0.3
 
   delayed-stream@1.0.0: {}
 
@@ -14314,6 +15354,10 @@ snapshots:
   dom-accessibility-api@0.6.3: {}
 
   dompurify@3.2.7:
+    optionalDependencies:
+      "@types/trusted-types": 2.0.7
+
+  dompurify@3.4.12:
     optionalDependencies:
       "@types/trusted-types": 2.0.7
 
@@ -14476,6 +15520,8 @@ snapshots:
       get-intrinsic: 1.3.0
       has-tostringtag: 1.0.2
       hasown: 2.0.3
+
+  es-toolkit@1.49.0: {}
 
   es6-error@4.1.1:
     optional: true
@@ -14919,6 +15965,8 @@ snapshots:
 
   graceful-fs@4.2.11: {}
 
+  hachure-fill@0.5.2: {}
+
   has-flag@4.0.0: {}
 
   has-property-descriptors@1.0.2:
@@ -15049,6 +16097,8 @@ snapshots:
       parent-module: 1.0.1
       resolve-from: 4.0.0
 
+  import-meta-resolve@4.2.0: {}
+
   indent-string@4.0.0: {}
 
   inflight@1.0.6:
@@ -15059,6 +16109,10 @@ snapshots:
   inherits@2.0.4: {}
 
   inline-style-parser@0.2.7: {}
+
+  internmap@1.0.1: {}
+
+  internmap@2.0.3: {}
 
   ip-address@10.2.0: {}
 
@@ -15234,13 +16288,23 @@ snapshots:
     optionalDependencies:
       graceful-fs: 4.2.11
 
+  katex@0.16.47:
+    dependencies:
+      commander: 8.3.0
+
   keyv@4.5.4:
     dependencies:
       json-buffer: 3.0.1
 
+  khroma@2.1.0: {}
+
   kleur@3.0.3: {}
 
   kleur@4.1.5: {}
+
+  layout-base@1.0.2: {}
+
+  layout-base@2.0.1: {}
 
   lazy-val@1.0.5: {}
 
@@ -15327,6 +16391,8 @@ snapshots:
     dependencies:
       p-locate: 4.1.0
 
+  lodash-es@4.18.1: {}
+
   lodash.escaperegexp@4.1.2: {}
 
   lodash.isequal@4.5.0: {}
@@ -15381,6 +16447,8 @@ snapshots:
   markdown-table@3.0.4: {}
 
   marked@14.0.0: {}
+
+  marked@16.4.2: {}
 
   matcher@3.0.0:
     dependencies:
@@ -15551,6 +16619,30 @@ snapshots:
   merge-stream@2.0.0: {}
 
   merge2@1.4.1: {}
+
+  mermaid@11.16.0:
+    dependencies:
+      "@braintree/sanitize-url": 7.1.2
+      "@iconify/utils": 3.1.4
+      "@mermaid-js/parser": 1.2.0
+      "@types/d3": 7.4.3
+      "@upsetjs/venn.js": 2.0.0
+      cytoscape: 3.34.0
+      cytoscape-cose-bilkent: 4.1.0(cytoscape@3.34.0)
+      cytoscape-fcose: 2.2.0(cytoscape@3.34.0)
+      d3: 7.9.0
+      d3-sankey: 0.12.3
+      dagre-d3-es: 7.0.14
+      dayjs: 1.11.21
+      dompurify: 3.4.12
+      es-toolkit: 1.49.0
+      katex: 0.16.47
+      khroma: 2.1.0
+      marked: 16.4.2
+      roughjs: 4.6.6
+      stylis: 4.4.0
+      ts-dedent: 2.3.0
+      uuid: 14.0.1
 
   meshoptimizer@1.1.1: {}
 
@@ -16032,6 +17124,8 @@ snapshots:
     dependencies:
       quansync: 0.2.11
 
+  package-manager-detector@1.7.0: {}
+
   parent-module@1.0.1:
     dependencies:
       callsites: 3.1.0
@@ -16062,6 +17156,8 @@ snapshots:
   parseurl@1.3.3: {}
 
   path-browserify@1.0.1: {}
+
+  path-data-parser@0.1.0: {}
 
   path-exists@3.0.0: {}
 
@@ -16127,6 +17223,13 @@ snapshots:
       base64-js: 1.5.1
       xmlbuilder: 15.1.1
     optional: true
+
+  points-on-curve@0.2.0: {}
+
+  points-on-path@0.2.1:
+    dependencies:
+      path-data-parser: 0.1.0
+      points-on-curve: 0.2.0
 
   postcss-load-config@6.0.1(jiti@2.7.0)(postcss@8.5.15)(tsx@4.22.3)(yaml@2.9.0):
     dependencies:
@@ -16547,6 +17650,8 @@ snapshots:
       sprintf-js: 1.1.3
     optional: true
 
+  robust-predicates@3.0.3: {}
+
   rollup@4.60.4:
     dependencies:
       "@types/estree": 1.0.8
@@ -16580,6 +17685,13 @@ snapshots:
 
   rope-sequence@1.3.4: {}
 
+  roughjs@4.6.6:
+    dependencies:
+      hachure-fill: 0.5.2
+      path-data-parser: 0.1.0
+      points-on-curve: 0.2.0
+      points-on-path: 0.2.1
+
   router@2.2.0:
     dependencies:
       debug: 4.4.3
@@ -16595,6 +17707,8 @@ snapshots:
   run-parallel@1.2.0:
     dependencies:
       queue-microtask: 1.2.3
+
+  rw@1.3.3: {}
 
   safer-buffer@2.1.2: {}
 
@@ -16869,6 +17983,8 @@ snapshots:
     dependencies:
       inline-style-parser: 0.2.7
 
+  stylis@4.4.0: {}
+
   sucrase@3.35.1:
     dependencies:
       "@jridgewell/gen-mapping": 0.3.13
@@ -16995,6 +18111,8 @@ snapshots:
       utf8-byte-length: 1.0.5
 
   ts-algebra@2.0.0: {}
+
+  ts-dedent@2.3.0: {}
 
   ts-interface-checker@0.1.13: {}
 
@@ -17141,6 +18259,8 @@ snapshots:
   utf8-byte-length@1.0.5: {}
 
   util-deprecate@1.0.2: {}
+
+  uuid@14.0.1: {}
 
   validate-npm-package-name@7.0.2: {}
 


### PR DESCRIPTION
## Summary

- render explicit fenced `mermaid` blocks in AgentGUI transcript Markdown
- lazy-load Mermaid and wait until streaming completes before diagram layout
- use strict rendering settings with bounded text/edge limits and source fallback
- preserve the existing fenced-code copy affordance for non-Mermaid blocks
- document the supported syntax and rendering boundary

## Why

AgentGUI previously displayed Mermaid flowchart source as an ordinary code block, so architecture and delivery flows were difficult to read in conversation transcripts.

## User impact

Agent responses can now include diagrams using a fenced `mermaid` block. Invalid or incomplete diagrams remain readable as source instead of leaving an empty transcript row.

## Validation

- `pnpm check:full`
- `pnpm --filter @tutti-os/agent-gui test` (129 files, 2244 tests)
- `pnpm --filter @tutti-os/agent-gui typecheck`
- `pnpm --filter @tutti-os/agent-gui build`
- `pnpm --filter @tutti-os/desktop build`
- `pnpm lint:ts`
- `pnpm check:i18n`
- `pnpm check:agent-activity-runtime-boundaries`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Render Mermaid diagrams in AgentGUI transcripts to make architecture and flow visuals readable. Fenced `mermaid` code blocks now render after streaming completes, with strict settings and a safe source fallback.

- **New Features**
  - Render fenced `mermaid` blocks as diagrams in transcript Markdown.
  - Lazy-load `mermaid` and defer layout until streaming ends.
  - Strict mode (`securityLevel: "strict"`, HTML labels off, bounded text/edge limits) with source shown on errors.
  - Keep existing copy affordance for non-`mermaid` code blocks; add i18n for rendering status and failure.

- **Dependencies**
  - Added `mermaid@11.16.0`.

<sup>Written for commit 9324c189b8bd86bb1e5a7853b319408b60954cc2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tutti-os/tutti/pull/1083?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

