### PR TITLE
fix(desktop): align sidecar smoke protocol with v2

### DIFF
--- a/apps/desktop/scripts/smoke-claude-sdk-sidecar.mjs
+++ b/apps/desktop/scripts/smoke-claude-sdk-sidecar.mjs
@@ -36,7 +36,7 @@ export async function smokeClaudeSDKSidecar({
   });
 
   const send = (request) => {
-    child.stdin.write(`${JSON.stringify({ version: 1, ...request })}\n`);
+    child.stdin.write(`${JSON.stringify({ version: 2, ...request })}\n`);
   };
   const waitForEvent = async (predicate, label) => {
     while (true) {


### PR DESCRIPTION
## Summary

- Send Claude SDK sidecar smoke requests with protocol version 2.
- Align the packaging smoke client with the protocol enforced by the sidecar and daemon.

## Root cause

The sidecar protocol was upgraded from v1 to v2, but the desktop packaging smoke script continued to send v1 requests. The release build therefore failed before signing when its vendored-sidecar smoke check rejected the first request.

## Validation

- `node apps/desktop/scripts/vendor-claude-sdk-sidecar.mjs --include-darwin-native-packages`
- `pnpm --filter @tutti-os/claude-sdk-sidecar test`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update the desktop packaging smoke test to send sidecar requests with protocol version 2. Aligns with the sidecar/daemon protocol and prevents release builds from failing the vendored-sidecar smoke check.

<sup>Written for commit 2382561d21b75f9687cdf11d2c2b50498ab9ea4b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tutti-os/tutti/pull/1096?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

