### PR TITLE
fix(workspace-files): respect hidden search opt-in

### DIFF
--- a/services/tuttid/data/workspace/local_files_search.go
+++ b/services/tuttid/data/workspace/local_files_search.go
@@ -84,8 +84,8 @@ func (a LocalFilesAdapter) Search(
 
 	maxCandidates := a.maxSearchCandidates()
 	ignoredDirectories := a.ignoredDirectories()
-	allowHiddenFiles := input.IncludeHidden || workspacefiles.SearchQueryTargetsHiddenFile(input.Query)
-	allowHiddenAndNoiseDirectories := input.IncludeHidden || workspacefiles.SearchQueryTargetsHiddenOrNoise(input.Query)
+	allowHiddenFiles := input.IncludeHidden
+	allowHiddenAndNoiseDirectories := input.IncludeHidden
 	candidates, stats, walkErr := walkSearchCandidates(ctx, rootPath, searchRootPath, input, searchWalkOptions{
 		allowHiddenAndNoiseDirectories: allowHiddenAndNoiseDirectories,
 		allowHiddenFiles:               allowHiddenFiles,

--- a/services/tuttid/data/workspace/local_files_test.go
+++ b/services/tuttid/data/workspace/local_files_test.go
@@ -1009,7 +1009,7 @@ func TestLocalFilesAdapterSearchSkipsHiddenFilesForNormalQueries(t *testing.T) {
 	}
 }
 
-func TestLocalFilesAdapterSearchIncludesHiddenFilesWhenQueryExplicitlyTargetsThem(t *testing.T) {
+func TestLocalFilesAdapterSearchSkipsHiddenFilesWhenQueryExplicitlyTargetsThemWithoutOptIn(t *testing.T) {
 	t.Parallel()
 
 	rootDir := t.TempDir()
@@ -1018,11 +1018,11 @@ func TestLocalFilesAdapterSearchIncludesHiddenFilesWhenQueryExplicitlyTargetsThe
 		t.Fatal(err)
 	}
 
-	visibleEnvPath := filepath.Join(rootDir, "docs", "env.md")
+	visibleEnvPath := filepath.Join(rootDir, "docs", "runtime.env")
 	if err := os.MkdirAll(filepath.Dir(visibleEnvPath), 0o755); err != nil {
 		t.Fatal(err)
 	}
-	if err := os.WriteFile(visibleEnvPath, []byte("env docs"), 0o644); err != nil {
+	if err := os.WriteFile(visibleEnvPath, []byte("VISIBLE=1\n"), 0o644); err != nil {
 		t.Fatal(err)
 	}
 
@@ -1035,11 +1035,13 @@ func TestLocalFilesAdapterSearchIncludesHiddenFilesWhenQueryExplicitlyTargetsThe
 	if err != nil {
 		t.Fatalf("Search() error = %v", err)
 	}
-	if len(result.Entries) == 0 {
-		t.Fatal("expected explicit hidden file match")
+	for _, entry := range result.Entries {
+		if entry.Path == "/workspace/.env" {
+			t.Fatalf("unexpected hidden file result %#v", entry)
+		}
 	}
-	if result.Entries[0].Path != "/workspace/.env" {
-		t.Fatalf("first result = %#v, want /workspace/.env", result.Entries[0])
+	if len(result.Entries) != 1 || result.Entries[0].Path != "/workspace/docs/runtime.env" {
+		t.Fatalf("entries = %#v, want visible runtime.env only", result.Entries)
 	}
 }
 


### PR DESCRIPTION
## Summary

- make workspace file search honor `includeHidden` as the sole hidden-item opt-in
- keep dot-prefixed files and hidden/noise directories out of reference picker search by default
- add regression coverage for explicit dotfile queries while preserving visible matches

## Root cause

`LocalFilesAdapter.Search` treated an explicit dotfile query as an implicit hidden-file opt-in. The desktop reference adapter omitted `includeHidden`, but the daemon still admitted hidden candidates based on query text, contradicting the API default and the workspace-domain convention that hidden filtering is controlled by the shared `includeHidden` switch.

## Impact

Reference picker searches no longer surface hidden files unless the caller explicitly sets `includeHidden=true`. Explicit opt-in and direct hidden-path navigation behavior remain unchanged.

## Validation

- `go test ./data/workspace -run 'TestLocalFilesAdapterSearch(SkipsHiddenFilesWhenQueryExplicitlyTargetsThemWithoutOptIn|SkipsHiddenFilesForNormalQueries|IncludesHiddenFilesWhenIncludeHiddenIsTrue|DoesNotDescendHiddenDirsFor.*)$' -count=1`
- `pnpm check:changed -- --failed-only --tail-lines 120`
- `pnpm lint:go`
- `pnpm test:go`
- `pnpm build:go`
- `pnpm check:full` (18 tasks passed)
