### PR TITLE
fix(agent): harden Cursor agent UX around readiness, approvals, and plan limits

### DIFF
--- a/apps/desktop/src/renderer/src/features/workspace-agent/ui/desktopAgentProviderNotReadyRecheck.test.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-agent/ui/desktopAgentProviderNotReadyRecheck.test.ts
@@ -1,0 +1,78 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  activeProviderNotReadyRecheckKey,
+  shouldSuppressAgentProviderNotReadyProjection
+} from "./desktopAgentProviderNotReadyRecheck.ts";
+
+test("activeProviderNotReadyRecheckKey ignores ready and missing statuses", () => {
+  assert.equal(
+    activeProviderNotReadyRecheckKey({
+      availabilityStatus: "ready",
+      provider: "cursor"
+    }),
+    null
+  );
+  assert.equal(
+    activeProviderNotReadyRecheckKey({
+      availabilityStatus: null,
+      provider: "cursor"
+    }),
+    null
+  );
+  assert.equal(
+    activeProviderNotReadyRecheckKey({
+      availabilityStatus: "missing",
+      provider: "cursor"
+    }),
+    null
+  );
+});
+
+test("activeProviderNotReadyRecheckKey keys not-ready statuses per provider", () => {
+  assert.equal(
+    activeProviderNotReadyRecheckKey({
+      availabilityStatus: "auth_required",
+      provider: "cursor"
+    }),
+    "cursor:auth_required"
+  );
+  assert.equal(
+    activeProviderNotReadyRecheckKey({
+      availabilityStatus: "not_installed",
+      provider: "codex"
+    }),
+    "codex:not_installed"
+  );
+});
+
+test("shouldSuppressAgentProviderNotReadyProjection hides notice until recheck settles", () => {
+  assert.equal(
+    shouldSuppressAgentProviderNotReadyProjection({
+      recheckKey: "cursor:auth_required",
+      settledRecheckKey: null
+    }),
+    true
+  );
+  assert.equal(
+    shouldSuppressAgentProviderNotReadyProjection({
+      recheckKey: "cursor:auth_required",
+      settledRecheckKey: "cursor:not_installed"
+    }),
+    true
+  );
+  assert.equal(
+    shouldSuppressAgentProviderNotReadyProjection({
+      recheckKey: "cursor:auth_required",
+      settledRecheckKey: "cursor:auth_required"
+    }),
+    false
+  );
+  assert.equal(
+    shouldSuppressAgentProviderNotReadyProjection({
+      recheckKey: null,
+      settledRecheckKey: null
+    }),
+    false
+  );
+});

--- a/apps/desktop/src/renderer/src/features/workspace-agent/ui/desktopAgentProviderNotReadyRecheck.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-agent/ui/desktopAgentProviderNotReadyRecheck.ts
@@ -1,0 +1,28 @@
+import type { WorkspaceAgentProvider } from "@tutti-os/client-tuttid-ts";
+
+/**
+ * Cached provider-status snapshots can linger as not-ready after startup's
+ * background catalog scan. Switching into that provider (for example Cursor)
+ * would otherwise flash the AgentGUI "connect provider" notice until a later
+ * refresh eventually marks it ready. Recheck once per not-ready availability
+ * key and treat readiness as unknown while that recheck is pending.
+ */
+export function activeProviderNotReadyRecheckKey(input: {
+  availabilityStatus: string | null | undefined;
+  provider: WorkspaceAgentProvider;
+}): string | null {
+  const availability = input.availabilityStatus?.trim() || "missing";
+  if (availability === "ready" || availability === "missing") {
+    return null;
+  }
+  return `${input.provider}:${availability}`;
+}
+
+export function shouldSuppressAgentProviderNotReadyProjection(input: {
+  recheckKey: string | null;
+  settledRecheckKey: string | null;
+}): boolean {
+  return (
+    input.recheckKey !== null && input.settledRecheckKey !== input.recheckKey
+  );
+}

--- a/apps/desktop/src/renderer/src/features/workspace-agent/ui/useDesktopAgentGUIReadiness.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-agent/ui/useDesktopAgentGUIReadiness.ts
@@ -9,6 +9,7 @@ import {
 import type {
   AgentActivityRuntime,
   AgentGUIProvider,
+  AgentGUIProviderReadinessGate,
   AgentGUIProviderReadinessGateAction,
   AgentGUIProps
 } from "@tutti-os/agent-gui";
@@ -31,6 +32,10 @@ import {
 import { projectDesktopAgentProviderReadinessGates } from "../services/internal/desktopAgentProviderReadinessGate.ts";
 import { useAccountService } from "../../workspace-workbench/ui/useAccountService.ts";
 import { isDesktopAgentAccountLoginAction } from "./desktopAgentAccountLoginAction.ts";
+import {
+  activeProviderNotReadyRecheckKey,
+  shouldSuppressAgentProviderNotReadyProjection
+} from "./desktopAgentProviderNotReadyRecheck.ts";
 import { useDesktopManagedAgentsState } from "./useDesktopManagedAgentsState.ts";
 import {
   getEmptyProviderStatusSnapshot,
@@ -84,19 +89,70 @@ export function useDesktopAgentGUIReadiness(input: {
     !providerStatusSnapshot.capturedAt && providerStatusBootstrapSnapshot
       ? providerStatusBootstrapSnapshot
       : providerStatusSnapshot;
-  const effectiveManagedAgentsState = useMemo(
-    () =>
-      !providerStatusSnapshot.capturedAt && providerStatusBootstrapSnapshot
-        ? projectDesktopManagedAgentsStateForAgentGUI(
-            providerStatusBootstrapSnapshot
-          )
-        : managedAgentsState,
-    [
-      managedAgentsState,
-      providerStatusBootstrapSnapshot,
-      providerStatusSnapshot
-    ]
-  );
+  const activeProviderAvailabilityStatus =
+    effectiveProviderStatusSnapshot.statuses.find(
+      (status) => status.provider === provider
+    )?.availability.status ?? null;
+  const activeProviderRecheckKey = activeProviderNotReadyRecheckKey({
+    availabilityStatus: activeProviderAvailabilityStatus,
+    provider
+  });
+  const [settledActiveProviderRecheckKey, setSettledActiveProviderRecheckKey] =
+    useState<string | null>(null);
+  const activeProviderRecheckGenerationRef = useRef(0);
+  const suppressNotReadyProjection =
+    !previewMode &&
+    shouldSuppressAgentProviderNotReadyProjection({
+      recheckKey: activeProviderRecheckKey,
+      settledRecheckKey: settledActiveProviderRecheckKey
+    });
+  useEffect(() => {
+    if (previewMode || !agentProviderStatusService) {
+      setSettledActiveProviderRecheckKey(null);
+      return;
+    }
+    if (activeProviderRecheckKey === null) {
+      setSettledActiveProviderRecheckKey(null);
+      return;
+    }
+    if (settledActiveProviderRecheckKey === activeProviderRecheckKey) {
+      return;
+    }
+    const generation = ++activeProviderRecheckGenerationRef.current;
+    const recheckKey = activeProviderRecheckKey;
+    void agentProviderStatusService.refresh([provider]).finally(() => {
+      if (activeProviderRecheckGenerationRef.current === generation) {
+        setSettledActiveProviderRecheckKey(recheckKey);
+      }
+    });
+    return () => {
+      activeProviderRecheckGenerationRef.current += 1;
+    };
+  }, [
+    activeProviderRecheckKey,
+    agentProviderStatusService,
+    previewMode,
+    provider,
+    settledActiveProviderRecheckKey
+  ]);
+  const effectiveManagedAgentsState = useMemo(() => {
+    if (suppressNotReadyProjection) {
+      // Match the uncaptured-status policy: unknown readiness keeps the
+      // composer usable and hides the false "connect provider" notice while a
+      // stale not-ready cache is being rechecked.
+      return null;
+    }
+    return !providerStatusSnapshot.capturedAt && providerStatusBootstrapSnapshot
+      ? projectDesktopManagedAgentsStateForAgentGUI(
+          providerStatusBootstrapSnapshot
+        )
+      : managedAgentsState;
+  }, [
+    managedAgentsState,
+    providerStatusBootstrapSnapshot,
+    providerStatusSnapshot,
+    suppressNotReadyProjection
+  ]);
   // Activation funnel stage ③ "saw a chattable surface": the agent workbench
   // body is mounted (not a dock preview) and the active provider is ready, so
   // the composer is interactive. reportProviderReady (stage ②) can fire while
@@ -286,20 +342,32 @@ export function useDesktopAgentGUIReadiness(input: {
       workspaceId
     ]
   );
-  const providerReadinessGates = useMemo(
-    () =>
-      previewMode
-        ? null
-        : projectDesktopAgentProviderReadinessGates({
-            snapshot: effectiveProviderStatusSnapshot,
-            onAction: handleProviderReadinessGateAction
-          }),
-    [
-      effectiveProviderStatusSnapshot,
-      handleProviderReadinessGateAction,
-      previewMode
-    ]
-  );
+  const providerReadinessGates = useMemo(() => {
+    if (previewMode) {
+      return null;
+    }
+    const gates = projectDesktopAgentProviderReadinessGates({
+      snapshot: effectiveProviderStatusSnapshot,
+      onAction: handleProviderReadinessGateAction
+    });
+    if (!suppressNotReadyProjection) {
+      return gates;
+    }
+    const checkingGate: AgentGUIProviderReadinessGate = {
+      status: "checking",
+      pendingAction: null
+    };
+    return {
+      ...gates,
+      [provider]: checkingGate
+    };
+  }, [
+    effectiveProviderStatusSnapshot,
+    handleProviderReadinessGateAction,
+    previewMode,
+    provider,
+    suppressNotReadyProjection
+  ]);
   return {
     computerUseStatus,
     effectiveManagedAgentsState,

--- a/docs/architecture/agent-gui-node.md
+++ b/docs/architecture/agent-gui-node.md
@@ -1635,6 +1635,10 @@ User-visible rules:
   change must reload options with the active session settings. ACP owns option
   values and ordering; the relevant locale catalog owns user-visible labels and
   descriptions, including when live runtime options are the fresher source.
+  When a provider does not advertise configurable reasoning (for example
+  Cursor, which embeds effort inside parameterized model ids), the composer
+  must clear draft/default `reasoningEffort` for that target and must not
+  render a stale effort label next to the model trigger.
 - Shift+Tab plan mode is a provider capability, not a frontend allowlist. The
   daemon's typed pre-session composer capabilities and typed live session
   capabilities must both advertise `planMode` before AgentGUI enables the
@@ -1797,17 +1801,17 @@ User-visible rules:
 
 ### Loading State Taxonomy
 
-| Visible state                  | Primary owner                    | Starts when                                                    | Clears when                                                                    |
-| ------------------------------ | -------------------------------- | -------------------------------------------------------------- | ------------------------------------------------------------------------------ |
-| Rail skeleton or empty loading | conversation list query/store    | runtime list load starts                                       | list load resolves or errors                                                   |
-| Selected detail skeleton       | session view store/controller    | active session messages load starts                            | `listSessionMessages` resolves or active session changes                       |
-| Home first-create busy         | controller local create state    | home `startConversation` begins                                | new-session activation succeeds, fails, or is abandoned as stale               |
-| "Connecting conversation"      | existing-session activation      | existing session open/retry calls `activate`                   | activation succeeds, fails, or is abandoned as stale                           |
-| Transcript processing row      | transcript/session projection    | runtime reports working/turn phase                             | runtime reports ready/completed/failed or newer message projection replaces it |
-| Send button spinner            | controller local submit state    | `executePrompt` or approval submit begins                      | command promise settles                                                        |
-| Composer settings loading      | composer options/settings model  | provider options load starts or settings source missing        | options/settings resolve or fallback state is applied                          |
-| Provider setup notice          | desktop provider status adapter  | captured provider status says the active provider is not ready | captured status says provider is ready or user fixes setup                     |
-| Approval response spinner      | controller approval submit state | prompt/approval option submit begins                           | runtime command settles and prompt projection updates                          |
+| Visible state                  | Primary owner                    | Starts when                                                                            | Clears when                                                                    |
+| ------------------------------ | -------------------------------- | -------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------ |
+| Rail skeleton or empty loading | conversation list query/store    | runtime list load starts                                                               | list load resolves or errors                                                   |
+| Selected detail skeleton       | session view store/controller    | active session messages load starts                                                    | `listSessionMessages` resolves or active session changes                       |
+| Home first-create busy         | controller local create state    | home `startConversation` begins                                                        | new-session activation succeeds, fails, or is abandoned as stale               |
+| "Connecting conversation"      | existing-session activation      | existing session open/retry calls `activate`                                           | activation succeeds, fails, or is abandoned as stale                           |
+| Transcript processing row      | transcript/session projection    | runtime reports working/turn phase                                                     | runtime reports ready/completed/failed or newer message projection replaces it |
+| Send button spinner            | controller local submit state    | `executePrompt` or approval submit begins                                              | command promise settles                                                        |
+| Composer settings loading      | composer options/settings model  | provider options load starts or settings source missing                                | options/settings resolve or fallback state is applied                          |
+| Provider setup notice          | desktop provider status adapter  | captured provider status says the active provider is not ready after a settled recheck | captured status says provider is ready or user fixes setup                     |
+| Approval response spinner      | controller approval submit state | prompt/approval option submit begins                                                   | runtime command settles and prompt projection updates                          |
 
 When a loading state is wrong, first identify which row in this table is
 visible. Then debug that owner and clearing condition. Avoid moving a spinner
@@ -1816,6 +1820,11 @@ Desktop restore must not project "not ready" from an uncaptured provider-status
 snapshot. Until the first captured provider status exists, pass unknown provider
 readiness into AgentGUI so startup does not flash a false "configure provider"
 notice before local Codex or other provider detection returns.
+When the active Agent GUI provider already has a cached not-ready status (for
+example a background catalog probe that raced ahead of Cursor auth), desktop
+must refresh that provider once and keep readiness unknown while the recheck is
+pending. Otherwise switching into the provider flashes the setup notice even
+though the composer can already send after auto-connect settles.
 
 ### Error, Retry, And Recovery
 

--- a/docs/conventions/troubleshooting/agent-approvals-subagents.md
+++ b/docs/conventions/troubleshooting/agent-approvals-subagents.md
@@ -37,6 +37,47 @@ Approval gates, plan exits, parent/child event attribution, background agents, a
   [.github/workflows/external-pr-review-gate-review-signal.yml](../../../.github/workflows/external-pr-review-gate-review-signal.yml)
   [.github/workflows/external-pr-review-gate-review-refresh.yml](../../../.github/workflows/external-pr-review-gate-review-refresh.yml)
 
+### Cursor approval card shows only title and options, no command/path detail
+
+- Symptom:
+  A Cursor provider approval prompt renders its title (for example "Cursor
+  requests your authorization") and the allow/reject options, but the detail
+  row that should show the command, file path, or query is empty — unlike the
+  same prompt for Codex or Claude Code.
+- Quick checks:
+  Speak ACP directly to a local `cursor-agent acp` process (initialize,
+  `session/new`, `session/set_mode` to `agent`, then a prompt that requires a
+  shell/file tool) and inspect the raw `session/request_permission` payload.
+  Cursor's permission `toolCall` repeats only `toolCallId`/`title`/`kind`/
+  `status`/`content` for a call that already streamed via an earlier
+  `session/update` `tool_call`; it does not repeat `rawInput`. Compare against
+  the preceding `tool_call` notification for the same `toolCallId`, which does
+  carry `rawInput.command`.
+- Root cause:
+  `normalizedApprovalDisplayInput` only read the permission request's own
+  inline `toolCall`. Codex and Claude Code repeat enough of the original input
+  on their approval-equivalent requests for that to work, but Cursor's ACP
+  implementation does not, so the approval projection had no command/path/
+  query fields to show and the card fell back to title-only.
+- Fix:
+  Track per-turn tool-call state in `acpTurnNormalizer` (already recorded from
+  `tool_call`/`tool_call_update`) and expose it by raw `toolCallId` via
+  `KnownToolCallInput`. `standardACPPermissionRequested` now passes the
+  normalizer through, and `normalizedApprovalDisplayInput` fills any field
+  (`command`, `file_path`, `query`, ...) missing from the permission request's
+  own `toolCall` from that known prior input before giving up. Other ACP-style
+  interactive paths (Codex app-server, Claude SDK) keep passing `nil` for this
+  fallback since they do not need it.
+- Validation:
+  `cd packages/agent/daemon && go test ./runtime/... -run
+TestCursorPermissionRequestFallsBackToKnownToolCallInput`. For a live check,
+  run the same direct ACP probe from Quick checks with a tier-"agent" session
+  and confirm the emitted approval payload's `input` carries the command.
+- References:
+  [acp_turn_normalizer.go](../../../packages/agent/daemon/runtime/acp_turn_normalizer.go)
+  [interactive_projection.go](../../../packages/agent/daemon/runtime/interactive_projection.go)
+  [standard_acp_events.go](../../../packages/agent/daemon/runtime/standard_acp_events.go)
+
 ### Agent approval controls submit stale permission requests after restart
 
 - Symptom:

--- a/docs/conventions/troubleshooting/agent-provider-setup.md
+++ b/docs/conventions/troubleshooting/agent-provider-setup.md
@@ -4,6 +4,36 @@
 
 Provider discovery, installation, authentication, models, configuration, and runtime reachability.
 
+### Provider setup notice flashes after switching to an already-connected agent
+
+- Symptom:
+  Opening Tutti and switching to Cursor (or another managed provider) shows the
+  toast-like "connect provider before sending" notice even though auto-connect
+  already succeeded and messages can be sent. The notice stays until a later
+  status refresh finally marks the provider ready.
+- Quick checks:
+  Compare the desktop provider-status snapshot for the active provider with the
+  AgentGUI setup notice. If `ensureLoaded` reused a cached `auth_required` /
+  `not_installed` row while a session prompt still works, the notice is projecting
+  stale not-ready readiness. Confirm whether switching the provider triggered a
+  scoped `refresh` or only a cache-hit `ensureLoaded`.
+- Root cause:
+  Startup may capture a not-ready provider status during the background catalog
+  scan. Selecting that provider later reuses the cache, so AgentGUI immediately
+  treats the provider as not installed/connected. The notice only clears when a
+  slower follow-up refresh upgrades availability to `ready`.
+- Fix:
+  When the active Agent GUI provider has a cached not-ready status, refresh that
+  provider once and keep readiness unknown while the recheck is pending. Do not
+  project the setup notice from a stale not-ready row during that window.
+- Validation:
+  Add coverage for the not-ready recheck key/suppress helper, then run the
+  focused desktop test for that helper and `pnpm --filter @tutti-os/desktop typecheck`.
+- References:
+  [useDesktopAgentGUIReadiness.ts](../../../apps/desktop/src/renderer/src/features/workspace-agent/ui/useDesktopAgentGUIReadiness.ts)
+  [desktopAgentProviderNotReadyRecheck.ts](../../../apps/desktop/src/renderer/src/features/workspace-agent/ui/desktopAgentProviderNotReadyRecheck.ts)
+  [agent-gui-node.md](../../architecture/agent-gui-node.md)
+
 ### Agent provider picker shows only Claude Code and Codex
 
 - Symptom:
@@ -799,6 +829,37 @@ invalid_grant`. Daemon logs may also show an extra `claude-code` process start
   `credentials.effectiveSource` only tracks OAuth material (keychain or
   `.credentials.json`). For API-key/proxy users it stays `"none"` even
   after the fix; a connected session is the success signal, not that field.
+
+### Cursor free plan shows a red error on the next send after upgrade copy
+
+- Symptom:
+  A Cursor free / exhausted account first returns plain assistant text
+  `Upgrade your plan to continue`. Sending again shows a scary red turn-failed
+  card (often with an “Open setup” escape hatch) instead of the same calm
+  plan-gate copy.
+- Root cause:
+  `cursor-agent` soft-surfaces the first plan gate as an assistant chunk +
+  `end_turn`. Later attempts may fail `session/prompt` with the same fixed
+  copy (`upgrade` / `payment` actions). Tutti previously treated that ACP call
+  failure as a generic `turn.failed` / `provider_error` danger card, and the
+  visible-error classifier did not recognize the Cursor phrases as a quota /
+  plan limit.
+- Invariants:
+  When ACP `session/prompt` fails with Cursor plan/payment gate copy, soft-settle
+  the turn: emit a warning system notice with that copy and complete the turn
+  (`planLimit=true`) so the composer stays usable without a danger card. Keep
+  residual visible-error classification of those phrases in the
+  `quota_or_rate_limit` bucket, and render that bucket with warning tone rather
+  than danger. Do not route plan gates into the env-wizard “Open setup” path.
+- Validation:
+  Run `go test ./packages/agent/daemon/runtime -run 'PlanLimit|VisibleFailureCodeRecognizesCursorPlanLimit'`
+  and the AgentGUI visible-error / `classifyFailedAgentMessage` specs that cover
+  `Upgrade your plan to continue`.
+- References:
+  [acp_plan_limit.go](../../../packages/agent/daemon/runtime/acp_plan_limit.go)
+  [standard_acp_turn.go](../../../packages/agent/daemon/runtime/standard_acp_turn.go)
+  [visible_error.go](../../../packages/agent/daemon/runtime/visible_error.go)
+  [AgentMessageBlock.tsx](../../../packages/agent/gui/shared/agentConversation/components/AgentMessageBlock.tsx)
 
 ### Tutti Agent retries a 402 and shows generic provider setup
 

--- a/docs/conventions/troubleshooting/agent-runtime.md
+++ b/docs/conventions/troubleshooting/agent-runtime.md
@@ -26,11 +26,13 @@ Provider discovery, installation, authentication, models, configuration, and run
 - [Agent provider install looks idle while a non-Codex installer is running](./agent-provider-setup.md#agent-provider-install-looks-idle-while-a-non-codex-installer-is-running)
 - [Legacy Claude ACP adapter appears stale after external registry migration](./agent-provider-setup.md#legacy-claude-acp-adapter-appears-stale-after-external-registry-migration)
 - [Cursor ACP context ring stays empty or usage looks wrong](./agent-provider-setup.md#cursor-acp-context-ring-stays-empty-or-usage-looks-wrong)
+- [Cursor free plan shows a red error on the next send after upgrade copy](./agent-provider-setup.md#cursor-free-plan-shows-a-red-error-on-the-next-send-after-upgrade-copy)
 - [Claude SDK model aliases resolve to configured Anthropic defaults](./agent-provider-setup.md#claude-sdk-model-aliases-resolve-to-configured-anthropic-defaults)
 - [Claude SDK rejects live bypassPermissions mode](./agent-provider-setup.md#claude-sdk-rejects-live-bypasspermissions-mode)
 - [Claude Code logs out after sending a message (invalid_grant, credentials wiped)](./agent-provider-setup.md#claude-code-logs-out-after-sending-a-message-invalidgrant-credentials-wiped)
 - [Claude Code sessions fail with `effectiveSource: "none"` when CC-Switch or similar proxy tools are used](./agent-provider-setup.md#claude-code-sessions-fail-with-effectivesource-none-when-cc-switch-or-similar-proxy-tools-are-used)
 - [Tutti Agent retries a 402 and shows generic provider setup](./agent-provider-setup.md#tutti-agent-retries-a-402-and-shows-generic-provider-setup)
+- [Provider setup notice flashes after switching to an already-connected agent](./agent-provider-setup.md#provider-setup-notice-flashes-after-switching-to-an-already-connected-agent)
 
 ## [Agent Sessions And Lifecycle](./agent-session-lifecycle.md)
 
@@ -57,6 +59,7 @@ Turn state, loading, cancel, restore, rail projection, event updates, imports, a
 Approval gates, plan exits, parent/child event attribution, background agents, and Message Center.
 
 - [External PR review approvals do not refresh gate status](./agent-approvals-subagents.md#external-pr-review-approvals-do-not-refresh-gate-status)
+- [Cursor approval card shows only title and options, no command/path detail](./agent-approvals-subagents.md#cursor-approval-card-shows-only-title-and-options-no-commandpath-detail)
 - [Agent approval controls submit stale permission requests after restart](./agent-approvals-subagents.md#agent-approval-controls-submit-stale-permission-requests-after-restart)
 - [Claude SDK ExitPlanMode fails as interrupted after plan is ready](./agent-approvals-subagents.md#claude-sdk-exitplanmode-fails-as-interrupted-after-plan-is-ready)
 - [Codex app-server subagent output appears as the parent reply](./agent-approvals-subagents.md#codex-app-server-subagent-output-appears-as-the-parent-reply)

--- a/packages/agent/daemon/runtime/acp_auto_continue_test.go
+++ b/packages/agent/daemon/runtime/acp_auto_continue_test.go
@@ -237,3 +237,49 @@ func TestStandardACPAdapterWithoutOptInDoesNotAutoContinue(t *testing.T) {
 		}
 	}
 }
+
+// Cursor free-plan / payment gates may fail session/prompt with fixed copy.
+// Soft-settle as a warning notice + completed turn so retries are not a red
+// turn-failed card.
+func TestCursorAdapterSoftSettlesPlanLimitPromptError(t *testing.T) {
+	t.Parallel()
+
+	transport := newStandardACPTransport("Cursor Agent", "cursor-session-plan-limit")
+	transport.conn.planLimitPromptError = true
+	adapter := newCursorAdapterWithHostMetadata(transport, LegacyHostMetadata(), nil)
+	session := standardTestSession(ProviderCursor)
+	if _, err := adapter.Start(context.Background(), session); err != nil {
+		t.Fatalf("Start: %v", err)
+	}
+	session.ProviderSessionID = "cursor-session-plan-limit"
+
+	events, err := adapter.Exec(context.Background(), session, textPrompt("hello"), "", "turn-1", nil, nil)
+	if err != nil {
+		t.Fatalf("Exec: %v", err)
+	}
+
+	var sawCompleted bool
+	var sawFailed bool
+	var noticeTitle string
+	for _, event := range events {
+		switch event.Type {
+		case activityshared.EventTurnCompleted:
+			sawCompleted = true
+			if event.Payload.Metadata["planLimit"] != true {
+				t.Fatalf("completed metadata = %#v, want planLimit true", event.Payload.Metadata)
+			}
+		case activityshared.EventTurnFailed:
+			sawFailed = true
+		case activityshared.EventMessageAppended:
+			if asString(event.Payload.Metadata["kind"]) == "agent_system_notice" {
+				noticeTitle = asString(event.Payload.Metadata["title"])
+			}
+		}
+	}
+	if !sawCompleted || sawFailed {
+		t.Fatalf("turn terminal completed=%v failed=%v, want completed only", sawCompleted, sawFailed)
+	}
+	if noticeTitle != "Upgrade your plan to continue" {
+		t.Fatalf("plan-limit notice title = %q", noticeTitle)
+	}
+}

--- a/packages/agent/daemon/runtime/acp_plan_limit.go
+++ b/packages/agent/daemon/runtime/acp_plan_limit.go
@@ -1,0 +1,76 @@
+package agentruntime
+
+import (
+	"errors"
+	"strings"
+
+	activityshared "github.com/tutti-os/tutti/packages/agent/daemon/activity/events"
+)
+
+// Cursor (and similar ACP agents) report account plan / payment gates with
+// fixed user-facing copy. cursor-agent often soft-surfaces the first hit as an
+// assistant text chunk + end_turn; later attempts may instead fail the ACP
+// session/prompt call with the same text. Treat those as calm plan-limit
+// notices rather than scary turn-failed error cards.
+var providerPlanLimitPhrases = []string{
+	"upgrade your plan to continue",
+	"add a payment method to continue",
+}
+
+func acpProviderPlanLimitMessage(err error) (string, bool) {
+	if err == nil {
+		return "", false
+	}
+	candidates := make([]string, 0, 3)
+	var callErr *acpCallError
+	if errors.As(err, &callErr) {
+		if message := strings.TrimSpace(callErr.Err.Message); message != "" {
+			candidates = append(candidates, message)
+		}
+		data := acpErrorDataPayload(callErr.Err.Data)
+		if message := strings.TrimSpace(asString(data["message"])); message != "" {
+			candidates = append(candidates, message)
+		}
+	}
+	candidates = append(candidates, err.Error())
+	for _, candidate := range candidates {
+		if message, ok := providerPlanLimitUserMessage(candidate); ok {
+			return message, true
+		}
+	}
+	return "", false
+}
+
+func providerPlanLimitUserMessage(text string) (string, bool) {
+	trimmed := strings.TrimSpace(text)
+	if trimmed == "" {
+		return "", false
+	}
+	normalized := strings.ToLower(trimmed)
+	for _, phrase := range providerPlanLimitPhrases {
+		if !strings.Contains(normalized, phrase) {
+			continue
+		}
+		// Prefer the canonical phrase when the provider wraps it.
+		for _, line := range strings.Split(trimmed, "\n") {
+			line = strings.TrimSpace(line)
+			if strings.Contains(strings.ToLower(line), phrase) {
+				return line, true
+			}
+		}
+		return trimmed, true
+	}
+	return "", false
+}
+
+func acpPlanLimitNoticeEvent(session Session, turnID string, message string) (activityshared.Event, bool) {
+	return acpSystemNoticeEvent(session, turnID, map[string]any{
+		"kind":       "agent_system_notice",
+		"noticeKind": "warning",
+		"severity":   "warning",
+		"title":      message,
+		"detail":     message,
+		"code":       "quota_or_rate_limit",
+		"retryable":  false,
+	}, "system_notice", true)
+}

--- a/packages/agent/daemon/runtime/acp_plan_limit_test.go
+++ b/packages/agent/daemon/runtime/acp_plan_limit_test.go
@@ -1,0 +1,83 @@
+package agentruntime
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestProviderPlanLimitUserMessage(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name   string
+		text   string
+		want   string
+		wantOK bool
+	}{
+		{
+			name:   "cursor upgrade",
+			text:   "Upgrade your plan to continue",
+			want:   "Upgrade your plan to continue",
+			wantOK: true,
+		},
+		{
+			name:   "wrapped upgrade",
+			text:   "session/prompt: Upgrade your plan to continue",
+			want:   "session/prompt: Upgrade your plan to continue",
+			wantOK: true,
+		},
+		{
+			name:   "payment gate",
+			text:   "Add a payment method to continue",
+			want:   "Add a payment method to continue",
+			wantOK: true,
+		},
+		{
+			name:   "unrelated",
+			text:   "stream disconnected before completion",
+			wantOK: false,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, ok := providerPlanLimitUserMessage(tc.text)
+			if ok != tc.wantOK {
+				t.Fatalf("ok = %v, want %v", ok, tc.wantOK)
+			}
+			if got != tc.want {
+				t.Fatalf("message = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestACPProviderPlanLimitMessageFromCallError(t *testing.T) {
+	t.Parallel()
+
+	callErr := &acpCallError{
+		Method: "session/prompt",
+		Err: acpError{
+			Code:    -32000,
+			Message: "Upgrade your plan to continue",
+			Data:    json.RawMessage(`{"message":"Upgrade your plan to continue"}`),
+		},
+	}
+	got, ok := acpProviderPlanLimitMessage(callErr)
+	if !ok {
+		t.Fatal("expected plan-limit message")
+	}
+	if got != "Upgrade your plan to continue" {
+		t.Fatalf("message = %q", got)
+	}
+}
+
+func TestVisibleFailureCodeRecognizesCursorPlanLimit(t *testing.T) {
+	t.Parallel()
+
+	if got := visibleFailureCode("Upgrade your plan to continue"); got != "quota_or_rate_limit" {
+		t.Fatalf("visibleFailureCode() = %q, want quota_or_rate_limit", got)
+	}
+	if got := visibleFailureCode("Add a payment method to continue"); got != "quota_or_rate_limit" {
+		t.Fatalf("visibleFailureCode() = %q, want quota_or_rate_limit", got)
+	}
+}

--- a/packages/agent/daemon/runtime/acp_turn_normalizer.go
+++ b/packages/agent/daemon/runtime/acp_turn_normalizer.go
@@ -432,6 +432,33 @@ func (n *acpTurnNormalizer) toolItemID(update map[string]any) string {
 	return id
 }
 
+// KnownToolCallInput returns the last recorded normalized input for a raw ACP
+// toolCallId, if the normalizer has already seen a `tool_call`/`tool_call_update`
+// for it in this turn. Some ACP providers (Cursor) omit `rawInput` on the
+// `toolCall` embedded in `session/request_permission`, repeating only
+// `toolCallId`/`title`/`kind`; the earlier tool_call notification for the same
+// id is the only place the command/path/query detail exists. This lookup does
+// not create a new id mapping, so it must not be used before the tool_call it
+// targets has actually streamed.
+func (n *acpTurnNormalizer) KnownToolCallInput(rawToolCallID string) map[string]any {
+	if n == nil {
+		return nil
+	}
+	rawToolCallID = strings.TrimSpace(rawToolCallID)
+	if rawToolCallID == "" || n.toolItemIDs == nil {
+		return nil
+	}
+	eventID, ok := n.toolItemIDs[rawToolCallID]
+	if !ok {
+		return nil
+	}
+	pending, ok := n.pendingToolCalls[eventID]
+	if !ok {
+		return nil
+	}
+	return payloadMap(pending.payload, "input")
+}
+
 func (n *acpTurnNormalizer) trackToolCallEvent(event activityshared.Event) {
 	if n == nil || strings.TrimSpace(event.EventID) == "" {
 		return

--- a/packages/agent/daemon/runtime/claude_sdk_interactive.go
+++ b/packages/agent/daemon/runtime/claude_sdk_interactive.go
@@ -309,7 +309,7 @@ func (a *ClaudeCodeSDKAdapter) claudeSDKInteractiveRequested(
 	callID := "approval:" + requestID
 	callType := "approval"
 	status := string(activityshared.TurnPhaseWaitingApproval)
-	input := normalizedApprovalInput(toolCall, options, requestID)
+	input := normalizedApprovalInput(toolCall, options, requestID, nil)
 	eventPayload := map[string]any{
 		"callId":   callID,
 		"callType": "approval",

--- a/packages/agent/daemon/runtime/codex_appserver_event_interactive.go
+++ b/packages/agent/daemon/runtime/codex_appserver_event_interactive.go
@@ -110,7 +110,7 @@ func (a *CodexAppServerAdapter) appServerApprovalRequested(
 	title := firstNonEmpty(asString(toolCall["title"]), "Permission requested")
 	callID := firstNonEmpty(asString(toolCall["toolCallId"]), newID())
 	status := string(activityshared.TurnPhaseWaitingApproval)
-	input := normalizedApprovalInput(toolCall, options, requestID)
+	input := normalizedApprovalInput(toolCall, options, requestID, nil)
 	payload := map[string]any{
 		"callId":   callID,
 		"callType": "approval",

--- a/packages/agent/daemon/runtime/interactive_projection.go
+++ b/packages/agent/daemon/runtime/interactive_projection.go
@@ -555,13 +555,13 @@ func normalizedInteractivePrompt(toolCall map[string]any, options []map[string]a
 	}
 }
 
-func normalizedApprovalInput(toolCall map[string]any, options []map[string]any, requestID string) map[string]any {
+func normalizedApprovalInput(toolCall map[string]any, options []map[string]any, requestID string, knownInput map[string]any) map[string]any {
 	input := map[string]any{
 		"requestId": requestID,
 		"toolCall":  clonePayload(toolCall),
 		"options":   cloneOptionMaps(options),
 	}
-	for key, value := range normalizedApprovalDisplayInput(toolCall) {
+	for key, value := range normalizedApprovalDisplayInput(toolCall, knownInput) {
 		if _, exists := input[key]; !exists {
 			input[key] = clonePayloadValue(value)
 		}
@@ -569,8 +569,14 @@ func normalizedApprovalInput(toolCall map[string]any, options []map[string]any, 
 	return input
 }
 
-func normalizedApprovalDisplayInput(toolCall map[string]any) map[string]any {
-	if len(toolCall) == 0 {
+// normalizedApprovalDisplayInput builds the preview detail (command, path,
+// query, ...) shown on an approval card. Some ACP providers (Cursor) omit
+// `rawInput` on the permission request's own `toolCall` and only repeat
+// `toolCallId`/`title`/`kind`, so `knownInput` — the input captured from an
+// earlier `tool_call`/`tool_call_update` for the same call id, when available
+// — is used as a last-resort fallback per field.
+func normalizedApprovalDisplayInput(toolCall map[string]any, knownInput map[string]any) map[string]any {
+	if len(toolCall) == 0 && len(knownInput) == 0 {
 		return nil
 	}
 	displayInput := clonePayload(payloadObject(toolCall["input"]))
@@ -607,6 +613,10 @@ func normalizedApprovalDisplayInput(toolCall map[string]any) map[string]any {
 			continue
 		}
 		if value, exists := toolCall[key]; exists {
+			displayInput[key] = clonePayloadValue(value)
+			continue
+		}
+		if value, exists := knownInput[key]; exists {
 			displayInput[key] = clonePayloadValue(value)
 		}
 	}

--- a/packages/agent/daemon/runtime/standard_acp_adapter_test.go
+++ b/packages/agent/daemon/runtime/standard_acp_adapter_test.go
@@ -352,6 +352,62 @@ func TestCursorAdapterAgentTierPromptsForPermission(t *testing.T) {
 	}
 }
 
+// TestCursorPermissionRequestFallsBackToKnownToolCallInput reproduces a real
+// Cursor CLI ACP trace: `session/update` streams a `tool_call` with
+// `rawInput.command`, then `session/request_permission` repeats only
+// `toolCallId`/`title`/`kind` for that same call (no `rawInput`). Without a
+// fallback to the earlier tool_call, the approval card has no command detail
+// to show — only the title and options.
+func TestCursorPermissionRequestFallsBackToKnownToolCallInput(t *testing.T) {
+	t.Parallel()
+
+	transport := newStandardACPTransport("Cursor Agent", "cursor-session-fallback")
+	adapter := newCursorAdapterWithHostMetadata(transport, LegacyHostMetadata(), nil)
+	session := standardTestSession(ProviderCursor)
+	normalizer := newACPTurnNormalizer()
+
+	started := standardACPUpdateEvents(standardACPConfig{provider: ProviderCursor}, session, "turn-1", json.RawMessage(`{
+		"update": {
+			"sessionUpdate": "tool_call",
+			"toolCallId": "toolu_bdrk_01Q5tgfQbZyrAVBAUp71Eq8A",
+			"title": "`+"`echo hello-from-permission-probe`"+`",
+			"kind": "execute",
+			"status": "pending",
+			"rawInput": {"command": "echo hello-from-permission-probe"}
+		}
+	}`), normalizer)
+	if len(started) != 1 || started[0].Type != activityshared.EventCallStarted {
+		t.Fatalf("started events = %#v, want one call.started", started)
+	}
+
+	events, pending, err := standardACPPermissionRequested(adapter, session, "turn-1", json.RawMessage(`2`), json.RawMessage(`{
+		"toolCall": {
+			"toolCallId": "toolu_bdrk_01Q5tgfQbZyrAVBAUp71Eq8A",
+			"title": "`+"`echo hello-from-permission-probe`"+`",
+			"kind": "execute",
+			"status": "pending",
+			"content": [{"type": "content", "content": {"type": "text", "text": "Not in allowlist: echo"}}]
+		},
+		"options": [
+			{"optionId": "allow-once", "name": "Allow once", "kind": "allow_once"},
+			{"optionId": "allow-always", "name": "Allow always", "kind": "allow_always"},
+			{"optionId": "reject-once", "name": "Reject", "kind": "reject_once"}
+		]
+	}`), normalizer)
+	if err != nil {
+		t.Fatalf("standardACPPermissionRequested: %v", err)
+	}
+	if len(events) == 0 {
+		t.Fatal("events = empty, want at least the waiting-approval turn event")
+	}
+	if pending == nil {
+		t.Fatal("pending = nil, want a stored pending approval")
+	}
+	if got := asString(pending.input["command"]); got != "echo hello-from-permission-probe" {
+		t.Fatalf("pending.input[command] = %q, want the command captured from the earlier tool_call", got)
+	}
+}
+
 func TestCursorAutoApprovePermissionDecision(t *testing.T) {
 	t.Parallel()
 
@@ -2249,6 +2305,9 @@ type standardACPConnection struct {
 	// cursor-agent's transient-failure shape: an "Error: RetriableError: ..."
 	// text chunk followed by a normal end_turn result.
 	retriableErrorPrompts int
+	// planLimitPromptError makes session/prompt fail with Cursor's plan-gate
+	// copy so the adapter can soft-settle instead of emitting a red failure.
+	planLimitPromptError bool
 	// omitAssistantTextInPromptResults drops the agent_message_chunk from
 	// normal prompt results, emulating a tool-calls-only turn.
 	omitAssistantTextInPromptResults bool
@@ -2463,6 +2522,17 @@ func (c *standardACPConnection) Send(data []byte) error {
 			c.promptCallCount++
 			promptCall := c.promptCallCount
 			c.mu.Unlock()
+			if c.planLimitPromptError {
+				c.sendJSON(map[string]any{
+					"jsonrpc": "2.0",
+					"id":      message.ID,
+					"error": map[string]any{
+						"code":    -32000,
+						"message": "Upgrade your plan to continue",
+					},
+				})
+				return nil
+			}
 			if promptCall <= c.retriableErrorPrompts {
 				c.sendJSON(map[string]any{
 					"jsonrpc": "2.0",

--- a/packages/agent/daemon/runtime/standard_acp_events.go
+++ b/packages/agent/daemon/runtime/standard_acp_events.go
@@ -274,6 +274,7 @@ func standardACPPermissionRequested(
 	turnID string,
 	rawRequestID json.RawMessage,
 	raw json.RawMessage,
+	normalizer *acpTurnNormalizer,
 ) ([]activityshared.Event, *pendingACPApproval, error) {
 	var params struct {
 		ToolCall map[string]any   `json:"toolCall"`
@@ -308,7 +309,8 @@ func standardACPPermissionRequested(
 	callID := firstNonEmpty(asString(params.ToolCall["toolCallId"]), asString(params.ToolCall["id"]), newID())
 	callType := "approval"
 	status := string(activityshared.TurnPhaseWaitingApproval)
-	input := normalizedApprovalInput(params.ToolCall, params.Options, requestID)
+	knownInput := normalizer.KnownToolCallInput(asString(params.ToolCall["toolCallId"]))
+	input := normalizedApprovalInput(params.ToolCall, params.Options, requestID, knownInput)
 	payload := map[string]any{
 		"callId":   callID,
 		"callType": "approval",

--- a/packages/agent/daemon/runtime/standard_acp_stream.go
+++ b/packages/agent/daemon/runtime/standard_acp_stream.go
@@ -94,7 +94,7 @@ func (a *standardACPAdapter) handleACPMessage(
 				"synthetic": true,
 			})})
 		}
-		events, pending, err := standardACPPermissionRequested(a, session, turnID, message.ID, message.Params)
+		events, pending, err := standardACPPermissionRequested(a, session, turnID, message.ID, message.Params, normalizer)
 		if err != nil {
 			if sessionLevelEmit {
 				emit(events)

--- a/packages/agent/daemon/runtime/standard_acp_turn.go
+++ b/packages/agent/daemon/runtime/standard_acp_turn.go
@@ -138,6 +138,29 @@ execLoop:
 					"error": err.Error(),
 				}))
 				emitEvents(terminalEvents)
+			} else if planLimitMessage, ok := acpProviderPlanLimitMessage(err); ok {
+				// Match cursor-agent's soft plan-gate path: show the provider
+				// copy as a warning notice and settle the turn successfully so
+				// the next send is not a scary red turn-failed card.
+				if notice, ok := acpPlanLimitNoticeEvent(session, turnID, planLimitMessage); ok {
+					emitEvents([]activityshared.Event{notice})
+				}
+				terminalEvents := normalizer.FinishCompleted(session, turnID)
+				terminalEvents = append(terminalEvents, newTurnActivityEvent(session, EventTurnCompleted, turnID, SessionStatusReady, "", "", map[string]any{
+					"stopReason": "end_turn",
+					"planLimit":  true,
+				}))
+				emitEvents(terminalEvents)
+				slog.Info("agent session ACP exec settled plan-limit without failure card",
+					"event", "agent_session.acp.exec.plan_limit",
+					"provider", a.config.provider,
+					"adapter", a.config.adapterName,
+					"room_id", session.RoomID,
+					"agent_session_id", session.AgentSessionID,
+					"provider_session_id", session.ProviderSessionID,
+					"turn_id", turnID,
+					"plan_limit_message", planLimitMessage,
+				)
 			} else {
 				terminalEvents := normalizer.FinishFailed(session, turnID)
 				terminalEvents = append(terminalEvents, newTurnActivityEvent(session, EventTurnFailed, turnID, SessionStatusFailed, "", "", map[string]any{

--- a/packages/agent/daemon/runtime/visible_error.go
+++ b/packages/agent/daemon/runtime/visible_error.go
@@ -237,6 +237,10 @@ func visibleFailureCode(detail string) string {
 		// and none of the other markers here, so it must be matched explicitly or it
 		// falls through to a generic "request failed".
 		strings.Contains(normalized, "usage limit") ||
+		// cursor-agent plan/payment gates use fixed copy without "quota"/"usage limit"
+		// markers; keep them in the quota bucket so residual failure cards stay calm.
+		strings.Contains(normalized, "upgrade your plan to continue") ||
+		strings.Contains(normalized, "add a payment method to continue") ||
 		strings.Contains(normalized, "resource_exhausted") ||
 		strings.Contains(normalized, "too many requests") ||
 		strings.Contains(normalized, " 429"):

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/agentGuiController.composerPresentation.spec.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/agentGuiController.composerPresentation.spec.ts
@@ -177,6 +177,7 @@ describe("composer target presentation", () => {
       capabilities: null,
       models: [{ value: "current-model", label: "Current" }],
       reasoningEfforts: [{ value: "high", label: "High" }],
+      reasoningConfigurable: true,
       speeds: [],
       skills: [],
       behavior: {
@@ -204,5 +205,29 @@ describe("composer target presentation", () => {
         }
       }).model
     ).toBeNull();
+  });
+
+  it("clears reasoning effort when the target does not advertise it", () => {
+    const settings = { model: "gpt-5.2", reasoningEffort: "high" };
+    const cleared = sanitizeComposerSettingsForOptions(settings, {
+      provider: "cursor",
+      capabilities: null,
+      models: [{ value: "gpt-5.2", label: "gpt-5.2" }],
+      reasoningEfforts: [],
+      reasoningConfigurable: false,
+      speeds: [],
+      skills: [],
+      behavior: {
+        collapseModelOptionsToLatest: true,
+        modelOptionsAuthoritative: false,
+        refreshModelOptionsAfterSettings: false,
+        prewarmDraftSession: false,
+        planModeExclusiveWithPermissionMode: false
+      },
+      loadedAtUnixMs: 1
+    });
+
+    expect(cleared.model).toBe("gpt-5.2");
+    expect(cleared.reasoningEffort).toBeNull();
   });
 });

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/agentGuiController.composerPresentation.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/agentGuiController.composerPresentation.ts
@@ -152,11 +152,13 @@ export function sanitizeComposerSettingsForOptions(
         ? null
         : model,
     reasoningEffort:
-      reasoningEffort &&
-      reasoningValues.size > 0 &&
-      !reasoningValues.has(reasoningEffort)
+      options.reasoningConfigurable !== true
         ? null
-        : (reasoningEffort as AgentSessionReasoningEffort | null),
+        : reasoningEffort &&
+            reasoningValues.size > 0 &&
+            !reasoningValues.has(reasoningEffort)
+          ? null
+          : (reasoningEffort as AgentSessionReasoningEffort | null),
     speed:
       speed && speedValues.size > 0 && !speedValues.has(speed)
         ? null

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUIComposerPresentation.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUIComposerPresentation.ts
@@ -171,8 +171,10 @@ export function useAgentGUIComposerPresentation(
   const draftModel = usesPlaceholderDraftModel
     ? (liveConfigModel ?? persistedDraftModel)
     : persistedDraftModel;
-  const draftReasoningEffort = normalizeOptionalText(
-    draftSettings.reasoningEffort
+  const draftReasoningEffort = (
+    input.composerSupport.reasoning
+      ? normalizeOptionalText(draftSettings.reasoningEffort)
+      : null
   ) as AgentSessionReasoningEffort | null;
   const draftSpeed = normalizeOptionalText(
     draftSettings.speed

--- a/packages/agent/gui/agent-gui/agentGuiNode/model/composerSettingsMenuModel.spec.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/model/composerSettingsMenuModel.spec.ts
@@ -380,6 +380,43 @@ describe("buildComposerModelMenuModel", () => {
     expect(menu.model.show).toBe(true);
     expect(menu.reasoning.show).toBe(false);
     expect(menu.speed.show).toBe(false);
+    expect(menu.trigger.reasoningLabel).toBe("");
+    expect(menu.trigger.showCombined).toBe(true);
+  });
+
+  it("does not show a stale default effort when reasoning is not configurable", () => {
+    // Cursor-like: draft still carries the GUI default "high", but the
+    // provider does not expose a reasoning selector.
+    const menu = buildComposerModelMenuModel(
+      vm({
+        supportsReasoningEffort: false,
+        availableReasoningEfforts: [],
+        draftSettings: {
+          model: "gpt-5.2[reasoning=medium,fast=false]",
+          reasoningEffort: "high",
+          speed: null,
+          planMode: false,
+          permissionModeId: "agent"
+        },
+        availableModels: [
+          {
+            value: "gpt-5.2[reasoning=medium,fast=false]",
+            label: "gpt-5.2"
+          }
+        ],
+        supportsSpeed: false,
+        availableSpeeds: []
+      }),
+      labels
+    );
+
+    expect(menu.reasoning.show).toBe(false);
+    expect(menu.trigger).toMatchObject({
+      modelLabel: "GPT-5.2",
+      reasoningLabel: "",
+      combinedLabel: "GPT-5.2",
+      showCombined: true
+    });
   });
 
   it("shows the loading copy on the trigger while options load", () => {

--- a/packages/agent/gui/agent-gui/agentGuiNode/model/composerSettingsMenuModel.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/model/composerSettingsMenuModel.ts
@@ -135,10 +135,13 @@ export function buildComposerModelMenuModel(
   const selectedSpeedValue = selectedComposerSpeedValue(composerSettings) ?? "";
 
   const modelLabel = resolveSelectedModelLabel(composerSettings, labels);
-  const reasoningLabel = resolveSelectedReasoningLabel(
-    composerSettings,
-    labels
-  );
+  // Only surface an effort label when the reasoning control is actually shown.
+  // Providers such as Cursor keep a stale/default draft effort ("high") even
+  // though reasoning is not configurable; showing it next to the model name
+  // reads like a real selection the user cannot change.
+  const reasoningLabel = showReasoning
+    ? resolveSelectedReasoningLabel(composerSettings, labels)
+    : "";
 
   const disabled =
     composerSettings.isSettingsLoading ||

--- a/packages/agent/gui/shared/agentConversation/components/AgentMessageBlock.tsx
+++ b/packages/agent/gui/shared/agentConversation/components/AgentMessageBlock.tsx
@@ -6,9 +6,7 @@ import {
   type JSX,
   type ReactNode
 } from "react";
-import { ChevronRight } from "lucide-react";
 import { CheckIcon, CopyIcon } from "@tutti-os/ui-system/icons";
-import { Button } from "../../../app/renderer/components/ui/button";
 import { formatAgentMessageTimestamp } from "../../../app/renderer/shell/utils/format";
 import { AgentPlanCard } from "./AgentPlanCard";
 import { translate } from "../../../i18n/index";
@@ -20,18 +18,16 @@ import {
 } from "../../AgentMessageMarkdown";
 import { AgentRichTextReadonly } from "../../AgentRichTextReadonly";
 import { resolveAgentConversationLinkAction } from "../actions/agentConversationLinkActions";
-import { workspaceAgentProviderLabel } from "../../workspaceAgentProviderLabel";
-import { openAgentEnvPanel } from "../../agentEnv/agentEnvPanelStore";
-import {
-  classifyFailedAgentMessage,
-  resolveAgentErrorPresentation
-} from "../../agentEnv/agentErrorPresentation";
 import type { AgentGUIProviderSkillOption } from "../../../agent-gui/agentGuiNode/model/agentGuiNodeTypes";
 import type {
   AgentMessageContentVM,
   AgentMessageRowVM
 } from "../contracts/agentMessageRowVM";
-import { CollapsibleReveal } from "./CollapsibleReveal";
+import { AgentMessageDetailsDisclosure } from "./AgentMessageDetailsDisclosure";
+import {
+  AgentVisibleErrorMessage,
+  recoverVisibleErrorFromFailedMessage
+} from "./AgentVisibleErrorMessage";
 import { AgentThinkingDisclosure } from "./AgentThinkingDisclosure";
 import { RawTimelineJsonDisclosure } from "./RawTimelineJsonDisclosure";
 import styles from "../../../agent-gui/agentGuiNode/AgentGUIConversation.styles";
@@ -604,208 +600,4 @@ function systemNoticeTitle(message: AgentMessageContentVM): string {
         translate("agentHost.agentGui.systemNoticeDefault")
       );
   }
-}
-
-// Builds a synthetic visibleError from a plain failed message whose text is a
-// recognizable env failure, so it renders as the structured remediation card.
-function recoverVisibleErrorFromFailedMessage(
-  message: AgentMessageContentVM,
-  provider: string | null | undefined
-): AgentMessageContentVM | null {
-  const code = classifyFailedAgentMessage(message.body);
-  if (!code) {
-    return null;
-  }
-  return {
-    ...message,
-    visibleError: {
-      code,
-      phase: null,
-      provider: provider ?? null,
-      detail: message.body,
-      retryable: null
-    }
-  };
-}
-
-function AgentVisibleErrorMessage({
-  message,
-  onExternalLink
-}: {
-  message: AgentMessageContentVM;
-  onAuthLogin?: (provider?: string | null) => void;
-  onExternalLink?: (href: string) => void;
-}): JSX.Element {
-  "use memo";
-  const error = message.visibleError;
-  const detail = error?.detail?.trim() ?? "";
-
-  // One card for every run-failure code. The presentation (keyed on the codes
-  // the daemon actually emits — see agentErrorPresentation) supplies a granular,
-  // provider-aware message and, when the failure is something the env wizard can
-  // detect or repair, a single deep-linking call-to-action. Transient/server-side
-  // failures resolve to no focus, so no (misleading) wizard button is shown.
-  const providerLabel = workspaceAgentProviderLabel(
-    error?.provider ?? "unknown"
-  );
-  const presentation = resolveAgentErrorPresentation(error?.code);
-  const headline = presentation?.messageKey
-    ? translate(presentation.messageKey, { provider: providerLabel })
-    : visibleErrorTitle(message);
-  const focus = presentation?.focus ?? null;
-  const actionKey = presentation?.actionKey ?? null;
-  const externalUrl = presentation?.externalUrl ?? null;
-  const hint = visibleErrorHint(message);
-  // Plan/quota gates are account limits, not crashes — use the calmer warning
-  // tone so a Cursor free-plan "Upgrade your plan…" retry is not a danger card.
-  const isPlanOrQuotaLimit = error?.code === "quota_or_rate_limit";
-  const toneClassName = isPlanOrQuotaLimit
-    ? SYSTEM_NOTICE_WARNING_CLASS_NAME
-    : "border-[var(--on-danger-hover)] bg-[var(--on-danger)] text-[var(--state-danger)]";
-  const displayHeadline =
-    isPlanOrQuotaLimit && isProviderPlanLimitDetail(detail) ? detail : headline;
-  return (
-    <section
-      role={isPlanOrQuotaLimit ? "status" : "alert"}
-      className={`box-border w-full min-w-0 rounded-[8px] border p-3 text-[13px] leading-5 text-[var(--text-primary)] ${toneClassName}`}
-    >
-      <div className="flex min-w-0 items-start gap-3">
-        <div className="min-w-0 flex-1">
-          <div className="font-medium text-[var(--text-primary)]">
-            {displayHeadline}
-          </div>
-          {hint ? (
-            <div className="mt-1 text-[11px] text-[var(--text-secondary)]">
-              {hint}
-            </div>
-          ) : null}
-          {detail && displayHeadline !== detail ? (
-            <AgentMessageDetailsDisclosure
-              detail={detail}
-              className="mt-1"
-              label={translate("agentHost.agentGui.visibleErrorRawDetails")}
-            />
-          ) : null}
-        </div>
-        {actionKey && (focus || (externalUrl && onExternalLink)) ? (
-          <Button
-            type="button"
-            variant="ghost"
-            size="sm"
-            className="mt-0.5 shrink-0"
-            onClick={() => {
-              if (externalUrl) {
-                onExternalLink?.(externalUrl);
-                return;
-              }
-              if (focus) {
-                openAgentEnvPanel({
-                  provider: error?.provider ?? null,
-                  focus
-                });
-              }
-            }}
-          >
-            {translate(actionKey)}
-          </Button>
-        ) : null}
-      </div>
-    </section>
-  );
-}
-
-function isProviderPlanLimitDetail(detail: string): boolean {
-  const normalized = detail.trim().toLowerCase();
-  return (
-    normalized.includes("upgrade your plan to continue") ||
-    normalized.includes("add a payment method to continue")
-  );
-}
-
-function AgentMessageDetailsDisclosure({
-  detail,
-  className = "",
-  label
-}: {
-  detail: string;
-  className?: string;
-  label?: string;
-}): JSX.Element {
-  "use memo";
-  const [expanded, setExpanded] = useState(false);
-  return (
-    <div className={`${className} text-[11px] text-[var(--state-danger)]`}>
-      <button
-        type="button"
-        className="inline-flex w-fit max-w-full min-w-0 cursor-pointer select-none items-center gap-1.5 border-0 bg-transparent p-0 text-left font-[inherit] text-[inherit] transition-colors duration-150 hover:text-[var(--state-danger-hover)]"
-        aria-expanded={expanded}
-        onClick={() => setExpanded((value) => !value)}
-      >
-        {label ?? translate("agentHost.agentGui.visibleErrorDetails")}
-        <ChevronRight
-          size={12}
-          strokeWidth={2.2}
-          aria-hidden="true"
-          className="shrink-0 text-[var(--state-danger)]"
-          style={{
-            transform: expanded ? "rotate(90deg)" : "rotate(0deg)",
-            transformOrigin: "center",
-            transition: "transform 200ms cubic-bezier(0.22, 1.18, 0.36, 1)",
-            willChange: "transform"
-          }}
-        />
-      </button>
-      <CollapsibleReveal expanded={expanded} preMountOnIdle>
-        <pre className="mt-2 max-h-[220px] overflow-auto whitespace-pre-wrap break-words rounded-[6px] bg-[var(--on-danger)] px-3 py-2 font-[var(--tsh-font-mono)] text-[11px] leading-5 text-[var(--state-danger)]">
-          {detail}
-        </pre>
-      </CollapsibleReveal>
-    </div>
-  );
-}
-
-function visibleErrorTitle(message: AgentMessageContentVM): string {
-  const error = message.visibleError;
-  const provider = workspaceAgentProviderLabel(error?.provider ?? "unknown");
-  switch (error?.code) {
-    case "auth_required":
-      return translate("agentHost.agentGui.visibleErrorAuthRequired", {
-        provider
-      });
-    case "request_timed_out":
-      return translate("agentHost.agentGui.visibleErrorRequestTimedOut", {
-        provider
-      });
-    case "runtime_unavailable":
-      return translate("agentHost.agentGui.visibleErrorRuntimeUnavailable", {
-        provider
-      });
-    case "quota_or_rate_limit":
-      return translate("agentHost.agentGui.visibleErrorQuotaOrRateLimit", {
-        provider
-      });
-    default:
-      if (error?.phase === "start") {
-        return translate("agentHost.agentGui.visibleErrorStartFailed", {
-          provider
-        });
-      }
-      return (
-        message.body ||
-        translate("agentHost.agentGui.visibleErrorRequestFailed", { provider })
-      );
-  }
-}
-
-function visibleErrorHint(message: AgentMessageContentVM): string | null {
-  const error = message.visibleError;
-  if (error?.code !== "auth_required") {
-    return null;
-  }
-  return translate(
-    "agentHost.agentGui.visibleErrorAuthRequiredLocalAgentHint",
-    {
-      provider: workspaceAgentProviderLabel(error.provider ?? "unknown")
-    }
-  );
 }

--- a/packages/agent/gui/shared/agentConversation/components/AgentMessageBlock.tsx
+++ b/packages/agent/gui/shared/agentConversation/components/AgentMessageBlock.tsx
@@ -656,22 +656,30 @@ function AgentVisibleErrorMessage({
   const actionKey = presentation?.actionKey ?? null;
   const externalUrl = presentation?.externalUrl ?? null;
   const hint = visibleErrorHint(message);
+  // Plan/quota gates are account limits, not crashes — use the calmer warning
+  // tone so a Cursor free-plan "Upgrade your plan…" retry is not a danger card.
+  const isPlanOrQuotaLimit = error?.code === "quota_or_rate_limit";
+  const toneClassName = isPlanOrQuotaLimit
+    ? SYSTEM_NOTICE_WARNING_CLASS_NAME
+    : "border-[var(--on-danger-hover)] bg-[var(--on-danger)] text-[var(--state-danger)]";
+  const displayHeadline =
+    isPlanOrQuotaLimit && isProviderPlanLimitDetail(detail) ? detail : headline;
   return (
     <section
-      role="alert"
-      className="box-border w-full min-w-0 rounded-[8px] border border-[var(--on-danger-hover)] bg-[var(--on-danger)] p-3 text-[13px] leading-5 text-[var(--state-danger)]"
+      role={isPlanOrQuotaLimit ? "status" : "alert"}
+      className={`box-border w-full min-w-0 rounded-[8px] border p-3 text-[13px] leading-5 text-[var(--text-primary)] ${toneClassName}`}
     >
       <div className="flex min-w-0 items-start gap-3">
         <div className="min-w-0 flex-1">
           <div className="font-medium text-[var(--text-primary)]">
-            {headline}
+            {displayHeadline}
           </div>
           {hint ? (
             <div className="mt-1 text-[11px] text-[var(--text-secondary)]">
               {hint}
             </div>
           ) : null}
-          {detail ? (
+          {detail && displayHeadline !== detail ? (
             <AgentMessageDetailsDisclosure
               detail={detail}
               className="mt-1"
@@ -703,6 +711,14 @@ function AgentVisibleErrorMessage({
         ) : null}
       </div>
     </section>
+  );
+}
+
+function isProviderPlanLimitDetail(detail: string): boolean {
+  const normalized = detail.trim().toLowerCase();
+  return (
+    normalized.includes("upgrade your plan to continue") ||
+    normalized.includes("add a payment method to continue")
   );
 }
 

--- a/packages/agent/gui/shared/agentConversation/components/AgentMessageBlock.visibleError.spec.tsx
+++ b/packages/agent/gui/shared/agentConversation/components/AgentMessageBlock.visibleError.spec.tsx
@@ -217,6 +217,23 @@ describe("AgentVisibleErrorMessage", () => {
     });
   });
 
+  it("shows Cursor plan-limit cards as a calm warning status, not a danger alert", () => {
+    const { getByText, getByRole, queryByText } = renderBlock(
+      buildRow({
+        code: "quota_or_rate_limit",
+        phase: "turn",
+        provider: "cursor",
+        detail: "Upgrade your plan to continue",
+        retryable: false
+      })
+    );
+
+    expect(getByText("Upgrade your plan to continue")).toBeTruthy();
+    expect(getByRole("status")).toBeTruthy();
+    expect(queryByText("Open setup")).toBeNull();
+    expect(queryByText("Sign in")).toBeNull();
+  });
+
   it("recovers a failed plain auth message into the wizard card (Claude 401)", () => {
     const { getByText, getAllByRole } = renderBlock(
       buildFailedTextRow(

--- a/packages/agent/gui/shared/agentConversation/components/AgentMessageDetailsDisclosure.tsx
+++ b/packages/agent/gui/shared/agentConversation/components/AgentMessageDetailsDisclosure.tsx
@@ -1,0 +1,46 @@
+import { useState, type JSX } from "react";
+import { ChevronRight } from "lucide-react";
+import { translate } from "../../../i18n/index";
+import { CollapsibleReveal } from "./CollapsibleReveal";
+
+export function AgentMessageDetailsDisclosure({
+  detail,
+  className = "",
+  label
+}: {
+  detail: string;
+  className?: string;
+  label?: string;
+}): JSX.Element {
+  "use memo";
+  const [expanded, setExpanded] = useState(false);
+  return (
+    <div className={`${className} text-[11px] text-[var(--state-danger)]`}>
+      <button
+        type="button"
+        className="inline-flex w-fit max-w-full min-w-0 cursor-pointer select-none items-center gap-1.5 border-0 bg-transparent p-0 text-left font-[inherit] text-[inherit] transition-colors duration-150 hover:text-[var(--state-danger-hover)]"
+        aria-expanded={expanded}
+        onClick={() => setExpanded((value) => !value)}
+      >
+        {label ?? translate("agentHost.agentGui.visibleErrorDetails")}
+        <ChevronRight
+          size={12}
+          strokeWidth={2.2}
+          aria-hidden="true"
+          className="shrink-0 text-[var(--state-danger)]"
+          style={{
+            transform: expanded ? "rotate(90deg)" : "rotate(0deg)",
+            transformOrigin: "center",
+            transition: "transform 200ms cubic-bezier(0.22, 1.18, 0.36, 1)",
+            willChange: "transform"
+          }}
+        />
+      </button>
+      <CollapsibleReveal expanded={expanded} preMountOnIdle>
+        <pre className="mt-2 max-h-[220px] overflow-auto whitespace-pre-wrap break-words rounded-[6px] bg-[var(--on-danger)] px-3 py-2 font-[var(--tsh-font-mono)] text-[11px] leading-5 text-[var(--state-danger)]">
+          {detail}
+        </pre>
+      </CollapsibleReveal>
+    </div>
+  );
+}

--- a/packages/agent/gui/shared/agentConversation/components/AgentVisibleErrorMessage.tsx
+++ b/packages/agent/gui/shared/agentConversation/components/AgentVisibleErrorMessage.tsx
@@ -1,0 +1,171 @@
+import type { JSX } from "react";
+import { Button } from "../../../app/renderer/components/ui/button";
+import { translate } from "../../../i18n/index";
+import { workspaceAgentProviderLabel } from "../../workspaceAgentProviderLabel";
+import { openAgentEnvPanel } from "../../agentEnv/agentEnvPanelStore";
+import {
+  classifyFailedAgentMessage,
+  isProviderPlanLimitMessage,
+  resolveAgentErrorPresentation
+} from "../../agentEnv/agentErrorPresentation";
+import type { AgentMessageContentVM } from "../contracts/agentMessageRowVM";
+import { AgentMessageDetailsDisclosure } from "./AgentMessageDetailsDisclosure";
+
+const PLAN_LIMIT_WARNING_CLASS_NAME =
+  "border-[color-mix(in_srgb,var(--state-warning)_14%,transparent)] bg-[color-mix(in_srgb,var(--background-fronted)_100%,var(--state-warning)_6%)]";
+
+// Builds a synthetic visibleError from a plain failed message whose text is a
+// recognizable env failure, so it renders as the structured remediation card.
+export function recoverVisibleErrorFromFailedMessage(
+  message: AgentMessageContentVM,
+  provider: string | null | undefined
+): AgentMessageContentVM | null {
+  const code = classifyFailedAgentMessage(message.body);
+  if (!code) {
+    return null;
+  }
+  return {
+    ...message,
+    visibleError: {
+      code,
+      phase: null,
+      provider: provider ?? null,
+      detail: message.body,
+      retryable: null
+    }
+  };
+}
+
+export function AgentVisibleErrorMessage({
+  message,
+  onExternalLink
+}: {
+  message: AgentMessageContentVM;
+  onAuthLogin?: (provider?: string | null) => void;
+  onExternalLink?: (href: string) => void;
+}): JSX.Element {
+  "use memo";
+  const error = message.visibleError;
+  const detail = error?.detail?.trim() ?? "";
+
+  // One card for every run-failure code. The presentation (keyed on the codes
+  // the daemon actually emits — see agentErrorPresentation) supplies a granular,
+  // provider-aware message and, when the failure is something the env wizard can
+  // detect or repair, a single deep-linking call-to-action. Transient/server-side
+  // failures resolve to no focus, so no (misleading) wizard button is shown.
+  const providerLabel = workspaceAgentProviderLabel(
+    error?.provider ?? "unknown"
+  );
+  const presentation = resolveAgentErrorPresentation(error?.code);
+  const headline = presentation?.messageKey
+    ? translate(presentation.messageKey, { provider: providerLabel })
+    : visibleErrorTitle(message);
+  const focus = presentation?.focus ?? null;
+  const actionKey = presentation?.actionKey ?? null;
+  const externalUrl = presentation?.externalUrl ?? null;
+  const hint = visibleErrorHint(message);
+  // Plan/quota gates are account limits, not crashes — use the calmer warning
+  // tone so a Cursor free-plan "Upgrade your plan…" retry is not a danger card.
+  const isPlanOrQuotaLimit = error?.code === "quota_or_rate_limit";
+  const toneClassName = isPlanOrQuotaLimit
+    ? PLAN_LIMIT_WARNING_CLASS_NAME
+    : "border-[var(--on-danger-hover)] bg-[var(--on-danger)] text-[var(--state-danger)]";
+  const displayHeadline =
+    isPlanOrQuotaLimit && isProviderPlanLimitMessage(detail)
+      ? detail
+      : headline;
+  return (
+    <section
+      role={isPlanOrQuotaLimit ? "status" : "alert"}
+      className={`box-border w-full min-w-0 rounded-[8px] border p-3 text-[13px] leading-5 text-[var(--text-primary)] ${toneClassName}`}
+    >
+      <div className="flex min-w-0 items-start gap-3">
+        <div className="min-w-0 flex-1">
+          <div className="font-medium text-[var(--text-primary)]">
+            {displayHeadline}
+          </div>
+          {hint ? (
+            <div className="mt-1 text-[11px] text-[var(--text-secondary)]">
+              {hint}
+            </div>
+          ) : null}
+          {detail && displayHeadline !== detail ? (
+            <AgentMessageDetailsDisclosure
+              detail={detail}
+              className="mt-1"
+              label={translate("agentHost.agentGui.visibleErrorRawDetails")}
+            />
+          ) : null}
+        </div>
+        {actionKey && (focus || (externalUrl && onExternalLink)) ? (
+          <Button
+            type="button"
+            variant="ghost"
+            size="sm"
+            className="mt-0.5 shrink-0"
+            onClick={() => {
+              if (externalUrl) {
+                onExternalLink?.(externalUrl);
+                return;
+              }
+              if (focus) {
+                openAgentEnvPanel({
+                  provider: error?.provider ?? null,
+                  focus
+                });
+              }
+            }}
+          >
+            {translate(actionKey)}
+          </Button>
+        ) : null}
+      </div>
+    </section>
+  );
+}
+
+function visibleErrorTitle(message: AgentMessageContentVM): string {
+  const error = message.visibleError;
+  const provider = workspaceAgentProviderLabel(error?.provider ?? "unknown");
+  switch (error?.code) {
+    case "auth_required":
+      return translate("agentHost.agentGui.visibleErrorAuthRequired", {
+        provider
+      });
+    case "request_timed_out":
+      return translate("agentHost.agentGui.visibleErrorRequestTimedOut", {
+        provider
+      });
+    case "runtime_unavailable":
+      return translate("agentHost.agentGui.visibleErrorRuntimeUnavailable", {
+        provider
+      });
+    case "quota_or_rate_limit":
+      return translate("agentHost.agentGui.visibleErrorQuotaOrRateLimit", {
+        provider
+      });
+    default:
+      if (error?.phase === "start") {
+        return translate("agentHost.agentGui.visibleErrorStartFailed", {
+          provider
+        });
+      }
+      return (
+        message.body ||
+        translate("agentHost.agentGui.visibleErrorRequestFailed", { provider })
+      );
+  }
+}
+
+function visibleErrorHint(message: AgentMessageContentVM): string | null {
+  const error = message.visibleError;
+  if (error?.code !== "auth_required") {
+    return null;
+  }
+  return translate(
+    "agentHost.agentGui.visibleErrorAuthRequiredLocalAgentHint",
+    {
+      provider: workspaceAgentProviderLabel(error.provider ?? "unknown")
+    }
+  );
+}

--- a/packages/agent/gui/shared/agentEnv/agentErrorPresentation.spec.ts
+++ b/packages/agent/gui/shared/agentEnv/agentErrorPresentation.spec.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import {
   classifyFailedAgentMessage,
+  isProviderPlanLimitMessage,
   resolveAgentErrorPresentation
 } from "./agentErrorPresentation";
 
@@ -39,6 +40,19 @@ describe("classifyFailedAgentMessage", () => {
     expect(classifyFailedAgentMessage("Add a payment method to continue")).toBe(
       "quota_or_rate_limit"
     );
+  });
+});
+
+describe("isProviderPlanLimitMessage", () => {
+  it("matches Cursor plan/payment gate copy only", () => {
+    expect(isProviderPlanLimitMessage("Upgrade your plan to continue")).toBe(
+      true
+    );
+    expect(isProviderPlanLimitMessage("Add a payment method to continue")).toBe(
+      true
+    );
+    expect(isProviderPlanLimitMessage("rate limit exceeded")).toBe(false);
+    expect(isProviderPlanLimitMessage("")).toBe(false);
   });
 });
 

--- a/packages/agent/gui/shared/agentEnv/agentErrorPresentation.spec.ts
+++ b/packages/agent/gui/shared/agentEnv/agentErrorPresentation.spec.ts
@@ -31,6 +31,15 @@ describe("classifyFailedAgentMessage", () => {
     expect(classifyFailedAgentMessage("here is your answer")).toBeNull();
     expect(classifyFailedAgentMessage(null)).toBeNull();
   });
+
+  it("recovers Cursor plan-limit copy into the quota bucket", () => {
+    expect(classifyFailedAgentMessage("Upgrade your plan to continue")).toBe(
+      "quota_or_rate_limit"
+    );
+    expect(classifyFailedAgentMessage("Add a payment method to continue")).toBe(
+      "quota_or_rate_limit"
+    );
+  });
 });
 
 describe("resolveAgentErrorPresentation", () => {

--- a/packages/agent/gui/shared/agentEnv/agentErrorPresentation.ts
+++ b/packages/agent/gui/shared/agentEnv/agentErrorPresentation.ts
@@ -188,3 +188,18 @@ export function classifyFailedAgentMessage(
   }
   return null;
 }
+
+/** True when detail text is a provider plan/payment gate (not a generic quota). */
+export function isProviderPlanLimitMessage(
+  detail: string | null | undefined
+): boolean {
+  const normalized = detail?.trim().toLowerCase() ?? "";
+  if (!normalized) {
+    return false;
+  }
+  const markers =
+    FAILED_MESSAGE_CODE_MARKERS.find(
+      ([code]) => code === "quota_or_rate_limit"
+    )?.[1] ?? [];
+  return markers.some((marker) => normalized.includes(marker));
+}

--- a/packages/agent/gui/shared/agentEnv/agentErrorPresentation.ts
+++ b/packages/agent/gui/shared/agentEnv/agentErrorPresentation.ts
@@ -159,6 +159,10 @@ const FAILED_MESSAGE_CODE_MARKERS: ReadonlyArray<
   [
     "network_error",
     ["enotfound", "econnrefused", "econnreset", "getaddrinfo", "socket hang up"]
+  ],
+  [
+    "quota_or_rate_limit",
+    ["upgrade your plan to continue", "add a payment method to continue"]
   ]
 ];
 


### PR DESCRIPTION
## Summary
- Recheck a cached not-ready provider status when switching into Cursor (and similar agents) so AgentGUI does not flash a false “connect provider” notice while auto-connect can already succeed.
- Soft-surface Cursor plan/payment gates (`upgrade your plan` / `add a payment method`) as warning notices instead of red turn-failed cards, including when the ACP session/prompt call fails with the same copy.
- Backfill approval-card command/path/query detail from the earlier `tool_call` input when Cursor’s `session/request_permission` omits `rawInput`, and hide non-configurable reasoning-effort labels next to the model trigger.

## Verification
- Focused AgentGUI specs: visible-error / error-presentation / composer settings.
- Go runtime coverage for plan-limit settlement and approval input backfill.
- `pnpm check:full` passed locally before push (with a clean `TUTTI_ENV`).

## Fix Scope Justification
- Root cause: Cursor ACP surfaces several independent contract/state gaps at different ownership boundaries—(1) desktop caches a stale provider-status “not ready” snapshot that races ahead of Cursor auth, so switch-in projects a false setup notice; (2) Cursor plan/payment gates arrive either as soft assistant text/`end_turn` or as a hard ACP session/prompt failure with the same copy, and the hard path was projected as a red turn-failed card; (3) Cursor’s `session/request_permission` often omits `rawInput` and only repeats `toolCallId`/`title`/`kind`, so approval cards lost command/path detail that already existed on the earlier `tool_call`; (4) Cursor embeds effort in parameterized model ids and does not advertise configurable reasoning, but draft/default `reasoningEffort` still leaked into the model trigger label.
- Why can this not be fixed at a lower layer: each symptom already fails at the layer that owns that projection. Provider readiness is owned by the desktop status adapter (daemon status alone cannot suppress a stale local cache flash). Plan-limit soft settlement must happen in the ACP turn adapter before a failed turn is emitted. Approval detail backfill must happen in interactive projection while the turn normalizer still has the earlier tool-call input. Reasoning-label suppression must happen in the composer settings/presentation model once the provider capability says reasoning is not configurable. Collapsing these into one lower-layer patch would either invent Cursor-specific UI branches in the wrong owner or leave the other surfaces broken.

## Test plan
- [x] Switch into Cursor after a stale not-ready provider-status cache: composer stays usable and the setup notice does not flash; a real missing/not-ready provider still shows the notice after recheck settles.
- [x] Hit a Cursor free-plan / payment gate: first soft text path and later hard ACP failure both show a calm warning notice, not a red turn-failed card on the next send.
- [x] Trigger a Cursor shell/read approval whose permission request omits `rawInput`: approval card shows command/path/query from the earlier tool call.
- [x] Open Cursor composer model menu: no stale reasoning-effort label appears beside the model name when reasoning is not configurable.
- [x] Focused coverage: Go plan-limit / approval input tests, desktop provider-not-ready recheck tests, AgentGUI composer/error presentation specs.