### PR TITLE
fix(agent-gui): share home composer draft across projects

### DIFF
--- a/docs/architecture/agent-gui-node.md
+++ b/docs/architecture/agent-gui-node.md
@@ -1702,36 +1702,37 @@ Only the submit boundary converts this array to the existing
 persistence protocols do not own a second draft representation.
 
 Draft content identity is independent from provider, model, and the other
-composer settings. On the home composer, content is cached under the normalized
-selected project path (`project:<path>`, or `project:<none>` without a project).
-An existing conversation uses `session:<agentSessionId>`. Switching providers
-within one project therefore preserves the whole message, switching projects
-restores the destination project's message, and returning home from a session
-restores the current project draft instead of the session draft. Provider/target
+composer settings. On the home composer, content is cached under one shared
+scope (`home`) for every selected project, including no project. An existing
+conversation uses `session:<agentSessionId>`. Switching providers or projects
+on home therefore preserves the whole message; returning home from a session
+restores the shared home draft instead of the session draft. Provider/target
 default settings, session settings, optimistic setting updates, model
 inheritance, validation, and fallback keep their existing ownership and keys;
-project identity must not be added to those setting caches.
+project identity must not be added to those setting caches or to the home draft
+scope.
 
 Attachment upload work also owns the draft scope where it started. If the user
-switches projects or sessions before an image or pasted-text upload settles,
-the completion or failure updates the latest draft in the original scope by
-block id; it must not read attachment projections from, or write results into,
-the newly selected scope. Derived attachment arrays used by the composer are
+switches sessions (or leaves home for a session) before an image or pasted-text
+upload settles, the completion or failure updates the latest draft in the
+original scope by block id; it must not read attachment projections from, or
+write results into, the newly selected scope. Switching projects on home does
+not change draft scope. Derived attachment arrays used by the composer are
 memoized from the atomic content value and synchronized together so rerenders
 cannot overwrite an optimistic attachment update with an older projection.
 
 Each composer submit records a lightweight snapshot of the source scope and its
 full content array, correlated by `clientSubmitId`; existing-session sends also
-record the destination session because a recovered submit can send a project
-draft to a previously active session. A successful first-message activation
-clears its project scope; an accepted/confirmed existing-session send,
-including a queued or recovered send, clears its recorded source scope. Failure
-or an uncertain state retains the draft. Before clearing, the controller
-compares the complete current array with the snapshot, including attachment
-upload metadata, so edits made while a request is pending are retained as one
-new message. Terminal results, immediate engine rejection, and conversation
-deletion discard snapshots that can no longer resolve. Non-composer control
-sends must not participate in this draft cleanup.
+record the destination session because a recovered submit can send a home draft
+to a previously active session. A successful first-message activation clears
+its home scope; an accepted/confirmed existing-session send, including a queued
+or recovered send, clears its recorded source scope. Failure or an uncertain
+state retains the draft. Before clearing, the controller compares the complete
+current array with the snapshot, including attachment upload metadata, so edits
+made while a request is pending are retained as one new message. Terminal
+results, immediate engine rejection, and conversation deletion discard
+snapshots that can no longer resolve. Non-composer control sends must not
+participate in this draft cleanup.
 
 User-visible rules:
 

--- a/docs/conventions/troubleshooting/agent-runtime.md
+++ b/docs/conventions/troubleshooting/agent-runtime.md
@@ -54,6 +54,7 @@ Turn state, loading, cancel, restore, rail projection, event updates, imports, a
 - [Remote agent cancel does not stop the local turn](./agent-session-lifecycle.md#remote-agent-cancel-does-not-stop-the-local-turn)
 - [Claude Code cancel leaves Write/tool cards stuck in progress](./agent-session-lifecycle.md#claude-code-cancel-leaves-writetool-cards-stuck-in-progress)
 - [AgentGUI freezes when session history is large](./agent-session-lifecycle.md#agentgui-freezes-when-session-history-is-large)
+- [AgentGUI @ Sessions tab is empty](./agent-session-lifecycle.md#agentgui--sessions-tab-is-empty)
 - [Agent diagnostics flood while a turn is streaming](./agent-session-lifecycle.md#agent-diagnostics-flood-while-a-turn-is-streaming)
 - [Imported sessions trigger fresh-completion indicators](./agent-session-lifecycle.md#imported-sessions-trigger-fresh-completion-indicators)
 - [Realtime agent completion does not show unread attention](./agent-session-lifecycle.md#realtime-agent-completion-does-not-show-unread-attention)

--- a/docs/conventions/troubleshooting/agent-session-lifecycle.md
+++ b/docs/conventions/troubleshooting/agent-session-lifecycle.md
@@ -637,6 +637,34 @@ Turn state, loading, cancel, restore, rail projection, event updates, imports, a
 - References:
   [desktopAgentActivityAdapter.ts](../../../apps/desktop/src/renderer/src/features/workspace-agent/services/desktopAgentActivityAdapter.ts)
   [createDesktopAgentActivityRuntime.ts](../../../apps/desktop/src/renderer/src/features/workspace-agent/services/createDesktopAgentActivityRuntime.ts)
+
+### AgentGUI @ Sessions tab is empty
+
+- Symptom:
+  Opening the composer `@` palette (default Sessions tab) shows no session
+  rows, even though the workspace has agent history.
+- Quick checks:
+  In `tuttid.log`, look for `event=workspace.agent_session.api.list_completed`
+  from `GET /v1/workspaces/{workspaceID}/agent-sessions` (the Sessions-tab
+  source). Check `session_count`. Do not confuse it with
+  `workspace.agent_session.messages.api.list_*` or
+  `workspace.agent_session.section.list_failed`.
+- Root cause:
+  The Sessions tab loads through `listWorkspaceAgentSessions`. Successful calls
+  previously left no durable log, so empty palettes could not be distinguished
+  from "API never ran" or "API returned zero sessions" in exported logs.
+- Fix:
+  Successful list responses now emit
+  `workspace.agent_session.api.list_completed` with `session_count`. If the
+  event is missing, the client never hit the endpoint; if `session_count=0`,
+  the daemon truly returned an empty list.
+- Validation:
+  Click the composer `@` button, confirm a
+  `workspace.agent_session.api.list_completed` line appears with a non-zero
+  `session_count` when sessions exist.
+- References:
+  [daemon_agent_session_list.go](../../../services/tuttid/api/daemon_agent_session_list.go)
+  [desktopRichTextAtAgentContributors.ts](../../../apps/desktop/src/renderer/src/features/rich-text-at/services/internal/desktopRichTextAtAgentContributors.ts)
   [agent-gui-node.md](../../architecture/agent-gui-node.md)
 
 ### Agent diagnostics flood while a turn is streaming

--- a/packages/agent/gui/agent-gui/agentGuiNode/AgentComposer.spec.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/AgentComposer.spec.tsx
@@ -3285,6 +3285,88 @@ describe("AgentComposer", () => {
     expect(await screen.findByRole("tooltip")).toHaveTextContent("提及上下文");
   });
 
+  it("focuses the shared home draft at the end after switching projects", async () => {
+    const draftContent = createDraft("keep typing here");
+    const { rerender } = render(
+      <AgentComposer
+        workspaceId="workspace-1"
+        currentUserId="user-1"
+        provider="codex"
+        draftContent={draftContent}
+        draftScopeKey="home"
+        availableCommands={[] satisfies readonly AgentHostAgentSessionCommand[]}
+        disabled={false}
+        submitDisabled={false}
+        placeholder="placeholder"
+        composerSettings={createComposerSettings({
+          selectedProjectPath: "/workspace/a"
+        })}
+        queuedPrompts={[]}
+        drainingQueuedPromptId={null}
+        canQueueWhileBusy={false}
+        showStopButton={false}
+        activePrompt={null}
+        isInterrupting={false}
+        isSendingTurn={false}
+        isSubmittingPrompt={false}
+        labels={createLabels()}
+        workspaceUserProjectI18n={workspaceUserProjectI18n}
+        onDraftContentChange={vi.fn()}
+        onSettingsChange={vi.fn()}
+        onSubmit={vi.fn()}
+        onSendQueuedPromptNext={vi.fn()}
+        onRemoveQueuedPrompt={vi.fn()}
+        onEditQueuedPrompt={vi.fn()}
+        onInterruptCurrentTurn={vi.fn()}
+        onSubmitInteractivePrompt={vi.fn()}
+      />
+    );
+
+    mockEditorFocusAtEnd.mockClear();
+    rerender(
+      <AgentComposer
+        workspaceId="workspace-1"
+        currentUserId="user-1"
+        provider="codex"
+        draftContent={draftContent}
+        draftScopeKey="home"
+        availableCommands={[] satisfies readonly AgentHostAgentSessionCommand[]}
+        disabled={false}
+        submitDisabled={false}
+        placeholder="placeholder"
+        composerSettings={createComposerSettings({
+          selectedProjectPath: "/workspace/b"
+        })}
+        queuedPrompts={[]}
+        drainingQueuedPromptId={null}
+        canQueueWhileBusy={false}
+        showStopButton={false}
+        activePrompt={null}
+        isInterrupting={false}
+        isSendingTurn={false}
+        isSubmittingPrompt={false}
+        labels={createLabels()}
+        workspaceUserProjectI18n={workspaceUserProjectI18n}
+        onDraftContentChange={vi.fn()}
+        onSettingsChange={vi.fn()}
+        onSubmit={vi.fn()}
+        onSendQueuedPromptNext={vi.fn()}
+        onRemoveQueuedPrompt={vi.fn()}
+        onEditQueuedPrompt={vi.fn()}
+        onInterruptCurrentTurn={vi.fn()}
+        onSubmitInteractivePrompt={vi.fn()}
+      />
+    );
+
+    await act(async () => {
+      await new Promise<void>((resolve) => {
+        window.setTimeout(resolve, 0);
+      });
+    });
+
+    expect(mockEditorFocusAtEnd).toHaveBeenCalled();
+  });
+
   it("hides the project row for locked dock composers in existing conversations", () => {
     const { container } = render(
       <AgentComposer

--- a/packages/agent/gui/agent-gui/agentGuiNode/AgentComposer.spec.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/AgentComposer.spec.tsx
@@ -339,15 +339,21 @@ vi.mock("./agentRichText/AgentRichTextEditor", async () => {
 
 vi.mock("./AgentComposerSettingsMenus", () => ({
   AgentProjectDropdown: ({
+    onDismissAutoFocus,
     onProjectMissingChange
   }: {
+    onDismissAutoFocus?: (event: Event) => void;
     onProjectMissingChange?: (isMissing: boolean) => void;
   }) => {
     queueMicrotask(() => {
       onProjectMissingChange?.(mockProjectMissingState.current);
     });
     return (
-      <button type="button" data-testid="agent-project-dropdown">
+      <button
+        type="button"
+        data-testid="agent-project-dropdown"
+        onClick={() => onDismissAutoFocus?.(new Event("focus"))}
+      >
         项目
       </button>
     );
@@ -3285,14 +3291,13 @@ describe("AgentComposer", () => {
     expect(await screen.findByRole("tooltip")).toHaveTextContent("提及上下文");
   });
 
-  it("focuses the shared home draft at the end after switching projects", async () => {
-    const draftContent = createDraft("keep typing here");
-    const { rerender } = render(
+  it("focuses the shared home draft at the end after the project menu dismisses", () => {
+    render(
       <AgentComposer
         workspaceId="workspace-1"
         currentUserId="user-1"
         provider="codex"
-        draftContent={draftContent}
+        draftContent={createDraft("keep typing here")}
         draftScopeKey="home"
         availableCommands={[] satisfies readonly AgentHostAgentSessionCommand[]}
         disabled={false}
@@ -3311,6 +3316,7 @@ describe("AgentComposer", () => {
         isSubmittingPrompt={false}
         labels={createLabels()}
         workspaceUserProjectI18n={workspaceUserProjectI18n}
+        layoutMode="hero"
         onDraftContentChange={vi.fn()}
         onSettingsChange={vi.fn()}
         onSubmit={vi.fn()}
@@ -3323,47 +3329,7 @@ describe("AgentComposer", () => {
     );
 
     mockEditorFocusAtEnd.mockClear();
-    rerender(
-      <AgentComposer
-        workspaceId="workspace-1"
-        currentUserId="user-1"
-        provider="codex"
-        draftContent={draftContent}
-        draftScopeKey="home"
-        availableCommands={[] satisfies readonly AgentHostAgentSessionCommand[]}
-        disabled={false}
-        submitDisabled={false}
-        placeholder="placeholder"
-        composerSettings={createComposerSettings({
-          selectedProjectPath: "/workspace/b"
-        })}
-        queuedPrompts={[]}
-        drainingQueuedPromptId={null}
-        canQueueWhileBusy={false}
-        showStopButton={false}
-        activePrompt={null}
-        isInterrupting={false}
-        isSendingTurn={false}
-        isSubmittingPrompt={false}
-        labels={createLabels()}
-        workspaceUserProjectI18n={workspaceUserProjectI18n}
-        onDraftContentChange={vi.fn()}
-        onSettingsChange={vi.fn()}
-        onSubmit={vi.fn()}
-        onSendQueuedPromptNext={vi.fn()}
-        onRemoveQueuedPrompt={vi.fn()}
-        onEditQueuedPrompt={vi.fn()}
-        onInterruptCurrentTurn={vi.fn()}
-        onSubmitInteractivePrompt={vi.fn()}
-      />
-    );
-
-    await act(async () => {
-      await new Promise<void>((resolve) => {
-        window.setTimeout(resolve, 0);
-      });
-    });
-
+    fireEvent.click(screen.getByTestId("agent-project-dropdown"));
     expect(mockEditorFocusAtEnd).toHaveBeenCalled();
   });
 

--- a/packages/agent/gui/agent-gui/agentGuiNode/AgentComposer.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/AgentComposer.tsx
@@ -1,4 +1,10 @@
-import { useEffect, useRef, useState, type HTMLAttributes } from "react";
+import {
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+  type HTMLAttributes
+} from "react";
 import type {
   AgentComposerDraft,
   AgentComposerDraftFile,
@@ -198,6 +204,7 @@ export function AgentComposer(props: AgentComposerProps): React.JSX.Element {
   const selectedProjectPath =
     composerSettings.selectedProjectPath?.trim() ?? "";
   const previousSelectedProjectPathRef = useRef(selectedProjectPath);
+  const previousProjectPathForFocusRef = useRef(selectedProjectPath);
   const [mentionSearchState, setMentionSearchState] =
     useState<AgentMentionSearchState>({
       status: "idle",
@@ -353,7 +360,9 @@ export function AgentComposer(props: AgentComposerProps): React.JSX.Element {
     if (isExternalDraftReplacement && draftPrompt) {
       window.requestAnimationFrame(() => {
         window.requestAnimationFrame(() => {
-          editorHandleRef.current?.focusAtStart();
+          // Prefer end so continued typing (and shared home drafts after a
+          // project switch) keep the caret after the text, not at the start.
+          editorHandleRef.current?.focusAtEnd();
         });
       });
     }
@@ -505,6 +514,35 @@ export function AgentComposer(props: AgentComposerProps): React.JSX.Element {
     defaultHandoffMenuLabel: labels.handoffConversationMenu
   });
   const { inputDisabled, isHeroLayout } = providerState;
+  const restoreComposerCaretAfterProjectMenu = useCallback(
+    (event?: Event) => {
+      event?.preventDefault();
+      if (inputDisabled) {
+        return;
+      }
+      editorHandleRef.current?.focusAtEnd();
+    },
+    [inputDisabled]
+  );
+  useEffect(() => {
+    if (previousProjectPathForFocusRef.current === selectedProjectPath) {
+      return;
+    }
+    previousProjectPathForFocusRef.current = selectedProjectPath;
+    // Backup for flows that leave the Radix menu without onCloseAutoFocus
+    // (for example the native directory picker). Select/dialog dismiss uses
+    // onDismissAutoFocus first so it can beat trigger focus restoration.
+    if (inputDisabled) {
+      return;
+    }
+    // timing: wait for native directory-picker focus churn before restoring caret
+    const timer = window.setTimeout(() => {
+      editorHandleRef.current?.focusAtEnd();
+    }, 0);
+    return () => {
+      window.clearTimeout(timer);
+    };
+  }, [inputDisabled, selectedProjectPath]);
   const focusAndDrop = useComposerFocusAndDrop({
     composerControlsHardDisabled,
     inputDisabled,
@@ -601,6 +639,7 @@ export function AgentComposer(props: AgentComposerProps): React.JSX.Element {
       mentionControllerRef={mentionControllerRef}
       getReferenceForFile={getReferenceForFile}
       promptFilesSupported={promptFilesSupported}
+      onDismissProjectMenuAutoFocus={restoreComposerCaretAfterProjectMenu}
       paletteDraftPrompt={paletteDraftPrompt}
       showFileMentionPalette={showFileMentionPalette}
       showSlashPalette={showSlashPalette}

--- a/packages/agent/gui/agent-gui/agentGuiNode/AgentComposer.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/AgentComposer.tsx
@@ -1,10 +1,4 @@
-import {
-  useCallback,
-  useEffect,
-  useRef,
-  useState,
-  type HTMLAttributes
-} from "react";
+import { useEffect, useRef, useState, type HTMLAttributes } from "react";
 import type {
   AgentComposerDraft,
   AgentComposerDraftFile,
@@ -204,7 +198,6 @@ export function AgentComposer(props: AgentComposerProps): React.JSX.Element {
   const selectedProjectPath =
     composerSettings.selectedProjectPath?.trim() ?? "";
   const previousSelectedProjectPathRef = useRef(selectedProjectPath);
-  const previousProjectPathForFocusRef = useRef(selectedProjectPath);
   const [mentionSearchState, setMentionSearchState] =
     useState<AgentMentionSearchState>({
       status: "idle",
@@ -514,35 +507,13 @@ export function AgentComposer(props: AgentComposerProps): React.JSX.Element {
     defaultHandoffMenuLabel: labels.handoffConversationMenu
   });
   const { inputDisabled, isHeroLayout } = providerState;
-  const restoreComposerCaretAfterProjectMenu = useCallback(
-    (event?: Event) => {
-      event?.preventDefault();
-      if (inputDisabled) {
-        return;
-      }
-      editorHandleRef.current?.focusAtEnd();
-    },
-    [inputDisabled]
-  );
-  useEffect(() => {
-    if (previousProjectPathForFocusRef.current === selectedProjectPath) {
-      return;
-    }
-    previousProjectPathForFocusRef.current = selectedProjectPath;
-    // Backup for flows that leave the Radix menu without onCloseAutoFocus
-    // (for example the native directory picker). Select/dialog dismiss uses
-    // onDismissAutoFocus first so it can beat trigger focus restoration.
+  const restoreComposerCaretAfterProjectMenu = (event: Event): void => {
+    event.preventDefault();
     if (inputDisabled) {
       return;
     }
-    // timing: wait for native directory-picker focus churn before restoring caret
-    const timer = window.setTimeout(() => {
-      editorHandleRef.current?.focusAtEnd();
-    }, 0);
-    return () => {
-      window.clearTimeout(timer);
-    };
-  }, [inputDisabled, selectedProjectPath]);
+    editorHandleRef.current?.focusAtEnd();
+  };
   const focusAndDrop = useComposerFocusAndDrop({
     composerControlsHardDisabled,
     inputDisabled,

--- a/packages/agent/gui/agent-gui/agentGuiNode/AgentComposerProjectMenu.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/AgentComposerProjectMenu.tsx
@@ -41,6 +41,7 @@ export function AgentProjectDropdown({
   i18n,
   previewMode = false,
   selectProjectDirectory,
+  onDismissAutoFocus,
   onProjectMissingChange,
   onProjectPathChange
 }: {
@@ -52,6 +53,7 @@ export function AgentProjectDropdown({
   labels: AgentProjectDropdownLabels;
   previewMode?: boolean;
   selectProjectDirectory?: () => Promise<{ path: string } | null>;
+  onDismissAutoFocus?: (event: Event) => void;
   onProjectMissingChange?: (isMissing: boolean) => void;
   onProjectPathChange: (
     path: string | null,
@@ -149,6 +151,7 @@ export function AgentProjectDropdown({
       )}
       selectedProjectPath={composerSettings.selectedProjectPath}
       service={agentHostApi.userProjects?.service ?? null}
+      onDismissAutoFocus={onDismissAutoFocus}
       onProjectMissingChange={onProjectMissingChange}
       onProjectPathChange={onProjectPathChange}
     />

--- a/packages/agent/gui/agent-gui/agentGuiNode/composer/AgentComposerView.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/composer/AgentComposerView.tsx
@@ -76,6 +76,7 @@ interface Props {
     | AgentHostApi["workspace"]["getReferenceForFile"]
     | undefined;
   promptFilesSupported: boolean;
+  onDismissProjectMenuAutoFocus?: (event: Event) => void;
   paletteDraftPrompt: string;
   showFileMentionPalette: boolean;
   showSlashPalette: boolean;
@@ -581,6 +582,7 @@ export function AgentComposerView(input: Props): React.JSX.Element {
                   projectMissingDescription: labels.projectMissingDescription
                 }}
                 selectProjectDirectory={selectProjectDirectory}
+                onDismissAutoFocus={input.onDismissProjectMenuAutoFocus}
                 onProjectMissingChange={input.setIsSelectedProjectMissing}
                 onProjectPathChange={onProjectPathChange}
               />

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/agentGuiController.draftMessageHelpers.spec.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/agentGuiController.draftMessageHelpers.spec.ts
@@ -89,7 +89,7 @@ describe("submitted composer draft cleanup", () => {
     expect(areAgentComposerDraftsEqual(current, submittedDraft)).toBe(false);
   });
 
-  it("does not clear a different project or session scope", () => {
+  it("does not clear a different draft scope", () => {
     const otherScopeKey = "session:session-2";
     const drafts = {
       [sourceScopeKey]: submittedDraft,
@@ -108,7 +108,7 @@ describe("submitted composer draft cleanup", () => {
         content: buildAgentComposerDraft({ prompt: "Keep me" })
       },
       "submit-3": {
-        sourceScopeKey: "project:/workspace/recovered",
+        sourceScopeKey: "home",
         targetAgentSessionId: "session-1",
         content: buildAgentComposerDraft({ prompt: "Recovered draft" })
       }

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/agentGuiController.draftMessageHelpers.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/agentGuiController.draftMessageHelpers.ts
@@ -347,13 +347,11 @@ export function deleteUnacceptedSubmittedDraftSnapshot(input: {
 }
 
 export function readAgentComposerDraftContent(input: {
-  projectPath: string | null;
   drafts: Record<string, AgentComposerDraft>;
 }): AgentComposerDraft {
   return (
-    input.drafts[
-      resolveAgentComposerDraftScopeKey({ projectPath: input.projectPath })
-    ] ?? EMPTY_AGENT_COMPOSER_DRAFT
+    input.drafts[resolveAgentComposerDraftScopeKey({})] ??
+    EMPTY_AGENT_COMPOSER_DRAFT
   );
 }
 

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUIContinueConversation.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUIContinueConversation.ts
@@ -35,7 +35,6 @@ interface UseAgentGUIContinueConversationInput {
   isComposerHomeRef: CurrentValue<boolean>;
   loadDraftComposerOptions(): void;
   persistActiveConversation(agentSessionId: string | null): void;
-  selectedProjectPathRef: CurrentValue<string | null>;
   setActiveConversationId: Dispatch<SetStateAction<string | null>>;
   setDetailError: Dispatch<SetStateAction<string | null>>;
   setDraftByScopeKey: Dispatch<
@@ -109,12 +108,11 @@ export function useAgentGUIContinueConversation(
     current.setDetailError(null);
     current.setDraftByScopeKey((drafts) => ({
       ...drafts,
-      [resolveAgentComposerDraftScopeKey({
-        projectPath: current.selectedProjectPathRef.current
-      })]: buildContinueInNewConversationDraft({
-        sourceDraft,
-        prompt: nextDraftPrompt
-      })
+      [resolveAgentComposerDraftScopeKey({})]:
+        buildContinueInNewConversationDraft({
+          sourceDraft,
+          prompt: nextDraftPrompt
+        })
     }));
     current.persistActiveConversation(null);
     current.loadDraftComposerOptions();

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUIConversationDetail.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUIConversationDetail.ts
@@ -136,7 +136,6 @@ export function useAgentGUIConversationDetail(
         })
       ] ?? EMPTY_AGENT_COMPOSER_DRAFT)
     : readAgentComposerDraftContent({
-        projectPath: input.selectedProjectPath,
         drafts: input.draftByScopeKey
       });
   const engineAvailableCommands = useEngineSelector(

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUIConversationHome.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUIConversationHome.ts
@@ -281,7 +281,7 @@ export function useAgentGUIConversationHome({
         return nextData;
       });
     }
-    const sourceScopeKey = resolveAgentComposerDraftScopeKey({ projectPath });
+    const sourceScopeKey = resolveAgentComposerDraftScopeKey({});
     const prefilledDraft = buildAgentComposerDraft({ prompt: draftPrompt });
     draftByScopeKeyRef.current = {
       ...draftByScopeKeyRef.current,

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUINewConversationActivation.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUINewConversationActivation.ts
@@ -180,9 +180,7 @@ export function useAgentGUINewConversationActivation(
         queued: false,
         startedAtUnixMs: Date.now()
       });
-      const sourceScopeKey = resolveAgentComposerDraftScopeKey({
-        projectPath: selectedProjectPath
-      });
+      const sourceScopeKey = resolveAgentComposerDraftScopeKey({});
       const submittedDraft =
         draftByScopeKeyRef.current[sourceScopeKey] ?? emptyAgentComposerDraft();
       submittedDraftSnapshotsRef.current[submitTrace.clientSubmitId] = {

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUISubmitInteractionActions.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUISubmitInteractionActions.ts
@@ -97,7 +97,6 @@ interface UseAgentGUISubmitInteractionActionsInput {
   }>;
   previewMode: boolean;
   promptImagesSupported: boolean;
-  selectedProjectPathRef: RefObject<string | null>;
   sessionEngine: AgentSessionEngine;
   setActiveConversationId: Dispatch<SetStateAction<string | null>>;
   setDetailError: Dispatch<SetStateAction<string | null>>;
@@ -139,7 +138,6 @@ export function useAgentGUISubmitInteractionActions(
     planActionsRef,
     previewMode,
     promptImagesSupported,
-    selectedProjectPathRef,
     sessionEngine,
     setActiveConversationId,
     setDetailError,
@@ -510,9 +508,7 @@ export function useAgentGUISubmitInteractionActions(
               normalizedContent,
               displayPromptText,
               {
-                sourceScopeKey: resolveAgentComposerDraftScopeKey({
-                  projectPath: selectedProjectPathRef.current
-                }),
+                sourceScopeKey: resolveAgentComposerDraftScopeKey({}),
                 trackDraft: true
               }
             );
@@ -693,8 +689,7 @@ export function useAgentGUISubmitInteractionActions(
       const draftKey =
         sourceScopeKey ??
         resolveAgentComposerDraftScopeKey({
-          agentSessionId,
-          projectPath: selectedProjectPathRef.current
+          agentSessionId
         });
       draftByScopeKeyRef.current = {
         ...draftByScopeKeyRef.current,

--- a/packages/agent/gui/agent-gui/agentGuiNode/model/agentComposerDraftScope.spec.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/model/agentComposerDraftScope.spec.ts
@@ -1,53 +1,43 @@
 import { describe, expect, it } from "vitest";
 import {
-  AGENT_COMPOSER_NO_PROJECT_SCOPE,
+  AGENT_COMPOSER_HOME_DRAFT_SCOPE,
   normalizeAgentComposerDraftProjectPath,
   resolveAgentComposerDraftScopeKey
 } from "./agentComposerDraftScope";
 
 describe("agentComposerDraftScope", () => {
-  it("uses one project scope regardless of provider or model selection", () => {
-    const projectPath = "/workspace/project-a";
-
-    expect(resolveAgentComposerDraftScopeKey({ projectPath })).toBe(
-      "project:/workspace/project-a"
-    );
-    expect(resolveAgentComposerDraftScopeKey({ projectPath })).toBe(
-      resolveAgentComposerDraftScopeKey({ projectPath })
-    );
-  });
-
-  it("keeps different project drafts isolated", () => {
+  it("shares one home draft across projects, providers, and empty selection", () => {
     expect(
-      resolveAgentComposerDraftScopeKey({ projectPath: "/workspace/a" })
-    ).not.toBe(
-      resolveAgentComposerDraftScopeKey({ projectPath: "/workspace/b" })
+      resolveAgentComposerDraftScopeKey({ projectPath: "/workspace/project-a" })
+    ).toBe(AGENT_COMPOSER_HOME_DRAFT_SCOPE);
+    expect(
+      resolveAgentComposerDraftScopeKey({ projectPath: "/workspace/project-b" })
+    ).toBe(AGENT_COMPOSER_HOME_DRAFT_SCOPE);
+    expect(resolveAgentComposerDraftScopeKey({ projectPath: null })).toBe(
+      AGENT_COMPOSER_HOME_DRAFT_SCOPE
+    );
+    expect(resolveAgentComposerDraftScopeKey({ projectPath: "  " })).toBe(
+      AGENT_COMPOSER_HOME_DRAFT_SCOPE
+    );
+    expect(resolveAgentComposerDraftScopeKey({})).toBe(
+      AGENT_COMPOSER_HOME_DRAFT_SCOPE
     );
   });
 
-  it("normalizes project separators and trailing slashes", () => {
+  it("normalizes project separators and trailing slashes for selected path", () => {
     expect(normalizeAgentComposerDraftProjectPath(" C:\\repo\\app\\ ")).toBe(
       "C:/repo/app"
     );
-    expect(
-      resolveAgentComposerDraftScopeKey({ projectPath: "/workspace/app///" })
-    ).toBe("project:/workspace/app");
+    expect(normalizeAgentComposerDraftProjectPath("/workspace/app///")).toBe(
+      "/workspace/app"
+    );
     expect(normalizeAgentComposerDraftProjectPath("/")).toBe("/");
     expect(normalizeAgentComposerDraftProjectPath("///")).toBe("/");
     expect(normalizeAgentComposerDraftProjectPath("C:\\")).toBe("C:/");
     expect(normalizeAgentComposerDraftProjectPath("C:\\\\\\")).toBe("C:/");
   });
 
-  it("uses a stable scope when no project is selected", () => {
-    expect(resolveAgentComposerDraftScopeKey({ projectPath: null })).toBe(
-      AGENT_COMPOSER_NO_PROJECT_SCOPE
-    );
-    expect(resolveAgentComposerDraftScopeKey({ projectPath: "  " })).toBe(
-      AGENT_COMPOSER_NO_PROJECT_SCOPE
-    );
-  });
-
-  it("gives an existing session precedence over project identity", () => {
+  it("gives an existing session precedence over the shared home draft", () => {
     expect(
       resolveAgentComposerDraftScopeKey({
         agentSessionId: " session-1 ",

--- a/packages/agent/gui/agent-gui/agentGuiNode/model/agentComposerDraftScope.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/model/agentComposerDraftScope.ts
@@ -1,4 +1,5 @@
-export const AGENT_COMPOSER_NO_PROJECT_SCOPE = "project:<none>";
+/** Shared home-composer draft scope. Project selection does not partition this. */
+export const AGENT_COMPOSER_HOME_DRAFT_SCOPE = "home";
 
 export function normalizeAgentComposerDraftProjectPath(
   value: string | null | undefined
@@ -14,14 +15,15 @@ export function normalizeAgentComposerDraftProjectPath(
 
 export function resolveAgentComposerDraftScopeKey(input: {
   agentSessionId?: string | null;
+  /**
+   * Retained for call-site compatibility. Home drafts ignore project identity;
+   * only an active session partitions composer draft content.
+   */
   projectPath?: string | null;
 }): string {
   const agentSessionId = input.agentSessionId?.trim() ?? "";
   if (agentSessionId) {
     return `session:${agentSessionId}`;
   }
-  const projectPath = normalizeAgentComposerDraftProjectPath(input.projectPath);
-  return projectPath
-    ? `project:${projectPath}`
-    : AGENT_COMPOSER_NO_PROJECT_SCOPE;
+  return AGENT_COMPOSER_HOME_DRAFT_SCOPE;
 }

--- a/packages/agent/gui/agent-gui/agentGuiNode/view/AgentGUIDetailPane.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/view/AgentGUIDetailPane.tsx
@@ -291,9 +291,8 @@ export const AgentGUIDetailPane = memo(function AgentGUIDetailPane({
   );
   const handleSelectHomeSuggestion = useCallback(
     (prompt: string) => {
-      // Don't request focus here: replacing the draft already makes the composer
-      // focus the filled prompt (focusAtStart). A second focus (focusAtEnd) would
-      // race it and make the cursor/scroll jump — a visible flicker on fill.
+      // Don't request focus here: replacing the draft already focuses the
+      // filled prompt at the end. A second focus request would race it.
       updateDraftContent(
         updateAgentComposerDraft(viewModel.composer.draftContent, { prompt })
       );
@@ -427,8 +426,7 @@ export const AgentGUIDetailPane = memo(function AgentGUIDetailPane({
       usage: viewModel.detail.usage,
       draftContent: viewModel.composer.draftContent,
       draftScopeKey: resolveAgentComposerDraftScopeKey({
-        agentSessionId: viewModel.rail.activeConversationId,
-        projectPath: viewModel.composer.composerSettings.selectedProjectPath
+        agentSessionId: viewModel.rail.activeConversationId
       }),
       availableCommands: viewModel.composer.availableCommands,
       hasCompactableContext: viewModel.detail.hasSentUserMessage,

--- a/packages/workspace/user-project/src/ui/internal/project/WorkspaceUserProjectSelect.tsx
+++ b/packages/workspace/user-project/src/ui/internal/project/WorkspaceUserProjectSelect.tsx
@@ -96,6 +96,12 @@ export interface WorkspaceUserProjectSelectProps {
   i18n?: WorkspaceUserProjectI18nRuntime;
   labels?: WorkspaceUserProjectSelectLabelOverrides;
   onProjectMissingChange?: (isMissing: boolean) => void;
+  /**
+   * Called when the select menu or create dialog is about to restore focus.
+   * Call `event.preventDefault()` to keep focus from returning to the trigger,
+   * then move focus to the preferred surface (for example the composer input).
+   */
+  onDismissAutoFocus?: (event: Event) => void;
   onProjectPathChange: (
     path: string | null,
     metadata?: {
@@ -204,6 +210,7 @@ export function WorkspaceUserProjectSelect({
   i18n = defaultWorkspaceUserProjectSelectI18n,
   labels,
   onProjectMissingChange,
+  onDismissAutoFocus,
   onProjectPathChange,
   projectLocked = false,
   renderAddProjectIcon,
@@ -578,94 +585,91 @@ export function WorkspaceUserProjectSelect({
             <WorkspaceUserProjectOverflowLabel label={triggerLabel} />
           </span>
         </SelectTrigger>
-        {isSelectOpen ? (
-          <SelectContent
-            align={contentAlign}
-            className={classNames?.content}
-            collisionPadding={16}
-            side={contentSide}
-            sideOffset={contentSideOffset}
-          >
-            {visibleProjects.map((project) => {
-              const projectLabel =
-                resolveWorkspaceUserProjectDisplayLabel(project);
-              return (
+        <SelectContent
+          align={contentAlign}
+          className={classNames?.content}
+          collisionPadding={16}
+          side={contentSide}
+          sideOffset={contentSideOffset}
+          onCloseAutoFocus={onDismissAutoFocus}
+        >
+          {visibleProjects.map((project) => {
+            const projectLabel =
+              resolveWorkspaceUserProjectDisplayLabel(project);
+            return (
+              <SelectItem
+                className={classNames?.item}
+                key={project.id || project.path}
+                value={project.path}
+              >
+                <span className="flex min-w-0 flex-1 items-center gap-2 pr-1">
+                  <FolderIcon aria-hidden size={15} />
+                  <WorkspaceUserProjectOverflowLabel label={projectLabel} />
+                </span>
+              </SelectItem>
+            );
+          })}
+          {showProjectActionDivider ? (
+            <SelectSeparator
+              className="mx-[12px] my-1 shrink-0 bg-[var(--line-2)]"
+              data-workspace-user-project-action-separator="true"
+            />
+          ) : null}
+          {hasProjectActions ? (
+            <SelectGroup
+              className="gap-0.5 p-0"
+              data-workspace-user-project-action-group="true"
+            >
+              {effectiveApi?.selectDirectory ? (
                 <SelectItem
                   className={classNames?.item}
-                  key={project.id || project.path}
-                  value={project.path}
+                  value={linkExistingProjectOptionValue}
                 >
                   <span className="flex min-w-0 flex-1 items-center gap-2 pr-1">
-                    <FolderIcon aria-hidden size={15} />
-                    <WorkspaceUserProjectOverflowLabel label={projectLabel} />
+                    <LinkIcon aria-hidden size={15} />
+                    <span className="truncate">
+                      {resolvedLabels.linkExistingProject}
+                    </span>
                   </span>
                 </SelectItem>
-              );
-            })}
-            {showProjectActionDivider ? (
-              <SelectSeparator
-                className="mx-[12px] my-1 shrink-0 bg-[var(--line-2)]"
-                data-workspace-user-project-action-separator="true"
-              />
-            ) : null}
-            {hasProjectActions ? (
-              <SelectGroup
-                className="gap-0.5 p-0"
-                data-workspace-user-project-action-group="true"
-              >
-                {effectiveApi?.selectDirectory ? (
-                  <SelectItem
-                    className={classNames?.item}
-                    value={linkExistingProjectOptionValue}
-                  >
-                    <span className="flex min-w-0 flex-1 items-center gap-2 pr-1">
-                      <LinkIcon aria-hidden size={15} />
-                      <span className="truncate">
-                        {resolvedLabels.linkExistingProject}
-                      </span>
-                    </span>
-                  </SelectItem>
-                ) : null}
-                {showCreateProjectAction ? (
-                  <SelectItem
-                    className={classNames?.item}
-                    value={addProjectOptionValue}
-                  >
-                    <span className="flex min-w-0 flex-1 items-center gap-2 pr-1">
-                      {renderAddProjectIcon?.() ?? (
-                        <NewWorkspaceLinedIcon
-                          aria-hidden
-                          data-workspace-user-project-add-icon="true"
-                          size={15}
-                        />
-                      )}
-                      <span className="truncate">
-                        {resolvedLabels.addProject}
-                      </span>
-                    </span>
-                  </SelectItem>
-                ) : null}
-                {showNoProjectAction ? (
-                  <SelectItem
-                    className={classNames?.item}
-                    value={noProjectOptionValue}
-                  >
-                    <span className="flex min-w-0 flex-1 items-center gap-2 pr-1">
-                      <NoWorkspaceLinedIcon
+              ) : null}
+              {showCreateProjectAction ? (
+                <SelectItem
+                  className={classNames?.item}
+                  value={addProjectOptionValue}
+                >
+                  <span className="flex min-w-0 flex-1 items-center gap-2 pr-1">
+                    {renderAddProjectIcon?.() ?? (
+                      <NewWorkspaceLinedIcon
                         aria-hidden
-                        data-agent-project-no-workspace-icon="true"
+                        data-workspace-user-project-add-icon="true"
                         size={15}
                       />
-                      <span className="truncate">
-                        {resolvedLabels.noProject}
-                      </span>
+                    )}
+                    <span className="truncate">
+                      {resolvedLabels.addProject}
                     </span>
-                  </SelectItem>
-                ) : null}
-              </SelectGroup>
-            ) : null}
-          </SelectContent>
-        ) : null}
+                  </span>
+                </SelectItem>
+              ) : null}
+              {showNoProjectAction ? (
+                <SelectItem
+                  className={classNames?.item}
+                  value={noProjectOptionValue}
+                >
+                  <span className="flex min-w-0 flex-1 items-center gap-2 pr-1">
+                    <NoWorkspaceLinedIcon
+                      aria-hidden
+                      data-agent-project-no-workspace-icon="true"
+                      size={15}
+                    />
+                    <span className="truncate">{resolvedLabels.noProject}</span>
+                  </span>
+                </SelectItem>
+              ) : null}
+            </SelectGroup>
+          ) : null}
+        </SelectContent>
       </Select>
       {isProjectDialogOpen ? (
         <Dialog
@@ -675,6 +679,7 @@ export function WorkspaceUserProjectSelect({
           <DialogContent
             className="w-[480px] max-w-[calc(100vw-32px)] sm:max-w-[480px]"
             showCloseButton={false}
+            onCloseAutoFocus={onDismissAutoFocus}
           >
             <form className="grid gap-4" onSubmit={submitProjectDialog}>
               <DialogHeader>

--- a/packages/workspace/user-project/src/ui/internal/project/WorkspaceUserProjectSelect.tsx
+++ b/packages/workspace/user-project/src/ui/internal/project/WorkspaceUserProjectSelect.tsx
@@ -528,12 +528,15 @@ export function WorkspaceUserProjectSelect({
     }
     if (nextValue === linkExistingProjectOptionValue) {
       void Promise.resolve(effectiveApi.selectDirectory?.())
-        .then((selection) => {
+        .then(async (selection) => {
           const path = selection?.path?.trim() ?? "";
           if (!path) {
             return;
           }
-          void useProjectPath(path, "select_existing");
+          await useProjectPath(path, "select_existing");
+          // Native directory pickers skip Radix close-auto-focus; restore the
+          // caller's preferred focus target after the path settles.
+          onDismissAutoFocus?.(new Event("focus"));
         })
         .catch(() => {});
       return;

--- a/services/tuttid/api/daemon_agent_session_list.go
+++ b/services/tuttid/api/daemon_agent_session_list.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"context"
+	"log/slog"
 	"strings"
 
 	tuttigenerated "github.com/tutti-os/tutti/services/tuttid/api/generated"
@@ -35,13 +36,19 @@ func (api DaemonAPI) ListWorkspaceAgentSessions(ctx context.Context, request tut
 		}
 		input.Limit = int(*request.Params.Limit)
 	}
-	sessions, err := api.AgentSessionService.ListFiltered(ctx, string(request.WorkspaceID), input)
+	workspaceID := string(request.WorkspaceID)
+	sessions, err := api.AgentSessionService.ListFiltered(ctx, workspaceID, input)
 	if err != nil {
 		return writeListWorkspaceAgentSessionsError(err), nil
 	}
+	slog.Info("workspace agent sessions list completed",
+		"event", "workspace.agent_session.api.list_completed",
+		"workspace_id", workspaceID,
+		"session_count", len(sessions),
+	)
 	return tuttigenerated.ListWorkspaceAgentSessions200JSONResponse{
 		Sessions:    generatedAgentSessions(sessions),
-		WorkspaceId: string(request.WorkspaceID),
+		WorkspaceId: workspaceID,
 	}, nil
 }
 


### PR DESCRIPTION
## Summary
- Home composer drafts now use one shared `home` scope across all project selections (including no project), so switching or creating a project keeps the prompt text.
- Existing conversation drafts remain isolated per `session:<id>`.
- After the project select/create dialog steals focus, restore the caret at the end of the shared home draft via `onDismissAutoFocus` (including after the native directory picker).

## Test plan
- [ ] On home composer, type a prompt, switch projects — text remains and caret is at the end.
- [ ] Create a new project from the composer menu — prompt is preserved; caret ends at the end of the text.
- [ ] Open an existing conversation, type a draft, switch away and back — session draft stays independent of home.
- [ ] Continue typing after project switch without clicking into the input again.
- [ ] Run focused agent-gui tests covering draft scope and project-menu focus restore.


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Share the home composer draft across projects so switching or creating a project keeps the prompt, while session drafts remain isolated. Restore the caret to the end after the project menu dismisses to keep typing smoothly.

- **Bug Fixes**
  - Home composer uses a shared `home` draft scope across all project selections; switching or creating projects no longer clears the prompt.
  - Existing conversations still use `session:<id>` drafts, keeping them separate from home.
  - Restores editor focus at the end after project select or native directory picker via `onDismissAutoFocus` (no timers).
  - `tuttid` now logs successful session list responses with `workspace.agent_session.api.list_completed` and `session_count` to diagnose empty `@` Sessions tab.

<sup>Written for commit a36e5091bc127e68341b99482303c822c207bf7c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tutti-os/tutti/pull/1126?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

