### PR TITLE
fix(agent): classify Codex rate-limit windows by duration

### DIFF
--- a/packages/agent/daemon/runtime/codex_appserver_adapter_test.go
+++ b/packages/agent/daemon/runtime/codex_appserver_adapter_test.go
@@ -4182,6 +4182,41 @@ func TestCodexAppServerAdapterRateLimitNotificationUpdatesUsage(t *testing.T) {
 	}
 }
 
+func TestCodexAppServerAdapterClassifiesPrimaryWeeklyRateLimitFromDuration(t *testing.T) {
+	t.Parallel()
+
+	adapter, transport, session := startedAppServerAdapter(t)
+	transport.conn.notify(appServerNotifyRateLimitsUpdated, map[string]any{
+		"rateLimits": map[string]any{
+			"primary": map[string]any{
+				"resetsAt":           1784604546,
+				"usedPercent":        14,
+				"windowDurationMins": 7 * 24 * 60,
+			},
+			"secondary": nil,
+		},
+	})
+	waitForCondition(t, func() bool {
+		state := adapter.SessionState(session)
+		usage, _ := state.RuntimeContext["usage"].(map[string]any)
+		quotas, _ := usage["quotas"].([]map[string]any)
+		if len(quotas) != 1 || asString(quotas[0]["quotaType"]) != "weekly" {
+			return false
+		}
+		remaining, _ := acpFloatValue(quotas[0]["percentRemaining"])
+		return remaining == 86
+	})
+	state := adapter.SessionState(session)
+	usage, _ := state.RuntimeContext["usage"].(map[string]any)
+	quotas, _ := usage["quotas"].([]map[string]any)
+	if len(quotas) != 1 {
+		t.Fatalf("quotas = %#v, want one weekly quota", quotas)
+	}
+	if resetsAt, _ := int64Value(quotas[0]["resetsAtUnixMs"]); resetsAt != 1784604546000 {
+		t.Fatalf("weekly quota resetsAt = %#v", quotas[0])
+	}
+}
+
 func TestCodexAppServerAdapterApplySessionSettings(t *testing.T) {
 	t.Parallel()
 

--- a/packages/agent/daemon/runtime/codex_appserver_event_state.go
+++ b/packages/agent/daemon/runtime/codex_appserver_event_state.go
@@ -168,7 +168,7 @@ func appServerRateLimitQuotas(snapshot map[string]any) []map[string]any {
 			usedPercent = 100
 		}
 		quota := map[string]any{
-			"quotaType":        window.quotaType,
+			"quotaType":        appServerRateLimitQuotaType(entry, window.quotaType),
 			"percentRemaining": 100 - usedPercent,
 		}
 		if resetsAt, ok := int64Value(entry["resetsAt"]); ok && resetsAt > 0 {
@@ -183,6 +183,21 @@ func appServerRateLimitQuotas(snapshot map[string]any) []map[string]any {
 		return nil
 	}
 	return quotas
+}
+
+func appServerRateLimitQuotaType(entry map[string]any, fallback string) string {
+	durationMins, ok := int64Value(entry["windowDurationMins"])
+	if !ok {
+		return fallback
+	}
+	switch durationMins {
+	case 5 * 60:
+		return "session"
+	case 7 * 24 * 60:
+		return "weekly"
+	default:
+		return fallback
+	}
 }
 
 func appServerSystemNoticeEvent(session Session, turnID string, noticeKind string, title string, detail string, metadata ...map[string]any) activityshared.Event {


### PR DESCRIPTION
## Summary

- classify Codex 5-hour and 7-day limits from windowDurationMins instead of primary/secondary position
- retain positional fallback when duration metadata is absent or unknown
- cover the weekly-only primary-window payload returned by current Codex app-server

## Testing

- pnpm check:full
- pnpm check:changed --tail-lines 30
- go test ./packages/agent/daemon/...
- focused Codex rate-limit adapter tests

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Classifies Codex rate-limit windows by `windowDurationMins` instead of primary/secondary, fixing mislabeling between 5-hour and 7-day quotas and supporting weekly-only payloads. Keeps a positional fallback when duration is missing or unknown.

- **Bug Fixes**
  - Map 5-hour to `session` and 7-day to `weekly` using `windowDurationMins`; fallback to primary/secondary if absent.
  - Support “primary weekly, no secondary” payloads from the Codex app-server; compute `percentRemaining` and `resetsAtUnixMs` correctly.
  - Added focused tests in `packages/agent/daemon/runtime/codex_appserver_adapter_test.go`.

<sup>Written for commit 98f34671fb4caec7a749624f398d71b1d6456d6c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tutti-os/tutti/pull/1109?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

