### PR TITLE
fix(ci): publish claude binaries via S3 conditional writes

### DIFF
--- a/.github/workflows/publish-claude-code-binaries.yml
+++ b/.github/workflows/publish-claude-code-binaries.yml
@@ -108,45 +108,74 @@ jobs:
             key="${prefix}/${relative_path}"
             local_size="$(wc -c < "${artifact}" | tr -d ' ')"
             local_sha256="$(sha256sum "${artifact}" | awk '{print $1}')"
-            # Keys are immutable: skip only when the object exists AND matches
-            # the staged bytes — the sha256 stored as object metadata at upload
-            # time when available, the size otherwise (e.g. a manually mirrored
-            # object). A mismatch means a corrupted or foreign publish and must
-            # stop the job. Any head-object failure other than a plain 404
-            # (auth, throttling, outage) must also stop the job instead of
-            # being treated as "missing".
-            if head_json="$(aws s3api head-object --bucket "${S3_BUCKET_VALUE}" --key "${key}" \
-                --output json 2>head-error.txt)"; then
-              remote_size="$(node -e "process.stdout.write(String(JSON.parse(process.argv[1]).ContentLength))" "${head_json}")"
-              remote_sha256="$(node -e "process.stdout.write(JSON.parse(process.argv[1]).Metadata?.['claude-sha256'] ?? '')" "${head_json}")"
-              # The size check is unconditional: the sha256 metadata is
-              # caller-supplied at upload time, not derived from the stored
-              # body, so matching metadata alone cannot vouch for the bytes.
-              if [ "${remote_size}" != "${local_size}" ]; then
-                echo "immutable key already exists with different content: s3://${S3_BUCKET_VALUE}/${key} (remote ${remote_size} bytes, staged ${local_size} bytes)" >&2
-                exit 1
-              fi
-              if [ -n "${remote_sha256}" ] && [ "${remote_sha256}" != "${local_sha256}" ]; then
-                echo "immutable key already exists with different content: s3://${S3_BUCKET_VALUE}/${key} (remote sha256 ${remote_sha256}, staged ${local_sha256})" >&2
-                exit 1
-              fi
-              echo "exists with matching content, skipping: s3://${S3_BUCKET_VALUE}/${key}"
-              skipped=$((skipped + 1))
-              continue
-            fi
-            if ! grep -qiE 'Not Found|NoSuchKey|404' head-error.txt; then
-              echo "head-object failed for s3://${S3_BUCKET_VALUE}/${key}:" >&2
-              cat head-error.txt >&2
-              exit 1
-            fi
             content_type="application/zstd"
             case "${artifact}" in
               *.json) content_type="application/json" ;;
             esac
-            aws s3 cp "${artifact}" "s3://${S3_BUCKET_VALUE}/${key}" \
-              --content-type "${content_type}" \
-              --cache-control "public, max-age=31536000, immutable" \
-              --metadata "claude-sha256=${local_sha256}"
-            uploaded=$((uploaded + 1))
+            # Keys are immutable. A conditional create (If-None-Match: *) has
+            # S3 itself enforce that: the object is written only when the key
+            # does not exist yet, atomically even across racing publishers. It
+            # also avoids probing missing keys with head-object, which reports
+            # 403 instead of 404 when the role lacks s3:ListBucket and would
+            # abort the job on a key that simply is not published yet.
+            outcome=""
+            for attempt in 1 2 3; do
+              if aws s3api put-object \
+                  --bucket "${S3_BUCKET_VALUE}" \
+                  --key "${key}" \
+                  --body "${artifact}" \
+                  --if-none-match '*' \
+                  --content-type "${content_type}" \
+                  --cache-control "public, max-age=31536000, immutable" \
+                  --metadata "claude-sha256=${local_sha256}" \
+                  >/dev/null 2>put-error.txt; then
+                outcome="uploaded"
+                break
+              fi
+              if grep -qiE 'PreconditionFailed' put-error.txt; then
+                outcome="exists"
+                break
+              fi
+              # 409 ConditionalRequestConflict: a concurrent publisher is
+              # writing this key right now. Wait for its create to land, then
+              # re-probe — the retry turns into a plain 412 once it exists.
+              if grep -qiE 'ConditionalRequestConflict' put-error.txt && [ "${attempt}" -lt 3 ]; then
+                sleep 15
+                continue
+              fi
+              echo "put-object failed for s3://${S3_BUCKET_VALUE}/${key}:" >&2
+              cat put-error.txt >&2
+              exit 1
+            done
+            if [ "${outcome}" = "uploaded" ]; then
+              echo "uploaded: s3://${S3_BUCKET_VALUE}/${key}"
+              uploaded=$((uploaded + 1))
+              continue
+            fi
+            # The key already exists: only treat it as published when it holds
+            # the staged bytes — a mismatch means a corrupted or foreign
+            # publish and must stop the job. head-object is reliable here
+            # regardless of s3:ListBucket because the object exists.
+            if ! head_json="$(aws s3api head-object --bucket "${S3_BUCKET_VALUE}" --key "${key}" \
+                --output json 2>head-error.txt)"; then
+              echo "existing object could not be verified for s3://${S3_BUCKET_VALUE}/${key} (does the role have s3:GetObject on this prefix?):" >&2
+              cat head-error.txt >&2
+              exit 1
+            fi
+            remote_size="$(node -e "process.stdout.write(String(JSON.parse(process.argv[1]).ContentLength))" "${head_json}")"
+            remote_sha256="$(node -e "process.stdout.write(JSON.parse(process.argv[1]).Metadata?.['claude-sha256'] ?? '')" "${head_json}")"
+            # The size check is unconditional: the sha256 metadata is
+            # caller-supplied at upload time, not derived from the stored
+            # body, so matching metadata alone cannot vouch for the bytes.
+            if [ "${remote_size}" != "${local_size}" ]; then
+              echo "immutable key already exists with different content: s3://${S3_BUCKET_VALUE}/${key} (remote ${remote_size} bytes, staged ${local_size} bytes)" >&2
+              exit 1
+            fi
+            if [ -n "${remote_sha256}" ] && [ "${remote_sha256}" != "${local_sha256}" ]; then
+              echo "immutable key already exists with different content: s3://${S3_BUCKET_VALUE}/${key} (remote sha256 ${remote_sha256}, staged ${local_sha256})" >&2
+              exit 1
+            fi
+            echo "exists with matching content, skipping: s3://${S3_BUCKET_VALUE}/${key}"
+            skipped=$((skipped + 1))
           done < <(find "${version_dir}" -type f | sort)
           echo "uploaded=${uploaded} skipped=${skipped} version=${CLAUDE_VERSION}"


### PR DESCRIPTION
## Summary

The first `Publish Claude Code Binaries` run on `main` (triggered by #1092's merge) failed before uploading anything: the `head-object` existence probe returned **403 Forbidden** for a key that simply did not exist yet. S3 reports 403 instead of 404 for missing keys when the caller lacks `s3:ListBucket`, and the guard added during #1092 review correctly treats non-404 probe failures as fatal. Net effect: the workflow can never publish a new version, the CDN has no `2.1.201` blobs, and packaged builds always fall back to the slow npm tarball path.

- Replace probe-then-copy with a conditional create: `aws s3api put-object --if-none-match '*'`. Missing keys are written atomically with no existence probe at all, and racing publishers can no longer double-write an immutable key — S3 hands the loser a 412 (`PreconditionFailed`) or a 409 (`ConditionalRequestConflict`, retried after a wait).
- `head-object` is now only used to verify keys that already exist, where it works regardless of `s3:ListBucket`.
- Verification order for existing keys is unchanged from the #1092 review decision: size is compared unconditionally first; the caller-supplied `claude-sha256` metadata remains an additional gate, never a substitute.

## Validation

- `bash -n` on the extracted upload-step script
- `node --test tools/scripts/desktop-release-config.test.mjs` (28 passed)
- End-to-end: `workflow_dispatch` of this branch's workflow against the production bucket (result reported in PR comments)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes production CDN publish behavior and IAM-sensitive S3 error handling, but scope is limited to one workflow step with preserved immutability checks on existing objects.
> 
> **Overview**
> Fixes **Publish Claude Code Binaries** failing on first publish when `head-object` on a missing key returns **403** (no `s3:ListBucket`) instead of 404, which blocked any new CDN blobs from being uploaded.
> 
> The upload step now **creates objects with** `put-object --if-none-match '*'` so S3 atomically writes only when the key is absent—no existence probe on new keys, and concurrent publishers get **412 PreconditionFailed** or **409 ConditionalRequestConflict** (retried after 15s) instead of double-writes. **`head-object` runs only after a conditional create loses**, to confirm an existing object matches staged **size** and **`claude-sha256`** metadata before counting it as skipped; mismatches still fail the job. Uploads use **`s3api put-object`** with the same content-type, cache-control, and metadata as before.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 19b13902e153d9b75dc80e5c76b842e5e6e5967a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes CI publishing of Claude Code binaries by using S3 conditional writes. This unblocks new releases and makes uploads atomic and safe under concurrency.

- **Bug Fixes**
  - Use `put-object --if-none-match '*'` to create only when the key is missing, avoiding `head-object` 403s without `s3:ListBucket`.
  - Handle races: treat 412 as “exists” and retry 409 with a short wait.
  - Only verify existing objects with `head-object`; compare size first, then optional `claude-sha256`; fail on mismatch.
  - Set `Content-Type`, immutable `Cache-Control`, and store `claude-sha256` metadata.

<sup>Written for commit 19b13902e153d9b75dc80e5c76b842e5e6e5967a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tutti-os/tutti/pull/1114?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

