### PR TITLE
fix(agent): classify desktop Codex usage windows by duration

### DIFF
--- a/apps/desktop/src/main/agentProviderUsageProbe.test.ts
+++ b/apps/desktop/src/main/agentProviderUsageProbe.test.ts
@@ -60,12 +60,12 @@ test("listDesktopWorkspaceAgentProbes maps Codex OAuth usage windows", async () 
           rate_limit: {
             primary_window: {
               used_percent: 7,
-              limit_window_seconds: 18000,
+              limit_window_seconds: 604800,
               reset_at: 1781182502
             },
             secondary_window: {
               used_percent: 12,
-              limit_window_seconds: 604800,
+              limit_window_seconds: 18000,
               reset_at: 1781750585
             }
           },
@@ -107,12 +107,12 @@ test("listDesktopWorkspaceAgentProbes maps Codex OAuth usage windows", async () 
     assert.deepEqual(provider?.usage?.quotas, [
       {
         percentRemaining: 93,
-        quotaType: "session",
+        quotaType: "weekly",
         resetsAtUnixMs: 1781182502000
       },
       {
         percentRemaining: 88,
-        quotaType: "weekly",
+        quotaType: "session",
         resetsAtUnixMs: 1781750585000
       },
       {

--- a/apps/desktop/src/main/agentProviderUsageProbe.ts
+++ b/apps/desktop/src/main/agentProviderUsageProbe.ts
@@ -20,6 +20,8 @@ export { setClaudeOAuthKeychainReaderForTesting } from "./claudeProviderUsagePro
 const CODEX_DEFAULT_CHATGPT_BASE_URL = "https://chatgpt.com/backend-api/";
 const CODEX_CHATGPT_USAGE_PATH = "/wham/usage";
 const CODEX_API_USAGE_PATH = "/api/codex/usage";
+const CODEX_SESSION_USAGE_WINDOW_SECONDS = 5 * 60 * 60;
+const CODEX_WEEKLY_USAGE_WINDOW_SECONDS = 7 * 24 * 60 * 60;
 
 interface CodexCredentials {
   accessToken: string;
@@ -452,16 +454,18 @@ function normalizeCodexChatGPTBaseUrl(value: string): string {
 
 function codexUsageQuotas(response: CodexUsageResponse): AgentUsageQuota[] {
   const quotas: AgentUsageQuota[] = [];
+  const primaryWindow = response.rate_limit?.primary_window;
   const primary = codexUsageWindowToQuota(
-    response.rate_limit?.primary_window,
-    "session"
+    primaryWindow,
+    codexUsageQuotaType(primaryWindow, "session")
   );
   if (primary) {
     quotas.push(primary);
   }
+  const secondaryWindow = response.rate_limit?.secondary_window;
   const secondary = codexUsageWindowToQuota(
-    response.rate_limit?.secondary_window,
-    "weekly"
+    secondaryWindow,
+    codexUsageQuotaType(secondaryWindow, "weekly")
   );
   if (secondary) {
     quotas.push(secondary);
@@ -490,6 +494,24 @@ function codexAdditionalRateLimitQuotas(
   return [primary, secondary].filter(
     (quota): quota is AgentUsageQuota => quota !== null
   );
+}
+
+// Keep duration semantics aligned with appServerRateLimitQuotaType in
+// packages/agent/daemon/runtime/codex_appserver_event_state.go. Empty-session
+// /status uses this desktop probe; active sessions use the daemon mapper.
+function codexUsageQuotaType(
+  window: CodexUsageWindow | null | undefined,
+  fallback: AgentUsageQuota["quotaType"]
+): AgentUsageQuota["quotaType"] {
+  const durationSeconds = numberValue(window?.limit_window_seconds);
+  switch (durationSeconds) {
+    case CODEX_SESSION_USAGE_WINDOW_SECONDS:
+      return "session";
+    case CODEX_WEEKLY_USAGE_WINDOW_SECONDS:
+      return "weekly";
+    default:
+      return fallback;
+  }
 }
 
 function codexUsageWindowToQuota(

--- a/docs/conventions/troubleshooting/agent-provider-setup.md
+++ b/docs/conventions/troubleshooting/agent-provider-setup.md
@@ -4,6 +4,35 @@
 
 Provider discovery, installation, authentication, models, configuration, and runtime reachability.
 
+### Codex `/status` shows a 5h limit for a weekly-only account window
+
+- Symptom:
+  Opening `/status` before starting a Codex conversation labels the only quota
+  as `5h limit`, while the upstream usage response reports a seven-day window.
+  An active conversation may show a different label.
+- Quick checks:
+  Inspect `agent.usage_probe.result` in desktop logs, then inspect the Codex
+  `/wham/usage` response shape. If `primary_window.limit_window_seconds` is
+  `604800` and `secondary_window` is absent, the primary slot is carrying the
+  weekly window. Compare this with daemon app-server telemetry, where the same
+  duration is `windowDurationMins: 10080`.
+- Root cause:
+  Empty-session `/status` loads account quotas through the desktop provider
+  probe, while active sessions receive canonical runtime usage from the daemon.
+  Both paths once inferred quota type from `primary`/`secondary` position, but
+  Codex may put the weekly-only quota in `primary`.
+- Fix:
+  Classify known Codex windows by duration in both mappers: five hours is
+  `session`, seven days is `weekly`. Use the positional type only when duration
+  is missing or unknown. Keep additional named rate limits typed as `model`.
+- Validation:
+  Cover a desktop probe response whose primary and secondary durations are
+  opposite their conventional positions, plus daemon mapper cases for a
+  weekly-only primary window. Verify both empty and active `/status` views.
+- References:
+  [agentProviderUsageProbe.ts](../../../apps/desktop/src/main/agentProviderUsageProbe.ts)
+  [codex_appserver_event_state.go](../../../packages/agent/daemon/runtime/codex_appserver_event_state.go)
+
 ### Provider setup notice flashes after switching to an already-connected agent
 
 - Symptom:

--- a/docs/conventions/troubleshooting/agent-runtime.md
+++ b/docs/conventions/troubleshooting/agent-runtime.md
@@ -8,6 +8,7 @@ Open only the area that matches the symptom:
 
 Provider discovery, installation, authentication, models, configuration, and runtime reachability.
 
+- [Codex `/status` shows a 5h limit for a weekly-only account window](./agent-provider-setup.md#codex-status-shows-a-5h-limit-for-a-weekly-only-account-window)
 - [Agent provider picker shows only Claude Code and Codex](./agent-provider-setup.md#agent-provider-picker-shows-only-claude-code-and-codex)
 - [Claude composer model list stays stale after credential switch](./agent-provider-setup.md#claude-composer-model-list-stays-stale-after-credential-switch)
 - [Claude SDK context window shows 200k for 1M models](./agent-provider-setup.md#claude-sdk-context-window-shows-200k-for-1m-models)

--- a/packages/agent/daemon/runtime/codex_appserver_event_state.go
+++ b/packages/agent/daemon/runtime/codex_appserver_event_state.go
@@ -185,6 +185,9 @@ func appServerRateLimitQuotas(snapshot map[string]any) []map[string]any {
 	return quotas
 }
 
+// Keep duration semantics aligned with codexUsageQuotaType in
+// apps/desktop/src/main/agentProviderUsageProbe.ts. Active sessions use this
+// daemon mapper; empty-session /status uses the desktop probe.
 func appServerRateLimitQuotaType(entry map[string]any, fallback string) string {
 	durationMins, ok := int64Value(entry["windowDurationMins"])
 	if !ok {


### PR DESCRIPTION
## Summary

- classify Codex desktop usage windows by duration instead of primary/secondary position
- preserve model quota typing and positional fallback for unknown durations
- add cross-references between desktop and daemon mappers
- document the empty-session versus active-session usage paths

Follow-up to #1109: that PR fixed the daemon runtime mapper; this PR fixes the desktop provider probe used by empty-session `/status`.

## Validation

- focused desktop provider usage probe tests
- focused Codex app-server rate-limit tests
- `pnpm check:changed` (failed Go lane rerun passed)
- `pnpm check:full` via pre-push hook
- desktop typecheck and build

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Codex desktop usage quota labels by classifying windows by duration (5h=session, 7d=weekly). Aligns the desktop probe with the daemon mapper so weekly-only accounts no longer show a 5h limit in empty-session `/status`.

- **Bug Fixes**
  - Infer quota type from `limit_window_seconds`; fall back to primary/secondary when unknown; keep additional rate limits typed as `model`.
  - Keep duration semantics consistent with the daemon runtime for both empty and active `/status`.
  - Update tests and troubleshooting docs; add cross-references between `apps/desktop` and `packages/agent/daemon` mappers.

<sup>Written for commit f26e2840d9deb6901a085be75d79dfe2868bd067. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tutti-os/tutti/pull/1110?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

