### PR TITLE
fix(agent-gui): address conversation rail review findings

### DIFF
--- a/docs/architecture/agent-gui-node.md
+++ b/docs/architecture/agent-gui-node.md
@@ -1131,7 +1131,9 @@ cover every visible session in the workspace rather than only the loaded rail
 sections. Each returned session is upserted into the same workspace engine;
 the search controller stores only result ids, cursor, and request state, then
 the rail joins those ids to canonical entities. It must not recreate the old
-conversation-summary cache. Search grouping renders only sections containing
+conversation-summary cache. An initial backend-search failure renders a
+localized retry action; retry reissues the current target-scoped query instead
+of presenting the failure as an empty result. Search grouping renders only sections containing
 matching rows; empty user-project and Chats sections remain hidden. Hosts without `listSessionsPage`, including
 preview-only hosts, may fall back to local title filtering of loaded rows.
 Ordinary section pages and backend search pages share one deterministic order:
@@ -1145,6 +1147,9 @@ Every section page and pinned page also carries `totalCount` for the full
 target-filtered scope before cursor pagination. Ordinary section pages exclude
 pinned sessions because those rows belong only to the dedicated pinned page;
 filtering pinned rows after section pagination corrupts page size and totals.
+If a refresh of an already-resolved section scope fails, keep its membership,
+cursor, and totals; only an unresolved or newly selected scope may resolve to an
+empty failure state.
 The active conversation is a
 display overlay, not a pageable row: it may render beside the first five rows,
 but it must not consume the local visible-item limit or advance the cursor.

--- a/docs/conventions/troubleshooting/agent-session-lifecycle.md
+++ b/docs/conventions/troubleshooting/agent-session-lifecycle.md
@@ -404,7 +404,11 @@ Turn state, loading, cancel, restore, rail projection, event updates, imports, a
 - Validation:
   Run `pnpm --filter @tutti-os/agent-gui test`,
   `pnpm --filter @tutti-os/agent-activity-core test`, and
-  `pnpm check:agent-activity-runtime-boundaries`. Cover Codex -> All -> Codex,
+  `pnpm check:agent-activity-runtime-boundaries`. Also run
+  `cd packages/agent/store-sqlite && go test ./... -run 'SessionSection|TurnsBackfill'`
+  and
+  `cd services/tuttid && go test ./service/agent ./api -run 'ListPage|SessionList|SessionSection'`
+  so cursor metadata and daemon ordering are covered. Cover Codex -> All -> Codex,
   client restart restore, active row outside first page, five-plus-active totals,
   nine-session Show more, slow provider refetch, and bounded snapshot omission.
 - References:

--- a/packages/agent/gui/agent-gui/agentGuiNode/AgentGUINode.labels.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/AgentGUINode.labels.ts
@@ -6,6 +6,7 @@ import type { AgentMessageMarkdownWorkspaceAppIcon } from "../../shared/AgentMes
 import type { AgentHomeSuggestionCategory } from "./model/agentGuiNodeTypes";
 import { resolveAgentGUIProviderDisplayLabel } from "./model/agentGuiProviderIdentity";
 import type { AgentGUIViewLabels } from "./AgentGUINodeView";
+import { agentGUIConversationRailLabels } from "./view/agentGUIConversationRailLabels";
 import { agentGUIProviderManagerLabels } from "./view/agentGUIProviderManagerLabels";
 
 const TASK_CENTER_WORKSPACE_APP_ID = "issue-manager";
@@ -410,10 +411,7 @@ export function useAgentGUIViewLabels(input: {
       agentSettingsMenu: t("agentHost.agentGui.agentSettingsMenu"),
       agentEnvSetup: t("agentHost.agentGui.agentEnvSetup"),
       ...agentGUIProviderManagerLabels(t),
-      noConversations: t("agentHost.agentGui.noConversations"),
-      emptyProjectConversations: t(
-        "agentHost.agentGui.emptyProjectConversations"
-      ),
+      ...agentGUIConversationRailLabels(t),
       conversationFilterAll: t("agentHost.agentGui.conversationFilterAll"),
       conversationFilterCodex: t("agentHost.agentGui.conversationFilterCodex"),
       conversationFilterClaudeCode: t(
@@ -421,17 +419,9 @@ export function useAgentGUIViewLabels(input: {
       ),
       conversationFilterTutti: t("agentHost.agentGui.conversationFilterTutti"),
       providerSwitchLabel: t("agentHost.agentGui.providerSwitchLabel"),
-      startConversation: t("agentHost.agentGui.startConversation"),
-      selectConversation: t("agentHost.agentGui.selectConversation"),
-      loadingConversations: t("agentHost.agentGui.loadingConversations"),
       loadingConversation: t("agentHost.agentGui.loadingConversation"),
       scrollToBottom: t("agentHost.agentGui.scrollToBottom"),
-      searchNoConversations: t("agentHost.agentGui.searchNoConversations"),
-      conversationUnavailable: t("agentHost.agentGui.conversationUnavailable"),
       fallbackAgentTitle,
-      searchPlaceholder: t("agentHost.agentGui.searchPlaceholder"),
-      sectionPinned: t("agentHost.agentGui.sectionPinned"),
-      sectionConversations: t("agentHost.agentGui.sectionConversations"),
       sectionToday: t("agentHost.agentGui.sectionToday"),
       sectionYesterday: t("agentHost.agentGui.sectionYesterday"),
       sectionEarlier: t("agentHost.agentGui.sectionEarlier"),

--- a/packages/agent/gui/agent-gui/agentGuiNode/AgentGUINodeView.layout.spec.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/AgentGUINodeView.layout.spec.tsx
@@ -3189,6 +3189,35 @@ describe("AgentGUINodeView layout persistence", () => {
     ).toHaveAttribute("data-disabled");
   });
 
+  it("shows a retry action when backend conversation search fails", async () => {
+    let requestCount = 0;
+    const activityRuntime: AgentActivityRuntime = {
+      ...createNoopAgentActivityRuntime(),
+      async listSessionsPage(input) {
+        requestCount += 1;
+        if (requestCount === 1) throw new Error("search unavailable");
+        return {
+          hasMore: false,
+          sessions: [],
+          workspaceId: input.workspaceId
+        };
+      }
+    };
+    renderAgentGUINodeView({ activityRuntime });
+
+    fireEvent.change(
+      screen.getByRole("searchbox", { name: "searchPlaceholder" }),
+      { target: { value: "backend" } }
+    );
+
+    expect(await screen.findByText("searchFailed")).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: "retrySearch" }));
+    await waitFor(() => expect(requestCount).toBe(2));
+    expect(
+      await screen.findByText("searchNoConversations")
+    ).toBeInTheDocument();
+  });
+
   it("uses the immutable backend candidate snapshot for one Chats batch delete", async () => {
     const requestCandidates = vi.fn(async () => [
       "loaded-session",
@@ -4767,7 +4796,7 @@ describe("AgentGUINodeView layout persistence", () => {
       showLessConversations: "Show less"
     };
     const baseViewModel = createViewModel({
-      agentTargets: [codexTarget, claudeTarget],
+      agentTargets: [claudeTarget],
       conversationFilter: {
         kind: "agentTarget",
         agentTargetId: claudeAgentTargetId
@@ -4818,6 +4847,57 @@ describe("AgentGUINodeView layout persistence", () => {
     ).not.toBeInTheDocument();
     expect(
       screen.queryByTestId("agent-gui-conversation-item-filter-session-6")
+    ).not.toBeInTheDocument();
+
+    rendered.rerender(
+      buildAgentGUINodeViewElement({ labels, viewModel: baseViewModel })
+    );
+    expect(
+      screen.queryByRole("button", { name: "Show less" })
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByTestId("agent-gui-conversation-item-filter-session-6")
+    ).not.toBeInTheDocument();
+  });
+
+  it("resets local section expansion when the all-filter fallback target changes", () => {
+    const codexTarget = createLocalAgentGUIAgentTarget("codex");
+    const claudeTarget = createLocalAgentGUIAgentTarget("claude-code");
+    const labels = {
+      ...createLabels(),
+      showMoreConversations: "Show more",
+      showLessConversations: "Show less"
+    };
+    const baseViewModel = createViewModel({
+      agentTargets: [codexTarget, claudeTarget],
+      conversationFilter: { kind: "all" },
+      conversations: Array.from({ length: 10 }, (_, index) =>
+        createConversationSummary(`fallback-session-${index + 1}`)
+      ),
+      selectedAgentTarget: claudeTarget
+    });
+    const rendered = renderAgentGUINodeView({
+      labels,
+      viewModel: baseViewModel
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: "Show more" }));
+    expect(
+      screen.getByTestId("agent-gui-conversation-item-fallback-session-10")
+    ).toBeInTheDocument();
+
+    rendered.rerender(
+      buildAgentGUINodeViewElement({
+        labels,
+        viewModel: {
+          ...baseViewModel,
+          agentTargets: [codexTarget],
+          selectedAgentTarget: codexTarget
+        }
+      })
+    );
+    expect(
+      screen.queryByTestId("agent-gui-conversation-item-fallback-session-6")
     ).not.toBeInTheDocument();
   });
 
@@ -7246,6 +7326,8 @@ function createLabels(): AgentGUIViewLabels {
     loadingConversation: "loadingConversation",
     scrollToBottom: "scrollToBottom",
     searchNoConversations: "searchNoConversations",
+    searchFailed: "searchFailed",
+    retrySearch: "retrySearch",
     conversationUnavailable: "conversationUnavailable",
     fallbackAgentTitle: "Agent",
     searchPlaceholder: "searchPlaceholder",

--- a/packages/agent/gui/agent-gui/agentGuiNode/agentGuiNodeViewConversation.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/agentGuiNodeViewConversation.tsx
@@ -1,4 +1,5 @@
 import { Spinner } from "@tutti-os/ui-system";
+import { normalizeAgentGUIProjectPath } from "./model/agentGuiConversationProjectResolver";
 import { AskLinedIcon } from "@tutti-os/ui-system/icons";
 import { resolveAgentGUIConversationSortTimeUnixMs } from "./model/agentGuiConversationModel";
 import type { AgentGUINodeViewModel } from "./model/agentGuiNodeTypes";
@@ -267,10 +268,6 @@ function resolveConversationProjectUpdatedAtUnixMs(
   );
 }
 
-export function normalizeConversationProjectPath(path: string): string {
-  return path.trim().replaceAll("\\", "/").replace(/\/+$/, "") || "/";
-}
-
 function normalizeConversationProjectPathCached(
   path: string,
   normalizedPathByPath: Map<string, string>
@@ -279,7 +276,7 @@ function normalizeConversationProjectPathCached(
   if (cached !== undefined) {
     return cached;
   }
-  const normalized = normalizeConversationProjectPath(path);
+  const normalized = normalizeAgentGUIProjectPath(path);
   normalizedPathByPath.set(path, normalized);
   return normalized;
 }

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/AgentGUIConversationRailController.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/AgentGUIConversationRailController.tsx
@@ -24,7 +24,6 @@ export const AgentGUIConversationRailController = memo(
         {...props}
         conversationQuery={conversationQuery}
         railQuery={railQuery}
-        railSearch={railQuery.railSearch}
         onConversationQueryChange={setConversationQuery}
       />
     );

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/AgentGUIConversationRailQueryController.spec.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/AgentGUIConversationRailQueryController.spec.ts
@@ -62,4 +62,74 @@ describe("AgentGUIConversationRailQueryController", () => {
     detachSecond();
     engine.dispose();
   });
+
+  it("retains resolved section pages when a same-scope refresh fails", async () => {
+    const engine = createTestAgentSessionEngine();
+    let requestCount = 0;
+    const listSessionSections = vi.fn<
+      NonNullable<ConversationRailQueryRuntime["listSessionSections"]>
+    >(async (input) => {
+      requestCount += 1;
+      if (requestCount > 1) throw new Error("transient failure");
+      return {
+        workspaceId: input.workspaceId,
+        sections: [
+          {
+            kind: "conversations",
+            sectionKey: "conversations",
+            sessions: [],
+            hasMore: true,
+            nextCursor: "cursor-1",
+            totalCount: 8
+          }
+        ]
+      };
+    });
+    const controller = new AgentGUIConversationRailQueryController({
+      engine,
+      getActiveConversationId: () => null,
+      runtime: {
+        listSessionSections,
+        listSessionSectionPage: async (input) => ({
+          kind: "conversations",
+          sectionKey: input.sectionKey,
+          sessions: [],
+          hasMore: false,
+          totalCount: 0
+        })
+      },
+      workspaceId: "test-workspace"
+    });
+    controller.configure({
+      conversationFilter: { kind: "all" },
+      previewMode: false,
+      sectionAgentTargetFallbackId: null,
+      userProjects: []
+    });
+
+    const detachFirst = controller.attach();
+    await vi.waitFor(() =>
+      expect(controller.getSnapshot().runtimeRailMemberships).toHaveLength(1)
+    );
+    detachFirst();
+
+    const detachSecond = controller.attach();
+    await vi.waitFor(() =>
+      expect(controller.getSnapshot().runtimeRailSectionsPending).toBe(false)
+    );
+    expect(controller.getSnapshot().runtimeRailMemberships).toEqual([
+      expect.objectContaining({ id: "conversations" })
+    ]);
+    expect(
+      controller.getSnapshot().sectionPageStates.get("conversations")
+    ).toEqual({
+      hasMore: true,
+      isLoading: false,
+      nextCursor: "cursor-1",
+      totalCount: 8
+    });
+
+    detachSecond();
+    engine.dispose();
+  });
 });

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/AgentGUIConversationRailQueryController.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/AgentGUIConversationRailQueryController.ts
@@ -172,8 +172,7 @@ export class AgentGUIConversationRailQueryController {
     this.queryState = {
       ...this.queryState,
       pending: this.runtimeSectionsEnabled(),
-      reconcilingSessionIds: [],
-      resolvedScopeKey: nextScopeKey
+      reconcilingSessionIds: []
     };
     this.emit();
     if (this.attached) this.refreshFirstPages();
@@ -371,6 +370,11 @@ export class AgentGUIConversationRailQueryController {
       });
   }
 
+  retrySearchResults(): void {
+    if (!this.searchQuery || !this.searchEnabled()) return;
+    this.requestSearch();
+  }
+
   private handleEngineState(state: AgentSessionEngineState): void {
     const next = membershipRecords(state);
     if (this.ingestingSessions || !this.runtimeSectionsEnabled()) {
@@ -406,13 +410,15 @@ export class AgentGUIConversationRailQueryController {
     }
     this.pagingRequestSequence += 1;
     const requestSequence = this.pagingRequestSequence;
+    const wasResolvedForScope =
+      this.queryState.resolvedScopeKey === scopeKey &&
+      this.queryState.sections !== null;
     this.cancelPagingRequests(false);
     const abortController = new AbortController();
     this.pagingAbortControllers.set("__first_pages__", abortController);
     this.queryState = {
       ...this.queryState,
-      pending: true,
-      resolvedScopeKey: scopeKey
+      pending: true
     };
     this.emit();
     void listSections({
@@ -464,13 +470,19 @@ export class AgentGUIConversationRailQueryController {
         ) {
           return;
         }
-        this.queryState = {
-          ...this.queryState,
-          pending: false,
-          resolvedScopeKey: scopeKey,
-          sectionPageStates: new Map(),
-          sections: []
-        };
+        this.queryState = wasResolvedForScope
+          ? {
+              ...this.queryState,
+              pending: false,
+              reconcilingSessionIds: []
+            }
+          : {
+              pending: false,
+              reconcilingSessionIds: [],
+              resolvedScopeKey: scopeKey,
+              sectionPageStates: new Map(),
+              sections: []
+            };
         this.emit();
       })
       .finally(() => {

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/agentGuiController.providerHelpers.spec.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/agentGuiController.providerHelpers.spec.ts
@@ -96,6 +96,19 @@ describe("provider rail target selection", () => {
       })
     ).toBe("open-home-composer");
   });
+
+  it("opens the selected target home when it has no agent target id", () => {
+    expect(
+      resolveAgentGUIProviderRailTargetSelection({
+        activeConversation: conversation(
+          "codex-session",
+          "local:codex",
+          "codex"
+        ),
+        nextFilter: { kind: "all" }
+      })
+    ).toBe("open-home-composer");
+  });
 });
 
 function snapshot(

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/agentGuiController.providerHelpers.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/agentGuiController.providerHelpers.ts
@@ -34,7 +34,8 @@ export function resolveAgentGUIProviderRailTargetSelection(input: {
   activeConversation: AgentGUIConversationSummary | null;
   nextFilter: AgentGUIConversationFilter;
 }): AgentGUIProviderRailTargetSelection {
-  return input.activeConversation &&
+  return input.nextFilter.kind === "agentTarget" &&
+    input.activeConversation &&
     matchesAgentGUIConversationSummaryFilter(
       input.activeConversation,
       input.nextFilter

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentConversationSelection.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentConversationSelection.ts
@@ -5,7 +5,6 @@ import type { AgentGUIConversationSummary } from "../model/agentGuiConversationM
 export type ConversationIntent =
   | { tag: "home" }
   | { tag: "requested"; id: string }
-  | { tag: "resolving"; id: string }
   | { tag: "active"; id: string };
 
 export function resolveConversationSummaryById(

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUIActivation.spec.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUIActivation.spec.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from "vitest";
+import { isPendingNewConversationActivationForSession } from "./useAgentGUIActivation";
+
+describe("isPendingNewConversationActivationForSession", () => {
+  const pendingActivation = {
+    agentSessionId: "session-pending",
+    mode: "new" as const,
+    status: "requested" as const
+  };
+
+  it("preserves only the session owned by the pending activation", () => {
+    expect(
+      isPendingNewConversationActivationForSession(
+        pendingActivation,
+        "session-pending"
+      )
+    ).toBe(true);
+    expect(
+      isPendingNewConversationActivationForSession(
+        pendingActivation,
+        "session-previous"
+      )
+    ).toBe(false);
+  });
+});

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUIActivation.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUIActivation.ts
@@ -60,6 +60,21 @@ export function isPendingNewConversationActivation(
   );
 }
 
+export function isPendingNewConversationActivationForSession(
+  activation:
+    | Pick<PendingActivationIntentRecord, "agentSessionId" | "mode" | "status">
+    | null
+    | undefined,
+  agentSessionId: string | null | undefined
+): boolean {
+  const normalizedSessionId = agentSessionId?.trim() ?? "";
+  return Boolean(
+    normalizedSessionId &&
+    activation?.agentSessionId.trim() === normalizedSessionId &&
+    isPendingNewConversationActivation(activation)
+  );
+}
+
 export function useAgentGUIActivation({
   engine,
   workspaceId,

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUIContinueConversation.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUIContinueConversation.ts
@@ -14,7 +14,7 @@ import {
 import { resolveAgentComposerDraftScopeKey } from "../model/agentComposerDraftScope";
 import { buildContinueInNewConversationPrompt } from "./agentGuiController.conversationHelpers";
 import { reportAgentGUIActiveConversationCleared } from "./agentGuiController.reporting";
-import { isPendingNewConversationActivation } from "./useAgentGUIActivation";
+import { isPendingNewConversationActivationForSession } from "./useAgentGUIActivation";
 import {
   resolveConversationSummaryById,
   type ConversationIntent
@@ -101,7 +101,12 @@ export function useAgentGUIContinueConversation(
       runtime: current.agentActivityRuntime,
       workspaceId: current.workspaceId
     });
-    if (!isPendingNewConversationActivation(current.activePendingActivation)) {
+    if (
+      !isPendingNewConversationActivationForSession(
+        current.activePendingActivation,
+        currentConversationId
+      )
+    ) {
       void current.unactivate(currentConversationId);
     }
     current.setIntent({ tag: "home" });

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUIConversationHome.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUIConversationHome.ts
@@ -21,7 +21,7 @@ import type {
 } from "../../../types";
 import { resolveAgentGUIAgentTarget } from "../../../agentTargets";
 import type { AgentGUIComposerTargetData } from "./agentGuiController.composerPresentation";
-import { isPendingNewConversationActivation } from "./useAgentGUIActivation";
+import { isPendingNewConversationActivationForSession } from "./useAgentGUIActivation";
 
 export interface AgentGUIPrefillPromptRequest {
   agentTargetId?: string | null;
@@ -142,7 +142,10 @@ export function useAgentGUIConversationHome({
       });
       if (
         previous &&
-        !isPendingNewConversationActivation(activePendingActivation)
+        !isPendingNewConversationActivationForSession(
+          activePendingActivation,
+          previous
+        )
       ) {
         void unactivate(previous);
       }

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUIConversationRailQuery.search.spec.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUIConversationRailQuery.search.spec.tsx
@@ -92,6 +92,48 @@ describe("useAgentGUIConversationRailQuery search", () => {
       engine.getSnapshot().sessionLifecycle.sessionsById["session-2"]?.title
     ).toBe("backend older result");
   });
+
+  it("exposes retry after an initial backend search failure", async () => {
+    const engine = createTestAgentSessionEngine("workspace-1");
+    let requestCount = 0;
+    const runtime = {
+      getSessionEngine: () => engine,
+      async listSessionsPage(input: AgentActivityRuntimeListSessionsPageInput) {
+        requestCount += 1;
+        if (requestCount === 1) throw new Error("search unavailable");
+        return {
+          hasMore: false,
+          sessions: [searchSession("session-retried", "retried result", 1)],
+          workspaceId: input.workspaceId
+        };
+      }
+    } as unknown as AgentActivityRuntime;
+    const wrapper = ({ children }: PropsWithChildren) => (
+      <AgentActivityRuntimeProvider runtime={runtime}>
+        {children}
+      </AgentActivityRuntimeProvider>
+    );
+    const { result } = renderHook(
+      () =>
+        useAgentGUIConversationRailQuery({
+          activeConversationId: null,
+          conversationFilter: { kind: "all" },
+          conversationQuery: "backend",
+          previewMode: false,
+          sectionAgentTargetFallbackId: null,
+          userProjects: [],
+          workspaceId: "workspace-1"
+        }),
+      { wrapper }
+    );
+
+    await waitFor(() => expect(result.current.railSearch.failed).toBe(true));
+    act(() => result.current.railSearch.retry());
+    await waitFor(() =>
+      expect(result.current.railSearch.sessionIds).toEqual(["session-retried"])
+    );
+    expect(result.current.railSearch.failed).toBe(false);
+  });
 });
 
 function searchSession(

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUIConversationRailQuery.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUIConversationRailQuery.ts
@@ -89,7 +89,8 @@ export function useAgentGUIConversationRailQuery({
       ) => controller.loadMoreSectionConversations(section),
       railSearch: {
         ...querySnapshot.railSearch,
-        loadMore: () => controller.loadMoreSearchResults()
+        loadMore: () => controller.loadMoreSearchResults(),
+        retry: () => controller.retrySearchResults()
       },
       runtimeRailConversations
     }),

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUIConversationRouting.spec.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUIConversationRouting.spec.tsx
@@ -16,7 +16,6 @@ describe("useAgentGUIConversationRouting", () => {
     });
     const selectConversation = vi.fn();
     const setIntent = vi.fn();
-    const syncConversationListProjection = vi.fn(async () => {});
 
     renderHook(() =>
       useAgentGUIConversationRouting({
@@ -33,7 +32,6 @@ describe("useAgentGUIConversationRouting", () => {
         selectConversation,
         sessionEngine,
         setIntent,
-        syncConversationListProjection,
         transientConversation: null,
         workspaceId: "workspace-1"
       })
@@ -41,7 +39,6 @@ describe("useAgentGUIConversationRouting", () => {
 
     expect(setIntent).not.toHaveBeenCalled();
     expect(selectConversation).not.toHaveBeenCalled();
-    expect(syncConversationListProjection).not.toHaveBeenCalled();
   });
 
   it("reconciles a persisted selection outside the bounded list after restart", () => {
@@ -53,7 +50,6 @@ describe("useAgentGUIConversationRouting", () => {
     });
     const selectConversation = vi.fn();
     const setIntent = vi.fn();
-    const syncConversationListProjection = vi.fn(async () => {});
 
     renderHook(() =>
       useAgentGUIConversationRouting({
@@ -70,7 +66,6 @@ describe("useAgentGUIConversationRouting", () => {
         selectConversation,
         sessionEngine,
         setIntent,
-        syncConversationListProjection,
         transientConversation: null,
         workspaceId: "workspace-1"
       })
@@ -85,10 +80,6 @@ describe("useAgentGUIConversationRouting", () => {
         "persisted-session"
       )
     ).not.toBeNull();
-    expect(setIntent).not.toHaveBeenCalledWith({
-      tag: "resolving",
-      id: "persisted-session"
-    });
-    expect(syncConversationListProjection).not.toHaveBeenCalled();
+    expect(setIntent).not.toHaveBeenCalled();
   });
 });

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUIConversationRouting.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUIConversationRouting.ts
@@ -6,7 +6,6 @@ import {
 import type { Dispatch, RefObject, SetStateAction } from "react";
 import { useCallback, useEffect } from "react";
 import type { AgentGUIConversationSummary } from "../model/agentGuiConversationModel";
-import { selectAgentGUIConversationId } from "../model/agentGuiConversationModel";
 import {
   normalizeAgentGUIOpenSessionRequest,
   type AgentGUIOpenSessionRequest
@@ -33,7 +32,6 @@ interface UseAgentGUIConversationRoutingInput {
   ): void;
   sessionEngine: AgentSessionEngine;
   setIntent: Dispatch<SetStateAction<ConversationIntent>>;
-  syncConversationListProjection(agentSessionId: string): Promise<void>;
   transientConversation: AgentGUIConversationSummary | null;
   workspaceId: string;
 }
@@ -55,7 +53,6 @@ export function useAgentGUIConversationRouting(
     selectConversation,
     sessionEngine,
     setIntent,
-    syncConversationListProjection,
     transientConversation,
     workspaceId
   } = input;
@@ -155,21 +152,6 @@ export function useAgentGUIConversationRouting(
         selectConversation(intent.id, { reloadConversations: false });
         ensureTransientOpenSessionConversation(intent.id);
         return;
-      case "resolving": {
-        if (resolveId(intent.id)) {
-          selectConversation(intent.id, { reloadConversations: false });
-          return;
-        }
-        const fallback = selectAgentGUIConversationId(
-          conversations,
-          activeConversationIdRef.current
-        );
-        if (fallback) {
-          selectConversation(fallback, { reloadConversations: false });
-        } else {
-          setIntent({ tag: "home" });
-        }
-      }
     }
   }, [
     conversationListQuery,
@@ -180,7 +162,6 @@ export function useAgentGUIConversationRouting(
     openSessionRequest,
     previewMode,
     selectConversation,
-    syncConversationListProjection,
     transientConversation
   ]);
 }

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUIConversationSelectionController.spec.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUIConversationSelectionController.spec.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from "vitest";
+import { clearFailedAgentGUIActivationSelection } from "./useAgentGUIConversationSelectionController";
+
+describe("clearFailedAgentGUIActivationSelection", () => {
+  it("does not clear a newer external selection", () => {
+    const current = {
+      lastActiveAgentSessionId: "session-newer",
+      provider: "codex" as const
+    };
+
+    expect(
+      clearFailedAgentGUIActivationSelection(current, "session-failed")
+    ).toBe(current);
+    expect(
+      clearFailedAgentGUIActivationSelection(current, "session-newer")
+        .lastActiveAgentSessionId
+    ).toBeNull();
+  });
+});

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUIConversationSelectionController.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUIConversationSelectionController.ts
@@ -16,6 +16,7 @@ import {
 import { sessionHasRenderableMessages } from "./useAgentConversationMessagePaging";
 import {
   isPendingNewConversationActivation,
+  isPendingNewConversationActivationForSession,
   type useAgentGUIActivation
 } from "./useAgentGUIActivation";
 import {
@@ -65,6 +66,16 @@ interface UseAgentGUIConversationSelectionControllerInput {
   setIsComposerHome: Dispatch<SetStateAction<boolean>>;
   setIsLoadingMessages: Dispatch<SetStateAction<boolean>>;
   workspaceId: string;
+}
+
+export function clearFailedAgentGUIActivationSelection(
+  current: AgentGUINodeData,
+  failedAgentSessionId: string
+): AgentGUINodeData {
+  return current.lastActiveAgentSessionId?.trim() ===
+    failedAgentSessionId.trim()
+    ? { ...current, lastActiveAgentSessionId: null }
+    : current;
 }
 
 export function useAgentGUIConversationSelectionController(
@@ -123,9 +134,10 @@ export function useAgentGUIConversationSelectionController(
       setIsComposerHome(true);
       setIntent({ tag: "home" });
       onDataChangeRef.current((current) =>
-        current.lastActiveAgentSessionId === null
-          ? current
-          : { ...current, lastActiveAgentSessionId: null }
+        clearFailedAgentGUIActivationSelection(
+          current,
+          activePendingActivation.agentSessionId
+        )
       );
       setDetailError(
         activePendingActivation.errorMessage ||
@@ -170,7 +182,10 @@ export function useAgentGUIConversationSelectionController(
       });
       if (
         previous &&
-        !isPendingNewConversationActivation(activePendingActivation)
+        !isPendingNewConversationActivationForSession(
+          activePendingActivation,
+          previous
+        )
       ) {
         void activation.unactivate(previous);
       }
@@ -191,7 +206,7 @@ export function useAgentGUIConversationSelectionController(
       ) {
         return current;
       }
-      if (current.tag === "requested" || current.tag === "resolving") {
+      if (current.tag === "requested") {
         return current;
       }
       return { tag: "requested", id: externalId };

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUINodeController.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUINodeController.ts
@@ -580,7 +580,6 @@ export function useAgentGUINodeController({
     selectConversation,
     sessionEngine,
     setIntent,
-    syncConversationListProjection,
     transientConversation,
     workspaceId
   });

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUIProviderHome.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUIProviderHome.ts
@@ -30,7 +30,7 @@ import {
   resolveAgentGUIProviderRailTargetSelection
 } from "./agentGuiController.providerHelpers";
 import { reportAgentGUIConversationFilterTargetUnresolved } from "./agentGuiController.reporting";
-import { isPendingNewConversationActivation } from "./useAgentGUIActivation";
+import { isPendingNewConversationActivationForSession } from "./useAgentGUIActivation";
 import {
   resolveConversationSummaryById,
   type ConversationIntent
@@ -213,8 +213,9 @@ export function useAgentGUIProviderHome(input: UseAgentGUIProviderHomeInput) {
       const previous = currentInput.activeConversationIdRef.current;
       if (
         previous &&
-        !isPendingNewConversationActivation(
-          currentInput.activePendingActivation
+        !isPendingNewConversationActivationForSession(
+          currentInput.activePendingActivation,
+          previous
         )
       ) {
         void currentInput.unactivate(previous);

--- a/packages/agent/gui/agent-gui/agentGuiNode/model/agentGuiConversationProjectResolver.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/model/agentGuiConversationProjectResolver.ts
@@ -168,7 +168,9 @@ function lookupAgentGUIConversationProject(
   return null;
 }
 
-function normalizeAgentGUIProjectPath(path: string | null | undefined): string {
+export function normalizeAgentGUIProjectPath(
+  path: string | null | undefined
+): string {
   const normalized = path?.trim().replaceAll("\\", "/") ?? "";
   if (!normalized) {
     return "";

--- a/packages/agent/gui/agent-gui/agentGuiNode/model/agentGuiConversationRail.spec.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/model/agentGuiConversationRail.spec.ts
@@ -5,6 +5,7 @@ import {
   insertConversationRailSectionOverlay,
   projectConversationRailSectionsWithActiveConversation,
   planRuntimeRailMembershipRefresh,
+  projectRuntimeSectionsToConversationRailMemberships,
   projectConversationRailSectionsWithTransientConversations,
   resolveConversationRailActiveConversation
 } from "./agentGuiConversationRail";
@@ -170,6 +171,32 @@ describe("planRuntimeRailMembershipRefresh", () => {
       kind: "refresh_first_pages",
       reconcilingSessionIds: ["new-session"]
     });
+  });
+});
+
+describe("projectRuntimeSectionsToConversationRailMemberships", () => {
+  it("preserves the daemon-owned project section key", () => {
+    const memberships = projectRuntimeSectionsToConversationRailMemberships({
+      sections: [
+        {
+          hasMore: false,
+          kind: "project",
+          sectionKey: "project:authoritative",
+          sessions: [],
+          totalCount: 0,
+          userProject: {
+            createdAtUnixMs: 1,
+            id: "project-1",
+            label: "Workspace",
+            path: "/workspace",
+            sectionKey: "project:authoritative",
+            updatedAtUnixMs: 2
+          }
+        }
+      ]
+    });
+
+    expect(memberships[0]?.project?.sectionKey).toBe("project:authoritative");
   });
 });
 

--- a/packages/agent/gui/agent-gui/agentGuiNode/model/agentGuiConversationRail.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/model/agentGuiConversationRail.ts
@@ -8,6 +8,7 @@ import {
   type ConversationSection
 } from "../agentGuiNodeViewConversation";
 import { resolveAgentGUIConversationSortTimeUnixMs } from "./agentGuiConversationModel";
+import { normalizeAgentGUIProjectPath } from "./agentGuiConversationProjectResolver";
 
 export interface ConversationRailLabels {
   sectionConversations: string;
@@ -17,11 +18,7 @@ export interface ConversationRailLabels {
 export function normalizeConversationRailProjectPath(
   path: string | null | undefined
 ): string {
-  const normalized = path?.trim().replaceAll("\\", "/") ?? "";
-  if (!normalized) {
-    return "";
-  }
-  return normalized.replace(/\/+$/, "") || "/";
+  return normalizeAgentGUIProjectPath(path);
 }
 
 export interface ConversationRailSectionPageState {
@@ -367,6 +364,7 @@ export function projectRuntimeSectionsToConversationRailMemberships(input: {
           label: section.userProject.label,
           lastUsedAtUnixMs: section.userProject.lastUsedAtUnixMs,
           path: section.userProject.path,
+          sectionKey: section.userProject.sectionKey,
           updatedAtUnixMs: section.userProject.updatedAtUnixMs
         }
       : null;
@@ -581,6 +579,7 @@ export function conversationProjectsRenderEqual(
         left.label === right.label &&
         left.createdAtUnixMs === right.createdAtUnixMs &&
         left.updatedAtUnixMs === right.updatedAtUnixMs &&
-        left.lastUsedAtUnixMs === right.lastUsedAtUnixMs)
+        left.lastUsedAtUnixMs === right.lastUsedAtUnixMs &&
+        left.sectionKey === right.sectionKey)
   );
 }

--- a/packages/agent/gui/agent-gui/agentGuiNode/view/AgentGUIConversationRailPane.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/view/AgentGUIConversationRailPane.tsx
@@ -8,7 +8,10 @@ import {
   useRef,
   useState
 } from "react";
-import { ConfirmationDialog } from "@tutti-os/ui-system";
+import {
+  Button as SystemButton,
+  ConfirmationDialog
+} from "@tutti-os/ui-system";
 import { ScrollArea } from "@tutti-os/ui-system/components";
 import { CreateChatIcon } from "@tutti-os/ui-system/icons";
 import { Button } from "../../../app/renderer/components/ui/button";
@@ -117,9 +120,6 @@ export type AgentGUIConversationRailPaneProps =
     conversationQuery: string;
     onConversationQueryChange: (query: string) => void;
     railQuery: ReturnType<typeof useAgentGUIConversationRailQuery>;
-    railSearch: ReturnType<
-      typeof useAgentGUIConversationRailQuery
-    >["railSearch"];
   };
 
 export type AgentGUIProjectActionDialog =
@@ -173,7 +173,6 @@ export const AgentGUIConversationRailPane = memo(
     sectionAgentTargetFallbackId,
     conversationQuery,
     railQuery,
-    railSearch,
     onCreateConversation,
     onSelectConversation,
     onToggleConversationPinned,
@@ -198,6 +197,7 @@ export const AgentGUIConversationRailPane = memo(
       useState<AgentGUIProjectActionDialog | null>(null);
     const [isRequestingBatchDeletion, setIsRequestingBatchDeletion] =
       useState(false);
+    const { railSearch } = railQuery;
     const railElementRef = useRef<HTMLElement | null>(null);
     const conversationListRef = useRef<HTMLDivElement | null>(null);
     const conversationItemElementsRef = useRef(
@@ -384,7 +384,7 @@ export const AgentGUIConversationRailPane = memo(
     const sectionPaginationScopeKey = `${
       conversationFilter.kind === "agentTarget"
         ? `${workspaceId}:agentTarget:${conversationFilter.agentTargetId.trim()}`
-        : `${workspaceId}:all`
+        : `${workspaceId}:all:${sectionAgentTargetFallbackId?.trim() ?? ""}`
     }:search:${conversationQuery.trim()}`;
     const toggleProjectSectionCollapsed = useCallback((sectionId: string) => {
       setCollapsedProjectSectionIds((current) => {
@@ -457,6 +457,10 @@ export const AgentGUIConversationRailPane = memo(
     );
     const shouldShowConversationEmptyState =
       !isConversationRailListLoading && groupedConversations.length === 0;
+    const shouldShowConversationSearchError =
+      backendSearchActive &&
+      railSearch.failed &&
+      railSearch.sessionIds.length === 0;
     const registerConversationItemElement = useCallback(
       (itemId: string, element: HTMLDivElement | null) => {
         if (element) {
@@ -525,6 +529,18 @@ export const AgentGUIConversationRailPane = memo(
             <AgentConversationListSkeleton
               label={labels.loadingConversations}
             />
+          ) : shouldShowConversationSearchError ? (
+            <div className={styles.emptyState}>
+              <span>{labels.searchFailed}</span>
+              <SystemButton
+                type="button"
+                variant="outline"
+                size="sm"
+                onClick={railSearch.retry}
+              >
+                {labels.retrySearch}
+              </SystemButton>
+            </div>
           ) : shouldShowConversationEmptyState ? (
             <div className={styles.emptyState}>
               <span>

--- a/packages/agent/gui/agent-gui/agentGuiNode/view/AgentGUIConversationRailSection.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/view/AgentGUIConversationRailSection.tsx
@@ -118,6 +118,12 @@ export const AgentGUIConversationRailSection = memo(
       limit: AGENT_GUI_CONVERSATION_RAIL_SECTION_PAGE_SIZE,
       scopeKey: paginationScopeKey
     }));
+    if (visibleItemLimitState.scopeKey !== paginationScopeKey) {
+      setVisibleItemLimitState({
+        limit: AGENT_GUI_CONVERSATION_RAIL_SECTION_PAGE_SIZE,
+        scopeKey: paginationScopeKey
+      });
+    }
     const visibleItemLimit =
       visibleItemLimitState.scopeKey === paginationScopeKey
         ? visibleItemLimitState.limit

--- a/packages/agent/gui/agent-gui/agentGuiNode/view/AgentGUINodeView.types.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/view/AgentGUINodeView.types.ts
@@ -174,6 +174,8 @@ export interface AgentGUIViewLabels {
   loadingConversation: string;
   scrollToBottom: string;
   searchNoConversations: string;
+  searchFailed: string;
+  retrySearch: string;
   conversationUnavailable: string;
   fallbackAgentTitle: string;
   searchPlaceholder: string;

--- a/packages/agent/gui/agent-gui/agentGuiNode/view/agentGUIConversationRailLabels.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/view/agentGUIConversationRailLabels.ts
@@ -1,0 +1,39 @@
+import type { TranslateFn } from "../../../i18n/index";
+import type { AgentGUIViewLabels } from "./AgentGUINodeView.types";
+
+type AgentGUIConversationRailLabels = Pick<
+  AgentGUIViewLabels,
+  | "conversationUnavailable"
+  | "emptyProjectConversations"
+  | "loadingConversations"
+  | "noConversations"
+  | "retrySearch"
+  | "searchFailed"
+  | "searchNoConversations"
+  | "searchPlaceholder"
+  | "sectionConversations"
+  | "sectionPinned"
+  | "selectConversation"
+  | "startConversation"
+>;
+
+export function agentGUIConversationRailLabels(
+  t: TranslateFn
+): AgentGUIConversationRailLabels {
+  return {
+    conversationUnavailable: t("agentHost.agentGui.conversationUnavailable"),
+    emptyProjectConversations: t(
+      "agentHost.agentGui.emptyProjectConversations"
+    ),
+    loadingConversations: t("agentHost.agentGui.loadingConversations"),
+    noConversations: t("agentHost.agentGui.noConversations"),
+    retrySearch: t("agentHost.agentGui.retrySearch"),
+    searchFailed: t("agentHost.agentGui.searchFailed"),
+    searchNoConversations: t("agentHost.agentGui.searchNoConversations"),
+    searchPlaceholder: t("agentHost.agentGui.searchPlaceholder"),
+    sectionConversations: t("agentHost.agentGui.sectionConversations"),
+    sectionPinned: t("agentHost.agentGui.sectionPinned"),
+    selectConversation: t("agentHost.agentGui.selectConversation"),
+    startConversation: t("agentHost.agentGui.startConversation")
+  };
+}

--- a/packages/agent/gui/app/renderer/i18n/locales/en.agentGui.ts
+++ b/packages/agent/gui/app/renderer/i18n/locales/en.agentGui.ts
@@ -352,6 +352,8 @@ export const enAgentGui = {
   loadingConversation: "Loading session...",
   scrollToBottom: "Scroll to bottom",
   searchNoConversations: "No related sessions",
+  searchFailed: "Could not search sessions",
+  retrySearch: "Retry search",
   conversationUnavailable: "Session unavailable.",
   contextPickerBrowseHint: "Search workspace files based on your input",
   contextPickerBrowseFileHint:

--- a/packages/agent/gui/app/renderer/i18n/locales/zh-CN.agentGui.ts
+++ b/packages/agent/gui/app/renderer/i18n/locales/zh-CN.agentGui.ts
@@ -328,6 +328,8 @@ export const zhCNAgentGui = {
   loadingConversation: "正在加载会话...",
   scrollToBottom: "滚动至底部",
   searchNoConversations: "暂无相关会话",
+  searchFailed: "无法搜索会话",
+  retrySearch: "重试搜索",
   conversationUnavailable: "会话不可用。",
   contextPickerBrowseHint: "根据你输入的内容搜索工作区文件",
   contextPickerBrowseFileHint:

--- a/packages/agent/store-sqlite/migrations.go
+++ b/packages/agent/store-sqlite/migrations.go
@@ -32,6 +32,7 @@ const schemaMigrationWorkspaceAgentActivityRailV1 = "workspace_agent_activity_ra
 const schemaMigrationWorkspaceAgentActivityTurnsV1 = "workspace_agent_activity_turns_v1"
 const schemaMigrationWorkspaceAgentActivityInteractionsV2 = "workspace_agent_activity_interactions_v2"
 const schemaMigrationWorkspaceAgentActivityMessagesV2 = "workspace_agent_activity_messages_v2"
+const schemaMigrationWorkspaceAgentActivityTurnIntegrityV1 = "workspace_agent_activity_turn_integrity_v1"
 const schemaMigrationWorkspaceAgentSessionMetadataV1 = "workspace_agent_session_metadata_v1"
 const schemaMigrationWorkspaceAgentSessionMetadataV2 = "workspace_agent_session_metadata_v2"
 const schemaMigrationWorkspaceAgentSessionEntitiesV3 = "workspace_agent_session_entities_v3"
@@ -114,6 +115,9 @@ CREATE TABLE IF NOT EXISTS `+schemaMigrationsTable+` (
 		return err
 	}
 	if err := s.applyWorkspaceAgentActivityMessagesV2(ctx); err != nil {
+		return err
+	}
+	if err := s.applyWorkspaceAgentActivityTurnIntegrityV1(ctx); err != nil {
 		return err
 	}
 	if err := s.applyWorkspaceAgentSessionMetadataV1(ctx); err != nil {

--- a/packages/agent/store-sqlite/migrations_turns.go
+++ b/packages/agent/store-sqlite/migrations_turns.go
@@ -357,7 +357,19 @@ INSERT INTO workspace_agent_messages_v2 (
   deleted_at_unix_ms, created_at_unix_ms, updated_at_unix_ms
 )
 SELECT
-  id, workspace_id, agent_session_id, message_id, version, NULLIF(TRIM(turn_id), ''), role, kind, status,
+  id, workspace_id, agent_session_id, message_id, version,
+  CASE
+    WHEN NULLIF(TRIM(turn_id), '') IS NULL THEN NULL
+    WHEN EXISTS (
+      SELECT 1
+      FROM workspace_agent_turns turn_parent
+      WHERE turn_parent.workspace_id = workspace_agent_messages.workspace_id
+        AND turn_parent.agent_session_id = workspace_agent_messages.agent_session_id
+        AND turn_parent.turn_id = TRIM(workspace_agent_messages.turn_id)
+    ) THEN TRIM(turn_id)
+    ELSE NULL
+  END,
+  role, kind, status,
   payload_json, occurred_at_unix_ms, started_at_unix_ms, completed_at_unix_ms,
   deleted_at_unix_ms, created_at_unix_ms, updated_at_unix_ms
 FROM workspace_agent_messages
@@ -381,6 +393,58 @@ CREATE INDEX IF NOT EXISTS idx_workspace_agent_messages_session_display
 		}
 		return recordMigrationTx(ctx, tx, schemaMigrationWorkspaceAgentActivityMessagesV2)
 	})
+}
+
+// applyWorkspaceAgentActivityTurnIntegrityV1 repairs child references written
+// by the original messages-v2 rebuild and adds the index used by conversation
+// rail latest-turn ordering.
+func (s *Store) applyWorkspaceAgentActivityTurnIntegrityV1(ctx context.Context) error {
+	applied, err := s.hasMigration(ctx, schemaMigrationWorkspaceAgentActivityTurnIntegrityV1)
+	if err != nil || applied {
+		return err
+	}
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("begin workspace agent activity turn integrity v1: %w", err)
+	}
+	committed := false
+	defer func() {
+		if !committed {
+			_ = tx.Rollback()
+		}
+	}()
+	if _, err := tx.ExecContext(ctx, `
+UPDATE workspace_agent_messages
+SET turn_id = NULL
+WHERE turn_id IS NOT NULL
+  AND NOT EXISTS (
+    SELECT 1
+    FROM workspace_agent_turns turn_parent
+    WHERE turn_parent.workspace_id = workspace_agent_messages.workspace_id
+      AND turn_parent.agent_session_id = workspace_agent_messages.agent_session_id
+      AND turn_parent.turn_id = workspace_agent_messages.turn_id
+  );
+
+CREATE INDEX IF NOT EXISTS idx_workspace_agent_turns_session_latest
+  ON workspace_agent_turns(
+    workspace_id,
+    agent_session_id,
+    updated_at_unix_ms DESC,
+    created_at_unix_ms DESC,
+    started_at_unix_ms DESC,
+    turn_id DESC
+  );
+`); err != nil {
+		return fmt.Errorf("apply workspace agent activity turn integrity v1: %w", err)
+	}
+	if err := recordMigrationTx(ctx, tx, schemaMigrationWorkspaceAgentActivityTurnIntegrityV1); err != nil {
+		return err
+	}
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("commit workspace agent activity turn integrity v1: %w", err)
+	}
+	committed = true
+	return nil
 }
 
 func runInConnTx(ctx context.Context, conn *sql.Conn, fn func(*sql.Tx) error) error {

--- a/packages/agent/store-sqlite/migrations_turns_test.go
+++ b/packages/agent/store-sqlite/migrations_turns_test.go
@@ -113,7 +113,7 @@ UPDATE workspace_agent_messages SET deleted_at_unix_ms = 130 WHERE workspace_id 
 
 	// Simulate a legacy database that has messages but predates the turns
 	// migration, then re-run Migrate so the backfill executes against them.
-	if _, err := store.db.ExecContext(ctx, `DELETE FROM `+schemaMigrationsTable+` WHERE id = ?`, schemaMigrationWorkspaceAgentActivityTurnsV1); err != nil {
+	if _, err := store.db.ExecContext(ctx, `DELETE FROM `+schemaMigrationsTable+` WHERE id IN (?, ?)`, schemaMigrationWorkspaceAgentActivityTurnsV1, schemaMigrationWorkspaceAgentActivityTurnIntegrityV1); err != nil {
 		t.Fatalf("reset turns migration ledger: %v", err)
 	}
 	if _, err := store.db.ExecContext(ctx, `PRAGMA foreign_keys = OFF`); err != nil {
@@ -163,6 +163,28 @@ UPDATE workspace_agent_messages SET deleted_at_unix_ms = 130 WHERE workspace_id 
 	}
 	if len(deletedTurns) != 0 {
 		t.Fatalf("deleted session turns = %#v, want none", deletedTurns)
+	}
+	var deletedMessageTurnID *string
+	if err := store.db.QueryRowContext(ctx, `
+SELECT turn_id
+FROM workspace_agent_messages
+WHERE workspace_id = 'ws-1' AND agent_session_id = 'session-deleted' AND message_id = 'msg-deleted'
+`).Scan(&deletedMessageTurnID); err != nil {
+		t.Fatalf("read deleted message turn id: %v", err)
+	}
+	if deletedMessageTurnID != nil {
+		t.Fatalf("deleted message turn id = %q, want NULL", *deletedMessageTurnID)
+	}
+	var foreignKeyViolationCount int
+	if err := store.db.QueryRowContext(ctx, `SELECT COUNT(*) FROM pragma_foreign_key_check`).Scan(&foreignKeyViolationCount); err != nil {
+		t.Fatalf("check foreign keys: %v", err)
+	}
+	if foreignKeyViolationCount != 0 {
+		t.Fatalf("foreign key violations = %d, want 0", foreignKeyViolationCount)
+	}
+	var latestTurnIndexCount int
+	if err := store.db.QueryRowContext(ctx, `SELECT COUNT(*) FROM sqlite_master WHERE type = 'index' AND name = 'idx_workspace_agent_turns_session_latest'`).Scan(&latestTurnIndexCount); err != nil || latestTurnIndexCount != 1 {
+		t.Fatalf("latest-turn index count = %d, error = %v", latestTurnIndexCount, err)
 	}
 
 	failedTurns, err := store.ListSessionTurns(ctx, "ws-1", "session-failed")

--- a/packages/agent/store-sqlite/repository.go
+++ b/packages/agent/store-sqlite/repository.go
@@ -125,13 +125,12 @@ type DeleteSessionsBatchResult struct {
 const PinnedSessionPageKey = "pinned"
 
 type SessionSectionPage struct {
-	WorkspaceID   string
-	SectionKey    string
-	Sessions      []Session
-	HasMore       bool
-	TotalCount    int
-	NextCursor    string
-	NextUpdatedAt int64
+	WorkspaceID string
+	SectionKey  string
+	Sessions    []Session
+	HasMore     bool
+	TotalCount  int
+	NextCursor  string
 }
 
 type Session struct {

--- a/packages/agent/store-sqlite/store_test.go
+++ b/packages/agent/store-sqlite/store_test.go
@@ -642,6 +642,9 @@ func TestStoreListSessionSectionOrdersAndPagesByLatestTurnStart(t *testing.T) {
 	if !page.HasMore || page.NextCursor != "3000|newer-start-older-update" {
 		t.Fatalf("first page hasMore=%v cursor=%q", page.HasMore, page.NextCursor)
 	}
+	if page.TotalCount != 2 {
+		t.Fatalf("first page total count = %d, want 2", page.TotalCount)
+	}
 
 	next, ok, err := store.ListSessionSection(ctx, ListSessionSectionInput{
 		WorkspaceID:          "ws-turn-order",
@@ -658,6 +661,9 @@ func TestStoreListSessionSectionOrdersAndPagesByLatestTurnStart(t *testing.T) {
 	}
 	if next.HasMore || next.NextCursor != "" {
 		t.Fatalf("next page hasMore=%v cursor=%q, want exhausted", next.HasMore, next.NextCursor)
+	}
+	if next.TotalCount != 2 {
+		t.Fatalf("next page total count = %d, want stable total 2", next.TotalCount)
 	}
 }
 

--- a/services/tuttid/api/openapi/tuttid.v1.yaml
+++ b/services/tuttid/api/openapi/tuttid.v1.yaml
@@ -7674,6 +7674,7 @@ components:
           type: boolean
         nextCursor:
           type: string
+          minLength: 1
           description: Cursor for the next older matching session page, encoded as conversationSortTimeUnixMs|agentSessionId.
     WorkspaceAgentSessionPage:
       type: object

--- a/services/tuttid/service/agent/activity_projection.go
+++ b/services/tuttid/service/agent/activity_projection.go
@@ -341,11 +341,11 @@ func (p *ActivityProjection) GetSession(workspaceID string, agentSessionID strin
 	return p.projectPersistedSession(context.Background(), persistedSessionFromActivity(session)), true
 }
 
-func (p *ActivityProjection) SessionDeleted(workspaceID string, agentSessionID string) (bool, error) {
+func (p *ActivityProjection) SessionDeleted(ctx context.Context, workspaceID string, agentSessionID string) (bool, error) {
 	if p == nil || p.repo == nil {
 		return false, nil
 	}
-	return p.repo.SessionDeleted(context.Background(), workspaceID, agentSessionID)
+	return p.repo.SessionDeleted(ctx, workspaceID, agentSessionID)
 }
 
 func (p *ActivityProjection) ListSessions(workspaceID string) ([]PersistedSession, bool) {

--- a/services/tuttid/service/agent/messages.go
+++ b/services/tuttid/service/agent/messages.go
@@ -58,7 +58,6 @@ func (s *Service) ListMessages(
 	agentSessionID string,
 	input ListMessagesInput,
 ) (SessionMessagesPage, error) {
-	_ = ctx
 	workspaceID = strings.TrimSpace(workspaceID)
 	agentSessionID = strings.TrimSpace(agentSessionID)
 	if workspaceID == "" || agentSessionID == "" {
@@ -101,7 +100,7 @@ func (s *Service) ListMessages(
 		}
 	}
 
-	exists, err := s.sessionExists(workspaceID, agentSessionID)
+	exists, err := s.sessionExists(ctx, workspaceID, agentSessionID)
 	if err != nil {
 		return SessionMessagesPage{}, err
 	}
@@ -151,7 +150,7 @@ func (s *Service) ListGeneratedFiles(
 	return files, nil
 }
 
-func (s *Service) sessionExists(workspaceID string, agentSessionID string) (bool, error) {
+func (s *Service) sessionExists(ctx context.Context, workspaceID string, agentSessionID string) (bool, error) {
 	workspaceID = strings.TrimSpace(workspaceID)
 	agentSessionID = strings.TrimSpace(agentSessionID)
 	if workspaceID == "" || agentSessionID == "" {
@@ -161,7 +160,7 @@ func (s *Service) sessionExists(workspaceID string, agentSessionID string) (bool
 		_, ok := s.controller().Session(workspaceID, agentSessionID)
 		return ok, nil
 	}
-	deleted, err := s.SessionReader.SessionDeleted(workspaceID, agentSessionID)
+	deleted, err := s.SessionReader.SessionDeleted(ctx, workspaceID, agentSessionID)
 	if err != nil {
 		return false, err
 	}

--- a/services/tuttid/service/agent/service.go
+++ b/services/tuttid/service/agent/service.go
@@ -441,7 +441,7 @@ func (s *Service) LocalAttachmentPath(ctx context.Context, workspaceID string, a
 
 func (s *Service) get(ctx context.Context, workspaceID string, agentSessionID string, _ bool) (Session, error) {
 	if s.SessionReader != nil {
-		deleted, err := s.SessionReader.SessionDeleted(workspaceID, agentSessionID)
+		deleted, err := s.SessionReader.SessionDeleted(ctx, workspaceID, agentSessionID)
 		if err != nil {
 			return Session{}, err
 		}

--- a/services/tuttid/service/agent/service_session_list.go
+++ b/services/tuttid/service/agent/service_session_list.go
@@ -80,7 +80,7 @@ func (s *Service) listFilteredSortedSessions(ctx context.Context, workspaceID st
 	sessions := s.controller().Sessions(workspaceID)
 	for _, session := range sessions {
 		if s.SessionReader != nil {
-			deleted, err := s.SessionReader.SessionDeleted(workspaceID, session.ID)
+			deleted, err := s.SessionReader.SessionDeleted(ctx, workspaceID, session.ID)
 			if err != nil {
 				return nil, err
 			}

--- a/services/tuttid/service/agent/service_test.go
+++ b/services/tuttid/service/agent/service_test.go
@@ -5884,7 +5884,7 @@ func (f fakeSessionReader) GetSession(workspaceID string, agentSessionID string)
 	return session, ok
 }
 
-func (f fakeSessionReader) SessionDeleted(workspaceID string, agentSessionID string) (bool, error) {
+func (f fakeSessionReader) SessionDeleted(_ context.Context, workspaceID string, agentSessionID string) (bool, error) {
 	return f.tombstoned[workspaceID+":"+agentSessionID], nil
 }
 

--- a/services/tuttid/service/agent/session_types.go
+++ b/services/tuttid/service/agent/session_types.go
@@ -240,7 +240,7 @@ type SessionMessage struct {
 type SessionReader interface {
 	GetSession(workspaceID string, agentSessionID string) (PersistedSession, bool)
 	ListSessions(workspaceID string) ([]PersistedSession, bool)
-	SessionDeleted(workspaceID string, agentSessionID string) (bool, error)
+	SessionDeleted(ctx context.Context, workspaceID string, agentSessionID string) (bool, error)
 }
 
 type SessionSectionReader interface {

--- a/services/tuttid/service/workspace/app_factory_test.go
+++ b/services/tuttid/service/workspace/app_factory_test.go
@@ -89,7 +89,7 @@ func (s factoryAgentSessionReaderStub) ListSessions(workspaceID string) ([]agent
 	return result, true
 }
 
-func (factoryAgentSessionReaderStub) SessionDeleted(string, string) (bool, error) {
+func (factoryAgentSessionReaderStub) SessionDeleted(context.Context, string, string) (bool, error) {
 	return false, nil
 }
 


### PR DESCRIPTION
## Summary

- address valid post-merge review findings from #1124 across rail query ownership, pagination scopes, selection transitions, backend search retry, and daemon cancellation
- harden turn migration integrity and add the supporting latest-turn lookup index
- preserve the established conversation order: resolved latest-turn start time descending, then session ID
- update AgentGUI architecture and troubleshooting validation docs

## Fix Scope Justification

- Root cause: #1124 changed the conversation rail contract across controller, renderer, daemon service, and SQLite ownership, but several invariants were incomplete at their actual sources: resolved query state was discarded on same-scope failure, effective target identity was absent from pagination scope, failed activation cleanup did not compare the persisted session ID, the messages-v2 migration retained orphaned turn references, and `SessionDeleted` dropped request context. The review also identified dead contracts and missing contract tests.
- Why this cannot be fixed at a lower layer: each correction is already made in its owning lower layer. Request retention/retry belongs to the rail query controller, pagination reset belongs to local UI state, target/session transitions belong to controller helpers, cursor validation belongs to OpenAPI, cancellation belongs to the service interface, and orphan repair/indexing belongs to SQLite migration. Moving these into one lower layer would either duplicate business state in the renderer or leave persisted/API invariants broken. Of 569 added lines, 311 are regression tests and 11 are required durable documentation.

## Fallback Three Questions

- Source: the explicit retry action represents a transient failure returned by the daemon-backed full-session search request; same-scope section retention represents a transient refresh failure after a scope has already resolved.
- Why it cannot be fixed at that source: transport/server failures cannot be eliminated by the renderer. The controller owns request state, so it must retain the last successful page and expose an explicit retry without fabricating local search results.
- Removal condition: these branches can be removed only if the runtime contract guarantees infallible search and section refreshes. No such guarantee exists; the branches are user-visible recovery behavior, not a timer or legacy compatibility path.

## Review triage

- fixed 18 findings still present after merge
- already resolved by merged code: search-mode project batch delete and independent search/section request cancellation
- deliberately unchanged: adding `createdAt` as a tie-breaker in renderer/service ordering, because current documented intent is equal resolved sort time -> session ID

## Verification

- `pnpm check:changed` (12/12)
- `pnpm check:full` (18/18, pre-push)
- Agent GUI full test suite passed
- AgentGUI layout: 147/147 tests
- `go test ./...` in `packages/agent/store-sqlite`
- `go test ./service/agent ./api ./service/workspace` in `services/tuttid`
- `pnpm check:api-generated`

## Checklist

- [x] I kept the change focused on post-merge conversation-rail review findings.
- [x] I updated documentation when behavior or troubleshooting validation changed.
- [x] README/CONTRIBUTING language variants are not affected.
- [x] I ran the lowest meaningful local checks and the full pre-push gate.
- [x] The commit is signed off with DCO.
