### PR TITLE
fix(agent-gui): make image draft delete button clickable

### DIFF
--- a/packages/agent/gui/agent-gui/agentGuiNode/AgentComposer.spec.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/AgentComposer.spec.tsx
@@ -5369,6 +5369,7 @@ describe("AgentComposer", () => {
       const removeButton = within(drafts).getByRole("button", {
         name: "移除引用"
       });
+      expect(removeButton).toHaveClass("z-[2]");
       fireEvent.click(removeButton);
       rerender(renderComposer());
 

--- a/packages/agent/gui/agent-gui/agentGuiNode/composer/AgentComposerDraftPreview.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/composer/AgentComposerDraftPreview.tsx
@@ -86,7 +86,7 @@ export function AgentComposerDraftImagePreview({
       ) : null}
       <button
         type="button"
-        className="absolute right-1 top-1 inline-flex size-5 items-center justify-center rounded-full border border-[color-mix(in_srgb,var(--text-primary)_16%,transparent)] bg-[color-mix(in_srgb,var(--background-fronted)_88%,transparent)] text-[var(--text-primary)] opacity-90 shadow-sm transition hover:opacity-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:color-mix(in_srgb,var(--text-primary)_34%,transparent)]"
+        className="absolute right-1 top-1 z-[2] inline-flex size-5 items-center justify-center rounded-full border border-[color-mix(in_srgb,var(--text-primary)_16%,transparent)] bg-[color-mix(in_srgb,var(--background-fronted)_88%,transparent)] text-[var(--text-primary)] opacity-90 shadow-sm transition hover:opacity-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:color-mix(in_srgb,var(--text-primary)_34%,transparent)]"
         aria-label={removeLabel}
         title={removeLabel}
         onClick={() => onRemove(image.id)}


### PR DESCRIPTION
## Summary
- raise the image draft delete button above ZoomableImage's full-size zoom trigger
- add a regression assertion for the stacking order

## Validation
- pnpm --filter @tutti-os/agent-gui test -- AgentComposer.spec.tsx --run
- pnpm check:full

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the image draft delete button in the Agent Composer by raising its z-index above the ZoomableImage overlay, ensuring it’s clickable. Adds a regression test to lock the stacking order.

- **Bug Fixes**
  - Set `z-[2]` on the delete button to sit above the zoom trigger.
  - Test asserts the button has `z-[2]` to prevent regressions.

<sup>Written for commit 690246b24fd77bb12c09f960e212c15cd69f2782. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tutti-os/tutti/pull/1097?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

