### PR TITLE
fix(agent-gui): preserve built-in conversation icons

### DIFF
--- a/docs/architecture/agent-gui-node.md
+++ b/docs/architecture/agent-gui-node.md
@@ -2366,10 +2366,12 @@ the resolved icon, label, and optional owner badge. The DOM rail, single-agent
 empty state, and WebGL empty-home carousel consume that same presentation;
 renderer adapters may differ, but they must not create parallel icon-only
 models that can silently discard badge or identity fields.
-Conversation rail rows resolve their icon from the conversation's
-`agentTargetId` through that same Target presentation. A provider-catalog icon
-is only a compatibility path for historical sessions without a resolvable
-Target; open extension providers must not require a renderer icon catalog entry.
+Conversation rail rows render icons through a monochrome CSS mask. Built-in
+providers therefore use their mask-safe flat catalog artwork before consulting
+the Target presentation; using a square colorful Target asset there collapses
+to a solid block. When an open extension provider has no built-in flat asset,
+the row resolves the signed Target `iconUrl` through the conversation's
+`agentTargetId`. Open providers must not require a renderer icon catalog entry.
 One carousel image-load owner fetches and decodes icon, vinyl-cover, and badge
 images for a complete item generation. Remote badge images must be requested
 with anonymous CORS before assigning `src`, and the asset host must return an

--- a/packages/agent/gui/agent-gui/agentGuiNode/AgentGUINodeView.layout.spec.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/AgentGUINodeView.layout.spec.tsx
@@ -28,6 +28,7 @@ import {
   createLocalAgentGUIAgentTarget,
   createLocalAgentGUIAgentTargets
 } from "../../agentTargets";
+import { resolveAgentGuiSessionProviderFlatIconUrl } from "../../agentGuiSessionProviderIconUrls";
 import {
   agentGUIProviderRailOrderStorageKey,
   parseAgentGUIProviderRailPreferences
@@ -6988,6 +6989,39 @@ function createViewModel(
 }
 
 describe("AgentGUINodeView conversation presentation", () => {
+  it("keeps the flat provider icon for a built-in Agent conversation", () => {
+    const targetIconUrl = "data:image/svg+xml;base64,codex-square";
+    const codexTarget = {
+      ...createLocalAgentGUIAgentTarget("codex"),
+      iconUrl: targetIconUrl
+    };
+    const agentTargetId = codexTarget.agentTargetId ?? "";
+    const conversation = createConversationSummary("codex-session", {
+      agentTargetId,
+      provider: "codex"
+    });
+    renderAgentGUINodeView({
+      viewModel: createViewModel({
+        selectedAgentTarget: codexTarget,
+        agentTargets: [codexTarget],
+        conversations: [conversation]
+      })
+    });
+
+    const row = screen.getByTestId("agent-gui-conversation-item-codex-session");
+    const icon = row.querySelector(
+      ".agent-gui-node__conversation-provider-icon"
+    );
+    const providerIconUrl = resolveAgentGuiSessionProviderFlatIconUrl("codex");
+    expect(providerIconUrl).not.toBeNull();
+    expect(icon).toHaveStyle({
+      "--agent-gui-conversation-provider-icon-url": `url("${providerIconUrl}")`
+    });
+    expect(icon).not.toHaveStyle({
+      "--agent-gui-conversation-provider-icon-url": `url("${targetIconUrl}")`
+    });
+  });
+
   it("uses the signed Agent Target icon for an extension conversation", () => {
     const iconUrl = "data:image/svg+xml;base64,gemini";
     const agentTargetId = "extension:gemini";

--- a/packages/agent/gui/agent-gui/agentGuiNode/view/AgentGUIConversationRailItem.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/view/AgentGUIConversationRailItem.tsx
@@ -50,8 +50,9 @@ function agentGUIConversationIconUrl(
     workspaceId
   });
   return (
+    resolveAgentGuiSessionProviderFlatIconUrl(provider) ||
     targetPresentation?.iconUrl?.trim() ||
-    resolveAgentGuiSessionProviderFlatIconUrl(provider)
+    null
   );
 }
 


### PR DESCRIPTION
## Summary

<!-- What changed and why? -->

## Verification

<!-- Commands run, manual checks, or why verification is not applicable. -->

## Fix Scope Justification

<!--
Required when a fix-titled PR changes more than 300 lines; delete otherwise.

- Root cause: which event or state is the actual source of the bug?
- Why can this not be fixed at a lower layer?
-->

## Fallback Three Questions

<!--
Required when this change adds a timer, retry, cache, or defensive branch;
delete otherwise.

- Source: which event or state does this fallback compensate for?
- Why can it not be fixed at that source?
- Removal condition: when can this fallback be deleted?
-->

## Checklist

- [ ] I kept the change focused on one concern.
- [ ] I updated documentation when behavior, setup, or contributor workflow changed.
- [ ] I updated all README/CONTRIBUTING language variants when changing their English source.
- [ ] I ran the lowest meaningful local checks for the changed surface.
- [ ] My commits are signed off with DCO when required: `git commit -s`.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Preserves built‑in provider icons in the conversation rail by preferring flat catalog icons under the CSS mask, falling back to signed Target icons for extensions. Fixes solid-block icons for built‑in agents and documents the behavior.

- **Bug Fixes**
  - Updated `AgentGUIConversationRailItem` to resolve `resolveAgentGuiSessionProviderFlatIconUrl(provider)` before the Target `iconUrl`; fallback to `null`.
  - Added a layout test to confirm built‑in conversations keep the flat provider icon and extensions use the signed Target icon.
  - Clarified icon resolution and mask behavior in `docs/architecture/agent-gui-node.md`.

<sup>Written for commit fab5f7a5e1f2d68b626687e23acf5665a6258040. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tutti-os/tutti/pull/1135?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

