### PR TITLE
fix(agent-gui): stage large pastes through explicit runtime contract

### DIFF
--- a/apps/desktop/src/renderer/src/features/workspace-agent/services/createDesktopAgentActivityRuntime.test.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-agent/services/createDesktopAgentActivityRuntime.test.ts
@@ -47,6 +47,46 @@ test("desktop agent activity runtime hides prompt uploads without archive suppor
   assert.equal(runtime.promptContentUploadSupport?.file, false);
   assert.equal(runtime.promptContentUploadSupport?.image, false);
   assert.equal(runtime.uploadPromptContent, undefined);
+  assert.equal(runtime.stagePastedText, undefined);
+});
+
+test("desktop agent activity runtime stages pasted text as a local prompt asset", async () => {
+  const archiveInputs: unknown[] = [];
+  const runtime = createDesktopAgentActivityRuntime(
+    createWorkspaceAgentActivityService(),
+    {
+      hostFilesApi: {
+        async archiveAgentPromptFile(input) {
+          archiveInputs.push(input);
+          return {
+            name: input.displayName ?? "attachment",
+            path: "/Users/local/Library/Application Support/Tutti/agent-prompt-assets/ws/pasted.txt",
+            sizeBytes: 12
+          };
+        }
+      }
+    }
+  );
+
+  const result = await runtime.stagePastedText?.({
+    workspaceId: "workspace-1",
+    text: "hello 世界",
+    name: "pasted-text.txt"
+  });
+
+  assert.deepEqual(archiveInputs, [
+    {
+      workspaceID: "workspace-1",
+      dataBase64: "aGVsbG8g5LiW55WM",
+      displayName: "pasted-text.txt",
+      mimeType: "text/plain"
+    }
+  ]);
+  assert.deepEqual(result, {
+    name: "pasted-text.txt",
+    path: "/Users/local/Library/Application Support/Tutti/agent-prompt-assets/ws/pasted.txt",
+    sizeBytes: 12
+  });
 });
 
 test("desktop agent activity runtime archives prompt file uploads", async () => {

--- a/apps/desktop/src/renderer/src/features/workspace-agent/services/createDesktopAgentActivityRuntime.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-agent/services/createDesktopAgentActivityRuntime.ts
@@ -378,6 +378,25 @@ export function createDesktopAgentActivityRuntime(
     },
     ...(archiveAgentPromptFile
       ? {
+          async stagePastedText(
+            input: Parameters<
+              NonNullable<AgentActivityRuntime["stagePastedText"]>
+            >[0]
+          ) {
+            const archived = await archiveAgentPromptFile({
+              workspaceID: input.workspaceId,
+              dataBase64: uint8ArrayToBase64(
+                new TextEncoder().encode(input.text)
+              ),
+              displayName: input.name,
+              mimeType: "text/plain"
+            });
+            return {
+              name: archived.name,
+              path: archived.path,
+              sizeBytes: archived.sizeBytes
+            };
+          },
           async uploadPromptContent(
             input: Parameters<
               NonNullable<AgentActivityRuntime["uploadPromptContent"]>

--- a/docs/architecture/agent-gui-node.md
+++ b/docs/architecture/agent-gui-node.md
@@ -2006,9 +2006,11 @@ Runtime capability declarations are also part of this contract. Missing
 capability keys default to enabled for backwards compatibility. Hosts can set
 `capabilities.canCancel`, `canSubmitInteractive`, `canGoalControl`, or
 `canUploadAttachment` to `false` to hide and no-op the corresponding AgentGUI
-UI affordance. `canUploadAttachment` applies to prompt attachment upload paths
-(pasted images, pasted large text, dropped/host-local files) and must not hide
-ordinary `@` references or workspace-reference mention selection.
+UI affordance. `canUploadAttachment` applies to prompt attachment paths and
+must not hide ordinary `@` references or workspace-reference mention
+selection. Large pasted text also requires the explicit optional
+`AgentActivityRuntime.stagePastedText` operation; generic file upload support
+is not sufficient evidence that a host can persist in-memory text.
 When `reportDiagnostic` is omitted, development builds use a low-cost console
 sink for AgentGUI diagnostics such as composer upload/submit state, message page
 requests/resolutions, render-state changes, and caught errors. Hosts can set
@@ -2338,6 +2340,25 @@ unless the paste leaves the caret immediately after the `@` trigger. A bare
 `@` paste may open the mention panel; a complete pasted query such as `@readme`
 should remain plain prompt text until the user explicitly places the caret in
 an active trigger position.
+
+Plain-text paste classification happens before structured mention-HTML
+delegation. Once the trimmed plain-text representation reaches 5,000
+characters, every editor paste entry point must classify it as large text and
+must not insert it inline. The composer creates one `pasted-text` draft item,
+then calls the dedicated `AgentActivityRuntime.stagePastedText` host boundary
+with raw text. The host owns local persistence and returns a managed absolute
+path, display name, and byte size. Do not encode pasted text as a generic
+`uploadPromptContent` file block or infer text-staging support from
+`promptContentUploadSupport.file`; external hosts may accept host paths while
+rejecting inline file bytes.
+
+The pasted-text state machine is `detected -> staging -> landed | failed`.
+Missing host support is a failed attachment state, not an inline fallback. The
+draft keeps the original text in memory so the user may explicitly restore it
+through “Show in text field”; automatic failure recovery must not violate the
+large-paste invariant. Uploading and failed pasted-text items block submission.
+The desktop runtime implements `stagePastedText` through the host prompt-asset
+archive and returns only the managed path metadata to AgentGUI.
 
 `workspace-reference` hrefs are the passive reference contract, not a visual
 metadata store. Do not serialize app icons into the href just to render a chip.

--- a/packages/agent/gui/README.md
+++ b/packages/agent/gui/README.md
@@ -27,9 +27,25 @@ Runtime-owned capability declarations are optional and default to enabled:
 - `canSubmitInteractive`: shows approval, ask-user, and plan-decision
   interaction entries.
 - `canGoalControl`: shows goal banner controls, `/goal`, and the goal badge.
-- `canUploadAttachment`: enables prompt attachment upload paths such as pasted
-  images, pasted large text, and dropped or host-local files. Ordinary `@`
-  references and workspace-reference mentions remain available.
+- `canUploadAttachment`: enables prompt attachment paths. Pasted large text
+  additionally requires the explicit `AgentActivityRuntime.stagePastedText`
+  host method; AgentGUI does not infer that capability from generic file
+  upload support. Ordinary `@` references and workspace-reference mentions
+  remain available.
+
+## Pasted Text Staging
+
+AgentGUI classifies plain-text clipboard content before delegating structured
+mention HTML. A trimmed payload of at least 5,000 characters is never inserted
+into the prompt automatically. It becomes a pasted-text draft attachment and
+is passed as raw text to `AgentActivityRuntime.stagePastedText`; the host owns
+local persistence and returns `{ path, name, sizeBytes }`.
+
+If the method is absent or staging fails, the attachment remains in an explicit
+failed state and retains its in-memory text. AgentGUI must not silently put the
+payload back into the input. The user can explicitly choose “Show in text
+field” to do that. Generic `uploadPromptContent` remains the contract for
+images and host-local files; it is not a pasted-text capability signal.
 
 Slash commands come from the runtime session command snapshot. AgentGUI keeps
 legacy provider-default slash entries unless the host passes

--- a/packages/agent/gui/agent-gui/agentGuiNode/AgentComposer.spec.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/AgentComposer.spec.tsx
@@ -18,6 +18,7 @@ import {
   resetAgentActivityRuntimeForTests,
   setAgentActivityRuntimeForTests,
   type AgentActivityRuntime,
+  type AgentActivityRuntimeStagePastedTextResult,
   type AgentActivityRuntimeUploadPromptContentResult
 } from "../../agentActivityRuntime";
 import type {
@@ -4127,9 +4128,7 @@ describe("AgentComposer", () => {
     ).not.toBeInTheDocument();
   });
 
-  it("falls back to inline text when the runtime cannot land pasted text", () => {
-    // Runtime without uploadPromptContent (e.g. web): the large paste must not
-    // be lost — it is re-inserted inline instead of becoming an un-landable chip.
+  it("keeps pasted large text out of the prompt when staging is unsupported", () => {
     setAgentActivityRuntimeForTests({} as unknown as AgentActivityRuntime);
 
     let draftContent = createDraft("hello");
@@ -4170,19 +4169,18 @@ describe("AgentComposer", () => {
 
     fireEvent.click(screen.getByTestId("mock-paste-large-text"));
 
-    expect(draftContent.prompt).toBe(
-      "hello\nfirst pasted line\nsecond pasted line"
-    );
-    expect(draftContent.largeTexts ?? []).toEqual([]);
-    expect(
-      screen.queryByTestId("agent-gui-composer-large-text-draft")
-    ).not.toBeInTheDocument();
+    expect(draftContent.prompt).toBe("hello");
+    expect(draftContent.largeTexts?.[0]).toMatchObject({
+      text: "first pasted line\nsecond pasted line",
+      uploading: false,
+      uploadError: expect.any(String)
+    });
   });
 
   it("does not upload pasted large text when attachment upload is disabled", () => {
-    const uploadPromptContent = vi.fn();
+    const stagePastedText = vi.fn();
     setAgentActivityRuntimeForTests({
-      uploadPromptContent
+      stagePastedText
     } as unknown as AgentActivityRuntime);
 
     let draftContent = createDraft("hello");
@@ -4224,24 +4222,26 @@ describe("AgentComposer", () => {
 
     fireEvent.click(screen.getByTestId("mock-paste-large-text"));
 
-    expect(uploadPromptContent).not.toHaveBeenCalled();
-    expect(draftContent.prompt).toBe(
-      "hello\nfirst pasted line\nsecond pasted line"
-    );
-    expect(draftContent.largeTexts ?? []).toEqual([]);
+    expect(stagePastedText).not.toHaveBeenCalled();
+    expect(draftContent.prompt).toBe("hello");
+    expect(draftContent.largeTexts?.[0]).toMatchObject({
+      text: "first pasted line\nsecond pasted line",
+      uploading: false,
+      uploadError: expect.any(String)
+    });
   });
 
   it("lands pasted large text as a file and submits a pasted-text file block", async () => {
-    type UploadResult = AgentActivityRuntimeUploadPromptContentResult;
+    type UploadResult = AgentActivityRuntimeStagePastedTextResult;
     let resolveUpload: (result: UploadResult) => void = () => undefined;
-    const uploadPromptContent = vi.fn(
+    const stagePastedText = vi.fn(
       () =>
         new Promise<UploadResult>((resolve) => {
           resolveUpload = resolve;
         })
     );
     setAgentActivityRuntimeForTests({
-      uploadPromptContent
+      stagePastedText
     } as unknown as AgentActivityRuntime);
 
     let draftContent = createDraft("");
@@ -4284,17 +4284,11 @@ describe("AgentComposer", () => {
 
     fireEvent.click(screen.getByTestId("mock-paste-large-text"));
 
-    // Phase 1: uploads the pasted text as UTF-8 base64 in a file block.
-    expect(uploadPromptContent).toHaveBeenCalledWith({
+    // Phase 1: stages raw pasted text through the dedicated host contract.
+    expect(stagePastedText).toHaveBeenCalledWith({
       workspaceId: "workspace-1",
-      content: [
-        {
-          type: "file",
-          data: "Zmlyc3QgcGFzdGVkIGxpbmUKc2Vjb25kIHBhc3RlZCBsaW5l",
-          mimeType: "text/plain",
-          name: "pasted-text.txt"
-        }
-      ]
+      text: "first pasted line\nsecond pasted line",
+      name: "pasted-text.txt"
     });
     expect(draftContent.largeTexts?.[0]).toMatchObject({
       text: "first pasted line\nsecond pasted line",
@@ -4317,14 +4311,9 @@ describe("AgentComposer", () => {
 
     // Phase 3: upload resolves → path filled, uploading cleared.
     resolveUpload({
-      content: [
-        {
-          type: "file",
-          path: "/archive/aa/deadbeef.txt",
-          name: "pasted-text.txt",
-          sizeBytes: 36
-        }
-      ]
+      path: "/archive/aa/deadbeef.txt",
+      name: "pasted-text.txt",
+      sizeBytes: 36
     });
     await waitFor(() =>
       expect(draftContent.largeTexts?.[0]).toMatchObject({
@@ -4359,16 +4348,16 @@ describe("AgentComposer", () => {
   });
 
   it("restores a pasted-text chip back into the composer as inline text", async () => {
-    type UploadResult = AgentActivityRuntimeUploadPromptContentResult;
+    type UploadResult = AgentActivityRuntimeStagePastedTextResult;
     let resolveUpload: (result: UploadResult) => void = () => undefined;
-    const uploadPromptContent = vi.fn(
+    const stagePastedText = vi.fn(
       () =>
         new Promise<UploadResult>((resolve) => {
           resolveUpload = resolve;
         })
     );
     setAgentActivityRuntimeForTests({
-      uploadPromptContent
+      stagePastedText
     } as unknown as AgentActivityRuntime);
 
     let draftContent = createDraft("hello");
@@ -4410,14 +4399,9 @@ describe("AgentComposer", () => {
 
     fireEvent.click(screen.getByTestId("mock-paste-large-text"));
     resolveUpload({
-      content: [
-        {
-          type: "file",
-          path: "/archive/aa/deadbeef.txt",
-          name: "pasted-text.txt",
-          sizeBytes: 36
-        }
-      ]
+      path: "/archive/aa/deadbeef.txt",
+      name: "pasted-text.txt",
+      sizeBytes: 36
     });
     await waitFor(() =>
       expect(draftContent.largeTexts?.[0]).toMatchObject({ uploading: false })

--- a/packages/agent/gui/agent-gui/agentGuiNode/AgentComposer.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/AgentComposer.tsx
@@ -156,6 +156,9 @@ export function AgentComposer(props: AgentComposerProps): React.JSX.Element {
   const promptFilesSupported = Boolean(
     resolveDroppedFileReferences && promptFileUploadSupported
   );
+  const pastedTextStagingSupported = Boolean(
+    canUploadAttachment && agentActivityRuntime?.stagePastedText
+  );
   const [isPaletteOpen, setIsPaletteOpen] = useState(true);
   const [isReviewPickerOpen, setIsReviewPickerOpen] = useState(false);
   const [isHandoffIconPlaying, setIsHandoffIconPlaying] = useState(false);
@@ -455,6 +458,7 @@ export function AgentComposer(props: AgentComposerProps): React.JSX.Element {
     promptImagesSupported: canUploadAttachment && promptImagesSupported,
     promptFileUploadSupported,
     promptFilesSupported,
+    pastedTextStagingSupported,
     editorHandleRef,
     draftPromptRef,
     draftImagesRef,

--- a/packages/agent/gui/agent-gui/agentGuiNode/agentRichText/AgentRichTextEditor.spec.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/agentRichText/AgentRichTextEditor.spec.tsx
@@ -368,6 +368,32 @@ describe("AgentRichTextEditor", () => {
     );
   });
 
+  it("detects long pasted text before handling structured mention html", async () => {
+    const onChange = vi.fn();
+    const onPasteLargeText = vi.fn();
+    const pastedText = "x".repeat(5_000);
+    render(
+      <AgentRichTextEditor
+        value="before "
+        disabled={false}
+        placeholder="Prompt"
+        onChange={onChange}
+        onSubmit={vi.fn()}
+        onPasteLargeText={onPasteLargeText}
+      />
+    );
+
+    fireEvent.paste(await screen.findByRole("textbox", { name: "Prompt" }), {
+      clipboardData: clipboard(
+        pastedText,
+        '<span data-agent-file-mention="true">copied mention</span>'
+      )
+    });
+
+    expect(onPasteLargeText).toHaveBeenCalledWith(pastedText);
+    expect(onChange).not.toHaveBeenCalledWith(expect.stringContaining("xxx"));
+  });
+
   it("keeps short pasted text inline when large text handling is available", async () => {
     const onChange = vi.fn();
     const onPasteLargeText = vi.fn();

--- a/packages/agent/gui/agent-gui/agentGuiNode/agentRichText/AgentRichTextEditor.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/agentRichText/AgentRichTextEditor.tsx
@@ -38,6 +38,7 @@ import type {
 } from "./AgentRichTextEditor.types";
 import {
   buildWorkspaceFileMentionDropContent,
+  classifyAgentRichTextTextPaste,
   createAgentRichTextCaretAnchorExtension,
   createAgentRichTextPlaceholderExtension,
   isAgentRichTextLargeTextPaste,
@@ -435,21 +436,24 @@ export const AgentRichTextEditor = forwardRef<
             }
           }
           const html = event.clipboardData?.getData("text/html") ?? "";
-          if (html.includes("data-agent-file-mention")) {
+          const text = event.clipboardData?.getData("text/plain") ?? "";
+          const textPasteKind = classifyAgentRichTextTextPaste(
+            text,
+            html,
+            Boolean(onPasteLargeTextRef.current)
+          );
+          if (textPasteKind === "empty") {
             return false;
           }
-          const text = event.clipboardData?.getData("text/plain") ?? "";
-          if (!text) {
+          if (textPasteKind === "large-text") {
+            event.preventDefault();
+            onPasteLargeTextRef.current?.(text);
+            return true;
+          }
+          if (textPasteKind === "structured-mention") {
             return false;
           }
           event.preventDefault();
-          if (
-            onPasteLargeTextRef.current &&
-            isAgentRichTextLargeTextPaste(text)
-          ) {
-            onPasteLargeTextRef.current(text);
-            return true;
-          }
           const currentEditor = editorRef.current;
           if (!currentEditor) {
             return true;

--- a/packages/agent/gui/agent-gui/agentGuiNode/agentRichText/agentRichTextEditorSupport.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/agentRichText/agentRichTextEditorSupport.ts
@@ -18,6 +18,28 @@ export function isAgentRichTextLargeTextPaste(text: string): boolean {
   return text.trim().length >= AGENT_RICH_TEXT_LARGE_PASTE_MIN_CHARS;
 }
 
+export type AgentRichTextTextPasteKind =
+  | "empty"
+  | "large-text"
+  | "plain-text"
+  | "structured-mention";
+
+export function classifyAgentRichTextTextPaste(
+  text: string,
+  html: string,
+  largeTextHandlingAvailable: boolean
+): AgentRichTextTextPasteKind {
+  if (!text) {
+    return "empty";
+  }
+  if (largeTextHandlingAvailable && isAgentRichTextLargeTextPaste(text)) {
+    return "large-text";
+  }
+  return html.includes("data-agent-file-mention")
+    ? "structured-mention"
+    : "plain-text";
+}
+
 export function buildWorkspaceFileMentionDropContent(
   entries: ReadonlyArray<{
     path: string;

--- a/packages/agent/gui/agent-gui/agentGuiNode/composer/ComposerDraftAttachments.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/composer/ComposerDraftAttachments.tsx
@@ -61,6 +61,9 @@ export function ComposerDraftAttachments({
             const attachmentTitle = translate(
               "agentHost.agentGui.pastedTextAttachmentTitle"
             );
+            const attachmentStatus = item.uploadError
+              ? translate("agentHost.agentGui.pastedTextAttachmentFailed")
+              : attachmentTitle;
             const restoreLabel = translate(
               "agentHost.agentGui.pastedTextRestoreToComposer"
             );
@@ -82,7 +85,9 @@ export function ComposerDraftAttachments({
                   className="flex min-w-0 items-center gap-2 rounded-[8px] text-left focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:color-mix(in_srgb,var(--text-primary)_34%,transparent)] disabled:cursor-default"
                   disabled={!canRestore}
                   aria-label={restoreLabel}
-                  title={canRestore ? restoreLabel : preview}
+                  title={
+                    item.uploadError ?? (canRestore ? restoreLabel : preview)
+                  }
                   onClick={() => expandDraftLargeTextToPrompt(item.id)}
                 >
                   <span className="flex size-9 shrink-0 items-center justify-center rounded-[8px] bg-[var(--transparency-hover)] text-[var(--text-secondary)]">
@@ -102,7 +107,7 @@ export function ComposerDraftAttachments({
                       {preview}
                     </span>
                     <span className="max-w-[200px] truncate text-[11px] text-[var(--text-tertiary)]">
-                      {attachmentTitle}
+                      {attachmentStatus}
                     </span>
                   </span>
                 </button>

--- a/packages/agent/gui/agent-gui/agentGuiNode/composer/composerDraftUtils.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/composer/composerDraftUtils.ts
@@ -1,23 +1,12 @@
 const GOAL_MODE_SLASH_COMMAND = "/goal";
 
 export const AGENT_COMPOSER_PASTED_TEXT_FILE_PREFIX = "pasted-text";
-export const AGENT_COMPOSER_PASTED_TEXT_MIME = "text/plain";
 
 export function agentComposerTextByteLength(text: string): number {
   if (typeof TextEncoder !== "undefined") {
     return new TextEncoder().encode(text).byteLength;
   }
   return text.length;
-}
-
-export function agentComposerTextToBase64(text: string): string {
-  const bytes = new TextEncoder().encode(text);
-  let binary = "";
-  const chunkSize = 0x8000;
-  for (let index = 0; index < bytes.length; index += chunkSize) {
-    binary += String.fromCharCode(...bytes.subarray(index, index + chunkSize));
-  }
-  return btoa(binary);
 }
 
 export function goalDraftObjectiveFromPrompt(prompt: string): string | null {

--- a/packages/agent/gui/agent-gui/agentGuiNode/composer/useComposerDraftAttachments.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/composer/useComposerDraftAttachments.ts
@@ -28,9 +28,7 @@ import {
 } from "../../../actions/workspaceLinkActions";
 import {
   AGENT_COMPOSER_PASTED_TEXT_FILE_PREFIX,
-  AGENT_COMPOSER_PASTED_TEXT_MIME,
   agentComposerTextByteLength,
-  agentComposerTextToBase64,
   buildGoalModePrompt,
   goalDraftObjectiveFromPrompt
 } from "./composerDraftUtils";
@@ -58,6 +56,7 @@ interface UseComposerDraftAttachmentsInput {
   promptImagesSupported: boolean;
   promptFileUploadSupported: boolean;
   promptFilesSupported: boolean;
+  pastedTextStagingSupported: boolean;
   editorHandleRef: RefObject<AgentRichTextEditorHandle | null>;
   draftPromptRef: RefObject<string>;
   draftImagesRef: RefObject<AgentComposerDraftImage[]>;
@@ -86,6 +85,7 @@ export function useComposerDraftAttachments({
   promptImagesSupported,
   promptFileUploadSupported,
   promptFilesSupported,
+  pastedTextStagingSupported,
   editorHandleRef,
   draftPromptRef,
   draftImagesRef,
@@ -398,30 +398,9 @@ export function useComposerDraftAttachments({
       if (!normalizedText.trim()) {
         return;
       }
-      const uploadPromptContent = promptFileUploadSupported
-        ? agentActivityRuntime?.uploadPromptContent
+      const stagePastedText = pastedTextStagingSupported
+        ? agentActivityRuntime?.stagePastedText
         : undefined;
-      if (!uploadPromptContent) {
-        // Landing is unsupported by this runtime (e.g. web). The editor already
-        // swallowed the native paste, so re-insert the text inline via the
-        // controlled prompt value to avoid losing it.
-        const currentPrompt = draftPromptRef.current;
-        const nextPrompt = currentPrompt.trim()
-          ? `${currentPrompt}\n${normalizedText}`
-          : normalizedText;
-        draftPromptRef.current = nextPrompt;
-        setPaletteDraftPrompt(nextPrompt);
-        onDraftContentChange({
-          prompt: nextPrompt,
-          images: draftImagesRef.current,
-          files: draftFilesRef.current,
-          largeTexts: draftLargeTextsRef.current
-        });
-        window.requestAnimationFrame(() => {
-          editorHandleRef.current?.focusAtEnd();
-        });
-        return;
-      }
       const id = crypto.randomUUID();
       const name = `${AGENT_COMPOSER_PASTED_TEXT_FILE_PREFIX}.txt`;
       const sizeBytes = agentComposerTextByteLength(normalizedText);
@@ -432,7 +411,13 @@ export function useComposerDraftAttachments({
           name,
           text: normalizedText,
           sizeBytes,
-          uploading: true
+          uploading: Boolean(stagePastedText),
+          ...(!stagePastedText
+            ? {
+                uploadError:
+                  "Pasted text staging is not supported by this agent runtime."
+              }
+            : {})
         }
       ];
       draftLargeTextsRef.current = nextDraftLargeTexts;
@@ -442,24 +427,18 @@ export function useComposerDraftAttachments({
         files: draftFilesRef.current,
         largeTexts: nextDraftLargeTexts
       });
-      void uploadPromptContent({
+      if (!stagePastedText) {
+        return;
+      }
+      void stagePastedText({
         workspaceId,
-        content: [
-          {
-            type: "file",
-            data: agentComposerTextToBase64(normalizedText),
-            mimeType: AGENT_COMPOSER_PASTED_TEXT_MIME,
-            name
-          }
-        ]
+        text: normalizedText,
+        name
       })
         .then((result) => {
-          const uploadedFile = result.content.find(
-            (block) => block.type === "file"
-          );
-          const uploadedPath = uploadedFile?.path?.trim() ?? "";
+          const uploadedPath = result.path.trim();
           if (!uploadedPath) {
-            throw new Error("Prompt text upload completed without path.");
+            throw new Error("Pasted text staging completed without path.");
           }
           const uploadedDraftLargeTexts = draftLargeTextsRef.current.map(
             (item) =>
@@ -467,7 +446,8 @@ export function useComposerDraftAttachments({
                 ? {
                     ...item,
                     path: uploadedPath,
-                    sizeBytes: uploadedFile?.sizeBytes ?? item.sizeBytes,
+                    name: result.name || item.name,
+                    sizeBytes: result.sizeBytes,
                     uploading: false
                   }
                 : item
@@ -500,7 +480,7 @@ export function useComposerDraftAttachments({
     [
       agentActivityRuntime,
       onDraftContentChange,
-      promptFileUploadSupported,
+      pastedTextStagingSupported,
       workspaceId
     ]
   );

--- a/packages/agent/gui/agentActivityRuntime.tsx
+++ b/packages/agent/gui/agentActivityRuntime.tsx
@@ -255,6 +255,23 @@ export interface AgentActivityRuntimeUploadPromptContentResult {
   content: AgentActivityRuntimePromptContentBlock[];
 }
 
+/**
+ * Dedicated host boundary for turning an in-memory text paste into a local
+ * prompt asset. The runtime owns persistence and returns a sendable host path;
+ * AgentGUI must not infer this capability from generic file-upload support.
+ */
+export interface AgentActivityRuntimeStagePastedTextInput {
+  name: string;
+  text: string;
+  workspaceId: string;
+}
+
+export interface AgentActivityRuntimeStagePastedTextResult {
+  name: string;
+  path: string;
+  sizeBytes: number;
+}
+
 export interface AgentActivityRuntimeSessionSectionScopeInput {
   agentTargetId?: string | null;
   sectionKey: string;
@@ -382,6 +399,9 @@ export interface AgentActivityRuntime {
   uploadPromptContent?(
     input: AgentActivityRuntimeUploadPromptContentInput
   ): Promise<AgentActivityRuntimeUploadPromptContentResult>;
+  stagePastedText?(
+    input: AgentActivityRuntimeStagePastedTextInput
+  ): Promise<AgentActivityRuntimeStagePastedTextResult>;
   readSessionAttachment?(
     input: AgentActivityRuntimeReadSessionAttachmentInput
   ): Promise<AgentActivityRuntimeSessionAttachment>;

--- a/packages/agent/gui/app/renderer/i18n/locales/en.agentGui.ts
+++ b/packages/agent/gui/app/renderer/i18n/locales/en.agentGui.ts
@@ -235,6 +235,7 @@ export const enAgentGui = {
   pastedTextFileLine:
     '- pasted text file "{{preview}}": {{path}}. Read this file before continuing.',
   pastedTextAttachmentTitle: "Pasted text",
+  pastedTextAttachmentFailed: "Pasted text couldn't be saved",
   pastedTextRestoreToComposer: "Show in text field",
   copyMessage: "Copy message",
   copyImage: "Copy image",

--- a/packages/agent/gui/app/renderer/i18n/locales/zh-CN.agentGui.ts
+++ b/packages/agent/gui/app/renderer/i18n/locales/zh-CN.agentGui.ts
@@ -218,6 +218,7 @@ export const zhCNAgentGui = {
   pastedTextFileLine:
     '- 粘贴的文本文件 "{{preview}}"：{{path}}，继续前请先阅读此文件。',
   pastedTextAttachmentTitle: "粘贴的文本",
+  pastedTextAttachmentFailed: "无法保存粘贴的文本",
   pastedTextRestoreToComposer: "在文本框中显示",
   copyMessage: "复制消息",
   copyImage: "复制图片",


### PR DESCRIPTION
## Summary
- classify plain-text paste before structured mention HTML so the 5,000-character threshold cannot be bypassed
- add a dedicated AgentActivityRuntime.stagePastedText host contract and desktop implementation
- keep unsupported or failed large pastes as explicit failed attachments instead of silently reinserting them inline
- document the pasted-text staging ownership and state machine

## Root cause
AgentGUI inferred in-memory pasted-text support from generic file upload support. Clipboard format branches could bypass classification, external hosts could advertise file support while rejecting inline bytes, and missing support silently restored the full payload to the input.

## Fix Scope Justification
- Root cause: the first invalid state is created when paste classification and persistence capability are split across the editor and Composer while the runtime exposes only a generic file boolean. That allows format branches to bypass the threshold and unsupported persistence to fall back inline.
- Lower layer: this cannot be fixed at a lower layer alone because the invariant spans clipboard classification, draft state, and the host persistence boundary. An editor-only fix leaves the ambiguous runtime contract and silent fallback; an upload-only fix cannot prevent editor branches from inserting the payload.

## Validation
- pnpm --filter @tutti-os/agent-gui test: 1953 passed
- pnpm --filter @tutti-os/desktop test: 1389 passed, 3 skipped
- AgentGUI and desktop typecheck passed
- pnpm check:agent-activity-runtime-boundaries passed
- pnpm check:i18n passed
- pnpm check:changed passed 11 lanes
- pre-push pnpm check:full passed 18 tasks