### PR TITLE
fix(agent): limit mention search to visible titles

### DIFF
--- a/apps/desktop/src/renderer/src/features/rich-text-at/services/internal/desktopRichTextAtService.test.ts
+++ b/apps/desktop/src/renderer/src/features/rich-text-at/services/internal/desktopRichTextAtService.test.ts
@@ -922,7 +922,7 @@ test("desktop rich text @ service uses task icon fallback for issue manager app 
   assert.ok(provider);
   const items = await provider.query({
     context: {},
-    keyword: "tasks",
+    keyword: "task",
     maxResults: 5,
     trigger: "@"
   });
@@ -1178,7 +1178,7 @@ test("desktop rich text @ service uses mention candidate description for workspa
   assert.ok(provider);
   const items = await provider.query({
     context: {},
-    keyword: "recurring",
+    keyword: "automation",
     maxResults: 5,
     trigger: "@"
   });
@@ -1198,7 +1198,7 @@ test("desktop rich text @ service uses mention candidate description for workspa
   );
 });
 
-test("desktop rich text @ service searches workspace app command metadata from mention candidates", async () => {
+test("desktop rich text @ service only matches workspace app display names", async () => {
   const service = new DesktopRichTextAtService({
     tuttidClient: {
       async listWorkspaceAppMentionCandidates(workspaceId: string) {
@@ -1206,14 +1206,14 @@ test("desktop rich text @ service searches workspace app command metadata from m
           workspaceId,
           apps: [
             createWorkspaceAppMentionCandidate({
-              appId: "automation",
+              appId: "scheduler-core",
               commandCount: 1,
               commandDescriptions: ["List automation definitions."],
               commandPaths: ["automation list"],
               commandSummaries: ["List automations"],
-              description: "Manage automations.",
+              description: "Review recurring schedules.",
               displayName: "Automation",
-              scopes: ["automation"]
+              scopes: ["schedule"]
             })
           ]
         };
@@ -1228,20 +1228,24 @@ test("desktop rich text @ service searches workspace app command metadata from m
     workspaceId: "workspace-1"
   });
   assert.ok(provider);
+  for (const keyword of ["scheduler", "recurring", "automations", "schedule"]) {
+    const items = await provider.query({
+      context: {},
+      keyword,
+      maxResults: 5,
+      trigger: "@"
+    });
+    assert.deepEqual(items, []);
+  }
+
   const items = await provider.query({
     context: {},
-    keyword: "automations",
+    keyword: "automation",
     maxResults: 5,
     trigger: "@"
   });
-
-  const item = items[0] as
-    | { description: string; displayName: string }
-    | undefined;
-  assert.ok(item);
-  assert.equal(item.displayName, "Automation");
-  assert.equal(item.description, "Manage automations.");
-  assert.equal(provider.getItemSubtitle?.(item), "Manage automations.");
+  assert.equal(items.length, 1);
+  assert.equal((items[0] as { displayName: string }).displayName, "Automation");
 });
 
 test("desktop rich text @ service emits enriched app + session meta when enrichment deps supplied", async () => {

--- a/apps/desktop/src/renderer/src/features/rich-text-at/services/internal/desktopRichTextAtService.ts
+++ b/apps/desktop/src/renderer/src/features/rich-text-at/services/internal/desktopRichTextAtService.ts
@@ -413,18 +413,7 @@ function workspaceAppMatchesKeyword(
   if (!keyword) {
     return true;
   }
-  const haystack = [
-    item.appId,
-    item.displayName,
-    item.description,
-    ...item.scopes,
-    ...item.commandPaths,
-    ...item.commandSummaries,
-    ...item.commandDescriptions
-  ]
-    .join("\n")
-    .toLowerCase();
-  return haystack.includes(keyword);
+  return item.displayName.toLowerCase().includes(keyword);
 }
 
 function findWorkspaceAppMentionLocalization(

--- a/docs/architecture/agent-gui-node.md
+++ b/docs/architecture/agent-gui-node.md
@@ -1723,6 +1723,9 @@ User-visible rules:
   backend, target-scoped, cursor-paged query across all visible sessions; its
   results are engine entities joined through ID-only query state. These queries
   may hide a session from the rail, but must not delete or unactivate it.
+- Conversation search matches only the user-visible session title. Session ids,
+  providers, and working directories are routing or runtime metadata and must
+  not produce title-search results.
 - Conversation target filters are also list-query concerns. The All rail filter
   applies no `agentTargetId` constraint; provider target rail filters such as
   Codex and Claude Code match sessions by `session.agentTargetId`, not by
@@ -2639,6 +2642,10 @@ the Apps tab queries only `workspace-app`; first-party launch targets appear in
 a separate Agents tab that queries only `agent-target`. Do not use the Apps tab
 as an agent fallback, because that recreates the old pseudo workspace-app
 contract.
+Workspace-app search in the Apps tab matches only the localized display name.
+App ids, descriptions, scopes, and CLI command metadata may enrich presentation
+or routing, but they must not produce search results that the visible app name
+cannot explain.
 
 Quick check:
 

--- a/packages/clients/tuttid-ts/src/generated/types.gen.ts
+++ b/packages/clients/tuttid-ts/src/generated/types.gen.ts
@@ -5520,6 +5520,9 @@ export type ListWorkspaceAgentSessionsData = {
   };
   query?: {
     agentTargetId?: string;
+    /**
+     * Case-insensitive, whitespace-tokenized search over the session title only.
+     */
     searchQuery?: string;
     cursor?: string;
     limit?: number;

--- a/services/tuttid/api/generated/types.gen.go
+++ b/services/tuttid/api/generated/types.gen.go
@@ -4808,9 +4808,11 @@ type ListWorkspaceAgentPinnedSessionPageParams struct {
 // ListWorkspaceAgentSessionsParams defines parameters for ListWorkspaceAgentSessions.
 type ListWorkspaceAgentSessionsParams struct {
 	AgentTargetId *string `form:"agentTargetId,omitempty" json:"agentTargetId,omitempty"`
-	SearchQuery   *string `form:"searchQuery,omitempty" json:"searchQuery,omitempty"`
-	Cursor        *string `form:"cursor,omitempty" json:"cursor,omitempty"`
-	Limit         *int    `form:"limit,omitempty" json:"limit,omitempty"`
+
+	// SearchQuery Case-insensitive, whitespace-tokenized search over the session title only.
+	SearchQuery *string `form:"searchQuery,omitempty" json:"searchQuery,omitempty"`
+	Cursor      *string `form:"cursor,omitempty" json:"cursor,omitempty"`
+	Limit       *int    `form:"limit,omitempty" json:"limit,omitempty"`
 }
 
 // ListWorkspaceAgentSessionMessagesParams defines parameters for ListWorkspaceAgentSessionMessages.

--- a/services/tuttid/api/openapi/tuttid.v1.yaml
+++ b/services/tuttid/api/openapi/tuttid.v1.yaml
@@ -1867,6 +1867,7 @@ paths:
         - name: searchQuery
           in: query
           required: false
+          description: Case-insensitive, whitespace-tokenized search over the session title only.
           schema:
             type: string
         - name: cursor

--- a/services/tuttid/service/agent/session_filter.go
+++ b/services/tuttid/service/agent/session_filter.go
@@ -37,12 +37,7 @@ func matchesSessionSearch(session Session, rawQuery string) bool {
 	if query == "" {
 		return true
 	}
-	haystack := strings.ToLower(strings.Join([]string{
-		session.ID,
-		session.Provider,
-		value(session.Title),
-		session.Cwd,
-	}, "\n"))
+	haystack := strings.ToLower(value(session.Title))
 	for _, token := range strings.Fields(query) {
 		if !strings.Contains(haystack, token) {
 			return false

--- a/services/tuttid/service/agent/session_filter_test.go
+++ b/services/tuttid/service/agent/session_filter_test.go
@@ -1,0 +1,35 @@
+package agent
+
+import "testing"
+
+func TestMatchesSessionSearchUsesTitleOnly(t *testing.T) {
+	title := "Fix Release Search"
+	session := Session{
+		ID:       "session-needle",
+		Provider: "provider-needle",
+		Cwd:      "/workspace/cwd-needle",
+		Title:    &title,
+	}
+
+	tests := []struct {
+		name  string
+		query string
+		want  bool
+	}{
+		{name: "empty query", query: "", want: true},
+		{name: "title substring", query: "release", want: true},
+		{name: "title tokens ignore case and whitespace", query: "  SEARCH fix  ", want: true},
+		{name: "all title tokens are required", query: "release missing", want: false},
+		{name: "session id is excluded", query: "session-needle", want: false},
+		{name: "provider is excluded", query: "provider-needle", want: false},
+		{name: "working directory is excluded", query: "cwd-needle", want: false},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if got := matchesSessionSearch(session, test.query); got != test.want {
+				t.Fatalf("matchesSessionSearch() = %v, want %v", got, test.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- match workspace apps only by their localized display name
- match agent sessions only by their user-visible title, excluding session ids, providers, and working directories
- document the search contracts and regenerate OpenAPI clients
- add regression coverage for hidden metadata not producing matches

## Verification

- `pnpm check:full`
- `node --import ./apps/desktop/test/register-asset-stub.mjs --test --experimental-strip-types apps/desktop/src/renderer/src/features/rich-text-at/services/internal/desktopRichTextAtService.test.ts`
- `go test ./service/agent`

## Checklist

- [x] I kept the change focused on one concern.
- [x] I updated documentation when behavior, setup, or contributor workflow changed.
- [x] I updated all README/CONTRIBUTING language variants when changing their English source.
- [x] I ran the lowest meaningful local checks for the changed surface.
- [x] My commits are signed off with DCO when required: `git commit -s`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Limits @-mention search to user-visible titles only for apps and conversations. Stops hidden metadata (ids, providers, CWD, descriptions, scopes, command metadata) from matching.

- **Bug Fixes**
  - Workspace apps: match only `displayName`; no matching on app id, description, scopes, or command metadata.
  - Agent sessions: match only the session title; case-insensitive, whitespace-tokenized; excludes session id, provider, and working directory.
  - Docs and API: documented the contract; updated OpenAPI and regenerated clients (`services/tuttid/api`, `packages/clients/tuttid-ts`); added backend and desktop regression tests.

<sup>Written for commit 0b36b9a177160c0087b4e6b7c5dba524c53250bf. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tutti-os/tutti/pull/1128?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

