### PR TITLE
feat(agent-gui): surface standalone decision toasts

### DIFF
--- a/apps/desktop/src/renderer/src/features/workspace-workbench/services/workspaceAgentDecisionToastVisibility.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/services/workspaceAgentDecisionToastVisibility.ts
@@ -13,9 +13,11 @@ export interface WorkspaceAgentDecisionToastVisibilityInput {
  * background the OS notification already covers the "please come back"
  * signal (see compositeNotificationService's background-only presentation),
  * and the pending decision remains available in the message center — the
- * toast itself would just be an unseen, disruptive interruption. Likewise,
- * when the session's own AgentGUI conversation window is already open, the
- * prompt is already visible inline there, so the toast would just duplicate it.
+ * toast itself would just be an unseen, disruptive interruption. The OS
+ * workspace caller also treats an open AgentGUI conversation as sufficient
+ * inline presentation. Standalone Agent intentionally passes false for that
+ * condition because its product contract includes the top-right decision card
+ * in addition to the inline prompt.
  */
 export function shouldShowWorkspaceAgentDecisionToast(
   input: WorkspaceAgentDecisionToastVisibilityInput

--- a/apps/desktop/src/renderer/src/features/workspace-workbench/ui/StandaloneAgentDecisionNotifications.tsx
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/ui/StandaloneAgentDecisionNotifications.tsx
@@ -1,0 +1,84 @@
+import { useMemo, useRef, type ReactNode } from "react";
+import {
+  buildWorkspaceAgentMessageCenterModelFromEngine,
+  selectWorkspaceAgentMessageCenterPresentation,
+  stabilizeWorkspaceAgentMessageCenterModel,
+  useEngineSelector,
+  workspaceAgentMessageCenterPresentationEqual,
+  type WorkspaceAgentMessageCenterModel
+} from "@tutti-os/agent-gui/agent-message-center";
+import type { I18nRuntime } from "@tutti-os/ui-i18n-runtime";
+import type { WorkspaceAgentActivityService } from "@renderer/features/workspace-agent";
+import { useWorkspaceAgentDecisionNotifications } from "./useWorkspaceAgentDecisionNotifications.tsx";
+
+const MESSAGE_CENTER_VISIBLE_HISTORY_MS = 7 * 24 * 60 * 60 * 1000;
+const emptySessionMessagesById = {};
+
+export function StandaloneAgentDecisionNotifications({
+  activityService,
+  i18n,
+  messageCenterOpen,
+  workspaceId
+}: {
+  activityService: WorkspaceAgentActivityService;
+  i18n: I18nRuntime<string>;
+  messageCenterOpen: boolean;
+  workspaceId: string;
+}): ReactNode {
+  const sessionEngine = useMemo(
+    () => activityService.getSessionEngine(workspaceId),
+    [activityService, workspaceId]
+  );
+  const presentation = useEngineSelector(
+    sessionEngine,
+    selectWorkspaceAgentMessageCenterPresentation,
+    workspaceAgentMessageCenterPresentationEqual
+  );
+  const itemCutoffUnixMs = useMemo(
+    () => Date.now() - MESSAGE_CENTER_VISIBLE_HISTORY_MS,
+    [workspaceId]
+  );
+  const modelRef = useRef<WorkspaceAgentMessageCenterModel | null>(null);
+  const modelWorkspaceIdRef = useRef<string | null>(null);
+  const model = useMemo(() => {
+    if (modelWorkspaceIdRef.current !== workspaceId) {
+      modelWorkspaceIdRef.current = workspaceId;
+      modelRef.current = null;
+    }
+    const nextModel = buildWorkspaceAgentMessageCenterModelFromEngine(
+      presentation,
+      {
+        sessionMessagesById: emptySessionMessagesById,
+        workspaceId
+      },
+      {
+        itemCutoffUnixMs,
+        promptFallbackLabels: {
+          constraintHeader: i18n.t(
+            "workspace.agentMessageCenter.promptConstraintHeader"
+          ),
+          inputHeader: i18n.t("workspace.agentMessageCenter.promptInputHeader"),
+          question: i18n.t("workspace.agentMessageCenter.promptQuestion"),
+          title: i18n.t("workspace.agentMessageCenter.promptTitle")
+        },
+        workspaceRoot: null
+      }
+    );
+    const stableModel = stabilizeWorkspaceAgentMessageCenterModel(
+      modelRef.current,
+      nextModel
+    );
+    modelRef.current = stableModel;
+    return stableModel;
+  }, [i18n, itemCutoffUnixMs, presentation, workspaceId]);
+
+  useWorkspaceAgentDecisionNotifications({
+    messageCenterOpen,
+    model,
+    sendBackgroundNotification: false,
+    sessionEngine,
+    workspaceId
+  });
+
+  return null;
+}

--- a/apps/desktop/src/renderer/src/features/workspace-workbench/ui/StandaloneAgentToolSidebar.tsx
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/ui/StandaloneAgentToolSidebar.tsx
@@ -39,6 +39,7 @@ import {
   type StandaloneAgentFileOpenRequest
 } from "./StandaloneAgentToolSidebarPanel.tsx";
 import { StandaloneAgentToolLoadingState } from "./StandaloneAgentToolLoadingState.tsx";
+import { StandaloneAgentDecisionNotifications } from "./StandaloneAgentDecisionNotifications.tsx";
 
 export type { StandaloneAgentFileOpenRequest } from "./StandaloneAgentToolSidebarPanel.tsx";
 const standaloneAgentToolPanelContentMountDelayMs = 260;
@@ -309,6 +310,12 @@ export function StandaloneAgentToolSidebar({
 
   return (
     <>
+      <StandaloneAgentDecisionNotifications
+        activityService={activityService}
+        i18n={i18n}
+        messageCenterOpen={activePanel === "messages"}
+        workspaceId={workspaceId}
+      />
       <div
         className="workbench-window__header workbench-window__header--custom"
         style={

--- a/apps/desktop/src/renderer/src/features/workspace-workbench/ui/WorkspaceAgentMessageCenterAction.tsx
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/ui/WorkspaceAgentMessageCenterAction.tsx
@@ -1,9 +1,6 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import {
-  AgentInteractivePromptSurface,
-  buildWorkspaceAgentInteractivePromptLabels,
   buildWorkspaceAgentMessageCenterModelFromEngine,
-  isWaitingMessageCenterItem,
   selectWorkspaceAgentMessageCenterPresentation,
   stabilizeWorkspaceAgentMessageCenterModel,
   workspaceAgentMessageCenterPromptStatus,
@@ -11,7 +8,6 @@ import {
   WorkspaceAgentMessageCenterPanel,
   dispatchAgentPlanPromptAction,
   useEngineSelector,
-  type WorkspaceAgentMessageCenterItem,
   type WorkspaceAgentMessageCenterModel
 } from "@tutti-os/agent-gui/agent-message-center";
 import {
@@ -23,18 +19,10 @@ import type { WorkspaceSummary } from "@tutti-os/client-tuttid-ts";
 import type { WorkbenchHostChromeRenderContext } from "@tutti-os/workbench-surface";
 import {
   Button,
-  CloseIcon,
-  StatusDot,
-  toast,
   Tooltip,
   TooltipContent,
   TooltipTrigger
 } from "@tutti-os/ui-system";
-import { INotificationService } from "@tutti-os/ui-notifications";
-import {
-  createDocumentNotificationVisibilityState,
-  type CompositeNotificationMessage
-} from "@renderer/lib/compositeNotificationService";
 import { useService } from "@tutti-os/infra/di";
 import { MessageCenterOpenedReporter } from "@renderer/features/analytics/reporters/message-center-opened/messageCenterOpenedReporter.ts";
 import { MessageCenterNotificationActionedReporter } from "@renderer/features/analytics/reporters/message-center-notification-actioned/messageCenterNotificationActionedReporter.ts";
@@ -44,11 +32,6 @@ import { runDesktopAgentGUILinkAction } from "@renderer/features/workspace-agent
 import { useTranslation } from "@renderer/i18n";
 import { cn } from "@renderer/lib/format";
 import { useWorkspaceWorkbenchHostService } from "./useWorkspaceWorkbenchHostService";
-import {
-  buildWorkspaceAgentDecisionNotification,
-  type WorkspaceAgentDecisionSubmitInput
-} from "../services/workspaceAgentDecisionNotification";
-import { shouldShowWorkspaceAgentDecisionToast } from "../services/workspaceAgentDecisionToastVisibility";
 import { resolveWorkspaceAgentMessageCenterTrigger } from "../services/workspaceAgentMessageCenterTrigger";
 import { toggleWorkspaceAgentMessageCenter } from "../services/workspaceAgentMessageCenterToggle";
 import { registerWorkspaceMessageCenterOpenHandler } from "../services/workspaceMessageCenterCoordinator";
@@ -60,13 +43,11 @@ import { requestWorkspaceIssueManagerLaunch } from "../services/workspaceIssueMa
 import { requestGroupChatLaunch } from "../services/groupChatLaunchCoordinator";
 import { resolveWorkspaceAgentStatusPetMood } from "../services/workspaceAgentStatusPetMood";
 import { WorkspaceAgentStatusPetIcon } from "./WorkspaceAgentStatusPetIcon";
+import { useWorkspaceAgentDecisionNotifications } from "./useWorkspaceAgentDecisionNotifications";
 
 const MESSAGE_CENTER_SUMMARY_MESSAGE_LIMIT = 20;
 const MESSAGE_CENTER_SUMMARY_PREFETCH_ITEM_LIMIT = 12;
 const MESSAGE_CENTER_VISIBLE_HISTORY_MS = 7 * 24 * 60 * 60 * 1000;
-const WORKSPACE_AGENT_DECISION_TOAST_DURATION = Infinity;
-const workspaceAgentDecisionToastClassName = "workspace-agent-decision-toast";
-
 export function WorkspaceAgentMessageCenterAction({
   launchNode,
   open,
@@ -83,26 +64,13 @@ export function WorkspaceAgentMessageCenterAction({
     IWorkspaceAgentActivityService
   );
   const reporterService = useService(IReporterService);
-  const notifications = useService(INotificationService);
   const workbenchHostService = useWorkspaceWorkbenchHostService();
-  const windowForegroundVisibility = useMemo(
-    () =>
-      createDocumentNotificationVisibilityState({
-        hasFocus: () => document.hasFocus(),
-        visibilityState: () => document.visibilityState
-      }),
-    []
-  );
   const [highlightedMessageCenterItemId, setHighlightedMessageCenterItemId] =
     useState<string | null>(null);
   const [sessionMessagesById, setSessionMessagesById] = useState<
     Record<string, AgentActivityMessage[]>
   >({});
   const requestedMessageSummarySessionIdsRef = useRef<Set<string>>(new Set());
-  const seenWaitingNotificationKeysRef = useRef<Set<string> | null>(null);
-  const activeWaitingNotificationToastIdsRef = useRef<Map<string, string>>(
-    new Map()
-  );
   const messageCenterModelRef = useRef<WorkspaceAgentMessageCenterModel | null>(
     null
   );
@@ -154,10 +122,19 @@ export function WorkspaceAgentMessageCenterAction({
     t,
     workspace.id
   ]);
-  const waitingItems = useMemo(
-    () => model.items.filter(isWaitingMessageCenterItem),
-    [model.items]
+  const isAgentGuiSessionOpenForWorkspace = useCallback(
+    (agentSessionId: string) =>
+      isWorkspaceAgentGuiSessionOpen(workspace.id, agentSessionId),
+    [workspace.id]
   );
+  useWorkspaceAgentDecisionNotifications({
+    isAgentGuiSessionOpen: isAgentGuiSessionOpenForWorkspace,
+    messageCenterOpen: open,
+    model,
+    sendBackgroundNotification: true,
+    sessionEngine,
+    workspaceId: workspace.id
+  });
   const triggerPetMood = useEngineSelector(
     sessionEngine,
     resolveWorkspaceAgentStatusPetMood
@@ -184,11 +161,6 @@ export function WorkspaceAgentMessageCenterAction({
   useEffect(() => {
     requestedMessageSummarySessionIdsRef.current.clear();
     setSessionMessagesById({});
-    seenWaitingNotificationKeysRef.current = null;
-    for (const toastId of activeWaitingNotificationToastIdsRef.current.values()) {
-      toast.dismiss(toastId);
-    }
-    activeWaitingNotificationToastIdsRef.current.clear();
     setHighlightedMessageCenterItemId(null);
   }, [workspace.id]);
 
@@ -210,164 +182,6 @@ export function WorkspaceAgentMessageCenterAction({
     },
     [launchNode, setOpen]
   );
-
-  useEffect(() => {
-    const waitingEntries = waitingItems.map(
-      (item) => [waitingNotificationKey(item), item] as const
-    );
-    const currentKeys = new Set(waitingEntries.map(([key]) => key));
-    for (const [
-      notificationKey,
-      toastId
-    ] of activeWaitingNotificationToastIdsRef.current) {
-      if (!currentKeys.has(notificationKey)) {
-        toast.dismiss(toastId);
-        activeWaitingNotificationToastIdsRef.current.delete(notificationKey);
-      }
-    }
-    const seenKeys = seenWaitingNotificationKeysRef.current;
-    if (!seenKeys) {
-      seenWaitingNotificationKeysRef.current = currentKeys;
-      return;
-    }
-    const nextSeenKeys = new Set(seenKeys);
-    for (const key of currentKeys) {
-      nextSeenKeys.add(key);
-    }
-    seenWaitingNotificationKeysRef.current = nextSeenKeys;
-    const newWaitingEntries = waitingEntries.filter(
-      ([key]) => !seenKeys.has(key)
-    );
-    for (const [notificationKey, item] of newWaitingEntries) {
-      const notification = buildWorkspaceAgentDecisionNotification(item, {
-        commandLabel: t(
-          "workspace.agentMessageCenter.waitingNotificationCommand"
-        ),
-        fallbackAgentName: t("workspace.agentGui.fallbackAgentLabel"),
-        planModes: [
-          {
-            id: "acceptEdits",
-            label: t(
-              "workspace.agentMessageCenter.waitingNotificationPlanAcceptEdits"
-            )
-          },
-          {
-            id: "default",
-            label: t(
-              "workspace.agentMessageCenter.waitingNotificationPlanAskFirst"
-            )
-          },
-          {
-            id: "bypassPermissions",
-            label: t(
-              "workspace.agentMessageCenter.waitingNotificationPlanAllowAll"
-            )
-          }
-        ]
-      });
-      if (!notification || notification.options.length === 0) {
-        continue;
-      }
-      const osMessage: CompositeNotificationMessage = {
-        description: notification.description,
-        level: "warning",
-        navigation: {
-          agentSessionId: item.agentSessionId,
-          provider: item.provider,
-          workspaceId: workspace.id
-        },
-        // The decision toast below already covers the in-app face; only
-        // raise the OS notification while the window is in the background.
-        presentation: "background-only",
-        title: t("workspace.agentMessageCenter.waitingNotificationTitle", {
-          title: notification.conversationTitle || notification.agentName
-        })
-      };
-      notifications.notify(osMessage);
-      if (
-        !shouldShowWorkspaceAgentDecisionToast({
-          agentGuiSessionOpen: isWorkspaceAgentGuiSessionOpen(
-            workspace.id,
-            item.agentSessionId
-          ),
-          messageCenterOpen: open,
-          windowForeground: windowForegroundVisibility.isForeground()
-        })
-      ) {
-        continue;
-      }
-      const toastId = `workspace-agent-waiting:${workspace.id}:${notificationKey}`;
-      activeWaitingNotificationToastIdsRef.current.set(
-        notificationKey,
-        toastId
-      );
-      toast.custom(
-        (id) => (
-          <WorkspaceAgentDecisionToast
-            agentIconUrl={notification.agentIconUrl}
-            agentName={notification.agentName}
-            closeLabel={t("common.close")}
-            conversationTitle={notification.conversationTitle}
-            prompt={notification.prompt}
-            promptLabels={buildWorkspaceAgentInteractivePromptLabels(
-              t as unknown as Parameters<
-                typeof buildWorkspaceAgentInteractivePromptLabels
-              >[0],
-              item.provider
-            )}
-            waitingStatusLabel={t(
-              "workspace.agentMessageCenter.waitingNotificationStatus"
-            )}
-            onClose={() => {
-              activeWaitingNotificationToastIdsRef.current.delete(
-                notificationKey
-              );
-              toast.dismiss(id);
-            }}
-            onSubmit={async (input) => {
-              const interaction = selectEnginePendingInteractions(
-                sessionEngine.getSnapshot(),
-                item.agentSessionId
-              ).find((candidate) => candidate.requestId === input.requestId);
-              if (!interaction) return;
-              sessionEngine.dispatch({
-                type: "interaction/responseRequested",
-                workspaceId: workspace.id,
-                agentSessionId: item.agentSessionId,
-                requestId: input.requestId,
-                turnId: interaction.turnId,
-                commandId: interactionCommandId({
-                  workspaceId: workspace.id,
-                  agentSessionId: item.agentSessionId,
-                  requestId: input.requestId
-                }),
-                ...(input.action ? { action: input.action } : {}),
-                ...(input.optionId ? { optionId: input.optionId } : {}),
-                ...(input.payload ? { payload: input.payload } : {})
-              });
-              activeWaitingNotificationToastIdsRef.current.delete(
-                notificationKey
-              );
-              toast.dismiss(id);
-            }}
-          />
-        ),
-        {
-          className: workspaceAgentDecisionToastClassName,
-          id: toastId,
-          duration: WORKSPACE_AGENT_DECISION_TOAST_DURATION
-        }
-      );
-    }
-  }, [
-    notifications,
-    open,
-    t,
-    waitingItems,
-    windowForegroundVisibility,
-    workspace.id,
-    sessionEngine
-  ]);
 
   useEffect(() => {
     if (!open) {
@@ -640,112 +454,6 @@ function interactionCommandId(input: {
     input.agentSessionId,
     input.turnId ?? "interaction",
     input.requestId
-  ].join(":");
-}
-
-function WorkspaceAgentDecisionToast({
-  agentIconUrl,
-  agentName,
-  closeLabel,
-  conversationTitle,
-  prompt,
-  promptLabels,
-  waitingStatusLabel,
-  onClose,
-  onSubmit
-}: {
-  agentIconUrl: string;
-  agentName: string;
-  closeLabel: string;
-  conversationTitle: string;
-  prompt: NonNullable<WorkspaceAgentMessageCenterItem["pendingPrompt"]>;
-  promptLabels: ReturnType<typeof buildWorkspaceAgentInteractivePromptLabels>;
-  waitingStatusLabel: string;
-  onClose: () => void;
-  onSubmit: (input: WorkspaceAgentDecisionSubmitInput) => Promise<void>;
-}) {
-  "use memo";
-  const [isSubmitting, setIsSubmitting] = useState(false);
-  const displayTitle = conversationTitle || agentName;
-
-  return (
-    <article className="relative w-full min-w-0 overflow-visible rounded-[12px] border border-[var(--tutti-purple-border)] bg-[var(--tutti-purple-bg)] p-3.5">
-      <span
-        aria-hidden="true"
-        className="workspace-agent-decision-toast__edge-glow agent-gui-edge-glow pointer-events-none inset-0 rounded-[12px]"
-        style={{ position: "absolute" }}
-      />
-      <Button
-        type="button"
-        aria-label={closeLabel}
-        className="workspace-agent-decision-toast__close absolute top-0 right-0 z-[2] size-6 translate-x-[35%] -translate-y-[35%] rounded-full border-[var(--line-2)] bg-[var(--background-panel)] text-[var(--text-secondary)] shadow-sm hover:bg-[var(--background-fronted)] hover:text-[var(--text-primary)] focus-visible:ring-[color-mix(in_srgb,var(--border-focus)_30%,transparent)]"
-        size="icon-xs"
-        variant="chrome"
-        onClick={onClose}
-      >
-        <CloseIcon className="size-4" />
-      </Button>
-      <div className="workspace-agent-decision-toast__content relative z-[1] grid min-w-0 gap-2.5 transition-opacity">
-        <div className="flex min-w-0 items-center justify-between gap-2.5 pr-2">
-          <h3 className="min-w-0 truncate text-[13px] font-bold leading-5 text-[var(--text-secondary)]">
-            {displayTitle}
-          </h3>
-          <span
-            className="inline-flex shrink-0 items-center gap-1.5 text-[11px] font-semibold leading-4 text-[var(--text-secondary)]"
-            data-status="waiting"
-            title={waitingStatusLabel}
-          >
-            <StatusDot
-              tone="amber"
-              pulse
-              size="sm"
-              title={waitingStatusLabel}
-            />
-            <span>{waitingStatusLabel}</span>
-          </span>
-        </div>
-        <div className="workspace-agent-decision-toast__prompt min-w-0">
-          <AgentInteractivePromptSurface
-            embedded
-            keyboardShortcuts={false}
-            prompt={prompt}
-            isSubmitting={isSubmitting}
-            labels={promptLabels}
-            onSubmit={(input) => {
-              setIsSubmitting(true);
-              void onSubmit(input).catch(() => {
-                setIsSubmitting(false);
-              });
-            }}
-          />
-        </div>
-        <div className="flex min-w-0 items-center gap-2 text-[13px] font-normal leading-5 text-[var(--text-secondary)]">
-          <span className="inline-flex size-5 shrink-0 items-center justify-center overflow-hidden rounded-full border border-[var(--line-1)] bg-[var(--transparency-block)]">
-            <img
-              src={agentIconUrl}
-              alt={agentName}
-              className="size-full object-cover"
-              decoding="async"
-              draggable={false}
-            />
-          </span>
-          <span className="min-w-0 truncate">{agentName}</span>
-        </div>
-      </div>
-    </article>
-  );
-}
-
-function waitingNotificationKey(item: WorkspaceAgentMessageCenterItem): string {
-  const requestId = item.pendingPrompt?.requestId.trim();
-  if (requestId) {
-    return `${item.agentSessionId}:prompt:${requestId}`;
-  }
-  return [
-    item.agentSessionId,
-    "attention",
-    item.needsAttentionKind ?? "waiting",
-    item.sortTimeUnixMs
   ].join(":");
 }
 

--- a/apps/desktop/src/renderer/src/features/workspace-workbench/ui/WorkspaceChrome.test.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/ui/WorkspaceChrome.test.ts
@@ -22,6 +22,13 @@ const messageCenterSource = readFileSync(
   ),
   "utf8"
 );
+const decisionNotificationsSource = readFileSync(
+  resolve(
+    dirname(fileURLToPath(import.meta.url)),
+    "useWorkspaceAgentDecisionNotifications.tsx"
+  ),
+  "utf8"
+);
 
 test("workspace chrome header releases the drag region while the message center is open", () => {
   assert.match(
@@ -84,18 +91,21 @@ test("workspace chrome gates the agent decision toast on window focus, message c
   // conversation is already visible.
   assert.match(
     messageCenterSource,
-    /shouldShowWorkspaceAgentDecisionToast\(\{\s*agentGuiSessionOpen: isWorkspaceAgentGuiSessionOpen\(\s*workspace\.id,\s*item\.agentSessionId\s*\),\s*messageCenterOpen: open,\s*windowForeground: windowForegroundVisibility\.isForeground\(\)\s*\}\)/
-  );
-  // The OS notification path (background-only presentation) must remain
-  // unconditional here — it is the mechanism that already correctly gates on
-  // focus for the OS face, and the message-center model/list must keep
-  // reflecting pending items regardless of toast visibility.
-  assert.match(
-    messageCenterSource,
-    /notifications\.notify\(osMessage\);\s*if \(\s*!shouldShowWorkspaceAgentDecisionToast/
+    /const isAgentGuiSessionOpenForWorkspace = useCallback\([\s\S]*?isWorkspaceAgentGuiSessionOpen\(workspace\.id, agentSessionId\)[\s\S]*?useWorkspaceAgentDecisionNotifications\(\{[\s\S]*?isAgentGuiSessionOpen: isAgentGuiSessionOpenForWorkspace,[\s\S]*?sendBackgroundNotification: true/
   );
   assert.match(
-    messageCenterSource,
+    decisionNotificationsSource,
+    /shouldShowWorkspaceAgentDecisionToast\(\{[\s\S]*?agentGuiSessionOpen:[\s\S]*?isAgentGuiSessionOpen\?\.\(item\.agentSessionId\) \?\? false,[\s\S]*?messageCenterOpen,[\s\S]*?windowForeground: windowForegroundVisibility\.isForeground\(\)/
+  );
+  // The OS workspace opts into the background-only face before applying the
+  // foreground toast visibility gate. Standalone reuses the same controller
+  // with this OS face disabled, so opening both renderers cannot duplicate it.
+  assert.match(
+    decisionNotificationsSource,
+    /if \(sendBackgroundNotification\) \{[\s\S]*?notifications\.notify\(osMessage\);[\s\S]*?shouldShowWorkspaceAgentDecisionToast/
+  );
+  assert.match(
+    decisionNotificationsSource,
     /createDocumentNotificationVisibilityState\(\{\s*hasFocus: \(\) => document\.hasFocus\(\),\s*visibilityState: \(\) => document\.visibilityState\s*\}\)/
   );
 });

--- a/apps/desktop/src/renderer/src/features/workspace-workbench/ui/standaloneAgentToolWorkbench.test.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/ui/standaloneAgentToolWorkbench.test.ts
@@ -47,6 +47,14 @@ const standaloneAgentMessageCenterToolPanelSource = readFileSync(
   new URL("./StandaloneAgentMessageCenterToolPanel.tsx", import.meta.url),
   "utf8"
 );
+const standaloneAgentDecisionNotificationsSource = readFileSync(
+  new URL("./StandaloneAgentDecisionNotifications.tsx", import.meta.url),
+  "utf8"
+);
+const workspaceAgentDecisionNotificationsSource = readFileSync(
+  new URL("./useWorkspaceAgentDecisionNotifications.tsx", import.meta.url),
+  "utf8"
+);
 const standaloneAgentIssueManagerToolPanelSource = readFileSync(
   new URL("./StandaloneAgentIssueManagerToolPanel.tsx", import.meta.url),
   "utf8"
@@ -456,6 +464,37 @@ test("standalone Agent message reminders remain activity-driven", () => {
   assert.doesNotMatch(
     standaloneAgentToolSidebarSource,
     /activityService\.load\(workspaceId\)/
+  );
+});
+
+test("standalone Agent reuses the OS decision toast for newly arrived approvals", () => {
+  assert.match(
+    standaloneAgentToolSidebarSource,
+    /<StandaloneAgentDecisionNotifications[\s\S]*?messageCenterOpen=\{activePanel === "messages"\}/
+  );
+  assert.match(
+    standaloneAgentDecisionNotificationsSource,
+    /useWorkspaceAgentDecisionNotifications\(\{[\s\S]*?sendBackgroundNotification: false,[\s\S]*?sessionEngine,[\s\S]*?workspaceId/
+  );
+  assert.doesNotMatch(
+    standaloneAgentDecisionNotificationsSource,
+    /isAgentGuiSessionOpen:/
+  );
+  assert.match(
+    workspaceAgentDecisionNotificationsSource,
+    /toast\.custom\([\s\S]*?<WorkspaceAgentDecisionToast/
+  );
+  assert.match(
+    workspaceAgentDecisionNotificationsSource,
+    /isAgentGuiSessionOpen\?\.\(item\.agentSessionId\) \?\? false/
+  );
+  assert.match(
+    workspaceAgentDecisionNotificationsSource,
+    /type: "interaction\/responseRequested"/
+  );
+  assert.match(
+    workspaceAgentDecisionNotificationsSource,
+    /if \(!seenKeys\) \{[\s\S]*?seenWaitingNotificationKeysRef\.current = currentKeys;[\s\S]*?return;/
   );
 });
 

--- a/apps/desktop/src/renderer/src/features/workspace-workbench/ui/useWorkspaceAgentDecisionNotifications.tsx
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/ui/useWorkspaceAgentDecisionNotifications.tsx
@@ -1,0 +1,366 @@
+import { useEffect, useMemo, useRef, useState } from "react";
+import {
+  AgentInteractivePromptSurface,
+  buildWorkspaceAgentInteractivePromptLabels,
+  isWaitingMessageCenterItem,
+  type WorkspaceAgentMessageCenterItem,
+  type WorkspaceAgentMessageCenterModel
+} from "@tutti-os/agent-gui/agent-message-center";
+import {
+  selectEnginePendingInteractions,
+  type AgentSessionEngine
+} from "@tutti-os/agent-activity-core";
+import { Button, CloseIcon, StatusDot, toast } from "@tutti-os/ui-system";
+import { INotificationService } from "@tutti-os/ui-notifications";
+import { useService } from "@tutti-os/infra/di";
+import {
+  createDocumentNotificationVisibilityState,
+  type CompositeNotificationMessage
+} from "@renderer/lib/compositeNotificationService";
+import { useTranslation } from "@renderer/i18n";
+import {
+  buildWorkspaceAgentDecisionNotification,
+  type WorkspaceAgentDecisionSubmitInput
+} from "../services/workspaceAgentDecisionNotification";
+import { shouldShowWorkspaceAgentDecisionToast } from "../services/workspaceAgentDecisionToastVisibility";
+
+const WORKSPACE_AGENT_DECISION_TOAST_DURATION = Infinity;
+const workspaceAgentDecisionToastClassName = "workspace-agent-decision-toast";
+
+export function useWorkspaceAgentDecisionNotifications(input: {
+  isAgentGuiSessionOpen?: (agentSessionId: string) => boolean;
+  messageCenterOpen: boolean;
+  model: WorkspaceAgentMessageCenterModel;
+  sendBackgroundNotification: boolean;
+  sessionEngine: AgentSessionEngine;
+  workspaceId: string;
+}): void {
+  const {
+    isAgentGuiSessionOpen,
+    messageCenterOpen,
+    model,
+    sendBackgroundNotification,
+    sessionEngine,
+    workspaceId
+  } = input;
+  const { t } = useTranslation();
+  const notifications = useService(INotificationService);
+  const windowForegroundVisibility = useMemo(
+    () =>
+      createDocumentNotificationVisibilityState({
+        hasFocus: () => document.hasFocus(),
+        visibilityState: () => document.visibilityState
+      }),
+    []
+  );
+  const waitingItems = useMemo(
+    () => model.items.filter(isWaitingMessageCenterItem),
+    [model.items]
+  );
+  const seenWaitingNotificationKeysRef = useRef<Set<string> | null>(null);
+  const activeWaitingNotificationToastIdsRef = useRef<Map<string, string>>(
+    new Map()
+  );
+
+  useEffect(() => {
+    seenWaitingNotificationKeysRef.current = null;
+    dismissActiveDecisionToasts(activeWaitingNotificationToastIdsRef.current);
+  }, [workspaceId]);
+
+  useEffect(
+    () => () => {
+      dismissActiveDecisionToasts(activeWaitingNotificationToastIdsRef.current);
+    },
+    []
+  );
+
+  useEffect(() => {
+    const waitingEntries = waitingItems.map(
+      (item) => [waitingNotificationKey(item), item] as const
+    );
+    const currentKeys = new Set(waitingEntries.map(([key]) => key));
+    for (const [
+      notificationKey,
+      toastId
+    ] of activeWaitingNotificationToastIdsRef.current) {
+      if (!currentKeys.has(notificationKey)) {
+        toast.dismiss(toastId);
+        activeWaitingNotificationToastIdsRef.current.delete(notificationKey);
+      }
+    }
+    const seenKeys = seenWaitingNotificationKeysRef.current;
+    if (!seenKeys) {
+      seenWaitingNotificationKeysRef.current = currentKeys;
+      return;
+    }
+    const nextSeenKeys = new Set(seenKeys);
+    for (const key of currentKeys) {
+      nextSeenKeys.add(key);
+    }
+    seenWaitingNotificationKeysRef.current = nextSeenKeys;
+    const newWaitingEntries = waitingEntries.filter(
+      ([key]) => !seenKeys.has(key)
+    );
+    for (const [notificationKey, item] of newWaitingEntries) {
+      const notification = buildWorkspaceAgentDecisionNotification(item, {
+        commandLabel: t(
+          "workspace.agentMessageCenter.waitingNotificationCommand"
+        ),
+        fallbackAgentName: t("workspace.agentGui.fallbackAgentLabel"),
+        planModes: [
+          {
+            id: "acceptEdits",
+            label: t(
+              "workspace.agentMessageCenter.waitingNotificationPlanAcceptEdits"
+            )
+          },
+          {
+            id: "default",
+            label: t(
+              "workspace.agentMessageCenter.waitingNotificationPlanAskFirst"
+            )
+          },
+          {
+            id: "bypassPermissions",
+            label: t(
+              "workspace.agentMessageCenter.waitingNotificationPlanAllowAll"
+            )
+          }
+        ]
+      });
+      if (!notification || notification.options.length === 0) {
+        continue;
+      }
+      if (sendBackgroundNotification) {
+        const osMessage: CompositeNotificationMessage = {
+          description: notification.description,
+          level: "warning",
+          navigation: {
+            agentSessionId: item.agentSessionId,
+            provider: item.provider,
+            workspaceId
+          },
+          // The decision toast below covers the foreground in-app face.
+          presentation: "background-only",
+          title: t("workspace.agentMessageCenter.waitingNotificationTitle", {
+            title: notification.conversationTitle || notification.agentName
+          })
+        };
+        notifications.notify(osMessage);
+      }
+      if (
+        !shouldShowWorkspaceAgentDecisionToast({
+          agentGuiSessionOpen:
+            isAgentGuiSessionOpen?.(item.agentSessionId) ?? false,
+          messageCenterOpen,
+          windowForeground: windowForegroundVisibility.isForeground()
+        })
+      ) {
+        continue;
+      }
+      const toastId = `workspace-agent-waiting:${workspaceId}:${notificationKey}`;
+      activeWaitingNotificationToastIdsRef.current.set(
+        notificationKey,
+        toastId
+      );
+      toast.custom(
+        (id) => (
+          <WorkspaceAgentDecisionToast
+            agentIconUrl={notification.agentIconUrl}
+            agentName={notification.agentName}
+            closeLabel={t("common.close")}
+            conversationTitle={notification.conversationTitle}
+            prompt={notification.prompt}
+            promptLabels={buildWorkspaceAgentInteractivePromptLabels(
+              t as unknown as Parameters<
+                typeof buildWorkspaceAgentInteractivePromptLabels
+              >[0],
+              item.provider
+            )}
+            waitingStatusLabel={t(
+              "workspace.agentMessageCenter.waitingNotificationStatus"
+            )}
+            onClose={() => {
+              activeWaitingNotificationToastIdsRef.current.delete(
+                notificationKey
+              );
+              toast.dismiss(id);
+            }}
+            onSubmit={async (submitInput) => {
+              const interaction = selectEnginePendingInteractions(
+                sessionEngine.getSnapshot(),
+                item.agentSessionId
+              ).find(
+                (candidate) => candidate.requestId === submitInput.requestId
+              );
+              if (!interaction) return;
+              sessionEngine.dispatch({
+                type: "interaction/responseRequested",
+                workspaceId,
+                agentSessionId: item.agentSessionId,
+                requestId: submitInput.requestId,
+                turnId: interaction.turnId,
+                commandId: interactionCommandId({
+                  workspaceId,
+                  agentSessionId: item.agentSessionId,
+                  requestId: submitInput.requestId
+                }),
+                ...(submitInput.action ? { action: submitInput.action } : {}),
+                ...(submitInput.optionId
+                  ? { optionId: submitInput.optionId }
+                  : {}),
+                ...(submitInput.payload ? { payload: submitInput.payload } : {})
+              });
+              activeWaitingNotificationToastIdsRef.current.delete(
+                notificationKey
+              );
+              toast.dismiss(id);
+            }}
+          />
+        ),
+        {
+          className: workspaceAgentDecisionToastClassName,
+          id: toastId,
+          duration: WORKSPACE_AGENT_DECISION_TOAST_DURATION
+        }
+      );
+    }
+  }, [
+    isAgentGuiSessionOpen,
+    messageCenterOpen,
+    notifications,
+    sendBackgroundNotification,
+    sessionEngine,
+    t,
+    waitingItems,
+    windowForegroundVisibility,
+    workspaceId
+  ]);
+}
+
+function WorkspaceAgentDecisionToast({
+  agentIconUrl,
+  agentName,
+  closeLabel,
+  conversationTitle,
+  prompt,
+  promptLabels,
+  waitingStatusLabel,
+  onClose,
+  onSubmit
+}: {
+  agentIconUrl: string;
+  agentName: string;
+  closeLabel: string;
+  conversationTitle: string;
+  prompt: NonNullable<WorkspaceAgentMessageCenterItem["pendingPrompt"]>;
+  promptLabels: ReturnType<typeof buildWorkspaceAgentInteractivePromptLabels>;
+  waitingStatusLabel: string;
+  onClose: () => void;
+  onSubmit: (input: WorkspaceAgentDecisionSubmitInput) => Promise<void>;
+}) {
+  "use memo";
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const displayTitle = conversationTitle || agentName;
+
+  return (
+    <article className="relative w-full min-w-0 overflow-visible rounded-[12px] border border-[var(--tutti-purple-border)] bg-[var(--tutti-purple-bg)] p-3.5">
+      <span
+        aria-hidden="true"
+        className="workspace-agent-decision-toast__edge-glow agent-gui-edge-glow pointer-events-none inset-0 rounded-[12px]"
+        style={{ position: "absolute" }}
+      />
+      <Button
+        type="button"
+        aria-label={closeLabel}
+        className="workspace-agent-decision-toast__close absolute top-0 right-0 z-[2] size-6 translate-x-[35%] -translate-y-[35%] rounded-full border-[var(--line-2)] bg-[var(--background-panel)] text-[var(--text-secondary)] shadow-sm hover:bg-[var(--background-fronted)] hover:text-[var(--text-primary)] focus-visible:ring-[color-mix(in_srgb,var(--border-focus)_30%,transparent)]"
+        size="icon-xs"
+        variant="chrome"
+        onClick={onClose}
+      >
+        <CloseIcon className="size-4" />
+      </Button>
+      <div className="workspace-agent-decision-toast__content relative z-[1] grid min-w-0 gap-2.5 transition-opacity">
+        <div className="flex min-w-0 items-center justify-between gap-2.5 pr-2">
+          <h3 className="min-w-0 truncate text-[13px] font-bold leading-5 text-[var(--text-secondary)]">
+            {displayTitle}
+          </h3>
+          <span
+            className="inline-flex shrink-0 items-center gap-1.5 text-[11px] font-semibold leading-4 text-[var(--text-secondary)]"
+            data-status="waiting"
+            title={waitingStatusLabel}
+          >
+            <StatusDot
+              tone="amber"
+              pulse
+              size="sm"
+              title={waitingStatusLabel}
+            />
+            <span>{waitingStatusLabel}</span>
+          </span>
+        </div>
+        <div className="workspace-agent-decision-toast__prompt min-w-0">
+          <AgentInteractivePromptSurface
+            embedded
+            keyboardShortcuts={false}
+            prompt={prompt}
+            isSubmitting={isSubmitting}
+            labels={promptLabels}
+            onSubmit={(submitInput) => {
+              setIsSubmitting(true);
+              void onSubmit(submitInput).catch(() => {
+                setIsSubmitting(false);
+              });
+            }}
+          />
+        </div>
+        <div className="flex min-w-0 items-center gap-2 text-[13px] font-normal leading-5 text-[var(--text-secondary)]">
+          <span className="inline-flex size-5 shrink-0 items-center justify-center overflow-hidden rounded-full border border-[var(--line-1)] bg-[var(--transparency-block)]">
+            <img
+              src={agentIconUrl}
+              alt={agentName}
+              className="size-full object-cover"
+              decoding="async"
+              draggable={false}
+            />
+          </span>
+          <span className="min-w-0 truncate">{agentName}</span>
+        </div>
+      </div>
+    </article>
+  );
+}
+
+function waitingNotificationKey(item: WorkspaceAgentMessageCenterItem): string {
+  const requestId = item.pendingPrompt?.requestId.trim();
+  if (requestId) {
+    return `${item.agentSessionId}:prompt:${requestId}`;
+  }
+  return [
+    item.agentSessionId,
+    "attention",
+    item.needsAttentionKind ?? "waiting",
+    item.sortTimeUnixMs
+  ].join(":");
+}
+
+function interactionCommandId(input: {
+  agentSessionId: string;
+  requestId: string;
+  turnId?: string;
+  workspaceId: string;
+}): string {
+  return [
+    input.workspaceId,
+    input.agentSessionId,
+    input.turnId ?? "interaction",
+    input.requestId
+  ].join(":");
+}
+
+function dismissActiveDecisionToasts(toastIds: Map<string, string>): void {
+  for (const toastId of toastIds.values()) {
+    toast.dismiss(toastId);
+  }
+  toastIds.clear();
+}

--- a/docs/architecture/agent-gui-node.md
+++ b/docs/architecture/agent-gui-node.md
@@ -110,6 +110,20 @@ durable Interaction(pending)
   -> approval / question / exit-plan presentation
 ```
 
+The workspace shell and standalone Agent window share one decision-notification
+controller and card presentation. When a new pending interaction arrives while
+the current window is foregrounded and its Message Center is closed, that
+window may surface the actionable card as a persistent top-right toast. Initial
+pending interactions are recorded without replaying historical toasts, and a
+resolved interaction dismisses its active toast. The workspace shell suppresses
+that toast when the same AgentGUI session is already open, while the standalone
+Agent window intentionally keeps the top-right card in addition to the inline
+prompt. The standalone window does not emit a second OS notification; the
+workspace shell remains the owner of the background-only OS face. Toast actions
+dispatch the same canonical
+`interaction/responseRequested` command as AgentGUI and Message Center instead
+of deriving actionability or response identity from transcript messages.
+
 Transcript messages are historical presentation only. A tool-call row with a
 `waiting_input` status must not create an approval dialog, question composer,
 exit-plan prompt, attention item, or pending-interaction view model. Session


### PR DESCRIPTION
## Summary

- reuse the OS workspace decision-toast controller and card in standalone Agent windows
- surface newly arrived approvals in the top-right while keeping Message Center and inline prompts canonical
- avoid replaying historical approvals and avoid duplicate standalone OS notifications
- document the shared interaction-notification lifecycle

## Validation

- `pnpm check:full`
- `pnpm --filter @tutti-os/desktop test` (1392 passed, 2 skipped)
- `pnpm --filter @tutti-os/desktop typecheck`
- `pnpm --filter @tutti-os/desktop build`
- `pnpm check:renderer-boundaries`
- `pnpm check:ui-boundaries`
- `pnpm check:i18n`
- repeated both observed Go runtime timing tests 10 times successfully

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reuse the shared decision-toast controller and card to show new agent approvals in standalone Agent windows without duplicating OS notifications or replaying history.

- **New Features**
  - Adds top-right decision toasts in standalone windows for newly arrived approvals when the window is foregrounded and the Message Center is closed.
  - Toast actions dispatch the canonical `interaction/responseRequested` command and auto-dismiss when resolved.
  - Standalone disables the background OS notification; the workspace shell remains the sole OS notifier.

- **Refactors**
  - Extracted `useWorkspaceAgentDecisionNotifications` and reused it in both the workspace shell and standalone window.
  - Simplified the workspace action code by removing inline toast logic and documented the shared lifecycle in `docs/architecture/agent-gui-node.md`.

<sup>Written for commit 834eef6985287aa05c6e2a30317360880bdd7c49. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tutti-os/tutti/pull/1125?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

