### PR TITLE
feat(agent): add CodeBuddy source and harden AgentGUI

### DIFF
--- a/apps/desktop/src/main/generated/defaults.ts
+++ b/apps/desktop/src/main/generated/defaults.ts
@@ -43,6 +43,15 @@ export const generatedDefaults = {
         signingPublicKey:
           "-----BEGIN PUBLIC KEY-----\nMCowBQYDK2VwAyEAXKvHPk/lWXqeK3Q1cg6vaOFfhqmXm3jcNgECsZ9XT/g=\n-----END PUBLIC KEY-----\n",
         enabled: false
+      },
+      {
+        key: "codebuddy",
+        releaseIndexUrl:
+          "https://d1x7gb6wqsqmnm.cloudfront.net/tutti-agent-releases/agents/codebuddy/versions.json",
+        signingKeyId: "tutti-codebuddy-release-v1",
+        signingPublicKey:
+          "-----BEGIN PUBLIC KEY-----\nMCowBQYDK2VwAyEAfzdtf41+SN0hrZqK0JX2pdDluCwpUbn1HPDoz4D7OxA=\n-----END PUBLIC KEY-----\n",
+        enabled: false
       }
     ]
   }

--- a/config/tutti.defaults.json
+++ b/config/tutti.defaults.json
@@ -41,6 +41,13 @@
         "signingKeyId": "tutti-gemini-release-v1",
         "signingPublicKey": "-----BEGIN PUBLIC KEY-----\nMCowBQYDK2VwAyEAXKvHPk/lWXqeK3Q1cg6vaOFfhqmXm3jcNgECsZ9XT/g=\n-----END PUBLIC KEY-----\n",
         "enabled": false
+      },
+      {
+        "key": "codebuddy",
+        "releaseIndexUrl": "https://d1x7gb6wqsqmnm.cloudfront.net/tutti-agent-releases/agents/codebuddy/versions.json",
+        "signingKeyId": "tutti-codebuddy-release-v1",
+        "signingPublicKey": "-----BEGIN PUBLIC KEY-----\nMCowBQYDK2VwAyEAfzdtf41+SN0hrZqK0JX2pdDluCwpUbn1HPDoz4D7OxA=\n-----END PUBLIC KEY-----\n",
+        "enabled": false
       }
     ]
   }

--- a/docs/conventions/runtime-overrides.md
+++ b/docs/conventions/runtime-overrides.md
@@ -94,7 +94,8 @@ Use the owner documents linked below for detailed behavior. This file exists to 
 
 Agent Extension source feature gates use
 `TUTTI_AGENT_EXTENSION_<KEY>_ENABLED`. The configured Gemini source therefore
-uses `TUTTI_AGENT_EXTENSION_GEMINI_ENABLED`. Boolean values accepted by Go's
+uses `TUTTI_AGENT_EXTENSION_GEMINI_ENABLED`, and the configured CodeBuddy
+source uses `TUTTI_AGENT_EXTENSION_CODEBUDDY_ENABLED`. Boolean values accepted by Go's
 `strconv.ParseBool` override the generated default; invalid values leave the
 generated default unchanged. A disabled source never downloads or registers
 its Agent Target.

--- a/docs/conventions/troubleshooting/README.md
+++ b/docs/conventions/troubleshooting/README.md
@@ -49,6 +49,8 @@ React rendering, Workbench state, external stores, input composition, and UI per
 - [Workbench node body warns about updating WorkbenchNodeLayer during render](./workbench-renderer.md#workbench-node-body-warns-about-updating-workbenchnodelayer-during-render)
 - [Renderer component repeatedly re-renders without visible changes](./workbench-renderer.md#renderer-component-repeatedly-re-renders-without-visible-changes)
 - [Inline custom-header menu is clipped to the Workbench title bar](./workbench-renderer.md#inline-custom-header-menu-is-clipped-to-the-workbench-title-bar)
+- [Dialog action reacts to Enter but ignores pointer clicks](./workbench-renderer.md#dialog-action-reacts-to-enter-but-ignores-pointer-clicks)
+- [Daemon validation error appears as untranslated developer text](./workbench-renderer.md#daemon-validation-error-appears-as-untranslated-developer-text)
 
 ## [Workspace Apps And Files](./workspace-apps-files.md)
 

--- a/docs/conventions/troubleshooting/workbench-renderer.md
+++ b/docs/conventions/troubleshooting/workbench-renderer.md
@@ -383,22 +383,38 @@
   Do not leave it enabled during normal development: it tracks every component
   and hook, and restoring a large AgentGUI session directory can then block the
   renderer long enough to keep Workbench hydration and the Dock non-interactive.
+  For AgentGUI render storms, trace the full
+  `engine -> selector -> projection -> controller -> section` chain. Separate
+  real summary-field changes from reference-only array, object, or callback
+  changes; a memoized leaf cannot contain churn created at the selector boundary.
 - Root cause:
   React StrictMode can intentionally replay setup/cleanup in development, but a
   continuously increasing render count usually means a parent is passing a new
   object/function every render or an effect writes state from a dependency that
-  changes on every render.
+  changes on every render. An external-store selector can also project a fresh
+  list for every unrelated engine event, after which a container rebuilds command
+  callbacks and fans one update out to every list section. A render-budget test
+  that injects an already-stable view model bypasses this production chain and
+  cannot detect that regression.
 - Fix:
   Stabilize the value at the ownership boundary, or remove derived presentation
   values from bidirectional state. For external/workbench state, only sync
-  canonical identifiers and derive display text from the owning service.
+  canonical identifiers and derive display text from the owning service. In
+  AgentGUI, select the narrow render projection with a render-field equality
+  function, keep command callbacks stable, and derive the active row from the
+  same stabilized conversation list.
 - Validation:
   With why-did-you-render enabled, reproduce once and confirm the noisy
   component lists the expected prop or hook difference. Then disable the tool
-  and run the affected renderer tests plus desktop typecheck.
+  and run the affected renderer tests plus desktop typecheck. AgentGUI budget
+  tests must dispatch a real engine update and assert the unrelated Rail subtree
+  stays at zero renders; do not replace this with a manual view-model rerender
+  that reuses the Rail reference by construction.
 - References:
   [main.tsx](../../../apps/desktop/src/renderer/src/main.tsx)
   [whyDidYouRender.ts](../../../apps/desktop/src/renderer/src/lib/whyDidYouRender.ts)
+  [useAgentGUIConversationRailQuery.ts](../../../packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUIConversationRailQuery.ts)
+  [useAgentGUIConversationRailQuery.search.spec.tsx](../../../packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUIConversationRailQuery.search.spec.tsx)
 
 ### Dense list panel stutters when mounted or resized
 
@@ -466,3 +482,54 @@
 - References:
   [StandaloneAgentToolSidebar.tsx](../../../apps/desktop/src/renderer/src/features/workspace-workbench/ui/StandaloneAgentToolSidebar.tsx)
   [standaloneAgentWindowBounds.ts](../../../apps/desktop/src/main/windows/standaloneAgentWindowBounds.ts)
+
+### Dialog action reacts to Enter but ignores pointer clicks
+
+- Symptom:
+  A dialog action succeeds from an input's Enter handler, but clicking its
+  visible action button does nothing. No request, caught error, or busy state is
+  produced.
+- Quick checks:
+  Trace `pointerdown`, `pointerup`, `click`, and the command boundary without
+  logging field contents. If both pointer events arrive but `click` and the
+  command do not, stop debugging the daemon or persistence layer.
+- Root cause:
+  Electron, a modal interaction layer, or surrounding Workbench chrome can
+  suppress the synthesized `click` even though the button receives the pointer
+  sequence. A handler wired only to `onClick` therefore never runs.
+- Fix:
+  Handle the primary `pointerup` as the pointer activation boundary. Preserve
+  keyboard activation explicitly, retain an assistive-technology click path,
+  and guard the async action with a synchronous in-flight ref so multiple event
+  paths cannot dispatch the command twice.
+- Validation:
+  Cover pointer activation, the following synthesized mouse click, keyboard
+  activation, blank input, and cancellation. Assert the command runs exactly
+  once for each accepted action.
+- References:
+  [AgentGUIRenameConversationDialog.tsx](../../../packages/agent/gui/agent-gui/agentGuiNode/view/AgentGUIRenameConversationDialog.tsx)
+
+### Daemon validation error appears as untranslated developer text
+
+- Symptom:
+  A renderer action shows an English daemon message such as a validation
+  failure while the UI locale is not English.
+- Quick checks:
+  Inspect the protocol error's `code`, `reason`, and `params`. If the reason is
+  generic and the UI falls through to `developerMessage`, the transport lost
+  the stable domain identity needed by i18n.
+- Root cause:
+  The daemon classified a specific business validation error as a generic
+  request failure. The renderer then had no stable key and exposed diagnostic
+  text as user-facing copy.
+- Fix:
+  Define a stable daemon error identity, publish a documented protocol `reason`
+  with interpolation-only `params`, then translate that reason in the owning UI
+  package. Never infer user-facing errors by matching developer-message text.
+- Validation:
+  Test service error identity, protocol classification and params, every locale
+  dictionary, and renderer mapping while an English `developerMessage` is
+  present. Run API-generation and i18n consistency checks.
+- References:
+  [apierrors.go](../../../services/tuttid/apierrors/apierrors.go)
+  [agentGuiController.errors.ts](../../../packages/agent/gui/agent-gui/agentGuiNode/controller/agentGuiController.errors.ts)

--- a/packages/agent/gui/agent-gui/agentGuiNode/AgentGUINode.spec.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/AgentGUINode.spec.tsx
@@ -2564,6 +2564,82 @@ describe("AgentGUINode", () => {
     });
   });
 
+  it("saves from pointer up without duplicating the following mouse click", async () => {
+    mockRenameConversation.mockResolvedValue(undefined);
+    mockViewModel = createViewModel({
+      conversations: [
+        {
+          id: "session-1",
+          provider: "codex",
+          title: "Session 1",
+          status: "ready",
+          cwd: "/workspace",
+          updatedAtUnixMs: 1
+        }
+      ],
+      activeConversationId: "session-1"
+    });
+    renderAgentGUINode();
+
+    fireEvent.doubleClick(screen.getByRole("button", { name: /Session 1/ }));
+    const input = screen.getByRole("textbox", {
+      name: "agentHost.agentGui.renameSessionTitle"
+    });
+    fireEvent.change(input, { target: { value: "Clicked rename" } });
+    const saveButton = screen.getByRole("button", {
+      name: "agentHost.agentGui.renameSessionSave"
+    });
+    fireEvent.pointerUp(saveButton, { button: 0, pointerType: "mouse" });
+    fireEvent.click(saveButton, { detail: 1 });
+
+    await waitFor(() => {
+      expect(mockRenameConversation).toHaveBeenCalledWith(
+        "session-1",
+        "Clicked rename"
+      );
+    });
+    expect(mockRenameConversation).toHaveBeenCalledTimes(1);
+  });
+
+  it("keeps keyboard activation on the rename save button", async () => {
+    mockRenameConversation.mockResolvedValue(undefined);
+    mockViewModel = createViewModel({
+      conversations: [
+        {
+          id: "session-1",
+          provider: "codex",
+          title: "Session 1",
+          status: "ready",
+          cwd: "/workspace",
+          updatedAtUnixMs: 1
+        }
+      ],
+      activeConversationId: "session-1"
+    });
+    renderAgentGUINode();
+
+    fireEvent.doubleClick(screen.getByRole("button", { name: /Session 1/ }));
+    fireEvent.change(
+      screen.getByRole("textbox", {
+        name: "agentHost.agentGui.renameSessionTitle"
+      }),
+      { target: { value: "Keyboard rename" } }
+    );
+    fireEvent.keyDown(
+      screen.getByRole("button", {
+        name: "agentHost.agentGui.renameSessionSave"
+      }),
+      { key: "Enter" }
+    );
+
+    await waitFor(() => {
+      expect(mockRenameConversation).toHaveBeenCalledWith(
+        "session-1",
+        "Keyboard rename"
+      );
+    });
+  });
+
   it("does not submit a blank rename title", async () => {
     mockRenameConversation.mockResolvedValue(undefined);
     mockViewModel = createViewModel({

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/AgentGUIConversationRailQueryController.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/AgentGUIConversationRailQueryController.ts
@@ -186,7 +186,9 @@ export class AgentGUIConversationRailQueryController {
     this.requestSearch();
   }
 
-  loadMoreSectionConversations(section: ConversationSection): void {
+  readonly loadMoreSectionConversations = (
+    section: ConversationSection
+  ): void => {
     const scopeKey = this.railSectionQueryKey;
     if (
       this.scope?.previewMode ||
@@ -303,9 +305,9 @@ export class AgentGUIConversationRailQueryController {
           this.pagingAbortControllers.delete(section.id);
         }
       });
-  }
+  };
 
-  loadMoreSearchResults(): void {
+  readonly loadMoreSearchResults = (): void => {
     const listSessionsPage = this.runtime.listSessionsPage;
     if (
       !this.searchEnabled() ||
@@ -368,12 +370,12 @@ export class AgentGUIConversationRailQueryController {
         };
         this.emit();
       });
-  }
+  };
 
-  retrySearchResults(): void {
+  readonly retrySearchResults = (): void => {
     if (!this.searchQuery || !this.searchEnabled()) return;
     this.requestSearch();
-  }
+  };
 
   private handleEngineState(state: AgentSessionEngineState): void {
     const next = membershipRecords(state);

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/agentGuiController.errors.spec.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/agentGuiController.errors.spec.ts
@@ -1,0 +1,35 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { setAgentGuiI18nTestLocale } from "../../../i18n/testUtils";
+import {
+  AGENT_SESSION_TITLE_TOO_LONG_REASON,
+  getAgentGUIErrorMessage
+} from "./agentGuiController.errors";
+
+describe("getAgentGUIErrorMessage", () => {
+  afterEach(() => setAgentGuiI18nTestLocale("en"));
+
+  it("localizes the structured session title limit error", () => {
+    setAgentGuiI18nTestLocale("zh-CN");
+
+    expect(
+      getAgentGUIErrorMessage({
+        debugMessage:
+          "invalid agent session request: title must be at most 120 characters",
+        params: { maxCharacters: 120 },
+        reason: AGENT_SESSION_TITLE_TOO_LONG_REASON
+      })
+    ).toBe("会话标题不能超过 120 个字符。");
+  });
+
+  it("uses a localized fallback when the limit param is absent", () => {
+    setAgentGuiI18nTestLocale("zh-CN");
+
+    expect(
+      getAgentGUIErrorMessage({
+        debugMessage:
+          "invalid agent session request: title must be at most 120 characters",
+        reason: AGENT_SESSION_TITLE_TOO_LONG_REASON
+      })
+    ).toBe("会话标题过长。");
+  });
+});

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/agentGuiController.errors.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/agentGuiController.errors.ts
@@ -8,6 +8,8 @@ export const AGENT_RESUME_SESSION_NOT_LOCAL_ERROR =
   "agent.resume_session_not_local";
 export const AGENT_SETTINGS_REQUIRE_NEW_SESSION_ERROR =
   "agent.settings_require_new_session";
+export const AGENT_SESSION_TITLE_TOO_LONG_REASON =
+  "workspace_agent_session_title_too_long";
 export const AGENT_SESSION_NOT_FOUND_ERROR = "session.not_found";
 export const AGENT_PROVIDER_SESSION_NOT_FOUND_FALLBACK_MESSAGE =
   "The previous agent session can no longer be restored.";
@@ -183,12 +185,29 @@ export function getAgentGUIErrorMessage(error: unknown): string {
     return translate("messages.agentResumeSessionNotLocal");
   if (isSettingsRequireNewSessionErrorCode(code))
     return translate("messages.agentSettingsRequireNewSession");
+  if (getAgentGUIErrorReason(error) === AGENT_SESSION_TITLE_TOO_LONG_REASON) {
+    const maxCharacters = getAgentGUIErrorNumberParam(error, "maxCharacters");
+    return maxCharacters === null
+      ? translate("messages.agentSessionTitleTooLongWithoutLimit")
+      : translate("messages.agentSessionTitleTooLong", { maxCharacters });
+  }
   if (error && typeof error === "object") {
     const debugMessage = (error as { debugMessage?: unknown }).debugMessage;
     if (typeof debugMessage === "string" && debugMessage.trim())
       return debugMessage.trim();
   }
   return error instanceof Error ? error.message : String(error);
+}
+
+function getAgentGUIErrorNumberParam(
+  error: unknown,
+  key: string
+): number | null {
+  if (!error || typeof error !== "object") return null;
+  const params = (error as { params?: unknown }).params;
+  if (!params || typeof params !== "object") return null;
+  const value = (params as Record<string, unknown>)[key];
+  return typeof value === "number" && Number.isFinite(value) ? value : null;
 }
 
 export function getAgentGUIRawErrorMessage(error: unknown): string | null {

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUIConversationPresentation.spec.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUIConversationPresentation.spec.tsx
@@ -1,0 +1,82 @@
+import { renderHook } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import type { AgentGUIConversationSummary } from "../model/agentGuiConversationModel";
+import { useAgentGUIConversationPresentation } from "./useAgentGUIConversationPresentation";
+
+type PresentationInput = Parameters<
+  typeof useAgentGUIConversationPresentation
+>[0];
+
+describe("useAgentGUIConversationPresentation", () => {
+  it("reuses visible and active conversation references for render-equal input", () => {
+    const conversation = createConversation();
+    const input = createInput(conversation);
+    const rendered = renderHook(
+      ({ value }: { value: PresentationInput }) =>
+        useAgentGUIConversationPresentation(value),
+      { initialProps: { value: input } }
+    );
+    const previous = rendered.result.current;
+
+    rendered.rerender({
+      value: {
+        ...input,
+        activityDisplayStatuses: new Map(),
+        conversations: [{ ...conversation }]
+      }
+    });
+
+    expect(rendered.result.current.visibleConversations).toBe(
+      previous.visibleConversations
+    );
+    expect(rendered.result.current.activeConversation).toBe(
+      previous.activeConversation
+    );
+  });
+});
+
+function createInput(
+  conversation: AgentGUIConversationSummary
+): PresentationInput {
+  const data = {
+    lastActiveAgentSessionId: conversation.id,
+    provider: conversation.provider
+  };
+  return {
+    activeConversationId: conversation.id,
+    activeLatestPendingSubmitTurnId: null,
+    activityDisplayStatuses: new Map(),
+    agentTargetsLoading: false,
+    conversations: [conversation],
+    currentUserId: "user-1",
+    data,
+    dataRef: { current: data },
+    defaultAgentTargetId: null,
+    draftByScopeKey: {},
+    hasUnconfirmedSubmit: false,
+    isCreatingConversation: false,
+    isSubmitting: true,
+    normalizedExplicitProviderTargets: [],
+    normalizedProviderTargets: [],
+    onDataChangeRef: { current: vi.fn() },
+    previewMode: true,
+    shouldUseStaticProviderTargets: false,
+    transientConversation: null,
+    userProjects: [],
+    workspacePath: "/workspace"
+  };
+}
+
+function createConversation(): AgentGUIConversationSummary {
+  return {
+    agentTargetId: "target-1",
+    cwd: "/workspace",
+    id: "session-1",
+    provider: "codex",
+    status: "ready",
+    title: "streaming session",
+    titleFallback: null,
+    updatedAtUnixMs: 1,
+    userId: "user-1"
+  };
+}

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUIConversationPresentation.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUIConversationPresentation.ts
@@ -57,19 +57,58 @@ interface UseAgentGUIConversationPresentationInput {
 export function useAgentGUIConversationPresentation(
   input: UseAgentGUIConversationPresentationInput
 ) {
-  const activeConversation = useMemo(() => {
-    const resolvedConversation = resolveConversationSummaryById(
+  const visibleConversationsRef = useRef<AgentGUIConversationSummary[] | null>(
+    null
+  );
+  const visibleConversations = useMemo(() => {
+    const source = mergeVisibleConversations(
       input.conversations,
-      input.activeConversationId,
       input.transientConversation
     );
-    const resolved = resolvedConversation
-      ? (applyAgentGUIConversationProjects(
-          [resolvedConversation],
-          input.userProjects,
-          { isNoProjectPath: input.isNoProjectPath }
-        )[0] ?? resolvedConversation)
-      : null;
+    const mapped = source.map((conversation) => {
+      const activityBusyStatus =
+        conversationBusyStatusFromAgentActivityDisplayStatus(
+          input.activityDisplayStatuses.get(conversation.id)
+        );
+      return activityBusyStatus && conversation.status !== activityBusyStatus
+        ? { ...conversation, status: activityBusyStatus }
+        : conversation;
+    });
+    const next = applyAgentGUIConversationProjects(mapped, input.userProjects, {
+      isNoProjectPath: input.isNoProjectPath
+    });
+    const stableNext = stableConversationSummaryList(
+      visibleConversationsRef.current,
+      next
+    );
+    visibleConversationsRef.current = stableNext;
+    return stableNext;
+  }, [
+    input.activityDisplayStatuses,
+    input.conversations,
+    input.isNoProjectPath,
+    input.transientConversation,
+    input.userProjects
+  ]);
+  const activeConversationRef = useRef<AgentGUIConversationSummary[] | null>(
+    null
+  );
+
+  const activeConversation = useMemo(() => {
+    const stabilize = (
+      next: AgentGUIConversationSummary | null
+    ): AgentGUIConversationSummary | null => {
+      const stable = stableConversationSummaryList(
+        activeConversationRef.current,
+        next ? [next] : []
+      );
+      activeConversationRef.current = stable;
+      return stable[0] ?? null;
+    };
+    const resolved = resolveConversationSummaryById(
+      visibleConversations,
+      input.activeConversationId
+    );
     if (resolved) {
       const activityDisplayStatus = input.activityDisplayStatuses.get(
         resolved.id
@@ -92,9 +131,11 @@ export function useAgentGUIConversationPresentation(
         (input.activeLatestPendingSubmitTurnId || input.isSubmitting)
           ? ("working" as const)
           : resolved.status);
-      return status === resolved.status ? resolved : { ...resolved, status };
+      return stabilize(
+        status === resolved.status ? resolved : { ...resolved, status }
+      );
     }
-    if (!input.activeConversationId) return null;
+    if (!input.activeConversationId) return stabilize(null);
     const providerLabel =
       (AGENT_PROVIDER_LABEL as Record<string, string>)[input.data.provider] ??
       input.data.provider ??
@@ -114,8 +155,12 @@ export function useAgentGUIConversationPresentation(
       conversationBusyStatusFromAgentActivityDisplayStatus(
         input.activityDisplayStatuses.get(input.activeConversationId)
       );
-    const fallbackUpdatedAtUnixMs = Date.now();
-    return {
+    const previousActiveConversation = activeConversationRef.current?.[0];
+    const fallbackUpdatedAtUnixMs =
+      previousActiveConversation?.id === input.activeConversationId
+        ? previousActiveConversation.updatedAtUnixMs
+        : Date.now();
+    return stabilize({
       id: input.activeConversationId,
       userId: input.currentUserId?.trim() || undefined,
       provider: input.data.provider,
@@ -130,12 +175,11 @@ export function useAgentGUIConversationPresentation(
       ),
       sortTimeUnixMs: fallbackUpdatedAtUnixMs,
       updatedAtUnixMs: fallbackUpdatedAtUnixMs
-    };
+    });
   }, [
     input.activeConversationId,
     input.activeLatestPendingSubmitTurnId,
     input.activityDisplayStatuses,
-    input.conversations,
     input.currentUserId,
     input.data.provider,
     input.draftByScopeKey,
@@ -143,8 +187,8 @@ export function useAgentGUIConversationPresentation(
     input.isCreatingConversation,
     input.isNoProjectPath,
     input.isSubmitting,
-    input.transientConversation,
     input.userProjects,
+    visibleConversations,
     input.workspacePath
   ]);
 
@@ -220,40 +264,6 @@ export function useAgentGUIConversationPresentation(
     input.agentTargetsLoading,
     input.shouldUseStaticProviderTargets,
     input.transientConversation
-  ]);
-
-  const visibleConversationsRef = useRef<AgentGUIConversationSummary[] | null>(
-    null
-  );
-  const visibleConversations = useMemo(() => {
-    const source = mergeVisibleConversations(
-      input.conversations,
-      input.transientConversation
-    );
-    const mapped = source.map((conversation) => {
-      const activityBusyStatus =
-        conversationBusyStatusFromAgentActivityDisplayStatus(
-          input.activityDisplayStatuses.get(conversation.id)
-        );
-      return activityBusyStatus && conversation.status !== activityBusyStatus
-        ? { ...conversation, status: activityBusyStatus }
-        : conversation;
-    });
-    const next = applyAgentGUIConversationProjects(mapped, input.userProjects, {
-      isNoProjectPath: input.isNoProjectPath
-    });
-    const stableNext = stableConversationSummaryList(
-      visibleConversationsRef.current,
-      next
-    );
-    visibleConversationsRef.current = stableNext;
-    return stableNext;
-  }, [
-    input.activityDisplayStatuses,
-    input.conversations,
-    input.isNoProjectPath,
-    input.transientConversation,
-    input.userProjects
   ]);
 
   return { activeConversation, visibleConversations };

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUIConversationRailQuery.search.spec.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUIConversationRailQuery.search.spec.tsx
@@ -1,4 +1,7 @@
-import { normalizeAgentActivitySession } from "@tutti-os/agent-activity-core";
+import {
+  normalizeAgentActivitySession,
+  type AgentActivityTurn
+} from "@tutti-os/agent-activity-core";
 import { act, renderHook, waitFor } from "@testing-library/react";
 import type { PropsWithChildren } from "react";
 import { describe, expect, it } from "vitest";
@@ -72,6 +75,10 @@ describe("useAgentGUIConversationRailQuery search", () => {
     expect(
       engine.getSnapshot().sessionLifecycle.sessionsById["session-1"]?.title
     ).toBe("backend first result");
+    const loadMoreSectionConversations =
+      result.current.loadMoreSectionConversations;
+    const loadMoreSearchResults = result.current.railSearch.loadMore;
+    const retrySearchResults = result.current.railSearch.retry;
 
     await act(async () => {
       result.current.railSearch.loadMore();
@@ -88,6 +95,11 @@ describe("useAgentGUIConversationRailQuery search", () => {
       "session-2"
     ]);
     expect(result.current.railSearch.hasMore).toBe(false);
+    expect(result.current.loadMoreSectionConversations).toBe(
+      loadMoreSectionConversations
+    );
+    expect(result.current.railSearch.loadMore).toBe(loadMoreSearchResults);
+    expect(result.current.railSearch.retry).toBe(retrySearchResults);
     expect(
       engine.getSnapshot().sessionLifecycle.sessionsById["session-2"]?.title
     ).toBe("backend older result");
@@ -134,7 +146,74 @@ describe("useAgentGUIConversationRailQuery search", () => {
     );
     expect(result.current.railSearch.failed).toBe(false);
   });
+
+  it("keeps the rail query idle when a streaming turn update does not change rail presentation", async () => {
+    const engine = createTestAgentSessionEngine("workspace-1");
+    engine.dispatch({
+      type: "session/upserted",
+      session: normalizeAgentActivitySession({
+        activeTurnId: "turn-1",
+        agentSessionId: "session-1",
+        agentTargetId: "target-1",
+        cwd: "/workspace",
+        latestTurnInteractions: [],
+        pendingInteractions: [],
+        provider: "codex",
+        title: "streaming session",
+        updatedAtUnixMs: 1,
+        workspaceId: "workspace-1"
+      })
+    });
+    engine.dispatch({ type: "turn/upserted", turn: runningTurn(1) });
+    const runtime = {
+      getSessionEngine: () => engine
+    } as unknown as AgentActivityRuntime;
+    const wrapper = ({ children }: PropsWithChildren) => (
+      <AgentActivityRuntimeProvider runtime={runtime}>
+        {children}
+      </AgentActivityRuntimeProvider>
+    );
+    let renderCount = 0;
+    const { result } = renderHook(
+      () => {
+        renderCount += 1;
+        return useAgentGUIConversationRailQuery({
+          activeConversationId: "session-1",
+          conversationFilter: { kind: "all" },
+          conversationQuery: "",
+          previewMode: true,
+          sectionAgentTargetFallbackId: null,
+          userProjects: [],
+          workspaceId: "workspace-1"
+        });
+      },
+      { wrapper }
+    );
+
+    await waitFor(() =>
+      expect(result.current.runtimeRailConversations).toHaveLength(1)
+    );
+    const previousResult = result.current;
+    const previousRenderCount = renderCount;
+
+    act(() => {
+      engine.dispatch({ type: "turn/upserted", turn: runningTurn(2) });
+    });
+
+    expect(renderCount).toBe(previousRenderCount);
+    expect(result.current).toBe(previousResult);
+  });
 });
+
+function runningTurn(updatedAtUnixMs: number): AgentActivityTurn {
+  return {
+    agentSessionId: "session-1",
+    phase: "running",
+    startedAtUnixMs: 1,
+    turnId: "turn-1",
+    updatedAtUnixMs
+  };
+}
 
 function searchSession(
   agentSessionId: string,

--- a/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUIConversationRailQuery.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/controller/useAgentGUIConversationRailQuery.ts
@@ -1,8 +1,13 @@
-import { selectWorkspaceAgentConsumerSessions } from "@tutti-os/agent-activity-core";
+import {
+  selectWorkspaceAgentConsumerSessions,
+  type AgentSessionEngineState
+} from "@tutti-os/agent-activity-core";
 import { useDeferredValue, useEffect, useMemo, useRef } from "react";
 import { useAgentActivityRuntime } from "../../../agentActivityRuntime";
 import { projectCanonicalAgentGUIConversationSummaries } from "../../../contexts/workspace/presentation/renderer/agentGuiConversationList/useAgentGuiConversationList";
 import { useEngineSelector } from "../../../shared/engine/useEngineSelector";
+import type { AgentGUIConversationSummary } from "../model/agentGuiConversationModel";
+import { conversationSummariesRenderEqual } from "../model/agentGuiConversationRail";
 import type { AgentGUINodeViewModel } from "../model/agentGuiNodeTypes";
 import {
   AgentGUIConversationRailQueryController,
@@ -70,31 +75,47 @@ export function useAgentGUIConversationRailQuery({
     identitySnapshot,
     Object.is
   );
-  const engineConsumerSessions = useEngineSelector(
+  const runtimeRailConversations = useEngineSelector(
     engine,
-    selectWorkspaceAgentConsumerSessions
+    selectRuntimeRailConversations,
+    conversationSummaryListsRenderEqual
   );
-  const runtimeRailConversations = useMemo(
-    () => projectCanonicalAgentGUIConversationSummaries(engineConsumerSessions),
-    [engineConsumerSessions]
-  );
-
   return useMemo(
     () => ({
       ...querySnapshot,
-      loadMoreSectionConversations: (
-        section: Parameters<
-          AgentGUIConversationRailQueryController["loadMoreSectionConversations"]
-        >[0]
-      ) => controller.loadMoreSectionConversations(section),
+      loadMoreSectionConversations: controller.loadMoreSectionConversations,
       railSearch: {
         ...querySnapshot.railSearch,
-        loadMore: () => controller.loadMoreSearchResults(),
-        retry: () => controller.retrySearchResults()
+        loadMore: controller.loadMoreSearchResults,
+        retry: controller.retrySearchResults
       },
       runtimeRailConversations
     }),
     [controller, querySnapshot, runtimeRailConversations]
+  );
+}
+
+function selectRuntimeRailConversations(
+  state: AgentSessionEngineState
+): AgentGUIConversationSummary[] {
+  return projectCanonicalAgentGUIConversationSummaries(
+    selectWorkspaceAgentConsumerSessions(state)
+  );
+}
+
+function conversationSummaryListsRenderEqual(
+  left: readonly AgentGUIConversationSummary[],
+  right: readonly AgentGUIConversationSummary[]
+): boolean {
+  return (
+    left.length === right.length &&
+    left.every((conversation, index) => {
+      const other = right[index];
+      return (
+        other !== undefined &&
+        conversationSummariesRenderEqual(conversation, other)
+      );
+    })
   );
 }
 

--- a/packages/agent/gui/agent-gui/agentGuiNode/model/agentGuiConversationRail.spec.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/model/agentGuiConversationRail.spec.ts
@@ -316,6 +316,26 @@ describe("projectConversationRailSectionsWithActiveConversation", () => {
     });
   });
 
+  it("reuses the active row when its project is render-equal to the section project", () => {
+    const active = {
+      ...conversation("active"),
+      project: {
+        id: "workspace",
+        label: "Workspace",
+        path: "/workspace",
+        sectionKey: "project:/workspace"
+      }
+    };
+
+    const projected = projectConversationRailSectionsWithActiveConversation({
+      activeConversation: active,
+      labels,
+      sections: section([active])
+    });
+
+    expect(projected.activeOverlay?.conversation).toBe(active);
+  });
+
   it("overlays only the missing active row into its matching server section", () => {
     const active = {
       ...conversation("active"),

--- a/packages/agent/gui/agent-gui/agentGuiNode/model/agentGuiConversationRail.ts
+++ b/packages/agent/gui/agent-gui/agentGuiNode/model/agentGuiConversationRail.ts
@@ -174,7 +174,10 @@ export function projectConversationRailSectionsWithActiveConversation(input: {
       activeOverlay: {
         conversation:
           loadedSection.kind === "project"
-            ? { ...activeConversation, project: loadedSection.project }
+            ? conversationWithRailProject(
+                activeConversation,
+                loadedSection.project
+              )
             : activeConversation,
         sectionId: loadedSection.id
       },
@@ -199,7 +202,10 @@ export function projectConversationRailSectionsWithActiveConversation(input: {
       activeOverlay: {
         conversation:
           matchingSection?.kind === "project"
-            ? { ...activeConversation, project: matchingSection.project }
+            ? conversationWithRailProject(
+                activeConversation,
+                matchingSection.project
+              )
             : activeConversation,
         sectionId: activeSection.id
       },
@@ -235,6 +241,15 @@ export function projectConversationRailSectionsWithActiveConversation(input: {
     },
     sections
   };
+}
+
+function conversationWithRailProject(
+  conversation: AgentGUINodeViewModel["rail"]["conversations"][number],
+  project: ConversationSection["project"]
+): AgentGUINodeViewModel["rail"]["conversations"][number] {
+  return conversationProjectsRenderEqual(conversation.project, project)
+    ? conversation
+    : { ...conversation, project };
 }
 
 export type ConversationRailMembershipRefreshPlan =

--- a/packages/agent/gui/agent-gui/agentGuiNode/view/AgentGUIConversationRailPane.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/view/AgentGUIConversationRailPane.tsx
@@ -35,6 +35,7 @@ import {
   projectConversationRailSectionsWithActiveConversation,
   projectConversationRailSectionsWithTransientConversations,
   resolveConversationRailActiveConversation,
+  stabilizeConversationSectionItems,
   stabilizeConversationSections
 } from "../model/agentGuiConversationRail";
 import type { useAgentGUIConversationRailQuery } from "../controller/useAgentGUIConversationRailQuery";
@@ -205,6 +206,9 @@ export const AgentGUIConversationRailPane = memo(
     );
     const activeConversationScrollCompletedRef = useRef<string | null>(null);
     const previousActiveConversationIdRef = useRef<string | null>(null);
+    const railActiveConversationRef = useRef<
+      AgentGUINodeViewModel["rail"]["conversations"]
+    >([]);
     const groupedConversationsRef = useRef<ConversationSection[] | null>(null);
     const {
       loadMoreSectionConversations,
@@ -243,11 +247,18 @@ export const AgentGUIConversationRailPane = memo(
         })
       : null;
 
-    const railActiveConversation = resolveConversationRailActiveConversation({
-      activeConversation,
-      activeConversationId,
-      conversations: railConversationEntities
-    });
+    const railActiveConversationCandidate =
+      resolveConversationRailActiveConversation({
+        activeConversation,
+        activeConversationId,
+        conversations: railConversationEntities
+      });
+    const stableRailActiveConversation = stabilizeConversationSectionItems(
+      railActiveConversationRef.current,
+      railActiveConversationCandidate ? [railActiveConversationCandidate] : []
+    );
+    railActiveConversationRef.current = stableRailActiveConversation;
+    const railActiveConversation = stableRailActiveConversation[0] ?? null;
     const runtimeSectionsWithTransientConversations =
       projectConversationRailSectionsWithTransientConversations({
         conversations,
@@ -552,132 +563,142 @@ export const AgentGUIConversationRailPane = memo(
               </span>
             </div>
           ) : (
-            groupedConversations.map((section, sectionIndex) => {
-              const projectPath =
-                section.kind === "project" ? (section.project?.path ?? "") : "";
-              const projectLabel =
-                section.kind === "project" ? section.label : "";
-              const isProjectSection = section.kind === "project";
-              const showProjectRailHeader =
-                !conversationQuery.trim() &&
-                section.kind !== "pinned" &&
-                (sectionIndex === 0 ||
-                  groupedConversations[sectionIndex - 1]?.kind === "pinned");
-              const isSectionCollapsed =
-                isProjectSection && collapsedProjectSectionIds.has(section.id);
-              const sectionPageState = sectionPageStates.get(section.id);
-              const searchSectionHasMore =
-                backendSearchActive &&
-                sectionIndex === groupedConversations.length - 1 &&
-                railSearch.hasMore;
-              const activeOverlayConversation =
-                !backendSearchActive &&
-                railActiveOverlay?.sectionId === section.id &&
-                (!conversationQuery.trim() ||
-                  filteredConversations.some(
-                    (conversation) =>
-                      conversation.id === railActiveOverlay.conversation.id
-                  ))
-                  ? railActiveOverlay.conversation
-                  : null;
-              const activeOverlayIsCanonical = Boolean(
-                activeOverlayConversation &&
-                section.items.some(
-                  (item) =>
-                    item.projectionSource !== "pending_activation" &&
-                    item.id === activeOverlayConversation.id
-                )
-              );
-              const activeOverlayCountsTowardTotal = Boolean(
-                activeOverlayConversation &&
-                activeOverlayConversation.projectionSource !==
-                  "pending_activation" &&
-                matchesAgentGUIConversationSummaryFilter(
-                  activeOverlayConversation,
-                  conversationFilter
-                )
-              );
-              const sectionTotalCount = backendSearchActive
-                ? section.items.length + (searchSectionHasMore ? 1 : 0)
-                : (sectionPageState?.totalCount ??
-                  section.items.filter(
-                    (item) => item.projectionSource !== "pending_activation"
-                  ).length +
-                    (activeOverlayCountsTowardTotal && !activeOverlayIsCanonical
-                      ? 1
-                      : 0));
-              const sectionHasMore =
-                searchSectionHasMore ||
-                (!conversationQuery.trim() &&
-                  sectionPageState?.hasMore === true);
-              return (
-                <Fragment key={section.id}>
-                  {showProjectRailHeader ? (
-                    <AgentGUIProjectRailHeader
+            <fieldset
+              className="contents"
+              disabled={runtimeRailSectionsPending && !backendSearchActive}
+            >
+              {groupedConversations.map((section, sectionIndex) => {
+                const projectPath =
+                  section.kind === "project"
+                    ? (section.project?.path ?? "")
+                    : "";
+                const projectLabel =
+                  section.kind === "project" ? section.label : "";
+                const isProjectSection = section.kind === "project";
+                const showProjectRailHeader =
+                  !conversationQuery.trim() &&
+                  section.kind !== "pinned" &&
+                  (sectionIndex === 0 ||
+                    groupedConversations[sectionIndex - 1]?.kind === "pinned");
+                const isSectionCollapsed =
+                  isProjectSection &&
+                  collapsedProjectSectionIds.has(section.id);
+                const sectionPageState = sectionPageStates.get(section.id);
+                const searchSectionHasMore =
+                  backendSearchActive &&
+                  sectionIndex === groupedConversations.length - 1 &&
+                  railSearch.hasMore;
+                const activeOverlayConversation =
+                  !backendSearchActive &&
+                  railActiveOverlay?.sectionId === section.id &&
+                  (!conversationQuery.trim() ||
+                    filteredConversations.some(
+                      (conversation) =>
+                        conversation.id === railActiveOverlay.conversation.id
+                    ))
+                    ? railActiveOverlay.conversation
+                    : null;
+                const activeOverlayIsCanonical = Boolean(
+                  activeOverlayConversation &&
+                  section.items.some(
+                    (item) =>
+                      item.projectionSource !== "pending_activation" &&
+                      item.id === activeOverlayConversation.id
+                  )
+                );
+                const activeOverlayCountsTowardTotal = Boolean(
+                  activeOverlayConversation &&
+                  activeOverlayConversation.projectionSource !==
+                    "pending_activation" &&
+                  matchesAgentGUIConversationSummaryFilter(
+                    activeOverlayConversation,
+                    conversationFilter
+                  )
+                );
+                const sectionTotalCount = backendSearchActive
+                  ? section.items.length + (searchSectionHasMore ? 1 : 0)
+                  : (sectionPageState?.totalCount ??
+                    section.items.filter(
+                      (item) => item.projectionSource !== "pending_activation"
+                    ).length +
+                      (activeOverlayCountsTowardTotal &&
+                      !activeOverlayIsCanonical
+                        ? 1
+                        : 0));
+                const sectionHasMore =
+                  searchSectionHasMore ||
+                  (!conversationQuery.trim() &&
+                    sectionPageState?.hasMore === true);
+                return (
+                  <Fragment key={section.id}>
+                    {showProjectRailHeader ? (
+                      <AgentGUIProjectRailHeader
+                        labels={labels}
+                        selectProjectDirectory={selectProjectDirectory}
+                        workspaceUserProjectI18n={workspaceUserProjectI18n}
+                      />
+                    ) : null}
+                    <AgentGUIConversationRailSection
+                      activeConversation={activeOverlayConversation}
+                      activeConversationCountsTowardTotal={
+                        activeOverlayCountsTowardTotal
+                      }
+                      activeConversationId={activeConversationId}
+                      createConversationDisabled={createConversationDisabled}
+                      currentTimeMs={currentTimeMs}
+                      isDeletingConversation={isDeletingConversation}
+                      isDeletingProjectConversations={
+                        isDeletingProjectConversations
+                      }
+                      isRequestingBatchDeletion={isRequestingBatchDeletion}
+                      isConversationSearchActive={Boolean(
+                        conversationQuery.trim()
+                      )}
+                      isLoadingMoreConversations={
+                        backendSearchActive
+                          ? railSearch.loadingMore
+                          : (sectionPageState?.isLoading ?? false)
+                      }
+                      isSectionCollapsed={isSectionCollapsed}
                       labels={labels}
-                      selectProjectDirectory={selectProjectDirectory}
-                      workspaceUserProjectI18n={workspaceUserProjectI18n}
+                      pendingDeleteConversationId={pendingDeleteConversationId}
+                      paginationScopeKey={sectionPaginationScopeKey}
+                      previewMode={previewMode}
+                      projectLabel={projectLabel}
+                      projectPath={projectPath}
+                      registerItemElement={registerConversationItemElement}
+                      section={section}
+                      sectionHasMore={sectionHasMore}
+                      sectionTotalCount={sectionTotalCount}
+                      uiLanguage={uiLanguage}
+                      workspaceId={workspaceId}
+                      onCancelDeleteConversation={onCancelDeleteConversation}
+                      onConfirmDeleteConversation={onConfirmDeleteConversation}
+                      onCreateConversation={onCreateConversation}
+                      onLoadMoreConversations={
+                        backendSearchActive
+                          ? railSearch.loadMore
+                          : loadMoreSectionConversations
+                      }
+                      onRequestDeleteConversation={onRequestDeleteConversation}
+                      onRequestRenameConversation={onRequestRenameConversation}
+                      onSelectConversation={onSelectConversation}
+                      onRequestSectionBatchDeletion={
+                        requestSectionBatchDeletion
+                      }
+                      setPendingProjectAction={setPendingProjectAction}
+                      onToggleConversationPinned={onToggleConversationPinned}
+                      onMarkConversationUnread={onMarkConversationUnread}
+                      onOpenProjectFiles={onOpenProjectFiles}
+                      onOpenConversationWindow={onOpenConversationWindow}
+                      onToggleProjectSectionCollapsed={
+                        toggleProjectSectionCollapsed
+                      }
                     />
-                  ) : null}
-                  <AgentGUIConversationRailSection
-                    activeConversation={activeOverlayConversation}
-                    activeConversationCountsTowardTotal={
-                      activeOverlayCountsTowardTotal
-                    }
-                    activeConversationId={activeConversationId}
-                    createConversationDisabled={createConversationDisabled}
-                    currentTimeMs={currentTimeMs}
-                    isDeletingConversation={isDeletingConversation}
-                    isDeletingProjectConversations={
-                      isDeletingProjectConversations
-                    }
-                    isRequestingBatchDeletion={isRequestingBatchDeletion}
-                    isConversationSearchActive={Boolean(
-                      conversationQuery.trim()
-                    )}
-                    isLoadingMoreConversations={
-                      backendSearchActive
-                        ? railSearch.loadingMore
-                        : runtimeRailSectionsPending ||
-                          (sectionPageState?.isLoading ?? false)
-                    }
-                    isSectionCollapsed={isSectionCollapsed}
-                    labels={labels}
-                    pendingDeleteConversationId={pendingDeleteConversationId}
-                    paginationScopeKey={sectionPaginationScopeKey}
-                    previewMode={previewMode}
-                    projectLabel={projectLabel}
-                    projectPath={projectPath}
-                    registerItemElement={registerConversationItemElement}
-                    section={section}
-                    sectionHasMore={sectionHasMore}
-                    sectionTotalCount={sectionTotalCount}
-                    uiLanguage={uiLanguage}
-                    workspaceId={workspaceId}
-                    onCancelDeleteConversation={onCancelDeleteConversation}
-                    onConfirmDeleteConversation={onConfirmDeleteConversation}
-                    onCreateConversation={onCreateConversation}
-                    onLoadMoreConversations={
-                      backendSearchActive
-                        ? railSearch.loadMore
-                        : loadMoreSectionConversations
-                    }
-                    onRequestDeleteConversation={onRequestDeleteConversation}
-                    onRequestRenameConversation={onRequestRenameConversation}
-                    onSelectConversation={onSelectConversation}
-                    onRequestSectionBatchDeletion={requestSectionBatchDeletion}
-                    setPendingProjectAction={setPendingProjectAction}
-                    onToggleConversationPinned={onToggleConversationPinned}
-                    onMarkConversationUnread={onMarkConversationUnread}
-                    onOpenProjectFiles={onOpenProjectFiles}
-                    onOpenConversationWindow={onOpenConversationWindow}
-                    onToggleProjectSectionCollapsed={
-                      toggleProjectSectionCollapsed
-                    }
-                  />
-                </Fragment>
-              );
-            })
+                  </Fragment>
+                );
+              })}
+            </fieldset>
           )}
         </ScrollArea>
         {footer ? <div className="shrink-0 pb-2">{footer}</div> : null}

--- a/packages/agent/gui/agent-gui/agentGuiNode/view/AgentGUIRenameConversationDialog.tsx
+++ b/packages/agent/gui/agent-gui/agentGuiNode/view/AgentGUIRenameConversationDialog.tsx
@@ -27,10 +27,14 @@ export const AgentGUIRenameConversationDialog = memo(
     "use memo";
     const [title, setTitle] = useState("");
     const [isSaving, setIsSaving] = useState(false);
+    const isSavingRef = useRef(false);
+    const keyboardActivationRef = useRef(false);
     const inputRef = useRef<HTMLInputElement | null>(null);
     const trimmedTitle = title.trim();
     useEffect(() => {
       if (!open || !conversation) {
+        isSavingRef.current = false;
+        keyboardActivationRef.current = false;
         setTitle("");
         setIsSaving(false);
         return;
@@ -49,14 +53,15 @@ export const AgentGUIRenameConversationDialog = memo(
       return () => window.clearTimeout(timer);
     }, [open, conversation?.id]);
     const closeRenameDialog = useCallback(() => {
-      if (!isSaving) {
+      if (!isSavingRef.current) {
         onOpenChange(false);
       }
-    }, [isSaving, onOpenChange]);
+    }, [onOpenChange]);
     const confirmRename = useCallback(() => {
-      if (!conversation || isSaving || !trimmedTitle) {
+      if (!conversation || isSavingRef.current || !trimmedTitle) {
         return;
       }
+      isSavingRef.current = true;
       setIsSaving(true);
       void onRename(conversation.id, trimmedTitle)
         .then(() => {
@@ -66,9 +71,11 @@ export const AgentGUIRenameConversationDialog = memo(
           inputRef.current?.focus();
         })
         .finally(() => {
+          isSavingRef.current = false;
+          keyboardActivationRef.current = false;
           setIsSaving(false);
         });
-    }, [conversation, isSaving, onOpenChange, onRename, trimmedTitle]);
+    }, [conversation, onOpenChange, onRename, trimmedTitle]);
     return (
       <ConfirmationDialog
         cancelLabel={labels.cancel}
@@ -99,7 +106,31 @@ export const AgentGUIRenameConversationDialog = memo(
               size="dialog"
               type="button"
               variant="default"
-              onClick={confirmRename}
+              onClick={(event) => {
+                if (event.detail !== 0) {
+                  return;
+                }
+                if (keyboardActivationRef.current) {
+                  keyboardActivationRef.current = false;
+                  return;
+                }
+                confirmRename();
+              }}
+              onKeyDown={(event) => {
+                if (
+                  (event.key === "Enter" || event.key === " ") &&
+                  !event.repeat
+                ) {
+                  event.preventDefault();
+                  keyboardActivationRef.current = true;
+                  confirmRename();
+                }
+              }}
+              onPointerUp={(event) => {
+                if (event.button === 0) {
+                  confirmRename();
+                }
+              }}
             >
               {labels.renameSessionSave}
             </Button>

--- a/packages/agent/gui/app/renderer/i18n/locales/en.messages.ts
+++ b/packages/agent/gui/app/renderer/i18n/locales/en.messages.ts
@@ -12,6 +12,9 @@ export const enMessages = {
   agentSessionReconnecting: "Reconnecting to the live agent session…",
   agentSettingsRequireNewSession:
     "This model can only be used in a new session to preserve context.",
+  agentSessionTitleTooLong:
+    "Session title must be {{maxCharacters}} characters or fewer.",
+  agentSessionTitleTooLongWithoutLimit: "Session title is too long.",
   agentPermissionModeAppliesNextTurn:
     "Permission mode will apply starting with your next message.",
   agentThisSessionMentionLabel: "this session",

--- a/packages/agent/gui/app/renderer/i18n/locales/zh-CN.messages.ts
+++ b/packages/agent/gui/app/renderer/i18n/locales/zh-CN.messages.ts
@@ -10,6 +10,8 @@ export const zhCNMessages = {
     "这段对话已导入成功，新开会话并 @ 这段对话，接着继续聊。",
   agentSessionReconnecting: "正在重新连接 Agent 会话…",
   agentSettingsRequireNewSession: "为了保留上下文，这个模型只能在新会话中使用",
+  agentSessionTitleTooLong: "会话标题不能超过 {{maxCharacters}} 个字符。",
+  agentSessionTitleTooLongWithoutLimit: "会话标题过长。",
   agentPermissionModeAppliesNextTurn: "权限模式将从你的下一条消息开始生效。",
   agentThisSessionMentionLabel: "本 session",
   terminalLaunchFailed: "终端启动失败：{{message}}",

--- a/packages/clients/tuttid-ts/src/generated/sdk.gen.ts
+++ b/packages/clients/tuttid-ts/src/generated/sdk.gen.ts
@@ -2186,6 +2186,8 @@ export const updateWorkspaceAgentSessionSettings = <
 
 /**
  * Update one workspace agent session title
+ *
+ * Titles longer than 120 Unicode characters return `invalid_request` with reason `workspace_agent_session_title_too_long` and `params.maxCharacters` set to 120.
  */
 export const updateWorkspaceAgentSessionTitle = <
   ThrowOnError extends boolean = false

--- a/services/tuttid/api/openapi/tuttid.v1.yaml
+++ b/services/tuttid/api/openapi/tuttid.v1.yaml
@@ -2896,6 +2896,10 @@ paths:
       tags:
         - agent-session
       summary: Update one workspace agent session title
+      description: >-
+        Titles longer than 120 Unicode characters return `invalid_request` with
+        reason `workspace_agent_session_title_too_long` and
+        `params.maxCharacters` set to 120.
       requestBody:
         required: true
         content:

--- a/services/tuttid/apierrors/apierrors.go
+++ b/services/tuttid/apierrors/apierrors.go
@@ -73,6 +73,7 @@ const (
 	ReasonWorkspaceFileNotFound                          = "workspace_file_not_found"
 	ReasonWorkspaceFileServiceUnavailable                = "workspace_file_service_unavailable"
 	ReasonWorkspaceAgentSessionNotFound                  = "workspace_agent_session_not_found"
+	ReasonWorkspaceAgentSessionTitleTooLong              = "workspace_agent_session_title_too_long"
 	ReasonWorkspaceAgentSessionUnavailable               = "workspace_agent_session_service_unavailable"
 	ReasonAgentProviderUnavailable                       = "agent_provider_unavailable"
 	ReasonAgentRuntimeOperationReconciling               = "agent_runtime_operation_reconciling"
@@ -407,6 +408,12 @@ func Classify(err error) *ProtocolError {
 		return WorkspaceTerminalNotFound(WithCause(err))
 	case errors.Is(err, workspaceservice.ErrTerminalNotRunning):
 		return InvalidRequest(ReasonWorkspaceTerminalNotRunning, WithCause(err))
+	case errors.Is(err, agentservice.ErrSessionTitleTooLong):
+		return InvalidRequest(
+			ReasonWorkspaceAgentSessionTitleTooLong,
+			WithCause(err),
+			WithParams(map[string]any{"maxCharacters": agentservice.MaxSessionTitleRunes}),
+		)
 	case errors.Is(err, agentservice.ErrInvalidArgument):
 		return InvalidRequest(ReasonMalformedRequest, WithCause(err))
 	case errors.Is(err, agentservice.ErrPromptImageUnsupported):

--- a/services/tuttid/apierrors/apierrors_test.go
+++ b/services/tuttid/apierrors/apierrors_test.go
@@ -19,3 +19,13 @@ func TestClassifyTerminalRuntimeOperationFailureIsNotRetryable(t *testing.T) {
 		t.Fatalf("classified = %#v, want stable terminal failure reason", classified)
 	}
 }
+
+func TestClassifySessionTitleTooLongHasStableReasonAndLimit(t *testing.T) {
+	classified := Classify(agentservice.ErrSessionTitleTooLong)
+	if classified.Reason != ReasonWorkspaceAgentSessionTitleTooLong {
+		t.Fatalf("reason = %q, want %q", classified.Reason, ReasonWorkspaceAgentSessionTitleTooLong)
+	}
+	if classified.Params["maxCharacters"] != agentservice.MaxSessionTitleRunes {
+		t.Fatalf("params = %#v, want maxCharacters = %d", classified.Params, agentservice.MaxSessionTitleRunes)
+	}
+}

--- a/services/tuttid/service/agent/composer_commands_test.go
+++ b/services/tuttid/service/agent/composer_commands_test.go
@@ -1,6 +1,9 @@
 package agent
 
-import "testing"
+import (
+	"context"
+	"testing"
+)
 
 type composerCommandSessionReaderStub struct {
 	sessions []PersistedSession
@@ -14,7 +17,7 @@ func (s composerCommandSessionReaderStub) ListSessions(string) ([]PersistedSessi
 	return s.sessions, true
 }
 
-func (composerCommandSessionReaderStub) SessionDeleted(string, string) (bool, error) {
+func (composerCommandSessionReaderStub) SessionDeleted(context.Context, string, string) (bool, error) {
 	return false, nil
 }
 

--- a/services/tuttid/service/agent/service_test.go
+++ b/services/tuttid/service/agent/service_test.go
@@ -124,9 +124,12 @@ func TestServiceUpdateTitleRejectsOverlongTitle(t *testing.T) {
 	service := newIsolatedAgentService(runtime)
 	service.SessionReader = &fakeSessionReader{}
 
-	_, err := service.UpdateTitle(context.Background(), "ws-1", "session-1", strings.Repeat("好", maxSessionTitleRunes+1))
+	_, err := service.UpdateTitle(context.Background(), "ws-1", "session-1", strings.Repeat("好", MaxSessionTitleRunes+1))
 	if !errors.Is(err, ErrInvalidArgument) {
 		t.Fatalf("UpdateTitle error = %v, want ErrInvalidArgument", err)
+	}
+	if !errors.Is(err, ErrSessionTitleTooLong) {
+		t.Fatalf("UpdateTitle error = %v, want ErrSessionTitleTooLong", err)
 	}
 }
 

--- a/services/tuttid/service/agent/service_update_title.go
+++ b/services/tuttid/service/agent/service_update_title.go
@@ -7,7 +7,13 @@ import (
 	"unicode/utf8"
 )
 
-const maxSessionTitleRunes = 120
+const MaxSessionTitleRunes = 120
+
+var ErrSessionTitleTooLong = fmt.Errorf(
+	"%w: title must be at most %d characters",
+	ErrInvalidArgument,
+	MaxSessionTitleRunes,
+)
 
 func (s *Service) UpdateTitle(ctx context.Context, workspaceID string, agentSessionID string, title string) (Session, error) {
 	workspaceID = strings.TrimSpace(workspaceID)
@@ -19,8 +25,8 @@ func (s *Service) UpdateTitle(ctx context.Context, workspaceID string, agentSess
 	if title == "" {
 		return Session{}, fmt.Errorf("%w: title is required", ErrInvalidArgument)
 	}
-	if utf8.RuneCountInString(title) > maxSessionTitleRunes {
-		return Session{}, fmt.Errorf("%w: title must be at most %d characters", ErrInvalidArgument, maxSessionTitleRunes)
+	if utf8.RuneCountInString(title) > MaxSessionTitleRunes {
+		return Session{}, ErrSessionTitleTooLong
 	}
 	updater, ok := s.SessionReader.(SessionTitleUpdater)
 	if !ok {

--- a/services/tuttid/types/defaults_generated.go
+++ b/services/tuttid/types/defaults_generated.go
@@ -41,6 +41,13 @@ var generatedDefaults = generatedDefaultsSpec{
 				SigningPublicKey: "-----BEGIN PUBLIC KEY-----\nMCowBQYDK2VwAyEAXKvHPk/lWXqeK3Q1cg6vaOFfhqmXm3jcNgECsZ9XT/g=\n-----END PUBLIC KEY-----\n",
 				Enabled:          false,
 			},
+			{
+				Key:              "codebuddy",
+				ReleaseIndexURL:  "https://d1x7gb6wqsqmnm.cloudfront.net/tutti-agent-releases/agents/codebuddy/versions.json",
+				SigningKeyID:     "tutti-codebuddy-release-v1",
+				SigningPublicKey: "-----BEGIN PUBLIC KEY-----\nMCowBQYDK2VwAyEAfzdtf41+SN0hrZqK0JX2pdDluCwpUbn1HPDoz4D7OxA=\n-----END PUBLIC KEY-----\n",
+				Enabled:          false,
+			},
 		},
 	},
 }

--- a/services/tuttid/types/defaults_test.go
+++ b/services/tuttid/types/defaults_test.go
@@ -52,11 +52,22 @@ func TestResolveAgentExtensionSourcesAppliesEnabledOverride(t *testing.T) {
 	t.Setenv("TUTTI_AGENT_EXTENSION_GEMINI_ENABLED", "true")
 
 	sources := ResolveAgentExtensionSources()
-	if len(sources) != 1 || sources[0].Key != "gemini" || !sources[0].Enabled {
-		t.Fatalf("agent extension sources = %#v", sources)
+	byKey := map[string]AgentExtensionSource{}
+	for _, source := range sources {
+		byKey[source.Key] = source
 	}
-	if sources[0].SigningKeyID == "" || sources[0].SigningPublicKey == "" {
-		t.Fatalf("agent extension trust configuration is incomplete: %#v", sources[0])
+	gemini, ok := byKey["gemini"]
+	if !ok || !gemini.Enabled {
+		t.Fatalf("gemini source override not applied: %#v", sources)
+	}
+	codebuddy, ok := byKey["codebuddy"]
+	if !ok || codebuddy.Enabled {
+		t.Fatalf("codebuddy source must stay disabled without override: %#v", sources)
+	}
+	for _, source := range []AgentExtensionSource{gemini, codebuddy} {
+		if source.SigningKeyID == "" || source.SigningPublicKey == "" {
+			t.Fatalf("agent extension trust configuration is incomplete: %#v", source)
+		}
 	}
 }
 

--- a/tools/degradation-baseline/agent-gui.json
+++ b/tools/degradation-baseline/agent-gui.json
@@ -14,7 +14,7 @@
     },
     "goFileLengthExemptions": 2,
     "identityProviderBranches": 2,
-    "memoCount": 436,
+    "memoCount": 435,
     "moduleMutableGlobals": 6,
     "overlayStores": 4,
     "providerBranches": 1,


### PR DESCRIPTION
## Summary

- Add a disabled CodeBuddy Agent Extension release source, generated defaults, override coverage, and durable runtime-override documentation.
- Stabilize AgentGUI conversation Rail selectors, callbacks, active-row projection, and section loading behavior so unrelated streaming updates do not fan out renders.
- Fix rename-dialog pointer activation while preserving keyboard and assistive activation without duplicate submissions.
- Give overlong session titles a stable daemon reason and interpolation params, then localize the AgentGUI error in English and Simplified Chinese.
- Update the stale `SessionReader` test stub to the current context-aware interface.

## Verification

- `pnpm check:full` — passed 18/18 tasks before commit.
- Pre-push `pnpm check:full` — passed 18/18 tasks again.
- Manual reproduction evidence confirmed pointer events reached the rename action while synthesized click did not, and the old daemon classified title limits as `malformed_request`.

## Fix Scope Justification

- Root cause: Rail selectors and projectors recreated render-visible identities during unrelated engine updates; the dialog relied on a synthesized click that Electron could suppress; title validation lost its domain identity when classified as a generic malformed request.
- Why this cannot be fixed at a lower layer: each fix now lives at its owning boundary — selector/projector identity in AgentGUI, pointer activation in the dialog, and validation identity in the daemon protocol classifier.

## Fallback Three Questions

- Source: the AgentGUI error boundary accepts unknown adapter errors, so a matching reason may arrive without `params.maxCharacters`.
- Why it cannot be fixed at that source: the daemon now supplies the param, but the renderer boundary also receives structurally compatible errors from adapters and tests.
- Removal condition: remove the localized no-limit branch once reason-specific params are required and runtime-validated across every AgentGUI adapter boundary.

## Checklist

- [ ] I kept the change focused on one concern. This PR intentionally contains all current Agent-domain workspace changes requested by the author.
- [x] I updated documentation when behavior, setup, or contributor workflow changed.
- [x] I updated all README/CONTRIBUTING language variants when changing their English source. No README or CONTRIBUTING files changed.
- [x] I ran the lowest meaningful local checks for the changed surface.
- [x] My commits are signed off with DCO when required: `git commit -s`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a disabled CodeBuddy Agent Extension source and hardens the AgentGUI conversation rail for fewer unnecessary renders. Also introduces a structured, localized error for overlong session titles and fixes the rename dialog’s click behavior.

- **New Features**
  - Added `codebuddy` Agent Extension source (disabled by default) with signed release index; enable via `TUTTI_AGENT_EXTENSION_CODEBUDDY_ENABLED`.
  - Defined stable error reason `workspace_agent_session_title_too_long` with `params.maxCharacters=120`; localized messages in English and zh-CN; OpenAPI/SDK docs updated.

- **Bug Fixes**
  - Stabilized `agent-gui` conversation rail selectors, projections, and callbacks to prevent render fan-out during streaming updates; added tests to keep the rail idle on non-visual turn changes.
  - Rename dialog now activates on primary `pointerup` and preserves keyboard/assistive activation while preventing duplicate submits; tests added.

<sup>Written for commit 219cf86a0afad37af671769760594eea612c2524. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/tutti-os/tutti/pull/1144?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

