### PR TITLE
fix(agent-gui): render session mentions as titles

### DIFF
--- a/packages/agent/gui/agent-gui/agentGuiNode/agentRichText/AgentMentionNodeView.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/agentRichText/AgentMentionNodeView.tsx
@@ -100,62 +100,6 @@ function normalizeKind(value: string): AgentMentionNodeViewKind {
   return "file";
 }
 
-function normalizeSessionTitle(value: string): string {
-  const trimmed = value.trim();
-  const withoutMentionPrefix = trimmed.replace(/^@+/, "").trim();
-  return withoutMentionPrefix || trimmed;
-}
-
-function parseDottedSessionText(
-  value: string
-): { participant: string; summary: string } | null {
-  const parts = value
-    .split("·")
-    .map((part) => part.trim())
-    .filter(Boolean);
-  if (parts.length < 3) {
-    return null;
-  }
-  return {
-    participant: `${parts[0]} & ${parts[1]}`,
-    summary: normalizeSessionTitle(parts.slice(2).join(" "))
-  };
-}
-
-function sessionPresentation(attrs: Record<string, unknown>): {
-  label: string;
-  summary: string;
-} {
-  const name = attrString(attrs, "name").trim();
-  const initiatorName = attrString(attrs, "initiatorName").trim();
-  const agentName = attrString(attrs, "agentName").trim();
-  const title = normalizeSessionTitle(attrString(attrs, "title") || name);
-  const inputPreview = attrString(attrs, "inputPreview").trim();
-
-  if (initiatorName && agentName) {
-    const dottedTitle = parseDottedSessionText(title);
-    return {
-      // i18n-check-ignore: Dynamic participant display names.
-      label: `${initiatorName} & ${agentName}`,
-      summary:
-        dottedTitle?.summary || (title && title !== name ? title : inputPreview)
-    };
-  }
-
-  const dottedName = parseDottedSessionText(name);
-  if (dottedName) {
-    return {
-      label: dottedName.participant,
-      summary: dottedName.summary
-    };
-  }
-
-  return {
-    label: name,
-    summary: title && title !== name ? title : inputPreview
-  };
-}
-
 function dirnameFromPath(path: string): string {
   const parts = path.split("/").filter(Boolean);
   if (parts.length <= 1) {
@@ -173,17 +117,15 @@ function mentionViewModel(
   const href = attrString(attrs, "href");
 
   if (kind === "session") {
-    const presentation = sessionPresentation(attrs);
-    const primary = `${presentation.label} ${presentation.summary}`.trim();
+    const label = attrString(attrs, "title").trim() || name.trim();
     return {
       ariaLabel:
-        `${t("agentHost.agentGui.mentionKindSession")} ${primary}`.trim(),
+        `${t("agentHost.agentGui.mentionKindSession")} ${label}`.trim(),
       directoryPath: "",
       entryKind: "",
       href,
       kind,
-      label: presentation.label,
-      summary: presentation.summary
+      label
     };
   }
 

--- a/packages/agent/gui/agent-gui/agentGuiNode/agentRichText/AgentRichTextEditor.spec.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/agentRichText/AgentRichTextEditor.spec.tsx
@@ -1149,7 +1149,7 @@ describe("AgentRichTextEditor", () => {
     render(
       <AgentRichTextEditor
         value={
-          "继续 [@wang jomes · Codex · @README.md 看看项目文件](mention://agent-session/session-1?workspaceId=room-1) " +
+          "继续 [@README.md 看看项目文件](mention://agent-session/session-1?workspaceId=room-1) " +
           "再处理 [@修复 room status 批量接口](mention://workspace-issue/issue-1?workspaceId=room-1)"
         }
         disabled={false}
@@ -1173,15 +1173,13 @@ describe("AgentRichTextEditor", () => {
     );
     expect(sessionMention).toHaveAttribute(
       "aria-label",
-      "Session wang jomes & Codex README.md 看看项目文件"
+      "Session README.md 看看项目文件"
     );
     expect(sessionMention).toHaveAttribute("data-slot", "mention-pill");
     expect(
       sessionMention.querySelector('button[aria-label="Remove mention"]')
     ).not.toBeNull();
-    expect(sessionMention).toHaveTextContent(
-      "wang jomes & Codex README.md 看看项目文件"
-    );
+    expect(sessionMention).toHaveTextContent("README.md 看看项目文件");
     expect(sessionMention.textContent).not.toContain("·");
     expect(sessionMention.textContent).not.toContain("@");
     expect(sessionMention.textContent).not.toContain("Session");
@@ -1209,7 +1207,7 @@ describe("AgentRichTextEditor", () => {
       <AgentGuiI18nProvider locale="zh-CN">
         <AgentRichTextEditor
           value={
-            "继续 [@wang jomes · Codex · @README.md 看看项目文件](mention://agent-session/session-1?workspaceId=room-1) " +
+            "继续 [@README.md 看看项目文件](mention://agent-session/session-1?workspaceId=room-1) " +
             "再处理 [@修复 room status 批量接口](mention://workspace-issue/issue-1?workspaceId=room-1)"
           }
           disabled={false}
@@ -1228,7 +1226,7 @@ describe("AgentRichTextEditor", () => {
 
     expect(mentions[0]).toHaveAttribute(
       "aria-label",
-      "会话 wang jomes & Codex README.md 看看项目文件"
+      "会话 README.md 看看项目文件"
     );
     expect(mentions[1]).toHaveAttribute(
       "aria-label",
@@ -1548,6 +1546,66 @@ describe("AgentRichTextEditor", () => {
     expect(
       editor.querySelector('[data-agent-mention-file-thumb="true"]')
     ).toBeNull();
+  });
+
+  it("renders inserted session mentions with only the canonical title", async () => {
+    let suggestionState: AgentFileMentionSuggestionState | null = null;
+    const onChange = vi.fn();
+    render(
+      <AgentRichTextEditor
+        value="@"
+        disabled={false}
+        placeholder="Prompt"
+        onChange={onChange}
+        onSubmit={vi.fn()}
+        onFileMentionSuggestionChange={(state) => {
+          suggestionState = state;
+        }}
+      />
+    );
+
+    const editor = await screen.findByRole("textbox", { name: "Prompt" });
+    await waitFor(() => expect(suggestionState).not.toBeNull());
+
+    act(() => {
+      suggestionState?.command({
+        kind: "session",
+        href: "mention://agent-session/session-1?workspaceId=room-1",
+        workspaceId: "room-1",
+        targetId: "session-1",
+        name: "@我打算去泰国旅游，你制定下旅游计划",
+        title: "我打算去泰国旅游，你制定下旅游计划",
+        scope: "my_sessions",
+        initiatorName: "User",
+        agentName: "Codex",
+        inputPreview: "我打算去泰国旅游，你制定下旅游计划"
+      });
+    });
+
+    const sessionMention = await waitFor(() => {
+      const mention = editor.querySelector(
+        '[data-slot="mention-pill"][data-agent-mention-kind="session"]'
+      );
+      expect(mention).not.toBeNull();
+      return mention!;
+    });
+    expect(sessionMention).toHaveTextContent(
+      "我打算去泰国旅游，你制定下旅游计划"
+    );
+    expect(sessionMention.textContent).toBe(
+      "我打算去泰国旅游，你制定下旅游计划"
+    );
+    const ariaLabel = sessionMention.getAttribute("aria-label") ?? "";
+    expect(ariaLabel).toContain("我打算去泰国旅游，你制定下旅游计划");
+    expect(
+      ariaLabel.match(/我打算去泰国旅游，你制定下旅游计划/gu)
+    ).toHaveLength(1);
+    expect(ariaLabel).not.toContain("User");
+    expect(ariaLabel).not.toContain("Codex");
+    await waitFor(() => expect(onChange).toHaveBeenCalled());
+    expect(onChange.mock.calls.at(-1)?.[0]).toContain(
+      "[@我打算去泰国旅游，你制定下旅游计划](mention://agent-session/session-1?workspaceId=room-1)"
+    );
   });
 
   it("renders workspace app mention chips with the app icon", async () => {

--- a/packages/agent/gui/agent-gui/agentGuiNode/agentRichText/agentFileMentionExtension.spec.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/agentRichText/agentFileMentionExtension.spec.ts
@@ -448,7 +448,7 @@ describe("agent session mention links", () => {
         workspaceId: "room-1",
         targetId: "session-1",
         agentTargetId: "local:claude-code",
-        name: "Session 1",
+        name: "Taylor & Claude Code Session 1",
         title: "Session 1",
         scope: "my_sessions",
         initiatorName: "Taylor",

--- a/packages/agent/gui/agent-gui/agentGuiNode/agentRichText/agentFileMentionExtension.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/agentRichText/agentFileMentionExtension.ts
@@ -19,10 +19,7 @@ import {
   parseAgentMentionHTMLElementAttrs
 } from "./agentMentionAttrs";
 import { formatAgentMentionMarkdown } from "./agentMentionMarkdown";
-import {
-  mentionVisual,
-  sessionMentionVisual
-} from "./agentMentionPresentation";
+import { mentionVisual } from "./agentMentionPresentation";
 
 export type {
   AgentContextMentionItem,
@@ -219,8 +216,6 @@ export function createAgentFileMentionExtension(
       const href = item.href;
       const tagName = options.renderAsLink ? "a" : "span";
       const visual = mentionVisual(item);
-      const sessionVisual =
-        item.kind === "session" ? sessionMentionVisual(item) : null;
       const sharedAttributes = {
         "data-agent-file-mention": "true",
         "data-agent-mention-href": href,
@@ -295,60 +290,28 @@ export function createAgentFileMentionExtension(
                 visual.primary
               ]
             ]
-          : item.kind === "session"
-            ? [
+          : [
+              [
+                "span",
+                {
+                  class: "tsh-agent-object-token__kind",
+                  "aria-hidden": "true"
+                },
                 [
                   "span",
                   {
-                    class: "tsh-agent-object-token__kind",
+                    class: "tsh-agent-object-token__kind-icon",
                     "aria-hidden": "true"
                   },
-                  [
-                    "span",
-                    {
-                      class: "tsh-agent-object-token__kind-icon",
-                      "aria-hidden": "true"
-                    },
-                    ""
-                  ]
-                ],
-                [
-                  "span",
-                  { class: "tsh-agent-object-token__main" },
-                  [
-                    "span",
-                    { class: "tsh-agent-object-token__participant" },
-                    sessionVisual?.participant ?? ""
-                  ],
-                  [
-                    "span",
-                    { class: "tsh-agent-object-token__summary" },
-                    sessionVisual?.summary ? ` ${sessionVisual.summary}` : ""
-                  ]
+                  ""
                 ]
+              ],
+              [
+                "span",
+                { class: "tsh-agent-object-token__main" },
+                visual.primary
               ]
-            : [
-                [
-                  "span",
-                  {
-                    class: "tsh-agent-object-token__kind",
-                    "aria-hidden": "true"
-                  },
-                  [
-                    "span",
-                    {
-                      class: "tsh-agent-object-token__kind-icon",
-                      "aria-hidden": "true"
-                    },
-                    ""
-                  ]
-                ],
-                [
-                  "span",
-                  { class: "tsh-agent-object-token__main" },
-                  visual.primary
-                ]
-              ])
+            ])
       ];
     },
 

--- a/packages/agent/gui/agent-gui/agentGuiNode/agentRichText/agentMentionMarkdown.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/agentRichText/agentMentionMarkdown.ts
@@ -113,7 +113,7 @@ export function formatAgentMentionMarkdown(
       agentSessionId: item.targetId,
       agentTargetId:
         item.agentTargetId ?? agentSessionTargetIdFromHref(item.href),
-      label: item.name,
+      label: item.title.trim() || item.name,
       workspaceId: item.workspaceId,
       withAtPrefix: true
     });

--- a/packages/agent/gui/agent-gui/agentGuiNode/agentRichText/agentMentionPresentation.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/agentRichText/agentMentionPresentation.ts
@@ -1,5 +1,4 @@
 import type { AgentContextMentionItem } from "./agentFileMentionContracts";
-import { normalizeAgentSessionMentionTitle } from "./agentMentionMarkdown";
 
 export function mentionVisual(item: AgentContextMentionItem): {
   kindLabel: string;
@@ -12,10 +11,9 @@ export function mentionVisual(item: AgentContextMentionItem): {
     };
   }
   if (item.kind === "session") {
-    const visual = sessionMentionVisual(item);
     return {
       kindLabel: "Session",
-      primary: `${visual.participant} ${visual.summary}`.trim()
+      primary: item.title.trim() || item.name.trim()
     };
   }
   if (item.kind === "workspace-app") {
@@ -51,59 +49,5 @@ export function mentionVisual(item: AgentContextMentionItem): {
   return {
     kindLabel: "Task",
     primary: item.name
-  };
-}
-
-export function sessionMentionVisual(
-  item: Extract<AgentContextMentionItem, { kind: "session" }>
-): {
-  participant: string;
-  summary: string;
-} {
-  const initiatorName = item.initiatorName.trim();
-  const agentName = item.agentName.trim();
-  const title = normalizeAgentSessionMentionTitle(item.title);
-  if (initiatorName && agentName) {
-    const dottedTitle = parseDottedSessionMentionText(title);
-    return {
-      participant: `${initiatorName} & ${agentName}`,
-      summary:
-        dottedTitle?.summary ||
-        (title && title !== item.name.trim()
-          ? title
-          : item.inputPreview?.trim() || "")
-    };
-  }
-
-  const dottedName = parseDottedSessionMentionText(item.name);
-  if (dottedName) {
-    return {
-      participant: dottedName.participant,
-      summary: dottedName.summary
-    };
-  }
-
-  return {
-    participant: item.name.trim(),
-    summary:
-      title && title !== item.name.trim()
-        ? title
-        : item.inputPreview?.trim() || ""
-  };
-}
-
-export function parseDottedSessionMentionText(
-  value: string
-): { participant: string; summary: string } | null {
-  const parts = value
-    .split("·")
-    .map((part) => part.trim())
-    .filter(Boolean);
-  if (parts.length < 3) {
-    return null;
-  }
-  return {
-    participant: `${parts[0]} & ${parts[1]}`,
-    summary: normalizeAgentSessionMentionTitle(parts.slice(2).join(" "))
   };
 }

--- a/packages/agent/gui/app/renderer/agentactivity.css
+++ b/packages/agent/gui/app/renderer/agentactivity.css
@@ -4212,10 +4212,6 @@ aside.workspace-agents-status-panel
   -webkit-mask-size: 16px 16px;
 }
 
-.tsh-agent-object-token--entity .tsh-agent-object-token__summary {
-  color: inherit;
-}
-
 .agent-gui-node__composer-textarea .agent-rich-text-mention-node {
   display: inline-flex;
   align-items: center;
@@ -8089,9 +8085,6 @@ html[data-theme="light"] [data-message-center-item-id].agent-gui-edge-glow {
 .agent-gui-node__composer-queued-prompt-markdown
   [data-agent-file-mention="true"]
   .tsh-agent-object-token__kind,
-.agent-gui-node__composer-queued-prompt-markdown
-  [data-agent-file-mention="true"]
-  .tsh-agent-object-token__summary,
 .agent-gui-node__composer-queued-prompt-markdown
   [data-agent-file-mention="true"]
   [data-agent-mention-app-icon="true"] {

--- a/packages/agent/gui/shared/AgentMessageMarkdown.spec.tsx
+++ b/packages/agent/gui/shared/AgentMessageMarkdown.spec.tsx
@@ -1290,14 +1290,14 @@ describe("AgentMessageMarkdown", () => {
     const { container } = render(
       <AgentMessageMarkdown
         content={
-          "回复 [@sunhello135-png & Nexight 长标题会话]\n(mention://agent-session/session-with-long-title?workspaceId=room-1)"
+          "回复 [@长标题会话]\n(mention://agent-session/session-with-long-title?workspaceId=room-1)"
         }
       />
     );
 
     const mention = container.querySelector('[data-agent-file-mention="true"]');
     expect(mention).toHaveAttribute("data-agent-mention-kind", "session");
-    expect(mention).toHaveTextContent("sunhello135-png & Nexight 长标题会话");
+    expect(mention).toHaveTextContent("长标题会话");
     expect(screen.queryByText(/mention:\/\/session/)).toBeNull();
   });
 

--- a/packages/agent/gui/shared/AgentMessageMarkdown.tsx
+++ b/packages/agent/gui/shared/AgentMessageMarkdown.tsx
@@ -652,10 +652,7 @@ function MentionLink({
   "use memo";
   // 标签截断时,hover 用设计系统 Tooltip 展示完整文本。trigger = 整个 chip(<a>),
   // 截断发生在内部 __main span,故在那上面测溢出。
-  const tooltipText =
-    mention.kind === "session"
-      ? `${mention.participant}${mention.summary ? ` ${mention.summary}` : ""}`.trim()
-      : mention.label;
+  const tooltipText = mention.label;
   const { ref: mainRef, overflowing } =
     useTextOverflow<HTMLSpanElement>(tooltipText);
   const link = (
@@ -721,23 +718,9 @@ function MentionLink({
           />
         </span>
       )}
-      {mention.kind === "session" ? (
-        <span className="tsh-agent-object-token__main" ref={mainRef}>
-          <span className="tsh-agent-object-token__participant">
-            {mention.participant}
-          </span>
-          {mention.summary ? (
-            <span className="tsh-agent-object-token__summary">
-              {" "}
-              {mention.summary}
-            </span>
-          ) : null}
-        </span>
-      ) : (
-        <span className="tsh-agent-object-token__main" ref={mainRef}>
-          {mention.label}
-        </span>
-      )}
+      <span className="tsh-agent-object-token__main" ref={mainRef}>
+        {mention.label}
+      </span>
     </a>
   );
 

--- a/packages/agent/gui/shared/agentMessageMarkdownLinks.ts
+++ b/packages/agent/gui/shared/agentMessageMarkdownLinks.ts
@@ -449,9 +449,7 @@ export interface ParsedMentionLink {
   kind: MentionKind;
   label: string;
   iconUrl?: string;
-  participant: string;
   referenceSource?: string;
-  summary: string;
   /** 引用文件数量(workspace-reference 专用,来自 href 的 count 参数)。 */
   fileCount?: number;
 }
@@ -503,7 +501,7 @@ export function parseMentionLink(
     rawLabel.trim().replace(/^@+/, "").trim() ||
     (kind === "workspace-app-factory" ? appFactoryFallbackLabel : "");
   if (kind === "pasted-text") {
-    return { kind, label, participant: label, summary: "" };
+    return { kind, label };
   }
   if (kind === "workspace-app" || kind === "workspace-app-factory") {
     const appId = kind === "workspace-app" ? entityId : "";
@@ -520,9 +518,7 @@ export function parseMentionLink(
               workspaceId
             })
           }
-        : {}),
-      participant: label,
-      summary: ""
+        : {})
     };
   }
   if (kind === "agent-target") {
@@ -539,9 +535,7 @@ export function parseMentionLink(
       kind,
       label: targetLabel,
       iconUrl:
-        target?.iconUrl?.trim() || managedAgentRoundedIconUrl(agentProviderId),
-      participant: targetLabel,
-      summary: ""
+        target?.iconUrl?.trim() || managedAgentRoundedIconUrl(agentProviderId)
     };
   }
   if (kind === "workspace-reference") {
@@ -560,25 +554,18 @@ export function parseMentionLink(
       label,
       iconUrl: mention.scope?.icon?.trim() || appIconUrl,
       fileCount: referenceFileCountFromParam(mention.scope?.count ?? null),
-      participant: label,
-      referenceSource: source || undefined,
-      summary: ""
+      referenceSource: source || undefined
     };
   }
   if (kind === "workspace-issue") {
     return {
       kind,
-      label,
-      participant: label,
-      summary: ""
+      label
     };
   }
-  const sessionLabel = parseSessionMentionLabel(label);
   return {
     kind,
-    label,
-    participant: sessionLabel.participant,
-    summary: sessionLabel.summary
+    label
   };
 }
 
@@ -614,26 +601,6 @@ export function resolveWorkspaceAppMentionIconUrl(input: {
   return (
     exactMatch?.iconUrl?.trim() || fallbackMatch?.iconUrl?.trim() || undefined
   );
-}
-
-export function parseSessionMentionLabel(label: string): {
-  participant: string;
-  summary: string;
-} {
-  const dottedParts = label
-    .split("·")
-    .map((part) => part.trim())
-    .filter(Boolean);
-  if (dottedParts.length >= 3) {
-    return {
-      participant: `${dottedParts[0]} & ${dottedParts[1]}`,
-      summary: dottedParts.slice(2).join(" ")
-    };
-  }
-  return {
-    participant: label,
-    summary: ""
-  };
 }
 
 export function markdownLinkEndIndex(content: string, index: number): number {


### PR DESCRIPTION
## Summary

- render session mention chips, tooltips, ARIA labels, static HTML, and message Markdown from the canonical session title only
- remove the obsolete participant/summary split, dotted-label parsing, prompt-preview fallback, and related dead styles
- serialize session mentions with the canonical title so participant metadata cannot pollute new prompts; keep participant and status metadata in the mention picker

## Verification

- `pnpm --filter @tutti-os/agent-gui typecheck`
- `pnpm --filter @tutti-os/agent-gui test` — 155 files, 2024 tests passed
- `pnpm check:changed` — 8 lanes passed
- `pnpm check:full` — blocked in the unchanged `origin/main` baseline by `check:agent-gui-provider-catalog-generated`: OpenAPI `AgentTargetProvider` actual set is empty while the generated catalog expects eight providers; this PR does not touch either surface

## Fix Scope Justification

- Root cause: the session mention renderer still inferred a two-part participant/summary display from `name`, `title`, and `inputPreview`, while the current provider contract already supplies the session title as the mention label. That stale inference duplicated the title and polluted overflow tooltips.
- Why can this not be fixed at a lower layer? The canonical title and mention identity are already correct at the provider boundary. The duplicate was created independently by composer, static HTML, message Markdown, and serialization presentation branches, so those obsolete branches had to be removed together.

## Checklist

- [x] I kept the change focused on one concern.
- [x] I checked documentation impact; the existing AgentGUI architecture already requires source conversation titles without agent/provider prefixes.
- [x] README/CONTRIBUTING language variants are not affected.
- [x] I ran the lowest meaningful local checks for the changed surface.
- [x] My commit is signed off with DCO.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Render session mentions using the canonical session title everywhere, removing participant/summary parsing. This fixes duplicated text in chips/tooltips and keeps serialized prompts clean.

- **Bug Fixes**
  - Removes duplicated titles and stray "·"/"@" artifacts in session mention chips, tooltips, and ARIA labels.
  - Serializes session mentions with `title` (fallback to `name`) so participant metadata doesn’t enter new prompts.

- **Refactors**
  - Deleted participant/summary split, dotted-label parsing, and prompt-preview fallback; removed related CSS.
  - Simplified NodeView and presentation paths to use a single title-based rendering.
  - Updated tests to reflect title-only behavior.

<sup>Written for commit 647b562f7014e8f385857d932fae2f36a72db5d8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tutti-os/tutti/pull/1139?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

