### PR TITLE
fix(agent): close Claude SDK synthetic turn lifecycle on session sink

### DIFF
--- a/docs/architecture/agent-gui-node.md
+++ b/docs/architecture/agent-gui-node.md
@@ -926,6 +926,12 @@ work is a new synthetic turn for AgentGUI lifecycle purposes. The sidecar and
 runtime adapter must publish a turn-start lifecycle patch before transcript or
 tool updates for that synthetic turn; otherwise AgentGuiNode will correctly keep
 the composer idle because the authoritative runtime state is still settled.
+The same adapter path must also publish that synthetic turn's
+completed/failed/canceled terminal through the session event sink. Synthetic
+turns are not submitted through `Exec()`/`ExecAsync()`, so they have no turn
+waiter; dropping waiter-less terminals as "untracked orphans" leaves durable
+`activeTurn` stuck in `running` and AgentGUI keeps showing the processing row
+after the assistant content has already finished.
 
 Do not persist the UI button state. A successful Undo only flips the local
 button to Reapply for the current render. If the page reloads, the source of

--- a/docs/conventions/troubleshooting/agent-approvals-subagents.md
+++ b/docs/conventions/troubleshooting/agent-approvals-subagents.md
@@ -258,14 +258,21 @@ TestCursorPermissionRequestFallsBackToKnownToolCallInput`. For a live check,
   resumes parent work after a background agent, the sidecar must emit
   `turn_started` for the synthetic continuation and the Go adapter must map it
   to `EventTurnStarted`; keep the background-agent wait banner separate from
-  this turn lifecycle. Top-level assistant text and thinking must be keyed by
-  SDK message/content-block segments rather than by turn id. Treat the live
-  `content_block.index` as a stream locator only, not as durable message
-  identity. Consolidated assistant messages are fallback/tail compensation only,
-  because their content array indexes can differ from live `stream_event` block
-  indexes when thinking or tools are present. Projection code that merges
-  repeated tool-message updates should remove stale `error` data when the
-  canonical status becomes completed.
+  this turn lifecycle. The adapter must also forward that synthetic turn's
+  `turn_completed` / `turn_failed` / `turn_canceled` through the same session
+  event sink. Synthetic turns never register an Exec waiter; treating every
+  waiter-less terminal as an untracked orphan drops the close event, leaves
+  durable `activeTurn.phase=running`, and keeps AgentGUI on
+  "正在规划下一步" after the final assistant message is already complete. Only
+  terminals for turns that never published `EventTurnStarted` on the session
+  sink should stay dropped (true queued orphans). Top-level assistant text and
+  thinking must be keyed by SDK message/content-block segments rather than by
+  turn id. Treat the live `content_block.index` as a stream locator only, not
+  as durable message identity. Consolidated assistant messages are
+  fallback/tail compensation only, because their content array indexes can
+  differ from live `stream_event` block indexes when thinking or tools are
+  present. Projection code that merges repeated tool-message updates should
+  remove stale `error` data when the canonical status becomes completed.
 - Validation:
   Add sidecar normalizer coverage for `parentToolUseId`/task steps and adapter
   coverage that terminal-after events still reach DB/UI through the session
@@ -274,8 +281,10 @@ TestCursorPermissionRequestFallsBackToKnownToolCallInput`. For a live check,
   copy clears when the background agent finishes. Add service coverage that
   runtime `backgroundAgents.count > 0` suppresses stale resume reconciliation
   even when there is no active parent turn. Add sidecar/adapter coverage for
-  synthetic continuation `turn_started`, plus projection coverage that a
-  completed tool update drops an earlier failed `error` payload. For alias
+  synthetic continuation `turn_started` plus the matching waiter-less
+  `turn_completed` closing through the session sink, and projection coverage
+  that a completed tool update drops an earlier failed `error` payload. Keep
+  coverage that never-started queued orphan terminals still drop. For alias
   binding, keep sidecar coverage that an unknown `task_id` racing ahead of its
   own launch does not bind to another running task, and Go adapter coverage
   that an alias conflict with a different recorded parent tool call keeps two

--- a/packages/agent/daemon/runtime/claude_sdk_adapter.go
+++ b/packages/agent/daemon/runtime/claude_sdk_adapter.go
@@ -63,6 +63,12 @@ type claudeSDKAdapterSession struct {
 	// fabricating a competing terminal transition. Guarded by the adapter
 	// mutex.
 	settledTurns map[string]string
+	// openSessionTurns remembers turn IDs whose EventTurnStarted was published
+	// through the session event sink without an Exec()/ExecAsync() waiter
+	// (synthetic background continuations). Their completed/failed/canceled
+	// terminal must close through the same sink; otherwise durable state stays
+	// running after the sidecar has finished. Guarded by the adapter mutex.
+	openSessionTurns map[string]struct{}
 	// goalArmTurnID is the sidecar turn carrying a queued /goal set command
 	// that has not settled yet; until it does, other turns settling must not
 	// be read as goal completion. Guarded by the adapter mutex.

--- a/packages/agent/daemon/runtime/claude_sdk_events.go
+++ b/packages/agent/daemon/runtime/claude_sdk_events.go
@@ -279,17 +279,16 @@ func (a *ClaudeCodeSDKAdapter) dispatchClaudeSDKEvent(agentSessionID string, ada
 		return
 	}
 	if terminal {
-		// No daemon-registered Exec()/ExecAsync() waiter is tracking this
-		// turnID's outcome: either its terminal event was already delivered
-		// once (the waiter already completed and was unregistered) or this
-		// turn never became the tracked active turn in the first place (for
-		// example an internal/queued Claude SDK turn — see turnQueue /
-		// settleQueuedTurn in the sidecar — that got settled without ever
-		// being submitted through Exec). Publishing it here would surface a
-		// stray, possibly contradictory outcome notification for the session:
-		// a phantom completed/failed toast landing alongside the real turn's
-		// own outcome toast for the same agent session. Drop it instead.
-		return
+		// No Exec()/ExecAsync() waiter is tracking this turnID. Drop only
+		// terminals for turns we never started on the session sink (queued
+		// orphans from sidecar turnQueue / settleQueuedTurn). Synthetic
+		// background continuations publish turn_started without a waiter;
+		// their completed/failed/canceled must close that same lifecycle.
+		if !a.consumeOpenSessionTurn(adapterSession, turnID) {
+			return
+		}
+	} else {
+		a.rememberOpenSessionTurns(adapterSession, next)
 	}
 	if err != nil {
 		next = append(next, newSessionActivityEvent(session, EventSessionFailed, SessionStatusFailed, map[string]any{
@@ -297,6 +296,59 @@ func (a *ClaudeCodeSDKAdapter) dispatchClaudeSDKEvent(agentSessionID string, ada
 		}))
 	}
 	a.emitClaudeSDKSessionEvents(agentSessionID, next)
+}
+
+// rememberOpenSessionTurns records turn IDs whose start was published through
+// the session event sink so a later waiter-less terminal can close them.
+func (a *ClaudeCodeSDKAdapter) rememberOpenSessionTurns(
+	adapterSession *claudeSDKAdapterSession,
+	events []activityshared.Event,
+) {
+	if a == nil || adapterSession == nil || len(events) == 0 {
+		return
+	}
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	for _, event := range events {
+		if event.Type != activityshared.EventTurnStarted {
+			continue
+		}
+		turnID := strings.TrimSpace(event.Payload.TurnID)
+		if turnID == "" {
+			continue
+		}
+		if adapterSession.openSessionTurns == nil {
+			adapterSession.openSessionTurns = make(map[string]struct{})
+		}
+		// Sessions are long-lived; keep the guard bounded rather than growing
+		// one entry per synthetic continuation forever.
+		if len(adapterSession.openSessionTurns) > 64 {
+			adapterSession.openSessionTurns = make(map[string]struct{})
+		}
+		adapterSession.openSessionTurns[turnID] = struct{}{}
+	}
+}
+
+// consumeOpenSessionTurn reports whether turnID was started on the session
+// sink and removes it so the matching terminal can be emitted once.
+func (a *ClaudeCodeSDKAdapter) consumeOpenSessionTurn(
+	adapterSession *claudeSDKAdapterSession,
+	turnID string,
+) bool {
+	if a == nil || adapterSession == nil {
+		return false
+	}
+	turnID = strings.TrimSpace(turnID)
+	if turnID == "" {
+		return false
+	}
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	if _, ok := adapterSession.openSessionTurns[turnID]; !ok {
+		return false
+	}
+	delete(adapterSession.openSessionTurns, turnID)
+	return true
 }
 
 func (a *ClaudeCodeSDKAdapter) registerClaudeSDKTurn(adapterSession *claudeSDKAdapterSession, turnID string, emit EventSink) *claudeSDKTurnWaiter {

--- a/packages/agent/daemon/runtime/claude_sdk_transport_test.go
+++ b/packages/agent/daemon/runtime/claude_sdk_transport_test.go
@@ -304,6 +304,78 @@ func TestClaudeCodeSDKAdapterDropsUntrackedTurnTerminalEvent(t *testing.T) {
 	}
 }
 
+// TestClaudeCodeSDKAdapterClosesSyntheticTurnLifecycleWithoutExecWaiter covers
+// the stuck "正在规划下一步" report: after a Claude SDK background Agent finishes,
+// the sidecar opens a synthetic continuation turn (turn_started, no Exec waiter)
+// and later settles it. Start and completed/failed/canceled must share the same
+// session-sink lifecycle; dropping the terminal left durable activeTurn running.
+func TestClaudeCodeSDKAdapterClosesSyntheticTurnLifecycleWithoutExecWaiter(t *testing.T) {
+	adapter := NewClaudeCodeSDKAdapter(nil)
+	session := standardTestSession(ProviderClaudeCode)
+	adapterSession := &claudeSDKAdapterSession{
+		session:           session,
+		providerSessionID: "provider-session-1",
+		pendingRequests:   make(map[string]*pendingInteractiveRequest),
+		pendingResponses:  make(map[string]chan claudeSDKSidecarEvent),
+		turns:             make(map[string]*claudeSDKTurnWaiter),
+		liveState:         newClaudeSDKLiveState(),
+	}
+	adapter.storeSession(session.AgentSessionID, adapterSession)
+
+	var published []activityshared.Event
+	adapter.SetSessionEventSink(func(agentSessionID string, events []activityshared.Event) {
+		if agentSessionID == session.AgentSessionID {
+			published = append(published, events...)
+		}
+	})
+
+	adapter.dispatchClaudeSDKEvent(session.AgentSessionID, adapterSession, claudeSDKSidecarEvent{
+		Type: "turn_started",
+		Payload: map[string]any{
+			"turnId":    "synthetic-continuation-1",
+			"synthetic": true,
+		},
+	})
+	adapter.dispatchClaudeSDKEvent(session.AgentSessionID, adapterSession, claudeSDKSidecarEvent{
+		Type: "assistant_completed",
+		Payload: map[string]any{
+			"turnId":  "synthetic-continuation-1",
+			"content": "background agent summary",
+		},
+	})
+	adapter.dispatchClaudeSDKEvent(session.AgentSessionID, adapterSession, claudeSDKSidecarEvent{
+		Type: "turn_completed",
+		Payload: map[string]any{
+			"turnId":     "synthetic-continuation-1",
+			"stopReason": "end_turn",
+		},
+	})
+
+	var sawStarted, sawMessage, sawCompleted bool
+	for _, event := range published {
+		switch event.Type {
+		case activityshared.EventTurnStarted:
+			sawStarted = true
+			if event.Payload.TurnID != "synthetic-continuation-1" {
+				t.Fatalf("start turn id = %q", event.Payload.TurnID)
+			}
+			if event.Payload.Metadata["synthetic"] != true {
+				t.Fatalf("start metadata = %#v, want synthetic=true", event.Payload.Metadata)
+			}
+		case activityshared.EventMessageAppended:
+			sawMessage = true
+		case activityshared.EventTurnCompleted:
+			sawCompleted = true
+			if event.Payload.TurnID != "synthetic-continuation-1" {
+				t.Fatalf("completed turn id = %q", event.Payload.TurnID)
+			}
+		}
+	}
+	if !sawStarted || !sawMessage || !sawCompleted {
+		t.Fatalf("published = %#v, want synthetic start + message + completed", published)
+	}
+}
+
 func TestClaudeCodeSDKAdapterRoundTripUsesReaderDispatcherAfterExec(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()


### PR DESCRIPTION
## Summary
- Claude SDK synthetic continuation turns publish `turn_started` without an Exec waiter; the adapter was dropping every waiter-less terminal as an untracked orphan.
- Track session-sink-started turns and forward their `completed`/`failed`/`canceled` through the same sink so durable `activeTurn` settles after background Agent continuations.
- Keep dropping never-started queued orphan terminals (phantom toast protection). Update architecture/troubleshooting notes and add a regression test.

## Test plan
- [x] `go test ./runtime -count=1 -run 'TestClaudeCodeSDKAdapter'` in `packages/agent/daemon`
- [ ] Reproduce Claude Code background Agent continuation: processing row clears after final assistant summary
- [ ] Confirm never-started orphan `turn_failed` still does not publish a stray session outcome


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes synthetic background continuation turns from the Claude SDK so their lifecycle closes on the session sink, preventing `activeTurn` from staying stuck and removing the lingering processing row after replies.

- **Bug Fixes**
  - Track session-sink-started synthetic turns and emit their `turn_completed` / `turn_failed` / `turn_canceled` through the same sink.
  - Drop only terminals for turns that never published `turn_started` (true queued orphans).
  - Add a regression test covering waiter-less synthetic continuation lifecycle.
  - Update architecture and troubleshooting docs to clarify the session-sink lifecycle.

<sup>Written for commit 54e4b22abfb020eda78b332556050970413d1ea6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tutti-os/tutti/pull/1120?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

