### PR TITLE
fix(agent-gui): simplify session sorting by user turn time

### DIFF
--- a/docs/architecture/agent-gui-node.md
+++ b/docs/architecture/agent-gui-node.md
@@ -47,6 +47,12 @@ turn and may contain many settled turns. Running, waiting, completed, failed,
 and canceled are turn lifecycle states; they must not be copied onto the
 session as a competing lifecycle field.
 
+Conversation lists order a session by the latest user turn: each turn's time is
+the earliest user message in that turn, and the session time is the maximum of
+those turn times. The renderer uses the projected latest turn directly rather
+than loading message history just to calculate this key. A session with no user
+message uses its creation time.
+
 Commands that cross process or persistence boundaries use a saga/outbox flow:
 
 ```text

--- a/packages/agent/gui/agent-gui/agentGuiNode/model/agentGuiConversationModel.spec.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/model/agentGuiConversationModel.spec.ts
@@ -232,6 +232,7 @@ describe("agentGuiConversationModel", () => {
           provider: "codex",
           sessionOrigin: AGENT_GUI_RUNTIME_SESSION_ORIGIN,
           title: "Runtime Codex",
+          createdAtUnixMs: 1,
           updatedAtUnixMs: 30
         }),
         workspaceAgentSession({
@@ -239,6 +240,7 @@ describe("agentGuiConversationModel", () => {
           provider: "codex",
           sessionOrigin: "WORKSPACE_AGENT_SESSION_ORIGIN_UNKNOWN",
           title: "Unknown Origin Codex",
+          createdAtUnixMs: 2,
           updatedAtUnixMs: 40
         }),
         workspaceAgentSession({

--- a/packages/agent/gui/agent-message-center/workspaceAgentMessageCenterEngineModel.ts
+++ b/packages/agent/gui/agent-message-center/workspaceAgentMessageCenterEngineModel.ts
@@ -42,6 +42,7 @@ export function buildWorkspaceAgentMessageCenterModelFromEngine(
         : null;
       return buildWorkspaceAgentMessageCenterItem({
         session: consumer.session,
+        latestTurn: consumer.latestTurn,
         messages: sessionMessages(snapshot.sessionMessagesById, consumer),
         status: consumer.displayStatus,
         needsAttention,

--- a/packages/agent/gui/agent-message-center/workspaceAgentMessageCenterModel.ts
+++ b/packages/agent/gui/agent-message-center/workspaceAgentMessageCenterModel.ts
@@ -93,6 +93,7 @@ export interface WorkspaceAgentMessageCenterPromptFallbackLabels {
 
 export interface BuildWorkspaceAgentMessageCenterItemInput {
   session: WorkspaceAgentMessageCenterSession;
+  latestTurn?: WorkspaceAgentConsumerSession["latestTurn"] | null;
   messages: readonly AgentActivityMessage[];
   status: WorkspaceAgentActivityStatus;
   needsAttention: AgentActivityNeedsAttentionItem | null;
@@ -107,6 +108,7 @@ type WorkspaceAgentMessageCenterSession =
 
 export function buildWorkspaceAgentMessageCenterItem({
   session,
+  latestTurn,
   messages,
   status,
   needsAttention,
@@ -153,8 +155,9 @@ export function buildWorkspaceAgentMessageCenterItem({
     needsAttentionKind: needsAttention?.kind ?? null,
     needsAttentionSummary: needsAttention?.summary ?? null,
     latestTurnOutcome,
-    sortTimeUnixMs: resolveWorkspaceAgentSessionSortTimeUnixMs(session, {
-      messages
+    sortTimeUnixMs: resolveWorkspaceAgentSessionSortTimeUnixMs({
+      ...session,
+      latestTurn
     })
   };
 }

--- a/packages/agent/gui/shared/workspaceAgentActivityListProjection.ts
+++ b/packages/agent/gui/shared/workspaceAgentActivityListProjection.ts
@@ -57,10 +57,7 @@ export function buildWorkspaceAgentActivityListViewModel(
       const agentProvider = resolveProvider(session, presence);
       const agentName = workspaceAgentProviderLabel(agentProvider);
       const resolvedSortTimeUnixMs = resolveWorkspaceAgentSessionSortTimeUnixMs(
-        session,
-        {
-          messages
-        }
+        session
       );
       const latestActivity = resolveLatestActivity(messages, status, {
         agentName,

--- a/packages/agent/gui/shared/workspaceAgentActivityListViewModel.spec.ts
+++ b/packages/agent/gui/shared/workspaceAgentActivityListViewModel.spec.ts
@@ -1027,6 +1027,7 @@ describe("buildWorkspaceAgentActivityListViewModel", () => {
           providerSessionId: "provider-20",
           cwd: "/repo",
           status: "completed",
+          createdAtUnixMs: 1_000,
           title: "产出 Landing 页面信息设计文档"
         },
         {
@@ -1037,6 +1038,7 @@ describe("buildWorkspaceAgentActivityListViewModel", () => {
           providerSessionId: "provider-21",
           cwd: "/repo",
           status: "failed",
+          createdAtUnixMs: 2_000,
           title: "Run failing issue"
         }
       ]
@@ -2195,6 +2197,7 @@ describe("buildWorkspaceAgentActivityListViewModel", () => {
           providerSessionId: "provider-22",
           cwd: "/repo",
           status: "completed",
+          createdAtUnixMs: 1_000,
           title: "Finished issue"
         },
         {
@@ -2205,6 +2208,7 @@ describe("buildWorkspaceAgentActivityListViewModel", () => {
           providerSessionId: "provider-23",
           cwd: "/repo",
           status: "canceled",
+          createdAtUnixMs: 2_000,
           title: "Canceled issue"
         },
         {
@@ -2215,6 +2219,7 @@ describe("buildWorkspaceAgentActivityListViewModel", () => {
           providerSessionId: "provider-24",
           cwd: "/repo",
           status: "canceled",
+          createdAtUnixMs: 3_000,
           title: "Canceled issue"
         }
       ]
@@ -2677,6 +2682,13 @@ describe("buildWorkspaceAgentActivityListViewModel", () => {
           providerSessionId: "provider-older-session-new-turn",
           cwd: "/repo",
           effectiveStatus: "working",
+          latestTurn: {
+            agentSessionId: "older-session-new-turn",
+            phase: "running",
+            startedAtUnixMs: 9000,
+            turnId: "turn-new",
+            updatedAtUnixMs: 9000
+          },
           updatedAtUnixMs: 9000,
           createdAtUnixMs: 1000,
           title: "Older session new turn"
@@ -2689,6 +2701,13 @@ describe("buildWorkspaceAgentActivityListViewModel", () => {
           providerSessionId: "provider-newer-session-old-turn",
           cwd: "/repo",
           effectiveStatus: "working",
+          latestTurn: {
+            agentSessionId: "newer-session-old-turn",
+            phase: "running",
+            startedAtUnixMs: 3000,
+            turnId: "turn-old",
+            updatedAtUnixMs: 3000
+          },
           updatedAtUnixMs: 8000,
           createdAtUnixMs: 2000,
           title: "Newer session old turn"
@@ -2727,7 +2746,7 @@ describe("buildWorkspaceAgentActivityListViewModel", () => {
     ]);
   });
 
-  it("falls back to session update time when messages have not been loaded", () => {
+  it("falls back to session creation time when messages have not been loaded", () => {
     const snapshot = {
       presences: [],
       sessions: [
@@ -2761,8 +2780,8 @@ describe("buildWorkspaceAgentActivityListViewModel", () => {
     const view = buildWorkspaceAgentActivityListViewModel(snapshot);
 
     expect(view.activities.map((activity) => activity.sessionId)).toEqual([
-      "created-earlier-updated-later",
-      "created-later-updated-earlier"
+      "created-later-updated-earlier",
+      "created-earlier-updated-later"
     ]);
   });
 

--- a/packages/agent/gui/shared/workspaceAgentSessionSortTime.spec.ts
+++ b/packages/agent/gui/shared/workspaceAgentSessionSortTime.spec.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from "vitest";
+import { resolveWorkspaceAgentSessionSortTimeUnixMs } from "./workspaceAgentSessionSortTime";
+
+describe("resolveWorkspaceAgentSessionSortTimeUnixMs", () => {
+  it("uses the canonical latest turn start", () => {
+    const sortTime = resolveWorkspaceAgentSessionSortTimeUnixMs(
+      {
+        createdAtUnixMs: 100,
+        latestTurn: { startedAtUnixMs: 250 }
+      }
+    );
+
+    expect(sortTime).toBe(250);
+  });
+
+  it("falls back to session creation time when there is no user message", () => {
+    const session = {
+      agentSessionId: "session-1",
+      createdAtUnixMs: 400,
+      endedAtUnixMs: 9_000,
+      latestTurn: null,
+      startedAtUnixMs: 500,
+      updatedAtUnixMs: 8_000
+    };
+
+    expect(resolveWorkspaceAgentSessionSortTimeUnixMs(session)).toBe(400);
+  });
+
+  it("falls back to session creation time before messages are loaded", () => {
+    const session = { createdAtUnixMs: 600, updatedAtUnixMs: 9_000 };
+    expect(resolveWorkspaceAgentSessionSortTimeUnixMs(session)).toBe(600);
+  });
+});

--- a/packages/agent/gui/shared/workspaceAgentSessionSortTime.ts
+++ b/packages/agent/gui/shared/workspaceAgentSessionSortTime.ts
@@ -1,109 +1,20 @@
 export interface WorkspaceAgentSessionSortTimeSession {
   createdAtUnixMs?: number;
-  endedAtUnixMs?: number | null;
-  id?: number;
-  agentSessionId?: string;
-  providerSessionId?: string | null;
-  startedAtUnixMs?: number;
-  updatedAtUnixMs?: number;
+  latestTurn?: WorkspaceAgentSessionSortTimeTurn | null;
 }
 
-export interface WorkspaceAgentSessionSortTimeMessage {
-  agentSessionId?: string;
-  occurredAtUnixMs?: number;
-  role?: string;
-  turnId?: string | null;
-}
-
-export interface WorkspaceAgentSessionSortTimeContext {
-  messages?: readonly WorkspaceAgentSessionSortTimeMessage[];
+export interface WorkspaceAgentSessionSortTimeTurn {
+  startedAtUnixMs: number;
 }
 
 export function resolveWorkspaceAgentSessionSortTimeUnixMs(
-  session: WorkspaceAgentSessionSortTimeSession,
-  context: WorkspaceAgentSessionSortTimeContext = {}
+  session: WorkspaceAgentSessionSortTimeSession
 ): number {
-  const hasSortContext = hasWorkspaceAgentSessionSortContext(context);
-  const fallbackUpdatedAtUnixMs = hasSortContext
-    ? null
-    : positiveNumber(session.updatedAtUnixMs);
   return (
-    latestUserTurnStartTimeUnixMs(session, context) ??
-    positiveNumber(session.endedAtUnixMs) ??
-    fallbackUpdatedAtUnixMs ??
-    positiveNumber(session.startedAtUnixMs) ??
+    positiveNumber(session.latestTurn?.startedAtUnixMs) ??
     positiveNumber(session.createdAtUnixMs) ??
-    positiveNumber(session.id) ??
     0
   );
-}
-
-function hasWorkspaceAgentSessionSortContext(
-  context: WorkspaceAgentSessionSortTimeContext
-): boolean {
-  return Boolean(context.messages?.length);
-}
-
-function latestUserTurnStartTimeUnixMs(
-  session: WorkspaceAgentSessionSortTimeSession,
-  context: WorkspaceAgentSessionSortTimeContext
-): number | null {
-  const sessionIds = new Set(
-    [session.agentSessionId, session.providerSessionId]
-      .map((value) => value?.trim())
-      .filter((value): value is string => Boolean(value))
-  );
-  const startsByTurnId = new Map<string, number>();
-  for (const message of context.messages ?? []) {
-    if (!matchesSession(message.agentSessionId, sessionIds)) {
-      continue;
-    }
-    const turnId = message.turnId?.trim();
-    if (!turnId) {
-      continue;
-    }
-    const role = normalizeToken(message.role);
-    if (role === "user") {
-      const startedAtUnixMs = positiveNumber(message.occurredAtUnixMs);
-      if (startedAtUnixMs !== null) {
-        startsByTurnId.set(
-          turnId,
-          minNullable(startsByTurnId.get(turnId) ?? null, startedAtUnixMs)!
-        );
-      }
-    }
-  }
-  let latest: number | null = null;
-  for (const startedAtUnixMs of startsByTurnId.values()) {
-    latest =
-      latest === null ? startedAtUnixMs : Math.max(latest, startedAtUnixMs);
-  }
-  return latest;
-}
-
-function matchesSession(
-  agentSessionId: string | undefined,
-  sessionIds: ReadonlySet<string>
-): boolean {
-  if (sessionIds.size === 0) {
-    return true;
-  }
-  const normalized = agentSessionId?.trim();
-  return Boolean(normalized && sessionIds.has(normalized));
-}
-
-function minNullable(left: number | null, right: number | null): number | null {
-  if (left === null) {
-    return right;
-  }
-  if (right === null) {
-    return left;
-  }
-  return Math.min(left, right);
-}
-
-function normalizeToken(value: string | undefined): string {
-  return value?.trim().toLowerCase() ?? "";
 }
 
 function positiveNumber(value: unknown): number | null {


### PR DESCRIPTION
## Summary

- Define one canonical session rail sort key: the latest user turn creation time, falling back to session creation time when no valid user turn exists.
- Compute each turn from its earliest user message and keep the persisted/runtime value monotonic.
- Make turnId mandatory at the write boundary, update SQLite backfill/live aggregation, projections, DTOs, cursor docs, and message-center ordering.
- Remove frontend session-id time fallbacks and add regression coverage.

## Validation

- AgentGUI tests: 147/147 passed
- activity-core tests: 40/40 passed
- Targeted Go tests for workspace, service/agent, API, SQLite, and sort-time runtime paths passed
- pnpm lint:ts passed
- pnpm typecheck passed
- Generated API and boundary checks passed
- git diff --check passed

## Known local limitation

The full Go runtime package still has existing Claude sidecar/transport integration failures in this environment (unsupported sidecar protocol version missing); deterministic sorting tests pass.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Simplifies session list ordering to use the latest user-turn start time with a creation-time fallback. Persists `last_turn_created_at_unix_ms` so the conversation rail and Message Center stay stable and consistent.

- **Refactors**
  - Persist and backfill `last_turn_created_at_unix_ms` in SQLite; resolve sort time from `latestTurn.startedAtUnixMs` with a fallback to `createdAtUnixMs`; remove message-history scans and frontend time fallbacks; pass `latestTurn` through the Message Center and activity list; update docs and tests.
  - Repair interim session schema in `@tutti-os/agent-gui` and shared DTOs: add runtime context and composer defaults, pinned/unread hooks, `resumable`, normalize provider IDs and add `gemini`; update the desktop adapter/host projection.
  - Make `turnId` required on message writes; runtime reporter/controller derives a monotonic user-turn start; add focused TS/Go tests for deterministic sorting.
  - Simplify `@tutti-os/agent-activity-core` by unifying session/message loading and merging; add a shared snapshot projection consumed by Agent GUI and Message Center.

- **Migration**
  - Run DB migrations to add and backfill `last_turn_created_at_unix_ms`.
  - Ensure runtimes emit events with `turnId`; update clients to the new session DTOs as needed.

<sup>Written for commit 136640fe820378d038ffb9778cc5ef12f23c0a20. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tutti-os/tutti/pull/1095?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

