### PR TITLE
fix(agent-gui): show agent identity after conversation starts

### DIFF
--- a/apps/desktop/src/renderer/src/features/workspace-workbench/services/internal/workspaceAgentGuiContribution.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/services/internal/workspaceAgentGuiContribution.ts
@@ -12,6 +12,7 @@ import {
   createAgentGuiWorkbenchContribution,
   type AgentGuiWorkbenchConversationIdentity
 } from "@tutti-os/agent-gui/workbench/contribution";
+import { resolveAgentGuiWorkbenchHeaderTitle } from "@tutti-os/agent-gui/workbench/sessionTitle";
 import { selectWorkspaceAgentConsumerSession } from "@tutti-os/agent-activity-core";
 import type {
   AgentGuiWorkbenchProvider,
@@ -394,6 +395,11 @@ function resolveWorkspaceAgentGuiDockPopupIdentity(
       ? agent.provider
       : null;
   const title = session?.title?.trim() || null;
+  const agentTitle = resolveAgentGuiWorkbenchHeaderTitle({
+    agentName: agent?.name,
+    conversationTitle: title,
+    provider: resolvedProvider
+  });
   // Never fall back to a concrete provider's icon (e.g. codex) while the real
   // provider is still unknown — leave iconUrl null so the header renders a
   // neutral placeholder until the provider resolves.
@@ -405,6 +411,7 @@ function resolveWorkspaceAgentGuiDockPopupIdentity(
         null)
       : null);
   return {
+    agentTitle,
     iconUrl,
     title
   };

--- a/apps/desktop/src/renderer/src/features/workspace-workbench/ui/StandaloneAgentWindow.test.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/ui/StandaloneAgentWindow.test.ts
@@ -13,6 +13,10 @@ const standaloneWindowPanelHostsSource = readFileSync(
   resolve(currentDirectory, "StandaloneAgentWindowPanelHosts.tsx"),
   "utf8"
 );
+const standaloneHeaderIdentitySource = readFileSync(
+  resolve(currentDirectory, "standaloneAgentHeaderIdentity.ts"),
+  "utf8"
+);
 const standaloneLaunchRoutingSource = readFileSync(
   resolve(currentDirectory, "useStandaloneAgentLaunchRouting.ts"),
   "utf8"
@@ -155,11 +159,20 @@ test("standalone Agent auto-hides the conversation rail below the standalone wid
   );
 });
 
-test("standalone Agent restores the active session title in the window header", () => {
+test("standalone Agent hides home identity and shows it after local session start", () => {
   assert.match(
     standaloneWindowSource,
-    /activitySnapshot\.sessions\s*\.find\([\s\S]*?session\.agentSessionId[\s\S]*?nodeState\.lastActiveAgentSessionId[\s\S]*?\)\s*\?\.title\?\.trim\(\) \|\| null/
+    /resolveStandaloneAgentHeaderIdentity\(\{[\s\S]*?agentTargetId: activeAgentTargetId,[\s\S]*?lastActiveAgentSessionId: nodeState\.lastActiveAgentSessionId,[\s\S]*?sessions: activitySnapshot\.sessions/
   );
+  assert.match(
+    standaloneHeaderIdentitySource,
+    /if \(!input\.lastActiveAgentSessionId\?\.trim\(\)\) \{[\s\S]*?agentTitle: null,[\s\S]*?conversationIconUrl: null,[\s\S]*?conversationTitle: null/
+  );
+  assert.match(
+    standaloneHeaderIdentitySource,
+    /agentTitle: resolveAgentGuiWorkbenchHeaderTitle\(\{[\s\S]*?agentName: agent\?\.name,[\s\S]*?conversationTitle,[\s\S]*?provider/
+  );
+  assert.match(standaloneWindowSource, /agentTitle=\{headerAgentTitle\}/);
   assert.match(
     standaloneWindowSource,
     /conversationTitle=\{headerConversationTitle\}/

--- a/apps/desktop/src/renderer/src/features/workspace-workbench/ui/StandaloneAgentWindow.tsx
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/ui/StandaloneAgentWindow.tsx
@@ -23,7 +23,6 @@ import {
   type AgentGuiWorkbenchConversationRailToggleDetail,
   type AgentGuiWorkbenchNewConversationDetail
 } from "@tutti-os/agent-gui/workbench/contribution";
-import { resolveAgentGuiSessionProviderIconUrl } from "@tutti-os/agent-gui/agentGuiSessionProviderIconUrls";
 import type {
   WorkbenchContribution,
   WorkbenchHostHandle,
@@ -34,7 +33,6 @@ import { createDesktopAgentGUIWorkbenchHostInput } from "@renderer/features/work
 import { IAgentsService } from "@renderer/features/workspace-agent/services/agentsService.interface.ts";
 import type { IAgentProviderStatusService as AgentProviderStatusService } from "@renderer/features/workspace-agent/services/agentProviderStatusService.interface.ts";
 import type { IWorkspaceAgentActivityService as WorkspaceAgentActivityService } from "@renderer/features/workspace-agent/services/workspaceAgentActivityService.interface.ts";
-import { resolveDesktopAgentGUIProviderForAgentTarget } from "@renderer/features/workspace-agent/ui/desktopAgentGUIWorkbenchStateHelpers.ts";
 import type { DesktopAgentGUIPrefillPromptRequest } from "@renderer/features/workspace-agent/services/desktopAgentGUIPrefillPromptActivation.ts";
 import { isDesktopAgentGUIProvider } from "@renderer/features/workspace-agent/desktopAgentGUINodeState.ts";
 import {
@@ -72,6 +70,7 @@ import { useWorkspaceSettingsService } from "./useWorkspaceSettingsService";
 import type { WorkspaceWorkbenchCapabilitySettingsTarget } from "../services/workspaceWorkbenchHostService.interface";
 import { resolveDesktopWindowIntent } from "@shared/contracts/windowIntent.ts";
 import { useStandaloneAgentLaunchRouting } from "./useStandaloneAgentLaunchRouting.ts";
+import { resolveStandaloneAgentHeaderIdentity } from "./standaloneAgentHeaderIdentity.ts";
 
 const LazyWorkspaceAccountMenu = lazy(() =>
   import("./WorkspaceAccountMenu").then(({ WorkspaceAccountMenu }) => ({
@@ -427,26 +426,19 @@ export function StandaloneAgentWindow({
     [launchProvider, workspaceId]
   );
   const activeAgentTargetId = nodeState.agentTargetId?.trim() || null;
-  const headerProvider = resolveDesktopAgentGUIProviderForAgentTarget(
-    activeAgentTargetId,
+  const {
+    agentTitle: headerAgentTitle,
+    conversationIconFallbackUrl: headerConversationIconFallbackUrl,
+    conversationIconUrl: headerConversationIconUrl,
+    conversationTitle: headerConversationTitle,
+    provider: headerProvider
+  } = resolveStandaloneAgentHeaderIdentity({
+    agentTargetId: activeAgentTargetId,
     agents,
-    readStandaloneNodeProvider(nodeState, launchProvider)
-  );
-  const headerAgentTarget = activeAgentTargetId
-    ? (agents.find((target) => target.agentTargetId === activeAgentTargetId) ??
-      null)
-    : null;
-  const headerConversationIconFallbackUrl =
-    resolveAgentGuiSessionProviderIconUrl(headerProvider);
-  const headerConversationIconUrl =
-    headerAgentTarget?.iconUrl ?? headerConversationIconFallbackUrl;
-  const headerConversationTitle =
-    activitySnapshot.sessions
-      .find(
-        (session) =>
-          session.agentSessionId === nodeState.lastActiveAgentSessionId
-      )
-      ?.title?.trim() || null;
+    fallbackProvider: readStandaloneNodeProvider(nodeState, launchProvider),
+    lastActiveAgentSessionId: nodeState.lastActiveAgentSessionId,
+    sessions: activitySnapshot.sessions
+  });
   const headerConversationRailWidthPx =
     typeof nodeState.conversationRailWidthPx === "number" &&
     Number.isFinite(nodeState.conversationRailWidthPx)
@@ -654,6 +646,7 @@ export function StandaloneAgentWindow({
         }
         renderHeader={(toolActions) => (
           <AgentGuiWorkbenchHeader
+            agentTitle={headerAgentTitle}
             copy={{
               collapseConversationRail: i18n.t(
                 "workspace.agentGui.collapseConversationRail"

--- a/apps/desktop/src/renderer/src/features/workspace-workbench/ui/standaloneAgentHeaderIdentity.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/ui/standaloneAgentHeaderIdentity.ts
@@ -1,0 +1,59 @@
+import type { AgentActivitySession } from "@tutti-os/agent-activity-core";
+import type { AgentGUIAgent } from "@tutti-os/agent-gui";
+import { resolveAgentGuiSessionProviderIconUrl } from "@tutti-os/agent-gui/agentGuiSessionProviderIconUrls";
+import { resolveAgentGuiWorkbenchHeaderTitle } from "@tutti-os/agent-gui/workbench";
+import type { DesktopAgentGUIProvider } from "@renderer/features/workspace-agent/desktopAgentGUINodeState.ts";
+import { resolveDesktopAgentGUIProviderForAgentTarget } from "@renderer/features/workspace-agent/ui/desktopAgentGUIWorkbenchStateHelpers.ts";
+
+export function resolveStandaloneAgentHeaderIdentity(input: {
+  agentTargetId?: string | null;
+  agents: readonly AgentGUIAgent[];
+  fallbackProvider: DesktopAgentGUIProvider;
+  lastActiveAgentSessionId?: string | null;
+  sessions: readonly AgentActivitySession[];
+}): {
+  agentTitle: string | null;
+  conversationIconFallbackUrl: string | null;
+  conversationIconUrl: string | null;
+  conversationTitle: string | null;
+  provider: DesktopAgentGUIProvider;
+} {
+  const agentTargetId = input.agentTargetId?.trim() || null;
+  const provider = resolveDesktopAgentGUIProviderForAgentTarget(
+    agentTargetId,
+    input.agents,
+    input.fallbackProvider
+  );
+  if (!input.lastActiveAgentSessionId?.trim()) {
+    return {
+      agentTitle: null,
+      conversationIconFallbackUrl: null,
+      conversationIconUrl: null,
+      conversationTitle: null,
+      provider
+    };
+  }
+  const agent = agentTargetId
+    ? (input.agents.find(
+        (candidate) => candidate.agentTargetId === agentTargetId
+      ) ?? null)
+    : null;
+  const conversationIconFallbackUrl =
+    resolveAgentGuiSessionProviderIconUrl(provider);
+  const conversationTitle =
+    input.sessions.find(
+      (session) => session.agentSessionId === input.lastActiveAgentSessionId
+    )?.title ?? null;
+
+  return {
+    agentTitle: resolveAgentGuiWorkbenchHeaderTitle({
+      agentName: agent?.name,
+      conversationTitle,
+      provider
+    }),
+    conversationIconFallbackUrl,
+    conversationIconUrl: agent?.iconUrl ?? conversationIconFallbackUrl,
+    conversationTitle,
+    provider
+  };
+}

--- a/docs/architecture/agent-gui-node.md
+++ b/docs/architecture/agent-gui-node.md
@@ -158,8 +158,13 @@ Unified dock and launchpad chrome should keep the generic Agent title and
 generic Agent artwork instead of provider-branded entries. Workbench Agent node
 headers show the generic Agent title while the conversation rail is expanded;
 standalone native Agent window headers omit that redundant app title. When the
-conversation rail is collapsed, the title area switches to the active session
-identity by showing the session's agent icon and conversation title.
+conversation rail is collapsed, the title area shows the active conversation's
+agent icon and directory name as soon as a local session id exists; it must not
+wait for provider-side session creation or conversation-title persistence. An
+empty new-conversation home does not show this header identity. The conversation
+title remains the detail title while the rail is expanded and the identity used
+by Dock previews; after submission, the expanded detail title area shows the
+agent icon immediately even before conversation-title persistence.
 
 AgentGuiNode may expose agent selection in multiple UI-local entry points,
 including the conversation rail agent grid and the agent select next to the

--- a/packages/agent/gui/workbench/contribution.ts
+++ b/packages/agent/gui/workbench/contribution.ts
@@ -56,6 +56,7 @@ export interface AgentGuiWorkbenchNewConversationDetail {
 }
 
 export interface AgentGuiWorkbenchConversationIdentity {
+  agentTitle?: string | null;
   iconUrl?: string | null;
   title: string | null;
 }
@@ -280,6 +281,7 @@ export function createAgentGuiWorkbenchContribution(
           };
 
           return createElement(AgentGuiWorkbenchHeader, {
+            agentTitle: conversationIdentity?.agentTitle,
             copy,
             conversationIconUrl,
             conversationIconFallbackUrl,

--- a/packages/agent/gui/workbench/header.test.tsx
+++ b/packages/agent/gui/workbench/header.test.tsx
@@ -172,6 +172,81 @@ describe("AgentGuiWorkbenchHeader", () => {
     expect(primary).toContainElement(actions);
   });
 
+  it("shows the selected agent identity in the collapsed header", () => {
+    render(
+      <AgentGuiWorkbenchHeader
+        agentTitle="Cursor"
+        copy={{
+          collapseConversationRail: "Collapse conversations",
+          expandConversationRail: "Expand conversations",
+          fallbackAgentLabel: "Agent",
+          newConversation: "New conversation"
+        }}
+        conversationIconUrl="asset://cursor.png"
+        conversationTitle="Fix the header"
+        isConversationRailAutoCollapsed={false}
+        isConversationRailCollapsed
+        nodeId="agent-gui-node-1"
+        onToggleConversationRail={() => {}}
+      />
+    );
+
+    expect(screen.getByText("Cursor")).toBeInTheDocument();
+    expect(screen.queryByText("Fix the header")).not.toBeInTheDocument();
+    expect(screen.getByTestId("agent-gui-window-session-icon")).toHaveAttribute(
+      "src",
+      "asset://cursor.png"
+    );
+  });
+
+  it("keeps the conversation title in the expanded detail header", () => {
+    render(
+      <AgentGuiWorkbenchHeader
+        agentTitle="Cursor"
+        copy={{
+          collapseConversationRail: "Collapse conversations",
+          expandConversationRail: "Expand conversations",
+          fallbackAgentLabel: "Agent",
+          newConversation: "New conversation"
+        }}
+        conversationTitle="Fix the header"
+        isConversationRailAutoCollapsed={false}
+        isConversationRailCollapsed={false}
+        nodeId="agent-gui-node-1"
+        onToggleConversationRail={() => {}}
+      />
+    );
+
+    expect(
+      screen.getByTestId("agent-gui-window-detail-title")
+    ).toHaveTextContent("Fix the header");
+    expect(screen.queryByText("Cursor")).not.toBeInTheDocument();
+  });
+
+  it("shows the selected agent icon before an expanded conversation has a title", () => {
+    render(
+      <AgentGuiWorkbenchHeader
+        agentTitle="Cursor"
+        copy={{
+          collapseConversationRail: "Collapse conversations",
+          expandConversationRail: "Expand conversations",
+          fallbackAgentLabel: "Agent",
+          newConversation: "New conversation"
+        }}
+        conversationIconUrl="asset://cursor.png"
+        isConversationRailAutoCollapsed={false}
+        isConversationRailCollapsed={false}
+        nodeId="agent-gui-node-1"
+        onToggleConversationRail={() => {}}
+      />
+    );
+
+    expect(
+      screen.getByTestId("agent-gui-window-detail-title-icon")
+    ).toHaveAttribute("src", "asset://cursor.png");
+    expect(screen.queryByText("Cursor")).not.toBeInTheDocument();
+  });
+
   it("uses the open-link-lined asset for the detached window action", () => {
     render(
       <AgentGuiWorkbenchHeader

--- a/packages/agent/gui/workbench/header.ts
+++ b/packages/agent/gui/workbench/header.ts
@@ -47,6 +47,7 @@ export interface AgentGuiWorkbenchHeaderCopy {
 
 export interface AgentGuiWorkbenchHeaderProps extends HTMLAttributes<HTMLElement> {
   copy: AgentGuiWorkbenchHeaderCopy;
+  agentTitle?: string | null;
   defaultActions?: ReactNode;
   displayMode?: WorkbenchDisplayMode;
   isConversationRailAutoCollapsed: boolean;
@@ -75,6 +76,7 @@ export interface AgentGuiWorkbenchHeaderProps extends HTMLAttributes<HTMLElement
 export function AgentGuiWorkbenchHeader({
   className,
   copy,
+  agentTitle,
   defaultActions: _defaultActions,
   displayMode,
   isConversationRailAutoCollapsed,
@@ -105,8 +107,12 @@ export function AgentGuiWorkbenchHeader({
   const sessionTitle = hasBodyRenderError
     ? ""
     : conversationTitle?.trim() || "";
+  const collapsedTitle = agentTitle?.trim() || sessionTitle;
   const sessionIconUrl = conversationIconUrl?.trim() || "";
   const sessionIconFallbackUrl = conversationIconFallbackUrl?.trim() || "";
+  const hasExpandedIdentity = Boolean(
+    collapsedTitle || sessionIconUrl || sessionIconFallbackUrl
+  );
   const safeDisplayMode = displayMode ?? "floating";
   const safeWindowActions = windowActions ?? {
     close: () => undefined,
@@ -226,7 +232,7 @@ export function AgentGuiWorkbenchHeader({
             onCreateConversation
           })
         : null,
-      isConversationRailCollapsed && sessionTitle
+      isConversationRailCollapsed && collapsedTitle
         ? createElement(
             "span",
             {
@@ -242,7 +248,7 @@ export function AgentGuiWorkbenchHeader({
               {
                 className: "agent-gui-workbench-header__title-text"
               },
-              sessionTitle
+              collapsedTitle
             )
           )
         : null,
@@ -256,13 +262,13 @@ export function AgentGuiWorkbenchHeader({
           )
         : null
     ),
-    !isConversationRailCollapsed && (sessionTitle || secondaryAccessory)
+    !isConversationRailCollapsed && (hasExpandedIdentity || secondaryAccessory)
       ? createElement(
           "div",
           {
             className: "agent-gui-workbench-header__detail"
           },
-          sessionTitle
+          hasExpandedIdentity
             ? createElement(
                 "div",
                 {
@@ -274,13 +280,15 @@ export function AgentGuiWorkbenchHeader({
                   src: sessionIconUrl,
                   testId: "agent-gui-window-detail-title-icon"
                 }),
-                createElement(
-                  "span",
-                  {
-                    className: "agent-gui-workbench-header__title-text"
-                  },
-                  sessionTitle
-                )
+                sessionTitle
+                  ? createElement(
+                      "span",
+                      {
+                        className: "agent-gui-workbench-header__title-text"
+                      },
+                      sessionTitle
+                    )
+                  : null
               )
             : null,
           secondaryAccessory

--- a/packages/agent/gui/workbench/index.ts
+++ b/packages/agent/gui/workbench/index.ts
@@ -60,9 +60,13 @@ export {
   type AgentGuiWorkbenchHeaderCopy,
   type AgentGuiWorkbenchHeaderProps
 } from "./header.ts";
-export { resolveAgentGuiWorkbenchSessionTitle } from "./sessionTitle.ts";
+export {
+  resolveAgentGuiWorkbenchHeaderTitle,
+  resolveAgentGuiWorkbenchSessionTitle
+} from "./sessionTitle.ts";
 export type {
   AgentGuiWorkbenchSessionTitleResult,
+  ResolveAgentGuiWorkbenchHeaderTitleInput,
   ResolveAgentGuiWorkbenchSessionTitleInput
 } from "./sessionTitle.ts";
 export {

--- a/packages/agent/gui/workbench/sessionTitle.test.ts
+++ b/packages/agent/gui/workbench/sessionTitle.test.ts
@@ -4,7 +4,32 @@ import {
   type AgentActivityMessage,
   type AgentActivitySession
 } from "@tutti-os/agent-activity-core";
-import { resolveAgentGuiWorkbenchSessionTitle } from "./sessionTitle";
+import {
+  resolveAgentGuiWorkbenchHeaderTitle,
+  resolveAgentGuiWorkbenchSessionTitle
+} from "./sessionTitle";
+
+describe("agent GUI workbench header titles", () => {
+  it("uses the selected agent name before a conversation title exists", () => {
+    expect(
+      resolveAgentGuiWorkbenchHeaderTitle({
+        agentName: "Cursor",
+        conversationTitle: null,
+        provider: "cursor"
+      })
+    ).toBe("Cursor");
+  });
+
+  it("keeps the selected agent name after a conversation title exists", () => {
+    expect(
+      resolveAgentGuiWorkbenchHeaderTitle({
+        agentName: "Cursor",
+        conversationTitle: "Fix the header",
+        provider: "cursor"
+      })
+    ).toBe("Cursor");
+  });
+});
 
 describe("agent GUI workbench session titles", () => {
   it("uses canonical snapshot titles", () => {

--- a/packages/agent/gui/workbench/sessionTitle.ts
+++ b/packages/agent/gui/workbench/sessionTitle.ts
@@ -6,9 +6,16 @@ import {
   firstAgentGUIUserMessageTitle,
   normalizeAgentGUIProviderIdentity,
   resolveAgentGUIExplicitConversationTitle,
+  resolveAgentGUIProviderDisplayLabel,
   type AgentGUIResolvedProvider
 } from "../shared/agentConversationTitleProjection.ts";
 import type { AgentGuiWorkbenchProvider } from "./types.ts";
+
+export interface ResolveAgentGuiWorkbenchHeaderTitleInput {
+  agentName?: string | null;
+  conversationTitle?: string | null;
+  provider?: string | null;
+}
 
 export interface ResolveAgentGuiWorkbenchSessionTitleInput {
   agentSessionId?: string | null;
@@ -22,6 +29,19 @@ export interface AgentGuiWorkbenchSessionTitleResult {
   agentSessionId: string | null;
   source: "snapshot" | "fallback" | "none";
   title: string | null;
+}
+
+export function resolveAgentGuiWorkbenchHeaderTitle({
+  agentName,
+  conversationTitle,
+  provider
+}: ResolveAgentGuiWorkbenchHeaderTitleInput): string | null {
+  return (
+    stripTitle(agentName) ||
+    stripTitle(resolveAgentGUIProviderDisplayLabel(provider, "")) ||
+    stripTitle(conversationTitle) ||
+    null
+  );
 }
 
 export function resolveAgentGuiWorkbenchSessionTitle({


### PR DESCRIPTION
## Summary

- hide the Agent identity on the empty new-conversation home
- show the selected Agent icon and name as soon as the local conversation starts
- keep the expanded header text tied to the persisted conversation title
- document the AgentGUI header identity lifecycle

## Validation

- `pnpm check:full`
- pre-commit AgentGUI, renderer, Electron runtime, and UI boundary checks

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Show the selected agent’s icon and name in the header as soon as a local conversation starts, while keeping the home screen empty and preserving correct behavior for collapsed vs. expanded headers.

- **Bug Fixes**
  - Hide identity on the empty new-conversation home.
  - Show agent icon and name immediately after a local session ID exists (no wait for provider/session title).
  - Collapsed header shows agent title; expanded detail keeps conversation title and shows the icon even before title persistence.
  - Added `resolveAgentGuiWorkbenchHeaderTitle` and `resolveStandaloneAgentHeaderIdentity`, and wired `agentTitle` through `AgentGuiWorkbenchHeader` and `@tutti-os/agent-gui/workbench`. Updated docs and tests.

<sup>Written for commit 59208299cf51550b99cc1c84830c1989bb21256c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tutti-os/tutti/pull/1122?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

