### PR TITLE
fix(release): verify prerelease updater metadata

### DIFF
--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -352,14 +352,17 @@ jobs:
             pnpm --filter @tutti-os/desktop build:mac:signed
           fi
 
-      - name: Materialize prerelease updater metadata
+      - name: Verify prerelease updater metadata
         if: ${{ needs.resolve.outputs.release_channel != 'stable' }}
         run: |
-          if [[ ! -f apps/desktop/dist/latest-mac.yml ]]; then
-            echo "latest-mac.yml is required before creating ${TUTTI_DESKTOP_RELEASE_CHANNEL}-mac.yml." >&2
+          # The generic updater provider derives the prerelease channel from
+          # the version, so electron-builder writes rc-mac.yml or beta-mac.yml
+          # directly instead of latest-mac.yml.
+          updater_metadata="apps/desktop/dist/${TUTTI_DESKTOP_RELEASE_CHANNEL}-mac.yml"
+          if [[ ! -f "${updater_metadata}" ]]; then
+            echo "${updater_metadata} is required for the ${TUTTI_DESKTOP_RELEASE_CHANNEL} updater channel." >&2
             exit 1
           fi
-          cp apps/desktop/dist/latest-mac.yml "apps/desktop/dist/${TUTTI_DESKTOP_RELEASE_CHANNEL}-mac.yml"
 
       - name: Upload release artifacts
         uses: actions/upload-artifact@v7

--- a/tools/scripts/desktop-release-config.test.mjs
+++ b/tools/scripts/desktop-release-config.test.mjs
@@ -661,20 +661,21 @@ test("desktop package declares the workspace package manager for electron-builde
   assert.equal(packageJson.packageManager, "pnpm@10.11.0");
 });
 
-test("desktop package generates updater metadata for every release channel", async () => {
+test("desktop package verifies channel-specific prerelease updater metadata", async () => {
   const packageJson = JSON.parse(await readFile(desktopPackagePath, "utf8"));
   const workflow = await readFile(workflowPath, "utf8");
 
   assert.equal(packageJson.build?.generateUpdatesFilesForAllChannels, true);
-  assert.match(workflow, /Materialize prerelease updater metadata/);
+  assert.match(workflow, /Verify prerelease updater metadata/);
   assert.match(
     workflow,
     /needs\.resolve\.outputs\.release_channel\s*!=\s*'stable'/
   );
   assert.match(
     workflow,
-    /cp apps\/desktop\/dist\/latest-mac\.yml "apps\/desktop\/dist\/\$\{TUTTI_DESKTOP_RELEASE_CHANNEL\}-mac\.yml"/
+    /updater_metadata="apps\/desktop\/dist\/\$\{TUTTI_DESKTOP_RELEASE_CHANNEL\}-mac\.yml"/
   );
+  assert.doesNotMatch(workflow, /cp apps\/desktop\/dist\/latest-mac\.yml/);
 });
 
 test("desktop package uses a distinct product identity from tsh desktop", async () => {


### PR DESCRIPTION
## Summary

- Verify the updater metadata generated for the active prerelease channel instead of copying a presumed `latest-mac.yml`.
- Cover the channel-specific contract in the desktop release configuration test.

## Root cause

With the generic updater provider, electron-builder derives `rc` or `beta` from the prerelease version and writes that channel's metadata file directly. The release workflow incorrectly required `latest-mac.yml`, causing the rc.4 release to fail after packaging and notarization succeeded.

## Validation

- `node --test tools/scripts/desktop-release-config.test.mjs`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Verify channel-specific prerelease updater metadata (`rc`/`beta`) in the desktop release workflow to prevent prerelease releases from failing and align with `electron-builder` behavior.

- **Bug Fixes**
  - Workflow now checks for `${TUTTI_DESKTOP_RELEASE_CHANNEL}-mac.yml` and fails if missing instead of copying `latest-mac.yml`.
  - Updated release config test to assert the verification step and block the old copy command.

<sup>Written for commit 22a1e30ac886e8a19ece0a90207096e94b4e0c17. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tutti-os/tutti/pull/1098?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

