### PR TITLE
fix(agent-gui): restore dock and session mention routing

### DIFF
--- a/apps/desktop/src/renderer/src/features/workspace-agent/services/desktopAgentGUILinkActions.test.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-agent/services/desktopAgentGUILinkActions.test.ts
@@ -14,6 +14,7 @@ test("desktop agent gui link actions launch workspace files with resolved action
   };
 
   const handled = await runDesktopAgentGUILinkAction(action, {
+    getAgentSession: failGetAgentSession,
     homeDirectory: "/Users/local",
     launchAgentGui: failLaunchAgentGui,
     launchWorkspaceIssueManager: failLaunchWorkspaceIssueManager,
@@ -49,6 +50,7 @@ test("desktop agent gui project menu opens the project folder path in workspace 
   };
 
   const handled = await runDesktopAgentGUILinkAction(action, {
+    getAgentSession: failGetAgentSession,
     homeDirectory: "/Users/local",
     launchAgentGui: failLaunchAgentGui,
     launchWorkspaceIssueManager: failLaunchWorkspaceIssueManager,
@@ -83,6 +85,7 @@ test("desktop agent gui link actions reveal local asset previews in workspace fi
       type: "open-local-asset-preview"
     },
     {
+      getAgentSession: failGetAgentSession,
       homeDirectory: "/Users/local",
       launchAgentGui: failLaunchAgentGui,
       launchWorkspaceIssueManager: failLaunchWorkspaceIssueManager,
@@ -116,6 +119,7 @@ test("desktop agent gui link actions open urls through the workspace browser", a
       url: "https://example.com"
     },
     {
+      getAgentSession: failGetAgentSession,
       launchAgentGui: failLaunchAgentGui,
       launchWorkspaceIssueManager: failLaunchWorkspaceIssueManager,
       launchWorkspaceFiles: failLaunchWorkspaceFiles,
@@ -144,12 +148,17 @@ test("desktop agent gui link actions launch agent sessions in the same workspace
   const handled = await runDesktopAgentGUILinkAction(
     {
       agentSessionId: "session-1",
-      agentTargetId: "local:claude-code",
       source: "agent-markdown",
       type: "open-agent-session",
       workspaceId: "workspace-1"
     },
     {
+      async getAgentSession() {
+        return {
+          agentTargetId: "local:claude-code",
+          provider: "claude-code"
+        };
+      },
       launchAgentGui(input) {
         launchedSessions.push(input);
         return true;
@@ -166,6 +175,7 @@ test("desktop agent gui link actions launch agent sessions in the same workspace
     {
       agentSessionId: "session-1",
       agentTargetId: "local:claude-code",
+      provider: "claude-code",
       workspaceId: "workspace-1"
     }
   ]);
@@ -187,6 +197,7 @@ test("desktop agent gui link actions launch workspace issue manager in the same 
       workspaceId: "workspace-1"
     },
     {
+      getAgentSession: failGetAgentSession,
       launchAgentGui: failLaunchAgentGui,
       launchWorkspaceIssueManager(input) {
         launchedIssues.push(input);
@@ -223,6 +234,7 @@ test("desktop agent gui link actions launch workspace apps in the same workspace
       workspaceId: "workspace-1"
     },
     {
+      getAgentSession: failGetAgentSession,
       launchAgentGui: failLaunchAgentGui,
       launchWorkspaceApp(input) {
         launchedApps.push(input);
@@ -255,6 +267,7 @@ test("desktop agent gui link actions route issue-manager app mentions to issue m
       workspaceId: "workspace-1"
     },
     {
+      getAgentSession: failGetAgentSession,
       launchAgentGui: failLaunchAgentGui,
       launchWorkspaceApp: failLaunchWorkspaceApp,
       launchWorkspaceIssueManager(input) {
@@ -277,6 +290,10 @@ test("desktop agent gui link actions route issue-manager app mentions to issue m
 
 function failLaunchAgentGui(): never {
   throw new Error("agent gui should not launch");
+}
+
+function failGetAgentSession(): never {
+  throw new Error("agent session should not load");
 }
 
 function failLaunchWorkspaceApp(): never {

--- a/apps/desktop/src/renderer/src/features/workspace-agent/services/desktopAgentGUILinkActions.test.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-agent/services/desktopAgentGUILinkActions.test.ts
@@ -181,6 +181,29 @@ test("desktop agent gui link actions launch agent sessions in the same workspace
   ]);
 });
 
+test("desktop agent gui link actions safely reject unavailable session mentions", async () => {
+  const handled = await runDesktopAgentGUILinkAction(
+    {
+      agentSessionId: "missing-session",
+      source: "agent-markdown",
+      type: "open-agent-session",
+      workspaceId: "workspace-1"
+    },
+    {
+      async getAgentSession() {
+        throw new Error("session not found");
+      },
+      launchAgentGui: failLaunchAgentGui,
+      launchWorkspaceIssueManager: failLaunchWorkspaceIssueManager,
+      launchWorkspaceFiles: failLaunchWorkspaceFiles,
+      openBrowserUrl: failOpenBrowserUrl,
+      workspaceId: "workspace-1"
+    }
+  );
+
+  assert.equal(handled, false);
+});
+
 test("desktop agent gui link actions launch workspace issue manager in the same workspace", async () => {
   const launchedIssues: unknown[] = [];
 

--- a/apps/desktop/src/renderer/src/features/workspace-agent/services/desktopAgentGUILinkActions.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-agent/services/desktopAgentGUILinkActions.ts
@@ -90,14 +90,21 @@ export async function runDesktopAgentGUILinkAction(
         url: action.url,
         workspaceId: dependencies.workspaceId
       });
-    case "open-agent-session":
+    case "open-agent-session": {
       if (action.workspaceId !== dependencies.workspaceId) {
         return false;
       }
-      const session = await dependencies.getAgentSession({
-        agentSessionId: action.agentSessionId,
-        workspaceId: dependencies.workspaceId
-      });
+      let session: Awaited<
+        ReturnType<DesktopAgentGUILinkActionDependencies["getAgentSession"]>
+      >;
+      try {
+        session = await dependencies.getAgentSession({
+          agentSessionId: action.agentSessionId,
+          workspaceId: dependencies.workspaceId
+        });
+      } catch {
+        return false;
+      }
       const provider = session.provider.trim();
       if (!provider) {
         return false;
@@ -108,6 +115,7 @@ export async function runDesktopAgentGUILinkAction(
         provider,
         workspaceId: dependencies.workspaceId
       });
+    }
     case "open-workspace-issue": {
       if (action.workspaceId !== dependencies.workspaceId) {
         return false;

--- a/apps/desktop/src/renderer/src/features/workspace-agent/services/desktopAgentGUILinkActions.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-agent/services/desktopAgentGUILinkActions.ts
@@ -9,6 +9,13 @@ import type { DesktopAgentGUIProvider } from "../desktopAgentGUINodeState.ts";
 const AGENT_PASTED_TEXT_MENTION_KIND = "pasted-text";
 
 export interface DesktopAgentGUILinkActionDependencies {
+  getAgentSession(input: {
+    agentSessionId: string;
+    workspaceId: string;
+  }): Promise<{
+    agentTargetId: string | null;
+    provider: DesktopAgentGUIProvider;
+  }>;
   homeDirectory?: string | null;
   launchAgentGui(input: {
     agentSessionId: string;
@@ -87,11 +94,18 @@ export async function runDesktopAgentGUILinkAction(
       if (action.workspaceId !== dependencies.workspaceId) {
         return false;
       }
+      const session = await dependencies.getAgentSession({
+        agentSessionId: action.agentSessionId,
+        workspaceId: dependencies.workspaceId
+      });
+      const provider = session.provider.trim();
+      if (!provider) {
+        return false;
+      }
       return dependencies.launchAgentGui({
         agentSessionId: action.agentSessionId,
-        ...(action.agentTargetId
-          ? { agentTargetId: action.agentTargetId }
-          : {}),
+        agentTargetId: session.agentTargetId,
+        provider,
         workspaceId: dependencies.workspaceId
       });
     case "open-workspace-issue": {

--- a/apps/desktop/src/renderer/src/features/workspace-workbench/services/internal/workspaceAgentGuiContribution.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/services/internal/workspaceAgentGuiContribution.ts
@@ -115,6 +115,11 @@ export function createWorkspaceAgentGuiContribution(input: {
     DesktopAgentGUIWorkbenchBodyProps["onLinkAction"]
   > = (action) => {
     void runDesktopAgentGUILinkAction(action, {
+      getAgentSession: ({ agentSessionId, workspaceId }) =>
+        input.workspaceAgentActivityService.getSession(
+          workspaceId,
+          agentSessionId
+        ),
       homeDirectory: input.platformApi.homeDirectory,
       launchAgentGui: requestWorkspaceAgentGuiLaunch,
       launchWorkspaceIssueManager: requestWorkspaceIssueManagerLaunch,

--- a/apps/desktop/src/renderer/src/features/workspace-workbench/services/internal/workspaceAgentProviderDockStateSource.test.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/services/internal/workspaceAgentProviderDockStateSource.test.ts
@@ -7,6 +7,7 @@ import type {
   IWorkspaceAgentActivityService
 } from "@renderer/features/workspace-agent";
 import type { WorkspaceWorkbenchDesktopI18nRuntime } from "@shared/i18n";
+import { workspaceAgentGuiUnifiedDockEntryId } from "../workspaceAgentGuiLaunch.ts";
 import { createWorkspaceAgentProviderDockStateSource as createWorkspaceAgentProviderDockStateSourceBase } from "./workspaceAgentProviderDockStateSource.ts";
 import { workspaceAgentGuiDockEntryId } from "./workspaceWorkbenchComposition.ts";
 
@@ -75,6 +76,19 @@ test("agent provider dock state source resolves dynamic login state", () => {
       },
       visibility: "always"
     }
+  );
+});
+
+test("agent provider dock state source leaves the unified dock identity unchanged", () => {
+  const service = createAgentProviderStatusService({ statuses: [] });
+  const source = createWorkspaceAgentProviderDockStateSource({
+    agentProviderStatusService: service,
+    i18n: createI18n()
+  });
+
+  assert.equal(
+    source.getEntryState(workspaceAgentGuiUnifiedDockEntryId()),
+    null
   );
 });
 

--- a/apps/desktop/src/renderer/src/features/workspace-workbench/services/internal/workspaceIssueManagerContribution.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/services/internal/workspaceIssueManagerContribution.ts
@@ -129,6 +129,11 @@ export function createWorkspaceIssueManagerContribution(input: {
           return;
         }
         await runDesktopAgentGUILinkAction(action, {
+          getAgentSession: ({ agentSessionId, workspaceId }) =>
+            input.workspaceAgentActivityService.getSession(
+              workspaceId,
+              agentSessionId
+            ),
           homeDirectory: input.platformApi.homeDirectory,
           launchAgentGui: requestWorkspaceAgentGuiLaunch,
           launchWorkspaceIssueManager: requestWorkspaceIssueManagerLaunch,
@@ -204,6 +209,11 @@ export function createWorkspaceIssueManagerContribution(input: {
           locale: input.locale,
           onLinkAction: (action) => {
             void runDesktopAgentGUILinkAction(action, {
+              getAgentSession: ({ agentSessionId, workspaceId }) =>
+                input.workspaceAgentActivityService.getSession(
+                  workspaceId,
+                  agentSessionId
+                ),
               homeDirectory: input.platformApi.homeDirectory,
               launchAgentGui: requestWorkspaceAgentGuiLaunch,
               launchWorkspaceIssueManager: requestWorkspaceIssueManagerLaunch,

--- a/apps/desktop/src/renderer/src/features/workspace-workbench/ui/StandaloneAgentWindow.tsx
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/ui/StandaloneAgentWindow.tsx
@@ -580,6 +580,7 @@ export function StandaloneAgentWindow({
     openFileInSidebar,
     setActivation,
     setNodeState,
+    workspaceAgentActivityService,
     workspaceAppCenterService,
     workspaceId
   });

--- a/apps/desktop/src/renderer/src/features/workspace-workbench/ui/WorkspaceAgentMessageCenterAction.tsx
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/ui/WorkspaceAgentMessageCenterAction.tsx
@@ -301,6 +301,7 @@ export function WorkspaceAgentMessageCenterAction({
           const nodeId = await launchNode?.(
             createWorkspaceAgentGuiSessionLaunchRequest({
               agentSessionId: input.agentSessionId,
+              agentTargetId: input.agentTargetId,
               provider: input.provider
             })
           );

--- a/apps/desktop/src/renderer/src/features/workspace-workbench/ui/WorkspaceAgentMessageCenterAction.tsx
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/ui/WorkspaceAgentMessageCenterAction.tsx
@@ -294,6 +294,8 @@ export function WorkspaceAgentMessageCenterAction({
   const handleLinkAction = useCallback(
     (action: Parameters<typeof runDesktopAgentGUILinkAction>[0]) => {
       void runDesktopAgentGUILinkAction(action, {
+        getAgentSession: ({ agentSessionId, workspaceId }) =>
+          workspaceAgentActivityService.getSession(workspaceId, agentSessionId),
         homeDirectory: workbenchHostService.getHomeDirectory(),
         launchAgentGui: async (input) => {
           const nodeId = await launchNode?.(
@@ -311,7 +313,12 @@ export function WorkspaceAgentMessageCenterAction({
         workspaceId: workspace.id
       });
     },
-    [launchNode, workbenchHostService, workspace.id]
+    [
+      launchNode,
+      workbenchHostService,
+      workspace.id,
+      workspaceAgentActivityService
+    ]
   );
   const closeMessageCenter = useCallback(() => {
     setOpen(false);

--- a/apps/desktop/src/renderer/src/features/workspace-workbench/ui/WorkspaceAppExternalBridge.tsx
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/ui/WorkspaceAppExternalBridge.tsx
@@ -22,6 +22,8 @@ import type {
 import type { TuttiExternalFileOpenInput } from "@tutti-os/workspace-external-core/contracts";
 import { resolveWorkspaceMentionLinkAction } from "@contexts/workspace/presentation/renderer/actions/workspaceLinkActions";
 import { runDesktopAgentGUILinkAction } from "@renderer/features/workspace-agent/services/desktopAgentGUILinkActions.ts";
+import { IWorkspaceAgentActivityService } from "@renderer/features/workspace-agent/services/workspaceAgentActivityService.interface.ts";
+import { useService } from "@tutti-os/infra/di";
 import { requestGroupChatLaunch } from "../services/groupChatLaunchCoordinator.ts";
 import { requestWorkspaceAgentGuiLaunch } from "@renderer/features/workspace-agent/services/workspaceAgentGuiLaunchCoordinator.ts";
 import { useWorkspaceAppCenterService } from "@renderer/features/workspace-app-center";
@@ -82,6 +84,9 @@ export function WorkspaceAppExternalBridge({
   const hostService = useWorkspaceWorkbenchHostService();
   const { service: settingsService } = useWorkspaceSettingsService();
   const { service: appCenterService } = useWorkspaceAppCenterService();
+  const workspaceAgentActivityService = useService(
+    IWorkspaceAgentActivityService
+  );
   const { t } = useTranslation();
   const [pendingFileSelect, setPendingFileSelect] =
     useState<PendingFileSelect | null>(null);
@@ -201,6 +206,11 @@ export function WorkspaceAppExternalBridge({
             throw new Error("Unsupported reference link.");
           }
           const opened = await runDesktopAgentGUILinkAction(action, {
+            getAgentSession: ({ agentSessionId, workspaceId }) =>
+              workspaceAgentActivityService.getSession(
+                workspaceId,
+                agentSessionId
+              ),
             launchAgentGui: requestWorkspaceAgentGuiLaunch,
             launchWorkspaceApp: async ({ appId, workspaceId }) => {
               await appCenterService.openApp({ appId, workspaceId });

--- a/apps/desktop/src/renderer/src/features/workspace-workbench/ui/WorkspaceAppExternalBridge.tsx
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/ui/WorkspaceAppExternalBridge.tsx
@@ -257,6 +257,7 @@ export function WorkspaceAppExternalBridge({
       openFileSelect,
       settingsService,
       userProjectsApi,
+      workspaceAgentActivityService,
       workspaceId
     ]
   );

--- a/apps/desktop/src/renderer/src/features/workspace-workbench/ui/WorkspaceChrome.test.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/ui/WorkspaceChrome.test.ts
@@ -61,6 +61,13 @@ test("workspace chrome deck submit dispatches plan decisions through the canonic
   assert.doesNotMatch(messageCenterSource, /PLAN_IMPLEMENTATION_PROMPT/);
 });
 
+test("workspace message center forwards canonical session identity into AgentGUI launches", () => {
+  assert.match(
+    messageCenterSource,
+    /createWorkspaceAgentGuiSessionLaunchRequest\(\{[\s\S]*?agentSessionId: input\.agentSessionId,[\s\S]*?agentTargetId: input\.agentTargetId,[\s\S]*?provider: input\.provider/
+  );
+});
+
 test("workspace chrome does not call updateSessionSettings or sendInput from the deck submit handler", () => {
   // Ensure the old branching logic in onSubmitPrompt is removed
   // (toast notification path at line 484 uses submitInteractive — that is expected to stay)

--- a/apps/desktop/src/renderer/src/features/workspace-workbench/ui/useStandaloneAgentLaunchRouting.ts
+++ b/apps/desktop/src/renderer/src/features/workspace-workbench/ui/useStandaloneAgentLaunchRouting.ts
@@ -11,6 +11,7 @@ import type { DesktopAgentDirectorySnapshot } from "@shared/contracts/agentDirec
 import type { DesktopHostWindowApi } from "@preload/types";
 import type { IWorkspaceAppCenterService } from "@renderer/features/workspace-app-center";
 import type { IAgentProviderStatusService as AgentProviderStatusService } from "@renderer/features/workspace-agent/services/agentProviderStatusService.interface.ts";
+import type { IWorkspaceAgentActivityService } from "@renderer/features/workspace-agent/services/workspaceAgentActivityService.interface.ts";
 import { runDesktopAgentGUILinkAction } from "@renderer/features/workspace-agent/services/desktopAgentGUILinkActions.ts";
 import type { DesktopAgentGUIWorkbenchBodyProps } from "@renderer/features/workspace-agent/ui/desktopAgentGUIWorkbenchModel.ts";
 import {
@@ -44,6 +45,7 @@ interface StandaloneAgentLaunchRoutingInput {
     SetStateAction<WorkbenchHostNodeBodyContext["activation"]>
   >;
   setNodeState: Dispatch<SetStateAction<DesktopAgentGUIWorkbenchState>>;
+  workspaceAgentActivityService: IWorkspaceAgentActivityService;
   workspaceAppCenterService: IWorkspaceAppCenterService;
   workspaceId: string;
 }
@@ -57,6 +59,7 @@ export function useStandaloneAgentLaunchRouting({
   openFileInSidebar,
   setActivation,
   setNodeState,
+  workspaceAgentActivityService,
   workspaceAppCenterService,
   workspaceId
 }: StandaloneAgentLaunchRoutingInput): {
@@ -140,6 +143,8 @@ export function useStandaloneAgentLaunchRouting({
   >(
     (action) => {
       void runDesktopAgentGUILinkAction(action, {
+        getAgentSession: ({ agentSessionId, workspaceId }) =>
+          workspaceAgentActivityService.getSession(workspaceId, agentSessionId),
         homeDirectory,
         launchAgentGui: requestWorkspaceAgentGuiLaunch,
         launchWorkspaceIssueManager: requestWorkspaceIssueManagerLaunch,
@@ -159,7 +164,13 @@ export function useStandaloneAgentLaunchRouting({
         workspaceId
       });
     },
-    [homeDirectory, openFileInSidebar, workspaceAppCenterService, workspaceId]
+    [
+      homeDirectory,
+      openFileInSidebar,
+      workspaceAgentActivityService,
+      workspaceAppCenterService,
+      workspaceId
+    ]
   );
 
   return {

--- a/docs/architecture/agent-gui-node.md
+++ b/docs/architecture/agent-gui-node.md
@@ -160,6 +160,13 @@ entries.
 Agent launches from Launchpad/All must still use the unified Agent dock entry
 identity (`agent-gui:unified`) so the resulting AgentGUI node appears under the
 same Dock icon as direct Dock launches.
+The unified dock identity is a reserved aggregate identifier, not a provider
+identifier. Provider extraction must recognize and exclude reserved aggregate
+identities before parsing the `agent-gui:<provider>` instance namespace, even
+though provider metadata accepts extension-defined strings. Provider-specific
+dock status must never override the unified entry's visibility; an aggregate
+status, if needed, must be modeled explicitly instead of synthesizing an
+`unified` provider.
 Empty launches from the unified Agent dock entry should set dock-entry reuse so
 the second dock click restores/focuses the existing AgentGUI node; draft
 prefill launches and explicit session launches keep their narrower reuse rules
@@ -204,6 +211,10 @@ mention's visible label must use the source conversation title without
 prefixing the source agent or provider name, because the submitted draft also
 becomes the new conversation's initial title. Source agent identity stays in
 the mention metadata instead of being duplicated into title text. The
+`agent-session` navigation path is session-authoritative: clicking a mention
+resolves the canonical session by workspace and session ID, then launches with
+that session's provider and Agent Target. It must not inherit the current
+AgentGUI node's target or derive a provider from the unified dock identity. The
 prefill activation provider is authoritative for the new workbench panel's
 initial provider chrome, so choosing Codex from a Claude Code session must open
 a Codex panel before the draft prefill effect runs. The prefilled handoff panel

--- a/packages/agent/gui/agent-gui/agentGuiNode/AgentGUINode.spec.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/AgentGUINode.spec.tsx
@@ -3905,7 +3905,7 @@ describe("AgentGUINode", () => {
     });
   });
 
-  it("forwards composer mention link actions without provider fallback", async () => {
+  it("forwards composer mention link actions without current-target fallback", async () => {
     const onLinkAction = vi.fn<(action: WorkspaceLinkAction) => void>();
     mockViewModel = createViewModel({
       activeConversationId: "session-1",
@@ -3914,7 +3914,11 @@ describe("AgentGUINode", () => {
     });
     renderAgentGUINode({
       onLinkAction,
-      state: { ...createViewModel().shell.data, provider: "codex" }
+      state: {
+        ...createViewModel().shell.data,
+        agentTargetId: "local:codex",
+        provider: "codex"
+      }
     });
 
     const editor = getComposerEditor();

--- a/packages/agent/gui/agent-gui/agentGuiNode/AgentGUINode.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/AgentGUINode.tsx
@@ -148,16 +148,9 @@ export const AgentGUINode = memo(function AgentGUINode({
   );
   const handleLinkAction = useCallback(
     (action: WorkspaceLinkAction) => {
-      const agentTargetId = state.agentTargetId?.trim() || null;
-      onLinkAction?.(
-        action.type === "open-agent-session" &&
-          !action.agentTargetId &&
-          agentTargetId
-          ? { ...action, agentTargetId }
-          : action
-      );
+      onLinkAction?.(action);
     },
-    [onLinkAction, state.agentTargetId]
+    [onLinkAction]
   );
   const handleAgentProviderLogin = useCallback(
     (provider?: string | null) => {

--- a/packages/agent/gui/agent-message-center/WorkspaceAgentMessageCenterCard.tsx
+++ b/packages/agent/gui/agent-message-center/WorkspaceAgentMessageCenterCard.tsx
@@ -587,20 +587,6 @@ export function MessageCenterSummary({
     summaryRef,
     shouldRenderRichSummary
   );
-  const handleLinkAction = useCallback(
-    (action: WorkspaceLinkAction): void => {
-      const agentTargetId = item.agentTargetId?.trim() || null;
-      onLinkAction?.(
-        action.type === "open-agent-session" &&
-          !action.agentTargetId &&
-          agentTargetId
-          ? { ...action, agentTargetId }
-          : action
-      );
-    },
-    [item.agentTargetId, onLinkAction]
-  );
-
   useEffect(() => {
     if (!shouldMeasureOverflow) {
       setIsOverflowing(false);
@@ -643,7 +629,7 @@ export function MessageCenterSummary({
         <AgentMessageMarkdown
           content={summary}
           className="[&_a]:text-[var(--tutti-purple)] [&_code]:text-[var(--text-secondary)] [&_hr]:border-t-[color-mix(in_srgb,var(--text-primary)_14%,transparent)] [&_ol]:!bg-transparent [&_p]:m-0 [&_th]:bg-[color-mix(in_srgb,var(--background-panel)_94%,var(--text-primary))] [&_th]:text-[var(--text-primary)] [&_ul]:!bg-transparent text-[var(--text-primary)]"
-          onLinkAction={handleLinkAction}
+          onLinkAction={onLinkAction}
           workspaceLinkContext={{
             workspaceRoot: item.cwd || null,
             basePath: item.cwd,

--- a/packages/agent/gui/agent-message-center/WorkspaceAgentMessageCenterPanel.spec.tsx
+++ b/packages/agent/gui/agent-message-center/WorkspaceAgentMessageCenterPanel.spec.tsx
@@ -722,7 +722,7 @@ describe("WorkspaceAgentMessageCenterCard", () => {
     });
   });
 
-  it("preserves the card agent target for targetless session links", () => {
+  it("does not apply the card agent target to linked sessions", () => {
     const onLinkAction = vi.fn();
     render(
       <TooltipProvider>
@@ -747,7 +747,6 @@ describe("WorkspaceAgentMessageCenterCard", () => {
       type: "open-agent-session",
       workspaceId: "workspace-1",
       agentSessionId: "session-2",
-      agentTargetId: "local:claude-code",
       source: "agent-markdown"
     });
   });

--- a/packages/agent/gui/workbench/launch.test.ts
+++ b/packages/agent/gui/workbench/launch.test.ts
@@ -81,8 +81,15 @@ describe("agent gui workbench launch contract", () => {
       agentGuiWorkbenchDockIdentityFromIdentifier("agent-gui:unified")
     ).toEqual({ kind: "unifiedAggregate" });
     expect(
+      agentGuiWorkbenchProviderFromIdentifier("agent-gui:unified")
+    ).toBeNull();
+    expect(agentGuiWorkbenchProviderFromIdentifier("agent-gui")).toBeNull();
+    expect(
       agentGuiWorkbenchDockIdentityFromIdentifier("agent-gui:claude-code")
     ).toBeNull();
+    expect(
+      agentGuiWorkbenchProviderFromIdentifier("agent-gui:extension-provider")
+    ).toBe("extension-provider");
   });
 
   it("launches sessions into provider panels until current session state can reuse a node", () => {

--- a/packages/agent/gui/workbench/launch.ts
+++ b/packages/agent/gui/workbench/launch.ts
@@ -76,6 +76,9 @@ export function createAgentGuiWorkbenchInstanceId(input: {
 export function agentGuiWorkbenchProviderFromIdentifier(
   value: string | null | undefined
 ): AgentGuiWorkbenchProvider | null {
+  if (agentGuiWorkbenchDockIdentityFromIdentifier(value)) {
+    return null;
+  }
   const normalized = value?.trim();
   if (!normalized?.startsWith(agentGuiWorkbenchDockEntryPrefix)) {
     return null;

--- a/tools/degradation-baseline/agent-gui.json
+++ b/tools/degradation-baseline/agent-gui.json
@@ -14,7 +14,7 @@
     },
     "goFileLengthExemptions": 2,
     "identityProviderBranches": 2,
-    "memoCount": 436,
+    "memoCount": 435,
     "moduleMutableGlobals": 6,
     "overlayStores": 4,
     "providerBranches": 1,


### PR DESCRIPTION
## Summary

- reserve `agent-gui:unified` as an aggregate dock identity instead of parsing it as a provider
- resolve `agent-session` mentions from the canonical workspace session and launch with that session provider and Agent Target
- remove current-node and message-center-card Agent Target fallbacks that coupled cross-session navigation to the source conversation
- safely reject unavailable or stale session mentions at the shared link-action boundary
- document the unified dock and session-authoritative navigation invariants

## Verification

- `pnpm check:full` — passed all 18 tasks
- `pnpm check:changed --tail-lines 80` — passed all 11 lanes after locking the improved AgentGUI degradation baseline
- AgentGUI package tests — passed 158 files / 2037 tests
- focused desktop link-action and workspace chrome tests — passed 16/16
- desktop typecheck — passed
- `make dev-web` — manually clicked the reported mention and confirmed the original Thailand planning session opened with its conversation content

## Checklist

- [x] I kept the change focused on one concern.
- [x] I updated documentation when behavior, setup, or contributor workflow changed.
- [x] I updated all README/CONTRIBUTING language variants when changing their English source. No README or CONTRIBUTING files changed.
- [x] I ran the lowest meaningful local checks for the changed surface.
- [x] My commits are signed off with DCO when required: `git commit -s`.