### PR TITLE
fix(agent-gui): resolve turn summaries from session cwd

### DIFF
--- a/docs/architecture/agent-gui-node.md
+++ b/docs/architecture/agent-gui-node.md
@@ -722,7 +722,10 @@ provider-specific rendering branches.
 Conversation file links use the selected project root when one exists. For a
 no-project session, the durable session cwd is the file-resolution root. This
 keeps link navigation attached to session identity instead of requiring project
-selection state.
+selection state. Every transcript file surface, including markdown links and
+turn-summary projection/actions, must pass the selected project root as
+`workspaceRoot` and the durable session cwd as `basePath`; do not substitute a
+synthetic `/` root or drop the cwd when no project root is selected.
 
 ## Desktop Host Boundary
 

--- a/packages/agent/gui/shared/agentConversation/components/AgentTranscriptItemView.tsx
+++ b/packages/agent/gui/shared/agentConversation/components/AgentTranscriptItemView.tsx
@@ -102,6 +102,7 @@ export const AgentTranscriptItemView = memo(function AgentTranscriptItemView({
         <AgentTurnSummaryRow
           row={row}
           workspaceRoot={workspaceRoot}
+          basePath={basePath}
           label={labels.turnSummary}
           onLinkAction={onLinkAction}
           previewMode={previewMode}

--- a/packages/agent/gui/shared/agentConversation/components/AgentTurnSummaryRow.spec.tsx
+++ b/packages/agent/gui/shared/agentConversation/components/AgentTurnSummaryRow.spec.tsx
@@ -1117,6 +1117,54 @@ describe("AgentTurnSummaryRow", () => {
     );
   });
 
+  it("opens relative file changes from the session cwd without a workspace root", () => {
+    const onLinkAction = vi.fn();
+    render(
+      <AgentTurnSummaryRow
+        row={{
+          kind: "turn-summary",
+          id: "turn-summary:no-project",
+          turnId: "turn-no-project",
+          fileCount: 1,
+          modifiedCount: 0,
+          createdCount: 1,
+          occurredAtUnixMs: 26,
+          files: [
+            {
+              label: "readme.md",
+              path: "readme.md",
+              fileName: "readme.md",
+              directory: null,
+              changeType: "created",
+              toolName: "Write",
+              messageId: "call:no-project",
+              content: "# LiYing",
+              occurredAtUnixMs: 26
+            }
+          ]
+        }}
+        workspaceRoot={null}
+        basePath="/Users/demo/Documents/tutti/session-1"
+        label="Changed files"
+        onLinkAction={onLinkAction}
+      />
+    );
+
+    fireEvent.click(
+      screen.getByRole("button", {
+        name: /agentHost\.workspaceAgentSessionDetailOpenFile:readme\.md/i
+      })
+    );
+
+    expect(onLinkAction).toHaveBeenCalledWith({
+      type: "open-workspace-file",
+      path: "/Users/demo/Documents/tutti/session-1/readme.md",
+      directoryPath: "/Users/demo/Documents/tutti/session-1",
+      workspaceRoot: "/Users/demo/Documents/tutti/session-1",
+      source: "agent-file-change"
+    });
+  });
+
   it("renders created edit-file content without falling back to monaco loading", async () => {
     render(
       <AgentTurnSummaryRow

--- a/packages/agent/gui/shared/agentConversation/components/AgentTurnSummaryRow.tsx
+++ b/packages/agent/gui/shared/agentConversation/components/AgentTurnSummaryRow.tsx
@@ -40,6 +40,7 @@ import { AgentUnifiedPatchViewer } from "./tool-renderers/file-diff/AgentUnified
 interface AgentTurnSummaryRowProps {
   row: AgentTurnSummaryRowVM;
   workspaceRoot?: string | null;
+  basePath?: string | null;
   label: string;
   onLinkAction?: (action: WorkspaceLinkAction) => void;
   previewMode?: boolean;
@@ -53,6 +54,7 @@ type PatchSupportState =
 export function AgentTurnSummaryRow({
   row,
   workspaceRoot,
+  basePath,
   onLinkAction
 }: AgentTurnSummaryRowProps): JSX.Element {
   "use memo";
@@ -307,6 +309,7 @@ export function AgentTurnSummaryRow({
                 key={key}
                 file={file}
                 workspaceRoot={workspaceRoot}
+                basePath={basePath}
                 expanded={Boolean(expandedFiles[key])}
                 onLinkAction={onLinkAction}
                 onToggle={() =>
@@ -329,6 +332,7 @@ export function AgentTurnSummaryRow({
                       key={key}
                       file={file}
                       workspaceRoot={workspaceRoot}
+                      basePath={basePath}
                       expanded={Boolean(expandedFiles[key])}
                       onLinkAction={onLinkAction}
                       onToggle={() =>
@@ -383,12 +387,14 @@ export function AgentTurnSummaryRow({
 function TurnSummaryFileCard({
   file,
   workspaceRoot,
+  basePath,
   expanded,
   onLinkAction,
   onToggle
 }: {
   file: AgentTurnSummaryFileVM;
   workspaceRoot?: string | null;
+  basePath?: string | null;
   expanded: boolean;
   onLinkAction?: (action: WorkspaceLinkAction) => void;
   onToggle: () => void;
@@ -397,6 +403,7 @@ function TurnSummaryFileCard({
   const action = resolveWorkspaceFileLinkAction({
     path: file.path,
     workspaceRoot: workspaceRoot,
+    basePath,
     source: "agent-file-change"
   });
   const canOpen = Boolean(action && onLinkAction);

--- a/packages/agent/gui/shared/agentConversation/projection/agentConversationProjection.spec.ts
+++ b/packages/agent/gui/shared/agentConversation/projection/agentConversationProjection.spec.ts
@@ -622,6 +622,25 @@ describe("projectAgentConversationVM", () => {
     expect(conversation.rows.map((row) => row.kind)).toContain("turn-summary");
   });
 
+  it("uses the session cwd for turn summaries when no workspace root is selected", () => {
+    const conversation = projectAgentConversationVM(
+      detailViewModel({
+        workspaceRoot: null,
+        showProcessingIndicator: false
+      })
+    );
+
+    const summary = conversation.rows.find(
+      (row) => row.kind === "turn-summary"
+    );
+    expect(summary).toMatchObject({
+      kind: "turn-summary",
+      files: expect.arrayContaining([
+        expect.objectContaining({ path: "/workspace/demo/src/App.tsx" })
+      ])
+    });
+  });
+
   it("derives pending approval and ask-user prompts from typed tool rows", () => {
     const detail = detailViewModel({
       turns: [

--- a/packages/agent/gui/shared/agentConversation/projection/agentConversationProjection.ts
+++ b/packages/agent/gui/shared/agentConversation/projection/agentConversationProjection.ts
@@ -48,6 +48,7 @@ export function projectAgentConversationVM(
     if (shouldShowTurnSummaryForTurn(detail, index)) {
       rows.push(
         ...projectAgentTurnSummaryRowForTurn(turn, {
+          defaultCwd: detail.cwd,
           workspaceRoot: detail.workspaceRoot
         })
       );

--- a/packages/agent/gui/shared/agentConversation/projection/agentTurnSummaryFileProjection.ts
+++ b/packages/agent/gui/shared/agentConversation/projection/agentTurnSummaryFileProjection.ts
@@ -173,7 +173,8 @@ export function normalizedFilePath(
   }
   return resolveWorkspaceFilePathCandidate({
     path,
-    workspaceRoot: options.workspaceRoot
+    workspaceRoot: options.workspaceRoot,
+    basePath: options.defaultCwd
   })
     ? path
     : null;

--- a/packages/agent/gui/shared/agentConversation/projection/agentTurnSummaryProjection.ts
+++ b/packages/agent/gui/shared/agentConversation/projection/agentTurnSummaryProjection.ts
@@ -114,7 +114,8 @@ function normalizedActivityFilePath(
     !isIgnoredFilePath(path) &&
     resolveWorkspaceFilePathCandidate({
       path,
-      workspaceRoot: options.workspaceRoot
+      workspaceRoot: options.workspaceRoot,
+      basePath: options.defaultCwd
     })
     ? path
     : null;


### PR DESCRIPTION
## Summary

- resolve turn-summary file paths against the durable session `cwd` when no project root is selected
- preserve `workspaceRoot` as the project boundary while forwarding `cwd` as the existing `basePath`
- use the same path context for summary-card file actions
- add regression coverage and document the AgentGUI path-resolution contract

## Verification

- `pnpm --filter @tutti-os/agent-gui exec vitest run shared/agentConversation/projection/agentConversationProjection.spec.ts shared/agentConversation/projection/agentTurnSummaryProjection.spec.ts shared/agentConversation/components/AgentTurnSummaryRow.spec.tsx shared/agentConversation/components/AgentTranscriptItemView.spec.tsx`
- `pnpm check:changed --tail-lines 80`
- `pnpm check:full`
- `make dev-web`: verified the existing Claude Code README session renders the changed-files summary and file-open action

## Checklist

- [x] I kept the change focused on one concern.
- [x] I updated documentation when behavior, setup, or contributor workflow changed.
- [x] I updated all README/CONTRIBUTING language variants when changing their English source.
- [x] I ran the lowest meaningful local checks for the changed surface.
- [x] My commits are signed off with DCO when required: `git commit -s`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes turn-summary file paths for no-project sessions by resolving them against the session cwd. Summary-card file actions now use the same path context, so links open the correct files.

- **Bug Fixes**
  - Use session `cwd` as `basePath` when no `workspaceRoot` is selected; keep `workspaceRoot` as the project boundary (no synthetic `/`).
  - Thread `basePath` from `AgentTranscriptItemView` → `AgentTurnSummaryRow` → file cards for consistent link resolution.
  - Add regression tests across projections/components and document the path-resolution contract in the architecture guide.

<sup>Written for commit 1b5c9f75ba2d43786199827f916f8d4534d08357. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tutti-os/tutti/pull/1127?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

