### PR TITLE
fix(workspace-files): preserve search relevance order

### DIFF
--- a/apps/desktop/src/renderer/src/features/workspace-agent/services/internal/wrapDesktopFileMentionProviderWithDockFiles.test.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-agent/services/internal/wrapDesktopFileMentionProviderWithDockFiles.test.ts
@@ -66,24 +66,24 @@ test("wrapDesktopFileMentionProviderWithDockFiles returns dock files for blank q
   ]);
 });
 
-test("wrapDesktopFileMentionProviderWithDockFiles prioritizes matching dock files in search", async () => {
+test("wrapDesktopFileMentionProviderWithDockFiles preserves provider relevance for non-blank searches", async () => {
   const provider = wrapDesktopFileMentionProviderWithDockFiles(
-    createTestFileProvider(async ({ keyword }) =>
-      keyword.includes("notes")
-        ? [
-            {
-              displayName: "notes.md",
-              path: "/workspace/docs/notes.md"
-            }
-          ]
-        : []
-    ),
+    createTestFileProvider(async () => [
+      {
+        displayName: "user",
+        path: "/Users/Sun/user"
+      },
+      {
+        displayName: "USER.md",
+        path: "/Users/Sun/docs/USER.md"
+      }
+    ]),
     {
       resolveDockFiles: () => [
         {
-          displayName: "README.md",
+          displayName: "renderer.js",
           kind: "file",
-          path: "/workspace/README.md",
+          path: "/Users/Sun/project/renderer.js",
           previewCacheKey
         }
       ]
@@ -91,17 +91,19 @@ test("wrapDesktopFileMentionProviderWithDockFiles prioritizes matching dock file
   );
 
   const items = await provider.query({
-    keyword: "readme",
+    keyword: "user",
     context: {},
     trigger: "@"
   });
 
   assert.deepEqual(items, [
     {
-      displayName: "README.md",
-      kind: "file",
-      path: "/workspace/README.md",
-      previewCacheKey
+      displayName: "user",
+      path: "/Users/Sun/user"
+    },
+    {
+      displayName: "USER.md",
+      path: "/Users/Sun/docs/USER.md"
     }
   ]);
 });

--- a/apps/desktop/src/renderer/src/features/workspace-agent/services/internal/wrapDesktopFileMentionProviderWithDockFiles.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-agent/services/internal/wrapDesktopFileMentionProviderWithDockFiles.ts
@@ -31,24 +31,14 @@ export function wrapDesktopFileMentionProviderWithDockFiles<TItem>(
       });
 
       if (!keyword) {
-        return filterDockFiles(allDockFiles, input.maxResults) as unknown as
+        return limitDockFiles(allDockFiles, input.maxResults) as unknown as
           | readonly TItem[]
           | Promise<readonly TItem[]>;
       }
 
-      const [dockMatches, searchResults] = await Promise.all([
-        Promise.resolve(
-          filterDockFiles(allDockFiles, input.maxResults, keyword)
-        ),
-        Promise.resolve(provider.query(input))
-      ]);
-      const merged = mergeDockAndSearchResults({
-        dockMatches: dockMatches as unknown as readonly TItem[],
-        getItemKey: provider.getItemKey,
-        maxResults: input.maxResults,
-        searchResults
-      });
-      return merged;
+      // The daemon-backed provider owns ranked search results. Dock files are
+      // a browse source and thumbnail cache, not a second relevance model.
+      return provider.query(input);
     },
     getItemIconUrl(item) {
       const path = provider.getItemKey(item);
@@ -89,51 +79,9 @@ async function hydrateDockFileThumbnails(input: {
   );
 }
 
-function filterDockFiles(
+function limitDockFiles(
   dockFiles: readonly WorkbenchDockFileMentionItem[],
-  maxResults?: number,
-  keyword?: string
+  maxResults?: number
 ): WorkbenchDockFileMentionItem[] {
-  const normalizedKeyword = keyword?.trim().toLowerCase() ?? "";
-  const filtered = normalizedKeyword
-    ? dockFiles.filter((item) =>
-        matchesDockFileKeyword(item, normalizedKeyword)
-      )
-    : dockFiles;
-  return filtered.slice(0, maxResults ?? filtered.length);
-}
-
-function matchesDockFileKeyword(
-  item: WorkbenchDockFileMentionItem,
-  keyword: string
-): boolean {
-  const haystack = `${item.displayName}\n${item.path}`.toLowerCase();
-  return keyword
-    .split(/\s+/)
-    .filter(Boolean)
-    .every((token) => haystack.includes(token));
-}
-
-function mergeDockAndSearchResults<TItem>(input: {
-  dockMatches: readonly TItem[];
-  getItemKey: (item: TItem) => string;
-  maxResults?: number;
-  searchResults: readonly TItem[];
-}): readonly TItem[] {
-  const seen = new Set<string>();
-  const merged: TItem[] = [];
-
-  for (const item of [...input.dockMatches, ...input.searchResults]) {
-    const key = input.getItemKey(item);
-    if (!key || seen.has(key)) {
-      continue;
-    }
-    seen.add(key);
-    merged.push(item);
-    if (input.maxResults !== undefined && merged.length >= input.maxResults) {
-      break;
-    }
-  }
-
-  return merged;
+  return dockFiles.slice(0, maxResults ?? dockFiles.length);
 }

--- a/docs/architecture/agent-reference-sources.md
+++ b/docs/architecture/agent-reference-sources.md
@@ -58,12 +58,37 @@ shared `ReferenceListBackend` / `createReferenceListSource` protocol. Local
 files wrap `WorkspaceFileReferenceAdapter` directly. Open, reveal, open-with,
 and preview operations remain source-owned and are delegated back to the host.
 
+## Search Relevance
+
+The daemon-backed source owns the ranked order for a non-empty local-file
+query. Shared picker controllers may deduplicate that response but must not
+re-sort it by node kind or label. Host-only collections such as open Dock files
+may provide the empty-query browse list and presentation metadata, but must not
+be prepended to ranked query results.
+
+Local-file queries are field-aware:
+
+- A query without path separators ranks exact basename, exact stem, name
+  prefix/substring/fuzzy matches, and only then parent-path matches.
+- A query with path separators is path intent. It ranks exact relative path,
+  path prefix, ordered path-segment matches, and then path fuzzy matches.
+- Logical or physical absolute paths inside the active local root are
+  normalized to that root before ranking. Paths outside the root are rejected.
+- A trailing separator denotes directory intent; it must not turn a same-stem
+  file into a directory match.
+
+The UI may display only the basename to conserve space. That presentation
+choice does not narrow the searchable fields and must not become a second
+ranking implementation.
+
 ## Invariants
 
 - Route every operation by `sourceId`; reject unknown sources.
 - Never derive hierarchy by splitting an opaque `nodeId`.
 - Keep node ids stable across repeated listings so selection and pagination can
   deduplicate safely.
+- Preserve source relevance order for search results; browsing order and search
+  order are distinct contracts.
 - Append cursor pages without reordering already loaded entries.
 - Hide unavailable sources before rendering their tabs or sidebar groups.
 - Expose only running workspace apps in the app-artifact sidebar; installed or

--- a/packages/workspace/file-reference/src/react/internal/reference/referenceSourcePickerController.test.ts
+++ b/packages/workspace/file-reference/src/react/internal/reference/referenceSourcePickerController.test.ts
@@ -522,6 +522,47 @@ test("search 在当前 tab 生效", async () => {
   );
 });
 
+test("search 保留 source 返回的相关性顺序", async () => {
+  const controller = createReferenceSourcePickerController({
+    aggregator: fakeAggregator({
+      tabs: tabsTwo,
+      children: {
+        [`workspace-file:${SOURCE_ROOT_NODE_ID}`]: {
+          entries: [],
+          nextCursor: null
+        }
+      },
+      search: {
+        "workspace-file:load_log": {
+          entries: [
+            file("workspace-file", "/Movies/load_log", "load_log"),
+            folder(
+              "workspace-file",
+              "/Music/downloaded_catalog_data",
+              "downloaded_catalog_data"
+            )
+          ],
+          nextCursor: null
+        }
+      }
+    }),
+    scope,
+    searchDebounceMs: 0
+  });
+
+  controller.open();
+  await flush();
+  controller.setSearchQuery("load_log");
+  await flush();
+
+  assert.deepEqual(
+    controller
+      .getSnapshot()
+      .bySource["workspace-file"]?.searchEntries.map((node) => node.ref.nodeId),
+    ["/Movies/load_log", "/Music/downloaded_catalog_data"]
+  );
+});
+
 test("setSearchQuery 把选中分组 nodeId 作为 withinNodeId 透传给 aggregator.search", async () => {
   const searchInputs: Array<{
     sourceId: string;

--- a/packages/workspace/file-reference/src/react/internal/reference/referenceSourcePickerController.ts
+++ b/packages/workspace/file-reference/src/react/internal/reference/referenceSourcePickerController.ts
@@ -14,6 +14,7 @@ import type {
 import { SOURCE_ROOT_NODE_ID } from "../../../core/referenceSourceAggregator.ts";
 import {
   appendReferencePage,
+  dedupeReferenceNodes,
   nodeRefKey,
   sortReferenceNodes
 } from "../../../core/referenceSourceUtils.ts";
@@ -461,7 +462,9 @@ export function createReferenceSourcePickerController(
         ...tab,
         isSearchLoading: false,
         isSearchLoadingMore: false,
-        searchEntries: sortReferenceNodes(result.entries),
+        // Search sources own relevance order. Browsing may group folders and
+        // sort names, but search must only deduplicate the ranked response.
+        searchEntries: dedupeReferenceNodes(result.entries),
         searchNextCursor: result.nextCursor ?? null,
         searchLimit: limit,
         // 本页返回数达到请求上限、且未触全局上限 → 认为可能还有更多(增长式分页启发式)。

--- a/packages/workspace/file-reference/src/react/internal/reference/useReferenceSourcePickerView.test.ts
+++ b/packages/workspace/file-reference/src/react/internal/reference/useReferenceSourcePickerView.test.ts
@@ -197,6 +197,89 @@ test("reference source picker shows html source as text", async () => {
   }
 });
 
+test("reference source picker keeps search relevance independent of browse arrangement", async () => {
+  const dom = new JSDOM('<!doctype html><div id="root"></div>');
+  const previousWindow = globalThis.window;
+  const previousDocument = globalThis.document;
+  const previousHTMLElement = globalThis.HTMLElement;
+  const previousActEnvironment = (
+    globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }
+  ).IS_REACT_ACT_ENVIRONMENT;
+  globalThis.window = dom.window;
+  globalThis.document = dom.window.document;
+  globalThis.HTMLElement = dom.window.HTMLElement;
+  (
+    globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }
+  ).IS_REACT_ACT_ENVIRONMENT = true;
+
+  let root: Root | null = null;
+  try {
+    const container = dom.window.document.getElementById("root");
+    assert.ok(container);
+
+    const exactFile = file("/workspace/load_log", "load_log");
+    const fuzzyFolder: ReferenceNode = {
+      displayName: "downloaded_catalog_data",
+      kind: "folder",
+      ref: {
+        nodeId: "/workspace/downloaded_catalog_data",
+        sourceId: "workspace-file"
+      }
+    };
+    const baseAggregator = createOpenWithAggregator(async () => []);
+    const aggregator: ReferenceSourceAggregator = {
+      ...baseAggregator,
+      search: async () => ({
+        entries: [exactFile, fuzzyFolder],
+        nextCursor: null
+      })
+    };
+    let latestView: PickerView | null = null;
+
+    function Harness() {
+      latestView = useReferenceSourcePickerView({
+        aggregator,
+        onClose() {},
+        onConfirm() {},
+        open: true,
+        workspaceId: "workspace-reference-search-order",
+        workspaceRootGroupLabel: "Workspace"
+      });
+      return null;
+    }
+
+    root = createRoot(container);
+    await act(async () => {
+      root?.render(createElement(Harness));
+    });
+    await act(async () => {
+      const view = requireLatestView(latestView);
+      view.setArrangeMode("name");
+      view.setSearchQuery("load_log");
+      await new Promise((resolve) => setTimeout(resolve, 220));
+    });
+
+    assert.deepEqual(
+      requireLatestView(latestView).searchResults.map(
+        (node) => node.ref.nodeId
+      ),
+      [exactFile.ref.nodeId, fuzzyFolder.ref.nodeId]
+    );
+  } finally {
+    if (root) {
+      await act(async () => {
+        root?.unmount();
+      });
+    }
+    globalThis.window = previousWindow;
+    globalThis.document = previousDocument;
+    globalThis.HTMLElement = previousHTMLElement;
+    (
+      globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }
+    ).IS_REACT_ACT_ENVIRONMENT = previousActEnvironment;
+  }
+});
+
 function createOpenWithAggregator(
   listOpenWithApplications: ReferenceSourceAggregator["listOpenWithApplications"]
 ): ReferenceSourceAggregator {

--- a/packages/workspace/file-reference/src/react/internal/reference/useReferenceSourcePickerView.ts
+++ b/packages/workspace/file-reference/src/react/internal/reference/useReferenceSourcePickerView.ts
@@ -291,8 +291,10 @@ export function useReferenceSourcePickerView({
     [currentChildren?.entries, sortNodes]
   );
   const searchResults = useMemo(
-    () => sortNodes(activeTabState?.searchEntries ?? []),
-    [activeTabState?.searchEntries, sortNodes]
+    // Browse arrangement is a presentation preference. Search results keep the
+    // source-owned relevance order regardless of that preference.
+    () => [...(activeTabState?.searchEntries ?? [])] as ReferenceNode[],
+    [activeTabState?.searchEntries]
   );
 
   // 每个源的左栏二级分组(左栏可多源同时展开,故按源全量计算):

--- a/packages/workspace/files/search.go
+++ b/packages/workspace/files/search.go
@@ -18,6 +18,12 @@ const (
 	searchDepthPenalty         = 120
 	searchHiddenSegmentPenalty = 8000
 	searchNoiseSegmentPenalty  = 16000
+
+	// Ranking compares the discrete match tier before fuzzy quality. The
+	// transport score encodes that tuple only after ordering has been decided.
+	searchRankScoreStep  = 1_000_000
+	searchRankQualityMax = searchRankScoreStep - 1
+	searchRankTierCount  = 8
 )
 
 var searchNoiseSegments = map[string]struct{}{
@@ -46,6 +52,8 @@ type normalizedSearchTerm struct {
 type normalizedSearchQuery struct {
 	term          normalizedSearchTerm
 	hasPathIntent bool
+	outsideRoot   bool
+	path          string
 	pathTerms     []normalizedSearchTerm
 	trailingSlash bool
 }
@@ -63,13 +71,31 @@ type searchCandidateContext struct {
 
 type scoredSearchMatch struct {
 	indices []int
-	score   int
+	quality int
 	target  SearchMatchTarget
+	tier    int
 }
 
 type textMatchResult struct {
 	indices []int
-	score   int
+	quality int
+	kind    textMatchKind
+}
+
+type textMatchKind int
+
+const (
+	textMatchExact textMatchKind = iota
+	textMatchPrefix
+	textMatchSubstring
+	textMatchFuzzy
+)
+
+type pathSequenceChoice struct {
+	indices          []int
+	lastSegmentIndex int
+	ok               bool
+	quality          int
 }
 
 func NormalizeSearchLimit(limit int) int {
@@ -170,15 +196,15 @@ func NormalizeSearchKinds(kinds []EntryKind) ([]EntryKind, error) {
 }
 
 func ScoreSearchCandidates(root LogicalPath, query string, candidates []SearchCandidate, limit int) []SearchEntry {
-	normalizedQuery := normalizeSearchQuery(query)
-	if normalizedQuery.term.normalized == "" {
+	normalizedQuery := normalizeSearchQuery(root, query)
+	if normalizedQuery.outsideRoot || normalizedQuery.term.normalized == "" {
 		return []SearchEntry{}
 	}
 
 	limit = NormalizeSearchLimit(limit)
 	type scoredEntry struct {
 		entry SearchEntry
-		score int
+		rank  scoredSearchMatch
 	}
 	scored := make([]scoredEntry, 0, len(candidates))
 	for _, candidate := range candidates {
@@ -197,8 +223,9 @@ func ScoreSearchCandidates(root LogicalPath, query string, candidates []SearchCa
 			continue
 		}
 		logicalPath := LogicalPath(path.Join(root.String(), relativePath))
+		transportScore := searchScoreForRank(match)
 		scored = append(scored, scoredEntry{
-			score: match.score,
+			rank: match,
 			entry: SearchEntry{
 				Path:          logicalPath,
 				Name:          path.Base(relativePath),
@@ -206,14 +233,17 @@ func ScoreSearchCandidates(root LogicalPath, query string, candidates []SearchCa
 				DirectoryPath: LogicalPathDir(logicalPath),
 				MatchIndices:  match.indices,
 				MatchTarget:   match.target,
-				Score:         match.score,
+				Score:         transportScore,
 			},
 		})
 	}
 
 	sort.SliceStable(scored, func(i, j int) bool {
-		if scored[i].score != scored[j].score {
-			return scored[i].score > scored[j].score
+		if scored[i].rank.tier != scored[j].rank.tier {
+			return scored[i].rank.tier < scored[j].rank.tier
+		}
+		if scored[i].rank.quality != scored[j].rank.quality {
+			return scored[i].rank.quality > scored[j].rank.quality
 		}
 		if scored[i].entry.Name != scored[j].entry.Name {
 			return scored[i].entry.Name < scored[j].entry.Name
@@ -230,11 +260,43 @@ func ScoreSearchCandidates(root LogicalPath, query string, candidates []SearchCa
 	return entries
 }
 
-func normalizeSearchQuery(query string) normalizedSearchQuery {
+func normalizeSearchQuery(root LogicalPath, query string) normalizedSearchQuery {
 	normalizedPath := strings.ToLower(strings.TrimSpace(strings.ReplaceAll(query, "\\", "/")))
-	term := normalizeSearchTerm(strings.ReplaceAll(normalizedPath, "/", " "))
-	pathTerms := make([]normalizedSearchTerm, 0, strings.Count(normalizedPath, "/")+1)
-	for _, part := range strings.Split(normalizedPath, "/") {
+	if normalizedPath == "" {
+		return normalizedSearchQuery{}
+	}
+
+	hasPathIntent := strings.Contains(normalizedPath, "/") || isWindowsAbsoluteSearchPath(normalizedPath)
+	trailingSlash := strings.HasSuffix(normalizedPath, "/")
+	outsideRoot := false
+	pathQuery := normalizedPath
+
+	if strings.HasPrefix(pathQuery, "~/") {
+		pathQuery = strings.TrimPrefix(pathQuery, "~/")
+	} else if isAbsoluteSearchPath(pathQuery) {
+		logicalRoot := strings.ToLower(NormalizeLogicalRoot(root.String()).String())
+		canonicalQuery := canonicalAbsoluteSearchPath(pathQuery)
+		if logicalRoot == "/" {
+			pathQuery = strings.TrimPrefix(canonicalQuery, "/")
+		} else if canonicalQuery == logicalRoot {
+			pathQuery = ""
+		} else if strings.HasPrefix(canonicalQuery, logicalRoot+"/") {
+			pathQuery = strings.TrimPrefix(canonicalQuery, logicalRoot+"/")
+		} else {
+			outsideRoot = true
+		}
+	}
+
+	pathQuery = path.Clean(pathQuery)
+	if pathQuery == "." {
+		pathQuery = ""
+	} else if pathQuery == ".." || strings.HasPrefix(pathQuery, "../") {
+		outsideRoot = true
+	}
+	pathQuery = strings.Trim(pathQuery, "/")
+	term := normalizeSearchTerm(strings.ReplaceAll(pathQuery, "/", " "))
+	pathTerms := make([]normalizedSearchTerm, 0, strings.Count(pathQuery, "/")+1)
+	for _, part := range strings.Split(pathQuery, "/") {
 		termPart := normalizeSearchTerm(part)
 		if termPart.normalized == "" {
 			continue
@@ -243,9 +305,11 @@ func normalizeSearchQuery(query string) normalizedSearchQuery {
 	}
 	return normalizedSearchQuery{
 		term:          term,
-		hasPathIntent: strings.Contains(normalizedPath, "/"),
+		hasPathIntent: hasPathIntent,
+		outsideRoot:   outsideRoot,
+		path:          pathQuery,
 		pathTerms:     pathTerms,
-		trailingSlash: strings.HasSuffix(normalizedPath, "/"),
+		trailingSlash: trailingSlash,
 	}
 }
 
@@ -254,13 +318,47 @@ func scoreSearchCandidate(query normalizedSearchQuery, candidate SearchCandidate
 
 	var match scoredSearchMatch
 	var ok bool
-	match, ok = scoreFilenameCandidate(query.term, context)
+	if query.hasPathIntent {
+		match, ok = scorePathIntentCandidate(query, context)
+	} else {
+		match, ok = scoreNameIntentCandidate(query, context)
+	}
 	if !ok {
 		return scoredSearchMatch{}, false
 	}
-	match.score = applySearchPenalties(query, context, match.score)
+	match.quality = applySearchPenalties(query, context, match.quality)
 	match.indices = compactSortedIndices(match.indices)
 	return match, true
+}
+
+func searchScoreForRank(match scoredSearchMatch) int {
+	quality := match.quality
+	if quality < 0 {
+		quality = 0
+	}
+	if quality > searchRankQualityMax {
+		quality = searchRankQualityMax
+	}
+	tierWeight := searchRankTierCount - match.tier
+	if tierWeight < 0 {
+		tierWeight = 0
+	}
+	return tierWeight*searchRankScoreStep + quality
+}
+
+func isAbsoluteSearchPath(value string) bool {
+	return strings.HasPrefix(value, "/") || isWindowsAbsoluteSearchPath(value)
+}
+
+func isWindowsAbsoluteSearchPath(value string) bool {
+	return len(value) >= 3 && value[1] == ':' && value[2] == '/'
+}
+
+func canonicalAbsoluteSearchPath(value string) string {
+	if isWindowsAbsoluteSearchPath(value) {
+		value = "/" + value
+	}
+	return path.Clean(value)
 }
 
 func createSearchCandidateContext(candidate SearchCandidate) searchCandidateContext {
@@ -299,118 +397,290 @@ func trimSearchStem(value string) string {
 	return stem
 }
 
-func scoreFilenameCandidate(term normalizedSearchTerm, candidate searchCandidateContext) (scoredSearchMatch, bool) {
-	if isDotLiteralSearchTerm(term) {
-		return scoreDotLiteralFilenameCandidate(term.tokens[0], candidate)
+func scoreNameIntentCandidate(query normalizedSearchQuery, candidate searchCandidateContext) (scoredSearchMatch, bool) {
+	if match, ok := scoreFilenameCandidate(query.term, candidate); ok {
+		return match, true
 	}
+
+	match, ok := scoreBestParentPathSegment(query.term, candidate)
+	if !ok {
+		return scoredSearchMatch{}, false
+	}
+	switch textMatchKind(match.tier) {
+	case textMatchExact:
+		match.tier = 5
+	case textMatchPrefix, textMatchSubstring:
+		match.tier = 6
+	default:
+		match.tier = 7
+	}
+	return match, true
+}
+
+func scorePathIntentCandidate(query normalizedSearchQuery, candidate searchCandidateContext) (scoredSearchMatch, bool) {
+	if query.path == "" {
+		return scoredSearchMatch{}, false
+	}
+	if candidate.relativePath == query.path && (!query.trailingSlash || candidate.kind == EntryKindDirectory) {
+		return scoredSearchMatch{
+			indices: sequentialSearchIndices(len(query.path)),
+			quality: searchRankQualityMax - len(candidate.relativePath),
+			target:  SearchMatchTargetPath,
+			tier:    0,
+		}, true
+	}
+	if strings.HasPrefix(candidate.relativePath, query.path) &&
+		(!query.trailingSlash || strings.HasPrefix(candidate.relativePath, query.path+"/")) {
+		return scoredSearchMatch{
+			indices: sequentialSearchIndices(len(query.path)),
+			quality: searchRankQualityMax - len(candidate.relativePath),
+			target:  SearchMatchTargetPath,
+			tier:    1,
+		}, true
+	}
+	if choice, ok := scorePathTermSequence(query.pathTerms, candidate.segments, query.trailingSlash); ok {
+		if query.trailingSlash &&
+			candidate.kind != EntryKindDirectory &&
+			choice.lastSegmentIndex == len(candidate.segments)-1 {
+			return scoredSearchMatch{}, false
+		}
+		return scoredSearchMatch{
+			indices: choice.indices,
+			quality: choice.quality / len(query.pathTerms),
+			target:  SearchMatchTargetPath,
+			tier:    2,
+		}, true
+	}
+	if !query.trailingSlash {
+		compactQuery := strings.ReplaceAll(query.path, "/", "")
+		if start, span, gaps, indices, ok := subsequenceMatch(candidate.relativePath, compactQuery); ok {
+			return scoredSearchMatch{
+				indices: indices,
+				quality: fuzzySearchQuality(start, span, gaps, len(candidate.relativePath)),
+				target:  SearchMatchTargetPath,
+				tier:    3,
+			}, true
+		}
+	}
+	return scoredSearchMatch{}, false
+}
+
+func scoreFilenameCandidate(term normalizedSearchTerm, candidate searchCandidateContext) (scoredSearchMatch, bool) {
 	if !candidateContainsFilenameDotLiteralTokens(term, candidate) {
 		return scoredSearchMatch{}, false
 	}
 
-	best := scoredSearchMatch{}
-	bestOk := false
-
-	if result, ok := scoreTextMatch(term, candidate.stem, 1000000, 930000, 60000); ok {
-		best = scoredSearchMatch{
-			indices: result.indices,
-			score:   result.score,
+	if searchTermEqualsTarget(term, candidate.basename) {
+		return scoredSearchMatch{
+			indices: sequentialSearchIndices(len(candidate.basename)),
+			quality: searchRankQualityMax - len(candidate.basename),
 			target:  SearchMatchTargetBasename,
-		}
-		bestOk = true
+			tier:    0,
+		}, true
 	}
-	if candidate.basename != candidate.stem {
-		if result, ok := scoreTextMatch(term, candidate.basename, 970000, 900000, 45000); ok && (!bestOk || result.score > best.score) {
-			best = scoredSearchMatch{
-				indices: result.indices,
-				score:   result.score,
-				target:  SearchMatchTargetBasename,
-			}
-			bestOk = true
-		}
+	if candidate.basename != candidate.stem && searchTermEqualsTarget(term, candidate.stem) {
+		return scoredSearchMatch{
+			indices: sequentialSearchIndices(len(candidate.stem)),
+			quality: searchRankQualityMax - len(candidate.basename),
+			target:  SearchMatchTargetBasename,
+			tier:    1,
+		}, true
 	}
 
-	return best, bestOk
+	best := scoredSearchMatch{}
+	bestOK := false
+	for _, target := range []string{candidate.stem, candidate.basename} {
+		result, ok := classifyTextMatch(term, target)
+		if !ok || result.kind == textMatchExact {
+			continue
+		}
+		tier := 4
+		switch result.kind {
+		case textMatchPrefix:
+			tier = 2
+		case textMatchSubstring:
+			tier = 3
+		case textMatchFuzzy:
+			tier = 4
+		}
+		match := scoredSearchMatch{
+			indices: result.indices,
+			quality: result.quality,
+			target:  SearchMatchTargetBasename,
+			tier:    tier,
+		}
+		if !bestOK || match.tier < best.tier || (match.tier == best.tier && match.quality > best.quality) {
+			best = match
+			bestOK = true
+		}
+	}
+	return best, bestOK
 }
 
-func scoreDotLiteralFilenameCandidate(literal string, candidate searchCandidateContext) (scoredSearchMatch, bool) {
-	index := strings.Index(candidate.basename, literal)
-	if index < 0 {
+func scoreBestParentPathSegment(term normalizedSearchTerm, candidate searchCandidateContext) (scoredSearchMatch, bool) {
+	if len(candidate.segments) <= 1 {
 		return scoredSearchMatch{}, false
 	}
-
-	score := 980000 - (index * 1000) - len(candidate.basename)
-	if strings.HasSuffix(candidate.basename, literal) {
-		score += 30000
+	best := scoredSearchMatch{}
+	bestOK := false
+	for index, segment := range candidate.segments[:len(candidate.segments)-1] {
+		result, ok := classifyTextMatch(term, segment)
+		if !ok {
+			continue
+		}
+		match := scoredSearchMatch{
+			indices: pathIndicesForSegment(candidate.segments, index, result.indices),
+			quality: result.quality - index*3000,
+			target:  SearchMatchTargetPath,
+			tier:    int(result.kind),
+		}
+		if !bestOK || match.tier < best.tier || (match.tier == best.tier && match.quality > best.quality) {
+			best = match
+			bestOK = true
+		}
 	}
-	if candidate.basename == literal {
-		score += 60000
-	}
-	if index == 0 {
-		score += 15000
-	}
-
-	indices := make([]int, 0, len(literal))
-	for offset := 0; offset < len(literal); offset++ {
-		indices = append(indices, index+offset)
-	}
-	return scoredSearchMatch{
-		indices: indices,
-		score:   score,
-		target:  SearchMatchTargetBasename,
-	}, true
+	return best, bestOK
 }
 
-func scoreTextMatch(term normalizedSearchTerm, target string, orderedBase int, subsequenceBase int, prefixBonus int) (textMatchResult, bool) {
+func scorePathTermSequence(terms []normalizedSearchTerm, segments []string, requireFinalExact bool) (pathSequenceChoice, bool) {
+	if len(terms) == 0 {
+		return pathSequenceChoice{}, false
+	}
+	memo := map[[2]int]pathSequenceChoice{}
+	var visit func(termIndex int, segmentIndex int) pathSequenceChoice
+	visit = func(termIndex int, segmentIndex int) pathSequenceChoice {
+		if termIndex == len(terms) {
+			return pathSequenceChoice{lastSegmentIndex: -1, ok: true}
+		}
+		key := [2]int{termIndex, segmentIndex}
+		if cached, ok := memo[key]; ok {
+			return cached
+		}
+
+		best := pathSequenceChoice{}
+		for index := segmentIndex; index < len(segments); index++ {
+			result, ok := scorePathSegmentTerm(
+				terms[termIndex],
+				segments[index],
+				requireFinalExact && termIndex == len(terms)-1,
+			)
+			if !ok {
+				continue
+			}
+			next := visit(termIndex+1, index+1)
+			if !next.ok {
+				continue
+			}
+			quality := result.quality + next.quality - (index-segmentIndex)*4000
+			choice := pathSequenceChoice{
+				indices: append(
+					pathIndicesForSegment(segments, index, result.indices),
+					next.indices...,
+				),
+				lastSegmentIndex: index,
+				ok:               true,
+				quality:          quality,
+			}
+			if next.lastSegmentIndex >= 0 {
+				choice.lastSegmentIndex = next.lastSegmentIndex
+			}
+			if !best.ok || choice.quality > best.quality {
+				best = choice
+			}
+		}
+		memo[key] = best
+		return best
+	}
+	result := visit(0, 0)
+	return result, result.ok
+}
+
+func scorePathSegmentTerm(term normalizedSearchTerm, segment string, requireExact bool) (textMatchResult, bool) {
+	best := textMatchResult{}
+	bestOK := false
+	targets := []string{trimSearchStem(segment), segment}
+	if requireExact {
+		targets = []string{segment}
+	}
+	for _, target := range targets {
+		result, ok := classifyTextMatch(term, target)
+		if !ok || (requireExact && result.kind != textMatchExact) {
+			continue
+		}
+		if !bestOK || result.kind < best.kind || (result.kind == best.kind && result.quality > best.quality) {
+			best = result
+			bestOK = true
+		}
+	}
+	return best, bestOK
+}
+
+func classifyTextMatch(term normalizedSearchTerm, target string) (textMatchResult, bool) {
 	if term.normalized == "" || target == "" {
 		return textMatchResult{}, false
 	}
-
-	best := textMatchResult{}
-	bestOk := false
+	if searchTermEqualsTarget(term, target) {
+		return textMatchResult{
+			indices: sequentialSearchIndices(len(target)),
+			quality: searchRankQualityMax - len(target),
+			kind:    textMatchExact,
+		}, true
+	}
 	if start, span, indices, ok := orderedTokenMatch(target, term.tokens); ok {
-		score := orderedBase - (start * 1200) - (span * 25) - len(target)
+		kind := textMatchSubstring
 		if start == 0 {
-			score += prefixBonus
+			kind = textMatchPrefix
 		}
-		if term.normalized == target || term.compact == target {
-			score += prefixBonus / 2
-		}
-		if span == len(target) {
-			score += prefixBonus / 3
-		}
-		best = textMatchResult{
+		return textMatchResult{
 			indices: indices,
-			score:   score,
-		}
-		bestOk = true
+			quality: orderedSearchQuality(start, span, len(target)),
+			kind:    kind,
+		}, true
 	}
 	if start, span, gaps, indices, ok := subsequenceMatch(target, term.compact); ok {
-		score := subsequenceBase - (start * 1000) - (gaps * 160) - (span * 35) - len(target)
-		if start == 0 {
-			score += prefixBonus / 2
-		}
-		if !bestOk || score > best.score {
-			best = textMatchResult{
-				indices: indices,
-				score:   score,
-			}
-			bestOk = true
-		}
+		return textMatchResult{
+			indices: indices,
+			quality: fuzzySearchQuality(start, span, gaps, len(target)),
+			kind:    textMatchFuzzy,
+		}, true
 	}
-	return best, bestOk
+	return textMatchResult{}, false
 }
 
-func applySearchPenalties(query normalizedSearchQuery, candidate searchCandidateContext, score int) int {
+func searchTermEqualsTarget(term normalizedSearchTerm, target string) bool {
+	return term.normalized == target || term.compact == target
+}
+
+func orderedSearchQuality(start int, span int, targetLength int) int {
+	return searchRankQualityMax - start*1200 - span*25 - targetLength
+}
+
+func fuzzySearchQuality(start int, span int, gaps int, targetLength int) int {
+	return 750000 - start*1000 - gaps*160 - span*35 - targetLength
+}
+
+func sequentialSearchIndices(length int) []int {
+	indices := make([]int, length)
+	for index := range indices {
+		indices[index] = index
+	}
+	return indices
+}
+
+func applySearchPenalties(query normalizedSearchQuery, candidate searchCandidateContext, quality int) int {
 	hiddenPenalty := candidate.hiddenSegments * searchHiddenSegmentPenalty
 	noisePenalty := candidate.noiseSegments * searchNoiseSegmentPenalty
 	if searchQueryTargetsHiddenOrNoise(query) {
 		hiddenPenalty /= 4
 		noisePenalty /= 4
 	}
-	score -= candidate.depth * searchDepthPenalty
-	score -= hiddenPenalty
-	score -= noisePenalty
-	return score
+	quality -= candidate.depth * searchDepthPenalty
+	quality -= hiddenPenalty
+	quality -= noisePenalty
+	if quality < 0 {
+		return 0
+	}
+	return quality
 }
 
 func searchQueryTargetsHiddenOrNoise(query normalizedSearchQuery) bool {
@@ -449,11 +719,11 @@ func searchPathTermTargetsHiddenOrNoiseDirectory(term normalizedSearchTerm, inde
 }
 
 func SearchQueryTargetsHiddenOrNoise(query string) bool {
-	return searchQueryTargetsHiddenOrNoise(normalizeSearchQuery(query))
+	return searchQueryTargetsHiddenOrNoise(normalizeSearchQuery(DefaultLogicalRoot, query))
 }
 
 func SearchQueryTargetsHiddenFile(query string) bool {
-	normalizedQuery := normalizeSearchQuery(query)
+	normalizedQuery := normalizeSearchQuery(DefaultLogicalRoot, query)
 	for _, token := range normalizedQuery.term.tokens {
 		if isDotLiteralToken(token) {
 			return true
@@ -469,10 +739,6 @@ func normalizeSearchTerm(value string) normalizedSearchTerm {
 		compact:    strings.Join(tokens, ""),
 		tokens:     tokens,
 	}
-}
-
-func isDotLiteralSearchTerm(term normalizedSearchTerm) bool {
-	return len(term.tokens) == 1 && isDotLiteralToken(term.tokens[0])
 }
 
 func isDotLiteralToken(token string) bool {
@@ -497,79 +763,6 @@ func isFilenameDotLiteralToken(token string) bool {
 	}
 	_, isNoiseSegment := searchNoiseSegments[token]
 	return !isNoiseSegment
-}
-
-func orderedTokenMatch(target string, tokens []string) (int, int, []int, bool) {
-	if len(tokens) == 0 {
-		return 0, 0, nil, false
-	}
-	cursor := 0
-	first := -1
-	last := -1
-	indices := make([]int, 0, len(target))
-	for _, token := range tokens {
-		index := strings.Index(target[cursor:], token)
-		if index < 0 {
-			return 0, 0, nil, false
-		}
-		position := cursor + index
-		if first < 0 {
-			first = position
-		}
-		last = position + len(token)
-		for tokenIndex := 0; tokenIndex < len(token); tokenIndex++ {
-			indices = append(indices, position+tokenIndex)
-		}
-		cursor = last
-	}
-	return first, last - first, indices, true
-}
-
-func subsequenceMatch(target string, query string) (int, int, int, []int, bool) {
-	if query == "" {
-		return 0, 0, 0, nil, false
-	}
-	first := -1
-	last := -1
-	previous := -1
-	gaps := 0
-	queryIndex := 0
-	indices := make([]int, 0, len(query))
-	for targetIndex := 0; targetIndex < len(target) && queryIndex < len(query); targetIndex++ {
-		if target[targetIndex] != query[queryIndex] {
-			continue
-		}
-		if first < 0 {
-			first = targetIndex
-		}
-		if previous >= 0 {
-			gaps += targetIndex - previous - 1
-		}
-		previous = targetIndex
-		last = targetIndex
-		indices = append(indices, targetIndex)
-		queryIndex++
-	}
-	if queryIndex != len(query) {
-		return 0, 0, 0, nil, false
-	}
-	return first, (last - first) + 1, gaps, indices, true
-}
-
-func compactSortedIndices(indices []int) []int {
-	if len(indices) == 0 {
-		return []int{}
-	}
-
-	sort.Ints(indices)
-	result := indices[:0]
-	for _, index := range indices {
-		if len(result) > 0 && result[len(result)-1] == index {
-			continue
-		}
-		result = append(result, index)
-	}
-	return append([]int(nil), result...)
 }
 
 func normalizeCandidateRelativePath(value string) string {

--- a/packages/workspace/files/search.go
+++ b/packages/workspace/files/search.go
@@ -266,13 +266,13 @@ func normalizeSearchQuery(root LogicalPath, query string) normalizedSearchQuery 
 		return normalizedSearchQuery{}
 	}
 
-	hasPathIntent := strings.Contains(normalizedPath, "/") || isWindowsAbsoluteSearchPath(normalizedPath)
+	hasPathIntent := strings.Contains(normalizedPath, "/")
 	trailingSlash := strings.HasSuffix(normalizedPath, "/")
 	outsideRoot := false
 	pathQuery := normalizedPath
 
 	if strings.HasPrefix(pathQuery, "~/") {
-		pathQuery = strings.TrimPrefix(pathQuery, "~/")
+		pathQuery = strings.TrimLeft(strings.TrimPrefix(pathQuery, "~/"), "/")
 	} else if isAbsoluteSearchPath(pathQuery) {
 		logicalRoot := strings.ToLower(NormalizeLogicalRoot(root.String()).String())
 		canonicalQuery := canonicalAbsoluteSearchPath(pathQuery)
@@ -400,6 +400,9 @@ func trimSearchStem(value string) string {
 func scoreNameIntentCandidate(query normalizedSearchQuery, candidate searchCandidateContext) (scoredSearchMatch, bool) {
 	if match, ok := scoreFilenameCandidate(query.term, candidate); ok {
 		return match, true
+	}
+	if searchTermContainsFilenameDotLiteral(query.term) {
+		return scoredSearchMatch{}, false
 	}
 
 	match, ok := scoreBestParentPathSegment(query.term, candidate)
@@ -763,6 +766,15 @@ func isFilenameDotLiteralToken(token string) bool {
 	}
 	_, isNoiseSegment := searchNoiseSegments[token]
 	return !isNoiseSegment
+}
+
+func searchTermContainsFilenameDotLiteral(term normalizedSearchTerm) bool {
+	for _, token := range term.tokens {
+		if isFilenameDotLiteralToken(token) {
+			return true
+		}
+	}
+	return false
 }
 
 func normalizeCandidateRelativePath(value string) string {

--- a/packages/workspace/files/search_match.go
+++ b/packages/workspace/files/search_match.go
@@ -1,0 +1,92 @@
+package workspacefiles
+
+import (
+	"sort"
+	"strings"
+)
+
+func orderedTokenMatch(target string, tokens []string) (int, int, []int, bool) {
+	if len(tokens) == 0 {
+		return 0, 0, nil, false
+	}
+	cursor := 0
+	first := -1
+	last := -1
+	indices := make([]int, 0, len(target))
+	for _, token := range tokens {
+		index := strings.Index(target[cursor:], token)
+		if index < 0 {
+			return 0, 0, nil, false
+		}
+		position := cursor + index
+		if first < 0 {
+			first = position
+		}
+		last = position + len(token)
+		for tokenIndex := 0; tokenIndex < len(token); tokenIndex++ {
+			indices = append(indices, position+tokenIndex)
+		}
+		cursor = last
+	}
+	return first, last - first, indices, true
+}
+
+func subsequenceMatch(target string, query string) (int, int, int, []int, bool) {
+	if query == "" {
+		return 0, 0, 0, nil, false
+	}
+	first := -1
+	last := -1
+	previous := -1
+	gaps := 0
+	queryIndex := 0
+	indices := make([]int, 0, len(query))
+	for targetIndex := 0; targetIndex < len(target) && queryIndex < len(query); targetIndex++ {
+		if target[targetIndex] != query[queryIndex] {
+			continue
+		}
+		if first < 0 {
+			first = targetIndex
+		}
+		if previous >= 0 {
+			gaps += targetIndex - previous - 1
+		}
+		previous = targetIndex
+		last = targetIndex
+		indices = append(indices, targetIndex)
+		queryIndex++
+	}
+	if queryIndex != len(query) {
+		return 0, 0, 0, nil, false
+	}
+	return first, (last - first) + 1, gaps, indices, true
+}
+
+func pathIndicesForSegment(segments []string, segmentIndex int, segmentIndices []int) []int {
+	offset := 0
+	for index := 0; index < segmentIndex; index++ {
+		offset += len(segments[index]) + 1
+	}
+
+	result := make([]int, 0, len(segmentIndices))
+	for _, matchIndex := range segmentIndices {
+		result = append(result, offset+matchIndex)
+	}
+	return result
+}
+
+func compactSortedIndices(indices []int) []int {
+	if len(indices) == 0 {
+		return []int{}
+	}
+
+	sort.Ints(indices)
+	result := indices[:0]
+	for _, index := range indices {
+		if len(result) > 0 && result[len(result)-1] == index {
+			continue
+		}
+		result = append(result, index)
+	}
+	return append([]int(nil), result...)
+}

--- a/packages/workspace/files/search_match.go
+++ b/packages/workspace/files/search_match.go
@@ -3,6 +3,7 @@ package workspacefiles
 import (
 	"sort"
 	"strings"
+	"unicode/utf8"
 )
 
 func orderedTokenMatch(target string, tokens []string) (int, int, []int, bool) {
@@ -35,31 +36,38 @@ func subsequenceMatch(target string, query string) (int, int, int, []int, bool) 
 	if query == "" {
 		return 0, 0, 0, nil, false
 	}
+	queryRunes := []rune(query)
 	first := -1
-	last := -1
-	previous := -1
+	lastEnd := -1
+	previousEnd := -1
 	gaps := 0
 	queryIndex := 0
 	indices := make([]int, 0, len(query))
-	for targetIndex := 0; targetIndex < len(target) && queryIndex < len(query); targetIndex++ {
-		if target[targetIndex] != query[queryIndex] {
+	for targetIndex, targetRune := range target {
+		if queryIndex >= len(queryRunes) {
+			break
+		}
+		if targetRune != queryRunes[queryIndex] {
 			continue
 		}
+		_, runeWidth := utf8.DecodeRuneInString(target[targetIndex:])
 		if first < 0 {
 			first = targetIndex
 		}
-		if previous >= 0 {
-			gaps += targetIndex - previous - 1
+		if previousEnd >= 0 {
+			gaps += targetIndex - previousEnd
 		}
-		previous = targetIndex
-		last = targetIndex
-		indices = append(indices, targetIndex)
+		for offset := 0; offset < runeWidth; offset++ {
+			indices = append(indices, targetIndex+offset)
+		}
+		previousEnd = targetIndex + runeWidth
+		lastEnd = previousEnd
 		queryIndex++
 	}
-	if queryIndex != len(query) {
+	if queryIndex != len(queryRunes) {
 		return 0, 0, 0, nil, false
 	}
-	return first, (last - first) + 1, gaps, indices, true
+	return first, lastEnd - first, gaps, indices, true
 }
 
 func pathIndicesForSegment(segments []string, segmentIndex int, segmentIndices []int) []int {

--- a/packages/workspace/files/search_test.go
+++ b/packages/workspace/files/search_test.go
@@ -57,6 +57,7 @@ func TestScoreSearchCandidatesRanksExactBasenameBeforeParentPathMatch(t *testing
 func TestScoreSearchCandidatesTreatsDotQueryAsLiteralFilenameFragment(t *testing.T) {
 	entries := ScoreSearchCandidates("/workspace", ".dmg", []SearchCandidate{
 		{Kind: EntryKindFile, RelativePath: ".agents/skills/baoyu-slide-deck/scripts/merge-to-pdf.ts"},
+		{Kind: EntryKindFile, RelativePath: ".dmg/readme.md"},
 		{Kind: EntryKindFile, RelativePath: "Downloads/googlechrome.dmg"},
 	}, 10)
 
@@ -68,6 +69,16 @@ func TestScoreSearchCandidatesTreatsDotQueryAsLiteralFilenameFragment(t *testing
 	}
 	if entries[0].MatchTarget != SearchMatchTargetBasename {
 		t.Fatalf("matchTarget = %q, want %q", entries[0].MatchTarget, SearchMatchTargetBasename)
+	}
+}
+
+func TestScoreSearchCandidatesRejectsEscapingHomeRelativePath(t *testing.T) {
+	entries := ScoreSearchCandidates("/workspace", "~//../secret", []SearchCandidate{
+		{Kind: EntryKindFile, RelativePath: "secret"},
+	}, 10)
+
+	if len(entries) != 0 {
+		t.Fatalf("entries = %#v, want no matches outside logical root", entries)
 	}
 }
 
@@ -306,6 +317,29 @@ func TestScoreSearchCandidatesLimitsAndFiltersInvalidCandidates(t *testing.T) {
 	}
 	if entries[0].Kind != EntryKindDirectory && entries[0].Kind != EntryKindFile {
 		t.Fatalf("unexpected kind %q", entries[0].Kind)
+	}
+}
+
+func TestSubsequenceMatchUsesUnicodeCodePointsAndByteOffsets(t *testing.T) {
+	if _, _, _, _, ok := subsequenceMatch("义市字", "中"); ok {
+		t.Fatal("subsequenceMatch() matched UTF-8 bytes across unrelated code points")
+	}
+
+	start, span, gaps, indices, ok := subsequenceMatch("甲中文", "中")
+	if !ok {
+		t.Fatal("subsequenceMatch() did not match an exact Unicode code point")
+	}
+	if start != 3 || span != 3 || gaps != 0 {
+		t.Fatalf("match metrics = (%d, %d, %d), want UTF-8 byte offsets (3, 3, 0)", start, span, gaps)
+	}
+	wantIndices := []int{3, 4, 5}
+	if len(indices) != len(wantIndices) {
+		t.Fatalf("indices = %#v, want %#v", indices, wantIndices)
+	}
+	for index := range wantIndices {
+		if indices[index] != wantIndices[index] {
+			t.Fatalf("indices = %#v, want %#v", indices, wantIndices)
+		}
 	}
 }
 

--- a/packages/workspace/files/search_test.go
+++ b/packages/workspace/files/search_test.go
@@ -37,14 +37,14 @@ func TestScoreSearchCandidatesSupportsMultiTokenBasenameQuery(t *testing.T) {
 	}
 }
 
-func TestScoreSearchCandidatesDoesNotMatchParentPathOnly(t *testing.T) {
+func TestScoreSearchCandidatesRanksExactBasenameBeforeParentPathMatch(t *testing.T) {
 	entries := ScoreSearchCandidates("/workspace", "New Project", []SearchCandidate{
 		{Kind: EntryKindDirectory, RelativePath: "Documents/New project/OpenCovibe/messages"},
 		{Kind: EntryKindDirectory, RelativePath: "Documents/New project"},
 	}, 10)
 
-	if len(entries) != 1 {
-		t.Fatalf("entries = %#v, want only basename match", entries)
+	if len(entries) != 2 {
+		t.Fatalf("entries = %#v, want basename and parent-path matches", entries)
 	}
 	if entries[0].Path != "/workspace/Documents/New project" {
 		t.Fatalf("entry = %#v, want New project directory only", entries[0])
@@ -138,15 +138,15 @@ func TestSearchQueryTargetsHiddenOrNoiseDoesNotTreatPathExtensionAsDirectoryInte
 	}
 }
 
-func TestScoreSearchCandidatesDoesNotMatchSlashQueryAgainstPath(t *testing.T) {
+func TestScoreSearchCandidatesMatchesSlashQueryAgainstRelativePath(t *testing.T) {
 	entries := ScoreSearchCandidates("/workspace", "tsh/", []SearchCandidate{
 		{Kind: EntryKindFile, RelativePath: ".agents/skills/lark-shared/SKILL.md"},
 		{Kind: EntryKindFile, RelativePath: "tools/tsh/runtime.md"},
 		{Kind: EntryKindFile, RelativePath: "notes/ts-helper/readme.md"},
 	}, 10)
 
-	if len(entries) != 0 {
-		t.Fatalf("entries = %#v, want no path-only matches", entries)
+	if len(entries) != 1 || entries[0].Path != "/workspace/tools/tsh/runtime.md" {
+		t.Fatalf("entries = %#v, want tools/tsh/runtime.md", entries)
 	}
 }
 
@@ -175,14 +175,14 @@ func TestScoreSearchCandidatesDoesNotMatchHiddenParentPath(t *testing.T) {
 	}
 }
 
-func TestScoreSearchCandidatesDoesNotMatchHiddenPathIntentQuery(t *testing.T) {
+func TestScoreSearchCandidatesMatchesExplicitHiddenPathIntentQuery(t *testing.T) {
 	entries := ScoreSearchCandidates("/workspace", ".git/conf", []SearchCandidate{
 		{Kind: EntryKindFile, RelativePath: ".git/config"},
 		{Kind: EntryKindFile, RelativePath: "configs/git.conf"},
 	}, 10)
 
-	if len(entries) != 0 {
-		t.Fatalf("entries = %#v, want no path-intent matches", entries)
+	if len(entries) == 0 || entries[0].Path != "/workspace/.git/config" {
+		t.Fatalf("entries = %#v, want explicit hidden path first", entries)
 	}
 }
 
@@ -207,23 +207,89 @@ func TestScoreSearchCandidatesPrefersDirectoryForTrailingSlashQuery(t *testing.T
 		{Kind: EntryKindDirectory, RelativePath: "src"},
 	}, 10)
 
-	if len(entries) < 2 {
-		t.Fatalf("entries length = %d, want at least 2", len(entries))
+	if len(entries) != 1 {
+		t.Fatalf("entries = %#v, want only the directory match", entries)
 	}
 	if entries[0].Kind != EntryKindDirectory || entries[0].Path != "/workspace/src" {
 		t.Fatalf("top entry = %#v, want directory /workspace/src", entries[0])
 	}
 }
 
-func TestScoreSearchCandidatesDoesNotMatchPathSegmentOrder(t *testing.T) {
+func TestScoreSearchCandidatesRejectsRelativePathTraversal(t *testing.T) {
+	entries := ScoreSearchCandidates("/workspace", "../secret", []SearchCandidate{
+		{Kind: EntryKindFile, RelativePath: "secret"},
+	}, 10)
+
+	if len(entries) != 0 {
+		t.Fatalf("entries = %#v, want no matches outside logical root", entries)
+	}
+}
+
+func TestScoreSearchCandidatesMatchesPathSegmentOrder(t *testing.T) {
 	entries := ScoreSearchCandidates("/workspace", "docs/work", []SearchCandidate{
 		{Kind: EntryKindFile, RelativePath: "docs/workspace.md"},
 		{Kind: EntryKindFile, RelativePath: "workspace/docs.md"},
 		{Kind: EntryKindFile, RelativePath: "notes/workspace-docs.md"},
 	}, 10)
 
+	if len(entries) == 0 || entries[0].Path != "/workspace/docs/workspace.md" {
+		t.Fatalf("entries = %#v, want docs/workspace.md", entries)
+	}
+}
+
+func TestScoreSearchCandidatesRanksExactBasenameBeforeStemAndFuzzyMatches(t *testing.T) {
+	entries := ScoreSearchCandidates("/Users/Sun", "user", []SearchCandidate{
+		{Kind: EntryKindFile, RelativePath: "project/renderer.js"},
+		{Kind: EntryKindFile, RelativePath: "docs/USER.md"},
+		{Kind: EntryKindDirectory, RelativePath: "user"},
+		{Kind: EntryKindFile, RelativePath: "src/user.go"},
+		{Kind: EntryKindFile, RelativePath: "src/user_test.go"},
+	}, 10)
+
+	if len(entries) != 4 {
+		t.Fatalf("entries = %#v, want four name matches", entries)
+	}
+	if entries[0].Path != "/Users/Sun/user" {
+		t.Fatalf("top entry = %#v, want exact folder /Users/Sun/user", entries[0])
+	}
+	if entries[1].Path != "/Users/Sun/docs/USER.md" {
+		t.Fatalf("second entry = %#v, want exact stem USER.md", entries[1])
+	}
+}
+
+func TestScoreSearchCandidatesRanksExactFileBeforeFuzzyDirectory(t *testing.T) {
+	entries := ScoreSearchCandidates("/workspace", "load_log", []SearchCandidate{
+		{Kind: EntryKindDirectory, RelativePath: "downloaded_catalog_data"},
+		{Kind: EntryKindFile, RelativePath: "load_log"},
+	}, 10)
+
+	if len(entries) != 2 {
+		t.Fatalf("entries = %#v, want exact and fuzzy matches", entries)
+	}
+	if entries[0].Path != "/workspace/load_log" || entries[0].Kind != EntryKindFile {
+		t.Fatalf("top entry = %#v, want exact file /workspace/load_log", entries[0])
+	}
+}
+
+func TestScoreSearchCandidatesNormalizesLogicalAbsolutePathQuery(t *testing.T) {
+	entries := ScoreSearchCandidates("/Users/Sun", "/Users/Sun/src/user", []SearchCandidate{
+		{Kind: EntryKindDirectory, RelativePath: "src/user"},
+		{Kind: EntryKindDirectory, RelativePath: "archive/src/user"},
+		{Kind: EntryKindFile, RelativePath: "src/user.go"},
+	}, 10)
+
+	if len(entries) == 0 || entries[0].Path != "/Users/Sun/src/user" {
+		t.Fatalf("entries = %#v, want exact absolute-path target first", entries)
+	}
+}
+
+func TestScoreSearchCandidatesRejectsAbsolutePathOutsideLogicalRoot(t *testing.T) {
+	entries := ScoreSearchCandidates("/Users/Sun", "/Users/Other/src/user", []SearchCandidate{
+		{Kind: EntryKindDirectory, RelativePath: "src/user"},
+	}, 10)
+
 	if len(entries) != 0 {
-		t.Fatalf("entries = %#v, want no path-segment matches", entries)
+		t.Fatalf("entries = %#v, want no matches outside logical root", entries)
 	}
 }
 

--- a/services/tuttid/data/workspace/local_files_search.go
+++ b/services/tuttid/data/workspace/local_files_search.go
@@ -144,7 +144,14 @@ func normalizePhysicalSearchQuery(root workspacefiles.WorkspaceRoot, query strin
 		return query
 	}
 
-	physicalRoot := filepath.Clean(strings.TrimSpace(root.PhysicalRoot))
+	physicalRootValue := strings.TrimSpace(root.PhysicalRoot)
+	if physicalRootValue == "" {
+		return query
+	}
+	physicalRoot, err := filepath.Abs(physicalRootValue)
+	if err != nil {
+		return query
+	}
 	physicalQuery := filepath.Clean(trimmed)
 	relative, err := filepath.Rel(physicalRoot, physicalQuery)
 	if err != nil || relative == ".." || strings.HasPrefix(relative, ".."+string(filepath.Separator)) {

--- a/services/tuttid/data/workspace/local_files_search.go
+++ b/services/tuttid/data/workspace/local_files_search.go
@@ -6,6 +6,7 @@ import (
 	"io/fs"
 	"log/slog"
 	"os"
+	"path"
 	"path/filepath"
 	"strings"
 	"time"
@@ -111,9 +112,10 @@ func (a LocalFilesAdapter) Search(
 	logicalRoot := workspacefiles.NormalizeLogicalRoot(root.LogicalRoot)
 	var entries []workspacefiles.SearchEntry
 	if strings.TrimSpace(input.Query) != "" {
+		scoreQuery := normalizePhysicalSearchQuery(root, input.Query)
 		entries = workspacefiles.ScoreSearchCandidates(
 			logicalRoot,
-			input.Query,
+			scoreQuery,
 			candidates,
 			input.Limit,
 		)
@@ -134,6 +136,33 @@ func (a LocalFilesAdapter) Search(
 		Root:        workspacefiles.NormalizeLogicalRoot(root.LogicalRoot),
 		Entries:     entries,
 	}, nil
+}
+
+func normalizePhysicalSearchQuery(root workspacefiles.WorkspaceRoot, query string) string {
+	trimmed := strings.TrimSpace(query)
+	if trimmed == "" || !filepath.IsAbs(trimmed) {
+		return query
+	}
+
+	physicalRoot := filepath.Clean(strings.TrimSpace(root.PhysicalRoot))
+	physicalQuery := filepath.Clean(trimmed)
+	relative, err := filepath.Rel(physicalRoot, physicalQuery)
+	if err != nil || relative == ".." || strings.HasPrefix(relative, ".."+string(filepath.Separator)) {
+		// ScoreSearchCandidates still handles logical absolute paths and rejects
+		// absolute paths outside that root.
+		return query
+	}
+	if relative == "." {
+		return ""
+	}
+	normalized := path.Join(
+		workspacefiles.NormalizeLogicalRoot(root.LogicalRoot).String(),
+		filepath.ToSlash(relative),
+	)
+	if strings.HasSuffix(trimmed, "/") || strings.HasSuffix(trimmed, "\\") {
+		normalized += "/"
+	}
+	return normalized
 }
 
 type searchWalkOptions struct {

--- a/services/tuttid/data/workspace/local_files_test.go
+++ b/services/tuttid/data/workspace/local_files_test.go
@@ -790,11 +790,11 @@ func TestLocalFilesAdapterSearchKeepsShallowMatchesBeforeDeepCandidateCap(t *tes
 	}
 }
 
-func TestLocalFilesAdapterSearchTypeFilterExcludesDirectoriesButKeepsMatchingFiles(t *testing.T) {
+func TestLocalFilesAdapterSearchTypeFilterKeepsFilenameAndParentPathMatches(t *testing.T) {
 	t.Parallel()
 
 	rootDir := t.TempDir()
-	// 一个目录名含 "22" 的文档文件:开启「document」筛选后仍只按文件名匹配关键词。
+	// 一个目录名含 "22" 的文档文件:普通名称查询仍可以低优先级命中相对路径段。
 	docInFolder := filepath.Join(rootDir, "reports22", "q3.csv")
 	if err := os.MkdirAll(filepath.Dir(docInFolder), 0o755); err != nil {
 		t.Fatal(err)
@@ -830,8 +830,8 @@ func TestLocalFilesAdapterSearchTypeFilterExcludesDirectoriesButKeepsMatchingFil
 			t.Fatalf("entry = %#v, directories must be excluded when a type filter is active", entry)
 		}
 	}
-	// 交集:文件名关键词 "22" ∩ 类型 document。
-	wantPaths := []string{"/workspace/data22.csv"}
+	// 交集:(文件名或相对路径关键词 "22") ∩ 类型 document。
+	wantPaths := []string{"/workspace/data22.csv", "/workspace/reports22/q3.csv"}
 	for _, want := range wantPaths {
 		if !gotPaths[want] {
 			t.Fatalf("entries = %#v, want to include %s", result.Entries, want)
@@ -910,6 +910,31 @@ func TestLocalFilesAdapterSearchWithoutWithinSpansWholeRoot(t *testing.T) {
 	}
 	if len(result.Entries) != 2 {
 		t.Fatalf("entries = %#v, want both matches across the whole root", result.Entries)
+	}
+}
+
+func TestLocalFilesAdapterSearchNormalizesPhysicalAbsolutePathQuery(t *testing.T) {
+	t.Parallel()
+
+	rootDir := t.TempDir()
+	target := filepath.Join(rootDir, "src", "user")
+	if err := os.MkdirAll(target, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(rootDir, "archive", "src", "user"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	adapter := LocalFilesAdapter{}
+	result, err := adapter.Search(context.Background(), localFilesRoot(rootDir), workspacefiles.SearchInput{
+		Query: target,
+		Limit: 20,
+	})
+	if err != nil {
+		t.Fatalf("Search() error = %v", err)
+	}
+	if len(result.Entries) == 0 || result.Entries[0].Path != "/workspace/src/user" {
+		t.Fatalf("entries = %#v, want physical absolute-path target first", result.Entries)
 	}
 }
 

--- a/services/tuttid/data/workspace/local_files_test.go
+++ b/services/tuttid/data/workspace/local_files_test.go
@@ -938,6 +938,36 @@ func TestLocalFilesAdapterSearchNormalizesPhysicalAbsolutePathQuery(t *testing.T
 	}
 }
 
+func TestLocalFilesAdapterSearchNormalizesPhysicalAbsolutePathWithRelativeRoot(t *testing.T) {
+	t.Parallel()
+
+	rootDir := t.TempDir()
+	target := filepath.Join(rootDir, "src", "user")
+	if err := os.MkdirAll(target, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	workingDirectory, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	relativeRoot, err := filepath.Rel(workingDirectory, rootDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	root := localFilesRoot(relativeRoot)
+
+	result, err := (LocalFilesAdapter{}).Search(context.Background(), root, workspacefiles.SearchInput{
+		Query: target,
+		Limit: 20,
+	})
+	if err != nil {
+		t.Fatalf("Search() error = %v", err)
+	}
+	if len(result.Entries) == 0 || result.Entries[0].Path != "/workspace/src/user" {
+		t.Fatalf("entries = %#v, want physical absolute-path target first", result.Entries)
+	}
+}
+
 func TestLocalFilesAdapterSearchReturnsPartialResultsWhenDeadlineExpires(t *testing.T) {
 	t.Parallel()
 

--- a/services/tuttid/service/agent/composer_commands_test.go
+++ b/services/tuttid/service/agent/composer_commands_test.go
@@ -1,6 +1,9 @@
 package agent
 
-import "testing"
+import (
+	"context"
+	"testing"
+)
 
 type composerCommandSessionReaderStub struct {
 	sessions []PersistedSession
@@ -14,7 +17,7 @@ func (s composerCommandSessionReaderStub) ListSessions(string) ([]PersistedSessi
 	return s.sessions, true
 }
 
-func (composerCommandSessionReaderStub) SessionDeleted(string, string) (bool, error) {
+func (composerCommandSessionReaderStub) SessionDeleted(context.Context, string, string) (bool, error) {
 	return false, nil
 }
 


### PR DESCRIPTION
## Summary

- make daemon-backed local-file search use explicit relevance tiers for exact basename, stem, fuzzy name, relative path, and absolute path intent
- preserve authoritative search order through the reference picker and Agent `@` provider instead of applying folder-first or Dock-first ordering
- normalize physical absolute paths within the active root, reject paths outside it, and keep trailing separators as directory intent
- add controller, view, desktop-provider, daemon-adapter, and core ranking regressions for the reported `user` and `load_log` cases
- document source-owned search relevance and path-query semantics

## Verification

- `pnpm check:changed --tail-lines 80` — passed 14 lanes
- `pnpm --filter @tutti-os/workspace-file-reference test` — 61 passed
- `pnpm --filter @tutti-os/workspace-file-reference typecheck` — passed
- `pnpm --filter @tutti-os/desktop test` — 1405 passed, 2 skipped
- `pnpm --filter @tutti-os/desktop typecheck` — passed
- `pnpm --filter @tutti-os/desktop build` — passed
- `go test ./...` in `packages/workspace/files` — passed
- `go test ./data/workspace` in `services/tuttid` — passed
- `pnpm check:renderer-boundaries` — passed
- `pnpm check:full` — passed 18 tasks

## Fix Scope Justification

- Root cause: the daemon did not express exact basename/path intent as stable rank tiers, while two consumers independently overwrote its order: the shared picker applied folder/name sorting and the desktop Agent `@` wrapper prepended Dock matches based on the displayed file's absolute path.
- Why can this not be fixed at a lower layer? Fixing only daemon scoring would still allow the picker and Dock wrapper to replace that ranking. Fixing only the UI would leave ambiguous name/path ranking and absolute-path handling inconsistent across consumers. The change therefore updates the rank owner and removes the two downstream competing relevance models.

## Checklist

- [x] I kept the change focused on one concern.
- [x] I updated documentation when behavior, setup, or contributor workflow changed.
- [x] I updated all README/CONTRIBUTING language variants when changing their English source.
- [x] I ran the lowest meaningful local checks for the changed surface.
- [x] My commits are signed off with DCO when required: `git commit -s`.
