### PR TITLE
fix(agent-gui): remove nested startup import waterfall

### DIFF
--- a/apps/desktop/src/renderer/src/features/workspace-workbench/services/internal/workspaceAgentGuiContribution.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/services/internal/workspaceAgentGuiContribution.ts
@@ -1,10 +1,4 @@
-import {
-  createElement,
-  lazy,
-  Suspense,
-  type CSSProperties,
-  type ReactNode
-} from "react";
+import { createElement, type CSSProperties, type ReactNode } from "react";
 import type {
   AgentGUIProvider,
   AgentGUIAllAgentsPresentation,
@@ -50,6 +44,7 @@ import { createDesktopAgentGUIWorkbenchHostInput } from "@renderer/features/work
 import { requestWorkspaceAgentGuiLaunch } from "@renderer/features/workspace-agent/services/workspaceAgentGuiLaunchCoordinator.ts";
 import type { IAgentProviderStatusService as AgentProviderStatusService } from "@renderer/features/workspace-agent/services/agentProviderStatusService.interface.ts";
 import type { DesktopAgentGUIWorkbenchBodyProps } from "@renderer/features/workspace-agent/ui/desktopAgentGUIWorkbenchModel.ts";
+import { DesktopAgentGUIWorkbenchBody } from "@renderer/features/workspace-agent/ui/DesktopAgentGUIWorkbenchBody.tsx";
 import { runDesktopAgentGUILinkAction } from "@renderer/features/workspace-agent/services/desktopAgentGUILinkActions.ts";
 import {
   workspaceWorkbenchDesktopI18nKeys,
@@ -61,12 +56,6 @@ import { requestWorkspaceIssueManagerLaunch } from "../workspaceIssueManagerLaun
 import { requestGroupChatLaunch } from "../groupChatLaunchCoordinator.ts";
 import { useExternalStoreValue } from "../../ui/useExternalStoreValue.ts";
 import { workspaceAgentGuiNodeFrame } from "./workspaceWorkbenchComposition.ts";
-
-const LazyDesktopAgentGUIWorkbenchBody = lazy(() =>
-  import("@renderer/features/workspace-agent/ui/DesktopAgentGUIWorkbenchBody.tsx").then(
-    (module) => ({ default: module.DesktopAgentGUIWorkbenchBody })
-  )
-);
 
 export function createWorkspaceAgentGuiContribution(input: {
   agentProviderStatusService: AgentProviderStatusService;
@@ -146,8 +135,9 @@ export function createWorkspaceAgentGuiContribution(input: {
       Parameters<typeof createAgentGuiWorkbenchContribution>[0]["renderBody"]
     >[1],
     options?: { previewMode?: boolean }
-  ) =>
-    createElement(DesktopWorkspaceAgentGUIWorkbenchBody, {
+  ) => {
+    const previewMode = options?.previewMode === true;
+    return createElement(DesktopWorkspaceAgentGUIWorkbenchBody, {
       agentActivityRuntime: agentGUIWorkbenchHostInput.agentActivityRuntime,
       agentHostApi: agentGUIWorkbenchHostInput.agentHostApi,
       appCenterService: input.appCenterService,
@@ -164,7 +154,7 @@ export function createWorkspaceAgentGuiContribution(input: {
         });
       },
       onStateChange: (...args) => helpers.onStateChange(...args),
-      previewMode: options?.previewMode,
+      previewMode,
       agentsService: helpers.agentDirectory,
       allAgentsPresentation: input.allAgentsPresentation,
       renderAgentsEmpty: input.renderAgentsEmpty,
@@ -192,6 +182,7 @@ export function createWorkspaceAgentGuiContribution(input: {
         agentGUIWorkbenchHostInput.resolveWorkspaceReferenceInitialTarget,
       workspaceId: input.workspaceId
     });
+  };
 
   return createAgentGuiWorkbenchContribution({
     copy: {
@@ -287,22 +278,14 @@ function DesktopWorkspaceAgentGUIWorkbenchBody({
     () => agentsService.getSnapshot(),
     () => agentsService.getSnapshot()
   );
-  return createElement(
-    Suspense,
-    {
-      fallback: createElement("div", {
-        className: "h-full min-h-0 bg-background"
-      })
-    },
-    createElement(LazyDesktopAgentGUIWorkbenchBody, {
-      ...props,
-      agentDirectory: snapshot,
-      defaultAgentTargetId: resolveDefaultAgentTargetId({
-        agents: snapshot.agents,
-        defaultProvider: defaultAgentProvider
-      })
+  return createElement(DesktopAgentGUIWorkbenchBody, {
+    ...props,
+    agentDirectory: snapshot,
+    defaultAgentTargetId: resolveDefaultAgentTargetId({
+      agents: snapshot.agents,
+      defaultProvider: defaultAgentProvider
     })
-  );
+  });
 }
 
 function resolveDefaultAgentTargetId(input: {

--- a/apps/desktop/src/renderer/src/features/workspace-workbench/ui/StandaloneAgentStartupShell.test.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/ui/StandaloneAgentStartupShell.test.ts
@@ -9,6 +9,13 @@ const startupShellSource = readFileSync(
   resolve(currentDirectory, "StandaloneAgentStartupShell.tsx"),
   "utf8"
 );
+const startupBodyShellSource = readFileSync(
+  resolve(
+    currentDirectory,
+    "../../../../../../../../packages/agent/gui/AgentGUIStartupShell.tsx"
+  ),
+  "utf8"
+);
 const standaloneWorkbenchSource = readFileSync(
   resolve(currentDirectory, "StandaloneAgentWorkbench.tsx"),
   "utf8"
@@ -44,8 +51,15 @@ const workspaceWindowSource = readFileSync(
   ),
   "utf8"
 );
+const workspaceAgentGuiContributionSource = readFileSync(
+  resolve(
+    currentDirectory,
+    "../services/internal/workspaceAgentGuiContribution.ts"
+  ),
+  "utf8"
+);
 
-test("standalone Agent renders a structured startup shell at every blocking boundary", () => {
+test("Agent surfaces render a structured startup shell at every blocking boundary", () => {
   assert.match(
     workspaceWindowSource,
     /routeView === "agent" \? \(\s*<StandaloneAgentStartupShell \/>/
@@ -55,9 +69,28 @@ test("standalone Agent renders a structured startup shell at every blocking boun
       ?.length,
     2
   );
-  assert.match(
+  assert.doesNotMatch(
     standaloneWindowSource,
-    /fallback=\{<StandaloneAgentStartupShell scope="body" \/>\}/
+    /LazyDesktopAgentGUIWorkbenchBody/
+  );
+  assert.match(
+    workspaceAgentGuiContributionSource,
+    /import \{ DesktopAgentGUIWorkbenchBody \} from "@renderer\/features\/workspace-agent\/ui\/DesktopAgentGUIWorkbenchBody\.tsx"/
+  );
+});
+
+test("OS and standalone Agent routes statically own the AgentGUI body", () => {
+  assert.doesNotMatch(
+    workspaceAgentGuiContributionSource,
+    /React\.lazy|lazy\(/
+  );
+  assert.doesNotMatch(
+    workspaceAgentGuiContributionSource,
+    /import\("@renderer\/features\/workspace-agent\/ui\/DesktopAgentGUIWorkbenchBody\.tsx"\)/
+  );
+  assert.match(
+    workspaceAgentGuiContributionSource,
+    /createElement\(DesktopAgentGUIWorkbenchBody, \{/
   );
 });
 
@@ -65,43 +98,49 @@ test("standalone Agent startup shell keeps the rail and new-conversation hero vi
   assert.match(startupShellSource, /data-agent-gui-startup-shell="window"/);
   assert.match(
     startupShellSource,
+    /<AgentGUIStartupShell loadingLabel=\{loadingLabel\} \/>/
+  );
+  assert.doesNotMatch(startupBodyShellSource, /AgentGUIStartupSource|source:/);
+  assert.doesNotMatch(startupBodyShellSource, /data-agent-gui-source/);
+  assert.match(
+    startupBodyShellSource,
     /gridTemplateColumns: "52px 280px minmax\(0, 1fr\)"/
   );
   assert.match(
-    startupShellSource,
+    startupBodyShellSource,
     /agent-gui-node__conversation-list-skeleton-row/
   );
   assert.match(
-    startupShellSource,
+    startupBodyShellSource,
     /agent-gui-node__empty-hero[\s\S]*?agent-gui-node__empty-hero-title/
   );
   assert.match(
-    startupShellSource,
+    startupBodyShellSource,
     /agent-gui-node__timeline agent-gui-node__timeline-centered[\s\S]*?data-agent-gui-startup-timeline-content="true"/
   );
   assert.match(
-    startupShellSource,
+    startupBodyShellSource,
     /agent-gui-node__empty-hero-icon-slot[\s\S]*?data-carousel-placeholder=\{true\}[\s\S]*?h-28/
   );
   assert.match(
-    startupShellSource,
+    startupBodyShellSource,
     /agent-gui-node__composer-hero[\s\S]*?data-layout="hero"[\s\S]*?agent-gui-node__composer-hero-prompt-input-area[\s\S]*?<textarea[\s\S]*?disabled/
   );
   assert.match(
-    startupShellSource,
+    startupBodyShellSource,
     /agent-gui-node__composer-footer[\s\S]*?agent-gui-node__composer-footer-left[\s\S]*?agent-gui-node__composer-footer-right/
   );
   assert.match(
-    startupShellSource,
+    startupBodyShellSource,
     /agent-gui-node__composer-project-row[\s\S]*?agent-gui-node__composer-prompt-tips[\s\S]*?agent-gui-node__composer-prompt-tip/
   );
   assert.match(
-    startupShellSource,
+    startupBodyShellSource,
     /agent-gui-node__empty-hero-suggestions[\s\S]*?agent-gui-node__empty-hero-suggestions-chips/
   );
-  assert.doesNotMatch(startupShellSource, /agent-gui-node__bottom-dock/);
-  assert.doesNotMatch(startupShellSource, /data-layout="dock"/);
-  assert.match(startupShellSource, /<Spinner/);
+  assert.doesNotMatch(startupBodyShellSource, /agent-gui-node__bottom-dock/);
+  assert.doesNotMatch(startupBodyShellSource, /data-layout="dock"/);
+  assert.match(startupBodyShellSource, /<Spinner/);
 });
 
 test("standalone Agent tool panels expose loading UI while deferred modules start", () => {

--- a/apps/desktop/src/renderer/src/features/workspace-workbench/ui/StandaloneAgentStartupShell.tsx
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/ui/StandaloneAgentStartupShell.tsx
@@ -1,15 +1,8 @@
 import type { CSSProperties, ReactNode } from "react";
-import { Spinner } from "@tutti-os/ui-system";
+import { AgentGUIStartupShell } from "@tutti-os/agent-gui/startup-shell";
 import { useTranslation } from "@renderer/i18n";
 
 const standaloneAgentStartupRailWidthPx = 332;
-const conversationSkeletonRowSizes = [
-  "long",
-  "medium",
-  "short",
-  "long",
-  "medium"
-] as const;
 
 export interface StandaloneAgentStartupShellProps {
   scope?: "body" | "window";
@@ -20,7 +13,7 @@ export function StandaloneAgentStartupShell({
 }: StandaloneAgentStartupShellProps): ReactNode {
   const { t } = useTranslation();
   const loadingLabel = t("common.loading");
-  const body = <StandaloneAgentStartupBody loadingLabel={loadingLabel} />;
+  const body = <AgentGUIStartupShell loadingLabel={loadingLabel} />;
 
   if (scope === "body") {
     return body;
@@ -101,164 +94,5 @@ function StandaloneAgentStartupHeader(): ReactNode {
         </div>
       </div>
     </header>
-  );
-}
-
-function StandaloneAgentStartupBody({
-  loadingLabel
-}: {
-  loadingLabel: string;
-}): ReactNode {
-  return (
-    <div
-      aria-busy="true"
-      className="agent-gui-node__shell h-full min-h-0 min-w-0"
-      data-agent-gui-startup-shell="body"
-    >
-      <div className="agent-gui-node__body">
-        <div
-          className="agent-gui-node__layout"
-          style={{
-            gridTemplateColumns: "52px 280px minmax(0, 1fr)"
-          }}
-        >
-          <aside className="flex h-full min-h-0 flex-col items-center gap-3 overflow-hidden bg-[var(--background-session-sidepanel)] px-2 pt-12">
-            {[0, 1, 2].map((index) => (
-              <span
-                aria-hidden="true"
-                className="size-8 shrink-0 rounded-lg bg-[var(--transparency-block)]"
-                key={index}
-              />
-            ))}
-          </aside>
-          <aside className="flex h-full min-h-0 min-w-0 flex-col overflow-hidden bg-[var(--background-session-sidepanel)] pt-12">
-            <div className="flex shrink-0 items-center gap-2 px-4 pb-4">
-              <span
-                aria-hidden="true"
-                className="h-8 min-w-0 flex-1 rounded-md bg-[var(--transparency-block)]"
-              />
-              <span
-                aria-hidden="true"
-                className="size-8 shrink-0 rounded-md bg-[var(--transparency-block)]"
-              />
-            </div>
-            <div className="min-h-0 flex-1 overflow-hidden px-4">
-              <div className="agent-gui-node__conversation-list-skeleton">
-                {conversationSkeletonRowSizes.map((size, index) => (
-                  <div
-                    className="agent-gui-node__conversation-list-skeleton-row"
-                    data-size={size}
-                    key={`${size}-${index}`}
-                  >
-                    <span className="agent-gui-node__conversation-list-skeleton-spine" />
-                    <span className="agent-gui-node__conversation-list-skeleton-rib agent-gui-node__conversation-list-skeleton-rib-primary" />
-                    <span className="agent-gui-node__conversation-list-skeleton-rib agent-gui-node__conversation-list-skeleton-rib-secondary" />
-                  </div>
-                ))}
-              </div>
-            </div>
-          </aside>
-          <section className="agent-gui-node__detail-panel">
-            <div className="agent-gui-node__detail pt-11">
-              <div className="flex h-full min-h-0 flex-1 flex-col">
-                <div className="agent-gui-node__timeline agent-gui-node__timeline-centered">
-                  <div
-                    className="grid min-w-full grid-cols-[minmax(0,1fr)] gap-6"
-                    data-agent-gui-startup-timeline-content="true"
-                  >
-                    <div className="agent-gui-node__empty-hero">
-                      <div className="agent-gui-node__empty-hero-body">
-                        <div
-                          className="agent-gui-node__empty-hero-icon-slot"
-                          data-carousel-placeholder={true}
-                        >
-                          <div
-                            aria-hidden="true"
-                            className="flex h-28 w-full items-center justify-center gap-4"
-                          >
-                            <span className="h-16 w-14 -rotate-6 rounded-lg bg-[var(--transparency-block)]" />
-                            <span className="size-20 rounded-xl bg-[var(--transparency-block)]" />
-                            <span className="h-16 w-14 rotate-6 rounded-lg bg-[var(--transparency-block)]" />
-                          </div>
-                        </div>
-                        <h2 className="agent-gui-node__empty-hero-title">
-                          <span
-                            aria-hidden="true"
-                            className="inline-block h-9 w-[min(440px,80%)] rounded-md bg-[var(--transparency-block)]"
-                          />
-                        </h2>
-                        <div
-                          className="agent-gui-node__composer-hero"
-                          data-layout="hero"
-                        >
-                          <div className="agent-gui-node__composer-input-group agent-gui-node__composer-input-group-hero">
-                            <div className="agent-gui-node__composer-input-shell agent-gui-node__composer-input-shell-hero">
-                              <div className="agent-gui-node__composer-hero-prompt-input-area">
-                                <textarea
-                                  aria-label={loadingLabel}
-                                  className="h-[46px] min-h-[46px] w-full resize-none border-0 bg-transparent p-0 text-[13px] outline-none"
-                                  disabled
-                                  rows={2}
-                                />
-                              </div>
-                              <div
-                                aria-hidden="true"
-                                className="agent-gui-node__composer-footer"
-                              >
-                                <div className="agent-gui-node__composer-footer-left">
-                                  <span className="size-7 rounded-md bg-[var(--transparency-block)]" />
-                                  <span className="h-7 w-20 rounded-md bg-[var(--transparency-block)]" />
-                                </div>
-                                <div className="agent-gui-node__composer-footer-right">
-                                  <span className="h-7 w-16 rounded-md bg-[var(--transparency-block)]" />
-                                  <Spinner
-                                    className="text-[var(--text-tertiary)]"
-                                    size={16}
-                                  />
-                                </div>
-                              </div>
-                            </div>
-                          </div>
-                          <div className="agent-gui-node__composer-project-row">
-                            <span
-                              aria-hidden="true"
-                              className="h-7 w-28 shrink-0 rounded-md bg-[var(--transparency-block)]"
-                            />
-                            <div className="agent-gui-node__composer-prompt-tips">
-                              <span className="agent-gui-node__composer-prompt-tip">
-                                <span className="agent-gui-node__composer-prompt-tip-track">
-                                  <span className="agent-gui-node__composer-prompt-tip-item">
-                                    <span
-                                      aria-hidden="true"
-                                      className="inline-block h-2.5 w-56 rounded-full bg-[var(--transparency-block)]"
-                                    />
-                                  </span>
-                                </span>
-                              </span>
-                            </div>
-                          </div>
-                        </div>
-                        <div className="agent-gui-node__empty-hero-suggestions">
-                          <div
-                            aria-hidden="true"
-                            className="agent-gui-node__empty-hero-suggestions-chips"
-                          >
-                            <span className="h-8 w-24 rounded-full bg-[var(--transparency-block)]" />
-                            <span className="h-8 w-32 rounded-full bg-[var(--transparency-block)]" />
-                            <span className="h-8 w-30 rounded-full bg-[var(--transparency-block)]" />
-                            <span className="h-8 w-36 rounded-full bg-[var(--transparency-block)]" />
-                            <span className="h-8 w-28 rounded-full bg-[var(--transparency-block)]" />
-                          </div>
-                        </div>
-                      </div>
-                    </div>
-                  </div>
-                </div>
-              </div>
-            </div>
-          </section>
-        </div>
-      </div>
-    </div>
   );
 }

--- a/apps/desktop/src/renderer/src/features/workspace-workbench/ui/StandaloneAgentWindow.test.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/ui/StandaloneAgentWindow.test.ts
@@ -117,7 +117,7 @@ test("standalone Agent handles task and app Agent launch requests", () => {
   );
   assert.match(
     standaloneWindowSource,
-    /<LazyDesktopAgentGUIWorkbenchBody[\s\S]*?prefillPromptBootstrapRequest=\{prefillPromptBootstrapRequest\}/
+    /<DesktopAgentGUIWorkbenchBody[\s\S]*?prefillPromptBootstrapRequest=\{prefillPromptBootstrapRequest\}/
   );
   assert.match(
     workbenchBodySource,
@@ -188,7 +188,22 @@ test("standalone Agent hides panel toggles until its content mounts", () => {
   );
   assert.match(
     standaloneWindowSource,
-    /<StandaloneAgentWindowContentReady onReady=\{handleContentReady\}>[\s\S]*?<LazyDesktopAgentGUIWorkbenchBody/
+    /<StandaloneAgentWindowContentReady onReady=\{handleContentReady\}>[\s\S]*?<DesktopAgentGUIWorkbenchBody/
+  );
+});
+
+test("standalone Agent loads its body with the route instead of adding a second lazy boundary", () => {
+  assert.match(
+    standaloneWindowSource,
+    /import \{ DesktopAgentGUIWorkbenchBody \} from "@renderer\/features\/workspace-agent\/ui\/DesktopAgentGUIWorkbenchBody\.tsx"/
+  );
+  assert.doesNotMatch(
+    standaloneWindowSource,
+    /LazyDesktopAgentGUIWorkbenchBody/
+  );
+  assert.doesNotMatch(
+    standaloneWindowSource,
+    /import\("@renderer\/features\/workspace-agent\/ui\/DesktopAgentGUIWorkbenchBody\.tsx"\)/
   );
 });
 

--- a/apps/desktop/src/renderer/src/features/workspace-workbench/ui/StandaloneAgentWindow.tsx
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/ui/StandaloneAgentWindow.tsx
@@ -56,12 +56,12 @@ import type { TuttiExternalFileOpenInput } from "@tutti-os/workspace-external-co
 import type { IReporterService } from "@renderer/features/analytics";
 import type { IDesktopRichTextAtService } from "@renderer/features/rich-text-at";
 import type { IWorkspaceUserProjectService } from "@renderer/features/workspace-user-project";
+import { DesktopAgentGUIWorkbenchBody } from "@renderer/features/workspace-agent/ui/DesktopAgentGUIWorkbenchBody.tsx";
 import { useTranslation } from "@renderer/i18n";
 import { AppUpdateStatus } from "@renderer/features/app-update";
 import { StandaloneAgentToolSidebar } from "./StandaloneAgentToolSidebar";
 import type { StandaloneAgentFileOpenRequest } from "./StandaloneAgentToolSidebar";
 import { WorkspaceAppExternalBridge } from "./WorkspaceAppExternalBridge";
-import { StandaloneAgentStartupShell } from "./StandaloneAgentStartupShell.tsx";
 import {
   createStandaloneAgentDockPreviewCache,
   createStandaloneAgentHost,
@@ -89,13 +89,6 @@ const LazyStandaloneAgentWindowPanelHosts = lazy(() =>
 const standaloneAgentNodeId = "standalone-agent-window-node";
 const standaloneAgentInstanceKey = "standalone-agent-window";
 const standaloneAgentDefaultConversationRailWidthPx = 280;
-const desktopAgentGUIWorkbenchBodyModulePromise =
-  import("@renderer/features/workspace-agent/ui/DesktopAgentGUIWorkbenchBody.tsx");
-const LazyDesktopAgentGUIWorkbenchBody = lazy(() =>
-  desktopAgentGUIWorkbenchBodyModulePromise.then((module) => ({
-    default: module.DesktopAgentGUIWorkbenchBody
-  }))
-);
 function renderStandaloneAgentSidebarFooter(): ReactNode {
   return (
     <Suspense fallback={null}>
@@ -714,71 +707,67 @@ export function StandaloneAgentWindow({
         resizeWindowContentWidth={resizeStandaloneAgentWindowContentWidth}
         workspaceId={workspaceId}
       >
-        <Suspense fallback={<StandaloneAgentStartupShell scope="body" />}>
-          <StandaloneAgentWindowContentReady onReady={handleContentReady}>
-            <LazyDesktopAgentGUIWorkbenchBody
-              agentActivityRuntime={agentGuiHostInput.agentActivityRuntime}
-              agentHostApi={agentGuiHostInput.agentHostApi}
-              appCenterService={workspaceAppCenterService}
-              agentProviderStatusService={agentProviderStatusService}
-              context={context}
-              computerUseApi={desktopApi.computerUse}
-              conversationRailAutoCollapseWidthPx={
-                AGENT_GUI_STANDALONE_AUTO_COLLAPSE_WIDTH_PX
-              }
-              dockPreviewCache={dockPreviewCache}
-              onLinkAction={handleLinkAction}
-              onCapabilitySettingsRequest={handleCapabilitySettingsRequest}
-              onOpenAgentConversationWindow={({ agentSessionId, provider }) => {
-                // Duplicate the complete live snapshot so the new window can
-                // hydrate before its first local refresh.
-                void hostWindowApi.openAgentWindow({
-                  agentSessionId,
-                  providerStatusSnapshot:
-                    agentProviderStatusService.getSnapshot(),
-                  agentDirectorySnapshot,
-                  provider,
-                  workspaceId
-                });
-              }}
-              onStateChange={setNodeState}
-              prefillPromptBootstrapRequest={prefillPromptBootstrapRequest}
-              providerStatusBootstrapSnapshot={providerStatusBootstrapSnapshot}
-              agentDirectory={agentDirectorySnapshot}
-              contextMentionProviders={
-                agentGuiHostInput.contextMentionProviders
-              }
-              runtimeApi={desktopApi.runtime}
-              trackAgentProviderChatReady={
-                agentGuiHostInput.trackAgentProviderChatReady
-              }
-              trackWorkspaceFileReferences={
-                agentGuiHostInput.trackWorkspaceFileReferences
-              }
-              workspaceFileReferenceAdapter={
-                agentGuiHostInput.workspaceFileReferenceAdapter
-              }
-              resolveDroppedFileReferences={
-                agentGuiHostInput.resolveDroppedFileReferences
-              }
-              onRequestGitBranches={agentGuiHostInput.onRequestGitBranches}
-              referenceSourceAggregator={
-                agentGuiHostInput.referenceSourceAggregator
-              }
-              renderSidebarFooter={renderStandaloneAgentSidebarFooter}
-              resolveWorkspaceReferenceEntryIconUrl={
-                agentGuiHostInput.resolveWorkspaceReferenceEntryIconUrl
-              }
-              resolveMentionReferenceTarget={
-                agentGuiHostInput.resolveMentionReferenceTarget
-              }
-              resolveWorkspaceReferenceInitialTarget={
-                agentGuiHostInput.resolveWorkspaceReferenceInitialTarget
-              }
-              workspaceId={workspaceId}
-            />
-          </StandaloneAgentWindowContentReady>
-        </Suspense>
+        <StandaloneAgentWindowContentReady onReady={handleContentReady}>
+          <DesktopAgentGUIWorkbenchBody
+            agentActivityRuntime={agentGuiHostInput.agentActivityRuntime}
+            agentHostApi={agentGuiHostInput.agentHostApi}
+            appCenterService={workspaceAppCenterService}
+            agentProviderStatusService={agentProviderStatusService}
+            context={context}
+            computerUseApi={desktopApi.computerUse}
+            conversationRailAutoCollapseWidthPx={
+              AGENT_GUI_STANDALONE_AUTO_COLLAPSE_WIDTH_PX
+            }
+            dockPreviewCache={dockPreviewCache}
+            onLinkAction={handleLinkAction}
+            onCapabilitySettingsRequest={handleCapabilitySettingsRequest}
+            onOpenAgentConversationWindow={({ agentSessionId, provider }) => {
+              // Duplicate the complete live snapshot so the new window can
+              // hydrate before its first local refresh.
+              void hostWindowApi.openAgentWindow({
+                agentSessionId,
+                providerStatusSnapshot:
+                  agentProviderStatusService.getSnapshot(),
+                agentDirectorySnapshot,
+                provider,
+                workspaceId
+              });
+            }}
+            onStateChange={setNodeState}
+            prefillPromptBootstrapRequest={prefillPromptBootstrapRequest}
+            providerStatusBootstrapSnapshot={providerStatusBootstrapSnapshot}
+            agentDirectory={agentDirectorySnapshot}
+            contextMentionProviders={agentGuiHostInput.contextMentionProviders}
+            runtimeApi={desktopApi.runtime}
+            trackAgentProviderChatReady={
+              agentGuiHostInput.trackAgentProviderChatReady
+            }
+            trackWorkspaceFileReferences={
+              agentGuiHostInput.trackWorkspaceFileReferences
+            }
+            workspaceFileReferenceAdapter={
+              agentGuiHostInput.workspaceFileReferenceAdapter
+            }
+            resolveDroppedFileReferences={
+              agentGuiHostInput.resolveDroppedFileReferences
+            }
+            onRequestGitBranches={agentGuiHostInput.onRequestGitBranches}
+            referenceSourceAggregator={
+              agentGuiHostInput.referenceSourceAggregator
+            }
+            renderSidebarFooter={renderStandaloneAgentSidebarFooter}
+            resolveWorkspaceReferenceEntryIconUrl={
+              agentGuiHostInput.resolveWorkspaceReferenceEntryIconUrl
+            }
+            resolveMentionReferenceTarget={
+              agentGuiHostInput.resolveMentionReferenceTarget
+            }
+            resolveWorkspaceReferenceInitialTarget={
+              agentGuiHostInput.resolveWorkspaceReferenceInitialTarget
+            }
+            workspaceId={workspaceId}
+          />
+        </StandaloneAgentWindowContentReady>
       </StandaloneAgentToolSidebar>
       {panelHostsReady ? (
         <Suspense fallback={null}>

--- a/docs/architecture/agent-gui-node.md
+++ b/docs/architecture/agent-gui-node.md
@@ -473,13 +473,20 @@ Agent window are separate dynamic entries; neither route may statically import
 the other route's body through a feature barrel. Workbench Agent contribution
 registration keeps only its lightweight node and dock descriptor on the OS
 cold path. The full `DesktopAgentGUIWorkbenchBody`, rich-text editor, mention
-search controller, and AgentGUI presentation graph load when an Agent surface
-is required. Entering standalone Agent mode starts a dynamic preload of that
-body while allowing the lightweight standalone shell to render independently;
-the body fetch must not block the shell, and OS mode must not trigger it.
+search controller, and AgentGUI presentation graph remain outside the common
+desktop shell entry. Both the OS workspace route and standalone Agent route
+statically own the body inside their already-lazy route chunks. This avoids a
+second body-level import waterfall after either route begins rendering while
+keeping non-workspace desktop routes outside the AgentGUI graph.
 Every blocking boundary before the real AgentGUI controller mounts uses that
 same startup-shell geometry: the route-level Suspense fallback, workspace
-catalog hydration, workbench host-session binding, and the lazy AgentGUI body.
+catalog hydration, and workbench host-session binding.
+The reusable body geometry is owned by the narrow
+`@tutti-os/agent-gui/startup-shell` entry. The primitive is runtime-source
+agnostic: local/shared ownership, directory loading, and launch routing remain
+host concerns. Desktop owns the optional standalone-window chrome around that
+body; another host may compose the same primitive at its own loading boundary
+without adding host identity to the AgentGUI presentation package.
 The full-window variant keeps the header, provider rail, conversation-rail
 skeleton, and empty-home hero composer visible; after the real header mounts,
 the body-only variant preserves that new-conversation geometry without
@@ -506,6 +513,9 @@ conversation-rail and right-panel toggles hidden; reveal them only after the
 body commits so loading chrome cannot target unavailable content.
 Startup optimizations such as mention browse warming must begin from the
 mounted AgentGUI lifecycle, never from workspace contribution registration.
+Local AgentGUI startup before the body module evaluates is module loading, not
+workspace or session hydration. Reserve hydration terminology for injecting or
+reconciling runtime state after the relevant controller exists.
 File activation in the standalone Agent window must use the host-owned right
 Files sidebar. Conversation links and workspace-reference preview requests open
 that panel and pass a reveal intent so the reusable file manager selects and

--- a/docs/conventions/troubleshooting/workbench-renderer.md
+++ b/docs/conventions/troubleshooting/workbench-renderer.md
@@ -82,18 +82,30 @@
 - Root cause:
   Development Vite transforms source modules on demand. An Agent-only route can
   therefore remain on a black Suspense fallback while nested lazy boundaries
-  discover large dependency graphs. Static imports for Browser, Terminal, File
+  discover large dependency graphs. In the desktop renderer, enabling Babel
+  React Compiler during `serve` makes every cold TSX request substantially more
+  expensive; a body import that reaches hundreds of TSX modules can spend
+  several seconds compiling even though all source files are local. A warm
+  request completing quickly distinguishes this from disk or loopback HTTP
+  throughput. Static imports for Browser, Terminal, File
   Manager, App Center, Message Center, settings/import panels, or account UI
   enlarge the shell graph even when those surfaces are closed. Starting
   Workspace App polling at mount can also prepare every app runtime during the
   same cold compile. Separately, a single global in-flight provider-status
   promise makes the active provider wait behind a slow all-provider scan.
 - Fix:
-  Keep workspace and standalone Agent routes separate. Dynamically preload the
-  full AgentGUI body without blocking the lightweight standalone shell. Render
+  Keep workspace and standalone Agent routes separate. Let both already-lazy
+  routes statically own the full AgentGUI body so neither adds a second import
+  waterfall beneath its route fallback. Render
   the same structured shell at the route Suspense, workspace hydration,
   host-session binding, and AgentGUI-body boundaries; a plain background at any
   one of those boundaries brings the apparent black screen back. Keep the
+  reusable body shell in the narrow `@tutti-os/agent-gui/startup-shell` entry;
+  let desktop compose standalone window chrome around it. Keep React Compiler
+  settings aligned between development and production; do not hide a cold
+  transform bottleneck by changing compiler semantics only in development.
+  Reduce the initial module graph, precompile a stable package boundary, or
+  schedule non-blocking preload work instead. Keep the
   right side shaped like the empty-home/new-conversation hero, not a selected
   conversation timeline with a bottom dock. Keep the fallback hero composer
   non-interactive until the real controller owns its draft.
@@ -113,7 +125,9 @@
   pre-controller return path renders the structured startup shell and every
   deferred tool body has a non-empty loading fallback.
   Finally cold-start local dev and compare the same timestamp landmarks; this
-  manual renderer verification requires explicit user approval.
+  manual renderer verification requires explicit user approval. If the dynamic
+  import still dominates, compare cold and warm module-graph timings before
+  investigating daemon hydration or provider discovery.
 - References:
   [agent-gui-node.md](../../architecture/agent-gui-node.md)
   [WorkspaceWindow.tsx](../../../apps/desktop/src/renderer/src/app/windows/workspace/WorkspaceWindow.tsx)

--- a/packages/agent/gui/AgentGUIStartupShell.tsx
+++ b/packages/agent/gui/AgentGUIStartupShell.tsx
@@ -1,0 +1,171 @@
+import type { ReactNode } from "react";
+import { Spinner } from "@tutti-os/ui-system";
+
+const conversationSkeletonRowSizes = [
+  "long",
+  "medium",
+  "short",
+  "long",
+  "medium"
+] as const;
+
+export interface AgentGUIStartupShellProps {
+  loadingLabel: string;
+}
+
+export function AgentGUIStartupShell({
+  loadingLabel
+}: AgentGUIStartupShellProps): ReactNode {
+  return (
+    <div
+      aria-busy="true"
+      className="agent-gui-node__shell h-full min-h-0 min-w-0"
+      data-agent-gui-startup-shell="body"
+    >
+      <div className="agent-gui-node__body">
+        <div
+          className="agent-gui-node__layout"
+          style={{
+            gridTemplateColumns: "52px 280px minmax(0, 1fr)"
+          }}
+        >
+          <aside className="flex h-full min-h-0 flex-col items-center gap-3 overflow-hidden bg-[var(--background-session-sidepanel)] px-2 pt-12">
+            {[0, 1, 2].map((index) => (
+              <span
+                aria-hidden="true"
+                className="size-8 shrink-0 rounded-lg bg-[var(--transparency-block)]"
+                key={index}
+              />
+            ))}
+          </aside>
+          <aside className="flex h-full min-h-0 min-w-0 flex-col overflow-hidden bg-[var(--background-session-sidepanel)] pt-12">
+            <div className="flex shrink-0 items-center gap-2 px-4 pb-4">
+              <span
+                aria-hidden="true"
+                className="h-8 min-w-0 flex-1 rounded-md bg-[var(--transparency-block)]"
+              />
+              <span
+                aria-hidden="true"
+                className="size-8 shrink-0 rounded-md bg-[var(--transparency-block)]"
+              />
+            </div>
+            <div className="min-h-0 flex-1 overflow-hidden px-4">
+              <div className="agent-gui-node__conversation-list-skeleton">
+                {conversationSkeletonRowSizes.map((size, index) => (
+                  <div
+                    className="agent-gui-node__conversation-list-skeleton-row"
+                    data-size={size}
+                    key={`${size}-${index}`}
+                  >
+                    <span className="agent-gui-node__conversation-list-skeleton-spine" />
+                    <span className="agent-gui-node__conversation-list-skeleton-rib agent-gui-node__conversation-list-skeleton-rib-primary" />
+                    <span className="agent-gui-node__conversation-list-skeleton-rib agent-gui-node__conversation-list-skeleton-rib-secondary" />
+                  </div>
+                ))}
+              </div>
+            </div>
+          </aside>
+          <section className="agent-gui-node__detail-panel">
+            <div className="agent-gui-node__detail pt-11">
+              <div className="flex h-full min-h-0 flex-1 flex-col">
+                <div className="agent-gui-node__timeline agent-gui-node__timeline-centered">
+                  <div
+                    className="grid min-w-full grid-cols-[minmax(0,1fr)] gap-6"
+                    data-agent-gui-startup-timeline-content="true"
+                  >
+                    <div className="agent-gui-node__empty-hero">
+                      <div className="agent-gui-node__empty-hero-body">
+                        <div
+                          className="agent-gui-node__empty-hero-icon-slot"
+                          data-carousel-placeholder={true}
+                        >
+                          <div
+                            aria-hidden="true"
+                            className="flex h-28 w-full items-center justify-center gap-4"
+                          >
+                            <span className="h-16 w-14 -rotate-6 rounded-lg bg-[var(--transparency-block)]" />
+                            <span className="size-20 rounded-xl bg-[var(--transparency-block)]" />
+                            <span className="h-16 w-14 rotate-6 rounded-lg bg-[var(--transparency-block)]" />
+                          </div>
+                        </div>
+                        <h2 className="agent-gui-node__empty-hero-title">
+                          <span
+                            aria-hidden="true"
+                            className="inline-block h-9 w-[min(440px,80%)] rounded-md bg-[var(--transparency-block)]"
+                          />
+                        </h2>
+                        <div
+                          className="agent-gui-node__composer-hero"
+                          data-layout="hero"
+                        >
+                          <div className="agent-gui-node__composer-input-group agent-gui-node__composer-input-group-hero">
+                            <div className="agent-gui-node__composer-input-shell agent-gui-node__composer-input-shell-hero">
+                              <div className="agent-gui-node__composer-hero-prompt-input-area">
+                                <textarea
+                                  aria-label={loadingLabel}
+                                  className="h-[46px] min-h-[46px] w-full resize-none border-0 bg-transparent p-0 text-[13px] outline-none"
+                                  disabled
+                                  rows={2}
+                                />
+                              </div>
+                              <div
+                                aria-hidden="true"
+                                className="agent-gui-node__composer-footer"
+                              >
+                                <div className="agent-gui-node__composer-footer-left">
+                                  <span className="size-7 rounded-md bg-[var(--transparency-block)]" />
+                                  <span className="h-7 w-20 rounded-md bg-[var(--transparency-block)]" />
+                                </div>
+                                <div className="agent-gui-node__composer-footer-right">
+                                  <span className="h-7 w-16 rounded-md bg-[var(--transparency-block)]" />
+                                  <Spinner
+                                    className="text-[var(--text-tertiary)]"
+                                    size={16}
+                                  />
+                                </div>
+                              </div>
+                            </div>
+                          </div>
+                          <div className="agent-gui-node__composer-project-row">
+                            <span
+                              aria-hidden="true"
+                              className="h-7 w-28 shrink-0 rounded-md bg-[var(--transparency-block)]"
+                            />
+                            <div className="agent-gui-node__composer-prompt-tips">
+                              <span className="agent-gui-node__composer-prompt-tip">
+                                <span className="agent-gui-node__composer-prompt-tip-track">
+                                  <span className="agent-gui-node__composer-prompt-tip-item">
+                                    <span
+                                      aria-hidden="true"
+                                      className="inline-block h-2.5 w-56 rounded-full bg-[var(--transparency-block)]"
+                                    />
+                                  </span>
+                                </span>
+                              </span>
+                            </div>
+                          </div>
+                        </div>
+                        <div className="agent-gui-node__empty-hero-suggestions">
+                          <div
+                            aria-hidden="true"
+                            className="agent-gui-node__empty-hero-suggestions-chips"
+                          >
+                            <span className="h-8 w-24 rounded-full bg-[var(--transparency-block)]" />
+                            <span className="h-8 w-32 rounded-full bg-[var(--transparency-block)]" />
+                            <span className="h-8 w-30 rounded-full bg-[var(--transparency-block)]" />
+                            <span className="h-8 w-36 rounded-full bg-[var(--transparency-block)]" />
+                            <span className="h-8 w-28 rounded-full bg-[var(--transparency-block)]" />
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </section>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/packages/agent/gui/package.json
+++ b/packages/agent/gui/package.json
@@ -7,6 +7,7 @@
   "exports": {
     ".": "./index.ts",
     "./agent-gui": "./AgentGUI.tsx",
+    "./startup-shell": "./AgentGUIStartupShell.tsx",
     "./agents": "./agents.ts",
     "./custom-mention": "./custom-mention.ts",
     "./dock-icons": "./dockIcons.ts",
@@ -115,6 +116,10 @@
         "types": "./dist/agent-gui.d.ts",
         "import": "./dist/agent-gui.js"
       },
+      "./startup-shell": {
+        "types": "./dist/startup-shell.d.ts",
+        "import": "./dist/startup-shell.js"
+      },
       "./agents": {
         "types": "./dist/agents.d.ts",
         "import": "./dist/agents.js"
@@ -210,6 +215,9 @@
       "*": {
         "agent-gui": [
           "./dist/agent-gui.d.ts"
+        ],
+        "startup-shell": [
+          "./dist/startup-shell.d.ts"
         ],
         "agents": [
           "./dist/agents.d.ts"

--- a/packages/agent/gui/tsup.config.ts
+++ b/packages/agent/gui/tsup.config.ts
@@ -6,6 +6,7 @@ export default defineConfig({
   entry: {
     index: "index.ts",
     "agent-gui": "AgentGUI.tsx",
+    "startup-shell": "AgentGUIStartupShell.tsx",
     agents: "agents.ts",
     "custom-mention": "custom-mention.ts",
     "dock-icons": "dockIcons.ts",


### PR DESCRIPTION
## Summary

- Statically include `DesktopAgentGUIWorkbenchBody` in the already-lazy OS workspace and standalone Agent routes, removing the second body-level dynamic import waterfall.
- Extract the source-agnostic AgentGUI body startup skeleton into `@tutti-os/agent-gui/startup-shell`; desktop continues to own standalone window chrome and host/runtime source decisions.
- Document the Vite + React Compiler cold-transform failure mode and distinguish module loading from runtime hydration.

## Verification

- `node --test apps/desktop/src/renderer/src/features/workspace-workbench/ui/StandaloneAgentStartupShell.test.ts apps/desktop/src/renderer/src/features/workspace-workbench/ui/StandaloneAgentWindow.test.ts` (17 passed)
- `pnpm check:changed --tail-lines 80` (11 lanes passed)
- `pnpm check:full` (18 tasks passed)
- Cold-start tracing before the change showed the nested body import taking about 4.6-5.0 seconds in development; after static ownership, body evaluation completed in about 39 ms and the remaining cold cost stayed at the route compilation boundary.

## Fix Scope Justification

- Root cause: after either Agent route rendered, a nested `React.lazy` import discovered and transformed the large AgentGUI TSX graph. With React Compiler enabled in Vite serve, that second cold compilation boundary produced a multi-second blank window.
- Why this cannot be fixed at a lower layer: the body-level import boundary is the source of the delayed discovery. A lower AgentGUI component does not execute until that import resolves. The line count is primarily moving the existing structured skeleton into a reusable package entry and updating route ownership/tests/docs, rather than adding new behavior.

## Checklist

- [x] I kept the change focused on one concern.
- [x] I updated documentation when behavior, setup, or contributor workflow changed.
- [x] I updated all README/CONTRIBUTING language variants when changing their English source.
- [x] I ran the lowest meaningful local checks for the changed surface.
- [x] My commits are signed off with DCO when required: `git commit -s`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Remove the nested body-level lazy import in Agent routes by statically including `DesktopAgentGUIWorkbenchBody`, which eliminates the second startup waterfall and fixes the multi‑second blank window in dev. Extracted a reusable startup shell to `@tutti-os/agent-gui/startup-shell` to keep the rail/hero visible while modules load.

- **Bug Fixes**
  - Statically load the AgentGUI body in both OS workspace and standalone routes; remove nested `React.lazy` boundary.
  - Keep a structured startup shell at route/hydration boundaries to avoid blank screens.
  - Dev cold-start: body compile dropped from ~4.6–5.0s to ~39ms; remaining cold cost stays at the route chunk.

- **Refactors**
  - Moved source-agnostic startup UI into `@tutti-os/agent-gui/startup-shell`; desktop retains standalone window chrome and host/runtime decisions.
  - Updated tests to assert static imports and shell geometry; expanded docs on Vite + React Compiler cold-transform behavior vs runtime hydration.

<sup>Written for commit fd093fb3ed764904b9477fe956d94a12c615f7fd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tutti-os/tutti/pull/1103?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

