### PR TITLE
fix(agent-gui): place sidebar slot above settings

### DIFF
--- a/packages/agent/gui/agent-gui/agentGuiNode/AgentGUINodeView.layout.spec.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/AgentGUINodeView.layout.spec.tsx
@@ -487,6 +487,7 @@ describe("AgentGUINodeView layout persistence", () => {
     });
 
     const footer = screen.getByTestId("agent-gui-sidebar-footer-slot");
+    const configFooter = screen.getByTestId("agent-gui-config-footer");
     const providerTileScrollArea = screen.getByRole("tablist", {
       name: "Switch provider"
     });
@@ -499,6 +500,7 @@ describe("AgentGUINodeView layout persistence", () => {
     expect(
       container.querySelector(".agent-gui-node__rail")
     ).not.toContainElement(footer);
+    expect(footer.nextElementSibling).toBe(configFooter);
     expect(renderSidebarFooter).toHaveBeenCalledWith({
       currentUserId: "user-1",
       activeConversation

--- a/packages/agent/gui/agent-gui/agentGuiNode/AgentGUINodeView.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/AgentGUINodeView.tsx
@@ -594,6 +594,17 @@ export function AgentGUINodeView({
               onUpdateConversationFilter={actions.updateConversationFilter}
               onRequestComposerFocus={requestComposerFocus}
             />
+            {renderSidebarFooter ? (
+              <div
+                className={`${styles.providerRailFooter} ${styles.providerRailSidebarFooter} nodrag tsh-desktop-no-drag`}
+                data-testid="agent-gui-sidebar-footer-slot"
+              >
+                {renderSidebarFooter({
+                  currentUserId: viewModel.shell.currentUserId,
+                  activeConversation: viewModel.rail.activeConversation
+                })}
+              </div>
+            ) : null}
             {shouldShowProviderRailConfigButton ? (
               <div
                 className={`${styles.providerRailFooter} ${styles.providerRailConfigFooter} nodrag tsh-desktop-no-drag`}
@@ -637,17 +648,6 @@ export function AgentGUINodeView({
                     />
                   </button>
                 )}
-              </div>
-            ) : null}
-            {renderSidebarFooter ? (
-              <div
-                className={`${styles.providerRailFooter} ${styles.providerRailSidebarFooter} nodrag tsh-desktop-no-drag`}
-                data-testid="agent-gui-sidebar-footer-slot"
-              >
-                {renderSidebarFooter({
-                  currentUserId: viewModel.shell.currentUserId,
-                  activeConversation: viewModel.rail.activeConversation
-                })}
               </div>
             ) : null}
           </aside>

--- a/packages/agent/gui/app/renderer/agentactivity.css
+++ b/packages/agent/gui/app/renderer/agentactivity.css
@@ -8907,7 +8907,16 @@ html[data-theme="light"] [data-message-center-item-id].agent-gui-edge-glow {
 }
 
 .agent-gui-node__provider-rail-sidebar-footer {
+  padding-bottom: 0;
+}
+
+.agent-gui-node__provider-rail-sidebar-footer:last-child {
   padding-bottom: 12px;
+}
+
+.agent-gui-node__provider-rail-sidebar-footer
+  + .agent-gui-node__provider-rail-config-footer {
+  margin-top: 8px;
 }
 
 .agent-gui-node__provider-rail-config-button {

--- a/packages/agent/gui/workbench/contribution.test.ts
+++ b/packages/agent/gui/workbench/contribution.test.ts
@@ -1797,6 +1797,14 @@ describe("agent GUI workbench contribution copy", () => {
     );
   });
 
+  it("separates the injected provider rail footer from settings", () => {
+    const css = readFileSync(resolve("app/renderer/agentactivity.css"), "utf8");
+
+    expect(css).toMatch(
+      /\.agent-gui-node__provider-rail-sidebar-footer\s*\+\s*\.agent-gui-node__provider-rail-config-footer\s*\{[^}]*margin-top:\s*8px;/s
+    );
+  });
+
   it("keeps provider manager drag hit boxes stable while previewing insertion", () => {
     const css = readFileSync(resolve("app/renderer/agentactivity.css"), "utf8");
 


### PR DESCRIPTION
## Summary

- render the host-injected provider rail footer above the settings control
- add an explicit 8px gap between the injected footer and settings
- preserve bottom-edge spacing when either footer is rendered alone
- add DOM-order and CSS-spacing regression coverage

## Verification

- `pnpm check:changed -- --tail-lines 80` (8 lanes passed)
- `pnpm --dir packages/agent/gui exec vitest run workbench/contribution.test.ts agent-gui/agentGuiNode/AgentGUINodeView.layout.spec.tsx --environment jsdom --maxWorkers=2` (190 tests passed)
- pre-commit formatting, Electron/UI/renderer boundary, and AgentGUI degradation checks passed
- `pnpm check:full` was attempted but stopped in the pre-existing `check:agent-gui-provider-catalog-generated` preflight: the OpenAPI provider schema was read as empty while the registry expected the current provider set

## Checklist

- [x] I kept the change focused on one concern.
- [x] I assessed documentation impact; no durable documentation update is needed for this local layout correction.
- [x] README/CONTRIBUTING language variants are not affected.
- [x] I ran the lowest meaningful local checks for the changed surface.
- [x] My commit is signed off with DCO: `git commit -s`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Moves the host-injected provider rail footer above the settings control in the sidebar to fix layout order and spacing. Adds an 8px gap between the two and preserves bottom padding when either appears alone.

- **Bug Fixes**
  - Render sidebar footer before the settings control to correct DOM order.
  - Add 8px margin between the injected footer and settings; keep 12px bottom padding when a single footer is present.
  - Add tests to cover DOM order and CSS spacing.

<sup>Written for commit 5c5a5bf7d57d25c10bd9af08d90e841c23a1999a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tutti-os/tutti/pull/1140?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

