### PR TITLE
fix(workspace-files): scope file preview visibility

### DIFF
--- a/apps/desktop/src/renderer/src/features/workspace-file-manager/ui/WorkspaceFileManagerPane.tsx
+++ b/apps/desktop/src/renderer/src/features/workspace-file-manager/ui/WorkspaceFileManagerPane.tsx
@@ -29,6 +29,7 @@ interface WorkspaceFileManagerPaneProps {
     requestID: string;
   } | null;
   restoredState?: WorkspaceFileManagerPersistedState | null;
+  showPreviewPanel?: boolean;
   workspaceID: string;
 }
 
@@ -36,6 +37,7 @@ export function WorkspaceFileManagerPane({
   className,
   revealIntent = null,
   restoredState = null,
+  showPreviewPanel = true,
   workspaceID
 }: WorkspaceFileManagerPaneProps) {
   const { i18n: appI18n, locale } = useTranslation();
@@ -169,7 +171,7 @@ export function WorkspaceFileManagerPane({
       resolveEntryIconUrl={resolveEntryIconUrl}
       renderExternalLocationContent={renderExternalLocationContent}
       session={session}
-      showPreviewPanel={false}
+      showPreviewPanel={showPreviewPanel}
       surface="embedded"
     />
   );

--- a/apps/desktop/src/renderer/src/features/workspace-workbench/ui/StandaloneAgentToolSidebarPanel.tsx
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/ui/StandaloneAgentToolSidebarPanel.tsx
@@ -105,6 +105,7 @@ export function StandaloneAgentToolSidebarPanel({
         <LazyWorkspaceFileManagerPane
           className="h-full"
           revealIntent={fileOpenRequest}
+          showPreviewPanel={false}
           workspaceID={workspaceId}
         />
       </Suspense>

--- a/apps/desktop/src/renderer/src/features/workspace-workbench/ui/WorkspaceFilesNodeBody.test.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/ui/WorkspaceFilesNodeBody.test.ts
@@ -1,0 +1,13 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import test from "node:test";
+
+const source = readFileSync(
+  new URL("./WorkspaceFilesNodeBody.tsx", import.meta.url),
+  "utf8"
+);
+
+test("workspace files node keeps the file preview panel visible", () => {
+  assert.match(source, /<WorkspaceFileManagerPane[\s\S]*?showPreviewPanel/);
+  assert.doesNotMatch(source, /showPreviewPanel=\{false\}/);
+});

--- a/apps/desktop/src/renderer/src/features/workspace-workbench/ui/WorkspaceFilesNodeBody.tsx
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/ui/WorkspaceFilesNodeBody.tsx
@@ -27,6 +27,7 @@ function WorkspaceFilesNodeBody({
         className="min-h-0 flex-1 text-[13px]"
         restoredState={externalNodeState}
         revealIntent={toWorkspaceFilesRevealIntent(activation)}
+        showPreviewPanel
         workspaceID={workspaceId}
       />
     </div>

--- a/apps/desktop/src/renderer/src/features/workspace-workbench/ui/standaloneAgentToolWorkbench.test.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/ui/standaloneAgentToolWorkbench.test.ts
@@ -306,7 +306,7 @@ test("standalone Agent right sidebar reserves layout space and reveals requested
   );
   assert.match(
     standaloneAgentToolSidebarPanelSource,
-    /<LazyWorkspaceFileManagerPane[\s\S]*?revealIntent=\{fileOpenRequest\}/
+    /<LazyWorkspaceFileManagerPane[\s\S]*?revealIntent=\{fileOpenRequest\}[\s\S]*?showPreviewPanel=\{false\}/
   );
 });
 


### PR DESCRIPTION
## Summary

- Restore the preview panel in the Workspace file manager node.
- Keep the preview panel disabled in the standalone Agent right-side Files tool.
- Pass the preview visibility switch through the desktop file manager pane and add regression coverage for both hosts.

## Verification

- pnpm check:full
- Focused desktop tests: 30 passed
- Desktop typecheck and Oxfmt checks passed

## Checklist

- [x] I kept the change focused on one concern.
- [x] I updated documentation when behavior, setup, or contributor workflow changed. No durable documentation impact was found.
- [x] I updated all README/CONTRIBUTING language variants when changing their English source. Not applicable.
- [x] I ran the lowest meaningful local checks for the changed surface.
- [x] My commits are signed off with DCO when required: git commit -s

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restore the file preview panel in the Workspace Files node and keep it disabled in the standalone Agent Files tool. Adds a `showPreviewPanel` toggle to scope behavior per host and includes tests to prevent regressions.

- **Bug Fixes**
  - Plumbed `showPreviewPanel` through `WorkspaceFileManagerPane` to control visibility per host.
  - Standalone Agent sidebar now passes `showPreviewPanel={false}`; tests assert workspace stays visible and standalone stays off.

<sup>Written for commit 3aa5553cec94358e894ee49d8502731ca83dad9d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tutti-os/tutti/pull/1104?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

