### PR TITLE
fix(agent): close Claude Code open tools on cancel

### DIFF
--- a/docs/architecture/claude-code-sdk-runtime.md
+++ b/docs/architecture/claude-code-sdk-runtime.md
@@ -37,6 +37,7 @@ The Go runtime under `packages/agent/daemon/runtime` is split by responsibility:
 | `claude_sdk_protocol.go`       | Protocol version and envelope validation                 |
 | `claude_sdk_session.go`        | Session storage, command/env helpers, and state payloads |
 | `claude_sdk_events.go`         | Sidecar event dispatch and lifecycle routing             |
+| `claude_sdk_turn.go`           | Per-turn event lifecycle via shared `acpTurnNormalizer`  |
 | `claude_sdk_activity.go`       | Conversion into normalized activity events               |
 | `claude_sdk_live_state.go`     | Live message, task, and usage state reconciliation       |
 | `claude_sdk_interactive.go`    | Approval and interactive prompt handling                 |
@@ -48,9 +49,14 @@ process/session lifecycle and normalization behind that selection. They must not
 raw SDK envelopes to services or GUI packages. Service-layer provider catalogs,
 composer profiles, targets, status probes, and identity projections consume the
 same `ProviderDescriptor` instead of re-registering Claude Code locally.
-Claude modules do not call ACP-owned helpers; protocol-neutral session and
-interactive activity projection have their own modules, while Claude goal,
-command, usage, and interaction decoding stay inside the Claude SDK boundary.
+Claude modules do not call ACP _protocol_ helpers (session-update decoding,
+standard ACP tool-call envelopes, and similar). Open tool-call bookkeeping and
+turn `Finish*` settlement reuse the shared adapter turn lifecycle
+(`acpTurnNormalizer`), the same entity Codex and standard ACP already use, so
+cancel/fail/complete close dangling tool cards instead of leaving them
+in progress. Protocol-neutral session and interactive activity projection have
+their own modules, while Claude goal, command, usage, and interaction decoding
+stay inside the Claude SDK boundary.
 New normalized session updates use `sessionUpdateKind`; the former ACP-named
 metadata key is accepted only while reading imported or durable historical
 events.

--- a/docs/conventions/troubleshooting/agent-runtime.md
+++ b/docs/conventions/troubleshooting/agent-runtime.md
@@ -52,6 +52,7 @@ Turn state, loading, cancel, restore, rail projection, event updates, imports, a
 - [Agent session restore breaks when durable snapshot ownership is split](./agent-session-lifecycle.md#agent-session-restore-breaks-when-durable-snapshot-ownership-is-split)
 - [Agent activity live updates fail after event schema changes](./agent-session-lifecycle.md#agent-activity-live-updates-fail-after-event-schema-changes)
 - [Remote agent cancel does not stop the local turn](./agent-session-lifecycle.md#remote-agent-cancel-does-not-stop-the-local-turn)
+- [Claude Code cancel leaves Write/tool cards stuck in progress](./agent-session-lifecycle.md#claude-code-cancel-leaves-writetool-cards-stuck-in-progress)
 - [AgentGUI freezes when session history is large](./agent-session-lifecycle.md#agentgui-freezes-when-session-history-is-large)
 - [Agent diagnostics flood while a turn is streaming](./agent-session-lifecycle.md#agent-diagnostics-flood-while-a-turn-is-streaming)
 - [Imported sessions trigger fresh-completion indicators](./agent-session-lifecycle.md#imported-sessions-trigger-fresh-completion-indicators)

--- a/docs/conventions/troubleshooting/agent-session-lifecycle.md
+++ b/docs/conventions/troubleshooting/agent-session-lifecycle.md
@@ -573,6 +573,45 @@ Turn state, loading, cancel, restore, rail projection, event updates, imports, a
   [controller.go](../../../packages/agent/daemon/runtime/controller.go)
   [controller_test.go](../../../packages/agent/daemon/runtime/controller_test.go)
 
+### Claude Code cancel leaves Write/tool cards stuck in progress
+
+- Symptom:
+  User stops a Claude Code turn while a tool such as Write is running. The turn
+  settles as canceled/interrupted, but the transcript still shows the tool as
+  in progress.
+- Quick checks:
+  Compare durable tool-call message status with turn outcome. If the turn is
+  interrupted/canceled and the open `tool_call` is still `running`, the Claude
+  SDK turn lifecycle did not finish dangling calls. Confirm Codex/ACP cancel of
+  the same shape closes open tools via `acpTurnNormalizer.FinishInterrupted`.
+- Root cause:
+  Claude Code SDK projected tool events without owning the shared turn event
+  lifecycle (`acpTurnNormalizer`). Cancel and sidecar `turn_canceled` settled
+  the turn without `Finish*`, so open tools never received a terminal
+  `call.failed`.
+- Fix:
+  Attach per-turn `acpTurnNormalizer` on the Claude SDK session. Track
+  `call.started/completed/failed` against that normalizer, and call
+  `FinishInterrupted` / `FinishFailed` / `FinishCompleted` as part of turn
+  terminalization (`Cancel`, sidecar `turn_*`, reader failure). Drop late tool
+  events after the turn is already settled.
+  Also: controller Cancel cancels the Exec context before `adapter.Cancel`.
+  Claude Exec unregisters its waiter on that context cancel, so Cancel must
+  finish open tools from the turn-normalizer map (not only live waiters), and
+  the Exec context-canceled path must retain CallFailed events instead of
+  replacing the whole event slice with a bare turn.canceled.
+- Validation:
+  `go test ./packages/agent/daemon/runtime -run 'TestClaudeCodeSDKAdapter(CancelFailsOpenToolCalls|CancelFailsOpenToolsAfterWaiterUnregistered|TurnCanceledFailsOpenToolCalls)'`.
+  Manually: start a long Write on Claude Code, press Stop, confirm the tool
+  card leaves "in progress". Rebuild/restart desktop so the running `tuttid`
+  binary includes the fix.
+- References:
+  [claude_sdk_turn.go](../../../packages/agent/daemon/runtime/claude_sdk_turn.go)
+  [claude_sdk_events.go](../../../packages/agent/daemon/runtime/claude_sdk_events.go)
+  [claude_sdk_execution.go](../../../packages/agent/daemon/runtime/claude_sdk_execution.go)
+  [controller_turn_exec.go](../../../packages/agent/daemon/runtime/controller_turn_exec.go)
+  [acp_turn_normalizer.go](../../../packages/agent/daemon/runtime/acp_turn_normalizer.go)
+
 ### AgentGUI freezes when session history is large
 
 - Symptom:

--- a/packages/agent/daemon/runtime/claude_sdk_adapter.go
+++ b/packages/agent/daemon/runtime/claude_sdk_adapter.go
@@ -47,9 +47,14 @@ type claudeSDKAdapterSession struct {
 	pendingRequests   map[string]*pendingInteractiveRequest
 	pendingResponses  map[string]chan claudeSDKSidecarEvent
 	turns             map[string]*claudeSDKTurnWaiter
-	liveState         claudeSDKLiveState
-	sendMu            sync.Mutex
-	readerStarted     bool
+	// turnNormalizers owns each Claude turn's event lifecycle the same way
+	// Codex/ACP use acpTurnNormalizer: track open tool calls while the turn is
+	// live, and Finish* closes dangling calls when the turn reaches a terminal
+	// state. Guarded by the adapter mutex.
+	turnNormalizers map[string]*acpTurnNormalizer
+	liveState       claudeSDKLiveState
+	sendMu          sync.Mutex
+	readerStarted   bool
 	// invalid is guarded by the adapter mutex. Once set, a stale Resume
 	// attempt must never put this session back into the live registry.
 	invalid bool

--- a/packages/agent/daemon/runtime/claude_sdk_event_projection_test.go
+++ b/packages/agent/daemon/runtime/claude_sdk_event_projection_test.go
@@ -608,6 +608,147 @@ func TestClaudeCodeSDKAdapterCancelClearsPendingInteractive(t *testing.T) {
 	}
 }
 
+func TestClaudeCodeSDKAdapterCancelFailsOpenToolCalls(t *testing.T) {
+	adapter := NewClaudeCodeSDKAdapter(nil)
+	session := standardTestSession(ProviderClaudeCode)
+	adapterSession := &claudeSDKAdapterSession{
+		conn:      &recordingClaudeSDKConnection{},
+		liveState: newClaudeSDKLiveState(),
+	}
+	adapter.storeSession(session.AgentSessionID, adapterSession)
+	adapter.registerClaudeSDKTurn(adapterSession, "turn-write", nil)
+
+	started, terminal, err := adapter.sidecarTurnEvents(adapterSession, session, "turn-write", claudeSDKSidecarEvent{
+		Type: "tool_started",
+		Payload: map[string]any{
+			"turnId":     "turn-write",
+			"toolCallId": "toolu-write",
+			"toolName":   "Write",
+			"name":       "Write",
+			"input": map[string]any{
+				"file_path": "/tmp/out.txt",
+				"content":   "partial",
+			},
+		},
+	})
+	if err != nil || terminal {
+		t.Fatalf("tool_started err=%v terminal=%v", err, terminal)
+	}
+	if len(started) != 1 || started[0].Type != activityshared.EventCallStarted {
+		t.Fatalf("started = %#v, want call.started", started)
+	}
+
+	events, err := adapter.Cancel(context.Background(), session, "user")
+	if err != nil {
+		t.Fatalf("Cancel: %v", err)
+	}
+	if len(events) != 2 {
+		t.Fatalf("cancel events = %#v, want failed open Write then interrupted turn", events)
+	}
+	if events[0].Type != activityshared.EventCallFailed ||
+		events[0].EventID != "claude-sdk:tool:toolu-write" ||
+		events[0].Payload.Status != SessionStatusCanceled {
+		t.Fatalf("open tool cancel event = %#v, want call.failed with canceled status", events[0])
+	}
+	if events[1].Type != activityshared.EventTurnCompleted ||
+		events[1].Payload.TurnOutcome != string(activityshared.TurnOutcomeInterrupted) {
+		t.Fatalf("cancel turn event = %#v, want interrupted turn", events[1])
+	}
+
+	late, terminal, err := adapter.sidecarTurnEvents(adapterSession, session, "turn-write", claudeSDKSidecarEvent{
+		Type: "tool_completed",
+		Payload: map[string]any{
+			"turnId":     "turn-write",
+			"toolCallId": "toolu-write",
+			"toolName":   "Write",
+			"name":       "Write",
+			"output":     map[string]any{"text": "done"},
+		},
+	})
+	if err != nil || terminal || len(late) != 0 {
+		t.Fatalf("late tool_completed after cancel = events=%#v terminal=%v err=%v, want dropped", late, terminal, err)
+	}
+}
+
+func TestClaudeCodeSDKAdapterCancelFailsOpenToolsAfterWaiterUnregistered(t *testing.T) {
+	// Mirrors controller Cancel ordering: active.cancel() makes Exec unregister
+	// its waiter before adapter.Cancel runs. Open tools must still close.
+	adapter := NewClaudeCodeSDKAdapter(nil)
+	session := standardTestSession(ProviderClaudeCode)
+	adapterSession := &claudeSDKAdapterSession{
+		conn:      &recordingClaudeSDKConnection{},
+		liveState: newClaudeSDKLiveState(),
+	}
+	adapter.storeSession(session.AgentSessionID, adapterSession)
+	waiter := adapter.registerClaudeSDKTurn(adapterSession, "turn-write", nil)
+
+	if _, _, err := adapter.sidecarTurnEvents(adapterSession, session, "turn-write", claudeSDKSidecarEvent{
+		Type: "tool_started",
+		Payload: map[string]any{
+			"turnId":     "turn-write",
+			"toolCallId": "toolu-write",
+			"toolName":   "Write",
+			"name":       "Write",
+			"input":      map[string]any{"file_path": "/tmp/out.txt", "content": "partial"},
+		},
+	}); err != nil {
+		t.Fatalf("tool_started: %v", err)
+	}
+
+	adapter.unregisterClaudeSDKTurn(adapterSession, "turn-write", waiter)
+	if got := adapter.liveClaudeSDKTurnIDs(adapterSession); len(got) != 0 {
+		t.Fatalf("live turns after unregister = %#v, want empty", got)
+	}
+
+	events, err := adapter.Cancel(context.Background(), session, "user")
+	if err != nil {
+		t.Fatalf("Cancel: %v", err)
+	}
+	if len(events) != 1 ||
+		events[0].Type != activityshared.EventCallFailed ||
+		events[0].EventID != "claude-sdk:tool:toolu-write" ||
+		events[0].Payload.Status != SessionStatusCanceled {
+		t.Fatalf("cancel events = %#v, want failed open Write even with no live waiter", events)
+	}
+}
+
+func TestClaudeCodeSDKAdapterTurnCanceledFailsOpenToolCalls(t *testing.T) {
+	adapter := NewClaudeCodeSDKAdapter(nil)
+	session := standardTestSession(ProviderClaudeCode)
+	adapterSession := &claudeSDKAdapterSession{liveState: newClaudeSDKLiveState()}
+
+	if _, _, err := adapter.sidecarTurnEvents(adapterSession, session, "turn-write", claudeSDKSidecarEvent{
+		Type: "tool_started",
+		Payload: map[string]any{
+			"turnId":     "turn-write",
+			"toolCallId": "toolu-write",
+			"toolName":   "Write",
+			"name":       "Write",
+			"input":      map[string]any{"file_path": "/tmp/out.txt", "content": "partial"},
+		},
+	}); err != nil {
+		t.Fatalf("tool_started: %v", err)
+	}
+
+	events, terminal, err := adapter.sidecarTurnEvents(adapterSession, session, "turn-write", claudeSDKSidecarEvent{
+		Type:    "turn_canceled",
+		Payload: map[string]any{"turnId": "turn-write"},
+	})
+	if err != nil || !terminal {
+		t.Fatalf("turn_canceled err=%v terminal=%v", err, terminal)
+	}
+	if len(events) < 2 ||
+		events[0].Type != activityshared.EventCallFailed ||
+		events[0].EventID != "claude-sdk:tool:toolu-write" ||
+		events[0].Payload.Status != SessionStatusCanceled {
+		t.Fatalf("turn_canceled events = %#v, want failed open Write then interrupted turn", events)
+	}
+	if events[1].Type != activityshared.EventTurnCompleted ||
+		events[1].Payload.TurnOutcome != string(activityshared.TurnOutcomeInterrupted) {
+		t.Fatalf("turn terminal = %#v, want interrupted", events[1])
+	}
+}
+
 // TestClaudeCodeSDKAdapterReaderFailureFailsPendingInteractive guards against
 // a real bug found while investigating a Feishu report (LENj32): if the
 // sidecar connection/process dies while a permission dialog is still

--- a/packages/agent/daemon/runtime/claude_sdk_events.go
+++ b/packages/agent/daemon/runtime/claude_sdk_events.go
@@ -102,11 +102,26 @@ func (a *ClaudeCodeSDKAdapter) sidecarTurnEvents(adapterSession *claudeSDKAdapte
 			"contentMode": messageContentModeSnapshot,
 		})}, false, nil
 	case "tool_started", "tool_updated":
-		return adapterSession.claudeSDKToolEvents(session, turnID, event.Payload, EventCallStarted, messageStreamStateStreaming, event.Type), false, nil
+		if a.turnAlreadySettled(adapterSession, turnID) {
+			return nil, false, nil
+		}
+		events := adapterSession.claudeSDKToolEvents(session, turnID, event.Payload, EventCallStarted, messageStreamStateStreaming, event.Type)
+		a.trackClaudeSDKTurnCallEvents(adapterSession, events)
+		return events, false, nil
 	case "tool_completed":
-		return adapterSession.claudeSDKToolEvents(session, turnID, event.Payload, EventCallCompleted, messageStreamStateCompleted, event.Type), false, nil
+		if a.turnAlreadySettled(adapterSession, turnID) {
+			return nil, false, nil
+		}
+		events := adapterSession.claudeSDKToolEvents(session, turnID, event.Payload, EventCallCompleted, messageStreamStateCompleted, event.Type)
+		a.trackClaudeSDKTurnCallEvents(adapterSession, events)
+		return events, false, nil
 	case "tool_failed":
-		return adapterSession.claudeSDKToolEvents(session, turnID, event.Payload, EventCallFailed, messageStreamStateFailed, event.Type), false, nil
+		if a.turnAlreadySettled(adapterSession, turnID) {
+			return nil, false, nil
+		}
+		events := adapterSession.claudeSDKToolEvents(session, turnID, event.Payload, EventCallFailed, messageStreamStateFailed, event.Type)
+		a.trackClaudeSDKTurnCallEvents(adapterSession, events)
+		return events, false, nil
 	case "task_started", "task_progress", "task_completed":
 		return adapterSession.claudeSDKTaskLifecycleEvents(session, turnID, event.Type, event.Payload), false, nil
 	case "plan_updated":
@@ -137,23 +152,26 @@ func (a *ClaudeCodeSDKAdapter) sidecarTurnEvents(adapterSession *claudeSDKAdapte
 		events = append(events, newSessionActivityEvent(session, EventSessionUpdated, firstNonEmpty(session.Status, SessionStatusReady), claudeSDKRuntimeContext(session, adapterSession)))
 		return events, false, nil
 	case "turn_completed":
-		events := []activityshared.Event{newTurnActivityEvent(session, EventTurnCompleted, turnID, SessionStatusReady, "", "", map[string]any{
+		events := a.finishClaudeSDKTurnLifecycle(adapterSession, session, turnID, claudeSDKTurnFinishCompleted, "")
+		events = append(events, newTurnActivityEvent(session, EventTurnCompleted, turnID, SessionStatusReady, "", "", map[string]any{
 			"adapter":    claudeSDKSidecarAdapterName,
 			"stopReason": firstNonEmpty(payloadString(event.Payload, "stopReason"), "end_turn"),
-		})}
+		}))
 		events = append(events, a.goalEventsOnTurnSettled(adapterSession, session, turnID, true)...)
 		return events, true, nil
 	case "turn_canceled":
-		events := []activityshared.Event{newTurnActivityEvent(session, EventTurnCanceled, turnID, SessionStatusCanceled, "", "", map[string]any{
+		events := a.finishClaudeSDKTurnLifecycle(adapterSession, session, turnID, claudeSDKTurnFinishInterrupted, "interrupted")
+		events = append(events, newTurnActivityEvent(session, EventTurnCanceled, turnID, SessionStatusCanceled, "", "", map[string]any{
 			"adapter": claudeSDKSidecarAdapterName,
-		})}
+		}))
 		events = append(events, a.goalEventsOnTurnSettled(adapterSession, session, turnID, false)...)
 		return events, true, nil
 	case "turn_failed":
-		events := []activityshared.Event{newTurnActivityEvent(session, EventTurnFailed, turnID, SessionStatusFailed, "", "", map[string]any{
+		events := a.finishClaudeSDKTurnLifecycle(adapterSession, session, turnID, claudeSDKTurnFinishFailed, "turn_failed")
+		events = append(events, newTurnActivityEvent(session, EventTurnFailed, turnID, SessionStatusFailed, "", "", map[string]any{
 			"adapter": claudeSDKSidecarAdapterName,
 			"error":   payloadString(event.Payload, "error"),
-		})}
+		}))
 		events = append(events, a.goalEventsOnTurnSettled(adapterSession, session, turnID, false)...)
 		return events, true, nil
 	default:
@@ -451,6 +469,12 @@ func (a *ClaudeCodeSDKAdapter) failClaudeSDKReader(agentSessionID string, adapte
 		session.AgentSessionID = agentSessionID
 	}
 	pendingFailureEvents := a.claudeSDKPendingRequestFailureEvents(adapterSession, session, "", err)
+	pendingFailureEvents = append(pendingFailureEvents, a.finishAllClaudeSDKTurnLifecycles(
+		adapterSession,
+		session,
+		claudeSDKTurnFinishFailed,
+		err.Error(),
+	)...)
 	a.removeSession(agentSessionID, adapterSession)
 	a.emitClaudeSDKSessionEvents(agentSessionID, pendingFailureEvents)
 }

--- a/packages/agent/daemon/runtime/claude_sdk_execution.go
+++ b/packages/agent/daemon/runtime/claude_sdk_execution.go
@@ -79,6 +79,16 @@ func (a *ClaudeCodeSDKAdapter) Exec(
 		}
 		return events, result.err
 	case <-ctx.Done():
+		// Controller cancel interrupts this context before adapter.Cancel.
+		// Close the turn lifecycle here too so dangling tool calls are not
+		// stranded if Cancel later finds no live waiter.
+		events = append(events, a.finishClaudeSDKTurnLifecycle(
+			adapterSession,
+			session,
+			turnID,
+			claudeSDKTurnFinishInterrupted,
+			"user_interrupt",
+		)...)
 		a.unregisterClaudeSDKTurn(adapterSession, turnID, waiter)
 		return events, ctx.Err()
 	}
@@ -141,6 +151,17 @@ func (a *ClaudeCodeSDKAdapter) Cancel(_ context.Context, session Session, _ stri
 		},
 	})
 	events := a.claudeSDKPendingRequestFailureEvents(adapterSession, session, "", errPermissionRequestCanceled)
+	// Finish open turn lifecycles by normalizer ownership, not by the live
+	// waiter registry. Controller Cancel cancels the Exec context first; Claude
+	// Exec then unregisters its waiter before adapter.Cancel runs. If we only
+	// finished live waiters, open Write/tool cards would stay "running" after
+	// the turn already settled canceled.
+	events = append(events, a.finishAllClaudeSDKTurnLifecycles(
+		adapterSession,
+		session,
+		claudeSDKTurnFinishInterrupted,
+		"user_interrupt",
+	)...)
 	for _, turnID := range a.liveClaudeSDKTurnIDs(adapterSession) {
 		if a.turnAlreadySettled(adapterSession, turnID) {
 			continue

--- a/packages/agent/daemon/runtime/claude_sdk_turn.go
+++ b/packages/agent/daemon/runtime/claude_sdk_turn.go
@@ -1,0 +1,137 @@
+package agentruntime
+
+import (
+	"sort"
+	"strings"
+
+	activityshared "github.com/tutti-os/tutti/packages/agent/daemon/activity/events"
+)
+
+// ensureClaudeSDKTurnNormalizerLocked returns the turn lifecycle owner for
+// turnID, creating it on first use. Caller must hold the adapter mutex.
+func (s *claudeSDKAdapterSession) ensureClaudeSDKTurnNormalizerLocked(turnID string) *acpTurnNormalizer {
+	turnID = strings.TrimSpace(turnID)
+	if s == nil || turnID == "" {
+		return nil
+	}
+	if s.turnNormalizers == nil {
+		s.turnNormalizers = make(map[string]*acpTurnNormalizer)
+	}
+	if normalizer := s.turnNormalizers[turnID]; normalizer != nil {
+		return normalizer
+	}
+	normalizer := newACPTurnNormalizer()
+	s.turnNormalizers[turnID] = normalizer
+	return normalizer
+}
+
+// trackClaudeSDKTurnCallEvents records call.started/completed/failed against
+// the shared ACP turn normalizer so Claude turns close open tools the same way
+// Codex/ACP do on FinishInterrupted/FinishFailed/FinishCompleted.
+func (a *ClaudeCodeSDKAdapter) trackClaudeSDKTurnCallEvents(
+	adapterSession *claudeSDKAdapterSession,
+	events []activityshared.Event,
+) {
+	if a == nil || adapterSession == nil || len(events) == 0 {
+		return
+	}
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	for _, event := range events {
+		switch event.Type {
+		case activityshared.EventCallStarted,
+			activityshared.EventCallCompleted,
+			activityshared.EventCallFailed:
+			turnID := strings.TrimSpace(event.Payload.TurnID)
+			if turnID == "" {
+				continue
+			}
+			normalizer := adapterSession.ensureClaudeSDKTurnNormalizerLocked(turnID)
+			if normalizer == nil {
+				continue
+			}
+			normalizer.trackToolCallEvent(event)
+		}
+	}
+}
+
+// takeClaudeSDKTurnNormalizerLocked removes and returns the turn lifecycle
+// owner for turnID. Caller must hold the adapter mutex.
+func (s *claudeSDKAdapterSession) takeClaudeSDKTurnNormalizerLocked(turnID string) *acpTurnNormalizer {
+	turnID = strings.TrimSpace(turnID)
+	if s == nil || turnID == "" || len(s.turnNormalizers) == 0 {
+		return nil
+	}
+	normalizer := s.turnNormalizers[turnID]
+	delete(s.turnNormalizers, turnID)
+	return normalizer
+}
+
+type claudeSDKTurnFinishKind string
+
+const (
+	claudeSDKTurnFinishCompleted   claudeSDKTurnFinishKind = "completed"
+	claudeSDKTurnFinishFailed      claudeSDKTurnFinishKind = "failed"
+	claudeSDKTurnFinishInterrupted claudeSDKTurnFinishKind = "interrupted"
+)
+
+// finishClaudeSDKTurnLifecycle closes the Claude turn's event lifecycle:
+// dangling tool calls (and any normalizer-owned streams) are settled before the
+// caller emits the turn terminal event. Idempotent once the normalizer is taken.
+func (a *ClaudeCodeSDKAdapter) finishClaudeSDKTurnLifecycle(
+	adapterSession *claudeSDKAdapterSession,
+	session Session,
+	turnID string,
+	kind claudeSDKTurnFinishKind,
+	reason string,
+) []activityshared.Event {
+	if a == nil || adapterSession == nil {
+		return nil
+	}
+	turnID = strings.TrimSpace(turnID)
+	if turnID == "" {
+		return nil
+	}
+	a.mu.Lock()
+	normalizer := adapterSession.takeClaudeSDKTurnNormalizerLocked(turnID)
+	a.mu.Unlock()
+	if normalizer == nil {
+		return nil
+	}
+	switch kind {
+	case claudeSDKTurnFinishCompleted:
+		return normalizer.FinishCompleted(session, turnID)
+	case claudeSDKTurnFinishFailed:
+		return normalizer.FinishFailed(session, turnID)
+	default:
+		return normalizer.FinishInterrupted(session, turnID, firstNonEmpty(strings.TrimSpace(reason), "interrupted"))
+	}
+}
+
+// finishAllClaudeSDKTurnLifecycles settles every still-open Claude turn
+// lifecycle (for example when the sidecar reader dies).
+func (a *ClaudeCodeSDKAdapter) finishAllClaudeSDKTurnLifecycles(
+	adapterSession *claudeSDKAdapterSession,
+	session Session,
+	kind claudeSDKTurnFinishKind,
+	reason string,
+) []activityshared.Event {
+	if a == nil || adapterSession == nil {
+		return nil
+	}
+	a.mu.Lock()
+	turnIDs := make([]string, 0, len(adapterSession.turnNormalizers))
+	for turnID := range adapterSession.turnNormalizers {
+		turnIDs = append(turnIDs, turnID)
+	}
+	a.mu.Unlock()
+	if len(turnIDs) == 0 {
+		return nil
+	}
+	sort.Strings(turnIDs)
+	events := make([]activityshared.Event, 0, len(turnIDs))
+	for _, turnID := range turnIDs {
+		events = append(events, a.finishClaudeSDKTurnLifecycle(adapterSession, session, turnID, kind, reason)...)
+	}
+	return events
+}

--- a/packages/agent/daemon/runtime/controller_turn_exec.go
+++ b/packages/agent/daemon/runtime/controller_turn_exec.go
@@ -65,9 +65,13 @@ func (c *Controller) runExecTurn(ctx context.Context, session Session, adapter A
 	shouldEmitTerminalEvents := false
 	if err != nil {
 		if errors.Is(err, context.Canceled) {
-			events = []activityshared.Event{newTurnActivityEvent(session, EventTurnCanceled, turnID, SessionStatusCanceled, "", "", map[string]any{
+			// Keep call-lifecycle close events Exec already produced (for
+			// example Claude finishing open tools on ctx cancel). Replacing the
+			// whole slice would drop those CallFailed updates and leave tool
+			// cards stuck in progress after Stop.
+			events = append(retainTurnCallLifecycleEvents(events, turnID), newTurnActivityEvent(session, EventTurnCanceled, turnID, SessionStatusCanceled, "", "", map[string]any{
 				"error": err.Error(),
-			})}
+			}))
 		} else {
 			events = []activityshared.Event{newTurnActivityEvent(session, EventTurnFailed, turnID, SessionStatusFailed, "", "", map[string]any{
 				"error": err.Error(),

--- a/packages/agent/daemon/runtime/controller_turn_state.go
+++ b/packages/agent/daemon/runtime/controller_turn_state.go
@@ -463,6 +463,28 @@ func unemittedActivityEvents(events []activityshared.Event, emitted []activitysh
 	return out
 }
 
+// retainTurnCallLifecycleEvents keeps call.started/completed/failed events for
+// turnID when synthesizing a context-canceled terminal. Controllers must not
+// discard adapter-produced CallFailed closes for open tools.
+func retainTurnCallLifecycleEvents(events []activityshared.Event, turnID string) []activityshared.Event {
+	turnID = strings.TrimSpace(turnID)
+	if len(events) == 0 || turnID == "" {
+		return nil
+	}
+	out := make([]activityshared.Event, 0, len(events))
+	for _, event := range events {
+		switch event.Type {
+		case activityshared.EventCallStarted,
+			activityshared.EventCallCompleted,
+			activityshared.EventCallFailed:
+			if strings.TrimSpace(event.Payload.TurnID) == turnID {
+				out = append(out, event)
+			}
+		}
+	}
+	return out
+}
+
 func activityEventIdentity(event activityshared.Event) string {
 	if event.EventID != "" {
 		return event.EventID


### PR DESCRIPTION
## Summary
- Align Claude Code SDK with the shared `acpTurnNormalizer` turn lifecycle so open tool calls (for example Write) are finished when a turn settles.
- Fix the real Stop race: controller cancels Exec context first and unregisters the waiter, so Cancel finishes tools from the turn-normalizer map (not only live waiters) and retains `CallFailed` events on context cancel.
- Document the failure mode and ownership in Claude SDK runtime + session-lifecycle troubleshooting.

## Test plan
- [x] `go test ./packages/agent/daemon/runtime -run 'TestClaudeCodeSDK'`
- [x] Regression: cancel with waiter already unregistered still fails open Write
- [x] Manual: long Claude Code Write + Stop; tool leaves in-progress (`failed`/`user_interrupt` in durable messages)
- [x] `pnpm check:full` (pre-push)


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Ensure Claude Code turns close open tool calls (like Write) on cancel, fail, or complete so tool cards don’t stay stuck in progress. This aligns the Claude SDK with the shared `acpTurnNormalizer` for consistent Stop behavior.

- **Bug Fixes**
  - Use per-turn lifecycle via `acpTurnNormalizer`; track `call.started/completed/failed` and `FinishInterrupted/Failed/Completed` on turn settle.
  - Fix cancel race: when Exec is canceled first, `Cancel` still closes tools from the normalizer map even if the waiter is gone.
  - Retain `call.failed` events on context cancel and then append the terminal turn event.
  - Drop late tool events once a turn is settled.
  - Finish all open turn lifecycles if the sidecar reader fails.
  - Added focused tests for cancel and `turn_canceled`; updated runtime and troubleshooting docs.

<sup>Written for commit e2d6cb0483c0e5317668ed8c7111cb713a7a95a4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tutti-os/tutti/pull/1121?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

