### PR TITLE
fix(workspace): stop project create dialog from submitting ancestor forms

### DIFF
--- a/packages/agent/gui/agent-gui/agentGuiNode/AgentComposerSettingsMenus.spec.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/AgentComposerSettingsMenus.spec.tsx
@@ -361,6 +361,55 @@ describe("AgentProjectDropdown", () => {
     expect(mockAgentHostApi.userProjects?.use).not.toHaveBeenCalled();
   });
 
+  it("does not submit an ancestor form when creating a project from the dialog", async () => {
+    const onAncestorFormSubmit = vi.fn(
+      (event: { preventDefault: () => void }) => {
+        event.preventDefault();
+      }
+    );
+    const onProjectPathChange = vi.fn();
+    mockAgentHostApi.userProjects = {
+      create: vi.fn().mockResolvedValue({
+        id: "dir-1",
+        path: "/Users/local/Documents/tutti/Tutti Demo",
+        label: "Tutti Demo"
+      }),
+      list: vi.fn().mockResolvedValue({ projects: [] }),
+      use: vi.fn()
+    };
+
+    render(
+      <form onSubmit={onAncestorFormSubmit}>
+        <AgentProjectDropdown
+          composerSettings={{
+            selectedProjectPath: null,
+            projectLocked: false
+          }}
+          labels={projectLabels}
+          i18n={workspaceUserProjectI18n}
+          onProjectPathChange={onProjectPathChange}
+        />
+      </form>
+    );
+
+    await openAddProjectDialog();
+    fireEvent.change(screen.getByPlaceholderText("Project name"), {
+      target: { value: "Tutti Demo" }
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Create" }));
+
+    await waitFor(() =>
+      expect(mockAgentHostApi.userProjects?.create).toHaveBeenCalledWith({
+        name: "Tutti Demo"
+      })
+    );
+    expect(onProjectPathChange).toHaveBeenCalledWith(
+      "/Users/local/Documents/tutti/Tutti Demo",
+      expect.objectContaining({ action: "create_new" })
+    );
+    expect(onAncestorFormSubmit).not.toHaveBeenCalled();
+  });
+
   it("shows a project name conflict when the created directory already exists", async () => {
     const onProjectPathChange = vi.fn();
     const conflictError = Object.assign(new Error("already exists"), {

--- a/packages/workspace/user-project/src/ui/internal/project/WorkspaceUserProjectSelect.tsx
+++ b/packages/workspace/user-project/src/ui/internal/project/WorkspaceUserProjectSelect.tsx
@@ -490,7 +490,11 @@ export function WorkspaceUserProjectSelect({
   ]);
 
   const submitProjectDialog = (event: FormEvent<HTMLFormElement>): void => {
+    // Dialog content is portaled in the DOM, but still sits under any ancestor
+    // React form (for example the Agent composer). Stop bubbling so Create /
+    // Enter cannot submit that outer form and send a draft prompt.
     event.preventDefault();
+    event.stopPropagation();
     void createProject();
   };
 


### PR DESCRIPTION
## Summary
- Stop submit event propagation from the portaled create-project dialog so Create/Enter cannot bubble into an ancestor form (e.g. Agent composer) and send a draft prompt.
- Add a regression test that creates a project from `AgentProjectDropdown` nested under a form and asserts the ancestor form is not submitted.

## Test plan
- [ ] Open Agent composer, open Add Project dialog, create a project with Create / Enter — project is created and selected, composer does not send a prompt.
- [ ] Run the new `AgentComposerSettingsMenus` / `AgentProjectDropdown` test covering ancestor-form submit isolation.
- [ ] Confirm existing create-project conflict and happy-path flows still work.


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevent the portaled Create Project dialog from submitting ancestor forms. Pressing Create/Enter now only creates a project and doesn’t send a draft prompt in the Agent composer.

- **Bug Fixes**
  - Stop submit event propagation in `WorkspaceUserProjectSelect` dialog submit handler.
  - Add regression test in `AgentComposerSettingsMenus.spec.tsx` to verify ancestor form is not submitted.

<sup>Written for commit cad18ce5924dc5fb1c3d5ec3c8352a17e3e69d1c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tutti-os/tutti/pull/1123?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

